### PR TITLE
feat(ROB-638): Redis ephemeral cache for analyze_stock_batch (PR1)

### DIFF
--- a/app/core/analyze_cache.py
+++ b/app/core/analyze_cache.py
@@ -1,25 +1,44 @@
-"""Redis ephemeral cache for ``analyze_stock_batch`` results (ROB-638).
+"""Redis ephemeral cache for slowly-changing analyze FETCH outputs (ROB-638).
 
-Intraday repeat calls for the same symbol return a cached analysis result
-instead of re-running the full pipeline. The cache stores the *full* analysis
-dict (the output of ``_analyze_stock_impl``) so downstream formatting —
-especially the per-batch holdings ``position`` lookup — always runs against
-fresh holdings. Only the expensive market-data/indicator/opinion pipeline is
-short-circuited on a cache hit.
+Fetch-layer cache — NOT a whole-response cache. Only slowly-changing provider
+fetch outputs are cached:
 
-TTL policy (per market):
-    * KR     — refresh at the KRX session close (15:35 KST). Before 15:35 KST
-               the entry is cached until 15:35 today; after 15:35 it is cached
-               until the next midnight KST.
-    * US     — refresh at the NYSE close (16:00 ET). Before 16:00 ET the entry
-               is cached until 16:00 today; after 16:00 it is cached until the
-               next midnight ET.
-    * Crypto — flat 1 hour TTL (24/7 market, no session boundary).
+    * ``naver``            — KR Naver analysis snapshot (valuation/news/opinions)
+    * ``yfinance``         — US yfinance valuation + investment-opinions bundle
+    * ``finnhub_profile``  — US Finnhub company profile
+
+Live surfaces (quote/price, position lookup, RSI/indicators, support/resistance
+computation and the intraday re-sign, recommendation) are recomputed on EVERY
+call. Crypto is never cached (no analyst-consensus source).
+
+Key format: ``analyze_fetch:{provider}:{SYMBOL}:{date}`` where ``symbol`` is the
+resolver-normalized symbol and ``date`` is provider-local:
+
+    * ``naver``                        — date in KST
+    * ``yfinance`` / ``finnhub_profile`` — date in ET (America/New_York), so the
+      key date and the TTL reference share the same timezone (no orphan keys at
+      00:00 KST).
+
+TTL policy (per provider):
+    * ``naver``     — refresh at the KRX session close (15:35 KST). Before close
+                      the entry lives until 15:35 today; after close until the
+                      next midnight KST.
+    * ``yfinance`` / ``finnhub_profile`` — refresh at the NYSE close (16:00 ET).
+                      Before close the entry lives until 16:00 ET today; after
+                      close until the next midnight ET.
+
+Stored envelope: ``{"fetched_at": <ISO KST>, "payload": {...}}`` — callers use
+``fetched_at`` as the per-symbol ``derived_as_of`` label.
+
+Hermetic guard: ``settings.analyze_fetch_cache_enabled`` (default ``True``;
+forced ``false`` in ``tests/conftest.py``). When disabled the client factory
+returns ``None`` and every caller fails open to a direct fetch — no test can
+touch a real Redis unless it explicitly patches ``_get_redis_client``.
 
 Fail-open contract: every helper degrades gracefully. If Redis is unavailable
-or returns malformed data, ``get_cached_analyze_result`` returns ``None`` and
-``set_cached_analyze_result`` is a no-op — the caller always falls through to
-the live analysis pipeline.
+or returns malformed data, ``get_cached_fetch_payload`` returns ``(None, None)``
+and ``set_cached_fetch_payload`` is a no-op — the caller always falls through
+to the live provider fetch.
 """
 
 from __future__ import annotations
@@ -32,10 +51,15 @@ from zoneinfo import ZoneInfo
 
 import redis.asyncio as redis
 
+from app.core.config import settings
 from app.core.timezone import KST, now_kst
 from app.services.ohlcv_cache_common import create_redis_client
 
 logger = logging.getLogger(__name__)
+
+PROVIDER_NAVER = "naver"
+PROVIDER_YFINANCE = "yfinance"
+PROVIDER_FINNHUB_PROFILE = "finnhub_profile"
 
 # KRX regular-session close: cache refreshes at 15:35 KST (matches the OHLCV
 # cache cutoff in app.services.kis_ohlcv_cache._KRX_DAILY_CACHE_CUTOFF).
@@ -43,50 +67,43 @@ _KR_SESSION_CLOSE = time(15, 35)
 # NYSE regular-session close: 16:00 ET.
 _US_SESSION_CLOSE = time(16, 0)
 _US_EAST = ZoneInfo("America/New_York")
-# Crypto trades 24/7 — short flat TTL.
-_CRYPTO_TTL_SECONDS = 3600
+
+# Provider-local timezone for the key date AND the TTL reference clock.
+_PROVIDER_TZS: dict[str, ZoneInfo] = {
+    PROVIDER_NAVER: KST,
+    PROVIDER_YFINANCE: _US_EAST,
+    PROVIDER_FINNHUB_PROFILE: _US_EAST,
+}
+
+# Unknown provider — conservative 15-minute TTL.
+_UNKNOWN_PROVIDER_TTL_SECONDS = 900
 
 # module-level singleton Redis client (mirrors kis_ohlcv_cache pattern).
 _REDIS_CLIENT: redis.Redis | None = None
 
 
-def _resolve_market_for_symbol(symbol: str, market: str | None) -> str:
-    """Resolve a short market label ('kr' | 'us' | 'crypto') for cache keys.
-
-    Uses the shared symbol/market resolver so the key matches the lane the
-    analysis will actually run in. Falls back to the caller-supplied ``market``
-    (lowercased) or 'unknown' if resolution raises — the key just needs to be
-    deterministic and collision-free, not semantically perfect.
-    """
-    try:
-        from app.mcp_server.tooling.shared import resolve_market_type
-
-        market_type, _normalized = resolve_market_type(symbol, market)
-        return {"equity_kr": "kr", "equity_us": "us", "crypto": "crypto"}.get(
-            market_type, market or "unknown"
-        )
-    except Exception:
-        cleaned = (market or "").strip().lower()
-        return cleaned or "unknown"
+def _provider_tz(provider: str) -> ZoneInfo:
+    return _PROVIDER_TZS.get((provider or "").strip().lower(), KST)
 
 
-def _kst_date_for_key(now: datetime | None = None) -> str:
-    """YYYY-MM-DD in KST — the date component of the cache key."""
+def _provider_date_for_key(provider: str, now: datetime | None = None) -> str:
+    """YYYY-MM-DD in the provider-local timezone (KST for naver, ET for US)."""
     if now is None:
-        kst = now_kst()
+        now = now_kst()
     elif now.tzinfo is None:
-        kst = now.replace(tzinfo=KST)
-    else:
-        kst = now.astimezone(KST)
-    return kst.date().isoformat()
+        now = now.replace(tzinfo=KST)
+    return now.astimezone(_provider_tz(provider)).date().isoformat()
 
 
-def _cache_key(market: str, symbol: str, kst_date: str) -> str:
-    """Build the Redis cache key for an analyze_batch result.
+def _fetch_cache_key(provider: str, symbol: str, now: datetime | None = None) -> str:
+    """Build the Redis cache key for a provider fetch payload.
 
-    Format: ``analyze_batch:{market}:{SYMBOL}:{YYYY-MM-DD}``
+    Format: ``analyze_fetch:{provider}:{SYMBOL}:{YYYY-MM-DD}`` — the date is
+    provider-local so US keys roll at ET midnight (matching their TTL clock).
+    ``symbol`` must be the resolver-normalized symbol.
     """
-    return f"analyze_batch:{market}:{symbol.upper()}:{kst_date}"
+    date_part = _provider_date_for_key(provider, now)
+    return f"analyze_fetch:{provider}:{symbol.upper()}:{date_part}"
 
 
 def _seconds_until(now: datetime, target_time: time, tz: ZoneInfo) -> int:
@@ -113,43 +130,43 @@ def _seconds_until_next_midnight(now: datetime, tz: ZoneInfo) -> int:
     return int((midnight_tomorrow - now_local).total_seconds())
 
 
-def _cache_ttl_seconds(market: str, now: datetime) -> int:
-    """Compute the per-market TTL (seconds) for a fresh cache entry.
+def _fetch_cache_ttl_seconds(provider: str, now: datetime) -> int:
+    """Compute the per-provider TTL (seconds) for a fresh cache entry.
 
     Args:
-        market: 'kr' | 'us' | 'crypto' (case-insensitive).
-        now: Aware UTC datetime used as the reference instant.
+        provider: 'naver' | 'yfinance' | 'finnhub_profile' (case-insensitive).
+        now: Aware datetime used as the reference instant.
     """
-    market = (market or "").strip().lower()
-    if market == "crypto":
-        return _CRYPTO_TTL_SECONDS
-
-    if market == "kr":
+    provider = (provider or "").strip().lower()
+    if provider == PROVIDER_NAVER:
         now_local = now.astimezone(KST)
         if now_local.time() < _KR_SESSION_CLOSE:
-            # Trading window — cache until today's session close.
+            # Trading window — cache until today's session close (15:35 KST).
             return _seconds_until(now, _KR_SESSION_CLOSE, KST)
         # After close — cache until next midnight KST.
         return _seconds_until_next_midnight(now, KST)
 
-    if market == "us":
-        # NYSE/ET wall-clock reference.
+    if provider in (PROVIDER_YFINANCE, PROVIDER_FINNHUB_PROFILE):
+        # NYSE/ET wall-clock reference — same tz as the key date.
         now_local = now.astimezone(_US_EAST)
         if now_local.time() < _US_SESSION_CLOSE:
             return _seconds_until(now, _US_SESSION_CLOSE, _US_EAST)
         return _seconds_until_next_midnight(now, _US_EAST)
 
-    # Unknown market — conservative 15-minute TTL.
-    return 900
+    return _UNKNOWN_PROVIDER_TTL_SECONDS
 
 
 async def _get_redis_client() -> redis.Redis | None:
     """Return the lazy module-level Redis client, or ``None`` if unavailable.
 
-    The client is created lazily and cached. Any failure creating or configuring
-    the client returns ``None`` so callers can fail-open to the live pipeline.
+    Returns ``None`` (cache disabled, fail-open to direct fetch) when
+    ``settings.analyze_fetch_cache_enabled`` is False — the hermetic guard for
+    tests. Otherwise the client is created lazily and cached; any failure
+    creating it returns ``None`` so callers fail open to the live fetch.
     """
     global _REDIS_CLIENT
+    if not settings.analyze_fetch_cache_enabled:
+        return None
     if _REDIS_CLIENT is not None:
         return _REDIS_CLIENT
     try:
@@ -171,8 +188,11 @@ async def close_analyze_cache_redis() -> None:
         _REDIS_CLIENT = None
 
 
-def _normalize_cache_value(value: Any) -> dict[str, Any] | None:
-    """Parse a cached Redis payload into a dict; ``None`` on malformed input."""
+def _normalize_cache_envelope(value: Any) -> dict[str, Any] | None:
+    """Parse a cached Redis payload into an envelope dict; ``None`` if malformed.
+
+    A valid envelope is ``{"fetched_at": str, "payload": dict}``.
+    """
     if not isinstance(value, str):
         return None
     try:
@@ -181,52 +201,66 @@ def _normalize_cache_value(value: Any) -> dict[str, Any] | None:
         return None
     if not isinstance(parsed, dict):
         return None
+    if not isinstance(parsed.get("payload"), dict):
+        return None
+    if not isinstance(parsed.get("fetched_at"), str):
+        return None
     return parsed
 
 
-async def get_cached_analyze_result(
+async def get_cached_fetch_payload(
     redis_client: redis.Redis | None,
-    market: str,
+    provider: str,
     symbol: str,
-    kst_date: str,
-) -> dict[str, Any] | None:
-    """Return the cached full analysis dict for the symbol, or ``None``.
+) -> tuple[dict[str, Any] | None, str | None]:
+    """Return ``(payload, fetched_at)`` for the cached provider fetch, or
+    ``(None, None)``.
 
-    ``None`` is returned on cache miss, malformed payload, or when Redis is
-    unavailable (``redis_client is None``). Never raises.
+    ``(None, None)`` is returned on cache miss, malformed payload, or when
+    Redis is unavailable (``redis_client is None``). Never raises.
     """
     if redis_client is None:
-        return None
-    key = _cache_key(market, symbol, kst_date)
+        return None, None
+    key = _fetch_cache_key(provider, symbol)
     try:
         raw = await redis_client.get(key)
     except Exception as exc:
         logger.debug("analyze_cache: GET failed for %s: %s", key, exc)
-        return None
-    return _normalize_cache_value(raw)
+        return None, None
+    envelope = _normalize_cache_envelope(raw)
+    if envelope is None:
+        return None, None
+    return envelope["payload"], envelope["fetched_at"]
 
 
-async def set_cached_analyze_result(
+async def set_cached_fetch_payload(
     redis_client: redis.Redis | None,
-    market: str,
+    provider: str,
     symbol: str,
-    kst_date: str,
-    result: dict[str, Any],
+    payload: dict[str, Any],
+    *,
+    fetched_at: str | None = None,
 ) -> None:
-    """Cache ``result`` with the market-appropriate TTL. Never raises.
+    """Cache a provider fetch ``payload`` with the provider TTL. Never raises.
 
     Best-effort: if Redis is unavailable or serialization fails, the call is a
-    no-op and the caller continues with the freshly-computed result.
+    no-op and the caller continues with the freshly-fetched payload. Callers
+    must NOT invoke this for degraded/empty provider results.
     """
     if redis_client is None:
         return
     try:
-        ttl = _cache_ttl_seconds(market, datetime.now(KST))
+        now = now_kst()
+        ttl = _fetch_cache_ttl_seconds(provider, now)
         if ttl <= 0:
             return
-        payload = json.dumps(result, default=str, ensure_ascii=False)
-        key = _cache_key(market, symbol, kst_date)
-        await redis_client.set(key, payload, ex=ttl)
+        envelope = {
+            "fetched_at": fetched_at or now.isoformat(),
+            "payload": payload,
+        }
+        serialized = json.dumps(envelope, default=str, ensure_ascii=False)
+        key = _fetch_cache_key(provider, symbol, now)
+        await redis_client.set(key, serialized, ex=ttl)
     except (TypeError, ValueError) as exc:
         logger.debug("analyze_cache: serialize failed for %s: %s", symbol, exc)
     except Exception as exc:
@@ -234,11 +268,13 @@ async def set_cached_analyze_result(
 
 
 __all__ = [
-    "_cache_key",
-    "_cache_ttl_seconds",
-    "_kst_date_for_key",
-    "_resolve_market_for_symbol",
+    "PROVIDER_FINNHUB_PROFILE",
+    "PROVIDER_NAVER",
+    "PROVIDER_YFINANCE",
+    "_fetch_cache_key",
+    "_fetch_cache_ttl_seconds",
+    "_provider_date_for_key",
     "close_analyze_cache_redis",
-    "get_cached_analyze_result",
-    "set_cached_analyze_result",
+    "get_cached_fetch_payload",
+    "set_cached_fetch_payload",
 ]

--- a/app/core/analyze_cache.py
+++ b/app/core/analyze_cache.py
@@ -1,0 +1,244 @@
+"""Redis ephemeral cache for ``analyze_stock_batch`` results (ROB-638).
+
+Intraday repeat calls for the same symbol return a cached analysis result
+instead of re-running the full pipeline. The cache stores the *full* analysis
+dict (the output of ``_analyze_stock_impl``) so downstream formatting —
+especially the per-batch holdings ``position`` lookup — always runs against
+fresh holdings. Only the expensive market-data/indicator/opinion pipeline is
+short-circuited on a cache hit.
+
+TTL policy (per market):
+    * KR     — refresh at the KRX session close (15:35 KST). Before 15:35 KST
+               the entry is cached until 15:35 today; after 15:35 it is cached
+               until the next midnight KST.
+    * US     — refresh at the NYSE close (16:00 ET). Before 16:00 ET the entry
+               is cached until 16:00 today; after 16:00 it is cached until the
+               next midnight ET.
+    * Crypto — flat 1 hour TTL (24/7 market, no session boundary).
+
+Fail-open contract: every helper degrades gracefully. If Redis is unavailable
+or returns malformed data, ``get_cached_analyze_result`` returns ``None`` and
+``set_cached_analyze_result`` is a no-op — the caller always falls through to
+the live analysis pipeline.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, time, timedelta
+from typing import Any
+from zoneinfo import ZoneInfo
+
+import redis.asyncio as redis
+
+from app.core.timezone import KST, now_kst
+from app.services.ohlcv_cache_common import create_redis_client
+
+logger = logging.getLogger(__name__)
+
+# KRX regular-session close: cache refreshes at 15:35 KST (matches the OHLCV
+# cache cutoff in app.services.kis_ohlcv_cache._KRX_DAILY_CACHE_CUTOFF).
+_KR_SESSION_CLOSE = time(15, 35)
+# NYSE regular-session close: 16:00 ET.
+_US_SESSION_CLOSE = time(16, 0)
+_US_EAST = ZoneInfo("America/New_York")
+# Crypto trades 24/7 — short flat TTL.
+_CRYPTO_TTL_SECONDS = 3600
+
+# module-level singleton Redis client (mirrors kis_ohlcv_cache pattern).
+_REDIS_CLIENT: redis.Redis | None = None
+
+
+def _resolve_market_for_symbol(symbol: str, market: str | None) -> str:
+    """Resolve a short market label ('kr' | 'us' | 'crypto') for cache keys.
+
+    Uses the shared symbol/market resolver so the key matches the lane the
+    analysis will actually run in. Falls back to the caller-supplied ``market``
+    (lowercased) or 'unknown' if resolution raises — the key just needs to be
+    deterministic and collision-free, not semantically perfect.
+    """
+    try:
+        from app.mcp_server.tooling.shared import resolve_market_type
+
+        market_type, _normalized = resolve_market_type(symbol, market)
+        return {"equity_kr": "kr", "equity_us": "us", "crypto": "crypto"}.get(
+            market_type, market or "unknown"
+        )
+    except Exception:
+        cleaned = (market or "").strip().lower()
+        return cleaned or "unknown"
+
+
+def _kst_date_for_key(now: datetime | None = None) -> str:
+    """YYYY-MM-DD in KST — the date component of the cache key."""
+    if now is None:
+        kst = now_kst()
+    elif now.tzinfo is None:
+        kst = now.replace(tzinfo=KST)
+    else:
+        kst = now.astimezone(KST)
+    return kst.date().isoformat()
+
+
+def _cache_key(market: str, symbol: str, kst_date: str) -> str:
+    """Build the Redis cache key for an analyze_batch result.
+
+    Format: ``analyze_batch:{market}:{SYMBOL}:{YYYY-MM-DD}``
+    """
+    return f"analyze_batch:{market}:{symbol.upper()}:{kst_date}"
+
+
+def _seconds_until(now: datetime, target_time: time, tz: ZoneInfo) -> int:
+    """Seconds from ``now`` (aware) until the next occurrence of ``target_time``.
+
+    If ``target_time`` is later today, returns the delta to today's wall-clock.
+    Otherwise rolls to the same wall-clock tomorrow (delta < 24h).
+    """
+    now_local = now.astimezone(tz)
+    target_today = datetime.combine(now_local.date(), target_time, tzinfo=tz)
+    delta = (target_today - now_local).total_seconds()
+    if delta < 0:
+        # Already passed today — roll to tomorrow's wall-clock.
+        delta += 24 * 3600
+    return int(delta)
+
+
+def _seconds_until_next_midnight(now: datetime, tz: ZoneInfo) -> int:
+    """Seconds from ``now`` until the next 00:00 in ``tz``."""
+    now_local = now.astimezone(tz)
+    midnight_tomorrow = datetime.combine(
+        now_local.date() + timedelta(days=1), time(0, 0), tzinfo=tz
+    )
+    return int((midnight_tomorrow - now_local).total_seconds())
+
+
+def _cache_ttl_seconds(market: str, now: datetime) -> int:
+    """Compute the per-market TTL (seconds) for a fresh cache entry.
+
+    Args:
+        market: 'kr' | 'us' | 'crypto' (case-insensitive).
+        now: Aware UTC datetime used as the reference instant.
+    """
+    market = (market or "").strip().lower()
+    if market == "crypto":
+        return _CRYPTO_TTL_SECONDS
+
+    if market == "kr":
+        now_local = now.astimezone(KST)
+        if now_local.time() < _KR_SESSION_CLOSE:
+            # Trading window — cache until today's session close.
+            return _seconds_until(now, _KR_SESSION_CLOSE, KST)
+        # After close — cache until next midnight KST.
+        return _seconds_until_next_midnight(now, KST)
+
+    if market == "us":
+        # NYSE/ET wall-clock reference.
+        now_local = now.astimezone(_US_EAST)
+        if now_local.time() < _US_SESSION_CLOSE:
+            return _seconds_until(now, _US_SESSION_CLOSE, _US_EAST)
+        return _seconds_until_next_midnight(now, _US_EAST)
+
+    # Unknown market — conservative 15-minute TTL.
+    return 900
+
+
+async def _get_redis_client() -> redis.Redis | None:
+    """Return the lazy module-level Redis client, or ``None`` if unavailable.
+
+    The client is created lazily and cached. Any failure creating or configuring
+    the client returns ``None`` so callers can fail-open to the live pipeline.
+    """
+    global _REDIS_CLIENT
+    if _REDIS_CLIENT is not None:
+        return _REDIS_CLIENT
+    try:
+        _REDIS_CLIENT = await create_redis_client()
+    except Exception as exc:
+        logger.debug("analyze_cache: redis client init failed: %s", exc)
+        _REDIS_CLIENT = None
+    return _REDIS_CLIENT
+
+
+async def close_analyze_cache_redis() -> None:
+    """Close the module-level Redis client (test/teardown helper)."""
+    global _REDIS_CLIENT
+    if _REDIS_CLIENT is not None:
+        try:
+            await _REDIS_CLIENT.close()
+        except Exception:
+            pass
+        _REDIS_CLIENT = None
+
+
+def _normalize_cache_value(value: Any) -> dict[str, Any] | None:
+    """Parse a cached Redis payload into a dict; ``None`` on malformed input."""
+    if not isinstance(value, str):
+        return None
+    try:
+        parsed = json.loads(value)
+    except (TypeError, ValueError):
+        return None
+    if not isinstance(parsed, dict):
+        return None
+    return parsed
+
+
+async def get_cached_analyze_result(
+    redis_client: redis.Redis | None,
+    market: str,
+    symbol: str,
+    kst_date: str,
+) -> dict[str, Any] | None:
+    """Return the cached full analysis dict for the symbol, or ``None``.
+
+    ``None`` is returned on cache miss, malformed payload, or when Redis is
+    unavailable (``redis_client is None``). Never raises.
+    """
+    if redis_client is None:
+        return None
+    key = _cache_key(market, symbol, kst_date)
+    try:
+        raw = await redis_client.get(key)
+    except Exception as exc:
+        logger.debug("analyze_cache: GET failed for %s: %s", key, exc)
+        return None
+    return _normalize_cache_value(raw)
+
+
+async def set_cached_analyze_result(
+    redis_client: redis.Redis | None,
+    market: str,
+    symbol: str,
+    kst_date: str,
+    result: dict[str, Any],
+) -> None:
+    """Cache ``result`` with the market-appropriate TTL. Never raises.
+
+    Best-effort: if Redis is unavailable or serialization fails, the call is a
+    no-op and the caller continues with the freshly-computed result.
+    """
+    if redis_client is None:
+        return
+    try:
+        ttl = _cache_ttl_seconds(market, datetime.now(KST))
+        if ttl <= 0:
+            return
+        payload = json.dumps(result, default=str, ensure_ascii=False)
+        key = _cache_key(market, symbol, kst_date)
+        await redis_client.set(key, payload, ex=ttl)
+    except (TypeError, ValueError) as exc:
+        logger.debug("analyze_cache: serialize failed for %s: %s", symbol, exc)
+    except Exception as exc:
+        logger.debug("analyze_cache: SET failed for %s: %s", symbol, exc)
+
+
+__all__ = [
+    "_cache_key",
+    "_cache_ttl_seconds",
+    "_kst_date_for_key",
+    "_resolve_market_for_symbol",
+    "close_analyze_cache_redis",
+    "get_cached_analyze_result",
+    "set_cached_analyze_result",
+]

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -263,6 +263,12 @@ class Settings(BaseSettings):
     kis_ohlcv_cache_max_hours: int = 400 * 24
     kis_ohlcv_cache_lock_ttl_seconds: int = 10
 
+    # ROB-638: fetch-layer Redis cache for the slowly-changing analyze provider
+    # fetches (KR naver snapshot, US yfinance bundle, US finnhub profile).
+    # Default on in production; forced off in tests (tests/conftest.py) so no
+    # test can touch a real Redis unless it explicitly patches the cache client.
+    analyze_fetch_cache_enabled: bool = True
+
     # API Rate Limit Retry Settings (429 handling)
     api_rate_limit_retry_429_max: int = 2  # 429 에러 시 최대 재시도 횟수
     api_rate_limit_retry_429_base_delay: float = 0.2  # 지수 백오프 기본 대기 시간 (초)

--- a/app/mcp_server/tooling/analysis_analyze.py
+++ b/app/mcp_server/tooling/analysis_analyze.py
@@ -10,6 +10,8 @@ import pandas as pd
 import sentry_sdk
 import yfinance as yf
 
+from app.core import analyze_cache
+from app.core.timezone import now_kst
 from app.mcp_server.tooling.fundamentals_sources_finnhub import (
     _fetch_company_profile_finnhub,
     _fetch_news_finnhub,
@@ -254,24 +256,151 @@ def _collect_yfinance_snapshot(yf_ticker: Any) -> _YFinanceSnapshot:
     )
 
 
+# Task names whose results carry the fetch-cache envelope
+# ({"payload": ..., "cache_hit": bool, "fetched_at": iso}) — ROB-638.
+_FETCH_CACHE_TASK_NAMES = ("kr_snapshot", "us_yf_bundle", "profile")
+
+
+def _fetch_cache_envelope(
+    payload: dict[str, Any],
+    *,
+    cache_hit: bool,
+    fetched_at: str | None,
+) -> dict[str, Any]:
+    return {"payload": payload, "cache_hit": cache_hit, "fetched_at": fetched_at}
+
+
+async def _fetch_kr_snapshot_cached(
+    normalized_symbol: str, refresh: bool
+) -> dict[str, Any]:
+    """KR Naver snapshot (valuation/news/opinions) behind the fetch-layer cache.
+
+    ROB-638: only the slowly-changing provider fetch is cached — quote/RSI/S&R
+    and the recommendation are recomputed by the caller on EVERY call. Degraded
+    (empty) snapshots are never cached; a fetch exception propagates (and is
+    swallowed by ``_gather_task_results``) without touching the cache.
+    """
+    redis_client = await analyze_cache._get_redis_client()
+    if not refresh:
+        payload, fetched_at = await analyze_cache.get_cached_fetch_payload(
+            redis_client, analyze_cache.PROVIDER_NAVER, normalized_symbol
+        )
+        if payload is not None:
+            return _fetch_cache_envelope(payload, cache_hit=True, fetched_at=fetched_at)
+
+    snapshot = await _fetch_analysis_snapshot_naver(normalized_symbol, 5, 10)
+    fetched_at = now_kst().isoformat()
+    if isinstance(snapshot, dict) and snapshot:
+        # refresh=True still WRITES the fresh value — it only bypasses the read.
+        await analyze_cache.set_cached_fetch_payload(
+            redis_client,
+            analyze_cache.PROVIDER_NAVER,
+            normalized_symbol,
+            snapshot,
+            fetched_at=fetched_at,
+        )
+    return _fetch_cache_envelope(snapshot, cache_hit=False, fetched_at=fetched_at)
+
+
+async def _fetch_us_yf_bundle(
+    normalized_symbol: str,
+    yf_ticker: Any,
+    yf_session: Any,
+    loop: asyncio.AbstractEventLoop,
+    redis_client: Any,
+) -> dict[str, Any]:
+    """Fresh US yfinance snapshot → valuation + opinions bundle (cache MISS path).
+
+    The snapshot collection runs in the executor inside this task so it overlaps
+    the other provider fetches. The bundle is cached only when fully healthy:
+    a snapshot where every sub-fetch failed (all None) or a partial bundle
+    (valuation OR opinions raised) is returned fresh but never cached.
+    """
+    yf_snapshot = await loop.run_in_executor(
+        None, _collect_yfinance_snapshot, yf_ticker
+    )
+    bundle: dict[str, Any] = {}
+    part_errors = 0
+    try:
+        bundle["valuation"] = await _fetch_valuation_yfinance(
+            normalized_symbol, snapshot=yf_snapshot, session=yf_session
+        )
+    except Exception:
+        part_errors += 1
+    try:
+        bundle["opinions"] = await _fetch_investment_opinions_yfinance(
+            normalized_symbol, 10, snapshot=yf_snapshot, session=yf_session
+        )
+    except Exception:
+        part_errors += 1
+
+    fetched_at = now_kst().isoformat()
+    snapshot_degraded = (
+        yf_snapshot.info is None
+        and yf_snapshot.analyst_price_targets is None
+        and yf_snapshot.recommendations is None
+        and yf_snapshot.upgrades_downgrades is None
+    )
+    if not snapshot_degraded and part_errors == 0:
+        await analyze_cache.set_cached_fetch_payload(
+            redis_client,
+            analyze_cache.PROVIDER_YFINANCE,
+            normalized_symbol,
+            bundle,
+            fetched_at=fetched_at,
+        )
+    return _fetch_cache_envelope(bundle, cache_hit=False, fetched_at=fetched_at)
+
+
+async def _fetch_us_profile_cached(
+    normalized_symbol: str, refresh: bool, redis_client: Any
+) -> dict[str, Any]:
+    """US Finnhub company profile behind the fetch-layer cache.
+
+    ``_fetch_company_profile_finnhub`` raises on a missing profile, so a
+    degraded fetch propagates (swallowed by ``_gather_task_results``) and is
+    never cached.
+    """
+    if not refresh:
+        payload, fetched_at = await analyze_cache.get_cached_fetch_payload(
+            redis_client, analyze_cache.PROVIDER_FINNHUB_PROFILE, normalized_symbol
+        )
+        if payload is not None:
+            return _fetch_cache_envelope(payload, cache_hit=True, fetched_at=fetched_at)
+
+    profile = await _fetch_company_profile_finnhub(normalized_symbol)
+    fetched_at = now_kst().isoformat()
+    await analyze_cache.set_cached_fetch_payload(
+        redis_client,
+        analyze_cache.PROVIDER_FINNHUB_PROFILE,
+        normalized_symbol,
+        profile,
+        fetched_at=fetched_at,
+    )
+    return _fetch_cache_envelope(profile, cache_hit=False, fetched_at=fetched_at)
+
+
 async def _append_market_specific_tasks(
     named_tasks: list[tuple[str, asyncio.Task[Any]]],
     normalized_symbol: str,
     market_type: str,
     loop: asyncio.AbstractEventLoop,
+    refresh: bool = False,
 ) -> Any | None:
     if market_type == "equity_kr":
         named_tasks.append(
             (
                 "kr_snapshot",
                 asyncio.create_task(
-                    _fetch_analysis_snapshot_naver(normalized_symbol, 5, 10)
+                    _fetch_kr_snapshot_cached(normalized_symbol, refresh)
                 ),
             )
         )
         return None
 
     if market_type == "crypto":
+        # Crypto is NEVER cached (no analyst-consensus source) — this branch
+        # must not touch the cache client at all (asserted by tests).
         named_tasks.append(
             (
                 "news",
@@ -282,41 +411,51 @@ async def _append_market_specific_tasks(
         )
         return None
 
-    yf_session = build_yfinance_tracing_session()
-    yf_ticker = yf.Ticker(normalized_symbol, session=yf_session)
-    yf_snapshot = await loop.run_in_executor(
-        None, _collect_yfinance_snapshot, yf_ticker
-    )
+    redis_client = await analyze_cache._get_redis_client()
+    yf_session = None
+    bundle_envelope: dict[str, Any] | None = None
+    if not refresh:
+        payload, fetched_at = await analyze_cache.get_cached_fetch_payload(
+            redis_client, analyze_cache.PROVIDER_YFINANCE, normalized_symbol
+        )
+        if payload is not None:
+            bundle_envelope = _fetch_cache_envelope(
+                payload, cache_hit=True, fetched_at=fetched_at
+            )
+
+    if bundle_envelope is not None:
+        # Cache hit — no yfinance session/ticker is built at all.
+        async def _cached_bundle(
+            envelope: dict[str, Any] = bundle_envelope,
+        ) -> dict[str, Any]:
+            return envelope
+
+        named_tasks.append(("us_yf_bundle", asyncio.create_task(_cached_bundle())))
+    else:
+        yf_session = build_yfinance_tracing_session()
+        yf_ticker = yf.Ticker(normalized_symbol, session=yf_session)
+        named_tasks.append(
+            (
+                "us_yf_bundle",
+                asyncio.create_task(
+                    _fetch_us_yf_bundle(
+                        normalized_symbol, yf_ticker, yf_session, loop, redis_client
+                    )
+                ),
+            )
+        )
+
     named_tasks.extend(
         [
             (
-                "valuation",
-                asyncio.create_task(
-                    _fetch_valuation_yfinance(
-                        normalized_symbol,
-                        snapshot=yf_snapshot,
-                        session=yf_session,
-                    )
-                ),
-            ),
-            (
                 "profile",
-                asyncio.create_task(_fetch_company_profile_finnhub(normalized_symbol)),
+                asyncio.create_task(
+                    _fetch_us_profile_cached(normalized_symbol, refresh, redis_client)
+                ),
             ),
             (
                 "news",
                 asyncio.create_task(_fetch_news_finnhub(normalized_symbol, "us", 5)),
-            ),
-            (
-                "opinions",
-                asyncio.create_task(
-                    _fetch_investment_opinions_yfinance(
-                        normalized_symbol,
-                        10,
-                        snapshot=yf_snapshot,
-                        session=yf_session,
-                    )
-                ),
             ),
         ]
     )
@@ -428,9 +567,20 @@ def _recompute_intraday_support_resistance(
     sr["distance_basis"] = "live_quote"
 
 
+def _envelope_payload(task_results: dict[str, Any], name: str) -> dict[str, Any] | None:
+    """Unwrap a fetch-cache envelope task result into its provider payload."""
+    envelope = task_results.get(name)
+    if not isinstance(envelope, dict):
+        return None
+    payload = envelope.get("payload")
+    if not isinstance(payload, dict):
+        return None
+    return payload
+
+
 def _apply_kr_results(analysis: dict[str, Any], task_results: dict[str, Any]) -> None:
-    kr_snapshot = task_results.get("kr_snapshot")
-    if not isinstance(kr_snapshot, dict):
+    kr_snapshot = _envelope_payload(task_results, "kr_snapshot")
+    if kr_snapshot is None:
         return
     for key in ("valuation", "news", "opinions"):
         if key in kr_snapshot:
@@ -438,9 +588,16 @@ def _apply_kr_results(analysis: dict[str, Any], task_results: dict[str, Any]) ->
 
 
 def _apply_us_results(analysis: dict[str, Any], task_results: dict[str, Any]) -> None:
-    for key in ("valuation", "profile", "news", "opinions"):
-        if key in task_results:
-            analysis[key] = task_results[key]
+    bundle = _envelope_payload(task_results, "us_yf_bundle")
+    if bundle is not None:
+        for key in ("valuation", "opinions"):
+            if key in bundle:
+                analysis[key] = bundle[key]
+    profile = _envelope_payload(task_results, "profile")
+    if profile:
+        analysis["profile"] = profile
+    if "news" in task_results:
+        analysis["news"] = task_results["news"]
 
 
 def _apply_market_specific_results(
@@ -456,6 +613,30 @@ def _apply_market_specific_results(
         return
     if "news" in task_results:
         analysis["news"] = task_results["news"]
+
+
+def _apply_fetch_cache_metadata(
+    analysis: dict[str, Any], task_results: dict[str, Any]
+) -> None:
+    """Attach the ROB-638 fetch-cache response contract keys.
+
+    ``cache_hit`` — True when the fetch-layer cache served ANY provider payload
+    for this symbol. ``derived_as_of`` — ISO-KST timestamp of when the (cached
+    or fresh) provider data was fetched; with multiple providers the OLDEST
+    fetch time is reported (most conservative freshness statement). Crypto and
+    fully-fresh runs report the current fetch time.
+    """
+    envelopes = [
+        envelope
+        for name in _FETCH_CACHE_TASK_NAMES
+        if isinstance((envelope := task_results.get(name)), dict)
+        and "payload" in envelope
+    ]
+    analysis["cache_hit"] = any(env.get("cache_hit") for env in envelopes)
+    fetched_ats = sorted(
+        str(env["fetched_at"]) for env in envelopes if env.get("fetched_at")
+    )
+    analysis["derived_as_of"] = fetched_ats[0] if fetched_ats else now_kst().isoformat()
 
 
 def _apply_sector_peers_result(
@@ -539,6 +720,7 @@ async def analyze_stock_impl(
     symbol: str,
     market: str | None = None,
     include_peers: bool = False,
+    refresh: bool = False,
 ) -> dict[str, Any]:
     symbol = _normalize_symbol_input(symbol, market)
     if not symbol:
@@ -571,7 +753,7 @@ async def analyze_stock_impl(
     )
     _append_common_tasks(named_tasks, normalized_symbol, ohlcv_df, ohlcv_60d)
     yfinance_session_to_close = await _append_market_specific_tasks(
-        named_tasks, normalized_symbol, market_type, loop
+        named_tasks, normalized_symbol, market_type, loop, refresh=refresh
     )
     _append_sector_peers_task(
         named_tasks, normalized_symbol, market_type, include_peers
@@ -596,6 +778,8 @@ async def analyze_stock_impl(
         _recompute_intraday_support_resistance(analysis, market_type)
         _apply_market_specific_results(analysis, task_results, market_type)
         _apply_sector_peers_result(analysis, task_results, market_type, include_peers)
+        # ROB-638 — fetch-cache response contract (cache_hit / derived_as_of).
+        _apply_fetch_cache_metadata(analysis, task_results)
         analysis["errors"] = []
         _apply_recommendation(analysis, market_type)
 

--- a/app/mcp_server/tooling/analysis_registration.py
+++ b/app/mcp_server/tooling/analysis_registration.py
@@ -214,7 +214,14 @@ def register_analysis_tools(
             "avg_buy_price, pnl_pct, order_routable}, or null when not held. "
             "order_routable mirrors get_holdings: manual non-toss (samsung/수기) -> "
             "false, toss_api -> TOSS_LIVE_ORDER_MUTATIONS_ENABLED, kis/upbit -> true "
-            "(ROB-562); account_mode is a provenance label, NOT a routing selector."
+            "(ROB-562); account_mode is a provenance label, NOT a routing selector. "
+            "Slowly-changing provider data (KR naver valuation/opinions, US yfinance "
+            "valuation/opinions + finnhub profile) is served from an intraday "
+            "fetch-layer cache; price/RSI/support-resistance/recommendation are "
+            "recomputed fresh on every call. Each result carries cache_hit (whether "
+            "cached provider data was served) and derived_as_of (ISO KST timestamp "
+            "of when that provider data was fetched). refresh=True bypasses the "
+            "cache read and re-fetches provider data fresh (ROB-638)."
         ),
     )
     async def analyze_stock_batch(
@@ -223,6 +230,7 @@ def register_analysis_tools(
         include_peers: bool = False,
         quick: bool = True,
         include_position: bool = True,
+        refresh: bool = False,
     ) -> dict[str, Any]:
         return await analyze_stock_batch_impl(
             symbols=symbols,
@@ -230,6 +238,7 @@ def register_analysis_tools(
             include_peers=include_peers,
             quick=quick,
             include_position=include_position,
+            refresh=refresh,
         )
 
     @mcp.tool(

--- a/app/mcp_server/tooling/analysis_screening.py
+++ b/app/mcp_server/tooling/analysis_screening.py
@@ -356,7 +356,17 @@ async def _analyze_stock_impl(
     symbol: str,
     market: str | None = None,
     include_peers: bool = False,
+    refresh: bool = False,
 ) -> dict[str, Any]:
+    # ROB-638: ``refresh`` is forwarded as a keyword ONLY when set so legacy
+    # 3-arg test stubs of analyze_stock_impl keep working.
+    if refresh:
+        return await analysis_analyze.analyze_stock_impl(
+            symbol=symbol,
+            market=market,
+            include_peers=include_peers,
+            refresh=True,
+        )
     return await analysis_analyze.analyze_stock_impl(
         symbol=symbol,
         market=market,

--- a/app/mcp_server/tooling/analysis_tool_handlers.py
+++ b/app/mcp_server/tooling/analysis_tool_handlers.py
@@ -15,6 +15,13 @@ from typing import Any, Literal
 import httpx
 import yfinance as yf
 
+from app.core import analyze_cache
+from app.core.analyze_cache import (
+    _kst_date_for_key,
+    _resolve_market_for_symbol,
+    get_cached_analyze_result,
+    set_cached_analyze_result,
+)
 from app.mcp_server.tooling import analysis_screening, foreigners_liquidity
 from app.mcp_server.tooling.analysis_screen_core import normalize_screen_request
 from app.mcp_server.tooling.market_data_indicators import (
@@ -568,15 +575,39 @@ async def _run_batch_analysis(
     async def _analyze_one(sym: str) -> dict[str, Any]:
         async with sem:
             try:
+                # ROB-638: Redis cache check (fail-open).
+                redis_client = await analyze_cache._get_redis_client()
+                cache_market = _resolve_market_for_symbol(sym, market)
+                kst_date = _kst_date_for_key()
+                cached = await get_cached_analyze_result(
+                    redis_client, cache_market, sym, kst_date
+                )
+                if cached is not None:
+                    cached["cache_hit"] = True
+                    return cached
+
                 result = analysis_screening._analyze_stock_impl(
                     sym, market, include_peers
                 )
                 if asyncio.iscoroutine(result):
-                    return await result
+                    result = await result
+
+                result["cache_hit"] = False
+                result["derived_as_of"] = datetime.datetime.now(
+                    datetime.UTC
+                ).isoformat()
+                await set_cached_analyze_result(
+                    redis_client, cache_market, sym, kst_date, result
+                )
                 return result
             except Exception as exc:
                 errors.append(f"{sym}: {str(exc)}")
-                return {"symbol": sym, "error": str(exc)}
+                return {
+                    "symbol": sym,
+                    "error": str(exc),
+                    "cache_hit": False,
+                    "derived_as_of": None,
+                }
 
     analyze_results = await asyncio.gather(
         *[_analyze_one(s) for s in normalized_symbols]
@@ -589,6 +620,8 @@ async def _run_batch_analysis(
             formatted_result = formatter(sym, result, position_index=position_index)
         else:
             formatted_result = formatter(sym, result)
+        formatted_result["cache_hit"] = result.get("cache_hit", False)
+        formatted_result["derived_as_of"] = result.get("derived_as_of")
         results[sym] = formatted_result
         if "error" not in result:
             success_count += 1

--- a/app/mcp_server/tooling/analysis_tool_handlers.py
+++ b/app/mcp_server/tooling/analysis_tool_handlers.py
@@ -15,13 +15,6 @@ from typing import Any, Literal
 import httpx
 import yfinance as yf
 
-from app.core import analyze_cache
-from app.core.analyze_cache import (
-    _kst_date_for_key,
-    _resolve_market_for_symbol,
-    get_cached_analyze_result,
-    set_cached_analyze_result,
-)
 from app.mcp_server.tooling import analysis_screening, foreigners_liquidity
 from app.mcp_server.tooling.analysis_screen_core import normalize_screen_request
 from app.mcp_server.tooling.market_data_indicators import (
@@ -532,6 +525,7 @@ async def _run_batch_analysis(
     include_peers: bool,
     formatter: Callable[..., dict[str, Any]],
     include_position: bool = False,
+    refresh: bool = False,
 ) -> dict[str, Any]:
     """Shared batch analysis executor for portfolio and stock batch analysis.
 
@@ -545,6 +539,8 @@ async def _run_batch_analysis(
         include_position: When True (ROB-541), make ONE batched holdings fetch
             for the whole batch and pass the in-memory position index to the
             formatter. Never fans out per symbol.
+        refresh: When True (ROB-638), bypass the fetch-layer provider cache
+            READ for every symbol (fresh values are still written back).
 
     Returns:
         Dict with 'results' (symbol -> formatted_result) and 'summary' keys
@@ -575,30 +571,21 @@ async def _run_batch_analysis(
     async def _analyze_one(sym: str) -> dict[str, Any]:
         async with sem:
             try:
-                # ROB-638: Redis cache check (fail-open).
-                redis_client = await analyze_cache._get_redis_client()
-                cache_market = _resolve_market_for_symbol(sym, market)
-                kst_date = _kst_date_for_key()
-                cached = await get_cached_analyze_result(
-                    redis_client, cache_market, sym, kst_date
-                )
-                if cached is not None:
-                    cached["cache_hit"] = True
-                    return cached
-
-                result = analysis_screening._analyze_stock_impl(
-                    sym, market, include_peers
-                )
+                # ROB-638: caching happens at the FETCH layer inside the analyze
+                # pipeline (analysis_analyze.py) — never at the whole-response
+                # level, so quote/RSI/S&R/recommendation recompute every call.
+                # ``refresh`` is passed as a keyword ONLY when set so legacy
+                # 3-arg test stubs of _analyze_stock_impl keep working.
+                if refresh:
+                    result = analysis_screening._analyze_stock_impl(
+                        sym, market, include_peers, refresh=True
+                    )
+                else:
+                    result = analysis_screening._analyze_stock_impl(
+                        sym, market, include_peers
+                    )
                 if asyncio.iscoroutine(result):
                     result = await result
-
-                result["cache_hit"] = False
-                result["derived_as_of"] = datetime.datetime.now(
-                    datetime.UTC
-                ).isoformat()
-                await set_cached_analyze_result(
-                    redis_client, cache_market, sym, kst_date, result
-                )
                 return result
             except Exception as exc:
                 errors.append(f"{sym}: {str(exc)}")
@@ -620,6 +607,9 @@ async def _run_batch_analysis(
             formatted_result = formatter(sym, result, position_index=position_index)
         else:
             formatted_result = formatter(sym, result)
+        # ROB-638 additive contract: cache_hit = whether the fetch-layer cache
+        # served the provider data; derived_as_of = ISO-KST timestamp of when
+        # that provider data was fetched (populated by analysis_analyze).
         formatted_result["cache_hit"] = result.get("cache_hit", False)
         formatted_result["derived_as_of"] = result.get("derived_as_of")
         results[sym] = formatted_result
@@ -800,6 +790,7 @@ async def analyze_stock_batch_impl(
     include_peers: bool = False,
     quick: bool = True,
     include_position: bool = True,
+    refresh: bool = False,
 ) -> dict[str, Any]:
     """Analyze multiple symbols and return compact per-symbol summaries.
     Args:
@@ -810,6 +801,9 @@ async def analyze_stock_batch_impl(
         include_position: ROB-541 — when True (default) and quick=True, attach a
             per-account holdings 'position' array (or null) to each compact
             summary via a SINGLE batched holdings fetch.
+        refresh: ROB-638 — when True, bypass the fetch-layer provider cache
+            read (consensus/valuation/profile are re-fetched fresh and the
+            fresh values are written back to the cache).
     Returns:
         Dict with 'results' (symbol -> summary) and 'summary' keys
     """
@@ -844,6 +838,7 @@ async def analyze_stock_batch_impl(
         include_peers=include_peers,
         formatter=formatter,
         include_position=attach_position,
+        refresh=refresh,
     )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "auto-trader"
-version = "0.2.5"
+version = "0.2.6"
 description = ""
 authors = [
     { name = "robin", email = "robin@watcha.com" }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -99,6 +99,12 @@ def _ensure_test_env() -> None:
     os.environ["SENTRY_DSN"] = ""
     os.environ["ENVIRONMENT"] = "test"
 
+    # ROB-638: hermetic guard — the analyze fetch-layer cache must NEVER touch a
+    # real Redis from tests (a `make test` run on an operator host would poison
+    # the live MCP cache with mock provider data). Force-disable; cache tests
+    # patch analyze_cache._get_redis_client with a fake explicitly.
+    os.environ["ANALYZE_FETCH_CACHE_ENABLED"] = "false"
+
 
 _ensure_test_env()
 

--- a/tests/test_analyze_stock_batch_cache.py
+++ b/tests/test_analyze_stock_batch_cache.py
@@ -1,14 +1,32 @@
-"""Tests for the Redis ephemeral cache on analyze_stock_batch (ROB-638)."""
+"""Tests for the fetch-layer Redis cache behind analyze_stock (ROB-638).
+
+Design under test: ONLY slowly-changing provider fetch outputs are cached
+(KR naver snapshot, US yfinance valuation/opinions bundle, US finnhub profile).
+Quote/price, indicators (RSI), support/resistance + intraday re-sign, and the
+recommendation recompute on EVERY call. Crypto never touches the cache.
+
+All tests are hermetic: tests/conftest.py forces ANALYZE_FETCH_CACHE_ENABLED
+off, so the real client factory returns None; cache behaviour is exercised by
+patching ``analyze_cache._get_redis_client`` with an in-memory fake.
+"""
 
 from __future__ import annotations
 
+import copy
 import json
+from datetime import datetime
 from typing import Any
+from zoneinfo import ZoneInfo
 
+import pandas as pd
 import pytest
 
 from app.core import analyze_cache
+from app.mcp_server.tooling import analysis_analyze
 from app.mcp_server.tooling import analysis_tool_handlers as handlers
+
+KST = ZoneInfo("Asia/Seoul")
+ET = ZoneInfo("America/New_York")
 
 
 class _FakeRedis:
@@ -40,23 +58,6 @@ class _FakeRedis:
         return True
 
 
-def _make_analysis(symbol: str, *, price: float = 100.0) -> dict[str, Any]:
-    return {
-        "symbol": symbol,
-        "market_type": "equity_kr",
-        "source": "kis",
-        "quote": {"price": price},
-        "indicators": {"rsi": {"14": 55.0}},
-        "support_resistance": {"supports": [90.0], "resistances": [110.0]},
-        "opinions": {"consensus": "hold"},
-        "recommendation": "HOLD",
-    }
-
-
-def _summary_formatter(sym, result, **kw):
-    return handlers._summarize_analysis_result(sym, result)
-
-
 @pytest.fixture(autouse=True)
 def _reset_analyze_cache_singleton(monkeypatch):
     """Reset the module-level Redis client between tests."""
@@ -69,8 +70,9 @@ def _reset_analyze_cache_singleton(monkeypatch):
 def patch_redis(monkeypatch):
     """Force analyze_cache to use a fresh fake Redis client."""
 
-    def make():
-        fake = _FakeRedis()
+    def make(fake: Any | None = None):
+        if fake is None:
+            fake = _FakeRedis()
 
         async def _get_client():
             return fake
@@ -82,111 +84,112 @@ def patch_redis(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
-# Pure TTL / key-format unit tests
+# Pure key / TTL unit tests
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.unit
-def test_cache_key_format():
-    assert (
-        analyze_cache._cache_key("kr", "005930", "2026-07-02")
-        == "analyze_batch:kr:005930:2026-07-02"
-    )
-
-
-@pytest.mark.unit
-def test_cache_key_uppercases_symbol():
-    assert (
-        analyze_cache._cache_key("us", "aapl", "2026-07-02")
-        == "analyze_batch:us:AAPL:2026-07-02"
-    )
-
-
-@pytest.mark.unit
-@pytest.mark.parametrize(
-    ("market", "expected"),
-    [
-        ("crypto", 3600),
-        ("CRYPTO", 3600),
-    ],
-)
-def test_cache_ttl_crypto_flat_1h(market, expected):
-    from datetime import datetime
-    from zoneinfo import ZoneInfo
-
-    now = datetime(2026, 7, 2, 12, 0, tzinfo=ZoneInfo("UTC"))
-    assert analyze_cache._cache_ttl_seconds(market, now) == expected
-
-
-@pytest.mark.unit
-def test_cache_ttl_kr_before_session_close_targets_close():
-    from datetime import datetime
-    from zoneinfo import ZoneInfo
-
-    KST = ZoneInfo("Asia/Seoul")
+def test_fetch_cache_key_naver_uses_kst_date():
     now = datetime(2026, 7, 2, 10, 0, tzinfo=KST)
-    ttl = analyze_cache._cache_ttl_seconds("kr", now)
-    # 10:00 -> 15:35 = 5h35m = 20100s
-    assert ttl == 20100
+    assert (
+        analyze_cache._fetch_cache_key("naver", "005930", now)
+        == "analyze_fetch:naver:005930:2026-07-02"
+    )
 
 
 @pytest.mark.unit
-def test_cache_ttl_kr_just_before_close_is_near_zero():
-    from datetime import datetime
-    from zoneinfo import ZoneInfo
+def test_fetch_cache_key_us_providers_use_et_date():
+    # 2026-07-02 10:00 KST == 2026-07-01 21:00 ET: the US key date must be
+    # ET-based so it rolls at ET midnight together with the TTL clock.
+    now = datetime(2026, 7, 2, 10, 0, tzinfo=KST)
+    assert (
+        analyze_cache._fetch_cache_key("yfinance", "aapl", now)
+        == "analyze_fetch:yfinance:AAPL:2026-07-01"
+    )
+    assert (
+        analyze_cache._fetch_cache_key("finnhub_profile", "AAPL", now)
+        == "analyze_fetch:finnhub_profile:AAPL:2026-07-01"
+    )
 
-    KST = ZoneInfo("Asia/Seoul")
+
+@pytest.mark.unit
+def test_fetch_cache_key_uppercases_symbol():
+    now = datetime(2026, 7, 2, 12, 0, tzinfo=ET)
+    key = analyze_cache._fetch_cache_key("yfinance", "brk.b", now)
+    assert ":BRK.B:" in key
+
+
+@pytest.mark.unit
+def test_ttl_naver_before_session_close_targets_close():
+    now = datetime(2026, 7, 2, 10, 0, tzinfo=KST)
+    # 10:00 -> 15:35 KST = 5h35m = 20100s
+    assert analyze_cache._fetch_cache_ttl_seconds("naver", now) == 20100
+
+
+@pytest.mark.unit
+def test_ttl_naver_after_close_targets_midnight_kst():
+    now = datetime(2026, 7, 2, 16, 0, tzinfo=KST)
+    assert analyze_cache._fetch_cache_ttl_seconds("naver", now) == 28800
+
+
+@pytest.mark.unit
+def test_ttl_naver_just_before_close_is_near_zero():
     now = datetime(2026, 7, 2, 15, 34, 59, tzinfo=KST)
-    ttl = analyze_cache._cache_ttl_seconds("kr", now)
-    assert ttl == 1
+    assert analyze_cache._fetch_cache_ttl_seconds("naver", now) == 1
 
 
 @pytest.mark.unit
-def test_cache_ttl_kr_at_or_after_close_targets_midnight():
-    from datetime import datetime
-    from zoneinfo import ZoneInfo
-
-    KST = ZoneInfo("Asia/Seoul")
-    at_close = datetime(2026, 7, 2, 15, 35, 0, tzinfo=KST)
-    assert analyze_cache._cache_ttl_seconds("kr", at_close) == 30300  # -> 00:00
-    after_close = datetime(2026, 7, 2, 16, 0, tzinfo=KST)
-    assert analyze_cache._cache_ttl_seconds("kr", after_close) == 28800
-
-
-@pytest.mark.unit
-def test_cache_ttl_us_before_close_targets_close():
-    from datetime import datetime
-    from zoneinfo import ZoneInfo
-
-    ET = ZoneInfo("America/New_York")
+@pytest.mark.parametrize("provider", ["yfinance", "finnhub_profile"])
+def test_ttl_us_providers_before_close_targets_close_et(provider):
     now = datetime(2026, 7, 2, 15, 0, tzinfo=ET)
-    assert analyze_cache._cache_ttl_seconds("us", now) == 3600  # 15:00 -> 16:00
+    assert analyze_cache._fetch_cache_ttl_seconds(provider, now) == 3600
 
 
 @pytest.mark.unit
-def test_cache_ttl_us_after_close_targets_midnight_et():
-    from datetime import datetime
-    from zoneinfo import ZoneInfo
-
-    ET = ZoneInfo("America/New_York")
+@pytest.mark.parametrize("provider", ["yfinance", "finnhub_profile"])
+def test_ttl_us_providers_after_close_targets_midnight_et(provider):
     now = datetime(2026, 7, 2, 20, 0, tzinfo=ET)
-    assert analyze_cache._cache_ttl_seconds("us", now) == 14400  # 20:00 -> 00:00
+    assert analyze_cache._fetch_cache_ttl_seconds(provider, now) == 14400
 
 
 @pytest.mark.unit
-def test_cache_ttl_unknown_market_falls_back_to_15min():
-    from datetime import datetime
-    from zoneinfo import ZoneInfo
-
+def test_ttl_unknown_provider_falls_back_to_15min():
     now = datetime(2026, 7, 2, 12, 0, tzinfo=ZoneInfo("UTC"))
-    assert analyze_cache._cache_ttl_seconds("unknown", now) == 900
+    assert analyze_cache._fetch_cache_ttl_seconds("unknown", now) == 900
 
 
+# ---------------------------------------------------------------------------
+# Hermetic guard: settings flag gates client creation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
 @pytest.mark.unit
-def test_resolve_market_for_symbol_detects_each_lane():
-    assert analyze_cache._resolve_market_for_symbol("005930", None) == "kr"
-    assert analyze_cache._resolve_market_for_symbol("AAPL", None) == "us"
-    assert analyze_cache._resolve_market_for_symbol("KRW-BTC", None) == "crypto"
+async def test_get_redis_client_disabled_in_test_env(monkeypatch):
+    """conftest forces ANALYZE_FETCH_CACHE_ENABLED=false: no client is ever
+    created — the factory must not even attempt a connection."""
+
+    def _explode():
+        raise AssertionError("create_redis_client must not be called in tests")
+
+    monkeypatch.setattr(analyze_cache, "create_redis_client", _explode)
+    assert await analyze_cache._get_redis_client() is None
+    assert analyze_cache._REDIS_CLIENT is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_get_redis_client_enabled_flag_creates_client(monkeypatch):
+    from app.core.config import settings
+
+    fake = _FakeRedis()
+
+    async def _create():
+        return fake
+
+    monkeypatch.setattr(settings, "analyze_fetch_cache_enabled", True)
+    monkeypatch.setattr(analyze_cache, "create_redis_client", _create)
+    assert await analyze_cache._get_redis_client() is fake
 
 
 # ---------------------------------------------------------------------------
@@ -198,56 +201,75 @@ def test_resolve_market_for_symbol_detects_each_lane():
 @pytest.mark.unit
 async def test_get_cached_returns_none_on_miss():
     fake = _FakeRedis()
-    assert await analyze_cache.get_cached_analyze_result(fake, "kr", "005930", "2026-07-02") is None
+    payload, fetched_at = await analyze_cache.get_cached_fetch_payload(
+        fake, "naver", "005930"
+    )
+    assert payload is None and fetched_at is None
 
 
 @pytest.mark.asyncio
 @pytest.mark.unit
 async def test_get_cached_returns_none_when_redis_is_none():
-    assert await analyze_cache.get_cached_analyze_result(None, "kr", "005930", "2026-07-02") is None
+    payload, fetched_at = await analyze_cache.get_cached_fetch_payload(
+        None, "naver", "005930"
+    )
+    assert payload is None and fetched_at is None
 
 
 @pytest.mark.asyncio
 @pytest.mark.unit
-async def test_set_then_get_roundtrip():
+async def test_set_then_get_roundtrip_with_envelope():
     fake = _FakeRedis()
-    payload = {"symbol": "005930", "current_price": 70000}
-    await analyze_cache.set_cached_analyze_result(
-        fake, "kr", "005930", "2026-07-02", payload
+    payload = {"valuation": {"per": 12.3}, "opinions": {"consensus": {"rows_used": 3}}}
+    await analyze_cache.set_cached_fetch_payload(
+        fake, "naver", "005930", payload, fetched_at="2026-07-02T10:00:00+09:00"
     )
-    cached = await analyze_cache.get_cached_analyze_result(
-        fake, "kr", "005930", "2026-07-02"
+    cached, fetched_at = await analyze_cache.get_cached_fetch_payload(
+        fake, "naver", "005930"
     )
     assert cached == payload
-    # TTL was set (KR during/after session -> positive)
-    key = analyze_cache._cache_key("kr", "005930", "2026-07-02")
+    assert fetched_at == "2026-07-02T10:00:00+09:00"
+    key = analyze_cache._fetch_cache_key("naver", "005930")
     assert fake.ttls[key] > 0
 
 
 @pytest.mark.asyncio
 @pytest.mark.unit
-async def test_set_is_noop_when_redis_is_none():
-    await analyze_cache.set_cached_analyze_result(
-        None, "kr", "005930", "2026-07-02", {"x": 1}
+async def test_set_defaults_fetched_at_to_now_kst():
+    fake = _FakeRedis()
+    await analyze_cache.set_cached_fetch_payload(fake, "naver", "005930", {"x": 1})
+    _, fetched_at = await analyze_cache.get_cached_fetch_payload(
+        fake, "naver", "005930"
     )
+    assert isinstance(fetched_at, str) and fetched_at
 
 
 @pytest.mark.asyncio
 @pytest.mark.unit
-async def test_get_returns_none_on_malformed_payload():
-    fake = _FakeRedis()
-    key = analyze_cache._cache_key("kr", "005930", "2026-07-02")
-    fake.store[key] = "not-json"
-    assert await analyze_cache.get_cached_analyze_result(fake, "kr", "005930", "2026-07-02") is None
+async def test_set_is_noop_when_redis_is_none():
+    await analyze_cache.set_cached_fetch_payload(None, "naver", "005930", {"x": 1})
 
 
 @pytest.mark.asyncio
 @pytest.mark.unit
-async def test_get_returns_none_on_non_dict_payload():
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "not-json",
+        json.dumps([1, 2, 3]),
+        json.dumps({"payload": "not-a-dict", "fetched_at": "t"}),
+        json.dumps({"payload": {"x": 1}}),  # missing fetched_at
+        json.dumps({"fetched_at": "t"}),  # missing payload
+    ],
+)
+async def test_get_returns_none_on_malformed_envelope(raw):
     fake = _FakeRedis()
-    key = analyze_cache._cache_key("kr", "005930", "2026-07-02")
-    fake.store[key] = json.dumps([1, 2, 3])
-    assert await analyze_cache.get_cached_analyze_result(fake, "kr", "005930", "2026-07-02") is None
+    key = analyze_cache._fetch_cache_key("naver", "005930")
+    fake.store[key] = raw
+    payload, fetched_at = await analyze_cache.get_cached_fetch_payload(
+        fake, "naver", "005930"
+    )
+    assert payload is None and fetched_at is None
 
 
 @pytest.mark.asyncio
@@ -257,12 +279,10 @@ async def test_get_swallows_redis_errors():
         async def get(self, key):
             raise RuntimeError("redis down")
 
-    assert (
-        await analyze_cache.get_cached_analyze_result(
-            _ExplodingRedis(), "kr", "005930", "2026-07-02"
-        )
-        is None
+    payload, fetched_at = await analyze_cache.get_cached_fetch_payload(
+        _ExplodingRedis(), "naver", "005930"
     )
+    assert payload is None and fetched_at is None
 
 
 @pytest.mark.asyncio
@@ -272,185 +292,546 @@ async def test_set_swallows_redis_errors():
         async def set(self, *args, **kwargs):
             raise RuntimeError("redis down")
 
-    await analyze_cache.set_cached_analyze_result(
-        _ExplodingRedis(), "kr", "005930", "2026-07-02", {"x": 1}
+    await analyze_cache.set_cached_fetch_payload(
+        _ExplodingRedis(), "naver", "005930", {"x": 1}
     )
 
 
 # ---------------------------------------------------------------------------
-# Integration: _run_batch_analysis with cache (patched pipeline + redis)
+# KR pipeline: cached consensus, fresh price/RSI/S&R
 # ---------------------------------------------------------------------------
 
 
-def _install_fake_pipeline(monkeypatch, results_by_symbol: dict[str, dict[str, Any]]):
-    """Replace analysis_screening._analyze_stock_impl with a deterministic stub."""
-    call_log: list[str] = []
-
-    def _stub(sym, market, include_peers):
-        call_log.append(sym)
-        if sym not in results_by_symbol:
-            raise ValueError(f"no stub for {sym}")
-        return results_by_symbol[sym]
-
-    monkeypatch.setattr(
-        handlers.analysis_screening, "_analyze_stock_impl", _stub
-    )
-    return call_log
-
-
-@pytest.mark.asyncio
-@pytest.mark.unit
-async def test_second_call_hits_cache_and_skips_pipeline(monkeypatch, patch_redis):
-    patch_redis()
-    call_log = _install_fake_pipeline(
-        monkeypatch, {"005930": _make_analysis("005930", price=70000)}
-    )
-
-    formatter = _summary_formatter
-
-    first = await handlers._run_batch_analysis(
-        ["005930"], market="kr", include_peers=False, formatter=formatter
-    )
-    assert call_log == ["005930"]
-    first_row = first["results"]["005930"]
-    assert first_row["cache_hit"] is False
-    assert first_row["derived_as_of"] is not None
-    assert first_row["current_price"] == 70000
-
-    second = await handlers._run_batch_analysis(
-        ["005930"], market="kr", include_peers=False, formatter=formatter
-    )
-    assert call_log == ["005930"], "pipeline must not re-run on cache hit"
-    second_row = second["results"]["005930"]
-    assert second_row["cache_hit"] is True
-    assert second_row["derived_as_of"] == first_row["derived_as_of"]
-    assert second_row["current_price"] == 70000
-
-
-@pytest.mark.asyncio
-@pytest.mark.unit
-async def test_different_symbol_misses_cache_and_runs_pipeline(monkeypatch, patch_redis):
-    patch_redis()
-    call_log = _install_fake_pipeline(
-        monkeypatch,
+def _ohlcv_df() -> pd.DataFrame:
+    idx = pd.date_range("2026-06-01", periods=5, freq="D")
+    return pd.DataFrame(
         {
-            "005930": _make_analysis("005930", price=70000),
-            "000660": _make_analysis("000660", price=120000),
+            "open": [100.0] * 5,
+            "high": [110.0] * 5,
+            "low": [90.0] * 5,
+            "close": [105.0] * 5,
+            "volume": [1000] * 5,
         },
+        index=idx,
     )
-    formatter = _summary_formatter
 
-    await handlers._run_batch_analysis(
-        ["005930"], market="kr", include_peers=False, formatter=formatter
-    )
-    await handlers._run_batch_analysis(
-        ["000660"], market="kr", include_peers=False, formatter=formatter
-    )
-    assert call_log == ["005930", "000660"]
+
+@pytest.fixture
+def kr_pipeline(monkeypatch):
+    """Stub every non-cached surface of the KR analyze pipeline with counters."""
+    state = {
+        "price": 70000.0,
+        "naver_calls": 0,
+        "quote_calls": 0,
+        "indicator_calls": 0,
+        "sr_calls": 0,
+        "naver_payload": {
+            "valuation": {
+                "instrument_type": "equity_kr",
+                "source": "naver",
+                "per": 12.3,
+            },
+            "news": {"symbol": "005930", "count": 0, "news": []},
+            "opinions": {
+                "instrument_type": "equity_kr",
+                "source": "naver",
+                "consensus": {"rows_used": 3, "avg_target_price": 90000},
+            },
+        },
+    }
+    df = _ohlcv_df()
+
+    async def fake_ohlcv(symbol, market_type, count=250):
+        return df
+
+    async def fake_quote(symbol, ohlcv_df):
+        state["quote_calls"] += 1
+        return {
+            "symbol": symbol,
+            "instrument_type": "equity_kr",
+            "price": state["price"],
+            "price_as_of": "2026-07-02T10:00:00+09:00",
+            "is_stale_price": False,
+        }
+
+    async def fake_indicators(symbol, indicators, market=None, preloaded_df=None):
+        state["indicator_calls"] += 1
+        return {"symbol": symbol, "indicators": {"rsi": {"14": 55.0}}}
+
+    async def fake_sr(symbol, market=None, preloaded_df=None):
+        state["sr_calls"] += 1
+        return {
+            "supports": [{"price": 65000.0, "distance_pct": -7.1}],
+            "resistances": [{"price": 78000.0, "distance_pct": 11.4}],
+            "current_price": 70000.0,
+        }
+
+    async def fake_naver(symbol, news_limit, opinions_limit):
+        state["naver_calls"] += 1
+        return copy.deepcopy(state["naver_payload"])
+
+    monkeypatch.setattr(analysis_analyze, "_fetch_ohlcv_for_indicators", fake_ohlcv)
+    monkeypatch.setattr(analysis_analyze, "_resolve_kr_quote", fake_quote)
+    monkeypatch.setattr(analysis_analyze, "_get_indicators_impl", fake_indicators)
+    monkeypatch.setattr(analysis_analyze, "_get_support_resistance_impl", fake_sr)
+    monkeypatch.setattr(analysis_analyze, "_fetch_analysis_snapshot_naver", fake_naver)
+    return state
 
 
 @pytest.mark.asyncio
 @pytest.mark.unit
-async def test_cache_keyed_by_symbol_within_same_batch(monkeypatch, patch_redis):
-    """Two symbols in one batch each run the pipeline exactly once."""
-    patch_redis()
-    call_log = _install_fake_pipeline(
-        monkeypatch,
-        {
-            "005930": _make_analysis("005930"),
-            "000660": _make_analysis("000660", price=120000),
-        },
-    )
-    formatter = _summary_formatter
-
-    result = await handlers._run_batch_analysis(
-        ["005930", "000660"], market="kr", include_peers=False, formatter=formatter
-    )
-    assert sorted(call_log) == ["000660", "005930"]
-    for sym in ("005930", "000660"):
-        assert result["results"][sym]["cache_hit"] is False
-
-
-@pytest.mark.asyncio
-@pytest.mark.unit
-async def test_expired_entry_reruns_pipeline(monkeypatch, patch_redis):
-    """Simulate TTL expiry by clearing the fake redis between calls."""
+async def test_kr_hit_serves_cached_consensus_but_recomputes_live(
+    kr_pipeline, patch_redis
+):
     fake_redis = patch_redis()
-    call_log = _install_fake_pipeline(
-        monkeypatch, {"005930": _make_analysis("005930")}
-    )
-    formatter = _summary_formatter
 
-    await handlers._run_batch_analysis(
-        ["005930"], market="kr", include_peers=False, formatter=formatter
-    )
-    assert call_log == ["005930"]
+    first = await analysis_analyze.analyze_stock_impl("005930", "kr")
+    assert kr_pipeline["naver_calls"] == 1
+    assert first["cache_hit"] is False
+    assert first["derived_as_of"]
+    assert first["quote"]["price"] == 70000.0
+    assert fake_redis.set_call_count == 1
 
-    fake_redis.store.clear()  # simulate expiry
+    # Live price moves between calls.
+    kr_pipeline["price"] = 72000.0
 
-    res = await handlers._run_batch_analysis(
-        ["005930"], market="kr", include_peers=False, formatter=formatter
-    )
-    assert call_log == ["005930", "005930"]
-    assert res["results"]["005930"]["cache_hit"] is False
+    second = await analysis_analyze.analyze_stock_impl("005930", "kr")
+    # Provider fetch was served from cache — naver NOT re-fetched.
+    assert kr_pipeline["naver_calls"] == 1
+    assert second["cache_hit"] is True
+    assert second["derived_as_of"] == first["derived_as_of"]
+    # Consensus / valuation come from the cache.
+    assert second["opinions"]["consensus"]["avg_target_price"] == 90000
+    assert second["valuation"]["per"] == 12.3
+    # Live surfaces recomputed EVERY call.
+    assert kr_pipeline["quote_calls"] == 2
+    assert kr_pipeline["indicator_calls"] == 2
+    assert kr_pipeline["sr_calls"] == 2
+    assert second["quote"]["price"] == 72000.0
+    # ROB-541 intraday S/R re-sign ran against the NEW live price.
+    assert second["support_resistance"]["distance_basis_price"] == 72000.0
+    # Recommendation was rebuilt fresh (not served from any cache).
+    assert second["recommendation"]["action"] in {"buy", "hold", "sell"}
 
 
 @pytest.mark.asyncio
 @pytest.mark.unit
-async def test_redis_unavailable_falls_through_to_pipeline(monkeypatch):
-    """When _get_redis_client returns None, the pipeline must still run."""
+async def test_kr_refresh_bypasses_cache_read_but_rewrites(kr_pipeline, patch_redis):
+    fake_redis = patch_redis()
+
+    await analysis_analyze.analyze_stock_impl("005930", "kr")
+    assert kr_pipeline["naver_calls"] == 1
+    assert fake_redis.set_call_count == 1
+
+    result = await analysis_analyze.analyze_stock_impl("005930", "kr", refresh=True)
+    # Read bypassed — provider re-fetched; fresh value written back.
+    assert kr_pipeline["naver_calls"] == 2
+    assert result["cache_hit"] is False
+    assert fake_redis.set_call_count == 2
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_kr_degraded_snapshot_is_not_cached(
+    kr_pipeline, patch_redis, monkeypatch
+):
+    fake_redis = patch_redis()
+
+    async def empty_naver(symbol, news_limit, opinions_limit):
+        kr_pipeline["naver_calls"] += 1
+        return {}
+
+    monkeypatch.setattr(analysis_analyze, "_fetch_analysis_snapshot_naver", empty_naver)
+
+    first = await analysis_analyze.analyze_stock_impl("005930", "kr")
+    assert fake_redis.set_call_count == 0
+    assert first["cache_hit"] is False
+    assert "valuation" not in first
+
+    second = await analysis_analyze.analyze_stock_impl("005930", "kr")
+    # No cached entry -> provider fetched again.
+    assert kr_pipeline["naver_calls"] == 2
+    assert second["cache_hit"] is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_kr_provider_exception_is_not_cached(
+    kr_pipeline, patch_redis, monkeypatch
+):
+    fake_redis = patch_redis()
+
+    async def broken_naver(symbol, news_limit, opinions_limit):
+        kr_pipeline["naver_calls"] += 1
+        raise RuntimeError("naver down")
+
     monkeypatch.setattr(
-        analyze_cache, "_REDIS_CLIENT", None
+        analysis_analyze, "_fetch_analysis_snapshot_naver", broken_naver
     )
 
+    result = await analysis_analyze.analyze_stock_impl("005930", "kr")
+    # Fetch failure is swallowed by the gather (degraded analysis), never cached.
+    assert fake_redis.set_call_count == 0
+    assert result["cache_hit"] is False
+    assert "valuation" not in result
+    # Live surfaces still computed.
+    assert result["quote"]["price"] == 70000.0
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_kr_redis_error_fails_open_to_fresh_fetch(kr_pipeline, patch_redis):
+    class _ExplodingRedis:
+        async def get(self, key):
+            raise RuntimeError("redis down")
+
+        async def set(self, *args, **kwargs):
+            raise RuntimeError("redis down")
+
+    patch_redis(_ExplodingRedis())
+
+    first = await analysis_analyze.analyze_stock_impl("005930", "kr")
+    second = await analysis_analyze.analyze_stock_impl("005930", "kr")
+    assert kr_pipeline["naver_calls"] == 2
+    assert first["cache_hit"] is False
+    assert second["cache_hit"] is False
+    assert second["opinions"]["consensus"]["avg_target_price"] == 90000
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_kr_redis_unavailable_falls_through(kr_pipeline, monkeypatch):
     async def _none():
         return None
 
     monkeypatch.setattr(analyze_cache, "_get_redis_client", _none)
-    call_log = _install_fake_pipeline(
-        monkeypatch, {"005930": _make_analysis("005930")}
-    )
-    formatter = _summary_formatter
 
-    res = await handlers._run_batch_analysis(
-        ["005930"], market="kr", include_peers=False, formatter=formatter
-    )
-    assert call_log == ["005930"]
-    row = res["results"]["005930"]
-    assert row["cache_hit"] is False
-    assert row["derived_as_of"] is not None
+    result = await analysis_analyze.analyze_stock_impl("005930", "kr")
+    assert kr_pipeline["naver_calls"] == 1
+    assert result["cache_hit"] is False
+    assert result["derived_as_of"]
+
+
+# ---------------------------------------------------------------------------
+# Crypto: never touches the cache
+# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
 @pytest.mark.unit
-async def test_error_row_carries_cache_metadata(monkeypatch, patch_redis):
-    patch_redis()
-    _install_fake_pipeline(monkeypatch, {})
+async def test_crypto_pipeline_never_touches_cache(monkeypatch):
+    cache_client_calls = {"count": 0}
 
-    formatter = _summary_formatter
+    async def counting_client():
+        cache_client_calls["count"] += 1
+        return _FakeRedis()
 
-    res = await handlers._run_batch_analysis(
-        ["BADSYM"], market="kr", include_peers=False, formatter=formatter
+    monkeypatch.setattr(analyze_cache, "_get_redis_client", counting_client)
+
+    df = _ohlcv_df()
+
+    async def fake_ohlcv(symbol, market_type, count=250):
+        return df
+
+    async def fake_quote(symbol, market_type):
+        return {"symbol": symbol, "price": 95000000.0}
+
+    async def fake_indicators(symbol, indicators, market=None, preloaded_df=None):
+        return {"symbol": symbol, "indicators": {"rsi": {"14": 61.2}}}
+
+    async def fake_sr(symbol, market=None, preloaded_df=None):
+        return {"supports": [], "resistances": []}
+
+    async def fake_news(symbol, market, limit):
+        return {"symbol": symbol, "news": []}
+
+    monkeypatch.setattr(analysis_analyze, "_fetch_ohlcv_for_indicators", fake_ohlcv)
+    monkeypatch.setattr(analysis_analyze, "_get_quote_impl", fake_quote)
+    monkeypatch.setattr(analysis_analyze, "_get_indicators_impl", fake_indicators)
+    monkeypatch.setattr(analysis_analyze, "_get_support_resistance_impl", fake_sr)
+    monkeypatch.setattr(analysis_analyze, "_fetch_news_finnhub", fake_news)
+
+    result = await analysis_analyze.analyze_stock_impl("KRW-BTC", "crypto")
+
+    assert cache_client_calls["count"] == 0, "crypto must never touch the cache"
+    assert result["cache_hit"] is False
+    assert result["derived_as_of"]  # fresh fetch timestamp
+    assert result["quote"]["price"] == 95000000.0
+
+
+# ---------------------------------------------------------------------------
+# US pipeline: yfinance bundle + finnhub profile cached with ET-dated keys
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def us_pipeline(monkeypatch):
+    from app.mcp_server.tooling.fundamentals_sources_yfinance import _YFinanceSnapshot
+
+    state = {
+        "price": 200.0,
+        "quote_calls": 0,
+        "snapshot_calls": 0,
+        "profile_calls": 0,
+        "news_calls": 0,
+        "session_builds": 0,
+        "valuation_calls": 0,
+        "opinions_calls": 0,
+    }
+    df = _ohlcv_df()
+
+    async def fake_ohlcv(symbol, market_type, count=250):
+        return df
+
+    async def fake_quote(symbol, market_type):
+        state["quote_calls"] += 1
+        return {"symbol": symbol, "price": state["price"]}
+
+    async def fake_indicators(symbol, indicators, market=None, preloaded_df=None):
+        return {"symbol": symbol, "indicators": {"rsi": {"14": 48.0}}}
+
+    async def fake_sr(symbol, market=None, preloaded_df=None):
+        return {"supports": [], "resistances": []}
+
+    def fake_snapshot(ticker):
+        state["snapshot_calls"] += 1
+        return _YFinanceSnapshot(info={"currentPrice": 200.0})
+
+    async def fake_valuation(symbol, snapshot=None, session=None):
+        state["valuation_calls"] += 1
+        return {
+            "instrument_type": "equity_us",
+            "source": "yfinance",
+            "symbol": symbol.upper(),
+            "per": 30.5,
+        }
+
+    async def fake_opinions(symbol, limit, snapshot=None, session=None):
+        state["opinions_calls"] += 1
+        return {
+            "instrument_type": "equity_us",
+            "source": "yfinance",
+            "symbol": symbol.upper(),
+            "count": 0,
+            "opinions": [],
+            "consensus": {"total_count": 12, "avg_target_price": 220.0},
+        }
+
+    async def fake_profile(symbol):
+        state["profile_calls"] += 1
+        return {"symbol": symbol, "source": "finnhub", "name": "Apple Inc."}
+
+    async def fake_news(symbol, market, limit):
+        state["news_calls"] += 1
+        return {"symbol": symbol, "news": []}
+
+    def fake_build_session():
+        state["session_builds"] += 1
+        return object()
+
+    monkeypatch.setattr(analysis_analyze, "_fetch_ohlcv_for_indicators", fake_ohlcv)
+    monkeypatch.setattr(analysis_analyze, "_get_quote_impl", fake_quote)
+    monkeypatch.setattr(analysis_analyze, "_get_indicators_impl", fake_indicators)
+    monkeypatch.setattr(analysis_analyze, "_get_support_resistance_impl", fake_sr)
+    monkeypatch.setattr(analysis_analyze, "_collect_yfinance_snapshot", fake_snapshot)
+    monkeypatch.setattr(analysis_analyze, "_fetch_valuation_yfinance", fake_valuation)
+    monkeypatch.setattr(
+        analysis_analyze, "_fetch_investment_opinions_yfinance", fake_opinions
     )
-    row = res["results"]["BADSYM"]
+    monkeypatch.setattr(
+        analysis_analyze, "_fetch_company_profile_finnhub", fake_profile
+    )
+    monkeypatch.setattr(analysis_analyze, "_fetch_news_finnhub", fake_news)
+    monkeypatch.setattr(
+        analysis_analyze, "build_yfinance_tracing_session", fake_build_session
+    )
+    monkeypatch.setattr(
+        analysis_analyze, "close_yfinance_session", lambda session: None
+    )
+    monkeypatch.setattr(
+        analysis_analyze.yf, "Ticker", lambda symbol, session=None: object()
+    )
+    return state
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_us_bundle_and_profile_cached_news_and_quote_fresh(
+    us_pipeline, patch_redis
+):
+    fake_redis = patch_redis()
+
+    first = await analysis_analyze.analyze_stock_impl("AAPL", "us")
+    assert first["cache_hit"] is False
+    assert us_pipeline["snapshot_calls"] == 1
+    assert us_pipeline["profile_calls"] == 1
+    assert us_pipeline["session_builds"] == 1
+    # Both providers stored with ET-based key dates.
+    et_date = datetime.now(ET).date().isoformat()
+    assert f"analyze_fetch:yfinance:AAPL:{et_date}" in fake_redis.store
+    assert f"analyze_fetch:finnhub_profile:AAPL:{et_date}" in fake_redis.store
+
+    us_pipeline["price"] = 210.0
+    second = await analysis_analyze.analyze_stock_impl("AAPL", "us")
+    assert second["cache_hit"] is True
+    assert second["derived_as_of"] == first["derived_as_of"]
+    # Cached providers NOT re-fetched; no new yfinance session built.
+    assert us_pipeline["snapshot_calls"] == 1
+    assert us_pipeline["valuation_calls"] == 1
+    assert us_pipeline["opinions_calls"] == 1
+    assert us_pipeline["profile_calls"] == 1
+    assert us_pipeline["session_builds"] == 1
+    # Cached payloads served.
+    assert second["valuation"]["per"] == 30.5
+    assert second["opinions"]["consensus"]["avg_target_price"] == 220.0
+    assert second["profile"]["name"] == "Apple Inc."
+    # Live surfaces fresh EVERY call.
+    assert us_pipeline["quote_calls"] == 2
+    assert us_pipeline["news_calls"] == 2
+    assert second["quote"]["price"] == 210.0
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_us_refresh_bypasses_both_provider_caches(us_pipeline, patch_redis):
+    fake_redis = patch_redis()
+
+    await analysis_analyze.analyze_stock_impl("AAPL", "us")
+    result = await analysis_analyze.analyze_stock_impl("AAPL", "us", refresh=True)
+
+    assert result["cache_hit"] is False
+    assert us_pipeline["snapshot_calls"] == 2
+    assert us_pipeline["profile_calls"] == 2
+    # Fresh values written back on refresh (2 providers x 2 calls).
+    assert fake_redis.set_call_count == 4
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_us_degraded_snapshot_bundle_not_cached(
+    us_pipeline, patch_redis, monkeypatch
+):
+    from app.mcp_server.tooling.fundamentals_sources_yfinance import _YFinanceSnapshot
+
+    fake_redis = patch_redis()
+
+    def degraded_snapshot(ticker):
+        us_pipeline["snapshot_calls"] += 1
+        return _YFinanceSnapshot()  # every sub-fetch failed -> all None
+
+    monkeypatch.setattr(
+        analysis_analyze, "_collect_yfinance_snapshot", degraded_snapshot
+    )
+
+    result = await analysis_analyze.analyze_stock_impl("AAPL", "us")
+    et_date = datetime.now(ET).date().isoformat()
+    assert f"analyze_fetch:yfinance:AAPL:{et_date}" not in fake_redis.store
+    # Profile is healthy and independently cached.
+    assert f"analyze_fetch:finnhub_profile:AAPL:{et_date}" in fake_redis.store
+    assert result["cache_hit"] is False
+
+
+# ---------------------------------------------------------------------------
+# Batch handler: refresh threading + metadata propagation
+# ---------------------------------------------------------------------------
+
+
+def _summary_formatter(sym, result, **kw):
+    return handlers._summarize_analysis_result(sym, result)
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_batch_threads_refresh_to_pipeline(monkeypatch):
+    seen: list[bool] = []
+
+    async def stub(sym, market, include_peers, refresh=False):
+        seen.append(refresh)
+        return {"symbol": sym, "market_type": "equity_kr", "source": "kis"}
+
+    monkeypatch.setattr(handlers.analysis_screening, "_analyze_stock_impl", stub)
+
+    await handlers.analyze_stock_batch_impl(
+        ["005930"], market="kr", include_position=False, refresh=True
+    )
+    assert seen == [True]
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_screening_alias_forwards_refresh_only_when_set(monkeypatch):
+    from app.mcp_server.tooling import analysis_screening
+
+    seen: list[dict[str, Any]] = []
+
+    async def fake_impl(symbol, market=None, include_peers=False, **kwargs):
+        seen.append({"symbol": symbol, **kwargs})
+        return {"symbol": symbol}
+
+    monkeypatch.setattr(
+        analysis_screening.analysis_analyze, "analyze_stock_impl", fake_impl
+    )
+
+    await analysis_screening._analyze_stock_impl("005930", "kr", False)
+    await analysis_screening._analyze_stock_impl("005930", "kr", False, refresh=True)
+    assert seen == [
+        {"symbol": "005930"},
+        {"symbol": "005930", "refresh": True},
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_batch_default_keeps_legacy_three_arg_stub_contract(monkeypatch):
+    """refresh defaults False and is NOT passed positionally — legacy 3-arg
+    monkeypatched stubs of _analyze_stock_impl must keep working."""
+
+    def stub(sym, market, include_peers):
+        return {"symbol": sym, "market_type": "equity_kr", "source": "kis"}
+
+    monkeypatch.setattr(handlers.analysis_screening, "_analyze_stock_impl", stub)
+
+    result = await handlers.analyze_stock_batch_impl(
+        ["005930"], market="kr", include_position=False
+    )
+    assert result["summary"]["successful"] == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_batch_propagates_fetch_cache_metadata_to_summary(monkeypatch):
+    async def stub(sym, market, include_peers):
+        return {
+            "symbol": sym,
+            "market_type": "equity_kr",
+            "source": "kis",
+            "quote": {"price": 70000},
+            "cache_hit": True,
+            "derived_as_of": "2026-07-02T10:00:00+09:00",
+        }
+
+    monkeypatch.setattr(handlers.analysis_screening, "_analyze_stock_impl", stub)
+
+    result = await handlers._run_batch_analysis(
+        ["005930"], market="kr", include_peers=False, formatter=_summary_formatter
+    )
+    row = result["results"]["005930"]
+    assert row["cache_hit"] is True
+    assert row["derived_as_of"] == "2026-07-02T10:00:00+09:00"
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_batch_error_row_carries_cache_metadata(monkeypatch):
+    async def stub(sym, market, include_peers):
+        raise ValueError("boom")
+
+    monkeypatch.setattr(handlers.analysis_screening, "_analyze_stock_impl", stub)
+
+    result = await handlers._run_batch_analysis(
+        ["BADSYM"], market="kr", include_peers=False, formatter=_summary_formatter
+    )
+    row = result["results"]["BADSYM"]
     assert "error" in row
     assert row["cache_hit"] is False
     assert row["derived_as_of"] is None
-
-
-@pytest.mark.asyncio
-@pytest.mark.unit
-async def test_redis_set_called_with_market_specific_ttl(monkeypatch, patch_redis):
-    fake_redis = patch_redis()
-    _install_fake_pipeline(
-        monkeypatch, {"KRW-BTC": _make_analysis("KRW-BTC")}
-    )
-    formatter = _summary_formatter
-
-    await handlers._run_batch_analysis(
-        ["KRW-BTC"], market="crypto", include_peers=False, formatter=formatter
-    )
-    key = analyze_cache._cache_key(
-        "crypto", "KRW-BTC", analyze_cache._kst_date_for_key()
-    )
-    assert fake_redis.ttls[key] == 3600

--- a/tests/test_analyze_stock_batch_cache.py
+++ b/tests/test_analyze_stock_batch_cache.py
@@ -1,0 +1,456 @@
+"""Tests for the Redis ephemeral cache on analyze_stock_batch (ROB-638)."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from app.core import analyze_cache
+from app.mcp_server.tooling import analysis_tool_handlers as handlers
+
+
+class _FakeRedis:
+    """Minimal async in-memory Redis for string get/set with TTL tracking."""
+
+    def __init__(self) -> None:
+        self.store: dict[str, str] = {}
+        self.ttls: dict[str, int] = {}
+        self.get_call_count = 0
+        self.set_call_count = 0
+
+    async def get(self, key: str) -> str | None:
+        self.get_call_count += 1
+        return self.store.get(key)
+
+    async def set(
+        self,
+        key: str,
+        value: str,
+        ex: int | None = None,
+        nx: bool = False,
+    ) -> bool:
+        self.set_call_count += 1
+        if nx and key in self.store:
+            return False
+        self.store[key] = value
+        if ex is not None:
+            self.ttls[key] = ex
+        return True
+
+
+def _make_analysis(symbol: str, *, price: float = 100.0) -> dict[str, Any]:
+    return {
+        "symbol": symbol,
+        "market_type": "equity_kr",
+        "source": "kis",
+        "quote": {"price": price},
+        "indicators": {"rsi": {"14": 55.0}},
+        "support_resistance": {"supports": [90.0], "resistances": [110.0]},
+        "opinions": {"consensus": "hold"},
+        "recommendation": "HOLD",
+    }
+
+
+def _summary_formatter(sym, result, **kw):
+    return handlers._summarize_analysis_result(sym, result)
+
+
+@pytest.fixture(autouse=True)
+def _reset_analyze_cache_singleton(monkeypatch):
+    """Reset the module-level Redis client between tests."""
+    monkeypatch.setattr(analyze_cache, "_REDIS_CLIENT", None)
+    yield
+    monkeypatch.setattr(analyze_cache, "_REDIS_CLIENT", None)
+
+
+@pytest.fixture
+def patch_redis(monkeypatch):
+    """Force analyze_cache to use a fresh fake Redis client."""
+
+    def make():
+        fake = _FakeRedis()
+
+        async def _get_client():
+            return fake
+
+        monkeypatch.setattr(analyze_cache, "_get_redis_client", _get_client)
+        return fake
+
+    return make
+
+
+# ---------------------------------------------------------------------------
+# Pure TTL / key-format unit tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_cache_key_format():
+    assert (
+        analyze_cache._cache_key("kr", "005930", "2026-07-02")
+        == "analyze_batch:kr:005930:2026-07-02"
+    )
+
+
+@pytest.mark.unit
+def test_cache_key_uppercases_symbol():
+    assert (
+        analyze_cache._cache_key("us", "aapl", "2026-07-02")
+        == "analyze_batch:us:AAPL:2026-07-02"
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("market", "expected"),
+    [
+        ("crypto", 3600),
+        ("CRYPTO", 3600),
+    ],
+)
+def test_cache_ttl_crypto_flat_1h(market, expected):
+    from datetime import datetime
+    from zoneinfo import ZoneInfo
+
+    now = datetime(2026, 7, 2, 12, 0, tzinfo=ZoneInfo("UTC"))
+    assert analyze_cache._cache_ttl_seconds(market, now) == expected
+
+
+@pytest.mark.unit
+def test_cache_ttl_kr_before_session_close_targets_close():
+    from datetime import datetime
+    from zoneinfo import ZoneInfo
+
+    KST = ZoneInfo("Asia/Seoul")
+    now = datetime(2026, 7, 2, 10, 0, tzinfo=KST)
+    ttl = analyze_cache._cache_ttl_seconds("kr", now)
+    # 10:00 -> 15:35 = 5h35m = 20100s
+    assert ttl == 20100
+
+
+@pytest.mark.unit
+def test_cache_ttl_kr_just_before_close_is_near_zero():
+    from datetime import datetime
+    from zoneinfo import ZoneInfo
+
+    KST = ZoneInfo("Asia/Seoul")
+    now = datetime(2026, 7, 2, 15, 34, 59, tzinfo=KST)
+    ttl = analyze_cache._cache_ttl_seconds("kr", now)
+    assert ttl == 1
+
+
+@pytest.mark.unit
+def test_cache_ttl_kr_at_or_after_close_targets_midnight():
+    from datetime import datetime
+    from zoneinfo import ZoneInfo
+
+    KST = ZoneInfo("Asia/Seoul")
+    at_close = datetime(2026, 7, 2, 15, 35, 0, tzinfo=KST)
+    assert analyze_cache._cache_ttl_seconds("kr", at_close) == 30300  # -> 00:00
+    after_close = datetime(2026, 7, 2, 16, 0, tzinfo=KST)
+    assert analyze_cache._cache_ttl_seconds("kr", after_close) == 28800
+
+
+@pytest.mark.unit
+def test_cache_ttl_us_before_close_targets_close():
+    from datetime import datetime
+    from zoneinfo import ZoneInfo
+
+    ET = ZoneInfo("America/New_York")
+    now = datetime(2026, 7, 2, 15, 0, tzinfo=ET)
+    assert analyze_cache._cache_ttl_seconds("us", now) == 3600  # 15:00 -> 16:00
+
+
+@pytest.mark.unit
+def test_cache_ttl_us_after_close_targets_midnight_et():
+    from datetime import datetime
+    from zoneinfo import ZoneInfo
+
+    ET = ZoneInfo("America/New_York")
+    now = datetime(2026, 7, 2, 20, 0, tzinfo=ET)
+    assert analyze_cache._cache_ttl_seconds("us", now) == 14400  # 20:00 -> 00:00
+
+
+@pytest.mark.unit
+def test_cache_ttl_unknown_market_falls_back_to_15min():
+    from datetime import datetime
+    from zoneinfo import ZoneInfo
+
+    now = datetime(2026, 7, 2, 12, 0, tzinfo=ZoneInfo("UTC"))
+    assert analyze_cache._cache_ttl_seconds("unknown", now) == 900
+
+
+@pytest.mark.unit
+def test_resolve_market_for_symbol_detects_each_lane():
+    assert analyze_cache._resolve_market_for_symbol("005930", None) == "kr"
+    assert analyze_cache._resolve_market_for_symbol("AAPL", None) == "us"
+    assert analyze_cache._resolve_market_for_symbol("KRW-BTC", None) == "crypto"
+
+
+# ---------------------------------------------------------------------------
+# get/set helper tests (with fake redis)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_get_cached_returns_none_on_miss():
+    fake = _FakeRedis()
+    assert await analyze_cache.get_cached_analyze_result(fake, "kr", "005930", "2026-07-02") is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_get_cached_returns_none_when_redis_is_none():
+    assert await analyze_cache.get_cached_analyze_result(None, "kr", "005930", "2026-07-02") is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_set_then_get_roundtrip():
+    fake = _FakeRedis()
+    payload = {"symbol": "005930", "current_price": 70000}
+    await analyze_cache.set_cached_analyze_result(
+        fake, "kr", "005930", "2026-07-02", payload
+    )
+    cached = await analyze_cache.get_cached_analyze_result(
+        fake, "kr", "005930", "2026-07-02"
+    )
+    assert cached == payload
+    # TTL was set (KR during/after session -> positive)
+    key = analyze_cache._cache_key("kr", "005930", "2026-07-02")
+    assert fake.ttls[key] > 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_set_is_noop_when_redis_is_none():
+    await analyze_cache.set_cached_analyze_result(
+        None, "kr", "005930", "2026-07-02", {"x": 1}
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_get_returns_none_on_malformed_payload():
+    fake = _FakeRedis()
+    key = analyze_cache._cache_key("kr", "005930", "2026-07-02")
+    fake.store[key] = "not-json"
+    assert await analyze_cache.get_cached_analyze_result(fake, "kr", "005930", "2026-07-02") is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_get_returns_none_on_non_dict_payload():
+    fake = _FakeRedis()
+    key = analyze_cache._cache_key("kr", "005930", "2026-07-02")
+    fake.store[key] = json.dumps([1, 2, 3])
+    assert await analyze_cache.get_cached_analyze_result(fake, "kr", "005930", "2026-07-02") is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_get_swallows_redis_errors():
+    class _ExplodingRedis:
+        async def get(self, key):
+            raise RuntimeError("redis down")
+
+    assert (
+        await analyze_cache.get_cached_analyze_result(
+            _ExplodingRedis(), "kr", "005930", "2026-07-02"
+        )
+        is None
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_set_swallows_redis_errors():
+    class _ExplodingRedis:
+        async def set(self, *args, **kwargs):
+            raise RuntimeError("redis down")
+
+    await analyze_cache.set_cached_analyze_result(
+        _ExplodingRedis(), "kr", "005930", "2026-07-02", {"x": 1}
+    )
+
+
+# ---------------------------------------------------------------------------
+# Integration: _run_batch_analysis with cache (patched pipeline + redis)
+# ---------------------------------------------------------------------------
+
+
+def _install_fake_pipeline(monkeypatch, results_by_symbol: dict[str, dict[str, Any]]):
+    """Replace analysis_screening._analyze_stock_impl with a deterministic stub."""
+    call_log: list[str] = []
+
+    def _stub(sym, market, include_peers):
+        call_log.append(sym)
+        if sym not in results_by_symbol:
+            raise ValueError(f"no stub for {sym}")
+        return results_by_symbol[sym]
+
+    monkeypatch.setattr(
+        handlers.analysis_screening, "_analyze_stock_impl", _stub
+    )
+    return call_log
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_second_call_hits_cache_and_skips_pipeline(monkeypatch, patch_redis):
+    patch_redis()
+    call_log = _install_fake_pipeline(
+        monkeypatch, {"005930": _make_analysis("005930", price=70000)}
+    )
+
+    formatter = _summary_formatter
+
+    first = await handlers._run_batch_analysis(
+        ["005930"], market="kr", include_peers=False, formatter=formatter
+    )
+    assert call_log == ["005930"]
+    first_row = first["results"]["005930"]
+    assert first_row["cache_hit"] is False
+    assert first_row["derived_as_of"] is not None
+    assert first_row["current_price"] == 70000
+
+    second = await handlers._run_batch_analysis(
+        ["005930"], market="kr", include_peers=False, formatter=formatter
+    )
+    assert call_log == ["005930"], "pipeline must not re-run on cache hit"
+    second_row = second["results"]["005930"]
+    assert second_row["cache_hit"] is True
+    assert second_row["derived_as_of"] == first_row["derived_as_of"]
+    assert second_row["current_price"] == 70000
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_different_symbol_misses_cache_and_runs_pipeline(monkeypatch, patch_redis):
+    patch_redis()
+    call_log = _install_fake_pipeline(
+        monkeypatch,
+        {
+            "005930": _make_analysis("005930", price=70000),
+            "000660": _make_analysis("000660", price=120000),
+        },
+    )
+    formatter = _summary_formatter
+
+    await handlers._run_batch_analysis(
+        ["005930"], market="kr", include_peers=False, formatter=formatter
+    )
+    await handlers._run_batch_analysis(
+        ["000660"], market="kr", include_peers=False, formatter=formatter
+    )
+    assert call_log == ["005930", "000660"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_cache_keyed_by_symbol_within_same_batch(monkeypatch, patch_redis):
+    """Two symbols in one batch each run the pipeline exactly once."""
+    patch_redis()
+    call_log = _install_fake_pipeline(
+        monkeypatch,
+        {
+            "005930": _make_analysis("005930"),
+            "000660": _make_analysis("000660", price=120000),
+        },
+    )
+    formatter = _summary_formatter
+
+    result = await handlers._run_batch_analysis(
+        ["005930", "000660"], market="kr", include_peers=False, formatter=formatter
+    )
+    assert sorted(call_log) == ["000660", "005930"]
+    for sym in ("005930", "000660"):
+        assert result["results"][sym]["cache_hit"] is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_expired_entry_reruns_pipeline(monkeypatch, patch_redis):
+    """Simulate TTL expiry by clearing the fake redis between calls."""
+    fake_redis = patch_redis()
+    call_log = _install_fake_pipeline(
+        monkeypatch, {"005930": _make_analysis("005930")}
+    )
+    formatter = _summary_formatter
+
+    await handlers._run_batch_analysis(
+        ["005930"], market="kr", include_peers=False, formatter=formatter
+    )
+    assert call_log == ["005930"]
+
+    fake_redis.store.clear()  # simulate expiry
+
+    res = await handlers._run_batch_analysis(
+        ["005930"], market="kr", include_peers=False, formatter=formatter
+    )
+    assert call_log == ["005930", "005930"]
+    assert res["results"]["005930"]["cache_hit"] is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_redis_unavailable_falls_through_to_pipeline(monkeypatch):
+    """When _get_redis_client returns None, the pipeline must still run."""
+    monkeypatch.setattr(
+        analyze_cache, "_REDIS_CLIENT", None
+    )
+
+    async def _none():
+        return None
+
+    monkeypatch.setattr(analyze_cache, "_get_redis_client", _none)
+    call_log = _install_fake_pipeline(
+        monkeypatch, {"005930": _make_analysis("005930")}
+    )
+    formatter = _summary_formatter
+
+    res = await handlers._run_batch_analysis(
+        ["005930"], market="kr", include_peers=False, formatter=formatter
+    )
+    assert call_log == ["005930"]
+    row = res["results"]["005930"]
+    assert row["cache_hit"] is False
+    assert row["derived_as_of"] is not None
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_error_row_carries_cache_metadata(monkeypatch, patch_redis):
+    patch_redis()
+    _install_fake_pipeline(monkeypatch, {})
+
+    formatter = _summary_formatter
+
+    res = await handlers._run_batch_analysis(
+        ["BADSYM"], market="kr", include_peers=False, formatter=formatter
+    )
+    row = res["results"]["BADSYM"]
+    assert "error" in row
+    assert row["cache_hit"] is False
+    assert row["derived_as_of"] is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_redis_set_called_with_market_specific_ttl(monkeypatch, patch_redis):
+    fake_redis = patch_redis()
+    _install_fake_pipeline(
+        monkeypatch, {"KRW-BTC": _make_analysis("KRW-BTC")}
+    )
+    formatter = _summary_formatter
+
+    await handlers._run_batch_analysis(
+        ["KRW-BTC"], market="crypto", include_peers=False, formatter=formatter
+    )
+    key = analyze_cache._cache_key(
+        "crypto", "KRW-BTC", analyze_cache._kst_date_for_key()
+    )
+    assert fake_redis.ttls[key] == 3600

--- a/tests/test_mcp_fundamentals_tools.py
+++ b/tests/test_mcp_fundamentals_tools.py
@@ -832,6 +832,11 @@ class TestAnalyzeStockBatch:
             "resistances": [{"price": 77000, "strength": "medium"}],
             # ROB-541: include_position defaults True; not held -> null.
             "position": None,
+            # ROB-638 additive fetch-cache contract keys. The mocked
+            # _analyze_stock_impl bypasses the real pipeline, so no fetch-layer
+            # cache is consulted: cache_hit False, derived_as_of None.
+            "cache_hit": False,
+            "derived_as_of": None,
         }
         # Single batched holdings fetch only — never per symbol.
         assert empty_collect.await_count == 1


### PR DESCRIPTION
## 개요

`analyze_stock_batch` intraday 재호출 시 Redis 캐시 히트로 전체 파이프라인 스킵. 응답에 `cache_hit` 플래그 + `derived_as_of` 라벨 추가.

## 변경 사항

- `app/core/analyze_cache.py`: Redis 캐시 헬퍼 (fail-open, KR 15:35 / US NYSE close / Crypto 1h TTL)
- `analysis_tool_handlers._run_batch_analysis` 진입점에 캐시 체크 + 저장 통합
- 원본 분석 결과 캐시, 포매팅(per-batch position)은 매번 fresh 실행
- 26 테스트 통과

## 동기화 노트

- 마이그레이션 없음 (Redis만 사용)
- 637, 639, 640, 641과 파일 겹침 없음 (analysis_tool_handlers.py만 수정)

## 모델 레인

`keep_on_gpt54`