### PR TITLE
feat: Binance Demo 스캘핑 Phase 1 — 측정 신뢰화 (손실게이트 realized_pnl + 일별 buy&hold 벤치마크)

### DIFF
--- a/alembic/versions/20260620_scalp_benchmark_return_bps.py
+++ b/alembic/versions/20260620_scalp_benchmark_return_bps.py
@@ -1,0 +1,33 @@
+"""add benchmark_return_bps to scalping_daily_reviews
+
+Revision ID: 20260620_scalp_benchmark
+Revises: 885e50ac5bb1
+Create Date: 2026-06-20
+
+Phase 1 — daily buy&hold benchmark column for the demo scalping review.
+Additive nullable; safe forward/backward.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "20260620_scalp_benchmark"
+down_revision: str | Sequence[str] | None = "885e50ac5bb1"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "scalping_daily_reviews",
+        sa.Column("benchmark_return_bps", sa.Numeric(12, 4), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("scalping_daily_reviews", "benchmark_return_bps")

--- a/app/models/scalping_reviews.py
+++ b/app/models/scalping_reviews.py
@@ -122,6 +122,9 @@ class ScalpingDailyReview(Base):
     net_return_bps: Mapped[Decimal | None] = mapped_column(
         Numeric(12, 4), nullable=True
     )
+    benchmark_return_bps: Mapped[Decimal | None] = mapped_column(
+        Numeric(12, 4), nullable=True
+    )
     avg_slippage_bps: Mapped[Decimal | None] = mapped_column(
         Numeric(12, 4), nullable=True
     )

--- a/app/routers/invest_scalping.py
+++ b/app/routers/invest_scalping.py
@@ -85,6 +85,7 @@ def _serialize_review(review: ScalpingDailyReview) -> dict[str, Any]:
             "grossPnlUsdt": _num(review.gross_pnl_usdt),
             "netPnlUsdt": _num(review.net_pnl_usdt),
             "netReturnBps": _num(review.net_return_bps),
+            "benchmarkReturnBps": _num(review.benchmark_return_bps),
             "avgSlippageBps": _num(review.avg_slippage_bps),
             "avgSpreadBps": _num(review.avg_spread_bps),
             "avgMaeBps": _num(review.avg_mae_bps),

--- a/app/services/brokers/binance/demo_scalping_exec/benchmark_runner.py
+++ b/app/services/brokers/binance/demo_scalping_exec/benchmark_runner.py
@@ -1,0 +1,91 @@
+"""Phase 1 — compute + store the daily buy&hold benchmark for a scalping review.
+
+Bridges the Demo market-data client (day open/close klines) and the pure
+benchmark math to the review service's storage. Lives under
+``demo_scalping_exec`` (already market-data-aware) — NOT under the review
+router/service, which must stay broker/market-data-free (ROB-315 boundary).
+Best-effort: any market-data failure leaves the benchmark NULL (the review
+still renders the strategy net PnL).
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import logging
+from collections import defaultdict
+from decimal import Decimal
+from typing import Any
+
+from app.services.scalping_reviews.benchmark import (
+    daily_buy_and_hold_return_bps,
+    notional_weighted_benchmark_bps,
+)
+from app.services.scalping_reviews.service import (
+    SCALPING_REVIEW_ACCOUNT_SCOPE,
+    ScalpingReviewService,
+)
+
+logger = logging.getLogger(__name__)
+
+
+async def compute_and_store_daily_benchmark(
+    *,
+    session: Any,
+    market_data: Any,
+    review_date: dt.date,
+    product: str,
+    now: dt.datetime,
+    session_tag: str = "",
+    account_scope: str = SCALPING_REVIEW_ACCOUNT_SCOPE,
+) -> Decimal | None:
+    """Compute the notional-weighted daily buy&hold benchmark from that day's
+    fill-proven analytics rows and store it on the review row. Returns the
+    stored value (``None`` when it cannot be computed). Never raises on a
+    market-data failure — logs and stores ``None``."""
+    service = ScalpingReviewService(session)
+    rows = await service.list_analytics(review_date=review_date, product=product)
+
+    notional_by_symbol: dict[str, Decimal] = defaultdict(lambda: Decimal("0"))
+    for row in rows:
+        if row.entry_price is None or row.entry_notional_usdt is None:
+            continue  # partial/anomaly row — no capital basis
+        notional_by_symbol[row.symbol] += row.entry_notional_usdt
+
+    value: Decimal | None = None
+    detail: dict[str, Any] = {}
+    try:
+        weighted: list[tuple[Decimal, Decimal]] = []
+        for symbol, notional in notional_by_symbol.items():
+            candles = await market_data.fetch_klines(
+                product, symbol, interval="1d", limit=1
+            )
+            if not candles:
+                continue
+            candle = candles[0]
+            bps = daily_buy_and_hold_return_bps(
+                open_price=candle.open, close_price=candle.close
+            )
+            weighted.append((notional, bps))
+            detail[symbol] = {
+                "open": str(candle.open),
+                "close": str(candle.close),
+                "bps": str(bps),
+                "notional_usdt": str(notional),
+            }
+        value = notional_weighted_benchmark_bps(weighted)
+    except Exception:  # noqa: BLE001 — benchmark is best-effort, never fatal
+        logger.exception(
+            "daily benchmark computation failed for %s %s", product, review_date
+        )
+        return None
+
+    await service.set_benchmark(
+        review_date=review_date,
+        product=product,
+        value=value,
+        now=now,
+        session_tag=session_tag,
+        account_scope=account_scope,
+        detail=detail or None,
+    )
+    return value

--- a/app/services/brokers/binance/demo_scalping_exec/benchmark_runner.py
+++ b/app/services/brokers/binance/demo_scalping_exec/benchmark_runner.py
@@ -77,6 +77,15 @@ async def compute_and_store_daily_benchmark(
         logger.exception(
             "daily benchmark computation failed for %s %s", product, review_date
         )
+        await service.set_benchmark(
+            review_date=review_date,
+            product=product,
+            value=None,
+            now=now,
+            session_tag=session_tag,
+            account_scope=account_scope,
+            detail=None,
+        )
         return None
 
     await service.set_benchmark(

--- a/app/services/brokers/binance/demo_scalping_exec/executor.py
+++ b/app/services/brokers/binance/demo_scalping_exec/executor.py
@@ -227,6 +227,27 @@ class DemoScalpingExecutor:
             return None
         return spot_avg_fill_price(cummulative_quote_qty=cq, executed_qty=eq)
 
+    def _round_trip_realized_pnl_usdt(
+        self, intent: OrderIntent, ref: Any, qty: Decimal
+    ) -> Decimal | None:
+        """Round-trip net PnL (USDT, signed; a loss is negative) for the durable
+        daily-loss-budget gate (``ledger_state._realized_loss_today``). ``None``
+        when either leg lacks a proven fill price — never fabricated. Independent
+        of the exit *reference* price (that only moves exit-slippage telemetry),
+        so this equals the analytics row's ``net_pnl_usdt``."""
+        entry_fill = self._open_fill_price
+        if entry_fill is None or self._close_fill_price is None:
+            return None
+        econ = build_round_trip_economics(
+            side=intent.side,
+            qty=qty,
+            entry_reference_price=intent.entry_reference_price or ref.price,
+            entry_fill_price=entry_fill,
+            fee_rate_bps=DEMO_SCALPING_FEE_RATE_BPS,
+            exit_fill_price=self._close_fill_price,
+        )
+        return econ.net_pnl_usdt
+
     async def _finalize_analytics(
         self,
         intent: OrderIntent,
@@ -914,9 +935,16 @@ class DemoScalpingExecutor:
                 extra_metadata_merge=_exit_metadata(exit_reason, monitor_error, "dust"),
             )
             if close_cid is not None and close_filled:
+                realized_pnl = self._round_trip_realized_pnl_usdt(intent, ref, qty)
                 await self.ledger.record_closed(client_order_id=close_cid, now=self.now)
                 await self.ledger.record_reconciled(
-                    client_order_id=close_cid, now=self.now
+                    client_order_id=close_cid,
+                    now=self.now,
+                    extra_metadata_merge=(
+                        {"realized_pnl_usdt": str(realized_pnl)}
+                        if realized_pnl is not None
+                        else None
+                    ),
                 )
             return ExecutionResult(
                 intent=intent,
@@ -1033,9 +1061,16 @@ class DemoScalpingExecutor:
                 extra_metadata_merge=_exit_metadata(exit_reason, monitor_error),
             )
             if close_cid is not None and close_filled:
+                realized_pnl = self._round_trip_realized_pnl_usdt(intent, ref, qty)
                 await self.ledger.record_closed(client_order_id=close_cid, now=self.now)
                 await self.ledger.record_reconciled(
-                    client_order_id=close_cid, now=self.now
+                    client_order_id=close_cid,
+                    now=self.now,
+                    extra_metadata_merge=(
+                        {"realized_pnl_usdt": str(realized_pnl)}
+                        if realized_pnl is not None
+                        else None
+                    ),
                 )
             return ExecutionResult(
                 intent=intent,

--- a/app/services/scalping_reviews/benchmark.py
+++ b/app/services/scalping_reviews/benchmark.py
@@ -1,0 +1,38 @@
+"""Phase 1 — pure daily buy&hold benchmark math for the demo scalping review.
+
+No DB, no network, no market-data client. The market-data fetch + storage
+live in ``demo_scalping_exec.benchmark_runner``; this module stays pure so it
+is trivially testable and safe to import from the review service boundary.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from decimal import Decimal
+
+_BPS = Decimal("10000")
+
+
+def daily_buy_and_hold_return_bps(
+    *, open_price: Decimal, close_price: Decimal
+) -> Decimal:
+    """Passive buy&hold return over the day in bps: ``(close/open - 1) * 1e4``."""
+    if open_price <= 0:
+        raise ValueError(f"open_price must be > 0, got {open_price}")
+    return (close_price / open_price - Decimal("1")) * _BPS
+
+
+def notional_weighted_benchmark_bps(
+    weighted: Sequence[tuple[Decimal, Decimal]],
+) -> Decimal | None:
+    """Notional-weighted mean of per-symbol benchmark bps.
+
+    ``weighted`` is a sequence of ``(notional_usdt, benchmark_bps)`` pairs.
+    Mirrors the strategy ``net_return_bps`` capital-weighting (rollup.py) so
+    strategy vs benchmark are comparable. Returns ``None`` when there is no
+    positive notional to weight by."""
+    total_notional = sum((n for n, _ in weighted), Decimal("0"))
+    if total_notional <= 0:
+        return None
+    weighted_sum = sum((n * b for n, b in weighted), Decimal("0"))
+    return weighted_sum / total_notional

--- a/app/services/scalping_reviews/service.py
+++ b/app/services/scalping_reviews/service.py
@@ -10,6 +10,7 @@ touches any broker / order / scheduler surface.
 from __future__ import annotations
 
 import datetime as dt
+from decimal import Decimal
 from typing import Any
 
 from sqlalchemy import select
@@ -161,6 +162,40 @@ class ScalpingReviewService:
         review.avg_holding_seconds = rollup.avg_holding_seconds
         review.exit_reason_counts = rollup.exit_reason_counts
         review.source_payload = rollup.source_payload
+
+    async def set_benchmark(
+        self,
+        *,
+        review_date: dt.date,
+        product: str,
+        value: Decimal | None,
+        now: dt.datetime,
+        session_tag: str = "",
+        account_scope: str = SCALPING_REVIEW_ACCOUNT_SCOPE,
+        detail: dict[str, Any] | None = None,
+    ) -> ScalpingDailyReview | None:
+        """Store the daily buy&hold benchmark on an existing review row.
+
+        Separate from ``build_draft`` (rollup-only, never imports a market-data
+        client) so the market-data-aware ``benchmark_runner`` computes the value
+        out of band and persists it here. No-op on a missing row (``None``) or a
+        ``locked`` review (returned untouched). ``detail`` (per-symbol audit) is
+        merged under ``source_payload['benchmark']``."""
+        _require_demo_scope(account_scope)
+        review = await self._get_by_key(
+            review_date, product, account_scope, session_tag
+        )
+        if review is None or review.status == "locked":
+            return review
+        review.benchmark_return_bps = value
+        if detail is not None:
+            review.source_payload = {
+                **(review.source_payload or {}),
+                "benchmark": detail,
+            }
+        review.updated_at = now
+        await self._session.flush()
+        return review
 
     # ------------------------------------------------------------------
     # Reads

--- a/docs/superpowers/plans/2026-06-20-binance-demo-phase1-measurement.md
+++ b/docs/superpowers/plans/2026-06-20-binance-demo-phase1-measurement.md
@@ -1,0 +1,1073 @@
+# Binance Demo 스캘핑 Phase 1 — 측정 신뢰화 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 매일 모의 루프의 수치를 신뢰 가능하게 만든다 — (A) 라운드트립 net PnL을 ledger에 기록해 손실예산 게이트를 실효화하고, (B) 일별 buy&hold 벤치마크로 전략 vs 패시브를 비교한다.
+
+**Architecture:** 기존 `demo_scalping_exec` 실행 경로 안의 두 변경. 변경 A는 `executor.py`가 close 행 reconcile 직전에 net PnL을 계산해 close 행 `extra_metadata['realized_pnl_usdt']`(부호 포함)에 durable하게 기록한다. 변경 B는 `scalping_daily_reviews`에 `benchmark_return_bps` 컬럼을 추가하고, market-data를 아는 **benchmark_runner**(+CLI)가 일별 buy&hold를 계산해 리뷰 행에 저장한다. 리뷰 라우터/서비스는 market-data를 import하지 않는다(ROB-315 경계).
+
+**Tech Stack:** Python 3.13, SQLAlchemy(async) + asyncpg, Alembic, FastAPI, pytest-asyncio, Decimal.
+
+> **스펙 정제 노트(§4.2 대비):** 스펙은 "ScalpingReviewService가 draft 시점에 벤치마크 계산"을 제안했으나, 라우터 정적 import-guard(`tests/test_invest_api_scalping_router.py:262`, 직접 import에 `brokers/binance/demo_scalping/market_data` 류 금지)와 서비스의 "broker 무접촉" 설계 원칙 때문에, 벤치마크의 market-data fetch는 **`demo_scalping_exec/benchmark_runner.py`(가드 밖, 이미 market-data-aware) + 운영 CLI**로 분리하고, 서비스에는 순수 저장 메서드(`set_benchmark`)만 추가한다. 측정 결과(컬럼·노출)는 스펙과 동일.
+
+## Global Constraints
+
+- Python 3.13+. 모든 변경은 worktree 브랜치 `feature/binance-demo-phase1-measurement`에서. canonical repo는 main 고정.
+- Decimal은 문자열로 직렬화/저장(정밀도 보존). `realized_pnl_usdt`는 `str(Decimal)`로 ledger `extra_metadata`에 저장 — `ledger_state._realized_loss_today`가 `Decimal(str(raw))`로 복원(`ledger_state.py:41`).
+- `realized_pnl_usdt`는 **부호 포함 net**(손실=음수). **close 행에만** 기록(open 행 미기록 → 라운드트립당 1회 집계, 이중계상 금지).
+- `net_pnl_usdt`는 entry/exit fill price·qty·side·fee_rate에만 의존하고 `exit_reference_price`와 무관(`cost.py:176-184`) → close 행 기록값 == analytics 행 값(drift 없음).
+- 마이그레이션은 additive nullable, 단일 head 유지. operator가 `alembic upgrade head` 수동 실행(프로덕션 cutover 게이트). 현재 head = `885e50ac5bb1`.
+- 라우터 `app/routers/invest_scalping.py`에 금지 substring(`brokers`/`scheduler`/`executor`/`demo_scalping`/`binance`/`order_intent`/`upbit`/`alpaca`/`kis_trading`/`kis_holdings`) 포함 import를 추가하지 말 것(`tests/test_invest_api_scalping_router.py:247-281`).
+- 스캘핑 리뷰 `account_scope`는 `"binance_demo"` 고정(`SCALPING_REVIEW_ACCOUNT_SCOPE`).
+- 수수료 5bps 추정 + funding=0(`contract.py:35`, `cost.py:52`) → net은 낙관 편향(측정 caveat). "실제값" 단정 금지.
+- TDD: 실패 테스트 → 최소 구현 → 통과 → 커밋. 베이스라인 515 green(데모 스캘핑 스코프).
+- 커밋 trailer:
+  ```
+  Co-Authored-By: Paperclip <noreply@paperclip.ing>
+  Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+  Claude-Session: https://claude.ai/code/session_0115yvcHYpLv3aLeKJ36Bo9w
+  ```
+
+---
+
+### Task 1: 라운드트립 net PnL을 close 행 reconcile 메타데이터에 기록 (변경 A)
+
+**Files:**
+- Modify: `app/services/brokers/binance/demo_scalping_exec/executor.py` (helper 추가 + spot/futures close-row reconcile 2곳)
+- Test: `tests/services/brokers/binance/demo_scalping_exec/test_executor_realized_pnl.py` (생성)
+
+**Interfaces:**
+- Consumes: `build_round_trip_economics(...)`, `DEMO_SCALPING_FEE_RATE_BPS`(둘 다 executor.py에 이미 import됨), `self._open_fill_price`, `self._close_fill_price`, `ledger.record_reconciled(*, client_order_id, now, extra_metadata_merge=None)`.
+- Produces: close 행 `extra_metadata['realized_pnl_usdt']`(str(Decimal), 음수=손실) — `ledger_state._realized_loss_today`가 소비.
+
+- [ ] **Step 1: 실패 테스트 작성**
+
+`tests/services/brokers/binance/demo_scalping_exec/test_executor_realized_pnl.py` 생성. 먼저 fixture 블록을 **`tests/services/brokers/binance/demo_scalping_exec/test_executor_analytics.py`의 30-146행(`_NOW`, `_REF`, `_limits`, `_intent`, `_Ref`, `_MD`, `_Sub`, `_OO`, `_Pos`, `_FakeFutures`)을 그대로 복사**해 파일 상단에 둔다. 그 아래에:
+
+```python
+from sqlalchemy import select
+
+from app.models.binance_demo_order_ledger import BinanceDemoOrderLedger
+from app.services.brokers.binance.demo.ledger import BinanceDemoLedgerService
+from app.services.brokers.binance.demo_scalping.contract import (
+    MarketConditions,
+    ScalpingRiskLimits,
+    evaluate_risk,
+)
+from app.services.brokers.binance.demo_scalping.ledger_state import load_ledger_snapshot
+
+
+@pytest.mark.asyncio
+async def test_close_row_carries_realized_pnl_open_row_does_not(db_session) -> None:
+    client = _FakeFutures(open_px="100", close_px="100.40")
+    md = _MD([100.0, 100.4])  # 2nd poll crosses TP
+    ex = DemoScalpingExecutor(
+        product="usdm_futures",
+        client=client,
+        session=db_session,
+        reference=_Ref(),
+        now=_NOW,
+        limits=_limits("RPNLWINUSDT"),
+        market_data=md,
+        poll_delay_seconds=0.0,
+    )
+    result = await ex.execute_monitored(
+        _intent("RPNLWINUSDT"), confirm=True, max_poll_count=5
+    )
+    assert result.status == "reconciled"
+
+    analytics = await ScalpTradeAnalyticsService(db_session).get_by_open_client_order_id(
+        result.open_client_order_id
+    )
+    close_row = await db_session.scalar(
+        select(BinanceDemoOrderLedger).where(
+            BinanceDemoOrderLedger.client_order_id == result.close_client_order_id
+        )
+    )
+    open_row = await db_session.scalar(
+        select(BinanceDemoOrderLedger).where(
+            BinanceDemoOrderLedger.client_order_id == result.open_client_order_id
+        )
+    )
+    # close row carries the signed net PnL, equal to the analytics net PnL.
+    assert close_row.extra_metadata is not None
+    assert "realized_pnl_usdt" in close_row.extra_metadata
+    assert (
+        Decimal(close_row.extra_metadata["realized_pnl_usdt"])
+        == analytics.net_pnl_usdt
+    )
+    # open row is NOT stamped — single-count for _realized_loss_today.
+    assert "realized_pnl_usdt" not in (open_row.extra_metadata or {})
+
+
+@pytest.mark.asyncio
+async def test_losing_round_trip_feeds_daily_loss_budget_gate(db_session) -> None:
+    client = _FakeFutures(open_px="100", close_px="99")  # BUY then exit lower → loss
+    ex = DemoScalpingExecutor(
+        product="usdm_futures",
+        client=client,
+        session=db_session,
+        reference=_Ref(),
+        now=_NOW,
+        limits=_limits("RPNLLOSSUSDT"),
+        market_data=None,
+        poll_delay_seconds=0.0,
+    )
+    result = await ex.execute(_intent("RPNLLOSSUSDT"), confirm=True)  # immediate open+close
+    assert result.status == "reconciled"
+
+    snapshot = await load_ledger_snapshot(
+        BinanceDemoLedgerService(db_session),
+        product="usdm_futures",
+        symbol="RPNLLOSSUSDT",
+        now=_NOW,
+    )
+    # gross loss ~ (99-100)*0.1 = -0.1 plus fees → realized loss >= 0.09.
+    assert snapshot.realized_loss_today_usdt >= Decimal("0.09")
+
+    decision = evaluate_risk(
+        product="usdm_futures",
+        symbol="RPNLLOSSUSDT",
+        side="BUY",
+        target_notional_usdt=Decimal("10"),
+        limits=ScalpingRiskLimits(
+            allowlist=frozenset({"RPNLLOSSUSDT"}),
+            excluded=frozenset(),
+            daily_loss_budget_usdt=Decimal("0.05"),
+        ),
+        ledger=snapshot,
+        market=MarketConditions(
+            spread_bps=Decimal("1"),
+            data_age_seconds=1.0,
+            spot_free_base_qty=Decimal("0"),
+        ),
+    )
+    assert "daily_loss_budget_exhausted" in decision.reason_codes
+```
+
+- [ ] **Step 2: 실패 확인**
+
+Run: `cd /Users/mgh3326/work/auto_trader.binance-phase1 && uv run pytest tests/services/brokers/binance/demo_scalping_exec/test_executor_realized_pnl.py -v`
+Expected: FAIL — `test_close_row_carries_realized_pnl_open_row_does_not`에서 `"realized_pnl_usdt" not in close_row.extra_metadata` (현재 미기록), `test_losing_round_trip...`에서 `realized_loss_today_usdt == 0`이라 `daily_loss_budget_exhausted` 미발화.
+
+- [ ] **Step 3: 헬퍼 추가**
+
+`executor.py`에서 `_finalize_analytics`(라인 230) 메서드 **바로 위**에 헬퍼를 추가:
+
+```python
+    def _round_trip_realized_pnl_usdt(
+        self, intent: OrderIntent, ref: Any, qty: Decimal
+    ) -> Decimal | None:
+        """Round-trip net PnL (USDT, signed; a loss is negative) for the durable
+        daily-loss-budget gate (``ledger_state._realized_loss_today``). ``None``
+        when either leg lacks a proven fill price — never fabricated. Independent
+        of the exit *reference* price (that only moves exit-slippage telemetry),
+        so this equals the analytics row's ``net_pnl_usdt``."""
+        entry_fill = self._open_fill_price
+        if entry_fill is None or self._close_fill_price is None:
+            return None
+        econ = build_round_trip_economics(
+            side=intent.side,
+            qty=qty,
+            entry_reference_price=intent.entry_reference_price or ref.price,
+            entry_fill_price=entry_fill,
+            fee_rate_bps=DEMO_SCALPING_FEE_RATE_BPS,
+            exit_fill_price=self._close_fill_price,
+        )
+        return econ.net_pnl_usdt
+```
+
+- [ ] **Step 4: spot close-row reconcile에 기록**
+
+`executor.py`의 `_close_and_reconcile_spot` 라인 916-920을 교체:
+
+```python
+            if close_cid is not None and close_filled:
+                realized_pnl = self._round_trip_realized_pnl_usdt(intent, ref, qty)
+                await self.ledger.record_closed(client_order_id=close_cid, now=self.now)
+                await self.ledger.record_reconciled(
+                    client_order_id=close_cid,
+                    now=self.now,
+                    extra_metadata_merge=(
+                        {"realized_pnl_usdt": str(realized_pnl)}
+                        if realized_pnl is not None
+                        else None
+                    ),
+                )
+```
+
+- [ ] **Step 5: futures close-row reconcile에 기록**
+
+`executor.py`의 `_close_and_reconcile_futures` 라인 1035-1039를 교체:
+
+```python
+            if close_cid is not None and close_filled:
+                realized_pnl = self._round_trip_realized_pnl_usdt(intent, ref, qty)
+                await self.ledger.record_closed(client_order_id=close_cid, now=self.now)
+                await self.ledger.record_reconciled(
+                    client_order_id=close_cid,
+                    now=self.now,
+                    extra_metadata_merge=(
+                        {"realized_pnl_usdt": str(realized_pnl)}
+                        if realized_pnl is not None
+                        else None
+                    ),
+                )
+```
+
+- [ ] **Step 6: 통과 확인 + 회귀**
+
+Run: `uv run pytest tests/services/brokers/binance/demo_scalping_exec/test_executor_realized_pnl.py tests/services/brokers/binance/demo_scalping_exec/test_executor_analytics.py -v`
+Expected: PASS (신규 2개 + 기존 analytics 회귀 전부 green — econ 값 불변, 위치만 추가).
+
+- [ ] **Step 7: 커밋**
+
+```bash
+cd /Users/mgh3326/work/auto_trader.binance-phase1
+git add app/services/brokers/binance/demo_scalping_exec/executor.py tests/services/brokers/binance/demo_scalping_exec/test_executor_realized_pnl.py
+git commit -F - <<'EOF'
+feat: record round-trip realized_pnl_usdt on close ledger row (변경 A)
+
+executor가 close 행 reconcile 직전 net PnL을 계산해 close 행
+extra_metadata['realized_pnl_usdt'](부호 포함)에 durable 기록 →
+ledger_state._realized_loss_today / DAILY_LOSS_BUDGET_EXHAUSTED 게이트 실효화.
+close 행에만 기록(이중계상 방지), partial 행은 미기록(날조 금지).
+
+Co-Authored-By: Paperclip <noreply@paperclip.ing>
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_0115yvcHYpLv3aLeKJ36Bo9w
+EOF
+```
+
+---
+
+### Task 2: `benchmark_return_bps` 컬럼 + 마이그레이션 (변경 B-1)
+
+**Files:**
+- Modify: `app/models/scalping_reviews.py` (컬럼 추가, `net_return_bps` 다음)
+- Create: `alembic/versions/20260620_scalp_benchmark_return_bps.py`
+- Test: `tests/services/scalping_reviews/test_benchmark_column.py` (생성)
+
+**Interfaces:**
+- Produces: `ScalpingDailyReview.benchmark_return_bps: Mapped[Decimal | None]` (Numeric(12,4), nullable).
+
+- [ ] **Step 1: 실패 테스트 작성**
+
+`tests/services/scalping_reviews/test_benchmark_column.py` 생성:
+
+```python
+from __future__ import annotations
+
+import datetime as dt
+from decimal import Decimal
+
+import pytest
+
+from app.models.scalping_reviews import ScalpingDailyReview
+
+_NOW = dt.datetime(2026, 6, 20, 12, 0, 0, tzinfo=dt.UTC)
+
+
+@pytest.mark.asyncio
+async def test_benchmark_return_bps_column_round_trips(db_session) -> None:
+    review = ScalpingDailyReview(
+        review_date=dt.date(2026, 6, 20),
+        product="usdm_futures",
+        account_scope="binance_demo",
+        session_tag="",
+        decision="review",
+        status="draft",
+        created_at=_NOW,
+        updated_at=_NOW,
+        benchmark_return_bps=Decimal("12.3456"),
+    )
+    db_session.add(review)
+    await db_session.flush()
+    await db_session.refresh(review)
+    assert review.benchmark_return_bps == Decimal("12.3456")
+```
+
+- [ ] **Step 2: 실패 확인**
+
+Run: `uv run pytest tests/services/scalping_reviews/test_benchmark_column.py -v`
+Expected: FAIL — `TypeError: 'benchmark_return_bps' is an invalid keyword argument` (모델에 컬럼 없음).
+
+- [ ] **Step 3: 모델에 컬럼 추가**
+
+`app/models/scalping_reviews.py`의 `net_return_bps` 컬럼(약 122-124행) **바로 다음**에 추가:
+
+```python
+    benchmark_return_bps: Mapped[Decimal | None] = mapped_column(
+        Numeric(12, 4), nullable=True
+    )
+```
+
+- [ ] **Step 4: 마이그레이션 생성**
+
+`alembic/versions/20260620_scalp_benchmark_return_bps.py` 생성:
+
+```python
+"""add benchmark_return_bps to scalping_daily_reviews
+
+Revision ID: 20260620_scalp_benchmark
+Revises: 885e50ac5bb1
+Create Date: 2026-06-20
+
+Phase 1 — daily buy&hold benchmark column for the demo scalping review.
+Additive nullable; safe forward/backward.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260620_scalp_benchmark"
+down_revision: str | Sequence[str] | None = "885e50ac5bb1"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "scalping_daily_reviews",
+        sa.Column("benchmark_return_bps", sa.Numeric(12, 4), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("scalping_daily_reviews", "benchmark_return_bps")
+```
+
+- [ ] **Step 5: 단일 head + 마이그레이션 적용 확인**
+
+Run: `uv run alembic heads`
+Expected: 단일 head `20260620_scalp_benchmark (head)`.
+Run: `uv run alembic upgrade head && uv run alembic current`
+Expected: 에러 없이 `20260620_scalp_benchmark`.
+
+- [ ] **Step 6: 통과 확인**
+
+Run: `uv run pytest tests/services/scalping_reviews/test_benchmark_column.py -v`
+Expected: PASS.
+
+- [ ] **Step 7: 커밋**
+
+```bash
+git add app/models/scalping_reviews.py alembic/versions/20260620_scalp_benchmark_return_bps.py tests/services/scalping_reviews/test_benchmark_column.py
+git commit -F - <<'EOF'
+feat: add benchmark_return_bps to scalping_daily_reviews (변경 B-1)
+
+일별 buy&hold 벤치마크 저장용 additive nullable 컬럼 + 마이그레이션
+(down_revision 885e50ac5bb1, 단일 head). operator alembic upgrade 게이트.
+
+Co-Authored-By: Paperclip <noreply@paperclip.ing>
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_0115yvcHYpLv3aLeKJ36Bo9w
+EOF
+```
+
+---
+
+### Task 3: 순수 벤치마크 함수 (변경 B-2)
+
+**Files:**
+- Create: `app/services/scalping_reviews/benchmark.py`
+- Test: `tests/services/scalping_reviews/test_benchmark.py` (생성)
+
+**Interfaces:**
+- Produces:
+  - `daily_buy_and_hold_return_bps(*, open_price: Decimal, close_price: Decimal) -> Decimal`
+  - `notional_weighted_benchmark_bps(weighted: Sequence[tuple[Decimal, Decimal]]) -> Decimal | None` (각 원소 `(notional_usdt, benchmark_bps)`)
+
+- [ ] **Step 1: 실패 테스트 작성**
+
+`tests/services/scalping_reviews/test_benchmark.py` 생성:
+
+```python
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from app.services.scalping_reviews.benchmark import (
+    daily_buy_and_hold_return_bps,
+    notional_weighted_benchmark_bps,
+)
+
+
+def test_daily_buy_and_hold_return_bps_up_down_flat() -> None:
+    assert daily_buy_and_hold_return_bps(
+        open_price=Decimal("100"), close_price=Decimal("101")
+    ) == Decimal("100")
+    assert daily_buy_and_hold_return_bps(
+        open_price=Decimal("100"), close_price=Decimal("99")
+    ) == Decimal("-100")
+    assert daily_buy_and_hold_return_bps(
+        open_price=Decimal("100"), close_price=Decimal("100")
+    ) == Decimal("0")
+
+
+def test_daily_buy_and_hold_rejects_nonpositive_open() -> None:
+    with pytest.raises(ValueError):
+        daily_buy_and_hold_return_bps(open_price=Decimal("0"), close_price=Decimal("1"))
+
+
+def test_notional_weighted_benchmark_bps_weights_by_notional() -> None:
+    # (100*100 + 300*-20) / 400 = 10
+    assert notional_weighted_benchmark_bps(
+        [(Decimal("100"), Decimal("100")), (Decimal("300"), Decimal("-20"))]
+    ) == Decimal("10")
+
+
+def test_notional_weighted_benchmark_bps_none_when_no_notional() -> None:
+    assert notional_weighted_benchmark_bps([]) is None
+    assert notional_weighted_benchmark_bps([(Decimal("0"), Decimal("100"))]) is None
+```
+
+- [ ] **Step 2: 실패 확인**
+
+Run: `uv run pytest tests/services/scalping_reviews/test_benchmark.py -v`
+Expected: FAIL — `ModuleNotFoundError: app.services.scalping_reviews.benchmark`.
+
+- [ ] **Step 3: 모듈 구현**
+
+`app/services/scalping_reviews/benchmark.py` 생성:
+
+```python
+"""Phase 1 — pure daily buy&hold benchmark math for the demo scalping review.
+
+No DB, no network, no market-data client. The market-data fetch + storage
+live in ``demo_scalping_exec.benchmark_runner``; this module stays pure so it
+is trivially testable and safe to import from the review service boundary.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from decimal import Decimal
+
+_BPS = Decimal("10000")
+
+
+def daily_buy_and_hold_return_bps(
+    *, open_price: Decimal, close_price: Decimal
+) -> Decimal:
+    """Passive buy&hold return over the day in bps: ``(close/open - 1) * 1e4``."""
+    if open_price <= 0:
+        raise ValueError(f"open_price must be > 0, got {open_price}")
+    return (close_price / open_price - Decimal("1")) * _BPS
+
+
+def notional_weighted_benchmark_bps(
+    weighted: Sequence[tuple[Decimal, Decimal]],
+) -> Decimal | None:
+    """Notional-weighted mean of per-symbol benchmark bps.
+
+    ``weighted`` is a sequence of ``(notional_usdt, benchmark_bps)`` pairs.
+    Mirrors the strategy ``net_return_bps`` capital-weighting (rollup.py) so
+    strategy vs benchmark are comparable. Returns ``None`` when there is no
+    positive notional to weight by."""
+    total_notional = sum((n for n, _ in weighted), Decimal("0"))
+    if total_notional <= 0:
+        return None
+    weighted_sum = sum((n * b for n, b in weighted), Decimal("0"))
+    return weighted_sum / total_notional
+```
+
+- [ ] **Step 4: 통과 확인**
+
+Run: `uv run pytest tests/services/scalping_reviews/test_benchmark.py -v`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add app/services/scalping_reviews/benchmark.py tests/services/scalping_reviews/test_benchmark.py
+git commit -F - <<'EOF'
+feat: pure daily buy&hold benchmark math (변경 B-2)
+
+daily_buy_and_hold_return_bps + notional_weighted_benchmark_bps (순수, DB/네트워크
+없음). 전략 net_return_bps와 동일한 capital-weighting.
+
+Co-Authored-By: Paperclip <noreply@paperclip.ing>
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_0115yvcHYpLv3aLeKJ36Bo9w
+EOF
+```
+
+---
+
+### Task 4: 서비스 저장 메서드 + 직렬화 노출 (변경 B-3)
+
+**Files:**
+- Modify: `app/services/scalping_reviews/service.py` (`set_benchmark` 추가)
+- Modify: `app/routers/invest_scalping.py` (`_serialize_review` metrics에 `benchmarkReturnBps`)
+- Test: `tests/services/scalping_reviews/test_service.py` (append) + `tests/services/scalping_reviews/test_serialize_benchmark.py` (생성)
+
+**Interfaces:**
+- Consumes: `ScalpingDailyReview.benchmark_return_bps`(Task 2), `_get_by_key`, `SCALPING_REVIEW_ACCOUNT_SCOPE`, `_require_demo_scope`.
+- Produces: `ScalpingReviewService.set_benchmark(*, review_date, product, value, now, session_tag="", account_scope=SCALPING_REVIEW_ACCOUNT_SCOPE, detail=None) -> ScalpingDailyReview | None` — benchmark_runner(Task 5)가 소비.
+
+- [ ] **Step 1: 실패 테스트 작성 (서비스)**
+
+`tests/services/scalping_reviews/test_service.py` **맨 끝에 append** (기존 `_instrument`/`_analytics`/`_DATE`/`_NOW` 헬퍼 재사용):
+
+```python
+@pytest.mark.asyncio
+async def test_set_benchmark_persists_value_and_detail(db_session) -> None:
+    iid = await _instrument(db_session)
+    await _analytics(
+        db_session, iid, tag="w",
+        entry_price=Decimal("100"), exit_price=Decimal("101"),
+        entry_notional_usdt=Decimal("100"), net_pnl_usdt=Decimal("0.9"),
+        gross_pnl_usdt=Decimal("1.0"), exit_reason="take_profit",
+    )
+    svc = ScalpingReviewService(db_session)
+    await svc.build_draft(review_date=_DATE, product="usdm_futures", now=_NOW)
+    updated = await svc.set_benchmark(
+        review_date=_DATE, product="usdm_futures", value=Decimal("12.5"), now=_NOW,
+        detail={"XRPUSDT": {"open": "100", "close": "100.5", "bps": "50"}},
+    )
+    assert updated is not None
+    assert updated.benchmark_return_bps == Decimal("12.5")
+    assert updated.source_payload["benchmark"]["XRPUSDT"]["bps"] == "50"
+    assert updated.net_pnl_usdt == Decimal("0.9")  # rollup metrics preserved
+
+
+@pytest.mark.asyncio
+async def test_set_benchmark_noop_on_missing_review(db_session) -> None:
+    svc = ScalpingReviewService(db_session)
+    assert await svc.set_benchmark(
+        review_date=dt.date(2099, 1, 1), product="usdm_futures",
+        value=Decimal("1"), now=_NOW,
+    ) is None
+
+
+@pytest.mark.asyncio
+async def test_set_benchmark_skips_locked_review(db_session) -> None:
+    iid = await _instrument(db_session)
+    await _analytics(
+        db_session, iid, tag="a",
+        entry_price=Decimal("100"), exit_price=Decimal("101"),
+        entry_notional_usdt=Decimal("100"), net_pnl_usdt=Decimal("0.5"),
+        gross_pnl_usdt=Decimal("0.6"), exit_reason="take_profit",
+    )
+    svc = ScalpingReviewService(db_session)
+    r = await svc.build_draft(review_date=_DATE, product="usdm_futures", now=_NOW)
+    await svc.update_review(r.id, now=_NOW, status="locked")
+    res = await svc.set_benchmark(
+        review_date=_DATE, product="usdm_futures", value=Decimal("9"), now=_NOW
+    )
+    assert res is not None and res.status == "locked"
+    assert res.benchmark_return_bps is None  # not written while locked
+```
+
+`tests/services/scalping_reviews/test_serialize_benchmark.py` 생성:
+
+```python
+from __future__ import annotations
+
+import datetime as dt
+from decimal import Decimal
+
+from app.models.scalping_reviews import ScalpingDailyReview
+from app.routers.invest_scalping import _serialize_review
+
+_NOW = dt.datetime(2026, 6, 20, 12, 0, 0, tzinfo=dt.UTC)
+
+
+def test_serialize_review_includes_benchmark_return_bps() -> None:
+    review = ScalpingDailyReview(
+        review_date=dt.date(2026, 6, 20),
+        product="usdm_futures",
+        account_scope="binance_demo",
+        session_tag="",
+        decision="review",
+        status="draft",
+        created_at=_NOW,
+        updated_at=_NOW,
+        benchmark_return_bps=Decimal("7.5"),
+    )
+    out = _serialize_review(review)
+    assert out["metrics"]["benchmarkReturnBps"] == "7.5"
+```
+
+- [ ] **Step 2: 실패 확인**
+
+Run: `uv run pytest tests/services/scalping_reviews/test_service.py -k set_benchmark tests/services/scalping_reviews/test_serialize_benchmark.py -v`
+Expected: FAIL — `AttributeError: 'ScalpingReviewService' object has no attribute 'set_benchmark'` 및 `KeyError: 'benchmarkReturnBps'`.
+
+- [ ] **Step 3: 서비스 메서드 추가**
+
+`app/services/scalping_reviews/service.py`의 `_apply_rollup`(static, 라인 148-163) **바로 다음**에 추가:
+
+```python
+    async def set_benchmark(
+        self,
+        *,
+        review_date: dt.date,
+        product: str,
+        value: Decimal | None,
+        now: dt.datetime,
+        session_tag: str = "",
+        account_scope: str = SCALPING_REVIEW_ACCOUNT_SCOPE,
+        detail: dict[str, Any] | None = None,
+    ) -> ScalpingDailyReview | None:
+        """Store the daily buy&hold benchmark on an existing review row.
+
+        Separate from ``build_draft`` (rollup-only, never imports a market-data
+        client) so the market-data-aware ``benchmark_runner`` computes the value
+        out of band and persists it here. No-op on a missing row (``None``) or a
+        ``locked`` review (returned untouched). ``detail`` (per-symbol audit) is
+        merged under ``source_payload['benchmark']``."""
+        _require_demo_scope(account_scope)
+        review = await self._get_by_key(
+            review_date, product, account_scope, session_tag
+        )
+        if review is None or review.status == "locked":
+            return review
+        review.benchmark_return_bps = value
+        if detail is not None:
+            review.source_payload = {
+                **(review.source_payload or {}),
+                "benchmark": detail,
+            }
+        review.updated_at = now
+        await self._session.flush()
+        return review
+```
+
+`Decimal`은 import 필요: `service.py` 상단 import에 `from decimal import Decimal` 추가(현재 없음). `Any`/`dt`는 이미 import됨.
+
+- [ ] **Step 4: 라우터 직렬화 노출**
+
+`app/routers/invest_scalping.py`의 `_serialize_review` metrics dict에서 `"netReturnBps": _num(review.net_return_bps),`(라인 87) **바로 다음**에 추가:
+
+```python
+            "benchmarkReturnBps": _num(review.benchmark_return_bps),
+```
+
+(import 추가 없음 — 라우터 가드 위반 없음.)
+
+- [ ] **Step 5: 통과 확인 + 라우터 가드 회귀**
+
+Run: `uv run pytest tests/services/scalping_reviews/test_service.py tests/services/scalping_reviews/test_serialize_benchmark.py tests/test_invest_api_scalping_router.py -v`
+Expected: PASS (set_benchmark 3개 + serialize 1개 + 기존 라우터/서비스 회귀 전부 green; `test_router_imports_no_broker_order_scheduler_modules` 포함).
+
+- [ ] **Step 6: 커밋**
+
+```bash
+git add app/services/scalping_reviews/service.py app/routers/invest_scalping.py tests/services/scalping_reviews/test_service.py tests/services/scalping_reviews/test_serialize_benchmark.py
+git commit -F - <<'EOF'
+feat: ScalpingReviewService.set_benchmark + serialize benchmarkReturnBps (변경 B-3)
+
+순수 저장 메서드(locked skip, source_payload['benchmark'] 머지) + 라우터
+직렬화 노출. 서비스/라우터는 market-data 무import(ROB-315 경계 유지).
+
+Co-Authored-By: Paperclip <noreply@paperclip.ing>
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_0115yvcHYpLv3aLeKJ36Bo9w
+EOF
+```
+
+---
+
+### Task 5: 벤치마크 runner + 운영 CLI (변경 B-4)
+
+**Files:**
+- Create: `app/services/brokers/binance/demo_scalping_exec/benchmark_runner.py`
+- Create: `scripts/binance_demo_scalping_benchmark.py`
+- Test: `tests/services/brokers/binance/demo_scalping_exec/test_benchmark_runner.py` (생성)
+
+**Interfaces:**
+- Consumes: `market_data.fetch_klines(product, symbol, interval="1d", limit=1) -> list[Candle]`, `ScalpingReviewService.list_analytics`/`set_benchmark`(Task 4), 순수 벤치마크 함수(Task 3).
+- Produces: `compute_and_store_daily_benchmark(*, session, market_data, review_date, product, now, session_tag="", account_scope=...) -> Decimal | None`.
+
+- [ ] **Step 1: 실패 테스트 작성**
+
+`tests/services/brokers/binance/demo_scalping_exec/test_benchmark_runner.py` 생성. `_instrument`/`_analytics`/`_DATE`/`_NOW` 헬퍼를 **`tests/services/scalping_reviews/test_service.py` 22-67행에서 복사**해 상단에 두고:
+
+```python
+from __future__ import annotations
+
+import datetime as dt
+from decimal import Decimal
+
+import pytest
+from sqlalchemy import select
+
+from app.models.crypto_instruments import CryptoInstrument
+from app.models.scalp_trade_analytics import ScalpTradeAnalytics
+from app.services.brokers.binance.demo_scalping.signal import Candle
+from app.services.brokers.binance.demo_scalping_exec.benchmark_runner import (
+    compute_and_store_daily_benchmark,
+)
+from app.services.scalping_reviews.service import ScalpingReviewService
+
+# (여기에 test_service.py 22-67행의 _DATE / _NOW / _instrument / _analytics 복사)
+
+
+class _FakeMD:
+    """day candle per symbol: {symbol: (open, close)}."""
+
+    def __init__(self, prices: dict[str, tuple[float, float]]) -> None:
+        self._prices = prices
+        self.calls: list[tuple] = []
+
+    async def fetch_klines(self, product, symbol, *, interval="1m", limit=50):
+        self.calls.append((product, symbol, interval, limit))
+        o, c = self._prices[symbol]
+        return [
+            Candle(
+                open_time_ms=0,
+                open=Decimal(str(o)),
+                high=Decimal(str(max(o, c))),
+                low=Decimal(str(min(o, c))),
+                close=Decimal(str(c)),
+                close_time_ms=0,
+            )
+        ]
+
+
+class _BoomMD:
+    async def fetch_klines(self, *a, **k):
+        raise RuntimeError("network down")
+
+
+@pytest.mark.asyncio
+async def test_runner_stores_notional_weighted_benchmark(db_session) -> None:
+    iid_x = await _instrument(db_session, "XRPUSDT")
+    iid_d = await _instrument(db_session, "DOGEUSDT")
+    await _analytics(
+        db_session, iid_x, tag="x", symbol="XRPUSDT",
+        entry_price=Decimal("100"), exit_price=Decimal("101"),
+        entry_notional_usdt=Decimal("100"), net_pnl_usdt=Decimal("0.9"),
+        gross_pnl_usdt=Decimal("1.0"), exit_reason="take_profit",
+    )
+    await _analytics(
+        db_session, iid_d, tag="d", symbol="DOGEUSDT",
+        entry_price=Decimal("0.1"), exit_price=Decimal("0.1"),
+        entry_notional_usdt=Decimal("300"), net_pnl_usdt=Decimal("0"),
+        gross_pnl_usdt=Decimal("0"), exit_reason="timeout",
+    )
+    svc = ScalpingReviewService(db_session)
+    await svc.build_draft(review_date=_DATE, product="usdm_futures", now=_NOW)
+    md = _FakeMD({"XRPUSDT": (100.0, 101.0), "DOGEUSDT": (100.0, 99.8)})  # +100bps, -20bps
+    value = await compute_and_store_daily_benchmark(
+        session=db_session, market_data=md, review_date=_DATE,
+        product="usdm_futures", now=_NOW,
+    )
+    # (100*100 + 300*-20) / 400 = 10
+    assert value == Decimal("10")
+    review = await svc._get_by_key(_DATE, "usdm_futures", "binance_demo", "")
+    assert review.benchmark_return_bps == Decimal("10")
+    assert "XRPUSDT" in review.source_payload["benchmark"]
+    assert all(c[2] == "1d" and c[3] == 1 for c in md.calls)  # day candle only
+
+
+@pytest.mark.asyncio
+async def test_runner_returns_none_when_market_data_fails(db_session) -> None:
+    iid = await _instrument(db_session, "XRPUSDT")
+    await _analytics(
+        db_session, iid, tag="x", symbol="XRPUSDT",
+        entry_price=Decimal("100"), exit_price=Decimal("101"),
+        entry_notional_usdt=Decimal("100"), net_pnl_usdt=Decimal("0.9"),
+        gross_pnl_usdt=Decimal("1.0"), exit_reason="take_profit",
+    )
+    svc = ScalpingReviewService(db_session)
+    await svc.build_draft(review_date=_DATE, product="usdm_futures", now=_NOW)
+    value = await compute_and_store_daily_benchmark(
+        session=db_session, market_data=_BoomMD(), review_date=_DATE,
+        product="usdm_futures", now=_NOW,
+    )
+    assert value is None
+    review = await svc._get_by_key(_DATE, "usdm_futures", "binance_demo", "")
+    assert review.benchmark_return_bps is None
+```
+
+> 참고: `_instrument(session, symbol)`은 `test_service.py`에서 두 번째 인자가 기본값 `"RVWXRPUSDT"`인 위치 인자다 — 위 테스트는 `"XRPUSDT"`/`"DOGEUSDT"`를 명시 전달한다. `_analytics(..., symbol=...)`는 `**kw`로 symbol을 덮어쓴다.
+
+- [ ] **Step 2: 실패 확인**
+
+Run: `uv run pytest tests/services/brokers/binance/demo_scalping_exec/test_benchmark_runner.py -v`
+Expected: FAIL — `ModuleNotFoundError: ...demo_scalping_exec.benchmark_runner`.
+
+- [ ] **Step 3: runner 구현**
+
+`app/services/brokers/binance/demo_scalping_exec/benchmark_runner.py` 생성:
+
+```python
+"""Phase 1 — compute + store the daily buy&hold benchmark for a scalping review.
+
+Bridges the Demo market-data client (day open/close klines) and the pure
+benchmark math to the review service's storage. Lives under
+``demo_scalping_exec`` (already market-data-aware) — NOT under the review
+router/service, which must stay broker/market-data-free (ROB-315 boundary).
+Best-effort: any market-data failure leaves the benchmark NULL (the review
+still renders the strategy net PnL).
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import logging
+from collections import defaultdict
+from decimal import Decimal
+from typing import Any
+
+from app.services.scalping_reviews.benchmark import (
+    daily_buy_and_hold_return_bps,
+    notional_weighted_benchmark_bps,
+)
+from app.services.scalping_reviews.service import (
+    SCALPING_REVIEW_ACCOUNT_SCOPE,
+    ScalpingReviewService,
+)
+
+logger = logging.getLogger(__name__)
+
+
+async def compute_and_store_daily_benchmark(
+    *,
+    session: Any,
+    market_data: Any,
+    review_date: dt.date,
+    product: str,
+    now: dt.datetime,
+    session_tag: str = "",
+    account_scope: str = SCALPING_REVIEW_ACCOUNT_SCOPE,
+) -> Decimal | None:
+    """Compute the notional-weighted daily buy&hold benchmark from that day's
+    fill-proven analytics rows and store it on the review row. Returns the
+    stored value (``None`` when it cannot be computed). Never raises on a
+    market-data failure — logs and stores ``None``."""
+    service = ScalpingReviewService(session)
+    rows = await service.list_analytics(review_date=review_date, product=product)
+
+    notional_by_symbol: dict[str, Decimal] = defaultdict(lambda: Decimal("0"))
+    for row in rows:
+        if row.entry_price is None or row.entry_notional_usdt is None:
+            continue  # partial/anomaly row — no capital basis
+        notional_by_symbol[row.symbol] += row.entry_notional_usdt
+
+    value: Decimal | None = None
+    detail: dict[str, Any] = {}
+    try:
+        weighted: list[tuple[Decimal, Decimal]] = []
+        for symbol, notional in notional_by_symbol.items():
+            candles = await market_data.fetch_klines(
+                product, symbol, interval="1d", limit=1
+            )
+            if not candles:
+                continue
+            candle = candles[0]
+            bps = daily_buy_and_hold_return_bps(
+                open_price=candle.open, close_price=candle.close
+            )
+            weighted.append((notional, bps))
+            detail[symbol] = {
+                "open": str(candle.open),
+                "close": str(candle.close),
+                "bps": str(bps),
+                "notional_usdt": str(notional),
+            }
+        value = notional_weighted_benchmark_bps(weighted)
+    except Exception:  # noqa: BLE001 — benchmark is best-effort, never fatal
+        logger.exception(
+            "daily benchmark computation failed for %s %s", product, review_date
+        )
+        return None
+
+    await service.set_benchmark(
+        review_date=review_date,
+        product=product,
+        value=value,
+        now=now,
+        session_tag=session_tag,
+        account_scope=account_scope,
+        detail=detail or None,
+    )
+    return value
+```
+
+- [ ] **Step 4: runner 테스트 통과 확인**
+
+Run: `uv run pytest tests/services/brokers/binance/demo_scalping_exec/test_benchmark_runner.py -v`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: CLI 구현 + 파싱 테스트**
+
+`scripts/binance_demo_scalping_benchmark.py` 생성:
+
+```python
+"""Phase 1 — operator CLI: build the daily scalping review draft + benchmark.
+
+Builds (or refreshes) the ``scalping_daily_reviews`` draft for a day/product
+from ``scalp_trade_analytics``, then computes + stores the notional-weighted
+daily buy&hold benchmark (Demo public klines, read-only). No broker/order
+mutation. Demo data hosts only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import datetime as dt
+import json
+import logging
+import sys
+
+logger = logging.getLogger("scalping_benchmark")
+
+_VALID_PRODUCTS = ("spot", "usdm_futures")
+
+
+def _parse_args(argv: list[str] | None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description=(
+            "Build the daily demo scalping review draft + notional-weighted "
+            "buy&hold benchmark (read-only; Demo data hosts only)."
+        )
+    )
+    p.add_argument("--product", required=True, choices=_VALID_PRODUCTS)
+    p.add_argument("--date", required=True, help="UTC review date YYYY-MM-DD")
+    p.add_argument("--session-tag", default="")
+    p.add_argument("--log-level", default="INFO")
+    return p.parse_args(argv)
+
+
+async def _run(args: argparse.Namespace) -> int:
+    review_date = dt.date.fromisoformat(args.date)
+    now = dt.datetime.now(dt.UTC)
+
+    from app.core.db import AsyncSessionLocal
+    from app.services.brokers.binance.demo_scalping.market_data import (
+        DemoScalpingMarketData,
+    )
+    from app.services.brokers.binance.demo_scalping_exec.benchmark_runner import (
+        compute_and_store_daily_benchmark,
+    )
+    from app.services.scalping_reviews.service import ScalpingReviewService
+
+    market_data = DemoScalpingMarketData()
+    try:
+        async with AsyncSessionLocal() as session:
+            service = ScalpingReviewService(session)
+            review = await service.build_draft(
+                review_date=review_date,
+                product=args.product,
+                now=now,
+                session_tag=args.session_tag,
+            )
+            value = await compute_and_store_daily_benchmark(
+                session=session,
+                market_data=market_data,
+                review_date=review_date,
+                product=args.product,
+                now=now,
+                session_tag=args.session_tag,
+            )
+            await session.commit()
+    finally:
+        await market_data.aclose()
+
+    print(
+        json.dumps(
+            {
+                "event": "scalping_benchmark",
+                "review_id": review.id,
+                "review_date": args.date,
+                "product": args.product,
+                "net_return_bps": (
+                    None if review.net_return_bps is None else str(review.net_return_bps)
+                ),
+                "benchmark_return_bps": None if value is None else str(value),
+            },
+            ensure_ascii=False,
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    logging.basicConfig(level=args.log_level.upper())
+    try:
+        return asyncio.run(_run(args))
+    except Exception as exc:  # noqa: BLE001 — top-level CLI guard
+        logger.error("scalping benchmark CLI failed: %s", exc)
+        return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+`tests/scripts/test_binance_demo_scalping_benchmark.py` 생성:
+
+```python
+from __future__ import annotations
+
+from scripts.binance_demo_scalping_benchmark import _parse_args
+
+
+def test_cli_parse_args() -> None:
+    ns = _parse_args(["--product", "usdm_futures", "--date", "2026-06-20"])
+    assert ns.product == "usdm_futures"
+    assert ns.date == "2026-06-20"
+    assert ns.session_tag == ""
+```
+
+- [ ] **Step 6: CLI 테스트 통과 확인**
+
+Run: `uv run pytest tests/scripts/test_binance_demo_scalping_benchmark.py -v`
+Expected: PASS.
+
+- [ ] **Step 7: 커밋**
+
+```bash
+git add app/services/brokers/binance/demo_scalping_exec/benchmark_runner.py scripts/binance_demo_scalping_benchmark.py tests/services/brokers/binance/demo_scalping_exec/test_benchmark_runner.py tests/scripts/test_binance_demo_scalping_benchmark.py
+git commit -F - <<'EOF'
+feat: daily benchmark runner + operator CLI (변경 B-4)
+
+demo_scalping_exec.benchmark_runner가 fill-proven analytics 행의 종목별 notional로
+일별 buy&hold(1d klines)를 notional 가중 계산해 리뷰 행에 저장(best-effort, 실패시 NULL).
+운영 CLI scripts/binance_demo_scalping_benchmark.py가 draft+benchmark를 묶어 실행.
+라우터/서비스 경계 유지(market-data는 runner/CLI에만).
+
+Co-Authored-By: Paperclip <noreply@paperclip.ing>
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_0115yvcHYpLv3aLeKJ36Bo9w
+EOF
+```
+
+---
+
+### 최종 검증 (전체 스위트)
+
+- [ ] **Step: 데모 스캘핑 스코프 전체 회귀**
+
+Run: `uv run pytest tests/ -q -k "demo_scalping or scalping or binance_demo or futures_demo" -p no:cacheprovider`
+Expected: 베이스라인 515 + 신규 테스트 전부 PASS, 0 failures.
+
+- [ ] **Step: lint/format/type**
+
+Run: `uv run ruff format app/ scripts/ tests/ && uv run ruff check app/ scripts/ tests/ && uv run ty check app/`
+Expected: clean (또는 변경 무관 기존 경고만).
+
+---
+
+## Self-Review (spec 대비)
+
+- **변경 A (결함#1)** → Task 1. close 행에 realized_pnl_usdt durable 기록, 단일집계, partial 미기록, 게이트 발화 e2e. ✓
+- **변경 B (벤치마크)** → Task 2(컬럼/마이그레이션) + Task 3(순수 계산) + Task 4(저장/노출) + Task 5(runner/CLI). 일별 buy&hold, notional 가중, source_payload 종목별 audit, 전략 vs 패시브 노출. ✓
+- **에러 처리(spec §6)** → realized_pnl durable txn / partial None / 벤치마크 best-effort NULL / additive 마이그레이션. ✓
+- **위험(spec §8)** → 이중계상(close-only + 단일집계 테스트), drift(net_pnl이 exit_reference 무관 — Global Constraints에 근거), grain(rollup 키 `(date,product,scope,tag)`와 set_benchmark 키 일치). ✓
+- **경계** → 라우터/서비스 market-data 무import, runner는 demo_scalping_exec(가드 밖). 라우터 가드 회귀 테스트 포함(Task 4 Step 5). ✓
+- **스펙 정제** → §4.2 "서비스 draft 시점 계산" → "runner/CLI 저장"으로 경계-안전하게 변경(상단 노트). 측정 결과는 동일.
+- **범위 밖 준수** → A/B session_tag·trade_retrospectives 마이그레이션·cron·LLM 미포함. ✓

--- a/docs/superpowers/specs/2026-06-19-binance-demo-phase1-measurement-design.md
+++ b/docs/superpowers/specs/2026-06-19-binance-demo-phase1-measurement-design.md
@@ -1,0 +1,167 @@
+# Binance Demo 스캘핑 Phase 1 — 측정 신뢰화 (Design)
+
+- **작성일**: 2026-06-19
+- **상태**: 승인됨 (브레인스토밍 → 스펙)
+- **브랜치**: `feature/binance-demo-phase1-measurement`
+- **선행 분석**: 본 세션의 2개 조사 워크플로 (히스토리/실패원인 + Phase 0 심층 정독)
+
+## 1. 배경 / 동기
+
+사용자 목표: Binance USD-M Futures Demo(`demo-fapi`)에서 **매일 자동 모의투자 루프**를
+돌리며 시행착오로 전략을 고쳐나간다. 과거 백테스트 라인(ROB-316/320/353/362/382/383)은
+모두 실패했고 ROB-384가 "단기 크립토 OHLCV 전략 라인 CLOSED"로 공식 종료했다. 실패의
+근본원인은 method가 아니라 **search-space(탐색한 전략 공간에 gross 엣지 없음)**였다.
+
+따라서 모의 루프의 가치는 "없던 엣지를 만드는 것"이 아니라 **인프라+회고 루프를 빠르게
+돌리며 다른 시그널 소스(LLM/이벤트/펀더멘털)를 싸게 시험**하는 데 있다. 이를 위해서는
+루프의 수치를 **신뢰**할 수 있어야 한다. 백테스트 실패의 4대 교훈을 모의에 그대로 반영한다:
+
+1. net(수수료+슬리피지 차감) 측정 필수 — "모의니까 비용 무시"하면 라이브 전환 때 동일 실패
+2. buy&hold 벤치마크 내장 — 능동 전략이 passive를 net으로 이기는지 처음부터 측정
+3. single-fold 자기기만 경계 — 며칠 좋은 결과 ≠ 엣지
+4. score-hacking 경계 — 단일 지표 최대화 금지(net+거래수+time_in_market 동시 관찰)
+
+## 2. 범위
+
+Phase 1 = **매일 모의 루프의 수치(손실 통제 + "유의미한가" 판단)를 신뢰 가능하게 만든다.**
+신규 기능이 아니라 **demo_scalping 인프라가 설계상 비워둔 자리 2곳을 채우는 것**이다.
+
+대상 경로: `app/services/brokers/binance/demo_scalping*` (executor/scheduler/analytics/rollup).
+Phase 0의 `scripts/binance_futures_demo_smoke.py`는 ledger만 쓰고 analytics/회고가 없으므로
+Phase 1은 **executor 경로**(`scripts/binance_demo_scalping_execute.py` / `run_scalping_tick`)를 대상으로 한다.
+
+### 2.1 In Scope (두 변경)
+
+- **변경 A — `realized_pnl_usdt` 기록 (결함#1 수리, 접근법 1A)**
+- **변경 B — 일별 buy&hold 벤치마크 (접근법 2A)**
+
+### 2.2 Out of Scope (명시적 제외)
+
+- A/B `session_tag`/`signal_snapshot` 배선 → Phase 3 (LLM 시그널 비교 시)
+- `trade_retrospectives` binance account_mode 마이그레이션(결함#2) → 스캘핑은 `scalping_daily_reviews`
+  를 쓰므로 불필요. 범용 회고 테이블로 통합할 때만 필요.
+- 매일 자동 cron(TaskIQ daily schedule) → Phase 2
+- LLM 시그널 주입(out-of-process) → Phase 3
+- `daily_order_count_cap` "하루 1회" 튜닝 → operator config(코드 변경 아님)
+- 5bps 수수료 추정을 실 Demo 커미션으로 교체 → 측정 caveat, 후속 가능
+
+## 3. 변경 A — `realized_pnl_usdt` 기록 (1A)
+
+### 3.1 문제 (검증된 결함#1)
+
+손실예산 가드는 `LedgerSnapshot.realized_loss_today_usdt`에 의존한다
+(`demo_scalping/contract.py:163` — `realized_loss_today_usdt >= daily_loss_budget_usdt`이면
+`DAILY_LOSS_BUDGET_EXHAUSTED`). 이 값은 `ledger_state._realized_loss_today`가
+**closed 행들의 `extra_metadata['realized_pnl_usdt']` 중 음수의 magnitude를 합산**해 만든다
+(`demo_scalping/ledger_state.py:34-44`).
+
+그러나 `demo_scalping_exec/executor.py` 어디에서도 `realized_pnl_usdt`를 ledger에 **쓰지 않는다**
+(grep 0건). `ledger_state.py:9-11`의 docstring이 이를 명시한다:
+*"Until PR2 writes that key, the sum is 0."* — 즉 설계상 비워둔 후속(PR2)이며,
+현재 손실예산 가드는 **영구 비발화(inert)**다. 매일 자동 루프로 가면 손실 누적 차단 부재 = 위험.
+
+### 3.2 설계
+
+`build_round_trip_economics(...)`(현재 `_finalize_analytics` 내부, `executor.py:266-274`) 호출을
+**close 행의 `record_reconciled` 전으로 1회 끌어올린다.** econ은 순수 계산(I/O 없음)이라 위치
+이동이 안전하다. 산출된 `econ.net_pnl_usdt`(부호 포함, 5bps 차감 net)를:
+
+1. **close 행의 reconcile `extra_metadata`에만** `realized_pnl_usdt`로 기록한다.
+   `_exit_metadata`(`executor.py:104-113`)를 확장하거나, close 행 `record_reconciled` 호출에만
+   해당 키를 병합한다. **open 행은 기록하지 않는다** → `_realized_loss_today`가 모든 closed 행을
+   합산하므로 라운드트립당 **정확히 1회**만 집계되어 이중계상을 방지한다.
+2. `_finalize_analytics`는 **같은 `econ`을 재사용**한다(재계산 없음) → 게이트↔분석 수치 drift 없음.
+
+### 3.3 규약
+
+- 저장 형식: 문자열(`str(Decimal)`) — `ledger_state.py:41`의 `Decimal(str(raw))`과 호환.
+- 부호: **음수 = 손실**(`ledger_state.py:42`가 `pnl < 0`일 때 `-pnl` 누적). net_pnl_usdt를 부호
+  그대로 저장한다.
+- 통화: USDT (USD-M 결제통화).
+- partial 행(`entry_fill is None`, `executor.py:261` → econ 계산 불가): `realized_pnl_usdt`
+  **미기록**. 게이트가 그 라운드트립을 단순 미집계(체결 증거 없는 PnL 날조 금지, ROB-313/315 원칙 유지).
+
+### 3.4 구현 전 검증 포인트
+
+- `BinanceDemoLedgerService.closed_rows_since`가 **close 행을 포함**하는지 확인
+  (포함해야 close 행 단독 기록으로 단일집계 성립). 플랜 1단계에서 확인.
+- `record_reconciled`가 `extra_metadata`를 받아 병합하는 정확한 시그니처 확인.
+- close 행 reconcile 호출 지점(`executor.py:911/918/1030/1037` 중 close 행에 해당하는 것) 식별.
+
+## 4. 변경 B — 일별 buy&hold 벤치마크 (2A)
+
+### 4.1 문제
+
+코드 어디에도 거래 벤치마크(buy&hold/passive)가 없다(grep 결과 144건 전부 ROB-271
+`invest_benchmark_gap`로 무관). 백테스트가 능동 전략이 BTC buy&hold(+359%)에 net으로
+완패한 교훈상, **벤치마크 없이는 "엣지"를 판정할 수 없다.**
+
+### 4.2 설계
+
+- **Additive 마이그레이션**: `scalping_daily_reviews.benchmark_return_bps` (Numeric, nullable).
+- **순수 함수**: `daily_buy_and_hold_return_bps(open_price, close_price) -> Decimal`
+  = `(close_price / open_price - 1) * 10000`.
+- **가격 출처**: 일별 리뷰 드래프트 시점(`ScalpingReviewService` / `rollup`)에 기존 `market_data`로
+  그날(UTC 일경계, `ledger_state._start_of_day_utc`와 동일 규약) **시가/종가 캔들**을 fetch.
+- **grain 정합**: rollup 단위(일별 집계 행)에 맞춘다. 다종목 거래 시 `benchmark_return_bps` =
+  **notional 가중평균**(전략 `net_return_bps = sum(net)/sum(notional)`와 동일 규약,
+  `rollup.py:69-134`). 종목별 상세는 `source_payload` JSONB에 audit용으로 저장.
+- **노출**: 일별 리뷰에 전략 `net_return_bps` vs `benchmark_return_bps`(+델타)를 나란히.
+
+### 4.3 구현 전 검증 포인트
+
+- `scalping_daily_reviews`의 grain(일별 1행 / (일,종목) / (일,account_scope))을 확인해
+  `benchmark_return_bps` 컬럼 의미와 가중 방식을 grain에 정합시킨다.
+- `market_data`의 일봉(또는 1m first/last-of-day) fetch 인터페이스 확인.
+
+## 5. 데이터 흐름
+
+```
+[매일 수동 tick] execute_monitored
+   → (변경A) econ 1회 계산(reconcile 전)
+     → close행 extra_metadata.realized_pnl_usdt(durable txn)
+     → analytics행(같은 econ 재사용)
+[같은 날 다음 tick] ledger_state._realized_loss_today = 실값
+   → evaluate_risk가 손실 누적 ≥ 예산이면 DAILY_LOSS_BUDGET_EXHAUSTED로 차단
+[일 마감] ScalpingReviewService 일별 리뷰 드래프트
+   → (변경B) 그날 시가/종가 fetch → benchmark_return_bps → 전략 vs 패시브
+```
+
+## 6. 에러 처리
+
+- econ 이동은 순수 계산 → 안전. `realized_pnl_usdt` 쓰기는 **durable reconcile 트랜잭션**의
+  일부(의도적 — 손실 게이트가 권위 있으려면 best-effort savepoint가 아니어야 함).
+- partial/no-fill → `realized_pnl_usdt` 미기록(게이트 미집계, 날조 없음).
+- 벤치마크 klines fetch 실패 → `benchmark_return_bps` NULL, 리뷰는 전략 net만으로 정상 렌더
+  (best-effort, 로그). 리뷰를 절대 차단하지 않는다.
+- 마이그레이션 additive + nullable → 안전, operator `alembic upgrade head` 게이트.
+
+## 7. 테스트
+
+- **단위**
+  - close 행에만 `realized_pnl_usdt` 기록(단일집계 단언, open 행 미기록 확인)
+  - 같은 날 누적 손실 ≥ 예산 시 `DAILY_LOSS_BUDGET_EXHAUSTED` 발화
+  - partial 행 → `realized_pnl_usdt` 미기록
+  - `daily_buy_and_hold_return_bps` 순수함수(부호 / open==close → 0 / 음·양)
+  - 벤치마크 klines 실패 → `benchmark_return_bps` NULL
+  - 다종목 → notional 가중 벤치마크
+- **통합**
+  - 같은 날 2-tick 시퀀스: 1차 손실 → 2차가 손실예산으로 차단되는 end-to-end
+- **회귀**
+  - 기존 analytics/reconcile 테스트 그대로 통과(econ 값 불변, 위치만 이동)
+
+## 8. 위험 / 함정
+
+- `realized_pnl` 이중계상(open+close 둘 다 기록 시) → close 단독 기록 + 단일집계 테스트로 방지.
+- 5bps 수수료 추정 + funding=0 가정(`cost.py`)이 USD-M net을 낙관 편향 → net을 "실제값"으로
+  단정 금지(측정 caveat). 후속에서 실 커미션 교체 가능.
+- 벤치마크 grain 불일치 → §4.3 검증으로 rollup grain에 정합.
+- `closed_rows_since`가 close 행 미포함이면 집계 0 → §3.4 검증 필수.
+
+## 9. 산출물 / 완료 기준
+
+- executor가 close 행에 `realized_pnl_usdt`를 기록하고, 같은 날 누적 손실이 예산 초과 시
+  다음 진입이 `DAILY_LOSS_BUDGET_EXHAUSTED`로 차단됨(통합 테스트 green).
+- 일별 리뷰가 `benchmark_return_bps`를 채우고 전략 net vs passive를 나란히 노출.
+- additive 마이그레이션 1개(operator `alembic upgrade head` 게이트).
+- 전 테스트 green, 기존 회귀 없음.

--- a/scripts/binance_demo_scalping_benchmark.py
+++ b/scripts/binance_demo_scalping_benchmark.py
@@ -82,6 +82,7 @@ async def _run(args: argparse.Namespace) -> int:
                     else str(review.net_return_bps)
                 ),
                 "benchmark_return_bps": None if value is None else str(value),
+                "net_basis": "5bps_estimate_funding_zero",
             },
             ensure_ascii=False,
             sort_keys=True,

--- a/scripts/binance_demo_scalping_benchmark.py
+++ b/scripts/binance_demo_scalping_benchmark.py
@@ -1,0 +1,104 @@
+"""Phase 1 — operator CLI: build the daily scalping review draft + benchmark.
+
+Builds (or refreshes) the ``scalping_daily_reviews`` draft for a day/product
+from ``scalp_trade_analytics``, then computes + stores the notional-weighted
+daily buy&hold benchmark (Demo public klines, read-only). No broker/order
+mutation. Demo data hosts only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import datetime as dt
+import json
+import logging
+import sys
+
+logger = logging.getLogger("scalping_benchmark")
+
+_VALID_PRODUCTS = ("spot", "usdm_futures")
+
+
+def _parse_args(argv: list[str] | None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description=(
+            "Build the daily demo scalping review draft + notional-weighted "
+            "buy&hold benchmark (read-only; Demo data hosts only)."
+        )
+    )
+    p.add_argument("--product", required=True, choices=_VALID_PRODUCTS)
+    p.add_argument("--date", required=True, help="UTC review date YYYY-MM-DD")
+    p.add_argument("--session-tag", default="")
+    p.add_argument("--log-level", default="INFO")
+    return p.parse_args(argv)
+
+
+async def _run(args: argparse.Namespace) -> int:
+    review_date = dt.date.fromisoformat(args.date)
+    now = dt.datetime.now(dt.UTC)
+
+    from app.core.db import AsyncSessionLocal
+    from app.services.brokers.binance.demo_scalping.market_data import (
+        DemoScalpingMarketData,
+    )
+    from app.services.brokers.binance.demo_scalping_exec.benchmark_runner import (
+        compute_and_store_daily_benchmark,
+    )
+    from app.services.scalping_reviews.service import ScalpingReviewService
+
+    market_data = DemoScalpingMarketData()
+    try:
+        async with AsyncSessionLocal() as session:
+            service = ScalpingReviewService(session)
+            review = await service.build_draft(
+                review_date=review_date,
+                product=args.product,
+                now=now,
+                session_tag=args.session_tag,
+            )
+            value = await compute_and_store_daily_benchmark(
+                session=session,
+                market_data=market_data,
+                review_date=review_date,
+                product=args.product,
+                now=now,
+                session_tag=args.session_tag,
+            )
+            await session.commit()
+    finally:
+        await market_data.aclose()
+
+    print(
+        json.dumps(
+            {
+                "event": "scalping_benchmark",
+                "review_id": review.id,
+                "review_date": args.date,
+                "product": args.product,
+                "net_return_bps": (
+                    None
+                    if review.net_return_bps is None
+                    else str(review.net_return_bps)
+                ),
+                "benchmark_return_bps": None if value is None else str(value),
+            },
+            ensure_ascii=False,
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    logging.basicConfig(level=args.log_level.upper())
+    try:
+        return asyncio.run(_run(args))
+    except Exception as exc:  # noqa: BLE001 — top-level CLI guard
+        logger.error("scalping benchmark CLI failed: %s", exc)
+        return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1298,6 +1298,14 @@ async def db_session():
                         "CHECK (account_mode IN ('kis_mock','kiwoom_mock','kis_live','toss_live','alpaca_paper','upbit_live'))"
                     )
                 )
+                # B-1 (binance-phase1) — benchmark_return_bps on scalping_daily_reviews.
+                # create_all is no-op on the persistent test table, so add here.
+                await conn.execute(
+                    text(
+                        "ALTER TABLE scalping_daily_reviews "
+                        "ADD COLUMN IF NOT EXISTS benchmark_return_bps NUMERIC(12, 4)"
+                    )
+                )
         finally:
             # Release the advisory lock BEFORE yielding so the per-test body
             # runs unserialized. The DDL above is durable + idempotent, so

--- a/tests/scripts/test_binance_demo_scalping_benchmark.py
+++ b/tests/scripts/test_binance_demo_scalping_benchmark.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from scripts.binance_demo_scalping_benchmark import _parse_args
+
+
+def test_cli_parse_args() -> None:
+    ns = _parse_args(["--product", "usdm_futures", "--date", "2026-06-20"])
+    assert ns.product == "usdm_futures"
+    assert ns.date == "2026-06-20"
+    assert ns.session_tag == ""

--- a/tests/services/brokers/binance/demo_scalping_exec/test_benchmark_runner.py
+++ b/tests/services/brokers/binance/demo_scalping_exec/test_benchmark_runner.py
@@ -174,6 +174,20 @@ async def test_runner_returns_none_when_market_data_fails(db_session) -> None:
     )
     svc = ScalpingReviewService(db_session)
     await svc.build_draft(review_date=_DATE, product="usdm_futures", now=_NOW)
+
+    # Seed a non-NULL sentinel so we can prove stale values are reset to NULL.
+    await svc.set_benchmark(
+        review_date=_DATE,
+        product="usdm_futures",
+        value=Decimal("99"),
+        now=_NOW,
+        session_tag="",
+        account_scope="binance_demo",
+        detail=None,
+    )
+    pre = await svc._get_by_key(_DATE, "usdm_futures", "binance_demo", "")
+    assert pre.benchmark_return_bps == Decimal("99"), "sentinel not set"
+
     value = await compute_and_store_daily_benchmark(
         session=db_session,
         market_data=_BoomMD(),
@@ -183,4 +197,5 @@ async def test_runner_returns_none_when_market_data_fails(db_session) -> None:
     )
     assert value is None
     review = await svc._get_by_key(_DATE, "usdm_futures", "binance_demo", "")
+    # stale sentinel must be cleared to NULL — not merely left as-is
     assert review.benchmark_return_bps is None

--- a/tests/services/brokers/binance/demo_scalping_exec/test_benchmark_runner.py
+++ b/tests/services/brokers/binance/demo_scalping_exec/test_benchmark_runner.py
@@ -1,0 +1,186 @@
+"""ROB-315 Phase 1 — BenchmarkRunner: compute + store daily buy&hold benchmark.
+
+Tests the ``compute_and_store_daily_benchmark`` orchestrator function which
+bridges market-data (fake / error) with ScalpingReviewService.set_benchmark.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from decimal import Decimal
+
+import pytest
+from sqlalchemy import select
+
+from app.models.crypto_instruments import CryptoInstrument
+from app.models.scalp_trade_analytics import ScalpTradeAnalytics
+from app.services.brokers.binance.demo_scalping.signal import Candle
+from app.services.brokers.binance.demo_scalping_exec.benchmark_runner import (
+    compute_and_store_daily_benchmark,
+)
+from app.services.scalping_reviews.service import ScalpingReviewService
+
+# ---------------------------------------------------------------------------
+# Helpers — copied from tests/services/scalping_reviews/test_service.py:22-67
+# ---------------------------------------------------------------------------
+
+_DATE = dt.date(2026, 5, 25)
+_NOW = dt.datetime(2026, 5, 25, 12, 0, 0, tzinfo=dt.UTC)
+
+
+async def _instrument(session, symbol="RVWXRPUSDT") -> int:
+    """Get-or-create — crypto_instruments persists across tests in the shared
+    test DB, so a fixed insert would collide on its unique key."""
+    existing = await session.scalar(
+        select(CryptoInstrument).where(
+            CryptoInstrument.venue == "binance",
+            CryptoInstrument.product == "usdm_futures",
+            CryptoInstrument.venue_symbol == symbol,
+        )
+    )
+    if existing is not None:
+        return existing.id
+    inst = CryptoInstrument(
+        venue="binance",
+        product="usdm_futures",
+        venue_symbol=symbol,
+        base_asset="XRP",
+        quote_asset="USDT",
+        status="active",
+    )
+    session.add(inst)
+    await session.flush()
+    return inst.id
+
+
+async def _analytics(session, instrument_id, *, created_at=_NOW, **kw):
+    base = {
+        "open_client_order_id": f"o-{kw.get('tag', '0')}",
+        "instrument_id": instrument_id,
+        "product": "usdm_futures",
+        "symbol": "XRPUSDT",
+        "side": "BUY",
+        "qty": Decimal("1"),
+        "created_at": created_at,
+        "updated_at": created_at,
+    }
+    kw.pop("tag", None)
+    base.update(kw)
+    row = ScalpTradeAnalytics(**base)
+    session.add(row)
+    await session.flush()
+    return row
+
+
+# ---------------------------------------------------------------------------
+# Fake market-data helpers
+# ---------------------------------------------------------------------------
+
+
+class _FakeMD:
+    """day candle per symbol: {symbol: (open, close)}."""
+
+    def __init__(self, prices: dict[str, tuple[float, float]]) -> None:
+        self._prices = prices
+        self.calls: list[tuple] = []
+
+    async def fetch_klines(self, product, symbol, *, interval="1m", limit=50):
+        self.calls.append((product, symbol, interval, limit))
+        o, c = self._prices[symbol]
+        return [
+            Candle(
+                open_time_ms=0,
+                open=Decimal(str(o)),
+                high=Decimal(str(max(o, c))),
+                low=Decimal(str(min(o, c))),
+                close=Decimal(str(c)),
+                close_time_ms=0,
+            )
+        ]
+
+
+class _BoomMD:
+    async def fetch_klines(self, *a, **k):
+        raise RuntimeError("network down")
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_runner_stores_notional_weighted_benchmark(db_session) -> None:
+    iid_x = await _instrument(db_session, "XRPUSDT")
+    iid_d = await _instrument(db_session, "DOGEUSDT")
+    await _analytics(
+        db_session,
+        iid_x,
+        tag="x",
+        symbol="XRPUSDT",
+        entry_price=Decimal("100"),
+        exit_price=Decimal("101"),
+        entry_notional_usdt=Decimal("100"),
+        net_pnl_usdt=Decimal("0.9"),
+        gross_pnl_usdt=Decimal("1.0"),
+        exit_reason="take_profit",
+    )
+    await _analytics(
+        db_session,
+        iid_d,
+        tag="d",
+        symbol="DOGEUSDT",
+        entry_price=Decimal("0.1"),
+        exit_price=Decimal("0.1"),
+        entry_notional_usdt=Decimal("300"),
+        net_pnl_usdt=Decimal("0"),
+        gross_pnl_usdt=Decimal("0"),
+        exit_reason="timeout",
+    )
+    svc = ScalpingReviewService(db_session)
+    await svc.build_draft(review_date=_DATE, product="usdm_futures", now=_NOW)
+    md = _FakeMD(
+        {"XRPUSDT": (100.0, 101.0), "DOGEUSDT": (100.0, 99.8)}
+    )  # +100bps, -20bps
+    value = await compute_and_store_daily_benchmark(
+        session=db_session,
+        market_data=md,
+        review_date=_DATE,
+        product="usdm_futures",
+        now=_NOW,
+    )
+    # (100*100 + 300*-20) / 400 = 10
+    assert value == Decimal("10")
+    review = await svc._get_by_key(_DATE, "usdm_futures", "binance_demo", "")
+    assert review.benchmark_return_bps == Decimal("10")
+    assert "XRPUSDT" in review.source_payload["benchmark"]
+    assert all(c[2] == "1d" and c[3] == 1 for c in md.calls)  # day candle only
+
+
+@pytest.mark.asyncio
+async def test_runner_returns_none_when_market_data_fails(db_session) -> None:
+    iid = await _instrument(db_session, "XRPUSDT")
+    await _analytics(
+        db_session,
+        iid,
+        tag="x",
+        symbol="XRPUSDT",
+        entry_price=Decimal("100"),
+        exit_price=Decimal("101"),
+        entry_notional_usdt=Decimal("100"),
+        net_pnl_usdt=Decimal("0.9"),
+        gross_pnl_usdt=Decimal("1.0"),
+        exit_reason="take_profit",
+    )
+    svc = ScalpingReviewService(db_session)
+    await svc.build_draft(review_date=_DATE, product="usdm_futures", now=_NOW)
+    value = await compute_and_store_daily_benchmark(
+        session=db_session,
+        market_data=_BoomMD(),
+        review_date=_DATE,
+        product="usdm_futures",
+        now=_NOW,
+    )
+    assert value is None
+    review = await svc._get_by_key(_DATE, "usdm_futures", "binance_demo", "")
+    assert review.benchmark_return_bps is None

--- a/tests/services/brokers/binance/demo_scalping_exec/test_executor_realized_pnl.py
+++ b/tests/services/brokers/binance/demo_scalping_exec/test_executor_realized_pnl.py
@@ -10,11 +10,16 @@ import datetime as dt
 from decimal import Decimal
 
 import pytest
+from sqlalchemy import select
 
+from app.models.binance_demo_order_ledger import BinanceDemoOrderLedger
+from app.services.brokers.binance.demo.ledger import BinanceDemoLedgerService
 from app.services.brokers.binance.demo_scalping.contract import (
     MarketConditions,
     ScalpingRiskLimits,
+    evaluate_risk,
 )
+from app.services.brokers.binance.demo_scalping.ledger_state import load_ledger_snapshot
 from app.services.brokers.binance.demo_scalping.market_data import BookTicker
 from app.services.brokers.binance.demo_scalping.order_intent import OrderIntent
 from app.services.brokers.binance.demo_scalping_exec.analytics import (
@@ -151,17 +156,6 @@ class _FakeFutures:
 # Tests
 # ---------------------------------------------------------------------------
 
-from sqlalchemy import select
-
-from app.models.binance_demo_order_ledger import BinanceDemoOrderLedger
-from app.services.brokers.binance.demo.ledger import BinanceDemoLedgerService
-from app.services.brokers.binance.demo_scalping.contract import (
-    MarketConditions,
-    ScalpingRiskLimits,
-    evaluate_risk,
-)
-from app.services.brokers.binance.demo_scalping.ledger_state import load_ledger_snapshot
-
 
 @pytest.mark.asyncio
 async def test_close_row_carries_realized_pnl_open_row_does_not(db_session) -> None:
@@ -182,9 +176,9 @@ async def test_close_row_carries_realized_pnl_open_row_does_not(db_session) -> N
     )
     assert result.status == "reconciled"
 
-    analytics = await ScalpTradeAnalyticsService(db_session).get_by_open_client_order_id(
-        result.open_client_order_id
-    )
+    analytics = await ScalpTradeAnalyticsService(
+        db_session
+    ).get_by_open_client_order_id(result.open_client_order_id)
     close_row = await db_session.scalar(
         select(BinanceDemoOrderLedger).where(
             BinanceDemoOrderLedger.client_order_id == result.close_client_order_id
@@ -199,8 +193,7 @@ async def test_close_row_carries_realized_pnl_open_row_does_not(db_session) -> N
     assert close_row.extra_metadata is not None
     assert "realized_pnl_usdt" in close_row.extra_metadata
     assert (
-        Decimal(close_row.extra_metadata["realized_pnl_usdt"])
-        == analytics.net_pnl_usdt
+        Decimal(close_row.extra_metadata["realized_pnl_usdt"]) == analytics.net_pnl_usdt
     )
     # open row is NOT stamped — single-count for _realized_loss_today.
     assert "realized_pnl_usdt" not in (open_row.extra_metadata or {})
@@ -219,7 +212,9 @@ async def test_losing_round_trip_feeds_daily_loss_budget_gate(db_session) -> Non
         market_data=None,
         poll_delay_seconds=0.0,
     )
-    result = await ex.execute(_intent("RPNLLOSSUSDT"), confirm=True)  # immediate open+close
+    result = await ex.execute(
+        _intent("RPNLLOSSUSDT"), confirm=True
+    )  # immediate open+close
     assert result.status == "reconciled"
 
     snapshot = await load_ledger_snapshot(

--- a/tests/services/brokers/binance/demo_scalping_exec/test_executor_realized_pnl.py
+++ b/tests/services/brokers/binance/demo_scalping_exec/test_executor_realized_pnl.py
@@ -1,0 +1,251 @@
+"""ROB-XXX Phase 1 변경 A — close 행 realized_pnl_usdt durable 기록.
+
+close 행 extra_metadata['realized_pnl_usdt']에 net PnL이 기록되고,
+open 행은 미기록이며, 손실 라운드트립이 daily_loss_budget 게이트를 활성화함을 검증.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from decimal import Decimal
+
+import pytest
+
+from app.services.brokers.binance.demo_scalping.contract import (
+    MarketConditions,
+    ScalpingRiskLimits,
+)
+from app.services.brokers.binance.demo_scalping.market_data import BookTicker
+from app.services.brokers.binance.demo_scalping.order_intent import OrderIntent
+from app.services.brokers.binance.demo_scalping_exec.analytics import (
+    ScalpTradeAnalyticsService,
+)
+from app.services.brokers.binance.demo_scalping_exec.executor import (
+    DemoScalpingExecutor,
+)
+from app.services.brokers.binance.demo_scalping_exec.reference import SymbolReference
+
+# ---------------------------------------------------------------------------
+# Fixture block — copied verbatim from test_executor_analytics.py lines 30-146
+# ---------------------------------------------------------------------------
+
+_NOW = dt.datetime(2026, 5, 25, 12, 0, 0, tzinfo=dt.UTC)
+_REF = SymbolReference(
+    price=Decimal("100"),
+    step_size=Decimal("0.1"),
+    min_notional=Decimal("5"),
+    tick_size=Decimal("0.01"),
+)
+
+
+def _limits(symbol: str) -> ScalpingRiskLimits:
+    return ScalpingRiskLimits(
+        allowlist=frozenset({symbol}),
+        excluded=frozenset(),
+        global_open_lifecycle_cap=10_000,
+        daily_order_count_cap=10_000,
+        daily_loss_budget_usdt=Decimal("1000000"),
+    )
+
+
+def _intent(symbol: str) -> OrderIntent:
+    return OrderIntent(
+        product="usdm_futures",
+        symbol=symbol,
+        side="BUY",
+        order_type="MARKET",
+        target_notional_usdt=Decimal("10"),
+        entry_reference_price=Decimal("100"),
+        tp_price=None,
+        sl_price=None,
+        confidence=Decimal("0.5"),
+        reason_codes=("enter_long_breakout",),
+        source_candle_close_time_ms=1,
+        evaluated_at_ms=2,
+    )
+
+
+class _Ref:
+    async def fetch(self, product, symbol):
+        return _REF
+
+    async def aclose(self):
+        return None
+
+
+class _MD:
+    def __init__(self, prices):
+        self._p = [Decimal(str(x)) for x in prices]
+        self.i = 0
+
+    async def fetch_book_ticker(self, product, symbol):
+        p = self._p[min(self.i, len(self._p) - 1)]
+        self.i += 1
+        return BookTicker(bid=p, ask=p)
+
+
+class _Sub:
+    def __init__(self, status, coid, avg, qty=Decimal("0.1")):
+        self.status = status
+        self.client_order_id = coid
+        self.broker_order_id = "b1"
+        self.avg_price = avg
+        self.executed_qty = qty
+
+
+class _OO:
+    def __init__(self, orders):
+        self.orders = orders
+
+
+class _Pos:
+    def __init__(self, amt):
+        self.position_amt = amt
+        self.is_flat = amt == 0
+
+
+class _FakeFutures:
+    """Open fills at ``open_px``; reduceOnly close fills at ``close_px``."""
+
+    def __init__(self, open_px, close_px):
+        self.open_px = Decimal(str(open_px))
+        self.close_px = Decimal(str(close_px))
+        self._amt = Decimal("0")
+
+    async def get_position_mode(self):
+        return type("M", (), {"is_hedge_mode": False})()
+
+    async def set_leverage(self, *, symbol, leverage):
+        return type("L", (), {"leverage": 1})()
+
+    async def submit_order(
+        self,
+        *,
+        symbol,
+        side,
+        order_type,
+        qty,
+        client_order_id=None,
+        price=None,
+        time_in_force=None,
+        reduce_only=False,
+        confirm=False,
+    ):
+        if reduce_only:
+            self._amt = Decimal("0")
+            return _Sub("FILLED", client_order_id, self.close_px, qty)
+        self._amt = qty if side == "BUY" else -qty
+        return _Sub("FILLED", client_order_id, self.open_px, qty)
+
+    async def get_order(self, *, symbol, client_order_id):
+        return _Sub("FILLED", client_order_id, self.open_px)
+
+    async def get_position(self, *, symbol):
+        return _Pos(self._amt)
+
+    async def get_open_orders(self, *, symbol):
+        return _OO([])
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+from sqlalchemy import select
+
+from app.models.binance_demo_order_ledger import BinanceDemoOrderLedger
+from app.services.brokers.binance.demo.ledger import BinanceDemoLedgerService
+from app.services.brokers.binance.demo_scalping.contract import (
+    MarketConditions,
+    ScalpingRiskLimits,
+    evaluate_risk,
+)
+from app.services.brokers.binance.demo_scalping.ledger_state import load_ledger_snapshot
+
+
+@pytest.mark.asyncio
+async def test_close_row_carries_realized_pnl_open_row_does_not(db_session) -> None:
+    client = _FakeFutures(open_px="100", close_px="100.40")
+    md = _MD([100.0, 100.4])  # 2nd poll crosses TP
+    ex = DemoScalpingExecutor(
+        product="usdm_futures",
+        client=client,
+        session=db_session,
+        reference=_Ref(),
+        now=_NOW,
+        limits=_limits("RPNLWINUSDT"),
+        market_data=md,
+        poll_delay_seconds=0.0,
+    )
+    result = await ex.execute_monitored(
+        _intent("RPNLWINUSDT"), confirm=True, max_poll_count=5
+    )
+    assert result.status == "reconciled"
+
+    analytics = await ScalpTradeAnalyticsService(db_session).get_by_open_client_order_id(
+        result.open_client_order_id
+    )
+    close_row = await db_session.scalar(
+        select(BinanceDemoOrderLedger).where(
+            BinanceDemoOrderLedger.client_order_id == result.close_client_order_id
+        )
+    )
+    open_row = await db_session.scalar(
+        select(BinanceDemoOrderLedger).where(
+            BinanceDemoOrderLedger.client_order_id == result.open_client_order_id
+        )
+    )
+    # close row carries the signed net PnL, equal to the analytics net PnL.
+    assert close_row.extra_metadata is not None
+    assert "realized_pnl_usdt" in close_row.extra_metadata
+    assert (
+        Decimal(close_row.extra_metadata["realized_pnl_usdt"])
+        == analytics.net_pnl_usdt
+    )
+    # open row is NOT stamped — single-count for _realized_loss_today.
+    assert "realized_pnl_usdt" not in (open_row.extra_metadata or {})
+
+
+@pytest.mark.asyncio
+async def test_losing_round_trip_feeds_daily_loss_budget_gate(db_session) -> None:
+    client = _FakeFutures(open_px="100", close_px="99")  # BUY then exit lower → loss
+    ex = DemoScalpingExecutor(
+        product="usdm_futures",
+        client=client,
+        session=db_session,
+        reference=_Ref(),
+        now=_NOW,
+        limits=_limits("RPNLLOSSUSDT"),
+        market_data=None,
+        poll_delay_seconds=0.0,
+    )
+    result = await ex.execute(_intent("RPNLLOSSUSDT"), confirm=True)  # immediate open+close
+    assert result.status == "reconciled"
+
+    snapshot = await load_ledger_snapshot(
+        BinanceDemoLedgerService(db_session),
+        product="usdm_futures",
+        symbol="RPNLLOSSUSDT",
+        now=_NOW,
+    )
+    # gross loss ~ (99-100)*0.1 = -0.1 plus fees → realized loss >= 0.09.
+    assert snapshot.realized_loss_today_usdt >= Decimal("0.09")
+
+    decision = evaluate_risk(
+        product="usdm_futures",
+        symbol="RPNLLOSSUSDT",
+        side="BUY",
+        target_notional_usdt=Decimal("10"),
+        limits=ScalpingRiskLimits(
+            allowlist=frozenset({"RPNLLOSSUSDT"}),
+            excluded=frozenset(),
+            daily_loss_budget_usdt=Decimal("0.05"),
+        ),
+        ledger=snapshot,
+        market=MarketConditions(
+            spread_bps=Decimal("1"),
+            data_age_seconds=1.0,
+            spot_free_base_qty=Decimal("0"),
+        ),
+    )
+    assert "daily_loss_budget_exhausted" in decision.reason_codes

--- a/tests/services/scalping_reviews/test_benchmark.py
+++ b/tests/services/scalping_reviews/test_benchmark.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from app.services.scalping_reviews.benchmark import (
+    daily_buy_and_hold_return_bps,
+    notional_weighted_benchmark_bps,
+)
+
+
+def test_daily_buy_and_hold_return_bps_up_down_flat() -> None:
+    assert daily_buy_and_hold_return_bps(
+        open_price=Decimal("100"), close_price=Decimal("101")
+    ) == Decimal("100")
+    assert daily_buy_and_hold_return_bps(
+        open_price=Decimal("100"), close_price=Decimal("99")
+    ) == Decimal("-100")
+    assert daily_buy_and_hold_return_bps(
+        open_price=Decimal("100"), close_price=Decimal("100")
+    ) == Decimal("0")
+
+
+def test_daily_buy_and_hold_rejects_nonpositive_open() -> None:
+    with pytest.raises(ValueError):
+        daily_buy_and_hold_return_bps(open_price=Decimal("0"), close_price=Decimal("1"))
+
+
+def test_notional_weighted_benchmark_bps_weights_by_notional() -> None:
+    # (100*100 + 300*-20) / 400 = 10
+    assert notional_weighted_benchmark_bps(
+        [(Decimal("100"), Decimal("100")), (Decimal("300"), Decimal("-20"))]
+    ) == Decimal("10")
+
+
+def test_notional_weighted_benchmark_bps_none_when_no_notional() -> None:
+    assert notional_weighted_benchmark_bps([]) is None
+    assert notional_weighted_benchmark_bps([(Decimal("0"), Decimal("100"))]) is None

--- a/tests/services/scalping_reviews/test_benchmark_column.py
+++ b/tests/services/scalping_reviews/test_benchmark_column.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import datetime as dt
+from decimal import Decimal
+
+import pytest
+
+from app.models.scalping_reviews import ScalpingDailyReview
+
+_NOW = dt.datetime(2026, 6, 20, 12, 0, 0, tzinfo=dt.UTC)
+
+
+@pytest.mark.asyncio
+async def test_benchmark_return_bps_column_round_trips(db_session) -> None:
+    review = ScalpingDailyReview(
+        review_date=dt.date(2026, 6, 20),
+        product="usdm_futures",
+        account_scope="binance_demo",
+        session_tag="",
+        decision="review",
+        status="draft",
+        created_at=_NOW,
+        updated_at=_NOW,
+        benchmark_return_bps=Decimal("12.3456"),
+    )
+    db_session.add(review)
+    await db_session.flush()
+    await db_session.refresh(review)
+    assert review.benchmark_return_bps == Decimal("12.3456")

--- a/tests/services/scalping_reviews/test_serialize_benchmark.py
+++ b/tests/services/scalping_reviews/test_serialize_benchmark.py
@@ -9,6 +9,21 @@ from app.routers.invest_scalping import _serialize_review
 _NOW = dt.datetime(2026, 6, 20, 12, 0, 0, tzinfo=dt.UTC)
 
 
+def test_serialize_review_benchmark_none_serializes_to_null() -> None:
+    review = ScalpingDailyReview(
+        review_date=dt.date(2026, 6, 20),
+        product="usdm_futures",
+        account_scope="binance_demo",
+        session_tag="",
+        decision="review",
+        status="draft",
+        created_at=_NOW,
+        updated_at=_NOW,
+    )
+    out = _serialize_review(review)
+    assert out["metrics"]["benchmarkReturnBps"] is None
+
+
 def test_serialize_review_includes_benchmark_return_bps() -> None:
     review = ScalpingDailyReview(
         review_date=dt.date(2026, 6, 20),

--- a/tests/services/scalping_reviews/test_serialize_benchmark.py
+++ b/tests/services/scalping_reviews/test_serialize_benchmark.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import datetime as dt
+from decimal import Decimal
+
+from app.models.scalping_reviews import ScalpingDailyReview
+from app.routers.invest_scalping import _serialize_review
+
+_NOW = dt.datetime(2026, 6, 20, 12, 0, 0, tzinfo=dt.UTC)
+
+
+def test_serialize_review_includes_benchmark_return_bps() -> None:
+    review = ScalpingDailyReview(
+        review_date=dt.date(2026, 6, 20),
+        product="usdm_futures",
+        account_scope="binance_demo",
+        session_tag="",
+        decision="review",
+        status="draft",
+        created_at=_NOW,
+        updated_at=_NOW,
+        benchmark_return_bps=Decimal("7.5"),
+    )
+    out = _serialize_review(review)
+    assert out["metrics"]["benchmarkReturnBps"] == "7.5"

--- a/tests/services/scalping_reviews/test_service.py
+++ b/tests/services/scalping_reviews/test_service.py
@@ -274,15 +274,23 @@ async def test_actions_crud(db_session) -> None:
 async def test_set_benchmark_persists_value_and_detail(db_session) -> None:
     iid = await _instrument(db_session)
     await _analytics(
-        db_session, iid, tag="w",
-        entry_price=Decimal("100"), exit_price=Decimal("101"),
-        entry_notional_usdt=Decimal("100"), net_pnl_usdt=Decimal("0.9"),
-        gross_pnl_usdt=Decimal("1.0"), exit_reason="take_profit",
+        db_session,
+        iid,
+        tag="w",
+        entry_price=Decimal("100"),
+        exit_price=Decimal("101"),
+        entry_notional_usdt=Decimal("100"),
+        net_pnl_usdt=Decimal("0.9"),
+        gross_pnl_usdt=Decimal("1.0"),
+        exit_reason="take_profit",
     )
     svc = ScalpingReviewService(db_session)
     await svc.build_draft(review_date=_DATE, product="usdm_futures", now=_NOW)
     updated = await svc.set_benchmark(
-        review_date=_DATE, product="usdm_futures", value=Decimal("12.5"), now=_NOW,
+        review_date=_DATE,
+        product="usdm_futures",
+        value=Decimal("12.5"),
+        now=_NOW,
         detail={"XRPUSDT": {"open": "100", "close": "100.5", "bps": "50"}},
     )
     assert updated is not None
@@ -294,20 +302,30 @@ async def test_set_benchmark_persists_value_and_detail(db_session) -> None:
 @pytest.mark.asyncio
 async def test_set_benchmark_noop_on_missing_review(db_session) -> None:
     svc = ScalpingReviewService(db_session)
-    assert await svc.set_benchmark(
-        review_date=dt.date(2099, 1, 1), product="usdm_futures",
-        value=Decimal("1"), now=_NOW,
-    ) is None
+    assert (
+        await svc.set_benchmark(
+            review_date=dt.date(2099, 1, 1),
+            product="usdm_futures",
+            value=Decimal("1"),
+            now=_NOW,
+        )
+        is None
+    )
 
 
 @pytest.mark.asyncio
 async def test_set_benchmark_skips_locked_review(db_session) -> None:
     iid = await _instrument(db_session)
     await _analytics(
-        db_session, iid, tag="a",
-        entry_price=Decimal("100"), exit_price=Decimal("101"),
-        entry_notional_usdt=Decimal("100"), net_pnl_usdt=Decimal("0.5"),
-        gross_pnl_usdt=Decimal("0.6"), exit_reason="take_profit",
+        db_session,
+        iid,
+        tag="a",
+        entry_price=Decimal("100"),
+        exit_price=Decimal("101"),
+        entry_notional_usdt=Decimal("100"),
+        net_pnl_usdt=Decimal("0.5"),
+        gross_pnl_usdt=Decimal("0.6"),
+        exit_reason="take_profit",
     )
     svc = ScalpingReviewService(db_session)
     r = await svc.build_draft(review_date=_DATE, product="usdm_futures", now=_NOW)

--- a/tests/services/scalping_reviews/test_service.py
+++ b/tests/services/scalping_reviews/test_service.py
@@ -268,3 +268,52 @@ async def test_actions_crud(db_session) -> None:
         await svc.add_action(review.id, action_type="bogus", title="x", now=_NOW)
     with pytest.raises(ScalpingReviewError):
         await svc.update_action(action.id, now=_NOW, status="bogus")
+
+
+@pytest.mark.asyncio
+async def test_set_benchmark_persists_value_and_detail(db_session) -> None:
+    iid = await _instrument(db_session)
+    await _analytics(
+        db_session, iid, tag="w",
+        entry_price=Decimal("100"), exit_price=Decimal("101"),
+        entry_notional_usdt=Decimal("100"), net_pnl_usdt=Decimal("0.9"),
+        gross_pnl_usdt=Decimal("1.0"), exit_reason="take_profit",
+    )
+    svc = ScalpingReviewService(db_session)
+    await svc.build_draft(review_date=_DATE, product="usdm_futures", now=_NOW)
+    updated = await svc.set_benchmark(
+        review_date=_DATE, product="usdm_futures", value=Decimal("12.5"), now=_NOW,
+        detail={"XRPUSDT": {"open": "100", "close": "100.5", "bps": "50"}},
+    )
+    assert updated is not None
+    assert updated.benchmark_return_bps == Decimal("12.5")
+    assert updated.source_payload["benchmark"]["XRPUSDT"]["bps"] == "50"
+    assert updated.net_pnl_usdt == Decimal("0.9")  # rollup metrics preserved
+
+
+@pytest.mark.asyncio
+async def test_set_benchmark_noop_on_missing_review(db_session) -> None:
+    svc = ScalpingReviewService(db_session)
+    assert await svc.set_benchmark(
+        review_date=dt.date(2099, 1, 1), product="usdm_futures",
+        value=Decimal("1"), now=_NOW,
+    ) is None
+
+
+@pytest.mark.asyncio
+async def test_set_benchmark_skips_locked_review(db_session) -> None:
+    iid = await _instrument(db_session)
+    await _analytics(
+        db_session, iid, tag="a",
+        entry_price=Decimal("100"), exit_price=Decimal("101"),
+        entry_notional_usdt=Decimal("100"), net_pnl_usdt=Decimal("0.5"),
+        gross_pnl_usdt=Decimal("0.6"), exit_reason="take_profit",
+    )
+    svc = ScalpingReviewService(db_session)
+    r = await svc.build_draft(review_date=_DATE, product="usdm_futures", now=_NOW)
+    await svc.update_review(r.id, now=_NOW, status="locked")
+    res = await svc.set_benchmark(
+        review_date=_DATE, product="usdm_futures", value=Decimal("9"), now=_NOW
+    )
+    assert res is not None and res.status == "locked"
+    assert res.benchmark_return_bps is None  # not written while locked


### PR DESCRIPTION
## 목적

Binance USD-M Futures Demo "매일 모의매매 루프"를 신뢰 가능하게 만드는 **Phase 1(측정 신뢰화)**. 과거 백테스트 라인(ROB-384 CLOSED, search-space 실패)의 교훈(net 측정·벤치마크 내장)을 모의 루프에 반영한다. 신규 기능이 아니라 **demo_scalping 인프라가 설계상 비워둔 자리 2곳을 채우는 것**.

- spec: `docs/superpowers/specs/2026-06-19-binance-demo-phase1-measurement-design.md`
- plan: `docs/superpowers/plans/2026-06-20-binance-demo-phase1-measurement.md`

## 변경 A — close 행에 realized_pnl_usdt 기록 (손실게이트 실효화)

`executor`가 라운드트립 net PnL을 **close 행** reconcile `extra_metadata['realized_pnl_usdt']`(부호 포함, 손실=음수)에 durable 기록 → `daily_loss_budget` 게이트가 실제로 동작(기존엔 미기록이라 영구 비발화, `ledger_state.py`가 의도한 "PR2" 자리).

- close 행에만 기록(open 행 미기록) → 라운드트립당 1회 집계, **이중계상 방지**
- partial(체결가 미확인) 행은 미기록(날조 금지)
- `net_pnl_usdt`는 `exit_reference_price` 무관(`cost.py`)이라 ledger값 == analytics값(drift 없음)
- spot/futures/immediate(execute) 전 경로 적용

## 변경 B — 일별 buy&hold 벤치마크

전략 net vs 패시브 비교용 일별 buy&hold 벤치마크.

- `scalping_daily_reviews.benchmark_return_bps` 컬럼 (additive nullable 마이그레이션, 단일 head `885e50ac5bb1` 기반)
- 순수 계산: `daily_buy_and_hold_return_bps` + notional 가중 `notional_weighted_benchmark_bps`
- 저장: `ScalpingReviewService.set_benchmark`(locked skip / 없는 행 None / source_payload 종목별 audit 머지) + 라우터 `benchmarkReturnBps` 노출
- market-data 인지 `demo_scalping_exec/benchmark_runner.py` + 운영 CLI `scripts/binance_demo_scalping_benchmark.py`가 1d klines로 계산·저장(best-effort, 실패 시 NULL로 리셋=재실행 멱등)

## 안전 / 경계

- 리뷰 라우터/서비스는 market-data를 import하지 않음(정적 가드 `tests/test_invest_api_scalping_router.py`); 벤치마크 fetch는 `demo_scalping_exec` runner/CLI에만 → 스펙 §4.2를 경계-안전하게 정제
- 마이그레이션 additive nullable + public schema, **operator `alembic upgrade head` 게이트**
- 수수료 5bps 추정 + funding=0 가정 → net 낙관 편향(측정 caveat; CLI 출력에 `net_basis` 마커로 표면화)

## 테스트 / 리뷰

- demo-scalping 스코프 회귀 **530 passed**(베이스라인 515 + 신규 15), 0 fail. ruff/ty clean(변경 파일).
- Subagent-Driven Development으로 실행: 태스크별 구현→리뷰→수정 루프 + **전체 브랜치 최종 리뷰(opus): Ready to merge=Yes**, 0 Critical / 0 Important. Important 1건(벤치마크 stale 미리셋)은 fix+재리뷰 완료.
- defer된 Minor(test-only/latent): _FakeFutures.get_order leg-aware, runner skip-symbol 로깅, 음수 notional 문서 등.

## Operator 액션 (머지 후)

1. `alembic upgrade head` (벤치마크 컬럼 적용; default 미적용)
2. 매일: tick 실행(executor 경로) → `scripts/binance_demo_scalping_benchmark.py --product usdm_futures --date <UTC>` 로 일별 리뷰 draft + 벤치마크 산출 → `/invest/scalping`에서 전략 net vs 패시브 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0115yvcHYpLv3aLeKJ36Bo9w