### PR TITLE
deploy: production ← main (ROB-680/681/682/683 insights follow-ups)

### DIFF
--- a/docs/plans/ROB-680-session-timeline-body-clamp.md
+++ b/docs/plans/ROB-680-session-timeline-body-clamp.md
@@ -1,0 +1,153 @@
+# ROB-680 — 세션 타임라인 본문 클램프 (판단 품질 above the fold)
+
+## 배경
+
+`/invest/insights`(desktop 전용, `src/routes.tsx` `{ path: "/insights", element: <DesktopInsightsPage /> }`)의
+**최근 핸드오프**(`SessionContextTimelinePanel`) 패널이 라이브에서 약 5370px 높이로
+페이지를 지배한다. 관측:
+
+- `fetchRecentSessionContext({ limit: 15 })` — 15행만 렌더하는데도 패널이 초대형.
+  라이브 데이터는 47건 중 34건(72%)이 `entry_type="decision"`.
+- 원인: `SessionRow`의 본문 div가 **본문 전체를 `white-space: pre-wrap`으로** 렌더한다
+  (`SessionContextTimelinePanel.tsx:77`):
+  ```tsx
+  <div style={{ fontSize: 13, opacity: 0.85, whiteSpace: "pre-wrap" }}>{entry.body}</div>
+  ```
+  긴 결정 메모(여러 줄/장문)가 그대로 펼쳐져 각 행이 수십~수백 px로 커진다.
+- 결과: 페이지 상단의 **판단 품질**(`ForecastCalibrationPanel`) 섹션이 아래로 밀려
+  스캔 불가. (섹션 순서는 ROB-677에서 이미 시장 관찰 → 판단 품질 → 학습·회고 →
+  세션 기록으로 정리됨. 그럼에도 세션 기록 패널 자체 높이가 페이지 전체 스크롤을
+  비대하게 만들고, 세션 기록 위 카드들의 "read density"를 떨어뜨림.)
+
+**목표**: 각 타임라인 행의 본문을 ~3줄로 시각적으로 클램프하고, 길이가 클램프
+임계를 넘는 행에만 per-row **더보기/접기** 토글(`useState`)을 붙여 타임라인을
+scannable하게 만든다. 이렇게 하면 세션 기록 패널이 압축되어 위 섹션들의 밀도가
+회복되고 판단 품질이 above the fold로 올라온다.
+
+**보존해야 할 기존 배선(회귀 금지)**:
+- ROB-673: `SessionRow` refs 푸터(심볼 `stockDetailPath` 링크 / `주문 …` / `리포트 …`).
+- ROB-676: `ENTRY_TYPE_TONE` Pill 색상 + `groupByDate` per-`kst_date` 그룹 헤더.
+- ROB-679: 행에는 시간만(`hhmm(entry.created_at)`), 날짜는 그룹 헤더에만.
+- ROB-677: `onEmptyChange` → 페이지 accumulating 배너.
+
+기존 코드베이스에 **동형 패턴이 이미 존재**하므로 그대로 차용한다:
+- CSS line-clamp: `src/components/signals/SignalCard.tsx:99-111`
+  (`display: -webkit-box` + `WebkitBoxOrient: "vertical"` + `WebkitLineClamp: 2` + `overflow: "hidden"`).
+- per-row 더보기/접기 토글 버튼: `src/components/news/NewsListItem.tsx:215-235`
+  (transparent 배경, `fontSize:12`, `fontWeight:700`, `aria-expanded`/`aria-controls`/`aria-label`,
+  라벨 `요약 접기`/`요약 보기`) 및 `src/components/discover/IssueCard.tsx:92-116`
+  (`aria-expanded` + `aria-controls` + 더보기/접기 aria-label).
+
+## 파일별 변경
+
+### 기존 파일
+
+1. **`frontend/invest/src/components/insights/SessionContextTimelinePanel.tsx`** (핵심)
+   - 파일 상단에 클램프 상수 추가: `const CLAMP_LINES = 3;` 와 본문이 "길다"고
+     간주할 임계 `const CLAMP_CHAR_THRESHOLD = 160;` (레이아웃 측정 없이 결정 가능한
+     content-based 휴리스틱 — jsdom 테스트 결정성 확보).
+   - 순수 헬퍼 `isBodyClampable(body: string): boolean` 추가:
+     `body.split("\n").length > CLAMP_LINES || body.length > CLAMP_CHAR_THRESHOLD`.
+   - 새 서브컴포넌트 `ExpandableBody({ body }: { body: string })`:
+     - `const [expanded, setExpanded] = useState(false);` — **per-row 로컬 상태**
+       (행은 `entry_uuid`로 keyed & ROB-676 그룹 내 순서 안정 → 로컬 상태 안전).
+     - `const clampable = isBodyClampable(body);`
+     - 본문 div: 항상 `whiteSpace: "pre-wrap"` 유지. `clampable && !expanded`일 때만
+       클램프 스타일 적용:
+       ```
+       display: "-webkit-box", WebkitBoxOrient: "vertical",
+       WebkitLineClamp: CLAMP_LINES, overflow: "hidden"
+       ```
+       그 외(짧은 본문 또는 expanded)에는 `display: "block"`, 클램프 없음.
+     - `clampable`일 때만 토글 `<button>` 렌더:
+       - `type="button"`, `onClick={() => setExpanded(v => !v)}`
+       - `aria-expanded={expanded}`, `aria-controls={bodyId}`,
+         `aria-label={expanded ? "본문 접기" : "본문 더보기"}`
+       - `data-testid="session-row-toggle"` (테스트 앵커)
+       - 라벨 텍스트 `{expanded ? "접기" : "더보기"}`, 스타일은 NewsListItem 토글과
+         동형(transparent bg, `fontSize:12`, `fontWeight:700`, `color: var(--fg-3)`,
+         `cursor:pointer`, `border:none`, `padding:"2px 0"`, `fontFamily:"inherit"`).
+       - 본문 div에는 `id={bodyId}`(예: `` `sess-body-${entry_uuid}` `` — id는
+         props로 전달하거나 `useId`로 생성) 부여해 `aria-controls`와 연결.
+   - `SessionRow`의 기존 본문 라인(`:77`)을 `<ExpandableBody body={entry.body} />`
+     (또는 `entry_uuid`를 함께 넘겨 id 생성)로 교체. **refs 푸터/Pill/시간/그룹 로직은
+     불변** — `ExpandableBody`는 title div와 refs 푸터 사이에만 삽입.
+   - import: `useState`는 이미 있음. id 생성에 `useId`를 쓰면 `react`에서 추가 import
+     (또는 `entry_uuid` 기반 문자열 id로 import 없이 처리 — 선호).
+
+2. **`frontend/invest/src/__tests__/SessionContextTimelinePanel.test.tsx`**
+   - 기존 유일 테스트(그룹/톤/hhmm/refs)는 **본문이 짧아** 토글이 없어야 하므로:
+     - 짧은 두 행에는 `queryByTestId("session-row-toggle")`가 없거나 개수 0임을 단언
+       추가(회귀 가드).
+   - **새 테스트 케이스** "clamps long bodies behind a 더보기 toggle":
+     - fixture에 `entry_type="decision"`, `body`가 6줄(`"a\nb\nc\nd\ne\nf"`) 또는
+       200+자 장문인 세 번째(또는 별도 fixture) 행 추가.
+     - `render` 후 해당 행에 `getByTestId("session-row-toggle")` 존재,
+       초기 `aria-expanded="false"`, 라벨 `더보기`.
+     - **본문 텍스트 자체는 DOM에 존재**함을 단언(jsdom은 CSS 클램프를 계산하지 않아
+       full text가 항상 렌더됨 — 텍스트 접근성 회귀 없음 확인).
+     - `fireEvent.click(toggle)` → `aria-expanded="true"`, 라벨 `접기`로 토글됨을 단언.
+   - `@testing-library/react`의 `fireEvent`(또는 이미 import된 것) 사용, 기존
+     `MemoryRouter` 래핑 유지.
+
+### 신규 파일
+없음. (`ExpandableBody`는 동일 파일 내 서브컴포넌트.)
+
+## 구현 단계 (순서/구체 위치)
+
+1. `SessionContextTimelinePanel.tsx` 상단(현재 `ENTRY_TYPE_TONE` 근처, `:22` 위/아래)에
+   `CLAMP_LINES`, `CLAMP_CHAR_THRESHOLD`, `isBodyClampable()` 순수 헬퍼 추가.
+2. `SessionRow`(`:54`) 위 또는 아래에 `ExpandableBody` 서브컴포넌트 정의
+   (SignalCard의 clamp 스타일 + NewsListItem의 토글 버튼 스타일 차용).
+3. `SessionRow` 본문 라인(`:77`)을 `<ExpandableBody ... />` 호출로 교체. id 연결을 위해
+   `entry.entry_uuid`(또는 title div의 `bodyId`)를 넘긴다. **refs 푸터(`:78-107`) 이전에
+   위치**시켜 시각 순서(제목 → 본문 → refs) 유지.
+4. 테스트 파일에 짧은 본문 no-toggle 회귀 단언 + 장문 toggle 케이스 추가.
+5. 로컬 검증:
+   `cd frontend/invest && npm run typecheck && npm test -- SessionContextTimelinePanel`.
+6. 전체 스위트 스모크: `cd frontend/invest && npm test`(insights 관련 파일만이라도).
+
+## 테스트
+
+- **단위/컴포넌트(vitest + jsdom, `frontend/invest/src/__tests__/SessionContextTimelinePanel.test.tsx`)**:
+  - 회귀: 기존 그룹 헤더(`2026-07-03`/`2026-07-02`), 톤(`decision=gain`,
+    `handoff_note=paper`), hhmm(`09:00`/`22:00`), refs 링크/주문 단언 **전부 그대로 통과**.
+  - 신규: 짧은 본문 → 토글 없음. 장문 본문 → 토글 존재 + 클릭 시
+    `aria-expanded`/라벨(`더보기`↔`접기`) 토글 + 본문 텍스트 상시 DOM 존재.
+- **typecheck**: `npm run typecheck`(신규 서브컴포넌트 props 타입 포함).
+- **수동/시각(선택, 배포 후)**: `/invest/insights`에서 세션 기록 패널이 압축되고
+  각 결정 행이 ~3줄로 클램프되며 더보기로 펼쳐지는지, refs/시간/그룹/톤이 유지되는지 확인.
+
+주의: jsdom은 레이아웃(`scrollHeight`/`offsetHeight`)을 계산하지 않으므로 DOM 측정 기반
+토글 결정은 테스트 불가 → **content-based 휴리스틱**(`isBodyClampable`)을 채택해
+결정성을 확보한다. 이 선택의 트레이드오프는 아래 리스크 참조.
+
+## 리스크·결정 필요
+
+- **[결정] 토글 노출 판정 방식 — 휴리스틱 vs DOM 측정.**
+  - 채택(권장): content-based 휴리스틱(`newline > 3 || length > 160`). 장점: jsdom에서
+    결정적으로 테스트 가능, `useLayoutEffect`/ref 불필요. 단점: 근사치라 경계 길이
+    본문에서 (a) 실제로는 3줄에 딱 맞는데 더보기가 뜨거나(펼쳐도 거의 변화 없음 —
+    cosmetic), (b) 임계 아래인데 좁은 뷰포트에서 4줄로 wrap될 수 있음. (b)를 줄이려
+    임계를 3줄 상당(~160자)보다 약간 낮게 잡아 **false-negative(내용이 잘렸는데
+    토글 없음)를 최소화**하고 fail-open(내용 노출) 방향으로 편향. 컬랩스 시에도
+    클램프는 3줄이라 짧은 본문엔 무해(잘릴 것이 없음).
+  - 대안: `useRef` + `useLayoutEffect`로 `scrollHeight > clientHeight` 측정해 토글 노출.
+    브라우저에서 정확하지만 jsdom에서 항상 false → 토글 케이스 테스트 불가(또는
+    측정 모킹 필요). 정확도가 중요하면 이 방식 + 테스트 전략 재설계 필요 — 리뷰어 판단.
+- **[결정] per-row 상태 소유 위치.** 채택: `ExpandableBody` 로컬 `useState`(캡슐화,
+  lifting/Set 배선 불필요, 행이 `entry_uuid`로 안정 keyed). 대안: 패널 레벨
+  `Set<entry_uuid>`(전역 펼침/접힘 컨트롤이 향후 필요하면 유리하나 현재 요구엔 과함).
+- **`WebkitLineClamp` 브라우저 지원**: `-webkit-box` 클램프는 모든 타깃(Chromium/WebKit/
+  최신 Firefox)에서 동작. 미지원 fallback 시 클램프가 안 될 뿐 내용/토글은 그대로 →
+  degrade-safe.
+- **`white-space: pre-wrap` + `-webkit-line-clamp` 상호작용**: 명시적 `\n`이 있는 본문도
+  `-webkit-box`가 N 시각 줄로 클램프하므로 안전. pre-wrap은 유지(펼쳤을 때 줄바꿈 보존).
+- **접근성**: 클램프는 CSS만이라 스크린리더/DOM에는 full text가 남음(내용 숨김 아님).
+  토글은 `aria-expanded`/`aria-controls`/`aria-label`로 IssueCard/NewsListItem과 동형.
+- **범위**: 변경은 shared `SessionContextTimelinePanel` 내부에 한정 — `/insights`는
+  desktop 단일 라우트라 미러링할 mobile 뷰 없음. `RetrospectivesPanel`(공유, /my에도
+  사용) 등 다른 패널은 건드리지 않음.
+- **대안(비채택, 문서화만)**: (1) `limit` 15→더 작게 축소 — 정보 손실, 스크롤 축소엔
+  둔함. (2) 세션 기록 섹션 전체 접기(collapse) — 패널 존재감은 줄지만 개별 행
+  scannability는 그대로. 본 이슈는 per-row 클램프가 핵심 요구이므로 위 두 안은 보조.

--- a/docs/plans/ROB-681-mobile-insights-viewport-dispatch.md
+++ b/docs/plans/ROB-681-mobile-insights-viewport-dispatch.md
@@ -1,0 +1,135 @@
+# ROB-681 — /insights viewport 분기 (mobile dispatch)
+
+## 배경
+
+`/invest/insights` 는 현재 `routes.tsx` 에서 **뷰포트 분기 없이** `DesktopInsightsPage` 를
+그대로 렌더한다 (`routes.tsx:86` — `{ path: "/insights", element: <DesktopInsightsPage /> }`).
+반면 다른 canonical 서페이스(`/`, `/my`, `/feed/news`, `/discover`, `/calendar`, `/reports`)는
+모두 `useViewport() === "mobile"` 로 모바일 셸을 고르는 Route 래퍼를 통해 렌더된다
+(`InvestHomeRoute`, `InvestPortfolioRoute`, `FeedNewsRoute`, `InvestDiscoverRoute`,
+`CalendarRoute`, `InvestmentReportsRoute`).
+
+결과적으로 모바일에서 `/invest/insights` 로 딥링크하면(ROB-672 가 추가한 모바일 홈의
+"인사이트" 카드 `MobileHomePage.tsx:46-51` 포함) `DesktopShell`(3-컬럼 데스크톱 레이아웃)이
+그대로 뜬다 — 하단 탭바/모바일 상단바 없이, 900px 미만 화면에 데스크톱 셸이 노출된다.
+
+**목표**: `/insights` 를 `InvestHomeRoute` 패턴대로 뷰포트 분기시킨다. 최소 변경 원칙:
+`InvestInsightsRoute` 래퍼 + `MobileInsightsPage`(동일 인사이트 패널을 `MobileShell` 로 감싸
+재사용). **`DesktopInsightsPage.tsx` 는 편집하지 않는다** — 형제 이슈 ROB-682 가 그 파일을
+편집하므로 병합 충돌을 피한다.
+
+### 재사용 가능성 조사 결과 (grounding)
+
+`DesktopInsightsPage.tsx` 가 렌더하는 무거운 패널들은 **전부 자체 파일에서 export** 되고,
+셸에 독립적이며(Card 기반, 자체 fetch), **props 는 전부 optional** 이다:
+
+| 패널/컴포넌트 | export 위치 | 관련 props (전부 optional) |
+|---|---|---|
+| `MarketParityStrip` | `components/home/MarketParityStrip` | `state`, `reload` (hook 주입) |
+| `CommonPreferredDisparityCardView` | `components/CommonPreferredDisparityCard` | `data` (hook 주입) |
+| `ForecastCalibrationPanel` | `components/insights/ForecastCalibrationPanel` | `onEmptyChange?`, `onClosedCorrelationIds?`, `linkedCorrelationIds?` |
+| `RetrospectivesPanel` | `components/my/RetrospectivesPanel` | `compact?`, `onCorrelationIds?`, `linkedCorrelationIds?` |
+| `AnalysisArtifactPanel` | `components/insights/AnalysisArtifactPanel` | `onEmptyChange?` |
+| `SessionContextTimelinePanel` | `components/insights/SessionContextTimelinePanel` | `onEmptyChange?` |
+| `PageSafetyNote` | `components/PageSafetyNote` | `routeId`, `heading`, `tag`, `items` |
+
+`DesktopInsightsPage.tsx` 내부에만 존재하고 **export 되지 않는** 것은 다음 소형 헬퍼와
+페이지 조정(coordination) 상태뿐이다:
+- 헬퍼: `SectionStatus`, `PageHeader`, `Section`, `AccumulatingBanner`,
+  `ReadOnlyGuardrailNote`, `RelatedScreensCard` (각 ~10–40줄의 정적 레이아웃)
+- 조정 상태: `forecastEmpty/artifactEmpty/sessionEmpty` → `allDataEmpty` 배너(ROB-677),
+  `closedForecastIds/retroIds` → `linkedCorrelationIds` 교차링크 memo(ROB-678)
+
+**결론**: `DesktopInsightsPage.tsx` 를 **편집할 필요 없음**. 무거운 패널은 그대로 import 재사용하고,
+export 되지 않은 소형 헬퍼·조정 상태만 `MobileInsightsPage` 에 소량 복제(duplicate)한다.
+공유 모듈로 추출(=`DesktopInsightsPage.tsx` 편집)하는 대안은 ROB-682 와 충돌하므로 채택하지 않는다.
+
+## 파일별 변경
+
+### 신규 `frontend/invest/src/pages/mobile/MobileInsightsPage.tsx`
+모바일 인사이트 페이지. `MobileShell title="인사이트"` 로 감싸고, 데스크톱과 **동일한 export 패널**을
+재사용한다. `DesktopInsightsPage.tsx` 의 조정 상태/소형 헬퍼를 로컬로 복제하여 파리티 유지:
+- hook: `useMarketParity()`, `useCommonPreferredDisparity()` (데스크톱과 동일)
+- 상태: `forecastEmpty/artifactEmpty/sessionEmpty` + `allDataEmpty`,
+  `closedForecastIds/retroIds` + `linkedCorrelationIds` memo (DesktopInsightsPage.tsx:121-134 그대로)
+- 로컬 헬퍼: `SectionStatus`/`PageHeader`/`Section`/`AccumulatingBanner`/`ReadOnlyGuardrailNote`/
+  `RelatedScreensCard` 를 모바일 여백(가로 16px, 다른 모바일 페이지와 동일)에 맞춰 복제.
+  헤더 `h1` 폰트는 모바일 톤(예: 22px)으로 축소.
+- 패널 렌더 순서/props 는 데스크톱과 동일. 단 `RetrospectivesPanel` 에 `compact` 를 전달하여
+  모바일에서 8행으로 제한(패널이 이미 지원: `RetrospectivesPanel.tsx:74,94`).
+- 컨테이너 padding 은 데스크톱의 `padding:24` → 모바일은 세로 gap 위주(`14px 0 16px` 등,
+  `MobileHomePage`/`MobileDiscoverPage` 관례) + 섹션별 `padding:"0 16px"`.
+
+### 신규 `frontend/invest/src/pages/InsightsRoute.tsx`
+`InvestInsightsRoute` 래퍼(export). `InvestHomeRoute`(`DesktopHomePage.tsx:33-36`) 와 동형:
+```tsx
+export function InvestInsightsRoute() {
+  const viewport = useViewport();
+  return viewport === "mobile" ? <MobileInsightsPage /> : <DesktopInsightsPage />;
+}
+```
+`DesktopInsightsPage` 와 `MobileInsightsPage` 를 둘 다 import 한다. 다른 서페이스는 래퍼를
+데스크톱 페이지 파일에 두지만(관례), ROB-682 가 `DesktopInsightsPage.tsx` 를 편집하므로
+**충돌 회피를 위해 별도 파일**에 둔다. 테스트가 래퍼를 직접 import 하기에 named export 필요.
+
+### 신규 `frontend/invest/src/__tests__/InvestInsightsRoute.test.tsx`
+`InvestHomeRoute.test.tsx` 를 미러한 뷰포트 분기 테스트(아래 테스트 섹션 참고).
+
+### 편집 `frontend/invest/src/routes.tsx` (유일하게 편집하는 기존 product 파일)
+- import 교체: `import { DesktopInsightsPage } from "./pages/desktop/DesktopInsightsPage";`
+  → `import { InvestInsightsRoute } from "./pages/InsightsRoute";`
+- element 교체: `{ path: "/insights", element: <DesktopInsightsPage /> }`
+  → `{ path: "/insights", element: <InvestInsightsRoute /> }` (`routes.tsx:86`)
+- (선택) 상단 라우트 계약 주석 `routes.tsx:20` 에 "responsive" 표기 보강.
+
+## 구현 단계
+
+1. **`MobileInsightsPage.tsx` 작성**
+   - `DesktopInsightsPage.tsx` 를 참조로, 소형 헬퍼(`SectionStatus`/`PageHeader`/`Section`/
+     `AccumulatingBanner`/`ReadOnlyGuardrailNote`/`RelatedScreensCard`)를 모바일 여백으로 복제.
+   - `useMarketParity`/`useCommonPreferredDisparity` + 3개 empty flag + crosslink memo 복제
+     (`DesktopInsightsPage.tsx:115-134`).
+   - `MobileShell title="인사이트"` 안에 섹션 순서(시장 관찰 → 판단 품질 → 학습·회고 → 세션 기록
+     → 관련 화면 → 가드레일)로 동일 패널 배치. `RetrospectivesPanel` 에 `compact` 추가.
+   - `ReadOnlyGuardrailNote` 는 `PageSafetyNote routeId="insights"` 를 그대로 사용(데스크톱과
+     동일 dismiss 키 공유 — 의도된 동작).
+2. **`InsightsRoute.tsx` 작성** — `useViewport` 분기 래퍼(위 스니펫).
+3. **`routes.tsx` 배선** — import + element 교체(`/insights`).
+4. **테스트 추가** — `InvestInsightsRoute.test.tsx`.
+5. **검증** — `cd frontend/invest && npm run typecheck && npm test`.
+
+## 테스트
+
+- **뷰포트 분기 (핵심, `InvestInsightsRoute.test.tsx`)**: `InvestHomeRoute.test.tsx` 미러.
+  - `useMarketParity`/`useCommonPreferredDisparity` 를 loading 스텁으로 `vi.mock` 하고,
+    자체 fetch 하는 4개 패널의 api 모듈(`api/forecasts`, `api/analysisArtifacts`,
+    `api/sessionContext`, `api/retrospectives`)은 빈 배열/no-op 로 `vi.mock`(또는 `mockRightRail`
+    관례 재사용)하여 동기 렌더.
+  - `setWidth(1280)` → `getByTestId("desktop-shell")` 존재 & `queryByTestId("mobile-shell")` null.
+  - `setWidth(600)` → `getByTestId("mobile-shell")` 존재 & `queryByTestId("desktop-shell")` null.
+  - `MemoryRouter basename="/invest" initialEntries={["/invest/insights"]}` 사용.
+- **모바일 스모크(선택)**: `setWidth(600)` 로 `MobileInsightsPage` 렌더 → `mobile-shell`,
+  `mobile-top-bar`(제목 "인사이트"), heading "인사이트" 존재.
+- **라우터 경로(선택)**: `routes.test.tsx` 스타일로 `/insights` 경로가 여전히 노출되는지 확인.
+- 기존 `DesktopInsightsPage.test.tsx` 는 파일 미편집이므로 그대로 통과해야 함(회귀 없음).
+- 전체: `cd frontend/invest && npm run typecheck && npm test`.
+
+## 리스크·결정 필요
+
+- **결정 1 — 래퍼 파일 위치**: (권장) 신규 `pages/InsightsRoute.tsx` 에 두어
+  `DesktopInsightsPage.tsx` 무편집 → ROB-682 와 파일 충돌 0. 대안은 관례대로
+  `DesktopInsightsPage.tsx` 에 `InvestInsightsRoute` 추가지만 ROB-682 편집과 겹쳐 비권장.
+  (두 경우 모두 `routes.tsx` 는 편집 필요.)
+- **결정 2 — 조정 상태 복제 vs 공유 추출**: (권장) 소형 헬퍼·조정 상태를 `MobileInsightsPage`
+  에 복제(중복 ~40–60줄, 순수 레이아웃). 공유 모듈 추출은 `DesktopInsightsPage.tsx` 편집이
+  필요해 ROB-682 와 충돌하므로 이번엔 배제. **드리프트 리스크**: ROB-682 가 데스크톱 IA/섹션을
+  바꾸면 모바일이 뒤처질 수 있음 → ROB-682 머지 후 공유 추출 후속(follow-up)으로 정리 가능.
+- **리스크 — 넓은 표의 가로 오버플로우**: `ForecastCalibrationPanel`/`AnalysisArtifactPanel` 등은
+  내부 표가 넓어 좁은 화면에서 가로 스크롤/오버플로우가 생길 수 있음. `MobileShell__scroll` 은
+  세로만 관리하므로 패널 내부 가로 처리는 패널 책임. 최소 버전에선 "패널 그대로 재사용" 수용,
+  가로 스크롤 컨테이너 폴리시는 후속 폴리시로 명시.
+- **리스크 — 하단 탭 비활성**: `MobileBottomNav` 에 "인사이트" 탭이 없어(홈/MY/뉴스/발견/캘린더)
+  인사이트에선 어떤 탭도 활성화되지 않음. 이는 `/reports` 모바일과 동일한 기존 동작으로 수용.
+- **`routes.tsx` 공유면**: 이번 이슈가 편집하는 유일한 기존 product 파일. 다른 인사이트 형제
+  이슈(680/683 등)가 `routes.tsx` 에 라우트를 추가/변경하면 병합 충돌 가능 — import 블록과
+  `/insights` 라인만 건드리므로 충돌면은 최소.

--- a/docs/plans/ROB-682-crosslink-symbol-join.md
+++ b/docs/plans/ROB-682-crosslink-symbol-join.md
@@ -1,0 +1,232 @@
+# ROB-682 — insights forecast↔회고 crosslink을 SYMBOL 키로 재배선
+
+/ insights (판단 품질 ↔ 학습·회고) 크로스링크는 ROB-678(G)에서 `correlation_id`
+정확 일치로 배선되었으나 **LIVE 데이터에서 구조적으로 죽어 있다**. 이 플랜은
+USER-PREFERRED 옵션 A(심볼 재키잉)로 교체한다. 코드 변경 없음 — 플랜 문서만.
+
+## 배경
+
+ROB-678의 페이지-조정 교집합(page-coordinated intersection)은 다음처럼 동작한다:
+
+- `ForecastCalibrationPanel` — closed 예측 로드 시
+  `onClosedCorrelationIds(closed.data.map(r => r.correlation_id).filter(non-null))`
+  로 correlation_id 배열을 페이지에 보고
+  (`ForecastCalibrationPanel.tsx:402-408`).
+- `RetrospectivesPanel` — 회고 로드 시
+  `onCorrelationIds(state.items.map(r => r.correlation_id).filter(non-null))`
+  로 보고 (`RetrospectivesPanel.tsx:114-120`).
+- `DesktopInsightsPage` — 두 배열을 받아 `linkedCorrelationIds` = **교집합**(Set)
+  을 계산해 다시 두 패널로 내려보냄 (`DesktopInsightsPage.tsx:127-134`,
+  `152-165`).
+- 렌더 시 교집합에 속한 행만 앵커 + 링크를 얻는다:
+  - closed 예측 행: `id="forecast-<corr>"` + `<a href="#retro-<corr>">회고↓</a>`
+    (`ForecastCalibrationPanel.tsx:298-327`, `ClosedList`).
+  - 회고 행: `id="retro-<corr>"` + `<a href="#forecast-<corr>">예측↑</a>`
+    (`RetrospectivesPanel.tsx:183-211`).
+
+### 왜 죽었는가 (근거)
+
+두 축의 `correlation_id`가 **분리된 네임스페이스**다:
+
+- 예측(forecast) 측: thesis-style — 예 `hynix-reentry-thesis-0703`.
+  `forecast_tools.py:53`은 심볼만 `.strip()`, correlation_id는 caller가 자유
+  형식으로 넣음.
+- 회고(retro) 측: exec-style — 예 `toss_live:...` / `live:<uuid>`.
+
+동일 종목 `000660`이 양쪽에 존재해도 corr_id가 달라 `linkedCorrelationIds`
+교집합이 **항상 공집합** → 앵커/링크가 절대 렌더되지 않음(구조적 dead code).
+
+### 옵션 A: SYMBOL 키로 재키잉
+
+교집합의 키를 correlation_id → **정규화된 심볼 키**로 바꾼다. 동일 종목이 예측·
+회고 양쪽에 있으면 그 종목의 예측 행 ↔ 회고 행을 서로 점프하는 링크를 렌더한다.
+
+**서버 측 심볼 정규화(근거 — 프런트 키가 이를 맞춰야 함):**
+
+- 회고: `trade_retrospective_service.py:96-105 _normalize_symbol`
+  - crypto → `KRW-<COIN>` (dash, upper)
+  - equity_us → `to_db_symbol(x).upper()` = `-`/`/`→`.`, upper → 예 `BRK.B`
+  - equity_kr/기타 → upper only (숫자코드 무변)
+- 예측: `forecast_tools.py:53` = `.strip()`만 (upper/구분자 정규화 **없음**).
+  → 같은 종목이라도 대소문자/구분자가 다를 수 있음(`BRK-B` vs `BRK.B`,
+  `btc` vs `KRW-BTC`).
+
+따라서 프런트 canonical 키는 **양쪽을 같은 형태로 접는다**: equity는
+`upper + (-|/)→.`(app DB 관례 `to_db_symbol`와 동형), crypto는 기존
+`stockDetailRouteSymbol("crypto", …)`(→ `KRW-BTC`) 재사용. market으로 접두(kr/us/
+crypto) 하여 크로스마켓 충돌을 배제한다.
+
+## 파일별 변경
+
+### 신규: `frontend/invest/src/insightsCrosslink.ts`
+
+크로스링크 심볼 키 헬퍼(순수 함수, 두 패널 공용 — 키 산출이 갈라지면 링크가 다시
+죽으므로 단일 소스로 강제).
+
+```ts
+import { stockDetailRouteSymbol } from "./stockDetailPath";
+
+export type CrosslinkMarket = "kr" | "us" | "crypto";
+
+// forecast instrument_type("equity_kr"|"equity_us"|"crypto") → market
+export function forecastMarket(instrumentType: string | null): CrosslinkMarket | null;
+
+// retro는 market(str) 우선, 없으면 instrument_type로 폴백
+export function retroMarket(
+  market: string | null,
+  instrumentType: string | null,
+): CrosslinkMarket | null;
+
+// 교집합 canonical 키. market·symbol 중 하나라도 없으면 null(링크 제외).
+//   crypto → `crypto:${stockDetailRouteSymbol("crypto", s)}`  (예 crypto:KRW-BTC)
+//   kr/us  → `${market}:${s.toUpperCase().replace(/[-/]/g, ".")}` (예 us:BRK.B, kr:000660)
+export function crosslinkKey(market: CrosslinkMarket | null, symbol: string): string | null;
+
+// 앵커/URL-fragment 안전 slug: 영숫자 외 → "-"
+//   us:BRK.B → us-BRK-B, crypto:KRW-BTC → crypto-KRW-BTC, kr:000660 → kr-000660
+export function crosslinkAnchorSlug(key: string): string;
+```
+
+- `INSTRUMENT_MARKET` 맵(`equity_kr→kr` 등)은 이 모듈에 단일 정의.
+  `ForecastCalibrationPanel.tsx:33-37`의 로컬 복제는 유지(돈/href 표시용)하되,
+  **크로스링크 키만** 이 모듈을 경유(블라스트 반경 최소화). 선택적으로 로컬
+  맵도 `forecastMarket`로 대체 가능(리스크·결정 필요 참조).
+
+### 수정: `frontend/invest/src/components/insights/ForecastCalibrationPanel.tsx`
+
+- import 추가: `forecastMarket, crosslinkKey, crosslinkAnchorSlug` from
+  `"../../insightsCrosslink"`.
+- Props(`351-359`) 이름 변경(내부 API, additive-safe):
+  `onClosedCorrelationIds` → `onClosedSymbolKeys`,
+  `linkedCorrelationIds` → `linkedSymbolKeys`.
+- 보고 effect(`402-408`): closed 행 → `crosslinkKey(forecastMarket(r.instrument_type), r.symbol)`
+  로 매핑, non-null 필터 + **중복 제거**(Set) 후 `onClosedSymbolKeys(keys)`.
+- `ClosedList`(`282-332`):
+  - prop `linkedCorrelationIds` → `linkedSymbolKeys`.
+  - map 밖에 `const anchored = new Set<string>()` 선언(앵커 id 중복 제거용).
+  - 행마다 `const key = crosslinkKey(forecastMarket(r.instrument_type), r.symbol)`,
+    `const slug = key ? crosslinkAnchorSlug(key) : null`,
+    `const linked = key != null && (linkedSymbolKeys?.has(key) ?? false)`.
+  - 앵커 id: `id={linked && slug && !anchored.has(key) ? \`forecast-${slug}\` : undefined}`
+    (첫 행에만 부여; 이후 `anchored.add(key)`). — 한 종목이 여러 closed 예측을
+    가질 때 **id 중복(invalid HTML)** 방지.
+  - 링크: `<a href={\`#retro-${slug}\`}>회고↓</a>`.
+
+### 수정: `frontend/invest/src/components/my/RetrospectivesPanel.tsx`
+
+(공유 패널 — /my desktop·mobile에서도 사용. 크로스링크 props는 optional이라
+그쪽은 no-op 유지 = additive-only.)
+
+- import 추가: `retroMarket, crosslinkKey, crosslinkAnchorSlug`.
+- Props(`73-81`) 이름 변경: `onCorrelationIds` → `onSymbolKeys`,
+  `linkedCorrelationIds` → `linkedSymbolKeys`.
+- 보고 effect(`114-120`): 행 → `crosslinkKey(retroMarket(r.market, r.instrument_type), r.symbol)`
+  매핑, non-null + 중복 제거 후 `onSymbolKeys(keys)`.
+- 행 렌더(`183-211`):
+  - `rows.map` 밖에 `const anchored = new Set<string>()`.
+  - `const key = crosslinkKey(retroMarket(row.market, row.instrument_type), row.symbol)`,
+    `slug`, `linked = key != null && (linkedSymbolKeys?.has(key) ?? false)`.
+  - 앵커 id: 첫 행에만 `retro-${slug}` (dedupe), 링크
+    `<a href={\`#forecast-${slug}\`}>예측↑</a>`.
+
+### 수정: `frontend/invest/src/pages/desktop/DesktopInsightsPage.tsx`
+
+- 상태 이름 변경(`127-134`):
+  `closedForecastIds` → `closedForecastKeys`, `retroIds` → `retroKeys`,
+  memo `linkedCorrelationIds` → `linkedSymbolKeys` (교집합 로직 동일).
+- 주석(`127-128`) 갱신: "by correlation_id" → "by normalized symbol key (ROB-682)".
+- 패널 배선(`152-165`):
+  `<ForecastCalibrationPanel onClosedSymbolKeys={setClosedForecastKeys} linkedSymbolKeys={linkedSymbolKeys} … />`,
+  `<RetrospectivesPanel onSymbolKeys={setRetroKeys} linkedSymbolKeys={linkedSymbolKeys} />`.
+
+### 테스트 파일(수정/신규)
+
+- 신규 `frontend/invest/src/__tests__/insightsCrosslink.test.ts` — 헬퍼 단위.
+- 수정 `frontend/invest/src/__tests__/ForecastCalibrationPanel.test.tsx`
+  (ROB-678 케이스 `157-178` 재작성).
+- 수정 `frontend/invest/src/__tests__/RetrospectivesPanel.test.tsx`
+  (ROB-678 케이스 `51-69` 재작성).
+- 수정 `frontend/invest/src/__tests__/DesktopInsightsPage.test.tsx`
+  (disjoint corr_id + same symbol 회귀 테스트 추가).
+
+## 구현 단계
+
+1. **헬퍼 모듈 신설** — `insightsCrosslink.ts`에 `forecastMarket`, `retroMarket`,
+   `crosslinkKey`, `crosslinkAnchorSlug` 작성. crypto는 `stockDetailRouteSymbol`
+   재사용, equity는 `upper + (-|/)→.`.
+2. **헬퍼 단위 테스트** — `insightsCrosslink.test.ts`:
+   - `crosslinkKey(forecastMarket("equity_us"), "BRK-B") === "us:BRK.B"` 이고
+     `crosslinkKey(forecastMarket("equity_us"), "brk.b") === "us:BRK.B"` (양쪽 접힘).
+   - `crosslinkKey("crypto", "btc") === "crypto:KRW-BTC"`,
+     `crosslinkKey("crypto", "KRW-BTC") === "crypto:KRW-BTC"`.
+   - `crosslinkKey("kr", "000660") === "kr:000660"`.
+   - `retroMarket("kr", null) === "kr"`, `retroMarket(null, "equity_us") === "us"`,
+     `retroMarket(null, null) === null`, `crosslinkKey(null, "X") === null`.
+   - `crosslinkAnchorSlug("us:BRK.B") === "us-BRK-B"`.
+3. **ForecastCalibrationPanel 재배선** — props rename, 보고 effect를 심볼 키로,
+   `ClosedList` 앵커/링크를 slug + dedupe로 교체.
+4. **RetrospectivesPanel 재배선** — 동일 패턴(공유 패널이므로 optional props
+   유지 확인).
+5. **DesktopInsightsPage 재배선** — 상태/ memo/ prop 이름 및 교집합.
+6. **패널 테스트 갱신** — 아래 "테스트" 참조.
+7. **DesktopInsightsPage 통합 회귀 테스트** 추가.
+8. `cd frontend/invest && npm run typecheck && npm test` 그린 확인.
+
+## 테스트
+
+- `insightsCrosslink.test.ts` (신규, 단위): 위 2단계 케이스.
+- `ForecastCalibrationPanel.test.tsx` — ROB-678 케이스 재작성:
+  closed 예측 심볼 `AAPL`/`equity_us`, correlation_id는 **무관한 thesis-style**
+  (예 `"aapl-thesis-0704"`). `<ForecastCalibrationPanel linkedSymbolKeys={new Set(["us:AAPL"])} />`.
+  단언: `link href === "#retro-us-AAPL"`, `getElementById("forecast-us-AAPL")` 존재.
+- `RetrospectivesPanel.test.tsx` — ROB-678 케이스 재작성:
+  회고 심볼 `005930`/`market:"kr"`, corr_id는 exec-style(`"toss_live:x"`).
+  `linkedSymbolKeys={new Set(["kr:005930"])}`. 단언: `href === "#forecast-kr-005930"`,
+  `getElementById("retro-kr-005930")` 존재.
+- `DesktopInsightsPage.test.tsx` — **핵심 회귀**: fetch mock으로 calibration/open/
+  closed(심볼 `AAPL`, corr `"aapl-thesis"`) + retrospectives(심볼 `AAPL`, corr
+  `"toss_live:uuid"`) + next-actions 반환. corr_id는 서로 disjoint지만 심볼 동일 →
+  크로스링크 `회고↓`/`예측↑` 링크가 렌더됨을 단언(ROB-678 스킴이었다면 dead).
+  추가로 두 축 심볼이 다른 경우(교집합 없음)엔 링크 부재도 단언.
+- 전체: `npm run typecheck`, `npm test` 그린.
+
+## 리스크·결정 필요
+
+**결정 필요(사용자 사인오프 후 구현):**
+
+1. **앵커 id 충돌 처리** — 한 종목이 closed 예측 N개 + 회고 M개를 가질 수 있어
+   `#forecast-<symbol>`/`#retro-<symbol>`가 모호. **권장(v1)**: 종목당 **첫 행에만**
+   앵커 id 부여(dedupe), 링크는 그 첫 행으로 점프(순수 앵커, JS 무). 링크는 모든
+   매칭 행에 표시 가능. **선택 확장(defer)**: "회고 N건↓" 카운트 배지 — 각 패널이
+   상대 축의 건수를 모르므로 페이지가 `Map<key,{forecastN,retroN}>`를 추가로 내려야
+   함(플럼빙 증가). scroll+highlight(JS)도 옵션. → 승인 요청: v1=첫 행 앵커로 확정?
+2. **키 입도(granularity)** — `market:symbol`(예 `kr:000660`) vs bare `symbol`.
+   **권장**: market 접두(크로스마켓 동일 티커 오매칭 방지). market이 한쪽이라도
+   null이면 링크 제외. → 승인: market-qualified 확정?
+3. **날짜 근접 필터(optional)** — 심볼-only는 같은 종목의 **오래된 무관한 회고**를
+   최신 예측에 링크할 수 있음. **권장(v1)**: 필터 OFF(심볼-only 단순). 필요 시
+   forecast `resolved_at` ↔ retro `created_at` ±N일 창 가드 추가 가능(양측 날짜
+   존재 시에만). → 승인: v1에서 근접 필터 생략 OK? (원하면 N일 값 지정)
+4. **구분자 정규화** — equity는 `upper + (-|/)→.`(app `to_db_symbol` 동형, 회고
+   서버 저장형 `BRK.B`와 일치). crypto는 `KRW-<COIN>`. → 승인: 이 정규화 규칙 OK?
+   (엣지: crypto 심볼이 dot형 `BTC.KRW`로 오면 `normalizeCryptoRouteSymbol`이
+   오정규화 가능 — 실데이터는 Upbit `KRW-BTC` 형이라 발생 가능성 낮음. 리스크로
+   기록.)
+5. **prop 이름 변경** — 공유 `RetrospectivesPanel`의 크로스링크 props를
+   correlation→symbolKey 의미로 rename. /my(desktop·mobile)는 미전달이라 무영향
+   (additive-only). → 관례상 진행하되 확인.
+
+**리스크:**
+
+- **ROB-681과 파일 충돌**: `DesktopInsightsPage.tsx`를 양쪽이 편집 → 병합 시
+  섹션 배선/ import 충돌 가능. 상태·memo·패널 prop 라인이 근접하므로 rebase 주의.
+- **키 산출 드리프트**: 두 패널이 다른 방식으로 키를 만들면 링크가 재-사망.
+  단일 `insightsCrosslink.ts`로 강제하여 완화.
+- crypto dot형 오정규화(위 4의 엣지) — 실데이터에선 저확률, 헬퍼 테스트로
+  KRW- 형 커버.
+- 서버 정규화 변경이 미래에 갈라지면 매칭 실패 — 프런트 정규화가 서버(`to_db_symbol`,
+  `_normalize_symbol`)와 동형임을 주석으로 명시해 회귀 방지.
+
+**스코프 밖 확인:** `/insights`는 `routes.tsx:86`에서 `DesktopInsightsPage`로
+직결(모바일 뷰포트 dispatch 없음) — 크로스링크는 데스크톱 인사이트에만 존재.
+백엔드/API/스키마 변경 없음(순수 프런트 read-only). DB·migration 0.

--- a/docs/plans/ROB-683-crypto-artifact-symbol-link.md
+++ b/docs/plans/ROB-683-crypto-artifact-symbol-link.md
@@ -1,0 +1,137 @@
+# ROB-683 — Crypto artifact 종목 링크 malformed 수정
+
+## 배경
+
+`/invest/insights` 의 분석 아티팩트 패널(`AnalysisArtifactPanel`)에서 코인 종목 링크가
+깨진 URL 로 렌더된다.
+
+LIVE evidence:
+- 아티팩트의 crypto `symbols[]` 는 **DB dot-format** 로 저장/서빙된다 (`KRW.XRP`, `KRW.ETH`, `KRW.SOL`).
+- 근거(백엔드): `app/services/analysis_artifact.py` 는 심볼 필터/조회 시
+  `app/core/symbol.py::to_db_symbol` 를 사용한다 (`to_db_symbol` = `-`/`/` → `.`).
+  즉 `analysis_artifacts.symbols` 컬럼의 crypto 값은 quote·base 를 점으로 구분한
+  `KRW.XRP` 형태이며, GIN 필터(`.op("@>")`, `.op("&&")`)도 dot-format 을 전제한다.
+- 프론트 `stockDetailPath('crypto', 'KRW.XRP')` →
+  `normalizeCryptoRouteSymbol('KRW.XRP')` 로 들어가면:
+  - `startsWith("KRW-")` false, `endsWith("-KRW")` false, `includes("-")` false
+  - → 마지막 분기에서 `KRW-${clean}` = **`KRW-KRW.XRP`** 를 반환 (오작동)
+  - → href `/invest/stocks/crypto/KRW-KRW.XRP` (broken; 상세 페이지 404/미스매치)
+- KR(`000660`)·US(`BRK-B`)·이미 잘 되는 crypto dash 형(`KRW-JUP`, `BTC` bare, `BTC-KRW`)은 정상.
+
+수정 방향: `normalizeCryptoRouteSymbol` 이 **dot-format crypto 심볼을 dash 로 정규화**하도록
+한다 (`KRW.XRP` → `KRW-XRP`). 이미 정상인 dash 형(`KRW-JUP`)·bare 형(`XRP`)은 불변이어야 한다.
+
+### 수정 위치 결정: 공유 헬퍼 (`stockDetailPath.normalizeCryptoRouteSymbol`)
+
+- **채택: 공유 `normalizeCryptoRouteSymbol` 수정** — 가장 안전하고 범위가 넓다.
+  `normalizeCryptoRouteSymbol` 은 crypto 라우트에서만 호출된다
+  (`stockDetailRouteSymbol` line 34 가 non-crypto 는 `cleanSymbol` 그대로 반환하며 가드).
+  따라서 dot→dash 정규화는 KR/US 심볼에 절대 닿지 않는다.
+- 이 한 곳을 고치면 crypto dot-format 을 소비할 수 있는 **모든** 호출부가 함께 고쳐진다:
+  `AnalysisArtifactPanel`(dot-format), `SessionContextTimelinePanel`(`refs.symbols`),
+  그리고 `stockDetailRouteSymbol` 를 쓰는 `RightRemotePanel` 등.
+- **기각: AnalysisArtifactPanel-only 수정** — 같은 dot-format 버그가 세션 타임라인 등
+  다른 crypto 소비자에서 재발할 수 있어 근본 해결이 아니다.
+- **기각: 백엔드에서 dash 형으로 emit** — 백엔드 canonical 은 dot 이고,
+  `analysis_artifacts.symbols` GIN 필터가 `to_db_symbol`(dot) 을 전제하므로 저장형을
+  바꾸면 필터·조회가 깨진다. 프론트 라우트 정규화가 올바른 계층.
+
+호출부 전수 확인(grep `stockDetailPath`/`stockDetailRouteSymbol`):
+crypto 심볼을 넘길 수 있는 곳 — insights: `AnalysisArtifactPanel`, `SessionContextTimelinePanel`,
+`ForecastCalibrationPanel`(instrument_type→market 매핑); my: `RetrospectivesPanel`(retro·next-action,
+**dash 형 `KRW-JUP`**), `UnifiedHoldingsTable`, `WatchAlertsPanel`, `SellHistoryPanel`,
+`BuyHistoryPanel`, `CurrentOrdersPanel`; mobile: `MobilePortfolioPage`; desktop: `RightRemotePanel`.
+retro/next-action 은 dash 형을 넘기므로 이번 수정 후에도 **불변**이어야 한다(회귀 테스트로 고정).
+
+## 파일별 변경
+
+### 기존 파일 (수정)
+
+- **`frontend/invest/src/stockDetailPath.ts`** — `normalizeCryptoRouteSymbol` 의 `clean`
+  정규화 단계에 dot→dash 변환을 추가한다. 나머지 분기 로직(`KRW-` prefix / `-KRW` suffix /
+  bare → `KRW-`)은 그대로 두면 dot 형이 dash 형과 동일 경로로 흡수된다.
+
+  현재:
+  ```ts
+  const clean = symbol.trim().toUpperCase();
+  ```
+  변경:
+  ```ts
+  // Crypto DB symbols arrive dot-format (KRW.XRP; app/core/symbol.to_db_symbol).
+  // Fold "." → "-" so KRW.XRP joins the KRW- dash path instead of falling through
+  // to the bare-symbol branch (which would emit KRW-KRW.XRP). Dash/bare forms
+  // already normalized here are unaffected since they contain no ".".
+  const clean = symbol.trim().toUpperCase().replace(/\./g, "-");
+  ```
+
+  변환 후 분기 추적:
+  - `KRW.XRP` → `KRW-XRP` → `startsWith("KRW-")` → `KRW-XRP` ✓
+  - `KRW-JUP` → `KRW-JUP`(dot 없음) → `startsWith("KRW-")` → `KRW-JUP` (불변) ✓
+  - `XRP` → `XRP`(dot 없음) → no `-` → `KRW-XRP` (불변) ✓
+  - `BTC-KRW` → `BTC-KRW` → `endsWith("-KRW")` → `KRW-BTC` (불변) ✓
+  - `BTC.ETH`(BTC 마켓 dot 형, 방어적) → `BTC-ETH` → `includes("-")` → `BTC-ETH` (마켓 접두 보존) ✓
+
+### 기존 파일 (테스트 추가)
+
+- **`frontend/invest/src/__tests__/stockDetailPath.test.ts`** — dot-format 회귀 케이스와
+  dash/bare 불변 케이스를 추가.
+
+### 신규 파일
+
+없음. (마이그레이션 0, 백엔드 변경 없음, 스키마 변경 없음)
+
+## 구현 단계
+
+1. `frontend/invest/src/stockDetailPath.ts` line 20 `const clean = symbol.trim().toUpperCase();`
+   를 `.replace(/\./g, "-")` 를 붙인 형태로 교체하고, 위 주석을 추가한다.
+   함수의 나머지 분기(21–25행)는 수정하지 않는다.
+2. `frontend/invest/src/__tests__/stockDetailPath.test.ts` 에 회귀 테스트 블록을 추가한다
+   (아래 "테스트" 참조). 기존 테스트는 그대로 통과해야 한다.
+3. `cd frontend/invest && npm run typecheck` (tsc) 로 타입 회귀 없음 확인.
+4. `cd frontend/invest && npm test -- stockDetailPath` 로 신규·기존 케이스 green 확인.
+5. (선택, 시각 확인) `AnalysisArtifactPanel` 렌더 시 crypto 링크가
+   `/invest/stocks/crypto/KRW-XRP` 로 생성되는지 dogfooding — 코드 변경은 없음.
+
+## 테스트
+
+`frontend/invest/src/__tests__/stockDetailPath.test.ts` 에 추가:
+
+```ts
+test("stock detail path normalizes dot-format crypto symbols (KRW.XRP → KRW-XRP)", () => {
+  expect(stockDetailPath("crypto", "KRW.XRP")).toBe("/stocks/crypto/KRW-XRP");
+  expect(stockDetailPath("CRYPTO", "KRW.ETH")).toBe("/stocks/crypto/KRW-ETH");
+  expect(stockDetailPath("crypto", "krw.sol")).toBe("/stocks/crypto/KRW-SOL");
+  expect(stockDetailRouteSymbol("crypto", "KRW.XRP")).toBe("KRW-XRP");
+});
+
+test("stock detail path leaves already-valid crypto dash/bare forms unchanged", () => {
+  // retro / next-action symbols arrive dash-form; must not regress.
+  expect(stockDetailPath("crypto", "KRW-JUP")).toBe("/stocks/crypto/KRW-JUP");
+  expect(stockDetailPath("crypto", "XRP")).toBe("/stocks/crypto/KRW-XRP");
+});
+```
+
+기존 테스트(`BTC`/`btc`/`BTC-KRW`/`KRW-BTC` → `KRW-BTC`, KR `005930`, US `BRK-B`)는
+변경 없이 통과해야 한다 — dot 미포함 입력은 `replace` 가 no-op 이기 때문.
+
+실행:
+- `cd frontend/invest && npm test -- stockDetailPath`
+- `cd frontend/invest && npm run typecheck`
+- (전체) `cd frontend/invest && npm test`
+
+## 리스크·결정 필요
+
+- **리스크: 낮음.** 순수 문자열 정규화 한 줄, crypto 라우트 전용 경로(비-crypto 는 line 34
+  가드로 미도달), 마이그레이션·백엔드·스키마 변경 없음.
+- **dash 형 회귀 없음 보장:** dot 미포함 입력에는 `replace(/\./g, "-")` 가 no-op 이므로
+  `KRW-JUP`/`XRP`/`BTC-KRW`/`005930`/`BRK-B` 등 기존 형태의 출력은 바이트 동일. 회귀 테스트로 고정.
+- **BTC/USDT 마켓 dot 형:** Upbit 은 KRW 외 BTC/USDT 마켓도 존재(`BTC.ETH` 등). dot→dash
+  변환은 마켓 접두를 보존(`BTC-ETH`)하므로 KRW 하드코딩보다 견고 — 별도 KRW-only 분기보다
+  `replace` 전역 치환을 선택한 이유.
+- **범위 밖(결정 불요, 명시만):**
+  - 백엔드 저장형(dot)·GIN 필터는 그대로 둔다 — canonical 유지.
+  - 모바일 뷰포트 dispatch(insights 모바일 셸)는 이 이슈 범위 아님. 링크 정규화는 공유
+    헬퍼라 데스크톱/모바일 양쪽에 자동 적용됨(추가 작업 없음).
+  - crypto 심볼의 bare→KRW 가정(`XRP` → `KRW-XRP`)은 기존 동작으로 유지(BTC/USDT 마켓
+    bare 심볼 구분은 pre-existing 한계, 이번 스코프 아님).
+- **결정 필요: 없음.** 수정 위치(공유 헬퍼)·정규화 방식(dot→dash 전역 치환) 모두 코드 근거로 확정.

--- a/frontend/invest/src/__tests__/DesktopInsightsPage.test.tsx
+++ b/frontend/invest/src/__tests__/DesktopInsightsPage.test.tsx
@@ -179,3 +179,79 @@ test("renders an empty market parity state without hiding the page", () => {
   expect(screen.getByText("승인된 패리티 카드가 없습니다.")).toBeInTheDocument();
   expect(screen.getByText("삼성전자 / 삼성전자우")).toBeInTheDocument();
 });
+
+// Builds a full-page fetch mock (calibration/open/closed/artifacts/
+// session-context/next-actions/retrospectives) with one closed forecast
+// (symbol AAPL, thesis-style correlation_id) and one retrospective whose
+// symbol is the given `retroSymbol` (exec-style correlation_id). The two
+// correlation_ids are always disjoint — under ROB-678's exact-id scheme the
+// crosslink would never render regardless of symbol overlap.
+function buildCrosslinkFetchMock(retroSymbol: string) {
+  return vi.fn(async (url: string) => {
+    const u = String(url);
+    let body: unknown = {};
+    if (u.includes("/calibration")) {
+      body = { group_by: "created_by", created_by: null, symbol: null, instrument_type: null, days: null, count: 0, groups: [], as_of: "2026-07-03T00:00:00Z" };
+    } else if (u.includes("/forecasts/open")) {
+      body = { kind: "open", symbol: null, created_by: null, instrument_type: null, count: 0, items: [], as_of: "2026-07-03T00:00:00Z" };
+    } else if (u.includes("/forecasts/closed")) {
+      body = {
+        kind: "closed", symbol: null, created_by: null, instrument_type: null, count: 1, as_of: "2026-07-03T00:00:00Z",
+        items: [{
+          id: 1, forecast_id: "f1", correlation_id: "aapl-thesis", created_by: "claude",
+          session_label: null, model_label: null, symbol: "AAPL", instrument_type: "equity_us",
+          forecast_target: null, horizon: null, probability: 0.7, probability_range_low: null,
+          probability_range_high: null, resolution_source: null, review_date: "2026-06-20",
+          status: "closed", outcome: true, observed_value: 175.5, resolved_at: "2026-06-21T00:00:00Z",
+          brier_score: 0.09, created_at: "2026-06-10T00:00:00Z",
+        }],
+      };
+    } else if (u.includes("/artifacts")) {
+      body = { success: true, count: 0, filters: {}, artifacts: [] };
+    } else if (u.includes("/session-context")) {
+      body = { success: true, count: 0, filters: {}, entries: [] };
+    } else if (u.includes("next-actions")) {
+      body = { market: "all", symbol: null, count: 0, scan_limit: 200, items: [] };
+    } else if (u.includes("retrospectives")) {
+      body = {
+        market: "all", trigger_type: null, root_cause_class: null, symbol: null, count: 1, total: 1, as_of: "2026-07-03T00:00:00Z",
+        items: [{
+          id: 1, correlation_id: "toss_live:uuid", symbol: retroSymbol, market: "us",
+          instrument_type: "equity_us", side: "sell", trigger_type: "fill", root_cause_class: null,
+          outcome: "win", realized_pnl: 100, realized_pnl_currency: "USD", pnl_pct: 1.2,
+          result_summary: null, lesson: `${retroSymbol} 매도 회고`, next_strategy: null,
+          intended_vs_happened: null, next_actions: null, guardrail_fired: null,
+          policy_version: null, created_at: "2026-07-01T00:00:00Z",
+        }],
+      };
+    }
+    return { ok: true, status: 200, json: async () => body };
+  });
+}
+
+test("crosslinks closed forecast <-> retrospective by symbol key, not correlation_id (ROB-682)", async () => {
+  vi.stubGlobal("fetch", buildCrosslinkFetchMock("AAPL") as unknown as typeof fetch);
+
+  render(wrap(<DesktopInsightsPage />));
+
+  // correlation_ids ("aapl-thesis" vs "toss_live:uuid") are disjoint — under
+  // ROB-678's exact-correlation_id scheme this crosslink would be dead.
+  const forecastLink = await screen.findByRole("link", { name: /회고/ });
+  expect(forecastLink).toHaveAttribute("href", "#retro-us-AAPL");
+  expect(document.getElementById("forecast-us-AAPL")).not.toBeNull();
+
+  const retroLink = await screen.findByRole("link", { name: "예측↑" });
+  expect(retroLink).toHaveAttribute("href", "#forecast-us-AAPL");
+  expect(document.getElementById("retro-us-AAPL")).not.toBeNull();
+});
+
+test("does not crosslink when symbols differ across axes (ROB-682)", async () => {
+  vi.stubGlobal("fetch", buildCrosslinkFetchMock("TSLA") as unknown as typeof fetch);
+
+  render(wrap(<DesktopInsightsPage />));
+
+  await screen.findByText("AAPL");
+  await screen.findByText(/TSLA 매도 회고/);
+  expect(screen.queryByRole("link", { name: /회고/ })).toBeNull();
+  expect(screen.queryByRole("link", { name: "예측↑" })).toBeNull();
+});

--- a/frontend/invest/src/__tests__/ForecastCalibrationPanel.test.tsx
+++ b/frontend/invest/src/__tests__/ForecastCalibrationPanel.test.tsx
@@ -154,10 +154,13 @@ test("calibration table sorts client-side on header click (ROB-675)", async () =
   expect(bodyGroups()).toEqual(["alpha", "beta"]);
 });
 
-test("closed forecast crosslinks to its retrospective when linked (ROB-678)", async () => {
+test("closed forecast crosslinks to its retrospective by symbol key (ROB-682)", async () => {
+  // correlation_id is deliberately unrelated thesis-style text — the
+  // crosslink no longer keys on it (ROB-678's exact-id scheme was
+  // structurally dead since forecast/retro correlation_ids never overlap).
   const closedLinked: ForecastListResponse = {
     ...closed,
-    items: [{ ...closed.items[0]!, correlation_id: "corr-1" }],
+    items: [{ ...closed.items[0]!, correlation_id: "aapl-thesis-0704" }],
   };
   const fetchMock = vi.fn((url: string) => {
     const u = String(url);
@@ -168,11 +171,11 @@ test("closed forecast crosslinks to its retrospective when linked (ROB-678)", as
 
   render(
     <MemoryRouter>
-      <ForecastCalibrationPanel linkedCorrelationIds={new Set(["corr-1"])} />
+      <ForecastCalibrationPanel linkedSymbolKeys={new Set(["us:AAPL"])} />
     </MemoryRouter>,
   );
 
   const link = await screen.findByRole("link", { name: /회고/ });
-  expect(link).toHaveAttribute("href", "#retro-corr-1");
-  expect(document.getElementById("forecast-corr-1")).not.toBeNull();
+  expect(link).toHaveAttribute("href", "#retro-us-AAPL");
+  expect(document.getElementById("forecast-us-AAPL")).not.toBeNull();
 });

--- a/frontend/invest/src/__tests__/InvestInsightsRoute.test.tsx
+++ b/frontend/invest/src/__tests__/InvestInsightsRoute.test.tsx
@@ -1,0 +1,59 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { InvestInsightsRoute } from "../pages/InsightsRoute";
+import { useCommonPreferredDisparity } from "../hooks/useCommonPreferredDisparity";
+import { useMarketParity } from "../hooks/useMarketParity";
+import { AccountPanelProvider } from "../desktop/AccountPanelProvider";
+import { mockRightRail } from "../test/mockRightRail";
+
+// Stub the two page-owned hooks so both the desktop and mobile insights pages
+// render synchronously in their loading branch — this test (an
+// InvestHomeRoute.test.tsx mirror) only cares about which shell is picked,
+// not the panel contents. The remaining self-fetching panels
+// (ForecastCalibrationPanel/AnalysisArtifactPanel/SessionContextTimelinePanel/
+// RetrospectivesPanel) are left unmocked, matching DesktopInsightsPage.test.tsx's
+// existing convention of not stubbing their fetches for shell-only assertions.
+vi.mock("../hooks/useMarketParity", () => ({ useMarketParity: vi.fn() }));
+vi.mock("../hooks/useCommonPreferredDisparity", () => ({ useCommonPreferredDisparity: vi.fn() }));
+
+function setWidth(w: number) {
+  Object.defineProperty(window, "innerWidth", { writable: true, configurable: true, value: w });
+}
+
+function wrap(ui: React.ReactElement) {
+  return (
+    <AccountPanelProvider>
+      <MemoryRouter basename="/invest" initialEntries={["/invest/insights"]}>{ui}</MemoryRouter>
+    </AccountPanelProvider>
+  );
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  mockRightRail();
+  vi.mocked(useMarketParity).mockReturnValue({ state: { status: "loading" }, reload: vi.fn() });
+  vi.mocked(useCommonPreferredDisparity).mockReturnValue({ status: "loading" });
+});
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe("InvestInsightsRoute responsive dispatch", () => {
+  it("renders the desktop shell at >= 900px", () => {
+    setWidth(1280);
+    render(wrap(<InvestInsightsRoute />));
+    expect(screen.getByTestId("desktop-shell")).toBeInTheDocument();
+    expect(screen.queryByTestId("mobile-shell")).toBeNull();
+  });
+
+  it("renders the mobile shell below 900px", () => {
+    setWidth(600);
+    render(wrap(<InvestInsightsRoute />));
+    expect(screen.getByTestId("mobile-shell")).toBeInTheDocument();
+    expect(screen.queryByTestId("desktop-shell")).toBeNull();
+    // Mobile smoke: top bar + heading both carry the page title.
+    expect(screen.getByTestId("mobile-top-bar")).toHaveTextContent("인사이트");
+    expect(screen.getByRole("heading", { name: "인사이트" })).toBeInTheDocument();
+  });
+});

--- a/frontend/invest/src/__tests__/RetrospectivesPanel.test.tsx
+++ b/frontend/invest/src/__tests__/RetrospectivesPanel.test.tsx
@@ -48,22 +48,29 @@ test("renders pinned next-action checklist and retrospective row", async () => {
   expect(screen.getByText(/분할 매수가 유효했다/)).toBeInTheDocument();
 });
 
-test("retrospective crosslinks to its forecast when linked (ROB-678)", async () => {
+test("retrospective crosslinks to its forecast by symbol key (ROB-682)", async () => {
+  // correlation_id is deliberately exec-style text ("toss_live:x") — the
+  // crosslink no longer keys on it (ROB-678's exact-id scheme was
+  // structurally dead since forecast/retro correlation_ids never overlap).
+  const listExec: RetrospectivesResponse = {
+    ...list,
+    items: [{ ...list.items[0]!, correlation_id: "toss_live:x" }],
+  };
   const fetchMock = vi.fn((url: string) =>
     Promise.resolve({
       ok: true,
-      json: async () => (String(url).includes("next-actions") ? na : list),
+      json: async () => (String(url).includes("next-actions") ? na : listExec),
     }),
   );
   vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
 
   render(
     <MemoryRouter>
-      <RetrospectivesPanel linkedCorrelationIds={new Set(["c"])} />
+      <RetrospectivesPanel linkedSymbolKeys={new Set(["kr:005930"])} />
     </MemoryRouter>,
   );
 
   const link = await screen.findByRole("link", { name: "예측↑" });
-  expect(link).toHaveAttribute("href", "#forecast-c");
-  expect(document.getElementById("retro-c")).not.toBeNull();
+  expect(link).toHaveAttribute("href", "#forecast-kr-005930");
+  expect(document.getElementById("retro-kr-005930")).not.toBeNull();
 });

--- a/frontend/invest/src/__tests__/SessionContextTimelinePanel.test.tsx
+++ b/frontend/invest/src/__tests__/SessionContextTimelinePanel.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { SessionContextTimelinePanel } from "../components/insights/SessionContextTimelinePanel";
@@ -84,5 +84,61 @@ describe("SessionContextTimelinePanel", () => {
     expect(screen.getByText("09:00")).toBeInTheDocument();
     expect(screen.getByText("22:00")).toBeInTheDocument();
     expect(screen.queryByText(/2026-07-03 09:00/)).not.toBeInTheDocument();
+
+    // ROB-680: short bodies stay unclamped — no 더보기/접기 toggle rendered
+    expect(screen.queryAllByTestId("session-row-toggle")).toHaveLength(0);
+  });
+
+  it("clamps long bodies behind a 더보기 toggle", async () => {
+    const longBody = {
+      ...body,
+      count: 3,
+      entries: [
+        ...body.entries,
+        {
+          entry_uuid: "e-3",
+          kst_date: "2026-07-03",
+          market: "kr",
+          account_scope: null,
+          entry_type: "decision" as const,
+          title: "장문 결정 메모",
+          body: "a\nb\nc\nd\ne\nf",
+          refs: {},
+          created_by: "claude",
+          session_label: null,
+          created_at: "2026-07-03T10:00:00+00:00",
+        },
+      ],
+    };
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: true,
+        status: 200,
+        json: async () => longBody,
+      })) as unknown as typeof fetch,
+    );
+
+    render(
+      <MemoryRouter>
+        <SessionContextTimelinePanel />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => screen.getByText("장문 결정 메모"));
+
+    const toggle = screen.getByTestId("session-row-toggle");
+    expect(toggle).toHaveAttribute("aria-expanded", "false");
+    expect(toggle).toHaveTextContent("더보기");
+
+    // jsdom does not compute CSS clamping, so the full body text is always in
+    // the DOM regardless of collapsed/expanded state — no accessibility regression.
+    expect(screen.getByText((_, node) => node?.textContent === "a\nb\nc\nd\ne\nf")).toBeInTheDocument();
+
+    fireEvent.click(toggle);
+
+    expect(toggle).toHaveAttribute("aria-expanded", "true");
+    expect(toggle).toHaveTextContent("접기");
   });
 });

--- a/frontend/invest/src/__tests__/insightsCrosslink.test.ts
+++ b/frontend/invest/src/__tests__/insightsCrosslink.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from "vitest";
+import {
+  crosslinkAnchorSlug,
+  crosslinkKey,
+  forecastMarket,
+  retroMarket,
+} from "../insightsCrosslink";
+
+describe("forecastMarket", () => {
+  test("maps known instrument_type values", () => {
+    expect(forecastMarket("equity_kr")).toBe("kr");
+    expect(forecastMarket("equity_us")).toBe("us");
+    expect(forecastMarket("crypto")).toBe("crypto");
+  });
+
+  test("returns null for unknown/missing instrument_type", () => {
+    expect(forecastMarket(null)).toBeNull();
+    expect(forecastMarket("bond")).toBeNull();
+  });
+});
+
+describe("retroMarket", () => {
+  test("prefers the explicit market column", () => {
+    expect(retroMarket("kr", null)).toBe("kr");
+    expect(retroMarket("kr", "equity_us")).toBe("kr");
+  });
+
+  test("falls back to instrument_type when market is missing", () => {
+    expect(retroMarket(null, "equity_us")).toBe("us");
+  });
+
+  test("returns null when neither side resolves", () => {
+    expect(retroMarket(null, null)).toBeNull();
+    expect(retroMarket("all", null)).toBeNull();
+  });
+});
+
+describe("crosslinkKey", () => {
+  test("folds equity symbols: upper + separators -> .", () => {
+    expect(crosslinkKey(forecastMarket("equity_us"), "BRK-B")).toBe("us:BRK.B");
+    expect(crosslinkKey(forecastMarket("equity_us"), "brk.b")).toBe("us:BRK.B");
+    expect(crosslinkKey("us", "BRK/B")).toBe("us:BRK.B");
+  });
+
+  test("folds crypto symbols via stockDetailRouteSymbol", () => {
+    expect(crosslinkKey("crypto", "btc")).toBe("crypto:KRW-BTC");
+    expect(crosslinkKey("crypto", "KRW-BTC")).toBe("crypto:KRW-BTC");
+  });
+
+  test("kr keeps numeric codes unchanged", () => {
+    expect(crosslinkKey("kr", "000660")).toBe("kr:000660");
+  });
+
+  test("returns null when market is null or symbol is empty", () => {
+    expect(crosslinkKey(null, "X")).toBeNull();
+    expect(crosslinkKey("kr", "  ")).toBeNull();
+  });
+});
+
+describe("crosslinkAnchorSlug", () => {
+  test("folds non-alphanumeric characters to '-'", () => {
+    expect(crosslinkAnchorSlug("us:BRK.B")).toBe("us-BRK-B");
+    expect(crosslinkAnchorSlug("crypto:KRW-BTC")).toBe("crypto-KRW-BTC");
+    expect(crosslinkAnchorSlug("kr:000660")).toBe("kr-000660");
+  });
+});

--- a/frontend/invest/src/__tests__/stockDetailPath.test.ts
+++ b/frontend/invest/src/__tests__/stockDetailPath.test.ts
@@ -24,3 +24,16 @@ test("stock detail path supports lowercase route market keys", () => {
   expect(stockDetailPath("us", "BRK-B")).toBe("/stocks/us/BRK-B");
   expect(stockDetailPath("crypto", "BTC")).toBe("/stocks/crypto/KRW-BTC");
 });
+
+test("stock detail path normalizes dot-format crypto symbols (KRW.XRP → KRW-XRP)", () => {
+  expect(stockDetailPath("crypto", "KRW.XRP")).toBe("/stocks/crypto/KRW-XRP");
+  expect(stockDetailPath("CRYPTO", "KRW.ETH")).toBe("/stocks/crypto/KRW-ETH");
+  expect(stockDetailPath("crypto", "krw.sol")).toBe("/stocks/crypto/KRW-SOL");
+  expect(stockDetailRouteSymbol("crypto", "KRW.XRP")).toBe("KRW-XRP");
+});
+
+test("stock detail path leaves already-valid crypto dash/bare forms unchanged", () => {
+  // retro / next-action symbols arrive dash-form; must not regress.
+  expect(stockDetailPath("crypto", "KRW-JUP")).toBe("/stocks/crypto/KRW-JUP");
+  expect(stockDetailPath("crypto", "XRP")).toBe("/stocks/crypto/KRW-XRP");
+});

--- a/frontend/invest/src/components/insights/ForecastCalibrationPanel.tsx
+++ b/frontend/invest/src/components/insights/ForecastCalibrationPanel.tsx
@@ -7,6 +7,7 @@ import {
   fetchOpenForecasts,
 } from "../../api/forecasts";
 import { Card, Pill } from "../../ds";
+import { crosslinkAnchorSlug, crosslinkKey, forecastMarket } from "../../insightsCrosslink";
 import { stockDetailPath } from "../../stockDetailPath";
 import { formatWatchMoney } from "../my/watchPresentation";
 import type {
@@ -281,10 +282,10 @@ function OpenList({ rows }: { rows: ForecastRow[] }) {
 
 function ClosedList({
   rows,
-  linkedCorrelationIds,
+  linkedSymbolKeys,
 }: {
   rows: ForecastRow[];
-  linkedCorrelationIds?: ReadonlySet<string>;
+  linkedSymbolKeys?: ReadonlySet<string>;
 }) {
   if (rows.length === 0) {
     return (
@@ -293,16 +294,26 @@ function ClosedList({
       </div>
     );
   }
+  // Anchor ids are keyed by symbol, so a symbol with multiple closed forecasts
+  // would otherwise emit duplicate DOM ids. Only the first matching row per
+  // key gets the anchor; the crosslink `<a>` still renders on every match.
+  const anchored = new Set<string>();
   return (
     <div style={{ display: "grid", gap: 6 }}>
       {rows.map((r) => {
         const target = formatForecastTarget(r);
         const market = r.instrument_type ? INSTRUMENT_MARKET[r.instrument_type] : undefined;
-        const linked = r.correlation_id != null && (linkedCorrelationIds?.has(r.correlation_id) ?? false);
+        const key = crosslinkKey(forecastMarket(r.instrument_type), r.symbol);
+        const slug = key != null ? crosslinkAnchorSlug(key) : null;
+        const linked = key != null && (linkedSymbolKeys?.has(key) ?? false);
+        const anchorId = linked && key != null && slug != null && !anchored.has(key)
+          ? `forecast-${slug}`
+          : undefined;
+        if (anchorId != null && key != null) anchored.add(key);
         return (
           <div
             key={r.id}
-            id={linked ? `forecast-${r.correlation_id}` : undefined}
+            id={anchorId}
             style={{ display: "flex", alignItems: "center", gap: 8, fontSize: 13, padding: "2px 0", flexWrap: "wrap" }}
           >
             <Pill tone={r.outcome ? "gain" : "loss"} size="sm">{r.outcome ? "적중" : "빗나감"}</Pill>
@@ -316,9 +327,9 @@ function ClosedList({
             {r.resolved_at && (
               <span style={{ color: "var(--fg-3)", fontSize: 11 }}>· {r.resolved_at.slice(0, 10)}</span>
             )}
-            {linked && (
+            {linked && slug != null && (
               <a
-                href={`#retro-${r.correlation_id}`}
+                href={`#retro-${slug}`}
                 style={{ color: "var(--link, #4a9)", textDecoration: "none", fontSize: 11 }}
               >
                 · 회고↓
@@ -350,12 +361,12 @@ function Section({ title, hint, children }: { title: string; hint?: string; chil
 
 export function ForecastCalibrationPanel({
   onEmptyChange,
-  onClosedCorrelationIds,
-  linkedCorrelationIds,
+  onClosedSymbolKeys,
+  linkedSymbolKeys,
 }: {
   onEmptyChange?: (isEmpty: boolean) => void;
-  onClosedCorrelationIds?: (ids: string[]) => void;
-  linkedCorrelationIds?: ReadonlySet<string>;
+  onClosedSymbolKeys?: (keys: string[]) => void;
+  linkedSymbolKeys?: ReadonlySet<string>;
 } = {}) {
   const [groupBy, setGroupBy] = useState<ForecastGroupBy>("created_by");
   const [days, setDays] = useState<number | "all">(90);
@@ -397,15 +408,17 @@ export function ForecastCalibrationPanel({
     onEmptyChange(flags.every((f) => f === true));
   }, [calib, open, closed, onEmptyChange]);
 
-  // Report closed-forecast correlation_ids so the page can crosslink them to
-  // matching retrospectives (ROB-678).
+  // Report closed-forecast symbol keys so the page can crosslink them to
+  // matching retrospectives (ROB-682 — re-keyed from correlation_id, which was
+  // structurally dead: the two id namespaces never overlap).
   useEffect(() => {
-    if (!onClosedCorrelationIds) return;
+    if (!onClosedSymbolKeys) return;
     if (closed.status !== "ready") return;
-    onClosedCorrelationIds(
-      closed.data.map((r) => r.correlation_id).filter((c): c is string => c != null),
-    );
-  }, [closed, onClosedCorrelationIds]);
+    const keys = closed.data
+      .map((r) => crosslinkKey(forecastMarket(r.instrument_type), r.symbol))
+      .filter((k): k is string => k != null);
+    onClosedSymbolKeys(Array.from(new Set(keys)));
+  }, [closed, onClosedSymbolKeys]);
 
   return (
     <Card>
@@ -470,7 +483,7 @@ export function ForecastCalibrationPanel({
         <Section title="최근 채점 결과" hint="가장 최근에 해소된 예측.">
           {closed.status === "loading" && <div style={{ padding: 16, color: "var(--fg-3)", fontSize: 13, textAlign: "center" }}>불러오는 중…</div>}
           {closed.status === "error" && <div role="alert" style={{ padding: 12, color: "var(--danger)", fontSize: 13 }}>채점 결과를 불러오지 못했습니다. {closed.message}</div>}
-          {closed.status === "ready" && <ClosedList rows={closed.data} linkedCorrelationIds={linkedCorrelationIds} />}
+          {closed.status === "ready" && <ClosedList rows={closed.data} linkedSymbolKeys={linkedSymbolKeys} />}
         </Section>
       </section>
     </Card>

--- a/frontend/invest/src/components/insights/SessionContextTimelinePanel.tsx
+++ b/frontend/invest/src/components/insights/SessionContextTimelinePanel.tsx
@@ -30,6 +30,73 @@ const ENTRY_TYPE_TONE: Record<SessionEntryType, PillTone> = {
   open_question: "warn",
 };
 
+// Visual clamp height (in lines) for a collapsed row body, and the
+// content-based threshold used to decide whether a row's body is long enough
+// to need a 더보기/접기 toggle. Content-based (not DOM-measured) so the
+// decision is deterministic under jsdom (no layout/scrollHeight available).
+const CLAMP_LINES = 3;
+const CLAMP_CHAR_THRESHOLD = 160;
+
+// Pure heuristic: more newlines than the clamp allows, or long enough that it
+// likely wraps past CLAMP_LINES. Biased fail-open (toggle shown) over
+// false-negative (content truncated with no way to expand it).
+function isBodyClampable(body: string): boolean {
+  return body.split("\n").length > CLAMP_LINES || body.length > CLAMP_CHAR_THRESHOLD;
+}
+
+// Body of one timeline entry, clamped to CLAMP_LINES with a per-row
+// 더보기/접기 toggle when the content is long enough to warrant one (per
+// isBodyClampable). Local state is safe here because each row is keyed by
+// entry_uuid (stable identity across renders/regroupings).
+function ExpandableBody({ body, bodyId }: { body: string; bodyId: string }) {
+  const [expanded, setExpanded] = useState(false);
+  const clampable = isBodyClampable(body);
+  return (
+    <div>
+      <div
+        id={bodyId}
+        style={{
+          fontSize: 13,
+          opacity: 0.85,
+          whiteSpace: "pre-wrap",
+          ...(clampable && !expanded
+            ? {
+                display: "-webkit-box",
+                WebkitBoxOrient: "vertical",
+                WebkitLineClamp: CLAMP_LINES,
+                overflow: "hidden",
+              }
+            : { display: "block" }),
+        }}
+      >
+        {body}
+      </div>
+      {clampable && (
+        <button
+          type="button"
+          data-testid="session-row-toggle"
+          onClick={() => setExpanded((v) => !v)}
+          aria-expanded={expanded}
+          aria-controls={bodyId}
+          aria-label={expanded ? "본문 접기" : "본문 더보기"}
+          style={{
+            border: "none",
+            background: "transparent",
+            color: "var(--fg-3)",
+            cursor: "pointer",
+            fontFamily: "inherit",
+            fontSize: 12,
+            fontWeight: 700,
+            padding: "2px 0",
+          }}
+        >
+          {expanded ? "접기" : "더보기"}
+        </button>
+      )}
+    </div>
+  );
+}
+
 // Bucket entries by kst_date, preserving the incoming newest-first order both
 // across groups (first date seen = newest) and within each group.
 function groupByDate(
@@ -74,7 +141,7 @@ function SessionRow({ entry }: { entry: SessionContextEntry }) {
         <span style={{ opacity: 0.6, fontSize: 12 }}>{hhmm(entry.created_at)}</span>
       </div>
       <div style={{ fontWeight: 700, marginTop: 4 }}>{entry.title}</div>
-      <div style={{ fontSize: 13, opacity: 0.85, whiteSpace: "pre-wrap" }}>{entry.body}</div>
+      <ExpandableBody body={entry.body} bodyId={`sess-body-${entry.entry_uuid}`} />
       {hasRefs && (
         <div
           style={{

--- a/frontend/invest/src/components/my/RetrospectivesPanel.tsx
+++ b/frontend/invest/src/components/my/RetrospectivesPanel.tsx
@@ -3,6 +3,7 @@ import { Link } from "react-router-dom";
 
 import { fetchOpenNextActions, fetchRetrospectives } from "../../api/retrospectives";
 import { Pill } from "../../ds";
+import { crosslinkAnchorSlug, crosslinkKey, retroMarket } from "../../insightsCrosslink";
 import { stockDetailPath } from "../../stockDetailPath";
 import type {
   NextActionRow,
@@ -72,12 +73,12 @@ function NextActionChecklist({ items }: { items: NextActionRow[] }) {
 
 export function RetrospectivesPanel({
   compact = false,
-  onCorrelationIds,
-  linkedCorrelationIds,
+  onSymbolKeys,
+  linkedSymbolKeys,
 }: {
   compact?: boolean;
-  onCorrelationIds?: (ids: string[]) => void;
-  linkedCorrelationIds?: ReadonlySet<string>;
+  onSymbolKeys?: (keys: string[]) => void;
+  linkedSymbolKeys?: ReadonlySet<string>;
 }) {
   const [market, setMarket] = useState<RetroMarket>("all");
   const [triggerType, setTriggerType] = useState<string>("");
@@ -109,15 +110,18 @@ export function RetrospectivesPanel({
     return () => { cancelled = true; };
   }, [market]);
 
-  // Report retrospective correlation_ids so a host page can crosslink them to
-  // matching closed forecasts (ROB-678). No-op off /insights (prop undefined).
+  // Report retrospective symbol keys so a host page can crosslink them to
+  // matching closed forecasts (ROB-682 — re-keyed from correlation_id, which
+  // was structurally dead: forecast/retro id namespaces never overlap).
+  // No-op off /insights (prop undefined) — /my never passes this prop.
   useEffect(() => {
-    if (!onCorrelationIds) return;
+    if (!onSymbolKeys) return;
     if (state.status !== "ready") return;
-    onCorrelationIds(
-      state.items.map((r) => r.correlation_id).filter((c): c is string => c != null),
-    );
-  }, [state, onCorrelationIds]);
+    const keys = state.items
+      .map((r) => crosslinkKey(retroMarket(r.market, r.instrument_type), r.symbol))
+      .filter((k): k is string => k != null);
+    onSymbolKeys(Array.from(new Set(keys)));
+  }, [state, onSymbolKeys]);
 
   const rows = useMemo(() => (state.status === "ready" ? state.items : []), [state]);
 
@@ -180,37 +184,50 @@ export function RetrospectivesPanel({
               </tr>
             </thead>
             <tbody>
-              {rows.map((row) => {
-                const href = row.market ? stockDetailPath(row.market as "kr" | "us" | "crypto", row.symbol) : null;
-                const linked = row.correlation_id != null && (linkedCorrelationIds?.has(row.correlation_id) ?? false);
-                return (
-                  <tr key={row.id} id={linked ? `retro-${row.correlation_id}` : undefined}>
-                    <td style={{ padding: "10px 14px", borderBottom: "1px solid var(--divider)", fontSize: 13, fontWeight: 700 }}>
-                      {href ? <Link to={href} style={{ color: "inherit", textDecoration: "none" }}>{row.symbol}</Link> : row.symbol}
-                    </td>
-                    <td style={{ padding: "10px 14px", borderBottom: "1px solid var(--divider)", fontSize: 12 }}>
-                      <div style={{ display: "flex", gap: 4, flexWrap: "wrap" }}>
-                        {row.trigger_type && <Pill tone="paper" size="sm">{row.trigger_type}</Pill>}
-                        {row.root_cause_class && <Pill tone="paper" size="sm">{row.root_cause_class}</Pill>}
-                      </div>
-                    </td>
-                    <td style={{ padding: "10px 14px", borderBottom: "1px solid var(--divider)", fontSize: 13, textAlign: "right", fontFeatureSettings: '"tnum"' }}>
-                      {pnlText(row)}
-                    </td>
-                    <td style={{ padding: "10px 14px", borderBottom: "1px solid var(--divider)", fontSize: 12, color: "var(--fg-2)", maxWidth: 320 }}>
-                      {row.lesson ?? row.result_summary ?? "—"}
-                      {linked && (
-                        <a
-                          href={`#forecast-${row.correlation_id}`}
-                          style={{ marginLeft: 8, color: "var(--link, #4a9)", textDecoration: "none", whiteSpace: "nowrap" }}
-                        >
-                          예측↑
-                        </a>
-                      )}
-                    </td>
-                  </tr>
-                );
-              })}
+              {(() => {
+                // Anchor ids are keyed by symbol, so a symbol with multiple
+                // retrospectives would otherwise emit duplicate DOM ids. Only
+                // the first matching row per key gets the anchor; the
+                // crosslink `<a>` still renders on every match.
+                const anchored = new Set<string>();
+                return rows.map((row) => {
+                  const href = row.market ? stockDetailPath(row.market as "kr" | "us" | "crypto", row.symbol) : null;
+                  const key = crosslinkKey(retroMarket(row.market, row.instrument_type), row.symbol);
+                  const slug = key != null ? crosslinkAnchorSlug(key) : null;
+                  const linked = key != null && (linkedSymbolKeys?.has(key) ?? false);
+                  const anchorId = linked && key != null && slug != null && !anchored.has(key)
+                    ? `retro-${slug}`
+                    : undefined;
+                  if (anchorId != null && key != null) anchored.add(key);
+                  return (
+                    <tr key={row.id} id={anchorId}>
+                      <td style={{ padding: "10px 14px", borderBottom: "1px solid var(--divider)", fontSize: 13, fontWeight: 700 }}>
+                        {href ? <Link to={href} style={{ color: "inherit", textDecoration: "none" }}>{row.symbol}</Link> : row.symbol}
+                      </td>
+                      <td style={{ padding: "10px 14px", borderBottom: "1px solid var(--divider)", fontSize: 12 }}>
+                        <div style={{ display: "flex", gap: 4, flexWrap: "wrap" }}>
+                          {row.trigger_type && <Pill tone="paper" size="sm">{row.trigger_type}</Pill>}
+                          {row.root_cause_class && <Pill tone="paper" size="sm">{row.root_cause_class}</Pill>}
+                        </div>
+                      </td>
+                      <td style={{ padding: "10px 14px", borderBottom: "1px solid var(--divider)", fontSize: 13, textAlign: "right", fontFeatureSettings: '"tnum"' }}>
+                        {pnlText(row)}
+                      </td>
+                      <td style={{ padding: "10px 14px", borderBottom: "1px solid var(--divider)", fontSize: 12, color: "var(--fg-2)", maxWidth: 320 }}>
+                        {row.lesson ?? row.result_summary ?? "—"}
+                        {linked && slug != null && (
+                          <a
+                            href={`#forecast-${slug}`}
+                            style={{ marginLeft: 8, color: "var(--link, #4a9)", textDecoration: "none", whiteSpace: "nowrap" }}
+                          >
+                            예측↑
+                          </a>
+                        )}
+                      </td>
+                    </tr>
+                  );
+                });
+              })()}
             </tbody>
           </table>
           {state.status === "ready" && (

--- a/frontend/invest/src/insightsCrosslink.ts
+++ b/frontend/invest/src/insightsCrosslink.ts
@@ -1,0 +1,67 @@
+// Shared crosslink key helpers for /insights (ROB-682).
+//
+// ROB-678 wired the forecast↔retrospective crosslink on exact `correlation_id`
+// equality, but the two id namespaces are disjoint in practice (forecast side
+// is thesis-style free text; retro side is exec-style `toss_live:...` /
+// `live:<uuid>`), so the intersection was always empty and the anchors/links
+// never rendered. This module re-keys the crosslink on a normalized
+// market-qualified SYMBOL instead — the one thing both sides genuinely share.
+//
+// Both ForecastCalibrationPanel and RetrospectivesPanel MUST derive their keys
+// through this module only. If the two panels compute keys differently, the
+// crosslink goes dead again in the same way ROB-678's correlation_id scheme
+// did.
+//
+// Normalization mirrors the server side so the same instrument folds to the
+// same key on both axes:
+//   - equity (kr/us): `upper()` + separators `(-|/) → .`, matching
+//     `app/core/symbol.to_db_symbol` / `trade_retrospective_service._normalize_symbol`.
+//   - crypto: reuse `stockDetailRouteSymbol("crypto", …)` (→ `KRW-<COIN>`),
+//     which already folds dot-format crypto symbols (ROB-683).
+import { stockDetailRouteSymbol } from "./stockDetailPath";
+
+export type CrosslinkMarket = "kr" | "us" | "crypto";
+
+// forecast_row.instrument_type ("equity_kr" | "equity_us" | "crypto") → market.
+// Single definition for crosslink purposes — panels may keep their own local
+// copies for display concerns (money formatting, hrefs), but crosslink key
+// derivation must go through forecastMarket()/retroMarket() below.
+const INSTRUMENT_MARKET: Record<string, CrosslinkMarket> = {
+  equity_kr: "kr",
+  equity_us: "us",
+  crypto: "crypto",
+};
+
+function asCrosslinkMarket(value: string | null | undefined): CrosslinkMarket | null {
+  return value === "kr" || value === "us" || value === "crypto" ? value : null;
+}
+
+export function forecastMarket(instrumentType: string | null): CrosslinkMarket | null {
+  if (!instrumentType) return null;
+  return INSTRUMENT_MARKET[instrumentType] ?? null;
+}
+
+// Retrospective rows carry an explicit `market` column; fall back to
+// `instrument_type` only when market is missing (mirrors server precedence).
+export function retroMarket(
+  market: string | null,
+  instrumentType: string | null,
+): CrosslinkMarket | null {
+  return asCrosslinkMarket(market) ?? forecastMarket(instrumentType);
+}
+
+// Canonical crosslink key. Either side missing (market null/unknown, or an
+// empty symbol) drops the link entirely rather than risk a cross-market or
+// cross-instrument false match.
+export function crosslinkKey(market: CrosslinkMarket | null, symbol: string): string | null {
+  const trimmed = symbol.trim();
+  if (!market || !trimmed) return null;
+  if (market === "crypto") return `crypto:${stockDetailRouteSymbol("crypto", trimmed)}`;
+  return `${market}:${trimmed.toUpperCase().replace(/[-/]/g, ".")}`;
+}
+
+// URL-fragment / DOM-id safe slug for a crosslink key (anchors + hrefs).
+// Non-alphanumeric characters (":", ".", "-") all fold to "-".
+export function crosslinkAnchorSlug(key: string): string {
+  return key.replace(/[^a-zA-Z0-9]/g, "-");
+}

--- a/frontend/invest/src/pages/InsightsRoute.tsx
+++ b/frontend/invest/src/pages/InsightsRoute.tsx
@@ -1,0 +1,16 @@
+// /invest/insights — read-only market insight cards.
+// Single canonical route wrapper — picks the desktop or mobile renderer based
+// on viewport width, mirroring InvestHomeRoute (pages/desktop/DesktopHomePage.tsx).
+//
+// Kept in its own file (rather than alongside DesktopInsightsPage.tsx, the
+// usual sibling-surface convention) because ROB-682 edits
+// pages/desktop/DesktopInsightsPage.tsx in parallel; keeping the wrapper here
+// avoids a merge conflict on that file (ROB-681).
+import { useViewport } from "../hooks/useViewport";
+import { DesktopInsightsPage } from "./desktop/DesktopInsightsPage";
+import { MobileInsightsPage } from "./mobile/MobileInsightsPage";
+
+export function InvestInsightsRoute() {
+  const viewport = useViewport();
+  return viewport === "mobile" ? <MobileInsightsPage /> : <DesktopInsightsPage />;
+}

--- a/frontend/invest/src/pages/desktop/DesktopInsightsPage.tsx
+++ b/frontend/invest/src/pages/desktop/DesktopInsightsPage.tsx
@@ -124,14 +124,16 @@ export function DesktopInsightsPage() {
   const allDataEmpty =
     forecastEmpty === true && artifactEmpty === true && sessionEmpty === true;
 
-  // Crosslink closed forecasts ↔ retrospectives by correlation_id (ROB-678):
-  // only the intersection (ids present on both sides) gets anchors + links.
-  const [closedForecastIds, setClosedForecastIds] = useState<string[]>([]);
-  const [retroIds, setRetroIds] = useState<string[]>([]);
-  const linkedCorrelationIds = useMemo(() => {
-    const retro = new Set(retroIds);
-    return new Set(closedForecastIds.filter((id) => retro.has(id)));
-  }, [closedForecastIds, retroIds]);
+  // Crosslink closed forecasts ↔ retrospectives by normalized symbol key
+  // (ROB-682): only the intersection (keys present on both sides) gets
+  // anchors + links. Re-keyed from correlation_id (ROB-678), which was
+  // structurally dead — the forecast/retro id namespaces never overlap.
+  const [closedForecastKeys, setClosedForecastKeys] = useState<string[]>([]);
+  const [retroKeys, setRetroKeys] = useState<string[]>([]);
+  const linkedSymbolKeys = useMemo(() => {
+    const retro = new Set(retroKeys);
+    return new Set(closedForecastKeys.filter((key) => retro.has(key)));
+  }, [closedForecastKeys, retroKeys]);
 
   return (
     <DesktopShell
@@ -152,15 +154,15 @@ export function DesktopInsightsPage() {
           <Section title="판단 품질">
             <ForecastCalibrationPanel
               onEmptyChange={setForecastEmpty}
-              onClosedCorrelationIds={setClosedForecastIds}
-              linkedCorrelationIds={linkedCorrelationIds}
+              onClosedSymbolKeys={setClosedForecastKeys}
+              linkedSymbolKeys={linkedSymbolKeys}
             />
           </Section>
 
           <Section title="학습·회고">
             <RetrospectivesPanel
-              onCorrelationIds={setRetroIds}
-              linkedCorrelationIds={linkedCorrelationIds}
+              onSymbolKeys={setRetroKeys}
+              linkedSymbolKeys={linkedSymbolKeys}
             />
           </Section>
 

--- a/frontend/invest/src/pages/mobile/MobileInsightsPage.tsx
+++ b/frontend/invest/src/pages/mobile/MobileInsightsPage.tsx
@@ -1,9 +1,11 @@
 // /invest/insights (mobile) — read-only market insight cards.
 // Mirrors DesktopInsightsPage.tsx's panel set, section order, and page-local
-// coordination state (ROB-681). DesktopInsightsPage.tsx itself is not edited
-// here — ROB-682 owns that file — so the small non-exported helpers and the
+// coordination state (ROB-681). The small non-exported helpers and the
 // empty/crosslink coordination state below are duplicated rather than shared
-// (see docs/plans/ROB-681-mobile-insights-viewport-dispatch.md).
+// (see docs/plans/ROB-681-mobile-insights-viewport-dispatch.md); ROB-682
+// re-keyed the crosslink state on both this file and DesktopInsightsPage.tsx
+// in lockstep (symbol key instead of correlation_id) to keep the duplicate
+// copies from drifting apart.
 import { useMemo, useState, type ReactNode } from "react";
 import { Link } from "react-router-dom";
 import { CommonPreferredDisparityCardView } from "../../components/CommonPreferredDisparityCard";
@@ -130,14 +132,18 @@ export function MobileInsightsPage() {
   const allDataEmpty =
     forecastEmpty === true && artifactEmpty === true && sessionEmpty === true;
 
-  // Crosslink closed forecasts ↔ retrospectives by correlation_id (ROB-678):
-  // only the intersection (ids present on both sides) gets anchors + links.
-  const [closedForecastIds, setClosedForecastIds] = useState<string[]>([]);
-  const [retroIds, setRetroIds] = useState<string[]>([]);
-  const linkedCorrelationIds = useMemo(() => {
-    const retro = new Set(retroIds);
-    return new Set(closedForecastIds.filter((id) => retro.has(id)));
-  }, [closedForecastIds, retroIds]);
+  // Crosslink closed forecasts ↔ retrospectives by normalized symbol key
+  // (ROB-682): only the intersection (keys present on both sides) gets
+  // anchors + links. Re-keyed from correlation_id (ROB-678), which was
+  // structurally dead — the forecast/retro id namespaces never overlap.
+  // Mirrors DesktopInsightsPage.tsx's coordination state 1:1 (see file-header
+  // note on why this is duplicated rather than shared).
+  const [closedForecastKeys, setClosedForecastKeys] = useState<string[]>([]);
+  const [retroKeys, setRetroKeys] = useState<string[]>([]);
+  const linkedSymbolKeys = useMemo(() => {
+    const retro = new Set(retroKeys);
+    return new Set(closedForecastKeys.filter((key) => retro.has(key)));
+  }, [closedForecastKeys, retroKeys]);
 
   return (
     <MobileShell title="인사이트">
@@ -167,8 +173,8 @@ export function MobileInsightsPage() {
           <Section title="판단 품질">
             <ForecastCalibrationPanel
               onEmptyChange={setForecastEmpty}
-              onClosedCorrelationIds={setClosedForecastIds}
-              linkedCorrelationIds={linkedCorrelationIds}
+              onClosedSymbolKeys={setClosedForecastKeys}
+              linkedSymbolKeys={linkedSymbolKeys}
             />
           </Section>
         </div>
@@ -177,8 +183,8 @@ export function MobileInsightsPage() {
           <Section title="학습·회고">
             <RetrospectivesPanel
               compact
-              onCorrelationIds={setRetroIds}
-              linkedCorrelationIds={linkedCorrelationIds}
+              onSymbolKeys={setRetroKeys}
+              linkedSymbolKeys={linkedSymbolKeys}
             />
           </Section>
         </div>

--- a/frontend/invest/src/pages/mobile/MobileInsightsPage.tsx
+++ b/frontend/invest/src/pages/mobile/MobileInsightsPage.tsx
@@ -1,0 +1,203 @@
+// /invest/insights (mobile) — read-only market insight cards.
+// Mirrors DesktopInsightsPage.tsx's panel set, section order, and page-local
+// coordination state (ROB-681). DesktopInsightsPage.tsx itself is not edited
+// here — ROB-682 owns that file — so the small non-exported helpers and the
+// empty/crosslink coordination state below are duplicated rather than shared
+// (see docs/plans/ROB-681-mobile-insights-viewport-dispatch.md).
+import { useMemo, useState, type ReactNode } from "react";
+import { Link } from "react-router-dom";
+import { CommonPreferredDisparityCardView } from "../../components/CommonPreferredDisparityCard";
+import { MarketParityStrip } from "../../components/home/MarketParityStrip";
+import { AnalysisArtifactPanel } from "../../components/insights/AnalysisArtifactPanel";
+import { ForecastCalibrationPanel } from "../../components/insights/ForecastCalibrationPanel";
+import { SessionContextTimelinePanel } from "../../components/insights/SessionContextTimelinePanel";
+import { RetrospectivesPanel } from "../../components/my/RetrospectivesPanel";
+import { PageSafetyNote } from "../../components/PageSafetyNote";
+import { MobileShell } from "../../mobile/MobileShell";
+import { Card } from "../../ds";
+import { useCommonPreferredDisparity } from "../../hooks/useCommonPreferredDisparity";
+import { useMarketParity } from "../../hooks/useMarketParity";
+
+function SectionStatus({ children }: { children: ReactNode }) {
+  return (
+    <div
+      role="status"
+      style={{
+        padding: 14,
+        background: "var(--surface)",
+        border: "1px solid var(--border)",
+        borderRadius: 14,
+        color: "var(--fg-3)",
+        fontSize: 13,
+      }}
+    >
+      {children}
+    </div>
+  );
+}
+
+function PageHeader() {
+  return (
+    <div style={{ display: "grid", gap: 6 }}>
+      <h1 style={{ margin: 0, fontSize: 22, letterSpacing: "-0.03em" }}>인사이트</h1>
+      <p style={{ margin: 0, color: "var(--fg-2)", fontSize: 13, lineHeight: 1.6 }}>
+        괴리·패리티 같은 시장 관찰과 예측 판단 품질·세션 기록을 한곳에서 봅니다. 모두 읽기 전용 관찰 자료입니다.
+      </p>
+    </div>
+  );
+}
+
+// Lightweight section label — deliberately smaller/muted than the panels' own
+// h2 titles so grouping reads as a divider, not a competing heading.
+function Section({ title, children }: { title: string; children: ReactNode }) {
+  return (
+    <section style={{ display: "grid", gap: 10 }}>
+      <h2
+        style={{
+          margin: 0,
+          fontSize: 12,
+          fontWeight: 800,
+          color: "var(--fg-3)",
+          letterSpacing: "0.04em",
+        }}
+      >
+        {title}
+      </h2>
+      {children}
+    </section>
+  );
+}
+
+function AccumulatingBanner() {
+  return (
+    <div
+      role="status"
+      style={{
+        padding: "12px 14px",
+        background: "var(--surface-2)",
+        border: "1px solid var(--border)",
+        borderRadius: 12,
+        color: "var(--fg-2)",
+        fontSize: 13,
+        lineHeight: 1.6,
+      }}
+    >
+      판단 품질·핸드오프 데이터는 아직 축적 중입니다 — 예측 채점(forecast_resolve)·분석 아티팩트·세션
+      메모가 쌓이면 아래 카드가 채워집니다.
+    </div>
+  );
+}
+
+function ReadOnlyGuardrailNote() {
+  return (
+    <PageSafetyNote
+      routeId="insights"
+      heading="읽기 전용 가드레일"
+      tag="인사이트"
+      items={[
+        "주문·매매·watch mutation API를 호출하지 않습니다.",
+        "기존 read-only /invest/api 응답만 표시합니다.",
+        "데이터 수집 활성화·백필·production DB write는 별도 승인 후 진행합니다.",
+        "raoni.xyz API에 production 의존성을 추가하지 않습니다.",
+      ]}
+    />
+  );
+}
+
+function RelatedScreensCard() {
+  return (
+    <Card>
+      <div style={{ fontWeight: 900, marginBottom: 8 }}>관련 화면</div>
+      <div style={{ display: "grid", gap: 8, fontSize: 13 }}>
+        <Link to="/" style={{ color: "var(--fg-1)", textDecoration: "none" }}>홈 compact 요약</Link>
+        <Link to="/market" style={{ color: "var(--fg-1)", textDecoration: "none" }}>시장 대시보드</Link>
+        <Link to="/stocks/kr/005930" style={{ color: "var(--fg-1)", textDecoration: "none" }}>종목 상세 리서치 예시</Link>
+      </div>
+    </Card>
+  );
+}
+
+export function MobileInsightsPage() {
+  const marketParity = useMarketParity();
+  const disparity = useCommonPreferredDisparity();
+
+  // Emptiness is owned by each panel (self-fetch); they report up via
+  // onEmptyChange so the page can show one accumulating banner instead of a
+  // stack of empty boxes. null = not-yet-resolved.
+  const [forecastEmpty, setForecastEmpty] = useState<boolean | null>(null);
+  const [artifactEmpty, setArtifactEmpty] = useState<boolean | null>(null);
+  const [sessionEmpty, setSessionEmpty] = useState<boolean | null>(null);
+  const allDataEmpty =
+    forecastEmpty === true && artifactEmpty === true && sessionEmpty === true;
+
+  // Crosslink closed forecasts ↔ retrospectives by correlation_id (ROB-678):
+  // only the intersection (ids present on both sides) gets anchors + links.
+  const [closedForecastIds, setClosedForecastIds] = useState<string[]>([]);
+  const [retroIds, setRetroIds] = useState<string[]>([]);
+  const linkedCorrelationIds = useMemo(() => {
+    const retro = new Set(retroIds);
+    return new Set(closedForecastIds.filter((id) => retro.has(id)));
+  }, [closedForecastIds, retroIds]);
+
+  return (
+    <MobileShell title="인사이트">
+      <div style={{ display: "flex", flexDirection: "column", gap: 14, padding: "14px 0 16px" }}>
+        <div style={{ padding: "0 16px" }}>
+          <PageHeader />
+        </div>
+
+        {allDataEmpty && (
+          <div style={{ padding: "0 16px" }}>
+            <AccumulatingBanner />
+          </div>
+        )}
+
+        <div style={{ padding: "0 16px" }}>
+          <Section title="시장 관찰">
+            <Card>
+              <MarketParityStrip state={marketParity.state} reload={marketParity.reload} />
+            </Card>
+            {disparity.status === "loading" && <SectionStatus>보통주/우선주 괴리 데이터를 불러오는 중…</SectionStatus>}
+            {disparity.status === "error" && <SectionStatus>보통주/우선주 괴리 데이터를 일시적으로 불러오지 못했습니다.</SectionStatus>}
+            {disparity.status === "ready" && <CommonPreferredDisparityCardView data={disparity.data} />}
+          </Section>
+        </div>
+
+        <div style={{ padding: "0 16px" }}>
+          <Section title="판단 품질">
+            <ForecastCalibrationPanel
+              onEmptyChange={setForecastEmpty}
+              onClosedCorrelationIds={setClosedForecastIds}
+              linkedCorrelationIds={linkedCorrelationIds}
+            />
+          </Section>
+        </div>
+
+        <div style={{ padding: "0 16px" }}>
+          <Section title="학습·회고">
+            <RetrospectivesPanel
+              compact
+              onCorrelationIds={setRetroIds}
+              linkedCorrelationIds={linkedCorrelationIds}
+            />
+          </Section>
+        </div>
+
+        <div style={{ padding: "0 16px" }}>
+          <Section title="세션 기록">
+            <AnalysisArtifactPanel onEmptyChange={setArtifactEmpty} />
+            <SessionContextTimelinePanel onEmptyChange={setSessionEmpty} />
+          </Section>
+        </div>
+
+        <div style={{ padding: "0 16px" }}>
+          <RelatedScreensCard />
+        </div>
+
+        <div style={{ padding: "0 16px" }}>
+          <ReadOnlyGuardrailNote />
+        </div>
+      </div>
+    </MobileShell>
+  );
+}

--- a/frontend/invest/src/routes.tsx
+++ b/frontend/invest/src/routes.tsx
@@ -17,7 +17,7 @@
 // /invest/my?tab=signals    — AI analysis signals within MY.
 // /invest/calendar          — Earnings/events calendar.
 // /invest/coverage          — Data coverage dashboard.
-// /invest/insights          — Read-only market insight cards.
+// /invest/insights          — Read-only market insight cards (responsive).
 // /invest/screener          — Stock screener (골라보기).
 // /invest/reports                 — Investment report list (ROB-265).
 // /invest/reports/:reportUuid     — Single investment report bundle.
@@ -33,7 +33,7 @@ import { CalendarRoute } from "./pages/desktop/DesktopCalendarPage";
 import { CoverageRoute } from "./pages/desktop/DesktopCoveragePage";
 import { DesktopScreenerPage } from "./pages/desktop/DesktopScreenerPage";
 import { DesktopMarketPage } from "./pages/desktop/DesktopMarketPage";
-import { DesktopInsightsPage } from "./pages/desktop/DesktopInsightsPage";
+import { InvestInsightsRoute } from "./pages/InsightsRoute";
 import { FxMacroRoute } from "./pages/desktop/FxMacroPage";
 import { DesktopCryptoPage } from "./pages/desktop/DesktopCryptoPage";
 import { ScalpingRoute } from "./pages/desktop/DesktopScalpingPage";
@@ -83,7 +83,7 @@ export const router = createBrowserRouter(
     { path: "/calendar", element: <CalendarRoute /> },
     { path: "/coverage", element: <CoverageRoute /> },
     { path: "/market", element: <DesktopMarketPage /> },
-    { path: "/insights", element: <DesktopInsightsPage /> },
+    { path: "/insights", element: <InvestInsightsRoute /> },
     { path: "/market/fx", element: <FxMacroRoute /> },
     { path: "/crypto", element: <DesktopCryptoPage /> },
     { path: "/crypto/:pair", element: <CryptoPairRedirect /> },

--- a/frontend/invest/src/stockDetailPath.ts
+++ b/frontend/invest/src/stockDetailPath.ts
@@ -17,7 +17,11 @@ function routeMarketParam(market: RouteMarket): StockDetailMarketParam {
 }
 
 function normalizeCryptoRouteSymbol(symbol: string): string {
-  const clean = symbol.trim().toUpperCase();
+  // Crypto DB symbols arrive dot-format (KRW.XRP; app/core/symbol.to_db_symbol).
+  // Fold "." → "-" so KRW.XRP joins the KRW- dash path instead of falling through
+  // to the bare-symbol branch (which would emit KRW-KRW.XRP). Dash/bare forms
+  // already normalized here are unaffected since they contain no ".".
+  const clean = symbol.trim().toUpperCase().replace(/\./g, "-");
   if (!clean) return clean;
   if (clean.startsWith("KRW-")) return clean;
   if (clean.endsWith("-KRW")) return `KRW-${clean.slice(0, -4)}`;


### PR DESCRIPTION
## Deploy to production (MacBook native blue-green)

Promotes `main` → `production`, deploying the 4 merged `/invest/insights` follow-ups (all frontend-only, migration 0, read-only, CI-green on main):

- **#1391 ROB-683** — crypto artifact 종목 link fix (`KRW.XRP` dot→dash)
- **#1393 ROB-680** — session timeline body clamp + 더보기 toggle
- **#1394 ROB-681** — mobile /insights viewport dispatch (`MobileInsightsPage`)
- **#1397 ROB-682** — forecast↔retro crosslink re-keyed on market+symbol (desktop + mobile)

`production..main` contains exactly these 4 commits, nothing else. Currently deployed release: `48112a49` (ROB-679).

🤖 Generated with [Claude Code](https://claude.com/claude-code)