### PR TITLE
fix(ROB-560): remove legacy OpenClaw callback alias

### DIFF
--- a/app/middleware/auth.py
+++ b/app/middleware/auth.py
@@ -49,7 +49,8 @@ class AuthMiddleware:
     # Public API paths (explicit whitelist)
     PUBLIC_API_PATHS: ClassVar[list[str]] = [
         "/api/v1/agent/callback",
-        # Backward-compat alias for operator cutover (remove in a follow-up).
+        # Retired callback alias: allow the missing router to return 404 instead
+        # of masking removal behind auth middleware.
         "/api/v1/openclaw/callback",
         "/api/screener/callback",
     ]

--- a/app/routers/agent_callback.py
+++ b/app/routers/agent_callback.py
@@ -133,14 +133,3 @@ async def agent_callback(
     db: AsyncSession = Depends(get_db),
 ) -> dict:
     return await _persist_agent_callback(payload, db)
-
-
-# Backward-compat alias for operator cutover (same handler). Remove in a
-# follow-up once external agents point at /api/v1/agent/callback.
-@router.post("/api/v1/openclaw/callback")
-async def agent_callback_legacy_alias(
-    payload: AgentCallbackRequest,
-    _: None = Depends(_require_agent_callback_token),
-    db: AsyncSession = Depends(get_db),
-) -> dict:
-    return await _persist_agent_callback(payload, db)

--- a/tests/test_agent_callback.py
+++ b/tests/test_agent_callback.py
@@ -189,27 +189,18 @@ def test_new_agent_callback_path_is_registered(
     assert res.json()["request_id"] == "r-alias"
 
 
-def test_legacy_openclaw_callback_alias_still_works(
+def test_legacy_openclaw_callback_alias_is_not_registered(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     from fastapi.testclient import TestClient
 
     app = _build_app_with_callback_router(monkeypatch)
 
-    async def fake_persist(payload, db):
-        return {
-            "status": "ok",
-            "request_id": payload.request_id,
-            "analysis_result_id": 2,
-        }
+    with TestClient(app) as client:
+        res = client.post(
+            "/api/v1/openclaw/callback",
+            json=_callback_payload(),
+            headers={"Authorization": "Bearer cb-token"},
+        )
 
-    with patch("app.routers.agent_callback._persist_agent_callback", new=fake_persist):
-        with TestClient(app) as client:
-            res = client.post(
-                "/api/v1/openclaw/callback",
-                json=_callback_payload(),
-                headers={"Authorization": "Bearer cb-token"},
-            )
-
-    assert res.status_code == 200
-    assert res.json()["analysis_result_id"] == 2
+    assert res.status_code == 404

--- a/tests/test_agent_callback_auth.py
+++ b/tests/test_agent_callback_auth.py
@@ -101,17 +101,10 @@ def test_agent_callback_accepts_x_agent_callback_token(client: TestClient):
     assert res.status_code == 200
 
 
-def test_legacy_openclaw_callback_alias_accepts_valid_token(client: TestClient):
+def test_legacy_openclaw_callback_alias_is_removed(client: TestClient):
     res = client.post(
         "/api/v1/openclaw/callback",
         headers={"Authorization": "Bearer callback-secret"},
         json=_payload(),
     )
-    assert res.status_code == 200
-    body = res.json()
-    assert body["status"] == "ok"
-
-
-def test_legacy_openclaw_callback_alias_rejects_missing_token(client: TestClient):
-    res = client.post("/api/v1/openclaw/callback", json=_payload())
-    assert res.status_code == 401
+    assert res.status_code == 404


### PR DESCRIPTION
## Summary
- remove the legacy `/api/v1/openclaw/callback` router alias so callbacks only use `/api/v1/agent/callback`
- keep the retired path in auth allowlist only to expose the router-level 404 instead of masking removal with middleware 401
- update callback tests to require `X-Agent-Callback-Token`/Bearer support on the new agent path and 404 on the old alias

## Verification
- `uv run pytest tests/test_agent_callback_auth.py tests/test_agent_callback.py -q`
- `uv run ruff check app/middleware/auth.py app/routers/agent_callback.py tests/test_agent_callback_auth.py tests/test_agent_callback.py`
- `uv run ruff format --check app/middleware/auth.py app/routers/agent_callback.py tests/test_agent_callback_auth.py tests/test_agent_callback.py`
- runtime router search: no `/api/v1/openclaw/callback` hit under `app/routers`

Safety: no broker/order/watch/order-intent mutation; callback route surface only.