### PR TITLE
feat(ROB-672): expose /invest/insights in header nav + mobile home card

### DIFF
--- a/frontend/invest/src/__tests__/DesktopHeader.test.tsx
+++ b/frontend/invest/src/__tests__/DesktopHeader.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from "@testing-library/react";
+import { createMemoryRouter, RouterProvider } from "react-router-dom";
+import { describe, expect, it } from "vitest";
+import { DesktopHeader } from "../desktop/DesktopHeader";
+
+function renderAt(path: string) {
+  const router = createMemoryRouter(
+    [{ path: "*", element: <DesktopHeader /> }],
+    { initialEntries: [`/invest${path}`], basename: "/invest" },
+  );
+  return render(<RouterProvider router={router} />);
+}
+
+describe("DesktopHeader", () => {
+  it("exposes an 인사이트 nav link to /invest/insights", () => {
+    renderAt("/");
+    expect(screen.getByRole("link", { name: /인사이트/ })).toHaveAttribute(
+      "href",
+      "/invest/insights",
+    );
+  });
+
+  it("places 인사이트 between 커버리지 and 골라보기 in the nav order", () => {
+    renderAt("/");
+    const labels = screen.getAllByRole("link").map((el) => el.textContent ?? "");
+    const coverage = labels.findIndex((t) => t.includes("커버리지"));
+    const insights = labels.findIndex((t) => t.includes("인사이트"));
+    const screener = labels.findIndex((t) => t.includes("골라보기"));
+    expect(coverage).toBeGreaterThanOrEqual(0);
+    expect(insights).toBe(coverage + 1);
+    expect(screener).toBe(insights + 1);
+  });
+});

--- a/frontend/invest/src/desktop/DesktopHeader.tsx
+++ b/frontend/invest/src/desktop/DesktopHeader.tsx
@@ -10,6 +10,7 @@ const LINKS: { to: string; label: string; end?: boolean }[] = [
   { to: "/calendar", label: "캘린더" },
   { to: "/market", label: "시장" },
   { to: "/coverage", label: "커버리지" },
+  { to: "/insights", label: "인사이트" },
   { to: "/screener", label: "골라보기" },
   { to: "/scalping", label: "스캘핑 일지" },
 ];

--- a/frontend/invest/src/pages/mobile/MobileHomePage.tsx
+++ b/frontend/invest/src/pages/mobile/MobileHomePage.tsx
@@ -44,6 +44,12 @@ const NAV_CARDS: MobileNavCard[] = [
     icon: <Icon name="flash" size={18} />,
   },
   {
+    to: "/insights",
+    label: "인사이트",
+    desc: "괴리·패리티 read-only 관찰",
+    icon: <Icon name="chart" size={18} />,
+  },
+  {
     to: "/my?tab=signals",
     label: "시그널",
     desc: "AI 분석 신호",


### PR DESCRIPTION
## [insights A] Discoverability — ROB-672

`/invest/insights` was reachable only via the 시장 page action button and the **desktop** home card — never from the top **header nav** or the **mobile** home. This surfaces it in both permanent-nav slots.

### Changes (frontend-only, migration 0, read-only)
- `DesktopHeader.tsx` — add `{ to: "/insights", label: "인사이트" }` to `LINKS`, after 커버리지.
- `MobileHomePage.tsx` — add an 인사이트 `NAV_CARDS` card (icon `chart`, mirrors the desktop home card). `MobileBottomNav` is intentionally left at 5 tabs.
- New `DesktopHeader.test.tsx` — asserts the link href `/invest/insights` and its nav order (between 커버리지 and 골라보기).

### Verification
- `npx vitest run src/__tests__/DesktopHeader.test.tsx` → 2/2 pass
- `npm run typecheck` → clean (validates the mobile `NAV_CARDS` entry shape)
- Full suite: 510 pass / 5 fail — the 5 failures are **pre-existing** calendar/coverage tests (`DaySection`, `MonthlyEventsTimeline`, `ActionReadiness`, `DesktopCalendarPage`), unrelated to this change.

### Stack
Part **1/7** of the `/invest/insights` polish stack (ROB-672→678). Base: `main`.

Out of scope (separate-issue candidate): mobile deep-linkers to `/insights` currently get the desktop shell — the route is not viewport-dispatched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an “인사이트” navigation link to the desktop header, placing it in the main nav alongside existing items.
  * Added an “인사이트” shortcut card on the mobile home page for quicker access.

* **Tests**
  * Added automated coverage to verify the new desktop navigation link and its position in the header order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->