### PR TITLE
feat(ROB-673): render already-fetched forecast/artifact/session fields

### DIFF
--- a/frontend/invest/src/__tests__/AnalysisArtifactPanel.test.tsx
+++ b/frontend/invest/src/__tests__/AnalysisArtifactPanel.test.tsx
@@ -62,5 +62,9 @@ describe("AnalysisArtifactPanel", () => {
     expect(screen.getByTestId("analysis-artifact-panel")).toBeTruthy();
     expect(screen.getByText(/stale/i)).toBeTruthy();
     expect(screen.getByText(/v2/)).toBeTruthy();
+
+    // ROB-673: 종목 column links each symbol to its stock detail page
+    const symLink = screen.getByRole("link", { name: "005930" });
+    expect(symLink).toHaveAttribute("href", "/stocks/kr/005930");
   });
 });

--- a/frontend/invest/src/__tests__/ForecastCalibrationPanel.test.tsx
+++ b/frontend/invest/src/__tests__/ForecastCalibrationPanel.test.tsx
@@ -19,7 +19,9 @@ const open: ForecastListResponse = {
   items: [{
     id: 1, forecast_id: "f1", correlation_id: null, created_by: "claude",
     session_label: null, model_label: null, symbol: "005930",
-    instrument_type: "equity_kr", forecast_target: null, horizon: null,
+    instrument_type: "equity_kr",
+    forecast_target: { kind: "price_target", direction: "at_or_above", target_price: 80000 },
+    horizon: "D+5",
     probability: 0.6, probability_range_low: null, probability_range_high: null,
     resolution_source: null, review_date: "2026-07-10", status: "open",
     outcome: null, observed_value: null, resolved_at: null, brier_score: null,
@@ -32,10 +34,12 @@ const closed: ForecastListResponse = {
   items: [{
     id: 2, forecast_id: "f2", correlation_id: null, created_by: "claude",
     session_label: null, model_label: null, symbol: "AAPL",
-    instrument_type: "equity_us", forecast_target: null, horizon: null,
+    instrument_type: "equity_us",
+    forecast_target: { kind: "price_target", direction: "at_or_below", target_price: 180 },
+    horizon: null,
     probability: 0.7, probability_range_low: null, probability_range_high: null,
     resolution_source: null, review_date: "2026-06-20", status: "closed",
-    outcome: true, observed_value: null, resolved_at: "2026-06-21T00:00:00Z",
+    outcome: true, observed_value: 175.5, resolved_at: "2026-06-21T00:00:00Z",
     brier_score: 0.09, created_at: "2026-06-10T00:00:00Z",
   }],
 };
@@ -63,4 +67,11 @@ test("renders calibration table, due queue and recent scored results", async () 
   // recent scored result: outcome badge + symbol
   expect(screen.getByText("적중")).toBeInTheDocument();
   expect(screen.getByText("AAPL")).toBeInTheDocument();
+
+  // ROB-673: open forecast surfaces its target + horizon
+  expect(screen.getByText(/목표 ≥ ₩80,000/)).toBeInTheDocument();
+  expect(screen.getByText(/D\+5/)).toBeInTheDocument();
+  // ROB-673: closed forecast surfaces target + realized observed value
+  expect(screen.getByText(/목표 ≤ \$180\.00/)).toBeInTheDocument();
+  expect(screen.getByText(/실현 \$175\.50/)).toBeInTheDocument();
 });

--- a/frontend/invest/src/__tests__/SessionContextTimelinePanel.test.tsx
+++ b/frontend/invest/src/__tests__/SessionContextTimelinePanel.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { SessionContextTimelinePanel } from "../components/insights/SessionContextTimelinePanel";
 
@@ -23,7 +24,7 @@ const body = {
       entry_type: "handoff_note",
       title: "다음 세션 인계",
       body: "삼성전자 매수 래더 절반 남음",
-      refs: {},
+      refs: { symbols: ["005930"], order_id: "ORD-1", report_uuid: "rep-abcdef1234" },
       created_by: "claude",
       session_label: null,
       created_at: "2026-07-03T09:00:00+00:00",
@@ -42,10 +43,19 @@ describe("SessionContextTimelinePanel", () => {
       })) as unknown as typeof fetch,
     );
 
-    render(<SessionContextTimelinePanel />);
+    render(
+      <MemoryRouter>
+        <SessionContextTimelinePanel />
+      </MemoryRouter>,
+    );
 
     await waitFor(() => screen.getByText("다음 세션 인계"));
     expect(screen.getByTestId("session-context-timeline-panel")).toBeTruthy();
     expect(screen.getByText("handoff_note")).toBeTruthy();
+
+    // ROB-673: refs crosslinks — symbol links to stock detail, provenance surfaced
+    const symLink = screen.getByRole("link", { name: "005930" });
+    expect(symLink).toHaveAttribute("href", "/stocks/kr/005930");
+    expect(screen.getByText(/주문 ORD-1/)).toBeInTheDocument();
   });
 });

--- a/frontend/invest/src/components/insights/AnalysisArtifactPanel.tsx
+++ b/frontend/invest/src/components/insights/AnalysisArtifactPanel.tsx
@@ -1,7 +1,9 @@
 import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
 
 import { fetchArtifactDetail, fetchArtifacts } from "../../api/analysisArtifacts";
 import { Card, Pill } from "../../ds";
+import { stockDetailPath } from "../../stockDetailPath";
 import type { ArtifactMeta, ArtifactRead } from "../../types/analysisArtifacts";
 
 type LoadState<T> =
@@ -89,6 +91,7 @@ export function AnalysisArtifactPanel() {
                 <tr>
                   <th style={th}>종류</th>
                   <th style={th}>제목</th>
+                  <th style={th}>종목</th>
                   <th style={th}>시장</th>
                   <th style={th}>as_of</th>
                   <th style={th}>상태</th>
@@ -119,6 +122,24 @@ export function AnalysisArtifactPanel() {
                       >
                         {a.title}
                       </button>
+                    </td>
+                    <td style={td}>
+                      {a.symbols.length > 0 ? (
+                        <span style={{ display: "inline-flex", gap: 6, flexWrap: "wrap" }}>
+                          {a.symbols.map((sym) => {
+                            const href = stockDetailPath(a.market, sym);
+                            return href ? (
+                              <Link key={sym} to={href} style={{ color: "var(--link, #4a9)", textDecoration: "none" }}>
+                                {sym}
+                              </Link>
+                            ) : (
+                              <span key={sym}>{sym}</span>
+                            );
+                          })}
+                        </span>
+                      ) : (
+                        <span style={{ color: "var(--fg-3)" }}>—</span>
+                      )}
                     </td>
                     <td style={td}>{a.market}</td>
                     <td style={td}>{fmt(a.as_of)}</td>

--- a/frontend/invest/src/components/insights/ForecastCalibrationPanel.tsx
+++ b/frontend/invest/src/components/insights/ForecastCalibrationPanel.tsx
@@ -8,6 +8,7 @@ import {
 } from "../../api/forecasts";
 import { Card, Pill } from "../../ds";
 import { stockDetailPath } from "../../stockDetailPath";
+import { formatWatchMoney } from "../my/watchPresentation";
 import type {
   CalibrationGroupRow,
   ForecastGroupBy,
@@ -41,6 +42,31 @@ function SymbolCell({ row }: { row: ForecastRow }) {
   ) : (
     <>{row.symbol}</>
   );
+}
+
+const DIRECTION_GLYPH: Record<string, string> = {
+  at_or_above: "≥",
+  at_or_below: "≤",
+};
+
+// forecast_target arrives as an untyped dict (Record<string, unknown>). Narrow
+// it and render "≥ ₩80,000"-style text for price_target kinds; fall back to the
+// raw kind label for other kinds, or null when absent.
+function formatForecastTarget(row: ForecastRow): string | null {
+  const t = row.forecast_target;
+  if (!t || typeof t !== "object") return null;
+  const kind = typeof t.kind === "string" ? t.kind : null;
+  if (!kind) return null;
+  if (kind === "price_target") {
+    const direction = typeof t.direction === "string" ? t.direction : null;
+    const price = typeof t.target_price === "number" ? t.target_price : null;
+    const market = row.instrument_type ? INSTRUMENT_MARKET[row.instrument_type] : undefined;
+    const glyph = direction ? DIRECTION_GLYPH[direction] ?? "" : "";
+    const priceText = price != null ? formatWatchMoney(price, market ?? "") : "";
+    const text = `${glyph}${glyph && priceText ? " " : ""}${priceText}`.trim();
+    return text || kind;
+  }
+  return kind;
 }
 
 function pct(x: number | null): string {
@@ -132,17 +158,22 @@ function OpenList({ rows }: { rows: ForecastRow[] }) {
   }
   return (
     <div style={{ display: "grid", gap: 6 }}>
-      {rows.map((r) => (
-        <div
-          key={r.id}
-          style={{ display: "flex", alignItems: "center", gap: 8, fontSize: 13, padding: "2px 0" }}
-        >
-          <span style={{ color: "var(--fg-3)", fontSize: 11, minWidth: 84 }}>{r.review_date ?? "—"}</span>
-          <span style={{ fontWeight: 700 }}><SymbolCell row={r} /></span>
-          <Pill tone="paper" size="sm">확신 {pct(r.probability)}</Pill>
-          {r.created_by && <span style={{ color: "var(--fg-3)", fontSize: 11 }}>· {r.created_by}</span>}
-        </div>
-      ))}
+      {rows.map((r) => {
+        const target = formatForecastTarget(r);
+        return (
+          <div
+            key={r.id}
+            style={{ display: "flex", alignItems: "center", gap: 8, fontSize: 13, padding: "2px 0", flexWrap: "wrap" }}
+          >
+            <span style={{ color: "var(--fg-3)", fontSize: 11, minWidth: 84 }}>{r.review_date ?? "—"}</span>
+            <span style={{ fontWeight: 700 }}><SymbolCell row={r} /></span>
+            <Pill tone="paper" size="sm">확신 {pct(r.probability)}</Pill>
+            {target && <span style={{ color: "var(--fg-3)", fontSize: 11 }}>· 목표 {target}</span>}
+            {r.horizon && <span style={{ color: "var(--fg-3)", fontSize: 11 }}>· {r.horizon}</span>}
+            {r.created_by && <span style={{ color: "var(--fg-3)", fontSize: 11 }}>· {r.created_by}</span>}
+          </div>
+        );
+      })}
     </div>
   );
 }
@@ -157,20 +188,28 @@ function ClosedList({ rows }: { rows: ForecastRow[] }) {
   }
   return (
     <div style={{ display: "grid", gap: 6 }}>
-      {rows.map((r) => (
-        <div
-          key={r.id}
-          style={{ display: "flex", alignItems: "center", gap: 8, fontSize: 13, padding: "2px 0" }}
-        >
-          <Pill tone={r.outcome ? "gain" : "loss"} size="sm">{r.outcome ? "적중" : "빗나감"}</Pill>
-          <span style={{ fontWeight: 700 }}><SymbolCell row={r} /></span>
-          <span style={{ color: "var(--fg-3)", fontSize: 11 }}>확신 {pct(r.probability)}</span>
-          <span style={{ color: "var(--fg-3)", fontSize: 11 }}>· Brier {num(r.brier_score)}</span>
-          {r.resolved_at && (
-            <span style={{ color: "var(--fg-3)", fontSize: 11 }}>· {r.resolved_at.slice(0, 10)}</span>
-          )}
-        </div>
-      ))}
+      {rows.map((r) => {
+        const target = formatForecastTarget(r);
+        const market = r.instrument_type ? INSTRUMENT_MARKET[r.instrument_type] : undefined;
+        return (
+          <div
+            key={r.id}
+            style={{ display: "flex", alignItems: "center", gap: 8, fontSize: 13, padding: "2px 0", flexWrap: "wrap" }}
+          >
+            <Pill tone={r.outcome ? "gain" : "loss"} size="sm">{r.outcome ? "적중" : "빗나감"}</Pill>
+            <span style={{ fontWeight: 700 }}><SymbolCell row={r} /></span>
+            <span style={{ color: "var(--fg-3)", fontSize: 11 }}>확신 {pct(r.probability)}</span>
+            {target && <span style={{ color: "var(--fg-3)", fontSize: 11 }}>· 목표 {target}</span>}
+            {r.observed_value != null && (
+              <span style={{ color: "var(--fg-3)", fontSize: 11 }}>· 실현 {formatWatchMoney(r.observed_value, market ?? "")}</span>
+            )}
+            <span style={{ color: "var(--fg-3)", fontSize: 11 }}>· Brier {num(r.brier_score)}</span>
+            {r.resolved_at && (
+              <span style={{ color: "var(--fg-3)", fontSize: 11 }}>· {r.resolved_at.slice(0, 10)}</span>
+            )}
+          </div>
+        );
+      })}
     </div>
   );
 }

--- a/frontend/invest/src/components/insights/SessionContextTimelinePanel.tsx
+++ b/frontend/invest/src/components/insights/SessionContextTimelinePanel.tsx
@@ -1,7 +1,9 @@
 import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
 
 import { fetchRecentSessionContext } from "../../api/sessionContext";
 import { Card, Pill } from "../../ds";
+import { stockDetailPath } from "../../stockDetailPath";
 import type { SessionContextEntry } from "../../types/sessionContext";
 
 type LoadState<T> =
@@ -62,38 +64,81 @@ export function SessionContextTimelinePanel() {
         )}
         {state.status === "ready" && state.data.length > 0 && (
           <ul style={{ listStyle: "none", margin: 0, padding: 0 }}>
-            {state.data.map((e) => (
-              <li
-                key={e.entry_uuid}
-                style={{
-                  padding: "10px 0",
-                  borderBottom: "1px solid var(--divider, #8882)",
-                }}
-              >
-                <div style={{ display: "flex", gap: 6, alignItems: "center", flexWrap: "wrap" }}>
-                  <Pill tone="paper" size="sm">
-                    {e.entry_type}
-                  </Pill>
-                  <Pill tone="paper" size="sm">
-                    {e.market}
-                  </Pill>
-                  {e.account_scope && (
-                    <Pill tone="paper" size="sm">
-                      {e.account_scope}
-                    </Pill>
-                  )}
-                  <span style={{ opacity: 0.6, fontSize: 12 }}>
-                    {e.kst_date} · {fmt(e.created_at)}
-                  </span>
-                </div>
-                <div style={{ fontWeight: 700, marginTop: 4 }}>{e.title}</div>
-                <div
-                  style={{ fontSize: 13, opacity: 0.85, whiteSpace: "pre-wrap" }}
+            {state.data.map((e) => {
+              const refs = e.refs as {
+                symbols?: unknown;
+                order_id?: unknown;
+                report_uuid?: unknown;
+              };
+              const refSymbols = Array.isArray(refs.symbols)
+                ? refs.symbols.filter((s): s is string => typeof s === "string")
+                : [];
+              const orderId = typeof refs.order_id === "string" ? refs.order_id : null;
+              const reportUuid = typeof refs.report_uuid === "string" ? refs.report_uuid : null;
+              const hasRefs = refSymbols.length > 0 || orderId != null || reportUuid != null;
+              return (
+                <li
+                  key={e.entry_uuid}
+                  style={{
+                    padding: "10px 0",
+                    borderBottom: "1px solid var(--divider, #8882)",
+                  }}
                 >
-                  {e.body}
-                </div>
-              </li>
-            ))}
+                  <div style={{ display: "flex", gap: 6, alignItems: "center", flexWrap: "wrap" }}>
+                    <Pill tone="paper" size="sm">
+                      {e.entry_type}
+                    </Pill>
+                    <Pill tone="paper" size="sm">
+                      {e.market}
+                    </Pill>
+                    {e.account_scope && (
+                      <Pill tone="paper" size="sm">
+                        {e.account_scope}
+                      </Pill>
+                    )}
+                    <span style={{ opacity: 0.6, fontSize: 12 }}>
+                      {e.kst_date} · {fmt(e.created_at)}
+                    </span>
+                  </div>
+                  <div style={{ fontWeight: 700, marginTop: 4 }}>{e.title}</div>
+                  <div
+                    style={{ fontSize: 13, opacity: 0.85, whiteSpace: "pre-wrap" }}
+                  >
+                    {e.body}
+                  </div>
+                  {hasRefs && (
+                    <div
+                      style={{
+                        display: "flex",
+                        gap: 8,
+                        flexWrap: "wrap",
+                        marginTop: 6,
+                        fontSize: 11,
+                        color: "var(--fg-3)",
+                        alignItems: "center",
+                      }}
+                    >
+                      {refSymbols.map((sym) => {
+                        const href = stockDetailPath(e.market, sym);
+                        return href ? (
+                          <Link
+                            key={sym}
+                            to={href}
+                            style={{ color: "var(--link, #4a9)", textDecoration: "none", fontWeight: 700 }}
+                          >
+                            {sym}
+                          </Link>
+                        ) : (
+                          <span key={sym} style={{ fontWeight: 700 }}>{sym}</span>
+                        );
+                      })}
+                      {orderId && <span>주문 {orderId}</span>}
+                      {reportUuid && <span>리포트 {reportUuid.slice(0, 8)}</span>}
+                    </div>
+                  )}
+                </li>
+              );
+            })}
           </ul>
         )}
       </section>


### PR DESCRIPTION
## [insights B] Render already-fetched-but-dropped fields — ROB-673

The three `/invest/insights` data panels drop fields the backend **already ships to the browser** (verified end-to-end: serializer → pydantic → TS type → API client). This renders them. Pure frontend, migration 0, read-only — no backend/schema/API-client change.

### Changes
- **Forecast** open/closed lists (`ForecastCalibrationPanel`): new `formatForecastTarget` helper renders `forecast_target` as `≥ ₩80,000` / `≤ $180.00` (direction glyph + `target_price` via `formatWatchMoney`, currency from `instrument_type`; falls back to raw `kind`). Open rows add **목표 + horizon**; closed rows add **목표 + 실현 `observed_value`** (the "how wrong were we" signal).
- **Analysis artifact** table (`AnalysisArtifactPanel`): new **종목** column linking each `symbols[]` entry to `/stocks/{market}/{symbol}`.
- **Session timeline** (`SessionContextTimelinePanel`): surfaces `refs` — `symbols` as stock-detail links, `order_id`/`report_uuid` as provenance.

### Verification
- `npx vitest run` on the 3 panel tests → **3/3 pass** (assert the new target/horizon/observed text, the 종목 link href, and the refs crosslink + provenance).
- **Landmine fixed:** `SessionContextTimelinePanel.test` rendered *without* a Router; wrapped in `MemoryRouter` now that the panel renders `<Link>`.
- `npm run typecheck` → clean.

### Stack
Part **2/7** of the `/invest/insights` polish stack. **Base: `rob-672` (#1382)** — merge after ROB-672.

🤖 Generated with [Claude Code](https://claude.com/claude-code)