### PR TITLE
feat(ROB-658): market-aware execution mapping — crypto/US place_order no longer misclassified as blocked in route_request

### DIFF
--- a/app/mcp_server/README.md
+++ b/app/mcp_server/README.md
@@ -1348,6 +1348,17 @@ is kept in sync by `tests/test_route_request_registry_diff.py`. Every DEFAULT
 tool must be classified into `READ_ONLY_ADVISORY_TOOLS` or a mutation set or CI
 fails (silent-drift guard).
 
+**Market-aware execution mapping (ROB-658):** the playbook lane sequences are
+KR-centric — their place steps hard-code `toss_place_order`/`kis_live_place_order`.
+On crypto/US profiles those tools are unregistered, so `route_request` substitutes
+the market's generic execution surface via `MARKET_EXECUTION_TOOLS`
+(`crypto`/`us` → `place_order`; `kr` → empty, already in the sequence). When a
+lane places orders but none of its KR place tools survive the profile
+intersection, the generic `place_order` is injected as the execution step and
+counted as the lane's own mutation — so it appears in `standard_tool_sequence` +
+`allowed_tools` instead of being misclassified into `blocked_actions`. KR output
+is unchanged.
+
 
 ### User Settings Tools
 

--- a/app/mcp_server/tooling/route_request_lanes.py
+++ b/app/mcp_server/tooling/route_request_lanes.py
@@ -158,6 +158,37 @@ MUTATION_TOOLS: frozenset[str] = frozenset(
     | KIWOOM_MOCK_TOOL_NAMES
 )
 
+# Market-aware execution mutation tools (ROB-658). The LANE_SEQUENCES above are
+# KR-centric (ported from the playbook, kept in sync by the registry-diff test),
+# so their execution steps hard-code toss/kis. On crypto/US profiles those tools
+# are unregistered, so without a market-aware supplement the generic place_order
+# — the real crypto/US execution surface — falls into blocked_actions and never
+# appears in the sequence/allowed list. KR needs no supplement (its execution
+# tools already live in LANE_SEQUENCES); US/crypto route execution through the
+# generic place_order, which the playbook lanes never list.
+MARKET_EXECUTION_TOOLS: dict[str, frozenset[str]] = {
+    "kr": frozenset(),
+    "us": frozenset({"place_order"}),
+    "crypto": frozenset({"place_order"}),
+}
+
+# Order-placement tools that mark a lane as "executing" (as opposed to a
+# fill-safety/preview or reconcile helper such as sell_ladder_fill_preview, which
+# is also mutation-classified but is not the actual place step). Used to decide
+# whether a lane warrants a market-aware execution step and whether that step's
+# KR-centric tools survived the profile intersection.
+_PLACE_ORDER_TOOLS: frozenset[str] = frozenset(
+    {"place_order", "toss_place_order", "kis_live_place_order"}
+)
+
+# Purpose text for the market execution step injected into the sequence when the
+# lane's KR-centric execution tools are absent from the live profile (crypto/US).
+_MARKET_EXEC_PURPOSE: dict[str, str] = {
+    "buy": "execute buy via generic place_order (crypto/US limit; dry_run preview -> live)",
+    "sell": "execute sell via generic place_order (crypto/US limit)",
+    "discovery": "execute buy on ranked winners via generic place_order (crypto/US limit)",
+}
+
 # Every non-mutation tool in the DEFAULT profile (computed 2026-07-02 as
 # DEFAULT-profile tools minus MUTATION_TOOLS) plus route_request itself. The
 # set-equality partition test (test_route_request_registry_diff.py) fails if a
@@ -286,15 +317,39 @@ def build_route_plan(
     """Assemble the deterministic route plan. Pure — no IO. Caller validates
     intent/market and resolves policy before calling."""
     lane = INTENT_TO_LANE[intent]
+    lane_tools = lane_tool_names(lane)
+    playbook_mutation = lane_tools & MUTATION_TOOLS
+    lane_place_tools = lane_tools & _PLACE_ORDER_TOOLS
+    # Executing lanes (buy/sell/discovery place orders) get a market-aware
+    # execution supplement; bootstrap has no place step, so it stays
+    # supplement-free and every mutation tool remains blocked. For KR the
+    # supplement is empty (its place tools already live in the sequence), so
+    # behaviour is identical to the KR-centric definition (no regression).
+    market_exec = (
+        MARKET_EXECUTION_TOOLS.get(market, frozenset())
+        if lane_place_tools
+        else frozenset()
+    )
+
     seq_steps = [
         step for step in LANE_SEQUENCES[lane] if step["tool"] in registered_tools
     ]
+    # If the lane places orders but none of its playbook place tools survived the
+    # profile intersection (crypto/US), surface the market's generic execution
+    # tool so the advisory shows + allows it instead of leaving the lane
+    # execution-less with place_order misclassified as blocked (ROB-658).
+    if lane_place_tools and not (lane_place_tools & registered_tools):
+        for tool in sorted(market_exec & registered_tools):
+            seq_steps.append({"tool": tool, "purpose": _MARKET_EXEC_PURPOSE[lane]})
+
     standard_tool_sequence = [
         {"step": i, "tool": step["tool"], "purpose": step["purpose"]}
         for i, step in enumerate(seq_steps, start=1)
     ]
-    lane_own_mutation = lane_tool_names(lane) & MUTATION_TOOLS
-    allowed = (lane_tool_names(lane) | set(READ_ONLY_ADVISORY_TOOLS)) & registered_tools
+    lane_own_mutation = playbook_mutation | market_exec
+    allowed = (
+        lane_tools | market_exec | set(READ_ONLY_ADVISORY_TOOLS)
+    ) & registered_tools
     blocked = (MUTATION_TOOLS - lane_own_mutation) & registered_tools
     return {
         "success": True,
@@ -316,6 +371,7 @@ __all__ = [
     "LANE_TO_POLICY_LANE",
     "LANE_SEQUENCES",
     "HARD_CONSTRAINTS",
+    "MARKET_EXECUTION_TOOLS",
     "MUTATION_TOOLS",
     "READ_ONLY_ADVISORY_TOOLS",
     "ALL_KNOWN_TOOLS",

--- a/app/mcp_server/tooling/route_request_registration.py
+++ b/app/mcp_server/tooling/route_request_registration.py
@@ -103,7 +103,9 @@ def register_route_request_tools(mcp: FastMCP) -> None:
             "output). ADVISORY ONLY — it does not block anything; it echoes "
             "get_trading_policy (ROB-646) with policy_version so a verdict can "
             "cite the criteria. standard_tool_sequence is intersected with the "
-            "live-registered tool surface (unregistered tools are dropped). "
+            "live-registered tool surface (unregistered tools are dropped); for "
+            "crypto/US the KR-centric place step is replaced by the generic "
+            "place_order execution tool (market-aware, ROB-658). "
             "Unknown intent/market returns success=false."
         ),
     )(route_request)

--- a/tests/test_route_request.py
+++ b/tests/test_route_request.py
@@ -89,6 +89,11 @@ def test_profile_intersection_crypto_drops_toss_place_order():
         s["tool"] for s in crypto_out["standard_tool_sequence"]
     ]
     assert "toss_place_order" not in crypto_out["allowed_tools"]
+    # ROB-658: the crypto execution tool (generic place_order) must be surfaced,
+    # not misclassified as blocked, on the CRYPTO profile.
+    assert "place_order" not in crypto_out["blocked_actions"]
+    assert "place_order" in crypto_out["allowed_tools"]
+    assert "place_order" in [s["tool"] for s in crypto_out["standard_tool_sequence"]]
 
 
 class TestRouteRequestRegisteredEveryProfile:

--- a/tests/test_route_request_lanes.py
+++ b/tests/test_route_request_lanes.py
@@ -108,6 +108,93 @@ def test_profile_intersection_drops_unregistered_tools():
     assert "toss_place_order" not in plan["blocked_actions"]
 
 
+# --- ROB-658: market-aware execution tool mapping -----------------------------
+
+# crypto/US profiles register the generic place_order surface but not the
+# KR-centric toss/kis execution tools.
+_CRYPTO_MUTATION = {
+    "place_order",
+    "modify_order",
+    "cancel_order",
+    "buy_ladder_fill_preview",
+    "sell_ladder_fill_preview",
+    "get_order_history",
+    "live_reconcile_orders",
+    "kis_mock_reconciliation_run",
+}
+_CRYPTO_REGISTERED = set(L.READ_ONLY_ADVISORY_TOOLS) | _CRYPTO_MUTATION
+
+
+def test_crypto_buy_does_not_block_generic_place_order():
+    plan = L.build_route_plan(
+        "buy_analysis",
+        "crypto",
+        registered_tools=_CRYPTO_REGISTERED,
+        verdict_thresholds=_fake_thresholds("crypto", "buy"),
+        policy_version=_VERSION,
+    )
+    # the real crypto execution tool must not be advised as blocked (ROB-658)
+    assert "place_order" not in plan["blocked_actions"]
+    # ...and it is surfaced as an allowed tool + a concrete execution step
+    assert "place_order" in plan["allowed_tools"]
+    steps = [s["tool"] for s in plan["standard_tool_sequence"]]
+    assert "place_order" in steps
+    # KR execution tools are unregistered on crypto -> dropped, never injected
+    assert "toss_place_order" not in steps
+    assert "kis_live_place_order" not in steps
+    # other generic mutations remain blocked (only place is the sanctioned step)
+    assert "modify_order" in plan["blocked_actions"]
+    assert "cancel_order" in plan["blocked_actions"]
+    # step numbers stay contiguous after injection
+    assert [s["step"] for s in plan["standard_tool_sequence"]] == list(
+        range(1, len(steps) + 1)
+    )
+
+
+def test_crypto_sell_and_discovery_surface_generic_place_order():
+    for intent in ("profit_taking", "discovery"):
+        plan = L.build_route_plan(
+            intent,
+            "crypto",
+            registered_tools=_CRYPTO_REGISTERED,
+            verdict_thresholds=_fake_thresholds("crypto", L.INTENT_TO_LANE[intent]),
+            policy_version=_VERSION,
+        )
+        assert "place_order" not in plan["blocked_actions"]
+        assert "place_order" in plan["allowed_tools"]
+        assert "place_order" in [s["tool"] for s in plan["standard_tool_sequence"]]
+
+
+def test_crypto_market_brief_still_blocks_all_mutation():
+    # bootstrap has no execution step -> even crypto's place_order stays blocked
+    plan = L.build_route_plan(
+        "market_brief",
+        "crypto",
+        registered_tools=_CRYPTO_REGISTERED,
+        verdict_thresholds=_fake_thresholds("crypto", "bootstrap", empty=True),
+        policy_version=_VERSION,
+    )
+    assert "place_order" in plan["blocked_actions"]
+    assert set(plan["blocked_actions"]) == (L.MUTATION_TOOLS & _CRYPTO_REGISTERED)
+
+
+def test_kr_buy_still_blocks_generic_place_order_no_regression():
+    # KR routes execution through toss/kis; the generic place_order stays blocked.
+    plan = L.build_route_plan(
+        "buy_analysis",
+        "kr",
+        registered_tools=_ALL,
+        verdict_thresholds=_fake_thresholds("kr", "buy"),
+        policy_version=_VERSION,
+    )
+    assert "place_order" in plan["blocked_actions"]
+    assert "place_order" not in plan["allowed_tools"]
+    steps = [s["tool"] for s in plan["standard_tool_sequence"]]
+    assert "place_order" not in steps
+    # KR execution tools are still the sanctioned, non-blocked path
+    assert "toss_place_order" not in plan["blocked_actions"]
+
+
 def test_hard_constraints_reference_policy_keys_not_numbers():
     plan = L.build_route_plan(
         "buy_analysis",


### PR DESCRIPTION
## What / Why

Follow-up to ROB-649 (`route_request` advisory lane router). The playbook lane
sequences are **KR-centric** — their execution steps hard-code
`toss_place_order`/`kis_live_place_order`. On **crypto/US** profiles those tools
are unregistered, so `build_route_plan`:

1. dropped the execution step from `standard_tool_sequence` (lane looked
   execution-less), and
2. computed the *registered* generic `place_order` — the real crypto/US
   execution surface — into **`blocked_actions`**.

Reproduction (before):
```
route_request(intent="buy_analysis", market="crypto")   # CRYPTO profile
# standard_tool_sequence: no execution step
# blocked_actions: [... "place_order" ...]   ← the actual buy tool, marked "blocked"
```

This is advisory-only (no enforcement), but the advice was misleading.

## Fix

Market-aware execution mapping in `build_route_plan` (option 1 from the issue):

- Add `MARKET_EXECUTION_TOOLS` (`crypto`/`us` → `place_order`; `kr` → empty —
  its place tools already live in the sequence).
- When a lane **places orders** but none of its KR place tools survive the
  profile intersection, inject the market's generic `place_order` as the
  execution step and count it as the lane's own mutation. Result: `place_order`
  appears in `standard_tool_sequence` + `allowed_tools` instead of
  `blocked_actions`.
- "Executing lane" detection keys on actual place-order tools
  (`_PLACE_ORDER_TOOLS`), **not** fill-safety/reconcile helpers — so
  `sell_ladder_fill_preview` stays a sanctioned sell-lane tool and `bootstrap`
  (no place step) still blocks every mutation tool.

`LANE_SEQUENCES` is untouched (stays synced to the playbook via the registry-diff
test); the mapping lives entirely in the pure builder.

## Acceptance criteria

- ✅ `route_request(buy_analysis, crypto)` `blocked_actions` no longer contains `place_order`
- ✅ No KR regression — KR DEFAULT route plans are **byte-identical** before/after across all four intents (verified via before/after diff)
- ✅ Deterministic, **migration 0**

## Tests

- New: crypto buy/sell/discovery surface generic `place_order` (allowed + sequence, not blocked); other generic mutations (`modify_order`/`cancel_order`) still blocked; crypto `market_brief` still blocks all mutation; KR buy still blocks generic `place_order` (regression guard).
- Registration-level crypto-profile integration assertion extended.
- `tests/test_route_request_{lanes,registry_diff}.py` + `test_route_request.py`: **30 passed**. Ruff/format/ty clean.

Note: `tests/test_mcp_server_main.py` has 11 pre-existing failures on the base branch (unrelated — ROB-603 latent timeout_middleware stub).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01REdu9nHkui88Vhw2Ga9zfW

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added market-aware execution routing so the generic `place_order` tool can appear for crypto/US flows when market-specific execution tools aren’t available.
  * Updated routing behavior so valid execution steps are included in the normal tool sequence instead of being treated as blocked.

* **Bug Fixes**
  * Corrected blocked/allowed tool handling for crypto and KR profiles.
  * Preserved existing KR execution behavior while improving crypto routing coverage.

* **Documentation**
  * Clarified tool-routing behavior in the request documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->