### PR TITLE
fix(ROB-596): KIS live 매수 precheck double-count 제거 — 이미 net인 브로커 orderable에서 미체결 매수 재차감

### DIFF
--- a/app/mcp_server/tooling/portfolio_cash.py
+++ b/app/mcp_server/tooling/portfolio_cash.py
@@ -47,50 +47,6 @@ async def _call_kis(method: Any, *args: Any, is_mock: bool, **kwargs: Any) -> An
     return await method(*args, **kwargs)
 
 
-async def _get_kis_domestic_pending_buy_amount(
-    kis: KISClient,
-    *,
-    is_mock: bool = False,
-) -> float:
-    total = 0.0
-    open_orders = await _call_kis(kis.inquire_korea_orders, is_mock=is_mock)
-    for order in open_orders:
-        if str(order.get("sll_buy_dvsn_cd", "")).strip() != "02":
-            continue
-        price = to_float(order.get("ord_unpr"), default=0.0)
-        qty = to_float(
-            order.get("nccs_qty") or order.get("ord_qty"),
-            default=0.0,
-        )
-        total += price * qty
-    return total
-
-
-async def _get_kis_overseas_pending_buy_amount_usd(
-    kis: KISClient,
-    *,
-    is_mock: bool = False,
-) -> float:
-    total = 0.0
-    # KIS documents NASD as a US-wide open-order lookup. Querying NYSE/AMEX as
-    # well can double-count the same locked cash when orders are mirrored there.
-    open_orders = await _call_kis(
-        kis.inquire_overseas_orders,
-        "NASD",
-        is_mock=is_mock,
-    )
-    for order in open_orders:
-        if str(order.get("sll_buy_dvsn_cd", "")).strip() != "02":
-            continue
-        price = to_float(order.get("ft_ord_unpr3"), default=0.0)
-        qty = to_float(
-            order.get("nccs_qty") or order.get("ft_ord_qty"),
-            default=0.0,
-        )
-        total += price * qty
-    return total
-
-
 def is_us_nation_name(value: Any) -> bool:
     normalized = str(value or "").strip().casefold()
     return normalized in {
@@ -269,31 +225,12 @@ async def get_cash_balance_impl(
                     )
                     dncl_amt = float(domestic_cash.get("balance", 0) or 0)
                     raw_orderable = float(domestic_cash.get("orderable", 0) or 0)
+                # ROB-596: 브로커 주문가능금액(stck_cash100_max_ord_psbl_amt)은 이미 접수된
+                # 미체결 매수를 netting한 실시간 값이다. 여기서 inquire_korea_orders 의
+                # 미체결 매수를 또 차감하면 double-count가 되어, 미정산 매도대금으로
+                # settled < orderable 인 상황에서 브로커가 받아줄 회전매수를 0으로 막는다.
+                # 브로커의 권위 있는 실시간 주문가능 값을 그대로 신뢰한다.
                 orderable = raw_orderable
-
-                try:
-                    pending_buy_amount = await _get_kis_domestic_pending_buy_amount(
-                        kis,
-                        is_mock=is_mock,
-                    )
-                    orderable = max(0.0, raw_orderable - pending_buy_amount)
-                except Exception as exc:
-                    msg = str(exc)
-                    is_mock_unsupported = is_mock and "mock" in msg.lower()
-                    logger.warning(
-                        "KR pending order deduction failed, using raw orderable: %s",
-                        msg,
-                    )
-                    if is_mock_unsupported:
-                        errors.append(
-                            {
-                                "source": "kis",
-                                "market": "kr",
-                                "error": "mock_unsupported: KIS domestic pending-orders "
-                                "inquiry is not available in mock mode",
-                                "mock_unsupported": True,
-                            }
-                        )
 
                 accounts.append(
                     {
@@ -341,19 +278,9 @@ async def get_cash_balance_impl(
                         default=0.0,
                     )
                     raw_orderable = extract_usd_orderable_from_row(usd_margin)
+                    # ROB-596: 해외 주문가능금액(frcr_gnrl_ord_psbl_amt)도 이미 net 이므로
+                    # 미체결 매수를 추가 차감하지 않는다 (KR 과 동일 double-count 방지).
                     orderable = raw_orderable
-
-                    try:
-                        pending_usd = await _get_kis_overseas_pending_buy_amount_usd(
-                            kis,
-                            is_mock=is_mock,
-                        )
-                        orderable = max(0.0, raw_orderable - pending_usd)
-                    except Exception as exc:
-                        logger.warning(
-                            "USD pending order deduction failed, using raw orderable: %s",
-                            exc,
-                        )
 
                     accounts.append(
                         {

--- a/scripts/rob596_orderable_diagnostic.py
+++ b/scripts/rob596_orderable_diagnostic.py
@@ -1,0 +1,305 @@
+#!/usr/bin/env python3
+"""ROB-596 — KIS 국내 live 주문가능(orderable) 진단 (READ-ONLY).
+
+증상: `kis_live_place_order`(KR 매수) 사전 잔고체크가 브로커가 받아줄 매수를
+"Insufficient KRW balance: 0 KRW < N KRW" 로 거부한다. 가설: `get_cash_balance_impl`
+이 이미 net 인 브로커 주문가능금액(stck_cash100_max_ord_psbl_amt)에서 미체결 매수
+(`_get_kis_domestic_pending_buy_amount`)를 한 번 더 빼는 double-count.
+
+이 스크립트는 **읽기 전용**이다. 주문/정정/취소 등 어떤 mutation 도 하지 않는다.
+운영자가 **미체결 매수 주문이 걸려 있는 순간**(예: 매수 래더 거치 직후) 1회 실행하면,
+프로덕션과 동일 경로로 다음을 한 화면에 보여 준다:
+
+  1) inquire_integrated_margin 의 orderable 후보 필드 전부 + 어느 필드가 선택됐는지
+     (= raw_orderable). 한투 앱의 "주문가능" 과 비교해 net 여부 확정.
+  2) inquire_korea_orders 의 미체결 매수 row 별 (ord_unpr, nccs_qty, ord_qty) 와
+     nccs_qty=0→ord_qty 폴백으로 인한 과대합산 여부.
+  3) 미체결 매수 합산 = pending_buy_amount (ROB-596 이전 double-count 차감분, 이제 비차감).
+  4) 실제 MCP orderable(수정 후) = get_cash_balance_impl.orderable ← precheck 가 보는 값.
+     ROB-596 수정으로 pending 을 빼지 않으므로 raw_orderable 과 같아야 한다.
+     비교용으로 구(舊) 공식 max(0, raw - pending) 도 함께 출력한다.
+  5) get_available_capital_impl 의 orderable (동일 소스인지 교차확인).
+
+해석 가이드:
+  * raw_orderable ≈ 한투 앱 주문가능  AND  (raw - pending) << 앱 주문가능
+        → double-count 확정 (브로커 필드가 이미 net).
+  * raw_orderable << 한투 앱 주문가능
+        → 선택된 필드가 미정산 매도대금을 제외한 현금-only 일 가능성 (필드 선택 이슈).
+  * pending_buy_amount ≈ raw_orderable
+        → orderable 가 정확히 0 으로 floor 되는 이유 (관측된 "0 KRW" 설명).
+  * 미체결 매수 row 중 nccs_qty 가 0/빈값인데 ord_qty>0 인 게 있으면
+        → 완전체결분이 still-pending 으로 과대합산 (latent 폴백 버그).
+
+Exit codes:
+    0  - 조회 성공
+    1  - 예기치 못한 예외
+    4  - KIS 자격증명 미설정
+
+사용법:
+    uv run python -m scripts.rob596_orderable_diagnostic
+    uv run python -m scripts.rob596_orderable_diagnostic --json   # 기계가독 JSON 만
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from typing import Any
+
+from app.core.config import settings
+from app.mcp_server.tooling.portfolio_cash import (
+    get_available_capital_impl,
+    get_cash_balance_impl,
+)
+from app.services.brokers.kis import (
+    KISClient,
+    extract_domestic_cash_summary_from_integrated_margin,
+)
+
+# extract_domestic_cash_summary_from_integrated_margin 의 orderable 후보 우선순위
+# (app/services/brokers/kis/account.py:63-72 와 동일 순서로 유지).
+_ORDERABLE_CANDIDATES = (
+    "stck_cash100_max_ord_psbl_amt",
+    "stck_itgr_cash100_ord_psbl_amt",
+    "stck_cash_ord_psbl_amt",
+    "stck_cash_objt_amt",
+)
+_BALANCE_FIELD = "stck_cash_objt_amt"
+
+
+def _to_float(val: Any, default: float = 0.0) -> float:
+    if val in ("", None):
+        return default
+    try:
+        return float(val)
+    except (ValueError, TypeError):
+        return default
+
+
+def _selected_orderable_field(payload: dict[str, Any]) -> tuple[str | None, float]:
+    """first_usable_positive_float 와 동일 규칙으로 선택 필드/값을 재현."""
+    first_numeric: float | None = None
+    first_numeric_field: str | None = None
+    for field in _ORDERABLE_CANDIDATES:
+        raw = payload.get(field)
+        if raw in ("", None):
+            continue
+        try:
+            parsed = float(raw)
+        except (ValueError, TypeError):
+            continue
+        if first_numeric is None:
+            first_numeric = parsed
+            first_numeric_field = field
+        if parsed > 0:
+            return field, parsed
+    if first_numeric is not None:
+        return first_numeric_field, first_numeric
+    return None, 0.0
+
+
+async def _collect() -> dict[str, Any]:
+    kis = KISClient()  # live (is_mock=False)
+
+    # --- 1) integrated margin: orderable 후보 필드 전부 노출 ---
+    margin_data = await kis.inquire_integrated_margin()
+    raw = margin_data.get("raw")
+    raw_payload = raw if isinstance(raw, dict) else margin_data
+
+    candidate_values: dict[str, dict[str, float | None]] = {}
+    for field in (_BALANCE_FIELD, *_ORDERABLE_CANDIDATES):
+        candidate_values[field] = {
+            "top_level": _to_float(margin_data.get(field), default=None)  # type: ignore[arg-type]
+            if margin_data.get(field) not in ("", None)
+            else None,
+            "raw": _to_float(raw_payload.get(field), default=None)  # type: ignore[arg-type]
+            if raw_payload.get(field) not in ("", None)
+            else None,
+        }
+
+    summary = extract_domestic_cash_summary_from_integrated_margin(margin_data)
+    raw_orderable = float(summary.get("orderable", 0) or 0)
+    balance = float(summary.get("balance", 0) or 0)
+    sel_field_top, _ = _selected_orderable_field(margin_data)
+    sel_field_raw, _ = _selected_orderable_field(raw_payload)
+    selected_field = sel_field_top or sel_field_raw
+
+    # --- 2) 미체결 매수 row 들 (ord_unpr / nccs_qty / ord_qty) ---
+    open_orders = await kis.inquire_korea_orders()
+    open_buys: list[dict[str, Any]] = []
+    for order in open_orders:
+        if str(order.get("sll_buy_dvsn_cd", "")).strip() != "02":
+            continue
+        nccs = order.get("nccs_qty")
+        ord_qty = order.get("ord_qty")
+        price = _to_float(order.get("ord_unpr"))
+        nccs_f = _to_float(nccs)
+        ordq_f = _to_float(ord_qty)
+        # 프로덕션과 동일: nccs_qty or ord_qty
+        used_qty = _to_float(nccs or ord_qty)
+        open_buys.append(
+            {
+                "pdno": order.get("pdno"),
+                "ord_unpr": price,
+                "nccs_qty": nccs_f,
+                "ord_qty": ordq_f,
+                "used_qty(nccs_or_ord)": used_qty,
+                "row_amount": price * used_qty,
+                "fallback_overcount": (nccs in ("", None) or nccs_f == 0.0)
+                and ordq_f > 0,
+            }
+        )
+
+    # --- 3) 미체결 매수 합산 (구 double-count 차감분; ROB-596 이후 비차감) ---
+    pending_buy_amount = sum(r["row_amount"] for r in open_buys)
+
+    # --- 4) 최종 MCP orderable (= precheck 가 보는 값) ---
+    computed_orderable = max(0.0, raw_orderable - pending_buy_amount)
+    cash_balance = await get_cash_balance_impl(account="kis_domestic")
+    kis_dom = next(
+        (
+            a
+            for a in cash_balance.get("accounts", [])
+            if a.get("account") == "kis_domestic"
+        ),
+        None,
+    )
+
+    # --- 5) 계획 도구 교차확인 ---
+    capital = await get_available_capital_impl(account="kis_domestic")
+
+    return {
+        "integrated_margin": {
+            "selected_orderable_field": selected_field,
+            "raw_orderable": raw_orderable,
+            "balance(settled, stck_cash_objt_amt)": balance,
+            "candidate_fields": candidate_values,
+        },
+        "open_buy_orders": {
+            "count": len(open_buys),
+            "rows": open_buys,
+            "any_fallback_overcount": any(r["fallback_overcount"] for r in open_buys),
+        },
+        "pending_buy_amount": pending_buy_amount,
+        "mcp_computed_orderable(max0_raw_minus_pending)": computed_orderable,
+        "get_cash_balance_impl.orderable": (kis_dom or {}).get("orderable"),
+        "get_available_capital_impl.orderable": next(
+            (
+                a.get("orderable")
+                for a in capital.get("accounts", [])
+                if a.get("account") == "kis_domestic"
+            ),
+            None,
+        ),
+        "errors": {
+            "cash_balance": cash_balance.get("errors"),
+            "available_capital": capital.get("errors"),
+        },
+    }
+
+
+def _print_human(d: dict[str, Any]) -> None:
+    im = d["integrated_margin"]
+    raw_orderable = im["raw_orderable"]
+    pending = d["pending_buy_amount"]
+    computed = d["mcp_computed_orderable(max0_raw_minus_pending)"]
+
+    print("=" * 72)
+    print("ROB-596 KIS 국내 live orderable 진단 (READ-ONLY, 주문 없음)")
+    print("=" * 72)
+    print(f"선택된 orderable 필드      : {im['selected_orderable_field']}")
+    print(f"raw_orderable (브로커)     : {raw_orderable:,.0f} KRW")
+    print(
+        f"  settled 예수금           : {im['balance(settled, stck_cash_objt_amt)']:,.0f} KRW"
+    )
+    print("  orderable 후보 필드들:")
+    for field, vals in im["candidate_fields"].items():
+        print(f"    {field:<34} top={vals['top_level']}  raw={vals['raw']}")
+    print("-" * 72)
+    ob = d["open_buy_orders"]
+    print(f"미체결 매수 주문 수        : {ob['count']}")
+    for r in ob["rows"]:
+        flag = "  ⚠ FALLBACK-OVERCOUNT" if r["fallback_overcount"] else ""
+        print(
+            f"    {str(r['pdno']):<8} @{r['ord_unpr']:,.0f} x "
+            f"nccs={r['nccs_qty']:.0f}/ord={r['ord_qty']:.0f} "
+            f"= {r['row_amount']:,.0f}{flag}"
+        )
+    print(f"pending_buy_amount (합산)  : {pending:,.0f} KRW")
+    print("-" * 72)
+    actual = d["get_cash_balance_impl.orderable"]
+    print(
+        f"구 double-count 공식 max(0,raw-pending) : {computed:,.0f} KRW   (ROB-596 이전 precheck 값, 참고)"
+    )
+    print(f"실제 MCP orderable (수정 후)            : {actual}   ← precheck 가 보는 값")
+    print(
+        f"get_available_capital_impl.orderable    : {d['get_available_capital_impl.orderable']}"
+    )
+    print("=" * 72)
+    print("해석:")
+    if ob["count"] == 0:
+        print("  · 미체결 매수가 0건 → 수정 효과(차감 안 함)를 대조할 수 없음.")
+        print("    매수 래더/미체결 매수가 걸린 순간 다시 실행하세요.")
+    else:
+        print(f"  · raw_orderable({raw_orderable:,.0f}) 를 한투 앱 '주문가능' 과 비교:")
+        print(
+            "      ≈ 같으면 → 브로커 필드가 이미 net → pending 재차감은 double-count 였음."
+        )
+        print("      << 앱 → 선택 필드가 미정산 매도대금 제외(현금-only) 가능성.")
+        if isinstance(actual, (int, float)) and raw_orderable > 0:
+            if abs(actual - raw_orderable) < 1.0:
+                print(
+                    f"  · ✅ 수정 확인: 실제 orderable({actual:,.0f}) == raw_orderable "
+                    f"→ pending({pending:,.0f}) 을 차감하지 않음."
+                )
+            else:
+                print(
+                    f"  · ⚠ 실제 orderable({actual:,.0f}) != raw_orderable({raw_orderable:,.0f}) "
+                    "→ 예상과 다름, 조사 필요."
+                )
+        if ob["any_fallback_overcount"]:
+            print(
+                "  · ⚠ nccs_qty=0→ord_qty 폴백 과대합산 row 존재 (완전체결분이 pending 으로 합산됨)."
+            )
+    if d["errors"]["cash_balance"] or d["errors"]["available_capital"]:
+        print(f"  · errors: {json.dumps(d['errors'], ensure_ascii=False)}")
+
+
+async def _run(*, as_json: bool) -> int:
+    data = await _collect()
+    if as_json:
+        print(json.dumps(data, ensure_ascii=False, default=str, indent=2))
+    else:
+        _print_human(data)
+        print()
+        print(json.dumps(data, ensure_ascii=False, default=str, indent=2))
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="ROB-596 KIS 국내 live orderable 진단 (read-only)"
+    )
+    parser.add_argument("--json", action="store_true", help="기계가독 JSON 만 출력")
+    args = parser.parse_args()
+
+    if not getattr(settings, "kis_app_key", None) or not getattr(
+        settings, "kis_app_secret", None
+    ):
+        print(
+            "KIS 자격증명(KIS_APP_KEY/KIS_APP_SECRET)이 설정되지 않았습니다.",
+            file=sys.stderr,
+        )
+        return 4
+
+    try:
+        return asyncio.run(_run(as_json=args.json))
+    except Exception as exc:  # noqa: BLE001
+        print(f"진단 실패: {exc.__class__.__name__}: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_mcp_portfolio_tools.py
+++ b/tests/test_mcp_portfolio_tools.py
@@ -394,82 +394,39 @@ async def test_get_cash_balance_kis_domestic_skips_zero_priority_orderables(
 
 
 @pytest.mark.asyncio
-async def test_get_cash_balance_kis_domestic_deducts_pending_buy_orders(monkeypatch):
-    tools = build_tools()
-
-    class MockKISClient:
-        async def inquire_integrated_margin(self):
-            return {
-                "dnca_tot_amt": "4300000.0",
-                "stck_cash_objt_amt": "4300000.0",
-                "stck_cash_ord_psbl_amt": "4300000.0",
-            }
-
-        async def inquire_korea_orders(self):
-            return [
-                {"sll_buy_dvsn_cd": "02", "ord_unpr": "250000", "nccs_qty": "1"},
-                {"sll_buy_dvsn_cd": "02", "ord_unpr": "800000", "nccs_qty": "1"},
-                {"sll_buy_dvsn_cd": "02", "ord_unpr": "2270000", "nccs_qty": "1"},
-                {"sll_buy_dvsn_cd": "01", "ord_unpr": "999999", "nccs_qty": "9"},
-            ]
-
-        async def inquire_overseas_margin(self):
-            return []
-
-    _patch_runtime_attr(monkeypatch, "KISClient", MockKISClient)
-
-    result = await tools["get_cash_balance"](account="kis_domestic")
-
-    assert result["accounts"][0]["balance"] == pytest.approx(4300000.0)
-    assert result["accounts"][0]["orderable"] == pytest.approx(980000.0)
-
-
-@pytest.mark.asyncio
-async def test_get_cash_balance_kis_domestic_pending_lookup_failure_keeps_raw_orderable(
+async def test_get_cash_balance_kis_domestic_orderable_ignores_pending_buys_rob596(
     monkeypatch,
 ):
+    """ROB-596: 브로커 주문가능금액(stck_cash100_max_ord_psbl_amt)은 이미 접수된
+    미체결 매수를 netting한 실시간 값이다. 로컬에서 미체결 매수를 또 차감하면
+    double-count가 되어, 미정산 매도대금으로 settled < orderable 인 상황에서
+    회전매수를 못 하고 0으로 막힌다(현실 재현). orderable 은 브로커 값 그대로여야 한다."""
     tools = build_tools()
 
     class MockKISClient:
         async def inquire_integrated_margin(self):
             return {
-                "dnca_tot_amt": "4300000.0",
-                "stck_cash_objt_amt": "4300000.0",
-                "stck_cash_ord_psbl_amt": "4300000.0",
+                "stck_cash_objt_amt": "348992.0",  # settled 예수금
+                # 미정산 D+2 매도대금 포함 주문가능 — 브로커가 이미 net 계산한 값
+                "stck_cash100_max_ord_psbl_amt": "2786548.0",
+                "stck_cash_ord_psbl_amt": "348992.0",
             }
 
         async def inquire_korea_orders(self):
-            raise RuntimeError("order inquiry failed")
-
-    _patch_runtime_attr(monkeypatch, "KISClient", MockKISClient)
-
-    result = await tools["get_cash_balance"](account="kis_domestic")
-
-    assert result["accounts"][0]["orderable"] == pytest.approx(4300000.0)
-
-
-@pytest.mark.asyncio
-async def test_get_cash_balance_kis_domestic_clamps_orderable_at_zero(monkeypatch):
-    tools = build_tools()
-
-    class MockKISClient:
-        async def inquire_integrated_margin(self):
-            return {
-                "dnca_tot_amt": "1000000.0",
-                "stck_cash_objt_amt": "1000000.0",
-                "stck_cash_ord_psbl_amt": "1000000.0",
-            }
-
-        async def inquire_korea_orders(self):
+            # 한전 10@40,000 + 15@38,600 = 979,000 미체결 매수.
+            # 브로커는 이 주문을 받을 때 이미 주문가능에서 차감했다.
             return [
-                {"sll_buy_dvsn_cd": "02", "ord_unpr": "600000", "nccs_qty": "2"},
+                {"sll_buy_dvsn_cd": "02", "ord_unpr": "40000", "nccs_qty": "10"},
+                {"sll_buy_dvsn_cd": "02", "ord_unpr": "38600", "nccs_qty": "15"},
             ]
 
     _patch_runtime_attr(monkeypatch, "KISClient", MockKISClient)
 
     result = await tools["get_cash_balance"](account="kis_domestic")
 
-    assert result["accounts"][0]["orderable"] == pytest.approx(0.0)
+    assert result["accounts"][0]["balance"] == pytest.approx(348992.0)
+    # 미체결 매수를 추가 차감하지 않는다 (double-count 금지) — 브로커 주문가능 그대로.
+    assert result["accounts"][0]["orderable"] == pytest.approx(2786548.0)
 
 
 @pytest.mark.asyncio
@@ -675,9 +632,11 @@ async def test_get_cash_balance_uses_new_kis_field_names(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_get_cash_balance_kis_overseas_avoids_duplicate_deduction_from_us_exchanges(
+async def test_get_cash_balance_kis_overseas_orderable_ignores_pending_buys_rob596(
     monkeypatch,
 ):
+    """ROB-596 (US): 해외 주문가능금액(frcr_gnrl_ord_psbl_amt)도 이미 net 이므로
+    미체결 매수를 추가 차감하지 않는다 (KR 과 동일 double-count 방지)."""
     tools = build_tools()
 
     class MockKISClient:
@@ -686,65 +645,22 @@ async def test_get_cash_balance_kis_overseas_avoids_duplicate_deduction_from_us_
                 {
                     "natn_name": "미국",
                     "crcy_cd": "USD",
-                    "frcr_dncl_amt1": "1000.0",
-                    "frcr_gnrl_ord_psbl_amt": "1000.0",
+                    "frcr_dncl_amt1": "5500.0",
+                    "frcr_gnrl_ord_psbl_amt": "5000.0",
                 }
             ]
 
         async def inquire_overseas_orders(self, exchange_code):
-            payload = {
-                "NASD": [
-                    {"sll_buy_dvsn_cd": "02", "ft_ord_unpr3": "100.0", "nccs_qty": "2"},
-                    {"sll_buy_dvsn_cd": "02", "ft_ord_unpr3": "50.0", "nccs_qty": "2"},
-                    {"sll_buy_dvsn_cd": "01", "ft_ord_unpr3": "999.0", "nccs_qty": "9"},
-                ],
-                # KIS NASD query is documented as a US-wide lookup, so these rows
-                # represent duplicates that must not be counted again.
-                "NYSE": [
-                    {"sll_buy_dvsn_cd": "02", "ft_ord_unpr3": "100.0", "nccs_qty": "2"},
-                ],
-                "AMEX": [
-                    {"sll_buy_dvsn_cd": "02", "ft_ord_unpr3": "50.0", "nccs_qty": "2"},
-                ],
-            }
-            return payload[exchange_code]
+            return [
+                {"sll_buy_dvsn_cd": "02", "ft_ord_unpr3": "100.0", "nccs_qty": "5"},
+            ]
 
     _patch_runtime_attr(monkeypatch, "KISClient", MockKISClient)
 
     result = await tools["get_cash_balance"](account="kis_overseas")
 
-    assert result["accounts"][0]["balance"] == pytest.approx(1000.0)
-    assert result["accounts"][0]["orderable"] == pytest.approx(700.0)
-
-
-@pytest.mark.asyncio
-async def test_get_cash_balance_kis_overseas_pending_lookup_failure_keeps_raw_orderable(
-    monkeypatch,
-    caplog,
-):
-    tools = build_tools()
-
-    class MockKISClient:
-        async def inquire_overseas_margin(self):
-            return [
-                {
-                    "natn_name": "미국",
-                    "crcy_cd": "USD",
-                    "frcr_dncl_amt1": "1000.0",
-                    "frcr_gnrl_ord_psbl_amt": "1000.0",
-                }
-            ]
-
-        async def inquire_overseas_orders(self, exchange_code):
-            raise RuntimeError("NASD failed")
-
-    _patch_runtime_attr(monkeypatch, "KISClient", MockKISClient)
-
-    with caplog.at_level("WARNING"):
-        result = await tools["get_cash_balance"](account="kis_overseas")
-
-    assert result["accounts"][0]["orderable"] == pytest.approx(1000.0)
-    assert "USD pending order deduction failed" in caplog.text
+    # 미체결 매수 500 USD 가 있어도 차감하지 않는다.
+    assert result["accounts"][0]["orderable"] == pytest.approx(5000.0)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_portfolio_cash_kis_mock.py
+++ b/tests/test_portfolio_cash_kis_mock.py
@@ -46,7 +46,12 @@ async def test_cash_balance_mock_uses_domestic_cash_not_integrated_margin(monkey
 
 
 @pytest.mark.asyncio
-async def test_cash_balance_mock_pending_buy_tolerates_egw02006(monkeypatch):
+async def test_cash_balance_mock_orderable_is_raw_without_pending_deduction(
+    monkeypatch,
+):
+    """ROB-596: mock KR orderable 는 inquire_domestic_cash_balance 의 raw 값을
+    그대로 쓴다. (과거엔 미체결 매수 차감을 시도했으나 mock 은 TTTC8036R 미지원이라
+    항상 raw 로 폴백했고, double-count 제거로 차감 자체를 하지 않는다.)"""
     fake_kis = MagicMock()
     fake_kis.inquire_domestic_cash_balance = AsyncMock(
         return_value={
@@ -58,8 +63,9 @@ async def test_cash_balance_mock_pending_buy_tolerates_egw02006(monkeypatch):
     fake_kis.inquire_overseas_margin = AsyncMock(
         side_effect=RuntimeError("mock unsupported"),
     )
+    # 더 이상 미체결 매수 조회를 하지 않으므로 호출되면 안 된다.
     fake_kis.inquire_korea_orders = AsyncMock(
-        side_effect=RuntimeError("EGW02006 모의투자 TR 이 아닙니다"),
+        side_effect=AssertionError("inquire_korea_orders must not be called"),
     )
 
     monkeypatch.setattr(
@@ -73,46 +79,6 @@ async def test_cash_balance_mock_pending_buy_tolerates_egw02006(monkeypatch):
 
     result = await portfolio_cash.get_cash_balance_impl(is_mock=True)
 
-    # Pending deduction failed -> orderable falls back to raw orderable
-    # (not zero, not crash).
     accounts = {a["account"]: a for a in result["accounts"]}
     assert accounts["kis_domestic"]["orderable"] == pytest.approx(1000.0)
-
-
-@pytest.mark.asyncio
-async def test_cash_balance_mock_pending_buy_records_mock_unsupported(monkeypatch):
-    fake_kis = MagicMock()
-    fake_kis.inquire_domestic_cash_balance = AsyncMock(
-        return_value={
-            "dnca_tot_amt": 1000.0,
-            "stck_cash_ord_psbl_amt": 1000.0,
-            "raw": {},
-        },
-    )
-    fake_kis.inquire_overseas_margin = AsyncMock(
-        side_effect=RuntimeError("mock unsupported"),
-    )
-    fake_kis.inquire_korea_orders = AsyncMock(
-        side_effect=RuntimeError(
-            "KIS domestic pending-orders inquiry (TTTC8036R) is not "
-            "available in mock mode."
-        ),
-    )
-
-    monkeypatch.setattr(
-        portfolio_cash, "_create_kis_client", lambda *, is_mock: fake_kis
-    )
-    monkeypatch.setattr(
-        portfolio_cash.upbit_service,
-        "fetch_krw_cash_summary",
-        AsyncMock(return_value={"balance": 0.0, "orderable": 0.0}),
-    )
-
-    result = await portfolio_cash.get_cash_balance_impl(is_mock=True)
-
-    assert any(
-        e.get("source") == "kis"
-        and e.get("market") == "kr"
-        and e.get("mock_unsupported") is True
-        for e in result["errors"]
-    ), result["errors"]
+    fake_kis.inquire_korea_orders.assert_not_called()


### PR DESCRIPTION
## 문제 (ROB-596)

`kis_live_place_order`(KR/US 매수) 사전 잔고체크가 **브로커가 받아줄 매수를** `Insufficient KRW balance: 0 KRW < N KRW` 로 거부한다. 2026-06-17 실계좌(kis_live, KR NXT) 재현: 한국전력 979,000 접수 → 직후 현대제철 517,500 거부(약 10분 간격 2회).

## 근본 원인 — double-count (이슈 진단 교정)

`get_cash_balance_impl` 의 live KR/US `orderable` 이 `max(0, raw_orderable − pending_buy_amount)` 였다. 그런데 `raw_orderable`(`stck_cash100_max_ord_psbl_amt` / `frcr_gnrl_ord_psbl_amt`)는 **브로커가 주문 접수 시 이미 cash를 lock한 실시간 net 값**이다. 거기서 `inquire_korea_orders` 의 미체결 매수를 또 빼면 같은 cash를 두 번 차감한다.

**read-only prod 진단으로 확증** (`scripts/rob596_orderable_diagnostic.py`):
- broker 주문가능 = **2,786,548** (미정산 D+2 매도대금 포함; settled 예수금 348,992 와 무관 → 이슈의 "settled cash 사용" 진단은 오진).
- 한전 접수 후 앱 주문가능 1,807,553 (정확히 −979,000) → 필드가 net임을 입증.
- 누적 미체결매수 X에 대해 `MCP orderable = max(0, 2,786,548 − 2X)` → **X ≥ 1,393,274 이면 0으로 floor**. 관측된 "0 KRW"를 정확히 설명.
- `get_available_capital` ↔ 주문툴 "상호모순"도 오진: 둘은 동일 `get_cash_balance_impl` 을 읽으며 2.78M vs 0 은 한전 전/후 **시점차**다.

## 수정

- live KR/US 모두 **`orderable = raw_orderable`** — 브로커의 권위 있는 실시간 net 필드를 그대로 신뢰. live 가 mock 과 일치(mock 은 원래 차감 없이 raw 사용).
- 이 차감에만 쓰이던 죽은 헬퍼 `_get_kis_domestic_pending_buy_amount` / `_get_kis_overseas_pending_buy_amount_usd` 제거 → `nccs_qty or ord_qty` 폴백 과대합산 latent 버그도 함께 소멸.

> 다운사이드 bounded: 설령 어떤 계정 상태에서 필드가 gross여도, precheck가 통과시킨 주문은 **브로커가 거부**(비파괴 — 체결/저널 없음)하므로 잘못된 체결로 이어지지 않는다.

## 테스트

- **회귀 2개 추가** (KR=2,786,548 / US=5,000): 미정산 매도대금으로 `settled < orderable` + 미체결 매수가 있어도 `orderable == raw`. RED 확증 `1,807,548 = 2,786,548 − 979,000`, `4,500 = 5,000 − 500`.
- **구 deduction 테스트 5개 삭제**: "브로커 필드 = gross"라는 (라이브 증거가 반증한) 가정을 박제한 것들.
- **mock 테스트 1개 재작성**: orderable == raw + `inquire_korea_orders` 미호출 단언.
- 영향 가능 파일 전수 sweep **296 tests green**, ruff + ty clean.

## 남은 것 (배포/검증)

- operator MCP 재시작.
- (옵션) 장중 미체결 매수 상태에서 `uv run python -m scripts.rob596_orderable_diagnostic` 1회 더 실행 → `stck_cash100_max` 가 실제 net으로 감소함을 직접 확증(현재는 장마감으로 pending 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
