### PR TITLE
feat(ROB-650): resolvable forecast ledger — forecast_save/resolve + Brier calibration

### DIFF
--- a/alembic/versions/20260702_rob650_trade_forecasts.py
+++ b/alembic/versions/20260702_rob650_trade_forecasts.py
@@ -1,0 +1,165 @@
+"""ROB-650 resolvable forecast ledger
+
+Revision ID: 20260702_rob650
+Revises: 20260702_rob641
+Create Date: 2026-07-02 00:00:00.000000
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "20260702_rob650"
+down_revision: str | None = "20260702_rob641"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "trade_forecasts",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column(
+            "forecast_id",
+            postgresql.UUID(as_uuid=True),
+            nullable=False,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column("artifact_uuid", sa.Text(), nullable=True),
+        sa.Column("journal_id", sa.BigInteger(), nullable=True),
+        sa.Column("report_uuid", sa.Text(), nullable=True),
+        sa.Column("report_item_uuid", sa.Text(), nullable=True),
+        sa.Column("correlation_id", sa.Text(), nullable=True),
+        sa.Column("created_by", sa.Text(), nullable=False),
+        sa.Column("session_label", sa.Text(), nullable=True),
+        sa.Column("model_label", sa.Text(), nullable=True),
+        sa.Column("policy_version", sa.Text(), nullable=True),
+        sa.Column("symbol", sa.Text(), nullable=False),
+        sa.Column(
+            "instrument_type",
+            postgresql.ENUM(name="instrument_type", create_type=False),
+            nullable=False,
+        ),
+        sa.Column(
+            "forecast_target",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+        ),
+        sa.Column("horizon", sa.Text(), nullable=True),
+        sa.Column("probability", sa.Numeric(5, 4), nullable=False),
+        sa.Column("probability_range_low", sa.Numeric(5, 4), nullable=True),
+        sa.Column("probability_range_high", sa.Numeric(5, 4), nullable=True),
+        sa.Column(
+            "evidence_ids",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=True,
+        ),
+        sa.Column("contrary_evidence", sa.Text(), nullable=True),
+        sa.Column("resolution_source", sa.Text(), nullable=True),
+        sa.Column("forecast_start_date", sa.Date(), nullable=True),
+        sa.Column("review_date", sa.Date(), nullable=False),
+        sa.Column(
+            "status",
+            sa.Text(),
+            nullable=False,
+            server_default=sa.text("'open'"),
+        ),
+        sa.Column("outcome", sa.Boolean(), nullable=True),
+        sa.Column("observed_value", sa.Numeric(20, 8), nullable=True),
+        sa.Column("resolved_at", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("brier_score", sa.Numeric(6, 5), nullable=True),
+        sa.Column(
+            "resolution_detail",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=True,
+        ),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("forecast_id", name="uq_trade_forecasts_forecast_id"),
+        sa.CheckConstraint(
+            "status IN ('open','closed')",
+            name="ck_trade_forecasts_status",
+        ),
+        sa.CheckConstraint(
+            "probability >= 0 AND probability <= 1",
+            name="ck_trade_forecasts_probability",
+        ),
+        sa.CheckConstraint(
+            "(probability_range_low IS NULL AND probability_range_high IS NULL) OR "
+            "(probability_range_low IS NOT NULL "
+            "AND probability_range_high IS NOT NULL "
+            "AND probability_range_low <= probability_range_high "
+            "AND probability >= probability_range_low "
+            "AND probability <= probability_range_high)",
+            name="ck_trade_forecasts_probability_range",
+        ),
+        sa.CheckConstraint(
+            "brier_score IS NULL OR (brier_score >= 0 AND brier_score <= 1)",
+            name="ck_trade_forecasts_brier_score",
+        ),
+        schema="review",
+    )
+    op.create_index(
+        "ix_trade_forecasts_status_review_date",
+        "trade_forecasts",
+        ["status", "review_date"],
+        schema="review",
+    )
+    op.create_index(
+        "ix_trade_forecasts_symbol",
+        "trade_forecasts",
+        ["symbol"],
+        schema="review",
+    )
+    op.create_index(
+        "ix_trade_forecasts_created_by",
+        "trade_forecasts",
+        ["created_by"],
+        schema="review",
+    )
+    op.create_index(
+        "ix_trade_forecasts_correlation_id",
+        "trade_forecasts",
+        ["correlation_id"],
+        schema="review",
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_trade_forecasts_correlation_id",
+        table_name="trade_forecasts",
+        schema="review",
+    )
+    op.drop_index(
+        "ix_trade_forecasts_created_by",
+        table_name="trade_forecasts",
+        schema="review",
+    )
+    op.drop_index(
+        "ix_trade_forecasts_symbol",
+        table_name="trade_forecasts",
+        schema="review",
+    )
+    op.drop_index(
+        "ix_trade_forecasts_status_review_date",
+        table_name="trade_forecasts",
+        schema="review",
+    )
+    op.drop_table("trade_forecasts", schema="review")

--- a/app/mcp_server/__init__.py
+++ b/app/mcp_server/__init__.py
@@ -53,6 +53,11 @@ AVAILABLE_TOOL_NAMES = [
     "save_trade_retrospective",
     "get_trade_retrospectives",
     "get_retrospective_aggregate",
+    # ROB-650: resolvable forecast ledger
+    "forecast_save",
+    "forecast_resolve",
+    "get_forecasts",
+    "get_forecast_calibration",
     # Crypto research tools
     "get_crypto_profile",
     "get_kimchi_premium",

--- a/app/mcp_server/tooling/forecast_registration.py
+++ b/app/mcp_server/tooling/forecast_registration.py
@@ -1,0 +1,78 @@
+# app/mcp_server/tooling/forecast_registration.py
+"""ROB-650 — MCP registration for resolvable forecast tools."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from app.mcp_server.tooling.forecast_tools import (
+    forecast_resolve,
+    forecast_save,
+    get_forecast_calibration,
+    get_forecasts,
+)
+
+FORECAST_TOOL_NAMES: set[str] = {
+    "forecast_save",
+    "forecast_resolve",
+    "get_forecasts",
+    "get_forecast_calibration",
+}
+
+
+def register_forecast_tools(mcp: Any) -> None:
+    _ = mcp.tool(
+        name="forecast_save",
+        description=(
+            "Record a resolvable probabilistic forecast (a buy thesis or a "
+            "profit-taking WATCH->PLACE verdict made resolvable). Required: "
+            "created_by, symbol, instrument_type in {equity_kr, equity_us, "
+            "crypto, forex, index}, forecast_target (object with 'kind'; for "
+            "'price_target' also 'direction' in {at_or_above, at_or_below} and "
+            "'target_price'), probability in [0,1], review_date (YYYY-MM-DD). "
+            "Optional probability_range_low/high (probability must fall inside), "
+            "horizon, evidence_ids, contrary_evidence, forecast_start_date, "
+            "artifact_uuid/journal_id/report_uuid/report_item_uuid/correlation_id "
+            "links, and session_label/model_label/policy_version for calibration. "
+            "Idempotent per forecast_id (omit to create; supply to update while "
+            "open — a closed/resolved forecast is immutable). Composition is the "
+            "caller's judgment; storage/scoring is deterministic."
+        ),
+    )(forecast_save)
+    _ = mcp.tool(
+        name="forecast_resolve",
+        description=(
+            "Resolve due forecasts deterministically and score them (Brier = "
+            "(probability - outcome)^2). dry_run-default: with dry_run=true "
+            "(default) it computes and previews without writing; dry_run=false "
+            "persists (status -> closed). With forecast_id it resolves that one; "
+            "without it, resolves every open forecast whose review_date has "
+            "passed (up to limit). price_target forecasts resolve against loaded "
+            "daily OHLCV (ROB-639 DB-first, equity_kr/equity_us/crypto). "
+            "Non-price kinds (or price forecasts you must override) require an "
+            "explicit forecast_id plus manual_outcome (bool) and manual_evidence. "
+            "Idempotent: a closed forecast is never re-scored."
+        ),
+    )(forecast_resolve)
+    _ = mcp.tool(
+        name="get_forecasts",
+        description=(
+            "List forecasts with filters (status open/closed, symbol, "
+            "created_by, correlation_id). Read-only."
+        ),
+    )(get_forecasts)
+    _ = mcp.tool(
+        name="get_forecast_calibration",
+        description=(
+            "Calibration aggregate over closed, scored forecasts: average Brier "
+            "score, hit-rate, average probability and calibration_gap "
+            "(avg_probability - hit_rate; positive = over-confident) per cohort. "
+            "group_by in {created_by, session_label, model_label, day} — the "
+            "objective metric for comparing whether different sessions/models "
+            "reach equally well-calibrated calls. Filters: created_by, symbol, "
+            "instrument_type, days. Read-only."
+        ),
+    )(get_forecast_calibration)
+
+
+__all__ = ["FORECAST_TOOL_NAMES", "register_forecast_tools"]

--- a/app/mcp_server/tooling/forecast_tools.py
+++ b/app/mcp_server/tooling/forecast_tools.py
@@ -1,0 +1,211 @@
+# app/mcp_server/tooling/forecast_tools.py
+"""ROB-650 — MCP tools for the resolvable forecast ledger."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, cast
+
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from app.core.db import AsyncSessionLocal
+from app.services.trade_journal.forecast_service import (
+    ForecastValidationError,
+    build_forecast_calibration_aggregate,
+    list_due_forecasts,
+    list_forecasts,
+    resolve_forecast,
+    save_forecast,
+    serialize_forecast,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _session_factory() -> async_sessionmaker[AsyncSession]:
+    return cast(async_sessionmaker[AsyncSession], cast(object, AsyncSessionLocal))
+
+
+async def forecast_save(
+    created_by: str,
+    symbol: str,
+    instrument_type: str,
+    forecast_target: dict,
+    probability: float,
+    review_date: str,
+    forecast_id: str | None = None,
+    horizon: str | None = None,
+    probability_range_low: float | None = None,
+    probability_range_high: float | None = None,
+    evidence_ids: list | None = None,
+    contrary_evidence: str | None = None,
+    forecast_start_date: str | None = None,
+    resolution_source: str | None = None,
+    session_label: str | None = None,
+    model_label: str | None = None,
+    policy_version: str | None = None,
+    artifact_uuid: str | None = None,
+    journal_id: int | None = None,
+    report_uuid: str | None = None,
+    report_item_uuid: str | None = None,
+    correlation_id: str | None = None,
+) -> dict[str, Any]:
+    symbol = (symbol or "").strip()
+    if not symbol:
+        return {"success": False, "error": "symbol is required"}
+    try:
+        async with _session_factory()() as db:
+            action, row = await save_forecast(
+                db,
+                created_by=created_by,
+                symbol=symbol,
+                instrument_type=instrument_type,
+                forecast_target=forecast_target,
+                probability=probability,
+                review_date=review_date,
+                forecast_id=forecast_id,
+                horizon=horizon,
+                probability_range_low=probability_range_low,
+                probability_range_high=probability_range_high,
+                evidence_ids=evidence_ids,
+                contrary_evidence=contrary_evidence,
+                forecast_start_date=forecast_start_date,
+                resolution_source=resolution_source,
+                session_label=session_label,
+                model_label=model_label,
+                policy_version=policy_version,
+                artifact_uuid=artifact_uuid,
+                journal_id=journal_id,
+                report_uuid=report_uuid,
+                report_item_uuid=report_item_uuid,
+                correlation_id=correlation_id,
+            )
+            await db.commit()
+            await db.refresh(row)
+            return {
+                "success": True,
+                "action": action,
+                "data": serialize_forecast(row),
+            }
+    except ForecastValidationError as exc:
+        return {"success": False, "error": str(exc)}
+    except Exception as exc:  # noqa: BLE001
+        logger.exception("forecast_save failed")
+        return {"success": False, "error": f"forecast_save failed: {exc}"}
+
+
+async def forecast_resolve(
+    forecast_id: str | None = None,
+    dry_run: bool = True,
+    manual_outcome: bool | None = None,
+    manual_observed_value: float | None = None,
+    manual_evidence: Any | None = None,
+    limit: int = 25,
+) -> dict[str, Any]:
+    persist = not dry_run
+    try:
+        async with _session_factory()() as db:
+            if forecast_id:
+                result = await resolve_forecast(
+                    db,
+                    forecast_id=forecast_id,
+                    persist=persist,
+                    manual_outcome=manual_outcome,
+                    manual_observed_value=manual_observed_value,
+                    manual_evidence=manual_evidence,
+                )
+                if persist and result.get("changed"):
+                    await db.commit()
+                return {"success": True, "dry_run": dry_run, "mode": "single", **result}
+
+            # Batch: resolve every due (review_date reached) open forecast.
+            if manual_outcome is not None or manual_evidence is not None:
+                return {
+                    "success": False,
+                    "error": "manual resolution requires an explicit forecast_id",
+                }
+            due = await list_due_forecasts(db, limit=limit)
+            results: list[dict[str, Any]] = []
+            changed_any = False
+            for row in due:
+                r = await resolve_forecast(
+                    db, forecast_id=row.forecast_id, persist=persist
+                )
+                changed_any = changed_any or bool(r.get("changed"))
+                results.append(
+                    {
+                        "forecast_id": str(row.forecast_id),
+                        "symbol": row.symbol,
+                        "status": r["status"],
+                        "changed": bool(r.get("changed")),
+                        "computed": r.get("computed"),
+                        "reason": r.get("reason"),
+                    }
+                )
+            if persist and changed_any:
+                await db.commit()
+            by_status: dict[str, int] = {}
+            for r in results:
+                by_status[r["status"]] = by_status.get(r["status"], 0) + 1
+            return {
+                "success": True,
+                "dry_run": dry_run,
+                "mode": "due_batch",
+                "due_count": len(due),
+                "by_status": by_status,
+                "results": results,
+            }
+    except ForecastValidationError as exc:
+        return {"success": False, "error": str(exc)}
+    except Exception as exc:  # noqa: BLE001
+        logger.exception("forecast_resolve failed")
+        return {"success": False, "error": f"forecast_resolve failed: {exc}"}
+
+
+async def get_forecasts(
+    status: str | None = None,
+    symbol: str | None = None,
+    created_by: str | None = None,
+    correlation_id: str | None = None,
+    limit: int = 50,
+) -> dict[str, Any]:
+    try:
+        async with _session_factory()() as db:
+            result = await list_forecasts(
+                db,
+                status=status,
+                symbol=symbol,
+                created_by=created_by,
+                correlation_id=correlation_id,
+                limit=limit,
+            )
+        return {"success": True, **result}
+    except Exception as exc:  # noqa: BLE001
+        logger.exception("get_forecasts failed")
+        return {"success": False, "error": f"get_forecasts failed: {exc}"}
+
+
+async def get_forecast_calibration(
+    group_by: str = "created_by",
+    created_by: str | None = None,
+    symbol: str | None = None,
+    instrument_type: str | None = None,
+    days: int | None = None,
+) -> dict[str, Any]:
+    try:
+        async with _session_factory()() as db:
+            result = await build_forecast_calibration_aggregate(
+                db,
+                group_by=group_by,
+                created_by=created_by,
+                symbol=symbol,
+                instrument_type=instrument_type,
+                days=days,
+            )
+        return {"success": True, **result}
+    except Exception as exc:  # noqa: BLE001
+        logger.exception("get_forecast_calibration failed")
+        return {
+            "success": False,
+            "error": f"get_forecast_calibration failed: {exc}",
+        }

--- a/app/mcp_server/tooling/registry.py
+++ b/app/mcp_server/tooling/registry.py
@@ -57,6 +57,7 @@ from app.mcp_server.tooling.analysis_artifact_registration import (
     register_analysis_artifact_tools,
 )
 from app.mcp_server.tooling.analysis_registration import register_analysis_tools
+from app.mcp_server.tooling.forecast_registration import register_forecast_tools
 from app.mcp_server.tooling.fundamentals_registration import register_fundamentals_tools
 from app.mcp_server.tooling.investment_hermes_handlers import (
     register_investment_hermes_tools,
@@ -159,6 +160,7 @@ def register_all_tools(mcp: FastMCP, profile: McpProfile = McpProfile.DEFAULT) -
     register_trade_journal_tools(mcp)
     register_mock_loop_retro_tools(mcp)
     register_trade_retrospective_tools(mcp)
+    register_forecast_tools(mcp)
 
     # ROB-269 Phase 2 — investment-snapshot MCP surface. Gated by
     # ``settings.INVESTMENT_SNAPSHOTS_MCP_ENABLED`` so the 3 read tools are

--- a/app/models/review.py
+++ b/app/models/review.py
@@ -1010,3 +1010,113 @@ class TradeRetrospective(Base):
         onupdate=func.now(),
         nullable=False,
     )
+
+
+# ---------------------------------------------------------------------------
+# review.trade_forecasts — resolvable probabilistic forecasts (ROB-650)
+# ---------------------------------------------------------------------------
+class TradeForecast(Base):
+    """ROB-650 — resolvable prediction ledger with deterministic scoring.
+
+    A forecast records a probabilistic, resolvable claim made when composing a
+    buy thesis or a profit-taking (WATCH→PLACE) verdict — e.g. "P(005930 touches
+    129,600 support by 2026-07-15) = 0.65". Composition is a Claude session
+    (LLM boundary); the record/resolve/score logic here is fully deterministic.
+
+    ``forecast_id`` is the idempotency key (client-supplied to update while open,
+    or auto-generated). ``forecast_target`` is a structured JSONB claim; the
+    ``price_target`` kind resolves deterministically against loaded daily OHLCV
+    (ROB-639), non-price kinds resolve via an operator-supplied manual outcome
+    (evidence required). ``correlation_id`` aligns with trade_retrospectives
+    (ROB-647) so a postmortem can cite the forecast it graded.
+    """
+
+    __tablename__ = "trade_forecasts"
+    __table_args__ = (
+        UniqueConstraint("forecast_id", name="uq_trade_forecasts_forecast_id"),
+        CheckConstraint(
+            "status IN ('open','closed')",
+            name="ck_trade_forecasts_status",
+        ),
+        CheckConstraint(
+            "probability >= 0 AND probability <= 1",
+            name="ck_trade_forecasts_probability",
+        ),
+        CheckConstraint(
+            "(probability_range_low IS NULL AND probability_range_high IS NULL) OR "
+            "(probability_range_low IS NOT NULL "
+            "AND probability_range_high IS NOT NULL "
+            "AND probability_range_low <= probability_range_high "
+            "AND probability >= probability_range_low "
+            "AND probability <= probability_range_high)",
+            name="ck_trade_forecasts_probability_range",
+        ),
+        CheckConstraint(
+            "brier_score IS NULL OR (brier_score >= 0 AND brier_score <= 1)",
+            name="ck_trade_forecasts_brier_score",
+        ),
+        Index("ix_trade_forecasts_status_review_date", "status", "review_date"),
+        Index("ix_trade_forecasts_symbol", "symbol"),
+        Index("ix_trade_forecasts_created_by", "created_by"),
+        Index("ix_trade_forecasts_correlation_id", "correlation_id"),
+        {"schema": "review"},
+    )
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    forecast_id: Mapped[uuid.UUID] = mapped_column(
+        PG_UUID(as_uuid=True),
+        nullable=False,
+        default=uuid.uuid4,
+        server_default=text("gen_random_uuid()"),
+    )
+
+    # Loose reference links (no FK — a forecast is a durable learning record
+    # that outlives the artifact/journal/report it was born from).
+    artifact_uuid: Mapped[str | None] = mapped_column(Text)
+    journal_id: Mapped[int | None] = mapped_column(BigInteger)
+    report_uuid: Mapped[str | None] = mapped_column(Text)
+    report_item_uuid: Mapped[str | None] = mapped_column(Text)
+    correlation_id: Mapped[str | None] = mapped_column(Text)
+
+    # Attribution (calibration groups by these labels).
+    created_by: Mapped[str] = mapped_column(Text, nullable=False)
+    session_label: Mapped[str | None] = mapped_column(Text)
+    model_label: Mapped[str | None] = mapped_column(Text)
+    policy_version: Mapped[str | None] = mapped_column(Text)
+
+    # The claim.
+    symbol: Mapped[str] = mapped_column(Text, nullable=False)
+    instrument_type: Mapped[InstrumentType] = mapped_column(
+        Enum(InstrumentType, name="instrument_type", create_type=False),
+        nullable=False,
+    )
+    forecast_target: Mapped[dict] = mapped_column(JSONB, nullable=False)
+    horizon: Mapped[str | None] = mapped_column(Text)
+    probability: Mapped[Decimal] = mapped_column(Numeric(5, 4), nullable=False)
+    probability_range_low: Mapped[Decimal | None] = mapped_column(Numeric(5, 4))
+    probability_range_high: Mapped[Decimal | None] = mapped_column(Numeric(5, 4))
+    evidence_ids: Mapped[list | None] = mapped_column(JSONB)
+    contrary_evidence: Mapped[str | None] = mapped_column(Text)
+    resolution_source: Mapped[str | None] = mapped_column(Text)
+    forecast_start_date: Mapped[date | None] = mapped_column(Date)
+    review_date: Mapped[date] = mapped_column(Date, nullable=False)
+    status: Mapped[str] = mapped_column(
+        Text, nullable=False, server_default=text("'open'")
+    )
+
+    # Deterministic resolution outputs (populated at resolve time).
+    outcome: Mapped[bool | None] = mapped_column(Boolean)
+    observed_value: Mapped[Decimal | None] = mapped_column(Numeric(20, 8))
+    resolved_at: Mapped[datetime | None] = mapped_column(TIMESTAMP(timezone=True))
+    brier_score: Mapped[Decimal | None] = mapped_column(Numeric(6, 5))
+    resolution_detail: Mapped[dict | None] = mapped_column(JSONB)
+
+    created_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )

--- a/app/services/daily_candles/repository.py
+++ b/app/services/daily_candles/repository.py
@@ -281,6 +281,113 @@ class DailyCandlesRepository:
             return None
         return row.latest
 
+    async def fetch_range(
+        self,
+        *,
+        market: MarketKey,
+        symbol: str,
+        partition: str,
+        start: datetime,
+        end: datetime,
+    ) -> list[DailyCandleRow]:
+        """Fetch daily candles with ``start <= time <= end`` (ascending).
+
+        Read-only window query used for deterministic forecast resolution
+        (ROB-650): unlike ``fetch_recent`` (latest-N), this returns exactly the
+        rows inside the resolution window regardless of how far in the past it
+        sits, so the same forecast resolves to the same outcome whenever it is
+        run.
+        """
+        if market == MarketKey.CRYPTO:
+            try:
+                iid = await self._resolve_instrument_id(
+                    symbol=symbol, partition=partition
+                )
+            except LookupError:
+                return []
+            sql = text(
+                """
+                SELECT time, :symbol AS symbol, :partition AS partition,
+                       open, high, low, close,
+                       NULL::numeric AS adj_close,
+                       base_volume AS volume, quote_volume AS value, source
+                FROM public.crypto_candles_1d
+                WHERE instrument_id = :iid AND time >= :start AND time <= :end
+                ORDER BY time ASC
+                """
+            )
+            result = await self._session.execute(
+                sql,
+                {
+                    "iid": iid,
+                    "symbol": symbol,
+                    "partition": partition,
+                    "start": start,
+                    "end": end,
+                },
+            )
+            out: list[DailyCandleRow] = []
+            for row in result.mappings().all():
+                out.append(
+                    DailyCandleRow(
+                        time_utc=row["time"],
+                        symbol=row["symbol"],
+                        partition=row["partition"],
+                        open=float(row["open"]),
+                        high=float(row["high"]),
+                        low=float(row["low"]),
+                        close=float(row["close"]),
+                        adj_close=None,
+                        volume=float(row["volume"])
+                        if row["volume"] is not None
+                        else 0.0,
+                        value=float(row["value"]) if row["value"] is not None else 0.0,
+                        source=row["source"],
+                    )
+                )
+            return out
+
+        cfg = self._config(market)
+        adj_close_select = (
+            "adj_close, " if self._supports_adj_close(market) else "NULL AS adj_close, "
+        )
+        sql = text(
+            f"""
+            SELECT time, symbol, {cfg.partition_col} AS partition,
+                   open, high, low, close, {adj_close_select}volume, value, source
+            FROM public.{cfg.table_name}
+            WHERE symbol = :symbol AND {cfg.partition_col} = :partition
+              AND time >= :start AND time <= :end
+            ORDER BY time ASC
+            """
+        )
+        result = await self._session.execute(
+            sql,
+            {"symbol": symbol, "partition": partition, "start": start, "end": end},
+        )
+        out = []
+        for row in result.mappings().all():
+            out.append(
+                DailyCandleRow(
+                    time_utc=row["time"],
+                    symbol=row["symbol"],
+                    partition=row["partition"],
+                    open=float(row["open"]),
+                    high=float(row["high"]),
+                    low=float(row["low"]),
+                    close=float(row["close"]),
+                    adj_close=(
+                        float(row["adj_close"])
+                        if row["adj_close"] is not None
+                        else None
+                    ),
+                    volume=float(row["volume"]),
+                    value=float(row["value"]),
+                    source=row["source"],
+                )
+            )
+        return out
+
     async def fetch_recent(
         self, *, market: MarketKey, symbol: str, partition: str, count: int
     ) -> list[DailyCandleRow]:

--- a/app/services/trade_journal/forecast_service.py
+++ b/app/services/trade_journal/forecast_service.py
@@ -1,0 +1,660 @@
+# app/services/trade_journal/forecast_service.py
+"""ROB-650 — resolvable forecast ledger: record, deterministic resolve, score.
+
+The repository is the only write surface for ``review.trade_forecasts``.
+Composition of a forecast (choosing the probability/thesis) is a Claude session
+(LLM boundary); everything here — recording, OHLCV-backed resolution, Brier
+scoring, calibration aggregation — is fully deterministic and side-effect-free
+apart from the DB write.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import uuid
+from datetime import date, datetime, timedelta
+from decimal import Decimal
+from typing import Any
+from zoneinfo import ZoneInfo
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.symbol import to_db_symbol
+from app.core.timezone import now_kst
+from app.models.review import TradeForecast
+from app.models.trading import InstrumentType
+from app.services.daily_candles.repository import (
+    DailyCandleRow,
+    DailyCandlesRepository,
+    MarketKey,
+)
+
+# Fallback policy stamp. ROB-646 (get_trading_policy YAML single source) has not
+# landed on this branch; until it does, forecasts stamp this module constant so
+# scoring cohorts remain comparable. When a caller supplies ``policy_version``
+# (e.g. from a future get_trading_policy contract) that value wins.
+POLICY_VERSION = "forecast.v1"
+
+_KST = ZoneInfo("Asia/Seoul")
+
+_VALID_INSTRUMENTS = {t.value for t in InstrumentType}
+# Instrument types with a loaded daily-candle store → deterministic auto-resolve.
+_AUTO_RESOLVABLE_INSTRUMENTS = {"equity_kr", "equity_us", "crypto"}
+_PRICE_DIRECTIONS = {"at_or_above", "at_or_below"}
+_GROUP_BY_FIELDS = {"created_by", "session_label", "model_label", "day"}
+
+
+class ForecastValidationError(ValueError):
+    """Raised when a forecast payload violates a typed constraint."""
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers (unit-tested in isolation)
+# ---------------------------------------------------------------------------
+def brier_score(probability: float, outcome: bool) -> float:
+    """Brier score for a single binary forecast: ``(p - o)**2``, o in {0,1}.
+
+    Boundaries: p=0/outcome=False -> 0; p=1/outcome=True -> 0; p=0.5 -> 0.25
+    regardless of outcome; a fully-wrong confident call (p=1, outcome=False)
+    -> 1.
+    """
+    o = 1.0 if outcome else 0.0
+    return (float(probability) - o) ** 2
+
+
+def classify_price_target_outcome(
+    candles: list[DailyCandleRow],
+    *,
+    direction: str,
+    target_price: float,
+) -> tuple[bool, float]:
+    """Deterministically resolve a price-target claim over a candle window.
+
+    ``at_or_above``: outcome is True iff any bar's ``high`` reaches the target;
+    the observed extreme is the window ``max(high)``. ``at_or_below``: True iff
+    any bar's ``low`` reaches the target; observed extreme is ``min(low)``.
+    Raises on empty candles (caller must guard) or an unknown direction.
+    """
+    if not candles:
+        raise ForecastValidationError("cannot classify an empty candle window")
+    if direction == "at_or_above":
+        extreme = max(c.high for c in candles)
+        return extreme >= target_price, extreme
+    if direction == "at_or_below":
+        extreme = min(c.low for c in candles)
+        return extreme <= target_price, extreme
+    raise ForecastValidationError(f"invalid price-target direction: {direction!r}")
+
+
+def _to_decimal(x: float | None) -> Decimal | None:
+    return Decimal(str(x)) if x is not None else None
+
+
+def _normalize_symbol(symbol: str, instrument_type: str) -> str:
+    normalized = symbol.strip().upper()
+    if instrument_type == "crypto":
+        if normalized and "-" not in normalized:
+            return f"KRW-{normalized}"
+        return normalized
+    if instrument_type == "equity_us":
+        return to_db_symbol(normalized).upper()
+    return normalized
+
+
+def _kst_date(value: datetime | None) -> date | None:
+    if value is None:
+        return None
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=dt.UTC)
+    return value.astimezone(_KST).date()
+
+
+def _row_date(row: DailyCandleRow) -> date:
+    ts = row.time_utc
+    if ts.tzinfo is None:
+        ts = ts.replace(tzinfo=dt.UTC)
+    return ts.date()
+
+
+def _parse_date(value: str | date, field: str) -> date:
+    if isinstance(value, date):
+        return value
+    try:
+        return datetime.strptime(value, "%Y-%m-%d").date()
+    except (ValueError, TypeError) as exc:
+        raise ForecastValidationError(f"{field} must be YYYY-MM-DD: {value!r}") from exc
+
+
+def _validate_forecast_target(target: Any) -> None:
+    if not isinstance(target, dict):
+        raise ForecastValidationError("forecast_target must be an object")
+    kind = target.get("kind")
+    if not kind or not isinstance(kind, str):
+        raise ForecastValidationError("forecast_target.kind is required")
+    if kind == "price_target":
+        direction = target.get("direction")
+        if direction not in _PRICE_DIRECTIONS:
+            raise ForecastValidationError(
+                f"price_target.direction must be one of {sorted(_PRICE_DIRECTIONS)}"
+            )
+        price = target.get("target_price")
+        try:
+            price_f = float(price)
+        except (TypeError, ValueError) as exc:
+            raise ForecastValidationError(
+                "price_target.target_price must be a number"
+            ) from exc
+        if price_f <= 0:
+            raise ForecastValidationError("price_target.target_price must be > 0")
+
+
+def serialize_forecast(r: TradeForecast) -> dict[str, Any]:
+    return {
+        "id": r.id,
+        "forecast_id": str(r.forecast_id),
+        "artifact_uuid": r.artifact_uuid,
+        "journal_id": r.journal_id,
+        "report_uuid": r.report_uuid,
+        "report_item_uuid": r.report_item_uuid,
+        "correlation_id": r.correlation_id,
+        "created_by": r.created_by,
+        "session_label": r.session_label,
+        "model_label": r.model_label,
+        "policy_version": r.policy_version,
+        "symbol": r.symbol,
+        "instrument_type": (
+            r.instrument_type.value
+            if hasattr(r.instrument_type, "value")
+            else str(r.instrument_type)
+        ),
+        "forecast_target": r.forecast_target,
+        "horizon": r.horizon,
+        "probability": float(r.probability) if r.probability is not None else None,
+        "probability_range_low": (
+            float(r.probability_range_low)
+            if r.probability_range_low is not None
+            else None
+        ),
+        "probability_range_high": (
+            float(r.probability_range_high)
+            if r.probability_range_high is not None
+            else None
+        ),
+        "evidence_ids": r.evidence_ids,
+        "contrary_evidence": r.contrary_evidence,
+        "resolution_source": r.resolution_source,
+        "forecast_start_date": (
+            r.forecast_start_date.isoformat() if r.forecast_start_date else None
+        ),
+        "review_date": r.review_date.isoformat() if r.review_date else None,
+        "status": r.status,
+        "outcome": r.outcome,
+        "observed_value": (
+            float(r.observed_value) if r.observed_value is not None else None
+        ),
+        "resolved_at": r.resolved_at.isoformat() if r.resolved_at else None,
+        "brier_score": float(r.brier_score) if r.brier_score is not None else None,
+        "resolution_detail": r.resolution_detail,
+        "created_at": r.created_at.isoformat() if r.created_at else None,
+        "updated_at": r.updated_at.isoformat() if r.updated_at else None,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Repository — the only write surface
+# ---------------------------------------------------------------------------
+class ForecastRepository:
+    """The only write surface for review.trade_forecasts."""
+
+    def __init__(self, db: AsyncSession):
+        self.db = db
+
+    async def get_by_forecast_id(self, forecast_id: uuid.UUID) -> TradeForecast | None:
+        result = await self.db.execute(
+            select(TradeForecast).where(TradeForecast.forecast_id == forecast_id)
+        )
+        return result.scalar_one_or_none()
+
+    async def upsert(self, payload: dict[str, Any]) -> tuple[str, TradeForecast]:
+        fid = payload.get("forecast_id")
+        if fid is not None:
+            existing = await self.get_by_forecast_id(fid)
+            if existing is not None:
+                if existing.status == "closed":
+                    raise ForecastValidationError(
+                        f"cannot modify a closed (resolved) forecast; forecast_id={fid}"
+                    )
+                for key, value in payload.items():
+                    setattr(existing, key, value)
+                await self.db.flush()
+                return "updated", existing
+        row = TradeForecast(**payload)
+        self.db.add(row)
+        await self.db.flush()
+        return "created", row
+
+
+def _coerce_forecast_id(value: str | uuid.UUID | None) -> uuid.UUID:
+    if value is None:
+        return uuid.uuid4()
+    if isinstance(value, uuid.UUID):
+        return value
+    try:
+        return uuid.UUID(str(value))
+    except (ValueError, TypeError) as exc:
+        raise ForecastValidationError(f"invalid forecast_id: {value!r}") from exc
+
+
+async def save_forecast(
+    db: AsyncSession,
+    *,
+    created_by: str,
+    symbol: str,
+    instrument_type: str,
+    forecast_target: dict,
+    probability: float,
+    review_date: str | date,
+    forecast_id: str | uuid.UUID | None = None,
+    horizon: str | None = None,
+    probability_range_low: float | None = None,
+    probability_range_high: float | None = None,
+    evidence_ids: list | None = None,
+    contrary_evidence: str | None = None,
+    forecast_start_date: str | date | None = None,
+    resolution_source: str | None = None,
+    session_label: str | None = None,
+    model_label: str | None = None,
+    policy_version: str | None = None,
+    artifact_uuid: str | None = None,
+    journal_id: int | None = None,
+    report_uuid: str | None = None,
+    report_item_uuid: str | None = None,
+    correlation_id: str | None = None,
+) -> tuple[str, TradeForecast]:
+    if not (created_by or "").strip():
+        raise ForecastValidationError("created_by is required")
+    if instrument_type not in _VALID_INSTRUMENTS:
+        raise ForecastValidationError(f"invalid instrument_type: {instrument_type}")
+    if not (symbol or "").strip():
+        raise ForecastValidationError("symbol is required")
+    try:
+        prob = float(probability)
+    except (TypeError, ValueError) as exc:
+        raise ForecastValidationError("probability must be a number") from exc
+    if not 0.0 <= prob <= 1.0:
+        raise ForecastValidationError("probability must be within [0, 1]")
+
+    lo = probability_range_low
+    hi = probability_range_high
+    if (lo is None) != (hi is None):
+        raise ForecastValidationError(
+            "probability_range requires both low and high (or neither)"
+        )
+    if lo is not None and hi is not None:
+        lo_f, hi_f = float(lo), float(hi)
+        if not (0.0 <= lo_f <= 1.0 and 0.0 <= hi_f <= 1.0):
+            raise ForecastValidationError("probability_range must be within [0, 1]")
+        if lo_f > hi_f:
+            raise ForecastValidationError("probability_range_low must be <= high")
+        if not lo_f <= prob <= hi_f:
+            raise ForecastValidationError(
+                "probability must fall within probability_range"
+            )
+
+    _validate_forecast_target(forecast_target)
+
+    review = _parse_date(review_date, "review_date")
+    start = (
+        _parse_date(forecast_start_date, "forecast_start_date")
+        if forecast_start_date is not None
+        else None
+    )
+    if start is not None and start > review:
+        raise ForecastValidationError("forecast_start_date must be <= review_date")
+
+    payload: dict[str, Any] = {
+        "forecast_id": _coerce_forecast_id(forecast_id),
+        "created_by": created_by.strip(),
+        "symbol": _normalize_symbol(symbol, instrument_type),
+        "instrument_type": instrument_type,
+        "forecast_target": forecast_target,
+        "probability": _to_decimal(prob),
+        "probability_range_low": _to_decimal(lo),
+        "probability_range_high": _to_decimal(hi),
+        "review_date": review,
+        "forecast_start_date": start,
+        "horizon": horizon,
+        "evidence_ids": evidence_ids,
+        "contrary_evidence": contrary_evidence,
+        "resolution_source": resolution_source,
+        "session_label": session_label,
+        "model_label": model_label,
+        "policy_version": policy_version or POLICY_VERSION,
+        "artifact_uuid": artifact_uuid,
+        "journal_id": journal_id,
+        "report_uuid": report_uuid,
+        "report_item_uuid": report_item_uuid,
+        "correlation_id": correlation_id,
+        "status": "open",
+    }
+    return await ForecastRepository(db).upsert(payload)
+
+
+async def get_forecast(
+    db: AsyncSession, forecast_id: str | uuid.UUID
+) -> TradeForecast | None:
+    return await ForecastRepository(db).get_by_forecast_id(
+        _coerce_forecast_id(forecast_id)
+    )
+
+
+async def list_due_forecasts(
+    db: AsyncSession,
+    *,
+    now: datetime | None = None,
+    limit: int = 50,
+) -> list[TradeForecast]:
+    today = (now or now_kst()).astimezone(_KST).date()
+    stmt = (
+        select(TradeForecast)
+        .where(
+            TradeForecast.status == "open",
+            TradeForecast.review_date <= today,
+        )
+        .order_by(TradeForecast.review_date.asc())
+        .limit(limit)
+    )
+    return list((await db.execute(stmt)).scalars().all())
+
+
+async def list_forecasts(
+    db: AsyncSession,
+    *,
+    status: str | None = None,
+    symbol: str | None = None,
+    created_by: str | None = None,
+    correlation_id: str | None = None,
+    limit: int = 50,
+) -> dict[str, Any]:
+    filters = []
+    if status is not None:
+        filters.append(TradeForecast.status == status)
+    if symbol is not None:
+        filters.append(TradeForecast.symbol == symbol.strip().upper())
+    if created_by is not None:
+        filters.append(TradeForecast.created_by == created_by)
+    if correlation_id is not None:
+        filters.append(TradeForecast.correlation_id == correlation_id)
+    stmt = (
+        select(TradeForecast)
+        .where(*filters)
+        .order_by(TradeForecast.created_at.desc())
+        .limit(limit)
+    )
+    rows = (await db.execute(stmt)).scalars().all()
+    by_status: dict[str, int] = {}
+    for r in rows:
+        by_status[r.status] = by_status.get(r.status, 0) + 1
+    return {
+        "entries": [serialize_forecast(r) for r in rows],
+        "summary": {"count": len(rows), "by_status": by_status},
+    }
+
+
+async def _read_window_candles(
+    db: AsyncSession,
+    *,
+    symbol: str,
+    instrument_type: str,
+    start_date: date,
+    review_date: date,
+) -> list[DailyCandleRow] | None:
+    """Read loaded daily candles within [start_date, review_date] (inclusive).
+
+    Returns ``None`` when the instrument's partition cannot be resolved (US
+    exchange lookup failure) so the caller can mark the forecast unresolved
+    rather than scoring against an empty window.
+    """
+    if instrument_type == "equity_kr":
+        market, partition = MarketKey.KR, "KRX"
+    elif instrument_type == "crypto":
+        market, partition = MarketKey.CRYPTO, "upbit_krw"
+    elif instrument_type == "equity_us":
+        from app.services.us_symbol_universe_service import get_us_exchange_by_symbol
+
+        try:
+            partition = await get_us_exchange_by_symbol(symbol, db=db)
+        except Exception:
+            return None
+        if not partition:
+            return None
+        market = MarketKey.US
+    else:
+        return None
+
+    # Pad the UTC window by 2 days each side to absorb tz/session boundary skew,
+    # then filter by the candle's calendar date for a clean inclusive window.
+    start_dt = datetime.combine(
+        start_date - timedelta(days=2), dt.time(0, 0), tzinfo=dt.UTC
+    )
+    end_dt = datetime.combine(
+        review_date + timedelta(days=2), dt.time(23, 59, 59), tzinfo=dt.UTC
+    )
+    repo = DailyCandlesRepository(session=db)
+    rows = await repo.fetch_range(
+        market=market,
+        symbol=symbol,
+        partition=partition,
+        start=start_dt,
+        end=end_dt,
+    )
+    return [r for r in rows if start_date <= _row_date(r) <= review_date]
+
+
+async def resolve_forecast(
+    db: AsyncSession,
+    *,
+    forecast_id: str | uuid.UUID,
+    persist: bool,
+    manual_outcome: bool | None = None,
+    manual_observed_value: float | None = None,
+    manual_evidence: Any | None = None,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Resolve one forecast. Idempotent: a closed forecast is never re-scored.
+
+    ``persist=False`` computes the outcome/Brier and returns a preview without
+    mutating the row (the dry-run default at the tool boundary). Price-target
+    forecasts resolve against loaded daily OHLCV; other kinds require
+    ``manual_outcome`` + ``manual_evidence``.
+    """
+    repo = ForecastRepository(db)
+    row = await repo.get_by_forecast_id(_coerce_forecast_id(forecast_id))
+    if row is None:
+        raise ForecastValidationError(f"forecast not found: {forecast_id}")
+    if row.status == "closed":
+        return {
+            "status": "already_closed",
+            "changed": False,
+            "forecast": serialize_forecast(row),
+        }
+
+    resolved_now = now or now_kst()
+    target = row.forecast_target or {}
+    kind = target.get("kind")
+    instrument = (
+        row.instrument_type.value
+        if hasattr(row.instrument_type, "value")
+        else str(row.instrument_type)
+    )
+
+    if manual_outcome is not None:
+        if not manual_evidence:
+            raise ForecastValidationError(
+                "manual resolution requires evidence (manual_evidence)"
+            )
+        outcome = bool(manual_outcome)
+        observed = manual_observed_value
+        resolution_source = "manual"
+        detail: dict[str, Any] = {
+            "resolved_kind": kind,
+            "manual_evidence": manual_evidence,
+        }
+    elif kind == "price_target":
+        if instrument not in _AUTO_RESOLVABLE_INSTRUMENTS:
+            return {
+                "status": "requires_manual",
+                "changed": False,
+                "reason": (
+                    f"instrument_type={instrument} has no daily candle store; "
+                    "supply manual_outcome + manual_evidence"
+                ),
+                "forecast": serialize_forecast(row),
+            }
+        start_date = row.forecast_start_date or _kst_date(row.created_at)
+        candles = await _read_window_candles(
+            db,
+            symbol=row.symbol,
+            instrument_type=instrument,
+            start_date=start_date,
+            review_date=row.review_date,
+        )
+        if not candles:
+            return {
+                "status": "unresolved_no_data",
+                "changed": False,
+                "reason": "no loaded daily candles in the resolution window",
+                "forecast": serialize_forecast(row),
+            }
+        direction = target.get("direction")
+        target_price = float(target.get("target_price"))
+        outcome, observed = classify_price_target_outcome(
+            candles, direction=direction, target_price=target_price
+        )
+        resolution_source = "ohlcv_day"
+        detail = {
+            "window_start": start_date.isoformat(),
+            "window_end": row.review_date.isoformat(),
+            "candles": len(candles),
+            "direction": direction,
+            "target_price": target_price,
+            "observed_extreme": observed,
+        }
+    else:
+        return {
+            "status": "requires_manual",
+            "changed": False,
+            "reason": (
+                f"forecast_target.kind={kind!r} is non-price; "
+                "supply manual_outcome + manual_evidence"
+            ),
+            "forecast": serialize_forecast(row),
+        }
+
+    brier = brier_score(float(row.probability), outcome)
+    computed = {
+        "outcome": outcome,
+        "observed_value": observed,
+        "brier_score": round(brier, 5),
+        "resolution_source": resolution_source,
+        "resolution_detail": detail,
+    }
+    if not persist:
+        return {
+            "status": "previewed",
+            "changed": False,
+            "computed": computed,
+            "forecast": serialize_forecast(row),
+        }
+
+    row.outcome = outcome
+    row.observed_value = _to_decimal(observed)
+    row.brier_score = _to_decimal(round(brier, 5))
+    row.resolution_source = resolution_source
+    row.resolution_detail = detail
+    row.resolved_at = resolved_now
+    row.status = "closed"
+    await db.flush()
+    return {
+        "status": "resolved",
+        "changed": True,
+        "computed": computed,
+        "forecast": serialize_forecast(row),
+    }
+
+
+def _group_key(r: TradeForecast, group_by: str) -> str:
+    if group_by == "day":
+        d = _kst_date(r.created_at)
+        return d.isoformat() if d else "unknown"
+    value = getattr(r, group_by, None)
+    return value if value else "unlabeled"
+
+
+async def build_forecast_calibration_aggregate(
+    db: AsyncSession,
+    *,
+    group_by: str = "created_by",
+    created_by: str | None = None,
+    symbol: str | None = None,
+    instrument_type: str | None = None,
+    days: int | None = None,
+) -> dict[str, Any]:
+    """Calibration: Brier + hit-rate per label cohort (closed forecasts only).
+
+    Groups closed, scored forecasts by ``created_by`` / ``session_label`` /
+    ``model_label`` / KST ``day`` — the objective metric behind an operator's
+    "does another LLM reach the same result" comparison. ``calibration_gap`` is
+    ``avg_probability - hit_rate`` (positive = over-confident).
+    """
+    if group_by not in _GROUP_BY_FIELDS:
+        group_by = "created_by"
+
+    filters = [
+        TradeForecast.status == "closed",
+        TradeForecast.brier_score.isnot(None),
+    ]
+    if created_by is not None:
+        filters.append(TradeForecast.created_by == created_by)
+    if symbol is not None:
+        filters.append(TradeForecast.symbol == symbol.strip().upper())
+    if instrument_type is not None:
+        filters.append(TradeForecast.instrument_type == instrument_type)
+    if days is not None:
+        filters.append(TradeForecast.resolved_at >= now_kst() - timedelta(days=days))
+
+    rows = (await db.execute(select(TradeForecast).where(*filters))).scalars().all()
+
+    groups: dict[str, list[TradeForecast]] = {}
+    for r in rows:
+        groups.setdefault(_group_key(r, group_by), []).append(r)
+
+    out: list[dict[str, Any]] = []
+    for key, items in groups.items():
+        n = len(items)
+        briers = [float(it.brier_score) for it in items if it.brier_score is not None]
+        hits = sum(1 for it in items if it.outcome)
+        probs = [float(it.probability) for it in items if it.probability is not None]
+        avg_brier = sum(briers) / len(briers) if briers else None
+        hit_rate = hits / n if n else None
+        avg_prob = sum(probs) / len(probs) if probs else None
+        calibration_gap = (
+            avg_prob - hit_rate
+            if (avg_prob is not None and hit_rate is not None)
+            else None
+        )
+        out.append(
+            {
+                "group": key,
+                "sample_size": n,
+                "hits": hits,
+                "misses": n - hits,
+                "hit_rate": hit_rate,
+                "avg_brier_score": avg_brier,
+                "avg_probability": avg_prob,
+                "calibration_gap": calibration_gap,
+            }
+        )
+    out.sort(key=lambda g: -g["sample_size"])
+    return {"group_by": group_by, "groups": out}

--- a/app/services/trade_journal/forecast_service.py
+++ b/app/services/trade_journal/forecast_service.py
@@ -576,6 +576,9 @@ async def resolve_forecast(
     row.resolved_at = resolved_now
     row.status = "closed"
     await db.flush()
+    # Reload server-computed columns (updated_at onupdate) within the async
+    # context so serialize_forecast doesn't trigger a lazy sync refresh.
+    await db.refresh(row)
     return {
         "status": "resolved",
         "changed": True,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "auto-trader"
-version = "0.2.6"
+version = "0.2.7"
 description = ""
 authors = [
     { name = "robin", email = "robin@watcha.com" }

--- a/tests/test_forecast_service.py
+++ b/tests/test_forecast_service.py
@@ -1,0 +1,409 @@
+# tests/test_forecast_service.py
+"""ROB-650 — forecast ledger save/resolve/aggregate integration tests."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import delete, select, text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.review import TradeForecast
+from app.services.daily_candles.repository import (
+    DailyCandleRow,
+    DailyCandlesRepository,
+    MarketKey,
+)
+from app.services.trade_journal import forecast_service as svc
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.usefixtures("investment_reports_cleanup_lock"),
+]
+
+_KR_TEST_SYMBOLS = ("998877", "997766")
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def _cleanup(
+    db_session: AsyncSession, investment_reports_cleanup_lock: AsyncSession
+):
+    await db_session.execute(delete(TradeForecast))
+    await db_session.execute(
+        text("DELETE FROM public.kr_candles_1d WHERE symbol = ANY(:syms)"),
+        {"syms": list(_KR_TEST_SYMBOLS)},
+    )
+    await db_session.commit()
+
+
+def _price_target(direction: str = "at_or_above", target_price: float = 130.0) -> dict:
+    return {
+        "kind": "price_target",
+        "direction": direction,
+        "target_price": target_price,
+    }
+
+
+async def _seed_kr_candles(db: AsyncSession, symbol: str, highs: list[float]) -> None:
+    rows = [
+        DailyCandleRow(
+            time_utc=datetime(2026, 6, 2 + i, tzinfo=UTC),
+            symbol=symbol,
+            partition="KRX",
+            open=h - 5,
+            high=h,
+            low=h - 10,
+            close=h - 2,
+            adj_close=None,
+            volume=1000.0,
+            value=h * 1000.0,
+            source="kis",
+        )
+        for i, h in enumerate(highs)
+    ]
+    await DailyCandlesRepository(session=db).upsert_rows(market=MarketKey.KR, rows=rows)
+    await db.commit()
+
+
+# --------------------------------------------------------------------------- #
+# save validation
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_save_rejects_probability_out_of_range(db_session: AsyncSession):
+    with pytest.raises(svc.ForecastValidationError):
+        await svc.save_forecast(
+            db_session,
+            created_by="claude",
+            symbol="005930",
+            instrument_type="equity_kr",
+            forecast_target=_price_target(),
+            probability=1.5,
+            review_date="2026-07-15",
+        )
+
+
+@pytest.mark.asyncio
+async def test_save_rejects_probability_outside_band(db_session: AsyncSession):
+    with pytest.raises(svc.ForecastValidationError):
+        await svc.save_forecast(
+            db_session,
+            created_by="claude",
+            symbol="005930",
+            instrument_type="equity_kr",
+            forecast_target=_price_target(),
+            probability=0.9,
+            probability_range_low=0.5,
+            probability_range_high=0.7,
+            review_date="2026-07-15",
+        )
+
+
+@pytest.mark.asyncio
+async def test_save_rejects_bad_price_target(db_session: AsyncSession):
+    with pytest.raises(svc.ForecastValidationError):
+        await svc.save_forecast(
+            db_session,
+            created_by="claude",
+            symbol="005930",
+            instrument_type="equity_kr",
+            forecast_target={"kind": "price_target", "direction": "up"},
+            probability=0.6,
+            review_date="2026-07-15",
+        )
+
+
+@pytest.mark.asyncio
+async def test_save_stamps_policy_version_and_normalizes_symbol(
+    db_session: AsyncSession,
+):
+    action, row = await svc.save_forecast(
+        db_session,
+        created_by="claude",
+        symbol="brk-b",
+        instrument_type="equity_us",
+        forecast_target=_price_target(),
+        probability=0.65,
+        review_date="2026-07-15",
+    )
+    await db_session.commit()
+    assert action == "created"
+    assert row.symbol == "BRK.B"
+    assert row.policy_version == svc.POLICY_VERSION
+    assert row.status == "open"
+
+
+@pytest.mark.asyncio
+async def test_save_idempotent_by_forecast_id_while_open(db_session: AsyncSession):
+    a1, row1 = await svc.save_forecast(
+        db_session,
+        created_by="claude",
+        symbol="005930",
+        instrument_type="equity_kr",
+        forecast_target=_price_target(),
+        probability=0.6,
+        review_date="2026-07-15",
+        contrary_evidence="v1",
+    )
+    await db_session.commit()
+    fid = str(row1.forecast_id)
+    a2, row2 = await svc.save_forecast(
+        db_session,
+        created_by="claude",
+        symbol="005930",
+        instrument_type="equity_kr",
+        forecast_target=_price_target(),
+        probability=0.6,
+        review_date="2026-07-15",
+        forecast_id=fid,
+        contrary_evidence="v2",
+    )
+    await db_session.commit()
+    assert (a1, a2) == ("created", "updated")
+    rows = (await db_session.execute(select(TradeForecast))).scalars().all()
+    assert len(rows) == 1
+    assert rows[0].contrary_evidence == "v2"
+
+
+# --------------------------------------------------------------------------- #
+# resolve
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_resolve_manual_requires_evidence(db_session: AsyncSession):
+    _, row = await svc.save_forecast(
+        db_session,
+        created_by="claude",
+        symbol="005930",
+        instrument_type="equity_kr",
+        forecast_target={"kind": "thesis_holds"},
+        probability=0.6,
+        review_date="2026-07-15",
+    )
+    await db_session.commit()
+    with pytest.raises(svc.ForecastValidationError):
+        await svc.resolve_forecast(
+            db_session,
+            forecast_id=str(row.forecast_id),
+            persist=True,
+            manual_outcome=True,
+        )
+
+
+@pytest.mark.asyncio
+async def test_resolve_dry_run_does_not_persist(db_session: AsyncSession):
+    _, row = await svc.save_forecast(
+        db_session,
+        created_by="claude",
+        symbol="005930",
+        instrument_type="equity_kr",
+        forecast_target={"kind": "thesis_holds"},
+        probability=0.5,
+        review_date="2026-07-15",
+    )
+    await db_session.commit()
+    result = await svc.resolve_forecast(
+        db_session,
+        forecast_id=str(row.forecast_id),
+        persist=False,
+        manual_outcome=True,
+        manual_evidence=["closed above 130"],
+    )
+    assert result["status"] == "previewed"
+    assert result["changed"] is False
+    assert result["computed"]["brier_score"] == pytest.approx(0.25)
+    await db_session.refresh(row)
+    assert row.status == "open"
+    assert row.brier_score is None
+
+
+@pytest.mark.asyncio
+async def test_resolve_manual_persists_and_scores(db_session: AsyncSession):
+    _, row = await svc.save_forecast(
+        db_session,
+        created_by="claude",
+        symbol="005930",
+        instrument_type="equity_kr",
+        forecast_target={"kind": "thesis_holds"},
+        probability=0.8,
+        review_date="2026-07-15",
+    )
+    await db_session.commit()
+    result = await svc.resolve_forecast(
+        db_session,
+        forecast_id=str(row.forecast_id),
+        persist=True,
+        manual_outcome=True,
+        manual_observed_value=131.0,
+        manual_evidence=["broke resistance"],
+    )
+    await db_session.commit()
+    assert result["status"] == "resolved"
+    assert result["changed"] is True
+    await db_session.refresh(row)
+    assert row.status == "closed"
+    assert row.outcome is True
+    assert row.resolution_source == "manual"
+    # (0.8 - 1)^2 = 0.04
+    assert float(row.brier_score) == pytest.approx(0.04)
+
+
+@pytest.mark.asyncio
+async def test_resolve_idempotent_closed_not_rescored(db_session: AsyncSession):
+    _, row = await svc.save_forecast(
+        db_session,
+        created_by="claude",
+        symbol="005930",
+        instrument_type="equity_kr",
+        forecast_target={"kind": "thesis_holds"},
+        probability=0.8,
+        review_date="2026-07-15",
+    )
+    await db_session.commit()
+    await svc.resolve_forecast(
+        db_session,
+        forecast_id=str(row.forecast_id),
+        persist=True,
+        manual_outcome=True,
+        manual_evidence=["e"],
+    )
+    await db_session.commit()
+    # Re-resolve with a contradictory outcome — must be ignored (idempotent).
+    second = await svc.resolve_forecast(
+        db_session,
+        forecast_id=str(row.forecast_id),
+        persist=True,
+        manual_outcome=False,
+        manual_evidence=["e2"],
+    )
+    await db_session.commit()
+    assert second["status"] == "already_closed"
+    assert second["changed"] is False
+    await db_session.refresh(row)
+    assert row.outcome is True
+    assert float(row.brier_score) == pytest.approx(0.04)
+
+
+@pytest.mark.asyncio
+async def test_save_cannot_modify_closed(db_session: AsyncSession):
+    _, row = await svc.save_forecast(
+        db_session,
+        created_by="claude",
+        symbol="005930",
+        instrument_type="equity_kr",
+        forecast_target={"kind": "thesis_holds"},
+        probability=0.8,
+        review_date="2026-07-15",
+    )
+    await db_session.commit()
+    await svc.resolve_forecast(
+        db_session,
+        forecast_id=str(row.forecast_id),
+        persist=True,
+        manual_outcome=True,
+        manual_evidence=["e"],
+    )
+    await db_session.commit()
+    with pytest.raises(svc.ForecastValidationError):
+        await svc.save_forecast(
+            db_session,
+            created_by="claude",
+            symbol="005930",
+            instrument_type="equity_kr",
+            forecast_target={"kind": "thesis_holds"},
+            probability=0.9,
+            review_date="2026-07-15",
+            forecast_id=str(row.forecast_id),
+        )
+
+
+@pytest.mark.asyncio
+async def test_resolve_price_target_from_ohlcv(db_session: AsyncSession):
+    await _seed_kr_candles(db_session, "998877", highs=[120.0, 131.0, 125.0])
+    _, row = await svc.save_forecast(
+        db_session,
+        created_by="claude",
+        symbol="998877",
+        instrument_type="equity_kr",
+        forecast_target=_price_target(direction="at_or_above", target_price=130.0),
+        probability=0.7,
+        forecast_start_date="2026-06-01",
+        review_date="2026-06-05",
+    )
+    await db_session.commit()
+    result = await svc.resolve_forecast(
+        db_session, forecast_id=str(row.forecast_id), persist=True
+    )
+    await db_session.commit()
+    assert result["status"] == "resolved"
+    assert result["computed"]["resolution_source"] == "ohlcv_day"
+    await db_session.refresh(row)
+    assert row.status == "closed"
+    assert row.outcome is True
+    assert float(row.observed_value) == pytest.approx(131.0)
+    # (0.7 - 1)^2 = 0.09
+    assert float(row.brier_score) == pytest.approx(0.09)
+
+
+@pytest.mark.asyncio
+async def test_resolve_price_target_unresolved_no_data(db_session: AsyncSession):
+    _, row = await svc.save_forecast(
+        db_session,
+        created_by="claude",
+        symbol="997766",
+        instrument_type="equity_kr",
+        forecast_target=_price_target(),
+        probability=0.6,
+        forecast_start_date="2026-06-01",
+        review_date="2026-06-05",
+    )
+    await db_session.commit()
+    result = await svc.resolve_forecast(
+        db_session, forecast_id=str(row.forecast_id), persist=True
+    )
+    assert result["status"] == "unresolved_no_data"
+    assert result["changed"] is False
+    await db_session.refresh(row)
+    assert row.status == "open"
+
+
+# --------------------------------------------------------------------------- #
+# calibration aggregate
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_calibration_aggregate_groups_by_created_by(db_session: AsyncSession):
+    async def _make(created_by: str, prob: float, outcome: bool) -> None:
+        _, row = await svc.save_forecast(
+            db_session,
+            created_by=created_by,
+            symbol="005930",
+            instrument_type="equity_kr",
+            forecast_target={"kind": "thesis_holds"},
+            probability=prob,
+            review_date="2026-07-15",
+        )
+        await db_session.commit()
+        await svc.resolve_forecast(
+            db_session,
+            forecast_id=str(row.forecast_id),
+            persist=True,
+            manual_outcome=outcome,
+            manual_evidence=["e"],
+        )
+        await db_session.commit()
+
+    await _make("claude", 0.8, True)
+    await _make("claude", 0.6, False)
+    await _make("gpt", 0.9, True)
+
+    agg = await svc.build_forecast_calibration_aggregate(
+        db_session, group_by="created_by"
+    )
+    assert agg["group_by"] == "created_by"
+    groups = {g["group"]: g for g in agg["groups"]}
+    assert groups["claude"]["sample_size"] == 2
+    assert groups["claude"]["hits"] == 1
+    assert groups["gpt"]["sample_size"] == 1
+    assert groups["gpt"]["hit_rate"] == pytest.approx(1.0)
+    # claude avg brier = ((0.8-1)^2 + (0.6-0)^2)/2 = (0.04 + 0.36)/2 = 0.20
+    assert groups["claude"]["avg_brier_score"] == pytest.approx(0.20)

--- a/tests/test_forecast_service.py
+++ b/tests/test_forecast_service.py
@@ -7,15 +7,11 @@ from datetime import UTC, datetime
 
 import pytest
 import pytest_asyncio
-from sqlalchemy import delete, select, text
+from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.review import TradeForecast
-from app.services.daily_candles.repository import (
-    DailyCandleRow,
-    DailyCandlesRepository,
-    MarketKey,
-)
+from app.services.daily_candles.repository import DailyCandleRow
 from app.services.trade_journal import forecast_service as svc
 
 pytestmark = [
@@ -23,18 +19,12 @@ pytestmark = [
     pytest.mark.usefixtures("investment_reports_cleanup_lock"),
 ]
 
-_KR_TEST_SYMBOLS = ("998877", "997766")
-
 
 @pytest_asyncio.fixture(autouse=True)
 async def _cleanup(
     db_session: AsyncSession, investment_reports_cleanup_lock: AsyncSession
 ):
     await db_session.execute(delete(TradeForecast))
-    await db_session.execute(
-        text("DELETE FROM public.kr_candles_1d WHERE symbol = ANY(:syms)"),
-        {"syms": list(_KR_TEST_SYMBOLS)},
-    )
     await db_session.commit()
 
 
@@ -46,11 +36,11 @@ def _price_target(direction: str = "at_or_above", target_price: float = 130.0) -
     }
 
 
-async def _seed_kr_candles(db: AsyncSession, symbol: str, highs: list[float]) -> None:
-    rows = [
+def _candles(highs: list[float]) -> list[DailyCandleRow]:
+    return [
         DailyCandleRow(
             time_utc=datetime(2026, 6, 2 + i, tzinfo=UTC),
-            symbol=symbol,
+            symbol="998877",
             partition="KRX",
             open=h - 5,
             high=h,
@@ -63,8 +53,6 @@ async def _seed_kr_candles(db: AsyncSession, symbol: str, highs: list[float]) ->
         )
         for i, h in enumerate(highs)
     ]
-    await DailyCandlesRepository(session=db).upsert_rows(market=MarketKey.KR, rows=rows)
-    await db.commit()
 
 
 # --------------------------------------------------------------------------- #
@@ -318,8 +306,15 @@ async def test_save_cannot_modify_closed(db_session: AsyncSession):
 
 
 @pytest.mark.asyncio
-async def test_resolve_price_target_from_ohlcv(db_session: AsyncSession):
-    await _seed_kr_candles(db_session, "998877", highs=[120.0, 131.0, 125.0])
+async def test_resolve_price_target_from_ohlcv(db_session: AsyncSession, monkeypatch):
+    # The daily-candle store (kr_candles_1d) has no ORM model and is absent from
+    # the create_all test DB, so patch the deterministic reader with canned bars
+    # (the DB-read plumbing is covered by the repository unit test).
+    async def _fake_read(*_a, **_k):
+        return _candles([120.0, 131.0, 125.0])
+
+    monkeypatch.setattr(svc, "_read_window_candles", _fake_read)
+
     _, row = await svc.save_forecast(
         db_session,
         created_by="claude",
@@ -346,7 +341,14 @@ async def test_resolve_price_target_from_ohlcv(db_session: AsyncSession):
 
 
 @pytest.mark.asyncio
-async def test_resolve_price_target_unresolved_no_data(db_session: AsyncSession):
+async def test_resolve_price_target_unresolved_no_data(
+    db_session: AsyncSession, monkeypatch
+):
+    async def _empty_read(*_a, **_k):
+        return []
+
+    monkeypatch.setattr(svc, "_read_window_candles", _empty_read)
+
     _, row = await svc.save_forecast(
         db_session,
         created_by="claude",

--- a/tests/test_forecast_service_pure.py
+++ b/tests/test_forecast_service_pure.py
@@ -1,0 +1,100 @@
+# tests/test_forecast_service_pure.py
+"""ROB-650 — pure (DB-free) unit tests for Brier + price-target classification."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from app.services.daily_candles.repository import DailyCandleRow
+from app.services.trade_journal.forecast_service import (
+    ForecastValidationError,
+    brier_score,
+    classify_price_target_outcome,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _candle(*, high: float, low: float, t: datetime | None = None) -> DailyCandleRow:
+    return DailyCandleRow(
+        time_utc=t or datetime(2026, 6, 3, tzinfo=UTC),
+        symbol="TEST",
+        partition="KRX",
+        open=(high + low) / 2,
+        high=high,
+        low=low,
+        close=(high + low) / 2,
+        adj_close=None,
+        volume=1000.0,
+        value=1000.0,
+        source="kis",
+    )
+
+
+@pytest.mark.parametrize(
+    ("probability", "outcome", "expected"),
+    [
+        (0.0, False, 0.0),
+        (0.0, True, 1.0),
+        (0.5, True, 0.25),
+        (0.5, False, 0.25),
+        (1.0, True, 0.0),
+        (1.0, False, 1.0),
+    ],
+)
+def test_brier_score_boundaries(probability, outcome, expected):
+    assert brier_score(probability, outcome) == pytest.approx(expected)
+
+
+def test_classify_at_or_above_hit():
+    candles = [
+        _candle(high=100.0, low=95.0),
+        _candle(high=131.0, low=120.0),  # touches target
+        _candle(high=110.0, low=105.0),
+    ]
+    hit, extreme = classify_price_target_outcome(
+        candles, direction="at_or_above", target_price=130.0
+    )
+    assert hit is True
+    assert extreme == pytest.approx(131.0)
+
+
+def test_classify_at_or_above_miss():
+    candles = [_candle(high=100.0, low=95.0), _candle(high=120.0, low=110.0)]
+    hit, extreme = classify_price_target_outcome(
+        candles, direction="at_or_above", target_price=130.0
+    )
+    assert hit is False
+    assert extreme == pytest.approx(120.0)  # max high observed
+
+
+def test_classify_at_or_below_hit():
+    candles = [_candle(high=100.0, low=95.0), _candle(high=90.0, low=79.0)]
+    hit, extreme = classify_price_target_outcome(
+        candles, direction="at_or_below", target_price=80.0
+    )
+    assert hit is True
+    assert extreme == pytest.approx(79.0)  # min low observed
+
+
+def test_classify_at_or_below_miss():
+    candles = [_candle(high=100.0, low=95.0), _candle(high=98.0, low=92.0)]
+    hit, extreme = classify_price_target_outcome(
+        candles, direction="at_or_below", target_price=80.0
+    )
+    assert hit is False
+    assert extreme == pytest.approx(92.0)
+
+
+def test_classify_empty_raises():
+    with pytest.raises(ForecastValidationError):
+        classify_price_target_outcome([], direction="at_or_above", target_price=1.0)
+
+
+def test_classify_invalid_direction_raises():
+    with pytest.raises(ForecastValidationError):
+        classify_price_target_outcome(
+            [_candle(high=1.0, low=0.5)], direction="sideways", target_price=1.0
+        )

--- a/tests/test_forecast_tools.py
+++ b/tests/test_forecast_tools.py
@@ -1,0 +1,160 @@
+# tests/test_forecast_tools.py
+"""ROB-650 — MCP tool envelopes + registration wiring for forecast tools."""
+
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import delete
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.mcp_server.tooling.forecast_tools import (
+    forecast_resolve,
+    forecast_save,
+    get_forecast_calibration,
+    get_forecasts,
+)
+from app.models.review import TradeForecast
+
+_EXPECTED_NAMES = {
+    "forecast_save",
+    "forecast_resolve",
+    "get_forecasts",
+    "get_forecast_calibration",
+}
+
+
+# --------------------------------------------------------------------------- #
+# DB-free wiring tests
+# --------------------------------------------------------------------------- #
+def test_tool_names_set_complete():
+    from app.mcp_server.tooling.forecast_registration import FORECAST_TOOL_NAMES
+
+    assert FORECAST_TOOL_NAMES == _EXPECTED_NAMES
+
+
+def test_tools_in_available_surface():
+    from app.mcp_server import AVAILABLE_TOOL_NAMES
+
+    for name in _EXPECTED_NAMES:
+        assert name in AVAILABLE_TOOL_NAMES
+
+
+def test_register_wires_four_tools():
+    from app.mcp_server.tooling.forecast_registration import register_forecast_tools
+
+    registered: list[str] = []
+
+    class _FakeMCP:
+        def tool(self, *, name, description):
+            registered.append(name)
+
+            def _wrap(fn):
+                return fn
+
+            return _wrap
+
+    register_forecast_tools(_FakeMCP())
+    assert set(registered) == _EXPECTED_NAMES
+
+
+@pytest.mark.asyncio
+async def test_save_missing_symbol_envelope():
+    # Short-circuits before any DB access.
+    res = await forecast_save(
+        created_by="claude",
+        symbol="   ",
+        instrument_type="equity_kr",
+        forecast_target={
+            "kind": "price_target",
+            "direction": "at_or_above",
+            "target_price": 1.0,
+        },
+        probability=0.5,
+        review_date="2026-07-15",
+    )
+    assert res["success"] is False
+    assert "symbol" in res["error"]
+
+
+# --------------------------------------------------------------------------- #
+# DB-backed envelope tests (opt-in: request the _clean fixture explicitly so
+# the wiring tests above stay DB-free)
+# --------------------------------------------------------------------------- #
+@pytest_asyncio.fixture
+async def _clean(
+    db_session: AsyncSession, investment_reports_cleanup_lock: AsyncSession
+) -> AsyncSession:
+    await db_session.execute(delete(TradeForecast))
+    await db_session.commit()
+    return db_session
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_save_and_resolve_envelope(_clean):
+    saved = await forecast_save(
+        created_by="claude",
+        symbol="005930",
+        instrument_type="equity_kr",
+        forecast_target={"kind": "thesis_holds"},
+        probability=0.7,
+        review_date="2026-07-15",
+        session_label="s1",
+    )
+    assert saved["success"] is True
+    assert saved["action"] == "created"
+    fid = saved["data"]["forecast_id"]
+
+    preview = await forecast_resolve(
+        forecast_id=fid,
+        dry_run=True,
+        manual_outcome=True,
+        manual_evidence=["target hit"],
+    )
+    assert preview["success"] is True
+    assert preview["dry_run"] is True
+    assert preview["status"] == "previewed"
+    assert preview["changed"] is False
+
+    committed = await forecast_resolve(
+        forecast_id=fid,
+        dry_run=False,
+        manual_outcome=True,
+        manual_evidence=["target hit"],
+    )
+    assert committed["success"] is True
+    assert committed["status"] == "resolved"
+    assert committed["changed"] is True
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_save_validation_error_envelope(_clean):
+    res = await forecast_save(
+        created_by="claude",
+        symbol="005930",
+        instrument_type="equity_kr",
+        forecast_target={
+            "kind": "price_target",
+            "direction": "at_or_above",
+            "target_price": 1.0,
+        },
+        probability=1.9,
+        review_date="2026-07-15",
+    )
+    assert res["success"] is False
+    assert "probability" in res["error"]
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_list_and_calibration_envelope(_clean):
+    lst = await get_forecasts(status="open")
+    assert lst["success"] is True
+    assert "entries" in lst
+
+    agg = await get_forecast_calibration(group_by="created_by")
+    assert agg["success"] is True
+    assert agg["group_by"] == "created_by"
+    assert "groups" in agg

--- a/tests/unit/services/daily_candles/test_repository.py
+++ b/tests/unit/services/daily_candles/test_repository.py
@@ -60,3 +60,37 @@ class TestUpsertRows:
 
         assert result == 0
         session.execute.assert_not_awaited()
+
+
+class TestFetchRange:
+    @pytest.mark.asyncio
+    async def test_fetch_range_binds_window_and_partition(self):
+        session = MagicMock()
+        result = MagicMock()
+        result.mappings.return_value.all.return_value = []
+        session.execute = AsyncMock(return_value=result)
+        repo = DailyCandlesRepository(session=session)
+
+        start = datetime(2026, 6, 1, tzinfo=UTC)
+        end = datetime(2026, 6, 30, tzinfo=UTC)
+        rows = await repo.fetch_range(
+            market=MarketKey.KR,
+            symbol="005930",
+            partition="KRX",
+            start=start,
+            end=end,
+        )
+
+        assert rows == []
+        assert session.execute.await_count == 1
+        args, _ = session.execute.await_args
+        sql = str(args[0])
+        params = args[1]
+        assert "time >= :start AND time <= :end" in sql
+        assert "ORDER BY time ASC" in sql
+        assert params == {
+            "symbol": "005930",
+            "partition": "KRX",
+            "start": start,
+            "end": end,
+        }

--- a/uv.lock
+++ b/uv.lock
@@ -222,7 +222,7 @@ wheels = [
 
 [[package]]
 name = "auto-trader"
-version = "0.2.5"
+version = "0.2.7"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
## 요약 (ROB-650)

매수 thesis / 익절 판정(WATCH→PLACE)을 **resolvable한 확률 예측**으로 기록하고, **OHLCV 결정적 해소 + Brier 채점**으로 검증하는 `review.trade_forecasts` 레저를 추가합니다. 조성(확률/논거 선택)은 Claude 세션(LLM boundary), 기록·해소·채점은 전부 결정적(service/repo 쓰기 경계 준수).

⚠️ 원본 전제 정정: tradingcodex의 Brier/해소 코드는 존재하지 않아(문서에서 명시적 유예) 해소·채점은 신규 설계.

## 산출물

- **모델 + 마이그레이션** (`20260702_rob650`, alembic 단일 head, down_revision `20260702_rob641`): 원본 10-필수필드 포팅 — `forecast_id`(멱등키), artifact/journal/report_item/correlation 링크, `forecast_target` JSONB, `probability`(+ 선택 range, `probability`가 range 내에 있는지 DB cross-column check), `review_date`, `status`(open/closed), 해소 필드(`outcome`/`observed_value`/`brier_score`/`resolved_at`), `policy_version` 스탬프.
- **`app/services/trade_journal/forecast_service.py`** (쓰기 유일 경로):
  - `save_forecast` — 타입 검증(probability 0..1, range 내 검증), 심볼 정규화, policy 스탬프. `forecast_id` 멱등(open 상태에서만 update; closed는 immutable).
  - `resolve_forecast` — **멱등(closed 재채점 금지)**. `price_target`은 DB-first 일봉 OHLCV(ROB-639)로 결정적 해소, 비가격형은 수동 outcome+evidence 필수. `dry_run`이면 미영속 preview.
  - `build_forecast_calibration_aggregate` — `created_by | session_label | model_label | day`별 Brier·적중률·calibration_gap → 운영자의 "다른 LLM도 같은 결과" 검증 객관 지표.
- **`DailyCandlesRepository.fetch_range`** — 결정적 window read(KR/US/crypto), read-only.
- **MCP 도구**: `forecast_save`, `forecast_resolve`(dry_run-default), `get_forecasts`, `get_forecast_calibration` — `trade_retrospective` 옆 always-on 등록 + `AVAILABLE_TOOL_NAMES` 등재.

## 수용 기준 충족

- 동일 forecast resolve 재실행 멱등(closed 재채점 금지) — `test_resolve_idempotent_closed_not_rescored`
- Brier 경계 unit 테스트(p=0/0.5/1) — `test_brier_score_boundaries`
- 집계 라벨별 그룹 반환 — `test_calibration_aggregate_groups_by_created_by`

## 검증

- `ruff format`/`check` clean, `ty check` clean, alembic 단일 head.
- DB-free 테스트 16개 통과(pure 12 + 도구 wiring 4). DB-backed 통합 테스트(save/resolve/OHLCV/aggregate)는 CI에서 실행(로컬 Postgres/.env 없음).
- 버전 `0.2.6 → 0.2.7` bump + relock.

## 스코프 결정

- **ROB-646 미상륙**: 이 브랜치에 `get_trading_policy`/policy YAML 없음 확인 → `policy_version`은 로컬 상수 `forecast.v1` 스탬프(caller override 가능)로 forward-compatible. ROB-646 상륙 시 계약 연결.
- **자동 해소 job 후속**: scheduleless TaskIQ(ROB-405/475 관례)는 별도 이슈. 본 PR의 `forecast_resolve`는 due 배치 on-demand 해소 지원.

## 운영자 후속 (머지 후)

- `alembic upgrade head` (단일 마이그레이션)
- MCP 재시작 → 4개 신규 도구 노출 확인 + read-only 스모크

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for saving, resolving, listing, and reviewing forecast records.
  * Added calibration summaries, including hit rate, average Brier score, and calibration gap.
  * Added a read-only daily candle range lookup to support deterministic forecast resolution.
  * Forecast tools are now available through the MCP interface.

* **Bug Fixes**
  * Improved resolution behavior so already-closed forecasts stay unchanged.
  * Added safer validation for forecast inputs, including probability ranges and price-target rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->