### PR TITLE
fix(test): de-flake test_invest_coverage news/calendar freshness date time-bomb (unblocks main CI)

### DIFF
--- a/tests/test_invest_coverage.py
+++ b/tests/test_invest_coverage.py
@@ -73,12 +73,18 @@ def app(db_session) -> FastAPI:
 async def test_build_invest_coverage_reports_fresh_partial_and_provider_unwired(
     db_session,
 ):
-    # Use a date that is intentionally distinct from the shared market-events
-    # freshness tests. The global test database is shared across xdist workers, so
-    # inserting a partition for 2026-05-11 here can race with tests that assert a
+    # Date KEY stays fixed and intentionally distinct from the shared
+    # market-events freshness tests: the global test DB is shared across xdist
+    # workers, so reusing 2026-05-11 here can race with tests asserting a
     # completely missing market-events partition on that day.
     trading_day = dt.date(2026, 6, 17)
-    now = dt.datetime(2026, 6, 17, 8, 0, tzinfo=dt.UTC)
+    # Wall-clock `now`, by contrast, MUST track real time. The news (24h),
+    # calendar (36h), holdings (24h) and pending-order (30m) freshness windows in
+    # invest_coverage_service compare row timestamps against datetime.now(), not
+    # `as_of`. A hardcoded `now` silently rots into a date time-bomb: once the
+    # wall-clock date advances past the window, the seeded "fresh" rows fall
+    # outside it and the expected-fresh surfaces flip to stale.
+    now = dt.datetime.now(dt.UTC)
     now_naive = now.replace(tzinfo=None)
 
     await db_session.execute(


### PR DESCRIPTION
## 요약

`tests/test_invest_coverage.py::test_build_invest_coverage_reports_fresh_partial_and_provider_unwired`가 **날짜 time-bomb**로 인해 **2026-06-20부터 main의 모든 CI에서 실패**하여 모든 PR 머지를 차단하고 있었습니다.

## 근본 원인 (증거 기반)

- 픽스처가 `now = dt.datetime(2026, 6, 17, 8, 0, ...)`를 **하드코딩**하고 news/calendar row를 그 시각으로 시드.
- `app/services/invest_coverage_service.py`는 신선도를 `as_of`가 아니라 **실시간 `datetime.now()`** 기준으로 계산:
  - news: `now - 24h` (`_news_surfaces` L533)
  - calendar: `now - 36h` 다운그레이드 (`_calendar_surfaces` L636)
- wall-clock이 그 윈도우를 지나는 순간(06-18 이후) 시드한 "fresh" row가 윈도우 밖으로 밀려나 expected-fresh surface가 `stale`로 뒤집힘 → `AssertionError: assert 'stale' == 'fresh'` (line 209, news_feed).
- main HEAD(ROB-599 #1338)가 06-17경 머지된 뒤 후속 머지가 없어 green이 박제됐고, 다음 PR이 처음으로 red를 봄.
- **ROB-601 무관 확정**: 이 테스트는 MCP/registry/kiwoom import 0; origin/main 직접 체크아웃에서도 동일 실패.

## 수정

wall-clock 시드를 날짜 키에서 분리:
- `trading_day = dt.date(2026, 6, 17)` **유지** — xdist 공유 DB 격리(2026-05-11 market-events 테스트와 충돌 회피) + 날짜 기반 screener/investor/calendar-count 단언 보존.
- `now = dt.datetime.now(dt.UTC)`로 변경 → news(24h)·calendar(36h)·holdings(24h)·pending(30m) 신선도 윈도우가 **달력 날짜와 무관하게 항상 충족**. 향후 동일 패턴 재발 방지 주석 추가.

**test-only, 프로덕션/스키마 변경 없음.**

## 검증

- `test_build_invest_coverage_reports_fresh_partial_and_provider_unwired` **pass** (직전 RED)
- `tests/test_invest_coverage.py` 전체 **11 passed**
- `ruff check` / `ruff format --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017BYGfwL63UjEptW5gDmqWz
