### PR TITLE
feat(ROB-648): analysis_artifacts lifecycle + fresh-artifact soft-gate hint

### DIFF
--- a/alembic/versions/20260702_rob648_analysis_artifacts_lifecycle.py
+++ b/alembic/versions/20260702_rob648_analysis_artifacts_lifecycle.py
@@ -1,0 +1,73 @@
+"""ROB-648 analysis artifact lifecycle fields
+
+content_hash (server-computed, nullable + lazy backfill), version (in-place
+bump), readiness_label (reduced advisory enum). All additive; existing
+save/list/get stay backward compatible.
+
+Revision ID: 20260702_rob648
+Revises: 20260702_rob641
+Create Date: 2026-07-02 06:00:00.000000
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "20260702_rob648"
+down_revision: str | None = "20260702_rob641"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # content_hash: nullable so pre-existing rows are not backfilled in-migration
+    # — the next save() computes and stores it (lazy backfill, ROB-648).
+    op.add_column(
+        "analysis_artifacts",
+        sa.Column("content_hash", sa.Text(), nullable=True),
+        schema="review",
+    )
+    # version: additive Integer, in-place bump on correlation_id re-save when the
+    # payload content actually changes. server_default 1 backfills existing rows.
+    op.add_column(
+        "analysis_artifacts",
+        sa.Column(
+            "version",
+            sa.Integer(),
+            nullable=False,
+            server_default=sa.text("1"),
+        ),
+        schema="review",
+    )
+    # readiness_label: caller-declared advisory. Reduced hard enum (tradingcodex
+    # lane labels excluded) — NULL allowed.
+    op.add_column(
+        "analysis_artifacts",
+        sa.Column("readiness_label", sa.Text(), nullable=True),
+        schema="review",
+    )
+    op.create_check_constraint(
+        "ck_analysis_artifacts_readiness_label",
+        "analysis_artifacts",
+        "readiness_label IS NULL OR readiness_label IN ("
+        "'screen_grade','not_decision_ready',"
+        "'ready_for_order_review','blocked'"
+        ")",
+        schema="review",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        "ck_analysis_artifacts_readiness_label",
+        "analysis_artifacts",
+        schema="review",
+        type_="check",
+    )
+    op.drop_column("analysis_artifacts", "readiness_label", schema="review")
+    op.drop_column("analysis_artifacts", "version", schema="review")
+    op.drop_column("analysis_artifacts", "content_hash", schema="review")

--- a/app/mcp_server/README.md
+++ b/app/mcp_server/README.md
@@ -198,6 +198,11 @@ MCP tools (market data, portfolio, order execution) exposed via `fastmcp`.
     for symbols outside the snapshot result path.
   - Default `quick=True` returns compact summary with: symbol, current_price,
     rsi_14, consensus, recommendation, supports (top 3), resistances (top 3).
+  - When a non-stale `analysis_artifact` already covers a symbol, that symbol's
+    compact summary also carries a `fresh_artifact_exists` hint
+    (`{artifact_uuid, as_of, kind}`) so you can choose to reuse the persisted
+    artifact via `analysis_artifact_get` instead of re-deriving. This is a soft
+    hint only — the analysis still runs and is returned.
 
 ### Snapshot-backed report generation
 
@@ -243,27 +248,45 @@ with today's candidate tournament.
 
 ### Analysis Artifact Tools
 
-`analysis_artifact_save(market, kind, title, symbols?, payload?, as_of?, valid_until?, created_by?, session_label?)`
+`analysis_artifact_save(market, kind, title, symbols?, payload?, as_of?, valid_until?, created_by?, session_label?, correlation_id?, account_scope?, readiness_label?)`
 persists a structured analysis artifact for cross-session reuse. It is for the
 durable outputs of analysis runs — screening rankings, profit-taking verdicts,
-support/resistance maps, flow assessments, candidate pools, and session
-summaries — so a later session can reuse them instead of recomputing. Save is
+support/resistance maps, flow assessments, candidate pools, session summaries,
+and briefings — so a later session can reuse them instead of recomputing. Save is
 explicit only; `analyze_stock_batch` and other analysis runs do not auto-persist.
+This is the cross-session artifact store; it is complementary to (not a duplicate
+of) the ROB-638 fetch-layer Redis cache, which dedupes slowly-changing provider
+fetches across calls within a run.
 
 Each artifact accepts:
 
 - `market` required: `kr`, `us`, or `crypto`.
 - `kind` required: `screening_ranking`, `profit_taking_verdicts`,
   `support_resistance_map`, `flow_assessment`, `candidate_pool`,
-  `session_summary`.
+  `session_summary`, `briefing`.
 - `title` required short title.
 - `symbols` optional string list; defaults to empty.
 - `payload` optional JSON object; defaults to empty.
 - `as_of` optional ISO datetime; defaults to now (UTC).
 - `valid_until` optional ISO datetime; when in the past the artifact is stale
-  and excluded from `analysis_artifact_list` unless `include_stale=true`.
+  and excluded from `analysis_artifact_list` unless `include_stale=true`. **When
+  omitted, the server assigns a per-kind default TTL** (price/screen kinds expire
+  at the end of the `as_of` KST day; `session_summary`/`briefing` at the end of
+  the next KST day) so an artifact is never never-stale.
 - `created_by` optional: `claude`, `operator`, `system`; defaults to `claude`.
 - `session_label` optional grouping label.
+- `correlation_id` optional idempotency key. Re-saving the same `correlation_id`
+  updates the row in place (omit to append a new row).
+- `account_scope` optional grouping/filter label.
+- `readiness_label` optional advisory (caller-declared, not a gate):
+  `screen_grade`, `not_decision_ready`, `ready_for_order_review`, `blocked`.
+
+The response includes `action` and the saved artifact. `action` is `created`
+(new row), `updated` (correlation_id re-save whose payload changed — `version` is
+bumped in place), or `unchanged` (correlation_id re-save whose canonical payload
+hashed identical — no write, `version` preserved). Each artifact carries a
+server-computed `content_hash` (over the canonical payload JSON) and an integer
+`version`.
 
 `analysis_artifact_list(market?, kind?, symbol?, since?, include_stale?, limit)`
 returns matching artifacts newest `as_of` first. `symbol` does a containment

--- a/app/mcp_server/tooling/analysis_artifact_registration.py
+++ b/app/mcp_server/tooling/analysis_artifact_registration.py
@@ -27,12 +27,21 @@ def register_analysis_artifact_tools(mcp: FastMCP) -> None:
         description=(
             "Persist a structured analysis artifact (screening ranking, "
             "profit-taking verdicts, support/resistance map, flow assessment, "
-            "candidate pool, or session summary) for cross-session reuse. "
-            "Explicit save only — analysis runs do not auto-persist. "
-            "Idempotent per correlation_id: re-saving the same correlation_id "
-            "updates the row in place (omit to append). Payload capped at "
-            "100KB (payload_too_large above that). Recent valid artifacts "
-            "are surfaced metadata-only in get_operating_briefing."
+            "candidate pool, session summary, or briefing) for cross-session "
+            "reuse. Explicit save only — analysis runs do not auto-persist. "
+            "Cross-session artifact store — complementary to, not a duplicate "
+            "of, the ROB-638 fetch-layer cache (which dedupes provider fetches "
+            "within a run). Idempotent per correlation_id: re-saving the same "
+            "correlation_id updates the row in place and bumps version "
+            "(action='updated'); an identical payload is a no-op "
+            "(action='unchanged', version preserved); omit correlation_id to "
+            "append. content_hash is server-computed over the payload. When "
+            "valid_until is omitted a per-kind default TTL is assigned so no "
+            "artifact is never-stale. Optional readiness_label is advisory "
+            "(screen_grade / not_decision_ready / ready_for_order_review / "
+            "blocked). Payload capped at 100KB (payload_too_large above that). "
+            "Recent valid artifacts are surfaced metadata-only in "
+            "get_operating_briefing."
         ),
     )(analysis_artifact_save)
     _ = mcp.tool(

--- a/app/mcp_server/tooling/analysis_artifact_tools.py
+++ b/app/mcp_server/tooling/analysis_artifact_tools.py
@@ -45,6 +45,7 @@ async def analysis_artifact_save(
     session_label: str | None = None,
     correlation_id: str | None = None,
     account_scope: str | None = None,
+    readiness_label: str | None = None,
 ) -> dict[str, Any]:
     """Persist a single analysis artifact for cross-session reuse."""
     size_bytes = len(
@@ -71,6 +72,7 @@ async def analysis_artifact_save(
                 "session_label": session_label,
                 "correlation_id": correlation_id,
                 "account_scope": account_scope,
+                "readiness_label": readiness_label,
             }
         )
     except ValidationError as exc:

--- a/app/mcp_server/tooling/analysis_registration.py
+++ b/app/mcp_server/tooling/analysis_registration.py
@@ -221,7 +221,11 @@ def register_analysis_tools(
             "recomputed fresh on every call. Each result carries cache_hit (whether "
             "cached provider data was served) and derived_as_of (ISO KST timestamp "
             "of when that provider data was fetched). refresh=True bypasses the "
-            "cache read and re-fetches provider data fresh (ROB-638)."
+            "cache read and re-fetches provider data fresh (ROB-638). When a "
+            "non-stale analysis_artifact already covers a symbol, that compact "
+            "summary also carries fresh_artifact_exists {artifact_uuid, as_of, "
+            "kind} — a soft reuse hint (fetch via analysis_artifact_get); the "
+            "analysis still runs (ROB-648)."
         ),
     )
     async def analyze_stock_batch(

--- a/app/mcp_server/tooling/analysis_tool_handlers.py
+++ b/app/mcp_server/tooling/analysis_tool_handlers.py
@@ -784,6 +784,58 @@ def _summarize_analysis_result(
     return summary
 
 
+async def _attach_fresh_artifact_hints(
+    results: dict[str, Any],
+    *,
+    market: str | None,
+) -> None:
+    """Annotate each successful per-symbol result with a fresh-artifact hint.
+
+    ROB-648 soft-gate: when a non-stale analysis_artifact already covers a
+    symbol, attach ``fresh_artifact_exists`` ({artifact_uuid, as_of, kind}) so
+    the caller can choose to reuse it. Purely advisory — never short-circuits
+    the analysis. Complementary to the ROB-638 fetch-layer cache (cross-call);
+    this surfaces cross-session persisted artifacts. Fail-open: any DB/lookup
+    error leaves results untouched.
+    """
+    symbols = [
+        sym
+        for sym, row in results.items()
+        if isinstance(row, dict) and "error" not in row
+    ]
+    if not symbols:
+        return
+    try:
+        from app.core.db import AsyncSessionLocal
+        from app.core.symbol import to_db_symbol
+        from app.services.analysis_artifact import AnalysisArtifactService
+
+        market_filter = market if market in {"kr", "us", "crypto"} else None
+        async with AsyncSessionLocal() as db:
+            service = AnalysisArtifactService(db)
+            rows = await service.fresh_artifacts_for_symbols(
+                symbols=symbols,
+                market=market_filter,  # type: ignore[arg-type]
+            )
+        # rows are newest-first; keep the first (most recent) hit per symbol.
+        by_symbol: dict[str, Any] = {}
+        for row in rows:
+            for artifact_symbol in row.symbols:
+                by_symbol.setdefault(artifact_symbol, row)
+        for sym, result in results.items():
+            if not isinstance(result, dict) or "error" in result:
+                continue
+            hit = by_symbol.get(to_db_symbol(str(sym).strip())) or by_symbol.get(sym)
+            if hit is not None:
+                result["fresh_artifact_exists"] = {
+                    "artifact_uuid": str(hit.artifact_uuid),
+                    "as_of": hit.as_of.isoformat(),
+                    "kind": hit.kind,
+                }
+    except Exception as exc:  # fail-open: hints are advisory-only
+        logger.debug("fresh_artifact_exists hint lookup skipped: %s", exc)
+
+
 async def analyze_stock_batch_impl(
     symbols: list[str | int],
     market: str | None = None,
@@ -832,7 +884,7 @@ async def analyze_stock_batch_impl(
         ) -> dict[str, Any]:
             return result
 
-    return await _run_batch_analysis(
+    response = await _run_batch_analysis(
         symbols,
         market=market,
         include_peers=include_peers,
@@ -840,6 +892,11 @@ async def analyze_stock_batch_impl(
         include_position=attach_position,
         refresh=refresh,
     )
+    # ROB-648: annotate each symbol that already has a fresh persisted artifact
+    # (soft reuse hint, fail-open). Only for the compact contract.
+    if quick:
+        await _attach_fresh_artifact_hints(response.get("results", {}), market=market)
+    return response
 
 
 async def analyze_portfolio_impl(

--- a/app/models/analysis_artifact.py
+++ b/app/models/analysis_artifact.py
@@ -11,6 +11,7 @@ from sqlalchemy import (
     BigInteger,
     CheckConstraint,
     Index,
+    Integer,
     Text,
     UniqueConstraint,
     text,
@@ -47,6 +48,13 @@ class AnalysisArtifact(Base):
         CheckConstraint(
             "created_by IN ('claude','operator','system')",
             name="created_by",
+        ),
+        CheckConstraint(
+            "readiness_label IS NULL OR readiness_label IN ("
+            "'screen_grade','not_decision_ready',"
+            "'ready_for_order_review','blocked'"
+            ")",
+            name="readiness_label",
         ),
         Index(
             "ix_analysis_artifacts_kind_market_as_of",
@@ -98,6 +106,18 @@ class AnalysisArtifact(Base):
     session_label: Mapped[str | None] = mapped_column(Text)
     correlation_id: Mapped[str | None] = mapped_column(Text)
     account_scope: Mapped[str | None] = mapped_column(Text)
+    # ROB-648 lifecycle fields. content_hash is server-computed over the
+    # canonical payload JSON (nullable + lazy backfill on next save). version is
+    # bumped in place on a correlation_id re-save whose payload content changed.
+    # readiness_label is a caller-declared advisory (reduced enum, see CHECK).
+    content_hash: Mapped[str | None] = mapped_column(Text)
+    version: Mapped[int] = mapped_column(
+        Integer,
+        nullable=False,
+        default=1,
+        server_default=text("1"),
+    )
+    readiness_label: Mapped[str | None] = mapped_column(Text)
     created_by: Mapped[str] = mapped_column(
         Text,
         nullable=False,

--- a/app/schemas/analysis_artifact.py
+++ b/app/schemas/analysis_artifact.py
@@ -20,6 +20,15 @@ AnalysisArtifactKindLiteral = Literal[
     "briefing",
 ]
 AnalysisArtifactCreatedByLiteral = Literal["claude", "operator", "system"]
+# ROB-648 reduced advisory readiness enum. tradingcodex-lane labels are
+# excluded; server-derived readiness gating is deferred (needs per-kind payload
+# schemas, P5+). Caller declares this; it is not a hard short-circuit gate.
+AnalysisArtifactReadinessLiteral = Literal[
+    "screen_grade",
+    "not_decision_ready",
+    "ready_for_order_review",
+    "blocked",
+]
 
 
 class AnalysisArtifactSave(BaseModel):
@@ -36,6 +45,9 @@ class AnalysisArtifactSave(BaseModel):
     session_label: str | None = None
     correlation_id: str | None = None
     account_scope: str | None = None
+    # Advisory only. content_hash/version are server-computed and intentionally
+    # NOT accepted from the caller.
+    readiness_label: AnalysisArtifactReadinessLiteral | None = None
 
     model_config = ConfigDict(extra="forbid")
 
@@ -158,6 +170,9 @@ class AnalysisArtifactMeta(BaseModel):
     session_label: str | None
     correlation_id: str | None
     account_scope: str | None
+    content_hash: str | None
+    version: int
+    readiness_label: AnalysisArtifactReadinessLiteral | None
     payload_size_bytes: int
     is_stale: bool
     created_by: AnalysisArtifactCreatedByLiteral
@@ -174,7 +189,9 @@ class AnalysisArtifactRead(AnalysisArtifactMeta):
 
 class AnalysisArtifactSaveResponse(BaseModel):
     success: Literal[True] = True
-    action: Literal["created", "updated"] = "created"
+    # 'unchanged' (ROB-648): a correlation_id re-save whose payload hashed
+    # identical to the stored row — no write, version preserved.
+    action: Literal["created", "updated", "unchanged"] = "created"
     artifact: AnalysisArtifactRead
 
 

--- a/app/services/analysis_artifact.py
+++ b/app/services/analysis_artifact.py
@@ -2,20 +2,63 @@
 
 from __future__ import annotations
 
-from datetime import UTC, datetime
+import hashlib
+import json
+from datetime import UTC, datetime, timedelta
 from typing import Any
 
 import sqlalchemy as sa
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.timezone import now_kst
+from app.core.timezone import KST, now_kst
 from app.models.analysis_artifact import AnalysisArtifact
 from app.schemas.analysis_artifact import (
     AnalysisArtifactKindLiteral,
     AnalysisArtifactSave,
 )
 from app.schemas.investment_reports import MarketLiteral
+
+# Per-kind default freshness horizon in KST calendar days from as_of. Every kind
+# has a concrete horizon so an omitted valid_until never yields a never-stale
+# artifact (NULL=never-stale problem, ROB-648). Price/screen-derived kinds
+# expire at the end of the as_of trading day; session summaries and briefings
+# carry to the end of the next day so a morning-after review still sees them.
+_DEFAULT_TTL_DAYS_BY_KIND: dict[str, int] = {
+    "screening_ranking": 0,
+    "profit_taking_verdicts": 0,
+    "support_resistance_map": 0,
+    "flow_assessment": 0,
+    "candidate_pool": 0,
+    "session_summary": 1,
+    "briefing": 1,
+}
+_DEFAULT_TTL_DAYS_FALLBACK = 0
+
+
+def compute_content_hash(payload: dict[str, Any] | None) -> str:
+    """Canonical sha256 over the payload JSON.
+
+    Sorted keys + ``ensure_ascii=False`` make the digest stable across
+    re-serialization, so an identical payload hashes equal and drives the
+    ``action='unchanged'`` no-op (ROB-648; mirrors
+    ``symbol_report_ingest.content_hash``).
+    """
+    blob = json.dumps(payload or {}, sort_keys=True, ensure_ascii=False, default=str)
+    return hashlib.sha256(blob.encode("utf-8")).hexdigest()
+
+
+def default_valid_until(kind: str, as_of: datetime) -> datetime:
+    """Per-kind default ``valid_until`` when the caller omits it (ROB-648).
+
+    End-of-KST-day (23:59:59) of ``as_of`` plus the per-kind horizon. A lenient
+    proxy for '장마감' that sidesteps per-market close times and the
+    created-after-close edge (end-of-day is always >= a same-day ``as_of``).
+    """
+    as_of_kst = as_of.astimezone(KST) if as_of.tzinfo else as_of.replace(tzinfo=KST)
+    horizon = _DEFAULT_TTL_DAYS_BY_KIND.get(kind, _DEFAULT_TTL_DAYS_FALLBACK)
+    day = (as_of_kst + timedelta(days=horizon)).date()
+    return datetime(day.year, day.month, day.day, 23, 59, 59, tzinfo=KST)
 
 
 class AnalysisArtifactService:
@@ -27,11 +70,24 @@ class AnalysisArtifactService:
     async def save(self, entry: AnalysisArtifactSave) -> tuple[AnalysisArtifact, str]:
         """Persist one artifact and return ``(row, action)``.
 
-        Without ``correlation_id`` every call appends a new row. With
-        ``correlation_id`` the call is idempotent: a retry (e.g. an MCP
-        timeout re-send) updates the existing row in place instead of
-        duplicating it (ROB-474 trade_retrospectives pattern).
+        Without ``correlation_id`` every call appends a new row (``created``).
+        With ``correlation_id`` the call is idempotent (ROB-474
+        trade_retrospectives pattern): the server hashes the canonical payload
+        and compares to the stored row —
+
+        * identical payload → no write, ``version`` preserved (``unchanged``);
+        * changed payload → in-place update with ``version`` bumped (``updated``);
+        * no prior row → insert at ``version`` 1 (``created``).
+
+        ``valid_until`` defaults to a per-kind TTL when omitted so no artifact is
+        ever never-stale, and ``content_hash`` is always server-computed (ROB-648).
         """
+        content_hash = compute_content_hash(entry.payload)
+        valid_until = (
+            entry.valid_until
+            if entry.valid_until is not None
+            else default_valid_until(entry.kind, entry.as_of)
+        )
         values: dict[str, Any] = {
             "market": entry.market,
             "kind": entry.kind,
@@ -39,11 +95,14 @@ class AnalysisArtifactService:
             "symbols": entry.symbols,
             "payload": entry.payload,
             "as_of": entry.as_of,
-            "valid_until": entry.valid_until,
+            "valid_until": valid_until,
             "created_by": entry.created_by,
             "session_label": entry.session_label,
             "correlation_id": entry.correlation_id,
             "account_scope": entry.account_scope,
+            "readiness_label": entry.readiness_label,
+            "content_hash": content_hash,
+            "version": 1,
         }
         if entry.correlation_id is None:
             row = AnalysisArtifact(**values)
@@ -52,11 +111,19 @@ class AnalysisArtifactService:
             await self._session.refresh(row)
             return row, "created"
 
-        existing_id = await self._session.scalar(
-            sa.select(AnalysisArtifact.id).where(
+        existing = await self._session.scalar(
+            sa.select(AnalysisArtifact).where(
                 AnalysisArtifact.correlation_id == entry.correlation_id
             )
         )
+        if existing is not None and existing.content_hash == content_hash:
+            # Identical canonical payload → no-op. version and content stay put
+            # (dedup: same content = reuse, not churn).
+            return existing, "unchanged"
+
+        # Changed content bumps in place; a legacy row with NULL content_hash
+        # (pre-migration) also lands here and gets its hash backfilled.
+        values["version"] = (existing.version + 1) if existing is not None else 1
         stmt = (
             pg_insert(AnalysisArtifact)
             .values(**values)
@@ -78,7 +145,7 @@ class AnalysisArtifactService:
             execution_options={"populate_existing": True},
         )
         row = result.one()
-        return row, "updated" if existing_id is not None else "created"
+        return row, "updated" if existing is not None else "created"
 
     async def list_artifacts(
         self,
@@ -126,6 +193,45 @@ class AnalysisArtifactService:
                 | (AnalysisArtifact.valid_until >= now)
             )
         result = await self._session.scalars(stmt.limit(capped_limit))
+        return list(result.all())
+
+    async def fresh_artifacts_for_symbols(
+        self,
+        *,
+        symbols: list[str],
+        market: MarketLiteral | None = None,
+        limit: int = 50,
+    ) -> list[AnalysisArtifact]:
+        """Non-stale artifacts overlapping any of ``symbols``, newest first.
+
+        Powers the ``analyze_stock_batch`` ``fresh_artifact_exists`` hint
+        (ROB-648) — a soft advisory, never a gate. Uses the Postgres ``&&``
+        array-overlap operator so one query covers the whole batch.
+        """
+        from app.core.symbol import to_db_symbol
+
+        normalized = sorted(
+            {to_db_symbol(s.strip()) for s in symbols if s and s.strip()}
+        )
+        if not normalized:
+            return []
+        now = now_kst()
+        stmt = (
+            sa.select(AnalysisArtifact)
+            .where(
+                AnalysisArtifact.symbols.op("&&")(
+                    sa.text(":fresh_symbols").bindparams(
+                        sa.bindparam("fresh_symbols", value=normalized),
+                    )
+                ),
+                (AnalysisArtifact.valid_until.is_(None))
+                | (AnalysisArtifact.valid_until >= now),
+            )
+            .order_by(AnalysisArtifact.as_of.desc(), AnalysisArtifact.id.desc())
+        )
+        if market is not None:
+            stmt = stmt.where(AnalysisArtifact.market == market)
+        result = await self._session.scalars(stmt.limit(max(1, min(int(limit), 100))))
         return list(result.all())
 
     async def get(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "auto-trader"
-version = "0.2.6"
+version = "0.2.7"
 description = ""
 authors = [
     { name = "robin", email = "robin@watcha.com" }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -654,6 +654,39 @@ async def db_session():
                         "ON review.analysis_artifacts (correlation_id)"
                     )
                 )
+                # ROB-648 lifecycle fields — patched in for pre-existing tables
+                # (fresh DBs get them via create_all).
+                await conn.execute(
+                    text(
+                        "ALTER TABLE review.analysis_artifacts "
+                        "ADD COLUMN IF NOT EXISTS content_hash TEXT"
+                    )
+                )
+                await conn.execute(
+                    text(
+                        "ALTER TABLE review.analysis_artifacts "
+                        "ADD COLUMN IF NOT EXISTS version INTEGER NOT NULL DEFAULT 1"
+                    )
+                )
+                await conn.execute(
+                    text(
+                        "ALTER TABLE review.analysis_artifacts "
+                        "ADD COLUMN IF NOT EXISTS readiness_label TEXT"
+                    )
+                )
+                await conn.execute(
+                    text(
+                        "DO $$ BEGIN "
+                        "IF NOT EXISTS (SELECT 1 FROM pg_constraint "
+                        "WHERE conname = 'ck_analysis_artifacts_readiness_label') "
+                        "THEN ALTER TABLE review.analysis_artifacts "
+                        "ADD CONSTRAINT ck_analysis_artifacts_readiness_label "
+                        "CHECK (readiness_label IS NULL OR readiness_label IN ("
+                        "'screen_grade','not_decision_ready',"
+                        "'ready_for_order_review','blocked')); "
+                        "END IF; END $$"
+                    )
+                )
                 # ROB-430 PR-② — week_high_52_date added to the (persistent) KR
                 # fundamentals snapshot table; create_all is a no-op on the existing
                 # table, so patch the column in here (mirrors the alembic migration).

--- a/tests/models/test_analysis_artifact_model.py
+++ b/tests/models/test_analysis_artifact_model.py
@@ -25,6 +25,9 @@ def test_analysis_artifact_model_contract() -> None:
         "session_label",
         "correlation_id",
         "account_scope",
+        "content_hash",
+        "version",
+        "readiness_label",
         "created_by",
         "created_at",
     }
@@ -36,6 +39,7 @@ def test_analysis_artifact_model_contract() -> None:
     assert "ck_analysis_artifacts_market" in constraint_names
     assert "ck_analysis_artifacts_kind" in constraint_names
     assert "ck_analysis_artifacts_created_by" in constraint_names
+    assert "ck_analysis_artifacts_readiness_label" in constraint_names
 
     assert any(
         isinstance(constraint, UniqueConstraint)

--- a/tests/schemas/test_analysis_artifact_schemas.py
+++ b/tests/schemas/test_analysis_artifact_schemas.py
@@ -92,6 +92,9 @@ def test_read_serializes_payload_from_attributes() -> None:
         session_label = None
         correlation_id = None
         account_scope = None
+        content_hash = None
+        version = 1
+        readiness_label = None
         payload_size_bytes = 24
         is_stale = False
         created_by = "operator"
@@ -103,6 +106,43 @@ def test_read_serializes_payload_from_attributes() -> None:
     dumped = response.model_dump(mode="json")
     assert dumped["artifact_uuid"] == "55555555-5555-5555-5555-555555555555"
     assert dumped["symbols"] == ["KRW-BTC"]
+
+
+@pytest.mark.unit
+def test_save_accepts_valid_readiness_label_and_rejects_bad() -> None:
+    entry = AnalysisArtifactSave.model_validate(
+        {
+            "market": "kr",
+            "kind": "candidate_pool",
+            "title": "with readiness",
+            "as_of": "2026-07-02T00:00:00+00:00",
+            "readiness_label": "ready_for_order_review",
+        }
+    )
+    assert entry.readiness_label == "ready_for_order_review"
+
+    # Omitted -> None (advisory, optional).
+    entry_none = AnalysisArtifactSave.model_validate(
+        {
+            "market": "kr",
+            "kind": "candidate_pool",
+            "title": "no readiness",
+            "as_of": "2026-07-02T00:00:00+00:00",
+        }
+    )
+    assert entry_none.readiness_label is None
+
+    with pytest.raises(ValidationError) as exc_info:
+        AnalysisArtifactSave.model_validate(
+            {
+                "market": "kr",
+                "kind": "candidate_pool",
+                "title": "bad readiness",
+                "as_of": "2026-07-02T00:00:00+00:00",
+                "readiness_label": "go_live",
+            }
+        )
+    assert "readiness_label" in str(exc_info.value)
 
 
 @pytest.mark.unit

--- a/tests/services/test_analysis_artifact_service.py
+++ b/tests/services/test_analysis_artifact_service.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import timedelta
+from datetime import datetime, timedelta
 from uuid import uuid4
 
 import pytest
@@ -8,9 +8,13 @@ import pytest_asyncio
 import sqlalchemy as sa
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.timezone import now_kst
+from app.core.timezone import KST, now_kst
 from app.schemas.analysis_artifact import AnalysisArtifactSave
-from app.services.analysis_artifact import AnalysisArtifactService
+from app.services.analysis_artifact import (
+    AnalysisArtifactService,
+    compute_content_hash,
+    default_valid_until,
+)
 
 
 @pytest_asyncio.fixture(autouse=True)
@@ -50,6 +54,7 @@ async def test_save_list_get_round_trip(db_session: AsyncSession) -> None:
         market="kr",
         kind="candidate_pool",
         symbol=symbol,
+        include_stale=True,
         limit=10,
     )
     assert [row.id for row in listed] == [saved.id]
@@ -165,6 +170,136 @@ async def test_list_symbol_containment_and_since_filter(
         limit=10,
     )
     assert [row.title for row in since_filtered] == ["new ranking"]
+
+
+@pytest.mark.unit
+def test_default_valid_until_is_per_kind_and_never_none() -> None:
+    as_of = datetime(2026, 7, 2, 3, 0, 0, tzinfo=KST)
+    # Price/screen-derived kind → end of the as_of KST day.
+    daily = default_valid_until("screening_ranking", as_of)
+    assert daily == datetime(2026, 7, 2, 23, 59, 59, tzinfo=KST)
+    # Session summary / briefing → end of the next KST day.
+    summary = default_valid_until("session_summary", as_of)
+    assert summary == datetime(2026, 7, 3, 23, 59, 59, tzinfo=KST)
+    # Unknown kind falls back to end of the as_of day (never None).
+    unknown = default_valid_until("mystery", as_of)
+    assert unknown == datetime(2026, 7, 2, 23, 59, 59, tzinfo=KST)
+
+
+@pytest.mark.unit
+def test_content_hash_is_order_insensitive() -> None:
+    a = compute_content_hash({"x": 1, "y": [1, 2]})
+    b = compute_content_hash({"y": [1, 2], "x": 1})
+    assert a == b
+    assert a != compute_content_hash({"x": 2, "y": [1, 2]})
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_save_applies_per_kind_default_ttl_when_omitted(
+    db_session: AsyncSession,
+) -> None:
+    service = AnalysisArtifactService(db_session)
+    as_of = datetime(2026, 7, 2, 3, 0, 0, tzinfo=KST)
+    saved, _ = await service.save(
+        AnalysisArtifactSave.model_validate(
+            {
+                "market": "kr",
+                "kind": "flow_assessment",
+                "title": "ttl default",
+                "symbols": [f"TEST_{uuid4().hex[:8]}"],
+                "as_of": as_of.isoformat(),
+            }
+        )
+    )
+    assert saved.valid_until is not None
+    assert saved.valid_until == default_valid_until("flow_assessment", as_of)
+    assert saved.content_hash == compute_content_hash({})
+    assert saved.version == 1
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_correlation_save_unchanged_then_bumped(
+    db_session: AsyncSession,
+) -> None:
+    service = AnalysisArtifactService(db_session)
+    corr = f"corr-{uuid4().hex[:12]}"
+    base = {
+        "market": "kr",
+        "kind": "profit_taking_verdicts",
+        "title": "v1",
+        "as_of": "2026-07-02T02:00:00+00:00",
+        "correlation_id": corr,
+        "payload": {"a": 1},
+    }
+
+    first, action1 = await service.save(AnalysisArtifactSave.model_validate(base))
+    assert action1 == "created"
+    assert first.version == 1
+
+    # Same payload (different title) → unchanged, version preserved, no write.
+    same, action2 = await service.save(
+        AnalysisArtifactSave.model_validate({**base, "title": "v1-retry"})
+    )
+    assert action2 == "unchanged"
+    assert same.id == first.id
+    assert same.version == 1
+    assert same.title == "v1"  # no-op: stored title untouched
+
+    # Changed payload → updated + version bump.
+    changed, action3 = await service.save(
+        AnalysisArtifactSave.model_validate(
+            {**base, "title": "v2", "payload": {"a": 2}}
+        )
+    )
+    assert action3 == "updated"
+    assert changed.id == first.id
+    assert changed.version == 2
+    assert changed.payload == {"a": 2}
+    assert changed.content_hash == compute_content_hash({"a": 2})
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_fresh_artifacts_for_symbols_overlap_and_staleness(
+    db_session: AsyncSession,
+) -> None:
+    service = AnalysisArtifactService(db_session)
+    sym = f"TEST_{uuid4().hex[:8]}"
+    other = f"TEST_{uuid4().hex[:8]}"
+    base = now_kst()
+
+    fresh, _ = await service.save(
+        AnalysisArtifactSave.model_validate(
+            {
+                "market": "kr",
+                "kind": "support_resistance_map",
+                "title": "fresh sr",
+                "symbols": [sym],
+                "as_of": base.isoformat(),
+                "valid_until": (base + timedelta(hours=6)).isoformat(),
+            }
+        )
+    )
+    await service.save(
+        AnalysisArtifactSave.model_validate(
+            {
+                "market": "kr",
+                "kind": "support_resistance_map",
+                "title": "stale sr",
+                "symbols": [sym],
+                "as_of": (base - timedelta(hours=2)).isoformat(),
+                "valid_until": (base - timedelta(hours=1)).isoformat(),
+            }
+        )
+    )
+
+    hits = await service.fresh_artifacts_for_symbols(symbols=[sym], market="kr")
+    assert [row.id for row in hits] == [fresh.id]
+
+    # A symbol with no artifact returns nothing.
+    assert await service.fresh_artifacts_for_symbols(symbols=[other]) == []
 
 
 @pytest.mark.integration

--- a/tests/test_analysis_artifact_mcp.py
+++ b/tests/test_analysis_artifact_mcp.py
@@ -82,6 +82,7 @@ async def test_save_list_get_round_trip(db_session: AsyncSession) -> None:
         market="kr",
         kind="profit_taking_verdicts",
         symbol=symbol,
+        include_stale=True,
         limit=10,
     )
 
@@ -158,10 +159,14 @@ async def test_symbol_normalization(db_session: AsyncSession) -> None:
     assert saved["symbols"] == ["BRK.B", "BRK.A", "AAPL"]
 
     # Dash input saved as dot-format must be findable by dot-format lookup.
-    list_response = await analysis_artifact_list(market="us", symbol="BRK.B")
+    list_response = await analysis_artifact_list(
+        market="us", symbol="BRK.B", include_stale=True
+    )
     assert list_response["count"] == 1
     # And a dash-format query normalizes to the same hit.
-    list_dash = await analysis_artifact_list(market="us", symbol="BRK-B")
+    list_dash = await analysis_artifact_list(
+        market="us", symbol="BRK-B", include_stale=True
+    )
     assert list_dash["count"] == 1
 
 
@@ -211,9 +216,94 @@ async def test_correlation_id_idempotent_upsert(db_session: AsyncSession) -> Non
     assert second["artifact"]["title"] == "v2"
 
     listed = await analysis_artifact_list(
-        market="kr", correlation_id=correlation_id, limit=10
+        market="kr", correlation_id=correlation_id, include_stale=True, limit=10
     )
     assert listed["count"] == 1
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_save_unchanged_on_identical_payload(db_session: AsyncSession) -> None:
+    correlation_id = f"corr-{uuid4().hex[:12]}"
+    first = await analysis_artifact_save(
+        market="kr",
+        kind="profit_taking_verdicts",
+        title="v1",
+        payload={"rev": 1},
+        as_of="2026-07-02T02:00:00+00:00",
+        correlation_id=correlation_id,
+    )
+    assert first["action"] == "created"
+    assert first["artifact"]["version"] == 1
+    assert first["artifact"]["content_hash"]
+
+    # Same payload re-saved (later as_of) → unchanged + version preserved.
+    again = await analysis_artifact_save(
+        market="kr",
+        kind="profit_taking_verdicts",
+        title="v1-again",
+        payload={"rev": 1},
+        as_of="2026-07-02T05:00:00+00:00",
+        correlation_id=correlation_id,
+    )
+    assert again["action"] == "unchanged"
+    assert again["artifact"]["id"] == first["artifact"]["id"]
+    assert again["artifact"]["version"] == 1
+    assert again["artifact"]["content_hash"] == first["artifact"]["content_hash"]
+
+    # Changed payload → updated + version bump.
+    changed = await analysis_artifact_save(
+        market="kr",
+        kind="profit_taking_verdicts",
+        title="v2",
+        payload={"rev": 2},
+        as_of="2026-07-02T06:00:00+00:00",
+        correlation_id=correlation_id,
+    )
+    assert changed["action"] == "updated"
+    assert changed["artifact"]["version"] == 2
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_save_assigns_default_valid_until_when_omitted(
+    db_session: AsyncSession,
+) -> None:
+    response = await analysis_artifact_save(
+        market="kr",
+        kind="screening_ranking",
+        title="ttl default",
+        symbols=[f"TEST_{uuid4().hex[:8]}"],
+        as_of="2026-07-02T03:00:00+09:00",
+    )
+    assert response["success"] is True
+    # NULL=never-stale is solved: an omitted valid_until is server-assigned.
+    assert response["artifact"]["valid_until"] is not None
+    assert response["artifact"]["readiness_label"] is None
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_save_accepts_readiness_label(db_session: AsyncSession) -> None:
+    response = await analysis_artifact_save(
+        market="kr",
+        kind="candidate_pool",
+        title="graded",
+        as_of="2026-07-02T03:00:00+09:00",
+        readiness_label="ready_for_order_review",
+    )
+    assert response["success"] is True
+    assert response["artifact"]["readiness_label"] == "ready_for_order_review"
+
+    bad = await analysis_artifact_save(
+        market="kr",
+        kind="candidate_pool",
+        title="bad grade",
+        as_of="2026-07-02T03:00:00+09:00",
+        readiness_label="go_live",
+    )
+    assert bad["success"] is False
+    assert bad["error"] == "invalid_request"
 
 
 @pytest.mark.integration
@@ -227,6 +317,9 @@ async def test_list_is_metadata_only(db_session: AsyncSession) -> None:
         symbols=[symbol],
         payload={"big": "가나다" * 100},
         as_of="2026-07-02T02:00:00+00:00",
+        # Explicit far-future valid_until so is_stale stays False regardless of
+        # the run date (the omitted-TTL default would expire end of as_of day).
+        valid_until="2099-01-01T00:00:00+09:00",
     )
 
     response = await analysis_artifact_list(market="kr", symbol=symbol, limit=5)
@@ -236,6 +329,46 @@ async def test_list_is_metadata_only(db_session: AsyncSession) -> None:
     assert "payload" not in row
     assert row["payload_size_bytes"] > 0
     assert row["is_stale"] is False
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_analyze_stock_batch_surfaces_fresh_artifact_hint(
+    db_session: AsyncSession, monkeypatch
+) -> None:
+    from app.mcp_server.tooling import analysis_tool_handlers as handlers
+
+    covered = "005930"
+    uncovered = "000660"
+    save_response = await analysis_artifact_save(
+        market="kr",
+        kind="screening_ranking",
+        title="fresh ranking",
+        symbols=[covered],
+        as_of="2026-07-02T02:00:00+00:00",
+        valid_until="2099-01-01T00:00:00+09:00",
+    )
+    assert save_response["success"] is True
+
+    def stub(sym, market, include_peers):
+        return {"symbol": sym, "market_type": "equity_kr", "source": "kis"}
+
+    monkeypatch.setattr(handlers.analysis_screening, "_analyze_stock_impl", stub)
+
+    result = await handlers.analyze_stock_batch_impl(
+        [covered, uncovered], market="kr", include_position=False
+    )
+
+    covered_row = result["results"][covered]
+    hint = covered_row["fresh_artifact_exists"]
+    assert hint["artifact_uuid"] == save_response["artifact"]["artifact_uuid"]
+    assert hint["kind"] == "screening_ranking"
+    # as_of is the same instant (compare parsed, format may differ across reads).
+    from dateutil.parser import parse
+
+    assert parse(hint["as_of"]) == parse(save_response["artifact"]["as_of"])
+    # A symbol with no fresh artifact carries no hint at all.
+    assert "fresh_artifact_exists" not in result["results"][uncovered]
 
 
 @pytest.mark.integration

--- a/uv.lock
+++ b/uv.lock
@@ -222,7 +222,7 @@ wheels = [
 
 [[package]]
 name = "auto-trader"
-version = "0.2.5"
+version = "0.2.7"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
## ROB-648 — P4: analysis_artifacts lifecycle (content_hash · version · readiness_label · per-kind TTL) + fresh-artifact soft-gate hint

Adds lifecycle fields to `review.analysis_artifacts` (ROB-637) and a **soft** reuse hint on `analyze_stock_batch`. No hard short-circuit gate (rejected: intraday price drift risk + per-kind TTL prerequisite).

### 산출물
1. **content_hash** — server-computed `sha256` over canonical payload JSON (`sort_keys=True, ensure_ascii=False`), caller-provided rejected (not a param). Nullable + lazy backfill (next save computes it). `save` returns **`action='unchanged'`** when a `correlation_id` re-save hashes identical (no write, version preserved). Mirrors `symbol_report_ingest.content_hash`.
2. **version** — additive `Integer NOT NULL server_default 1`, in-place bump. `UNIQUE(correlation_id)` preserved, no history rows (ROB-474 pattern). Bumps only when payload content changes.
3. **readiness_label** — reduced advisory enum CHECK (`screen_grade` / `not_decision_ready` / `ready_for_order_review` / `blocked`), nullable, caller-declared (server-derived gating deferred to P5+).
4. **per-kind 기본 TTL** — omitted `valid_until` → `default_valid_until(kind, as_of)`: price/screen kinds = end of `as_of` KST day; `session_summary`/`briefing` = end of next KST day. Resolves the NULL=never-stale gap.
5. **soft-gate 힌트** — `analyze_stock_batch` (quick) per-symbol `fresh_artifact_exists {artifact_uuid, as_of, kind}` when a non-stale artifact covers the symbol. **Fail-open** (DB error ⇒ analysis unaffected), one Postgres `&&` overlap query for the batch. No short-circuit.
6. **README/도구 설명 드리프트 수정** — save signature gains `correlation_id` / `account_scope` / `readiness_label`; `briefing` kind added; ROB-638 fetch-layer cache (cross-call) vs artifact store (cross-session) **complementarity** noted (not double coverage).

### 수용 기준
- ✅ 마이그레이션 1개(additive), 기존 save/list/get 백컴팻
- ✅ 동일 payload 재저장 → `action='unchanged'` + version 불변; 변경 → version+1
- ✅ `valid_until` 생략 저장이 kind별 기본 TTL 부여받음
- ✅ `analyze_stock_batch` 응답에 힌트 필드(fresh artifact 있을 때만)

### 마이그레이션
`20260702_rob648` — `down_revision = 20260702_rob641`, **단일 head 확인**. Additive columns + `ck_analysis_artifacts_readiness_label` CHECK. `content_hash` nullable (in-migration 백필 불필요). conftest가 pre-existing 테이블에 새 컬럼/CHECK 패치(ROB-637 패턴).

### 판단 콜
`content_hash`는 **payload만** 대상(스펙 "canonical payload JSON 대상" + 수용 기준). 따라서 동일 payload + 다른 title/readiness_label 재저장은 `unchanged` no-op이라 해당 메타 변경이 반영되지 않음 — advisory 필드라 스펙대로. README/코드 주석에 명시.

### 검증
- 아티팩트 테스트 스위트 **30 pass** (신규: unchanged/version bump, per-kind TTL, readiness accept/reject, batch hint present/absent, fresh-for-symbols overlap+staleness), batch cache **54 pass**, mcp_server **355 pass**.
- `ruff format --check` + `ruff check` + `ty` 전부 green.
- 마이그레이션 DDL을 scratch 테이블에 적용해 CHECK 강제/version 기본값 확인. conftest 드리프트 패치 경로도 시뮬레이션 검증.
- pyproject 0.2.6→**0.2.7** + uv.lock 동기화(committed lock이 0.2.5로 drift돼 있어 함께 교정).

### 잔여 (operator)
- `alembic upgrade head` (프로덕션 cutover)
- MCP 재시작 후 `analysis_artifact_save`(action='unchanged'/version/TTL) + `analyze_stock_batch`(fresh_artifact_exists) 스모크

🤖 Generated with [Claude Code](https://claude.com/claude-code)