### PR TITLE
feat(ROB-640): wire foreign_holding_rate into investor_flow_snapshots

### DIFF
--- a/app/jobs/investor_flow_snapshots.py
+++ b/app/jobs/investor_flow_snapshots.py
@@ -6,6 +6,7 @@ import datetime as dt
 import logging
 from collections import Counter
 from dataclasses import dataclass, field
+from decimal import Decimal
 
 import sqlalchemy as sa
 
@@ -44,6 +45,12 @@ class InvestorFlowSnapshotSample:
     individual_net: int | None
     double_buy: bool
     double_sell: bool
+    # ROB-640 market fields so dry-run approval packets show the wired values.
+    close: Decimal | None = None
+    change_rate: Decimal | None = None  # percent, e.g. 1.5 for 1.5%
+    volume: int | None = None
+    foreign_holding_shares: int | None = None
+    foreign_holding_rate: Decimal | None = None  # percent 0-100
 
 
 @dataclass(frozen=True)
@@ -189,6 +196,11 @@ def _sample(payload: InvestorFlowSnapshotUpsert) -> InvestorFlowSnapshotSample:
         individual_net=payload.individual_net,
         double_buy=_double_buy(payload),
         double_sell=_double_sell(payload),
+        close=payload.close,
+        change_rate=payload.change_rate,
+        volume=payload.volume,
+        foreign_holding_shares=payload.foreign_holding_shares,
+        foreign_holding_rate=payload.foreign_holding_rate,
     )
 
 

--- a/app/models/investor_flow_snapshot.py
+++ b/app/models/investor_flow_snapshot.py
@@ -80,6 +80,7 @@ class InvestorFlowSnapshot(Base):
 
     # ROB-575 market fields (wired in ROB-640):
     close: Mapped[Decimal | None] = mapped_column(Numeric(20, 6), nullable=True)
+    # change_rate is stored as a percent (e.g. 1.5 for 1.5%)
     change_rate: Mapped[Decimal | None] = mapped_column(Numeric(10, 4), nullable=True)
     volume: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
     foreign_holding_shares: Mapped[int | None] = mapped_column(

--- a/app/models/investor_flow_snapshot.py
+++ b/app/models/investor_flow_snapshot.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import date, datetime
+from decimal import Decimal
 
 from sqlalchemy import (
     TIMESTAMP,
@@ -10,6 +11,7 @@ from sqlalchemy import (
     Date,
     Index,
     Integer,
+    Numeric,
     String,
     UniqueConstraint,
     func,
@@ -75,6 +77,17 @@ class InvestorFlowSnapshot(Base):
 
     double_buy: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
     double_sell: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+
+    # ROB-575 market fields (wired in ROB-640):
+    close: Mapped[Decimal | None] = mapped_column(Numeric(20, 6), nullable=True)
+    change_rate: Mapped[Decimal | None] = mapped_column(Numeric(10, 4), nullable=True)
+    volume: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
+    foreign_holding_shares: Mapped[int | None] = mapped_column(
+        BigInteger, nullable=True
+    )
+    foreign_holding_rate: Mapped[Decimal | None] = mapped_column(
+        Numeric(10, 4), nullable=True
+    )
 
     foreign_consecutive_buy_days: Mapped[int | None] = mapped_column(
         Integer, nullable=True

--- a/app/services/investor_flow_snapshots/builder.py
+++ b/app/services/investor_flow_snapshots/builder.py
@@ -237,6 +237,10 @@ async def build_investor_flow_snapshots(
                 individual_net = _derive_individual(foreign_net, institution_net)
             close = row.get("close")
             change_rate = row.get("change_pct")
+            if change_rate is not None:
+                # Naver fetcher returns change_pct as a fraction (e.g., 0.015 for 1.5%).
+                # Multiply by 100 to store as a percent (e.g., 1.5).
+                change_rate = change_rate * 100
             volume = _int_or_none(row.get("volume"))
             foreign_holding_shares = _int_or_none(row.get("foreign_holding_shares"))
             foreign_holding_rate = row.get("foreign_holding_rate")

--- a/app/services/investor_flow_snapshots/builder.py
+++ b/app/services/investor_flow_snapshots/builder.py
@@ -235,6 +235,11 @@ async def build_investor_flow_snapshots(
             individual_net = _int_or_none(row.get("individual_net"))
             if individual_net is None:
                 individual_net = _derive_individual(foreign_net, institution_net)
+            close = row.get("close")
+            change_rate = row.get("change_pct")
+            volume = _int_or_none(row.get("volume"))
+            foreign_holding_shares = _int_or_none(row.get("foreign_holding_shares"))
+            foreign_holding_rate = row.get("foreign_holding_rate")
             built.append(
                 InvestorFlowSnapshotUpsert(
                     market="kr",
@@ -243,6 +248,11 @@ async def build_investor_flow_snapshots(
                     foreign_net=foreign_net,
                     institution_net=institution_net,
                     individual_net=individual_net,
+                    close=close,
+                    change_rate=change_rate,
+                    volume=volume,
+                    foreign_holding_shares=foreign_holding_shares,
+                    foreign_holding_rate=foreign_holding_rate,
                     source="naver_finance",
                     collected_at=collected_at,
                 )

--- a/app/services/investor_flow_snapshots/repository.py
+++ b/app/services/investor_flow_snapshots/repository.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import datetime as dt
 from collections.abc import Iterable
+from decimal import Decimal
 
 from pydantic import BaseModel, ConfigDict
 from sqlalchemy import func, select
@@ -26,6 +27,12 @@ class InvestorFlowSnapshotUpsert(BaseModel):
     institution_net_sell_rank: int | None = None
     double_buy: bool | None = None
     double_sell: bool | None = None
+    # ROB-575 market fields (wired in ROB-640):
+    close: Decimal | None = None
+    change_rate: Decimal | None = None
+    volume: int | None = None
+    foreign_holding_shares: int | None = None
+    foreign_holding_rate: Decimal | None = None
     foreign_consecutive_buy_days: int | None = None
     foreign_consecutive_sell_days: int | None = None
     institution_consecutive_buy_days: int | None = None

--- a/app/services/investor_flow_snapshots/repository.py
+++ b/app/services/investor_flow_snapshots/repository.py
@@ -29,6 +29,7 @@ class InvestorFlowSnapshotUpsert(BaseModel):
     double_sell: bool | None = None
     # ROB-575 market fields (wired in ROB-640):
     close: Decimal | None = None
+    # change_rate is stored as a percent (e.g. 1.5 for 1.5%)
     change_rate: Decimal | None = None
     volume: int | None = None
     foreign_holding_shares: int | None = None

--- a/tests/test_investor_flow_snapshot_fields.py
+++ b/tests/test_investor_flow_snapshot_fields.py
@@ -1,0 +1,196 @@
+"""ROB-640: verify the 5 ROB-575 market fields are wired through the upsert
+schema, the builder Naver mapping, and the repository ON CONFLICT path."""
+
+from __future__ import annotations
+
+import datetime as dt
+from decimal import Decimal
+
+import pytest
+from pydantic import ValidationError
+from sqlalchemy.dialects import postgresql
+from sqlalchemy.dialects.postgresql import insert
+
+from app.models.investor_flow_snapshot import InvestorFlowSnapshot
+from app.services.investor_flow_snapshots.builder import (
+    build_investor_flow_snapshots,
+)
+from app.services.investor_flow_snapshots.repository import (
+    InvestorFlowSnapshotUpsert,
+    _with_derived_flags,
+)
+
+_NEW_FIELDS = ("close", "change_rate", "volume", "foreign_holding_shares",
+               "foreign_holding_rate")
+
+
+@pytest.mark.unit
+def test_upsert_schema_accepts_five_new_fields():
+    payload = InvestorFlowSnapshotUpsert(
+        market="kr",
+        symbol="005930",
+        snapshot_date=dt.date(2026, 7, 1),
+        source="naver_finance",
+        close=Decimal("70000"),
+        change_rate=Decimal("1.5"),
+        volume=12_345_678,
+        foreign_holding_shares=1_234_567,
+        foreign_holding_rate=Decimal("8.5"),
+    )
+    assert payload.close == Decimal("70000")
+    assert payload.change_rate == Decimal("1.5")
+    assert payload.volume == 12_345_678
+    assert payload.foreign_holding_shares == 1_234_567
+    assert payload.foreign_holding_rate == Decimal("8.5")
+
+
+@pytest.mark.unit
+def test_upsert_schema_new_fields_default_to_none():
+    payload = InvestorFlowSnapshotUpsert(
+        market="kr",
+        symbol="005930",
+        snapshot_date=dt.date(2026, 7, 1),
+        source="naver_finance",
+    )
+    assert payload.close is None
+    assert payload.change_rate is None
+    assert payload.volume is None
+    assert payload.foreign_holding_shares is None
+    assert payload.foreign_holding_rate is None
+
+
+@pytest.mark.unit
+def test_upsert_schema_rejects_unknown_field():
+    with pytest.raises(ValidationError):
+        InvestorFlowSnapshotUpsert(
+            market="kr",
+            symbol="005930",
+            snapshot_date=dt.date(2026, 7, 1),
+            source="naver_finance",
+            unknown_column=42,  # type: ignore[call-arg]
+        )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_builder_maps_naver_fields_to_upsert_payloads():
+    async def fetcher(symbol: str, days: int):
+        return {
+            "symbol": symbol,
+            "data": [
+                {
+                    "date": "2026-07-01",
+                    "close": 70000.0,
+                    "change_pct": 1.5,
+                    "volume": 12_345_678,
+                    "institutional_net": 200,
+                    "foreign_net": 300,
+                    "foreign_holding_shares": 1_234_567,
+                    "foreign_holding_rate": 8.5,
+                },
+            ],
+        }
+
+    result = await build_investor_flow_snapshots(
+        symbols=["005930"],
+        days=1,
+        fetcher=fetcher,
+    )
+
+    assert len(result.payloads) == 1
+    payload = result.payloads[0]
+    assert payload.close == Decimal("70000")
+    assert payload.change_rate == Decimal("1.5")
+    assert payload.volume == 12_345_678
+    assert payload.foreign_holding_shares == 1_234_567
+    assert payload.foreign_holding_rate == Decimal("8.5")
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_builder_handles_missing_naver_market_fields():
+    """Legacy 7-cell Naver rows may omit close/volume/holding fields."""
+
+    async def fetcher(symbol: str, days: int):
+        return {
+            "symbol": symbol,
+            "data": [
+                {
+                    "date": "2026-07-01",
+                    "foreign_net": 300,
+                    "institutional_net": 200,
+                },
+            ],
+        }
+
+    result = await build_investor_flow_snapshots(
+        symbols=["005930"],
+        days=1,
+        fetcher=fetcher,
+    )
+
+    assert len(result.payloads) == 1
+    payload = result.payloads[0]
+    assert payload.close is None
+    assert payload.change_rate is None
+    assert payload.volume is None
+    assert payload.foreign_holding_shares is None
+    assert payload.foreign_holding_rate is None
+
+
+@pytest.mark.unit
+def test_upsert_insert_includes_five_fields():
+    payload = InvestorFlowSnapshotUpsert(
+        market="kr",
+        symbol="005930",
+        snapshot_date=dt.date(2026, 7, 1),
+        source="naver_finance",
+        foreign_net=300,
+        institution_net=200,
+        individual_net=-500,
+        close=Decimal("70000"),
+        change_rate=Decimal("1.5"),
+        volume=12_345_678,
+        foreign_holding_shares=1_234_567,
+        foreign_holding_rate=Decimal("8.5"),
+    )
+    values = _with_derived_flags(payload)
+    stmt = insert(InvestorFlowSnapshot).values(**values)
+    sql_text = str(stmt.compile(dialect=postgresql.dialect()))
+
+    for col in _NEW_FIELDS:
+        assert col in sql_text, f"INSERT missing column: {col}"
+
+
+@pytest.mark.unit
+def test_upsert_on_conflict_includes_five_fields():
+    payload = InvestorFlowSnapshotUpsert(
+        market="kr",
+        symbol="005930",
+        snapshot_date=dt.date(2026, 7, 1),
+        source="naver_finance",
+        foreign_net=300,
+        institution_net=200,
+        individual_net=-500,
+        close=Decimal("70000"),
+        change_rate=Decimal("1.5"),
+        volume=12_345_678,
+        foreign_holding_shares=1_234_567,
+        foreign_holding_rate=Decimal("8.5"),
+    )
+    values = _with_derived_flags(payload)
+    stmt = insert(InvestorFlowSnapshot).values(**values)
+    stmt = stmt.on_conflict_do_update(
+        constraint="uq_investor_flow_snapshots_market_symbol_date_source",
+        set_={
+            key: stmt.excluded[key]
+            for key in values
+            if key not in {"market", "symbol", "snapshot_date", "source"}
+        },
+    )
+
+    sql_text = str(stmt.compile(dialect=postgresql.dialect()))
+    assert "ON CONFLICT" in sql_text
+    assert "DO UPDATE SET" in sql_text
+    for col in _NEW_FIELDS:
+        assert col in sql_text, f"ON CONFLICT SET missing column: {col}"

--- a/tests/test_investor_flow_snapshot_fields.py
+++ b/tests/test_investor_flow_snapshot_fields.py
@@ -20,8 +20,13 @@ from app.services.investor_flow_snapshots.repository import (
     _with_derived_flags,
 )
 
-_NEW_FIELDS = ("close", "change_rate", "volume", "foreign_holding_shares",
-               "foreign_holding_rate")
+_NEW_FIELDS = (
+    "close",
+    "change_rate",
+    "volume",
+    "foreign_holding_shares",
+    "foreign_holding_rate",
+)
 
 
 @pytest.mark.unit
@@ -81,7 +86,7 @@ async def test_builder_maps_naver_fields_to_upsert_payloads():
                 {
                     "date": "2026-07-01",
                     "close": 70000.0,
-                    "change_pct": 1.5,
+                    "change_pct": 0.015,
                     "volume": 12_345_678,
                     "institutional_net": 200,
                     "foreign_net": 300,
@@ -104,6 +109,59 @@ async def test_builder_maps_naver_fields_to_upsert_payloads():
     assert payload.volume == 12_345_678
     assert payload.foreign_holding_shares == 1_234_567
     assert payload.foreign_holding_rate == Decimal("8.5")
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_builder_integration_with_html_fixture(monkeypatch: pytest.MonkeyPatch):
+    from bs4 import BeautifulSoup
+
+    sample_html = """
+    <html>
+    <body>
+    <table class="type2">
+        <tbody><tr><td></td></tr></tbody>
+    </table>
+    <table class="type2">
+        <tr>
+            <td>2026.07.01</td>
+            <td>75,000</td>
+            <td>▲500</td>
+            <td>+0.67%</td>
+            <td>10,000,000</td>
+            <td>1,000,000</td>
+            <td>-500,000</td>
+            <td>2,790,424,635</td>
+            <td>47.73%</td>
+        </tr>
+    </table>
+    </body>
+    </html>
+    """
+
+    async def mock_fetch_html(*args, **kwargs):
+        return BeautifulSoup(sample_html, "lxml")
+
+    monkeypatch.setattr(
+        "app.services.naver_finance.investor._fetch_html", mock_fetch_html
+    )
+
+    result = await build_investor_flow_snapshots(
+        symbols=["005930"],
+        days=1,
+    )
+
+    assert len(result.payloads) == 1
+    payload = result.payloads[0]
+    assert payload.snapshot_date == dt.date(2026, 7, 1)
+    assert payload.close == Decimal("75000")
+    # 0.0067 (fraction parsed from +0.67%) multiplied by 100 is 0.67
+    assert payload.change_rate == pytest.approx(Decimal("0.67"))
+    assert payload.volume == 10_000_000
+    assert payload.foreign_net == -500_000
+    assert payload.institution_net == 1_000_000
+    assert payload.foreign_holding_shares == 2_790_424_635
+    assert payload.foreign_holding_rate == pytest.approx(Decimal("47.73"))
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## 개요

ROB-575 마이그레이션이 이미 `foreign_holding_rate`, `foreign_holding_shares`, `close`, `change_rate`, `volume` 5개 컬럼을 추가했지만, Pydantic 스키마/builder/repository가 사용하지 않음. 이 PR은 wiring만 수행.

## 변경 사항

- `InvestorFlowSnapshotUpsert`에 5개 필드 추가 (모두 optional, Naver 미제공 시 None)
- Builder에서 Naver 9-cell row → upsert 페이로드 매핑
- Repository `upsert()`의 INSERT/ON CONFLICT DO UPDATE가 values dict에서 자동 구성되므로 별도 변경 불필요
- ORM 모델에 5개 컬럼 매핑 추가 (migration은 이미 존재하지만 ORM 매핑 누락이었음)

## 마이그레이션

없음. ROB-575가 이미 적용 완료.

## 동기화 노트

- 마이그레이션 없음 → 637/638/639/641과 완전 병렬 가능
- 빌더 스케줄 가동은 운영자가 `investor_flow_schedule_enabled` + `investor_flow_snapshots_commit_enabled` flip으로 활성화 (inert-safe)

## 모델 레인

`keep_on_gpt54`