### PR TITLE
feat(ROB-646): trading policy YAML single source + get_trading_policy + version stamping + concentration cap

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -705,7 +705,15 @@ pytest tests/ -v -m "not slow"               # 느린 테스트 제외
 - URL: `http://localhost:8000/stock-latest/`
 - 기능: 종목별 최신 분석 결과 조회
 
+### Trading Policy YAML 단일 소스 (ROB-646)
 
+`config/trading_policy.yaml` = 매매 판단 임계값 단일 소스 (ROB-643 플레이북 policy_keys에서 시드). **operator PR로만 편집 — 쓰기 도구 없음.**
+
+- **스키마/로더**: `app/schemas/trading_policy.py`, `app/services/trading_policy_service.py`
+- **MCP 도구**: `get_trading_policy(market, lane)` — market×lane 임계값 + `{version, content_hash}` echo; 없는 키는 `success=false, error=unknown_key`
+- **버전 스탬핑 계약**: 판정 기록(evidence_snapshot·trade_retrospectives·forecast)은 `{version, content_hash}` 인용. `get_operating_briefing`가 run-start에 `policy_version` echo.
+- **강제 범위**: 섹터 클러스터 집중도 cap만 매수 프리뷰에서 코드 검사 (`sector_concentration` 필드, **fail-open** — 경고만, 차단 안 함). 나머지 임계값은 advisory.
+- **관할**: 판단 임계값 전용. fail-closed 코드 가드(손실매도/ladder/RSI 스코어링)·`symbol_trade_settings`(라이브 사이징)·`trade_profile`(dead)와 분리. migration 0.
 
 ## 문제 해결
 

--- a/app/mcp_server/README.md
+++ b/app/mcp_server/README.md
@@ -1318,6 +1318,16 @@ Response shape:
 - `errors`: broker, cash, exchange-rate, or KRX ETF partial failures
 - `warnings`: non-fatal valuation omissions
 
+### `get_trading_policy` spec
+
+- `get_trading_policy(market, lane)`
+  - Query trading policy judgment thresholds.
+  - Read-only, single source `config/trading_policy.yaml`, operator-PR-edited (no write tool).
+  - Args `market ∈ {kr,us,crypto}` × `lane ∈ {buy,sell,discovery}`.
+  - An unknown key maps to `success=false, error=unknown_key`.
+  - **Version-stamping contract**: consumers cite `{version, content_hash}` (from `get_trading_policy` or the `policy_version` field of `get_operating_briefing`) in `report_item.evidence_snapshot`, `trade_retrospectives`, and forecast records so the judging criteria are recoverable.
+  - The buy-preview `sector_concentration` field is **fail-open** advisory (never blocks).
+
 ### User Settings Tools
 
 - `get_user_setting(key)` - Get a user setting value by key. Returns the JSON value or None if not found.

--- a/app/mcp_server/tooling/operating_briefing.py
+++ b/app/mcp_server/tooling/operating_briefing.py
@@ -27,6 +27,7 @@ from app.services.investment_reports.query_service import (
 )
 from app.services.investment_reports.repository import InvestmentReportsRepository
 from app.services.session_context import SessionContextService
+from app.services.trading_policy_service import policy_version_stamp
 
 
 def _normalize_watch_symbol(symbol: str | None, market: str | None) -> str | None:
@@ -371,6 +372,11 @@ async def get_operating_briefing_impl(
             {"source": "account_costs", "error": str(exc)}
         )
 
+    try:
+        policy_version = policy_version_stamp()
+    except Exception as exc:  # noqa: BLE001 — fail-open, briefing must still return
+        policy_version = {"error": str(exc)}
+
     response = {
         "success": True,
         "market": market,
@@ -424,6 +430,7 @@ async def get_operating_briefing_impl(
         "latest_report": latest_report,
         "session_context": session_context,
         "analysis_artifacts": analysis_artifacts,
+        "policy_version": policy_version,
     }
     return OperatingBriefingResponse.model_validate(response).model_dump(mode="json")
 

--- a/app/mcp_server/tooling/order_execution.py
+++ b/app/mcp_server/tooling/order_execution.py
@@ -1190,7 +1190,6 @@ async def _place_order_impl(
             elif market_type == "crypto":
                 mkt_mapped = "crypto"
 
-            acct_name = "upbit" if market_type == "crypto" else "kis"
             cur_mapped = "KRW" if market_type != "equity_us" else "USD"
 
             sector_conc = await evaluate_sector_concentration(
@@ -1198,11 +1197,9 @@ async def _place_order_impl(
                 market=mkt_mapped,
                 order_estimated_value=dry_run_result.get("estimated_value"),
                 order_currency=cur_mapped,
-                account_ctx={
-                    "account": acct_name,
-                    "market": mkt_mapped,
-                    "is_mock": is_mock,
-                },
+                # ROB-646 Finding 1: whole-portfolio scope (no account/market
+                # filter) so KIS and Toss buy paths measure the same denominator.
+                account_ctx={"is_mock": is_mock},
             )
             dry_run_result["sector_concentration"] = sector_conc
             if sector_conc.get("verdict") == "over" and not balance_warning:

--- a/app/mcp_server/tooling/order_execution.py
+++ b/app/mcp_server/tooling/order_execution.py
@@ -40,6 +40,7 @@ from app.mcp_server.tooling.order_validation import (
     _resolve_scalping_exit_context,
     _validate_defensive_trim_preconditions,
     _validate_sell_side,
+    evaluate_sector_concentration,
 )
 from app.mcp_server.tooling.shared import logger
 from app.mcp_server.tooling.shared import (
@@ -1181,6 +1182,31 @@ async def _place_order_impl(
             if dry_run:
                 return _build_dry_run_blocked_response(dry_run_result, balance_error)
             return balance_error
+
+        if side_lower == "buy":
+            mkt_mapped = "kr"
+            if market_type == "equity_us":
+                mkt_mapped = "us"
+            elif market_type == "crypto":
+                mkt_mapped = "crypto"
+
+            acct_name = "upbit" if market_type == "crypto" else "kis"
+            cur_mapped = "KRW" if market_type != "equity_us" else "USD"
+
+            sector_conc = await evaluate_sector_concentration(
+                symbol=normalized_symbol,
+                market=mkt_mapped,
+                order_estimated_value=dry_run_result.get("estimated_value"),
+                order_currency=cur_mapped,
+                account_ctx={
+                    "account": acct_name,
+                    "market": mkt_mapped,
+                    "is_mock": is_mock,
+                },
+            )
+            dry_run_result["sector_concentration"] = sector_conc
+            if sector_conc.get("verdict") == "over" and not balance_warning:
+                balance_warning = sector_conc.get("warning")
 
         # Dry-run exit
         if dry_run:

--- a/app/mcp_server/tooling/order_validation.py
+++ b/app/mcp_server/tooling/order_validation.py
@@ -173,6 +173,10 @@ async def compute_sector_cluster_weights(
     )
     from app.services.trading_policy_service import sector_cluster_for
 
+    # ROB-646 Finding 1: measure against the WHOLE portfolio consistently.
+    # Both call sites pass account_ctx with only ``is_mock`` (no account/market
+    # filter), so the denominator is the full cross-broker book for that
+    # mock/live scope — the KIS and Toss buy paths now agree.
     alloc = await get_portfolio_allocation_impl(
         account=account_ctx.get("account"),
         market=account_ctx.get("market"),
@@ -183,20 +187,39 @@ async def compute_sector_cluster_weights(
     positions = alloc.get("positions") or []
     clusters: dict[str, float] = {}
     total = 0.0
-    async with AsyncSessionLocal() as db:
-        for pos in positions:
-            value_krw = pos.get("value_krw")
-            if value_krw is None:
-                continue
-            total += float(value_krw)
-            label = pos.get("sector") or pos.get("sector_name")
-            if label is None and pos.get("symbol"):
-                label = await _lookup_symbol_sector_label(
-                    db, symbol=str(pos.get("symbol")), market=market
-                )
+    # Positions with no inline sector label need a universe lookup; defer them
+    # so a portfolio of already-labelled holdings never opens a DB session.
+    pending_lookups: list[tuple[str, str, float]] = []
+    for pos in positions:
+        value_krw = pos.get("value_krw")
+        if value_krw is None:
+            continue
+        value = float(value_krw)
+        total += value
+        label = pos.get("sector") or pos.get("sector_name")
+        if label is not None:
             cluster = sector_cluster_for(label)
             if cluster is not None:
-                clusters[cluster] = clusters.get(cluster, 0.0) + float(value_krw)
+                clusters[cluster] = clusters.get(cluster, 0.0) + value
+            continue
+        # ROB-646 Finding 1/5: resolve each holding via its OWN market, not the
+        # buy's market, so a US holding is looked up in the US universe.
+        pos_market = _position_market(pos) or (
+            market if market in ("kr", "us") else None
+        )
+        symbol_val = pos.get("symbol")
+        if pos_market and symbol_val:
+            pending_lookups.append((str(symbol_val), pos_market, value))
+
+    if pending_lookups:
+        async with AsyncSessionLocal() as db:
+            for symbol_val, pos_market, value in pending_lookups:
+                label = await _lookup_symbol_sector_label(
+                    db, symbol=symbol_val, market=pos_market
+                )
+                cluster = sector_cluster_for(label)
+                if cluster is not None:
+                    clusters[cluster] = clusters.get(cluster, 0.0) + value
     return {"clusters": clusters, "total_krw": total, "usd_krw": usd_krw}
 
 
@@ -599,6 +622,21 @@ def _order_value_to_krw(
     if cur in ("USD", "$"):
         rate = float(usd_krw or 0.0)
         return float(value) * rate if rate > 0 else None
+    return None
+
+
+def _position_market(pos: dict[str, Any]) -> str | None:
+    """ROB-646 — map a portfolio position's asset class to its sector-lookup market.
+
+    Returns ``kr`` / ``us`` for equities; ``None`` for crypto / cash / other
+    (which have no sector cluster). Uses ``effective_asset_class`` (falls back to
+    ``surface_asset_class``) from ``get_portfolio_allocation_impl``.
+    """
+    cls = pos.get("effective_asset_class") or pos.get("surface_asset_class")
+    if cls == "kr_equity":
+        return "kr"
+    if cls == "us_equity":
+        return "us"
     return None
 
 

--- a/app/mcp_server/tooling/order_validation.py
+++ b/app/mcp_server/tooling/order_validation.py
@@ -156,9 +156,18 @@ async def compute_sector_cluster_weights(
 
     ROB-646 — reuses ``get_portfolio_allocation_impl(include_positions=True)`` for
     per-position KRW values + ``usd_krw``, joins each holding's sector label to
-    ``sector_cluster_for``, and groups by sector cluster. May raise on any data
-    gap; the orchestrator (``evaluate_sector_concentration``) fails open.
+    ``sector_cluster_for``, and groups by sector cluster.
+
+    The allocation impl does not currently populate ``sector`` / ``sector_name``
+    on position rows, so for any position missing a label we fall back to a
+    per-position universe→``symbol_sectors`` lookup via ``_lookup_symbol_sector_label``
+    (best-effort, fails open). Without this enrichment the cap silently maps 0
+    holdings in prod; with it, real cluster weights are aggregated.
+
+    May raise on any data gap; the orchestrator (``evaluate_sector_concentration``)
+    fails open.
     """
+    from app.core.db import AsyncSessionLocal
     from app.mcp_server.tooling.portfolio_allocation import (
         get_portfolio_allocation_impl,
     )
@@ -174,15 +183,20 @@ async def compute_sector_cluster_weights(
     positions = alloc.get("positions") or []
     clusters: dict[str, float] = {}
     total = 0.0
-    for pos in positions:
-        value_krw = pos.get("value_krw")
-        if value_krw is None:
-            continue
-        total += float(value_krw)
-        label = pos.get("sector") or pos.get("sector_name")
-        cluster = sector_cluster_for(label)
-        if cluster is not None:
-            clusters[cluster] = clusters.get(cluster, 0.0) + float(value_krw)
+    async with AsyncSessionLocal() as db:
+        for pos in positions:
+            value_krw = pos.get("value_krw")
+            if value_krw is None:
+                continue
+            total += float(value_krw)
+            label = pos.get("sector") or pos.get("sector_name")
+            if label is None and pos.get("symbol"):
+                label = await _lookup_symbol_sector_label(
+                    db, symbol=str(pos.get("symbol")), market=market
+                )
+            cluster = sector_cluster_for(label)
+            if cluster is not None:
+                clusters[cluster] = clusters.get(cluster, 0.0) + float(value_krw)
     return {"clusters": clusters, "total_krw": total, "usd_krw": usd_krw}
 
 

--- a/app/mcp_server/tooling/order_validation.py
+++ b/app/mcp_server/tooling/order_validation.py
@@ -149,6 +149,131 @@ def evaluate_market_sell_loss_guard(
     return None
 
 
+async def compute_sector_cluster_weights(
+    *, market: str, account_ctx: dict[str, Any]
+) -> dict[str, Any]:
+    """Best-effort current portfolio weight by sector cluster (KRW).
+
+    ROB-646 — reuses ``get_portfolio_allocation_impl(include_positions=True)`` for
+    per-position KRW values + ``usd_krw``, joins each holding's sector label to
+    ``sector_cluster_for``, and groups by sector cluster. May raise on any data
+    gap; the orchestrator (``evaluate_sector_concentration``) fails open.
+    """
+    from app.mcp_server.tooling.portfolio_allocation import (
+        get_portfolio_allocation_impl,
+    )
+    from app.services.trading_policy_service import sector_cluster_for
+
+    alloc = await get_portfolio_allocation_impl(
+        account=account_ctx.get("account"),
+        market=account_ctx.get("market"),
+        include_positions=True,
+        is_mock=account_ctx.get("is_mock", False),
+    )
+    usd_krw = float(alloc.get("currency", {}).get("usd_krw") or 0.0)
+    positions = alloc.get("positions") or []
+    clusters: dict[str, float] = {}
+    total = 0.0
+    for pos in positions:
+        value_krw = pos.get("value_krw")
+        if value_krw is None:
+            continue
+        total += float(value_krw)
+        label = pos.get("sector") or pos.get("sector_name")
+        cluster = sector_cluster_for(label)
+        if cluster is not None:
+            clusters[cluster] = clusters.get(cluster, 0.0) + float(value_krw)
+    return {"clusters": clusters, "total_krw": total, "usd_krw": usd_krw}
+
+
+async def resolve_symbol_cluster(*, symbol: str, market: str) -> str | None:
+    """Resolve a symbol's sector cluster via the universe→symbol_sectors join.
+
+    ROB-646 — best-effort; returns ``None`` on unknown symbol or missing sector.
+    May raise on DB errors; the orchestrator fails open.
+    """
+    from app.core.db import AsyncSessionLocal
+    from app.services.trading_policy_service import sector_cluster_for
+
+    async with AsyncSessionLocal() as db:
+        label = await _lookup_symbol_sector_label(db, symbol=symbol, market=market)
+    return sector_cluster_for(label)
+
+
+async def evaluate_sector_concentration(
+    *,
+    symbol: str,
+    market: str,
+    order_estimated_value: float | None,
+    order_currency: str,
+    account_ctx: dict[str, Any],
+    _weights_provider: Any = compute_sector_cluster_weights,
+    _cluster_resolver: Any = resolve_symbol_cluster,
+) -> dict[str, Any]:
+    """ROB-646 — fail-open sector-cluster concentration check for buy previews.
+
+    Never raises, never blocks. ``verdict == "over"`` produces a soft ``warning``
+    field only — Task 5 wires this into the buy-preview path without flipping any
+    ``success`` flag. The broad ``except Exception`` catch-all is required by the
+    fail-open contract; do not narrow it.
+    """
+    try:
+        if market == "crypto":
+            return {
+                "verdict": "unknown",
+                "fail_open": True,
+                "reason": "crypto (no sectors)",
+            }
+        from app.services.trading_policy_service import get_policy_for
+
+        policy = get_policy_for(market, "buy")
+        cap = policy["thresholds"]["portfolio.sector_cluster_cap_pct"]["value"]
+
+        cluster = await _cluster_resolver(symbol=symbol, market=market)
+        if cluster is None:
+            return {
+                "verdict": "unknown",
+                "fail_open": True,
+                "reason": f"no sector-cluster mapping for {symbol}",
+            }
+
+        weights = await _weights_provider(market=market, account_ctx=account_ctx)
+        total = float(weights.get("total_krw") or 0.0)
+        if total <= 0:
+            return {
+                "verdict": "unknown",
+                "fail_open": True,
+                "reason": "empty portfolio total",
+            }
+        current_value = float(weights.get("clusters", {}).get(cluster, 0.0))
+        current_pct = current_value / total * 100.0
+
+        order_krw = _order_value_to_krw(
+            order_estimated_value, order_currency, weights.get("usd_krw")
+        )
+        if order_krw is None:
+            projected_pct = current_pct
+        else:
+            projected_pct = (current_value + order_krw) / (total + order_krw) * 100.0
+
+        result: dict[str, Any] = {
+            "verdict": "over" if projected_pct > float(cap) else "within",
+            "cluster": cluster,
+            "cap_pct": cap,
+            "current_pct": round(current_pct, 2),
+            "projected_pct": round(projected_pct, 2),
+            "fail_open": False,
+        }
+        if result["verdict"] == "over":
+            result["warning"] = (
+                f"{cluster} projected {result['projected_pct']}% exceeds "
+                f"sector-cluster cap {cap}%"
+            )
+        return result
+    except Exception as exc:  # noqa: BLE001 — fail-open by contract
+        return {"verdict": "unknown", "fail_open": True, "reason": str(exc)}
+
+
 def _is_cached_approved(approval_issue_id: str) -> bool:
     expires_at = _defensive_trim_success_cache.get(approval_issue_id)
     if expires_at is None:
@@ -441,6 +566,59 @@ def _no_holdings_sell_message(symbol: str, market_type: str, is_mock: bool) -> s
             f"(e.g. toss/samsung) are reference-only and cannot be sold via this "
             f"channel — check get_holdings 'order_routable'/'account_mode'."
         )
+
+
+def _order_value_to_krw(
+    value: float | None, currency: str, usd_krw: Any
+) -> float | None:
+    """ROB-646 — convert an order's estimated value to KRW (best-effort).
+
+    Returns ``None`` when the value is ``None`` or the currency is unsupported /
+    FX rate unavailable. The caller (``evaluate_sector_concentration``) treats
+    ``None`` as "skip the order from the projection" (fail-open).
+    """
+    if value is None:
+        return None
+    cur = (currency or "").upper()
+    if cur in ("KRW", "₩", ""):
+        return float(value)
+    if cur in ("USD", "$"):
+        rate = float(usd_krw or 0.0)
+        return float(value) * rate if rate > 0 else None
+    return None
+
+
+async def _lookup_symbol_sector_label(
+    db: Any, *, symbol: str, market: str
+) -> str | None:
+    """ROB-646 — return a symbol's sector label via the universe→symbol_sectors join.
+
+    Best-effort read over existing tables. Returns ``None`` on unknown symbol,
+    unknown market, or missing sector. Migration 0 — reads only.
+    """
+    from sqlalchemy import select
+
+    from app.models.symbol_sectors import SymbolSector
+
+    if market == "kr":
+        from app.models.kr_symbol_universe import KRSymbolUniverse as Univ
+    elif market == "us":
+        from app.core.symbol import to_db_symbol
+        from app.models.us_symbol_universe import USSymbolUniverse as Univ
+
+        symbol = to_db_symbol(symbol)
+    else:
+        return None
+    stmt = (
+        select(SymbolSector.name_kr, SymbolSector.name_en)
+        .join(Univ, Univ.sector_id == SymbolSector.id)
+        .where(Univ.symbol == symbol)
+        .limit(1)
+    )
+    row = (await db.execute(stmt)).first()
+    if not row:
+        return None
+    return row[0] or row[1]
 
 
 async def _get_holdings_for_order(

--- a/app/mcp_server/tooling/orders_toss_variants.py
+++ b/app/mcp_server/tooling/orders_toss_variants.py
@@ -788,7 +788,8 @@ async def toss_preview_order(
             market=mkt,
             order_estimated_value=estimated_val,
             order_currency=order_currency,
-            account_ctx={"account_mode": ACCOUNT_MODE_TOSS_LIVE},
+            # ROB-646 Finding 1: whole live portfolio (Toss is live-only)
+            account_ctx={"is_mock": False},
         )
         if sector_conc and sector_conc.get("warning"):
             order_warnings.append(sector_conc["warning"])
@@ -996,7 +997,8 @@ async def _toss_place_order_impl(
                 market=mkt,
                 order_estimated_value=estimated_val,
                 order_currency=order_currency,
-                account_ctx={"account_mode": ACCOUNT_MODE_TOSS_LIVE},
+                # ROB-646 Finding 1: whole live portfolio (Toss is live-only)
+                account_ctx={"is_mock": False},
             )
             if sector_conc and sector_conc.get("warning"):
                 order_warnings.append(sector_conc["warning"])

--- a/app/mcp_server/tooling/orders_toss_variants.py
+++ b/app/mcp_server/tooling/orders_toss_variants.py
@@ -24,6 +24,7 @@ from app.mcp_server.tooling.account_modes import (
     ACCOUNT_MODE_TOSS_LIVE,
     normalize_account_mode,
 )
+from app.mcp_server.tooling.order_validation import evaluate_sector_concentration
 from app.mcp_server.tooling.portfolio_cash import get_account_costs_setting
 from app.mcp_server.tooling.toss_approval import (
     APPROVAL_TTL_SECONDS,
@@ -773,6 +774,25 @@ async def toss_preview_order(
         order_amount=order_amount_dec,
     )
 
+    sector_conc = None
+    if side == "buy":
+        estimated_val_str = cost_context.get("estimated_value")
+        estimated_val = (
+            float(estimated_val_str) if estimated_val_str is not None else None
+        )
+        order_currency = cost_context.get("estimated_value_currency") or (
+            "KRW" if mkt == "kr" else "USD"
+        )
+        sector_conc = await evaluate_sector_concentration(
+            symbol=symbol,
+            market=mkt,
+            order_estimated_value=estimated_val,
+            order_currency=order_currency,
+            account_ctx={"account_mode": ACCOUNT_MODE_TOSS_LIVE},
+        )
+        if sector_conc and sector_conc.get("warning"):
+            order_warnings.append(sector_conc["warning"])
+
     response = {
         "success": True,
         "preview": True,
@@ -787,6 +807,7 @@ async def toss_preview_order(
         "warnings_check_message": warnings_check_msg,
         "approval_hash": approval_hash,
         "approval_expires_at": approval_expires_at,
+        "sector_concentration": sector_conc,
         **cost_context,
     }
     if price_context_message is not None:
@@ -944,11 +965,51 @@ async def _toss_place_order_impl(
             )
 
     if dry_run:
-        return {
+        sector_conc = None
+        order_warnings = []
+        if side == "buy":
+            effective_price = price_dec
+            if effective_price is None:
+                try:
+                    async with _client_context() as client:
+                        current_price_dec, _, _ = await _preview_price_context(
+                            client, symbol
+                        )
+                        effective_price = current_price_dec
+                except Exception:
+                    pass
+            cost_context = await _preview_cost_context(
+                market=mkt,
+                quantity=quantity_dec,
+                effective_price=effective_price,
+                order_amount=order_amount_dec,
+            )
+            estimated_val_str = cost_context.get("estimated_value")
+            estimated_val = (
+                float(estimated_val_str) if estimated_val_str is not None else None
+            )
+            order_currency = cost_context.get("estimated_value_currency") or (
+                "KRW" if mkt == "kr" else "USD"
+            )
+            sector_conc = await evaluate_sector_concentration(
+                symbol=symbol,
+                market=mkt,
+                order_estimated_value=estimated_val,
+                order_currency=order_currency,
+                account_ctx={"account_mode": ACCOUNT_MODE_TOSS_LIVE},
+            )
+            if sector_conc and sector_conc.get("warning"):
+                order_warnings.append(sector_conc["warning"])
+
+        dry_run_res = {
             "success": True,
             **base_response,
             "payload_preview": payload,
+            "sector_concentration": sector_conc,
         }
+        if order_warnings:
+            dry_run_res["order_warnings"] = order_warnings
+        return dry_run_res
 
     if not confirm:
         return {

--- a/app/mcp_server/tooling/registry.py
+++ b/app/mcp_server/tooling/registry.py
@@ -107,6 +107,9 @@ from app.mcp_server.tooling.trade_journal_registration import (
 from app.mcp_server.tooling.trade_retrospective_registration import (
     register_trade_retrospective_tools,
 )
+from app.mcp_server.tooling.trading_policy_registration import (
+    register_trading_policy_tools,
+)
 from app.mcp_server.tooling.us_dual_paper import register_us_dual_paper_tools
 from app.mcp_server.tooling.user_settings_registration import (
     register_user_settings_tools,
@@ -142,6 +145,9 @@ def register_all_tools(mcp: FastMCP, profile: McpProfile = McpProfile.DEFAULT) -
     register_session_context_tools(mcp)
     register_analysis_artifact_tools(mcp)
     register_operating_briefing_tools(mcp)
+    # ROB-646 — read-only policy thresholds + version stamp; always registered
+    # so every profile can cite the stamp when recording a verdict.
+    register_trading_policy_tools(mcp)
     if snapshot_report_generator_enabled:
         register_investment_hermes_tools(mcp)
     # ROB-447: register_market_report_tools removed — its get_market_reports /

--- a/app/mcp_server/tooling/trading_policy_registration.py
+++ b/app/mcp_server/tooling/trading_policy_registration.py
@@ -1,0 +1,36 @@
+"""Registration for the read-only get_trading_policy MCP tool (ROB-646)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from app.mcp_server.tooling.trading_policy_tools import get_trading_policy
+
+if TYPE_CHECKING:
+    from fastmcp import FastMCP
+
+TRADING_POLICY_TOOL_NAMES: set[str] = {"get_trading_policy"}
+
+
+def register_trading_policy_tools(mcp: FastMCP) -> None:
+    _ = mcp.tool(
+        name="get_trading_policy",
+        description=(
+            "Read trading judgment thresholds for a market x lane from the "
+            "single authoritative config/trading_policy.yaml. Args: "
+            "market in {kr, us, crypto}, lane in {buy, sell, discovery} "
+            "(sell = profit-taking). Returns resolved thresholds (value/unit/"
+            "semantics/source) plus the policy version stamp "
+            "{version, content_hash}. VERSION-STAMPING CONTRACT: cite this "
+            "stamp when recording a verdict (report item evidence_snapshot, "
+            "trade_retrospectives, forecast) so the criteria are recoverable. "
+            "Unknown market/lane returns success=false, error=unknown_key. "
+            "Read-only — the policy is edited by operator PR, never by a tool."
+        ),
+    )(get_trading_policy)
+
+
+__all__ = [
+    "TRADING_POLICY_TOOL_NAMES",
+    "register_trading_policy_tools",
+]

--- a/app/mcp_server/tooling/trading_policy_tools.py
+++ b/app/mcp_server/tooling/trading_policy_tools.py
@@ -1,0 +1,24 @@
+"""Read-only get_trading_policy MCP tool (ROB-646).
+
+Echoes market x lane judgment thresholds plus the policy version stamp
+({version, content_hash}). Consumers cite the stamp so a verdict record can
+recover "what criteria did we judge under?". Operator edits via PR only —
+there is no write tool."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from app.services.trading_policy_service import (
+    TradingPolicyKeyError,
+    get_policy_for,
+)
+
+
+async def get_trading_policy(market: str, lane: str) -> dict[str, Any]:
+    """Return trading-policy thresholds for a market x lane, plus the version stamp."""
+    try:
+        view = get_policy_for(market, lane)
+    except TradingPolicyKeyError as exc:
+        return {"success": False, "error": "unknown_key", "detail": str(exc)}
+    return {"success": True, **view}

--- a/app/schemas/investment_reports.py
+++ b/app/schemas/investment_reports.py
@@ -1121,6 +1121,9 @@ class OperatingBriefingResponse(BaseModel):
     # ROB-637 — metadata-only recent analysis artifacts; defaulted so
     # pre-existing constructors of this shape keep validating.
     analysis_artifacts: dict[str, Any] = Field(default_factory=dict)
+    # ROB-646 — lightweight policy version pin ({version, content_hash}) so a
+    # session records which policy it ran under. Defaulted for back-compat.
+    policy_version: dict[str, Any] | None = None
 
 
 class InvestmentReportCreateResponse(BaseModel):

--- a/app/schemas/trading_policy.py
+++ b/app/schemas/trading_policy.py
@@ -1,0 +1,48 @@
+"""Pydantic schema for config/trading_policy.yaml (ROB-646).
+
+The YAML is the single authoritative source of trading judgment thresholds
+(seeded verbatim from the ROB-643 playbook policy_keys block). This module
+validates its shape; extra="forbid" everywhere so a typo in the operator PR
+fails loudly instead of silently dropping a key.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict
+
+Lane = Literal["buy", "sell", "discovery"]
+Market = Literal["kr", "us", "crypto"]
+
+ThresholdValue = int | float | str | list[int | float]
+
+
+class PolicyThreshold(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    lanes: list[Lane]
+    value: ThresholdValue
+    unit: str
+    semantics: str
+    of: int | None = None
+
+
+class PolicyAuthority(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    scope: str
+    governs: str
+    does_not_govern: list[str]
+
+
+class TradingPolicyDocument(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    version: str
+    captured_as_of: str
+    source: str
+    authority: PolicyAuthority
+    sector_clusters: dict[str, list[str]]
+    thresholds: dict[str, PolicyThreshold]
+    market_overrides: dict[Market, dict[str, ThresholdValue]]

--- a/app/services/trading_policy_service.py
+++ b/app/services/trading_policy_service.py
@@ -98,7 +98,11 @@ def sector_cluster_for(label: str | None) -> str | None:
     needle = label.strip().casefold()
     for cluster, members in doc.sector_clusters.items():
         for member in members:
-            m = member.casefold()
-            if m in needle or needle in m:
+            m = member.strip().casefold()
+            # ROB-646 Finding 3: one-directional (member is a substring of the
+            # label). The reverse direction (label ⊂ member) widened the surface
+            # and misclassified short labels; dropping it removes that class of
+            # false positive while preserving KR prefix coverage.
+            if m and m in needle:
                 return cluster
     return None

--- a/app/services/trading_policy_service.py
+++ b/app/services/trading_policy_service.py
@@ -1,0 +1,104 @@
+"""Loader for config/trading_policy.yaml — the single authoritative source
+of trading judgment thresholds (ROB-646). Read-only; operator edits via PR."""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from app.schemas.trading_policy import TradingPolicyDocument
+
+_POLICY_PATH: Path = (
+    Path(__file__).resolve().parents[2] / "config" / "trading_policy.yaml"
+)
+
+_cache: dict[str, Any] = {"key": None, "doc": None, "hash": None}
+
+
+class TradingPolicyKeyError(ValueError):
+    """Unknown market or lane requested from the trading policy."""
+
+
+def _reset_cache_for_tests() -> None:
+    _cache["key"] = None
+    _cache["doc"] = None
+    _cache["hash"] = None
+
+
+def _load() -> tuple[TradingPolicyDocument, str]:
+    stat = _POLICY_PATH.stat()
+    key = (str(_POLICY_PATH), stat.st_mtime_ns, stat.st_size)
+    if _cache["key"] == key and _cache["doc"] is not None:
+        return _cache["doc"], _cache["hash"]
+    raw_bytes = _POLICY_PATH.read_bytes()
+    doc = TradingPolicyDocument.model_validate(yaml.safe_load(raw_bytes))
+    content_hash = hashlib.sha256(raw_bytes).hexdigest()[:12]
+    _cache.update(key=key, doc=doc, hash=content_hash)
+    return doc, content_hash
+
+
+def load_trading_policy() -> TradingPolicyDocument:
+    return _load()[0]
+
+
+def policy_content_hash() -> str:
+    return _load()[1]
+
+
+def policy_version_stamp() -> dict[str, str]:
+    doc, content_hash = _load()
+    return {"version": doc.version, "content_hash": content_hash}
+
+
+def get_policy_for(market: str, lane: str) -> dict[str, Any]:
+    doc, content_hash = _load()
+    if market not in doc.market_overrides:
+        raise TradingPolicyKeyError(
+            f"unknown market {market!r}; valid: {sorted(doc.market_overrides)}"
+        )
+    valid_lanes = {"buy", "sell", "discovery"}
+    if lane not in valid_lanes:
+        raise TradingPolicyKeyError(
+            f"unknown lane {lane!r}; valid: {sorted(valid_lanes)}"
+        )
+    overrides = doc.market_overrides[market]
+    thresholds: dict[str, Any] = {}
+    for key, spec in doc.thresholds.items():
+        if lane not in spec.lanes:
+            continue
+        if key in overrides:
+            value = overrides[key]
+            source = "override"
+        else:
+            value = spec.value
+            source = "default"
+        thresholds[key] = {
+            "value": value,
+            "unit": spec.unit,
+            "semantics": spec.semantics,
+            "of": spec.of,
+            "source": source,
+        }
+    return {
+        "market": market,
+        "lane": lane,
+        "version": doc.version,
+        "content_hash": content_hash,
+        "thresholds": thresholds,
+    }
+
+
+def sector_cluster_for(label: str | None) -> str | None:
+    if not label:
+        return None
+    doc, _ = _load()
+    needle = label.strip().casefold()
+    for cluster, members in doc.sector_clusters.items():
+        for member in members:
+            m = member.casefold()
+            if m in needle or needle in m:
+                return cluster
+    return None

--- a/config/trading_policy.yaml
+++ b/config/trading_policy.yaml
@@ -17,13 +17,16 @@ authority:
     - "sell_conditions — dormant/test-only (not authoritative)"
     - "trade_profile — dead since ROB-488 (not revived)"
 
-# Raw-sector -> cluster grouping for the concentration cap. A symbol's
-# symbol_sectors label (name_kr / name_en / source_key) is matched
-# case-insensitively against these entries. Best-effort; unmapped => fail-open.
+# Raw-sector -> cluster grouping for the concentration cap. A member matches a
+# symbol's symbol_sectors label (name_kr / name_en / source_key) when the member
+# is a case-insensitive SUBSTRING of the label (one-directional: member ⊂ label),
+# so "반도체" matches "반도체와반도체장비" but "의료" does NOT invent a match against
+# "의료정밀". List members as specific labels, not broad umbrellas. Best-effort;
+# unmapped => fail-open.
 sector_clusters:
   financials: ["금융", "은행", "증권", "보험", "Financial Services", "Banks", "Insurance"]
   shipbuilding_defense: ["조선", "방산", "항공우주", "Aerospace & Defense"]
-  bio: ["제약", "바이오", "의료", "Biotechnology", "Drug Manufacturers", "Healthcare"]
+  bio: ["제약", "바이오", "Biotechnology", "Drug Manufacturers"]
   semis_memory: ["반도체", "메모리", "Semiconductors", "Semiconductor Equipment & Materials"]
 
 thresholds:

--- a/config/trading_policy.yaml
+++ b/config/trading_policy.yaml
@@ -1,0 +1,115 @@
+# Trading policy — single authoritative source (ROB-646).
+# Seeded verbatim from docs/playbooks/trading-decision-playbook.md policy_keys
+# (captured 2026-07-02). Edited by operator PR ONLY — there is no write tool.
+# Repo is public; exposing these values is an accepted decision.
+version: "2026-07-02.1"
+captured_as_of: "2026-07-02"
+source: "ROB-643 playbook policy_keys (seed); this file is now authoritative"
+
+authority:
+  scope: judgment_thresholds_only
+  governs: "advisory judgment thresholds + the sector-cluster concentration cap"
+  does_not_govern:
+    - "loss_guard code guard (order_validation.py avg*1.01) — stays fail-closed in code"
+    - "ladder near-market guard (ladder_fill_safety.py 0.3%) — code"
+    - "RSI scoring bands (scoring.py) — code"
+    - "symbol_trade_settings — live per-symbol sizing (separate authority)"
+    - "sell_conditions — dormant/test-only (not authoritative)"
+    - "trade_profile — dead since ROB-488 (not revived)"
+
+# Raw-sector -> cluster grouping for the concentration cap. A symbol's
+# symbol_sectors label (name_kr / name_en / source_key) is matched
+# case-insensitively against these entries. Best-effort; unmapped => fail-open.
+sector_clusters:
+  financials: ["금융", "은행", "증권", "보험", "Financial Services", "Banks", "Insurance"]
+  shipbuilding_defense: ["조선", "방산", "항공우주", "Aerospace & Defense"]
+  bio: ["제약", "바이오", "의료", "Biotechnology", "Drug Manufacturers", "Healthcare"]
+  semis_memory: ["반도체", "메모리", "Semiconductors", "Semiconductor Equipment & Materials"]
+
+thresholds:
+  recovery_gate.min_conditions_met:
+    lanes: [buy]
+    value: 2
+    unit: count
+    of: 4
+    semantics: min recovery-gate conditions to deploy reserve (else support-conditional only)
+  portfolio.sector_cluster_cap_pct:
+    lanes: [buy, sell]
+    value: 10
+    unit: percent
+    semantics: over-concentration cap per sector cluster (~9-10%)
+  portfolio.max_symbols_per_theme:
+    lanes: [buy, discovery]
+    value: 1
+    unit: count
+    semantics: one symbol per theme
+  order.day_expiry_kst:
+    lanes: [buy, sell]
+    value: "20:00"
+    unit: kst_time
+    semantics: DAY order expiry; unfilled -> re-place next day
+  buy.deep_limit_pct_range:
+    lanes: [buy]
+    value: [-12, -3]
+    unit: percent
+    semantics: deep limit distance below current price (pull-back catch, no chasing)
+  buy.per_symbol_notional_krw_range:
+    lanes: [buy, discovery]
+    value: [200000, 400000]
+    unit: krw
+    semantics: per-symbol order sizing for new entries (policy threshold, not account balance)
+  sell.loss_guard_min_multiple:
+    lanes: [buy, sell]
+    value: 1.01
+    unit: multiple_of_avg_cost
+    semantics: minimum sell price as multiple of average cost (loss guard)
+  sell.breakeven_near_pct:
+    lanes: [sell]
+    value: 2
+    unit: percent
+    semantics: near-breakeven scan band (+/-)
+  sell.resistance_near_pct:
+    lanes: [sell]
+    value: 6
+    unit: percent
+    semantics: resistance-proximity threshold for PLACE vs WATCH
+  sell.rsi_place_min:
+    lanes: [sell]
+    value: 58
+    unit: rsi
+    semantics: RSI at/above which PLACE is favored
+  sell.upside_place_max_pct:
+    lanes: [sell]
+    value: 45
+    unit: percent
+    semantics: honest upside below which PLACE is favored
+  sell.watch_rsi_max:
+    lanes: [sell]
+    value: 52
+    unit: rsi
+    semantics: RSI below which WATCH (let-it-run) is allowed
+  sell.watch_upside_min_pct:
+    lanes: [sell]
+    value: 50
+    unit: percent
+    semantics: upside at/above which WATCH (let-it-run) is allowed
+  screen.rsi_max:
+    lanes: [discovery]
+    value: 45
+    unit: rsi
+    semantics: max RSI for a discovery candidate
+  screen.support_within_pct:
+    lanes: [discovery]
+    value: 8
+    unit: percent
+    semantics: strong support must be within this distance
+  screen.upside_min_pct:
+    lanes: [discovery]
+    value: 40
+    unit: percent
+    semantics: minimum honest upside for a candidate
+
+market_overrides:
+  kr: {}
+  us: {}
+  crypto: {}

--- a/docs/playbooks/trading-decision-playbook.md
+++ b/docs/playbooks/trading-decision-playbook.md
@@ -259,6 +259,16 @@ Captured as-of **2026-07-02** from the 2026-06-19 → 2026-07-02 live sessions.
 Once ROB-646 `trading_policy.yaml` lands it is the single authoritative source;
 these values are the seed, not a second source of truth.
 
+> **Authority (ROB-646, landed):** `config/trading_policy.yaml` is now the
+> single authoritative source of these values; this block is the historical
+> seed. The policy governs **judgment thresholds + the sector-cluster
+> concentration cap only** — NOT the fail-closed code guards (loss guard,
+> ladder near-market, RSI scoring bands), NOT `symbol_trade_settings` (live
+> sizing), and it does not revive `trade_profile` (dead since ROB-488). Lane
+> `sell` = "profit_taking" (same lane, human alias). Read it via
+> `get_trading_policy(market, lane)`.
+
+
 ```yaml
 # playbook-machine-readable: policy_keys (ROB-646 initial-value capture)
 # authoritative_source_when_landed: ROB-646 trading_policy.yaml

--- a/docs/superpowers/plans/2026-07-02-rob-646-trading-policy-yaml.md
+++ b/docs/superpowers/plans/2026-07-02-rob-646-trading-policy-yaml.md
@@ -1,0 +1,1233 @@
+# ROB-646 Trading Policy YAML Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make a repo-committed `config/trading_policy.yaml` the single authoritative source of trading judgment thresholds, expose it read-only via a `get_trading_policy` MCP tool, stamp its version into run-start briefing, and add a soft fail-open sector-cluster concentration cap check to buy previews.
+
+**Architecture:** A YAML file (seeded verbatim from the ROB-643 playbook `policy_keys:`) is validated by a pydantic `TradingPolicyDocument` (`extra="forbid"`) and read through a load-once service that resolves `(market, lane)` with per-market overrides and produces a `{version, content_hash}` stamp. A new read-only MCP tool echoes resolved thresholds + the stamp. A pure, always-fail-open `evaluate_sector_concentration` helper reads the cap from the policy, best-effort aggregates current portfolio weight by sector-cluster, and attaches a `sector_concentration` field to both the shared (KIS/crypto) and Toss buy previews — never blocking. `get_operating_briefing` gains a lightweight `policy_version` field.
+
+**Tech Stack:** Python 3.13, pydantic v2, PyYAML, FastMCP, pytest (async), SQLAlchemy async.
+
+## Global Constraints
+
+- **migration 0** — no DB schema changes anywhere in this work.
+- **No write tool** for the policy — operator edits via PR only. Read-only surfaces only.
+- **No account-specific data** in the YAML (no account numbers, balances, asset size). Order-sizing thresholds are policy values, not balances.
+- **Concentration check is fail-open, warning-field-first** — it MUST NOT flip `success` to `False`, MUST NOT raise, and MUST NOT block any order on any market or any data gap.
+- **Do NOT migrate the fail-closed code guards** (loss guard `avg×1.01` in `order_validation.py`, ladder near-market `0.3%`, RSI scoring bands) into YAML — they stay in code.
+- **Do NOT revive `trade_profile`** (dormant since ROB-488).
+- **Canonical lane name is `sell`** (matches playbook `policy_keys` lane tags + ROB-649). `profit_taking` is a documented human alias only, never a key.
+- **Markets:** `Literal["kr","us","crypto"]`. **Lanes:** `Literal["buy","sell","discovery"]`.
+- All threshold values are transcribed **verbatim** from `docs/playbooks/trading-decision-playbook.md` lines 265–352 (the `policy_keys:` block). Do not invent or round values.
+- Tests must be broker-free / DB-free where possible (inject fakes); follow the `tests/_mcp_tooling_support.DummyMCP` + `register_all_tools` matrix pattern for registration tests.
+
+---
+
+## Task 1: Policy YAML file + pydantic schema + dependency
+
+**Files:**
+- Modify: `pyproject.toml` (add `pyyaml` to `dependencies`; add `types-PyYAML` to the dev/typing group)
+- Create: `config/trading_policy.yaml`
+- Create: `app/schemas/trading_policy.py`
+- Test: `tests/schemas/test_trading_policy_schema.py`
+
+**Interfaces:**
+- Produces:
+  - `app/schemas/trading_policy.py`:
+    - `Lane = Literal["buy", "sell", "discovery"]`
+    - `Market = Literal["kr", "us", "crypto"]`
+    - `class PolicyThreshold(BaseModel)` — `model_config = ConfigDict(extra="forbid")`; fields: `lanes: list[Lane]`, `value: int | float | str | list[int | float]`, `unit: str`, `semantics: str`, `of: int | None = None`.
+    - `class PolicyAuthority(BaseModel)` — `extra="forbid"`; `scope: str`, `governs: str`, `does_not_govern: list[str]`.
+    - `class TradingPolicyDocument(BaseModel)` — `extra="forbid"`; `version: str`, `captured_as_of: str`, `source: str`, `authority: PolicyAuthority`, `sector_clusters: dict[str, list[str]]`, `thresholds: dict[str, PolicyThreshold]`, `market_overrides: dict[Market, dict[str, int | float | str | list[int | float]]]`.
+  - `config/trading_policy.yaml` — validates against `TradingPolicyDocument`.
+
+- [ ] **Step 1: Add PyYAML dependency**
+
+In `pyproject.toml`, under `[project]` `dependencies` (the list starting ~line 10), add:
+```toml
+    "pyyaml>=6.0.1,<7.0.0",
+```
+And in the dev/typing dependency group (where other `types-*` stubs live — grep `types-` in `pyproject.toml` to find the group), add:
+```toml
+    "types-PyYAML>=6.0.0",
+```
+Then sync:
+```bash
+uv sync --all-groups
+```
+Expected: resolves without error; `python3 -c "import yaml; print(yaml.__version__)"` prints a 6.x version.
+
+- [ ] **Step 2: Write the schema**
+
+Create `app/schemas/trading_policy.py`:
+```python
+"""Pydantic schema for config/trading_policy.yaml (ROB-646).
+
+The YAML is the single authoritative source of trading judgment thresholds
+(seeded verbatim from the ROB-643 playbook policy_keys block). This module
+validates its shape; extra="forbid" everywhere so a typo in the operator PR
+fails loudly instead of silently dropping a key.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict
+
+Lane = Literal["buy", "sell", "discovery"]
+Market = Literal["kr", "us", "crypto"]
+
+ThresholdValue = int | float | str | list[int | float]
+
+
+class PolicyThreshold(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    lanes: list[Lane]
+    value: ThresholdValue
+    unit: str
+    semantics: str
+    of: int | None = None
+
+
+class PolicyAuthority(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    scope: str
+    governs: str
+    does_not_govern: list[str]
+
+
+class TradingPolicyDocument(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    version: str
+    captured_as_of: str
+    source: str
+    authority: PolicyAuthority
+    sector_clusters: dict[str, list[str]]
+    thresholds: dict[str, PolicyThreshold]
+    market_overrides: dict[Market, dict[str, ThresholdValue]]
+```
+
+- [ ] **Step 3: Write the config YAML**
+
+Create `config/trading_policy.yaml`. Copy every threshold value verbatim from `docs/playbooks/trading-decision-playbook.md` lines 265–352:
+```yaml
+# Trading policy — single authoritative source (ROB-646).
+# Seeded verbatim from docs/playbooks/trading-decision-playbook.md policy_keys
+# (captured 2026-07-02). Edited by operator PR ONLY — there is no write tool.
+# Repo is public; exposing these values is an accepted decision.
+version: "2026-07-02.1"
+captured_as_of: "2026-07-02"
+source: "ROB-643 playbook policy_keys (seed); this file is now authoritative"
+
+authority:
+  scope: judgment_thresholds_only
+  governs: "advisory judgment thresholds + the sector-cluster concentration cap"
+  does_not_govern:
+    - "loss_guard code guard (order_validation.py avg*1.01) — stays fail-closed in code"
+    - "ladder near-market guard (ladder_fill_safety.py 0.3%) — code"
+    - "RSI scoring bands (scoring.py) — code"
+    - "symbol_trade_settings — live per-symbol sizing (separate authority)"
+    - "sell_conditions — dormant/test-only (not authoritative)"
+    - "trade_profile — dead since ROB-488 (not revived)"
+
+# Raw-sector -> cluster grouping for the concentration cap. A symbol's
+# symbol_sectors label (name_kr / name_en / source_key) is matched
+# case-insensitively against these entries. Best-effort; unmapped => fail-open.
+sector_clusters:
+  financials: ["금융", "은행", "증권", "보험", "Financial Services", "Banks", "Insurance"]
+  shipbuilding_defense: ["조선", "방산", "항공우주", "Aerospace & Defense"]
+  bio: ["제약", "바이오", "의료", "Biotechnology", "Drug Manufacturers", "Healthcare"]
+  semis_memory: ["반도체", "메모리", "Semiconductors", "Semiconductor Equipment & Materials"]
+
+thresholds:
+  recovery_gate.min_conditions_met:
+    lanes: [buy]
+    value: 2
+    unit: count
+    of: 4
+    semantics: min recovery-gate conditions to deploy reserve (else support-conditional only)
+  portfolio.sector_cluster_cap_pct:
+    lanes: [buy, sell]
+    value: 10
+    unit: percent
+    semantics: over-concentration cap per sector cluster (~9-10%)
+  portfolio.max_symbols_per_theme:
+    lanes: [buy, discovery]
+    value: 1
+    unit: count
+    semantics: one symbol per theme
+  order.day_expiry_kst:
+    lanes: [buy, sell]
+    value: "20:00"
+    unit: kst_time
+    semantics: DAY order expiry; unfilled -> re-place next day
+  buy.deep_limit_pct_range:
+    lanes: [buy]
+    value: [-12, -3]
+    unit: percent
+    semantics: deep limit distance below current price (pull-back catch, no chasing)
+  buy.per_symbol_notional_krw_range:
+    lanes: [buy, discovery]
+    value: [200000, 400000]
+    unit: krw
+    semantics: per-symbol order sizing for new entries (policy threshold, not account balance)
+  sell.loss_guard_min_multiple:
+    lanes: [buy, sell]
+    value: 1.01
+    unit: multiple_of_avg_cost
+    semantics: minimum sell price as multiple of average cost (loss guard)
+  sell.breakeven_near_pct:
+    lanes: [sell]
+    value: 2
+    unit: percent
+    semantics: near-breakeven scan band (+/-)
+  sell.resistance_near_pct:
+    lanes: [sell]
+    value: 6
+    unit: percent
+    semantics: resistance-proximity threshold for PLACE vs WATCH
+  sell.rsi_place_min:
+    lanes: [sell]
+    value: 58
+    unit: rsi
+    semantics: RSI at/above which PLACE is favored
+  sell.upside_place_max_pct:
+    lanes: [sell]
+    value: 45
+    unit: percent
+    semantics: honest upside below which PLACE is favored
+  sell.watch_rsi_max:
+    lanes: [sell]
+    value: 52
+    unit: rsi
+    semantics: RSI below which WATCH (let-it-run) is allowed
+  sell.watch_upside_min_pct:
+    lanes: [sell]
+    value: 50
+    unit: percent
+    semantics: upside at/above which WATCH (let-it-run) is allowed
+  screen.rsi_max:
+    lanes: [discovery]
+    value: 45
+    unit: rsi
+    semantics: max RSI for a discovery candidate
+  screen.support_within_pct:
+    lanes: [discovery]
+    value: 8
+    unit: percent
+    semantics: strong support must be within this distance
+  screen.upside_min_pct:
+    lanes: [discovery]
+    value: 40
+    unit: percent
+    semantics: minimum honest upside for a candidate
+
+market_overrides:
+  kr: {}
+  us: {}
+  crypto: {}
+```
+
+- [ ] **Step 4: Write the failing test**
+
+Create `tests/schemas/test_trading_policy_schema.py`:
+```python
+from pathlib import Path
+
+import pytest
+import yaml
+from pydantic import ValidationError
+
+from app.schemas.trading_policy import TradingPolicyDocument
+
+_CONFIG = Path(__file__).resolve().parents[2] / "config" / "trading_policy.yaml"
+
+
+def _raw() -> dict:
+    return yaml.safe_load(_CONFIG.read_text(encoding="utf-8"))
+
+
+def test_shipped_config_validates():
+    doc = TradingPolicyDocument.model_validate(_raw())
+    assert doc.version == "2026-07-02.1"
+    # verbatim seed values from the playbook policy_keys
+    assert doc.thresholds["portfolio.sector_cluster_cap_pct"].value == 10
+    assert doc.thresholds["sell.loss_guard_min_multiple"].value == 1.01
+    assert doc.thresholds["screen.rsi_max"].value == 45
+    assert doc.thresholds["buy.deep_limit_pct_range"].value == [-12, -3]
+    assert set(doc.market_overrides.keys()) == {"kr", "us", "crypto"}
+    assert "semis_memory" in doc.sector_clusters
+
+
+def test_extra_key_rejected():
+    raw = _raw()
+    raw["unexpected_top_level"] = 1
+    with pytest.raises(ValidationError):
+        TradingPolicyDocument.model_validate(raw)
+
+
+def test_extra_threshold_key_rejected():
+    raw = _raw()
+    raw["thresholds"]["screen.rsi_max"]["bogus"] = 1
+    with pytest.raises(ValidationError):
+        TradingPolicyDocument.model_validate(raw)
+```
+
+- [ ] **Step 5: Run tests**
+
+Run: `uv run pytest tests/schemas/test_trading_policy_schema.py -v`
+Expected: 3 passed. (If `tests/schemas/` lacks `__init__.py`, do not add one — the repo uses rootdir-based collection; confirm with a sibling test dir.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add pyproject.toml uv.lock config/trading_policy.yaml app/schemas/trading_policy.py tests/schemas/test_trading_policy_schema.py
+git commit -m "feat(ROB-646): trading policy YAML + schema (seed from playbook)"
+```
+
+---
+
+## Task 2: Policy loader service
+
+**Files:**
+- Create: `app/services/trading_policy_service.py`
+- Test: `tests/services/test_trading_policy_service.py`
+
+**Interfaces:**
+- Consumes: `app.schemas.trading_policy.TradingPolicyDocument`, `config/trading_policy.yaml`.
+- Produces:
+  - `class TradingPolicyKeyError(ValueError)` — raised for unknown market or lane.
+  - `def load_trading_policy() -> TradingPolicyDocument` — load-once, cached by file (mtime,size); re-reads if the file changes.
+  - `def policy_content_hash() -> str` — `sha256(raw_bytes)[:12]`.
+  - `def policy_version_stamp() -> dict[str, str]` — `{"version": <version>, "content_hash": <hash>}`.
+  - `def get_policy_for(market: str, lane: str) -> dict` — resolved view (see shape below); raises `TradingPolicyKeyError` on unknown market/lane.
+  - `def sector_cluster_for(label: str | None) -> str | None` — reverse lookup over `sector_clusters`, case-insensitive substring match; `None` when unmapped or `label` is falsy.
+  - `_POLICY_PATH: Path` (module-level, for tests to monkeypatch).
+
+  `get_policy_for` return shape:
+  ```python
+  {
+    "market": market, "lane": lane,
+    "version": <str>, "content_hash": <str>,
+    "thresholds": {
+      "<key>": {"value": ..., "unit": ..., "semantics": ..., "of": <int|None>, "source": "default"|"override"},
+      ...
+    },
+  }
+  ```
+  A threshold is included iff `lane in threshold.lanes`. If `market_overrides[market]` has the key, `value` is the override and `source="override"`, else `source="default"`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/services/test_trading_policy_service.py`:
+```python
+import pytest
+
+from app.services import trading_policy_service as svc
+
+
+def test_version_stamp_has_version_and_hash():
+    stamp = svc.policy_version_stamp()
+    assert stamp["version"] == "2026-07-02.1"
+    assert len(stamp["content_hash"]) == 12
+
+
+def test_content_hash_stable_across_calls():
+    assert svc.policy_content_hash() == svc.policy_content_hash()
+
+
+def test_get_policy_for_buy_kr_includes_cap_and_version():
+    view = svc.get_policy_for("kr", "buy")
+    assert view["version"] == "2026-07-02.1"
+    assert view["content_hash"]
+    t = view["thresholds"]
+    # buy lane references these (playbook lane tags)
+    assert t["portfolio.sector_cluster_cap_pct"]["value"] == 10
+    assert t["portfolio.sector_cluster_cap_pct"]["source"] == "default"
+    assert t["recovery_gate.min_conditions_met"]["value"] == 2
+    assert t["sell.loss_guard_min_multiple"]["value"] == 1.01
+    # sell-only threshold must NOT appear in the buy lane
+    assert "sell.rsi_place_min" not in t
+
+
+def test_get_policy_for_sell_lane_has_sell_keys():
+    t = svc.get_policy_for("kr", "sell")["thresholds"]
+    assert t["sell.rsi_place_min"]["value"] == 58
+    assert "screen.rsi_max" not in t
+
+
+def test_unknown_market_raises():
+    with pytest.raises(svc.TradingPolicyKeyError):
+        svc.get_policy_for("jp", "buy")
+
+
+def test_unknown_lane_raises():
+    with pytest.raises(svc.TradingPolicyKeyError):
+        svc.get_policy_for("kr", "scalp")
+
+
+def test_market_override_applied(monkeypatch, tmp_path):
+    import yaml
+    from pathlib import Path
+
+    raw = yaml.safe_load(svc._POLICY_PATH.read_text(encoding="utf-8"))
+    raw["market_overrides"]["us"]["screen.rsi_max"] = 55
+    p = tmp_path / "trading_policy.yaml"
+    p.write_text(yaml.safe_dump(raw), encoding="utf-8")
+    monkeypatch.setattr(svc, "_POLICY_PATH", Path(p))
+    svc.load_trading_policy.cache_clear() if hasattr(svc.load_trading_policy, "cache_clear") else None
+    svc._reset_cache_for_tests()
+    t = svc.get_policy_for("us", "discovery")["thresholds"]
+    assert t["screen.rsi_max"]["value"] == 55
+    assert t["screen.rsi_max"]["source"] == "override"
+
+
+def test_sector_cluster_for():
+    assert svc.sector_cluster_for("반도체") == "semis_memory"
+    assert svc.sector_cluster_for("Financial Services") == "financials"
+    assert svc.sector_cluster_for("정체불명업종") is None
+    assert svc.sector_cluster_for(None) is None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/services/test_trading_policy_service.py -v`
+Expected: FAIL / ImportError (module not defined).
+
+- [ ] **Step 3: Write the service**
+
+Create `app/services/trading_policy_service.py`:
+```python
+"""Loader for config/trading_policy.yaml — the single authoritative source
+of trading judgment thresholds (ROB-646). Read-only; operator edits via PR."""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from app.schemas.trading_policy import TradingPolicyDocument
+
+_POLICY_PATH: Path = Path(__file__).resolve().parents[2] / "config" / "trading_policy.yaml"
+
+_cache: dict[str, Any] = {"key": None, "doc": None, "hash": None}
+
+
+class TradingPolicyKeyError(ValueError):
+    """Unknown market or lane requested from the trading policy."""
+
+
+def _reset_cache_for_tests() -> None:
+    _cache["key"] = None
+    _cache["doc"] = None
+    _cache["hash"] = None
+
+
+def _load() -> tuple[TradingPolicyDocument, str]:
+    stat = _POLICY_PATH.stat()
+    key = (str(_POLICY_PATH), stat.st_mtime_ns, stat.st_size)
+    if _cache["key"] == key and _cache["doc"] is not None:
+        return _cache["doc"], _cache["hash"]
+    raw_bytes = _POLICY_PATH.read_bytes()
+    doc = TradingPolicyDocument.model_validate(yaml.safe_load(raw_bytes))
+    content_hash = hashlib.sha256(raw_bytes).hexdigest()[:12]
+    _cache.update(key=key, doc=doc, hash=content_hash)
+    return doc, content_hash
+
+
+def load_trading_policy() -> TradingPolicyDocument:
+    return _load()[0]
+
+
+def policy_content_hash() -> str:
+    return _load()[1]
+
+
+def policy_version_stamp() -> dict[str, str]:
+    doc, content_hash = _load()
+    return {"version": doc.version, "content_hash": content_hash}
+
+
+def get_policy_for(market: str, lane: str) -> dict[str, Any]:
+    doc, content_hash = _load()
+    if market not in doc.market_overrides:
+        raise TradingPolicyKeyError(
+            f"unknown market {market!r}; valid: {sorted(doc.market_overrides)}"
+        )
+    valid_lanes = {"buy", "sell", "discovery"}
+    if lane not in valid_lanes:
+        raise TradingPolicyKeyError(
+            f"unknown lane {lane!r}; valid: {sorted(valid_lanes)}"
+        )
+    overrides = doc.market_overrides[market]
+    thresholds: dict[str, Any] = {}
+    for key, spec in doc.thresholds.items():
+        if lane not in spec.lanes:
+            continue
+        if key in overrides:
+            value = overrides[key]
+            source = "override"
+        else:
+            value = spec.value
+            source = "default"
+        thresholds[key] = {
+            "value": value,
+            "unit": spec.unit,
+            "semantics": spec.semantics,
+            "of": spec.of,
+            "source": source,
+        }
+    return {
+        "market": market,
+        "lane": lane,
+        "version": doc.version,
+        "content_hash": content_hash,
+        "thresholds": thresholds,
+    }
+
+
+def sector_cluster_for(label: str | None) -> str | None:
+    if not label:
+        return None
+    doc, _ = _load()
+    needle = label.strip().casefold()
+    for cluster, members in doc.sector_clusters.items():
+        for member in members:
+            m = member.casefold()
+            if m in needle or needle in m:
+                return cluster
+    return None
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `uv run pytest tests/services/test_trading_policy_service.py -v`
+Expected: all passed. (The `cache_clear()` line in the override test is a no-op guard; `_reset_cache_for_tests()` does the real reset.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/trading_policy_service.py tests/services/test_trading_policy_service.py
+git commit -m "feat(ROB-646): trading policy loader service (market x lane resolve + version stamp)"
+```
+
+---
+
+## Task 3: `get_trading_policy` MCP tool + registration
+
+**Files:**
+- Create: `app/mcp_server/tooling/trading_policy_tools.py`
+- Create: `app/mcp_server/tooling/trading_policy_registration.py`
+- Modify: `app/mcp_server/tooling/registry.py` (import ~line 100–112; call in the always-registered read-only block ~line 127–154)
+- Test: `tests/mcp_server/test_trading_policy_tool.py`
+
+**Interfaces:**
+- Consumes: `app.services.trading_policy_service.get_policy_for`, `TradingPolicyKeyError`.
+- Produces:
+  - `async def get_trading_policy(market: str, lane: str) -> dict[str, Any]` — success returns `get_policy_for(...)` plus `"success": True`; unknown key returns `{"success": False, "error": "unknown_key", "detail": <str>}`.
+  - `def register_trading_policy_tools(mcp) -> None`, `TRADING_POLICY_TOOL_NAMES: set[str] = {"get_trading_policy"}`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/mcp_server/test_trading_policy_tool.py`:
+```python
+from typing import Any, cast
+
+import pytest
+
+from app.mcp_server.profiles import McpProfile
+from app.mcp_server.tooling.registry import register_all_tools
+from app.mcp_server.tooling.trading_policy_tools import get_trading_policy
+from tests._mcp_tooling_support import DummyMCP
+
+
+@pytest.mark.asyncio
+async def test_get_trading_policy_returns_thresholds_and_version():
+    out = await get_trading_policy(market="kr", lane="buy")
+    assert out["success"] is True
+    assert out["version"] == "2026-07-02.1"
+    assert out["content_hash"]
+    assert out["thresholds"]["portfolio.sector_cluster_cap_pct"]["value"] == 10
+
+
+@pytest.mark.asyncio
+async def test_get_trading_policy_unknown_key_explicit_error():
+    out = await get_trading_policy(market="jp", lane="buy")
+    assert out["success"] is False
+    assert out["error"] == "unknown_key"
+    assert "jp" in out["detail"]
+
+
+def test_tool_registered_in_default_profile():
+    mcp = DummyMCP()
+    register_all_tools(cast(Any, mcp), profile=McpProfile.DEFAULT)
+    assert "get_trading_policy" in mcp.tools
+
+
+def test_tool_registered_in_crypto_profile():
+    mcp = DummyMCP()
+    register_all_tools(cast(Any, mcp), profile=McpProfile.CRYPTO)
+    assert "get_trading_policy" in mcp.tools
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/mcp_server/test_trading_policy_tool.py -v`
+Expected: FAIL / ImportError.
+
+- [ ] **Step 3: Write the tool handler**
+
+Create `app/mcp_server/tooling/trading_policy_tools.py`:
+```python
+"""Read-only get_trading_policy MCP tool (ROB-646).
+
+Echoes market x lane judgment thresholds plus the policy version stamp
+({version, content_hash}). Consumers cite the stamp so a verdict record can
+recover "what criteria did we judge under?". Operator edits via PR only —
+there is no write tool."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from app.services.trading_policy_service import (
+    TradingPolicyKeyError,
+    get_policy_for,
+)
+
+
+async def get_trading_policy(market: str, lane: str) -> dict[str, Any]:
+    """Return trading-policy thresholds for a market x lane, plus the version stamp."""
+    try:
+        view = get_policy_for(market, lane)
+    except TradingPolicyKeyError as exc:
+        return {"success": False, "error": "unknown_key", "detail": str(exc)}
+    return {"success": True, **view}
+```
+
+- [ ] **Step 4: Write the registration**
+
+Create `app/mcp_server/tooling/trading_policy_registration.py`:
+```python
+"""Registration for the read-only get_trading_policy MCP tool (ROB-646)."""
+
+from __future__ import annotations
+
+from mcp.server.fastmcp import FastMCP
+
+from app.mcp_server.tooling.trading_policy_tools import get_trading_policy
+
+TRADING_POLICY_TOOL_NAMES: set[str] = {"get_trading_policy"}
+
+
+def register_trading_policy_tools(mcp: FastMCP) -> None:
+    _ = mcp.tool(
+        name="get_trading_policy",
+        description=(
+            "Read trading judgment thresholds for a market x lane from the "
+            "single authoritative config/trading_policy.yaml. Args: "
+            "market in {kr, us, crypto}, lane in {buy, sell, discovery} "
+            "(sell = profit-taking). Returns resolved thresholds (value/unit/"
+            "semantics/source) plus the policy version stamp "
+            "{version, content_hash}. VERSION-STAMPING CONTRACT: cite this "
+            "stamp when recording a verdict (report item evidence_snapshot, "
+            "trade_retrospectives, forecast) so the criteria are recoverable. "
+            "Unknown market/lane returns success=false, error=unknown_key. "
+            "Read-only — the policy is edited by operator PR, never by a tool."
+        ),
+    )(get_trading_policy)
+```
+Confirm the `FastMCP` import path matches the sibling registration modules (grep `from mcp.server.fastmcp import FastMCP` in `app/mcp_server/tooling/session_context_registration.py`; use whatever that file uses).
+
+- [ ] **Step 5: Wire into registry**
+
+In `app/mcp_server/tooling/registry.py`, add the import next to the other registration imports (~line 100):
+```python
+from app.mcp_server.tooling.trading_policy_registration import (
+    register_trading_policy_tools,
+)
+```
+And in the always-registered read-only block (the section around `register_session_context_tools(mcp)` at ~line 141, NOT inside any `if profile is McpProfile.DEFAULT:` branch), add:
+```python
+    register_trading_policy_tools(mcp)
+```
+
+- [ ] **Step 6: Run tests**
+
+Run: `uv run pytest tests/mcp_server/test_trading_policy_tool.py -v`
+Expected: 4 passed.
+
+- [ ] **Step 7: Guard against name collision**
+
+Run: `uv run pytest tests/test_playbook_tool_names.py tests/test_mcp_profiles.py -v` (server boots with `on_duplicate="error"`; a name clash would fail here).
+Expected: passed.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add app/mcp_server/tooling/trading_policy_tools.py app/mcp_server/tooling/trading_policy_registration.py app/mcp_server/tooling/registry.py tests/mcp_server/test_trading_policy_tool.py
+git commit -m "feat(ROB-646): get_trading_policy read-only MCP tool (all profiles)"
+```
+
+---
+
+## Task 4: `evaluate_sector_concentration` fail-open helper
+
+**Files:**
+- Modify: `app/mcp_server/tooling/order_validation.py` (add helper + two internal seams near the other guard helpers, after `evaluate_market_sell_loss_guard` ~line 149)
+- Test: `tests/mcp_server/test_sector_concentration.py`
+
+**Interfaces:**
+- Consumes: `app.services.trading_policy_service.get_policy_for`, `sector_cluster_for`.
+- Produces (all in `order_validation.py`):
+  - `async def compute_sector_cluster_weights(*, market: str, account_ctx: dict[str, Any]) -> dict[str, Any]` — best-effort; returns `{"clusters": {cluster: value_krw}, "total_krw": float, "usd_krw": float}`. May raise; the orchestrator catches.
+  - `async def resolve_symbol_cluster(*, symbol: str, market: str) -> str | None` — join universe→`symbol_sectors`, then `sector_cluster_for(label)`. May raise; orchestrator catches.
+  - `async def evaluate_sector_concentration(*, symbol, market, order_estimated_value, order_currency, account_ctx, _weights_provider=compute_sector_cluster_weights, _cluster_resolver=resolve_symbol_cluster) -> dict[str, Any]` — NEVER raises, NEVER blocks. Return shapes:
+    - within: `{"verdict": "within", "cluster": str, "cap_pct": float, "current_pct": float, "projected_pct": float, "fail_open": False}`
+    - over: same as within but `"verdict": "over"` + `"warning": "<cluster> projected <p>% exceeds cap <cap>%"`
+    - unknown: `{"verdict": "unknown", "fail_open": True, "reason": <str>}`
+
+- [ ] **Step 1: Write the failing test** (broker-free; inject fakes)
+
+Create `tests/mcp_server/test_sector_concentration.py`:
+```python
+import pytest
+
+from app.mcp_server.tooling import order_validation as ov
+
+
+async def _weights_ok(*, market, account_ctx):
+    # semis cluster currently 800k of 10M total = 8%
+    return {"clusters": {"semis_memory": 800_000.0}, "total_krw": 10_000_000.0, "usd_krw": 1350.0}
+
+
+async def _cluster_semis(*, symbol, market):
+    return "semis_memory"
+
+
+@pytest.mark.asyncio
+async def test_within_cap():
+    out = await ov.evaluate_sector_concentration(
+        symbol="005930", market="kr", order_estimated_value=100_000.0,
+        order_currency="KRW", account_ctx={},
+        _weights_provider=_weights_ok, _cluster_resolver=_cluster_semis,
+    )
+    assert out["verdict"] == "within"
+    assert out["cluster"] == "semis_memory"
+    assert out["cap_pct"] == 10
+    assert out["fail_open"] is False
+    # projected = (800k + 100k) / (10M + 100k) ~= 8.9%
+    assert 8.5 < out["projected_pct"] < 9.3
+
+
+@pytest.mark.asyncio
+async def test_over_cap_warns_but_does_not_block():
+    async def _weights_hot(*, market, account_ctx):
+        return {"clusters": {"semis_memory": 950_000.0}, "total_krw": 10_000_000.0, "usd_krw": 1350.0}
+
+    out = await ov.evaluate_sector_concentration(
+        symbol="000660", market="kr", order_estimated_value=300_000.0,
+        order_currency="KRW", account_ctx={},
+        _weights_provider=_weights_hot, _cluster_resolver=_cluster_semis,
+    )
+    assert out["verdict"] == "over"
+    assert "warning" in out
+    assert out["fail_open"] is False
+
+
+@pytest.mark.asyncio
+async def test_crypto_fails_open():
+    out = await ov.evaluate_sector_concentration(
+        symbol="KRW-BTC", market="crypto", order_estimated_value=100_000.0,
+        order_currency="KRW", account_ctx={},
+        _weights_provider=_weights_ok, _cluster_resolver=_cluster_semis,
+    )
+    assert out["verdict"] == "unknown"
+    assert out["fail_open"] is True
+    assert "crypto" in out["reason"]
+
+
+@pytest.mark.asyncio
+async def test_unmapped_cluster_fails_open():
+    async def _no_cluster(*, symbol, market):
+        return None
+
+    out = await ov.evaluate_sector_concentration(
+        symbol="123456", market="kr", order_estimated_value=100_000.0,
+        order_currency="KRW", account_ctx={},
+        _weights_provider=_weights_ok, _cluster_resolver=_no_cluster,
+    )
+    assert out["verdict"] == "unknown"
+    assert out["fail_open"] is True
+
+
+@pytest.mark.asyncio
+async def test_provider_exception_fails_open():
+    async def _boom(*, market, account_ctx):
+        raise RuntimeError("broker down")
+
+    out = await ov.evaluate_sector_concentration(
+        symbol="005930", market="kr", order_estimated_value=100_000.0,
+        order_currency="KRW", account_ctx={},
+        _weights_provider=_boom, _cluster_resolver=_cluster_semis,
+    )
+    assert out["verdict"] == "unknown"
+    assert out["fail_open"] is True
+    assert "broker down" in out["reason"]
+
+
+@pytest.mark.asyncio
+async def test_missing_order_value_uses_current_only():
+    out = await ov.evaluate_sector_concentration(
+        symbol="005930", market="kr", order_estimated_value=None,
+        order_currency="KRW", account_ctx={},
+        _weights_provider=_weights_ok, _cluster_resolver=_cluster_semis,
+    )
+    # current 8% within cap; projected omitted or equals current
+    assert out["verdict"] == "within"
+    assert out["current_pct"] == pytest.approx(8.0, abs=0.01)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/mcp_server/test_sector_concentration.py -v`
+Expected: FAIL (helpers not defined).
+
+- [ ] **Step 3: Implement the helpers**
+
+In `app/mcp_server/tooling/order_validation.py`, after `evaluate_market_sell_loss_guard` (~line 149), add:
+```python
+async def compute_sector_cluster_weights(
+    *, market: str, account_ctx: dict[str, Any]
+) -> dict[str, Any]:
+    """Best-effort current portfolio weight by sector cluster (KRW).
+
+    Reuses get_portfolio_allocation_impl(include_positions=True) for position
+    KRW values + usd_krw, joins each holding to symbol_sectors, and groups by
+    sector cluster. Raises on any data gap; the orchestrator fails open."""
+    from app.mcp_server.tooling.portfolio_allocation import (
+        get_portfolio_allocation_impl,
+    )
+    from app.services.trading_policy_service import sector_cluster_for
+
+    alloc = await get_portfolio_allocation_impl(
+        account=account_ctx.get("account"),
+        market=account_ctx.get("market"),
+        include_positions=True,
+        is_mock=account_ctx.get("is_mock", False),
+    )
+    usd_krw = float(alloc.get("currency", {}).get("usd_krw") or 0.0)
+    positions = alloc.get("positions") or []
+    clusters: dict[str, float] = {}
+    total = 0.0
+    for pos in positions:
+        value_krw = pos.get("value_krw")
+        if value_krw is None:
+            continue
+        total += float(value_krw)
+        label = pos.get("sector") or pos.get("sector_name")
+        cluster = sector_cluster_for(label)
+        if cluster is not None:
+            clusters[cluster] = clusters.get(cluster, 0.0) + float(value_krw)
+    return {"clusters": clusters, "total_krw": total, "usd_krw": usd_krw}
+
+
+async def resolve_symbol_cluster(*, symbol: str, market: str) -> str | None:
+    """Resolve a symbol's sector-cluster via symbol_sectors (best-effort)."""
+    from app.core.db import AsyncSessionLocal
+    from app.services.trading_policy_service import sector_cluster_for
+
+    async with AsyncSessionLocal() as db:
+        label = await _lookup_symbol_sector_label(db, symbol=symbol, market=market)
+    return sector_cluster_for(label)
+
+
+async def evaluate_sector_concentration(
+    *,
+    symbol: str,
+    market: str,
+    order_estimated_value: float | None,
+    order_currency: str,
+    account_ctx: dict[str, Any],
+    _weights_provider=compute_sector_cluster_weights,
+    _cluster_resolver=resolve_symbol_cluster,
+) -> dict[str, Any]:
+    """Fail-open sector-cluster concentration check for buy previews.
+
+    Never raises, never blocks. `over` produces a soft warning field only."""
+    try:
+        if market == "crypto":
+            return {"verdict": "unknown", "fail_open": True, "reason": "crypto (no sectors)"}
+        from app.services.trading_policy_service import get_policy_for
+
+        policy = get_policy_for(market, "buy")
+        cap = policy["thresholds"]["portfolio.sector_cluster_cap_pct"]["value"]
+
+        cluster = await _cluster_resolver(symbol=symbol, market=market)
+        if cluster is None:
+            return {
+                "verdict": "unknown", "fail_open": True,
+                "reason": f"no sector-cluster mapping for {symbol}",
+            }
+
+        weights = await _weights_provider(market=market, account_ctx=account_ctx)
+        total = float(weights.get("total_krw") or 0.0)
+        if total <= 0:
+            return {"verdict": "unknown", "fail_open": True, "reason": "empty portfolio total"}
+        current_value = float(weights.get("clusters", {}).get(cluster, 0.0))
+        current_pct = current_value / total * 100.0
+
+        order_krw = _order_value_to_krw(order_estimated_value, order_currency, weights.get("usd_krw"))
+        if order_krw is None:
+            projected_pct = current_pct
+        else:
+            projected_pct = (current_value + order_krw) / (total + order_krw) * 100.0
+
+        result = {
+            "verdict": "over" if projected_pct > float(cap) else "within",
+            "cluster": cluster, "cap_pct": cap,
+            "current_pct": round(current_pct, 2),
+            "projected_pct": round(projected_pct, 2),
+            "fail_open": False,
+        }
+        if result["verdict"] == "over":
+            result["warning"] = (
+                f"{cluster} projected {result['projected_pct']}% exceeds "
+                f"sector-cluster cap {cap}%"
+            )
+        return result
+    except Exception as exc:  # noqa: BLE001 — fail-open by contract
+        return {"verdict": "unknown", "fail_open": True, "reason": str(exc)}
+```
+Add these small helpers in the same module (near the data-lookup helpers ~line 446):
+```python
+def _order_value_to_krw(value: float | None, currency: str, usd_krw: Any) -> float | None:
+    if value is None:
+        return None
+    cur = (currency or "").upper()
+    if cur in ("KRW", "₩", ""):
+        return float(value)
+    if cur in ("USD", "$"):
+        rate = float(usd_krw or 0.0)
+        return float(value) * rate if rate > 0 else None
+    return None
+
+
+async def _lookup_symbol_sector_label(db, *, symbol: str, market: str) -> str | None:
+    """Return a symbol's sector label (name_kr/name_en) via the universe join.
+    Best-effort; returns None on unknown symbol or missing sector."""
+    from sqlalchemy import select
+
+    from app.models.symbol_sectors import SymbolSector
+
+    if market == "kr":
+        from app.models.kr_symbol_universe import KRSymbolUniverse as Univ
+    elif market == "us":
+        from app.core.symbol import to_db_symbol
+        from app.models.us_symbol_universe import USSymbolUniverse as Univ
+
+        symbol = to_db_symbol(symbol)
+    else:
+        return None
+    stmt = (
+        select(SymbolSector.name_kr, SymbolSector.name_en)
+        .join(Univ, Univ.sector_id == SymbolSector.id)
+        .where(Univ.symbol == symbol)
+        .limit(1)
+    )
+    row = (await db.execute(stmt)).first()
+    if not row:
+        return None
+    return row[0] or row[1]
+```
+Confirm `Any` is imported at the top of `order_validation.py` (it is used elsewhere; grep `from typing import`). Confirm the `USSymbolUniverse.symbol` / `KRSymbolUniverse.symbol` column names against the models (the exploration report cited `sector_id` on both). Confirm `positions[*]` exposes a `sector`/`sector_name` and `value_krw` from `get_portfolio_allocation_impl(include_positions=True)`; if the position rows don't carry a sector label, `compute_sector_cluster_weights` still works but will map fewer holdings (acceptable — fail-open). If needed, enrich via `_lookup_symbol_sector_label` per position inside `compute_sector_cluster_weights`.
+
+- [ ] **Step 4: Run tests**
+
+Run: `uv run pytest tests/mcp_server/test_sector_concentration.py -v`
+Expected: all passed (unit tests inject `_weights_provider`/`_cluster_resolver`, so no DB/broker).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/mcp_server/tooling/order_validation.py tests/mcp_server/test_sector_concentration.py
+git commit -m "feat(ROB-646): fail-open sector-cluster concentration helper"
+```
+
+---
+
+## Task 5: Wire concentration field into buy previews (shared + Toss)
+
+**Files:**
+- Modify: `app/mcp_server/tooling/order_execution.py` (`_place_order_impl`, buy branch, after the `_check_balance_and_warn` block ~lines 1086–1103)
+- Modify: `app/mcp_server/tooling/orders_toss_variants.py` (`toss_preview_order` response assembly ~line 745; `_toss_place_order_impl` dry-run return ~line 859)
+- Test: `tests/mcp_server/test_buy_preview_concentration_field.py`
+
+**Interfaces:**
+- Consumes: `order_validation.evaluate_sector_concentration`.
+- Produces: buy previews carry a `sector_concentration` dict (the helper's return). `verdict == "over"` never flips `success`.
+
+- [ ] **Step 1: Write the failing test** (monkeypatch the helper — no broker)
+
+Create `tests/mcp_server/test_buy_preview_concentration_field.py`:
+```python
+import pytest
+
+from app.mcp_server.tooling import order_execution
+
+
+@pytest.mark.asyncio
+async def test_shared_buy_preview_includes_concentration(monkeypatch):
+    async def _fake_conc(**kwargs):
+        return {"verdict": "within", "cluster": "semis_memory", "cap_pct": 10,
+                "current_pct": 8.0, "projected_pct": 8.9, "fail_open": False}
+
+    monkeypatch.setattr(order_execution, "evaluate_sector_concentration", _fake_conc, raising=False)
+    # ... drive _place_order_impl with a dry_run buy on a fake KIS/crypto path
+    # (mirror the existing dry_run preview tests in tests/mcp_server for the
+    # minimal fixture set — assert the response dict has "sector_concentration"
+    # and success stays True even when verdict == "over").
+```
+Look at the existing dry-run preview tests (grep `dry_run` under `tests/mcp_server/` — e.g. tests exercising `kis_live_place_order` or `_place_order_impl`) and reuse their fixture/monkeypatch scaffold to invoke a buy preview. Assert:
+- `resp["sector_concentration"]["verdict"]` present.
+- With an `over` verdict, `resp["success"] is True` (fail-open contract).
+
+Add a parallel test for Toss:
+```python
+@pytest.mark.asyncio
+async def test_toss_buy_preview_includes_concentration(monkeypatch):
+    from app.mcp_server.tooling import orders_toss_variants
+    async def _fake_conc(**kwargs):
+        return {"verdict": "over", "cluster": "financials", "cap_pct": 10,
+                "current_pct": 9.5, "projected_pct": 11.2, "fail_open": False,
+                "warning": "financials projected 11.2% exceeds sector-cluster cap 10%"}
+    monkeypatch.setattr(orders_toss_variants, "evaluate_sector_concentration", _fake_conc, raising=False)
+    # drive toss_preview_order for a buy (reuse existing toss preview test scaffold)
+    # assert resp["sector_concentration"]["verdict"] == "over" and resp["success"] is True
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/mcp_server/test_buy_preview_concentration_field.py -v`
+Expected: FAIL (field absent).
+
+- [ ] **Step 3: Wire the shared path**
+
+In `order_execution.py`, import at top:
+```python
+from app.mcp_server.tooling.order_validation import evaluate_sector_concentration
+```
+In `_place_order_impl`, in the **buy** branch, right after the balance pre-check block (~line 1103, before `_build_dry_run_response`), add:
+```python
+        if side == "buy":
+            sector_conc = await evaluate_sector_concentration(
+                symbol=symbol,
+                market=market,
+                order_estimated_value=dry_run_result.get("estimated_value"),
+                order_currency=currency,
+                account_ctx={"account": account, "market": market, "is_mock": is_mock},
+            )
+            dry_run_result["sector_concentration"] = sector_conc
+            if sector_conc.get("verdict") == "over" and not balance_warning:
+                balance_warning = sector_conc.get("warning")
+```
+Match the actual local variable names in `_place_order_impl` (`side`, `symbol`, `market`, `currency`, `account`, `is_mock`, `dry_run_result`, `balance_warning`) — grep the function body first and adapt. Because `_build_dry_run_response` splats `**dry_run_result`, the field surfaces automatically. Do NOT touch `success`.
+
+- [ ] **Step 4: Wire the Toss path**
+
+In `orders_toss_variants.py`, import `evaluate_sector_concentration` at top. In `toss_preview_order`, when the order is a **buy**, before assembling the response (~line 745), compute:
+```python
+    sector_conc = None
+    if side == "buy":
+        sector_conc = await evaluate_sector_concentration(
+            symbol=symbol, market=mkt,
+            order_estimated_value=<estimated_value_local>,
+            order_currency=<currency_local>,
+            account_ctx={"account_mode": ACCOUNT_MODE_TOSS_LIVE},
+        )
+```
+and add `"sector_concentration": sector_conc` into the response dict (~line 752, alongside `order_warnings`). If `sector_conc` carries a `warning`, also append it to `order_warnings`. Mirror the same in `_toss_place_order_impl`'s dry-run return (~line 859). Use the estimated-value / currency locals that already exist in those functions (grep the function bodies).
+
+Note: Toss markets map to `kr`/`us`; pass the resolved market string the function already computes (`mkt`). The helper fail-opens for anything it can't map.
+
+- [ ] **Step 5: Run tests**
+
+Run: `uv run pytest tests/mcp_server/test_buy_preview_concentration_field.py -v`
+Expected: passed.
+
+- [ ] **Step 6: Regression — existing preview tests still pass**
+
+Run: `uv run pytest tests/mcp_server/ -k "preview or place_order or toss" -q`
+Expected: no regressions (new field is additive; `success` unchanged).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add app/mcp_server/tooling/order_execution.py app/mcp_server/tooling/orders_toss_variants.py tests/mcp_server/test_buy_preview_concentration_field.py
+git commit -m "feat(ROB-646): sector-concentration field on shared + Toss buy previews (fail-open)"
+```
+
+---
+
+## Task 6: Briefing policy-version echo
+
+**Files:**
+- Modify: `app/schemas/investment_reports.py` (`OperatingBriefingResponse` ~line 1108 — add `policy_version` field)
+- Modify: `app/mcp_server/tooling/operating_briefing.py` (`get_operating_briefing_impl` — add `policy_version` to the response dict ~line 376)
+- Test: `tests/mcp_server/test_operating_briefing_policy_version.py`
+
+**Interfaces:**
+- Consumes: `app.services.trading_policy_service.policy_version_stamp`.
+- Produces: `OperatingBriefingResponse.policy_version: dict[str, Any] | None = None`; briefing response includes `policy_version = {version, content_hash}` (or `{"error": <reason>}` fail-open, still non-blocking).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/mcp_server/test_operating_briefing_policy_version.py`:
+```python
+import pytest
+
+from app.mcp_server.tooling import operating_briefing
+
+
+@pytest.mark.asyncio
+async def test_briefing_includes_policy_version(monkeypatch):
+    # stub the heavy sub-calls so this stays a unit test; mirror the scaffold
+    # used by the existing operating_briefing tests (grep tests/mcp_server for
+    # get_operating_briefing_impl). The only new assertion:
+    resp = await operating_briefing.get_operating_briefing_impl(market="kr")
+    assert resp["policy_version"]["version"] == "2026-07-02.1"
+    assert resp["policy_version"]["content_hash"]
+```
+If no lightweight scaffold exists, add a `test_policy_version_stamp_shape` unit test on the imported stamp and a smaller assertion that the impl merges it (patch `policy_version_stamp` and assert the response key). Keep it broker-free by monkeypatching `_get_holdings_impl`, `collect_pending_orders_snapshot`, etc., following the closest existing briefing test.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/mcp_server/test_operating_briefing_policy_version.py -v`
+Expected: FAIL (key absent).
+
+- [ ] **Step 3: Add the schema field**
+
+In `app/schemas/investment_reports.py`, in `OperatingBriefingResponse` (after `analysis_artifacts`, ~line 1123):
+```python
+    # ROB-646 — lightweight policy version pin ({version, content_hash}) so a
+    # session records which policy it ran under. Defaulted for back-compat.
+    policy_version: dict[str, Any] | None = None
+```
+Confirm `Any` is already imported in that module (it is used above).
+
+- [ ] **Step 4: Populate it in the impl**
+
+In `operating_briefing.py`, near the top add:
+```python
+from app.services.trading_policy_service import policy_version_stamp
+```
+In `get_operating_briefing_impl`, before building the response dict (~line 375), add:
+```python
+    try:
+        policy_version = policy_version_stamp()
+    except Exception as exc:  # noqa: BLE001 — fail-open, briefing must still return
+        policy_version = {"error": str(exc)}
+```
+Add `"policy_version": policy_version,` as a key in the returned dict (alongside `analysis_artifacts` ~line 426).
+
+- [ ] **Step 5: Run tests**
+
+Run: `uv run pytest tests/mcp_server/test_operating_briefing_policy_version.py -v`
+Expected: passed.
+
+- [ ] **Step 6: Regression**
+
+Run: `uv run pytest tests/mcp_server/ -k briefing -q`
+Expected: no regressions.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add app/schemas/investment_reports.py app/mcp_server/tooling/operating_briefing.py tests/mcp_server/test_operating_briefing_policy_version.py
+git commit -m "feat(ROB-646): echo policy_version in get_operating_briefing (fail-open)"
+```
+
+---
+
+## Task 7: Docs — authority declaration + version-stamping contract
+
+**Files:**
+- Modify: `docs/playbooks/trading-decision-playbook.md` (Policy-key capture section ~line 256–260)
+- Modify: `app/mcp_server/README.md`
+- Modify: `CLAUDE.md` (add a short ROB-646 section next to the other tool contracts)
+
+**Interfaces:** docs only. No code.
+
+- [ ] **Step 1: Playbook authority note**
+
+In `docs/playbooks/trading-decision-playbook.md`, in the "Policy-key capture (ROB-646 initial values)" section (~line 256), append a note (the playbook already says these become non-authoritative once the YAML lands — close that loop):
+```markdown
+> **Authority (ROB-646, landed):** `config/trading_policy.yaml` is now the
+> single authoritative source of these values; this block is the historical
+> seed. The policy governs **judgment thresholds + the sector-cluster
+> concentration cap only** — NOT the fail-closed code guards (loss guard,
+> ladder near-market, RSI scoring bands), NOT `symbol_trade_settings` (live
+> sizing), and it does not revive `trade_profile` (dead since ROB-488). Lane
+> `sell` = "profit_taking" (same lane, human alias). Read it via
+> `get_trading_policy(market, lane)`.
+```
+
+- [ ] **Step 2: README version-stamping contract**
+
+In `app/mcp_server/README.md`, add a `get_trading_policy` entry documenting:
+- read-only, single source `config/trading_policy.yaml`, operator-PR-edited (no write tool);
+- args `market ∈ {kr,us,crypto}` × `lane ∈ {buy,sell,discovery}`; unknown key → `success=false, error=unknown_key`;
+- **version-stamping contract**: consumers cite `{version, content_hash}` (from `get_trading_policy` or the `policy_version` field of `get_operating_briefing`) in `report_item.evidence_snapshot`, `trade_retrospectives`, and forecast records so the judging criteria are recoverable;
+- the buy-preview `sector_concentration` field is **fail-open** advisory (never blocks).
+
+- [ ] **Step 3: CLAUDE.md contract section**
+
+In `CLAUDE.md`, add a short section (mirroring the other `### ...` tool-contract blocks):
+```markdown
+### Trading Policy YAML 단일 소스 (ROB-646)
+
+`config/trading_policy.yaml` = 매매 판단 임계값 단일 소스 (ROB-643 플레이북
+policy_keys에서 시드). **operator PR로만 편집 — 쓰기 도구 없음.**
+
+- **스키마/로더**: `app/schemas/trading_policy.py`, `app/services/trading_policy_service.py`
+- **MCP 도구**: `get_trading_policy(market, lane)` — market×lane 임계값 + `{version, content_hash}` echo; 없는 키는 `success=false, error=unknown_key`
+- **버전 스탬핑 계약**: 판정 기록(evidence_snapshot·trade_retrospectives·forecast)은 `{version, content_hash}` 인용. `get_operating_briefing`가 run-start에 `policy_version` echo.
+- **강제 범위**: 섹터 클러스터 집중도 cap만 매수 프리뷰에서 코드 검사 (`sector_concentration` 필드, **fail-open** — 경고만, 차단 안 함). 나머지 임계값은 advisory.
+- **관할**: 판단 임계값 전용. fail-closed 코드 가드(손실매도/ladder/RSI 스코어링)·`symbol_trade_settings`(라이브 사이징)·`trade_profile`(dead)와 분리. migration 0.
+```
+
+- [ ] **Step 4: Verify playbook drift guard still passes**
+
+Run: `uv run pytest tests/test_playbook_tool_names.py -v`
+Expected: passed (docs edits don't touch the `lanes:` blocks).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/playbooks/trading-decision-playbook.md app/mcp_server/README.md CLAUDE.md
+git commit -m "docs(ROB-646): policy authority declaration + version-stamping contract"
+```
+
+---
+
+## Final verification (before PR)
+
+- [ ] Full lint + type: `make lint` (Ruff + ty). Fix any findings.
+- [ ] Format: `uv run ruff format app/ tests/ config/` then `uv run ruff check app/ tests/` (CI lint covers both `app/` and `tests/`).
+- [ ] Targeted suite: `uv run pytest tests/schemas/test_trading_policy_schema.py tests/services/test_trading_policy_service.py tests/mcp_server/test_trading_policy_tool.py tests/mcp_server/test_sector_concentration.py tests/mcp_server/test_buy_preview_concentration_field.py tests/mcp_server/test_operating_briefing_policy_version.py tests/test_playbook_tool_names.py tests/test_mcp_profiles.py -v`
+- [ ] Confirm `git grep -n "migration"` shows no alembic version added (migration 0).
+- [ ] Confirm no runtime LLM provider import was added (the ROB-501 guard: `uv run pytest tests/services/action_report/snapshot_backed/test_no_internal_llm_imports.py`).
+
+## Self-review notes (author)
+
+- **Spec coverage:** YAML+schema (T1), loader/version/hash/unknown-key (T2), get_trading_policy tool + registration (T3), fail-open concentration helper (T4), buy-preview wiring shared+Toss (T5), briefing echo (T6), docs authority + stamping contract (T7). All spec sections mapped.
+- **AC mapping:** market×lane+version + explicit unknown-key error → T2/T3; buy-preview concentration field + fail-open reason → T4/T5; stamping contract in tool desc + README → T3/T7; migration 0 → global constraint + final check.
+- **Type consistency:** `get_policy_for` view shape is defined once (T2) and consumed unchanged in T3; `evaluate_sector_concentration` return shape defined in T4 and asserted unchanged in T5; `policy_version_stamp()` shape `{version, content_hash}` consistent across T2/T3/T6.
+- **Open impl-time confirmations flagged inline:** `_place_order_impl` local var names (T5 step 3), Toss estimated-value/currency locals (T5 step 4), universe `symbol` column name + position `sector` field (T4 step 3), `FastMCP` import path (T3 step 4), `tests/schemas` package init convention (T1 step 5). These are lookups, not design gaps.

--- a/docs/superpowers/specs/2026-07-02-rob-646-trading-policy-yaml-design.md
+++ b/docs/superpowers/specs/2026-07-02-rob-646-trading-policy-yaml-design.md
@@ -1,0 +1,251 @@
+# ROB-646 — Trading policy YAML single source + `get_trading_policy` + version stamping + buy-preview concentration cap
+
+**Status:** design (approved decisions from 2026-07-02 scoping session + this brainstorm)
+**Issue:** ROB-646 (parent ROB-644, project "auto_trader Trading Decision Workspace")
+**Depends on:** ROB-643 (merged `a46b958e`) — the playbook `policy_keys:` block is the initial-value source.
+**Migration:** 0 (no DB changes).
+
+## Problem
+
+Verdict/judgment thresholds (RSI bands, upside minimums, sector cap, order sizing,
+recovery-gate count, etc.) live **only in prompt/context** today. They drift across
+sessions and models because no tool enforces or even echoes them. ROB-643 captured
+them **once** in the playbook `policy_keys:` block as an as-is baseline, explicitly
+labelled "seed, not a second source of truth — ROB-646 YAML becomes authoritative
+when it lands."
+
+This work makes that YAML the single authoritative source, exposes it read-only via
+MCP, stamps a policy version into run-start briefing, and adds the first (soft,
+fail-open) coded enforcement: a sector-cluster concentration cap check on buy previews.
+
+## Confirmed decisions (carried in)
+
+- **Storage = repo-committed YAML, single source.** PR review is the approval gate;
+  git is version/audit. Numbers are public (repo is public) — accepted. **No
+  account-specific data** (account numbers, balances, asset size) in the YAML.
+- **No write tools.** Operator edits via PR only. No `set_user_setting`-style ungated write.
+- **Scoping:** market (kr/us/crypto) × lane (buy/sell/discovery).
+- **Enforcement scope = hybrid.** Only the sector-cluster concentration cap (~9–10%)
+  is coded, on buy previews, **warning-field-first, fail-open**. All other thresholds
+  (RSI, resistance, upside, deep-limit, sizing…) are **advisory** — the tool echoes
+  them; the session cites them.
+- **Consumer stamping contract:** verdict records cite `policy_version` (explicit
+  version + content hash) so "what criteria did we judge under?" is recoverable from
+  report-item `evidence_snapshot`, `trade_retrospectives`, and forecast (P3, downstream).
+  Run-start briefing echoes the policy version (lightweight pin).
+- **Do NOT revive `trade_profile`** (dormant since ROB-488 `6bb1954d`). Declare
+  authority instead (see Authority below) to prevent a 4th split-brain.
+- **Do NOT migrate the fail-closed code guards** (loss guard `avg×1.01`,
+  ladder near-market `0.3%`, RSI scoring bands). Those stay as code. The policy YAML
+  is for **judgment thresholds only.**
+
+## Brainstorm decisions
+
+1. **YAML shape:** per-lane `defaults` (the captured values) + optional per-market
+   overrides. `get_trading_policy(market, lane)` resolves override→default. No
+   fabricated us/crypto numbers — KR-captured values are the shared default.
+2. **Cap-check depth:** lean best-effort, fail-open. The raw-sector→cluster grouping
+   lives **in the policy YAML** (it is a policy concern). Compute current + projected
+   cluster weight from positions joined to `symbol_sectors`; any missing sector data
+   or unmapped cluster ⇒ a fail-open field with a reason, never a block.
+3. **Buy-path coverage:** wire the shared path (`kis_live_place_order` + crypto) **and**
+   the Toss preview (Toss is the preferred, fee-free buy route and has its own preview).
+4. **Briefing echo:** in scope — `get_operating_briefing` gains a lightweight
+   `policy_version` field.
+5. **Lane naming:** canonical lane is **`sell`** (matches the playbook `policy_keys`
+   lane tags and ROB-649 `route_request` lane names). `profit_taking` is documented as
+   the human alias — not a second key.
+
+## Architecture
+
+### 1. `config/trading_policy.yaml` (new, repo root)
+
+Single authoritative source. Shape:
+
+```yaml
+version: "2026-07-02.1"          # explicit, bumped by operator on edit
+captured_as_of: "2026-07-02"     # provenance of the seed values
+source: "ROB-643 playbook policy_keys (seed); this file is now authoritative"
+
+authority:                       # split-brain prevention (see Authority section)
+  scope: judgment_thresholds_only
+  governs: "advisory judgment thresholds + the sector-cluster concentration cap"
+  does_not_govern:
+    - "loss_guard code guard (order_validation.py avg*1.01) — stays fail-closed in code"
+    - "ladder near-market guard (ladder_fill_safety.py 0.3%) — code"
+    - "RSI scoring bands (scoring.py) — code"
+    - "symbol_trade_settings — live per-symbol sizing (separate authority)"
+    - "sell_conditions — dormant/test-only (not authoritative)"
+    - "trade_profile — dead since ROB-488 (not revived)"
+
+# raw-sector -> cluster grouping used by the concentration cap.
+# keys under each cluster are matched against a symbol's symbol_sectors label
+# (name_kr / name_en / source_key). Best-effort; unmapped sectors => fail-open.
+sector_clusters:
+  financials: ["금융", "은행", "증권", "보험", "Financial Services", "Banks"]
+  shipbuilding_defense: ["조선", "방산", "Aerospace & Defense", ...]
+  bio: ["제약", "바이오", "Biotechnology", "Drug Manufacturers", ...]
+  semis_memory: ["반도체", "Semiconductors", ...]
+
+# defaults: captured thresholds, each tagged with the lanes that reference it
+# (exactly mirrors the playbook policy_keys `lanes:` membership).
+thresholds:
+  recovery_gate.min_conditions_met: {lanes: [buy], value: 2, unit: count, of: 4, semantics: "..."}
+  portfolio.sector_cluster_cap_pct: {lanes: [buy, sell], value: 10, unit: percent, semantics: "..."}
+  portfolio.max_symbols_per_theme: {lanes: [buy, discovery], value: 1, unit: count, semantics: "..."}
+  order.day_expiry_kst: {lanes: [buy, sell], value: "20:00", unit: kst_time, semantics: "..."}
+  buy.deep_limit_pct_range: {lanes: [buy], value: [-12, -3], unit: percent, semantics: "..."}
+  buy.per_symbol_notional_krw_range: {lanes: [buy, discovery], value: [200000, 400000], unit: krw, semantics: "..."}
+  sell.loss_guard_min_multiple: {lanes: [buy, sell], value: 1.01, unit: multiple_of_avg_cost, semantics: "..."}
+  sell.breakeven_near_pct: {lanes: [sell], value: 2, unit: percent, semantics: "..."}
+  sell.resistance_near_pct: {lanes: [sell], value: 6, unit: percent, semantics: "..."}
+  sell.rsi_place_min: {lanes: [sell], value: 58, unit: rsi, semantics: "..."}
+  sell.upside_place_max_pct: {lanes: [sell], value: 45, unit: percent, semantics: "..."}
+  sell.watch_rsi_max: {lanes: [sell], value: 52, unit: rsi, semantics: "..."}
+  sell.watch_upside_min_pct: {lanes: [sell], value: 50, unit: percent, semantics: "..."}
+  screen.rsi_max: {lanes: [discovery], value: 45, unit: rsi, semantics: "..."}
+  screen.support_within_pct: {lanes: [discovery], value: 8, unit: percent, semantics: "..."}
+  screen.upside_min_pct: {lanes: [discovery], value: 40, unit: percent, semantics: "..."}
+
+# per-market value overrides (empty at seed; KR is the captured baseline).
+market_overrides:
+  kr: {}
+  us: {}
+  crypto: {}   # equity-only keys (sector cap, RSI screens) may be marked N/A here later
+```
+
+All values above are transcribed verbatim from the ROB-643 `policy_keys:` block
+(playbook lines 265–352). The `semantics:` strings are copied from the playbook.
+
+### 2. `app/schemas/trading_policy.py` (new)
+
+Pydantic DTOs, `extra="forbid"` (matches `app/schemas/session_context.py` convention):
+
+- `PolicyThreshold` — `lanes: list[Lane]`, `value: <int|float|str|list>`, `unit: str`,
+  `semantics: str`, optional `of: int`.
+- `PolicyAuthority`, `TradingPolicyDocument` — top-level: `version`, `captured_as_of`,
+  `source`, `authority`, `sector_clusters: dict[str, list[str]]`,
+  `thresholds: dict[str, PolicyThreshold]`, `market_overrides: dict[Market, dict[str, Any]]`.
+- `Lane = Literal["buy","sell","discovery"]`, `Market = Literal["kr","us","crypto"]`.
+- Response DTO `TradingPolicyView` — `{version, content_hash, market, lane, thresholds: {...resolved...}}`.
+
+### 3. `app/services/trading_policy_service.py` (new)
+
+- `_POLICY_PATH = Path(__file__).resolve().parents[2] / "config" / "trading_policy.yaml"`
+  (`app/services/` → parents[2] = repo root; verify at impl time).
+- `load_trading_policy() -> TradingPolicyDocument` — `yaml.safe_load` + validate.
+  Load-once cache keyed by file mtime+size (so operator edits are picked up without
+  a restart in dev, but no re-read per call).
+- `policy_content_hash() -> str` — `sha256(raw_bytes).hexdigest()[:12]`.
+- `policy_version_stamp() -> dict` — `{"version": ..., "content_hash": ...}`. This is
+  the value consumers cite.
+- `get_policy_for(market: str, lane: str) -> TradingPolicyView` — validate market/lane
+  against the enums; **unknown market or lane raises `TradingPolicyKeyError`** (explicit,
+  not silent). Collect thresholds whose `lanes` contains `lane`, apply
+  `market_overrides[market][key]` when present (mark `source: default|override`), return
+  the view with `version` + `content_hash`.
+- `sector_cluster_for(label: str) -> str | None` — reverse lookup of `sector_clusters`
+  (case-insensitive substring/exact match, best-effort). Returns `None` when unmapped.
+
+### 4. `evaluate_sector_concentration(...)` in `app/mcp_server/tooling/order_validation.py`
+
+The shared, fail-open concentration helper (async — needs positions + sector I/O):
+
+```python
+async def evaluate_sector_concentration(
+    db, *, symbol: str, market: str, order_value_krw: float | None, account_ctx
+) -> dict:
+    # returns one of:
+    #   {"verdict": "within", "cluster": ..., "cap_pct": 10, "current_pct": ..., "projected_pct": ..., "fail_open": False}
+    #   {"verdict": "over",   "cluster": ..., "cap_pct": 10, "current_pct": ..., "projected_pct": ..., "fail_open": False, "warning": "..."}
+    #   {"verdict": "unknown", "fail_open": True, "reason": "sector data missing for X" | "no cluster mapping" | "crypto (no sectors)" | "<exc>"}
+```
+
+- Reads `cap_pct` from `get_policy_for(market, "buy").thresholds["portfolio.sector_cluster_cap_pct"]`.
+- Best-effort current sector-cluster weights: reuse existing portfolio positions
+  (via `portfolio_allocation_service` positions collector), join each held symbol to
+  `symbol_sectors` (universe `sector_id` → `SymbolSector`, the `screener_service.py`
+  outerjoin pattern), map label → cluster via `sector_cluster_for`, aggregate
+  `value_krw` per cluster / total.
+- Projected weight = (current cluster value + this order's KRW value) / (total + order value).
+- **Fail-open everywhere:** crypto market, symbol with no sector, unmapped cluster, or
+  ANY exception ⇒ `{"verdict": "unknown", "fail_open": True, "reason": ...}`. Never
+  raises, never blocks.
+
+### 5. Wire into buy previews (two call sites, one helper)
+
+- **Shared path** — `order_execution._place_order_impl`, buy side only, after the
+  `_check_balance_and_warn` block (~lines 1086–1103): call the helper, attach the result
+  as `dry_run_result["sector_concentration"]`. `_build_dry_run_response` already splats
+  `**dry_run_result`, so it surfaces automatically. `verdict == "over"` sets an
+  additional soft `warning` string; it does **not** flip `success` to False.
+- **Toss path** — `orders_toss_variants.toss_preview_order` (response assembly ~line 745)
+  and `_toss_place_order_impl` dry-run return (~line 859): attach the same
+  `sector_concentration` key. Buy side only.
+
+### 6. `get_trading_policy` MCP tool (read-only)
+
+Three-file split (matches session_context convention):
+- `app/mcp_server/tooling/trading_policy_tools.py` — `async def get_trading_policy(market, lane) -> dict`.
+  Validates via the request DTO; on unknown market/lane returns an **explicit error dict**
+  (`{"success": False, "error": "unknown_key", ...}`) rather than raising; on success
+  returns `TradingPolicyView.model_dump(mode="json")` including `version` + `content_hash`.
+- `app/mcp_server/tooling/trading_policy_registration.py` — `register_trading_policy_tools(mcp)`
+  + `TRADING_POLICY_TOOL_NAMES`. Description states the version-stamping contract.
+- `app/mcp_server/tooling/registry.py` — import + call in the **always-registered**
+  read-only block (appears in DEFAULT and every profile), NOT the profile-gated branch.
+
+### 7. Briefing version echo
+
+`get_operating_briefing` handler gains `policy_version = policy_version_stamp()`
+(`{version, content_hash}`) as an additive top-level field. Fail-open: if the policy
+file fails to load, the field is `None` with a reason and the briefing still returns.
+
+### 8. Docs
+
+- Update `docs/playbooks/trading-decision-playbook.md`: add an **Authority** note (this
+  YAML now authoritative; `profit_taking` = alias of `sell` lane) — the playbook already
+  flagged itself as "seed, not source" so this closes that loop.
+- Update `app/mcp_server/README.md` (or the tooling README): document `get_trading_policy`
+  + the version-stamping contract (consumers cite `{version, content_hash}` from the tool
+  or briefing in `evidence_snapshot` / `trade_retrospectives` / forecast).
+- Add the authority declaration referenced by the issue (jurisdiction vs
+  sell_conditions / symbol_trade_settings / trade_profile).
+
+### 9. Dependency
+
+Add `pyyaml` (+ `types-PyYAML` in the dev/typing group) as explicit deps in
+`pyproject.toml`. It is present transitively today but app code should not rely on that.
+
+## Out of scope (explicit)
+
+- Wiring `policy_version` into `report_item.evidence_snapshot` / `trade_retrospectives`
+  write paths — this PR provides the **source** + documents the **contract** + briefing
+  echo. Downstream consumers cite it in their own issues (forecast = P3).
+- Any write/edit tool for the policy (operator PR only).
+- Reviving `trade_profile`.
+- Migrating the fail-closed code guards into YAML.
+
+## Testing
+
+- **service:** valid load; `content_hash` stable across calls, changes when file bytes
+  change; unknown market/lane raises `TradingPolicyKeyError`; override resolution marks
+  `source`; `version` present; `sector_cluster_for` mapping + `None` for unmapped.
+- **schema:** `extra="forbid"` rejects unknown top-level / threshold keys.
+- **tool:** returns thresholds + version for a valid (market, lane); unknown key ⇒
+  explicit error dict (AC).
+- **concentration helper:** `within` / `over` / `unknown`; fail-open on missing sector,
+  unmapped cluster, crypto, and injected exception; never raises; `over` never blocks.
+- **preview wiring:** shared path (kis_live/crypto) and Toss preview both include
+  `sector_concentration`; crypto ⇒ fail-open field; `over` keeps `success: True`.
+- **briefing:** `policy_version` present; fail-open when file unreadable.
+- **registration:** `get_trading_policy` registered in DEFAULT profile (reuse the
+  `DummyMCP` + `register_all_tools` matrix pattern used by `tests/test_playbook_tool_names.py`).
+
+## Acceptance criteria (from issue)
+
+- [x] `get_trading_policy` returns market×lane thresholds + version; unknown key ⇒ explicit error.
+- [x] Buy preview response has a concentration-check field (cap / current weight / verdict);
+      fail-open + reason on missing sector data.
+- [x] Version-stamping contract stated in tool description + README.
+- [x] migration 0.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "passlib[bcrypt]>=1.7.4,<2.0.0",
     "bcrypt>=4.3.0,<5.0.0",
     "python-multipart>=0.0.6,<0.1.0",
+    "pyyaml>=6.0.1,<7.0.0",
     "websockets>=15,<17.0",
     "taskiq>=0.11.18,<1.0.0",
     "taskiq-redis>=1.0.0,<2.0.0",
@@ -66,6 +67,7 @@ dev = [
     "ruff>=0.14.10",
     "ty>=0.0.18,<0.1.0",
     "pytest-httpx>=0.36.2",
+    "types-PyYAML>=6.0.0",
 ]
 
 [tool.pytest.ini_options]

--- a/tests/mcp_server/test_buy_preview_concentration_field.py
+++ b/tests/mcp_server/test_buy_preview_concentration_field.py
@@ -1,0 +1,170 @@
+from decimal import Decimal
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.mcp_server.tooling import order_execution
+
+
+@pytest.mark.asyncio
+async def test_shared_buy_preview_includes_concentration(monkeypatch):
+    async def _fake_conc(**kwargs):
+        return {
+            "verdict": "over",
+            "cluster": "semis_memory",
+            "cap_pct": 10,
+            "current_pct": 8.0,
+            "projected_pct": 11.5,
+            "fail_open": False,
+            "warning": "semis_memory projected 11.5% exceeds sector-cluster cap 10%",
+        }
+
+    monkeypatch.setattr(
+        order_execution, "evaluate_sector_concentration", _fake_conc, raising=False
+    )
+    monkeypatch.setattr(
+        order_execution, "_fetch_current_price", AsyncMock(return_value=55000.0)
+    )
+    monkeypatch.setattr(
+        order_execution,
+        "_build_preview",
+        AsyncMock(
+            return_value={
+                "price": 55000,
+                "quantity": 10,
+                "estimated_value": 550000.0,
+                "fee": 0,
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        order_execution, "_check_balance_and_warn", AsyncMock(return_value=(None, None))
+    )
+    monkeypatch.setattr(order_execution, "_record_order_history", AsyncMock())
+
+    result = await order_execution._place_order_impl(
+        symbol="005930",
+        side="buy",
+        order_type="limit",
+        quantity=10,
+        price=55000.0,
+        dry_run=True,
+        is_mock=True,
+    )
+
+    assert result["success"] is True
+    assert "sector_concentration" in result
+    assert result["sector_concentration"]["verdict"] == "over"
+    assert (
+        result["sector_concentration"]["warning"]
+        == "semis_memory projected 11.5% exceeds sector-cluster cap 10%"
+    )
+
+
+@pytest.mark.asyncio
+async def test_toss_buy_preview_includes_concentration(monkeypatch):
+    # Enable Toss preview environment
+    from app.core.config import settings
+    from app.mcp_server.tooling import orders_toss_variants
+
+    monkeypatch.setattr(settings, "toss_api_enabled", True)
+    monkeypatch.setattr(orders_toss_variants, "validate_toss_api_config", lambda: [])
+
+    # Stub cost context and currency rate helpers
+    async def _stub_toss_costs():
+        return {
+            "version": 1,
+            "accounts": {
+                "toss": {
+                    "broker": "toss",
+                    "markets": {
+                        "kr": {"commission_bps": 0.0, "fx_spread_bps": 0.0},
+                        "us": {"commission_bps": 10.0, "fx_spread_bps": 1.7},
+                    },
+                }
+            },
+        }
+
+    async def _stub_usd_krw_quote():
+        return SimpleNamespace(default_rate=1360.0, source="toss")
+
+    monkeypatch.setattr(
+        orders_toss_variants,
+        "get_account_costs_setting",
+        AsyncMock(side_effect=_stub_toss_costs),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        orders_toss_variants,
+        "get_usd_krw_rate_details",
+        AsyncMock(side_effect=_stub_usd_krw_quote),
+        raising=False,
+    )
+
+    # Mock Toss Client
+    class _FakeTossClient:
+        async def aclose(self):
+            return None
+
+        async def list_orders(self, **kwargs):
+            return SimpleNamespace(orders=[])
+
+        async def fetch_multiple_current_prices(self, symbols):
+            return {"005930": Decimal("50000")}
+
+    class _FakeClientContext:
+        async def __aenter__(self):
+            return _FakeTossClient()
+
+        async def __aexit__(self, exc_type, exc_val, exc_tb):
+            pass
+
+    monkeypatch.setattr(
+        orders_toss_variants, "_client_context", lambda: _FakeClientContext()
+    )
+
+    async def _fake_conc(**kwargs):
+        return {
+            "verdict": "over",
+            "cluster": "financials",
+            "cap_pct": 10,
+            "current_pct": 9.5,
+            "projected_pct": 11.2,
+            "fail_open": False,
+            "warning": "financials projected 11.2% exceeds sector-cluster cap 10%",
+        }
+
+    monkeypatch.setattr(
+        orders_toss_variants, "evaluate_sector_concentration", _fake_conc, raising=False
+    )
+
+    res = await orders_toss_variants.toss_preview_order(
+        symbol="005930",
+        side="buy",
+        quantity=3,
+        price="50000",
+        order_amount="150000",
+        account_mode="toss_live",
+    )
+
+    assert res["success"] is True
+    assert "sector_concentration" in res
+    assert res["sector_concentration"]["verdict"] == "over"
+    assert (
+        "financials projected 11.2% exceeds sector-cluster cap 10%"
+        in res["order_warnings"]
+    )
+
+    res_place = await orders_toss_variants.toss_place_order(
+        symbol="005930",
+        side="buy",
+        quantity="3",
+        price="50000",
+        order_amount="150000",
+        account_mode="toss_live",
+        dry_run=True,
+    )
+    assert res_place["success"] is True
+    assert "sector_concentration" in res_place
+    assert res_place["sector_concentration"]["verdict"] == "over"

--- a/tests/mcp_server/test_buy_preview_concentration_field.py
+++ b/tests/mcp_server/test_buy_preview_concentration_field.py
@@ -168,3 +168,59 @@ async def test_toss_buy_preview_includes_concentration(monkeypatch):
     assert res_place["success"] is True
     assert "sector_concentration" in res_place
     assert res_place["sector_concentration"]["verdict"] == "over"
+
+
+@pytest.mark.asyncio
+async def test_shared_buy_preview_uses_whole_portfolio_scope(monkeypatch):
+    # ROB-646 Finding 1: the KIS/crypto call site must pass a whole-portfolio
+    # account_ctx (only is_mock, no account/market filter) so its denominator
+    # matches the Toss path.
+    captured: dict = {}
+
+    async def _capture_conc(**kwargs):
+        captured.update(kwargs)
+        return {
+            "verdict": "within",
+            "cluster": "semis_memory",
+            "cap_pct": 10,
+            "current_pct": 1.0,
+            "projected_pct": 1.1,
+            "fail_open": False,
+        }
+
+    monkeypatch.setattr(
+        order_execution, "evaluate_sector_concentration", _capture_conc, raising=False
+    )
+    monkeypatch.setattr(
+        order_execution, "_fetch_current_price", AsyncMock(return_value=55000.0)
+    )
+    monkeypatch.setattr(
+        order_execution,
+        "_build_preview",
+        AsyncMock(
+            return_value={
+                "price": 55000,
+                "quantity": 10,
+                "estimated_value": 550000.0,
+                "fee": 0,
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        order_execution, "_check_balance_and_warn", AsyncMock(return_value=(None, None))
+    )
+    monkeypatch.setattr(order_execution, "_record_order_history", AsyncMock())
+
+    await order_execution._place_order_impl(
+        symbol="005930",
+        side="buy",
+        order_type="limit",
+        quantity=10,
+        price=55000.0,
+        dry_run=True,
+        is_mock=True,
+    )
+
+    assert captured["account_ctx"] == {"is_mock": True}
+    assert "account" not in captured["account_ctx"]
+    assert "market" not in captured["account_ctx"]

--- a/tests/mcp_server/test_operating_briefing_policy_version.py
+++ b/tests/mcp_server/test_operating_briefing_policy_version.py
@@ -1,0 +1,55 @@
+from datetime import UTC, datetime
+
+import pytest
+
+from app.mcp_server.tooling import operating_briefing as ob
+
+
+@pytest.mark.asyncio
+async def test_briefing_includes_policy_version(monkeypatch):
+    async def fake_holdings(**kwargs):
+        return {
+            "total_positions": 0,
+            "summary": {"total_value": 0},
+            "accounts": [],
+            "errors": [],
+        }
+
+    class FakePendingSnapshot:
+        orders = []
+        as_of = "2026-07-02T16:30:00+09:00"
+        freshness_status = "fresh"
+        unavailable_reason = None
+        account_scope = "kis_live"
+
+    async def fake_pending(db, *, market, account_scope):
+        return FakePendingSnapshot()
+
+    async def fake_active_watches(**kwargs):
+        return {
+            "success": True,
+            "count": 0,
+            "as_of": datetime.now(tz=UTC).isoformat(),
+            "active_watches": [],
+        }
+
+    async def fake_latest_report(db, *, market, account_scope):
+        return None
+
+    async def fake_recent_session(db, *, market, account_scope, limit):
+        return {"count": 0, "entries": []}
+
+    async def fake_recent_analysis(db, *, market):
+        return {"count": 0, "artifacts": []}
+
+    monkeypatch.setattr(ob, "_get_holdings_impl", fake_holdings)
+    monkeypatch.setattr(ob, "collect_pending_orders_snapshot", fake_pending)
+    monkeypatch.setattr(ob, "list_active_watches_impl", fake_active_watches)
+    monkeypatch.setattr(ob, "_latest_report_summary", fake_latest_report)
+    monkeypatch.setattr(ob, "_recent_session_context", fake_recent_session)
+    monkeypatch.setattr(ob, "_recent_analysis_artifacts", fake_recent_analysis)
+
+    resp = await ob.get_operating_briefing_impl(market="kr")
+    assert "policy_version" in resp
+    assert resp["policy_version"]["version"] == "2026-07-02.1"
+    assert resp["policy_version"]["content_hash"]

--- a/tests/mcp_server/test_sector_concentration.py
+++ b/tests/mcp_server/test_sector_concentration.py
@@ -1,0 +1,127 @@
+import pytest
+
+from app.mcp_server.tooling import order_validation as ov
+
+
+async def _weights_ok(*, market, account_ctx):
+    # semis cluster currently 800k of 10M total = 8%
+    return {
+        "clusters": {"semis_memory": 800_000.0},
+        "total_krw": 10_000_000.0,
+        "usd_krw": 1350.0,
+    }
+
+
+async def _cluster_semis(*, symbol, market):
+    return "semis_memory"
+
+
+@pytest.mark.asyncio
+async def test_within_cap():
+    out = await ov.evaluate_sector_concentration(
+        symbol="005930",
+        market="kr",
+        order_estimated_value=100_000.0,
+        order_currency="KRW",
+        account_ctx={},
+        _weights_provider=_weights_ok,
+        _cluster_resolver=_cluster_semis,
+    )
+    assert out["verdict"] == "within"
+    assert out["cluster"] == "semis_memory"
+    assert out["cap_pct"] == 10
+    assert out["fail_open"] is False
+    # projected = (800k + 100k) / (10M + 100k) ~= 8.9%
+    assert 8.5 < out["projected_pct"] < 9.3
+
+
+@pytest.mark.asyncio
+async def test_over_cap_warns_but_does_not_block():
+    async def _weights_hot(*, market, account_ctx):
+        return {
+            "clusters": {"semis_memory": 950_000.0},
+            "total_krw": 10_000_000.0,
+            "usd_krw": 1350.0,
+        }
+
+    out = await ov.evaluate_sector_concentration(
+        symbol="000660",
+        market="kr",
+        order_estimated_value=300_000.0,
+        order_currency="KRW",
+        account_ctx={},
+        _weights_provider=_weights_hot,
+        _cluster_resolver=_cluster_semis,
+    )
+    assert out["verdict"] == "over"
+    assert "warning" in out
+    assert out["fail_open"] is False
+
+
+@pytest.mark.asyncio
+async def test_crypto_fails_open():
+    out = await ov.evaluate_sector_concentration(
+        symbol="KRW-BTC",
+        market="crypto",
+        order_estimated_value=100_000.0,
+        order_currency="KRW",
+        account_ctx={},
+        _weights_provider=_weights_ok,
+        _cluster_resolver=_cluster_semis,
+    )
+    assert out["verdict"] == "unknown"
+    assert out["fail_open"] is True
+    assert "crypto" in out["reason"]
+
+
+@pytest.mark.asyncio
+async def test_unmapped_cluster_fails_open():
+    async def _no_cluster(*, symbol, market):
+        return None
+
+    out = await ov.evaluate_sector_concentration(
+        symbol="123456",
+        market="kr",
+        order_estimated_value=100_000.0,
+        order_currency="KRW",
+        account_ctx={},
+        _weights_provider=_weights_ok,
+        _cluster_resolver=_no_cluster,
+    )
+    assert out["verdict"] == "unknown"
+    assert out["fail_open"] is True
+
+
+@pytest.mark.asyncio
+async def test_provider_exception_fails_open():
+    async def _boom(*, market, account_ctx):
+        raise RuntimeError("broker down")
+
+    out = await ov.evaluate_sector_concentration(
+        symbol="005930",
+        market="kr",
+        order_estimated_value=100_000.0,
+        order_currency="KRW",
+        account_ctx={},
+        _weights_provider=_boom,
+        _cluster_resolver=_cluster_semis,
+    )
+    assert out["verdict"] == "unknown"
+    assert out["fail_open"] is True
+    assert "broker down" in out["reason"]
+
+
+@pytest.mark.asyncio
+async def test_missing_order_value_uses_current_only():
+    out = await ov.evaluate_sector_concentration(
+        symbol="005930",
+        market="kr",
+        order_estimated_value=None,
+        order_currency="KRW",
+        account_ctx={},
+        _weights_provider=_weights_ok,
+        _cluster_resolver=_cluster_semis,
+    )
+    # current 8% within cap; projected omitted or equals current
+    assert out["verdict"] == "within"
+    assert out["current_pct"] == pytest.approx(8.0, abs=0.01)

--- a/tests/mcp_server/test_sector_concentration.py
+++ b/tests/mcp_server/test_sector_concentration.py
@@ -125,3 +125,92 @@ async def test_missing_order_value_uses_current_only():
     # current 8% within cap; projected omitted or equals current
     assert out["verdict"] == "within"
     assert out["current_pct"] == pytest.approx(8.0, abs=0.01)
+
+
+# --- ROB-646 Finding 1: whole-portfolio aggregation + per-position market ---
+
+
+@pytest.mark.asyncio
+async def test_compute_weights_aggregates_whole_portfolio(monkeypatch):
+    async def _fake_alloc(**kwargs):
+        return {
+            "currency": {"usd_krw": 1300.0},
+            "positions": [
+                {
+                    "symbol": "005930",
+                    "effective_asset_class": "kr_equity",
+                    "value_krw": 800_000.0,
+                    "sector": "반도체",
+                },
+                {
+                    "symbol": "AAPL",
+                    "effective_asset_class": "us_equity",
+                    "value_krw": 1_200_000.0,
+                    "sector": "Semiconductors",
+                },
+                {
+                    "symbol": "KRW-BTC",
+                    "effective_asset_class": "crypto",
+                    "value_krw": 2_000_000.0,
+                },
+            ],
+        }
+
+    monkeypatch.setattr(
+        "app.mcp_server.tooling.portfolio_allocation.get_portfolio_allocation_impl",
+        _fake_alloc,
+    )
+    out = await ov.compute_sector_cluster_weights(
+        market="kr", account_ctx={"is_mock": False}
+    )
+    # crypto counts toward the denominator (it IS part of the portfolio)
+    assert out["total_krw"] == 4_000_000.0
+    # KR + US semis holdings aggregate into one cluster
+    assert out["clusters"]["semis_memory"] == 2_000_000.0
+    assert out["usd_krw"] == 1300.0
+
+
+@pytest.mark.asyncio
+async def test_compute_weights_resolves_per_position_market(monkeypatch):
+    # A US holding with no inline sector label must be looked up in the US
+    # universe even though the *buy's* market is "kr" (whole-portfolio view).
+    async def _fake_alloc(**kwargs):
+        return {
+            "currency": {"usd_krw": 1300.0},
+            "positions": [
+                {
+                    "symbol": "AAPL",
+                    "effective_asset_class": "us_equity",
+                    "value_krw": 1_000_000.0,
+                },
+            ],
+        }
+
+    monkeypatch.setattr(
+        "app.mcp_server.tooling.portfolio_allocation.get_portfolio_allocation_impl",
+        _fake_alloc,
+    )
+    seen: dict[str, str] = {}
+
+    async def _fake_lookup(db, *, symbol, market):
+        seen["symbol"] = symbol
+        seen["market"] = market
+        return "Semiconductors"
+
+    monkeypatch.setattr(ov, "_lookup_symbol_sector_label", _fake_lookup)
+
+    class _FakeCM:
+        async def __aenter__(self):
+            return object()
+
+        async def __aexit__(self, *a):
+            return False
+
+    monkeypatch.setattr("app.core.db.AsyncSessionLocal", lambda: _FakeCM())
+
+    out = await ov.compute_sector_cluster_weights(
+        market="kr", account_ctx={"is_mock": False}
+    )
+    assert seen["market"] == "us"
+    assert seen["symbol"] == "AAPL"
+    assert out["clusters"]["semis_memory"] == 1_000_000.0

--- a/tests/mcp_server/test_trading_policy_tool.py
+++ b/tests/mcp_server/test_trading_policy_tool.py
@@ -1,0 +1,37 @@
+from typing import Any, cast
+
+import pytest
+
+from app.mcp_server.profiles import McpProfile
+from app.mcp_server.tooling.registry import register_all_tools
+from app.mcp_server.tooling.trading_policy_tools import get_trading_policy
+from tests._mcp_tooling_support import DummyMCP
+
+
+@pytest.mark.asyncio
+async def test_get_trading_policy_returns_thresholds_and_version():
+    out = await get_trading_policy(market="kr", lane="buy")
+    assert out["success"] is True
+    assert out["version"] == "2026-07-02.1"
+    assert out["content_hash"]
+    assert out["thresholds"]["portfolio.sector_cluster_cap_pct"]["value"] == 10
+
+
+@pytest.mark.asyncio
+async def test_get_trading_policy_unknown_key_explicit_error():
+    out = await get_trading_policy(market="jp", lane="buy")
+    assert out["success"] is False
+    assert out["error"] == "unknown_key"
+    assert "jp" in out["detail"]
+
+
+def test_tool_registered_in_default_profile():
+    mcp = DummyMCP()
+    register_all_tools(cast(Any, mcp), profile=McpProfile.DEFAULT)
+    assert "get_trading_policy" in mcp.tools
+
+
+def test_tool_registered_in_crypto_profile():
+    mcp = DummyMCP()
+    register_all_tools(cast(Any, mcp), profile=McpProfile.CRYPTO)
+    assert "get_trading_policy" in mcp.tools

--- a/tests/schemas/test_trading_policy_schema.py
+++ b/tests/schemas/test_trading_policy_schema.py
@@ -1,0 +1,39 @@
+from pathlib import Path
+
+import pytest
+import yaml
+from pydantic import ValidationError
+
+from app.schemas.trading_policy import TradingPolicyDocument
+
+_CONFIG = Path(__file__).resolve().parents[2] / "config" / "trading_policy.yaml"
+
+
+def _raw() -> dict:
+    return yaml.safe_load(_CONFIG.read_text(encoding="utf-8"))
+
+
+def test_shipped_config_validates():
+    doc = TradingPolicyDocument.model_validate(_raw())
+    assert doc.version == "2026-07-02.1"
+    # verbatim seed values from the playbook policy_keys
+    assert doc.thresholds["portfolio.sector_cluster_cap_pct"].value == 10
+    assert doc.thresholds["sell.loss_guard_min_multiple"].value == 1.01
+    assert doc.thresholds["screen.rsi_max"].value == 45
+    assert doc.thresholds["buy.deep_limit_pct_range"].value == [-12, -3]
+    assert set(doc.market_overrides.keys()) == {"kr", "us", "crypto"}
+    assert "semis_memory" in doc.sector_clusters
+
+
+def test_extra_key_rejected():
+    raw = _raw()
+    raw["unexpected_top_level"] = 1
+    with pytest.raises(ValidationError):
+        TradingPolicyDocument.model_validate(raw)
+
+
+def test_extra_threshold_key_rejected():
+    raw = _raw()
+    raw["thresholds"]["screen.rsi_max"]["bogus"] = 1
+    with pytest.raises(ValidationError):
+        TradingPolicyDocument.model_validate(raw)

--- a/tests/services/test_trading_policy_service.py
+++ b/tests/services/test_trading_policy_service.py
@@ -1,0 +1,69 @@
+import pytest
+
+from app.services import trading_policy_service as svc
+
+
+def test_version_stamp_has_version_and_hash():
+    stamp = svc.policy_version_stamp()
+    assert stamp["version"] == "2026-07-02.1"
+    assert len(stamp["content_hash"]) == 12
+
+
+def test_content_hash_stable_across_calls():
+    assert svc.policy_content_hash() == svc.policy_content_hash()
+
+
+def test_get_policy_for_buy_kr_includes_cap_and_version():
+    view = svc.get_policy_for("kr", "buy")
+    assert view["version"] == "2026-07-02.1"
+    assert view["content_hash"]
+    t = view["thresholds"]
+    # buy lane references these (playbook lane tags)
+    assert t["portfolio.sector_cluster_cap_pct"]["value"] == 10
+    assert t["portfolio.sector_cluster_cap_pct"]["source"] == "default"
+    assert t["recovery_gate.min_conditions_met"]["value"] == 2
+    assert t["sell.loss_guard_min_multiple"]["value"] == 1.01
+    # sell-only threshold must NOT appear in the buy lane
+    assert "sell.rsi_place_min" not in t
+
+
+def test_get_policy_for_sell_lane_has_sell_keys():
+    t = svc.get_policy_for("kr", "sell")["thresholds"]
+    assert t["sell.rsi_place_min"]["value"] == 58
+    assert "screen.rsi_max" not in t
+
+
+def test_unknown_market_raises():
+    with pytest.raises(svc.TradingPolicyKeyError):
+        svc.get_policy_for("jp", "buy")
+
+
+def test_unknown_lane_raises():
+    with pytest.raises(svc.TradingPolicyKeyError):
+        svc.get_policy_for("kr", "scalp")
+
+
+def test_market_override_applied(monkeypatch, tmp_path):
+    from pathlib import Path
+
+    import yaml
+
+    raw = yaml.safe_load(svc._POLICY_PATH.read_text(encoding="utf-8"))
+    raw["market_overrides"]["us"]["screen.rsi_max"] = 55
+    p = tmp_path / "trading_policy.yaml"
+    p.write_text(yaml.safe_dump(raw), encoding="utf-8")
+    monkeypatch.setattr(svc, "_POLICY_PATH", Path(p))
+    svc.load_trading_policy.cache_clear() if hasattr(
+        svc.load_trading_policy, "cache_clear"
+    ) else None
+    svc._reset_cache_for_tests()
+    t = svc.get_policy_for("us", "discovery")["thresholds"]
+    assert t["screen.rsi_max"]["value"] == 55
+    assert t["screen.rsi_max"]["source"] == "override"
+
+
+def test_sector_cluster_for():
+    assert svc.sector_cluster_for("반도체") == "semis_memory"
+    assert svc.sector_cluster_for("Financial Services") == "financials"
+    assert svc.sector_cluster_for("정체불명업종") is None
+    assert svc.sector_cluster_for(None) is None

--- a/tests/services/test_trading_policy_service.py
+++ b/tests/services/test_trading_policy_service.py
@@ -67,3 +67,26 @@ def test_sector_cluster_for():
     assert svc.sector_cluster_for("Financial Services") == "financials"
     assert svc.sector_cluster_for("정체불명업종") is None
     assert svc.sector_cluster_for(None) is None
+
+
+def test_sector_cluster_for_no_cjk_substring_false_positive():
+    # ROB-646 Finding 3: "의료" must not spill into unrelated 업종 like
+    # "의료정밀" (medical *precision instruments*). Member "의료" removed +
+    # matcher is one-directional (member is a substring of the label, not the
+    # reverse), so "의료정밀" resolves to no cluster.
+    assert svc.sector_cluster_for("의료정밀") is None
+
+
+def test_sector_cluster_for_broad_healthcare_not_bio():
+    # ROB-646 Finding 3: a generic "Healthcare" sector (e.g. managed-care /
+    # health insurers) must not be bucketed as bio.
+    assert svc.sector_cluster_for("Healthcare") is None
+    assert svc.sector_cluster_for("Healthcare Plans") is None
+
+
+def test_sector_cluster_for_prefix_coverage_preserved():
+    # One-directional match still gives real KR coverage: the Naver 업종
+    # "반도체와반도체장비" contains the member "반도체".
+    assert svc.sector_cluster_for("반도체와반도체장비") == "semis_memory"
+    # yfinance em-dash variants still map (member is a substring of the label).
+    assert svc.sector_cluster_for("Drug Manufacturers—General") == "bio"

--- a/uv.lock
+++ b/uv.lock
@@ -248,6 +248,7 @@ dependencies = [
     { name = "pydantic-settings" },
     { name = "pyjwt" },
     { name = "python-multipart" },
+    { name = "pyyaml" },
     { name = "redis" },
     { name = "sentry-sdk", extra = ["fastapi"] },
     { name = "setuptools" },
@@ -273,6 +274,7 @@ dev = [
     { name = "ruff" },
     { name = "safety" },
     { name = "ty" },
+    { name = "types-pyyaml" },
 ]
 test = [
     { name = "aiosqlite" },
@@ -310,6 +312,7 @@ requires-dist = [
     { name = "pydantic-settings", specifier = ">=2.10.1,<3.0.0" },
     { name = "pyjwt", specifier = ">=2.8.0,<3.0.0" },
     { name = "python-multipart", specifier = ">=0.0.6,<0.1.0" },
+    { name = "pyyaml", specifier = ">=6.0.1,<7.0.0" },
     { name = "redis", specifier = ">=7.2.0,<8.0.0" },
     { name = "sentry-sdk", extras = ["fastapi"], specifier = ">=2.18.0,<3.0.0" },
     { name = "setuptools", specifier = ">=70.0.0" },
@@ -335,6 +338,7 @@ dev = [
     { name = "ruff", specifier = ">=0.14.10" },
     { name = "safety", specifier = ">=3.7.0,<3.8.0" },
     { name = "ty", specifier = ">=0.0.18,<0.1.0" },
+    { name = "types-pyyaml", specifier = ">=6.0.0" },
 ]
 test = [
     { name = "aiosqlite", specifier = ">=0.19.0,<1.0.0" },
@@ -3002,6 +3006,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f5/24/cb09efec5cc954f7f9b930bf8279447d24618bb6758d4f6adf2574c41780/typer-0.24.1.tar.gz", hash = "sha256:e39b4732d65fbdcde189ae76cf7cd48aeae72919dea1fdfc16593be016256b45", size = 118613, upload-time = "2026-02-21T16:54:40.609Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4a/91/48db081e7a63bb37284f9fbcefda7c44c277b18b0e13fbc36ea2335b71e6/typer-0.24.1-py3-none-any.whl", hash = "sha256:112c1f0ce578bfb4cab9ffdabc68f031416ebcc216536611ba21f04e9aa84c9e", size = 56085, upload-time = "2026-02-21T16:54:41.616Z" },
+]
+
+[[package]]
+name = "types-pyyaml"
+version = "6.0.12.20260518"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b8/83/4a1afc3fbfcf5b8d46fc390cd95ed6b0dc9010a265f4e9f46314efffa37a/types_pyyaml-6.0.12.20260518.tar.gz", hash = "sha256:d917f83fb38462550338c1297faedd860b3ec83912b96b1e3d73255f7473e466", size = 17850, upload-time = "2026-05-18T06:01:58.675Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/06/a2/c01db32be2ae7d6a1689972f3c492b149ee4e164b12fdfd9f64b50888215/types_pyyaml-6.0.12.20260518-py3-none-any.whl", hash = "sha256:d2150f75a231c9fe9c7463bd29487d93e60bac90400287351384bc2284eba7cd", size = 20312, upload-time = "2026-05-18T06:01:57.368Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## ROB-646 — Trading policy YAML single source + `get_trading_policy` + version stamping + buy-preview concentration cap

Makes a repo-committed `config/trading_policy.yaml` the single authoritative source of trading **judgment** thresholds (seeded verbatim from the ROB-643 playbook `policy_keys`), exposes it read-only, stamps its version into run-start briefing, and adds a soft **fail-open** sector-cluster concentration check to buy previews.

### What landed
- **`config/trading_policy.yaml`** — single source. `thresholds` (lane-tagged, values transcribed verbatim from the playbook) + per-market `market_overrides` + `sector_clusters` grouping + an `authority` declaration. Operator-PR-edited; **no write tool**.
- **`app/schemas/trading_policy.py`** — pydantic DTOs, `extra="forbid"`.
- **`app/services/trading_policy_service.py`** — load-once loader, `content_hash`, `get_policy_for(market, lane)` (unknown key → `TradingPolicyKeyError`), `policy_version_stamp`, `sector_cluster_for`.
- **`get_trading_policy(market, lane)`** — read-only MCP tool, registered in **all** profiles; echoes `{version, content_hash}`; unknown key → `success=false, error=unknown_key`.
- **`evaluate_sector_concentration`** (`order_validation.py`) — fail-open (crypto / missing sector / any exception → `unknown`); **never raises, never blocks, never flips `success`**. Wired into both the shared (KIS/crypto) buy path **and** Toss preview; `over` is a soft warning only.
- **`get_operating_briefing`** — lightweight `policy_version` echo (fail-open).
- Docs: playbook authority note, README version-stamping contract, CLAUDE.md section.

### Scoping decisions
- Lane `sell` is canonical (matches playbook + ROB-649); `profit_taking` is a documented alias.
- Concentration cap measures the **whole cross-broker portfolio** consistently on both buy paths; each holding is resolved via its own market.
- Sector-cluster matching is one-directional (member ⊂ label) to avoid false positives.

### Verification
- ROB-646 suite + profiles/playbook/order/toss/briefing regression: **all green**; `ruff` + `ty` clean.
- **migration 0**; no in-process LLM provider import (ROB-501 guard passes).

### Follow-ups (non-blocking, fail-open — filed separately)
- Concentration measurement runs a full `get_portfolio_allocation` round-trip on every live buy preview (latency/load).
- US `name_kr` preference / cross-market holdings can leave a cluster unmapped (under-coverage, fail-open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a read-only trading policy lookup so policy thresholds can be retrieved by market and lane.
  * Buy previews and dry runs now show sector concentration checks and related warnings.
  * Operating briefing responses now include a policy version stamp for traceability.

* **Bug Fixes**
  * Sector concentration checks now fail open on missing or unmapped data, avoiding unnecessary order blocking.

* **Documentation**
  * Updated guidance for the new policy source and how to reference it.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->