### PR TITLE
feat(ROB-677): /insights IA cleanup + empty-state aggregation

### DIFF
--- a/frontend/invest/src/__tests__/DesktopInsightsPage.test.tsx
+++ b/frontend/invest/src/__tests__/DesktopInsightsPage.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
-import { beforeEach, expect, test, vi } from "vitest";
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
 
 import { DesktopInsightsPage } from "../pages/desktop/DesktopInsightsPage";
 import { useCommonPreferredDisparity } from "../hooks/useCommonPreferredDisparity";
@@ -106,15 +106,46 @@ beforeEach(() => {
   vi.mocked(useCommonPreferredDisparity).mockReturnValue(disparityReady);
 });
 
+afterEach(() => vi.unstubAllGlobals());
+
 test("renders the dedicated read-only insights scaffold", () => {
   render(wrap(<DesktopInsightsPage />));
 
   expect(screen.getByRole("heading", { name: "인사이트" })).toBeInTheDocument();
-  expect(screen.getByText(/ROB-253 decision/)).toBeInTheDocument();
+  // ROB-677: the dev-facing "ROB-253 decision" eyebrow is gone from production UI
+  expect(screen.queryByText(/ROB-253/)).not.toBeInTheDocument();
+  // ROB-677: cards grouped into labelled sections
+  expect(screen.getByRole("heading", { name: "시장 관찰" })).toBeInTheDocument();
+  expect(screen.getByRole("heading", { name: "판단 품질" })).toBeInTheDocument();
+  expect(screen.getByRole("heading", { name: "세션 기록" })).toBeInTheDocument();
   expect(screen.getByText(/주문·매매·watch mutation API를 호출하지 않습니다/)).toBeInTheDocument();
   expect(screen.getByText("KOSPI ETF parity")).toBeInTheDocument();
   expect(screen.getByText("삼성전자 / 삼성전자우")).toBeInTheDocument();
   expect(screen.getByRole("link", { name: "시장 대시보드" })).toHaveAttribute("href", "/invest/market");
+});
+
+test("shows the accumulating banner when all three data panels are empty (ROB-677)", async () => {
+  const fetchMock = vi.fn(async (url: string) => {
+    const u = String(url);
+    let body: unknown = {};
+    if (u.includes("/calibration")) {
+      body = { group_by: "created_by", created_by: null, symbol: null, instrument_type: null, days: null, count: 0, groups: [], as_of: "2026-07-03T00:00:00Z" };
+    } else if (u.includes("/forecasts/open") || u.includes("/forecasts/closed")) {
+      body = { kind: "open", symbol: null, created_by: null, instrument_type: null, count: 0, items: [], as_of: "2026-07-03T00:00:00Z" };
+    } else if (u.includes("/artifacts")) {
+      body = { success: true, count: 0, filters: {}, artifacts: [] };
+    } else if (u.includes("/session-context")) {
+      body = { success: true, count: 0, filters: {}, entries: [] };
+    }
+    return { ok: true, status: 200, json: async () => body };
+  });
+  vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+  render(wrap(<DesktopInsightsPage />));
+
+  expect(
+    await screen.findByText(/판단 품질·핸드오프 데이터는 아직 축적 중입니다/),
+  ).toBeInTheDocument();
 });
 
 test("renders loading and error states for independent insight widgets", () => {

--- a/frontend/invest/src/components/insights/AnalysisArtifactPanel.tsx
+++ b/frontend/invest/src/components/insights/AnalysisArtifactPanel.tsx
@@ -62,7 +62,9 @@ function fmt(ts: string): string {
   return ts.replace("T", " ").slice(0, 16);
 }
 
-export function AnalysisArtifactPanel() {
+export function AnalysisArtifactPanel({
+  onEmptyChange,
+}: { onEmptyChange?: (isEmpty: boolean) => void } = {}) {
   const [state, setState] = useState<LoadState<ArtifactMeta[]>>({
     status: "loading",
   });
@@ -96,6 +98,12 @@ export function AnalysisArtifactPanel() {
       cancelled = true;
     };
   }, [market, kind, readiness]);
+
+  // Report emptiness to the page (ROB-677 banner): empty only when ready + no rows.
+  useEffect(() => {
+    if (!onEmptyChange) return;
+    onEmptyChange(state.status === "ready" && state.data.length === 0);
+  }, [state, onEmptyChange]);
 
   async function openDetail(id: number) {
     setDetail(null);
@@ -163,8 +171,8 @@ export function AnalysisArtifactPanel() {
           </div>
         )}
         {state.status === "ready" && state.data.length === 0 && (
-          <div style={{ padding: 12, color: "var(--fg-3)", fontSize: 13 }}>
-            저장된 분석 아티팩트가 없습니다.
+          <div style={{ padding: 12, color: "var(--fg-3)", fontSize: 13, lineHeight: 1.6 }}>
+            저장된 분석 아티팩트가 없습니다 — 분석 세션이 스크리닝·판정·브리핑을 기록하면 쌓입니다(필터를 넓혀보세요).
           </div>
         )}
         {state.status === "ready" && state.data.length > 0 && (

--- a/frontend/invest/src/components/insights/ForecastCalibrationPanel.tsx
+++ b/frontend/invest/src/components/insights/ForecastCalibrationPanel.tsx
@@ -169,8 +169,8 @@ function CalibrationTable({ rows }: { rows: CalibrationGroupRow[] }) {
 
   if (rows.length === 0) {
     return (
-      <div style={{ padding: 16, color: "var(--fg-3)", fontSize: 13, textAlign: "center" }}>
-        채점 완료된 예측이 아직 없습니다.
+      <div style={{ padding: 16, color: "var(--fg-3)", fontSize: 13, textAlign: "center", lineHeight: 1.6 }}>
+        채점 완료된 예측이 아직 없습니다 — forecast_resolve 실행 후 review_date가 지난 closed 예측에서 채워집니다.
       </div>
     );
   }
@@ -332,7 +332,9 @@ function Section({ title, hint, children }: { title: string; hint?: string; chil
   );
 }
 
-export function ForecastCalibrationPanel() {
+export function ForecastCalibrationPanel({
+  onEmptyChange,
+}: { onEmptyChange?: (isEmpty: boolean) => void } = {}) {
   const [groupBy, setGroupBy] = useState<ForecastGroupBy>("created_by");
   const [days, setDays] = useState<number | "all">(90);
   const [calib, setCalib] = useState<LoadState<CalibrationGroupRow[]>>({ status: "loading" });
@@ -364,6 +366,14 @@ export function ForecastCalibrationPanel() {
       });
     return () => { cancelled = true; };
   }, []);
+
+  // Report emptiness to the page (ROB-677 banner): empty only when all three
+  // sub-fetches are ready AND empty; loading/error counts as not-empty.
+  useEffect(() => {
+    if (!onEmptyChange) return;
+    const flags = [calib, open, closed].map((s) => (s.status === "ready" ? s.data.length === 0 : null));
+    onEmptyChange(flags.every((f) => f === true));
+  }, [calib, open, closed, onEmptyChange]);
 
   return (
     <Card>

--- a/frontend/invest/src/components/insights/SessionContextTimelinePanel.tsx
+++ b/frontend/invest/src/components/insights/SessionContextTimelinePanel.tsx
@@ -108,7 +108,9 @@ function SessionRow({ entry }: { entry: SessionContextEntry }) {
   );
 }
 
-export function SessionContextTimelinePanel() {
+export function SessionContextTimelinePanel({
+  onEmptyChange,
+}: { onEmptyChange?: (isEmpty: boolean) => void } = {}) {
   const [state, setState] = useState<LoadState<SessionContextEntry[]>>({
     status: "loading",
   });
@@ -131,6 +133,12 @@ export function SessionContextTimelinePanel() {
     };
   }, []);
 
+  // Report emptiness to the page (ROB-677 banner): empty only when ready + no rows.
+  useEffect(() => {
+    if (!onEmptyChange) return;
+    onEmptyChange(state.status === "ready" && state.data.length === 0);
+  }, [state, onEmptyChange]);
+
   return (
     <Card data-testid="session-context-timeline-panel">
       <section style={{ display: "grid", gap: 12 }}>
@@ -151,8 +159,8 @@ export function SessionContextTimelinePanel() {
           </div>
         )}
         {state.status === "ready" && state.data.length === 0 && (
-          <div style={{ padding: 12, color: "var(--fg-3)", fontSize: 13 }}>
-            최근 세션 컨텍스트 없음
+          <div style={{ padding: 12, color: "var(--fg-3)", fontSize: 13, lineHeight: 1.6 }}>
+            최근 세션 컨텍스트 없음 — 운영 세션이 결정·계획·핸드오프 메모를 남기면 여기에 타임라인으로 쌓입니다.
           </div>
         )}
         {state.status === "ready" && state.data.length > 0 && (

--- a/frontend/invest/src/pages/desktop/DesktopInsightsPage.tsx
+++ b/frontend/invest/src/pages/desktop/DesktopInsightsPage.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from "react";
+import { useState, type ReactNode } from "react";
 import { Link } from "react-router-dom";
 import { CommonPreferredDisparityCardView } from "../../components/CommonPreferredDisparityCard";
 import { MarketParityStrip } from "../../components/home/MarketParityStrip";
@@ -29,19 +29,55 @@ function SectionStatus({ children }: { children: ReactNode }) {
   );
 }
 
-function DecisionCard() {
+function PageHeader() {
   return (
-    <Card>
-      <div style={{ display: "grid", gap: 8 }}>
-        <div style={{ fontSize: 12, color: "var(--fg-3)", fontWeight: 800 }}>ROB-253 decision</div>
-        <h1 style={{ margin: 0, fontSize: 28, letterSpacing: "-0.05em" }}>인사이트</h1>
-        <p style={{ margin: 0, color: "var(--fg-2)", fontSize: 14, lineHeight: 1.6 }}>
-          홈에는 compact 요약만 남기고, 괴리·패리티처럼 해석 주의가 필요한 read-only 관찰 카드는
-          /invest/insights에서 모아 봅니다. 종목별 리서치 컨센서스는 symbol context가 필요하므로
-          개별 종목 상세 화면에 유지합니다.
-        </p>
-      </div>
-    </Card>
+    <div style={{ display: "grid", gap: 8 }}>
+      <h1 style={{ margin: 0, fontSize: 28, letterSpacing: "-0.05em" }}>인사이트</h1>
+      <p style={{ margin: 0, color: "var(--fg-2)", fontSize: 14, lineHeight: 1.6 }}>
+        괴리·패리티 같은 시장 관찰과 예측 판단 품질·세션 기록을 한곳에서 봅니다. 모두 읽기 전용 관찰 자료입니다.
+      </p>
+    </div>
+  );
+}
+
+// Lightweight section label — deliberately smaller/muted than the panels' own
+// h2 titles so grouping reads as a divider, not a competing heading.
+function Section({ title, children }: { title: string; children: ReactNode }) {
+  return (
+    <section style={{ display: "grid", gap: 12 }}>
+      <h2
+        style={{
+          margin: 0,
+          fontSize: 13,
+          fontWeight: 800,
+          color: "var(--fg-3)",
+          letterSpacing: "0.04em",
+        }}
+      >
+        {title}
+      </h2>
+      {children}
+    </section>
+  );
+}
+
+function AccumulatingBanner() {
+  return (
+    <div
+      role="status"
+      style={{
+        padding: "12px 14px",
+        background: "var(--surface-2)",
+        border: "1px solid var(--border)",
+        borderRadius: 12,
+        color: "var(--fg-2)",
+        fontSize: 13,
+        lineHeight: 1.6,
+      }}
+    >
+      판단 품질·핸드오프 데이터는 아직 축적 중입니다 — 예측 채점(forecast_resolve)·분석 아티팩트·세션
+      메모가 쌓이면 아래 카드가 채워집니다.
+    </div>
   );
 }
 
@@ -78,26 +114,42 @@ export function DesktopInsightsPage() {
   const marketParity = useMarketParity();
   const disparity = useCommonPreferredDisparity();
 
+  // Emptiness is owned by each panel (self-fetch); they report up via
+  // onEmptyChange so the page can show one accumulating banner instead of a
+  // stack of empty boxes. null = not-yet-resolved.
+  const [forecastEmpty, setForecastEmpty] = useState<boolean | null>(null);
+  const [artifactEmpty, setArtifactEmpty] = useState<boolean | null>(null);
+  const [sessionEmpty, setSessionEmpty] = useState<boolean | null>(null);
+  const allDataEmpty =
+    forecastEmpty === true && artifactEmpty === true && sessionEmpty === true;
+
   return (
     <DesktopShell
       center={
-        <div style={{ padding: 24, display: "grid", gap: 16 }}>
-          <ReadOnlyGuardrailNote />
-          <DecisionCard />
+        <div style={{ padding: 24, display: "grid", gap: 20 }}>
+          <PageHeader />
+          {allDataEmpty && <AccumulatingBanner />}
 
-          <Card>
-            <MarketParityStrip state={marketParity.state} reload={marketParity.reload} />
-          </Card>
+          <Section title="시장 관찰">
+            <Card>
+              <MarketParityStrip state={marketParity.state} reload={marketParity.reload} />
+            </Card>
+            {disparity.status === "loading" && <SectionStatus>보통주/우선주 괴리 데이터를 불러오는 중…</SectionStatus>}
+            {disparity.status === "error" && <SectionStatus>보통주/우선주 괴리 데이터를 일시적으로 불러오지 못했습니다.</SectionStatus>}
+            {disparity.status === "ready" && <CommonPreferredDisparityCardView data={disparity.data} />}
+          </Section>
 
-          {disparity.status === "loading" && <SectionStatus>보통주/우선주 괴리 데이터를 불러오는 중…</SectionStatus>}
-          {disparity.status === "error" && <SectionStatus>보통주/우선주 괴리 데이터를 일시적으로 불러오지 못했습니다.</SectionStatus>}
-          {disparity.status === "ready" && <CommonPreferredDisparityCardView data={disparity.data} />}
+          <Section title="판단 품질">
+            <ForecastCalibrationPanel onEmptyChange={setForecastEmpty} />
+          </Section>
 
-          <ForecastCalibrationPanel />
-          <AnalysisArtifactPanel />
-          <SessionContextTimelinePanel />
+          <Section title="세션 기록">
+            <AnalysisArtifactPanel onEmptyChange={setArtifactEmpty} />
+            <SessionContextTimelinePanel onEmptyChange={setSessionEmpty} />
+          </Section>
 
           <RelatedScreensCard />
+          <ReadOnlyGuardrailNote />
         </div>
       }
     />


### PR DESCRIPTION
## [insights F] Page IA cleanup — ROB-677

`/insights` was a flat stack of unthemed read-only cards led by a **dev-facing** meta card, with real data pushed below the fold. Reorganized. Frontend-only, migration 0, read-only.

### Changes
- **Removed** the `ROB-253 decision` eyebrow from production UI → clean `h1 인사이트` + one-liner.
- **Sections**: 시장 관찰 (MarketParityStrip + 보통주/우선주 괴리), 판단 품질 (Forecast 캘리브레이션), 세션 기록 (아티팩트 + 세션 타임라인). Section labels are deliberately smaller/muted to avoid double-heading the panels' own `h2`s.
- **Demoted** `ReadOnlyGuardrailNote` from top → bottom.
- **Empty-state aggregation**: emptiness wasn't observable from the page (panels self-fetch), so each panel gains an **additive optional `onEmptyChange`** prop; the page shows one "데이터 축적 중" banner when *all three* are empty instead of a stack of empty boxes. Each panel's empty copy now says what/how it fills (calibration fills only from `forecast_resolve` + closed rows past `review_date`).

### Verification
- Page + 3 panel tests, **10/10 pass**; full suite **514 pass / 5 fail** (the 5 are pre-existing calendar/coverage failures, unchanged).
- New test stubs empty payloads for all three endpoints and asserts the aggregate banner; `ROB-253` assertion removed.
- `npm run typecheck` → clean.

### Stack
Part **6/7**. **Base: `rob-676` (#1386)** — merge after ROB-676. (Note: ROB-678 stacks on this and adds a 4th panel into the 세션 기록 section.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)