### PR TITLE
feat(ROB-682): re-key /insights forecast↔retro crosslink on market+symbol

### DIFF
--- a/docs/plans/ROB-682-crosslink-symbol-join.md
+++ b/docs/plans/ROB-682-crosslink-symbol-join.md
@@ -1,0 +1,232 @@
+# ROB-682 — insights forecast↔회고 crosslink을 SYMBOL 키로 재배선
+
+/ insights (판단 품질 ↔ 학습·회고) 크로스링크는 ROB-678(G)에서 `correlation_id`
+정확 일치로 배선되었으나 **LIVE 데이터에서 구조적으로 죽어 있다**. 이 플랜은
+USER-PREFERRED 옵션 A(심볼 재키잉)로 교체한다. 코드 변경 없음 — 플랜 문서만.
+
+## 배경
+
+ROB-678의 페이지-조정 교집합(page-coordinated intersection)은 다음처럼 동작한다:
+
+- `ForecastCalibrationPanel` — closed 예측 로드 시
+  `onClosedCorrelationIds(closed.data.map(r => r.correlation_id).filter(non-null))`
+  로 correlation_id 배열을 페이지에 보고
+  (`ForecastCalibrationPanel.tsx:402-408`).
+- `RetrospectivesPanel` — 회고 로드 시
+  `onCorrelationIds(state.items.map(r => r.correlation_id).filter(non-null))`
+  로 보고 (`RetrospectivesPanel.tsx:114-120`).
+- `DesktopInsightsPage` — 두 배열을 받아 `linkedCorrelationIds` = **교집합**(Set)
+  을 계산해 다시 두 패널로 내려보냄 (`DesktopInsightsPage.tsx:127-134`,
+  `152-165`).
+- 렌더 시 교집합에 속한 행만 앵커 + 링크를 얻는다:
+  - closed 예측 행: `id="forecast-<corr>"` + `<a href="#retro-<corr>">회고↓</a>`
+    (`ForecastCalibrationPanel.tsx:298-327`, `ClosedList`).
+  - 회고 행: `id="retro-<corr>"` + `<a href="#forecast-<corr>">예측↑</a>`
+    (`RetrospectivesPanel.tsx:183-211`).
+
+### 왜 죽었는가 (근거)
+
+두 축의 `correlation_id`가 **분리된 네임스페이스**다:
+
+- 예측(forecast) 측: thesis-style — 예 `hynix-reentry-thesis-0703`.
+  `forecast_tools.py:53`은 심볼만 `.strip()`, correlation_id는 caller가 자유
+  형식으로 넣음.
+- 회고(retro) 측: exec-style — 예 `toss_live:...` / `live:<uuid>`.
+
+동일 종목 `000660`이 양쪽에 존재해도 corr_id가 달라 `linkedCorrelationIds`
+교집합이 **항상 공집합** → 앵커/링크가 절대 렌더되지 않음(구조적 dead code).
+
+### 옵션 A: SYMBOL 키로 재키잉
+
+교집합의 키를 correlation_id → **정규화된 심볼 키**로 바꾼다. 동일 종목이 예측·
+회고 양쪽에 있으면 그 종목의 예측 행 ↔ 회고 행을 서로 점프하는 링크를 렌더한다.
+
+**서버 측 심볼 정규화(근거 — 프런트 키가 이를 맞춰야 함):**
+
+- 회고: `trade_retrospective_service.py:96-105 _normalize_symbol`
+  - crypto → `KRW-<COIN>` (dash, upper)
+  - equity_us → `to_db_symbol(x).upper()` = `-`/`/`→`.`, upper → 예 `BRK.B`
+  - equity_kr/기타 → upper only (숫자코드 무변)
+- 예측: `forecast_tools.py:53` = `.strip()`만 (upper/구분자 정규화 **없음**).
+  → 같은 종목이라도 대소문자/구분자가 다를 수 있음(`BRK-B` vs `BRK.B`,
+  `btc` vs `KRW-BTC`).
+
+따라서 프런트 canonical 키는 **양쪽을 같은 형태로 접는다**: equity는
+`upper + (-|/)→.`(app DB 관례 `to_db_symbol`와 동형), crypto는 기존
+`stockDetailRouteSymbol("crypto", …)`(→ `KRW-BTC`) 재사용. market으로 접두(kr/us/
+crypto) 하여 크로스마켓 충돌을 배제한다.
+
+## 파일별 변경
+
+### 신규: `frontend/invest/src/insightsCrosslink.ts`
+
+크로스링크 심볼 키 헬퍼(순수 함수, 두 패널 공용 — 키 산출이 갈라지면 링크가 다시
+죽으므로 단일 소스로 강제).
+
+```ts
+import { stockDetailRouteSymbol } from "./stockDetailPath";
+
+export type CrosslinkMarket = "kr" | "us" | "crypto";
+
+// forecast instrument_type("equity_kr"|"equity_us"|"crypto") → market
+export function forecastMarket(instrumentType: string | null): CrosslinkMarket | null;
+
+// retro는 market(str) 우선, 없으면 instrument_type로 폴백
+export function retroMarket(
+  market: string | null,
+  instrumentType: string | null,
+): CrosslinkMarket | null;
+
+// 교집합 canonical 키. market·symbol 중 하나라도 없으면 null(링크 제외).
+//   crypto → `crypto:${stockDetailRouteSymbol("crypto", s)}`  (예 crypto:KRW-BTC)
+//   kr/us  → `${market}:${s.toUpperCase().replace(/[-/]/g, ".")}` (예 us:BRK.B, kr:000660)
+export function crosslinkKey(market: CrosslinkMarket | null, symbol: string): string | null;
+
+// 앵커/URL-fragment 안전 slug: 영숫자 외 → "-"
+//   us:BRK.B → us-BRK-B, crypto:KRW-BTC → crypto-KRW-BTC, kr:000660 → kr-000660
+export function crosslinkAnchorSlug(key: string): string;
+```
+
+- `INSTRUMENT_MARKET` 맵(`equity_kr→kr` 등)은 이 모듈에 단일 정의.
+  `ForecastCalibrationPanel.tsx:33-37`의 로컬 복제는 유지(돈/href 표시용)하되,
+  **크로스링크 키만** 이 모듈을 경유(블라스트 반경 최소화). 선택적으로 로컬
+  맵도 `forecastMarket`로 대체 가능(리스크·결정 필요 참조).
+
+### 수정: `frontend/invest/src/components/insights/ForecastCalibrationPanel.tsx`
+
+- import 추가: `forecastMarket, crosslinkKey, crosslinkAnchorSlug` from
+  `"../../insightsCrosslink"`.
+- Props(`351-359`) 이름 변경(내부 API, additive-safe):
+  `onClosedCorrelationIds` → `onClosedSymbolKeys`,
+  `linkedCorrelationIds` → `linkedSymbolKeys`.
+- 보고 effect(`402-408`): closed 행 → `crosslinkKey(forecastMarket(r.instrument_type), r.symbol)`
+  로 매핑, non-null 필터 + **중복 제거**(Set) 후 `onClosedSymbolKeys(keys)`.
+- `ClosedList`(`282-332`):
+  - prop `linkedCorrelationIds` → `linkedSymbolKeys`.
+  - map 밖에 `const anchored = new Set<string>()` 선언(앵커 id 중복 제거용).
+  - 행마다 `const key = crosslinkKey(forecastMarket(r.instrument_type), r.symbol)`,
+    `const slug = key ? crosslinkAnchorSlug(key) : null`,
+    `const linked = key != null && (linkedSymbolKeys?.has(key) ?? false)`.
+  - 앵커 id: `id={linked && slug && !anchored.has(key) ? \`forecast-${slug}\` : undefined}`
+    (첫 행에만 부여; 이후 `anchored.add(key)`). — 한 종목이 여러 closed 예측을
+    가질 때 **id 중복(invalid HTML)** 방지.
+  - 링크: `<a href={\`#retro-${slug}\`}>회고↓</a>`.
+
+### 수정: `frontend/invest/src/components/my/RetrospectivesPanel.tsx`
+
+(공유 패널 — /my desktop·mobile에서도 사용. 크로스링크 props는 optional이라
+그쪽은 no-op 유지 = additive-only.)
+
+- import 추가: `retroMarket, crosslinkKey, crosslinkAnchorSlug`.
+- Props(`73-81`) 이름 변경: `onCorrelationIds` → `onSymbolKeys`,
+  `linkedCorrelationIds` → `linkedSymbolKeys`.
+- 보고 effect(`114-120`): 행 → `crosslinkKey(retroMarket(r.market, r.instrument_type), r.symbol)`
+  매핑, non-null + 중복 제거 후 `onSymbolKeys(keys)`.
+- 행 렌더(`183-211`):
+  - `rows.map` 밖에 `const anchored = new Set<string>()`.
+  - `const key = crosslinkKey(retroMarket(row.market, row.instrument_type), row.symbol)`,
+    `slug`, `linked = key != null && (linkedSymbolKeys?.has(key) ?? false)`.
+  - 앵커 id: 첫 행에만 `retro-${slug}` (dedupe), 링크
+    `<a href={\`#forecast-${slug}\`}>예측↑</a>`.
+
+### 수정: `frontend/invest/src/pages/desktop/DesktopInsightsPage.tsx`
+
+- 상태 이름 변경(`127-134`):
+  `closedForecastIds` → `closedForecastKeys`, `retroIds` → `retroKeys`,
+  memo `linkedCorrelationIds` → `linkedSymbolKeys` (교집합 로직 동일).
+- 주석(`127-128`) 갱신: "by correlation_id" → "by normalized symbol key (ROB-682)".
+- 패널 배선(`152-165`):
+  `<ForecastCalibrationPanel onClosedSymbolKeys={setClosedForecastKeys} linkedSymbolKeys={linkedSymbolKeys} … />`,
+  `<RetrospectivesPanel onSymbolKeys={setRetroKeys} linkedSymbolKeys={linkedSymbolKeys} />`.
+
+### 테스트 파일(수정/신규)
+
+- 신규 `frontend/invest/src/__tests__/insightsCrosslink.test.ts` — 헬퍼 단위.
+- 수정 `frontend/invest/src/__tests__/ForecastCalibrationPanel.test.tsx`
+  (ROB-678 케이스 `157-178` 재작성).
+- 수정 `frontend/invest/src/__tests__/RetrospectivesPanel.test.tsx`
+  (ROB-678 케이스 `51-69` 재작성).
+- 수정 `frontend/invest/src/__tests__/DesktopInsightsPage.test.tsx`
+  (disjoint corr_id + same symbol 회귀 테스트 추가).
+
+## 구현 단계
+
+1. **헬퍼 모듈 신설** — `insightsCrosslink.ts`에 `forecastMarket`, `retroMarket`,
+   `crosslinkKey`, `crosslinkAnchorSlug` 작성. crypto는 `stockDetailRouteSymbol`
+   재사용, equity는 `upper + (-|/)→.`.
+2. **헬퍼 단위 테스트** — `insightsCrosslink.test.ts`:
+   - `crosslinkKey(forecastMarket("equity_us"), "BRK-B") === "us:BRK.B"` 이고
+     `crosslinkKey(forecastMarket("equity_us"), "brk.b") === "us:BRK.B"` (양쪽 접힘).
+   - `crosslinkKey("crypto", "btc") === "crypto:KRW-BTC"`,
+     `crosslinkKey("crypto", "KRW-BTC") === "crypto:KRW-BTC"`.
+   - `crosslinkKey("kr", "000660") === "kr:000660"`.
+   - `retroMarket("kr", null) === "kr"`, `retroMarket(null, "equity_us") === "us"`,
+     `retroMarket(null, null) === null`, `crosslinkKey(null, "X") === null`.
+   - `crosslinkAnchorSlug("us:BRK.B") === "us-BRK-B"`.
+3. **ForecastCalibrationPanel 재배선** — props rename, 보고 effect를 심볼 키로,
+   `ClosedList` 앵커/링크를 slug + dedupe로 교체.
+4. **RetrospectivesPanel 재배선** — 동일 패턴(공유 패널이므로 optional props
+   유지 확인).
+5. **DesktopInsightsPage 재배선** — 상태/ memo/ prop 이름 및 교집합.
+6. **패널 테스트 갱신** — 아래 "테스트" 참조.
+7. **DesktopInsightsPage 통합 회귀 테스트** 추가.
+8. `cd frontend/invest && npm run typecheck && npm test` 그린 확인.
+
+## 테스트
+
+- `insightsCrosslink.test.ts` (신규, 단위): 위 2단계 케이스.
+- `ForecastCalibrationPanel.test.tsx` — ROB-678 케이스 재작성:
+  closed 예측 심볼 `AAPL`/`equity_us`, correlation_id는 **무관한 thesis-style**
+  (예 `"aapl-thesis-0704"`). `<ForecastCalibrationPanel linkedSymbolKeys={new Set(["us:AAPL"])} />`.
+  단언: `link href === "#retro-us-AAPL"`, `getElementById("forecast-us-AAPL")` 존재.
+- `RetrospectivesPanel.test.tsx` — ROB-678 케이스 재작성:
+  회고 심볼 `005930`/`market:"kr"`, corr_id는 exec-style(`"toss_live:x"`).
+  `linkedSymbolKeys={new Set(["kr:005930"])}`. 단언: `href === "#forecast-kr-005930"`,
+  `getElementById("retro-kr-005930")` 존재.
+- `DesktopInsightsPage.test.tsx` — **핵심 회귀**: fetch mock으로 calibration/open/
+  closed(심볼 `AAPL`, corr `"aapl-thesis"`) + retrospectives(심볼 `AAPL`, corr
+  `"toss_live:uuid"`) + next-actions 반환. corr_id는 서로 disjoint지만 심볼 동일 →
+  크로스링크 `회고↓`/`예측↑` 링크가 렌더됨을 단언(ROB-678 스킴이었다면 dead).
+  추가로 두 축 심볼이 다른 경우(교집합 없음)엔 링크 부재도 단언.
+- 전체: `npm run typecheck`, `npm test` 그린.
+
+## 리스크·결정 필요
+
+**결정 필요(사용자 사인오프 후 구현):**
+
+1. **앵커 id 충돌 처리** — 한 종목이 closed 예측 N개 + 회고 M개를 가질 수 있어
+   `#forecast-<symbol>`/`#retro-<symbol>`가 모호. **권장(v1)**: 종목당 **첫 행에만**
+   앵커 id 부여(dedupe), 링크는 그 첫 행으로 점프(순수 앵커, JS 무). 링크는 모든
+   매칭 행에 표시 가능. **선택 확장(defer)**: "회고 N건↓" 카운트 배지 — 각 패널이
+   상대 축의 건수를 모르므로 페이지가 `Map<key,{forecastN,retroN}>`를 추가로 내려야
+   함(플럼빙 증가). scroll+highlight(JS)도 옵션. → 승인 요청: v1=첫 행 앵커로 확정?
+2. **키 입도(granularity)** — `market:symbol`(예 `kr:000660`) vs bare `symbol`.
+   **권장**: market 접두(크로스마켓 동일 티커 오매칭 방지). market이 한쪽이라도
+   null이면 링크 제외. → 승인: market-qualified 확정?
+3. **날짜 근접 필터(optional)** — 심볼-only는 같은 종목의 **오래된 무관한 회고**를
+   최신 예측에 링크할 수 있음. **권장(v1)**: 필터 OFF(심볼-only 단순). 필요 시
+   forecast `resolved_at` ↔ retro `created_at` ±N일 창 가드 추가 가능(양측 날짜
+   존재 시에만). → 승인: v1에서 근접 필터 생략 OK? (원하면 N일 값 지정)
+4. **구분자 정규화** — equity는 `upper + (-|/)→.`(app `to_db_symbol` 동형, 회고
+   서버 저장형 `BRK.B`와 일치). crypto는 `KRW-<COIN>`. → 승인: 이 정규화 규칙 OK?
+   (엣지: crypto 심볼이 dot형 `BTC.KRW`로 오면 `normalizeCryptoRouteSymbol`이
+   오정규화 가능 — 실데이터는 Upbit `KRW-BTC` 형이라 발생 가능성 낮음. 리스크로
+   기록.)
+5. **prop 이름 변경** — 공유 `RetrospectivesPanel`의 크로스링크 props를
+   correlation→symbolKey 의미로 rename. /my(desktop·mobile)는 미전달이라 무영향
+   (additive-only). → 관례상 진행하되 확인.
+
+**리스크:**
+
+- **ROB-681과 파일 충돌**: `DesktopInsightsPage.tsx`를 양쪽이 편집 → 병합 시
+  섹션 배선/ import 충돌 가능. 상태·memo·패널 prop 라인이 근접하므로 rebase 주의.
+- **키 산출 드리프트**: 두 패널이 다른 방식으로 키를 만들면 링크가 재-사망.
+  단일 `insightsCrosslink.ts`로 강제하여 완화.
+- crypto dot형 오정규화(위 4의 엣지) — 실데이터에선 저확률, 헬퍼 테스트로
+  KRW- 형 커버.
+- 서버 정규화 변경이 미래에 갈라지면 매칭 실패 — 프런트 정규화가 서버(`to_db_symbol`,
+  `_normalize_symbol`)와 동형임을 주석으로 명시해 회귀 방지.
+
+**스코프 밖 확인:** `/insights`는 `routes.tsx:86`에서 `DesktopInsightsPage`로
+직결(모바일 뷰포트 dispatch 없음) — 크로스링크는 데스크톱 인사이트에만 존재.
+백엔드/API/스키마 변경 없음(순수 프런트 read-only). DB·migration 0.

--- a/frontend/invest/src/__tests__/DesktopInsightsPage.test.tsx
+++ b/frontend/invest/src/__tests__/DesktopInsightsPage.test.tsx
@@ -179,3 +179,79 @@ test("renders an empty market parity state without hiding the page", () => {
   expect(screen.getByText("승인된 패리티 카드가 없습니다.")).toBeInTheDocument();
   expect(screen.getByText("삼성전자 / 삼성전자우")).toBeInTheDocument();
 });
+
+// Builds a full-page fetch mock (calibration/open/closed/artifacts/
+// session-context/next-actions/retrospectives) with one closed forecast
+// (symbol AAPL, thesis-style correlation_id) and one retrospective whose
+// symbol is the given `retroSymbol` (exec-style correlation_id). The two
+// correlation_ids are always disjoint — under ROB-678's exact-id scheme the
+// crosslink would never render regardless of symbol overlap.
+function buildCrosslinkFetchMock(retroSymbol: string) {
+  return vi.fn(async (url: string) => {
+    const u = String(url);
+    let body: unknown = {};
+    if (u.includes("/calibration")) {
+      body = { group_by: "created_by", created_by: null, symbol: null, instrument_type: null, days: null, count: 0, groups: [], as_of: "2026-07-03T00:00:00Z" };
+    } else if (u.includes("/forecasts/open")) {
+      body = { kind: "open", symbol: null, created_by: null, instrument_type: null, count: 0, items: [], as_of: "2026-07-03T00:00:00Z" };
+    } else if (u.includes("/forecasts/closed")) {
+      body = {
+        kind: "closed", symbol: null, created_by: null, instrument_type: null, count: 1, as_of: "2026-07-03T00:00:00Z",
+        items: [{
+          id: 1, forecast_id: "f1", correlation_id: "aapl-thesis", created_by: "claude",
+          session_label: null, model_label: null, symbol: "AAPL", instrument_type: "equity_us",
+          forecast_target: null, horizon: null, probability: 0.7, probability_range_low: null,
+          probability_range_high: null, resolution_source: null, review_date: "2026-06-20",
+          status: "closed", outcome: true, observed_value: 175.5, resolved_at: "2026-06-21T00:00:00Z",
+          brier_score: 0.09, created_at: "2026-06-10T00:00:00Z",
+        }],
+      };
+    } else if (u.includes("/artifacts")) {
+      body = { success: true, count: 0, filters: {}, artifacts: [] };
+    } else if (u.includes("/session-context")) {
+      body = { success: true, count: 0, filters: {}, entries: [] };
+    } else if (u.includes("next-actions")) {
+      body = { market: "all", symbol: null, count: 0, scan_limit: 200, items: [] };
+    } else if (u.includes("retrospectives")) {
+      body = {
+        market: "all", trigger_type: null, root_cause_class: null, symbol: null, count: 1, total: 1, as_of: "2026-07-03T00:00:00Z",
+        items: [{
+          id: 1, correlation_id: "toss_live:uuid", symbol: retroSymbol, market: "us",
+          instrument_type: "equity_us", side: "sell", trigger_type: "fill", root_cause_class: null,
+          outcome: "win", realized_pnl: 100, realized_pnl_currency: "USD", pnl_pct: 1.2,
+          result_summary: null, lesson: `${retroSymbol} 매도 회고`, next_strategy: null,
+          intended_vs_happened: null, next_actions: null, guardrail_fired: null,
+          policy_version: null, created_at: "2026-07-01T00:00:00Z",
+        }],
+      };
+    }
+    return { ok: true, status: 200, json: async () => body };
+  });
+}
+
+test("crosslinks closed forecast <-> retrospective by symbol key, not correlation_id (ROB-682)", async () => {
+  vi.stubGlobal("fetch", buildCrosslinkFetchMock("AAPL") as unknown as typeof fetch);
+
+  render(wrap(<DesktopInsightsPage />));
+
+  // correlation_ids ("aapl-thesis" vs "toss_live:uuid") are disjoint — under
+  // ROB-678's exact-correlation_id scheme this crosslink would be dead.
+  const forecastLink = await screen.findByRole("link", { name: /회고/ });
+  expect(forecastLink).toHaveAttribute("href", "#retro-us-AAPL");
+  expect(document.getElementById("forecast-us-AAPL")).not.toBeNull();
+
+  const retroLink = await screen.findByRole("link", { name: "예측↑" });
+  expect(retroLink).toHaveAttribute("href", "#forecast-us-AAPL");
+  expect(document.getElementById("retro-us-AAPL")).not.toBeNull();
+});
+
+test("does not crosslink when symbols differ across axes (ROB-682)", async () => {
+  vi.stubGlobal("fetch", buildCrosslinkFetchMock("TSLA") as unknown as typeof fetch);
+
+  render(wrap(<DesktopInsightsPage />));
+
+  await screen.findByText("AAPL");
+  await screen.findByText(/TSLA 매도 회고/);
+  expect(screen.queryByRole("link", { name: /회고/ })).toBeNull();
+  expect(screen.queryByRole("link", { name: "예측↑" })).toBeNull();
+});

--- a/frontend/invest/src/__tests__/ForecastCalibrationPanel.test.tsx
+++ b/frontend/invest/src/__tests__/ForecastCalibrationPanel.test.tsx
@@ -154,10 +154,13 @@ test("calibration table sorts client-side on header click (ROB-675)", async () =
   expect(bodyGroups()).toEqual(["alpha", "beta"]);
 });
 
-test("closed forecast crosslinks to its retrospective when linked (ROB-678)", async () => {
+test("closed forecast crosslinks to its retrospective by symbol key (ROB-682)", async () => {
+  // correlation_id is deliberately unrelated thesis-style text — the
+  // crosslink no longer keys on it (ROB-678's exact-id scheme was
+  // structurally dead since forecast/retro correlation_ids never overlap).
   const closedLinked: ForecastListResponse = {
     ...closed,
-    items: [{ ...closed.items[0]!, correlation_id: "corr-1" }],
+    items: [{ ...closed.items[0]!, correlation_id: "aapl-thesis-0704" }],
   };
   const fetchMock = vi.fn((url: string) => {
     const u = String(url);
@@ -168,11 +171,11 @@ test("closed forecast crosslinks to its retrospective when linked (ROB-678)", as
 
   render(
     <MemoryRouter>
-      <ForecastCalibrationPanel linkedCorrelationIds={new Set(["corr-1"])} />
+      <ForecastCalibrationPanel linkedSymbolKeys={new Set(["us:AAPL"])} />
     </MemoryRouter>,
   );
 
   const link = await screen.findByRole("link", { name: /회고/ });
-  expect(link).toHaveAttribute("href", "#retro-corr-1");
-  expect(document.getElementById("forecast-corr-1")).not.toBeNull();
+  expect(link).toHaveAttribute("href", "#retro-us-AAPL");
+  expect(document.getElementById("forecast-us-AAPL")).not.toBeNull();
 });

--- a/frontend/invest/src/__tests__/RetrospectivesPanel.test.tsx
+++ b/frontend/invest/src/__tests__/RetrospectivesPanel.test.tsx
@@ -48,22 +48,29 @@ test("renders pinned next-action checklist and retrospective row", async () => {
   expect(screen.getByText(/분할 매수가 유효했다/)).toBeInTheDocument();
 });
 
-test("retrospective crosslinks to its forecast when linked (ROB-678)", async () => {
+test("retrospective crosslinks to its forecast by symbol key (ROB-682)", async () => {
+  // correlation_id is deliberately exec-style text ("toss_live:x") — the
+  // crosslink no longer keys on it (ROB-678's exact-id scheme was
+  // structurally dead since forecast/retro correlation_ids never overlap).
+  const listExec: RetrospectivesResponse = {
+    ...list,
+    items: [{ ...list.items[0]!, correlation_id: "toss_live:x" }],
+  };
   const fetchMock = vi.fn((url: string) =>
     Promise.resolve({
       ok: true,
-      json: async () => (String(url).includes("next-actions") ? na : list),
+      json: async () => (String(url).includes("next-actions") ? na : listExec),
     }),
   );
   vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
 
   render(
     <MemoryRouter>
-      <RetrospectivesPanel linkedCorrelationIds={new Set(["c"])} />
+      <RetrospectivesPanel linkedSymbolKeys={new Set(["kr:005930"])} />
     </MemoryRouter>,
   );
 
   const link = await screen.findByRole("link", { name: "예측↑" });
-  expect(link).toHaveAttribute("href", "#forecast-c");
-  expect(document.getElementById("retro-c")).not.toBeNull();
+  expect(link).toHaveAttribute("href", "#forecast-kr-005930");
+  expect(document.getElementById("retro-kr-005930")).not.toBeNull();
 });

--- a/frontend/invest/src/__tests__/insightsCrosslink.test.ts
+++ b/frontend/invest/src/__tests__/insightsCrosslink.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from "vitest";
+import {
+  crosslinkAnchorSlug,
+  crosslinkKey,
+  forecastMarket,
+  retroMarket,
+} from "../insightsCrosslink";
+
+describe("forecastMarket", () => {
+  test("maps known instrument_type values", () => {
+    expect(forecastMarket("equity_kr")).toBe("kr");
+    expect(forecastMarket("equity_us")).toBe("us");
+    expect(forecastMarket("crypto")).toBe("crypto");
+  });
+
+  test("returns null for unknown/missing instrument_type", () => {
+    expect(forecastMarket(null)).toBeNull();
+    expect(forecastMarket("bond")).toBeNull();
+  });
+});
+
+describe("retroMarket", () => {
+  test("prefers the explicit market column", () => {
+    expect(retroMarket("kr", null)).toBe("kr");
+    expect(retroMarket("kr", "equity_us")).toBe("kr");
+  });
+
+  test("falls back to instrument_type when market is missing", () => {
+    expect(retroMarket(null, "equity_us")).toBe("us");
+  });
+
+  test("returns null when neither side resolves", () => {
+    expect(retroMarket(null, null)).toBeNull();
+    expect(retroMarket("all", null)).toBeNull();
+  });
+});
+
+describe("crosslinkKey", () => {
+  test("folds equity symbols: upper + separators -> .", () => {
+    expect(crosslinkKey(forecastMarket("equity_us"), "BRK-B")).toBe("us:BRK.B");
+    expect(crosslinkKey(forecastMarket("equity_us"), "brk.b")).toBe("us:BRK.B");
+    expect(crosslinkKey("us", "BRK/B")).toBe("us:BRK.B");
+  });
+
+  test("folds crypto symbols via stockDetailRouteSymbol", () => {
+    expect(crosslinkKey("crypto", "btc")).toBe("crypto:KRW-BTC");
+    expect(crosslinkKey("crypto", "KRW-BTC")).toBe("crypto:KRW-BTC");
+  });
+
+  test("kr keeps numeric codes unchanged", () => {
+    expect(crosslinkKey("kr", "000660")).toBe("kr:000660");
+  });
+
+  test("returns null when market is null or symbol is empty", () => {
+    expect(crosslinkKey(null, "X")).toBeNull();
+    expect(crosslinkKey("kr", "  ")).toBeNull();
+  });
+});
+
+describe("crosslinkAnchorSlug", () => {
+  test("folds non-alphanumeric characters to '-'", () => {
+    expect(crosslinkAnchorSlug("us:BRK.B")).toBe("us-BRK-B");
+    expect(crosslinkAnchorSlug("crypto:KRW-BTC")).toBe("crypto-KRW-BTC");
+    expect(crosslinkAnchorSlug("kr:000660")).toBe("kr-000660");
+  });
+});

--- a/frontend/invest/src/components/insights/ForecastCalibrationPanel.tsx
+++ b/frontend/invest/src/components/insights/ForecastCalibrationPanel.tsx
@@ -7,6 +7,7 @@ import {
   fetchOpenForecasts,
 } from "../../api/forecasts";
 import { Card, Pill } from "../../ds";
+import { crosslinkAnchorSlug, crosslinkKey, forecastMarket } from "../../insightsCrosslink";
 import { stockDetailPath } from "../../stockDetailPath";
 import { formatWatchMoney } from "../my/watchPresentation";
 import type {
@@ -281,10 +282,10 @@ function OpenList({ rows }: { rows: ForecastRow[] }) {
 
 function ClosedList({
   rows,
-  linkedCorrelationIds,
+  linkedSymbolKeys,
 }: {
   rows: ForecastRow[];
-  linkedCorrelationIds?: ReadonlySet<string>;
+  linkedSymbolKeys?: ReadonlySet<string>;
 }) {
   if (rows.length === 0) {
     return (
@@ -293,16 +294,26 @@ function ClosedList({
       </div>
     );
   }
+  // Anchor ids are keyed by symbol, so a symbol with multiple closed forecasts
+  // would otherwise emit duplicate DOM ids. Only the first matching row per
+  // key gets the anchor; the crosslink `<a>` still renders on every match.
+  const anchored = new Set<string>();
   return (
     <div style={{ display: "grid", gap: 6 }}>
       {rows.map((r) => {
         const target = formatForecastTarget(r);
         const market = r.instrument_type ? INSTRUMENT_MARKET[r.instrument_type] : undefined;
-        const linked = r.correlation_id != null && (linkedCorrelationIds?.has(r.correlation_id) ?? false);
+        const key = crosslinkKey(forecastMarket(r.instrument_type), r.symbol);
+        const slug = key != null ? crosslinkAnchorSlug(key) : null;
+        const linked = key != null && (linkedSymbolKeys?.has(key) ?? false);
+        const anchorId = linked && key != null && slug != null && !anchored.has(key)
+          ? `forecast-${slug}`
+          : undefined;
+        if (anchorId != null && key != null) anchored.add(key);
         return (
           <div
             key={r.id}
-            id={linked ? `forecast-${r.correlation_id}` : undefined}
+            id={anchorId}
             style={{ display: "flex", alignItems: "center", gap: 8, fontSize: 13, padding: "2px 0", flexWrap: "wrap" }}
           >
             <Pill tone={r.outcome ? "gain" : "loss"} size="sm">{r.outcome ? "적중" : "빗나감"}</Pill>
@@ -316,9 +327,9 @@ function ClosedList({
             {r.resolved_at && (
               <span style={{ color: "var(--fg-3)", fontSize: 11 }}>· {r.resolved_at.slice(0, 10)}</span>
             )}
-            {linked && (
+            {linked && slug != null && (
               <a
-                href={`#retro-${r.correlation_id}`}
+                href={`#retro-${slug}`}
                 style={{ color: "var(--link, #4a9)", textDecoration: "none", fontSize: 11 }}
               >
                 · 회고↓
@@ -350,12 +361,12 @@ function Section({ title, hint, children }: { title: string; hint?: string; chil
 
 export function ForecastCalibrationPanel({
   onEmptyChange,
-  onClosedCorrelationIds,
-  linkedCorrelationIds,
+  onClosedSymbolKeys,
+  linkedSymbolKeys,
 }: {
   onEmptyChange?: (isEmpty: boolean) => void;
-  onClosedCorrelationIds?: (ids: string[]) => void;
-  linkedCorrelationIds?: ReadonlySet<string>;
+  onClosedSymbolKeys?: (keys: string[]) => void;
+  linkedSymbolKeys?: ReadonlySet<string>;
 } = {}) {
   const [groupBy, setGroupBy] = useState<ForecastGroupBy>("created_by");
   const [days, setDays] = useState<number | "all">(90);
@@ -397,15 +408,17 @@ export function ForecastCalibrationPanel({
     onEmptyChange(flags.every((f) => f === true));
   }, [calib, open, closed, onEmptyChange]);
 
-  // Report closed-forecast correlation_ids so the page can crosslink them to
-  // matching retrospectives (ROB-678).
+  // Report closed-forecast symbol keys so the page can crosslink them to
+  // matching retrospectives (ROB-682 — re-keyed from correlation_id, which was
+  // structurally dead: the two id namespaces never overlap).
   useEffect(() => {
-    if (!onClosedCorrelationIds) return;
+    if (!onClosedSymbolKeys) return;
     if (closed.status !== "ready") return;
-    onClosedCorrelationIds(
-      closed.data.map((r) => r.correlation_id).filter((c): c is string => c != null),
-    );
-  }, [closed, onClosedCorrelationIds]);
+    const keys = closed.data
+      .map((r) => crosslinkKey(forecastMarket(r.instrument_type), r.symbol))
+      .filter((k): k is string => k != null);
+    onClosedSymbolKeys(Array.from(new Set(keys)));
+  }, [closed, onClosedSymbolKeys]);
 
   return (
     <Card>
@@ -470,7 +483,7 @@ export function ForecastCalibrationPanel({
         <Section title="최근 채점 결과" hint="가장 최근에 해소된 예측.">
           {closed.status === "loading" && <div style={{ padding: 16, color: "var(--fg-3)", fontSize: 13, textAlign: "center" }}>불러오는 중…</div>}
           {closed.status === "error" && <div role="alert" style={{ padding: 12, color: "var(--danger)", fontSize: 13 }}>채점 결과를 불러오지 못했습니다. {closed.message}</div>}
-          {closed.status === "ready" && <ClosedList rows={closed.data} linkedCorrelationIds={linkedCorrelationIds} />}
+          {closed.status === "ready" && <ClosedList rows={closed.data} linkedSymbolKeys={linkedSymbolKeys} />}
         </Section>
       </section>
     </Card>

--- a/frontend/invest/src/components/my/RetrospectivesPanel.tsx
+++ b/frontend/invest/src/components/my/RetrospectivesPanel.tsx
@@ -3,6 +3,7 @@ import { Link } from "react-router-dom";
 
 import { fetchOpenNextActions, fetchRetrospectives } from "../../api/retrospectives";
 import { Pill } from "../../ds";
+import { crosslinkAnchorSlug, crosslinkKey, retroMarket } from "../../insightsCrosslink";
 import { stockDetailPath } from "../../stockDetailPath";
 import type {
   NextActionRow,
@@ -72,12 +73,12 @@ function NextActionChecklist({ items }: { items: NextActionRow[] }) {
 
 export function RetrospectivesPanel({
   compact = false,
-  onCorrelationIds,
-  linkedCorrelationIds,
+  onSymbolKeys,
+  linkedSymbolKeys,
 }: {
   compact?: boolean;
-  onCorrelationIds?: (ids: string[]) => void;
-  linkedCorrelationIds?: ReadonlySet<string>;
+  onSymbolKeys?: (keys: string[]) => void;
+  linkedSymbolKeys?: ReadonlySet<string>;
 }) {
   const [market, setMarket] = useState<RetroMarket>("all");
   const [triggerType, setTriggerType] = useState<string>("");
@@ -109,15 +110,18 @@ export function RetrospectivesPanel({
     return () => { cancelled = true; };
   }, [market]);
 
-  // Report retrospective correlation_ids so a host page can crosslink them to
-  // matching closed forecasts (ROB-678). No-op off /insights (prop undefined).
+  // Report retrospective symbol keys so a host page can crosslink them to
+  // matching closed forecasts (ROB-682 — re-keyed from correlation_id, which
+  // was structurally dead: forecast/retro id namespaces never overlap).
+  // No-op off /insights (prop undefined) — /my never passes this prop.
   useEffect(() => {
-    if (!onCorrelationIds) return;
+    if (!onSymbolKeys) return;
     if (state.status !== "ready") return;
-    onCorrelationIds(
-      state.items.map((r) => r.correlation_id).filter((c): c is string => c != null),
-    );
-  }, [state, onCorrelationIds]);
+    const keys = state.items
+      .map((r) => crosslinkKey(retroMarket(r.market, r.instrument_type), r.symbol))
+      .filter((k): k is string => k != null);
+    onSymbolKeys(Array.from(new Set(keys)));
+  }, [state, onSymbolKeys]);
 
   const rows = useMemo(() => (state.status === "ready" ? state.items : []), [state]);
 
@@ -180,37 +184,50 @@ export function RetrospectivesPanel({
               </tr>
             </thead>
             <tbody>
-              {rows.map((row) => {
-                const href = row.market ? stockDetailPath(row.market as "kr" | "us" | "crypto", row.symbol) : null;
-                const linked = row.correlation_id != null && (linkedCorrelationIds?.has(row.correlation_id) ?? false);
-                return (
-                  <tr key={row.id} id={linked ? `retro-${row.correlation_id}` : undefined}>
-                    <td style={{ padding: "10px 14px", borderBottom: "1px solid var(--divider)", fontSize: 13, fontWeight: 700 }}>
-                      {href ? <Link to={href} style={{ color: "inherit", textDecoration: "none" }}>{row.symbol}</Link> : row.symbol}
-                    </td>
-                    <td style={{ padding: "10px 14px", borderBottom: "1px solid var(--divider)", fontSize: 12 }}>
-                      <div style={{ display: "flex", gap: 4, flexWrap: "wrap" }}>
-                        {row.trigger_type && <Pill tone="paper" size="sm">{row.trigger_type}</Pill>}
-                        {row.root_cause_class && <Pill tone="paper" size="sm">{row.root_cause_class}</Pill>}
-                      </div>
-                    </td>
-                    <td style={{ padding: "10px 14px", borderBottom: "1px solid var(--divider)", fontSize: 13, textAlign: "right", fontFeatureSettings: '"tnum"' }}>
-                      {pnlText(row)}
-                    </td>
-                    <td style={{ padding: "10px 14px", borderBottom: "1px solid var(--divider)", fontSize: 12, color: "var(--fg-2)", maxWidth: 320 }}>
-                      {row.lesson ?? row.result_summary ?? "—"}
-                      {linked && (
-                        <a
-                          href={`#forecast-${row.correlation_id}`}
-                          style={{ marginLeft: 8, color: "var(--link, #4a9)", textDecoration: "none", whiteSpace: "nowrap" }}
-                        >
-                          예측↑
-                        </a>
-                      )}
-                    </td>
-                  </tr>
-                );
-              })}
+              {(() => {
+                // Anchor ids are keyed by symbol, so a symbol with multiple
+                // retrospectives would otherwise emit duplicate DOM ids. Only
+                // the first matching row per key gets the anchor; the
+                // crosslink `<a>` still renders on every match.
+                const anchored = new Set<string>();
+                return rows.map((row) => {
+                  const href = row.market ? stockDetailPath(row.market as "kr" | "us" | "crypto", row.symbol) : null;
+                  const key = crosslinkKey(retroMarket(row.market, row.instrument_type), row.symbol);
+                  const slug = key != null ? crosslinkAnchorSlug(key) : null;
+                  const linked = key != null && (linkedSymbolKeys?.has(key) ?? false);
+                  const anchorId = linked && key != null && slug != null && !anchored.has(key)
+                    ? `retro-${slug}`
+                    : undefined;
+                  if (anchorId != null && key != null) anchored.add(key);
+                  return (
+                    <tr key={row.id} id={anchorId}>
+                      <td style={{ padding: "10px 14px", borderBottom: "1px solid var(--divider)", fontSize: 13, fontWeight: 700 }}>
+                        {href ? <Link to={href} style={{ color: "inherit", textDecoration: "none" }}>{row.symbol}</Link> : row.symbol}
+                      </td>
+                      <td style={{ padding: "10px 14px", borderBottom: "1px solid var(--divider)", fontSize: 12 }}>
+                        <div style={{ display: "flex", gap: 4, flexWrap: "wrap" }}>
+                          {row.trigger_type && <Pill tone="paper" size="sm">{row.trigger_type}</Pill>}
+                          {row.root_cause_class && <Pill tone="paper" size="sm">{row.root_cause_class}</Pill>}
+                        </div>
+                      </td>
+                      <td style={{ padding: "10px 14px", borderBottom: "1px solid var(--divider)", fontSize: 13, textAlign: "right", fontFeatureSettings: '"tnum"' }}>
+                        {pnlText(row)}
+                      </td>
+                      <td style={{ padding: "10px 14px", borderBottom: "1px solid var(--divider)", fontSize: 12, color: "var(--fg-2)", maxWidth: 320 }}>
+                        {row.lesson ?? row.result_summary ?? "—"}
+                        {linked && slug != null && (
+                          <a
+                            href={`#forecast-${slug}`}
+                            style={{ marginLeft: 8, color: "var(--link, #4a9)", textDecoration: "none", whiteSpace: "nowrap" }}
+                          >
+                            예측↑
+                          </a>
+                        )}
+                      </td>
+                    </tr>
+                  );
+                });
+              })()}
             </tbody>
           </table>
           {state.status === "ready" && (

--- a/frontend/invest/src/insightsCrosslink.ts
+++ b/frontend/invest/src/insightsCrosslink.ts
@@ -1,0 +1,67 @@
+// Shared crosslink key helpers for /insights (ROB-682).
+//
+// ROB-678 wired the forecast↔retrospective crosslink on exact `correlation_id`
+// equality, but the two id namespaces are disjoint in practice (forecast side
+// is thesis-style free text; retro side is exec-style `toss_live:...` /
+// `live:<uuid>`), so the intersection was always empty and the anchors/links
+// never rendered. This module re-keys the crosslink on a normalized
+// market-qualified SYMBOL instead — the one thing both sides genuinely share.
+//
+// Both ForecastCalibrationPanel and RetrospectivesPanel MUST derive their keys
+// through this module only. If the two panels compute keys differently, the
+// crosslink goes dead again in the same way ROB-678's correlation_id scheme
+// did.
+//
+// Normalization mirrors the server side so the same instrument folds to the
+// same key on both axes:
+//   - equity (kr/us): `upper()` + separators `(-|/) → .`, matching
+//     `app/core/symbol.to_db_symbol` / `trade_retrospective_service._normalize_symbol`.
+//   - crypto: reuse `stockDetailRouteSymbol("crypto", …)` (→ `KRW-<COIN>`),
+//     which already folds dot-format crypto symbols (ROB-683).
+import { stockDetailRouteSymbol } from "./stockDetailPath";
+
+export type CrosslinkMarket = "kr" | "us" | "crypto";
+
+// forecast_row.instrument_type ("equity_kr" | "equity_us" | "crypto") → market.
+// Single definition for crosslink purposes — panels may keep their own local
+// copies for display concerns (money formatting, hrefs), but crosslink key
+// derivation must go through forecastMarket()/retroMarket() below.
+const INSTRUMENT_MARKET: Record<string, CrosslinkMarket> = {
+  equity_kr: "kr",
+  equity_us: "us",
+  crypto: "crypto",
+};
+
+function asCrosslinkMarket(value: string | null | undefined): CrosslinkMarket | null {
+  return value === "kr" || value === "us" || value === "crypto" ? value : null;
+}
+
+export function forecastMarket(instrumentType: string | null): CrosslinkMarket | null {
+  if (!instrumentType) return null;
+  return INSTRUMENT_MARKET[instrumentType] ?? null;
+}
+
+// Retrospective rows carry an explicit `market` column; fall back to
+// `instrument_type` only when market is missing (mirrors server precedence).
+export function retroMarket(
+  market: string | null,
+  instrumentType: string | null,
+): CrosslinkMarket | null {
+  return asCrosslinkMarket(market) ?? forecastMarket(instrumentType);
+}
+
+// Canonical crosslink key. Either side missing (market null/unknown, or an
+// empty symbol) drops the link entirely rather than risk a cross-market or
+// cross-instrument false match.
+export function crosslinkKey(market: CrosslinkMarket | null, symbol: string): string | null {
+  const trimmed = symbol.trim();
+  if (!market || !trimmed) return null;
+  if (market === "crypto") return `crypto:${stockDetailRouteSymbol("crypto", trimmed)}`;
+  return `${market}:${trimmed.toUpperCase().replace(/[-/]/g, ".")}`;
+}
+
+// URL-fragment / DOM-id safe slug for a crosslink key (anchors + hrefs).
+// Non-alphanumeric characters (":", ".", "-") all fold to "-".
+export function crosslinkAnchorSlug(key: string): string {
+  return key.replace(/[^a-zA-Z0-9]/g, "-");
+}

--- a/frontend/invest/src/pages/desktop/DesktopInsightsPage.tsx
+++ b/frontend/invest/src/pages/desktop/DesktopInsightsPage.tsx
@@ -124,14 +124,16 @@ export function DesktopInsightsPage() {
   const allDataEmpty =
     forecastEmpty === true && artifactEmpty === true && sessionEmpty === true;
 
-  // Crosslink closed forecasts ↔ retrospectives by correlation_id (ROB-678):
-  // only the intersection (ids present on both sides) gets anchors + links.
-  const [closedForecastIds, setClosedForecastIds] = useState<string[]>([]);
-  const [retroIds, setRetroIds] = useState<string[]>([]);
-  const linkedCorrelationIds = useMemo(() => {
-    const retro = new Set(retroIds);
-    return new Set(closedForecastIds.filter((id) => retro.has(id)));
-  }, [closedForecastIds, retroIds]);
+  // Crosslink closed forecasts ↔ retrospectives by normalized symbol key
+  // (ROB-682): only the intersection (keys present on both sides) gets
+  // anchors + links. Re-keyed from correlation_id (ROB-678), which was
+  // structurally dead — the forecast/retro id namespaces never overlap.
+  const [closedForecastKeys, setClosedForecastKeys] = useState<string[]>([]);
+  const [retroKeys, setRetroKeys] = useState<string[]>([]);
+  const linkedSymbolKeys = useMemo(() => {
+    const retro = new Set(retroKeys);
+    return new Set(closedForecastKeys.filter((key) => retro.has(key)));
+  }, [closedForecastKeys, retroKeys]);
 
   return (
     <DesktopShell
@@ -152,15 +154,15 @@ export function DesktopInsightsPage() {
           <Section title="판단 품질">
             <ForecastCalibrationPanel
               onEmptyChange={setForecastEmpty}
-              onClosedCorrelationIds={setClosedForecastIds}
-              linkedCorrelationIds={linkedCorrelationIds}
+              onClosedSymbolKeys={setClosedForecastKeys}
+              linkedSymbolKeys={linkedSymbolKeys}
             />
           </Section>
 
           <Section title="학습·회고">
             <RetrospectivesPanel
-              onCorrelationIds={setRetroIds}
-              linkedCorrelationIds={linkedCorrelationIds}
+              onSymbolKeys={setRetroKeys}
+              linkedSymbolKeys={linkedSymbolKeys}
             />
           </Section>
 

--- a/frontend/invest/src/pages/mobile/MobileInsightsPage.tsx
+++ b/frontend/invest/src/pages/mobile/MobileInsightsPage.tsx
@@ -1,9 +1,11 @@
 // /invest/insights (mobile) — read-only market insight cards.
 // Mirrors DesktopInsightsPage.tsx's panel set, section order, and page-local
-// coordination state (ROB-681). DesktopInsightsPage.tsx itself is not edited
-// here — ROB-682 owns that file — so the small non-exported helpers and the
+// coordination state (ROB-681). The small non-exported helpers and the
 // empty/crosslink coordination state below are duplicated rather than shared
-// (see docs/plans/ROB-681-mobile-insights-viewport-dispatch.md).
+// (see docs/plans/ROB-681-mobile-insights-viewport-dispatch.md); ROB-682
+// re-keyed the crosslink state on both this file and DesktopInsightsPage.tsx
+// in lockstep (symbol key instead of correlation_id) to keep the duplicate
+// copies from drifting apart.
 import { useMemo, useState, type ReactNode } from "react";
 import { Link } from "react-router-dom";
 import { CommonPreferredDisparityCardView } from "../../components/CommonPreferredDisparityCard";
@@ -130,14 +132,18 @@ export function MobileInsightsPage() {
   const allDataEmpty =
     forecastEmpty === true && artifactEmpty === true && sessionEmpty === true;
 
-  // Crosslink closed forecasts ↔ retrospectives by correlation_id (ROB-678):
-  // only the intersection (ids present on both sides) gets anchors + links.
-  const [closedForecastIds, setClosedForecastIds] = useState<string[]>([]);
-  const [retroIds, setRetroIds] = useState<string[]>([]);
-  const linkedCorrelationIds = useMemo(() => {
-    const retro = new Set(retroIds);
-    return new Set(closedForecastIds.filter((id) => retro.has(id)));
-  }, [closedForecastIds, retroIds]);
+  // Crosslink closed forecasts ↔ retrospectives by normalized symbol key
+  // (ROB-682): only the intersection (keys present on both sides) gets
+  // anchors + links. Re-keyed from correlation_id (ROB-678), which was
+  // structurally dead — the forecast/retro id namespaces never overlap.
+  // Mirrors DesktopInsightsPage.tsx's coordination state 1:1 (see file-header
+  // note on why this is duplicated rather than shared).
+  const [closedForecastKeys, setClosedForecastKeys] = useState<string[]>([]);
+  const [retroKeys, setRetroKeys] = useState<string[]>([]);
+  const linkedSymbolKeys = useMemo(() => {
+    const retro = new Set(retroKeys);
+    return new Set(closedForecastKeys.filter((key) => retro.has(key)));
+  }, [closedForecastKeys, retroKeys]);
 
   return (
     <MobileShell title="인사이트">
@@ -167,8 +173,8 @@ export function MobileInsightsPage() {
           <Section title="판단 품질">
             <ForecastCalibrationPanel
               onEmptyChange={setForecastEmpty}
-              onClosedCorrelationIds={setClosedForecastIds}
-              linkedCorrelationIds={linkedCorrelationIds}
+              onClosedSymbolKeys={setClosedForecastKeys}
+              linkedSymbolKeys={linkedSymbolKeys}
             />
           </Section>
         </div>
@@ -177,8 +183,8 @@ export function MobileInsightsPage() {
           <Section title="학습·회고">
             <RetrospectivesPanel
               compact
-              onCorrelationIds={setRetroIds}
-              linkedCorrelationIds={linkedCorrelationIds}
+              onSymbolKeys={setRetroKeys}
+              linkedSymbolKeys={linkedSymbolKeys}
             />
           </Section>
         </div>


### PR DESCRIPTION
## [insights J] forecast↔retro crosslink re-key (symbol join) — ROB-682

Post-deploy DB check found ROB-678's crosslink was **structurally dead**: forecast `correlation_id`s are thesis-style (`hynix-reentry-thesis-0703`) while retrospective ones are exec-style (`toss_live:…`/`live:<uuid>`) — disjoint namespaces, so the exact-match intersection is always empty even though the same symbol appears on both sides.

### Change (frontend-only, migration 0, read-only)
Re-key the crosslink from `correlation_id` to a normalized **market-qualified symbol key** via a new shared `insightsCrosslink.ts`:
- `crosslinkKey(market, symbol)` — `kr:000660`, `crypto:KRW-BTC` (crypto reuses `stockDetailRouteSymbol`, which already carries the ROB-683 dot fix); equity folds `upper + (-|/)→.` to match server `to_db_symbol`. Null when market/symbol missing.
- Forecast market from `instrument_type`; retro market from `RetrospectiveRow.market`.
- Panels rename props `correlation→symbolKey` (still optional → **`/my` unaffected**, verified: portfolio pages pass none). Anchors go to the **first** row per key; later matching rows still render the jump-link (no duplicate DOM id).
- **Both `DesktopInsightsPage` and `MobileInsightsPage`** updated (mobile had duplicated the dead ROB-678 coordination from ROB-681) — kept in sync.

### Verification
- New `insightsCrosslink.test.ts` (spec table) + rewired panel/page crosslink tests. New `DesktopInsightsPage` tests prove the link **now fires** on matching `us:AAPL` (dead under ROB-678) and does **not** fire on `AAPL` vs `TSLA`.
- typecheck 0; touched tests 22/22; full suite 533 pass / 5 pre-existing calendar-coverage fail.

Note: live it still needs *closed* forecasts to show (currently all open, review_date future — see ROB-684). Implemented via Sonnet subagent, independently verified. Base `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)