### PR TITLE
feat(ROB-675): calibration confidence-vs-hit bar + header sort + small-sample guard

### DIFF
--- a/frontend/invest/src/__tests__/ForecastCalibrationPanel.test.tsx
+++ b/frontend/invest/src/__tests__/ForecastCalibrationPanel.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { afterEach, expect, test, vi } from "vitest";
 import { ForecastCalibrationPanel } from "../components/insights/ForecastCalibrationPanel";
@@ -74,6 +74,10 @@ test("renders calibration table, due queue and recent scored results", async () 
   // ROB-673: closed forecast surfaces target + realized observed value
   expect(screen.getByText(/목표 ≤ \$180\.00/)).toBeInTheDocument();
   expect(screen.getByText(/실현 \$175\.50/)).toBeInTheDocument();
+
+  // ROB-675: sample_size=4 (<5) trips the small-sample guard + surfaces misses
+  expect(screen.getByText(/소표본/)).toBeInTheDocument();
+  expect(screen.getByText(/실패 1/)).toBeInTheDocument();
 });
 
 test("days control refetches calibration with the selected window (ROB-674)", async () => {
@@ -107,4 +111,45 @@ test("days control refetches calibration with the selected window (ROB-674)", as
   await waitFor(() =>
     expect(calls.some((u) => u.includes("/calibration") && !u.includes("days="))).toBe(true),
   );
+});
+
+test("calibration table sorts client-side on header click (ROB-675)", async () => {
+  const multi: CalibrationResponse = {
+    ...calib,
+    count: 2,
+    groups: [
+      { group: "alpha", sample_size: 10, hits: 6, misses: 4, hit_rate: 0.6, avg_brier_score: 0.2, avg_probability: 0.7, calibration_gap: 0.1 },
+      { group: "beta", sample_size: 8, hits: 7, misses: 1, hit_rate: 0.875, avg_brier_score: 0.1, avg_probability: 0.8, calibration_gap: -0.075 },
+    ],
+  };
+  const fetchMock = vi.fn((url: string) => {
+    const u = String(url);
+    const b = u.includes("/calibration") ? multi : u.includes("/open") ? open : closed;
+    return Promise.resolve({ ok: true, json: async () => b });
+  });
+  vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+  render(
+    <MemoryRouter>
+      <ForecastCalibrationPanel />
+    </MemoryRouter>,
+  );
+  await waitFor(() => expect(screen.getByText("alpha")).toBeInTheDocument());
+
+  const bodyGroups = () =>
+    screen
+      .getAllByRole("row")
+      .slice(1)
+      .map((row) => within(row).getAllByRole("cell")[0]?.textContent ?? "");
+
+  // default preserves server order
+  expect(bodyGroups()).toEqual(["alpha", "beta"]);
+
+  // 적중률 desc: beta (0.875) before alpha (0.6)
+  fireEvent.click(screen.getByRole("columnheader", { name: /적중률/ }));
+  expect(bodyGroups()).toEqual(["beta", "alpha"]);
+
+  // toggle → asc: alpha before beta
+  fireEvent.click(screen.getByRole("columnheader", { name: /적중률/ }));
+  expect(bodyGroups()).toEqual(["alpha", "beta"]);
 });

--- a/frontend/invest/src/components/insights/ForecastCalibrationPanel.tsx
+++ b/frontend/invest/src/components/insights/ForecastCalibrationPanel.tsx
@@ -110,7 +110,63 @@ const tdNum: React.CSSProperties = {
   fontFeatureSettings: '"tnum"',
 };
 
+type SortKey = "sample_size" | "hit_rate" | "avg_brier_score" | "calibration_gap";
+
+// Client-side sort. key===null preserves the server order (sample_size desc,
+// per forecast_service). Nulls always sort last regardless of direction.
+function sortRows(
+  rows: CalibrationGroupRow[],
+  key: SortKey | null,
+  dir: "asc" | "desc",
+): CalibrationGroupRow[] {
+  if (key === null) return rows;
+  const factor = dir === "asc" ? 1 : -1;
+  return [...rows].sort((a, b) => {
+    const av = a[key];
+    const bv = b[key];
+    if (av == null && bv == null) return 0;
+    if (av == null) return 1;
+    if (bv == null) return -1;
+    return (av - bv) * factor;
+  });
+}
+
+// Two stacked fill bars: confidence (avg_probability) over actual (hit_rate).
+// The length difference is the calibration gap, made visible at a glance.
+function CalibrationBar({ confidence, actual }: { confidence: number | null; actual: number | null }) {
+  const track: React.CSSProperties = {
+    position: "relative",
+    width: 88,
+    height: 6,
+    borderRadius: 3,
+    background: "var(--surface-2)",
+    overflow: "hidden",
+  };
+  const clamp = (x: number) => Math.max(0, Math.min(1, x));
+  return (
+    <div style={{ display: "grid", gap: 3 }} aria-hidden>
+      <div style={track} title="확신(평균확신)">
+        {confidence != null && (
+          <div style={{ position: "absolute", top: 0, bottom: 0, left: 0, width: `${clamp(confidence) * 100}%`, background: "var(--fg-3)" }} />
+        )}
+      </div>
+      <div style={track} title="실제(적중률)">
+        {actual != null && (
+          <div style={{ position: "absolute", top: 0, bottom: 0, left: 0, width: `${clamp(actual) * 100}%`, background: "var(--accent)" }} />
+        )}
+      </div>
+    </div>
+  );
+}
+
+const SMALL_SAMPLE = 5;
+
 function CalibrationTable({ rows }: { rows: CalibrationGroupRow[] }) {
+  const [sort, setSort] = useState<{ key: SortKey | null; dir: "asc" | "desc" }>({
+    key: null,
+    dir: "desc",
+  });
+
   if (rows.length === 0) {
     return (
       <div style={{ padding: 16, color: "var(--fg-3)", fontSize: 13, textAlign: "center" }}>
@@ -118,31 +174,68 @@ function CalibrationTable({ rows }: { rows: CalibrationGroupRow[] }) {
       </div>
     );
   }
+
+  const sorted = sortRows(rows, sort.key, sort.dir);
+
+  // Header click cycles desc → asc → server-order (null).
+  const toggleSort = (key: SortKey) =>
+    setSort((s) => {
+      if (s.key !== key) return { key, dir: "desc" };
+      if (s.dir === "desc") return { key, dir: "asc" };
+      return { key: null, dir: "desc" };
+    });
+
+  const sortableTh = (key: SortKey, label: string) => {
+    const active = sort.key === key;
+    return (
+      <th
+        style={{ ...th, textAlign: "right", cursor: "pointer", userSelect: "none" }}
+        onClick={() => toggleSort(key)}
+        aria-sort={active ? (sort.dir === "asc" ? "ascending" : "descending") : "none"}
+      >
+        {label}
+        {active ? (sort.dir === "asc" ? " ▲" : " ▼") : ""}
+      </th>
+    );
+  };
+
   return (
     <div style={{ overflowX: "auto" }}>
-      <table style={{ width: "100%", borderCollapse: "collapse", minWidth: 560 }}>
+      <table style={{ width: "100%", borderCollapse: "collapse", minWidth: 640 }}>
         <thead>
           <tr style={{ color: "var(--fg-3)", fontSize: 11, textAlign: "left" }}>
             <th style={th}>그룹</th>
-            <th style={{ ...th, textAlign: "right" }}>표본</th>
-            <th style={{ ...th, textAlign: "right" }}>적중률</th>
+            {sortableTh("sample_size", "표본")}
+            {sortableTh("hit_rate", "적중률")}
             <th style={{ ...th, textAlign: "right" }}>평균확신</th>
-            <th style={{ ...th, textAlign: "right" }}>Brier</th>
-            <th style={{ ...th, textAlign: "right" }}>보정오차</th>
+            <th style={{ ...th, textAlign: "center" }}>확신·적중</th>
+            {sortableTh("avg_brier_score", "Brier")}
+            {sortableTh("calibration_gap", "보정오차")}
           </tr>
         </thead>
         <tbody>
-          {rows.map((r) => {
+          {sorted.map((r) => {
             const gap = gapText(r.calibration_gap);
+            const small = r.sample_size < SMALL_SAMPLE;
             return (
-              <tr key={r.group}>
-                <td style={{ ...td, fontWeight: 700 }}>{r.group}</td>
+              <tr key={r.group} style={small ? { background: "var(--surface-2)" } : undefined}>
+                <td style={{ ...td, fontWeight: 700 }}>
+                  <span style={{ display: "inline-flex", gap: 6, alignItems: "center", flexWrap: "wrap" }}>
+                    {r.group}
+                    {small && <Pill tone="warn" size="sm">n={r.sample_size} 소표본</Pill>}
+                  </span>
+                </td>
                 <td style={tdNum}>
                   {r.sample_size}
-                  <span style={{ color: "var(--fg-3)", fontSize: 11 }}> ({r.hits}/{r.sample_size})</span>
+                  <span style={{ color: "var(--fg-3)", fontSize: 11 }}> (적중 {r.hits} · 실패 {r.misses})</span>
                 </td>
                 <td style={tdNum}>{pct(r.hit_rate)}</td>
                 <td style={tdNum}>{pct(r.avg_probability)}</td>
+                <td style={{ ...td, textAlign: "center" }}>
+                  <div style={{ display: "inline-flex" }}>
+                    <CalibrationBar confidence={r.avg_probability} actual={r.hit_rate} />
+                  </div>
+                </td>
                 <td style={tdNum}>{num(r.avg_brier_score)}</td>
                 <td style={{ ...tdNum }}>
                   <Pill tone={gap.tone} size="sm">{gap.text}</Pill>


### PR DESCRIPTION
## [insights D] Calibration trust visualization — ROB-675

The panel promised "Brier·적중률·보정오차" comparison but `CalibrationTable` was a plain number grid, and rows were locked to server `sample_size` order — so a `1/1 = 100%` cohort read with the same visual weight as a 40-sample one. Scoped entirely to `CalibrationTable`; **no new data** (`avg_probability`/`hit_rate`/`misses` already on the row).

### Changes
- **Confidence-vs-hit bar** per row: two stacked fills — confidence (`avg_probability`) over actual (`hit_rate`). The length difference *is* the calibration gap.
- **Header sort** — clicking 표본/적중률/Brier/보정오차 cycles `desc → asc → server-order` client-side; default preserves the server `sample_size`-desc order.
- **Small-sample guard** — `sample_size < 5` rows get a muted background + `n=k 소표본` pill and surface the previously-hidden `misses` (`적중 h · 실패 m`).

### Verification
- `ForecastCalibrationPanel.test`, **3/3 pass** — the n=4 fixture now asserts the 소표본 pill + misses; a 2-group fixture asserts header-click reorders rows and toggles direction.
- `npm run typecheck` → clean.

### Stack
Part **4/7**. **Base: `rob-674` (#1384)** — merge after ROB-674.

🤖 Generated with [Claude Code](https://claude.com/claude-code)