### PR TITLE
feat(ROB-592): /invest 종목 상세 — per-symbol 감시(watch) 카드 + 체결 내역 상세 업그레이드

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.3.1] - 2026-06-17
+
+### Added (ROB-592 — stock detail per-symbol watch card + fill detail upgrade)
+- Per-symbol watch card on the stock detail page (`/invest/stocks/:market/:symbol`): new `WatchCard` reuses the ROB-591 watch read endpoint via a new optional `symbol` query param on `GET /trading/api/invest/watches` (no new endpoint). Backend canonicalizes US separator forms (`BRK-B`/`BRK/B` → `BRK.B`) like the ROB-559 order-ledger endpoint; KR/crypto matched raw.
+- Extract watch row presentation helpers into shared `components/my/watchPresentation.ts` (status/proximity pill tones + labels, money/date/condition formatters); `WatchAlertsPanel` and the new `WatchCard` both consume them (single source of truth).
+- Upgrade the stock detail 체결 내역 (`OrdersCard`) from a bare `side quantity` list to a full table (일시 · 구분(매수/매도) · 수량 · 단가 · 총액 · 출처) using the existing `/orders` data; currency inferred from market (KR/crypto → ₩, US → $), source labelled 실시간/보정/수동.
+
+### Changed (ROB-591 follow-up)
+- `WatchPanelService.list_watches` accepts an optional `symbol` filter (forwarded to `repository.list_alerts(symbol=...)`).
+
 ## [0.3.0] - 2026-06-17
 
 ### Added (ROB-591 — /invest/my watch tab + watch read endpoint)

--- a/app/routers/invest_watches.py
+++ b/app/routers/invest_watches.py
@@ -34,5 +34,8 @@ async def list_watches(
     service: Annotated[WatchPanelService, Depends(get_watch_panel_service)],
     market: Annotated[Market, Query()] = "all",
     status: Annotated[Status, Query()] = "all",
+    symbol: Annotated[str | None, Query()] = None,
 ) -> WatchesResponse:
-    return await service.list_watches(market=market, status=status)
+    # `symbol` scopes the panel to a single instrument for the stock detail
+    # page (ROB-592). Omitted by the /invest/my watch tab (ROB-591).
+    return await service.list_watches(market=market, status=status, symbol=symbol)

--- a/app/services/invest_view_model/watch_panel_service.py
+++ b/app/services/invest_view_model/watch_panel_service.py
@@ -10,6 +10,7 @@ from typing import Literal
 import sqlalchemy as sa
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.symbol import to_db_symbol
 from app.models.investment_reports import InvestmentWatchAlert, InvestmentWatchEvent
 from app.models.market_quote_snapshot import MarketQuoteSnapshot
 from app.schemas.invest_watches import (
@@ -58,6 +59,7 @@ class WatchPanelService:
         *,
         market: Literal["all", "kr", "us", "crypto"] = "all",
         status: Literal["all", "active", "triggered", "expired", "canceled"] = "all",
+        symbol: str | None = None,
     ) -> WatchesResponse:
         repo = InvestmentReportsRepository(self._db)
         now = self._clock()
@@ -65,9 +67,20 @@ class WatchPanelService:
         # 1. Fetch alerts
         db_market = None if market == "all" else market
         db_status = None if status == "all" else status
+        # Per-symbol callers (stock detail page) pass the route symbol, which may
+        # arrive in a separator form (US BRK-B / BRK/B) different from the dot
+        # form (BRK.B) the alert table stores. Canonicalize per market exactly
+        # like the ROB-559 order-ledger endpoint (linked_orders.list_live_orders_
+        # for_symbol): US → to_db_symbol; KR/crypto matched raw (upper). Fails
+        # safe to an empty result on any residual mismatch.
+        db_symbol: str | None = None
+        if symbol:
+            sym = symbol.strip().upper()
+            db_symbol = to_db_symbol(sym) if market == "us" else sym
         alerts = await repo.list_alerts(
             market=db_market,
             status=db_status,
+            symbol=db_symbol,
             limit=250,
         )
 

--- a/frontend/invest/src/__tests__/StockDetailPage.test.tsx
+++ b/frontend/invest/src/__tests__/StockDetailPage.test.tsx
@@ -1,8 +1,9 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { afterEach, beforeEach, expect, test, vi } from "vitest";
 import { StockDetailPage } from "../pages/stock-detail/StockDetailPage";
 import * as stockApi from "../api/stockDetail";
+import * as watchApi from "../api/watches";
 import { AccountPanelProvider } from "../desktop/AccountPanelProvider";
 import { mockRightRail } from "../test/mockRightRail";
 import type {
@@ -260,6 +261,16 @@ beforeEach(() => {
   vi.spyOn(stockApi, "fetchStockDetailOrders").mockResolvedValue(orders);
   vi.spyOn(stockApi, "fetchStockDetailNews").mockResolvedValue(news);
   vi.spyOn(stockApi, "fetchStockDetailResearchConsensus").mockResolvedValue(researchConsensus);
+  vi.spyOn(watchApi, "fetchWatches").mockResolvedValue({
+    market: "us",
+    status: "all",
+    count: 0,
+    data_state: "ok",
+    as_of: "2026-05-10T09:31:00Z",
+    items: [],
+    warnings: [],
+    empty_reason: null,
+  });
 });
 
 afterEach(() => {
@@ -383,6 +394,73 @@ test("keeps buy/sell controls disabled and shows explicit orderbook plus empty o
   expect(screen.getByTestId("stock-detail-trade-guardrail")).toHaveTextContent("read_only_mvp");
   expect(screen.getByTestId("stock-detail-orderbook")).toHaveTextContent("US 호가는 아직 지원하지 않습니다");
   expect(await screen.findByTestId("stock-detail-orders")).toHaveTextContent("체결 내역이 없습니다");
+});
+
+test("renders the upgraded fill table (buy/sell · price · notional) and the per-symbol watch card", async () => {
+  vi.mocked(stockApi.fetchStockDetailOrders).mockResolvedValue({
+    symbol: "QQQM",
+    market: "us",
+    items: [
+      { orderId: "o1", symbol: "QQQM", market: "us", side: "buy", quantity: 2, price: 200, filledAt: "2026-05-09T13:30:00Z", account: "kis", source: "reconciler" },
+      { orderId: "o2", symbol: "QQQM", market: "us", side: "sell", quantity: 3, price: 210, filledAt: "2026-05-10T13:30:00Z", account: "kis", source: "websocket" },
+    ],
+    nextCursor: null,
+    meta: { emptyState: null, warnings: [] },
+  });
+  vi.mocked(watchApi.fetchWatches).mockResolvedValue({
+    market: "us",
+    status: "all",
+    count: 1,
+    data_state: "ok",
+    as_of: "2026-05-10T09:31:00Z",
+    items: [
+      {
+        alert_uuid: "a1",
+        source_report_uuid: "r1",
+        market: "us",
+        symbol: "QQQM",
+        symbol_name: "Invesco NASDAQ 100 ETF",
+        target_kind: "asset",
+        metric: "price_above",
+        operator: "above",
+        threshold: "230",
+        threshold_high: null,
+        status: "active",
+        valid_until: "2026-05-20T00:00:00Z",
+        intent: "sell_review",
+        action_mode: "notify_only",
+        rationale: "목표가 근접 시 분할 매도 검토",
+        trigger_checklist: [],
+        max_action: {},
+        current_price: "211.34",
+        proximity_band: "within_1_pct",
+        last_event: null,
+        near_expiry: false,
+      },
+    ],
+    warnings: [],
+    empty_reason: null,
+  });
+
+  renderPage();
+
+  const ordersCard = within(await screen.findByTestId("stock-detail-orders"));
+  expect(ordersCard.getByText("일시")).toBeInTheDocument();
+  expect(ordersCard.getByText("구분")).toBeInTheDocument();
+  expect(ordersCard.getByText("총액")).toBeInTheDocument();
+  expect(ordersCard.getByText("매수")).toBeInTheDocument();
+  expect(ordersCard.getByText("매도")).toBeInTheDocument();
+  // notional = price × quantity, formatted for USD (buy 2×200, sell 3×210)
+  expect(ordersCard.getByText("$400.00")).toBeInTheDocument();
+  expect(ordersCard.getByText("$630.00")).toBeInTheDocument();
+  expect(ordersCard.getByText("보정")).toBeInTheDocument();
+  expect(ordersCard.getByText("실시간")).toBeInTheDocument();
+
+  const watchCard = within(await screen.findByTestId("stock-detail-watch"));
+  expect(watchCard.getByText("감시중")).toBeInTheDocument();
+  expect(watchCard.getByText(/가격 \$230.00 이상/)).toBeInTheDocument();
+  expect(watchCard.getByText("목표가 근접 시 분할 매도 검토")).toBeInTheDocument();
+  await waitFor(() => expect(watchApi.fetchWatches).toHaveBeenCalledWith("us", "all", "QQQM"));
 });
 
 test("omits external community clone and uses a local memo placeholder", async () => {

--- a/frontend/invest/src/__tests__/WatchCard.test.tsx
+++ b/frontend/invest/src/__tests__/WatchCard.test.tsx
@@ -1,0 +1,95 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, test } from "vitest";
+import { WatchCard } from "../desktop/stock-detail/WatchCard";
+import type { WatchAlertRow } from "../types/watches";
+
+function watch(overrides: Partial<WatchAlertRow> = {}): WatchAlertRow {
+  return {
+    alert_uuid: "alert-1",
+    source_report_uuid: "report-1",
+    market: "kr",
+    symbol: "005930",
+    symbol_name: "삼성전자",
+    target_kind: "asset",
+    metric: "price_below",
+    operator: "below",
+    threshold: "70000",
+    threshold_high: null,
+    status: "active",
+    valid_until: "2026-06-18T03:00:00Z",
+    intent: "buy_review",
+    action_mode: "notify_only",
+    rationale: "진입가 근접 시 분할 매수 검토",
+    trigger_checklist: [],
+    max_action: {},
+    current_price: "69800",
+    proximity_band: "hit",
+    last_event: null,
+    near_expiry: true,
+    ...overrides,
+  };
+}
+
+describe("WatchCard", () => {
+  test("shows loading state when watches is undefined", () => {
+    render(<WatchCard watches={undefined} />);
+    expect(screen.getByText("불러오는 중입니다…")).toBeInTheDocument();
+  });
+
+  test("shows empty state when no watches", () => {
+    render(<WatchCard watches={[]} />);
+    expect(screen.getByText("등록된 감시가 없습니다.")).toBeInTheDocument();
+  });
+
+  test("renders an active price watch with condition, proximity and current price", () => {
+    render(<WatchCard watches={[watch()]} />);
+    // condition: "가격 ₩70,000 이하"
+    expect(screen.getByText(/가격 ₩70,000 이하/)).toBeInTheDocument();
+    // status + proximity + near-expiry pills
+    expect(screen.getByText("감시중")).toBeInTheDocument();
+    expect(screen.getByText("도달")).toBeInTheDocument();
+    expect(screen.getByText("임박")).toBeInTheDocument();
+    // current price formatted for KR
+    expect(screen.getByText("₩69,800")).toBeInTheDocument();
+    expect(screen.getByText("진입가 근접 시 분할 매수 검토")).toBeInTheDocument();
+  });
+
+  test("renders a between-operator zone condition with both thresholds", () => {
+    render(
+      <WatchCard
+        watches={[
+          watch({
+            metric: "price",
+            operator: "between",
+            threshold: "70000",
+            threshold_high: "80000",
+            proximity_band: null,
+          }),
+        ]}
+      />,
+    );
+    expect(screen.getByText(/가격 ₩70,000 ~ ₩80,000/)).toBeInTheDocument();
+  });
+
+  test("renders triggered watch with last event outcome", () => {
+    render(
+      <WatchCard
+        watches={[
+          watch({
+            status: "triggered",
+            proximity_band: null,
+            current_price: null,
+            last_event: {
+              event_uuid: "evt-1",
+              outcome: "notified",
+              current_value: "69000",
+              created_at: "2026-06-17T03:00:00Z",
+            },
+          }),
+        ]}
+      />,
+    );
+    expect(screen.getByText("발화됨")).toBeInTheDocument();
+    expect(screen.getByText(/notified/)).toBeInTheDocument();
+  });
+});

--- a/frontend/invest/src/api/watches.ts
+++ b/frontend/invest/src/api/watches.ts
@@ -5,8 +5,11 @@ const BASE = "/trading/api/invest/watches";
 export async function fetchWatches(
   market: WatchMarket = "all",
   status: WatchStatus = "all",
+  symbol?: string,
 ): Promise<WatchesResponse> {
   const q = new URLSearchParams({ market, status });
+  // ROB-592: per-symbol scope for the stock detail watch card.
+  if (symbol) q.set("symbol", symbol);
   const res = await fetch(`${BASE}?${q}`, { credentials: "include" });
   if (!res.ok) throw new Error(`watches ${res.status}`);
   return res.json();

--- a/frontend/invest/src/components/my/WatchAlertsPanel.tsx
+++ b/frontend/invest/src/components/my/WatchAlertsPanel.tsx
@@ -5,11 +5,20 @@ import { fetchWatches } from "../../api/watches";
 import { Pill } from "../../ds";
 import { stockDetailPath } from "../../stockDetailPath";
 import type {
-  WatchAlertRow,
   WatchMarket,
   WatchStatus,
   WatchesResponse,
 } from "../../types/watches";
+import {
+  PROXIMITY_BAND_LABELS,
+  PROXIMITY_BAND_TONES,
+  WATCH_MARKET_LABEL as MARKET_LABEL,
+  WATCH_STATUS_LABELS,
+  WATCH_STATUS_TONES,
+  formatWatchCondition as formatCondition,
+  formatWatchDateTime as formatDateTime,
+  formatWatchMoney as formatMoney,
+} from "./watchPresentation";
 
 const MARKET_OPTIONS: { key: WatchMarket; label: string }[] = [
   { key: "all", label: "전체" },
@@ -25,76 +34,6 @@ const STATUS_OPTIONS: { key: WatchStatus; label: string }[] = [
   { key: "expired", label: "만료됨" },
   { key: "canceled", label: "취소됨" },
 ];
-
-const WATCH_STATUS_TONES: Record<string, "accent" | "warn" | "paper" | "loss"> = {
-  active: "accent",
-  triggered: "accent",
-  expired: "warn",
-  canceled: "warn",
-};
-
-const WATCH_STATUS_LABELS: Record<string, string> = {
-  active: "감시중",
-  triggered: "발화됨",
-  expired: "만료됨",
-  canceled: "취소됨",
-};
-
-const PROXIMITY_BAND_TONES: Record<string, "accent" | "warn" | "paper"> = {
-  hit: "accent",
-  within_0_5_pct: "warn",
-  within_1_pct: "paper",
-  outside: "paper",
-};
-
-const PROXIMITY_BAND_LABELS: Record<string, string> = {
-  hit: "도달",
-  within_0_5_pct: "0.5% 이내",
-  within_1_pct: "1.0% 이내",
-  outside: "대기",
-};
-
-const MARKET_LABEL: Record<string, string> = {
-  kr: "국내",
-  us: "미국",
-  crypto: "코인",
-};
-
-function formatMoney(value: string | number | null | undefined, market: string): string {
-  if (value == null || value === "") return "—";
-  const n = typeof value === "number" ? value : Number(value);
-  if (!Number.isFinite(n)) return "—";
-
-  if (market === "us") {
-    return `$${n.toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 4 })}`;
-  }
-  if (market === "kr") return `₩${Math.round(n).toLocaleString("ko-KR")}`;
-  return `${n.toLocaleString("ko-KR", { maximumFractionDigits: 8 })}`;
-}
-
-function formatDateTime(value: string | null): string {
-  if (!value) return "—";
-  const dt = new Date(value);
-  if (Number.isNaN(dt.getTime())) return value;
-  return new Intl.DateTimeFormat("ko-KR", {
-    month: "2-digit",
-    day: "2-digit",
-    hour: "2-digit",
-    minute: "2-digit",
-    hour12: false,
-    timeZone: "Asia/Seoul",
-  }).format(dt);
-}
-
-function formatCondition(row: WatchAlertRow): string {
-  const op = row.operator === "above" ? "이상" : row.operator === "below" ? "이하" : "범위";
-  const metricName = row.metric === "price_above" || row.metric === "price_below" || row.metric === "price" ? "가격" : row.metric;
-
-  if (row.operator === "between" && row.threshold_high) {
-    return `${metricName} ${formatMoney(row.threshold, row.market)} ~ ${formatMoney(row.threshold_high, row.market)}`;
-  }
-  return `${metricName} ${formatMoney(row.threshold, row.market)} ${op}`;
-}
 
 export function WatchAlertsPanel({ compact = false }: { compact?: boolean }) {
   const [market, setMarket] = useState<WatchMarket>("all");

--- a/frontend/invest/src/components/my/watchPresentation.ts
+++ b/frontend/invest/src/components/my/watchPresentation.ts
@@ -1,0 +1,78 @@
+// Shared presentation helpers for watch alert rows (ROB-591 panel + ROB-592
+// per-symbol stock-detail card). Single source of truth so the /invest/my watch
+// tab and the stock detail watch card render identically.
+
+import type { WatchAlertRow } from "../../types/watches";
+
+export const WATCH_STATUS_TONES: Record<string, "accent" | "warn" | "paper" | "loss"> = {
+  active: "accent",
+  triggered: "accent",
+  expired: "warn",
+  canceled: "warn",
+};
+
+export const WATCH_STATUS_LABELS: Record<string, string> = {
+  active: "감시중",
+  triggered: "발화됨",
+  expired: "만료됨",
+  canceled: "취소됨",
+};
+
+export const PROXIMITY_BAND_TONES: Record<string, "accent" | "warn" | "paper"> = {
+  hit: "accent",
+  within_0_5_pct: "warn",
+  within_1_pct: "paper",
+  outside: "paper",
+};
+
+export const PROXIMITY_BAND_LABELS: Record<string, string> = {
+  hit: "도달",
+  within_0_5_pct: "0.5% 이내",
+  within_1_pct: "1.0% 이내",
+  outside: "대기",
+};
+
+export const WATCH_MARKET_LABEL: Record<string, string> = {
+  kr: "국내",
+  us: "미국",
+  crypto: "코인",
+};
+
+export function formatWatchMoney(value: string | number | null | undefined, market: string): string {
+  if (value == null || value === "") return "—";
+  const n = typeof value === "number" ? value : Number(value);
+  if (!Number.isFinite(n)) return "—";
+
+  if (market === "us") {
+    return `$${n.toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 4 })}`;
+  }
+  if (market === "kr") return `₩${Math.round(n).toLocaleString("ko-KR")}`;
+  return `${n.toLocaleString("ko-KR", { maximumFractionDigits: 8 })}`;
+}
+
+export function formatWatchDateTime(value: string | null): string {
+  if (!value) return "—";
+  const dt = new Date(value);
+  if (Number.isNaN(dt.getTime())) return value;
+  return new Intl.DateTimeFormat("ko-KR", {
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+    timeZone: "Asia/Seoul",
+  }).format(dt);
+}
+
+export function formatWatchCondition(row: WatchAlertRow): string {
+  const op = row.operator === "above" ? "이상" : row.operator === "below" ? "이하" : "범위";
+  const metricName =
+    row.metric === "price_above" || row.metric === "price_below" || row.metric === "price"
+      ? "가격"
+      : row.metric;
+
+  if (row.operator === "between" && row.threshold_high) {
+    return `${metricName} ${formatWatchMoney(row.threshold, row.market)} ~ ${formatWatchMoney(row.threshold_high, row.market)}`;
+  }
+  return `${metricName} ${formatWatchMoney(row.threshold, row.market)} ${op}`;
+}

--- a/frontend/invest/src/desktop/stock-detail/WatchCard.tsx
+++ b/frontend/invest/src/desktop/stock-detail/WatchCard.tsx
@@ -1,0 +1,80 @@
+// ROB-592 — per-symbol watch card for the stock detail page.
+// Reuses the ROB-591 watch read endpoint (filtered by symbol) and the shared
+// presentation helpers so a symbol's active/triggered watches render with the
+// same condition + proximity semantics as the /invest/my 감시 tab.
+
+import { Card, Pill } from "../../ds";
+import {
+  PROXIMITY_BAND_LABELS,
+  PROXIMITY_BAND_TONES,
+  WATCH_STATUS_LABELS,
+  WATCH_STATUS_TONES,
+  formatWatchCondition,
+  formatWatchDateTime,
+  formatWatchMoney,
+} from "../../components/my/watchPresentation";
+import type { WatchAlertRow } from "../../types/watches";
+
+export function WatchCard({ watches }: { watches: WatchAlertRow[] | undefined }) {
+  return (
+    <Card data-testid="stock-detail-watch">
+      <h2 style={{ margin: "0 0 4px", fontSize: 16 }}>감시</h2>
+      <p style={{ margin: "0 0 8px", fontSize: 12, color: "var(--fg-3)" }}>
+        이 종목의 AI 감시 트리거 (조건 · 근접도 · 발화)
+      </p>
+      {!watches ? (
+        <p style={{ margin: 0, color: "var(--fg-3)" }}>불러오는 중입니다…</p>
+      ) : null}
+      {watches && watches.length === 0 ? (
+        <p style={{ margin: 0, color: "var(--fg-3)" }}>등록된 감시가 없습니다.</p>
+      ) : null}
+      {watches && watches.length > 0 ? (
+        <div style={{ display: "grid", gap: 8 }}>
+          {watches.map((row) => (
+            <div
+              key={row.alert_uuid}
+              style={{
+                border: "1px solid var(--divider)",
+                borderRadius: 12,
+                padding: "10px 12px",
+                display: "grid",
+                gap: 6,
+              }}
+            >
+              <div style={{ display: "flex", justifyContent: "space-between", gap: 8, alignItems: "center" }}>
+                <div style={{ display: "flex", gap: 6, flexWrap: "wrap", alignItems: "center" }}>
+                  <Pill tone={WATCH_STATUS_TONES[row.status] ?? "paper"} size="sm">
+                    {WATCH_STATUS_LABELS[row.status] ?? row.status}
+                  </Pill>
+                  {row.near_expiry ? (
+                    <Pill tone="warn" size="sm">임박</Pill>
+                  ) : null}
+                  {row.status === "active" && row.proximity_band ? (
+                    <Pill tone={PROXIMITY_BAND_TONES[row.proximity_band] ?? "paper"} size="sm">
+                      {PROXIMITY_BAND_LABELS[row.proximity_band] ?? row.proximity_band}
+                    </Pill>
+                  ) : null}
+                </div>
+                <div style={{ fontSize: 13, fontWeight: 700, fontFeatureSettings: '"tnum"' }}>
+                  {row.current_price ? formatWatchMoney(row.current_price, row.market) : null}
+                </div>
+              </div>
+              <div style={{ fontSize: 13 }}>{formatWatchCondition(row)}</div>
+              <div style={{ fontSize: 11, color: "var(--fg-3)" }}>
+                만료: {formatWatchDateTime(row.valid_until)} · {row.intent} · {row.action_mode}
+              </div>
+              {row.rationale ? (
+                <div style={{ fontSize: 12, color: "var(--fg-2)" }}>{row.rationale}</div>
+              ) : null}
+              {row.last_event ? (
+                <div style={{ fontSize: 11, color: "var(--fg-3)" }}>
+                  발화: {formatWatchDateTime(row.last_event.created_at)} ({row.last_event.outcome})
+                </div>
+              ) : null}
+            </div>
+          ))}
+        </div>
+      ) : null}
+    </Card>
+  );
+}

--- a/frontend/invest/src/pages/stock-detail/StockDetailPage.tsx
+++ b/frontend/invest/src/pages/stock-detail/StockDetailPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState, type CSSProperties } from "react";
 import { useParams } from "react-router-dom";
 import { DesktopShell } from "../../desktop/DesktopShell";
 import { Button, Card, Hairline, Krw, PL, Pill, Sparkline, Usd } from "../../ds";
@@ -10,11 +10,14 @@ import {
   fetchStockDetailOrders,
   fetchStockDetailResearchConsensus,
 } from "../../api/stockDetail";
+import { fetchWatches } from "../../api/watches";
 import { InvestorFlowCard } from "../../desktop/stock-detail/InvestorFlowCard";
 import { OrderLedgerCard } from "../../desktop/stock-detail/OrderLedgerCard";
+import { WatchCard } from "../../desktop/stock-detail/WatchCard";
 import { accountSourceMeta } from "../../desktop/AccountSourceMeta";
 import type { LinkedOrder } from "../../types/investmentReports";
 import type {
+  OrderSide,
   StockDetailCandlesResponse,
   StockDetailFxSensitivity,
   StockDetailMarket,
@@ -24,6 +27,7 @@ import type {
   StockDetailResponse,
   StockDetailHolding,
 } from "../../types/stockDetail";
+import type { WatchAlertRow } from "../../types/watches";
 
 function fmtPct(v: number | null | undefined): string {
   if (v == null) return "−";
@@ -222,14 +226,100 @@ function OrderbookCard({ data }: { data: StockDetailResponse }) {
   );
 }
 
-function OrdersCard({ orders }: { orders: StockDetailOrdersResponse | undefined }) {
+const ORDER_SOURCE_LABELS: Record<string, string> = {
+  websocket: "실시간",
+  reconciler: "보정",
+  manual_import: "수동",
+};
+
+function fmtOrderMoney(value: number | null | undefined, market: StockDetailMarket): string {
+  if (value == null || !Number.isFinite(value)) return "−";
+  if (market === "us") {
+    return `$${value.toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 4 })}`;
+  }
+  // kr + crypto (Upbit pairs are KRW-quoted)
+  return `₩${Math.round(value).toLocaleString("ko-KR")}`;
+}
+
+function fmtOrderTime(value: string | null): string {
+  if (!value) return "−";
+  const dt = new Date(value);
+  if (Number.isNaN(dt.getTime())) return value;
+  return new Intl.DateTimeFormat("ko-KR", {
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+    timeZone: "Asia/Seoul",
+  }).format(dt);
+}
+
+function orderSideMeta(side: OrderSide): { label: string; tone: "gain" | "loss" | "paper" } {
+  if (side === "buy") return { label: "매수", tone: "gain" };
+  if (side === "sell") return { label: "매도", tone: "loss" };
+  return { label: String(side), tone: "paper" };
+}
+
+const ordersTh: CSSProperties = {
+  padding: "8px 12px",
+  borderTop: "1px solid var(--divider)",
+  borderBottom: "1px solid var(--divider)",
+  color: "var(--fg-3)",
+  fontSize: 11,
+  textAlign: "left",
+  whiteSpace: "nowrap",
+};
+
+const ordersTd: CSSProperties = {
+  padding: "10px 12px",
+  borderBottom: "1px solid var(--divider)",
+  fontSize: 13,
+  whiteSpace: "nowrap",
+};
+
+function OrdersCard({ orders, market }: { orders: StockDetailOrdersResponse | undefined; market: StockDetailMarket }) {
   const empty = orders?.meta.emptyState === "no_filled_orders" || orders?.items.length === 0;
   return (
     <Card data-testid="stock-detail-orders">
-      <h2 style={{ margin: "0 0 8px", fontSize: 16 }}>체결 내역</h2>
+      <h2 style={{ margin: "0 0 4px", fontSize: 16 }}>체결 내역</h2>
+      <p style={{ margin: "0 0 8px", fontSize: 12, color: "var(--fg-3)" }}>매수 · 매도 체결 (일시 · 단가 · 총액)</p>
       {!orders ? <p style={{ margin: 0, color: "var(--fg-3)" }}>불러오는 중입니다…</p> : null}
       {orders && empty ? <p style={{ margin: 0, color: "var(--fg-3)" }}>체결 내역이 없습니다.</p> : null}
-      {orders && !empty ? <ul>{orders.items.map((o) => <li key={o.orderId ?? `${o.side}-${o.filledAt}`}>{o.side} {o.quantity}</li>)}</ul> : null}
+      {orders && !empty ? (
+        <div style={{ overflowX: "auto" }}>
+          <table style={{ width: "100%", borderCollapse: "collapse" }}>
+            <thead>
+              <tr>
+                <th style={ordersTh}>일시</th>
+                <th style={ordersTh}>구분</th>
+                <th style={{ ...ordersTh, textAlign: "right" }}>수량</th>
+                <th style={{ ...ordersTh, textAlign: "right" }}>단가</th>
+                <th style={{ ...ordersTh, textAlign: "right" }}>총액</th>
+                <th style={ordersTh}>출처</th>
+              </tr>
+            </thead>
+            <tbody>
+              {orders.items.map((o, idx) => {
+                const side = orderSideMeta(o.side);
+                const notional = o.price != null ? o.price * o.quantity : null;
+                return (
+                  <tr key={o.orderId ?? `${o.side}-${o.filledAt}-${o.quantity}-${idx}`}>
+                    <td style={{ ...ordersTd, color: "var(--fg-2)", fontSize: 12 }}>{fmtOrderTime(o.filledAt)}</td>
+                    <td style={ordersTd}>
+                      <Pill tone={side.tone} size="sm">{side.label}</Pill>
+                    </td>
+                    <td style={{ ...ordersTd, textAlign: "right", fontFeatureSettings: '"tnum"' }}>{fmtQty(o.quantity)}</td>
+                    <td style={{ ...ordersTd, textAlign: "right", fontFeatureSettings: '"tnum"' }}>{fmtOrderMoney(o.price, market)}</td>
+                    <td style={{ ...ordersTd, textAlign: "right", fontWeight: 800, fontFeatureSettings: '"tnum"' }}>{fmtOrderMoney(notional, market)}</td>
+                    <td style={{ ...ordersTd, color: "var(--fg-3)", fontSize: 12 }}>{ORDER_SOURCE_LABELS[o.source ?? ""] ?? o.source ?? "−"}</td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      ) : null}
     </Card>
   );
 }
@@ -409,6 +499,7 @@ export function StockDetailPage() {
   const [candles, setCandles] = useState<StockDetailCandlesResponse | undefined>();
   const [orders, setOrders] = useState<StockDetailOrdersResponse | undefined>();
   const [orderLedger, setOrderLedger] = useState<LinkedOrder[] | undefined>();
+  const [watches, setWatches] = useState<WatchAlertRow[] | undefined>();
   const [news, setNews] = useState<StockDetailNewsResponse | undefined>();
   const [researchConsensus, setResearchConsensus] = useState<StockDetailResearchConsensusResponse | undefined>();
   const [researchErr, setResearchErr] = useState<string | undefined>();
@@ -420,6 +511,7 @@ export function StockDetailPage() {
     setCandles(undefined);
     setOrders(undefined);
     setOrderLedger(undefined);
+    setWatches(undefined);
     setNews(undefined);
     setResearchConsensus(undefined);
     setResearchErr(undefined);
@@ -442,6 +534,9 @@ export function StockDetailPage() {
     fetchStockDetailOrderLedger({ market, symbol, days: 90 })
       .then((r) => !cancel && setOrderLedger(r))
       .catch(() => !cancel && setOrderLedger([]));
+    fetchWatches(market, "all", symbol)
+      .then((r) => !cancel && setWatches(r.items))
+      .catch(() => !cancel && setWatches([]));
     fetchStockDetailNews({ market, symbol, limit: 5 })
       .then((r) => !cancel && setNews(r))
       .catch(() => undefined);
@@ -489,9 +584,10 @@ export function StockDetailPage() {
               <ChartCard candles={candles} />
               <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 14 }}>
                 <OrderbookCard data={data} />
-                <OrdersCard orders={orders} />
+                <OrdersCard orders={orders} market={market} />
               </div>
               <OrderLedgerCard orders={orderLedger} />
+              <WatchCard watches={watches} />
               <NewsCard news={news} />
               {data.market === "kr" && data.investorFlow ? (
                 <InvestorFlowCard data={data.investorFlow} />

--- a/tests/routers/test_invest_watches_router.py
+++ b/tests/routers/test_invest_watches_router.py
@@ -12,15 +12,16 @@ from app.schemas.invest_watches import WatchesResponse
 
 class _StubWatchPanelService:
     def __init__(self) -> None:
-        self.calls: list[tuple[str, str]] = []
+        self.calls: list[tuple[str, str, str | None]] = []
 
     async def list_watches(
         self,
         *,
         market: str = "all",
         status: str = "all",
+        symbol: str | None = None,
     ) -> WatchesResponse:
-        self.calls.append((market, status))
+        self.calls.append((market, status, symbol))
         return WatchesResponse(
             market=market,  # type: ignore[arg-type]
             status=status,  # type: ignore[arg-type]
@@ -54,7 +55,7 @@ def test_watches_endpoint_defaults_to_all() -> None:
     assert response.status_code == 200
     assert response.json()["market"] == "all"
     assert response.json()["status"] == "all"
-    assert service.calls == [("all", "all")]
+    assert service.calls == [("all", "all", None)]
 
 
 @pytest.mark.unit
@@ -67,7 +68,18 @@ def test_watches_endpoint_accepts_filters() -> None:
     assert response.status_code == 200
     assert response.json()["market"] == "crypto"
     assert response.json()["status"] == "active"
-    assert service.calls == [("crypto", "active")]
+    assert service.calls == [("crypto", "active", None)]
+
+
+@pytest.mark.unit
+def test_watches_endpoint_forwards_symbol_filter() -> None:
+    service = _StubWatchPanelService()
+    client = _make_client(service)
+
+    response = client.get("/trading/api/invest/watches?market=kr&symbol=005930")
+
+    assert response.status_code == 200
+    assert service.calls == [("kr", "all", "005930")]
 
 
 @pytest.mark.unit
@@ -99,6 +111,7 @@ def test_watches_default_service_receives_db_dependency(monkeypatch) -> None:
             *,
             market: str = "all",
             status: str = "all",
+            symbol: str | None = None,
         ) -> WatchesResponse:
             return WatchesResponse(
                 market=market,  # type: ignore[arg-type]

--- a/tests/services/invest_view_model/test_watch_panel_service.py
+++ b/tests/services/invest_view_model/test_watch_panel_service.py
@@ -154,3 +154,51 @@ async def test_watch_panel_service_list_watches(session: AsyncSession) -> None: 
     resp_kr = await service.list_watches(market="kr", status="active")
     assert resp_kr.count == 1
     assert resp_kr.items[0].symbol == "005930"
+
+    # Per-symbol scope (ROB-592 stock detail page reuse)
+    resp_symbol = await service.list_watches(market="kr", symbol="005930")
+    assert resp_symbol.count == 1
+    assert resp_symbol.items[0].symbol == "005930"
+    # Proximity still enriched under the symbol scope (active price alert).
+    assert resp_symbol.items[0].proximity_band == "hit"
+
+    # Symbol that has no alert in this market returns empty (no crash).
+    resp_symbol_none = await service.list_watches(market="us", symbol="005930")
+    assert resp_symbol_none.count == 0
+
+
+@pytest.mark.asyncio
+async def test_watch_panel_service_us_symbol_normalization(
+    session: AsyncSession,  # noqa: F811
+) -> None:
+    """US separator forms (BRK-B / BRK/B) resolve to the dot form the alert stores."""
+    now = dt.datetime(2026, 6, 17, 12, 0, tzinfo=dt.UTC)
+
+    alert = InvestmentWatchAlert(
+        alert_uuid=uuid.uuid4(),
+        idempotency_key="key-brk",
+        source_report_uuid=uuid.uuid4(),
+        source_item_uuid=uuid.uuid4(),
+        market="us",
+        target_kind="asset",
+        symbol="BRK.B",  # alert table stores the dot form
+        metric="price_above",
+        operator="above",
+        threshold=Decimal("500"),
+        threshold_key="500",
+        intent="sell_review",
+        action_mode="notify_only",
+        rationale="brk watch",
+        valid_until=now + dt.timedelta(days=5),
+        status="active",
+    )
+    session.add(alert)
+    await session.flush()
+
+    service = WatchPanelService(db=session, clock=now)
+
+    # Hyphen and slash separators both canonicalize to BRK.B and match.
+    for route_symbol in ("BRK-B", "brk-b", "BRK/B", "BRK.B"):
+        resp = await service.list_watches(market="us", symbol=route_symbol)
+        assert resp.count == 1, route_symbol
+        assert resp.items[0].symbol == "BRK.B"


### PR DESCRIPTION
## Summary

ROB-591 follow-up. 종목 상세 페이지(`/invest/stocks/:market/:symbol`)에 **(A) per-symbol 감시(watch) 카드**와 **(B) 체결 내역 상세 업그레이드**를 추가. 주문 기록(OrderLedgerCard, ROB-559)은 이미 존재 — 범위 아님.

Closes [ROB-592](https://linear.app/mgh3326/issue/ROB-592). Related: ROB-591 (watch 읽기 엔드포인트 제공), ROB-559 (종목상세 주문 기록).

## Part A — per-symbol 감시 카드

- **엔드포인트 재사용 (신규 엔드포인트 없음)**: ROB-591의 `GET /trading/api/invest/watches`에 optional `symbol` 쿼리파라미터 추가. `WatchPanelService.list_watches(symbol=...)` → `repository.list_alerts(symbol=...)`.
- **US 심볼 정규화**: 라우트 심볼이 `BRK-B`/`BRK/B`로 와도 alert 저장 형식(`BRK.B`)으로 매칭되도록 `to_db_symbol` 적용 (ROB-559 order-ledger 패턴 미러). KR/crypto는 raw upper. 잔여 불일치 시 빈 카드로 fail-safe(크래시 없음).
- **프런트**: `desktop/stock-detail/WatchCard.tsx` (신규). WatchAlertsPanel의 표현 헬퍼(status/proximity pill, money/date/condition)를 `components/my/watchPresentation.ts`로 추출해 양쪽이 공유(DRY). `fetchWatches`에 symbol 인자. `StockDetailPage`의 OrderLedgerCard 옆에 배선.

## Part B — 체결 내역 상세 업그레이드

- `OrdersCard`(체결 내역)를 `side 수량` 단순 리스트 → 풀 테이블(**일시 · 구분(매수/매도) · 수량 · 단가 · 총액 · 출처**)로. 기존 `/orders`(StockDetailOrder) 데이터 사용 — 데이터 소스 교체·신규 fetch 없음. 통화는 market 추론(KR/crypto → ₩, US → $), 총액 = 단가 × 수량, 출처 라벨 실시간/보정/수동.
- 단일 종목 페이지라 symbol_name은 불필요. read-only MVP 유지(매수/매도 버튼 비활성 그대로 — 운영자 결정 "정보 표시만").

## Tests

- **Backend**: `test_invest_watches_router` symbol-forward 케이스 추가; `test_watch_panel_service` symbol-filter + **US 정규화(BRK-B/BRK/B/brk-b → BRK.B)** 케이스 추가.
- **Frontend**: `WatchCard.test.tsx` (loading/empty/active/**between**/triggered) 신규; `StockDetailPage.test.tsx`에 fill-table(매수/매도·단가·총액·출처) + watch-card 렌더 테스트 추가 + `fetchWatches` 모킹.

## 검증

- ✅ backend `ruff format`/`ruff check`/`ty` clean; watch 라우터·서비스 + `test_invest_api_router_safety` import-guard 11/11 통과
- ✅ frontend `npm run typecheck` clean; WatchCard 5 + StockDetailPage 13 통과
- ✅ frontend 전체: 실패 5건은 **기존 ROB-505 baseline**(ActionReadiness/DaySection/DesktopCalendarPage/MonthlyEventsTimeline)뿐 — 이 PR 무관

## Migration

없음. (`investment_watch_alerts`/`market_quote_snapshots` 테이블 기존, 신규 컬럼 없음)

## Notes / 알려진 한계

- **크립토 proximity/매칭**: per-symbol 매칭은 `(market, symbol)` 정확 비교(ROB-559 order-ledger와 동일 semantics). 크립토 심볼이 두 테이블에서 다른 형식(`KRW-BTC` vs `BTC`)이면 빈 카드로 fail-safe. 감시 탭→상세 이동 경로(`stockDetailPath(market, alert.symbol)`)는 round-trip 매칭됨.
- 단일 운영자 모델(alert에 user_id 없음) — ROB-591과 동일.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a watch alerts card to the stock detail page, displaying active price monitors for the selected symbol.
  * Enhanced orders table with enriched columns, including formatted amounts, source labels, and computed notional values.
  * Watch filtering now supports symbol-based scoping to show only relevant alerts per instrument.

* **Improvements**
  * Improved watch alert presentation consistency across the app with market-specific formatting for currencies and thresholds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->