### PR TITLE
feat(ROB-641): analyst_consensus_snapshots — consensus/target price history

### DIFF
--- a/alembic/versions/20260702_rob641_analyst_consensus_snapshots.py
+++ b/alembic/versions/20260702_rob641_analyst_consensus_snapshots.py
@@ -6,8 +6,9 @@ Create Date: 2026-07-02
 
 New snapshot table for analyst consensus data (buy/hold/sell counts, target
 prices). Clones the market_quote_snapshots / market_valuation_snapshots pattern
-but lives in the ``review`` schema and keys on ``snapshot_date``.
-KR source: naver_finance. US source: yfinance.
+(``public`` schema, like all sibling snapshot tables) and keys on
+``snapshot_date`` (market-local calendar date: kr → Asia/Seoul,
+us → America/New_York). KR source: naver_finance. US source: yfinance.
 """
 
 from __future__ import annotations
@@ -76,19 +77,16 @@ def upgrade() -> None:
             "source",
             name="uq_analyst_consensus_snapshots_market_symbol_date_source",
         ),
-        schema="review",
     )
     op.create_index(
         "ix_analyst_consensus_snapshots_market_symbol_date",
         "analyst_consensus_snapshots",
         ["market", "symbol", sa.text("snapshot_date DESC")],
-        schema="review",
     )
     op.create_index(
         "ix_analyst_consensus_snapshots_market_date",
         "analyst_consensus_snapshots",
         ["market", sa.text("snapshot_date DESC")],
-        schema="review",
     )
 
 
@@ -96,11 +94,9 @@ def downgrade() -> None:
     op.drop_index(
         "ix_analyst_consensus_snapshots_market_date",
         table_name="analyst_consensus_snapshots",
-        schema="review",
     )
     op.drop_index(
         "ix_analyst_consensus_snapshots_market_symbol_date",
         table_name="analyst_consensus_snapshots",
-        schema="review",
     )
-    op.drop_table("analyst_consensus_snapshots", schema="review")
+    op.drop_table("analyst_consensus_snapshots")

--- a/alembic/versions/20260702_rob641_analyst_consensus_snapshots.py
+++ b/alembic/versions/20260702_rob641_analyst_consensus_snapshots.py
@@ -1,0 +1,106 @@
+"""add analyst_consensus_snapshots (ROB-641)
+
+Revision ID: 20260702_rob641
+Revises: 20260620_scalp_benchmark
+Create Date: 2026-07-02
+
+New snapshot table for analyst consensus data (buy/hold/sell counts, target
+prices). Clones the market_quote_snapshots / market_valuation_snapshots pattern
+but lives in the ``review`` schema and keys on ``snapshot_date``.
+KR source: naver_finance. US source: yfinance.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "20260702_rob641"
+down_revision: str | Sequence[str] | None = "20260620_scalp_benchmark"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "analyst_consensus_snapshots",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("market", sa.Text(), nullable=False),
+        sa.Column("symbol", sa.Text(), nullable=False),
+        sa.Column("source", sa.Text(), nullable=False),
+        sa.Column("snapshot_date", sa.Date(), nullable=False),
+        sa.Column("buy_count", sa.Integer(), nullable=True),
+        sa.Column("hold_count", sa.Integer(), nullable=True),
+        sa.Column("sell_count", sa.Integer(), nullable=True),
+        sa.Column("strong_buy_count", sa.Integer(), nullable=True),
+        sa.Column("total_count", sa.Integer(), nullable=True),
+        sa.Column("target_mean", sa.Numeric(20, 4), nullable=True),
+        sa.Column("target_median", sa.Numeric(20, 4), nullable=True),
+        sa.Column("target_high", sa.Numeric(20, 4), nullable=True),
+        sa.Column("target_low", sa.Numeric(20, 4), nullable=True),
+        sa.Column("upside_pct", sa.Numeric(10, 4), nullable=True),
+        sa.Column("analyst_count", sa.Integer(), nullable=True),
+        sa.Column("newest_opinion_date", sa.Date(), nullable=True),
+        sa.Column("current_price", sa.Numeric(20, 4), nullable=True),
+        sa.Column(
+            "raw_payload", postgresql.JSONB(astext_type=sa.Text()), nullable=True
+        ),
+        sa.Column(
+            "collected_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.CheckConstraint(
+            "market IN ('kr', 'us')", name="ck_analyst_consensus_snapshots_market"
+        ),
+        sa.CheckConstraint(
+            "source IN ('naver_finance', 'yfinance')",
+            name="ck_analyst_consensus_snapshots_source",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "market",
+            "symbol",
+            "snapshot_date",
+            "source",
+            name="uq_analyst_consensus_snapshots_market_symbol_date_source",
+        ),
+        schema="review",
+    )
+    op.create_index(
+        "ix_analyst_consensus_snapshots_market_symbol_date",
+        "analyst_consensus_snapshots",
+        ["market", "symbol", sa.text("snapshot_date DESC")],
+        schema="review",
+    )
+    op.create_index(
+        "ix_analyst_consensus_snapshots_market_date",
+        "analyst_consensus_snapshots",
+        ["market", sa.text("snapshot_date DESC")],
+        schema="review",
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_analyst_consensus_snapshots_market_date",
+        table_name="analyst_consensus_snapshots",
+        schema="review",
+    )
+    op.drop_index(
+        "ix_analyst_consensus_snapshots_market_symbol_date",
+        table_name="analyst_consensus_snapshots",
+        schema="review",
+    )
+    op.drop_table("analyst_consensus_snapshots", schema="review")

--- a/app/jobs/analyst_consensus_snapshots.py
+++ b/app/jobs/analyst_consensus_snapshots.py
@@ -11,22 +11,26 @@ from decimal import Decimal
 import sqlalchemy as sa
 
 from app.core.db import AsyncSessionLocal
+from app.core.symbol import to_db_symbol
 from app.models.analyst_consensus_snapshot import AnalystConsensusSnapshot
 from app.services.analyst_consensus_snapshots.builder import build_consensus_snapshots
 from app.services.analyst_consensus_snapshots.repository import (
     AnalystConsensusSnapshotsRepository,
     AnalystConsensusSnapshotUpsert,
 )
+from app.services.candles_sync_common import build_symbol_union
 
 logger = logging.getLogger(__name__)
+
+_WATCH_ALERTS_LIMIT = 500
+_DEFAULT_USER_ID = 1
 
 
 @dataclass(frozen=True)
 class AnalystConsensusSnapshotBuildRequest:
     market: str = "kr"
     symbols: tuple[str, ...] = ()
-    limit: int | None = 20
-    all_symbols: bool = False
+    limit: int | None = None
     batch_size: int = 100
     concurrency: int = 4
     commit: bool = False
@@ -67,57 +71,108 @@ def _validate_market(market: str) -> str:
 
 
 def _normalize_symbol(symbol: str) -> str:
-    return symbol.strip().upper()
+    return to_db_symbol(symbol.strip().upper())
 
 
-async def resolve_symbols(market: str, override: list[str], limit: int) -> list[str]:
+def _normalize_kr_holding_symbol(value: object) -> str | None:
+    """KR holdings/watch symbol → 6-digit code (kr_candles_sync sibling)."""
+    text_value = str(value or "").strip().upper()
+    if not text_value:
+        return None
+    if len(text_value) < 6:
+        text_value = text_value.zfill(6)
+    if len(text_value) == 6 and text_value.isalnum():
+        return text_value
+    return None
+
+
+def _normalize_us_holding_symbol(value: object) -> str | None:
+    """US holdings/watch symbol → DB dot format (us_candles_sync sibling)."""
+    normalized = to_db_symbol(str(value or "").strip().upper())
+    return normalized or None
+
+
+async def _fetch_kis_holdings(market: str) -> list[object]:
+    """Live KIS holdings read (kr/us_candles_sync sibling pattern)."""
+    from app.services.brokers.kis.client import KISClient
+
+    kis = KISClient()
+    if market == "kr":
+        return list(await kis.fetch_my_stocks())
+    return list(await kis.fetch_my_us_stocks())
+
+
+async def _fetch_manual_holdings(market: str, user_id: int) -> list[object]:
+    from app.models.manual_holdings import MarketType
+    from app.services.manual_holdings_service import ManualHoldingsService
+
+    market_type = MarketType.KR if market == "kr" else MarketType.US
+    async with AsyncSessionLocal() as session:
+        return list(
+            await ManualHoldingsService(session).get_holdings_by_user(
+                user_id=user_id,
+                market_type=market_type,
+            )
+        )
+
+
+async def _fetch_active_watch_symbols(market: str) -> list[str]:
+    """Active asset-kind investment_watch_alerts symbols for the market."""
+    from app.services.investment_reports.repository import InvestmentReportsRepository
+
+    async with AsyncSessionLocal() as session:
+        alerts = await InvestmentReportsRepository(session).list_active_alerts(
+            market=market,
+            valid_at=dt.datetime.now(dt.UTC),
+            limit=_WATCH_ALERTS_LIMIT,
+        )
+    return [
+        alert.symbol
+        for alert in alerts
+        if getattr(alert, "target_kind", "asset") == "asset"
+    ]
+
+
+async def _resolve_holdings_and_watch_symbols(
+    market: str, *, user_id: int = _DEFAULT_USER_ID
+) -> set[str]:
+    """Default snapshot scope: holdings ∪ active watch (ROB-641).
+
+    Holdings = live KIS holdings ∪ manual holdings (candles-sync sibling
+    pattern); watch = active ``investment_watch_alerts`` asset symbols. The
+    alphabetical top-N universe scan (and the full-universe option) was
+    removed: consensus fetches are ~12 HTTP requests per symbol, so scope is
+    restricted to symbols the operator actually holds or watches.
+    """
+    normalize = (
+        _normalize_kr_holding_symbol if market == "kr" else _normalize_us_holding_symbol
+    )
+    holdings_field = "pdno" if market == "kr" else "ovrs_pdno"
+    kis_holdings = await _fetch_kis_holdings(market)
+    manual_holdings = await _fetch_manual_holdings(market, user_id)
+    symbols = build_symbol_union(
+        kis_holdings,
+        manual_holdings,
+        holdings_field=holdings_field,
+        normalize_fn=normalize,
+    )
+    for raw_symbol in await _fetch_active_watch_symbols(market):
+        normalized = normalize(raw_symbol)
+        if normalized is not None:
+            symbols.add(normalized)
+    return symbols
+
+
+async def resolve_symbols(
+    market: str, override: list[str], limit: int | None = None
+) -> list[str]:
     market_norm = _validate_market(market)
     if override:
         return [_normalize_symbol(symbol) for symbol in override if symbol.strip()]
-    async with AsyncSessionLocal() as session:
-        if market_norm == "kr":
-            from app.models.kr_symbol_universe import KRSymbolUniverse
-
-            stmt = (
-                sa.select(KRSymbolUniverse.symbol)
-                .where(KRSymbolUniverse.is_active.is_(True))
-                .order_by(KRSymbolUniverse.symbol)
-                .limit(limit)
-            )
-        else:
-            from app.models.us_symbol_universe import USSymbolUniverse
-
-            stmt = (
-                sa.select(USSymbolUniverse.symbol)
-                .where(USSymbolUniverse.is_active.is_(True))
-                .order_by(USSymbolUniverse.symbol)
-                .limit(limit)
-            )
-        result = await session.execute(stmt)
-        return [r[0] for r in result.all()]
-
-
-async def resolve_active_universe(market: str) -> list[str]:
-    market_norm = _validate_market(market)
-    async with AsyncSessionLocal() as session:
-        if market_norm == "kr":
-            from app.models.kr_symbol_universe import KRSymbolUniverse
-
-            stmt = (
-                sa.select(KRSymbolUniverse.symbol)
-                .where(KRSymbolUniverse.is_active.is_(True))
-                .order_by(KRSymbolUniverse.symbol)
-            )
-        else:
-            from app.models.us_symbol_universe import USSymbolUniverse
-
-            stmt = (
-                sa.select(USSymbolUniverse.symbol)
-                .where(USSymbolUniverse.is_active.is_(True))
-                .order_by(USSymbolUniverse.symbol)
-            )
-        result = await session.execute(stmt)
-        return [r[0] for r in result.all()]
+    symbols = sorted(await _resolve_holdings_and_watch_symbols(market_norm))
+    if limit is not None:
+        symbols = symbols[: max(0, limit)]
+    return symbols
 
 
 def _payload_key(
@@ -194,11 +249,7 @@ async def run_analyst_consensus_snapshot_build(
 ) -> AnalystConsensusSnapshotBuildResult:
     market = _validate_market(request.market)
     started_at = request.now or dt.datetime.now(dt.UTC)
-    symbols = await (
-        resolve_active_universe(market)
-        if request.all_symbols
-        else resolve_symbols(market, list(request.symbols), request.limit or 20)
-    )
+    symbols = await resolve_symbols(market, list(request.symbols), request.limit)
     if not symbols:
         finished_at = dt.datetime.now(dt.UTC)
         return AnalystConsensusSnapshotBuildResult(
@@ -216,9 +267,7 @@ async def run_analyst_consensus_snapshot_build(
             },
             warnings=("no symbols resolved",),
         )
-    effective_batch_size = max(
-        1, request.batch_size if request.all_symbols else len(symbols)
-    )
+    effective_batch_size = max(1, request.batch_size)
     idempotency = Counter(
         {"wouldInsert": 0, "wouldUpdate": 0, "duplicatePayloadKeys": 0}
     )

--- a/app/jobs/analyst_consensus_snapshots.py
+++ b/app/jobs/analyst_consensus_snapshots.py
@@ -1,0 +1,259 @@
+"""Dry-run-first job runner for analyst_consensus_snapshots rows (ROB-641)."""
+
+from __future__ import annotations
+
+import datetime as dt
+import logging
+from collections import Counter
+from dataclasses import dataclass, field
+from decimal import Decimal
+
+import sqlalchemy as sa
+
+from app.core.db import AsyncSessionLocal
+from app.models.analyst_consensus_snapshot import AnalystConsensusSnapshot
+from app.services.analyst_consensus_snapshots.builder import build_consensus_snapshots
+from app.services.analyst_consensus_snapshots.repository import (
+    AnalystConsensusSnapshotsRepository,
+    AnalystConsensusSnapshotUpsert,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class AnalystConsensusSnapshotBuildRequest:
+    market: str = "kr"
+    symbols: tuple[str, ...] = ()
+    limit: int | None = 20
+    all_symbols: bool = False
+    batch_size: int = 100
+    concurrency: int = 4
+    commit: bool = False
+    now: dt.datetime | None = None
+
+
+@dataclass(frozen=True)
+class AnalystConsensusSnapshotSample:
+    market: str
+    symbol: str
+    source: str
+    snapshot_date: dt.date
+    total_count: int | None
+    target_mean: Decimal | None
+    current_price: Decimal | None
+
+
+@dataclass(frozen=True)
+class AnalystConsensusSnapshotBuildResult:
+    market: str
+    symbols_resolved: int
+    snapshots_built: int
+    committed: bool
+    batches: int
+    started_at: dt.datetime
+    finished_at: dt.datetime
+    snapshot_date_distribution: dict[str, int] = field(default_factory=dict)
+    idempotency: dict[str, int] = field(default_factory=dict)
+    samples: tuple[AnalystConsensusSnapshotSample, ...] = ()
+    warnings: tuple[str, ...] = ()
+
+
+def _validate_market(market: str) -> str:
+    market_norm = market.strip().lower()
+    if market_norm not in {"kr", "us"}:
+        raise ValueError(f"Unsupported consensus snapshot market: {market}")
+    return market_norm
+
+
+def _normalize_symbol(symbol: str) -> str:
+    return symbol.strip().upper()
+
+
+async def resolve_symbols(market: str, override: list[str], limit: int) -> list[str]:
+    market_norm = _validate_market(market)
+    if override:
+        return [_normalize_symbol(symbol) for symbol in override if symbol.strip()]
+    async with AsyncSessionLocal() as session:
+        if market_norm == "kr":
+            from app.models.kr_symbol_universe import KRSymbolUniverse
+
+            stmt = (
+                sa.select(KRSymbolUniverse.symbol)
+                .where(KRSymbolUniverse.is_active.is_(True))
+                .order_by(KRSymbolUniverse.symbol)
+                .limit(limit)
+            )
+        else:
+            from app.models.us_symbol_universe import USSymbolUniverse
+
+            stmt = (
+                sa.select(USSymbolUniverse.symbol)
+                .where(USSymbolUniverse.is_active.is_(True))
+                .order_by(USSymbolUniverse.symbol)
+                .limit(limit)
+            )
+        result = await session.execute(stmt)
+        return [r[0] for r in result.all()]
+
+
+async def resolve_active_universe(market: str) -> list[str]:
+    market_norm = _validate_market(market)
+    async with AsyncSessionLocal() as session:
+        if market_norm == "kr":
+            from app.models.kr_symbol_universe import KRSymbolUniverse
+
+            stmt = (
+                sa.select(KRSymbolUniverse.symbol)
+                .where(KRSymbolUniverse.is_active.is_(True))
+                .order_by(KRSymbolUniverse.symbol)
+            )
+        else:
+            from app.models.us_symbol_universe import USSymbolUniverse
+
+            stmt = (
+                sa.select(USSymbolUniverse.symbol)
+                .where(USSymbolUniverse.is_active.is_(True))
+                .order_by(USSymbolUniverse.symbol)
+            )
+        result = await session.execute(stmt)
+        return [r[0] for r in result.all()]
+
+
+def _payload_key(
+    payload: AnalystConsensusSnapshotUpsert,
+) -> tuple[str, str, dt.date, str]:
+    return (
+        payload.market.strip().lower(),
+        _normalize_symbol(payload.symbol),
+        payload.snapshot_date,
+        payload.source.strip().lower(),
+    )
+
+
+async def _classify_idempotency(
+    payloads: list[AnalystConsensusSnapshotUpsert],
+) -> dict[str, int]:
+    keys = [_payload_key(payload) for payload in payloads]
+    duplicate_payload_keys = sum(
+        count - 1 for count in Counter(keys).values() if count > 1
+    )
+    unique_keys = set(keys)
+    if not unique_keys:
+        return {
+            "wouldInsert": 0,
+            "wouldUpdate": 0,
+            "duplicatePayloadKeys": duplicate_payload_keys,
+        }
+    conditions = [
+        sa.and_(
+            AnalystConsensusSnapshot.market == market,
+            AnalystConsensusSnapshot.symbol == symbol,
+            AnalystConsensusSnapshot.snapshot_date == snapshot_date,
+            AnalystConsensusSnapshot.source == source,
+        )
+        for market, symbol, snapshot_date, source in unique_keys
+    ]
+    async with AsyncSessionLocal() as session:
+        result = await session.execute(
+            sa.select(
+                AnalystConsensusSnapshot.market,
+                AnalystConsensusSnapshot.symbol,
+                AnalystConsensusSnapshot.snapshot_date,
+                AnalystConsensusSnapshot.source,
+            ).where(sa.or_(*conditions))
+        )
+        existing = set(result.all())
+    return {
+        "wouldInsert": len(unique_keys) - len(existing),
+        "wouldUpdate": len(existing),
+        "duplicatePayloadKeys": duplicate_payload_keys,
+    }
+
+
+async def _commit_payloads(payloads: list[AnalystConsensusSnapshotUpsert]) -> None:
+    async with AsyncSessionLocal() as session:
+        await AnalystConsensusSnapshotsRepository(session).upsert(payloads)
+        await session.commit()
+
+
+def _sample(payload: AnalystConsensusSnapshotUpsert) -> AnalystConsensusSnapshotSample:
+    return AnalystConsensusSnapshotSample(
+        market=payload.market,
+        symbol=payload.symbol,
+        source=payload.source,
+        snapshot_date=payload.snapshot_date,
+        total_count=payload.total_count,
+        target_mean=payload.target_mean,
+        current_price=payload.current_price,
+    )
+
+
+async def run_analyst_consensus_snapshot_build(
+    request: AnalystConsensusSnapshotBuildRequest,
+) -> AnalystConsensusSnapshotBuildResult:
+    market = _validate_market(request.market)
+    started_at = request.now or dt.datetime.now(dt.UTC)
+    symbols = await (
+        resolve_active_universe(market)
+        if request.all_symbols
+        else resolve_symbols(market, list(request.symbols), request.limit or 20)
+    )
+    if not symbols:
+        finished_at = dt.datetime.now(dt.UTC)
+        return AnalystConsensusSnapshotBuildResult(
+            market=market,
+            symbols_resolved=0,
+            snapshots_built=0,
+            committed=request.commit,
+            batches=0,
+            started_at=started_at,
+            finished_at=finished_at,
+            idempotency={
+                "wouldInsert": 0,
+                "wouldUpdate": 0,
+                "duplicatePayloadKeys": 0,
+            },
+            warnings=("no symbols resolved",),
+        )
+    effective_batch_size = max(
+        1, request.batch_size if request.all_symbols else len(symbols)
+    )
+    idempotency = Counter(
+        {"wouldInsert": 0, "wouldUpdate": 0, "duplicatePayloadKeys": 0}
+    )
+    distribution: Counter[str] = Counter()
+    samples: list[AnalystConsensusSnapshotSample] = []
+    warnings: list[str] = []
+    total_built = 0
+    batches = 0
+    for start in range(0, len(symbols), effective_batch_size):
+        batches += 1
+        result = await build_consensus_snapshots(
+            market=market,
+            symbols=symbols[start : start + effective_batch_size],
+            now=started_at,
+            concurrency=request.concurrency,
+        )
+        payloads = list(result.payloads)
+        warnings.extend(f"batch {batches}: {warning}" for warning in result.warnings)
+        total_built += len(payloads)
+        distribution.update(p.snapshot_date.isoformat() for p in payloads)
+        idempotency.update(await _classify_idempotency(payloads))
+        samples.extend(_sample(p) for p in payloads[: max(0, 10 - len(samples))])
+        if request.commit and payloads:
+            await _commit_payloads(payloads)
+    finished_at = dt.datetime.now(dt.UTC)
+    return AnalystConsensusSnapshotBuildResult(
+        market=market,
+        symbols_resolved=len(symbols),
+        snapshots_built=total_built,
+        committed=request.commit,
+        batches=batches,
+        started_at=started_at,
+        finished_at=finished_at,
+        snapshot_date_distribution=dict(sorted(distribution.items())),
+        idempotency=dict(idempotency),
+        samples=tuple(samples),
+        warnings=tuple(warnings),
+    )

--- a/app/mcp_server/tooling/fundamentals_sources_yfinance.py
+++ b/app/mcp_server/tooling/fundamentals_sources_yfinance.py
@@ -368,6 +368,14 @@ async def _fetch_investment_opinions_yfinance(
     if target_consensus is not None:
         consensus.update(target_consensus)
 
+    # ROB-641: surface Yahoo's analyst headcount so snapshot consumers can
+    # store a real analyst_count instead of duplicating total_count.
+    number_of_analyst_opinions = _normalize_yahoo_count(
+        (info or {}).get("numberOfAnalystOpinions")
+    )
+    if number_of_analyst_opinions is not None:
+        consensus["number_of_analyst_opinions"] = number_of_analyst_opinions
+
     result = {
         "instrument_type": "equity_us",
         "source": "yfinance",

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -1,5 +1,6 @@
 # app/models/__init__.py
 from .analysis import StockAnalysisResult, StockInfo
+from .analyst_consensus_snapshot import AnalystConsensusSnapshot
 from .base import Base
 from .binance_demo_order_ledger import BinanceDemoOrderLedger
 from .crypto_candles import CryptoCandle1d, CryptoCandle1m
@@ -119,6 +120,7 @@ from .user_settings import UserSetting
 
 __all__ = [
     "Base",
+    "AnalystConsensusSnapshot",
     "BinanceDemoOrderLedger",
     "ScalpTradeAnalytics",
     "ScalpingDailyReview",

--- a/app/models/analyst_consensus_snapshot.py
+++ b/app/models/analyst_consensus_snapshot.py
@@ -14,6 +14,7 @@ from sqlalchemy import (
     Text,
     UniqueConstraint,
     func,
+    text,
 )
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column
@@ -22,6 +23,17 @@ from app.models.base import Base
 
 
 class AnalystConsensusSnapshot(Base):
+    """Daily analyst consensus snapshot (ROB-641).
+
+    Lives in the ``public`` schema alongside the other snapshot tables
+    (``market_quote_snapshots``, ``market_valuation_snapshots``, ...).
+
+    ``snapshot_date`` convention: the market-local calendar date at build
+    time — ``Asia/Seoul`` for ``kr`` rows, ``America/New_York`` for ``us``
+    rows. A 00:30 KST build therefore records the KST date for KR, not the
+    previous UTC date.
+    """
+
     __tablename__ = "analyst_consensus_snapshots"
     __table_args__ = (
         UniqueConstraint(
@@ -42,14 +54,13 @@ class AnalystConsensusSnapshot(Base):
             "ix_analyst_consensus_snapshots_market_symbol_date",
             "market",
             "symbol",
-            "snapshot_date",
+            text("snapshot_date DESC"),
         ),
         Index(
             "ix_analyst_consensus_snapshots_market_date",
             "market",
-            "snapshot_date",
+            text("snapshot_date DESC"),
         ),
-        {"schema": "review"},
     )
 
     id: Mapped[int] = mapped_column(BigInteger, primary_key=True)

--- a/app/models/analyst_consensus_snapshot.py
+++ b/app/models/analyst_consensus_snapshot.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from datetime import date, datetime
+from decimal import Decimal
+
+from sqlalchemy import (
+    TIMESTAMP,
+    BigInteger,
+    CheckConstraint,
+    Date,
+    Index,
+    Integer,
+    Numeric,
+    Text,
+    UniqueConstraint,
+    func,
+)
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base
+
+
+class AnalystConsensusSnapshot(Base):
+    __tablename__ = "analyst_consensus_snapshots"
+    __table_args__ = (
+        UniqueConstraint(
+            "market",
+            "symbol",
+            "snapshot_date",
+            "source",
+            name="uq_analyst_consensus_snapshots_market_symbol_date_source",
+        ),
+        CheckConstraint(
+            "market IN ('kr', 'us')", name="ck_analyst_consensus_snapshots_market"
+        ),
+        CheckConstraint(
+            "source IN ('naver_finance', 'yfinance')",
+            name="ck_analyst_consensus_snapshots_source",
+        ),
+        Index(
+            "ix_analyst_consensus_snapshots_market_symbol_date",
+            "market",
+            "symbol",
+            "snapshot_date",
+        ),
+        Index(
+            "ix_analyst_consensus_snapshots_market_date",
+            "market",
+            "snapshot_date",
+        ),
+        {"schema": "review"},
+    )
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    market: Mapped[str] = mapped_column(Text, nullable=False)
+    symbol: Mapped[str] = mapped_column(Text, nullable=False)
+    source: Mapped[str] = mapped_column(Text, nullable=False)
+    snapshot_date: Mapped[date] = mapped_column(Date, nullable=False)
+    buy_count: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    hold_count: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    sell_count: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    strong_buy_count: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    total_count: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    target_mean: Mapped[Decimal | None] = mapped_column(Numeric(20, 4), nullable=True)
+    target_median: Mapped[Decimal | None] = mapped_column(Numeric(20, 4), nullable=True)
+    target_high: Mapped[Decimal | None] = mapped_column(Numeric(20, 4), nullable=True)
+    target_low: Mapped[Decimal | None] = mapped_column(Numeric(20, 4), nullable=True)
+    upside_pct: Mapped[Decimal | None] = mapped_column(Numeric(10, 4), nullable=True)
+    analyst_count: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    newest_opinion_date: Mapped[date | None] = mapped_column(Date, nullable=True)
+    current_price: Mapped[Decimal | None] = mapped_column(Numeric(20, 4), nullable=True)
+    raw_payload: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+    collected_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), server_default=func.now(), nullable=False
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), server_default=func.now(), nullable=False
+    )

--- a/app/services/analyst_consensus_snapshots/__init__.py
+++ b/app/services/analyst_consensus_snapshots/__init__.py
@@ -1,0 +1,11 @@
+from app.services.analyst_consensus_snapshots.repository import (
+    AnalystConsensusSnapshotsRepository,
+    AnalystConsensusSnapshotUpsert,
+    ConsensusCoverageCounts,
+)
+
+__all__ = [
+    "AnalystConsensusSnapshotUpsert",
+    "AnalystConsensusSnapshotsRepository",
+    "ConsensusCoverageCounts",
+]

--- a/app/services/analyst_consensus_snapshots/builder.py
+++ b/app/services/analyst_consensus_snapshots/builder.py
@@ -7,6 +7,7 @@ from collections.abc import Awaitable, Callable, Iterable
 from dataclasses import dataclass
 from decimal import Decimal
 from typing import Any
+from zoneinfo import ZoneInfo
 
 from app.services.analyst_consensus_snapshots.repository import (
     AnalystConsensusSnapshotUpsert,
@@ -20,6 +21,19 @@ _SOURCE_FOR_MARKET: dict[str, str] = {
     "kr": "naver_finance",
     "us": "yfinance",
 }
+
+# snapshot_date convention: the market-local calendar date (kr → Asia/Seoul,
+# us → America/New_York). A 00:30 KST run must record the KST date, not the
+# previous UTC date. Keep in sync with the AnalystConsensusSnapshot docstring.
+_MARKET_TZ: dict[str, dt.tzinfo] = {
+    "kr": ZoneInfo("Asia/Seoul"),
+    "us": ZoneInfo("America/New_York"),
+}
+
+# KR consensus stats reflect only the fetched opinion rows, so fetch up to the
+# handler cap (handle_get_investment_opinions clamps limit to 30) instead of
+# the default 10 which silently truncates well-covered symbols (ROB-641).
+OPINIONS_LIMIT = 30
 
 
 @dataclass(frozen=True)
@@ -89,7 +103,9 @@ async def default_consensus_fetcher(market: str, symbol: str) -> dict[str, Any]:
         handle_get_investment_opinions,
     )
 
-    payload = await handle_get_investment_opinions(symbol=symbol, market=market)
+    payload = await handle_get_investment_opinions(
+        symbol=symbol, market=market, limit=OPINIONS_LIMIT
+    )
     if payload.get("error"):
         raise ValueError(str(payload["error"]))
 
@@ -107,6 +123,7 @@ async def default_consensus_fetcher(market: str, symbol: str) -> dict[str, Any]:
         "source": source,
         "consensus": consensus,
         "opinions": opinions,
+        "opinions_limit": OPINIONS_LIMIT,
         "newest_opinion_date": newest,
     }
 
@@ -120,35 +137,63 @@ def _payload_from_consensus(
 ) -> AnalystConsensusSnapshotUpsert | None:
     consensus = data.get("consensus") or {}
 
-    # Skip if there is no meaningful data at all (all counts and prices null).
     total = _to_int(consensus.get("total_count"))
     current = _to_decimal(consensus.get("current_price"))
-    target_mean = _to_decimal(consensus.get("avg_target_price"))
-    if total is None and current is None and target_mean is None:
+    counts = (
+        _to_int(consensus.get("buy_count")),
+        _to_int(consensus.get("hold_count")),
+        _to_int(consensus.get("sell_count")),
+        _to_int(consensus.get("strong_buy_count")),
+        total,
+    )
+    targets = (
+        _to_decimal(consensus.get("avg_target_price")),
+        _to_decimal(consensus.get("median_target_price")),
+        _to_decimal(consensus.get("max_target_price")),
+        _to_decimal(consensus.get("min_target_price")),
+        _to_decimal(consensus.get("upside_pct")),
+    )
+    # Skip unless there is at least one real consensus count or target field.
+    # A row carrying only current_price is a quote, not a consensus snapshot.
+    if all(value is None for value in (*counts, *targets)):
         return None
+
+    # analyst_count: KR carries the normalizer's usable-target-price count
+    # (target_price_count, app/services/analyst_normalizer.py); US carries
+    # yfinance's numberOfAnalystOpinions. Fall back to total_count when absent.
+    analyst_count = _to_int(consensus.get("target_price_count"))
+    if analyst_count is None:
+        analyst_count = _to_int(consensus.get("number_of_analyst_opinions"))
+    if analyst_count is None:
+        analyst_count = total
+
+    raw_payload: dict[str, Any] = {
+        "consensus": consensus,
+        "opinion_count": len(data.get("opinions") or []),
+    }
+    opinions_limit = _to_int(data.get("opinions_limit"))
+    if opinions_limit is not None:
+        raw_payload["opinions_limit"] = opinions_limit
 
     return AnalystConsensusSnapshotUpsert(
         market=market,
         symbol=symbol.strip().upper(),
         source=data.get("source", _SOURCE_FOR_MARKET.get(market, market)),
         snapshot_date=snapshot_date,
-        buy_count=_to_int(consensus.get("buy_count")),
-        hold_count=_to_int(consensus.get("hold_count")),
-        sell_count=_to_int(consensus.get("sell_count")),
-        strong_buy_count=_to_int(consensus.get("strong_buy_count")),
+        buy_count=counts[0],
+        hold_count=counts[1],
+        sell_count=counts[2],
+        strong_buy_count=counts[3],
         total_count=total,
-        target_mean=target_mean,
-        target_median=_to_decimal(consensus.get("median_target_price")),
-        target_high=_to_decimal(consensus.get("max_target_price")),
-        target_low=_to_decimal(consensus.get("min_target_price")),
-        upside_pct=_to_decimal(consensus.get("upside_pct")),
-        analyst_count=total,
+        target_mean=targets[0],
+        target_median=targets[1],
+        target_high=targets[2],
+        target_low=targets[3],
+        upside_pct=targets[4],
+        analyst_count=analyst_count,
         newest_opinion_date=data.get("newest_opinion_date"),
         current_price=current,
-        raw_payload={
-            "consensus": consensus,
-            "opinion_count": len(data.get("opinions") or []),
-        },
+        raw_payload=raw_payload,
     )
 
 
@@ -162,8 +207,10 @@ async def build_consensus_snapshots(
 ) -> AnalystConsensusBuildResult:
     market_norm = market.strip().lower()
     fetch = fetcher or default_consensus_fetcher
-    snapshot_dt = (now or dt.datetime.now(dt.UTC)).astimezone(dt.UTC)
-    snapshot_date = snapshot_dt.date()
+    # snapshot_date is the market-local calendar date (kr → Asia/Seoul,
+    # us → America/New_York) so a KST-morning run never books the prior day.
+    snapshot_tz = _MARKET_TZ.get(market_norm, dt.UTC)
+    snapshot_date = (now or dt.datetime.now(dt.UTC)).astimezone(snapshot_tz).date()
     sem = asyncio.Semaphore(max(1, concurrency))
     symbols_list = [symbol.strip().upper() for symbol in symbols if symbol.strip()]
     payloads: list[AnalystConsensusSnapshotUpsert | None] = [None] * len(symbols_list)

--- a/app/services/analyst_consensus_snapshots/builder.py
+++ b/app/services/analyst_consensus_snapshots/builder.py
@@ -1,0 +1,204 @@
+from __future__ import annotations
+
+import asyncio
+import datetime as dt
+import logging
+from collections.abc import Awaitable, Callable, Iterable
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import Any
+
+from app.services.analyst_consensus_snapshots.repository import (
+    AnalystConsensusSnapshotUpsert,
+)
+
+logger = logging.getLogger(__name__)
+
+ConsensusFetcher = Callable[[str, str], Awaitable[dict[str, Any]]]
+
+_SOURCE_FOR_MARKET: dict[str, str] = {
+    "kr": "naver_finance",
+    "us": "yfinance",
+}
+
+
+@dataclass(frozen=True)
+class AnalystConsensusBuildResult:
+    payloads: tuple[AnalystConsensusSnapshotUpsert, ...]
+    warnings: tuple[str, ...] = ()
+
+
+def _to_decimal(value: Any) -> Decimal | None:
+    if value is None:
+        return None
+    try:
+        return Decimal(str(value))
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _to_int(value: Any) -> int | None:
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _to_date(value: Any) -> dt.date | None:
+    if value is None:
+        return None
+    if isinstance(value, dt.date) and not isinstance(value, dt.datetime):
+        return value
+    if isinstance(value, dt.datetime):
+        return value.date()
+    if isinstance(value, str):
+        text = value.strip()[:10]
+        try:
+            return dt.date.fromisoformat(text.replace(".", "-").replace("/", "-"))
+        except ValueError:
+            return None
+    return None
+
+
+def _newest_opinion_date_from_list(opinions: list[Any]) -> dt.date | None:
+    """Extract the most recent opinion date from a list of opinion dicts."""
+    best: dt.date | None = None
+    for op in opinions:
+        if not isinstance(op, dict):
+            continue
+        for key in ("date", "report_date", "published_date", "published_at"):
+            parsed = _to_date(op.get(key))
+            if parsed is not None and (best is None or parsed > best):
+                best = parsed
+    return best
+
+
+async def default_consensus_fetcher(market: str, symbol: str) -> dict[str, Any]:
+    """Fetch analyst consensus data for a symbol in a market.
+
+    Uses ``handle_get_investment_opinions`` which routes KR → naver_finance and
+    US → yfinance, returning a unified ``consensus`` dict with buy/hold/sell
+    counts, target prices, upside, and current price.
+
+    Raises on error so the builder's per-symbol exception handler can record a
+    warning and continue with the next symbol.
+    """
+    from app.mcp_server.tooling.fundamentals._valuation import (
+        handle_get_investment_opinions,
+    )
+
+    payload = await handle_get_investment_opinions(symbol=symbol, market=market)
+    if payload.get("error"):
+        raise ValueError(str(payload["error"]))
+
+    consensus = payload.get("consensus") or {}
+    opinions = payload.get("opinions") or []
+    source = _SOURCE_FOR_MARKET.get(market.strip().lower(), market.strip().lower())
+
+    # newest_opinion_date: KR consensus dict carries it directly; US does not
+    # but the opinions list has per-row dates we can scan.
+    newest = _to_date(consensus.get("newest_opinion_date"))
+    if newest is None and isinstance(opinions, list):
+        newest = _newest_opinion_date_from_list(opinions)
+
+    return {
+        "source": source,
+        "consensus": consensus,
+        "opinions": opinions,
+        "newest_opinion_date": newest,
+    }
+
+
+def _payload_from_consensus(
+    *,
+    market: str,
+    symbol: str,
+    data: dict[str, Any],
+    snapshot_date: dt.date,
+) -> AnalystConsensusSnapshotUpsert | None:
+    consensus = data.get("consensus") or {}
+
+    # Skip if there is no meaningful data at all (all counts and prices null).
+    total = _to_int(consensus.get("total_count"))
+    current = _to_decimal(consensus.get("current_price"))
+    target_mean = _to_decimal(consensus.get("avg_target_price"))
+    if total is None and current is None and target_mean is None:
+        return None
+
+    return AnalystConsensusSnapshotUpsert(
+        market=market,
+        symbol=symbol.strip().upper(),
+        source=data.get("source", _SOURCE_FOR_MARKET.get(market, market)),
+        snapshot_date=snapshot_date,
+        buy_count=_to_int(consensus.get("buy_count")),
+        hold_count=_to_int(consensus.get("hold_count")),
+        sell_count=_to_int(consensus.get("sell_count")),
+        strong_buy_count=_to_int(consensus.get("strong_buy_count")),
+        total_count=total,
+        target_mean=target_mean,
+        target_median=_to_decimal(consensus.get("median_target_price")),
+        target_high=_to_decimal(consensus.get("max_target_price")),
+        target_low=_to_decimal(consensus.get("min_target_price")),
+        upside_pct=_to_decimal(consensus.get("upside_pct")),
+        analyst_count=total,
+        newest_opinion_date=data.get("newest_opinion_date"),
+        current_price=current,
+        raw_payload={
+            "consensus": consensus,
+            "opinion_count": len(data.get("opinions") or []),
+        },
+    )
+
+
+async def build_consensus_snapshots(
+    *,
+    market: str,
+    symbols: Iterable[str],
+    now: dt.datetime | None = None,
+    concurrency: int = 4,
+    fetcher: ConsensusFetcher | None = None,
+) -> AnalystConsensusBuildResult:
+    market_norm = market.strip().lower()
+    fetch = fetcher or default_consensus_fetcher
+    snapshot_dt = (now or dt.datetime.now(dt.UTC)).astimezone(dt.UTC)
+    snapshot_date = snapshot_dt.date()
+    sem = asyncio.Semaphore(max(1, concurrency))
+    symbols_list = [symbol.strip().upper() for symbol in symbols if symbol.strip()]
+    payloads: list[AnalystConsensusSnapshotUpsert | None] = [None] * len(symbols_list)
+    warnings: list[str] = []
+
+    async def _one(idx: int, symbol: str) -> None:
+        async with sem:
+            try:
+                data = await fetch(market_norm, symbol)
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    "consensus snapshot fetch failed market=%s symbol=%s: %s",
+                    market_norm,
+                    symbol,
+                    exc,
+                )
+                warnings.append(f"{symbol}: fetch failed ({exc})")
+                return
+            payload = _payload_from_consensus(
+                market=market_norm,
+                symbol=symbol,
+                data=data,
+                snapshot_date=snapshot_date,
+            )
+            if payload is None:
+                warnings.append(
+                    f"{symbol}: skipped because consensus data is unavailable"
+                )
+                return
+            payloads[idx] = payload
+
+    await asyncio.gather(
+        *(_one(idx, symbol) for idx, symbol in enumerate(symbols_list))
+    )
+    return AnalystConsensusBuildResult(
+        payloads=tuple(payload for payload in payloads if payload is not None),
+        warnings=tuple(warnings),
+    )

--- a/app/services/analyst_consensus_snapshots/repository.py
+++ b/app/services/analyst_consensus_snapshots/repository.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import datetime as dt
+import logging
 from collections.abc import Iterable
 from dataclasses import dataclass
 from decimal import Decimal
@@ -12,6 +13,10 @@ from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.analyst_consensus_snapshot import AnalystConsensusSnapshot
+
+logger = logging.getLogger(__name__)
+
+_CONFLICT_KEY_FIELDS = ("market", "symbol", "snapshot_date", "source")
 
 
 class AnalystConsensusSnapshotUpsert(BaseModel):
@@ -53,6 +58,26 @@ def _normalize_payload(row: AnalystConsensusSnapshotUpsert) -> dict:
     return values
 
 
+def _dedupe_payload(payload: list[dict]) -> tuple[list[dict], int]:
+    """Collapse duplicate conflict keys, keeping the last occurrence.
+
+    A single multi-row ``VALUES`` upsert cannot reference the same ON CONFLICT
+    key twice (Postgres raises "command cannot affect row a second time"), so
+    duplicates must be removed before the statement is built. Last occurrence
+    wins (last-write-wins, matching the financial_fundamentals precedent);
+    surviving keys keep their first-seen position so output order is stable.
+    Returns ``(deduped_rows, dropped_count)``.
+    """
+    by_key: dict[tuple, dict] = {}
+    dropped = 0
+    for values in payload:
+        key = tuple(values[field] for field in _CONFLICT_KEY_FIELDS)
+        if key in by_key:
+            dropped += 1
+        by_key[key] = values
+    return list(by_key.values()), dropped
+
+
 class AnalystConsensusSnapshotsRepository:
     def __init__(self, session: AsyncSession) -> None:
         self._session = session
@@ -61,6 +86,13 @@ class AnalystConsensusSnapshotsRepository:
         payload = [_normalize_payload(row) for row in rows]
         if not payload:
             return 0
+        payload, dropped = _dedupe_payload(payload)
+        if dropped:
+            logger.info(
+                "analyst_consensus upsert collapsed %d duplicate conflict key(s) "
+                "(kept last occurrence)",
+                dropped,
+            )
         stmt = insert(AnalystConsensusSnapshot).values(payload)
         stmt = stmt.on_conflict_do_update(
             constraint="uq_analyst_consensus_snapshots_market_symbol_date_source",

--- a/app/services/analyst_consensus_snapshots/repository.py
+++ b/app/services/analyst_consensus_snapshots/repository.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+import datetime as dt
+from collections.abc import Iterable
+from dataclasses import dataclass
+from decimal import Decimal
+
+import sqlalchemy as sa
+from pydantic import BaseModel, ConfigDict
+from sqlalchemy import func, select
+from sqlalchemy.dialects.postgresql import insert
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.analyst_consensus_snapshot import AnalystConsensusSnapshot
+
+
+class AnalystConsensusSnapshotUpsert(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    market: str
+    symbol: str
+    source: str
+    snapshot_date: dt.date
+    buy_count: int | None = None
+    hold_count: int | None = None
+    sell_count: int | None = None
+    strong_buy_count: int | None = None
+    total_count: int | None = None
+    target_mean: Decimal | None = None
+    target_median: Decimal | None = None
+    target_high: Decimal | None = None
+    target_low: Decimal | None = None
+    upside_pct: Decimal | None = None
+    analyst_count: int | None = None
+    newest_opinion_date: dt.date | None = None
+    current_price: Decimal | None = None
+    raw_payload: dict | None = None
+
+
+@dataclass(frozen=True)
+class ConsensusCoverageCounts:
+    fresh_symbols: int
+    stale_symbols: int
+    latest_snapshot_date: dt.date | None
+    total_symbols: int
+
+
+def _normalize_payload(row: AnalystConsensusSnapshotUpsert) -> dict:
+    values = row.model_dump()
+    values["market"] = values["market"].strip().lower()
+    values["symbol"] = values["symbol"].strip().upper()
+    values["source"] = values["source"].strip().lower()
+    return values
+
+
+class AnalystConsensusSnapshotsRepository:
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def upsert(self, rows: Iterable[AnalystConsensusSnapshotUpsert]) -> int:
+        payload = [_normalize_payload(row) for row in rows]
+        if not payload:
+            return 0
+        stmt = insert(AnalystConsensusSnapshot).values(payload)
+        stmt = stmt.on_conflict_do_update(
+            constraint="uq_analyst_consensus_snapshots_market_symbol_date_source",
+            set_={
+                "buy_count": stmt.excluded.buy_count,
+                "hold_count": stmt.excluded.hold_count,
+                "sell_count": stmt.excluded.sell_count,
+                "strong_buy_count": stmt.excluded.strong_buy_count,
+                "total_count": stmt.excluded.total_count,
+                "target_mean": stmt.excluded.target_mean,
+                "target_median": stmt.excluded.target_median,
+                "target_high": stmt.excluded.target_high,
+                "target_low": stmt.excluded.target_low,
+                "upside_pct": stmt.excluded.upside_pct,
+                "analyst_count": stmt.excluded.analyst_count,
+                "newest_opinion_date": stmt.excluded.newest_opinion_date,
+                "current_price": stmt.excluded.current_price,
+                "raw_payload": stmt.excluded.raw_payload,
+                "collected_at": func.now(),
+            },
+        )
+        result = await self._session.execute(stmt)
+        return result.rowcount or 0
+
+    async def coverage_counts(
+        self, market: str, *, fresh_after: dt.date
+    ) -> ConsensusCoverageCounts:
+        latest_subq = (
+            select(
+                AnalystConsensusSnapshot.symbol.label("symbol"),
+                func.max(AnalystConsensusSnapshot.snapshot_date).label("latest_date"),
+            )
+            .where(AnalystConsensusSnapshot.market == market.strip().lower())
+            .group_by(AnalystConsensusSnapshot.symbol)
+            .subquery()
+        )
+        row = (
+            await self._session.execute(
+                select(
+                    func.count()
+                    .filter(latest_subq.c.latest_date >= fresh_after)
+                    .label("fresh"),
+                    func.count()
+                    .filter(latest_subq.c.latest_date < fresh_after)
+                    .label("stale"),
+                    func.max(latest_subq.c.latest_date).label("latest_date"),
+                    func.count().label("total"),
+                ).select_from(latest_subq)
+            )
+        ).one()
+        return ConsensusCoverageCounts(
+            fresh_symbols=int(row.fresh or 0),
+            stale_symbols=int(row.stale or 0),
+            latest_snapshot_date=row.latest_date,
+            total_symbols=int(row.total or 0),
+        )
+
+    async def existing_keys(
+        self, rows: Iterable[AnalystConsensusSnapshotUpsert]
+    ) -> set[tuple[str, str, dt.date, str]]:
+        keys = {
+            (
+                row.market.strip().lower(),
+                row.symbol.strip().upper(),
+                row.snapshot_date,
+                row.source.strip().lower(),
+            )
+            for row in rows
+        }
+        if not keys:
+            return set()
+        conditions = [
+            sa.and_(
+                AnalystConsensusSnapshot.market == market,
+                AnalystConsensusSnapshot.symbol == symbol,
+                AnalystConsensusSnapshot.snapshot_date == snapshot_date,
+                AnalystConsensusSnapshot.source == source,
+            )
+            for market, symbol, snapshot_date, source in keys
+        ]
+        result = await self._session.execute(
+            select(
+                AnalystConsensusSnapshot.market,
+                AnalystConsensusSnapshot.symbol,
+                AnalystConsensusSnapshot.snapshot_date,
+                AnalystConsensusSnapshot.source,
+            ).where(sa.or_(*conditions))
+        )
+        return {(r.market, r.symbol, r.snapshot_date, r.source) for r in result.all()}

--- a/app/tasks/__init__.py
+++ b/app/tasks/__init__.py
@@ -1,4 +1,5 @@
 from app.tasks import (
+    analyst_consensus_snapshot_tasks,
     crypto_pending_order_alert_tasks,
     daily_candles_tasks,
     daily_scan_tasks,
@@ -30,6 +31,7 @@ from app.tasks import (
 )
 
 TASKIQ_TASK_MODULES = (
+    analyst_consensus_snapshot_tasks,
     crypto_pending_order_alert_tasks,
     daily_candles_tasks,
     daily_scan_tasks,

--- a/app/tasks/analyst_consensus_snapshot_tasks.py
+++ b/app/tasks/analyst_consensus_snapshot_tasks.py
@@ -20,19 +20,21 @@ from app.jobs.analyst_consensus_snapshots import (
 async def build_analyst_consensus_snapshots(
     market: Literal["kr", "us"] = "kr",
     symbols: list[str] | None = None,
-    limit: int | None = 20,
-    all_symbols: bool = False,
+    limit: int | None = None,
     batch_size: int = 100,
     concurrency: int = 4,
     commit: bool = False,
 ) -> dict[str, Any]:
-    """Build analyst_consensus_snapshots rows, dry-run by default."""
+    """Build analyst_consensus_snapshots rows, dry-run by default.
+
+    Default scope is holdings ∪ active watch symbols (no full-universe
+    option); pass ``symbols`` for an explicit override.
+    """
     result = await run_analyst_consensus_snapshot_build(
         AnalystConsensusSnapshotBuildRequest(
             market=market,
             symbols=tuple(symbols or ()),
             limit=limit,
-            all_symbols=all_symbols,
             batch_size=batch_size,
             concurrency=concurrency,
             commit=commit,

--- a/app/tasks/analyst_consensus_snapshot_tasks.py
+++ b/app/tasks/analyst_consensus_snapshot_tasks.py
@@ -1,0 +1,68 @@
+"""TaskIQ wrappers for analyst consensus snapshot freshness (ROB-641).
+
+No recurring schedule is attached intentionally. Operators can enqueue this task
+manually in dry-run mode to produce an approval packet. Persisting rows requires
+commit=True and separate production database-write approval.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from app.core.taskiq_broker import broker
+from app.jobs.analyst_consensus_snapshots import (
+    AnalystConsensusSnapshotBuildRequest,
+    run_analyst_consensus_snapshot_build,
+)
+
+
+@broker.task(task_name="build_analyst_consensus_snapshots")
+async def build_analyst_consensus_snapshots(
+    market: Literal["kr", "us"] = "kr",
+    symbols: list[str] | None = None,
+    limit: int | None = 20,
+    all_symbols: bool = False,
+    batch_size: int = 100,
+    concurrency: int = 4,
+    commit: bool = False,
+) -> dict[str, Any]:
+    """Build analyst_consensus_snapshots rows, dry-run by default."""
+    result = await run_analyst_consensus_snapshot_build(
+        AnalystConsensusSnapshotBuildRequest(
+            market=market,
+            symbols=tuple(symbols or ()),
+            limit=limit,
+            all_symbols=all_symbols,
+            batch_size=batch_size,
+            concurrency=concurrency,
+            commit=commit,
+        )
+    )
+    return {
+        "market": result.market,
+        "symbolsResolved": result.symbols_resolved,
+        "snapshotsBuilt": result.snapshots_built,
+        "committed": result.committed,
+        "batches": result.batches,
+        "startedAt": result.started_at.isoformat(),
+        "finishedAt": result.finished_at.isoformat(),
+        "snapshotDateDistribution": result.snapshot_date_distribution,
+        "idempotency": result.idempotency,
+        "samples": [
+            {
+                "market": sample.market,
+                "symbol": sample.symbol,
+                "source": sample.source,
+                "snapshotDate": sample.snapshot_date.isoformat(),
+                "totalCount": sample.total_count,
+                "targetMean": str(sample.target_mean)
+                if sample.target_mean is not None
+                else None,
+                "currentPrice": str(sample.current_price)
+                if sample.current_price is not None
+                else None,
+            }
+            for sample in result.samples
+        ],
+        "warnings": list(result.warnings),
+    }

--- a/scripts/build_analyst_consensus_snapshots.py
+++ b/scripts/build_analyst_consensus_snapshots.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Build analyst_consensus_snapshots rows (ROB-641).
+
+DEFAULTS TO --dry-run: prints an approval-packet-friendly summary without
+committing to the database. Pass --commit only after explicit operator approval.
+
+Default symbol scope is holdings ∪ active watch symbols (KIS holdings +
+manual holdings + active investment_watch_alerts). There is intentionally no
+full-universe option — consensus fetches are expensive per symbol. Use
+--symbol for explicit overrides.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Dry-run-first analyst consensus snapshots builder (ROB-641)."
+    )
+    parser.add_argument("--market", choices=["kr", "us"], default="kr")
+    parser.add_argument(
+        "--symbol",
+        action="append",
+        default=[],
+        help="Restrict to specific symbols. Can be passed multiple times.",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help=(
+            "Cap the resolved holdings∪watch symbol count. "
+            "Defaults to no cap (the scope is already bounded)."
+        ),
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=100,
+        help="Symbols per processing batch.",
+    )
+    parser.add_argument(
+        "--concurrency", type=int, default=4, help="Per-symbol fetch concurrency."
+    )
+    parser.add_argument(
+        "--commit",
+        action="store_true",
+        help="Actually write to the database. Default is --dry-run/no writes.",
+    )
+    args = parser.parse_args(argv)
+    if args.limit is not None and args.limit < 1:
+        parser.error("--limit must be >= 1")
+    if args.batch_size < 1:
+        parser.error("--batch-size must be >= 1")
+    if args.concurrency < 1:
+        parser.error("--concurrency must be >= 1")
+    args.dry_run = not args.commit
+    return args
+
+
+def _print_result(result) -> None:
+    print(
+        f"\nbuilt {result.snapshots_built} consensus snapshots "
+        f"for {result.symbols_resolved} {result.market.upper()} symbols "
+        f"(dry_run={not result.committed}, batches={result.batches}):"
+    )
+    print("idempotency:")
+    for key in ("wouldInsert", "wouldUpdate", "duplicatePayloadKeys"):
+        print(f"  {key}: {result.idempotency.get(key, 0)}")
+    distribution = getattr(result, "snapshot_date_distribution", {})
+    if distribution:
+        print("snapshot date distribution:")
+        for snapshot_key, count in distribution.items():
+            print(f"  {snapshot_key}: {count}")
+    if result.samples:
+        print("samples:")
+        for sample in result.samples[:10]:
+            print(f"  {sample}")
+    if result.warnings:
+        print("warnings:")
+        for warning in result.warnings:
+            print(f"  - {warning}")
+    if not result.committed:
+        print("\n--dry-run: no rows written.\n")
+    else:
+        print(f"\ncommitted {result.snapshots_built} rows.\n")
+
+
+async def run(args: argparse.Namespace) -> int:
+    from app.jobs import analyst_consensus_snapshots as snapshot_job
+
+    request = snapshot_job.AnalystConsensusSnapshotBuildRequest(
+        market=args.market,
+        symbols=tuple(args.symbol),
+        limit=args.limit,
+        batch_size=args.batch_size,
+        concurrency=args.concurrency,
+        commit=args.commit,
+    )
+    result = await snapshot_job.run_analyst_consensus_snapshot_build(request)
+    _print_result(result)
+    return 0
+
+
+async def main() -> int:
+    args = parse_args()
+    from app.core.cli import setup_logging_and_sentry
+
+    setup_logging_and_sentry(service_name="build-analyst-consensus-snapshots")
+    return await run(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/tests/jobs/test_analyst_consensus_snapshots_job.py
+++ b/tests/jobs/test_analyst_consensus_snapshots_job.py
@@ -1,0 +1,207 @@
+"""Job-level behaviour for analyst_consensus_snapshots (ROB-641).
+
+Covers holdings ∪ watch symbol resolution (mocked resolvers), the
+to_db_symbol override normalization, TaskIQ registration, and the
+end-to-end upsert dedupe on duplicate payload keys.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from types import SimpleNamespace
+from typing import Any
+from zoneinfo import ZoneInfo
+
+import pytest
+import sqlalchemy as sa
+
+from app.jobs import analyst_consensus_snapshots as snapshot_job
+from app.jobs.analyst_consensus_snapshots import (
+    AnalystConsensusSnapshotBuildRequest,
+    resolve_symbols,
+    run_analyst_consensus_snapshot_build,
+)
+from app.models.analyst_consensus_snapshot import AnalystConsensusSnapshot
+
+_KST = ZoneInfo("Asia/Seoul")
+
+_UNIQUE = 0
+
+
+def _unique_symbol() -> str:
+    global _UNIQUE
+    _UNIQUE += 1
+    return f"T641J{_UNIQUE:04d}"
+
+
+def _patch_resolvers(
+    monkeypatch,
+    *,
+    kis: list[dict[str, Any]],
+    manual: list[Any],
+    watch: list[str],
+) -> None:
+    async def fake_kis(market: str) -> list[Any]:
+        return list(kis)
+
+    async def fake_manual(market: str, user_id: int) -> list[Any]:
+        return list(manual)
+
+    async def fake_watch(market: str) -> list[str]:
+        return list(watch)
+
+    monkeypatch.setattr(snapshot_job, "_fetch_kis_holdings", fake_kis)
+    monkeypatch.setattr(snapshot_job, "_fetch_manual_holdings", fake_manual)
+    monkeypatch.setattr(snapshot_job, "_fetch_active_watch_symbols", fake_watch)
+
+
+@pytest.mark.unit
+def test_task_module_is_registered() -> None:
+    """ROB-641: the TaskIQ module must be in the worker's explicit load list."""
+    from app.tasks import TASKIQ_TASK_MODULES, analyst_consensus_snapshot_tasks
+
+    assert analyst_consensus_snapshot_tasks in TASKIQ_TASK_MODULES
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_resolve_symbols_override_normalized_with_to_db_symbol() -> None:
+    symbols = await resolve_symbols("us", ["brk-b", " aapl ", "BRK/A", ""])
+    assert symbols == ["BRK.B", "AAPL", "BRK.A"]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_resolve_symbols_kr_holdings_union_watch(monkeypatch) -> None:
+    _patch_resolvers(
+        monkeypatch,
+        kis=[{"pdno": "005930"}, {"pdno": "000660"}],
+        manual=[SimpleNamespace(ticker="035420")],
+        # "5930" normalizes to 005930 → duplicate collapses into the union.
+        watch=["005380", "5930"],
+    )
+    symbols = await resolve_symbols("kr", [])
+    assert symbols == ["000660", "005380", "005930", "035420"]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_resolve_symbols_us_holdings_union_watch(monkeypatch) -> None:
+    _patch_resolvers(
+        monkeypatch,
+        kis=[{"ovrs_pdno": "BRK/B"}],
+        manual=[SimpleNamespace(ticker="aapl")],
+        watch=["TSLA", "BRK-B"],
+    )
+    symbols = await resolve_symbols("us", [])
+    assert symbols == ["AAPL", "BRK.B", "TSLA"]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_resolve_symbols_limit_caps_resolved_set(monkeypatch) -> None:
+    _patch_resolvers(
+        monkeypatch,
+        kis=[{"pdno": "005930"}, {"pdno": "000660"}],
+        manual=[],
+        watch=["035420"],
+    )
+    symbols = await resolve_symbols("kr", [], limit=2)
+    assert symbols == ["000660", "005930"]
+
+
+@pytest.mark.unit
+def test_job_surface_has_no_full_universe_option() -> None:
+    """The all_symbols full-universe scan was removed from the job surface."""
+    import dataclasses
+
+    field_names = {
+        field.name for field in dataclasses.fields(AnalystConsensusSnapshotBuildRequest)
+    }
+    assert "all_symbols" not in field_names
+    assert not hasattr(snapshot_job, "resolve_active_universe")
+
+
+def _fake_build_with_fetcher(consensus: dict[str, Any]):
+    """Wrap the real builder with a network-free fetcher."""
+    from app.services.analyst_consensus_snapshots.builder import (
+        build_consensus_snapshots,
+    )
+
+    async def fake_fetcher(market: str, symbol: str) -> dict[str, Any]:
+        return {
+            "source": "naver_finance",
+            "consensus": consensus,
+            "opinions": [],
+            "opinions_limit": 30,
+            "newest_opinion_date": None,
+        }
+
+    async def build(**kwargs: Any):
+        return await build_consensus_snapshots(fetcher=fake_fetcher, **kwargs)
+
+    return build
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_run_job_dedupes_duplicate_payload_keys_on_commit(
+    db_session, monkeypatch
+) -> None:
+    """Duplicate symbol input → duplicatePayloadKeys surfaced, single DB row."""
+    symbol = _unique_symbol()
+    await db_session.execute(
+        sa.delete(AnalystConsensusSnapshot).where(
+            AnalystConsensusSnapshot.symbol == symbol
+        )
+    )
+    await db_session.commit()
+
+    consensus = {
+        "buy_count": 4,
+        "hold_count": 2,
+        "sell_count": 1,
+        "strong_buy_count": 1,
+        "total_count": 7,
+        "avg_target_price": 90000,
+        "current_price": 80000,
+    }
+    monkeypatch.setattr(
+        snapshot_job,
+        "build_consensus_snapshots",
+        _fake_build_with_fetcher(consensus),
+    )
+
+    result = await run_analyst_consensus_snapshot_build(
+        AnalystConsensusSnapshotBuildRequest(
+            market="kr",
+            symbols=(symbol, symbol),
+            commit=True,
+            now=dt.datetime(2026, 7, 2, 0, 30, tzinfo=_KST),
+        )
+    )
+    assert result.symbols_resolved == 2
+    assert result.snapshots_built == 2
+    assert result.idempotency["duplicatePayloadKeys"] == 1
+
+    rows = (
+        (
+            await db_session.execute(
+                sa.select(AnalystConsensusSnapshot).where(
+                    AnalystConsensusSnapshot.symbol == symbol
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(rows) == 1
+    # KST-morning run books the KST calendar date.
+    assert rows[0].snapshot_date == dt.date(2026, 7, 2)
+
+    await db_session.execute(
+        sa.delete(AnalystConsensusSnapshot).where(
+            AnalystConsensusSnapshot.symbol == symbol
+        )
+    )
+    await db_session.commit()

--- a/tests/models/test_analyst_consensus_snapshot_model.py
+++ b/tests/models/test_analyst_consensus_snapshot_model.py
@@ -1,0 +1,115 @@
+"""AnalystConsensusSnapshot table contract (ROB-641)."""
+
+from __future__ import annotations
+
+import datetime as dt
+from decimal import Decimal
+
+import pytest
+import sqlalchemy as sa
+from sqlalchemy.exc import IntegrityError
+
+from app.models.analyst_consensus_snapshot import AnalystConsensusSnapshot
+
+_UNIQUE = 0
+
+
+def _unique_symbol() -> str:
+    """Generate a unique symbol per-test to avoid shared-DB collisions."""
+    global _UNIQUE
+    _UNIQUE += 1
+    return f"T641M{_UNIQUE:04d}"
+
+
+def _make_row(
+    *, market: str = "kr", symbol: str | None = None
+) -> AnalystConsensusSnapshot:
+    return AnalystConsensusSnapshot(
+        market=market,
+        symbol=symbol or _unique_symbol(),
+        source="naver_finance" if market == "kr" else "yfinance",
+        snapshot_date=dt.date(2026, 7, 2),
+        buy_count=5,
+        hold_count=3,
+        sell_count=1,
+        strong_buy_count=2,
+        total_count=9,
+        target_mean=Decimal("85000.0000"),
+        target_median=Decimal("82000.0000"),
+        target_high=Decimal("95000.0000"),
+        target_low=Decimal("70000.0000"),
+        upside_pct=Decimal("12.5000"),
+        analyst_count=9,
+        newest_opinion_date=dt.date(2026, 6, 28),
+        current_price=Decimal("76000.0000"),
+        raw_payload={"consensus": {"buy_count": 5}},
+    )
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_insert_and_read_back(db_session) -> None:
+    symbol = _unique_symbol()
+    db_session.add(_make_row(symbol=symbol))
+    await db_session.flush()
+    row = (
+        await db_session.execute(
+            sa.select(AnalystConsensusSnapshot).where(
+                AnalystConsensusSnapshot.symbol == symbol
+            )
+        )
+    ).scalar_one()
+    assert row.market == "kr"
+    assert row.source == "naver_finance"
+    assert row.snapshot_date == dt.date(2026, 7, 2)
+    assert row.buy_count == 5
+    assert row.total_count == 9
+    assert row.target_mean == Decimal("85000.0000")
+    assert row.upside_pct == Decimal("12.5000")
+    assert row.newest_opinion_date == dt.date(2026, 6, 28)
+    assert row.current_price == Decimal("76000.0000")
+    assert row.raw_payload["consensus"]["buy_count"] == 5
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_duplicate_violates_unique(db_session) -> None:
+    symbol = _unique_symbol()
+    for _ in range(2):
+        db_session.add(_make_row(symbol=symbol))
+    with pytest.raises(IntegrityError):
+        await db_session.flush()
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_check_constraint_rejects_invalid_market(db_session) -> None:
+    row = _make_row(market="crypto")
+    db_session.add(row)
+    with pytest.raises(IntegrityError):
+        await db_session.flush()
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_check_constraint_rejects_invalid_source(db_session) -> None:
+    symbol = _unique_symbol()
+    row = _make_row(symbol=symbol)
+    row.source = "bloomberg"
+    db_session.add(row)
+    with pytest.raises(IntegrityError):
+        await db_session.flush()
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_nullable_counts_allowed(db_session) -> None:
+    symbol = _unique_symbol()
+    row = _make_row(symbol=symbol)
+    row.buy_count = None
+    row.hold_count = None
+    row.sell_count = None
+    row.total_count = None
+    db_session.add(row)
+    await db_session.flush()
+    assert row.id is not None

--- a/tests/services/test_analyst_consensus_snapshot_builder.py
+++ b/tests/services/test_analyst_consensus_snapshot_builder.py
@@ -1,0 +1,202 @@
+"""Builder behaviour for analyst consensus snapshots (ROB-641).
+
+Covers the market-local snapshot_date convention (kr → Asia/Seoul,
+us → America/New_York), the limit=30 opinions fetch, the meaningful-data
+gate, and analyst_count wiring.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from typing import Any
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from app.services.analyst_consensus_snapshots.builder import (
+    OPINIONS_LIMIT,
+    build_consensus_snapshots,
+    default_consensus_fetcher,
+)
+
+_KST = ZoneInfo("Asia/Seoul")
+
+
+def _kr_consensus(**overrides: Any) -> dict[str, Any]:
+    consensus: dict[str, Any] = {
+        "buy_count": 10,
+        "hold_count": 5,
+        "sell_count": 2,
+        "strong_buy_count": 3,
+        "total_count": 17,
+        "avg_target_price": 100000,
+        "median_target_price": 95000,
+        "min_target_price": 80000,
+        "max_target_price": 120000,
+        "upside_pct": 15.5,
+        "current_price": 86000,
+    }
+    consensus.update(overrides)
+    return consensus
+
+
+def _fake_fetcher(consensus: dict[str, Any], *, source: str = "naver_finance"):
+    async def fetch(market: str, symbol: str) -> dict[str, Any]:
+        return {
+            "source": source,
+            "consensus": consensus,
+            "opinions": [],
+            "opinions_limit": OPINIONS_LIMIT,
+            "newest_opinion_date": None,
+        }
+
+    return fetch
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_snapshot_date_kst_morning_is_kst_date_for_kr() -> None:
+    """00:30 KST must book the KST calendar date, not the previous UTC day."""
+    now = dt.datetime(2026, 7, 2, 0, 30, tzinfo=_KST)  # 2026-07-01T15:30Z
+    result = await build_consensus_snapshots(
+        market="kr",
+        symbols=["005930"],
+        now=now,
+        fetcher=_fake_fetcher(_kr_consensus()),
+    )
+    assert len(result.payloads) == 1
+    assert result.payloads[0].snapshot_date == dt.date(2026, 7, 2)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_snapshot_date_us_uses_eastern_calendar_date() -> None:
+    """01:30 KST Jul 2 is 12:30 ET Jul 1 → US rows book the ET date."""
+    now = dt.datetime(2026, 7, 2, 1, 30, tzinfo=_KST)
+    result = await build_consensus_snapshots(
+        market="us",
+        symbols=["AAPL"],
+        now=now,
+        fetcher=_fake_fetcher(_kr_consensus(), source="yfinance"),
+    )
+    assert len(result.payloads) == 1
+    assert result.payloads[0].snapshot_date == dt.date(2026, 7, 1)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_default_fetcher_passes_limit_30(monkeypatch) -> None:
+    captured: dict[str, Any] = {}
+
+    async def fake_handler(**kwargs: Any) -> dict[str, Any]:
+        captured.update(kwargs)
+        return {"consensus": _kr_consensus(), "opinions": []}
+
+    monkeypatch.setattr(
+        "app.mcp_server.tooling.fundamentals._valuation.handle_get_investment_opinions",
+        fake_handler,
+    )
+    data = await default_consensus_fetcher("kr", "005930")
+    assert captured["limit"] == 30
+    assert data["opinions_limit"] == 30
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_raw_payload_records_opinions_limit() -> None:
+    result = await build_consensus_snapshots(
+        market="kr",
+        symbols=["005930"],
+        now=dt.datetime(2026, 7, 2, 9, 0, tzinfo=_KST),
+        fetcher=_fake_fetcher(_kr_consensus()),
+    )
+    assert result.payloads[0].raw_payload["opinions_limit"] == OPINIONS_LIMIT
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_meaningful_data_gate_skips_current_price_only_rows() -> None:
+    """A row carrying only current_price is a quote, not consensus data."""
+    consensus = {
+        "buy_count": None,
+        "hold_count": None,
+        "sell_count": None,
+        "strong_buy_count": None,
+        "total_count": None,
+        "avg_target_price": None,
+        "median_target_price": None,
+        "min_target_price": None,
+        "max_target_price": None,
+        "upside_pct": None,
+        "current_price": 185.5,
+    }
+    result = await build_consensus_snapshots(
+        market="us",
+        symbols=["NOCOV"],
+        now=dt.datetime(2026, 7, 2, 9, 0, tzinfo=_KST),
+        fetcher=_fake_fetcher(consensus, source="yfinance"),
+    )
+    assert result.payloads == ()
+    assert any("NOCOV" in warning for warning in result.warnings)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_meaningful_data_gate_keeps_target_only_rows() -> None:
+    """Target fields without counts still qualify (e.g. Yahoo target-only)."""
+    consensus = {
+        "total_count": None,
+        "avg_target_price": 210.0,
+        "current_price": 185.5,
+    }
+    result = await build_consensus_snapshots(
+        market="us",
+        symbols=["TGTONLY"],
+        now=dt.datetime(2026, 7, 2, 9, 0, tzinfo=_KST),
+        fetcher=_fake_fetcher(consensus, source="yfinance"),
+    )
+    assert len(result.payloads) == 1
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_analyst_count_kr_uses_target_price_count() -> None:
+    result = await build_consensus_snapshots(
+        market="kr",
+        symbols=["005930"],
+        now=dt.datetime(2026, 7, 2, 9, 0, tzinfo=_KST),
+        fetcher=_fake_fetcher(_kr_consensus(target_price_count=12)),
+    )
+    payload = result.payloads[0]
+    assert payload.total_count == 17
+    assert payload.analyst_count == 12
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_analyst_count_us_uses_number_of_analyst_opinions() -> None:
+    result = await build_consensus_snapshots(
+        market="us",
+        symbols=["AAPL"],
+        now=dt.datetime(2026, 7, 2, 9, 0, tzinfo=_KST),
+        fetcher=_fake_fetcher(
+            _kr_consensus(total_count=30, number_of_analyst_opinions=25),
+            source="yfinance",
+        ),
+    )
+    payload = result.payloads[0]
+    assert payload.total_count == 30
+    assert payload.analyst_count == 25
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_analyst_count_falls_back_to_total_count() -> None:
+    result = await build_consensus_snapshots(
+        market="kr",
+        symbols=["005930"],
+        now=dt.datetime(2026, 7, 2, 9, 0, tzinfo=_KST),
+        fetcher=_fake_fetcher(_kr_consensus()),
+    )
+    payload = result.payloads[0]
+    assert payload.analyst_count == payload.total_count == 17

--- a/tests/services/test_analyst_consensus_snapshot_service.py
+++ b/tests/services/test_analyst_consensus_snapshot_service.py
@@ -105,6 +105,43 @@ async def test_upsert_is_idempotent_on_unique_key(db_session) -> None:
 
 @pytest.mark.integration
 @pytest.mark.asyncio
+async def test_upsert_dedupes_duplicate_keys_in_single_call(db_session) -> None:
+    """Same conflict key twice in one payload must not crash Postgres.
+
+    Without pre-statement dedupe a multi-row INSERT ... ON CONFLICT raises
+    "ON CONFLICT DO UPDATE command cannot affect row a second time".
+    Last occurrence wins.
+    """
+    symbol = _unique_symbol()
+    await _cleanup(db_session, [symbol])
+
+    repo = AnalystConsensusSnapshotsRepository(db_session)
+    n = await repo.upsert(
+        [
+            _row(symbol=symbol, buy_count=10),
+            _row(symbol=symbol, buy_count=42),
+        ]
+    )
+    await db_session.commit()
+    assert n == 1
+
+    rows = (
+        (
+            await db_session.execute(
+                sa.select(AnalystConsensusSnapshot).where(
+                    AnalystConsensusSnapshot.symbol == symbol
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(rows) == 1
+    assert rows[0].buy_count == 42
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
 async def test_coverage_counts_fresh_vs_stale(db_session) -> None:
     sym_a = _unique_symbol()
     sym_b = _unique_symbol()

--- a/tests/services/test_analyst_consensus_snapshot_service.py
+++ b/tests/services/test_analyst_consensus_snapshot_service.py
@@ -1,0 +1,189 @@
+"""AnalystConsensusSnapshotsRepository upsert → coverage → existing_keys roundtrip (ROB-641)."""
+
+from __future__ import annotations
+
+import datetime as dt
+from decimal import Decimal
+
+import pytest
+import sqlalchemy as sa
+
+from app.models.analyst_consensus_snapshot import AnalystConsensusSnapshot
+from app.services.analyst_consensus_snapshots.repository import (
+    AnalystConsensusSnapshotsRepository,
+    AnalystConsensusSnapshotUpsert,
+)
+
+_UNIQUE = 0
+
+
+def _unique_symbol() -> str:
+    global _UNIQUE
+    _UNIQUE += 1
+    return f"T641S{_UNIQUE:04d}"
+
+
+def _row(
+    *,
+    symbol: str,
+    snapshot_date: dt.date = dt.date(2026, 7, 2),
+    source: str = "naver_finance",
+    buy_count: int = 10,
+    target_mean: Decimal = Decimal("100000.0000"),
+) -> AnalystConsensusSnapshotUpsert:
+    return AnalystConsensusSnapshotUpsert(
+        market="kr",
+        symbol=symbol,
+        source=source,
+        snapshot_date=snapshot_date,
+        buy_count=buy_count,
+        hold_count=5,
+        sell_count=2,
+        strong_buy_count=3,
+        total_count=17,
+        target_mean=target_mean,
+        target_median=Decimal("95000.0000"),
+        target_high=Decimal("120000.0000"),
+        target_low=Decimal("80000.0000"),
+        upside_pct=Decimal("15.5000"),
+        analyst_count=17,
+        newest_opinion_date=dt.date(2026, 6, 30),
+        current_price=Decimal("86000.0000"),
+        raw_payload={"consensus": {"buy_count": buy_count}},
+    )
+
+
+async def _cleanup(db_session, symbols: list[str]) -> None:
+    await db_session.execute(
+        sa.delete(AnalystConsensusSnapshot).where(
+            AnalystConsensusSnapshot.symbol.in_(symbols)
+        )
+    )
+    await db_session.commit()
+
+
+async def _cleanup_all_test_rows(db_session) -> None:
+    """Remove ALL test-prefix rows so market-wide coverage_counts is clean."""
+    await db_session.execute(
+        sa.delete(AnalystConsensusSnapshot).where(
+            AnalystConsensusSnapshot.symbol.like("T641%")
+        )
+    )
+    await db_session.commit()
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_upsert_is_idempotent_on_unique_key(db_session) -> None:
+    symbol = _unique_symbol()
+    await _cleanup(db_session, [symbol])
+
+    repo = AnalystConsensusSnapshotsRepository(db_session)
+
+    n = await repo.upsert([_row(symbol=symbol, buy_count=10)])
+    await db_session.commit()
+    assert n == 1
+
+    # Same key → UPDATE not duplicate INSERT.
+    await repo.upsert([_row(symbol=symbol, buy_count=99)])
+    await db_session.commit()
+
+    rows = (
+        (
+            await db_session.execute(
+                sa.select(AnalystConsensusSnapshot).where(
+                    AnalystConsensusSnapshot.symbol == symbol
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(rows) == 1
+    assert rows[0].buy_count == 99
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_coverage_counts_fresh_vs_stale(db_session) -> None:
+    sym_a = _unique_symbol()
+    sym_b = _unique_symbol()
+    await _cleanup_all_test_rows(db_session)
+
+    repo = AnalystConsensusSnapshotsRepository(db_session)
+    fresh_date = dt.date(2026, 7, 2)
+    stale_date = dt.date(2026, 6, 1)
+    await repo.upsert(
+        [
+            _row(symbol=sym_a, snapshot_date=fresh_date),
+            _row(symbol=sym_b, snapshot_date=stale_date),
+        ]
+    )
+    await db_session.commit()
+
+    counts = await repo.coverage_counts("kr", fresh_after=dt.date(2026, 6, 15))
+    assert counts.fresh_symbols == 1  # sym_a (2026-07-02 >= cutoff)
+    assert counts.stale_symbols == 1  # sym_b (2026-06-01 < cutoff)
+    assert counts.latest_snapshot_date == fresh_date
+    assert counts.total_symbols == 2
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_existing_keys_pre_flight(db_session) -> None:
+    sym_a = _unique_symbol()
+    sym_b = _unique_symbol()
+    sym_c = _unique_symbol()
+    await _cleanup(db_session, [sym_a, sym_b, sym_c])
+
+    repo = AnalystConsensusSnapshotsRepository(db_session)
+    snapshot_date = dt.date(2026, 7, 2)
+    await repo.upsert([_row(symbol=sym_a, snapshot_date=snapshot_date)])
+    await db_session.commit()
+
+    # sym_a exists, sym_b and sym_c do not.
+    existing = await repo.existing_keys(
+        [
+            _row(symbol=sym_a, snapshot_date=snapshot_date),
+            _row(symbol=sym_b, snapshot_date=snapshot_date),
+            _row(symbol=sym_c, snapshot_date=snapshot_date),
+        ]
+    )
+    assert len(existing) == 1
+    key = next(iter(existing))
+    assert key[0] == "kr"
+    assert key[1] == sym_a
+    assert key[2] == snapshot_date
+    assert key[3] == "naver_finance"
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_different_sources_coexist(db_session) -> None:
+    symbol = _unique_symbol()
+    await _cleanup(db_session, [symbol])
+
+    repo = AnalystConsensusSnapshotsRepository(db_session)
+    snapshot_date = dt.date(2026, 7, 2)
+    await repo.upsert(
+        [
+            _row(symbol=symbol, snapshot_date=snapshot_date, source="naver_finance"),
+            _row(symbol=symbol, snapshot_date=snapshot_date, source="yfinance"),
+        ]
+    )
+    await db_session.commit()
+
+    rows = (
+        (
+            await db_session.execute(
+                sa.select(AnalystConsensusSnapshot).where(
+                    AnalystConsensusSnapshot.symbol == symbol
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(rows) == 2
+    sources = {r.source for r in rows}
+    assert sources == {"naver_finance", "yfinance"}


### PR DESCRIPTION
## 개요

애널리스트 컨센서스/목표가 일별 이력 축적용 신규 스냅샷 테이블. `market_quote_snapshots` 패턴 클론. 리비전 모멘텀 분석 기반 마련.

## 변경 사항

- 신규 테이블 `review.analyst_consensus_snapshots`: market/symbol/snapshot_date/source UNIQUE, buy/hold/sell 카운트, 목표가 통계(mean/median/high/low), upside_pct, raw_payload JSONB
- 5개 신규 파일: model, repo, builder, job, task (market_quote_snapshots 클론)
- KR = Naver consensus (`build_consensus` 22키 활용), US = yfinance recommendations + price_targets
- 9 테스트 통과

## 마이그레이션

- `alembic/versions/20260702_rob641_analyst_consensus_snapshots.py`
- down_revision: `20260620_scalp_benchmark` (현재 HEAD)

## 동기화 노트

- 637과 같은 head에서 분기 → 637 먼저 머지, 이 PR 리베이스 후 `down_revision = 637_revision`으로 업데이트
- 638과 시너지: ROB-638 PR2의 consensus Redis 캐시 warm-up과 이력 축적을 한 fetch로 겸할 수 있음

## 모델 레인

`keep_on_gpt54`