### PR TITLE
feat(ROB-676): session timeline entry_type colors + kst_date grouping

### DIFF
--- a/frontend/invest/src/__tests__/SessionContextTimelinePanel.test.tsx
+++ b/frontend/invest/src/__tests__/SessionContextTimelinePanel.test.tsx
@@ -7,7 +7,7 @@ afterEach(() => vi.unstubAllGlobals());
 
 const body = {
   success: true as const,
-  count: 1,
+  count: 2,
   filters: {
     market: null,
     account_scope: null,
@@ -28,6 +28,19 @@ const body = {
       created_by: "claude",
       session_label: null,
       created_at: "2026-07-03T09:00:00+00:00",
+    },
+    {
+      entry_uuid: "e-2",
+      kst_date: "2026-07-02",
+      market: "us",
+      account_scope: null,
+      entry_type: "decision",
+      title: "AAPL 관망 결정",
+      body: "실적 발표 전까지 대기",
+      refs: {},
+      created_by: "claude",
+      session_label: null,
+      created_at: "2026-07-02T22:00:00+00:00",
     },
   ],
 };
@@ -57,5 +70,14 @@ describe("SessionContextTimelinePanel", () => {
     const symLink = screen.getByRole("link", { name: "005930" });
     expect(symLink).toHaveAttribute("href", "/stocks/kr/005930");
     expect(screen.getByText(/주문 ORD-1/)).toBeInTheDocument();
+
+    // ROB-676: entry_type → Pill tone mapping (decision=gain, handoff_note=paper)
+    expect(screen.getByText("decision")).toHaveAttribute("data-tone", "gain");
+    expect(screen.getByText("handoff_note")).toHaveAttribute("data-tone", "paper");
+
+    // ROB-676: rows grouped under per-kst_date headers (newest date first)
+    expect(screen.getByText("2026-07-03")).toBeInTheDocument();
+    expect(screen.getByText("2026-07-02")).toBeInTheDocument();
+    expect(screen.getByText("AAPL 관망 결정")).toBeInTheDocument();
   });
 });

--- a/frontend/invest/src/components/insights/SessionContextTimelinePanel.tsx
+++ b/frontend/invest/src/components/insights/SessionContextTimelinePanel.tsx
@@ -3,8 +3,9 @@ import { Link } from "react-router-dom";
 
 import { fetchRecentSessionContext } from "../../api/sessionContext";
 import { Card, Pill } from "../../ds";
+import type { PillTone } from "../../ds";
 import { stockDetailPath } from "../../stockDetailPath";
-import type { SessionContextEntry } from "../../types/sessionContext";
+import type { SessionContextEntry, SessionEntryType } from "../../types/sessionContext";
 
 type LoadState<T> =
   | { status: "loading" }
@@ -13,6 +14,98 @@ type LoadState<T> =
 
 function fmt(ts: string): string {
   return ts.replace("T", " ").slice(0, 16);
+}
+
+// 8 entry_type values (session_context schema) → Pill tone, so decision /
+// deferred / next_action etc. read distinctly instead of uniform grey.
+const ENTRY_TYPE_TONE: Record<SessionEntryType, PillTone> = {
+  decision: "gain",
+  next_action: "accent",
+  plan: "accent",
+  handoff_note: "paper",
+  deferred: "loss",
+  rejected_candidate: "loss",
+  constraint: "warn",
+  open_question: "warn",
+};
+
+// Bucket entries by kst_date, preserving the incoming newest-first order both
+// across groups (first date seen = newest) and within each group.
+function groupByDate(
+  entries: SessionContextEntry[],
+): { kst_date: string; entries: SessionContextEntry[] }[] {
+  const groups: { kst_date: string; entries: SessionContextEntry[] }[] = [];
+  const index = new Map<string, SessionContextEntry[]>();
+  for (const e of entries) {
+    let bucket = index.get(e.kst_date);
+    if (!bucket) {
+      bucket = [];
+      index.set(e.kst_date, bucket);
+      groups.push({ kst_date: e.kst_date, entries: bucket });
+    }
+    bucket.push(e);
+  }
+  return groups;
+}
+
+// One timeline entry. Owns the refs footer (ROB-673) so the date-grouping
+// wrapper (this ticket) and the per-row content stay decoupled.
+function SessionRow({ entry }: { entry: SessionContextEntry }) {
+  const refs = entry.refs as {
+    symbols?: unknown;
+    order_id?: unknown;
+    report_uuid?: unknown;
+  };
+  const refSymbols = Array.isArray(refs.symbols)
+    ? refs.symbols.filter((s): s is string => typeof s === "string")
+    : [];
+  const orderId = typeof refs.order_id === "string" ? refs.order_id : null;
+  const reportUuid = typeof refs.report_uuid === "string" ? refs.report_uuid : null;
+  const hasRefs = refSymbols.length > 0 || orderId != null || reportUuid != null;
+  return (
+    <li style={{ padding: "10px 0", borderBottom: "1px solid var(--divider, #8882)" }}>
+      <div style={{ display: "flex", gap: 6, alignItems: "center", flexWrap: "wrap" }}>
+        <Pill tone={ENTRY_TYPE_TONE[entry.entry_type] ?? "paper"} size="sm">
+          {entry.entry_type}
+        </Pill>
+        <Pill tone="paper" size="sm">{entry.market}</Pill>
+        {entry.account_scope && <Pill tone="paper" size="sm">{entry.account_scope}</Pill>}
+        <span style={{ opacity: 0.6, fontSize: 12 }}>{fmt(entry.created_at)}</span>
+      </div>
+      <div style={{ fontWeight: 700, marginTop: 4 }}>{entry.title}</div>
+      <div style={{ fontSize: 13, opacity: 0.85, whiteSpace: "pre-wrap" }}>{entry.body}</div>
+      {hasRefs && (
+        <div
+          style={{
+            display: "flex",
+            gap: 8,
+            flexWrap: "wrap",
+            marginTop: 6,
+            fontSize: 11,
+            color: "var(--fg-3)",
+            alignItems: "center",
+          }}
+        >
+          {refSymbols.map((sym) => {
+            const href = stockDetailPath(entry.market, sym);
+            return href ? (
+              <Link
+                key={sym}
+                to={href}
+                style={{ color: "var(--link, #4a9)", textDecoration: "none", fontWeight: 700 }}
+              >
+                {sym}
+              </Link>
+            ) : (
+              <span key={sym} style={{ fontWeight: 700 }}>{sym}</span>
+            );
+          })}
+          {orderId && <span>주문 {orderId}</span>}
+          {reportUuid && <span>리포트 {reportUuid.slice(0, 8)}</span>}
+        </div>
+      )}
+    </li>
+  );
 }
 
 export function SessionContextTimelinePanel() {
@@ -63,83 +156,28 @@ export function SessionContextTimelinePanel() {
           </div>
         )}
         {state.status === "ready" && state.data.length > 0 && (
-          <ul style={{ listStyle: "none", margin: 0, padding: 0 }}>
-            {state.data.map((e) => {
-              const refs = e.refs as {
-                symbols?: unknown;
-                order_id?: unknown;
-                report_uuid?: unknown;
-              };
-              const refSymbols = Array.isArray(refs.symbols)
-                ? refs.symbols.filter((s): s is string => typeof s === "string")
-                : [];
-              const orderId = typeof refs.order_id === "string" ? refs.order_id : null;
-              const reportUuid = typeof refs.report_uuid === "string" ? refs.report_uuid : null;
-              const hasRefs = refSymbols.length > 0 || orderId != null || reportUuid != null;
-              return (
-                <li
-                  key={e.entry_uuid}
+          <div style={{ display: "grid", gap: 12 }}>
+            {groupByDate(state.data).map((group) => (
+              <div key={group.kst_date}>
+                <div
                   style={{
-                    padding: "10px 0",
-                    borderBottom: "1px solid var(--divider, #8882)",
+                    fontSize: 12,
+                    fontWeight: 800,
+                    color: "var(--fg-2)",
+                    borderBottom: "1px solid var(--divider)",
+                    paddingBottom: 4,
                   }}
                 >
-                  <div style={{ display: "flex", gap: 6, alignItems: "center", flexWrap: "wrap" }}>
-                    <Pill tone="paper" size="sm">
-                      {e.entry_type}
-                    </Pill>
-                    <Pill tone="paper" size="sm">
-                      {e.market}
-                    </Pill>
-                    {e.account_scope && (
-                      <Pill tone="paper" size="sm">
-                        {e.account_scope}
-                      </Pill>
-                    )}
-                    <span style={{ opacity: 0.6, fontSize: 12 }}>
-                      {e.kst_date} · {fmt(e.created_at)}
-                    </span>
-                  </div>
-                  <div style={{ fontWeight: 700, marginTop: 4 }}>{e.title}</div>
-                  <div
-                    style={{ fontSize: 13, opacity: 0.85, whiteSpace: "pre-wrap" }}
-                  >
-                    {e.body}
-                  </div>
-                  {hasRefs && (
-                    <div
-                      style={{
-                        display: "flex",
-                        gap: 8,
-                        flexWrap: "wrap",
-                        marginTop: 6,
-                        fontSize: 11,
-                        color: "var(--fg-3)",
-                        alignItems: "center",
-                      }}
-                    >
-                      {refSymbols.map((sym) => {
-                        const href = stockDetailPath(e.market, sym);
-                        return href ? (
-                          <Link
-                            key={sym}
-                            to={href}
-                            style={{ color: "var(--link, #4a9)", textDecoration: "none", fontWeight: 700 }}
-                          >
-                            {sym}
-                          </Link>
-                        ) : (
-                          <span key={sym} style={{ fontWeight: 700 }}>{sym}</span>
-                        );
-                      })}
-                      {orderId && <span>주문 {orderId}</span>}
-                      {reportUuid && <span>리포트 {reportUuid.slice(0, 8)}</span>}
-                    </div>
-                  )}
-                </li>
-              );
-            })}
-          </ul>
+                  {group.kst_date}
+                </div>
+                <ul style={{ listStyle: "none", margin: 0, padding: 0 }}>
+                  {group.entries.map((e) => (
+                    <SessionRow key={e.entry_uuid} entry={e} />
+                  ))}
+                </ul>
+              </div>
+            ))}
+          </div>
         )}
       </section>
     </Card>


### PR DESCRIPTION
## [insights E] Session handoff timeline structure — ROB-676

`SessionContextTimelinePanel` rendered all **8** `entry_type` values as one grey pill in a flat newest-first list — no visual distinction, no timeline structure. Frontend-only, migration 0, read-only.

### Changes
- **`ENTRY_TYPE_TONE`** maps each of the 8 `entry_type` values → `Pill` tone: `decision`=gain, `deferred`/`rejected_candidate`=loss, `constraint`/`open_question`=warn, `plan`/`next_action`=accent, `handoff_note`=paper.
- **Date grouping** — rows bucket under per-`kst_date` headers (newest date first; newest-first within each day). `kst_date` moved from the row meta to the group header.
- **Extracted `SessionRow`** which owns the ROB-673 refs footer, keeping the grouping wrapper and per-row content decoupled (this is the coordination seam the ROB-673 grounding flagged).

### Verification
- `SessionContextTimelinePanel.test`, **1/1 pass** — asserts the `entry_type → data-tone` mapping (decision=gain, handoff_note=paper) and two per-date group headers; the ROB-673 refs assertions still hold.
- `npm run typecheck` → clean.

### Stack
Part **5/7**. **Base: `rob-675` (#1385)** — merge after ROB-675.

🤖 Generated with [Claude Code](https://claude.com/claude-code)