### PR TITLE
feat(ROB-666): allow order-history helpers in route_request buy lane

### DIFF
--- a/app/mcp_server/tooling/route_request_lanes.py
+++ b/app/mcp_server/tooling/route_request_lanes.py
@@ -202,15 +202,20 @@ _PLACE_ORDER_TOOLS: frozenset[str] = frozenset(
 # dry_run flag, so they need no separate entry here.)
 PREVIEW_TOOLS: frozenset[str] = frozenset({"toss_preview_order"})
 
-# ROB-660: per-lane allowed-only helper tools. The order-status tools
+# ROB-660 / ROB-666: per-lane allowed-only helper tools. The order-status tools
 # (kis_live_get_order_history / toss_get_order_history) are read-only in reality
 # but bucketed in MUTATION_TOOLS for registry partitioning, so build_route_plan
 # would otherwise block them even in the lane that needs them. The sell lane needs
-# them to confirm a cancel took effect and to check sell-order fill status. They
-# are un-blocked here (allowed) WITHOUT entering the ordered sequence (confirmation
-# helpers, not workflow steps) or the playbook YAML. Parallels MARKET_EXECUTION_TOOLS
-# (ROB-658) as an allowed supplement.
+# them to confirm a cancel took effect and to check sell-order fill status
+# (ROB-660); the buy lane needs them to confirm a buy fill and to check KIS
+# regular-session survival after the 15:30 expiry (ROB-657 rule) so it can
+# re-place (ROB-666). They are un-blocked here (allowed) WITHOUT entering the
+# ordered sequence (confirmation helpers, not workflow steps) or the playbook YAML.
+# Parallels MARKET_EXECUTION_TOOLS (ROB-658) as an allowed supplement. A minimal
+# per-lane allowance (not a MUTATION_TOOLS -> READ_ONLY reclassification) keeps
+# discovery/bootstrap unchanged.
 LANE_EXTRA_ALLOWED: dict[str, frozenset[str]] = {
+    "buy": frozenset({"kis_live_get_order_history", "toss_get_order_history"}),
     "sell": frozenset({"kis_live_get_order_history", "toss_get_order_history"}),
 }
 

--- a/tests/test_route_request_lanes.py
+++ b/tests/test_route_request_lanes.py
@@ -245,6 +245,24 @@ def test_sell_lane_history_helpers_allowed_but_not_sequenced():
         assert tool not in steps, tool
 
 
+def test_buy_lane_history_helpers_allowed_but_not_sequenced():
+    # ROB-666: buy lane needs the order-status helpers to confirm a buy fill and
+    # to check KIS regular-session survival after 15:30 (ROB-657 rule). Symmetric
+    # to the sell-lane allowance (ROB-660): allowed, never in the ordered sequence.
+    plan = L.build_route_plan(
+        "buy_analysis",
+        "kr",
+        registered_tools=_ALL,
+        verdict_thresholds=_fake_thresholds("kr", "buy"),
+        policy_version=_VERSION,
+    )
+    steps = [s["tool"] for s in plan["standard_tool_sequence"]]
+    for tool in ("kis_live_get_order_history", "toss_get_order_history"):
+        assert tool in plan["allowed_tools"], tool
+        assert tool not in plan["blocked_actions"], tool
+        assert tool not in steps, tool
+
+
 def test_sell_lane_routing_does_not_leak_into_buy_lane():
     buy = L.build_route_plan(
         "buy_analysis",
@@ -253,10 +271,10 @@ def test_sell_lane_routing_does_not_leak_into_buy_lane():
         verdict_thresholds=_fake_thresholds("kr", "buy"),
         policy_version=_VERSION,
     )
-    # sell-lane-only tools remain blocked in the buy lane (no cross-lane leak)
+    # sell-lane-only execution tools remain blocked in the buy lane (no cross-lane
+    # leak). The order-history helpers are now allowed in both lanes (ROB-666), so
+    # they are asserted separately in test_buy_lane_history_helpers_allowed_*.
     assert "toss_cancel_order" in buy["blocked_actions"]
-    assert "kis_live_get_order_history" in buy["blocked_actions"]
-    assert "toss_get_order_history" in buy["blocked_actions"]
 
 
 def test_sell_lane_new_kr_tools_dropped_when_unregistered_on_crypto():


### PR DESCRIPTION
## 배경 (ROB-660 후속)

ROB-660(#1372)은 sell lane에만 `LANE_EXTRA_ALLOWED`로 `kis_live_get_order_history` / `toss_get_order_history`를 허용했습니다. **buy lane은 여전히 두 도구가 `blocked_actions`** — 매수 주문 체결확인, KIS 정규장 접수분 15:30 소멸 후 생존확인·재배치(ROB-657 실측 운영 룰)가 buy lane 준수 하에서 불가했습니다. sell에서 고친 것과 동류 갭.

## 변경 (택1 중 **최소 옵션** 선택)

- `LANE_EXTRA_ALLOWED["buy"]`에 두 read-only order-status 헬퍼 추가 — ROB-660 sell 패턴 그대로.
- allowed로 노출하되 ordered sequence에는 넣지 않음 (체결확인 헬퍼, 워크플로 스텝 아님). playbook YAML 미변경.
- **근본 옵션(MUTATION_TOOLS → READ_ONLY 재분류)은 의도적으로 배제** — discovery/bootstrap까지 노출을 원치 않아 per-lane 최소 허용 유지.
- registry-diff 합집합 불변 유지. migration 0.

## 테스트

- `test_buy_lane_history_helpers_allowed_but_not_sequenced` 추가 (sell 대칭).
- cross-lane-leak 테스트는 이제 sell-only 실행도구(`toss_cancel_order`)만 buy에서 blocked임을 검증하도록 조정.
- `test_route_request_lanes.py` 17 pass, `test_route_request_registry_diff.py` 6 pass, `test_route_request.py` 27 pass. ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)