### PR TITLE
fix(ROB-631): toss_reconcile_orders KR equity booking 복구 (InstrumentType + 90s 예산)

### DIFF
--- a/app/mcp_server/timeout_middleware.py
+++ b/app/mcp_server/timeout_middleware.py
@@ -62,9 +62,11 @@ ELEVATED_TOOL_TIMEOUTS_S: dict[str, float] = {
     # OHLCV + indicator compute; news fetch.
     "get_indicators": 75.0,
     "get_news": 75.0,
-    # Order reconcile fan-out over daily order history.
+    # Order reconcile fan-out over daily order history (KIS/live) or per-order
+    # detail GET per open ledger row (Toss, N+1 — ROB-631).
     "kis_live_reconcile_orders": 90.0,
     "live_reconcile_orders": 90.0,
+    "toss_reconcile_orders": 90.0,
 }
 
 

--- a/app/mcp_server/tooling/toss_live_ledger.py
+++ b/app/mcp_server/tooling/toss_live_ledger.py
@@ -304,7 +304,7 @@ async def _reconcile_one_toss_row(
 
     trade_id = await _save_order_fill(
         symbol=row.symbol,
-        instrument_type=("equity" if row.market == "kr" else "equity_us"),
+        instrument_type=("equity_kr" if row.market == "kr" else "equity_us"),
         side=row.side,
         price=float(avg_price),
         quantity=float(delta),
@@ -320,7 +320,7 @@ async def _reconcile_one_toss_row(
     if row.side == "buy" and row.journal_id is None:
         jr = await _create_trade_journal_for_buy(
             symbol=row.symbol,
-            market_type=("equity" if row.market == "kr" else "equity_us"),
+            market_type=("equity_kr" if row.market == "kr" else "equity_us"),
             preview={
                 "price": float(avg_price),
                 "quantity": float(broker_cum),

--- a/docs/runbooks/toss-live-order-reconcile.md
+++ b/docs/runbooks/toss-live-order-reconcile.md
@@ -109,6 +109,60 @@ For each row, verify the Toss broker UI/API order detail before booking a fill,
 closing the row, or resetting it for another reconcile attempt. Do not infer a
 cancel or fill from a missing/failed order-detail response.
 
+## Re-opening `'equity'` InstrumentType Anomalies (ROB-631)
+
+Before the ROB-631 fix, KR equity fills were booked with the invalid instrument
+type literal `"equity"`. `InstrumentType("equity")` raised
+`ValueError: 'equity' is not a valid InstrumentType` (valid members are
+`equity_kr`, `equity_us`, `crypto`, `forex`, `index`), so KR rows were parked as
+`status='anomaly'` / `requires_manual_review=true` instead of booked
+(e.g. ledger 139, 169 두산에너빌리티 034020).
+
+The fix changes the KR branch to `"equity_kr"`. New KR fills book normally, but
+**existing anomaly rows are not re-processed automatically**: `list_open` only
+selects `status IN ('accepted','pending','partial')`, and there is no
+service-level reset method. The anomaly path wrote no `filled_qty` / `trade_id`
+/ `journal_id`, so re-booking is safe and idempotent once the row is re-opened
+(`review.trades` insert is `ON CONFLICT DO NOTHING` on
+`uq_review_trades_account_order`; the buy journal is gated on `journal_id IS NULL`).
+
+Remediation (operator, one-off after deploying the fix):
+
+1. Identify the bug-caused rows — these carry the exact InstrumentType error and
+   nothing else. **Any other anomaly (e.g. 403/non-JSON) must be verified
+   against the Toss broker order detail first and must NOT be reset blindly.**
+
+   ```sql
+   SELECT id, market, symbol, broker_order_id, status, last_reconcile_error
+   FROM review.toss_live_order_ledger
+   WHERE status = 'anomaly'
+     AND requires_manual_review IS TRUE
+     AND last_reconcile_error->>'type' = 'ValueError'
+     AND last_reconcile_error->>'message' LIKE '%is not a valid InstrumentType%';
+   ```
+
+2. After confirming the rows above are exactly the bug-caused ones, re-open them
+   so reconcile can pick them up again:
+
+   ```sql
+   UPDATE review.toss_live_order_ledger
+   SET status = 'accepted',
+       requires_manual_review = FALSE,
+       manual_review_reason = NULL,
+       last_reconcile_error = NULL
+   WHERE id IN (139, 169);  -- replace with the ids confirmed in step 1
+   ```
+
+3. Re-run reconcile against the broker order detail to book the fills:
+
+   ```bash
+   toss_reconcile_orders(market="kr", symbol="034020", dry_run=True)
+   toss_reconcile_orders(market="kr", symbol="034020", dry_run=False)
+   ```
+
+4. Confirm the rows now show `status='filled'` (or `partial`) with non-null
+   `trade_id` / `journal_id`, and that `review.trades` + the buy journal exist.
+
 ## US FX PnL Split
 
 Toss `GET /orders/{orderId}` execution does not include fill-time FX fields. For

--- a/tests/mcp_server/tooling/test_toss_live_ledger.py
+++ b/tests/mcp_server/tooling/test_toss_live_ledger.py
@@ -39,20 +39,22 @@ def _patch_session_factory(db_session):
         yield
 
 
-async def _accepted(db_session, *, side: str = "buy"):
+async def _accepted(db_session, *, side: str = "buy", market: str = "us"):
+    is_kr = market == "kr"
+    suffix = side if market == "us" else f"{market}-{side}"
     return await TossLiveOrderLedgerService(db_session).record_send(
         operation_kind="place",
-        market="us",
-        symbol="AAPL",
+        market=market,
+        symbol="034020" if is_kr else "AAPL",
         side=side,
         order_type="limit",
         time_in_force="DAY",
-        quantity=Decimal("2"),
-        price=Decimal("190"),
+        quantity=Decimal("3") if is_kr else Decimal("2"),
+        price=Decimal("85000") if is_kr else Decimal("190"),
         order_amount=None,
-        currency="USD",
-        client_order_id=f"cid-{side}",
-        broker_order_id=f"ord-{side}",
+        currency="KRW" if is_kr else "USD",
+        client_order_id=f"cid-{suffix}",
+        broker_order_id=f"ord-{suffix}",
         original_order_id=None,
         status="accepted",
         broker_status=None,
@@ -109,6 +111,116 @@ async def test_reconcile_filled_buy_books_once(db_session):
     assert m_fill.await_count == 1
     assert m_fill.await_args.kwargs["fee"] == 0.06
     assert m_journal.await_count == 1
+
+
+async def test_reconcile_filled_kr_buy_books_with_equity_kr_instrument_type(db_session):
+    """ROB-631: KR equity fills must book with InstrumentType.equity_kr.
+
+    The reconcile path previously hardcoded the invalid literal ``"equity"`` for
+    KR rows, which is not an ``InstrumentType`` member, so the buy-journal create
+    raised ``ValueError: 'equity' is not a valid InstrumentType`` and the row was
+    parked as anomaly/requires_manual_review instead of being booked.
+    """
+    from app.mcp_server.tooling import toss_live_ledger as mod
+    from app.mcp_server.tooling.toss_live_evidence import TossFillEvidence
+    from app.models.trading import InstrumentType
+
+    row = await _accepted(db_session, side="buy", market="kr")
+    evidence = TossFillEvidence(
+        verdict="filled",
+        local_status="filled",
+        broker_status="FILLED",
+        filled_qty=Decimal("3"),
+        avg_price=Decimal("85000"),
+        commission=Decimal("100"),
+        tax=Decimal("50"),
+        fee_total=Decimal("150"),
+        settlement_date=None,
+        raw_order={"status": "FILLED"},
+        reason="filled",
+    )
+
+    class _Adapter:
+        fetch_evidence = AsyncMock(return_value=evidence)
+
+    with (
+        patch.object(mod.settings, "toss_fill_notify_enabled", False),
+        patch.object(mod, "TossEvidenceAdapter", return_value=_Adapter()),
+        patch.object(
+            mod, "_save_order_fill", new=AsyncMock(return_value=101)
+        ) as m_fill,
+        patch.object(
+            mod,
+            "_create_trade_journal_for_buy",
+            new=AsyncMock(return_value={"journal_created": True, "journal_id": 202}),
+        ) as m_journal,
+        patch.object(mod, "_link_journal_to_fill", new=AsyncMock()),
+    ):
+        out = await mod._reconcile_one_toss_row(row, dry_run=False)
+
+    assert out["action"] == "booked"
+    # The instrument type fed to both the trade-fill insert and the buy journal
+    # must be a valid InstrumentType member for KR equities, not the bare "equity".
+    assert m_fill.await_args.kwargs["instrument_type"] == "equity_kr"
+    assert m_journal.await_args.kwargs["market_type"] == "equity_kr"
+    # Bind the contract to the real consequence: InstrumentType(...) must not raise.
+    assert (
+        InstrumentType(m_journal.await_args.kwargs["market_type"])
+        is InstrumentType.equity_kr
+    )
+
+
+async def test_reconcile_filled_kr_sell_books_with_equity_kr_instrument_type(
+    db_session,
+):
+    """ROB-631: KR sell fills also pass instrument type to _save_order_fill.
+
+    On the sell path the bad "equity" literal was swallowed by _save_order_fill's
+    try/except, silently dropping the trade row. The fill must carry "equity_kr".
+    """
+    from app.mcp_server.tooling import toss_live_ledger as mod
+    from app.mcp_server.tooling.toss_live_evidence import TossFillEvidence
+
+    row = await _accepted(db_session, side="sell", market="kr")
+    evidence = TossFillEvidence(
+        verdict="filled",
+        local_status="filled",
+        broker_status="FILLED",
+        filled_qty=Decimal("3"),
+        avg_price=Decimal("90000"),
+        commission=Decimal("100"),
+        tax=Decimal("50"),
+        fee_total=Decimal("150"),
+        settlement_date=None,
+        raw_order={"status": "FILLED"},
+        reason="filled",
+    )
+    close_result = {
+        "journals_closed": 1,
+        "journals_kept": 0,
+        "closed_ids": [77],
+        "total_pnl_pct": 5.0,
+        "realized_pnl_basis": "journal_entry",
+        "total_pnl_krw": 15000.0,
+    }
+
+    class _Adapter:
+        fetch_evidence = AsyncMock(return_value=evidence)
+
+    with (
+        patch.object(mod.settings, "toss_fill_notify_enabled", False),
+        patch.object(mod, "TossEvidenceAdapter", return_value=_Adapter()),
+        patch.object(
+            mod, "_save_order_fill", new=AsyncMock(return_value=303)
+        ) as m_fill,
+        patch.object(
+            mod, "_close_journals_on_sell", new=AsyncMock(return_value=close_result)
+        ),
+    ):
+        out = await mod._reconcile_one_toss_row(row, dry_run=False)
+
+    assert out["action"] == "booked"
+    assert m_fill.await_args.kwargs["instrument_type"] == "equity_kr"
 
 
 async def test_reconcile_cancelled_partial_books_delta_and_terminal(db_session):

--- a/tests/test_mcp_timeout_middleware.py
+++ b/tests/test_mcp_timeout_middleware.py
@@ -88,6 +88,17 @@ def test_budget_resolution_default_and_overrides() -> None:
 
 
 @pytest.mark.unit
+def test_reconcile_tools_share_elevated_budget() -> None:
+    # ROB-631: toss_reconcile_orders fans out a single-detail GET per open order
+    # and was being killed by the 45s default; it must get the same elevated budget
+    # as its KIS/live reconcile siblings.
+    mw = ToolTimeoutMiddleware(default_timeout_s=45.0)
+    assert mw._budget_for("kis_live_reconcile_orders") == 90.0
+    assert mw._budget_for("live_reconcile_orders") == 90.0
+    assert mw._budget_for("toss_reconcile_orders") == 90.0
+
+
+@pytest.mark.unit
 @pytest.mark.asyncio
 async def test_tool_own_timeouterror_propagates_unwrapped() -> None:
     # A tool that raises its OWN TimeoutError BEFORE the budget elapses must NOT be


### PR DESCRIPTION
## 문제 (ROB-631, High)

2026-06-30 두산에너빌리티(034020) 체결 후 `toss_reconcile_orders(market="kr", symbol="034020", dry_run=False)`가 **ValueError `"'equity' is not a valid InstrumentType"`** 로 실패 → 체결된 KR 주식이 `anomaly`/`requires_manual_review`로 빠져 **거래일지·realized_pnl·ledger booking 무력화**. (ledger 139/169)

## 근본 원인

`InstrumentType` StrEnum(`app/models/trading.py:19-24`)에는 `equity_kr / equity_us / crypto / forex / index`만 존재하고 `equity` 멤버가 없음. 그런데 reconcile이 KR 분기에서 **잘못된 리터럴 `"equity"`를 하드코딩** (`toss_live_ledger.py:307,323`):

- KR 매수 → `_create_trade_journal_for_buy` → `order_journal.py:180`의 `InstrumentType("equity")`가 **raise** → reconcile 루프가 잡아 anomaly 처리.
- KR 매도 → 같은 `"equity"`가 `_save_order_fill`로 가는데, 거긴 enum insert 에러를 **조용히 삼켜** `review.trades`에 기록 안 됨 (잠복 데이터 손실).

형제 경로(`live_order_ledger.py`, `kis_live_ledger.py`)는 유효 enum 값을 넘겨 정상 동작 — Toss 경로만 버그.

## 변경

| 변경 | 위치 |
|---|---|
| KR 분기 `"equity"` → `"equity_kr"` | `toss_live_ledger.py:307,323` |
| `ELEVATED_TOOL_TIMEOUTS_S`에 `toss_reconcile_orders: 90.0` 추가 (no-symbol limit 100이 45s 기본 예산에 죽던 부수 이슈; KIS/live 형제와 동일) | `timeout_middleware.py` |
| 배포 후 막힌 anomaly 행 운영자 SQL 복구 절차 | `docs/runbooks/toss-live-order-reconcile.md` |
| KR 매수/매도 booking 회귀 2건 + reconcile 90s 예산 1건 (TDD RED→GREEN) | `test_toss_live_ledger.py`, `test_mcp_timeout_middleware.py` |

## 검증

- 신규 3개 테스트: RED(`'equity' == 'equity_kr'`, `45.0 == 90.0`) → fix → GREEN.
- toss reconcile + timeout 스위트 **93 passed**, ruff format/check 클린.
- `app/` 전체에 다른 bare `"equity"` → `InstrumentType` 유입 경로 없음 확인(나머지는 UI assetType/share-class screening 등 별개 도메인).

## 운영자 후속 (배포 후)

막힌 행은 fix 후에도 자동 재처리 안 됨(`list_open`이 `anomaly` 제외). 런북 절차대로 139/169을 `accepted`로 reset → `toss_reconcile_orders(market="kr", symbol="034020", dry_run=False)` 재실행 → booking 확인.

## 범위 밖 (분리)

N+1(`get_order` per-row) 근본 재작성과 관측성 묶음(REJECTED 무알림 · ledger open-set lag)은 **ROB-632**로 분리.

🤖 Generated with [Claude Code](https://claude.com/claude-code)