### PR TITLE
feat(ROB-637): analysis artifact storage — save/list/get MCP tools

### DIFF
--- a/alembic/versions/20260702_rob637_analysis_artifacts.py
+++ b/alembic/versions/20260702_rob637_analysis_artifacts.py
@@ -1,0 +1,134 @@
+"""ROB-637 analysis artifact persistence store
+
+Revision ID: 20260702_rob637
+Revises: 20260620_scalp_benchmark
+Create Date: 2026-07-02 00:00:00.000000
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "20260702_rob637"
+down_revision: str | None = "20260620_scalp_benchmark"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "analysis_artifacts",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column(
+            "artifact_uuid",
+            postgresql.UUID(as_uuid=True),
+            nullable=False,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column("market", sa.Text(), nullable=False),
+        sa.Column("kind", sa.Text(), nullable=False),
+        sa.Column("title", sa.Text(), nullable=False),
+        sa.Column(
+            "symbols",
+            postgresql.ARRAY(sa.Text()),
+            nullable=False,
+            server_default=sa.text("'{}'"),
+        ),
+        sa.Column(
+            "payload",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default=sa.text("'{}'::jsonb"),
+        ),
+        sa.Column(
+            "as_of",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+        ),
+        sa.Column(
+            "valid_until",
+            sa.TIMESTAMP(timezone=True),
+            nullable=True,
+        ),
+        sa.Column("session_label", sa.Text(), nullable=True),
+        sa.Column(
+            "created_by",
+            sa.Text(),
+            nullable=False,
+            server_default=sa.text("'claude'"),
+        ),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "artifact_uuid",
+            name="uq_analysis_artifacts_artifact_uuid",
+        ),
+        sa.CheckConstraint(
+            "market IN ('kr','us','crypto')",
+            name="ck_analysis_artifacts_market",
+        ),
+        sa.CheckConstraint(
+            "kind IN ("
+            "'screening_ranking','profit_taking_verdicts',"
+            "'support_resistance_map','flow_assessment',"
+            "'candidate_pool','session_summary'"
+            ")",
+            name="ck_analysis_artifacts_kind",
+        ),
+        sa.CheckConstraint(
+            "created_by IN ('claude','operator','system')",
+            name="ck_analysis_artifacts_created_by",
+        ),
+        schema="review",
+    )
+    op.create_index(
+        "ix_analysis_artifacts_kind_market_as_of",
+        "analysis_artifacts",
+        ["kind", "market", sa.text("as_of DESC")],
+        schema="review",
+    )
+    op.create_index(
+        "ix_analysis_artifacts_symbols_gin",
+        "analysis_artifacts",
+        ["symbols"],
+        unique=False,
+        schema="review",
+        postgresql_using="gin",
+    )
+    op.create_index(
+        "ix_analysis_artifacts_payload_gin",
+        "analysis_artifacts",
+        ["payload"],
+        unique=False,
+        schema="review",
+        postgresql_using="gin",
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_analysis_artifacts_payload_gin",
+        table_name="analysis_artifacts",
+        schema="review",
+    )
+    op.drop_index(
+        "ix_analysis_artifacts_symbols_gin",
+        table_name="analysis_artifacts",
+        schema="review",
+    )
+    op.drop_index(
+        "ix_analysis_artifacts_kind_market_as_of",
+        table_name="analysis_artifacts",
+        schema="review",
+    )
+    op.drop_table("analysis_artifacts", schema="review")

--- a/alembic/versions/20260702_rob637_analysis_artifacts.py
+++ b/alembic/versions/20260702_rob637_analysis_artifacts.py
@@ -56,6 +56,8 @@ def upgrade() -> None:
             nullable=True,
         ),
         sa.Column("session_label", sa.Text(), nullable=True),
+        sa.Column("correlation_id", sa.Text(), nullable=True),
+        sa.Column("account_scope", sa.Text(), nullable=True),
         sa.Column(
             "created_by",
             sa.Text(),
@@ -73,6 +75,10 @@ def upgrade() -> None:
             "artifact_uuid",
             name="uq_analysis_artifacts_artifact_uuid",
         ),
+        sa.UniqueConstraint(
+            "correlation_id",
+            name="uq_analysis_artifacts_correlation_id",
+        ),
         sa.CheckConstraint(
             "market IN ('kr','us','crypto')",
             name="ck_analysis_artifacts_market",
@@ -81,7 +87,7 @@ def upgrade() -> None:
             "kind IN ("
             "'screening_ranking','profit_taking_verdicts',"
             "'support_resistance_map','flow_assessment',"
-            "'candidate_pool','session_summary'"
+            "'candidate_pool','session_summary','briefing'"
             ")",
             name="ck_analysis_artifacts_kind",
         ),
@@ -105,22 +111,11 @@ def upgrade() -> None:
         schema="review",
         postgresql_using="gin",
     )
-    op.create_index(
-        "ix_analysis_artifacts_payload_gin",
-        "analysis_artifacts",
-        ["payload"],
-        unique=False,
-        schema="review",
-        postgresql_using="gin",
-    )
+    # NOTE: no GIN index on payload — no payload-containment query exists;
+    # a payload GIN would be pure write amplification (review finding).
 
 
 def downgrade() -> None:
-    op.drop_index(
-        "ix_analysis_artifacts_payload_gin",
-        table_name="analysis_artifacts",
-        schema="review",
-    )
     op.drop_index(
         "ix_analysis_artifacts_symbols_gin",
         table_name="analysis_artifacts",

--- a/app/mcp_server/README.md
+++ b/app/mcp_server/README.md
@@ -241,6 +241,39 @@ returns recent entries newest first. `limit` is clamped to 1..100 and defaults
 to 20. New trading sessions should call this before comparing yesterday's plan
 with today's candidate tournament.
 
+### Analysis Artifact Tools
+
+`analysis_artifact_save(market, kind, title, symbols?, payload?, as_of?, valid_until?, created_by?, session_label?)`
+persists a structured analysis artifact for cross-session reuse. It is for the
+durable outputs of analysis runs — screening rankings, profit-taking verdicts,
+support/resistance maps, flow assessments, candidate pools, and session
+summaries — so a later session can reuse them instead of recomputing. Save is
+explicit only; `analyze_stock_batch` and other analysis runs do not auto-persist.
+
+Each artifact accepts:
+
+- `market` required: `kr`, `us`, or `crypto`.
+- `kind` required: `screening_ranking`, `profit_taking_verdicts`,
+  `support_resistance_map`, `flow_assessment`, `candidate_pool`,
+  `session_summary`.
+- `title` required short title.
+- `symbols` optional string list; defaults to empty.
+- `payload` optional JSON object; defaults to empty.
+- `as_of` optional ISO datetime; defaults to now (UTC).
+- `valid_until` optional ISO datetime; when in the past the artifact is stale
+  and excluded from `analysis_artifact_list` unless `include_stale=true`.
+- `created_by` optional: `claude`, `operator`, `system`; defaults to `claude`.
+- `session_label` optional grouping label.
+
+`analysis_artifact_list(market?, kind?, symbol?, since?, include_stale?, limit)`
+returns matching artifacts newest `as_of` first. `symbol` does a containment
+match on the `symbols` array. `limit` is clamped to 1..100 and defaults to 20.
+Stale rows (`valid_until` in the past) are excluded unless `include_stale=true`.
+
+`analysis_artifact_get(artifact_id)` returns a single artifact including the
+full payload, by numeric `id` or `artifact_uuid` string. Missing ids return
+`success=false` with `error="not_found"`.
+
 ### Investment Report Tools
 
 - `investment_report_add_items(report_uuid, items, actor=None)` - Append new proposal items to an existing draft investment report. The item payload contract matches `investment_report_create`. Duplicate `client_item_key` rows are returned as existing items and are not rewritten. Non-draft reports return `error="not_draft"`. No broker, order, or watch mutation is performed.

--- a/app/mcp_server/tooling/__init__.py
+++ b/app/mcp_server/tooling/__init__.py
@@ -32,6 +32,7 @@ __all__ = [
     "register_investment_snapshots_tools",
     "register_trade_journal_tools",
     "register_news_tools",
+    "register_analysis_artifact_tools",
     "register_session_context_tools",
 ]
 
@@ -75,6 +76,10 @@ _LAZY_EXPORTS: dict[str, tuple[str, str]] = {
     "register_session_context_tools": (
         "app.mcp_server.tooling.session_context_registration",
         "register_session_context_tools",
+    ),
+    "register_analysis_artifact_tools": (
+        "app.mcp_server.tooling.analysis_artifact_registration",
+        "register_analysis_artifact_tools",
     ),
 }
 

--- a/app/mcp_server/tooling/analysis_artifact_registration.py
+++ b/app/mcp_server/tooling/analysis_artifact_registration.py
@@ -28,17 +28,23 @@ def register_analysis_artifact_tools(mcp: FastMCP) -> None:
             "Persist a structured analysis artifact (screening ranking, "
             "profit-taking verdicts, support/resistance map, flow assessment, "
             "candidate pool, or session summary) for cross-session reuse. "
-            "Explicit save only — analysis runs do not auto-persist."
+            "Explicit save only — analysis runs do not auto-persist. "
+            "Idempotent per correlation_id: re-saving the same correlation_id "
+            "updates the row in place (omit to append). Payload capped at "
+            "100KB (payload_too_large above that). Recent valid artifacts "
+            "are surfaced metadata-only in get_operating_briefing."
         ),
     )(analysis_artifact_save)
     _ = mcp.tool(
         name="analysis_artifact_list",
         description=(
-            "List persisted analysis artifacts, newest as_of first. "
-            "Optional filters: market, kind, symbol (containment match on the "
-            "symbols array), since, include_stale, limit clamped to 1..100. "
-            "Stale rows (valid_until in the past) are excluded unless "
-            "include_stale=true."
+            "List persisted analysis artifacts, newest as_of first — "
+            "metadata only, no payload (payload_size_bytes hints the "
+            "analysis_artifact_get cost). Optional filters: market, kind, "
+            "symbol (containment match on the symbols array), since, "
+            "correlation_id, account_scope, include_stale, limit clamped to "
+            "1..100. Stale rows (valid_until in the past) are excluded unless "
+            "include_stale=true; each row carries is_stale."
         ),
     )(analysis_artifact_list)
     _ = mcp.tool(

--- a/app/mcp_server/tooling/analysis_artifact_registration.py
+++ b/app/mcp_server/tooling/analysis_artifact_registration.py
@@ -1,0 +1,56 @@
+"""MCP registration for ROB-637 analysis artifact tools."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from app.mcp_server.tooling.analysis_artifact_tools import (
+    analysis_artifact_get,
+    analysis_artifact_list,
+    analysis_artifact_save,
+)
+
+if TYPE_CHECKING:
+    from fastmcp import FastMCP
+
+
+ANALYSIS_ARTIFACT_TOOL_NAMES: set[str] = {
+    "analysis_artifact_save",
+    "analysis_artifact_list",
+    "analysis_artifact_get",
+}
+
+
+def register_analysis_artifact_tools(mcp: FastMCP) -> None:
+    _ = mcp.tool(
+        name="analysis_artifact_save",
+        description=(
+            "Persist a structured analysis artifact (screening ranking, "
+            "profit-taking verdicts, support/resistance map, flow assessment, "
+            "candidate pool, or session summary) for cross-session reuse. "
+            "Explicit save only — analysis runs do not auto-persist."
+        ),
+    )(analysis_artifact_save)
+    _ = mcp.tool(
+        name="analysis_artifact_list",
+        description=(
+            "List persisted analysis artifacts, newest as_of first. "
+            "Optional filters: market, kind, symbol (containment match on the "
+            "symbols array), since, include_stale, limit clamped to 1..100. "
+            "Stale rows (valid_until in the past) are excluded unless "
+            "include_stale=true."
+        ),
+    )(analysis_artifact_list)
+    _ = mcp.tool(
+        name="analysis_artifact_get",
+        description=(
+            "Fetch a single analysis artifact by numeric id or artifact_uuid, "
+            "including the full payload."
+        ),
+    )(analysis_artifact_get)
+
+
+__all__ = [
+    "ANALYSIS_ARTIFACT_TOOL_NAMES",
+    "register_analysis_artifact_tools",
+]

--- a/app/mcp_server/tooling/analysis_artifact_tools.py
+++ b/app/mcp_server/tooling/analysis_artifact_tools.py
@@ -1,0 +1,128 @@
+"""MCP tools for ROB-637 analysis artifact persistence."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+from pydantic import ValidationError
+
+from app.core.db import AsyncSessionLocal
+from app.schemas.analysis_artifact import (
+    AnalysisArtifactGetResponse,
+    AnalysisArtifactListRequest,
+    AnalysisArtifactListResponse,
+    AnalysisArtifactRead,
+    AnalysisArtifactSave,
+    AnalysisArtifactSaveResponse,
+)
+from app.services.analysis_artifact import AnalysisArtifactService
+
+
+def _validation_error(exc: ValidationError) -> dict[str, Any]:
+    return {
+        "success": False,
+        "error": "invalid_request",
+        "detail": exc.errors(),
+    }
+
+
+async def analysis_artifact_save(
+    market: str,
+    kind: str,
+    title: str,
+    symbols: list[str] | None = None,
+    payload: dict[str, Any] | None = None,
+    as_of: str | None = None,
+    valid_until: str | None = None,
+    created_by: str = "claude",
+    session_label: str | None = None,
+) -> dict[str, Any]:
+    """Persist a single analysis artifact for cross-session reuse."""
+    try:
+        entry = AnalysisArtifactSave.model_validate(
+            {
+                "market": market,
+                "kind": kind,
+                "title": title,
+                "symbols": symbols or [],
+                "payload": payload or {},
+                "as_of": as_of or datetime.now(tz=UTC).isoformat(),
+                "valid_until": valid_until,
+                "created_by": created_by,
+                "session_label": session_label,
+            }
+        )
+    except ValidationError as exc:
+        return _validation_error(exc)
+
+    async with AsyncSessionLocal() as db:
+        service = AnalysisArtifactService(db)
+        row = await service.save(entry)
+        await db.commit()
+        response = AnalysisArtifactSaveResponse(
+            artifact=AnalysisArtifactRead.model_validate(row),
+        )
+    return response.model_dump(mode="json")
+
+
+async def analysis_artifact_list(
+    market: str | None = None,
+    kind: str | None = None,
+    symbol: str | None = None,
+    since: str | None = None,
+    include_stale: bool = False,
+    limit: int = 20,
+) -> dict[str, Any]:
+    """Return analysis artifacts matching filters, newest ``as_of`` first."""
+    try:
+        request = AnalysisArtifactListRequest.model_validate(
+            {
+                "market": market,
+                "kind": kind,
+                "symbol": symbol,
+                "since": since,
+                "include_stale": include_stale,
+                "limit": limit,
+            }
+        )
+    except ValidationError as exc:
+        return _validation_error(exc)
+
+    async with AsyncSessionLocal() as db:
+        service = AnalysisArtifactService(db)
+        rows = await service.list_artifacts(
+            market=request.market,
+            kind=request.kind,
+            symbol=request.symbol,
+            since=request.since,
+            include_stale=request.include_stale,
+            limit=request.limit,
+        )
+        response = AnalysisArtifactListResponse(
+            count=len(rows),
+            filters=request,
+            artifacts=[
+                AnalysisArtifactRead.model_validate(row) for row in rows
+            ],
+        )
+    return response.model_dump(mode="json")
+
+
+async def analysis_artifact_get(
+    artifact_id: int | str,
+) -> dict[str, Any]:
+    """Return a single analysis artifact by id or artifact_uuid."""
+    async with AsyncSessionLocal() as db:
+        service = AnalysisArtifactService(db)
+        row = await service.get(artifact_id)
+        if row is None:
+            return {
+                "success": False,
+                "error": "not_found",
+                "artifact_id": artifact_id,
+            }
+        response = AnalysisArtifactGetResponse(
+            artifact=AnalysisArtifactRead.model_validate(row),
+        )
+    return response.model_dump(mode="json")

--- a/app/mcp_server/tooling/analysis_artifact_tools.py
+++ b/app/mcp_server/tooling/analysis_artifact_tools.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from datetime import UTC, datetime
 from typing import Any
 
@@ -12,11 +13,16 @@ from app.schemas.analysis_artifact import (
     AnalysisArtifactGetResponse,
     AnalysisArtifactListRequest,
     AnalysisArtifactListResponse,
+    AnalysisArtifactMeta,
     AnalysisArtifactRead,
     AnalysisArtifactSave,
     AnalysisArtifactSaveResponse,
 )
 from app.services.analysis_artifact import AnalysisArtifactService
+
+# Save-side payload cap (ROB-628 size discipline). Measured on real UTF-8
+# bytes (ensure_ascii=False) so Korean payloads are not ~6x over-counted.
+PAYLOAD_CAP_BYTES = 100 * 1024
 
 
 def _validation_error(exc: ValidationError) -> dict[str, Any]:
@@ -37,8 +43,20 @@ async def analysis_artifact_save(
     valid_until: str | None = None,
     created_by: str = "claude",
     session_label: str | None = None,
+    correlation_id: str | None = None,
+    account_scope: str | None = None,
 ) -> dict[str, Any]:
     """Persist a single analysis artifact for cross-session reuse."""
+    size_bytes = len(
+        json.dumps(payload or {}, ensure_ascii=False, default=str).encode("utf-8")
+    )
+    if size_bytes > PAYLOAD_CAP_BYTES:
+        return {
+            "success": False,
+            "error": "payload_too_large",
+            "size_bytes": size_bytes,
+            "cap_bytes": PAYLOAD_CAP_BYTES,
+        }
     try:
         entry = AnalysisArtifactSave.model_validate(
             {
@@ -51,6 +69,8 @@ async def analysis_artifact_save(
                 "valid_until": valid_until,
                 "created_by": created_by,
                 "session_label": session_label,
+                "correlation_id": correlation_id,
+                "account_scope": account_scope,
             }
         )
     except ValidationError as exc:
@@ -58,9 +78,10 @@ async def analysis_artifact_save(
 
     async with AsyncSessionLocal() as db:
         service = AnalysisArtifactService(db)
-        row = await service.save(entry)
+        row, action = await service.save(entry)
         await db.commit()
         response = AnalysisArtifactSaveResponse(
+            action=action,  # type: ignore[arg-type]
             artifact=AnalysisArtifactRead.model_validate(row),
         )
     return response.model_dump(mode="json")
@@ -73,6 +94,8 @@ async def analysis_artifact_list(
     since: str | None = None,
     include_stale: bool = False,
     limit: int = 20,
+    correlation_id: str | None = None,
+    account_scope: str | None = None,
 ) -> dict[str, Any]:
     """Return analysis artifacts matching filters, newest ``as_of`` first."""
     try:
@@ -84,6 +107,8 @@ async def analysis_artifact_list(
                 "since": since,
                 "include_stale": include_stale,
                 "limit": limit,
+                "correlation_id": correlation_id,
+                "account_scope": account_scope,
             }
         )
     except ValidationError as exc:
@@ -98,13 +123,15 @@ async def analysis_artifact_list(
             since=request.since,
             include_stale=request.include_stale,
             limit=request.limit,
+            correlation_id=request.correlation_id,
+            account_scope=request.account_scope,
         )
         response = AnalysisArtifactListResponse(
             count=len(rows),
             filters=request,
-            artifacts=[
-                AnalysisArtifactRead.model_validate(row) for row in rows
-            ],
+            # Metadata-only on purpose (token-lean): payload is served by
+            # analysis_artifact_get, never by list.
+            artifacts=[AnalysisArtifactMeta.model_validate(row) for row in rows],
         )
     return response.model_dump(mode="json")
 

--- a/app/mcp_server/tooling/operating_briefing.py
+++ b/app/mcp_server/tooling/operating_briefing.py
@@ -12,6 +12,7 @@ from app.mcp_server.tooling.pending_orders_snapshot import (
 )
 from app.mcp_server.tooling.portfolio_cash import get_account_costs_setting
 from app.mcp_server.tooling.portfolio_holdings import _get_holdings_impl
+from app.schemas.analysis_artifact import AnalysisArtifactMeta
 from app.schemas.investment_reports import (
     ActiveWatchesListResponse,
     InvestmentWatchAlertResponse,
@@ -19,6 +20,7 @@ from app.schemas.investment_reports import (
 )
 from app.schemas.session_context import SessionContextResponse
 from app.services.account_routing import compact_cost_profile
+from app.services.analysis_artifact import AnalysisArtifactService
 from app.services.investment_reports.query_service import (
     InvestmentReportQueryService,
     _advisory_draft_profiles,
@@ -235,6 +237,32 @@ async def _recent_session_context(
     }
 
 
+async def _recent_analysis_artifacts(
+    db: Any,
+    *,
+    market: str,
+    limit: int = 10,
+) -> dict[str, Any]:
+    """Metadata-only recent valid artifacts (ROB-637 briefing surfacing).
+
+    Payloads are intentionally excluded — a new session learns what analysis
+    already exists and fetches bodies via analysis_artifact_get on demand.
+    """
+    service = AnalysisArtifactService(db)
+    rows = await service.list_artifacts(
+        market=market,  # type: ignore[arg-type]
+        include_stale=False,
+        limit=max(1, min(int(limit), 20)),
+    )
+    return {
+        "count": len(rows),
+        "artifacts": [
+            AnalysisArtifactMeta.model_validate(row).model_dump(mode="json")
+            for row in rows
+        ],
+    }
+
+
 def _section_unavailable_reason(section: str, exc: Exception) -> str:
     return f"{section}_failed:{type(exc).__name__}:{exc}"
 
@@ -295,6 +323,26 @@ async def get_operating_briefing_impl(
                 "unavailable_reason": reason,
             }
 
+        try:
+            analysis_artifacts = await _recent_analysis_artifacts(
+                db,
+                market=market,
+            )
+            analysis_artifacts_staleness = {
+                "freshness_status": "db_read",
+            }
+        except Exception as exc:  # noqa: BLE001
+            reason = _section_unavailable_reason("analysis_artifacts", exc)
+            analysis_artifacts = {
+                "count": 0,
+                "artifacts": [],
+                "unavailable_reason": reason,
+            }
+            analysis_artifacts_staleness = {
+                "freshness_status": "unavailable",
+                "unavailable_reason": reason,
+            }
+
     try:
         active_watches = await list_active_watches_impl(market=market)
         active_watches_staleness = {
@@ -342,6 +390,7 @@ async def get_operating_briefing_impl(
             "active_watches": active_watches_staleness,
             "latest_report": latest_report_staleness,
             "session_context": session_context_staleness,
+            "analysis_artifacts": analysis_artifacts_staleness,
         },
         "holdings": {
             "filters": holdings.get("filters"),
@@ -374,6 +423,7 @@ async def get_operating_briefing_impl(
         },
         "latest_report": latest_report,
         "session_context": session_context,
+        "analysis_artifacts": analysis_artifacts,
     }
     return OperatingBriefingResponse.model_validate(response).model_dump(mode="json")
 

--- a/app/mcp_server/tooling/registry.py
+++ b/app/mcp_server/tooling/registry.py
@@ -53,6 +53,9 @@ from app.mcp_server.tooling.alpaca_paper_orders import (
 from app.mcp_server.tooling.alpaca_paper_preview import (
     register_alpaca_paper_preview_tools,
 )
+from app.mcp_server.tooling.analysis_artifact_registration import (
+    register_analysis_artifact_tools,
+)
 from app.mcp_server.tooling.analysis_registration import register_analysis_tools
 from app.mcp_server.tooling.fundamentals_registration import register_fundamentals_tools
 from app.mcp_server.tooling.investment_hermes_handlers import (
@@ -136,6 +139,7 @@ def register_all_tools(mcp: FastMCP, profile: McpProfile = McpProfile.DEFAULT) -
         include_snapshot_generator=snapshot_report_generator_enabled,
     )
     register_session_context_tools(mcp)
+    register_analysis_artifact_tools(mcp)
     register_operating_briefing_tools(mcp)
     if snapshot_report_generator_enabled:
         register_investment_hermes_tools(mcp)

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -1,5 +1,6 @@
 # app/models/__init__.py
 from .analysis import StockAnalysisResult, StockInfo
+from .analysis_artifact import AnalysisArtifact
 from .base import Base
 from .binance_demo_order_ledger import BinanceDemoOrderLedger
 from .crypto_candles import CryptoCandle1d, CryptoCandle1m
@@ -119,6 +120,7 @@ from .user_settings import UserSetting
 
 __all__ = [
     "Base",
+    "AnalysisArtifact",
     "BinanceDemoOrderLedger",
     "ScalpTradeAnalytics",
     "ScalpingDailyReview",

--- a/app/models/analysis_artifact.py
+++ b/app/models/analysis_artifact.py
@@ -1,0 +1,110 @@
+"""Analysis artifact persistence (ROB-637)."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Any
+
+from sqlalchemy import (
+    TIMESTAMP,
+    BigInteger,
+    CheckConstraint,
+    Index,
+    Text,
+    UniqueConstraint,
+    text,
+)
+from sqlalchemy.dialects.postgresql import ARRAY, JSONB
+from sqlalchemy.dialects.postgresql import UUID as PG_UUID
+from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.sql import func
+
+from app.models.base import Base
+
+
+class AnalysisArtifact(Base):
+    """Persisted analysis artifacts for cross-session analysis reuse."""
+
+    __tablename__ = "analysis_artifacts"
+    __table_args__ = (
+        UniqueConstraint(
+            "artifact_uuid",
+            name="uq_analysis_artifacts_artifact_uuid",
+        ),
+        CheckConstraint(
+            "market IN ('kr','us','crypto')",
+            name="market",
+        ),
+        CheckConstraint(
+            "kind IN ("
+            "'screening_ranking','profit_taking_verdicts',"
+            "'support_resistance_map','flow_assessment',"
+            "'candidate_pool','session_summary'"
+            ")",
+            name="kind",
+        ),
+        CheckConstraint(
+            "created_by IN ('claude','operator','system')",
+            name="created_by",
+        ),
+        Index(
+            "ix_analysis_artifacts_kind_market_as_of",
+            "kind",
+            "market",
+            text("as_of DESC"),
+        ),
+        Index(
+            "ix_analysis_artifacts_symbols_gin",
+            "symbols",
+            postgresql_using="gin",
+        ),
+        Index(
+            "ix_analysis_artifacts_payload_gin",
+            "payload",
+            postgresql_using="gin",
+        ),
+        {"schema": "review"},
+    )
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    artifact_uuid: Mapped[uuid.UUID] = mapped_column(
+        PG_UUID(as_uuid=True),
+        nullable=False,
+        default=uuid.uuid4,
+    )
+    market: Mapped[str] = mapped_column(Text, nullable=False)
+    kind: Mapped[str] = mapped_column(Text, nullable=False)
+    title: Mapped[str] = mapped_column(Text, nullable=False)
+    symbols: Mapped[list[str]] = mapped_column(
+        ARRAY(Text),
+        nullable=False,
+        default=list,
+        server_default=text("'{}'"),
+    )
+    payload: Mapped[dict[str, Any]] = mapped_column(
+        JSONB,
+        nullable=False,
+        default=dict,
+        server_default=text("'{}'::jsonb"),
+    )
+    as_of: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True),
+        nullable=False,
+    )
+    valid_until: Mapped[datetime | None] = mapped_column(
+        TIMESTAMP(timezone=True),
+        nullable=True,
+    )
+    session_label: Mapped[str | None] = mapped_column(Text)
+    created_by: Mapped[str] = mapped_column(
+        Text,
+        nullable=False,
+        default="claude",
+        server_default=text("'claude'"),
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+    )

--- a/app/models/analysis_artifact.py
+++ b/app/models/analysis_artifact.py
@@ -40,7 +40,7 @@ class AnalysisArtifact(Base):
             "kind IN ("
             "'screening_ranking','profit_taking_verdicts',"
             "'support_resistance_map','flow_assessment',"
-            "'candidate_pool','session_summary'"
+            "'candidate_pool','session_summary','briefing'"
             ")",
             name="kind",
         ),
@@ -59,10 +59,9 @@ class AnalysisArtifact(Base):
             "symbols",
             postgresql_using="gin",
         ),
-        Index(
-            "ix_analysis_artifacts_payload_gin",
-            "payload",
-            postgresql_using="gin",
+        UniqueConstraint(
+            "correlation_id",
+            name="uq_analysis_artifacts_correlation_id",
         ),
         {"schema": "review"},
     )
@@ -97,6 +96,8 @@ class AnalysisArtifact(Base):
         nullable=True,
     )
     session_label: Mapped[str | None] = mapped_column(Text)
+    correlation_id: Mapped[str | None] = mapped_column(Text)
+    account_scope: Mapped[str | None] = mapped_column(Text)
     created_by: Mapped[str] = mapped_column(
         Text,
         nullable=False,
@@ -108,3 +109,21 @@ class AnalysisArtifact(Base):
         nullable=False,
         server_default=func.now(),
     )
+
+    @property
+    def is_stale(self) -> bool:
+        if self.valid_until is None:
+            return False
+        from app.core.timezone import now_kst
+
+        return self.valid_until < now_kst()
+
+    @property
+    def payload_size_bytes(self) -> int:
+        import json
+
+        # ensure_ascii=False so Korean text measures at its real UTF-8 size
+        # instead of the ~6x escaped size (ROB-628 lesson).
+        return len(
+            json.dumps(self.payload, ensure_ascii=False, default=str).encode("utf-8")
+        )

--- a/app/schemas/analysis_artifact.py
+++ b/app/schemas/analysis_artifact.py
@@ -1,0 +1,121 @@
+"""ROB-637 analysis artifact DTOs for MCP and service boundaries."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Literal
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from app.schemas.investment_reports import MarketLiteral
+
+AnalysisArtifactKindLiteral = Literal[
+    "screening_ranking",
+    "profit_taking_verdicts",
+    "support_resistance_map",
+    "flow_assessment",
+    "candidate_pool",
+    "session_summary",
+]
+AnalysisArtifactCreatedByLiteral = Literal["claude", "operator", "system"]
+
+
+class AnalysisArtifactSave(BaseModel):
+    """Input payload for persisting a single analysis artifact."""
+
+    market: MarketLiteral
+    kind: AnalysisArtifactKindLiteral
+    title: str = Field(min_length=1)
+    symbols: list[str] = Field(default_factory=list)
+    payload: dict[str, Any] = Field(default_factory=dict)
+    as_of: datetime
+    valid_until: datetime | None = None
+    created_by: AnalysisArtifactCreatedByLiteral = "claude"
+    session_label: str | None = None
+
+    model_config = ConfigDict(extra="forbid")
+
+    @field_validator("title", "session_label", mode="before")
+    @classmethod
+    def _strip_optional_text(cls, value: object) -> object:
+        if isinstance(value, str):
+            return value.strip()
+        return value
+
+    @field_validator("symbols", mode="before")
+    @classmethod
+    def _clean_symbols(cls, value: object) -> list[str]:
+        if value is None:
+            return []
+        if not isinstance(value, list):
+            raise ValueError("symbols must be a list")
+        cleaned = [str(item).strip() for item in value if str(item).strip()]
+        return cleaned
+
+
+class AnalysisArtifactListRequest(BaseModel):
+    """Filter parameters for listing analysis artifacts."""
+
+    market: MarketLiteral | None = None
+    kind: AnalysisArtifactKindLiteral | None = None
+    symbol: str | None = None
+    since: datetime | None = None
+    include_stale: bool = False
+    limit: int = Field(default=20, ge=1)
+
+    model_config = ConfigDict(extra="forbid")
+
+    @field_validator("symbol", mode="before")
+    @classmethod
+    def _strip_symbol(cls, value: object) -> object:
+        if isinstance(value, str):
+            return value.strip() or None
+        return value
+
+    @field_validator("limit", mode="before")
+    @classmethod
+    def _clamp_limit(cls, value: object) -> int:
+        limit = 20 if value is None else int(value)
+        return max(1, min(limit, 100))
+
+
+class AnalysisArtifactMeta(BaseModel):
+    """Lightweight artifact metadata (no payload) for list responses."""
+
+    id: int
+    artifact_uuid: UUID
+    market: MarketLiteral
+    kind: AnalysisArtifactKindLiteral
+    title: str
+    symbols: list[str]
+    as_of: datetime
+    valid_until: datetime | None
+    session_label: str | None
+    created_by: AnalysisArtifactCreatedByLiteral
+    created_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class AnalysisArtifactRead(AnalysisArtifactMeta):
+    """Full artifact including the payload."""
+
+    payload: dict[str, Any]
+
+
+class AnalysisArtifactSaveResponse(BaseModel):
+    success: Literal[True] = True
+    artifact: AnalysisArtifactRead
+
+
+class AnalysisArtifactListResponse(BaseModel):
+    success: Literal[True] = True
+    count: int
+    filters: AnalysisArtifactListRequest
+    artifacts: list[AnalysisArtifactMeta]
+
+
+class AnalysisArtifactGetResponse(BaseModel):
+    success: Literal[True] = True
+    artifact: AnalysisArtifactRead

--- a/app/schemas/analysis_artifact.py
+++ b/app/schemas/analysis_artifact.py
@@ -17,6 +17,7 @@ AnalysisArtifactKindLiteral = Literal[
     "flow_assessment",
     "candidate_pool",
     "session_summary",
+    "briefing",
 ]
 AnalysisArtifactCreatedByLiteral = Literal["claude", "operator", "system"]
 
@@ -33,14 +34,47 @@ class AnalysisArtifactSave(BaseModel):
     valid_until: datetime | None = None
     created_by: AnalysisArtifactCreatedByLiteral = "claude"
     session_label: str | None = None
+    correlation_id: str | None = None
+    account_scope: str | None = None
 
     model_config = ConfigDict(extra="forbid")
+
+    @field_validator("as_of", "valid_until", mode="before")
+    @classmethod
+    def _coerce_datetime_to_kst(cls, value: object) -> object:
+        if value is None:
+            return None
+        if isinstance(value, str):
+            try:
+                from dateutil.parser import parse
+
+                value = parse(value)
+            except Exception:
+                pass
+        if isinstance(value, datetime):
+            if value.tzinfo is None:
+                from app.core.timezone import KST
+
+                value = value.replace(tzinfo=KST)
+        return value
+
+    @field_validator("payload", mode="after")
+    @classmethod
+    def _validate_payload_size(cls, value: dict[str, Any]) -> dict[str, Any]:
+        import json
+
+        # ensure_ascii=False: measure real UTF-8 bytes, not the ~6x escaped
+        # size for Korean text (ROB-628 lesson). 100 KB cap.
+        payload_json = json.dumps(value, ensure_ascii=False, default=str)
+        if len(payload_json.encode("utf-8")) > 100 * 1024:
+            raise ValueError("payload size must not exceed 100KB")
+        return value
 
     @field_validator("title", "session_label", mode="before")
     @classmethod
     def _strip_optional_text(cls, value: object) -> object:
         if isinstance(value, str):
-            return value.strip()
+            return value.strip() or None
         return value
 
     @field_validator("symbols", mode="before")
@@ -50,7 +84,11 @@ class AnalysisArtifactSave(BaseModel):
             return []
         if not isinstance(value, list):
             raise ValueError("symbols must be a list")
-        cleaned = [str(item).strip() for item in value if str(item).strip()]
+        from app.core.symbol import to_db_symbol
+
+        cleaned = [
+            to_db_symbol(str(item).strip()) for item in value if str(item).strip()
+        ]
         return cleaned
 
 
@@ -63,14 +101,40 @@ class AnalysisArtifactListRequest(BaseModel):
     since: datetime | None = None
     include_stale: bool = False
     limit: int = Field(default=20, ge=1)
+    correlation_id: str | None = None
+    account_scope: str | None = None
 
     model_config = ConfigDict(extra="forbid")
+
+    @field_validator("since", mode="before")
+    @classmethod
+    def _coerce_since_to_kst(cls, value: object) -> object:
+        if value is None:
+            return None
+        if isinstance(value, str):
+            try:
+                from dateutil.parser import parse
+
+                value = parse(value)
+            except Exception:
+                pass
+        if isinstance(value, datetime):
+            if value.tzinfo is None:
+                from app.core.timezone import KST
+
+                value = value.replace(tzinfo=KST)
+        return value
 
     @field_validator("symbol", mode="before")
     @classmethod
     def _strip_symbol(cls, value: object) -> object:
         if isinstance(value, str):
-            return value.strip() or None
+            val = value.strip()
+            if val:
+                from app.core.symbol import to_db_symbol
+
+                return to_db_symbol(val)
+            return None
         return value
 
     @field_validator("limit", mode="before")
@@ -92,6 +156,10 @@ class AnalysisArtifactMeta(BaseModel):
     as_of: datetime
     valid_until: datetime | None
     session_label: str | None
+    correlation_id: str | None
+    account_scope: str | None
+    payload_size_bytes: int
+    is_stale: bool
     created_by: AnalysisArtifactCreatedByLiteral
     created_at: datetime
 
@@ -106,6 +174,7 @@ class AnalysisArtifactRead(AnalysisArtifactMeta):
 
 class AnalysisArtifactSaveResponse(BaseModel):
     success: Literal[True] = True
+    action: Literal["created", "updated"] = "created"
     artifact: AnalysisArtifactRead
 
 

--- a/app/schemas/investment_reports.py
+++ b/app/schemas/investment_reports.py
@@ -1118,6 +1118,9 @@ class OperatingBriefingResponse(BaseModel):
     active_watches: dict[str, Any]
     latest_report: dict[str, Any] | None
     session_context: dict[str, Any]
+    # ROB-637 — metadata-only recent analysis artifacts; defaulted so
+    # pre-existing constructors of this shape keep validating.
+    analysis_artifacts: dict[str, Any] = Field(default_factory=dict)
 
 
 class InvestmentReportCreateResponse(BaseModel):

--- a/app/services/analysis_artifact.py
+++ b/app/services/analysis_artifact.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime
+from typing import Any
 
 import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.timezone import now_kst
@@ -22,23 +24,61 @@ class AnalysisArtifactService:
     def __init__(self, session: AsyncSession) -> None:
         self._session = session
 
-    async def save(self, entry: AnalysisArtifactSave) -> AnalysisArtifact:
-        """Insert a single artifact row and return the refreshed row."""
-        row = AnalysisArtifact(
-            market=entry.market,
-            kind=entry.kind,
-            title=entry.title,
-            symbols=entry.symbols,
-            payload=entry.payload,
-            as_of=entry.as_of,
-            valid_until=entry.valid_until,
-            created_by=entry.created_by,
-            session_label=entry.session_label,
+    async def save(self, entry: AnalysisArtifactSave) -> tuple[AnalysisArtifact, str]:
+        """Persist one artifact and return ``(row, action)``.
+
+        Without ``correlation_id`` every call appends a new row. With
+        ``correlation_id`` the call is idempotent: a retry (e.g. an MCP
+        timeout re-send) updates the existing row in place instead of
+        duplicating it (ROB-474 trade_retrospectives pattern).
+        """
+        values: dict[str, Any] = {
+            "market": entry.market,
+            "kind": entry.kind,
+            "title": entry.title,
+            "symbols": entry.symbols,
+            "payload": entry.payload,
+            "as_of": entry.as_of,
+            "valid_until": entry.valid_until,
+            "created_by": entry.created_by,
+            "session_label": entry.session_label,
+            "correlation_id": entry.correlation_id,
+            "account_scope": entry.account_scope,
+        }
+        if entry.correlation_id is None:
+            row = AnalysisArtifact(**values)
+            self._session.add(row)
+            await self._session.flush()
+            await self._session.refresh(row)
+            return row, "created"
+
+        existing_id = await self._session.scalar(
+            sa.select(AnalysisArtifact.id).where(
+                AnalysisArtifact.correlation_id == entry.correlation_id
+            )
         )
-        self._session.add(row)
-        await self._session.flush()
-        await self._session.refresh(row)
-        return row
+        stmt = (
+            pg_insert(AnalysisArtifact)
+            .values(**values)
+            .on_conflict_do_update(
+                # index_elements (not constraint=) so both a UNIQUE
+                # constraint (fresh create_all) and a plain unique index
+                # (patched-in on pre-existing DBs) satisfy the arbiter.
+                index_elements=[AnalysisArtifact.correlation_id],
+                set_={
+                    key: value
+                    for key, value in values.items()
+                    if key != "correlation_id"
+                },
+            )
+            .returning(AnalysisArtifact)
+        )
+        result = await self._session.scalars(
+            stmt,
+            execution_options={"populate_existing": True},
+        )
+        row = result.one()
+        return row, "updated" if existing_id is not None else "created"
 
     async def list_artifacts(
         self,
@@ -49,6 +89,8 @@ class AnalysisArtifactService:
         since: datetime | None = None,
         include_stale: bool = False,
         limit: int = 20,
+        correlation_id: str | None = None,
+        account_scope: str | None = None,
     ) -> list[AnalysisArtifact]:
         """Query artifacts with filters, newest ``as_of`` first."""
         capped_limit = max(1, min(int(limit), 100))
@@ -61,15 +103,22 @@ class AnalysisArtifactService:
         if kind is not None:
             stmt = stmt.where(AnalysisArtifact.kind == kind)
         if symbol:
+            from app.core.symbol import to_db_symbol
+
+            normalized_symbol = to_db_symbol(symbol.strip())
             stmt = stmt.where(
                 AnalysisArtifact.symbols.op("@>")(
                     sa.text(":symbol").bindparams(
-                        sa.bindparam("symbol", value=[symbol]),
+                        sa.bindparam("symbol", value=[normalized_symbol]),
                     )
                 )
             )
         if since is not None:
             stmt = stmt.where(AnalysisArtifact.as_of >= since)
+        if correlation_id is not None:
+            stmt = stmt.where(AnalysisArtifact.correlation_id == correlation_id)
+        if account_scope is not None:
+            stmt = stmt.where(AnalysisArtifact.account_scope == account_scope)
         if not include_stale:
             now = now_kst()
             stmt = stmt.where(
@@ -101,9 +150,7 @@ class AnalysisArtifactService:
                     AnalysisArtifact.artifact_uuid == parsed_uuid
                 )
         else:
-            stmt = sa.select(AnalysisArtifact).where(
-                AnalysisArtifact.id == artifact_id
-            )
+            stmt = sa.select(AnalysisArtifact).where(AnalysisArtifact.id == artifact_id)
         result = await self._session.scalars(stmt)
         return result.first()
 

--- a/app/services/analysis_artifact.py
+++ b/app/services/analysis_artifact.py
@@ -1,0 +1,114 @@
+"""Service layer for ROB-637 analysis artifact persistence."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import sqlalchemy as sa
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.timezone import now_kst
+from app.models.analysis_artifact import AnalysisArtifact
+from app.schemas.analysis_artifact import (
+    AnalysisArtifactKindLiteral,
+    AnalysisArtifactSave,
+)
+from app.schemas.investment_reports import MarketLiteral
+
+
+class AnalysisArtifactService:
+    """Writer and filtered reader for persisted analysis artifacts."""
+
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def save(self, entry: AnalysisArtifactSave) -> AnalysisArtifact:
+        """Insert a single artifact row and return the refreshed row."""
+        row = AnalysisArtifact(
+            market=entry.market,
+            kind=entry.kind,
+            title=entry.title,
+            symbols=entry.symbols,
+            payload=entry.payload,
+            as_of=entry.as_of,
+            valid_until=entry.valid_until,
+            created_by=entry.created_by,
+            session_label=entry.session_label,
+        )
+        self._session.add(row)
+        await self._session.flush()
+        await self._session.refresh(row)
+        return row
+
+    async def list_artifacts(
+        self,
+        *,
+        market: MarketLiteral | None = None,
+        kind: AnalysisArtifactKindLiteral | None = None,
+        symbol: str | None = None,
+        since: datetime | None = None,
+        include_stale: bool = False,
+        limit: int = 20,
+    ) -> list[AnalysisArtifact]:
+        """Query artifacts with filters, newest ``as_of`` first."""
+        capped_limit = max(1, min(int(limit), 100))
+        stmt = sa.select(AnalysisArtifact).order_by(
+            AnalysisArtifact.as_of.desc(),
+            AnalysisArtifact.id.desc(),
+        )
+        if market is not None:
+            stmt = stmt.where(AnalysisArtifact.market == market)
+        if kind is not None:
+            stmt = stmt.where(AnalysisArtifact.kind == kind)
+        if symbol:
+            stmt = stmt.where(
+                AnalysisArtifact.symbols.op("@>")(
+                    sa.text(":symbol").bindparams(
+                        sa.bindparam("symbol", value=[symbol]),
+                    )
+                )
+            )
+        if since is not None:
+            stmt = stmt.where(AnalysisArtifact.as_of >= since)
+        if not include_stale:
+            now = now_kst()
+            stmt = stmt.where(
+                (AnalysisArtifact.valid_until.is_(None))
+                | (AnalysisArtifact.valid_until >= now)
+            )
+        result = await self._session.scalars(stmt.limit(capped_limit))
+        return list(result.all())
+
+    async def get(
+        self,
+        artifact_id: int | str,
+    ) -> AnalysisArtifact | None:
+        """Return a single artifact by id or artifact_uuid, or None."""
+        if isinstance(artifact_id, str):
+            try:
+                numeric_id = int(artifact_id)
+                stmt = sa.select(AnalysisArtifact).where(
+                    AnalysisArtifact.id == numeric_id
+                )
+            except ValueError:
+                from uuid import UUID
+
+                try:
+                    parsed_uuid = UUID(artifact_id)
+                except ValueError:
+                    return None
+                stmt = sa.select(AnalysisArtifact).where(
+                    AnalysisArtifact.artifact_uuid == parsed_uuid
+                )
+        else:
+            stmt = sa.select(AnalysisArtifact).where(
+                AnalysisArtifact.id == artifact_id
+            )
+        result = await self._session.scalars(stmt)
+        return result.first()
+
+
+# Re-exported for callers that want a stable UTC "now" for as_of defaults.
+def utc_now() -> datetime:
+    """Return a timezone-aware UTC now (matches DB TIMESTAMPTZ semantics)."""
+    return datetime.now(tz=UTC)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "auto-trader"
-version = "0.2.4"
+version = "0.2.5"
 description = ""
 authors = [
     { name = "robin", email = "robin@watcha.com" }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -627,6 +627,27 @@ async def db_session():
                         "ADD COLUMN IF NOT EXISTS is_common_stock BOOLEAN"
                     )
                 )
+                await conn.execute(
+                    text(
+                        "ALTER TABLE review.analysis_artifacts "
+                        "ADD COLUMN IF NOT EXISTS correlation_id TEXT"
+                    )
+                )
+                await conn.execute(
+                    text(
+                        "ALTER TABLE review.analysis_artifacts "
+                        "ADD COLUMN IF NOT EXISTS account_scope TEXT"
+                    )
+                )
+                # correlation_id idempotent-upsert needs the unique index on
+                # pre-existing tables (fresh DBs get it via create_all).
+                await conn.execute(
+                    text(
+                        "CREATE UNIQUE INDEX IF NOT EXISTS "
+                        "uq_analysis_artifacts_correlation_id "
+                        "ON review.analysis_artifacts (correlation_id)"
+                    )
+                )
                 # ROB-430 PR-② — week_high_52_date added to the (persistent) KR
                 # fundamentals snapshot table; create_all is a no-op on the existing
                 # table, so patch the column in here (mirrors the alembic migration).

--- a/tests/mcp_server/test_operating_briefing_tools.py
+++ b/tests/mcp_server/test_operating_briefing_tools.py
@@ -181,11 +181,25 @@ async def test_get_operating_briefing_composes_all_sections(
             "entries": [{"title": "handoff", "entry_type": "next_action"}],
         }
 
+    async def fake_analysis_artifacts(db, *, market, limit=10):
+        assert market == "kr"
+        return {
+            "count": 1,
+            "artifacts": [
+                {
+                    "kind": "screening_ranking",
+                    "title": "오늘의 발굴 랭킹",
+                    "is_stale": False,
+                }
+            ],
+        }
+
     monkeypatch.setattr(ob, "_get_holdings_impl", fake_holdings)
     monkeypatch.setattr(ob, "collect_pending_orders_snapshot", fake_pending)
     monkeypatch.setattr(ob, "list_active_watches_impl", fake_active_watches)
     monkeypatch.setattr(ob, "_latest_report_summary", fake_latest_report)
     monkeypatch.setattr(ob, "_recent_session_context", fake_session_context)
+    monkeypatch.setattr(ob, "_recent_analysis_artifacts", fake_analysis_artifacts)
 
     result = await ob.get_operating_briefing_impl(
         market="kr",
@@ -201,6 +215,9 @@ async def test_get_operating_briefing_composes_all_sections(
     assert result["active_watches"]["count"] == 1
     assert result["latest_report"]["title"] == "latest plan"
     assert result["session_context"]["entries"][0]["title"] == "handoff"
+    assert result["analysis_artifacts"]["count"] == 1
+    assert result["analysis_artifacts"]["artifacts"][0]["kind"] == "screening_ranking"
+    assert result["staleness"]["analysis_artifacts"]["freshness_status"] == "db_read"
     assert result["staleness"]["pending_orders"]["freshness_status"] == "fresh"
 
 
@@ -290,6 +307,7 @@ async def test_get_operating_briefing_surfaces_per_account_routability(
         ("latest_report", "_latest_report_summary"),
         ("session_context", "_recent_session_context"),
         ("active_watches", "list_active_watches_impl"),
+        ("analysis_artifacts", "_recent_analysis_artifacts"),
     ],
 )
 async def test_get_operating_briefing_fail_opens_optional_sections(
@@ -340,6 +358,9 @@ async def test_get_operating_briefing_fail_opens_optional_sections(
             "active_watches": [{"symbol": "005930"}],
         }
 
+    async def ok_analysis_artifacts(db, *, market, limit=10):
+        return {"count": 1, "artifacts": [{"title": "recent ranking"}]}
+
     async def boom(*args, **kwargs):
         raise RuntimeError("section boom")
 
@@ -348,6 +369,7 @@ async def test_get_operating_briefing_fail_opens_optional_sections(
     monkeypatch.setattr(ob, "_latest_report_summary", ok_latest_report)
     monkeypatch.setattr(ob, "_recent_session_context", ok_session_context)
     monkeypatch.setattr(ob, "list_active_watches_impl", ok_active_watches)
+    monkeypatch.setattr(ob, "_recent_analysis_artifacts", ok_analysis_artifacts)
     monkeypatch.setattr(ob, patch_name, boom)
 
     result = await ob.get_operating_briefing_impl(
@@ -367,6 +389,14 @@ async def test_get_operating_briefing_fail_opens_optional_sections(
             "count": 0,
             "entries": [],
             "unavailable_reason": "session_context_failed:RuntimeError:section boom",
+        }
+    elif section_name == "analysis_artifacts":
+        assert result["analysis_artifacts"] == {
+            "count": 0,
+            "artifacts": [],
+            "unavailable_reason": (
+                "analysis_artifacts_failed:RuntimeError:section boom"
+            ),
         }
     else:
         assert result["active_watches"] == {

--- a/tests/models/test_analysis_artifact_model.py
+++ b/tests/models/test_analysis_artifact_model.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import CheckConstraint, Index, UniqueConstraint
+
+from app.models.analysis_artifact import AnalysisArtifact
+
+
+@pytest.mark.unit
+def test_analysis_artifact_model_contract() -> None:
+    assert AnalysisArtifact.__tablename__ == "analysis_artifacts"
+    assert AnalysisArtifact.__table__.schema == "review"
+
+    column_names = {column.name for column in AnalysisArtifact.__table__.columns}
+    assert column_names == {
+        "id",
+        "artifact_uuid",
+        "market",
+        "kind",
+        "title",
+        "symbols",
+        "payload",
+        "as_of",
+        "valid_until",
+        "session_label",
+        "created_by",
+        "created_at",
+    }
+
+    constraints = AnalysisArtifact.__table__.constraints
+    constraint_names = {constraint.name for constraint in constraints}
+    assert "uq_analysis_artifacts_artifact_uuid" in constraint_names
+    assert "ck_analysis_artifacts_market" in constraint_names
+    assert "ck_analysis_artifacts_kind" in constraint_names
+    assert "ck_analysis_artifacts_created_by" in constraint_names
+
+    assert any(
+        isinstance(constraint, UniqueConstraint)
+        and constraint.name == "uq_analysis_artifacts_artifact_uuid"
+        for constraint in constraints
+    )
+    assert any(isinstance(constraint, CheckConstraint) for constraint in constraints)
+
+    indexes = AnalysisArtifact.__table__.indexes
+    index_names = {index.name for index in indexes}
+    assert {
+        "ix_analysis_artifacts_kind_market_as_of",
+        "ix_analysis_artifacts_symbols_gin",
+        "ix_analysis_artifacts_payload_gin",
+    }.issubset(index_names)
+    assert any(
+        isinstance(index, Index)
+        and index.name == "ix_analysis_artifacts_symbols_gin"
+        and index.dialect_options["postgresql"]["using"] == "gin"
+        for index in indexes
+    )
+    assert any(
+        isinstance(index, Index)
+        and index.name == "ix_analysis_artifacts_payload_gin"
+        and index.dialect_options["postgresql"]["using"] == "gin"
+        for index in indexes
+    )

--- a/tests/models/test_analysis_artifact_model.py
+++ b/tests/models/test_analysis_artifact_model.py
@@ -23,6 +23,8 @@ def test_analysis_artifact_model_contract() -> None:
         "as_of",
         "valid_until",
         "session_label",
+        "correlation_id",
+        "account_scope",
         "created_by",
         "created_at",
     }
@@ -30,6 +32,7 @@ def test_analysis_artifact_model_contract() -> None:
     constraints = AnalysisArtifact.__table__.constraints
     constraint_names = {constraint.name for constraint in constraints}
     assert "uq_analysis_artifacts_artifact_uuid" in constraint_names
+    assert "uq_analysis_artifacts_correlation_id" in constraint_names
     assert "ck_analysis_artifacts_market" in constraint_names
     assert "ck_analysis_artifacts_kind" in constraint_names
     assert "ck_analysis_artifacts_created_by" in constraint_names
@@ -39,6 +42,11 @@ def test_analysis_artifact_model_contract() -> None:
         and constraint.name == "uq_analysis_artifacts_artifact_uuid"
         for constraint in constraints
     )
+    assert any(
+        isinstance(constraint, UniqueConstraint)
+        and constraint.name == "uq_analysis_artifacts_correlation_id"
+        for constraint in constraints
+    )
     assert any(isinstance(constraint, CheckConstraint) for constraint in constraints)
 
     indexes = AnalysisArtifact.__table__.indexes
@@ -46,17 +54,13 @@ def test_analysis_artifact_model_contract() -> None:
     assert {
         "ix_analysis_artifacts_kind_market_as_of",
         "ix_analysis_artifacts_symbols_gin",
-        "ix_analysis_artifacts_payload_gin",
     }.issubset(index_names)
+    # No GIN(payload) index by design — no payload-containment query exists;
+    # it would be pure write amplification (review finding).
+    assert "ix_analysis_artifacts_payload_gin" not in index_names
     assert any(
         isinstance(index, Index)
         and index.name == "ix_analysis_artifacts_symbols_gin"
-        and index.dialect_options["postgresql"]["using"] == "gin"
-        for index in indexes
-    )
-    assert any(
-        isinstance(index, Index)
-        and index.name == "ix_analysis_artifacts_payload_gin"
         and index.dialect_options["postgresql"]["using"] == "gin"
         for index in indexes
     )

--- a/tests/schemas/test_analysis_artifact_schemas.py
+++ b/tests/schemas/test_analysis_artifact_schemas.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from uuid import UUID
+
+import pytest
+from pydantic import ValidationError
+
+from app.schemas.analysis_artifact import (
+    AnalysisArtifactListRequest,
+    AnalysisArtifactRead,
+    AnalysisArtifactSave,
+)
+
+
+@pytest.mark.unit
+def test_save_strips_title_and_cleans_symbols() -> None:
+    entry = AnalysisArtifactSave.model_validate(
+        {
+            "market": "kr",
+            "kind": "candidate_pool",
+            "title": "  KR candidates  ",
+            "symbols": ["  005930  ", "", "DB"],
+            "payload": {"top": ["005930"]},
+            "as_of": "2026-07-02T00:00:00+00:00",
+            "created_by": "claude",
+            "session_label": "kr-2026-07-02",
+        }
+    )
+
+    assert entry.title == "KR candidates"
+    assert entry.symbols == ["005930", "DB"]
+    assert entry.payload == {"top": ["005930"]}
+    assert entry.as_of == datetime(2026, 7, 2, tzinfo=UTC)
+
+
+@pytest.mark.unit
+def test_save_rejects_unknown_kind_and_extra_field() -> None:
+    with pytest.raises(ValidationError) as exc_info:
+        AnalysisArtifactSave.model_validate(
+            {
+                "market": "kr",
+                "kind": "mystery",
+                "title": "x",
+                "as_of": "2026-07-02T00:00:00+00:00",
+            }
+        )
+
+    rendered = str(exc_info.value)
+    assert "kind" in rendered
+
+    with pytest.raises(ValidationError):
+        AnalysisArtifactSave.model_validate(
+            {
+                "market": "kr",
+                "kind": "candidate_pool",
+                "title": "x",
+                "as_of": "2026-07-02T00:00:00+00:00",
+                "unexpected": True,
+            }
+        )
+
+
+@pytest.mark.unit
+def test_list_request_clamps_limit_and_strips_symbol() -> None:
+    request = AnalysisArtifactListRequest.model_validate(
+        {
+            "market": "us",
+            "kind": "screening_ranking",
+            "symbol": "  AAPL  ",
+            "limit": 500,
+        }
+    )
+
+    assert request.limit == 100
+    assert request.symbol == "AAPL"
+    assert request.include_stale is False
+
+
+@pytest.mark.unit
+def test_read_serializes_payload_from_attributes() -> None:
+    class Row:
+        id = 42
+        artifact_uuid = UUID("55555555-5555-5555-5555-555555555555")
+        market = "crypto"
+        kind = "flow_assessment"
+        title = "BTC flow"
+        symbols = ["KRW-BTC"]
+        payload = {"net_flow": 1_000_000}
+        as_of = datetime(2026, 7, 2, tzinfo=UTC)
+        valid_until = None
+        session_label = None
+        created_by = "operator"
+        created_at = datetime(2026, 7, 2, 1, 2, 3, tzinfo=UTC)
+
+    response = AnalysisArtifactRead.model_validate(Row())
+
+    assert response.payload == {"net_flow": 1_000_000}
+    dumped = response.model_dump(mode="json")
+    assert dumped["artifact_uuid"] == "55555555-5555-5555-5555-555555555555"
+    assert dumped["symbols"] == ["KRW-BTC"]

--- a/tests/schemas/test_analysis_artifact_schemas.py
+++ b/tests/schemas/test_analysis_artifact_schemas.py
@@ -90,6 +90,10 @@ def test_read_serializes_payload_from_attributes() -> None:
         as_of = datetime(2026, 7, 2, tzinfo=UTC)
         valid_until = None
         session_label = None
+        correlation_id = None
+        account_scope = None
+        payload_size_bytes = 24
+        is_stale = False
         created_by = "operator"
         created_at = datetime(2026, 7, 2, 1, 2, 3, tzinfo=UTC)
 
@@ -99,3 +103,19 @@ def test_read_serializes_payload_from_attributes() -> None:
     dumped = response.model_dump(mode="json")
     assert dumped["artifact_uuid"] == "55555555-5555-5555-5555-555555555555"
     assert dumped["symbols"] == ["KRW-BTC"]
+
+
+@pytest.mark.unit
+def test_save_rejects_payload_over_100kb() -> None:
+    large_payload = {"data": "x" * 105000}
+    with pytest.raises(ValidationError) as exc_info:
+        AnalysisArtifactSave.model_validate(
+            {
+                "market": "kr",
+                "kind": "candidate_pool",
+                "title": "too large",
+                "as_of": "2026-07-02T00:00:00+00:00",
+                "payload": large_payload,
+            }
+        )
+    assert "payload size must not exceed 100KB" in str(exc_info.value)

--- a/tests/services/test_analysis_artifact_service.py
+++ b/tests/services/test_analysis_artifact_service.py
@@ -16,16 +16,12 @@ from app.services.analysis_artifact import AnalysisArtifactService
 @pytest_asyncio.fixture(autouse=True)
 async def _clean_analysis_artifacts(db_session: AsyncSession):
     await db_session.execute(
-        sa.text(
-            'TRUNCATE TABLE review."analysis_artifacts" RESTART IDENTITY CASCADE'
-        )
+        sa.text('TRUNCATE TABLE review."analysis_artifacts" RESTART IDENTITY CASCADE')
     )
     await db_session.commit()
     yield
     await db_session.execute(
-        sa.text(
-            'TRUNCATE TABLE review."analysis_artifacts" RESTART IDENTITY CASCADE'
-        )
+        sa.text('TRUNCATE TABLE review."analysis_artifacts" RESTART IDENTITY CASCADE')
     )
     await db_session.commit()
 
@@ -34,7 +30,7 @@ async def _clean_analysis_artifacts(db_session: AsyncSession):
 @pytest.mark.asyncio
 async def test_save_list_get_round_trip(db_session: AsyncSession) -> None:
     service = AnalysisArtifactService(db_session)
-    symbol = f"TEST-{uuid4().hex[:8]}"
+    symbol = f"TEST_{uuid4().hex[:8]}"
     entry = AnalysisArtifactSave.model_validate(
         {
             "market": "kr",
@@ -47,7 +43,8 @@ async def test_save_list_get_round_trip(db_session: AsyncSession) -> None:
         }
     )
 
-    saved = await service.save(entry)
+    saved, action = await service.save(entry)
+    assert action == "created"
 
     listed = await service.list_artifacts(
         market="kr",
@@ -73,8 +70,8 @@ async def test_list_excludes_stale_unless_include_stale(
 ) -> None:
     service = AnalysisArtifactService(db_session)
     base = now_kst()
-    stale_symbol = f"TEST-{uuid4().hex[:8]}"
-    fresh_symbol = f"TEST-{uuid4().hex[:8]}"
+    stale_symbol = f"TEST_{uuid4().hex[:8]}"
+    fresh_symbol = f"TEST_{uuid4().hex[:8]}"
 
     await service.save(
         AnalysisArtifactSave.model_validate(
@@ -123,8 +120,8 @@ async def test_list_symbol_containment_and_since_filter(
     db_session: AsyncSession,
 ) -> None:
     service = AnalysisArtifactService(db_session)
-    shared_symbol = f"TEST-{uuid4().hex[:8]}"
-    other_symbol = f"TEST-{uuid4().hex[:8]}"
+    shared_symbol = f"TEST_{uuid4().hex[:8]}"
+    other_symbol = f"TEST_{uuid4().hex[:8]}"
     base = now_kst()
 
     await service.save(

--- a/tests/services/test_analysis_artifact_service.py
+++ b/tests/services/test_analysis_artifact_service.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+from datetime import timedelta
+from uuid import uuid4
+
+import pytest
+import pytest_asyncio
+import sqlalchemy as sa
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.timezone import now_kst
+from app.schemas.analysis_artifact import AnalysisArtifactSave
+from app.services.analysis_artifact import AnalysisArtifactService
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def _clean_analysis_artifacts(db_session: AsyncSession):
+    await db_session.execute(
+        sa.text(
+            'TRUNCATE TABLE review."analysis_artifacts" RESTART IDENTITY CASCADE'
+        )
+    )
+    await db_session.commit()
+    yield
+    await db_session.execute(
+        sa.text(
+            'TRUNCATE TABLE review."analysis_artifacts" RESTART IDENTITY CASCADE'
+        )
+    )
+    await db_session.commit()
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_save_list_get_round_trip(db_session: AsyncSession) -> None:
+    service = AnalysisArtifactService(db_session)
+    symbol = f"TEST-{uuid4().hex[:8]}"
+    entry = AnalysisArtifactSave.model_validate(
+        {
+            "market": "kr",
+            "kind": "candidate_pool",
+            "title": "round-trip candidate pool",
+            "symbols": [symbol, "005930"],
+            "payload": {"ranked": [symbol, "005930"]},
+            "as_of": "2026-07-02T01:00:00+00:00",
+            "created_by": "claude",
+        }
+    )
+
+    saved = await service.save(entry)
+
+    listed = await service.list_artifacts(
+        market="kr",
+        kind="candidate_pool",
+        symbol=symbol,
+        limit=10,
+    )
+    assert [row.id for row in listed] == [saved.id]
+
+    fetched = await service.get(saved.id)
+    assert fetched is not None
+    assert fetched.payload == {"ranked": [symbol, "005930"]}
+
+    fetched_by_uuid = await service.get(str(saved.artifact_uuid))
+    assert fetched_by_uuid is not None
+    assert fetched_by_uuid.id == saved.id
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_list_excludes_stale_unless_include_stale(
+    db_session: AsyncSession,
+) -> None:
+    service = AnalysisArtifactService(db_session)
+    base = now_kst()
+    stale_symbol = f"TEST-{uuid4().hex[:8]}"
+    fresh_symbol = f"TEST-{uuid4().hex[:8]}"
+
+    await service.save(
+        AnalysisArtifactSave.model_validate(
+            {
+                "market": "kr",
+                "kind": "session_summary",
+                "title": "stale summary",
+                "symbols": [stale_symbol],
+                "as_of": (base - timedelta(hours=2)).isoformat(),
+                "valid_until": (base - timedelta(hours=1)).isoformat(),
+            }
+        )
+    )
+    await service.save(
+        AnalysisArtifactSave.model_validate(
+            {
+                "market": "kr",
+                "kind": "session_summary",
+                "title": "fresh summary",
+                "symbols": [fresh_symbol],
+                "as_of": base.isoformat(),
+                "valid_until": (base + timedelta(hours=1)).isoformat(),
+            }
+        )
+    )
+
+    fresh_only = await service.list_artifacts(
+        market="kr",
+        kind="session_summary",
+        limit=10,
+    )
+    assert {row.title for row in fresh_only} == {"fresh summary"}
+
+    with_stale = await service.list_artifacts(
+        market="kr",
+        kind="session_summary",
+        include_stale=True,
+        limit=10,
+    )
+    assert {row.title for row in with_stale} == {"stale summary", "fresh summary"}
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_list_symbol_containment_and_since_filter(
+    db_session: AsyncSession,
+) -> None:
+    service = AnalysisArtifactService(db_session)
+    shared_symbol = f"TEST-{uuid4().hex[:8]}"
+    other_symbol = f"TEST-{uuid4().hex[:8]}"
+    base = now_kst()
+
+    await service.save(
+        AnalysisArtifactSave.model_validate(
+            {
+                "market": "us",
+                "kind": "screening_ranking",
+                "title": "old ranking",
+                "symbols": [shared_symbol],
+                "as_of": (base - timedelta(days=2)).isoformat(),
+            }
+        )
+    )
+    await service.save(
+        AnalysisArtifactSave.model_validate(
+            {
+                "market": "us",
+                "kind": "screening_ranking",
+                "title": "new ranking",
+                "symbols": [shared_symbol, other_symbol],
+                "as_of": base.isoformat(),
+            }
+        )
+    )
+
+    by_symbol = await service.list_artifacts(
+        market="us",
+        kind="screening_ranking",
+        symbol=other_symbol,
+        include_stale=True,
+        limit=10,
+    )
+    assert [row.title for row in by_symbol] == ["new ranking"]
+
+    since_filtered = await service.list_artifacts(
+        market="us",
+        kind="screening_ranking",
+        symbol=shared_symbol,
+        since=base - timedelta(days=1),
+        include_stale=True,
+        limit=10,
+    )
+    assert [row.title for row in since_filtered] == ["new ranking"]
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_get_returns_none_for_missing(db_session: AsyncSession) -> None:
+    service = AnalysisArtifactService(db_session)
+
+    assert await service.get(999_999_999) is None
+    assert await service.get("not-a-uuid-or-int") is None

--- a/tests/test_analysis_artifact_mcp.py
+++ b/tests/test_analysis_artifact_mcp.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+import pytest_asyncio
+import sqlalchemy as sa
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.mcp_server.tooling.analysis_artifact_registration import (
+    ANALYSIS_ARTIFACT_TOOL_NAMES,
+    register_analysis_artifact_tools,
+)
+from app.mcp_server.tooling.analysis_artifact_tools import (
+    analysis_artifact_get,
+    analysis_artifact_list,
+    analysis_artifact_save,
+)
+
+
+class FakeMCP:
+    def __init__(self) -> None:
+        self.tools: dict[str, object] = {}
+
+    def tool(self, *, name: str, description: str):
+        assert description
+
+        def decorator(fn):
+            self.tools[name] = fn
+            return fn
+
+        return decorator
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def _clean_analysis_artifacts(db_session: AsyncSession):
+    await db_session.execute(
+        sa.text(
+            'TRUNCATE TABLE review."analysis_artifacts" RESTART IDENTITY CASCADE'
+        )
+    )
+    await db_session.commit()
+    yield
+    await db_session.execute(
+        sa.text(
+            'TRUNCATE TABLE review."analysis_artifacts" RESTART IDENTITY CASCADE'
+        )
+    )
+    await db_session.commit()
+
+
+def test_analysis_artifact_tool_names_register() -> None:
+    mcp = FakeMCP()
+
+    register_analysis_artifact_tools(mcp)  # type: ignore[arg-type]
+
+    assert ANALYSIS_ARTIFACT_TOOL_NAMES == {
+        "analysis_artifact_save",
+        "analysis_artifact_list",
+        "analysis_artifact_get",
+    }
+    assert set(mcp.tools) == ANALYSIS_ARTIFACT_TOOL_NAMES
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_save_list_get_round_trip(db_session: AsyncSession) -> None:
+    symbol = f"TEST-{uuid4().hex[:8]}"
+    save_response = await analysis_artifact_save(
+        market="kr",
+        kind="profit_taking_verdicts",
+        title="KR profit verdicts",
+        symbols=[symbol],
+        payload={"verdicts": [{symbol: "hold"}]},
+        as_of="2026-07-02T02:00:00+00:00",
+        created_by="claude",
+        session_label="kr-2026-07-02",
+    )
+
+    assert save_response["success"] is True
+    saved = save_response["artifact"]
+    assert saved["symbols"] == [symbol]
+    assert saved["payload"]["verdicts"] == [{symbol: "hold"}]
+
+    list_response = await analysis_artifact_list(
+        market="kr",
+        kind="profit_taking_verdicts",
+        symbol=symbol,
+        limit=10,
+    )
+
+    assert list_response["success"] is True
+    assert list_response["count"] == 1
+    assert list_response["artifacts"][0]["artifact_uuid"] == saved["artifact_uuid"]
+
+    get_response = await analysis_artifact_get(saved["id"])
+
+    assert get_response["success"] is True
+    assert get_response["artifact"]["payload"] == saved["payload"]
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_save_rejects_invalid_kind(db_session: AsyncSession) -> None:
+    response = await analysis_artifact_save(
+        market="kr",
+        kind="bogus_kind",
+        title="x",
+        as_of="2026-07-02T02:00:00+00:00",
+    )
+
+    assert response["success"] is False
+    assert response["error"] == "invalid_request"
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_get_returns_not_found_for_missing(
+    db_session: AsyncSession,
+) -> None:
+    response = await analysis_artifact_get(999_999_999)
+
+    assert response == {
+        "success": False,
+        "error": "not_found",
+        "artifact_id": 999_999_999,
+    }
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_list_returns_empty_when_no_match(
+    db_session: AsyncSession,
+) -> None:
+    await analysis_artifact_save(
+        market="us",
+        kind="candidate_pool",
+        title="US pool",
+        symbols=[f"TEST-{uuid4().hex[:8]}"],
+        as_of="2026-07-02T02:00:00+00:00",
+    )
+
+    response = await analysis_artifact_list(market="crypto", limit=20)
+
+    assert response["success"] is True
+    assert response["count"] == 0
+    assert response["artifacts"] == []

--- a/tests/test_analysis_artifact_mcp.py
+++ b/tests/test_analysis_artifact_mcp.py
@@ -35,16 +35,12 @@ class FakeMCP:
 @pytest_asyncio.fixture(autouse=True)
 async def _clean_analysis_artifacts(db_session: AsyncSession):
     await db_session.execute(
-        sa.text(
-            'TRUNCATE TABLE review."analysis_artifacts" RESTART IDENTITY CASCADE'
-        )
+        sa.text('TRUNCATE TABLE review."analysis_artifacts" RESTART IDENTITY CASCADE')
     )
     await db_session.commit()
     yield
     await db_session.execute(
-        sa.text(
-            'TRUNCATE TABLE review."analysis_artifacts" RESTART IDENTITY CASCADE'
-        )
+        sa.text('TRUNCATE TABLE review."analysis_artifacts" RESTART IDENTITY CASCADE')
     )
     await db_session.commit()
 
@@ -65,7 +61,7 @@ def test_analysis_artifact_tool_names_register() -> None:
 @pytest.mark.integration
 @pytest.mark.asyncio
 async def test_save_list_get_round_trip(db_session: AsyncSession) -> None:
-    symbol = f"TEST-{uuid4().hex[:8]}"
+    symbol = f"TEST_{uuid4().hex[:8]}"
     save_response = await analysis_artifact_save(
         market="kr",
         kind="profit_taking_verdicts",
@@ -145,3 +141,123 @@ async def test_list_returns_empty_when_no_match(
     assert response["success"] is True
     assert response["count"] == 0
     assert response["artifacts"] == []
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_symbol_normalization(db_session: AsyncSession) -> None:
+    save_response = await analysis_artifact_save(
+        market="us",
+        kind="screening_ranking",
+        title="US normal",
+        symbols=["BRK-B", "BRK/A", "AAPL"],
+        as_of="2026-07-02T02:00:00+00:00",
+    )
+    assert save_response["success"] is True
+    saved = save_response["artifact"]
+    assert saved["symbols"] == ["BRK.B", "BRK.A", "AAPL"]
+
+    # Dash input saved as dot-format must be findable by dot-format lookup.
+    list_response = await analysis_artifact_list(market="us", symbol="BRK.B")
+    assert list_response["count"] == 1
+    # And a dash-format query normalizes to the same hit.
+    list_dash = await analysis_artifact_list(market="us", symbol="BRK-B")
+    assert list_dash["count"] == 1
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_save_rejects_payload_too_large(db_session: AsyncSession) -> None:
+    response = await analysis_artifact_save(
+        market="kr",
+        kind="screening_ranking",
+        title="too big",
+        payload={"blob": "x" * (101 * 1024)},
+        as_of="2026-07-02T02:00:00+00:00",
+    )
+
+    assert response["success"] is False
+    assert response["error"] == "payload_too_large"
+    assert response["size_bytes"] > response["cap_bytes"] == 100 * 1024
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_correlation_id_idempotent_upsert(db_session: AsyncSession) -> None:
+    correlation_id = f"corr-{uuid4().hex[:12]}"
+    first = await analysis_artifact_save(
+        market="kr",
+        kind="profit_taking_verdicts",
+        title="v1",
+        payload={"rev": 1},
+        as_of="2026-07-02T02:00:00+00:00",
+        correlation_id=correlation_id,
+    )
+    assert first["success"] is True
+    assert first["action"] == "created"
+
+    second = await analysis_artifact_save(
+        market="kr",
+        kind="profit_taking_verdicts",
+        title="v2",
+        payload={"rev": 2},
+        as_of="2026-07-02T03:00:00+00:00",
+        correlation_id=correlation_id,
+    )
+    assert second["success"] is True
+    assert second["action"] == "updated"
+    assert second["artifact"]["id"] == first["artifact"]["id"]
+    assert second["artifact"]["payload"] == {"rev": 2}
+    assert second["artifact"]["title"] == "v2"
+
+    listed = await analysis_artifact_list(
+        market="kr", correlation_id=correlation_id, limit=10
+    )
+    assert listed["count"] == 1
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_list_is_metadata_only(db_session: AsyncSession) -> None:
+    symbol = f"TEST_{uuid4().hex[:8]}"
+    await analysis_artifact_save(
+        market="kr",
+        kind="flow_assessment",
+        title="meta only",
+        symbols=[symbol],
+        payload={"big": "가나다" * 100},
+        as_of="2026-07-02T02:00:00+00:00",
+    )
+
+    response = await analysis_artifact_list(market="kr", symbol=symbol, limit=5)
+
+    assert response["count"] == 1
+    row = response["artifacts"][0]
+    assert "payload" not in row
+    assert row["payload_size_bytes"] > 0
+    assert row["is_stale"] is False
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_stale_artifact_flagged_and_filtered(db_session: AsyncSession) -> None:
+    symbol = f"TEST_{uuid4().hex[:8]}"
+    save_response = await analysis_artifact_save(
+        market="kr",
+        kind="support_resistance_map",
+        title="stale one",
+        symbols=[symbol],
+        as_of="2026-07-01T02:00:00+00:00",
+        valid_until="2026-07-01T06:35:00+09:00",
+    )
+    saved = save_response["artifact"]
+    assert saved["is_stale"] is True
+
+    default_list = await analysis_artifact_list(market="kr", symbol=symbol)
+    assert default_list["count"] == 0
+
+    with_stale = await analysis_artifact_list(
+        market="kr", symbol=symbol, include_stale=True
+    )
+    assert with_stale["count"] == 1
+    assert with_stale["artifacts"][0]["is_stale"] is True


### PR DESCRIPTION
## 개요

분석 아티팩트(스크리닝 랭킹, 익절 판정, 지지/저항 맵 등)를 DB에 저장해 세션 간 재사용하는 구조. ROB-516 `session_context_append/get_recent` 패턴을 라인-포-라인 클론.

## 변경 사항

- 신규 테이블 `review.analysis_artifacts` (BIGSERIAL PK, UUID, market/kind/created_by CHECKs, TEXT[] symbols, JSONB payload, GIN 인덱스)
- 3개 MCP 도구: `analysis_artifact_save` / `_list` / `_get`
- 별도 명시적 저장 도구 (자동 저장 아님) — 운영자/Claude가 분석 후 호출
- 14 신규 테스트 + 7 회귀 테스트 통과

## 마이그레이션

- `alembic/versions/20260702_rob637_analysis_artifacts.py`
- down_revision: `20260620_scalp_benchmark` (현재 HEAD)

## 동기화 노트

- 641이 같은 head에서 분기 — 머지 순서: 637 먼저 → 641 리베이스
- 638, 639, 640은 alembic 무관, 병렬 머지 가능

## 모델 레인

`keep_on_gpt54` (루틴 구현, 로컬 블래스트 반경)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added reusable analysis artifact tools to MCP: save, list, and fetch artifacts across sessions.
  * Artifacts support payload persistence, symbol/time filtering, and staleness-aware listing, plus metadata-only listing.
  * Added correlation-aware save behavior and added artifact metadata into the operating briefing response.
  * Included documentation for the new tool interfaces.

* **Bug Fixes**
  * Improved input validation and returned consistent error shapes for invalid requests, missing artifacts, and oversized payloads.

* **Tests**
  * Added/extended unit and integration coverage for schemas, database persistence, and MCP end-to-end behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->