### PR TITLE
feat: Phase 3 D-PR1 — LLM 결정 주입 MCP 도구 (반자동 데모 스캘핑, dry_run+confirm)

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -230,6 +230,8 @@ class Settings(BaseSettings):
     kis_mock_scalping_ws_confirm: bool = False
     # Phase 2 — daily demo scalping review + buy&hold benchmark flow (default-off).
     binance_demo_scalping_review_flow_enabled: bool = False
+    # Phase 3 — gate for the LLM decision-injection MCP tool (default-off).
+    binance_demo_scalping_enabled: bool = False
 
     # KIS Rate Limiting (HTTP API)
     kis_rate_limit_rate: int = 19  # 초당 최대 요청 수 (안전 마진으로 20-1)

--- a/app/mcp_server/tooling/binance_demo_scalping_handler.py
+++ b/app/mcp_server/tooling/binance_demo_scalping_handler.py
@@ -56,7 +56,8 @@ async def _execute_confirmed_round_trip(
     now: dt.datetime,
 ) -> Any:
     """Construct the demo executor and run one monitored round-trip. Real Demo
-    order — only reached on confirm=True. Mirrors scripts/binance_demo_scalping_execute."""
+    order — only reached on confirm=True. Mirrors the confirmed execution path in
+    scripts/binance_demo_scalping_execute.py."""
     from app.core.db import AsyncSessionLocal
     from app.services.brokers.binance.demo_scalping.market_data import (
         DemoScalpingMarketData,

--- a/app/mcp_server/tooling/binance_demo_scalping_handler.py
+++ b/app/mcp_server/tooling/binance_demo_scalping_handler.py
@@ -1,0 +1,202 @@
+"""Phase 3 — LLM decision-injection MCP tool for Binance Demo scalping.
+
+The out-of-process LLM (an MCP session) reads market data + recent scalping
+reviews, decides, and calls ``binance_demo_scalping_submit_decision`` with its
+decision + rationale. The tool is deterministic: it executes the LLM's decision
+via the existing ``DemoScalpingExecutor.execute_monitored`` (one round-trip),
+tagging the trade ``session_tag="llm"`` and recording the rationale in
+``signal_snapshot``. NO LLM call here — judgment belongs to the MCP caller
+(runtime in-process LLM boundary). Demo-only; dry_run default + confirm gate.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import logging
+from decimal import Decimal
+from typing import Any, Literal
+
+from app.services.brokers.binance.demo_scalping.contract import ScalpingRiskLimits
+from app.services.brokers.binance.demo_scalping.order_intent import OrderIntent
+
+logger = logging.getLogger(__name__)
+
+_ALLOWLIST = frozenset({"XRPUSDT", "DOGEUSDT", "SOLUSDT"})
+
+
+def _build_intent(
+    *, symbol: str, side: str, notional_usdt: Decimal, now: dt.datetime
+) -> OrderIntent:
+    now_ms = int(now.timestamp() * 1000)
+    return OrderIntent(
+        product="usdm_futures",
+        symbol=symbol,
+        side=side,
+        order_type="MARKET",
+        target_notional_usdt=notional_usdt,
+        entry_reference_price=None,
+        tp_price=None,
+        sl_price=None,
+        confidence=Decimal("0"),
+        reason_codes=("llm_decision",),
+        source_candle_close_time_ms=now_ms,
+        evaluated_at_ms=now_ms,
+    )
+
+
+async def _execute_confirmed_round_trip(
+    *,
+    symbol: str,
+    side: str,
+    tp_bps: Decimal,
+    sl_bps: Decimal,
+    notional_usdt: Decimal,
+    session_tag: str,
+    signal_snapshot: dict[str, Any],
+    now: dt.datetime,
+) -> Any:
+    """Construct the demo executor and run one monitored round-trip. Real Demo
+    order — only reached on confirm=True. Mirrors scripts/binance_demo_scalping_execute."""
+    from app.core.db import AsyncSessionLocal
+    from app.services.brokers.binance.demo_scalping.market_data import (
+        DemoScalpingMarketData,
+    )
+    from app.services.brokers.binance.demo_scalping_exec.executor import (
+        DemoScalpingExecutor,
+    )
+    from app.services.brokers.binance.demo_scalping_exec.reference import (
+        DemoReferenceData,
+    )
+    from app.services.brokers.binance.futures_demo.execution_client import (
+        BinanceFuturesDemoExecutionClient,
+    )
+
+    limits = ScalpingRiskLimits()
+    client = BinanceFuturesDemoExecutionClient.from_env()
+    reference = DemoReferenceData()
+    market_data = DemoScalpingMarketData()
+    try:
+        async with AsyncSessionLocal() as session:
+            executor = DemoScalpingExecutor(
+                product="usdm_futures",
+                client=client,
+                session=session,
+                reference=reference,
+                now=now,
+                limits=limits,
+                market_data=market_data,
+            )
+            intent = _build_intent(
+                symbol=symbol, side=side, notional_usdt=notional_usdt, now=now
+            )
+            result = await executor.execute_monitored(
+                intent,
+                confirm=True,
+                tp_bps=tp_bps,
+                sl_bps=sl_bps,
+                session_tag=session_tag,
+                signal_snapshot=signal_snapshot,
+            )
+            await session.commit()
+            return result
+    finally:
+        await reference.aclose()
+        await market_data.aclose()
+        aclose = getattr(client, "aclose", None)
+        if aclose is not None:
+            await aclose()
+
+
+async def binance_demo_scalping_submit_decision(
+    symbol: str,
+    side: Literal["BUY", "SELL"],
+    rationale: str,
+    tp_bps: float = 30.0,
+    sl_bps: float = 20.0,
+    notional_usdt: float = 10.0,
+    dry_run: bool = True,
+    confirm: bool = False,
+) -> dict[str, Any]:
+    """Submit an LLM-decided Binance Demo (USD-M futures) scalping round-trip.
+
+    DEMO ONLY. ``dry_run`` (default) returns the plan with no order. A real Demo
+    order requires ``dry_run=False`` AND ``confirm=True``. The trade is tagged
+    ``session_tag="llm"`` and the rationale is recorded in ``signal_snapshot`` so
+    the daily review can compare LLM vs the rule-based baseline. Symbols limited
+    to XRPUSDT/DOGEUSDT/SOLUSDT; 1x; notional capped at 10 USDT by the executor."""
+    sym = symbol.upper().strip()
+    if sym not in _ALLOWLIST:
+        return {
+            "status": "rejected",
+            "error": f"symbol {sym!r} not allowlisted (allowed: {sorted(_ALLOWLIST)})",
+        }
+    if side not in ("BUY", "SELL"):
+        return {"status": "rejected", "error": f"side must be BUY|SELL, got {side!r}"}
+    if not rationale or not rationale.strip():
+        return {"status": "rejected", "error": "rationale must be a non-empty string"}
+
+    notional = Decimal(str(notional_usdt))
+    signal_snapshot = {
+        "source": "llm",
+        "rationale": rationale.strip(),
+        "requested_side": side,
+        "tp_bps": str(tp_bps),
+        "sl_bps": str(sl_bps),
+    }
+
+    if dry_run or not confirm:
+        return {
+            "status": "planned",
+            "dry_run": True,
+            "symbol": sym,
+            "side": side,
+            "rationale": rationale.strip(),
+            "session_tag": "llm",
+            "notional_usdt": str(notional),
+            "tp_bps": str(tp_bps),
+            "sl_bps": str(sl_bps),
+            "note": "set dry_run=false AND confirm=true to place the real Demo order",
+        }
+
+    now = dt.datetime.now(dt.UTC)
+    try:
+        result = await _execute_confirmed_round_trip(
+            symbol=sym,
+            side=side,
+            tp_bps=Decimal(str(tp_bps)),
+            sl_bps=Decimal(str(sl_bps)),
+            notional_usdt=notional,
+            session_tag="llm",
+            signal_snapshot=signal_snapshot,
+            now=now,
+        )
+    except Exception as exc:  # noqa: BLE001 — surface broker/setup errors as data
+        logger.exception("binance demo scalping submit_decision failed")
+        return {"status": "error", "error": f"{type(exc).__name__}: {exc}"}
+
+    evidence = result.to_evidence_dict()
+    return {
+        "status": result.status,
+        "dry_run": False,
+        "symbol": sym,
+        "side": side,
+        "rationale": rationale.strip(),
+        "session_tag": "llm",
+        "open_client_order_id": result.open_client_order_id,
+        "close_client_order_id": result.close_client_order_id,
+        "exit_reason": result.exit_reason,
+        "evidence": evidence,
+    }
+
+
+def register_binance_demo_scalping_tools(mcp: Any) -> None:
+    mcp.tool(
+        name="binance_demo_scalping_submit_decision",
+        description=(
+            "Submit an LLM-decided Binance Demo (USD-M futures) scalping "
+            "round-trip. DEMO ONLY, dry_run default; real order needs "
+            "dry_run=false + confirm=true. Tags the trade session_tag='llm' and "
+            "records the rationale for LLM-vs-baseline comparison. Symbols: "
+            "XRPUSDT/DOGEUSDT/SOLUSDT; 1x; <=10 USDT."
+        ),
+    )(binance_demo_scalping_submit_decision)

--- a/app/mcp_server/tooling/binance_demo_scalping_handler.py
+++ b/app/mcp_server/tooling/binance_demo_scalping_handler.py
@@ -125,6 +125,7 @@ async def binance_demo_scalping_submit_decision(
     the daily review can compare LLM vs the rule-based baseline. Symbols limited
     to XRPUSDT/DOGEUSDT/SOLUSDT; 1x; notional capped at 10 USDT by the executor."""
     sym = symbol.upper().strip()
+    side = side.upper().strip()
     if sym not in _ALLOWLIST:
         return {
             "status": "rejected",

--- a/app/mcp_server/tooling/registry.py
+++ b/app/mcp_server/tooling/registry.py
@@ -179,6 +179,12 @@ def register_all_tools(mcp: FastMCP, profile: McpProfile = McpProfile.DEFAULT) -
         # still fail-closes on missing credentials at call time.
         if settings.kiwoom_mock_enabled:
             orders_kiwoom_variants.register(mcp)
+        if settings.binance_demo_scalping_enabled:
+            from app.mcp_server.tooling.binance_demo_scalping_handler import (
+                register_binance_demo_scalping_tools,
+            )
+
+            register_binance_demo_scalping_tools(mcp)
     elif profile is McpProfile.HERMES_PAPER_KIS:
         # Paper-only: only mock-pinned order surface. Live surface is physically absent.
         register_kis_mock_order_tools(mcp)

--- a/app/services/brokers/binance/demo_scalping_exec/executor.py
+++ b/app/services/brokers/binance/demo_scalping_exec/executor.py
@@ -257,6 +257,8 @@ class DemoScalpingExecutor:
         instrument_id: int,
         result: ExecutionResult,
         telemetry: _RunTelemetry | None = None,
+        session_tag: str | None = None,
+        signal_snapshot: dict[str, Any] | None = None,
     ) -> None:
         """Best-effort: write one ``scalp_trade_analytics`` round-trip row.
 
@@ -281,7 +283,8 @@ class DemoScalpingExecutor:
         try:
             if entry_fill is None:
                 await self._record_partial_analytics(
-                    intent, qty, instrument_id, result, tele
+                    intent, qty, instrument_id, result, tele,
+                    session_tag=session_tag, signal_snapshot=signal_snapshot,
                 )
                 return
             econ = build_round_trip_economics(
@@ -319,6 +322,8 @@ class DemoScalpingExecutor:
                     net_return_bps=econ.net_return_bps,
                     holding_seconds=tele.holding_seconds,
                     exit_reason=result.exit_reason,
+                    session_tag=session_tag,
+                    signal_snapshot=signal_snapshot,
                     now=self.now,
                 )
         except Exception:  # noqa: BLE001 — analytics is best-effort, never fatal
@@ -335,6 +340,8 @@ class DemoScalpingExecutor:
         instrument_id: int,
         result: ExecutionResult,
         tele: _RunTelemetry,
+        session_tag: str | None = None,
+        signal_snapshot: dict[str, Any] | None = None,
     ) -> None:
         """Record a round-trip with no derivable entry fill price: the fill is
         proven (the run reached reconcile) but no avg price evidence exists, so
@@ -361,6 +368,8 @@ class DemoScalpingExecutor:
                 mfe_bps=tele.mfe_bps,
                 holding_seconds=tele.holding_seconds,
                 exit_reason=result.exit_reason,
+                session_tag=session_tag,
+                signal_snapshot=signal_snapshot,
                 now=self.now,
             )
 
@@ -370,6 +379,8 @@ class DemoScalpingExecutor:
         *,
         confirm: bool = False,
         market: MarketConditions | None = None,
+        session_tag: str | None = None,
+        signal_snapshot: dict[str, Any] | None = None,
     ) -> ExecutionResult:
         """One-shot: open + immediate close-flat (no hold)."""
         prep = await self._preflight(intent, confirm, market)
@@ -393,7 +404,8 @@ class DemoScalpingExecutor:
         # No monitor path on an immediate run: only spread@fill (entry) is known.
         telemetry = _RunTelemetry(entry_spread_bps=self._entry_spread_bps)
         await self._finalize_analytics(
-            intent, ref, qty, notional, instrument_id, result, telemetry
+            intent, ref, qty, notional, instrument_id, result, telemetry,
+            session_tag=session_tag, signal_snapshot=signal_snapshot,
         )
         return result
 
@@ -408,6 +420,8 @@ class DemoScalpingExecutor:
         max_poll_count: int = 30,
         poll_interval_s: float | None = None,
         max_runtime_s: float = 300.0,
+        session_tag: str | None = None,
+        signal_snapshot: dict[str, Any] | None = None,
     ) -> ExecutionResult:
         """Open, then poll the bookTicker within a bounded window and
         MARKET-close on a TP/SL cross — failsafe-close at window end. Always
@@ -490,7 +504,8 @@ class DemoScalpingExecutor:
             exit_reference_price=outcome.exit_conservative,
         )
         await self._finalize_analytics(
-            intent, ref, qty, notional, instrument_id, result, telemetry
+            intent, ref, qty, notional, instrument_id, result, telemetry,
+            session_tag=session_tag, signal_snapshot=signal_snapshot,
         )
         return result
 

--- a/app/services/brokers/binance/demo_scalping_exec/executor.py
+++ b/app/services/brokers/binance/demo_scalping_exec/executor.py
@@ -283,8 +283,13 @@ class DemoScalpingExecutor:
         try:
             if entry_fill is None:
                 await self._record_partial_analytics(
-                    intent, qty, instrument_id, result, tele,
-                    session_tag=session_tag, signal_snapshot=signal_snapshot,
+                    intent,
+                    qty,
+                    instrument_id,
+                    result,
+                    tele,
+                    session_tag=session_tag,
+                    signal_snapshot=signal_snapshot,
                 )
                 return
             econ = build_round_trip_economics(
@@ -404,8 +409,15 @@ class DemoScalpingExecutor:
         # No monitor path on an immediate run: only spread@fill (entry) is known.
         telemetry = _RunTelemetry(entry_spread_bps=self._entry_spread_bps)
         await self._finalize_analytics(
-            intent, ref, qty, notional, instrument_id, result, telemetry,
-            session_tag=session_tag, signal_snapshot=signal_snapshot,
+            intent,
+            ref,
+            qty,
+            notional,
+            instrument_id,
+            result,
+            telemetry,
+            session_tag=session_tag,
+            signal_snapshot=signal_snapshot,
         )
         return result
 
@@ -504,8 +516,15 @@ class DemoScalpingExecutor:
             exit_reference_price=outcome.exit_conservative,
         )
         await self._finalize_analytics(
-            intent, ref, qty, notional, instrument_id, result, telemetry,
-            session_tag=session_tag, signal_snapshot=signal_snapshot,
+            intent,
+            ref,
+            qty,
+            notional,
+            instrument_id,
+            result,
+            telemetry,
+            session_tag=session_tag,
+            signal_snapshot=signal_snapshot,
         )
         return result
 

--- a/docs/runbooks/binance-demo-scalping-llm-session.md
+++ b/docs/runbooks/binance-demo-scalping-llm-session.md
@@ -1,0 +1,19 @@
+# Binance Demo 스캘핑 — 매일 LLM 결정 세션 (Phase 3, 반자동)
+
+매일 사람이 MCP 세션을 트리거해 LLM이 데모 스캘핑 결정을 주입한다.
+
+## 전제
+- `BINANCE_DEMO_SCALPING_ENABLED=true` (MCP 도구 등록 게이트) + futures demo 자격증명.
+- 데모 전용. 실 주문은 `confirm=true`에서만.
+
+## 절차 (MCP 세션)
+1. **시장 읽기** — `get_crypto_*`(funding/OI/캔들) 및 최근 스캘핑 리뷰/벤치마크(`/invest/scalping`)와
+   과거 결정·결과(이전 `signal_snapshot`/리뷰)를 검토한다.
+2. **결정** — symbol(XRPUSDT/DOGEUSDT/SOLUSDT 중)·side·근거(rationale)를 정한다.
+3. **dry-run 확인** — `binance_demo_scalping_submit_decision(symbol, side, rationale, dry_run=true)`로 계획 확인.
+4. **주입** — `...(dry_run=false, confirm=true)`로 실 데모 라운드트립 실행. 결과(status/realized_pnl)를 기록.
+5. **회고** — 다음 세션에서 직전 결정의 결과(net vs buy&hold, LLM vs 규칙 baseline)를 보고 전략을 조정한다.
+
+## 안전
+- 1x · notional<=10 USDT · 손실예산 게이트(Phase 1) · demo-fapi only — executor가 강제.
+- 같은 날 결과는 `session_tag="llm"`로 분리 집계(규칙 baseline과 비교; surfacing은 D-PR2).

--- a/docs/superpowers/plans/2026-06-22-binance-demo-scalping-llm-decision.md
+++ b/docs/superpowers/plans/2026-06-22-binance-demo-scalping-llm-decision.md
@@ -1,0 +1,637 @@
+# Binance Demo 스캘핑 LLM 결정 주입 (Phase 3, D-PR1) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** out-of-process LLM(MCP 세션)이 내린 결정을 `binance_demo_scalping_submit_decision` MCP 도구로 데모 스캘핑에 주입(monitored 라운드트립, `session_tag="llm"` + 근거 `signal_snapshot` 기록, dry_run+confirm).
+
+**Architecture:** ① executor에 `session_tag`+`signal_snapshot` 배선(→ 이미 인자 보유한 `analytics.record`) ② MCP 도구가 기존 `DemoScalpingExecutor.execute_monitored`를 그대로 호출(모든 데모 안전경계 상속). LLM은 도구 호출자일 뿐 도구 내 LLM 호출 없음(런타임 경계 준수).
+
+**Tech Stack:** Python 3.13, FastMCP, SQLAlchemy(async), DemoScalpingExecutor/futures_demo, pytest-asyncio, Decimal.
+
+> **스펙 정제(§3.2 기록처):** 스펙은 결정/근거를 `strategy_events`에 기록한다 했으나, 추출 결과 `TradingDecisionStrategyEvent`는 제약된 source/event_type enum + `user_id`/`session_id`가 필요해 스캘프 결정에 부적합. 대신 **`scalp_trade_analytics.signal_snapshot`(JSONB)**에 기록 — 이미 컬럼과 `record()` 인자가 존재하고, LLM 근거가 그 트레이드의 분석 행에 co-locate되어 더 단순·적합. `session_tag`와 동일 배선으로 함께 전달.
+
+## Global Constraints
+
+- Python 3.13+. 변경은 worktree `feature/binance-demo-scalping-llm-decision`에서. canonical repo는 main 고정.
+- **LLM 호출 없음**: 도구는 LLM이 제출한 결정을 결정론적으로 실행만(런타임 in-process LLM import 금지 경계 준수).
+- **데모 전용 안전경계 상속**: `BinanceFuturesDemoExecutionClient.from_env()` + `DemoScalpingExecutor` 재사용 → demo-fapi only / 1x / 심볼 allowlist(XRP/DOGE/SOL) / notional cap 10 / Phase1 손실게이트. 새 주문 mutation 경로 없음.
+- **이중 게이트**: dry_run 기본 True + `confirm=True` 필수(실 데모 주문). 도구 등록은 `settings.binance_demo_scalping_enabled`(default False) 게이트(kiwoom_mock 패턴).
+- **무회귀**: executor `session_tag`/`signal_snapshot` 기본 `None` → 기존 호출자(스케줄러 규칙기반)는 NULL 유지.
+- **ROB-285 audit**: 새 binance-참조 파일은 `tests/services/brokers/binance/test_audit_no_signed_endpoints.py` ALLOWED_LEGACY_FILES에 등재. 추가 후 audit 테스트로 검증해 새로 플래그되는 파일(핸들러 모듈, 필요시 registry.py)도 등재.
+- **세션 검증 범위**: binance 관련 변경이므로 `tests/services/brokers/binance/` 전체 + `tests/mcp_server/`(또는 도구 테스트) 실행(Phase 2 교훈: audit 테스트는 한 단계 위 디렉토리).
+- 마이그레이션 없음(session_tag/signal_snapshot 컬럼은 ROB-313 기존). D-PR2(리뷰 비교 surfacing)는 후속.
+- 커밋 trailer:
+  ```
+  Co-Authored-By: Paperclip <noreply@paperclip.ing>
+  Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+  Claude-Session: https://claude.ai/code/session_0115yvcHYpLv3aLeKJ36Bo9w
+  ```
+
+## File Structure
+
+- `app/services/brokers/binance/demo_scalping_exec/executor.py` (수정) — `execute`/`execute_monitored`/`_finalize_analytics`/`_record_partial_analytics`에 `session_tag`+`signal_snapshot` 배선.
+- `app/core/config.py` (수정) — `binance_demo_scalping_enabled: bool = False`.
+- `app/mcp_server/tooling/binance_demo_scalping_handler.py` (생성) — 핸들러 + `register_binance_demo_scalping_tools(mcp)`.
+- `app/mcp_server/tooling/registry.py` (수정) — DEFAULT 프로필에서 게이트 조건부 등록.
+- `tests/services/brokers/binance/test_audit_no_signed_endpoints.py` (수정) — allowlist 등재.
+- `docs/runbooks/binance-demo-scalping-llm-session.md` (생성) — 운영 런북.
+- Test: `tests/services/brokers/binance/demo_scalping_exec/test_executor_session_tag.py` (생성), `tests/mcp_server/test_binance_demo_scalping_submit_decision.py` (생성).
+
+---
+
+### Task 1: executor `session_tag` + `signal_snapshot` 배선
+
+**Files:**
+- Modify: `app/services/brokers/binance/demo_scalping_exec/executor.py`
+- Test: `tests/services/brokers/binance/demo_scalping_exec/test_executor_session_tag.py` (생성)
+
+**Interfaces:**
+- Consumes: `ScalpTradeAnalyticsService.record(*, ..., session_tag: str | None = None, signal_snapshot: dict | None = None)` (이미 존재).
+- Produces: `execute_monitored(*, ..., session_tag: str | None = None, signal_snapshot: dict[str, Any] | None = None)` 및 `execute(*, ..., session_tag=None, signal_snapshot=None)` — Task 2가 호출.
+
+- [ ] **Step 1: 실패 테스트 작성**
+
+`tests/services/brokers/binance/demo_scalping_exec/test_executor_session_tag.py` 생성. **`tests/services/brokers/binance/demo_scalping_exec/test_executor_analytics.py`의 30-146행(`_NOW`,`_REF`,`_limits`,`_intent`,`_Ref`,`_MD`,`_Sub`,`_OO`,`_Pos`,`_FakeFutures`)을 복사**한 뒤:
+
+```python
+from app.services.brokers.binance.demo_scalping_exec.analytics import (
+    ScalpTradeAnalyticsService,
+)
+
+
+@pytest.mark.asyncio
+async def test_session_tag_and_signal_snapshot_recorded(db_session) -> None:
+    client = _FakeFutures(open_px="100", close_px="100.40")
+    md = _MD([100.0, 100.4])
+    ex = DemoScalpingExecutor(
+        product="usdm_futures", client=client, session=db_session,
+        reference=_Ref(), now=_NOW, limits=_limits("LLMTAGUSDT"),
+        market_data=md, poll_delay_seconds=0.0,
+    )
+    snap = {"source": "llm", "rationale": "funding flip + oversold"}
+    result = await ex.execute_monitored(
+        _intent("LLMTAGUSDT"), confirm=True, max_poll_count=5,
+        session_tag="llm", signal_snapshot=snap,
+    )
+    assert result.status == "reconciled"
+    row = await ScalpTradeAnalyticsService(db_session).get_by_open_client_order_id(
+        result.open_client_order_id
+    )
+    assert row is not None
+    assert row.session_tag == "llm"
+    assert row.signal_snapshot == snap
+
+
+@pytest.mark.asyncio
+async def test_session_tag_defaults_none_no_regression(db_session) -> None:
+    client = _FakeFutures(open_px="100", close_px="100.40")
+    md = _MD([100.0, 100.4])
+    ex = DemoScalpingExecutor(
+        product="usdm_futures", client=client, session=db_session,
+        reference=_Ref(), now=_NOW, limits=_limits("NOTAGUSDT"),
+        market_data=md, poll_delay_seconds=0.0,
+    )
+    result = await ex.execute_monitored(_intent("NOTAGUSDT"), confirm=True, max_poll_count=5)
+    row = await ScalpTradeAnalyticsService(db_session).get_by_open_client_order_id(
+        result.open_client_order_id
+    )
+    assert row is not None
+    assert row.session_tag is None
+    assert row.signal_snapshot is None
+```
+
+- [ ] **Step 2: 실패 확인**
+
+Run: `cd /Users/mgh3326/work/auto_trader.phase3-llm-decision && uv run pytest tests/services/brokers/binance/demo_scalping_exec/test_executor_session_tag.py -v`
+Expected: FAIL — `execute_monitored() got an unexpected keyword argument 'session_tag'`.
+
+- [ ] **Step 3: `execute_monitored` / `execute` 시그니처에 파라미터 추가**
+
+`executor.py`의 `execute` 시그니처(현재 `async def execute(self, intent, *, confirm=False, market=None)`)를 교체:
+
+```python
+    async def execute(
+        self,
+        intent: OrderIntent,
+        *,
+        confirm: bool = False,
+        market: MarketConditions | None = None,
+        session_tag: str | None = None,
+        signal_snapshot: dict[str, Any] | None = None,
+    ) -> ExecutionResult:
+```
+
+`execute_monitored` 시그니처에 동일 2개 파라미터 추가(기존 파라미터 뒤, `max_runtime_s: float = 300.0,` 다음):
+
+```python
+        session_tag: str | None = None,
+        signal_snapshot: dict[str, Any] | None = None,
+```
+
+- [ ] **Step 4: `_finalize_analytics` 호출 2곳에 전달**
+
+`execute` 내 `_finalize_analytics` 호출(현재 `await self._finalize_analytics(intent, ref, qty, notional, instrument_id, result, telemetry)`)과 `execute_monitored` 내 동일 호출을 둘 다 교체:
+
+```python
+        await self._finalize_analytics(
+            intent, ref, qty, notional, instrument_id, result, telemetry,
+            session_tag=session_tag, signal_snapshot=signal_snapshot,
+        )
+```
+
+- [ ] **Step 5: `_finalize_analytics` / `_record_partial_analytics` 시그니처 + record 호출에 전달**
+
+`_finalize_analytics` 시그니처(현재 끝 `telemetry: _RunTelemetry | None = None,`)에 추가:
+
+```python
+        session_tag: str | None = None,
+        signal_snapshot: dict[str, Any] | None = None,
+```
+
+`_finalize_analytics` 내 `self._record_partial_analytics(intent, qty, instrument_id, result, tele)` 호출을 교체:
+
+```python
+            await self._record_partial_analytics(
+                intent, qty, instrument_id, result, tele,
+                session_tag=session_tag, signal_snapshot=signal_snapshot,
+            )
+```
+
+`_finalize_analytics` 내 `self.analytics.record(...)` 호출의 `now=self.now,` **직전에** 추가:
+
+```python
+                    session_tag=session_tag,
+                    signal_snapshot=signal_snapshot,
+```
+
+`_record_partial_analytics` 시그니처(현재 끝 `tele: _RunTelemetry,`)에 추가:
+
+```python
+        session_tag: str | None = None,
+        signal_snapshot: dict[str, Any] | None = None,
+```
+
+`_record_partial_analytics` 내 `self.analytics.record(...)` 호출의 `now=self.now,` **직전에** 추가:
+
+```python
+                session_tag=session_tag,
+                signal_snapshot=signal_snapshot,
+```
+
+`Any`가 executor.py에 import돼 있는지 확인(파일 상단에 `from typing import Any` — 이미 `ExecutionResult.to_evidence_dict`가 `dict[str, Any]`를 쓰므로 존재).
+
+- [ ] **Step 6: 통과 + 회귀**
+
+Run: `uv run pytest tests/services/brokers/binance/demo_scalping_exec/test_executor_session_tag.py tests/services/brokers/binance/demo_scalping_exec/test_executor_analytics.py tests/services/brokers/binance/demo_scalping_exec/test_executor_realized_pnl.py -v`
+Expected: PASS (신규 2 + 기존 analytics/realized_pnl 회귀 green — 기본 None이라 무변경).
+
+- [ ] **Step 7: 커밋**
+
+```bash
+git add app/services/brokers/binance/demo_scalping_exec/executor.py tests/services/brokers/binance/demo_scalping_exec/test_executor_session_tag.py
+git commit -F - <<'EOF'
+feat: thread session_tag + signal_snapshot through demo scalping executor
+
+execute/execute_monitored가 session_tag·signal_snapshot을 받아
+_finalize_analytics/_record_partial_analytics → analytics.record로 전달
+(record는 이미 인자 보유). 기본 None이라 무회귀. LLM 트레이드 태깅·근거기록 토대.
+
+Co-Authored-By: Paperclip <noreply@paperclip.ing>
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_0115yvcHYpLv3aLeKJ36Bo9w
+EOF
+```
+
+---
+
+### Task 2: `binance_demo_scalping_submit_decision` MCP 도구 + 등록 + 런북
+
+**Files:**
+- Modify: `app/core/config.py` (`binance_demo_scalping_enabled` flag)
+- Create: `app/mcp_server/tooling/binance_demo_scalping_handler.py`
+- Modify: `app/mcp_server/tooling/registry.py` (DEFAULT 프로필 조건부 등록)
+- Modify: `tests/services/brokers/binance/test_audit_no_signed_endpoints.py` (allowlist)
+- Create: `docs/runbooks/binance-demo-scalping-llm-session.md`
+- Test: `tests/mcp_server/test_binance_demo_scalping_submit_decision.py` (생성)
+
+**Interfaces:**
+- Consumes: Task 1의 `execute_monitored(..., session_tag, signal_snapshot)`; `build_manual_intent`(scripts) 동등 로직; `ScalpingRiskLimits`; `BinanceFuturesDemoExecutionClient.from_env`/`DemoReferenceData`/`DemoScalpingMarketData`/`DemoScalpingExecutor`; `AsyncSessionLocal`; `settings.binance_demo_scalping_enabled`.
+- Produces: MCP 도구 `binance_demo_scalping_submit_decision`.
+
+- [ ] **Step 1: 실패 테스트 작성**
+
+`tests/mcp_server/test_binance_demo_scalping_submit_decision.py` 생성:
+
+```python
+from __future__ import annotations
+
+from decimal import Decimal
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+import app.mcp_server.tooling.binance_demo_scalping_handler as mod
+
+
+@pytest.mark.asyncio
+async def test_dry_run_returns_plan_no_order() -> None:
+    result = await mod.binance_demo_scalping_submit_decision(
+        symbol="XRPUSDT", side="BUY", rationale="funding flip", dry_run=True
+    )
+    assert result["status"] == "planned"
+    assert result["dry_run"] is True
+    assert result["symbol"] == "XRPUSDT"
+    assert result["side"] == "BUY"
+    assert result["session_tag"] == "llm"
+    assert "rationale" in result
+
+
+@pytest.mark.asyncio
+async def test_rejects_non_allowlisted_symbol() -> None:
+    result = await mod.binance_demo_scalping_submit_decision(
+        symbol="BTCUSDT", side="BUY", rationale="x", dry_run=True
+    )
+    assert result["status"] == "rejected"
+    assert "symbol" in result["error"].lower()
+
+
+@pytest.mark.asyncio
+async def test_rejects_empty_rationale() -> None:
+    result = await mod.binance_demo_scalping_submit_decision(
+        symbol="XRPUSDT", side="BUY", rationale="  ", dry_run=True
+    )
+    assert result["status"] == "rejected"
+    assert "rationale" in result["error"].lower()
+
+
+@pytest.mark.asyncio
+async def test_confirm_executes_monitored_with_llm_tag() -> None:
+    fake_result = type(
+        "R", (), {
+            "status": "reconciled",
+            "open_client_order_id": "rob307-x",
+            "close_client_order_id": "rob307-y",
+            "exit_reason": "take_profit",
+            "to_evidence_dict": lambda self: {"status": "reconciled"},
+        },
+    )()
+    captured: dict = {}
+
+    async def fake_run(**kwargs):
+        captured.update(kwargs)
+        return fake_result
+
+    with patch.object(mod, "_execute_confirmed_round_trip", AsyncMock(side_effect=fake_run)):
+        result = await mod.binance_demo_scalping_submit_decision(
+            symbol="SOLUSDT", side="SELL", rationale="OI surge fade",
+            dry_run=False, confirm=True,
+        )
+    assert result["status"] == "reconciled"
+    assert captured["session_tag"] == "llm"
+    assert captured["signal_snapshot"]["rationale"] == "OI surge fade"
+    assert captured["signal_snapshot"]["source"] == "llm"
+    assert captured["symbol"] == "SOLUSDT"
+    assert captured["side"] == "SELL"
+
+
+@pytest.mark.asyncio
+async def test_confirm_required_for_real_order() -> None:
+    # dry_run False but confirm False → still a plan, no execution.
+    result = await mod.binance_demo_scalping_submit_decision(
+        symbol="XRPUSDT", side="BUY", rationale="x", dry_run=False, confirm=False
+    )
+    assert result["status"] == "planned"
+    assert result["dry_run"] is True
+```
+
+- [ ] **Step 2: 실패 확인**
+
+Run: `uv run pytest tests/mcp_server/test_binance_demo_scalping_submit_decision.py -v`
+Expected: FAIL — `ModuleNotFoundError: app.mcp_server.tooling.binance_demo_scalping_handler`.
+
+- [ ] **Step 3: config flag 추가**
+
+`app/core/config.py`의 `binance_demo_scalping_review_flow_enabled: bool = False`(Phase 2에서 추가됨) **바로 다음**에:
+
+```python
+    # Phase 3 — gate for the LLM decision-injection MCP tool (default-off).
+    binance_demo_scalping_enabled: bool = False
+```
+
+- [ ] **Step 4: 핸들러 모듈 구현**
+
+`app/mcp_server/tooling/binance_demo_scalping_handler.py` 생성:
+
+```python
+"""Phase 3 — LLM decision-injection MCP tool for Binance Demo scalping.
+
+The out-of-process LLM (an MCP session) reads market data + recent scalping
+reviews, decides, and calls ``binance_demo_scalping_submit_decision`` with its
+decision + rationale. The tool is deterministic: it executes the LLM's decision
+via the existing ``DemoScalpingExecutor.execute_monitored`` (one round-trip),
+tagging the trade ``session_tag="llm"`` and recording the rationale in
+``signal_snapshot``. NO LLM call here — judgment belongs to the MCP caller
+(runtime in-process LLM boundary). Demo-only; dry_run default + confirm gate.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import logging
+from decimal import Decimal
+from typing import Any, Literal
+
+from app.services.brokers.binance.demo_scalping.contract import ScalpingRiskLimits
+from app.services.brokers.binance.demo_scalping.order_intent import OrderIntent
+
+logger = logging.getLogger(__name__)
+
+_ALLOWLIST = frozenset({"XRPUSDT", "DOGEUSDT", "SOLUSDT"})
+
+
+def _build_intent(
+    *, symbol: str, side: str, notional_usdt: Decimal, now: dt.datetime
+) -> OrderIntent:
+    now_ms = int(now.timestamp() * 1000)
+    return OrderIntent(
+        product="usdm_futures",
+        symbol=symbol,
+        side=side,
+        order_type="MARKET",
+        target_notional_usdt=notional_usdt,
+        entry_reference_price=None,
+        tp_price=None,
+        sl_price=None,
+        confidence=Decimal("0"),
+        reason_codes=("llm_decision",),
+        source_candle_close_time_ms=now_ms,
+        evaluated_at_ms=now_ms,
+    )
+
+
+async def _execute_confirmed_round_trip(
+    *,
+    symbol: str,
+    side: str,
+    tp_bps: Decimal,
+    sl_bps: Decimal,
+    notional_usdt: Decimal,
+    session_tag: str,
+    signal_snapshot: dict[str, Any],
+    now: dt.datetime,
+) -> Any:
+    """Construct the demo executor and run one monitored round-trip. Real Demo
+    order — only reached on confirm=True. Mirrors scripts/binance_demo_scalping_execute."""
+    from app.core.db import AsyncSessionLocal
+    from app.services.brokers.binance.demo_scalping.market_data import (
+        DemoScalpingMarketData,
+    )
+    from app.services.brokers.binance.demo_scalping_exec.executor import (
+        DemoScalpingExecutor,
+    )
+    from app.services.brokers.binance.demo_scalping_exec.reference import (
+        DemoReferenceData,
+    )
+    from app.services.brokers.binance.futures_demo.execution_client import (
+        BinanceFuturesDemoExecutionClient,
+    )
+
+    limits = ScalpingRiskLimits()
+    client = BinanceFuturesDemoExecutionClient.from_env()
+    reference = DemoReferenceData()
+    market_data = DemoScalpingMarketData()
+    try:
+        async with AsyncSessionLocal() as session:
+            executor = DemoScalpingExecutor(
+                product="usdm_futures",
+                client=client,
+                session=session,
+                reference=reference,
+                now=now,
+                limits=limits,
+                market_data=market_data,
+            )
+            intent = _build_intent(
+                symbol=symbol, side=side, notional_usdt=notional_usdt, now=now
+            )
+            result = await executor.execute_monitored(
+                intent,
+                confirm=True,
+                tp_bps=tp_bps,
+                sl_bps=sl_bps,
+                session_tag=session_tag,
+                signal_snapshot=signal_snapshot,
+            )
+            await session.commit()
+            return result
+    finally:
+        await reference.aclose()
+        await market_data.aclose()
+        aclose = getattr(client, "aclose", None)
+        if aclose is not None:
+            await aclose()
+
+
+async def binance_demo_scalping_submit_decision(
+    symbol: str,
+    side: Literal["BUY", "SELL"],
+    rationale: str,
+    tp_bps: float = 30.0,
+    sl_bps: float = 20.0,
+    notional_usdt: float = 10.0,
+    dry_run: bool = True,
+    confirm: bool = False,
+) -> dict[str, Any]:
+    """Submit an LLM-decided Binance Demo (USD-M futures) scalping round-trip.
+
+    DEMO ONLY. ``dry_run`` (default) returns the plan with no order. A real Demo
+    order requires ``dry_run=False`` AND ``confirm=True``. The trade is tagged
+    ``session_tag="llm"`` and the rationale is recorded in ``signal_snapshot`` so
+    the daily review can compare LLM vs the rule-based baseline. Symbols limited
+    to XRPUSDT/DOGEUSDT/SOLUSDT; 1x; notional capped at 10 USDT by the executor."""
+    sym = symbol.upper().strip()
+    if sym not in _ALLOWLIST:
+        return {
+            "status": "rejected",
+            "error": f"symbol {sym!r} not allowlisted (allowed: {sorted(_ALLOWLIST)})",
+        }
+    if side not in ("BUY", "SELL"):
+        return {"status": "rejected", "error": f"side must be BUY|SELL, got {side!r}"}
+    if not rationale or not rationale.strip():
+        return {"status": "rejected", "error": "rationale must be a non-empty string"}
+
+    notional = Decimal(str(notional_usdt))
+    signal_snapshot = {
+        "source": "llm",
+        "rationale": rationale.strip(),
+        "requested_side": side,
+        "tp_bps": str(tp_bps),
+        "sl_bps": str(sl_bps),
+    }
+
+    if dry_run or not confirm:
+        return {
+            "status": "planned",
+            "dry_run": True,
+            "symbol": sym,
+            "side": side,
+            "rationale": rationale.strip(),
+            "session_tag": "llm",
+            "notional_usdt": str(notional),
+            "tp_bps": str(tp_bps),
+            "sl_bps": str(sl_bps),
+            "note": "set dry_run=false AND confirm=true to place the real Demo order",
+        }
+
+    now = dt.datetime.now(dt.UTC)
+    try:
+        result = await _execute_confirmed_round_trip(
+            symbol=sym,
+            side=side,
+            tp_bps=Decimal(str(tp_bps)),
+            sl_bps=Decimal(str(sl_bps)),
+            notional_usdt=notional,
+            session_tag="llm",
+            signal_snapshot=signal_snapshot,
+            now=now,
+        )
+    except Exception as exc:  # noqa: BLE001 — surface broker/setup errors as data
+        logger.exception("binance demo scalping submit_decision failed")
+        return {"status": "error", "error": f"{type(exc).__name__}: {exc}"}
+
+    evidence = result.to_evidence_dict()
+    return {
+        "status": result.status,
+        "dry_run": False,
+        "symbol": sym,
+        "side": side,
+        "rationale": rationale.strip(),
+        "session_tag": "llm",
+        "open_client_order_id": result.open_client_order_id,
+        "close_client_order_id": result.close_client_order_id,
+        "exit_reason": result.exit_reason,
+        "evidence": evidence,
+    }
+
+
+def register_binance_demo_scalping_tools(mcp: Any) -> None:
+    mcp.tool(
+        name="binance_demo_scalping_submit_decision",
+        description=(
+            "Submit an LLM-decided Binance Demo (USD-M futures) scalping "
+            "round-trip. DEMO ONLY, dry_run default; real order needs "
+            "dry_run=false + confirm=true. Tags the trade session_tag='llm' and "
+            "records the rationale for LLM-vs-baseline comparison. Symbols: "
+            "XRPUSDT/DOGEUSDT/SOLUSDT; 1x; <=10 USDT."
+        ),
+    )(binance_demo_scalping_submit_decision)
+```
+
+- [ ] **Step 5: registry.py 조건부 등록**
+
+`app/mcp_server/tooling/registry.py`의 `register_all_tools` 내 DEFAULT 프로필 블록에서 `if settings.kiwoom_mock_enabled:` 등록 줄 **다음에** 추가:
+
+```python
+        if settings.binance_demo_scalping_enabled:
+            from app.mcp_server.tooling.binance_demo_scalping_handler import (
+                register_binance_demo_scalping_tools,
+            )
+
+            register_binance_demo_scalping_tools(mcp)
+```
+
+(import을 함수 내부 lazy로 두어 게이트 off 시 모듈 로드 비용 0.)
+
+- [ ] **Step 6: ROB-285 audit allowlist 등재**
+
+`tests/services/brokers/binance/test_audit_no_signed_endpoints.py`의 ALLOWED_LEGACY_FILES에서 Phase 2 블록(`"app/core/config.py",` 등) **다음에** 추가:
+
+```python
+        # Phase 3 — LLM decision-injection MCP tool. Deterministic executor of an
+        # LLM-submitted decision (no signed HTTP itself; reuses futures_demo via
+        # execute_monitored). References "Binance" via imports + tool name only.
+        "app/mcp_server/tooling/binance_demo_scalping_handler.py",
+```
+
+- [ ] **Step 7: 런북 작성**
+
+`docs/runbooks/binance-demo-scalping-llm-session.md` 생성:
+
+```markdown
+# Binance Demo 스캘핑 — 매일 LLM 결정 세션 (Phase 3, 반자동)
+
+매일 사람이 MCP 세션을 트리거해 LLM이 데모 스캘핑 결정을 주입한다.
+
+## 전제
+- `BINANCE_DEMO_SCALPING_ENABLED=true` (MCP 도구 등록 게이트) + futures demo 자격증명.
+- 데모 전용. 실 주문은 `confirm=true`에서만.
+
+## 절차 (MCP 세션)
+1. **시장 읽기** — `get_crypto_*`(funding/OI/캔들) 및 최근 스캘핑 리뷰/벤치마크(`/invest/scalping`)와
+   과거 결정·결과(이전 `signal_snapshot`/리뷰)를 검토한다.
+2. **결정** — symbol(XRPUSDT/DOGEUSDT/SOLUSDT 중)·side·근거(rationale)를 정한다.
+3. **dry-run 확인** — `binance_demo_scalping_submit_decision(symbol, side, rationale, dry_run=true)`로 계획 확인.
+4. **주입** — `...(dry_run=false, confirm=true)`로 실 데모 라운드트립 실행. 결과(status/realized_pnl)를 기록.
+5. **회고** — 다음 세션에서 직전 결정의 결과(net vs buy&hold, LLM vs 규칙 baseline)를 보고 전략을 조정한다.
+
+## 안전
+- 1x · notional<=10 USDT · 손실예산 게이트(Phase 1) · demo-fapi only — executor가 강제.
+- 같은 날 결과는 `session_tag="llm"`로 분리 집계(규칙 baseline과 비교; surfacing은 D-PR2).
+```
+
+- [ ] **Step 8: 통과 + audit + 회귀**
+
+Run:
+```bash
+uv run pytest tests/mcp_server/test_binance_demo_scalping_submit_decision.py tests/services/brokers/binance/test_audit_no_signed_endpoints.py -v
+```
+Expected: PASS (도구 5 + audit). audit가 registry.py를 새로 플래그하면 그 파일도 ALLOWED_LEGACY_FILES에 동일 형식으로 등재 후 재실행.
+
+- [ ] **Step 9: 커밋**
+
+```bash
+git add app/core/config.py app/mcp_server/tooling/binance_demo_scalping_handler.py app/mcp_server/tooling/registry.py tests/services/brokers/binance/test_audit_no_signed_endpoints.py tests/mcp_server/test_binance_demo_scalping_submit_decision.py docs/runbooks/binance-demo-scalping-llm-session.md
+git commit -F - <<'EOF'
+feat: binance_demo_scalping_submit_decision MCP tool (Phase 3 D-PR1)
+
+out-of-process LLM의 결정을 데모 스캘핑에 주입하는 결정론적 MCP 도구.
+execute_monitored 재사용(session_tag="llm" + signal_snapshot 근거기록),
+dry_run 기본+confirm 게이트, allowlist/데모 안전경계 상속. settings 게이트로
+DEFAULT 프로필 조건부 등록. ROB-285 allowlist 등재. 운영 런북 포함.
+
+Co-Authored-By: Paperclip <noreply@paperclip.ing>
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_0115yvcHYpLv3aLeKJ36Bo9w
+EOF
+```
+
+---
+
+### 최종 검증
+
+- [ ] **Step: binance 패키지 전체 + MCP + lint/type**
+
+Run:
+```bash
+cd /Users/mgh3326/work/auto_trader.phase3-llm-decision
+uv run pytest tests/services/brokers/binance/ tests/mcp_server/test_binance_demo_scalping_submit_decision.py -q -p no:cacheprovider
+uv run ruff format app/services/brokers/binance/demo_scalping_exec/executor.py app/mcp_server/tooling/binance_demo_scalping_handler.py app/mcp_server/tooling/registry.py app/core/config.py tests/services/brokers/binance/demo_scalping_exec/test_executor_session_tag.py tests/mcp_server/test_binance_demo_scalping_submit_decision.py
+uv run ruff check app/mcp_server/tooling/binance_demo_scalping_handler.py app/services/brokers/binance/demo_scalping_exec/executor.py app/mcp_server/tooling/registry.py app/core/config.py
+uv run ty check app/
+```
+Expected: 신규 테스트 + binance 패키지(audit 포함) 회귀 PASS, ruff/ty clean.
+
+---
+
+## Self-Review (spec 대비)
+
+- **§2.1-1 session_tag 배선** → Task 1(+signal_snapshot 동반). ✓
+- **§2.1-2 결정 주입 MCP 도구** → Task 2. ✓ (dry_run/confirm/allowlist/게이트/실행)
+- **§2.1-3 런북** → Task 2 Step 7. ✓
+- **§3.2 기록처** → 스펙의 strategy_events를 `signal_snapshot`으로 정제(상단 노트; 추출로 strategy_events 부적합 확인). ✓
+- **§5 경계** → LLM 호출 없음(결정론적), 데모 전용(from_env/executor 재사용), 이중게이트, ROB-285 allowlist, 무회귀(기본 None). ✓
+- **§6 에러** → 게이트/allowlist/빈 rationale 거부, dry_run 계획만, execute 예외 → error dict, 거래는 executor가 anomaly 처리. ✓
+- **§7 테스트** → session_tag/snapshot 기록+무회귀(Task1); dry_run/confirm/게이트/allowlist/기록(Task2). ✓
+- **§8 위험** → measurability(session_tag 분리), dry_run 기본, ROB-285. ✓
+- **범위밖** → D-PR2(리뷰 비교 surfacing)·Hermes 자율·자동 피드백 미포함. ✓
+- 마이그레이션 없음(session_tag/signal_snapshot 기존 컬럼). ✓

--- a/docs/superpowers/specs/2026-06-22-binance-demo-scalping-llm-decision-design.md
+++ b/docs/superpowers/specs/2026-06-22-binance-demo-scalping-llm-decision-design.md
@@ -1,0 +1,94 @@
+# Binance Demo 스캘핑 LLM 결정 주입 (Phase 3 / Design)
+
+- **작성일**: 2026-06-22
+- **상태**: 승인됨 (브레인스토밍 → 스펙)
+- **브랜치**: `feature/binance-demo-scalping-llm-decision`
+- **선행**: Phase 1(측정 신뢰화, PR #1342) + Phase 2(일별 리뷰+벤치마크 자동화, PR #1345) merged·라이브
+
+## 1. 배경 / 동기
+
+매일 자동 데모 스캘핑 루프는 **규칙기반 시그널**(SMA 브레이크아웃)로 돌고 있고, Phase 1/2로 거래마다 net PnL + 일별 buy&hold 벤치마크가 측정된다. 측정 결과: 규칙기반은 예상대로 **수수료만 내는 baseline**(net ≈ -10bps/거래). 사용자 원래 비전의 핵심 = **"LLM이 시장을 보고 전략을 결정 → 투자 → 회고"**.
+
+런타임은 in-process LLM을 못 부른다(AST guard, LLM 판단은 out-of-process). 따라서 Phase 3 = **out-of-process LLM(MCP 세션)이 내린 결정을 데모 스캘핑에 주입하는 결정론적 surface(MCP 도구)**. LLM은 도구의 *호출자*이고, 도구 자체엔 LLM 호출이 없다(경계 준수). 첫 슬라이스는 **반자동**: 사람이 매일 MCP 세션을 트리거 → LLM이 읽고 결정 → 도구로 주입.
+
+## 2. 범위
+
+### 2.1 In scope (D-PR1)
+1. **session_tag 배선** — `DemoScalpingExecutor.execute`/`execute_monitored`가 `session_tag`를 받아 `_finalize_analytics`/`_record_partial_analytics` → `analytics.record(session_tag=...)`로 전달. (Phase 1에서 미룬 배선; LLM 트레이드를 `"llm"`으로 태깅해 규칙 baseline과 분리 측정하기 위해 필요.)
+2. **결정 주입 MCP 도구** `binance_demo_scalping_submit_decision` — LLM이 결정(symbol/side/rationale[+선택])을 제출하면 `execute_monitored(session_tag="llm")` 1 라운드트립 실행 + 결정·근거를 `strategy_events`에 기록. dry_run 기본 + confirm 이중게이트.
+3. **일별 LLM 세션 런북** `docs/runbooks/binance-demo-scalping-llm-session.md` — 매일 MCP 세션 절차.
+
+### 2.2 Out of scope
+- **D-PR2 (후속)**: Phase 2 flow를 session_tag별("", "llm") 반복 + 각 buy&hold 벤치마크 → `/invest/scalping`에 LLM vs 규칙 baseline 리뷰행 나란히 surfacing.
+- LLM 자율 실행(Hermes) — 첫 슬라이스는 반자동(사람 트리거 MCP 세션).
+- 회고 → 전략 자동 수정 루프(코드가 자동으로 전략을 바꾸지 않음; 사람/세션이 회고를 읽고 다음 결정에 반영).
+- 신규 시장-읽기 도구 — LLM은 기존 `get_crypto_*` + 스캘핑 리뷰 read + `strategy_events` list로 컨텍스트 확보.
+
+## 3. 컴포넌트
+
+### 3.1 session_tag 배선 (executor → analytics)
+- `DemoScalpingExecutor.execute(*, ..., session_tag: str | None = None)` 및 `execute_monitored(*, ..., session_tag: str | None = None)` 추가.
+- `_finalize_analytics`/`_record_partial_analytics`가 `session_tag`를 `analytics.record(session_tag=...)`로 전달(`ScalpTradeAnalyticsService.record`는 이미 `session_tag` 인자 보유 — Phase 1 미배선 부분).
+- 기본값 `None` → 기존 호출자(스케줄러 규칙기반)는 `session_tag=None`(=NULL, 규칙 baseline) 유지(무회귀).
+
+### 3.2 MCP 도구 `binance_demo_scalping_submit_decision`
+- 위치: `app/mcp_server/tooling/` (신규 모듈), 기존 broker order MCP 도구의 dry_run+confirm 패턴 준수.
+- **입력**: `symbol`(allowlist XRP/DOGE/SOL only), `side`(BUY|SELL), `rationale`(비어있지 않은 str — LLM 근거, 필수), 선택 `tp_bps`/`sl_bps`(기본=executor 기본 30/20), `notional_usdt`(기본=risk cap 10), `product`(기본 `usdm_futures`), `dry_run`(기본 True), `confirm`(기본 False).
+- **동작**:
+  1. 게이트: `BINANCE_DEMO_SCALPING_ENABLED` + futures demo enabled. 미설정 → 명확한 disabled 응답(주문 0).
+  2. allowlist/side 검증(네트워크 전).
+  3. `build_order_intent`로 OrderIntent 구성(notional cap 핀).
+  4. **dry_run(=not confirm)**: 계획(intent 요약)만 반환, 주문/기록 0.
+  5. **confirm=True**: `execute_monitored(intent, confirm=True, session_tag="llm", ...)` 1 라운드트립(open→bounded TP/SL→reduceOnly close→reconcile) → 결정+근거+결과(status/realized_pnl/cids)를 `strategy_events`에 기록 → 결과 dict 반환.
+- **반환**: `{status, dry_run, symbol, side, rationale, session_tag, ...실행결과 or 계획}`.
+
+### 3.3 런북
+매일 MCP 세션 절차: LLM이 (a) `get_crypto_*`(funding/OI/캔들) + (b) 최근 스캘핑 리뷰/벤치마크 + (c) 과거 `strategy_events` 결정·결과를 읽고 → 결정 + 근거 → `binance_demo_scalping_submit_decision(confirm=True)`. 안전: dry_run으로 먼저 확인 권장.
+
+## 4. 데이터 흐름
+
+```
+[사람이 매일 MCP 세션 트리거]
+ LLM: get_crypto_* + 스캘핑 리뷰/벤치마크 + strategy_events 읽기 → 결정(symbol/side/근거)
+   → binance_demo_scalping_submit_decision(confirm=True)
+        → execute_monitored(session_tag="llm")   # 기존 안전경계: demo-fapi/1x/cap/Phase1 손실게이트
+        → scalp_trade_analytics 행(session_tag="llm") + 손실게이트 realized_pnl
+        → strategy_events 기록(결정 + 근거 + realized_pnl)
+ (D-PR2) 일별 리뷰가 session_tag="llm" 별도 행 → /invest/scalping에서 규칙 baseline과 비교
+```
+
+## 5. 경계 / 안전
+- **LLM 호출 없음**: 도구는 LLM이 제출한 결정을 결정론적으로 실행만. LLM 판단은 MCP 호출자(세션) 소유 — 런타임 in-process LLM 경계 준수.
+- **데모 전용**: 기존 `BinanceFuturesDemoExecutionClient` + `DemoScalpingExecutor` 재사용 → host allowlist(demo-fapi only)/1x/심볼 allowlist/notional cap/Phase1 손실게이트 전부 상속. 새 주문 mutation 경로 없음.
+- **이중 게이트**: dry_run 기본 + `confirm=True` 필수(실 데모 주문). `BINANCE_DEMO_SCALPING_ENABLED` default-off.
+- **ROB-285 audit**: 새 binance-참조 파일(MCP 도구 모듈)을 `tests/services/brokers/binance/test_audit_no_signed_endpoints.py` ALLOWED_LEGACY_FILES에 등재(Phase 2 교훈).
+- **무회귀**: `session_tag` 기본 None → 스케줄러 규칙기반 트레이드는 NULL 태그 유지.
+
+## 6. 에러 처리
+- 게이트 off / 자격증명 없음 → disabled/명확 에러(주문 0).
+- allowlist 외 symbol / 잘못된 side / 빈 rationale → 검증 거부(네트워크 전).
+- dry_run → 계획만(주문·기록 0).
+- execute_monitored가 blocked(리스크 게이트, 예: 손실예산/cap) → 그 상태를 반환(주문 안 나감); anomaly → executor가 이미 처리(가짜성공 없음).
+- strategy_events 기록 실패는 best-effort(거래는 이미 reconcile됨; 기록 실패를 로깅하되 거래 결과는 반환).
+
+## 7. 테스트
+- **session_tag 배선**: `execute_monitored(session_tag="llm")` → `scalp_trade_analytics` 행의 `session_tag == "llm"`; 미지정 시 NULL(무회귀). (fake client + db_session)
+- **MCP 도구**:
+  - dry_run(기본) → 주문 0, 계획 반환, strategy_events 0.
+  - confirm → execute_monitored 호출(fake executor/client) + strategy_events 기록 + session_tag="llm".
+  - 게이트 off → disabled(주문 0).
+  - allowlist 외 symbol / 빈 rationale → 거부.
+- 기존 executor/analytics 회귀(session_tag 추가가 기존 동작 무변경).
+
+## 8. 위험 / 함정
+- **measurability**: LLM 트레이드와 스케줄러 규칙 트레이드가 같은 날 섞이면 측정 혼란 → session_tag="llm"로 분리(리뷰 grain이 session_tag 포함). 비교 surfacing은 D-PR2.
+- **dry_run 우회 금지**: confirm 없이는 절대 실주문 안 나가게(도구 기본 dry_run).
+- **백테스트 교훈**: LLM도 baseline(-10bps 수수료)을 net으로 못 이기면 의미 없음 → D-PR2의 LLM vs 규칙 비교가 판정 도구. "며칠 좋은 결과 = single-fold 우연" 경계.
+- **ROB-285 audit**: 새 파일 allowlist 등재 누락 시 CI fail(Phase 2에서 겪음).
+
+## 9. 산출물 / 완료 기준
+- executor `session_tag` 배선 + `analytics` 기록(태깅 테스트 green, 무회귀).
+- `binance_demo_scalping_submit_decision` MCP 도구(dry_run/confirm/게이트/allowlist/기록 테스트 green).
+- 런북.
+- ROB-285 audit allowlist 갱신. 마이그레이션 없음.
+- D-PR2(리뷰 비교 surfacing)는 후속.

--- a/tests/mcp_server/test_binance_demo_scalping_submit_decision.py
+++ b/tests/mcp_server/test_binance_demo_scalping_submit_decision.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from decimal import Decimal
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+import app.mcp_server.tooling.binance_demo_scalping_handler as mod
+
+
+@pytest.mark.asyncio
+async def test_dry_run_returns_plan_no_order() -> None:
+    result = await mod.binance_demo_scalping_submit_decision(
+        symbol="XRPUSDT", side="BUY", rationale="funding flip", dry_run=True
+    )
+    assert result["status"] == "planned"
+    assert result["dry_run"] is True
+    assert result["symbol"] == "XRPUSDT"
+    assert result["side"] == "BUY"
+    assert result["session_tag"] == "llm"
+    assert "rationale" in result
+
+
+@pytest.mark.asyncio
+async def test_rejects_non_allowlisted_symbol() -> None:
+    result = await mod.binance_demo_scalping_submit_decision(
+        symbol="BTCUSDT", side="BUY", rationale="x", dry_run=True
+    )
+    assert result["status"] == "rejected"
+    assert "symbol" in result["error"].lower()
+
+
+@pytest.mark.asyncio
+async def test_rejects_empty_rationale() -> None:
+    result = await mod.binance_demo_scalping_submit_decision(
+        symbol="XRPUSDT", side="BUY", rationale="  ", dry_run=True
+    )
+    assert result["status"] == "rejected"
+    assert "rationale" in result["error"].lower()
+
+
+@pytest.mark.asyncio
+async def test_confirm_executes_monitored_with_llm_tag() -> None:
+    fake_result = type(
+        "R",
+        (),
+        {
+            "status": "reconciled",
+            "open_client_order_id": "rob307-x",
+            "close_client_order_id": "rob307-y",
+            "exit_reason": "take_profit",
+            "to_evidence_dict": lambda self: {"status": "reconciled"},
+        },
+    )()
+    captured: dict = {}
+
+    async def fake_run(**kwargs):
+        captured.update(kwargs)
+        return fake_result
+
+    with patch.object(
+        mod, "_execute_confirmed_round_trip", AsyncMock(side_effect=fake_run)
+    ):
+        result = await mod.binance_demo_scalping_submit_decision(
+            symbol="SOLUSDT",
+            side="SELL",
+            rationale="OI surge fade",
+            dry_run=False,
+            confirm=True,
+        )
+    assert result["status"] == "reconciled"
+    assert captured["session_tag"] == "llm"
+    assert captured["signal_snapshot"]["rationale"] == "OI surge fade"
+    assert captured["signal_snapshot"]["source"] == "llm"
+    assert captured["symbol"] == "SOLUSDT"
+    assert captured["side"] == "SELL"
+
+
+@pytest.mark.asyncio
+async def test_confirm_required_for_real_order() -> None:
+    # dry_run False but confirm False → still a plan, no execution.
+    result = await mod.binance_demo_scalping_submit_decision(
+        symbol="XRPUSDT", side="BUY", rationale="x", dry_run=False, confirm=False
+    )
+    assert result["status"] == "planned"
+    assert result["dry_run"] is True

--- a/tests/mcp_server/test_binance_demo_scalping_submit_decision.py
+++ b/tests/mcp_server/test_binance_demo_scalping_submit_decision.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from decimal import Decimal
 from unittest.mock import AsyncMock, patch
 
 import pytest

--- a/tests/mcp_server/test_binance_demo_scalping_submit_decision.py
+++ b/tests/mcp_server/test_binance_demo_scalping_submit_decision.py
@@ -69,6 +69,7 @@ async def test_confirm_executes_monitored_with_llm_tag() -> None:
             confirm=True,
         )
     assert result["status"] == "reconciled"
+    assert result["dry_run"] is False
     assert captured["session_tag"] == "llm"
     assert captured["signal_snapshot"]["rationale"] == "OI surge fade"
     assert captured["signal_snapshot"]["source"] == "llm"

--- a/tests/services/brokers/binance/demo_scalping_exec/test_executor_session_tag.py
+++ b/tests/services/brokers/binance/demo_scalping_exec/test_executor_session_tag.py
@@ -181,3 +181,25 @@ async def test_session_tag_defaults_none_no_regression(db_session) -> None:
     assert row is not None
     assert row.session_tag is None
     assert row.signal_snapshot is None
+
+
+@pytest.mark.asyncio
+async def test_execute_one_shot_records_session_tag(db_session) -> None:
+    client = _FakeFutures(open_px="100", close_px="100.20")
+    ex = DemoScalpingExecutor(
+        product="usdm_futures", client=client, session=db_session,
+        reference=_Ref(), now=_NOW, limits=_limits("ONESHOTTAGUSDT"),
+        market_data=None, poll_delay_seconds=0.0,
+    )
+    snap = {"source": "llm", "rationale": "immediate one-shot"}
+    result = await ex.execute(
+        _intent("ONESHOTTAGUSDT"), confirm=True,
+        session_tag="llm", signal_snapshot=snap,
+    )
+    assert result.status == "reconciled"
+    row = await ScalpTradeAnalyticsService(db_session).get_by_open_client_order_id(
+        result.open_client_order_id
+    )
+    assert row is not None
+    assert row.session_tag == "llm"
+    assert row.signal_snapshot == snap

--- a/tests/services/brokers/binance/demo_scalping_exec/test_executor_session_tag.py
+++ b/tests/services/brokers/binance/demo_scalping_exec/test_executor_session_tag.py
@@ -1,0 +1,183 @@
+"""Task 1 — session_tag + signal_snapshot threaded through the executor.
+
+Verifies that execute_monitored forwards session_tag/signal_snapshot to the
+analytics row, and that callers omitting them get NULL (no regression).
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from decimal import Decimal
+
+import pytest
+
+from app.services.brokers.binance.demo_scalping.contract import (
+    ScalpingRiskLimits,
+)
+from app.services.brokers.binance.demo_scalping.market_data import BookTicker
+from app.services.brokers.binance.demo_scalping.order_intent import OrderIntent
+from app.services.brokers.binance.demo_scalping_exec.analytics import (
+    ScalpTradeAnalyticsService,
+)
+from app.services.brokers.binance.demo_scalping_exec.executor import (
+    DemoScalpingExecutor,
+)
+from app.services.brokers.binance.demo_scalping_exec.reference import SymbolReference
+
+_NOW = dt.datetime(2026, 5, 25, 12, 0, 0, tzinfo=dt.UTC)
+_REF = SymbolReference(
+    price=Decimal("100"),
+    step_size=Decimal("0.1"),
+    min_notional=Decimal("5"),
+    tick_size=Decimal("0.01"),
+)
+
+
+def _limits(symbol: str) -> ScalpingRiskLimits:
+    return ScalpingRiskLimits(
+        allowlist=frozenset({symbol}),
+        excluded=frozenset(),
+        global_open_lifecycle_cap=10_000,
+        daily_order_count_cap=10_000,
+        daily_loss_budget_usdt=Decimal("1000000"),
+    )
+
+
+def _intent(symbol: str) -> OrderIntent:
+    return OrderIntent(
+        product="usdm_futures",
+        symbol=symbol,
+        side="BUY",
+        order_type="MARKET",
+        target_notional_usdt=Decimal("10"),
+        entry_reference_price=Decimal("100"),
+        tp_price=None,
+        sl_price=None,
+        confidence=Decimal("0.5"),
+        reason_codes=("enter_long_breakout",),
+        source_candle_close_time_ms=1,
+        evaluated_at_ms=2,
+    )
+
+
+class _Ref:
+    async def fetch(self, product, symbol):
+        return _REF
+
+    async def aclose(self):
+        return None
+
+
+class _MD:
+    def __init__(self, prices):
+        self._p = [Decimal(str(x)) for x in prices]
+        self.i = 0
+
+    async def fetch_book_ticker(self, product, symbol):
+        p = self._p[min(self.i, len(self._p) - 1)]
+        self.i += 1
+        return BookTicker(bid=p, ask=p)
+
+
+class _Sub:
+    def __init__(self, status, coid, avg, qty=Decimal("0.1")):
+        self.status = status
+        self.client_order_id = coid
+        self.broker_order_id = "b1"
+        self.avg_price = avg
+        self.executed_qty = qty
+
+
+class _OO:
+    def __init__(self, orders):
+        self.orders = orders
+
+
+class _Pos:
+    def __init__(self, amt):
+        self.position_amt = amt
+        self.is_flat = amt == 0
+
+
+class _FakeFutures:
+    """Open fills at ``open_px``; reduceOnly close fills at ``close_px``."""
+
+    def __init__(self, open_px, close_px):
+        self.open_px = Decimal(str(open_px))
+        self.close_px = Decimal(str(close_px))
+        self._amt = Decimal("0")
+
+    async def get_position_mode(self):
+        return type("M", (), {"is_hedge_mode": False})()
+
+    async def set_leverage(self, *, symbol, leverage):
+        return type("L", (), {"leverage": 1})()
+
+    async def submit_order(
+        self,
+        *,
+        symbol,
+        side,
+        order_type,
+        qty,
+        client_order_id=None,
+        price=None,
+        time_in_force=None,
+        reduce_only=False,
+        confirm=False,
+    ):
+        if reduce_only:
+            self._amt = Decimal("0")
+            return _Sub("FILLED", client_order_id, self.close_px, qty)
+        self._amt = qty if side == "BUY" else -qty
+        return _Sub("FILLED", client_order_id, self.open_px, qty)
+
+    async def get_order(self, *, symbol, client_order_id):
+        return _Sub("FILLED", client_order_id, self.open_px)
+
+    async def get_position(self, *, symbol):
+        return _Pos(self._amt)
+
+    async def get_open_orders(self, *, symbol):
+        return _OO([])
+
+
+@pytest.mark.asyncio
+async def test_session_tag_and_signal_snapshot_recorded(db_session) -> None:
+    client = _FakeFutures(open_px="100", close_px="100.40")
+    md = _MD([100.0, 100.4])
+    ex = DemoScalpingExecutor(
+        product="usdm_futures", client=client, session=db_session,
+        reference=_Ref(), now=_NOW, limits=_limits("LLMTAGUSDT"),
+        market_data=md, poll_delay_seconds=0.0,
+    )
+    snap = {"source": "llm", "rationale": "funding flip + oversold"}
+    result = await ex.execute_monitored(
+        _intent("LLMTAGUSDT"), confirm=True, max_poll_count=5,
+        session_tag="llm", signal_snapshot=snap,
+    )
+    assert result.status == "reconciled"
+    row = await ScalpTradeAnalyticsService(db_session).get_by_open_client_order_id(
+        result.open_client_order_id
+    )
+    assert row is not None
+    assert row.session_tag == "llm"
+    assert row.signal_snapshot == snap
+
+
+@pytest.mark.asyncio
+async def test_session_tag_defaults_none_no_regression(db_session) -> None:
+    client = _FakeFutures(open_px="100", close_px="100.40")
+    md = _MD([100.0, 100.4])
+    ex = DemoScalpingExecutor(
+        product="usdm_futures", client=client, session=db_session,
+        reference=_Ref(), now=_NOW, limits=_limits("NOTAGUSDT"),
+        market_data=md, poll_delay_seconds=0.0,
+    )
+    result = await ex.execute_monitored(_intent("NOTAGUSDT"), confirm=True, max_poll_count=5)
+    row = await ScalpTradeAnalyticsService(db_session).get_by_open_client_order_id(
+        result.open_client_order_id
+    )
+    assert row is not None
+    assert row.session_tag is None
+    assert row.signal_snapshot is None

--- a/tests/services/brokers/binance/demo_scalping_exec/test_executor_session_tag.py
+++ b/tests/services/brokers/binance/demo_scalping_exec/test_executor_session_tag.py
@@ -147,14 +147,22 @@ async def test_session_tag_and_signal_snapshot_recorded(db_session) -> None:
     client = _FakeFutures(open_px="100", close_px="100.40")
     md = _MD([100.0, 100.4])
     ex = DemoScalpingExecutor(
-        product="usdm_futures", client=client, session=db_session,
-        reference=_Ref(), now=_NOW, limits=_limits("LLMTAGUSDT"),
-        market_data=md, poll_delay_seconds=0.0,
+        product="usdm_futures",
+        client=client,
+        session=db_session,
+        reference=_Ref(),
+        now=_NOW,
+        limits=_limits("LLMTAGUSDT"),
+        market_data=md,
+        poll_delay_seconds=0.0,
     )
     snap = {"source": "llm", "rationale": "funding flip + oversold"}
     result = await ex.execute_monitored(
-        _intent("LLMTAGUSDT"), confirm=True, max_poll_count=5,
-        session_tag="llm", signal_snapshot=snap,
+        _intent("LLMTAGUSDT"),
+        confirm=True,
+        max_poll_count=5,
+        session_tag="llm",
+        signal_snapshot=snap,
     )
     assert result.status == "reconciled"
     row = await ScalpTradeAnalyticsService(db_session).get_by_open_client_order_id(
@@ -170,11 +178,18 @@ async def test_session_tag_defaults_none_no_regression(db_session) -> None:
     client = _FakeFutures(open_px="100", close_px="100.40")
     md = _MD([100.0, 100.4])
     ex = DemoScalpingExecutor(
-        product="usdm_futures", client=client, session=db_session,
-        reference=_Ref(), now=_NOW, limits=_limits("NOTAGUSDT"),
-        market_data=md, poll_delay_seconds=0.0,
+        product="usdm_futures",
+        client=client,
+        session=db_session,
+        reference=_Ref(),
+        now=_NOW,
+        limits=_limits("NOTAGUSDT"),
+        market_data=md,
+        poll_delay_seconds=0.0,
     )
-    result = await ex.execute_monitored(_intent("NOTAGUSDT"), confirm=True, max_poll_count=5)
+    result = await ex.execute_monitored(
+        _intent("NOTAGUSDT"), confirm=True, max_poll_count=5
+    )
     row = await ScalpTradeAnalyticsService(db_session).get_by_open_client_order_id(
         result.open_client_order_id
     )
@@ -187,14 +202,21 @@ async def test_session_tag_defaults_none_no_regression(db_session) -> None:
 async def test_execute_one_shot_records_session_tag(db_session) -> None:
     client = _FakeFutures(open_px="100", close_px="100.20")
     ex = DemoScalpingExecutor(
-        product="usdm_futures", client=client, session=db_session,
-        reference=_Ref(), now=_NOW, limits=_limits("ONESHOTTAGUSDT"),
-        market_data=None, poll_delay_seconds=0.0,
+        product="usdm_futures",
+        client=client,
+        session=db_session,
+        reference=_Ref(),
+        now=_NOW,
+        limits=_limits("ONESHOTTAGUSDT"),
+        market_data=None,
+        poll_delay_seconds=0.0,
     )
     snap = {"source": "llm", "rationale": "immediate one-shot"}
     result = await ex.execute(
-        _intent("ONESHOTTAGUSDT"), confirm=True,
-        session_tag="llm", signal_snapshot=snap,
+        _intent("ONESHOTTAGUSDT"),
+        confirm=True,
+        session_tag="llm",
+        signal_snapshot=snap,
     )
     assert result.status == "reconciled"
     row = await ScalpTradeAnalyticsService(db_session).get_by_open_client_order_id(

--- a/tests/services/brokers/binance/test_audit_no_signed_endpoints.py
+++ b/tests/services/brokers/binance/test_audit_no_signed_endpoints.py
@@ -103,6 +103,14 @@ ALLOWED_LEGACY_FILES: frozenset[str] = frozenset(
         "app/jobs/binance_demo_scalping_review.py",
         "app/flows/binance_demo_scalping_review_flow.py",
         "app/core/config.py",
+        # Phase 3 — LLM decision-injection MCP tool. Deterministic executor of an
+        # LLM-submitted decision (no signed HTTP itself; reuses futures_demo via
+        # execute_monitored). References "Binance" via imports + tool name only.
+        "app/mcp_server/tooling/binance_demo_scalping_handler.py",
+        # Phase 3 — registry.py conditionally imports the Phase 3 MCP handler
+        # under settings.binance_demo_scalping_enabled; references "Binance" only
+        # via the import path + settings flag name (no HTTP/WS surface).
+        "app/mcp_server/tooling/registry.py",
         # ROB-323 / ROB-325 — the operator Naver remote-debug audit's Chrome
         # CDP host allowlist. Contains NO Binance HTTP/WS/signed surface; it is
         # a strict 127.0.0.1:9222 allowlist and references "binance" only in a


### PR DESCRIPTION
## 목적

매일 자동 데모 스캘핑 루프는 규칙기반 시그널(net ≈ -10bps/거래 = 수수료 baseline)로 돈다. 사용자 비전의 핵심 = **LLM이 시장을 보고 결정 → 데모 매매 → 회고**. 런타임은 in-process LLM을 못 부르므로(경계), **out-of-process LLM(MCP 세션)이 내린 결정을 데모 스캘핑에 주입하는 결정론적 MCP 도구**를 추가한다(반자동: 사람이 매일 세션 트리거).

- spec: `docs/superpowers/specs/2026-06-22-binance-demo-scalping-llm-decision-design.md`
- plan: `docs/superpowers/plans/2026-06-22-binance-demo-scalping-llm-decision.md`

## 변경 (D-PR1)

- **executor `session_tag`+`signal_snapshot` 배선** — `execute`/`execute_monitored` → `_finalize_analytics`/`_record_partial_analytics` → `analytics.record`(인자 이미 보유, Phase 1 미배선). 기본 None → 무회귀.
- **MCP 도구 `binance_demo_scalping_submit_decision`** — LLM이 `(symbol, side, rationale[, tp_bps, sl_bps, notional])`를 제출 → `execute_monitored(session_tag="llm", signal_snapshot={source:llm, rationale,...})` 1 라운드트립. dry_run 기본 True + confirm 필수. allowlist(XRP/DOGE/SOL). `settings.binance_demo_scalping_enabled`(default False) 게이트로 DEFAULT 프로필 조건부 등록.
- **런북** `docs/runbooks/binance-demo-scalping-llm-session.md` — 매일 MCP 세션 절차.

## 안전 / 경계

- **LLM 호출 없음**: 도구는 LLM이 제출한 결정을 결정론적으로 실행만(런타임 경계 준수). 주문/브로커 mutation 모듈은 **confirm 경로 lazy import**로만.
- **데모 전용 안전경계 상속**: `from_env` + `execute_monitored` 재사용 → demo-fapi only / 1x / allowlist / notional cap 10 / Phase1 손실게이트. 새 mutation 경로 없음.
- **이중 게이트**: dry_run 기본 + confirm 필수. default-off 등록 게이트.
- **ROB-285 audit**: 새 핸들러 + registry.py를 ALLOWED_LEGACY_FILES 등재.
- 마이그레이션 없음(session_tag/signal_snapshot은 ROB-313 기존 컬럼).

## 측정 (LLM vs baseline)

LLM 트레이드는 `session_tag="llm"`로 태깅 → 리뷰 grain이 session_tag 포함이라 규칙 baseline(`session_tag=""`)과 **별도 리뷰행으로 분리**. 비교 surfacing은 **D-PR2(후속)**: Phase 2 flow를 session_tag별 반복 + 각 buy&hold 벤치마크 → `/invest/scalping`에 나란히.

## 테스트 / 리뷰

- 신규: session_tag 배선 3(monitored/one-shot/무회귀) + 도구 5(dry_run/confirm/게이트/allowlist/기록). binance 스코프 회귀 **525 passed**, ruff/ty clean.
- Subagent-Driven: 태스크별 구현→리뷰→수정 + **전체 브랜치 최종 리뷰(opus): Ready to merge**. 기록처 strategy_events→signal_snapshot 정제(부적합 확인), side 정규화·docstring 등 리뷰 fix 반영.

## Operator 활성화 (머지 후)

1. `BINANCE_DEMO_SCALPING_ENABLED=true` (도구 등록 게이트; Phase 0에서 이미 prod 설정됨)
2. MCP 서버 재시작(도구 등록 반영) → 매일 런북대로 MCP 세션에서 `binance_demo_scalping_submit_decision` 사용

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0115yvcHYpLv3aLeKJ36Bo9w

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added MCP tool for submitting Binance demo scalping decisions with dry-run validation mode (enabled by configuration flag; defaults to off).
  * Added session tracking for LLM-generated trades to distinguish them in analytics and reporting.

* **Documentation**
  * Added operational runbook and design specification for daily LLM decision session workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->