### PR TITLE
feat(ROB-595): non-CDP Toss buy-balance/AI-signal + Naver analyst consensus MCP tools

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -360,6 +360,9 @@ class Settings(BaseSettings):
     # explicitly enables it after a ToS/endpoint review. Aggregate counts only (never raw text).
     retail_sentiment_live_enabled: bool = False
 
+    # ROB-595: 비공식 토스 컨슈머 API (wts-info-api) 신호 — ToS 리뷰 전까지 비활성
+    toss_consumer_signals_enabled: bool = False
+
     # ROB-281 — Gates cron registration for KR/US screener snapshot scheduled refreshes.
     # When False, scheduled tasks remain defined as broker tasks (so operators can still
     # kick them manually via ``taskiq kick``) but no cron entries are registered. Pairs

--- a/app/mcp_server/README.md
+++ b/app/mcp_server/README.md
@@ -118,6 +118,8 @@ MCP tools (market data, portfolio, order execution) exposed via `fastmcp`.
     numeric fields are preserved and `data_state` is downgraded to `"stale"`
     with `data_state_reason: "kr_index_fresh_clock_payload_lagging"` and `as_of`.
 - `get_investment_opinions(symbol, limit=10, market=None)`
+- `get_analyst_consensus(symbol)`
+  - Get analyst consensus (recommendation mean and price target mean) for a Korean stock from Naver mobile integration API. Distinct from `get_investment_opinions` (report-level). Korean stocks only.
 - `get_short_interest(symbol, days=20)`
   - 6자리 KR 종목코드만 지원 (예: `005930`)
   - US ticker (`AAPL`, `SMCI`) 와 crypto symbol (`KRW-BTC`) 은 지원하지 않음
@@ -130,6 +132,10 @@ MCP tools (market data, portfolio, order execution) exposed via `fastmcp`.
   - `as_of` is inferred from the latest returned KIS slot (`bsop_hour_gb`: 09:30, 10:00, 11:20, 13:20, 14:30) on the KST request date because the KIS payload does not include a date field.
   - When the date attribution would be dishonest — the slot time is in the future (after-midnight/pre-market calls) or the request date is not an XKRX session day (weekend/holiday) — `as_of` is `null` and the `note` flags that rows likely belong to the previous trading session.
   - This is not a confirmed daily close figure and should not be mixed with `get_investor_trends` day/week/month history.
+- `get_toss_buy_balance(symbol)`
+  - Toss orderbook balance rate (buyBalanceRate/sellBalanceRate) and foreigner holding ratio — NOT user buy ratio. Live per-call, operator-gated. Disabled by default (returns `status='disabled'` unless `TOSS_CONSUMER_SIGNALS_ENABLED=true` is set). Korean stocks only.
+- `get_toss_ai_signal(symbol)`
+  - Toss AI signal (direction + reasoning). Live per-call, operator-gated. Disabled by default (returns `status='disabled'` unless `TOSS_CONSUMER_SIGNALS_ENABLED=true` is set). Korean stocks only.
 - `get_volume_profile(symbol, market=None, period=60, bins=20)`
 - `get_order_history(symbol=None, status="all", order_id=None, limit=50, account_mode=None)`
   - `status="pending"` 만 symbol 없이 호출 가능

--- a/app/mcp_server/tooling/fundamentals/_analyst_consensus.py
+++ b/app/mcp_server/tooling/fundamentals/_analyst_consensus.py
@@ -1,0 +1,51 @@
+"""ROB-595: Naver analyst consensus tool handler (KR)."""
+
+from __future__ import annotations
+
+import datetime as dt
+from typing import Any
+
+from app.mcp_server.tooling.shared import error_payload as _error_payload
+from app.mcp_server.tooling.shared import (
+    is_korean_equity_code as _is_korean_equity_code,
+)
+from app.services.naver_finance.consensus import fetch_analyst_consensus
+
+
+async def handle_get_analyst_consensus(symbol: str) -> dict[str, Any]:
+    """Get analyst consensus (recommendation mean and price target mean) for a Korean stock. Live per-call."""
+    symbol = (symbol or "").strip()
+    if not symbol:
+        raise ValueError("symbol is required")
+    if not _is_korean_equity_code(symbol):
+        raise ValueError(
+            "Analyst consensus is only available for Korean stocks "
+            "(6-digit codes like '005930')"
+        )
+
+    now = dt.datetime.now(dt.UTC)
+    base = {
+        "symbol": symbol,
+        "source": "naver_integration",
+        "market": "kr",
+        "observed_at": now.isoformat(),
+    }
+
+    try:
+        clean_code = symbol
+        if len(clean_code) == 7 and clean_code.upper().startswith("A"):
+            clean_code = clean_code[1:]
+
+        result = await fetch_analyst_consensus(clean_code)
+        return {
+            **base,
+            "status": "ok",
+            **result,
+        }
+    except Exception as exc:  # noqa: BLE001
+        return _error_payload(
+            source="naver_integration",
+            message=str(exc),
+            symbol=symbol,
+            instrument_type="equity_kr",
+        )

--- a/app/mcp_server/tooling/fundamentals/_toss_signals.py
+++ b/app/mcp_server/tooling/fundamentals/_toss_signals.py
@@ -1,0 +1,114 @@
+"""ROB-595: Toss orderbook balance rate and AI signal (KR).
+
+Safety:
+  * Live fetch is OFF by default (``settings.toss_consumer_signals_enabled``).
+    Off → status="disabled".
+  * AGGREGATE ONLY: buyBalanceRate, sellBalanceRate, foreignerRatio, signalDirection, reasoning, relatedReasoning.
+  * No DB. Live per-call.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from typing import Any
+
+from app.core.config import settings
+from app.mcp_server.tooling.shared import error_payload as _error_payload
+from app.mcp_server.tooling.shared import (
+    is_korean_equity_code as _is_korean_equity_code,
+)
+from app.services.toss_consumer.client import TossConsumerClient, _to_product_code
+
+
+async def handle_get_toss_buy_balance(symbol: str) -> dict[str, Any]:
+    """Toss orderbook balance rate (buyBalanceRate/sellBalanceRate) and foreigner ratio. Live per-call, operator-gated."""
+    symbol = (symbol or "").strip()
+    if not symbol:
+        raise ValueError("symbol is required")
+    if not _is_korean_equity_code(symbol):
+        raise ValueError(
+            "Toss buy balance rate is only available for Korean stocks "
+            "(6-digit codes like '005930')"
+        )
+
+    now = dt.datetime.now(dt.UTC)
+    base = {
+        "symbol": symbol,
+        "source": "toss_consumer",
+        "market": "kr",
+        "observed_at": now.isoformat(),
+    }
+
+    # Pattern B gate
+    if not settings.toss_consumer_signals_enabled:
+        return {
+            **base,
+            "status": "disabled",
+            "note": (
+                "Toss consumer signals are disabled (set TOSS_CONSUMER_SIGNALS_ENABLED=true after ToS review)"
+            ),
+        }
+
+    try:
+        product_code = _to_product_code(symbol)
+        client = TossConsumerClient()
+        result = await client.fetch_buy_balance(product_code)
+        return {
+            **base,
+            "status": "ok",
+            **result,
+        }
+    except Exception as exc:  # noqa: BLE001
+        return _error_payload(
+            source="toss_consumer",
+            message=str(exc),
+            symbol=symbol,
+            instrument_type="equity_kr",
+        )
+
+
+async def handle_get_toss_ai_signal(symbol: str) -> dict[str, Any]:
+    """Toss AI signal (direction + reasoning). Live per-call, operator-gated."""
+    symbol = (symbol or "").strip()
+    if not symbol:
+        raise ValueError("symbol is required")
+    if not _is_korean_equity_code(symbol):
+        raise ValueError(
+            "Toss AI signal is only available for Korean stocks "
+            "(6-digit codes like '005930')"
+        )
+
+    now = dt.datetime.now(dt.UTC)
+    base = {
+        "symbol": symbol,
+        "source": "toss_consumer",
+        "market": "kr",
+        "observed_at": now.isoformat(),
+    }
+
+    # Pattern B gate
+    if not settings.toss_consumer_signals_enabled:
+        return {
+            **base,
+            "status": "disabled",
+            "note": (
+                "Toss consumer signals are disabled (set TOSS_CONSUMER_SIGNALS_ENABLED=true after ToS review)"
+            ),
+        }
+
+    try:
+        product_code = _to_product_code(symbol)
+        client = TossConsumerClient()
+        result = await client.fetch_ai_signal(product_code)
+        return {
+            **base,
+            "status": "ok",
+            **result,
+        }
+    except Exception as exc:  # noqa: BLE001
+        return _error_payload(
+            source="toss_consumer",
+            message=str(exc),
+            symbol=symbol,
+            instrument_type="equity_kr",
+        )

--- a/app/mcp_server/tooling/fundamentals_handlers.py
+++ b/app/mcp_server/tooling/fundamentals_handlers.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from app.mcp_server.tooling.fundamentals._analyst_consensus import (
+    handle_get_analyst_consensus,
+)
 from app.mcp_server.tooling.fundamentals._cost_basis_distribution import (
     _DEFAULT_GET_COST_BASIS_DISTRIBUTION_IMPL,
 )
@@ -53,6 +56,10 @@ from app.mcp_server.tooling.fundamentals._support_resistance import (
 from app.mcp_server.tooling.fundamentals._support_resistance import (
     get_support_resistance_impl as _get_support_resistance_impl,
 )
+from app.mcp_server.tooling.fundamentals._toss_signals import (
+    handle_get_toss_ai_signal,
+    handle_get_toss_buy_balance,
+)
 from app.mcp_server.tooling.fundamentals._upbit_index import (
     handle_get_upbit_altseason,
     handle_get_upbit_index,
@@ -79,6 +86,7 @@ FUNDAMENTALS_TOOL_NAMES: set[str] = {
     "get_investor_trends",
     "get_intraday_investor_flow",
     "get_investment_opinions",
+    "get_analyst_consensus",
     "get_valuation",
     "get_short_interest",
     "get_kimchi_premium",
@@ -90,6 +98,8 @@ FUNDAMENTALS_TOOL_NAMES: set[str] = {
     "get_crypto_order_flow",
     "get_crypto_social",
     "get_retail_sentiment",
+    "get_toss_buy_balance",
+    "get_toss_ai_signal",
     "get_fx_rate",
     "get_market_index",
     "get_upbit_index",
@@ -274,6 +284,18 @@ def _register_fundamentals_tools_impl(
         )
 
     @mcp.tool(
+        name="get_analyst_consensus",
+        description=(
+            "Analyst consensus from Naver: recommendation mean (1-5 scale) and price target mean. "
+            "Distinct from get_investment_opinions (report-level)."
+        ),
+    )
+    async def get_analyst_consensus(
+        symbol: str,
+    ) -> dict[str, Any]:
+        return await handle_get_analyst_consensus(symbol)
+
+    @mcp.tool(
         name="get_valuation",
         description=(
             "Get valuation metrics for a US or Korean stock. Crypto symbols are not "
@@ -432,6 +454,29 @@ def _register_fundamentals_tools_impl(
         window: str = "1d",
     ) -> dict[str, Any]:
         return await handle_get_retail_sentiment(symbol, market, window)
+
+    @mcp.tool(
+        name="get_toss_buy_balance",
+        description=(
+            "Toss orderbook balance rate (buyBalanceRate/sellBalanceRate) and foreigner holding ratio — "
+            "NOT user buy ratio. Live per-call, operator-gated."
+        ),
+    )
+    async def get_toss_buy_balance(
+        symbol: str,
+    ) -> dict[str, Any]:
+        return await handle_get_toss_buy_balance(symbol)
+
+    @mcp.tool(
+        name="get_toss_ai_signal",
+        description=(
+            "Toss AI signal (direction + reasoning). Live per-call, operator-gated."
+        ),
+    )
+    async def get_toss_ai_signal(
+        symbol: str,
+    ) -> dict[str, Any]:
+        return await handle_get_toss_ai_signal(symbol)
 
     @mcp.tool(
         name="get_fx_rate",

--- a/app/services/naver_finance/__init__.py
+++ b/app/services/naver_finance/__init__.py
@@ -15,6 +15,9 @@ from app.services.naver_finance.company import (
 from app.services.naver_finance.company import (
     fetch_financials as fetch_financials,
 )
+from app.services.naver_finance.consensus import (
+    fetch_analyst_consensus as fetch_analyst_consensus,
+)
 from app.services.naver_finance.investor import (
     _build_investment_opinions_from_company_list_soup as _build_investment_opinions_from_company_list_soup,
 )
@@ -145,4 +148,5 @@ __all__ = [
     "fetch_news",
     "fetch_sector_peers",
     "fetch_valuation",
+    "fetch_analyst_consensus",
 ]

--- a/app/services/naver_finance/consensus.py
+++ b/app/services/naver_finance/consensus.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+
+from app.services.naver_finance.parser import DEFAULT_HEADERS
+
+NAVER_INTEGRATION_URL = "https://m.stock.naver.com/api/stock/{code}/integration"
+
+
+async def fetch_analyst_consensus(code: str) -> dict[str, Any]:
+    """Fetch analyst consensus from Naver mobile integration API.
+
+    Args:
+        code: 6-digit Korean stock code (e.g. "005930").
+
+    Returns:
+        Dict containing recomm_mean, price_target_mean, and warnings.
+    """
+    code = (code or "").strip()
+    if not (len(code) == 6 and code.isdigit()):
+        raise ValueError(f"Invalid Korean stock code: {code}")
+
+    url = NAVER_INTEGRATION_URL.format(code=code)
+    async with httpx.AsyncClient(headers=DEFAULT_HEADERS, timeout=10) as client:
+        response = await client.get(url)
+        response.raise_for_status()
+        payload = response.json()
+
+    warnings: list[str] = []
+
+    consensus_info = payload.get("consensusInfo")
+    if not isinstance(consensus_info, dict):
+        warnings.append("missing or invalid key: consensusInfo")
+        consensus_info = {}
+
+    recomm_mean = None
+    if "recommMean" in consensus_info:
+        recomm_mean = consensus_info["recommMean"]
+    else:
+        warnings.append("missing key: recommMean")
+
+    price_target_mean = None
+    if "priceTargetMean" in consensus_info:
+        price_target_mean = consensus_info["priceTargetMean"]
+    else:
+        warnings.append("missing key: priceTargetMean")
+
+    return {
+        "recomm_mean": recomm_mean,
+        "price_target_mean": price_target_mean,
+        "warnings": warnings,
+    }

--- a/app/services/toss_consumer/__init__.py
+++ b/app/services/toss_consumer/__init__.py
@@ -1,0 +1,1 @@
+# Blank package marker for toss_consumer

--- a/app/services/toss_consumer/client.py
+++ b/app/services/toss_consumer/client.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from typing import Any
+
+from app.services.toss_consumer.transport import build_toss_consumer_client
+
+
+def _to_product_code(symbol: str) -> str:
+    s = (symbol or "").strip().upper()
+    if len(s) == 7 and s.startswith("A") and s[1:].isdigit():
+        return s
+    if len(s) == 6 and s.isdigit():
+        return f"A{s}"
+    raise ValueError(f"Invalid Korean equity symbol: {symbol}")
+
+
+def _extract_envelope(payload: Any) -> Any:
+    """Unwrap ``result``/``data`` envelopes if present (fail-open for drift)."""
+    target = payload
+    if isinstance(payload, dict):
+        if isinstance(payload.get("result"), dict):
+            target = payload["result"]
+        elif isinstance(payload.get("data"), dict):
+            target = payload["data"]
+    return target
+
+
+class TossConsumerClient:
+    """Live per-call fetcher for the unofficial Toss consumer API (wts-info-api).
+
+    Each method opens and closes its own httpx client so long-running processes
+    never accumulate leaked connections. Matches the naver_finance per-call
+    ``async with httpx.AsyncClient(...)`` convention.
+    """
+
+    async def fetch_buy_balance(self, product_code: str) -> dict[str, Any]:
+        async with build_toss_consumer_client() as client:
+            response = await client.get(
+                "/api/v1/stock-infos/trade/trend/trading-trend",
+                params={"productCode": product_code},
+            )
+            response.raise_for_status()
+            payload = response.json()
+
+        target = _extract_envelope(payload)
+        warnings: list[str] = []
+
+        def _get_val(key: str) -> Any:
+            if isinstance(target, dict) and key in target:
+                return target[key]
+            warnings.append(f"missing key: {key}")
+            return None
+
+        buy_balance_rate = _get_val("buyBalanceRate")
+        sell_balance_rate = _get_val("sellBalanceRate")
+        foreigner_ratio = _get_val("foreignerRatio")
+
+        return {
+            "buyBalanceRate": buy_balance_rate,
+            "sellBalanceRate": sell_balance_rate,
+            "foreignerRatio": foreigner_ratio,
+            "warnings": warnings,
+        }
+
+    async def fetch_ai_signal(self, product_code: str) -> dict[str, Any]:
+        async with build_toss_consumer_client() as client:
+            response = await client.get(
+                "/api/v1/dashboard/wts/overview/ai-signals/detail",
+                params={"productCode": product_code, "productType": "STOCKS"},
+            )
+            response.raise_for_status()
+            payload = response.json()
+
+        target = _extract_envelope(payload)
+        warnings: list[str] = []
+
+        def _get_val(key: str) -> Any:
+            if isinstance(target, dict) and key in target:
+                return target[key]
+            warnings.append(f"missing key: {key}")
+            return None
+
+        signal_direction = _get_val("signalDirection")
+        reasoning = _get_val("reasoning")
+        related_reasoning = _get_val("relatedReasoning")
+
+        return {
+            "signalDirection": signal_direction,
+            "reasoning": reasoning,
+            "relatedReasoning": related_reasoning,
+            "warnings": warnings,
+        }

--- a/app/services/toss_consumer/transport.py
+++ b/app/services/toss_consumer/transport.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from typing import Final
+from urllib.parse import urlsplit
+
+import httpx
+
+from app.services.brokers.toss.errors import TossHostBlocked
+
+TOSS_CONSUMER_HOSTS: Final[frozenset[str]] = frozenset({"wts-info-api.tossinvest.com"})
+DEFAULT_TOSS_CONSUMER_BASE_URL: Final[str] = "https://wts-info-api.tossinvest.com"
+DEFAULT_TOSS_CONSUMER_TIMEOUT: Final[float] = 10.0
+
+
+def assert_toss_consumer_host(host: str | None, *, scheme: str | None = None) -> None:
+    if scheme is not None and scheme != "https":
+        raise TossHostBlocked(
+            f"Scheme {scheme!r} is not allowed for Toss Consumer API; https is required."
+        )
+    if host not in TOSS_CONSUMER_HOSTS:
+        raise TossHostBlocked(
+            f"Host {host!r} is not in TOSS_CONSUMER_HOSTS. "
+            "Allowed: " + ", ".join(sorted(TOSS_CONSUMER_HOSTS))
+        )
+
+
+def _assert_base_url_is_toss_consumer(base_url: str) -> None:
+    parsed = urlsplit(base_url)
+    assert_toss_consumer_host(parsed.hostname, scheme=parsed.scheme)
+
+
+async def _on_request(request: httpx.Request) -> None:
+    assert_toss_consumer_host(request.url.host, scheme=request.url.scheme)
+
+
+async def _on_response(response: httpx.Response) -> None:
+    if 300 <= response.status_code < 400:
+        location = response.headers.get("location", "")
+        raise TossHostBlocked(
+            f"Unexpected redirect from {response.request.url} to {location!r}; "
+            "Toss Consumer API endpoints do not legitimately redirect. Refusing."
+        )
+
+
+def build_toss_consumer_client(
+    *,
+    base_url: str = DEFAULT_TOSS_CONSUMER_BASE_URL,
+    timeout: float = DEFAULT_TOSS_CONSUMER_TIMEOUT,
+    transport: httpx.AsyncBaseTransport | None = None,
+) -> httpx.AsyncClient:
+    _assert_base_url_is_toss_consumer(base_url)
+    return httpx.AsyncClient(
+        base_url=base_url,
+        timeout=timeout,
+        follow_redirects=False,
+        transport=transport,
+        event_hooks={"request": [_on_request], "response": [_on_response]},
+    )

--- a/tests/test_mcp_analyst_consensus.py
+++ b/tests/test_mcp_analyst_consensus.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import pytest
+
+from app.mcp_server.tooling.fundamentals import _analyst_consensus as mod
+from app.mcp_server.tooling.fundamentals._valuation import (
+    handle_get_investment_opinions,
+)
+from app.mcp_server.tooling.fundamentals_handlers import FUNDAMENTALS_TOOL_NAMES
+
+pytestmark = [pytest.mark.unit]
+
+
+@pytest.mark.asyncio
+async def test_handle_get_analyst_consensus_ok(monkeypatch):
+    async def mock_fetch_analyst_consensus(code: str):
+        assert code == "005930"
+        return {
+            "recomm_mean": 4.2,
+            "price_target_mean": 92000,
+            "warnings": [],
+        }
+
+    monkeypatch.setattr(mod, "fetch_analyst_consensus", mock_fetch_analyst_consensus)
+
+    # 6-digit stock code
+    res = await mod.handle_get_analyst_consensus("005930")
+    assert res["status"] == "ok"
+    assert res["recomm_mean"] == 4.2
+    assert res["price_target_mean"] == 92000
+    assert res["symbol"] == "005930"
+    assert res["source"] == "naver_integration"
+
+    # A-prefixed 7-digit code
+    res_a = await mod.handle_get_analyst_consensus("A005930")
+    assert res_a["status"] == "ok"
+    assert res_a["recomm_mean"] == 4.2
+    assert res_a["price_target_mean"] == 92000
+    assert res_a["symbol"] == "A005930"
+    assert res_a["source"] == "naver_integration"
+
+
+@pytest.mark.asyncio
+async def test_handle_get_analyst_consensus_error(monkeypatch):
+    async def mock_fetch_error(code: str):
+        raise RuntimeError("Naver API down")
+
+    monkeypatch.setattr(mod, "fetch_analyst_consensus", mock_fetch_error)
+
+    res = await mod.handle_get_analyst_consensus("005930")
+    assert "error" in res
+    assert "Naver API down" in res["error"]
+    assert res["source"] == "naver_integration"
+
+
+@pytest.mark.asyncio
+async def test_handle_get_analyst_consensus_validation():
+    with pytest.raises(ValueError, match="only available for Korean stocks"):
+        await mod.handle_get_analyst_consensus("AAPL")
+
+
+def test_tool_collision_prevention():
+    assert "get_investment_opinions" in FUNDAMENTALS_TOOL_NAMES
+    assert "get_analyst_consensus" in FUNDAMENTALS_TOOL_NAMES
+    assert mod.handle_get_analyst_consensus is not handle_get_investment_opinions

--- a/tests/test_mcp_toss_signals.py
+++ b/tests/test_mcp_toss_signals.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import pytest
+
+from app.mcp_server.tooling.fundamentals import _toss_signals as mod
+
+pytestmark = [pytest.mark.unit]
+
+
+@pytest.mark.asyncio
+async def test_disabled_by_default(monkeypatch):
+    monkeypatch.setattr(mod.settings, "toss_consumer_signals_enabled", False)
+
+    out_balance = await mod.handle_get_toss_buy_balance("005930")
+    assert out_balance["status"] == "disabled"
+    assert out_balance["source"] == "toss_consumer"
+    assert "disabled" in out_balance["note"]
+
+    out_signal = await mod.handle_get_toss_ai_signal("005930")
+    assert out_signal["status"] == "disabled"
+    assert out_signal["source"] == "toss_consumer"
+    assert "disabled" in out_signal["note"]
+
+
+@pytest.mark.asyncio
+async def test_enabled_and_ok_response(monkeypatch):
+    monkeypatch.setattr(mod.settings, "toss_consumer_signals_enabled", True)
+
+    async def mock_fetch_buy_balance(self, product_code: str):
+        assert product_code == "A005930"
+        return {
+            "buyBalanceRate": 0.6,
+            "sellBalanceRate": 0.4,
+            "foreignerRatio": 0.5,
+            "warnings": [],
+        }
+
+    async def mock_fetch_ai_signal(self, product_code: str):
+        assert product_code == "A005930"
+        return {
+            "signalDirection": "BUY",
+            "reasoning": "Technical indicator support",
+            "relatedReasoning": "Consensus target raised",
+            "warnings": [],
+        }
+
+    monkeypatch.setattr(
+        mod.TossConsumerClient, "fetch_buy_balance", mock_fetch_buy_balance
+    )
+    monkeypatch.setattr(mod.TossConsumerClient, "fetch_ai_signal", mock_fetch_ai_signal)
+
+    out_balance = await mod.handle_get_toss_buy_balance("005930")
+    assert out_balance["status"] == "ok"
+    assert out_balance["buyBalanceRate"] == 0.6
+    assert out_balance["sellBalanceRate"] == 0.4
+    assert out_balance["foreignerRatio"] == 0.5
+    assert not out_balance["warnings"]
+
+    out_signal = await mod.handle_get_toss_ai_signal("005930")
+    assert out_signal["status"] == "ok"
+    assert out_signal["signalDirection"] == "BUY"
+    assert out_signal["reasoning"] == "Technical indicator support"
+    assert out_signal["relatedReasoning"] == "Consensus target raised"
+    assert not out_signal["warnings"]
+
+
+@pytest.mark.asyncio
+async def test_enabled_but_http_error(monkeypatch):
+    monkeypatch.setattr(mod.settings, "toss_consumer_signals_enabled", True)
+
+    async def mock_fetch_error(self, product_code: str):
+        raise RuntimeError("WTS API is down")
+
+    monkeypatch.setattr(mod.TossConsumerClient, "fetch_buy_balance", mock_fetch_error)
+    monkeypatch.setattr(mod.TossConsumerClient, "fetch_ai_signal", mock_fetch_error)
+
+    out_balance = await mod.handle_get_toss_buy_balance("005930")
+    assert "error" in out_balance
+    assert "WTS API is down" in out_balance["error"]
+    assert out_balance["source"] == "toss_consumer"
+
+    out_signal = await mod.handle_get_toss_ai_signal("005930")
+    assert "error" in out_signal
+    assert "WTS API is down" in out_signal["error"]
+    assert out_signal["source"] == "toss_consumer"
+
+
+@pytest.mark.asyncio
+async def test_non_kr_symbol_validation(monkeypatch):
+    monkeypatch.setattr(mod.settings, "toss_consumer_signals_enabled", True)
+
+    with pytest.raises(ValueError, match="only available for Korean stocks"):
+        await mod.handle_get_toss_buy_balance("AAPL")
+
+    with pytest.raises(ValueError, match="only available for Korean stocks"):
+        await mod.handle_get_toss_ai_signal("AAPL")
+
+
+def test_honest_labeling_description():
+    doc_balance = mod.handle_get_toss_buy_balance.__doc__ or ""
+    assert "orderbook balance rate" in doc_balance
+    # "user buy ratio" should not be used as it is misleading
+    assert "user buy ratio" not in doc_balance.lower()
+    assert "retail polarity" not in doc_balance.lower()

--- a/tests/test_naver_consensus_fetch.py
+++ b/tests/test_naver_consensus_fetch.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import pytest
+
+from app.services.naver_finance.consensus import fetch_analyst_consensus
+
+pytestmark = [pytest.mark.unit]
+
+
+@pytest.mark.asyncio
+async def test_fetch_analyst_consensus_ok(httpx_mock):
+    httpx_mock.add_response(
+        url="https://m.stock.naver.com/api/stock/005930/integration",
+        json={
+            "consensusInfo": {
+                "recommMean": 4.5,
+                "priceTargetMean": 95000,
+            }
+        },
+    )
+
+    res = await fetch_analyst_consensus("005930")
+    assert res["recomm_mean"] == 4.5
+    assert res["price_target_mean"] == 95000
+    assert not res["warnings"]
+
+
+@pytest.mark.asyncio
+async def test_fetch_analyst_consensus_fail_open(httpx_mock):
+    httpx_mock.add_response(
+        url="https://m.stock.naver.com/api/stock/005930/integration",
+        json={
+            "consensusInfo": {
+                "recommMean": 3.8,
+                # priceTargetMean is missing
+            }
+        },
+    )
+
+    res = await fetch_analyst_consensus("005930")
+    assert res["recomm_mean"] == 3.8
+    assert res["price_target_mean"] is None
+    assert len(res["warnings"]) == 1
+    assert "priceTargetMean" in res["warnings"][0]
+
+
+@pytest.mark.asyncio
+async def test_fetch_analyst_consensus_invalid_key_envelope(httpx_mock):
+    httpx_mock.add_response(
+        url="https://m.stock.naver.com/api/stock/005930/integration",
+        json={
+            # consensusInfo is completely missing or is null
+            "consensusInfo": None
+        },
+    )
+
+    res = await fetch_analyst_consensus("005930")
+    assert res["recomm_mean"] is None
+    assert res["price_target_mean"] is None
+    assert (
+        len(res["warnings"]) == 3
+    )  # consensusInfo, recommMean, priceTargetMean warnings
+
+
+@pytest.mark.asyncio
+async def test_fetch_analyst_consensus_validation():
+    with pytest.raises(ValueError, match="Invalid Korean stock code"):
+        # Not KR code (non-digit)
+        await fetch_analyst_consensus("AAPL")
+
+    with pytest.raises(ValueError, match="Invalid Korean stock code"):
+        # Length is wrong
+        await fetch_analyst_consensus("12345")

--- a/tests/test_toss_consumer_client.py
+++ b/tests/test_toss_consumer_client.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import pytest
+
+from app.services.toss_consumer.client import TossConsumerClient, _to_product_code
+
+pytestmark = [pytest.mark.unit]
+
+
+def test_to_product_code_conversion():
+    assert _to_product_code("005930") == "A005930"
+    assert _to_product_code("A005930") == "A005930"
+    with pytest.raises(ValueError, match="Invalid Korean equity symbol"):
+        _to_product_code("AAPL")
+    with pytest.raises(ValueError, match="Invalid Korean equity symbol"):
+        _to_product_code("00593")  # too short
+    with pytest.raises(ValueError, match="Invalid Korean equity symbol"):
+        _to_product_code("A00593")  # too short A pattern
+
+
+@pytest.mark.asyncio
+async def test_fetch_buy_balance_flat_json(httpx_mock):
+    client = TossConsumerClient()
+    httpx_mock.add_response(
+        url="https://wts-info-api.tossinvest.com/api/v1/stock-infos/trade/trend/trading-trend?productCode=A005930",
+        json={
+            "buyBalanceRate": 0.65,
+            "sellBalanceRate": 0.35,
+            "foreignerRatio": 0.52,
+        },
+    )
+
+    res = await client.fetch_buy_balance("A005930")
+    assert res["buyBalanceRate"] == 0.65
+    assert res["sellBalanceRate"] == 0.35
+    assert res["foreignerRatio"] == 0.52
+    assert not res["warnings"]
+
+
+@pytest.mark.asyncio
+async def test_fetch_buy_balance_wrapped_result(httpx_mock):
+    client = TossConsumerClient()
+    httpx_mock.add_response(
+        url="https://wts-info-api.tossinvest.com/api/v1/stock-infos/trade/trend/trading-trend?productCode=A005930",
+        json={
+            "result": {
+                "buyBalanceRate": 0.70,
+                "sellBalanceRate": 0.30,
+                "foreignerRatio": 0.50,
+            }
+        },
+    )
+
+    res = await client.fetch_buy_balance("A005930")
+    assert res["buyBalanceRate"] == 0.70
+    assert res["sellBalanceRate"] == 0.30
+    assert res["foreignerRatio"] == 0.50
+    assert not res["warnings"]
+
+
+@pytest.mark.asyncio
+async def test_fetch_buy_balance_fail_open_keys(httpx_mock):
+    client = TossConsumerClient()
+    httpx_mock.add_response(
+        url="https://wts-info-api.tossinvest.com/api/v1/stock-infos/trade/trend/trading-trend?productCode=A005930",
+        json={
+            # buyBalanceRate missing
+            "sellBalanceRate": 0.30,
+            "foreignerRatio": 0.50,
+        },
+    )
+
+    res = await client.fetch_buy_balance("A005930")
+    assert res["buyBalanceRate"] is None
+    assert res["sellBalanceRate"] == 0.30
+    assert res["foreignerRatio"] == 0.50
+    assert len(res["warnings"]) == 1
+    assert "buyBalanceRate" in res["warnings"][0]
+
+
+@pytest.mark.asyncio
+async def test_fetch_ai_signal_flat_json(httpx_mock):
+    client = TossConsumerClient()
+    httpx_mock.add_response(
+        url="https://wts-info-api.tossinvest.com/api/v1/dashboard/wts/overview/ai-signals/detail?productCode=A005930&productType=STOCKS",
+        json={
+            "signalDirection": "BUY",
+            "reasoning": "Strong earnings forecast",
+            "relatedReasoning": "Consistent market leadership",
+        },
+    )
+
+    res = await client.fetch_ai_signal("A005930")
+    assert res["signalDirection"] == "BUY"
+    assert res["reasoning"] == "Strong earnings forecast"
+    assert res["relatedReasoning"] == "Consistent market leadership"
+    assert not res["warnings"]
+
+
+@pytest.mark.asyncio
+async def test_fetch_ai_signal_wrapped_data(httpx_mock):
+    client = TossConsumerClient()
+    httpx_mock.add_response(
+        url="https://wts-info-api.tossinvest.com/api/v1/dashboard/wts/overview/ai-signals/detail?productCode=A005930&productType=STOCKS",
+        json={
+            "data": {
+                "signalDirection": "SELL",
+                "reasoning": "Overbought condition",
+                "relatedReasoning": "RSI indicator crossover",
+            }
+        },
+    )
+
+    res = await client.fetch_ai_signal("A005930")
+    assert res["signalDirection"] == "SELL"
+    assert res["reasoning"] == "Overbought condition"
+    assert res["relatedReasoning"] == "RSI indicator crossover"
+    assert not res["warnings"]
+
+
+@pytest.mark.asyncio
+async def test_fetch_ai_signal_fail_open_keys(httpx_mock):
+    client = TossConsumerClient()
+    httpx_mock.add_response(
+        url="https://wts-info-api.tossinvest.com/api/v1/dashboard/wts/overview/ai-signals/detail?productCode=A005930&productType=STOCKS",
+        json={
+            # signalDirection and reasoning missing
+            "relatedReasoning": "Technical breakout",
+        },
+    )
+
+    res = await client.fetch_ai_signal("A005930")
+    assert res["signalDirection"] is None
+    assert res["reasoning"] is None
+    assert res["relatedReasoning"] == "Technical breakout"
+    assert len(res["warnings"]) == 2
+    assert "signalDirection" in res["warnings"][0]
+    assert "reasoning" in res["warnings"][1]

--- a/tests/test_toss_consumer_transport.py
+++ b/tests/test_toss_consumer_transport.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from app.services.brokers.toss.errors import TossHostBlocked
+from app.services.toss_consumer.transport import (
+    assert_toss_consumer_host,
+    build_toss_consumer_client,
+)
+
+pytestmark = [pytest.mark.unit]
+
+
+def test_assert_toss_consumer_host():
+    # Valid host & scheme
+    assert_toss_consumer_host("wts-info-api.tossinvest.com", scheme="https")
+
+    # Invalid scheme
+    with pytest.raises(TossHostBlocked, match="Scheme .* is not allowed"):
+        assert_toss_consumer_host("wts-info-api.tossinvest.com", scheme="http")
+
+    # Invalid host
+    with pytest.raises(TossHostBlocked, match="Host .* is not in TOSS_CONSUMER_HOSTS"):
+        assert_toss_consumer_host("openapi.tossinvest.com", scheme="https")
+
+    with pytest.raises(TossHostBlocked, match="Host .* is not in TOSS_CONSUMER_HOSTS"):
+        assert_toss_consumer_host("google.com", scheme="https")
+
+
+@pytest.mark.asyncio
+async def test_build_toss_consumer_client_redirect_block():
+    client = build_toss_consumer_client()
+    assert str(client.base_url).rstrip("/") == "https://wts-info-api.tossinvest.com"
+    assert client.follow_redirects is False
+
+    # Check hooks assert correct host on request
+    req = httpx.Request("GET", "https://openapi.tossinvest.com/some/path")
+    with pytest.raises(TossHostBlocked):
+        for hook in client.event_hooks["request"]:
+            await hook(req)
+
+    # Check hook blocks redirects
+    resp_redirect = httpx.Response(
+        302, headers={"Location": "https://other.com"}, request=req
+    )
+    with pytest.raises(TossHostBlocked, match="Unexpected redirect"):
+        for hook in client.event_hooks["response"]:
+            await hook(resp_redirect)


### PR DESCRIPTION
## Summary

Adds three operator-gated MCP tools that surface non-CDP HTTP signals without the CDP(9222) dependency (ROB-595, follow-up to ROB-586).

- **`get_toss_buy_balance`** — Toss orderbook balance rate (`buyBalanceRate`/`sellBalanceRate`) + foreigner holding ratio, via the unofficial `wts-info-api.tossinvest.com` consumer API. 수급(net buy volume) intentionally excluded — already covered by `get_investor_trends` (Naver).
- **`get_toss_ai_signal`** — Toss AI `signalDirection` + `reasoning` + `relatedReasoning`.
- **`get_analyst_consensus`** — Naver `m.stock.naver.com /integration` `recommMean` + `priceTargetMean`. Net-new vs `get_investment_opinions` (report-level — it does not expose a recommendation mean).

## Safety boundaries

- **Host isolation**: `wts-info-api.tossinvest.com` lives in a separate `TOSS_CONSUMER_HOSTS` allowlist, fully isolated from the official `openapi.tossinvest.com` OAuth client. Reuses `TossHostBlocked`, enforces https, blocks redirects (`follow_redirects=False`).
- **Default-off (Pattern B)**: Toss tools return `status="disabled"` with an activation hint until `TOSS_CONSUMER_SIGNALS_ENABLED=true` is set after ToS review. Disabled state performs zero fetches.
- **Honest labeling**: never described as "user buy ratio" / "retail polarity" — labeled as orderbook balance rate. Honest-label docstring assertion included.
- **Aggregate-only** (ROB-199/449 contract inherited); no DB, no migrations; live per-call.
- **fail-open parsing** tolerates unofficial-API key drift (missing keys → `null` + `warnings`); both flat and `result`/`data` envelopes handled.
- **Connection lifecycle**: per-call httpx clients opened/closed via `async with build_toss_consumer_client()` (matches `naver_finance` convention) — no leaks in the long-running MCP process.

## Review-fix applied

Verification caught an httpx client lifecycle leak (`TossConsumerClient` stored the client without closing it). Fixed so each `fetch_*` opens/closes its own client. Also added the missing `pytestmark = [pytest.mark.unit]` to `test_mcp_toss_signals.py` for marker consistency with the other 4 new test files.

## Plan note

Original plan (`.omo/plans/ROB-595.md`, Momus-reviewed OKAY) split this into 2 PRs (Toss / consensus). They are combined here because the registration surface (`fundamentals_handlers.py` + README) is shared and the changes are cohesive. Reviewers: flag if you prefer a split.

## Test coverage

- 22 new unit tests: transport allowlist/https/redirect-block, client fail-open + product-code conversion, handler gate off/on + HTTP-error path + honest-label docstring, consensus fetch fail-open + invalid-envelope, tool-name collision prevention.
- Existing fundamentals suite (219 tests) unaffected.
- `ruff` + `ty` clean on all changed files.

## ⚠️ Model-lane / merge gate

Per `AGENTS.md` guardrails, this integrates a **new unofficial external host** with **ToS not yet cleared** → tagging `high_risk_change` + `needs_strer_model_review` + `hold_for_final_review`. Recommend Opus/CTO review of the host allowlist + fail-open parsing before merge, and keeping `TOSS_CONSUMER_SIGNALS_ENABLED=false` until ToS review clears live use.

Closes ROB-595.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added analyst consensus tool providing Korean stock recommendations and price targets
  * Added two Toss-powered Korean equity tools: buy/sell balance metrics and AI-driven directional signals (disabled by default)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->