### PR TITLE
feat(ROB-565): add account routing advisory

### DIFF
--- a/app/mcp_server/README.md
+++ b/app/mcp_server/README.md
@@ -62,6 +62,13 @@ MCP tools (market data, portfolio, order execution) exposed via `fastmcp`.
   - `default_rate` mirrors the scalar exchange-rate behavior used by existing portfolio and cash consumers.
   - Unsupported pairs raise a tool argument error. FX pairs are not market indices; `get_market_index("USDKRW")` remains unsupported.
   - Trends, bank-specific quotes, preferential effective rates, exchange execution, and US-order total-cost routing are outside ROB-567 P1.
+- `suggest_order_account(symbol, market=None, side="buy", quantity, price=None, usd_krw=None)`
+  - Read-only advisory tool. It never submits, previews, routes, modifies, or cancels an order.
+  - Supports KR/US buys only. Crypto, Upbit, manual cash, paper accounts, and sells are out of scope.
+  - Compares KIS/Toss using orderable cash, commission bps, FX spread bps, optional Toss notional limit, and existing-position consolidation.
+  - If a symbol is already held in one candidate account, that account wins unless the cheaper alternative saves at least `position_consolidation_threshold_bps` of order notional.
+  - Default thresholds: KR 25 bps, US 40 bps. US is stricter because FX basis and overseas tax lots split by account.
+  - Always returns `cost_comparison` for both candidate accounts and `position_consolidation` with either `foregone_savings_krw` or `distribution_warning`.
 - `get_orderbook(symbol, market="kr")`
 - US equity quote price resolution uses KIS overseas current price first when `settings.us_quote_kis_primary` is enabled, then falls back to Yahoo `fast_info`
   - US quote response keeps `source: "kis_overseas"` or `source: "yahoo"` and includes `previous_close/open/high/low/volume` when the provider supplies them
@@ -1205,6 +1212,45 @@ These tools provide a generic key-value storage for user preferences and setting
 
 Common settings:
 - `manual_cash`: Stores manually-managed cash amounts (e.g., `{"amount": 15000000}`) for accounts not backed by APIs (Toss, etc.)
+- `account_costs`: Stores broker fee/cost profiles and thresholds used for routing suggestions.
+
+### `account_costs` user setting
+
+`set_user_setting(key="account_costs", value={...})` stores operator-maintained
+broker cost metadata used by `suggest_order_account`, `get_available_capital`,
+and `get_operating_briefing`.
+
+Required shape:
+
+```json
+{
+  "version": 1,
+  "routing": {
+    "position_consolidation_threshold_bps": {"kr": 25, "us": 40}
+  },
+  "accounts": {
+    "kis_domestic": {
+      "broker": "kis",
+      "markets": {"kr": {"commission_bps": 14.7, "fx_spread_bps": 0}}
+    },
+    "kis_overseas": {
+      "broker": "kis",
+      "markets": {"us": {"commission_bps": 25, "fx_spread_bps": 20}}
+    },
+    "toss": {
+      "broker": "toss",
+      "limits": {"max_order_notional_krw": 1000000},
+      "markets": {
+        "kr": {"commission_bps": 0, "fx_spread_bps": 0},
+        "us": {"commission_bps": 10, "fx_spread_bps": 1.7}
+      }
+    }
+  }
+}
+```
+
+Values are basis points. `25` means 0.25%. If the setting is missing or invalid,
+the system uses default seed values and marks the result `review_required`.
 
 ### `update_manual_holdings` spec
 

--- a/app/mcp_server/__init__.py
+++ b/app/mcp_server/__init__.py
@@ -33,6 +33,7 @@ AVAILABLE_TOOL_NAMES = [
     "get_short_interest",
     "get_market_index",
     "get_fx_rate",
+    "suggest_order_account",
     "get_support_resistance",
     "get_sector_peers",
     "get_cash_balance",

--- a/app/mcp_server/tooling/account_routing_registration.py
+++ b/app/mcp_server/tooling/account_routing_registration.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from app.mcp_server.tooling.account_routing_tools import suggest_order_account_impl
+
+if TYPE_CHECKING:
+    from fastmcp import FastMCP
+
+
+ACCOUNT_ROUTING_TOOL_NAMES: set[str] = {"suggest_order_account"}
+
+
+def register_account_routing_tools(mcp: FastMCP) -> None:
+    @mcp.tool(
+        name="suggest_order_account",
+        description=(
+            "Read-only advisory: compare KIS/Toss buy-account costs for KR/US "
+            "stocks using commission, FX spread, orderable cash, Toss notional "
+            "limits, and existing-position consolidation. Never submits or "
+            "routes an order automatically; operator final decision required."
+        ),
+    )
+    async def suggest_order_account(
+        symbol: str,
+        market: str | None = None,
+        side: str = "buy",
+        quantity: float = 0,
+        price: float | None = None,
+        usd_krw: float | None = None,
+    ) -> dict[str, Any]:
+        return await suggest_order_account_impl(
+            symbol=symbol,
+            market=market,
+            side=side,
+            quantity=quantity,
+            price=price,
+            usd_krw=usd_krw,
+        )
+
+
+__all__ = ["ACCOUNT_ROUTING_TOOL_NAMES", "register_account_routing_tools"]

--- a/app/mcp_server/tooling/account_routing_tools.py
+++ b/app/mcp_server/tooling/account_routing_tools.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from app.mcp_server.tooling.market_data_quotes import (
+    _fetch_quote_equity_kr,
+    _fetch_quote_equity_us,
+)
+from app.mcp_server.tooling.portfolio_cash import get_available_capital_impl
+from app.mcp_server.tooling.portfolio_holdings import _get_holdings_impl
+from app.mcp_server.tooling.user_settings_tools import get_user_setting
+from app.services.account_routing import AccountRoutingInput, suggest_account_from_snapshot
+from app.services.exchange_rate_service import get_usd_krw_rate
+
+
+async def _resolve_price(symbol: str, market: Literal["kr", "us"], price: float | None) -> tuple[float, str]:
+    if price is not None:
+        value = float(price)
+        if value <= 0:
+            raise ValueError("price must be positive")
+        return value, "input"
+    if market == "kr":
+        quote = await _fetch_quote_equity_kr(symbol)
+    else:
+        quote = await _fetch_quote_equity_us(symbol)
+    resolved = float(quote["price"])
+    if resolved <= 0:
+        raise ValueError("resolved quote price must be positive")
+    return resolved, str(quote.get("source") or "quote")
+
+
+def _normalize_market(market: str | None, symbol: str) -> Literal["kr", "us"]:
+    raw = (market or "").strip().lower()
+    if raw in {"kr", "equity_kr"}:
+        return "kr"
+    if raw in {"us", "equity_us"}:
+        return "us"
+    if raw:
+        raise ValueError("suggest_order_account supports market='kr' or market='us'")
+    stripped = symbol.strip()
+    return "kr" if stripped.isdigit() and len(stripped) == 6 else "us"
+
+
+async def suggest_order_account_impl(
+    *,
+    symbol: str,
+    market: str | None = None,
+    side: str = "buy",
+    quantity: float,
+    price: float | None = None,
+    usd_krw: float | None = None,
+) -> dict[str, Any]:
+    normalized_market = _normalize_market(market, symbol)
+    resolved_price, price_source = await _resolve_price(symbol, normalized_market, price)
+    resolved_usd_krw = usd_krw
+    if normalized_market == "us" and resolved_usd_krw is None:
+        resolved_usd_krw = await get_usd_krw_rate()
+    account_costs = await get_user_setting("account_costs")
+    capital = await get_available_capital_impl(include_manual=False)
+    holdings = await _get_holdings_impl(
+        market=normalized_market,
+        include_current_price=False,
+        minimum_value=0,
+    )
+    result = suggest_account_from_snapshot(
+        AccountRoutingInput(
+            symbol=symbol,
+            market=normalized_market,
+            side=side,
+            quantity=float(quantity),
+            price=resolved_price,
+            usd_krw=resolved_usd_krw,
+            account_costs=account_costs,
+            capital_snapshot=capital,
+            holdings_snapshot=holdings,
+        )
+    )
+    result["price_source"] = price_source
+    return result
+
+
+__all__ = ["suggest_order_account_impl"]

--- a/app/mcp_server/tooling/account_routing_tools.py
+++ b/app/mcp_server/tooling/account_routing_tools.py
@@ -9,11 +9,16 @@ from app.mcp_server.tooling.market_data_quotes import (
 from app.mcp_server.tooling.portfolio_cash import get_available_capital_impl
 from app.mcp_server.tooling.portfolio_holdings import _get_holdings_impl
 from app.mcp_server.tooling.user_settings_tools import get_user_setting
-from app.services.account_routing import AccountRoutingInput, suggest_account_from_snapshot
+from app.services.account_routing import (
+    AccountRoutingInput,
+    suggest_account_from_snapshot,
+)
 from app.services.exchange_rate_service import get_usd_krw_rate
 
 
-async def _resolve_price(symbol: str, market: Literal["kr", "us"], price: float | None) -> tuple[float, str]:
+async def _resolve_price(
+    symbol: str, market: Literal["kr", "us"], price: float | None
+) -> tuple[float, str]:
     if price is not None:
         value = float(price)
         if value <= 0:
@@ -51,7 +56,9 @@ async def suggest_order_account_impl(
     usd_krw: float | None = None,
 ) -> dict[str, Any]:
     normalized_market = _normalize_market(market, symbol)
-    resolved_price, price_source = await _resolve_price(symbol, normalized_market, price)
+    resolved_price, price_source = await _resolve_price(
+        symbol, normalized_market, price
+    )
     resolved_usd_krw = usd_krw
     if normalized_market == "us" and resolved_usd_krw is None:
         resolved_usd_krw = await get_usd_krw_rate()

--- a/app/mcp_server/tooling/account_routing_tools.py
+++ b/app/mcp_server/tooling/account_routing_tools.py
@@ -55,6 +55,10 @@ async def suggest_order_account_impl(
     price: float | None = None,
     usd_krw: float | None = None,
 ) -> dict[str, Any]:
+    if side.lower() != "buy":
+        raise ValueError("suggest_order_account supports buy side only")
+    if quantity <= 0:
+        raise ValueError("quantity must be positive")
     normalized_market = _normalize_market(market, symbol)
     resolved_price, price_source = await _resolve_price(
         symbol, normalized_market, price

--- a/app/mcp_server/tooling/operating_briefing.py
+++ b/app/mcp_server/tooling/operating_briefing.py
@@ -10,15 +10,15 @@ from app.mcp_server.tooling.pending_orders_snapshot import (
     DEFAULT_PENDING_ORDERS_ACCOUNT_SCOPE,
     collect_pending_orders_snapshot,
 )
-from app.mcp_server.tooling.portfolio_holdings import _get_holdings_impl
 from app.mcp_server.tooling.portfolio_cash import get_account_costs_setting
-from app.services.account_routing import compact_cost_profile
+from app.mcp_server.tooling.portfolio_holdings import _get_holdings_impl
 from app.schemas.investment_reports import (
     ActiveWatchesListResponse,
     InvestmentWatchAlertResponse,
     OperatingBriefingResponse,
 )
 from app.schemas.session_context import SessionContextResponse
+from app.services.account_routing import compact_cost_profile
 from app.services.investment_reports.query_service import (
     InvestmentReportQueryService,
     _advisory_draft_profiles,

--- a/app/mcp_server/tooling/operating_briefing.py
+++ b/app/mcp_server/tooling/operating_briefing.py
@@ -11,6 +11,8 @@ from app.mcp_server.tooling.pending_orders_snapshot import (
     collect_pending_orders_snapshot,
 )
 from app.mcp_server.tooling.portfolio_holdings import _get_holdings_impl
+from app.mcp_server.tooling.portfolio_cash import get_account_costs_setting
+from app.services.account_routing import compact_cost_profile
 from app.schemas.investment_reports import (
     ActiveWatchesListResponse,
     InvestmentWatchAlertResponse,
@@ -107,7 +109,12 @@ def _flatten_positions(holdings: dict[str, Any]) -> list[dict[str, Any]]:
     return positions
 
 
-def _account_routability(holdings: dict[str, Any]) -> list[dict[str, Any]]:
+def _account_routability(
+    holdings: dict[str, Any],
+    *,
+    market: str,
+    account_costs: dict[str, Any] | None,
+) -> list[dict[str, Any]]:
     """Compact per-account routability summary for the briefing (ROB-541).
 
     Surfaces ``account_mode`` (ROB-357 provenance label) and the authoritative
@@ -116,15 +123,22 @@ def _account_routability(holdings: dict[str, Any]) -> list[dict[str, Any]]:
     """
     accounts: list[dict[str, Any]] = []
     for account in holdings.get("accounts") or []:
-        accounts.append(
-            {
-                "account": account.get("account"),
-                "account_name": account.get("account_name"),
-                "account_mode": account.get("account_mode"),
-                "order_routable": account.get("order_routable"),
-                "position_count": len(account.get("positions") or []),
-            }
-        )
+        row = {
+            "account": account.get("account"),
+            "account_name": account.get("account_name"),
+            "account_mode": account.get("account_mode"),
+            "order_routable": account.get("order_routable"),
+            "position_count": len(account.get("positions") or []),
+        }
+        if market in {"kr", "us"}:
+            profile = compact_cost_profile(
+                str(account.get("account") or ""),
+                market,  # type: ignore[arg-type]
+                account_costs,
+            )
+            if profile is not None:
+                row["cost_profile"] = profile
+        accounts.append(row)
     return accounts
 
 
@@ -301,6 +315,14 @@ async def get_operating_briefing_impl(
         }
 
     active_watches_unavailable_reason = active_watches.get("unavailable_reason")
+    try:
+        account_costs = await get_account_costs_setting()
+    except Exception as exc:  # noqa: BLE001
+        account_costs = None
+        holdings.setdefault("errors", []).append(
+            {"source": "account_costs", "error": str(exc)}
+        )
+
     response = {
         "success": True,
         "market": market,
@@ -329,7 +351,11 @@ async def get_operating_briefing_impl(
             "top_movers": _top_movers(holdings),
             # ROB-541 — per-account routable/account_mode so a reference-only
             # (toss/manual) holding is distinguishable from a kis_live-sellable one.
-            "accounts": _account_routability(holdings),
+            "accounts": _account_routability(
+                holdings,
+                market=market,
+                account_costs=account_costs,
+            ),
             "errors": holdings.get("errors") or [],
         },
         "pending_orders": {

--- a/app/mcp_server/tooling/portfolio_cash.py
+++ b/app/mcp_server/tooling/portfolio_cash.py
@@ -490,7 +490,12 @@ async def get_available_capital_impl(
             logger.warning("Failed to get manual cash setting: %s", exc)
             errors.append({"source": "manual_cash", "error": str(exc)})
 
-    account_costs = await get_account_costs_setting()
+    try:
+        account_costs = await get_account_costs_setting()
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("Failed to get account cost setting: %s", exc)
+        errors.append({"source": "account_costs", "error": str(exc)})
+        account_costs = None
     for processed_acc in processed_accounts:
         account_id = str(processed_acc.get("account") or "")
         market = "us" if processed_acc.get("currency") == "USD" else "kr"

--- a/app/mcp_server/tooling/portfolio_cash.py
+++ b/app/mcp_server/tooling/portfolio_cash.py
@@ -17,7 +17,16 @@ from app.mcp_server.tooling.shared import (
 from app.mcp_server.tooling.shared import (
     normalize_account_filter as _normalize_account_filter,
 )
-from app.mcp_server.tooling.user_settings_tools import get_manual_cash_setting
+from app.mcp_server.tooling.user_settings_tools import (
+    get_manual_cash_setting,
+    get_user_setting,
+)
+from app.services.account_routing import compact_cost_profile
+
+
+async def get_account_costs_setting() -> dict[str, Any] | None:
+    value = await get_user_setting("account_costs")
+    return value if isinstance(value, dict) else None
 from app.services.brokers.kis import (
     KISClient,
     extract_domestic_cash_summary_from_integrated_margin,
@@ -481,6 +490,14 @@ async def get_available_capital_impl(
             logger.warning("Failed to get manual cash setting: %s", exc)
             errors.append({"source": "manual_cash", "error": str(exc)})
 
+    account_costs = await get_account_costs_setting()
+    for processed_acc in processed_accounts:
+        account_id = str(processed_acc.get("account") or "")
+        market = "us" if processed_acc.get("currency") == "USD" else "kr"
+        profile = compact_cost_profile(account_id, market, account_costs)
+        if profile is not None:
+            processed_acc["cost_profile"] = profile
+
     return {
         "accounts": processed_accounts,
         "manual_cash": manual_cash_result,
@@ -498,6 +515,7 @@ __all__ = [
     "get_cash_balance_impl",
     "get_available_capital_impl",
     "get_usd_krw_rate",
+    "get_account_costs_setting",
     "is_us_nation_name",
     "extract_usd_orderable_from_row",
     "select_usd_row_for_us_order",

--- a/app/mcp_server/tooling/portfolio_cash.py
+++ b/app/mcp_server/tooling/portfolio_cash.py
@@ -22,17 +22,17 @@ from app.mcp_server.tooling.user_settings_tools import (
     get_user_setting,
 )
 from app.services.account_routing import compact_cost_profile
-
-
-async def get_account_costs_setting() -> dict[str, Any] | None:
-    value = await get_user_setting("account_costs")
-    return value if isinstance(value, dict) else None
 from app.services.brokers.kis import (
     KISClient,
     extract_domestic_cash_summary_from_integrated_margin,
 )
 from app.services.exchange_rate_service import get_usd_krw_rate as _get_usd_krw_rate
 from app.services.toss_portfolio_service import fetch_toss_cash_snapshot
+
+
+async def get_account_costs_setting() -> dict[str, Any] | None:
+    value = await get_user_setting("account_costs")
+    return value if isinstance(value, dict) else None
 
 
 def _create_kis_client(*, is_mock: bool) -> KISClient:

--- a/app/mcp_server/tooling/registry.py
+++ b/app/mcp_server/tooling/registry.py
@@ -40,6 +40,9 @@ from typing import TYPE_CHECKING
 from app.core.config import settings
 from app.mcp_server.profiles import McpProfile
 from app.mcp_server.tooling import orders_kiwoom_variants
+from app.mcp_server.tooling.account_routing_registration import (
+    register_account_routing_tools,
+)
 from app.mcp_server.tooling.alpaca_paper import register_alpaca_paper_tools
 from app.mcp_server.tooling.alpaca_paper_ledger_read import (
     register_alpaca_paper_ledger_read_tools,
@@ -91,9 +94,6 @@ from app.mcp_server.tooling.paper_journal_registration import (
     register_paper_journal_tools,
 )
 from app.mcp_server.tooling.portfolio_registration import register_portfolio_tools
-from app.mcp_server.tooling.account_routing_registration import (
-    register_account_routing_tools,
-)
 from app.mcp_server.tooling.session_context_registration import (
     register_session_context_tools,
 )

--- a/app/mcp_server/tooling/registry.py
+++ b/app/mcp_server/tooling/registry.py
@@ -91,6 +91,9 @@ from app.mcp_server.tooling.paper_journal_registration import (
     register_paper_journal_tools,
 )
 from app.mcp_server.tooling.portfolio_registration import register_portfolio_tools
+from app.mcp_server.tooling.account_routing_registration import (
+    register_account_routing_tools,
+)
 from app.mcp_server.tooling.session_context_registration import (
     register_session_context_tools,
 )
@@ -148,6 +151,7 @@ def register_all_tools(mcp: FastMCP, profile: McpProfile = McpProfile.DEFAULT) -
 
     # Always: live/mock account read-only tools and journals.
     register_portfolio_tools(mcp)
+    register_account_routing_tools(mcp)
     register_trade_journal_tools(mcp)
     register_mock_loop_retro_tools(mcp)
     register_trade_retrospective_tools(mcp)

--- a/app/mcp_server/tooling/user_settings_registration.py
+++ b/app/mcp_server/tooling/user_settings_registration.py
@@ -28,6 +28,7 @@ def register_user_settings_tools(mcp: FastMCP) -> None:
         name="set_user_setting",
         description=(
             "Set a user setting value by key (upsert). "
+            "Supported operator-maintained keys include 'manual_cash' and 'account_costs'. "
             "Creates or updates the setting and returns the serialized result with key, value, and updated_at."
         ),
     )(set_user_setting)

--- a/app/services/account_routing.py
+++ b/app/services/account_routing.py
@@ -1,0 +1,378 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Literal
+
+Market = Literal["kr", "us"]
+
+DEFAULT_ACCOUNT_COSTS: dict[str, Any] = {
+    "version": 1,
+    "routing": {
+        "position_consolidation_threshold_bps": {
+            "kr": 25.0,
+            "us": 40.0,
+        }
+    },
+    "accounts": {
+        "kis_domestic": {
+            "broker": "kis",
+            "label": "KIS domestic",
+            "markets": {"kr": {"commission_bps": 14.7, "fx_spread_bps": 0.0}},
+        },
+        "kis_overseas": {
+            "broker": "kis",
+            "label": "KIS overseas",
+            "markets": {"us": {"commission_bps": 25.0, "fx_spread_bps": 20.0}},
+        },
+        "toss": {
+            "broker": "toss",
+            "label": "Toss",
+            "limits": {"max_order_notional_krw": 1_000_000.0},
+            "markets": {
+                "kr": {"commission_bps": 0.0, "fx_spread_bps": 0.0},
+                "us": {"commission_bps": 10.0, "fx_spread_bps": 1.7},
+            },
+        },
+    },
+}
+
+
+@dataclass(frozen=True)
+class MarketCostProfile:
+    commission_bps: float
+    fx_spread_bps: float
+
+
+@dataclass(frozen=True)
+class AccountCostProfiles:
+    raw: dict[str, Any]
+    source: str
+    review_required: bool
+
+    def threshold_bps(self, market: Market) -> float:
+        routing = self.raw.get("routing") if isinstance(self.raw, dict) else {}
+        thresholds = (
+            routing.get("position_consolidation_threshold_bps", {})
+            if isinstance(routing, dict)
+            else {}
+        )
+        fallback = DEFAULT_ACCOUNT_COSTS["routing"]["position_consolidation_threshold_bps"][market]
+        return float(thresholds.get(market, fallback))
+
+    def account(self, account_id: str) -> dict[str, Any]:
+        accounts = self.raw.get("accounts", {}) if isinstance(self.raw, dict) else {}
+        value = accounts.get(account_id, {})
+        return value if isinstance(value, dict) else {}
+
+    def market_profile(self, account_id: str, market: Market) -> MarketCostProfile:
+        account = self.account(account_id)
+        markets = account.get("markets", {}) if isinstance(account, dict) else {}
+        profile = markets.get(market, {}) if isinstance(markets, dict) else {}
+        default = DEFAULT_ACCOUNT_COSTS["accounts"].get(account_id, {}).get("markets", {}).get(market, {})
+        return MarketCostProfile(
+            commission_bps=float(profile.get("commission_bps", default.get("commission_bps", 0.0))),
+            fx_spread_bps=float(profile.get("fx_spread_bps", default.get("fx_spread_bps", 0.0))),
+        )
+
+    def max_order_notional_krw(self, account_id: str) -> float | None:
+        account = self.account(account_id)
+        limits = account.get("limits", {}) if isinstance(account, dict) else {}
+        value = limits.get("max_order_notional_krw") if isinstance(limits, dict) else None
+        return None if value is None else float(value)
+
+
+@dataclass(frozen=True)
+class AccountRoutingInput:
+    symbol: str
+    market: Market
+    side: str
+    quantity: float
+    price: float
+    usd_krw: float | None
+    account_costs: dict[str, Any] | None
+    capital_snapshot: dict[str, Any]
+    holdings_snapshot: dict[str, Any]
+
+
+def build_cost_profiles(value: dict[str, Any] | None) -> AccountCostProfiles:
+    if not isinstance(value, dict) or int(value.get("version", 0) or 0) != 1:
+        return AccountCostProfiles(
+            raw=DEFAULT_ACCOUNT_COSTS,
+            source="default_seed",
+            review_required=True,
+        )
+    return AccountCostProfiles(raw=value, source="user_setting", review_required=False)
+
+
+def compact_cost_profile(
+    account_id: str,
+    market: Market,
+    value: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    profiles = build_cost_profiles(value)
+    if account_id not in _candidate_accounts(market):
+        return None
+    profile = profiles.market_profile(account_id, market)
+    return {
+        "commission_bps": profile.commission_bps,
+        "fx_spread_bps": profile.fx_spread_bps,
+        "source": profiles.source,
+        "review_required": profiles.review_required,
+    }
+
+
+def _candidate_accounts(market: Market) -> tuple[str, str]:
+    if market == "kr":
+        return ("kis_domestic", "toss")
+    return ("kis_overseas", "toss")
+
+
+def _orderable_by_account_currency(snapshot: dict[str, Any]) -> dict[str, dict[str, float]]:
+    result: dict[str, dict[str, float]] = {}
+    for row in snapshot.get("accounts") or []:
+        account = str(row.get("account") or "")
+        currency = str(row.get("currency") or "KRW").upper()
+        orderable = float(row.get("orderable") or 0.0)
+        bucket = result.setdefault(account, {"KRW": 0.0, "USD": 0.0})
+        if currency in bucket:
+            bucket[currency] += orderable
+    return result
+
+
+def _existing_accounts(snapshot: dict[str, Any], *, symbol: str, market: Market) -> list[str]:
+    normalized = symbol.strip().upper() if market == "us" else symbol.strip()
+    found: list[str] = []
+    for account in snapshot.get("accounts") or []:
+        account_id = str(account.get("account") or "")
+        if account_id not in _candidate_accounts(market):
+            continue
+        for position in account.get("positions") or []:
+            pos_symbol = str(position.get("symbol") or "")
+            comparable = pos_symbol.upper() if market == "us" else pos_symbol
+            if comparable == normalized and account_id not in found:
+                found.append(account_id)
+    return found
+
+
+def _notional(input: AccountRoutingInput) -> dict[str, float | None | str]:
+    if input.market == "us":
+        if input.usd_krw is None or input.usd_krw <= 0:
+            raise ValueError("usd_krw is required for US account routing")
+        notional_usd = float(input.quantity) * float(input.price)
+        return {
+            "currency": "USD",
+            "notional_usd": notional_usd,
+            "notional_krw": notional_usd * float(input.usd_krw),
+            "usd_krw": float(input.usd_krw),
+        }
+    return {
+        "currency": "KRW",
+        "notional_usd": None,
+        "notional_krw": float(input.quantity) * float(input.price),
+        "usd_krw": None,
+    }
+
+
+def _cost_row(
+    *,
+    account_id: str,
+    market: Market,
+    notional_krw: float,
+    notional_usd: float | None,
+    cash: dict[str, float],
+    usd_krw: float | None,
+    profiles: AccountCostProfiles,
+) -> dict[str, Any]:
+    profile = profiles.market_profile(account_id, market)
+    ineligible_reason = None
+    usd_orderable = float(cash.get("USD") or 0.0)
+    krw_orderable = float(cash.get("KRW") or 0.0)
+    usd_orderable_krw = usd_orderable * float(usd_krw or 0.0)
+    orderable_krw = krw_orderable + usd_orderable_krw
+    max_notional = profiles.max_order_notional_krw(account_id)
+    if max_notional is not None and notional_krw > max_notional:
+        ineligible_reason = "notional_limit_exceeded"
+    elif orderable_krw < notional_krw:
+        ineligible_reason = "insufficient_orderable_cash"
+    commission_base = notional_krw
+    commission_cost_krw = commission_base * profile.commission_bps / 10_000.0
+    fx_notional_krw = (
+        max(0.0, notional_krw - usd_orderable_krw) if market == "us" else 0.0
+    )
+    fx_cost_krw = fx_notional_krw * profile.fx_spread_bps / 10_000.0
+    return {
+        "eligible": ineligible_reason is None,
+        "commission_bps": profile.commission_bps,
+        "fx_spread_bps": profile.fx_spread_bps,
+        "commission_cost_krw": commission_cost_krw,
+        "fx_notional_krw": fx_notional_krw,
+        "fx_cost_krw": fx_cost_krw,
+        "total_cost_krw": commission_cost_krw + fx_cost_krw,
+        "orderable_krw": orderable_krw,
+        "orderable_usd": usd_orderable,
+        "orderable_cash_krw": krw_orderable,
+        "notional_usd": notional_usd,
+        "ineligible_reason": ineligible_reason,
+    }
+
+
+def suggest_account_from_snapshot(input: AccountRoutingInput) -> dict[str, Any]:
+    if input.side.lower() != "buy":
+        raise ValueError("suggest_order_account supports buy side only")
+    if input.market not in ("kr", "us"):
+        raise ValueError("suggest_order_account supports kr/us markets only")
+    if input.quantity <= 0:
+        raise ValueError("quantity must be positive")
+    if input.price <= 0:
+        raise ValueError("price must be positive")
+
+    profiles = build_cost_profiles(input.account_costs)
+    notional = _notional(input)
+    notional_krw = float(notional["notional_krw"] or 0.0)
+    notional_usd = notional["notional_usd"]
+    orderable = _orderable_by_account_currency(input.capital_snapshot)
+    candidates = _candidate_accounts(input.market)
+    cost_comparison = {
+        account: _cost_row(
+            account_id=account,
+            market=input.market,
+            notional_krw=notional_krw,
+            notional_usd=float(notional_usd) if notional_usd is not None else None,
+            cash=orderable.get(account, {}),
+            usd_krw=input.usd_krw,
+            profiles=profiles,
+        )
+        for account in candidates
+    }
+    eligible = {
+        account: row
+        for account, row in cost_comparison.items()
+        if row["eligible"]
+    }
+    existing = _existing_accounts(
+        input.holdings_snapshot,
+        symbol=input.symbol,
+        market=input.market,
+    )
+    notes = ["Advisory only. Operator must choose the final order account."]
+    if input.market == "us":
+        notes.append(
+            "US recommendations use a stronger consolidation threshold because FX basis and tax lots split by account."
+        )
+    data_quality = []
+    if profiles.review_required:
+        data_quality.append("using_default_account_costs_review_required")
+
+    if not eligible:
+        return {
+            "success": False,
+            "advisory_only": True,
+            "symbol": input.symbol,
+            "market": input.market,
+            "side": input.side.lower(),
+            "quantity": input.quantity,
+            "price": input.price,
+            "notional": notional,
+            "recommended_account": None,
+            "cost_comparison": cost_comparison,
+            "position_consolidation": {
+                "existing_accounts": existing,
+                "decision": "no_eligible_account",
+                "distribution_warning": False,
+            },
+            "reason_codes": ["no_eligible_account"],
+            "data_quality": data_quality,
+            "notes": notes,
+            "errors": input.capital_snapshot.get("errors", []) + input.holdings_snapshot.get("errors", []),
+        }
+
+    cheapest = min(eligible, key=lambda key: eligible[key]["total_cost_krw"])
+    threshold_bps = profiles.threshold_bps(input.market)
+    threshold_amount = notional_krw * threshold_bps / 10_000.0
+    reason_codes: list[str] = []
+    preferred_existing = existing[0] if len(existing) == 1 else None
+    decision = "no_existing_position"
+    recommended = cheapest
+    foregone_savings = None
+    savings_vs_existing = None
+    distribution_warning = False
+    existing_ineligible = False
+
+    if len(existing) > 1:
+        decision = "already_split_cheapest_eligible"
+        reason_codes.append("already_split")
+    elif preferred_existing is not None:
+        if preferred_existing not in eligible:
+            decision = "existing_account_ineligible"
+            existing_ineligible = True
+            reason_codes.append("existing_account_ineligible")
+        else:
+            existing_cost = eligible[preferred_existing]["total_cost_krw"]
+            cheapest_cost = eligible[cheapest]["total_cost_krw"]
+            savings_vs_existing = max(0.0, existing_cost - cheapest_cost)
+            if cheapest != preferred_existing and savings_vs_existing >= threshold_amount:
+                decision = "break_for_cost"
+                recommended = cheapest
+                distribution_warning = True
+                reason_codes.append("distribution_warning")
+            else:
+                decision = "keep_existing"
+                recommended = preferred_existing
+                foregone_savings = savings_vs_existing
+                reason_codes.append("existing_position_below_threshold")
+    else:
+        reason_codes.append("lowest_total_cost")
+
+    return {
+        "success": True,
+        "advisory_only": True,
+        "symbol": input.symbol,
+        "market": input.market,
+        "side": input.side.lower(),
+        "quantity": input.quantity,
+        "price": input.price,
+        "notional": notional,
+        "recommended_account": recommended,
+        "cost_comparison": cost_comparison,
+        "position_consolidation": {
+            "existing_accounts": existing,
+            "preferred_existing_account": preferred_existing,
+            "threshold_bps": threshold_bps,
+            "threshold_amount_krw": threshold_amount,
+            "savings_vs_existing_krw": savings_vs_existing,
+            "decision": decision,
+            "foregone_savings_krw": foregone_savings,
+            "distribution_warning": distribution_warning,
+            "existing_account_ineligible": existing_ineligible,
+            "note": _consolidation_note(decision),
+        },
+        "reason_codes": reason_codes,
+        "data_quality": data_quality,
+        "notes": notes,
+        "errors": input.capital_snapshot.get("errors", []) + input.holdings_snapshot.get("errors", []),
+    }
+
+
+def _consolidation_note(decision: str) -> str:
+    if decision == "keep_existing":
+        return "Existing position consolidation wins because savings are below threshold."
+    if decision == "break_for_cost":
+        return "Cheaper account exceeds the consolidation break threshold; distribution warning applies."
+    if decision == "existing_account_ineligible":
+        return "Existing position account is not eligible for this buy size."
+    if decision == "already_split_cheapest_eligible":
+        return "Position is already split across candidate accounts; cheapest eligible account wins."
+    if decision == "no_eligible_account":
+        return "No compared account has enough eligible buying power."
+    return "No existing KIS/Toss position; cheapest eligible account wins."
+
+
+__all__ = [
+    "DEFAULT_ACCOUNT_COSTS",
+    "AccountCostProfiles",
+    "AccountRoutingInput",
+    "MarketCostProfile",
+    "build_cost_profiles",
+    "compact_cost_profile",
+    "suggest_account_from_snapshot",
+]

--- a/app/services/account_routing.py
+++ b/app/services/account_routing.py
@@ -56,7 +56,9 @@ class AccountCostProfiles:
             if isinstance(routing, dict)
             else {}
         )
-        fallback = DEFAULT_ACCOUNT_COSTS["routing"]["position_consolidation_threshold_bps"][market]
+        fallback = DEFAULT_ACCOUNT_COSTS["routing"][
+            "position_consolidation_threshold_bps"
+        ][market]
         return float(thresholds.get(market, fallback))
 
     def account(self, account_id: str) -> dict[str, Any]:
@@ -68,16 +70,27 @@ class AccountCostProfiles:
         account = self.account(account_id)
         markets = account.get("markets", {}) if isinstance(account, dict) else {}
         profile = markets.get(market, {}) if isinstance(markets, dict) else {}
-        default = DEFAULT_ACCOUNT_COSTS["accounts"].get(account_id, {}).get("markets", {}).get(market, {})
+        default = (
+            DEFAULT_ACCOUNT_COSTS["accounts"]
+            .get(account_id, {})
+            .get("markets", {})
+            .get(market, {})
+        )
         return MarketCostProfile(
-            commission_bps=float(profile.get("commission_bps", default.get("commission_bps", 0.0))),
-            fx_spread_bps=float(profile.get("fx_spread_bps", default.get("fx_spread_bps", 0.0))),
+            commission_bps=float(
+                profile.get("commission_bps", default.get("commission_bps", 0.0))
+            ),
+            fx_spread_bps=float(
+                profile.get("fx_spread_bps", default.get("fx_spread_bps", 0.0))
+            ),
         )
 
     def max_order_notional_krw(self, account_id: str) -> float | None:
         account = self.account(account_id)
         limits = account.get("limits", {}) if isinstance(account, dict) else {}
-        value = limits.get("max_order_notional_krw") if isinstance(limits, dict) else None
+        value = (
+            limits.get("max_order_notional_krw") if isinstance(limits, dict) else None
+        )
         return None if value is None else float(value)
 
 
@@ -127,7 +140,9 @@ def _candidate_accounts(market: Market) -> tuple[str, str]:
     return ("kis_overseas", "toss")
 
 
-def _orderable_by_account_currency(snapshot: dict[str, Any]) -> dict[str, dict[str, float]]:
+def _orderable_by_account_currency(
+    snapshot: dict[str, Any],
+) -> dict[str, dict[str, float]]:
     result: dict[str, dict[str, float]] = {}
     for row in snapshot.get("accounts") or []:
         account = str(row.get("account") or "")
@@ -139,7 +154,9 @@ def _orderable_by_account_currency(snapshot: dict[str, Any]) -> dict[str, dict[s
     return result
 
 
-def _existing_accounts(snapshot: dict[str, Any], *, symbol: str, market: Market) -> list[str]:
+def _existing_accounts(
+    snapshot: dict[str, Any], *, symbol: str, market: Market
+) -> list[str]:
     normalized = symbol.strip().upper() if market == "us" else symbol.strip()
     found: list[str] = []
     for account in snapshot.get("accounts") or []:
@@ -245,9 +262,7 @@ def suggest_account_from_snapshot(input: AccountRoutingInput) -> dict[str, Any]:
         for account in candidates
     }
     eligible = {
-        account: row
-        for account, row in cost_comparison.items()
-        if row["eligible"]
+        account: row for account, row in cost_comparison.items() if row["eligible"]
     }
     existing = _existing_accounts(
         input.holdings_snapshot,
@@ -283,7 +298,8 @@ def suggest_account_from_snapshot(input: AccountRoutingInput) -> dict[str, Any]:
             "reason_codes": ["no_eligible_account"],
             "data_quality": data_quality,
             "notes": notes,
-            "errors": input.capital_snapshot.get("errors", []) + input.holdings_snapshot.get("errors", []),
+            "errors": input.capital_snapshot.get("errors", [])
+            + input.holdings_snapshot.get("errors", []),
         }
 
     cheapest = min(eligible, key=lambda key: eligible[key]["total_cost_krw"])
@@ -310,7 +326,10 @@ def suggest_account_from_snapshot(input: AccountRoutingInput) -> dict[str, Any]:
             existing_cost = eligible[preferred_existing]["total_cost_krw"]
             cheapest_cost = eligible[cheapest]["total_cost_krw"]
             savings_vs_existing = max(0.0, existing_cost - cheapest_cost)
-            if cheapest != preferred_existing and savings_vs_existing >= threshold_amount:
+            if (
+                cheapest != preferred_existing
+                and savings_vs_existing >= threshold_amount
+            ):
                 decision = "break_for_cost"
                 recommended = cheapest
                 distribution_warning = True
@@ -349,13 +368,16 @@ def suggest_account_from_snapshot(input: AccountRoutingInput) -> dict[str, Any]:
         "reason_codes": reason_codes,
         "data_quality": data_quality,
         "notes": notes,
-        "errors": input.capital_snapshot.get("errors", []) + input.holdings_snapshot.get("errors", []),
+        "errors": input.capital_snapshot.get("errors", [])
+        + input.holdings_snapshot.get("errors", []),
     }
 
 
 def _consolidation_note(decision: str) -> str:
     if decision == "keep_existing":
-        return "Existing position consolidation wins because savings are below threshold."
+        return (
+            "Existing position consolidation wins because savings are below threshold."
+        )
     if decision == "break_for_cost":
         return "Cheaper account exceeds the consolidation break threshold; distribution warning applies."
     if decision == "existing_account_ineligible":

--- a/app/services/account_routing.py
+++ b/app/services/account_routing.py
@@ -59,7 +59,7 @@ class AccountCostProfiles:
         fallback = DEFAULT_ACCOUNT_COSTS["routing"][
             "position_consolidation_threshold_bps"
         ][market]
-        return float(thresholds.get(market, fallback))
+        return _float_or_default(thresholds.get(market), fallback)
 
     def account(self, account_id: str) -> dict[str, Any]:
         accounts = self.raw.get("accounts", {}) if isinstance(self.raw, dict) else {}
@@ -77,21 +77,29 @@ class AccountCostProfiles:
             .get(market, {})
         )
         return MarketCostProfile(
-            commission_bps=float(
-                profile.get("commission_bps", default.get("commission_bps", 0.0))
+            commission_bps=_float_or_default(
+                profile.get("commission_bps"),
+                float(default.get("commission_bps", 0.0)),
             ),
-            fx_spread_bps=float(
-                profile.get("fx_spread_bps", default.get("fx_spread_bps", 0.0))
+            fx_spread_bps=_float_or_default(
+                profile.get("fx_spread_bps"),
+                float(default.get("fx_spread_bps", 0.0)),
             ),
         )
 
     def max_order_notional_krw(self, account_id: str) -> float | None:
         account = self.account(account_id)
         limits = account.get("limits", {}) if isinstance(account, dict) else {}
-        value = (
-            limits.get("max_order_notional_krw") if isinstance(limits, dict) else None
+        if not isinstance(limits, dict) or "max_order_notional_krw" not in limits:
+            return None
+        default_limits = (
+            DEFAULT_ACCOUNT_COSTS["accounts"].get(account_id, {}).get("limits", {})
         )
-        return None if value is None else float(value)
+        default_value = default_limits.get("max_order_notional_krw")
+        fallback = None if default_value is None else float(default_value)
+        return _optional_float_or_default(
+            limits.get("max_order_notional_krw"), fallback
+        )
 
 
 @dataclass(frozen=True)
@@ -108,13 +116,79 @@ class AccountRoutingInput:
 
 
 def build_cost_profiles(value: dict[str, Any] | None) -> AccountCostProfiles:
-    if not isinstance(value, dict) or int(value.get("version", 0) or 0) != 1:
+    if not isinstance(value, dict):
         return AccountCostProfiles(
             raw=DEFAULT_ACCOUNT_COSTS,
             source="default_seed",
             review_required=True,
         )
-    return AccountCostProfiles(raw=value, source="user_setting", review_required=False)
+    try:
+        version = int(value.get("version", 0) or 0)
+    except (TypeError, ValueError):
+        version = 0
+    if version != 1:
+        return AccountCostProfiles(
+            raw=DEFAULT_ACCOUNT_COSTS,
+            source="default_seed",
+            review_required=True,
+        )
+    return AccountCostProfiles(
+        raw=value,
+        source="user_setting",
+        review_required=_has_invalid_numeric_values(value),
+    )
+
+
+def _float_or_default(value: Any, default: float) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _optional_float_or_default(value: Any, default: float | None) -> float | None:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _is_invalid_number(value: Any) -> bool:
+    try:
+        float(value)
+    except (TypeError, ValueError):
+        return True
+    return False
+
+
+def _has_invalid_numeric_values(value: dict[str, Any]) -> bool:
+    routing = value.get("routing")
+    if isinstance(routing, dict):
+        thresholds = routing.get("position_consolidation_threshold_bps")
+        if isinstance(thresholds, dict):
+            if any(_is_invalid_number(raw) for raw in thresholds.values()):
+                return True
+
+    accounts = value.get("accounts")
+    if not isinstance(accounts, dict):
+        return False
+    for account in accounts.values():
+        if not isinstance(account, dict):
+            continue
+        limits = account.get("limits")
+        if isinstance(limits, dict) and "max_order_notional_krw" in limits:
+            if _is_invalid_number(limits.get("max_order_notional_krw")):
+                return True
+        markets = account.get("markets")
+        if not isinstance(markets, dict):
+            continue
+        for market_profile in markets.values():
+            if not isinstance(market_profile, dict):
+                continue
+            for key in ("commission_bps", "fx_spread_bps"):
+                if key in market_profile and _is_invalid_number(market_profile[key]):
+                    return True
+    return False
 
 
 def compact_cost_profile(
@@ -123,9 +197,10 @@ def compact_cost_profile(
     value: dict[str, Any] | None,
 ) -> dict[str, Any] | None:
     profiles = build_cost_profiles(value)
-    if account_id not in _candidate_accounts(market):
+    cost_account_id = cost_profile_account_id(account_id, market)
+    if cost_account_id not in _candidate_accounts(market):
         return None
-    profile = profiles.market_profile(account_id, market)
+    profile = profiles.market_profile(cost_account_id, market)
     return {
         "commission_bps": profile.commission_bps,
         "fx_spread_bps": profile.fx_spread_bps,
@@ -138,6 +213,31 @@ def _candidate_accounts(market: Market) -> tuple[str, str]:
     if market == "kr":
         return ("kis_domestic", "toss")
     return ("kis_overseas", "toss")
+
+
+def cost_profile_account_id(
+    account_id: str,
+    market: Market,
+    *,
+    broker: str | None = None,
+    source: str | None = None,
+) -> str:
+    """Map holdings account labels to routing/cost account ids.
+
+    KIS holdings are grouped as ``account='kis'`` by portfolio_holdings, while
+    cash/cost profiles are split by market as ``kis_domestic`` and
+    ``kis_overseas``.
+    """
+    normalized = str(account_id or "").strip().lower()
+    normalized_broker = str(broker or "").strip().lower()
+    normalized_source = str(source or "").strip().lower()
+    if (
+        normalized == "kis"
+        or normalized_broker == "kis"
+        or normalized_source == "kis_api"
+    ):
+        return "kis_domestic" if market == "kr" else "kis_overseas"
+    return normalized
 
 
 def _orderable_by_account_currency(
@@ -160,7 +260,12 @@ def _existing_accounts(
     normalized = symbol.strip().upper() if market == "us" else symbol.strip()
     found: list[str] = []
     for account in snapshot.get("accounts") or []:
-        account_id = str(account.get("account") or "")
+        account_id = cost_profile_account_id(
+            str(account.get("account") or ""),
+            market,
+            broker=account.get("broker"),
+            source=account.get("source"),
+        )
         if account_id not in _candidate_accounts(market):
             continue
         for position in account.get("positions") or []:
@@ -396,5 +501,6 @@ __all__ = [
     "MarketCostProfile",
     "build_cost_profiles",
     "compact_cost_profile",
+    "cost_profile_account_id",
     "suggest_account_from_snapshot",
 ]

--- a/tests/mcp_server/test_account_routing_tools.py
+++ b/tests/mcp_server/test_account_routing_tools.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+import pytest
+
+from app.mcp_server.profiles import McpProfile
+from app.mcp_server.tooling.account_routing_registration import (
+    ACCOUNT_ROUTING_TOOL_NAMES,
+    register_account_routing_tools,
+)
+from app.mcp_server.tooling.registry import register_all_tools
+
+
+class DummyMCP:
+    def __init__(self) -> None:
+        self.tools: dict[str, Callable[..., Any]] = {}
+
+    def tool(self, *, name: str, description: str):
+        assert description
+
+        def decorator(fn):
+            self.tools[name] = fn
+            return fn
+
+        return decorator
+
+
+def test_account_routing_tool_names_register():
+    mcp = DummyMCP()
+
+    register_account_routing_tools(mcp)  # type: ignore[arg-type]
+
+    assert ACCOUNT_ROUTING_TOOL_NAMES == {"suggest_order_account"}
+    assert set(mcp.tools) == {"suggest_order_account"}
+
+
+@pytest.mark.parametrize("profile", list(McpProfile))
+def test_suggest_order_account_registered_on_all_read_profiles(profile):
+    mcp = DummyMCP()
+
+    register_all_tools(mcp, profile=profile)  # type: ignore[arg-type]
+
+    assert "suggest_order_account" in mcp.tools
+
+
+@pytest.mark.asyncio
+async def test_registered_tool_delegates_to_impl(monkeypatch):
+    from app.mcp_server.tooling import account_routing_registration
+
+    calls = []
+
+    async def fake_impl(**kwargs):
+        calls.append(kwargs)
+        return {"success": True, "recommended_account": "toss"}
+
+    monkeypatch.setattr(
+        account_routing_registration,
+        "suggest_order_account_impl",
+        fake_impl,
+    )
+    mcp = DummyMCP()
+    register_account_routing_tools(mcp)  # type: ignore[arg-type]
+
+    result = await mcp.tools["suggest_order_account"](
+        symbol="005930",
+        market="kr",
+        side="buy",
+        quantity=10,
+        price=75_000,
+    )
+
+    assert result == {"success": True, "recommended_account": "toss"}
+    assert calls == [
+        {
+            "symbol": "005930",
+            "market": "kr",
+            "side": "buy",
+            "quantity": 10,
+            "price": 75_000,
+            "usd_krw": None,
+        }
+    ]

--- a/tests/mcp_server/test_account_routing_tools.py
+++ b/tests/mcp_server/test_account_routing_tools.py
@@ -125,7 +125,8 @@ async def test_suggest_order_account_impl_uses_snapshots_and_user_costs(monkeypa
         return {
             "accounts": [
                 {
-                    "account": "kis_domestic",
+                    "account": "kis",
+                    "broker": "kis",
                     "positions": [{"symbol": "005930", "quantity": 1}],
                 }
             ],

--- a/tests/mcp_server/test_account_routing_tools.py
+++ b/tests/mcp_server/test_account_routing_tools.py
@@ -92,9 +92,7 @@ async def test_suggest_order_account_impl_uses_snapshots_and_user_costs(monkeypa
         assert key == "account_costs"
         return {
             "version": 1,
-            "routing": {
-                "position_consolidation_threshold_bps": {"kr": 25, "us": 40}
-            },
+            "routing": {"position_consolidation_threshold_bps": {"kr": 25, "us": 40}},
             "accounts": {
                 "kis_domestic": {
                     "broker": "kis",
@@ -111,7 +109,11 @@ async def test_suggest_order_account_impl_uses_snapshots_and_user_costs(monkeypa
         assert kwargs["include_manual"] is False
         return {
             "accounts": [
-                {"account": "kis_domestic", "currency": "KRW", "orderable": 2_000_000.0},
+                {
+                    "account": "kis_domestic",
+                    "currency": "KRW",
+                    "orderable": 2_000_000.0,
+                },
                 {"account": "toss", "currency": "KRW", "orderable": 1_000_000.0},
             ],
             "errors": [],
@@ -144,7 +146,9 @@ async def test_suggest_order_account_impl_uses_snapshots_and_user_costs(monkeypa
 
     assert result["success"] is True
     assert result["recommended_account"] == "kis_domestic"
-    assert result["position_consolidation"]["foregone_savings_krw"] == pytest.approx(1102.5)
+    assert result["position_consolidation"]["foregone_savings_krw"] == pytest.approx(
+        1102.5
+    )
     assert result["cost_comparison"]["toss"]["total_cost_krw"] == pytest.approx(0)
     assert result["advisory_only"] is True
     assert result["price_source"] == "input"

--- a/tests/mcp_server/test_account_routing_tools.py
+++ b/tests/mcp_server/test_account_routing_tools.py
@@ -156,6 +156,25 @@ async def test_suggest_order_account_impl_uses_snapshots_and_user_costs(monkeypa
 
 
 @pytest.mark.asyncio
+async def test_suggest_order_account_impl_rejects_sell_before_quote(monkeypatch):
+    from app.mcp_server.tooling import account_routing_tools as tools
+
+    async def fail_quote(_symbol):
+        raise AssertionError("quote should not be fetched for unsupported side")
+
+    monkeypatch.setattr(tools, "_fetch_quote_equity_kr", fail_quote)
+
+    with pytest.raises(ValueError, match="buy side only"):
+        await tools.suggest_order_account_impl(
+            symbol="005930",
+            market="kr",
+            side="sell",
+            quantity=10,
+            price=None,
+        )
+
+
+@pytest.mark.asyncio
 async def test_suggest_order_account_impl_fetches_us_fx_when_missing(monkeypatch):
     from app.mcp_server.tooling import account_routing_tools as tools
 

--- a/tests/mcp_server/test_account_routing_tools.py
+++ b/tests/mcp_server/test_account_routing_tools.py
@@ -82,3 +82,112 @@ async def test_registered_tool_delegates_to_impl(monkeypatch):
             "usd_krw": None,
         }
     ]
+
+
+@pytest.mark.asyncio
+async def test_suggest_order_account_impl_uses_snapshots_and_user_costs(monkeypatch):
+    from app.mcp_server.tooling import account_routing_tools as tools
+
+    async def fake_setting(key):
+        assert key == "account_costs"
+        return {
+            "version": 1,
+            "routing": {
+                "position_consolidation_threshold_bps": {"kr": 25, "us": 40}
+            },
+            "accounts": {
+                "kis_domestic": {
+                    "broker": "kis",
+                    "markets": {"kr": {"commission_bps": 14.7, "fx_spread_bps": 0}},
+                },
+                "toss": {
+                    "broker": "toss",
+                    "markets": {"kr": {"commission_bps": 0, "fx_spread_bps": 0}},
+                },
+            },
+        }
+
+    async def fake_capital(**kwargs):
+        assert kwargs["include_manual"] is False
+        return {
+            "accounts": [
+                {"account": "kis_domestic", "currency": "KRW", "orderable": 2_000_000.0},
+                {"account": "toss", "currency": "KRW", "orderable": 1_000_000.0},
+            ],
+            "errors": [],
+        }
+
+    async def fake_holdings(**kwargs):
+        assert kwargs["market"] == "kr"
+        assert kwargs["include_current_price"] is False
+        return {
+            "accounts": [
+                {
+                    "account": "kis_domestic",
+                    "positions": [{"symbol": "005930", "quantity": 1}],
+                }
+            ],
+            "errors": [],
+        }
+
+    monkeypatch.setattr(tools, "get_user_setting", fake_setting)
+    monkeypatch.setattr(tools, "get_available_capital_impl", fake_capital)
+    monkeypatch.setattr(tools, "_get_holdings_impl", fake_holdings)
+
+    result = await tools.suggest_order_account_impl(
+        symbol="005930",
+        market="kr",
+        side="buy",
+        quantity=10,
+        price=75_000,
+    )
+
+    assert result["success"] is True
+    assert result["recommended_account"] == "kis_domestic"
+    assert result["position_consolidation"]["foregone_savings_krw"] == pytest.approx(1102.5)
+    assert result["cost_comparison"]["toss"]["total_cost_krw"] == pytest.approx(0)
+    assert result["advisory_only"] is True
+    assert result["price_source"] == "input"
+
+
+@pytest.mark.asyncio
+async def test_suggest_order_account_impl_fetches_us_fx_when_missing(monkeypatch):
+    from app.mcp_server.tooling import account_routing_tools as tools
+
+    async def fake_setting(key):
+        assert key == "account_costs"
+        return None
+
+    async def fake_capital(**kwargs):
+        assert kwargs["include_manual"] is False
+        return {
+            "accounts": [
+                {"account": "kis_overseas", "currency": "USD", "orderable": 2_000.0},
+                {"account": "toss", "currency": "USD", "orderable": 500.0},
+            ],
+            "errors": [],
+        }
+
+    async def fake_holdings(**kwargs):
+        assert kwargs["market"] == "us"
+        return {"accounts": [], "errors": []}
+
+    async def fake_usd_krw_rate():
+        return 1500.0
+
+    monkeypatch.setattr(tools, "get_user_setting", fake_setting)
+    monkeypatch.setattr(tools, "get_available_capital_impl", fake_capital)
+    monkeypatch.setattr(tools, "_get_holdings_impl", fake_holdings)
+    monkeypatch.setattr(tools, "get_usd_krw_rate", fake_usd_krw_rate)
+
+    result = await tools.suggest_order_account_impl(
+        symbol="AAPL",
+        market="us",
+        side="buy",
+        quantity=1,
+        price=100,
+    )
+
+    assert result["notional"]["usd_krw"] == pytest.approx(1500.0)
+    assert set(result["cost_comparison"]) == {"kis_overseas", "toss"}
+    assert result["data_quality"] == ["using_default_account_costs_review_required"]

--- a/tests/mcp_server/test_account_routing_tools.py
+++ b/tests/mcp_server/test_account_routing_tools.py
@@ -175,6 +175,152 @@ async def test_suggest_order_account_impl_rejects_sell_before_quote(monkeypatch)
 
 
 @pytest.mark.asyncio
+async def test_suggest_order_account_impl_rejects_bad_quantity_before_quote(
+    monkeypatch,
+):
+    from app.mcp_server.tooling import account_routing_tools as tools
+
+    async def fail_quote(_symbol):
+        raise AssertionError("quote should not be fetched for invalid quantity")
+
+    monkeypatch.setattr(tools, "_fetch_quote_equity_kr", fail_quote)
+
+    with pytest.raises(ValueError, match="quantity must be positive"):
+        await tools.suggest_order_account_impl(
+            symbol="005930",
+            market="kr",
+            side="buy",
+            quantity=0,
+            price=None,
+        )
+
+
+@pytest.mark.asyncio
+async def test_suggest_order_account_impl_rejects_invalid_market_before_quote(
+    monkeypatch,
+):
+    from app.mcp_server.tooling import account_routing_tools as tools
+
+    async def fail_quote(_symbol):
+        raise AssertionError("quote should not be fetched for invalid market")
+
+    monkeypatch.setattr(tools, "_fetch_quote_equity_kr", fail_quote)
+    monkeypatch.setattr(tools, "_fetch_quote_equity_us", fail_quote)
+
+    with pytest.raises(ValueError, match="market='kr' or market='us'"):
+        await tools.suggest_order_account_impl(
+            symbol="005930",
+            market="crypto",
+            side="buy",
+            quantity=1,
+            price=None,
+        )
+
+
+@pytest.mark.asyncio
+async def test_suggest_order_account_impl_rejects_non_positive_input_price():
+    from app.mcp_server.tooling import account_routing_tools as tools
+
+    with pytest.raises(ValueError, match="price must be positive"):
+        await tools.suggest_order_account_impl(
+            symbol="005930",
+            market="kr",
+            side="buy",
+            quantity=1,
+            price=0,
+        )
+
+
+@pytest.mark.asyncio
+async def test_suggest_order_account_impl_resolves_default_kr_quote(monkeypatch):
+    from app.mcp_server.tooling import account_routing_tools as tools
+
+    async def fake_kr_quote(symbol):
+        assert symbol == "005930"
+        return {"price": 76_000, "source": ""}
+
+    async def fake_setting(key):
+        assert key == "account_costs"
+        return None
+
+    async def fake_capital(**kwargs):
+        assert kwargs["include_manual"] is False
+        return {
+            "accounts": [
+                {"account": "kis_domestic", "currency": "KRW", "orderable": 2_000_000},
+                {"account": "toss", "currency": "KRW", "orderable": 1_000_000},
+            ],
+            "errors": [],
+        }
+
+    async def fake_holdings(**kwargs):
+        assert kwargs["market"] == "kr"
+        return {"accounts": [], "errors": []}
+
+    monkeypatch.setattr(tools, "_fetch_quote_equity_kr", fake_kr_quote)
+    monkeypatch.setattr(tools, "get_user_setting", fake_setting)
+    monkeypatch.setattr(tools, "get_available_capital_impl", fake_capital)
+    monkeypatch.setattr(tools, "_get_holdings_impl", fake_holdings)
+
+    result = await tools.suggest_order_account_impl(
+        symbol="005930",
+        market=None,
+        side="buy",
+        quantity=1,
+        price=None,
+    )
+
+    assert result["market"] == "kr"
+    assert result["price"] == pytest.approx(76_000)
+    assert result["price_source"] == "quote"
+
+
+@pytest.mark.asyncio
+async def test_suggest_order_account_impl_resolves_default_us_quote(monkeypatch):
+    from app.mcp_server.tooling import account_routing_tools as tools
+
+    async def fake_us_quote(symbol):
+        assert symbol == "AAPL"
+        return {"price": 100, "source": "fake_us_quote"}
+
+    async def fake_setting(key):
+        assert key == "account_costs"
+        return None
+
+    async def fake_capital(**kwargs):
+        assert kwargs["include_manual"] is False
+        return {
+            "accounts": [
+                {"account": "kis_overseas", "currency": "USD", "orderable": 2_000},
+                {"account": "toss", "currency": "USD", "orderable": 500},
+            ],
+            "errors": [],
+        }
+
+    async def fake_holdings(**kwargs):
+        assert kwargs["market"] == "us"
+        return {"accounts": [], "errors": []}
+
+    monkeypatch.setattr(tools, "_fetch_quote_equity_us", fake_us_quote)
+    monkeypatch.setattr(tools, "get_user_setting", fake_setting)
+    monkeypatch.setattr(tools, "get_available_capital_impl", fake_capital)
+    monkeypatch.setattr(tools, "_get_holdings_impl", fake_holdings)
+
+    result = await tools.suggest_order_account_impl(
+        symbol="AAPL",
+        market=None,
+        side="buy",
+        quantity=1,
+        price=None,
+        usd_krw=1500,
+    )
+
+    assert result["market"] == "us"
+    assert result["price"] == pytest.approx(100)
+    assert result["price_source"] == "fake_us_quote"
+
+
+@pytest.mark.asyncio
 async def test_suggest_order_account_impl_fetches_us_fx_when_missing(monkeypatch):
     from app.mcp_server.tooling import account_routing_tools as tools
 

--- a/tests/mcp_server/test_operating_briefing_tools.py
+++ b/tests/mcp_server/test_operating_briefing_tools.py
@@ -641,3 +641,69 @@ async def test_get_operating_briefing_accounts_include_cost_profile(monkeypatch)
     assert account["account"] == "kis"
     assert account["cost_profile"]["commission_bps"] == pytest.approx(1.4)
     assert account["cost_profile"]["source"] == "user_setting"
+
+
+@pytest.mark.asyncio
+async def test_get_operating_briefing_degrades_when_cost_profile_setting_fails(
+    monkeypatch,
+):
+    from datetime import UTC, datetime
+
+    from app.mcp_server.tooling import operating_briefing as ob
+
+    async def fake_holdings(**kwargs):
+        return {
+            "total_positions": 1,
+            "summary": {},
+            "accounts": [
+                {
+                    "account": "kis",
+                    "broker": "kis",
+                    "account_name": "기본 계좌",
+                    "account_mode": "kis_live",
+                    "order_routable": True,
+                    "positions": [{"symbol": "005930"}],
+                }
+            ],
+            "errors": [],
+        }
+
+    async def fake_pending(db, *, market, account_scope):
+        return SimpleNamespace(
+            orders=[],
+            as_of=datetime.now(tz=UTC).isoformat(),
+            freshness_status="fresh",
+            unavailable_reason=None,
+        )
+
+    async def fake_active_watches(**kwargs):
+        return {"success": True, "count": 0, "active_watches": []}
+
+    async def fake_latest_report(*args, **kwargs):
+        return None
+
+    async def fake_session_context(*args, **kwargs):
+        return {"count": 0, "entries": []}
+
+    async def fake_account_costs():
+        raise RuntimeError("cost settings unavailable")
+
+    monkeypatch.setattr(ob, "_get_holdings_impl", fake_holdings)
+    monkeypatch.setattr(ob, "collect_pending_orders_snapshot", fake_pending)
+    monkeypatch.setattr(ob, "list_active_watches_impl", fake_active_watches)
+    monkeypatch.setattr(ob, "_latest_report_summary", fake_latest_report)
+    monkeypatch.setattr(ob, "_recent_session_context", fake_session_context)
+    monkeypatch.setattr(ob, "get_account_costs_setting", fake_account_costs)
+
+    result = await ob.get_operating_briefing_impl(market="kr", account_scope="kis_live")
+
+    account = result["holdings"]["accounts"][0]
+    assert account["cost_profile"] == {
+        "commission_bps": 14.7,
+        "fx_spread_bps": 0.0,
+        "source": "default_seed",
+        "review_required": True,
+    }
+    assert result["holdings"]["errors"] == [
+        {"source": "account_costs", "error": "cost settings unavailable"}
+    ]

--- a/tests/mcp_server/test_operating_briefing_tools.py
+++ b/tests/mcp_server/test_operating_briefing_tools.py
@@ -609,9 +609,7 @@ async def test_get_operating_briefing_accounts_include_cost_profile(monkeypatch)
     async def fake_account_costs():
         return {
             "version": 1,
-            "routing": {
-                "position_consolidation_threshold_bps": {"kr": 25, "us": 40}
-            },
+            "routing": {"position_consolidation_threshold_bps": {"kr": 25, "us": 40}},
             "accounts": {
                 "kis_domestic": {
                     "broker": "kis",

--- a/tests/mcp_server/test_operating_briefing_tools.py
+++ b/tests/mcp_server/test_operating_briefing_tools.py
@@ -574,3 +574,71 @@ async def test_get_operating_briefing_reads_active_watch_and_session_context(
         e for e in result["session_context"]["entries"] if e["title"] == "재평가"
     ]
     assert len(matching_entries) >= 1
+
+
+@pytest.mark.asyncio
+async def test_get_operating_briefing_accounts_include_cost_profile(monkeypatch):
+    from datetime import UTC, datetime
+
+    from app.mcp_server.tooling import operating_briefing as ob
+
+    async def fake_holdings(**kwargs):
+        return {
+            "total_positions": 1,
+            "summary": {},
+            "accounts": [
+                {
+                    "account": "kis_domestic",
+                    "account_name": "기본 계좌",
+                    "account_mode": "kis_live",
+                    "order_routable": True,
+                    "positions": [{"symbol": "005930"}],
+                }
+            ],
+            "errors": [],
+        }
+
+    async def fake_pending(db, *, market, account_scope):
+        return SimpleNamespace(
+            orders=[],
+            as_of=datetime.now(tz=UTC).isoformat(),
+            freshness_status="fresh",
+            unavailable_reason=None,
+        )
+
+    async def fake_account_costs():
+        return {
+            "version": 1,
+            "routing": {
+                "position_consolidation_threshold_bps": {"kr": 25, "us": 40}
+            },
+            "accounts": {
+                "kis_domestic": {
+                    "broker": "kis",
+                    "markets": {"kr": {"commission_bps": 1.4, "fx_spread_bps": 0}},
+                }
+            },
+        }
+
+    async def fake_active_watches(**kwargs):
+        return {"success": True, "count": 0, "active_watches": []}
+
+    async def fake_latest_report(*args, **kwargs):
+        return None
+
+    async def fake_session_context(*args, **kwargs):
+        return {"count": 0, "entries": []}
+
+    monkeypatch.setattr(ob, "_get_holdings_impl", fake_holdings)
+    monkeypatch.setattr(ob, "collect_pending_orders_snapshot", fake_pending)
+    monkeypatch.setattr(ob, "list_active_watches_impl", fake_active_watches)
+    monkeypatch.setattr(ob, "_latest_report_summary", fake_latest_report)
+    monkeypatch.setattr(ob, "_recent_session_context", fake_session_context)
+    monkeypatch.setattr(ob, "get_account_costs_setting", fake_account_costs)
+
+    result = await ob.get_operating_briefing_impl(market="kr", account_scope="kis_live")
+
+    account = result["holdings"]["accounts"][0]
+    assert account["account"] == "kis_domestic"
+    assert account["cost_profile"]["commission_bps"] == pytest.approx(1.4)
+    assert account["cost_profile"]["source"] == "user_setting"

--- a/tests/mcp_server/test_operating_briefing_tools.py
+++ b/tests/mcp_server/test_operating_briefing_tools.py
@@ -588,7 +588,8 @@ async def test_get_operating_briefing_accounts_include_cost_profile(monkeypatch)
             "summary": {},
             "accounts": [
                 {
-                    "account": "kis_domestic",
+                    "account": "kis",
+                    "broker": "kis",
                     "account_name": "기본 계좌",
                     "account_mode": "kis_live",
                     "order_routable": True,
@@ -637,6 +638,6 @@ async def test_get_operating_briefing_accounts_include_cost_profile(monkeypatch)
     result = await ob.get_operating_briefing_impl(market="kr", account_scope="kis_live")
 
     account = result["holdings"]["accounts"][0]
-    assert account["account"] == "kis_domestic"
+    assert account["account"] == "kis"
     assert account["cost_profile"]["commission_bps"] == pytest.approx(1.4)
     assert account["cost_profile"]["source"] == "user_setting"

--- a/tests/services/test_account_routing.py
+++ b/tests/services/test_account_routing.py
@@ -117,6 +117,14 @@ def test_invalid_cost_profile_values_fall_back_to_review_required_defaults():
     assert profiles.max_order_notional_krw("toss") == pytest.approx(1_000_000)
 
 
+def test_invalid_cost_profile_version_uses_default_seed():
+    profiles = build_cost_profiles({"version": "bad"})
+
+    assert profiles.source == "default_seed"
+    assert profiles.review_required is True
+    assert profiles.threshold_bps("kr") == pytest.approx(25)
+
+
 def test_no_existing_holding_recommends_cheapest_eligible_account():
     result = suggest_account_from_snapshot(
         AccountRoutingInput(
@@ -139,6 +147,51 @@ def test_no_existing_holding_recommends_cheapest_eligible_account():
     )
     assert result["cost_comparison"]["toss"]["total_cost_krw"] == pytest.approx(0)
     assert result["position_consolidation"]["decision"] == "no_existing_position"
+
+
+@pytest.mark.parametrize(
+    ("side", "market", "quantity", "price", "message"),
+    [
+        ("sell", "kr", 1, 75_000, "buy side only"),
+        ("buy", "crypto", 1, 75_000, "kr/us markets only"),
+        ("buy", "kr", 0, 75_000, "quantity must be positive"),
+        ("buy", "kr", 1, 0, "price must be positive"),
+    ],
+)
+def test_invalid_routing_inputs_raise_before_recommendation(
+    side, market, quantity, price, message
+):
+    with pytest.raises(ValueError, match=message):
+        suggest_account_from_snapshot(
+            AccountRoutingInput(
+                symbol="005930",
+                market=market,
+                side=side,
+                quantity=quantity,
+                price=price,
+                usd_krw=None,
+                account_costs=DEFAULT_ACCOUNT_COSTS,
+                capital_snapshot=_cash(),
+                holdings_snapshot=_holdings([]),
+            )
+        )
+
+
+def test_us_routing_requires_usd_krw_rate():
+    with pytest.raises(ValueError, match="usd_krw is required"):
+        suggest_account_from_snapshot(
+            AccountRoutingInput(
+                symbol="AAPL",
+                market="us",
+                side="buy",
+                quantity=1,
+                price=100,
+                usd_krw=None,
+                account_costs=DEFAULT_ACCOUNT_COSTS,
+                capital_snapshot=_cash(),
+                holdings_snapshot=_holdings([]),
+            )
+        )
 
 
 def test_existing_kr_holding_keeps_existing_when_savings_below_threshold():
@@ -248,6 +301,54 @@ def test_existing_kr_holding_breaks_consolidation_when_savings_exceed_threshold(
     assert result["position_consolidation"]["decision"] == "break_for_cost"
     assert result["position_consolidation"]["distribution_warning"] is True
     assert "distribution_warning" in result["reason_codes"]
+
+
+def test_existing_account_ineligible_recommends_cheapest_eligible_account():
+    result = suggest_account_from_snapshot(
+        AccountRoutingInput(
+            symbol="005930",
+            market="kr",
+            side="buy",
+            quantity=10,
+            price=75_000,
+            usd_krw=None,
+            account_costs=DEFAULT_ACCOUNT_COSTS,
+            capital_snapshot=_cash(kis_domestic=0, toss_krw=1_000_000),
+            holdings_snapshot=_holdings(["kis_domestic"]),
+        )
+    )
+
+    assert result["recommended_account"] == "toss"
+    assert result["position_consolidation"]["decision"] == "existing_account_ineligible"
+    assert result["position_consolidation"]["existing_account_ineligible"] is True
+    assert "not eligible" in result["position_consolidation"]["note"]
+
+
+def test_already_split_position_prefers_cheapest_eligible_account():
+    result = suggest_account_from_snapshot(
+        AccountRoutingInput(
+            symbol="005930",
+            market="kr",
+            side="buy",
+            quantity=10,
+            price=75_000,
+            usd_krw=None,
+            account_costs=DEFAULT_ACCOUNT_COSTS,
+            capital_snapshot=_cash(),
+            holdings_snapshot=_holdings(["kis_domestic", "toss"]),
+        )
+    )
+
+    assert result["recommended_account"] == "toss"
+    assert (
+        result["position_consolidation"]["decision"]
+        == "already_split_cheapest_eligible"
+    )
+    assert result["position_consolidation"]["existing_accounts"] == [
+        "kis_domestic",
+        "toss",
+    ]
+    assert "already split" in result["position_consolidation"]["note"]
 
 
 def test_existing_us_holding_uses_stronger_40_bps_threshold():

--- a/tests/services/test_account_routing.py
+++ b/tests/services/test_account_routing.py
@@ -87,6 +87,36 @@ def test_default_cost_profiles_are_review_required_until_operator_override():
     assert profiles.market_profile("toss", "us").commission_bps == pytest.approx(10)
 
 
+def test_invalid_cost_profile_values_fall_back_to_review_required_defaults():
+    profiles = build_cost_profiles(
+        {
+            "version": 1,
+            "routing": {"position_consolidation_threshold_bps": {"kr": "bad"}},
+            "accounts": {
+                "kis_domestic": {
+                    "markets": {
+                        "kr": {
+                            "commission_bps": "bad",
+                            "fx_spread_bps": "bad",
+                        }
+                    }
+                },
+                "toss": {"limits": {"max_order_notional_krw": "bad"}},
+            },
+        }
+    )
+
+    assert profiles.review_required is True
+    assert profiles.threshold_bps("kr") == pytest.approx(25)
+    assert profiles.market_profile(
+        "kis_domestic", "kr"
+    ).commission_bps == pytest.approx(14.7)
+    assert profiles.market_profile("kis_domestic", "kr").fx_spread_bps == pytest.approx(
+        0
+    )
+    assert profiles.max_order_notional_krw("toss") == pytest.approx(1_000_000)
+
+
 def test_no_existing_holding_recommends_cheapest_eligible_account():
     result = suggest_account_from_snapshot(
         AccountRoutingInput(
@@ -139,6 +169,64 @@ def test_existing_kr_holding_keeps_existing_when_savings_below_threshold():
     )
     assert result["position_consolidation"]["distribution_warning"] is False
     assert "existing_position_below_threshold" in result["reason_codes"]
+
+
+def test_kis_holding_alias_maps_to_domestic_routing_account_for_kr():
+    result = suggest_account_from_snapshot(
+        AccountRoutingInput(
+            symbol="005930",
+            market="kr",
+            side="buy",
+            quantity=10,
+            price=75_000,
+            usd_krw=None,
+            account_costs=DEFAULT_ACCOUNT_COSTS,
+            capital_snapshot=_cash(),
+            holdings_snapshot={
+                "accounts": [
+                    {
+                        "account": "kis",
+                        "broker": "kis",
+                        "positions": [{"symbol": "005930", "quantity": 1}],
+                    }
+                ],
+                "errors": [],
+            },
+        )
+    )
+
+    assert result["recommended_account"] == "kis_domestic"
+    assert result["position_consolidation"]["existing_accounts"] == ["kis_domestic"]
+    assert result["position_consolidation"]["decision"] == "keep_existing"
+
+
+def test_kis_holding_alias_maps_to_overseas_routing_account_for_us():
+    result = suggest_account_from_snapshot(
+        AccountRoutingInput(
+            symbol="AAPL",
+            market="us",
+            side="buy",
+            quantity=2,
+            price=100,
+            usd_krw=1500,
+            account_costs=DEFAULT_ACCOUNT_COSTS,
+            capital_snapshot=_cash(),
+            holdings_snapshot={
+                "accounts": [
+                    {
+                        "account": "kis",
+                        "broker": "kis",
+                        "positions": [{"symbol": "AAPL", "quantity": 1}],
+                    }
+                ],
+                "errors": [],
+            },
+        )
+    )
+
+    assert result["recommended_account"] == "kis_overseas"
+    assert result["position_consolidation"]["existing_accounts"] == ["kis_overseas"]
+    assert result["position_consolidation"]["decision"] == "keep_existing"
 
 
 def test_existing_kr_holding_breaks_consolidation_when_savings_exceed_threshold():

--- a/tests/services/test_account_routing.py
+++ b/tests/services/test_account_routing.py
@@ -12,7 +12,9 @@ from app.services.account_routing import (
 )
 
 
-def _cash(*, kis_domestic=2_000_000, kis_overseas=2_000, toss_krw=1_000_000, toss_usd=500):
+def _cash(
+    *, kis_domestic=2_000_000, kis_overseas=2_000, toss_krw=1_000_000, toss_usd=500
+):
     return {
         "accounts": [
             {
@@ -66,7 +68,9 @@ def _holdings(accounts: list[str]):
 
 def _costs_with_kis_kr_commission(commission_bps: float):
     costs = deepcopy(DEFAULT_ACCOUNT_COSTS)
-    costs["accounts"]["kis_domestic"]["markets"]["kr"]["commission_bps"] = commission_bps
+    costs["accounts"]["kis_domestic"]["markets"]["kr"]["commission_bps"] = (
+        commission_bps
+    )
     return costs
 
 
@@ -77,7 +81,9 @@ def test_default_cost_profiles_are_review_required_until_operator_override():
     assert profiles.review_required is True
     assert profiles.threshold_bps("kr") == pytest.approx(25)
     assert profiles.threshold_bps("us") == pytest.approx(40)
-    assert profiles.market_profile("kis_domestic", "kr").commission_bps == pytest.approx(14.7)
+    assert profiles.market_profile(
+        "kis_domestic", "kr"
+    ).commission_bps == pytest.approx(14.7)
     assert profiles.market_profile("toss", "us").commission_bps == pytest.approx(10)
 
 
@@ -98,7 +104,9 @@ def test_no_existing_holding_recommends_cheapest_eligible_account():
 
     assert result["success"] is True
     assert result["recommended_account"] == "toss"
-    assert result["cost_comparison"]["kis_domestic"]["total_cost_krw"] == pytest.approx(1102.5)
+    assert result["cost_comparison"]["kis_domestic"]["total_cost_krw"] == pytest.approx(
+        1102.5
+    )
     assert result["cost_comparison"]["toss"]["total_cost_krw"] == pytest.approx(0)
     assert result["position_consolidation"]["decision"] == "no_existing_position"
 
@@ -120,9 +128,15 @@ def test_existing_kr_holding_keeps_existing_when_savings_below_threshold():
 
     assert result["recommended_account"] == "kis_domestic"
     assert result["position_consolidation"]["threshold_bps"] == pytest.approx(25)
-    assert result["position_consolidation"]["threshold_amount_krw"] == pytest.approx(1875)
-    assert result["position_consolidation"]["savings_vs_existing_krw"] == pytest.approx(1102.5)
-    assert result["position_consolidation"]["foregone_savings_krw"] == pytest.approx(1102.5)
+    assert result["position_consolidation"]["threshold_amount_krw"] == pytest.approx(
+        1875
+    )
+    assert result["position_consolidation"]["savings_vs_existing_krw"] == pytest.approx(
+        1102.5
+    )
+    assert result["position_consolidation"]["foregone_savings_krw"] == pytest.approx(
+        1102.5
+    )
     assert result["position_consolidation"]["distribution_warning"] is False
     assert "existing_position_below_threshold" in result["reason_codes"]
 
@@ -166,7 +180,9 @@ def test_existing_us_holding_uses_stronger_40_bps_threshold():
     assert result["recommended_account"] == "kis_overseas"
     assert result["position_consolidation"]["threshold_bps"] == pytest.approx(40)
     assert result["position_consolidation"]["distribution_warning"] is False
-    assert result["cost_comparison"]["kis_overseas"]["fx_notional_krw"] == pytest.approx(0)
+    assert result["cost_comparison"]["kis_overseas"][
+        "fx_notional_krw"
+    ] == pytest.approx(0)
     assert any("tax lots" in note.lower() for note in result["notes"])
 
 
@@ -187,7 +203,10 @@ def test_toss_notional_cap_makes_toss_ineligible_and_falls_back_to_kis():
 
     assert result["recommended_account"] == "kis_domestic"
     assert result["cost_comparison"]["toss"]["eligible"] is False
-    assert result["cost_comparison"]["toss"]["ineligible_reason"] == "notional_limit_exceeded"
+    assert (
+        result["cost_comparison"]["toss"]["ineligible_reason"]
+        == "notional_limit_exceeded"
+    )
 
 
 def test_no_eligible_accounts_returns_failure_with_both_rows():
@@ -208,5 +227,11 @@ def test_no_eligible_accounts_returns_failure_with_both_rows():
     assert result["success"] is False
     assert result["recommended_account"] is None
     assert set(result["cost_comparison"]) == {"kis_domestic", "toss"}
-    assert result["cost_comparison"]["kis_domestic"]["ineligible_reason"] == "insufficient_orderable_cash"
-    assert result["cost_comparison"]["toss"]["ineligible_reason"] == "insufficient_orderable_cash"
+    assert (
+        result["cost_comparison"]["kis_domestic"]["ineligible_reason"]
+        == "insufficient_orderable_cash"
+    )
+    assert (
+        result["cost_comparison"]["toss"]["ineligible_reason"]
+        == "insufficient_orderable_cash"
+    )

--- a/tests/services/test_account_routing.py
+++ b/tests/services/test_account_routing.py
@@ -1,0 +1,212 @@
+from __future__ import annotations
+
+from copy import deepcopy
+
+import pytest
+
+from app.services.account_routing import (
+    DEFAULT_ACCOUNT_COSTS,
+    AccountRoutingInput,
+    build_cost_profiles,
+    suggest_account_from_snapshot,
+)
+
+
+def _cash(*, kis_domestic=2_000_000, kis_overseas=2_000, toss_krw=1_000_000, toss_usd=500):
+    return {
+        "accounts": [
+            {
+                "account": "kis_domestic",
+                "broker": "kis",
+                "currency": "KRW",
+                "orderable": float(kis_domestic),
+            },
+            {
+                "account": "kis_overseas",
+                "broker": "kis",
+                "currency": "USD",
+                "orderable": float(kis_overseas),
+            },
+            {
+                "account": "toss",
+                "broker": "toss",
+                "currency": "KRW",
+                "orderable": float(toss_krw),
+            },
+            {
+                "account": "toss",
+                "broker": "toss",
+                "currency": "USD",
+                "orderable": float(toss_usd),
+            },
+        ],
+        "summary": {"exchange_rate_usd_krw": 1500.0},
+        "errors": [],
+    }
+
+
+def _holdings(accounts: list[str]):
+    return {
+        "accounts": [
+            {
+                "account": account,
+                "positions": [
+                    {
+                        "symbol": "005930" if account != "kis_overseas" else "AAPL",
+                        "quantity": 1,
+                        "evaluation_amount": 100_000,
+                    }
+                ],
+            }
+            for account in accounts
+        ],
+        "errors": [],
+    }
+
+
+def _costs_with_kis_kr_commission(commission_bps: float):
+    costs = deepcopy(DEFAULT_ACCOUNT_COSTS)
+    costs["accounts"]["kis_domestic"]["markets"]["kr"]["commission_bps"] = commission_bps
+    return costs
+
+
+def test_default_cost_profiles_are_review_required_until_operator_override():
+    profiles = build_cost_profiles(None)
+
+    assert profiles.source == "default_seed"
+    assert profiles.review_required is True
+    assert profiles.threshold_bps("kr") == pytest.approx(25)
+    assert profiles.threshold_bps("us") == pytest.approx(40)
+    assert profiles.market_profile("kis_domestic", "kr").commission_bps == pytest.approx(14.7)
+    assert profiles.market_profile("toss", "us").commission_bps == pytest.approx(10)
+
+
+def test_no_existing_holding_recommends_cheapest_eligible_account():
+    result = suggest_account_from_snapshot(
+        AccountRoutingInput(
+            symbol="005930",
+            market="kr",
+            side="buy",
+            quantity=10,
+            price=75_000,
+            usd_krw=None,
+            account_costs=DEFAULT_ACCOUNT_COSTS,
+            capital_snapshot=_cash(),
+            holdings_snapshot=_holdings([]),
+        )
+    )
+
+    assert result["success"] is True
+    assert result["recommended_account"] == "toss"
+    assert result["cost_comparison"]["kis_domestic"]["total_cost_krw"] == pytest.approx(1102.5)
+    assert result["cost_comparison"]["toss"]["total_cost_krw"] == pytest.approx(0)
+    assert result["position_consolidation"]["decision"] == "no_existing_position"
+
+
+def test_existing_kr_holding_keeps_existing_when_savings_below_threshold():
+    result = suggest_account_from_snapshot(
+        AccountRoutingInput(
+            symbol="005930",
+            market="kr",
+            side="buy",
+            quantity=10,
+            price=75_000,
+            usd_krw=None,
+            account_costs=DEFAULT_ACCOUNT_COSTS,
+            capital_snapshot=_cash(),
+            holdings_snapshot=_holdings(["kis_domestic"]),
+        )
+    )
+
+    assert result["recommended_account"] == "kis_domestic"
+    assert result["position_consolidation"]["threshold_bps"] == pytest.approx(25)
+    assert result["position_consolidation"]["threshold_amount_krw"] == pytest.approx(1875)
+    assert result["position_consolidation"]["savings_vs_existing_krw"] == pytest.approx(1102.5)
+    assert result["position_consolidation"]["foregone_savings_krw"] == pytest.approx(1102.5)
+    assert result["position_consolidation"]["distribution_warning"] is False
+    assert "existing_position_below_threshold" in result["reason_codes"]
+
+
+def test_existing_kr_holding_breaks_consolidation_when_savings_exceed_threshold():
+    result = suggest_account_from_snapshot(
+        AccountRoutingInput(
+            symbol="005930",
+            market="kr",
+            side="buy",
+            quantity=10,
+            price=75_000,
+            usd_krw=None,
+            account_costs=_costs_with_kis_kr_commission(40.0),
+            capital_snapshot=_cash(toss_krw=1_000_000),
+            holdings_snapshot=_holdings(["kis_domestic"]),
+        )
+    )
+
+    assert result["recommended_account"] == "toss"
+    assert result["position_consolidation"]["decision"] == "break_for_cost"
+    assert result["position_consolidation"]["distribution_warning"] is True
+    assert "distribution_warning" in result["reason_codes"]
+
+
+def test_existing_us_holding_uses_stronger_40_bps_threshold():
+    result = suggest_account_from_snapshot(
+        AccountRoutingInput(
+            symbol="AAPL",
+            market="us",
+            side="buy",
+            quantity=2,
+            price=100,
+            usd_krw=1500,
+            account_costs=DEFAULT_ACCOUNT_COSTS,
+            capital_snapshot=_cash(),
+            holdings_snapshot=_holdings(["kis_overseas"]),
+        )
+    )
+
+    assert result["recommended_account"] == "kis_overseas"
+    assert result["position_consolidation"]["threshold_bps"] == pytest.approx(40)
+    assert result["position_consolidation"]["distribution_warning"] is False
+    assert result["cost_comparison"]["kis_overseas"]["fx_notional_krw"] == pytest.approx(0)
+    assert any("tax lots" in note.lower() for note in result["notes"])
+
+
+def test_toss_notional_cap_makes_toss_ineligible_and_falls_back_to_kis():
+    result = suggest_account_from_snapshot(
+        AccountRoutingInput(
+            symbol="005930",
+            market="kr",
+            side="buy",
+            quantity=20,
+            price=75_000,
+            usd_krw=None,
+            account_costs=DEFAULT_ACCOUNT_COSTS,
+            capital_snapshot=_cash(kis_domestic=2_000_000, toss_krw=2_000_000),
+            holdings_snapshot=_holdings([]),
+        )
+    )
+
+    assert result["recommended_account"] == "kis_domestic"
+    assert result["cost_comparison"]["toss"]["eligible"] is False
+    assert result["cost_comparison"]["toss"]["ineligible_reason"] == "notional_limit_exceeded"
+
+
+def test_no_eligible_accounts_returns_failure_with_both_rows():
+    result = suggest_account_from_snapshot(
+        AccountRoutingInput(
+            symbol="005930",
+            market="kr",
+            side="buy",
+            quantity=10,
+            price=75_000,
+            usd_krw=None,
+            account_costs=DEFAULT_ACCOUNT_COSTS,
+            capital_snapshot=_cash(kis_domestic=0, toss_krw=0),
+            holdings_snapshot=_holdings([]),
+        )
+    )
+
+    assert result["success"] is False
+    assert result["recommended_account"] is None
+    assert set(result["cost_comparison"]) == {"kis_domestic", "toss"}
+    assert result["cost_comparison"]["kis_domestic"]["ineligible_reason"] == "insufficient_orderable_cash"
+    assert result["cost_comparison"]["toss"]["ineligible_reason"] == "insufficient_orderable_cash"

--- a/tests/test_mcp_available_capital.py
+++ b/tests/test_mcp_available_capital.py
@@ -527,3 +527,48 @@ async def test_get_available_capital_degrades_when_cost_profile_setting_fails(
     assert result["errors"] == [
         {"source": "account_costs", "error": "settings unavailable"}
     ]
+
+
+@pytest.mark.asyncio
+async def test_get_available_capital_degrades_when_manual_cash_setting_fails(
+    monkeypatch,
+):
+    from app.mcp_server.tooling import portfolio_cash
+
+    async def mock_get_cash_balance_impl(account=None, **_kwargs):
+        return {
+            "accounts": [
+                {
+                    "account": "kis_domestic",
+                    "broker": "kis",
+                    "currency": "KRW",
+                    "orderable": 1_000_000.0,
+                }
+            ],
+            "summary": {"total_krw": 1_000_000.0, "total_usd": 0.0},
+            "errors": [],
+        }
+
+    async def mock_get_manual_cash_setting():
+        raise RuntimeError("manual setting unavailable")
+
+    async def mock_get_account_costs_setting():
+        return None
+
+    monkeypatch.setattr(
+        portfolio_cash, "get_cash_balance_impl", mock_get_cash_balance_impl
+    )
+    monkeypatch.setattr(
+        portfolio_cash, "get_manual_cash_setting", mock_get_manual_cash_setting
+    )
+    monkeypatch.setattr(
+        portfolio_cash, "get_account_costs_setting", mock_get_account_costs_setting
+    )
+    monkeypatch.setattr(portfolio_cash, "now_kst", lambda: datetime.now(UTC))
+
+    result = await portfolio_cash.get_available_capital_impl(include_manual=True)
+
+    assert result["manual_cash"] is None
+    assert result["errors"] == [
+        {"source": "manual_cash", "error": "manual setting unavailable"}
+    ]

--- a/tests/test_mcp_available_capital.py
+++ b/tests/test_mcp_available_capital.py
@@ -437,9 +437,7 @@ async def test_get_available_capital_adds_cost_profiles(monkeypatch):
     async def mock_get_account_costs_setting():
         return {
             "version": 1,
-            "routing": {
-                "position_consolidation_threshold_bps": {"kr": 25, "us": 40}
-            },
+            "routing": {"position_consolidation_threshold_bps": {"kr": 25, "us": 40}},
             "accounts": {
                 "kis_domestic": {
                     "broker": "kis",
@@ -452,8 +450,12 @@ async def test_get_available_capital_adds_cost_profiles(monkeypatch):
             },
         }
 
-    monkeypatch.setattr(portfolio_cash, "get_cash_balance_impl", mock_get_cash_balance_impl)
-    monkeypatch.setattr(portfolio_cash, "get_account_costs_setting", mock_get_account_costs_setting)
+    monkeypatch.setattr(
+        portfolio_cash, "get_cash_balance_impl", mock_get_cash_balance_impl
+    )
+    monkeypatch.setattr(
+        portfolio_cash, "get_account_costs_setting", mock_get_account_costs_setting
+    )
     monkeypatch.setattr(portfolio_cash, "get_manual_cash_setting", lambda: None)
     monkeypatch.setattr(portfolio_cash, "now_kst", lambda: datetime.now(UTC))
 

--- a/tests/test_mcp_available_capital.py
+++ b/tests/test_mcp_available_capital.py
@@ -408,3 +408,63 @@ async def test_get_available_capital_includes_fresh_manual_cash_in_total(monkeyp
     assert result["manual_cash"]["included_in_total"] is True
     assert result["summary"]["total_orderable_krw"] == pytest.approx(6000000.0)
     assert result["summary"]["manual_cash_excluded_krw"] == pytest.approx(0.0)
+
+
+@pytest.mark.asyncio
+async def test_get_available_capital_adds_cost_profiles(monkeypatch):
+    from app.mcp_server.tooling import portfolio_cash
+
+    async def mock_get_cash_balance_impl(account=None, **_kwargs):
+        return {
+            "accounts": [
+                {
+                    "account": "kis_domestic",
+                    "broker": "kis",
+                    "currency": "KRW",
+                    "orderable": 1_000_000.0,
+                },
+                {
+                    "account": "toss",
+                    "broker": "toss",
+                    "currency": "KRW",
+                    "orderable": 1_000_000.0,
+                },
+            ],
+            "summary": {"total_krw": 2_000_000.0, "total_usd": 0.0},
+            "errors": [],
+        }
+
+    async def mock_get_account_costs_setting():
+        return {
+            "version": 1,
+            "routing": {
+                "position_consolidation_threshold_bps": {"kr": 25, "us": 40}
+            },
+            "accounts": {
+                "kis_domestic": {
+                    "broker": "kis",
+                    "markets": {"kr": {"commission_bps": 1.4, "fx_spread_bps": 0}},
+                },
+                "toss": {
+                    "broker": "toss",
+                    "markets": {"kr": {"commission_bps": 0, "fx_spread_bps": 0}},
+                },
+            },
+        }
+
+    monkeypatch.setattr(portfolio_cash, "get_cash_balance_impl", mock_get_cash_balance_impl)
+    monkeypatch.setattr(portfolio_cash, "get_account_costs_setting", mock_get_account_costs_setting)
+    monkeypatch.setattr(portfolio_cash, "get_manual_cash_setting", lambda: None)
+    monkeypatch.setattr(portfolio_cash, "now_kst", lambda: datetime.now(UTC))
+
+    result = await portfolio_cash.get_available_capital_impl()
+
+    kis = next(row for row in result["accounts"] if row["account"] == "kis_domestic")
+    toss = next(row for row in result["accounts"] if row["account"] == "toss")
+    assert kis["cost_profile"] == {
+        "commission_bps": 1.4,
+        "fx_spread_bps": 0.0,
+        "source": "user_setting",
+        "review_required": False,
+    }
+    assert toss["cost_profile"]["commission_bps"] == pytest.approx(0)

--- a/tests/test_mcp_available_capital.py
+++ b/tests/test_mcp_available_capital.py
@@ -456,7 +456,13 @@ async def test_get_available_capital_adds_cost_profiles(monkeypatch):
     monkeypatch.setattr(
         portfolio_cash, "get_account_costs_setting", mock_get_account_costs_setting
     )
-    monkeypatch.setattr(portfolio_cash, "get_manual_cash_setting", lambda: None)
+
+    async def mock_get_manual_cash_setting():
+        return None
+
+    monkeypatch.setattr(
+        portfolio_cash, "get_manual_cash_setting", mock_get_manual_cash_setting
+    )
     monkeypatch.setattr(portfolio_cash, "now_kst", lambda: datetime.now(UTC))
 
     result = await portfolio_cash.get_available_capital_impl()
@@ -470,3 +476,54 @@ async def test_get_available_capital_adds_cost_profiles(monkeypatch):
         "review_required": False,
     }
     assert toss["cost_profile"]["commission_bps"] == pytest.approx(0)
+
+
+@pytest.mark.asyncio
+async def test_get_available_capital_degrades_when_cost_profile_setting_fails(
+    monkeypatch,
+):
+    from app.mcp_server.tooling import portfolio_cash
+
+    async def mock_get_cash_balance_impl(account=None, **_kwargs):
+        return {
+            "accounts": [
+                {
+                    "account": "kis_domestic",
+                    "broker": "kis",
+                    "currency": "KRW",
+                    "orderable": 1_000_000.0,
+                }
+            ],
+            "summary": {"total_krw": 1_000_000.0, "total_usd": 0.0},
+            "errors": [],
+        }
+
+    async def mock_get_account_costs_setting():
+        raise RuntimeError("settings unavailable")
+
+    monkeypatch.setattr(
+        portfolio_cash, "get_cash_balance_impl", mock_get_cash_balance_impl
+    )
+    monkeypatch.setattr(
+        portfolio_cash, "get_account_costs_setting", mock_get_account_costs_setting
+    )
+
+    async def mock_get_manual_cash_setting():
+        return None
+
+    monkeypatch.setattr(
+        portfolio_cash, "get_manual_cash_setting", mock_get_manual_cash_setting
+    )
+    monkeypatch.setattr(portfolio_cash, "now_kst", lambda: datetime.now(UTC))
+
+    result = await portfolio_cash.get_available_capital_impl()
+
+    assert result["accounts"][0]["cost_profile"] == {
+        "commission_bps": 14.7,
+        "fx_spread_bps": 0.0,
+        "source": "default_seed",
+        "review_required": True,
+    }
+    assert result["errors"] == [
+        {"source": "account_costs", "error": "settings unavailable"}
+    ]


### PR DESCRIPTION
## Summary
- add read-only suggest_order_account MCP advisory for KIS/Toss KR/US buy routing
- add account_costs cost profile handling and cost annotations in available capital / operating briefing
- apply notional-percent consolidation thresholds with KIS holdings alias handling and advisory-only notes
- harden invalid account_costs values and setting lookup failures

## Verification
- uv run pytest tests/services/test_account_routing.py tests/mcp_server/test_account_routing_tools.py tests/test_mcp_available_capital.py tests/mcp_server/test_operating_briefing_tools.py tests/test_mcp_tool_registration_boot.py -q
- make lint

## Risk
- Trading decision policy change; remains read-only and does not mutate live order paths.
- Linear ROB-565 retains high_risk_change / needs_stronger_model_review context.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added advisory tool to recommend optimal trading account based on commission and cost analysis.
  * Added configurable user setting for broker cost profiles and routing thresholds.
  * Account information now includes computed cost profile metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->