### PR TITLE
fix(ROB-590): US tvscreener valuation dividend unit + JSONB-safe raw_payload

### DIFF
--- a/app/services/market_valuation_snapshots/builder.py
+++ b/app/services/market_valuation_snapshots/builder.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass
 from decimal import Decimal
 from typing import Any
 
+from app.core.json_safe import sanitize_non_finite
 from app.services.market_quote_snapshots.builder import redact_sensitive_payload
 from app.services.market_valuation_snapshots.repository import (
     MarketValuationSnapshotUpsert,
@@ -180,6 +181,12 @@ async def build_valuation_snapshots_bulk_for_us(
         symbol = row.get("symbol", "").split(":")[-1]  # Strip exchange prefix
         if not symbol:
             continue
+        # ROB-590 bug A: tvscreener dividend_yield is a PERCENT (e.g. 0.36 = 0.36%),
+        # but market_valuation_snapshots stores a RATIO (parity with the KR ROB-444
+        # path and the Finnhub fallback). Divide by 100 so the high_yield_value gate
+        # (>= 0.03) and the displayed percent are correct.
+        _div = _to_decimal(row.get("dividends_yield"))
+        dividend_yield = (_div / Decimal("100")) if _div is not None else None
         payloads.append(
             MarketValuationSnapshotUpsert(
                 market="us",
@@ -189,12 +196,16 @@ async def build_valuation_snapshots_bulk_for_us(
                 per=_to_decimal(row.get("price_earnings_ttm")),
                 pbr=_to_decimal(row.get("price_book_ratio")),
                 roe=_to_decimal(row.get("return_on_equity")),
-                dividend_yield=_to_decimal(row.get("dividends_yield")),
+                dividend_yield=dividend_yield,
                 market_cap=_to_decimal(row.get("market_cap_basic")),
                 high_52w=_to_decimal(row.get("price_52_week_high")),
                 low_52w=_to_decimal(row.get("price_52_week_low")),
                 high_52w_date=_to_date(row.get("price_52_week_high_date")),
-                raw_payload=row,
+                # ROB-590 bug B: non-dividend / unprofitable stocks come back with
+                # NaN metrics; the default engine JSON serializer would emit invalid
+                # `NaN` tokens that Postgres jsonb rejects. Scrub non-finite floats
+                # (the provider already serialises the date as an ISO string).
+                raw_payload=sanitize_non_finite(row),
             )
         )
     return MarketValuationBuildResult(payloads=tuple(payloads))

--- a/app/services/market_valuation_snapshots/us_provider.py
+++ b/app/services/market_valuation_snapshots/us_provider.py
@@ -90,6 +90,11 @@ class TvScreenerUsValuationProvider:
             if not symbol:
                 continue
 
+            # ROB-590: serialise the 52w-high date as an ISO STRING (not a dt.date)
+            # so the mapped row — which is stored verbatim as raw_payload — stays
+            # strict-JSON / Postgres-jsonb safe. _to_date in the builder parses it
+            # back for the typed column.
+            hi_date = _date_from_epoch_seconds(row_dict.get("price_52_week_high_date"))
             mapped_row = {
                 "symbol": symbol,
                 "price_earnings_ttm": row_dict.get("price_to_earnings_ratio_ttm")
@@ -108,9 +113,7 @@ class TvScreenerUsValuationProvider:
                 or row_dict.get("week_high_52"),
                 "price_52_week_low": row_dict.get("52_week_low")
                 or row_dict.get("week_low_52"),
-                "price_52_week_high_date": _date_from_epoch_seconds(
-                    row_dict.get("price_52_week_high_date")
-                ),
+                "price_52_week_high_date": hi_date.isoformat() if hi_date else None,
             }
             mapped_rows.append(mapped_row)
 

--- a/tests/test_us_valuation_bulk_tvscreener.py
+++ b/tests/test_us_valuation_bulk_tvscreener.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import datetime as dt
+import json
 from decimal import Decimal
 from typing import Any
 
@@ -103,7 +104,9 @@ async def test_fetch_rows_full_universe_cap(monkeypatch, _patch_tvscreener):
     assert first_row["return_on_equity"] == 10.0
     assert first_row["price_52_week_high"] == 50.0
     assert first_row["price_52_week_low"] == 20.0
-    assert first_row["price_52_week_high_date"] == dt.date(2026, 5, 14)
+    # ROB-590: provider emits an ISO date STRING (JSON-safe boundary), not a
+    # dt.date object — so raw_payload stays Postgres-jsonb serializable.
+    assert first_row["price_52_week_high_date"] == "2026-05-14"
 
 
 @pytest.mark.asyncio
@@ -136,7 +139,9 @@ async def test_build_valuation_snapshots_bulk_for_us(monkeypatch, _patch_tvscree
     assert p.per == Decimal("15.5")
     assert p.pbr == Decimal("1.5")
     assert p.roe == Decimal("10.0")
-    assert p.dividend_yield == Decimal("2.5")
+    # ROB-590: tvscreener dividend_yield is a PERCENT (2.5 = 2.5%); the column
+    # stores a RATIO, so it must be divided by 100.
+    assert p.dividend_yield == Decimal("0.025")
     assert p.market_cap == Decimal("1000000")
     assert p.high_52w == Decimal("50.0")
     assert p.low_52w == Decimal("20.0")
@@ -172,3 +177,77 @@ async def test_build_valuation_snapshots_for_market_routing(
     assert len(result_filtered.payloads) == 2
     symbols_returned = {p.symbol for p in result_filtered.payloads}
     assert symbols_returned == {"SYM1", "SYM3"}
+
+
+def _fake_df_with_gaps() -> pd.DataFrame:
+    # Non-dividend / unprofitable stocks: tvscreener returns NaN for those metrics
+    # (e.g. live NVDA/GOOG dividend=NaN). raw_payload must stay strict-JSON because
+    # Postgres JSONB rejects NaN tokens.
+    return pd.DataFrame(
+        {
+            "symbol": ["NASDAQ:NODIV"],
+            "market_capitalization": [4.3e12],
+            "price_to_earnings_ratio_ttm": [float("nan")],
+            "price_to_book_mrq": [1.3],
+            "dividend_yield": [float("nan")],
+            "return_on_equity_ttm": [float("nan")],
+            "52_week_high": [55.97],
+            "52_week_low": [48.88],
+            "price_52_week_high_date": [1778765400],
+        }
+    )
+
+
+class _FixedDfService:
+    def __init__(self, df: pd.DataFrame) -> None:
+        self._df = df
+
+    async def query_stock_screener(
+        self, *, columns: Any, markets: Any, limit: int | None = None
+    ) -> pd.DataFrame:
+        return self._df
+
+
+@pytest.mark.asyncio
+async def test_bulk_raw_payload_is_strict_json_safe(monkeypatch, _patch_tvscreener):
+    # ROB-590 bug B: NaN metrics + a date object in raw_payload broke the JSONB
+    # commit (default engine serializer is json.dumps; Postgres rejects NaN). The
+    # bulk path must scrub non-finite floats and serialize the date as a string.
+    service = _FixedDfService(_fake_df_with_gaps())
+    monkeypatch.setattr(provider_mod, "TvScreenerService", lambda **kw: service)
+
+    result = await build_valuation_snapshots_bulk_for_us(
+        snapshot_date=dt.date(2026, 6, 16), limit=5
+    )
+
+    assert len(result.payloads) == 1
+    p = result.payloads[0]
+    # NaN metrics -> typed columns None (never NaN Decimals)
+    assert p.per is None
+    assert p.dividend_yield is None
+    assert p.roe is None
+    # strict-JSON invariant == what Postgres JSONB accepts: no NaN tokens, no
+    # non-native types (the date must already be a string).
+    json.dumps(p.raw_payload, allow_nan=False)
+    assert p.raw_payload["dividends_yield"] is None
+    assert p.raw_payload["price_52_week_high_date"] == "2026-05-14"
+    # typed date column still resolves to a real date
+    assert p.high_52w_date == dt.date(2026, 5, 14)
+
+
+@pytest.mark.asyncio
+async def test_bulk_dividend_yield_percent_converted_to_ratio(
+    monkeypatch, _patch_tvscreener
+):
+    # ROB-590 bug A: tvscreener dividend_yield is PERCENT (e.g. 0.36 = 0.36%); the
+    # market_valuation_snapshots column stores a RATIO (parity with ROB-444 / Finnhub).
+    df = _fake_df_with_gaps()
+    df["dividend_yield"] = [0.36]
+    service = _FixedDfService(df)
+    monkeypatch.setattr(provider_mod, "TvScreenerService", lambda **kw: service)
+
+    result = await build_valuation_snapshots_bulk_for_us(
+        snapshot_date=dt.date(2026, 6, 16), limit=5
+    )
+
+    assert result.payloads[0].dividend_yield == Decimal("0.0036")


### PR DESCRIPTION
## Summary

Post-merge follow-up to **ROB-588 / PR #1330** (US market valuation → tvscreener bulk sourcing). That PR's architecture is correct (per-symbol Yahoo fan-out removed → `getaddrinfo` thread exhaustion fixed), but it landed **two data bugs that are currently on `main`**. Both are small and surgical.

Fixes ROB-590.

## 🔴 Bug A — `dividend_yield` 100× (percent stored into a ratio column)
- tvscreener `dividend_yield` is a **PERCENT** (live: AAPL `0.36` = 0.36%, NVDA `0.47`), but `market_valuation_snapshots.dividend_yield` is a **RATIO** (`fundamentals_screener.py:530` "stores dividend_yield as a RATIO"; gate `>= 0.03`; display `*100`).
- The bulk path stored the raw percent → the `high_yield_value` dividend floor is ~100× too loose (a 0.36% stock passes `0.36 ≥ 0.03`) and the displayed yield is inflated 100×.
- **Fix:** divide by 100 — parity with the KR ROB-444 path and the Finnhub fallback.
- ⚠️ `roe` is intentionally left raw: tvscreener `return_on_equity_ttm` is also a percent (live NVDA 114.3 / AAPL 141.5) and the column convention is percent. `market_cap`/`per`/`pbr`/`52w` are also live-verified correct.

## 🔴 Bug B — `raw_payload` not JSON-safe (NaN floats + `dt.date` object) → JSONB commit failure
- Non-dividend / unprofitable stocks return `NaN` for `dividend_yield`/`per`/`roe` (live: GOOGM/GOOGN dividend = `NaN`); these are common across the ~12k universe. The provider also put a `dt.date` object into the row.
- The engine has no custom `json_serializer` (`app/core/db.py`), so the default `json.dumps` emits invalid `NaN` tokens and chokes on the date object → **Postgres jsonb rejects the write**. The first scheduled `--all --commit` run would fail (dry-run never commits, and the existing tests had no NaN, so CI didn't catch it).
- **Fix:** provider serialises the 52w-high date as an **ISO string**; builder scrubs non-finite floats via `app/core/json_safe.sanitize_non_finite`.

## Tests
- `test_bulk_dividend_yield_percent_converted_to_ratio`: `0.36` (percent) → `Decimal("0.0036")` (ratio).
- `test_bulk_raw_payload_is_strict_json_safe`: NaN metrics → typed columns `None` **and** `json.dumps(raw_payload, allow_nan=False)` succeeds (mirrors the Postgres jsonb constraint); date stored as ISO string; typed `high_52w_date` still parses.
- Updated existing assertions that encoded the buggy behavior (dividend `2.5`→`0.025`; provider date → ISO string).
- TDD: watched all 4 fail for the expected reasons, then implemented. `6 passed`. Related suite (`-k "market_valuation or valuation_bulk"`) `43 passed`, ruff + ty clean.

## Deferred (not in this PR)
- **Coverage gate (fail-loud)**: abort/alert when tvscreener returns far fewer rows than the expected universe (degraded-source protection). It was a *recommended* (not required) item in ROB-590 and touches job orchestration (threshold + dry-run/commit interaction), so it's kept out to keep this fix focused and low-risk. Track as a follow-up if desired.
- No migration / no behavior change outside the US tvscreener bulk path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)