### PR TITLE
fix(ROB-629): get_top_stocks foreigners 외인 랭킹 정상화 (명명필드+buy/sell split+market_cap+필터)

### DIFF
--- a/app/mcp_server/tooling/analysis_registration.py
+++ b/app/mcp_server/tooling/analysis_registration.py
@@ -83,7 +83,10 @@ def register_analysis_tools(
         name="get_top_stocks",
         description=(
             "Get top stocks by ranking type across different markets (KR/US/Crypto). "
-            "KR: volume, market_cap, gainers, losers, foreigners "
+            "KR: volume, market_cap, gainers, losers, foreign_net_buy, "
+            "foreign_net_sell (foreigners = back-compat alias for foreign_net_buy). "
+            "Foreign rankings expose named foreign_net_qty / foreign_net_amount "
+            "fields (no longer stuffed into volume/trade_amount). "
             "US: volume, market_cap, gainers, losers "
             "Crypto: volume, gainers, losers, relative_strength (vs BTC 24h)."
         ),

--- a/app/mcp_server/tooling/analysis_registration.py
+++ b/app/mcp_server/tooling/analysis_registration.py
@@ -86,7 +86,11 @@ def register_analysis_tools(
             "KR: volume, market_cap, gainers, losers, foreign_net_buy, "
             "foreign_net_sell (foreigners = back-compat alias for foreign_net_buy). "
             "Foreign rankings expose named foreign_net_qty / foreign_net_amount "
-            "fields (no longer stuffed into volume/trade_amount). "
+            "fields (no longer stuffed into volume/trade_amount), backfill "
+            "market_cap from fundamentals snapshots with a market_cap_source "
+            "provenance tag, and apply a default-ON liquidity filter "
+            "(|foreign_net_amount| >= FOREIGNERS_MIN_NET_AMOUNT_KRW, default 1억 "
+            "KRW; pass include_illiquid=true to bypass). "
             "US: volume, market_cap, gainers, losers "
             "Crypto: volume, gainers, losers, relative_strength (vs BTC 24h)."
         ),
@@ -95,11 +99,13 @@ def register_analysis_tools(
         market: str = "kr",
         ranking_type: str = "volume",
         limit: int = 20,
+        include_illiquid: bool = False,
     ) -> dict[str, Any]:
         return await get_top_stocks_impl(
             market=market,
             ranking_type=ranking_type,
             limit=limit,
+            include_illiquid=include_illiquid,
         )
 
     @mcp.tool(

--- a/app/mcp_server/tooling/analysis_screening.py
+++ b/app/mcp_server/tooling/analysis_screening.py
@@ -137,6 +137,41 @@ def _map_kr_row(row: dict[str, Any], rank: int) -> dict[str, Any]:
     }
 
 
+def _map_kr_foreign_row(row: dict[str, Any], rank: int) -> dict[str, Any]:
+    """Foreigners-ranking row mapper (ROB-629).
+
+    The foreign net-buy / net-sell ranking carries *foreign-investor net flow*,
+    not whole-market accumulated volume/value. Surface that as NAMED keys
+    (``foreign_net_qty`` from ``frgn_ntby_qty`` and ``foreign_net_amount`` from
+    ``frgn_ntby_tr_pbmn``) instead of stuffing them into the generic ``volume``
+    / ``trade_amount`` slots — the old ``_map_kr_row`` fallback silently
+    mislabeled foreign net flow as total market volume.
+
+    ``volume`` / ``trade_amount`` / ``market_cap`` stay honest: populated only
+    from ``acml_vol`` / ``acml_tr_pbmn`` / ``hts_avls`` when KIS returns them
+    (the foreign ranking typically omits them), else ``None`` — never
+    fabricated from the foreign fields.
+    """
+    symbol = _first_present(row, "stck_shrn_iscd", "mksc_shrn_iscd") or ""
+    name = row.get("hts_kor_isnm", "")
+    price = _to_optional_float(row.get("stck_prpr"))
+    change_rate = _normalize_change_rate_equity(row.get("prdy_ctrt"))
+    market_cap = _to_optional_float(_first_present(row, "hts_avls", "stck_avls"))
+
+    return {
+        "rank": rank,
+        "symbol": symbol,
+        "name": name,
+        "price": price,
+        "change_rate": round(change_rate, 2) if change_rate is not None else None,
+        "volume": _to_optional_int(row.get("acml_vol")),
+        "market_cap": market_cap,
+        "trade_amount": _to_optional_float(row.get("acml_tr_pbmn")),
+        "foreign_net_qty": _to_optional_int(row.get("frgn_ntby_qty")),
+        "foreign_net_amount": _to_optional_float(row.get("frgn_ntby_tr_pbmn")),
+    }
+
+
 def _map_us_row(row: dict[str, Any], rank: int) -> dict[str, Any]:
     symbol = row.get("symbol", "")
     name = row.get("longName", "") or row.get("shortName", symbol)
@@ -370,6 +405,7 @@ async def _recommend_stocks_impl(
 __all__ = [
     "_error_payload",
     "_map_kr_row",
+    "_map_kr_foreign_row",
     "_map_us_row",
     "_map_crypto_row",
     "_get_us_rankings",

--- a/app/mcp_server/tooling/analysis_tool_handlers.py
+++ b/app/mcp_server/tooling/analysis_tool_handlers.py
@@ -15,7 +15,7 @@ from typing import Any, Literal
 import httpx
 import yfinance as yf
 
-from app.mcp_server.tooling import analysis_screening
+from app.mcp_server.tooling import analysis_screening, foreigners_liquidity
 from app.mcp_server.tooling.analysis_screen_core import normalize_screen_request
 from app.mcp_server.tooling.market_data_indicators import (
     _fetch_ohlcv_for_indicators,
@@ -86,6 +86,7 @@ async def get_top_stocks_impl(
     market: str = "kr",
     ranking_type: str = "volume",
     limit: int = 20,
+    include_illiquid: bool = False,
 ) -> dict[str, Any]:
     market = (market or "").strip().lower()
     ranking_type = (ranking_type or "").strip().lower()
@@ -249,6 +250,46 @@ async def get_top_stocks_impl(
                     ),
                 }
 
+    # ROB-629 B2: foreigners liquidity backfill + default-ON liquidity filter.
+    liquidity_filter_meta: dict[str, Any] | None = None
+    if market == "kr" and foreigners_liquidity.is_foreigners_ranking(ranking_type):
+        await foreigners_liquidity.backfill_foreigners_market_cap(rankings)
+        kept, excluded = foreigners_liquidity.filter_illiquid_foreigners(
+            rankings, include_illiquid=include_illiquid
+        )
+        liquidity_filter_meta = {
+            "include_illiquid": include_illiquid,
+            "min_foreign_net_amount_krw": (
+                foreigners_liquidity.MIN_FOREIGN_NET_AMOUNT_KRW
+            ),
+            "min_market_cap_krw": foreigners_liquidity.MIN_MARKET_CAP_KRW,
+            "excluded_count": excluded,
+        }
+        if not include_illiquid and rankings and not kept:
+            # Filter emptied a non-empty list (e.g. off-hours / all-junk).
+            # Honest degraded signal — never fabricate rows.
+            return {
+                "rankings": [],
+                "total_count": 0,
+                "market": market,
+                "ranking_type": ranking_type,
+                "timestamp": datetime.datetime.now(kst_tz).isoformat(),
+                "source": source,
+                **({"data_state": data_state} if data_state is not None else {}),
+                "status": "degraded",
+                "degraded_reason": (
+                    f"all {excluded} foreign-flow row(s) fell below the liquidity "
+                    f"threshold (foreign_net_amount >= "
+                    f"{foreigners_liquidity.MIN_FOREIGN_NET_AMOUNT_KRW:.0f} KRW); "
+                    "pass include_illiquid=true to bypass, or retry during market "
+                    "hours when foreign net flow is non-trivial"
+                ),
+                "liquidity_filter": liquidity_filter_meta,
+            }
+        rankings = kept
+        for new_rank, row in enumerate(rankings, start=1):
+            row["rank"] = new_rank
+
     if len(rankings) == 0 and market == "kr" and ranking_type == "losers":
         return analysis_screening._error_payload(
             source="kis",
@@ -273,6 +314,8 @@ async def get_top_stocks_impl(
     }
     if data_state is not None:
         response["data_state"] = data_state
+    if liquidity_filter_meta is not None:
+        response["liquidity_filter"] = liquidity_filter_meta
     return response
 
 

--- a/app/mcp_server/tooling/analysis_tool_handlers.py
+++ b/app/mcp_server/tooling/analysis_tool_handlers.py
@@ -150,9 +150,7 @@ async def get_top_stocks_impl(
                 )
                 source = "kis"
             elif resolved_ranking_type in _FOREIGN_RANKING_TYPES:
-                rank_sort = (
-                    "1" if resolved_ranking_type == "foreign_net_sell" else "0"
-                )
+                rank_sort = "1" if resolved_ranking_type == "foreign_net_sell" else "0"
                 data = await kis.foreign_buying_rank(
                     market="J", limit=fetch_limit, rank_sort=rank_sort
                 )
@@ -168,9 +166,7 @@ async def get_top_stocks_impl(
                         continue
 
                 if resolved_ranking_type in _FOREIGN_RANKING_TYPES:
-                    mapped = analysis_screening._map_kr_foreign_row(
-                        row, filtered_rank
-                    )
+                    mapped = analysis_screening._map_kr_foreign_row(row, filtered_rank)
                 else:
                     mapped = analysis_screening._map_kr_row(row, filtered_rank)
                 rankings.append(mapped)

--- a/app/mcp_server/tooling/analysis_tool_handlers.py
+++ b/app/mcp_server/tooling/analysis_tool_handlers.py
@@ -35,6 +35,11 @@ from app.services.brokers.kis.client import KISClient
 
 logger = logging.getLogger(__name__)
 
+# ROB-629: the legacy "foreigners" ranking is split into directional foreign
+# net-flow rankings. "foreigners" is kept as a back-compat alias for
+# "foreign_net_buy".
+_FOREIGN_RANKING_TYPES = frozenset({"foreign_net_buy", "foreign_net_sell"})
+
 _CORRELATION_COMPANY_NAME_ERROR = (
     "get_correlation does not support company-name inputs because it has no "
     "market parameter. Use ticker/code inputs directly."
@@ -86,12 +91,22 @@ async def get_top_stocks_impl(
     ranking_type = (ranking_type or "").strip().lower()
     limit_clamped = max(1, min(limit, 50))
 
+    # ROB-629: "foreigners" is the back-compat alias for the net-buy ranking.
+    # Resolve the alias for dispatch + guard logic, but echo the caller's
+    # ORIGINAL ranking_type in the response so existing callers keep seeing
+    # "foreigners".
+    resolved_ranking_type = (
+        "foreign_net_buy" if ranking_type == "foreigners" else ranking_type
+    )
+
     supported_combinations = {
         ("kr", "volume"),
         ("kr", "market_cap"),
         ("kr", "gainers"),
         ("kr", "losers"),
         ("kr", "foreigners"),
+        ("kr", "foreign_net_buy"),
+        ("kr", "foreign_net_sell"),
         ("us", "volume"),
         ("us", "market_cap"),
         ("us", "gainers"),
@@ -133,8 +148,13 @@ async def get_top_stocks_impl(
                     market="J", direction=direction, limit=fetch_limit
                 )
                 source = "kis"
-            elif ranking_type == "foreigners":
-                data = await kis.foreign_buying_rank(market="J", limit=fetch_limit)
+            elif resolved_ranking_type in _FOREIGN_RANKING_TYPES:
+                rank_sort = (
+                    "1" if resolved_ranking_type == "foreign_net_sell" else "0"
+                )
+                data = await kis.foreign_buying_rank(
+                    market="J", limit=fetch_limit, rank_sort=rank_sort
+                )
                 source = "kis"
             else:
                 data = []
@@ -146,7 +166,12 @@ async def get_top_stocks_impl(
                     if change_rate is None or change_rate >= 0:
                         continue
 
-                mapped = analysis_screening._map_kr_row(row, filtered_rank)
+                if resolved_ranking_type in _FOREIGN_RANKING_TYPES:
+                    mapped = analysis_screening._map_kr_foreign_row(
+                        row, filtered_rank
+                    )
+                else:
+                    mapped = analysis_screening._map_kr_row(row, filtered_rank)
                 rankings.append(mapped)
                 filtered_rank += 1
                 if len(rankings) >= limit_clamped:
@@ -177,10 +202,10 @@ async def get_top_stocks_impl(
 
     kst_tz = datetime.timezone(datetime.timedelta(hours=9))
 
-    # ROB-464: outside the KRX regular session the gainers/losers rankings come
-    # back with every change rate at 0, alphabetically ordered — not a real
-    # ranking. Suppress that fake-0 garbage and tag the session instead of
-    # presenting it as live data.
+    # ROB-464 / ROB-629: outside the KRX regular session the directional KR
+    # rankings come back as fake-0 가집계 garbage — gainers/losers with every
+    # change rate at 0, and the foreign net-flow ranking with no real net flow.
+    # Suppress that and tag the session instead of presenting it as live data.
     data_state: str | None = None
     if market == "kr":
         data_state = kr_market_data_state()
@@ -200,6 +225,27 @@ async def get_top_stocks_impl(
                         "with all change rates at 0 (not a real ranking). Returning "
                         "no rows instead of fake-0 entries — retry during market "
                         "hours (09:00–15:30 KST)."
+                    ),
+                }
+        elif resolved_ranking_type in _FOREIGN_RANKING_TYPES:
+            has_real_flow = any(
+                r.get("foreign_net_qty") or r.get("foreign_net_amount")
+                for r in rankings
+            )
+            if data_state != DATA_STATE_FRESH and not has_real_flow:
+                return {
+                    "rankings": [],
+                    "total_count": 0,
+                    "market": market,
+                    "ranking_type": ranking_type,
+                    "timestamp": datetime.datetime.now(kst_tz).isoformat(),
+                    "source": source,
+                    "data_state": data_state,
+                    "note": (
+                        "KRX is not in regular session; the foreign net-trade "
+                        "ranking comes back with no real net flow (가집계 fake-0). "
+                        "Returning no rows instead of fake-0 entries — retry "
+                        "during market hours (09:00–15:30 KST)."
                     ),
                 }
 

--- a/app/mcp_server/tooling/foreigners_liquidity.py
+++ b/app/mcp_server/tooling/foreigners_liquidity.py
@@ -26,14 +26,37 @@ from app.services.invest_kr_fundamentals_snapshots.repository import (
 
 logger = logging.getLogger(__name__)
 
+
+def _env_float(name: str, default: float) -> float:
+    """Parse a float env override, falling back to ``default`` (logging a
+    warning) on missing/blank/non-numeric input.
+
+    These constants are read at IMPORT time, and this module is imported at the
+    top of ``analysis_tool_handlers``. A bare ``float(os.getenv(...))`` would
+    raise ``ValueError`` at import on a bad operator value, taking down ALL
+    get_top_stocks rankings — not just KR foreigners. Fail soft to the default
+    instead.
+    """
+    raw = os.getenv(name)
+    if raw is None or raw.strip() == "":
+        return default
+    try:
+        return float(raw)
+    except ValueError:
+        logger.warning("Invalid %s=%r; falling back to default %s", name, raw, default)
+        return default
+
+
 # Operator-tunable. Foreign net-flow KRW magnitude below this == clear junk.
-MIN_FOREIGN_NET_AMOUNT_KRW: float = float(
-    os.getenv("FOREIGNERS_MIN_NET_AMOUNT_KRW", "100000000")  # 1억 KRW
+MIN_FOREIGN_NET_AMOUNT_KRW: float = _env_float(
+    "FOREIGNERS_MIN_NET_AMOUNT_KRW",
+    100000000.0,  # 1억 KRW
 )
 # Optional market-cap floor, applied ONLY where market_cap is known (never
 # excludes a row just because cap is null).
-MIN_MARKET_CAP_KRW: float = float(
-    os.getenv("FOREIGNERS_MIN_MARKET_CAP_KRW", "30000000000")  # 300억 KRW
+MIN_MARKET_CAP_KRW: float = _env_float(
+    "FOREIGNERS_MIN_MARKET_CAP_KRW",
+    30000000000.0,  # 300억 KRW
 )
 
 _FOREIGNERS_RANKING_TYPES: frozenset[str] = frozenset(
@@ -50,12 +73,16 @@ def _row_symbol(row: dict[str, Any]) -> str:
 
 
 def _abs_foreign_amount(row: dict[str, Any]) -> float | None:
-    """Magnitude of foreign net flow (KRW). Reads B1's ``foreign_net_amount``
-    with fallback to the current ``trade_amount`` key (same frgn_ntby_tr_pbmn)."""
-    raw = row.get("foreign_net_amount")
-    if raw is None:
-        raw = row.get("trade_amount")
-    val = _to_optional_float(raw)
+    """Magnitude of foreign net flow (KRW), read ONLY from B1's
+    ``foreign_net_amount`` (frgn_ntby_tr_pbmn).
+
+    F6: post-B1 ``_map_kr_foreign_row`` ALWAYS emits ``foreign_net_amount`` and a
+    DISTINCT ``trade_amount`` sourced from ``acml_tr_pbmn`` (whole-market
+    accumulated trade value — NOT foreign net flow). We deliberately do NOT fall
+    back to ``trade_amount``: judging foreign liquidity by whole-market volume
+    would be the wrong signal. No row in the shipped pipeline reaches this filter
+    without a ``foreign_net_amount`` key, so honest null (excluded) is correct."""
+    val = _to_optional_float(row.get("foreign_net_amount"))
     return abs(val) if val is not None else None
 
 
@@ -135,15 +162,11 @@ async def backfill_foreigners_market_cap(
     session_factory: Any = AsyncSessionLocal,
 ) -> None:
     """Bounded (top-N rows already clamped to <=50) batched market_cap backfill."""
-    symbols = list(
-        dict.fromkeys(s for r in rows if (s := _row_symbol(r)))
-    )
+    symbols = list(dict.fromkeys(s for r in rows if (s := _row_symbol(r))))
     snapshot_caps, shares_map = await _fetch_market_cap_maps(
         symbols, session_factory=session_factory
     )
-    apply_market_cap_backfill(
-        rows, snapshot_caps=snapshot_caps, shares_map=shares_map
-    )
+    apply_market_cap_backfill(rows, snapshot_caps=snapshot_caps, shares_map=shares_map)
 
 
 def filter_illiquid_foreigners(

--- a/app/mcp_server/tooling/foreigners_liquidity.py
+++ b/app/mcp_server/tooling/foreigners_liquidity.py
@@ -1,0 +1,177 @@
+"""ROB-629 B2: market_cap backfill + liquidity filter for the KR foreigners
+(foreign_net_buy / foreign_net_sell) ranking.
+
+The KIS foreign-buying-rank payload reliably carries the foreign net-flow KRW
+value (frgn_ntby_tr_pbmn -> foreign_net_amount) but usually OMITS market cap.
+So we (1) backfill market_cap from invest_kr_fundamentals_snapshots, falling
+back to shares_outstanding x price, honest null when neither is available; and
+(2) drop clear-junk illiquid rows using the ALWAYS-PRESENT foreign_net_amount
+as the primary signal (NOT the null-prone market_cap)."""
+
+from __future__ import annotations
+
+import logging
+import os
+from decimal import Decimal
+from typing import Any
+
+import sqlalchemy as sa
+
+from app.core.db import AsyncSessionLocal
+from app.mcp_server.tooling.shared import to_optional_float as _to_optional_float
+from app.models.kr_symbol_universe import KRSymbolUniverse
+from app.services.invest_kr_fundamentals_snapshots.repository import (
+    InvestKrFundamentalsSnapshotsRepository,
+)
+
+logger = logging.getLogger(__name__)
+
+# Operator-tunable. Foreign net-flow KRW magnitude below this == clear junk.
+MIN_FOREIGN_NET_AMOUNT_KRW: float = float(
+    os.getenv("FOREIGNERS_MIN_NET_AMOUNT_KRW", "100000000")  # 1억 KRW
+)
+# Optional market-cap floor, applied ONLY where market_cap is known (never
+# excludes a row just because cap is null).
+MIN_MARKET_CAP_KRW: float = float(
+    os.getenv("FOREIGNERS_MIN_MARKET_CAP_KRW", "30000000000")  # 300억 KRW
+)
+
+_FOREIGNERS_RANKING_TYPES: frozenset[str] = frozenset(
+    {"foreign_net_buy", "foreign_net_sell", "foreigners"}
+)
+
+
+def is_foreigners_ranking(ranking_type: str) -> bool:
+    return (ranking_type or "").strip().lower() in _FOREIGNERS_RANKING_TYPES
+
+
+def _row_symbol(row: dict[str, Any]) -> str:
+    return str(row.get("symbol") or "").strip()
+
+
+def _abs_foreign_amount(row: dict[str, Any]) -> float | None:
+    """Magnitude of foreign net flow (KRW). Reads B1's ``foreign_net_amount``
+    with fallback to the current ``trade_amount`` key (same frgn_ntby_tr_pbmn)."""
+    raw = row.get("foreign_net_amount")
+    if raw is None:
+        raw = row.get("trade_amount")
+    val = _to_optional_float(raw)
+    return abs(val) if val is not None else None
+
+
+async def _fetch_market_cap_maps(
+    symbols: list[str],
+    *,
+    session_factory: Any = AsyncSessionLocal,
+) -> tuple[dict[str, Decimal], dict[str, Decimal]]:
+    """(snapshot_market_caps, shares_outstanding_map) for ``symbols``.
+
+    Snapshot caps come from the latest fundamentals partition; shares come from
+    kr_symbol_universe only for symbols missing a snapshot cap. fail-open: any
+    DB error returns ({}, {}) so the foreigners path never breaks on a DB hiccup
+    (market_cap simply stays null)."""
+    if not symbols:
+        return {}, {}
+    try:
+        async with session_factory() as db:
+            repo = InvestKrFundamentalsSnapshotsRepository(db)
+            snapshot_caps = await repo.market_cap_by_symbols(symbols)
+            need_fallback = [s for s in symbols if s not in snapshot_caps]
+            shares_map: dict[str, Decimal] = {}
+            if need_fallback:
+                rows = (
+                    await db.execute(
+                        sa.select(
+                            KRSymbolUniverse.symbol,
+                            KRSymbolUniverse.shares_outstanding,
+                        ).where(KRSymbolUniverse.symbol.in_(need_fallback))
+                    )
+                ).all()
+                shares_map = {
+                    r.symbol: r.shares_outstanding
+                    for r in rows
+                    if r.shares_outstanding is not None
+                }
+            return snapshot_caps, shares_map
+    except Exception:  # noqa: BLE001 — fail-open, leave market_cap untouched
+        logger.warning("foreigners market_cap fetch failed", exc_info=True)
+        return {}, {}
+
+
+def apply_market_cap_backfill(
+    rows: list[dict[str, Any]],
+    *,
+    snapshot_caps: dict[str, Decimal],
+    shares_map: dict[str, Decimal],
+) -> None:
+    """Pure in-place backfill of market_cap with provenance, NEVER fabricated.
+
+    Precedence: keep existing (KIS payload) value -> fundamentals snapshot cap
+    -> shares_outstanding x price -> honest null."""
+    for row in rows:
+        existing = row.get("market_cap")
+        if existing is not None:
+            row.setdefault("market_cap_source", "kis_payload")
+            continue
+        symbol = _row_symbol(row)
+        cap = snapshot_caps.get(symbol)
+        if cap is not None:
+            row["market_cap"] = float(cap)
+            row["market_cap_source"] = "fundamentals_snapshot"
+            continue
+        shares = shares_map.get(symbol)
+        price = _to_optional_float(row.get("price"))
+        if shares is not None and price is not None:
+            row["market_cap"] = float(shares) * price
+            row["market_cap_source"] = "shares_outstanding_x_price"
+            continue
+        row["market_cap"] = None
+        row["market_cap_source"] = None
+
+
+async def backfill_foreigners_market_cap(
+    rows: list[dict[str, Any]],
+    *,
+    session_factory: Any = AsyncSessionLocal,
+) -> None:
+    """Bounded (top-N rows already clamped to <=50) batched market_cap backfill."""
+    symbols = list(
+        dict.fromkeys(s for r in rows if (s := _row_symbol(r)))
+    )
+    snapshot_caps, shares_map = await _fetch_market_cap_maps(
+        symbols, session_factory=session_factory
+    )
+    apply_market_cap_backfill(
+        rows, snapshot_caps=snapshot_caps, shares_map=shares_map
+    )
+
+
+def filter_illiquid_foreigners(
+    rows: list[dict[str, Any]],
+    *,
+    include_illiquid: bool = False,
+    min_foreign_net_amount_krw: float = MIN_FOREIGN_NET_AMOUNT_KRW,
+    min_market_cap_krw: float | None = MIN_MARKET_CAP_KRW,
+) -> tuple[list[dict[str, Any]], int]:
+    """Default-ON liquidity filter. Robust signal = |foreign_net_amount| (KRW,
+    always present), with an OPTIONAL market_cap floor applied only where cap is
+    known. ``include_illiquid=True`` bypasses. Returns (kept_rows, excluded)."""
+    if include_illiquid:
+        return list(rows), 0
+    kept: list[dict[str, Any]] = []
+    excluded = 0
+    for row in rows:
+        amount = _abs_foreign_amount(row)
+        if amount is None or amount < min_foreign_net_amount_krw:
+            excluded += 1
+            continue
+        cap = _to_optional_float(row.get("market_cap"))
+        if (
+            min_market_cap_krw is not None
+            and cap is not None
+            and cap < min_market_cap_krw
+        ):
+            excluded += 1
+            continue
+        kept.append(row)
+    return kept, excluded

--- a/app/services/brokers/kis/client.py
+++ b/app/services/brokers/kis/client.py
@@ -140,9 +140,9 @@ class KISClient(BaseKISClient):
         return await self._market_data.fluctuation_rank(market, direction, limit)
 
     async def foreign_buying_rank(
-        self, market: str = "J", limit: int = 30
+        self, market: str = "J", limit: int = 30, rank_sort: str = "0"
     ) -> list[dict[str, Any]]:
-        return await self._market_data.foreign_buying_rank(market, limit)
+        return await self._market_data.foreign_buying_rank(market, limit, rank_sort)
 
     async def inquire_price(self, code: str, market: str = "J") -> DataFrame:
         return await self._market_data.inquire_price(code, market)

--- a/app/services/brokers/kis/domestic_market_data.py
+++ b/app/services/brokers/kis/domestic_market_data.py
@@ -166,8 +166,11 @@ class DomesticMarketDataMixin(MarketDataBase):
         return negatives[:limit]
 
     async def foreign_buying_rank(
-        self, market: str = "J", limit: int = 30
+        self, market: str = "J", limit: int = 30, rank_sort: str = "0"
     ) -> list[dict]:
+        # FID_RANK_SORT_CLS_CODE: "0"=순매수 상위(net buy), "1"=순매도 상위(net sell).
+        # FID_ETC_CLS_CODE="1" pins the ranking to 외국인 (foreigners).
+        rank_sort_cls_code = "1" if str(rank_sort) == "1" else "0"
         js = await self._request_with_token_retry(
             tr_id=constants.FOREIGN_BUYING_RANK_TR,
             url=self._kis_url(constants.FOREIGN_BUYING_RANK_URL),
@@ -176,7 +179,7 @@ class DomesticMarketDataMixin(MarketDataBase):
                 "FID_COND_SCR_DIV_CODE": "16449",
                 "FID_INPUT_ISCD": "0000",
                 "FID_DIV_CLS_CODE": "0",
-                "FID_RANK_SORT_CLS_CODE": "0",
+                "FID_RANK_SORT_CLS_CODE": rank_sort_cls_code,
                 "FID_ETC_CLS_CODE": "1",
             },
             api_name="foreign_buying_rank",

--- a/app/services/invest_kr_fundamentals_snapshots/repository.py
+++ b/app/services/invest_kr_fundamentals_snapshots/repository.py
@@ -81,6 +81,44 @@ class InvestKrFundamentalsSnapshotsRepository:
         )
         return result.scalar_one_or_none()
 
+    async def market_cap_by_symbols(
+        self, symbols: list[str]
+    ) -> dict[str, Decimal]:
+        """ROB-629: latest-partition market_cap for the given KR symbols.
+
+        Single batched query keyed by the most recent ``snapshot_date`` that
+        has data for any of ``symbols`` (mirrors ``_rsi_by_symbol``'s
+        latest-date + ``symbol.in_()`` precedent). Only non-null market_cap
+        rows are returned — callers fall back / keep honest null otherwise.
+        """
+        if not symbols:
+            return {}
+        latest = (
+            await self._session.execute(
+                select(func.max(InvestKrFundamentalsSnapshot.snapshot_date)).where(
+                    InvestKrFundamentalsSnapshot.symbol.in_(symbols)
+                )
+            )
+        ).scalar_one_or_none()
+        if latest is None:
+            return {}
+        rows = (
+            await self._session.execute(
+                select(
+                    InvestKrFundamentalsSnapshot.symbol,
+                    InvestKrFundamentalsSnapshot.market_cap,
+                ).where(
+                    InvestKrFundamentalsSnapshot.snapshot_date == latest,
+                    InvestKrFundamentalsSnapshot.symbol.in_(symbols),
+                )
+            )
+        ).all()
+        return {
+            row.symbol: row.market_cap
+            for row in rows
+            if row.market_cap is not None
+        }
+
     async def coverage(self, *, today: dt.date) -> KrFundamentalsCoverageCounts:
         latest = await self.latest_partition()
         if latest is None:

--- a/app/services/invest_kr_fundamentals_snapshots/repository.py
+++ b/app/services/invest_kr_fundamentals_snapshots/repository.py
@@ -81,9 +81,7 @@ class InvestKrFundamentalsSnapshotsRepository:
         )
         return result.scalar_one_or_none()
 
-    async def market_cap_by_symbols(
-        self, symbols: list[str]
-    ) -> dict[str, Decimal]:
+    async def market_cap_by_symbols(self, symbols: list[str]) -> dict[str, Decimal]:
         """ROB-629: latest-partition market_cap for the given KR symbols.
 
         Single batched query keyed by the most recent ``snapshot_date`` that
@@ -114,9 +112,7 @@ class InvestKrFundamentalsSnapshotsRepository:
             )
         ).all()
         return {
-            row.symbol: row.market_cap
-            for row in rows
-            if row.market_cap is not None
+            row.symbol: row.market_cap for row in rows if row.market_cap is not None
         }
 
     async def coverage(self, *, today: dt.date) -> KrFundamentalsCoverageCounts:

--- a/tests/test_foreigners_liquidity.py
+++ b/tests/test_foreigners_liquidity.py
@@ -11,6 +11,29 @@ from app.services.invest_kr_fundamentals_snapshots.repository import (
 
 
 # --------------------------------------------------------------------------
+# Env-float helper (F4: import-time crash robustness)
+# --------------------------------------------------------------------------
+class TestEnvFloat:
+    def test_valid_value_parsed(self, monkeypatch):
+        monkeypatch.setenv("FL_TEST_FLOAT", "250000000")
+        assert fl._env_float("FL_TEST_FLOAT", 1.0) == 250000000.0
+
+    def test_unset_uses_default(self, monkeypatch):
+        monkeypatch.delenv("FL_TEST_FLOAT", raising=False)
+        assert fl._env_float("FL_TEST_FLOAT", 1.0) == 1.0
+
+    def test_blank_uses_default(self, monkeypatch):
+        monkeypatch.setenv("FL_TEST_FLOAT", "   ")
+        assert fl._env_float("FL_TEST_FLOAT", 7.0) == 7.0
+
+    def test_non_numeric_falls_back_and_does_not_raise(self, monkeypatch):
+        # The real bug: a non-numeric operator env value used to raise ValueError
+        # AT IMPORT, taking down ALL get_top_stocks rankings.
+        monkeypatch.setenv("FL_TEST_FLOAT", "not-a-number")
+        assert fl._env_float("FL_TEST_FLOAT", 100000000.0) == 100000000.0
+
+
+# --------------------------------------------------------------------------
 # Pure backfill
 # --------------------------------------------------------------------------
 class TestApplyMarketCapBackfill:
@@ -84,9 +107,7 @@ class TestFilterIlliquidForeigners:
         rows = [
             {"symbol": "MICRO", "foreign_net_amount": 5e11, "market_cap": 1e9},
         ]
-        kept, excluded = fl.filter_illiquid_foreigners(
-            rows, min_market_cap_krw=3e10
-        )
+        kept, excluded = fl.filter_illiquid_foreigners(rows, min_market_cap_krw=3e10)
         assert excluded == 1
         assert kept == []
 
@@ -98,12 +119,31 @@ class TestFilterIlliquidForeigners:
         assert excluded == 0
         assert [r["symbol"] for r in kept] == ["OK"]
 
-    def test_fallback_reads_trade_amount_key_pre_b1(self):
-        # Before B1 the mapper emits trade_amount, not foreign_net_amount.
+    def test_only_uses_foreign_net_amount_not_whole_market_trade_amount(self):
+        # F6: post-B1 the mapper ALWAYS emits foreign_net_amount; trade_amount is
+        # a DISTINCT whole-market accumulated value (acml_tr_pbmn) — NOT foreign
+        # net flow. The filter must judge liquidity ONLY by the real foreign-net
+        # signal. A junk-low foreign_net_amount must NOT be rescued by a large
+        # whole-market trade_amount.
+        rows = [
+            {
+                "symbol": "900111",
+                "foreign_net_amount": 5_000_000.0,  # junk (< 1억 threshold)
+                "trade_amount": 9e11,  # huge whole-market value — wrong signal
+                "market_cap": None,
+            }
+        ]
+        kept, excluded = fl.filter_illiquid_foreigners(rows)
+        assert excluded == 1
+        assert kept == []
+
+    def test_missing_foreign_net_amount_is_excluded(self):
+        # F6: with no foreign_net_amount, there is no real foreign-net signal —
+        # the row is excluded (the old trade_amount fallback is gone).
         rows = [{"symbol": "005930", "trade_amount": 4e11, "market_cap": None}]
         kept, excluded = fl.filter_illiquid_foreigners(rows)
-        assert excluded == 0
-        assert len(kept) == 1
+        assert excluded == 1
+        assert kept == []
 
     def test_negative_net_sell_amount_uses_magnitude(self):
         rows = [{"symbol": "005930", "foreign_net_amount": -4e11, "market_cap": None}]
@@ -166,3 +206,146 @@ class TestMarketCapBySymbols:
         session = _FakeSession([_FakeResult(scalar=None)])
         repo = InvestKrFundamentalsSnapshotsRepository(cast(Any, session))
         assert await repo.market_cap_by_symbols(["005930"]) == {}
+
+
+# --------------------------------------------------------------------------
+# _fetch_market_cap_maps body (T3): one session, batched .in_() selects,
+# fail-open, shares_outstanding fallback only for snapshot-missing symbols.
+# --------------------------------------------------------------------------
+class _RecordingSession:
+    """Async-context-manager fake session that records executed statements and
+    returns queued results in order."""
+
+    def __init__(self, results, *, raise_on_execute=False):
+        self._results = list(results)
+        self.statements: list[Any] = []
+        self._raise_on_execute = raise_on_execute
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def execute(self, stmt):
+        self.statements.append(stmt)
+        if self._raise_on_execute:
+            raise RuntimeError("simulated DB error")
+        return self._results.pop(0)
+
+
+def _factory_for(session):
+    def _factory():
+        return session
+
+    return _factory
+
+
+@pytest.mark.asyncio
+class TestFetchMarketCapMaps:
+    async def test_empty_symbols_short_circuits(self):
+        # No session ever opened.
+        opened = []
+
+        def _factory():
+            opened.append(True)
+            raise AssertionError("session_factory must not be called for []")
+
+        caps, shares = await fl._fetch_market_cap_maps([], session_factory=_factory)
+        assert caps == {}
+        assert shares == {}
+        assert opened == []
+
+    async def test_db_error_fails_open(self):
+        session = _RecordingSession([], raise_on_execute=True)
+        caps, shares = await fl._fetch_market_cap_maps(
+            ["005930", "000660"], session_factory=_factory_for(session)
+        )
+        assert caps == {}
+        assert shares == {}
+
+    async def test_subset_snapshot_plus_shares_fallback_for_missing_only(self):
+        import datetime as dt
+
+        session = _RecordingSession(
+            [
+                # market_cap_by_symbols: latest partition date
+                _FakeResult(scalar=dt.date(2026, 6, 29)),
+                # market_cap_by_symbols: rows — snapshot covers 005930 only
+                _FakeResult(
+                    rows=[
+                        SimpleNamespace(symbol="005930", market_cap=Decimal("4e14")),
+                    ]
+                ),
+                # shares-outstanding fallback for the MISSING symbol (000660)
+                _FakeResult(
+                    rows=[
+                        SimpleNamespace(
+                            symbol="000660", shares_outstanding=Decimal("6e8")
+                        ),
+                    ]
+                ),
+            ]
+        )
+
+        caps, shares = await fl._fetch_market_cap_maps(
+            ["005930", "000660"], session_factory=_factory_for(session)
+        )
+
+        assert caps == {"005930": Decimal("4e14")}
+        assert shares == {"000660": Decimal("6e8")}
+
+        # Three statements: 2 from market_cap_by_symbols + 1 shares fallback.
+        assert len(session.statements) == 3
+        # The shares fallback query targets ONLY the missing symbol (000660),
+        # never the already-covered 005930.
+        shares_sql = str(
+            session.statements[2].compile(compile_kwargs={"literal_binds": True})
+        )
+        assert "000660" in shares_sql
+        assert "005930" not in shares_sql
+
+    async def test_no_fallback_query_when_snapshot_covers_all(self):
+        import datetime as dt
+
+        session = _RecordingSession(
+            [
+                _FakeResult(scalar=dt.date(2026, 6, 29)),
+                _FakeResult(
+                    rows=[
+                        SimpleNamespace(symbol="005930", market_cap=Decimal("4e14")),
+                    ]
+                ),
+            ]
+        )
+
+        caps, shares = await fl._fetch_market_cap_maps(
+            ["005930"], session_factory=_factory_for(session)
+        )
+
+        assert caps == {"005930": Decimal("4e14")}
+        assert shares == {}
+        # No third (shares) query issued — nothing was missing.
+        assert len(session.statements) == 2
+
+    async def test_null_shares_outstanding_filtered_out(self):
+        import datetime as dt
+
+        session = _RecordingSession(
+            [
+                _FakeResult(scalar=dt.date(2026, 6, 29)),
+                _FakeResult(rows=[]),  # snapshot covers nothing
+                _FakeResult(
+                    rows=[
+                        SimpleNamespace(symbol="000660", shares_outstanding=None),
+                    ]
+                ),
+            ]
+        )
+
+        caps, shares = await fl._fetch_market_cap_maps(
+            ["000660"], session_factory=_factory_for(session)
+        )
+
+        assert caps == {}
+        assert shares == {}  # null shares_outstanding dropped, not fabricated

--- a/tests/test_foreigners_liquidity.py
+++ b/tests/test_foreigners_liquidity.py
@@ -1,0 +1,168 @@
+from decimal import Decimal
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
+
+from app.mcp_server.tooling import foreigners_liquidity as fl
+from app.services.invest_kr_fundamentals_snapshots.repository import (
+    InvestKrFundamentalsSnapshotsRepository,
+)
+
+
+# --------------------------------------------------------------------------
+# Pure backfill
+# --------------------------------------------------------------------------
+class TestApplyMarketCapBackfill:
+    def test_backfilled_from_snapshot(self):
+        rows = [{"symbol": "005930", "price": 80000.0, "market_cap": None}]
+        fl.apply_market_cap_backfill(
+            rows,
+            snapshot_caps={"005930": Decimal("400000000000000")},
+            shares_map={},
+        )
+        assert rows[0]["market_cap"] == 4e14
+        assert rows[0]["market_cap_source"] == "fundamentals_snapshot"
+
+    def test_fallback_shares_times_price(self):
+        rows = [{"symbol": "005930", "price": 80000.0, "market_cap": None}]
+        fl.apply_market_cap_backfill(
+            rows,
+            snapshot_caps={},  # no snapshot
+            shares_map={"005930": Decimal("6000000000")},
+        )
+        assert rows[0]["market_cap"] == pytest.approx(6_000_000_000 * 80000.0)
+        assert rows[0]["market_cap_source"] == "shares_outstanding_x_price"
+
+    def test_honest_null_when_both_missing(self):
+        rows = [{"symbol": "999999", "price": 1000.0, "market_cap": None}]
+        fl.apply_market_cap_backfill(rows, snapshot_caps={}, shares_map={})
+        assert rows[0]["market_cap"] is None
+        assert rows[0]["market_cap_source"] is None
+
+    def test_no_fabrication_when_price_missing(self):
+        rows = [{"symbol": "005930", "price": None, "market_cap": None}]
+        fl.apply_market_cap_backfill(
+            rows, snapshot_caps={}, shares_map={"005930": Decimal("6000000000")}
+        )
+        assert rows[0]["market_cap"] is None
+        assert rows[0]["market_cap_source"] is None
+
+    def test_keeps_existing_kis_payload_market_cap(self):
+        rows = [{"symbol": "005930", "price": 80000.0, "market_cap": 1.23e14}]
+        fl.apply_market_cap_backfill(
+            rows,
+            snapshot_caps={"005930": Decimal("9e14")},
+            shares_map={},
+        )
+        assert rows[0]["market_cap"] == 1.23e14  # unchanged
+        assert rows[0]["market_cap_source"] == "kis_payload"
+
+
+# --------------------------------------------------------------------------
+# Pure filter
+# --------------------------------------------------------------------------
+class TestFilterIlliquidForeigners:
+    def _rows(self):
+        return [
+            {"symbol": "005930", "foreign_net_amount": 4e11, "market_cap": 1e14},
+            {"symbol": "JUNK1", "foreign_net_amount": 5_000_000.0, "market_cap": None},
+        ]
+
+    def test_filter_excludes_low_foreign_amount(self):
+        kept, excluded = fl.filter_illiquid_foreigners(self._rows())
+        assert excluded == 1
+        assert [r["symbol"] for r in kept] == ["005930"]
+
+    def test_include_illiquid_keeps_all(self):
+        rows = self._rows()
+        kept, excluded = fl.filter_illiquid_foreigners(rows, include_illiquid=True)
+        assert excluded == 0
+        assert len(kept) == 2
+
+    def test_market_cap_floor_excludes_when_known_and_tiny(self):
+        rows = [
+            {"symbol": "MICRO", "foreign_net_amount": 5e11, "market_cap": 1e9},
+        ]
+        kept, excluded = fl.filter_illiquid_foreigners(
+            rows, min_market_cap_krw=3e10
+        )
+        assert excluded == 1
+        assert kept == []
+
+    def test_market_cap_null_does_not_trigger_floor(self):
+        rows = [
+            {"symbol": "OK", "foreign_net_amount": 5e11, "market_cap": None},
+        ]
+        kept, excluded = fl.filter_illiquid_foreigners(rows)
+        assert excluded == 0
+        assert [r["symbol"] for r in kept] == ["OK"]
+
+    def test_fallback_reads_trade_amount_key_pre_b1(self):
+        # Before B1 the mapper emits trade_amount, not foreign_net_amount.
+        rows = [{"symbol": "005930", "trade_amount": 4e11, "market_cap": None}]
+        kept, excluded = fl.filter_illiquid_foreigners(rows)
+        assert excluded == 0
+        assert len(kept) == 1
+
+    def test_negative_net_sell_amount_uses_magnitude(self):
+        rows = [{"symbol": "005930", "foreign_net_amount": -4e11, "market_cap": None}]
+        kept, _ = fl.filter_illiquid_foreigners(rows)
+        assert [r["symbol"] for r in kept] == ["005930"]
+
+
+# --------------------------------------------------------------------------
+# Batched repository reader (mocked session)
+# --------------------------------------------------------------------------
+class _FakeResult:
+    def __init__(self, *, scalar=None, rows=None):
+        self._scalar = scalar
+        self._rows = rows or []
+
+    def scalar_one_or_none(self):
+        return self._scalar
+
+    def all(self):
+        return self._rows
+
+
+class _FakeSession:
+    def __init__(self, results):
+        self._results = list(results)
+        self.executed = 0
+
+    async def execute(self, _stmt):
+        self.executed += 1
+        return self._results.pop(0)
+
+
+@pytest.mark.asyncio
+class TestMarketCapBySymbols:
+    async def test_returns_non_null_caps_for_latest_partition(self):
+        import datetime as dt
+
+        session = _FakeSession(
+            [
+                _FakeResult(scalar=dt.date(2026, 6, 29)),
+                _FakeResult(
+                    rows=[
+                        SimpleNamespace(symbol="005930", market_cap=Decimal("4e14")),
+                        SimpleNamespace(symbol="000660", market_cap=None),
+                    ]
+                ),
+            ]
+        )
+        repo = InvestKrFundamentalsSnapshotsRepository(cast(Any, session))
+        out = await repo.market_cap_by_symbols(["005930", "000660"])
+        assert out == {"005930": Decimal("4e14")}  # null filtered out
+
+    async def test_empty_symbols_short_circuits(self):
+        session = _FakeSession([])
+        repo = InvestKrFundamentalsSnapshotsRepository(cast(Any, session))
+        assert await repo.market_cap_by_symbols([]) == {}
+        assert session.executed == 0
+
+    async def test_no_partition_returns_empty(self):
+        session = _FakeSession([_FakeResult(scalar=None)])
+        repo = InvestKrFundamentalsSnapshotsRepository(cast(Any, session))
+        assert await repo.market_cap_by_symbols(["005930"]) == {}

--- a/tests/test_kis_rankings.py
+++ b/tests/test_kis_rankings.py
@@ -185,8 +185,19 @@ class TestKISRankingAPIParams:
 
         assert result[0]["stck_shrn_iscd"] == "035420"
 
-    async def test_foreign_buying_rank_api_params(self, monkeypatch):
-        """foreign_buying_rank가 올바른 URL, tr_id, 파라미터로 API 호출하는지 검증"""
+    @pytest.mark.parametrize(
+        "call_kwargs, expected_code",
+        [
+            ({}, "0"),  # default = 순매수 상위 (net buy)
+            ({"rank_sort": "0"}, "0"),  # explicit net buy
+            ({"rank_sort": "1"}, "1"),  # 순매도 상위 (net sell)
+        ],
+    )
+    async def test_foreign_buying_rank_api_params(
+        self, monkeypatch, call_kwargs, expected_code
+    ):
+        """foreign_buying_rank가 rank_sort에 따라 FID_RANK_SORT_CLS_CODE를
+        '0'(순매수)/'1'(순매도)로 토글하는지 검증 (ROB-629)."""
         captured_requests = []
 
         async def mock_get(self, url, headers, params, timeout):
@@ -202,9 +213,8 @@ class TestKISRankingAPIParams:
                         "hts_kor_isnm": "삼성전자",
                         "stck_prpr": "80000",
                         "prdy_ctrt": "1.0",
-                        "acml_vol": "10000000",
-                        "hts_avls": "100000000000000",
-                        "acml_tr_pbmn": "800000000000000",
+                        "frgn_ntby_qty": "5000000",
+                        "frgn_ntby_tr_pbmn": "400000000000",
                     }
                 ],
             }
@@ -220,7 +230,9 @@ class TestKISRankingAPIParams:
             mock_get_token,
         )
 
-        result = await KISClient().foreign_buying_rank(market="J", limit=5)
+        result = await KISClient().foreign_buying_rank(
+            market="J", limit=5, **call_kwargs
+        )
 
         assert len(captured_requests) == 1
         req = captured_requests[0]
@@ -235,7 +247,8 @@ class TestKISRankingAPIParams:
         assert req["params"]["FID_COND_SCR_DIV_CODE"] == "16449"
         assert req["params"]["FID_INPUT_ISCD"] == "0000"
         assert req["params"]["FID_DIV_CLS_CODE"] == "0"
-        assert req["params"]["FID_RANK_SORT_CLS_CODE"] == "0"
+        # ROB-629: parametrized rank_sort (was hardcoded "0").
+        assert req["params"]["FID_RANK_SORT_CLS_CODE"] == expected_code
         assert req["params"]["FID_ETC_CLS_CODE"] == "1"
 
         assert len(result) == 1

--- a/tests/test_mcp_top_stocks.py
+++ b/tests/test_mcp_top_stocks.py
@@ -32,6 +32,19 @@ def build_tools() -> dict[str, Callable[..., Any]]:
 
 @pytest.mark.asyncio
 class TestMCPTopStocks:
+    @pytest.fixture(autouse=True)
+    def _neutralize_foreigners_market_cap_fetch(self, monkeypatch):
+        # ROB-629 B2: the foreigners backfill block calls a DB reader
+        # (_fetch_market_cap_maps). Keep these routing/mapping tests hermetic and
+        # fast — only TestForeignersLiquidity exercises real caps.
+        async def _no_op_fetch(*args, **kwargs):
+            return {}, {}
+
+        monkeypatch.setattr(
+            "app.mcp_server.tooling.foreigners_liquidity._fetch_market_cap_maps",
+            _no_op_fetch,
+        )
+
     async def test_get_top_stocks_us_uses_analysis_screening_rankings_alias(
         self, monkeypatch
     ):
@@ -1368,3 +1381,121 @@ class TestMCPRegressionTests:
         assert result["rankings"][1]["change_rate"] == pytest.approx(
             -1.0
         )  # -0.01 * 100
+
+
+@pytest.mark.asyncio
+class TestForeignersLiquidity:
+    async def _patch_fetch(self, monkeypatch, snapshot_caps=None, shares=None):
+        from decimal import Decimal as _D
+
+        from app.mcp_server.tooling import foreigners_liquidity
+
+        async def fake_fetch(symbols, *, session_factory=None):
+            return (
+                {k: _D(str(v)) for k, v in (snapshot_caps or {}).items()},
+                {k: _D(str(v)) for k, v in (shares or {}).items()},
+            )
+
+        monkeypatch.setattr(
+            foreigners_liquidity, "_fetch_market_cap_maps", fake_fetch
+        )
+
+    async def test_backfill_wired_from_snapshot(self, monkeypatch):
+        tools = build_tools()
+        await self._patch_fetch(monkeypatch, snapshot_caps={"005930": 4e14})
+
+        class MockKISClient:
+            async def foreign_buying_rank(self, market, limit, rank_sort="0"):
+                return [
+                    {
+                        "stck_shrn_iscd": "005930",
+                        "hts_kor_isnm": "삼성전자",
+                        "stck_prpr": "80000",
+                        "prdy_ctrt": "1.0",
+                        "frgn_ntby_qty": "5000000",
+                        "frgn_ntby_tr_pbmn": "400000000000",
+                    }
+                ]
+
+        monkeypatch.setattr(analysis_tool_handlers, "KISClient", MockKISClient)
+        result = await tools["get_top_stocks"](market="kr", ranking_type="foreigners")
+        row = result["rankings"][0]
+        assert row["market_cap"] == 4e14
+        assert row["market_cap_source"] == "fundamentals_snapshot"
+        assert result["liquidity_filter"]["include_illiquid"] is False
+        assert result["liquidity_filter"]["excluded_count"] == 0
+
+    async def test_filter_excludes_junk_default_on(self, monkeypatch):
+        tools = build_tools()
+        await self._patch_fetch(monkeypatch)  # no caps -> null
+
+        class MockKISClient:
+            async def foreign_buying_rank(self, market, limit, rank_sort="0"):
+                return [
+                    {
+                        "stck_shrn_iscd": "005930",
+                        "hts_kor_isnm": "삼성전자",
+                        "stck_prpr": "80000",
+                        "frgn_ntby_qty": "5000000",
+                        "frgn_ntby_tr_pbmn": "400000000000",
+                    },
+                    {
+                        "stck_shrn_iscd": "900111",
+                        "hts_kor_isnm": "잡주",
+                        "stck_prpr": "300",
+                        "frgn_ntby_qty": "1000",
+                        "frgn_ntby_tr_pbmn": "300000",  # 30만 KRW — junk
+                    },
+                ]
+
+        monkeypatch.setattr(analysis_tool_handlers, "KISClient", MockKISClient)
+        result = await tools["get_top_stocks"](market="kr", ranking_type="foreigners")
+        assert [r["symbol"] for r in result["rankings"]] == ["005930"]
+        assert result["rankings"][0]["rank"] == 1
+        assert result["liquidity_filter"]["excluded_count"] == 1
+
+    async def test_include_illiquid_keeps_all(self, monkeypatch):
+        tools = build_tools()
+        await self._patch_fetch(monkeypatch)
+
+        class MockKISClient:
+            async def foreign_buying_rank(self, market, limit, rank_sort="0"):
+                return [
+                    {
+                        "stck_shrn_iscd": "900111",
+                        "hts_kor_isnm": "잡주",
+                        "stck_prpr": "300",
+                        "frgn_ntby_tr_pbmn": "300000",
+                    }
+                ]
+
+        monkeypatch.setattr(analysis_tool_handlers, "KISClient", MockKISClient)
+        result = await tools["get_top_stocks"](
+            market="kr", ranking_type="foreigners", include_illiquid=True
+        )
+        assert len(result["rankings"]) == 1
+        assert result["liquidity_filter"]["include_illiquid"] is True
+        assert result["liquidity_filter"]["excluded_count"] == 0
+
+    async def test_filter_empties_sets_degraded(self, monkeypatch):
+        tools = build_tools()
+        await self._patch_fetch(monkeypatch)
+
+        class MockKISClient:
+            async def foreign_buying_rank(self, market, limit, rank_sort="0"):
+                return [
+                    {
+                        "stck_shrn_iscd": "900111",
+                        "hts_kor_isnm": "잡주",
+                        "stck_prpr": "300",
+                        "frgn_ntby_tr_pbmn": "300000",  # below threshold
+                    }
+                ]
+
+        monkeypatch.setattr(analysis_tool_handlers, "KISClient", MockKISClient)
+        result = await tools["get_top_stocks"](market="kr", ranking_type="foreigners")
+        assert result["rankings"] == []
+        assert result["total_count"] == 0
+        assert result["status"] == "degraded"
+        assert "liquidity threshold" in result["degraded_reason"]
+        assert result["liquidity_filter"]["excluded_count"] == 1

--- a/tests/test_mcp_top_stocks.py
+++ b/tests/test_mcp_top_stocks.py
@@ -222,20 +222,22 @@ class TestMCPTopStocks:
         tools = build_tools()
 
         class MockKISClient:
-            async def foreign_buying_rank(self, market, limit):
+            async def foreign_buying_rank(self, market, limit, rank_sort="0"):
                 return [
                     {
                         "mksc_shrn_iscd": "900210",
                         "hts_kor_isnm": "KODEX 200",
                         "stck_prpr": "35000",
                         "prdy_ctrt": "1.0",
-                        "acml_vol": "20000000",
-                        "hts_avls": "5000000000000",
-                        "acml_tr_pbmn": "700000000000000",
+                        "frgn_ntby_qty": "20000000",
+                        "frgn_ntby_tr_pbmn": "700000000000",
                     }
                 ]
 
         monkeypatch.setattr(analysis_tool_handlers, "KISClient", MockKISClient)
+        monkeypatch.setattr(
+            analysis_tool_handlers, "kr_market_data_state", lambda *a, **k: "fresh"
+        )
 
         result = await tools["get_top_stocks"](market="kr", ranking_type="foreigners")
 
@@ -243,6 +245,7 @@ class TestMCPTopStocks:
         assert len(result["rankings"]) == 1
         assert result["rankings"][0]["symbol"] == "900210"
         assert result["rankings"][0]["name"] == "KODEX 200"
+        assert result["source"] == "kis"
 
     async def test_kr_gainers_routing(self, monkeypatch):
         tools = build_tools()
@@ -328,20 +331,22 @@ class TestMCPTopStocks:
         tools = build_tools()
 
         class MockKISClient:
-            async def foreign_buying_rank(self, market, limit):
+            async def foreign_buying_rank(self, market, limit, rank_sort="0"):
                 return [
                     {
                         "stck_shrn_iscd": "005930",
                         "hts_kor_isnm": "삼성전자",
                         "stck_prpr": "80000",
                         "prdy_ctrt": "1.0",
-                        "acml_vol": "10000000",
-                        "hts_avls": "100000000000000",
-                        "acml_tr_pbmn": "800000000000000",
+                        "frgn_ntby_qty": "10000000",
+                        "frgn_ntby_tr_pbmn": "800000000000",
                     }
                 ]
 
         monkeypatch.setattr(analysis_tool_handlers, "KISClient", MockKISClient)
+        monkeypatch.setattr(
+            analysis_tool_handlers, "kr_market_data_state", lambda *a, **k: "fresh"
+        )
 
         result = await tools["get_top_stocks"](market="kr", ranking_type="foreigners")
 
@@ -905,11 +910,14 @@ class TestMCPTopStocks:
         assert "Upbit API error" in result["error"]
 
     async def test_kr_foreigners_ranking_foreign_specific_fields(self, monkeypatch):
-        """foreigners 랭킹에서 외국인 전용 필드(frgn_ntby_qty, frgn_ntby_tr_pbmn) 사용 테스트"""
+        """ROB-629: foreigners ranking surfaces foreign net flow as NAMED fields
+        (foreign_net_qty / foreign_net_amount) and no longer stuffs them into the
+        generic volume / trade_amount slots. hts_avls is NOT fabricated — the real
+        KIS foreign ranking does not return it, so market_cap is honestly null."""
         tools = build_tools()
 
         class MockKISClient:
-            async def foreign_buying_rank(self, market, limit):
+            async def foreign_buying_rank(self, market, limit, rank_sort="0"):
                 return [
                     {
                         "stck_shrn_iscd": "005930",
@@ -917,7 +925,6 @@ class TestMCPTopStocks:
                         "stck_prpr": "80000",
                         "prdy_ctrt": "1.0",
                         "frgn_ntby_qty": "5000000",
-                        "hts_avls": "100000000000000",
                         "frgn_ntby_tr_pbmn": "400000000000",
                     },
                     {
@@ -926,27 +933,85 @@ class TestMCPTopStocks:
                         "stck_prpr": "120000",
                         "prdy_ctrt": "1.5",
                         "frgn_ntby_qty": "3000000",
-                        "hts_avls": "50000000000000",
                         "frgn_ntby_tr_pbmn": "360000000000",
                     },
                 ]
 
         monkeypatch.setattr(analysis_tool_handlers, "KISClient", MockKISClient)
+        monkeypatch.setattr(
+            analysis_tool_handlers, "kr_market_data_state", lambda *a, **k: "fresh"
+        )
 
         result = await tools["get_top_stocks"](market="kr", ranking_type="foreigners")
 
         assert result["ranking_type"] == "foreigners"
         assert len(result["rankings"]) == 2
 
-        assert result["rankings"][0]["symbol"] == "005930"
-        assert result["rankings"][0]["name"] == "삼성전자"
-        assert result["rankings"][0]["volume"] == 5000000
-        assert result["rankings"][0]["trade_amount"] == pytest.approx(400000000000.0)
+        first = result["rankings"][0]
+        assert first["symbol"] == "005930"
+        assert first["name"] == "삼성전자"
+        # Named foreign fields — the whole point of ROB-629.
+        assert first["foreign_net_qty"] == 5000000
+        assert first["foreign_net_amount"] == pytest.approx(400000000000.0)
+        # Generic slots are NO LONGER stuffed with the foreign values.
+        assert first["volume"] is None
+        assert first["trade_amount"] is None
+        # market_cap honestly null (hts_avls not returned by the foreign ranking).
+        assert first["market_cap"] is None
 
-        assert result["rankings"][1]["symbol"] == "005380"
-        assert result["rankings"][1]["name"] == "LG전자"
-        assert result["rankings"][1]["volume"] == 3000000
-        assert result["rankings"][1]["trade_amount"] == pytest.approx(360000000000.0)
+        second = result["rankings"][1]
+        assert second["symbol"] == "005380"
+        assert second["name"] == "LG전자"
+        assert second["foreign_net_qty"] == 3000000
+        assert second["foreign_net_amount"] == pytest.approx(360000000000.0)
+        assert second["volume"] is None
+        assert second["trade_amount"] is None
+
+    async def test_kr_foreign_net_buy_and_sell_split_dispatch(self, monkeypatch):
+        """ROB-629: foreign_net_buy passes FID rank_sort '0' (net buy),
+        foreign_net_sell passes '1' (net sell); 'foreigners' aliases
+        foreign_net_buy. Response echoes the caller's original ranking_type."""
+        tools = build_tools()
+
+        captured: list[str] = []
+
+        class MockKISClient:
+            async def foreign_buying_rank(self, market, limit, rank_sort="0"):
+                captured.append(rank_sort)
+                return [
+                    {
+                        "stck_shrn_iscd": "005930",
+                        "hts_kor_isnm": "삼성전자",
+                        "stck_prpr": "80000",
+                        "prdy_ctrt": "1.0",
+                        "frgn_ntby_qty": "5000000",
+                        "frgn_ntby_tr_pbmn": "400000000000",
+                    }
+                ]
+
+        monkeypatch.setattr(analysis_tool_handlers, "KISClient", MockKISClient)
+        monkeypatch.setattr(
+            analysis_tool_handlers, "kr_market_data_state", lambda *a, **k: "fresh"
+        )
+
+        buy = await tools["get_top_stocks"](
+            market="kr", ranking_type="foreign_net_buy"
+        )
+        assert buy["ranking_type"] == "foreign_net_buy"
+        assert len(buy["rankings"]) == 1
+
+        sell = await tools["get_top_stocks"](
+            market="kr", ranking_type="foreign_net_sell"
+        )
+        assert sell["ranking_type"] == "foreign_net_sell"
+        assert len(sell["rankings"]) == 1
+
+        alias = await tools["get_top_stocks"](market="kr", ranking_type="foreigners")
+        assert alias["ranking_type"] == "foreigners"
+        assert len(alias["rankings"]) == 1
+
+        # net buy -> "0", net sell -> "1", foreigners alias -> "0".
+        assert captured == ["0", "1", "0"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_mcp_top_stocks.py
+++ b/tests/test_mcp_top_stocks.py
@@ -1007,9 +1007,7 @@ class TestMCPTopStocks:
             analysis_tool_handlers, "kr_market_data_state", lambda *a, **k: "fresh"
         )
 
-        buy = await tools["get_top_stocks"](
-            market="kr", ranking_type="foreign_net_buy"
-        )
+        buy = await tools["get_top_stocks"](market="kr", ranking_type="foreign_net_buy")
         assert buy["ranking_type"] == "foreign_net_buy"
         assert len(buy["rankings"]) == 1
 
@@ -1396,9 +1394,7 @@ class TestForeignersLiquidity:
                 {k: _D(str(v)) for k, v in (shares or {}).items()},
             )
 
-        monkeypatch.setattr(
-            foreigners_liquidity, "_fetch_market_cap_maps", fake_fetch
-        )
+        monkeypatch.setattr(foreigners_liquidity, "_fetch_market_cap_maps", fake_fetch)
 
     async def test_backfill_wired_from_snapshot(self, monkeypatch):
         tools = build_tools()
@@ -1499,3 +1495,84 @@ class TestForeignersLiquidity:
         assert result["status"] == "degraded"
         assert "liquidity threshold" in result["degraded_reason"]
         assert result["liquidity_filter"]["excluded_count"] == 1
+
+    async def test_foreigners_offsession_fake_zero_flow_suppressed(self, monkeypatch):
+        """T1: off-session the KIS foreign-buying-rank returns fake-0 가집계 rows
+        (no real net flow). When data_state is NON-fresh and no row carries real
+        foreign flow, the guard suppresses the fake-0 rows and tags data_state —
+        never presenting 가집계 zeros as live foreign flow."""
+        tools = build_tools()
+        await self._patch_fetch(monkeypatch)
+
+        class MockKISClient:
+            async def foreign_buying_rank(self, market, limit, rank_sort="0"):
+                return [
+                    {
+                        "stck_shrn_iscd": "005930",
+                        "hts_kor_isnm": "삼성전자",
+                        "stck_prpr": "80000",
+                        "prdy_ctrt": "0.00",
+                        "frgn_ntby_qty": "0",
+                        "frgn_ntby_tr_pbmn": "0",
+                    },
+                    {
+                        "stck_shrn_iscd": "000660",
+                        "hts_kor_isnm": "SK하이닉스",
+                        "stck_prpr": "180000",
+                        "prdy_ctrt": "0.00",
+                        "frgn_ntby_qty": "0",
+                        "frgn_ntby_tr_pbmn": "0",
+                    },
+                ]
+
+        monkeypatch.setattr(analysis_tool_handlers, "KISClient", MockKISClient)
+        monkeypatch.setattr(
+            analysis_tool_handlers,
+            "kr_market_data_state",
+            lambda *a, **k: "premarket_unavailable",
+        )
+
+        result = await tools["get_top_stocks"](market="kr", ranking_type="foreigners")
+
+        assert result["data_state"] == "premarket_unavailable"
+        assert result["rankings"] == []
+        assert result["total_count"] == 0
+        assert result.get("note")
+        # Suppressed BEFORE the liquidity filter ran — no liquidity meta attached.
+        assert "liquidity_filter" not in result
+
+    async def test_foreigners_offsession_real_flow_not_suppressed(self, monkeypatch):
+        """T1 positive counterpart: NON-fresh data_state but a row carries real
+        foreign net flow (has_real_flow=True) must NOT be suppressed — the guard
+        only drops the all-fake-0 case."""
+        tools = build_tools()
+        await self._patch_fetch(monkeypatch)
+
+        class MockKISClient:
+            async def foreign_buying_rank(self, market, limit, rank_sort="0"):
+                return [
+                    {
+                        "stck_shrn_iscd": "005930",
+                        "hts_kor_isnm": "삼성전자",
+                        "stck_prpr": "80000",
+                        "prdy_ctrt": "1.0",
+                        "frgn_ntby_qty": "5000000",
+                        "frgn_ntby_tr_pbmn": "400000000000",
+                    }
+                ]
+
+        monkeypatch.setattr(analysis_tool_handlers, "KISClient", MockKISClient)
+        monkeypatch.setattr(
+            analysis_tool_handlers,
+            "kr_market_data_state",
+            lambda *a, **k: "premarket_unavailable",
+        )
+
+        result = await tools["get_top_stocks"](market="kr", ranking_type="foreigners")
+
+        # Real flow survives; data_state is still tagged honestly as non-fresh.
+        assert result["data_state"] == "premarket_unavailable"
+        assert len(result["rankings"]) == 1
+        assert result["rankings"][0]["symbol"] == "005930"
+        assert result["rankings"][0]["foreign_net_amount"] == pytest.approx(4e11)
+        assert "note" not in result


### PR DESCRIPTION
## ROB-629 — `get_top_stocks(ranking_type=foreigners)` 외인 랭킹 정상화

`foreigners` 랭킹이 의미 불명확·잡주만·market_cap 전부 null·외인 net 필드 부재로 활용 불가하던 문제 해결. **마이그레이션 0, 순수 read-layer, KRX-only.**

### Task 5 — 명명 필드 + buy/sell split (`429e749a`)
- `foreign_net_qty`(`frgn_ntby_qty`) / `foreign_net_amount`(`frgn_ntby_tr_pbmn`)를 **명시 키로 표면** (기존 `volume`/`trade_amount` mislabel 중단)
- `ranking_type` 분리: `foreign_net_buy` / `foreign_net_sell` (`FID_RANK_SORT_CLS_CODE` 0/1), `foreigners`는 `foreign_net_buy` alias
- 가집계 off-session fake-0 suppress 가드

### Task 6 — market_cap backfill + 유동성 필터 (`0b686be4`)
- `market_cap` backfill: KIS payload → snapshot → shares×price → **honest null**(provenance `market_cap_source`)
- 기본 ON 유동성 필터: `|foreign_net_amount|` 임계(env-tunable), `include_illiquid` bypass, 필터-empties 시 정직 degraded

### 검증 후속 수정 (`c7b2c15a`/`ea12ab34`/`05e5ff01`)
8-에이전트 적대 리뷰 후 수정:
- **F4** import-time `float(os.getenv)` → `_env_float` 가드 (오타 env로 전체 랭킹 다운 방지)
- **F6** `_abs_foreign_amount` `trade_amount` 폴백 제거 (whole-market wrong-signal 위험 제거; 유일 콜러가 `foreign_net_amount` 항상 보장)
- **T1/T3** off-session fake-0 suppress 가드 테스트 + `_fetch_market_cap_maps` fail-open/shares-폴백 테스트, ruff format

### 검증
- **96 tests pass**, `ruff check`/`ruff format`/`ty check app/` 모두 green
- 마이그레이션 0, broker/order/watch mutation 도달 없음

---

## ⚠️ Post-merge operator 장중 검증 게이트 (필수)

`foreign_net_sell` 방향 의미는 오프라인에서 검증 불가 — **KRX 정규장(09:00–15:30 KST)** 중 실 KIS 호출로 아래 확인 필요:

- [ ] **net-sell 방향** — `get_top_stocks(market="kr", ranking_type="foreign_net_sell")`(FID `FID_RANK_SORT_CLS_CODE='1'`)가 실제 순매도 상위 반환, `foreign_net_qty`/`foreign_net_amount`가 매도 사이드
- [ ] **유동성 필터** — 기본 ON이 잡주(1억 KRW 미만 외인 net) 제외·대형주(예: 삼성전자 005930) 표면, `liquidity_filter.excluded_count` 타당, `include_illiquid=true`로 전체 복원
- [ ] **named 필드 값** — `foreign_net_qty`/`foreign_net_amount` 정상 magnitude, `market_cap` + `market_cap_source` 정합, null은 honest

> `foreign_net_buy`(=`foreigners` alias)는 기존 동작이라 저위험. **`foreign_net_sell`만 검증 대기.** 임계값 env: `FOREIGNERS_MIN_NET_AMOUNT_KRW`(기본 1억) / `FOREIGNERS_MIN_MARKET_CAP_KRW`(기본 300억).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F2treu74Jiun6cMrTSttN2
