### PR TITLE
feat(ROB-661): trade_retrospective_pending cancel-family noise filter + include_cancelled opt-in

### DIFF
--- a/app/mcp_server/tooling/trade_retrospective_registration.py
+++ b/app/mcp_server/tooling/trade_retrospective_registration.py
@@ -63,10 +63,15 @@ def register_trade_retrospective_tools(mcp: Any) -> None:
             "List lifecycle-terminal live orders across the 3 live ledgers "
             "(kis_live KR, generic live US/crypto, toss_live) that still lack a "
             "trade retrospective, over a KST trade_date window (default: last 14 "
-            "days). Each row carries a suggested_correlation_id to pass to "
+            "days). Defaults to actionable terminals only: filled / rejected / "
+            "anomaly. Cancel-family rows (cancelled — which includes DAY expiry "
+            "and strategic cancels — plus toss cancel_rejected/replace_rejected) "
+            "are hidden by default and their count is reported in "
+            "excluded_by_filter; pass include_cancelled=true to surface them. "
+            "Each row carries a suggested_correlation_id to pass to "
             "save_trade_retrospective so it is marked covered next scan. Optional "
             "account_mode filter in {kis_live, upbit_live, toss_live}. Read-only "
-            "due-list — no broker/order mutation. (ROB-647)"
+            "due-list — no broker/order mutation. (ROB-647, ROB-661)"
         ),
     )(trade_retrospective_pending)
 

--- a/app/mcp_server/tooling/trade_retrospective_tools.py
+++ b/app/mcp_server/tooling/trade_retrospective_tools.py
@@ -199,6 +199,7 @@ async def trade_retrospective_pending(
     kst_date_to: str | None = None,
     account_mode: str | None = None,
     limit: int = 100,
+    include_cancelled: bool = False,
 ) -> dict[str, Any]:
     today = now_kst().date().isoformat()
     date_to = kst_date_to or today
@@ -212,6 +213,7 @@ async def trade_retrospective_pending(
                 kst_date_to=date_to,
                 account_mode=account_mode,
                 limit=limit,
+                include_cancelled=include_cancelled,
             )
         return {"success": True, **result}
     except Exception as exc:  # noqa: BLE001

--- a/app/services/trade_journal/trade_retrospective_service.py
+++ b/app/services/trade_journal/trade_retrospective_service.py
@@ -620,9 +620,7 @@ _KIS_LIVE_CANCEL_TERMINAL = frozenset({"cancelled"})
 _GENERIC_LIVE_DEFAULT_TERMINAL = frozenset({"filled", "rejected", "anomaly"})
 _GENERIC_LIVE_CANCEL_TERMINAL = frozenset({"cancelled"})
 _TOSS_DEFAULT_TERMINAL = frozenset({"filled", "rejected", "anomaly"})
-_TOSS_CANCEL_TERMINAL = frozenset(
-    {"cancelled", "cancel_rejected", "replace_rejected"}
-)
+_TOSS_CANCEL_TERMINAL = frozenset({"cancelled", "cancel_rejected", "replace_rejected"})
 
 _KIS_LIVE_TERMINAL = _KIS_LIVE_DEFAULT_TERMINAL | _KIS_LIVE_CANCEL_TERMINAL
 _GENERIC_LIVE_TERMINAL = _GENERIC_LIVE_DEFAULT_TERMINAL | _GENERIC_LIVE_CANCEL_TERMINAL

--- a/app/services/trade_journal/trade_retrospective_service.py
+++ b/app/services/trade_journal/trade_retrospective_service.py
@@ -608,21 +608,31 @@ async def build_retrospective_aggregate(
     }
 
 
-# ROB-647 — terminal (lifecycle-complete) statuses per live ledger. A terminal
-# order deserves a postmortem regardless of whether it filled: rejected /
-# cancelled / anomaly are as instructive as filled. Non-terminal states
-# (accepted / pending / partial / replaced) are omitted — they may still change.
-_KIS_LIVE_TERMINAL = frozenset({"filled", "cancelled", "rejected", "anomaly"})
-_GENERIC_LIVE_TERMINAL = frozenset({"filled", "cancelled", "rejected", "anomaly"})
-_TOSS_TERMINAL = frozenset(
-    {
-        "filled",
-        "cancelled",
-        "rejected",
-        "cancel_rejected",
-        "replace_rejected",
-        "anomaly",
-    }
+# ROB-647/ROB-661 — terminal (lifecycle-complete) statuses per live ledger,
+# split into a DEFAULT group (always due for a retrospective: filled / rejected /
+# anomaly) and a CANCEL-family group (DAY expiry collapses to `cancelled`, plus
+# Toss cancel/replace rejections). Cancel-family is noise by default (grid
+# re-placement churn) and only surfaces when include_cancelled=True. Non-terminal
+# states (accepted / pending / partial / replaced) stay omitted — they may still
+# change.
+_KIS_LIVE_DEFAULT_TERMINAL = frozenset({"filled", "rejected", "anomaly"})
+_KIS_LIVE_CANCEL_TERMINAL = frozenset({"cancelled"})
+_GENERIC_LIVE_DEFAULT_TERMINAL = frozenset({"filled", "rejected", "anomaly"})
+_GENERIC_LIVE_CANCEL_TERMINAL = frozenset({"cancelled"})
+_TOSS_DEFAULT_TERMINAL = frozenset({"filled", "rejected", "anomaly"})
+_TOSS_CANCEL_TERMINAL = frozenset(
+    {"cancelled", "cancel_rejected", "replace_rejected"}
+)
+
+_KIS_LIVE_TERMINAL = _KIS_LIVE_DEFAULT_TERMINAL | _KIS_LIVE_CANCEL_TERMINAL
+_GENERIC_LIVE_TERMINAL = _GENERIC_LIVE_DEFAULT_TERMINAL | _GENERIC_LIVE_CANCEL_TERMINAL
+_TOSS_TERMINAL = _TOSS_DEFAULT_TERMINAL | _TOSS_CANCEL_TERMINAL
+
+# Statuses hidden from `pending` unless include_cancelled=True. Disjoint from the
+# DEFAULT statuses (note: `rejected` is DEFAULT; `cancel_rejected` /
+# `replace_rejected` are cancel-family).
+_CANCEL_FAMILY_STATUSES = (
+    _KIS_LIVE_CANCEL_TERMINAL | _GENERIC_LIVE_CANCEL_TERMINAL | _TOSS_CANCEL_TERMINAL
 )
 # Bound per-ledger scan so a wide window cannot load unbounded rows.
 _PENDING_LEDGER_FETCH_CAP = 1000
@@ -693,6 +703,7 @@ async def build_retrospective_pending(
     kst_date_to: str,
     account_mode: str | None = None,
     limit: int = 100,
+    include_cancelled: bool = False,
 ) -> dict[str, Any]:
     """List terminal live-ledger orders (3 ledgers) lacking a retrospective.
 
@@ -701,6 +712,10 @@ async def build_retrospective_pending(
     window, then subtracts rows already covered by a retrospective (matched on
     report_item_uuid or the suggested correlation_id). Mirrors the ROB-120
     coverage pattern (terminal-without-artifact).
+
+    Cancel-family rows (cancelled / cancel_rejected / replace_rejected) are
+    hidden unless include_cancelled=True; the hidden count is reported in
+    excluded_by_filter.
     """
     window_start = _kst_day_start(kst_date_from)
     window_end = _kst_day_end(kst_date_to)
@@ -805,6 +820,16 @@ async def build_retrospective_pending(
             if not _is_covered(entry, covered_cids, covered_uuids):
                 pending.append(entry)
 
+    excluded_cancelled = 0
+    if not include_cancelled:
+        kept: list[dict[str, Any]] = []
+        for entry in pending:
+            if entry["status"] in _CANCEL_FAMILY_STATUSES:
+                excluded_cancelled += 1
+            else:
+                kept.append(entry)
+        pending = kept
+
     pending.sort(key=lambda e: e["trade_date_kst"] or "", reverse=True)
     total_pending = len(pending)
     limited = pending[: max(0, limit)]
@@ -812,8 +837,10 @@ async def build_retrospective_pending(
         "kst_date_from": kst_date_from,
         "kst_date_to": kst_date_to,
         "account_mode": account_mode,
+        "include_cancelled": include_cancelled,
         "terminal_scanned": scanned,
         "total_pending": total_pending,
         "returned": len(limited),
+        "excluded_by_filter": {"cancelled": excluded_cancelled},
         "pending": limited,
     }

--- a/docs/superpowers/plans/2026-07-03-rob-661-retrospective-pending-noise-filter.md
+++ b/docs/superpowers/plans/2026-07-03-rob-661-retrospective-pending-noise-filter.md
@@ -1,0 +1,451 @@
+# ROB-661 — `trade_retrospective_pending` Noise Filter Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `trade_retrospective_pending` default to actionable retros
+(`filled + rejected + anomaly`) and hide cancel-family noise (DAY expiry +
+strategic cancels) behind an opt-in `include_cancelled` param, with a transparent
+`excluded_by_filter` count.
+
+**Architecture:** Split each live ledger's terminal-status frozenset into a
+DEFAULT group (always scanned into `pending`) and a CANCEL-family group
+(`cancelled` + Toss `cancel_rejected`/`replace_rejected`). The scan still fetches
+the full terminal set (so we can count what we hide), then post-filters
+cancel-family entries out of `pending` unless `include_cancelled=True`. The MCP
+wrapper passes the flag through and documents the default.
+
+**Tech Stack:** Python 3.13, SQLAlchemy async, pytest / pytest-asyncio, FastMCP.
+
+## Global Constraints
+
+- Migration count: **0** — read-only tool behavior change only, no schema.
+- Backcompat: existing response keys (`kst_date_from`, `kst_date_to`,
+  `account_mode`, `terminal_scanned`, `total_pending`, `returned`, `pending`)
+  MUST remain; only additive keys are new.
+- `expired` is NOT a distinct ledger status — KIS collapses `expired → cancelled`
+  at booking (`app/mcp_server/tooling/kis_live_ledger.py:49`). Filtering
+  `cancelled` therefore covers both DAY expiry and strategic cancels.
+- Run tests with: `uv run --all-groups pytest` (bare `uv run` lacks
+  pytest_asyncio). Integration tests need the persistent test DB at
+  `localhost:5432`; conftest forces `DATABASE_URL`.
+- Anomaly stays in the DEFAULT set (real fills leaked to `anomaly` before the
+  ROB-631 fix; booking/reconcile anomalies deserve a retro).
+- Scope: proposal 1 (filter) only. Proposals 2 (daily net-summary bundling) and
+  3 (broker-evidence fill detection) are explicitly deferred.
+
+---
+
+### Task 1: Service — split terminal sets, add `include_cancelled`, excluded count
+
+**Files:**
+- Modify: `app/services/trade_journal/trade_retrospective_service.py:611-628`
+  (terminal-status constants) and `:689-819` (`build_retrospective_pending`)
+- Test: `tests/test_trade_retrospective_pending.py`
+
+**Interfaces:**
+- Consumes: existing `_pending_entry`, `_is_covered`, `_covered_keys`,
+  `_kst_day_start`, `_kst_day_end`, ledger models `KISLiveOrderLedger`,
+  `LiveOrderLedger`, `TossLiveOrderLedger`.
+- Produces: `build_retrospective_pending(db, *, kst_date_from, kst_date_to,
+  account_mode=None, limit=100, include_cancelled=False) -> dict`. Return dict
+  gains keys `include_cancelled: bool` and `excluded_by_filter: {"cancelled":
+  int}`. Cancel-family statuses = `{"cancelled", "cancel_rejected",
+  "replace_rejected"}`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_trade_retrospective_pending.py` (helpers `_kis_row`,
+`_generic_row`, `_toss_row` already exist in that file):
+
+```python
+@pytest.mark.asyncio
+async def test_cancelled_excluded_by_default(db_session: AsyncSession):
+    db_session.add_all(
+        [
+            _kis_row(order_no="K-FILL", status="filled"),
+            _kis_row(order_no="K-CANCEL", status="cancelled"),
+        ]
+    )
+    await db_session.commit()
+
+    result = await svc.build_retrospective_pending(
+        db_session, kst_date_from="2000-01-01", kst_date_to="2100-01-01"
+    )
+    refs = {p["suggested_correlation_id"] for p in result["pending"]}
+    assert refs == {"kis_live:K-FILL"}
+    assert result["total_pending"] == 1
+    assert result["include_cancelled"] is False
+    assert result["excluded_by_filter"] == {"cancelled": 1}
+
+
+@pytest.mark.asyncio
+async def test_include_cancelled_restores_cancel_rows(db_session: AsyncSession):
+    db_session.add_all(
+        [
+            _kis_row(order_no="K-FILL", status="filled"),
+            _kis_row(order_no="K-CANCEL", status="cancelled"),
+        ]
+    )
+    await db_session.commit()
+
+    result = await svc.build_retrospective_pending(
+        db_session,
+        kst_date_from="2000-01-01",
+        kst_date_to="2100-01-01",
+        include_cancelled=True,
+    )
+    refs = {p["suggested_correlation_id"] for p in result["pending"]}
+    assert refs == {"kis_live:K-FILL", "kis_live:K-CANCEL"}
+    assert result["total_pending"] == 2
+    assert result["include_cancelled"] is True
+    assert result["excluded_by_filter"] == {"cancelled": 0}
+
+
+@pytest.mark.asyncio
+async def test_anomaly_and_rejected_kept_by_default(db_session: AsyncSession):
+    db_session.add_all(
+        [
+            _kis_row(order_no="K-ANOM", status="anomaly"),
+            _kis_row(order_no="K-REJ", status="rejected"),
+        ]
+    )
+    await db_session.commit()
+
+    result = await svc.build_retrospective_pending(
+        db_session, kst_date_from="2000-01-01", kst_date_to="2100-01-01"
+    )
+    refs = {p["suggested_correlation_id"] for p in result["pending"]}
+    assert refs == {"kis_live:K-ANOM", "kis_live:K-REJ"}
+    assert result["excluded_by_filter"] == {"cancelled": 0}
+
+
+@pytest.mark.asyncio
+async def test_toss_cancel_family_excluded_by_default(db_session: AsyncSession):
+    db_session.add_all(
+        [
+            _toss_row(client_order_id="T-CR", status="cancel_rejected"),
+            _toss_row(client_order_id="T-RR", status="replace_rejected"),
+            _toss_row(client_order_id="T-FILL", broker_order_id="TB-FILL", status="filled"),
+        ]
+    )
+    await db_session.commit()
+
+    default = await svc.build_retrospective_pending(
+        db_session, kst_date_from="2000-01-01", kst_date_to="2100-01-01"
+    )
+    assert {p["ledger"] for p in default["pending"]} == {"toss_live"}
+    assert default["total_pending"] == 1  # only the filled row
+    assert default["excluded_by_filter"] == {"cancelled": 2}
+
+    opted_in = await svc.build_retrospective_pending(
+        db_session,
+        kst_date_from="2000-01-01",
+        kst_date_to="2100-01-01",
+        include_cancelled=True,
+    )
+    assert opted_in["total_pending"] == 3
+    assert opted_in["excluded_by_filter"] == {"cancelled": 0}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `uv run --all-groups pytest tests/test_trade_retrospective_pending.py -k "cancelled or anomaly_and_rejected or toss_cancel_family" -v`
+Expected: FAIL — `KeyError: 'include_cancelled'` / `KeyError: 'excluded_by_filter'`
+(cancel rows currently appear in `pending`), and
+`build_retrospective_pending() got an unexpected keyword argument 'include_cancelled'`.
+
+- [ ] **Step 3: Split the terminal-status constants**
+
+Replace `app/services/trade_journal/trade_retrospective_service.py:611-626` (the
+three `_*_TERMINAL` frozenset definitions and their comment) with:
+
+```python
+# ROB-647/ROB-661 — terminal (lifecycle-complete) statuses per live ledger,
+# split into a DEFAULT group (always due for a retrospective: filled / rejected /
+# anomaly) and a CANCEL-family group (DAY expiry collapses to `cancelled`, plus
+# Toss cancel/replace rejections). Cancel-family is noise by default (grid
+# re-placement churn) and only surfaces when include_cancelled=True. Non-terminal
+# states (accepted / pending / partial / replaced) stay omitted — they may still
+# change.
+_KIS_LIVE_DEFAULT_TERMINAL = frozenset({"filled", "rejected", "anomaly"})
+_KIS_LIVE_CANCEL_TERMINAL = frozenset({"cancelled"})
+_GENERIC_LIVE_DEFAULT_TERMINAL = frozenset({"filled", "rejected", "anomaly"})
+_GENERIC_LIVE_CANCEL_TERMINAL = frozenset({"cancelled"})
+_TOSS_DEFAULT_TERMINAL = frozenset({"filled", "rejected", "anomaly"})
+_TOSS_CANCEL_TERMINAL = frozenset(
+    {"cancelled", "cancel_rejected", "replace_rejected"}
+)
+
+_KIS_LIVE_TERMINAL = _KIS_LIVE_DEFAULT_TERMINAL | _KIS_LIVE_CANCEL_TERMINAL
+_GENERIC_LIVE_TERMINAL = _GENERIC_LIVE_DEFAULT_TERMINAL | _GENERIC_LIVE_CANCEL_TERMINAL
+_TOSS_TERMINAL = _TOSS_DEFAULT_TERMINAL | _TOSS_CANCEL_TERMINAL
+
+# Statuses hidden from `pending` unless include_cancelled=True. Disjoint from the
+# DEFAULT statuses (note: `rejected` is DEFAULT; `cancel_rejected` /
+# `replace_rejected` are cancel-family).
+_CANCEL_FAMILY_STATUSES = (
+    _KIS_LIVE_CANCEL_TERMINAL | _GENERIC_LIVE_CANCEL_TERMINAL | _TOSS_CANCEL_TERMINAL
+)
+```
+
+The `_PENDING_LEDGER_FETCH_CAP = 1000` line immediately below stays unchanged.
+
+- [ ] **Step 4: Add the `include_cancelled` param and post-filter**
+
+In `build_retrospective_pending`, change the signature (currently at
+`:689-696`) to add the new keyword-only param before `limit` is fine; place it
+last to stay additive:
+
+```python
+async def build_retrospective_pending(
+    db: AsyncSession,
+    *,
+    kst_date_from: str,
+    kst_date_to: str,
+    account_mode: str | None = None,
+    limit: int = 100,
+    include_cancelled: bool = False,
+) -> dict[str, Any]:
+```
+
+The three ledger scan loops stay unchanged (they already use the union
+`_KIS_LIVE_TERMINAL` / `_GENERIC_LIVE_TERMINAL` / `_TOSS_TERMINAL`). Replace the
+tail of the function (currently `:808-819`, from `pending.sort(...)` to the
+`return`) with:
+
+```python
+    excluded_cancelled = 0
+    if not include_cancelled:
+        kept: list[dict[str, Any]] = []
+        for entry in pending:
+            if entry["status"] in _CANCEL_FAMILY_STATUSES:
+                excluded_cancelled += 1
+            else:
+                kept.append(entry)
+        pending = kept
+
+    pending.sort(key=lambda e: e["trade_date_kst"] or "", reverse=True)
+    total_pending = len(pending)
+    limited = pending[: max(0, limit)]
+    return {
+        "kst_date_from": kst_date_from,
+        "kst_date_to": kst_date_to,
+        "account_mode": account_mode,
+        "include_cancelled": include_cancelled,
+        "terminal_scanned": scanned,
+        "total_pending": total_pending,
+        "returned": len(limited),
+        "excluded_by_filter": {"cancelled": excluded_cancelled},
+        "pending": limited,
+    }
+```
+
+Also update the function docstring's first line to note the default filter, e.g.
+after the existing summary add: `Cancel-family rows (cancelled / cancel_rejected
+/ replace_rejected) are hidden unless include_cancelled=True; the hidden count is
+reported in excluded_by_filter.`
+
+- [ ] **Step 5: Run the new tests to verify they pass**
+
+Run: `uv run --all-groups pytest tests/test_trade_retrospective_pending.py -k "cancelled or anomaly_and_rejected or toss_cancel_family" -v`
+Expected: PASS (4 tests).
+
+- [ ] **Step 6: Run the full pending suite for regressions**
+
+Run: `uv run --all-groups pytest tests/test_trade_retrospective_pending.py -v`
+Expected: PASS — all pre-existing tests still green (they only assert
+`filled` rows and `total_pending`, which are unaffected by the default filter).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add app/services/trade_journal/trade_retrospective_service.py tests/test_trade_retrospective_pending.py
+git commit -m "feat(ROB-661): default retrospective_pending to filled/rejected/anomaly, opt-in cancelled
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: MCP wrapper — pass `include_cancelled` through + document default
+
+**Files:**
+- Modify: `app/mcp_server/tooling/trade_retrospective_tools.py:197-216`
+  (`trade_retrospective_pending` wrapper)
+- Modify: `app/mcp_server/tooling/trade_retrospective_registration.py:60-71`
+  (tool description)
+- Test: `tests/test_trade_retrospective_tools.py`
+
+**Interfaces:**
+- Consumes: `build_retrospective_pending(..., include_cancelled=...)` from Task 1.
+- Produces: MCP tool `trade_retrospective_pending(kst_date_from=None,
+  kst_date_to=None, account_mode=None, limit=100, include_cancelled=False)`
+  returning `{"success": True, ..., "include_cancelled": ..., "excluded_by_filter":
+  {...}}`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_trade_retrospective_tools.py` (imports `now_kst`,
+`KISLiveOrderLedger`, and `trade_retrospective_pending` already present — see the
+existing `test_pending_tool_envelope`):
+
+```python
+@pytest.mark.asyncio
+async def test_pending_tool_include_cancelled_passthrough(db_session: AsyncSession):
+    db_session.add_all(
+        [
+            KISLiveOrderLedger(
+                trade_date=now_kst(),
+                symbol="005930",
+                instrument_type="equity_kr",
+                side="buy",
+                order_type="limit",
+                account_mode="kis_live",
+                broker="kis",
+                status="cancelled",
+                lifecycle_state="cancelled",
+                order_no="K-TOOL-CANCEL",
+            )
+        ]
+    )
+    await db_session.commit()
+
+    default = await trade_retrospective_pending()
+    assert default["success"] is True
+    assert default["include_cancelled"] is False
+    default_refs = {p["suggested_correlation_id"] for p in default["pending"]}
+    assert "kis_live:K-TOOL-CANCEL" not in default_refs
+    assert default["excluded_by_filter"]["cancelled"] >= 1
+
+    opted = await trade_retrospective_pending(include_cancelled=True)
+    assert opted["include_cancelled"] is True
+    opted_refs = {p["suggested_correlation_id"] for p in opted["pending"]}
+    assert "kis_live:K-TOOL-CANCEL" in opted_refs
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `uv run --all-groups pytest tests/test_trade_retrospective_tools.py::test_pending_tool_include_cancelled_passthrough -v`
+Expected: FAIL — `trade_retrospective_pending() got an unexpected keyword
+argument 'include_cancelled'`.
+
+- [ ] **Step 3: Add the param to the MCP wrapper**
+
+In `app/mcp_server/tooling/trade_retrospective_tools.py`, change the wrapper
+signature and the service call (currently `:197-215`):
+
+```python
+async def trade_retrospective_pending(
+    kst_date_from: str | None = None,
+    kst_date_to: str | None = None,
+    account_mode: str | None = None,
+    limit: int = 100,
+    include_cancelled: bool = False,
+) -> dict[str, Any]:
+    today = now_kst().date().isoformat()
+    date_to = kst_date_to or today
+    # Default lookback window: 14 KST days ending today.
+    date_from = kst_date_from or (now_kst().date() - timedelta(days=14)).isoformat()
+    try:
+        async with _session_factory()() as db:
+            result = await build_retrospective_pending(
+                db,
+                kst_date_from=date_from,
+                kst_date_to=date_to,
+                account_mode=account_mode,
+                limit=limit,
+                include_cancelled=include_cancelled,
+            )
+        return {"success": True, **result}
+    except Exception as exc:  # noqa: BLE001
+        logger.exception("trade_retrospective_pending failed")
+        return {"success": False, "error": f"trade_retrospective_pending failed: {exc}"}
+```
+
+- [ ] **Step 4: Update the tool description**
+
+In `app/mcp_server/tooling/trade_retrospective_registration.py:62-70`, replace
+the description string with:
+
+```python
+        description=(
+            "List lifecycle-terminal live orders across the 3 live ledgers "
+            "(kis_live KR, generic live US/crypto, toss_live) that still lack a "
+            "trade retrospective, over a KST trade_date window (default: last 14 "
+            "days). Defaults to actionable terminals only: filled / rejected / "
+            "anomaly. Cancel-family rows (cancelled — which includes DAY expiry "
+            "and strategic cancels — plus toss cancel_rejected/replace_rejected) "
+            "are hidden by default and their count is reported in "
+            "excluded_by_filter; pass include_cancelled=true to surface them. "
+            "Each row carries a suggested_correlation_id to pass to "
+            "save_trade_retrospective so it is marked covered next scan. Optional "
+            "account_mode filter in {kis_live, upbit_live, toss_live}. Read-only "
+            "due-list — no broker/order mutation. (ROB-647, ROB-661)"
+        ),
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `uv run --all-groups pytest tests/test_trade_retrospective_tools.py::test_pending_tool_include_cancelled_passthrough -v`
+Expected: PASS.
+
+- [ ] **Step 6: Run the full tools suite for regressions**
+
+Run: `uv run --all-groups pytest tests/test_trade_retrospective_tools.py -v`
+Expected: PASS — including `test_pending_tool_envelope` (unchanged filled row)
+and `test_register_wires_three_tools` (description text change is not asserted).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add app/mcp_server/tooling/trade_retrospective_tools.py app/mcp_server/tooling/trade_retrospective_registration.py tests/test_trade_retrospective_tools.py
+git commit -m "feat(ROB-661): expose include_cancelled on trade_retrospective_pending MCP tool
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Lint, typecheck, and final regression gate
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Format + lint**
+
+Run: `make format && make lint`
+Expected: ruff clean, ty clean. (The `make lint` includes `app/` and `tests/`.)
+
+- [ ] **Step 2: Run both retrospective suites together**
+
+Run: `uv run --all-groups pytest tests/test_trade_retrospective_pending.py tests/test_trade_retrospective_tools.py -v`
+Expected: all PASS.
+
+- [ ] **Step 3: Confirm single alembic head (no migration added)**
+
+Run: `uv run alembic heads`
+Expected: exactly one head, unchanged from `main` (migration count 0 for this
+change).
+
+- [ ] **Step 4: Commit any formatting-only changes**
+
+```bash
+git add -A
+git commit -m "chore(ROB-661): ruff format" || echo "nothing to format"
+```
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** DEFAULT/CANCEL split (Task 1 Step 3) ✓; `include_cancelled`
+  param service + MCP (Task 1 Step 4, Task 2 Step 3) ✓; `excluded_by_filter`
+  transparency (Task 1 Step 4) ✓; anomaly kept default (Task 1 test
+  `test_anomaly_and_rejected_kept_by_default`) ✓; Toss cancel-family
+  classification (Task 1 `test_toss_cancel_family_excluded_by_default`) ✓; MCP
+  description (Task 2 Step 4) ✓; migration 0 (Task 3 Step 3) ✓.
+- **Deferred (spec §범위 밖):** proposal 2 (daily net-summary bundling), proposal
+  3 (broker-evidence fill detection) — not in any task, by design.
+- **Type consistency:** `include_cancelled: bool` and `excluded_by_filter:
+  {"cancelled": int}` used identically across service, wrapper, and tests.
+  Cancel-family status set spelled `_CANCEL_FAMILY_STATUSES` everywhere it is
+  referenced.

--- a/docs/superpowers/specs/2026-07-03-rob-661-retrospective-pending-noise-filter-design.md
+++ b/docs/superpowers/specs/2026-07-03-rob-661-retrospective-pending-noise-filter-design.md
@@ -1,0 +1,93 @@
+# ROB-661 — `trade_retrospective_pending` 노이즈 필터 (제안 1)
+
+## 배경 / 문제
+
+`trade_retrospective_pending` (ROB-647) 는 3개 live ledger
+(`kis_live_order_ledger`, `live_order_ledger`, `toss_live_order_ledger`) 에서
+lifecycle-terminal 상태이면서 회고(retrospective)가 아직 없는 주문을 due-list 로
+반환한다. 2026-07-03 첫 실전 스캔에서 신뢰도 문제가 드러났다:
+
+- **노이즈**: DAY 만료(매일 15~20건, 그물 재배치 운영 특성) + 전략적 취소(죽은 주문
+  정리 목적) 가 전부 `cancelled` terminal 로 잡혀 due 목록을 스팸화. 진짜 회고
+  대상(체결·거부)이 묻힌다.
+- **누락**: 7/2 네오위즈/대웅 매도 **체결**이 목록에 없었음. 원인은 ROB-631
+  (Toss KR fill booking `'equity' InstrumentType` ValueError) 로 ledger 가
+  accepted-only 에 머물렀던 것. ROB-631 은 이미 main (`e4ada0f0`) 에 머지되어
+  신규 fill 은 정상 booking 되므로 **이 스펙 범위 밖**.
+
+핵심 사실: `expired` 는 별도 ledger status 가 아니다. KIS 는 booking 시점에
+`expired → cancelled` 로 collapse 한다 (`kis_live_ledger.py:49`). 따라서 ledger
+status 레벨에서 DAY-만료와 전략적 취소는 **모두 `cancelled` 한 버킷**이다.
+
+## 범위
+
+**제안 1 (트리거 필터) 만.** 제안 2(일자별 그물 요약 묶음), 제안 3(broker-evidence
+fill 탐지) 는 명시적으로 defer. 마이그레이션 0 — 읽기 전용 도구 변경만.
+
+## 설계
+
+### 기본/opt-in terminal 집합
+
+각 ledger 의 terminal 상수를 두 그룹으로 분리한다:
+
+| ledger | DEFAULT (항상) | CANCEL-family (opt-in) |
+|--------|----------------|------------------------|
+| KIS live | `filled, rejected, anomaly` | `cancelled` |
+| Generic live | `filled, rejected, anomaly` | `cancelled` |
+| Toss live | `filled, rejected, anomaly` | `cancelled, cancel_rejected, replace_rejected` |
+
+- `anomaly` 는 **기본 유지** — booking/reconcile 실패 신호라 회고 가치가 있고,
+  ROB-631 이전엔 진짜 fill 이 anomaly 로 새는 경우도 있었다.
+- CANCEL-family (`cancelled` = DAY 만료 + 전략적 취소 포함) 는 기본 제외.
+
+### 파라미터
+
+`build_retrospective_pending(..., include_cancelled: bool = False)` 및 MCP
+`trade_retrospective_pending(..., include_cancelled: bool = False)` 추가.
+
+- `include_cancelled=False` (기본): DEFAULT 집합만 `pending` 에 노출.
+- `include_cancelled=True`: DEFAULT ∪ CANCEL-family (= 현행 전체 terminal 동작 =
+  깔끔한 backcompat).
+
+### 스캔 & 카운트
+
+- 스캔은 각 ledger 에서 `DEFAULT ∪ CANCEL` 전체를 1회 fetch (현행 per-ledger
+  `_PENDING_LEDGER_FETCH_CAP = 1000` 유지). cancel 물량 ~20/일 × 14일 = 280 건으로
+  cap 1000 을 넘지 않는다. `trade_date desc` 정렬이라 최근 fill/reject 가 cap 에
+  밀리지 않는다.
+- coverage 차감(기존 `_is_covered`) 후, `include_cancelled=False` 이면 status 가
+  CANCEL-family 인 entry 를 `pending` 에서 빼고 **제외 건수를 센다**.
+
+### 응답 (투명성)
+
+기존 키(`kst_date_from/to`, `account_mode`, `terminal_scanned`, `total_pending`,
+`returned`, `pending`) 는 그대로 유지하고 추가:
+
+- `include_cancelled`: bool echo
+- `excluded_by_filter`: `{"cancelled": N}` — coverage 차감된 실제 숨겨진 cancel
+  건수 (silent drop 방지, no-silent-caps 원칙). `include_cancelled=True` 면
+  `{"cancelled": 0}`.
+
+`total_pending` / `returned` / `pending` 는 필터 **적용 후** 값이다.
+
+### MCP 도구 description
+
+기본=filled/rejected/anomaly, cancelled(DAY 만료·전략적 취소 포함)은
+`include_cancelled=true` 로만 노출된다는 점을 description 에 명시.
+
+## 테스트 (TDD)
+
+1. 기본 스캔이 cancel-family entry 를 `pending` 에서 제외하고 `excluded_by_filter`
+   에 카운트.
+2. `include_cancelled=True` 시 cancel-family 포함 (현행 전체 terminal 동작).
+3. `anomaly` 는 기본에서 유지됨.
+4. Toss `cancel_rejected` / `replace_rejected` 가 CANCEL-family 로 분류 (기본 제외,
+   opt-in 시 포함).
+5. `filled` / `rejected` 는 두 모드 모두 포함.
+6. MCP 래퍼가 `include_cancelled` 를 서비스로 pass-through.
+
+## 범위 밖 (defer)
+
+- 제안 2: 일자별 그물 요약 묶음 (하루 20건 개별 대신 요약 1건).
+- 제안 3: broker evidence / positions delta 기반 fill 탐지 (ROB-631 머지로 신규
+  fill 은 이미 booking).

--- a/tests/test_trade_retrospective_pending.py
+++ b/tests/test_trade_retrospective_pending.py
@@ -222,3 +222,92 @@ async def test_rejected_order_without_order_no_uses_row_id(db_session: AsyncSess
     entry = result["pending"][0]
     assert entry["order_ref"] is None
     assert entry["suggested_correlation_id"].startswith("kis_live:id:")
+
+
+@pytest.mark.asyncio
+async def test_cancelled_excluded_by_default(db_session: AsyncSession):
+    db_session.add_all(
+        [
+            _kis_row(order_no="K-FILL", status="filled"),
+            _kis_row(order_no="K-CANCEL", status="cancelled"),
+        ]
+    )
+    await db_session.commit()
+
+    result = await svc.build_retrospective_pending(
+        db_session, kst_date_from="2000-01-01", kst_date_to="2100-01-01"
+    )
+    refs = {p["suggested_correlation_id"] for p in result["pending"]}
+    assert refs == {"kis_live:K-FILL"}
+    assert result["total_pending"] == 1
+    assert result["include_cancelled"] is False
+    assert result["excluded_by_filter"] == {"cancelled": 1}
+
+
+@pytest.mark.asyncio
+async def test_include_cancelled_restores_cancel_rows(db_session: AsyncSession):
+    db_session.add_all(
+        [
+            _kis_row(order_no="K-FILL", status="filled"),
+            _kis_row(order_no="K-CANCEL", status="cancelled"),
+        ]
+    )
+    await db_session.commit()
+
+    result = await svc.build_retrospective_pending(
+        db_session,
+        kst_date_from="2000-01-01",
+        kst_date_to="2100-01-01",
+        include_cancelled=True,
+    )
+    refs = {p["suggested_correlation_id"] for p in result["pending"]}
+    assert refs == {"kis_live:K-FILL", "kis_live:K-CANCEL"}
+    assert result["total_pending"] == 2
+    assert result["include_cancelled"] is True
+    assert result["excluded_by_filter"] == {"cancelled": 0}
+
+
+@pytest.mark.asyncio
+async def test_anomaly_and_rejected_kept_by_default(db_session: AsyncSession):
+    db_session.add_all(
+        [
+            _kis_row(order_no="K-ANOM", status="anomaly"),
+            _kis_row(order_no="K-REJ", status="rejected"),
+        ]
+    )
+    await db_session.commit()
+
+    result = await svc.build_retrospective_pending(
+        db_session, kst_date_from="2000-01-01", kst_date_to="2100-01-01"
+    )
+    refs = {p["suggested_correlation_id"] for p in result["pending"]}
+    assert refs == {"kis_live:K-ANOM", "kis_live:K-REJ"}
+    assert result["excluded_by_filter"] == {"cancelled": 0}
+
+
+@pytest.mark.asyncio
+async def test_toss_cancel_family_excluded_by_default(db_session: AsyncSession):
+    db_session.add_all(
+        [
+            _toss_row(client_order_id="T-CR", status="cancel_rejected"),
+            _toss_row(client_order_id="T-RR", status="replace_rejected"),
+            _toss_row(client_order_id="T-FILL", broker_order_id="TB-FILL", status="filled"),
+        ]
+    )
+    await db_session.commit()
+
+    default = await svc.build_retrospective_pending(
+        db_session, kst_date_from="2000-01-01", kst_date_to="2100-01-01"
+    )
+    assert {p["ledger"] for p in default["pending"]} == {"toss_live"}
+    assert default["total_pending"] == 1  # only the filled row
+    assert default["excluded_by_filter"] == {"cancelled": 2}
+
+    opted_in = await svc.build_retrospective_pending(
+        db_session,
+        kst_date_from="2000-01-01",
+        kst_date_to="2100-01-01",
+        include_cancelled=True,
+    )
+    assert opted_in["total_pending"] == 3
+    assert opted_in["excluded_by_filter"] == {"cancelled": 0}

--- a/tests/test_trade_retrospective_pending.py
+++ b/tests/test_trade_retrospective_pending.py
@@ -291,7 +291,9 @@ async def test_toss_cancel_family_excluded_by_default(db_session: AsyncSession):
         [
             _toss_row(client_order_id="T-CR", status="cancel_rejected"),
             _toss_row(client_order_id="T-RR", status="replace_rejected"),
-            _toss_row(client_order_id="T-FILL", broker_order_id="TB-FILL", status="filled"),
+            _toss_row(
+                client_order_id="T-FILL", broker_order_id="TB-FILL", status="filled"
+            ),
         ]
     )
     await db_session.commit()

--- a/tests/test_trade_retrospective_tools.py
+++ b/tests/test_trade_retrospective_tools.py
@@ -245,3 +245,36 @@ async def test_pending_tool_envelope(db_session: AsyncSession):
     assert res["success"] is True
     refs = {p["suggested_correlation_id"] for p in res["pending"]}
     assert "kis_live:K-TOOL-1" in refs
+
+
+@pytest.mark.asyncio
+async def test_pending_tool_include_cancelled_passthrough(db_session: AsyncSession):
+    db_session.add_all(
+        [
+            KISLiveOrderLedger(
+                trade_date=now_kst(),
+                symbol="005930",
+                instrument_type="equity_kr",
+                side="buy",
+                order_type="limit",
+                account_mode="kis_live",
+                broker="kis",
+                status="cancelled",
+                lifecycle_state="cancelled",
+                order_no="K-TOOL-CANCEL",
+            )
+        ]
+    )
+    await db_session.commit()
+
+    default = await trade_retrospective_pending()
+    assert default["success"] is True
+    assert default["include_cancelled"] is False
+    default_refs = {p["suggested_correlation_id"] for p in default["pending"]}
+    assert "kis_live:K-TOOL-CANCEL" not in default_refs
+    assert default["excluded_by_filter"]["cancelled"] >= 1
+
+    opted = await trade_retrospective_pending(include_cancelled=True)
+    assert opted["include_cancelled"] is True
+    opted_refs = {p["suggested_correlation_id"] for p in opted["pending"]}
+    assert "kis_live:K-TOOL-CANCEL" in opted_refs


### PR DESCRIPTION
## Summary

`trade_retrospective_pending` now defaults to **actionable** retros (filled / rejected / anomaly) and hides cancel-family noise behind an opt-in `include_cancelled` param, with a transparent `excluded_by_filter` count.

Cancel-family = `cancelled` (which KIS collapses DAY expiry + strategic cancels into at booking) plus Toss `cancel_rejected` / `replace_rejected`. These were drowning the pending list in grid re-placement churn.

## Changes

- **Service** (`app/services/trade_journal/trade_retrospective_service.py`): split each ledger's terminal-status frozenset into a DEFAULT group (always scanned) and a CANCEL-family group. The scan still fetches the full union (so `terminal_scanned` counts everything), then post-filters cancel-family out of `pending` unless `include_cancelled=True`. New return keys: `include_cancelled: bool`, `excluded_by_filter: {"cancelled": int}`. Existing 7 keys preserved.
- **MCP wrapper** (`app/mcp_server/tooling/trade_retrospective_tools.py`): exposes `include_cancelled: bool = False`, forwards to the service. New keys surface via the existing `{"success": True, **result}` spread.
- **Tool description** (`app/mcp_server/tooling/trade_retrospective_registration.py`): documents the new default behavior + opt-in.

## Design notes

- `anomaly` stays in DEFAULT (real fills leaked to `anomaly` before ROB-631; booking/reconcile anomalies deserve a retro).
- `expired` is NOT a distinct ledger status — KIS collapses `expired → cancelled` at booking, so filtering `cancelled` covers DAY expiry. Verified at `app/mcp_server/tooling/kis_live_ledger.py` `_STATUS_TO_LIFECYCLE`.
- Filter runs AFTER coverage dedup, so `terminal_scanned` still counts all terminal rows while `pending` excludes cancel-family. `excluded_by_filter` counts cancel-family rows that passed the coverage check.
- **Scope: proposal 1 (filter) only.** Proposals 2 (daily net-summary bundling) and 3 (broker-evidence fill detection) are explicitly deferred.

## Constraints

- **Migration count: 0** — read-only tool behavior change, no schema.
- **Backcompat:** existing response keys unchanged; only additive (`include_cancelled`, `excluded_by_filter`).
- Verified: `build_retrospective_pending` has a single production caller (this MCP wrapper) — additive param with `False` default cannot break any other contract.

## Test plan

- TDD: 4 new service tests + 1 new wrapper test, all RED → GREEN.
- `uv run --all-groups pytest tests/test_trade_retrospective_pending.py tests/test_trade_retrospective_tools.py` → **25/25 PASS**.
- `make lint` → clean (ruff + ty).
- `uv run alembic heads` → single head (`20260702_rob653`), migration count 0.

Coverage matrix: default-excludes-cancel, opt-in-restores, anomaly/rejected-kept-default, Toss cancel-family (cancel_rejected + replace_rejected), MCP passthrough (both branches).

## Review status

Each commit reviewed individually (spec + quality, no Critical/Important) + a final whole-branch review (**Ready to merge: Yes**). Two non-blocking Minor noted for optional follow-up: docstring clarifying `excluded_by_filter` vs `terminal_scanned` reconcilability, and wrapper keyword-only asymmetry (matches surrounding style).

Design spec: `docs/superpowers/specs/2026-07-03-rob-661-retrospective-pending-noise-filter-design.md`
Plan: `docs/superpowers/plans/2026-07-03-rob-661-retrospective-pending-noise-filter.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional `include_cancelled` setting to the pending retrospective view, letting you show or hide cancelled-family items.
  * The response now includes `excluded_by_filter` and echoes the selected filter mode.
  * Default results now focus on actionable terminal items while preserving filled, rejected, and anomaly entries.

* **Bug Fixes**
  * Reduced noise in pending retrospective results by hiding cancel-related entries by default, including expiry and strategic cancel cases.
  * Improved handling for Toss cancel/reject statuses so they’re grouped consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->