### PR TITLE
cleanup(ROB-667): invest read-router efficiency + next-actions completeness + 401 guard

### DIFF
--- a/app/mcp_server/tooling/analysis_artifact_registration.py
+++ b/app/mcp_server/tooling/analysis_artifact_registration.py
@@ -48,8 +48,7 @@ def register_analysis_artifact_tools(mcp: FastMCP) -> None:
         name="analysis_artifact_list",
         description=(
             "List persisted analysis artifacts, newest as_of first — "
-            "metadata only, no payload (payload_size_bytes hints the "
-            "analysis_artifact_get cost). Optional filters: market, kind, "
+            "metadata only, no payload. Optional filters: market, kind, "
             "symbol (containment match on the symbols array), since, "
             "correlation_id, account_scope, include_stale, limit clamped to "
             "1..100. Stale rows (valid_until in the past) are excluded unless "

--- a/app/schemas/analysis_artifact.py
+++ b/app/schemas/analysis_artifact.py
@@ -174,7 +174,6 @@ class AnalysisArtifactMeta(BaseModel):
     content_hash: str | None
     version: int
     readiness_label: AnalysisArtifactReadinessLiteral | None
-    payload_size_bytes: int
     is_stale: bool
     created_by: AnalysisArtifactCreatedByLiteral
     created_at: datetime
@@ -186,6 +185,7 @@ class AnalysisArtifactRead(AnalysisArtifactMeta):
     """Full artifact including the payload."""
 
     payload: dict[str, Any]
+    payload_size_bytes: int
 
 
 class AnalysisArtifactSaveResponse(BaseModel):

--- a/app/services/analysis_artifact.py
+++ b/app/services/analysis_artifact.py
@@ -10,6 +10,7 @@ from typing import Any
 import sqlalchemy as sa
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import defer
 
 from app.core.timezone import KST, now_kst
 from app.models.analysis_artifact import AnalysisArtifact
@@ -163,9 +164,13 @@ class AnalysisArtifactService:
     ) -> list[AnalysisArtifact]:
         """Query artifacts with filters, newest ``as_of`` first."""
         capped_limit = max(1, min(int(limit), 100))
-        stmt = sa.select(AnalysisArtifact).order_by(
-            AnalysisArtifact.as_of.desc(),
-            AnalysisArtifact.id.desc(),
+        stmt = (
+            sa.select(AnalysisArtifact)
+            .options(defer(AnalysisArtifact.payload))
+            .order_by(
+                AnalysisArtifact.as_of.desc(),
+                AnalysisArtifact.id.desc(),
+            )
         )
         if market is not None:
             stmt = stmt.where(AnalysisArtifact.market == market)
@@ -222,6 +227,7 @@ class AnalysisArtifactService:
         now = now_kst()
         stmt = (
             sa.select(AnalysisArtifact)
+            .options(defer(AnalysisArtifact.payload))
             .where(
                 AnalysisArtifact.symbols.op("&&")(
                     sa.text(":fresh_symbols").bindparams(

--- a/app/services/trade_journal/forecast_service.py
+++ b/app/services/trade_journal/forecast_service.py
@@ -19,6 +19,7 @@ from zoneinfo import ZoneInfo
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import defer
 
 from app.core.symbol import to_db_symbol
 from app.core.timezone import now_kst
@@ -713,6 +714,25 @@ def _group_key(r: TradeForecast, group_by: str) -> str:
     return value if value else "unlabeled"
 
 
+async def _fetch_calibration_rows(
+    db: AsyncSession, *, filters: list
+) -> list[TradeForecast]:
+    """Fetch closed+scored forecasts for calibration with the unused JSONB
+    payload columns deferred. Calibration needs ALL matching rows (no LIMIT);
+    it only reads brier_score/outcome/probability + the grouping attribute, so
+    forecast_target / evidence_ids / resolution_detail are pure load waste."""
+    result = await db.execute(
+        select(TradeForecast)
+        .where(*filters)
+        .options(
+            defer(TradeForecast.forecast_target),
+            defer(TradeForecast.evidence_ids),
+            defer(TradeForecast.resolution_detail),
+        )
+    )
+    return list(result.scalars().all())
+
+
 async def build_forecast_calibration_aggregate(
     db: AsyncSession,
     *,
@@ -748,7 +768,7 @@ async def build_forecast_calibration_aggregate(
     if days is not None:
         filters.append(TradeForecast.resolved_at >= now_kst() - timedelta(days=days))
 
-    rows = (await db.execute(select(TradeForecast).where(*filters))).scalars().all()
+    rows = await _fetch_calibration_rows(db, filters=filters)
 
     groups: dict[str, list[TradeForecast]] = {}
     for r in rows:

--- a/app/services/trade_journal/trade_retrospective_service.py
+++ b/app/services/trade_journal/trade_retrospective_service.py
@@ -13,7 +13,7 @@ from typing import Any
 from zoneinfo import ZoneInfo
 
 from pydantic import ValidationError
-from sqlalchemy import func, select
+from sqlalchemy import func, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.symbol import to_db_symbol
@@ -524,11 +524,38 @@ async def get_open_next_actions(
     means "not done" (open/in_progress/unset all surface); a set narrows to
     exact status values.
     """
-    filters = []
+    filters: list = []
     if market is not None:
         filters.append(TradeRetrospective.market == market)
     if symbol is not None:
         filters.append(TradeRetrospective.symbol == symbol.strip().upper())
+
+    # ROB-667: pre-select (in SQL) only retrospectives that have at least one
+    # actionable, non-done next_action, so the recency bound below caps the
+    # RELEVANT set instead of silently dropping open actions behind newer
+    # done-only rows. jsonb_typeof guard avoids errors on legacy non-array rows.
+    if statuses is None:
+        status_clause = "COALESCE(elem->>'status','') <> 'done'"
+        bind: dict = {}
+    else:
+        status_clause = "elem->>'status' = ANY(:na_statuses)"
+        bind = {"na_statuses": list(statuses)}
+
+    has_open_action = text(
+        f"""
+        jsonb_typeof(trade_retrospectives.next_actions) = 'array'
+        AND EXISTS (
+            SELECT 1
+            FROM jsonb_array_elements(trade_retrospectives.next_actions) AS elem
+            WHERE elem ? 'action'
+              AND {status_clause}
+        )
+        """
+    )
+    if bind:
+        has_open_action = has_open_action.bindparams(**bind)
+    filters.append(has_open_action)
+
     stmt = (
         select(TradeRetrospective)
         .where(*filters)

--- a/frontend/invest/src/__tests__/AnalysisArtifactPanel.test.tsx
+++ b/frontend/invest/src/__tests__/AnalysisArtifactPanel.test.tsx
@@ -34,7 +34,6 @@ const listBody = {
       content_hash: "abc123def456",
       version: 2,
       readiness_label: "ready_for_order_review",
-      payload_size_bytes: 128,
       is_stale: true,
       created_by: "claude",
       created_at: "2026-07-03T00:00:00+00:00",

--- a/frontend/invest/src/components/insights/AnalysisArtifactPanel.tsx
+++ b/frontend/invest/src/components/insights/AnalysisArtifactPanel.tsx
@@ -93,7 +93,6 @@ export function AnalysisArtifactPanel() {
                   <th style={th}>as_of</th>
                   <th style={th}>상태</th>
                   <th style={th}>ver</th>
-                  <th style={th}>payload</th>
                 </tr>
               </thead>
               <tbody>
@@ -142,7 +141,6 @@ export function AnalysisArtifactPanel() {
                       </span>
                     </td>
                     <td style={td}>v{a.version}</td>
-                    <td style={td}>{a.payload_size_bytes}B</td>
                   </tr>
                 ))}
               </tbody>

--- a/frontend/invest/src/types/analysisArtifacts.ts
+++ b/frontend/invest/src/types/analysisArtifacts.ts
@@ -33,13 +33,15 @@ export interface ArtifactMeta {
   content_hash: string | null;
   version: number;
   readiness_label: ArtifactReadiness | null;
-  payload_size_bytes: number;
   is_stale: boolean;
   created_by: ArtifactCreatedBy;
   created_at: string;
 }
 
 export interface ArtifactRead extends ArtifactMeta {
+  // Detail-only (ROB-667): the list response omits payload_size_bytes so the
+  // list query can defer the JSONB payload; only the detail endpoint carries it.
+  payload_size_bytes: number;
   payload: Record<string, unknown>;
 }
 

--- a/tests/routers/test_invest_retrospectives_router.py
+++ b/tests/routers/test_invest_retrospectives_router.py
@@ -185,4 +185,3 @@ def test_next_actions_requires_authentication():
     r = client.get("/trading/api/invest/retrospectives/next-actions")
     assert r.status_code == 401
     assert r.json()["detail"] == "로그인이 필요합니다."
-

--- a/tests/routers/test_invest_retrospectives_router.py
+++ b/tests/routers/test_invest_retrospectives_router.py
@@ -156,3 +156,33 @@ def test_next_actions_status_csv_narrows(monkeypatch):
     )
     assert r.status_code == 200
     assert calls["na"]["statuses"] == frozenset({"open", "in_progress"})
+
+
+def _make_unauth_client():
+    """Client with the real get_authenticated_user (no override) -> 401 path."""
+    from app.core.db import get_db
+    from app.routers import invest_retrospectives
+
+    app = FastAPI()
+    app.include_router(invest_retrospectives.router)
+    # Only stub get_db; leave get_authenticated_user real so the cookieless
+    # request resolves to HTTP 401 (state.user absent, no session cookie).
+    app.dependency_overrides[get_db] = lambda: "db"
+    return TestClient(app)
+
+
+@pytest.mark.unit
+def test_list_requires_authentication():
+    client = _make_unauth_client()
+    r = client.get("/trading/api/invest/retrospectives")
+    assert r.status_code == 401
+    assert r.json()["detail"] == "로그인이 필요합니다."
+
+
+@pytest.mark.unit
+def test_next_actions_requires_authentication():
+    client = _make_unauth_client()
+    r = client.get("/trading/api/invest/retrospectives/next-actions")
+    assert r.status_code == 401
+    assert r.json()["detail"] == "로그인이 필요합니다."
+

--- a/tests/services/test_analysis_artifact_service.py
+++ b/tests/services/test_analysis_artifact_service.py
@@ -59,6 +59,15 @@ async def test_save_list_get_round_trip(db_session: AsyncSession) -> None:
     )
     assert [row.id for row in listed] == [saved.id]
 
+    import sqlalchemy as sa
+
+    service._session.expunge_all()
+    listed = await service.list_artifacts(
+        market="kr", kind="candidate_pool", symbol=symbol, include_stale=True, limit=10
+    )
+    assert [row.id for row in listed] == [saved.id]
+    assert "payload" in sa.inspect(listed[0]).unloaded
+
     fetched = await service.get(saved.id)
     assert fetched is not None
     assert fetched.payload == {"ranked": [symbol, "005930"]}

--- a/tests/test_analysis_artifact_mcp.py
+++ b/tests/test_analysis_artifact_mcp.py
@@ -327,7 +327,7 @@ async def test_list_is_metadata_only(db_session: AsyncSession) -> None:
     assert response["count"] == 1
     row = response["artifacts"][0]
     assert "payload" not in row
-    assert "payload_size_bytes" not in row   # ROB-667: size hint is detail-only now
+    assert "payload_size_bytes" not in row  # ROB-667: size hint is detail-only now
     assert row["is_stale"] is False
 
 

--- a/tests/test_analysis_artifact_mcp.py
+++ b/tests/test_analysis_artifact_mcp.py
@@ -327,7 +327,7 @@ async def test_list_is_metadata_only(db_session: AsyncSession) -> None:
     assert response["count"] == 1
     row = response["artifacts"][0]
     assert "payload" not in row
-    assert row["payload_size_bytes"] > 0
+    assert "payload_size_bytes" not in row   # ROB-667: size hint is detail-only now
     assert row["is_stale"] is False
 
 

--- a/tests/test_forecast_service.py
+++ b/tests/test_forecast_service.py
@@ -375,6 +375,50 @@ async def test_resolve_price_target_unresolved_no_data(
 # calibration aggregate
 # --------------------------------------------------------------------------- #
 @pytest.mark.asyncio
+async def test_calibration_rows_defer_unused_jsonb(db_session: AsyncSession):
+    """ROB-667: the calibration fetch must not hydrate the 3 unused JSONB
+    columns (forecast_target / evidence_ids / resolution_detail)."""
+    import sqlalchemy as sa
+
+    async def _make(created_by: str, prob: float, outcome: bool) -> None:
+        _, row = await svc.save_forecast(
+            db_session,
+            created_by=created_by,
+            symbol="005930",
+            instrument_type="equity_kr",
+            forecast_target={"kind": "thesis_holds"},
+            probability=prob,
+            review_date="2026-07-15",
+        )
+        await db_session.commit()
+        await svc.resolve_forecast(
+            db_session,
+            forecast_id=str(row.forecast_id),
+            persist=True,
+            manual_outcome=outcome,
+            manual_evidence=["e"],
+        )
+        await db_session.commit()
+
+    await _make("sessionA", 0.7, True)
+
+    # Drop the identity map so the next query re-materializes with defer applied.
+    db_session.expunge_all()
+
+    filters = [
+        TradeForecast.status == "closed",
+        TradeForecast.brier_score.isnot(None),
+    ]
+    rows = await svc._fetch_calibration_rows(db_session, filters=filters)
+
+    assert rows, "expected at least one closed+scored forecast"
+    unloaded = sa.inspect(rows[0]).unloaded
+    assert "forecast_target" in unloaded
+    assert "evidence_ids" in unloaded
+    assert "resolution_detail" in unloaded
+
+
+@pytest.mark.asyncio
 async def test_calibration_aggregate_groups_by_created_by(db_session: AsyncSession):
     async def _make(created_by: str, prob: float, outcome: bool) -> None:
         _, row = await svc.save_forecast(

--- a/tests/test_trade_retrospective_web_read.py
+++ b/tests/test_trade_retrospective_web_read.py
@@ -39,6 +39,7 @@ async def _add(
     realized_pnl: Decimal | None = None,
     next_actions: list | None = None,
     correlation_id: str,
+    created_at: datetime | None = None,
 ) -> TradeRetrospective:
     row = TradeRetrospective(
         symbol=symbol,
@@ -51,7 +52,7 @@ async def _add(
         realized_pnl=realized_pnl,
         next_actions=next_actions,
         correlation_id=correlation_id,
-        created_at=datetime(2026, 7, 1, tzinfo=UTC),
+        created_at=created_at or datetime(2026, 7, 1, tzinfo=UTC),
     )
     db.add(row)
     await db.commit()
@@ -159,3 +160,35 @@ async def test_get_open_next_actions_scopes_by_symbol_and_status(
 
     res2 = await svc.get_open_next_actions(db_session, statuses=frozenset({"open"}))
     assert [i["action"] for i in res2["items"]] == ["B"]
+
+
+@pytest.mark.asyncio
+async def test_open_next_action_survives_recency_bound(db_session: AsyncSession):
+    """ROB-667: an open next_action on an OLD retrospective must still surface
+    even when >200 newer done-only retrospectives exist (completeness)."""
+    # Oldest row: has an OPEN action; must survive.
+    await _add(
+        db_session,
+        symbol="005930",
+        market="kr",
+        next_actions=[{"action": "재진입 검토", "status": "open"}],
+        correlation_id="old_open",
+        created_at=datetime(2026, 7, 1, tzinfo=UTC),
+    )
+    # 220 newer rows, all done-only (noise that would evict the old open one
+    # under a plain recency bound).
+    for i in range(220):
+        await _add(
+            db_session,
+            symbol="000660",
+            market="kr",
+            next_actions=[{"action": f"noise {i}", "status": "done"}],
+            correlation_id=f"noise_{i}",
+            created_at=datetime(2026, 7, 2, tzinfo=UTC),
+        )
+    await db_session.commit()
+
+    result = await svc.get_open_next_actions(db_session, market="kr")
+
+    actions = [it["action"] for it in result["items"]]
+    assert "재진입 검토" in actions


### PR DESCRIPTION
Closes ROB-667. Four non-blocking minors from the ROB-662~666 batch adversarial review, one migration-0 cleanup.

## Changes
1. **Forecast calibration (ROB-663 finding)** — `defer()` the 3 unused JSONB columns (`forecast_target`/`evidence_ids`/`resolution_detail`) in the all-rows calibration scan. Behavior-identical (existing aggregate test + new unloaded-column assertion). No LIMIT — calibration needs all closed rows.
2. **Artifact list payload (ROB-664 finding)** — `defer(payload)` in `list_artifacts` and move `payload_size_bytes` from the list schema (`AnalysisArtifactMeta`) to detail (`AnalysisArtifactRead`). The `@property` (`json.dumps(payload)`) forced a full JSONB load per row despite the body omitting payload. Frontend: the artifacts panel list column consumed this field, so its size column + the `ArtifactMeta` field are removed (moved to detail-only in the TS mirror); MCP tool description + tests updated.
3. **next-actions completeness (ROB-662 finding)** — SQL `jsonb_array_elements` EXISTS pre-filter (guarded by `jsonb_typeof='array'`) so the 200-row recency bound caps only retrospectives that actually have an open action, instead of dropping an old open action behind newer done-only rows. null-status-open inclusion preserved; Python `_incomplete` loop retained as the authoritative per-item filter.
4. **401 regression guard (ROB-662 finding)** — two unauth tests on the retrospectives endpoints (the read-router suite previously never exercised the unauthenticated path).

## Verification
- Backend: 68 touched tests pass. Adversarial multi-agent review: forecast/next-actions/401 SOUND; the artifact-frontend consumer (missed by the original plan) is fixed here.
- Frontend: `typecheck` clean, `AnalysisArtifactPanel` vitest green. (Pre-existing ROB-505 calendar/coverage vitest failures are unrelated and not run in CI.)

## Safety
Read-path + tests + one MCP description string + frontend list column. No broker/order/watch mutation. **Migration 0.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Artifact lists now show a cleaner set of metadata, with payload size moved to the detailed view.
  * Open next actions now continue to surface older unresolved items even when newer completed items exist.

* **Bug Fixes**
  * Improved handling of legacy retrospective data so open next actions can be found more reliably.
  * Auth checks for invest retrospectives endpoints are now enforced as expected.

* **Refactor**
  * Reduced unnecessary data loading for artifact and forecast-related queries, improving responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->