### PR TITLE
feat(ROB-678): retrospectives panel on /insights + forecast↔retro crosslink

### DIFF
--- a/frontend/invest/src/__tests__/DesktopInsightsPage.test.tsx
+++ b/frontend/invest/src/__tests__/DesktopInsightsPage.test.tsx
@@ -122,6 +122,9 @@ test("renders the dedicated read-only insights scaffold", () => {
   expect(screen.getByText("KOSPI ETF parity")).toBeInTheDocument();
   expect(screen.getByText("삼성전자 / 삼성전자우")).toBeInTheDocument();
   expect(screen.getByRole("link", { name: "시장 대시보드" })).toHaveAttribute("href", "/invest/market");
+  // ROB-678: retrospectives panel mounted under a 학습·회고 section
+  expect(screen.getByRole("heading", { name: "학습·회고" })).toBeInTheDocument();
+  expect(screen.getByTestId("retrospectives-panel")).toBeInTheDocument();
 });
 
 test("shows the accumulating banner when all three data panels are empty (ROB-677)", async () => {
@@ -136,6 +139,10 @@ test("shows the accumulating banner when all three data panels are empty (ROB-67
       body = { success: true, count: 0, filters: {}, artifacts: [] };
     } else if (u.includes("/session-context")) {
       body = { success: true, count: 0, filters: {}, entries: [] };
+    } else if (u.includes("next-actions")) {
+      body = { market: "all", symbol: null, count: 0, scan_limit: 200, items: [] };
+    } else if (u.includes("retrospectives")) {
+      body = { market: "all", trigger_type: null, root_cause_class: null, symbol: null, count: 0, total: 0, items: [], as_of: "2026-07-03T00:00:00Z" };
     }
     return { ok: true, status: 200, json: async () => body };
   });

--- a/frontend/invest/src/__tests__/ForecastCalibrationPanel.test.tsx
+++ b/frontend/invest/src/__tests__/ForecastCalibrationPanel.test.tsx
@@ -153,3 +153,26 @@ test("calibration table sorts client-side on header click (ROB-675)", async () =
   fireEvent.click(screen.getByRole("columnheader", { name: /적중률/ }));
   expect(bodyGroups()).toEqual(["alpha", "beta"]);
 });
+
+test("closed forecast crosslinks to its retrospective when linked (ROB-678)", async () => {
+  const closedLinked: ForecastListResponse = {
+    ...closed,
+    items: [{ ...closed.items[0]!, correlation_id: "corr-1" }],
+  };
+  const fetchMock = vi.fn((url: string) => {
+    const u = String(url);
+    const b = u.includes("/calibration") ? calib : u.includes("/open") ? open : closedLinked;
+    return Promise.resolve({ ok: true, json: async () => b });
+  });
+  vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+  render(
+    <MemoryRouter>
+      <ForecastCalibrationPanel linkedCorrelationIds={new Set(["corr-1"])} />
+    </MemoryRouter>,
+  );
+
+  const link = await screen.findByRole("link", { name: /회고/ });
+  expect(link).toHaveAttribute("href", "#retro-corr-1");
+  expect(document.getElementById("forecast-corr-1")).not.toBeNull();
+});

--- a/frontend/invest/src/__tests__/RetrospectivesPanel.test.tsx
+++ b/frontend/invest/src/__tests__/RetrospectivesPanel.test.tsx
@@ -47,3 +47,23 @@ test("renders pinned next-action checklist and retrospective row", async () => {
   await waitFor(() => expect(screen.getByText("재진입 룰 재검토")).toBeInTheDocument());
   expect(screen.getByText(/분할 매수가 유효했다/)).toBeInTheDocument();
 });
+
+test("retrospective crosslinks to its forecast when linked (ROB-678)", async () => {
+  const fetchMock = vi.fn((url: string) =>
+    Promise.resolve({
+      ok: true,
+      json: async () => (String(url).includes("next-actions") ? na : list),
+    }),
+  );
+  vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+  render(
+    <MemoryRouter>
+      <RetrospectivesPanel linkedCorrelationIds={new Set(["c"])} />
+    </MemoryRouter>,
+  );
+
+  const link = await screen.findByRole("link", { name: "예측↑" });
+  expect(link).toHaveAttribute("href", "#forecast-c");
+  expect(document.getElementById("retro-c")).not.toBeNull();
+});

--- a/frontend/invest/src/components/insights/ForecastCalibrationPanel.tsx
+++ b/frontend/invest/src/components/insights/ForecastCalibrationPanel.tsx
@@ -279,7 +279,13 @@ function OpenList({ rows }: { rows: ForecastRow[] }) {
   );
 }
 
-function ClosedList({ rows }: { rows: ForecastRow[] }) {
+function ClosedList({
+  rows,
+  linkedCorrelationIds,
+}: {
+  rows: ForecastRow[];
+  linkedCorrelationIds?: ReadonlySet<string>;
+}) {
   if (rows.length === 0) {
     return (
       <div style={{ padding: 16, color: "var(--fg-3)", fontSize: 13, textAlign: "center" }}>
@@ -292,9 +298,11 @@ function ClosedList({ rows }: { rows: ForecastRow[] }) {
       {rows.map((r) => {
         const target = formatForecastTarget(r);
         const market = r.instrument_type ? INSTRUMENT_MARKET[r.instrument_type] : undefined;
+        const linked = r.correlation_id != null && (linkedCorrelationIds?.has(r.correlation_id) ?? false);
         return (
           <div
             key={r.id}
+            id={linked ? `forecast-${r.correlation_id}` : undefined}
             style={{ display: "flex", alignItems: "center", gap: 8, fontSize: 13, padding: "2px 0", flexWrap: "wrap" }}
           >
             <Pill tone={r.outcome ? "gain" : "loss"} size="sm">{r.outcome ? "적중" : "빗나감"}</Pill>
@@ -307,6 +315,14 @@ function ClosedList({ rows }: { rows: ForecastRow[] }) {
             <span style={{ color: "var(--fg-3)", fontSize: 11 }}>· Brier {num(r.brier_score)}</span>
             {r.resolved_at && (
               <span style={{ color: "var(--fg-3)", fontSize: 11 }}>· {r.resolved_at.slice(0, 10)}</span>
+            )}
+            {linked && (
+              <a
+                href={`#retro-${r.correlation_id}`}
+                style={{ color: "var(--link, #4a9)", textDecoration: "none", fontSize: 11 }}
+              >
+                · 회고↓
+              </a>
             )}
           </div>
         );
@@ -334,7 +350,13 @@ function Section({ title, hint, children }: { title: string; hint?: string; chil
 
 export function ForecastCalibrationPanel({
   onEmptyChange,
-}: { onEmptyChange?: (isEmpty: boolean) => void } = {}) {
+  onClosedCorrelationIds,
+  linkedCorrelationIds,
+}: {
+  onEmptyChange?: (isEmpty: boolean) => void;
+  onClosedCorrelationIds?: (ids: string[]) => void;
+  linkedCorrelationIds?: ReadonlySet<string>;
+} = {}) {
   const [groupBy, setGroupBy] = useState<ForecastGroupBy>("created_by");
   const [days, setDays] = useState<number | "all">(90);
   const [calib, setCalib] = useState<LoadState<CalibrationGroupRow[]>>({ status: "loading" });
@@ -374,6 +396,16 @@ export function ForecastCalibrationPanel({
     const flags = [calib, open, closed].map((s) => (s.status === "ready" ? s.data.length === 0 : null));
     onEmptyChange(flags.every((f) => f === true));
   }, [calib, open, closed, onEmptyChange]);
+
+  // Report closed-forecast correlation_ids so the page can crosslink them to
+  // matching retrospectives (ROB-678).
+  useEffect(() => {
+    if (!onClosedCorrelationIds) return;
+    if (closed.status !== "ready") return;
+    onClosedCorrelationIds(
+      closed.data.map((r) => r.correlation_id).filter((c): c is string => c != null),
+    );
+  }, [closed, onClosedCorrelationIds]);
 
   return (
     <Card>
@@ -438,7 +470,7 @@ export function ForecastCalibrationPanel({
         <Section title="최근 채점 결과" hint="가장 최근에 해소된 예측.">
           {closed.status === "loading" && <div style={{ padding: 16, color: "var(--fg-3)", fontSize: 13, textAlign: "center" }}>불러오는 중…</div>}
           {closed.status === "error" && <div role="alert" style={{ padding: 12, color: "var(--danger)", fontSize: 13 }}>채점 결과를 불러오지 못했습니다. {closed.message}</div>}
-          {closed.status === "ready" && <ClosedList rows={closed.data} />}
+          {closed.status === "ready" && <ClosedList rows={closed.data} linkedCorrelationIds={linkedCorrelationIds} />}
         </Section>
       </section>
     </Card>

--- a/frontend/invest/src/components/my/RetrospectivesPanel.tsx
+++ b/frontend/invest/src/components/my/RetrospectivesPanel.tsx
@@ -70,7 +70,15 @@ function NextActionChecklist({ items }: { items: NextActionRow[] }) {
   );
 }
 
-export function RetrospectivesPanel({ compact = false }: { compact?: boolean }) {
+export function RetrospectivesPanel({
+  compact = false,
+  onCorrelationIds,
+  linkedCorrelationIds,
+}: {
+  compact?: boolean;
+  onCorrelationIds?: (ids: string[]) => void;
+  linkedCorrelationIds?: ReadonlySet<string>;
+}) {
   const [market, setMarket] = useState<RetroMarket>("all");
   const [triggerType, setTriggerType] = useState<string>("");
   const [nextActions, setNextActions] = useState<NextActionRow[]>([]);
@@ -100,6 +108,16 @@ export function RetrospectivesPanel({ compact = false }: { compact?: boolean }) 
       .catch(() => { if (!cancelled) setNextActions([]); });
     return () => { cancelled = true; };
   }, [market]);
+
+  // Report retrospective correlation_ids so a host page can crosslink them to
+  // matching closed forecasts (ROB-678). No-op off /insights (prop undefined).
+  useEffect(() => {
+    if (!onCorrelationIds) return;
+    if (state.status !== "ready") return;
+    onCorrelationIds(
+      state.items.map((r) => r.correlation_id).filter((c): c is string => c != null),
+    );
+  }, [state, onCorrelationIds]);
 
   const rows = useMemo(() => (state.status === "ready" ? state.items : []), [state]);
 
@@ -164,8 +182,9 @@ export function RetrospectivesPanel({ compact = false }: { compact?: boolean }) 
             <tbody>
               {rows.map((row) => {
                 const href = row.market ? stockDetailPath(row.market as "kr" | "us" | "crypto", row.symbol) : null;
+                const linked = row.correlation_id != null && (linkedCorrelationIds?.has(row.correlation_id) ?? false);
                 return (
-                  <tr key={row.id}>
+                  <tr key={row.id} id={linked ? `retro-${row.correlation_id}` : undefined}>
                     <td style={{ padding: "10px 14px", borderBottom: "1px solid var(--divider)", fontSize: 13, fontWeight: 700 }}>
                       {href ? <Link to={href} style={{ color: "inherit", textDecoration: "none" }}>{row.symbol}</Link> : row.symbol}
                     </td>
@@ -180,6 +199,14 @@ export function RetrospectivesPanel({ compact = false }: { compact?: boolean }) 
                     </td>
                     <td style={{ padding: "10px 14px", borderBottom: "1px solid var(--divider)", fontSize: 12, color: "var(--fg-2)", maxWidth: 320 }}>
                       {row.lesson ?? row.result_summary ?? "—"}
+                      {linked && (
+                        <a
+                          href={`#forecast-${row.correlation_id}`}
+                          style={{ marginLeft: 8, color: "var(--link, #4a9)", textDecoration: "none", whiteSpace: "nowrap" }}
+                        >
+                          예측↑
+                        </a>
+                      )}
                     </td>
                   </tr>
                 );

--- a/frontend/invest/src/pages/desktop/DesktopInsightsPage.tsx
+++ b/frontend/invest/src/pages/desktop/DesktopInsightsPage.tsx
@@ -1,10 +1,11 @@
-import { useState, type ReactNode } from "react";
+import { useMemo, useState, type ReactNode } from "react";
 import { Link } from "react-router-dom";
 import { CommonPreferredDisparityCardView } from "../../components/CommonPreferredDisparityCard";
 import { MarketParityStrip } from "../../components/home/MarketParityStrip";
 import { AnalysisArtifactPanel } from "../../components/insights/AnalysisArtifactPanel";
 import { ForecastCalibrationPanel } from "../../components/insights/ForecastCalibrationPanel";
 import { SessionContextTimelinePanel } from "../../components/insights/SessionContextTimelinePanel";
+import { RetrospectivesPanel } from "../../components/my/RetrospectivesPanel";
 import { PageSafetyNote } from "../../components/PageSafetyNote";
 import { DesktopShell } from "../../desktop/DesktopShell";
 import { Card } from "../../ds";
@@ -123,6 +124,15 @@ export function DesktopInsightsPage() {
   const allDataEmpty =
     forecastEmpty === true && artifactEmpty === true && sessionEmpty === true;
 
+  // Crosslink closed forecasts ↔ retrospectives by correlation_id (ROB-678):
+  // only the intersection (ids present on both sides) gets anchors + links.
+  const [closedForecastIds, setClosedForecastIds] = useState<string[]>([]);
+  const [retroIds, setRetroIds] = useState<string[]>([]);
+  const linkedCorrelationIds = useMemo(() => {
+    const retro = new Set(retroIds);
+    return new Set(closedForecastIds.filter((id) => retro.has(id)));
+  }, [closedForecastIds, retroIds]);
+
   return (
     <DesktopShell
       center={
@@ -140,7 +150,18 @@ export function DesktopInsightsPage() {
           </Section>
 
           <Section title="판단 품질">
-            <ForecastCalibrationPanel onEmptyChange={setForecastEmpty} />
+            <ForecastCalibrationPanel
+              onEmptyChange={setForecastEmpty}
+              onClosedCorrelationIds={setClosedForecastIds}
+              linkedCorrelationIds={linkedCorrelationIds}
+            />
+          </Section>
+
+          <Section title="학습·회고">
+            <RetrospectivesPanel
+              onCorrelationIds={setRetroIds}
+              linkedCorrelationIds={linkedCorrelationIds}
+            />
           </Section>
 
           <Section title="세션 기록">


### PR DESCRIPTION
## [insights G] Retrospectives on /insights + crosslink — ROB-678

The completed sibling read surface `RetrospectivesPanel` (retros + `/next-actions` rollup) lived only on `/my`. Retrospectives are learning material, so they belong next to forecast calibration. Frontend + reused read routers (no new backend), migration 0, read-only.

### Changes
- **New 학습·회고 section** renders `<RetrospectivesPanel/>` on `/insights` — reuses `GET /invest/retrospectives` + `/next-actions`; the panel's market/trigger filters come along for free.
- **Symmetric `correlation_id` crosslink** (the model docstring aligns `forecast.correlation_id` ↔ `trade_retrospectives`): both panels report their `correlation_id`s up, the page computes the **intersection**, and passes it back — so only ids present on *both* sides get anchors + links (no dead links). Closed forecast rows get `id=forecast-<cid>` + a `회고↓` link to `#retro-<cid>`; retro rows get `id=retro-<cid>` + a `예측↑` link to `#forecast-<cid>`.
- `RetrospectivesPanel`'s new props are **additive/optional** → `/my` behavior unchanged.

### Verification
- Page + 2 component tests, **10/10 pass**; full suite **516 pass / 5 fail** (the 5 are pre-existing calendar/coverage; no `/my` regression from the shared-component change).
- Component tests assert both link directions + anchors; the ROB-677 empty-banner test now also stubs the retrospectives/next-actions endpoints.
- `npm run typecheck` → clean.

### Stack
Part **7/7** (final). **Base: `rob-677` (#1387)** — merge after ROB-677.

🤖 Generated with [Claude Code](https://claude.com/claude-code)