### PR TITLE
fix(deploy): blue/green bootstrap retries launchd EIO + path-bootout

### DIFF
--- a/ops/native/scripts/native_deploy_lib.sh
+++ b/ops/native/scripts/native_deploy_lib.sh
@@ -75,6 +75,22 @@ sync_release_to_color_symlink() {
 }
 
 # bootstrap_color <service> <color>
+#
+# Retry/path-bootout semantics mirror restart_single_active_services() in
+# scripts/deploy-native.sh: macOS launchd can keep a failed/disabled
+# plist-PATH registration around after a label bootout (and tears jobs down
+# asynchronously), so an immediate bootstrap can return EIO
+# ("Bootstrap failed: 5: Input/output error") even though the label is no
+# longer visible. Boot out the installed plist PATH too, then retry the
+# bootstrap a few times to ride out the teardown before giving up. Without
+# this a single transient EIO aborts the whole blue/green deploy (observed in
+# GitHub Actions run 28408243128). The two implementations are kept separate
+# on purpose: restart_single_active_services() must run even when the deploy
+# rollback fires before native_deploy_lib.sh is sourced.
+#
+# Tunables (defaults match the single-active path: 5 attempts, 1s backoff):
+#   AUTO_TRADER_BOOTSTRAP_ATTEMPTS        (default 5)
+#   AUTO_TRADER_BOOTSTRAP_RETRY_SECONDS   (default 1)
 bootstrap_color() {
   local service="$1" color="$2"
   _bg_validate_service "$service" || return $?
@@ -88,7 +104,26 @@ bootstrap_color() {
   mkdir -p "$(dirname "$target")"
   install -m 0644 "$plist" "$target"
   launchctl bootout "gui/$uid/$label" 2>/dev/null || true
-  launchctl bootstrap "gui/$uid" "$target"
+  launchctl bootout "gui/$uid" "$target" 2>/dev/null || true
+
+  local attempts="${AUTO_TRADER_BOOTSTRAP_ATTEMPTS:-5}"
+  local interval="${AUTO_TRADER_BOOTSTRAP_RETRY_SECONDS:-1}"
+  # Clamp a misconfigured (non-numeric or <1) attempt count back to the default
+  # so the loop always runs at least once; otherwise execution would fall
+  # through to enable/kickstart against a label that was never bootstrapped.
+  [[ "$attempts" =~ ^[0-9]+$ ]] && (( attempts >= 1 )) || attempts=5
+  local attempt
+  for ((attempt = 1; attempt <= attempts; attempt++)); do
+    if launchctl bootstrap "gui/$uid" "$target"; then
+      break
+    fi
+    if (( attempt == attempts )); then
+      echo "bootstrap_color: $label failed to bootstrap after $attempt attempts" >&2
+      return 5
+    fi
+    sleep "$interval"
+  done
+
   launchctl enable "gui/$uid/$label"
   launchctl kickstart -k "gui/$uid/$label"
 }
@@ -98,11 +133,17 @@ drain_color() {
   local service="$1" color="$2"
   _bg_validate_service "$service" || return $?
   _bg_validate_color "$color" || return $?
-  local label uid
+  local label uid target
   label="$(color_label "$service" "$color")"
   uid="$(_ndl_uid)"
+  target="$HOME/Library/LaunchAgents/$label.plist"
   launchctl bootout "gui/$uid/$label" 2>/dev/null || true
-  # Leave plist on disk so re-bootstrap works on next deploy.
+  # Also boot out by plist PATH. macOS launchd can keep a stale plist-path
+  # registration after a label-only bootout; left to accumulate these surface
+  # later as a bootstrap EIO ("5: Input/output error"). Path-bootout keeps the
+  # domain clean so the next bootstrap_color starts from a clean slate. Best
+  # effort, like the label bootout. Plist stays on disk for re-bootstrap.
+  launchctl bootout "gui/$uid" "$target" 2>/dev/null || true
 }
 
 # probe_color_direct <color>

--- a/tests/scripts/test_deploy_native_bluegreen.py
+++ b/tests/scripts/test_deploy_native_bluegreen.py
@@ -135,11 +135,189 @@ def test_bootstrap_color_invokes_launchctl(tmp_path: Path) -> None:
     assert "bootstrap" in log and "api-green" in log
 
 
+def test_bootstrap_color_retries_and_path_bootouts_on_eio(tmp_path: Path) -> None:
+    """launchctl bootstrap can return EIO ("5: Input/output error") right after a
+    label bootout while launchd finishes its asynchronous teardown / keeps a
+    stale plist-PATH registration around. bootstrap_color must boot out the
+    plist PATH too (not just the label) and retry the bootstrap, mirroring the
+    proven restart_single_active_services() path in scripts/deploy-native.sh.
+
+    Regression guard for the deploy abort observed in GitHub Actions run
+    28408243128 ("bootstrap api-blue failed" -> "Bootstrap failed: 5:
+    Input/output error"): a single transient EIO must not kill the deploy.
+    """
+    base = _setup_base(tmp_path)
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir(exist_ok=True)
+    # launchctl stub: the FIRST `bootstrap` returns EIO (exit 5); later attempts
+    # succeed. Every invocation is still logged so we can assert the call shape.
+    (bin_dir / "launchctl").write_text(
+        "#!/usr/bin/env bash\n"
+        'echo "launchctl $*" >>"$LAUNCHCTL_LOG"\n'
+        'if [[ "$1" == "bootstrap" ]]; then\n'
+        '  cnt_file="$LAUNCHCTL_LOG.bootstrap_count"\n'
+        '  cnt=$(( $(cat "$cnt_file" 2>/dev/null || echo 0) + 1 ))\n'
+        '  echo "$cnt" >"$cnt_file"\n'
+        "  if (( cnt == 1 )); then\n"
+        '    echo "Bootstrap failed: 5: Input/output error" >&2\n'
+        "    exit 5\n"
+        "  fi\n"
+        "fi\n"
+        "exit 0\n"
+    )
+    (bin_dir / "launchctl").chmod(0o755)
+    log = tmp_path / "launchctl.log"
+    log.write_text("")
+    env = {
+        "PATH": f"{bin_dir}:{os.environ['PATH']}",
+        "HOME": str(tmp_path),
+        "AUTO_TRADER_BASE": str(base),
+        "LAUNCHCTL_LOG": str(log),
+        # Keep the retry backoff instant so the test stays fast.
+        "AUTO_TRADER_BOOTSTRAP_RETRY_SECONDS": "0",
+    }
+    script = f'set -Eeuo pipefail\nsource "{LIB}"\nbootstrap_color api green\n'
+    proc = subprocess.run(
+        ["bash", "-c", script], check=False, capture_output=True, text=True, env=env
+    )
+    log_text = log.read_text()
+    assert proc.returncode == 0, (
+        f"bootstrap_color must survive a transient EIO via retry; "
+        f"rc={proc.returncode} stderr={proc.stderr}\nlog:\n{log_text}"
+    )
+
+    target = f"{tmp_path}/Library/LaunchAgents/com.robinco.auto-trader.api-green.plist"
+    bootout_lines = [
+        line for line in log_text.splitlines() if line.startswith("launchctl bootout")
+    ]
+    # Must boot out the plist PATH (target), not just the label, to clear a
+    # stale plist-path registration that survives a label-only bootout.
+    assert any(target in line for line in bootout_lines), (
+        f"expected a path-level bootout of {target}; bootout lines:\n"
+        + "\n".join(bootout_lines)
+    )
+
+    bootstrap_lines = [
+        line for line in log_text.splitlines() if line.startswith("launchctl bootstrap")
+    ]
+    # Must retry the bootstrap (>=2 attempts) so a single EIO does not abort.
+    assert len(bootstrap_lines) >= 2, (
+        "expected bootstrap to be retried after EIO; bootstrap lines:\n"
+        + "\n".join(bootstrap_lines)
+    )
+
+
+def test_bootstrap_color_gives_up_after_bounded_attempts(tmp_path: Path) -> None:
+    """When bootstrap EIOs on every attempt, bootstrap_color must give up after a
+    BOUNDED number of attempts (no infinite loop) and return non-zero so the
+    blue/green flow rolls back instead of hanging the deploy.
+    """
+    base = _setup_base(tmp_path)
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir(exist_ok=True)
+    # launchctl stub: every `bootstrap` returns EIO (exit 5); everything else ok.
+    (bin_dir / "launchctl").write_text(
+        "#!/usr/bin/env bash\n"
+        'echo "launchctl $*" >>"$LAUNCHCTL_LOG"\n'
+        '[[ "$1" == "bootstrap" ]] && exit 5\n'
+        "exit 0\n"
+    )
+    (bin_dir / "launchctl").chmod(0o755)
+    log = tmp_path / "launchctl.log"
+    log.write_text("")
+    env = {
+        "PATH": f"{bin_dir}:{os.environ['PATH']}",
+        "HOME": str(tmp_path),
+        "AUTO_TRADER_BASE": str(base),
+        "LAUNCHCTL_LOG": str(log),
+        "AUTO_TRADER_BOOTSTRAP_ATTEMPTS": "3",
+        "AUTO_TRADER_BOOTSTRAP_RETRY_SECONDS": "0",
+    }
+    script = f'set -Eeuo pipefail\nsource "{LIB}"\nbootstrap_color api green\n'
+    proc = subprocess.run(
+        ["bash", "-c", script], check=False, capture_output=True, text=True, env=env
+    )
+    log_text = log.read_text()
+    assert proc.returncode != 0, (
+        f"bootstrap_color must fail when every bootstrap EIOs; log:\n{log_text}"
+    )
+    bootstrap_lines = [
+        line for line in log_text.splitlines() if line.startswith("launchctl bootstrap")
+    ]
+    # Exactly the configured attempt count — bounded, not infinite, not fewer.
+    assert len(bootstrap_lines) == 3, (
+        f"expected exactly 3 bootstrap attempts (bounded retry); got "
+        f"{len(bootstrap_lines)}:\n" + "\n".join(bootstrap_lines)
+    )
+    # Must NOT have enabled/kickstarted a job that never bootstrapped.
+    assert not any(
+        line.startswith("launchctl kickstart") for line in log_text.splitlines()
+    ), f"must not kickstart after exhausting bootstrap retries; log:\n{log_text}"
+
+
+def test_bootstrap_color_clamps_misconfigured_attempt_count(tmp_path: Path) -> None:
+    """A misconfigured AUTO_TRADER_BOOTSTRAP_ATTEMPTS (0 / non-numeric) must be
+    clamped back to the default so the retry loop still runs at least once.
+    Otherwise execution would fall through to enable/kickstart against a label
+    that was never bootstrapped.
+    """
+    base = _setup_base(tmp_path)
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir(exist_ok=True)
+    # bootstrap always EIOs: with a working clamp the loop runs the default 5x
+    # then gives up; with a broken clamp the loop runs 0x and falls through.
+    (bin_dir / "launchctl").write_text(
+        "#!/usr/bin/env bash\n"
+        'echo "launchctl $*" >>"$LAUNCHCTL_LOG"\n'
+        '[[ "$1" == "bootstrap" ]] && exit 5\n'
+        "exit 0\n"
+    )
+    (bin_dir / "launchctl").chmod(0o755)
+    log = tmp_path / "launchctl.log"
+    log.write_text("")
+    env = {
+        "PATH": f"{bin_dir}:{os.environ['PATH']}",
+        "HOME": str(tmp_path),
+        "AUTO_TRADER_BASE": str(base),
+        "LAUNCHCTL_LOG": str(log),
+        "AUTO_TRADER_BOOTSTRAP_ATTEMPTS": "0",  # misconfigured
+        "AUTO_TRADER_BOOTSTRAP_RETRY_SECONDS": "0",
+    }
+    script = f'set -Eeuo pipefail\nsource "{LIB}"\nbootstrap_color api green\n'
+    proc = subprocess.run(
+        ["bash", "-c", script], check=False, capture_output=True, text=True, env=env
+    )
+    log_text = log.read_text()
+    bootstrap_lines = [
+        line for line in log_text.splitlines() if line.startswith("launchctl bootstrap")
+    ]
+    # Clamped to the default of 5 attempts — never 0.
+    assert len(bootstrap_lines) == 5, (
+        f"expected attempt count clamped to default 5; got "
+        f"{len(bootstrap_lines)}:\n" + "\n".join(bootstrap_lines)
+    )
+    assert proc.returncode != 0
+    # Never kickstart a label that never bootstrapped.
+    assert not any(
+        line.startswith("launchctl kickstart") for line in log_text.splitlines()
+    ), f"must not kickstart when no bootstrap succeeded; log:\n{log_text}"
+
+
 def test_drain_color_bootouts(tmp_path: Path) -> None:
     base = _setup_base(tmp_path)
     proc = _run_bash("drain_color api blue", base, tmp_path)
     assert proc.returncode == 0, proc.stderr
-    assert "bootout" in proc.launchctl_log and "api-blue" in proc.launchctl_log  # type: ignore[attr-defined]
+    log = proc.launchctl_log  # type: ignore[attr-defined]
+    assert "bootout" in log and "api-blue" in log
+    # Must ALSO boot out by plist PATH so launchd does not accumulate stale
+    # plist-path registrations, which are the source of later bootstrap EIO
+    # (the leftover loaded inactive-color jobs seen on the host are evidence a
+    # label-only drain does not fully deregister).
+    target = f"{tmp_path}/Library/LaunchAgents/com.robinco.auto-trader.api-blue.plist"
+    assert any(
+        line.startswith("launchctl bootout") and target in line
+        for line in log.splitlines()
+    ), f"expected a path-level bootout of {target}; log:\n{log}"
 
 
 def test_probe_color_direct_passes(tmp_path: Path) -> None:


### PR DESCRIPTION
## 문제

production 배포(GitHub Actions run [28408243128](https://github.com/mgh3326/auto_trader/actions/runs/28408243128))가 **블루/그린 launchd 부트스트랩**에서 중단:

```
active api=green mcp=blue; bootstrapping api=blue mcp=green
Bootstrap failed: 5: Input/output error
bootstrap api-blue failed
Deploy failed with exit code 1
```

빌드·Alembic·preflight는 모두 통과했고, `launchctl bootstrap`이 `5: Input/output error`(EIO)를 반환하며 죽었습니다. macOS launchd는 label을 막 bootout한 직후(비동기 teardown)거나 stale plist-PATH 등록이 남아 있을 때 이 EIO를 반환합니다.

## 근본 원인 — 두 부트스트랩 구현의 drift

| 경로 | 사용처 | path-bootout | EIO 재시도 |
|------|--------|:---:|:---:|
| `restart_single_active_services()` (`scripts/deploy-native.sh:134`) | worker/scheduler/websocket | ✅ | ✅ 5×/1s |
| `bootstrap_color()` (`ops/native/scripts/native_deploy_lib.sh:78`) | **api/mcp 블루그린** | ❌ | ❌ 단발 |

`deploy-native.sh:149-151`에는 *이 EIO를 정확히 설명하는 주석*과 방어 코드(plist-PATH bootout + 5회 재시도)가 이미 있었지만, 블루/그린 경로(`bootstrap_color`)에는 포팅되지 않았습니다. 단발 EIO 하나가 배포 전체를 중단시켰습니다.

라이브 호스트 조사에서 비활성 색상 잔존 job(`mcp-green`이 `mcp=blue` 활성 중에도 로드됨)을 확인 — 이 호스트가 실제로 그 launchd 상태에 자주 빠진다는 직접 증거.

## 수정

- **`bootstrap_color`**: 검증된 single-active 패턴 포팅 — plist-PATH bootout 추가 + bounded 재시도(`AUTO_TRADER_BOOTSTRAP_ATTEMPTS`=5 / `AUTO_TRADER_BOOTSTRAP_RETRY_SECONDS`=1 튜너블, attempt count는 `>=1`로 clamp). 두 구현을 일부러 분리 유지(rollback이 lib source 전에 발생 가능).
- **`drain_color`**: label-only bootout이 stale 등록을 누적시키는 *근본 원인*이므로 plist-PATH bootout도 추가 — domain을 깨끗하게 유지.
- **테스트**: 프로덕션 EIO를 그대로 재현 + 재시도/path-bootout/bounded give-up/clamp 검증, drain_color path-bootout 검증.

## 검증

- TDD: 실패 테스트가 프로덕션 에러(`rc=5, "Bootstrap failed: 5: Input/output error"`)를 정확히 재현 → RED → 수정 후 GREEN
- 배포 스크립트 테스트 33개 전부 통과 (bluegreen 14 / preflight / rollback-split), `bash -n` OK, ruff lint+format 클린
- 3-에이전트 적대적 검증(root-cause 반증 / fix 안전성 / 완전성) **전부 CONFIRMED** — `set -e` 산술 안전성, 콜사이트(forward + rollback) 안전성, latency bound 확인. path-bootout은 color-scoped라 라이브 활성 색상에 절대 영향 없음.
- migration 0 · app 코드 무변경 · 배포 인프라(bash)만 변경

## ⚠️ 운영 주의 (operator)

1. **실패한 run 28408243128을 "Re-run" 하지 말 것** — 같은 옛 SHA를 재배포해 수정 없는 `bootstrap_color`를 다시 source하므로 동일 EIO 재발 가능. **이 PR 머지 후 머지 커밋을 대상으로 새 production 배포를 트리거**해야 수정본이 실행됨 (`deploy-native.sh`가 `$NEW_RELEASE`에서 lib를 source하므로 자가 적용).
2. 현재 프로덕션은 정상 가동 중이나 **구버전 서빙**(api=`47441b05`). 다음 배포가 심링크/색상 상태를 자가 치유.

## 후속(별도 이슈 권장 — 본 실패의 원인 아님)

- 블루/그린이 bootstrap 전에 실패하면 `current-blue/green` 심링크가 실패 릴리스를 가리킨 채 복원 안 됨(`BLUEGREEN_COMMITTED=0`이라 rollback이 심링크 미복원).
- split-color 토폴로지에서 비활성 색상 sync가 양쪽 활성 심링크를 덮어써, 라이브 job 재기동 시 미검증 릴리스 서빙 가능.
- `drain_color` eviction을 bounded poll로 검증(잔존 job 누적 방지).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved app startup reliability by retrying service registration when temporary launch errors occur.
  * Ensured shutdown clears both service and plist-based registrations to avoid stale entries causing future startup issues.

* **Tests**
  * Added coverage for retry behavior, retry limits, and invalid retry settings.
  * Strengthened shutdown tests to verify both registration types are removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->