### PR TITLE
ROB-575 PR1: fix investor flow stale baseline

### DIFF
--- a/app/services/invest_view_model/investor_flow_service.py
+++ b/app/services/invest_view_model/investor_flow_service.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 import datetime as dt
 from zoneinfo import ZoneInfo
 
-from app.services.market_events.session_calendar import previous_trading_session
-
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.investor_flow_snapshot import InvestorFlowSnapshot
@@ -12,6 +10,7 @@ from app.schemas.investor_flow import InvestorFlowItem, InvestorFlowResponse
 from app.services.investor_flow_snapshots.repository import (
     InvestorFlowSnapshotsRepository,
 )
+from app.services.market_events.session_calendar import previous_trading_session
 
 
 def _normalize_symbol(symbol: str) -> str:

--- a/app/services/invest_view_model/investor_flow_service.py
+++ b/app/services/invest_view_model/investor_flow_service.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
 import datetime as dt
+from zoneinfo import ZoneInfo
+
+from app.services.market_events.session_calendar import previous_trading_session
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -13,6 +16,29 @@ from app.services.investor_flow_snapshots.repository import (
 
 def _normalize_symbol(symbol: str) -> str:
     return symbol.strip().upper()
+
+
+_KST = ZoneInfo("Asia/Seoul")
+
+
+def _resolve_investor_flow_as_of(
+    as_of: dt.date | None = None, *, now: dt.datetime | None = None
+) -> dt.date:
+    """Effective KR investor-flow snapshot date.
+
+    Naver daily investor-flow rows are loaded next morning for the previous KR
+    session. When callers do not pass an explicit effective date, compare stored
+    snapshots against the previous confirmed XKRX trading session, not calendar
+    today. This removes weekend and holiday false stale banners.
+    """
+    if as_of is not None:
+        return as_of
+    moment = now or dt.datetime.now(dt.UTC)
+    if moment.tzinfo is None:
+        moment = moment.replace(tzinfo=dt.UTC)
+    today_kst = moment.astimezone(_KST).date()
+    previous = previous_trading_session("kr", today_kst)
+    return previous or today_kst
 
 
 def _state_for_snapshot(
@@ -86,7 +112,7 @@ async def latest_items_for_symbols(
     normalized_market = market.strip().lower()
     if normalized_market != "kr":
         raise ValueError("investor_flow only supports market=kr")
-    today = as_of or dt.date.today()
+    today = _resolve_investor_flow_as_of(as_of)
     normalized_symbols = [
         _normalize_symbol(symbol) for symbol in symbols if symbol.strip()
     ]
@@ -113,7 +139,7 @@ async def build_investor_flow_cards(
     normalized_market = market.strip().lower()
     if normalized_market != "kr":
         raise ValueError("investor_flow only supports market=kr")
-    today = as_of or dt.date.today()
+    today = _resolve_investor_flow_as_of(as_of)
     normalized_symbols = [
         _normalize_symbol(symbol) for symbol in symbols if symbol.strip()
     ]

--- a/docs/runbooks/invest-screener-snapshots.md
+++ b/docs/runbooks/invest-screener-snapshots.md
@@ -427,4 +427,3 @@ INVESTOR_FLOW_SNAPSHOTS_COMMIT_ENABLED=false
 ```
 
 This stops cron registration and DB writes. Existing rows remain read-only.
-

--- a/docs/runbooks/invest-screener-snapshots.md
+++ b/docs/runbooks/invest-screener-snapshots.md
@@ -374,3 +374,57 @@ US 펀더멘털 프리셋 4종(`high_yield_value`/`undervalued_growth`/`profitab
 
 ### Freshness 확인 방법
 스크리너 응답의 `freshness.primary.snapshotDate` 가 직전 거래일인지, `dataState`가 `"fresh"` 인지, 펀더멘털 preset rows의 `priceLabel` 이 `"-"`가 아닌 실제 가격(close)으로 표시되는지 확인한다.
+
+## 12. KR investor-flow snapshots activation (ROB-575)
+
+### Overview
+`investor_flow_snapshots` backs `/invest/api/investor-flow`, `/invest/stocks/kr/{symbol}` investor-flow cards, and snapshot-backed report context. Code defaults stay paused by design:
+
+- `INVESTOR_FLOW_SCHEDULE_ENABLED=false` means the TaskIQ cron is not registered.
+- `INVESTOR_FLOW_SNAPSHOTS_COMMIT_ENABLED=false` means scheduled execution is dry-run only.
+
+### Manual dry-run
+
+```bash
+uv run python -m scripts.build_investor_flow_snapshots --market kr --all --days 20
+```
+
+Check that `snapshotsBuilt` is non-zero, warnings are bounded, and `snapshotDateDistribution` includes the previous KR trading session.
+
+### Manual backfill after approval
+
+```bash
+uv run python -m scripts.build_investor_flow_snapshots --market kr --all --days 20 --commit
+```
+
+### Scheduled activation after approval
+
+Set both env vars in the worker/scheduler runtime environment:
+
+```bash
+INVESTOR_FLOW_SCHEDULE_ENABLED=true
+INVESTOR_FLOW_SNAPSHOTS_COMMIT_ENABLED=true
+```
+
+The registered TaskIQ cron remains `30 8 * * 1-5` KST and is holiday-gated. It targets the previous KR trading session because Naver daily investor-flow rows finalize the next morning.
+
+### Verification
+
+```bash
+uv run python -m scripts.build_investor_flow_snapshots --market kr --all --days 20
+uv run pytest tests/test_investor_flow_service.py tests/test_investor_flow_snapshot_tasks.py tests/test_snapshot_schedulers_rob438.py -v
+```
+
+For a known KR symbol, confirm the investor-flow card no longer shows a stale banner on weekends or holidays when the latest stored snapshot equals the previous KR trading session.
+
+### Rollback
+
+Set both env vars back to false and restart the scheduler/worker runtime:
+
+```bash
+INVESTOR_FLOW_SCHEDULE_ENABLED=false
+INVESTOR_FLOW_SNAPSHOTS_COMMIT_ENABLED=false
+```
+
+This stops cron registration and DB writes. Existing rows remain read-only.
+

--- a/tests/test_investor_flow_service.py
+++ b/tests/test_investor_flow_service.py
@@ -227,7 +227,7 @@ async def test_investor_flow_endpoint_returns_read_only_view_model(
         InvestorFlowSnapshotUpsert(
             market="kr",
             symbol="900196",
-            snapshot_date=dt.date.today(),
+            snapshot_date=flow_service._resolve_investor_flow_as_of(),
             foreign_net=10,
             institution_net=20,
             individual_net=-30,

--- a/tests/test_investor_flow_service.py
+++ b/tests/test_investor_flow_service.py
@@ -71,9 +71,7 @@ def test_resolve_investor_flow_as_of_defaults_to_previous_kr_session(monkeypatch
         calls.append((market, day))
         return dt.date(2026, 6, 12)
 
-    monkeypatch.setattr(
-        flow_service, "previous_trading_session", fake_previous_session
-    )
+    monkeypatch.setattr(flow_service, "previous_trading_session", fake_previous_session)
 
     now = dt.datetime(2026, 6, 15, 0, 5, tzinfo=dt.UTC)  # Mon 09:05 KST
 
@@ -89,9 +87,9 @@ def test_resolve_investor_flow_as_of_keeps_explicit_effective_date(monkeypatch):
 
     monkeypatch.setattr(flow_service, "previous_trading_session", fail_if_called)
 
-    assert flow_service._resolve_investor_flow_as_of(
-        dt.date(2026, 5, 11)
-    ) == dt.date(2026, 5, 11)
+    assert flow_service._resolve_investor_flow_as_of(dt.date(2026, 5, 11)) == dt.date(
+        2026, 5, 11
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_investor_flow_service.py
+++ b/tests/test_investor_flow_service.py
@@ -9,6 +9,7 @@ from httpx import ASGITransport, AsyncClient
 from app.core.db import get_db
 from app.routers.dependencies import get_authenticated_user
 from app.routers.invest_api import router as invest_api_router
+from app.services.invest_view_model import investor_flow_service as flow_service
 from app.services.invest_view_model.investor_flow_service import (
     build_investor_flow_cards,
 )
@@ -61,6 +62,73 @@ async def test_build_investor_flow_cards_marks_missing_symbol(db_session):
     assert response.items[0].symbol == missing_symbol
     assert response.items[0].dataState == "missing"
     assert response.items[0].source is None
+
+
+def test_resolve_investor_flow_as_of_defaults_to_previous_kr_session(monkeypatch):
+    calls: list[tuple[str, dt.date]] = []
+
+    def fake_previous_session(market: str, day: dt.date) -> dt.date | None:
+        calls.append((market, day))
+        return dt.date(2026, 6, 12)
+
+    monkeypatch.setattr(
+        flow_service, "previous_trading_session", fake_previous_session
+    )
+
+    now = dt.datetime(2026, 6, 15, 0, 5, tzinfo=dt.UTC)  # Mon 09:05 KST
+
+    assert flow_service._resolve_investor_flow_as_of(None, now=now) == dt.date(
+        2026, 6, 12
+    )
+    assert calls == [("kr", dt.date(2026, 6, 15))]
+
+
+def test_resolve_investor_flow_as_of_keeps_explicit_effective_date(monkeypatch):
+    def fail_if_called(market: str, day: dt.date) -> dt.date | None:
+        raise AssertionError(f"unexpected calendar lookup: {market} {day}")
+
+    monkeypatch.setattr(flow_service, "previous_trading_session", fail_if_called)
+
+    assert flow_service._resolve_investor_flow_as_of(
+        dt.date(2026, 5, 11)
+    ) == dt.date(2026, 5, 11)
+
+
+@pytest.mark.asyncio
+async def test_build_investor_flow_cards_uses_previous_kr_session_by_default(
+    db_session, monkeypatch
+):
+    repo = InvestorFlowSnapshotsRepository(db_session)
+    await repo.upsert(
+        InvestorFlowSnapshotUpsert(
+            market="kr",
+            symbol="900198",
+            snapshot_date=dt.date(2026, 6, 12),
+            foreign_net=10,
+            institution_net=20,
+            individual_net=-30,
+            source="naver_finance",
+            collected_at=dt.datetime(2026, 6, 12, 7, 0, tzinfo=dt.UTC),
+        )
+    )
+    await db_session.commit()
+
+    monkeypatch.setattr(
+        flow_service,
+        "_resolve_investor_flow_as_of",
+        lambda as_of=None, *, now=None: dt.date(2026, 6, 12),
+    )
+
+    response = await flow_service.build_investor_flow_cards(
+        db=db_session,
+        symbols=["900198"],
+        market="kr",
+        max_stale_days=1,
+    )
+
+    assert response.asOf == dt.date(2026, 6, 12)
+    assert response.dataState == "fresh"
+    assert response.items[0].dataState == "fresh"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Resolve investor-flow default freshness against the previous KR trading session instead of calendar today.
- Keep explicit as_of behavior unchanged and document schedule/commit gate activation.
- Add regression coverage for weekend/holiday stale false positives and scheduler guardrails.

## Test Plan
- make lint
- uv run pytest tests/test_investor_flow_service.py tests/test_market_session.py tests/services/market_events/test_session_calendar.py tests/test_investor_flow_snapshot_tasks.py tests/test_snapshot_schedulers_rob438.py -v
- git diff --check origin/main...HEAD

## Notes
- Migration-free PR1. Schedule and commit gates remain default-off; runbook documents operator activation after approval.