### PR TITLE
feat(ROB-591): /invest/my 감시(watch) 탭 + watch 읽기 엔드포인트

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.3.0] - 2026-06-17
+
+### Added (ROB-591 — /invest/my watch tab + watch read endpoint)
+- New read-only endpoint `GET /trading/api/invest/watches` with `market` (all/kr/us/crypto) and `status` (all/active/triggered/expired/canceled) filters, backed by `InvestmentReportsRepository.list_alerts`.
+- Generalize `list_active_alerts` into `list_alerts` (new `status` param) with backward-compatible delegation from `list_active_alerts`; all existing callers unaffected (522 regression tests pass).
+- New `WatchPanelService` enriches rows with symbol names (fail-open), price proximity for `price_above`/`price_below` metrics via `compute_price_proximity`, latest trigger event lookup for non-active rows, and `near_expiry` flag (active alerts with `valid_until` ≤ 2 days).
+- New Pydantic schemas `WatchesResponse`, `WatchAlertRow`, `WatchEventSummary` with `ConfigDict(extra="forbid")` and Decimal field serializers matching invest schema conventions.
+- New frontend `WatchAlertsPanel` with market/status filters, proximity pill, status pill, near_expiry badge, and symbol links to stock detail page.
+- Wire `watchAlerts` tab into desktop and mobile portfolio pages (`portfolioTabs.ts` union, `PORTFOLIO_TABS` array, and `parsePortfolioTab` string check).
+- Current price resolved from `market_quote_snapshots` table; data_state reflects snapshot availability (ok/degraded/unavailable).
+
 ## [0.2.3] - 2026-06-16
 
 ### Added (ROB-582 — Cross-asset allocation roll-up)

--- a/app/main.py
+++ b/app/main.py
@@ -36,6 +36,7 @@ from app.routers import (
     invest_fills,
     invest_open_orders,
     invest_scalping,
+    invest_watches,
     invest_web_spa,
     investment_dimension_reports,
     investment_hermes_http,
@@ -191,6 +192,7 @@ def create_app() -> FastAPI:
     app.include_router(invest_scalping.router)
     app.include_router(invest_fills.router)
     app.include_router(invest_open_orders.router)
+    app.include_router(invest_watches.router)
     app.include_router(invest_app_spa.router)
     app.include_router(invest_web_spa.router)
     app.include_router(trade_journals.router)

--- a/app/routers/invest_watches.py
+++ b/app/routers/invest_watches.py
@@ -1,0 +1,38 @@
+"""FastAPI router for watch alerts in the /invest panel (ROB-591)."""
+
+from __future__ import annotations
+
+from typing import Annotated, Literal
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.db import get_db
+from app.models.trading import User
+from app.routers.dependencies import get_authenticated_user
+from app.schemas.invest_watches import WatchesResponse
+from app.services.invest_view_model.watch_panel_service import WatchPanelService
+
+router = APIRouter(
+    prefix="/trading/api/invest/watches",
+    tags=["invest-watches"],
+)
+
+Market = Literal["all", "kr", "us", "crypto"]
+Status = Literal["all", "active", "triggered", "expired", "canceled"]
+
+
+def get_watch_panel_service(
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> WatchPanelService:
+    return WatchPanelService(db=db)
+
+
+@router.get("")
+async def list_watches(
+    _user: Annotated[User, Depends(get_authenticated_user)],
+    service: Annotated[WatchPanelService, Depends(get_watch_panel_service)],
+    market: Annotated[Market, Query()] = "all",
+    status: Annotated[Status, Query()] = "all",
+) -> WatchesResponse:
+    return await service.list_watches(market=market, status=status)

--- a/app/schemas/invest_watches.py
+++ b/app/schemas/invest_watches.py
@@ -1,0 +1,79 @@
+"""Read-only schemas for /invest watch alerts (ROB-591)."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from decimal import Decimal
+from typing import Literal
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field, field_serializer
+
+WatchAlertStatus = Literal["active", "triggered", "expired", "canceled"]
+WatchProximityBand = Literal["hit", "within_0_5_pct", "within_1_pct", "outside"]
+WatchDataState = Literal["ok", "degraded", "unavailable"]
+
+
+class WatchEventSummary(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    event_uuid: UUID
+    outcome: (
+        str  # notified/review_required/preview_attached/executed/expired/ignored/failed
+    )
+    current_value: Decimal | None
+    created_at: datetime
+
+    @field_serializer("current_value")
+    def _decimal_to_json(self, value: Decimal | None) -> str | None:
+        if value is None:
+            return None
+        return format(value, "f")
+
+
+class WatchAlertRow(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    alert_uuid: UUID
+    source_report_uuid: UUID
+    market: Literal["kr", "us", "crypto"]
+    symbol: str = Field(min_length=1)
+    symbol_name: str | None = None
+    target_kind: str
+    metric: str
+    operator: Literal["above", "below", "between"]
+    threshold: Decimal
+    threshold_high: Decimal | None = None
+    status: WatchAlertStatus
+    valid_until: datetime
+    intent: str
+    action_mode: str
+    rationale: str
+    trigger_checklist: list[dict] = Field(default_factory=list)
+    max_action: dict = Field(default_factory=dict)
+    # 근접도 (price metric만, 외 metric은 null)
+    current_price: Decimal | None = None
+    proximity_band: WatchProximityBand | None = None
+    # 최근 트리거 (triggered/expired 행에 의미)
+    last_event: WatchEventSummary | None = None
+    # valid_until 임박 플래그 (active 한정, <= 2일)
+    near_expiry: bool = False
+
+    @field_serializer("threshold", "threshold_high", "current_price")
+    def _decimal_to_json(self, value: Decimal | None) -> str | None:
+        if value is None:
+            return None
+        return format(value, "f")
+
+
+class WatchesResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    market: Literal["all", "kr", "us", "crypto"]
+    status: Literal["all", "active", "triggered", "expired", "canceled"] = "all"
+    count: int = Field(ge=0)
+    data_state: WatchDataState
+    as_of: datetime
+    items: list[WatchAlertRow]
+    warnings: list[str] = Field(default_factory=list)
+    empty_reason: str | None = None

--- a/app/services/invest_view_model/watch_panel_service.py
+++ b/app/services/invest_view_model/watch_panel_service.py
@@ -1,0 +1,334 @@
+"""Service for /invest watch panel (ROB-591)."""
+
+from __future__ import annotations
+
+import datetime as dt
+import logging
+from decimal import Decimal
+from typing import Literal
+
+import sqlalchemy as sa
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.investment_reports import InvestmentWatchAlert, InvestmentWatchEvent
+from app.models.market_quote_snapshot import MarketQuoteSnapshot
+from app.schemas.invest_watches import (
+    WatchAlertRow,
+    WatchDataState,
+    WatchesResponse,
+    WatchEventSummary,
+    WatchProximityBand,
+)
+from app.services.investment_reports.repository import InvestmentReportsRepository
+from app.services.kr_symbol_universe_service import get_kr_names_by_symbols
+from app.services.upbit_symbol_universe_service import get_upbit_market_display_names
+from app.services.us_symbol_universe_service import get_us_names_by_symbols
+from app.services.watch_proximity import compute_price_proximity
+
+logger = logging.getLogger(__name__)
+
+
+def _to_decimal(val: object) -> Decimal | None:
+    if val is None:
+        return None
+    if isinstance(val, Decimal):
+        return val
+    try:
+        return Decimal(str(val))
+    except (TypeError, ValueError):
+        return None
+
+
+class WatchPanelService:
+    def __init__(
+        self,
+        *,
+        db: AsyncSession,
+        clock: dt.datetime | None = None,
+    ) -> None:
+        self._db = db
+        self._clock = (
+            (lambda: clock)
+            if clock is not None
+            else (lambda: dt.datetime.now(tz=dt.UTC))
+        )
+
+    async def list_watches(
+        self,
+        *,
+        market: Literal["all", "kr", "us", "crypto"] = "all",
+        status: Literal["all", "active", "triggered", "expired", "canceled"] = "all",
+    ) -> WatchesResponse:
+        repo = InvestmentReportsRepository(self._db)
+        now = self._clock()
+
+        # 1. Fetch alerts
+        db_market = None if market == "all" else market
+        db_status = None if status == "all" else status
+        alerts = await repo.list_alerts(
+            market=db_market,
+            status=db_status,
+            limit=250,
+        )
+
+        # 2. Enrich symbol names (fail-open)
+        symbol_names = await self._attach_symbol_names(alerts)
+
+        # 3. Fetch latest quotes for active price-metric alerts
+        active_price_alerts = [
+            a
+            for a in alerts
+            if a.status == "active" and a.metric in ("price_above", "price_below")
+        ]
+
+        snapshots: dict[tuple[str, str], MarketQuoteSnapshot] = {}
+        pairs = list({(a.market, a.symbol) for a in active_price_alerts})
+        if pairs:
+            try:
+                subq = (
+                    sa.select(
+                        MarketQuoteSnapshot.market,
+                        MarketQuoteSnapshot.symbol,
+                        sa.func.max(MarketQuoteSnapshot.snapshot_at).label("max_at"),
+                    )
+                    .where(
+                        sa.tuple_(
+                            MarketQuoteSnapshot.market, MarketQuoteSnapshot.symbol
+                        ).in_(pairs)
+                    )
+                    .group_by(MarketQuoteSnapshot.market, MarketQuoteSnapshot.symbol)
+                    .subquery()
+                )
+                stmt = sa.select(MarketQuoteSnapshot).join(
+                    subq,
+                    sa.and_(
+                        MarketQuoteSnapshot.market == subq.c.market,
+                        MarketQuoteSnapshot.symbol == subq.c.symbol,
+                        MarketQuoteSnapshot.snapshot_at == subq.c.max_at,
+                    ),
+                )
+                res = await self._db.execute(stmt)
+                for snapshot in res.scalars().all():
+                    snapshots[(snapshot.market, snapshot.symbol)] = snapshot
+            except Exception:
+                logger.exception("Failed to query market quote snapshots")
+
+        # Determine data_state
+        active_price_alert_count = len(active_price_alerts)
+        resolved_count = 0
+        for a in active_price_alerts:
+            if (a.market, a.symbol) in snapshots:
+                resolved_count += 1
+
+        if active_price_alert_count > 0:
+            if resolved_count == active_price_alert_count:
+                data_state: WatchDataState = "ok"
+            elif resolved_count > 0:
+                data_state: WatchDataState = "degraded"
+            else:
+                data_state: WatchDataState = "unavailable"
+        else:
+            data_state: WatchDataState = "ok"
+
+        # 4. Fetch last events for triggered/expired/canceled alerts
+        non_active_alerts = [a for a in alerts if a.status != "active"]
+        alert_ids = [a.id for a in non_active_alerts]
+        last_events: dict[int, InvestmentWatchEvent] = {}
+        if alert_ids:
+            try:
+                subq = (
+                    sa.select(
+                        InvestmentWatchEvent.alert_id,
+                        sa.func.max(InvestmentWatchEvent.created_at).label(
+                            "max_created"
+                        ),
+                    )
+                    .where(InvestmentWatchEvent.alert_id.in_(alert_ids))
+                    .group_by(InvestmentWatchEvent.alert_id)
+                    .subquery()
+                )
+                stmt = sa.select(InvestmentWatchEvent).join(
+                    subq,
+                    sa.and_(
+                        InvestmentWatchEvent.alert_id == subq.c.alert_id,
+                        InvestmentWatchEvent.created_at == subq.c.max_created,
+                    ),
+                )
+                res = await self._db.execute(stmt)
+                for event in res.scalars().all():
+                    if event.alert_id is not None:
+                        last_events[event.alert_id] = event
+            except Exception:
+                logger.exception("Failed to query investment watch events")
+
+        # 5. Build items
+        items: list[WatchAlertRow] = []
+        for alert in alerts:
+            symbol_name = symbol_names.get((alert.market, alert.symbol))
+
+            # Near expiry logic for active alerts
+            near_expiry = False
+            if alert.status == "active" and alert.valid_until - now <= dt.timedelta(
+                days=2
+            ):
+                near_expiry = True
+
+            # Proximity calculation for active price alerts
+            current_price: Decimal | None = None
+            proximity_band: WatchProximityBand | None = None
+            if alert.status == "active" and alert.metric in (
+                "price_above",
+                "price_below",
+            ):
+                snapshot = snapshots.get((alert.market, alert.symbol))
+                if snapshot is not None:
+                    current_price = snapshot.price
+                    try:
+                        prox_res = compute_price_proximity(
+                            market=alert.market,
+                            target_kind=alert.target_kind,
+                            symbol=alert.symbol,
+                            condition_type=alert.metric,
+                            threshold=float(alert.threshold),
+                            current=float(snapshot.price),
+                        )
+                        # We classification match: band literal
+                        proximity_band = prox_res.band
+                    except Exception:
+                        logger.warning(
+                            "Failed to compute proximity for alert %s",
+                            alert.id,
+                            exc_info=True,
+                        )
+
+            # Last event for triggered/expired/canceled alerts
+            last_event_summary: WatchEventSummary | None = None
+            if alert.status != "active":
+                event = last_events.get(alert.id)
+                if event is not None:
+                    last_event_summary = WatchEventSummary(
+                        event_uuid=event.event_uuid,
+                        outcome=event.outcome,
+                        current_value=_to_decimal(event.current_value),
+                        created_at=event.created_at,
+                    )
+
+            # Build trigger_checklist & max_action defaults
+            trigger_checklist = alert.trigger_checklist or []
+            max_action = alert.max_action or {}
+
+            items.append(
+                WatchAlertRow(
+                    alert_uuid=alert.alert_uuid,
+                    source_report_uuid=alert.source_report_uuid,
+                    market=alert.market,  # type: ignore[arg-type]
+                    symbol=alert.symbol,
+                    symbol_name=symbol_name,
+                    target_kind=alert.target_kind,
+                    metric=alert.metric,
+                    operator=alert.operator,  # type: ignore[arg-type]
+                    threshold=_to_decimal(alert.threshold),
+                    threshold_high=_to_decimal(alert.threshold_high),
+                    status=alert.status,  # type: ignore[arg-type]
+                    valid_until=alert.valid_until,
+                    intent=alert.intent,
+                    action_mode=alert.action_mode,
+                    rationale=alert.rationale,
+                    trigger_checklist=trigger_checklist,
+                    max_action=max_action,
+                    current_price=current_price,
+                    proximity_band=proximity_band,
+                    last_event=last_event_summary,
+                    near_expiry=near_expiry,
+                )
+            )
+
+        warnings: list[str] = []
+        if data_state == "degraded":
+            warnings.append(
+                "Some active price watch items could not retrieve current prices from the database."
+            )
+        elif data_state == "unavailable":
+            warnings.append(
+                "All active price watch items failed to retrieve current prices from the database."
+            )
+
+        empty_reason = None
+        if not items:
+            if status == "all":
+                empty_reason = "No watch alerts found."
+            else:
+                empty_reason = f"No {status} watch alerts found."
+
+        return WatchesResponse(
+            market=market,
+            status=status,
+            count=len(items),
+            data_state=data_state,
+            as_of=now,
+            items=items,
+            warnings=warnings,
+            empty_reason=empty_reason,
+        )
+
+    async def _attach_symbol_names(
+        self, alerts: list[InvestmentWatchAlert]
+    ) -> dict[tuple[str, str], str]:
+        """Best-effort display-name enrichment."""
+        if not alerts:
+            return {}
+
+        kr_symbols = sorted({alert.symbol for alert in alerts if alert.market == "kr"})
+        us_symbols = sorted({alert.symbol for alert in alerts if alert.market == "us"})
+        crypto_markets = sorted(
+            {
+                alert.symbol.strip().upper()
+                for alert in alerts
+                if alert.market == "crypto"
+            }
+        )
+
+        async def _safe(coro, label: str):
+            try:
+                return await coro
+            except Exception:  # noqa: BLE001 - display names must fail open
+                logger.warning(
+                    "watch-panel symbol-name resolution failed for %s",
+                    label,
+                    exc_info=True,
+                )
+                return {}
+
+        kr_names = (
+            await _safe(get_kr_names_by_symbols(kr_symbols, self._db), "kr")
+            if kr_symbols
+            else {}
+        )
+        us_names = (
+            await _safe(get_us_names_by_symbols(us_symbols, self._db), "us")
+            if us_symbols
+            else {}
+        )
+        crypto_names = (
+            await _safe(
+                get_upbit_market_display_names(crypto_markets, self._db), "crypto"
+            )
+            if crypto_markets
+            else {}
+        )
+
+        symbol_names: dict[tuple[str, str], str] = {}
+        for alert in alerts:
+            name: str | None = None
+            if alert.market == "kr":
+                name = kr_names.get(alert.symbol)
+            elif alert.market == "us":
+                name = us_names.get(alert.symbol)
+            elif alert.market == "crypto":
+                display = crypto_names.get(alert.symbol.strip().upper())
+                if display:
+                    name = display.get("korean_name") or display.get("english_name")
+
+            if name and name != alert.symbol:
+                symbol_names[(alert.market, alert.symbol)] = name
+        return symbol_names

--- a/app/services/investment_reports/repository.py
+++ b/app/services/investment_reports/repository.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 from collections.abc import Collection
 from datetime import datetime
-from typing import Any
+from typing import Any, Literal
 from uuid import UUID
 
 import sqlalchemy as sa
@@ -340,19 +340,20 @@ class InvestmentReportsRepository:
             )
         )
 
-    async def list_active_alerts(
+    async def list_alerts(
         self,
         *,
         market: str | None = None,
         symbol: str | None = None,
+        status: Literal["active", "triggered", "expired", "canceled"] | None = None,
         valid_at: datetime | None = None,
         include_expired_status_rows: bool = False,
-        limit: int = 100,
+        limit: int = 250,
     ) -> list[InvestmentWatchAlert]:
         capped_limit = max(1, min(int(limit), 250))
-        stmt = sa.select(InvestmentWatchAlert).where(
-            InvestmentWatchAlert.status == "active"
-        )
+        stmt = sa.select(InvestmentWatchAlert)
+        if status is not None:
+            stmt = stmt.where(InvestmentWatchAlert.status == status)
         if market is not None:
             stmt = stmt.where(InvestmentWatchAlert.market == market)
         if symbol is not None:
@@ -364,6 +365,24 @@ class InvestmentReportsRepository:
         )
         result = await self._session.scalars(stmt)
         return list(result.all())
+
+    async def list_active_alerts(
+        self,
+        *,
+        market: str | None = None,
+        symbol: str | None = None,
+        valid_at: datetime | None = None,
+        include_expired_status_rows: bool = False,
+        limit: int = 100,
+    ) -> list[InvestmentWatchAlert]:
+        return await self.list_alerts(
+            market=market,
+            symbol=symbol,
+            status="active",
+            valid_at=valid_at,
+            include_expired_status_rows=include_expired_status_rows,
+            limit=limit,
+        )
 
     async def list_alerts_for_source_reports(
         self, source_report_uuids: list[UUID], *, status: str | None = None

--- a/frontend/invest/src/api/watches.ts
+++ b/frontend/invest/src/api/watches.ts
@@ -1,0 +1,13 @@
+import type { WatchesResponse, WatchMarket, WatchStatus } from "../types/watches";
+
+const BASE = "/trading/api/invest/watches";
+
+export async function fetchWatches(
+  market: WatchMarket = "all",
+  status: WatchStatus = "all",
+): Promise<WatchesResponse> {
+  const q = new URLSearchParams({ market, status });
+  const res = await fetch(`${BASE}?${q}`, { credentials: "include" });
+  if (!res.ok) throw new Error(`watches ${res.status}`);
+  return res.json();
+}

--- a/frontend/invest/src/components/my/WatchAlertsPanel.tsx
+++ b/frontend/invest/src/components/my/WatchAlertsPanel.tsx
@@ -1,0 +1,332 @@
+import { useEffect, useMemo, useState } from "react";
+import { Link } from "react-router-dom";
+
+import { fetchWatches } from "../../api/watches";
+import { Pill } from "../../ds";
+import { stockDetailPath } from "../../stockDetailPath";
+import type {
+  WatchAlertRow,
+  WatchMarket,
+  WatchStatus,
+  WatchesResponse,
+} from "../../types/watches";
+
+const MARKET_OPTIONS: { key: WatchMarket; label: string }[] = [
+  { key: "all", label: "전체" },
+  { key: "kr", label: "국내" },
+  { key: "us", label: "미국" },
+  { key: "crypto", label: "코인" },
+];
+
+const STATUS_OPTIONS: { key: WatchStatus; label: string }[] = [
+  { key: "all", label: "전체 상태" },
+  { key: "active", label: "감시중" },
+  { key: "triggered", label: "감시발화" },
+  { key: "expired", label: "만료됨" },
+  { key: "canceled", label: "취소됨" },
+];
+
+const WATCH_STATUS_TONES: Record<string, "accent" | "warn" | "paper" | "loss"> = {
+  active: "accent",
+  triggered: "accent",
+  expired: "warn",
+  canceled: "warn",
+};
+
+const WATCH_STATUS_LABELS: Record<string, string> = {
+  active: "감시중",
+  triggered: "발화됨",
+  expired: "만료됨",
+  canceled: "취소됨",
+};
+
+const PROXIMITY_BAND_TONES: Record<string, "accent" | "warn" | "paper"> = {
+  hit: "accent",
+  within_0_5_pct: "warn",
+  within_1_pct: "paper",
+  outside: "paper",
+};
+
+const PROXIMITY_BAND_LABELS: Record<string, string> = {
+  hit: "도달",
+  within_0_5_pct: "0.5% 이내",
+  within_1_pct: "1.0% 이내",
+  outside: "대기",
+};
+
+const MARKET_LABEL: Record<string, string> = {
+  kr: "국내",
+  us: "미국",
+  crypto: "코인",
+};
+
+function formatMoney(value: string | number | null | undefined, market: string): string {
+  if (value == null || value === "") return "—";
+  const n = typeof value === "number" ? value : Number(value);
+  if (!Number.isFinite(n)) return "—";
+
+  if (market === "us") {
+    return `$${n.toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 4 })}`;
+  }
+  if (market === "kr") return `₩${Math.round(n).toLocaleString("ko-KR")}`;
+  return `${n.toLocaleString("ko-KR", { maximumFractionDigits: 8 })}`;
+}
+
+function formatDateTime(value: string | null): string {
+  if (!value) return "—";
+  const dt = new Date(value);
+  if (Number.isNaN(dt.getTime())) return value;
+  return new Intl.DateTimeFormat("ko-KR", {
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+    timeZone: "Asia/Seoul",
+  }).format(dt);
+}
+
+function formatCondition(row: WatchAlertRow): string {
+  const op = row.operator === "above" ? "이상" : row.operator === "below" ? "이하" : "범위";
+  const metricName = row.metric === "price_above" || row.metric === "price_below" || row.metric === "price" ? "가격" : row.metric;
+
+  if (row.operator === "between" && row.threshold_high) {
+    return `${metricName} ${formatMoney(row.threshold, row.market)} ~ ${formatMoney(row.threshold_high, row.market)}`;
+  }
+  return `${metricName} ${formatMoney(row.threshold, row.market)} ${op}`;
+}
+
+export function WatchAlertsPanel({ compact = false }: { compact?: boolean }) {
+  const [market, setMarket] = useState<WatchMarket>("all");
+  const [status, setStatus] = useState<WatchStatus>("all");
+  const [state, setState] = useState<
+    | { status: "loading" }
+    | { status: "ready"; data: WatchesResponse }
+    | { status: "error"; message: string }
+  >({ status: "loading" });
+
+  useEffect(() => {
+    let cancelled = false;
+    setState({ status: "loading" });
+    fetchWatches(market, status)
+      .then((data) => {
+        if (!cancelled) setState({ status: "ready", data });
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) setState({ status: "error", message: err instanceof Error ? err.message : String(err) });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [market, status]);
+
+  const rawRows = useMemo(() => (state.status === "ready" ? state.data.items : []), [state]);
+  const rows = useMemo(() => (compact ? rawRows.slice(0, 8) : rawRows), [rawRows, compact]);
+  const dataState = state.status === "ready" ? state.data.data_state : null;
+
+  return (
+    <section
+      data-testid="watch-alerts-panel"
+      style={{
+        border: "1px solid var(--border)",
+        borderRadius: 16,
+        background: "var(--surface)",
+        overflow: "hidden",
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          alignItems: compact ? "flex-start" : "center",
+          justifyContent: "space-between",
+          gap: 12,
+          padding: compact ? "14px 14px 10px" : "16px 18px 12px",
+          flexDirection: compact ? "column" : "row",
+        }}
+      >
+        <div>
+          <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
+            <h2 style={{ margin: 0, fontSize: compact ? 16 : 18 }}>AI 감시 트리거</h2>
+            {dataState && (
+              <Pill tone={dataState === "ok" ? "accent" : dataState === "degraded" ? "warn" : "loss"} size="sm">
+                {dataState === "ok" ? "실시간" : dataState === "degraded" ? "시세 지연" : "확인 불가"}
+              </Pill>
+            )}
+          </div>
+          <p style={{ margin: "4px 0 0", fontSize: 12, color: "var(--fg-3)" }}>
+            AI가 포착한 감시 대상과 실시간 조건 및 근접도를 표시합니다.
+          </p>
+        </div>
+        <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+          <div style={{ display: "flex", gap: 6, flexWrap: "wrap", alignSelf: "flex-end" }}>
+            {MARKET_OPTIONS.map((option) => {
+              const active = market === option.key;
+              return (
+                <button
+                  key={option.key}
+                  type="button"
+                  onClick={() => setMarket(option.key)}
+                  style={{
+                    border: "none",
+                    borderRadius: 999,
+                    padding: "4px 8px",
+                    fontSize: 11,
+                    fontWeight: 700,
+                    cursor: "pointer",
+                    fontFamily: "inherit",
+                    background: active ? "var(--fg)" : "var(--surface-2)",
+                    color: active ? "var(--bg)" : "var(--fg-2)",
+                  }}
+                >
+                  {option.label}
+                </button>
+              );
+            })}
+          </div>
+          <div style={{ display: "flex", gap: 6, flexWrap: "wrap", alignSelf: "flex-end" }}>
+            {STATUS_OPTIONS.map((option) => {
+              const active = status === option.key;
+              return (
+                <button
+                  key={option.key}
+                  type="button"
+                  onClick={() => setStatus(option.key)}
+                  style={{
+                    border: "none",
+                    borderRadius: 999,
+                    padding: "4px 8px",
+                    fontSize: 11,
+                    fontWeight: 700,
+                    cursor: "pointer",
+                    fontFamily: "inherit",
+                    background: active ? "var(--fg)" : "var(--surface-2)",
+                    color: active ? "var(--bg)" : "var(--fg-2)",
+                  }}
+                >
+                  {option.label}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+
+      {state.status === "ready" && state.data.warnings.length > 0 && (
+        <div role="alert" style={{ margin: "0 14px 12px", padding: "8px 10px", borderRadius: 10, background: "var(--warn-soft)", color: "var(--warn)", fontSize: 12 }}>
+          {state.data.warnings.join(" · ")}
+        </div>
+      )}
+
+      {state.status === "loading" && (
+        <div style={{ padding: 24, color: "var(--fg-3)", fontSize: 13, textAlign: "center" }}>감시 목록을 불러오는 중…</div>
+      )}
+
+      {state.status === "error" && (
+        <div role="alert" style={{ padding: 16, color: "var(--danger)", fontSize: 13 }}>
+          감시 목록을 불러오지 못했습니다. {state.message}
+        </div>
+      )}
+
+      {state.status === "ready" && rows.length === 0 && (
+        <div style={{ padding: 24, color: "var(--fg-3)", fontSize: 13, textAlign: "center" }}>
+          {state.data.empty_reason ?? "활성화된 감시 항목이 없습니다."}
+        </div>
+      )}
+
+      {state.status === "ready" && rows.length > 0 && (
+        <div style={{ overflowX: "auto" }}>
+          <table style={{ width: "100%", borderCollapse: "collapse", minWidth: compact ? 0 : 860 }}>
+            <thead>
+              <tr style={{ color: "var(--fg-3)", fontSize: 11, textAlign: "left" }}>
+                <th style={{ padding: "8px 14px", borderTop: "1px solid var(--divider)", borderBottom: "1px solid var(--divider)" }}>상태</th>
+                <th style={{ padding: "8px 14px", borderTop: "1px solid var(--divider)", borderBottom: "1px solid var(--divider)" }}>종목</th>
+                <th style={{ padding: "8px 14px", borderTop: "1px solid var(--divider)", borderBottom: "1px solid var(--divider)" }}>감시 조건</th>
+                <th style={{ padding: "8px 14px", borderTop: "1px solid var(--divider)", borderBottom: "1px solid var(--divider)", textAlign: "right" }}>현재가</th>
+                {!compact && <th style={{ padding: "8px 14px", borderTop: "1px solid var(--divider)", borderBottom: "1px solid var(--divider)" }}>인텐트 / 액션</th>}
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((row) => {
+                const targetMarket = row.market;
+                const href = stockDetailPath(targetMarket, row.symbol);
+                const dispName = row.symbol_name && row.symbol_name !== row.symbol ? row.symbol_name : row.symbol;
+                
+                const symbolBlock = (
+                  <>
+                    <div style={{ fontSize: 13, fontWeight: 800 }}>{dispName}</div>
+                    <div style={{ marginTop: 2, fontSize: 11, color: "var(--fg-3)" }}>
+                      {row.symbol} · {MARKET_LABEL[row.market]}
+                    </div>
+                  </>
+                );
+
+                return (
+                  <tr key={row.alert_uuid}>
+                    <td style={{ padding: "10px 14px", borderBottom: "1px solid var(--divider)" }}>
+                      <div style={{ display: "flex", gap: 6, flexWrap: "wrap", alignItems: "center" }}>
+                        <Pill tone={WATCH_STATUS_TONES[row.status] ?? "paper"} size="sm">
+                          {WATCH_STATUS_LABELS[row.status] ?? row.status}
+                        </Pill>
+                        {row.near_expiry && (
+                          <Pill tone="warn" size="sm">임박</Pill>
+                        )}
+                        {row.status === "active" && row.proximity_band && (
+                          <Pill tone={PROXIMITY_BAND_TONES[row.proximity_band] ?? "paper"} size="sm">
+                            {PROXIMITY_BAND_LABELS[row.proximity_band] ?? row.proximity_band}
+                          </Pill>
+                        )}
+                      </div>
+                      <div style={{ marginTop: 3, fontSize: 11, color: "var(--fg-3)" }}>
+                        만료: {formatDateTime(row.valid_until)}
+                      </div>
+                    </td>
+                    <td style={{ padding: "10px 14px", borderBottom: "1px solid var(--divider)" }}>
+                      {href ? (
+                        <Link to={href} style={{ color: "inherit", textDecoration: "none" }}>
+                          {symbolBlock}
+                        </Link>
+                      ) : (
+                        symbolBlock
+                      )}
+                    </td>
+                    <td style={{ padding: "10px 14px", borderBottom: "1px solid var(--divider)", fontSize: 13 }}>
+                      <div>{formatCondition(row)}</div>
+                      {!compact && row.rationale && (
+                        <div style={{ marginTop: 3, fontSize: 11, color: "var(--fg-3)", maxWidth: 300, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                          {row.rationale}
+                        </div>
+                      )}
+                    </td>
+                    <td style={{ padding: "10px 14px", borderBottom: "1px solid var(--divider)", fontSize: 13, textAlign: "right", fontFeatureSettings: '"tnum"' }}>
+                      {row.current_price ? (
+                        <span style={{ fontWeight: 600 }}>{formatMoney(row.current_price, row.market)}</span>
+                      ) : (
+                        <span style={{ color: "var(--fg-3)" }}>—</span>
+                      )}
+                    </td>
+                    {!compact && (
+                      <td style={{ padding: "10px 14px", borderBottom: "1px solid var(--divider)" }}>
+                        <div style={{ display: "flex", gap: 4, flexWrap: "wrap" }}>
+                          <Pill tone="paper" size="sm">{row.intent}</Pill>
+                          <Pill tone="paper" size="sm">{row.action_mode}</Pill>
+                        </div>
+                        {row.last_event && (
+                          <div style={{ marginTop: 4, fontSize: 11, color: "var(--fg-3)" }}>
+                            발화: {formatDateTime(row.last_event.created_at)} ({row.last_event.outcome})
+                          </div>
+                        )}
+                      </td>
+                    )}
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+          <div style={{ padding: "8px 14px", fontSize: 11, color: "var(--fg-3)" }}>
+            총 {rawRows.length.toLocaleString("ko-KR")}건{compact && rawRows.length > 8 && " (최근 8건 표시)"}
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/frontend/invest/src/components/my/portfolioTabs.ts
+++ b/frontend/invest/src/components/my/portfolioTabs.ts
@@ -1,6 +1,6 @@
 import { useSearchParams } from "react-router-dom";
 
-export type PortfolioTab = "holdings" | "signals" | "sellHistory" | "buyHistory" | "currentOrders";
+export type PortfolioTab = "holdings" | "signals" | "sellHistory" | "buyHistory" | "currentOrders" | "watchAlerts";
 
 export const PORTFOLIO_TABS: { key: PortfolioTab; label: string }[] = [
   { key: "holdings", label: "보유 현황" },
@@ -8,10 +8,11 @@ export const PORTFOLIO_TABS: { key: PortfolioTab; label: string }[] = [
   { key: "sellHistory", label: "매도 이력" },
   { key: "buyHistory", label: "매수 이력" },
   { key: "currentOrders", label: "현재 주문" },
+  { key: "watchAlerts", label: "감시" },
 ];
 
 function parsePortfolioTab(value: string | null): PortfolioTab {
-  return value === "signals" || value === "sellHistory" || value === "buyHistory" || value === "currentOrders"
+  return value === "signals" || value === "sellHistory" || value === "buyHistory" || value === "currentOrders" || value === "watchAlerts"
     ? value
     : "holdings";
 }

--- a/frontend/invest/src/pages/desktop/DesktopPortfolioPage.tsx
+++ b/frontend/invest/src/pages/desktop/DesktopPortfolioPage.tsx
@@ -16,6 +16,7 @@ import { BuyHistoryPanel } from "../../components/my/BuyHistoryPanel";
 import { PORTFOLIO_TABS, usePortfolioTabSearchParam, type PortfolioTab } from "../../components/my/portfolioTabs";
 import { SignalsPanel } from "../../components/signals/SignalsPanel";
 import { CurrentOrdersPanel } from "../../components/my/CurrentOrdersPanel";
+import { WatchAlertsPanel } from "../../components/my/WatchAlertsPanel";
 import { MobilePortfolioPage } from "../mobile/MobilePortfolioPage";
 import type { AssetCategoryKey } from "../../types/filters";
 import type { AccountSource, HomeSummary } from "../../types/invest";
@@ -29,6 +30,7 @@ function portfolioTitle(tab: PortfolioTab): string {
   if (tab === "holdings") return "통합 보유 현황";
   if (tab === "signals") return "내 투자 시그널";
   if (tab === "currentOrders") return "현재 주문";
+  if (tab === "watchAlerts") return "감시";
   if (tab === "buyHistory") return "매수 이력";
   return "매도 이력";
 }
@@ -37,6 +39,7 @@ function portfolioDescription(tab: PortfolioTab): string {
   if (tab === "holdings") return "KIS, Toss/manual, 모의/수동 계좌를 한 화면에서 비교하고 종목별 출처를 확인합니다.";
   if (tab === "signals") return "보유·관심 종목과 시장별 AI 분석 시그널을 내 투자 화면에서 함께 확인합니다.";
   if (tab === "currentOrders") return "KIS/Toss/Upbit 실계좌의 현재 미체결·대기 주문을 읽기 전용으로 확인합니다.";
+  if (tab === "watchAlerts") return "AI가 포착한 감시 대상과 실시간 조건 및 근접도를 확인합니다.";
   if (tab === "buyHistory") return "KIS/Upbit 체결 보정 ledger 기준 최근 매수 체결을 별도 화면에서 확인합니다.";
   return "KIS/Upbit 체결 보정 ledger 기준 최근 매도 체결을 별도 화면에서 확인합니다.";
 }
@@ -152,6 +155,8 @@ export function DesktopPortfolioPage() {
                 <CurrentOrdersPanel />
               ) : activeTab === "buyHistory" ? (
                 <BuyHistoryPanel />
+              ) : activeTab === "watchAlerts" ? (
+                <WatchAlertsPanel />
               ) : (
                 <SellHistoryPanel />
               )}

--- a/frontend/invest/src/pages/mobile/MobilePortfolioPage.tsx
+++ b/frontend/invest/src/pages/mobile/MobilePortfolioPage.tsx
@@ -11,6 +11,7 @@ import { PL, Pill } from "../../ds";
 import { SellHistoryPanel } from "../../components/my/SellHistoryPanel";
 import { BuyHistoryPanel } from "../../components/my/BuyHistoryPanel";
 import { CurrentOrdersPanel } from "../../components/my/CurrentOrdersPanel";
+import { WatchAlertsPanel } from "../../components/my/WatchAlertsPanel";
 import { PORTFOLIO_TABS, usePortfolioTabSearchParam, type PortfolioTab } from "../../components/my/portfolioTabs";
 import { SignalsPanel } from "../../components/signals/SignalsPanel";
 import type { AccountSource, GroupedHolding, HomeSummary, PriceState } from "../../types/invest";
@@ -320,6 +321,10 @@ export function MobilePortfolioPage() {
           ) : activeTab === "buyHistory" ? (
             <section style={{ padding: "0 16px" }}>
               <BuyHistoryPanel compact />
+            </section>
+          ) : activeTab === "watchAlerts" ? (
+            <section style={{ padding: "0 16px" }}>
+              <WatchAlertsPanel compact />
             </section>
           ) : (
             <section style={{ padding: "0 16px" }}>

--- a/frontend/invest/src/types/watches.ts
+++ b/frontend/invest/src/types/watches.ts
@@ -1,0 +1,48 @@
+export type WatchMarket = "all" | "kr" | "us" | "crypto";
+export type WatchRowMarket = "kr" | "us" | "crypto";
+export type WatchStatus = "all" | "active" | "triggered" | "expired" | "canceled";
+export type WatchAlertStatus = "active" | "triggered" | "expired" | "canceled";
+export type WatchProximityBand = "hit" | "within_0_5_pct" | "within_1_pct" | "outside";
+export type WatchDataState = "ok" | "degraded" | "unavailable";
+
+export interface WatchEventSummary {
+  event_uuid: string;
+  outcome: string;
+  current_value: string | null;
+  created_at: string;
+}
+
+export interface WatchAlertRow {
+  alert_uuid: string;
+  source_report_uuid: string;
+  market: WatchRowMarket;
+  symbol: string;
+  symbol_name: string | null;
+  target_kind: string;
+  metric: string;
+  operator: "above" | "below" | "between";
+  threshold: string;
+  threshold_high: string | null;
+  status: WatchAlertStatus;
+  valid_until: string;
+  intent: string;
+  action_mode: string;
+  rationale: string;
+  trigger_checklist: any[];
+  max_action: Record<string, any>;
+  current_price: string | null;
+  proximity_band: WatchProximityBand | null;
+  last_event: WatchEventSummary | null;
+  near_expiry: boolean;
+}
+
+export interface WatchesResponse {
+  market: WatchMarket;
+  status: WatchStatus;
+  count: number;
+  data_state: WatchDataState;
+  as_of: string;
+  items: WatchAlertRow[];
+  warnings: string[];
+  empty_reason: string | null;
+}

--- a/tests/routers/test_invest_watches_router.py
+++ b/tests/routers/test_invest_watches_router.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import datetime as dt
+from types import SimpleNamespace
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.schemas.invest_watches import WatchesResponse
+
+
+class _StubWatchPanelService:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str]] = []
+
+    async def list_watches(
+        self,
+        *,
+        market: str = "all",
+        status: str = "all",
+    ) -> WatchesResponse:
+        self.calls.append((market, status))
+        return WatchesResponse(
+            market=market,  # type: ignore[arg-type]
+            status=status,  # type: ignore[arg-type]
+            count=0,
+            data_state="ok",
+            as_of=dt.datetime(2026, 6, 17, 0, 0, tzinfo=dt.UTC),
+            items=[],
+            warnings=[],
+            empty_reason="No watch alerts found.",
+        )
+
+
+def _make_client(service: _StubWatchPanelService) -> TestClient:
+    from app.routers import invest_watches
+    from app.routers.dependencies import get_authenticated_user
+
+    app = FastAPI()
+    app.include_router(invest_watches.router)
+    app.dependency_overrides[get_authenticated_user] = lambda: SimpleNamespace(id=1)
+    app.dependency_overrides[invest_watches.get_watch_panel_service] = lambda: service
+    return TestClient(app)
+
+
+@pytest.mark.unit
+def test_watches_endpoint_defaults_to_all() -> None:
+    service = _StubWatchPanelService()
+    client = _make_client(service)
+
+    response = client.get("/trading/api/invest/watches")
+
+    assert response.status_code == 200
+    assert response.json()["market"] == "all"
+    assert response.json()["status"] == "all"
+    assert service.calls == [("all", "all")]
+
+
+@pytest.mark.unit
+def test_watches_endpoint_accepts_filters() -> None:
+    service = _StubWatchPanelService()
+    client = _make_client(service)
+
+    response = client.get("/trading/api/invest/watches?market=crypto&status=active")
+
+    assert response.status_code == 200
+    assert response.json()["market"] == "crypto"
+    assert response.json()["status"] == "active"
+    assert service.calls == [("crypto", "active")]
+
+
+@pytest.mark.unit
+def test_watches_endpoint_rejects_unknown_filters() -> None:
+    service = _StubWatchPanelService()
+    client = _make_client(service)
+
+    response = client.get("/trading/api/invest/watches?market=paper")
+    assert response.status_code == 422
+
+    response = client.get("/trading/api/invest/watches?status=done")
+    assert response.status_code == 422
+
+
+@pytest.mark.unit
+def test_watches_default_service_receives_db_dependency(monkeypatch) -> None:
+    from app.core.db import get_db
+    from app.routers import invest_watches
+    from app.routers.dependencies import get_authenticated_user
+
+    captured = {}
+
+    class _Service:
+        def __init__(self, *, db):
+            captured["db"] = db
+
+        async def list_watches(
+            self,
+            *,
+            market: str = "all",
+            status: str = "all",
+        ) -> WatchesResponse:
+            return WatchesResponse(
+                market=market,  # type: ignore[arg-type]
+                status=status,  # type: ignore[arg-type]
+                count=0,
+                data_state="ok",
+                as_of=dt.datetime(2026, 6, 17, 0, 0, tzinfo=dt.UTC),
+                items=[],
+                warnings=[],
+                empty_reason="No watch alerts found.",
+            )
+
+    monkeypatch.setattr(invest_watches, "WatchPanelService", _Service)
+
+    app = FastAPI()
+    app.include_router(invest_watches.router)
+    app.dependency_overrides[get_authenticated_user] = lambda: SimpleNamespace(id=1)
+    app.dependency_overrides[get_db] = lambda: "db-session"
+
+    response = TestClient(app).get("/trading/api/invest/watches")
+
+    assert response.status_code == 200
+    assert captured["db"] == "db-session"

--- a/tests/services/invest_view_model/test_watch_panel_service.py
+++ b/tests/services/invest_view_model/test_watch_panel_service.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+import datetime as dt
+import uuid
+from decimal import Decimal
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.investment_reports import InvestmentWatchAlert, InvestmentWatchEvent
+from app.models.market_quote_snapshot import MarketQuoteSnapshot
+from app.services.invest_view_model.watch_panel_service import WatchPanelService
+from tests._investment_reports_helpers import session  # noqa: F401
+
+
+@pytest.mark.asyncio
+async def test_watch_panel_service_list_watches(session: AsyncSession) -> None:  # noqa: F811
+    # Delete from market_quote_snapshots (which is not in the reports helper cleanup)
+    # We do NOT commit; the rollback at teardown will restore previous state.
+    await session.execute(text("DELETE FROM market_quote_snapshots"))
+    await session.flush()
+
+    now = dt.datetime(2026, 6, 17, 12, 0, tzinfo=dt.UTC)
+
+    # 1. Insert alert
+    alert1 = InvestmentWatchAlert(
+        alert_uuid=uuid.uuid4(),
+        idempotency_key="key-1",
+        source_report_uuid=uuid.uuid4(),
+        source_item_uuid=uuid.uuid4(),
+        market="kr",
+        target_kind="asset",
+        symbol="005930",
+        metric="price_below",
+        operator="below",
+        threshold=Decimal("70000"),
+        threshold_key="70000",
+        intent="buy_review",
+        action_mode="notify_only",
+        rationale="test rationale",
+        valid_until=now + dt.timedelta(days=1),  # near_expiry will be True
+        status="active",
+    )
+    session.add(alert1)
+
+    alert2 = InvestmentWatchAlert(
+        alert_uuid=uuid.uuid4(),
+        idempotency_key="key-2",
+        source_report_uuid=uuid.uuid4(),
+        source_item_uuid=uuid.uuid4(),
+        market="us",
+        target_kind="asset",
+        symbol="AAPL",
+        metric="price_above",
+        operator="above",
+        threshold=Decimal("200"),
+        threshold_key="200",
+        intent="sell_review",
+        action_mode="notify_only",
+        rationale="test rationale 2",
+        valid_until=now + dt.timedelta(days=5),  # near_expiry will be False
+        status="active",
+    )
+    session.add(alert2)
+
+    # Triggered alert with event
+    alert3 = InvestmentWatchAlert(
+        alert_uuid=uuid.uuid4(),
+        idempotency_key="key-3",
+        source_report_uuid=uuid.uuid4(),
+        source_item_uuid=uuid.uuid4(),
+        market="crypto",
+        target_kind="asset",
+        symbol="BTC",
+        metric="price_below",
+        operator="below",
+        threshold=Decimal("60000"),
+        threshold_key="60000",
+        intent="buy_review",
+        action_mode="notify_only",
+        rationale="test rationale 3",
+        valid_until=now - dt.timedelta(days=1),
+        status="triggered",
+    )
+    session.add(alert3)
+    await session.flush()
+    await session.refresh(alert3)
+
+    event = InvestmentWatchEvent(
+        event_uuid=uuid.uuid4(),
+        idempotency_key="event-key-1",
+        alert_id=alert3.id,
+        source_report_uuid=alert3.source_report_uuid,
+        source_item_uuid=alert3.source_item_uuid,
+        market="crypto",
+        target_kind="asset",
+        symbol="BTC",
+        metric="price_below",
+        operator="below",
+        threshold=Decimal("60000"),
+        threshold_key="60000",
+        intent="buy_review",
+        action_mode="notify_only",
+        current_value=Decimal("59000"),
+        outcome="notified",
+        correlation_id="corr-1",
+        kst_date="2026-06-17",
+        created_at=now,
+    )
+    session.add(event)
+
+    # 2. Insert quote snapshots
+    # Snapshot for 005930
+    snapshot1 = MarketQuoteSnapshot(
+        market="kr",
+        symbol="005930",
+        source="naver_finance",
+        snapshot_at=now - dt.timedelta(minutes=5),
+        price=Decimal("69800"),
+    )
+    session.add(snapshot1)
+    await session.flush()
+
+    service = WatchPanelService(db=session, clock=now)
+
+    # Test list all
+    resp = await service.list_watches(market="all", status="all")
+    assert resp.count == 3
+    assert resp.data_state == "degraded"  # AAPL has no snapshot price
+    assert len(resp.warnings) == 1
+
+    # Check alert1 fields (kr, 005930)
+    row1 = next(item for item in resp.items if item.symbol == "005930")
+    assert row1.near_expiry is True
+    assert row1.current_price == Decimal("69800")
+    assert row1.proximity_band == "hit"  # 69800 <= 70000 for price_below
+    assert row1.last_event is None
+
+    # Check alert2 fields (us, AAPL)
+    row2 = next(item for item in resp.items if item.symbol == "AAPL")
+    assert row2.near_expiry is False
+    assert row2.current_price is None
+    assert row2.proximity_band is None
+
+    # Check alert3 fields (crypto, BTC)
+    row3 = next(item for item in resp.items if item.symbol == "BTC")
+    assert row3.status == "triggered"
+    assert row3.last_event is not None
+    assert row3.last_event.outcome == "notified"
+    assert row3.last_event.current_value == Decimal("59000")
+
+    # Test filtering
+    resp_kr = await service.list_watches(market="kr", status="active")
+    assert resp_kr.count == 1
+    assert resp_kr.items[0].symbol == "005930"


### PR DESCRIPTION
## Summary

`/invest/my`에 **감시(watchAlerts)** 탭 추가. 활성 트리거 워치(`InvestmentWatchAlert`)를 한 화면에서 조회. 종목 클릭 시 상세 이동. 읽기 전용 엔드포인트 `GET /trading/api/invest/watches`를 foundation으로 추가 (후속 ROB-592 종목 상세 per-symbol 카드가 재사용).

Closes [ROB-591](https://linear.app/mgh3326/issue/ROB-591).

## 결정사항 (사용자 확정)

- **status 노출**: 전체 (active/triggered/expired/canceled)
- **근접도 계산**: price_above/price_below metric만, 외 metric은 null
- **현재가 소스**: `market_quote_snapshots` DB 스냅샷 + data_state 신선도 표시

## Backend

- **`app/routers/invest_watches.py`** (신규): `GET /trading/api/invest/watches` with `market` (all/kr/us/crypto) + `status` (all/active/triggered/expired/canceled) 쿼리파라미터. `invest_open_orders.py` 템플릿.
- **`app/services/invest_view_model/watch_panel_service.py`** (신규): `WatchPanelService.list_watches()` — `list_alerts` 호출 후 enrich:
  - symbol_name (fail-open, `get_kr/us_names_by_symbols` + `get_upbit_market_display_names`)
  - current_price + proximity_band (price metric만, `compute_price_proximity` 재사용)
  - last_event (non-active 행, `InvestmentWatchEvent` 최신 1건)
  - near_expiry (active, valid_until ≤ 2일)
  - data_state (ok/degraded/unavailable, 스냅샷 해상도 기준)
- **`app/schemas/invest_watches.py`** (신규): `WatchesResponse` / `WatchAlertRow` / `WatchEventSummary`. `ConfigDict(extra="forbid")`, Decimal field_serializer, invest 컨벤션 준수.
- **`app/services/investment_reports/repository.py`** (수정): `list_active_alerts` → `list_alerts` 일반화 (status 파라미터 추가). 기존 `list_active_alerts`는 위임 보존 → 하위 호환성 완벽 (522 regression 통과).
- **`app/main.py`**: 라우터 등록.

## Frontend

- **`frontend/invest/src/components/my/portfolioTabs.ts`** (수정): `watchAlerts` 탭 추가 (union + array + parser 3곳).
- **`frontend/invest/src/components/my/WatchAlertsPanel.tsx`** (신규): market/status 필터, 근접도 pill, status pill, near_expiry 뱃지, 종목 링크, last_event 표시. `CurrentOrdersPanel` 템플릿.
- **`frontend/invest/src/api/watches.ts`** + **`types/watches.ts`** (신규): fetch 클라이언트 + 타입.
- **`pages/desktop/DesktopPortfolioPage.tsx`** + **`pages/mobile/MobilePortfolioPage.tsx`** (수정): watchAlerts 케이스 배선 (title/description/렌더).

## Tests

- `tests/routers/test_invest_watches_router.py`: 4 cases (default, filters, 422 unknown, db 의존성 주입)
- `tests/services/invest_view_model/test_watch_panel_service.py`: 통합 테스트 — active/triggered/near_expiry/proximity/data_state 3개 시나리오

## 검증

- ✅ `make lint` (ruff + ty) 통과
- ✅ 백엔드 타겟 테스트 5/5 통과 (merge 후 재확인)
- ✅ 회귀 522/522 통과 (`list_active_alerts` caller 5곳 영향 无)
- ✅ `npm run typecheck` 통과
- ✅ frontend 테스트: ROB-591 무관 (실패 5개는 캘린더/coverage 기존 실패 — `git stash`로 검증)

## Migration

없음. `investment_watch_alerts` / `investment_watch_events` / `market_quote_snapshots` 테이블 전부 기존.

## Notes

- 단일 운영자 모델 (`InvestmentWatchAlert`에 user_id 없음) — 멀티유저 도입 시 스코핑 추가 필요.
- `WatchPanelService.clock` 타입이 `datetime | None` (CurrentOrdersService의 `Callable[[], datetime]`과 상이). 동작은 정확, 테스트 통과. 취향 차이.
- `WatchAlertsPanel` 프런트 테스트 미작성 (백엔드 테스트는 충실). `BuyHistoryPanel.test.tsx` 등 일관성 차원에서 후속 추가 권장.

## Review lane

`keep_on_gpt54` + `candidate_for_sonnet` (data_state 설계 판단). 고위험 변경 아님 (읽기 전용, 마이그레이션 없음, 하위 호환 보존).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new watch alerts endpoint with market and status filtering capabilities.
  * Introduced a Watch Alerts Panel on portfolio pages (desktop and mobile) featuring real-time price proximity indicators, alert status badges, and near-expiry warnings for monitored investment targets.

* **Tests**
  * Added comprehensive test coverage for watch alerts router and service functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->