### PR TITLE
fix(ROB-645): remove KIS/Upbit order POST timeout retry (live double-submit) + Upbit identifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.3.2] - 2026-07-02
+
+### Fixed (ROB-645 — order POST timeout retry → live double-submit exposure removed)
+- KIS order-mutation callsites (domestic + overseas: order/cancel/modify) now pass `retry_request_errors=False` and `max_retries_override=0` to the shared transport, so a timed-out **or** rate-limited (EGW00215 '초과' / HTTP 429) order POST is sent exactly once and never re-POSTed. Read paths (quotes/balance/history) keep their existing RequestError and rate-limit retries.
+- Upbit order-creation POSTs (`POST /v1/orders`) are excluded from the `_retry_with_backoff` RequestError retry (a timed-out order may have reached the broker); GET reads and DELETE cancels keep retrying. Each Upbit order now carries a unique `identifier` client idempotency key (uuid4 per order) so a resent/duplicate order is rejected by the broker.
+- A timed-out/network-failed order send now surfaces an explicit, non-blank error (`outcome_unknown: true` + `reconcile_tool`) telling the caller to run `kis_live_reconcile_orders` (KR) / `live_reconcile_orders` (US·crypto) instead of re-sending — never a blank error, never an auto-retry.
+
+### Added (ROB-585 absorbed by ROB-645 — KIS batch order pre-send throttle)
+- Order TR_IDs (domestic/overseas order-cash + order-rvsecncl) throttled to 8/s in `DEFAULT_KIS_API_RATE_LIMITS`. With order re-POST retries removed, this pre-send wait is the sole guard against the KIS 초당 거래건수 limit; orders that still exceed it fail fast rather than being re-sent. Supersedes PR #1331 (its `max_retries_override=3` would have re-POSTed on EGW00215).
+
 ## [0.3.1] - 2026-06-17
 
 ### Added (ROB-592 — stock detail per-symbol watch card + fill detail upgrade)

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -45,6 +45,35 @@ DEFAULT_KIS_API_RATE_LIMITS: ApiRateLimitMap = {
         "rate": 10,
         "period": 1.0,
     },
+    # ROB-585 (absorbed by ROB-645): order TRs throttled to 8/s so batch orders
+    # stay under the KIS ledger limit (EGW00215 '초당 거래건수 초과'). ROB-645
+    # removes all order re-POST retries, so this pre-send wait is the only guard
+    # against the rate limit — orders that still exceed it fail fast, never re-sent.
+    "TTTC0012U|/uapi/domestic-stock/v1/trading/order-cash": {"rate": 8, "period": 1.0},
+    "VTTC0012U|/uapi/domestic-stock/v1/trading/order-cash": {"rate": 8, "period": 1.0},
+    "TTTC0011U|/uapi/domestic-stock/v1/trading/order-cash": {"rate": 8, "period": 1.0},
+    "VTTC0011U|/uapi/domestic-stock/v1/trading/order-cash": {"rate": 8, "period": 1.0},
+    "TTTC0013U|/uapi/domestic-stock/v1/trading/order-rvsecncl": {
+        "rate": 8,
+        "period": 1.0,
+    },
+    "VTTC0013U|/uapi/domestic-stock/v1/trading/order-rvsecncl": {
+        "rate": 8,
+        "period": 1.0,
+    },
+    "TTTT1002U|/uapi/overseas-stock/v1/trading/order": {"rate": 8, "period": 1.0},
+    "VTTT1002U|/uapi/overseas-stock/v1/trading/order": {"rate": 8, "period": 1.0},
+    "TTTT1006U|/uapi/overseas-stock/v1/trading/order": {"rate": 8, "period": 1.0},
+    "VTTT1006U|/uapi/overseas-stock/v1/trading/order": {"rate": 8, "period": 1.0},
+    "VTTT1001U|/uapi/overseas-stock/v1/trading/order": {"rate": 8, "period": 1.0},
+    "TTTT1004U|/uapi/overseas-stock/v1/trading/order-rvsecncl": {
+        "rate": 8,
+        "period": 1.0,
+    },
+    "VTTT1004U|/uapi/overseas-stock/v1/trading/order-rvsecncl": {
+        "rate": 8,
+        "period": 1.0,
+    },
 }
 
 DEFAULT_UPBIT_API_RATE_LIMITS: ApiRateLimitMap = {

--- a/app/mcp_server/tooling/order_execution.py
+++ b/app/mcp_server/tooling/order_execution.py
@@ -12,6 +12,8 @@ from decimal import Decimal
 from typing import Any, Literal
 from typing import cast as typing_cast
 
+import httpx
+
 import app.services.brokers.upbit.client as upbit_service
 from app.core.exceptions import describe_exception
 from app.mcp_server.caller_identity import get_caller_source
@@ -700,6 +702,18 @@ async def _execute_and_record(
             market_type=market_type,
             is_mock=is_mock,
         )
+    except httpx.RequestError as send_exc:
+        # ROB-645: the order POST itself timed out / failed with no broker response.
+        # Outcome is UNKNOWN (may have been accepted) — never re-send; reconcile.
+        logger.error(
+            "execute_order 실패(outcome unknown): stage=execute_order, "
+            "market_type=%s, symbol=%s, side=%s, error=%s",
+            market_type,
+            normalized_symbol,
+            side,
+            describe_exception(send_exc),
+        )
+        raise OrderSendOutcomeUnknown(send_exc) from send_exc
     except Exception as exec_exc:
         logger.error(
             "execute_order 실패: stage=execute_order, market_type=%s, "
@@ -923,6 +937,72 @@ def _build_order_error(
         "symbol": symbol,
         "instrument_type": market_type,
     }
+
+
+class OrderSendOutcomeUnknown(Exception):
+    """ROB-645 — an order POST failed with no definitive broker response
+    (timeout/network error), so we cannot tell whether the order was accepted.
+
+    Raised ONLY around the actual send (``_execute_order``); a RequestError during
+    a pre-send read (price/balance/preview) means the order was never submitted and
+    must NOT be treated as outcome-unknown. Wraps the original transport exception.
+    """
+
+    def __init__(self, original: BaseException) -> None:
+        super().__init__(describe_exception(original))
+        self.original = original
+
+
+# ROB-645: reconcile tool to consult when an order's send outcome is unknown.
+# Only live paths have a reconcile tool (KR → kis_live_reconcile_orders,
+# US/crypto → live_reconcile_orders). Mock has none, so we never name a phantom.
+_LIVE_RECONCILE_TOOL_BY_MARKET = {
+    "equity_kr": "kis_live_reconcile_orders",
+    "equity_us": "live_reconcile_orders",
+    "crypto": "live_reconcile_orders",
+}
+
+
+def _reconcile_tool_for(*, market_type: str, is_mock: bool) -> str | None:
+    """Return the reconcile MCP tool that confirms whether an order was accepted."""
+    if is_mock:
+        return None
+    return _LIVE_RECONCILE_TOOL_BY_MARKET.get(market_type)
+
+
+def _augment_error_for_unknown_outcome(
+    base_error: dict[str, Any],
+    exc: BaseException,
+    *,
+    market_type: str,
+    is_mock: bool,
+) -> dict[str, Any]:
+    """ROB-645 — enrich an order error when the send outcome is UNKNOWN.
+
+    A timed-out / network-failed order POST may have reached the broker even
+    though no response came back. We no longer retry such sends (retry =
+    double-submit), so surface an explicit, non-blank error that tells the caller
+    to reconcile — never to re-send. Anything that is not a send-time
+    outcome-unknown failure (a definitive rejection, or a pre-send read timeout)
+    is left unchanged: no order was created.
+    """
+    if not isinstance(exc, OrderSendOutcomeUnknown):
+        return base_error
+
+    reconcile_tool = _reconcile_tool_for(market_type=market_type, is_mock=is_mock)
+    reason = describe_exception(exc.original)
+    if reconcile_tool:
+        confirm_hint = f"{reconcile_tool} 도구로 실제 접수 여부를 확인하세요."
+    else:
+        confirm_hint = "브로커에서 실제 주문 상태를 확인하세요."
+
+    enriched = dict(base_error)
+    enriched["outcome_unknown"] = True
+    enriched["reconcile_tool"] = reconcile_tool
+    enriched["error"] = (
+        f"주문 접수 여부 불확실 (전송 실패: {reason}). 재전송하지 말고 {confirm_hint}"
+    )
+    return enriched
 
 
 async def _place_order_impl(
@@ -1160,7 +1240,12 @@ async def _place_order_impl(
             ),
             caller_source=get_caller_source() if defensive_trim_ctx else None,
         )
-        return _order_error(describe_exception(exc))
+        # ROB-645: a timed-out order send has an unknown outcome — tell the caller
+        # to reconcile instead of re-sending (order retries are disabled).
+        base_error = _order_error(describe_exception(exc))
+        return _augment_error_for_unknown_outcome(
+            base_error, exc, market_type=market_type, is_mock=is_mock
+        )
 
 
 __all__ = [

--- a/app/services/brokers/kis/base.py
+++ b/app/services/brokers/kis/base.py
@@ -384,6 +384,7 @@ class BaseKISClient:
         api_name: str = "unknown",
         tr_id: str | None = None,
         retry_request_errors: bool = True,
+        max_retries_override: int | None = None,
     ) -> dict[str, Any]:
         """Make HTTP request with rate limiting and 429 retry logic.
 
@@ -397,6 +398,9 @@ class BaseKISClient:
             api_name: Human-readable API name for logging
             tr_id: KIS TR_ID for per-API rate limiting
             retry_request_errors: whether to retry on httpx.RequestError (timeouts, etc)
+            max_retries_override: cap the retry count for this call. ROB-645 order
+                submission passes ``0`` so a timed-out or rate-limited (EGW00215)
+                order POST is sent exactly once and never re-POSTed.
 
         Returns:
             Parsed JSON response
@@ -416,6 +420,7 @@ class BaseKISClient:
             api_name=api_name,
             tr_id=tr_id,
             retry_request_errors=retry_request_errors,
+            max_retries_override=max_retries_override,
         )
         return data
 
@@ -431,6 +436,7 @@ class BaseKISClient:
         api_name: str = "unknown",
         tr_id: str | None = None,
         retry_request_errors: bool = True,
+        max_retries_override: int | None = None,
     ) -> tuple[dict[str, Any], dict[str, str]]:
         """Like :meth:`_request_with_rate_limit` but also returns response headers.
 
@@ -450,7 +456,11 @@ class BaseKISClient:
 
         rate, period = self._get_rate_limit_for_api(api_key)
         limiter = await self._get_limiter(api_key, rate=rate, period=period)
-        max_retries = self._settings.api_rate_limit_retry_429_max
+        max_retries = (
+            max_retries_override
+            if max_retries_override is not None
+            else self._settings.api_rate_limit_retry_429_max
+        )
 
         last_error: Exception | None = None
 

--- a/app/services/brokers/kis/domestic_orders.py
+++ b/app/services/brokers/kis/domestic_orders.py
@@ -315,6 +315,11 @@ class DomesticOrderClient:
             timeout=10,
             api_name="order_korea_stock",
             tr_id=tr_id,
+            # ROB-645: never re-POST an order. retry_request_errors=False drops
+            # timeout/network retries; max_retries_override=0 drops EGW00215/'초과'
+            # and 429 re-POSTs (throttle is pre-send wait only).
+            retry_request_errors=False,
+            max_retries_override=0,
         )
 
         if js.get("rt_cd") != "0":
@@ -481,6 +486,10 @@ class DomesticOrderClient:
             timeout=10,
             api_name="cancel_korea_order",
             tr_id=tr_id,
+            # ROB-645: cancel is by order-number so a re-POST is relatively benign,
+            # but keep the no-double-submit policy uniform across order mutations.
+            retry_request_errors=False,
+            max_retries_override=0,
         )
 
         if js.get("rt_cd") != "0":
@@ -797,6 +806,10 @@ class DomesticOrderClient:
             timeout=10,
             api_name="modify_korea_order",
             tr_id=tr_id,
+            # ROB-645: a re-applied modify can double-mutate an already-modified
+            # order, so it must not be re-POSTed either.
+            retry_request_errors=False,
+            max_retries_override=0,
         )
 
         if js.get("rt_cd") != "0":

--- a/app/services/brokers/kis/overseas_orders.py
+++ b/app/services/brokers/kis/overseas_orders.py
@@ -185,6 +185,9 @@ class OverseasOrderClient:
             timeout=10,
             api_name="order_overseas_stock",
             tr_id=tr_id,
+            # ROB-645: never re-POST an order (see domestic order_korea_stock).
+            retry_request_errors=False,
+            max_retries_override=0,
         )
 
         if js.get("rt_cd") != "0":
@@ -489,6 +492,9 @@ class OverseasOrderClient:
             timeout=10,
             api_name="cancel_overseas_order",
             tr_id=tr_id,
+            # ROB-645: keep the no-double-submit policy uniform across mutations.
+            retry_request_errors=False,
+            max_retries_override=0,
         )
 
         if js.get("rt_cd") != "0":
@@ -767,6 +773,9 @@ class OverseasOrderClient:
             timeout=10,
             api_name="modify_overseas_order",
             tr_id=tr_id,
+            # ROB-645: a re-applied modify can double-mutate; do not re-POST.
+            retry_request_errors=False,
+            max_retries_override=0,
         )
 
         if js.get("rt_cd") != "0":

--- a/app/services/brokers/kis/protocols.py
+++ b/app/services/brokers/kis/protocols.py
@@ -54,6 +54,8 @@ class KISClientProtocol(Protocol):
         timeout: float = 5.0,
         api_name: str = "unknown",
         tr_id: str | None = None,
+        retry_request_errors: bool = True,
+        max_retries_override: int | None = None,
     ) -> dict[str, Any]:
         """Make HTTP request with rate limiting and retry logic."""
         ...
@@ -69,6 +71,8 @@ class KISClientProtocol(Protocol):
         timeout: float = 5.0,
         api_name: str = "unknown",
         tr_id: str | None = None,
+        retry_request_errors: bool = True,
+        max_retries_override: int | None = None,
     ) -> tuple[dict[str, Any], dict[str, str]]:
         """Make HTTP request with rate limiting and return parsed data plus headers."""
         ...

--- a/app/services/brokers/upbit/client.py
+++ b/app/services/brokers/upbit/client.py
@@ -100,6 +100,7 @@ async def _retry_with_backoff(
     url: str,
     max_retries: int | None = None,
     base_delay: float | None = None,
+    retry_request_errors: bool = True,
 ) -> Any:
     """Common retry-with-backoff loop for Upbit API requests.
 
@@ -114,6 +115,10 @@ async def _retry_with_backoff(
     max_retries / base_delay
         Override ``settings.api_rate_limit_retry_429_max`` /
         ``settings.api_rate_limit_retry_429_base_delay``.
+    retry_request_errors
+        Whether to retry on ``httpx.RequestError`` (timeouts/network). ROB-645:
+        order-creation POSTs pass ``False`` so a timed-out order is never re-sent
+        (429 rate-limit retries are unaffected and still apply).
     """
     if max_retries is None:
         max_retries = settings.api_rate_limit_retry_429_max
@@ -166,7 +171,7 @@ async def _retry_with_backoff(
                 continue
             raise
         except httpx.RequestError as e:
-            if attempt < max_retries:
+            if retry_request_errors and attempt < max_retries:
                 wait_time = base_delay * (2**attempt) + random.uniform(0, 0.1)
                 logger.warning(
                     "[upbit] Request error: %s, attempt %d/%d, retrying in %.3fs (url=%s)",
@@ -878,7 +883,15 @@ async def _request_with_auth(
             else:
                 raise ValueError(f"지원하지 않는 HTTP 메서드: {method}")
 
-    return await _retry_with_backoff(limiter, send, url=url)
+    # ROB-645: order-creation POSTs (POST /v1/orders) must not retry RequestError —
+    # a timed-out order may have reached the broker, so a retry would double-submit.
+    # Reads (GET) and cancels (DELETE /order) keep the existing RequestError retry.
+    is_order_submission = method.upper() == "POST" and api_path.rstrip("/").endswith(
+        "/orders"
+    )
+    return await _retry_with_backoff(
+        limiter, send, url=url, retry_request_errors=not is_order_submission
+    )
 
 
 # Re-export order functions for backward compatibility using lazy loading to avoid circular imports.

--- a/app/services/brokers/upbit/orders.py
+++ b/app/services/brokers/upbit/orders.py
@@ -7,12 +7,24 @@ Market data functions remain in client.py.
 from __future__ import annotations
 
 import logging
+import uuid
 from datetime import datetime
 from typing import Any
 
 import app.services.brokers.upbit.client as _client
 
 logger = logging.getLogger(__name__)
+
+
+def _new_order_identifier() -> str:
+    """ROB-645: unique client idempotency key for an Upbit order.
+
+    Upbit rejects a reused ``identifier`` for the account, so a resent/duplicate
+    order fails instead of double-executing, and the key doubles as a client-side
+    handle for order lookup/reconcile. A random uuid4 per order guarantees
+    uniqueness; content-based derivation is a later follow-up (ROB-653).
+    """
+    return str(uuid.uuid4())
 
 
 async def fetch_open_orders(market: str | None = None) -> list[dict[str, Any]]:
@@ -94,6 +106,7 @@ async def place_sell_order(market: str, volume: str, price: str) -> dict[str, An
         "volume": volume,
         "price": price,
         "ord_type": "limit",  # 지정가 주문
+        "identifier": _new_order_identifier(),
     }
 
     return await _client._request_with_auth("POST", url, body_params=body_params)
@@ -121,6 +134,7 @@ async def place_market_sell_order(market: str, volume: str) -> dict[str, Any]:
         "side": "ask",  # 매도
         "volume": volume,
         "ord_type": "market",  # 시장가 주문 (즉시 체결)
+        "identifier": _new_order_identifier(),
     }
 
     return await _client._request_with_auth("POST", url, body_params=body_params)
@@ -156,6 +170,7 @@ async def place_buy_order(
         "market": market,
         "side": "bid",  # 매수
         "ord_type": ord_type,
+        "identifier": _new_order_identifier(),
     }
 
     if ord_type == "limit":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "auto-trader"
-version = "0.2.6"
+version = "0.3.2"
 description = ""
 authors = [
     { name = "robin", email = "robin@watcha.com" }

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -39,6 +39,33 @@ EXPECTED_KIS_API_RATE_LIMITS = {
         "rate": 10,
         "period": 1.0,
     },
+    # ROB-585 (absorbed by ROB-645): pre-send throttle for order TRs (8/s) so
+    # batch orders stay under the KIS ledger limit without any retry re-POST.
+    "TTTC0012U|/uapi/domestic-stock/v1/trading/order-cash": {"rate": 8, "period": 1.0},
+    "VTTC0012U|/uapi/domestic-stock/v1/trading/order-cash": {"rate": 8, "period": 1.0},
+    "TTTC0011U|/uapi/domestic-stock/v1/trading/order-cash": {"rate": 8, "period": 1.0},
+    "VTTC0011U|/uapi/domestic-stock/v1/trading/order-cash": {"rate": 8, "period": 1.0},
+    "TTTC0013U|/uapi/domestic-stock/v1/trading/order-rvsecncl": {
+        "rate": 8,
+        "period": 1.0,
+    },
+    "VTTC0013U|/uapi/domestic-stock/v1/trading/order-rvsecncl": {
+        "rate": 8,
+        "period": 1.0,
+    },
+    "TTTT1002U|/uapi/overseas-stock/v1/trading/order": {"rate": 8, "period": 1.0},
+    "VTTT1002U|/uapi/overseas-stock/v1/trading/order": {"rate": 8, "period": 1.0},
+    "TTTT1006U|/uapi/overseas-stock/v1/trading/order": {"rate": 8, "period": 1.0},
+    "VTTT1006U|/uapi/overseas-stock/v1/trading/order": {"rate": 8, "period": 1.0},
+    "VTTT1001U|/uapi/overseas-stock/v1/trading/order": {"rate": 8, "period": 1.0},
+    "TTTT1004U|/uapi/overseas-stock/v1/trading/order-rvsecncl": {
+        "rate": 8,
+        "period": 1.0,
+    },
+    "VTTT1004U|/uapi/overseas-stock/v1/trading/order-rvsecncl": {
+        "rate": 8,
+        "period": 1.0,
+    },
 }
 
 EXPECTED_UPBIT_API_RATE_LIMITS = {

--- a/tests/test_kis_base_rate_limit.py
+++ b/tests/test_kis_base_rate_limit.py
@@ -152,3 +152,95 @@ async def test_request_error_retry_log_names_the_exception(monkeypatch, caplog):
             )
 
     assert any("ReadTimeout" in r.getMessage() for r in caplog.records)
+
+
+def _make_rate_limited_response():
+    """A 200 response whose KIS body signals '초과' (EGW00215-style throttle)."""
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.headers = {}
+    resp.json.return_value = {
+        "rt_cd": "1",
+        "msg_cd": "EGW00215",
+        "msg1": "초당 거래건수를 초과하였습니다.",
+    }
+    return resp
+
+
+class TestOrderPathNoDoubleSubmit:
+    """ROB-645: order-submission callsites pass max_retries_override=0 so a timed-out
+    or rate-limited order POST is sent exactly once (never re-POSTed)."""
+
+    def _order_client(self, monkeypatch):
+        client = _FastRetryClient()
+        limiter = MagicMock()
+        limiter.acquire = AsyncMock()
+        monkeypatch.setattr(client, "_get_limiter", AsyncMock(return_value=limiter))
+        monkeypatch.setattr(
+            client, "_ensure_client", AsyncMock(return_value=MagicMock())
+        )
+        return client
+
+    @pytest.mark.asyncio
+    async def test_no_retry_on_request_error_when_max_retries_zero(self, monkeypatch):
+        client = self._order_client(monkeypatch)
+        execute = AsyncMock(side_effect=httpx.ReadTimeout(""))
+        monkeypatch.setattr(client, "_execute_http_request", execute)
+
+        with pytest.raises(httpx.ReadTimeout):
+            await client._request_with_rate_limit_with_headers(
+                "POST",
+                "https://host/uapi/domestic-stock/v1/trading/order-cash",
+                headers={},
+                json_body={"PDNO": "005930"},
+                retry_request_errors=False,
+                max_retries_override=0,
+                api_name="order_korea_stock",
+            )
+
+        # Exactly one POST — no re-submission of a timed-out order.
+        assert execute.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_no_repost_on_rate_limit_heuristic_when_max_retries_zero(
+        self, monkeypatch
+    ):
+        client = self._order_client(monkeypatch)
+        execute = AsyncMock(return_value=_make_rate_limited_response())
+        monkeypatch.setattr(client, "_execute_http_request", execute)
+
+        data, _headers = await client._request_with_rate_limit_with_headers(
+            "POST",
+            "https://host/uapi/domestic-stock/v1/trading/order-cash",
+            headers={},
+            json_body={"PDNO": "005930"},
+            retry_request_errors=False,
+            max_retries_override=0,
+            api_name="order_korea_stock",
+        )
+
+        # EGW00215 '초과' is surfaced as the error body, not retried (no re-POST).
+        assert data["rt_cd"] == "1"
+        assert data["msg_cd"] == "EGW00215"
+        assert execute.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_read_path_still_retries_request_errors(self, monkeypatch):
+        """Regression: default read path keeps retrying transient RequestErrors."""
+        client = self._order_client(monkeypatch)
+        ok = MagicMock()
+        ok.status_code = 200
+        ok.headers = {}
+        ok.json.return_value = {"rt_cd": "0", "output": []}
+        execute = AsyncMock(side_effect=[httpx.ReadTimeout(""), ok])
+        monkeypatch.setattr(client, "_execute_http_request", execute)
+
+        data, _headers = await client._request_with_rate_limit_with_headers(
+            "GET",
+            "https://host/uapi/domestic-stock/v1/quotations/inquire-price",
+            headers={},
+            api_name="inquire_price",
+        )
+
+        assert data["rt_cd"] == "0"
+        assert execute.await_count == 2  # retried once, then succeeded

--- a/tests/test_kis_order_no_double_submit.py
+++ b/tests/test_kis_order_no_double_submit.py
@@ -1,0 +1,92 @@
+"""ROB-645: KIS order-submission callsites must never re-POST a timed-out order.
+
+Each order-mutation path passes ``retry_request_errors=False`` (no RequestError
+retry) and ``max_retries_override=0`` (no EGW00215/'초과'/429 re-POST) to the shared
+transport, so a single order request reaches the broker exactly once.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+
+
+def _make_parent():
+    parent = MagicMock()
+    parent._ensure_token = AsyncMock()
+    parent._hdr_base = {}
+    parent._kis_url = lambda path: f"https://host{path}"
+    settings = MagicMock()
+    settings.kis_account_no = "1234567890"
+    settings.kis_access_token = "test-token"
+    parent._settings = settings
+    parent._request_with_rate_limit = AsyncMock(
+        return_value={
+            "rt_cd": "0",
+            "output": {"ODNO": "0001", "ORD_TMD": "090000"},
+            "msg1": "정상처리",
+        }
+    )
+    return parent
+
+
+@pytest.mark.unit
+class TestDomesticOrderNoDoubleSubmit:
+    @pytest.fixture(autouse=True)
+    def _no_nxt(self, monkeypatch):
+        from app.services.brokers.kis import domestic_orders
+
+        monkeypatch.setattr(
+            domestic_orders, "is_nxt_eligible", AsyncMock(return_value=False)
+        )
+
+    def _client(self):
+        from app.services.brokers.kis.domestic_orders import DomesticOrderClient
+
+        parent = _make_parent()
+        return DomesticOrderClient(parent), parent
+
+    @pytest.mark.asyncio
+    async def test_order_korea_stock_disables_retry_and_repost(self):
+        instance, parent = self._client()
+
+        await instance.order_korea_stock("005930", "buy", 1, 1000, is_mock=False)
+
+        parent._request_with_rate_limit.assert_awaited_once()
+        kwargs = parent._request_with_rate_limit.await_args.kwargs
+        assert kwargs["retry_request_errors"] is False
+        assert kwargs["max_retries_override"] == 0
+
+    @pytest.mark.asyncio
+    async def test_order_korea_stock_timeout_sends_exactly_once(self):
+        instance, parent = self._client()
+        parent._request_with_rate_limit = AsyncMock(side_effect=httpx.ReadTimeout(""))
+
+        with pytest.raises(httpx.ReadTimeout):
+            await instance.order_korea_stock("005930", "buy", 1, 1000, is_mock=False)
+
+        assert parent._request_with_rate_limit.await_count == 1
+
+
+@pytest.mark.unit
+class TestOverseasOrderNoDoubleSubmit:
+    def _client(self):
+        from app.services.brokers.kis.overseas_orders import OverseasOrderClient
+
+        parent = _make_parent()
+        return OverseasOrderClient(parent), parent
+
+    @pytest.mark.asyncio
+    async def test_order_overseas_stock_disables_retry_and_repost(self):
+        instance, parent = self._client()
+
+        await instance.order_overseas_stock(
+            "AAPL", "NASD", "buy", 1, 100.0, is_mock=False
+        )
+
+        parent._request_with_rate_limit.assert_awaited_once()
+        kwargs = parent._request_with_rate_limit.await_args.kwargs
+        assert kwargs["retry_request_errors"] is False
+        assert kwargs["max_retries_override"] == 0

--- a/tests/test_mcp_place_order.py
+++ b/tests/test_mcp_place_order.py
@@ -156,6 +156,52 @@ async def test_place_order_sell_with_amount_error():
         )
 
 
+@pytest.mark.asyncio
+async def test_place_order_send_timeout_surfaces_outcome_unknown(monkeypatch):
+    """ROB-645: a live order whose send times out returns an explicit
+    outcome-unknown error pointing at the reconcile tool (never a blank error,
+    never a retry)."""
+    import httpx
+
+    tools = build_tools()
+
+    monkeypatch.setattr(
+        upbit_service,
+        "fetch_multiple_current_prices",
+        AsyncMock(return_value={"KRW-BTC": 50000000.0}),
+    )
+    monkeypatch.setattr(
+        upbit_service,
+        "fetch_my_coins",
+        AsyncMock(
+            return_value=[{"currency": "KRW", "balance": "5000000", "locked": "0"}]
+        ),
+    )
+    # The order POST times out — outcome is unknown (may have reached the broker).
+    monkeypatch.setattr(
+        upbit_service,
+        "place_buy_order",
+        AsyncMock(side_effect=httpx.ReadTimeout("")),
+    )
+
+    result = await tools["place_order"](
+        symbol="KRW-BTC",
+        side="buy",
+        order_type="limit",
+        amount=100000.0,
+        price=49000000.0,
+        dry_run=False,
+        thesis="t",
+        strategy="s",
+    )
+
+    assert result["success"] is False
+    assert result["outcome_unknown"] is True
+    assert result["reconcile_tool"] == "live_reconcile_orders"
+    assert result["error"].strip()
+    assert "불확실" in result["error"]
+
+
 # ----------------------------------------------------------------------
 # Upbit order tests
 # ----------------------------------------------------------------------

--- a/tests/test_order_outcome_unknown.py
+++ b/tests/test_order_outcome_unknown.py
@@ -1,0 +1,143 @@
+"""ROB-645: a timed-out / network-failed order POST has an UNKNOWN outcome.
+
+Since we no longer retry order sends (retry = double-submit), the tool response
+must surface an explicit, non-blank error telling the operator to reconcile
+rather than re-send.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+
+@pytest.mark.unit
+class TestReconcileToolFor:
+    def test_kr_live(self):
+        from app.mcp_server.tooling.order_execution import _reconcile_tool_for
+
+        assert (
+            _reconcile_tool_for(market_type="equity_kr", is_mock=False)
+            == "kis_live_reconcile_orders"
+        )
+
+    def test_us_live(self):
+        from app.mcp_server.tooling.order_execution import _reconcile_tool_for
+
+        assert (
+            _reconcile_tool_for(market_type="equity_us", is_mock=False)
+            == "live_reconcile_orders"
+        )
+
+    def test_crypto_live(self):
+        from app.mcp_server.tooling.order_execution import _reconcile_tool_for
+
+        assert (
+            _reconcile_tool_for(market_type="crypto", is_mock=False)
+            == "live_reconcile_orders"
+        )
+
+    def test_mock_has_no_reconcile_tool(self):
+        from app.mcp_server.tooling.order_execution import _reconcile_tool_for
+
+        # No kis_mock_reconcile_orders tool exists — must not name a phantom tool.
+        assert _reconcile_tool_for(market_type="equity_kr", is_mock=True) is None
+
+
+@pytest.mark.unit
+class TestAugmentErrorForUnknownOutcome:
+    def _base(self):
+        return {
+            "success": False,
+            "error": "ReadTimeout",
+            "source": "kis",
+            "symbol": "005930",
+            "instrument_type": "equity_kr",
+        }
+
+    def test_timeout_flags_outcome_unknown_and_names_reconcile_tool(self):
+        from app.mcp_server.tooling.order_execution import (
+            OrderSendOutcomeUnknown,
+            _augment_error_for_unknown_outcome,
+        )
+
+        result = _augment_error_for_unknown_outcome(
+            self._base(),
+            OrderSendOutcomeUnknown(httpx.ReadTimeout("")),
+            market_type="equity_kr",
+            is_mock=False,
+        )
+
+        assert result["success"] is False
+        assert result["outcome_unknown"] is True
+        assert result["reconcile_tool"] == "kis_live_reconcile_orders"
+        # Non-blank, actionable reason mentioning the reconcile tool + uncertainty.
+        assert result["error"].strip()
+        assert "kis_live_reconcile_orders" in result["error"]
+        assert "불확실" in result["error"]
+        # The concrete transport reason is preserved (ROB-600: never blank).
+        assert "ReadTimeout" in result["error"]
+
+    def test_us_timeout_points_at_live_reconcile(self):
+        from app.mcp_server.tooling.order_execution import (
+            OrderSendOutcomeUnknown,
+            _augment_error_for_unknown_outcome,
+        )
+
+        result = _augment_error_for_unknown_outcome(
+            self._base(),
+            OrderSendOutcomeUnknown(httpx.ConnectTimeout("")),
+            market_type="equity_us",
+            is_mock=False,
+        )
+        assert result["reconcile_tool"] == "live_reconcile_orders"
+        assert "live_reconcile_orders" in result["error"]
+
+    def test_mock_timeout_has_no_phantom_tool(self):
+        from app.mcp_server.tooling.order_execution import (
+            OrderSendOutcomeUnknown,
+            _augment_error_for_unknown_outcome,
+        )
+
+        result = _augment_error_for_unknown_outcome(
+            self._base(),
+            OrderSendOutcomeUnknown(httpx.ReadTimeout("")),
+            market_type="equity_kr",
+            is_mock=True,
+        )
+        assert result["outcome_unknown"] is True
+        assert result["reconcile_tool"] is None
+        assert "불확실" in result["error"]
+
+    def test_non_request_error_is_left_unchanged(self):
+        from app.mcp_server.tooling.order_execution import (
+            _augment_error_for_unknown_outcome,
+        )
+
+        base = self._base()
+        result = _augment_error_for_unknown_outcome(
+            base,
+            RuntimeError("EGW00215 초당 거래건수 초과"),
+            market_type="equity_kr",
+            is_mock=False,
+        )
+        # A definitive broker rejection is NOT outcome-unknown.
+        assert "outcome_unknown" not in result
+        assert result == base
+
+    def test_raw_presend_request_error_is_left_unchanged(self):
+        from app.mcp_server.tooling.order_execution import (
+            _augment_error_for_unknown_outcome,
+        )
+
+        base = self._base()
+        # A bare RequestError (e.g. price fetch before the order is sent) means the
+        # order was NEVER submitted — must not be flagged outcome-unknown.
+        result = _augment_error_for_unknown_outcome(
+            base,
+            httpx.ReadTimeout(""),
+            market_type="equity_kr",
+            is_mock=False,
+        )
+        assert "outcome_unknown" not in result
+        assert result == base

--- a/tests/test_upbit_orders.py
+++ b/tests/test_upbit_orders.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import uuid
 from unittest.mock import AsyncMock
 
 import pytest
@@ -42,3 +43,55 @@ class TestUpbitClosedOrders:
             "start_time": "2026-02-01T00:00:00+00:00",
             "end_time": "2026-02-07T00:00:00+00:00",
         }
+
+
+@pytest.mark.unit
+class TestUpbitOrderIdempotencyIdentifier:
+    """ROB-645: every Upbit order-creation POST carries a unique client identifier
+    (idempotency key) so a resent/duplicate order is rejected by the broker."""
+
+    def _mock_request(self, monkeypatch):
+        from app.services.brokers.upbit import orders
+
+        request = AsyncMock(return_value={"uuid": "server-uuid"})
+        monkeypatch.setattr(orders._client, "_request_with_auth", request)
+        return orders, request
+
+    def _assert_valid_identifier(self, request):
+        body = request.await_args.kwargs["body_params"]
+        assert "identifier" in body
+        # Must be a unique, valid client identifier (uuid4 in this slice).
+        uuid.UUID(str(body["identifier"]))
+
+    @pytest.mark.asyncio
+    async def test_place_buy_order_includes_identifier(self, monkeypatch):
+        orders, request = self._mock_request(monkeypatch)
+        await orders.place_buy_order("KRW-BTC", "1000", "0.5", "limit")
+        self._assert_valid_identifier(request)
+
+    @pytest.mark.asyncio
+    async def test_place_sell_order_includes_identifier(self, monkeypatch):
+        orders, request = self._mock_request(monkeypatch)
+        await orders.place_sell_order("KRW-BTC", "0.5", "1000")
+        self._assert_valid_identifier(request)
+
+    @pytest.mark.asyncio
+    async def test_place_market_sell_order_includes_identifier(self, monkeypatch):
+        orders, request = self._mock_request(monkeypatch)
+        await orders.place_market_sell_order("KRW-BTC", "0.5")
+        self._assert_valid_identifier(request)
+
+    @pytest.mark.asyncio
+    async def test_place_market_buy_order_includes_identifier(self, monkeypatch):
+        orders, request = self._mock_request(monkeypatch)
+        await orders.place_market_buy_order("KRW-BTC", "10000")
+        self._assert_valid_identifier(request)
+
+    @pytest.mark.asyncio
+    async def test_each_order_gets_a_distinct_identifier(self, monkeypatch):
+        orders, request = self._mock_request(monkeypatch)
+        await orders.place_buy_order("KRW-BTC", "1000", "0.5", "limit")
+        first = request.await_args.kwargs["body_params"]["identifier"]
+        await orders.place_buy_order("KRW-BTC", "1000", "0.5", "limit")
+        second = request.await_args.kwargs["body_params"]["identifier"]
+        assert first != second

--- a/tests/test_upbit_retry.py
+++ b/tests/test_upbit_retry.py
@@ -106,3 +106,71 @@ async def test_non_429_http_error_raises_immediately():
         )
 
     assert send_fn.await_count == 1  # no retry on 500
+
+
+@pytest.mark.asyncio
+async def test_no_retry_on_request_error_when_disabled():
+    """ROB-645: order POST must not retry RequestError (would double-submit)."""
+    from app.services.brokers.upbit.client import _retry_with_backoff
+
+    send_fn = AsyncMock(side_effect=httpx.RequestError("connection reset"))
+
+    with pytest.raises(httpx.RequestError):
+        await _retry_with_backoff(
+            _make_limiter(),
+            send_fn,
+            url="https://test/orders",
+            max_retries=3,
+            base_delay=0.01,
+            retry_request_errors=False,
+        )
+
+    assert send_fn.await_count == 1  # sent exactly once, never re-sent
+
+
+@pytest.mark.asyncio
+async def test_order_post_disables_request_error_retry(monkeypatch):
+    """ROB-645: _request_with_auth POST /orders threads retry_request_errors=False."""
+    from unittest.mock import MagicMock
+
+    from app.services.brokers.upbit import client
+
+    captured: dict = {}
+
+    async def fake_retry(limiter, send_fn, *, url, **kwargs):
+        captured["url"] = url
+        captured.update(kwargs)
+        return {"uuid": "x"}
+
+    monkeypatch.setattr(client, "_retry_with_backoff", fake_retry)
+    monkeypatch.setattr(client, "get_limiter", AsyncMock(return_value=MagicMock()))
+    monkeypatch.setattr(client.jwt, "encode", lambda *a, **k: "tok")
+
+    await client._request_with_auth(
+        "POST", f"{client.UPBIT_REST}/orders", body_params={"market": "KRW-BTC"}
+    )
+
+    assert captured["retry_request_errors"] is False
+
+
+@pytest.mark.asyncio
+async def test_get_request_keeps_request_error_retry(monkeypatch):
+    """ROB-645: read paths (GET) keep the existing RequestError retry."""
+    from unittest.mock import MagicMock
+
+    from app.services.brokers.upbit import client
+
+    captured: dict = {}
+
+    async def fake_retry(limiter, send_fn, *, url, **kwargs):
+        captured["url"] = url
+        captured.update(kwargs)
+        return []
+
+    monkeypatch.setattr(client, "_retry_with_backoff", fake_retry)
+    monkeypatch.setattr(client, "get_limiter", AsyncMock(return_value=MagicMock()))
+    monkeypatch.setattr(client.jwt, "encode", lambda *a, **k: "tok")
+
+    await client._request_with_auth("GET", f"{client.UPBIT_REST}/accounts")
+
+    assert captured.get("retry_request_errors", True) is True

--- a/uv.lock
+++ b/uv.lock
@@ -222,7 +222,7 @@ wheels = [
 
 [[package]]
 name = "auto-trader"
-version = "0.2.5"
+version = "0.3.2"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
## What & why

Transport-level **order double-submit exposure** found during ROB-643/644 scoping. The approval-hash gate (ROB-644 P6) can't stop transport-layer duplicates, so this is the logical prerequisite fix.

- **KIS** (`base.py`): `_request_with_rate_limit` defaults `retry_request_errors=True`, and order callsites didn't override it → a timed-out order POST was re-POSTed. The rate-limit heuristic (`'초과'` substring) also re-POSTed orders. KIS has no client idempotency field, so the broker can't dedupe.
- **Upbit** (`client.py`): `_retry_with_backoff` retried `httpx.RequestError` on **all** requests including `POST /orders`, and didn't send the `identifier` idempotency parameter.

## Changes (TDD, migration 0)

**Task A — KIS order submit path**
- Order/cancel/modify callsites (domestic + overseas, 6 sites) pass `retry_request_errors=False` **and** `max_retries_override=0` → a timed-out **or** rate-limited (EGW00215 `'초과'` / HTTP 429) order POST is sent **exactly once**, never re-POSTed. Read paths keep their retries (default unchanged; new `max_retries_override` param threaded through `base.py` + `protocols.py`).
- Token-expiry recursion (`EGW00123/EGW00121`) audited and **left as-is**: an auth-rejected POST (`rt_cd != 0`) means the order was not created, so the fresh-token resubmit is safe — distinct from a timeout (no response).

**Task B — Upbit**
- `POST /v1/orders` (order creation) excluded from the `_retry_with_backoff` RequestError retry; GET reads and DELETE cancels keep retrying.
- Each order carries a unique `identifier` (uuid4 per order) idempotency key — a resent/duplicate order is rejected by Upbit. Content-based keys are a later follow-up (ROB-653).

**Task C — outcome-unknown surfacing**
- A send-time timeout/network failure surfaces an explicit, non-blank error with additive fields `outcome_unknown: true` + `reconcile_tool` (`kis_live_reconcile_orders` for KR, `live_reconcile_orders` for US/crypto; `null` for mock — no phantom tool). Reuses ROB-600 `describe_exception`.
- **Narrowed** to actual send failures via `OrderSendOutcomeUnknown` (raised only around `_execute_order`), so a pre-send read timeout (e.g. price fetch) is unaffected — ROB-600 behaviour preserved.

## ROB-585 PR #1331 disposition → **superseded (option b)**

#1331 was already `CONFLICTING` with main and mixed two concerns; critically its `max_retries_override=3` on order paths **would still re-POST orders on EGW00215**, violating ROB-645's safety boundary. This PR:
- **Absorbs #1331's still-valid ①** pre-send throttle (order TRs → 8/s in `DEFAULT_KIS_API_RATE_LIMITS`). With order re-POST retries removed, this pre-send wait is now the *sole* guard against the KIS 초당 거래건수 limit.
- **Supersedes #1331's ②** with the stricter `max_retries_override=0`.
- #1331 will be closed with a superseding comment (kept single-PR to avoid same-file conflicts).

## Tests
- KIS transport: order path sends once on timeout **and** on `'초과'`; read path still retries (`test_kis_base_rate_limit.py`).
- KIS callsites: all order mutations pass the no-retry flags (`test_kis_order_no_double_submit.py`).
- Upbit: `_retry_with_backoff` no-retry when disabled; `POST /orders` threads the flag while GET keeps retry; every order body carries a distinct uuid4 identifier (`test_upbit_retry.py`, `test_upbit_orders.py`).
- Outcome-unknown: pure helper + end-to-end `place_order` timeout (`test_order_outcome_unknown.py`, `test_mcp_place_order.py`); ROB-600 pre-send timeout regression preserved.
- Config throttle present at 8/s (`test_config.py`).
- Gates: `ruff format --check`/`ruff check` (app + tests) clean, `ty check app/` clean, affected suites green.

## Operator follow-up (post-merge)
- Deploy + **restart the MCP server** (transport code loaded in-process).
- Timeout is impractical to reproduce live — unit evidence suffices; after deploy, confirm no orphan pendings via the reconcile tools.

Closes ROB-645.