### PR TITLE
feat: Phase 2 — 데모 스캘핑 일별 리뷰+buy&hold 벤치마크 자동화 (Prefect flow, default-off)

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -228,6 +228,8 @@ class Settings(BaseSettings):
     # ROB-321 PR4b: per-run order-mutation gate for the scalping daemon. Without
     # it the daemon dry-runs (preview only, no mock order, no ledger write).
     kis_mock_scalping_ws_confirm: bool = False
+    # Phase 2 — daily demo scalping review + buy&hold benchmark flow (default-off).
+    binance_demo_scalping_review_flow_enabled: bool = False
 
     # KIS Rate Limiting (HTTP API)
     kis_rate_limit_rate: int = 19  # 초당 최대 요청 수 (안전 마진으로 20-1)

--- a/app/flows/binance_demo_scalping_review_flow.py
+++ b/app/flows/binance_demo_scalping_review_flow.py
@@ -1,0 +1,26 @@
+"""Phase 2 — Prefect wrapper for the daily demo scalping review + benchmark.
+
+Importable only; NO deployment registered here. Recurrence lives in
+robin-prefect-automations (paused-by-default). Default-OFF via
+``settings.binance_demo_scalping_review_flow_enabled`` (enforced in the job).
+All logic is in app/jobs/binance_demo_scalping_review.py (prefect-free).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from prefect import flow, task
+
+from app.jobs.binance_demo_scalping_review import run_demo_scalping_review_refresh
+
+
+@task(name="binance_demo_scalping_review")
+async def binance_demo_scalping_review_task() -> dict[str, Any]:
+    return await run_demo_scalping_review_refresh()
+
+
+@flow(name="binance_demo_scalping_review")
+async def binance_demo_scalping_review_flow() -> dict[str, Any]:
+    """Daily review + buy&hold benchmark; deployment registration deferred."""
+    return await binance_demo_scalping_review_task()

--- a/app/jobs/binance_demo_scalping_review.py
+++ b/app/jobs/binance_demo_scalping_review.py
@@ -1,0 +1,118 @@
+"""Phase 2 — daily demo scalping review + buy&hold benchmark refresh (job logic).
+
+Prefect-free so it is unit-testable (the @flow/@task wrapper lives in
+``app/flows/binance_demo_scalping_review_flow.py``). Default-OFF behind
+``settings.binance_demo_scalping_review_flow_enabled``. Read-only w.r.t.
+brokers/orders: rolls that day's ``scalp_trade_analytics`` into the daily
+review draft (``build_draft``) and computes the notional-weighted daily
+buy&hold benchmark (``compute_and_store_daily_benchmark``). Per-product
+failures are isolated via a SAVEPOINT so one product cannot poison another.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import logging
+from collections.abc import Sequence
+from decimal import Decimal
+from typing import Any
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import settings
+from app.core.db import AsyncSessionLocal
+from app.services.brokers.binance.demo_scalping.market_data import (
+    DemoScalpingMarketData,
+)
+from app.services.brokers.binance.demo_scalping_exec.benchmark_runner import (
+    compute_and_store_daily_benchmark,
+)
+from app.services.scalping_reviews.service import ScalpingReviewService
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_PRODUCTS: tuple[str, ...] = ("spot", "usdm_futures")
+
+
+def _num(value: Decimal | None) -> str | None:
+    return None if value is None else str(value)
+
+
+async def _refresh_with_session(
+    session: AsyncSession,
+    market_data: Any,
+    review_date: dt.date,
+    products: Sequence[str],
+    now: dt.datetime,
+) -> dict[str, Any]:
+    service = ScalpingReviewService(session)
+    summaries: list[dict[str, Any]] = []
+    errors: list[dict[str, str]] = []
+    for product in products:
+        try:
+            async with session.begin_nested():  # SAVEPOINT: isolate per product
+                review = await service.build_draft(
+                    review_date=review_date, product=product, now=now
+                )
+                benchmark = await compute_and_store_daily_benchmark(
+                    session=session,
+                    market_data=market_data,
+                    review_date=review_date,
+                    product=product,
+                    now=now,
+                )
+                summaries.append(
+                    {
+                        "product": product,
+                        "tradeCount": review.trade_count,
+                        "netReturnBps": _num(review.net_return_bps),
+                        "benchmarkReturnBps": _num(benchmark),
+                    }
+                )
+        except Exception as exc:  # noqa: BLE001 — isolate; savepoint rolled back
+            logger.exception(
+                "demo scalping review refresh failed for product=%s", product
+            )
+            errors.append({"product": product, "error": f"{type(exc).__name__}: {exc}"})
+    return {
+        "status": "ran",
+        "reviewDate": review_date.isoformat(),
+        "products": summaries,
+        "errors": errors,
+    }
+
+
+async def run_demo_scalping_review_refresh(
+    *,
+    review_date: dt.date | None = None,
+    products: Sequence[str] = _DEFAULT_PRODUCTS,
+    now: dt.datetime | None = None,
+    session: AsyncSession | None = None,
+    market_data: Any | None = None,
+) -> dict[str, Any]:
+    """Build the daily review draft + buy&hold benchmark per demo product.
+
+    No-op (``{"status": "disabled"}``) unless the env flag is set. When
+    ``session``/``market_data`` are injected (tests) they are used as-is and
+    NOT committed/closed by this function; otherwise they are created and
+    committed/closed here."""
+    if not settings.binance_demo_scalping_review_flow_enabled:
+        return {"status": "disabled"}
+
+    now = now or dt.datetime.now(dt.UTC)
+    review_date = review_date or now.astimezone(dt.UTC).date()
+
+    owns_md = market_data is None
+    md = market_data or DemoScalpingMarketData()
+    try:
+        if session is not None:
+            return await _refresh_with_session(session, md, review_date, products, now)
+        async with AsyncSessionLocal() as own_session:
+            result = await _refresh_with_session(
+                own_session, md, review_date, products, now
+            )
+            await own_session.commit()
+            return result
+    finally:
+        if owns_md:
+            await md.aclose()

--- a/docs/superpowers/plans/2026-06-21-binance-demo-scalping-review-flow.md
+++ b/docs/superpowers/plans/2026-06-21-binance-demo-scalping-review-flow.md
@@ -1,0 +1,496 @@
+# Binance Demo 스캘핑 일별 리뷰+벤치마크 자동화 (Phase 2) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 매일 자동으로 데모 product별 스캘핑 리뷰 draft 롤업 + buy&hold 벤치마크를 생성해 `/invest/scalping`에 전략 net vs 패시브가 채워지게 한다. recurrence는 Prefect로 통일.
+
+**Architecture:** 실제 로직은 prefect-free `app/jobs/binance_demo_scalping_review.py`(유닛테스트 가능), `app/flows/binance_demo_scalping_review_flow.py`는 thin Prefect 래퍼(정적 테스트만 — Prefect는 프로젝트 의존성이 아님). env-gate default-off. 배포 등록은 외부(robin-prefect-automations) deferred·paused. 읽기전용(주문 mutation 없음).
+
+**Tech Stack:** Python 3.13, SQLAlchemy(async), Prefect(@flow/@task, 미설치=정적테스트), pytest-asyncio, Decimal.
+
+## Global Constraints
+
+- Python 3.13+. 변경은 worktree `feature/binance-demo-scalping-review-flow`에서. canonical repo는 main 고정.
+- **Prefect는 미설치** — `app/flows/*` 모듈은 테스트에서 import 불가. 실제 로직은 `app/jobs/`(prefect-free)에 두고 flow는 thin 래퍼. flow 테스트는 정적(파일 내용) only (기존 `tests/test_invest_screener_snapshots_us_flow.py` 패턴).
+- **default-off**: `settings.binance_demo_scalping_review_flow_enabled`(기본 False). 미설정 시 `{"status":"disabled"}` no-op.
+- **읽기전용 경계**: 주문/브로커 mutation 모듈(executor/execution_client) import 금지. `ScalpingReviewService`/`benchmark_runner`/`DemoScalpingMarketData`만.
+- **In-repo cron 금지**: `@broker.task(schedule=...)` 부착 금지(Prefect로 통일). 실제 recurrence는 외부 deployment(이 PR 아님).
+- 마이그레이션 없음(`benchmark_return_bps` 컬럼은 Phase 1에서 추가됨).
+- account_scope는 `"binance_demo"`(`SCALPING_REVIEW_ACCOUNT_SCOPE`) 고정, session_tag 기본 `""`.
+- Decimal은 문자열 직렬화(`_num`).
+- TDD: 실패 테스트 → 최소 구현 → 통과 → 커밋.
+- 커밋 trailer:
+  ```
+  Co-Authored-By: Paperclip <noreply@paperclip.ing>
+  Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+  Claude-Session: https://claude.ai/code/session_0115yvcHYpLv3aLeKJ36Bo9w
+  ```
+
+## File Structure
+
+- `app/core/config.py` (수정) — `binance_demo_scalping_review_flow_enabled: bool = False` 추가.
+- `app/jobs/binance_demo_scalping_review.py` (생성) — `run_demo_scalping_review_refresh(...)` 실제 로직(prefect-free, 유닛테스트 가능).
+- `app/flows/binance_demo_scalping_review_flow.py` (생성) — thin `@task`+`@flow` 래퍼.
+- `tests/jobs/test_binance_demo_scalping_review.py` (생성) — job 유닛테스트(게이트 off/on/격리).
+- `tests/test_binance_demo_scalping_review_flow.py` (생성) — flow 정적 테스트.
+
+---
+
+### Task 1: config flag + job 로직 + job 유닛테스트
+
+**Files:**
+- Modify: `app/core/config.py` (Settings 클래스, `kis_mock_scalping_ws_confirm: bool = False` 근처)
+- Create: `app/jobs/binance_demo_scalping_review.py`
+- Test: `tests/jobs/test_binance_demo_scalping_review.py`
+
+**Interfaces:**
+- Consumes: `settings.binance_demo_scalping_review_flow_enabled`(이 태스크가 추가); `ScalpingReviewService(session).build_draft(*, review_date, product, now, session_tag="", account_scope=SCALPING_REVIEW_ACCOUNT_SCOPE) -> ScalpingDailyReview`(`.trade_count`,`.net_return_bps`,`.benchmark_return_bps`); `compute_and_store_daily_benchmark(*, session, market_data, review_date, product, now, session_tag="", account_scope=...) -> Decimal | None`; `DemoScalpingMarketData()`/`.aclose()`/`.fetch_klines(product, symbol, *, interval, limit)`; `AsyncSessionLocal`.
+- Produces: `run_demo_scalping_review_refresh(*, review_date: dt.date | None = None, products: Sequence[str] = ("spot","usdm_futures"), now: dt.datetime | None = None, session: AsyncSession | None = None, market_data: Any | None = None) -> dict[str, Any]` — `{"status":"disabled"}` or `{"status":"ran","reviewDate":iso,"products":[{product,tradeCount,netReturnBps,benchmarkReturnBps}],"errors":[{product,error}]}`. Task 2가 호출.
+
+- [ ] **Step 1: 실패 테스트 작성**
+
+`tests/jobs/test_binance_demo_scalping_review.py` 생성. 상단에 **`tests/services/scalping_reviews/test_service.py`의 22-67행(`_DATE`,`_NOW`,`_instrument`,`_analytics`)을 복사**하고, **`tests/services/brokers/binance/demo_scalping_exec/test_benchmark_runner.py`의 `_FakeMD` 클래스를 복사**(또는 아래 정의를 사용)한 뒤:
+
+```python
+from __future__ import annotations
+
+import datetime as dt
+from decimal import Decimal
+
+import pytest
+from sqlalchemy import select
+
+from app.core.config import settings
+from app.jobs.binance_demo_scalping_review import run_demo_scalping_review_refresh
+from app.models.crypto_instruments import CryptoInstrument
+from app.models.scalp_trade_analytics import ScalpTradeAnalytics
+from app.services.brokers.binance.demo_scalping.signal import Candle
+from app.services.scalping_reviews.service import ScalpingReviewService
+
+# (여기에 test_service.py 22-67행의 _DATE/_NOW/_instrument/_analytics 복사)
+
+
+class _FakeMD:
+    def __init__(self, prices: dict[str, tuple[float, float]]) -> None:
+        self._prices = prices
+
+    async def fetch_klines(self, product, symbol, *, interval="1m", limit=50):
+        o, c = self._prices[symbol]
+        return [
+            Candle(
+                open_time_ms=0,
+                open=Decimal(str(o)),
+                high=Decimal(str(max(o, c))),
+                low=Decimal(str(min(o, c))),
+                close=Decimal(str(c)),
+                close_time_ms=0,
+            )
+        ]
+
+    async def aclose(self) -> None:  # pragma: no cover - injected, not owned
+        return None
+
+
+@pytest.mark.asyncio
+async def test_disabled_gate_is_noop(monkeypatch) -> None:
+    monkeypatch.setattr(settings, "binance_demo_scalping_review_flow_enabled", False)
+    result = await run_demo_scalping_review_refresh(
+        review_date=_DATE, products=("usdm_futures",), now=_NOW
+    )
+    assert result == {"status": "disabled"}
+
+
+@pytest.mark.asyncio
+async def test_enabled_builds_review_and_benchmark(db_session, monkeypatch) -> None:
+    monkeypatch.setattr(settings, "binance_demo_scalping_review_flow_enabled", True)
+    iid = await _instrument(db_session, "XRPUSDT")
+    await _analytics(
+        db_session, iid, tag="w", symbol="XRPUSDT",
+        entry_price=Decimal("100"), exit_price=Decimal("101"),
+        entry_notional_usdt=Decimal("100"), net_pnl_usdt=Decimal("0.9"),
+        gross_pnl_usdt=Decimal("1.0"), exit_reason="take_profit",
+    )
+    md = _FakeMD({"XRPUSDT": (100.0, 101.0)})  # +100 bps
+    result = await run_demo_scalping_review_refresh(
+        session=db_session, market_data=md, review_date=_DATE,
+        products=("usdm_futures",), now=_NOW,
+    )
+    assert result["status"] == "ran"
+    assert result["reviewDate"] == _DATE.isoformat()
+    assert result["errors"] == []
+    [summary] = result["products"]
+    assert summary == {
+        "product": "usdm_futures",
+        "tradeCount": 1,
+        "netReturnBps": "90.0000",
+        "benchmarkReturnBps": "100",
+    }
+    review = await ScalpingReviewService(db_session)._get_by_key(
+        _DATE, "usdm_futures", "binance_demo", ""
+    )
+    assert review is not None and review.benchmark_return_bps == Decimal("100")
+
+
+@pytest.mark.asyncio
+async def test_product_failure_is_isolated(db_session, monkeypatch) -> None:
+    monkeypatch.setattr(settings, "binance_demo_scalping_review_flow_enabled", True)
+    iid = await _instrument(db_session, "XRPUSDT")
+    await _analytics(
+        db_session, iid, tag="w", symbol="XRPUSDT",
+        entry_price=Decimal("100"), exit_price=Decimal("101"),
+        entry_notional_usdt=Decimal("100"), net_pnl_usdt=Decimal("0.9"),
+        gross_pnl_usdt=Decimal("1.0"), exit_reason="take_profit",
+    )
+    md = _FakeMD({"XRPUSDT": (100.0, 101.0)})
+    orig = ScalpingReviewService.build_draft
+
+    async def flaky(self, *, review_date, product, now, **kw):
+        if product == "spot":
+            raise RuntimeError("boom")
+        return await orig(self, review_date=review_date, product=product, now=now, **kw)
+
+    monkeypatch.setattr(ScalpingReviewService, "build_draft", flaky)
+    result = await run_demo_scalping_review_refresh(
+        session=db_session, market_data=md, review_date=_DATE,
+        products=("spot", "usdm_futures"), now=_NOW,
+    )
+    assert result["status"] == "ran"
+    assert [s["product"] for s in result["products"]] == ["usdm_futures"]
+    assert [e["product"] for e in result["errors"]] == ["spot"]
+```
+
+> 참고: `netReturnBps == "90.0000"` — net_pnl 0.9 / entry_notional 100 × 10000 = 90 bps, `Numeric(12,4)`라 `"90.0000"`. `benchmarkReturnBps == "100"` — 단일 심볼 (101/100-1)×10000.
+
+- [ ] **Step 2: 실패 확인**
+
+Run: `cd /Users/mgh3326/work/auto_trader.phase2-review-flow && uv run pytest tests/jobs/test_binance_demo_scalping_review.py -v`
+Expected: FAIL — `ModuleNotFoundError: app.jobs.binance_demo_scalping_review` (및 `settings`에 flag 속성 없음 → AttributeError on monkeypatch).
+
+- [ ] **Step 3: config flag 추가**
+
+`app/core/config.py`의 `kis_mock_scalping_ws_confirm: bool = False`(약 230행) **바로 다음**에 추가:
+
+```python
+    # Phase 2 — daily demo scalping review + buy&hold benchmark flow (default-off).
+    binance_demo_scalping_review_flow_enabled: bool = False
+```
+
+- [ ] **Step 4: job 모듈 구현**
+
+`app/jobs/binance_demo_scalping_review.py` 생성:
+
+```python
+"""Phase 2 — daily demo scalping review + buy&hold benchmark refresh (job logic).
+
+Prefect-free so it is unit-testable (the @flow/@task wrapper lives in
+``app/flows/binance_demo_scalping_review_flow.py``). Default-OFF behind
+``settings.binance_demo_scalping_review_flow_enabled``. Read-only w.r.t.
+brokers/orders: rolls that day's ``scalp_trade_analytics`` into the daily
+review draft (``build_draft``) and computes the notional-weighted daily
+buy&hold benchmark (``compute_and_store_daily_benchmark``). Per-product
+failures are isolated via a SAVEPOINT so one product cannot poison another.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import logging
+from collections.abc import Sequence
+from decimal import Decimal
+from typing import Any
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import settings
+from app.core.db import AsyncSessionLocal
+from app.services.brokers.binance.demo_scalping.market_data import (
+    DemoScalpingMarketData,
+)
+from app.services.brokers.binance.demo_scalping_exec.benchmark_runner import (
+    compute_and_store_daily_benchmark,
+)
+from app.services.scalping_reviews.service import ScalpingReviewService
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_PRODUCTS: tuple[str, ...] = ("spot", "usdm_futures")
+
+
+def _num(value: Decimal | None) -> str | None:
+    return None if value is None else str(value)
+
+
+async def _refresh_with_session(
+    session: AsyncSession,
+    market_data: Any,
+    review_date: dt.date,
+    products: Sequence[str],
+    now: dt.datetime,
+) -> dict[str, Any]:
+    service = ScalpingReviewService(session)
+    summaries: list[dict[str, Any]] = []
+    errors: list[dict[str, str]] = []
+    for product in products:
+        try:
+            async with session.begin_nested():  # SAVEPOINT: isolate per product
+                review = await service.build_draft(
+                    review_date=review_date, product=product, now=now
+                )
+                benchmark = await compute_and_store_daily_benchmark(
+                    session=session,
+                    market_data=market_data,
+                    review_date=review_date,
+                    product=product,
+                    now=now,
+                )
+                summaries.append(
+                    {
+                        "product": product,
+                        "tradeCount": review.trade_count,
+                        "netReturnBps": _num(review.net_return_bps),
+                        "benchmarkReturnBps": _num(benchmark),
+                    }
+                )
+        except Exception as exc:  # noqa: BLE001 — isolate; savepoint rolled back
+            logger.exception(
+                "demo scalping review refresh failed for product=%s", product
+            )
+            errors.append(
+                {"product": product, "error": f"{type(exc).__name__}: {exc}"}
+            )
+    return {
+        "status": "ran",
+        "reviewDate": review_date.isoformat(),
+        "products": summaries,
+        "errors": errors,
+    }
+
+
+async def run_demo_scalping_review_refresh(
+    *,
+    review_date: dt.date | None = None,
+    products: Sequence[str] = _DEFAULT_PRODUCTS,
+    now: dt.datetime | None = None,
+    session: AsyncSession | None = None,
+    market_data: Any | None = None,
+) -> dict[str, Any]:
+    """Build the daily review draft + buy&hold benchmark per demo product.
+
+    No-op (``{"status": "disabled"}``) unless the env flag is set. When
+    ``session``/``market_data`` are injected (tests) they are used as-is and
+    NOT committed/closed by this function; otherwise they are created and
+    committed/closed here."""
+    if not settings.binance_demo_scalping_review_flow_enabled:
+        return {"status": "disabled"}
+
+    now = now or dt.datetime.now(dt.UTC)
+    review_date = review_date or now.astimezone(dt.UTC).date()
+
+    owns_md = market_data is None
+    md = market_data or DemoScalpingMarketData()
+    try:
+        if session is not None:
+            return await _refresh_with_session(
+                session, md, review_date, products, now
+            )
+        async with AsyncSessionLocal() as own_session:
+            result = await _refresh_with_session(
+                own_session, md, review_date, products, now
+            )
+            await own_session.commit()
+            return result
+    finally:
+        if owns_md:
+            await md.aclose()
+```
+
+- [ ] **Step 5: 통과 확인**
+
+Run: `uv run pytest tests/jobs/test_binance_demo_scalping_review.py -v`
+Expected: PASS (3 tests).
+
+- [ ] **Step 6: 커밋**
+
+```bash
+cd /Users/mgh3326/work/auto_trader.phase2-review-flow
+git add app/core/config.py app/jobs/binance_demo_scalping_review.py tests/jobs/test_binance_demo_scalping_review.py
+git commit -F - <<'EOF'
+feat: daily demo scalping review + benchmark job (Phase 2)
+
+prefect-free run_demo_scalping_review_refresh: product별 build_draft 롤업 +
+buy&hold 벤치마크(benchmark_runner). env-gate default-off, product별 SAVEPOINT
+격리, 주입형 session/market_data로 유닛테스트 가능. 읽기전용(주문 mutation 없음).
+
+Co-Authored-By: Paperclip <noreply@paperclip.ing>
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_0115yvcHYpLv3aLeKJ36Bo9w
+EOF
+```
+
+---
+
+### Task 2: thin Prefect flow 래퍼 + 정적 테스트
+
+**Files:**
+- Create: `app/flows/binance_demo_scalping_review_flow.py`
+- Test: `tests/test_binance_demo_scalping_review_flow.py`
+
+**Interfaces:**
+- Consumes: `run_demo_scalping_review_refresh()`(Task 1).
+- Produces: `binance_demo_scalping_review_flow` (Prefect `@flow`), `binance_demo_scalping_review_task` (`@task`).
+
+- [ ] **Step 1: 실패 테스트 작성**
+
+`tests/test_binance_demo_scalping_review_flow.py` 생성 (Prefect 미설치이므로 정적 검증 — `tests/test_invest_screener_snapshots_us_flow.py` 패턴):
+
+```python
+"""Static checks for the Phase 2 demo scalping review Prefect flow.
+
+Prefect is not a project dependency, so the flow module is validated by file
+content (decorators / names / delegation / deferred deployment), not import.
+The real logic is unit-tested in tests/jobs/test_binance_demo_scalping_review.py.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+_FLOW_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "app"
+    / "flows"
+    / "binance_demo_scalping_review_flow.py"
+)
+
+
+def test_flow_file_exists() -> None:
+    assert _FLOW_PATH.exists(), f"Flow file not found at {_FLOW_PATH}"
+
+
+def test_flow_declares_prefect_flow_and_task() -> None:
+    text = _FLOW_PATH.read_text()
+    assert "@flow" in text, "Missing @flow decorator"
+    assert "@task" in text, "Missing @task decorator"
+    assert "binance_demo_scalping_review" in text, "Missing flow name"
+
+
+def test_flow_delegates_to_job() -> None:
+    text = _FLOW_PATH.read_text()
+    assert "run_demo_scalping_review_refresh" in text, (
+        "Flow must delegate to the prefect-free job helper"
+    )
+
+
+def test_flow_does_not_attach_in_repo_schedule() -> None:
+    text = _FLOW_PATH.read_text()
+    assert "@broker.task" not in text and "schedule=" not in text, (
+        "Recurrence is Prefect-only; no in-repo TaskIQ schedule"
+    )
+
+
+def test_flow_not_registered_via_deployment_yaml() -> None:
+    project_root = _FLOW_PATH.parents[1]
+    import pytest
+
+    yaml_files = list(project_root.glob("**/*.yaml")) + list(
+        project_root.glob("**/*.yml")
+    )
+    for yf in yaml_files:
+        if ".venv" in str(yf) or ".git" in str(yf):
+            continue
+        if "binance_demo_scalping_review" in yf.read_text():
+            pytest.fail(
+                f"Deployment YAML references the flow at {yf}; "
+                "registration is deferred (external robin-prefect-automations)."
+            )
+```
+
+- [ ] **Step 2: 실패 확인**
+
+Run: `uv run pytest tests/test_binance_demo_scalping_review_flow.py -v`
+Expected: FAIL — `test_flow_file_exists` (파일 없음).
+
+- [ ] **Step 3: flow 래퍼 구현**
+
+`app/flows/binance_demo_scalping_review_flow.py` 생성:
+
+```python
+"""Phase 2 — Prefect wrapper for the daily demo scalping review + benchmark.
+
+Importable only; NO deployment registered here. Recurrence lives in
+robin-prefect-automations (paused-by-default). Default-OFF via
+``settings.binance_demo_scalping_review_flow_enabled`` (enforced in the job).
+All logic is in app/jobs/binance_demo_scalping_review.py (prefect-free).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from prefect import flow, task
+
+from app.jobs.binance_demo_scalping_review import run_demo_scalping_review_refresh
+
+
+@task(name="binance_demo_scalping_review")
+async def binance_demo_scalping_review_task() -> dict[str, Any]:
+    return await run_demo_scalping_review_refresh()
+
+
+@flow(name="binance_demo_scalping_review")
+async def binance_demo_scalping_review_flow() -> dict[str, Any]:
+    """Daily review + buy&hold benchmark; deployment registration deferred."""
+    return await binance_demo_scalping_review_task()
+```
+
+- [ ] **Step 4: 통과 확인**
+
+Run: `uv run pytest tests/test_binance_demo_scalping_review_flow.py -v`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add app/flows/binance_demo_scalping_review_flow.py tests/test_binance_demo_scalping_review_flow.py
+git commit -F - <<'EOF'
+feat: Prefect flow wrapper for daily demo scalping review (Phase 2)
+
+thin @task/@flow가 prefect-free job(run_demo_scalping_review_refresh)에 위임.
+배포 등록은 외부(robin-prefect-automations) deferred·paused. in-repo TaskIQ
+schedule 미부착(Prefect 통일). Prefect 미설치라 정적 테스트.
+
+Co-Authored-By: Paperclip <noreply@paperclip.ing>
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_0115yvcHYpLv3aLeKJ36Bo9w
+EOF
+```
+
+---
+
+### 최종 검증
+
+- [ ] **Step: 관련 스코프 회귀 + lint/type**
+
+Run:
+```bash
+cd /Users/mgh3326/work/auto_trader.phase2-review-flow
+uv run pytest tests/jobs/test_binance_demo_scalping_review.py tests/test_binance_demo_scalping_review_flow.py tests/services/scalping_reviews/ tests/services/brokers/binance/demo_scalping_exec/ -q
+uv run ruff format app/jobs/binance_demo_scalping_review.py app/flows/binance_demo_scalping_review_flow.py app/core/config.py tests/jobs/test_binance_demo_scalping_review.py tests/test_binance_demo_scalping_review_flow.py
+uv run ruff check app/jobs/binance_demo_scalping_review.py app/flows/binance_demo_scalping_review_flow.py app/core/config.py tests/jobs/test_binance_demo_scalping_review.py tests/test_binance_demo_scalping_review_flow.py
+uv run ty check app/
+```
+Expected: 신규 8 tests + 관련 스코프 회귀 전부 PASS, ruff/ty clean.
+
+---
+
+## Self-Review (spec 대비)
+
+- **§3.1 job 로직(build_draft + benchmark per product)** → Task 1. ✓ (스펙은 flow 파일에 로직, but Prefect 미설치라 prefect-free job 모듈로 분리 — 정제, 더 testable)
+- **§3.2 config flag** → Task 1 Step 3. ✓
+- **§3.1 flow 래퍼** → Task 2. ✓
+- **§5 경계(읽기전용, 라우터 무관, default-off)** → job/flow가 executor/execution_client 미import; gate; 정적 테스트가 `@broker.task`/`schedule=` 금지 확인. ✓
+- **§6 에러처리(게이트 off no-op / product 격리 / md 실패 best-effort)** → gate test, 격리 test(savepoint), benchmark_runner 자체 best-effort. ✓
+- **§7 테스트** → gate off / gate on per-product / 격리 3종 + flow 정적 5종. ✓
+- **§8 위험(중복스케줄 금지)** → Global Constraints + flow 정적 테스트가 `@broker.task`/`schedule=` 부재 단언. ✓
+- **§2 범위밖(배포 등록 외부)** → flow docstring + 정적 테스트가 deployment yaml 부재 단언; 플랜은 배포 등록 안 함. ✓
+- 마이그레이션 없음(Phase 1 컬럼 재사용) ✓.

--- a/docs/superpowers/specs/2026-06-21-binance-demo-scalping-review-flow-design.md
+++ b/docs/superpowers/specs/2026-06-21-binance-demo-scalping-review-flow-design.md
@@ -1,0 +1,110 @@
+# Binance Demo 스캘핑 일별 리뷰+벤치마크 자동화 (Phase 2 / Design)
+
+- **작성일**: 2026-06-21
+- **상태**: 승인됨 (브레인스토밍 → 스펙)
+- **브랜치**: `feature/binance-demo-scalping-review-flow`
+- **선행**: Phase 1(변경 A/B) merged·라이브 (PR #1342); 트레이딩 틱은 외부 Prefect(robin-prefect-automations)가 이미 매일 kick 중
+
+## 1. 배경 / 동기
+
+Binance USD-M Futures Demo "매일 자동 모의루프"에서 **트레이딩 틱은 이미 자동**(스케줄러/외부 Prefect)이지만, **일별 리뷰 draft + buy&hold 벤치마크는 자동 생성되지 않는다**(스케줄러는 거래만 돌리고 `ScalpingReviewService.build_draft` / `benchmark_runner`를 호출하지 않음). 그래서 `/invest/scalping`에 "전략 net vs 패시브(buy&hold)"가 매일 자동으로 채워지지 않는다.
+
+Phase 2 = **이 측정/리뷰 자동화**. recurrence는 **Prefect로 통일** — 트레이딩 틱이 이미 Prefect에 있으므로, 리뷰/벤치마크도 Prefect flow로 두어 **스캘핑 루프 전체(거래+측정)를 하나의 control plane에서 스케줄·관측·일시정지**할 수 있게 한다. (읽기전용 리뷰는 in-repo TaskIQ cron도 가능하나, 루프 응집/단일 가시성을 위해 Prefect 채택.)
+
+## 2. 범위
+
+**In scope:** 매일 자동으로 데모 product별 (1) 리뷰 draft 롤업 + (2) buy&hold 벤치마크를 생성·저장하는 **Prefect flow** 추가. 기존 `app/flows/*_flow.py` 패턴(env-gate default-off, 배포 등록은 외부/deferred) 준수.
+
+**Out of scope:**
+- 트레이딩 틱 (외부 Prefect, 무변경)
+- verdict/회고 자동 초안 (Phase 3)
+- LLM 시그널 (Phase 3)
+- **실제 Prefect 배포 등록** — robin-prefect-automations(외부 레포), operator, paused-by-default (이 PR 아님)
+- UI 변경 (`/invest/scalping`은 이미 `benchmarkReturnBps` 노출 — Phase 1에서 완료)
+
+## 3. 컴포넌트
+
+### 3.1 신규: `app/flows/binance_demo_scalping_review_flow.py`
+
+기존 `invest_screener_snapshots_us_flow.py` 패턴(순수 helper + `@task` + `@flow` + dict 반환)을 따른다.
+
+```python
+async def run_demo_scalping_review_refresh(
+    *,
+    review_date: dt.date | None = None,        # 기본: 현재 UTC date
+    products: Sequence[str] = ("spot", "usdm_futures"),
+    now: dt.datetime | None = None,
+) -> dict[str, Any]
+```
+
+- **게이트**: `settings.binance_demo_scalping_review_flow_enabled` False면 즉시 `{"status": "disabled"}` 반환(작업 0, DB 쓰기 0).
+- 활성 시:
+  - `now` 기본 = 현재 UTC(`dt.datetime.now(dt.UTC)`), `review_date` 기본 = `now.date()`.
+  - `market_data = DemoScalpingMarketData()` 1회 생성, `async with AsyncSessionLocal() as session:` 1회.
+  - **product별 루프** (try/except 격리):
+    - `service.build_draft(review_date=..., product=p, now=now)` (그날 `scalp_trade_analytics` → `scalping_daily_reviews` 롤업)
+    - `await compute_and_store_daily_benchmark(session=session, market_data=market_data, review_date=..., product=p, now=now)` (1d klines → `benchmark_return_bps`)
+    - product 결과 요약(trade_count / net_return_bps / benchmark_return_bps) 수집; 예외는 errors에 기록하고 다음 product 계속.
+  - `await session.commit()`; `finally: await market_data.aclose()`.
+  - 반환: `{"status": "ran", "reviewDate": ..., "products": [...요약...], "errors": [...]}`.
+- `@task(name="binance_demo_scalping_review")` + `@flow(name="binance_demo_scalping_review")` 래퍼.
+
+### 3.2 `app/core/config.py`
+
+신규 설정 필드:
+```python
+binance_demo_scalping_review_flow_enabled: bool = False
+```
+(env `BINANCE_DEMO_SCALPING_REVIEW_FLOW_ENABLED`, pydantic case-insensitive. 기본 False = default-off.)
+
+### 3.3 (이 PR 아님) Prefect 배포 등록
+
+robin-prefect-automations에 deployment 등록, **paused-by-default**. **권장 cron: 매일 ~23:55 UTC** (그날 거래 완료 + 1d 캔들 거의 완성 시점 반영). 운영자가 (a) `BINANCE_DEMO_SCALPING_REVIEW_FLOW_ENABLED=true` 설정 + (b) deployment unpause 시 자동 동작.
+
+## 4. 데이터 흐름
+
+```
+[외부 Prefect cron ~23:55 UTC] → binance_demo_scalping_review_flow
+   → [게이트 off → {"status":"disabled"} no-op]
+   → 게이트 on: 각 product(spot, usdm_futures):
+        build_draft  (scalp_trade_analytics 그날 롤업 → scalping_daily_reviews)
+        benchmark    (DemoScalpingMarketData 1d klines → benchmark_return_bps)
+   → /invest/scalping 에서 전략 net_return_bps vs benchmark_return_bps 자동 표시
+```
+
+## 5. 경계 / 안전
+
+- flow는 `DemoScalpingMarketData` + `ScalpingReviewService` + `benchmark_runner`를 import — **flow/worker 컨텍스트라 허용**(`/invest/api/scalping` 라우터 정적 import-guard와 무관; flow는 그 라우터가 아님).
+- **브로커/주문 mutation 없음**: `scalp_trade_analytics`(읽기) + klines(읽기) + `scalping_daily_reviews`/`scalping_reviews` 쓰기만.
+- **default-off**: env flag 미설정 시 no-op. 실제 recurrence는 외부 deployment unpause(operator)까지 비활성.
+- product별 try/except 격리: 한 product 실패가 다른 product를 막지 않음.
+- 벤치마크는 `benchmark_runner`가 이미 market-data 실패 시 None(best-effort) — 리뷰는 전략 net만으로 정상.
+
+## 6. 에러 처리
+
+- 게이트 off → `{"status": "disabled"}`.
+- product별 예외 → 해당 product 요약 대신 `errors`에 `{product, error}` 기록, 나머지 product 계속, flow는 성공 반환(부분 성공).
+- `market_data.aclose()`는 finally(생성 실패 시에도 안전).
+- DB 오류(build_draft/commit)는 전파(데이터 정합 보호) — best-effort 대상은 market-data fetch뿐.
+
+## 7. 테스트
+
+- **게이트 off**: `binance_demo_scalping_review_flow_enabled=False` → `{"status":"disabled"}`, `scalping_daily_reviews` 행 0 (DB 무변경).
+- **게이트 on (fake market_data + db_session + seeded `scalp_trade_analytics`)**: product별 `scalping_daily_reviews` 행 생성 + `net_return_bps` + `benchmark_return_bps` 채워짐. 반환 dict에 product별 요약.
+- **product 격리**: 한 product의 market_data fetch가 raise → 그 product benchmark NULL(또는 errors 기록)이지만 다른 product는 정상 완료.
+- **review_date 기본값**: `now` 미지정 시 현재 UTC date로 롤업.
+- (순수 단위) `run_demo_scalping_review_refresh`를 직접 호출하는 테스트(Prefect flow 런타임 없이 helper 단위 테스트 — 스크리너 flow의 `run_*` helper 테스트 패턴).
+
+## 8. 위험 / 함정
+
+- **중복 스케줄 금지**: in-repo TaskIQ cron으로도 만들지 말 것(Prefect로 통일). flow에 `@broker.task(schedule=...)` 부착 금지.
+- **read-only 보장**: flow가 실수로 주문 경로(executor/execution_client)를 import하지 않도록 — `benchmark_runner`/`service`/`market_data`만.
+- **시점**: review_date=현재 UTC date이므로, cron이 UTC 일경계 직전(~23:55)이 아니면 "그날" 데이터가 부분적일 수 있음 — 권장 cron 준수 또는 operator가 prior-day로 `review_date` 지정 가능.
+- **default-off**: 배포만으로는 안 돎(env flag + 외부 deployment unpause 필요) — 의도된 안전장치.
+
+## 9. 산출물 / 완료 기준
+
+- `app/flows/binance_demo_scalping_review_flow.py` (helper + task + flow) + `config.py` flag.
+- 게이트 off no-op / 게이트 on product별 리뷰+벤치마크 생성 / product 격리 테스트 green.
+- 마이그레이션 없음(Phase 1에서 `benchmark_return_bps` 컬럼 이미 추가됨).
+- 배포 등록(외부, paused)은 operator 후속 — 런북/Linear 코멘트로 활성화 절차 안내.

--- a/tests/jobs/test_binance_demo_scalping_review.py
+++ b/tests/jobs/test_binance_demo_scalping_review.py
@@ -1,0 +1,189 @@
+"""Task 1 — run_demo_scalping_review_refresh: unit tests (TDD Step 1).
+
+Helpers copied from:
+  - tests/services/scalping_reviews/test_service.py : 22-67  (_DATE/_NOW/_instrument/_analytics)
+  - tests/services/brokers/binance/demo_scalping_exec/test_benchmark_runner.py : _FakeMD
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from decimal import Decimal
+
+import pytest
+from sqlalchemy import select
+
+from app.core.config import settings
+from app.jobs.binance_demo_scalping_review import run_demo_scalping_review_refresh
+from app.models.crypto_instruments import CryptoInstrument
+from app.models.scalp_trade_analytics import ScalpTradeAnalytics
+from app.services.brokers.binance.demo_scalping.signal import Candle
+from app.services.scalping_reviews.service import ScalpingReviewService
+
+# ---------------------------------------------------------------------------
+# Helpers — copied from tests/services/scalping_reviews/test_service.py:22-67
+# ---------------------------------------------------------------------------
+
+_DATE = dt.date(2026, 5, 25)
+_NOW = dt.datetime(2026, 5, 25, 12, 0, 0, tzinfo=dt.UTC)
+
+
+async def _instrument(session, symbol="RVWXRPUSDT") -> int:
+    """Get-or-create — crypto_instruments persists across tests in the shared
+    test DB, so a fixed insert would collide on its unique key."""
+    existing = await session.scalar(
+        select(CryptoInstrument).where(
+            CryptoInstrument.venue == "binance",
+            CryptoInstrument.product == "usdm_futures",
+            CryptoInstrument.venue_symbol == symbol,
+        )
+    )
+    if existing is not None:
+        return existing.id
+    inst = CryptoInstrument(
+        venue="binance",
+        product="usdm_futures",
+        venue_symbol=symbol,
+        base_asset="XRP",
+        quote_asset="USDT",
+        status="active",
+    )
+    session.add(inst)
+    await session.flush()
+    return inst.id
+
+
+async def _analytics(session, instrument_id, *, created_at=_NOW, **kw):
+    base = {
+        "open_client_order_id": f"o-{kw.get('tag', '0')}",
+        "instrument_id": instrument_id,
+        "product": "usdm_futures",
+        "symbol": "XRPUSDT",
+        "side": "BUY",
+        "qty": Decimal("1"),
+        "created_at": created_at,
+        "updated_at": created_at,
+    }
+    kw.pop("tag", None)
+    base.update(kw)
+    row = ScalpTradeAnalytics(**base)
+    session.add(row)
+    await session.flush()
+    return row
+
+
+# ---------------------------------------------------------------------------
+# Fake market-data helper (adapted from test_benchmark_runner.py)
+# ---------------------------------------------------------------------------
+
+
+class _FakeMD:
+    def __init__(self, prices: dict[str, tuple[float, float]]) -> None:
+        self._prices = prices
+
+    async def fetch_klines(self, product, symbol, *, interval="1m", limit=50):
+        o, c = self._prices[symbol]
+        return [
+            Candle(
+                open_time_ms=0,
+                open=Decimal(str(o)),
+                high=Decimal(str(max(o, c))),
+                low=Decimal(str(min(o, c))),
+                close=Decimal(str(c)),
+                close_time_ms=0,
+            )
+        ]
+
+    async def aclose(self) -> None:  # pragma: no cover - injected, not owned
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_disabled_gate_is_noop(monkeypatch) -> None:
+    monkeypatch.setattr(settings, "binance_demo_scalping_review_flow_enabled", False)
+    result = await run_demo_scalping_review_refresh(
+        review_date=_DATE, products=("usdm_futures",), now=_NOW
+    )
+    assert result == {"status": "disabled"}
+
+
+@pytest.mark.asyncio
+async def test_enabled_builds_review_and_benchmark(db_session, monkeypatch) -> None:
+    monkeypatch.setattr(settings, "binance_demo_scalping_review_flow_enabled", True)
+    iid = await _instrument(db_session, "XRPUSDT")
+    await _analytics(
+        db_session,
+        iid,
+        tag="w",
+        symbol="XRPUSDT",
+        entry_price=Decimal("100"),
+        exit_price=Decimal("101"),
+        entry_notional_usdt=Decimal("100"),
+        net_pnl_usdt=Decimal("0.9"),
+        gross_pnl_usdt=Decimal("1.0"),
+        exit_reason="take_profit",
+    )
+    md = _FakeMD({"XRPUSDT": (100.0, 101.0)})  # +100 bps
+    result = await run_demo_scalping_review_refresh(
+        session=db_session,
+        market_data=md,
+        review_date=_DATE,
+        products=("usdm_futures",),
+        now=_NOW,
+    )
+    assert result["status"] == "ran"
+    assert result["reviewDate"] == _DATE.isoformat()
+    assert result["errors"] == []
+    [summary] = result["products"]
+    assert summary == {
+        "product": "usdm_futures",
+        "tradeCount": 1,
+        "netReturnBps": "90.0000",
+        "benchmarkReturnBps": "100.00",  # (101/100-1)*10000 = Decimal('100.00')
+    }
+    review = await ScalpingReviewService(db_session)._get_by_key(
+        _DATE, "usdm_futures", "binance_demo", ""
+    )
+    assert review is not None and review.benchmark_return_bps == Decimal("100")
+
+
+@pytest.mark.asyncio
+async def test_product_failure_is_isolated(db_session, monkeypatch) -> None:
+    monkeypatch.setattr(settings, "binance_demo_scalping_review_flow_enabled", True)
+    iid = await _instrument(db_session, "XRPUSDT")
+    await _analytics(
+        db_session,
+        iid,
+        tag="w",
+        symbol="XRPUSDT",
+        entry_price=Decimal("100"),
+        exit_price=Decimal("101"),
+        entry_notional_usdt=Decimal("100"),
+        net_pnl_usdt=Decimal("0.9"),
+        gross_pnl_usdt=Decimal("1.0"),
+        exit_reason="take_profit",
+    )
+    md = _FakeMD({"XRPUSDT": (100.0, 101.0)})
+    orig = ScalpingReviewService.build_draft
+
+    async def flaky(self, *, review_date, product, now, **kw):
+        if product == "spot":
+            raise RuntimeError("boom")
+        return await orig(self, review_date=review_date, product=product, now=now, **kw)
+
+    monkeypatch.setattr(ScalpingReviewService, "build_draft", flaky)
+    result = await run_demo_scalping_review_refresh(
+        session=db_session,
+        market_data=md,
+        review_date=_DATE,
+        products=("spot", "usdm_futures"),
+        now=_NOW,
+    )
+    assert result["status"] == "ran"
+    assert [s["product"] for s in result["products"]] == ["usdm_futures"]
+    assert [e["product"] for e in result["errors"]] == ["spot"]

--- a/tests/services/brokers/binance/test_audit_no_signed_endpoints.py
+++ b/tests/services/brokers/binance/test_audit_no_signed_endpoints.py
@@ -94,6 +94,15 @@ ALLOWED_LEGACY_FILES: frozenset[str] = frozenset(
         # imports + the BINANCE_DEMO_SCALPING_* env-flag names.
         "app/jobs/binance_demo_scalping_runner.py",
         "app/tasks/binance_demo_scalping_tasks.py",
+        # Phase 2 — Demo scalping daily review + buy&hold benchmark automation.
+        # Orchestration only: the job rolls scalp_trade_analytics into the review
+        # draft and computes the benchmark via the in-package adapters; the flow
+        # is a thin Prefect wrapper; config holds the default-off env flag. No
+        # signed HTTP/WS — references "Binance" via imports + the
+        # BINANCE_DEMO_SCALPING_REVIEW_FLOW_ENABLED flag name only.
+        "app/jobs/binance_demo_scalping_review.py",
+        "app/flows/binance_demo_scalping_review_flow.py",
+        "app/core/config.py",
         # ROB-323 / ROB-325 — the operator Naver remote-debug audit's Chrome
         # CDP host allowlist. Contains NO Binance HTTP/WS/signed surface; it is
         # a strict 127.0.0.1:9222 allowlist and references "binance" only in a

--- a/tests/test_binance_demo_scalping_review_flow.py
+++ b/tests/test_binance_demo_scalping_review_flow.py
@@ -1,0 +1,59 @@
+"""Static checks for the Phase 2 demo scalping review Prefect flow.
+
+Prefect is not a project dependency, so the flow module is validated by file
+content (decorators / names / delegation / deferred deployment), not import.
+The real logic is unit-tested in tests/jobs/test_binance_demo_scalping_review.py.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+_FLOW_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "app"
+    / "flows"
+    / "binance_demo_scalping_review_flow.py"
+)
+
+
+def test_flow_file_exists() -> None:
+    assert _FLOW_PATH.exists(), f"Flow file not found at {_FLOW_PATH}"
+
+
+def test_flow_declares_prefect_flow_and_task() -> None:
+    text = _FLOW_PATH.read_text()
+    assert "@flow" in text, "Missing @flow decorator"
+    assert "@task" in text, "Missing @task decorator"
+    assert "binance_demo_scalping_review" in text, "Missing flow name"
+
+
+def test_flow_delegates_to_job() -> None:
+    text = _FLOW_PATH.read_text()
+    assert "run_demo_scalping_review_refresh" in text, (
+        "Flow must delegate to the prefect-free job helper"
+    )
+
+
+def test_flow_does_not_attach_in_repo_schedule() -> None:
+    text = _FLOW_PATH.read_text()
+    assert "@broker.task" not in text and "schedule=" not in text, (
+        "Recurrence is Prefect-only; no in-repo TaskIQ schedule"
+    )
+
+
+def test_flow_not_registered_via_deployment_yaml() -> None:
+    project_root = _FLOW_PATH.parents[1]
+    import pytest
+
+    yaml_files = list(project_root.glob("**/*.yaml")) + list(
+        project_root.glob("**/*.yml")
+    )
+    for yf in yaml_files:
+        if ".venv" in str(yf) or ".git" in str(yf):
+            continue
+        if "binance_demo_scalping_review" in yf.read_text():
+            pytest.fail(
+                f"Deployment YAML references the flow at {yf}; "
+                "registration is deferred (external robin-prefect-automations)."
+            )

--- a/tests/test_binance_demo_scalping_review_flow.py
+++ b/tests/test_binance_demo_scalping_review_flow.py
@@ -43,7 +43,7 @@ def test_flow_does_not_attach_in_repo_schedule() -> None:
 
 
 def test_flow_not_registered_via_deployment_yaml() -> None:
-    project_root = _FLOW_PATH.parents[1]
+    project_root = _FLOW_PATH.parents[2]
     import pytest
 
     yaml_files = list(project_root.glob("**/*.yaml")) + list(


### PR DESCRIPTION
## 목적

Binance Demo 스캘핑 "매일 자동 모의루프"에서 트레이딩 틱은 이미 외부 Prefect가 자동 실행 중이나, **일별 리뷰 draft + buy&hold 벤치마크는 자동 생성되지 않았다**. 이 PR은 그 측정/리뷰를 자동화해 `/invest/scalping`에 **전략 net vs 패시브(buy&hold)**가 매일 채워지게 한다. recurrence는 **Prefect로 통일**(트레이딩 틱과 동일 control plane).

- spec: `docs/superpowers/specs/2026-06-21-binance-demo-scalping-review-flow-design.md`
- plan: `docs/superpowers/plans/2026-06-21-binance-demo-scalping-review-flow.md`

## 변경

- **`app/jobs/binance_demo_scalping_review.py`** (신규) — prefect-free 로직 `run_demo_scalping_review_refresh`: product별 `ScalpingReviewService.build_draft`(그날 `scalp_trade_analytics` 롤업) + `compute_and_store_daily_benchmark`(1d klines → `benchmark_return_bps`). env-gate default-off, **product별 SAVEPOINT 격리**, 주입형 session/market_data(유닛테스트 가능).
- **`app/flows/binance_demo_scalping_review_flow.py`** (신규) — thin Prefect `@task`/`@flow` 래퍼(로직 없이 job 위임). Prefect 미설치라 정적 테스트.
- **`app/core/config.py`** — `binance_demo_scalping_review_flow_enabled: bool = False` (default-off).

## 안전 / 경계

- **읽기전용**: 주문/브로커 mutation 모듈 미import — `scalp_trade_analytics`/klines 읽기 + `scalping_daily_reviews` 쓰기만.
- **default-off**: env flag 미설정 시 `{"status":"disabled"}` no-op(자원 열기 전 반환).
- **In-repo cron 미부착**: recurrence는 Prefect 전용. **배포 등록은 외부(robin-prefect-automations) deferred·paused** (이 PR 아님) — 정적 테스트가 deployment yaml 부재 검증.
- **마이그레이션 없음**(`benchmark_return_bps` 컬럼은 Phase 1에서 추가).

## 테스트 / 리뷰

- 신규 8 tests(job 유닛 3: 게이트 off / 게이트 on per-product / product 격리 — SAVEPOINT 실증; flow 정적 5) + 관련 스코프 회귀 **76 passed**. ruff/ty clean.
- Subagent-Driven 실행: 태스크별 구현→리뷰→수정 + **전체 브랜치 최종 리뷰(opus): Ready to merge**. 최종 리뷰 fix 1건 반영(deployment-yaml 가드 스캔 루트 repo root로 확대).

## Operator 활성화 (머지 후, 외부)

1. `BINANCE_DEMO_SCALPING_REVIEW_FLOW_ENABLED=true` 설정
2. robin-prefect-automations에 `binance_demo_scalping_review` flow deployment 등록·unpause (권장 cron ~23:55 UTC daily — 그날 마감 반영)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0115yvcHYpLv3aLeKJ36Bo9w

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Phase 2 daily Binance demo scalping review automation that also computes buy&hold benchmarks.
  * Introduced a configuration flag to keep the workflow disabled by default.

* **Documentation**
  * Added a superpowers plan and design spec covering the new daily review + benchmark automation workflow and its execution/testing approach.

* **Tests**
  * Added unit tests for enable/disable behavior and per-product failure isolation.
  * Added static validation tests for the Prefect flow wrapper and deferred deployment setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->