### PR TITLE
feat: Phase 3 D-PR2 — 스캘핑 리뷰 LLM vs 규칙 baseline 비교 (session_tag 분리)

### DIFF
--- a/app/jobs/binance_demo_scalping_review.py
+++ b/app/jobs/binance_demo_scalping_review.py
@@ -51,7 +51,8 @@ async def _refresh_with_session(
     for product in products:
         try:
             tags = sorted(
-                {""} | set(
+                {""}
+                | set(
                     await service.list_session_tags(
                         review_date=review_date, product=product
                     )
@@ -65,7 +66,9 @@ async def _refresh_with_session(
             continue
         for session_tag in tags:
             try:
-                async with session.begin_nested():  # SAVEPOINT: isolate per (product, tag)
+                async with (
+                    session.begin_nested()
+                ):  # SAVEPOINT: isolate per (product, tag)
                     review = await service.build_draft(
                         review_date=review_date,
                         product=product,

--- a/app/jobs/binance_demo_scalping_review.py
+++ b/app/jobs/binance_demo_scalping_review.py
@@ -50,30 +50,58 @@ async def _refresh_with_session(
     errors: list[dict[str, str]] = []
     for product in products:
         try:
-            async with session.begin_nested():  # SAVEPOINT: isolate per product
-                review = await service.build_draft(
-                    review_date=review_date, product=product, now=now
+            tags = sorted(
+                {""} | set(
+                    await service.list_session_tags(
+                        review_date=review_date, product=product
+                    )
                 )
-                benchmark = await compute_and_store_daily_benchmark(
-                    session=session,
-                    market_data=market_data,
-                    review_date=review_date,
-                    product=product,
-                    now=now,
-                )
-                summaries.append(
-                    {
-                        "product": product,
-                        "tradeCount": review.trade_count,
-                        "netReturnBps": _num(review.net_return_bps),
-                        "benchmarkReturnBps": _num(benchmark),
-                    }
-                )
-        except Exception as exc:  # noqa: BLE001 — isolate; savepoint rolled back
+            )
+        except Exception as exc:  # noqa: BLE001 — isolate product on enumeration failure
             logger.exception(
-                "demo scalping review refresh failed for product=%s", product
+                "demo scalping review tag enumeration failed for product=%s", product
             )
             errors.append({"product": product, "error": f"{type(exc).__name__}: {exc}"})
+            continue
+        for session_tag in tags:
+            try:
+                async with session.begin_nested():  # SAVEPOINT: isolate per (product, tag)
+                    review = await service.build_draft(
+                        review_date=review_date,
+                        product=product,
+                        now=now,
+                        session_tag=session_tag,
+                    )
+                    benchmark = await compute_and_store_daily_benchmark(
+                        session=session,
+                        market_data=market_data,
+                        review_date=review_date,
+                        product=product,
+                        now=now,
+                        session_tag=session_tag,
+                    )
+                    summaries.append(
+                        {
+                            "product": product,
+                            "sessionTag": session_tag,
+                            "tradeCount": review.trade_count,
+                            "netReturnBps": _num(review.net_return_bps),
+                            "benchmarkReturnBps": _num(benchmark),
+                        }
+                    )
+            except Exception as exc:  # noqa: BLE001 — isolate; savepoint rolled back
+                logger.exception(
+                    "demo scalping review refresh failed for product=%s tag=%s",
+                    product,
+                    session_tag,
+                )
+                errors.append(
+                    {
+                        "product": product,
+                        "sessionTag": session_tag,
+                        "error": f"{type(exc).__name__}: {exc}",
+                    }
+                )
     return {
         "status": "ran",
         "reviewDate": review_date.isoformat(),

--- a/app/services/brokers/binance/demo_scalping_exec/benchmark_runner.py
+++ b/app/services/brokers/binance/demo_scalping_exec/benchmark_runner.py
@@ -43,7 +43,9 @@ async def compute_and_store_daily_benchmark(
     stored value (``None`` when it cannot be computed). Never raises on a
     market-data failure — logs and stores ``None``."""
     service = ScalpingReviewService(session)
-    rows = await service.list_analytics(review_date=review_date, product=product)
+    rows = await service.list_analytics(
+        review_date=review_date, product=product, session_tag=session_tag
+    )
 
     notional_by_symbol: dict[str, Decimal] = defaultdict(lambda: Decimal("0"))
     for row in rows:

--- a/app/services/scalping_reviews/service.py
+++ b/app/services/scalping_reviews/service.py
@@ -13,7 +13,7 @@ import datetime as dt
 from decimal import Decimal
 from typing import Any
 
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.scalp_trade_analytics import ScalpTradeAnalytics
@@ -77,7 +77,7 @@ class ScalpingReviewService:
         refreshes the rollup metrics in place, preserves operator inputs, and
         leaves a ``locked`` review untouched."""
         _require_demo_scope(account_scope)
-        rollup = await self._rollup_for(review_date, product)
+        rollup = await self._rollup_for(review_date, product, session_tag=session_tag)
 
         existing = await self._get_by_key(
             review_date, product, account_scope, session_tag
@@ -121,29 +121,52 @@ class ScalpingReviewService:
         )
 
     async def list_analytics(
-        self, *, review_date: dt.date, product: str
+        self, *, review_date: dt.date, product: str, session_tag: str | None = None
     ) -> list[ScalpTradeAnalytics]:
         """Raw scalp_trade_analytics round-trip rows for a day/product, oldest
-        first. Read-only — the per-trade table renders these; the review UI
-        never edits them."""
+        first. ``session_tag=None`` returns all rows (the per-trade table);
+        a value filters to ``COALESCE(session_tag,'') == session_tag`` so the
+        per-tag review rolls up only its own trades. Read-only."""
         start = dt.datetime.combine(review_date, dt.time.min, tzinfo=dt.UTC)
         end = start + dt.timedelta(days=1)
-        return list(
-            (
-                await self._session.scalars(
-                    select(ScalpTradeAnalytics)
-                    .where(
-                        ScalpTradeAnalytics.product == product,
-                        ScalpTradeAnalytics.created_at >= start,
-                        ScalpTradeAnalytics.created_at < end,
-                    )
-                    .order_by(ScalpTradeAnalytics.created_at)
-                )
-            ).all()
+        stmt = select(ScalpTradeAnalytics).where(
+            ScalpTradeAnalytics.product == product,
+            ScalpTradeAnalytics.created_at >= start,
+            ScalpTradeAnalytics.created_at < end,
         )
+        if session_tag is not None:
+            stmt = stmt.where(
+                func.coalesce(ScalpTradeAnalytics.session_tag, "") == session_tag
+            )
+        stmt = stmt.order_by(ScalpTradeAnalytics.created_at)
+        return list((await self._session.scalars(stmt)).all())
 
-    async def _rollup_for(self, review_date: dt.date, product: str) -> RollupResult:
-        rows = await self.list_analytics(review_date=review_date, product=product)
+    async def list_session_tags(
+        self, *, review_date: dt.date, product: str
+    ) -> list[str]:
+        """Distinct ``COALESCE(session_tag,'')`` for that day/product, sorted.
+        Empty list when no analytics rows exist."""
+        start = dt.datetime.combine(review_date, dt.time.min, tzinfo=dt.UTC)
+        end = start + dt.timedelta(days=1)
+        tag_col = func.coalesce(ScalpTradeAnalytics.session_tag, "")
+        rows = await self._session.scalars(
+            select(tag_col)
+            .where(
+                ScalpTradeAnalytics.product == product,
+                ScalpTradeAnalytics.created_at >= start,
+                ScalpTradeAnalytics.created_at < end,
+            )
+            .distinct()
+            .order_by(tag_col)
+        )
+        return list(rows)
+
+    async def _rollup_for(
+        self, review_date: dt.date, product: str, session_tag: str = ""
+    ) -> RollupResult:
+        rows = await self.list_analytics(
+            review_date=review_date, product=product, session_tag=session_tag
+        )
         return build_rollup(rows)
 
     @staticmethod

--- a/app/services/scalping_reviews/service.py
+++ b/app/services/scalping_reviews/service.py
@@ -238,7 +238,9 @@ class ScalpingReviewService:
         if product is not None:
             stmt = stmt.where(ScalpingDailyReview.product == product)
         stmt = stmt.order_by(
-            ScalpingDailyReview.review_date.desc(), ScalpingDailyReview.product
+            ScalpingDailyReview.review_date.desc(),
+            ScalpingDailyReview.product,
+            ScalpingDailyReview.session_tag,
         )
         return list((await self._session.scalars(stmt)).all())
 

--- a/docs/superpowers/plans/2026-06-22-binance-demo-scalping-review-comparison.md
+++ b/docs/superpowers/plans/2026-06-22-binance-demo-scalping-review-comparison.md
@@ -1,0 +1,505 @@
+# Binance Demo 스캘핑 리뷰 LLM vs 규칙 비교 (Phase 3 D-PR2) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 일별 스캘핑 리뷰/벤치마크를 `session_tag`별로 분리 생성(혼합 집계 수정)하고, `/invest/scalping`에서 LLM(`"llm"`)과 규칙 baseline(`""`)을 별도 카드로 비교 가능하게 한다.
+
+**Architecture:** ① `list_analytics`/`_rollup_for`/`build_draft`/benchmark_runner에 `COALESCE(session_tag,'')` 필터 추가 ② 신규 `list_session_tags` distinct ③ 일별 flow가 `{""} ∪ distinct tags` 순회 ④ 프런트가 전 tag 리뷰를 라벨된 비교 strip으로 렌더.
+
+**Tech Stack:** Python 3.13, SQLAlchemy(async, `func.coalesce`), pytest-asyncio, React/TypeScript, vitest.
+
+## Global Constraints
+
+- 변경은 worktree `feature/binance-demo-scalping-review-comparison`에서. canonical repo는 main 고정.
+- **무회귀 — `list_analytics` 기본값 `session_tag: str | None = None`(=필터 없음, 전체)**: 트레이드 테이블 등 기존 호출자는 session_tag를 안 넘기므로 전 행을 받아야 한다. `None`이면 필터 미적용. `_rollup_for`/benchmark는 review의 `session_tag`(str, `""` 포함)를 명시 전달해 필터.
+- **NULL/"" 정합**: 필터·distinct 모두 `func.coalesce(ScalpTradeAnalytics.session_tag, "")` 사용. 스케줄러(규칙)=NULL, llm 도구=`"llm"`, 리뷰 baseline grain=`""`.
+- **de-mixing(의도된 동작 변경)**: 기존 `""` 리뷰는 rule+llm 혼합이었으나 이제 rule(NULL/"")만 집계.
+- **flow는 `{""}` 항상 포함**: 빈 날에도 규칙 baseline `""` 리뷰 생성(Phase 2 무회귀). per-(product, tag) `begin_nested()` SAVEPOINT 격리.
+- 마이그레이션 없음(`session_tag`는 기존 컬럼: `scalp_trade_analytics.session_tag` nullable, `scalping_daily_reviews.session_tag` NOT NULL server_default="").
+- 데모 전용 / 주문·브로커 mutation 없음(리뷰는 read+집계 persistence).
+- 커밋 trailer:
+  ```
+  Co-Authored-By: Paperclip <noreply@paperclip.ing>
+  Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+  Claude-Session: https://claude.ai/code/session_0115yvcHYpLv3aLeKJ36Bo9w
+  ```
+
+## File Structure
+
+- `app/services/scalping_reviews/service.py` (수정) — `list_analytics` 필터 + `_rollup_for`/`build_draft` 스레딩 + `list_session_tags` 신규 + `func` import.
+- `app/services/brokers/binance/demo_scalping_exec/benchmark_runner.py` (수정) — `list_analytics` 호출에 session_tag.
+- `app/jobs/binance_demo_scalping_review.py` (수정) — `_refresh_with_session` tag 순회.
+- `frontend/invest/src/pages/desktop/DesktopScalpingPage.tsx` (수정) — SESSION_TAG_LABEL + 비교 strip + 카드 라벨.
+- Test: `tests/services/scalping_reviews/test_service.py`, `tests/jobs/test_binance_demo_scalping_review.py`, `frontend/invest/src/__tests__/DesktopScalpingPage.test.tsx`.
+
+---
+
+### Task 1: 리뷰 rollup을 session_tag로 분리 (service.py)
+
+**Files:**
+- Modify: `app/services/scalping_reviews/service.py`
+- Test: `tests/services/scalping_reviews/test_service.py`
+
+**Interfaces:**
+- Produces: `list_analytics(*, review_date, product, session_tag: str | None = None)`; `_rollup_for(review_date, product, session_tag: str = "")`; `list_session_tags(*, review_date, product) -> list[str]`; `build_draft`가 자기 `session_tag`로 집계.
+
+- [ ] **Step 1: 실패 테스트 작성**
+
+`tests/services/scalping_reviews/test_service.py`에 추가(기존 `_instrument`/`_analytics`/`_NOW`/`_DATE` 헬퍼 재사용; `_analytics`는 `**kw`로 `session_tag` 전달 가능, `tag=`는 open_client_order_id 구분용). `ScalpingReviewService`는 파일 상단에서 이미 import됨:
+
+```python
+@pytest.mark.asyncio
+async def test_rollup_separates_by_session_tag(db_session) -> None:
+    iid = await _instrument(db_session, "SEPXRPUSDT")
+    # 규칙(NULL) 1건 + llm 2건, 같은 날/product
+    await _analytics(db_session, iid, tag="rule1", symbol="SEPXRPUSDT",
+                     entry_price=Decimal("100"), exit_price=Decimal("101"),
+                     entry_notional_usdt=Decimal("100"), net_pnl_usdt=Decimal("0.9"),
+                     gross_pnl_usdt=Decimal("1.0"), net_return_bps=Decimal("90"),
+                     exit_reason="take_profit")
+    for i in range(2):
+        await _analytics(db_session, iid, tag=f"llm{i}", symbol="SEPXRPUSDT",
+                         session_tag="llm", entry_price=Decimal("100"),
+                         exit_price=Decimal("102"), entry_notional_usdt=Decimal("100"),
+                         net_pnl_usdt=Decimal("1.5"), gross_pnl_usdt=Decimal("1.6"),
+                         net_return_bps=Decimal("150"), exit_reason="take_profit")
+    svc = ScalpingReviewService(db_session)
+    rule_review = await svc.build_draft(review_date=_DATE, product="usdm_futures", now=_NOW, session_tag="")
+    llm_review = await svc.build_draft(review_date=_DATE, product="usdm_futures", now=_NOW, session_tag="llm")
+    assert rule_review.trade_count == 1
+    assert llm_review.trade_count == 2
+    # list_analytics: None=전체(무회귀), 값=필터
+    assert len(await svc.list_analytics(review_date=_DATE, product="usdm_futures")) == 3
+    assert len(await svc.list_analytics(review_date=_DATE, product="usdm_futures", session_tag="")) == 1
+    assert len(await svc.list_analytics(review_date=_DATE, product="usdm_futures", session_tag="llm")) == 2
+
+
+@pytest.mark.asyncio
+async def test_list_session_tags_distinct_coalesced(db_session) -> None:
+    iid = await _instrument(db_session, "TAGXRPUSDT")
+    await _analytics(db_session, iid, tag="n", symbol="TAGXRPUSDT")  # NULL → ""
+    await _analytics(db_session, iid, tag="l1", symbol="TAGXRPUSDT", session_tag="llm")
+    await _analytics(db_session, iid, tag="l2", symbol="TAGXRPUSDT", session_tag="llm")
+    svc = ScalpingReviewService(db_session)
+    tags = await svc.list_session_tags(review_date=_DATE, product="usdm_futures")
+    assert tags == ["", "llm"]
+```
+
+- [ ] **Step 2: 실패 확인**
+
+Run: `cd /Users/mgh3326/work/auto_trader.phase3-dpr2-review-comparison && uv run pytest tests/services/scalping_reviews/test_service.py::test_rollup_separates_by_session_tag tests/services/scalping_reviews/test_service.py::test_list_session_tags_distinct_coalesced -v`
+Expected: FAIL — `list_analytics() got an unexpected keyword argument 'session_tag'` / `AttributeError: list_session_tags`. (test deps 없으면 `uv sync --all-groups` 먼저.)
+
+- [ ] **Step 3: `func` import 추가**
+
+`service.py` 상단 `from sqlalchemy import select`를 교체:
+
+```python
+from sqlalchemy import func, select
+```
+
+- [ ] **Step 4: `list_analytics`에 session_tag 필터(None=전체)**
+
+`list_analytics` 메서드 전체를 교체:
+
+```python
+    async def list_analytics(
+        self, *, review_date: dt.date, product: str, session_tag: str | None = None
+    ) -> list[ScalpTradeAnalytics]:
+        """Raw scalp_trade_analytics round-trip rows for a day/product, oldest
+        first. ``session_tag=None`` returns all rows (the per-trade table);
+        a value filters to ``COALESCE(session_tag,'') == session_tag`` so the
+        per-tag review rolls up only its own trades. Read-only."""
+        start = dt.datetime.combine(review_date, dt.time.min, tzinfo=dt.UTC)
+        end = start + dt.timedelta(days=1)
+        stmt = select(ScalpTradeAnalytics).where(
+            ScalpTradeAnalytics.product == product,
+            ScalpTradeAnalytics.created_at >= start,
+            ScalpTradeAnalytics.created_at < end,
+        )
+        if session_tag is not None:
+            stmt = stmt.where(
+                func.coalesce(ScalpTradeAnalytics.session_tag, "") == session_tag
+            )
+        stmt = stmt.order_by(ScalpTradeAnalytics.created_at)
+        return list((await self._session.scalars(stmt)).all())
+```
+
+- [ ] **Step 5: `_rollup_for` + `build_draft` 스레딩 + `list_session_tags` 신규**
+
+`_rollup_for` 교체:
+
+```python
+    async def _rollup_for(
+        self, review_date: dt.date, product: str, session_tag: str = ""
+    ) -> RollupResult:
+        rows = await self.list_analytics(
+            review_date=review_date, product=product, session_tag=session_tag
+        )
+        return build_rollup(rows)
+```
+
+`build_draft` 내 `rollup = await self._rollup_for(review_date, product)`를 교체:
+
+```python
+        rollup = await self._rollup_for(review_date, product, session_tag=session_tag)
+```
+
+`list_analytics` 메서드 **다음에** `list_session_tags` 추가:
+
+```python
+    async def list_session_tags(
+        self, *, review_date: dt.date, product: str
+    ) -> list[str]:
+        """Distinct ``COALESCE(session_tag,'')`` for that day/product, sorted.
+        Empty list when no analytics rows exist."""
+        start = dt.datetime.combine(review_date, dt.time.min, tzinfo=dt.UTC)
+        end = start + dt.timedelta(days=1)
+        tag_col = func.coalesce(ScalpTradeAnalytics.session_tag, "")
+        rows = await self._session.scalars(
+            select(tag_col)
+            .where(
+                ScalpTradeAnalytics.product == product,
+                ScalpTradeAnalytics.created_at >= start,
+                ScalpTradeAnalytics.created_at < end,
+            )
+            .distinct()
+            .order_by(tag_col)
+        )
+        return list(rows)
+```
+
+- [ ] **Step 6: 통과 + 회귀**
+
+Run: `uv run pytest tests/services/scalping_reviews/test_service.py -v`
+Expected: PASS (신규 2 + 기존 전부 green — 기존 호출자는 session_tag 미전달 → None → 전체, build_draft는 기본 ""로 NULL/"" 집계 무회귀).
+
+- [ ] **Step 7: 커밋**
+
+```bash
+git add app/services/scalping_reviews/service.py tests/services/scalping_reviews/test_service.py
+git commit -F - <<'EOF'
+feat: scope scalping review rollup by session_tag
+
+list_analytics에 COALESCE(session_tag,'') 필터(None=전체, 무회귀) + _rollup_for/
+build_draft가 자기 session_tag로 집계 분리(rule NULL/"" vs llm de-mixing) +
+list_session_tags distinct 신규.
+
+Co-Authored-By: Paperclip <noreply@paperclip.ing>
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_0115yvcHYpLv3aLeKJ36Bo9w
+EOF
+```
+
+---
+
+### Task 2: benchmark 분리 + flow tag 순회
+
+**Files:**
+- Modify: `app/services/brokers/binance/demo_scalping_exec/benchmark_runner.py`
+- Modify: `app/jobs/binance_demo_scalping_review.py`
+- Test: `tests/jobs/test_binance_demo_scalping_review.py`
+
+**Interfaces:**
+- Consumes: Task 1의 `list_analytics(..., session_tag=...)`, `list_session_tags(...)`, `build_draft(..., session_tag=...)`.
+- Produces: flow가 (product, tag)별 리뷰+벤치마크 생성; summary 항목에 `sessionTag`.
+
+- [ ] **Step 1: 실패 테스트 작성**
+
+`tests/jobs/test_binance_demo_scalping_review.py`에 추가(기존 `_instrument`/`_analytics`/`_FakeMD`/`_DATE`/`_NOW`/`settings`/`run_demo_scalping_review_refresh`/`ScalpingReviewService` 재사용):
+
+```python
+@pytest.mark.asyncio
+async def test_flow_builds_per_session_tag(db_session, monkeypatch) -> None:
+    monkeypatch.setattr(settings, "binance_demo_scalping_review_flow_enabled", True)
+    iid = await _instrument(db_session, "XRPUSDT")
+    # 규칙(NULL) 1 + llm 1
+    await _analytics(db_session, iid, tag="r", symbol="XRPUSDT",
+                     entry_price=Decimal("100"), exit_price=Decimal("101"),
+                     entry_notional_usdt=Decimal("100"), net_pnl_usdt=Decimal("0.9"),
+                     gross_pnl_usdt=Decimal("1.0"), net_return_bps=Decimal("90"),
+                     exit_reason="take_profit")
+    await _analytics(db_session, iid, tag="l", symbol="XRPUSDT", session_tag="llm",
+                     entry_price=Decimal("100"), exit_price=Decimal("102"),
+                     entry_notional_usdt=Decimal("100"), net_pnl_usdt=Decimal("1.5"),
+                     gross_pnl_usdt=Decimal("1.6"), net_return_bps=Decimal("150"),
+                     exit_reason="take_profit")
+    md = _FakeMD({"XRPUSDT": (100.0, 101.0)})
+    result = await run_demo_scalping_review_refresh(
+        session=db_session, market_data=md, review_date=_DATE,
+        products=("usdm_futures",), now=_NOW,
+    )
+    assert result["status"] == "ran"
+    tags = {s["sessionTag"] for s in result["products"]}
+    assert tags == {"", "llm"}
+    svc = ScalpingReviewService(db_session)
+    rule = await svc._get_by_key(_DATE, "usdm_futures", "binance_demo", "")
+    llm = await svc._get_by_key(_DATE, "usdm_futures", "binance_demo", "llm")
+    assert rule.trade_count == 1 and llm.trade_count == 1
+    assert llm.benchmark_return_bps is not None  # benchmark per tag stored
+
+
+@pytest.mark.asyncio
+async def test_flow_empty_day_still_builds_rule_baseline(db_session, monkeypatch) -> None:
+    monkeypatch.setattr(settings, "binance_demo_scalping_review_flow_enabled", True)
+    md = _FakeMD({})
+    result = await run_demo_scalping_review_refresh(
+        session=db_session, market_data=md, review_date=_DATE,
+        products=("usdm_futures",), now=_NOW,
+    )
+    assert [s["sessionTag"] for s in result["products"]] == [""]  # {""} always
+    svc = ScalpingReviewService(db_session)
+    assert await svc._get_by_key(_DATE, "usdm_futures", "binance_demo", "") is not None
+```
+
+- [ ] **Step 2: 실패 확인**
+
+Run: `uv run pytest tests/jobs/test_binance_demo_scalping_review.py::test_flow_builds_per_session_tag tests/jobs/test_binance_demo_scalping_review.py::test_flow_empty_day_still_builds_rule_baseline -v`
+Expected: FAIL — summary 항목에 `sessionTag` 없음 / llm 리뷰 행 없음(현재 "" 한 행만, 혼합 집계).
+
+- [ ] **Step 3: benchmark_runner에 session_tag 필터 전달**
+
+`benchmark_runner.py`의 `rows = await service.list_analytics(review_date=review_date, product=product)`를 교체:
+
+```python
+    rows = await service.list_analytics(
+        review_date=review_date, product=product, session_tag=session_tag
+    )
+```
+
+- [ ] **Step 4: `_refresh_with_session` tag 순회**
+
+`_refresh_with_session`의 `for product in products:` 블록 전체를 교체:
+
+```python
+    for product in products:
+        try:
+            tags = sorted(
+                {""} | set(
+                    await service.list_session_tags(
+                        review_date=review_date, product=product
+                    )
+                )
+            )
+        except Exception as exc:  # noqa: BLE001 — isolate product on enumeration failure
+            logger.exception(
+                "demo scalping review tag enumeration failed for product=%s", product
+            )
+            errors.append({"product": product, "error": f"{type(exc).__name__}: {exc}"})
+            continue
+        for session_tag in tags:
+            try:
+                async with session.begin_nested():  # SAVEPOINT: isolate per (product, tag)
+                    review = await service.build_draft(
+                        review_date=review_date,
+                        product=product,
+                        now=now,
+                        session_tag=session_tag,
+                    )
+                    benchmark = await compute_and_store_daily_benchmark(
+                        session=session,
+                        market_data=market_data,
+                        review_date=review_date,
+                        product=product,
+                        now=now,
+                        session_tag=session_tag,
+                    )
+                    summaries.append(
+                        {
+                            "product": product,
+                            "sessionTag": session_tag,
+                            "tradeCount": review.trade_count,
+                            "netReturnBps": _num(review.net_return_bps),
+                            "benchmarkReturnBps": _num(benchmark),
+                        }
+                    )
+            except Exception as exc:  # noqa: BLE001 — isolate; savepoint rolled back
+                logger.exception(
+                    "demo scalping review refresh failed for product=%s tag=%s",
+                    product,
+                    session_tag,
+                )
+                errors.append(
+                    {
+                        "product": product,
+                        "sessionTag": session_tag,
+                        "error": f"{type(exc).__name__}: {exc}",
+                    }
+                )
+```
+
+- [ ] **Step 5: 통과 + 회귀**
+
+Run: `uv run pytest tests/jobs/test_binance_demo_scalping_review.py -v`
+Expected: PASS (신규 2 + 기존 — 기존 테스트는 NULL 트레이드만이라 tags={""}, "" 리뷰 동일 생성).
+
+- [ ] **Step 6: 커밋**
+
+```bash
+git add app/services/brokers/binance/demo_scalping_exec/benchmark_runner.py app/jobs/binance_demo_scalping_review.py tests/jobs/test_binance_demo_scalping_review.py
+git commit -F - <<'EOF'
+feat: per-session_tag review+benchmark in daily refresh flow
+
+benchmark_runner가 session_tag로 analytics 필터(tag별 buy&hold) + flow가
+{""}∪distinct tag 순회하여 (product,tag)별 리뷰+벤치마크 생성(규칙 항상 포함,
+per-(product,tag) SAVEPOINT 격리). LLM vs 규칙 baseline 분리 측정.
+
+Co-Authored-By: Paperclip <noreply@paperclip.ing>
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_0115yvcHYpLv3aLeKJ36Bo9w
+EOF
+```
+
+---
+
+### Task 3: 프런트 — tag 라벨 + 비교 strip
+
+**Files:**
+- Modify: `frontend/invest/src/pages/desktop/DesktopScalpingPage.tsx`
+- Test: `frontend/invest/src/__tests__/DesktopScalpingPage.test.tsx`
+
+**Interfaces:**
+- Consumes: `fetchScalpingReviews(...)` → `{items: ScalpingReview[]}` (tag별 행); `ScalpingReview.sessionTag`, `.metrics.{tradeCount,winCount,lossCount,netReturnBps,netPnlUsdt}`.
+
+- [ ] **Step 1: 실패 테스트 작성**
+
+`frontend/invest/src/__tests__/DesktopScalpingPage.test.tsx`에 추가(기존 `REVIEW`/`ACTION`/`TRADE_OK`/`wrap`/`ScalpingRoute`/`scalpingApi` 재사용). 두 tag 리뷰를 반환하도록 mock:
+
+```typescript
+test("renders per-session_tag comparison strip with labels", async () => {
+  const ruleReview = { ...REVIEW, id: 1, sessionTag: "", metrics: { ...REVIEW.metrics, netReturnBps: "-10" } };
+  const llmReview = { ...REVIEW, id: 2, sessionTag: "llm", metrics: { ...REVIEW.metrics, netReturnBps: "150" } };
+  vi.spyOn(scalpingApi, "fetchScalpingReviews").mockResolvedValue({ items: [ruleReview, llmReview] });
+  vi.spyOn(scalpingApi, "fetchScalpingReview").mockResolvedValue({ review: ruleReview, actions: [ACTION] });
+  vi.spyOn(scalpingApi, "fetchScalpingTrades").mockResolvedValue({ items: [TRADE_OK] });
+
+  render(wrap(<ScalpingRoute />));
+
+  await waitFor(() => expect(screen.getByTestId("scalping-session-comparison")).toBeInTheDocument());
+  const strip = screen.getByTestId("scalping-session-comparison");
+  expect(within(strip).getByText("규칙")).toBeInTheDocument();
+  expect(within(strip).getByText("LLM")).toBeInTheDocument();
+});
+```
+
+`within` import 확인: 파일 상단 `import { render, screen, waitFor } from "@testing-library/react";`에 `within` 추가.
+
+- [ ] **Step 2: 실패 확인**
+
+Run: `cd /Users/mgh3326/work/auto_trader.phase3-dpr2-review-comparison/frontend/invest && npm test -- DesktopScalpingPage 2>&1 | tail -20`
+Expected: FAIL — `scalping-session-comparison` testid 없음.
+
+- [ ] **Step 3: SESSION_TAG_LABEL 추가**
+
+`DesktopScalpingPage.tsx`의 `STATUS_LABEL` 정의 근처(파일 상단 라벨 상수들 옆)에 추가:
+
+```typescript
+const SESSION_TAG_LABEL: Record<string, string> = { "": "규칙", llm: "LLM" };
+const sessionTagLabel = (tag: string): string => SESSION_TAG_LABEL[tag] ?? tag ?? "규칙";
+```
+
+- [ ] **Step 4: 전체 items 보관**
+
+`load` 콜백에서 `const found = reviews.items[0] ?? null;` 위에 전체 리스트 상태 저장 추가. 컴포넌트 상단 state 선언부(`const [building, setBuilding] = useState(false);` 다음)에:
+
+```typescript
+  const [reviewList, setReviewList] = useState<ScalpingReview[]>([]);
+```
+
+(`ScalpingReview` 타입 import가 없으면 `import type { ScalpingReview, ScalpingProduct } from "../../types/scalping";`에 추가.)
+
+`load` 콜백 내 `const found = reviews.items[0] ?? null;` **앞에** 추가:
+
+```typescript
+      setReviewList(reviews.items);
+```
+
+- [ ] **Step 5: 비교 strip 렌더**
+
+`{/* 2. Daily loop card */}` 블록 **앞에**(summary 다음) 추가:
+
+```typescript
+              {/* 1.5 Per-session_tag comparison (LLM vs rule baseline) */}
+              {reviewList.length > 1 && (
+                <Card>
+                  <h2 style={{ margin: "0 0 8px", fontSize: 16 }}>세션별 비교 (LLM vs 규칙)</h2>
+                  <div data-testid="scalping-session-comparison" style={{ display: "grid", gap: 6 }}>
+                    {reviewList.map((r) => (
+                      <div key={r.id} style={{ display: "flex", gap: 12, flexWrap: "wrap", fontSize: 13 }}>
+                        <strong style={{ minWidth: 48 }}>{sessionTagLabel(r.sessionTag)}</strong>
+                        <span style={{ color: "var(--fg-3)" }}>{r.metrics.tradeCount}건</span>
+                        <span style={{ color: "var(--fg-3)" }}>승/패 {r.metrics.winCount}/{r.metrics.lossCount}</span>
+                        <span>net {na(r.metrics.netReturnBps)} bps</span>
+                        <span>순손익 {na(r.metrics.netPnlUsdt)}</span>
+                      </div>
+                    ))}
+                  </div>
+                </Card>
+              )}
+```
+
+(`na(...)` 헬퍼는 이 파일에서 이미 사용 중 — 라인 199 `na(metrics.netPnlUsdt)`.)
+
+`{/* 2. Daily loop card */}`의 카드 헤더 `<span>`에 sessionTag 라벨 추가 — 라인 214-217의 `<span>`을 교체:
+
+```typescript
+                    <span style={{ color: "var(--fg-3)", fontSize: 12 }}>
+                      [{sessionTagLabel(review.sessionTag)}] {STATUS_LABEL[review.status] ?? review.status}
+                      {exitReasonSummary ? ` · 종료사유: ${exitReasonSummary}` : ""}
+                    </span>
+```
+
+- [ ] **Step 6: 통과 + 회귀**
+
+Run: `cd /Users/mgh3326/work/auto_trader.phase3-dpr2-review-comparison/frontend/invest && npm test -- DesktopScalpingPage 2>&1 | tail -20 && npx tsc --noEmit 2>&1 | tail -5`
+Expected: 신규 + 기존 DesktopScalpingPage 테스트 PASS, tsc clean.
+
+- [ ] **Step 7: 커밋**
+
+```bash
+cd /Users/mgh3326/work/auto_trader.phase3-dpr2-review-comparison
+git add frontend/invest/src/pages/desktop/DesktopScalpingPage.tsx frontend/invest/src/__tests__/DesktopScalpingPage.test.tsx
+git commit -F - <<'EOF'
+feat(invest): per-session_tag scalping review comparison strip + labels
+
+/invest/scalping이 전 session_tag 리뷰를 라벨된 비교 strip으로 렌더(규칙 vs LLM
+net bps·순손익 나란히) + 일별 루프 카드에 tag 라벨. 기존 items[0] 단일 렌더 유지.
+
+Co-Authored-By: Paperclip <noreply@paperclip.ing>
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_0115yvcHYpLv3aLeKJ36Bo9w
+EOF
+```
+
+---
+
+### 최종 검증
+
+- [ ] **Step: 백엔드 스코프 + 프런트 + lint/type**
+
+Run:
+```bash
+cd /Users/mgh3326/work/auto_trader.phase3-dpr2-review-comparison
+uv run pytest tests/services/scalping_reviews/ tests/jobs/test_binance_demo_scalping_review.py tests/services/brokers/binance/ -q -p no:cacheprovider
+uv run ruff format --check app/services/scalping_reviews/service.py app/services/brokers/binance/demo_scalping_exec/benchmark_runner.py app/jobs/binance_demo_scalping_review.py
+uv run ruff check app/services/scalping_reviews/service.py app/services/brokers/binance/demo_scalping_exec/benchmark_runner.py app/jobs/binance_demo_scalping_review.py
+uv run ty check app/
+cd frontend/invest && npm test -- DesktopScalpingPage 2>&1 | tail -5
+```
+Expected: 백엔드 신규+회귀 PASS(binance audit 포함 — 새 binance-참조 파일 없으므로 allowlist 변경 불필요), ruff/ty clean, 프런트 PASS.
+
+---
+
+## Self-Review (spec 대비)
+
+- **§2.1 rollup session_tag 필터** → Task 1(list_analytics None-default 필터 + _rollup_for/build_draft 스레딩). ✓
+- **§2.1 benchmark 필터** → Task 2 Step 3. ✓
+- **§2.1 tag 열거** → Task 1 list_session_tags. ✓
+- **§2.1 flow tag 순회** → Task 2 Step 4(`{""}∪distinct`, per-(product,tag) SAVEPOINT). ✓
+- **§2.1 UI 라벨** → Task 3(SESSION_TAG_LABEL + 비교 strip + 카드 라벨). ✓
+- **§5 NULL/"" 정합** → `func.coalesce(...,"")` 필터·distinct 일관(Task 1). ✓
+- **§6 에러** → tag enumeration 실패 시 product skip, (product,tag) SAVEPOINT 격리, 빈 날 `{""}`만(무회귀). ✓
+- **§7 테스트** → rollup 분리/distinct(T1), flow per-tag/빈 날(T2), UI 라벨 strip(T3), 무회귀(None default + 기존 테스트). ✓
+- **§8 무회귀** → list_analytics 기본 None(전체); build_draft 기본 ""; 기존 호출자 불변. ✓
+- 마이그레이션 없음. 전용 비교 컴포넌트(델타/승패 표)·benchmark 프런트 surfacing은 후속(범위 밖). ✓
+- **타입 일관**: `list_analytics(session_tag: str|None=None)` ↔ `_rollup_for(session_tag: str="")` ↔ `build_draft(session_tag="")` ↔ benchmark/flow가 str 전달; `list_session_tags -> list[str]`. ✓

--- a/docs/superpowers/specs/2026-06-22-binance-demo-scalping-review-comparison-design.md
+++ b/docs/superpowers/specs/2026-06-22-binance-demo-scalping-review-comparison-design.md
@@ -1,0 +1,84 @@
+# Binance Demo 스캘핑 리뷰 LLM vs 규칙 비교 (Phase 3 D-PR2 / Design)
+
+- **작성일**: 2026-06-22
+- **상태**: 승인됨 (브레인스토밍 → 스펙)
+- **브랜치**: `feature/binance-demo-scalping-review-comparison`
+- **선행**: Phase 2(일별 리뷰+벤치마크 자동화, #1345) + Phase 3 D-PR1(LLM 결정 주입 `session_tag="llm"`, #1346) merged
+
+## 1. 배경 / 동기
+
+D-PR1로 LLM 트레이드는 `scalp_trade_analytics.session_tag="llm"`로 태깅된다. 그러나 일별 리뷰/벤치마크 생성 경로(`build_draft` / `compute_and_store_daily_benchmark`)는 **`session_tag` 필터가 없어** 그날·product의 **모든 트레이드(규칙 NULL + llm)를 한 리뷰 행에 혼합 집계**한다(latent — D-PR1 이전엔 트레이드가 전부 NULL이라 무해했음). 결과적으로 "LLM이 규칙 baseline을 이기는가"를 측정할 수 없다.
+
+`scalping_daily_reviews` 리뷰 grain은 `(review_date, product, account_scope, session_tag)`로 **이미 session_tag를 포함**하고, `/invest/scalping` read는 그 행들을 그대로 반환·직렬화(`sessionTag`)한다. 따라서 리뷰/벤치마크를 **session_tag별로 분리 생성**하기만 하면, LLM(`"llm"`)과 규칙 baseline(`""`)이 별도 리뷰 행으로 분리되어 나란히 비교된다.
+
+## 2. 범위
+
+### 2.1 In scope
+- **rollup session_tag 필터** — `list_analytics`/`_rollup_for`/`build_draft`가 session_tag로 집계 분리(혼합 수정).
+- **benchmark session_tag 필터** — `compute_and_store_daily_benchmark`(이미 session_tag 인자 보유)가 내부 analytics 조회도 tag로 필터.
+- **tag 열거** — 신규 `list_session_tags(review_date, product)` distinct.
+- **flow tag 순회** — `_refresh_with_session`가 product마다 `{""} ∪ distinct tags` 순회하여 (product, tag)별 리뷰+벤치마크 생성.
+- **UI 라벨** — `/invest/scalping` 리뷰 카드에 sessionTag 표시 라벨 매핑(`""`→"규칙", `"llm"`→"LLM").
+
+### 2.2 Out of scope
+- 전용 side-by-side 비교 컴포넌트(net_return_bps 델타·승패 표) — 후속.
+- Hermes 자율 실행.
+- 스케줄러(규칙) 트레이드에 명시 tag 부여(외부 코드; NULL 유지하고 `COALESCE`로 처리).
+
+## 3. 컴포넌트
+
+### 3.1 rollup session_tag 필터 (`app/services/scalping_reviews/service.py`)
+- `list_analytics(*, review_date, product, session_tag: str | None = None)` — `session_tag=None`이면 기존처럼 전체(무회귀); 값이 있으면 `WHERE COALESCE(session_tag,'') = :session_tag` 추가.
+- `_rollup_for(review_date, product, session_tag: str | None = None)` — `list_analytics`에 전달.
+- `build_draft(*, ..., session_tag="")` — 자기 `session_tag`를 `_rollup_for`에 전달(현재는 전달 안 함). **결과: 각 리뷰 행이 자기 tag 트레이드만 집계.**
+
+### 3.2 benchmark session_tag 필터 (`app/services/brokers/binance/demo_scalping_exec/benchmark_runner.py`)
+- `compute_and_store_daily_benchmark(*, ..., session_tag="")`의 내부 `service.list_analytics(review_date, product)` 호출에 `session_tag=session_tag` 추가 → tag별 notional-weighted buy&hold.
+
+### 3.3 tag 열거 (`service.py`)
+- 신규 `list_session_tags(*, review_date, product) -> list[str]` — 그날·product의 `SELECT DISTINCT COALESCE(session_tag,'')` (정렬). 트레이드 없으면 빈 리스트.
+
+### 3.4 flow tag 순회 (`app/jobs/binance_demo_scalping_review.py`)
+- `_refresh_with_session`가 product마다 `tags = sorted({""} | set(list_session_tags(review_date, product)))` (규칙 baseline `""` 항상 포함) 순회 → 각 (product, tag) `build_draft(session_tag=tag)` + `compute_and_store_daily_benchmark(session_tag=tag)`. per-(product, tag) `begin_nested()` SAVEPOINT 격리(기존 per-product 패턴 확장).
+- summary는 (product, tag)별 항목.
+
+### 3.5 UI 라벨 (`/invest/scalping` 프런트)
+- 리뷰 카드 컴포넌트가 sessionTag를 표시 라벨로 매핑: `""`(또는 falsy)→"규칙", `"llm"`→"LLM", 기타→그대로. (백엔드 직렬화 `sessionTag`는 불변.)
+
+## 4. 데이터 흐름
+
+```
+일별 flow → product마다:
+  tags = sorted({""} ∪ distinct(COALESCE(session_tag,'')))   # 규칙 항상 + 발견된 llm 등
+  for tag in tags:
+    build_draft(session_tag=tag)                  # COALESCE(session_tag,'')=tag 만 집계
+    compute_and_store_daily_benchmark(session_tag=tag)
+→ /invest/scalping: (date,product)당 tag별 행 → "규칙" vs "LLM" 나란히 (net_return_bps + buy&hold 벤치마크)
+```
+
+## 5. NULL/"" 정합
+- 스케줄러(규칙) 트레이드 = `session_tag NULL`; 리뷰 baseline grain = `""`. 필터를 `COALESCE(session_tag,'')`로 통일 → `""` 리뷰가 NULL(규칙) 트레이드를 집계, `"llm"` 리뷰가 `"llm"` 트레이드를 집계.
+- **의도된 동작 변경(de-mixing)**: 기존 `""` 리뷰는 rule+llm 혼합 집계였으나 이제 rule만. 측정 정확화가 목적.
+
+## 6. 에러 처리
+- flow의 (product, tag)별 실패는 SAVEPOINT 격리로 다른 (product, tag)에 전파 안 됨(기존 per-product 패턴 유지). 실패 항목은 summary에 에러 표기.
+- 트레이드 없는 날: `list_session_tags`=빈 → `tags={""}` → `""` 리뷰만 생성(빈 rollup), 기존 Phase 2 무회귀.
+- `session_tag=None`(기존 호출자) → 필터 미적용 전체 집계(무회귀).
+
+## 7. 테스트
+- **rollup 필터**: 같은 날·product에 rule(NULL)+llm 트레이드 혼재 → `build_draft(session_tag="")`=rule만, `build_draft(session_tag="llm")`=llm만 집계. `session_tag=None`이면 전체(무회귀).
+- **list_session_tags**: NULL→"" coalesce + distinct + 정렬; 빈 날 빈 리스트.
+- **flow**: 발견 tag별 리뷰+벤치마크 생성, `""` 항상 포함, 빈 날도 `""` 생성(무회귀), (product,tag) 격리.
+- **benchmark 필터**: tag별 notional만으로 가중(혼합 아님).
+- **UI 라벨**: sessionTag 매핑(""→규칙, llm→LLM) 단위 테스트(프런트 vitest).
+
+## 8. 위험 / 함정
+- **de-mixing 동작 변경**: 기존 `""` 리뷰 숫자가 바뀐다(llm 제외). 의도된 수정이나 명시.
+- **무회귀**: `session_tag=None` 기본 경로(다른 호출자) 불변; 빈 날 `""` 리뷰 항상 생성.
+- **`COALESCE` 일관**: 필터·distinct 양쪽 모두 `COALESCE(session_tag,'')` 동일 적용(NULL/"" 분기 방지).
+- **마이그레이션 없음**(session_tag는 기존 컬럼).
+
+## 9. 산출물 / 완료 기준
+- `list_analytics`/`_rollup_for`/`build_draft` session_tag 필터 + `list_session_tags` + benchmark_runner 필터 + flow tag 순회 + UI 라벨.
+- 테스트 green(rollup 분리, distinct, flow per-tag, benchmark 분리, UI 라벨, 무회귀).
+- 마이그레이션 없음. 전용 비교 컴포넌트는 후속.

--- a/frontend/invest/src/__tests__/DesktopScalpingPage.test.tsx
+++ b/frontend/invest/src/__tests__/DesktopScalpingPage.test.tsx
@@ -1,5 +1,5 @@
 import type { ReactElement } from "react";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { beforeEach, expect, test, vi } from "vitest";
 
@@ -145,6 +145,21 @@ test("ready state renders summary, daily loop, trade table, and actions", async 
   // Action list with status.
   expect(screen.getByText("TP를 40bps로 확대")).toBeInTheDocument();
   expect(screen.getByText("적용됨")).toBeInTheDocument();
+});
+
+test("renders per-session_tag comparison strip with labels", async () => {
+  const ruleReview = { ...REVIEW, id: 1, sessionTag: "", metrics: { ...REVIEW.metrics, netReturnBps: "-10" } };
+  const llmReview = { ...REVIEW, id: 2, sessionTag: "llm", metrics: { ...REVIEW.metrics, netReturnBps: "150" } };
+  vi.spyOn(scalpingApi, "fetchScalpingReviews").mockResolvedValue({ items: [ruleReview, llmReview] });
+  vi.spyOn(scalpingApi, "fetchScalpingReview").mockResolvedValue({ review: ruleReview, actions: [ACTION] });
+  vi.spyOn(scalpingApi, "fetchScalpingTrades").mockResolvedValue({ items: [TRADE_OK] });
+
+  render(wrap(<ScalpingRoute />));
+
+  await waitFor(() => expect(screen.getByTestId("scalping-session-comparison")).toBeInTheDocument());
+  const strip = screen.getByTestId("scalping-session-comparison");
+  expect(within(strip).getByText("규칙")).toBeInTheDocument();
+  expect(within(strip).getByText("LLM")).toBeInTheDocument();
 });
 
 test("null telemetry renders n/a, never 0 or blank", async () => {

--- a/frontend/invest/src/pages/desktop/DesktopScalpingPage.tsx
+++ b/frontend/invest/src/pages/desktop/DesktopScalpingPage.tsx
@@ -34,6 +34,9 @@ const STATUS_LABEL: Record<string, string> = {
   locked: "잠김",
 };
 
+const SESSION_TAG_LABEL: Record<string, string> = { "": "규칙", llm: "LLM" };
+const sessionTagLabel = (tag: string): string => SESSION_TAG_LABEL[tag] ?? tag ?? "규칙";
+
 const ACTION_STATUS_LABEL: Record<string, string> = {
   open: "열림",
   applied: "적용됨",
@@ -78,6 +81,7 @@ export function ScalpingRoute() {
   const [loading, setLoading] = useState(true);
   const [err, setErr] = useState<string | null>(null);
   const [building, setBuilding] = useState(false);
+  const [reviewList, setReviewList] = useState<ScalpingReview[]>([]);
 
   const load = useCallback(async (signal?: AbortSignal) => {
     setLoading(true);
@@ -87,6 +91,7 @@ export function ScalpingRoute() {
         fetchScalpingReviews({ date, product, signal }),
         fetchScalpingTrades({ date, product, signal }),
       ]);
+      setReviewList(reviews.items);
       const found = reviews.items[0] ?? null;
       setReview(found);
       setTrades(tradesResp.items);
@@ -206,13 +211,31 @@ export function ScalpingRoute() {
                 </Card>
               )}
 
+              {/* 1.5 Per-session_tag comparison (LLM vs rule baseline) */}
+              {reviewList.length > 1 && (
+                <Card>
+                  <h2 style={{ margin: "0 0 8px", fontSize: 16 }}>세션별 비교 (LLM vs 규칙)</h2>
+                  <div data-testid="scalping-session-comparison" style={{ display: "grid", gap: 6 }}>
+                    {reviewList.map((r) => (
+                      <div key={r.id} style={{ display: "flex", gap: 12, flexWrap: "wrap", fontSize: 13 }}>
+                        <strong style={{ minWidth: 48 }}>{sessionTagLabel(r.sessionTag)}</strong>
+                        <span style={{ color: "var(--fg-3)" }}>{r.metrics.tradeCount}건</span>
+                        <span style={{ color: "var(--fg-3)" }}>승/패 {r.metrics.winCount}/{r.metrics.lossCount}</span>
+                        <span>net {na(r.metrics.netReturnBps)} bps</span>
+                        <span>순손익 {na(r.metrics.netPnlUsdt)}</span>
+                      </div>
+                    ))}
+                  </div>
+                </Card>
+              )}
+
               {/* 2. Daily loop card */}
               {review && (
                 <Card>
                   <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 8 }}>
                     <h2 style={{ margin: 0, fontSize: 16 }}>실행 → 관측 → 원인 → 개선 → 다음 실행</h2>
                     <span style={{ color: "var(--fg-3)", fontSize: 12 }}>
-                      {STATUS_LABEL[review.status] ?? review.status}
+                      [{sessionTagLabel(review.sessionTag)}] {STATUS_LABEL[review.status] ?? review.status}
                       {exitReasonSummary ? ` · 종료사유: ${exitReasonSummary}` : ""}
                     </span>
                   </div>

--- a/frontend/invest/src/pages/desktop/DesktopScalpingPage.tsx
+++ b/frontend/invest/src/pages/desktop/DesktopScalpingPage.tsx
@@ -35,7 +35,7 @@ const STATUS_LABEL: Record<string, string> = {
 };
 
 const SESSION_TAG_LABEL: Record<string, string> = { "": "규칙", llm: "LLM" };
-const sessionTagLabel = (tag: string): string => SESSION_TAG_LABEL[tag] ?? tag ?? "규칙";
+const sessionTagLabel = (tag: string): string => SESSION_TAG_LABEL[tag] ?? tag;
 
 const ACTION_STATUS_LABEL: Record<string, string> = {
   open: "열림",

--- a/tests/jobs/test_binance_demo_scalping_review.py
+++ b/tests/jobs/test_binance_demo_scalping_review.py
@@ -195,20 +195,40 @@ async def test_flow_builds_per_session_tag(db_session, monkeypatch) -> None:
     monkeypatch.setattr(settings, "binance_demo_scalping_review_flow_enabled", True)
     iid = await _instrument(db_session, "XRPUSDT")
     # 규칙(NULL) 1 + llm 1
-    await _analytics(db_session, iid, tag="r", symbol="XRPUSDT",
-                     entry_price=Decimal("100"), exit_price=Decimal("101"),
-                     entry_notional_usdt=Decimal("100"), net_pnl_usdt=Decimal("0.9"),
-                     gross_pnl_usdt=Decimal("1.0"), net_return_bps=Decimal("90"),
-                     exit_reason="take_profit")
-    await _analytics(db_session, iid, tag="l", symbol="XRPUSDT", session_tag="llm",
-                     entry_price=Decimal("100"), exit_price=Decimal("102"),
-                     entry_notional_usdt=Decimal("100"), net_pnl_usdt=Decimal("1.5"),
-                     gross_pnl_usdt=Decimal("1.6"), net_return_bps=Decimal("150"),
-                     exit_reason="take_profit")
+    await _analytics(
+        db_session,
+        iid,
+        tag="r",
+        symbol="XRPUSDT",
+        entry_price=Decimal("100"),
+        exit_price=Decimal("101"),
+        entry_notional_usdt=Decimal("100"),
+        net_pnl_usdt=Decimal("0.9"),
+        gross_pnl_usdt=Decimal("1.0"),
+        net_return_bps=Decimal("90"),
+        exit_reason="take_profit",
+    )
+    await _analytics(
+        db_session,
+        iid,
+        tag="l",
+        symbol="XRPUSDT",
+        session_tag="llm",
+        entry_price=Decimal("100"),
+        exit_price=Decimal("102"),
+        entry_notional_usdt=Decimal("100"),
+        net_pnl_usdt=Decimal("1.5"),
+        gross_pnl_usdt=Decimal("1.6"),
+        net_return_bps=Decimal("150"),
+        exit_reason="take_profit",
+    )
     md = _FakeMD({"XRPUSDT": (100.0, 101.0)})
     result = await run_demo_scalping_review_refresh(
-        session=db_session, market_data=md, review_date=_DATE,
-        products=("usdm_futures",), now=_NOW,
+        session=db_session,
+        market_data=md,
+        review_date=_DATE,
+        products=("usdm_futures",),
+        now=_NOW,
     )
     assert result["status"] == "ran"
     tags = {s["sessionTag"] for s in result["products"]}
@@ -221,12 +241,17 @@ async def test_flow_builds_per_session_tag(db_session, monkeypatch) -> None:
 
 
 @pytest.mark.asyncio
-async def test_flow_empty_day_still_builds_rule_baseline(db_session, monkeypatch) -> None:
+async def test_flow_empty_day_still_builds_rule_baseline(
+    db_session, monkeypatch
+) -> None:
     monkeypatch.setattr(settings, "binance_demo_scalping_review_flow_enabled", True)
     md = _FakeMD({})
     result = await run_demo_scalping_review_refresh(
-        session=db_session, market_data=md, review_date=_DATE,
-        products=("usdm_futures",), now=_NOW,
+        session=db_session,
+        market_data=md,
+        review_date=_DATE,
+        products=("usdm_futures",),
+        now=_NOW,
     )
     assert [s["sessionTag"] for s in result["products"]] == [""]  # {""} always
     svc = ScalpingReviewService(db_session)

--- a/tests/jobs/test_binance_demo_scalping_review.py
+++ b/tests/jobs/test_binance_demo_scalping_review.py
@@ -142,6 +142,7 @@ async def test_enabled_builds_review_and_benchmark(db_session, monkeypatch) -> N
     [summary] = result["products"]
     assert summary == {
         "product": "usdm_futures",
+        "sessionTag": "",
         "tradeCount": 1,
         "netReturnBps": "90.0000",
         "benchmarkReturnBps": "100.00",  # (101/100-1)*10000 = Decimal('100.00')
@@ -187,3 +188,46 @@ async def test_product_failure_is_isolated(db_session, monkeypatch) -> None:
     assert result["status"] == "ran"
     assert [s["product"] for s in result["products"]] == ["usdm_futures"]
     assert [e["product"] for e in result["errors"]] == ["spot"]
+
+
+@pytest.mark.asyncio
+async def test_flow_builds_per_session_tag(db_session, monkeypatch) -> None:
+    monkeypatch.setattr(settings, "binance_demo_scalping_review_flow_enabled", True)
+    iid = await _instrument(db_session, "XRPUSDT")
+    # 규칙(NULL) 1 + llm 1
+    await _analytics(db_session, iid, tag="r", symbol="XRPUSDT",
+                     entry_price=Decimal("100"), exit_price=Decimal("101"),
+                     entry_notional_usdt=Decimal("100"), net_pnl_usdt=Decimal("0.9"),
+                     gross_pnl_usdt=Decimal("1.0"), net_return_bps=Decimal("90"),
+                     exit_reason="take_profit")
+    await _analytics(db_session, iid, tag="l", symbol="XRPUSDT", session_tag="llm",
+                     entry_price=Decimal("100"), exit_price=Decimal("102"),
+                     entry_notional_usdt=Decimal("100"), net_pnl_usdt=Decimal("1.5"),
+                     gross_pnl_usdt=Decimal("1.6"), net_return_bps=Decimal("150"),
+                     exit_reason="take_profit")
+    md = _FakeMD({"XRPUSDT": (100.0, 101.0)})
+    result = await run_demo_scalping_review_refresh(
+        session=db_session, market_data=md, review_date=_DATE,
+        products=("usdm_futures",), now=_NOW,
+    )
+    assert result["status"] == "ran"
+    tags = {s["sessionTag"] for s in result["products"]}
+    assert tags == {"", "llm"}
+    svc = ScalpingReviewService(db_session)
+    rule = await svc._get_by_key(_DATE, "usdm_futures", "binance_demo", "")
+    llm = await svc._get_by_key(_DATE, "usdm_futures", "binance_demo", "llm")
+    assert rule.trade_count == 1 and llm.trade_count == 1
+    assert llm.benchmark_return_bps is not None  # benchmark per tag stored
+
+
+@pytest.mark.asyncio
+async def test_flow_empty_day_still_builds_rule_baseline(db_session, monkeypatch) -> None:
+    monkeypatch.setattr(settings, "binance_demo_scalping_review_flow_enabled", True)
+    md = _FakeMD({})
+    result = await run_demo_scalping_review_refresh(
+        session=db_session, market_data=md, review_date=_DATE,
+        products=("usdm_futures",), now=_NOW,
+    )
+    assert [s["sessionTag"] for s in result["products"]] == [""]  # {""} always
+    svc = ScalpingReviewService(db_session)
+    assert await svc._get_by_key(_DATE, "usdm_futures", "binance_demo", "") is not None

--- a/tests/services/scalping_reviews/test_service.py
+++ b/tests/services/scalping_reviews/test_service.py
@@ -341,26 +341,61 @@ async def test_set_benchmark_skips_locked_review(db_session) -> None:
 async def test_rollup_separates_by_session_tag(db_session) -> None:
     iid = await _instrument(db_session, "SEPXRPUSDT")
     # 규칙(NULL) 1건 + llm 2건, 같은 날/product
-    await _analytics(db_session, iid, tag="rule1", symbol="SEPXRPUSDT",
-                     entry_price=Decimal("100"), exit_price=Decimal("101"),
-                     entry_notional_usdt=Decimal("100"), net_pnl_usdt=Decimal("0.9"),
-                     gross_pnl_usdt=Decimal("1.0"), net_return_bps=Decimal("90"),
-                     exit_reason="take_profit")
+    await _analytics(
+        db_session,
+        iid,
+        tag="rule1",
+        symbol="SEPXRPUSDT",
+        entry_price=Decimal("100"),
+        exit_price=Decimal("101"),
+        entry_notional_usdt=Decimal("100"),
+        net_pnl_usdt=Decimal("0.9"),
+        gross_pnl_usdt=Decimal("1.0"),
+        net_return_bps=Decimal("90"),
+        exit_reason="take_profit",
+    )
     for i in range(2):
-        await _analytics(db_session, iid, tag=f"llm{i}", symbol="SEPXRPUSDT",
-                         session_tag="llm", entry_price=Decimal("100"),
-                         exit_price=Decimal("102"), entry_notional_usdt=Decimal("100"),
-                         net_pnl_usdt=Decimal("1.5"), gross_pnl_usdt=Decimal("1.6"),
-                         net_return_bps=Decimal("150"), exit_reason="take_profit")
+        await _analytics(
+            db_session,
+            iid,
+            tag=f"llm{i}",
+            symbol="SEPXRPUSDT",
+            session_tag="llm",
+            entry_price=Decimal("100"),
+            exit_price=Decimal("102"),
+            entry_notional_usdt=Decimal("100"),
+            net_pnl_usdt=Decimal("1.5"),
+            gross_pnl_usdt=Decimal("1.6"),
+            net_return_bps=Decimal("150"),
+            exit_reason="take_profit",
+        )
     svc = ScalpingReviewService(db_session)
-    rule_review = await svc.build_draft(review_date=_DATE, product="usdm_futures", now=_NOW, session_tag="")
-    llm_review = await svc.build_draft(review_date=_DATE, product="usdm_futures", now=_NOW, session_tag="llm")
+    rule_review = await svc.build_draft(
+        review_date=_DATE, product="usdm_futures", now=_NOW, session_tag=""
+    )
+    llm_review = await svc.build_draft(
+        review_date=_DATE, product="usdm_futures", now=_NOW, session_tag="llm"
+    )
     assert rule_review.trade_count == 1
     assert llm_review.trade_count == 2
     # list_analytics: None=전체(무회귀), 값=필터
     assert len(await svc.list_analytics(review_date=_DATE, product="usdm_futures")) == 3
-    assert len(await svc.list_analytics(review_date=_DATE, product="usdm_futures", session_tag="")) == 1
-    assert len(await svc.list_analytics(review_date=_DATE, product="usdm_futures", session_tag="llm")) == 2
+    assert (
+        len(
+            await svc.list_analytics(
+                review_date=_DATE, product="usdm_futures", session_tag=""
+            )
+        )
+        == 1
+    )
+    assert (
+        len(
+            await svc.list_analytics(
+                review_date=_DATE, product="usdm_futures", session_tag="llm"
+            )
+        )
+        == 2
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/services/scalping_reviews/test_service.py
+++ b/tests/services/scalping_reviews/test_service.py
@@ -335,3 +335,40 @@ async def test_set_benchmark_skips_locked_review(db_session) -> None:
     )
     assert res is not None and res.status == "locked"
     assert res.benchmark_return_bps is None  # not written while locked
+
+
+@pytest.mark.asyncio
+async def test_rollup_separates_by_session_tag(db_session) -> None:
+    iid = await _instrument(db_session, "SEPXRPUSDT")
+    # 규칙(NULL) 1건 + llm 2건, 같은 날/product
+    await _analytics(db_session, iid, tag="rule1", symbol="SEPXRPUSDT",
+                     entry_price=Decimal("100"), exit_price=Decimal("101"),
+                     entry_notional_usdt=Decimal("100"), net_pnl_usdt=Decimal("0.9"),
+                     gross_pnl_usdt=Decimal("1.0"), net_return_bps=Decimal("90"),
+                     exit_reason="take_profit")
+    for i in range(2):
+        await _analytics(db_session, iid, tag=f"llm{i}", symbol="SEPXRPUSDT",
+                         session_tag="llm", entry_price=Decimal("100"),
+                         exit_price=Decimal("102"), entry_notional_usdt=Decimal("100"),
+                         net_pnl_usdt=Decimal("1.5"), gross_pnl_usdt=Decimal("1.6"),
+                         net_return_bps=Decimal("150"), exit_reason="take_profit")
+    svc = ScalpingReviewService(db_session)
+    rule_review = await svc.build_draft(review_date=_DATE, product="usdm_futures", now=_NOW, session_tag="")
+    llm_review = await svc.build_draft(review_date=_DATE, product="usdm_futures", now=_NOW, session_tag="llm")
+    assert rule_review.trade_count == 1
+    assert llm_review.trade_count == 2
+    # list_analytics: None=전체(무회귀), 값=필터
+    assert len(await svc.list_analytics(review_date=_DATE, product="usdm_futures")) == 3
+    assert len(await svc.list_analytics(review_date=_DATE, product="usdm_futures", session_tag="")) == 1
+    assert len(await svc.list_analytics(review_date=_DATE, product="usdm_futures", session_tag="llm")) == 2
+
+
+@pytest.mark.asyncio
+async def test_list_session_tags_distinct_coalesced(db_session) -> None:
+    iid = await _instrument(db_session, "TAGXRPUSDT")
+    await _analytics(db_session, iid, tag="n", symbol="TAGXRPUSDT")  # NULL → ""
+    await _analytics(db_session, iid, tag="l1", symbol="TAGXRPUSDT", session_tag="llm")
+    await _analytics(db_session, iid, tag="l2", symbol="TAGXRPUSDT", session_tag="llm")
+    svc = ScalpingReviewService(db_session)
+    tags = await svc.list_session_tags(review_date=_DATE, product="usdm_futures")
+    assert tags == ["", "llm"]


### PR DESCRIPTION
## 목적

D-PR1(#1346)로 LLM 데모 트레이드는 `scalp_trade_analytics.session_tag="llm"`로 태깅된다. 그러나 일별 리뷰/벤치마크 생성이 `session_tag` 필터가 없어 **규칙(NULL)+llm 트레이드를 한 리뷰 행에 혼합 집계**했다(latent — 트레이드가 전부 NULL이던 D-PR1 이전엔 무해). 결과적으로 "LLM이 규칙 baseline을 이기나"를 측정할 수 없었다. 이 PR이 리뷰/벤치마크를 **session_tag별로 분리 생성**해 `/invest/scalping`에서 LLM vs 규칙을 나란히 비교 가능하게 한다.

- spec: `docs/superpowers/specs/2026-06-22-binance-demo-scalping-review-comparison-design.md`
- plan: `docs/superpowers/plans/2026-06-22-binance-demo-scalping-review-comparison.md`

## 변경

- **rollup session_tag 분리** — `list_analytics(*, session_tag: str | None = None)`에 `COALESCE(session_tag,'')` 필터(`None`=전체→무회귀), `_rollup_for`/`build_draft`가 자기 session_tag로 집계, `list_session_tags` distinct 신규.
- **benchmark 분리** — `compute_and_store_daily_benchmark`가 tag별 analytics로 buy&hold 계산.
- **flow tag 순회** — 일별 flow가 product마다 `{""} ∪ distinct tags` 순회(규칙 baseline 항상 포함), (product, tag)별 리뷰+벤치마크 생성, per-(product, tag) SAVEPOINT 격리.
- **프런트** — `/invest/scalping`: `SESSION_TAG_LABEL`(""→규칙/llm→LLM) + 전 tag 비교 strip(net bps·순손익 나란히) + 일별 카드 tag 라벨 + `list_reviews` 결정적 정렬(hero 카드=규칙 baseline).

## 동작 변경 (de-mixing, 의도됨)

기존 `""` 리뷰는 rule+llm 혼합이었으나 이제 **rule(NULL/"")만** 집계. 측정 정확화가 목적. `COALESCE(session_tag,'')`로 스케줄러 NULL과 리뷰 `""` baseline을 정합.

## 안전 / 무회귀

- **무회귀**: `list_analytics` 기본 `None`(필터 없음, 전체) → 트레이드 테이블 등 기존 호출자 보존(검증됨). flow `{""}` 항상 포함 → 빈 날도 규칙 baseline 생성.
- 데모 전용 / 주문·브로커 mutation 없음. 마이그레이션 없음(`session_tag`는 기존 컬럼).

## 테스트 / 리뷰

- 신규: rollup 분리(None=전체/""=rule/llm 분리), `list_session_tags` distinct, flow per-tag+빈날 `[""]`, 프런트 비교 strip 라벨. 백엔드 스코프 회귀 **547 passed**, ruff/ty clean, 프런트 vitest+tsc green.
- Subagent-Driven 3태스크(구현→리뷰→수정) + **opus 전체 브랜치 최종 리뷰: Ready to merge (Yes)**. 0 Critical/Important.
- Follow-up(non-blocking): per-(product,tag) tag-실패 격리 전용 테스트(SAVEPOINT 코드는 검증됨).

## Operator (머지 후)

추가 조치 없음 — 다음 일별 리뷰 flow 실행 시 자동으로 tag별 리뷰가 생성된다. (LLM 트레이드가 있어야 "llm" 행이 나타남.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0115yvcHYpLv3aLeKJ36Bo9w

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Daily scalping reviews now separate by session type (rules vs LLM strategies)
  * Added per-session comparison card displaying trade counts and metrics
  * Session labels now displayed on daily loop status

* **Documentation**
  * Added implementation plan and design specification for session-based review comparison

* **Tests**
  * Extended test coverage for per-session rollups and comparison UI rendering

<!-- end of auto-generated comment: release notes by coderabbit.ai -->