### PR TITLE
fix(ROB-679): session timeline row shows time only (drop repeated date)

### DIFF
--- a/frontend/invest/src/__tests__/SessionContextTimelinePanel.test.tsx
+++ b/frontend/invest/src/__tests__/SessionContextTimelinePanel.test.tsx
@@ -79,5 +79,10 @@ describe("SessionContextTimelinePanel", () => {
     expect(screen.getByText("2026-07-03")).toBeInTheDocument();
     expect(screen.getByText("2026-07-02")).toBeInTheDocument();
     expect(screen.getByText("AAPL 관망 결정")).toBeInTheDocument();
+
+    // ROB-679: row shows time only (HH:MM); the date is not repeated from the group header
+    expect(screen.getByText("09:00")).toBeInTheDocument();
+    expect(screen.getByText("22:00")).toBeInTheDocument();
+    expect(screen.queryByText(/2026-07-03 09:00/)).not.toBeInTheDocument();
   });
 });

--- a/frontend/invest/src/components/insights/SessionContextTimelinePanel.tsx
+++ b/frontend/invest/src/components/insights/SessionContextTimelinePanel.tsx
@@ -12,8 +12,9 @@ type LoadState<T> =
   | { status: "ready"; data: T }
   | { status: "error"; message: string };
 
-function fmt(ts: string): string {
-  return ts.replace("T", " ").slice(0, 16);
+// Row shows time only (HH:MM); the date lives in the per-kst_date group header.
+function hhmm(ts: string): string {
+  return ts.slice(11, 16);
 }
 
 // 8 entry_type values (session_context schema) → Pill tone, so decision /
@@ -70,7 +71,7 @@ function SessionRow({ entry }: { entry: SessionContextEntry }) {
         </Pill>
         <Pill tone="paper" size="sm">{entry.market}</Pill>
         {entry.account_scope && <Pill tone="paper" size="sm">{entry.account_scope}</Pill>}
-        <span style={{ opacity: 0.6, fontSize: 12 }}>{fmt(entry.created_at)}</span>
+        <span style={{ opacity: 0.6, fontSize: 12 }}>{hhmm(entry.created_at)}</span>
       </div>
       <div style={{ fontWeight: 700, marginTop: 4 }}>{entry.title}</div>
       <div style={{ fontSize: 13, opacity: 0.85, whiteSpace: "pre-wrap" }}>{entry.body}</div>


### PR DESCRIPTION
## ROB-679 — session timeline row date redundancy

Post-deploy polish. ROB-676 (insights E) introduced per-`kst_date` group headers and removed the row's inline date, but the row time still rendered `fmt(created_at)` = `"YYYY-MM-DD HH:MM"` — so every row repeated the date already shown in its group header.

### Change (frontend-only, migration 0, read-only)
- `SessionContextTimelinePanel` — replace `fmt` (date+time) with `hhmm` (time-only, `created_at.slice(11,16)`). The date now appears once, in the group header. TZ behavior unchanged (still a string slice).

### Verification
- `SessionContextTimelinePanel.test` — asserts rows show `09:00`/`22:00` and that `2026-07-03 09:00` no longer appears; group headers still render.
- `npm run typecheck` → clean.

Base: `main`. Follow-up to the ROB-672→678 /insights family.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Timeline entries now display only the time (`HH:MM`) instead of repeating the full date and time together.
  * Updated the timeline view to keep each row’s timestamp display compact and easier to scan.
  * Adjusted test coverage to confirm the new time-only formatting appears consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->