### PR TITLE
deploy: ROB-685~689 Sentry perf batch → production

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -314,6 +314,17 @@ class Settings(BaseSettings):
     # test can touch a real Redis unless it explicitly patches the cache client.
     analyze_fetch_cache_enabled: bool = True
 
+    # ROB-688: bound the get_sector_peers KR peer fanout so the concurrent burst
+    # to m.stock.naver.com stops tripping Naver server-side throttling.
+    naver_peer_fetch_concurrency: int = 5
+    naver_peer_fetch_timeout_seconds: float = 5.0
+
+    # ROB-688: short-TTL fail-open Redis cache for the get_sector_peers KR
+    # /basic+/integration bundle and the sector page. Intraday staleness of
+    # current_price/change_pct up to the TTL is acceptable for a comparison tool.
+    naver_peer_cache_enabled: bool = True
+    naver_peer_cache_ttl_seconds: int = 600
+
     # API Rate Limit Retry Settings (429 handling)
     api_rate_limit_retry_429_max: int = 2  # 429 에러 시 최대 재시도 횟수
     api_rate_limit_retry_429_base_delay: float = 0.2  # 지수 백오프 기본 대기 시간 (초)

--- a/app/mcp_server/tooling/analysis_registration.py
+++ b/app/mcp_server/tooling/analysis_registration.py
@@ -334,6 +334,11 @@ def register_analysis_tools(
             "sort='matched_presets_desc' ranks multi-preset intersections first. "
             "Read-only. Preset sweeps are capped at 5 presets; analyst filters require at most "
             "200 merged rows before enrichment. "
+            "KR analyst consensus (buy/hold/sell counts + target prices) is cached "
+            "daily per symbol (Redis, KST-date TTL); the displayed target-upside is "
+            "recomputed each call from a fresh price so it stays intraday-current. "
+            "min_analyst_* filters resolve consensus from the cache and only the "
+            "returned page is enriched. "
             "Results are capped (default 40) and paginated via limit/offset."
         ),
     )

--- a/app/mcp_server/tooling/analysis_tool_handlers.py
+++ b/app/mcp_server/tooling/analysis_tool_handlers.py
@@ -660,6 +660,7 @@ async def _build_batch_position_index(
             account=None,
             market=market,
             include_current_price=False,
+            need_sellable=False,
         )
     except Exception as exc:
         detail = str(exc).strip() or exc.__class__.__name__

--- a/app/mcp_server/tooling/fundamentals/_market_index.py
+++ b/app/mcp_server/tooling/fundamentals/_market_index.py
@@ -129,3 +129,39 @@ async def handle_get_market_index(
             indices.append({"symbol": _DEFAULT_INDICES[i], "error": str(r)})
 
     return {"indices": indices}
+
+
+async def handle_get_market_index_current_only(symbol: str) -> dict[str, Any]:
+    """ROB-689: current-quote-only index fetch (drops the unused history page).
+
+    market-parity's get_index_quote reads only the current row, but the shared
+    handle_get_market_index also fetches a full history page per call. This sibling
+    returns the same current-row shape ({"indices": [row]}) WITHOUT the history
+    fetch. _fetch_index_kr_current (basic + 1-row price page) is kept intact so the
+    'open' field is present and _tag_kr_index_data_state can still apply the ROB-464
+    freshness override. The shared handle_get_market_index is intentionally NOT
+    modified (its other callers consume the history).
+    """
+    sym = (symbol or "").strip().upper()
+    meta = _INDEX_META.get(sym)
+    if meta is None:
+        raise ValueError(
+            f"Unknown index symbol '{sym}'. Supported: {', '.join(sorted(_INDEX_META))}"
+        )
+    try:
+        if meta["source"] == "naver":
+            current_data = await _fetch_index_kr_current(
+                meta["naver_code"], meta["name"]
+            )
+            return {"indices": [_tag_kr_index_data_state(current_data)]}
+        if meta["source"] == "coingecko":
+            current_data = await _fetch_index_crypto_current(
+                meta["cg_metric"], meta["name"], sym
+            )
+            return {"indices": [current_data]}
+        current_data = await _fetch_index_us_current(
+            meta["yf_ticker"], meta["name"], sym
+        )
+        return {"indices": [current_data]}
+    except Exception as exc:
+        return _error_payload(source=meta["source"], message=str(exc), symbol=sym)

--- a/app/mcp_server/tooling/portfolio_holdings.py
+++ b/app/mcp_server/tooling/portfolio_holdings.py
@@ -547,6 +547,8 @@ def _toss_api_position_to_mcp(position: TossPortfolioPosition) -> dict[str, Any]
 
 async def _collect_toss_api_positions(
     market_filter: str | None,
+    *,
+    need_sellable: bool = True,
 ) -> tuple[list[dict[str, Any]], list[dict[str, Any]], bool]:
     if not bool(getattr(settings, "toss_api_enabled", False)):
         return [], [], False
@@ -554,7 +556,7 @@ async def _collect_toss_api_positions(
         return [], [], False
 
     try:
-        snapshot = await fetch_toss_portfolio_snapshot()
+        snapshot = await fetch_toss_portfolio_snapshot(need_sellable=need_sellable)
     except Exception as exc:
         return (
             [],
@@ -786,6 +788,7 @@ async def _collect_portfolio_positions(
     account_name: str | None = None,
     user_id: int = _MCP_USER_ID,
     is_mock: bool = False,
+    need_sellable: bool = True,
 ) -> tuple[list[dict[str, Any]], list[dict[str, Any]], str | None, str | None]:
     # Short-circuit to paper handler when the caller asked for a paper account.
     from app.mcp_server.tooling.paper_portfolio_handler import (
@@ -873,7 +876,9 @@ async def _collect_portfolio_positions(
             toss_api_positions,
             toss_api_errors,
             toss_api_succeeded,
-        ) = await _collect_toss_api_positions(market_filter)
+        ) = await _collect_toss_api_positions(
+            market_filter, need_sellable=need_sellable
+        )
         positions.extend(toss_api_positions)
         errors.extend(toss_api_errors)
 

--- a/app/mcp_server/tooling/screener_snapshot_tool.py
+++ b/app/mcp_server/tooling/screener_snapshot_tool.py
@@ -12,6 +12,7 @@ return their default snapshot results (and say so), expanding as more presets ge
 
 from __future__ import annotations
 
+import functools
 import logging
 from typing import Any, Literal, cast
 
@@ -161,14 +162,6 @@ def _holding_market_filter(market: str) -> str | None:
     if normalized == "us":
         return "equity_us"
     return None
-
-
-def _consensus_count(row: dict[str, Any], key: str) -> int:
-    try:
-        value = (row.get("analysisContext") or {}).get("consensus", {}).get(key)
-        return int(value or 0)
-    except (TypeError, ValueError, AttributeError):
-        return 0
 
 
 def _filter_min_market_cap_with_warning(
@@ -450,8 +443,16 @@ async def screen_stocks_snapshot_impl(
     eff_limit = max(1, min(int(limit), _MAX_RESULT_LIMIT))
     eff_offset = max(0, int(offset))
 
-    # ROB-515: if analyst filtering is requested, we must enrich BEFORE pagination
-    # so we can filter on the enriched buyCount across the whole set.
+    # ROB-686: per-call memo shared by both the counts resolver and the page
+    # enrichment provider so a symbol resolved once (cache/live) is never
+    # re-fetched within the same tool call.
+    memo: dict[str, Any] = {}
+
+    # ROB-686: min_analyst_* now resolves consensus COUNTS once via the KR
+    # Redis cache-aside (bounded by _MAX_ANALYST_ENRICHMENT_ROWS), filters,
+    # paginates, and only THEN full-enriches the returned page — replacing the
+    # old ROB-515 behavior of live-enriching the entire matched set (up to 200
+    # rows) before pagination.
     if min_analyst_count is not None or min_analyst_buy_count is not None:
         if len(all_results) > _MAX_ANALYST_ENRICHMENT_ROWS:
             return {
@@ -472,28 +473,53 @@ async def screen_stocks_snapshot_impl(
                 },
             }
 
+        from app.core import analyze_cache
+        from app.services.invest_view_model import analyst_consensus_cache
+
+        redis_client = await analyze_cache._get_redis_client()
+        matched_symbols = [
+            str(r.get("symbol") or "").strip() for r in all_results if r.get("symbol")
+        ]
+        counts = await analyst_consensus_cache.resolve_consensus_counts(
+            symbols=matched_symbols,
+            market=market,
+            redis_client=redis_client,
+            memo=memo,
+        )
+
+        def _passes(row: dict[str, Any]) -> bool:
+            c = counts.get(str(row.get("symbol") or "").strip())
+            if c is None:
+                return False
+            if min_analyst_count is not None and (c.get("totalCount") or 0) < int(
+                min_analyst_count
+            ):
+                return False
+            if min_analyst_buy_count is not None and (c.get("buyCount") or 0) < int(
+                min_analyst_buy_count
+            ):
+                return False
+            return True
+
+        all_results = [r for r in all_results if _passes(r)]
+        total_available = len(all_results)
+        page = all_results[eff_offset : eff_offset + eff_limit]
+
         from app.services.invest_view_model.screener_analysis_enrichment import (
             enrich_snapshot_page,
         )
 
         enrichment = await enrich_snapshot_page(
-            rows=all_results,
+            rows=page,
             market=market,
             session_factory=_session_factory(),
+            opinion_provider=functools.partial(
+                analyst_consensus_cache.cached_opinion_provider,
+                redis_client=redis_client,
+                memo=memo,
+            ),
         )
-        all_results = enrichment["results"]
-        if min_analyst_count is not None:
-            min_total = int(min_analyst_count)
-            all_results = [
-                r for r in all_results if _consensus_count(r, "totalCount") >= min_total
-            ]
-        if min_analyst_buy_count is not None:
-            min_buy = int(min_analyst_buy_count)
-            all_results = [
-                r for r in all_results if _consensus_count(r, "buyCount") >= min_buy
-            ]
-        total_available = len(all_results)
-        page = all_results[eff_offset : eff_offset + eff_limit]
+        page = enrichment["results"]
         payload["analysisEnrichment"] = enrichment["summary"]
     else:
         page = all_results[eff_offset : eff_offset + eff_limit]
@@ -510,14 +536,22 @@ async def screen_stocks_snapshot_impl(
     }
 
     if min_analyst_count is None and min_analyst_buy_count is None:
+        from app.core import analyze_cache
+        from app.services.invest_view_model import analyst_consensus_cache
         from app.services.invest_view_model.screener_analysis_enrichment import (
             enrich_snapshot_page,
         )
 
+        redis_client = await analyze_cache._get_redis_client()
         enrichment = await enrich_snapshot_page(
             rows=page,
             market=market,
             session_factory=_session_factory(),
+            opinion_provider=functools.partial(
+                analyst_consensus_cache.cached_opinion_provider,
+                redis_client=redis_client,
+                memo=memo,
+            ),
         )
         payload["results"] = enrichment["results"]
         payload["analysisEnrichment"] = enrichment["summary"]

--- a/app/mcp_server/tooling/toss_live_evidence.py
+++ b/app/mcp_server/tooling/toss_live_evidence.py
@@ -153,7 +153,17 @@ def classify_toss_order_evidence(order: Any) -> TossFillEvidence:
 
 
 class TossEvidenceAdapter:
+    def __init__(self, client: TossReadClient | None = None) -> None:
+        # An injected client is caller-owned (shared across the reconcile run) and
+        # must NOT be closed here. Only a self-newed client (client=None, legacy
+        # path) is closed in fetch_evidence. ROB-687: sharing one client removes
+        # the per-row /accounts N+1.
+        self._client = client
+
     async def fetch_evidence(self, row: Any) -> TossFillEvidence:
+        if self._client is not None:
+            order = await self._client.get_order(str(row.broker_order_id))
+            return classify_toss_order_evidence(order)
         client = TossReadClient.from_settings()
         try:
             order = await client.get_order(str(row.broker_order_id))

--- a/app/mcp_server/tooling/toss_live_ledger.py
+++ b/app/mcp_server/tooling/toss_live_ledger.py
@@ -6,6 +6,7 @@ from decimal import Decimal
 from typing import Any
 
 import httpx
+import sentry_sdk
 
 from app.core.config import settings
 from app.core.portfolio_links import build_position_detail_url
@@ -23,6 +24,7 @@ from app.mcp_server.tooling.toss_live_evidence import (
 )
 from app.models.review import TossLiveOrderLedger
 from app.monitoring.trade_notifier import get_trade_notifier
+from app.services.brokers.toss import TossReadClient
 from app.services.brokers.toss.errors import TossApiResponseError, TossRateLimitError
 from app.services.fill_notification import (
     is_fill_notifiable,
@@ -216,6 +218,7 @@ async def _reconcile_one_toss_row(
     *,
     dry_run: bool,
     evidence_source: Any | None = None,
+    fallback_client: Any | None = None,
 ) -> dict[str, Any]:
     base = {
         "ledger_id": row.id,
@@ -228,7 +231,7 @@ async def _reconcile_one_toss_row(
     if evidence_source is not None:
         evidence = await evidence_source.evidence_for(row)
     else:
-        evidence = await TossEvidenceAdapter().fetch_evidence(row)
+        evidence = await TossEvidenceAdapter(client=fallback_client).fetch_evidence(row)
     base["verdict"] = evidence.verdict
     base["broker_status"] = evidence.broker_status
     base["local_status"] = evidence.local_status
@@ -581,26 +584,52 @@ async def toss_reconcile_orders_impl(
     reconciled: list[dict[str, Any]] = []
     counts: dict[str, int] = {}
 
+    batch_build_error: dict[str, Any] | None = None
+
+    # ROB-687 — one TossReadClient for the whole run so account-seq is resolved at
+    # most once (per-instance cache; client.py:128-129,135) instead of once per
+    # fresh per-row client. The ACCOUNT group is 1 TPS (rate_limiter.py:27), so a
+    # per-row /accounts N+1 serializes into ~1s of sleep per open row. Defensive:
+    # if Toss is disabled/misconfigured, degrade exactly as before (per-row/batch
+    # construct their own; the per-row error handler classifies the failure).
+    shared_client: TossReadClient | None = None
+    if rows:
+        try:
+            shared_client = TossReadClient.from_settings()
+        except Exception as exc:  # noqa: BLE001 — degrade to legacy path
+            logger.warning(
+                "toss reconcile: shared client unavailable (%s); legacy per-row path",
+                exc,
+            )
+            shared_client = None
+
     evidence_source = None
     if rows:
         try:
             evidence_source = await TossBatchEvidenceSource.build(
-                rows=rows, symbol=symbol
+                rows=rows, symbol=symbol, client=shared_client
             )
         except Exception as exc:  # noqa: BLE001 — batch is an optimization
-            # Any batch-build failure (disabled/network/transient) degrades to the
-            # per-row single-fetch path; per-row R1 classification still applies.
-            logger.warning(
-                "toss reconcile batch evidence build failed; per-row fallback: %s",
-                exc,
+            # Any batch-build failure (disabled/network/transient/bug) degrades to
+            # the per-row single-fetch path; per-row R1 classification still applies.
+            # ROB-687: this was previously a silent one-line WARNING, which hid the
+            # root cause of the /accounts N+1 for weeks — surface it with a stack
+            # trace + Sentry capture + a result echo so it can be diagnosed.
+            logger.exception(
+                "toss reconcile batch evidence build failed; per-row fallback"
             )
+            sentry_sdk.capture_exception(exc)
+            batch_build_error = {"type": type(exc).__name__, "message": str(exc)}
             evidence_source = None
 
     try:
         for row in rows:
             try:
                 outcome = await _reconcile_one_toss_row(
-                    row, dry_run=dry_run, evidence_source=evidence_source
+                    row,
+                    dry_run=dry_run,
+                    evidence_source=evidence_source,
+                    fallback_client=shared_client,
                 )
             except Exception as exc:  # noqa: BLE001 — classified in the handler
                 outcome = await _handle_reconcile_row_error(row, exc, dry_run=dry_run)
@@ -609,7 +638,9 @@ async def toss_reconcile_orders_impl(
             counts[verdict] = counts.get(verdict, 0) + 1
     finally:
         if evidence_source is not None:
-            await evidence_source.aclose()
+            await evidence_source.aclose()  # no-op for a run-owned client
+        if shared_client is not None:
+            await shared_client.aclose()
 
     result: dict[str, Any] = {
         "success": True,
@@ -617,6 +648,7 @@ async def toss_reconcile_orders_impl(
         "counts": counts,
         "reconciled": reconciled,
         "reopened": reopen_report,  # {dry_run, reopened, candidates}
+        "batch_build_error": batch_build_error,
         "message": (
             f"Reconciled {len(reconciled)} Toss live order(s) "
             f"(dry_run={dry_run}): {counts}"

--- a/app/services/invest_home_readers.py
+++ b/app/services/invest_home_readers.py
@@ -551,7 +551,9 @@ class TossApiHomeReader:
                 op="invest.home.toss_api.phase",
                 name="invest.home.toss_api.snapshot",
             ) as span:
-                snapshot = await fetch_toss_portfolio_snapshot()
+                snapshot = await fetch_toss_portfolio_snapshot(
+                    need_sellable=mutations_enabled
+                )
                 span.set_data("position_count", len(snapshot.positions))
                 span.set_data("error_count", len(snapshot.errors))
             holdings: list[Holding] = []

--- a/app/services/invest_view_model/analyst_consensus_cache.py
+++ b/app/services/invest_view_model/analyst_consensus_cache.py
@@ -1,0 +1,243 @@
+"""ROB-686 — KR analyst-consensus Redis cache-aside for the snapshot screener.
+
+Caches the DAILY-STABLE analyst consensus (buy/hold/sell/total counts + target
+prices) per (market, symbol, KST-date) so screen_stocks_snapshot stops re-scraping
+Naver research pages (company_list/company_read) on every call. The volatile
+current_price/upside_pct are stripped before caching and recomputed on the
+returned page from a fresh price (see cached_opinion_provider). KR only; US
+(yfinance) is not cached. Fail-open + hermetic: reuses app.core.analyze_cache's
+Redis client + TTL, guarded by settings.analyze_fetch_cache_enabled.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from datetime import datetime
+from typing import Any
+
+from app.core import analyze_cache
+from app.core.timezone import now_kst
+
+logger = logging.getLogger(__name__)
+
+_KEY_PREFIX = "screener_consensus"
+
+_STABLE_CONSENSUS_FIELDS: frozenset[str] = frozenset(
+    {
+        "buy_count",
+        "hold_count",
+        "sell_count",
+        "strong_buy_count",
+        "total_count",
+        "avg_target_price",
+        "median_target_price",
+        "min_target_price",
+        "max_target_price",
+        "rows_total",
+        "rows_used",
+        "rows_excluded_stale",
+        "rows_undated",
+        "newest_opinion_date",
+        "window_months",
+        "target_price_count",
+        "target_price_honest",
+    }
+)
+
+
+def _consensus_cache_key(market: str, symbol: str, now: datetime | None = None) -> str:
+    date_part = analyze_cache._provider_date_for_key(analyze_cache.PROVIDER_NAVER, now)
+    return f"{_KEY_PREFIX}:{analyze_cache.PROVIDER_NAVER}:{symbol.upper()}:{date_part}"
+
+
+def _strip_volatile(consensus: dict[str, Any]) -> dict[str, Any]:
+    return {k: v for k, v in consensus.items() if k in _STABLE_CONSENSUS_FIELDS}
+
+
+async def get_cached_consensus(
+    redis_client: Any, market: str, symbol: str
+) -> dict[str, Any] | None:
+    if redis_client is None or (market or "").strip().lower() != "kr":
+        return None
+    key = _consensus_cache_key(market, symbol)
+    try:
+        raw = await redis_client.get(key)
+    except Exception as exc:  # noqa: BLE001 — fail-open
+        logger.debug("consensus_cache GET failed %s: %s", key, exc)
+        return None
+    if not isinstance(raw, str):
+        return None
+    try:
+        parsed = json.loads(raw)
+    except (TypeError, ValueError):
+        return None
+    return parsed if isinstance(parsed, dict) else None
+
+
+async def set_cached_consensus(
+    redis_client: Any, market: str, symbol: str, consensus: dict[str, Any]
+) -> None:
+    if redis_client is None or (market or "").strip().lower() != "kr":
+        return
+    total = consensus.get("total_count")
+    if not isinstance(total, int) or total <= 0:
+        return  # never cache a degraded/empty consensus
+    try:
+        now = now_kst()
+        ttl = analyze_cache._fetch_cache_ttl_seconds(analyze_cache.PROVIDER_NAVER, now)
+        if ttl <= 0:
+            return
+        serialized = json.dumps(
+            _strip_volatile(consensus), default=str, ensure_ascii=False
+        )
+        await redis_client.set(
+            _consensus_cache_key(market, symbol, now), serialized, ex=ttl
+        )
+    except Exception as exc:  # noqa: BLE001 — fail-open
+        logger.debug("consensus_cache SET failed %s: %s", symbol, exc)
+
+
+async def resolve_consensus(
+    *,
+    symbol: str,
+    market: str,
+    redis_client: Any = None,
+    memo: dict[str, dict[str, Any] | None] | None = None,
+    opinion_fetcher: Any = None,
+) -> dict[str, Any] | None:
+    market_norm = (market or "").strip().lower()
+    memo_key = f"{market_norm}:{symbol.upper()}"
+    if memo is not None and memo_key in memo:
+        return memo[memo_key]
+
+    if opinion_fetcher is None:
+        from app.mcp_server.tooling.fundamentals._valuation import (
+            handle_get_investment_opinions,
+        )
+
+        opinion_fetcher = handle_get_investment_opinions
+
+    if market_norm == "kr":
+        cached = await get_cached_consensus(redis_client, market_norm, symbol)
+        if cached is not None:
+            if memo is not None:
+                memo[memo_key] = cached
+            return cached
+
+    stable: dict[str, Any] | None = None
+    try:
+        # limit=10 preserves the existing filter/page ceiling (see interface note);
+        # do NOT bump this — a higher cap triples cold company_read.naver fetches.
+        payload = await opinion_fetcher(symbol=symbol, market=market_norm, limit=10)
+        consensus = (
+            (payload or {}).get("consensus") if isinstance(payload, dict) else None
+        )
+        if isinstance(consensus, dict) and isinstance(
+            consensus.get("total_count"), int
+        ):
+            if market_norm == "kr":
+                await set_cached_consensus(redis_client, market_norm, symbol, consensus)
+                stable = _strip_volatile(consensus)
+            else:
+                stable = consensus  # US: not cached, returned as-is
+    except Exception as exc:  # noqa: BLE001 — fail-open
+        logger.debug("resolve_consensus live fetch failed %s: %s", symbol, exc)
+        stable = None
+
+    if memo is not None:
+        memo[memo_key] = stable
+    return stable
+
+
+async def resolve_consensus_counts(
+    *,
+    symbols: list[str],
+    market: str,
+    redis_client: Any = None,
+    memo: dict[str, dict[str, Any] | None] | None = None,
+    concurrency: int = 4,
+    opinion_fetcher: Any = None,
+) -> dict[str, dict[str, int | None]]:
+    sem = asyncio.Semaphore(max(1, concurrency))  # NOT raised — Naver is throttling
+    out: dict[str, dict[str, int | None]] = {}
+
+    async def _one(symbol: str) -> None:
+        async with sem:
+            stable = await resolve_consensus(
+                symbol=symbol,
+                market=market,
+                redis_client=redis_client,
+                memo=memo,
+                opinion_fetcher=opinion_fetcher,
+            )
+            if stable is not None:
+                out[symbol] = {
+                    "totalCount": stable.get("total_count"),
+                    "buyCount": stable.get("buy_count"),
+                }
+
+    await asyncio.gather(*(_one(s) for s in dict.fromkeys(symbols)))
+    return out
+
+
+def _recompute_upside(
+    consensus: dict[str, Any], price: float | int | None
+) -> dict[str, Any]:
+    out = dict(consensus)
+    avg = out.get("avg_target_price")
+    if (
+        price
+        and isinstance(price, (int, float))
+        and avg
+        and isinstance(avg, (int, float))
+    ):
+        out["current_price"] = price
+        out["upside_pct"] = round((avg - price) / price * 100, 2)
+    else:
+        out.pop("current_price", None)
+        out.pop("upside_pct", None)
+    return out
+
+
+async def cached_opinion_provider(
+    *,
+    symbol: str,
+    market: str,
+    limit: int = 10,
+    redis_client: Any = None,
+    memo: dict[str, dict[str, Any] | None] | None = None,
+    price_fetcher: Any = None,
+    opinion_fetcher: Any = None,
+) -> dict[str, Any]:
+    market_norm = (market or "").strip().lower()
+    if market_norm != "kr":
+        from app.mcp_server.tooling.fundamentals._valuation import (
+            handle_get_investment_opinions,
+        )
+
+        return await handle_get_investment_opinions(
+            symbol=symbol, market=market_norm, limit=limit
+        )
+
+    stable = await resolve_consensus(
+        symbol=symbol,
+        market=market_norm,
+        redis_client=redis_client,
+        memo=memo,
+        opinion_fetcher=opinion_fetcher,
+    )
+    if stable is None:
+        return {"error": "analyst_consensus_unavailable"}
+
+    if price_fetcher is None:
+        from app.services.naver_finance.investor import _fetch_current_price
+
+        price_fetcher = _fetch_current_price
+    try:
+        price = await price_fetcher(symbol)
+    except Exception:  # noqa: BLE001 — fail-open, no stale upside
+        price = None
+
+    return {"source": "naver", "consensus": _recompute_upside(stable, price)}

--- a/app/services/invest_view_model/market_parity_service.py
+++ b/app/services/invest_view_model/market_parity_service.py
@@ -15,7 +15,9 @@ from decimal import ROUND_HALF_UP, Decimal, InvalidOperation
 from typing import Any, Protocol
 
 from app.mcp_server.tooling.fundamentals._crypto import handle_get_kimchi_premium
-from app.mcp_server.tooling.fundamentals._market_index import handle_get_market_index
+from app.mcp_server.tooling.fundamentals._market_index import (
+    handle_get_market_index_current_only,
+)
 from app.schemas.invest_market_parity import (
     InvestMarketParityCard,
     InvestMarketParityResponse,
@@ -76,7 +78,7 @@ class DefaultMarketParityProvider:
     """
 
     async def get_index_quote(self, symbol: str) -> ParityQuote | None:
-        payload = await handle_get_market_index(symbol=symbol, period="day", count=1)
+        payload = await handle_get_market_index_current_only(symbol)
         row = _first_index_row(payload, symbol)
         if row is None:
             return None
@@ -524,26 +526,12 @@ async def build_market_parity(
     warnings: list[str] = []
     cards: list[InvestMarketParityCard] = []
 
-    index_card, index_warnings = await _build_index_card(
-        provider,
-        IndexParityConfig(
-            id="ewy-kospi-implied-parity",
-            title="EWY implied KOSPI parity",
-            base_symbol="KOSPI",
-            proxy_symbol="EWY",
-        ),
+    index_config = IndexParityConfig(
+        id="ewy-kospi-implied-parity",
+        title="EWY implied KOSPI parity",
+        base_symbol="KOSPI",
+        proxy_symbol="EWY",
     )
-    cards.append(index_card)
-    warnings.extend(index_warnings)
-
-    stablecoin_card, stablecoin_warnings = await _build_stablecoin_card(provider)
-    cards.append(stablecoin_card)
-    warnings.extend(stablecoin_warnings)
-
-    kimchi_card, kimchi_warnings = await _build_kimchi_card(provider)
-    cards.append(kimchi_card)
-    warnings.extend(kimchi_warnings)
-
     synthetic_configs = [
         SyntheticParityConfig(
             base_symbol="005930",
@@ -558,8 +546,30 @@ async def build_market_parity(
             title="SK hynix synthetic parity",
         ),
     ][: max(limit, 0)]
-    for config in synthetic_configs:
-        card, card_warnings = await _build_synthetic_card(provider, config)
+
+    # ROB-689: the four card builders are independent; gather them so the two
+    # network-bound cards (index=KOSPI/naver, kimchi=upbit+binance+er-api) overlap
+    # instead of summing. Order of cards + warnings is preserved exactly (gather
+    # returns results positionally), so the response is byte-identical to serial.
+    (
+        (index_card, index_warnings),
+        (stablecoin_card, stablecoin_warnings),
+        (kimchi_card, kimchi_warnings),
+        *synthetic_results,
+    ) = await asyncio.gather(
+        _build_index_card(provider, index_config),
+        _build_stablecoin_card(provider),
+        _build_kimchi_card(provider),
+        *(_build_synthetic_card(provider, config) for config in synthetic_configs),
+    )
+
+    cards.append(index_card)
+    warnings.extend(index_warnings)
+    cards.append(stablecoin_card)
+    warnings.extend(stablecoin_warnings)
+    cards.append(kimchi_card)
+    warnings.extend(kimchi_warnings)
+    for card, card_warnings in synthetic_results:
         cards.append(card)
         warnings.extend(card_warnings)
 

--- a/app/services/naver_finance/peer_cache.py
+++ b/app/services/naver_finance/peer_cache.py
@@ -1,0 +1,116 @@
+"""ROB-688 — short-TTL fail-open Redis cache for get_sector_peers KR fetches.
+
+Cache-aside over the Naver mobile /basic+/integration bundle (keyed by stock
+code) and the sector detail page derivation (keyed by industry code). Mirrors
+the fail-open contract of app.core.analyze_cache: any Redis outage or malformed
+payload degrades to a live fetch and never raises. Gated by
+settings.naver_peer_cache_enabled (forced off in tests/conftest.py).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+import redis.asyncio as redis
+
+from app.core.config import settings
+from app.services.ohlcv_cache_common import create_redis_client
+
+logger = logging.getLogger(__name__)
+
+_INTEG_PREFIX = "naver_peer:integ:"
+_SECTOR_PREFIX = "naver_peer:sector:"
+_REDIS_CLIENT: redis.Redis | None = None
+
+
+async def _get_redis_client() -> redis.Redis | None:
+    global _REDIS_CLIENT
+    if not settings.naver_peer_cache_enabled:
+        return None
+    if _REDIS_CLIENT is not None:
+        return _REDIS_CLIENT
+    try:
+        _REDIS_CLIENT = await create_redis_client()
+    except Exception as exc:  # noqa: BLE001 — fail open to live fetch
+        logger.debug("peer_cache: redis init failed: %s", exc)
+        _REDIS_CLIENT = None
+    return _REDIS_CLIENT
+
+
+async def close_peer_cache_redis() -> None:
+    global _REDIS_CLIENT
+    if _REDIS_CLIENT is not None:
+        try:
+            await _REDIS_CLIENT.close()
+        except Exception:  # noqa: BLE001
+            pass
+        _REDIS_CLIENT = None
+
+
+def _parse_dict(value: Any) -> dict[str, Any] | None:
+    if not isinstance(value, str):
+        return None
+    try:
+        parsed = json.loads(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if isinstance(parsed, dict) else None
+
+
+async def _get(redis_client: redis.Redis | None, key: str) -> dict[str, Any] | None:
+    if redis_client is None:
+        return None
+    try:
+        raw = await redis_client.get(key)
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("peer_cache: GET failed for %s: %s", key, exc)
+        return None
+    return _parse_dict(raw)
+
+
+async def _set(
+    redis_client: redis.Redis | None, key: str, payload: dict[str, Any]
+) -> None:
+    if redis_client is None:
+        return
+    try:
+        ttl = max(1, int(settings.naver_peer_cache_ttl_seconds))
+        serialized = json.dumps(payload, default=str, ensure_ascii=False)
+        await redis_client.set(key, serialized, ex=ttl)
+    except Exception as exc:  # noqa: BLE001 — best-effort
+        logger.debug("peer_cache: SET failed for %s: %s", key, exc)
+
+
+async def get_cached_integration(
+    redis_client: redis.Redis | None, code: str
+) -> dict[str, Any] | None:
+    return await _get(redis_client, f"{_INTEG_PREFIX}{code.upper()}")
+
+
+async def set_cached_integration(
+    redis_client: redis.Redis | None, code: str, payload: dict[str, Any]
+) -> None:
+    await _set(redis_client, f"{_INTEG_PREFIX}{code.upper()}", payload)
+
+
+async def get_cached_sector(
+    redis_client: redis.Redis | None, industry_code: str
+) -> dict[str, Any] | None:
+    return await _get(redis_client, f"{_SECTOR_PREFIX}{industry_code}")
+
+
+async def set_cached_sector(
+    redis_client: redis.Redis | None, industry_code: str, payload: dict[str, Any]
+) -> None:
+    await _set(redis_client, f"{_SECTOR_PREFIX}{industry_code}", payload)
+
+
+__all__ = [
+    "close_peer_cache_redis",
+    "get_cached_integration",
+    "get_cached_sector",
+    "set_cached_integration",
+    "set_cached_sector",
+]

--- a/app/services/naver_finance/valuation.py
+++ b/app/services/naver_finance/valuation.py
@@ -10,7 +10,9 @@ from typing import Any
 import httpx
 from bs4 import BeautifulSoup
 
+from app.core.config import settings
 from app.core.number_utils import parse_korean_number as _parse_korean_number
+from app.services.naver_finance import peer_cache
 from app.services.naver_finance.parser import (
     DEFAULT_HEADERS,
     NAVER_FINANCE_BASE,
@@ -307,15 +309,27 @@ def _parse_total_infos(total_infos: list[dict[str, Any]]) -> dict[str, Any]:
 async def _fetch_integration(
     code: str,
     client: httpx.AsyncClient,
+    request_timeout: float | None = None,
 ) -> dict[str, Any]:
     """Fetch the Naver mobile basic + integration endpoints for a single stock.
+
+    Args:
+        request_timeout: optional per-request timeout override (ROB-688) — when
+            provided, applied to both requests via ``client.get(..., timeout=...)``
+            without touching the shared client-level timeout. ``None`` (default)
+            keeps the client-level timeout, preserving existing callers'
+            behavior (``fetch_valuation``'s overlay and the target fetch inside
+            ``fetch_sector_peers``).
 
     Returns a dict with ``name``, ``per``, ``pbr``, ``market_cap``, ``current_price``,
     ``change_pct``, ``industry_code``, ``peers_raw``.
     """
+    get_kwargs: dict[str, Any] = {}
+    if request_timeout is not None:
+        get_kwargs["timeout"] = request_timeout
     r_basic, r_integ = await asyncio.gather(
-        client.get(f"{NAVER_MOBILE_API}/{code}/basic"),
-        client.get(f"{NAVER_MOBILE_API}/{code}/integration"),
+        client.get(f"{NAVER_MOBILE_API}/{code}/basic", **get_kwargs),
+        client.get(f"{NAVER_MOBILE_API}/{code}/integration", **get_kwargs),
     )
     r_basic.raise_for_status()
     r_integ.raise_for_status()
@@ -353,6 +367,27 @@ async def _fetch_integration(
     }
 
 
+async def _fetch_integration_cached(
+    code: str,
+    client: httpx.AsyncClient,
+    redis_client: Any = None,
+    *,
+    request_timeout: float | None = None,
+) -> dict[str, Any]:
+    """Cache-aside over ``_fetch_integration`` (ROB-688).
+
+    Fail-open: any cache miss or Redis outage falls through to the live fetch;
+    only non-degraded results (a resolved name) are written back.
+    """
+    cached = await peer_cache.get_cached_integration(redis_client, code)
+    if cached is not None:
+        return cached
+    result = await _fetch_integration(code, client, request_timeout=request_timeout)
+    if result.get("name"):
+        await peer_cache.set_cached_integration(redis_client, code, result)
+    return result
+
+
 async def fetch_sector_peers(
     code: str,
     limit: int = 5,
@@ -377,11 +412,12 @@ async def fetch_sector_peers(
         Dict with ``symbol``, ``name``, ``sector``, ``peers`` list, and
         ``comparison`` metrics.
     """
+    redis_client = await peer_cache._get_redis_client()
     async with httpx.AsyncClient(
         headers=DEFAULT_HEADERS,
         timeout=10,
     ) as client:
-        target = await _fetch_integration(code, client)
+        target = await _fetch_integration_cached(code, client, redis_client)
         sector_name: str | None = None
 
         # ---- Collect peer codes from integration response ----
@@ -391,28 +427,44 @@ async def fetch_sector_peers(
             if pc and pc != code:
                 peer_codes.append(pc)
 
+        integration_peer_count = len(peer_codes)
+
         industry_code = target.get("industry_code")
         sector_soup = None
         if industry_code:
+            # Sector page is dual-purpose: sector NAME (always) + extra peers.
+            # Fetch it once regardless of whether we need extras (constraint).
             sector_soup = await _fetch_sector_soup(str(industry_code), client)
 
-        # If we need more peers, scrape the sector detail page.
-        if len(peer_codes) < limit and sector_soup is not None:
-            extra_codes = _parse_sector_stock_codes(sector_soup)
-            seen = {code, *peer_codes}
-            for ec in extra_codes:
-                if ec not in seen:
-                    peer_codes.append(ec)
-                    seen.add(ec)
+        if integration_peer_count < limit:
+            # Not enough peers from integration — pad with sector-scraped codes,
+            # then fetch a few extras in case some fail.
+            if sector_soup is not None:
+                extra_codes = _parse_sector_stock_codes(sector_soup)
+                seen = {code, *peer_codes}
+                for ec in extra_codes:
+                    if ec not in seen:
+                        peer_codes.append(ec)
+                        seen.add(ec)
+            peer_codes = peer_codes[: limit + 5]
+        else:
+            # Integration already has enough peers — no over-fetch padding.
+            peer_codes = peer_codes[:limit]
 
-        # ---- Fetch integration data for each peer concurrently ----
-        peer_codes = peer_codes[: limit + 5]  # fetch extras in case some fail
+        # ---- Fetch integration data for each peer concurrently (bounded) ----
+        semaphore = asyncio.Semaphore(max(1, settings.naver_peer_fetch_concurrency))
 
         async def _safe_fetch(pc: str) -> dict[str, Any] | None:
-            try:
-                return await _fetch_integration(pc, client)
-            except Exception:
-                return None
+            async with semaphore:
+                try:
+                    return await _fetch_integration_cached(
+                        pc,
+                        client,
+                        redis_client,
+                        request_timeout=settings.naver_peer_fetch_timeout_seconds,
+                    )
+                except Exception:
+                    return None
 
         peer_results = await asyncio.gather(*[_safe_fetch(pc) for pc in peer_codes])
 

--- a/app/services/toss_portfolio_service.py
+++ b/app/services/toss_portfolio_service.py
@@ -130,6 +130,7 @@ async def fetch_toss_cash_snapshot(
 
 async def fetch_toss_portfolio_snapshot(
     *,
+    need_sellable: bool = True,
     client: TossPortfolioClient | None = None,
 ) -> TossPortfolioSnapshot:
     created_client = client is None
@@ -145,29 +146,38 @@ async def fetch_toss_portfolio_snapshot(
 
         errors: list[dict[str, Any]] = []
 
-        with sentry_sdk.start_span(
-            op="invest.home.toss_api.phase",
-            name="invest.home.toss_api.sellable_quantity",
-        ) as span:
-            span.set_data("position_count", len(holdings.items))
-            sellable_results = await asyncio.gather(
-                *[
-                    active_client.sellable_quantity(symbol=item.symbol)
-                    for item in holdings.items
-                ],
-                return_exceptions=True,
+        if need_sellable:
+            with sentry_sdk.start_span(
+                op="invest.home.toss_api.phase",
+                name="invest.home.toss_api.sellable_quantity",
+            ) as span:
+                span.set_data("position_count", len(holdings.items))
+                sellable_results = await asyncio.gather(
+                    *[
+                        active_client.sellable_quantity(symbol=item.symbol)
+                        for item in holdings.items
+                    ],
+                    return_exceptions=True,
+                )
+                span.set_data(
+                    "error_count",
+                    sum(
+                        1
+                        for result in sellable_results
+                        if isinstance(result, BaseException)
+                    ),
+                )
+            paired: list[tuple[Any, Any]] = list(
+                zip(holdings.items, sellable_results, strict=True)
             )
-            span.set_data(
-                "error_count",
-                sum(
-                    1
-                    for result in sellable_results
-                    if isinstance(result, BaseException)
-                ),
-            )
+        else:
+            # ROB-685: caller does not consume sellable_quantity — skip the
+            # per-holding GET /sellable-quantity (ORDER_INFO, 6 TPS) fanout that
+            # otherwise serializes to ~6/sec and dominates wall time.
+            paired = [(item, None) for item in holdings.items]
 
         positions: list[TossPortfolioPosition] = []
-        for item, sellable_result in zip(holdings.items, sellable_results, strict=True):
+        for item, sellable_result in paired:
             sellable_quantity: Decimal | None = None
             if isinstance(sellable_result, BaseException):
                 errors.append(
@@ -178,7 +188,7 @@ async def fetch_toss_portfolio_snapshot(
                         "error": str(sellable_result),
                     }
                 )
-            else:
+            elif sellable_result is not None:
                 sellable_quantity = sellable_result.sellable_quantity
 
             instrument_type = _instrument_type_for_market_country(item.market_country)

--- a/docs/plans/ROB-685-toss-sellable-quantity-nplus1-skip.md
+++ b/docs/plans/ROB-685-toss-sellable-quantity-nplus1-skip.md
@@ -1,0 +1,412 @@
+# Toss `sellable_quantity` N+1 Fanout — Caller-Scoped Skip Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (- [ ]) syntax.
+
+**Goal:** Kill the dominant latency bottleneck across four Sentry transactions (`/invest/api/home`, `/invest/api/account-panel`, `get_holdings`, `analyze_stock_batch`) by making `fetch_toss_portfolio_snapshot()` **not** fan out one `GET /api/v1/sellable-quantity` per holding when the caller does not consume the value. Today every one of ~47 holdings issues a `TossApiGroup.ORDER_INFO` request whose process-global rate limiter caps at 6 TPS (3 TPS during 09:00–09:10 KST), so the `asyncio.gather` serializes to ~6/sec → 13–17 s of pure wall-time. In the default config (`TOSS_LIVE_ORDER_MUTATIONS_ENABLED` off) the invest_home reader computes `_toss_sellable_quantity()` → `0.0` and **discards** the fetched value, and the `analyze_stock_batch` position index never reads sellable at all — so the fanout is wasted work. We thread a `need_sellable` flag (**default `True`**) through the shared fetch chain and pass `False` from exactly the callers that provably do not consume the value, without ever reading a global feature flag inside the shared function.
+
+**Architecture:** Current (slow) flow — `fetch_toss_portfolio_snapshot()` (`app/services/toss_portfolio_service.py:131`) unconditionally builds `[active_client.sellable_quantity(symbol=item.symbol) for item in holdings.items]` and `asyncio.gather`s it inside the `invest.home.toss_api.sellable_quantity` span (`toss_portfolio_service.py:148-167`); each call routes through `TossReadClient.sellable_quantity` (`app/services/brokers/toss/client.py:310-319`, `group=TossApiGroup.ORDER_INFO`) whose shared `TossRateLimiter.acquire` (`app/services/brokers/toss/rate_limiter.py:57-73`) admits only `_BASE_LIMITS[ORDER_INFO]=6` per sliding second (`rate_limiter.py:35`), dropping to `3` in the 09:00–09:10 peak window (`rate_limiter.py:52-55`). Two hot callers reach this function: the invest_home reader `TossApiHomeReader.fetch` (`app/services/invest_home_readers.py:554`) which then throws the value away via `_toss_sellable_quantity(position, mutations_enabled)` returning `0.0` when mutations are off (`invest_home_readers.py:516-524`), and the MCP `_collect_toss_api_positions` → `_collect_portfolio_positions` chain (`app/mcp_server/tooling/portfolio_holdings.py:557,876`), one branch of which feeds `analyze_stock_batch`'s `_build_batch_position_index` (`app/mcp_server/tooling/analysis_tool_handlers.py:642-693`) that indexes only `account/qty/avg_buy_price/pnl_pct/order_routable` and never reads `sellable_quantity`.
+
+Target flow — `fetch_toss_portfolio_snapshot(*, need_sellable: bool = True, client=None)` branches: when `need_sellable` is `True` it behaves exactly as today (gather + span + zip); when `False` it skips the `ORDER_INFO` fanout entirely and builds every `TossPortfolioPosition` with `sellable_quantity=None`. The flag is threaded caller-scoped: `_collect_toss_api_positions(market_filter, *, need_sellable=True)` → `_collect_portfolio_positions(..., need_sellable=True)` forward it (both default `True`), `_build_batch_position_index` passes `need_sellable=False` (never reads sellable), and `TossApiHomeReader.fetch` passes `need_sellable=mutations_enabled` (i.e. `False` when the flag is off, since the value would be discarded). The MCP `get_holdings`/`_toss_api_position_to_mcp` path and every action_report/recommend consumer keep the default `True`, so sellable stays in MCP output and sell classification is untouched. Net: home + account-panel (mutations off) and `analyze_stock_batch` drop the 13–17 s serial prefix; the Toss 6-TPS cap is never touched.
+
+**Tech Stack:** Python 3.13, uv, pytest (`@pytest.mark.asyncio`, marker `unit`), asyncio, SQLAlchemy async (unchanged here), httpx (Toss transport, unchanged), pydantic/dataclass DTOs, Sentry spans. Toss Open API `GET /api/v1/sellable-quantity` (`TossApiGroup.ORDER_INFO`, 6 TPS / 3 TPS peak).
+
+## Global Constraints
+
+Copied verbatim; every task implicitly includes these.
+
+- **CALLER-SCOPED SKIP ONLY — do NOT read the global TOSS_LIVE_ORDER_MUTATIONS_ENABLED inside the shared fetch_toss_portfolio_snapshot / _collect_toss_api_positions / _collect_portfolio_positions.** The MCP path _toss_api_position_to_mcp (portfolio_holdings.py ~543) AND sell classification (action_report auto_emit / action_verdict, portfolio_action_service: sellable_quantity>0 → sell_review) consume sellable_quantity UNCONDITIONALLY. The new need_sellable parameter MUST default True; only _build_batch_position_index and the invest_home readers (when mutations off) pass False. A global-flag skip would silently break sell classification and drop sellable from MCP holdings output.
+- sellable-quantity is a read-only GET; no broker/order mutation is on this path.
+- migration-0 (no DB change).
+- **Never raise the ORDER_INFO 6 TPS cap** (3 TPS in the 09:00–09:10 KST peak window). It is a broker constraint; increasing it risks 429s. `app/services/brokers/toss/rate_limiter.py` is NOT edited by this plan.
+- **The shared functions default `need_sellable=True`.** Behavior for every un-migrated caller (MCP `get_holdings`, `_toss_api_position_to_mcp`, `analysis_recommend`, `portfolio_allocation`, `fundamentals/_news`, `portfolio_rotation_service`) is byte-for-byte identical to today.
+- Read-only path: no broker / order / watch / order-intent mutation is introduced or reached.
+- Run tests with `uv run pytest <path> -v`. Lint with `make lint`. Do NOT commit unless the executing skill says so; each task lists its own commit message.
+
+---
+
+## Approach / decision note
+
+- **This plan implements the skip only — no cache, no precompute.** For the mutations-ON future (where sellable *is* consumed and the fanout is real work), the lower-risk follow-up is **lazy per-symbol load on the sell modal / a Toss bulk endpoint**, NOT a stateful short-TTL Redis cache: sellable_quantity changes intraday as orders fill, so a cache invites staleness/invalidation bugs on a value that gates real sell sizing. That work is deferred to **ROB-686** and is explicitly out of scope here. (Recorded in key_decisions.)
+- **`account_seq` / account resolution (ROB-687) is not in this plan's path.** The skip does not touch account resolution; `fetch_toss_portfolio_snapshot` still builds its client via `TossReadClient.from_settings()` exactly as today.
+- **The MCP `get_holdings` tool keeps the fetch (default `True`).** Per the caller-scoped constraint, `_get_holdings_impl` and `_toss_api_position_to_mcp` continue to emit `sellable_quantity`, so the `get_holdings` Sentry transaction is intentionally NOT sped up by this change (its output and downstream sell classification genuinely read the value). The dominant win — `analyze_stock_batch` (3,882 sellable calls / 7d) plus home + account-panel — is captured. (Recorded in open_questions for reviewer sign-off.)
+
+---
+
+## File Structure
+
+| File | Create/Modify | Responsibility (which Task) |
+|------|---------------|-----------------------------|
+| `app/services/toss_portfolio_service.py` | Modify | Task 1 — add `need_sellable: bool = True` to `fetch_toss_portfolio_snapshot`; skip the `ORDER_INFO` gather + span when `False`, build positions with `sellable_quantity=None`. |
+| `app/mcp_server/tooling/portfolio_holdings.py` | Modify | Task 2 — thread `need_sellable` (default `True`) through `_collect_toss_api_positions` and `_collect_portfolio_positions`; forward to the toss fetch. |
+| `app/mcp_server/tooling/analysis_tool_handlers.py` | Modify | Task 2 — `_build_batch_position_index` passes `need_sellable=False`. |
+| `app/services/invest_home_readers.py` | Modify | Task 3 — `TossApiHomeReader.fetch` passes `need_sellable=mutations_enabled` to the shared fetch. |
+| `tests/test_toss_portfolio_service.py` | Modify | Task 1 tests (add skip cases to the existing file). |
+| `tests/mcp_server/tooling/test_toss_sellable_need_flag.py` | Create | Task 2 tests (batch-index passes `False`; collect forwards the flag; default stays `True`). |
+| `tests/test_invest_home_readers.py` | Modify | Task 3 tests (new assertions + update the 3 existing Toss-reader fakes to accept `need_sellable`). |
+
+> **NOT touched:**
+> - `app/services/brokers/toss/rate_limiter.py` and `.../client.py` — the 6-TPS `ORDER_INFO` cap and the `sellable_quantity` GET are unchanged; we reduce *how often* it is called, never *how fast*.
+> - `app/mcp_server/tooling/portfolio_holdings.py::_toss_api_position_to_mcp` (~`:520-545`) and `_get_holdings_impl` (~`:1022`) — keep default `True`; MCP holdings output keeps `sellable_quantity`.
+> - `app/services/action_report/**` (`auto_emit.py`, `action_verdict.py`), `app/services/portfolio_action_service.py`, `app/services/portfolio_action_classifier.py`, `app/mcp_server/tooling/analysis_recommend.py`, `app/mcp_server/tooling/portfolio_allocation.py`, `app/mcp_server/tooling/fundamentals/_news.py`, `app/services/portfolio_rotation_service.py` — all consume `_collect_portfolio_positions` at its default (`True`); sell classification (`sellable_quantity > 0 → sell_review`) is byte-for-byte unchanged.
+> - `app/services/invest_home_service.py::_sellable_quantity` and `build_grouped_holdings` — the invest_home grouping already coerces toss sellable to `0.0` when mutations are off, so skipping the fetch changes nothing downstream of the reader.
+> - No Redis cache / precompute (ROB-686), no `account_seq` change (ROB-687), no DB migration.
+
+---
+
+## Task 1 — `fetch_toss_portfolio_snapshot(need_sellable=True)` skips the ORDER_INFO fanout (migration-0)
+
+**Files:**
+- Modify `app/services/toss_portfolio_service.py` — `fetch_toss_portfolio_snapshot` def at `:131`; the sellable gather + span at `:148-167`; the position-build `zip` loop at `:169-203`.
+- Test (modify) `tests/test_toss_portfolio_service.py` — add skip cases beside the existing `test_fetch_toss_portfolio_snapshot_*` (the `_FakeTossClient` records `sellable_calls`).
+
+**Interfaces:**
+- Produces: `async def fetch_toss_portfolio_snapshot(*, need_sellable: bool = True, client: TossPortfolioClient | None = None) -> TossPortfolioSnapshot`. When `need_sellable=False`: no `sellable_quantity` call is issued, the `invest.home.toss_api.sellable_quantity` span is skipped, and every returned `TossPortfolioPosition.sellable_quantity is None`. Holdings fetch, cash snapshot, KR/US mapping, and error semantics are unchanged.
+- Consumes: `TossPortfolioClient.sellable_quantity(*, symbol)` (only when `need_sellable=True`), `active_client.holdings()`, `fetch_toss_cash_snapshot(client=...)`.
+
+Steps:
+
+- [ ] **Write failing test — skip issues zero sellable calls and yields `sellable_quantity=None`.** Append to `tests/test_toss_portfolio_service.py`:
+```python
+@pytest.mark.asyncio
+async def test_fetch_toss_portfolio_snapshot_skips_sellable_when_not_needed() -> None:
+    client = _FakeTossClient()
+
+    snapshot = await fetch_toss_portfolio_snapshot(client=client, need_sellable=False)
+
+    # ROB-685: the ORDER_INFO N+1 fanout is skipped entirely.
+    assert client.sellable_calls == []
+    assert len(snapshot.positions) == 1
+    assert snapshot.positions[0].sellable_quantity is None
+    # Holdings + cash still resolve normally.
+    assert snapshot.positions[0].symbol == "BRK.B"
+    assert snapshot.cash_krw == Decimal("123456")
+    assert snapshot.errors == []
+
+
+@pytest.mark.asyncio
+async def test_fetch_toss_portfolio_snapshot_default_still_fetches_sellable() -> None:
+    client = _FakeTossClient()
+
+    snapshot = await fetch_toss_portfolio_snapshot(client=client)
+
+    # Default is unchanged: sellable is fetched and mapped.
+    assert client.sellable_calls == ["BRK.B"]
+    assert snapshot.positions[0].sellable_quantity == Decimal("1.25")
+```
+
+- [ ] **Run it — fails.** `uv run pytest tests/test_toss_portfolio_service.py -v -k "skips_sellable or default_still_fetches"`
+  Expected: `test_..._skips_sellable_when_not_needed` FAILS — today `fetch_toss_portfolio_snapshot` has no `need_sellable` kwarg (`TypeError: unexpected keyword argument`). The `default_still_fetches` test passes today (locks the default so the refactor cannot regress it).
+
+- [ ] **Minimal impl — branch on `need_sellable`.** In `app/services/toss_portfolio_service.py`, change the signature at `:131`:
+```python
+async def fetch_toss_portfolio_snapshot(
+    *,
+    need_sellable: bool = True,
+    client: TossPortfolioClient | None = None,
+) -> TossPortfolioSnapshot:
+```
+Replace the sellable gather span (`:148-167`) + the `zip(holdings.items, sellable_results, ...)` loop head (`:169-170`) with a branch that produces `(item, sellable_result)` pairs either way:
+```python
+        errors: list[dict[str, Any]] = []
+
+        if need_sellable:
+            with sentry_sdk.start_span(
+                op="invest.home.toss_api.phase",
+                name="invest.home.toss_api.sellable_quantity",
+            ) as span:
+                span.set_data("position_count", len(holdings.items))
+                sellable_results = await asyncio.gather(
+                    *[
+                        active_client.sellable_quantity(symbol=item.symbol)
+                        for item in holdings.items
+                    ],
+                    return_exceptions=True,
+                )
+                span.set_data(
+                    "error_count",
+                    sum(
+                        1
+                        for result in sellable_results
+                        if isinstance(result, BaseException)
+                    ),
+                )
+            paired: list[tuple[Any, Any]] = list(
+                zip(holdings.items, sellable_results, strict=True)
+            )
+        else:
+            # ROB-685: caller does not consume sellable_quantity — skip the
+            # per-holding GET /sellable-quantity (ORDER_INFO, 6 TPS) fanout that
+            # otherwise serializes to ~6/sec and dominates wall time.
+            paired = [(item, None) for item in holdings.items]
+
+        positions: list[TossPortfolioPosition] = []
+        for item, sellable_result in paired:
+            sellable_quantity: Decimal | None = None
+            if isinstance(sellable_result, BaseException):
+                errors.append(
+                    {
+                        "source": "toss_api",
+                        "stage": "sellable_quantity",
+                        "symbol": item.symbol,
+                        "error": str(sellable_result),
+                    }
+                )
+            elif sellable_result is not None:
+                sellable_quantity = sellable_result.sellable_quantity
+            ...  # rest of the position append block is UNCHANGED
+```
+Leave the `TossPortfolioPosition(...)` construction, cash snapshot (`:205-206`), return (`:208-213`), and `finally` client-close (`:214-216`) exactly as-is.
+
+- [ ] **Run it — passes.** `uv run pytest tests/test_toss_portfolio_service.py -v` → all pass (new skip cases + the 4 pre-existing cases, incl. `..._keeps_position_when_sellable_fails` which still exercises the `isinstance(..., BaseException)` branch under the default `True`).
+
+- [ ] **Regression — phase-span + reader suites unaffected by the default.** `uv run pytest tests/test_invest_home_readers.py -v -k "toss"`
+  Expected: `test_toss_portfolio_snapshot_emits_phase_spans` still asserts `invest.home.toss_api.sellable_quantity in started` (default `True` keeps the span). The 3 `test_toss_api_home_reader_*` still pass — they monkeypatch the reader's `fetch_toss_portfolio_snapshot`, which Task 3 (not yet applied) does not change.
+
+- [ ] **Lint.** `make lint`
+
+- [ ] **Commit.** `git add -A && git commit -m "perf(ROB-685): fetch_toss_portfolio_snapshot skips ORDER_INFO sellable fanout when need_sellable=False"`
+
+---
+
+## Task 2 — Thread `need_sellable` through the MCP collect chain; `analyze_stock_batch` passes `False` (migration-0)
+
+**Files:**
+- Modify `app/mcp_server/tooling/portfolio_holdings.py` — `_collect_toss_api_positions` def at `:548` (fetch call at `:557`); `_collect_portfolio_positions` def at `:781` (toss branch at `:871-878`).
+- Modify `app/mcp_server/tooling/analysis_tool_handlers.py` — `_build_batch_position_index` at `:642`, its `_collect_portfolio_positions(...)` call at `:659-663`.
+- Test (create) `tests/mcp_server/tooling/test_toss_sellable_need_flag.py`.
+
+**Interfaces:**
+- Produces: `async def _collect_toss_api_positions(market_filter: str | None, *, need_sellable: bool = True) -> tuple[list[dict], list[dict], bool]` — forwards `need_sellable` to `fetch_toss_portfolio_snapshot`.
+- Produces: `_collect_portfolio_positions(*, account, market, include_current_price, account_name=None, user_id=_MCP_USER_ID, is_mock=False, need_sellable: bool = True)` — forwards to `_collect_toss_api_positions(market_filter, need_sellable=need_sellable)`.
+- Consumes: `_build_batch_position_index` calls `_collect_portfolio_positions(account=None, market=market, include_current_price=False, need_sellable=False)`.
+- `_build_batch_position_index` imports `_collect_portfolio_positions` lazily inside the function (`analysis_tool_handlers.py:651-655`), so tests monkeypatch the attribute on `portfolio_holdings` (mirrors `tests/mcp_server/tooling/test_get_holdings_news.py:141`).
+
+Steps:
+
+- [ ] **Write failing test — batch index passes `False`, collect forwards the flag, default is `True`.** Create `tests/mcp_server/tooling/test_toss_sellable_need_flag.py`:
+```python
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from app.mcp_server.tooling import analysis_tool_handlers, portfolio_holdings
+
+pytestmark = [pytest.mark.unit, pytest.mark.asyncio]
+
+
+async def test_build_batch_position_index_requests_no_sellable(monkeypatch):
+    captured: dict[str, Any] = {}
+
+    async def fake_collect(**kwargs):
+        captured.update(kwargs)
+        return [], [], kwargs.get("market"), None
+
+    monkeypatch.setattr(
+        portfolio_holdings, "_collect_portfolio_positions", fake_collect
+    )
+
+    index, err = await analysis_tool_handlers._build_batch_position_index("kr")
+
+    assert err is None
+    assert index == {}
+    # ROB-685: the batch index never reads sellable_quantity.
+    assert captured["need_sellable"] is False
+    assert captured["include_current_price"] is False
+
+
+async def test_collect_portfolio_positions_forwards_need_sellable_to_toss(monkeypatch):
+    calls: list[bool] = []
+
+    async def fake_fetch(*, need_sellable: bool = True):
+        calls.append(need_sellable)
+
+        class _Snap:
+            positions: list[Any] = []
+            errors: list[Any] = []
+
+        return _Snap()
+
+    monkeypatch.setattr(portfolio_holdings.settings, "toss_api_enabled", True)
+    monkeypatch.setattr(
+        portfolio_holdings, "fetch_toss_portfolio_snapshot", fake_fetch
+    )
+
+    # Isolate the sibling collectors — with market=None, _collect_portfolio_positions
+    # otherwise fans out to the REAL _collect_kis_positions / _collect_upbit_positions
+    # (live KIS/Upbit HTTP) and _collect_manual_positions (AsyncSessionLocal DB). That
+    # makes this a slow, non-hermetic test, and _collect_upbit_positions can surface
+    # UpbitSymbolUniverseLookupError, which _collect_portfolio_positions RE-RAISES
+    # (portfolio_holdings.py:857-858) → the test would crash before asserting. Stub
+    # all three to empty so only the toss forwarding path is exercised. They are
+    # module globals resolved at call time, so setattr on the module patches them.
+    async def _empty(*args, **kwargs):
+        return [], []
+
+    monkeypatch.setattr(portfolio_holdings, "_collect_kis_positions", _empty)
+    monkeypatch.setattr(portfolio_holdings, "_collect_upbit_positions", _empty)
+    monkeypatch.setattr(portfolio_holdings, "_collect_manual_positions", _empty)
+
+    # Default path keeps sellable (MCP / sell-classification contract).
+    await portfolio_holdings._collect_portfolio_positions(
+        account=None, market=None, include_current_price=False
+    )
+    # Explicit opt-out threads through.
+    await portfolio_holdings._collect_portfolio_positions(
+        account=None, market=None, include_current_price=False, need_sellable=False
+    )
+
+    assert calls == [True, False]
+
+
+async def test_collect_toss_api_positions_defaults_need_sellable_true(monkeypatch):
+    seen: list[bool] = []
+
+    async def fake_fetch(*, need_sellable: bool = True):
+        seen.append(need_sellable)
+
+        class _Snap:
+            positions: list[Any] = []
+            errors: list[Any] = []
+
+        return _Snap()
+
+    monkeypatch.setattr(portfolio_holdings.settings, "toss_api_enabled", True)
+    monkeypatch.setattr(
+        portfolio_holdings, "fetch_toss_portfolio_snapshot", fake_fetch
+    )
+
+    await portfolio_holdings._collect_toss_api_positions(None)
+    await portfolio_holdings._collect_toss_api_positions(None, need_sellable=False)
+
+    assert seen == [True, False]
+```
+
+- [ ] **Run it — fails.** `uv run pytest tests/mcp_server/tooling/test_toss_sellable_need_flag.py -v`
+  Expected: all three FAIL — `_collect_portfolio_positions`/`_collect_toss_api_positions` have no `need_sellable` kwarg (`TypeError`), and `_build_batch_position_index` does not pass one (`KeyError: 'need_sellable'`).
+
+- [ ] **Minimal impl part A — `_collect_toss_api_positions`.** In `app/mcp_server/tooling/portfolio_holdings.py:548`, add the kwarg and forward it:
+```python
+async def _collect_toss_api_positions(
+    market_filter: str | None,
+    *,
+    need_sellable: bool = True,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]], bool]:
+    if not bool(getattr(settings, "toss_api_enabled", False)):
+        return [], [], False
+    if market_filter == "crypto":
+        return [], [], False
+
+    try:
+        snapshot = await fetch_toss_portfolio_snapshot(need_sellable=need_sellable)
+    except Exception as exc:
+        ...
+```
+
+- [ ] **Minimal impl part B — `_collect_portfolio_positions`.** In `portfolio_holdings.py:781`, add `need_sellable: bool = True` to the keyword-only signature, and at the toss branch (`:871-876`) forward it:
+```python
+    if bool(getattr(settings, "toss_api_enabled", False)):
+        (
+            toss_api_positions,
+            toss_api_errors,
+            toss_api_succeeded,
+        ) = await _collect_toss_api_positions(market_filter, need_sellable=need_sellable)
+```
+
+- [ ] **Minimal impl part C — `_build_batch_position_index` opts out.** In `app/mcp_server/tooling/analysis_tool_handlers.py:659`:
+```python
+        positions, _errors, _market, _account = await _collect_portfolio_positions(
+            account=None,
+            market=market,
+            include_current_price=False,
+            need_sellable=False,
+        )
+```
+
+- [ ] **Run it — passes.** `uv run pytest tests/mcp_server/tooling/test_toss_sellable_need_flag.py -v` → 3 passed.
+
+- [ ] **Regression — MCP holdings + batch + recommend suites keep default behavior.** `uv run pytest tests/test_mcp_portfolio_tools.py tests/mcp_server/tooling/test_get_holdings_news.py tests/test_mcp_holdings_rob562.py tests/test_mcp_recommend_flow.py -q`
+  Expected: all pass — every un-migrated caller (`get_holdings`, recommend, allocation) still calls `_collect_portfolio_positions` at the default `need_sellable=True`, so `_toss_api_position_to_mcp` still emits `sellable_quantity` and sell classification is unchanged.
+
+- [ ] **Lint.** `make lint`
+
+- [ ] **Commit.** `git add -A && git commit -m "perf(ROB-685): analyze_stock_batch position index skips toss sellable fetch (need_sellable=False)"`
+
+---
+
+## Task 3 — invest_home Toss reader passes `need_sellable=mutations_enabled` (migration-0)
+
+**Files:**
+- Modify `app/services/invest_home_readers.py` — `TossApiHomeReader.fetch` at `:539`; `mutations_enabled` resolved at `:547-549`; the snapshot fetch at `:554`.
+- Test (modify) `tests/test_invest_home_readers.py` — add a new assertion test AND update the 3 existing Toss-reader fakes (`test_toss_api_home_reader_maps_read_only_holdings_and_cash` `:1523`, `..._tradeable_when_mutations_enabled` `:1587`, `..._converts_us_holdings_to_krw` `:1635`) so their `fake_fetch_toss_snapshot` accepts the new kwarg.
+
+**Interfaces:**
+- Consumes: `settings.toss_live_order_mutations_enabled` (already read at `invest_home_readers.py:547-549` into `mutations_enabled`).
+- Produces: the sole `fetch_toss_portfolio_snapshot()` call at `:554` becomes `fetch_toss_portfolio_snapshot(need_sellable=mutations_enabled)` — when mutations are off (default) the ORDER_INFO fanout is skipped; the reader already collapses toss sellable to `0.0` via `_toss_sellable_quantity(position, mutations_enabled)` (`:516-524`), so output is unchanged.
+
+Steps:
+
+- [ ] **Write failing test — reader passes `need_sellable` = the mutation flag.** Add to `tests/test_invest_home_readers.py`:
+```python
+@pytest.mark.asyncio
+@pytest.mark.parametrize("mutations,expected_need", [(False, False), (True, True)])
+async def test_toss_api_home_reader_gates_sellable_fetch_on_mutations(
+    monkeypatch, mutations, expected_need
+):
+    from decimal import Decimal
+
+    from app.core.config import settings as _cfg
+    from app.services import invest_home_readers as readers
+    from app.services.toss_portfolio_service import TossPortfolioSnapshot
+
+    captured: dict[str, bool] = {}
+
+    async def fake_fetch_toss_snapshot(*, need_sellable: bool = True):
+        captured["need_sellable"] = need_sellable
+        return TossPortfolioSnapshot(
+            positions=[], cash_krw=Decimal("1"), cash_usd=Decimal("1")
+        )
+
+    monkeypatch.setattr(
+        readers, "fetch_toss_portfolio_snapshot", fake_fetch_toss_snapshot
+    )
+    monkeypatch.setattr(
+        _cfg, "toss_live_order_mutations_enabled", mutations, raising=False
+    )
+
+    await readers.TossApiHomeReader().fetch(user_id=1)
+
+    # ROB-685: mutations off (default) => reader discards sellable anyway => skip fetch.
+    assert captured["need_sellable"] is expected_need
+```
+
+- [ ] **Run it — fails.** `uv run pytest tests/test_invest_home_readers.py -v -k "gates_sellable_fetch"`
+  Expected: both params FAIL — today `TossApiHomeReader.fetch` calls `fetch_toss_portfolio_snapshot()` with no kwarg, so `captured["need_sellable"]` is always the default `True` (the `mutations=False` case fails on `True is not False`).
+
+- [ ] **Minimal impl — pass the flag.** In `app/services/invest_home_readers.py`, the `mutations_enabled` bool is already computed at `:547-549`. Change the fetch at `:554`:
+```python
+                snapshot = await fetch_toss_portfolio_snapshot(
+                    need_sellable=mutations_enabled
+                )
+```
+(No other reader logic changes — `_toss_sellable_quantity` / `_toss_pending_sell_quantity` already return `0.0` when `mutations_enabled` is `False`, so a `None` sellable from the skipped fetch is never read on that branch.)
+
+- [ ] **Update the 3 existing Toss-reader fakes to accept the kwarg.** In `tests/test_invest_home_readers.py`, change each `async def fake_fetch_toss_snapshot():` (at `:1523`, `:1587`, `:1635`) to `async def fake_fetch_toss_snapshot(*, need_sellable: bool = True):`. Behavior is unchanged; this only keeps them call-compatible with the new keyword. (The `test_toss_portfolio_snapshot_emits_phase_spans` test at `:1680` calls the real service with `client=...` and default `True`, so it is unaffected.)
+
+- [ ] **Run it — passes.** `uv run pytest tests/test_invest_home_readers.py -v -k "toss"` → all pass (new gating test both params + the 3 updated fakes + the phase-span test).
+
+- [ ] **Regression — full reader suite.** `uv run pytest tests/test_invest_home_readers.py -q` → no failures.
+
+- [ ] **Lint.** `make lint`
+
+- [ ] **Commit.** `git add -A && git commit -m "perf(ROB-685): invest_home toss reader skips sellable fetch when mutations disabled"`
+
+---
+
+## Done criteria
+
+- `fetch_toss_portfolio_snapshot(need_sellable=False)` issues **zero** `GET /sellable-quantity` calls and returns positions with `sellable_quantity=None`; default `True` is byte-for-byte unchanged.
+- `analyze_stock_batch` (`_build_batch_position_index`) and invest_home home/account-panel (mutations off) no longer pay the ORDER_INFO serial prefix.
+- MCP `get_holdings` output still contains `sellable_quantity`; `sell_review` classification (`sellable_quantity > 0`) is unchanged — verified by the un-touched `tests/test_mcp_portfolio_tools.py` / action_report suites staying green.
+- `make lint` clean; no alembic revision added.

--- a/docs/plans/ROB-686-screener-analyst-consensus-cache.md
+++ b/docs/plans/ROB-686-screener-analyst-consensus-cache.md
@@ -1,0 +1,801 @@
+# Screener Analyst-Consensus Cache + Pre-Pagination Over-Enrichment Fix Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (- [ ]) syntax.
+
+**Goal:** Stop `screen_stocks_snapshot` from live-scraping Naver analyst-research pages on every call (Sentry 7d: avg 24s, p95 78s; `company_read.naver` = 6,274 calls / 8.41M ms / ~75% of all child HTTP). Route the KR analyst-consensus enrichment through a per-symbol Redis cache-aside keyed by `(market, symbol, KST-date)` (reusing the proven ROB-638 `app/core/analyze_cache` infrastructure), and fix the pre-pagination over-enrichment so the `min_analyst_*` filter resolves consensus counts once (cache-aside, bounded) instead of fully live-enriching up to 200 rows before pagination. Displayed target-upside stays intraday-fresh by recomputing `currentPrice`/`upsidePct` from a cheap fresh Naver price on the returned page only. Do NOT raise `Semaphore(4)` — the 8-9s tails mean Naver is already throttling; the win is fewer requests, not more concurrency.
+
+**Architecture:** Today `screen_stocks_snapshot_impl` (`app/mcp_server/tooling/screener_snapshot_tool.py:198`) builds the merged preset result set, then in the `min_analyst_*` branch (`:455`) it live-enriches the **entire** matched set (capped at `_MAX_ANALYST_ENRICHMENT_ROWS = 200`, `:195`) via `enrich_snapshot_page(rows=all_results, ...)` (`:479`) *before* pagination, filters on the enriched `analysisContext.consensus` counts (`_consensus_count`, `:166`/`:488`/`:493`), then paginates. `enrich_snapshot_page` (`app/services/invest_view_model/screener_analysis_enrichment.py:346`) fans out per symbol under `asyncio.Semaphore(4)` (`:390`) calling `handle_get_investment_opinions` (its `opinion_provider` default, `:351`). For KR that dispatches to `fetch_investment_opinions` (`app/services/naver_finance/investor.py:304`) = 1 `company_list.naver` (`:329`) + up to 10 gathered `company_read.naver` (`:123`) + 1 `item/main.naver` current price (`_fetch_current_price`, `:287`/`:333`); every fetch opens a **fresh** `httpx.AsyncClient` with no cache (`app/services/naver_finance/parser.py:80`,`:92`). Nothing is cached anywhere, so every screener call re-scrapes; the `min_analyst_*` × 200-row path is the 78s p95.
+
+Target flow: a new module `app/services/invest_view_model/analyst_consensus_cache.py` provides a KR Redis cache-aside layer over `handle_get_investment_opinions`, keyed `screener_consensus:naver:{SYMBOL}:{KST-date}` with the same session-close TTL/timezone/fail-open helpers as `analyze_cache` (`_get_redis_client`/`_fetch_cache_ttl_seconds`/`_provider_date_for_key`, guarded by `settings.analyze_fetch_cache_enabled`). Only the **daily-stable** consensus fields (buy/hold/sell/strong-buy/total counts + avg/median/min/max target prices + metadata) are cached; the volatile `current_price`/`upside_pct` are stripped before caching and **recomputed** on the returned page from a fresh `_fetch_current_price`. The tool's `min_analyst_*` branch is rewritten to (1) resolve consensus **counts** for all matched symbols via the cache-aside layer (cold entries fetched once under the existing `Semaphore(4)`, warmed into Redis + a per-call memo), (2) filter, (3) paginate, (4) `enrich_snapshot_page(rows=page, opinion_provider=<cached provider>)` for the returned page only. US (yfinance) stays exactly as-is — it is a single non-fanout call per symbol and is not implicated in the Sentry bottleneck.
+
+**Tech Stack:** Python 3.13, uv, pytest (markers `unit`/`asyncio`), SQLAlchemy async (read-only lazy-fill only), httpx, FastMCP tool registration, pydantic v2 (`ScreenerAnalysisConsensus`), `redis.asyncio` (via `app/core/analyze_cache` + `app/services/ohlcv_cache_common.create_redis_client`).
+
+## Approach / decision
+
+- **Redis cache-aside, migration-0 — NOT a new precompute table.** A precompute table already exists (`analyst_consensus_snapshots`, ROB-641: `app/models/analyst_consensus_snapshot.py`, `app/services/analyst_consensus_snapshots/{repository,builder}.py`, `app/jobs/analyst_consensus_snapshots.py`), but its nightly builder scopes symbols to **holdings ∪ active watch** (`app/jobs/analyst_consensus_snapshots.py:136` `_resolve_holdings_and_watch_symbols`), which gives poor coverage for a *discovery* screener that surfaces arbitrary new candidates. A per-symbol Redis cache-aside populates on demand for **any** discovery symbol with a daily TTL, fully covers the `min_analyst_*` filter inputs + buy/hold/sell label, and stays migration-0. Per the Global Constraints, the Redis path is preferred when it covers the filter+label needs. The ROB-641 precompute table is intentionally left untouched (it serves other consumers; broadening its scope is a possible follow-up, not this ticket).
+- **Reuse `app/core/analyze_cache` infra, distinct key namespace.** The key prefix is `screener_consensus:` (NOT `analyze_fetch:`) so screener consensus payloads never collide with the analyze path's whole-snapshot bundle, while the TTL/timezone/redis-client/fail-open/hermetic-guard helpers are reused verbatim. The same `settings.analyze_fetch_cache_enabled` flag guards it (already forced `false` in `tests/conftest.py:106`), so tests stay hermetic by default.
+- **KR-only scope.** All new caching + the upside recompute are gated on `market == "kr"`. US routes straight to the existing live `handle_get_investment_opinions` (uncached) via the same `resolve_consensus`/`cached_opinion_provider` path — behaviorally equivalent to today's live enrich, so US freshness is unchanged. Only the *filter* code path is new for US; the produced counts are identical to the old enriched-consensus counts.
+- **Known tradeoff — zero-coverage symbols are re-fetched every call.** `set_cached_consensus` refuses to persist any consensus with `total_count <= 0` (never cache a degraded/transient-failure result). Because a *genuinely* zero-coverage symbol also has `total_count == 0`, discovery symbols with no analyst reports are re-scraped live on every screener call (the cache only warms symbols that HAVE coverage). This is the conservative choice (a network blip must not poison the day with a fake "no coverage" verdict). A safe future refinement — distinguishing a *fetch-succeeded-but-empty* consensus (`build_consensus` returns a dict with `total_count == 0`) from a *fetch-failed* one (`resolve_consensus` returns `None`) and caching only the former — is intentionally out of scope here to keep the primary fix minimal.
+
+## Global Constraints
+
+Copied verbatim; every task implicitly includes these.
+
+- **FRESHNESS: the consensus payload embeds currentPrice/upsidePct. Caching the whole consensus for 1-24h makes displayed target-upside intraday-stale. Cache keyed by (market, symbol, KST-date) is correct for the min_analyst_* FILTER inputs (buyCount/totalCount are daily-stable) and the buy/hold/sell label; but recompute currentPrice-derived upside cheaply rather than serving a day-old price.**
+- **Read-only advisory screener. The only write on the path is sector lazy-fill (fail-open); no broker/order/watch/order-intent mutation.**
+- **If choosing the precompute path, adding a snapshot table/column IS allowed but must ship its own alembic migration and follow the InvestScreenerSnapshotsRepository write-only pattern; prefer the Redis-cache path if it fully covers the filter+label needs to stay migration-0. State the decision explicitly.** → Decision: Redis-cache path (see "Approach / decision"). **Migration-0.**
+- **Do NOT raise `asyncio.Semaphore(4)`** in `enrich_snapshot_page` or the new cache-aside resolver — the 8-9s Naver tails mean Naver is already throttling; the fix reduces request count, it does not add concurrency.
+- **Migration-0.** No new DB table/column, no alembic revision. The new module is a Redis cache-aside layer only. (The existing `analyst_consensus_snapshots` table is not read or written by this plan.)
+- **Fail-open, hermetic.** The cache degrades to a direct live fetch whenever Redis is unavailable/disabled or returns malformed data (never raises). Guarded by `settings.analyze_fetch_cache_enabled` (default forced `false` in `tests/conftest.py:106`); no test may touch a real Redis unless it explicitly patches the client factory.
+- **US path unchanged.** Every new code path is gated on `market == "kr"`; `market == "us"` continues to call the live `handle_get_investment_opinions` with no cache and no upside recompute.
+- Run tests: `uv run pytest <path> -v`. Lint: `make lint`. Do NOT commit unless the executing skill says so; each task lists its own commit message.
+
+## File Structure
+
+| File | Create/Modify | Responsibility (Task) |
+|------|---------------|------------------------|
+| `app/services/invest_view_model/analyst_consensus_cache.py` | Create | Task 1 — KR consensus Redis cache primitives (key, stable-field strip, get/set, TTL reuse). Task 2 — cache-aside `resolve_consensus` + per-call memo, `resolve_consensus_counts` (filter), `cached_opinion_provider` (page provider w/ fresh-price upside recompute). |
+| `app/mcp_server/tooling/screener_snapshot_tool.py` | Modify | Task 3 — rewrite the `min_analyst_*` branch (`:455`) to resolve counts via cache-aside + enrich only the page; inject `cached_opinion_provider` into both `enrich_snapshot_page` calls (`:479`,`:517`). |
+| `app/mcp_server/tooling/analysis_registration.py` | Modify | Task 4 — update the `screen_stocks_snapshot` tool description (`:316`) to note KR consensus is cached (daily) with intraday upside recompute. |
+| `docs/runbooks/screener-analyst-consensus-cache.md` | Create | Task 4 — operator note: cache key/TTL, `ANALYZE_FETCH_CACHE_ENABLED` gate, fail-open, how to invalidate. |
+| `tests/services/test_analyst_consensus_cache.py` | Create | Task 1 + Task 2 tests. |
+| `tests/test_screener_snapshot_tool.py` | Modify | Task 3 tests (append min_analyst cache-aside + page-only-enrich cases). |
+
+> **NOT touched:**
+> - **`app/services/analyst_consensus_snapshots/**`, `app/models/analyst_consensus_snapshot.py`, `app/jobs/analyst_consensus_snapshots.py`, `app/tasks/analyst_consensus_snapshot_tasks.py`** — the ROB-641 precompute stack. This plan chose the Redis-cache path (holdings∪watch scope is too narrow for discovery); the precompute table is left entirely alone.
+> - **`app/core/analyze_cache.py`** — reused read-only (its pure helpers `_get_redis_client`/`_fetch_cache_ttl_seconds`/`_provider_date_for_key`/`PROVIDER_NAVER` are imported, not edited) so the analyze-path cache (ROB-638) is unaffected and there is no key-namespace collision.
+> - **`app/services/naver_finance/investor.py` / `parser.py`** — the live fetch functions are consumed unchanged; no per-fetch client pooling or signature change (that would be a broader refactor and a collision risk). Caching happens one layer up.
+> - **US / yfinance opinions path** (`app/mcp_server/tooling/fundamentals_sources_yfinance.py`) — unchanged; US is not the bottleneck.
+
+---
+
+## Task 1 — KR consensus Redis cache primitives (new module, migration-0)
+
+**Files:**
+- Create `app/services/invest_view_model/analyst_consensus_cache.py`.
+- Test (create) `tests/services/test_analyst_consensus_cache.py`.
+
+**Interfaces (produced):**
+- `_consensus_cache_key(market: str, symbol: str, now: datetime | None = None) -> str` → `"screener_consensus:naver:{SYMBOL}:{KST-date}"` (KR only; delegates the date to `analyze_cache._provider_date_for_key(PROVIDER_NAVER, now)`).
+- `_STABLE_CONSENSUS_FIELDS: frozenset[str]` — the daily-stable keys copied into the cache: `buy_count, hold_count, sell_count, strong_buy_count, total_count, avg_target_price, median_target_price, min_target_price, max_target_price, rows_total, rows_used, rows_excluded_stale, rows_undated, newest_opinion_date, window_months, target_price_count, target_price_honest`. `current_price` and `upside_pct` are **excluded** (volatile).
+- `_strip_volatile(consensus: dict[str, Any]) -> dict[str, Any]` — returns a copy with only `_STABLE_CONSENSUS_FIELDS` present (never `current_price`/`upside_pct`).
+- `async def get_cached_consensus(redis_client, market: str, symbol: str) -> dict[str, Any] | None` — returns the cached stable consensus dict or `None` (miss / malformed / redis None / non-KR). Never raises.
+- `async def set_cached_consensus(redis_client, market: str, symbol: str, consensus: dict[str, Any]) -> None` — caches `_strip_volatile(consensus)` with TTL `analyze_cache._fetch_cache_ttl_seconds(PROVIDER_NAVER, now_kst())`. No-op when: `redis_client is None`, `market != "kr"`, or consensus has no positive `total_count` (never cache a degraded/empty consensus). Never raises.
+
+**Interfaces (consumed):** `app/core.analyze_cache` (`_get_redis_client`, `_fetch_cache_ttl_seconds`, `_provider_date_for_key`, `PROVIDER_NAVER`), `app/core.timezone.now_kst`, `app/core.config.settings.analyze_fetch_cache_enabled`.
+
+Steps:
+
+- [ ] **Write failing test — key format + volatile stripping.** Create `tests/services/test_analyst_consensus_cache.py`:
+```python
+from __future__ import annotations
+
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from app.services.invest_view_model import analyst_consensus_cache as cache
+
+pytestmark = pytest.mark.unit
+
+_KST = ZoneInfo("Asia/Seoul")
+
+
+def test_cache_key_is_kst_dated_and_namespaced():
+    now = datetime(2026, 7, 4, 9, 0, tzinfo=_KST)
+    assert (
+        cache._consensus_cache_key("kr", "005930", now)
+        == "screener_consensus:naver:005930:2026-07-04"
+    )
+
+
+def test_strip_volatile_drops_current_price_and_upside():
+    consensus = {
+        "buy_count": 2,
+        "hold_count": 1,
+        "sell_count": 0,
+        "total_count": 3,
+        "avg_target_price": 78500,
+        "current_price": 69900,
+        "upside_pct": 12.3,
+    }
+    stable = cache._strip_volatile(consensus)
+    assert stable["buy_count"] == 2
+    assert stable["avg_target_price"] == 78500
+    assert "current_price" not in stable
+    assert "upside_pct" not in stable
+```
+
+- [ ] **Run it — fails.** `uv run pytest tests/services/test_analyst_consensus_cache.py -v` → ImportError (module absent).
+
+- [ ] **Minimal impl — module scaffold + key + strip.** Create `app/services/invest_view_model/analyst_consensus_cache.py`:
+```python
+"""ROB-686 — KR analyst-consensus Redis cache-aside for the snapshot screener.
+
+Caches the DAILY-STABLE analyst consensus (buy/hold/sell/total counts + target
+prices) per (market, symbol, KST-date) so screen_stocks_snapshot stops re-scraping
+Naver research pages (company_list/company_read) on every call. The volatile
+current_price/upside_pct are stripped before caching and recomputed on the
+returned page from a fresh price (see cached_opinion_provider). KR only; US
+(yfinance) is not cached. Fail-open + hermetic: reuses app.core.analyze_cache's
+Redis client + TTL, guarded by settings.analyze_fetch_cache_enabled.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime
+from typing import Any
+
+from app.core import analyze_cache
+from app.core.timezone import now_kst
+
+logger = logging.getLogger(__name__)
+
+_KEY_PREFIX = "screener_consensus"
+
+_STABLE_CONSENSUS_FIELDS: frozenset[str] = frozenset(
+    {
+        "buy_count",
+        "hold_count",
+        "sell_count",
+        "strong_buy_count",
+        "total_count",
+        "avg_target_price",
+        "median_target_price",
+        "min_target_price",
+        "max_target_price",
+        "rows_total",
+        "rows_used",
+        "rows_excluded_stale",
+        "rows_undated",
+        "newest_opinion_date",
+        "window_months",
+        "target_price_count",
+        "target_price_honest",
+    }
+)
+
+
+def _consensus_cache_key(market: str, symbol: str, now: datetime | None = None) -> str:
+    date_part = analyze_cache._provider_date_for_key(analyze_cache.PROVIDER_NAVER, now)
+    return f"{_KEY_PREFIX}:{analyze_cache.PROVIDER_NAVER}:{symbol.upper()}:{date_part}"
+
+
+def _strip_volatile(consensus: dict[str, Any]) -> dict[str, Any]:
+    return {k: v for k, v in consensus.items() if k in _STABLE_CONSENSUS_FIELDS}
+```
+
+- [ ] **Run it — passes.** `uv run pytest tests/services/test_analyst_consensus_cache.py -v` → 2 passed.
+
+- [ ] **Write failing test — get/set round-trip via fake redis, never-cache-degraded, fail-open.** Append:
+```python
+class _FakeRedis:
+    def __init__(self) -> None:
+        self.store: dict[str, str] = {}
+
+    async def get(self, key):
+        return self.store.get(key)
+
+    async def set(self, key, value, ex=None):
+        self.store[key] = value
+
+
+@pytest.mark.asyncio
+async def test_set_then_get_round_trips_stable_fields_only():
+    redis = _FakeRedis()
+    consensus = {
+        "buy_count": 2,
+        "total_count": 3,
+        "avg_target_price": 78500,
+        "current_price": 69900,
+        "upside_pct": 12.3,
+    }
+    await cache.set_cached_consensus(redis, "kr", "005930", consensus)
+    got = await cache.get_cached_consensus(redis, "kr", "005930")
+    assert got is not None
+    assert got["total_count"] == 3
+    assert got["avg_target_price"] == 78500
+    assert "current_price" not in got  # volatile never persisted
+    assert "upside_pct" not in got
+
+
+@pytest.mark.asyncio
+async def test_set_is_noop_for_degraded_or_us_or_no_redis():
+    redis = _FakeRedis()
+    # total_count 0 → degraded, never cached
+    await cache.set_cached_consensus(redis, "kr", "000660", {"total_count": 0})
+    assert await cache.get_cached_consensus(redis, "kr", "000660") is None
+    # US never cached
+    await cache.set_cached_consensus(redis, "us", "AAPL", {"total_count": 5})
+    assert redis.store == {}
+    # redis None → no-op, no raise
+    await cache.set_cached_consensus(None, "kr", "005930", {"total_count": 3})
+
+
+@pytest.mark.asyncio
+async def test_get_fail_open_on_malformed_and_none():
+    assert await cache.get_cached_consensus(None, "kr", "005930") is None
+
+    class _Boom:
+        async def get(self, key):
+            raise RuntimeError("redis down")
+
+    assert await cache.get_cached_consensus(_Boom(), "kr", "005930") is None
+```
+
+- [ ] **Run it — fails.** `uv run pytest tests/services/test_analyst_consensus_cache.py -v` → `get_cached_consensus`/`set_cached_consensus` undefined.
+
+- [ ] **Minimal impl — get/set with TTL reuse + guards.** Append to the module:
+```python
+async def get_cached_consensus(
+    redis_client: Any, market: str, symbol: str
+) -> dict[str, Any] | None:
+    if redis_client is None or (market or "").strip().lower() != "kr":
+        return None
+    key = _consensus_cache_key(market, symbol)
+    try:
+        raw = await redis_client.get(key)
+    except Exception as exc:  # noqa: BLE001 — fail-open
+        logger.debug("consensus_cache GET failed %s: %s", key, exc)
+        return None
+    if not isinstance(raw, str):
+        return None
+    try:
+        parsed = json.loads(raw)
+    except (TypeError, ValueError):
+        return None
+    return parsed if isinstance(parsed, dict) else None
+
+
+async def set_cached_consensus(
+    redis_client: Any, market: str, symbol: str, consensus: dict[str, Any]
+) -> None:
+    if redis_client is None or (market or "").strip().lower() != "kr":
+        return
+    total = consensus.get("total_count")
+    if not isinstance(total, int) or total <= 0:
+        return  # never cache a degraded/empty consensus
+    try:
+        now = now_kst()
+        ttl = analyze_cache._fetch_cache_ttl_seconds(analyze_cache.PROVIDER_NAVER, now)
+        if ttl <= 0:
+            return
+        serialized = json.dumps(
+            _strip_volatile(consensus), default=str, ensure_ascii=False
+        )
+        await redis_client.set(_consensus_cache_key(market, symbol, now), serialized, ex=ttl)
+    except Exception as exc:  # noqa: BLE001 — fail-open
+        logger.debug("consensus_cache SET failed %s: %s", symbol, exc)
+```
+
+- [ ] **Run it — passes.** `uv run pytest tests/services/test_analyst_consensus_cache.py -v` → all passed.
+
+- [ ] **Commit.** `git add -A && git commit -m "feat(ROB-686): KR analyst-consensus Redis cache primitives (get/set/strip)"`
+
+---
+
+## Task 2 — Cache-aside resolution + filter counts + page provider (new module, migration-0)
+
+**Files:**
+- Modify `app/services/invest_view_model/analyst_consensus_cache.py` (append resolution layer).
+- Test (append) `tests/services/test_analyst_consensus_cache.py`.
+
+**Interfaces (produced):**
+- `async def resolve_consensus(*, symbol: str, market: str, redis_client: Any = None, memo: dict[str, dict[str, Any] | None] | None = None, opinion_fetcher=handle_get_investment_opinions) -> dict[str, Any] | None` — cache-aside for the daily-stable consensus dict. Order: per-call `memo` → Redis (`get_cached_consensus`) → live `opinion_fetcher(symbol=..., market=..., limit=10)` (KR); on live success extract `payload["consensus"]`, `set_cached_consensus`, store stable copy in `memo`. Returns the **stable** consensus dict (no `current_price`/`upside_pct`), or `None` on failure/degraded. US: bypasses Redis, returns the live `payload["consensus"]` (memoized only). Never raises (fail-open → `None`). **`limit=10` is deliberate**: it matches the value the current min_analyst path + page enrich already use (`enrich_snapshot_page._opinion_payload` calls the provider with `limit=10` — `screener_analysis_enrichment.py:141`), so `totalCount`'s ~10 ceiling and thus `min_analyst_count` filter semantics are preserved, and cold `company_read.naver` fetches per symbol are not inflated (a higher cap would triple them, working against the ticket's goal).
+- `async def resolve_consensus_counts(*, symbols: list[str], market: str, redis_client: Any = None, memo=None, concurrency: int = 4, opinion_fetcher=None) -> dict[str, dict[str, int | None]]` — resolves `{symbol: {"totalCount": int|None, "buyCount": int|None}}` for the `min_analyst_*` filter, cache-aside, under `asyncio.Semaphore(concurrency)` (default 4 — **not raised**). `opinion_fetcher` is threaded down to `resolve_consensus` for test injection (defaults to the lazily-imported `handle_get_investment_opinions`). Missing/failed symbols are simply absent from the dict; a symbol that fetched successfully but has zero coverage is present with `totalCount=0` (and is dropped by any `>= 1` filter).
+- `async def cached_opinion_provider(*, symbol: str, market: str, limit: int = 10, redis_client: Any = None, memo=None, price_fetcher=_fetch_current_price) -> dict[str, Any]` — drop-in replacement for `handle_get_investment_opinions` as `enrich_snapshot_page`'s `opinion_provider`. KR: `resolve_consensus(...)`; on a stable hit, recompute `current_price`/`upside_pct` from a fresh `price_fetcher(symbol)` (fail-open: leave both absent if the price fetch fails/returns None), return `{"source": "naver", "consensus": {...}}`. On miss returns `{"error": "analyst_consensus_unavailable"}`. US: delegates to `handle_get_investment_opinions(symbol=..., market="us", limit=...)` unchanged.
+
+**Interfaces (consumed):** `app.mcp_server.tooling.fundamentals._valuation.handle_get_investment_opinions`, `app.services.naver_finance.investor._fetch_current_price` (single `item/main.naver`), `analyze_cache._get_redis_client`.
+
+Notes: `resolve_consensus`/`cached_opinion_provider` accept injectable `opinion_fetcher`/`price_fetcher` so tests never hit the network. Imports of `handle_get_investment_opinions` and `_fetch_current_price` are done lazily inside the functions (module-import cost + avoid import cycles), mirroring the existing lazy imports in `screener_analysis_enrichment.py`.
+
+Steps:
+
+- [ ] **Write failing test — cache-aside prefers cache/memo over live fetch.** Append to `tests/services/test_analyst_consensus_cache.py`:
+```python
+@pytest.mark.asyncio
+async def test_resolve_consensus_uses_cache_and_skips_live_fetch():
+    redis = _FakeRedis()
+    await cache.set_cached_consensus(
+        redis, "kr", "005930", {"buy_count": 2, "total_count": 3, "avg_target_price": 78500}
+    )
+    calls: list[str] = []
+
+    async def _live(*, symbol, market, limit):
+        calls.append(symbol)
+        return {"consensus": {"total_count": 99}}
+
+    got = await cache.resolve_consensus(
+        symbol="005930", market="kr", redis_client=redis, opinion_fetcher=_live
+    )
+    assert got is not None and got["total_count"] == 3  # from cache, not live 99
+    assert calls == []  # live fetcher never called
+
+
+@pytest.mark.asyncio
+async def test_resolve_consensus_populates_cache_and_memo_on_miss():
+    redis = _FakeRedis()
+    memo: dict = {}
+    calls: list[str] = []
+
+    async def _live(*, symbol, market, limit):
+        calls.append(symbol)
+        return {
+            "consensus": {
+                "buy_count": 1,
+                "total_count": 2,
+                "avg_target_price": 100,
+                "current_price": 90,
+                "upside_pct": 11.1,
+            }
+        }
+
+    got = await cache.resolve_consensus(
+        symbol="000660", market="kr", redis_client=redis, memo=memo, opinion_fetcher=_live
+    )
+    assert got["total_count"] == 2 and "current_price" not in got  # stable only
+    assert (await cache.get_cached_consensus(redis, "kr", "000660"))["total_count"] == 2
+    # second resolve is served from memo — live fetcher not called again
+    await cache.resolve_consensus(
+        symbol="000660", market="kr", redis_client=redis, memo=memo, opinion_fetcher=_live
+    )
+    assert calls == ["000660"]
+```
+
+- [ ] **Run it — fails.** `resolve_consensus` undefined.
+
+- [ ] **Minimal impl — `resolve_consensus`.** Append:
+```python
+async def resolve_consensus(
+    *,
+    symbol: str,
+    market: str,
+    redis_client: Any = None,
+    memo: dict[str, dict[str, Any] | None] | None = None,
+    opinion_fetcher: Any = None,
+) -> dict[str, Any] | None:
+    market_norm = (market or "").strip().lower()
+    memo_key = f"{market_norm}:{symbol.upper()}"
+    if memo is not None and memo_key in memo:
+        return memo[memo_key]
+
+    if opinion_fetcher is None:
+        from app.mcp_server.tooling.fundamentals._valuation import (
+            handle_get_investment_opinions,
+        )
+
+        opinion_fetcher = handle_get_investment_opinions
+
+    if market_norm == "kr":
+        cached = await get_cached_consensus(redis_client, market_norm, symbol)
+        if cached is not None:
+            if memo is not None:
+                memo[memo_key] = cached
+            return cached
+
+    stable: dict[str, Any] | None = None
+    try:
+        # limit=10 preserves the existing filter/page ceiling (see interface note);
+        # do NOT bump this — a higher cap triples cold company_read.naver fetches.
+        payload = await opinion_fetcher(symbol=symbol, market=market_norm, limit=10)
+        consensus = (payload or {}).get("consensus") if isinstance(payload, dict) else None
+        if isinstance(consensus, dict) and isinstance(consensus.get("total_count"), int):
+            if market_norm == "kr":
+                await set_cached_consensus(redis_client, market_norm, symbol, consensus)
+                stable = _strip_volatile(consensus)
+            else:
+                stable = consensus  # US: not cached, returned as-is
+    except Exception as exc:  # noqa: BLE001 — fail-open
+        logger.debug("resolve_consensus live fetch failed %s: %s", symbol, exc)
+        stable = None
+
+    if memo is not None:
+        memo[memo_key] = stable
+    return stable
+```
+
+- [ ] **Run it — passes.** `uv run pytest tests/services/test_analyst_consensus_cache.py -v` → all passed.
+
+- [ ] **Write failing test — counts resolver + page provider upside recompute.** Append:
+```python
+@pytest.mark.asyncio
+async def test_resolve_consensus_counts_maps_symbols():
+    redis = _FakeRedis()
+    await cache.set_cached_consensus(
+        redis, "kr", "005930", {"buy_count": 2, "total_count": 3}
+    )
+
+    async def _live(*, symbol, market, limit):
+        return {"consensus": {"buy_count": 5, "total_count": 7}}
+
+    memo: dict = {}
+    counts = await cache.resolve_consensus_counts(
+        symbols=["005930", "000660"], market="kr", redis_client=redis, memo=memo,
+        opinion_fetcher=_live,
+    )
+    assert counts["005930"] == {"totalCount": 3, "buyCount": 2}   # cache
+    assert counts["000660"] == {"totalCount": 7, "buyCount": 5}   # live
+
+
+@pytest.mark.asyncio
+async def test_cached_opinion_provider_recomputes_upside_from_fresh_price():
+    redis = _FakeRedis()
+    await cache.set_cached_consensus(
+        redis, "kr", "005930",
+        {"buy_count": 2, "hold_count": 1, "sell_count": 0, "total_count": 3,
+         "avg_target_price": 110},
+    )
+
+    async def _price(code):
+        return 100  # fresh price → upside = (110-100)/100*100 = 10.0
+
+    payload = await cache.cached_opinion_provider(
+        symbol="005930", market="kr", redis_client=redis, price_fetcher=_price,
+    )
+    c = payload["consensus"]
+    assert c["current_price"] == 100
+    assert c["upside_pct"] == pytest.approx(10.0)
+    assert c["total_count"] == 3  # daily-stable count preserved
+
+
+@pytest.mark.asyncio
+async def test_cached_opinion_provider_fail_open_when_price_missing():
+    redis = _FakeRedis()
+    await cache.set_cached_consensus(
+        redis, "kr", "005930", {"total_count": 3, "avg_target_price": 110},
+    )
+
+    async def _price(code):
+        return None  # price unavailable → no stale upside served
+
+    payload = await cache.cached_opinion_provider(
+        symbol="005930", market="kr", redis_client=redis, price_fetcher=_price,
+    )
+    c = payload["consensus"]
+    assert c.get("upside_pct") is None
+    assert c.get("current_price") is None
+```
+
+- [ ] **Run it — fails.** `resolve_consensus_counts` / `cached_opinion_provider` undefined.
+
+- [ ] **Minimal impl — counts resolver + page provider.** Append:
+```python
+import asyncio
+
+
+async def resolve_consensus_counts(
+    *,
+    symbols: list[str],
+    market: str,
+    redis_client: Any = None,
+    memo: dict[str, dict[str, Any] | None] | None = None,
+    concurrency: int = 4,
+    opinion_fetcher: Any = None,
+) -> dict[str, dict[str, int | None]]:
+    sem = asyncio.Semaphore(max(1, concurrency))  # NOT raised — Naver is throttling
+    out: dict[str, dict[str, int | None]] = {}
+
+    async def _one(symbol: str) -> None:
+        async with sem:
+            stable = await resolve_consensus(
+                symbol=symbol, market=market, redis_client=redis_client,
+                memo=memo, opinion_fetcher=opinion_fetcher,
+            )
+            if stable is not None:
+                out[symbol] = {
+                    "totalCount": stable.get("total_count"),
+                    "buyCount": stable.get("buy_count"),
+                }
+
+    await asyncio.gather(*(_one(s) for s in dict.fromkeys(symbols)))
+    return out
+
+
+def _recompute_upside(consensus: dict[str, Any], price: float | int | None) -> dict[str, Any]:
+    out = dict(consensus)
+    avg = out.get("avg_target_price")
+    if price and isinstance(price, (int, float)) and avg and isinstance(avg, (int, float)):
+        out["current_price"] = price
+        out["upside_pct"] = round((avg - price) / price * 100, 2)
+    else:
+        out.pop("current_price", None)
+        out.pop("upside_pct", None)
+    return out
+
+
+async def cached_opinion_provider(
+    *,
+    symbol: str,
+    market: str,
+    limit: int = 10,
+    redis_client: Any = None,
+    memo: dict[str, dict[str, Any] | None] | None = None,
+    price_fetcher: Any = None,
+    opinion_fetcher: Any = None,
+) -> dict[str, Any]:
+    market_norm = (market or "").strip().lower()
+    if market_norm != "kr":
+        from app.mcp_server.tooling.fundamentals._valuation import (
+            handle_get_investment_opinions,
+        )
+
+        return await handle_get_investment_opinions(
+            symbol=symbol, market=market_norm, limit=limit
+        )
+
+    stable = await resolve_consensus(
+        symbol=symbol, market=market_norm, redis_client=redis_client,
+        memo=memo, opinion_fetcher=opinion_fetcher,
+    )
+    if stable is None:
+        return {"error": "analyst_consensus_unavailable"}
+
+    if price_fetcher is None:
+        from app.services.naver_finance.investor import _fetch_current_price
+
+        price_fetcher = _fetch_current_price
+    try:
+        price = await price_fetcher(symbol)
+    except Exception:  # noqa: BLE001 — fail-open, no stale upside
+        price = None
+
+    return {"source": "naver", "consensus": _recompute_upside(stable, price)}
+```
+
+- [ ] **Run it — passes.** `uv run pytest tests/services/test_analyst_consensus_cache.py -v` → all passed.
+
+- [ ] **Lint.** `make lint`.
+
+- [ ] **Commit.** `git add -A && git commit -m "feat(ROB-686): KR consensus cache-aside resolve/counts/page-provider with fresh-price upside"`
+
+---
+
+## Task 3 — Rewire the screener `min_analyst_*` branch (fix pre-pagination over-enrichment, migration-0)
+
+**Files:**
+- Modify `app/mcp_server/tooling/screener_snapshot_tool.py` — the `min_analyst_*` branch (`:455`–`:497`) and both `enrich_snapshot_page` calls (`:479`,`:517`).
+- Test (append) `tests/test_screener_snapshot_tool.py`.
+
+**Interfaces (consumed):** `analyst_consensus_cache.resolve_consensus_counts`, `analyst_consensus_cache.cached_opinion_provider`, `analyze_cache._get_redis_client`.
+
+**Current behavior to replace (`:455`–`:497`):** when `min_analyst_*` is set, the tool hard-errors above 200 rows, then live-`enrich_snapshot_page`s the **whole** matched set, filters on the enriched `analysisContext.consensus`, and paginates. The no-filter branch (`:512`–`:523`) already enriches only the page.
+
+**Target behavior:**
+1. Build a per-call `memo: dict = {}` and `redis_client = await analyze_cache._get_redis_client()` once.
+2. `min_analyst_*` branch: keep the `_MAX_ANALYST_ENRICHMENT_ROWS` cold-path guard (now a *resolution* bound), then `counts = await resolve_consensus_counts(symbols=[all matched symbols], market=market, redis_client=redis_client, memo=memo)`; filter `all_results` by `counts[symbol]["totalCount"] >= min_analyst_count` and/or `["buyCount"] >= min_analyst_buy_count` (drop symbols absent from `counts`); recompute `total_available`; paginate; then `enrich_snapshot_page(rows=page, market=market, session_factory=_session_factory(), opinion_provider=functools.partial(cached_opinion_provider, redis_client=redis_client, memo=memo))`.
+3. No-filter branch (`:512`): same `opinion_provider=partial(cached_opinion_provider, redis_client=redis_client, memo=memo)` injection so the KR page consensus is cached too.
+4. `_consensus_count` (`:166`) is no longer used by the filter (it read enriched rows). Remove it if unused after the rewrite, else leave a single caller. Verify with `grep -n _consensus_count app/mcp_server/tooling/screener_snapshot_tool.py`.
+
+Steps:
+
+- [ ] **Write failing test — min_analyst path filters via cache-aside counts and enriches only the page.** Append to `tests/test_screener_snapshot_tool.py` (reuse `_patch_build_with_n_results` / `_FakeCM` already in the file):
+```python
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_min_analyst_filters_via_counts_and_enriches_only_page(monkeypatch) -> None:
+    _patch_build_with_n_results(monkeypatch, 5)  # symbols S0..S4
+
+    async def _fake_counts(*, symbols, market, redis_client=None, memo=None, **kw):
+        # S0,S1,S2 qualify (>=3), S3,S4 do not
+        return {
+            s: {"totalCount": (3 if i < 3 else 1), "buyCount": (2 if i < 3 else 0)}
+            for i, s in enumerate(symbols)
+        }
+
+    monkeypatch.setattr(
+        "app.services.invest_view_model.analyst_consensus_cache.resolve_consensus_counts",
+        _fake_counts,
+    )
+
+    enriched_symbols: list[list[str]] = []
+
+    async def _fake_enrich_page(*, rows, market, session_factory, opinion_provider=None):
+        enriched_symbols.append([r["symbol"] for r in rows])
+        return {
+            "results": [{**r, "analystLabel": "x", "analysisContext": {}} for r in rows],
+            "summary": {"attempted": len(rows), "warnings": []},
+        }
+
+    monkeypatch.setattr(
+        "app.services.invest_view_model.screener_analysis_enrichment.enrich_snapshot_page",
+        _fake_enrich_page,
+    )
+
+    out = await tool.screen_stocks_snapshot_impl(
+        preset="consecutive_gainers", market="kr", min_analyst_count=3, limit=2, offset=0
+    )
+    # 3 qualified, page of 2
+    assert out["pagination"]["total_available"] == 3
+    assert len(out["results"]) == 2
+    # enrichment saw ONLY the 2 returned page rows, not all matched/qualified rows
+    assert enriched_symbols == [["S0", "S1"]]
+```
+
+- [ ] **Run it — fails.** Current impl enriches all 5 rows before filtering (asserts on `enriched_symbols == [["S0","S1"]]` and `total_available == 3` fail).
+
+- [ ] **Minimal impl — rewrite the branch.** In `app/mcp_server/tooling/screener_snapshot_tool.py`:
+  - Add near the other imports: `import functools`.
+  - Before the pagination block (`:448`), add `memo: dict[str, Any] = {}` and, lazily inside the enrichment sections, `from app.services.invest_view_model import analyst_consensus_cache` + `from app.core import analyze_cache`; resolve `redis_client = await analyze_cache._get_redis_client()` once.
+  - Replace the `min_analyst_*` branch (`:455`–`:497`) with:
+```python
+    if min_analyst_count is not None or min_analyst_buy_count is not None:
+        if len(all_results) > _MAX_ANALYST_ENRICHMENT_ROWS:
+            return {
+                "error": (
+                    "analyst enrichment row cap exceeded; narrow presets, "
+                    "market-cap filters, or exclude_symbols before applying analyst filters"
+                ),
+                "preset": preset,
+                "presets": preset_ids,
+                "results": [],
+                "pagination": {
+                    "total_available": len(all_results),
+                    "returned_count": 0,
+                    "offset": eff_offset,
+                    "limit": eff_limit,
+                    "has_more": False,
+                    "next_offset": None,
+                },
+            }
+
+        from app.core import analyze_cache
+        from app.services.invest_view_model import analyst_consensus_cache
+
+        redis_client = await analyze_cache._get_redis_client()
+        matched_symbols = [
+            str(r.get("symbol") or "").strip()
+            for r in all_results
+            if r.get("symbol")
+        ]
+        counts = await analyst_consensus_cache.resolve_consensus_counts(
+            symbols=matched_symbols,
+            market=market,
+            redis_client=redis_client,
+            memo=memo,
+        )
+
+        def _passes(row: dict[str, Any]) -> bool:
+            c = counts.get(str(row.get("symbol") or "").strip())
+            if c is None:
+                return False
+            if min_analyst_count is not None and (c.get("totalCount") or 0) < int(
+                min_analyst_count
+            ):
+                return False
+            if min_analyst_buy_count is not None and (c.get("buyCount") or 0) < int(
+                min_analyst_buy_count
+            ):
+                return False
+            return True
+
+        all_results = [r for r in all_results if _passes(r)]
+        total_available = len(all_results)
+        page = all_results[eff_offset : eff_offset + eff_limit]
+
+        from app.services.invest_view_model.screener_analysis_enrichment import (
+            enrich_snapshot_page,
+        )
+
+        enrichment = await enrich_snapshot_page(
+            rows=page,
+            market=market,
+            session_factory=_session_factory(),
+            opinion_provider=functools.partial(
+                analyst_consensus_cache.cached_opinion_provider,
+                redis_client=redis_client,
+                memo=memo,
+            ),
+        )
+        page = enrichment["results"]
+        payload["analysisEnrichment"] = enrichment["summary"]
+    else:
+        page = all_results[eff_offset : eff_offset + eff_limit]
+```
+  - Replace the no-filter enrichment block (`:512`–`:523`) so it injects the cached provider:
+```python
+    if min_analyst_count is None and min_analyst_buy_count is None:
+        from app.core import analyze_cache
+        from app.services.invest_view_model import analyst_consensus_cache
+        from app.services.invest_view_model.screener_analysis_enrichment import (
+            enrich_snapshot_page,
+        )
+
+        redis_client = await analyze_cache._get_redis_client()
+        enrichment = await enrich_snapshot_page(
+            rows=page,
+            market=market,
+            session_factory=_session_factory(),
+            opinion_provider=functools.partial(
+                analyst_consensus_cache.cached_opinion_provider,
+                redis_client=redis_client,
+                memo=memo,
+            ),
+        )
+        payload["results"] = enrichment["results"]
+        payload["analysisEnrichment"] = enrichment["summary"]
+```
+  - Remove `_consensus_count` (`:166`) if now unused (confirm via grep).
+
+- [ ] **Run it — passes.** `uv run pytest tests/test_screener_snapshot_tool.py -k "min_analyst_filters_via_counts" -v` → passes.
+
+- [ ] **REQUIRED — rewrite the existing `test_snapshot_tool_filters_market_cap_and_analyst` (`tests/test_screener_snapshot_tool.py:811`).** This is the pre-existing coverage for the `min_analyst_*` filter and it **WILL BREAK** under the rewrite: today it filters on the enriched `analysisContext.consensus` produced by a monkeypatched `enrich_snapshot_page`; the new impl filters on `resolve_consensus_counts` (which this test does **not** stub), so its two analyst sub-assertions (`min_analyst_buy_count=1` at `:867` and `min_analyst_count=1` at `:879`) would fall through to a real live `handle_get_investment_opinions` network fetch (fail-open → empty counts → both symbols dropped → assertions fail). Split it: keep the two market-cap sub-cases (no `min_analyst_*`) on the existing `_fake_enrich_page` (add `**kwargs`/`opinion_provider=None` — it already takes `**kwargs`), and for the analyst sub-cases monkeypatch `app.services.invest_view_model.analyst_consensus_cache.resolve_consensus_counts` to return the S1/S2 counts directly, e.g.:
+```python
+    async def _fake_counts(*, symbols, market, redis_client=None, memo=None, **kw):
+        return {
+            "S1": {"totalCount": 2, "buyCount": 2},
+            "S2": {"totalCount": 1, "buyCount": 0},
+        }
+
+    monkeypatch.setattr(
+        "app.services.invest_view_model.analyst_consensus_cache.resolve_consensus_counts",
+        _fake_counts,
+    )
+```
+  Then `min_analyst_buy_count=1` → `["S1"]`, `min_analyst_count=1` → `["S1", "S2"]` (unchanged expectations), but now sourced from the cache-aside counts instead of enriched rows. The page-only `enrich_snapshot_page` fake for these sub-cases must accept `opinion_provider=None`.
+
+- [ ] **Adjust the remaining `_fake_enrich_page` signatures.** In `tests/test_screener_snapshot_tool.py`, every monkeypatched `enrich_snapshot_page` fake must accept the now-always-injected `opinion_provider` kwarg. Update `test_enriches_only_returned_page`'s `_fake_enrich_page(*, rows, market, session_factory)` → add `opinion_provider=None` (its no-filter branch now passes the cached provider partial). `test_snapshot_tool_filters_market_cap_and_analyst`'s fake already uses `**kwargs` so it absorbs it. `test_snapshot_tool_analyst_filter_rejects_large_unpaged_enrichment` (`:986`, 201 rows) still passes untouched — the `_MAX_ANALYST_ENRICHMENT_ROWS` guard returns the row-cap error before `resolve_consensus_counts` is ever reached.
+
+- [ ] **Regression — full tool + enrichment suites.** `uv run pytest tests/test_screener_snapshot_tool.py tests/services/test_screener_analysis_enrichment.py -v` → all pass. (`test_screener_analysis_enrichment.py` exercises `enrich_snapshot_page` directly with its own `opinion_provider`; its signature is unchanged by this plan, so it stays green.)
+
+- [ ] **Lint.** `make lint`.
+
+- [ ] **Commit.** `git add -A && git commit -m "fix(ROB-686): screener min_analyst filters via cached counts, enrich only the page"`
+
+---
+
+## Task 4 — Tool description + operator runbook (doc-only, migration-0)
+
+**Files:**
+- Modify `app/mcp_server/tooling/analysis_registration.py` — `screen_stocks_snapshot` description (`:316`–`:338`).
+- Create `docs/runbooks/screener-analyst-consensus-cache.md`.
+
+**Interfaces:** no signature change; `register_analysis_tools(mcp)` unchanged.
+
+Steps:
+
+- [ ] **Write failing test — description mentions the cache + intraday upside recompute.** Append to `tests/test_screener_snapshot_tool.py` (or a small new `tests/mcp_server/tooling/test_screen_stocks_snapshot_docs.py` mirroring the ROB-669 `_FakeMCP` doc-test pattern):
+```python
+def test_screen_stocks_snapshot_description_notes_consensus_cache():
+    from app.mcp_server.tooling.analysis_registration import register_analysis_tools
+
+    class _FakeMCP:
+        def __init__(self):
+            self.descriptions = {}
+
+        def tool(self, *, name, description, **kw):
+            def _d(fn):
+                self.descriptions[name] = description
+                return fn
+            return _d
+
+    mcp = _FakeMCP()
+    register_analysis_tools(mcp)
+    desc = mcp.descriptions["screen_stocks_snapshot"].lower()
+    assert "consensus" in desc
+    assert "cache" in desc or "cached" in desc
+```
+  (Confirm `register_analysis_tools` is the real registrar name via `grep -n "def register" app/mcp_server/tooling/analysis_registration.py` and that `_FakeMCP.tool` accepts the same kwargs the real registration uses.)
+
+- [ ] **Run it — fails.** Current description names no cache.
+
+- [ ] **Minimal impl — extend the description.** Append one sentence to the `screen_stocks_snapshot` description string (`:316`), e.g.:
+  `"KR analyst consensus (buy/hold/sell counts + target prices) is cached daily per symbol (Redis, KST-date TTL); the displayed target-upside is recomputed each call from a fresh price so it stays intraday-current. min_analyst_* filters resolve consensus from the cache and only the returned page is enriched."`
+
+- [ ] **Run it — passes.**
+
+- [ ] **Create the runbook.** `docs/runbooks/screener-analyst-consensus-cache.md`: cache key format (`screener_consensus:naver:{SYMBOL}:{KST-date}`), TTL (session-close 15:35 KST, then next KST midnight — same as ROB-638 `analyze_cache`), the `ANALYZE_FETCH_CACHE_ENABLED` gate (shared with the analyze path; `false` disables → live fetch every call), fail-open behavior, KR-only scope (US uncached), and how to invalidate (`redis-cli --scan --pattern "screener_consensus:*"` then `DEL`). Note migration-0 and that the ROB-641 `analyst_consensus_snapshots` precompute table is a separate, untouched surface.
+
+- [ ] **Lint.** `make lint`.
+
+- [ ] **Commit.** `git add -A && git commit -m "docs(ROB-686): note screener consensus cache in tool description + runbook"`
+
+---
+
+## Verification (whole plan)
+
+- [ ] `uv run pytest tests/services/test_analyst_consensus_cache.py tests/test_screener_snapshot_tool.py tests/services/test_screener_analysis_enrichment.py -v` → all green.
+- [ ] `make lint` clean.
+- [ ] Sanity: with `ANALYZE_FETCH_CACHE_ENABLED=false` (test default) every path falls open to live fetch and existing behavior is preserved; with it enabled, a second `screen_stocks_snapshot` call for the same KR symbols in the same KST day issues **no** `company_list.naver`/`company_read.naver` (only the per-page `item/main.naver` price recompute). Confirm via the resolver/provider unit tests (network-injected), not a live call.

--- a/docs/plans/ROB-687-toss-reconcile-account-seq-nplus1.md
+++ b/docs/plans/ROB-687-toss-reconcile-account-seq-nplus1.md
@@ -1,0 +1,576 @@
+# Toss Reconcile — Eliminate per-row /accounts N+1 via one shared client + diagnose the swallowed batch build failure Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (- [ ]) syntax.
+
+**Goal:** Cut `toss_reconcile_orders` wall time (Sentry 7d: avg 26.3s, p95 82.5s — worst of all transactions) by removing the per-ledger-row `GET /api/v1/accounts` N+1. The bottleneck is an *uninstrumented* rate-limiter sleep: the ACCOUNT group is capped at **1 TPS** (`rate_limiter.py:27`), and ~27 fresh `TossReadClient` instances per run each resolve their own account-seq header via `/accounts`, serializing into ~22.7s of `acquire()` sleep (187 `/accounts` calls across 7 runs; `http.client` sums 40.8s of a 183.7s transaction total → ~78% is uninstrumented ACCOUNT sleep). The N+1 is a *fallback* path that only runs because ROB-669's `TossBatchEvidenceSource.build` (which resolves account-seq ONCE and batches evidence) is failing every run and being silently swallowed (`toss_live_ledger.py:590-597` → `evidence_source=None`). This plan (1) makes the swallowed build failure observable and DIAGNOSES + fixes its real root cause, and (2) makes the whole reconcile run reuse ONE `TossReadClient` so account-seq is resolved at most once even when batch build is unavailable — defense-in-depth that neutralizes the N+1 regardless of the batch path. `asyncio.gather` over rows is explicitly rejected (the shared 1-TPS ACCOUNT limiter serializes concurrent calls anyway — the fix must reduce call COUNT, not add concurrency).
+
+**Architecture (current → target):** Today `toss_reconcile_orders_impl` (`toss_live_ledger.py:547`) builds a batch source with `TossBatchEvidenceSource.build(rows=rows, symbol=symbol)` — **no client passed**, so `build` news its own `TossReadClient.from_settings()` (`toss_live_evidence.py:215`). When that build raises, the `except` at `toss_live_ledger.py:590-597` logs a one-line WARNING (`"...: %s", exc` — no stack, not sent to Sentry) and sets `evidence_source=None`. The per-row loop then falls back to `TossEvidenceAdapter().fetch_evidence(row)` (`toss_live_ledger.py:231`), and that adapter news a **fresh** `TossReadClient.from_settings()` **per row** (`toss_live_evidence.py:157`). Each fresh client has an empty per-instance `_account_seq` cache (`client.py:63`), so its first `account_required` call triggers `_resolve_account_seq()` → `GET /api/v1/accounts` (`client.py:98-99, 127-136`), each gated by the 1-TPS ACCOUNT limiter (`rate_limiter.py:57-73`). N clients ⇒ N `/accounts` ⇒ N seconds of serialized sleep. **Target:** `toss_reconcile_orders_impl` constructs exactly one `TossReadClient` per run, passes it into `TossBatchEvidenceSource.build(..., client=shared)` (so `build` no longer news its own and `owns_client=False`), and threads it into the per-row fallback via `TossEvidenceAdapter(client=shared)` — which reuses the injected client and does **not** close it. Because a single client instance caches `_account_seq` after the first resolution (`client.py:128-129,135`), `/accounts` is called **at most once** per run (0 if the operator sets `toss_api_account_seq`), regardless of whether batch build succeeds or falls back. Separately, the swallowed build failure is upgraded to `logger.exception` + `sentry_sdk.capture_exception` + a `batch_build_error` echo in the tool result, and its real root cause is reproduced, named, regression-tested, and fixed.
+
+**Tech Stack:** Python 3.13, uv, pytest (markers `unit`/`asyncio`), SQLAlchemy async, httpx (`httpx.MockTransport` for client-level tests), FastMCP tool registration, pydantic v2, Redis (OAuth token cache), `sentry_sdk`. Toss Open API read-only GETs: `GET /api/v1/accounts`, `GET /api/v1/orders`, `GET /api/v1/orders/{orderId}`.
+
+## Global Constraints
+
+Copied verbatim; every task implicitly includes these.
+
+- **fix (3) requires DIAGNOSING the actual swallowed exception, not assuming — include a task that reproduces `TossBatchEvidenceSource.build` failure and names the root cause before patching.**
+- **hardcoding `toss_api_account_seq` (fix 1) bypasses the "exactly one account" guard in `client.py:~131-134` — the configured value must match the intended single account; the plan must preserve or re-assert that guard.**
+- **All three legs touch only read-only GETs (accounts/get_order/list_orders); reconcile DB writes and evidence-gated booking are unchanged; no broker mutation.**
+- **migration-0.** No new DB column, no new `status` enum value, no alembic revision. The `status` CHECK constraint (`app/models/review.py:513-519`) and every ledger column are untouched. All changes are in the reconcile read/evidence path.
+- **Read-only path / no broker-order-watch mutation.** No `place_order` / `modify_order` / `cancel_order` / watch-trigger mutation is reachable from any code changed here. Send-time rows stay accepted-only; fills/journals/realized_pnl are still booked ONLY from confirmed execution evidence via the existing `_reconcile_one_toss_row` booking calls.
+- **Approach decision (config vs runtime resolution): prefer runtime single-resolution over hardcoding config.** We do NOT set `settings.toss_api_account_seq` to a literal. The single shared client resolves account-seq once at runtime (instance cache), which keeps the `_resolve_account_seq` "exactly one account" guard (`client.py:131-134`) ACTIVE and untouched. Config `toss_api_account_seq` (`config.py:246`) remains an optional operator fast-path (if set → 0 `/accounts`, and the operator is responsible for it matching the single account). This is lower-risk than hardcoding: no config change is required to fix the bug, and the guard cannot be silently bypassed.
+- **`classify_toss_order_evidence(order)` is reused UNCHANGED.** The shared-client wiring changes only *which client instance* fetches evidence, never how evidence is classified or booked.
+- **Backward-compatible signatures.** `TossEvidenceAdapter.__init__` gains an optional `client=None` (legacy new-and-close path preserved for `client=None`). `_reconcile_one_toss_row(row, *, dry_run, evidence_source=None)` gains an optional `fallback_client=None`. The public `toss_reconcile_orders_impl(*, symbol, order_id, market, dry_run, limit)` keyword signature and the `toss_reconcile_orders` MCP tool signature are BOTH unchanged, so the paused TaskIQ caller (`app/tasks/toss_live_reconcile_tasks.py:35`) and the MCP wrapper (`orders_toss_variants.py:1698`) are unaffected.
+- Run tests: `uv run pytest <path> -v`. Lint: `make lint`. Do NOT commit unless the executing skill says so; each task lists its own commit message.
+
+---
+
+## File Structure
+
+| File | Create/Modify | Responsibility (Task) |
+|------|---------------|-----------------------|
+| `app/mcp_server/tooling/toss_live_ledger.py` | Modify | Task 1 — surface the swallowed batch-build failure (`logger.exception` + `sentry_sdk.capture_exception` + `batch_build_error` echo). Task 3 — construct one shared `TossReadClient`, pass to `build(..., client=shared)`, thread `fallback_client` into `_reconcile_one_toss_row`, close once. |
+| `app/mcp_server/tooling/toss_live_evidence.py` | Modify | Task 2 — `TossEvidenceAdapter.__init__(client=None)`: reuse an injected client without closing it; keep the legacy new-and-close path for `client=None`. |
+| `docs/runbooks/toss-live-order-reconcile.md` | Modify | Task 4 — document the diagnosed root cause, the shared-client / account-seq behavior, and how to read `batch_build_error` in the tool output. |
+| `tests/mcp_server/tooling/test_toss_reconcile_resilience.py` | Modify | Task 1 tests (build-failure surfaced + captured + still falls back). |
+| `tests/mcp_server/tooling/test_toss_live_evidence.py` | Modify | Task 2 tests (adapter reuses injected client, does not close it; legacy path unchanged). |
+| `tests/mcp_server/tooling/test_toss_reconcile_account_seq.py` | Create | Task 3 run-level test (one shared client across a multi-row run; reused by batch build + per-row fallback; closed once). |
+| `tests/services/brokers/toss/test_client.py` | Modify | Task 3 client-level regression locks (account-seq resolved once then cached; exactly-one-account guard preserved). |
+| `tests/mcp_server/tooling/test_toss_batch_evidence_source.py` | Modify | Task 4 regression test reproducing the diagnosed real build failure (fake-client shape/error). |
+
+> **NOT touched:**
+> - **`app/services/brokers/toss/client.py`** — `_resolve_account_seq` and its "exactly one account" guard (`:131-134`) and per-instance cache (`:135`) are the *mechanism* we rely on; they are correct and stay verbatim. The fix is to reuse one client instance, not to change resolution.
+> - **`app/services/brokers/toss/rate_limiter.py`** — the ACCOUNT=1-TPS bucket (`:27`) is a real Toss limit; we reduce the number of ACCOUNT calls, we do not touch the limiter.
+> - **`app/mcp_server/tooling/orders_toss_variants.py`** — the `toss_reconcile_orders` MCP wrapper / `register_toss_live_order_tools` are left exactly as-is (no signature or description change).
+> - **`app/config` / `.env`** — we deliberately do NOT hardcode `toss_api_account_seq` (see the approach decision); runtime single-resolution keeps the guard active.
+> - **`TossBatchEvidenceSource` windowing/pagination logic** — only its `build(..., client=)` injection is exercised; the CLOSED window + cap logic (`toss_live_evidence.py:227-270`) is unchanged except as required by Task 4's diagnosed fix.
+
+---
+
+## Task 1 — Surface the swallowed `TossBatchEvidenceSource.build` failure (Fix 3a, observability, migration-0)
+
+The batch-build `except` (`toss_live_ledger.py:590-597`) currently emits a single-line WARNING with `%s` of the exception — no stack trace, not sent to Sentry, not echoed in the tool result. That is exactly why the failure has been invisible for so long (Sentry sees only the downstream N+1, never the cause). This task makes the failure observable so Task 4 can diagnose it, WITHOUT changing the fail-open fallback behavior.
+
+**Files:**
+- Modify `app/mcp_server/tooling/toss_live_ledger.py` — add `import sentry_sdk` near the top imports (`:1-33`); replace the `except` body at `:590-597` with `logger.exception(...)` + `sentry_sdk.capture_exception(exc)` + set a local `batch_build_error` dict; initialize `batch_build_error = None` before the `if rows:` block (`:584`); echo it in `result` (`:614-624`).
+- Test (modify) `tests/mcp_server/tooling/test_toss_reconcile_resilience.py`.
+
+**Interfaces:**
+- Consumes: `sentry_sdk.capture_exception(exc)` (same library already used in `app/mcp_server/tooling/analysis_analyze.py:10`).
+- Produces: `toss_reconcile_orders_impl(...)` result gains an optional key `"batch_build_error": {"type": str, "message": str} | None`. No signature change. Fail-open fallback (`evidence_source=None` → per-row) is unchanged.
+
+Steps:
+
+- [ ] **Write failing test — a batch-build failure is captured to Sentry + echoed, and per-row fallback still reconciles.** Append to `tests/mcp_server/tooling/test_toss_reconcile_resilience.py` (the `_patch_session_factory`, `_clean`, `_accepted` fixtures/helpers already exist in that file):
+```python
+async def test_batch_build_failure_is_surfaced_and_captured(db_session):
+    from app.mcp_server.tooling import toss_live_ledger as mod
+    from app.mcp_server.tooling.toss_live_evidence import TossFillEvidence
+
+    await _accepted(db_session)
+
+    pending = TossFillEvidence(
+        verdict="pending", local_status="pending", broker_status="PENDING",
+        filled_qty=Decimal("0"), avg_price=None, commission=None, tax=None,
+        fee_total=Decimal("0"), settlement_date=None,
+        raw_order={"status": "PENDING"}, reason="pending",
+    )
+
+    class _Adapter:
+        fetch_evidence = AsyncMock(return_value=pending)
+
+    with (
+        patch.object(
+            mod.TossBatchEvidenceSource,
+            "build",
+            new=AsyncMock(side_effect=RuntimeError("boom-build-fails")),
+        ),
+        patch.object(mod, "TossEvidenceAdapter", return_value=_Adapter()),
+        patch.object(mod.sentry_sdk, "capture_exception") as capture,
+    ):
+        out = await mod.toss_reconcile_orders_impl(dry_run=False)
+
+    # fail-open: per-row fallback still reconciles the row
+    assert out["counts"] == {"pending": 1}
+    # observability: the real exception reaches Sentry + is echoed for operators
+    capture.assert_called_once()
+    assert out["batch_build_error"]["type"] == "RuntimeError"
+    assert "boom-build-fails" in out["batch_build_error"]["message"]
+```
+
+- [ ] **Run it — fails.** `uv run pytest tests/mcp_server/tooling/test_toss_reconcile_resilience.py -k surfaced -v`
+  Expected: `AttributeError: <module ...> does not have the attribute 'sentry_sdk'` (not imported yet) and `KeyError: 'batch_build_error'` (not echoed).
+
+- [ ] **Minimal impl — import sentry, upgrade the except, echo the error.** In `app/mcp_server/tooling/toss_live_ledger.py`:
+  1. Add `import sentry_sdk` alongside the existing top-level imports (with `import httpx` / `import logging` near `:1-8`).
+  2. Before the `if rows:` batch build (currently `:584`), initialize `batch_build_error: dict[str, Any] | None = None`.
+  3. Replace the `except` body (`:590-597`) with:
+```python
+        except Exception as exc:  # noqa: BLE001 — batch is an optimization
+            # Any batch-build failure (disabled/network/transient/bug) degrades to
+            # the per-row single-fetch path; per-row R1 classification still applies.
+            # ROB-687: this was previously a silent one-line WARNING, which hid the
+            # root cause of the /accounts N+1 for weeks — surface it with a stack
+            # trace + Sentry capture + a result echo so it can be diagnosed.
+            logger.exception(
+                "toss reconcile batch evidence build failed; per-row fallback"
+            )
+            sentry_sdk.capture_exception(exc)
+            batch_build_error = {"type": type(exc).__name__, "message": str(exc)}
+            evidence_source = None
+```
+  4. In the `result` dict assembly (`:614-624`), add after `"reopened": reopen_report,`:
+```python
+        "batch_build_error": batch_build_error,
+```
+
+- [ ] **Run it — passes.** `uv run pytest tests/mcp_server/tooling/test_toss_reconcile_resilience.py -k surfaced -v` → 1 passed.
+
+- [ ] **Regression — existing resilience + fallback tests unaffected.** `uv run pytest tests/mcp_server/tooling/test_toss_reconcile_resilience.py -v`
+  Expected: all pass, including `test_impl_batch_build_failure_falls_back_per_row` (fail-open behavior preserved) and `test_impl_uses_batch_source_and_echoes_window` (success path echoes `batch_build_error: None`).
+
+- [ ] **Lint.** `make lint`
+
+- [ ] **Commit.** `git add -A && git commit -m "obs(ROB-687): surface swallowed toss batch-build failure (sentry + echo)"`
+
+---
+
+## Task 2 — `TossEvidenceAdapter` reuses an injected client without closing it (Fix 2 enabler, migration-0)
+
+To share one client across the run, the per-row fallback adapter must accept an injected client that it does **not** own (the run owns and closes it). Today the adapter unconditionally news + closes a fresh client per call (`toss_live_evidence.py:156-162`), which is the N+1. This task adds the injection point while preserving the legacy new-and-close behavior for `client=None`.
+
+**Files:**
+- Modify `app/mcp_server/tooling/toss_live_evidence.py` — add `TossEvidenceAdapter.__init__(self, client: TossReadClient | None = None)` and branch `fetch_evidence` on the injected client (`:155-162`).
+- Test (modify) `tests/mcp_server/tooling/test_toss_live_evidence.py`.
+
+**Interfaces:**
+- Produces `TossEvidenceAdapter(client: TossReadClient | None = None)`. When `client` is provided: `fetch_evidence(row)` calls `client.get_order(...)` and does NOT `aclose()` it (caller-owned). When `client is None`: unchanged — news `TossReadClient.from_settings()` and `aclose()`s it in `finally`.
+- Consumes `TossReadClient.get_order(order_id: str) -> TossOrder` (`client.py:289`), `classify_toss_order_evidence` (`toss_live_evidence.py:78`).
+
+Steps:
+
+- [ ] **Write failing test — injected client is reused and NOT closed; legacy path unchanged.** Append to `tests/mcp_server/tooling/test_toss_live_evidence.py`:
+```python
+@pytest.mark.asyncio
+async def test_adapter_reuses_injected_client_without_closing():
+    from app.mcp_server.tooling import toss_live_evidence as ev
+
+    class _Row:
+        broker_order_id = "ord-9"
+
+    injected = SimpleNamespace(
+        get_order=AsyncMock(
+            return_value=_order(
+                "FILLED",
+                {"filledQuantity": Decimal("1"), "averageFilledPrice": Decimal("10")},
+            )
+        ),
+        aclose=AsyncMock(),
+    )
+
+    # from_settings must NOT be called when a client is injected.
+    with patch.object(
+        ev.TossReadClient, "from_settings", side_effect=AssertionError("newed a client")
+    ):
+        evidence = await ev.TossEvidenceAdapter(client=injected).fetch_evidence(_Row())
+
+    assert evidence.verdict == "filled"
+    injected.get_order.assert_awaited_once_with("ord-9")
+    injected.aclose.assert_not_awaited()  # caller owns the shared client
+```
+  (The existing `test_adapter_fetches_single_order_detail` at the bottom of this file exercises the legacy `client=None` path — keep it; it must stay green.)
+
+- [ ] **Run it — fails.** `uv run pytest tests/mcp_server/tooling/test_toss_live_evidence.py -k injected -v`
+  Expected: `TypeError: TossEvidenceAdapter() takes no arguments` (no `__init__` yet).
+
+- [ ] **Minimal impl — inject the client.** Replace `TossEvidenceAdapter` (`toss_live_evidence.py:155-162`) with:
+```python
+class TossEvidenceAdapter:
+    def __init__(self, client: TossReadClient | None = None) -> None:
+        # An injected client is caller-owned (shared across the reconcile run) and
+        # must NOT be closed here. Only a self-newed client (client=None, legacy
+        # path) is closed in fetch_evidence. ROB-687: sharing one client removes
+        # the per-row /accounts N+1.
+        self._client = client
+
+    async def fetch_evidence(self, row: Any) -> TossFillEvidence:
+        if self._client is not None:
+            order = await self._client.get_order(str(row.broker_order_id))
+            return classify_toss_order_evidence(order)
+        client = TossReadClient.from_settings()
+        try:
+            order = await client.get_order(str(row.broker_order_id))
+            return classify_toss_order_evidence(order)
+        finally:
+            await client.aclose()
+```
+
+- [ ] **Run it — passes.** `uv run pytest tests/mcp_server/tooling/test_toss_live_evidence.py -v` → all pass (new injected test + legacy `test_adapter_fetches_single_order_detail`).
+
+- [ ] **Lint.** `make lint`
+
+- [ ] **Commit.** `git add -A && git commit -m "refactor(ROB-687): TossEvidenceAdapter accepts a caller-owned shared client"`
+
+---
+
+## Task 3 — One shared `TossReadClient` per reconcile run; account-seq resolved once (Fix 1 + Fix 2, migration-0)
+
+Construct exactly one `TossReadClient` at the start of the run, hand it to `TossBatchEvidenceSource.build(..., client=shared)` (so `build` no longer news its own and `owns_client=False`), and thread it into the per-row fallback via `_reconcile_one_toss_row(..., fallback_client=shared)`. Because a single client instance caches `_account_seq` after the first resolution (`client.py:128-129,135`), `/accounts` is called at most once per run — even when batch build fails and every row falls back. The shared client is closed exactly once in `finally`.
+
+**Files:**
+- Modify `app/mcp_server/tooling/toss_live_ledger.py` — add `from app.services.brokers.toss import TossReadClient` to the imports (`:1-33`); construct the shared client (defensively) before the batch build (`:584`); pass `client=shared_client` to `TossBatchEvidenceSource.build` (`:587-589`); add `fallback_client` to `_reconcile_one_toss_row` (`:214-219`) and use it in the fallback branch (`:228-231`); thread `fallback_client=shared_client` at the call site (`:602-604`); close the shared client in `finally` (`:610-612`).
+  > **Line anchors are for the pre-Task-1 file.** Task 1 already edited this same region (added `import sentry_sdk`, a `batch_build_error = None` init, an expanded `except` body, and a `"batch_build_error"` echo), so by the time Task 3 runs the `:584-612` region has drifted down a few lines. The `:214-231` / `:602-604` anchors (in `_reconcile_one_toss_row` and its call site) are unaffected by Task 1. Task 3 supplies a **full-region replacement** for `:584-612`, so locate the region by content (the `evidence_source = None` / `if rows:` batch-build block through the `finally: … aclose()`), not by absolute line number.
+- Test (create) `tests/mcp_server/tooling/test_toss_reconcile_account_seq.py`.
+- Test (modify) `tests/services/brokers/toss/test_client.py` — client-level regression locks for resolve-once + guard.
+
+**Interfaces:**
+- `_reconcile_one_toss_row(row, *, dry_run, evidence_source=None, fallback_client=None)` — the fallback branch becomes `TossEvidenceAdapter(client=fallback_client).fetch_evidence(row)`.
+- `toss_reconcile_orders_impl` builds `shared_client = TossReadClient.from_settings()` inside a `try/except` (degrade to `None` if Toss is disabled/misconfigured), passes it to `build(client=shared_client)` and each `_reconcile_one_toss_row(..., fallback_client=shared_client)`, and closes it once (`await shared_client.aclose()`) alongside `evidence_source.aclose()` (which now no-ops for a run-owned client, `owns_client=False`).
+- Consumes `TossBatchEvidenceSource.build(*, rows, symbol=None, client=None)` (`toss_live_evidence.py:206-213`) — the `client` kwarg + `owns_client` gate (`:214`, `:281-283`) already exist.
+
+Steps:
+
+- [ ] **Write failing test — the whole run uses ONE shared client (reused by batch build + per-row fallback) and closes it once.** Create `tests/mcp_server/tooling/test_toss_reconcile_account_seq.py`:
+```python
+from __future__ import annotations
+
+from decimal import Decimal
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import delete
+
+from app.models.review import TossLiveOrderLedger
+from app.services.brokers.toss.dto import TossOrder
+from app.services.toss_live_order_ledger_service import TossLiveOrderLedgerService
+
+pytestmark = [pytest.mark.unit, pytest.mark.asyncio]
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def _clean(db_session):
+    await db_session.execute(delete(TossLiveOrderLedger))
+    await db_session.commit()
+    yield
+
+
+@pytest.fixture(autouse=True)
+def _patch_session_factory(db_session):
+    from app.mcp_server.tooling import toss_live_ledger
+
+    mock_cm = AsyncMock()
+    mock_cm.__aenter__.return_value = db_session
+    mock_cm.__aexit__.return_value = None
+    with patch.object(
+        toss_live_ledger, "_order_session_factory", return_value=lambda: mock_cm
+    ):
+        yield
+
+
+async def _accepted(db_session, *, cid: str, oid: str):
+    return await TossLiveOrderLedgerService(db_session).record_send(
+        operation_kind="place", market="kr", symbol="034020", side="buy",
+        order_type="limit", time_in_force="DAY", quantity=Decimal("3"),
+        price=Decimal("85000"), order_amount=None, currency="KRW",
+        client_order_id=cid, broker_order_id=oid, original_order_id=None,
+        status="accepted", broker_status=None, response_code="0",
+        response_message=None, raw_response={}, thesis="t", strategy="s",
+    )
+
+
+def _pending_order(order_id: str) -> TossOrder:
+    return TossOrder(
+        order_id=order_id, symbol="034020", side="buy", order_type="limit",
+        time_in_force="DAY", status="PENDING", price=Decimal("85000"),
+        quantity=Decimal("3"), order_amount=None, currency="KRW",
+        ordered_at="2026-07-01T00:00:00Z", canceled_at=None,
+        execution={"filledQuantity": Decimal("0")},
+    )
+
+
+async def test_run_uses_one_shared_client_reused_by_batch_and_fallback(db_session):
+    from app.mcp_server.tooling import toss_live_ledger as mod
+
+    await _accepted(db_session, cid="c1", oid="o1")
+    await _accepted(db_session, cid="c2", oid="o2")
+
+    # A single fake client. list_orders raises so batch build fails and the run
+    # MUST fall back per-row AND reuse this exact client (never new one per row).
+    fake_client = SimpleNamespace(
+        list_orders=AsyncMock(side_effect=RuntimeError("force-build-fail")),
+        get_order=AsyncMock(side_effect=lambda oid: _pending_order(oid)),
+        aclose=AsyncMock(),
+    )
+    from_settings = MagicMock(return_value=fake_client)
+
+    with patch.object(mod.TossReadClient, "from_settings", from_settings):
+        out = await mod.toss_reconcile_orders_impl(dry_run=False)
+
+    assert from_settings.call_count == 1          # ONE client for the whole run
+    assert fake_client.get_order.await_count == 2  # both rows via the shared client
+    fake_client.aclose.assert_awaited_once()       # closed exactly once
+    assert out["counts"] == {"pending": 2}
+```
+
+- [ ] **Run it — fails.** `uv run pytest tests/mcp_server/tooling/test_toss_reconcile_account_seq.py -v`
+  Expected: `AttributeError: <module 'app.mcp_server.tooling.toss_live_ledger'> does not have the attribute 'TossReadClient'` (not imported / not constructed in the impl yet). Even after import, on the current impl `from_settings.call_count` would be 2 (one per fresh per-row adapter client) and `aclose` would not be the shared client — locking the N+1 regression.
+
+- [ ] **Minimal impl part A — `_reconcile_one_toss_row` accepts `fallback_client`.** In `app/mcp_server/tooling/toss_live_ledger.py` change the signature (`:214-219`) and the fallback branch (`:228-231`):
+```python
+async def _reconcile_one_toss_row(
+    row: TossLiveOrderLedger,
+    *,
+    dry_run: bool,
+    evidence_source: Any | None = None,
+    fallback_client: Any | None = None,
+) -> dict[str, Any]:
+    ...
+    if evidence_source is not None:
+        evidence = await evidence_source.evidence_for(row)
+    else:
+        evidence = await TossEvidenceAdapter(client=fallback_client).fetch_evidence(row)
+```
+
+- [ ] **Minimal impl part B — build one shared client, thread it, close it once.** Add the import near the other service imports (`:31`):
+```python
+from app.services.brokers.toss import TossReadClient
+```
+Rewrite the region `:584-612` so the shared client is built once, passed to `build`, threaded into the fallback, and closed once:
+```python
+    batch_build_error: dict[str, Any] | None = None
+
+    # ROB-687 — one TossReadClient for the whole run so account-seq is resolved at
+    # most once (per-instance cache; client.py:128-129,135) instead of once per
+    # fresh per-row client. The ACCOUNT group is 1 TPS (rate_limiter.py:27), so a
+    # per-row /accounts N+1 serializes into ~1s of sleep per open row. Defensive:
+    # if Toss is disabled/misconfigured, degrade exactly as before (per-row/batch
+    # construct their own; the per-row error handler classifies the failure).
+    shared_client: TossReadClient | None = None
+    if rows:
+        try:
+            shared_client = TossReadClient.from_settings()
+        except Exception as exc:  # noqa: BLE001 — degrade to legacy path
+            logger.warning(
+                "toss reconcile: shared client unavailable (%s); legacy per-row path",
+                exc,
+            )
+            shared_client = None
+
+    evidence_source = None
+    if rows:
+        try:
+            evidence_source = await TossBatchEvidenceSource.build(
+                rows=rows, symbol=symbol, client=shared_client
+            )
+        except Exception as exc:  # noqa: BLE001 — batch is an optimization
+            logger.exception(
+                "toss reconcile batch evidence build failed; per-row fallback"
+            )
+            sentry_sdk.capture_exception(exc)
+            batch_build_error = {"type": type(exc).__name__, "message": str(exc)}
+            evidence_source = None
+
+    try:
+        for row in rows:
+            try:
+                outcome = await _reconcile_one_toss_row(
+                    row,
+                    dry_run=dry_run,
+                    evidence_source=evidence_source,
+                    fallback_client=shared_client,
+                )
+            except Exception as exc:  # noqa: BLE001 — classified in the handler
+                outcome = await _handle_reconcile_row_error(row, exc, dry_run=dry_run)
+            reconciled.append(outcome)
+            verdict = str(outcome.get("verdict", "anomaly"))
+            counts[verdict] = counts.get(verdict, 0) + 1
+    finally:
+        if evidence_source is not None:
+            await evidence_source.aclose()  # no-op for a run-owned client
+        if shared_client is not None:
+            await shared_client.aclose()
+```
+  Notes: (1) `batch_build_error` initialization + echo were added in Task 1; keep the single initialization here and do not duplicate. (2) When `build` receives `client=shared_client` (not None), `TossBatchEvidenceSource.build` sets `owns_client=False` (`toss_live_evidence.py:214`), so `evidence_source.aclose()` no-ops and the run's `finally` owns the close. (3) When Toss is disabled, `shared_client` is `None`; `build(client=None)` internally news+owns its own client (legacy behavior), so nothing regresses.
+
+- [ ] **Run it — passes.** `uv run pytest tests/mcp_server/tooling/test_toss_reconcile_account_seq.py -v` → 1 passed.
+
+- [ ] **Write client-level regression locks — resolve-once + guard preserved.** Append to `tests/services/brokers/toss/test_client.py` (mirrors the existing `test_holdings_auto_resolves_single_account_header` MockTransport pattern; `_TokenManager` and `_json` helpers already exist there):
+```python
+@pytest.mark.asyncio
+async def test_account_seq_resolved_once_then_cached_across_calls() -> None:
+    accounts_hits = 0
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal accounts_hits
+        if request.url.path == "/api/v1/accounts":
+            accounts_hits += 1
+            return httpx.Response(
+                200,
+                json=_json([{"accountNo": "1", "accountSeq": 7, "accountType": "B"}]),
+                request=request,
+            )
+        # `/api/v1/orders/{id}` (single-order detail) is parsed by `parse_order`,
+        # which requires a FULL flat order row (orderId/symbol/side/orderType/
+        # timeInForce/status/quantity/currency/orderedAt). Returning the list shape
+        # `{"orders": []}` here would raise KeyError('orderId') inside parse_order
+        # (parse_order delegates to parse_orders([raw])) — so branch on the path and
+        # return a valid single-order body. The `/api/v1/orders` LIST path still
+        # returns the `{"orders": []}` page shape parse_orders expects.
+        if request.url.path.startswith("/api/v1/orders/"):
+            return httpx.Response(
+                200,
+                json=_json(
+                    {
+                        "orderId": "ord-1",
+                        "symbol": "034020",
+                        "side": "BUY",
+                        "orderType": "LIMIT",
+                        "timeInForce": "DAY",
+                        "status": "PENDING",
+                        "quantity": "3",
+                        "currency": "KRW",
+                        "orderedAt": "2026-07-01T00:00:00Z",
+                    }
+                ),
+                request=request,
+            )
+        return httpx.Response(200, json=_json({"orders": []}), request=request)
+
+    # account_seq=None → resolution goes through /accounts; the instance caches it.
+    client = TossReadClient(
+        token_manager=_TokenManager(),
+        account_seq=None,
+        transport=httpx.MockTransport(handler),
+    )
+    try:
+        await client.list_orders(status="OPEN")
+        await client.list_orders(status="CLOSED")
+        await client.get_order("ord-1")
+    finally:
+        await client.aclose()
+
+    assert accounts_hits == 1  # ROB-687: one /accounts for the whole client lifetime
+
+
+@pytest.mark.asyncio
+async def test_account_seq_guard_rejects_multiple_accounts() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/v1/accounts":
+            return httpx.Response(
+                200,
+                json=_json(
+                    [
+                        {"accountNo": "1", "accountSeq": 7, "accountType": "B"},
+                        {"accountNo": "2", "accountSeq": 8, "accountType": "B"},
+                    ]
+                ),
+                request=request,
+            )
+        return httpx.Response(200, json=_json({"orders": []}), request=request)
+
+    client = TossReadClient(
+        token_manager=_TokenManager(),
+        account_seq=None,
+        transport=httpx.MockTransport(handler),
+    )
+    try:
+        with pytest.raises(ValueError, match="exactly one account"):
+            await client.list_orders(status="OPEN")
+    finally:
+        await client.aclose()
+```
+  (These lock the guard/cache the runtime-resolution decision depends on. They pass on the current `client.py` — that is intentional: they guarantee no future refactor silently drops the guard or re-introduces per-call resolution.)
+
+- [ ] **Run it — passes.** `uv run pytest tests/services/brokers/toss/test_client.py -k "account_seq" -v` → 2 passed.
+
+- [ ] **Regression — full ledger + evidence + batch suites unchanged.** `uv run pytest tests/mcp_server/tooling/test_toss_live_ledger.py tests/mcp_server/tooling/test_toss_live_evidence.py tests/mcp_server/tooling/test_toss_batch_evidence_source.py tests/mcp_server/tooling/test_toss_reconcile_resilience.py -v`
+  Expected: all pass. In particular `test_impl_uses_batch_source_and_echoes_window` (from_settings NOT patched → `shared_client` degrades to `None` via `TossApiDisabled`; `build` is mocked → `fake_source`; `fake_source.aclose` awaited once; `shared_client` is `None` so not closed) and `test_impl_batch_build_failure_falls_back_per_row` (`mod.TossEvidenceAdapter` patched to a `MagicMock`, invoked with `client=...`, returns `_Adapter()`) stay green.
+
+- [ ] **Lint.** `make lint`
+
+- [ ] **Commit.** `git add -A && git commit -m "perf(ROB-687): share one TossReadClient per reconcile run, kill /accounts N+1"`
+
+---
+
+## Task 4 — Diagnose + fix the real `TossBatchEvidenceSource.build` failure (Fix 3b, migration-0)
+
+> **CLOSED — NO REPRO (Step B live diagnosis, 2026-07-04):** The premise that
+> `TossBatchEvidenceSource.build` fails every run was an **incorrect inference from
+> stale Sentry data**. A read-only live probe (GET-only: `/accounts`, `/orders`
+> OPEN/CLOSED, `build()`) against the prod Toss env confirmed `build()` **succeeds**
+> — both an empty-window build and a realistic 60-day window that paginated
+> multiple CLOSED pages into 276 orders (no cap, no exception; OAuth OK, exactly 1
+> account so the guard passes). Timeline evidence is decisive: all 7 Sentry
+> `toss_reconcile_orders` runs (the source of the `187 /accounts`) occurred
+> 2026-06-30 → 2026-07-03 00:20 KST — **before ROB-669 even existed** (its commit
+> is 2026-07-03 20:08 KST; deployed to production ~2026-07-04 06:30 KST). So the
+> N+1 was the **pre-ROB-669 per-row code**, which ROB-669's batch source already
+> fixes. There is no `build` failure to diagnose. Task 4 is dropped.
+
+**Re-scoped outcome:** Tasks 1–3 (this PR) are retained as **observability +
+defense-in-depth**, not as the fix for an active bug:
+- Task 1 (observability) is the lasting value — if `build` ever *does* fail in the
+  future (transient/network/disabled), it is now surfaced (`logger.exception` +
+  `sentry_sdk.capture_exception` + `batch_build_error` echo) instead of silently
+  reverting to the per-row `/accounts` N+1.
+- Tasks 2–3 (one shared client threaded into the per-row fallback) ensure that even
+  in that degraded path the `/accounts` call happens at most once, not per row.
+
+The active N+1 the ticket was opened for is already resolved by ROB-669 (deployed).
+The next real post-deploy `toss_reconcile_orders` run should show ≤1 `/accounts`;
+there have been no runs since deploy, so this is confirmed by the live `build()`
+probe rather than by a fresh Sentry sample.
+
+**Files:**
+- Modify `app/mcp_server/tooling/toss_live_evidence.py` and/or `app/services/brokers/toss/client.py` / `dto.py` — the fix, scoped to whatever the diagnosis names. (Anticipated to be a small, read-path-only change; migration-0.)
+- Test (modify) `tests/mcp_server/tooling/test_toss_batch_evidence_source.py` — a regression test reproducing the diagnosed failure with a fake client.
+- Modify `docs/runbooks/toss-live-order-reconcile.md` — record the root cause + the shared-client/account-seq behavior + how to read `batch_build_error`.
+
+**Diagnosis procedure (do this BEFORE writing any fix):**
+
+- [ ] **Reproduce and capture the real exception.** Obtain the actual `TossBatchEvidenceSource.build` exception from ONE of (in order of preference):
+  1. The Sentry issue newly produced by Task 1's `sentry_sdk.capture_exception` (the WARN→exception upgrade means the stack + type now land in Sentry) — read the top frame + exception type/message.
+  2. A `batch_build_error` echo from a real `toss_reconcile_orders` call in a non-prod/staging run (`docs/runbooks/toss-live-order-reconcile.md`) or via `scripts/toss_live_smoke.py` (`toss_live_smoke` imports `toss_reconcile_orders_impl` and already has `_has_reconcile_anomaly` handling) with `TOSS_API_ENABLED=true`.
+  Record the exact exception type, message, and the offending call (which `list_orders`/parse step) in the PR description and the runbook. **Do not proceed to the fix until the exception is named.**
+
+- [ ] **Confirm which hypothesis holds (verify, do not assume).** Candidate causes to check against the captured exception — treat each as a hypothesis to confirm or reject, not a conclusion:
+  - **H1 — `list_orders(status="OPEN")` request rejected.** Toss may reject `status=OPEN` (casing/param) or the `symbol=None` omission for the OPEN listing; a 4xx/`TossApiResponseError` here would abort `build` at `toss_live_evidence.py:229`.
+  - **H2 — `parse_orders` field mismatch.** The list-endpoint row shape may differ from the single-order shape `parse_order` handles (e.g. execution nesting, missing `orderId`), so `parse_orders` raises even though per-row `get_order`/`parse_order` succeeds — which precisely matches the Sentry evidence (per-row `get_order` works, batch list does not).
+  - **H3 — CLOSED window params.** `from`/`to` date format from `_kst_date_str` (`toss_live_evidence.py:224-225`) or the `limit=100` param may be rejected by `GET /orders?status=CLOSED` (422).
+  - **H4 — account guard `!= 1`.** UNLIKELY (Sentry shows per-row `get_order` succeeding, so `/accounts` returns exactly one) — but confirm it is not intermittent multi-account.
+  - Note: `trade_date` is a tz-aware `TIMESTAMP` (`app/models/review.py:529-531`), so `_kst_date_str`'s `.astimezone` is safe — H "naive-date" is already ruled out.
+
+**Steps (after the cause is named — example shown for the most-likely H2; adapt to the confirmed cause):**
+
+- [ ] **Write failing regression test reproducing the diagnosed failure.** Append to `tests/mcp_server/tooling/test_toss_batch_evidence_source.py` a test that drives `TossBatchEvidenceSource.build` with a fake client returning the real failing shape/error, asserting build currently raises (or drops the row) the way production does. Example skeleton (fill in with the confirmed cause):
+```python
+async def test_build_handles_real_open_list_shape():
+    # Reproduce the diagnosed root cause (e.g. the OPEN list row shape that made
+    # parse_orders raise / the OPEN status param Toss rejected). Assert build now
+    # succeeds and maps the row instead of raising.
+    ...
+```
+
+- [ ] **Run it — fails.** `uv run pytest tests/mcp_server/tooling/test_toss_batch_evidence_source.py -k real -v` → reproduces the production failure.
+
+- [ ] **Minimal impl — fix the named root cause only.** Apply the smallest read-path change that makes `build` succeed for the real Toss response (e.g. correct the OPEN `status` value/param, make `parse_orders` tolerate the list row shape, or fix the CLOSED window param). Keep `classify_toss_order_evidence`, the CLOSED windowing/cap, and all booking unchanged. No broker mutation, migration-0.
+
+- [ ] **Run it — passes.** `uv run pytest tests/mcp_server/tooling/test_toss_batch_evidence_source.py -v` → all pass.
+
+- [ ] **Runbook — document the diagnosis + behavior.** In `docs/runbooks/toss-live-order-reconcile.md`, add a short section: the named root cause and its fix; that a healthy run now issues ONE `/accounts` (0 if `toss_api_account_seq` is set) and 2–4 `list_orders`; that a non-`None` `batch_build_error` in the tool output means the run silently fell back to per-row fetches (investigate the echoed type/message + the Sentry issue); and the explicit note that `toss_api_account_seq` is NOT hardcoded so the `_resolve_account_seq` "exactly one account" guard stays active — if an operator sets it, the value must match the single account.
+
+- [ ] **Regression — batch source + full toss reconcile path.** `uv run pytest tests/mcp_server/tooling/test_toss_batch_evidence_source.py tests/mcp_server/tooling/test_toss_reconcile_account_seq.py tests/mcp_server/tooling/test_toss_reconcile_resilience.py tests/mcp_server/tooling/test_toss_live_ledger.py -v` → all pass.
+
+- [ ] **Lint.** `make lint`
+
+- [ ] **Commit.** `git add -A && git commit -m "fix(ROB-687): fix diagnosed TossBatchEvidenceSource.build failure + runbook"`
+
+---
+
+## Verification checklist (whole plan)
+
+- [ ] `uv run pytest tests/mcp_server/tooling/test_toss_reconcile_account_seq.py tests/mcp_server/tooling/test_toss_reconcile_resilience.py tests/mcp_server/tooling/test_toss_live_evidence.py tests/mcp_server/tooling/test_toss_batch_evidence_source.py tests/mcp_server/tooling/test_toss_live_ledger.py tests/services/brokers/toss/test_client.py -v` → all green.
+- [ ] `make lint` clean.
+- [ ] Manual reasoning check: a healthy run issues **one** `GET /api/v1/accounts` (0 with `toss_api_account_seq` set) and **2–4** `list_orders`; a batch-build failure now emits a Sentry event + `batch_build_error` echo AND still resolves account-seq once (shared client), so even the degraded path is ≤1 `/accounts` — down from ~27.
+- [ ] No migration, no broker mutation, no MCP tool signature change, no config hardcoding; `_resolve_account_seq` guard intact.

--- a/docs/plans/ROB-688-sector-peers-bounded-fanout.md
+++ b/docs/plans/ROB-688-sector-peers-bounded-fanout.md
@@ -1,0 +1,795 @@
+# get_sector_peers — Bound the Naver Fanout (Semaphore) + Short-TTL Cache + Trim Over-fetch Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (- [ ]) syntax.
+
+**Goal:** Make the KR (`market="kr"`) path of `get_sector_peers` stop amplifying one MCP tool call into a ~29-request concurrent burst against `m.stock.naver.com` that trips Naver's server-side throttling and stalls individual calls out to the 10s httpx timeout (Sentry 7d: p95 = 11.5s, 24 calls > 9s, sum 1.40M ms). Four surgical, independently-testable fixes in `app/services/naver_finance/valuation.py::fetch_sector_peers`: (1) **[load-bearing]** bound the peer fanout with an `asyncio.Semaphore` so the same calls run at ~676ms unthrottled instead of colliding into timeout stragglers; (2) add a peer-only, per-request short timeout for fast-fail on a stuck peer without breaking the currently-succeeding ~10s target fetch; (3) trim the over-fetch so the `limit + 5` padding is only paid when the integration endpoint returned fewer than `limit` peers; (4) add a short-TTL, fail-open Redis cache (cache-aside, keyed by stock code for the `/basic`+`/integration` bundle and by industry code for the sector page) for the recurring-symbol hits observed in Sentry. Read-only advisory path, migration-0.
+
+**Architecture:** Today `fetch_sector_peers(code, limit=5)` (`app/services/naver_finance/valuation.py:356`) opens one shared `httpx.AsyncClient(timeout=10)` (`:380`), does a bare `await _fetch_integration(code, client)` for the target (`:384`, NOT wrapped in `_safe_fetch`), fetches the sector page once (`_fetch_sector_soup`, `:396-397`), pads the peer-code list to `peer_codes[: limit + 5]` unconditionally (`:409`), and then fires **all** peer fetches through an unbounded `asyncio.gather(*[_safe_fetch(pc) ...])` (`:417`) — each `_safe_fetch` (`:411`) calls `_fetch_integration` which itself is 2 requests (`/basic` + `/integration`, `asyncio.gather` at `:316`). With `limit=5` that is `(limit+5) × 2 = 20` peer requests + 2 target + 1 sector ≈ 23–29 simultaneous connections; Naver throttles the burst and tail calls stall to the 10s client timeout. There is no cache, so recurring symbols (Sentry: `006400`/`450080`/`247540`/`043260` each 2×/7d) re-pay the full burst every call.
+
+After the fix, `fetch_sector_peers` (a) acquires a per-call `asyncio.Semaphore(settings.naver_peer_fetch_concurrency)` inside `_safe_fetch` so at most N peer fetches (~5) are in flight — the burst that trips throttling never forms; (b) passes a short `request_timeout` (`settings.naver_peer_fetch_timeout_seconds`, ~5s) into `_fetch_integration` for peers only, while the target keeps the client-level 10s (its bare await at `:384` is unchanged and still succeeds); (c) only appends sector-scraped extras and pads to `limit + 5` when the integration endpoint returned `< limit` peers — otherwise it caps to `limit`, cutting peer requests roughly in half on the common path; and (d) routes every `_fetch_integration` call through a fail-open cache-aside wrapper (`app/services/naver_finance/peer_cache.py`) so a cache hit within the short TTL skips the network entirely. The sector page fetch (`:396-397`) stays exactly once per call and remains the sole source of the output `sector` **name**.
+
+**Tech Stack:** Python 3.13, uv, pytest (markers `unit`/`asyncio`), httpx `AsyncClient` (per-request `timeout=` override), `asyncio.Semaphore`, `redis.asyncio` (fail-open cache-aside mirroring `app/core/analyze_cache.py`), pydantic-settings (`app/core/config.Settings`), BeautifulSoup4/lxml (Naver scrape), FastMCP tool surface (`get_sector_peers`).
+
+## Global Constraints
+
+Copied verbatim; every task implicitly includes these.
+
+- **KEEP the sector-name scrape:** sise_group_detail.naver (sector soup) is the ONLY source of the output "sector" NAME (integration returns only industry_code). Do NOT "skip the sector scrape when integration peers >= limit" — that nulls the sector field on the common path. It is dual-purpose (extra peers AND sector name).
+- **Fix (4): the timeout must be a PEER-ONLY / per-request timeout.** The target fetch (valuation.py:~384) is a bare await NOT wrapped in _safe_fetch and shares the client; lowering the global client timeout would make a currently-succeeding ~10s target fast-fail into a whole-tool error.
+- **Read-only advisory (no broker/order/watch mutation).** Caching only makes current_price/change_pct up to TTL stale (acceptable for a sector-comparison tool).
+- **migration-0.** No new DB column, table, or alembic revision. The only additive persistence is Redis (ephemeral, TTL'd). New config fields on `app/core/config.Settings` are runtime-tunable knobs, not schema.
+- **Fail-open everywhere.** The Semaphore, the short peer timeout, the trim, and the cache must each degrade to *at worst* today's behavior: a peer fetch failure already returns `None` from `_safe_fetch` and is dropped from the peer list; a cache/Redis outage must fall through to the live fetch and never raise; a peer-timeout must not surface as a whole-tool error.
+- Run tests: `uv run pytest <path> -v`. Lint: `make lint`. Do NOT commit unless the executing skill says so; each task lists its own commit message.
+
+---
+
+## Approach / decision note
+
+- **Cache = Redis short-TTL cache-aside, NOT a persisted-snapshot precompute.** Lower risk and satisfies migration-0: it reuses the exact fail-open pattern already shipped in `app/core/analyze_cache.py` (lazy module-level client, settings gate, `_normalize_cache_envelope`, best-effort GET/SET that never raise). No new table, no scheduler/TaskIQ, no cutover. A cache/Redis outage transparently degrades to today's direct fetch. Precompute would need a table + a refresh job + a migration — rejected.
+- **Knobs live on `Settings` (runtime resolution), not module constants.** `naver_peer_fetch_concurrency` (default `5`), `naver_peer_fetch_timeout_seconds` (default `5.0`), `naver_peer_cache_enabled` (default `True`), `naver_peer_cache_ttl_seconds` (default `600` = 10 min intraday). Operators tune without a code change; tests monkeypatch `settings`. `naver_peer_cache_enabled` is force-disabled in `tests/conftest.py` (same hermetic guard as `ANALYZE_FETCH_CACHE_ENABLED`) so no test can touch a real Redis.
+- **The Semaphore is created per-call inside `fetch_sector_peers`, not as a module-level singleton.** A module-level `asyncio.Semaphore` binds to the event loop that constructed it; pytest-asyncio (and the MCP server's task lifecycle) use fresh loops, so a singleton would raise "bound to a different event loop". A fresh `asyncio.Semaphore(n)` per call is the standard safe pattern and is trivially test-isolated.
+- **Concurrency default 5** (finding suggested 4–6): comfortably below Naver's throttle threshold while keeping the common `limit=5` (~10–12 peer requests after trim) to ~2–3 sequential waves.
+
+---
+
+## File Structure
+
+| File | Create/Modify | Responsibility (which Task) |
+|------|---------------|------------------------------|
+| `app/core/config.py` | Modify | Task 1 — `naver_peer_fetch_concurrency`. Task 2 — `naver_peer_fetch_timeout_seconds`. Task 4 — `naver_peer_cache_enabled` + `naver_peer_cache_ttl_seconds`. |
+| `app/services/naver_finance/valuation.py` | Modify | Task 1 — per-call `Semaphore` around `_safe_fetch`. Task 2 — `request_timeout` param on `_fetch_integration`; peers pass short timeout, target keeps client default. Task 3 — trim `limit + 5` padding to only fire when integration peers `< limit`. Task 4 — route target + peer fetches through `_fetch_integration_cached`; cache the sector-page derivation. |
+| `app/services/naver_finance/peer_cache.py` | Create | Task 4 — fail-open Redis cache-aside helpers (`_get_redis_client`, `get_cached_integration`/`set_cached_integration`, `get_cached_sector`/`set_cached_sector`) mirroring `app/core/analyze_cache.py`. |
+| `app/services/naver_finance/__init__.py` | Modify | Task 4 — re-export the new `peer_cache` helpers (optional, only if tests import via the package façade). |
+| `tests/conftest.py` | Modify | Task 4 — force `NAVER_PEER_CACHE_ENABLED=false` in `_ensure_test_env` (hermetic guard). |
+| `tests/test_naver_finance.py` | Modify | Task 1/2/3 — append new test classes mirroring `TestFetchSectorPeers` (`:1505`). |
+| `tests/test_naver_peer_cache.py` | Create | Task 4 — cache-aside unit tests (hit/miss/fail-open/TTL/disabled). |
+
+> **NOT touched:** `app/mcp_server/tooling/fundamentals/_sector_peers.py` (the `handle_get_sector_peers` dispatcher, `:32`) and `app/mcp_server/tooling/fundamentals_sources_naver.py::_fetch_sector_peers_naver` (`:134`) keep their signatures and behavior — the KR entry still calls `naver_finance.fetch_sector_peers(symbol, limit=limit)` (`:137`). **All fanout call sites funnel through this single `fetch_sector_peers`, so fixing it covers every caller — no other wiring needs to change.** Note the effective `limit` is often larger than the `5` this plan uses in examples: `handle_get_sector_peers` caps at `20` (`_sector_peers.py:44` `min(max(limit, 1), 20)`), and the analyze/fundamentals flows call `_fetch_sector_peers_naver(symbol, limit=10)` (`app/analysis/stages/fundamentals_stage.py:22`, `app/mcp_server/tooling/analysis_analyze.py:482`) — those `limit=10`/`20` paths are where the largest bursts (and the biggest wins) occur. Every fix here (Semaphore, peer timeout, trim, cache) is limit-agnostic. The US path (`_fetch_sector_peers_us`) and crypto rejection are out of scope. `_parse_peer_comparison`, `_parse_industry_info`, `_parse_sector_name`, `_parse_sector_stock_codes`, and `fetch_valuation`'s own `_fetch_integration` overlay (`:264-273`) are behavior-unchanged. This plan deliberately confines the fix to `fetch_sector_peers` + one new cache module + config knobs to avoid collision with any concurrent fundamentals work.
+
+---
+
+## Task 1 — Bound the peer fanout with an `asyncio.Semaphore` (load-bearing, migration-0)
+
+**Files:**
+- Modify `app/core/config.py:315` (add `naver_peer_fetch_concurrency` near the other cache/knob fields around `:299-315`).
+- Modify `app/services/naver_finance/valuation.py:411` (`_safe_fetch`) and `:417` (unbounded `asyncio.gather`) inside `fetch_sector_peers`.
+- Test (modify) `tests/test_naver_finance.py` — append `TestFetchSectorPeersConcurrency` after `TestFetchSectorPeers` (`:1505`).
+
+**Interfaces:**
+- Consumes `settings.naver_peer_fetch_concurrency: int` (new, default `5`).
+- Produces: `fetch_sector_peers(code, limit=5)` signature UNCHANGED. Internally, `_safe_fetch(pc)` acquires a per-call `asyncio.Semaphore(max(1, settings.naver_peer_fetch_concurrency))` created once per `fetch_sector_peers` invocation before awaiting `_fetch_integration`.
+
+Steps:
+
+- [ ] **Write failing test — peak in-flight peer fetches never exceeds the configured cap.** Append to `tests/test_naver_finance.py`:
+```python
+@pytest.mark.asyncio
+@pytest.mark.unit
+class TestFetchSectorPeersConcurrency:
+    async def test_peer_fanout_is_bounded_by_semaphore(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from app.core.config import settings
+
+        monkeypatch.setattr(settings, "naver_peer_fetch_concurrency", 3)
+
+        # Target returns 8 integration peers so, pre-trim, 8 peer fetches queue.
+        peers_raw = [{"itemCode": f"00000{i}"} for i in range(1, 9)]
+
+        in_flight = 0
+        peak = 0
+
+        async def fake_fetch_integration(
+            code: str, _client: Any, *args: Any, **kwargs: Any
+        ) -> dict[str, Any]:
+            nonlocal in_flight, peak
+            if code == "000100":  # target
+                return {
+                    "symbol": code, "name": "Target", "per": 10, "pbr": 1.1,
+                    "market_cap": 1000, "current_price": 50000, "change_pct": 1.0,
+                    "industry_code": "123", "peers_raw": peers_raw,
+                }
+            in_flight += 1
+            peak = max(peak, in_flight)
+            await asyncio.sleep(0.01)  # hold the slot so overlap is observable
+            in_flight -= 1
+            return {
+                "symbol": code, "name": "Peer", "per": 11, "pbr": 1.2,
+                "market_cap": 900, "current_price": 40000, "change_pct": 0.5,
+                "industry_code": "123", "peers_raw": [],
+            }
+
+        class FakeResponse:
+            content = b"<html><head><title>x : Npay</title></head></html>"
+
+        class FakeClient:
+            async def __aenter__(self) -> "FakeClient":
+                return self
+
+            async def __aexit__(self, *_a: Any) -> None:
+                return None
+
+            async def get(self, url: str, params: Any = None) -> FakeResponse:
+                return FakeResponse()
+
+        import httpx
+
+        monkeypatch.setattr(httpx, "AsyncClient", lambda **_k: FakeClient())
+        monkeypatch.setattr(
+            naver_finance.valuation, "_fetch_integration", fake_fetch_integration
+        )
+
+        result = await naver_finance.fetch_sector_peers("000100", limit=8)
+
+        assert peak <= 3, f"peak in-flight {peak} exceeded semaphore cap 3"
+        assert len(result["peers"]) == 8
+```
+  (Note: `import asyncio` is already at the top of `valuation.py` (`:5`); the test module (`tests/test_naver_finance.py`) does **not** currently import `asyncio` at the top, and the fake above uses `await asyncio.sleep(0.01)` — so add a top-level `import asyncio` to the test module header. `Any` is already imported at the test module top.)
+
+- [ ] **Run it — fails.** `uv run pytest tests/test_naver_finance.py -k Concurrency -v`
+  Expected: `peak` reaches 8 (unbounded `asyncio.gather` at `:417` runs all peer fetches concurrently) → `assert peak <= 3` FAILS.
+
+- [ ] **Add the setting.** In `app/core/config.py`, near the other knob fields (after `:315` `analyze_fetch_cache_enabled`), add:
+```python
+    # ROB-688: bound the get_sector_peers KR peer fanout so the concurrent burst
+    # to m.stock.naver.com stops tripping Naver server-side throttling.
+    naver_peer_fetch_concurrency: int = 5
+```
+
+- [ ] **Minimal impl — wrap `_safe_fetch` in a per-call Semaphore.** In `app/services/naver_finance/valuation.py`, inside `fetch_sector_peers`, replace the `_safe_fetch` definition (`:411-415`) and its use (`:417`):
+```python
+        # ---- Fetch integration data for each peer concurrently (bounded) ----
+        peer_codes = peer_codes[: limit + 5]  # (Task 3 makes this conditional)
+
+        semaphore = asyncio.Semaphore(max(1, settings.naver_peer_fetch_concurrency))
+
+        async def _safe_fetch(pc: str) -> dict[str, Any] | None:
+            async with semaphore:
+                try:
+                    return await _fetch_integration(pc, client)
+                except Exception:
+                    return None
+
+        peer_results = await asyncio.gather(*[_safe_fetch(pc) for pc in peer_codes])
+```
+  Add `from app.core.config import settings` to the imports at the top of `valuation.py` (verify it is not already imported).
+
+- [ ] **Run it — passes.** `uv run pytest tests/test_naver_finance.py -k Concurrency -v` → passes (`peak <= 3`).
+
+- [ ] **Regression — existing sector-peers test still green.** `uv run pytest tests/test_naver_finance.py -k "SectorPeers or FetchValuation" -v` → all pass (the existing `test_fetches_sector_page_once_for_codes_and_name` at `:1506` still asserts `len(sector_gets) == 1` and `peers[0]["symbol"] == "000002"`; the Semaphore does not change call counts).
+
+- [ ] **Lint.** `make lint`.
+
+- [ ] **Commit.** `git add -A && git commit -m "perf(ROB-688): bound get_sector_peers KR peer fanout with asyncio.Semaphore (load-bearing)"`
+
+---
+
+## Task 2 — Peer-only per-request short timeout (fast-fail, migration-0)
+
+**Files:**
+- Modify `app/core/config.py` (add `naver_peer_fetch_timeout_seconds` beside the Task 1 field).
+- Modify `app/services/naver_finance/valuation.py:307-319` (`_fetch_integration` — add `request_timeout` param, apply to both `client.get`s) and the peer call site inside `fetch_sector_peers` (`_safe_fetch`, from Task 1). The target call at `:384` is LEFT with no `request_timeout` (keeps the client-level 10s).
+- Test (modify) `tests/test_naver_finance.py` — append `TestFetchSectorPeersPeerTimeout`.
+
+**Interfaces:**
+- Consumes `settings.naver_peer_fetch_timeout_seconds: float` (new, default `5.0`).
+- Produces `_fetch_integration(code, client, request_timeout: float | None = None)` — when `request_timeout` is not None it is passed as `client.get(url, timeout=request_timeout)` to each of the `/basic` and `/integration` requests; when None the client-level default (10s) applies. **Backward-compatible:** the existing 2-arg call `_fetch_integration(code, client)` (used by `fetch_valuation` at `:266` and by the target fetch at `:384`) is unchanged.
+
+Steps:
+
+- [ ] **Write failing test — peers get the short per-request timeout, target keeps the client default.** Append to `tests/test_naver_finance.py`:
+```python
+@pytest.mark.asyncio
+@pytest.mark.unit
+class TestFetchSectorPeersPeerTimeout:
+    async def test_peers_use_short_request_timeout_target_uses_default(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from app.core.config import settings
+
+        monkeypatch.setattr(settings, "naver_peer_fetch_timeout_seconds", 5.0)
+        monkeypatch.setattr(settings, "naver_peer_fetch_concurrency", 5)
+
+        # Record the request_timeout each _fetch_integration call receives.
+        seen: dict[str, float | None] = {}
+
+        async def fake_fetch_integration(
+            code: str, _client: Any, request_timeout: float | None = None
+        ) -> dict[str, Any]:
+            seen[code] = request_timeout
+            base = {
+                "symbol": code, "name": code, "per": 10, "pbr": 1.0,
+                "market_cap": 100, "current_price": 1, "change_pct": 0.0,
+                "industry_code": "123", "peers_raw": [],
+            }
+            if code == "000100":
+                base["peers_raw"] = [{"itemCode": "000200"}]
+            return base
+
+        class FakeResponse:
+            content = b"<html><head><title>x : Npay</title></head></html>"
+
+        class FakeClient:
+            async def __aenter__(self) -> "FakeClient":
+                return self
+
+            async def __aexit__(self, *_a: Any) -> None:
+                return None
+
+            async def get(self, url: str, params: Any = None) -> FakeResponse:
+                return FakeResponse()
+
+        import httpx
+
+        monkeypatch.setattr(httpx, "AsyncClient", lambda **_k: FakeClient())
+        monkeypatch.setattr(
+            naver_finance.valuation, "_fetch_integration", fake_fetch_integration
+        )
+
+        await naver_finance.fetch_sector_peers("000100", limit=1)
+
+        assert seen["000100"] is None, "target must keep the client-level 10s timeout"
+        assert seen["000200"] == 5.0, "peer must use the short per-request timeout"
+```
+
+- [ ] **Run it — fails.** `uv run pytest tests/test_naver_finance.py -k PeerTimeout -v`
+  Expected: `seen["000200"]` is `None` (peers currently call `_fetch_integration(pc, client)` with no `request_timeout`) → `assert seen["000200"] == 5.0` FAILS. (The `fake_fetch_integration` already declares the param, so the earlier tasks' fakes stay compatible.)
+
+- [ ] **Add the setting.** In `app/core/config.py`, beside the Task 1 field:
+```python
+    naver_peer_fetch_timeout_seconds: float = 5.0
+```
+
+- [ ] **Minimal impl part A — `_fetch_integration` accepts `request_timeout`.** In `app/services/naver_finance/valuation.py`, change the signature (`:307-310`) and the two-request gather (`:316-319`):
+```python
+async def _fetch_integration(
+    code: str,
+    client: httpx.AsyncClient,
+    request_timeout: float | None = None,
+) -> dict[str, Any]:
+    ...
+    get_kwargs: dict[str, Any] = {}
+    if request_timeout is not None:
+        get_kwargs["timeout"] = request_timeout
+    r_basic, r_integ = await asyncio.gather(
+        client.get(f"{NAVER_MOBILE_API}/{code}/basic", **get_kwargs),
+        client.get(f"{NAVER_MOBILE_API}/{code}/integration", **get_kwargs),
+    )
+```
+  (httpx `AsyncClient.get` accepts a per-request `timeout=` that overrides the client-level timeout for that request only.)
+
+- [ ] **Minimal impl part B — peers pass the short timeout; target does not.** In `fetch_sector_peers`, update `_safe_fetch` (from Task 1) so the peer fetch passes the configured peer timeout:
+```python
+        async def _safe_fetch(pc: str) -> dict[str, Any] | None:
+            async with semaphore:
+                try:
+                    return await _fetch_integration(
+                        pc,
+                        client,
+                        request_timeout=settings.naver_peer_fetch_timeout_seconds,
+                    )
+                except Exception:
+                    return None
+```
+  Leave the target fetch at `:384` as `target = await _fetch_integration(code, client)` — no `request_timeout`, so it keeps the client-level 10s (constraint: the bare-await target must not fast-fail).
+
+- [ ] **Update the EXISTING sector-peers test fake to accept `request_timeout` (REQUIRED — this is a real regression, not a no-op).** The existing `TestFetchSectorPeers::test_fetches_sector_page_once_for_codes_and_name` (`tests/test_naver_finance.py:1542-1545`) monkeypatches `_fetch_integration` with a **2-arg** fake `async def fake_fetch_integration(code, _client)`. After part B the peer path calls `_fetch_integration(pc, client, request_timeout=...)`, so that fake raises `TypeError: unexpected keyword argument 'request_timeout'`; `_safe_fetch` swallows it → peer `000002` is dropped → `result["peers"][0]` raises `IndexError` and the test FAILS. (After Task 4 the *target* also routes through `_fetch_integration_cached(..., request_timeout=None)`, so the same 2-arg fake breaks the un-wrapped target call → whole-tool error.) Widen its signature — behavior otherwise unchanged:
+```python
+        async def fake_fetch_integration(
+            code: str,
+            _client: Any,
+            request_timeout: float | None = None,
+        ) -> dict[str, Any]:
+```
+  (Note: the `TestFetchValuation` fakes at `:1307/:1324/:1353` are also 2-arg but are SAFE — `fetch_valuation` is unchanged and still calls `_fetch_integration(code, client)` with two *positional* args, never the `request_timeout` keyword — so leave them as-is.)
+
+- [ ] **Run it — passes.** `uv run pytest tests/test_naver_finance.py -k "PeerTimeout or SectorPeers" -v` → passes (the widened existing fake keeps `test_fetches_sector_page_once_for_codes_and_name` green).
+
+- [ ] **Regression — `_fetch_integration` callers unchanged.** `uv run pytest tests/test_naver_finance.py -k "FetchValuation or SectorPeers or ParseTotalInfos" -v` → all pass (the overlay call in `fetch_valuation` at `:266` still uses the 2-arg positional form; default `request_timeout=None` preserves 10s behavior; the `SectorPeers` test passes only because the previous step widened its fake).
+
+- [ ] **Lint.** `make lint`.
+
+- [ ] **Commit.** `git add -A && git commit -m "perf(ROB-688): peer-only per-request timeout for get_sector_peers fast-fail (target keeps 10s)"`
+
+---
+
+## Task 3 — Trim the over-fetch: only pad `limit + 5` when integration peers `< limit` (migration-0)
+
+**Files:**
+- Modify `app/services/naver_finance/valuation.py:388-409` inside `fetch_sector_peers` — capture the integration peer count, gate the sector-scraped extras + the `limit + 5` padding on `count < limit`, and cap to `limit` otherwise. The sector-page fetch (`:396-397`) and the sector-name parse (`:420-421`) stay UNCONDITIONAL when `industry_code` is present.
+- Test (modify) `tests/test_naver_finance.py` — append `TestFetchSectorPeersTrim`.
+
+**Interfaces:**
+- Produces: `fetch_sector_peers` UNCHANGED signature. Internal behavior: when the `/integration` endpoint already returned `>= limit` peer codes, exactly `limit` peer fetches are issued (no `+5` extras, no scrape-derived padding), while the sector page is still fetched once and the output `sector` name is still populated.
+
+Steps:
+
+- [ ] **Write failing test — enough integration peers ⇒ only `limit` peer fetches, sector name still present.** Append to `tests/test_naver_finance.py`:
+```python
+@pytest.mark.asyncio
+@pytest.mark.unit
+class TestFetchSectorPeersTrim:
+    async def test_no_overfetch_when_integration_has_enough_peers(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from app.core.config import settings
+
+        monkeypatch.setattr(settings, "naver_peer_fetch_concurrency", 10)
+
+        # Integration returns 8 peers; limit=5 -> should fetch exactly 5, not 10.
+        peers_raw = [{"itemCode": f"90000{i}"} for i in range(1, 9)]
+        fetched_peer_codes: list[str] = []
+
+        async def fake_fetch_integration(
+            code: str, _client: Any, request_timeout: float | None = None
+        ) -> dict[str, Any]:
+            if code != "000100":
+                fetched_peer_codes.append(code)
+            base = {
+                "symbol": code, "name": code, "per": 10, "pbr": 1.0,
+                "market_cap": 100, "current_price": 1, "change_pct": 0.0,
+                "industry_code": "123", "peers_raw": [],
+            }
+            if code == "000100":
+                base["peers_raw"] = peers_raw
+            return base
+
+        sector_gets: list[Any] = []
+
+        class FakeResponse:
+            content = (
+                "<html><head><title>반도체 : Npay 증권</title></head>"
+                "<body><table class='type_5'>"
+                "<tr><td><a href='/item/main.naver?code=777777'>P</a></td></tr>"
+                "</table></body></html>"
+            ).encode("euc-kr")
+
+        class FakeClient:
+            async def __aenter__(self) -> "FakeClient":
+                return self
+
+            async def __aexit__(self, *_a: Any) -> None:
+                return None
+
+            async def get(self, url: str, params: Any = None) -> FakeResponse:
+                sector_gets.append((url, params))
+                return FakeResponse()
+
+        import httpx
+
+        monkeypatch.setattr(httpx, "AsyncClient", lambda **_k: FakeClient())
+        monkeypatch.setattr(
+            naver_finance.valuation, "_fetch_integration", fake_fetch_integration
+        )
+
+        result = await naver_finance.fetch_sector_peers("000100", limit=5)
+
+        assert len(fetched_peer_codes) == 5, (
+            f"expected 5 peer fetches, got {len(fetched_peer_codes)}"
+        )
+        # sector name still resolved from the scrape (dual-purpose page)
+        assert result["sector"] == "반도체"
+        # sector page still fetched exactly once (never skipped)
+        assert len(sector_gets) == 1
+        # scrape-derived extra (777777) must NOT appear — integration peers sufficed
+        assert "777777" not in fetched_peer_codes
+```
+
+- [ ] **Run it — fails.** `uv run pytest tests/test_naver_finance.py -k Trim -v`
+  Expected: current code sets `peer_codes = peer_codes[: limit + 5]` unconditionally (`:409`) → 8 integration peers padded to `min(8, 10) = 8` fetches → `assert len(...) == 5` FAILS.
+
+- [ ] **Minimal impl — gate the extras + padding on `integration_count < limit`.** In `app/services/naver_finance/valuation.py`, restructure `:388-409`:
+```python
+        # ---- Collect peer codes from integration response ----
+        peer_codes: list[str] = []
+        for p in target["peers_raw"]:
+            pc = p.get("itemCode", "")
+            if pc and pc != code:
+                peer_codes.append(pc)
+
+        integration_peer_count = len(peer_codes)
+
+        industry_code = target.get("industry_code")
+        sector_soup = None
+        if industry_code:
+            # Sector page is dual-purpose: sector NAME (always) + extra peers.
+            # Fetch it once regardless of whether we need extras (constraint).
+            sector_soup = await _fetch_sector_soup(str(industry_code), client)
+
+        if integration_peer_count < limit:
+            # Not enough peers from integration — pad with sector-scraped codes,
+            # then fetch a few extras in case some fail.
+            if sector_soup is not None:
+                extra_codes = _parse_sector_stock_codes(sector_soup)
+                seen = {code, *peer_codes}
+                for ec in extra_codes:
+                    if ec not in seen:
+                        peer_codes.append(ec)
+                        seen.add(ec)
+            peer_codes = peer_codes[: limit + 5]
+        else:
+            # Integration already has enough peers — no over-fetch padding.
+            peer_codes = peer_codes[:limit]
+```
+  Note: the old `:400-406` block that appended `extra_codes` now lives inside the `if integration_peer_count < limit:` branch, and the unconditional `peer_codes = peer_codes[: limit + 5]` at `:409` is removed (the Task 1 line `peer_codes = peer_codes[: limit + 5]  # (Task 3 makes this conditional)` is superseded by this block). Leave the sector-name parse (`:420-421`, `if sector_soup is not None: sector_name = _parse_sector_name(sector_soup)`) exactly as-is so the name is always populated.
+
+- [ ] **Run it — passes.** `uv run pytest tests/test_naver_finance.py -k Trim -v` → passes.
+
+- [ ] **Regression — fewer-than-limit path still scrapes extras.** `uv run pytest tests/test_naver_finance.py -k "SectorPeers or Concurrency or PeerTimeout" -v` → all pass. In particular `test_fetches_sector_page_once_for_codes_and_name` (`:1506`, target has 0 integration peers, limit=1 ⇒ `0 < 1` branch ⇒ scrape extras ⇒ peer `000002`, sector `반도체`, `len(sector_gets) == 1`) stays green (its fake was widened to accept `request_timeout` in Task 2).
+
+- [ ] **Lint.** `make lint`.
+
+- [ ] **Commit.** `git add -A && git commit -m "perf(ROB-688): trim get_sector_peers over-fetch — pad limit+5 only when integration peers < limit"`
+
+---
+
+## Task 4 — Short-TTL fail-open Redis cache for the integration bundle + sector page (migration-0)
+
+**Files:**
+- Create `app/services/naver_finance/peer_cache.py` — fail-open cache-aside helpers mirroring `app/core/analyze_cache.py` (`_get_redis_client`, `get_cached_integration`/`set_cached_integration` keyed by code, `get_cached_sector`/`set_cached_sector` keyed by industry code, `close_peer_cache_redis`).
+- Modify `app/core/config.py` — `naver_peer_cache_enabled: bool = True`, `naver_peer_cache_ttl_seconds: int = 600`.
+- Modify `tests/conftest.py:106` — add `os.environ["NAVER_PEER_CACHE_ENABLED"] = "false"` in `_ensure_test_env`.
+- Modify `app/services/naver_finance/valuation.py` — add `_fetch_integration_cached(code, client, redis_client, *, request_timeout=None)`; route the target (`:384`) and peer (`_safe_fetch`) fetches through it; cache the sector-page derivation (`{sector_name, extra_codes}`) around `_fetch_sector_soup`.
+- Optionally modify `app/services/naver_finance/__init__.py` to re-export `peer_cache` helpers (only if the cache test imports via the package façade).
+- Test (create) `tests/test_naver_peer_cache.py`.
+
+**Interfaces:**
+- Consumes `settings.naver_peer_cache_enabled: bool`, `settings.naver_peer_cache_ttl_seconds: int`.
+- Produces (in `peer_cache.py`):
+  - `async _get_redis_client() -> redis.Redis | None` — returns `None` when `naver_peer_cache_enabled` is False or client init fails (hermetic + fail-open).
+  - `async get_cached_integration(redis_client, code) -> dict[str, Any] | None` / `async set_cached_integration(redis_client, code, payload) -> None` — key `naver_peer:integ:{CODE}`, TTL `naver_peer_cache_ttl_seconds`. Never raise.
+  - `async get_cached_sector(redis_client, industry_code) -> dict[str, Any] | None` / `async set_cached_sector(redis_client, industry_code, payload) -> None` — key `naver_peer:sector:{INDUSTRY}`, payload `{"sector_name": str|None, "extra_codes": list[str]}`, TTL as above. Never raise.
+- Produces (in `valuation.py`) `_fetch_integration_cached(code, client, redis_client, *, request_timeout=None) -> dict[str, Any]` — cache-aside over `_fetch_integration`. On hit returns the cached dict (skips network); on miss fetches live and best-effort caches non-degraded results. `fetch_sector_peers` opens one `redis_client = await peer_cache._get_redis_client()` per call and threads it through target + peers + sector.
+
+Steps:
+
+- [ ] **Write failing test — cache-aside hit skips network; disabled/None fails open.** Create `tests/test_naver_peer_cache.py`:
+```python
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from app.services.naver_finance import peer_cache
+
+pytestmark = [pytest.mark.unit, pytest.mark.asyncio]
+
+
+class _FakeRedis:
+    def __init__(self) -> None:
+        self.store: dict[str, str] = {}
+        self.set_calls: list[tuple[str, str, int | None]] = []
+
+    async def get(self, key: str) -> str | None:
+        return self.store.get(key)
+
+    async def set(self, key: str, value: str, ex: int | None = None) -> None:
+        self.store[key] = value
+        self.set_calls.append((key, value, ex))
+
+
+async def test_set_then_get_integration_roundtrips_with_ttl(monkeypatch):
+    from app.core.config import settings
+
+    monkeypatch.setattr(settings, "naver_peer_cache_ttl_seconds", 600)
+    r = _FakeRedis()
+    payload = {"symbol": "006400", "per": 12.3, "market_cap": 999, "peers_raw": []}
+    await peer_cache.set_cached_integration(r, "006400", payload)
+    assert r.set_calls and r.set_calls[0][2] == 600  # TTL applied
+
+    got = await peer_cache.get_cached_integration(r, "006400")
+    assert got == payload
+
+
+async def test_get_with_none_client_returns_none_fail_open():
+    assert await peer_cache.get_cached_integration(None, "006400") is None
+    # set with None client is a no-op (must not raise)
+    await peer_cache.set_cached_integration(None, "006400", {"a": 1})
+
+
+async def test_get_client_returns_none_when_disabled(monkeypatch):
+    from app.core.config import settings
+
+    monkeypatch.setattr(settings, "naver_peer_cache_enabled", False)
+    assert await peer_cache._get_redis_client() is None
+
+
+async def test_malformed_cache_value_returns_none(monkeypatch):
+    r = _FakeRedis()
+    r.store["naver_peer:integ:006400"] = "{not json"
+    assert await peer_cache.get_cached_integration(r, "006400") is None
+
+
+async def test_sector_payload_roundtrips(monkeypatch):
+    r = _FakeRedis()
+    payload = {"sector_name": "반도체", "extra_codes": ["000660", "000990"]}
+    await peer_cache.set_cached_sector(r, "123", payload)
+    assert await peer_cache.get_cached_sector(r, "123") == payload
+```
+
+- [ ] **Run it — fails.** `uv run pytest tests/test_naver_peer_cache.py -v`
+  Expected: `ModuleNotFoundError: app.services.naver_finance.peer_cache` (module does not exist yet).
+
+- [ ] **Add the settings + conftest guard.** In `app/core/config.py` (beside the Task 1/2 fields):
+```python
+    # ROB-688: short-TTL fail-open Redis cache for the get_sector_peers KR
+    # /basic+/integration bundle and the sector page. Intraday staleness of
+    # current_price/change_pct up to the TTL is acceptable for a comparison tool.
+    naver_peer_cache_enabled: bool = True
+    naver_peer_cache_ttl_seconds: int = 600
+```
+  In `tests/conftest.py`, inside `_ensure_test_env` right after the `ANALYZE_FETCH_CACHE_ENABLED` line (`:106`):
+```python
+    # ROB-688: same hermetic guard for the sector-peers cache — never touch a
+    # real Redis from tests; cache tests inject a fake client explicitly.
+    os.environ["NAVER_PEER_CACHE_ENABLED"] = "false"
+```
+
+- [ ] **Minimal impl — create `peer_cache.py`.** New file `app/services/naver_finance/peer_cache.py`, mirroring `app/core/analyze_cache.py`'s fail-open contract (lazy singleton client, settings gate, `json.dumps(default=str)`, GET/SET that never raise):
+```python
+"""ROB-688 — short-TTL fail-open Redis cache for get_sector_peers KR fetches.
+
+Cache-aside over the Naver mobile /basic+/integration bundle (keyed by stock
+code) and the sector detail page derivation (keyed by industry code). Mirrors
+the fail-open contract of app.core.analyze_cache: any Redis outage or malformed
+payload degrades to a live fetch and never raises. Gated by
+settings.naver_peer_cache_enabled (forced off in tests/conftest.py).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+import redis.asyncio as redis
+
+from app.core.config import settings
+from app.services.ohlcv_cache_common import create_redis_client
+
+logger = logging.getLogger(__name__)
+
+_INTEG_PREFIX = "naver_peer:integ:"
+_SECTOR_PREFIX = "naver_peer:sector:"
+_REDIS_CLIENT: redis.Redis | None = None
+
+
+async def _get_redis_client() -> redis.Redis | None:
+    global _REDIS_CLIENT
+    if not settings.naver_peer_cache_enabled:
+        return None
+    if _REDIS_CLIENT is not None:
+        return _REDIS_CLIENT
+    try:
+        _REDIS_CLIENT = await create_redis_client()
+    except Exception as exc:  # noqa: BLE001 — fail open to live fetch
+        logger.debug("peer_cache: redis init failed: %s", exc)
+        _REDIS_CLIENT = None
+    return _REDIS_CLIENT
+
+
+async def close_peer_cache_redis() -> None:
+    global _REDIS_CLIENT
+    if _REDIS_CLIENT is not None:
+        try:
+            await _REDIS_CLIENT.close()
+        except Exception:  # noqa: BLE001
+            pass
+        _REDIS_CLIENT = None
+
+
+def _parse_dict(value: Any) -> dict[str, Any] | None:
+    if not isinstance(value, str):
+        return None
+    try:
+        parsed = json.loads(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if isinstance(parsed, dict) else None
+
+
+async def _get(redis_client: redis.Redis | None, key: str) -> dict[str, Any] | None:
+    if redis_client is None:
+        return None
+    try:
+        raw = await redis_client.get(key)
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("peer_cache: GET failed for %s: %s", key, exc)
+        return None
+    return _parse_dict(raw)
+
+
+async def _set(redis_client: redis.Redis | None, key: str, payload: dict[str, Any]) -> None:
+    if redis_client is None:
+        return
+    try:
+        ttl = max(1, int(settings.naver_peer_cache_ttl_seconds))
+        serialized = json.dumps(payload, default=str, ensure_ascii=False)
+        await redis_client.set(key, serialized, ex=ttl)
+    except Exception as exc:  # noqa: BLE001 — best-effort
+        logger.debug("peer_cache: SET failed for %s: %s", key, exc)
+
+
+async def get_cached_integration(
+    redis_client: redis.Redis | None, code: str
+) -> dict[str, Any] | None:
+    return await _get(redis_client, f"{_INTEG_PREFIX}{code.upper()}")
+
+
+async def set_cached_integration(
+    redis_client: redis.Redis | None, code: str, payload: dict[str, Any]
+) -> None:
+    await _set(redis_client, f"{_INTEG_PREFIX}{code.upper()}", payload)
+
+
+async def get_cached_sector(
+    redis_client: redis.Redis | None, industry_code: str
+) -> dict[str, Any] | None:
+    return await _get(redis_client, f"{_SECTOR_PREFIX}{industry_code}")
+
+
+async def set_cached_sector(
+    redis_client: redis.Redis | None, industry_code: str, payload: dict[str, Any]
+) -> None:
+    await _set(redis_client, f"{_SECTOR_PREFIX}{industry_code}", payload)
+```
+
+- [ ] **Run the cache unit tests — pass.** `uv run pytest tests/test_naver_peer_cache.py -v` → all pass (note `_get_redis_client` disabled-path test flips `naver_peer_cache_enabled` True via monkeypatch is unnecessary — conftest already forces it False; the disabled test asserts None).
+
+- [ ] **Write failing test — `fetch_sector_peers` serves the target from the integration cache (no network for it).** Append to `tests/test_naver_finance.py` a `TestFetchSectorPeersCache` class that (a) monkeypatches `settings.naver_peer_cache_enabled = True`, (b) patches `naver_finance.peer_cache._get_redis_client` to return a fake redis pre-seeded with `naver_peer:integ:000100` = the target payload, (c) patches `_fetch_integration` to raise if called for `000100` (proving the cache short-circuits the target), returning normal data for peers, and asserts the returned `symbol/current_price` come from the cached payload:
+```python
+@pytest.mark.asyncio
+@pytest.mark.unit
+class TestFetchSectorPeersCache:
+    async def test_target_served_from_integration_cache(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import json
+
+        from app.core.config import settings
+        from app.services.naver_finance import peer_cache
+
+        monkeypatch.setattr(settings, "naver_peer_cache_enabled", True)
+        monkeypatch.setattr(settings, "naver_peer_fetch_concurrency", 5)
+
+        class _FakeRedis:
+            def __init__(self) -> None:
+                self.store: dict[str, str] = {}
+
+            async def get(self, key: str) -> str | None:
+                return self.store.get(key)
+
+            async def set(self, key: str, value: str, ex: int | None = None) -> None:
+                self.store[key] = value
+
+        fake = _FakeRedis()
+        fake.store["naver_peer:integ:000100"] = json.dumps({
+            "symbol": "000100", "name": "CachedTarget", "per": 7, "pbr": 0.9,
+            "market_cap": 500, "current_price": 12345, "change_pct": 2.0,
+            "industry_code": "123", "peers_raw": [{"itemCode": "000200"}],
+        })
+
+        async def fake_get_client() -> Any:
+            return fake
+
+        monkeypatch.setattr(peer_cache, "_get_redis_client", fake_get_client)
+
+        async def fake_fetch_integration(
+            code: str, _client: Any, request_timeout: float | None = None
+        ) -> dict[str, Any]:
+            if code == "000100":
+                raise AssertionError("target must be served from cache, not fetched")
+            return {
+                "symbol": code, "name": "Peer", "per": 11, "pbr": 1.2,
+                "market_cap": 900, "current_price": 40000, "change_pct": 0.5,
+                "industry_code": "123", "peers_raw": [],
+            }
+
+        class FakeResponse:
+            content = b"<html><head><title>x : Npay</title></head></html>"
+
+        class FakeClient:
+            async def __aenter__(self) -> "FakeClient":
+                return self
+
+            async def __aexit__(self, *_a: Any) -> None:
+                return None
+
+            async def get(self, url: str, params: Any = None) -> FakeResponse:
+                return FakeResponse()
+
+        import httpx
+
+        monkeypatch.setattr(httpx, "AsyncClient", lambda **_k: FakeClient())
+        monkeypatch.setattr(
+            naver_finance.valuation, "_fetch_integration", fake_fetch_integration
+        )
+
+        result = await naver_finance.fetch_sector_peers("000100", limit=1)
+
+        assert result["name"] == "CachedTarget"
+        assert result["current_price"] == 12345
+        assert result["peers"][0]["symbol"] == "000200"
+```
+
+- [ ] **Run it — fails.** `uv run pytest tests/test_naver_finance.py -k "SectorPeersCache" -v`
+  Expected: `AssertionError: target must be served from cache, not fetched` — `fetch_sector_peers` does not consult the cache yet.
+
+- [ ] **Minimal impl — cache-aside wrapper + wiring in `valuation.py`.** Add `from app.services.naver_finance import peer_cache` (or lazy import to avoid a cycle — `peer_cache` imports only config + ohlcv_cache_common, so a top-level import is safe) and a wrapper above `fetch_sector_peers`:
+```python
+async def _fetch_integration_cached(
+    code: str,
+    client: httpx.AsyncClient,
+    redis_client: Any = None,
+    *,
+    request_timeout: float | None = None,
+) -> dict[str, Any]:
+    """Cache-aside over _fetch_integration (ROB-688). Fail-open: any cache miss
+    or Redis outage falls through to the live fetch; only non-degraded results
+    (a resolved name) are written back."""
+    cached = await peer_cache.get_cached_integration(redis_client, code)
+    if cached is not None:
+        return cached
+    result = await _fetch_integration(code, client, request_timeout=request_timeout)
+    if result.get("name"):
+        await peer_cache.set_cached_integration(redis_client, code, result)
+    return result
+```
+  In `fetch_sector_peers`, open the client and one Redis handle, then route target + peers through the wrapper:
+```python
+    redis_client = await peer_cache._get_redis_client()
+    async with httpx.AsyncClient(headers=DEFAULT_HEADERS, timeout=10) as client:
+        target = await _fetch_integration_cached(code, client, redis_client)
+        ...
+        async def _safe_fetch(pc: str) -> dict[str, Any] | None:
+            async with semaphore:
+                try:
+                    return await _fetch_integration_cached(
+                        pc,
+                        client,
+                        redis_client,
+                        request_timeout=settings.naver_peer_fetch_timeout_seconds,
+                    )
+                except Exception:
+                    return None
+```
+  For the sector page, wrap `_fetch_sector_soup` + derivation in a cache-aside on `industry_code` so a hit skips both the HTTP scrape and re-parse:
+```python
+        industry_code = target.get("industry_code")
+        sector_name = None
+        cached_sector = (
+            await peer_cache.get_cached_sector(redis_client, str(industry_code))
+            if industry_code
+            else None
+        )
+        if cached_sector is not None:
+            sector_name = cached_sector.get("sector_name")
+            extra_codes_cached = list(cached_sector.get("extra_codes", []))
+            sector_soup = None  # already derived; no scrape needed
+        else:
+            extra_codes_cached = None
+            sector_soup = (
+                await _fetch_sector_soup(str(industry_code), client)
+                if industry_code
+                else None
+            )
+```
+  Then, in the `< limit` branch, source extras from `extra_codes_cached` when present else `_parse_sector_stock_codes(sector_soup)`; after the peer gather, resolve `sector_name` from `sector_soup` (when not already cached) via `_parse_sector_name`, and write back `set_cached_sector(redis_client, str(industry_code), {"sector_name": sector_name, "extra_codes": extra_codes_used})`. **Keep the constraint invariant:** the sector name is still resolved on every fresh call (scrape) and only *reused* from cache — never nulled.
+
+  > **Implementation note for the executor:** keep this sector-cache wiring minimal — the load-bearing win is the integration-bundle cache + Semaphore. If the sector-cache branching risks regressing `test_fetches_sector_page_once_for_codes_and_name`, it is acceptable to cache ONLY the integration bundle in this task and leave the sector page fetched-live-each-call (still one fetch), deferring sector-page caching to a follow-up — but the integration-bundle cache and the "sector name never nulled" invariant are required.
+
+- [ ] **Run it — passes.** `uv run pytest tests/test_naver_finance.py -k "SectorPeersCache" -v` → passes.
+
+- [ ] **Regression — full naver suite + cache suite green with cache disabled by default.** `uv run pytest tests/test_naver_finance.py tests/test_naver_peer_cache.py -v` → all pass. With `NAVER_PEER_CACHE_ENABLED=false` (conftest), `_get_redis_client()` returns `None`, so `_fetch_integration_cached(code, client, None, request_timeout=...)` skips the cache and fails open to `_fetch_integration(code, client, request_timeout=...)`. Note this now routes the **target** through `_fetch_integration_cached(..., request_timeout=None)` too, so the existing `test_fetches_sector_page_once_for_codes_and_name` relies on the Task 2 fake widening (a 2-arg fake would raise `TypeError` on the un-wrapped target). Behavior is otherwise identical to today for every existing sector-peers/valuation test.
+
+- [ ] **Lint.** `make lint`.
+
+- [ ] **Commit.** `git add -A && git commit -m "perf(ROB-688): short-TTL fail-open Redis cache for get_sector_peers integration+sector fetches"`
+
+---
+
+## Done criteria
+
+- A KR `get_sector_peers` call with `limit=5` issues at most `naver_peer_fetch_concurrency` (≈5) concurrent peer fetches instead of the ~20-request burst; peers fast-fail at ≈5s while the target keeps its 10s budget; the common path (integration already returns ≥ `limit` peers) issues only `limit` peer fetches; and a repeat call for a recurring symbol within the TTL serves the integration bundle from Redis. The output contract (`symbol/name/sector/current_price/change_pct/per/pbr/market_cap/peers/comparison`) is unchanged, `sector` is never nulled on the common path, and every new path fails open to today's behavior when Redis is down or the cache is disabled.
+- migration-0, no broker/order/watch mutation, `make lint` clean, `uv run pytest tests/test_naver_finance.py tests/test_naver_peer_cache.py -v` green.

--- a/docs/plans/ROB-689-market-parity-serial-cards.md
+++ b/docs/plans/ROB-689-market-parity-serial-cards.md
@@ -1,0 +1,399 @@
+# /invest/api/market-parity — Parallelize Card Builders + Drop Unused KOSPI History Fetch Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (- [ ]) syntax.
+
+**Goal:** Shave latency off the read-only `GET /invest/api/market-parity` endpoint (Sentry: avg ~3.6s, p95 ~6.6s; `http.client` ≈ 76% of server time — Naver KOSPI index + er-api FX). Two mechanical inefficiencies exist: (1) `build_market_parity` awaits the four independent card builders (index / stablecoin / kimchi / synthetic) **serially** instead of via `asyncio.gather`, and (2) `get_index_quote` calls the shared `handle_get_market_index(count=1)`, which for KOSPI fires **three** Naver HTTP calls (basic + a 1-row price page **inside** `_fetch_index_kr_current`, plus a full `_fetch_index_kr_history` page) even though market-parity only reads the current value — the history page is fetched and discarded. **Be honest: this is a Low-priority, low-ROI change.** An adversarial pass downgraded the expected win: because the calls *inside* each leaf handler are already `asyncio.gather`-ed, card-level parallelization overlaps the two network-bound cards (index + kimchi) and dropping the wasted history call cuts spans/upstream load — realistic best case is **avg ~3.6s → ~3.0s, not ~0.8s.** BUT the Sentry transaction avg (~3,573ms) being ≈ the *serial* sum of the HTTP calls is a clue that the within-handler gathers may not actually overlap in practice; if that is true, dropping the two wasted Naver `/price`+`/history` calls could instead save ~1.3s serially. **Task 1 is therefore a mandatory diagnostic** that reads the code + a representative trace to decide which mechanism actually pays, before writing any production code. Both fixes are unconditionally *correct* (they never change output); the diagnostic only calibrates the honest savings claim and confirms there is no reason not to ship them.
+
+**Architecture:** Today `build_market_parity` (`app/services/invest_view_model/market_parity_service.py:513`) builds cards with sequential awaits: `_build_index_card` (`:527`), `_build_stablecoin_card` (`:539`), `_build_kimchi_card` (`:543`), then a `for` loop of `_build_synthetic_card` (`:561`–`:564`). In the default provider only the index card (KOSPI → Naver) and the kimchi card (Upbit + Binance + er-api FX, gathered inside `_fetch_kimchi_premium`, `app/mcp_server/tooling/fundamentals_sources_naver.py:224`) do real network I/O; stablecoin/synthetic legs return `None` immediately. Because the two network-bound cards run one-after-another, their HTTP time adds instead of overlapping. Separately, `DefaultMarketParityProvider.get_index_quote` (`:78`) calls `handle_get_market_index(symbol="KOSPI", period="day", count=1)` (`app/mcp_server/tooling/fundamentals/_market_index.py:62`); the naver branch (`:83`) does `asyncio.gather(_fetch_index_kr_current(...), _fetch_index_kr_history(...))`, and `_fetch_index_kr_current` (`app/mcp_server/tooling/fundamentals_sources_indices.py:65`) *itself* gathers a `/basic` and a `/price?pageSize=1` call (`:70`). Market-parity's `_first_index_row` reads only `row["current"]`/`row["open"]` from the `indices` list and discards `history` (grep confirms the service never references `history`). Target flow: (a) `build_market_parity` gathers the four builders concurrently while preserving exact card + warning ordering; (b) a new **current-only** helper `handle_get_market_index_current_only(symbol)` in `_market_index.py` reuses `_fetch_index_kr_current` + `_tag_kr_index_data_state` (so the ROB-464 `open`-based freshness override still fires) but omits the `_fetch_index_kr_history` call, and `get_index_quote` calls it instead of the shared handler. The shared `handle_get_market_index` is left **byte-for-byte unchanged** so its other callers keep their history payload.
+
+**Tech Stack:** Python 3.13, uv, pytest (markers `unit`/`asyncio`), `asyncio.gather`, httpx (Naver/er-api leaf fetchers), FastAPI read router, pydantic v2 (`InvestMarketParityResponse`/`InvestMarketParityCard`). No DB, no Redis, no broker/order/watch code paths.
+
+## Global Constraints
+
+Copied verbatim; every task implicitly includes these.
+
+- **Scope fix #2 to get_index_quote's OWN fetch path — do NOT change the shared handle_get_market_index (other callers consume the history).**
+- **A naive basic-only path drops the 'open' field that ROB-464's _is_fresh_clock_lagging_kr_index (_market_index.py:~38-59) uses to mark the KR index stale and set as_of — preserve it (silently disabling that freshness override is a regression).**
+- **A 30-60s cache must cache the data_state-tagged payload to preserve ROB-464 freshness semantics. At current traffic (6 req/7d) cache hit rate is ~0, so the cache is a low-value follow-up, not the headline.**
+- **Read-only /invest view; no broker/order/watch mutation. migration-0.**
+- **Be honest about the low ROI in the Goal; this issue is Low priority.**
+- **Migration-0.** No new DB column, no alembic revision, no schema change. This is a pure read-path latency refactor.
+- Read-only path: no broker / order / watch / order-intent mutation is introduced or reachable from any changed line. No new network *sources* are added — only the removal of one already-fetched-and-discarded call and a reordering of existing awaits.
+- Run tests: `uv run pytest <path> -v`. Lint: `make lint`. Do NOT commit unless the executing skill says so; each task lists its own commit message.
+
+---
+
+## Approach / decisions (read before Task 1)
+
+- **Fix #2 mechanism = new sibling function, NOT a parameter on the shared handler.** The lowest-risk way to satisfy "do NOT change the shared `handle_get_market_index`" is to add a new `handle_get_market_index_current_only(symbol)` in `_market_index.py` that reuses the existing, already-tested leaf fetchers (`_fetch_index_kr_current`, `_fetch_index_crypto_current`, `_fetch_index_us_current`) and the `_tag_kr_index_data_state` tagger, and to point only `get_index_quote` at it. Adding an `include_history=False` kwarg to the shared handler was rejected: it edits the shared function's body/signature and risks other callers, which the constraint forbids.
+- **The `open` field is preserved for free.** The ROB-464 freshness override reads `open` and `current`, both of which come from `_fetch_index_kr_current` (`/basic` + `/price?pageSize=1`). Only the *separate* `_fetch_index_kr_history` call is dropped. Keeping `_fetch_index_kr_current` intact and still calling `_tag_kr_index_data_state` on its result means the stale-tagging + `as_of` behavior is byte-identical to today.
+- **Cache = deferred, not built.** Per the verbatim constraint, at ~6 requests / 7 days the hit rate is ~0, so a 30–60s cache is documented as a follow-up (see "Deferred / Non-goal") and intentionally NOT implemented in this plan. If it is ever added it MUST wrap the `data_state`-tagged payload (post-`_tag_kr_index_data_state`), never the raw pre-tag Naver JSON.
+- **Both fixes are output-preserving.** Task 2 only reorders awaits (card order + warning order held constant); Task 3 only removes a discarded fetch. No test should observe a value change — only fewer upstream calls and concurrency.
+
+---
+
+## File Structure
+
+| File | Create/Modify | Responsibility (which Task) |
+|------|---------------|-----------------------------|
+| `app/mcp_server/tooling/fundamentals/_market_index.py` | Modify | Task 3 — add `handle_get_market_index_current_only(symbol)` (current-row only; reuses `_tag_kr_index_data_state`). Shared `handle_get_market_index` untouched. |
+| `app/services/invest_view_model/market_parity_service.py` | Modify | Task 2 — `build_market_parity` gathers the four card builders (order preserved). Task 3 — `get_index_quote` calls the new current-only helper + swaps the import. |
+| `tests/test_invest_market_parity_service.py` | Modify | Task 2 — concurrency proof (index+kimchi overlap) + output-unchanged regressions. Task 3 — `get_index_quote` uses the current-only helper. |
+| `tests/mcp_server/tooling/test_market_index_current_only.py` | Create | Task 3 — current-only helper drops history, preserves ROB-464 freshness tag; guard that shared `handle_get_market_index` still returns `history`. |
+
+> **NOT touched:**
+> - **The shared `handle_get_market_index` body/signature (`_market_index.py:62`)** and its default-batch path (`:104`–`:131`) — other callers (`get_market_index` MCP tool, snapshot collectors) consume `history`; Task 3 adds a *sibling* function and never edits this one. A guard test locks it.
+> - **The leaf fetchers `_fetch_index_kr_current` / `_fetch_index_kr_history` / `_fetch_index_us_*` / `_fetch_index_crypto_current` (`fundamentals_sources_indices.py`)** — reused as-is; no edits (dropping history = *not calling* `_fetch_index_kr_history`, not changing it).
+> - **`_tag_kr_index_data_state` / `_is_fresh_clock_lagging_kr_index` (`_market_index.py:38`,`:46`)** — reused verbatim so the ROB-464 `open`/`as_of` freshness semantics are identical.
+> - **The kimchi path (`_crypto.py`, `fundamentals_sources_naver.py`) and all non-index card legs** — Task 2 only changes *when* `_build_kimchi_card` is scheduled (concurrently), never its internals.
+> - **The router (`app/routers/invest_api.py:212`) and `InvestMarketParityResponse` schema** — signatures and output shape unchanged.
+> - **No cache layer / Redis** — see Deferred / Non-goal.
+
+---
+
+## Task 1 — Diagnostic: do the within-card gathers actually overlap? (measurement, no production code, no commit)
+
+**This task ships NO production code and has no TDD test — it is measurement + a recorded decision that calibrates the honest savings claim and confirms both fixes are safe to proceed.** It exists because the adversarial review found the ROI hinges on whether `asyncio.gather` inside the leaf handlers overlaps in practice (avg ≈ serial-HTTP-sum is a red flag). Tasks 2 and 3 proceed **regardless** of the finding (both are output-preserving and correct); the finding only sets the expected-savings language in the PR description and the eventual retro.
+
+**Files:** none modified. Optionally a throwaway script under the scratchpad dir (never committed).
+
+Steps:
+
+- [ ] **Re-read the two hot paths and confirm the code-level claims** (anchor the exact current line numbers, they may drift):
+  - `build_market_parity` serial awaits: `market_parity_service.py:527` (index), `:539` (stablecoin), `:543` (kimchi), `:561`–`:564` (synthetic loop).
+  - `get_index_quote` → `handle_get_market_index(...count=1)`: `market_parity_service.py:79`.
+  - naver branch `asyncio.gather(current, history)`: `_market_index.py:83`.
+  - `_fetch_index_kr_current` internal `asyncio.gather(basic, price)`: `fundamentals_sources_indices.py:70`.
+  - kimchi `asyncio.gather(upbit, binance, er-api)`: `fundamentals_sources_naver.py:224`.
+  - Confirm the service **never** reads `history`: `grep -n "history" app/services/invest_view_model/market_parity_service.py` → expect no hits.
+- [ ] **Pull a representative trace.** In Sentry, open a recent `GET /invest/api/market-parity` transaction (server-side). Inspect the `http.client` spans and record, for the two Naver calls and the er-api call, each span's **start** and **end** offsets. Determine overlap:
+  - If the three Naver spans (basic / price / history) START at ~the same offset and their durations overlap → the within-handler gathers **do** overlap; dropping history saves ≈ **0ms wall** (only cuts one span + upstream load).
+  - If they START sequentially (each begins ≈ when the previous ends) → the gathers do **not** overlap in practice (event-loop starvation, DNS, or per-call `httpx.AsyncClient` setup serializing) → dropping the history call saves ≈ **one Naver RTT** serially, and card-level `gather` (Task 2) additionally overlaps index vs kimchi.
+- [ ] **If Sentry is unavailable to the executor**, fall back to a local measurement: in the scratchpad dir write a throwaway async script that calls `handle_get_market_index("KOSPI", count=1)` and, separately, the proposed `handle_get_market_index_current_only("KOSPI")`, wrapping each leaf fetcher with a `time.perf_counter()` log of enter/exit. Compare wall times and enter/exit interleaving. **Do not commit this script.** (This is a live-network probe; it is measurement only and touches no repo file.)
+- [ ] **Record the decision.** Write 3–5 sentences into the PR description (and the ROB-689 retro memory) stating: (a) whether the within-card gathers overlap, (b) the resulting *honest* expected savings (`~0.5s` overlap win from Task 2 + `~0ms`..`~1.3s` from Task 3 depending on (a)), and (c) confirmation that neither fix changes output. Both Task 2 and Task 3 are GO regardless.
+- [ ] **No commit for this task.**
+
+---
+
+## Task 2 — Parallelize the four independent card builders (output-preserving, migration-0)
+
+**Files:**
+- Modify `app/services/invest_view_model/market_parity_service.py` — rewrite the body of `build_market_parity` (`:527`–`:564`) to gather `_build_index_card`, `_build_stablecoin_card`, `_build_kimchi_card`, and the `_build_synthetic_card` calls concurrently while appending cards/warnings in the exact same order.
+- Test (modify) `tests/test_invest_market_parity_service.py` — add a deterministic concurrency proof + an ordering/output-unchanged regression.
+
+**Interfaces:**
+- Consumes (unchanged): `_build_index_card(provider, config) -> tuple[InvestMarketParityCard, list[str]]` (`:235`), `_build_stablecoin_card(provider) -> tuple[...]` (`:290`), `_build_kimchi_card(provider) -> tuple[...]` (`:367`), `_build_synthetic_card(provider, config) -> tuple[...]` (`:400`). Each is already exception-contained per-leg via `_capture` (`:207`, `asyncio.wait_for(..., timeout=6)`), so gathering them cannot surface a new exception.
+- Produces: `build_market_parity(...) -> InvestMarketParityResponse` — signature and output **unchanged**; only scheduling changes.
+
+Steps:
+
+- [ ] **Write failing test — the index and kimchi builders run concurrently.** Add to `tests/test_invest_market_parity_service.py` a provider that forces overlap via two `asyncio.Event`s, so under serial scheduling the index leg times out (→ `missing`) and under `gather` it resolves (→ `fresh`):
+```python
+import asyncio
+
+
+class _OverlapProbeProvider(_StubParityProvider):
+    """Proves index-card and kimchi-card run concurrently.
+
+    get_index_quote sets ``index_started`` then blocks on ``kimchi_started``;
+    get_crypto_kimchi_premium sets ``kimchi_started`` then blocks on
+    ``index_started``. Under serial card building the index leg's inner
+    wait_for(1.0) times out (kimchi has not started yet) -> index card 'missing'.
+    Under asyncio.gather both events fire and both resolve -> index card 'fresh'.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.index_started = asyncio.Event()
+        self.kimchi_started = asyncio.Event()
+
+    async def get_index_quote(self, symbol: str) -> ParityQuote | None:
+        self.index_started.set()
+        await asyncio.wait_for(self.kimchi_started.wait(), timeout=1.0)
+        return await super().get_index_quote(symbol)
+
+    async def get_crypto_kimchi_premium(self, symbol: str) -> dict[str, Any] | None:
+        self.kimchi_started.set()
+        await asyncio.wait_for(self.index_started.wait(), timeout=1.0)
+        return await super().get_crypto_kimchi_premium(symbol)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_build_market_parity_builds_cards_concurrently() -> None:
+    response = await build_market_parity(_OverlapProbeProvider())
+    cards = {card.id: card for card in response.cards}
+    # Under serial scheduling the index leg would time out -> 'missing'.
+    assert cards["ewy-kospi-implied-parity"].dataState == "fresh"
+    assert cards["btc-kimchi-premium"].dataState == "fresh"
+```
+
+- [ ] **Run it — fails.** `uv run pytest tests/test_invest_market_parity_service.py -k concurrently -v`
+  Expected: FAIL — current serial code builds the index card fully first; its `get_index_quote` blocks on `kimchi_started` (never set yet) and the inner `wait_for(1.0)` raises `TimeoutError`, which `_capture` swallows → `base=None` → index card `dataState == "missing"` (`emptyReason == "market_index_unavailable"`).
+
+- [ ] **Minimal impl — gather the builders, preserve order.** In `market_parity_service.py`, replace the serial block (`:527`–`:564`, from `index_card, index_warnings = await _build_index_card(...)` through the `for config in synthetic_configs:` loop) with:
+```python
+    index_config = IndexParityConfig(
+        id="ewy-kospi-implied-parity",
+        title="EWY implied KOSPI parity",
+        base_symbol="KOSPI",
+        proxy_symbol="EWY",
+    )
+    synthetic_configs = [
+        SyntheticParityConfig(
+            base_symbol="005930",
+            base_name="삼성전자",
+            synthetic_symbol="xyz:SMSN",
+            title="Samsung Electronics synthetic parity",
+        ),
+        SyntheticParityConfig(
+            base_symbol="000660",
+            base_name="SK하이닉스",
+            synthetic_symbol="xyz:SKHX",
+            title="SK hynix synthetic parity",
+        ),
+    ][: max(limit, 0)]
+
+    # ROB-689: the four card builders are independent; gather them so the two
+    # network-bound cards (index=KOSPI/naver, kimchi=upbit+binance+er-api) overlap
+    # instead of summing. Order of cards + warnings is preserved exactly (gather
+    # returns results positionally), so the response is byte-identical to serial.
+    (
+        (index_card, index_warnings),
+        (stablecoin_card, stablecoin_warnings),
+        (kimchi_card, kimchi_warnings),
+        *synthetic_results,
+    ) = await asyncio.gather(
+        _build_index_card(provider, index_config),
+        _build_stablecoin_card(provider),
+        _build_kimchi_card(provider),
+        *(_build_synthetic_card(provider, config) for config in synthetic_configs),
+    )
+
+    cards.append(index_card)
+    warnings.extend(index_warnings)
+    cards.append(stablecoin_card)
+    warnings.extend(stablecoin_warnings)
+    cards.append(kimchi_card)
+    warnings.extend(kimchi_warnings)
+    for card, card_warnings in synthetic_results:
+        cards.append(card)
+        warnings.extend(card_warnings)
+```
+  (`asyncio` is already imported at `:11`. `IndexParityConfig`/`SyntheticParityConfig` are already defined. Leave everything after `if not include_disabled:` unchanged.)
+
+- [ ] **Run it — passes.** `uv run pytest tests/test_invest_market_parity_service.py -k concurrently -v` → 1 passed.
+
+- [ ] **Regression — existing correctness + ordering unchanged.** `uv run pytest tests/test_invest_market_parity_service.py -v`
+  Expected: all four pre-existing tests still pass (`test_build_market_parity_calculates_stubbed_cards`, `..._defaults_to_approval_gated_missing_cards`, `..._redacts_provider_exception_to_warning`, `..._can_hide_disabled_cards`) — card ids/order, premium math, warning surfacing, and `include_disabled=False` filtering are all order-preserved. Also `uv run pytest tests/test_invest_market_parity_router.py -v` → passes (router stub still receives `market/include_disabled/limit`).
+
+- [ ] **Lint.** `make lint`
+
+- [ ] **Commit.** `git add -A && git commit -m "perf(ROB-689): gather independent market-parity card builders (Fix #1)"`
+
+---
+
+## Task 3 — Current-only index fetch: drop the unused KOSPI history page (output-preserving, migration-0)
+
+**Files:**
+- Modify `app/mcp_server/tooling/fundamentals/_market_index.py` — add `handle_get_market_index_current_only(symbol)` next to `handle_get_market_index` (`:62`), reusing `_INDEX_META`, the leaf `_fetch_index_*_current` fetchers, `_tag_kr_index_data_state` (`:46`), and `_error_payload`. The shared handler stays untouched.
+- Modify `app/services/invest_view_model/market_parity_service.py` — swap the import at `:18` to the new helper and change `get_index_quote` (`:79`) to call `handle_get_market_index_current_only(symbol)` (no `period`/`count`).
+- Test (create) `tests/mcp_server/tooling/test_market_index_current_only.py` — handler-level: drops history, preserves ROB-464 tag; guard that the shared handler still returns `history`.
+- Test (modify) `tests/test_invest_market_parity_service.py` — provider-level: `get_index_quote` reads `current` via the current-only helper.
+
+**Interfaces:**
+- Produces `handle_get_market_index_current_only(symbol: str) -> dict[str, Any]` → `{"indices": [ <current-row dict> ]}` (no `"history"` key). naver rows are passed through `_tag_kr_index_data_state`; unknown symbol → `ValueError`; leaf failure → `_error_payload(source=..., message=..., symbol=...)` (same shape as the shared handler's except branch).
+- Consumes (unchanged, imported already at `_market_index.py:9`–`:17`): `_INDEX_META`, `_fetch_index_kr_current`, `_fetch_index_crypto_current`, `_fetch_index_us_current`, `_tag_kr_index_data_state`, `_error_payload`.
+- `DefaultMarketParityProvider.get_index_quote(symbol) -> ParityQuote | None` — signature unchanged; internally now calls the current-only helper.
+
+Steps:
+
+- [ ] **Write failing test — helper returns current-only, no history call, tag preserved.** Create `tests/mcp_server/tooling/test_market_index_current_only.py`:
+```python
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+import app.mcp_server.tooling.fundamentals._market_index as mkt
+
+pytestmark = [pytest.mark.unit, pytest.mark.asyncio]
+
+
+async def test_current_only_kospi_skips_history_call(monkeypatch):
+    current = AsyncMock(
+        return_value={
+            "symbol": "KOSPI",
+            "name": "코스피",
+            "current": 2450.5,
+            "change": -45.3,
+            "change_pct": -1.82,
+            "open": 2390.0,
+            "source": "naver",
+        }
+    )
+    history = AsyncMock(return_value=[{"date": "2026-02-01", "close": 2450.5}])
+    monkeypatch.setattr(mkt, "_fetch_index_kr_current", current)
+    monkeypatch.setattr(mkt, "_fetch_index_kr_history", history)
+
+    result = await mkt.handle_get_market_index_current_only("KOSPI")
+
+    assert "history" not in result
+    assert result["indices"][0]["current"] == pytest.approx(2450.5)
+    assert result["indices"][0]["data_state"]  # tagged by _tag_kr_index_data_state
+    current.assert_awaited_once()
+    history.assert_not_awaited()  # the wasted history page is never fetched
+
+
+async def test_current_only_preserves_rob464_stale_override(monkeypatch):
+    # change/change_pct == 0 but open != current on a FRESH clock -> ROB-464 marks
+    # the KR index stale and stamps as_of. This must survive the current-only path.
+    current = AsyncMock(
+        return_value={
+            "symbol": "KOSPI",
+            "name": "코스피",
+            "current": 8123.62,
+            "change": 0,
+            "change_pct": 0,
+            "open": 8263.85,
+            "source": "naver",
+        }
+    )
+    monkeypatch.setattr(mkt, "_fetch_index_kr_current", current)
+    monkeypatch.setattr(mkt, "_fetch_index_kr_history", AsyncMock())
+    monkeypatch.setattr(mkt, "kr_market_data_state", lambda *a, **k: "fresh")
+
+    result = await mkt.handle_get_market_index_current_only("KOSPI")
+    row = result["indices"][0]
+
+    assert row["data_state"] == "stale"
+    assert row["data_state_reason"] == mkt._KR_INDEX_LAGGING_REASON
+    assert row["as_of"]  # stamped
+
+
+async def test_current_only_unknown_symbol_raises():
+    with pytest.raises(ValueError):
+        await mkt.handle_get_market_index_current_only("NOPE")
+
+
+async def test_current_only_leaf_failure_returns_error_payload(monkeypatch):
+    monkeypatch.setattr(
+        mkt, "_fetch_index_kr_current", AsyncMock(side_effect=RuntimeError("boom"))
+    )
+    result = await mkt.handle_get_market_index_current_only("KOSPI")
+    assert "error" in result
+
+
+async def test_shared_handler_still_returns_history(monkeypatch):
+    # GUARD (constraint): the shared handle_get_market_index MUST keep fetching
+    # history for its other callers. Task 3 must not touch it.
+    monkeypatch.setattr(
+        mkt,
+        "_fetch_index_kr_current",
+        AsyncMock(return_value={"symbol": "KOSPI", "current": 2450.5, "open": 2390.0}),
+    )
+    history = AsyncMock(return_value=[{"date": "2026-02-01", "close": 2450.5}])
+    monkeypatch.setattr(mkt, "_fetch_index_kr_history", history)
+
+    result = await mkt.handle_get_market_index(symbol="KOSPI", count=1)
+
+    assert "history" in result
+    history.assert_awaited_once()
+```
+
+- [ ] **Run it — fails.** `uv run pytest tests/mcp_server/tooling/test_market_index_current_only.py -v`
+  Expected: the four `current_only` tests FAIL with `AttributeError: module ... has no attribute 'handle_get_market_index_current_only'`; `test_shared_handler_still_returns_history` PASSES already (guard baseline).
+
+- [ ] **Minimal impl — add the current-only helper.** In `app/mcp_server/tooling/fundamentals/_market_index.py`, add (below `handle_get_market_index`, reusing the already-imported helpers):
+```python
+async def handle_get_market_index_current_only(symbol: str) -> dict[str, Any]:
+    """ROB-689: current-quote-only index fetch (drops the unused history page).
+
+    market-parity's get_index_quote reads only the current row, but the shared
+    handle_get_market_index also fetches a full history page per call. This sibling
+    returns the same current-row shape ({"indices": [row]}) WITHOUT the history
+    fetch. _fetch_index_kr_current (basic + 1-row price page) is kept intact so the
+    'open' field is present and _tag_kr_index_data_state can still apply the ROB-464
+    freshness override. The shared handle_get_market_index is intentionally NOT
+    modified (its other callers consume the history).
+    """
+    sym = (symbol or "").strip().upper()
+    meta = _INDEX_META.get(sym)
+    if meta is None:
+        raise ValueError(
+            f"Unknown index symbol '{sym}'. Supported: {', '.join(sorted(_INDEX_META))}"
+        )
+    try:
+        if meta["source"] == "naver":
+            current_data = await _fetch_index_kr_current(
+                meta["naver_code"], meta["name"]
+            )
+            return {"indices": [_tag_kr_index_data_state(current_data)]}
+        if meta["source"] == "coingecko":
+            current_data = await _fetch_index_crypto_current(
+                meta["cg_metric"], meta["name"], sym
+            )
+            return {"indices": [current_data]}
+        current_data = await _fetch_index_us_current(
+            meta["yf_ticker"], meta["name"], sym
+        )
+        return {"indices": [current_data]}
+    except Exception as exc:
+        return _error_payload(source=meta["source"], message=str(exc), symbol=sym)
+```
+  Add `_fetch_index_crypto_current` and `_fetch_index_us_current` to the existing import block from `fundamentals_sources_indices` (`:9`–`:17`) if not already listed (`_fetch_index_kr_current`, `_fetch_index_us_current`, and `_fetch_index_crypto_current` are all already imported — verify and add only what's missing).
+
+- [ ] **Run it — passes.** `uv run pytest tests/mcp_server/tooling/test_market_index_current_only.py -v` → 5 passed.
+
+- [ ] **Write failing test — provider uses the current-only helper.** Add to `tests/test_invest_market_parity_service.py`:
+```python
+from decimal import Decimal
+from unittest.mock import AsyncMock
+
+from app.services.invest_view_model.market_parity_service import (
+    DefaultMarketParityProvider,
+)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_default_provider_index_quote_uses_current_only(monkeypatch) -> None:
+    import app.services.invest_view_model.market_parity_service as svc
+
+    called = AsyncMock(
+        return_value={
+            "indices": [
+                {"symbol": "KOSPI", "current": 2450.5, "source": "naver"}
+            ]
+        }
+    )
+    monkeypatch.setattr(svc, "handle_get_market_index_current_only", called)
+
+    quote = await DefaultMarketParityProvider().get_index_quote("KOSPI")
+
+    assert quote is not None
+    assert quote.price == Decimal("2450.5")
+    called.assert_awaited_once_with("KOSPI")
+```
+
+- [ ] **Run it — fails.** `uv run pytest tests/test_invest_market_parity_service.py -k current_only -v`
+  Expected: FAIL — `market_parity_service` has no name `handle_get_market_index_current_only` (still imports/calls `handle_get_market_index`).
+
+- [ ] **Minimal impl — rewire get_index_quote.** In `app/services/invest_view_model/market_parity_service.py`:
+  - Change the import (`:18`) from `handle_get_market_index` to `handle_get_market_index_current_only` (confirm `handle_get_market_index` is used nowhere else in this file — grep shows only `get_index_quote`).
+  - In `get_index_quote` (`:79`) replace `payload = await handle_get_market_index(symbol=symbol, period="day", count=1)` with `payload = await handle_get_market_index_current_only(symbol)`. Leave the rest of the method (`_first_index_row`, `ParityQuote` construction) unchanged.
+
+- [ ] **Run it — passes.** `uv run pytest tests/test_invest_market_parity_service.py -k current_only -v` → 1 passed.
+
+- [ ] **Regression — service + handler suites.** `uv run pytest tests/test_invest_market_parity_service.py tests/mcp_server/tooling/test_market_index_current_only.py -v` and `uv run pytest tests/test_mcp_fundamentals_tools.py -k Index -v` → all pass (the shared-handler tests in `TestGetMarketIndex`, including `test_single_kr_index` asserting `"history" in result`, are untouched).
+
+- [ ] **Lint.** `make lint`
+
+- [ ] **Commit.** `git add -A && git commit -m "perf(ROB-689): current-only index fetch for market-parity, drop unused KOSPI history (Fix #2)"`
+
+---
+
+## Deferred / Non-goal — 30–60s response cache
+
+Per the Global Constraint: *"A 30-60s cache must cache the data_state-tagged payload to preserve ROB-464 freshness semantics. At current traffic (6 req/7d) cache hit rate is ~0, so the cache is a low-value follow-up, not the headline."* This plan **does not** implement a cache. Rationale: at ~6 requests / 7 days the expected hit rate is ~0, so it would add a Redis dependency and a staleness-window to the read path for effectively zero latency benefit today. If a future traffic increase justifies it, the follow-up MUST cache the **`_tag_kr_index_data_state`-tagged** payload (post-tag, so the ROB-464 `data_state`/`as_of`/`data_state_reason` fields are cached, never the raw pre-tag Naver JSON), with a TTL of 30–60s, and remain read-only/migration-0. Tracked as a separate low-priority ticket, not ROB-689.

--- a/docs/runbooks/screener-analyst-consensus-cache.md
+++ b/docs/runbooks/screener-analyst-consensus-cache.md
@@ -1,0 +1,114 @@
+# Screener analyst-consensus cache (ROB-686)
+
+`screen_stocks_snapshot`'s `min_analyst_*` filters and the per-page KR analyst
+consensus (buy/hold/sell counts, target prices, analyst label) are now backed
+by a per-symbol Redis cache-aside instead of live-scraping Naver research
+pages (`company_list.naver` + up to 10 `company_read.naver`) on every call.
+This runbook is the operator note for the cache: key format, TTL, the shared
+kill switch, fail-open behavior, scope, and how to invalidate.
+
+> **Migration-0.** This is a Redis cache-aside layer only — no new DB
+> table/column, no alembic revision. The pre-existing `analyst_consensus_snapshots`
+> precompute table (ROB-641, `app/models/analyst_consensus_snapshot.py`) is a
+> separate surface (scoped to holdings ∪ active watch) and is not read or
+> written by this cache.
+
+---
+
+## 1. What is cached (and what is NOT)
+
+Only the **daily-stable** analyst consensus fields are cached:
+`buy_count`, `hold_count`, `sell_count`, `strong_buy_count`, `total_count`,
+`avg_target_price`, `median_target_price`, `min_target_price`,
+`max_target_price`, `rows_total`, `rows_used`, `rows_excluded_stale`,
+`rows_undated`, `newest_opinion_date`, `window_months`, `target_price_count`,
+`target_price_honest`.
+
+`current_price` and `upside_pct` are **never cached** — they are stripped
+before the cache write and recomputed on every call from a fresh
+`_fetch_current_price` (a single `item/main.naver` GET), so the displayed
+target-upside never serves a stale intraday price even when the consensus
+counts themselves are a cache hit.
+
+A consensus with `total_count <= 0` is never persisted (a network blip must
+not poison the day with a fake "no coverage" verdict) — genuinely
+zero-coverage discovery symbols are re-fetched live on every call. This is a
+known, accepted tradeoff (see the implementation plan's "Known tradeoff"
+note); a future refinement could distinguish fetch-failed from
+fetch-succeeded-but-empty and cache the latter.
+
+## 2. Key format + TTL
+
+```
+screener_consensus:naver:{SYMBOL}:{YYYY-MM-DD in KST}
+```
+
+- Namespace prefix `screener_consensus:` is **distinct** from the
+  analyze-path fetch cache's `analyze_fetch:` prefix (ROB-638,
+  `app/core/analyze_cache.py`) — the two caches never collide even though
+  they share the same Redis client + TTL helpers.
+- TTL matches the ROB-638 `naver` provider TTL: before the KRX session close
+  (15:35 KST) the entry lives until today's close; after close it lives
+  until the next KST midnight.
+- KR only. US (yfinance) consensus is never cached — `market == "us"` always
+  calls the live `handle_get_investment_opinions` (behaviorally unchanged
+  from before this change).
+
+## 3. Env / config gate
+
+`ANALYZE_FETCH_CACHE_ENABLED` (shared with the ROB-638 analyze-path cache;
+`settings.analyze_fetch_cache_enabled`, default `true` in production,
+force-set to `false` in `tests/conftest.py`).
+
+- `false` → `analyze_cache._get_redis_client()` returns `None` →
+  every consensus cache/get/set call is a no-op → every symbol falls open to
+  a direct live fetch on every call (today's pre-ROB-686 behavior).
+- `true` → the cache-aside path is active.
+
+There is no dedicated env var for this cache — it deliberately reuses the
+same gate as the analyze-path cache so there is exactly one on/off switch
+for "does auto_trader ever cache a Naver fetch."
+
+## 4. Fail-open behavior
+
+Every helper in `app/services/invest_view_model/analyst_consensus_cache.py`
+degrades to a live fetch and never raises:
+
+- Redis unavailable / connection error on GET or SET → treated as a miss /
+  no-op, logged at `debug`.
+- Malformed cached payload (not a JSON dict) → treated as a miss.
+- Live fetch failure/exception → the symbol is simply absent from the
+  filter-counts map (dropped by `min_analyst_*`) or returns
+  `{"error": "analyst_consensus_unavailable"}` from the page provider —
+  same shape as the pre-existing `enrich_snapshot_page` error path.
+- Fresh-price fetch failure at page-enrichment time → `current_price`/
+  `upside_pct` are simply omitted from the response rather than serving a
+  stale value.
+
+## 5. How to invalidate
+
+```bash
+docker compose exec redis redis-cli --scan --pattern "screener_consensus:*"
+# review the keys, then:
+docker compose exec redis redis-cli --scan --pattern "screener_consensus:*" | xargs -n 1 redis-cli DEL
+```
+
+Because the key embeds the KST date, no manual invalidation is normally
+required — entries roll over automatically at the next session-close/midnight
+boundary. Manual invalidation is only useful to force an immediate re-fetch
+(e.g. after a broker data correction) within the same trading day.
+
+## 6. Scope / what did NOT change
+
+- `asyncio.Semaphore(4)` in both `enrich_snapshot_page` and the new
+  `resolve_consensus_counts` resolver is unchanged — Naver was already
+  throttling; this fix reduces request *count*, not concurrency.
+- The consensus fetch limit stays `limit=10` (matches the pre-existing
+  `enrich_snapshot_page` / `_opinion_payload` call) — raising it would change
+  `totalCount` filter semantics and triple cold `company_read.naver` fetches
+  per symbol.
+- `app/services/naver_finance/investor.py` / `parser.py` and the ROB-641
+  precompute stack (`app/services/analyst_consensus_snapshots/**`,
+  `app/jobs/analyst_consensus_snapshots.py`) are untouched.
+- Read-only advisory screener: no broker/order/watch/order-intent mutation
+  on this path.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -105,6 +105,10 @@ def _ensure_test_env() -> None:
     # patch analyze_cache._get_redis_client with a fake explicitly.
     os.environ["ANALYZE_FETCH_CACHE_ENABLED"] = "false"
 
+    # ROB-688: same hermetic guard for the sector-peers cache — never touch a
+    # real Redis from tests; cache tests inject a fake client explicitly.
+    os.environ["NAVER_PEER_CACHE_ENABLED"] = "false"
+
 
 _ensure_test_env()
 

--- a/tests/mcp_server/tooling/test_market_index_current_only.py
+++ b/tests/mcp_server/tooling/test_market_index_current_only.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+import app.mcp_server.tooling.fundamentals._market_index as mkt
+
+pytestmark = [pytest.mark.unit, pytest.mark.asyncio]
+
+
+async def test_current_only_kospi_skips_history_call(monkeypatch):
+    current = AsyncMock(
+        return_value={
+            "symbol": "KOSPI",
+            "name": "코스피",
+            "current": 2450.5,
+            "change": -45.3,
+            "change_pct": -1.82,
+            "open": 2390.0,
+            "source": "naver",
+        }
+    )
+    history = AsyncMock(return_value=[{"date": "2026-02-01", "close": 2450.5}])
+    monkeypatch.setattr(mkt, "_fetch_index_kr_current", current)
+    monkeypatch.setattr(mkt, "_fetch_index_kr_history", history)
+
+    result = await mkt.handle_get_market_index_current_only("KOSPI")
+
+    assert "history" not in result
+    assert result["indices"][0]["current"] == pytest.approx(2450.5)
+    assert result["indices"][0]["data_state"]  # tagged by _tag_kr_index_data_state
+    current.assert_awaited_once()
+    history.assert_not_awaited()  # the wasted history page is never fetched
+
+
+async def test_current_only_preserves_rob464_stale_override(monkeypatch):
+    # change/change_pct == 0 but open != current on a FRESH clock -> ROB-464 marks
+    # the KR index stale and stamps as_of. This must survive the current-only path.
+    current = AsyncMock(
+        return_value={
+            "symbol": "KOSPI",
+            "name": "코스피",
+            "current": 8123.62,
+            "change": 0,
+            "change_pct": 0,
+            "open": 8263.85,
+            "source": "naver",
+        }
+    )
+    monkeypatch.setattr(mkt, "_fetch_index_kr_current", current)
+    monkeypatch.setattr(mkt, "_fetch_index_kr_history", AsyncMock())
+    monkeypatch.setattr(mkt, "kr_market_data_state", lambda *a, **k: "fresh")
+
+    result = await mkt.handle_get_market_index_current_only("KOSPI")
+    row = result["indices"][0]
+
+    assert row["data_state"] == "stale"
+    assert row["data_state_reason"] == mkt._KR_INDEX_LAGGING_REASON
+    assert row["as_of"]  # stamped
+
+
+async def test_current_only_unknown_symbol_raises():
+    with pytest.raises(ValueError):
+        await mkt.handle_get_market_index_current_only("NOPE")
+
+
+async def test_current_only_leaf_failure_returns_error_payload(monkeypatch):
+    monkeypatch.setattr(
+        mkt, "_fetch_index_kr_current", AsyncMock(side_effect=RuntimeError("boom"))
+    )
+    result = await mkt.handle_get_market_index_current_only("KOSPI")
+    assert "error" in result
+
+
+async def test_shared_handler_still_returns_history(monkeypatch):
+    # GUARD (constraint): the shared handle_get_market_index MUST keep fetching
+    # history for its other callers. Task 3 must not touch it.
+    monkeypatch.setattr(
+        mkt,
+        "_fetch_index_kr_current",
+        AsyncMock(return_value={"symbol": "KOSPI", "current": 2450.5, "open": 2390.0}),
+    )
+    history = AsyncMock(return_value=[{"date": "2026-02-01", "close": 2450.5}])
+    monkeypatch.setattr(mkt, "_fetch_index_kr_history", history)
+
+    result = await mkt.handle_get_market_index(symbol="KOSPI", count=1)
+
+    assert "history" in result
+    history.assert_awaited_once()

--- a/tests/mcp_server/tooling/test_screen_stocks_snapshot_docs.py
+++ b/tests/mcp_server/tooling/test_screen_stocks_snapshot_docs.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+def test_screen_stocks_snapshot_description_notes_consensus_cache():
+    from app.mcp_server.tooling.analysis_registration import register_analysis_tools
+
+    class _FakeMCP:
+        def __init__(self):
+            self.descriptions = {}
+
+        def tool(self, *, name, description, **kw):
+            def _d(fn):
+                self.descriptions[name] = description
+                return fn
+
+            return _d
+
+    mcp = _FakeMCP()
+    register_analysis_tools(mcp)
+    desc = mcp.descriptions["screen_stocks_snapshot"].lower()
+    assert "consensus" in desc
+    assert "cache" in desc or "cached" in desc

--- a/tests/mcp_server/tooling/test_toss_live_evidence.py
+++ b/tests/mcp_server/tooling/test_toss_live_evidence.py
@@ -122,3 +122,31 @@ async def test_adapter_fetches_single_order_detail():
     assert evidence.verdict == "filled"
     client.get_order.assert_awaited_once_with("ord-1")
     client.aclose.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_adapter_reuses_injected_client_without_closing():
+    from app.mcp_server.tooling import toss_live_evidence as ev
+
+    class _Row:
+        broker_order_id = "ord-9"
+
+    injected = SimpleNamespace(
+        get_order=AsyncMock(
+            return_value=_order(
+                "FILLED",
+                {"filledQuantity": Decimal("1"), "averageFilledPrice": Decimal("10")},
+            )
+        ),
+        aclose=AsyncMock(),
+    )
+
+    # from_settings must NOT be called when a client is injected.
+    with patch.object(
+        ev.TossReadClient, "from_settings", side_effect=AssertionError("newed a client")
+    ):
+        evidence = await ev.TossEvidenceAdapter(client=injected).fetch_evidence(_Row())
+
+    assert evidence.verdict == "filled"
+    injected.get_order.assert_awaited_once_with("ord-9")
+    injected.aclose.assert_not_awaited()  # caller owns the shared client

--- a/tests/mcp_server/tooling/test_toss_reconcile_account_seq.py
+++ b/tests/mcp_server/tooling/test_toss_reconcile_account_seq.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from decimal import Decimal
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import delete
+
+from app.models.review import TossLiveOrderLedger
+from app.services.brokers.toss.dto import TossOrder
+from app.services.toss_live_order_ledger_service import TossLiveOrderLedgerService
+
+pytestmark = [pytest.mark.unit, pytest.mark.asyncio]
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def _clean(db_session):
+    await db_session.execute(delete(TossLiveOrderLedger))
+    await db_session.commit()
+    yield
+
+
+@pytest.fixture(autouse=True)
+def _patch_session_factory(db_session):
+    from app.mcp_server.tooling import toss_live_ledger
+
+    mock_cm = AsyncMock()
+    mock_cm.__aenter__.return_value = db_session
+    mock_cm.__aexit__.return_value = None
+    with patch.object(
+        toss_live_ledger, "_order_session_factory", return_value=lambda: mock_cm
+    ):
+        yield
+
+
+async def _accepted(db_session, *, cid: str, oid: str):
+    return await TossLiveOrderLedgerService(db_session).record_send(
+        operation_kind="place",
+        market="kr",
+        symbol="034020",
+        side="buy",
+        order_type="limit",
+        time_in_force="DAY",
+        quantity=Decimal("3"),
+        price=Decimal("85000"),
+        order_amount=None,
+        currency="KRW",
+        client_order_id=cid,
+        broker_order_id=oid,
+        original_order_id=None,
+        status="accepted",
+        broker_status=None,
+        response_code="0",
+        response_message=None,
+        raw_response={},
+        thesis="t",
+        strategy="s",
+    )
+
+
+def _pending_order(order_id: str) -> TossOrder:
+    return TossOrder(
+        order_id=order_id,
+        symbol="034020",
+        side="buy",
+        order_type="limit",
+        time_in_force="DAY",
+        status="PENDING",
+        price=Decimal("85000"),
+        quantity=Decimal("3"),
+        order_amount=None,
+        currency="KRW",
+        ordered_at="2026-07-01T00:00:00Z",
+        canceled_at=None,
+        execution={"filledQuantity": Decimal("0")},
+    )
+
+
+async def test_run_uses_one_shared_client_reused_by_batch_and_fallback(db_session):
+    from app.mcp_server.tooling import toss_live_ledger as mod
+
+    await _accepted(db_session, cid="c1", oid="o1")
+    await _accepted(db_session, cid="c2", oid="o2")
+
+    # A single fake client. list_orders raises so batch build fails and the run
+    # MUST fall back per-row AND reuse this exact client (never new one per row).
+    fake_client = SimpleNamespace(
+        list_orders=AsyncMock(side_effect=RuntimeError("force-build-fail")),
+        get_order=AsyncMock(side_effect=lambda oid: _pending_order(oid)),
+        aclose=AsyncMock(),
+    )
+    from_settings = MagicMock(return_value=fake_client)
+
+    with patch.object(mod.TossReadClient, "from_settings", from_settings):
+        out = await mod.toss_reconcile_orders_impl(dry_run=False)
+
+    assert from_settings.call_count == 1  # ONE client for the whole run
+    assert fake_client.get_order.await_count == 2  # both rows via the shared client
+    fake_client.aclose.assert_awaited_once()  # closed exactly once
+    assert out["counts"] == {"pending": 2}

--- a/tests/mcp_server/tooling/test_toss_reconcile_resilience.py
+++ b/tests/mcp_server/tooling/test_toss_reconcile_resilience.py
@@ -251,3 +251,45 @@ async def test_impl_reopen_anomalies_runs_before_list(db_session):
     # work-list, so it was reconciled this same pass (verdict pending here).
     reopened = await db_session.get(TossLiveOrderLedger, bug.id)
     assert reopened.status in {"accepted", "pending"}
+
+
+async def test_batch_build_failure_is_surfaced_and_captured(db_session):
+    from app.mcp_server.tooling import toss_live_ledger as mod
+    from app.mcp_server.tooling.toss_live_evidence import TossFillEvidence
+
+    await _accepted(db_session)
+
+    pending = TossFillEvidence(
+        verdict="pending",
+        local_status="pending",
+        broker_status="PENDING",
+        filled_qty=Decimal("0"),
+        avg_price=None,
+        commission=None,
+        tax=None,
+        fee_total=Decimal("0"),
+        settlement_date=None,
+        raw_order={"status": "PENDING"},
+        reason="pending",
+    )
+
+    class _Adapter:
+        fetch_evidence = AsyncMock(return_value=pending)
+
+    with (
+        patch.object(
+            mod.TossBatchEvidenceSource,
+            "build",
+            new=AsyncMock(side_effect=RuntimeError("boom-build-fails")),
+        ),
+        patch.object(mod, "TossEvidenceAdapter", return_value=_Adapter()),
+        patch.object(mod.sentry_sdk, "capture_exception") as capture,
+    ):
+        out = await mod.toss_reconcile_orders_impl(dry_run=False)
+
+    # fail-open: per-row fallback still reconciles the row
+    assert out["counts"] == {"pending": 1}
+    # observability: the real exception reaches Sentry + is echoed for operators
+    capture.assert_called_once()
+    assert out["batch_build_error"]["type"] == "RuntimeError"
+    assert "boom-build-fails" in out["batch_build_error"]["message"]

--- a/tests/mcp_server/tooling/test_toss_sellable_need_flag.py
+++ b/tests/mcp_server/tooling/test_toss_sellable_need_flag.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from app.mcp_server.tooling import analysis_tool_handlers, portfolio_holdings
+
+pytestmark = [pytest.mark.unit, pytest.mark.asyncio]
+
+
+async def test_build_batch_position_index_requests_no_sellable(monkeypatch):
+    captured: dict[str, Any] = {}
+
+    async def fake_collect(**kwargs):
+        captured.update(kwargs)
+        return [], [], kwargs.get("market"), None
+
+    monkeypatch.setattr(
+        portfolio_holdings, "_collect_portfolio_positions", fake_collect
+    )
+
+    index, err = await analysis_tool_handlers._build_batch_position_index("kr")
+
+    assert err is None
+    assert index == {}
+    # ROB-685: the batch index never reads sellable_quantity.
+    assert captured["need_sellable"] is False
+    assert captured["include_current_price"] is False
+
+
+async def test_collect_portfolio_positions_forwards_need_sellable_to_toss(monkeypatch):
+    calls: list[bool] = []
+
+    async def fake_fetch(*, need_sellable: bool = True):
+        calls.append(need_sellable)
+
+        class _Snap:
+            positions: list[Any] = []
+            errors: list[Any] = []
+
+        return _Snap()
+
+    monkeypatch.setattr(portfolio_holdings.settings, "toss_api_enabled", True)
+    monkeypatch.setattr(portfolio_holdings, "fetch_toss_portfolio_snapshot", fake_fetch)
+
+    # Isolate the sibling collectors — with market=None, _collect_portfolio_positions
+    # otherwise fans out to the REAL _collect_kis_positions / _collect_upbit_positions
+    # (live KIS/Upbit HTTP) and _collect_manual_positions (AsyncSessionLocal DB). That
+    # makes this a slow, non-hermetic test, and _collect_upbit_positions can surface
+    # UpbitSymbolUniverseLookupError, which _collect_portfolio_positions RE-RAISES
+    # (portfolio_holdings.py:857-858) → the test would crash before asserting. Stub
+    # all three to empty so only the toss forwarding path is exercised. They are
+    # module globals resolved at call time, so setattr on the module patches them.
+    async def _empty(*args, **kwargs):
+        return [], []
+
+    monkeypatch.setattr(portfolio_holdings, "_collect_kis_positions", _empty)
+    monkeypatch.setattr(portfolio_holdings, "_collect_upbit_positions", _empty)
+    monkeypatch.setattr(portfolio_holdings, "_collect_manual_positions", _empty)
+
+    # Default path keeps sellable (MCP / sell-classification contract).
+    await portfolio_holdings._collect_portfolio_positions(
+        account=None, market=None, include_current_price=False
+    )
+    # Explicit opt-out threads through.
+    await portfolio_holdings._collect_portfolio_positions(
+        account=None, market=None, include_current_price=False, need_sellable=False
+    )
+
+    assert calls == [True, False]
+
+
+async def test_collect_toss_api_positions_defaults_need_sellable_true(monkeypatch):
+    seen: list[bool] = []
+
+    async def fake_fetch(*, need_sellable: bool = True):
+        seen.append(need_sellable)
+
+        class _Snap:
+            positions: list[Any] = []
+            errors: list[Any] = []
+
+        return _Snap()
+
+    monkeypatch.setattr(portfolio_holdings.settings, "toss_api_enabled", True)
+    monkeypatch.setattr(portfolio_holdings, "fetch_toss_portfolio_snapshot", fake_fetch)
+
+    await portfolio_holdings._collect_toss_api_positions(None)
+    await portfolio_holdings._collect_toss_api_positions(None, need_sellable=False)
+
+    assert seen == [True, False]

--- a/tests/services/brokers/toss/test_client.py
+++ b/tests/services/brokers/toss/test_client.py
@@ -122,6 +122,90 @@ async def test_holdings_auto_resolves_single_account_header() -> None:
 
 
 @pytest.mark.asyncio
+async def test_account_seq_resolved_once_then_cached_across_calls() -> None:
+    accounts_hits = 0
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal accounts_hits
+        if request.url.path == "/api/v1/accounts":
+            accounts_hits += 1
+            return httpx.Response(
+                200,
+                json=_json([{"accountNo": "1", "accountSeq": 7, "accountType": "B"}]),
+                request=request,
+            )
+        # `/api/v1/orders/{id}` (single-order detail) is parsed by `parse_order`,
+        # which requires a FULL flat order row (orderId/symbol/side/orderType/
+        # timeInForce/status/quantity/currency/orderedAt). Returning the list shape
+        # `{"orders": []}` here would raise KeyError('orderId') inside parse_order
+        # (parse_order delegates to parse_orders([raw])) — so branch on the path and
+        # return a valid single-order body. The `/api/v1/orders` LIST path still
+        # returns the `{"orders": []}` page shape parse_orders expects.
+        if request.url.path.startswith("/api/v1/orders/"):
+            return httpx.Response(
+                200,
+                json=_json(
+                    {
+                        "orderId": "ord-1",
+                        "symbol": "034020",
+                        "side": "BUY",
+                        "orderType": "LIMIT",
+                        "timeInForce": "DAY",
+                        "status": "PENDING",
+                        "quantity": "3",
+                        "currency": "KRW",
+                        "orderedAt": "2026-07-01T00:00:00Z",
+                    }
+                ),
+                request=request,
+            )
+        return httpx.Response(200, json=_json({"orders": []}), request=request)
+
+    # account_seq=None → resolution goes through /accounts; the instance caches it.
+    client = TossReadClient(
+        token_manager=_TokenManager(),
+        account_seq=None,
+        transport=httpx.MockTransport(handler),
+    )
+    try:
+        await client.list_orders(status="OPEN")
+        await client.list_orders(status="CLOSED")
+        await client.get_order("ord-1")
+    finally:
+        await client.aclose()
+
+    assert accounts_hits == 1  # ROB-687: one /accounts for the whole client lifetime
+
+
+@pytest.mark.asyncio
+async def test_account_seq_guard_rejects_multiple_accounts() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/v1/accounts":
+            return httpx.Response(
+                200,
+                json=_json(
+                    [
+                        {"accountNo": "1", "accountSeq": 7, "accountType": "B"},
+                        {"accountNo": "2", "accountSeq": 8, "accountType": "B"},
+                    ]
+                ),
+                request=request,
+            )
+        return httpx.Response(200, json=_json({"orders": []}), request=request)
+
+    client = TossReadClient(
+        token_manager=_TokenManager(),
+        account_seq=None,
+        transport=httpx.MockTransport(handler),
+    )
+    try:
+        with pytest.raises(ValueError, match="exactly one account"):
+            await client.list_orders(status="OPEN")
+    finally:
+        await client.aclose()
+
+
+@pytest.mark.asyncio
 async def test_prices_rejects_more_than_200_symbols() -> None:
     client = TossReadClient(
         token_manager=_TokenManager(),

--- a/tests/services/test_analyst_consensus_cache.py
+++ b/tests/services/test_analyst_consensus_cache.py
@@ -1,0 +1,228 @@
+from __future__ import annotations
+
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from app.services.invest_view_model import analyst_consensus_cache as cache
+
+pytestmark = pytest.mark.unit
+
+_KST = ZoneInfo("Asia/Seoul")
+
+
+def test_cache_key_is_kst_dated_and_namespaced():
+    now = datetime(2026, 7, 4, 9, 0, tzinfo=_KST)
+    assert (
+        cache._consensus_cache_key("kr", "005930", now)
+        == "screener_consensus:naver:005930:2026-07-04"
+    )
+
+
+def test_strip_volatile_drops_current_price_and_upside():
+    consensus = {
+        "buy_count": 2,
+        "hold_count": 1,
+        "sell_count": 0,
+        "total_count": 3,
+        "avg_target_price": 78500,
+        "current_price": 69900,
+        "upside_pct": 12.3,
+    }
+    stable = cache._strip_volatile(consensus)
+    assert stable["buy_count"] == 2
+    assert stable["avg_target_price"] == 78500
+    assert "current_price" not in stable
+    assert "upside_pct" not in stable
+
+
+class _FakeRedis:
+    def __init__(self) -> None:
+        self.store: dict[str, str] = {}
+
+    async def get(self, key):
+        return self.store.get(key)
+
+    async def set(self, key, value, ex=None):
+        self.store[key] = value
+
+
+@pytest.mark.asyncio
+async def test_set_then_get_round_trips_stable_fields_only():
+    redis = _FakeRedis()
+    consensus = {
+        "buy_count": 2,
+        "total_count": 3,
+        "avg_target_price": 78500,
+        "current_price": 69900,
+        "upside_pct": 12.3,
+    }
+    await cache.set_cached_consensus(redis, "kr", "005930", consensus)
+    got = await cache.get_cached_consensus(redis, "kr", "005930")
+    assert got is not None
+    assert got["total_count"] == 3
+    assert got["avg_target_price"] == 78500
+    assert "current_price" not in got  # volatile never persisted
+    assert "upside_pct" not in got
+
+
+@pytest.mark.asyncio
+async def test_set_is_noop_for_degraded_or_us_or_no_redis():
+    redis = _FakeRedis()
+    # total_count 0 → degraded, never cached
+    await cache.set_cached_consensus(redis, "kr", "000660", {"total_count": 0})
+    assert await cache.get_cached_consensus(redis, "kr", "000660") is None
+    # US never cached
+    await cache.set_cached_consensus(redis, "us", "AAPL", {"total_count": 5})
+    assert redis.store == {}
+    # redis None → no-op, no raise
+    await cache.set_cached_consensus(None, "kr", "005930", {"total_count": 3})
+
+
+@pytest.mark.asyncio
+async def test_get_fail_open_on_malformed_and_none():
+    assert await cache.get_cached_consensus(None, "kr", "005930") is None
+
+    class _Boom:
+        async def get(self, key):
+            raise RuntimeError("redis down")
+
+    assert await cache.get_cached_consensus(_Boom(), "kr", "005930") is None
+
+
+@pytest.mark.asyncio
+async def test_resolve_consensus_uses_cache_and_skips_live_fetch():
+    redis = _FakeRedis()
+    await cache.set_cached_consensus(
+        redis,
+        "kr",
+        "005930",
+        {"buy_count": 2, "total_count": 3, "avg_target_price": 78500},
+    )
+    calls: list[str] = []
+
+    async def _live(*, symbol, market, limit):
+        calls.append(symbol)
+        return {"consensus": {"total_count": 99}}
+
+    got = await cache.resolve_consensus(
+        symbol="005930", market="kr", redis_client=redis, opinion_fetcher=_live
+    )
+    assert got is not None and got["total_count"] == 3  # from cache, not live 99
+    assert calls == []  # live fetcher never called
+
+
+@pytest.mark.asyncio
+async def test_resolve_consensus_populates_cache_and_memo_on_miss():
+    redis = _FakeRedis()
+    memo: dict = {}
+    calls: list[str] = []
+
+    async def _live(*, symbol, market, limit):
+        calls.append(symbol)
+        return {
+            "consensus": {
+                "buy_count": 1,
+                "total_count": 2,
+                "avg_target_price": 100,
+                "current_price": 90,
+                "upside_pct": 11.1,
+            }
+        }
+
+    got = await cache.resolve_consensus(
+        symbol="000660",
+        market="kr",
+        redis_client=redis,
+        memo=memo,
+        opinion_fetcher=_live,
+    )
+    assert got["total_count"] == 2 and "current_price" not in got  # stable only
+    assert (await cache.get_cached_consensus(redis, "kr", "000660"))["total_count"] == 2
+    # second resolve is served from memo — live fetcher not called again
+    await cache.resolve_consensus(
+        symbol="000660",
+        market="kr",
+        redis_client=redis,
+        memo=memo,
+        opinion_fetcher=_live,
+    )
+    assert calls == ["000660"]
+
+
+@pytest.mark.asyncio
+async def test_resolve_consensus_counts_maps_symbols():
+    redis = _FakeRedis()
+    await cache.set_cached_consensus(
+        redis, "kr", "005930", {"buy_count": 2, "total_count": 3}
+    )
+
+    async def _live(*, symbol, market, limit):
+        return {"consensus": {"buy_count": 5, "total_count": 7}}
+
+    memo: dict = {}
+    counts = await cache.resolve_consensus_counts(
+        symbols=["005930", "000660"],
+        market="kr",
+        redis_client=redis,
+        memo=memo,
+        opinion_fetcher=_live,
+    )
+    assert counts["005930"] == {"totalCount": 3, "buyCount": 2}  # cache
+    assert counts["000660"] == {"totalCount": 7, "buyCount": 5}  # live
+
+
+@pytest.mark.asyncio
+async def test_cached_opinion_provider_recomputes_upside_from_fresh_price():
+    redis = _FakeRedis()
+    await cache.set_cached_consensus(
+        redis,
+        "kr",
+        "005930",
+        {
+            "buy_count": 2,
+            "hold_count": 1,
+            "sell_count": 0,
+            "total_count": 3,
+            "avg_target_price": 110,
+        },
+    )
+
+    async def _price(code):
+        return 100  # fresh price → upside = (110-100)/100*100 = 10.0
+
+    payload = await cache.cached_opinion_provider(
+        symbol="005930",
+        market="kr",
+        redis_client=redis,
+        price_fetcher=_price,
+    )
+    c = payload["consensus"]
+    assert c["current_price"] == 100
+    assert c["upside_pct"] == pytest.approx(10.0)
+    assert c["total_count"] == 3  # daily-stable count preserved
+
+
+@pytest.mark.asyncio
+async def test_cached_opinion_provider_fail_open_when_price_missing():
+    redis = _FakeRedis()
+    await cache.set_cached_consensus(
+        redis,
+        "kr",
+        "005930",
+        {"total_count": 3, "avg_target_price": 110},
+    )
+
+    async def _price(code):
+        return None  # price unavailable → no stale upside served
+
+    payload = await cache.cached_opinion_provider(
+        symbol="005930",
+        market="kr",
+        redis_client=redis,
+        price_fetcher=_price,
+    )
+    c = payload["consensus"]
+    assert c.get("upside_pct") is None
+    assert c.get("current_price") is None

--- a/tests/test_invest_home_readers.py
+++ b/tests/test_invest_home_readers.py
@@ -1520,7 +1520,7 @@ async def test_toss_api_home_reader_maps_read_only_holdings_and_cash(monkeypatch
         TossPortfolioSnapshot,
     )
 
-    async def fake_fetch_toss_snapshot():
+    async def fake_fetch_toss_snapshot(*, need_sellable: bool = True):
         return TossPortfolioSnapshot(
             positions=[
                 TossPortfolioPosition(
@@ -1584,7 +1584,7 @@ async def test_toss_api_home_reader_tradeable_when_mutations_enabled(monkeypatch
         TossPortfolioSnapshot,
     )
 
-    async def fake_fetch_toss_snapshot():
+    async def fake_fetch_toss_snapshot(*, need_sellable: bool = True):
         return TossPortfolioSnapshot(
             positions=[
                 TossPortfolioPosition(
@@ -1632,7 +1632,7 @@ async def test_toss_api_home_reader_converts_us_holdings_to_krw(monkeypatch):
         TossPortfolioSnapshot,
     )
 
-    async def fake_fetch_toss_snapshot():
+    async def fake_fetch_toss_snapshot(*, need_sellable: bool = True):
         return TossPortfolioSnapshot(
             positions=[
                 TossPortfolioPosition(
@@ -1673,6 +1673,38 @@ async def test_toss_api_home_reader_converts_us_holdings_to_krw(monkeypatch):
     assert result.accounts[0].valueKrw == pytest.approx(645.18 * 1300.0)
     assert result.accounts[0].costBasisKrw == pytest.approx(600.0 * 1300.0)
     assert result.accounts[0].pnlKrw == pytest.approx(45.18 * 1300.0)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("mutations,expected_need", [(False, False), (True, True)])
+async def test_toss_api_home_reader_gates_sellable_fetch_on_mutations(
+    monkeypatch, mutations, expected_need
+):
+    from decimal import Decimal
+
+    from app.core.config import settings as _cfg
+    from app.services import invest_home_readers as readers
+    from app.services.toss_portfolio_service import TossPortfolioSnapshot
+
+    captured: dict[str, bool] = {}
+
+    async def fake_fetch_toss_snapshot(*, need_sellable: bool = True):
+        captured["need_sellable"] = need_sellable
+        return TossPortfolioSnapshot(
+            positions=[], cash_krw=Decimal("1"), cash_usd=Decimal("1")
+        )
+
+    monkeypatch.setattr(
+        readers, "fetch_toss_portfolio_snapshot", fake_fetch_toss_snapshot
+    )
+    monkeypatch.setattr(
+        _cfg, "toss_live_order_mutations_enabled", mutations, raising=False
+    )
+
+    await readers.TossApiHomeReader().fetch(user_id=1)
+
+    # ROB-685: mutations off (default) => reader discards sellable anyway => skip fetch.
+    assert captured["need_sellable"] is expected_need
 
 
 @pytest.mark.asyncio

--- a/tests/test_invest_market_parity_service.py
+++ b/tests/test_invest_market_parity_service.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import asyncio
 from datetime import UTC, datetime
 from decimal import Decimal
 from typing import Any
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -163,3 +165,58 @@ async def test_build_market_parity_can_hide_disabled_cards() -> None:
         "stablecoin_fx_premium",
         "crypto_kimchi_premium",
     }
+
+
+class _OverlapProbeProvider(_StubParityProvider):
+    """Proves index-card and kimchi-card run concurrently.
+
+    get_index_quote sets ``index_started`` then blocks on ``kimchi_started``;
+    get_crypto_kimchi_premium sets ``kimchi_started`` then blocks on
+    ``index_started``. Under serial card building the index leg's inner
+    wait_for(1.0) times out (kimchi has not started yet) -> index card 'missing'.
+    Under asyncio.gather both events fire and both resolve -> index card 'fresh'.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.index_started = asyncio.Event()
+        self.kimchi_started = asyncio.Event()
+
+    async def get_index_quote(self, symbol: str) -> ParityQuote | None:
+        self.index_started.set()
+        await asyncio.wait_for(self.kimchi_started.wait(), timeout=1.0)
+        return await super().get_index_quote(symbol)
+
+    async def get_crypto_kimchi_premium(self, symbol: str) -> dict[str, Any] | None:
+        self.kimchi_started.set()
+        await asyncio.wait_for(self.index_started.wait(), timeout=1.0)
+        return await super().get_crypto_kimchi_premium(symbol)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_build_market_parity_builds_cards_concurrently() -> None:
+    response = await build_market_parity(_OverlapProbeProvider())
+    cards = {card.id: card for card in response.cards}
+    # Under serial scheduling the index leg would time out -> 'missing'.
+    assert cards["ewy-kospi-implied-parity"].dataState == "fresh"
+    assert cards["btc-kimchi-premium"].dataState == "fresh"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_default_provider_index_quote_uses_current_only(monkeypatch) -> None:
+    import app.services.invest_view_model.market_parity_service as svc
+
+    called = AsyncMock(
+        return_value={
+            "indices": [{"symbol": "KOSPI", "current": 2450.5, "source": "naver"}]
+        }
+    )
+    monkeypatch.setattr(svc, "handle_get_market_index_current_only", called)
+
+    quote = await svc.DefaultMarketParityProvider().get_index_quote("KOSPI")
+
+    assert quote is not None
+    assert quote.price == Decimal("2450.5")
+    called.assert_awaited_once_with("KOSPI")

--- a/tests/test_mcp_portfolio_tools.py
+++ b/tests/test_mcp_portfolio_tools.py
@@ -3424,7 +3424,7 @@ async def test_get_holdings_toss_api_enabled_adds_read_only_toss_account(monkeyp
     async def fake_collect_manual_positions(*args, **kwargs):
         return [], []
 
-    async def fake_fetch_toss_snapshot():
+    async def fake_fetch_toss_snapshot(*, need_sellable: bool = True):
         return TossPortfolioSnapshot(
             positions=[
                 TossPortfolioPosition(
@@ -3491,7 +3491,7 @@ async def test_get_holdings_toss_api_market_filter_keeps_us_position(monkeypatch
     async def fake_collect_manual_positions(*args, **kwargs):
         return [], []
 
-    async def fake_fetch_toss_snapshot():
+    async def fake_fetch_toss_snapshot(*, need_sellable: bool = True):
         return TossPortfolioSnapshot(
             positions=[
                 TossPortfolioPosition(
@@ -3571,7 +3571,7 @@ async def test_get_holdings_toss_api_success_hides_duplicate_toss_manual(monkeyp
             }
         ], []
 
-    async def fake_fetch_toss_snapshot():
+    async def fake_fetch_toss_snapshot(*, need_sellable: bool = True):
         return TossPortfolioSnapshot(
             positions=[
                 TossPortfolioPosition(
@@ -3646,7 +3646,7 @@ async def test_get_holdings_toss_api_failure_keeps_manual_fallback(monkeypatch):
             }
         ], []
 
-    async def fake_fetch_toss_snapshot():
+    async def fake_fetch_toss_snapshot(*, need_sellable: bool = True):
         raise RuntimeError("toss unavailable")
 
     monkeypatch.setattr(portfolio_holdings.settings, "toss_api_enabled", True)

--- a/tests/test_naver_finance.py
+++ b/tests/test_naver_finance.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from datetime import date, timedelta
 from typing import Any
 from unittest.mock import AsyncMock
@@ -1542,6 +1543,7 @@ class TestFetchSectorPeers:
         async def fake_fetch_integration(
             code: str,
             _client: Any,
+            request_timeout: float | None = None,
         ) -> dict[str, Any]:
             if code == "000001":
                 return {
@@ -1581,3 +1583,299 @@ class TestFetchSectorPeers:
         assert result["sector"] == "반도체"
         assert result["peers"][0]["symbol"] == "000002"
         assert len(sector_gets) == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+class TestFetchSectorPeersConcurrency:
+    async def test_peer_fanout_is_bounded_by_semaphore(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from app.core.config import settings
+
+        monkeypatch.setattr(settings, "naver_peer_fetch_concurrency", 3)
+
+        # Target returns 8 integration peers so, pre-trim, 8 peer fetches queue.
+        peers_raw = [{"itemCode": f"00000{i}"} for i in range(1, 9)]
+
+        in_flight = 0
+        peak = 0
+
+        async def fake_fetch_integration(
+            code: str, _client: Any, *args: Any, **kwargs: Any
+        ) -> dict[str, Any]:
+            nonlocal in_flight, peak
+            if code == "000100":  # target
+                return {
+                    "symbol": code,
+                    "name": "Target",
+                    "per": 10,
+                    "pbr": 1.1,
+                    "market_cap": 1000,
+                    "current_price": 50000,
+                    "change_pct": 1.0,
+                    "industry_code": "123",
+                    "peers_raw": peers_raw,
+                }
+            in_flight += 1
+            peak = max(peak, in_flight)
+            await asyncio.sleep(0.01)  # hold the slot so overlap is observable
+            in_flight -= 1
+            return {
+                "symbol": code,
+                "name": "Peer",
+                "per": 11,
+                "pbr": 1.2,
+                "market_cap": 900,
+                "current_price": 40000,
+                "change_pct": 0.5,
+                "industry_code": "123",
+                "peers_raw": [],
+            }
+
+        class FakeResponse:
+            content = b"<html><head><title>x : Npay</title></head></html>"
+
+        class FakeClient:
+            async def __aenter__(self) -> FakeClient:
+                return self
+
+            async def __aexit__(self, *_a: Any) -> None:
+                return None
+
+            async def get(self, url: str, params: Any = None) -> FakeResponse:
+                return FakeResponse()
+
+        import httpx
+
+        monkeypatch.setattr(httpx, "AsyncClient", lambda **_k: FakeClient())
+        monkeypatch.setattr(
+            naver_finance.valuation, "_fetch_integration", fake_fetch_integration
+        )
+
+        result = await naver_finance.fetch_sector_peers("000100", limit=8)
+
+        assert peak <= 3, f"peak in-flight {peak} exceeded semaphore cap 3"
+        assert len(result["peers"]) == 8
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+class TestFetchSectorPeersPeerTimeout:
+    async def test_peers_use_short_request_timeout_target_uses_default(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from app.core.config import settings
+
+        monkeypatch.setattr(settings, "naver_peer_fetch_timeout_seconds", 5.0)
+        monkeypatch.setattr(settings, "naver_peer_fetch_concurrency", 5)
+
+        # Record the request_timeout each _fetch_integration call receives.
+        seen: dict[str, float | None] = {}
+
+        async def fake_fetch_integration(
+            code: str, _client: Any, request_timeout: float | None = None
+        ) -> dict[str, Any]:
+            seen[code] = request_timeout
+            base = {
+                "symbol": code,
+                "name": code,
+                "per": 10,
+                "pbr": 1.0,
+                "market_cap": 100,
+                "current_price": 1,
+                "change_pct": 0.0,
+                "industry_code": "123",
+                "peers_raw": [],
+            }
+            if code == "000100":
+                base["peers_raw"] = [{"itemCode": "000200"}]
+            return base
+
+        class FakeResponse:
+            content = b"<html><head><title>x : Npay</title></head></html>"
+
+        class FakeClient:
+            async def __aenter__(self) -> FakeClient:
+                return self
+
+            async def __aexit__(self, *_a: Any) -> None:
+                return None
+
+            async def get(self, url: str, params: Any = None) -> FakeResponse:
+                return FakeResponse()
+
+        import httpx
+
+        monkeypatch.setattr(httpx, "AsyncClient", lambda **_k: FakeClient())
+        monkeypatch.setattr(
+            naver_finance.valuation, "_fetch_integration", fake_fetch_integration
+        )
+
+        await naver_finance.fetch_sector_peers("000100", limit=1)
+
+        assert seen["000100"] is None, "target must keep the client-level 10s timeout"
+        assert seen["000200"] == 5.0, "peer must use the short per-request timeout"
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+class TestFetchSectorPeersTrim:
+    async def test_no_overfetch_when_integration_has_enough_peers(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from app.core.config import settings
+
+        monkeypatch.setattr(settings, "naver_peer_fetch_concurrency", 10)
+
+        # Integration returns 8 peers; limit=5 -> should fetch exactly 5, not 10.
+        peers_raw = [{"itemCode": f"90000{i}"} for i in range(1, 9)]
+        fetched_peer_codes: list[str] = []
+
+        async def fake_fetch_integration(
+            code: str, _client: Any, request_timeout: float | None = None
+        ) -> dict[str, Any]:
+            if code != "000100":
+                fetched_peer_codes.append(code)
+            base = {
+                "symbol": code,
+                "name": code,
+                "per": 10,
+                "pbr": 1.0,
+                "market_cap": 100,
+                "current_price": 1,
+                "change_pct": 0.0,
+                "industry_code": "123",
+                "peers_raw": [],
+            }
+            if code == "000100":
+                base["peers_raw"] = peers_raw
+            return base
+
+        sector_gets: list[Any] = []
+
+        class FakeResponse:
+            content = (
+                "<html><head><title>반도체 : Npay 증권</title></head>"
+                "<body><table class='type_5'>"
+                "<tr><td><a href='/item/main.naver?code=777777'>P</a></td></tr>"
+                "</table></body></html>"
+            ).encode("euc-kr")
+
+        class FakeClient:
+            async def __aenter__(self) -> FakeClient:
+                return self
+
+            async def __aexit__(self, *_a: Any) -> None:
+                return None
+
+            async def get(self, url: str, params: Any = None) -> FakeResponse:
+                sector_gets.append((url, params))
+                return FakeResponse()
+
+        import httpx
+
+        monkeypatch.setattr(httpx, "AsyncClient", lambda **_k: FakeClient())
+        monkeypatch.setattr(
+            naver_finance.valuation, "_fetch_integration", fake_fetch_integration
+        )
+
+        result = await naver_finance.fetch_sector_peers("000100", limit=5)
+
+        assert len(fetched_peer_codes) == 5, (
+            f"expected 5 peer fetches, got {len(fetched_peer_codes)}"
+        )
+        # sector name still resolved from the scrape (dual-purpose page)
+        assert result["sector"] == "반도체"
+        # sector page still fetched exactly once (never skipped)
+        assert len(sector_gets) == 1
+        # scrape-derived extra (777777) must NOT appear — integration peers sufficed
+        assert "777777" not in fetched_peer_codes
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+class TestFetchSectorPeersCache:
+    async def test_target_served_from_integration_cache(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import json
+
+        from app.core.config import settings
+        from app.services.naver_finance import peer_cache
+
+        monkeypatch.setattr(settings, "naver_peer_cache_enabled", True)
+        monkeypatch.setattr(settings, "naver_peer_fetch_concurrency", 5)
+
+        class _FakeRedis:
+            def __init__(self) -> None:
+                self.store: dict[str, str] = {}
+
+            async def get(self, key: str) -> str | None:
+                return self.store.get(key)
+
+            async def set(self, key: str, value: str, ex: int | None = None) -> None:
+                self.store[key] = value
+
+        fake = _FakeRedis()
+        fake.store["naver_peer:integ:000100"] = json.dumps(
+            {
+                "symbol": "000100",
+                "name": "CachedTarget",
+                "per": 7,
+                "pbr": 0.9,
+                "market_cap": 500,
+                "current_price": 12345,
+                "change_pct": 2.0,
+                "industry_code": "123",
+                "peers_raw": [{"itemCode": "000200"}],
+            }
+        )
+
+        async def fake_get_client() -> Any:
+            return fake
+
+        monkeypatch.setattr(peer_cache, "_get_redis_client", fake_get_client)
+
+        async def fake_fetch_integration(
+            code: str, _client: Any, request_timeout: float | None = None
+        ) -> dict[str, Any]:
+            if code == "000100":
+                raise AssertionError("target must be served from cache, not fetched")
+            return {
+                "symbol": code,
+                "name": "Peer",
+                "per": 11,
+                "pbr": 1.2,
+                "market_cap": 900,
+                "current_price": 40000,
+                "change_pct": 0.5,
+                "industry_code": "123",
+                "peers_raw": [],
+            }
+
+        class FakeResponse:
+            content = b"<html><head><title>x : Npay</title></head></html>"
+
+        class FakeClient:
+            async def __aenter__(self) -> FakeClient:
+                return self
+
+            async def __aexit__(self, *_a: Any) -> None:
+                return None
+
+            async def get(self, url: str, params: Any = None) -> FakeResponse:
+                return FakeResponse()
+
+        import httpx
+
+        monkeypatch.setattr(httpx, "AsyncClient", lambda **_k: FakeClient())
+        monkeypatch.setattr(
+            naver_finance.valuation, "_fetch_integration", fake_fetch_integration
+        )
+
+        result = await naver_finance.fetch_sector_peers("000100", limit=1)
+
+        assert result["name"] == "CachedTarget"
+        assert result["current_price"] == 12345
+        assert result["peers"][0]["symbol"] == "000200"

--- a/tests/test_naver_peer_cache.py
+++ b/tests/test_naver_peer_cache.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import pytest
+
+from app.services.naver_finance import peer_cache
+
+pytestmark = [pytest.mark.unit, pytest.mark.asyncio]
+
+
+class _FakeRedis:
+    def __init__(self) -> None:
+        self.store: dict[str, str] = {}
+        self.set_calls: list[tuple[str, str, int | None]] = []
+
+    async def get(self, key: str) -> str | None:
+        return self.store.get(key)
+
+    async def set(self, key: str, value: str, ex: int | None = None) -> None:
+        self.store[key] = value
+        self.set_calls.append((key, value, ex))
+
+
+async def test_set_then_get_integration_roundtrips_with_ttl(monkeypatch):
+    from app.core.config import settings
+
+    monkeypatch.setattr(settings, "naver_peer_cache_ttl_seconds", 600)
+    r = _FakeRedis()
+    payload = {"symbol": "006400", "per": 12.3, "market_cap": 999, "peers_raw": []}
+    await peer_cache.set_cached_integration(r, "006400", payload)
+    assert r.set_calls and r.set_calls[0][2] == 600  # TTL applied
+
+    got = await peer_cache.get_cached_integration(r, "006400")
+    assert got == payload
+
+
+async def test_get_with_none_client_returns_none_fail_open():
+    assert await peer_cache.get_cached_integration(None, "006400") is None
+    # set with None client is a no-op (must not raise)
+    await peer_cache.set_cached_integration(None, "006400", {"a": 1})
+
+
+async def test_get_client_returns_none_when_disabled(monkeypatch):
+    from app.core.config import settings
+
+    monkeypatch.setattr(settings, "naver_peer_cache_enabled", False)
+    assert await peer_cache._get_redis_client() is None
+
+
+async def test_malformed_cache_value_returns_none(monkeypatch):
+    r = _FakeRedis()
+    r.store["naver_peer:integ:006400"] = "{not json"
+    assert await peer_cache.get_cached_integration(r, "006400") is None
+
+
+async def test_sector_payload_roundtrips(monkeypatch):
+    r = _FakeRedis()
+    payload = {"sector_name": "반도체", "extra_codes": ["000660", "000990"]}
+    await peer_cache.set_cached_sector(r, "123", payload)
+    assert await peer_cache.get_cached_sector(r, "123") == payload

--- a/tests/test_screener_snapshot_tool.py
+++ b/tests/test_screener_snapshot_tool.py
@@ -201,7 +201,11 @@ async def test_enriches_only_returned_page(monkeypatch) -> None:
     captured: dict[str, Any] = {}
 
     async def _fake_enrich_page(
-        *, rows: list[dict[str, Any]], market: str, session_factory
+        *,
+        rows: list[dict[str, Any]],
+        market: str,
+        session_factory,
+        opinion_provider=None,
     ):
         captured["symbols"] = [row["symbol"] for row in rows]
         captured["market"] = market
@@ -863,6 +867,20 @@ async def test_snapshot_tool_filters_market_cap_and_analyst(monkeypatch) -> None
     )
     assert [r["symbol"] for r in out["results"]] == ["S1"]
 
+    # ROB-686: min_analyst_* now resolves counts via the cache-aside resolver
+    # BEFORE enrichment, so stub resolve_consensus_counts directly (the
+    # _fake_enrich_page consensus stub above is no longer the filter input).
+    async def _fake_counts(*, symbols, market, redis_client=None, memo=None, **kw):
+        return {
+            "S1": {"totalCount": 2, "buyCount": 2},
+            "S2": {"totalCount": 1, "buyCount": 0},
+        }
+
+    monkeypatch.setattr(
+        "app.services.invest_view_model.analyst_consensus_cache.resolve_consensus_counts",
+        _fake_counts,
+    )
+
     # Min analyst buy 1 -> S2 gone
     out = await tool.screen_stocks_snapshot_impl(
         preset="consecutive_gainers", market="kr", min_analyst_buy_count=1
@@ -1017,3 +1035,54 @@ async def test_snapshot_tool_analyst_filter_rejects_large_unpaged_enrichment(
     assert "error" in out
     assert "analyst enrichment row cap" in out["error"]
     assert out["results"] == []
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_min_analyst_filters_via_counts_and_enriches_only_page(
+    monkeypatch,
+) -> None:
+    _patch_build_with_n_results(monkeypatch, 5)  # symbols S0..S4
+
+    async def _fake_counts(*, symbols, market, redis_client=None, memo=None, **kw):
+        # S0,S1,S2 qualify (>=3), S3,S4 do not
+        return {
+            s: {"totalCount": (3 if i < 3 else 1), "buyCount": (2 if i < 3 else 0)}
+            for i, s in enumerate(symbols)
+        }
+
+    monkeypatch.setattr(
+        "app.services.invest_view_model.analyst_consensus_cache.resolve_consensus_counts",
+        _fake_counts,
+    )
+
+    enriched_symbols: list[list[str]] = []
+
+    async def _fake_enrich_page(
+        *, rows, market, session_factory, opinion_provider=None
+    ):
+        enriched_symbols.append([r["symbol"] for r in rows])
+        return {
+            "results": [
+                {**r, "analystLabel": "x", "analysisContext": {}} for r in rows
+            ],
+            "summary": {"attempted": len(rows), "warnings": []},
+        }
+
+    monkeypatch.setattr(
+        "app.services.invest_view_model.screener_analysis_enrichment.enrich_snapshot_page",
+        _fake_enrich_page,
+    )
+
+    out = await tool.screen_stocks_snapshot_impl(
+        preset="consecutive_gainers",
+        market="kr",
+        min_analyst_count=3,
+        limit=2,
+        offset=0,
+    )
+    # 3 qualified, page of 2
+    assert out["pagination"]["total_available"] == 3
+    assert len(out["results"]) == 2
+    # enrichment saw ONLY the 2 returned page rows, not all matched/qualified rows
+    assert enriched_symbols == [["S0", "S1"]]

--- a/tests/test_toss_portfolio_service.py
+++ b/tests/test_toss_portfolio_service.py
@@ -130,6 +130,33 @@ async def test_fetch_toss_portfolio_snapshot_maps_kr_market() -> None:
 
 
 @pytest.mark.asyncio
+async def test_fetch_toss_portfolio_snapshot_skips_sellable_when_not_needed() -> None:
+    client = _FakeTossClient()
+
+    snapshot = await fetch_toss_portfolio_snapshot(client=client, need_sellable=False)
+
+    # ROB-685: the ORDER_INFO N+1 fanout is skipped entirely.
+    assert client.sellable_calls == []
+    assert len(snapshot.positions) == 1
+    assert snapshot.positions[0].sellable_quantity is None
+    # Holdings + cash still resolve normally.
+    assert snapshot.positions[0].symbol == "BRK.B"
+    assert snapshot.cash_krw == Decimal("123456")
+    assert snapshot.errors == []
+
+
+@pytest.mark.asyncio
+async def test_fetch_toss_portfolio_snapshot_default_still_fetches_sellable() -> None:
+    client = _FakeTossClient()
+
+    snapshot = await fetch_toss_portfolio_snapshot(client=client)
+
+    # Default is unchanged: sellable is fetched and mapped.
+    assert client.sellable_calls == ["BRK.B"]
+    assert snapshot.positions[0].sellable_quantity == Decimal("1.25")
+
+
+@pytest.mark.asyncio
 async def test_fetch_toss_cash_snapshot_does_not_fetch_holdings_or_sellable() -> None:
     class Client(_FakeTossClient):
         async def holdings(self) -> TossHoldings:


### PR DESCRIPTION
## Deploy — ROB-685~689 Sentry performance batch (5 PRs)

Ships the Sentry-driven perf batch to production. main is 5 ahead of production; the only content difference is these 5 PRs (verified — no production divergence).

- ROB-685 (#1392) — Toss `sellable_quantity` N+1 skip → home/account-panel/get_holdings/analyze_stock_batch
- ROB-686 (#1396) — Naver analyst-consensus Redis cache + min_analyst filter before pagination
- ROB-688 (#1395) — get_sector_peers bounded fanout + fail-open cache
- ROB-689 (#1398) — market-parity card parallelization + current-only KOSPI fetch
- ROB-687 (#1400) — toss reconcile observability + shared-client fallback (defense-in-depth)

**Safety:** all read-only / perf, no broker/order/watch mutation, **migration 0** (no schema/alembic changes). Each merged to main with CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015NC4CDLK3bbjDuCYxxzEc7
