### PR TITLE
feat(ROB-639): get_ohlcv(period=day) DB-first read-through

### DIFF
--- a/app/mcp_server/tooling/market_data_indicators.py
+++ b/app/mcp_server/tooling/market_data_indicators.py
@@ -5,11 +5,8 @@ from __future__ import annotations
 import asyncio
 import datetime
 import logging
-from datetime import UTC, timedelta
-from functools import lru_cache
 from typing import Any, Literal
 
-import exchange_calendars as xcals
 import numpy as np
 import pandas as pd
 
@@ -130,72 +127,18 @@ async def _fetch_ohlcv_for_volume_profile(
 # Daily candle store helpers (cache-first read path)
 # ---------------------------------------------------------------------------
 
-_OHLCV_COLUMNS = ["date", "open", "high", "low", "close", "volume", "value"]
-
-
-@lru_cache(maxsize=4)
-def _get_calendar(exchange: str):
-    return xcals.get_calendar(exchange)
-
-
-def _latest_exchange_session(exchange: str) -> datetime.date | None:
-    """Return the most-recent past session date for the given exchange.
-
-    `exchange` accepts any calendar name supported by exchange_calendars
-    (e.g., 'XKRX', 'XNYS').
-    """
-    cal = _get_calendar(exchange)
-    now = datetime.datetime.now(datetime.UTC)
-    try:
-        session = cal.minute_to_past_session(pd.Timestamp(now), count=1)
-    except Exception:
-        return None
-    return pd.Timestamp(session).date()
-
-
-def _cache_is_fresh_equity(rows: list, exchange: str) -> bool:
-    """Cache is fresh if the newest row covers the latest closed exchange session."""
-    if not rows:
-        return False
-    latest_session = _latest_exchange_session(exchange)
-    if latest_session is None:
-        return False
-    latest_row = max(r.time_utc for r in rows)
-    return pd.Timestamp(latest_row).date() >= latest_session
-
-
-def _cache_is_fresh_crypto(rows: list) -> bool:
-    """Return True if the newest row's timestamp is within the last 24 hours."""
-    if not rows:
-        return False
-    newest = max(r.time_utc for r in rows)
-    if newest.tzinfo is None:
-        newest = newest.replace(tzinfo=UTC)
-    return datetime.datetime.now(UTC) - newest < timedelta(hours=24)
-
-
-def _rows_to_frame(rows: list) -> pd.DataFrame:
-    """Convert a list of DailyCandleRow to a DataFrame with standard OHLCV columns."""
-    if not rows:
-        return pd.DataFrame(columns=_OHLCV_COLUMNS)
-    records = []
-    for row in rows:
-        ts = row.time_utc
-        if ts.tzinfo is None:
-            ts = ts.replace(tzinfo=UTC)
-        records.append(
-            {
-                "date": ts.date(),
-                "open": row.open,
-                "high": row.high,
-                "low": row.low,
-                "close": row.close,
-                "volume": row.volume,
-                "value": row.value,
-            }
-        )
-    df = pd.DataFrame(records, columns=_OHLCV_COLUMNS)
-    return df.sort_values("date").reset_index(drop=True)
+# Re-exported under underscore aliases to preserve existing call sites. The
+# canonical implementations live in read_service so get_ohlcv and indicators
+# share one freshness rule. ROB-639.
+from app.services.daily_candles.read_service import (  # noqa: E402
+    cache_is_fresh_crypto as _cache_is_fresh_crypto,
+)
+from app.services.daily_candles.read_service import (  # noqa: E402
+    cache_is_fresh_equity as _cache_is_fresh_equity,
+)
+from app.services.daily_candles.read_service import (  # noqa: E402
+    rows_to_frame as _rows_to_frame,
+)
 
 
 async def _cache_first_kr(*, symbol: str, count: int) -> pd.DataFrame:

--- a/app/services/daily_candles/read_service.py
+++ b/app/services/daily_candles/read_service.py
@@ -11,11 +11,20 @@ Design:
 * ``cache_first_kr`` / ``cache_first_us`` perform the READ-ONLY DB-first
   lookup and return ``None`` on miss/stale data so the caller can run its
   own fallback (KIS, Yahoo, Toss...) and optional write-back.
+* Fail-open: ``cache_first_*`` return ``None`` (never raise) on ANY DB/
+  calendar failure — DB trouble must degrade to the live path, not hard-fail
+  ``get_ohlcv``. ``write_back_*`` are likewise best-effort and return 0.
 
 Freshness rule for equity caches (KR/US): the newest DB row must cover the
 most-recent closed exchange session (``XKRX`` for KR, ``XNYS`` for US).
-The calendar lookup uses ``exchange_calendars``; the KRX 15:35 KST close is
-captured implicitly because ``XKRX`` sessions end at 15:30 KST (06:30 UTC).
+
+KR intraday rule (ROB-639 review): while the KRX daily bar for *today* may
+still be forming (session day, before the 15:35 KST cutoff shared with
+``kis_ohlcv_cache.KRX_DAILY_CACHE_CUTOFF``), ``cache_first_kr`` returns
+``None`` so the live KIS path serves — the old live path included today's
+forming bar and DB-first must not silently drop it. After the cutoff and on
+non-session days the DB-first path proceeds. The US path needs no such gate:
+the Yahoo daily path is already closed-bucket only.
 """
 
 from __future__ import annotations
@@ -27,7 +36,9 @@ from functools import lru_cache
 import exchange_calendars as xcals
 import pandas as pd
 
+from app.core.timezone import KST, now_kst
 from app.services.daily_candles.repository import DailyCandleRow
+from app.services.kis_ohlcv_cache import KRX_DAILY_CACHE_CUTOFF
 
 logger = logging.getLogger(__name__)
 
@@ -43,31 +54,145 @@ def get_calendar(exchange: str):
     return xcals.get_calendar(exchange)
 
 
-def latest_exchange_session(exchange: str) -> datetime.date | None:
-    """Return the most-recent past session date for the given exchange.
+def _coerce_kst(now: datetime.datetime | None) -> datetime.datetime:
+    """Coerce an optional (possibly naive) datetime to a KST-aware datetime."""
+    current = now or now_kst()
+    if current.tzinfo is None:
+        return current.replace(tzinfo=KST)
+    return current.astimezone(KST)
+
+
+def _coerce_utc_timestamp(now: datetime.datetime | None) -> pd.Timestamp:
+    """Coerce an optional (possibly naive) datetime to a UTC pd.Timestamp."""
+    ts = (
+        pd.Timestamp(now)
+        if now is not None
+        else pd.Timestamp(datetime.datetime.now(datetime.UTC))
+    )
+    if ts.tzinfo is None:
+        return ts.tz_localize(datetime.UTC)
+    return ts.tz_convert(datetime.UTC)
+
+
+def latest_exchange_session(
+    exchange: str, now: datetime.datetime | None = None
+) -> datetime.date | None:
+    """Return the most-recent *closed* session date for the given exchange.
 
     ``exchange`` accepts any calendar name supported by exchange_calendars
-    (e.g., ``'XKRX'`` for KRX, ``'XNYS'`` for NYSE). Returns ``None`` if the
-    library raises (rare, but defensive for early/late session edges).
+    (e.g., ``'XKRX'`` for KRX, ``'XNYS'`` for NYSE). ``now`` is injectable for
+    tests; defaults to the real clock. Returns ``None`` if the library raises
+    (rare, but defensive for early/late session edges).
+
+    ``minute_to_past_session`` excludes an in-progress session, so during
+    trading hours this returns the *previous* session.
     """
     cal = get_calendar(exchange)
-    now = datetime.datetime.now(datetime.UTC)
     try:
-        session = cal.minute_to_past_session(pd.Timestamp(now), count=1)
+        session = cal.minute_to_past_session(_coerce_utc_timestamp(now), count=1)
     except Exception:
         return None
     return pd.Timestamp(session).date()
 
 
-def cache_is_fresh_equity(rows: list[DailyCandleRow], exchange: str) -> bool:
+def kr_daily_bar_may_be_forming(now: datetime.datetime | None = None) -> bool:
+    """True while today's KRX daily bar may still be forming.
+
+    That is: today (KST) is an XKRX session day AND the current KST time is
+    before the shared ``KRX_DAILY_CACHE_CUTOFF`` (15:35 — session close plus
+    settling buffer, same semantics as ``kis_ohlcv_cache``).
+    """
+    current = _coerce_kst(now)
+    try:
+        cal = get_calendar("XKRX")
+        if not bool(cal.is_session(pd.Timestamp(current.date()))):
+            return False
+    except Exception:
+        # Calendar failure: don't block the DB path here — the freshness
+        # check downstream is the authority and also fails closed to live.
+        return False
+    return current.time() < KRX_DAILY_CACHE_CUTOFF
+
+
+def last_final_session_kr(now: datetime.datetime | None = None) -> datetime.date | None:
+    """Most recent XKRX session whose daily bar is final (15:35 KST cutoff).
+
+    Today counts only after ``KRX_DAILY_CACHE_CUTOFF``; otherwise the latest
+    session strictly before today. Returns ``None`` on calendar failure.
+    """
+    current = _coerce_kst(now)
+    today = current.date()
+    try:
+        cal = get_calendar("XKRX")
+        ts_today = pd.Timestamp(today)
+        if bool(cal.is_session(ts_today)) and current.time() >= KRX_DAILY_CACHE_CUTOFF:
+            return today
+        prev = cal.date_to_session(
+            ts_today - pd.Timedelta(days=1), direction="previous"
+        )
+        return pd.Timestamp(prev).date()
+    except Exception:
+        return None
+
+
+def last_final_session_us(now: datetime.datetime | None = None) -> datetime.date | None:
+    """Most recent *closed* XNYS session (the US daily bar is final at close)."""
+    return latest_exchange_session("XNYS", now=now)
+
+
+def drop_forming_daily_rows(
+    frame: pd.DataFrame, *, market: str, now: datetime.datetime | None = None
+) -> pd.DataFrame:
+    """Drop rows whose session is not yet closed (forming intraday bars).
+
+    Used by the write-back paths so a partial intraday bar fetched live is
+    never persisted into ``kr/us_candles_1d`` as an authoritative daily row.
+    ``market`` is ``'kr'`` or ``'us'``. If the last final session cannot be
+    determined, the frame is returned unchanged (best-effort write-back).
+    """
+    if frame is None or frame.empty:
+        return frame
+    last_final = (
+        last_final_session_kr(now) if market == "kr" else last_final_session_us(now)
+    )
+    if last_final is None:
+        return frame
+    if "date" in frame.columns:
+        dates = pd.to_datetime(frame["date"], errors="coerce").dt.date
+    elif "datetime" in frame.columns:
+        dates = pd.to_datetime(frame["datetime"], errors="coerce").dt.date
+    else:
+        return frame
+    mask = pd.Series(
+        [d is not pd.NaT and d is not None and d <= last_final for d in dates],
+        index=frame.index,
+    )
+    if mask.all():
+        return frame
+    dropped = int((~mask).sum())
+    logger.debug(
+        "drop_forming_daily_rows market=%s dropped=%d last_final=%s",
+        market,
+        dropped,
+        last_final,
+    )
+    return frame.loc[mask]
+
+
+def cache_is_fresh_equity(
+    rows: list[DailyCandleRow],
+    exchange: str,
+    now: datetime.datetime | None = None,
+) -> bool:
     """Cache is fresh if the newest row covers the latest closed exchange session.
 
     For KR this encodes the 15:30 KST (06:30 UTC) session close of ``XKRX`` —
     a row timestamped after the latest session's close satisfies the rule.
+    ``now`` is injectable for tests; defaults to the real clock.
     """
     if not rows:
         return False
-    latest_session = latest_exchange_session(exchange)
+    latest_session = latest_exchange_session(exchange, now=now)
     if latest_session is None:
         return False
     latest_row = max(r.time_utc for r in rows)
@@ -116,8 +241,10 @@ async def cache_first_kr(
     symbol: str,
     count: int,
     end: datetime.datetime | None = None,
+    *,
+    now: datetime.datetime | None = None,
 ) -> pd.DataFrame | None:
-    """DB-first read for KR daily candles. Returns ``None`` on miss/stale.
+    """DB-first read for KR daily candles. Returns ``None`` on miss/stale/error.
 
     Reads the latest ``count`` rows from ``kr_candles_1d`` (venue ``KRX``)
     via ``DailyCandlesRepository.fetch_recent``. If the DB has at least
@@ -125,39 +252,65 @@ async def cache_first_kr(
     session, returns a sorted OHLCV DataFrame. Otherwise returns ``None``
     so the caller can fall back to a live API (KIS).
 
+    While today's KRX daily bar may still be forming (session day, before
+    the 15:35 KST cutoff) this always returns ``None`` — the live KIS path
+    includes today's forming bar, which the DB does not carry.
+
+    Fail-open: any DB/calendar exception is logged and swallowed, returning
+    ``None`` so the caller's live path serves.
+
     ``end`` is currently a forward-compatibility placeholder: when non-None
     (historical query), the cache is bypassed and ``None`` is returned, so
     the caller's live path can apply the historical end-date filter.
+    ``now`` is injectable for tests; defaults to the real clock.
     """
     if end is not None:
         # Historical queries cannot be served by the latest-N cache.
         return None
 
-    from app.core.db import AsyncSessionLocal
-    from app.services.daily_candles.repository import DailyCandlesRepository, MarketKey
+    try:
+        if kr_daily_bar_may_be_forming(now):
+            # ROB-639: intraday KRX — serve live so today's forming bar is
+            # included (parity with the pre-DB-first live path).
+            return None
 
-    partition = "KRX"
-    async with AsyncSessionLocal() as session:
-        repo = DailyCandlesRepository(session=session)
-        cached = await repo.fetch_recent(
-            market=MarketKey.KR, symbol=symbol, partition=partition, count=count
+        from app.core.db import AsyncSessionLocal
+        from app.services.daily_candles.repository import (
+            DailyCandlesRepository,
+            MarketKey,
         )
-        if len(cached) >= count and cache_is_fresh_equity(cached, "XKRX"):
-            logger.debug(
-                "daily_candles cache hit market=kr symbol=%s rows=%d",
-                symbol,
-                len(cached),
+
+        partition = "KRX"
+        async with AsyncSessionLocal() as session:
+            repo = DailyCandlesRepository(session=session)
+            cached = await repo.fetch_recent(
+                market=MarketKey.KR, symbol=symbol, partition=partition, count=count
             )
-            return rows_to_frame(cached)
-    return None
+            if len(cached) >= count and cache_is_fresh_equity(cached, "XKRX", now=now):
+                logger.debug(
+                    "daily_candles cache hit market=kr symbol=%s rows=%d",
+                    symbol,
+                    len(cached),
+                )
+                return rows_to_frame(cached)
+        return None
+    except Exception:
+        logger.warning(
+            "cache_first_kr failed symbol=%s; falling back to live path",
+            symbol,
+            exc_info=True,
+        )
+        return None
 
 
 async def cache_first_us(
     symbol: str,
     count: int,
     end: datetime.datetime | None = None,
+    *,
+    now: datetime.datetime | None = None,
 ) -> pd.DataFrame | None:
-    """DB-first read for US daily candles. Returns ``None`` on miss/stale.
+    """DB-first read for US daily candles. Returns ``None`` on miss/stale/error.
 
     Resolves the symbol's exchange (``NASDAQ`` / ``NYSE`` / ``AMEX``) via
     ``get_us_exchange_by_symbol`` and reads the latest ``count`` rows from
@@ -165,42 +318,70 @@ async def cache_first_us(
     all US sessions including AMEX). Returns ``None`` when the DB is
     insufficient or stale so the caller can fall back to a live API
     (Yahoo → Toss).
+
+    Fail-open: any DB/calendar exception is logged and swallowed, returning
+    ``None`` so the caller's live path serves. ``now`` is injectable for
+    tests; defaults to the real clock.
     """
     if end is not None:
         return None
 
-    from app.core.db import AsyncSessionLocal
-    from app.services.daily_candles.repository import DailyCandlesRepository, MarketKey
-    from app.services.us_symbol_universe_service import get_us_exchange_by_symbol
-
-    async with AsyncSessionLocal() as session:
-        try:
-            partition = await get_us_exchange_by_symbol(symbol, db=session)
-        except Exception:
-            logger.warning(
-                "Could not resolve US exchange for symbol=%s; defaulting to NASD",
-                symbol,
-            )
-            partition = "NASD"
-
-        repo = DailyCandlesRepository(session=session)
-        cached = await repo.fetch_recent(
-            market=MarketKey.US, symbol=symbol, partition=partition, count=count
+    try:
+        from app.core.db import AsyncSessionLocal
+        from app.services.daily_candles.repository import (
+            DailyCandlesRepository,
+            MarketKey,
         )
-        if len(cached) >= count and cache_is_fresh_equity(cached, "XNYS"):
-            logger.debug(
-                "daily_candles cache hit market=us symbol=%s rows=%d",
-                symbol,
-                len(cached),
+        from app.services.us_symbol_universe_service import get_us_exchange_by_symbol
+
+        async with AsyncSessionLocal() as session:
+            try:
+                partition = await get_us_exchange_by_symbol(symbol, db=session)
+            except Exception:
+                logger.warning(
+                    "Could not resolve US exchange for symbol=%s; defaulting to NASD",
+                    symbol,
+                )
+                # The failed lookup may have aborted the transaction; roll it
+                # back before reusing this session, otherwise the next query
+                # raises InFailedSQLTransactionError (poisoned session).
+                await session.rollback()
+                partition = "NASD"
+
+            repo = DailyCandlesRepository(session=session)
+            cached = await repo.fetch_recent(
+                market=MarketKey.US, symbol=symbol, partition=partition, count=count
             )
-            return rows_to_frame(cached)
-    return None
+            if len(cached) >= count and cache_is_fresh_equity(cached, "XNYS", now=now):
+                logger.debug(
+                    "daily_candles cache hit market=us symbol=%s rows=%d",
+                    symbol,
+                    len(cached),
+                )
+                return rows_to_frame(cached)
+        return None
+    except Exception:
+        logger.warning(
+            "cache_first_us failed symbol=%s; falling back to live path",
+            symbol,
+            exc_info=True,
+        )
+        return None
 
 
 async def write_back_kr(
-    frame: pd.DataFrame, *, symbol: str, partition: str = "KRX", source: str = "kis"
+    frame: pd.DataFrame,
+    *,
+    symbol: str,
+    partition: str = "KRX",
+    source: str = "kis",
+    now: datetime.datetime | None = None,
 ) -> int:
     """Write a freshly fetched KR daily frame back into ``kr_candles_1d``.
+
+    Rows whose session is not yet final (today's forming intraday bar) are
+    dropped before the upsert so a partial bar is never persisted as an
+    authoritative daily row.
 
     Best-effort: any error is swallowed and logged so that write-back
     failures never propagate to the caller's read path. Returns the number
@@ -208,14 +389,20 @@ async def write_back_kr(
     """
     if frame is None or frame.empty:
         return 0
-    from app.core.db import AsyncSessionLocal
-    from app.services.daily_candles.converters import frame_to_rows
-    from app.services.daily_candles.repository import DailyCandlesRepository, MarketKey
-
-    repo_rows = frame_to_rows(frame, symbol=symbol, partition=partition, source=source)
-    if not repo_rows:
-        return 0
     try:
+        from app.core.db import AsyncSessionLocal
+        from app.services.daily_candles.converters import frame_to_rows
+        from app.services.daily_candles.repository import (
+            DailyCandlesRepository,
+            MarketKey,
+        )
+
+        frame = drop_forming_daily_rows(frame, market="kr", now=now)
+        repo_rows = frame_to_rows(
+            frame, symbol=symbol, partition=partition, source=source
+        )
+        if not repo_rows:
+            return 0
         async with AsyncSessionLocal() as session:
             repo = DailyCandlesRepository(session=session)
             upserted = await repo.upsert_rows(market=MarketKey.KR, rows=repo_rows)
@@ -223,10 +410,7 @@ async def write_back_kr(
             return upserted
     except Exception:
         logger.exception(
-            "write_back_kr failed symbol=%s partition=%s rows=%d",
-            symbol,
-            partition,
-            len(repo_rows),
+            "write_back_kr failed symbol=%s partition=%s", symbol, partition
         )
         return 0
 
@@ -237,6 +421,7 @@ async def write_back_us(
     symbol: str,
     partition: str | None = None,
     source: str = "yahoo",
+    now: datetime.datetime | None = None,
 ) -> int:
     """Write a freshly fetched US daily frame back into ``us_candles_1d``.
 
@@ -246,41 +431,62 @@ async def write_back_us(
 
     If ``partition`` is ``None`` the exchange is resolved via
     ``get_us_exchange_by_symbol`` (defaulting to ``'NASD'`` on failure).
+
+    Rows whose session is not yet closed (a forming intraday bar) are
+    dropped before the upsert. When the frame lacks an ``adj_close`` column
+    the upsert leaves existing ``adj_close`` values untouched (so a plain
+    Yahoo/Toss frame does not null out ``yahoo_fallback`` adjusted closes).
+
+    Best-effort: any error is swallowed and logged; returns 0 on failure.
     """
     if frame is None or frame.empty:
         return 0
-    from app.core.db import AsyncSessionLocal
-    from app.services.daily_candles.converters import frame_to_rows
-    from app.services.daily_candles.repository import DailyCandlesRepository, MarketKey
-    from app.services.us_symbol_universe_service import get_us_exchange_by_symbol
-
-    if partition is None:
-        async with AsyncSessionLocal() as session:
-            try:
-                partition = await get_us_exchange_by_symbol(symbol, db=session)
-            except Exception:
-                logger.warning(
-                    "write_back_us: could not resolve exchange for symbol=%s; "
-                    "defaulting to NASD",
-                    symbol,
-                )
-                partition = "NASD"
-
-    repo_rows = frame_to_rows(frame, symbol=symbol, partition=partition, source=source)
-    if not repo_rows:
-        return 0
     try:
+        from app.core.db import AsyncSessionLocal
+        from app.services.daily_candles.converters import frame_to_rows
+        from app.services.daily_candles.repository import (
+            DailyCandlesRepository,
+            MarketKey,
+        )
+
+        frame = drop_forming_daily_rows(frame, market="us", now=now)
+        if frame.empty:
+            return 0
+
+        if partition is None:
+            from app.services.us_symbol_universe_service import (
+                get_us_exchange_by_symbol,
+            )
+
+            async with AsyncSessionLocal() as session:
+                try:
+                    partition = await get_us_exchange_by_symbol(symbol, db=session)
+                except Exception:
+                    logger.warning(
+                        "write_back_us: could not resolve exchange for symbol=%s; "
+                        "defaulting to NASD",
+                        symbol,
+                    )
+                    partition = "NASD"
+
+        repo_rows = frame_to_rows(
+            frame, symbol=symbol, partition=partition, source=source
+        )
+        if not repo_rows:
+            return 0
+        update_adj_close = "adj_close" in frame.columns
         async with AsyncSessionLocal() as session:
             repo = DailyCandlesRepository(session=session)
-            upserted = await repo.upsert_rows(market=MarketKey.US, rows=repo_rows)
+            upserted = await repo.upsert_rows(
+                market=MarketKey.US,
+                rows=repo_rows,
+                update_adj_close=update_adj_close,
+            )
             await session.commit()
             return upserted
     except Exception:
         logger.exception(
-            "write_back_us failed symbol=%s partition=%s rows=%d",
-            symbol,
-            partition,
-            len(repo_rows),
+            "write_back_us failed symbol=%s partition=%s", symbol, partition
         )
         return 0
 
@@ -291,7 +497,11 @@ __all__ = [
     "cache_first_us",
     "cache_is_fresh_crypto",
     "cache_is_fresh_equity",
+    "drop_forming_daily_rows",
     "get_calendar",
+    "kr_daily_bar_may_be_forming",
+    "last_final_session_kr",
+    "last_final_session_us",
     "latest_exchange_session",
     "rows_to_frame",
     "write_back_kr",

--- a/app/services/daily_candles/read_service.py
+++ b/app/services/daily_candles/read_service.py
@@ -1,0 +1,299 @@
+"""DB-first read-through service for daily OHLCV (ROB-639).
+
+Extracted from ``market_data_indicators._cache_first_*`` so that
+``get_ohlcv(period='day')`` can read KR/US daily candles from the DB before
+falling back to live upstream APIs.
+
+Design:
+
+* Public helpers (``cache_is_fresh_equity``, ``rows_to_frame``...) are shared
+  with ``market_data_indicators`` to avoid drift in freshness semantics.
+* ``cache_first_kr`` / ``cache_first_us`` perform the READ-ONLY DB-first
+  lookup and return ``None`` on miss/stale data so the caller can run its
+  own fallback (KIS, Yahoo, Toss...) and optional write-back.
+
+Freshness rule for equity caches (KR/US): the newest DB row must cover the
+most-recent closed exchange session (``XKRX`` for KR, ``XNYS`` for US).
+The calendar lookup uses ``exchange_calendars``; the KRX 15:35 KST close is
+captured implicitly because ``XKRX`` sessions end at 15:30 KST (06:30 UTC).
+"""
+
+from __future__ import annotations
+
+import datetime
+import logging
+from functools import lru_cache
+
+import exchange_calendars as xcals
+import pandas as pd
+
+from app.services.daily_candles.repository import DailyCandleRow
+
+logger = logging.getLogger(__name__)
+
+# Canonical OHLCV column ordering produced by ``rows_to_frame``. Kept here so
+# consumers (``market_data_indicators`` and ``get_ohlcv``) share one source of
+# truth for the frame shape.
+OHLCV_COLUMNS = ["date", "open", "high", "low", "close", "volume", "value"]
+
+
+@lru_cache(maxsize=4)
+def get_calendar(exchange: str):
+    """Return (and cache) an ``exchange_calendars`` calendar by name."""
+    return xcals.get_calendar(exchange)
+
+
+def latest_exchange_session(exchange: str) -> datetime.date | None:
+    """Return the most-recent past session date for the given exchange.
+
+    ``exchange`` accepts any calendar name supported by exchange_calendars
+    (e.g., ``'XKRX'`` for KRX, ``'XNYS'`` for NYSE). Returns ``None`` if the
+    library raises (rare, but defensive for early/late session edges).
+    """
+    cal = get_calendar(exchange)
+    now = datetime.datetime.now(datetime.UTC)
+    try:
+        session = cal.minute_to_past_session(pd.Timestamp(now), count=1)
+    except Exception:
+        return None
+    return pd.Timestamp(session).date()
+
+
+def cache_is_fresh_equity(rows: list[DailyCandleRow], exchange: str) -> bool:
+    """Cache is fresh if the newest row covers the latest closed exchange session.
+
+    For KR this encodes the 15:30 KST (06:30 UTC) session close of ``XKRX`` —
+    a row timestamped after the latest session's close satisfies the rule.
+    """
+    if not rows:
+        return False
+    latest_session = latest_exchange_session(exchange)
+    if latest_session is None:
+        return False
+    latest_row = max(r.time_utc for r in rows)
+    return pd.Timestamp(latest_row).date() >= latest_session
+
+
+def cache_is_fresh_crypto(rows: list[DailyCandleRow]) -> bool:
+    """Return True if the newest row's timestamp is within the last 24 hours."""
+    if not rows:
+        return False
+    newest = max(r.time_utc for r in rows)
+    if newest.tzinfo is None:
+        newest = newest.replace(tzinfo=datetime.UTC)
+    return datetime.datetime.now(datetime.UTC) - newest < datetime.timedelta(hours=24)
+
+
+def rows_to_frame(rows: list[DailyCandleRow]) -> pd.DataFrame:
+    """Convert a list of ``DailyCandleRow`` to a canonical OHLCV DataFrame.
+
+    Returns an empty DataFrame (with the standard column set) when ``rows``
+    is empty. Output is sorted ascending by date and reset-indexed.
+    """
+    if not rows:
+        return pd.DataFrame(columns=OHLCV_COLUMNS)
+    records = []
+    for row in rows:
+        ts = row.time_utc
+        if ts.tzinfo is None:
+            ts = ts.replace(tzinfo=datetime.UTC)
+        records.append(
+            {
+                "date": ts.date(),
+                "open": row.open,
+                "high": row.high,
+                "low": row.low,
+                "close": row.close,
+                "volume": row.volume,
+                "value": row.value,
+            }
+        )
+    df = pd.DataFrame(records, columns=OHLCV_COLUMNS)
+    return df.sort_values("date").reset_index(drop=True)
+
+
+async def cache_first_kr(
+    symbol: str,
+    count: int,
+    end: datetime.datetime | None = None,
+) -> pd.DataFrame | None:
+    """DB-first read for KR daily candles. Returns ``None`` on miss/stale.
+
+    Reads the latest ``count`` rows from ``kr_candles_1d`` (venue ``KRX``)
+    via ``DailyCandlesRepository.fetch_recent``. If the DB has at least
+    ``count`` rows AND the newest row covers the most-recent closed ``XKRX``
+    session, returns a sorted OHLCV DataFrame. Otherwise returns ``None``
+    so the caller can fall back to a live API (KIS).
+
+    ``end`` is currently a forward-compatibility placeholder: when non-None
+    (historical query), the cache is bypassed and ``None`` is returned, so
+    the caller's live path can apply the historical end-date filter.
+    """
+    if end is not None:
+        # Historical queries cannot be served by the latest-N cache.
+        return None
+
+    from app.core.db import AsyncSessionLocal
+    from app.services.daily_candles.repository import DailyCandlesRepository, MarketKey
+
+    partition = "KRX"
+    async with AsyncSessionLocal() as session:
+        repo = DailyCandlesRepository(session=session)
+        cached = await repo.fetch_recent(
+            market=MarketKey.KR, symbol=symbol, partition=partition, count=count
+        )
+        if len(cached) >= count and cache_is_fresh_equity(cached, "XKRX"):
+            logger.debug(
+                "daily_candles cache hit market=kr symbol=%s rows=%d",
+                symbol,
+                len(cached),
+            )
+            return rows_to_frame(cached)
+    return None
+
+
+async def cache_first_us(
+    symbol: str,
+    count: int,
+    end: datetime.datetime | None = None,
+) -> pd.DataFrame | None:
+    """DB-first read for US daily candles. Returns ``None`` on miss/stale.
+
+    Resolves the symbol's exchange (``NASDAQ`` / ``NYSE`` / ``AMEX``) via
+    ``get_us_exchange_by_symbol`` and reads the latest ``count`` rows from
+    ``us_candles_1d``. Freshness uses the ``XNYS`` calendar (which covers
+    all US sessions including AMEX). Returns ``None`` when the DB is
+    insufficient or stale so the caller can fall back to a live API
+    (Yahoo → Toss).
+    """
+    if end is not None:
+        return None
+
+    from app.core.db import AsyncSessionLocal
+    from app.services.daily_candles.repository import DailyCandlesRepository, MarketKey
+    from app.services.us_symbol_universe_service import get_us_exchange_by_symbol
+
+    async with AsyncSessionLocal() as session:
+        try:
+            partition = await get_us_exchange_by_symbol(symbol, db=session)
+        except Exception:
+            logger.warning(
+                "Could not resolve US exchange for symbol=%s; defaulting to NASD",
+                symbol,
+            )
+            partition = "NASD"
+
+        repo = DailyCandlesRepository(session=session)
+        cached = await repo.fetch_recent(
+            market=MarketKey.US, symbol=symbol, partition=partition, count=count
+        )
+        if len(cached) >= count and cache_is_fresh_equity(cached, "XNYS"):
+            logger.debug(
+                "daily_candles cache hit market=us symbol=%s rows=%d",
+                symbol,
+                len(cached),
+            )
+            return rows_to_frame(cached)
+    return None
+
+
+async def write_back_kr(
+    frame: pd.DataFrame, *, symbol: str, partition: str = "KRX", source: str = "kis"
+) -> int:
+    """Write a freshly fetched KR daily frame back into ``kr_candles_1d``.
+
+    Best-effort: any error is swallowed and logged so that write-back
+    failures never propagate to the caller's read path. Returns the number
+    of rows upserted (0 on failure or empty frame).
+    """
+    if frame is None or frame.empty:
+        return 0
+    from app.core.db import AsyncSessionLocal
+    from app.services.daily_candles.converters import frame_to_rows
+    from app.services.daily_candles.repository import DailyCandlesRepository, MarketKey
+
+    repo_rows = frame_to_rows(frame, symbol=symbol, partition=partition, source=source)
+    if not repo_rows:
+        return 0
+    try:
+        async with AsyncSessionLocal() as session:
+            repo = DailyCandlesRepository(session=session)
+            upserted = await repo.upsert_rows(market=MarketKey.KR, rows=repo_rows)
+            await session.commit()
+            return upserted
+    except Exception:
+        logger.exception(
+            "write_back_kr failed symbol=%s partition=%s rows=%d",
+            symbol,
+            partition,
+            len(repo_rows),
+        )
+        return 0
+
+
+async def write_back_us(
+    frame: pd.DataFrame,
+    *,
+    symbol: str,
+    partition: str | None = None,
+    source: str = "yahoo",
+) -> int:
+    """Write a freshly fetched US daily frame back into ``us_candles_1d``.
+
+    ``source`` defaults to ``'yahoo'`` because the most common write-back
+    caller in ``get_ohlcv`` is the US Yahoo path. Pass ``'toss'`` if the
+    frame came from the Toss fallback.
+
+    If ``partition`` is ``None`` the exchange is resolved via
+    ``get_us_exchange_by_symbol`` (defaulting to ``'NASD'`` on failure).
+    """
+    if frame is None or frame.empty:
+        return 0
+    from app.core.db import AsyncSessionLocal
+    from app.services.daily_candles.converters import frame_to_rows
+    from app.services.daily_candles.repository import DailyCandlesRepository, MarketKey
+    from app.services.us_symbol_universe_service import get_us_exchange_by_symbol
+
+    if partition is None:
+        async with AsyncSessionLocal() as session:
+            try:
+                partition = await get_us_exchange_by_symbol(symbol, db=session)
+            except Exception:
+                logger.warning(
+                    "write_back_us: could not resolve exchange for symbol=%s; "
+                    "defaulting to NASD",
+                    symbol,
+                )
+                partition = "NASD"
+
+    repo_rows = frame_to_rows(frame, symbol=symbol, partition=partition, source=source)
+    if not repo_rows:
+        return 0
+    try:
+        async with AsyncSessionLocal() as session:
+            repo = DailyCandlesRepository(session=session)
+            upserted = await repo.upsert_rows(market=MarketKey.US, rows=repo_rows)
+            await session.commit()
+            return upserted
+    except Exception:
+        logger.exception(
+            "write_back_us failed symbol=%s partition=%s rows=%d",
+            symbol,
+            partition,
+            len(repo_rows),
+        )
+        return 0
+
+
+__all__ = [
+    "OHLCV_COLUMNS",
+    "cache_first_kr",
+    "cache_first_us",
+    "cache_is_fresh_crypto",
+    "cache_is_fresh_equity",
+    "get_calendar",
+    "latest_exchange_session",
+    "rows_to_frame",
+    "write_back_kr",
+    "write_back_us",
+]

--- a/app/services/daily_candles/repository.py
+++ b/app/services/daily_candles/repository.py
@@ -78,8 +78,19 @@ class DailyCandlesRepository:
         return market == MarketKey.US
 
     async def upsert_rows(
-        self, *, market: MarketKey, rows: list[DailyCandleRow]
+        self,
+        *,
+        market: MarketKey,
+        rows: list[DailyCandleRow],
+        update_adj_close: bool = True,
     ) -> int:
+        """Upsert daily candle rows.
+
+        ``update_adj_close=False`` (US only) keeps ``adj_close`` out of the
+        ON CONFLICT UPDATE SET so a frame without adjusted closes (plain
+        Yahoo/Toss write-back) does not null existing ``yahoo_fallback``
+        values. New rows still insert ``adj_close`` (as NULL).
+        """
         if not rows:
             return 0
 
@@ -91,7 +102,9 @@ class DailyCandlesRepository:
 
         cfg = self._config(market)
         upsert_sql = self._build_market_upsert(
-            cfg, with_adj_close=self._supports_adj_close(market)
+            cfg,
+            with_adj_close=self._supports_adj_close(market),
+            update_adj_close=update_adj_close,
         )
         payload: list[dict[str, object]] = []
         for row in rows:
@@ -195,7 +208,7 @@ class DailyCandlesRepository:
 
     @staticmethod
     def _build_market_upsert(
-        cfg: SyncTableConfig, *, with_adj_close: bool
+        cfg: SyncTableConfig, *, with_adj_close: bool, update_adj_close: bool = True
     ) -> TextClause:
         cols = [
             "time",
@@ -213,9 +226,10 @@ class DailyCandlesRepository:
             cols.insert(7, "adj_close")
         placeholders = ", ".join(f":{c}" for c in cols)
         col_list = ", ".join(cols)
-        update_cols = [
-            c for c in cols if c not in {"time", "symbol", cfg.partition_col}
-        ]
+        excluded_from_update = {"time", "symbol", cfg.partition_col}
+        if with_adj_close and not update_adj_close:
+            excluded_from_update.add("adj_close")
+        update_cols = [c for c in cols if c not in excluded_from_update]
         update_clause = ", ".join(f"{c}=EXCLUDED.{c}" for c in update_cols)
         return text(
             f"""

--- a/app/services/kis_ohlcv_cache.py
+++ b/app/services/kis_ohlcv_cache.py
@@ -27,7 +27,11 @@ logger = logging.getLogger(__name__)
 
 _SUPPORTED_PERIODS = {"day", "1h"}
 _DAY_COLUMNS = ["date", "open", "high", "low", "close", "volume", "value"]
-_KRX_DAILY_CACHE_CUTOFF = time(15, 35)
+# Public name (ROB-639): ``daily_candles.read_service`` reuses this cutoff so
+# the DB-first gate and the Redis daily cache share one KRX finalization
+# boundary (the 15:30 close plus a settling buffer). Do not fork the value.
+KRX_DAILY_CACHE_CUTOFF = time(15, 35)
+_KRX_DAILY_CACHE_CUTOFF = KRX_DAILY_CACHE_CUTOFF
 _HOURLY_COLUMNS = [
     "datetime",
     "date",

--- a/app/services/market_data/service.py
+++ b/app/services/market_data/service.py
@@ -635,9 +635,7 @@ async def get_ohlcv(
             # back to Yahoo → Toss on miss/stale. week/month stay live (v1).
             capped_count = min(count, 200)
             if resolved_period == "day":
-                db_frame = await cache_first_us(
-                    resolved_symbol, capped_count, end
-                )
+                db_frame = await cache_first_us(resolved_symbol, capped_count, end)
                 if db_frame is not None and not db_frame.empty:
                     return _to_candle_rows(
                         db_frame,
@@ -680,9 +678,7 @@ async def get_ohlcv(
             # ROB-639: day → DB-first read-through (kr_candles_1d). week/month
             # stay on the live path (v1 scope).
             if resolved_period == "day":
-                db_frame = await cache_first_kr(
-                    resolved_symbol, capped_count, end
-                )
+                db_frame = await cache_first_kr(resolved_symbol, capped_count, end)
                 if db_frame is not None and not db_frame.empty:
                     return _to_candle_rows(
                         db_frame,

--- a/app/services/market_data/service.py
+++ b/app/services/market_data/service.py
@@ -17,6 +17,12 @@ from app.services.brokers.upbit.client import fetch_multiple_current_prices
 from app.services.brokers.upbit.client import fetch_ohlcv as fetch_upbit_ohlcv
 from app.services.brokers.yahoo.client import fetch_fast_info
 from app.services.brokers.yahoo.client import fetch_ohlcv as fetch_yahoo_ohlcv
+from app.services.daily_candles.read_service import (
+    cache_first_kr,
+    cache_first_us,
+    write_back_kr,
+    write_back_us,
+)
 from app.services.domain_errors import (
     RateLimitError,
     SymbolNotFoundError,
@@ -625,8 +631,21 @@ async def get_ohlcv(
                     source="kis",
                     period=resolved_period,
                 )
-            # day/week/month use Yahoo Finance with Toss day-only fallback
+            # ROB-639: day → DB-first read-through (kr/us_candles_1d). Falls
+            # back to Yahoo → Toss on miss/stale. week/month stay live (v1).
             capped_count = min(count, 200)
+            if resolved_period == "day":
+                db_frame = await cache_first_us(
+                    resolved_symbol, capped_count, end
+                )
+                if db_frame is not None and not db_frame.empty:
+                    return _to_candle_rows(
+                        db_frame,
+                        symbol=resolved_symbol,
+                        market=resolved_market,
+                        source="db",
+                        period=resolved_period,
+                    )
             try:
                 frame = await fetch_yahoo_ohlcv(
                     ticker=resolved_symbol,
@@ -644,6 +663,8 @@ async def get_ohlcv(
                     end_date=end,
                 )
                 source = "toss"
+            if resolved_period == "day":
+                await write_back_us(frame, symbol=resolved_symbol, source=source)
             return _to_candle_rows(
                 frame,
                 symbol=resolved_symbol,
@@ -655,13 +676,30 @@ async def get_ohlcv(
         kis = KISClient()
         if resolved_period in {"day", "week", "month"}:
             period_map = {"day": "D", "week": "W", "month": "M"}
+            capped_count = min(count, 200)
+            # ROB-639: day → DB-first read-through (kr_candles_1d). week/month
+            # stay on the live path (v1 scope).
+            if resolved_period == "day":
+                db_frame = await cache_first_kr(
+                    resolved_symbol, capped_count, end
+                )
+                if db_frame is not None and not db_frame.empty:
+                    return _to_candle_rows(
+                        db_frame,
+                        symbol=resolved_symbol,
+                        market=resolved_market,
+                        source="db",
+                        period=resolved_period,
+                    )
             frame = await kis.inquire_daily_itemchartprice(
                 code=resolved_symbol,
                 market="J",
-                n=min(count, 200),
+                n=capped_count,
                 period=period_map[resolved_period],
                 end_date=(pd.Timestamp(end.date()) if end is not None else None),
             )
+            if resolved_period == "day":
+                await write_back_kr(frame, symbol=resolved_symbol)
             return _to_candle_rows(
                 frame,
                 symbol=resolved_symbol,

--- a/tests/test_get_ohlcv_day_db_first.py
+++ b/tests/test_get_ohlcv_day_db_first.py
@@ -18,16 +18,63 @@ import datetime as dt
 from datetime import UTC, timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import exchange_calendars as xcals
 import pandas as pd
 import pytest
 
+from app.core.timezone import KST
 from app.services.daily_candles.read_service import (
     cache_first_kr,
     cache_first_us,
     cache_is_fresh_equity,
+    write_back_kr,
+    write_back_us,
 )
 from app.services.daily_candles.repository import DailyCandleRow
 from app.services.market_data import service as market_data_service
+
+
+def _krx_latest_and_prev_session() -> tuple[dt.date, dt.date]:
+    """(latest XKRX session on-or-before today, the session before it)."""
+    cal = xcals.get_calendar("XKRX")
+    today = dt.datetime.now(tz=KST).date()
+    latest = cal.date_to_session(pd.Timestamp(today), direction="previous")
+    prev = cal.previous_session(latest)
+    return pd.Timestamp(latest).date(), pd.Timestamp(prev).date()
+
+
+def _xnys_latest_and_prev_session() -> tuple[dt.date, dt.date]:
+    cal = xcals.get_calendar("XNYS")
+    today = dt.datetime.now(tz=UTC).date()
+    latest = cal.date_to_session(pd.Timestamp(today), direction="previous")
+    prev = cal.previous_session(latest)
+    return pd.Timestamp(latest).date(), pd.Timestamp(prev).date()
+
+
+def _kst_at(day: dt.date, hour: int, minute: int = 0) -> dt.datetime:
+    return dt.datetime.combine(day, dt.time(hour, minute), tzinfo=KST)
+
+
+def _after_cutoff_now() -> dt.datetime:
+    """16:00 KST on the latest XKRX session — past the 15:35 cutoff."""
+    latest, _ = _krx_latest_and_prev_session()
+    return _kst_at(latest, 16, 0)
+
+
+class _FakeSession:
+    """Minimal async-session stand-in for write_back tests (no real DB)."""
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def commit(self):
+        return None
+
+    async def rollback(self):
+        return None
 
 
 def _make_row(
@@ -106,9 +153,7 @@ async def test_kr_day_db_hit_returns_db_rows_without_kis(monkeypatch):
     write_back_mock = AsyncMock(return_value=5)
     monkeypatch.setattr(market_data_service, "write_back_kr", write_back_mock)
 
-    candles = await market_data_service.get_ohlcv(
-        "005930", "kr", "day", count=5
-    )
+    candles = await market_data_service.get_ohlcv("005930", "kr", "day", count=5)
 
     assert len(candles) == 5
     assert all(c.source == "db" for c in candles)
@@ -129,9 +174,7 @@ async def test_us_day_db_hit_returns_db_rows_without_yahoo(monkeypatch):
     write_back_mock = AsyncMock(return_value=5)
     monkeypatch.setattr(market_data_service, "write_back_us", write_back_mock)
 
-    candles = await market_data_service.get_ohlcv(
-        "MSFT", "us", "day", count=5
-    )
+    candles = await market_data_service.get_ohlcv("MSFT", "us", "day", count=5)
 
     assert len(candles) == 5
     assert all(c.source == "db" for c in candles)
@@ -169,15 +212,11 @@ async def test_kr_day_db_miss_falls_back_to_kis_and_writes_back(monkeypatch):
     write_back_mock = AsyncMock(return_value=1)
     monkeypatch.setattr(market_data_service, "write_back_kr", write_back_mock)
 
-    candles = await market_data_service.get_ohlcv(
-        "005930", "kr", "day", count=5
-    )
+    candles = await market_data_service.get_ohlcv("005930", "kr", "day", count=5)
 
     assert len(candles) == 1
     assert candles[0].source == "kis"
-    write_back_mock.assert_awaited_once_with(
-        kis_frame, symbol="005930"
-    )
+    write_back_mock.assert_awaited_once_with(kis_frame, symbol="005930")
 
 
 @pytest.mark.asyncio
@@ -205,16 +244,12 @@ async def test_us_day_db_miss_falls_back_to_yahoo_and_writes_back(monkeypatch):
     write_back_mock = AsyncMock(return_value=1)
     monkeypatch.setattr(market_data_service, "write_back_us", write_back_mock)
 
-    candles = await market_data_service.get_ohlcv(
-        "MSFT", "us", "day", count=5
-    )
+    candles = await market_data_service.get_ohlcv("MSFT", "us", "day", count=5)
 
     assert len(candles) == 1
     assert candles[0].source == "yahoo"
     yahoo_mock.assert_awaited_once()
-    write_back_mock.assert_awaited_once_with(
-        yahoo_frame, symbol="MSFT", source="yahoo"
-    )
+    write_back_mock.assert_awaited_once_with(yahoo_frame, symbol="MSFT", source="yahoo")
 
 
 @pytest.mark.asyncio
@@ -247,15 +282,11 @@ async def test_us_day_db_miss_yahoo_failure_uses_toss_and_writes_back(monkeypatc
     write_back_mock = AsyncMock(return_value=1)
     monkeypatch.setattr(market_data_service, "write_back_us", write_back_mock)
 
-    candles = await market_data_service.get_ohlcv(
-        "MSFT", "us", "day", count=5
-    )
+    candles = await market_data_service.get_ohlcv("MSFT", "us", "day", count=5)
 
     assert candles[0].source == "toss"
     toss_mock.assert_awaited_once()
-    write_back_mock.assert_awaited_once_with(
-        toss_frame, symbol="MSFT", source="toss"
-    )
+    write_back_mock.assert_awaited_once_with(toss_frame, symbol="MSFT", source="toss")
 
 
 @pytest.mark.asyncio
@@ -284,13 +315,9 @@ async def test_kr_week_does_not_use_db_cache(monkeypatch):
             return kis_frame
 
     monkeypatch.setattr(market_data_service, "KISClient", lambda: _StubKIS())
-    monkeypatch.setattr(
-        market_data_service, "write_back_kr", AsyncMock(return_value=0)
-    )
+    monkeypatch.setattr(market_data_service, "write_back_kr", AsyncMock(return_value=0))
 
-    candles = await market_data_service.get_ohlcv(
-        "005930", "kr", "week", count=5
-    )
+    candles = await market_data_service.get_ohlcv("005930", "kr", "week", count=5)
 
     assert candles[0].source == "kis"
     cache_mock.assert_not_awaited()
@@ -320,13 +347,9 @@ async def test_us_week_does_not_use_db_cache(monkeypatch):
         "fetch_yahoo_ohlcv",
         AsyncMock(return_value=yahoo_frame),
     )
-    monkeypatch.setattr(
-        market_data_service, "write_back_us", AsyncMock(return_value=0)
-    )
+    monkeypatch.setattr(market_data_service, "write_back_us", AsyncMock(return_value=0))
 
-    candles = await market_data_service.get_ohlcv(
-        "MSFT", "us", "week", count=5
-    )
+    candles = await market_data_service.get_ohlcv("MSFT", "us", "week", count=5)
 
     assert candles[0].source == "yahoo"
     cache_mock.assert_not_awaited()
@@ -356,7 +379,9 @@ async def test_cache_first_kr_returns_frame_when_fresh():
             return_value=True,
         ),
     ):
-        result = await cache_first_kr("005930", count=5)
+        # now= after the 15:35 cutoff so the intraday live-passthrough gate
+        # does not fire and the DB path is actually exercised.
+        result = await cache_first_kr("005930", count=5, now=_after_cutoff_now())
 
     assert result is not None
     assert len(result) == 5
@@ -382,7 +407,7 @@ async def test_cache_first_kr_returns_none_when_stale():
             return_value=False,
         ),
     ):
-        result = await cache_first_kr("005930", count=5)
+        result = await cache_first_kr("005930", count=5, now=_after_cutoff_now())
 
     assert result is None
 
@@ -403,7 +428,7 @@ async def test_cache_first_kr_returns_none_when_insufficient_rows():
             return_value=True,
         ),
     ):
-        result = await cache_first_kr("005930", count=10)
+        result = await cache_first_kr("005930", count=10, now=_after_cutoff_now())
 
     assert result is None
 
@@ -415,7 +440,7 @@ async def test_cache_first_kr_returns_none_when_db_empty():
         "app.services.daily_candles.repository.DailyCandlesRepository.fetch_recent",
         new=AsyncMock(return_value=[]),
     ):
-        result = await cache_first_kr("005930", count=5)
+        result = await cache_first_kr("005930", count=5, now=_after_cutoff_now())
     assert result is None
 
 
@@ -544,3 +569,342 @@ def test_cache_is_fresh_equity_before_krx_close_previous_session():
         return_value=prev_session.date(),
     ):
         assert cache_is_fresh_equity(rows_stale, "XKRX") is False
+
+
+# ---------------------------------------------------------------------------
+# KR intraday live-passthrough gate (ROB-639 review fix #2)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cache_first_kr_intraday_session_bypasses_db_even_when_fresh():
+    """11:00 KST on a KRX session day → None (live serves the forming bar),
+    even though the DB would be sufficient and fresh. Non-tautological: the
+    repository is patched to return fresh rows and must not even be hit."""
+    latest, _prev = _krx_latest_and_prev_session()
+    intraday_now = _kst_at(latest, 11, 0)
+    closed_utc = dt.datetime.combine(latest, dt.time(6, 31), tzinfo=UTC)
+    rows = [
+        _make_row("005930", "KRX", closed_utc - timedelta(days=i), 70000.0 + i)
+        for i in range(5)
+    ]
+
+    fetch_mock = AsyncMock(return_value=list(reversed(rows)))
+    with patch(
+        "app.services.daily_candles.repository.DailyCandlesRepository.fetch_recent",
+        new=fetch_mock,
+    ):
+        result = await cache_first_kr("005930", count=5, now=intraday_now)
+
+    assert result is None
+    fetch_mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_cache_first_kr_after_cutoff_serves_db_covering_today():
+    """After 15:35 KST on a session day, a DB whose newest row covers today's
+    session is served (real freshness logic — latest_exchange_session is NOT
+    patched)."""
+    latest, _prev = _krx_latest_and_prev_session()
+    after_cutoff = _kst_at(latest, 16, 0)
+    # 06:31 UTC = 15:31 KST → timestamped on the latest session's date.
+    newest = dt.datetime.combine(latest, dt.time(6, 31), tzinfo=UTC)
+    rows = [
+        _make_row("005930", "KRX", newest - timedelta(days=i), 70000.0 + i)
+        for i in range(5)
+    ]
+
+    with patch(
+        "app.services.daily_candles.repository.DailyCandlesRepository.fetch_recent",
+        new=AsyncMock(return_value=list(reversed(rows))),
+    ):
+        result = await cache_first_kr("005930", count=5, now=after_cutoff)
+
+    assert result is not None
+    assert len(result) == 5
+    assert result["date"].max() == latest
+
+
+@pytest.mark.asyncio
+async def test_cache_first_kr_after_cutoff_stale_db_returns_none():
+    """After 15:35 KST on a session day, a DB whose newest row only covers the
+    PREVIOUS session is stale → None (live path must refresh today's close)."""
+    latest, prev = _krx_latest_and_prev_session()
+    after_cutoff = _kst_at(latest, 16, 0)
+    newest = dt.datetime.combine(prev, dt.time(6, 31), tzinfo=UTC)
+    rows = [
+        _make_row("005930", "KRX", newest - timedelta(days=i), 70000.0 + i)
+        for i in range(5)
+    ]
+
+    with patch(
+        "app.services.daily_candles.repository.DailyCandlesRepository.fetch_recent",
+        new=AsyncMock(return_value=list(reversed(rows))),
+    ):
+        result = await cache_first_kr("005930", count=5, now=after_cutoff)
+
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Fail-open on DB errors (ROB-639 review fix #1)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cache_first_kr_returns_none_when_db_raises():
+    """Any DB exception must degrade to None (live fallback), never raise."""
+    with patch(
+        "app.services.daily_candles.repository.DailyCandlesRepository.fetch_recent",
+        new=AsyncMock(side_effect=RuntimeError("db down")),
+    ):
+        result = await cache_first_kr("005930", count=5, now=_after_cutoff_now())
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_cache_first_us_returns_none_when_db_raises_after_lookup_failure():
+    """Poisoned-session regression (CI failure shape): the exchange lookup
+    fails AND the subsequent fetch raises (e.g. InFailedSQLTransactionError).
+    cache_first_us must swallow it and return None so live Yahoo serves."""
+    with (
+        patch(
+            "app.services.us_symbol_universe_service.get_us_exchange_by_symbol",
+            new=AsyncMock(side_effect=RuntimeError("relation does not exist")),
+        ),
+        patch(
+            "app.services.daily_candles.repository.DailyCandlesRepository.fetch_recent",
+            new=AsyncMock(side_effect=RuntimeError("current transaction is aborted")),
+        ),
+    ):
+        result = await cache_first_us("ZZFAILOPEN", count=5)
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_cache_first_us_rolls_back_session_after_lookup_failure():
+    """After a failed exchange lookup the session must be rolled back before
+    it is reused for fetch_recent (the aborted-transaction fix)."""
+    fake_session = _FakeSession()
+    rollback_mock = AsyncMock()
+    fake_session.rollback = rollback_mock  # type: ignore[method-assign]
+
+    with (
+        patch("app.core.db.AsyncSessionLocal", new=lambda: fake_session),
+        patch(
+            "app.services.us_symbol_universe_service.get_us_exchange_by_symbol",
+            new=AsyncMock(side_effect=RuntimeError("lookup failed")),
+        ),
+        patch(
+            "app.services.daily_candles.repository.DailyCandlesRepository.fetch_recent",
+            new=AsyncMock(return_value=[]),
+        ),
+    ):
+        result = await cache_first_us("ZZROLLBACK", count=5)
+
+    assert result is None
+    rollback_mock.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# Forming-bar write-back guard (ROB-639 review fix #3)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_write_back_kr_drops_forming_bar_intraday():
+    """At 11:00 KST on session S, a frame holding [prev session, S] must only
+    persist the prev-session row — S's bar is still forming."""
+    latest, prev = _krx_latest_and_prev_session()
+    intraday_now = _kst_at(latest, 11, 0)
+    frame = pd.DataFrame(
+        [
+            {
+                "date": prev,
+                "open": 100.0,
+                "high": 110.0,
+                "low": 90.0,
+                "close": 105.0,
+                "volume": 1000.0,
+                "value": 105000.0,
+            },
+            {
+                "date": latest,  # forming intraday bar
+                "open": 105.0,
+                "high": 108.0,
+                "low": 104.0,
+                "close": 107.0,
+                "volume": 500.0,
+                "value": 53500.0,
+            },
+        ]
+    )
+    upsert_mock = AsyncMock(return_value=1)
+
+    with (
+        patch("app.core.db.AsyncSessionLocal", new=lambda: _FakeSession()),
+        patch(
+            "app.services.daily_candles.repository.DailyCandlesRepository.upsert_rows",
+            new=upsert_mock,
+        ),
+    ):
+        upserted = await write_back_kr(frame, symbol="ZZWBKR1", now=intraday_now)
+
+    assert upserted == 1
+    upsert_mock.assert_awaited_once()
+    persisted = upsert_mock.call_args.kwargs["rows"]
+    assert [r.time_utc.date() for r in persisted] == [prev]
+
+
+@pytest.mark.asyncio
+async def test_write_back_kr_all_forming_rows_writes_nothing():
+    """A frame containing only today's forming bar persists nothing."""
+    latest, _prev = _krx_latest_and_prev_session()
+    intraday_now = _kst_at(latest, 11, 0)
+    frame = pd.DataFrame(
+        [
+            {
+                "date": latest,
+                "open": 105.0,
+                "high": 108.0,
+                "low": 104.0,
+                "close": 107.0,
+                "volume": 500.0,
+                "value": 53500.0,
+            }
+        ]
+    )
+    upsert_mock = AsyncMock(return_value=1)
+
+    with (
+        patch("app.core.db.AsyncSessionLocal", new=lambda: _FakeSession()),
+        patch(
+            "app.services.daily_candles.repository.DailyCandlesRepository.upsert_rows",
+            new=upsert_mock,
+        ),
+    ):
+        upserted = await write_back_kr(frame, symbol="ZZWBKR2", now=intraday_now)
+
+    assert upserted == 0
+    upsert_mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_write_back_kr_after_cutoff_keeps_todays_bar():
+    """After 15:35 KST, today's bar is final and must be persisted."""
+    latest, prev = _krx_latest_and_prev_session()
+    after_cutoff = _kst_at(latest, 16, 0)
+    frame = pd.DataFrame(
+        [
+            {
+                "date": prev,
+                "open": 100.0,
+                "high": 110.0,
+                "low": 90.0,
+                "close": 105.0,
+                "volume": 1000.0,
+                "value": 105000.0,
+            },
+            {
+                "date": latest,
+                "open": 105.0,
+                "high": 108.0,
+                "low": 104.0,
+                "close": 107.0,
+                "volume": 500.0,
+                "value": 53500.0,
+            },
+        ]
+    )
+    upsert_mock = AsyncMock(return_value=2)
+
+    with (
+        patch("app.core.db.AsyncSessionLocal", new=lambda: _FakeSession()),
+        patch(
+            "app.services.daily_candles.repository.DailyCandlesRepository.upsert_rows",
+            new=upsert_mock,
+        ),
+    ):
+        upserted = await write_back_kr(frame, symbol="ZZWBKR3", now=after_cutoff)
+
+    assert upserted == 2
+    persisted = upsert_mock.call_args.kwargs["rows"]
+    assert sorted(r.time_utc.date() for r in persisted) == sorted([prev, latest])
+
+
+@pytest.mark.asyncio
+async def test_write_back_us_drops_forming_bar_and_preserves_adj_close():
+    """Mid-session US write-back drops the forming bar; a frame without an
+    adj_close column must not update adj_close (yahoo_fallback guard)."""
+    latest, prev = _xnys_latest_and_prev_session()
+    # 15:00 UTC is mid-session on any XNYS session day (incl. half days).
+    mid_session_now = dt.datetime.combine(latest, dt.time(15, 0), tzinfo=UTC)
+    frame = pd.DataFrame(
+        [
+            {
+                "date": prev,
+                "open": 150.0,
+                "high": 152.0,
+                "low": 148.0,
+                "close": 151.0,
+                "volume": 1000.0,
+                "value": 151000.0,
+            },
+            {
+                "date": latest,  # forming intraday bar
+                "open": 151.0,
+                "high": 153.0,
+                "low": 150.0,
+                "close": 152.0,
+                "volume": 500.0,
+                "value": 76000.0,
+            },
+        ]
+    )
+    upsert_mock = AsyncMock(return_value=1)
+
+    with (
+        patch("app.core.db.AsyncSessionLocal", new=lambda: _FakeSession()),
+        patch(
+            "app.services.daily_candles.repository.DailyCandlesRepository.upsert_rows",
+            new=upsert_mock,
+        ),
+    ):
+        upserted = await write_back_us(
+            frame,
+            symbol="ZZWBUS1",
+            partition="NASD",
+            source="yahoo",
+            now=mid_session_now,
+        )
+
+    assert upserted == 1
+    upsert_mock.assert_awaited_once()
+    kwargs = upsert_mock.call_args.kwargs
+    assert [r.time_utc.date() for r in kwargs["rows"]] == [prev]
+    assert kwargs["update_adj_close"] is False
+
+
+def test_upsert_sql_excludes_adj_close_from_update_when_guarded():
+    """update_adj_close=False keeps adj_close in the INSERT column list but
+    out of the ON CONFLICT UPDATE SET."""
+    from app.services.daily_candles.repository import (
+        _TABLE_CONFIGS,
+        DailyCandlesRepository,
+        MarketKey,
+    )
+
+    cfg = _TABLE_CONFIGS[MarketKey.US]
+    guarded = str(
+        DailyCandlesRepository._build_market_upsert(
+            cfg, with_adj_close=True, update_adj_close=False
+        )
+    )
+    default = str(
+        DailyCandlesRepository._build_market_upsert(
+            cfg, with_adj_close=True, update_adj_close=True
+        )
+    )
+    assert "adj_close" in guarded  # still inserted
+    assert "adj_close=EXCLUDED.adj_close" not in guarded
+    assert "adj_close=EXCLUDED.adj_close" in default

--- a/tests/test_get_ohlcv_day_db_first.py
+++ b/tests/test_get_ohlcv_day_db_first.py
@@ -1,0 +1,546 @@
+"""Unit tests for ROB-639: get_ohlcv(period='day') DB-first read-through.
+
+Covers:
+- DB hit: get_ohlcv returns DB rows without calling KIS/Yahoo
+- DB miss/stale: get_ohlcv falls back to live API and writes back to DB
+- end_date bypass: historical queries skip the cache
+- cache_is_fresh_equity: 15:35 KRX cutoff boundary cases
+
+The get_ohlcv-level tests mock cache_first_kr/us at the module level (same
+pattern as read_kr_intraday_candles in test_market_data_service.py). The
+read_service-level tests mock DailyCandlesRepository.fetch_recent and
+cache_is_fresh_equity to exercise the freshness gate directly.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from datetime import UTC, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pandas as pd
+import pytest
+
+from app.services.daily_candles.read_service import (
+    cache_first_kr,
+    cache_first_us,
+    cache_is_fresh_equity,
+)
+from app.services.daily_candles.repository import DailyCandleRow
+from app.services.market_data import service as market_data_service
+
+
+def _make_row(
+    symbol: str,
+    partition: str,
+    t: dt.datetime,
+    close: float,
+    source: str = "kis",
+) -> DailyCandleRow:
+    return DailyCandleRow(
+        time_utc=t,
+        symbol=symbol,
+        partition=partition,
+        open=close - 1.0,
+        high=close + 0.5,
+        low=close - 1.5,
+        close=close,
+        adj_close=None,
+        volume=1000.0,
+        value=close * 1000.0,
+        source=source,
+    )
+
+
+def _kr_db_frame(n: int = 5) -> pd.DataFrame:
+    today = dt.datetime.now(UTC).replace(hour=12, minute=0, second=0, microsecond=0)
+    return pd.DataFrame(
+        [
+            {
+                "date": (today - timedelta(days=i)).date(),
+                "open": 70000.0 + i,
+                "high": 70500.0 + i,
+                "low": 69500.0 + i,
+                "close": 70200.0 + i,
+                "volume": 100000.0,
+                "value": 70200.0 * 100000.0,
+            }
+            for i in range(n)
+        ]
+    )
+
+
+def _us_db_frame(n: int = 5) -> pd.DataFrame:
+    today = dt.datetime.now(UTC).replace(hour=22, minute=0, second=0, microsecond=0)
+    return pd.DataFrame(
+        [
+            {
+                "date": (today - timedelta(days=i)).date(),
+                "open": 150.0 + i,
+                "high": 152.0 + i,
+                "low": 148.0 + i,
+                "close": 151.0 + i,
+                "volume": 5_000_000.0,
+                "value": 151.0 * 5_000_000.0,
+            }
+            for i in range(n)
+        ]
+    )
+
+
+# ---------------------------------------------------------------------------
+# get_ohlcv integration tests (mock cache_first_* at module level)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_kr_day_db_hit_returns_db_rows_without_kis(monkeypatch):
+    """When DB has fresh rows, get_ohlcv returns them with source='db'."""
+    db_frame = _kr_db_frame(n=5)
+    monkeypatch.setattr(
+        market_data_service, "cache_first_kr", AsyncMock(return_value=db_frame)
+    )
+    kis_instance = MagicMock()
+    kis_instance.inquire_daily_itemchartprice = AsyncMock()
+    monkeypatch.setattr(market_data_service, "KISClient", lambda: kis_instance)
+    write_back_mock = AsyncMock(return_value=5)
+    monkeypatch.setattr(market_data_service, "write_back_kr", write_back_mock)
+
+    candles = await market_data_service.get_ohlcv(
+        "005930", "kr", "day", count=5
+    )
+
+    assert len(candles) == 5
+    assert all(c.source == "db" for c in candles)
+    assert all(c.period == "day" for c in candles)
+    kis_instance.inquire_daily_itemchartprice.assert_not_called()
+    write_back_mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_us_day_db_hit_returns_db_rows_without_yahoo(monkeypatch):
+    """When DB has fresh US rows, get_ohlcv returns them with source='db'."""
+    db_frame = _us_db_frame(n=5)
+    monkeypatch.setattr(
+        market_data_service, "cache_first_us", AsyncMock(return_value=db_frame)
+    )
+    yahoo_mock = AsyncMock()
+    monkeypatch.setattr(market_data_service, "fetch_yahoo_ohlcv", yahoo_mock)
+    write_back_mock = AsyncMock(return_value=5)
+    monkeypatch.setattr(market_data_service, "write_back_us", write_back_mock)
+
+    candles = await market_data_service.get_ohlcv(
+        "MSFT", "us", "day", count=5
+    )
+
+    assert len(candles) == 5
+    assert all(c.source == "db" for c in candles)
+    yahoo_mock.assert_not_awaited()
+    write_back_mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_kr_day_db_miss_falls_back_to_kis_and_writes_back(monkeypatch):
+    """When DB misses, get_ohlcv calls KIS, writes back, returns kis rows."""
+    monkeypatch.setattr(
+        market_data_service, "cache_first_kr", AsyncMock(return_value=None)
+    )
+
+    kis_frame = pd.DataFrame(
+        [
+            {
+                "datetime": pd.Timestamp("2026-07-01 15:30:00"),
+                "date": dt.date(2026, 7, 1),
+                "open": 70000.0,
+                "high": 70500.0,
+                "low": 69500.0,
+                "close": 70200.0,
+                "volume": 100000.0,
+                "value": 70200.0 * 100000.0,
+            }
+        ]
+    )
+
+    class _StubKIS:
+        async def inquire_daily_itemchartprice(self, **kwargs):
+            return kis_frame
+
+    monkeypatch.setattr(market_data_service, "KISClient", lambda: _StubKIS())
+    write_back_mock = AsyncMock(return_value=1)
+    monkeypatch.setattr(market_data_service, "write_back_kr", write_back_mock)
+
+    candles = await market_data_service.get_ohlcv(
+        "005930", "kr", "day", count=5
+    )
+
+    assert len(candles) == 1
+    assert candles[0].source == "kis"
+    write_back_mock.assert_awaited_once_with(
+        kis_frame, symbol="005930"
+    )
+
+
+@pytest.mark.asyncio
+async def test_us_day_db_miss_falls_back_to_yahoo_and_writes_back(monkeypatch):
+    """When DB misses for US, get_ohlcv calls Yahoo, writes back, returns yahoo rows."""
+    monkeypatch.setattr(
+        market_data_service, "cache_first_us", AsyncMock(return_value=None)
+    )
+
+    yahoo_frame = pd.DataFrame(
+        [
+            {
+                "date": dt.date(2026, 7, 1),
+                "open": 150.0,
+                "high": 152.0,
+                "low": 148.0,
+                "close": 151.0,
+                "volume": 5_000_000.0,
+                "value": 151.0 * 5_000_000.0,
+            }
+        ]
+    )
+    yahoo_mock = AsyncMock(return_value=yahoo_frame)
+    monkeypatch.setattr(market_data_service, "fetch_yahoo_ohlcv", yahoo_mock)
+    write_back_mock = AsyncMock(return_value=1)
+    monkeypatch.setattr(market_data_service, "write_back_us", write_back_mock)
+
+    candles = await market_data_service.get_ohlcv(
+        "MSFT", "us", "day", count=5
+    )
+
+    assert len(candles) == 1
+    assert candles[0].source == "yahoo"
+    yahoo_mock.assert_awaited_once()
+    write_back_mock.assert_awaited_once_with(
+        yahoo_frame, symbol="MSFT", source="yahoo"
+    )
+
+
+@pytest.mark.asyncio
+async def test_us_day_db_miss_yahoo_failure_uses_toss_and_writes_back(monkeypatch):
+    """When DB misses and Yahoo fails for US day, Toss fallback fires and write-back runs with source='toss'."""
+    monkeypatch.setattr(
+        market_data_service, "cache_first_us", AsyncMock(return_value=None)
+    )
+    monkeypatch.setattr(
+        market_data_service,
+        "fetch_yahoo_ohlcv",
+        AsyncMock(side_effect=RuntimeError("yahoo down")),
+    )
+
+    toss_frame = pd.DataFrame(
+        [
+            {
+                "datetime": pd.Timestamp("2026-07-01 16:00:00"),
+                "open": 150.0,
+                "high": 152.0,
+                "low": 148.0,
+                "close": 151.0,
+                "volume": 5_000_000.0,
+                "value": 151.0 * 5_000_000.0,
+            }
+        ]
+    )
+    toss_mock = AsyncMock(return_value=toss_frame)
+    monkeypatch.setattr(market_data_service, "fetch_daily_toss_frame", toss_mock)
+    write_back_mock = AsyncMock(return_value=1)
+    monkeypatch.setattr(market_data_service, "write_back_us", write_back_mock)
+
+    candles = await market_data_service.get_ohlcv(
+        "MSFT", "us", "day", count=5
+    )
+
+    assert candles[0].source == "toss"
+    toss_mock.assert_awaited_once()
+    write_back_mock.assert_awaited_once_with(
+        toss_frame, symbol="MSFT", source="toss"
+    )
+
+
+@pytest.mark.asyncio
+async def test_kr_week_does_not_use_db_cache(monkeypatch):
+    """week period must NOT hit the DB cache (v1 scope: day only)."""
+    cache_mock = AsyncMock(return_value=None)
+    monkeypatch.setattr(market_data_service, "cache_first_kr", cache_mock)
+
+    kis_frame = pd.DataFrame(
+        [
+            {
+                "datetime": pd.Timestamp("2026-07-01"),
+                "date": dt.date(2026, 7, 1),
+                "open": 70000.0,
+                "high": 70500.0,
+                "low": 69500.0,
+                "close": 70200.0,
+                "volume": 100000.0,
+                "value": 70200.0 * 100000.0,
+            }
+        ]
+    )
+
+    class _StubKIS:
+        async def inquire_daily_itemchartprice(self, **kwargs):
+            return kis_frame
+
+    monkeypatch.setattr(market_data_service, "KISClient", lambda: _StubKIS())
+    monkeypatch.setattr(
+        market_data_service, "write_back_kr", AsyncMock(return_value=0)
+    )
+
+    candles = await market_data_service.get_ohlcv(
+        "005930", "kr", "week", count=5
+    )
+
+    assert candles[0].source == "kis"
+    cache_mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_us_week_does_not_use_db_cache(monkeypatch):
+    """week period must NOT hit the DB cache (v1 scope: day only)."""
+    cache_mock = AsyncMock(return_value=None)
+    monkeypatch.setattr(market_data_service, "cache_first_us", cache_mock)
+
+    yahoo_frame = pd.DataFrame(
+        [
+            {
+                "date": dt.date(2026, 7, 1),
+                "open": 150.0,
+                "high": 152.0,
+                "low": 148.0,
+                "close": 151.0,
+                "volume": 5_000_000.0,
+                "value": 151.0 * 5_000_000.0,
+            }
+        ]
+    )
+    monkeypatch.setattr(
+        market_data_service,
+        "fetch_yahoo_ohlcv",
+        AsyncMock(return_value=yahoo_frame),
+    )
+    monkeypatch.setattr(
+        market_data_service, "write_back_us", AsyncMock(return_value=0)
+    )
+
+    candles = await market_data_service.get_ohlcv(
+        "MSFT", "us", "week", count=5
+    )
+
+    assert candles[0].source == "yahoo"
+    cache_mock.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# read_service unit tests (mock repository + freshness gate)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cache_first_kr_returns_frame_when_fresh():
+    """When DB has >= count rows AND freshness passes, returns a DataFrame."""
+    today = dt.datetime.now(UTC).replace(hour=12, minute=0, second=0, microsecond=0)
+    rows = [
+        _make_row("005930", "KRX", today - timedelta(days=i), 70000.0 + i)
+        for i in range(5)
+    ]
+
+    with (
+        patch(
+            "app.services.daily_candles.repository.DailyCandlesRepository.fetch_recent",
+            new=AsyncMock(return_value=list(reversed(rows))),
+        ),
+        patch(
+            "app.services.daily_candles.read_service.cache_is_fresh_equity",
+            return_value=True,
+        ),
+    ):
+        result = await cache_first_kr("005930", count=5)
+
+    assert result is not None
+    assert len(result) == 5
+    assert "close" in result.columns
+
+
+@pytest.mark.asyncio
+async def test_cache_first_kr_returns_none_when_stale():
+    """When DB rows fail the freshness check, returns None (caller falls back)."""
+    today = dt.datetime.now(UTC).replace(hour=12, minute=0, second=0, microsecond=0)
+    rows = [
+        _make_row("005930", "KRX", today - timedelta(days=i), 70000.0 + i)
+        for i in range(5)
+    ]
+
+    with (
+        patch(
+            "app.services.daily_candles.repository.DailyCandlesRepository.fetch_recent",
+            new=AsyncMock(return_value=list(reversed(rows))),
+        ),
+        patch(
+            "app.services.daily_candles.read_service.cache_is_fresh_equity",
+            return_value=False,
+        ),
+    ):
+        result = await cache_first_kr("005930", count=5)
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_cache_first_kr_returns_none_when_insufficient_rows():
+    """When DB has fewer rows than count, returns None even if rows are fresh."""
+    today = dt.datetime.now(UTC).replace(hour=12, minute=0, second=0, microsecond=0)
+    rows = [_make_row("005930", "KRX", today, 70000.0)]  # only 1 row
+
+    with (
+        patch(
+            "app.services.daily_candles.repository.DailyCandlesRepository.fetch_recent",
+            new=AsyncMock(return_value=rows),
+        ),
+        patch(
+            "app.services.daily_candles.read_service.cache_is_fresh_equity",
+            return_value=True,
+        ),
+    ):
+        result = await cache_first_kr("005930", count=10)
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_cache_first_kr_returns_none_when_db_empty():
+    """Empty DB → None."""
+    with patch(
+        "app.services.daily_candles.repository.DailyCandlesRepository.fetch_recent",
+        new=AsyncMock(return_value=[]),
+    ):
+        result = await cache_first_kr("005930", count=5)
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_cache_first_kr_bypasses_cache_when_end_is_provided():
+    """Historical queries (end != None) must bypass the DB cache."""
+    result = await cache_first_kr(
+        "005930", count=5, end=dt.datetime(2025, 1, 1, tzinfo=UTC)
+    )
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_cache_first_us_bypasses_cache_when_end_is_provided():
+    result = await cache_first_us(
+        "MSFT", count=5, end=dt.datetime(2025, 1, 1, tzinfo=UTC)
+    )
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_cache_first_us_returns_none_when_symbol_not_resolved():
+    """If get_us_exchange_by_symbol fails, defaults to NASD and proceeds;
+    if DB is then empty, returns None."""
+    with (
+        patch(
+            "app.services.us_symbol_universe_service.get_us_exchange_by_symbol",
+            new=AsyncMock(side_effect=RuntimeError("lookup failed")),
+        ),
+        patch(
+            "app.services.daily_candles.repository.DailyCandlesRepository.fetch_recent",
+            new=AsyncMock(return_value=[]),
+        ),
+    ):
+        result = await cache_first_us("UNKNOWN", count=5)
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Freshness boundary tests (15:35 KRX cutoff semantics)
+# ---------------------------------------------------------------------------
+
+
+def test_cache_is_fresh_equity_true_when_row_matches_latest_session():
+    """Row timestamped ON the latest session date → fresh."""
+    today = dt.datetime.now(UTC).replace(hour=12, minute=0, second=0, microsecond=0)
+    rows = [_make_row("005930", "KRX", today, 70000.0)]
+
+    with patch(
+        "app.services.daily_candles.read_service.latest_exchange_session",
+        return_value=today.date(),
+    ):
+        assert cache_is_fresh_equity(rows, "XKRX") is True
+
+
+def test_cache_is_fresh_equity_false_when_row_is_older_than_latest_session():
+    """Row from yesterday but latest session is today → stale."""
+    today = dt.datetime.now(UTC).replace(hour=12, minute=0, second=0, microsecond=0)
+    yesterday = today - timedelta(days=1)
+    rows = [_make_row("005930", "KRX", yesterday, 70000.0)]
+
+    with patch(
+        "app.services.daily_candles.read_service.latest_exchange_session",
+        return_value=today.date(),
+    ):
+        assert cache_is_fresh_equity(rows, "XKRX") is False
+
+
+def test_cache_is_fresh_equity_false_for_empty_rows():
+    assert cache_is_fresh_equity([], "XKRX") is False
+
+
+def test_cache_is_fresh_equity_uses_newest_row_when_multiple():
+    """When multiple rows exist, freshness uses the newest (max time)."""
+    today = dt.datetime.now(UTC).replace(hour=12, minute=0, second=0, microsecond=0)
+    old = today - timedelta(days=10)
+    rows = [
+        _make_row("005930", "KRX", old, 70000.0),
+        _make_row("005930", "KRX", today, 71000.0),  # newest
+    ]
+
+    with patch(
+        "app.services.daily_candles.read_service.latest_exchange_session",
+        return_value=today.date(),
+    ):
+        assert cache_is_fresh_equity(rows, "XKRX") is True
+
+
+def test_cache_is_fresh_equity_after_krx_close_same_session():
+    """Simulates the 15:35 KST scenario: after the 15:30 close, a row
+    timestamped with today's session is fresh (latest_session == today)."""
+    # 06:30 UTC = 15:30 KST (XKRX close)
+    after_close_utc = dt.datetime.now(UTC).replace(
+        hour=7, minute=0, second=0, microsecond=0
+    )
+    rows = [_make_row("005930", "KRX", after_close_utc, 70000.0)]
+
+    with patch(
+        "app.services.daily_candles.read_service.latest_exchange_session",
+        return_value=after_close_utc.date(),
+    ):
+        assert cache_is_fresh_equity(rows, "XKRX") is True
+
+
+def test_cache_is_fresh_equity_before_krx_close_previous_session():
+    """Simulates pre-open: latest_session is the previous trading day.
+    A row from that previous session is fresh; today's row is not yet
+    expected because the session hasn't closed."""
+    today = dt.datetime.now(UTC).replace(
+        hour=0, minute=0, second=0, microsecond=0
+    )  # 09:00 KST
+    prev_session = today - timedelta(days=1)
+
+    # DB has previous session's row → fresh
+    rows_prev = [_make_row("005930", "KRX", prev_session, 70000.0)]
+    with patch(
+        "app.services.daily_candles.read_service.latest_exchange_session",
+        return_value=prev_session.date(),
+    ):
+        assert cache_is_fresh_equity(rows_prev, "XKRX") is True
+
+    # DB has a row from 2 days ago → stale (one session behind)
+    rows_stale = [_make_row("005930", "KRX", prev_session - timedelta(days=1), 70000.0)]
+    with patch(
+        "app.services.daily_candles.read_service.latest_exchange_session",
+        return_value=prev_session.date(),
+    ):
+        assert cache_is_fresh_equity(rows_stale, "XKRX") is False

--- a/tests/test_market_data_service.py
+++ b/tests/test_market_data_service.py
@@ -204,6 +204,12 @@ async def test_get_ohlcv_us_day_uses_yahoo(
     )
     fetch_mock = AsyncMock(return_value=frame)
     monkeypatch.setattr(market_data_service, "fetch_yahoo_ohlcv", fetch_mock)
+    # ROB-639: day is DB-first now — patch the DB seam so this test stays a
+    # pure Yahoo-path test and never touches the shared test DB.
+    monkeypatch.setattr(
+        market_data_service, "cache_first_us", AsyncMock(return_value=None)
+    )
+    monkeypatch.setattr(market_data_service, "write_back_us", AsyncMock(return_value=0))
 
     candles = await market_data_service.get_ohlcv(
         symbol="AAPL",
@@ -1499,6 +1505,12 @@ async def test_get_ohlcv_us_day_uses_toss_when_yahoo_fails(monkeypatch):
     )
     toss_mock = AsyncMock(return_value=toss_df)
     monkeypatch.setattr(market_data_service, "fetch_daily_toss_frame", toss_mock)
+    # ROB-639: day is DB-first now — patch the DB seam so this test stays a
+    # pure Toss-fallback test and never touches the shared test DB.
+    monkeypatch.setattr(
+        market_data_service, "cache_first_us", AsyncMock(return_value=None)
+    )
+    monkeypatch.setattr(market_data_service, "write_back_us", AsyncMock(return_value=0))
 
     candles = await market_data_service.get_ohlcv("AAPL", "us", "day", count=5)
 


### PR DESCRIPTION
## 개요

`get_ohlcv(period='day')`가 `kr_candles_1d` / `us_candles_1d`에서 먼저 읽고, miss/stale 시 KIS/Yahoo live API fallback. 15:35 KRX 컷오프 보존.

## 변경 사항

- 신규 `app/services/daily_candles/read_service.py`: `cache_first_kr` / `cache_first_us` + `cache_is_fresh_equity` 추출 (market_data_indicators에서 공유)
- `app/services/market_data/service.py::get_ohlcv` day 경로 DB-first 전환
- `market_data_indicators`의 기존 호출자 호환 유지
- week/month는 v1에서 live 유지 (요청 외)
- 20 테스트 통과

## 마이그레이션

없음.

## 모델 레인

`keep_on_gpt54`