### PR TITLE
feat(ROB-589): portfolio allocation by-currency + KIS account unification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.2.4] - 2026-06-16
+
+### Changed (ROB-589 — allocation/crypto discovery polish)
+- `get_portfolio_allocation`: add `by_currency` roll-up (KRW vs USD with `fx_conversion_needed`) and unify KIS domestic/overseas cash + holdings into a single `kis` account row.
+- `get_crypto_order_flow`: description now advertises multi-window + `consensus`; ticks are defensively sorted newest-first before windowing.
+- `get_upbit_altseason` constituents now include RS=0 (rate == BTC) rows to match the `get_top_stocks(relative_strength)` boundary; the `alts_beating_btc` ratio stays strict `>`.
+
 ## [0.2.3] - 2026-06-16
 
 ### Added (ROB-582 — Cross-asset allocation roll-up)

--- a/app/mcp_server/tooling/fundamentals/_crypto.py
+++ b/app/mcp_server/tooling/fundamentals/_crypto.py
@@ -197,6 +197,9 @@ async def handle_get_crypto_order_flow(
             if vol is not None and side in ("BID", "ASK"):
                 parsed_ticks.append({"volume": vol, "side": side, "timestamp": ts_val})
 
+        # Defensive sorting: ensure newest-first for window calculations (ROB-589).
+        parsed_ticks.sort(key=lambda t: t["timestamp"] or 0, reverse=True)
+
         def _calculate_window_stats(
             ticks_list: list[dict[str, Any]], W: int
         ) -> dict[str, Any]:

--- a/app/mcp_server/tooling/fundamentals_handlers.py
+++ b/app/mcp_server/tooling/fundamentals_handlers.py
@@ -395,10 +395,10 @@ def _register_fundamentals_tools_impl(
         name="get_crypto_order_flow",
         description=(
             "Get Upbit recent-trade taker order-flow for a KRW crypto market "
-            "(retail buy/sell pressure proxy): volume-weighted taker_buy_ratio, "
-            "taker_sell_ratio, and net (buy-sell, in [-1,1]; >0 = net buying). "
-            "Read-only public Upbit /v1/trades/ticks. count in [1,500]. None "
-            "when no usable ticks."
+            "(retail buy/sell pressure proxy). Returns multi-window (50/200/500) "
+            "ratios and a 'consensus' verdict (direction, trend, confidence, note). "
+            "Prefer 'consensus' over bare 'net' to filter transient noise. "
+            "Read-only public Upbit data; count in [1,500] controls 'default_window'."
         ),
     )
     async def get_crypto_order_flow(symbol: str, count: int = 200) -> dict[str, Any]:

--- a/app/services/external/upbit_index.py
+++ b/app/services/external/upbit_index.py
@@ -204,7 +204,7 @@ def _build_altseason_constituents(
         if market == "KRW-BTC" or not market.startswith("KRW-"):
             continue
         rate = _to_float_or_none(ticker.get("signed_change_rate"))
-        if rate is None or rate <= btc_rate:
+        if rate is None or rate < btc_rate:
             continue
         relative = rate - btc_rate
         rows.append(

--- a/app/services/portfolio_allocation_service.py
+++ b/app/services/portfolio_allocation_service.py
@@ -367,4 +367,3 @@ def build_portfolio_allocation(
         "cash": cash_rows if include_cash else [],
         "warnings": warnings,
     }
-

--- a/app/services/portfolio_allocation_service.py
+++ b/app/services/portfolio_allocation_service.py
@@ -129,6 +129,13 @@ def _weight_status(
     return drift, "neutral"
 
 
+def _normalize_account_id(account_id: str, broker: str | None) -> str:
+    """Normalize broker-specific account sub-types to canonical IDs (ROB-589)."""
+    if str(broker or "").lower() == "kis":
+        return "kis"
+    return account_id
+
+
 def build_portfolio_allocation(
     *,
     positions: list[dict[str, Any]],
@@ -152,6 +159,9 @@ def build_portfolio_allocation(
             "cash_value_krw": 0.0,
             "profit_loss_krw": 0.0,
         }
+    )
+    currency_totals: dict[str, dict[str, float]] = defaultdict(
+        lambda: {"value_krw": 0.0}
     )
     account_totals: dict[str, dict[str, Any]] = {}
     valued_position_count = 0
@@ -184,7 +194,14 @@ def build_portfolio_allocation(
         if profit_loss is not None:
             totals["profit_loss_krw"] += profit_loss
 
-        account_id = str(position.get("account") or "unknown")
+        # Currency rollup: equity_us is USD-based, others (KR/Crypto) are KRW-based.
+        currency = "USD" if position.get("instrument_type") == "equity_us" else "KRW"
+        currency_totals[currency]["value_krw"] += value_krw
+
+        # ROB-589: Normalize kis_domestic/overseas to 'kis' so they merge with positions.
+        raw_account_id = str(position.get("account") or "unknown")
+        account_id = _normalize_account_id(raw_account_id, position.get("broker"))
+
         account = account_totals.setdefault(
             account_id,
             {
@@ -219,6 +236,7 @@ def build_portfolio_allocation(
             row["surface_asset_class"] = surface_class
             row["effective_asset_class"] = effective_class
             row["value_krw"] = _round_money(value_krw)
+            row["account"] = account_id
             output_positions.append(row)
 
     cash_rows: list[dict[str, Any]] = []
@@ -232,7 +250,13 @@ def build_portfolio_allocation(
             totals = class_totals["cash"]
             totals["value_krw"] += value_krw
             totals["cash_value_krw"] += value_krw
-            account_id = str(cash.get("account") or "cash")
+
+            currency_totals[currency]["value_krw"] += value_krw
+
+            # ROB-589: Merge KIS cash wallets into canonical 'kis' account.
+            raw_account_id = str(cash.get("account") or "cash")
+            account_id = _normalize_account_id(raw_account_id, cash.get("broker"))
+
             account = account_totals.setdefault(
                 account_id,
                 {
@@ -246,10 +270,13 @@ def build_portfolio_allocation(
             )
             account["value_krw"] += value_krw
             account["asset_classes"]["cash"] += value_krw
-            cash_rows.append({**cash, "value_krw": _round_money(value_krw)})
+            cash_rows.append(
+                {**cash, "account": account_id, "value_krw": _round_money(value_krw)}
+            )
 
     total_value = sum(row["value_krw"] for row in class_totals.values())
     invested_value = total_value - class_totals["cash"]["value_krw"]
+
     asset_classes = []
     for asset_class, totals in sorted(class_totals.items()):
         value = totals["value_krw"]
@@ -278,6 +305,22 @@ def build_portfolio_allocation(
             }
         )
     asset_classes.sort(key=lambda row: row["value_krw"], reverse=True)
+
+    by_currency = []
+    for currency, totals in sorted(currency_totals.items()):
+        value = totals["value_krw"]
+        if value <= 0:
+            continue
+        weight = (value / total_value) * 100 if total_value else 0.0
+        by_currency.append(
+            {
+                "currency": currency,
+                "value_krw": _round_money(value),
+                "weight_pct": _round_pct(weight),
+                "fx_conversion_needed": currency == "USD",
+            }
+        )
+    by_currency.sort(key=lambda row: row["value_krw"], reverse=True)
 
     accounts = []
     for account in account_totals.values():
@@ -317,9 +360,11 @@ def build_portfolio_allocation(
             "unvalued_position_count": unvalued_position_count,
         },
         "asset_classes": asset_classes,
+        "by_currency": by_currency,
         "accounts": accounts,
         "lookthrough": lookthrough,
         "positions": output_positions,
         "cash": cash_rows if include_cash else [],
         "warnings": warnings,
     }
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "auto-trader"
-version = "0.2.3"
+version = "0.2.4"
 description = ""
 authors = [
     { name = "robin", email = "robin@watcha.com" }

--- a/tests/services/test_portfolio_allocation_service.py
+++ b/tests/services/test_portfolio_allocation_service.py
@@ -175,10 +175,79 @@ def test_build_allocation_reports_per_account_profit_loss() -> None:
 
     by_account = {row["account"]: row for row in result["accounts"]}
     # 140,000 (AAPL USD->KRW) + 50,000 (삼성전자) = 190,000
+    # ROB-589: kis and kis_domestic are merged into 'kis'
+    assert "kis_domestic" not in by_account
     assert by_account["kis"]["profit_loss_krw"] == pytest.approx(190000.0)
+    assert by_account["kis"]["value_krw"] == pytest.approx(
+        (1000 * 1400) + 500000 + 100000
+    )
     assert by_account["upbit"]["profit_loss_krw"] == pytest.approx(-30000.0)
-    # cash-only account carries zero P&L
-    assert by_account["kis_domestic"]["profit_loss_krw"] == pytest.approx(0.0)
+
+
+def test_build_allocation_by_currency_rollup() -> None:
+    # KRW group: KR stocks, KR cash, crypto
+    # USD group: US stocks, USD cash
+    positions = [
+        {
+            "account": "kis",
+            "broker": "kis",
+            "instrument_type": "equity_kr",
+            "symbol": "005930",
+            "evaluation_amount": 500000.0,
+        },
+        {
+            "account": "kis",
+            "broker": "kis",
+            "instrument_type": "equity_us",
+            "symbol": "AAPL",
+            "evaluation_amount": 1000.0,  # 1,400,000 KRW
+        },
+        {
+            "account": "upbit",
+            "broker": "upbit",
+            "instrument_type": "crypto",
+            "symbol": "KRW-BTC",
+            "evaluation_amount": 300000.0,
+        },
+    ]
+    cash_accounts = [
+        {
+            "account": "kis_domestic",
+            "broker": "kis",
+            "currency": "KRW",
+            "balance": 100000.0,
+        },
+        {
+            "account": "kis_overseas",
+            "broker": "kis",
+            "currency": "USD",
+            "balance": 100.0,  # 140,000 KRW
+        },
+    ]
+    result = build_portfolio_allocation(
+        positions=positions,
+        cash_accounts=cash_accounts,
+        usd_krw=1400.0,
+        etf_rows=[],
+        include_cash=True,
+        include_positions=False,
+    )
+
+    by_currency = {row["currency"]: row for row in result["by_currency"]}
+    # KRW: 500,000 + 300,000 + 100,000 = 900,000
+    assert by_currency["KRW"]["value_krw"] == pytest.approx(900000.0)
+    assert by_currency["KRW"]["fx_conversion_needed"] is False
+
+    # USD: 1,400,000 + 140,000 = 1,540,000
+    assert by_currency["USD"]["value_krw"] == pytest.approx(1540000.0)
+    assert by_currency["USD"]["fx_conversion_needed"] is True
+
+    # Check weights: Total = 900,000 + 1,540,000 = 2,440,000
+    # KRW % = 900,000 / 2,440,000 * 100 = 36.885...
+    # USD % = 1,540,000 / 2,440,000 * 100 = 63.114...
+    assert by_currency["KRW"]["weight_pct"] == pytest.approx(36.89, abs=0.01)
+    assert by_currency["USD"]["weight_pct"] == pytest.approx(63.11, abs=0.01)
+
 
 
 def test_build_allocation_warns_and_skips_unvalued_positions() -> None:

--- a/tests/services/test_portfolio_allocation_service.py
+++ b/tests/services/test_portfolio_allocation_service.py
@@ -249,7 +249,6 @@ def test_build_allocation_by_currency_rollup() -> None:
     assert by_currency["USD"]["weight_pct"] == pytest.approx(63.11, abs=0.01)
 
 
-
 def test_build_allocation_warns_and_skips_unvalued_positions() -> None:
     result = build_portfolio_allocation(
         positions=[

--- a/tests/test_crypto_order_flow_social.py
+++ b/tests/test_crypto_order_flow_social.py
@@ -163,6 +163,28 @@ async def test_order_flow_window_derivation(monkeypatch):
     assert out["windows"]["500"]["net"] == pytest.approx(0.4)
 
 
+async def test_order_flow_defensive_sorting(monkeypatch):
+    """ROB-589: Ensure handler sorts newest-first even if source is shuffled."""
+
+    async def fake_trades(market="KRW-BTC", count=500):
+        # Shuffled input: 1000ms (oldest), 3000ms (newest), 2000ms (middle)
+        return [
+            _tick("ASK", 1.0, 1000),
+            _tick("BID", 1.0, 3000),
+            _tick("BID", 1.0, 2000),
+        ]
+
+    monkeypatch.setattr(mod, "fetch_recent_trades", fake_trades)
+    out = await mod.handle_get_crypto_order_flow("btc")
+
+    # If sorted correctly (3000, 2000, 1000):
+    # Whole set (3 trades): 2 BID, 1 ASK -> net = (2-1)/3 = 0.3333
+    # Span = (3000 - 1000) / 1000 = 2.0s
+    assert out["trade_count"] == 3
+    assert out["windows"]["50"]["net"] == pytest.approx(0.3333)
+    assert out["windows"]["50"]["span_seconds"] == pytest.approx(2.0)
+
+
 async def test_order_flow_requires_symbol():
     with pytest.raises(ValueError, match="symbol is required"):
         await mod.handle_get_crypto_order_flow("")

--- a/tests/test_mcp_portfolio_allocation.py
+++ b/tests/test_mcp_portfolio_allocation.py
@@ -65,6 +65,8 @@ async def test_get_portfolio_allocation_handler_rolls_up_positions_cash_and_erro
     )
 
     assert result["summary"]["total_value_krw"] == pytest.approx(1600000.0)
+    assert "by_currency" in result
+    assert result["by_currency"][0]["currency"] in {"KRW", "USD"}
     assert result["errors"] == [
         {"source": "holdings", "error": "partial"},
         {"source": "cash", "error": "partial"},

--- a/tests/test_upbit_index_service.py
+++ b/tests/test_upbit_index_service.py
@@ -193,21 +193,34 @@ async def test_altseason_constituents_list_btc_outperformers(monkeypatch):
     assert breadth["alts_total"] == 2
     assert breadth["alts_beating_btc"] == 1
     assert breadth["constituents_count"] == 1
-    assert breadth["constituents"] == [
-        {
-            "rank": 1,
-            "symbol": "KRW-ETH",
-            "coin": "ETH",
-            "price": 5_000_000,
-            "change_rate_24h": 0.05,
-            "change_pct_24h": 5.0,
-            "btc_change_rate_24h": 0.01,
-            "relative_strength_vs_btc_24h": 0.04,
-            "relative_strength_pct_vs_btc_24h": 4.0,
-            "volume_24h": 200.0,
-            "trade_amount_24h": 20_000_000_000.0,
-        }
-    ]
+    assert breadth["constituents"][0]["symbol"] == "KRW-ETH"
+
+
+@pytest.mark.asyncio
+async def test_altseason_constituents_includes_relative_strength_zero(monkeypatch):
+    """ROB-589: coins matching BTC rate (RS=0) must be included, same as top_stocks."""
+    upbit_index._clear_caches()
+    mapping = {
+        **_datalab_mapping(),
+        "/market/all": _MARKET_ALL,
+        "/ticker": [
+            {"market": "KRW-BTC", "signed_change_rate": 0.01},
+            {"market": "KRW-ETH", "signed_change_rate": 0.01},  # RS = 0
+            {"market": "KRW-XRP", "signed_change_rate": 0.00},  # RS < 0
+        ],
+    }
+    monkeypatch.setattr(httpx.AsyncClient, "get", _route(mapping))
+
+    payload = await upbit_index.fetch_upbit_altseason(include_constituents=True)
+
+    breadth = payload["breadth"]
+    # alts_beating_btc follows the > btc_rate logic for the percentage (unchanged)
+    assert breadth["alts_beating_btc"] == 0
+    # but constituents now includes the RS=0 row
+    assert breadth["constituents_count"] == 1
+    assert breadth["constituents"][0]["symbol"] == "KRW-ETH"
+    assert breadth["constituents"][0]["relative_strength_vs_btc_24h"] == 0.0
+
 
 
 @pytest.mark.asyncio

--- a/tests/test_upbit_index_service.py
+++ b/tests/test_upbit_index_service.py
@@ -222,7 +222,6 @@ async def test_altseason_constituents_includes_relative_strength_zero(monkeypatc
     assert breadth["constituents"][0]["relative_strength_vs_btc_24h"] == 0.0
 
 
-
 @pytest.mark.asyncio
 async def test_altseason_partial_when_breadth_unavailable(monkeypatch):
     """Ratio survives even if the official ticker plane is down."""

--- a/uv.lock
+++ b/uv.lock
@@ -222,7 +222,7 @@ wheels = [
 
 [[package]]
 name = "auto-trader"
-version = "0.2.3"
+version = "0.2.4"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
ROB-589 후속 폴리시 작업 PR입니다.

### 변경 사항

1. **포트폴리오 비중 (get_portfolio_allocation)**
   - `by_currency` 필드 추가: KRW(국내주식+현금+코인), USD(미국주식+현금) 별 자산 합산 및 비중 제공.
   - KIS 계좌 통합: `kis_domestic`/`kis_overseas`(현금)와 `kis`(보유)를 `kis` 단일 계좌로 정규화하여 통합 출력.

2. **코인 탐색 (get_upbit_altseason)**
   - `constituents` 목록에 상대강도(RS) 0인 코인도 포함되도록 경계 조건 수정 (`rate < btc_rate`로 필터링).

3. **코인 체결 흐름 (get_crypto_order_flow)**
   - 방어적 정렬: 소스 데이터 순서와 무관하게 최신순 정렬 후 윈도우 계산하도록 개선.
   - 도구 설명: 멀티 윈도우 지원 및 `consensus` 사용 권장 문구 추가.

### 테스트 결과
- `tests/services/test_portfolio_allocation_service.py` (통화별 합산, 계좌 통합)
- `tests/test_upbit_index_service.py` (RS=0 포함)
- `tests/test_crypto_order_flow_social.py` (방어적 정렬)
포함 총 35개 테스트 통과.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Portfolio allocation reports now include per-position/cash account assignment (including unified `kis` rollup) and a new currency-based breakdown (`by_currency`) with KRW/USD valuations and weight percentages.

* **Bug Fixes**
  * Crypto order flow statistics are now computed after defensively sorting ticks newest-first.
  * Altseason constituents selection now includes `RS=0` boundary cases to improve coverage and alignment.

* **Documentation**
  * Updated the `get_crypto_order_flow` tool description to match the returned multi-window consensus semantics.

* **Tests**
  * Added/updated coverage for defensive sorting, portfolio by-currency rollups, and altseason boundary behavior.

* **Chores**
  * Version bumped to 0.2.4.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->