### PR TITLE
feat(ROB-601): surface kiwoom_mock_* in DEFAULT MCP profile behind KIWOOM_MOCK_ENABLED

### DIFF
--- a/app/mcp_server/tooling/registry.py
+++ b/app/mcp_server/tooling/registry.py
@@ -171,6 +171,14 @@ def register_all_tools(mcp: FastMCP, profile: McpProfile = McpProfile.DEFAULT) -
         register_kis_mock_order_tools(mcp)
         register_live_reconcile_tools(mcp)
         register_toss_live_order_tools(mcp)
+        # ROB-601: optionally surface kiwoom_mock_* in the operator DEFAULT
+        # session so analyze→approval→order can run through kiwoom mock without
+        # switching to the isolated KIWOOM profile (which drops every other
+        # broker's order surface). Gated by ``settings.kiwoom_mock_enabled`` so
+        # the tools are physically absent unless the operator opts in; each tool
+        # still fail-closes on missing credentials at call time.
+        if settings.kiwoom_mock_enabled:
+            orders_kiwoom_variants.register(mcp)
     elif profile is McpProfile.HERMES_PAPER_KIS:
         # Paper-only: only mock-pinned order surface. Live surface is physically absent.
         register_kis_mock_order_tools(mcp)

--- a/env.example
+++ b/env.example
@@ -26,6 +26,22 @@ KIS_MOCK_APP_SECRET=
 KIS_MOCK_ACCOUNT_NO=
 KIS_MOCK_BASE_URL=https://openapivts.koreainvestment.com:29443
 KIS_MOCK_ACCESS_TOKEN=
+
+# Kiwoom Securities mock/sandbox account settings (mock host only).
+# Keep credential values in operator-managed runtime env files; do not commit them.
+# ROB-601: set KIWOOM_MOCK_ENABLED=true to also surface kiwoom_mock_* tools in the
+# DEFAULT MCP profile (otherwise they live only under MCP_PROFILE=kiwoom). Tools
+# fail closed without real credentials regardless of the flag.
+# The credential keys stay commented so they default to None (not "") when this
+# file is sourced into the test/CI env via scripts/setup-test-env.sh —
+# test_kiwoom_mock_config asserts None defaults. Operators uncomment and fill
+# them in their own runtime env file.
+KIWOOM_MOCK_ENABLED=false
+# KIWOOM_MOCK_APP_KEY=
+# KIWOOM_MOCK_APP_SECRET=
+# KIWOOM_MOCK_ACCOUNT_NO=
+KIWOOM_MOCK_BASE_URL=https://mockapi.kiwoom.com
+# KIWOOM_MOCK_ACCESS_TOKEN=
 MCP_PROFILE=default
 
 # KIS WebSocket 설정

--- a/tests/test_mcp_profiles.py
+++ b/tests/test_mcp_profiles.py
@@ -97,10 +97,11 @@ class TestDefaultProfile:
         assert TOSS_LIVE_ORDER_TOOL_NAMES <= mcp.tools.keys()
 
     def test_does_not_register_split_profile_tools(self) -> None:
+        # US/DB paper surfaces are profile-isolated and never appear in DEFAULT.
+        # kiwoom_mock_* is flag-gated in DEFAULT (ROB-601) — its presence/absence
+        # is owned by ``TestKiwoomDefaultProfileGate``, not this assertion.
         mcp = _build_mcp(McpProfile.DEFAULT)
-        split_only = (
-            _US_PAPER_TOOL_NAMES | _DB_PAPER_TOOL_NAMES | KIWOOM_MOCK_TOOL_NAMES
-        )
+        split_only = _US_PAPER_TOOL_NAMES | _DB_PAPER_TOOL_NAMES
         assert split_only.isdisjoint(mcp.tools.keys())
 
 
@@ -190,6 +191,34 @@ class TestKiwoomProfile:
     def test_registers_kiwoom_mock_tools(self) -> None:
         mcp = _build_mcp(McpProfile.KIWOOM)
         assert KIWOOM_MOCK_TOOL_NAMES <= mcp.tools.keys()
+
+
+class TestKiwoomDefaultProfileGate:
+    """ROB-601: kiwoom_mock_* tools surface in the operator DEFAULT profile when
+    ``settings.kiwoom_mock_enabled`` is true, so analyze→approval→order can run
+    through kiwoom mock in the everyday session (the isolated KIWOOM profile
+    drops every other broker's order surface and cannot substitute it).
+
+    The flag defaults to ``False`` so the out-of-box DEFAULT surface is
+    unchanged (pinned by ``TestOrderSurfaceMatrix``); fail-closed runtime config
+    validation still blocks any tool call without real credentials.
+    """
+
+    def test_registers_kiwoom_mock_in_default_when_flag_enabled(
+        self, monkeypatch
+    ) -> None:
+        from app.core.config import settings
+
+        monkeypatch.setattr(settings, "kiwoom_mock_enabled", True)
+        mcp = _build_mcp(McpProfile.DEFAULT)
+        assert KIWOOM_MOCK_TOOL_NAMES <= mcp.tools.keys()
+
+    def test_omits_kiwoom_mock_in_default_when_flag_disabled(self, monkeypatch) -> None:
+        from app.core.config import settings
+
+        monkeypatch.setattr(settings, "kiwoom_mock_enabled", False)
+        mcp = _build_mcp(McpProfile.DEFAULT)
+        assert KIWOOM_MOCK_TOOL_NAMES.isdisjoint(mcp.tools.keys())
 
 
 _ALPACA_MUTATING = ALPACA_PAPER_MUTATING_TOOL_NAMES


### PR DESCRIPTION
## 요약 (ROB-601)

키움 모의 주문 풀스택(`kiwoom_mock_*` 7종, ROB-97/319/522~527)은 구현돼 있으나, ROB-488(PR#1226)의 프로파일 분리 이후 **`MCP_PROFILE=default` 운영 세션에 0개 노출**되어 운영자가 평소 세션에서 키움 모의로 분석→승인→주문 루프를 못 태웠습니다. `MCP_PROFILE=kiwoom` 프로파일은 키움 외 모든 브로커 주문 표면이 빠진 **고립 프로파일**이라 평상 세션을 대체할 수 없습니다 (요청 옵션 (b) 부적합).

이 PR은 요청 옵션 **(a)** — `KIWOOM_MOCK_ENABLED=true`면 DEFAULT 프로파일에도 키움 모의 도구를 옵션 게이트로 노출합니다.

## 변경

- **`registry.py`**: DEFAULT 분기에 `if settings.kiwoom_mock_enabled: orders_kiwoom_variants.register(mcp)` 추가. 바로 위 `INVESTMENT_SNAPSHOTS_MCP_ENABLED` 게이트와 동일 패턴. 플래그 기본 `False` → out-of-box DEFAULT 표면 **무변경**. 각 도구는 자격증명 없으면 호출 시점에 fail-closed(이중 방어). **KIWOOM 프로파일 분기는 그대로 유지**(하위호환).
- **`env.example`**: `KIWOOM_MOCK_*` 6키 문서화(mock 호스트 전용).
- **tests**: 신규 `TestKiwoomDefaultProfileGate`(플래그 ON→노출 / OFF→부재). 키움이 이제 DEFAULT에서 플래그 게이트이므로 `test_does_not_register_split_profile_tools`에서 키움 제거(의미론은 신규 클래스가 소유). `TestOrderSurfaceMatrix`의 default 핀은 플래그 OFF 기본값이라 그대로 유효.

## 검증

- `tests/test_mcp_profiles.py` **51 passed** (프로파일별 order 표면 매트릭스 핀 포함)
- 키움 variant/guard **74 passed**, registration boot **7 passed**, account_routing pass
- `ruff check` / `ruff format --check` / `ty check` **clean**
- **migration 0**, 라이브 주문 경로 무변경, 플래그 OFF 기본 → 안전 병합 가능

## 운영자 액션 (코드 아님)

1. `.env(.env.prod.native)`에 실 키움 모의 자격증명 주입 (`KIWOOM_MOCK_APP_KEY/APP_SECRET/ACCOUNT_NO`)
2. `KIWOOM_MOCK_ENABLED=true`
3. MCP 서버 재시작
4. `kiwoom_mock_*` ToolSearch 노출 확인 + 분석→승인→주문 스모크

## 범위 밖 (별도 follow-up)

- 집계 read 라우팅: `get_holdings`/`get_available_capital`가 `account_mode='kiwoom_mock'` 미라우팅 (현재 전용 도구로만 읽힘). KIS mock과의 read 대칭 — 설계 차이지 버그 아님, PR-1 차단요소 아님.
- 키움 모의 reconcile 잡(`kis_mock_reconciliation_run` 대응물) — accepted≠filled 부킹/실현손익.

## 참고: 무관한 선재 결함

`tests/test_mcp_server_main.py` 11개 실패는 **이 PR과 무관**하며 baseline(이 변경 제거)에서도 동일하게 실패합니다. 근본 원인은 ROB-469 PR2(#1200, 54cc0a0f)가 `main.py`에 `app.mcp_server.timeout_middleware` import를 추가했으나 `_load_main_module` 테스트 헬퍼의 sys.modules stub이 갱신되지 않은 것 — 별도 follow-up으로 추적.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017BYGfwL63UjEptW5gDmqWz


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Kiwoom mock order tools are now available in the DEFAULT profile when enabled via the `KIWOOM_MOCK_ENABLED` flag, without requiring profile switching.

* **Chores**
  * Added environment variables for Kiwoom mock sandbox configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->