### PR TITLE
fix(ROB-625): dry_run 매수 잔액부족 차단 일원화 + KIS 필드 진단 breakdown [HOLD]

### DIFF
--- a/app/mcp_server/README.md
+++ b/app/mcp_server/README.md
@@ -400,6 +400,14 @@ official KIS mock, and KIS live account paths:
   Toss stock warnings before order submission; active `LIQUIDATION_TRADING`
   blocks non-dry-run buys before KIS POST, while lookup failures are fail-open
   and surfaced in the response metadata.
+- **Buy balance pre-check (ROB-625)**: For `side="buy"`, both `dry_run=True` and
+  `dry_run=False` apply the *same* orderable-cash pre-check against the shared
+  `get_cash_balance` source. Insufficient balance returns `success=false` with an
+  `insufficient_balance: true` flag and an `insufficient_balance_detail` block
+  (`balance`, `order_amount`, `currency`, `shortfall`, and — for US — a KIS field
+  `breakdown` exposing `frcr_dncl_amt1`/`frcr_gnrl_ord_psbl_amt`). On `dry_run=True`
+  the preview body (estimated value, fee) is still returned so the operator can
+  size a deposit. This closes the prior "dry_run passes → live rejects" gap.
 - `account_mode="toss_live"`: official Toss Securities live KR/US account. Uses Toss credentials, maps to `toss_live` routing, and fails closed when `TOSS_API_ENABLED=false` or credentials are missing. Actual Toss order mutation POSTs also require `TOSS_LIVE_ORDER_MUTATIONS_ENABLED=true`; keep this false until the accepted-order ledger and operator live-smoke hold are cleared.
 
 Do not use `account_type="paper"` for official KIS mock. It is always DB
@@ -1152,10 +1160,10 @@ Broker-specific contract:
   - `formatted`: formatted total KRW string (e.g. `"700,000 KRW"`)
 - **KIS domestic (`account="kis_domestic"`)**
   - `balance`: `stck_cash_objt_amt` (`intgr-margin`)
-  - `orderable`: domestic integrated-margin orderable minus pending KR buy-order notional; if pending-order lookup fails, raw KIS orderable is returned; result is clamped at `0.0`
+  - `orderable`: domestic integrated-margin orderable (`stck_cash100_max_ord_psbl_amt`). ROB-596: this KIS field already nets accepted-but-unfilled buy orders in real time, so pending buys are **not** subtracted again (no double-count). It is the single source shared by `get_available_capital` and the `place_order` KRW buy pre-check.
 - **KIS overseas (`account="kis_overseas"`)**
   - `balance`: USD cash balance (`frcr_dncl_amt1` fallback `frcr_dncl_amt_2`)
-  - `orderable`: USD orderable cash minus pending US buy-order notional; if pending-order lookup fails, raw KIS orderable is returned; result is clamped at `0.0`
+  - `orderable`: USD orderable cash (`frcr_gnrl_ord_psbl_amt`). ROB-596: this KIS field already nets accepted-but-unfilled buy orders in real time, so pending buys are **not** subtracted again (no double-count). It is the single source shared by `get_available_capital` and the `place_order` USD buy pre-check.
 - **Toss (`account="toss"`, only when `TOSS_API_ENABLED=true`)**
   - `balance`: Toss buying power for the row currency
   - `orderable`: `0.0`; Toss portfolio integration is read-only in ROB-532, while order mutation tools are delivered separately

--- a/app/mcp_server/tooling/order_execution.py
+++ b/app/mcp_server/tooling/order_execution.py
@@ -632,6 +632,23 @@ def _build_dry_run_response(
     return result
 
 
+def _build_dry_run_blocked_response(
+    dry_run_result: dict[str, Any],
+    balance_error: dict[str, Any],
+) -> dict[str, Any]:
+    """ROB-625 — dry_run 잔액부족 차단 응답.
+
+    live와 동일하게 success=False로 차단하되, 프리뷰 본문(estimated_value/fee 등)을
+    유지해 운영자가 입금액을 산정할 수 있게 한다. ``balance_error`` 가 success/error/
+    insufficient_balance(_detail) 차단 플래그를 덮어쓰도록 뒤에 병합한다.
+    """
+    return {
+        **dry_run_result,
+        **balance_error,
+        "dry_run": True,
+    }
+
+
 async def _execute_and_record(
     *,
     normalized_symbol: str,
@@ -1065,6 +1082,7 @@ async def _place_order_impl(
 
         # Balance pre-check for buy orders
         balance_warning: str | None = None
+        balance_error: dict[str, Any] | None = None
         if side_lower == "buy":
             balance_warning, balance_error = await _check_balance_and_warn(
                 market_type=market_type,
@@ -1075,8 +1093,14 @@ async def _place_order_impl(
                 order_error_fn=_order_error,
                 is_mock=is_mock,
             )
-            if balance_error is not None:
-                return balance_error
+
+        if balance_error is not None:
+            # ROB-625 — dry_run도 잔액부족을 차단하되 프리뷰 본문은 유지한다.
+            # (dry_run에서 balance_error가 set되는 경우는 잔액부족 분기뿐: mock 미지원/
+            #  조회불가 등은 (warning, None)으로 반환되어 balance_warning 경로로 빠진다.)
+            if dry_run:
+                return _build_dry_run_blocked_response(dry_run_result, balance_error)
+            return balance_error
 
         # Dry-run exit
         if dry_run:

--- a/app/mcp_server/tooling/order_validation.py
+++ b/app/mcp_server/tooling/order_validation.py
@@ -486,17 +486,68 @@ async def _get_holdings_for_order(
 
 
 async def _live_kis_orderable(account_token: str) -> float:
-    """live KIS 예약-차감 orderable (단일 소스 = get_available_capital의 소스).
+    """live KIS 주문가능(orderable) — 단일 소스 = get_available_capital의 소스.
 
     ``account_token``: "kis_domestic" (KRW) | "kis_overseas" (USD).
-    ``get_cash_balance_impl``이 raw orderable에서 대기주문 예약을 차감(실패 시 raw
-    fallback)하므로 precheck가 get_available_capital과 동일 orderable을 본다.
+    ROB-596 이후 ``get_cash_balance_impl``은 브로커 주문가능 필드(이미 미체결 매수를
+    net한 실시간 값)를 추가 차감 없이 그대로 반환한다(double-count 방지). 따라서
+    precheck가 get_available_capital과 동일한 orderable을 본다.
     """
     result = await get_cash_balance_impl(account=account_token, is_mock=False)
     for acc in result.get("accounts", []):
         if acc.get("account") == account_token:
             return float(acc.get("orderable") or 0.0)
     raise RuntimeError(f"{account_token} orderable not found in cash balance")
+
+
+async def _live_kis_balance_breakdown(
+    market_type: str, orderable: float
+) -> dict[str, Any] | None:
+    """ROB-625 — 잔액부족 에러 진단용 KIS 필드 breakdown (read-only, graceful).
+
+    cash(현금)와 orderable(주문가능)이 어느 KIS 필드에서 왔는지, 둘 중 무엇이 주문을
+    막았는지 운영자가 에러메시지만으로 판별하게 한다. equity_us 우선 구현(ROB-625
+    재현 케이스). 조회 실패/미지원이면 ``None`` 을 반환해 잔액체크 자체는 절대 막지
+    않는다. 잔액부족 에러 경로에서만 1회 호출되므로 추가 조회 비용은 무시 가능.
+
+    ``orderable`` 은 차단 결정에 이미 쓰인 값을 그대로 받아 breakdown에 노출한다.
+    재조회 스냅샷에서 다시 읽지 않으므로, 한 에러 detail 안에서 결정값(balance)과
+    breakdown의 orderable이 race로 어긋나는 일이 없다.
+    """
+    if market_type != "equity_us":
+        return None
+    try:
+        result = await get_cash_balance_impl(account="kis_overseas", is_mock=False)
+    except Exception as exc:  # graceful: 진단 실패가 주문 가드를 깨면 안 됨
+        logger.warning("balance breakdown 조회 실패 (graceful degrade): %s", exc)
+        return None
+    for acc in result.get("accounts", []):
+        if acc.get("account") == "kis_overseas":
+            return {
+                # cash는 frcr_dncl_amt1 우선, 없으면 frcr_dncl_amt_2 폴백이라 값의
+                # 출처를 단정할 수 없으므로 라벨에 두 필드를 모두 명시한다.
+                "cash_balance": acc.get("balance"),
+                "cash_field": "frcr_dncl_amt1/frcr_dncl_amt_2",
+                "orderable": orderable,
+                "orderable_field": "frcr_gnrl_ord_psbl_amt",
+                "source": "kis_overseas.inquire_overseas_margin",
+            }
+    return None
+
+
+def _format_balance_breakdown_suffix(breakdown: dict[str, Any], currency: str) -> str:
+    """ROB-625 — KIS 필드 breakdown을 사람이 읽을 에러 접미사로 변환."""
+    value_fmt = "{:,.2f}" if currency == "USD" else "{:,.0f}"
+
+    def _fmt(value: Any) -> str:
+        return value_fmt.format(value) if isinstance(value, (int, float)) else "unknown"
+
+    return (
+        " KIS field breakdown: "
+        f"cash_balance({breakdown['cash_field']})={_fmt(breakdown.get('cash_balance'))}, "
+        f"orderable({breakdown['orderable_field']})={_fmt(breakdown.get('orderable'))}, "
+        f"source={breakdown['source']}."
+    )
 
 
 async def _get_balance_for_order(market_type: str, is_mock: bool = False) -> float:
@@ -515,12 +566,14 @@ async def _get_balance_for_order(market_type: str, is_mock: bool = False) -> flo
                 is_mock=is_mock,
             )
             return float(cash_summary.get("stck_cash_ord_psbl_amt") or 0)
-        # ROB-419 — live: reservation-aware orderable (== get_available_capital),
-        # so pending-order cash reservations are not treated as spendable.
+        # ROB-419/596 — live: broker orderable via the single source
+        # (== get_available_capital). ROB-596 removed the extra pending-buy
+        # subtraction; the broker field is already net (no double-count).
         return await _live_kis_orderable("kis_domestic")
 
     if not is_mock:
-        # ROB-419 — live US: reservation-aware orderable via the single source.
+        # ROB-419/596 — live US: broker orderable via the single source
+        # (already net of pending buys; no extra subtraction).
         return await _live_kis_orderable("kis_overseas")
 
     # mock US: KIS 모의투자엔 해외 orderable-cash 서비스가 없음(OPSQ0002). ROB-417
@@ -1117,6 +1170,17 @@ async def _check_balance_and_warn(
         order_amount,
     )
 
+    # ROB-625 Phase 3 — 진단 가시성: 어떤 KIS 필드가 주문을 막았는지(cash vs orderable)
+    # 노출한다. equity_us 우선, graceful None. live 경로에서만 의미가 있으므로
+    # is_mock 이면 생략한다.
+    breakdown = None
+    if not is_mock:
+        breakdown = await _live_kis_balance_breakdown(market_type, balance)
+
+    currency = {"crypto": "KRW", "equity_kr": "KRW", "equity_us": "USD"}.get(
+        market_type, "USD"
+    )
+
     messages = {
         "crypto": (
             f"Insufficient KRW balance: {balance:,.0f} KRW < {order_amount:,.0f} KRW. "
@@ -1131,8 +1195,24 @@ async def _check_balance_and_warn(
             "Please deposit USD to your KIS overseas account, then retry."
         ),
     }
-    warning = messages.get(market_type, messages["equity_us"])
+    message = messages.get(market_type, messages["equity_us"])
+    if breakdown is not None:
+        message += _format_balance_breakdown_suffix(breakdown, currency)
 
-    if not dry_run:
-        return None, order_error_fn(warning)
-    return warning, None
+    # ROB-625 Phase 2 — dry_run도 live와 동일하게 잔액부족을 차단한다("dry_run 통과 →
+    # live 거부" 갭 제거). 차단 플래그 + 구조화된 detail을 첨부하고, 호출자
+    # (order_execution)가 dry_run이면 프리뷰 본문을 함께 유지해 운영자가 입금액을
+    # 산정할 수 있게 한다. (mock 미지원/조회불가 등 다른 dry_run 경고 경로는 위에서
+    # 이미 (warning, None)으로 반환되어 이 분기에 도달하지 않는다.)
+    error = order_error_fn(message)
+    error["insufficient_balance"] = True
+    detail: dict[str, Any] = {
+        "balance": balance,
+        "order_amount": order_amount,
+        "currency": currency,
+        "shortfall": max(0.0, order_amount - balance),
+    }
+    if breakdown is not None:
+        detail["breakdown"] = breakdown
+    error["insufficient_balance_detail"] = detail
+    return None, error

--- a/tests/test_mcp_place_order.py
+++ b/tests/test_mcp_place_order.py
@@ -320,14 +320,13 @@ async def test_place_order_insufficient_balance_upbit(monkeypatch):
         dry_run=True,
     )
 
-    assert result["success"] is True, (
-        f"Expected success=True with warning, got {result}"
-    )
+    # ROB-625: dry_run도 잔액부족을 차단(success=False)하되 프리뷰 본문은 유지한다.
+    assert result["success"] is False, result
     assert result["dry_run"] is True
-    assert "warning" in result
-    assert "Insufficient" in result["warning"]
-    assert "deposit" in result["warning"].lower()
-    assert "Upbit" in result["warning"]
+    assert result["insufficient_balance"] is True
+    assert "Insufficient" in result["error"]
+    assert "deposit" in result["error"].lower()
+    assert "Upbit" in result["error"]
 
 
 @pytest.mark.asyncio
@@ -378,11 +377,12 @@ async def test_place_order_insufficient_balance_kis_domestic(monkeypatch):
         dry_run=True,
     )
 
-    assert result["success"] is True
+    # ROB-625: dry_run도 잔액부족을 차단한다 (equity_kr breakdown은 US-우선이라 생략).
+    assert result["success"] is False, result
     assert result["dry_run"] is True
-    assert "warning" in result
-    assert "Insufficient" in result["warning"]
-    assert "KIS domestic account" in result["warning"]
+    assert result["insufficient_balance"] is True
+    assert "Insufficient" in result["error"]
+    assert "KIS domestic account" in result["error"]
 
 
 @pytest.mark.asyncio
@@ -481,13 +481,16 @@ async def test_place_order_insufficient_balance_kis_overseas(monkeypatch):
         dry_run=True,
     )
 
-    assert result["success"] is True
+    # ROB-625: dry_run도 잔액부족을 차단(success=False)하고, Phase 3 KIS 필드
+    # breakdown을 에러메시지에 노출한다.
+    assert result["success"] is False, result
     assert result["dry_run"] is True
-    assert "warning" in result
-    assert "Insufficient" in result["warning"]
-    assert "KIS overseas account" in result["warning"]
-    assert "deposit" in result["warning"].lower()
-    assert "100.00 USD < 500.00 USD" in result["warning"]
+    assert result["insufficient_balance"] is True
+    assert "Insufficient" in result["error"]
+    assert "KIS overseas account" in result["error"]
+    assert "deposit" in result["error"].lower()
+    assert "100.00 USD < 500.00 USD" in result["error"]
+    assert "frcr_gnrl_ord_psbl_amt" in result["error"]
 
 
 # ----------------------------------------------------------------------
@@ -578,10 +581,11 @@ async def test_place_order_us_uses_frcr_gnrl_orderable_when_ord1_is_zero(monkeyp
         dry_run=True,
     )
 
-    assert result["success"] is True
+    # ROB-625: dry_run 잔액부족 차단. ord1=0이어도 frcr_gnrl_ord_psbl_amt로 판단.
+    assert result["success"] is False, result
     assert result["dry_run"] is True
-    assert "warning" in result
-    assert "100.00 USD < 500.00 USD" in result["warning"]
+    assert result["insufficient_balance"] is True
+    assert "100.00 USD < 500.00 USD" in result["error"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_order_live_precheck_reservation.py
+++ b/tests/test_order_live_precheck_reservation.py
@@ -1,4 +1,10 @@
-"""ROB-419 — live buy precheck uses reservation-aware orderable (== get_available_capital)."""
+"""live buy precheck uses the shared broker orderable (== get_available_capital).
+
+ROB-419 introduced the single-source precheck; ROB-596 then removed the extra
+pending-buy subtraction (the broker orderable field is already net), so the
+precheck reads the raw broker orderable. These tests assert the precheck reads
+that shared ``orderable`` field — the "reservation" names are historical.
+"""
 
 from __future__ import annotations
 
@@ -67,7 +73,7 @@ async def test_live_us_buy_blocked_when_orderable_reserved_to_zero(monkeypatch):
 
     monkeypatch.setattr(order_validation, "get_cash_balance_impl", fake_cash)
 
-    # dry_run: insufficient warning (no error, preview still returned upstream).
+    # ROB-625: dry_run도 잔액부족이면 차단(error 반환)한다. 이전엔 (warning, None).
     warning, error = await _check_balance_and_warn(
         market_type="equity_us",
         normalized_symbol="MSFT",
@@ -77,8 +83,11 @@ async def test_live_us_buy_blocked_when_orderable_reserved_to_zero(monkeypatch):
         order_error_fn=_order_error,
         is_mock=False,
     )
-    assert error is None
-    assert warning is not None and "Insufficient" in warning
+    assert warning is None
+    assert error is not None
+    assert error["success"] is False
+    assert error["insufficient_balance"] is True
+    assert "Insufficient" in error["error"]
 
     # non-dry_run: hard error.
     warning2, error2 = await _check_balance_and_warn(

--- a/tests/test_rob625_dry_run_balance_block.py
+++ b/tests/test_rob625_dry_run_balance_block.py
@@ -1,0 +1,306 @@
+"""ROB-625 — dry_run 잔액부족 일원화 + 진단 breakdown.
+
+Phase 2: dry_run=True 매수도 잔액부족이면 live와 동일하게 차단(success=False)하되,
+프리뷰 본문(estimated_value 등)은 유지하고 구조화된 차단 플래그를 첨부한다.
+Phase 3: equity_us 잔액부족 에러에 KIS 필드 breakdown
+(frcr_dncl_amt1 / frcr_gnrl_ord_psbl_amt / source)을 노출한다.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.mcp_server.tooling import order_validation
+from app.mcp_server.tooling.order_validation import _check_balance_and_warn
+from tests._mcp_tooling_support import _patch_runtime_attr, build_tools
+
+
+def _order_error(message: str) -> dict:
+    return {"success": False, "error": message}
+
+
+def _fake_preview(payload: dict):
+    async def _preview(*args, **kwargs):
+        return dict(payload)
+
+    return _preview
+
+
+def _fake_overseas_cash(balance: float, orderable: float):
+    async def fake_cash(account=None, *, is_mock=False):
+        return {
+            "accounts": [
+                {
+                    "account": "kis_overseas",
+                    "currency": "USD",
+                    "balance": balance,
+                    "orderable": orderable,
+                }
+            ]
+        }
+
+    return fake_cash
+
+
+# ---------------------------------------------------------------------------
+# Phase 2 — dry_run blocks insufficient balance (preview retained upstream)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_check_balance_dry_run_insufficient_returns_error(monkeypatch):
+    """dry_run=True equity_us 잔액부족 → (None, error) 반환 (이전엔 (warning, None))."""
+    monkeypatch.setattr(
+        order_validation, "get_cash_balance_impl", _fake_overseas_cash(84.09, 75.22)
+    )
+
+    warning, error = await _check_balance_and_warn(
+        market_type="equity_us",
+        normalized_symbol="ADSK",
+        side="buy",
+        order_amount=184.0,
+        dry_run=True,
+        order_error_fn=_order_error,
+        is_mock=False,
+    )
+
+    assert warning is None
+    assert error is not None
+    assert error["success"] is False
+    assert error["insufficient_balance"] is True
+    assert "Insufficient USD balance" in error["error"]
+
+
+@pytest.mark.asyncio
+async def test_check_balance_live_insufficient_unchanged(monkeypatch):
+    """live(dry_run=False) 잔액부족은 기존대로 hard error."""
+    monkeypatch.setattr(
+        order_validation, "get_cash_balance_impl", _fake_overseas_cash(84.09, 75.22)
+    )
+
+    warning, error = await _check_balance_and_warn(
+        market_type="equity_us",
+        normalized_symbol="ADSK",
+        side="buy",
+        order_amount=184.0,
+        dry_run=False,
+        order_error_fn=_order_error,
+        is_mock=False,
+    )
+
+    assert warning is None
+    assert error is not None
+    assert error["success"] is False
+    assert error["insufficient_balance"] is True
+
+
+@pytest.mark.asyncio
+async def test_check_balance_sufficient_passes(monkeypatch):
+    """충분 잔액은 dry_run/live 무관하게 통과 (None, None)."""
+    monkeypatch.setattr(
+        order_validation, "get_cash_balance_impl", _fake_overseas_cash(500.0, 500.0)
+    )
+
+    warning, error = await _check_balance_and_warn(
+        market_type="equity_us",
+        normalized_symbol="ADSK",
+        side="buy",
+        order_amount=184.0,
+        dry_run=True,
+        order_error_fn=_order_error,
+        is_mock=False,
+    )
+
+    assert warning is None
+    assert error is None
+
+
+# ---------------------------------------------------------------------------
+# Phase 3 — KIS field breakdown in the insufficient-balance error
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_check_balance_error_includes_kis_field_breakdown(monkeypatch):
+    """equity_us 잔액부족 에러에 cash/orderable KIS 필드명 + 값 노출."""
+    monkeypatch.setattr(
+        order_validation, "get_cash_balance_impl", _fake_overseas_cash(84.09, 75.22)
+    )
+
+    _, error = await _check_balance_and_warn(
+        market_type="equity_us",
+        normalized_symbol="ADSK",
+        side="buy",
+        order_amount=184.0,
+        dry_run=False,
+        order_error_fn=_order_error,
+        is_mock=False,
+    )
+
+    assert error is not None
+    # human-readable message carries the field names for at-a-glance triage.
+    assert "frcr_dncl_amt1" in error["error"]
+    assert "frcr_gnrl_ord_psbl_amt" in error["error"]
+
+    detail = error["insufficient_balance_detail"]
+    assert detail["balance"] == pytest.approx(75.22)
+    assert detail["order_amount"] == pytest.approx(184.0)
+    assert detail["currency"] == "USD"
+    assert detail["shortfall"] == pytest.approx(184.0 - 75.22)
+
+    breakdown = detail["breakdown"]
+    assert breakdown["cash_balance"] == pytest.approx(84.09)
+    # cash는 frcr_dncl_amt1 우선 / frcr_dncl_amt_2 폴백 — 라벨에 둘 다 명시.
+    assert breakdown["cash_field"] == "frcr_dncl_amt1/frcr_dncl_amt_2"
+    assert breakdown["orderable"] == pytest.approx(75.22)
+    # breakdown의 orderable == 차단 결정에 쓰인 balance (재조회 race 모순 방지).
+    assert breakdown["orderable"] == detail["balance"]
+    assert breakdown["orderable_field"] == "frcr_gnrl_ord_psbl_amt"
+    assert breakdown["source"] == "kis_overseas.inquire_overseas_margin"
+
+
+@pytest.mark.asyncio
+async def test_check_balance_crypto_insufficient_no_breakdown(monkeypatch):
+    """crypto는 breakdown 없이도 정상 차단된다 (equity_us-우선 구현)."""
+
+    class FakeUpbit:
+        async def fetch_my_coins(self):
+            return [{"currency": "KRW", "balance": 1000.0}]
+
+    monkeypatch.setattr(order_validation, "upbit_service", FakeUpbit())
+
+    _, error = await _check_balance_and_warn(
+        market_type="crypto",
+        normalized_symbol="KRW-BTC",
+        side="buy",
+        order_amount=50000.0,
+        dry_run=True,
+        order_error_fn=_order_error,
+        is_mock=False,
+    )
+
+    assert error is not None
+    assert error["insufficient_balance"] is True
+    assert "breakdown" not in error["insufficient_balance_detail"]
+
+
+@pytest.mark.asyncio
+async def test_check_balance_breakdown_graceful_when_lookup_fails(monkeypatch):
+    """breakdown 조회 실패 시 balance만 사용, 차단은 그대로 동작(graceful degrade)."""
+
+    call = {"n": 0}
+
+    async def flaky_cash(account=None, *, is_mock=False):
+        call["n"] += 1
+        # 1st call (balance read) succeeds; 2nd call (breakdown re-fetch) fails.
+        if call["n"] == 1:
+            return {
+                "accounts": [
+                    {"account": "kis_overseas", "currency": "USD", "orderable": 75.22}
+                ]
+            }
+        raise RuntimeError("breakdown lookup boom")
+
+    monkeypatch.setattr(order_validation, "get_cash_balance_impl", flaky_cash)
+
+    _, error = await _check_balance_and_warn(
+        market_type="equity_us",
+        normalized_symbol="ADSK",
+        side="buy",
+        order_amount=184.0,
+        dry_run=False,
+        order_error_fn=_order_error,
+        is_mock=False,
+    )
+
+    assert error is not None
+    assert error["insufficient_balance"] is True
+    # breakdown unavailable → omitted, but the block still carries the scalars.
+    assert "breakdown" not in error["insufficient_balance_detail"]
+    assert error["insufficient_balance_detail"]["balance"] == pytest.approx(75.22)
+
+
+@pytest.mark.asyncio
+async def test_check_balance_breakdown_none_when_account_missing(monkeypatch):
+    """breakdown 재조회 결과에 kis_overseas 계정이 없으면 None (graceful), 차단은 유지."""
+
+    call = {"n": 0}
+
+    async def cash(account=None, *, is_mock=False):
+        call["n"] += 1
+        if call["n"] == 1:
+            # balance read for the block decision.
+            return {
+                "accounts": [
+                    {"account": "kis_overseas", "currency": "USD", "orderable": 75.22}
+                ]
+            }
+        # breakdown re-fetch: matching account absent → helper returns None.
+        return {"accounts": []}
+
+    monkeypatch.setattr(order_validation, "get_cash_balance_impl", cash)
+
+    _, error = await _check_balance_and_warn(
+        market_type="equity_us",
+        normalized_symbol="ADSK",
+        side="buy",
+        order_amount=184.0,
+        dry_run=False,
+        order_error_fn=_order_error,
+        is_mock=False,
+    )
+
+    assert error is not None
+    assert error["insufficient_balance"] is True
+    assert "breakdown" not in error["insufficient_balance_detail"]
+
+
+# ---------------------------------------------------------------------------
+# Phase 2 — caller keeps the dry_run preview body on the blocked response
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_place_order_dry_run_insufficient_keeps_preview_body(monkeypatch):
+    """dry_run 매수 잔액부족 → success=False지만 프리뷰 본문 + breakdown 유지."""
+    tools = build_tools()
+
+    class DummyKISClient:
+        async def inquire_overseas_margin(self):
+            return [
+                {
+                    "natn_name": "미국",
+                    "crcy_cd": "USD",
+                    "frcr_dncl_amt1": "84.09",
+                    "frcr_gnrl_ord_psbl_amt": "75.22",
+                }
+            ]
+
+    _patch_runtime_attr(monkeypatch, "KISClient", DummyKISClient)
+    _patch_runtime_attr(
+        monkeypatch,
+        "_preview_order",
+        # AsyncMock-free: a plain coroutine keeps the marker field deterministic.
+        _fake_preview(
+            {"estimated_value": 184.0, "fee": 0.09, "preview_marker": "kept"}
+        ),
+    )
+
+    result = await tools["place_order"](
+        symbol="ADSK",
+        side="buy",
+        order_type="limit",
+        quantity=1,
+        price=184.0,
+        dry_run=True,
+    )
+
+    assert result["success"] is False
+    assert result["dry_run"] is True
+    assert result["insufficient_balance"] is True
+    assert "Insufficient USD balance" in result["error"]
+    # preview body retained so the operator can size a deposit.
+    assert result["estimated_value"] == pytest.approx(184.0)
+    assert result["preview_marker"] == "kept"
+    # Phase 3 breakdown surfaced in the error message.
+    assert "frcr_gnrl_ord_psbl_amt" in result["error"]


### PR DESCRIPTION
## ⚠️ HOLD — DO NOT MERGE/DEPLOY (live order boundary)

`high_risk_change` · `needs_stronger_model_review` · `hold_for_final_review`.
`kis_live_place_order` 사전 잔액체크(live order boundary)를 변경하므로 **CTO/Opus 최종 리뷰 전 merge/deploy/live 실행 금지**. Draft 상태 유지.

Linear: [ROB-625](https://linear.app/mgh3326/issue/ROB-625) · follow-up [ROB-627](https://linear.app/mgh3326/issue/ROB-627)

## 검증 결론: 헤드라인 false-reject는 HEAD에서 ROB-596이 이미 코드수정 (= 배포 문제)

다른 세션 플랜(`.omo/plans/rob-625-plan.md`)을 4-에이전트 코드추적 + 적대 판정 워크플로로 검증한 결과:

- ADSK $184 거부의 헤드라인 버그는 **ROB-596(`b603b6eb`, PR #1336, HEAD 포함)이 이미 제거**. precheck `_live_kis_orderable`는 `get_available_capital`과 **동일 `get_cash_balance_impl` / 동일 `frcr_gnrl_ord_psbl_amt`**(브로커 net 필드)를 읽으며 추가 차감하지 않음 → ADSK는 `$193.72 ≥ $184` → **통과**.
- 보고된 `$75.22`는 **삭제된 공식 `max(0, raw − pending)`으로만** 재현됨 (`193.72 − 118.5 PLTR = 75.22`); 2차 재현 BSX `$0.00`도 동일 floor. ⇒ **2026-06-22/23 prod는 ROB-596 미배포 구버전을 돌렸을 가능성 매우 높음**.
- 보고된 "$312 vs $193"은 코드 divergence가 아니라 같은 필드의 PLTR 매수 전/후 **타이밍 아티팩트**.

➡️ 본 PR은 헤드라인 fix가 아니라 **잔여 갭(dry_run 일원화 + 진단 + 문서)**을 메운다.

## 변경 내용

### Phase 2 — dry_run 잔액부족 차단 일원화
`side="buy"`의 dry_run도 live와 **동일 precheck**로 차단(`success=false`)하되, **프리뷰 본문(estimated_value/fee) 유지** + `insufficient_balance: true` + `insufficient_balance_detail`(`balance`/`order_amount`/`currency`/`shortfall`/`breakdown`). "dry_run 통과 → live 거부" 갭 제거. (전 마켓 crypto/KR/US 적용. mock 미지원/조회불가 등 기존 dry_run 경고 경로는 `(warning, None)`으로 보존 → `_build_dry_run_response`/`balance_warning` 유지.)

### Phase 3 — 잔액부족 에러 진단 가시성 (equity_us 우선)
에러 메시지/`detail.breakdown`에 KIS 필드 노출: `cash(frcr_dncl_amt1/frcr_dncl_amt_2)`, `orderable(frcr_gnrl_ord_psbl_amt)`, `source`. `_get_balance_for_order` **float 시그니처 유지(low-churn)**, graceful `None`, breakdown의 `orderable`은 차단 결정값을 재사용(재조회 race 모순 방지).

### Phase 4 — 문서/주석 동기화
README `kis_overseas`/`kis_domestic` orderable 스펙을 ROB-596(차감 없음)으로 갱신 + place_order dry_run 잔액가드 명문화. 스테일 "reservation-aware"/"대기주문 차감" 주석·docstring 정정.

## `insufficient_balance` 컨벤션 주의
기존에 `app/jobs/analyze.py`가 `bool(result.get("insufficient_balance"))`로, `stock_info_service.py`가 `True`로 쓰던 컨벤션이 있어, MCP 경로도 **`True`(bool) 유지** + 상세는 별도 키 `insufficient_balance_detail`로 분리(타입 충돌 회피).

## G3 분리 → ROB-627
`frcr_gnrl_ord_psbl_amt`(미정산 D+2/통합증거금 포함 net 필드)를 precheck가 그대로 신뢰할지 vs settled-only cash 정책 검토. 운영자 수동 $184 체결이 net 필드 권위를 방증 → 버그 아닌 정책 이슈로 분리.

## 검증
- `make lint` (ruff + ruff-format + ty) ✅
- 전체 unit 스위트 **11,903 passed / 0 failed** ✅
- order-surface 회귀 배치 267 passed; ROB-625 신규/갱신 13 테스트 green
- 적대 멀티렌즈 리뷰(11 에이전트) **0 blocker / 0 major**; 1 minor(cash_field mislabel) + 1 nit(orderable 재조회 divergence) **수정 완료**

## Operator 액션 (배포 게이트)
1. prod 이미지/git SHA에 `b603b6eb`(ROB-596) 포함 여부 확인 — **미포함이면 배포가 곧 헤드라인 fix**.
2. 배포 후 live 스모크: ADSK류 재매수 `dry_run → live` 일치, 잔액부족 시 에러에 `frcr_*` breakdown 노출 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0111pF5cV9a8tuffH8XWgqLz


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Dry-run order previews now fail when balance is insufficient, matching live order behavior.
  * Insufficient-balance responses now include clearer error details and balance breakdowns where available.
  * Preview responses still retain estimated value and fee information when blocked.

* **Documentation**
  * Updated account routing and balance guidance to reflect current cash/orderable handling and insufficient-balance behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->