### PR TITLE
fix(ROB-657): kis_live_get_order_history expired status + is_live for dead KR orders

### DIFF
--- a/app/mcp_server/tooling/orders_history.py
+++ b/app/mcp_server/tooling/orders_history.py
@@ -60,6 +60,7 @@ def _calculate_order_summary(orders: list[dict[str, Any]]) -> dict[str, Any]:
     pending = sum(1 for o in orders if o.get("status") == "pending")
     partial = sum(1 for o in orders if o.get("status") == "partial")
     cancelled = sum(1 for o in orders if o.get("status") == "cancelled")
+    expired = sum(1 for o in orders if o.get("status") == "expired")
 
     return {
         "total_orders": total_orders,
@@ -67,6 +68,7 @@ def _calculate_order_summary(orders: list[dict[str, Any]]) -> dict[str, Any]:
         "pending": pending,
         "partial": partial,
         "cancelled": cancelled,
+        "expired": expired,
     }
 
 

--- a/app/mcp_server/tooling/orders_modify_cancel.py
+++ b/app/mcp_server/tooling/orders_modify_cancel.py
@@ -113,13 +113,22 @@ def _build_temp_kr_order_id(
     return f"TEMP_KR_{digest}"
 
 
-def _map_kis_status(filled: int, remaining: int, status_name: str | None) -> str:
+def _map_kis_status(
+    ordered: int, filled: int, remaining: int, status_name: str | None
+) -> str:
     normalized_name = str(status_name or "").strip()
 
-    if normalized_name in ("접수", "주문접수"):
-        return "pending"
+    # Explicit cancel evidence is authoritative at any point.
     if normalized_name == "주문취소":
         return "cancelled"
+    # ROB-657: nothing filled and nothing left to modify/cancel
+    # (정정취소가능수량 0) means the order is dead (EOD expiry / reject).
+    # KIS ledger truth is "alive iff rmn_qty > 0", so this wins over a
+    # stale '접수' status name that TTTC8036R may still carry.
+    if ordered > 0 and filled == 0 and remaining <= 0:
+        return "expired"
+    if normalized_name in ("접수", "주문접수"):
+        return "pending"
     if normalized_name == "체결":
         if filled > 0 and remaining > 0:
             return "partial"

--- a/app/mcp_server/tooling/orders_modify_cancel.py
+++ b/app/mcp_server/tooling/orders_modify_cancel.py
@@ -380,6 +380,7 @@ def _normalize_kis_overseas_order(order: dict[str, Any]) -> dict[str, Any]:
     )
 
     status = _map_kis_status(
+        ordered,
         filled,
         remaining,
         _get_kis_field(order, "prcs_stat_name", "PRCS_STAT_NAME"),
@@ -390,6 +391,7 @@ def _normalize_kis_overseas_order(order: dict[str, Any]) -> dict[str, Any]:
         "symbol": _get_kis_field(order, "pdno", "PDNO"),
         "side": side,
         "status": status,
+        "is_live": status in ("pending", "partial"),
         "ordered_qty": ordered,
         "filled_qty": filled,
         "remaining_qty": remaining,

--- a/app/mcp_server/tooling/orders_modify_cancel.py
+++ b/app/mcp_server/tooling/orders_modify_cancel.py
@@ -186,6 +186,7 @@ def _normalize_kis_domestic_order(order: dict[str, Any]) -> dict[str, Any]:
     )
 
     status = _map_kis_status(
+        ordered,
         filled,
         remaining,
         _get_kis_field(order, "prcs_stat_name", "PRCS_STAT_NAME"),
@@ -219,6 +220,7 @@ def _normalize_kis_domestic_order(order: dict[str, Any]) -> dict[str, Any]:
         "symbol": symbol,
         "side": side,
         "status": status,
+        "is_live": status in ("pending", "partial"),
         "ordered_qty": ordered,
         "filled_qty": filled,
         "remaining_qty": remaining,

--- a/docs/superpowers/plans/2026-07-03-rob-657-kis-order-history-expired-status.md
+++ b/docs/superpowers/plans/2026-07-03-rob-657-kis-order-history-expired-status.md
@@ -1,0 +1,555 @@
+# ROB-657 — `kis_live_get_order_history` expired-status + `is_live` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop `kis_live_get_order_history` from reporting a dead KR order (`filled==0 && remaining==0`) as `status="pending"`; map it to `expired` and add an explicit `is_live` boolean.
+
+**Architecture:** The shared `_map_kis_status` helper gains an `ordered` argument and a terminal-death rule (`ordered>0 && filled==0 && remaining<=0 → "expired"`), ordered so explicit cancel evidence still wins. Both KIS normalizers pass `ordered` and emit `is_live = status in ("pending","partial")`. The order-history summary gains an `expired` count. Existing status-filtering already excludes non-`pending`/`partial` from `status="pending"` queries, so the dead order drops out of the live view for free. No DB migration (response-shape additive).
+
+**Tech Stack:** Python 3.13, pytest (`@pytest.mark.unit`), ruff + ty, uv.
+
+## Global Constraints
+
+- Migration: **none** — additive response fields only.
+- Do not change the tool query `Literal` `["all","pending","filled","cancelled"]`; `expired` surfaces under `status="all"`.
+- Follow existing KIS field-access idiom: `_get_kis_field(order, "snake", "UPPER", ...)`.
+- KR domestic is the only path that can hit the bug; overseas shares the helper and must keep passing tests (its `remaining = ordered - filled` never triggers the death rule).
+- Commit message trailer: `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`.
+- Spec: `docs/superpowers/specs/2026-07-03-rob-657-kis-order-history-expired-status-design.md`.
+
+---
+
+## File Structure
+
+- `app/mcp_server/tooling/orders_modify_cancel.py` — `_map_kis_status` (signature + death rule), `_normalize_kis_domestic_order` (pass `ordered`, add `is_live`), `_normalize_kis_overseas_order` (pass `ordered`, add `is_live`).
+- `app/mcp_server/tooling/orders_history.py` — `_calculate_order_summary` (add `expired` count).
+- `tests/test_kis_domestic_order_normalization.py` — status/normalizer unit tests.
+- `tests/test_orders_history_summary_rob657.py` (new) — summary + `get_order_history_impl` integration.
+- `app/mcp_server/README.md` — order-history status doc (only if it enumerates status values).
+
+---
+
+### Task 1: `_map_kis_status` death rule + signature
+
+**Files:**
+- Modify: `app/mcp_server/tooling/orders_modify_cancel.py:116-134` (`_map_kis_status`)
+- Test: `tests/test_kis_domestic_order_normalization.py:11-32`
+
+**Interfaces:**
+- Produces: `_map_kis_status(ordered: int, filled: int, remaining: int, status_name: str | None) -> str`. Returns one of `"pending" | "partial" | "filled" | "cancelled" | "expired"`. Death rule: `ordered > 0 and filled == 0 and remaining <= 0` → `"expired"`, evaluated after the explicit `"주문취소"` → `"cancelled"` check and before every other branch.
+
+- [ ] **Step 1: Update the failing test**
+
+Replace the existing parametrized test (lines 11-32) so every case passes `ordered` and the death cases expect `expired`:
+
+```python
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("ordered", "filled", "remaining", "status_name", "expected"),
+    [
+        # Live / filled / partial — unchanged behavior.
+        (10, 10, 0, "체결", "filled"),
+        (10, 0, 10, "접수", "pending"),
+        (10, 5, 5, "체결", "partial"),
+        (10, 10, 0, None, "filled"),
+        (10, 10, 0, "", "filled"),
+        (10, 5, 5, None, "partial"),
+        (10, 0, 10, None, "pending"),
+        # Explicit cancel evidence wins even with 0/0.
+        (8, 0, 0, "주문취소", "cancelled"),
+        # ROB-657: dead order (nothing filled, nothing left) → expired,
+        # regardless of a stale/absent status name.
+        (8, 0, 0, None, "expired"),
+        (8, 0, 0, "", "expired"),
+        (8, 0, 0, "접수", "expired"),
+        (8, 0, 0, "미체결", "expired"),
+        # Degenerate empty row → no order to expire.
+        (0, 0, 0, None, "pending"),
+    ],
+)
+def test_map_kis_status_handles_named_and_unnamed_statuses(
+    ordered: int,
+    filled: int,
+    remaining: int,
+    status_name: str | None,
+    expected: str,
+) -> None:
+    assert _map_kis_status(ordered, filled, remaining, status_name) == expected
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_kis_domestic_order_normalization.py::test_map_kis_status_handles_named_and_unnamed_statuses -v`
+Expected: FAIL — `_map_kis_status()` takes 3 positional args (TypeError) / wrong results.
+
+- [ ] **Step 3: Implement the death rule + signature**
+
+Replace `_map_kis_status` (lines 116-134) with:
+
+```python
+def _map_kis_status(
+    ordered: int, filled: int, remaining: int, status_name: str | None
+) -> str:
+    normalized_name = str(status_name or "").strip()
+
+    # Explicit cancel evidence is authoritative at any point.
+    if normalized_name == "주문취소":
+        return "cancelled"
+    # ROB-657: nothing filled and nothing left to modify/cancel
+    # (정정취소가능수량 0) means the order is dead (EOD expiry / reject).
+    # KIS ledger truth is "alive iff rmn_qty > 0", so this wins over a
+    # stale '접수' status name that TTTC8036R may still carry.
+    if ordered > 0 and filled == 0 and remaining <= 0:
+        return "expired"
+    if normalized_name in ("접수", "주문접수"):
+        return "pending"
+    if normalized_name == "체결":
+        if filled > 0 and remaining > 0:
+            return "partial"
+        return "filled"
+    if normalized_name == "미체결":
+        return "pending"
+
+    if filled > 0 and remaining <= 0:
+        return "filled"
+    if filled > 0 and remaining > 0:
+        return "partial"
+    return "pending"
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_kis_domestic_order_normalization.py::test_map_kis_status_handles_named_and_unnamed_statuses -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/mcp_server/tooling/orders_modify_cancel.py tests/test_kis_domestic_order_normalization.py
+git commit -m "fix(ROB-657): _map_kis_status maps dead KR order (0 filled/0 remaining) to expired
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: KR domestic normalizer — pass `ordered`, add `is_live`, expired end-to-end
+
+**Files:**
+- Modify: `app/mcp_server/tooling/orders_modify_cancel.py:179-221` (`_normalize_kis_domestic_order`)
+- Test: `tests/test_kis_domestic_order_normalization.py`
+
+**Interfaces:**
+- Consumes: `_map_kis_status(ordered, filled, remaining, status_name)` from Task 1.
+- Produces: `_normalize_kis_domestic_order(order)` return dict now includes `"is_live": bool` where `is_live == (status in ("pending", "partial"))`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_kis_domestic_order_normalization.py`:
+
+```python
+@pytest.mark.unit
+def test_normalize_kis_domestic_order_dead_order_is_expired_not_live() -> None:
+    # ROB-657 repro: 기아 000270, 8 ordered, 0 filled, 0 remaining.
+    normalized = _normalize_kis_domestic_order(
+        _build_domestic_order(
+            pdno="000270",
+            ord_qty="8",
+            tot_ccld_qty="0",
+            rmn_qty="0",
+        )
+    )
+
+    assert normalized["status"] == "expired"
+    assert normalized["is_live"] is False
+    assert normalized["ordered_qty"] == 8
+    assert normalized["filled_qty"] == 0
+    assert normalized["remaining_qty"] == 0
+
+
+@pytest.mark.unit
+def test_normalize_kis_domestic_order_live_pending_is_live() -> None:
+    normalized = _normalize_kis_domestic_order(
+        _build_domestic_order(
+            ord_qty="10",
+            tot_ccld_qty="0",
+            rmn_qty="10",
+        )
+    )
+
+    assert normalized["status"] == "pending"
+    assert normalized["is_live"] is True
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_kis_domestic_order_normalization.py -k "dead_order_is_expired or live_pending_is_live" -v`
+Expected: FAIL — `KeyError: 'is_live'` and/or `status == "pending"` for the dead order.
+
+- [ ] **Step 3: Implement**
+
+In `_normalize_kis_domestic_order`, change the `_map_kis_status` call (around line 179) to pass `ordered`:
+
+```python
+    status = _map_kis_status(
+        ordered,
+        filled,
+        remaining,
+        _get_kis_field(order, "prcs_stat_name", "PRCS_STAT_NAME"),
+    )
+```
+
+Then add `is_live` to the returned dict (after the `"status": status,` line, ~line 212):
+
+```python
+        "status": status,
+        "is_live": status in ("pending", "partial"),
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_kis_domestic_order_normalization.py -v`
+Expected: PASS (new tests + all pre-existing normalizer tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/mcp_server/tooling/orders_modify_cancel.py tests/test_kis_domestic_order_normalization.py
+git commit -m "fix(ROB-657): KR normalizer surfaces expired status + is_live flag
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Overseas normalizer — pass `ordered`, add `is_live`
+
+**Files:**
+- Modify: `app/mcp_server/tooling/orders_modify_cancel.py:352-393` (`_normalize_kis_overseas_order`)
+- Test: `tests/test_kis_domestic_order_normalization.py`
+
+**Interfaces:**
+- Consumes: `_map_kis_status(ordered, filled, remaining, status_name)` from Task 1.
+- Produces: `_normalize_kis_overseas_order(order)` return dict includes `"is_live": bool`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_kis_domestic_order_normalization.py`:
+
+```python
+from app.mcp_server.tooling.orders_modify_cancel import (  # noqa: E402
+    _normalize_kis_overseas_order,
+)
+
+
+@pytest.mark.unit
+def test_normalize_kis_overseas_order_reports_is_live() -> None:
+    live = _normalize_kis_overseas_order(
+        {
+            "odno": "0007654321",
+            "sll_buy_dvsn_cd": "02",
+            "pdno": "AAPL",
+            "ft_ord_qty": "10",
+            "ft_ccld_qty": "0",
+            "ft_ord_unpr3": "200.5",
+            "ord_dt": "20260401",
+            "ord_tmd": "223000",
+        }
+    )
+    assert live["status"] == "pending"
+    assert live["is_live"] is True
+    assert live["remaining_qty"] == 10
+
+    done = _normalize_kis_overseas_order(
+        {
+            "odno": "0007654322",
+            "sll_buy_dvsn_cd": "02",
+            "pdno": "AAPL",
+            "ft_ord_qty": "10",
+            "ft_ccld_qty": "10",
+            "ft_ccld_unpr3": "201.0",
+            "ord_dt": "20260401",
+            "ord_tmd": "223500",
+        }
+    )
+    assert done["status"] == "filled"
+    assert done["is_live"] is False
+```
+
+(Prefer moving the `_normalize_kis_overseas_order` import to the top import block alongside `_map_kis_status` / `_normalize_kis_domestic_order` rather than an inline import; the inline form above is a fallback if you keep imports grouped per-test.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_kis_domestic_order_normalization.py::test_normalize_kis_overseas_order_reports_is_live -v`
+Expected: FAIL — `KeyError: 'is_live'`.
+
+- [ ] **Step 3: Implement**
+
+In `_normalize_kis_overseas_order`, change the `_map_kis_status` call (around line 371) to pass `ordered`:
+
+```python
+    status = _map_kis_status(
+        ordered,
+        filled,
+        remaining,
+        _get_kis_field(order, "prcs_stat_name", "PRCS_STAT_NAME"),
+    )
+```
+
+Add `is_live` to the returned dict (after `"status": status,`, ~line 381):
+
+```python
+        "status": status,
+        "is_live": status in ("pending", "partial"),
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_kis_domestic_order_normalization.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/mcp_server/tooling/orders_modify_cancel.py tests/test_kis_domestic_order_normalization.py
+git commit -m "fix(ROB-657): overseas normalizer passes ordered + emits is_live
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Order summary `expired` count
+
+**Files:**
+- Modify: `app/mcp_server/tooling/orders_history.py:57-70` (`_calculate_order_summary`)
+- Test: `tests/test_orders_history_summary_rob657.py` (new)
+
+**Interfaces:**
+- Produces: `_calculate_order_summary(orders)` return dict now includes `"expired": int` (count of `status == "expired"`).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_orders_history_summary_rob657.py`:
+
+```python
+from __future__ import annotations
+
+import pytest
+
+from app.mcp_server.tooling.orders_history import _calculate_order_summary
+
+
+@pytest.mark.unit
+def test_calculate_order_summary_counts_expired() -> None:
+    orders = [
+        {"status": "expired"},
+        {"status": "pending"},
+        {"status": "filled"},
+        {"status": "expired"},
+    ]
+
+    summary = _calculate_order_summary(orders)
+
+    assert summary["expired"] == 2
+    assert summary["pending"] == 1
+    assert summary["filled"] == 1
+    assert summary["total_orders"] == 4
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_orders_history_summary_rob657.py -v`
+Expected: FAIL — `KeyError: 'expired'`.
+
+- [ ] **Step 3: Implement**
+
+In `_calculate_order_summary` add the count and include it in the return dict:
+
+```python
+def _calculate_order_summary(orders: list[dict[str, Any]]) -> dict[str, Any]:
+    total_orders = len(orders)
+    filled = sum(1 for o in orders if o.get("status") == "filled")
+    pending = sum(1 for o in orders if o.get("status") == "pending")
+    partial = sum(1 for o in orders if o.get("status") == "partial")
+    cancelled = sum(1 for o in orders if o.get("status") == "cancelled")
+    expired = sum(1 for o in orders if o.get("status") == "expired")
+
+    return {
+        "total_orders": total_orders,
+        "filled": filled,
+        "pending": pending,
+        "partial": partial,
+        "cancelled": cancelled,
+        "expired": expired,
+    }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_orders_history_summary_rob657.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/mcp_server/tooling/orders_history.py tests/test_orders_history_summary_rob657.py
+git commit -m "fix(ROB-657): order-history summary reports expired count
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: `get_order_history_impl` integration — dead order drops out of pending, shows as expired under all
+
+**Files:**
+- Test: `tests/test_orders_history_summary_rob657.py` (extend)
+
+**Interfaces:**
+- Consumes: `get_order_history_impl(symbol=..., status=..., is_mock=False)` from `app/mcp_server/tooling/orders_history.py`; the KR fetch path calls `KISClient.inquire_korea_orders` (patched) whose rows flow through `_normalize_kis_domestic_order`.
+
+- [ ] **Step 1: Write the failing test**
+
+Extend `tests/test_orders_history_summary_rob657.py`. Patch the KR pending-orders broker call so exactly the dead 기아 row is returned; assert the tool no longer reports it as live:
+
+```python
+from unittest.mock import AsyncMock, patch
+
+import app.mcp_server.tooling.orders_history as orders_history
+
+_KIA_DEAD_ROW = {
+    "ord_dt": "20260702",
+    "ord_tmd": "100800",
+    "odno": "0013894000",
+    "sll_buy_dvsn_cd": "02",
+    "pdno": "000270",
+    "prdt_name": "기아",
+    "ord_qty": "8",
+    "ord_unpr": "129600",
+    "tot_ccld_qty": "0",
+    "rmn_qty": "0",
+}
+
+
+def _patch_kr(rows: list[dict]):
+    # inquire_daily_order_domestic is only hit for status in (filled/cancelled);
+    # return [] there so the pending path is what matters.
+    client = AsyncMock()
+    client.inquire_korea_orders = AsyncMock(return_value=rows)
+    client.inquire_daily_order_domestic = AsyncMock(return_value=[])
+    return patch.object(
+        orders_history, "_create_kis_client", lambda *, is_mock: client
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_get_order_history_all_marks_dead_order_expired() -> None:
+    with _patch_kr([_KIA_DEAD_ROW]):
+        resp = await orders_history.get_order_history_impl(
+            symbol="000270", status="all", market="kr", is_mock=False
+        )
+
+    orders = resp["orders"]
+    assert len(orders) == 1
+    assert orders[0]["order_id"] == "0013894000"
+    assert orders[0]["status"] == "expired"
+    assert orders[0]["is_live"] is False
+    assert resp["summary"]["expired"] == 1
+    assert resp["summary"]["pending"] == 0
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_get_order_history_pending_excludes_dead_order() -> None:
+    with _patch_kr([_KIA_DEAD_ROW]):
+        resp = await orders_history.get_order_history_impl(
+            symbol="000270", status="pending", market="kr", is_mock=False
+        )
+
+    assert resp["orders"] == []
+    assert resp["summary"]["pending"] == 0
+    assert resp["summary"]["expired"] == 0
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_orders_history_summary_rob657.py -k get_order_history -v`
+Expected: BEFORE Tasks 1-4 it would fail; after them it should already pass — run it to confirm the integration wiring. If it fails on `market` resolution or client patching, adjust the patch target to the actual client factory (`_create_kis_client`) — that is the seam `_fetch_kr_orders` uses.
+
+Note: if `_resolve_market_type("000270", "kr")` needs a DB/universe lookup, prefer passing `market="kr"` (already done) so `market_types == ["equity_kr"]` without symbol resolution. If resolution still triggers network/DB, patch `orders_history._resolve_market_type` to return `("equity_kr", "000270")`.
+
+- [ ] **Step 3: Implement**
+
+No product code change expected — Tasks 1-4 already deliver the behavior. If Step 2 revealed a real gap (e.g. `is_live` not propagated through `_filter_and_sort_orders`, which does `dict(o)` copy and should preserve it), fix it minimally and note it here.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_orders_history_summary_rob657.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/test_orders_history_summary_rob657.py
+git commit -m "test(ROB-657): get_order_history keeps dead order out of pending view
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: Docs + full verification
+
+**Files:**
+- Modify: `app/mcp_server/README.md` (only if it enumerates order-history status values / fields)
+- No test file changes.
+
+**Interfaces:** none (documentation + gate).
+
+- [ ] **Step 1: Check the README for order-history status docs**
+
+Run: `grep -n "get_order_history\|is_live\|\"pending\"\|status.*filled.*cancelled" app/mcp_server/README.md`
+
+If the order-history tool documents its returned `status` values or per-order fields, add `expired` to the status list and document `is_live` (bool; true only for `pending`/`partial`). If it does not enumerate them, skip the edit — do not invent a new doc section.
+
+- [ ] **Step 2: Format + lint**
+
+Run: `make format && make lint`
+Expected: no errors (ruff + ty clean).
+
+- [ ] **Step 3: Run the focused + regression test set**
+
+Run:
+```bash
+uv run pytest tests/test_kis_domestic_order_normalization.py tests/test_orders_history_summary_rob657.py tests/test_orders_history_kis_mock.py tests/test_mcp_kis_order_variants.py -v
+```
+Expected: PASS (no regressions in mock/variant suites).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add -A
+git commit -m "docs(ROB-657): document expired status + is_live in order-history tool
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+(If Step 1 produced no README change, fold this commit into whatever docs/verification note remains, or skip if the tree is clean.)
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- 변경 1 (status death rule) → Task 1 (+ wired in Tasks 2/3).
+- 변경 2 (`is_live`) → Task 2 (KR), Task 3 (overseas).
+- 변경 3 (summary `expired`) → Task 4.
+- Filtering consequence (pending excludes / all includes) → Task 5.
+- Docs → Task 6.
+- Out-of-scope #3 (`expected_expiry`/NXT carry) → intentionally not planned; noted in spec.
+
+**Placeholder scan:** No TBD/TODO. Task 5 Step 3 is conditional ("no change expected") with a concrete fallback seam named — acceptable because it is a verification-of-wiring task, not a hidden implementation.
+
+**Type consistency:** `_map_kis_status(ordered, filled, remaining, status_name)` used identically in Tasks 1, 2, 3. `is_live` defined as `status in ("pending", "partial")` in Tasks 2 and 3. `summary["expired"]` produced in Task 4 and asserted in Tasks 4/5. Query `Literal` untouched throughout.

--- a/docs/superpowers/specs/2026-07-03-rob-657-kis-order-history-expired-status-design.md
+++ b/docs/superpowers/specs/2026-07-03-rob-657-kis-order-history-expired-status-design.md
@@ -1,0 +1,164 @@
+# ROB-657 — `kis_live_get_order_history`: 소멸된 주문을 `pending`으로 오표시하는 결함 수정
+
+- **Linear**: ROB-657 (High)
+- **Related**: ROB-631 (Toss DAY 만료→REJECTED), ROB-476/487 (`live_order_expiry` 분류기)
+- **Date**: 2026-07-03
+- **Scope decision**: 제안 1+2만 (status 도출 + `is_live`). 제안 3(NXT carry / `expected_expiry`)은 후속.
+- **Migration**: 없음 (응답 shape additive)
+
+## 배경 / 증거
+
+2026-07-02 실거래: 기아(000270) 8주 @129,600 매수(odno 0013894000)가 15:30 정규장
+마감 시점에 실제로 소멸(운영자 KIS 앱: 미체결 없음 + 주문가능 전액 복원). 그러나
+`kis_live_get_order_history(symbol="000270", status="all")`는 16:09·17:08 두 차례 모두
+`status="pending"`으로 반환 → Claude가 "주문 살아있음"으로 두 번 오판.
+
+모순 페이로드:
+```json
+{"order_id":"0013894000","status":"pending","ordered_qty":8,"filled_qty":0,"remaining_qty":0}
+```
+`remaining_qty=0` + `filled_qty=0` = 정정취소가능수량 0 = **죽은 주문**(KIS 원장 기준)인데
+`status`가 `pending`으로 분류되고 `summary.pending=1`.
+
+## 근본 원인
+
+`app/mcp_server/tooling/orders_modify_cancel.py::_map_kis_status(filled, remaining, status_name)`:
+
+```python
+def _map_kis_status(filled: int, remaining: int, status_name: str | None) -> str:
+    normalized_name = str(status_name or "").strip()
+    if normalized_name in ("접수", "주문접수"):
+        return "pending"
+    if normalized_name == "주문취소":
+        return "cancelled"
+    if normalized_name == "체결":
+        if filled > 0 and remaining > 0:
+            return "partial"
+        return "filled"
+    if normalized_name == "미체결":
+        return "pending"
+    if filled > 0 and remaining <= 0:
+        return "filled"
+    if filled > 0 and remaining > 0:
+        return "partial"
+    return "pending"          # ← 기아 주문(filled=0, remaining=0)이 여기로 떨어짐
+```
+
+- 죽은 주문(`filled==0 && remaining==0`)에 대한 규칙이 없음 → 기본값 `pending`.
+- `inquire_korea_orders`(TTTC8036R, 정정취소가능주문조회)는 `prcs_stat_name`을 실제로
+  싣지 않는 것으로 실측됨(ROB-487 note) → name 분기가 안 걸리고 기본값으로 낙하.
+
+코드베이스는 이미 올바른 semantic을 다른 곳에 갖고 있음:
+- `app/services/brokers/kis/domestic_orders.py:560`: `rmn_qty: 잔여수량 (> 0 이면 주문 생존)`
+- `app/services/brokers/kis/live_order_expiry.py`: EOD day-order 소멸을 `expired`/`cancelled`로 분류.
+
+## 변경 사항
+
+### 변경 1 — `_map_kis_status` 종료(death) 규칙 추가
+
+시그니처에 `ordered`를 추가하고, **명시적 취소 증거가 우선**하도록 순서를 잡아 death 규칙을 삽입:
+
+```python
+def _map_kis_status(ordered: int, filled: int, remaining: int, status_name: str | None) -> str:
+    normalized_name = str(status_name or "").strip()
+
+    # 명시적 취소 증거는 언제나 우선.
+    if normalized_name == "주문취소":
+        return "cancelled"
+    # ROB-657: 체결 0 + 잔여 0 = 정정취소가능수량 0 = 소멸된 주문(만료/거부).
+    # KIS 원장에서 "주문 생존 = rmn_qty > 0"이므로 stale한 '접수' 상태명보다 우선.
+    if ordered > 0 and filled == 0 and remaining <= 0:
+        return "expired"
+    if normalized_name in ("접수", "주문접수"):
+        return "pending"
+    if normalized_name == "체결":
+        if filled > 0 and remaining > 0:
+            return "partial"
+        return "filled"
+    if normalized_name == "미체결":
+        return "pending"
+    if filled > 0 and remaining <= 0:
+        return "filled"
+    if filled > 0 and remaining > 0:
+        return "partial"
+    return "pending"
+```
+
+동작표:
+
+| ordered | filled | remaining | name     | before   | after     |
+|---------|--------|-----------|----------|----------|-----------|
+| 8       | 0      | 0         | `""`/None| pending  | **expired** |
+| 8       | 0      | 0         | 접수     | pending  | **expired** |
+| 8       | 0      | 0         | 미체결   | pending  | **expired** |
+| 8       | 0      | 0         | 주문취소 | cancelled| cancelled |
+| 10      | 0      | 10        | 접수/None| pending  | pending   |
+| 5       | 5      | 5         | 체결/None| partial  | partial   |
+| 10      | 10     | 0         | 체결/None| filled   | filled    |
+| 0       | 0      | 0         | None     | pending  | pending (degenerate, 소멸시킬 주문 없음) |
+
+호출부(같은 파일):
+- `_normalize_kis_domestic_order` — `_map_kis_status(ordered, filled, remaining, prcs_stat_name)`
+- `_normalize_kis_overseas_order` — `_map_kis_status(ordered, filled, remaining, prcs_stat_name)`
+  (overseas는 `remaining = ordered - filled`이라 death 경로에 원래 못 들어가지만 공유 헬퍼로 무해히 커버.)
+
+### 변경 2 — `is_live: bool` 명시 필드
+
+`_normalize_kis_domestic_order` / `_normalize_kis_overseas_order` 반환 dict에 추가:
+
+```python
+"is_live": status in ("pending", "partial"),
+```
+
+LLM이 `remaining_qty`/`filled_qty` 모순을 추론하지 않고 단일 boolean으로 생존 여부를 읽게 함.
+`expired`/`cancelled`/`filled` → `is_live=false`.
+
+### 변경 3 — `summary`에 `expired` 반영
+
+`orders_history.py::_calculate_order_summary`에 카운트 추가:
+
+```python
+expired = sum(1 for o in orders if o.get("status") == "expired")
+return {..., "cancelled": cancelled, "expired": expired}
+```
+
+파생 효과(기존 `_filter_and_sort_orders` 그대로):
+- `status="pending"` 쿼리 → death 주문은 이제 `expired`이므로 **제외**(pending/partial만 통과).
+- `status="all"` 쿼리 → `expired` + `is_live=false`로 노출, `summary.expired=1`, `summary.pending=0`.
+- 쿼리 파라미터 `Literal`은 `["all","pending","filled","cancelled"]` 유지 — `expired`는 `all`에서 노출되므로 새 쿼리 enum 불필요.
+
+## 범위 밖 (후속)
+
+- **제안 3** — 정규장 마감 시 KRX→NXT carry 여부를 실측해 `expected_expiry`를 15:30/20:00로
+  정확화. `get_order_history`는 `expected_expiry`를 방출하지 않으며, 이 필드는
+  `app/services/action_report/snapshot_backed/collectors/pending_orders.py` 및
+  `app/mcp_server/tooling/kis_live_ledger.py`에 존재. 라이브 실측이 필요하므로 별도 이슈로 분리.
+
+## 테스트
+
+`tests/test_kis_domestic_order_normalization.py` (신규/수정):
+- `_map_kis_status` parametrized: 시그니처 `ordered` 추가에 맞춰 모든 케이스 갱신.
+  - `(8,0,0,None)` / `(8,0,0,"")` / `(8,0,0,"접수")` / `(8,0,0,"미체결")` → `expired`
+  - `(8,0,0,"주문취소")` → `cancelled`
+  - `(0,0,0,None)` → `pending` (degenerate)
+  - 기존 live/partial/filled 케이스 → 불변
+- `_normalize_kis_domestic_order`:
+  - 기아 shape(`ord_qty=8, tot_ccld_qty=0, rmn_qty=0`) → `status="expired"`, `is_live=False`, `remaining_qty=0`
+  - live pending(`rmn_qty=10`) → `is_live=True`
+- `_normalize_kis_overseas_order`: `is_live` 필드 존재 + 값 정합.
+- `_calculate_order_summary`: `expired` 카운트 포함.
+- `get_order_history_impl` 통합(브로커 모킹, KR):
+  - `status="all"` → 죽은 주문이 `expired`/`is_live=False`, `summary.expired=1`, `summary.pending=0`
+  - `status="pending"` → 죽은 주문 제외(빈 orders 또는 미포함)
+
+## 문서
+
+- `_map_kis_status` docstring에 death 규칙(ROB-657) 근거 주석.
+- `app/mcp_server/README.md`의 order-history 도구 설명이 status 값을 열거하면 `expired`/`is_live` 반영.
+```
+
+## 검증
+
+- `make format && make lint` (ruff + ty)
+- `uv run pytest tests/test_kis_domestic_order_normalization.py tests/test_orders_history_kis_mock.py -v`
+- 관련 회귀: `uv run pytest tests/test_mcp_kis_order_variants.py -v`

--- a/tests/test_kis_domestic_order_normalization.py
+++ b/tests/test_kis_domestic_order_normalization.py
@@ -5,6 +5,7 @@ import pytest
 from app.mcp_server.tooling.orders_modify_cancel import (
     _map_kis_status,
     _normalize_kis_domestic_order,
+    _normalize_kis_overseas_order,
 )
 
 
@@ -184,3 +185,37 @@ def test_normalize_kis_domestic_order_live_pending_is_live() -> None:
 
     assert normalized["status"] == "pending"
     assert normalized["is_live"] is True
+
+
+@pytest.mark.unit
+def test_normalize_kis_overseas_order_reports_is_live() -> None:
+    live = _normalize_kis_overseas_order(
+        {
+            "odno": "0007654321",
+            "sll_buy_dvsn_cd": "02",
+            "pdno": "AAPL",
+            "ft_ord_qty": "10",
+            "ft_ccld_qty": "0",
+            "ft_ord_unpr3": "200.5",
+            "ord_dt": "20260401",
+            "ord_tmd": "223000",
+        }
+    )
+    assert live["status"] == "pending"
+    assert live["is_live"] is True
+    assert live["remaining_qty"] == 10
+
+    done = _normalize_kis_overseas_order(
+        {
+            "odno": "0007654322",
+            "sll_buy_dvsn_cd": "02",
+            "pdno": "AAPL",
+            "ft_ord_qty": "10",
+            "ft_ccld_qty": "10",
+            "ft_ccld_unpr3": "201.0",
+            "ord_dt": "20260401",
+            "ord_tmd": "223500",
+        }
+    )
+    assert done["status"] == "filled"
+    assert done["is_live"] is False

--- a/tests/test_kis_domestic_order_normalization.py
+++ b/tests/test_kis_domestic_order_normalization.py
@@ -151,3 +151,36 @@ def test_normalize_kis_domestic_order_keeps_output_pending_status() -> None:
     assert normalized["status"] == "pending"
     assert normalized["filled_qty"] == 0
     assert normalized["remaining_qty"] == 10
+
+
+@pytest.mark.unit
+def test_normalize_kis_domestic_order_dead_order_is_expired_not_live() -> None:
+    # ROB-657 repro: 기아 000270, 8 ordered, 0 filled, 0 remaining.
+    normalized = _normalize_kis_domestic_order(
+        _build_domestic_order(
+            pdno="000270",
+            ord_qty="8",
+            tot_ccld_qty="0",
+            rmn_qty="0",
+        )
+    )
+
+    assert normalized["status"] == "expired"
+    assert normalized["is_live"] is False
+    assert normalized["ordered_qty"] == 8
+    assert normalized["filled_qty"] == 0
+    assert normalized["remaining_qty"] == 0
+
+
+@pytest.mark.unit
+def test_normalize_kis_domestic_order_live_pending_is_live() -> None:
+    normalized = _normalize_kis_domestic_order(
+        _build_domestic_order(
+            ord_qty="10",
+            tot_ccld_qty="0",
+            rmn_qty="10",
+        )
+    )
+
+    assert normalized["status"] == "pending"
+    assert normalized["is_live"] is True

--- a/tests/test_kis_domestic_order_normalization.py
+++ b/tests/test_kis_domestic_order_normalization.py
@@ -10,26 +10,36 @@ from app.mcp_server.tooling.orders_modify_cancel import (
 
 @pytest.mark.unit
 @pytest.mark.parametrize(
-    ("filled", "remaining", "status_name", "expected"),
+    ("ordered", "filled", "remaining", "status_name", "expected"),
     [
-        (10, 0, "체결", "filled"),
-        (0, 10, "접수", "pending"),
-        (5, 5, "체결", "partial"),
-        (0, 0, "주문취소", "cancelled"),
-        (10, 0, None, "filled"),
-        (10, 0, "", "filled"),
-        (5, 5, None, "partial"),
-        (0, 10, None, "pending"),
-        (0, 0, None, "pending"),
+        # Live / filled / partial — unchanged behavior.
+        (10, 10, 0, "체결", "filled"),
+        (10, 0, 10, "접수", "pending"),
+        (10, 5, 5, "체결", "partial"),
+        (10, 10, 0, None, "filled"),
+        (10, 10, 0, "", "filled"),
+        (10, 5, 5, None, "partial"),
+        (10, 0, 10, None, "pending"),
+        # Explicit cancel evidence wins even with 0/0.
+        (8, 0, 0, "주문취소", "cancelled"),
+        # ROB-657: dead order (nothing filled, nothing left) → expired,
+        # regardless of a stale/absent status name.
+        (8, 0, 0, None, "expired"),
+        (8, 0, 0, "", "expired"),
+        (8, 0, 0, "접수", "expired"),
+        (8, 0, 0, "미체결", "expired"),
+        # Degenerate empty row → no order to expire.
+        (0, 0, 0, None, "pending"),
     ],
 )
 def test_map_kis_status_handles_named_and_unnamed_statuses(
+    ordered: int,
     filled: int,
     remaining: int,
     status_name: str | None,
     expected: str,
 ) -> None:
-    assert _map_kis_status(filled, remaining, status_name) == expected
+    assert _map_kis_status(ordered, filled, remaining, status_name) == expected
 
 
 def _build_domestic_order(**overrides: str) -> dict[str, str]:

--- a/tests/test_orders_history_summary_rob657.py
+++ b/tests/test_orders_history_summary_rob657.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+from unittest.mock import AsyncMock, patch
+
 import pytest
 
+import app.mcp_server.tooling.orders_history as orders_history
 from app.mcp_server.tooling.orders_history import _calculate_order_summary
 
 
@@ -20,3 +23,58 @@ def test_calculate_order_summary_counts_expired() -> None:
     assert summary["pending"] == 1
     assert summary["filled"] == 1
     assert summary["total_orders"] == 4
+
+
+_KIA_DEAD_ROW = {
+    "ord_dt": "20260702",
+    "ord_tmd": "100800",
+    "odno": "0013894000",
+    "sll_buy_dvsn_cd": "02",
+    "pdno": "000270",
+    "prdt_name": "기아",
+    "ord_qty": "8",
+    "ord_unpr": "129600",
+    "tot_ccld_qty": "0",
+    "rmn_qty": "0",
+}
+
+
+def _patch_kr(rows: list[dict]):
+    # inquire_daily_order_domestic is only hit for status in (filled/cancelled);
+    # return [] there so the pending path is what matters.
+    client = AsyncMock()
+    client.inquire_korea_orders = AsyncMock(return_value=rows)
+    client.inquire_daily_order_domestic = AsyncMock(return_value=[])
+    return patch.object(
+        orders_history, "_create_kis_client", lambda *, is_mock: client
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_get_order_history_all_marks_dead_order_expired() -> None:
+    with _patch_kr([_KIA_DEAD_ROW]):
+        resp = await orders_history.get_order_history_impl(
+            symbol="000270", status="all", market="kr", is_mock=False
+        )
+
+    orders = resp["orders"]
+    assert len(orders) == 1
+    assert orders[0]["order_id"] == "0013894000"
+    assert orders[0]["status"] == "expired"
+    assert orders[0]["is_live"] is False
+    assert resp["summary"]["expired"] == 1
+    assert resp["summary"]["pending"] == 0
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_get_order_history_pending_excludes_dead_order() -> None:
+    with _patch_kr([_KIA_DEAD_ROW]):
+        resp = await orders_history.get_order_history_impl(
+            symbol="000270", status="pending", market="kr", is_mock=False
+        )
+
+    assert resp["orders"] == []
+    assert resp["summary"]["pending"] == 0
+    assert resp["summary"]["expired"] == 0

--- a/tests/test_orders_history_summary_rob657.py
+++ b/tests/test_orders_history_summary_rob657.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import pytest
+
+from app.mcp_server.tooling.orders_history import _calculate_order_summary
+
+
+@pytest.mark.unit
+def test_calculate_order_summary_counts_expired() -> None:
+    orders = [
+        {"status": "expired"},
+        {"status": "pending"},
+        {"status": "filled"},
+        {"status": "expired"},
+    ]
+
+    summary = _calculate_order_summary(orders)
+
+    assert summary["expired"] == 2
+    assert summary["pending"] == 1
+    assert summary["filled"] == 1
+    assert summary["total_orders"] == 4

--- a/tests/test_orders_history_summary_rob657.py
+++ b/tests/test_orders_history_summary_rob657.py
@@ -45,9 +45,7 @@ def _patch_kr(rows: list[dict]):
     client = AsyncMock()
     client.inquire_korea_orders = AsyncMock(return_value=rows)
     client.inquire_daily_order_domestic = AsyncMock(return_value=[])
-    return patch.object(
-        orders_history, "_create_kis_client", lambda *, is_mock: client
-    )
+    return patch.object(orders_history, "_create_kis_client", lambda *, is_mock: client)
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## ROB-657 — `kis_live_get_order_history` expired status + `is_live`

Fixes the order-history misreporting that caused 2 operational misjudgments on 2026-07-02 (기아 000270 dead order shown as `status="pending"` with `remaining_qty=0`, leading Claude to believe a live order was still resting for ~7h). [Linear: ROB-657](https://linear.app/mgh3326/issue/ROB-657/kis-live-get-order-history-소멸된-주문을-statuspending으로-오표시-remaining-qty0)

## Problem

A dead KR order (`ordered>0 && filled==0 && remaining==0` — i.e. 정정취소가능수량 0, the KIS-ledger definition of "dead") fell through `_map_kis_status` to the default `return "pending"`, because the stale/absent `PRCS_STAT_NAME` (`접수`/`미체결`) won over the ledger truth. Result:

```json
{"order_id":"0013894000","status":"pending","ordered_qty":8,"filled_qty":0,"remaining_qty":0}
```

`status="pending"` contradicts `remaining_qty=0` → LLM/operator must infer liveness from contradictory fields → operational misjudgment.

## Fix

Additive response-shape change (no migration, no tool-query `Literal` change). `expired` surfaces under `status="all"`; the existing `status="pending"` filter drops dead orders from the live view for free.

1. **`_map_kis_status(ordered, filled, remaining, status_name)`** — new 4-arg signature with a terminal-death rule. Load-bearing branch order: explicit `주문취소 → cancelled` **first**, then `ordered>0 && filled==0 && remaining<=0 → expired`, then the named-status branches. Cancel evidence always wins; the death rule wins over a stale `접수` name. Degenerate empty row (`ordered==0`) still → `pending` (no order to expire).
2. **`is_live: bool`** — both `_normalize_kis_domestic_order` and `_normalize_kis_overseas_order` emit `is_live = status in ("pending", "partial")`. Removes the need to infer liveness from contradictory quantity fields.
3. **`_calculate_order_summary`** — adds an `expired` count.
4. Overseas path can never hit the death rule (`remaining = ordered - filled`, so a 0-filled overseas order always has `remaining == ordered > 0`); it gains `is_live` for parity and keeps passing tests.

## Spec & plan

- Spec: `docs/superpowers/specs/2026-07-03-rob-657-kis-order-history-expired-status-design.md`
- Plan: `docs/superpowers/plans/2026-07-03-rob-657-kis-order-history-expired-status.md` (executed task-by-task with strict TDD red→green)

## Verification

- `uv run pytest tests/test_kis_domestic_order_normalization.py tests/test_orders_history_summary_rob657.py tests/test_orders_history_kis_mock.py tests/test_mcp_kis_order_variants.py -v` → **56 passed, 0 failed**
- `make lint` → ruff check ✓, ruff format --check ✓ (2330 files), ty ✓ — all clean
- Diff scope: `app/mcp_server/tooling/orders_modify_cancel.py`, `app/mcp_server/tooling/orders_history.py`, `tests/test_kis_domestic_order_normalization.py`, `tests/test_orders_history_summary_rob657.py` (new). No DB migration, no new dependencies.
- README not modified: `app/mcp_server/README.md` documents only the `get_order_history` query-parameter rules, not per-order returned status values (per plan guidance, no doc section was invented).

## Out of scope

- **expected_expiry / NXT-carry accuracy (proposal #3 in the issue)** — "정규장 마감 시 KRX 미체결 주문의 NXT carry 여부 실측" is intentionally deferred; tracked separately in the spec. This PR fixes status *reporting*; it does not change expiry *prediction*.

## Model-lane guardrails (per `AGENTS.md`)

`keep_on_gpt54` — routine focused bug fix, additive response fields, no migration, local blast radius. Not a `high_risk_change` (no auth/security, no DB schema/migration, no live-order approval boundary change, no broad refactor — this is read-only order-history status mapping).

## Commits

- `eea8ece9` fix(ROB-657): `_map_kis_status` death rule → expired
- `880701c2` fix(ROB-657): KR normalizer `is_live` + `ordered`
- `b004b4ca` fix(ROB-657): overseas normalizer `is_live` + `ordered`
- `96ae14f9` fix(ROB-657): order-history summary `expired` count
- `d359a584` test(ROB-657): dead order kept out of pending view (integration)
- `af8d0189` style(ROB-657): ruff-format (Task 6 gate)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
