### PR TITLE
fix(ROB-600): kis_mock KR 주문/잔고 타임아웃 빈에러→구체사유 + mock read 타임아웃 5→10 + summary.unavailable_sources

### DIFF
--- a/app/core/exceptions.py
+++ b/app/core/exceptions.py
@@ -1,0 +1,18 @@
+"""Shared exception helpers."""
+
+from __future__ import annotations
+
+
+def describe_exception(exc: BaseException) -> str:
+    """Return a non-empty, concrete reason string for an exception.
+
+    httpx timeout exceptions (ReadTimeout / ConnectTimeout / PoolTimeout, ...) are
+    frequently constructed with no message, so ``str(exc)`` yields ``""``. Surfacing
+    that empty string as a user-facing ``error`` makes timeouts undiagnosable
+    (ROB-600). When the message is empty/whitespace, fall back to the exception class
+    name so e.g. ``ReadTimeout`` is shown instead of ``""``.
+
+    Consolidates the ``str(exc) or exc.__class__.__name__`` idiom scattered across the
+    codebase.
+    """
+    return str(exc).strip() or type(exc).__name__

--- a/app/mcp_server/tooling/order_execution.py
+++ b/app/mcp_server/tooling/order_execution.py
@@ -13,6 +13,7 @@ from typing import Any, Literal
 from typing import cast as typing_cast
 
 import app.services.brokers.upbit.client as upbit_service
+from app.core.exceptions import describe_exception
 from app.mcp_server.caller_identity import get_caller_source
 from app.mcp_server.tick_size import adjust_tick_size_kr, get_tick_size_kr
 from app.mcp_server.tooling.order_journal import (
@@ -24,7 +25,6 @@ from app.mcp_server.tooling.order_journal import (
     _save_order_fill,
     _validate_buy_journal_requirements,
 )
-from app.core.exceptions import describe_exception
 from app.mcp_server.tooling.order_validation import (
     DefensiveTrimContext,
     ScalpingExitContext,

--- a/app/mcp_server/tooling/order_execution.py
+++ b/app/mcp_server/tooling/order_execution.py
@@ -24,6 +24,7 @@ from app.mcp_server.tooling.order_journal import (
     _save_order_fill,
     _validate_buy_journal_requirements,
 )
+from app.core.exceptions import describe_exception
 from app.mcp_server.tooling.order_validation import (
     DefensiveTrimContext,
     ScalpingExitContext,
@@ -1125,7 +1126,7 @@ async def _place_order_impl(
             amount=0,
             reason=reason,
             dry_run=True,
-            error=str(exc),
+            error=describe_exception(exc),
             defensive_trim=defensive_trim_ctx is not None,
             approval_issue_id=(
                 defensive_trim_ctx.approval_issue_id if defensive_trim_ctx else None
@@ -1135,7 +1136,7 @@ async def _place_order_impl(
             ),
             caller_source=get_caller_source() if defensive_trim_ctx else None,
         )
-        return _order_error(str(exc))
+        return _order_error(describe_exception(exc))
 
 
 __all__ = [

--- a/app/mcp_server/tooling/portfolio_cash.py
+++ b/app/mcp_server/tooling/portfolio_cash.py
@@ -26,6 +26,7 @@ from app.services.brokers.kis import (
     KISClient,
     extract_domestic_cash_summary_from_integrated_margin,
 )
+from app.core.exceptions import describe_exception
 from app.services.exchange_rate_service import get_usd_krw_rate as _get_usd_krw_rate
 from app.services.toss_portfolio_service import fetch_toss_cash_snapshot
 
@@ -117,12 +118,17 @@ async def get_cash_balance_impl(
         )
         return {
             "accounts": rows,
-            "summary": {"total_krw": total_krw, "total_usd": total_usd},
+            "summary": {
+                "total_krw": total_krw,
+                "total_usd": total_usd,
+                "unavailable_sources": {},
+            },
             "errors": errors,
         }
 
     accounts: list[dict[str, Any]] = []
     errors: list[dict[str, Any]] = []
+    unavailable_sources: dict[str, str] = {}
     total_krw = 0.0
     total_usd = 0.0
 
@@ -171,9 +177,11 @@ async def get_cash_balance_impl(
                     raise RuntimeError(
                         f"Toss cash balance query failed: {exc}"
                     ) from exc
+                reason = describe_exception(exc)
                 errors.append(
-                    {"source": "toss_api", "market": "cash", "error": str(exc)}
+                    {"source": "toss_api", "market": "cash", "error": reason}
                 )
+                unavailable_sources["toss"] = reason
 
     if account_filter is None or account_filter in ("upbit",):
         try:
@@ -193,7 +201,9 @@ async def get_cash_balance_impl(
             )
             total_krw += krw_balance
         except Exception as exc:
-            errors.append({"source": "upbit", "market": "crypto", "error": str(exc)})
+            reason = describe_exception(exc)
+            errors.append({"source": "upbit", "market": "crypto", "error": reason})
+            unavailable_sources["upbit"] = reason
 
     if account_filter is None or account_filter in (
         "kis",
@@ -249,17 +259,17 @@ async def get_cash_balance_impl(
                     raise RuntimeError(
                         f"KIS domestic cash balance query failed: {exc}"
                     ) from exc
-                errors.append({"source": "kis", "market": "kr", "error": str(exc)})
+                reason = describe_exception(exc)
+                errors.append({"source": "kis", "market": "kr", "error": reason})
+                unavailable_sources["kis_domestic"] = reason
 
         if account_filter is None or account_filter in ("kis", "kis_overseas"):
             if is_mock:
-                errors.append(
-                    {
-                        "source": "kis",
-                        "market": "us",
-                        "error": "mock_unsupported: KIS overseas margin is not available in mock mode",
-                    }
+                reason = (
+                    "mock_unsupported: KIS overseas margin is not available in mock mode"
                 )
+                errors.append({"source": "kis", "market": "us", "error": reason})
+                unavailable_sources["kis_overseas"] = reason
             else:
                 try:
                     overseas_margin_data = await _call_kis(
@@ -300,13 +310,16 @@ async def get_cash_balance_impl(
                         raise RuntimeError(
                             f"KIS overseas cash balance query failed: {exc}"
                         ) from exc
-                    errors.append({"source": "kis", "market": "us", "error": str(exc)})
+                    reason = describe_exception(exc)
+                    errors.append({"source": "kis", "market": "us", "error": reason})
+                    unavailable_sources["kis_overseas"] = reason
 
     return {
         "accounts": accounts,
         "summary": {
             "total_krw": total_krw,
             "total_usd": total_usd,
+            "unavailable_sources": unavailable_sources,
         },
         "errors": errors,
     }

--- a/app/mcp_server/tooling/portfolio_cash.py
+++ b/app/mcp_server/tooling/portfolio_cash.py
@@ -451,6 +451,11 @@ async def get_available_capital_impl(
             "manual_cash_excluded_krw": manual_cash_excluded_krw,
             "exchange_rate_usd_krw": exchange_rate,
             "as_of": now_kst().isoformat(),
+            # ROB-600: propagate per-source lookup failures so a failed KIS read is
+            # not mistaken for 0 orderable cash.
+            "unavailable_sources": cash_result.get("summary", {}).get(
+                "unavailable_sources", {}
+            ),
         },
         "errors": errors,
     }

--- a/app/mcp_server/tooling/portfolio_cash.py
+++ b/app/mcp_server/tooling/portfolio_cash.py
@@ -8,6 +8,7 @@ from typing import Any
 
 import app.services.brokers.upbit.client as upbit_service
 from app.core.config import settings
+from app.core.exceptions import describe_exception
 from app.core.timezone import now_kst
 from app.mcp_server.tooling.account_modes import toss_live_mutations_enabled
 from app.mcp_server.tooling.shared import (
@@ -26,7 +27,6 @@ from app.services.brokers.kis import (
     KISClient,
     extract_domestic_cash_summary_from_integrated_margin,
 )
-from app.core.exceptions import describe_exception
 from app.services.exchange_rate_service import get_usd_krw_rate as _get_usd_krw_rate
 from app.services.toss_portfolio_service import fetch_toss_cash_snapshot
 
@@ -178,9 +178,7 @@ async def get_cash_balance_impl(
                         f"Toss cash balance query failed: {exc}"
                     ) from exc
                 reason = describe_exception(exc)
-                errors.append(
-                    {"source": "toss_api", "market": "cash", "error": reason}
-                )
+                errors.append({"source": "toss_api", "market": "cash", "error": reason})
                 unavailable_sources["toss"] = reason
 
     if account_filter is None or account_filter in ("upbit",):
@@ -265,9 +263,7 @@ async def get_cash_balance_impl(
 
         if account_filter is None or account_filter in ("kis", "kis_overseas"):
             if is_mock:
-                reason = (
-                    "mock_unsupported: KIS overseas margin is not available in mock mode"
-                )
+                reason = "mock_unsupported: KIS overseas margin is not available in mock mode"
                 errors.append({"source": "kis", "market": "us", "error": reason})
                 unavailable_sources["kis_overseas"] = reason
             else:

--- a/app/services/brokers/kis/account.py
+++ b/app/services/brokers/kis/account.py
@@ -562,7 +562,10 @@ class AccountClient:
             self._parent._kis_url(constants.DOMESTIC_BALANCE_URL),
             headers=hdr,
             params=params,
-            timeout=5,
+            # ROB-600: mock VTS(openapivts) responds slowly near the 5s boundary →
+            # intermittent ReadTimeout. Mock read uses 10s (mirrors ROB-270); live
+            # host stays at 5s. No order-send timeout change (double-submit risk).
+            timeout=10 if is_mock else 5,
             api_name="inquire_domestic_cash_balance",
             tr_id=tr_id,
         )

--- a/app/services/brokers/kis/base.py
+++ b/app/services/brokers/kis/base.py
@@ -17,6 +17,7 @@ import httpx
 
 from app.core.async_rate_limiter import RateLimitExceededError, get_limiter
 from app.core.config import settings
+from app.core.exceptions import describe_exception
 from app.services.redis_token_manager import redis_token_manager
 
 
@@ -544,7 +545,7 @@ class BaseKISClient:
                         "[%s] Request error for %s: %s, attempt %d/%d, retrying in %.3fs",
                         "kis",
                         api_name,
-                        e,
+                        describe_exception(e),
                         attempt + 1,
                         max_retries + 1,
                         wait_time,
@@ -554,7 +555,8 @@ class BaseKISClient:
                 raise
 
         raise RateLimitExceededError(
-            f"KIS rate limit retries exhausted for {api_name}: {last_error}"
+            f"KIS rate limit retries exhausted for {api_name}: "
+            f"{describe_exception(last_error) if last_error is not None else 'rate limited'}"
         )
 
     def _get_rate_limit_for_api(self, api_key: str) -> tuple[int, float]:

--- a/docs/superpowers/plans/2026-06-19-rob600-kis-mock-kr-timeout.md
+++ b/docs/superpowers/plans/2026-06-19-rob600-kis-mock-kr-timeout.md
@@ -1,0 +1,865 @@
+# ROB-600 kis_mock KR Timeout / Empty-Error Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** kis_mock KR-domestic 주문/잔고의 간헐적 타임아웃이 진단 불가능한 빈 에러("")로 표면화되는 것을 고친다 — 구체 사유 노출 + mock read 타임아웃 상향 + 잔고 조회실패를 정직하게 표시.
+
+**Architecture:** (a) 공용 `describe_exception` 헬퍼로 빈 예외 문자열을 클래스명으로 폴백(`order_execution`, `portfolio_cash`, `kis/base` 호출부). (b) `inquire_domestic_cash_balance`의 read 타임아웃을 mock일 때 5→10초. (c) `get_cash_balance_impl`/`get_available_capital_impl`의 `summary`에 `unavailable_sources` dict를 additive로 추가(placeholder row 미사용 → live precheck 회귀 방지). DB 마이그레이션 0, MCP 계약 하위호환.
+
+**Tech Stack:** Python 3.13, pytest / pytest-asyncio, httpx, unittest.mock. uv 런너.
+
+## Global Constraints
+
+- **주문 전송(place/cancel/modify)에는 타임아웃 재시도를 추가하지 않는다** (double-submit 위험; ROB-585 스코프). 이 플랜은 `domestic_orders.py`/`overseas_orders.py`를 건드리지 않는다.
+- **DB 마이그레이션 0** — 스키마/모델 변경 없음.
+- **MCP 계약은 additive only** — `summary.unavailable_sources`(신규 optional `dict[str,str]`), error 문자열이 빈→비-빈으로만 변경.
+- `unavailable_sources` shape = `dict[str, str]` (`{account_key: reason}`), 코드베이스 기존 관용구와 동일.
+- live/US read 타임아웃, 기존 ~10곳 `str(exc) or __class__.__name__` 일괄 마이그레이션은 **스코프 밖**.
+- 모든 테스트는 DB/실네트워크 없이 모킹으로 구성. 명령은 `uv run pytest ...`.
+- 커밋 메시지 footer:
+  ```
+  Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+  Claude-Session: https://claude.ai/code/session_01QTE5SngqNmNPp8Dx9hdwUU
+  ```
+
+---
+
+### Task 1: `describe_exception` 공용 헬퍼
+
+**Files:**
+- Create: `app/core/exceptions.py`
+- Test: `tests/core/test_exceptions.py`
+
+**Interfaces:**
+- Produces: `describe_exception(exc: BaseException) -> str` — 비어있지 않은 구체 사유(메시지 없으면 클래스명).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/core/test_exceptions.py`:
+
+```python
+import httpx
+
+from app.core.exceptions import describe_exception
+
+
+def test_empty_message_falls_back_to_class_name():
+    assert describe_exception(httpx.ReadTimeout("")) == "ReadTimeout"
+    assert describe_exception(httpx.ConnectTimeout("")) == "ConnectTimeout"
+
+
+def test_whitespace_only_message_falls_back_to_class_name():
+    assert describe_exception(ValueError("   ")) == "ValueError"
+
+
+def test_nonempty_message_is_preserved():
+    assert describe_exception(RuntimeError("EGW00201 초당 거래건수 초과")) == (
+        "EGW00201 초당 거래건수 초과"
+    )
+    assert describe_exception(httpx.ReadTimeout("Read timed out")) == "Read timed out"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/core/test_exceptions.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'app.core.exceptions'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `app/core/exceptions.py`:
+
+```python
+"""Shared exception helpers."""
+
+from __future__ import annotations
+
+
+def describe_exception(exc: BaseException) -> str:
+    """Return a non-empty, concrete reason string for an exception.
+
+    httpx timeout exceptions (ReadTimeout / ConnectTimeout / PoolTimeout, ...) are
+    frequently constructed with no message, so ``str(exc)`` yields ``""``. Surfacing
+    that empty string as a user-facing ``error`` makes timeouts undiagnosable
+    (ROB-600). When the message is empty/whitespace, fall back to the exception class
+    name so e.g. ``ReadTimeout`` is shown instead of ``""``.
+
+    Consolidates the ``str(exc) or exc.__class__.__name__`` idiom scattered across the
+    codebase.
+    """
+    return str(exc).strip() or type(exc).__name__
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/core/test_exceptions.py -v`
+Expected: PASS (3 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/core/exceptions.py tests/core/test_exceptions.py
+git commit -m "feat(ROB-600): describe_exception helper — non-empty reason for empty-str exceptions
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01QTE5SngqNmNPp8Dx9hdwUU"
+```
+
+---
+
+### Task 2: (a) order-send 빈에러 → 구체사유 (`order_execution.py`)
+
+**Files:**
+- Modify: `app/mcp_server/tooling/order_execution.py` (import; `:1128` `error=`; `:1138` `_order_error`)
+- Test: `tests/test_mcp_place_order.py` (append)
+
+**Interfaces:**
+- Consumes: `describe_exception` (Task 1).
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_mcp_place_order.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_place_order_readtimeout_surfaces_class_name(monkeypatch):
+    """ROB-600: a ReadTimeout during execution must surface 'ReadTimeout', not ''."""
+    import httpx
+
+    from app.mcp_server.tooling import order_execution
+
+    recorded = AsyncMock()
+    monkeypatch.setattr(
+        order_execution,
+        "_resolve_market_type",
+        lambda symbol, market: ("equity_kr", "005930"),
+    )
+    monkeypatch.setattr(order_execution, "_record_order_history", recorded)
+    monkeypatch.setattr(
+        order_execution,
+        "_fetch_current_price",
+        AsyncMock(side_effect=httpx.ReadTimeout("")),
+    )
+
+    result = await order_execution._place_order_impl(
+        symbol="005930",
+        side="sell",
+        order_type="limit",
+        quantity=1,
+        price=370000.0,
+        dry_run=False,
+        is_mock=True,
+    )
+
+    assert result["success"] is False
+    assert result["error"] == "ReadTimeout"
+    assert result["source"] == "kis"
+    # :1128 — order-history record also gets the concrete reason, not ""
+    assert recorded.await_args.kwargs["error"] == "ReadTimeout"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_mcp_place_order.py::test_place_order_readtimeout_surfaces_class_name -v`
+Expected: FAIL — `assert '' == 'ReadTimeout'` (current code uses bare `str(exc)`)
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `app/mcp_server/tooling/order_execution.py`, add the import next to the existing `from app.mcp_server.tooling.shared import ...` block (around line 41):
+
+```python
+from app.core.exceptions import describe_exception
+```
+
+Change the `_record_order_history` call inside the outer `except Exception as exc:` block (line ~1128) from:
+
+```python
+            error=str(exc),
+```
+to:
+```python
+            error=describe_exception(exc),
+```
+
+Change the final return (line ~1138) from:
+
+```python
+        return _order_error(str(exc))
+```
+to:
+```python
+        return _order_error(describe_exception(exc))
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_mcp_place_order.py::test_place_order_readtimeout_surfaces_class_name -v`
+Expected: PASS
+
+- [ ] **Step 5: Run the surrounding suite to confirm no regression**
+
+Run: `uv run pytest tests/test_mcp_place_order.py -q`
+Expected: PASS (all existing tests still green)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/mcp_server/tooling/order_execution.py tests/test_mcp_place_order.py
+git commit -m "fix(ROB-600): order-send timeout surfaces concrete reason, not empty error
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01QTE5SngqNmNPp8Dx9hdwUU"
+```
+
+---
+
+### Task 3: (b) mock read 타임아웃 5→10 (`account.py`)
+
+**Files:**
+- Modify: `app/services/brokers/kis/account.py:565` (`inquire_domestic_cash_balance` timeout)
+- Test: `tests/services/brokers/kis/test_account_cash_timeout.py` (create)
+
+**Interfaces:**
+- `AccountClient(parent).inquire_domestic_cash_balance(is_mock: bool) -> dict` — request timeout is `10` when `is_mock=True`, else `5`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/services/brokers/kis/test_account_cash_timeout.py`:
+
+```python
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.services.brokers.kis.account import AccountClient
+
+
+class _Settings:
+    kis_account_no = "12345678-01"
+    kis_access_token = "tok"
+
+
+def _make_account_client():
+    parent = MagicMock()
+    parent._settings = _Settings()
+    parent._ensure_token = AsyncMock()
+    parent._hdr_base = {}
+    parent._kis_url = lambda path: f"https://host{path}"
+    parent._request_with_rate_limit = AsyncMock(
+        return_value={"rt_cd": "0", "output2": [{}]}
+    )
+    return AccountClient(parent), parent
+
+
+@pytest.mark.asyncio
+async def test_inquire_domestic_cash_balance_mock_uses_10s_timeout():
+    """ROB-600: mock VTS is slow near the 5s boundary; mock read uses 10s."""
+    client, parent = _make_account_client()
+    await client.inquire_domestic_cash_balance(is_mock=True)
+    assert parent._request_with_rate_limit.call_args.kwargs["timeout"] == 10
+
+
+@pytest.mark.asyncio
+async def test_inquire_domestic_cash_balance_live_keeps_5s_timeout():
+    client, parent = _make_account_client()
+    await client.inquire_domestic_cash_balance(is_mock=False)
+    assert parent._request_with_rate_limit.call_args.kwargs["timeout"] == 5
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/services/brokers/kis/test_account_cash_timeout.py -v`
+Expected: FAIL on the mock case — `assert 5 == 10` (current code hardcodes `timeout=5`)
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `app/services/brokers/kis/account.py`, inside `inquire_domestic_cash_balance` (the `_request_with_rate_limit` call near line 560-568), change:
+
+```python
+            timeout=5,
+```
+to:
+```python
+            # ROB-600: mock VTS(openapivts) responds slowly near the 5s boundary →
+            # intermittent ReadTimeout. Mock read uses 10s (mirrors ROB-270); live
+            # host stays at 5s. No order-send timeout change (double-submit risk).
+            timeout=10 if is_mock else 5,
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/services/brokers/kis/test_account_cash_timeout.py -v`
+Expected: PASS (2 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/brokers/kis/account.py tests/services/brokers/kis/test_account_cash_timeout.py
+git commit -m "fix(ROB-600): mock domestic cash read timeout 5->10s (slow openapivts boundary)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01QTE5SngqNmNPp8Dx9hdwUU"
+```
+
+---
+
+### Task 4: (a)+(c) `get_cash_balance_impl` — 구체사유 + `unavailable_sources`
+
+**Files:**
+- Modify: `app/mcp_server/tooling/portfolio_cash.py` (import; `unavailable_sources` 누적 at toss/upbit/kis_kr/kis_us; summary 추가; paper-path summary)
+- Test: `tests/test_portfolio_cash_kis_mock.py` (append)
+
+**Interfaces:**
+- Consumes: `describe_exception` (Task 1).
+- Produces: `get_cash_balance_impl(...)["summary"]["unavailable_sources"] : dict[str, str]` — `{account_key: reason}`, 실패 없으면 `{}`. `accounts[]`엔 실패 source row를 추가하지 않는다.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_portfolio_cash_kis_mock.py` (top already imports `AsyncMock, MagicMock, pytest, portfolio_cash`; add `import httpx` at the top of the file):
+
+```python
+@pytest.mark.asyncio
+async def test_cash_balance_mock_kis_timeout_surfaces_reason_and_marks_unavailable(
+    monkeypatch,
+):
+    """ROB-600: a KIS read timeout must (1) surface 'ReadTimeout' (not ''),
+    (2) appear in summary.unavailable_sources, (3) NOT add a kis_domestic row,
+    (4) leave total_krw excluding KIS."""
+    fake_kis = MagicMock()
+    fake_kis.inquire_domestic_cash_balance = AsyncMock(side_effect=httpx.ReadTimeout(""))
+
+    monkeypatch.setattr(
+        portfolio_cash, "_create_kis_client", lambda *, is_mock: fake_kis
+    )
+    monkeypatch.setattr(
+        portfolio_cash.upbit_service,
+        "fetch_krw_cash_summary",
+        AsyncMock(return_value={"balance": 0.0, "orderable": 0.0}),
+    )
+
+    result = await portfolio_cash.get_cash_balance_impl(is_mock=True)
+
+    # (1) concrete reason, not empty
+    kis_kr_err = next(
+        e for e in result["errors"] if e["source"] == "kis" and e["market"] == "kr"
+    )
+    assert kis_kr_err["error"] == "ReadTimeout"
+    # (2) machine-readable unavailable flag
+    assert result["summary"]["unavailable_sources"]["kis_domestic"] == "ReadTimeout"
+    # (3) no placeholder row injected
+    assert "kis_domestic" not in {a["account"] for a in result["accounts"]}
+    # (4) KIS cash not silently summed as a number
+    assert result["summary"]["total_krw"] == pytest.approx(0.0)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_portfolio_cash_kis_mock.py::test_cash_balance_mock_kis_timeout_surfaces_reason_and_marks_unavailable -v`
+Expected: FAIL — `KeyError: 'unavailable_sources'` (summary has no such key yet) and the error would be `""` not `"ReadTimeout"`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `app/mcp_server/tooling/portfolio_cash.py`:
+
+3a. Add the import near the top (with the other `from app...` imports):
+
+```python
+from app.core.exceptions import describe_exception
+```
+
+3b. Initialize the accumulator next to `errors` (the non-paper branch, around line 124-127). Change:
+
+```python
+    accounts: list[dict[str, Any]] = []
+    errors: list[dict[str, Any]] = []
+    total_krw = 0.0
+    total_usd = 0.0
+```
+to:
+```python
+    accounts: list[dict[str, Any]] = []
+    errors: list[dict[str, Any]] = []
+    unavailable_sources: dict[str, str] = {}
+    total_krw = 0.0
+    total_usd = 0.0
+```
+
+3c. Toss except (around line 169-176). Change:
+
+```python
+            except Exception as exc:
+                if strict_mode:
+                    raise RuntimeError(
+                        f"Toss cash balance query failed: {exc}"
+                    ) from exc
+                errors.append(
+                    {"source": "toss_api", "market": "cash", "error": str(exc)}
+                )
+```
+to:
+```python
+            except Exception as exc:
+                if strict_mode:
+                    raise RuntimeError(
+                        f"Toss cash balance query failed: {exc}"
+                    ) from exc
+                reason = describe_exception(exc)
+                errors.append(
+                    {"source": "toss_api", "market": "cash", "error": reason}
+                )
+                unavailable_sources["toss"] = reason
+```
+
+3d. Upbit except (around line 195-196). Change:
+
+```python
+        except Exception as exc:
+            errors.append({"source": "upbit", "market": "crypto", "error": str(exc)})
+```
+to:
+```python
+        except Exception as exc:
+            reason = describe_exception(exc)
+            errors.append({"source": "upbit", "market": "crypto", "error": reason})
+            unavailable_sources["upbit"] = reason
+```
+
+3e. KIS domestic except (around line 247-252). Change:
+
+```python
+            except Exception as exc:
+                if strict_mode:
+                    raise RuntimeError(
+                        f"KIS domestic cash balance query failed: {exc}"
+                    ) from exc
+                errors.append({"source": "kis", "market": "kr", "error": str(exc)})
+```
+to:
+```python
+            except Exception as exc:
+                if strict_mode:
+                    raise RuntimeError(
+                        f"KIS domestic cash balance query failed: {exc}"
+                    ) from exc
+                reason = describe_exception(exc)
+                errors.append({"source": "kis", "market": "kr", "error": reason})
+                unavailable_sources["kis_domestic"] = reason
+```
+
+3f. KIS overseas mock_unsupported (around line 255-262). Change:
+
+```python
+            if is_mock:
+                errors.append(
+                    {
+                        "source": "kis",
+                        "market": "us",
+                        "error": "mock_unsupported: KIS overseas margin is not available in mock mode",
+                    }
+                )
+```
+to:
+```python
+            if is_mock:
+                reason = (
+                    "mock_unsupported: KIS overseas margin is not available in mock mode"
+                )
+                errors.append({"source": "kis", "market": "us", "error": reason})
+                unavailable_sources["kis_overseas"] = reason
+```
+
+3g. KIS overseas except (around line 298-303). Change:
+
+```python
+                except Exception as exc:
+                    if strict_mode:
+                        raise RuntimeError(
+                            f"KIS overseas cash balance query failed: {exc}"
+                        ) from exc
+                    errors.append({"source": "kis", "market": "us", "error": str(exc)})
+```
+to:
+```python
+                except Exception as exc:
+                    if strict_mode:
+                        raise RuntimeError(
+                            f"KIS overseas cash balance query failed: {exc}"
+                        ) from exc
+                    reason = describe_exception(exc)
+                    errors.append({"source": "kis", "market": "us", "error": reason})
+                    unavailable_sources["kis_overseas"] = reason
+```
+
+3h. Non-paper return summary (around line 305-312). Change:
+
+```python
+    return {
+        "accounts": accounts,
+        "summary": {
+            "total_krw": total_krw,
+            "total_usd": total_usd,
+        },
+        "errors": errors,
+    }
+```
+to:
+```python
+    return {
+        "accounts": accounts,
+        "summary": {
+            "total_krw": total_krw,
+            "total_usd": total_usd,
+            "unavailable_sources": unavailable_sources,
+        },
+        "errors": errors,
+    }
+```
+
+3i. Paper-account early return (around line 118-122) — keep the contract uniform. Change:
+
+```python
+        return {
+            "accounts": rows,
+            "summary": {"total_krw": total_krw, "total_usd": total_usd},
+            "errors": errors,
+        }
+```
+to:
+```python
+        return {
+            "accounts": rows,
+            "summary": {
+                "total_krw": total_krw,
+                "total_usd": total_usd,
+                "unavailable_sources": {},
+            },
+            "errors": errors,
+        }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_portfolio_cash_kis_mock.py::test_cash_balance_mock_kis_timeout_surfaces_reason_and_marks_unavailable -v`
+Expected: PASS
+
+- [ ] **Step 5: Run the file to confirm existing tests still pass**
+
+Run: `uv run pytest tests/test_portfolio_cash_kis_mock.py -q`
+Expected: PASS (existing 2 + new 1)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/mcp_server/tooling/portfolio_cash.py tests/test_portfolio_cash_kis_mock.py
+git commit -m "fix(ROB-600): cash balance surfaces concrete reason + summary.unavailable_sources
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01QTE5SngqNmNPp8Dx9hdwUU"
+```
+
+---
+
+### Task 5: (c) `get_available_capital_impl` 전파 + live-precheck 회귀가드
+
+**Files:**
+- Modify: `app/mcp_server/tooling/portfolio_cash.py` (`get_available_capital_impl` summary에 `unavailable_sources` 전파, around line 433-442)
+- Test: `tests/test_portfolio_cash_kis_mock.py` (append)
+
+**Interfaces:**
+- Consumes: `get_cash_balance_impl(...)["summary"]["unavailable_sources"]` (Task 4).
+- Produces: `get_available_capital_impl(...)["summary"]["unavailable_sources"] : dict[str, str]`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_portfolio_cash_kis_mock.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_available_capital_propagates_unavailable_sources(monkeypatch):
+    """ROB-600: capital summary carries unavailable_sources so KIS failure is not
+    mistaken for 0 orderable cash."""
+    fake_kis = MagicMock()
+    fake_kis.inquire_domestic_cash_balance = AsyncMock(side_effect=httpx.ReadTimeout(""))
+
+    monkeypatch.setattr(
+        portfolio_cash, "_create_kis_client", lambda *, is_mock: fake_kis
+    )
+    monkeypatch.setattr(
+        portfolio_cash.upbit_service,
+        "fetch_krw_cash_summary",
+        AsyncMock(return_value={"balance": 0.0, "orderable": 0.0}),
+    )
+    monkeypatch.setattr(
+        portfolio_cash, "get_account_costs_setting", AsyncMock(return_value=None)
+    )
+
+    result = await portfolio_cash.get_available_capital_impl(
+        include_manual=False, is_mock=True
+    )
+
+    assert result["summary"]["unavailable_sources"]["kis_domestic"] == "ReadTimeout"
+    assert result["summary"]["total_orderable_krw"] == pytest.approx(0.0)
+
+
+@pytest.mark.asyncio
+async def test_live_kis_orderable_raises_when_row_missing(monkeypatch):
+    """ROB-600 regression guard: with NO placeholder row added, the live precheck
+    source still RAISES on a missing kis row instead of silently reading 0."""
+    from app.mcp_server.tooling import order_validation
+
+    monkeypatch.setattr(
+        order_validation,
+        "get_cash_balance_impl",
+        AsyncMock(
+            return_value={
+                "accounts": [],
+                "summary": {
+                    "total_krw": 0.0,
+                    "total_usd": 0.0,
+                    "unavailable_sources": {"kis_domestic": "ReadTimeout"},
+                },
+                "errors": [{"source": "kis", "market": "kr", "error": "ReadTimeout"}],
+            }
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="orderable not found"):
+        await order_validation._live_kis_orderable("kis_domestic")
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_portfolio_cash_kis_mock.py::test_available_capital_propagates_unavailable_sources tests/test_portfolio_cash_kis_mock.py::test_live_kis_orderable_raises_when_row_missing -v`
+Expected: `test_available_capital_propagates_unavailable_sources` FAILS — `KeyError: 'unavailable_sources'` (capital summary doesn't carry it yet). `test_live_kis_orderable_raises_when_row_missing` should already PASS (it locks in pre-existing behavior — confirms no placeholder regression). If it fails, a placeholder row was wrongly added.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `app/mcp_server/tooling/portfolio_cash.py`, `get_available_capital_impl`'s return (around line 433-442). Change:
+
+```python
+    return {
+        "accounts": processed_accounts,
+        "manual_cash": manual_cash_result,
+        "summary": {
+            "total_orderable_krw": total_orderable_krw,
+            "manual_cash_excluded_krw": manual_cash_excluded_krw,
+            "exchange_rate_usd_krw": exchange_rate,
+            "as_of": now_kst().isoformat(),
+        },
+        "errors": errors,
+    }
+```
+to:
+```python
+    return {
+        "accounts": processed_accounts,
+        "manual_cash": manual_cash_result,
+        "summary": {
+            "total_orderable_krw": total_orderable_krw,
+            "manual_cash_excluded_krw": manual_cash_excluded_krw,
+            "exchange_rate_usd_krw": exchange_rate,
+            "as_of": now_kst().isoformat(),
+            # ROB-600: propagate per-source lookup failures so a failed KIS read is
+            # not mistaken for 0 orderable cash.
+            "unavailable_sources": cash_result.get("summary", {}).get(
+                "unavailable_sources", {}
+            ),
+        },
+        "errors": errors,
+    }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_portfolio_cash_kis_mock.py::test_available_capital_propagates_unavailable_sources tests/test_portfolio_cash_kis_mock.py::test_live_kis_orderable_raises_when_row_missing -v`
+Expected: PASS (2 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/mcp_server/tooling/portfolio_cash.py tests/test_portfolio_cash_kis_mock.py
+git commit -m "fix(ROB-600): propagate unavailable_sources into available_capital summary
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01QTE5SngqNmNPp8Dx9hdwUU"
+```
+
+---
+
+### Task 6: (a) `kis/base.py` 재시도 로그 구체화
+
+**Files:**
+- Modify: `app/services/brokers/kis/base.py` (import; `:544` retry log; `:557` RateLimitExceededError 방어 guard)
+- Test: `tests/test_kis_base_rate_limit.py` (append)
+
+**Interfaces:**
+- Consumes: `describe_exception` (Task 1).
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_kis_base_rate_limit.py` (top adds `import logging`, `import httpx`, and `from unittest.mock import AsyncMock`; `MagicMock` already imported):
+
+```python
+class _FastRetrySettings:
+    kis_app_key = "key"
+    kis_app_secret = "secret"
+    kis_access_token = "token"
+    api_rate_limit_retry_429_max = 1
+    api_rate_limit_retry_429_base_delay = 0.0
+    kis_rate_limit_rate = 19
+    kis_rate_limit_period = 1.0
+
+
+class _FastRetryClient(BaseKISClient):
+    def __init__(self) -> None:  # type: ignore[override]
+        self._unmapped_rate_limit_keys_logged: set = set()
+        type(self)._shared_client_lock = None
+
+    @property  # type: ignore[override]
+    def _settings(self):  # type: ignore[override]
+        return _FastRetrySettings()
+
+
+@pytest.mark.asyncio
+async def test_request_error_retry_log_names_the_exception(monkeypatch, caplog):
+    """ROB-600: a ReadTimeout('') retry must log 'ReadTimeout', not a blank reason.
+    The exception itself re-raises (bare raise); the empty str() is handled at the
+    call sites via describe_exception."""
+    client = _FastRetryClient()
+    limiter = MagicMock()
+    limiter.acquire = AsyncMock()
+    monkeypatch.setattr(client, "_get_limiter", AsyncMock(return_value=limiter))
+    monkeypatch.setattr(client, "_ensure_client", AsyncMock(return_value=MagicMock()))
+    monkeypatch.setattr(
+        client,
+        "_execute_http_request",
+        AsyncMock(side_effect=httpx.ReadTimeout("")),
+    )
+
+    with caplog.at_level(logging.WARNING):
+        with pytest.raises(httpx.ReadTimeout):
+            await client._request_with_rate_limit_with_headers(
+                "GET",
+                "https://host/path",
+                headers={},
+                retry_request_errors=True,
+                api_name="inquire_domestic_cash_balance",
+            )
+
+    assert any("ReadTimeout" in r.getMessage() for r in caplog.records)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_kis_base_rate_limit.py::test_request_error_retry_log_names_the_exception -v`
+Expected: FAIL — no log record contains "ReadTimeout" (current log formats the empty `e` → blank reason).
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `app/services/brokers/kis/base.py`, add the import near the top (with the other `from app...`/stdlib imports, after `import httpx`):
+
+```python
+from app.core.exceptions import describe_exception
+```
+
+In the `except httpx.RequestError as e:` retry branch (around line 537-554), change the warning call argument from `e` to `describe_exception(e)`:
+
+```python
+            except httpx.RequestError as e:
+                last_error = e
+                if retry_request_errors and attempt < max_retries:
+                    wait_time = self._calculate_retry_delay(
+                        attempt=attempt, retry_after=0
+                    )
+                    logging.warning(
+                        "[%s] Request error for %s: %s, attempt %d/%d, retrying in %.3fs",
+                        "kis",
+                        api_name,
+                        describe_exception(e),
+                        attempt + 1,
+                        max_retries + 1,
+                        wait_time,
+                    )
+                    await asyncio.sleep(wait_time)
+                    continue
+                raise
+```
+
+In the final `RateLimitExceededError` raise (around line 556-558) — defensive guard so the 429-heuristic-exhaustion message is never blank (note `last_error` may be `None` on that path):
+
+```python
+        raise RateLimitExceededError(
+            f"KIS rate limit retries exhausted for {api_name}: "
+            f"{describe_exception(last_error) if last_error is not None else 'rate limited'}"
+        )
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_kis_base_rate_limit.py::test_request_error_retry_log_names_the_exception -v`
+Expected: PASS
+
+- [ ] **Step 5: Run the file to confirm no regression**
+
+Run: `uv run pytest tests/test_kis_base_rate_limit.py -q`
+Expected: PASS (existing TestCalculateRetryDelay / TestParseKisResponse + new test)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/services/brokers/kis/base.py tests/test_kis_base_rate_limit.py
+git commit -m "fix(ROB-600): KIS retry log + rate-limit-exhausted message name the exception
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01QTE5SngqNmNPp8Dx9hdwUU"
+```
+
+---
+
+### Task 7: 전체 검증 + lint/typecheck
+
+**Files:** (none — verification only)
+
+- [ ] **Step 1: Run the full set of touched tests**
+
+Run:
+```bash
+uv run pytest tests/core/test_exceptions.py \
+  tests/test_mcp_place_order.py \
+  tests/services/brokers/kis/test_account_cash_timeout.py \
+  tests/test_portfolio_cash_kis_mock.py \
+  tests/test_kis_base_rate_limit.py -q
+```
+Expected: all PASS.
+
+- [ ] **Step 2: Lint + typecheck (CI gate — app/ AND tests/)**
+
+Run: `uv run ruff format app/ tests/ && uv run ruff check app/ tests/ && uv run ty check app/`
+Expected: clean (no format diffs left uncommitted, no lint errors, no type errors). If `ruff format` changes files, re-add and amend the relevant commit.
+
+- [ ] **Step 3: Broader regression sweep (modules importing the touched code)**
+
+Run: `uv run pytest tests/ -q -k "portfolio or order_execution or kis_base or account or capital or cash"`
+Expected: PASS. Investigate any shared-DB ordering flakes by re-running the failing test in isolation.
+
+- [ ] **Step 4: Commit any format-only fixups (if Step 2 changed files)**
+
+```bash
+git add -A && git commit -m "style(ROB-600): ruff format
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01QTE5SngqNmNPp8Dx9hdwUU"
+```
+
+---
+
+## Self-Review (작성자 체크)
+
+**Spec coverage:**
+- (a) 빈에러→구체사유: Task 2 (order_execution :1128/:1138), Task 4 (portfolio_cash kis :252/:303, +toss/upbit), Task 6 (base.py :544/:557), 헬퍼 Task 1. ✅
+- (b) mock read 타임아웃 5→10: Task 3. ✅
+- (c) unavailable_sources + placeholder 금지: Task 4 (get_cash_balance_impl + 회귀단언 "no row"), Task 5 (get_available_capital_impl 전파 + _live_kis_orderable raise 가드). ✅
+- 제약(주문 재시도 미추가, migration 0, additive 계약): Global Constraints + 어떤 task도 domestic_orders/overseas_orders/스키마 미변경. ✅
+
+**Placeholder scan:** 모든 step에 실제 코드/명령/기대출력 존재. TODO/TBD 없음. ✅
+
+**Type consistency:** `describe_exception(exc: BaseException) -> str` (Task 1) → Task 2/4/6에서 동일 사용. `unavailable_sources: dict[str, str]` (Task 4 생성) → Task 5에서 `cash_result["summary"]["unavailable_sources"]` 동일 키로 소비. `inquire_domestic_cash_balance(is_mock)` timeout 단언(Task 3)이 호출부 시그니처와 일치. ✅

--- a/docs/superpowers/specs/2026-06-19-rob600-kis-mock-kr-timeout-design.md
+++ b/docs/superpowers/specs/2026-06-19-rob600-kis-mock-kr-timeout-design.md
@@ -1,0 +1,148 @@
+# ROB-600 — kis_mock KR 국내 주문/잔고 간헐적 타임아웃이 빈 에러("")로 실패
+
+- **Linear**: [ROB-600](https://linear.app/mgh3326/issue/ROB-600) · Bug / High
+- **날짜**: 2026-06-19
+- **브랜치**: `rob-600`
+- **범위 결정**: 옵션 A — 진단가능(a) + 정직한 잔고(c) + read 타임아웃(b). **주문 전송 재시도는 추가하지 않음**.
+
+---
+
+## 1. 문제 (Symptom)
+
+`account_mode='kis_mock'`의 **KR 국내** 주문/잔고 경로가 간헐적으로 **빈 에러(`""`) / ReadTimeout**으로 실패한다. 에러 메시지가 비어 있어 운영자가 원인 진단 불가.
+
+2026-06-19 장중(10:23~10:35 KST) 운영 MCP 세션 재현:
+
+- `get_available_capital(kis_mock)` / `get_cash_balance(kis_mock)`: `errors[]={source:'kis', market:'kr', error:''}` (빈 문자열), `accounts[]`에 `kis_domestic` 라인 누락, `summary` total에 KIS 모의현금 미반영 → **현금 0으로 오인**. 3회 연속.
+- `kis_mock_place_order(005930 sell 370000 x2, dry_run=False)`: `{success:false, error:"", source:"kis"}`. 2회 연속.
+- 직전 buy `dry_run=True`: 성공하나 `warning: "KIS mock balance precheck unavailable: ReadTimeout"` ← **여기만 사유가 보임**.
+
+약 1시간 전 프로브에선 정상(orderable 3,102,026 반환) → 상시장애 아닌 **간헐적 타임아웃**.
+
+---
+
+## 2. 근본 원인 (코드로 확정)
+
+### 2.1 빈 에러 문자열
+`str(httpx.ReadTimeout())`은 **빈 문자열**이다 (실증: `str(httpx.ReadTimeout('')) == ''`). 타임아웃 예외를 잡는 자리들이 `or <classname>` 폴백 없이 **bare `str(exc)`**를 쓴다:
+
+- `app/mcp_server/tooling/order_execution.py:1138` — `_order_error(str(exc))` (주문 sell 빈에러의 진원지; sell은 buy precheck를 안 타고 바로 outer except로 떨어짐)
+- `app/mcp_server/tooling/order_execution.py:1128` — `error=str(exc)` (히스토리 기록)
+- `app/mcp_server/tooling/portfolio_cash.py:252` (kis kr) / `:303` (kis us) — `errors.append({..., "error": str(exc)})`
+- 별도 진원지: `app/services/brokers/kis/account.py:584` — `RuntimeError(f"{msg_cd} {msg1}")`에서 `msg1`이 빈 값이면 비-타임아웃 실패도 hollow
+
+**정답은 이미 코드에 존재**: precheck `order_validation.py:1067`와 preview `order_execution.py:1060`는 `str(exc) or exc.__class__.__name__`를 써서 "ReadTimeout"이 보인다. 이 관용구는 코드베이스 ~10곳(`kis_live_ledger`, `toss_live_ledger`, `kis_mock_ledger`, `live_order_ledger` …)에 copy-paste되어 있으나 **공용 헬퍼는 없다**.
+
+### 2.2 간헐 타임아웃의 진짜 레버 = read 타임아웃 5s
+- 잔고 read `account.py:565` `inquire_domestic_cash_balance`는 `timeout=5`, 주문은 `timeout=10`. 모의 호스트 `openapivts.koreainvestment.com:29443`(`config.py:185`)가 느려 5s 경계에서 간헐 ReadTimeout.
+- **선례**: `invest_home_readers.py:995` ROB-270 주석 — *"mock VTS is slow near the 5s boundary; 10s 단일 시도 + ReadTimeout 재시도 끔"*. 같은 처방을 MCP 잔고/자본 도구에는 아직 안 깔았을 뿐.
+
+### 2.3 잔고가 0으로 오인되는 메커니즘
+`portfolio_cash.py:235-246` — `kis_domestic` account dict 생성과 `total_krw += dncl_amt`가 **모두 try 블록 안**. 예외 시 둘 다 skip → `accounts[]`에서 라인 누락 + total 미반영. `summary`(`:305-312`)가 `accounts[]`를 합산하므로 KIS 현금이 **조용히 0**. `get_available_capital_impl`도 같은 `accounts[]`를 받아 `total_orderable_krw`를 합산(`:372-378`)하므로 동일하게 누락.
+
+---
+
+## 3. 제약 / 비-목표
+
+- **주문 전송(place/cancel/modify)에는 타임아웃 재시도를 추가하지 않는다.** 타임아웃은 실패를 증명하지 않음(이미 접수됐을 수 있음) → 재시도 = double-submit 위험. idempotency key 없이는 금지.
+- ⚠️ 본 브랜치에는 **ROB-585(주문 no-timeout-retry, EGW00215 throttle)가 미머지**다 (`grep EGW00215 app/` 0건, `3c873dca`는 HEAD 조상 아님). 따라서 현재 주문 전송은 default `retry_request_errors=True`로 동작한다. 이 잠재 double-submit 하드닝은 **ROB-585 스코프에 위임**하고 ROB-600은 건드리지 않는다.
+- live/US read 타임아웃 튜닝, 기존 ~10곳 헬퍼 일괄 마이그레이션은 **스코프 밖**.
+
+---
+
+## 4. 설계
+
+### 4.1 공용 헬퍼 — `app/core/exceptions.py` (신규)
+
+```python
+def describe_exception(exc: BaseException) -> str:
+    """비어있지 않은 구체 사유를 반환한다.
+
+    httpx 타임아웃 예외(ReadTimeout/ConnectTimeout/PoolTimeout 등)는 ``str()``이
+    빈 문자열이라, 그대로 노출하면 진단 불가능한 ``error: ""``가 된다. 메시지가
+    비면 클래스명으로 폴백해 'ReadTimeout' 같은 구체 사유를 표면화한다 (ROB-600).
+
+    코드베이스에 흩어진 ``str(exc) or exc.__class__.__name__`` 관용구를 단일화한다.
+    """
+    return str(exc).strip() or type(exc).__name__
+```
+
+`app/core/`는 `app/services/`(base.py)와 `app/mcp_server/`(order/cash) 양쪽이 import 가능한 공유 레이어. base.py는 이미 `app/core`(settings)를 import하므로 순환참조 없음.
+
+### 4.2 결함 (a) — 빈에러 → 구체사유 (behavior-preserving, 문자열만)
+
+| 자리 | 변경 |
+|---|---|
+| `order_execution.py:1138` | `return _order_error(describe_exception(exc))` |
+| `order_execution.py:1128` | `error=describe_exception(exc)` |
+| `portfolio_cash.py:252` (kis kr) | `"error": describe_exception(exc)` |
+| `portfolio_cash.py:303` (kis us) | `"error": describe_exception(exc)` |
+| `kis/base.py:544` (빈 로그) | 로그 포맷 인자를 `describe_exception(e)`로 |
+| `kis/base.py:557` (`RateLimitExceededError`) | `f"... {describe_exception(last_error)}"` |
+
+모두 문자열만 바꾸므로 제어흐름·반환계약 불변. (`account.py:584`의 hollow `msg1`은 (a)의 호출부 폴백으로 이미 비-빈 처리되므로 별도 변경 불필요 — 단 `msg_cd`가 메시지에 포함되어 그대로 살아남는다.)
+
+### 4.3 결함 (b) — read 타임아웃 (mock-aware, 잔고 read만)
+
+`account.py:565` `inquire_domestic_cash_balance`:
+
+```python
+timeout=10 if is_mock else 5,
+```
+
+- retry는 기존 default `retry_request_errors=True` 유지 → 이슈 제안 #2의 "자동 1~2회 재시도" 충족(429/RequestError 재시도 경로는 `base.py:537-554`에 이미 존재).
+- 이 함수는 잔고집계(`portfolio_cash.py:209`)와 **mock buy precheck read**(`order_validation.py:513`) 양쪽이 호출하므로 한 변경으로 둘 다 해결.
+- live/US read(`inquire_integrated_margin`, `inquire_overseas_margin`, `fetch_my_stocks`)는 무변경.
+
+### 4.4 결함 (c) — "조회실패(미반영)" 명시 (consumer-safe)
+
+`portfolio_cash.get_cash_balance_impl`에서 source별 except가 잡힐 때마다 `unavailable_sources`를 누적해 `summary`에 노출하고, `get_available_capital_impl` summary로도 전파한다.
+
+```jsonc
+"summary": {
+  "total_krw": 0.0, "total_usd": 0.0,
+  "unavailable_sources": [
+    {"account": "kis_domestic", "market": "kr", "reason": "ReadTimeout"}
+  ]
+}
+```
+
+- **`accounts[]`엔 placeholder row를 넣지 않는다.** 이유: `order_validation.py:498` `_live_kis_orderable`은 `accounts[]`에서 `kis_domestic` row를 찾고 **부재 시 `raise RuntimeError`**(loud)한다. placeholder row(`orderable: None`)를 넣으면 `None or 0.0 == 0.0`을 반환해 **live buy precheck가 실패를 silent 0으로 오인**하는 회귀가 생긴다. row를 넣지 않으면 raise-on-missing이 보존된다. `total_orderable_krw` 합산(`:375` `or 0.0`)도 영향 없음.
+- `errors[]`의 사유는 (a)로 이미 non-empty. `unavailable_sources`는 그것을 first-class·machine-readable로 승격 → 호출 에이전트가 "현금 0"과 "조회 실패"를 구분.
+- 적용 범위: `get_cash_balance_impl`의 toss/upbit/kis_kr/kis_us 모든 caught source 실패를 `unavailable_sources`에 반영(정직성, 추가 비용 미미). `summary`는 기존 키에 `unavailable_sources`만 additive 추가.
+
+---
+
+## 5. 테스트 (TDD)
+
+| 대상 | 단언 |
+|---|---|
+| `describe_exception` 단위 | `ReadTimeout('')` → `"ReadTimeout"`; `RuntimeError("EGW00201 x")` → `"EGW00201 x"` |
+| `_place_order_impl` | 실행부가 `httpx.ReadTimeout('')` raise → `result["error"] == "ReadTimeout"` (not `""`) |
+| `get_cash_balance_impl` (mock) | kis read가 `ReadTimeout` → `errors[].error == "ReadTimeout"`, `summary.unavailable_sources`에 `kis_domestic`, `total_krw`에 kis 미포함, **`accounts[]`에 `kis_domestic` row 없음** |
+| `get_available_capital_impl` | `summary.unavailable_sources` 전파, `total_orderable_krw` 불변 |
+| 회귀가드 | `_live_kis_orderable`은 kis row 부재 시 여전히 `raise`(placeholder 없음 증명) |
+| 타임아웃 | `inquire_domestic_cash_balance(is_mock=True)` → request 레이어에 `timeout=10`; `is_mock=False` → `timeout=5` |
+| `base.py` | `last_error=ReadTimeout('')`일 때 `RateLimitExceededError` 메시지 non-empty |
+
+테스트는 DB/실네트워크 없이 모킹(`_request_with_rate_limit` / kis client 메서드 / httpx 예외 주입)으로 구성.
+
+---
+
+## 6. 영향 / 호환성
+
+- **DB 마이그레이션 0** (스키마/모델 변경 없음).
+- MCP 계약은 **additive**: `summary.unavailable_sources`는 신규 optional 필드, `error` 문자열이 빈→비-빈으로만 바뀜 → 하위호환.
+- 런타임 LLM 경계·브로커 mutation 경로 무관(읽기/에러표면화/타임아웃 상수만).
+- 운영자 영향: 배포 후 잔고/주문 도구가 실패 사유를 구체적으로 보고, `unavailable_sources`로 "현금 0 오인" 차단. MCP 재시작 외 별도 operator 조치 없음.
+
+---
+
+## 7. 변경 파일 요약
+
+- `app/core/exceptions.py` (신규) — `describe_exception`
+- `app/mcp_server/tooling/order_execution.py` — `:1128`, `:1138`
+- `app/mcp_server/tooling/portfolio_cash.py` — `:252`, `:303`, `unavailable_sources` (get_cash_balance_impl + get_available_capital_impl summary)
+- `app/services/brokers/kis/account.py` — `:565` timeout mock-aware
+- `app/services/brokers/kis/base.py` — `:544`, `:557` 로그/예외 문구 보강
+- 테스트 — 위 7개 케이스

--- a/docs/superpowers/specs/2026-06-19-rob600-kis-mock-kr-timeout-design.md
+++ b/docs/superpowers/specs/2026-06-19-rob600-kis-mock-kr-timeout-design.md
@@ -98,18 +98,18 @@ timeout=10 if is_mock else 5,
 
 `portfolio_cash.get_cash_balance_impl`에서 source별 except가 잡힐 때마다 `unavailable_sources`를 누적해 `summary`에 노출하고, `get_available_capital_impl` summary로도 전파한다.
 
+**shape = `dict[str, str]` (`{account_key: reason}`)** — 코드베이스에 이미 존재하는 `unavailable_sources` 관용구(investment_reports snapshot row의 `{"naver":"확인 불가","toss":"soft_stale"}`)와 동일 형태를 따른다. account_key가 시장을 인코딩(`kis_domestic`/`kis_overseas`/`toss`/`upbit`).
+
 ```jsonc
 "summary": {
   "total_krw": 0.0, "total_usd": 0.0,
-  "unavailable_sources": [
-    {"account": "kis_domestic", "market": "kr", "reason": "ReadTimeout"}
-  ]
+  "unavailable_sources": { "kis_domestic": "ReadTimeout" }
 }
 ```
 
 - **`accounts[]`엔 placeholder row를 넣지 않는다.** 이유: `order_validation.py:498` `_live_kis_orderable`은 `accounts[]`에서 `kis_domestic` row를 찾고 **부재 시 `raise RuntimeError`**(loud)한다. placeholder row(`orderable: None`)를 넣으면 `None or 0.0 == 0.0`을 반환해 **live buy precheck가 실패를 silent 0으로 오인**하는 회귀가 생긴다. row를 넣지 않으면 raise-on-missing이 보존된다. `total_orderable_krw` 합산(`:375` `or 0.0`)도 영향 없음.
 - `errors[]`의 사유는 (a)로 이미 non-empty. `unavailable_sources`는 그것을 first-class·machine-readable로 승격 → 호출 에이전트가 "현금 0"과 "조회 실패"를 구분.
-- 적용 범위: `get_cash_balance_impl`의 toss/upbit/kis_kr/kis_us 모든 caught source 실패를 `unavailable_sources`에 반영(정직성, 추가 비용 미미). `summary`는 기존 키에 `unavailable_sources`만 additive 추가.
+- 적용 범위: `get_cash_balance_impl`의 toss/upbit/kis_kr/kis_us 모든 caught source 실패를 `unavailable_sources`에 반영(정직성, 추가 비용 미미). `summary`는 기존 키에 `unavailable_sources`만 additive 추가. 실패가 없으면 빈 dict `{}`.
 
 ---
 
@@ -119,11 +119,11 @@ timeout=10 if is_mock else 5,
 |---|---|
 | `describe_exception` 단위 | `ReadTimeout('')` → `"ReadTimeout"`; `RuntimeError("EGW00201 x")` → `"EGW00201 x"` |
 | `_place_order_impl` | 실행부가 `httpx.ReadTimeout('')` raise → `result["error"] == "ReadTimeout"` (not `""`) |
-| `get_cash_balance_impl` (mock) | kis read가 `ReadTimeout` → `errors[].error == "ReadTimeout"`, `summary.unavailable_sources`에 `kis_domestic`, `total_krw`에 kis 미포함, **`accounts[]`에 `kis_domestic` row 없음** |
+| `get_cash_balance_impl` (mock) | kis read가 `ReadTimeout` → `errors[].error == "ReadTimeout"`, `summary.unavailable_sources["kis_domestic"] == "ReadTimeout"`, `total_krw`에 kis 미포함, **`accounts[]`에 `kis_domestic` row 없음** |
 | `get_available_capital_impl` | `summary.unavailable_sources` 전파, `total_orderable_krw` 불변 |
 | 회귀가드 | `_live_kis_orderable`은 kis row 부재 시 여전히 `raise`(placeholder 없음 증명) |
 | 타임아웃 | `inquire_domestic_cash_balance(is_mock=True)` → request 레이어에 `timeout=10`; `is_mock=False` → `timeout=5` |
-| `base.py` | `last_error=ReadTimeout('')`일 때 `RateLimitExceededError` 메시지 non-empty |
+| `base.py` (`:544`) | RequestError 재시도 로그가 `describe_exception(e)` 적용으로 "ReadTimeout" 포함(caplog). 재시도 소진 시 ReadTimeout는 그대로 re-raise(`:554` bare raise)되고 빈 str은 **호출부 describe_exception**(Task 2/4)이 처리. `:557` RateLimitExceededError는 429-heuristic 소진 전용(`last_error`가 None일 수 있음)이라 방어적 guard만 적용, 별도 테스트 없음 |
 
 테스트는 DB/실네트워크 없이 모킹(`_request_with_rate_limit` / kis client 메서드 / httpx 예외 주입)으로 구성.
 

--- a/tests/core/test_exceptions.py
+++ b/tests/core/test_exceptions.py
@@ -1,0 +1,19 @@
+import httpx
+
+from app.core.exceptions import describe_exception
+
+
+def test_empty_message_falls_back_to_class_name():
+    assert describe_exception(httpx.ReadTimeout("")) == "ReadTimeout"
+    assert describe_exception(httpx.ConnectTimeout("")) == "ConnectTimeout"
+
+
+def test_whitespace_only_message_falls_back_to_class_name():
+    assert describe_exception(ValueError("   ")) == "ValueError"
+
+
+def test_nonempty_message_is_preserved():
+    assert describe_exception(RuntimeError("EGW00201 초당 거래건수 초과")) == (
+        "EGW00201 초당 거래건수 초과"
+    )
+    assert describe_exception(httpx.ReadTimeout("Read timed out")) == "Read timed out"

--- a/tests/services/brokers/kis/test_account_cash_timeout.py
+++ b/tests/services/brokers/kis/test_account_cash_timeout.py
@@ -1,0 +1,37 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.services.brokers.kis.account import AccountClient
+
+
+class _Settings:
+    kis_account_no = "12345678-01"
+    kis_access_token = "tok"
+
+
+def _make_account_client():
+    parent = MagicMock()
+    parent._settings = _Settings()
+    parent._ensure_token = AsyncMock()
+    parent._hdr_base = {}
+    parent._kis_url = lambda path: f"https://host{path}"
+    parent._request_with_rate_limit = AsyncMock(
+        return_value={"rt_cd": "0", "output2": [{}]}
+    )
+    return AccountClient(parent), parent
+
+
+@pytest.mark.asyncio
+async def test_inquire_domestic_cash_balance_mock_uses_10s_timeout():
+    """ROB-600: mock VTS is slow near the 5s boundary; mock read uses 10s."""
+    client, parent = _make_account_client()
+    await client.inquire_domestic_cash_balance(is_mock=True)
+    assert parent._request_with_rate_limit.call_args.kwargs["timeout"] == 10
+
+
+@pytest.mark.asyncio
+async def test_inquire_domestic_cash_balance_live_keeps_5s_timeout():
+    client, parent = _make_account_client()
+    await client.inquire_domestic_cash_balance(is_mock=False)
+    assert parent._request_with_rate_limit.call_args.kwargs["timeout"] == 5

--- a/tests/test_kis_base_rate_limit.py
+++ b/tests/test_kis_base_rate_limit.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+import logging
+from unittest.mock import AsyncMock, MagicMock
 
+import httpx
 import pytest
 
 from app.services.brokers.kis.base import BaseKISClient
@@ -101,3 +103,52 @@ class TestParseKisResponse:
 
         data, is_rate_limited = client._parse_kis_response(response, api_name="test")
         assert is_rate_limited is False
+
+
+class _FastRetrySettings:
+    kis_app_key = "key"
+    kis_app_secret = "secret"
+    kis_access_token = "token"
+    api_rate_limit_retry_429_max = 1
+    api_rate_limit_retry_429_base_delay = 0.0
+    kis_rate_limit_rate = 19
+    kis_rate_limit_period = 1.0
+
+
+class _FastRetryClient(BaseKISClient):
+    def __init__(self) -> None:  # type: ignore[override]
+        self._unmapped_rate_limit_keys_logged: set = set()
+        type(self)._shared_client_lock = None
+
+    @property  # type: ignore[override]
+    def _settings(self):  # type: ignore[override]
+        return _FastRetrySettings()
+
+
+@pytest.mark.asyncio
+async def test_request_error_retry_log_names_the_exception(monkeypatch, caplog):
+    """ROB-600: a ReadTimeout('') retry must log 'ReadTimeout', not a blank reason.
+    The exception itself re-raises (bare raise); the empty str() is handled at the
+    call sites via describe_exception."""
+    client = _FastRetryClient()
+    limiter = MagicMock()
+    limiter.acquire = AsyncMock()
+    monkeypatch.setattr(client, "_get_limiter", AsyncMock(return_value=limiter))
+    monkeypatch.setattr(client, "_ensure_client", AsyncMock(return_value=MagicMock()))
+    monkeypatch.setattr(
+        client,
+        "_execute_http_request",
+        AsyncMock(side_effect=httpx.ReadTimeout("")),
+    )
+
+    with caplog.at_level(logging.WARNING):
+        with pytest.raises(httpx.ReadTimeout):
+            await client._request_with_rate_limit_with_headers(
+                "GET",
+                "https://host/path",
+                headers={},
+                retry_request_errors=True,
+                api_name="inquire_domestic_cash_balance",
+            )
+
+    assert any("ReadTimeout" in r.getMessage() for r in caplog.records)

--- a/tests/test_mcp_place_order.py
+++ b/tests/test_mcp_place_order.py
@@ -2810,3 +2810,40 @@ def test_order_tool_descriptions_drop_daily_order_cap_advertising() -> None:
     for description in (generic_desc, kis_live_desc):
         assert "orders/day" not in description
         assert "Safety limit: max" not in description
+
+
+@pytest.mark.asyncio
+async def test_place_order_readtimeout_surfaces_class_name(monkeypatch):
+    """ROB-600: a ReadTimeout during execution must surface 'ReadTimeout', not ''."""
+    import httpx
+
+    from app.mcp_server.tooling import order_execution
+
+    recorded = AsyncMock()
+    monkeypatch.setattr(
+        order_execution,
+        "_resolve_market_type",
+        lambda symbol, market: ("equity_kr", "005930"),
+    )
+    monkeypatch.setattr(order_execution, "_record_order_history", recorded)
+    monkeypatch.setattr(
+        order_execution,
+        "_fetch_current_price",
+        AsyncMock(side_effect=httpx.ReadTimeout("")),
+    )
+
+    result = await order_execution._place_order_impl(
+        symbol="005930",
+        side="sell",
+        order_type="limit",
+        quantity=1,
+        price=370000.0,
+        dry_run=False,
+        is_mock=True,
+    )
+
+    assert result["success"] is False
+    assert result["error"] == "ReadTimeout"
+    assert result["source"] == "kis"
+    # :1128 — order-history record also gets the concrete reason, not ""
+    assert recorded.await_args.kwargs["error"] == "ReadTimeout"

--- a/tests/test_mcp_portfolio_tools.py
+++ b/tests/test_mcp_portfolio_tools.py
@@ -3726,7 +3726,11 @@ async def test_get_cash_balance_toss_api_enabled_adds_krw_and_usd(monkeypatch):
             "formatted": "789.01 USD",
         },
     ]
-    assert result["summary"] == {"total_krw": 123456.0, "total_usd": 789.01}
+    assert result["summary"] == {
+        "total_krw": 123456.0,
+        "total_usd": 789.01,
+        "unavailable_sources": {},
+    }
     assert result["errors"] == []
 
 

--- a/tests/test_portfolio_cash_kis_mock.py
+++ b/tests/test_portfolio_cash_kis_mock.py
@@ -1,5 +1,6 @@
 from unittest.mock import AsyncMock, MagicMock
 
+import httpx
 import pytest
 
 from app.mcp_server.tooling import portfolio_cash
@@ -82,3 +83,37 @@ async def test_cash_balance_mock_orderable_is_raw_without_pending_deduction(
     accounts = {a["account"]: a for a in result["accounts"]}
     assert accounts["kis_domestic"]["orderable"] == pytest.approx(1000.0)
     fake_kis.inquire_korea_orders.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_cash_balance_mock_kis_timeout_surfaces_reason_and_marks_unavailable(
+    monkeypatch,
+):
+    """ROB-600: a KIS read timeout must (1) surface 'ReadTimeout' (not ''),
+    (2) appear in summary.unavailable_sources, (3) NOT add a kis_domestic row,
+    (4) leave total_krw excluding KIS."""
+    fake_kis = MagicMock()
+    fake_kis.inquire_domestic_cash_balance = AsyncMock(side_effect=httpx.ReadTimeout(""))
+
+    monkeypatch.setattr(
+        portfolio_cash, "_create_kis_client", lambda *, is_mock: fake_kis
+    )
+    monkeypatch.setattr(
+        portfolio_cash.upbit_service,
+        "fetch_krw_cash_summary",
+        AsyncMock(return_value={"balance": 0.0, "orderable": 0.0}),
+    )
+
+    result = await portfolio_cash.get_cash_balance_impl(is_mock=True)
+
+    # (1) concrete reason, not empty
+    kis_kr_err = next(
+        e for e in result["errors"] if e["source"] == "kis" and e["market"] == "kr"
+    )
+    assert kis_kr_err["error"] == "ReadTimeout"
+    # (2) machine-readable unavailable flag
+    assert result["summary"]["unavailable_sources"]["kis_domestic"] == "ReadTimeout"
+    # (3) no placeholder row injected
+    assert "kis_domestic" not in {a["account"] for a in result["accounts"]}
+    # (4) KIS cash not silently summed as a number
+    assert result["summary"]["total_krw"] == pytest.approx(0.0)

--- a/tests/test_portfolio_cash_kis_mock.py
+++ b/tests/test_portfolio_cash_kis_mock.py
@@ -117,3 +117,56 @@ async def test_cash_balance_mock_kis_timeout_surfaces_reason_and_marks_unavailab
     assert "kis_domestic" not in {a["account"] for a in result["accounts"]}
     # (4) KIS cash not silently summed as a number
     assert result["summary"]["total_krw"] == pytest.approx(0.0)
+
+
+@pytest.mark.asyncio
+async def test_available_capital_propagates_unavailable_sources(monkeypatch):
+    """ROB-600: capital summary carries unavailable_sources so KIS failure is not
+    mistaken for 0 orderable cash."""
+    fake_kis = MagicMock()
+    fake_kis.inquire_domestic_cash_balance = AsyncMock(side_effect=httpx.ReadTimeout(""))
+
+    monkeypatch.setattr(
+        portfolio_cash, "_create_kis_client", lambda *, is_mock: fake_kis
+    )
+    monkeypatch.setattr(
+        portfolio_cash.upbit_service,
+        "fetch_krw_cash_summary",
+        AsyncMock(return_value={"balance": 0.0, "orderable": 0.0}),
+    )
+    monkeypatch.setattr(
+        portfolio_cash, "get_account_costs_setting", AsyncMock(return_value=None)
+    )
+
+    result = await portfolio_cash.get_available_capital_impl(
+        include_manual=False, is_mock=True
+    )
+
+    assert result["summary"]["unavailable_sources"]["kis_domestic"] == "ReadTimeout"
+    assert result["summary"]["total_orderable_krw"] == pytest.approx(0.0)
+
+
+@pytest.mark.asyncio
+async def test_live_kis_orderable_raises_when_row_missing(monkeypatch):
+    """ROB-600 regression guard: with NO placeholder row added, the live precheck
+    source still RAISES on a missing kis row instead of silently reading 0."""
+    from app.mcp_server.tooling import order_validation
+
+    monkeypatch.setattr(
+        order_validation,
+        "get_cash_balance_impl",
+        AsyncMock(
+            return_value={
+                "accounts": [],
+                "summary": {
+                    "total_krw": 0.0,
+                    "total_usd": 0.0,
+                    "unavailable_sources": {"kis_domestic": "ReadTimeout"},
+                },
+                "errors": [{"source": "kis", "market": "kr", "error": "ReadTimeout"}],
+            }
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="orderable not found"):
+        await order_validation._live_kis_orderable("kis_domestic")

--- a/tests/test_portfolio_cash_kis_mock.py
+++ b/tests/test_portfolio_cash_kis_mock.py
@@ -93,7 +93,9 @@ async def test_cash_balance_mock_kis_timeout_surfaces_reason_and_marks_unavailab
     (2) appear in summary.unavailable_sources, (3) NOT add a kis_domestic row,
     (4) leave total_krw excluding KIS."""
     fake_kis = MagicMock()
-    fake_kis.inquire_domestic_cash_balance = AsyncMock(side_effect=httpx.ReadTimeout(""))
+    fake_kis.inquire_domestic_cash_balance = AsyncMock(
+        side_effect=httpx.ReadTimeout("")
+    )
 
     monkeypatch.setattr(
         portfolio_cash, "_create_kis_client", lambda *, is_mock: fake_kis
@@ -124,7 +126,9 @@ async def test_available_capital_propagates_unavailable_sources(monkeypatch):
     """ROB-600: capital summary carries unavailable_sources so KIS failure is not
     mistaken for 0 orderable cash."""
     fake_kis = MagicMock()
-    fake_kis.inquire_domestic_cash_balance = AsyncMock(side_effect=httpx.ReadTimeout(""))
+    fake_kis.inquire_domestic_cash_balance = AsyncMock(
+        side_effect=httpx.ReadTimeout("")
+    )
 
     monkeypatch.setattr(
         portfolio_cash, "_create_kis_client", lambda *, is_mock: fake_kis


### PR DESCRIPTION
## 문제 (ROB-600, Bug/High)

`account_mode='kis_mock'`의 **KR 국내** 주문/잔고 경로가 간헐적 타임아웃에 **빈 에러(`""`) / ReadTimeout**으로 실패 → 운영자가 원인 진단 불가. 잔고는 실패한 KIS 줄을 조용히 누락해 **현금 0으로 오인**.

근본 원인 (코드로 확정):
- `str(httpx.ReadTimeout())` == `""` 인데, 잡는 자리들이 `or <classname>` 폴백 없이 bare `str(exc)` 사용 → `error: ""`.
- mock 호스트(openapivts)가 느려 잔고 read의 **5s 타임아웃** 경계에서 간헐 ReadTimeout (ROB-270 선례 동일).
- `get_cash_balance_impl`이 실패 source의 account row를 try 블록 안에서 만들어 예외 시 통째로 누락 → summary total이 KIS 없이 합산.

## 수정 (스코프 A: 진단가능 + 정직 + read 타임아웃)

**(a) 빈에러 → 구체사유** — 공용 헬퍼 `app/core/exceptions.py::describe_exception(exc)` (`str(exc).strip() or type(exc).__name__`, 흩어진 ~10곳 관용구 단일화) 를 order-send(`order_execution.py`), 잔고(`portfolio_cash.py`), 전송 로그(`kis/base.py`) 호출부에 적용. 이제 `"ReadTimeout"`이 표면화.

**(b) mock read 타임아웃 5→10** — `account.py inquire_domestic_cash_balance` 를 `timeout=10 if is_mock else 5` (mock-aware). 잔고집계 + mock buy precheck read 둘 다 같은 함수라 한 번에 해결. retry는 기존 default 유지.

**(c) 정직한 잔고** — `get_cash_balance_impl`/`get_available_capital_impl` summary에 **additive** `unavailable_sources: dict[str,str]`(`{account_key: reason}`) 추가. 실패 source는 `errors[]` + `unavailable_sources`로만 노출, **`accounts[]`엔 placeholder row 미추가** (그래야 `_live_kis_orderable`의 raise-on-missing 보존 → live precheck가 실패를 silent 0으로 오인 안 함).

## 안전 경계 (불변)

- ⚠️ **주문 전송 재시도 미추가** — 타임아웃은 실패를 증명 못함(double-submit 위험). `domestic_orders.py`/`overseas_orders.py` 무변경. no-timeout-retry 하드닝은 ROB-585에 위임.
- `kis/base.py` 변경은 **문자열만**(로그 + RateLimitExceededError 메시지); RequestError 소진 시 bare `raise`(원 예외 재전파) 유지 → live 호출부 무영향.
- **DB 마이그레이션 0**, MCP 계약은 **하위호환**(신규 optional `summary.unavailable_sources` + error 문자열 ""→non-empty).

## 검증

- touched 스위트 177 passed, 전체 회귀 스윕 708 passed.
- `ruff format`/`ruff check` (app+tests) clean, `ty check app` clean.
- TDD(RED→GREEN) 전 태스크 적용. 7-task subagent 구현 + per-task 리뷰 + 최종 whole-branch 리뷰(opus): **Ready to merge = Yes**, 0 Critical / 0 Important. 핵심 안전제약(no placeholder row, base.py behavior-preserving) 구조 + 회귀가드 테스트로 검증.
- 잔여 warning 2건은 pre-existing(PydanticDeprecatedSince20, app/auth/schemas.py).

## 운영자 메모

배포 후 MCP 재시작이면 충분(마이그레이션/스키마 변경 없음). 장중 kis_mock 잔고/주문 도구가 타임아웃 시 `"ReadTimeout"` 등 구체 사유와 `summary.unavailable_sources`를 보고하는지 스모크.

후속(비-블로커): `order_execution.py:1061` 잔존 hand-rolled 관용구를 `describe_exception`으로 이관, toss/upbit `unavailable_sources` 누적 경로 전용 테스트.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QTE5SngqNmNPp8Dx9hdwUU

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Bug Fixes**
- Error messages no longer display as blank strings; now show the concrete error type (e.g., "ReadTimeout")
- Cash balance queries now clearly identify and report which data sources are unavailable
- Improved timeout handling for mock API environments to reduce unnecessary failures
- Order placement failures now report more descriptive error messages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->