### PR TITLE
fix(ROB-599): /invest 감시 패널 500 — trigger_checklist list[str] + per-row 격리

### DIFF
--- a/app/schemas/invest_watches.py
+++ b/app/schemas/invest_watches.py
@@ -49,7 +49,9 @@ class WatchAlertRow(BaseModel):
     intent: str
     action_mode: str
     rationale: str
-    trigger_checklist: list[dict] = Field(default_factory=list)
+    # Watch checklists are free-text strings (CLAUDE.md contract: string[]);
+    # the alert table stores them as a JSON list of strings.
+    trigger_checklist: list[str] = Field(default_factory=list)
     max_action: dict = Field(default_factory=dict)
     # 근접도 (price metric만, 외 metric은 null)
     current_price: Decimal | None = None

--- a/app/services/invest_view_model/watch_panel_service.py
+++ b/app/services/invest_view_model/watch_panel_service.py
@@ -40,6 +40,87 @@ def _to_decimal(val: object) -> Decimal | None:
         return None
 
 
+def _build_watch_row(
+    alert: InvestmentWatchAlert,
+    *,
+    symbol_name: str | None,
+    snapshot: MarketQuoteSnapshot | None,
+    last_event: InvestmentWatchEvent | None,
+    now: dt.datetime,
+) -> WatchAlertRow:
+    """Project a single alert into a WatchAlertRow.
+
+    Raises on malformed alert data (caught + skipped by the caller so one bad
+    row never 500s the whole panel).
+    """
+    # Near expiry (active alerts whose valid_until is within 2 days).
+    near_expiry = alert.status == "active" and alert.valid_until - now <= dt.timedelta(
+        days=2
+    )
+
+    # Proximity for active price-metric alerts (price_above/price_below only).
+    current_price: Decimal | None = None
+    proximity_band: WatchProximityBand | None = None
+    if (
+        alert.status == "active"
+        and alert.metric in ("price_above", "price_below")
+        and snapshot is not None
+    ):
+        current_price = snapshot.price
+        try:
+            prox_res = compute_price_proximity(
+                market=alert.market,
+                target_kind=alert.target_kind,
+                symbol=alert.symbol,
+                condition_type=alert.metric,
+                threshold=float(alert.threshold),
+                current=float(snapshot.price),
+            )
+            proximity_band = prox_res.band
+        except Exception:
+            logger.warning(
+                "Failed to compute proximity for alert %s", alert.id, exc_info=True
+            )
+
+    # Latest trigger event for non-active alerts.
+    last_event_summary: WatchEventSummary | None = None
+    if alert.status != "active" and last_event is not None:
+        last_event_summary = WatchEventSummary(
+            event_uuid=last_event.event_uuid,
+            outcome=last_event.outcome,
+            current_value=_to_decimal(last_event.current_value),
+            created_at=last_event.created_at,
+        )
+
+    # Watch checklists are free-text strings; coerce defensively so a stray
+    # non-str scalar degrades to text rather than failing the whole row.
+    trigger_checklist = [str(item) for item in (alert.trigger_checklist or [])]
+
+    return WatchAlertRow(
+        alert_uuid=alert.alert_uuid,
+        source_report_uuid=alert.source_report_uuid,
+        market=alert.market,  # type: ignore[arg-type]
+        symbol=alert.symbol,
+        symbol_name=symbol_name,
+        target_kind=alert.target_kind,
+        metric=alert.metric,
+        operator=alert.operator,  # type: ignore[arg-type]
+        threshold=_to_decimal(alert.threshold),
+        threshold_high=_to_decimal(alert.threshold_high),
+        status=alert.status,  # type: ignore[arg-type]
+        valid_until=alert.valid_until,
+        intent=alert.intent,
+        action_mode=alert.action_mode,
+        rationale=alert.rationale,
+        trigger_checklist=trigger_checklist,
+        max_action=alert.max_action or {},
+        current_price=current_price,
+        proximity_band=proximity_band,
+        last_event=last_event_summary,
+        near_expiry=near_expiry,
+    )
+
+
 class WatchPanelService:
     def __init__(
         self,
@@ -174,89 +255,34 @@ class WatchPanelService:
             except Exception:
                 logger.exception("Failed to query investment watch events")
 
-        # 5. Build items
+        # 5. Build items. Per-row isolation: a single malformed alert (e.g. an
+        #    unexpected field shape) must NOT 500 the whole panel — skip it and
+        #    surface the count in warnings (honest degrade for a read endpoint).
         items: list[WatchAlertRow] = []
+        skipped = 0
         for alert in alerts:
-            symbol_name = symbol_names.get((alert.market, alert.symbol))
-
-            # Near expiry logic for active alerts
-            near_expiry = False
-            if alert.status == "active" and alert.valid_until - now <= dt.timedelta(
-                days=2
-            ):
-                near_expiry = True
-
-            # Proximity calculation for active price alerts
-            current_price: Decimal | None = None
-            proximity_band: WatchProximityBand | None = None
-            if alert.status == "active" and alert.metric in (
-                "price_above",
-                "price_below",
-            ):
-                snapshot = snapshots.get((alert.market, alert.symbol))
-                if snapshot is not None:
-                    current_price = snapshot.price
-                    try:
-                        prox_res = compute_price_proximity(
-                            market=alert.market,
-                            target_kind=alert.target_kind,
-                            symbol=alert.symbol,
-                            condition_type=alert.metric,
-                            threshold=float(alert.threshold),
-                            current=float(snapshot.price),
-                        )
-                        # We classification match: band literal
-                        proximity_band = prox_res.band
-                    except Exception:
-                        logger.warning(
-                            "Failed to compute proximity for alert %s",
-                            alert.id,
-                            exc_info=True,
-                        )
-
-            # Last event for triggered/expired/canceled alerts
-            last_event_summary: WatchEventSummary | None = None
-            if alert.status != "active":
-                event = last_events.get(alert.id)
-                if event is not None:
-                    last_event_summary = WatchEventSummary(
-                        event_uuid=event.event_uuid,
-                        outcome=event.outcome,
-                        current_value=_to_decimal(event.current_value),
-                        created_at=event.created_at,
+            try:
+                items.append(
+                    _build_watch_row(
+                        alert,
+                        symbol_name=symbol_names.get((alert.market, alert.symbol)),
+                        snapshot=snapshots.get((alert.market, alert.symbol)),
+                        last_event=last_events.get(alert.id),
+                        now=now,
                     )
-
-            # Build trigger_checklist & max_action defaults
-            trigger_checklist = alert.trigger_checklist or []
-            max_action = alert.max_action or {}
-
-            items.append(
-                WatchAlertRow(
-                    alert_uuid=alert.alert_uuid,
-                    source_report_uuid=alert.source_report_uuid,
-                    market=alert.market,  # type: ignore[arg-type]
-                    symbol=alert.symbol,
-                    symbol_name=symbol_name,
-                    target_kind=alert.target_kind,
-                    metric=alert.metric,
-                    operator=alert.operator,  # type: ignore[arg-type]
-                    threshold=_to_decimal(alert.threshold),
-                    threshold_high=_to_decimal(alert.threshold_high),
-                    status=alert.status,  # type: ignore[arg-type]
-                    valid_until=alert.valid_until,
-                    intent=alert.intent,
-                    action_mode=alert.action_mode,
-                    rationale=alert.rationale,
-                    trigger_checklist=trigger_checklist,
-                    max_action=max_action,
-                    current_price=current_price,
-                    proximity_band=proximity_band,
-                    last_event=last_event_summary,
-                    near_expiry=near_expiry,
                 )
-            )
+            except Exception:
+                logger.exception(
+                    "Failed to build watch row for alert %s; skipping",
+                    getattr(alert, "id", None),
+                )
+                skipped += 1
 
         warnings: list[str] = []
+        if skipped:
+            warnings.append(
+                f"{skipped} watch item(s) could not be displayed due to a data issue."
+            )
         if data_state == "degraded":
             warnings.append(
                 "Some active price watch items could not retrieve current prices from the database."

--- a/tests/services/invest_view_model/test_watch_panel_service.py
+++ b/tests/services/invest_view_model/test_watch_panel_service.py
@@ -39,6 +39,9 @@ async def test_watch_panel_service_list_watches(session: AsyncSession) -> None: 
         intent="buy_review",
         action_mode="notify_only",
         rationale="test rationale",
+        # Real watches carry a string[] checklist (ROB-599 prod 500 repro:
+        # the schema previously typed this list[dict] → ValidationError → 500).
+        trigger_checklist=["005930 현재가 조회 확인", "실주문 없음 확인"],
         valid_until=now + dt.timedelta(days=1),  # near_expiry will be True
         status="active",
     )
@@ -136,6 +139,8 @@ async def test_watch_panel_service_list_watches(session: AsyncSession) -> None: 
     assert row1.current_price == Decimal("69800")
     assert row1.proximity_band == "hit"  # 69800 <= 70000 for price_below
     assert row1.last_event is None
+    # String checklist round-trips (ROB-599 regression guard).
+    assert row1.trigger_checklist == ["005930 현재가 조회 확인", "실주문 없음 확인"]
 
     # Check alert2 fields (us, AAPL)
     row2 = next(item for item in resp.items if item.symbol == "AAPL")
@@ -202,3 +207,59 @@ async def test_watch_panel_service_us_symbol_normalization(
         resp = await service.list_watches(market="us", symbol=route_symbol)
         assert resp.count == 1, route_symbol
         assert resp.items[0].symbol == "BRK.B"
+
+
+@pytest.mark.asyncio
+async def test_watch_panel_service_skips_unbuildable_row(
+    session: AsyncSession,  # noqa: F811
+    monkeypatch,
+) -> None:
+    """One alert that fails to project must not 500 the whole panel (ROB-599).
+
+    The good alert is still returned and the skipped count is surfaced in
+    warnings (honest degrade for a read endpoint).
+    """
+    now = dt.datetime(2026, 6, 17, 12, 0, tzinfo=dt.UTC)
+
+    def _alert(idem: str, symbol: str) -> InvestmentWatchAlert:
+        return InvestmentWatchAlert(
+            alert_uuid=uuid.uuid4(),
+            idempotency_key=idem,
+            source_report_uuid=uuid.uuid4(),
+            source_item_uuid=uuid.uuid4(),
+            market="us",
+            target_kind="asset",
+            symbol=symbol,
+            metric="price_above",
+            operator="above",
+            threshold=Decimal("100"),
+            threshold_key="100",
+            intent="sell_review",
+            action_mode="notify_only",
+            rationale="r",
+            valid_until=now + dt.timedelta(days=5),
+            status="active",
+        )
+
+    session.add(_alert("good", "AAA"))
+    session.add(_alert("bad", "BBB"))
+    await session.flush()
+
+    # Force the projection of the "BBB" alert to raise; the panel must survive.
+    from app.services.invest_view_model import watch_panel_service as mod
+
+    real_build = mod._build_watch_row
+
+    def _flaky(alert, **kwargs):
+        if alert.symbol == "BBB":
+            raise ValueError("boom")
+        return real_build(alert, **kwargs)
+
+    monkeypatch.setattr(mod, "_build_watch_row", _flaky)
+
+    service = WatchPanelService(db=session, clock=now)
+    resp = await service.list_watches(market="us", status="all")
+
+    assert resp.count == 1
+    assert resp.items[0].symbol == "AAA"
+    assert any("could not be displayed" in w for w in resp.warnings)


### PR DESCRIPTION
## 증상

배포 직후 `/invest/my` 감시 탭(+ 종목상세 감시 카드)에서 **`watches 500`**. Sentry [AUTO_TRADER-2B1](https://mgh3326-daum.sentry.io/issues/7559056226/).

Closes [ROB-599](https://linear.app/mgh3326/issue/ROB-599). ROB-591/592 후속 버그.

## 근본 원인

`WatchAlertRow.trigger_checklist`를 **`list[dict]`** 로 타이핑(ROB-591)했는데, 실제 alert 테이블·계약은 **`list[str]`**:

```
ValidationError: 3 validation errors for WatchAlertRow
trigger_checklist.0  Input should be a valid dictionary
  [input_value='BTC 현재가 조회 확인', input_type=str]
```

체크리스트가 있는 워치가 1건이라도 있으면 **패널 응답 전체가 500**. (모델 `Mapped[list]`, CLAUDE.md "trigger_checklist: string[]".) ROB-591/592 테스트가 전부 빈 `[]`만 써서 못 잡음.

## 수정

1. **스키마**: `trigger_checklist: list[dict] → list[str]` (`app/schemas/invest_watches.py`).
2. **per-row 격리**: per-alert projection을 `_build_watch_row`로 추출 + 빌드 루프를 `try/except`로 감싸 **단일 이상 행이 패널 전체 500을 내지 않게** skip(로깅 + 응답 `warnings`에 "N건 표시 불가"). 체크리스트 항목은 `str()` 방어적 강제. read-only 패널이 단일 행 이상치로 전면 불능되던 fragility 제거.
3. **테스트**: 문자열 `trigger_checklist` round-trip(직접 repro) + per-row skip 가드.

## 무관

화면 하단 `toss_api 429 rate-limit-exceeded`는 ROB-562 degraded surface의 비치명 경고(레이트리미터 정상). 이 500과 별개 — 손대지 않음.

## 검증

- ✅ `ruff check app/ tests/` + `ruff format --check` + `ty check app/ --error-on-warning` clean
- ✅ watch 서비스+라우터 8/8 통과 (round-trip·US 정규화·skip 가드 포함)
- migration 0, 프런트 무변경(`trigger_checklist: any[]` agnostic)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience of the watch alerts panel—individual alerts that fail to process no longer prevent the entire panel from rendering.
  * Added warning message informing users when watch items cannot be displayed due to underlying data issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->