### PR TITLE
feat(ROB-674): wire forecast days + artifact market/kind/readiness filters

### DIFF
--- a/frontend/invest/src/__tests__/AnalysisArtifactPanel.test.tsx
+++ b/frontend/invest/src/__tests__/AnalysisArtifactPanel.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { AnalysisArtifactPanel } from "../components/insights/AnalysisArtifactPanel";
@@ -66,5 +66,34 @@ describe("AnalysisArtifactPanel", () => {
     // ROB-673: 종목 column links each symbol to its stock detail page
     const symLink = screen.getByRole("link", { name: "005930" });
     expect(symLink).toHaveAttribute("href", "/stocks/kr/005930");
+  });
+
+  it("refetches with the corresponding query param when a filter changes (ROB-674)", async () => {
+    const calls: string[] = [];
+    const fetchMock = vi.fn(async (url: string) => {
+      const u = String(url);
+      calls.push(u);
+      const body = u.includes("/artifacts/") && !u.endsWith("/3")
+        ? listBody
+        : { success: true, artifact: { ...listBody.artifacts[0], payload: { k: "v" } } };
+      return { ok: true, status: 200, json: async () => body };
+    });
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+    render(
+      <MemoryRouter>
+        <AnalysisArtifactPanel />
+      </MemoryRouter>,
+    );
+    await waitFor(() => screen.getByText("KR 스크리닝"));
+
+    fireEvent.change(screen.getByLabelText("시장 필터"), { target: { value: "us" } });
+    await waitFor(() => expect(calls.some((u) => u.includes("market=us"))).toBe(true));
+
+    fireEvent.change(screen.getByLabelText("종류 필터"), { target: { value: "briefing" } });
+    await waitFor(() => expect(calls.some((u) => u.includes("kind=briefing"))).toBe(true));
+
+    fireEvent.change(screen.getByLabelText("준비상태 필터"), { target: { value: "blocked" } });
+    await waitFor(() => expect(calls.some((u) => u.includes("readiness_label=blocked"))).toBe(true));
   });
 });

--- a/frontend/invest/src/__tests__/ForecastCalibrationPanel.test.tsx
+++ b/frontend/invest/src/__tests__/ForecastCalibrationPanel.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { afterEach, expect, test, vi } from "vitest";
 import { ForecastCalibrationPanel } from "../components/insights/ForecastCalibrationPanel";
@@ -74,4 +74,37 @@ test("renders calibration table, due queue and recent scored results", async () 
   // ROB-673: closed forecast surfaces target + realized observed value
   expect(screen.getByText(/목표 ≤ \$180\.00/)).toBeInTheDocument();
   expect(screen.getByText(/실현 \$175\.50/)).toBeInTheDocument();
+});
+
+test("days control refetches calibration with the selected window (ROB-674)", async () => {
+  const calls: string[] = [];
+  const fetchMock = vi.fn((url: string) => {
+    const u = String(url);
+    calls.push(u);
+    const body = u.includes("/calibration") ? calib : u.includes("/open") ? open : closed;
+    return Promise.resolve({ ok: true, json: async () => body });
+  });
+  vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+  render(
+    <MemoryRouter>
+      <ForecastCalibrationPanel />
+    </MemoryRouter>,
+  );
+  await waitFor(() => expect(screen.getByText("hermes")).toBeInTheDocument());
+
+  // default window is 90일
+  expect(calls.some((u) => u.includes("/calibration") && u.includes("days=90"))).toBe(true);
+
+  // 30일 → refetch with days=30
+  fireEvent.click(screen.getByRole("button", { name: "30일" }));
+  await waitFor(() =>
+    expect(calls.some((u) => u.includes("/calibration") && u.includes("days=30"))).toBe(true),
+  );
+
+  // 전체 → omit days param entirely
+  fireEvent.click(screen.getByRole("button", { name: "전체" }));
+  await waitFor(() =>
+    expect(calls.some((u) => u.includes("/calibration") && !u.includes("days="))).toBe(true),
+  );
 });

--- a/frontend/invest/src/components/insights/AnalysisArtifactPanel.tsx
+++ b/frontend/invest/src/components/insights/AnalysisArtifactPanel.tsx
@@ -4,7 +4,12 @@ import { Link } from "react-router-dom";
 import { fetchArtifactDetail, fetchArtifacts } from "../../api/analysisArtifacts";
 import { Card, Pill } from "../../ds";
 import { stockDetailPath } from "../../stockDetailPath";
-import type { ArtifactMeta, ArtifactRead } from "../../types/analysisArtifacts";
+import type {
+  ArtifactKind,
+  ArtifactMeta,
+  ArtifactRead,
+  ArtifactReadiness,
+} from "../../types/analysisArtifacts";
 
 type LoadState<T> =
   | { status: "loading" }
@@ -20,6 +25,39 @@ const th: React.CSSProperties = {
 };
 const td: React.CSSProperties = { padding: "6px 8px", fontSize: 13 };
 
+const selectStyle: React.CSSProperties = {
+  border: "1px solid var(--border)",
+  borderRadius: 8,
+  padding: "4px 8px",
+  fontSize: 12,
+  background: "var(--surface-2)",
+  color: "var(--fg-1)",
+  fontFamily: "inherit",
+};
+
+const MARKET_OPTIONS: { key: "kr" | "us" | "crypto"; label: string }[] = [
+  { key: "kr", label: "국내" },
+  { key: "us", label: "미국" },
+  { key: "crypto", label: "코인" },
+];
+
+const KIND_OPTIONS: { key: ArtifactKind; label: string }[] = [
+  { key: "screening_ranking", label: "스크리닝 랭킹" },
+  { key: "profit_taking_verdicts", label: "익절 판정" },
+  { key: "support_resistance_map", label: "지지/저항" },
+  { key: "flow_assessment", label: "수급 평가" },
+  { key: "candidate_pool", label: "후보 풀" },
+  { key: "session_summary", label: "세션 요약" },
+  { key: "briefing", label: "브리핑" },
+];
+
+const READINESS_OPTIONS: { key: ArtifactReadiness; label: string }[] = [
+  { key: "screen_grade", label: "스크리닝 등급" },
+  { key: "not_decision_ready", label: "미결정" },
+  { key: "ready_for_order_review", label: "주문검토 가능" },
+  { key: "blocked", label: "차단" },
+];
+
 function fmt(ts: string): string {
   return ts.replace("T", " ").slice(0, 16);
 }
@@ -30,10 +68,20 @@ export function AnalysisArtifactPanel() {
   });
   const [detail, setDetail] = useState<ArtifactRead | null>(null);
   const [detailError, setDetailError] = useState<string | null>(null);
+  const [market, setMarket] = useState<"kr" | "us" | "crypto" | "">("");
+  const [kind, setKind] = useState<ArtifactKind | "">("");
+  const [readiness, setReadiness] = useState<ArtifactReadiness | "">("");
 
   useEffect(() => {
     let cancelled = false;
-    fetchArtifacts({ includeStale: true, limit: 20 })
+    setState({ status: "loading" });
+    fetchArtifacts({
+      includeStale: true,
+      limit: 20,
+      market: market || undefined,
+      kind: kind || undefined,
+      readinessLabel: readiness || undefined,
+    })
       .then((res) => {
         if (!cancelled) setState({ status: "ready", data: res.artifacts });
       })
@@ -47,7 +95,7 @@ export function AnalysisArtifactPanel() {
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [market, kind, readiness]);
 
   async function openDetail(id: number) {
     setDetail(null);
@@ -68,6 +116,41 @@ export function AnalysisArtifactPanel() {
           <p style={{ margin: "4px 0 0", fontSize: 12, color: "var(--fg-3)" }}>
             review.analysis_artifacts에서 가장 최근 결정 자료 — 시장/종류/준비상태 필터와 신선도 배지로 활용.
           </p>
+        </div>
+        <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+          <select
+            aria-label="시장 필터"
+            value={market}
+            onChange={(e) => setMarket(e.target.value as "kr" | "us" | "crypto" | "")}
+            style={selectStyle}
+          >
+            <option value="">전체 시장</option>
+            {MARKET_OPTIONS.map((o) => (
+              <option key={o.key} value={o.key}>{o.label}</option>
+            ))}
+          </select>
+          <select
+            aria-label="종류 필터"
+            value={kind}
+            onChange={(e) => setKind(e.target.value as ArtifactKind | "")}
+            style={selectStyle}
+          >
+            <option value="">전체 종류</option>
+            {KIND_OPTIONS.map((o) => (
+              <option key={o.key} value={o.key}>{o.label}</option>
+            ))}
+          </select>
+          <select
+            aria-label="준비상태 필터"
+            value={readiness}
+            onChange={(e) => setReadiness(e.target.value as ArtifactReadiness | "")}
+            style={selectStyle}
+          >
+            <option value="">전체 준비상태</option>
+            {READINESS_OPTIONS.map((o) => (
+              <option key={o.key} value={o.key}>{o.label}</option>
+            ))}
+          </select>
         </div>
         {state.status === "loading" && (
           <div style={{ padding: 12, color: "var(--fg-3)", fontSize: 13 }}>

--- a/frontend/invest/src/components/insights/ForecastCalibrationPanel.tsx
+++ b/frontend/invest/src/components/insights/ForecastCalibrationPanel.tsx
@@ -22,6 +22,14 @@ const GROUP_BY_OPTIONS: { key: ForecastGroupBy; label: string }[] = [
   { key: "day", label: "일자" },
 ];
 
+// "전체" = omit the days param entirely (the backend has no all-time sentinel;
+// days is Query(ge=1)), so the calibration aggregate spans the full history.
+const DAYS_OPTIONS: { key: number | "all"; label: string }[] = [
+  { key: 30, label: "30일" },
+  { key: 90, label: "90일" },
+  { key: "all", label: "전체" },
+];
+
 const INSTRUMENT_MARKET: Record<string, "kr" | "us" | "crypto"> = {
   equity_kr: "kr",
   equity_us: "us",
@@ -233,6 +241,7 @@ function Section({ title, hint, children }: { title: string; hint?: string; chil
 
 export function ForecastCalibrationPanel() {
   const [groupBy, setGroupBy] = useState<ForecastGroupBy>("created_by");
+  const [days, setDays] = useState<number | "all">(90);
   const [calib, setCalib] = useState<LoadState<CalibrationGroupRow[]>>({ status: "loading" });
   const [open, setOpen] = useState<LoadState<ForecastRow[]>>({ status: "loading" });
   const [closed, setClosed] = useState<LoadState<ForecastRow[]>>({ status: "loading" });
@@ -240,13 +249,13 @@ export function ForecastCalibrationPanel() {
   useEffect(() => {
     let cancelled = false;
     setCalib({ status: "loading" });
-    fetchForecastCalibration({ groupBy })
+    fetchForecastCalibration({ groupBy, days: days === "all" ? undefined : days })
       .then((d) => { if (!cancelled) setCalib({ status: "ready", data: d.groups }); })
       .catch((e: unknown) => {
         if (!cancelled) setCalib({ status: "error", message: e instanceof Error ? e.message : String(e) });
       });
     return () => { cancelled = true; };
-  }, [groupBy]);
+  }, [groupBy, days]);
 
   useEffect(() => {
     let cancelled = false;
@@ -273,22 +282,41 @@ export function ForecastCalibrationPanel() {
               어떤 모델·세션의 판단을 얼마나 믿을 수 있는지 — resolvable 예측의 Brier·적중률·보정오차.
             </p>
           </div>
-          <div style={{ display: "flex", gap: 6, flexWrap: "wrap" }}>
-            {GROUP_BY_OPTIONS.map((o) => (
-              <button
-                key={o.key}
-                type="button"
-                onClick={() => setGroupBy(o.key)}
-                style={{
-                  border: "none", borderRadius: 999, padding: "4px 10px", fontSize: 11,
-                  fontWeight: 700, cursor: "pointer", fontFamily: "inherit",
-                  background: groupBy === o.key ? "var(--fg)" : "var(--surface-2)",
-                  color: groupBy === o.key ? "var(--bg)" : "var(--fg-2)",
-                }}
-              >
-                {o.label}
-              </button>
-            ))}
+          <div style={{ display: "flex", flexDirection: "column", gap: 6, alignItems: "flex-end" }}>
+            <div style={{ display: "flex", gap: 6, flexWrap: "wrap" }}>
+              {GROUP_BY_OPTIONS.map((o) => (
+                <button
+                  key={o.key}
+                  type="button"
+                  onClick={() => setGroupBy(o.key)}
+                  style={{
+                    border: "none", borderRadius: 999, padding: "4px 10px", fontSize: 11,
+                    fontWeight: 700, cursor: "pointer", fontFamily: "inherit",
+                    background: groupBy === o.key ? "var(--fg)" : "var(--surface-2)",
+                    color: groupBy === o.key ? "var(--bg)" : "var(--fg-2)",
+                  }}
+                >
+                  {o.label}
+                </button>
+              ))}
+            </div>
+            <div style={{ display: "flex", gap: 6, flexWrap: "wrap" }}>
+              {DAYS_OPTIONS.map((o) => (
+                <button
+                  key={String(o.key)}
+                  type="button"
+                  onClick={() => setDays(o.key)}
+                  style={{
+                    border: "none", borderRadius: 999, padding: "4px 10px", fontSize: 11,
+                    fontWeight: 700, cursor: "pointer", fontFamily: "inherit",
+                    background: days === o.key ? "var(--fg)" : "var(--surface-2)",
+                    color: days === o.key ? "var(--bg)" : "var(--fg-2)",
+                  }}
+                >
+                  {o.label}
+                </button>
+              ))}
+            </div>
           </div>
         </div>
 


### PR DESCRIPTION
## [insights C] Wire filter controls — ROB-674

The filters were **already end-to-end** (router validates `days`/`market`/`kind`/`readiness_label`; the API clients serialize them) — the panels just never rendered controls. This adds them. Frontend-only, migration 0, read-only.

### Changes
- **ForecastCalibrationPanel** — `30일 / 90일 / 전체` segmented control (default `90`) beside the group-by row. `전체` **omits** the `days` param (backend `days` is `Query(ge=1)`, no all-time sentinel). Threaded into the calibration fetch + effect deps. Enables "지난 30일 기준 이 모델 믿을만한가".
- **AnalysisArtifactPanel** — `시장 / 종류 / 준비상태` selects (the subtitle already advertised "시장/종류/준비상태 필터" but none existed). Refetch on change.

### Verification
- 2 panel tests, **4/4 pass** — assert each control refetches with the matching query string (`days=30`, `market=us`, `kind=briefing`, `readiness_label=blocked`) and that `전체` omits `days`.
- `npm run typecheck` → clean.

### Stack
Part **3/7**. **Base: `rob-673` (#1383)** — merge after ROB-673.

🤖 Generated with [Claude Code](https://claude.com/claude-code)