### PR TITLE
fix(ROB-575): restore investor flow migration history

### DIFF
--- a/alembic/versions/20260615_rob575_investor_flow_snapshot_market_fields.py
+++ b/alembic/versions/20260615_rob575_investor_flow_snapshot_market_fields.py
@@ -1,0 +1,48 @@
+"""Add market fields to investor flow snapshots for ROB-575.
+
+Revision ID: 20260615_rob575
+Revises: 20260615_rob568_us_fx_pnl
+Create Date: 2026-06-15
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "20260615_rob575"
+down_revision = "20260615_rob568_us_fx_pnl"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "investor_flow_snapshots",
+        sa.Column("close", sa.Numeric(20, 6), nullable=True),
+    )
+    op.add_column(
+        "investor_flow_snapshots",
+        sa.Column("change_rate", sa.Numeric(10, 4), nullable=True),
+    )
+    op.add_column(
+        "investor_flow_snapshots",
+        sa.Column("volume", sa.BigInteger(), nullable=True),
+    )
+    op.add_column(
+        "investor_flow_snapshots",
+        sa.Column("foreign_holding_shares", sa.BigInteger(), nullable=True),
+    )
+    op.add_column(
+        "investor_flow_snapshots",
+        sa.Column("foreign_holding_rate", sa.Numeric(10, 4), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("investor_flow_snapshots", "foreign_holding_rate")
+    op.drop_column("investor_flow_snapshots", "foreign_holding_shares")
+    op.drop_column("investor_flow_snapshots", "volume")
+    op.drop_column("investor_flow_snapshots", "change_rate")
+    op.drop_column("investor_flow_snapshots", "close")


### PR DESCRIPTION
## Summary
- Adds the missing Alembic revision file `20260615_rob575` to main without wiring ROB-575 runtime/model/frontend behavior.
- Keeps production DB migration history recognizable after the DB was already stamped at `20260615_rob575` and the physical columns are present.
- Unblocks the ROB-573/ROB-574 production deploy path while ROB-575 PR1/PR2 can remain under final-review hold.

## Scope / safety
- Migration file only.
- No model/schema consumer changes, no API/frontend behavior changes.
- No env/secret/scheduler changes.
- No broker/order/watch/order-intent mutation.

## Verification
- `git diff --cached --check`
- `uv run alembic heads` → single head `20260615_rob575`
- Alembic script graph probe: `20260615_rob575` down_revision=`20260615_rob568_us_fx_pnl`, single head
- `uv run ruff check alembic/versions/20260615_rob575_investor_flow_snapshot_market_fields.py`
- `uv run ruff format --check alembic/versions/20260615_rob575_investor_flow_snapshot_market_fields.py`

Refs ROB-573, ROB-575.
