### PR TITLE
feat(ROB-663): forecast calibration dashboard — trade_forecasts read-only web surface

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -34,6 +34,7 @@ from app.routers import (
     invest_api,
     invest_app_spa,
     invest_fills,
+    invest_forecasts,
     invest_open_orders,
     invest_retrospectives,
     invest_scalping,
@@ -195,6 +196,7 @@ def create_app() -> FastAPI:
     app.include_router(invest_open_orders.router)
     app.include_router(invest_watches.router)
     app.include_router(invest_retrospectives.router)
+    app.include_router(invest_forecasts.router)
     app.include_router(invest_app_spa.router)
     app.include_router(invest_web_spa.router)
     app.include_router(trade_journals.router)

--- a/app/routers/invest_forecasts.py
+++ b/app/routers/invest_forecasts.py
@@ -1,0 +1,130 @@
+"""FastAPI router for /invest forecast calibration read surface (ROB-663).
+
+Read-only exposure of ``review.trade_forecasts`` (ROB-650): calibration cohorts
+(Brier / hit-rate / calibration-gap), the scoring-due open queue, and recent
+scored history. Scoring (``forecast_resolve``) stays MCP-only — the web reads,
+never writes; no broker/order/watch mutation is reachable from here.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.db import get_db
+from app.models.trading import User
+from app.routers.dependencies import get_authenticated_user
+from app.schemas.invest_forecasts import (
+    VALID_GROUP_BY,
+    VALID_INSTRUMENT_TYPES,
+    CalibrationGroupRow,
+    CalibrationResponse,
+    ForecastListResponse,
+    ForecastRow,
+)
+from app.services.trade_journal import forecast_service as fc_svc
+
+router = APIRouter(
+    prefix="/trading/api/invest/forecasts",
+    tags=["invest-forecasts"],
+)
+
+
+def _validate_instrument_type(instrument_type: str | None) -> None:
+    if instrument_type is not None and instrument_type not in VALID_INSTRUMENT_TYPES:
+        raise HTTPException(
+            status_code=422, detail=f"invalid instrument_type: {instrument_type}"
+        )
+
+
+@router.get("/calibration")
+async def get_forecast_calibration(
+    _user: Annotated[User, Depends(get_authenticated_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
+    group_by: Annotated[str, Query()] = "created_by",
+    created_by: Annotated[str | None, Query()] = None,
+    symbol: Annotated[str | None, Query()] = None,
+    instrument_type: Annotated[str | None, Query()] = None,
+    days: Annotated[int | None, Query(ge=1)] = None,
+) -> CalibrationResponse:
+    if group_by not in VALID_GROUP_BY:
+        raise HTTPException(status_code=422, detail=f"invalid group_by: {group_by}")
+    _validate_instrument_type(instrument_type)
+    result = await fc_svc.build_forecast_calibration_aggregate(
+        db,
+        group_by=group_by,
+        created_by=created_by,
+        symbol=symbol,
+        instrument_type=instrument_type,
+        days=days,
+    )
+    groups = result["groups"]
+    return CalibrationResponse(
+        group_by=result["group_by"],
+        created_by=created_by,
+        symbol=symbol,
+        instrument_type=instrument_type,
+        days=days,
+        count=len(groups),
+        groups=[CalibrationGroupRow(**g) for g in groups],
+        as_of=datetime.now(UTC),
+    )
+
+
+@router.get("/open")
+async def list_open_forecasts(
+    _user: Annotated[User, Depends(get_authenticated_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
+    symbol: Annotated[str | None, Query()] = None,
+    created_by: Annotated[str | None, Query()] = None,
+    instrument_type: Annotated[str | None, Query()] = None,
+    limit: Annotated[int, Query(ge=1, le=200)] = 50,
+) -> ForecastListResponse:
+    _validate_instrument_type(instrument_type)
+    result = await fc_svc.list_open_forecasts(
+        db,
+        symbol=symbol,
+        created_by=created_by,
+        instrument_type=instrument_type,
+        limit=limit,
+    )
+    return ForecastListResponse(
+        kind="open",
+        symbol=symbol,
+        created_by=created_by,
+        instrument_type=instrument_type,
+        count=result["summary"]["count"],
+        items=[ForecastRow(**e) for e in result["entries"]],
+        as_of=datetime.now(UTC),
+    )
+
+
+@router.get("/closed")
+async def list_closed_forecasts(
+    _user: Annotated[User, Depends(get_authenticated_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
+    symbol: Annotated[str | None, Query()] = None,
+    created_by: Annotated[str | None, Query()] = None,
+    instrument_type: Annotated[str | None, Query()] = None,
+    limit: Annotated[int, Query(ge=1, le=200)] = 50,
+) -> ForecastListResponse:
+    _validate_instrument_type(instrument_type)
+    result = await fc_svc.list_closed_forecasts(
+        db,
+        symbol=symbol,
+        created_by=created_by,
+        instrument_type=instrument_type,
+        limit=limit,
+    )
+    return ForecastListResponse(
+        kind="closed",
+        symbol=symbol,
+        created_by=created_by,
+        instrument_type=instrument_type,
+        count=result["summary"]["count"],
+        items=[ForecastRow(**e) for e in result["entries"]],
+        as_of=datetime.now(UTC),
+    )

--- a/app/schemas/invest_forecasts.py
+++ b/app/schemas/invest_forecasts.py
@@ -1,0 +1,83 @@
+"""Read-only schemas for /invest forecast calibration surface (ROB-663)."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from app.models.trading import InstrumentType
+
+# The calibration cohort keys accepted by ``build_forecast_calibration_aggregate``
+# (mirrors ``forecast_service._GROUP_BY_FIELDS``). "day" is the KST calendar date.
+VALID_GROUP_BY = frozenset({"created_by", "session_label", "model_label", "day"})
+VALID_INSTRUMENT_TYPES = frozenset(t.value for t in InstrumentType)
+
+ForecastKind = Literal["open", "closed"]
+
+
+class CalibrationGroupRow(BaseModel):
+    # extra=ignore: fed the full aggregate group dict; we keep a stable subset.
+    model_config = ConfigDict(extra="ignore")
+
+    group: str
+    sample_size: int = Field(ge=0)
+    hits: int = Field(ge=0)
+    misses: int = Field(ge=0)
+    hit_rate: float | None = None
+    avg_brier_score: float | None = None
+    avg_probability: float | None = None
+    calibration_gap: float | None = None
+
+
+class CalibrationResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    group_by: str
+    created_by: str | None = None
+    symbol: str | None = None
+    instrument_type: str | None = None
+    days: int | None = None
+    count: int = Field(ge=0)
+    groups: list[CalibrationGroupRow]
+    as_of: datetime
+
+
+class ForecastRow(BaseModel):
+    # extra=ignore: fed the full serialize_forecast(...) dict; we keep a subset.
+    model_config = ConfigDict(extra="ignore")
+
+    id: int
+    forecast_id: str
+    correlation_id: str | None = None
+    created_by: str | None = None
+    session_label: str | None = None
+    model_label: str | None = None
+    symbol: str
+    instrument_type: str | None = None
+    forecast_target: dict[str, Any] | None = None
+    horizon: str | None = None
+    probability: float | None = None
+    probability_range_low: float | None = None
+    probability_range_high: float | None = None
+    resolution_source: str | None = None
+    review_date: str | None = None
+    status: str | None = None
+    outcome: bool | None = None
+    observed_value: float | None = None
+    resolved_at: str | None = None
+    brier_score: float | None = None
+    created_at: str | None = None
+
+
+class ForecastListResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    kind: ForecastKind
+    symbol: str | None = None
+    created_by: str | None = None
+    instrument_type: str | None = None
+    count: int = Field(ge=0)
+    items: list[ForecastRow]
+    as_of: datetime

--- a/app/services/trade_journal/forecast_service.py
+++ b/app/services/trade_journal/forecast_service.py
@@ -435,6 +435,91 @@ async def list_forecasts(
     }
 
 
+def _forecast_scope_filters(
+    *,
+    status: str | None,
+    symbol: str | None,
+    created_by: str | None,
+    instrument_type: str | None,
+) -> list[Any]:
+    filters: list[Any] = []
+    if status is not None:
+        filters.append(TradeForecast.status == status)
+    if symbol is not None:
+        filters.append(
+            TradeForecast.symbol
+            == _normalize_symbol_for_filter(symbol, instrument_type)
+        )
+    if created_by is not None:
+        filters.append(TradeForecast.created_by == created_by)
+    if instrument_type is not None:
+        filters.append(TradeForecast.instrument_type == instrument_type)
+    return filters
+
+
+async def _run_forecast_listing(
+    db: AsyncSession, *, filters: list[Any], order_by: Any, limit: int
+) -> dict[str, Any]:
+    stmt = select(TradeForecast).where(*filters).order_by(order_by).limit(limit)
+    rows = (await db.execute(stmt)).scalars().all()
+    by_status: dict[str, int] = {}
+    for r in rows:
+        by_status[r.status] = by_status.get(r.status, 0) + 1
+    return {
+        "entries": [serialize_forecast(r) for r in rows],
+        "summary": {"count": len(rows), "by_status": by_status},
+    }
+
+
+async def list_open_forecasts(
+    db: AsyncSession,
+    *,
+    symbol: str | None = None,
+    created_by: str | None = None,
+    instrument_type: str | None = None,
+    limit: int = 50,
+) -> dict[str, Any]:
+    """Open forecasts ordered by ``review_date`` ASC — the scoring-due queue (ROB-663).
+
+    Soonest (and overdue) review dates sort first so the web surface can show the
+    "채점 due 대기열". Ordering is done in SQL so ``limit`` selects the most imminent
+    rows rather than merely the most-recently-created ones.
+    """
+    filters = _forecast_scope_filters(
+        status="open",
+        symbol=symbol,
+        created_by=created_by,
+        instrument_type=instrument_type,
+    )
+    return await _run_forecast_listing(
+        db, filters=filters, order_by=TradeForecast.review_date.asc(), limit=limit
+    )
+
+
+async def list_closed_forecasts(
+    db: AsyncSession,
+    *,
+    symbol: str | None = None,
+    created_by: str | None = None,
+    instrument_type: str | None = None,
+    limit: int = 50,
+) -> dict[str, Any]:
+    """Closed/scored forecasts ordered by ``resolved_at`` DESC — recent scoring
+    history with ``outcome``/``brier_score`` populated (ROB-663)."""
+    filters = _forecast_scope_filters(
+        status="closed",
+        symbol=symbol,
+        created_by=created_by,
+        instrument_type=instrument_type,
+    )
+    return await _run_forecast_listing(
+        db,
+        filters=filters,
+        order_by=TradeForecast.resolved_at.desc().nulls_last(),
+        limit=limit,
+    )
+
+
 async def _read_window_candles(
     db: AsyncSession,
     *,

--- a/frontend/invest/src/__tests__/ForecastCalibrationPanel.test.tsx
+++ b/frontend/invest/src/__tests__/ForecastCalibrationPanel.test.tsx
@@ -1,0 +1,66 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, expect, test, vi } from "vitest";
+import { ForecastCalibrationPanel } from "../components/insights/ForecastCalibrationPanel";
+import type { CalibrationResponse, ForecastListResponse } from "../types/forecasts";
+
+const calib: CalibrationResponse = {
+  group_by: "created_by", created_by: null, symbol: null, instrument_type: null,
+  days: null, count: 1, as_of: "2026-07-01T00:00:00Z",
+  groups: [{
+    group: "hermes", sample_size: 4, hits: 3, misses: 1,
+    hit_rate: 0.75, avg_brier_score: 0.18, avg_probability: 0.8,
+    calibration_gap: 0.05,
+  }],
+};
+const open: ForecastListResponse = {
+  kind: "open", symbol: null, created_by: null, instrument_type: null,
+  count: 1, as_of: "2026-07-01T00:00:00Z",
+  items: [{
+    id: 1, forecast_id: "f1", correlation_id: null, created_by: "claude",
+    session_label: null, model_label: null, symbol: "005930",
+    instrument_type: "equity_kr", forecast_target: null, horizon: null,
+    probability: 0.6, probability_range_low: null, probability_range_high: null,
+    resolution_source: null, review_date: "2026-07-10", status: "open",
+    outcome: null, observed_value: null, resolved_at: null, brier_score: null,
+    created_at: "2026-07-01T00:00:00Z",
+  }],
+};
+const closed: ForecastListResponse = {
+  kind: "closed", symbol: null, created_by: null, instrument_type: null,
+  count: 1, as_of: "2026-07-01T00:00:00Z",
+  items: [{
+    id: 2, forecast_id: "f2", correlation_id: null, created_by: "claude",
+    session_label: null, model_label: null, symbol: "AAPL",
+    instrument_type: "equity_us", forecast_target: null, horizon: null,
+    probability: 0.7, probability_range_low: null, probability_range_high: null,
+    resolution_source: null, review_date: "2026-06-20", status: "closed",
+    outcome: true, observed_value: null, resolved_at: "2026-06-21T00:00:00Z",
+    brier_score: 0.09, created_at: "2026-06-10T00:00:00Z",
+  }],
+};
+
+afterEach(() => vi.unstubAllGlobals());
+
+test("renders calibration table, due queue and recent scored results", async () => {
+  const fetchMock = vi.fn((url: string) => {
+    const u = String(url);
+    const body = u.includes("/calibration") ? calib : u.includes("/open") ? open : closed;
+    return Promise.resolve({ ok: true, json: async () => body });
+  });
+  vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+  render(
+    <MemoryRouter>
+      <ForecastCalibrationPanel />
+    </MemoryRouter>,
+  );
+
+  // calibration cohort row
+  await waitFor(() => expect(screen.getByText("hermes")).toBeInTheDocument());
+  // due-queue open forecast (symbol link)
+  expect(screen.getByText("005930")).toBeInTheDocument();
+  // recent scored result: outcome badge + symbol
+  expect(screen.getByText("적중")).toBeInTheDocument();
+  expect(screen.getByText("AAPL")).toBeInTheDocument();
+});

--- a/frontend/invest/src/__tests__/forecasts.api.test.ts
+++ b/frontend/invest/src/__tests__/forecasts.api.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, expect, test, vi } from "vitest";
+import {
+  fetchClosedForecasts,
+  fetchForecastCalibration,
+  fetchOpenForecasts,
+} from "../api/forecasts";
+import type { CalibrationResponse, ForecastListResponse } from "../types/forecasts";
+
+const calib: CalibrationResponse = {
+  group_by: "created_by", created_by: null, symbol: null, instrument_type: null,
+  days: null, count: 0, groups: [], as_of: "2026-07-01T00:00:00Z",
+};
+const list: ForecastListResponse = {
+  kind: "open", symbol: null, created_by: null, instrument_type: null,
+  count: 0, items: [], as_of: "2026-07-01T00:00:00Z",
+};
+
+afterEach(() => vi.unstubAllGlobals());
+
+test("fetchForecastCalibration sends group_by + filters with credentials", async () => {
+  const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => calib });
+  vi.stubGlobal("fetch", fetchMock);
+
+  await expect(
+    fetchForecastCalibration({ groupBy: "model_label", symbol: "AAPL", days: 30 }),
+  ).resolves.toEqual(calib);
+
+  const [url, init] = fetchMock.mock.calls[0]!;
+  expect(init).toEqual({ credentials: "include" });
+  expect(String(url)).toMatch(/^\/trading\/api\/invest\/forecasts\/calibration\?/);
+  const params = new URLSearchParams(String(url).split("?")[1]);
+  expect(params.get("group_by")).toBe("model_label");
+  expect(params.get("symbol")).toBe("AAPL");
+  expect(params.get("days")).toBe("30");
+});
+
+test("fetchOpenForecasts / fetchClosedForecasts hit their endpoints", async () => {
+  const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => list });
+  vi.stubGlobal("fetch", fetchMock);
+
+  await fetchOpenForecasts({ limit: 20 });
+  expect(String(fetchMock.mock.calls[0]![0])).toMatch(
+    /^\/trading\/api\/invest\/forecasts\/open\?/,
+  );
+
+  await fetchClosedForecasts({ symbol: "005930" });
+  const closedUrl = String(fetchMock.mock.calls[1]![0]);
+  expect(closedUrl).toMatch(/^\/trading\/api\/invest\/forecasts\/closed\?/);
+  expect(new URLSearchParams(closedUrl.split("?")[1]).get("symbol")).toBe("005930");
+});
+
+test("rejects non-OK responses", async () => {
+  vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, status: 401 }));
+  await expect(fetchForecastCalibration()).rejects.toThrow("forecast calibration 401");
+});

--- a/frontend/invest/src/api/forecasts.ts
+++ b/frontend/invest/src/api/forecasts.ts
@@ -1,0 +1,68 @@
+import type {
+  CalibrationResponse,
+  ForecastGroupBy,
+  ForecastListResponse,
+} from "../types/forecasts";
+
+const BASE = "/trading/api/invest/forecasts";
+
+export interface CalibrationQuery {
+  groupBy?: ForecastGroupBy;
+  createdBy?: string;
+  symbol?: string;
+  instrumentType?: string;
+  days?: number;
+}
+
+export async function fetchForecastCalibration(
+  q: CalibrationQuery = {},
+): Promise<CalibrationResponse> {
+  const params = new URLSearchParams();
+  if (q.groupBy) params.set("group_by", q.groupBy);
+  if (q.createdBy) params.set("created_by", q.createdBy);
+  if (q.symbol) params.set("symbol", q.symbol);
+  if (q.instrumentType) params.set("instrument_type", q.instrumentType);
+  if (q.days != null) params.set("days", String(q.days));
+  const qs = params.toString();
+  const res = await fetch(`${BASE}/calibration${qs ? `?${qs}` : ""}`, {
+    credentials: "include",
+  });
+  if (!res.ok) throw new Error(`forecast calibration ${res.status}`);
+  return res.json();
+}
+
+export interface ForecastListQuery {
+  symbol?: string;
+  createdBy?: string;
+  instrumentType?: string;
+  limit?: number;
+}
+
+async function fetchForecastList(
+  kind: "open" | "closed",
+  q: ForecastListQuery = {},
+): Promise<ForecastListResponse> {
+  const params = new URLSearchParams();
+  if (q.symbol) params.set("symbol", q.symbol);
+  if (q.createdBy) params.set("created_by", q.createdBy);
+  if (q.instrumentType) params.set("instrument_type", q.instrumentType);
+  if (q.limit != null) params.set("limit", String(q.limit));
+  const qs = params.toString();
+  const res = await fetch(`${BASE}/${kind}${qs ? `?${qs}` : ""}`, {
+    credentials: "include",
+  });
+  if (!res.ok) throw new Error(`forecast ${kind} ${res.status}`);
+  return res.json();
+}
+
+export function fetchOpenForecasts(
+  q: ForecastListQuery = {},
+): Promise<ForecastListResponse> {
+  return fetchForecastList("open", q);
+}
+
+export function fetchClosedForecasts(
+  q: ForecastListQuery = {},
+): Promise<ForecastListResponse> {
+  return fetchForecastList("closed", q);
+}

--- a/frontend/invest/src/components/insights/ForecastCalibrationPanel.tsx
+++ b/frontend/invest/src/components/insights/ForecastCalibrationPanel.tsx
@@ -1,0 +1,276 @@
+import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+
+import {
+  fetchClosedForecasts,
+  fetchForecastCalibration,
+  fetchOpenForecasts,
+} from "../../api/forecasts";
+import { Card, Pill } from "../../ds";
+import { stockDetailPath } from "../../stockDetailPath";
+import type {
+  CalibrationGroupRow,
+  ForecastGroupBy,
+  ForecastRow,
+} from "../../types/forecasts";
+
+const GROUP_BY_OPTIONS: { key: ForecastGroupBy; label: string }[] = [
+  { key: "created_by", label: "작성자" },
+  { key: "model_label", label: "모델" },
+  { key: "session_label", label: "세션" },
+  { key: "day", label: "일자" },
+];
+
+const INSTRUMENT_MARKET: Record<string, "kr" | "us" | "crypto"> = {
+  equity_kr: "kr",
+  equity_us: "us",
+  crypto: "crypto",
+};
+
+function symbolHref(row: ForecastRow): string | null {
+  const market = row.instrument_type ? INSTRUMENT_MARKET[row.instrument_type] : undefined;
+  return market ? stockDetailPath(market, row.symbol) : null;
+}
+
+function SymbolCell({ row }: { row: ForecastRow }) {
+  const href = symbolHref(row);
+  return href ? (
+    <Link to={href} style={{ color: "inherit", textDecoration: "none" }}>
+      {row.symbol}
+    </Link>
+  ) : (
+    <>{row.symbol}</>
+  );
+}
+
+function pct(x: number | null): string {
+  return x == null ? "—" : `${(x * 100).toFixed(0)}%`;
+}
+
+function num(x: number | null, digits = 3): string {
+  return x == null ? "—" : x.toFixed(digits);
+}
+
+function gapText(x: number | null): { text: string; tone: "gain" | "loss" | "paper" } {
+  if (x == null) return { text: "—", tone: "paper" };
+  const sign = x > 0 ? "+" : "";
+  // positive gap = over-confident (predicted higher than realized) → caution
+  const tone = Math.abs(x) < 0.05 ? "paper" : x > 0 ? "loss" : "gain";
+  return { text: `${sign}${x.toFixed(3)}`, tone };
+}
+
+const th: React.CSSProperties = {
+  padding: "8px 12px",
+  borderTop: "1px solid var(--divider)",
+  borderBottom: "1px solid var(--divider)",
+  fontWeight: 700,
+};
+const td: React.CSSProperties = {
+  padding: "9px 12px",
+  borderBottom: "1px solid var(--divider)",
+  fontSize: 13,
+};
+const tdNum: React.CSSProperties = {
+  ...td,
+  textAlign: "right",
+  fontFeatureSettings: '"tnum"',
+};
+
+function CalibrationTable({ rows }: { rows: CalibrationGroupRow[] }) {
+  if (rows.length === 0) {
+    return (
+      <div style={{ padding: 16, color: "var(--fg-3)", fontSize: 13, textAlign: "center" }}>
+        채점 완료된 예측이 아직 없습니다.
+      </div>
+    );
+  }
+  return (
+    <div style={{ overflowX: "auto" }}>
+      <table style={{ width: "100%", borderCollapse: "collapse", minWidth: 560 }}>
+        <thead>
+          <tr style={{ color: "var(--fg-3)", fontSize: 11, textAlign: "left" }}>
+            <th style={th}>그룹</th>
+            <th style={{ ...th, textAlign: "right" }}>표본</th>
+            <th style={{ ...th, textAlign: "right" }}>적중률</th>
+            <th style={{ ...th, textAlign: "right" }}>평균확신</th>
+            <th style={{ ...th, textAlign: "right" }}>Brier</th>
+            <th style={{ ...th, textAlign: "right" }}>보정오차</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((r) => {
+            const gap = gapText(r.calibration_gap);
+            return (
+              <tr key={r.group}>
+                <td style={{ ...td, fontWeight: 700 }}>{r.group}</td>
+                <td style={tdNum}>
+                  {r.sample_size}
+                  <span style={{ color: "var(--fg-3)", fontSize: 11 }}> ({r.hits}/{r.sample_size})</span>
+                </td>
+                <td style={tdNum}>{pct(r.hit_rate)}</td>
+                <td style={tdNum}>{pct(r.avg_probability)}</td>
+                <td style={tdNum}>{num(r.avg_brier_score)}</td>
+                <td style={{ ...tdNum }}>
+                  <Pill tone={gap.tone} size="sm">{gap.text}</Pill>
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function OpenList({ rows }: { rows: ForecastRow[] }) {
+  if (rows.length === 0) {
+    return (
+      <div style={{ padding: 16, color: "var(--fg-3)", fontSize: 13, textAlign: "center" }}>
+        대기 중인 예측이 없습니다.
+      </div>
+    );
+  }
+  return (
+    <div style={{ display: "grid", gap: 6 }}>
+      {rows.map((r) => (
+        <div
+          key={r.id}
+          style={{ display: "flex", alignItems: "center", gap: 8, fontSize: 13, padding: "2px 0" }}
+        >
+          <span style={{ color: "var(--fg-3)", fontSize: 11, minWidth: 84 }}>{r.review_date ?? "—"}</span>
+          <span style={{ fontWeight: 700 }}><SymbolCell row={r} /></span>
+          <Pill tone="paper" size="sm">확신 {pct(r.probability)}</Pill>
+          {r.created_by && <span style={{ color: "var(--fg-3)", fontSize: 11 }}>· {r.created_by}</span>}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function ClosedList({ rows }: { rows: ForecastRow[] }) {
+  if (rows.length === 0) {
+    return (
+      <div style={{ padding: 16, color: "var(--fg-3)", fontSize: 13, textAlign: "center" }}>
+        최근 채점 결과가 없습니다.
+      </div>
+    );
+  }
+  return (
+    <div style={{ display: "grid", gap: 6 }}>
+      {rows.map((r) => (
+        <div
+          key={r.id}
+          style={{ display: "flex", alignItems: "center", gap: 8, fontSize: 13, padding: "2px 0" }}
+        >
+          <Pill tone={r.outcome ? "gain" : "loss"} size="sm">{r.outcome ? "적중" : "빗나감"}</Pill>
+          <span style={{ fontWeight: 700 }}><SymbolCell row={r} /></span>
+          <span style={{ color: "var(--fg-3)", fontSize: 11 }}>확신 {pct(r.probability)}</span>
+          <span style={{ color: "var(--fg-3)", fontSize: 11 }}>· Brier {num(r.brier_score)}</span>
+          {r.resolved_at && (
+            <span style={{ color: "var(--fg-3)", fontSize: 11 }}>· {r.resolved_at.slice(0, 10)}</span>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+type LoadState<T> =
+  | { status: "loading" }
+  | { status: "ready"; data: T }
+  | { status: "error"; message: string };
+
+function Section({ title, hint, children }: { title: string; hint?: string; children: React.ReactNode }) {
+  return (
+    <div style={{ display: "grid", gap: 8 }}>
+      <div>
+        <h3 style={{ margin: 0, fontSize: 15 }}>{title}</h3>
+        {hint && <p style={{ margin: "2px 0 0", fontSize: 12, color: "var(--fg-3)" }}>{hint}</p>}
+      </div>
+      {children}
+    </div>
+  );
+}
+
+export function ForecastCalibrationPanel() {
+  const [groupBy, setGroupBy] = useState<ForecastGroupBy>("created_by");
+  const [calib, setCalib] = useState<LoadState<CalibrationGroupRow[]>>({ status: "loading" });
+  const [open, setOpen] = useState<LoadState<ForecastRow[]>>({ status: "loading" });
+  const [closed, setClosed] = useState<LoadState<ForecastRow[]>>({ status: "loading" });
+
+  useEffect(() => {
+    let cancelled = false;
+    setCalib({ status: "loading" });
+    fetchForecastCalibration({ groupBy })
+      .then((d) => { if (!cancelled) setCalib({ status: "ready", data: d.groups }); })
+      .catch((e: unknown) => {
+        if (!cancelled) setCalib({ status: "error", message: e instanceof Error ? e.message : String(e) });
+      });
+    return () => { cancelled = true; };
+  }, [groupBy]);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetchOpenForecasts({ limit: 20 })
+      .then((d) => { if (!cancelled) setOpen({ status: "ready", data: d.items }); })
+      .catch((e: unknown) => {
+        if (!cancelled) setOpen({ status: "error", message: e instanceof Error ? e.message : String(e) });
+      });
+    fetchClosedForecasts({ limit: 20 })
+      .then((d) => { if (!cancelled) setClosed({ status: "ready", data: d.items }); })
+      .catch((e: unknown) => {
+        if (!cancelled) setClosed({ status: "error", message: e instanceof Error ? e.message : String(e) });
+      });
+    return () => { cancelled = true; };
+  }, []);
+
+  return (
+    <Card>
+      <section data-testid="forecast-calibration-panel" style={{ display: "grid", gap: 16 }}>
+        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", gap: 12, flexWrap: "wrap" }}>
+          <div>
+            <h2 style={{ margin: 0, fontSize: 18 }}>예측 캘리브레이션</h2>
+            <p style={{ margin: "4px 0 0", fontSize: 12, color: "var(--fg-3)" }}>
+              어떤 모델·세션의 판단을 얼마나 믿을 수 있는지 — resolvable 예측의 Brier·적중률·보정오차.
+            </p>
+          </div>
+          <div style={{ display: "flex", gap: 6, flexWrap: "wrap" }}>
+            {GROUP_BY_OPTIONS.map((o) => (
+              <button
+                key={o.key}
+                type="button"
+                onClick={() => setGroupBy(o.key)}
+                style={{
+                  border: "none", borderRadius: 999, padding: "4px 10px", fontSize: 11,
+                  fontWeight: 700, cursor: "pointer", fontFamily: "inherit",
+                  background: groupBy === o.key ? "var(--fg)" : "var(--surface-2)",
+                  color: groupBy === o.key ? "var(--bg)" : "var(--fg-2)",
+                }}
+              >
+                {o.label}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <Section title="그룹별 신뢰도" hint="양수 보정오차 = 과신(예측이 실현보다 높음).">
+          {calib.status === "loading" && <div style={{ padding: 16, color: "var(--fg-3)", fontSize: 13, textAlign: "center" }}>불러오는 중…</div>}
+          {calib.status === "error" && <div role="alert" style={{ padding: 12, color: "var(--danger)", fontSize: 13 }}>캘리브레이션을 불러오지 못했습니다. {calib.message}</div>}
+          {calib.status === "ready" && <CalibrationTable rows={calib.data} />}
+        </Section>
+
+        <Section title="채점 대기열" hint="review_date 임박순 — 채점이 필요한 열린 예측.">
+          {open.status === "loading" && <div style={{ padding: 16, color: "var(--fg-3)", fontSize: 13, textAlign: "center" }}>불러오는 중…</div>}
+          {open.status === "error" && <div role="alert" style={{ padding: 12, color: "var(--danger)", fontSize: 13 }}>대기열을 불러오지 못했습니다. {open.message}</div>}
+          {open.status === "ready" && <OpenList rows={open.data} />}
+        </Section>
+
+        <Section title="최근 채점 결과" hint="가장 최근에 해소된 예측.">
+          {closed.status === "loading" && <div style={{ padding: 16, color: "var(--fg-3)", fontSize: 13, textAlign: "center" }}>불러오는 중…</div>}
+          {closed.status === "error" && <div role="alert" style={{ padding: 12, color: "var(--danger)", fontSize: 13 }}>채점 결과를 불러오지 못했습니다. {closed.message}</div>}
+          {closed.status === "ready" && <ClosedList rows={closed.data} />}
+        </Section>
+      </section>
+    </Card>
+  );
+}

--- a/frontend/invest/src/pages/desktop/DesktopInsightsPage.tsx
+++ b/frontend/invest/src/pages/desktop/DesktopInsightsPage.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from "react";
 import { Link } from "react-router-dom";
 import { CommonPreferredDisparityCardView } from "../../components/CommonPreferredDisparityCard";
 import { MarketParityStrip } from "../../components/home/MarketParityStrip";
+import { ForecastCalibrationPanel } from "../../components/insights/ForecastCalibrationPanel";
 import { PageSafetyNote } from "../../components/PageSafetyNote";
 import { DesktopShell } from "../../desktop/DesktopShell";
 import { Card } from "../../ds";
@@ -89,6 +90,8 @@ export function DesktopInsightsPage() {
           {disparity.status === "loading" && <SectionStatus>보통주/우선주 괴리 데이터를 불러오는 중…</SectionStatus>}
           {disparity.status === "error" && <SectionStatus>보통주/우선주 괴리 데이터를 일시적으로 불러오지 못했습니다.</SectionStatus>}
           {disparity.status === "ready" && <CommonPreferredDisparityCardView data={disparity.data} />}
+
+          <ForecastCalibrationPanel />
 
           <RelatedScreensCard />
         </div>

--- a/frontend/invest/src/types/forecasts.ts
+++ b/frontend/invest/src/types/forecasts.ts
@@ -1,0 +1,60 @@
+// Read-only forecast calibration surface (ROB-663).
+// Mirrors app/schemas/invest_forecasts.py field-for-field (snake_case preserved).
+
+export type ForecastGroupBy = "created_by" | "session_label" | "model_label" | "day";
+
+export interface CalibrationGroupRow {
+  group: string;
+  sample_size: number;
+  hits: number;
+  misses: number;
+  hit_rate: number | null;
+  avg_brier_score: number | null;
+  avg_probability: number | null;
+  calibration_gap: number | null;
+}
+
+export interface CalibrationResponse {
+  group_by: string;
+  created_by: string | null;
+  symbol: string | null;
+  instrument_type: string | null;
+  days: number | null;
+  count: number;
+  groups: CalibrationGroupRow[];
+  as_of: string;
+}
+
+export interface ForecastRow {
+  id: number;
+  forecast_id: string;
+  correlation_id: string | null;
+  created_by: string | null;
+  session_label: string | null;
+  model_label: string | null;
+  symbol: string;
+  instrument_type: string | null;
+  forecast_target: Record<string, unknown> | null;
+  horizon: string | null;
+  probability: number | null;
+  probability_range_low: number | null;
+  probability_range_high: number | null;
+  resolution_source: string | null;
+  review_date: string | null;
+  status: string | null;
+  outcome: boolean | null;
+  observed_value: number | null;
+  resolved_at: string | null;
+  brier_score: number | null;
+  created_at: string | null;
+}
+
+export interface ForecastListResponse {
+  kind: "open" | "closed";
+  symbol: string | null;
+  created_by: string | null;
+  instrument_type: string | null;
+  count: number;
+  items: ForecastRow[];
+  as_of: string;
+}

--- a/tests/routers/test_invest_forecasts_router.py
+++ b/tests/routers/test_invest_forecasts_router.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+def _make_client(monkeypatch, *, calib=None, open_res=None, closed_res=None):
+    from app.core.db import get_db
+    from app.routers import invest_forecasts
+    from app.routers.dependencies import get_authenticated_user
+
+    calls: dict = {}
+
+    async def _fake_calib(db, **kwargs):
+        calls["calib"] = kwargs
+        return calib or {"group_by": kwargs.get("group_by", "created_by"), "groups": []}
+
+    async def _fake_open(db, **kwargs):
+        calls["open"] = kwargs
+        return open_res or {"entries": [], "summary": {"count": 0, "by_status": {}}}
+
+    async def _fake_closed(db, **kwargs):
+        calls["closed"] = kwargs
+        return closed_res or {"entries": [], "summary": {"count": 0, "by_status": {}}}
+
+    monkeypatch.setattr(
+        invest_forecasts.fc_svc, "build_forecast_calibration_aggregate", _fake_calib
+    )
+    monkeypatch.setattr(invest_forecasts.fc_svc, "list_open_forecasts", _fake_open)
+    monkeypatch.setattr(invest_forecasts.fc_svc, "list_closed_forecasts", _fake_closed)
+
+    app = FastAPI()
+    app.include_router(invest_forecasts.router)
+    app.dependency_overrides[get_authenticated_user] = lambda: SimpleNamespace(id=1)
+    app.dependency_overrides[get_db] = lambda: "db"
+    return TestClient(app), calls
+
+
+@pytest.mark.unit
+def test_calibration_defaults(monkeypatch):
+    client, calls = _make_client(monkeypatch)
+    r = client.get("/trading/api/invest/forecasts/calibration")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["group_by"] == "created_by"
+    assert body["count"] == 0
+    assert calls["calib"]["group_by"] == "created_by"
+
+
+@pytest.mark.unit
+def test_calibration_forwards_filters(monkeypatch):
+    client, calls = _make_client(monkeypatch)
+    r = client.get(
+        "/trading/api/invest/forecasts/calibration"
+        "?group_by=model_label&created_by=hermes&symbol=AAPL"
+        "&instrument_type=equity_us&days=30"
+    )
+    assert r.status_code == 200
+    assert calls["calib"]["group_by"] == "model_label"
+    assert calls["calib"]["created_by"] == "hermes"
+    assert calls["calib"]["symbol"] == "AAPL"
+    assert calls["calib"]["instrument_type"] == "equity_us"
+    assert calls["calib"]["days"] == 30
+
+
+@pytest.mark.unit
+def test_calibration_maps_groups(monkeypatch):
+    group = {
+        "group": "hermes",
+        "sample_size": 4,
+        "hits": 3,
+        "misses": 1,
+        "hit_rate": 0.75,
+        "avg_brier_score": 0.18,
+        "avg_probability": 0.8,
+        "calibration_gap": 0.05,
+        "extra_dropped": "x",
+    }
+    client, _ = _make_client(
+        monkeypatch, calib={"group_by": "created_by", "groups": [group]}
+    )
+    r = client.get("/trading/api/invest/forecasts/calibration")
+    body = r.json()
+    assert body["count"] == 1
+    assert body["groups"][0]["group"] == "hermes"
+    assert body["groups"][0]["hit_rate"] == 0.75
+    assert "extra_dropped" not in body["groups"][0]
+
+
+@pytest.mark.unit
+def test_calibration_rejects_invalid_group_by(monkeypatch):
+    client, _ = _make_client(monkeypatch)
+    r = client.get("/trading/api/invest/forecasts/calibration?group_by=bogus")
+    assert r.status_code == 422
+
+
+@pytest.mark.unit
+def test_rejects_invalid_instrument_type(monkeypatch):
+    client, _ = _make_client(monkeypatch)
+    assert (
+        client.get(
+            "/trading/api/invest/forecasts/calibration?instrument_type=bogus"
+        ).status_code
+        == 422
+    )
+    assert (
+        client.get(
+            "/trading/api/invest/forecasts/open?instrument_type=bogus"
+        ).status_code
+        == 422
+    )
+
+
+@pytest.mark.unit
+def test_open_forwards_filters_and_maps(monkeypatch):
+    entry = {
+        "id": 7,
+        "forecast_id": "11111111-1111-1111-1111-111111111111",
+        "symbol": "005930",
+        "instrument_type": "equity_kr",
+        "probability": 0.6,
+        "review_date": "2026-07-10",
+        "status": "open",
+        "created_at": "2026-07-01T00:00:00+00:00",
+        "extra_dropped": "x",
+    }
+    client, calls = _make_client(
+        monkeypatch,
+        open_res={
+            "entries": [entry],
+            "summary": {"count": 1, "by_status": {"open": 1}},
+        },
+    )
+    r = client.get(
+        "/trading/api/invest/forecasts/open?symbol=005930&created_by=hermes&limit=10"
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["kind"] == "open"
+    assert body["count"] == 1
+    assert body["items"][0]["id"] == 7
+    assert "extra_dropped" not in body["items"][0]
+    assert calls["open"]["symbol"] == "005930"
+    assert calls["open"]["created_by"] == "hermes"
+    assert calls["open"]["limit"] == 10
+
+
+@pytest.mark.unit
+def test_closed_endpoint(monkeypatch):
+    entry = {
+        "id": 9,
+        "forecast_id": "22222222-2222-2222-2222-222222222222",
+        "symbol": "AAPL",
+        "instrument_type": "equity_us",
+        "probability": 0.7,
+        "review_date": "2026-06-20",
+        "status": "closed",
+        "outcome": True,
+        "brier_score": 0.09,
+        "resolved_at": "2026-06-21T00:00:00+00:00",
+        "created_at": "2026-06-10T00:00:00+00:00",
+    }
+    client, calls = _make_client(
+        monkeypatch,
+        closed_res={
+            "entries": [entry],
+            "summary": {"count": 1, "by_status": {"closed": 1}},
+        },
+    )
+    r = client.get("/trading/api/invest/forecasts/closed?instrument_type=equity_us")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["kind"] == "closed"
+    assert body["count"] == 1
+    assert body["items"][0]["outcome"] is True
+    assert body["items"][0]["brier_score"] == 0.09
+    assert calls["closed"]["instrument_type"] == "equity_us"

--- a/tests/test_forecast_web_read.py
+++ b/tests/test_forecast_web_read.py
@@ -1,0 +1,147 @@
+# tests/test_forecast_web_read.py
+"""ROB-663 — forecast web read helpers: due-queue ordering + recent scored history."""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+from decimal import Decimal
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import delete
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.review import TradeForecast
+from app.services.trade_journal import forecast_service as svc
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.usefixtures("investment_reports_cleanup_lock"),
+]
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def _cleanup(
+    db_session: AsyncSession, investment_reports_cleanup_lock: AsyncSession
+):
+    await db_session.execute(delete(TradeForecast))
+    await db_session.commit()
+
+
+def _target() -> dict:
+    return {"kind": "price_target", "direction": "at_or_above", "target_price": 130.0}
+
+
+async def _add(
+    db: AsyncSession,
+    *,
+    symbol: str,
+    instrument_type: str = "equity_kr",
+    created_by: str = "claude",
+    review_date: date,
+    status: str = "open",
+    probability: float = 0.6,
+    outcome: bool | None = None,
+    brier_score: float | None = None,
+    resolved_at: datetime | None = None,
+) -> TradeForecast:
+    row = TradeForecast(
+        created_by=created_by,
+        symbol=symbol,
+        instrument_type=instrument_type,
+        forecast_target=_target(),
+        probability=Decimal(str(probability)),
+        review_date=review_date,
+        status=status,
+        outcome=outcome,
+        brier_score=Decimal(str(brier_score)) if brier_score is not None else None,
+        resolved_at=resolved_at,
+    )
+    db.add(row)
+    await db.flush()
+    return row
+
+
+@pytest.mark.asyncio
+async def test_list_open_forecasts_orders_by_review_date_asc(db_session: AsyncSession):
+    await _add(db_session, symbol="000660", review_date=date(2026, 7, 20))
+    await _add(db_session, symbol="005930", review_date=date(2026, 7, 5))
+    await _add(db_session, symbol="035720", review_date=date(2026, 7, 12))
+    await db_session.commit()
+
+    result = await svc.list_open_forecasts(db_session)
+    symbols = [e["symbol"] for e in result["entries"]]
+    # soonest (and overdue) review dates first — the scoring-due queue
+    assert symbols == ["005930", "035720", "000660"]
+    assert result["summary"]["count"] == 3
+
+
+@pytest.mark.asyncio
+async def test_list_open_forecasts_excludes_closed_and_filters_symbol(
+    db_session: AsyncSession,
+):
+    await _add(db_session, symbol="005930", review_date=date(2026, 7, 5))
+    await _add(
+        db_session,
+        symbol="005930",
+        review_date=date(2026, 6, 1),
+        status="closed",
+        outcome=True,
+        brier_score=0.04,
+        resolved_at=datetime(2026, 6, 2, tzinfo=UTC),
+    )
+    await _add(db_session, symbol="000660", review_date=date(2026, 7, 6))
+    await db_session.commit()
+
+    result = await svc.list_open_forecasts(db_session, symbol="005930")
+    assert [e["symbol"] for e in result["entries"]] == ["005930"]
+    assert result["entries"][0]["status"] == "open"
+
+
+@pytest.mark.asyncio
+async def test_list_open_forecasts_normalizes_us_symbol(db_session: AsyncSession):
+    await _add(
+        db_session,
+        symbol="BRK.B",
+        instrument_type="equity_us",
+        review_date=date(2026, 7, 8),
+    )
+    await db_session.commit()
+
+    # query in Yahoo/dash form still matches the stored dot form
+    result = await svc.list_open_forecasts(db_session, symbol="BRK-B")
+    assert [e["symbol"] for e in result["entries"]] == ["BRK.B"]
+
+
+@pytest.mark.asyncio
+async def test_list_closed_forecasts_orders_by_resolved_at_desc(
+    db_session: AsyncSession,
+):
+    await _add(
+        db_session,
+        symbol="005930",
+        review_date=date(2026, 6, 1),
+        status="closed",
+        outcome=True,
+        brier_score=0.04,
+        resolved_at=datetime(2026, 6, 2, tzinfo=UTC),
+    )
+    await _add(
+        db_session,
+        symbol="000660",
+        review_date=date(2026, 6, 10),
+        status="closed",
+        outcome=False,
+        brier_score=0.81,
+        resolved_at=datetime(2026, 6, 15, tzinfo=UTC),
+    )
+    # an open row must never appear in the closed listing
+    await _add(db_session, symbol="035720", review_date=date(2026, 7, 1))
+    await db_session.commit()
+
+    result = await svc.list_closed_forecasts(db_session)
+    entries = result["entries"]
+    assert [e["symbol"] for e in entries] == ["000660", "005930"]
+    assert entries[0]["outcome"] is False
+    assert entries[0]["brier_score"] == 0.81
+    assert all(e["status"] == "closed" for e in entries)


### PR DESCRIPTION
## 배경

`review.trade_forecasts`(ROB-650)와 `get_forecast_calibration`(created_by/session_label/model_label/day별 Brier·hit_rate·calibration_gap)이 계산까지 해주는데 **웹 표면이 없었음**. "어떤 모델·세션의 판단을 얼마나 믿을 수 있나"는 resolvable forecast 시스템의 존재 이유 — 운영자가 MCP 세션을 열지 않고 봐야 할 지표. ROB-662(회고 browser, #1375) 패턴을 그대로 미러.

## 배치

프런트는 기존 **`/invest/insights`** 페이지(read-only 관찰 카드 surface)에 추가. 모델·세션 신뢰도는 workspace-level 인사이트라 per-portfolio `/my` 탭이나 신규 `/workspace`보다 `/insights` 성격에 부합.

## 변경 (read-only · 브로커/주문/watch mutation 없음 · migration 0)

**백엔드** (`forecast_service` 재사용)
- `app/routers/invest_forecasts.py` — `GET /trading/api/invest/forecasts`, `get_authenticated_user` 가드
  - `/calibration` — `group_by ∈ {created_by, session_label, model_label, day}` + created_by/symbol/instrument_type/days 필터
  - `/open` — **review_date ASC** (채점 due 대기열)
  - `/closed` — **resolved_at DESC** (최근 채점 이력, outcome/brier 포함)
- `app/schemas/invest_forecasts.py` — row=`extra=ignore`(serialize dict splat), envelope=`extra=forbid`
- `forecast_service.py` — `list_open_forecasts` / `list_closed_forecasts` 읽기 헬퍼 신규. 기존 `list_forecasts`는 `created_at DESC`라 "review_date 임박순"에 안 맞고, created_at-limited fetch를 재정렬하면 soonest-review 행이 drop되는 함정 → SQL 레벨 정렬로 해결
- `app/main.py` — 라우터 등록

**프런트** (`frontend/invest/src`)
- `types/forecasts.ts`, `api/forecasts.ts`(`credentials: include`), `components/insights/ForecastCalibrationPanel.tsx`(group_by 칩 + 캘리브레이션 테이블 + due 큐 + 최근 채점, 적중/빗나감 Pill tone, instrument_type→market 심볼 링크), `DesktopInsightsPage.tsx` 배선

## 안전 경계

채점(`forecast_resolve`)은 MCP 세션 전용 유지 — 웹은 읽기만. in-process LLM provider import 없음. migration 0.

## 테스트

- 백엔드: router 7 unit + service 4 integration(review_date/resolved_at 정렬, closed 제외, US 심볼 정규화) — 기존 forecast 테스트 포함 **36 pass**, full-app 라우트 3개 등록 확인, `make lint`(ruff/ty) green
- 프런트: 신규 2 파일(api + panel render) pass, `typecheck` green
- 프런트 full suite의 5 fail은 **pre-existing**(calendar/coverage: DaySection·MonthlyEventsTimeline·ActionReadiness·DesktopCalendarPage — 본 변경 stash 후에도 동일 재현, ROB-505 stale set)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new invest forecasts dashboard section showing calibration results, open forecasts, and recently closed forecasts.
  * Introduced new API endpoints for calibration and forecast lists, with support for filtering and date/count metadata.
  * Added client-side API helpers and matching UI types for the new forecast views.

* **Bug Fixes**
  * Improved forecast list ordering and symbol matching so filtered results are more accurate.
  * Added validation for unsupported grouping and instrument values, returning clear errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->