### PR TITLE
feat(ROB-651): Toss preview→place approval-hash binding + content-based clientOrderId idempotency (P6-A)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -244,6 +244,7 @@ Kiwoom **모의투자** 전용 MCP order/account lifecycle. 7개 도구 모두 `
 - **레저**: `review.toss_live_order_ledger` (`app/services/toss_live_order_ledger_service.py`, accepted-only + `record_send` 멱등 replay) + `toss_reconcile_orders`(단건 상세 fill-evidence, ROB-395/407 패턴)
 - **데이터 소스**: 환율 `exchange_rate_service`(토스 primary+폴백, midRate), 종목 마스터+시총 `toss_symbol_master_service`(gap-fill only — 기존 source 있으면 skip), warnings 가드 `warnings_guard`(LIQUIDATION 매수만 차단·매도 면제), 캔들 `market_data/toss_ohlcv`(1m/5m/15m/30m toss-first 페이지네이션, 1h는 DB hourly), 캘린더 `brokers/toss/market_calendar`(NXT/데이마켓)
 - **CLI/런북**: `scripts/toss_live_smoke.py`(preflight/order-test/confirm), `docs/runbooks/toss-live-smoke.md`, `toss-live-order-reconcile.md`, `toss-symbol-master-sync.md`
+- **ROB-651 (P6-A)**: `toss_preview_order`가 정규화(tick-snap) 이후 `approval_hash`(self-contained 토큰, TTL 5분) + `approval_expires_at`를 반환. `toss_place_order(approval_hash=...)`는 자기 파라미터로 canonical을 재계산해 불일치/만료 시 fail-closed(`error_code` + `diff`). 롤아웃 `TOSS_APPROVAL_HASH_MODE ∈ {off,optional,warn,required}`(기본 `optional`, 백컴팻). `clientOrderId`는 uuid4 → 결정적 `tossp6-<sha16>(canonical|거래일salt|rung)` 멱등키(KR=KST/US=ET 거래일; 같은 거래일 동일주문 dedupe, 익일 신규). 같은 날 진짜 동일 두 번째 주문은 `rung` discriminator로 분리. 컬럼: `review.toss_live_order_ledger.approval_hash`(digest). 공유경로(KIS/Upbit)는 ROB-653 P6-B.
 
 **안전 경계 / env 게이트 (모두 default off)**:
 - `TOSS_API_ENABLED` — 마스터 게이트. 미설정 시 read 클라이언트도 `TossApiDisabled`

--- a/alembic/versions/20260702_rob651_toss_approval_hash.py
+++ b/alembic/versions/20260702_rob651_toss_approval_hash.py
@@ -1,0 +1,37 @@
+"""add approval_hash to toss_live_order_ledger (ROB-651)
+
+Revision ID: 20260702_rob651
+Revises: 20260702_rob641
+Create Date: 2026-07-02
+
+Additive nullable column storing the content digest (``p6a-<16hex>``) of the
+placed order's canonical payload — the approval-hash binding between
+toss_preview_order and toss_place_order (ROB-651 P6-A).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "20260702_rob651"
+down_revision: str | Sequence[str] | None = "20260702_rob641"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "toss_live_order_ledger",
+        sa.Column("approval_hash", sa.Text(), nullable=True),
+        schema="review",
+    )
+
+
+def downgrade() -> None:
+    op.drop_column(
+        "toss_live_order_ledger", "approval_hash", schema="review"
+    )

--- a/alembic/versions/20260702_rob651_toss_approval_hash.py
+++ b/alembic/versions/20260702_rob651_toss_approval_hash.py
@@ -1,7 +1,7 @@
 """add approval_hash to toss_live_order_ledger (ROB-651)
 
 Revision ID: 20260702_rob651
-Revises: 20260702_rob641
+Revises: 20260702_rob650
 Create Date: 2026-07-02
 
 Additive nullable column storing the content digest (``p6a-<16hex>``) of the
@@ -18,7 +18,7 @@ import sqlalchemy as sa
 from alembic import op
 
 revision: str = "20260702_rob651"
-down_revision: str | Sequence[str] | None = "20260702_rob641"
+down_revision: str | Sequence[str] | None = "20260702_rob650"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -244,6 +244,7 @@ class Settings(BaseSettings):
     # ROB-576 — Toss fill notifications are inert until explicitly enabled by
     # the operator. Toss auto-reconcile gates live with the task flags below.
     toss_fill_notify_enabled: bool = False
+    toss_approval_hash_mode: str = "optional"  # off | optional | warn | required
 
     # KIS WebSocket
     kis_ws_is_mock: bool = False  # Mock 모드 (테스트용)

--- a/app/mcp_server/tooling/orders_toss_variants.py
+++ b/app/mcp_server/tooling/orders_toss_variants.py
@@ -13,9 +13,19 @@ import re
 import uuid
 from collections.abc import Iterable
 from contextlib import asynccontextmanager
-from datetime import date, datetime
+from datetime import date, datetime, timedelta
 from decimal import Decimal
 from typing import TYPE_CHECKING, Any, Literal, cast
+
+from app.core.timezone import KST, now_kst
+from app.mcp_server.tooling.toss_approval import (
+    APPROVAL_TTL_SECONDS,
+    build_canonical_payload,
+    derive_approval_digest,
+    derive_client_order_id,
+    encode_approval_token,
+    verify_approval_token,
+)
 
 from app.core.config import settings, validate_toss_api_config
 from app.mcp_server.tick_size import adjust_tick_size_kr, get_tick_size_kr
@@ -650,6 +660,7 @@ async def toss_preview_order(
     time_in_force: Literal["DAY", "CLS"] = "DAY",
     account_mode: str | None = None,
     account_type: str | None = None,
+    rung: str | int | None = None,
 ) -> dict[str, Any]:
     if (guard := _entry_guard(account_mode, account_type)) is not None:
         return guard
@@ -677,19 +688,42 @@ async def toss_preview_order(
                 "adjusted_price": _stringify_decimal(price_dec),
             }
 
+    quantity_str = _stringify_decimal(quantity_dec)
+    price_str = _stringify_decimal(price_dec)
+    order_amount_str = _stringify_decimal(order_amount_dec)
+
+    canonical = build_canonical_payload(
+        market=mkt,
+        symbol=symbol,
+        side=side,
+        order_type=order_type,
+        time_in_force=time_in_force,
+        quantity=quantity_str,
+        price=price_str,
+        order_amount=order_amount_str,
+    )
+    now = now_kst()
+    client_order_id = derive_client_order_id(
+        canonical, market=mkt, now=now, rung=rung
+    )
+    approval_hash = encode_approval_token(canonical, now=now)
+    approval_expires_at = (
+        now + timedelta(seconds=APPROVAL_TTL_SECONDS)
+    ).astimezone(KST).isoformat()
+
     payload: dict[str, Any] = {
-        "clientOrderId": _new_client_order_id(),
+        "clientOrderId": client_order_id,
         "symbol": symbol,
         "side": side.upper(),
         "orderType": order_type.upper(),
         "timeInForce": time_in_force,
     }
-    if quantity_dec is not None:
-        payload["quantity"] = _stringify_decimal(quantity_dec)
-    if price_dec is not None:
-        payload["price"] = _stringify_decimal(price_dec)
-    if order_amount_dec is not None:
-        payload["orderAmount"] = _stringify_decimal(order_amount_dec)
+    if quantity_str is not None:
+        payload["quantity"] = quantity_str
+    if price_str is not None:
+        payload["price"] = price_str
+    if order_amount_str is not None:
+        payload["orderAmount"] = order_amount_str
 
     warnings_list = []
     warnings_check_msg = None
@@ -754,6 +788,8 @@ async def toss_preview_order(
         "account_mode": ACCOUNT_MODE_TOSS_LIVE,
         "warnings": warnings_list,
         "warnings_check_message": warnings_check_msg,
+        "approval_hash": approval_hash,
+        "approval_expires_at": approval_expires_at,
         **cost_context,
     }
     if price_context_message is not None:

--- a/app/mcp_server/tooling/orders_toss_variants.py
+++ b/app/mcp_server/tooling/orders_toss_variants.py
@@ -823,6 +823,8 @@ async def _toss_place_order_impl(
     report_item_uuid: str | None = None,
     account_mode: str | None = None,
     account_type: str | None = None,
+    approval_hash: str | None = None,
+    rung: str | int | None = None,
     client_order_id_override: str | None = None,
 ) -> dict[str, Any]:
     if (guard := _entry_guard(account_mode, account_type)) is not None:
@@ -859,19 +861,39 @@ async def _toss_place_order_impl(
                 "adjusted_price": _stringify_decimal(price_dec),
             }
 
+    quantity_str = _stringify_decimal(quantity_dec)
+    price_str = _stringify_decimal(price_dec)
+    order_amount_str = _stringify_decimal(order_amount_dec)
+
+    canonical = build_canonical_payload(
+        market=mkt,
+        symbol=symbol,
+        side=side,
+        order_type=order_type,
+        time_in_force=time_in_force,
+        quantity=quantity_str,
+        price=price_str,
+        order_amount=order_amount_str,
+    )
+    now = now_kst()
+    client_order_id = client_order_id_override or derive_client_order_id(
+        canonical, market=mkt, now=now, rung=rung
+    )
+    ledger_approval_hash = derive_approval_digest(canonical)
+
     payload: dict[str, Any] = {
-        "clientOrderId": client_order_id_override or _new_client_order_id(),
+        "clientOrderId": client_order_id,
         "symbol": symbol,
         "side": side.upper(),
         "orderType": order_type.upper(),
         "timeInForce": time_in_force,
     }
-    if quantity_dec is not None:
-        payload["quantity"] = _stringify_decimal(quantity_dec)
-    if price_dec is not None:
-        payload["price"] = _stringify_decimal(price_dec)
-    if order_amount_dec is not None:
-        payload["orderAmount"] = _stringify_decimal(order_amount_dec)
+    if quantity_str is not None:
+        payload["quantity"] = quantity_str
+    if price_str is not None:
+        payload["price"] = price_str
+    if order_amount_str is not None:
+        payload["orderAmount"] = order_amount_str
     if confirm_high_value_order:
         payload["confirmHighValueOrder"] = True
 
@@ -891,6 +913,38 @@ async def _toss_place_order_impl(
         id_guard := _client_order_id_error(client_order_id_override, base_response)
     ) is not None:
         return id_guard
+    mode = getattr(settings, "toss_approval_hash_mode", "optional")
+    if mode != "off":
+        if approval_hash is not None:
+            result = verify_approval_token(approval_hash, canonical, now=now)
+            if not result.ok:
+                err = {
+                    "success": False,
+                    **base_response,
+                    "error": result.message,
+                    "error_code": result.error_code,
+                }
+                if result.diff is not None:
+                    err["diff"] = result.diff
+                return err
+        elif mode == "required":
+            return {
+                "success": False,
+                **base_response,
+                "error": (
+                    "toss_place_order requires approval_hash "
+                    "(TOSS_APPROVAL_HASH_MODE=required). Re-preview and pass "
+                    "approval_hash from toss_preview_order."
+                ),
+                "error_code": "approval_hash_required",
+            }
+        elif mode == "warn":
+            logger.warning(
+                "toss_place_order called without approval_hash "
+                "(mode=warn) symbol=%s side=%s",
+                symbol,
+                side,
+            )
 
     if dry_run:
         return {
@@ -986,6 +1040,7 @@ async def _toss_place_order_impl(
                 notes=notes,
                 indicators_snapshot=indicators_snapshot,
                 report_item_uuid=report_item_uuid,
+                approval_hash=ledger_approval_hash,
             )
             return {
                 "success": True,
@@ -1040,6 +1095,8 @@ async def toss_place_order(
     report_item_uuid: str | None = None,
     account_mode: str | None = None,
     account_type: str | None = None,
+    approval_hash: str | None = None,
+    rung: str | int | None = None,
 ) -> dict[str, Any]:
     return await _toss_place_order_impl(
         symbol=symbol,
@@ -1065,6 +1122,8 @@ async def toss_place_order(
         report_item_uuid=report_item_uuid,
         account_mode=account_mode,
         account_type=account_type,
+        approval_hash=approval_hash,
+        rung=rung,
         client_order_id_override=None,
     )
 

--- a/app/mcp_server/tooling/orders_toss_variants.py
+++ b/app/mcp_server/tooling/orders_toss_variants.py
@@ -17,7 +17,14 @@ from datetime import date, datetime, timedelta
 from decimal import Decimal
 from typing import TYPE_CHECKING, Any, Literal, cast
 
+from app.core.config import settings, validate_toss_api_config
 from app.core.timezone import KST, now_kst
+from app.mcp_server.tick_size import adjust_tick_size_kr, get_tick_size_kr
+from app.mcp_server.tooling.account_modes import (
+    ACCOUNT_MODE_TOSS_LIVE,
+    normalize_account_mode,
+)
+from app.mcp_server.tooling.portfolio_cash import get_account_costs_setting
 from app.mcp_server.tooling.toss_approval import (
     APPROVAL_TTL_SECONDS,
     build_canonical_payload,
@@ -26,14 +33,6 @@ from app.mcp_server.tooling.toss_approval import (
     encode_approval_token,
     verify_approval_token,
 )
-
-from app.core.config import settings, validate_toss_api_config
-from app.mcp_server.tick_size import adjust_tick_size_kr, get_tick_size_kr
-from app.mcp_server.tooling.account_modes import (
-    ACCOUNT_MODE_TOSS_LIVE,
-    normalize_account_mode,
-)
-from app.mcp_server.tooling.portfolio_cash import get_account_costs_setting
 from app.mcp_server.tooling.toss_live_ledger import (
     record_toss_place_order,
     record_toss_replacement_order,
@@ -703,13 +702,11 @@ async def toss_preview_order(
         order_amount=order_amount_str,
     )
     now = now_kst()
-    client_order_id = derive_client_order_id(
-        canonical, market=mkt, now=now, rung=rung
-    )
+    client_order_id = derive_client_order_id(canonical, market=mkt, now=now, rung=rung)
     approval_hash = encode_approval_token(canonical, now=now)
     approval_expires_at = (
-        now + timedelta(seconds=APPROVAL_TTL_SECONDS)
-    ).astimezone(KST).isoformat()
+        (now + timedelta(seconds=APPROVAL_TTL_SECONDS)).astimezone(KST).isoformat()
+    )
 
     payload: dict[str, Any] = {
         "clientOrderId": client_order_id,

--- a/app/mcp_server/tooling/toss_approval.py
+++ b/app/mcp_server/tooling/toss_approval.py
@@ -1,0 +1,160 @@
+"""ROB-651 P6-A — Toss approval-hash + content-based clientOrderId primitives.
+
+Pure helpers (no DB, no network, ``now`` injected) shared by
+``toss_preview_order`` and ``toss_place_order`` so a previewed order and the
+placed order are bound to the same canonical content, and the Toss
+``clientOrderId`` is a deterministic content + trading-day-salt idempotency key
+instead of a fresh uuid4 per call.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any
+from zoneinfo import ZoneInfo
+
+from app.core.timezone import KST
+
+APPROVAL_TOKEN_VERSION = "p6a1"
+APPROVAL_DIGEST_PREFIX = "p6a"
+CLIENT_ORDER_ID_PREFIX = "tossp6"
+APPROVAL_TTL_SECONDS = 300
+
+_ET = ZoneInfo("America/New_York")
+
+
+@dataclass
+class ApprovalResult:
+    ok: bool
+    error_code: str | None = None
+    message: str | None = None
+    diff: dict[str, Any] | None = None
+    digest: str | None = None
+
+
+def build_canonical_payload(
+    *,
+    market: str,
+    symbol: str,
+    side: str,
+    order_type: str,
+    time_in_force: str,
+    quantity: str | None,
+    price: str | None,
+    order_amount: str | None,
+) -> dict[str, Any]:
+    """Canonical order content shared by preview and place.
+
+    ``quantity``/``price``/``order_amount`` must already be the stringified
+    wire values (post tick-snap) or ``None`` so preview and place derive an
+    identical digest. ``clientOrderId`` and ``confirmHighValueOrder`` are
+    intentionally excluded (the former is derived from this; the latter is an
+    operator flag, not economic intent).
+    """
+    return {
+        "market": market,
+        "symbol": symbol,
+        "side": side.upper(),
+        "orderType": order_type.upper(),
+        "timeInForce": time_in_force,
+        "quantity": quantity,
+        "price": price,
+        "orderAmount": order_amount,
+    }
+
+
+def _canonical_json(canonical: dict[str, Any]) -> str:
+    return json.dumps(canonical, sort_keys=True, separators=(",", ":"))
+
+
+def derive_approval_digest(canonical: dict[str, Any]) -> str:
+    digest = hashlib.sha256(_canonical_json(canonical).encode()).hexdigest()[:16]
+    return f"{APPROVAL_DIGEST_PREFIX}-{digest}"
+
+
+def trading_day_salt(market: str, now: datetime) -> str:
+    """ISO trading-day date. ``us`` → America/New_York (DST-aware), else KST."""
+    tz = _ET if market == "us" else KST
+    return now.astimezone(tz).date().isoformat()
+
+
+def derive_client_order_id(
+    canonical: dict[str, Any],
+    *,
+    market: str,
+    now: datetime,
+    rung: str | int | None = None,
+) -> str:
+    salt = trading_day_salt(market, now)
+    disc = "" if rung is None else str(rung)
+    blob = f"{_canonical_json(canonical)}|{salt}|{disc}".encode()
+    digest = hashlib.sha256(blob).hexdigest()[:16]
+    return f"{CLIENT_ORDER_ID_PREFIX}-{digest}"
+
+
+def encode_approval_token(canonical: dict[str, Any], *, now: datetime) -> str:
+    payload = json.dumps(
+        {"iat": int(now.timestamp()), "canon": canonical},
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode()
+    blob = base64.urlsafe_b64encode(payload).decode().rstrip("=")
+    return f"{APPROVAL_TOKEN_VERSION}.{blob}"
+
+
+def decode_approval_token(token: str) -> tuple[int, dict[str, Any]]:
+    version, _, blob = token.partition(".")
+    if version != APPROVAL_TOKEN_VERSION or not blob:
+        raise ValueError("unsupported approval token")
+    pad = "=" * (-len(blob) % 4)
+    raw = base64.urlsafe_b64decode(blob + pad)
+    obj = json.loads(raw)
+    iat = int(obj["iat"])
+    canon = obj["canon"]
+    if not isinstance(canon, dict):
+        raise ValueError("malformed approval token payload")
+    return iat, canon
+
+
+def _diff_canonical(
+    previewed: dict[str, Any], placing: dict[str, Any]
+) -> dict[str, Any]:
+    keys = set(previewed) | set(placing)
+    return {
+        key: {"previewed": previewed.get(key), "placing": placing.get(key)}
+        for key in sorted(keys)
+        if previewed.get(key) != placing.get(key)
+    }
+
+
+def verify_approval_token(
+    token: str, placing_canonical: dict[str, Any], *, now: datetime
+) -> ApprovalResult:
+    try:
+        iat, previewed = decode_approval_token(token)
+    except Exception:
+        return ApprovalResult(
+            ok=False,
+            error_code="invalid_approval_hash",
+            message=(
+                "approval_hash is not a valid approval token; re-preview required"
+            ),
+        )
+    if int(now.timestamp()) - iat > APPROVAL_TTL_SECONDS:
+        return ApprovalResult(
+            ok=False,
+            error_code="approval_expired",
+            message="approval_hash expired; re-preview required",
+        )
+    if previewed != placing_canonical:
+        return ApprovalResult(
+            ok=False,
+            error_code="approval_hash_mismatch",
+            message="placing order does not match previewed order",
+            diff=_diff_canonical(previewed, placing_canonical),
+        )
+    return ApprovalResult(ok=True, digest=derive_approval_digest(placing_canonical))

--- a/app/mcp_server/tooling/toss_live_ledger.py
+++ b/app/mcp_server/tooling/toss_live_ledger.py
@@ -76,6 +76,7 @@ async def record_toss_place_order(
     notes: str | None,
     indicators_snapshot: dict[str, Any] | None,
     report_item_uuid: str | None,
+    approval_hash: str | None = None,
 ) -> dict[str, Any]:
     status = "accepted" if broker_order_id else "rejected"
     async with _order_session_factory()() as db:
@@ -108,6 +109,7 @@ async def record_toss_place_order(
             exit_reason=exit_reason,
             indicators_snapshot=indicators_snapshot,
             report_item_uuid=report_item_uuid,
+            approval_hash=approval_hash,
         )
     return {
         "ledger_id": row.id,

--- a/app/models/review.py
+++ b/app/models/review.py
@@ -533,6 +533,7 @@ class TossLiveOrderLedger(Base):
     exit_reason: Mapped[str | None] = mapped_column(Text)
     indicators_snapshot: Mapped[dict | None] = mapped_column(JSONB)
     report_item_uuid: Mapped[uuid.UUID | None] = mapped_column(PG_UUID(as_uuid=True))
+    approval_hash: Mapped[str | None] = mapped_column(Text)
 
     filled_qty: Mapped[Decimal | None] = mapped_column(Numeric(20, 8))
     avg_fill_price: Mapped[Decimal | None] = mapped_column(Numeric(20, 8))

--- a/app/services/toss_live_order_ledger_service.py
+++ b/app/services/toss_live_order_ledger_service.py
@@ -94,6 +94,7 @@ class TossLiveOrderLedgerService:
         exit_reason: str | None = None,
         indicators_snapshot: dict[str, Any] | None = None,
         report_item_uuid: str | uuid.UUID | None = None,
+        approval_hash: str | None = None,
     ) -> TossLiveOrderLedger:
         # ROB-545 B2 — idempotent on client_order_id. A live POST retried with
         # the same clientOrderId (the smoke's idempotency check) must not raise a
@@ -147,6 +148,7 @@ class TossLiveOrderLedgerService:
             exit_reason=exit_reason,
             indicators_snapshot=indicators_snapshot,
             report_item_uuid=parse_report_item_uuid(report_item_uuid),
+            approval_hash=approval_hash,
         )
         self._db.add(row)
         await self._db.flush()

--- a/docs/superpowers/plans/2026-07-02-rob-651-toss-approval-hash-idempotency.md
+++ b/docs/superpowers/plans/2026-07-02-rob-651-toss-approval-hash-idempotency.md
@@ -1,0 +1,1144 @@
+# ROB-651 P6-A — Toss approval-hash + content-based clientOrderId Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Bind `toss_preview_order` → `toss_place_order` with a content-based approval token (TTL 5min, fail-closed on mismatch) and replace uuid4 `clientOrderId` with a deterministic content+trading-day-salt idempotency key.
+
+**Architecture:** A new pure module `toss_approval.py` holds all hash/token/salt primitives (no DB, no network, `now` injected → fully unit-testable). `orders_toss_variants.py` wires it into preview (emit token + deterministic clientOrderId) and place (verify token under a config-gated rollout mode + deterministic clientOrderId). The `toss_live_order_ledger` gains an additive nullable `approval_hash` column storing the content digest of every placed order.
+
+**Tech Stack:** Python 3.13, FastMCP tools, SQLAlchemy async ORM, Alembic, pytest (`uv run pytest`).
+
+## Global Constraints
+
+- **Scope: Toss only.** KIS/Upbit shared-path port is P6-B (ROB-653) — do not touch shared `_place_order_impl`.
+- **Rollout default = `optional`.** Existing `toss_place_order` calls without `approval_hash` must keep working (back-compat).
+- **Deterministic clientOrderId is always ON** (independent of `approval_hash` presence/mode).
+- **Migration is additive + nullable only.** `down_revision = "20260702_rob641"` (current head). One migration.
+- **`record_send` replay contract unchanged**: query-first on `client_order_id`; existing row returned as-is, approval_hash never overwritten on replay.
+- **No new infra dependency** on the place path (stateless token; no Redis).
+- **Trust model** (issue §5): token is accident-prevention, not adversary defense — single operator confirm-as-approval.
+- Constants: `APPROVAL_TTL_SECONDS = 300`, token version `"p6a1"`, digest prefix `"p6a"`, clientOrderId prefix `"tossp6"`.
+- Run tests with `uv run pytest`. Lint with `uv run ruff format app/ tests/ && uv run ruff check app/ tests/` before final commit (CI lints `app/` **and** `tests/`).
+
+---
+
+## File Structure
+
+- **Create** `app/mcp_server/tooling/toss_approval.py` — pure primitives (canonical, digest, clientOrderId, trading-day salt, token encode/decode/verify). No DB/network.
+- **Create** `tests/test_toss_approval.py` — pure unit tests for the module.
+- **Modify** `app/models/review.py` — add `approval_hash` column to `TossLiveOrderLedger`.
+- **Create** `alembic/versions/20260702_rob651_toss_approval_hash.py` — additive nullable column.
+- **Modify** `app/services/toss_live_order_ledger_service.py` — `record_send(..., approval_hash=None)`.
+- **Modify** `app/mcp_server/tooling/toss_live_ledger.py` — `record_toss_place_order(..., approval_hash=None)` pass-through.
+- **Modify** `app/core/config.py` — add `toss_approval_hash_mode: str = "optional"`.
+- **Modify** `app/mcp_server/tooling/orders_toss_variants.py` — wire preview + place.
+- **Modify** `tests/test_mcp_toss_order_variants.py` — tool-level tests.
+- **Modify** `tests/test_rob538_toss_live_ledger_schema.py` — ledger column/record_send test.
+
+---
+
+## Task 1: Pure approval module (`toss_approval.py`)
+
+**Files:**
+- Create: `app/mcp_server/tooling/toss_approval.py`
+- Test: `tests/test_toss_approval.py`
+
+**Interfaces:**
+- Consumes: `app.core.timezone.KST`.
+- Produces:
+  - `build_canonical_payload(*, market: str, symbol: str, side: str, order_type: str, time_in_force: str, quantity: str | None, price: str | None, order_amount: str | None) -> dict[str, Any]` — `quantity/price/order_amount` are already-stringified wire values (post tick-snap) or `None`.
+  - `derive_approval_digest(canonical: dict) -> str` → `"p6a-<16hex>"`.
+  - `trading_day_salt(market: str, now: datetime) -> str` → ISO date; `us` → ET, else KST.
+  - `derive_client_order_id(canonical: dict, *, market: str, now: datetime, rung: str | int | None = None) -> str` → `"tossp6-<16hex>"`.
+  - `encode_approval_token(canonical: dict, *, now: datetime) -> str` → `"p6a1.<b64url>"`.
+  - `decode_approval_token(token: str) -> tuple[int, dict]` → `(iat_epoch, previewed_canonical)`; raises `ValueError` on bad token.
+  - `verify_approval_token(token: str, placing_canonical: dict, *, now: datetime) -> ApprovalResult`.
+  - `ApprovalResult` dataclass: `ok: bool`, `error_code: str | None`, `message: str | None`, `diff: dict | None`, `digest: str | None`.
+  - `APPROVAL_TTL_SECONDS: int = 300`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_toss_approval.py`:
+
+```python
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from app.core.timezone import KST
+from app.mcp_server.tooling.toss_approval import (
+    APPROVAL_TTL_SECONDS,
+    build_canonical_payload,
+    decode_approval_token,
+    derive_approval_digest,
+    derive_client_order_id,
+    encode_approval_token,
+    trading_day_salt,
+    verify_approval_token,
+)
+
+_ET = ZoneInfo("America/New_York")
+
+
+def _canon(**overrides):
+    base = dict(
+        market="kr",
+        symbol="005930",
+        side="buy",
+        order_type="limit",
+        time_in_force="DAY",
+        quantity="10",
+        price="70000",
+        order_amount=None,
+    )
+    base.update(overrides)
+    return build_canonical_payload(**base)
+
+
+def test_canonical_uppercases_and_is_stable():
+    a = _canon()
+    b = _canon()
+    assert a == b
+    assert a["side"] == "BUY"
+    assert a["orderType"] == "LIMIT"
+    assert derive_approval_digest(a) == derive_approval_digest(b)
+
+
+def test_canonical_price_change_changes_digest():
+    assert derive_approval_digest(_canon(price="70000")) != derive_approval_digest(
+        _canon(price="70100")
+    )
+
+
+def test_amount_based_buy_hashes_wire_payload():
+    canon = _canon(quantity=None, price=None, order_amount="1000000")
+    digest = derive_approval_digest(canon)
+    assert digest.startswith("p6a-")
+    assert len(digest) == len("p6a-") + 16
+
+
+def test_trading_day_salt_kr_uses_kst_us_uses_et():
+    # 2026-07-02 23:30 KST == 2026-07-02 10:30 ET (same US calendar date here)
+    now = datetime(2026, 7, 2, 23, 30, tzinfo=KST)
+    assert trading_day_salt("kr", now) == "2026-07-02"
+    assert trading_day_salt("us", now) == now.astimezone(_ET).date().isoformat()
+
+
+def test_client_order_id_deterministic_same_day():
+    now = datetime(2026, 7, 2, 10, 0, tzinfo=KST)
+    canon = _canon()
+    assert derive_client_order_id(canon, market="kr", now=now) == derive_client_order_id(
+        canon, market="kr", now=now
+    )
+
+
+def test_client_order_id_changes_next_trading_day():
+    canon = _canon()
+    today = datetime(2026, 7, 2, 10, 0, tzinfo=KST)
+    tomorrow = datetime(2026, 7, 3, 10, 0, tzinfo=KST)
+    assert derive_client_order_id(canon, market="kr", now=today) != derive_client_order_id(
+        canon, market="kr", now=tomorrow
+    )
+
+
+def test_client_order_id_rung_discriminator_splits():
+    now = datetime(2026, 7, 2, 10, 0, tzinfo=KST)
+    canon = _canon()
+    base = derive_client_order_id(canon, market="kr", now=now)
+    r2 = derive_client_order_id(canon, market="kr", now=now, rung=2)
+    assert base != r2
+    assert r2.startswith("tossp6-")
+
+
+def test_client_order_id_is_safe_segment():
+    now = datetime(2026, 7, 2, 10, 0, tzinfo=KST)
+    cid = derive_client_order_id(_canon(), market="kr", now=now)
+    assert cid.replace("-", "").replace("_", "").isalnum()
+    assert len(cid) <= 40
+
+
+def test_token_roundtrip_and_verify_ok():
+    now = datetime(2026, 7, 2, 10, 0, tzinfo=KST)
+    canon = _canon()
+    token = encode_approval_token(canon, now=now)
+    assert token.startswith("p6a1.")
+    iat, decoded = decode_approval_token(token)
+    assert decoded == canon
+    result = verify_approval_token(token, canon, now=now)
+    assert result.ok is True
+    assert result.digest == derive_approval_digest(canon)
+
+
+def test_verify_mismatch_returns_diff():
+    now = datetime(2026, 7, 2, 10, 0, tzinfo=KST)
+    token = encode_approval_token(_canon(price="70000"), now=now)
+    result = verify_approval_token(token, _canon(price="70100"), now=now)
+    assert result.ok is False
+    assert result.error_code == "approval_hash_mismatch"
+    assert "price" in result.diff
+    assert result.diff["price"] == {"previewed": "70000", "placing": "70100"}
+
+
+def test_verify_expired_after_ttl():
+    issued = datetime(2026, 7, 2, 10, 0, tzinfo=KST)
+    token = encode_approval_token(_canon(), now=issued)
+    later = issued + timedelta(seconds=APPROVAL_TTL_SECONDS + 1)
+    result = verify_approval_token(token, _canon(), now=later)
+    assert result.ok is False
+    assert result.error_code == "approval_expired"
+
+
+def test_verify_within_ttl_ok():
+    issued = datetime(2026, 7, 2, 10, 0, tzinfo=KST)
+    token = encode_approval_token(_canon(), now=issued)
+    later = issued + timedelta(seconds=APPROVAL_TTL_SECONDS - 1)
+    assert verify_approval_token(token, _canon(), now=later).ok is True
+
+
+def test_verify_invalid_token():
+    now = datetime(2026, 7, 2, 10, 0, tzinfo=KST)
+    result = verify_approval_token("not-a-token", _canon(), now=now)
+    assert result.ok is False
+    assert result.error_code == "invalid_approval_hash"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_toss_approval.py -q`
+Expected: FAIL / collection error — `ModuleNotFoundError: app.mcp_server.tooling.toss_approval`.
+
+- [ ] **Step 3: Write the module**
+
+Create `app/mcp_server/tooling/toss_approval.py`:
+
+```python
+"""ROB-651 P6-A — Toss approval-hash + content-based clientOrderId primitives.
+
+Pure helpers (no DB, no network, ``now`` injected) shared by
+``toss_preview_order`` and ``toss_place_order`` so a previewed order and the
+placed order are bound to the same canonical content, and the Toss
+``clientOrderId`` is a deterministic content + trading-day-salt idempotency key
+instead of a fresh uuid4 per call.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any
+from zoneinfo import ZoneInfo
+
+from app.core.timezone import KST
+
+APPROVAL_TOKEN_VERSION = "p6a1"
+APPROVAL_DIGEST_PREFIX = "p6a"
+CLIENT_ORDER_ID_PREFIX = "tossp6"
+APPROVAL_TTL_SECONDS = 300
+
+_ET = ZoneInfo("America/New_York")
+
+
+@dataclass
+class ApprovalResult:
+    ok: bool
+    error_code: str | None = None
+    message: str | None = None
+    diff: dict[str, Any] | None = None
+    digest: str | None = None
+
+
+def build_canonical_payload(
+    *,
+    market: str,
+    symbol: str,
+    side: str,
+    order_type: str,
+    time_in_force: str,
+    quantity: str | None,
+    price: str | None,
+    order_amount: str | None,
+) -> dict[str, Any]:
+    """Canonical order content shared by preview and place.
+
+    ``quantity``/``price``/``order_amount`` must already be the stringified
+    wire values (post tick-snap) or ``None`` so preview and place derive an
+    identical digest. ``clientOrderId`` and ``confirmHighValueOrder`` are
+    intentionally excluded (the former is derived from this; the latter is an
+    operator flag, not economic intent).
+    """
+    return {
+        "market": market,
+        "symbol": symbol,
+        "side": side.upper(),
+        "orderType": order_type.upper(),
+        "timeInForce": time_in_force,
+        "quantity": quantity,
+        "price": price,
+        "orderAmount": order_amount,
+    }
+
+
+def _canonical_json(canonical: dict[str, Any]) -> str:
+    return json.dumps(canonical, sort_keys=True, separators=(",", ":"))
+
+
+def derive_approval_digest(canonical: dict[str, Any]) -> str:
+    digest = hashlib.sha256(_canonical_json(canonical).encode()).hexdigest()[:16]
+    return f"{APPROVAL_DIGEST_PREFIX}-{digest}"
+
+
+def trading_day_salt(market: str, now: datetime) -> str:
+    """ISO trading-day date. ``us`` → America/New_York (DST-aware), else KST."""
+    tz = _ET if market == "us" else KST
+    return now.astimezone(tz).date().isoformat()
+
+
+def derive_client_order_id(
+    canonical: dict[str, Any],
+    *,
+    market: str,
+    now: datetime,
+    rung: str | int | None = None,
+) -> str:
+    salt = trading_day_salt(market, now)
+    disc = "" if rung is None else str(rung)
+    blob = f"{_canonical_json(canonical)}|{salt}|{disc}".encode()
+    digest = hashlib.sha256(blob).hexdigest()[:16]
+    return f"{CLIENT_ORDER_ID_PREFIX}-{digest}"
+
+
+def encode_approval_token(canonical: dict[str, Any], *, now: datetime) -> str:
+    payload = json.dumps(
+        {"iat": int(now.timestamp()), "canon": canonical},
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode()
+    blob = base64.urlsafe_b64encode(payload).decode().rstrip("=")
+    return f"{APPROVAL_TOKEN_VERSION}.{blob}"
+
+
+def decode_approval_token(token: str) -> tuple[int, dict[str, Any]]:
+    version, _, blob = token.partition(".")
+    if version != APPROVAL_TOKEN_VERSION or not blob:
+        raise ValueError("unsupported approval token")
+    pad = "=" * (-len(blob) % 4)
+    raw = base64.urlsafe_b64decode(blob + pad)
+    obj = json.loads(raw)
+    iat = int(obj["iat"])
+    canon = obj["canon"]
+    if not isinstance(canon, dict):
+        raise ValueError("malformed approval token payload")
+    return iat, canon
+
+
+def _diff_canonical(
+    previewed: dict[str, Any], placing: dict[str, Any]
+) -> dict[str, Any]:
+    keys = set(previewed) | set(placing)
+    return {
+        key: {"previewed": previewed.get(key), "placing": placing.get(key)}
+        for key in sorted(keys)
+        if previewed.get(key) != placing.get(key)
+    }
+
+
+def verify_approval_token(
+    token: str, placing_canonical: dict[str, Any], *, now: datetime
+) -> ApprovalResult:
+    try:
+        iat, previewed = decode_approval_token(token)
+    except Exception:
+        return ApprovalResult(
+            ok=False,
+            error_code="invalid_approval_hash",
+            message=(
+                "approval_hash is not a valid approval token; re-preview required"
+            ),
+        )
+    if int(now.timestamp()) - iat > APPROVAL_TTL_SECONDS:
+        return ApprovalResult(
+            ok=False,
+            error_code="approval_expired",
+            message="approval_hash expired; re-preview required",
+        )
+    if previewed != placing_canonical:
+        return ApprovalResult(
+            ok=False,
+            error_code="approval_hash_mismatch",
+            message="placing order does not match previewed order",
+            diff=_diff_canonical(previewed, placing_canonical),
+        )
+    return ApprovalResult(ok=True, digest=derive_approval_digest(placing_canonical))
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_toss_approval.py -q`
+Expected: PASS (all tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/mcp_server/tooling/toss_approval.py tests/test_toss_approval.py
+git commit -m "feat(ROB-651): pure Toss approval-hash + clientOrderId primitives
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Ledger column + migration + service pass-through
+
+**Files:**
+- Modify: `app/models/review.py` (class `TossLiveOrderLedger`, after `report_item_uuid` column ~`app/models/review.py:537`)
+- Create: `alembic/versions/20260702_rob651_toss_approval_hash.py`
+- Modify: `app/services/toss_live_order_ledger_service.py:66-155` (`record_send`)
+- Modify: `app/mcp_server/tooling/toss_live_ledger.py:55` (`record_toss_place_order`)
+- Test: `tests/test_rob538_toss_live_ledger_schema.py`
+
+**Interfaces:**
+- Consumes: nothing from Task 1.
+- Produces:
+  - `TossLiveOrderLedger.approval_hash: Mapped[str | None]` (Text, nullable).
+  - `record_send(..., approval_hash: str | None = None)` — sets column on insert; **never** overwrites on replay.
+  - `record_toss_place_order(..., approval_hash: str | None = None)` — pass-through.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/test_rob538_toss_live_ledger_schema.py` (append at end of file):
+
+```python
+def test_toss_live_order_ledger_has_approval_hash_column():
+    from app.models.review import TossLiveOrderLedger
+
+    col = TossLiveOrderLedger.__table__.columns["approval_hash"]
+    assert col.nullable is True
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_rob538_toss_live_ledger_schema.py::test_toss_live_order_ledger_has_approval_hash_column -q`
+Expected: FAIL — `KeyError: 'approval_hash'`.
+
+- [ ] **Step 3: Add the model column**
+
+In `app/models/review.py`, inside `TossLiveOrderLedger`, immediately after the `report_item_uuid` column line:
+
+```python
+    approval_hash: Mapped[str | None] = mapped_column(Text)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_rob538_toss_live_ledger_schema.py::test_toss_live_order_ledger_has_approval_hash_column -q`
+Expected: PASS.
+
+- [ ] **Step 5: Write the migration**
+
+Create `alembic/versions/20260702_rob651_toss_approval_hash.py`:
+
+```python
+"""add approval_hash to toss_live_order_ledger (ROB-651)
+
+Revision ID: 20260702_rob651
+Revises: 20260702_rob641
+Create Date: 2026-07-02
+
+Additive nullable column storing the content digest (``p6a-<16hex>``) of the
+placed order's canonical payload — the approval-hash binding between
+toss_preview_order and toss_place_order (ROB-651 P6-A).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "20260702_rob651"
+down_revision: str | Sequence[str] | None = "20260702_rob641"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "toss_live_order_ledger",
+        sa.Column("approval_hash", sa.Text(), nullable=True),
+        schema="review",
+    )
+
+
+def downgrade() -> None:
+    op.drop_column(
+        "toss_live_order_ledger", "approval_hash", schema="review"
+    )
+```
+
+- [ ] **Step 6: Verify migration chains from head (offline check)**
+
+Run: `uv run alembic heads`
+Expected: single head `20260702_rob651` (no multi-head). If `alembic` needs a DB and is unavailable, instead grep-confirm `down_revision` matches the prior head:
+Run: `grep -h "^revision\|^down_revision" alembic/versions/20260702_rob651_toss_approval_hash.py`
+Expected: `revision = "20260702_rob651"`, `down_revision = "20260702_rob641"`.
+
+- [ ] **Step 7: Add `approval_hash` to `record_send`**
+
+In `app/services/toss_live_order_ledger_service.py`, add the parameter to `record_send`'s signature (after `report_item_uuid: str | uuid.UUID | None = None,`):
+
+```python
+        approval_hash: str | None = None,
+```
+
+And in the `TossLiveOrderLedger(...)` constructor call (after `report_item_uuid=parse_report_item_uuid(report_item_uuid),`):
+
+```python
+            approval_hash=approval_hash,
+```
+
+The replay branch (`if existing is not None: ... return existing`) is left untouched — a replayed row keeps its original `approval_hash`.
+
+- [ ] **Step 8: Add `approval_hash` to `record_toss_place_order`**
+
+In `app/mcp_server/tooling/toss_live_ledger.py`, add to `record_toss_place_order`'s signature (after `report_item_uuid: str | None,`):
+
+```python
+    approval_hash: str | None = None,
+```
+
+And pass it through in the `record_send(...)` call (after `report_item_uuid=report_item_uuid,`):
+
+```python
+            approval_hash=approval_hash,
+```
+
+- [ ] **Step 9: Write the record_send behavior tests**
+
+Add to `tests/test_rob538_toss_live_ledger_schema.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_record_send_stores_approval_hash(toss_ledger_session):
+    # toss_ledger_session: existing async-session fixture in this file.
+    from app.services.toss_live_order_ledger_service import TossLiveOrderLedgerService
+
+    svc = TossLiveOrderLedgerService(toss_ledger_session)
+    row = await svc.record_send(
+        operation_kind="place",
+        market="kr",
+        symbol="005930",
+        side="buy",
+        order_type="limit",
+        time_in_force="DAY",
+        quantity=None,
+        price=None,
+        order_amount=None,
+        currency="KRW",
+        client_order_id="tossp6-deadbeefdeadbeef",
+        broker_order_id="BRK-1",
+        original_order_id=None,
+        status="accepted",
+        broker_status=None,
+        response_code="0",
+        response_message=None,
+        raw_response=None,
+        approval_hash="p6a-abc123abc123abc1",
+    )
+    assert row.approval_hash == "p6a-abc123abc123abc1"
+
+
+@pytest.mark.asyncio
+async def test_record_send_replay_keeps_original_approval_hash(toss_ledger_session):
+    from app.services.toss_live_order_ledger_service import TossLiveOrderLedgerService
+
+    svc = TossLiveOrderLedgerService(toss_ledger_session)
+    common = dict(
+        operation_kind="place",
+        market="kr",
+        symbol="005930",
+        side="buy",
+        order_type="limit",
+        time_in_force="DAY",
+        quantity=None,
+        price=None,
+        order_amount=None,
+        currency="KRW",
+        client_order_id="tossp6-cafecafecafecafe",
+        broker_order_id="BRK-2",
+        original_order_id=None,
+        status="accepted",
+        broker_status=None,
+        response_code="0",
+        response_message=None,
+        raw_response=None,
+    )
+    first = await svc.record_send(**common, approval_hash="p6a-original00000000")
+    replay = await svc.record_send(**common, approval_hash="p6a-different0000000")
+    assert replay.id == first.id
+    assert replay.approval_hash == "p6a-original00000000"
+```
+
+> **NOTE for implementer:** Confirm the async-session fixture name in this file (grep `def .*session` / `@pytest.fixture` in `tests/test_rob538_toss_live_ledger_schema.py`). If it differs from `toss_ledger_session`, use the existing fixture name. If the file has no DB-session fixture, reuse the session fixture used by `test_rob538_toss_live_ledger_schema.py`'s existing insert/replay tests (this file already exercises `record_send`).
+
+- [ ] **Step 10: Run the ledger tests**
+
+Run: `uv run pytest tests/test_rob538_toss_live_ledger_schema.py -q`
+Expected: PASS (new column test + both record_send tests + pre-existing tests).
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add app/models/review.py alembic/versions/20260702_rob651_toss_approval_hash.py \
+        app/services/toss_live_order_ledger_service.py \
+        app/mcp_server/tooling/toss_live_ledger.py \
+        tests/test_rob538_toss_live_ledger_schema.py
+git commit -m "feat(ROB-651): toss_live_order_ledger.approval_hash column + record_send pass-through
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Wire `toss_preview_order`
+
+**Files:**
+- Modify: `app/mcp_server/tooling/orders_toss_variants.py` (`toss_preview_order` `:642-765`)
+- Test: `tests/test_mcp_toss_order_variants.py`
+
+**Interfaces:**
+- Consumes (Task 1): `build_canonical_payload`, `derive_client_order_id`, `encode_approval_token`, `APPROVAL_TTL_SECONDS`.
+- Produces: `toss_preview_order` response now contains `approval_hash` (token str), `approval_expires_at` (ISO KST str), and `payload_preview["clientOrderId"]` is the deterministic id. New optional param `rung: str | int | None = None`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/test_mcp_toss_order_variants.py` (follow the file's existing async test + monkeypatch style for `_client_context`/warnings; grep existing preview tests for the fixture pattern and reuse it):
+
+```python
+@pytest.mark.asyncio
+async def test_preview_emits_approval_hash_and_deterministic_client_order_id(
+    monkeypatch,
+):
+    from datetime import datetime
+
+    from app.core.timezone import KST
+    from app.mcp_server.tooling import orders_toss_variants as otv
+
+    fixed = datetime(2026, 7, 2, 10, 0, tzinfo=KST)
+    monkeypatch.setattr(otv, "now_kst", lambda: fixed)
+    # reuse the file's existing helper that stubs _client_context + warnings guard;
+    # if none exists, monkeypatch otv._client_context and otv.check_warnings_guard.
+
+    res1 = await otv.toss_preview_order(
+        symbol="005930", side="buy", order_type="limit",
+        quantity="10", price="70000", market="kr",
+    )
+    res2 = await otv.toss_preview_order(
+        symbol="005930", side="buy", order_type="limit",
+        quantity="10", price="70000", market="kr",
+    )
+    assert res1["success"] is True
+    assert res1["approval_hash"].startswith("p6a1.")
+    assert res1["approval_expires_at"]  # ISO string
+    cid = res1["payload_preview"]["clientOrderId"]
+    assert cid.startswith("tossp6-")
+    # deterministic: identical params + same trading day -> identical id + token payload
+    assert res2["payload_preview"]["clientOrderId"] == cid
+
+
+@pytest.mark.asyncio
+async def test_preview_rung_discriminator_changes_client_order_id(monkeypatch):
+    from datetime import datetime
+
+    from app.core.timezone import KST
+    from app.mcp_server.tooling import orders_toss_variants as otv
+
+    monkeypatch.setattr(otv, "now_kst", lambda: datetime(2026, 7, 2, 10, 0, tzinfo=KST))
+    # stub client/warnings as above
+
+    base = await otv.toss_preview_order(
+        symbol="005930", side="buy", order_type="limit",
+        quantity="10", price="70000", market="kr",
+    )
+    r2 = await otv.toss_preview_order(
+        symbol="005930", side="buy", order_type="limit",
+        quantity="10", price="70000", market="kr", rung=2,
+    )
+    assert (
+        base["payload_preview"]["clientOrderId"]
+        != r2["payload_preview"]["clientOrderId"]
+    )
+```
+
+> **NOTE:** `toss_preview_order` calls `_client_context()` (network). Reuse whatever stub the existing preview tests in this file use. Grep `toss_preview_order` in the test file for the established monkeypatch pattern; do not invent a new one.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_mcp_toss_order_variants.py -q -k "approval_hash or rung_discriminator"`
+Expected: FAIL — `KeyError: 'approval_hash'` / `TypeError: unexpected keyword argument 'rung'`.
+
+- [ ] **Step 3: Add the timezone import + module seam**
+
+In `app/mcp_server/tooling/orders_toss_variants.py`, extend the timezone import and add the approval module import near the existing imports (after line 20-36 block):
+
+```python
+from app.core.timezone import KST, now_kst
+from app.mcp_server.tooling.toss_approval import (
+    APPROVAL_TTL_SECONDS,
+    build_canonical_payload,
+    derive_approval_digest,
+    derive_client_order_id,
+    encode_approval_token,
+    verify_approval_token,
+)
+```
+
+(`now_kst` referenced as a module attribute so tests can `monkeypatch.setattr(otv, "now_kst", ...)`. `KST` is used to format `approval_expires_at` and add the TTL.)
+
+- [ ] **Step 4: Rewrite the preview payload/response block**
+
+In `toss_preview_order`, add `rung: str | int | None = None` to the signature (after `account_type: str | None = None,`).
+
+Replace the payload-construction block (currently starting `payload: dict[str, Any] = {"clientOrderId": _new_client_order_id(), ...}` through the conditional `quantity`/`price`/`orderAmount` adds) with:
+
+```python
+    quantity_str = _stringify_decimal(quantity_dec)
+    price_str = _stringify_decimal(price_dec)
+    order_amount_str = _stringify_decimal(order_amount_dec)
+
+    canonical = build_canonical_payload(
+        market=mkt,
+        symbol=symbol,
+        side=side,
+        order_type=order_type,
+        time_in_force=time_in_force,
+        quantity=quantity_str,
+        price=price_str,
+        order_amount=order_amount_str,
+    )
+    now = now_kst()
+    client_order_id = derive_client_order_id(
+        canonical, market=mkt, now=now, rung=rung
+    )
+    approval_hash = encode_approval_token(canonical, now=now)
+    approval_expires_at = (
+        now + timedelta(seconds=APPROVAL_TTL_SECONDS)
+    ).astimezone(KST).isoformat()
+
+    payload: dict[str, Any] = {
+        "clientOrderId": client_order_id,
+        "symbol": symbol,
+        "side": side.upper(),
+        "orderType": order_type.upper(),
+        "timeInForce": time_in_force,
+    }
+    if quantity_str is not None:
+        payload["quantity"] = quantity_str
+    if price_str is not None:
+        payload["price"] = price_str
+    if order_amount_str is not None:
+        payload["orderAmount"] = order_amount_str
+```
+
+Add `timedelta` to the `datetime` import at the top: change `from datetime import date, datetime` to `from datetime import date, datetime, timedelta`.
+
+Then add the two new keys to the `response = { ... }` dict (alongside `"payload_preview": payload,`):
+
+```python
+        "approval_hash": approval_hash,
+        "approval_expires_at": approval_expires_at,
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_mcp_toss_order_variants.py -q -k "approval_hash or rung_discriminator"`
+Expected: PASS.
+
+- [ ] **Step 6: Run the full Toss variants suite (no regressions)**
+
+Run: `uv run pytest tests/test_mcp_toss_order_variants.py tests/test_mcp_toss_order_variants_rob561.py -q`
+Expected: PASS. If a pre-existing test asserted `clientOrderId` was a 32-char uuid hex, update it to assert the `tossp6-` deterministic prefix (this is the intended contract change; note it in the commit).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add app/mcp_server/tooling/orders_toss_variants.py tests/test_mcp_toss_order_variants.py
+git commit -m "feat(ROB-651): toss_preview_order emits approval_hash token + deterministic clientOrderId
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Wire `toss_place_order` + rollout mode gate
+
+**Files:**
+- Modify: `app/core/config.py:184+` (`Settings`) — add `toss_approval_hash_mode`
+- Modify: `app/mcp_server/tooling/orders_toss_variants.py` (`_toss_place_order_impl` `:766-982`, `toss_place_order` `:983-1035`)
+- Test: `tests/test_mcp_toss_order_variants.py`
+
+**Interfaces:**
+- Consumes (Task 1): `build_canonical_payload`, `derive_client_order_id`, `derive_approval_digest`, `verify_approval_token`. (Task 2): `record_toss_place_order(..., approval_hash=...)`.
+- Produces: `_toss_place_order_impl` + `toss_place_order` accept `approval_hash: str | None = None` and `rung: str | int | None = None`. Fail-closed error codes on the response `"error_code"`: `invalid_approval_hash`, `approval_expired`, `approval_hash_mismatch` (with `"diff"`), `approval_hash_required`.
+
+- [ ] **Step 1: Add the config flag**
+
+In `app/core/config.py`, in `Settings` next to the other `toss_*` fields (~line 246):
+
+```python
+    toss_approval_hash_mode: str = "optional"  # off | optional | warn | required
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+Add to `tests/test_mcp_toss_order_variants.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_place_dry_run_matching_hash_passes(monkeypatch):
+    from datetime import datetime
+
+    from app.core.timezone import KST
+    from app.mcp_server.tooling import orders_toss_variants as otv
+
+    monkeypatch.setattr(otv, "now_kst", lambda: datetime(2026, 7, 2, 10, 0, tzinfo=KST))
+    # stub _client_context + warnings as the existing place tests do
+
+    prev = await otv.toss_preview_order(
+        symbol="005930", side="buy", order_type="limit",
+        quantity="10", price="70000", market="kr",
+    )
+    res = await otv.toss_place_order(
+        symbol="005930", side="buy", order_type="limit",
+        quantity="10", price="70000", market="kr",
+        dry_run=True, approval_hash=prev["approval_hash"],
+    )
+    assert res["success"] is True
+    # placed clientOrderId matches previewed (idempotent)
+    assert res["client_order_id"] == prev["payload_preview"]["clientOrderId"]
+
+
+@pytest.mark.asyncio
+async def test_place_mismatched_hash_fails_closed_with_diff(monkeypatch):
+    from datetime import datetime
+
+    from app.core.timezone import KST
+    from app.mcp_server.tooling import orders_toss_variants as otv
+
+    monkeypatch.setattr(otv, "now_kst", lambda: datetime(2026, 7, 2, 10, 0, tzinfo=KST))
+
+    prev = await otv.toss_preview_order(
+        symbol="005930", side="buy", order_type="limit",
+        quantity="10", price="70000", market="kr",
+    )
+    res = await otv.toss_place_order(
+        symbol="005930", side="buy", order_type="limit",
+        quantity="10", price="70100", market="kr",  # price differs
+        dry_run=True, approval_hash=prev["approval_hash"],
+    )
+    assert res["success"] is False
+    assert res["error_code"] == "approval_hash_mismatch"
+    assert "price" in res["diff"]
+
+
+@pytest.mark.asyncio
+async def test_place_expired_hash_requires_repreview(monkeypatch):
+    from datetime import datetime, timedelta
+
+    from app.core.timezone import KST
+    from app.mcp_server.tooling import orders_toss_variants as otv
+
+    issued = datetime(2026, 7, 2, 10, 0, tzinfo=KST)
+    monkeypatch.setattr(otv, "now_kst", lambda: issued)
+    prev = await otv.toss_preview_order(
+        symbol="005930", side="buy", order_type="limit",
+        quantity="10", price="70000", market="kr",
+    )
+    monkeypatch.setattr(otv, "now_kst", lambda: issued + timedelta(seconds=301))
+    res = await otv.toss_place_order(
+        symbol="005930", side="buy", order_type="limit",
+        quantity="10", price="70000", market="kr",
+        dry_run=True, approval_hash=prev["approval_hash"],
+    )
+    assert res["success"] is False
+    assert res["error_code"] == "approval_expired"
+
+
+@pytest.mark.asyncio
+async def test_place_optional_mode_without_hash_passes(monkeypatch):
+    from datetime import datetime
+
+    from app.core.timezone import KST
+    from app.mcp_server.tooling import orders_toss_variants as otv
+
+    monkeypatch.setattr(otv, "now_kst", lambda: datetime(2026, 7, 2, 10, 0, tzinfo=KST))
+    monkeypatch.setattr(otv.settings, "toss_approval_hash_mode", "optional", raising=False)
+    res = await otv.toss_place_order(
+        symbol="005930", side="buy", order_type="limit",
+        quantity="10", price="70000", market="kr", dry_run=True,
+    )
+    assert res["success"] is True
+
+
+@pytest.mark.asyncio
+async def test_place_required_mode_without_hash_fails_closed(monkeypatch):
+    from datetime import datetime
+
+    from app.core.timezone import KST
+    from app.mcp_server.tooling import orders_toss_variants as otv
+
+    monkeypatch.setattr(otv, "now_kst", lambda: datetime(2026, 7, 2, 10, 0, tzinfo=KST))
+    monkeypatch.setattr(otv.settings, "toss_approval_hash_mode", "required", raising=False)
+    res = await otv.toss_place_order(
+        symbol="005930", side="buy", order_type="limit",
+        quantity="10", price="70000", market="kr", dry_run=True,
+    )
+    assert res["success"] is False
+    assert res["error_code"] == "approval_hash_required"
+```
+
+> **NOTE:** These place tests are `dry_run=True`, so `_live_mutation_disabled_error` and the broker `execute_order` path are not reached — no broker stub needed beyond `_client_context` which dry-run does not enter. Verify by reading `_toss_place_order_impl`: the `dry_run` early return happens **before** `execute_order`. The approval-gate must be placed **before** that dry-run return so dry-run exercises it.
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_mcp_toss_order_variants.py -q -k "place_dry_run_matching or mismatched_hash or expired_hash or optional_mode or required_mode"`
+Expected: FAIL — `TypeError: unexpected keyword argument 'approval_hash'`.
+
+- [ ] **Step 4: Add params + approval gate to `_toss_place_order_impl`**
+
+Add to the signature (after `account_type: str | None = None,`, before `client_order_id_override: str | None = None,`):
+
+```python
+    approval_hash: str | None = None,
+    rung: str | int | None = None,
+```
+
+Replace the payload-construction block (currently `payload: dict[str, Any] = {"clientOrderId": client_order_id_override or _new_client_order_id(), ...}` and the conditional field adds) with the canonical-first version:
+
+```python
+    quantity_str = _stringify_decimal(quantity_dec)
+    price_str = _stringify_decimal(price_dec)
+    order_amount_str = _stringify_decimal(order_amount_dec)
+
+    canonical = build_canonical_payload(
+        market=mkt,
+        symbol=symbol,
+        side=side,
+        order_type=order_type,
+        time_in_force=time_in_force,
+        quantity=quantity_str,
+        price=price_str,
+        order_amount=order_amount_str,
+    )
+    now = now_kst()
+    client_order_id = client_order_id_override or derive_client_order_id(
+        canonical, market=mkt, now=now, rung=rung
+    )
+    ledger_approval_hash = derive_approval_digest(canonical)
+
+    payload: dict[str, Any] = {
+        "clientOrderId": client_order_id,
+        "symbol": symbol,
+        "side": side.upper(),
+        "orderType": order_type.upper(),
+        "timeInForce": time_in_force,
+    }
+    if quantity_str is not None:
+        payload["quantity"] = quantity_str
+    if price_str is not None:
+        payload["price"] = price_str
+    if order_amount_str is not None:
+        payload["orderAmount"] = order_amount_str
+    if confirm_high_value_order:
+        payload["confirmHighValueOrder"] = True
+```
+
+Then, immediately **after** `base_response = {...}` and the existing `_client_order_id_error` guard, and **before** the `if dry_run:` return, insert the approval gate:
+
+```python
+    mode = getattr(settings, "toss_approval_hash_mode", "optional")
+    if mode != "off":
+        if approval_hash is not None:
+            result = verify_approval_token(approval_hash, canonical, now=now)
+            if not result.ok:
+                err = {
+                    "success": False,
+                    **base_response,
+                    "error": result.message,
+                    "error_code": result.error_code,
+                }
+                if result.diff is not None:
+                    err["diff"] = result.diff
+                return err
+        elif mode == "required":
+            return {
+                "success": False,
+                **base_response,
+                "error": (
+                    "toss_place_order requires approval_hash "
+                    "(TOSS_APPROVAL_HASH_MODE=required). Re-preview and pass "
+                    "approval_hash from toss_preview_order."
+                ),
+                "error_code": "approval_hash_required",
+            }
+        elif mode == "warn":
+            logger.warning(
+                "toss_place_order called without approval_hash "
+                "(mode=warn) symbol=%s side=%s",
+                symbol,
+                side,
+            )
+```
+
+Finally, pass the digest into the ledger write. In the `record_toss_place_order(...)` call inside `execute_order`, add (after `report_item_uuid=report_item_uuid,`):
+
+```python
+                approval_hash=ledger_approval_hash,
+```
+
+> **NOTE:** `now_kst` is already imported (Task 3). `client_order_id_override` stays a real parameter but `toss_place_order` keeps passing `None`, so the deterministic id is always used from the public tool. The two dry-run/confirm return paths already spread `base_response` which carries `client_order_id`.
+
+- [ ] **Step 5: Thread the new params through `toss_place_order`**
+
+In `toss_place_order`'s signature add `approval_hash: str | None = None,` and `rung: str | int | None = None,` (after `account_type: str | None = None,`), and pass them into the `_toss_place_order_impl(...)` call (add alongside the existing kwargs, keeping `client_order_id_override=None`):
+
+```python
+        approval_hash=approval_hash,
+        rung=rung,
+```
+
+- [ ] **Step 6: Run the new place tests**
+
+Run: `uv run pytest tests/test_mcp_toss_order_variants.py -q -k "place_dry_run_matching or mismatched_hash or expired_hash or optional_mode or required_mode"`
+Expected: PASS.
+
+- [ ] **Step 7: Run the full Toss suite + ledger + module (no regressions)**
+
+Run: `uv run pytest tests/test_mcp_toss_order_variants.py tests/test_mcp_toss_order_variants_rob561.py tests/test_toss_approval.py tests/test_rob538_toss_live_ledger_schema.py -q`
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add app/core/config.py app/mcp_server/tooling/orders_toss_variants.py \
+        tests/test_mcp_toss_order_variants.py
+git commit -m "feat(ROB-651): toss_place_order approval_hash verification + rollout mode gate
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Idempotency integration test + docs + lint
+
+**Files:**
+- Test: `tests/test_mcp_toss_order_variants.py`
+- Modify: `CLAUDE.md` (Toss section — document `approval_hash` + `rung` + `TOSS_APPROVAL_HASH_MODE`)
+- Modify: `env.example` (add `TOSS_APPROVAL_HASH_MODE=optional` comment line)
+
+**Interfaces:**
+- Consumes: everything from Tasks 1–4.
+- Produces: acceptance-criteria coverage test; operator-facing docs.
+
+- [ ] **Step 1: Write the idempotency (same-day vs next-day) test**
+
+Add to `tests/test_mcp_toss_order_variants.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_client_order_id_same_day_stable_next_day_new(monkeypatch):
+    from datetime import datetime
+
+    from app.core.timezone import KST
+    from app.mcp_server.tooling import orders_toss_variants as otv
+
+    def _prev():
+        return otv.toss_preview_order(
+            symbol="005930", side="buy", order_type="limit",
+            quantity="10", price="70000", market="kr",
+        )
+
+    monkeypatch.setattr(otv, "now_kst", lambda: datetime(2026, 7, 2, 10, 0, tzinfo=KST))
+    day1_a = await _prev()
+    monkeypatch.setattr(otv, "now_kst", lambda: datetime(2026, 7, 2, 15, 0, tzinfo=KST))
+    day1_b = await _prev()
+    monkeypatch.setattr(otv, "now_kst", lambda: datetime(2026, 7, 3, 10, 0, tzinfo=KST))
+    day2 = await _prev()
+
+    cid1a = day1_a["payload_preview"]["clientOrderId"]
+    cid1b = day1_b["payload_preview"]["clientOrderId"]
+    cid2 = day2["payload_preview"]["clientOrderId"]
+    assert cid1a == cid1b  # same trading day -> broker/ledger dedupe key
+    assert cid1a != cid2   # next trading day -> new order allowed
+```
+
+- [ ] **Step 2: Run it**
+
+Run: `uv run pytest tests/test_mcp_toss_order_variants.py -q -k "same_day_stable_next_day"`
+Expected: PASS.
+
+- [ ] **Step 3: Document in CLAUDE.md**
+
+In `CLAUDE.md`, under the "토스증권 Open API (ROB-529)" section, append a bullet:
+
+```markdown
+- **ROB-651 (P6-A)**: `toss_preview_order`가 정규화(tick-snap) 이후 `approval_hash`(self-contained 토큰, TTL 5분) + `approval_expires_at`를 반환. `toss_place_order(approval_hash=...)`는 자기 파라미터로 canonical을 재계산해 불일치/만료 시 fail-closed(`error_code` + `diff`). 롤아웃 `TOSS_APPROVAL_HASH_MODE ∈ {off,optional,warn,required}`(기본 `optional`, 백컴팻). `clientOrderId`는 uuid4 → 결정적 `tossp6-<sha16>(canonical|거래일salt|rung)` 멱등키(KR=KST/US=ET 거래일; 같은 거래일 동일주문 dedupe, 익일 신규). 같은 날 진짜 동일 두 번째 주문은 `rung` discriminator로 분리. 컬럼: `review.toss_live_order_ledger.approval_hash`(digest). 공유경로(KIS/Upbit)는 ROB-653 P6-B.
+```
+
+- [ ] **Step 4: Document in env.example**
+
+In `env.example`, near the Toss env vars, add:
+
+```bash
+# ROB-651 P6-A — Toss preview→place approval-hash 강제 수준 (off|optional|warn|required)
+TOSS_APPROVAL_HASH_MODE=optional
+```
+
+- [ ] **Step 5: Lint the whole change**
+
+Run: `uv run ruff format app/ tests/ && uv run ruff check app/ tests/`
+Expected: no errors; if `ruff check` reports fixable issues, run `uv run ruff check --fix app/ tests/` and re-run.
+
+- [ ] **Step 6: Full targeted regression run**
+
+Run:
+```bash
+uv run pytest tests/test_toss_approval.py tests/test_mcp_toss_order_variants.py \
+  tests/test_mcp_toss_order_variants_rob561.py tests/test_rob538_toss_live_ledger_schema.py -q
+```
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add tests/test_mcp_toss_order_variants.py CLAUDE.md env.example
+git commit -m "test(ROB-651): idempotency same-day/next-day coverage + docs
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- §1 canonical / two derived values → Task 1 (`build_canonical_payload`, `derive_approval_digest`, `derive_client_order_id`) ✅
+- §2 stateless token / TTL / diff → Task 1 (`encode/decode/verify_approval_token`) + Task 4 (gate) ✅
+- §3 deterministic clientOrderId always ON → Task 3 (preview) + Task 4 (place, `client_order_id_override or derive_...`) ✅
+- §4 rollout config gate → Task 4 (`toss_approval_hash_mode` off/optional/warn/required) ✅
+- §5 ledger additive column + migration + record_send/wrapper + replay-unchanged → Task 2 ✅
+- §6 tool surface (preview response keys, place params, `rung`) → Tasks 3 & 4 ✅
+- Acceptance: mismatch fail-closed + diff (Task 4 test), same-day/next-day (Task 5 test), TTL expiry (Task 4 test), back-compat optional (Task 4 test) ✅
+
+**Placeholder scan:** No TBD/TODO/"handle edge cases" placeholders; every code step carries full code.
+
+**Type consistency:** `approval_hash` names two related values by design and this is called out in the spec/plan — the tool **param/response** `approval_hash` is the *token* (`p6a1.…`); the **ledger column** `approval_hash` stores the *digest* (`p6a-…`, from `derive_approval_digest`). `derive_client_order_id`, `verify_approval_token`, `ApprovalResult.error_code` names match across Tasks 1/3/4. `now_kst` is imported and referenced as a module attribute in Tasks 3–5 so monkeypatch works.
+
+**Open confirmation for implementer (does not block):** fixture name in `tests/test_rob538_toss_live_ledger_schema.py` (Task 2 Step 9) and the existing `_client_context`/warnings monkeypatch pattern in `tests/test_mcp_toss_order_variants.py` (Tasks 3–5) — reuse existing, do not invent.

--- a/docs/superpowers/specs/2026-07-02-rob-651-toss-approval-hash-idempotency-design.md
+++ b/docs/superpowers/specs/2026-07-02-rob-651-toss-approval-hash-idempotency-design.md
@@ -1,0 +1,132 @@
+# ROB-651 P6-A — Toss preview→place approval-hash 바인딩 + 콘텐츠 기반 clientOrderId (KST/ET 거래일 salt) 멱등키
+
+- **Linear**: ROB-651 (parent ROB-644; blocks ROB-653 P6-B; blocked-by ROB-645 — merged `75ee8878`)
+- **Date**: 2026-07-02
+- **Scope**: Toss 라이브 주문(`toss_preview_order` / `toss_place_order`)만. 공유 경로(KIS/Upbit)는 P6-B(ROB-653) 후속.
+
+## 문제
+
+`toss_preview_order`와 `toss_place_order`는 **독립 호출**로 각자 payload를 구성한다. 프리뷰한 것과 다른 주문이 나가도 아무것도 막지 않는다. `clientOrderId`는 place마다 uuid4 신규 발급(`orders_toss_variants.py:191-192`, `:827`)이라 동일 주문을 실수로 두 번 제출해도 브로커/레저가 dedupe하지 못한다.
+
+정확한 선례가 리포에 존재한다: `alpaca_paper_orders.py:74-93` — `_canonical_payload` + `client_order_id = prefix + sha256(canonical JSON)[:16]`, preview/submit 동일 재계산 = 콘텐츠 바인딩 멱등(paper 전용).
+
+## 확정 스펙 결정 (2026-07-02)
+
+1. **TTL = 5분** — 프리뷰 후 재프리뷰 없이 place 가능한 유효시간.
+2. **amount 기반 매수(orderAmount, quantity 없음)** = wire payload 그대로 해시. orderAmount는 wire payload에 결정적으로 존재하므로 그대로 sha256. quantity 강제 없음.
+3. **롤아웃 기본값 = `optional`** — config 게이트로 `off / optional / warn / required` 승격.
+4. **거래일 salt = 시장별** — KR = KST 날짜, US = ET 날짜(America/New_York, DST 반영). US 세션이 KST 자정을 넘어도 같은 거래일 → 자정경계 재시도 이중제출 방지.
+5. **승인 주체 = operator confirm-as-approval** (이슈 §5). 제2 주체가 없어 creator≠approver 분리는 collapse. hash의 실질 가치는 "프리뷰한 것만 실행됨" 보장 — 사고(프리뷰≠실행) 방지용이지 악의적 호출자 방어가 아님.
+
+## 설계
+
+### 1. Canonical payload (프리뷰/플레이스 공통 재계산)
+
+tick-snap **이후** wire payload에서 경제적 의도를 정의하는 필드만 정규화. `clientOrderId`(파생값이라 순환), `confirmHighValueOrder`(오퍼레이터 플래그, 경제적 의도 아님)는 **제외**.
+
+```python
+canonical = {
+    "market": mkt,             # kr | us  (동일 심볼 KR/US 구분)
+    "symbol": symbol,
+    "side": side.upper(),      # BUY | SELL
+    "orderType": order_type.upper(),   # LIMIT | MARKET
+    "timeInForce": time_in_force,      # DAY | CLS
+    "quantity": <str|None>,
+    "price": <snap된 str|None>,
+    "orderAmount": <str|None>,
+}
+canonical_json = json.dumps(canonical, sort_keys=True, separators=(",", ":"))
+```
+
+두 값을 파생:
+
+- **approval_digest (content digest)** = `f"p6a-{sha256(canonical_json)[:16]}"` — 레저 `approval_hash` 컬럼에 저장, 로그·프리뷰 응답에 노출. "프리뷰한 것 = 실행되는 것" 바인딩.
+- **clientOrderId (멱등키)** = `f"tossp6-{sha256(f'{canonical_json}|{trading_day}|{rung}'.encode())[:16]}"` (`rung` 없으면 빈 문자열). 23자, 영숫자+dash → `_client_order_id_error` safe-segment 통과.
+  - `trading_day` = `_trading_day_salt(market)`: KR → `now_kst().date().isoformat()`, US → `now.astimezone(ZoneInfo("America/New_York")).date().isoformat()`.
+
+### 2. TTL/diff 전달 — stateless token (Redis 미사용)
+
+`toss_place_order`의 `approval_hash` 파라미터는 프리뷰가 돌려준 **self-contained 토큰**:
+
+```
+approval_hash = "p6a1." + base64url(json.dumps(
+    {"iat": <issued_epoch_int>, "canon": <canonical dict>},
+    sort_keys=True, separators=(",", ":"),
+))
+```
+
+place 검증 흐름:
+
+1. 토큰 파싱 실패/버전 불일치 → fail-closed(`invalid_approval_hash`).
+2. `now_epoch - iat > 300` → fail-closed(`approval_expired`, "re-preview required").
+3. place 자기 파라미터로 `canonical`을 **재계산** → 토큰의 `canon`과 필드별 비교.
+   - 불일치 → fail-closed(`approval_hash_mismatch`) + `diff`(프리뷰 canon vs 재계산 canon의 상이 필드 dict).
+4. 일치 & TTL 유효 → 진행. 레저에 `approval_digest` 저장.
+
+**stateless 선택 근거**: place 경로에 Redis 의존 추가 없음(Redis 다운이 라이브 주문을 차단하는 실패모드 회피), 완전 결정적 테스트(`now` 주입), 재계산으로 content 바인딩. 단일 오퍼레이터 신뢰모델(§5)이라 토큰 위변조는 위협모델 밖. `diff`는 토큰에 canon을 임베드하므로 정확한 필드 단위로 산출 가능.
+
+### 3. 결정적 clientOrderId — 기본 ON
+
+uuid4 대신 결정적 해시가 **기본 동작**. hash 미제공(optional 단계)이어도 적용 — 이게 실질 이중제출 방지 핵심이고 strictly safer.
+
+- 같은 거래일 · 같은 rung · 같은 payload → 같은 clientOrderId → 브로커 dedupe + 레저 `record_send` replay(기존 행 반환).
+- 익일 → `trading_day` salt 변경 → 신규 clientOrderId → 신규 주문 성공.
+- **같은 날 진짜 동일한 두 번째 주문**이 필요하면 `rung` discriminator로 분리(문서화).
+
+### 4. 롤아웃 게이트 (config)
+
+`Settings`에 `toss_approval_hash_mode: str = "optional"` 추가 (env `TOSS_APPROVAL_HASH_MODE`), 값 ∈ `{off, optional, warn, required}`:
+
+| mode | hash 제공 | hash 미제공 |
+|------|-----------|-------------|
+| `off` | 무시(검증 안 함) | 진행 |
+| `optional`(기본) | 검증(불일치/만료 → fail-closed) | 진행(백컴팻) |
+| `warn` | 검증 | 경고 로그 후 진행 |
+| `required` | 검증 | fail-closed(`approval_hash_required`) |
+
+결정적 clientOrderId는 mode와 무관하게 항상 ON.
+
+### 5. 레저 & 마이그레이션
+
+- `review.toss_live_order_ledger`에 `approval_hash` **additive nullable Text 컬럼** (마이그레이션 1개, `down_revision` = 현재 head).
+- `TossLiveOrderLedgerService.record_send` + `record_toss_place_order` 래퍼에 optional `approval_hash: str | None = None` 파라미터 추가.
+- **replay 계약 불변**: `client_order_id` 기준 query-first replay(`toss_live_order_ledger_service.py:66-155`) 그대로. 기존 행 반환 시 approval_hash 덮어쓰지 않음.
+
+### 6. 도구 표면 변경
+
+- `toss_preview_order`: 응답에 `approval_hash`(토큰), `approval_expires_at`(ISO KST, now+5min), `payload_preview.clientOrderId`(결정적). optional `rung: str | int | None = None` 파라미터.
+- `toss_place_order`: optional `approval_hash: str | None = None`, optional `rung: str | int | None = None`.
+- `_toss_place_order_impl`이 실제 검증/파생 수행. `toss_place_order`는 두 신규 인자를 통과시킴(기존 `client_order_id_override=None` 봉인 유지 — override는 이제 결정적 파생으로 대체되므로 계속 None).
+
+## 테스트 계획 (TDD)
+
+**순수 유닛 (DB/네트워크 불필요):**
+- `canonical` 안정성: 동일 입력 → 동일 digest; tick-snap 반영; quantity/price/orderAmount None 조합.
+- 토큰 encode/decode roundtrip; 버전/base64 손상 → 파싱 실패.
+- content 불일치 → `diff`에 상이 필드만.
+- TTL: `iat` 주입, `now` 주입 → 300s 경계 만료/유효.
+- clientOrderId 결정성 + `trading_day` 변화(KST/ET, `now` 주입) + `rung` 변화로 키 분기.
+- amount 기반(orderAmount만) 해시 성립.
+
+**도구 레벨:**
+- preview→place happy path: preview의 approval_hash를 place에 전달 → 일치 통과(dry_run).
+- place 파라미터가 preview와 다름 → mismatch fail-closed + diff.
+- 만료 토큰 → `approval_expired`.
+- mode `optional` + hash 없음 → 통과; `required` + hash 없음 → fail-closed; `warn` + 없음 → 경고 후 통과.
+- 같은 거래일 재제출 → 동일 clientOrderId(레저 replay); 익일(`now` 주입) → 신규 clientOrderId.
+
+**레저:**
+- `record_send`에 approval_hash 저장; replay 시 기존 행 approval_hash 불변.
+
+## 수용 기준 (이슈)
+
+- ✅ hash 불일치 place가 fail-closed + diff 사유
+- ✅ 동일 payload 같은 날 재제출 → 브로커/레저 dedupe, 익일 재제출 → 신규 주문 성공
+- ✅ TTL 만료 hash → 재프리뷰 요구 에러
+- ✅ 기존 `toss_place_order` 호출(optional 단계) 백컴팻
+
+## 비목표 / 후속
+
+- KIS/Upbit 공유 `_place_order_impl` 포팅 → P6-B(ROB-653).
+- `warn`/`required` 승격 = 운영자 cutover 결정(이 PR은 `optional` 기본).
+- `toss_modify_order`는 이번 스코프 밖(place 바인딩 우선).

--- a/env.example
+++ b/env.example
@@ -442,6 +442,8 @@ TOSS_API_BASE_URL=https://openapi.tossinvest.com
 # Arms live order mutations (place/modify/cancel) AND the holdings sellability
 # / orderable-cash / tradeability surfaces (ROB-549). Keep false until cleared.
 TOSS_LIVE_ORDER_MUTATIONS_ENABLED=false
+# ROB-651 P6-A — Toss preview→place approval-hash 강제 수준 (off|optional|warn|required)
+TOSS_APPROVAL_HASH_MODE=optional
 
 # ========================================
 # WATCH_NOTIFY 설정 (ROB-566)

--- a/tests/services/test_toss_live_order_ledger_service.py
+++ b/tests/services/test_toss_live_order_ledger_service.py
@@ -369,3 +369,36 @@ async def test_update_reconcile_outcome_records_us_fx_fields(db_session):
     assert refreshed.fx_pnl_krw == Decimal("22772.00")
     assert refreshed.fx_rate_source == "reconcile_spot"
     assert refreshed.fx_pnl_accuracy == "approximate"
+
+
+# ROB-651 P6-A — record_send stores approval_hash on insert only;
+# a replay with the same client_order_id must keep the original hash.
+
+
+async def test_record_send_stores_approval_hash(db_session):
+    svc = TossLiveOrderLedgerService(db_session)
+
+    row = await svc.record_send(
+        **_place_kwargs(
+            client_order_id="cid-approval-hash",
+            broker_order_id="ord-approval-hash",
+        ),
+        approval_hash="p6a-abc123abc123abc1",
+    )
+
+    assert row.approval_hash == "p6a-abc123abc123abc1"
+
+
+async def test_record_send_replay_keeps_original_approval_hash(db_session):
+    svc = TossLiveOrderLedgerService(db_session)
+
+    common = _place_kwargs(
+        client_order_id="cid-approval-replay",
+        broker_order_id="ord-approval-replay",
+    )
+    first = await svc.record_send(**common, approval_hash="p6a-original00000000")
+    replay = await svc.record_send(**common, approval_hash="p6a-different0000000")
+
+    assert replay.id == first.id
+    assert replay.approval_hash == "p6a-original00000000"
+

--- a/tests/services/test_toss_live_order_ledger_service.py
+++ b/tests/services/test_toss_live_order_ledger_service.py
@@ -401,4 +401,3 @@ async def test_record_send_replay_keeps_original_approval_hash(db_session):
 
     assert replay.id == first.id
     assert replay.approval_hash == "p6a-original00000000"
-

--- a/tests/test_mcp_toss_order_variants.py
+++ b/tests/test_mcp_toss_order_variants.py
@@ -2136,6 +2136,7 @@ async def test_preview_emits_approval_hash_and_deterministic_client_order_id(
     monkeypatch,
 ):
     from datetime import datetime
+
     from app.core.timezone import KST
 
     otv = _enable_toss_preview(monkeypatch)
@@ -2177,6 +2178,7 @@ async def test_preview_emits_approval_hash_and_deterministic_client_order_id(
 @pytest.mark.asyncio
 async def test_preview_rung_discriminator_changes_client_order_id(monkeypatch):
     from datetime import datetime
+
     from app.core.timezone import KST
 
     otv = _enable_toss_preview(monkeypatch)
@@ -2215,8 +2217,8 @@ async def test_preview_rung_discriminator_changes_client_order_id(monkeypatch):
 @pytest.mark.asyncio
 async def test_place_dry_run_matching_hash_passes(monkeypatch):
     from datetime import datetime
+
     from app.core.timezone import KST
-    from app.mcp_server.tooling import orders_toss_variants as otv
 
     otv = _enable_toss_preview(monkeypatch)
     mock_client = MockTossClient(monkeypatch)
@@ -2254,8 +2256,8 @@ async def test_place_dry_run_matching_hash_passes(monkeypatch):
 @pytest.mark.asyncio
 async def test_place_mismatched_hash_fails_closed_with_diff(monkeypatch):
     from datetime import datetime
+
     from app.core.timezone import KST
-    from app.mcp_server.tooling import orders_toss_variants as otv
 
     otv = _enable_toss_preview(monkeypatch)
     mock_client = MockTossClient(monkeypatch)
@@ -2293,8 +2295,8 @@ async def test_place_mismatched_hash_fails_closed_with_diff(monkeypatch):
 @pytest.mark.asyncio
 async def test_place_expired_hash_requires_repreview(monkeypatch):
     from datetime import datetime, timedelta
+
     from app.core.timezone import KST
-    from app.mcp_server.tooling import orders_toss_variants as otv
 
     otv = _enable_toss_preview(monkeypatch)
     mock_client = MockTossClient(monkeypatch)
@@ -2332,8 +2334,8 @@ async def test_place_expired_hash_requires_repreview(monkeypatch):
 @pytest.mark.asyncio
 async def test_place_optional_mode_without_hash_passes(monkeypatch):
     from datetime import datetime
+
     from app.core.timezone import KST
-    from app.mcp_server.tooling import orders_toss_variants as otv
 
     otv = _enable_toss_preview(monkeypatch)
     mock_client = MockTossClient(monkeypatch)
@@ -2361,8 +2363,8 @@ async def test_place_optional_mode_without_hash_passes(monkeypatch):
 @pytest.mark.asyncio
 async def test_place_required_mode_without_hash_fails_closed(monkeypatch):
     from datetime import datetime
+
     from app.core.timezone import KST
-    from app.mcp_server.tooling import orders_toss_variants as otv
 
     otv = _enable_toss_preview(monkeypatch)
     mock_client = MockTossClient(monkeypatch)
@@ -2386,3 +2388,40 @@ async def test_place_required_mode_without_hash_fails_closed(monkeypatch):
     )
     assert res["success"] is False
     assert res["error_code"] == "approval_hash_required"
+
+
+@pytest.mark.asyncio
+async def test_client_order_id_same_day_stable_next_day_new(monkeypatch):
+    from datetime import datetime
+
+    from app.core.timezone import KST
+
+    otv = _enable_toss_preview(monkeypatch)
+    mock_client = MockTossClient(monkeypatch)
+    mock_client.prices_list = [
+        {"symbol": "005930", "last_price": Decimal("70000"), "currency": "KRW"}
+    ]
+
+    def _prev():
+        return otv.toss_preview_order(
+            symbol="005930",
+            side="buy",
+            order_type="limit",
+            quantity="10",
+            price="70000",
+            market="kr",
+            account_mode="toss_live",
+        )
+
+    monkeypatch.setattr(otv, "now_kst", lambda: datetime(2026, 7, 2, 10, 0, tzinfo=KST))
+    day1_a = await _prev()
+    monkeypatch.setattr(otv, "now_kst", lambda: datetime(2026, 7, 2, 15, 0, tzinfo=KST))
+    day1_b = await _prev()
+    monkeypatch.setattr(otv, "now_kst", lambda: datetime(2026, 7, 3, 10, 0, tzinfo=KST))
+    day2 = await _prev()
+
+    cid1a = day1_a["payload_preview"]["clientOrderId"]
+    cid1b = day1_b["payload_preview"]["clientOrderId"]
+    cid2 = day2["payload_preview"]["clientOrderId"]
+    assert cid1a == cid1b  # same trading day -> broker/ledger dedupe key
+    assert cid1a != cid2  # next trading day -> new order allowed

--- a/tests/test_mcp_toss_order_variants.py
+++ b/tests/test_mcp_toss_order_variants.py
@@ -2391,6 +2391,80 @@ async def test_place_required_mode_without_hash_fails_closed(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_place_warn_mode_without_hash_passes_and_logs(monkeypatch, caplog):
+    import logging
+    from datetime import datetime
+
+    from app.core.timezone import KST
+
+    otv = _enable_toss_preview(monkeypatch)
+    mock_client = MockTossClient(monkeypatch)
+    mock_client.prices_list = [
+        {"symbol": "005930", "last_price": Decimal("70000"), "currency": "KRW"}
+    ]
+
+    monkeypatch.setattr(otv, "now_kst", lambda: datetime(2026, 7, 2, 10, 0, tzinfo=KST))
+    monkeypatch.setattr(otv.settings, "toss_approval_hash_mode", "warn", raising=False)
+
+    with caplog.at_level(logging.WARNING, logger=otv.logger.name):
+        res = await otv.toss_place_order(
+            symbol="005930",
+            side="buy",
+            order_type="limit",
+            quantity="10",
+            price="70000",
+            market="kr",
+            dry_run=True,
+            account_mode="toss_live",
+        )
+    assert res["success"] is True
+    assert any("without approval_hash" in rec.getMessage() for rec in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_place_off_mode_ignores_mismatched_hash(monkeypatch):
+    from datetime import datetime
+
+    from app.core.timezone import KST
+
+    otv = _enable_toss_preview(monkeypatch)
+    mock_client = MockTossClient(monkeypatch)
+    mock_client.prices_list = [
+        {"symbol": "005930", "last_price": Decimal("70000"), "currency": "KRW"}
+    ]
+
+    monkeypatch.setattr(otv, "now_kst", lambda: datetime(2026, 7, 2, 10, 0, tzinfo=KST))
+
+    # Preview under any mode to mint a valid token bound to price=70000.
+    prev = await otv.toss_preview_order(
+        symbol="005930",
+        side="buy",
+        order_type="limit",
+        quantity="10",
+        price="70000",
+        market="kr",
+        account_mode="toss_live",
+    )
+
+    # off mode: verification is skipped entirely, so a token bound to a
+    # *different* order must NOT fail-close.
+    monkeypatch.setattr(otv.settings, "toss_approval_hash_mode", "off", raising=False)
+    res = await otv.toss_place_order(
+        symbol="005930",
+        side="buy",
+        order_type="limit",
+        quantity="10",
+        price="70100",  # differs from the previewed 70000
+        market="kr",
+        dry_run=True,
+        approval_hash=prev["approval_hash"],
+        account_mode="toss_live",
+    )
+    assert res["success"] is True
+    assert "error_code" not in res
+
+
+@pytest.mark.asyncio
 async def test_client_order_id_same_day_stable_next_day_new(monkeypatch):
     from datetime import datetime
 

--- a/tests/test_mcp_toss_order_variants.py
+++ b/tests/test_mcp_toss_order_variants.py
@@ -2210,3 +2210,179 @@ async def test_preview_rung_discriminator_changes_client_order_id(monkeypatch):
         base["payload_preview"]["clientOrderId"]
         != r2["payload_preview"]["clientOrderId"]
     )
+
+
+@pytest.mark.asyncio
+async def test_place_dry_run_matching_hash_passes(monkeypatch):
+    from datetime import datetime
+    from app.core.timezone import KST
+    from app.mcp_server.tooling import orders_toss_variants as otv
+
+    otv = _enable_toss_preview(monkeypatch)
+    mock_client = MockTossClient(monkeypatch)
+    mock_client.prices_list = [
+        {"symbol": "005930", "last_price": Decimal("70000"), "currency": "KRW"}
+    ]
+
+    monkeypatch.setattr(otv, "now_kst", lambda: datetime(2026, 7, 2, 10, 0, tzinfo=KST))
+
+    prev = await otv.toss_preview_order(
+        symbol="005930",
+        side="buy",
+        order_type="limit",
+        quantity="10",
+        price="70000",
+        market="kr",
+        account_mode="toss_live",
+    )
+    res = await otv.toss_place_order(
+        symbol="005930",
+        side="buy",
+        order_type="limit",
+        quantity="10",
+        price="70000",
+        market="kr",
+        dry_run=True,
+        approval_hash=prev["approval_hash"],
+        account_mode="toss_live",
+    )
+    assert res["success"] is True
+    # placed clientOrderId matches previewed (idempotent)
+    assert res["client_order_id"] == prev["payload_preview"]["clientOrderId"]
+
+
+@pytest.mark.asyncio
+async def test_place_mismatched_hash_fails_closed_with_diff(monkeypatch):
+    from datetime import datetime
+    from app.core.timezone import KST
+    from app.mcp_server.tooling import orders_toss_variants as otv
+
+    otv = _enable_toss_preview(monkeypatch)
+    mock_client = MockTossClient(monkeypatch)
+    mock_client.prices_list = [
+        {"symbol": "005930", "last_price": Decimal("70000"), "currency": "KRW"}
+    ]
+
+    monkeypatch.setattr(otv, "now_kst", lambda: datetime(2026, 7, 2, 10, 0, tzinfo=KST))
+
+    prev = await otv.toss_preview_order(
+        symbol="005930",
+        side="buy",
+        order_type="limit",
+        quantity="10",
+        price="70000",
+        market="kr",
+        account_mode="toss_live",
+    )
+    res = await otv.toss_place_order(
+        symbol="005930",
+        side="buy",
+        order_type="limit",
+        quantity="10",
+        price="70100",
+        market="kr",  # price differs
+        dry_run=True,
+        approval_hash=prev["approval_hash"],
+        account_mode="toss_live",
+    )
+    assert res["success"] is False
+    assert res["error_code"] == "approval_hash_mismatch"
+    assert "price" in res["diff"]
+
+
+@pytest.mark.asyncio
+async def test_place_expired_hash_requires_repreview(monkeypatch):
+    from datetime import datetime, timedelta
+    from app.core.timezone import KST
+    from app.mcp_server.tooling import orders_toss_variants as otv
+
+    otv = _enable_toss_preview(monkeypatch)
+    mock_client = MockTossClient(monkeypatch)
+    mock_client.prices_list = [
+        {"symbol": "005930", "last_price": Decimal("70000"), "currency": "KRW"}
+    ]
+
+    issued = datetime(2026, 7, 2, 10, 0, tzinfo=KST)
+    monkeypatch.setattr(otv, "now_kst", lambda: issued)
+    prev = await otv.toss_preview_order(
+        symbol="005930",
+        side="buy",
+        order_type="limit",
+        quantity="10",
+        price="70000",
+        market="kr",
+        account_mode="toss_live",
+    )
+    monkeypatch.setattr(otv, "now_kst", lambda: issued + timedelta(seconds=301))
+    res = await otv.toss_place_order(
+        symbol="005930",
+        side="buy",
+        order_type="limit",
+        quantity="10",
+        price="70000",
+        market="kr",
+        dry_run=True,
+        approval_hash=prev["approval_hash"],
+        account_mode="toss_live",
+    )
+    assert res["success"] is False
+    assert res["error_code"] == "approval_expired"
+
+
+@pytest.mark.asyncio
+async def test_place_optional_mode_without_hash_passes(monkeypatch):
+    from datetime import datetime
+    from app.core.timezone import KST
+    from app.mcp_server.tooling import orders_toss_variants as otv
+
+    otv = _enable_toss_preview(monkeypatch)
+    mock_client = MockTossClient(monkeypatch)
+    mock_client.prices_list = [
+        {"symbol": "005930", "last_price": Decimal("70000"), "currency": "KRW"}
+    ]
+
+    monkeypatch.setattr(otv, "now_kst", lambda: datetime(2026, 7, 2, 10, 0, tzinfo=KST))
+    monkeypatch.setattr(
+        otv.settings, "toss_approval_hash_mode", "optional", raising=False
+    )
+    res = await otv.toss_place_order(
+        symbol="005930",
+        side="buy",
+        order_type="limit",
+        quantity="10",
+        price="70000",
+        market="kr",
+        dry_run=True,
+        account_mode="toss_live",
+    )
+    assert res["success"] is True
+
+
+@pytest.mark.asyncio
+async def test_place_required_mode_without_hash_fails_closed(monkeypatch):
+    from datetime import datetime
+    from app.core.timezone import KST
+    from app.mcp_server.tooling import orders_toss_variants as otv
+
+    otv = _enable_toss_preview(monkeypatch)
+    mock_client = MockTossClient(monkeypatch)
+    mock_client.prices_list = [
+        {"symbol": "005930", "last_price": Decimal("70000"), "currency": "KRW"}
+    ]
+
+    monkeypatch.setattr(otv, "now_kst", lambda: datetime(2026, 7, 2, 10, 0, tzinfo=KST))
+    monkeypatch.setattr(
+        otv.settings, "toss_approval_hash_mode", "required", raising=False
+    )
+    res = await otv.toss_place_order(
+        symbol="005930",
+        side="buy",
+        order_type="limit",
+        quantity="10",
+        price="70000",
+        market="kr",
+        dry_run=True,
+        account_mode="toss_live",
+    )
+    assert res["success"] is False
+    assert res["error_code"] == "approval_hash_required"

--- a/tests/test_mcp_toss_order_variants.py
+++ b/tests/test_mcp_toss_order_variants.py
@@ -2129,3 +2129,84 @@ async def test_private_place_impl_rejects_whitespace_padded_client_order_id_over
     assert result["success"] is False
     assert "Unsafe client order id rejected" in result["error"]
     assert not mock_client.placed_payloads
+
+
+@pytest.mark.asyncio
+async def test_preview_emits_approval_hash_and_deterministic_client_order_id(
+    monkeypatch,
+):
+    from datetime import datetime
+    from app.core.timezone import KST
+
+    otv = _enable_toss_preview(monkeypatch)
+    mock_client = MockTossClient(monkeypatch)
+    mock_client.prices_list = [
+        {"symbol": "005930", "last_price": Decimal("70000"), "currency": "KRW"}
+    ]
+
+    fixed = datetime(2026, 7, 2, 10, 0, tzinfo=KST)
+    monkeypatch.setattr(otv, "now_kst", lambda: fixed)
+
+    res1 = await otv.toss_preview_order(
+        symbol="005930",
+        side="buy",
+        order_type="limit",
+        quantity="10",
+        price="70000",
+        market="kr",
+        account_mode="toss_live",
+    )
+    res2 = await otv.toss_preview_order(
+        symbol="005930",
+        side="buy",
+        order_type="limit",
+        quantity="10",
+        price="70000",
+        market="kr",
+        account_mode="toss_live",
+    )
+    assert res1["success"] is True
+    assert res1["approval_hash"].startswith("p6a1.")
+    assert res1["approval_expires_at"]  # ISO string
+    cid = res1["payload_preview"]["clientOrderId"]
+    assert cid.startswith("tossp6-")
+    # deterministic: identical params + same trading day -> identical id + token payload
+    assert res2["payload_preview"]["clientOrderId"] == cid
+
+
+@pytest.mark.asyncio
+async def test_preview_rung_discriminator_changes_client_order_id(monkeypatch):
+    from datetime import datetime
+    from app.core.timezone import KST
+
+    otv = _enable_toss_preview(monkeypatch)
+    mock_client = MockTossClient(monkeypatch)
+    mock_client.prices_list = [
+        {"symbol": "005930", "last_price": Decimal("70000"), "currency": "KRW"}
+    ]
+
+    monkeypatch.setattr(otv, "now_kst", lambda: datetime(2026, 7, 2, 10, 0, tzinfo=KST))
+
+    base = await otv.toss_preview_order(
+        symbol="005930",
+        side="buy",
+        order_type="limit",
+        quantity="10",
+        price="70000",
+        market="kr",
+        account_mode="toss_live",
+    )
+    r2 = await otv.toss_preview_order(
+        symbol="005930",
+        side="buy",
+        order_type="limit",
+        quantity="10",
+        price="70000",
+        market="kr",
+        rung=2,
+        account_mode="toss_live",
+    )
+    assert (
+        base["payload_preview"]["clientOrderId"]
+        != r2["payload_preview"]["clientOrderId"]
+    )

--- a/tests/test_rob538_toss_live_ledger_schema.py
+++ b/tests/test_rob538_toss_live_ledger_schema.py
@@ -60,3 +60,10 @@ def test_toss_live_order_ledger_is_exported():
     import app.models as models
 
     assert hasattr(models, "TossLiveOrderLedger")
+
+
+def test_toss_live_order_ledger_has_approval_hash_column():
+    from app.models.review import TossLiveOrderLedger
+
+    col = TossLiveOrderLedger.__table__.columns["approval_hash"]
+    assert col.nullable is True

--- a/tests/test_toss_approval.py
+++ b/tests/test_toss_approval.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 from datetime import datetime, timedelta
 from zoneinfo import ZoneInfo
 
-import pytest
-
 from app.core.timezone import KST
 from app.mcp_server.tooling.toss_approval import (
     APPROVAL_TTL_SECONDS,
@@ -21,16 +19,16 @@ _ET = ZoneInfo("America/New_York")
 
 
 def _canon(**overrides):
-    base = dict(
-        market="kr",
-        symbol="005930",
-        side="buy",
-        order_type="limit",
-        time_in_force="DAY",
-        quantity="10",
-        price="70000",
-        order_amount=None,
-    )
+    base = {
+        "market": "kr",
+        "symbol": "005930",
+        "side": "buy",
+        "order_type": "limit",
+        "time_in_force": "DAY",
+        "quantity": "10",
+        "price": "70000",
+        "order_amount": None,
+    }
     base.update(overrides)
     return build_canonical_payload(**base)
 
@@ -67,18 +65,18 @@ def test_trading_day_salt_kr_uses_kst_us_uses_et():
 def test_client_order_id_deterministic_same_day():
     now = datetime(2026, 7, 2, 10, 0, tzinfo=KST)
     canon = _canon()
-    assert derive_client_order_id(canon, market="kr", now=now) == derive_client_order_id(
+    assert derive_client_order_id(
         canon, market="kr", now=now
-    )
+    ) == derive_client_order_id(canon, market="kr", now=now)
 
 
 def test_client_order_id_changes_next_trading_day():
     canon = _canon()
     today = datetime(2026, 7, 2, 10, 0, tzinfo=KST)
     tomorrow = datetime(2026, 7, 3, 10, 0, tzinfo=KST)
-    assert derive_client_order_id(canon, market="kr", now=today) != derive_client_order_id(
-        canon, market="kr", now=tomorrow
-    )
+    assert derive_client_order_id(
+        canon, market="kr", now=today
+    ) != derive_client_order_id(canon, market="kr", now=tomorrow)
 
 
 def test_client_order_id_rung_discriminator_splits():

--- a/tests/test_toss_approval.py
+++ b/tests/test_toss_approval.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from app.core.timezone import KST
+from app.mcp_server.tooling.toss_approval import (
+    APPROVAL_TTL_SECONDS,
+    build_canonical_payload,
+    decode_approval_token,
+    derive_approval_digest,
+    derive_client_order_id,
+    encode_approval_token,
+    trading_day_salt,
+    verify_approval_token,
+)
+
+_ET = ZoneInfo("America/New_York")
+
+
+def _canon(**overrides):
+    base = dict(
+        market="kr",
+        symbol="005930",
+        side="buy",
+        order_type="limit",
+        time_in_force="DAY",
+        quantity="10",
+        price="70000",
+        order_amount=None,
+    )
+    base.update(overrides)
+    return build_canonical_payload(**base)
+
+
+def test_canonical_uppercases_and_is_stable():
+    a = _canon()
+    b = _canon()
+    assert a == b
+    assert a["side"] == "BUY"
+    assert a["orderType"] == "LIMIT"
+    assert derive_approval_digest(a) == derive_approval_digest(b)
+
+
+def test_canonical_price_change_changes_digest():
+    assert derive_approval_digest(_canon(price="70000")) != derive_approval_digest(
+        _canon(price="70100")
+    )
+
+
+def test_amount_based_buy_hashes_wire_payload():
+    canon = _canon(quantity=None, price=None, order_amount="1000000")
+    digest = derive_approval_digest(canon)
+    assert digest.startswith("p6a-")
+    assert len(digest) == len("p6a-") + 16
+
+
+def test_trading_day_salt_kr_uses_kst_us_uses_et():
+    # 2026-07-02 23:30 KST == 2026-07-02 10:30 ET (same US calendar date here)
+    now = datetime(2026, 7, 2, 23, 30, tzinfo=KST)
+    assert trading_day_salt("kr", now) == "2026-07-02"
+    assert trading_day_salt("us", now) == now.astimezone(_ET).date().isoformat()
+
+
+def test_client_order_id_deterministic_same_day():
+    now = datetime(2026, 7, 2, 10, 0, tzinfo=KST)
+    canon = _canon()
+    assert derive_client_order_id(canon, market="kr", now=now) == derive_client_order_id(
+        canon, market="kr", now=now
+    )
+
+
+def test_client_order_id_changes_next_trading_day():
+    canon = _canon()
+    today = datetime(2026, 7, 2, 10, 0, tzinfo=KST)
+    tomorrow = datetime(2026, 7, 3, 10, 0, tzinfo=KST)
+    assert derive_client_order_id(canon, market="kr", now=today) != derive_client_order_id(
+        canon, market="kr", now=tomorrow
+    )
+
+
+def test_client_order_id_rung_discriminator_splits():
+    now = datetime(2026, 7, 2, 10, 0, tzinfo=KST)
+    canon = _canon()
+    base = derive_client_order_id(canon, market="kr", now=now)
+    r2 = derive_client_order_id(canon, market="kr", now=now, rung=2)
+    assert base != r2
+    assert r2.startswith("tossp6-")
+
+
+def test_client_order_id_is_safe_segment():
+    now = datetime(2026, 7, 2, 10, 0, tzinfo=KST)
+    cid = derive_client_order_id(_canon(), market="kr", now=now)
+    assert cid.replace("-", "").replace("_", "").isalnum()
+    assert len(cid) <= 40
+
+
+def test_token_roundtrip_and_verify_ok():
+    now = datetime(2026, 7, 2, 10, 0, tzinfo=KST)
+    canon = _canon()
+    token = encode_approval_token(canon, now=now)
+    assert token.startswith("p6a1.")
+    iat, decoded = decode_approval_token(token)
+    assert decoded == canon
+    result = verify_approval_token(token, canon, now=now)
+    assert result.ok is True
+    assert result.digest == derive_approval_digest(canon)
+
+
+def test_verify_mismatch_returns_diff():
+    now = datetime(2026, 7, 2, 10, 0, tzinfo=KST)
+    token = encode_approval_token(_canon(price="70000"), now=now)
+    result = verify_approval_token(token, _canon(price="70100"), now=now)
+    assert result.ok is False
+    assert result.error_code == "approval_hash_mismatch"
+    assert "price" in result.diff
+    assert result.diff["price"] == {"previewed": "70000", "placing": "70100"}
+
+
+def test_verify_expired_after_ttl():
+    issued = datetime(2026, 7, 2, 10, 0, tzinfo=KST)
+    token = encode_approval_token(_canon(), now=issued)
+    later = issued + timedelta(seconds=APPROVAL_TTL_SECONDS + 1)
+    result = verify_approval_token(token, _canon(), now=later)
+    assert result.ok is False
+    assert result.error_code == "approval_expired"
+
+
+def test_verify_within_ttl_ok():
+    issued = datetime(2026, 7, 2, 10, 0, tzinfo=KST)
+    token = encode_approval_token(_canon(), now=issued)
+    later = issued + timedelta(seconds=APPROVAL_TTL_SECONDS - 1)
+    assert verify_approval_token(token, _canon(), now=later).ok is True
+
+
+def test_verify_invalid_token():
+    now = datetime(2026, 7, 2, 10, 0, tzinfo=KST)
+    result = verify_approval_token("not-a-token", _canon(), now=now)
+    assert result.ok is False
+    assert result.error_code == "invalid_approval_hash"


### PR DESCRIPTION
## ROB-651 P6-A — Toss preview→place approval-hash 바인딩 + 콘텐츠 기반 clientOrderId 멱등키

Linear: [ROB-651](https://linear.app/mgh3326/issue/ROB-651) (parent ROB-644 · blocks ROB-653 P6-B · blocked-by ROB-645 ✅ merged)

### 문제
`toss_preview_order`와 `toss_place_order`가 **독립 호출**로 각자 payload를 구성 — 프리뷰한 것과 다른 주문이 나가도 막지 못함. `clientOrderId`는 place마다 uuid4 신규 발급이라 동일 주문 실수 재제출을 브로커/레저가 dedupe하지 못함.

### 설계
- **Canonical payload**(tick-snap 이후, `clientOrderId`/`confirmHighValueOrder` 제외)를 preview·place가 동일 재계산해 두 값 파생:
  - **approval_hash 토큰** = `p6a1.<base64(iat+canon)>` — self-contained(TTL 5분 + diff 임베드), **stateless**(Redis 미사용 → place 경로 인프라 의존 0).
  - **clientOrderId** = `tossp6-<sha256(canonical | 거래일salt | rung)[:16]>` — 결정적 멱등키. 거래일 salt는 **KR=KST / US=ET**(자정경계 재시도 이중제출 방지).
- **place 검증**: 자기 파라미터로 canonical 재계산 → 불일치/만료 시 **fail-closed + diff/error_code**. 레저엔 content digest(`p6a-<16hex>`) 저장.
- **롤아웃 게이트** `TOSS_APPROVAL_HASH_MODE ∈ {off, optional, warn, required}` (**기본 `optional`** = 백컴팻). 결정적 clientOrderId는 mode 무관 항상 ON.
- **레저**: `review.toss_live_order_ledger.approval_hash` additive nullable 컬럼(마이그레이션 1개, 단일 head `rob650`에서 체인). `record_send` replay 계약 불변(replay 시 미덮어씀).

### 수용 기준 (전부 테스트 커버)
- ✅ hash 불일치 place → fail-closed + diff (`test_place_mismatched_hash_fails_closed_with_diff`)
- ✅ 같은 거래일 재제출 → dedupe / 익일 → 신규 (`test_client_order_id_same_day_stable_next_day_new`)
- ✅ TTL 만료 → 재프리뷰 요구 (`test_place_expired_hash_requires_repreview`)
- ✅ 기존 호출(optional) 백컴팻 (`test_place_optional_mode_without_hash_passes`)
- ✅ warn/off 모드 (`test_place_warn_mode_without_hash_passes_and_logs`, `test_place_off_mode_ignores_mismatched_hash`)

### 테스트
- 신규 순수 모듈 유닛 14 + 도구레벨 12 (`test_toss_approval.py`, `test_mcp_toss_order_variants.py`)
- toss 전체 회귀 pass · ruff clean · LLM-import 가드/tool-name drift green
- 기존 `record_send` 호출자 23곳 무영향(신규 param keyword-only default None)

### 스코프 / 후속
- **Toss 전용.** KIS/Upbit 공유 `_place_order_impl` 포팅 → **ROB-653 P6-B**.
- `warn`/`required` 승격 = 운영자 cutover 결정(이 PR은 `optional`).

### 배포 (operator)
머지 후: `alembic upgrade head` (rob651 additive 컬럼) + MCP 재시작. 마이그레이션 미실행이어도 컬럼 참조는 write-path에만 있어 read 무영향.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
