### PR TITLE
feat(ROB-647): postmortem structuring for trade_retrospectives

### DIFF
--- a/alembic/versions/20260702_rob647_trade_retrospective_postmortem.py
+++ b/alembic/versions/20260702_rob647_trade_retrospective_postmortem.py
@@ -1,0 +1,95 @@
+"""add postmortem structuring columns to trade_retrospectives (ROB-647)
+
+Revision ID: 20260702_rob647
+Revises: 20260702_rob641
+Create Date: 2026-07-02
+
+Additive-only. Adds six nullable columns to review.trade_retrospectives so a
+retrospective can carry structured postmortem context:
+
+* trigger_type          — what triggered the retro (fill/rejected_order/expired/
+                          thesis_change/policy_violation/…), CHECK-constrained
+                          and deliberately distinct from ``outcome`` (kis
+                          reconcile collapses expired -> cancelled at the outcome
+                          layer, so ``expired`` only survives here).
+* root_cause_class      — CHECK-constrained taxonomy (user_input/analysis/policy/
+                          execution/harness), ported from tradingcodex.
+* intended_vs_happened  — validated JSONB deviation structure.
+* next_actions          — validated JSONB list (Linear identifiers only; no API
+                          client in-repo).
+* guardrail_fired       — identifier of the guard that fired.
+* policy_version        — policy version cited by the postmortem (P5 alignment).
+
+No existing column/constraint is modified: existing save callers stay
+backward-compatible (all new fields optional; next_actions is obligatory only
+when trigger_type is set — enforced in the service layer, not the DB).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "20260702_rob647"
+down_revision: str | Sequence[str] | None = "20260702_rob641"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_TABLE = "trade_retrospectives"
+_SCHEMA = "review"
+
+_NEW_COLUMNS = (
+    ("trigger_type", sa.Text()),
+    ("root_cause_class", sa.Text()),
+    ("intended_vs_happened", postgresql.JSONB(astext_type=sa.Text())),
+    ("next_actions", postgresql.JSONB(astext_type=sa.Text())),
+    ("guardrail_fired", sa.Text()),
+    ("policy_version", sa.Text()),
+)
+
+
+def upgrade() -> None:
+    for name, col_type in _NEW_COLUMNS:
+        op.add_column(
+            _TABLE,
+            sa.Column(name, col_type, nullable=True),
+            schema=_SCHEMA,
+        )
+    op.create_check_constraint(
+        "ck_trade_retrospectives_trigger_type",
+        _TABLE,
+        "trigger_type IS NULL OR trigger_type IN ("
+        "'fill','partial_fill','rejected_order','cancelled','expired',"
+        "'thesis_change','policy_violation','stale_evidence','guardrail_block'"
+        ")",
+        schema=_SCHEMA,
+    )
+    op.create_check_constraint(
+        "ck_trade_retrospectives_root_cause_class",
+        _TABLE,
+        "root_cause_class IS NULL OR root_cause_class IN ("
+        "'user_input','analysis','policy','execution','harness'"
+        ")",
+        schema=_SCHEMA,
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        "ck_trade_retrospectives_root_cause_class",
+        _TABLE,
+        schema=_SCHEMA,
+        type_="check",
+    )
+    op.drop_constraint(
+        "ck_trade_retrospectives_trigger_type",
+        _TABLE,
+        schema=_SCHEMA,
+        type_="check",
+    )
+    for name, _ in reversed(_NEW_COLUMNS):
+        op.drop_column(_TABLE, name, schema=_SCHEMA)

--- a/app/mcp_server/__init__.py
+++ b/app/mcp_server/__init__.py
@@ -53,6 +53,7 @@ AVAILABLE_TOOL_NAMES = [
     "save_trade_retrospective",
     "get_trade_retrospectives",
     "get_retrospective_aggregate",
+    "trade_retrospective_pending",
     # Crypto research tools
     "get_crypto_profile",
     "get_kimchi_premium",

--- a/app/mcp_server/tooling/trade_retrospective_registration.py
+++ b/app/mcp_server/tooling/trade_retrospective_registration.py
@@ -9,12 +9,14 @@ from app.mcp_server.tooling.trade_retrospective_tools import (
     get_retrospective_aggregate,
     get_trade_retrospectives,
     save_trade_retrospective,
+    trade_retrospective_pending,
 )
 
 TRADE_RETROSPECTIVE_TOOL_NAMES: set[str] = {
     "save_trade_retrospective",
     "get_trade_retrospectives",
     "get_retrospective_aggregate",
+    "trade_retrospective_pending",
 }
 
 
@@ -44,13 +46,29 @@ def register_trade_retrospective_tools(mcp: Any) -> None:
     _ = mcp.tool(
         name="get_retrospective_aggregate",
         description=(
-            "Aggregate retrospectives by strategy_key or KST day over a KST date "
-            "window: win_rate_pct, avg_pnl_pct, absolute realized_pnl sum (per "
-            "currency), wins/misses. Only rows with fill evidence are counted "
-            "(excluded_no_fill_evidence reported). Read-only. Complements "
-            "get_mock_loop_retrospective (KST-day x watch-loop x percent)."
+            "Aggregate retrospectives by group_by in {strategy, day, trigger_type, "
+            "root_cause} over a KST date window: win_rate_pct, avg_pnl_pct, "
+            "absolute realized_pnl sum (per currency), wins/misses, plus "
+            "by_outcome/by_trigger_type/by_root_cause_class breakdowns per group. "
+            "PnL-oriented dims (strategy/day) count only fill-evidence rows "
+            "(excluded_no_fill_evidence reported); process dims "
+            "(trigger_type/root_cause) include no-evidence rows so "
+            "rejected/cancelled postmortems are analyzed too. Read-only. "
+            "Complements get_mock_loop_retrospective."
         ),
     )(get_retrospective_aggregate)
+    _ = mcp.tool(
+        name="trade_retrospective_pending",
+        description=(
+            "List lifecycle-terminal live orders across the 3 live ledgers "
+            "(kis_live KR, generic live US/crypto, toss_live) that still lack a "
+            "trade retrospective, over a KST trade_date window (default: last 14 "
+            "days). Each row carries a suggested_correlation_id to pass to "
+            "save_trade_retrospective so it is marked covered next scan. Optional "
+            "account_mode filter in {kis_live, upbit_live, toss_live}. Read-only "
+            "due-list — no broker/order mutation. (ROB-647)"
+        ),
+    )(trade_retrospective_pending)
 
 
 __all__ = ["TRADE_RETROSPECTIVE_TOOL_NAMES", "register_trade_retrospective_tools"]

--- a/app/mcp_server/tooling/trade_retrospective_tools.py
+++ b/app/mcp_server/tooling/trade_retrospective_tools.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import logging
+from datetime import timedelta
 from typing import Any, cast
 
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
@@ -13,6 +14,7 @@ from app.core.timezone import now_kst
 from app.services.trade_journal.trade_retrospective_service import (
     RetrospectiveValidationError,
     build_retrospective_aggregate,
+    build_retrospective_pending,
     get_retrospectives,
     save_retrospective,
     serialize_retrospective,
@@ -56,10 +58,32 @@ async def save_trade_retrospective(
     total_pnl_krw: float | None = None,
     fx_rate_source: str | None = None,
     fx_pnl_accuracy: str | None = None,
+    trigger_type: str | None = None,
+    root_cause_class: str | None = None,
+    intended_vs_happened: dict | None = None,
+    next_actions: list | None = None,
+    guardrail_fired: str | None = None,
+    policy_version: str | None = None,
 ) -> dict[str, Any]:
     symbol = (symbol or "").strip()
     if not symbol:
         return {"success": False, "error": "symbol is required"}
+    # ROB-647 — forward postmortem fields only when the caller supplied them, so
+    # an idempotent re-save that omits them preserves prior values (the service
+    # distinguishes omitted from explicit-None via a sentinel).
+    postmortem: dict[str, Any] = {}
+    if trigger_type is not None:
+        postmortem["trigger_type"] = trigger_type
+    if root_cause_class is not None:
+        postmortem["root_cause_class"] = root_cause_class
+    if intended_vs_happened is not None:
+        postmortem["intended_vs_happened"] = intended_vs_happened
+    if next_actions is not None:
+        postmortem["next_actions"] = next_actions
+    if guardrail_fired is not None:
+        postmortem["guardrail_fired"] = guardrail_fired
+    if policy_version is not None:
+        postmortem["policy_version"] = policy_version
     try:
         async with _session_factory()() as db:
             action, row = await save_retrospective(
@@ -94,6 +118,7 @@ async def save_trade_retrospective(
                 total_pnl_krw=total_pnl_krw,
                 fx_rate_source=fx_rate_source,
                 fx_pnl_accuracy=fx_pnl_accuracy,
+                **postmortem,
             )
             await db.commit()
             await db.refresh(row)
@@ -167,3 +192,28 @@ async def get_retrospective_aggregate(
     except Exception as exc:  # noqa: BLE001
         logger.exception("get_retrospective_aggregate failed")
         return {"success": False, "error": f"get_retrospective_aggregate failed: {exc}"}
+
+
+async def trade_retrospective_pending(
+    kst_date_from: str | None = None,
+    kst_date_to: str | None = None,
+    account_mode: str | None = None,
+    limit: int = 100,
+) -> dict[str, Any]:
+    today = now_kst().date().isoformat()
+    date_to = kst_date_to or today
+    # Default lookback window: 14 KST days ending today.
+    date_from = kst_date_from or (now_kst().date() - timedelta(days=14)).isoformat()
+    try:
+        async with _session_factory()() as db:
+            result = await build_retrospective_pending(
+                db,
+                kst_date_from=date_from,
+                kst_date_to=date_to,
+                account_mode=account_mode,
+                limit=limit,
+            )
+        return {"success": True, **result}
+    except Exception as exc:  # noqa: BLE001
+        logger.exception("trade_retrospective_pending failed")
+        return {"success": False, "error": f"trade_retrospective_pending failed: {exc}"}

--- a/app/models/review.py
+++ b/app/models/review.py
@@ -946,6 +946,23 @@ class TradeRetrospective(Base):
             "realized_pnl_source IN ('caller_supplied','derived_from_journal')",
             name="ck_trade_retrospectives_pnl_source",
         ),
+        # ROB-647 — postmortem structuring. trigger_type is deliberately
+        # separate from outcome (expired collapses to cancelled at the outcome
+        # layer; see kis_live_ledger.py). Kept in lock-step with
+        # app/schemas/trade_retrospective.py VALID_TRIGGER_TYPES.
+        CheckConstraint(
+            "trigger_type IS NULL OR trigger_type IN ("
+            "'fill','partial_fill','rejected_order','cancelled','expired',"
+            "'thesis_change','policy_violation','stale_evidence','guardrail_block'"
+            ")",
+            name="ck_trade_retrospectives_trigger_type",
+        ),
+        CheckConstraint(
+            "root_cause_class IS NULL OR root_cause_class IN ("
+            "'user_input','analysis','policy','execution','harness'"
+            ")",
+            name="ck_trade_retrospectives_root_cause_class",
+        ),
         Index("ix_trade_retrospectives_correlation_id", "correlation_id"),
         Index("ix_trade_retrospectives_journal_id", "journal_id"),
         Index("ix_trade_retrospectives_strategy_key", "strategy_key"),
@@ -1001,6 +1018,16 @@ class TradeRetrospective(Base):
     next_strategy: Mapped[str | None] = mapped_column(Text)
     evidence_snapshot: Mapped[dict | None] = mapped_column(JSONB)
     created_by_profile: Mapped[str | None] = mapped_column(Text)
+
+    # ROB-647 — postmortem structuring (all additive nullable). JSONB fields are
+    # validated through app/schemas/trade_retrospective.py before write.
+    trigger_type: Mapped[str | None] = mapped_column(Text)
+    root_cause_class: Mapped[str | None] = mapped_column(Text)
+    intended_vs_happened: Mapped[dict | None] = mapped_column(JSONB)
+    next_actions: Mapped[list | None] = mapped_column(JSONB)
+    guardrail_fired: Mapped[str | None] = mapped_column(Text)
+    policy_version: Mapped[str | None] = mapped_column(Text)
+
     created_at: Mapped[datetime] = mapped_column(
         TIMESTAMP(timezone=True), server_default=func.now(), nullable=False
     )

--- a/app/schemas/trade_retrospective.py
+++ b/app/schemas/trade_retrospective.py
@@ -1,0 +1,126 @@
+# app/schemas/trade_retrospective.py
+"""ROB-647 — validated JSONB payloads for postmortem structuring.
+
+``review.trade_retrospectives`` gains additive nullable columns whose JSONB
+values MUST be structurally validated (evidence_snapshot's fully-unvalidated
+passthrough is the anti-pattern we are avoiding — see
+trade_retrospective_service.py). These pydantic models are the typed contract
+for ``intended_vs_happened`` and ``next_actions``; the service coerces raw dicts
+through them and raises ``RetrospectiveValidationError`` on any violation.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+# trigger_type is a CLOSED set kept in lock-step with the DB CHECK
+# (ck_trade_retrospectives_trigger_type) and the alembic migration. It is
+# deliberately distinct from ``outcome``: kis reconcile collapses expired ->
+# cancelled (kis_live_ledger.py), so ``expired`` only survives as a trigger_type.
+VALID_TRIGGER_TYPES: frozenset[str] = frozenset(
+    {
+        "fill",
+        "partial_fill",
+        "rejected_order",
+        "cancelled",
+        "expired",
+        "thesis_change",
+        "policy_violation",
+        "stale_evidence",
+        "guardrail_block",
+    }
+)
+
+# root_cause_class — ported from tradingcodex's postmortem taxonomy.
+VALID_ROOT_CAUSE_CLASSES: frozenset[str] = frozenset(
+    {
+        "user_input",
+        "analysis",
+        "policy",
+        "execution",
+        "harness",
+    }
+)
+
+_VALID_NEXT_ACTION_STATUS: frozenset[str] = frozenset({"open", "in_progress", "done"})
+
+
+class Deviation(BaseModel):
+    """One dimension where intent diverged from what happened.
+
+    Richer than a scalar plan_price/fill_price pair: it names the dimension
+    (price/timing/size/…) and carries planned vs actual plus an optional
+    numeric delta.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    dimension: str
+    planned: Any | None = None
+    actual: Any | None = None
+    delta: float | None = None
+    unit: str | None = None
+    note: str | None = None
+
+    @field_validator("dimension")
+    @classmethod
+    def _dimension_non_empty(cls, v: str) -> str:
+        v = (v or "").strip()
+        if not v:
+            raise ValueError("dimension must be a non-empty string")
+        return v
+
+
+class IntendedVsHappened(BaseModel):
+    """Structured intended-vs-happened deviation record."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    summary: str | None = None
+    deviations: list[Deviation] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def _at_least_one_signal(self) -> IntendedVsHappened:
+        if not self.deviations and not (self.summary and self.summary.strip()):
+            raise ValueError(
+                "intended_vs_happened requires a summary or at least one deviation"
+            )
+        return self
+
+
+class NextAction(BaseModel):
+    """A follow-up action derived from the postmortem.
+
+    ``issue_id`` stores a Linear identifier ONLY (mirrors
+    trade_journal.paperclip_issue_id) — issue creation is the caller/session's
+    job; the repo never adds a Linear API client.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    action: str
+    owner: str | None = None
+    issue_id: str | None = None
+    status: str | None = None
+    due_kst_date: str | None = None
+
+    @field_validator("action")
+    @classmethod
+    def _action_non_empty(cls, v: str) -> str:
+        v = (v or "").strip()
+        if not v:
+            raise ValueError("action must be a non-empty string")
+        return v
+
+    @field_validator("status")
+    @classmethod
+    def _status_allowed(cls, v: str | None) -> str | None:
+        if v is None:
+            return None
+        if v not in _VALID_NEXT_ACTION_STATUS:
+            raise ValueError(
+                f"invalid status: {v} (allowed: {sorted(_VALID_NEXT_ACTION_STATUS)})"
+            )
+        return v

--- a/app/services/trade_journal/trade_retrospective_service.py
+++ b/app/services/trade_journal/trade_retrospective_service.py
@@ -12,13 +12,29 @@ from decimal import Decimal, InvalidOperation
 from typing import Any
 from zoneinfo import ZoneInfo
 
+from pydantic import ValidationError
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.symbol import to_db_symbol
 from app.core.timezone import now_kst
-from app.models.review import TradeRetrospective
+from app.models.review import (
+    KISLiveOrderLedger,
+    LiveOrderLedger,
+    TossLiveOrderLedger,
+    TradeRetrospective,
+)
 from app.models.trade_journal import TradeJournal
+from app.schemas.trade_retrospective import (
+    VALID_ROOT_CAUSE_CLASSES,
+    VALID_TRIGGER_TYPES,
+    IntendedVsHappened,
+    NextAction,
+)
+
+# Sentinel: distinguishes "caller did not provide this field" (preserve on
+# upsert) from "caller explicitly set None" (clear the field).
+_UNSET: Any = object()
 
 _VALID_ACCOUNT_MODES = {
     "kis_mock",
@@ -40,6 +56,41 @@ _KST = ZoneInfo("Asia/Seoul")
 
 class RetrospectiveValidationError(ValueError):
     """Raised when a retrospective payload violates a typed constraint."""
+
+
+def _coerce_intended_vs_happened(raw: Any) -> dict[str, Any]:
+    """Validate ``intended_vs_happened`` through the pydantic contract."""
+    if not isinstance(raw, dict):
+        raise RetrospectiveValidationError(
+            "intended_vs_happened must be an object (dict)"
+        )
+    try:
+        model = IntendedVsHappened.model_validate(raw)
+    except ValidationError as exc:
+        raise RetrospectiveValidationError(
+            f"invalid intended_vs_happened: {exc.errors(include_url=False)}"
+        ) from exc
+    return model.model_dump(exclude_none=True)
+
+
+def _coerce_next_actions(raw: Any) -> list[dict[str, Any]]:
+    """Validate ``next_actions`` (a list of NextAction objects)."""
+    if not isinstance(raw, list):
+        raise RetrospectiveValidationError("next_actions must be a list")
+    out: list[dict[str, Any]] = []
+    for i, item in enumerate(raw):
+        if not isinstance(item, dict):
+            raise RetrospectiveValidationError(
+                f"next_actions[{i}] must be an object (dict)"
+            )
+        try:
+            model = NextAction.model_validate(item)
+        except ValidationError as exc:
+            raise RetrospectiveValidationError(
+                f"invalid next_actions[{i}]: {exc.errors(include_url=False)}"
+            ) from exc
+        out.append(model.model_dump(exclude_none=True))
+    return out
 
 
 def _normalize_symbol(symbol: str, instrument_type: str) -> str:
@@ -126,6 +177,12 @@ def serialize_retrospective(r: TradeRetrospective) -> dict[str, Any]:
         "next_strategy": r.next_strategy,
         "evidence_snapshot": r.evidence_snapshot,
         "created_by_profile": r.created_by_profile,
+        "trigger_type": r.trigger_type,
+        "root_cause_class": r.root_cause_class,
+        "intended_vs_happened": r.intended_vs_happened,
+        "next_actions": r.next_actions,
+        "guardrail_fired": r.guardrail_fired,
+        "policy_version": r.policy_version,
         "created_at": r.created_at.isoformat() if r.created_at else None,
         "updated_at": r.updated_at.isoformat() if r.updated_at else None,
     }
@@ -223,6 +280,12 @@ async def save_retrospective(
     total_pnl_krw: float | None = None,
     fx_rate_source: str | None = None,
     fx_pnl_accuracy: str | None = None,
+    trigger_type: Any = _UNSET,
+    root_cause_class: Any = _UNSET,
+    intended_vs_happened: Any = _UNSET,
+    next_actions: Any = _UNSET,
+    guardrail_fired: Any = _UNSET,
+    policy_version: Any = _UNSET,
 ) -> tuple[str, TradeRetrospective]:
     if account_mode not in _VALID_ACCOUNT_MODES:
         raise RetrospectiveValidationError(f"invalid account_mode: {account_mode}")
@@ -237,6 +300,36 @@ async def save_retrospective(
         raise RetrospectiveValidationError(
             f"invalid realized_pnl_currency: {realized_pnl_currency}"
         )
+
+    # ROB-647 — postmortem fields. Each uses the _UNSET sentinel so an omitted
+    # field is preserved across idempotent correlation_id upserts, while an
+    # explicit None clears it.
+    trigger_set = trigger_type is not _UNSET and trigger_type is not None
+    if trigger_set and trigger_type not in VALID_TRIGGER_TYPES:
+        raise RetrospectiveValidationError(f"invalid trigger_type: {trigger_type}")
+    if (
+        root_cause_class is not _UNSET
+        and root_cause_class is not None
+        and root_cause_class not in VALID_ROOT_CAUSE_CLASSES
+    ):
+        raise RetrospectiveValidationError(
+            f"invalid root_cause_class: {root_cause_class}"
+        )
+
+    next_actions_value: Any = _UNSET
+    if next_actions is not _UNSET and next_actions is not None:
+        next_actions_value = _coerce_next_actions(next_actions)
+
+    # Conditional obligation: setting a trigger_type demands a non-empty
+    # next_actions list in the same call (backcompat: no obligation otherwise).
+    if trigger_set and (next_actions_value is _UNSET or not next_actions_value):
+        raise RetrospectiveValidationError(
+            "next_actions is required (non-empty list) when trigger_type is set"
+        )
+
+    intended_vs_happened_value: Any = _UNSET
+    if intended_vs_happened is not _UNSET and intended_vs_happened is not None:
+        intended_vs_happened_value = _coerce_intended_vs_happened(intended_vs_happened)
 
     # Note: kiwoom_mock is legacy special case; for US/crypto live, evidence
     # should be available.
@@ -323,6 +416,26 @@ async def save_retrospective(
         "fx_rate_source": fx_rate_source,
         "fx_pnl_accuracy": fx_pnl_accuracy,
     }
+
+    # ROB-647 — only include provided postmortem fields so an idempotent
+    # re-save that omits them does not clobber prior values (partial-update).
+    if trigger_type is not _UNSET:
+        payload["trigger_type"] = trigger_type
+    if root_cause_class is not _UNSET:
+        payload["root_cause_class"] = root_cause_class
+    if intended_vs_happened is not _UNSET:
+        payload["intended_vs_happened"] = (
+            None if intended_vs_happened_value is _UNSET else intended_vs_happened_value
+        )
+    if next_actions is not _UNSET:
+        payload["next_actions"] = (
+            None if next_actions_value is _UNSET else next_actions_value
+        )
+    if guardrail_fired is not _UNSET:
+        payload["guardrail_fired"] = guardrail_fired
+    if policy_version is not _UNSET:
+        payload["policy_version"] = policy_version
+
     repo = TradeRetrospectiveRepository(db)
     return await repo.upsert(payload)
 
@@ -403,8 +516,12 @@ async def build_retrospective_aggregate(
     strategy_key: str | None = None,
     group_by: str = "strategy",
 ) -> dict[str, Any]:
-    if group_by not in ("strategy", "day"):
+    if group_by not in ("strategy", "day", "trigger_type", "root_cause"):
         group_by = "strategy"
+    # Process dimensions (trigger_type/root_cause) are about *why* an order
+    # resolved, not PnL — so no-fill-evidence rows (e.g. rejected/cancelled)
+    # must be included, not excluded as they are for the PnL-oriented dims.
+    include_no_evidence = group_by in ("trigger_type", "root_cause")
     filters = []
     if account_mode is not None:
         filters.append(TradeRetrospective.account_mode == account_mode)
@@ -424,14 +541,17 @@ async def build_retrospective_aggregate(
     groups: dict[str, list[TradeRetrospective]] = {}
     excluded_no_evidence = 0
     for r in rows:
-        if not r.fill_evidence_available:
+        if not r.fill_evidence_available and not include_no_evidence:
             excluded_no_evidence += 1
             continue
-        key = (
-            (r.strategy_key or "no_strategy")
-            if group_by == "strategy"
-            else _kst_date_str(r.created_at)
-        )
+        if group_by == "strategy":
+            key = r.strategy_key or "no_strategy"
+        elif group_by == "day":
+            key = _kst_date_str(r.created_at)
+        elif group_by == "trigger_type":
+            key = r.trigger_type or "no_trigger_type"
+        else:  # root_cause
+            key = r.root_cause_class or "no_root_cause"
         groups.setdefault(key, []).append(r)
 
     out: list[dict[str, Any]] = []
@@ -452,8 +572,18 @@ async def build_retrospective_aggregate(
             float(it.total_pnl_krw) for it in items if it.total_pnl_krw is not None
         )
         by_outcome: dict[str, int] = {}
+        by_trigger_type: dict[str, int] = {}
+        by_root_cause_class: dict[str, int] = {}
         for it in items:
             by_outcome[it.outcome] = by_outcome.get(it.outcome, 0) + 1
+            if it.trigger_type:
+                by_trigger_type[it.trigger_type] = (
+                    by_trigger_type.get(it.trigger_type, 0) + 1
+                )
+            if it.root_cause_class:
+                by_root_cause_class[it.root_cause_class] = (
+                    by_root_cause_class.get(it.root_cause_class, 0) + 1
+                )
         out.append(
             {
                 "group": key,
@@ -466,6 +596,8 @@ async def build_retrospective_aggregate(
                 "fx_pnl_krw_sum": fx_pnl_krw_sum,
                 "total_pnl_krw_sum": total_pnl_krw_sum,
                 "by_outcome": by_outcome,
+                "by_trigger_type": by_trigger_type,
+                "by_root_cause_class": by_root_cause_class,
             }
         )
     out.sort(key=lambda g: -g["sample_size"])
@@ -473,4 +605,215 @@ async def build_retrospective_aggregate(
         "group_by": group_by,
         "groups": out,
         "excluded_no_fill_evidence": excluded_no_evidence,
+    }
+
+
+# ROB-647 — terminal (lifecycle-complete) statuses per live ledger. A terminal
+# order deserves a postmortem regardless of whether it filled: rejected /
+# cancelled / anomaly are as instructive as filled. Non-terminal states
+# (accepted / pending / partial / replaced) are omitted — they may still change.
+_KIS_LIVE_TERMINAL = frozenset({"filled", "cancelled", "rejected", "anomaly"})
+_GENERIC_LIVE_TERMINAL = frozenset({"filled", "cancelled", "rejected", "anomaly"})
+_TOSS_TERMINAL = frozenset(
+    {
+        "filled",
+        "cancelled",
+        "rejected",
+        "cancel_rejected",
+        "replace_rejected",
+        "anomaly",
+    }
+)
+# Bound per-ledger scan so a wide window cannot load unbounded rows.
+_PENDING_LEDGER_FETCH_CAP = 1000
+
+
+async def _covered_keys(db: AsyncSession) -> tuple[set[str], set[str]]:
+    """(correlation_ids, report_item_uuids) already carrying a retrospective."""
+    rows = (
+        await db.execute(
+            select(
+                TradeRetrospective.correlation_id,
+                TradeRetrospective.report_item_uuid,
+            )
+        )
+    ).all()
+    covered_cids = {str(cid) for cid, _ in rows if cid}
+    covered_uuids = {str(uid) for _, uid in rows if uid}
+    return covered_cids, covered_uuids
+
+
+def _pending_entry(
+    *,
+    ledger: str,
+    account_mode: str,
+    market: str,
+    instrument_type: str,
+    symbol: str,
+    side: str | None,
+    status: str,
+    order_ref: str | None,
+    report_item_uuid: Any,
+    trade_date: datetime | None,
+    row_id: int,
+) -> dict[str, Any]:
+    ref = order_ref or f"id:{row_id}"
+    return {
+        "ledger": ledger,
+        "ledger_row_id": row_id,
+        "account_mode": account_mode,
+        "market": market,
+        "instrument_type": instrument_type,
+        "symbol": symbol,
+        "side": side,
+        "status": status,
+        "order_ref": order_ref,
+        "report_item_uuid": str(report_item_uuid) if report_item_uuid else None,
+        "trade_date_kst": trade_date.astimezone(_KST).isoformat()
+        if trade_date
+        else None,
+        # The correlation_id a session should pass to save_trade_retrospective so
+        # the row is marked covered on the next pending scan.
+        "suggested_correlation_id": f"{ledger}:{ref}",
+    }
+
+
+def _is_covered(
+    entry: dict[str, Any], covered_cids: set[str], covered_uuids: set[str]
+) -> bool:
+    if entry["report_item_uuid"] and entry["report_item_uuid"] in covered_uuids:
+        return True
+    return entry["suggested_correlation_id"] in covered_cids
+
+
+async def build_retrospective_pending(
+    db: AsyncSession,
+    *,
+    kst_date_from: str,
+    kst_date_to: str,
+    account_mode: str | None = None,
+    limit: int = 100,
+) -> dict[str, Any]:
+    """List terminal live-ledger orders (3 ledgers) lacking a retrospective.
+
+    Read-only. Scans review.{kis_live_order_ledger, live_order_ledger,
+    toss_live_order_ledger} for lifecycle-terminal rows in the KST trade_date
+    window, then subtracts rows already covered by a retrospective (matched on
+    report_item_uuid or the suggested correlation_id). Mirrors the ROB-120
+    coverage pattern (terminal-without-artifact).
+    """
+    window_start = _kst_day_start(kst_date_from)
+    window_end = _kst_day_end(kst_date_to)
+    covered_cids, covered_uuids = await _covered_keys(db)
+
+    pending: list[dict[str, Any]] = []
+    scanned = 0
+
+    # 1. KIS live (KR domestic)
+    if account_mode in (None, "kis_live"):
+        stmt = (
+            select(KISLiveOrderLedger)
+            .where(
+                KISLiveOrderLedger.status.in_(_KIS_LIVE_TERMINAL),
+                KISLiveOrderLedger.trade_date >= window_start,
+                KISLiveOrderLedger.trade_date <= window_end,
+            )
+            .order_by(KISLiveOrderLedger.trade_date.desc())
+            .limit(_PENDING_LEDGER_FETCH_CAP)
+        )
+        for row in (await db.execute(stmt)).scalars().all():
+            scanned += 1
+            entry = _pending_entry(
+                ledger="kis_live",
+                account_mode=row.account_mode,
+                market="kr",
+                instrument_type=row.instrument_type,
+                symbol=row.symbol,
+                side=row.side,
+                status=row.status,
+                order_ref=row.order_no,
+                report_item_uuid=row.report_item_uuid,
+                trade_date=row.trade_date,
+                row_id=row.id,
+            )
+            if not _is_covered(entry, covered_cids, covered_uuids):
+                pending.append(entry)
+
+    # 2. Generic live ledger (US KIS + crypto Upbit)
+    if account_mode in (None, "kis_live", "upbit_live"):
+        gfilters = [
+            LiveOrderLedger.status.in_(_GENERIC_LIVE_TERMINAL),
+            LiveOrderLedger.trade_date >= window_start,
+            LiveOrderLedger.trade_date <= window_end,
+        ]
+        if account_mode is not None:
+            gfilters.append(LiveOrderLedger.account_scope == account_mode)
+        stmt = (
+            select(LiveOrderLedger)
+            .where(*gfilters)
+            .order_by(LiveOrderLedger.trade_date.desc())
+            .limit(_PENDING_LEDGER_FETCH_CAP)
+        )
+        for row in (await db.execute(stmt)).scalars().all():
+            scanned += 1
+            instrument_type = "equity_us" if row.market == "us" else "crypto"
+            entry = _pending_entry(
+                ledger="live",
+                account_mode=row.account_scope,
+                market=row.market,
+                instrument_type=instrument_type,
+                symbol=row.symbol,
+                side=row.side,
+                status=row.status,
+                order_ref=row.order_no,
+                report_item_uuid=row.report_item_uuid,
+                trade_date=row.trade_date,
+                row_id=row.id,
+            )
+            if not _is_covered(entry, covered_cids, covered_uuids):
+                pending.append(entry)
+
+    # 3. Toss live ledger (place operations only; modify/cancel are follow-ups)
+    if account_mode in (None, "toss_live"):
+        stmt = (
+            select(TossLiveOrderLedger)
+            .where(
+                TossLiveOrderLedger.status.in_(_TOSS_TERMINAL),
+                TossLiveOrderLedger.operation_kind == "place",
+                TossLiveOrderLedger.trade_date >= window_start,
+                TossLiveOrderLedger.trade_date <= window_end,
+            )
+            .order_by(TossLiveOrderLedger.trade_date.desc())
+            .limit(_PENDING_LEDGER_FETCH_CAP)
+        )
+        for row in (await db.execute(stmt)).scalars().all():
+            scanned += 1
+            instrument_type = "equity_kr" if row.market == "kr" else "equity_us"
+            entry = _pending_entry(
+                ledger="toss_live",
+                account_mode=row.account_mode,
+                market=row.market,
+                instrument_type=instrument_type,
+                symbol=row.symbol,
+                side=row.side,
+                status=row.status,
+                order_ref=row.broker_order_id or row.client_order_id,
+                report_item_uuid=row.report_item_uuid,
+                trade_date=row.trade_date,
+                row_id=row.id,
+            )
+            if not _is_covered(entry, covered_cids, covered_uuids):
+                pending.append(entry)
+
+    pending.sort(key=lambda e: e["trade_date_kst"] or "", reverse=True)
+    total_pending = len(pending)
+    limited = pending[: max(0, limit)]
+    return {
+        "kst_date_from": kst_date_from,
+        "kst_date_to": kst_date_to,
+        "account_mode": account_mode,
+        "terminal_scanned": scanned,
+        "total_pending": total_pending,
+        "returned": len(limited),
+        "pending": limited,
     }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1325,6 +1325,54 @@ async def db_session():
                         "CHECK (account_mode IN ('kis_mock','kiwoom_mock','kis_live','toss_live','alpaca_paper','upbit_live'))"
                     )
                 )
+                # ROB-647 — postmortem structuring columns + CHECK constraints.
+                # create_all is no-op on the persistent test table; mirror the
+                # additive migration 20260702_rob647 here.
+                for col, ddl in (
+                    ("trigger_type", "TEXT"),
+                    ("root_cause_class", "TEXT"),
+                    ("intended_vs_happened", "JSONB"),
+                    ("next_actions", "JSONB"),
+                    ("guardrail_fired", "TEXT"),
+                    ("policy_version", "TEXT"),
+                ):
+                    await conn.execute(
+                        text(
+                            f"ALTER TABLE review.trade_retrospectives "
+                            f"ADD COLUMN IF NOT EXISTS {col} {ddl}"
+                        )
+                    )
+                await conn.execute(
+                    text(
+                        "ALTER TABLE review.trade_retrospectives "
+                        "DROP CONSTRAINT IF EXISTS ck_trade_retrospectives_trigger_type"
+                    )
+                )
+                await conn.execute(
+                    text(
+                        "ALTER TABLE review.trade_retrospectives "
+                        "ADD CONSTRAINT ck_trade_retrospectives_trigger_type "
+                        "CHECK (trigger_type IS NULL OR trigger_type IN ("
+                        "'fill','partial_fill','rejected_order','cancelled','expired',"
+                        "'thesis_change','policy_violation','stale_evidence',"
+                        "'guardrail_block'))"
+                    )
+                )
+                await conn.execute(
+                    text(
+                        "ALTER TABLE review.trade_retrospectives "
+                        "DROP CONSTRAINT IF EXISTS "
+                        "ck_trade_retrospectives_root_cause_class"
+                    )
+                )
+                await conn.execute(
+                    text(
+                        "ALTER TABLE review.trade_retrospectives "
+                        "ADD CONSTRAINT ck_trade_retrospectives_root_cause_class "
+                        "CHECK (root_cause_class IS NULL OR root_cause_class IN ("
+                        "'user_input','analysis','policy','execution','harness'))"
+                    )
+                )
                 # B-1 (binance-phase1) — benchmark_return_bps on scalping_daily_reviews.
                 # create_all is no-op on the persistent test table, so add here.
                 await conn.execute(

--- a/tests/test_trade_retrospective_aggregate.py
+++ b/tests/test_trade_retrospective_aggregate.py
@@ -209,3 +209,97 @@ async def test_aggregate_sums_fx_and_total_krw(db_session: AsyncSession):
     group = result["groups"][0]
     assert group["fx_pnl_krw_sum"] == pytest.approx(22772.0)
     assert group["total_pnl_krw_sum"] == pytest.approx(112963.4)
+
+
+# ---------------------------------------------------------------------------
+# ROB-647 — trigger_type / root_cause grouping dimensions
+# ---------------------------------------------------------------------------
+
+
+async def _seed_postmortem(
+    db,
+    *,
+    trigger_type,
+    root_cause_class,
+    account_mode="kis_live",
+    outcome="filled",
+):
+    await svc.save_retrospective(
+        db,
+        symbol="005930",
+        instrument_type="equity_kr",
+        account_mode=account_mode,
+        outcome=outcome,
+        trigger_type=trigger_type,
+        root_cause_class=root_cause_class,
+        next_actions=[{"action": "follow up"}],
+    )
+    await db.commit()
+
+
+@pytest.mark.asyncio
+async def test_aggregate_group_by_trigger_type(db_session: AsyncSession):
+    await _seed_postmortem(db_session, trigger_type="fill", root_cause_class="analysis")
+    await _seed_postmortem(
+        db_session, trigger_type="fill", root_cause_class="execution"
+    )
+    await _seed_postmortem(
+        db_session,
+        trigger_type="rejected_order",
+        root_cause_class="policy",
+        outcome="rejected",
+    )
+    result = await svc.build_retrospective_aggregate(
+        db_session, group_by="trigger_type"
+    )
+    assert result["group_by"] == "trigger_type"
+    groups = {g["group"]: g for g in result["groups"]}
+    assert groups["fill"]["sample_size"] == 2
+    assert groups["rejected_order"]["sample_size"] == 1
+    # per-group breakdown dimensions present
+    assert groups["fill"]["by_root_cause_class"] == {"analysis": 1, "execution": 1}
+
+
+@pytest.mark.asyncio
+async def test_aggregate_group_by_root_cause(db_session: AsyncSession):
+    await _seed_postmortem(db_session, trigger_type="fill", root_cause_class="analysis")
+    await _seed_postmortem(
+        db_session,
+        trigger_type="policy_violation",
+        root_cause_class="policy",
+        outcome="rejected",
+    )
+    result = await svc.build_retrospective_aggregate(db_session, group_by="root_cause")
+    groups = {g["group"]: g for g in result["groups"]}
+    assert set(groups) == {"analysis", "policy"}
+    assert groups["policy"]["by_trigger_type"] == {"policy_violation": 1}
+
+
+@pytest.mark.asyncio
+async def test_process_dims_include_no_fill_evidence_rows(db_session: AsyncSession):
+    # kiwoom_mock has no fill evidence — excluded from PnL dims, INCLUDED in
+    # process dims (rejected/cancelled postmortems must still be analyzed).
+    await svc.save_retrospective(
+        db_session,
+        symbol="005930",
+        instrument_type="equity_kr",
+        account_mode="kiwoom_mock",
+        outcome="rejected",
+        trigger_type="rejected_order",
+        root_cause_class="policy",
+        next_actions=[{"action": "review policy"}],
+    )
+    await db_session.commit()
+
+    by_strategy = await svc.build_retrospective_aggregate(
+        db_session, group_by="strategy"
+    )
+    assert by_strategy["excluded_no_fill_evidence"] == 1
+    assert by_strategy["groups"] == []
+
+    by_trigger = await svc.build_retrospective_aggregate(
+        db_session, group_by="trigger_type"
+    )
+    assert by_trigger["excluded_no_fill_evidence"] == 0
+    groups = {g["group"]: g for g in by_trigger["groups"]}
+    assert groups["rejected_order"]["sample_size"] == 1

--- a/tests/test_trade_retrospective_model.py
+++ b/tests/test_trade_retrospective_model.py
@@ -78,3 +78,76 @@ def test_trade_retrospective_us_fx_columns_present():
 def test_trade_retrospective_account_mode_constraint_matches_migration():
     constraint_names = {c.name for c in TradeRetrospective.__table__.constraints}
     assert "ck_trade_retrospectives_account_mode" in constraint_names
+
+
+# ---------------------------------------------------------------------------
+# ROB-647 — postmortem columns + CHECK constraints
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_postmortem_columns_round_trip(db_session: AsyncSession):
+    row = TradeRetrospective(
+        symbol="005930",
+        instrument_type="equity_kr",
+        account_mode="kis_live",
+        outcome="rejected",
+        correlation_id="cid-pm-1",
+        trigger_type="rejected_order",
+        root_cause_class="execution",
+        intended_vs_happened={"summary": "bounced"},
+        next_actions=[{"action": "retry"}],
+        guardrail_fired="opposite_pending",
+        policy_version="p5-v1",
+    )
+    db_session.add(row)
+    await db_session.commit()
+    got = (
+        await db_session.execute(
+            select(TradeRetrospective).where(
+                TradeRetrospective.correlation_id == "cid-pm-1"
+            )
+        )
+    ).scalar_one()
+    assert got.trigger_type == "rejected_order"
+    assert got.root_cause_class == "execution"
+    assert got.intended_vs_happened == {"summary": "bounced"}
+    assert got.next_actions == [{"action": "retry"}]
+    assert got.guardrail_fired == "opposite_pending"
+    assert got.policy_version == "p5-v1"
+
+
+@pytest.mark.asyncio
+async def test_invalid_trigger_type_rejected_by_db(db_session: AsyncSession):
+    from sqlalchemy.exc import IntegrityError
+
+    row = TradeRetrospective(
+        symbol="005930",
+        instrument_type="equity_kr",
+        account_mode="kis_live",
+        outcome="filled",
+        correlation_id="cid-bad-trigger",
+        trigger_type="not_a_real_trigger",
+    )
+    db_session.add(row)
+    with pytest.raises(IntegrityError):
+        await db_session.commit()
+    await db_session.rollback()
+
+
+@pytest.mark.asyncio
+async def test_invalid_root_cause_rejected_by_db(db_session: AsyncSession):
+    from sqlalchemy.exc import IntegrityError
+
+    row = TradeRetrospective(
+        symbol="005930",
+        instrument_type="equity_kr",
+        account_mode="kis_live",
+        outcome="filled",
+        correlation_id="cid-bad-rc",
+        root_cause_class="not_a_class",
+    )
+    db_session.add(row)
+    with pytest.raises(IntegrityError):
+        await db_session.commit()
+    await db_session.rollback()

--- a/tests/test_trade_retrospective_pending.py
+++ b/tests/test_trade_retrospective_pending.py
@@ -1,0 +1,224 @@
+# tests/test_trade_retrospective_pending.py
+"""ROB-647 — trade_retrospective_pending due-list across 3 live ledgers."""
+
+from __future__ import annotations
+
+import uuid
+from decimal import Decimal
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import delete
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.timezone import now_kst
+from app.models.review import (
+    KISLiveOrderLedger,
+    LiveOrderLedger,
+    TossLiveOrderLedger,
+    TradeRetrospective,
+)
+from app.services.trade_journal import trade_retrospective_service as svc
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.usefixtures("investment_reports_cleanup_lock"),
+]
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def _cleanup(
+    db_session: AsyncSession, investment_reports_cleanup_lock: AsyncSession
+):
+    for model in (
+        TradeRetrospective,
+        KISLiveOrderLedger,
+        LiveOrderLedger,
+        TossLiveOrderLedger,
+    ):
+        await db_session.execute(delete(model))
+    await db_session.commit()
+
+
+def _kis_row(*, order_no, status="filled", report_item_uuid=None):
+    return KISLiveOrderLedger(
+        trade_date=now_kst(),
+        symbol="005930",
+        instrument_type="equity_kr",
+        side="buy",
+        order_type="limit",
+        account_mode="kis_live",
+        broker="kis",
+        status=status,
+        lifecycle_state=status,
+        order_no=order_no,
+        quantity=Decimal("1"),
+        report_item_uuid=report_item_uuid,
+    )
+
+
+def _generic_row(*, order_no, market="us", account_scope="kis_live", status="filled"):
+    return LiveOrderLedger(
+        trade_date=now_kst(),
+        broker="kis" if account_scope == "kis_live" else "upbit",
+        account_scope=account_scope,
+        market=market,
+        symbol="AAPL" if market == "us" else "KRW-BTC",
+        side="buy",
+        order_kind="limit",
+        status=status,
+        lifecycle_state=status,
+        order_no=order_no,
+    )
+
+
+def _toss_row(*, client_order_id, broker_order_id=None, status="filled", op="place"):
+    return TossLiveOrderLedger(
+        trade_date=now_kst(),
+        broker="toss",
+        account_mode="toss_live",
+        operation_kind=op,
+        market="kr",
+        symbol="005930",
+        side="buy",
+        order_type="limit",
+        status=status,
+        client_order_id=client_order_id,
+        broker_order_id=broker_order_id,
+    )
+
+
+@pytest.mark.asyncio
+async def test_lists_terminal_rows_from_all_three_ledgers(db_session: AsyncSession):
+    db_session.add_all(
+        [
+            _kis_row(order_no="K1"),
+            _generic_row(order_no="G1"),
+            _toss_row(client_order_id="T1", broker_order_id="TB1"),
+        ]
+    )
+    await db_session.commit()
+
+    result = await svc.build_retrospective_pending(
+        db_session, kst_date_from="2000-01-01", kst_date_to="2100-01-01"
+    )
+    ledgers = {p["ledger"] for p in result["pending"]}
+    assert ledgers == {"kis_live", "live", "toss_live"}
+    assert result["total_pending"] == 3
+    # suggested correlation ids are namespaced per ledger
+    by_ledger = {p["ledger"]: p for p in result["pending"]}
+    assert by_ledger["kis_live"]["suggested_correlation_id"] == "kis_live:K1"
+    assert by_ledger["live"]["suggested_correlation_id"] == "live:G1"
+    assert by_ledger["toss_live"]["suggested_correlation_id"] == "toss_live:TB1"
+
+
+@pytest.mark.asyncio
+async def test_non_terminal_rows_excluded(db_session: AsyncSession):
+    db_session.add_all(
+        [
+            _kis_row(order_no="K1", status="accepted"),
+            _generic_row(order_no="G1", status="pending"),
+            _toss_row(client_order_id="T1", status="partial"),
+        ]
+    )
+    await db_session.commit()
+    result = await svc.build_retrospective_pending(
+        db_session, kst_date_from="2000-01-01", kst_date_to="2100-01-01"
+    )
+    assert result["total_pending"] == 0
+
+
+@pytest.mark.asyncio
+async def test_covered_by_suggested_correlation_id(db_session: AsyncSession):
+    db_session.add(_kis_row(order_no="K1"))
+    await db_session.commit()
+    # A retrospective written with the tool-suggested correlation_id covers it.
+    await svc.save_retrospective(
+        db_session,
+        symbol="005930",
+        instrument_type="equity_kr",
+        account_mode="kis_live",
+        outcome="filled",
+        correlation_id="kis_live:K1",
+    )
+    await db_session.commit()
+
+    result = await svc.build_retrospective_pending(
+        db_session, kst_date_from="2000-01-01", kst_date_to="2100-01-01"
+    )
+    assert result["total_pending"] == 0
+
+
+@pytest.mark.asyncio
+async def test_covered_by_report_item_uuid(db_session: AsyncSession):
+    rid = uuid.uuid4()
+    db_session.add(_kis_row(order_no="K1", report_item_uuid=rid))
+    await db_session.commit()
+    await svc.save_retrospective(
+        db_session,
+        symbol="005930",
+        instrument_type="equity_kr",
+        account_mode="kis_live",
+        outcome="filled",
+        report_item_uuid=str(rid),
+    )
+    await db_session.commit()
+
+    result = await svc.build_retrospective_pending(
+        db_session, kst_date_from="2000-01-01", kst_date_to="2100-01-01"
+    )
+    assert result["total_pending"] == 0
+
+
+@pytest.mark.asyncio
+async def test_account_mode_filter(db_session: AsyncSession):
+    db_session.add_all(
+        [
+            _kis_row(order_no="K1"),
+            _generic_row(order_no="G1", market="crypto", account_scope="upbit_live"),
+            _toss_row(client_order_id="T1", broker_order_id="TB1"),
+        ]
+    )
+    await db_session.commit()
+
+    result = await svc.build_retrospective_pending(
+        db_session,
+        kst_date_from="2000-01-01",
+        kst_date_to="2100-01-01",
+        account_mode="toss_live",
+    )
+    assert {p["ledger"] for p in result["pending"]} == {"toss_live"}
+
+    result_upbit = await svc.build_retrospective_pending(
+        db_session,
+        kst_date_from="2000-01-01",
+        kst_date_to="2100-01-01",
+        account_mode="upbit_live",
+    )
+    assert {p["ledger"] for p in result_upbit["pending"]} == {"live"}
+    assert result_upbit["pending"][0]["market"] == "crypto"
+
+
+@pytest.mark.asyncio
+async def test_toss_non_place_operations_excluded(db_session: AsyncSession):
+    db_session.add(
+        _toss_row(client_order_id="T-cancel", broker_order_id="TBc", op="cancel")
+    )
+    await db_session.commit()
+    result = await svc.build_retrospective_pending(
+        db_session, kst_date_from="2000-01-01", kst_date_to="2100-01-01"
+    )
+    assert result["total_pending"] == 0
+
+
+@pytest.mark.asyncio
+async def test_rejected_order_without_order_no_uses_row_id(db_session: AsyncSession):
+    db_session.add(_kis_row(order_no=None, status="rejected"))
+    await db_session.commit()
+    result = await svc.build_retrospective_pending(
+        db_session, kst_date_from="2000-01-01", kst_date_to="2100-01-01"
+    )
+    assert result["total_pending"] == 1
+    entry = result["pending"][0]
+    assert entry["order_ref"] is None
+    assert entry["suggested_correlation_id"].startswith("kis_live:id:")

--- a/tests/test_trade_retrospective_schema.py
+++ b/tests/test_trade_retrospective_schema.py
@@ -1,0 +1,92 @@
+# tests/test_trade_retrospective_schema.py
+"""ROB-647 — pure-unit validation of postmortem JSONB pydantic contracts."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from app.schemas.trade_retrospective import (
+    VALID_ROOT_CAUSE_CLASSES,
+    VALID_TRIGGER_TYPES,
+    IntendedVsHappened,
+    NextAction,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def test_trigger_type_taxonomy_is_closed_and_stable():
+    assert "expired" in VALID_TRIGGER_TYPES
+    assert "fill" in VALID_TRIGGER_TYPES
+    assert "policy_violation" in VALID_TRIGGER_TYPES
+    # expired must NOT be an outcome — it only survives as a trigger_type.
+    assert VALID_ROOT_CAUSE_CLASSES == {
+        "user_input",
+        "analysis",
+        "policy",
+        "execution",
+        "harness",
+    }
+
+
+def test_intended_vs_happened_requires_a_signal():
+    with pytest.raises(ValidationError):
+        IntendedVsHappened.model_validate({})
+    with pytest.raises(ValidationError):
+        IntendedVsHappened.model_validate({"deviations": []})
+
+
+def test_intended_vs_happened_summary_only_ok():
+    m = IntendedVsHappened.model_validate({"summary": "entered late"})
+    assert m.summary == "entered late"
+    assert m.deviations == []
+
+
+def test_intended_vs_happened_deviation_structure():
+    m = IntendedVsHappened.model_validate(
+        {
+            "deviations": [
+                {
+                    "dimension": "price",
+                    "planned": 100.0,
+                    "actual": 103.5,
+                    "delta": 3.5,
+                    "unit": "USD",
+                }
+            ]
+        }
+    )
+    assert m.deviations[0].dimension == "price"
+    assert m.deviations[0].delta == 3.5
+
+
+def test_intended_vs_happened_rejects_unknown_key():
+    with pytest.raises(ValidationError):
+        IntendedVsHappened.model_validate({"summary": "x", "bogus": 1})
+
+
+def test_intended_vs_happened_rejects_empty_dimension():
+    with pytest.raises(ValidationError):
+        IntendedVsHappened.model_validate({"deviations": [{"dimension": "  "}]})
+
+
+def test_next_action_requires_action():
+    with pytest.raises(ValidationError):
+        NextAction.model_validate({"owner": "claude"})
+    with pytest.raises(ValidationError):
+        NextAction.model_validate({"action": "   "})
+
+
+def test_next_action_status_constrained():
+    with pytest.raises(ValidationError):
+        NextAction.model_validate({"action": "do", "status": "wip"})
+    m = NextAction.model_validate(
+        {"action": "raise issue", "issue_id": "ROB-999", "status": "open"}
+    )
+    assert m.issue_id == "ROB-999"
+
+
+def test_next_action_rejects_unknown_key():
+    with pytest.raises(ValidationError):
+        NextAction.model_validate({"action": "do", "bogus": True})

--- a/tests/test_trade_retrospective_service.py
+++ b/tests/test_trade_retrospective_service.py
@@ -391,3 +391,174 @@ async def test_retrospective_derives_fx_fields_from_journal(
     assert row.total_pnl_krw == Decimal("112963.4000")
     assert row.fx_rate_source == "reconcile_spot"
     assert row.fx_pnl_accuracy == "approximate"
+
+
+# ---------------------------------------------------------------------------
+# ROB-647 — postmortem structuring
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_postmortem_fields_persist(db_session: AsyncSession):
+    action, row = await svc.save_retrospective(
+        db_session,
+        symbol="005930",
+        instrument_type="equity_kr",
+        account_mode="kis_live",
+        outcome="rejected",
+        trigger_type="rejected_order",
+        root_cause_class="execution",
+        guardrail_fired="loss_sell_guard",
+        policy_version="p5-v3",
+        intended_vs_happened={
+            "summary": "order bounced",
+            "deviations": [{"dimension": "price", "planned": 100, "actual": 0}],
+        },
+        next_actions=[{"action": "retry with limit", "issue_id": "ROB-1"}],
+    )
+    await db_session.commit()
+    assert action == "created"
+    assert row.trigger_type == "rejected_order"
+    assert row.root_cause_class == "execution"
+    assert row.guardrail_fired == "loss_sell_guard"
+    assert row.policy_version == "p5-v3"
+    assert row.intended_vs_happened["deviations"][0]["dimension"] == "price"
+    assert row.next_actions[0]["action"] == "retry with limit"
+    assert row.next_actions[0]["issue_id"] == "ROB-1"
+
+
+@pytest.mark.asyncio
+async def test_trigger_type_requires_next_actions(db_session: AsyncSession):
+    with pytest.raises(svc.RetrospectiveValidationError):
+        await svc.save_retrospective(
+            db_session,
+            symbol="005930",
+            instrument_type="equity_kr",
+            account_mode="kis_live",
+            outcome="filled",
+            trigger_type="fill",
+        )
+
+
+@pytest.mark.asyncio
+async def test_trigger_type_rejects_empty_next_actions(db_session: AsyncSession):
+    with pytest.raises(svc.RetrospectiveValidationError):
+        await svc.save_retrospective(
+            db_session,
+            symbol="005930",
+            instrument_type="equity_kr",
+            account_mode="kis_live",
+            outcome="filled",
+            trigger_type="fill",
+            next_actions=[],
+        )
+
+
+@pytest.mark.asyncio
+async def test_invalid_trigger_type_rejected(db_session: AsyncSession):
+    with pytest.raises(svc.RetrospectiveValidationError):
+        await svc.save_retrospective(
+            db_session,
+            symbol="005930",
+            instrument_type="equity_kr",
+            account_mode="kis_live",
+            outcome="filled",
+            trigger_type="bogus",
+            next_actions=[{"action": "x"}],
+        )
+
+
+@pytest.mark.asyncio
+async def test_invalid_root_cause_class_rejected(db_session: AsyncSession):
+    with pytest.raises(svc.RetrospectiveValidationError):
+        await svc.save_retrospective(
+            db_session,
+            symbol="005930",
+            instrument_type="equity_kr",
+            account_mode="kis_live",
+            outcome="filled",
+            root_cause_class="bogus",
+        )
+
+
+@pytest.mark.asyncio
+async def test_invalid_intended_vs_happened_rejected(db_session: AsyncSession):
+    with pytest.raises(svc.RetrospectiveValidationError):
+        await svc.save_retrospective(
+            db_session,
+            symbol="005930",
+            instrument_type="equity_kr",
+            account_mode="kis_live",
+            outcome="filled",
+            intended_vs_happened={"unknown_key": 1},
+        )
+
+
+@pytest.mark.asyncio
+async def test_next_actions_allowed_without_trigger_type(db_session: AsyncSession):
+    # Obligation is conditional: next_actions may exist with no trigger_type.
+    _, row = await svc.save_retrospective(
+        db_session,
+        symbol="005930",
+        instrument_type="equity_kr",
+        account_mode="kis_live",
+        outcome="filled",
+        next_actions=[{"action": "watch for pullback"}],
+    )
+    await db_session.commit()
+    assert row.trigger_type is None
+    assert row.next_actions[0]["action"] == "watch for pullback"
+
+
+@pytest.mark.asyncio
+async def test_upsert_preserves_omitted_postmortem_fields(db_session: AsyncSession):
+    # First: rich postmortem keyed by correlation_id.
+    await svc.save_retrospective(
+        db_session,
+        symbol="005930",
+        instrument_type="equity_kr",
+        account_mode="kis_live",
+        outcome="filled",
+        correlation_id="cid-preserve",
+        trigger_type="fill",
+        root_cause_class="analysis",
+        next_actions=[{"action": "hold"}],
+    )
+    await db_session.commit()
+
+    # Second: idempotent re-save (e.g. lean outcome update) omitting postmortem.
+    action, row = await svc.save_retrospective(
+        db_session,
+        symbol="005930",
+        instrument_type="equity_kr",
+        account_mode="kis_live",
+        outcome="filled",
+        correlation_id="cid-preserve",
+        pnl_pct=2.0,
+    )
+    await db_session.commit()
+    assert action == "updated"
+    assert row.trigger_type == "fill"
+    assert row.root_cause_class == "analysis"
+    assert row.next_actions[0]["action"] == "hold"
+    assert float(row.pnl_pct) == 2.0
+
+
+@pytest.mark.asyncio
+async def test_serialize_includes_postmortem_fields(db_session: AsyncSession):
+    _, row = await svc.save_retrospective(
+        db_session,
+        symbol="005930",
+        instrument_type="equity_kr",
+        account_mode="kis_live",
+        outcome="cancelled",
+        trigger_type="expired",
+        next_actions=[{"action": "resubmit tomorrow"}],
+    )
+    await db_session.commit()
+    data = svc.serialize_retrospective(row)
+    assert data["trigger_type"] == "expired"
+    assert data["next_actions"][0]["action"] == "resubmit tomorrow"
+    assert "intended_vs_happened" in data
+    assert "guardrail_fired" in data
+    assert "policy_version" in data

--- a/tests/test_trade_retrospective_tools.py
+++ b/tests/test_trade_retrospective_tools.py
@@ -8,12 +8,14 @@ import pytest_asyncio
 from sqlalchemy import delete
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.timezone import now_kst
 from app.mcp_server.tooling.trade_retrospective_tools import (
     get_retrospective_aggregate,
     get_trade_retrospectives,
     save_trade_retrospective,
+    trade_retrospective_pending,
 )
-from app.models.review import TradeRetrospective
+from app.models.review import KISLiveOrderLedger, TradeRetrospective
 
 pytestmark = [
     pytest.mark.integration,
@@ -26,6 +28,7 @@ async def _cleanup(
     db_session: AsyncSession, investment_reports_cleanup_lock: AsyncSession
 ):
     await db_session.execute(delete(TradeRetrospective))
+    await db_session.execute(delete(KISLiveOrderLedger))
     await db_session.commit()
 
 
@@ -145,6 +148,7 @@ def test_tool_names_set_complete():
         "save_trade_retrospective",
         "get_trade_retrospectives",
         "get_retrospective_aggregate",
+        "trade_retrospective_pending",
     }
 
 
@@ -155,6 +159,7 @@ def test_tools_in_available_surface():
         "save_trade_retrospective",
         "get_trade_retrospectives",
         "get_retrospective_aggregate",
+        "trade_retrospective_pending",
     ):
         assert name in AVAILABLE_TOOL_NAMES
 
@@ -180,4 +185,63 @@ def test_register_wires_three_tools():
         "save_trade_retrospective",
         "get_trade_retrospectives",
         "get_retrospective_aggregate",
+        "trade_retrospective_pending",
     }
+
+
+# ---------------------------------------------------------------------------
+# ROB-647 — postmortem forwarding + due-list tool
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_save_with_postmortem_envelope():
+    res = await save_trade_retrospective(
+        symbol="005930",
+        instrument_type="equity_kr",
+        account_mode="kis_live",
+        outcome="filled",
+        trigger_type="fill",
+        root_cause_class="analysis",
+        next_actions=[{"action": "scale in", "issue_id": "ROB-2"}],
+    )
+    assert res["success"] is True
+    assert res["data"]["trigger_type"] == "fill"
+    assert res["data"]["next_actions"][0]["issue_id"] == "ROB-2"
+
+
+@pytest.mark.asyncio
+async def test_save_trigger_without_next_actions_envelope():
+    res = await save_trade_retrospective(
+        symbol="005930",
+        instrument_type="equity_kr",
+        account_mode="kis_live",
+        outcome="filled",
+        trigger_type="fill",
+    )
+    assert res["success"] is False
+    assert "next_actions" in res["error"]
+
+
+@pytest.mark.asyncio
+async def test_pending_tool_envelope(db_session: AsyncSession):
+    db_session.add(
+        KISLiveOrderLedger(
+            trade_date=now_kst(),
+            symbol="005930",
+            instrument_type="equity_kr",
+            side="buy",
+            order_type="limit",
+            account_mode="kis_live",
+            broker="kis",
+            status="filled",
+            lifecycle_state="filled",
+            order_no="K-TOOL-1",
+        )
+    )
+    await db_session.commit()
+
+    res = await trade_retrospective_pending()
+    assert res["success"] is True
+    refs = {p["suggested_correlation_id"] for p in res["pending"]}
+    assert "kis_live:K-TOOL-1" in refs


### PR DESCRIPTION
## What (ROB-647)

Additive-only **postmortem structuring** on `review.trade_retrospectives` + a read-only **due-list MCP tool**. Follows the confirmed scoping decision: reconcile kernel (3 ledgers) is **unchanged** — automatic skeleton-row creation was rejected because `TradeRetrospectiveRepository.upsert` overwrites whole rows (footgun); automation is deferred.

## Migration `20260702_rob647` (additive only, backcompat)

Six nullable columns on `review.trade_retrospectives`:
- **`trigger_type`** — CHECK-constrained, deliberately **distinct from `outcome`**. KIS reconcile collapses `expired → cancelled` at the outcome layer (`kis_live_ledger.py`), so `expired` only survives as a trigger_type.
- **`root_cause_class`** — CHECK (`user_input`/`analysis`/`policy`/`execution`/`harness`), ported from tradingcodex.
- **`intended_vs_happened`** — validated JSONB (deviation structure beyond a scalar plan/fill pair).
- **`next_actions`** — validated JSONB list. `issue_id` stores a **Linear identifier only** (mirrors `trade_journal.paperclip_issue_id`); no Linear API client added.
- **`guardrail_fired`**, **`policy_version`** (P5 policy-stamping alignment).

## Service (`trade_retrospective_service.py`)

- pydantic contracts (`app/schemas/trade_retrospective.py`) for the JSONB fields — `evidence_snapshot`'s fully-unvalidated passthrough is **not** repeated.
- `save_retrospective`: all new fields optional; **setting `trigger_type` requires a non-empty `next_actions`** (conditional obligation; existing callers stay backcompat).
- **upsert partial-update**: new fields use an `_UNSET` sentinel, so an idempotent re-save that omits them **preserves** prior postmortem values (addresses the whole-row-overwrite footgun for the additive fields).
- `build_retrospective_aggregate`: `group_by` adds `{trigger_type, root_cause}` (process dims **include** no-fill-evidence rows so rejected/cancelled postmortems are analyzed) + per-group `by_trigger_type`/`by_root_cause_class` breakdowns.
- `build_retrospective_pending`: lifecycle-**terminal** rows across the 3 live ledgers (`kis_live` KR, generic live US/crypto, `toss_live`) lacking a retrospective, matched on `report_item_uuid` or a namespaced `suggested_correlation_id`, KST `trade_date` windowed (ROB-120 coverage pattern).

## MCP

- New read-only **`trade_retrospective_pending`** tool (default 14-day KST lookback; each row carries a `suggested_correlation_id` to pass back to `save_trade_retrospective`).
- `save_trade_retrospective` forwards postmortem fields only when supplied (preserves partial-update through the tool surface).
- `get_retrospective_aggregate` description updated for the new group_by dims.

## Tests

`test_trade_retrospective_schema.py` (pure unit), `_model` (CHECK round-trip + DB rejection), `_service` (validation, conditional obligation, partial-update preservation), `_aggregate` (trigger/root_cause dims + no-evidence inclusion), `_pending` (3 ledgers, coverage matching, account_mode filter, place-only toss, order-no-less fallback), `_tools` (postmortem envelope + due-list). All green; ruff + `ty` clean; single alembic head; playbook tool-name drift test (ROB-643) green.

## Out of scope / notes

- The `operator_session_context.account_scope` CHECK drift (missing `toss_live`/`kiwoom_mock`) was flagged in the issue as a *candidate*; left out to keep this migration strictly additive (a CHECK swap on a different table).
- `next_actions → Linear` issue creation remains the session's job (identifier storage only).

## Operator

Additive migration is included but **not** auto-applied: `uv run alembic upgrade head`, then restart the MCP server to expose `trade_retrospective_pending`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)