### PR TITLE
feat(ROB-691): judgment scoreboard + trade-history filters on /insights

### DIFF
--- a/app/routers/invest_retrospectives.py
+++ b/app/routers/invest_retrospectives.py
@@ -1,4 +1,11 @@
-"""FastAPI router for /invest retrospectives read surface (ROB-662)."""
+"""FastAPI router for /invest retrospectives read surface (ROB-662).
+
+ROB-691 adds trade-history filters to the list endpoint (win/loss/decided,
+symbol prefix search, KST date range) and a `/scoreboard` read endpoint that
+mirrors the existing deterministic `build_retrospective_aggregate` (win-rate /
+realized-PnL / win-loss). The service is not touched beyond additive query
+params — this router only adds a totals rollup on top of its per-group output.
+"""
 
 from __future__ import annotations
 
@@ -17,12 +24,18 @@ from app.schemas.invest_retrospectives import (
     NextActionsResponse,
     RetrospectiveRow,
     RetrospectivesResponse,
+    ScoreboardGroupRow,
+    ScoreboardResponse,
+    ScoreboardTotals,
 )
 from app.schemas.trade_retrospective import (
     VALID_ROOT_CAUSE_CLASSES,
     VALID_TRIGGER_TYPES,
 )
 from app.services.trade_journal import trade_retrospective_service as retro_svc
+from app.services.trade_journal.trade_retrospective_service import (
+    VALID_OUTCOME_FILTERS,
+)
 
 router = APIRouter(
     prefix="/trading/api/invest/retrospectives",
@@ -31,12 +44,29 @@ router = APIRouter(
 
 Market = Literal["all", "kr", "us", "crypto"]
 
+_VALID_SCOREBOARD_GROUP_BY = frozenset(
+    {"strategy", "day", "trigger_type", "root_cause"}
+)
+
 
 def _normalize_symbol(symbol: str | None, market: Market) -> str | None:
     if not symbol:
         return None
     sym = symbol.strip()
     return to_db_symbol(sym) if market == "us" else sym.upper()
+
+
+def _parse_kst_date(label: str, value: str | None) -> str | None:
+    """Validate a `YYYY-MM-DD` KST-calendar-date query param, 422 on malformed input."""
+    if value is None:
+        return None
+    try:
+        datetime.strptime(value, "%Y-%m-%d")
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=422, detail=f"invalid {label}: {value} (expected YYYY-MM-DD)"
+        ) from exc
+    return value
 
 
 @router.get("")
@@ -47,6 +77,10 @@ async def list_retrospectives(
     trigger_type: Annotated[str | None, Query()] = None,
     root_cause_class: Annotated[str | None, Query()] = None,
     symbol: Annotated[str | None, Query()] = None,
+    outcome_filter: Annotated[str | None, Query()] = None,
+    q: Annotated[str | None, Query(max_length=32)] = None,
+    kst_date_from: Annotated[str | None, Query()] = None,
+    kst_date_to: Annotated[str | None, Query()] = None,
     days: Annotated[int | None, Query(ge=1)] = None,
     limit: Annotated[int, Query(ge=1, le=200)] = 50,
     offset: Annotated[int, Query(ge=0)] = 0,
@@ -62,6 +96,12 @@ async def list_retrospectives(
         raise HTTPException(
             status_code=422, detail=f"invalid root_cause_class: {root_cause_class}"
         )
+    if outcome_filter is not None and outcome_filter not in VALID_OUTCOME_FILTERS:
+        raise HTTPException(
+            status_code=422, detail=f"invalid outcome_filter: {outcome_filter}"
+        )
+    date_from = _parse_kst_date("kst_date_from", kst_date_from)
+    date_to = _parse_kst_date("kst_date_to", kst_date_to)
     db_symbol = _normalize_symbol(symbol, market)
     result = await retro_svc.get_retrospectives(
         db,
@@ -69,6 +109,10 @@ async def list_retrospectives(
         trigger_type=trigger_type,
         root_cause_class=root_cause_class,
         symbol=db_symbol,
+        outcome_filter=outcome_filter,
+        symbol_search=q,
+        kst_date_from=date_from,
+        kst_date_to=date_to,
         days=days,
         limit=limit,
         offset=offset,
@@ -79,9 +123,83 @@ async def list_retrospectives(
         trigger_type=trigger_type,
         root_cause_class=root_cause_class,
         symbol=db_symbol,
+        outcome_filter=outcome_filter,
+        q=q,
+        kst_date_from=date_from,
+        kst_date_to=date_to,
         count=summary["count"],
         total=summary["total"],
         items=[RetrospectiveRow(**e) for e in result["entries"]],
+        as_of=datetime.now(UTC),
+    )
+
+
+@router.get("/scoreboard")
+async def get_retrospective_scoreboard(
+    _user: Annotated[User, Depends(get_authenticated_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
+    group_by: Annotated[str, Query()] = "strategy",
+    market: Annotated[Market, Query()] = "all",
+    account_mode: Annotated[str | None, Query()] = None,
+    strategy_key: Annotated[str | None, Query()] = None,
+    kst_date_from: Annotated[str | None, Query()] = None,
+    kst_date_to: Annotated[str | None, Query()] = None,
+) -> ScoreboardResponse:
+    """Judgment scoreboard: win-rate / realized-PnL / win-loss.
+
+    Thin read wrapper over `build_retrospective_aggregate` (no new business
+    logic in the service) plus a router-side totals rollup across groups. Per
+    plan §3.4/§4 the headline `totals` are only meaningful for the PnL-oriented
+    groupings (strategy/day) — trigger_type/root_cause include no-fill-evidence
+    rows (`include_no_evidence`) and dilute the win/loss meaning, so callers
+    that want the headline tile should request `group_by=strategy`.
+    """
+    if group_by not in _VALID_SCOREBOARD_GROUP_BY:
+        raise HTTPException(status_code=422, detail=f"invalid group_by: {group_by}")
+    date_from = _parse_kst_date("kst_date_from", kst_date_from)
+    date_to = _parse_kst_date("kst_date_to", kst_date_to)
+    result = await retro_svc.build_retrospective_aggregate(
+        db,
+        kst_date_from=date_from,
+        kst_date_to=date_to,
+        account_mode=account_mode,
+        market=None if market == "all" else market,
+        strategy_key=strategy_key,
+        group_by=group_by,
+    )
+    groups = result["groups"]
+
+    total_sample_size = sum(g["sample_size"] for g in groups)
+    total_wins = sum(g["wins"] for g in groups)
+    total_misses = sum(g["misses"] for g in groups)
+    decided = total_wins + total_misses
+    win_rate_pct = (total_wins / decided * 100.0) if decided else None
+    realized_pnl_sum: dict[str, float] = {}
+    for g in groups:
+        for currency, amount in g["realized_pnl_sum"].items():
+            realized_pnl_sum[currency] = realized_pnl_sum.get(currency, 0.0) + amount
+    fx_pnl_krw_sum = sum(g["fx_pnl_krw_sum"] for g in groups)
+    total_pnl_krw_sum = sum(g["total_pnl_krw_sum"] for g in groups)
+
+    totals = ScoreboardTotals(
+        sample_size=total_sample_size,
+        wins=total_wins,
+        misses=total_misses,
+        decided=decided,
+        win_rate_pct=win_rate_pct,
+        realized_pnl_sum=realized_pnl_sum,
+        fx_pnl_krw_sum=fx_pnl_krw_sum,
+        total_pnl_krw_sum=total_pnl_krw_sum,
+        excluded_no_fill_evidence=result["excluded_no_fill_evidence"],
+    )
+    return ScoreboardResponse(
+        group_by=result["group_by"],
+        market=market,
+        kst_date_from=date_from,
+        kst_date_to=date_to,
+        count=len(groups),
+        groups=[ScoreboardGroupRow(**g) for g in groups],
+        totals=totals,
         as_of=datetime.now(UTC),
     )
 

--- a/app/schemas/invest_retrospectives.py
+++ b/app/schemas/invest_retrospectives.py
@@ -41,9 +41,63 @@ class RetrospectivesResponse(BaseModel):
     trigger_type: str | None = None
     root_cause_class: str | None = None
     symbol: str | None = None
+    # ROB-691 — trade-history filters (echoed so the client can confirm what
+    # was actually applied).
+    outcome_filter: str | None = None
+    q: str | None = None
+    kst_date_from: str | None = None
+    kst_date_to: str | None = None
     count: int = Field(ge=0)
     total: int = Field(ge=0)
     items: list[RetrospectiveRow]
+    as_of: datetime
+
+
+# ROB-691 — judgment scoreboard (win-rate / realized-PnL / win-loss), mirroring
+# build_retrospective_aggregate's group dict field-for-field (extra="ignore":
+# the service returns a superset the aggregate already computes; we keep a
+# stable subset here).
+class ScoreboardGroupRow(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    group: str
+    sample_size: int = Field(ge=0)
+    wins: int = Field(ge=0)
+    misses: int = Field(ge=0)
+    win_rate_pct: float | None = None
+    avg_pnl_pct: float | None = None
+    realized_pnl_sum: dict[str, float] = Field(default_factory=dict)
+    fx_pnl_krw_sum: float = 0.0
+    total_pnl_krw_sum: float = 0.0
+    by_outcome: dict[str, int] = Field(default_factory=dict)
+    by_trigger_type: dict[str, int] = Field(default_factory=dict)
+    by_root_cause_class: dict[str, int] = Field(default_factory=dict)
+
+
+class ScoreboardTotals(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    sample_size: int = Field(ge=0)
+    wins: int = Field(ge=0)
+    misses: int = Field(ge=0)
+    decided: int = Field(ge=0)
+    win_rate_pct: float | None = None
+    realized_pnl_sum: dict[str, float] = Field(default_factory=dict)
+    fx_pnl_krw_sum: float = 0.0
+    total_pnl_krw_sum: float = 0.0
+    excluded_no_fill_evidence: int = Field(ge=0)
+
+
+class ScoreboardResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    group_by: str
+    market: Literal["all", "kr", "us", "crypto"]
+    kst_date_from: str | None = None
+    kst_date_to: str | None = None
+    count: int = Field(ge=0)
+    groups: list[ScoreboardGroupRow]
+    totals: ScoreboardTotals
     as_of: datetime
 
 

--- a/app/services/trade_journal/trade_retrospective_service.py
+++ b/app/services/trade_journal/trade_retrospective_service.py
@@ -13,8 +13,9 @@ from typing import Any
 from zoneinfo import ZoneInfo
 
 from pydantic import ValidationError
-from sqlalchemy import func, select, text
+from sqlalchemy import and_, func, or_, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.sql.elements import ColumnElement
 
 from app.core.symbol import to_db_symbol
 from app.core.timezone import now_kst
@@ -469,6 +470,10 @@ async def get_retrospectives(
     days: int | None = None,
     trigger_type: str | None = None,
     root_cause_class: str | None = None,
+    outcome_filter: str | None = None,
+    symbol_search: str | None = None,
+    kst_date_from: str | None = None,
+    kst_date_to: str | None = None,
     limit: int = 50,
     offset: int = 0,
 ) -> dict[str, Any]:
@@ -487,6 +492,29 @@ async def get_retrospectives(
         filters.append(TradeRetrospective.trigger_type == trigger_type)
     if root_cause_class is not None:
         filters.append(TradeRetrospective.root_cause_class == root_cause_class)
+    if symbol_search is not None and symbol_search.strip():
+        filters.append(
+            TradeRetrospective.symbol.ilike(_prefix_like(symbol_search), escape="\\")
+        )
+    # kst_date_from/to reuse the same `_kst_day_start`/`_kst_day_end` KST
+    # calendar-day helpers as build_retrospective_aggregate (§ plan 3.3/4) —
+    # do not reimplement the day-boundary math here.
+    if kst_date_from is not None:
+        filters.append(TradeRetrospective.created_at >= _kst_day_start(kst_date_from))
+    if kst_date_to is not None:
+        filters.append(TradeRetrospective.created_at <= _kst_day_end(kst_date_to))
+    if outcome_filter is not None:
+        if outcome_filter == "win":
+            filters.append(_sql_is_win())
+        elif outcome_filter == "loss":
+            filters.append(_sql_is_loss())
+        elif outcome_filter == "decided":
+            filters.append(_sql_is_decided())
+        else:
+            raise RetrospectiveValidationError(
+                f"invalid outcome_filter: {outcome_filter} "
+                f"(allowed: {sorted(VALID_OUTCOME_FILTERS)})"
+            )
     if days is not None:
         filters.append(
             TradeRetrospective.created_at >= now_kst() - timedelta(days=days)
@@ -609,6 +637,76 @@ def _is_win(r: TradeRetrospective) -> bool:
 
 def _is_decided(r: TradeRetrospective) -> bool:
     return r.realized_pnl is not None or r.pnl_pct is not None
+
+
+# ROB-691 — SQL-side mirrors of `_is_win`/`_is_decided` above, used by
+# get_retrospectives' `outcome_filter` query param. MUST be kept in lock-step
+# with the Python predicates (same tie=0-is-a-loss rule, same pnl_pct
+# fallback-only-when-realized_pnl-is-NULL semantics); see the parallel
+# equivalence test in tests/test_trade_retrospective_aggregate.py
+# (test_outcome_filter_matches_python_predicate) that guards against drift.
+VALID_OUTCOME_FILTERS: frozenset[str] = frozenset({"win", "loss", "decided"})
+
+
+def _sql_is_decided() -> ColumnElement[bool]:
+    """SQL predicate mirroring `_is_decided` — keep in lock-step."""
+    return or_(
+        TradeRetrospective.realized_pnl.isnot(None),
+        TradeRetrospective.pnl_pct.isnot(None),
+    )
+
+
+def _sql_is_win() -> ColumnElement[bool]:
+    """SQL predicate mirroring `_is_win` — keep in lock-step.
+
+    `_is_win`: if realized_pnl is not None -> realized_pnl > 0 (strict; a tie
+    at 0 is NOT a win); else -> pnl_pct is not None and pnl_pct > 0.
+    """
+    return or_(
+        TradeRetrospective.realized_pnl > 0,
+        and_(
+            TradeRetrospective.realized_pnl.is_(None),
+            TradeRetrospective.pnl_pct > 0,
+        ),
+    )
+
+
+def _sql_is_loss() -> ColumnElement[bool]:
+    """SQL predicate = decided AND NOT win, spelled out explicitly (rather
+    than `and_(_sql_is_decided(), not_(_sql_is_win()))`) to avoid SQL's
+    three-valued NULL logic silently mis-classifying NULL columns as "unknown"
+    instead of following the Python if/else short-circuit. Keep in lock-step
+    with `_is_win`/`_is_decided`.
+    """
+    return or_(
+        and_(
+            TradeRetrospective.realized_pnl.isnot(None),
+            TradeRetrospective.realized_pnl <= 0,
+        ),
+        and_(
+            TradeRetrospective.realized_pnl.is_(None),
+            TradeRetrospective.pnl_pct.isnot(None),
+            TradeRetrospective.pnl_pct <= 0,
+        ),
+    )
+
+
+def _prefix_like(raw: str) -> str:
+    """Prefix-match token for `Column.ilike(..., escape="\\\\")`.
+
+    Symbols are stored upper-cased (see `_normalize_symbol`), so the search
+    token is upper-cased too. `%`/`_` are LIKE wildcards — escape them so a
+    literal search token (e.g. a symbol containing `_`) does not accidentally
+    widen the match.
+    """
+    escaped = (
+        raw.strip()
+        .upper()
+        .replace("\\", "\\\\")
+        .replace("%", "\\%")
+        .replace("_", "\\_")
+    )
+    return f"{escaped}%"
 
 
 async def build_retrospective_aggregate(

--- a/docs/plans/ROB-691-judgment-scoreboard-plan.md
+++ b/docs/plans/ROB-691-judgment-scoreboard-plan.md
@@ -1,0 +1,331 @@
+# ROB-691 — 판단 성적표(승률·실현손익·승패) 웹 노출 + 거래이력 필터
+
+판단 성적표(승률·실현손익·승패)를 웹에 표면화하고, 거래(회고) 이력에
+**승패 / 심볼검색 / 날짜범위** 필터를 추가한다. 결정론 집계·거래이력 로직은
+이미 존재하므로 새 비즈 로직은 최소화하고, 대부분 **read 라우터 확장 + 프런트**
+작업이다. Migration 0 (read-only).
+
+---
+
+## 1) 목표
+
+- 이미 존재하는 결정론 집계 `build_retrospective_aggregate`(승률·승/패·통화별 실현손익
+  ·by_outcome/by_trigger_type/by_root_cause)를 MCP 전용에서 **FastAPI read 엔드포인트**로
+  미러링하여 `/invest/insights` 웹에 "판단 성적표" 타일로 노출.
+- 회고 이력 리스트(`GET /trading/api/invest/retrospectives`)에 **승패 필터·심볼 prefix
+  검색·KST 날짜범위(from/to)** 필터를 추가 (기존엔 부재).
+- 의미 라벨을 명확히: auto_trader 승패는 **실 체결 + PnL 증거 기반**(무증거·rejected·
+  cancelled 제외)이라 self-declared보다 강하나 표본이 적다 → UI에 "체결·증거 기반" 명시.
+- 브로커/주문/워치 mutation 도달 금지. 기존 invest read 라우터 auth 패턴 준수.
+
+---
+
+## 2) 검증된 현재 상태 (file:line, 교정 포함)
+
+### 결정론 집계 서비스 — `app/services/trade_journal/trade_retrospective_service.py`
+- **교정**: 이슈는 `~604-711`로 표기했으나 실제:
+  - `_is_win(r)` = **604-607** — `realized_pnl is not None → realized_pnl > 0`, 아니면
+    `pnl_pct is not None and pnl_pct > 0`.
+  - `_is_decided(r)` = **610-611** — `realized_pnl is not None or pnl_pct is not None`.
+  - `build_retrospective_aggregate(...)` def = **614-713** (본문 끝 713).
+- `kst_date_from/to` 파라미터 지원 확인: 시그니처 **617-618**, 적용 **637-640**
+  (`_kst_day_start`/`_kst_day_end` = **447-454**, `_KST = ZoneInfo("Asia/Seoul")` line 54).
+- 그룹 dict 반환 필드(692-706): `group, sample_size, wins, misses,
+  win_rate_pct(=wins/decided*100 | None), avg_pnl_pct, realized_pnl_sum(통화별 dict),
+  fx_pnl_krw_sum, total_pnl_krw_sum, by_outcome, by_trigger_type, by_root_cause_class`.
+- 최상위 반환(709-713): `{group_by, groups(sample_size desc 정렬), excluded_no_fill_evidence}`.
+- **중요한 설계 사실**: 반환은 **그룹별**이고 **전체 롤업(totals)은 없음**. 헤드라인 타일
+  1개를 그리려면 그룹 합산이 필요 (§3, §4에서 라우터 롤업으로 해결 — 서비스 무수정).
+- `include_no_evidence`(629): `group_by ∈ {trigger_type, root_cause}` 일 때만 무증거 행 포함
+  → 이 두 그룹핑의 win_rate/decided 의미는 희석됨. 헤드라인은 strategy/day 그룹핑 고정.
+- `_is_win`은 `>0`만 승 → **동점(0)은 패로 분류** (decided이지만 win 아님). UI/필터 문구 반영.
+
+### 리스트 서비스 — `get_retrospectives(...)` = **461-513**
+- 현재 필터: `symbol`(strip().upper() **정확일치**, 476-477), `account_mode`, `strategy_key`,
+  `market`, `correlation_id`, `days`(상대일수), `trigger_type`, `root_cause_class`,
+  `limit`, `offset`. **부재 확인**: `kst_date_from/to`(절대 날짜범위) 없음, **승패 필터** 없음,
+  **심볼 prefix/LIKE** 없음(정확일치만). → §4에서 확장.
+
+### MCP 전용 노출 (FastAPI 라우터 부재 재확인)
+- `get_retrospective_aggregate(...)` = `app/mcp_server/tooling/trade_retrospective_tools.py`
+  **164-194** (오늘 default로 from/to 채움). `app/routers/` 전체 grep 결과 aggregate/win_rate
+  라우터 **없음** → 신규 노출 필요. ✔
+
+### 미러 대상 read 라우터 패턴 — `app/routers/invest_forecasts.py` (전체 1-131)
+- prefix `/trading/api/invest/forecasts`, `/calibration`(집계) + `/open` + `/closed`(리스트)가
+  **한 파일에** 공존. 각 핸들러: `Depends(get_authenticated_user)` + `Depends(get_db)`,
+  잘못된 enum → `HTTPException(422)`, 응답 스키마 `model_config=extra="forbid"`,
+  `as_of=datetime.now(UTC)`. **→ 스코어보드도 별도 파일이 아니라 기존 retrospectives 라우터에
+  `/scoreboard`로 붙이는 것이 동형(교정: 이슈의 "새 라우터 파일"보다 기존 확장이 정합).**
+
+### 거래이력 라우터
+- `app/routers/invest_fills.py` **24-59**: `recent`/`by-symbol`/`sell-history`/`freshness`;
+  필터 `market/side/days/limit`뿐. 승패·심볼검색·from/to **부재**. (이번 스코프 밖 — 회고 이력에 집중.)
+- `app/routers/invest_retrospectives.py` **42-114**: `GET ""`(list) 필터
+  `market/trigger_type/root_cause_class/symbol(정확)/days/limit/offset`; `GET /next-actions`.
+  `_normalize_symbol`(35-39) US는 `to_db_symbol`, 그 외 upper. 승패·심볼검색·from/to **부재** 확인.
+
+### 프런트
+- `frontend/invest/src/pages/desktop/DesktopInsightsPage.tsx` — Section "판단 품질"(154-160)에
+  `<ForecastCalibrationPanel/>`, "학습·회고"(162-167)에 `<RetrospectivesPanel/>`.
+- `frontend/invest/src/pages/mobile/MobileInsightsPage.tsx` — 데스크톱과 **1:1 미러**(파일 헤더
+  주석대로 의도적 중복). 172-190에 동일 두 패널. **양쪽 lockstep 수정 필요.**
+- `frontend/invest/src/pages/desktop/DesktopPortfolioPage.tsx` — 탭 UI, `retrospectives` 탭
+  (163-164)에서 `<RetrospectivesPanel/>` 재사용. `portfolioTabs.ts`에 탭 목록.
+- `components/insights/ForecastCalibrationPanel.tsx` — **타일/표 스타일 참조원**: 칩 토글
+  (그룹/일수), 표 정렬, `Pill`(gain/loss/paper/warn), 소표본 가드(`SMALL_SAMPLE=5`), `CalibrationBar`,
+  `LoadState<T>` 패턴, `Section`/`Card`.
+- `components/my/RetrospectivesPanel.tsx` — 회고 리스트; 시장 칩(14-19) + 트리거 칩(21-32)
+  이미 존재. **여기에 승패/심볼검색/날짜범위 필터 추가** → /insights·/my 양쪽에 이득.
+- `components/my/SellHistoryPanel.tsx` — **교정**: 통화별 합은 `profitByCurrency` **107-124**,
+  `totalByCurrency` **97-105**. 통화별 dict→행 렌더 패턴 참조 (실현손익 통화별 타일에 재사용).
+- API/타입: `api/retrospectives.ts`(+`RetrospectivesQuery`), `types/retrospectives.ts`,
+  `api/forecasts.ts`(집계 fetch 참조), `types/forecasts.ts`.
+
+### auth / 테스트 관례
+- `app/routers/dependencies.py` `get_authenticated_user`(35-39) → 미인증 시 401 `"로그인이 필요합니다."`.
+- 라우터 등록: `app/main.py` 37-40 import, 197-201 `include_router`. 신규 없이 기존 확장이면 등록 무변경.
+- 라우터 테스트 관례: `tests/routers/test_invest_retrospectives_router.py` — `monkeypatch`로 서비스
+  함수 대체 + `app.dependency_overrides`로 auth/db 스텁, 파라미터 forwarding·422·401 검증.
+- 서비스 통합 테스트 관례: `tests/test_trade_retrospective_aggregate.py` — `svc.save_retrospective`로
+  시드 후 집계 검증(`@pytest.mark.integration`, cleanup fixture).
+- 모델: `app/models/review.py` `TradeRetrospective` — `symbol`(Text,1024), `market`(Text|None,1031),
+  `account_mode`(Text,1030), `outcome`(Text,1033), `realized_pnl`(Numeric,1036),
+  `realized_pnl_currency`(Text,1037), `pnl_pct`(Numeric,1039), `fill_evidence_available`(Bool,1050),
+  `created_at`(1069). 승패 SQL predicate를 이 컬럼들로 표현 가능.
+
+---
+
+## 3) 설계 결정
+
+### 3.1 타일 위치 — **/insights "판단 품질" 섹션** (ForecastCalibrationPanel 위)
+근거:
+- 지표의 본질이 **결정된(decided) 회고의 승률**로, 판단 품질(judgment quality)이다. 이미
+  /insights "판단 품질"에 있는 `ForecastCalibrationPanel`(예측 신뢰도)과 형제 지표.
+- /insights는 이미 "예측 판단 품질·회고"를 프레이밍하고 `RetrospectivesPanel`을 "학습·회고"로
+  호스팅 → 성적표는 그 위 헤드라인으로 자연스럽게 얹힘.
+- **실현손익의 포트폴리오 성격 반론 처리**: 여기서의 실현손익은 개별 보유 평가액이 아니라 "결정된
+  회고들의 통화별 실현손익 합계" = *내 판단이 얼마나 벌었나*의 스코어카드 스탯이다. 라이브 포트폴리오
+  상태(/my 보유 현황)와 의미가 다르므로 /insights가 정합. `total_pnl_krw_sum`도 있으면 보조 표기.
+- 결정: **1차 홈 = /insights** (신규 `JudgmentScoreboardPanel`). /my 회고 탭에는 성적표 타일을
+  중복 배치하지 않는다(스코프 절제). 단, **회고 리스트 필터 개선은 `RetrospectivesPanel`에 넣어**
+  /insights·/my 양쪽이 자동으로 이득을 본다.
+- 데스크톱·모바일 InsightsPage는 1:1 미러이므로 **양쪽 lockstep**으로 패널 삽입.
+
+### 3.2 의미 라벨 — "체결·증거 기반"
+- 패널 타이틀 "판단 성적표", 서브텍스트:
+  "체결·증거 기반 — 실제 체결과 PnL 증거가 있는 회고만 집계합니다(무증거·거부·취소 제외).
+  자기신고보다 강하지만 표본이 적을 수 있습니다."
+- `excluded_no_fill_evidence` 카운트를 muted 각주로 표기("증거 부족 N건 제외").
+- 소표본(decided < 5) 시 `ForecastCalibrationPanel`과 동일하게 `Pill tone="warn"` "소표본" 경고.
+- 동점(0) = 패 규칙(`_is_win`은 `>0`) 문구화: 승률 정의를 "실현손익 > 0 기준"으로 표기.
+
+### 3.3 필터 구현
+- **승패 필터** = `_is_win`/`_is_decided` 재사용을 **SQL WHERE**로 번역(서비스 `get_retrospectives`에
+  `outcome_filter: "win"|"loss"|"decided"` 추가). Python predicate와 병렬 유지(주석 cross-ref + 병렬
+  테스트로 drift 방지):
+  - `decided`: `realized_pnl IS NOT NULL OR pnl_pct IS NOT NULL`
+  - `win`: `realized_pnl > 0 OR (realized_pnl IS NULL AND pnl_pct > 0)`
+  - `loss`: decided AND NOT win
+    `= (realized_pnl IS NOT NULL AND realized_pnl <= 0) OR (realized_pnl IS NULL AND pnl_pct IS NOT NULL AND pnl_pct <= 0)`
+  - SQLAlchemy `and_/or_`로 구성. **정합성 함정**: 정확히 `_is_win`/`_is_decided`와 동일 경계여야 함.
+- **심볼검색** = prefix(ILIKE) — 기존 `symbol`(정확일치)은 보존하고 신규 `q` 파라미터로 분리:
+  서비스 `symbol_search: str | None` → `TradeRetrospective.symbol.ilike(f"{q.strip().upper()}%")`
+  (심볼은 upper 저장). LIKE 와일드카드는 escape. US 대시/슬래시 정규화는 prefix엔 미적용(사용자가 접두만 입력).
+- **날짜범위(from/to)** = 서비스가 이미 가진 `_kst_day_start/_kst_day_end`를 `get_retrospectives`에
+  `kst_date_from/kst_date_to`로 노출(집계 서비스와 동일 시맨틱). 라우터에서 `YYYY-MM-DD` 형식 검증(422).
+  기존 `days`와 공존 시 둘 다 AND 적용(문서화).
+
+### 3.4 스코어보드 엔드포인트 배치 — **기존 라우터 확장** (신규 파일 X)
+- `invest_forecasts.py`가 `/calibration`+`/open`+`/closed`를 한 파일에 두듯, 회고 집계는 회고 관심사이므로
+  `app/routers/invest_retrospectives.py`에 `GET /scoreboard` 추가. `main.py` 등록 무변경.
+- (대안: 신규 `invest_scoreboard.py` — 채택 안 함, 응집도·등록비용 이유. 필요 시 손쉽게 분리 가능.)
+
+---
+
+## 4) 단계별 구현 (API 스키마 포함)
+
+### Step 1 — 서비스 `get_retrospectives` 필터 확장 (`trade_retrospective_service.py`)
+시그니처에 추가: `outcome_filter: str | None = None`, `symbol_search: str | None = None`,
+`kst_date_from: str | None = None`, `kst_date_to: str | None = None`.
+- 필터 절 추가(기존 `filters` 리스트에):
+  - `symbol_search` → `filters.append(TradeRetrospective.symbol.ilike(_prefix_like(symbol_search)))`
+    (`_prefix_like`는 `%_` escape 후 `f"{s.strip().upper()}%"`).
+  - `kst_date_from/to` → `_kst_day_start/_kst_day_end` 재사용(집계와 동일).
+  - `outcome_filter` → §3.3 SQL predicate. `_is_win`/`_is_decided` 바로 위/옆에 SQL 헬퍼
+    `_sql_is_win()`/`_sql_is_decided()`를 정의하고 주석으로 "keep in lock-step with `_is_win`/`_is_decided`".
+- 반환 dict·정렬 무변경. `total`/`count`는 필터 반영된 값으로 자연 계산됨(기존 로직 재사용).
+
+### Step 2 — 라우터 확장 (`app/routers/invest_retrospectives.py`)
+
+**2a. 기존 `GET ""` 리스트에 필터 추가**
+```python
+outcome_filter: Annotated[str | None, Query()] = None,   # "win" | "loss" | "decided"
+q: Annotated[str | None, Query(max_length=32)] = None,    # 심볼 prefix 검색
+kst_date_from: Annotated[str | None, Query()] = None,     # YYYY-MM-DD (KST)
+kst_date_to: Annotated[str | None, Query()] = None,
+```
+- 검증: `outcome_filter not in {None,"win","loss","decided"}` → 422;
+  날짜는 `_parse_kst_date`(라우터 로컬, `datetime.strptime(..,"%Y-%m-%d")` 실패 시 422).
+- 서비스로 forward. `symbol`(정확)과 `q`(prefix)는 공존 가능(둘 다 AND).
+- `RetrospectivesResponse`(`extra="forbid"`)에 echo 필드 추가: `outcome_filter/q/kst_date_from/kst_date_to`
+  (schema에 optional 필드 추가).
+
+**2b. 신규 `GET /scoreboard`**
+```python
+@router.get("/scoreboard")
+async def get_retrospective_scoreboard(
+    _user, db,
+    group_by: Annotated[str, Query()] = "strategy",   # strategy|day|trigger_type|root_cause
+    market: Annotated[Market, Query()] = "all",
+    account_mode: Annotated[str | None, Query()] = None,
+    strategy_key: Annotated[str | None, Query()] = None,
+    kst_date_from: Annotated[str | None, Query()] = None,
+    kst_date_to: Annotated[str | None, Query()] = None,
+) -> ScoreboardResponse:
+```
+- `group_by not in {"strategy","day","trigger_type","root_cause"}` → 422. 날짜 형식 검증(422).
+- `retro_svc.build_retrospective_aggregate(db, group_by=..., market=None if all, ...)` 호출.
+- **totals 롤업**을 라우터에서 순수 계산**(서비스 무수정, 결정론)**:
+  `total_wins=Σg.wins`, `total_misses=Σg.misses`, `decided=wins+misses`,
+  `win_rate_pct=wins/decided*100 | None`, `realized_pnl_sum`=통화별 merge,
+  `fx_pnl_krw_sum/total_pnl_krw_sum/sample_size` 합, `excluded_no_fill_evidence` 그대로.
+- **정합성 주의**: totals의 승률 의미가 명확하려면 group_by는 strategy/day(PnL 지향)여야 함.
+  헤드라인 타일용 요청은 프런트가 항상 `group_by=strategy`로 보내고, 브레이크다운 토글은 별도 요청.
+  응답에 `group_by`를 echo해 프런트가 인지.
+
+**2c. 스키마** (`app/schemas/invest_retrospectives.py`에 추가, `extra` 규칙 기존 관례 준수)
+```python
+class ScoreboardGroupRow(BaseModel):
+    model_config = ConfigDict(extra="ignore")   # 집계 group dict 전체 주입, 부분 유지
+    group: str
+    sample_size: int = Field(ge=0)
+    wins: int = Field(ge=0)
+    misses: int = Field(ge=0)
+    win_rate_pct: float | None = None
+    avg_pnl_pct: float | None = None
+    realized_pnl_sum: dict[str, float] = Field(default_factory=dict)
+    fx_pnl_krw_sum: float = 0.0
+    total_pnl_krw_sum: float = 0.0
+    by_outcome: dict[str, int] = Field(default_factory=dict)
+    by_trigger_type: dict[str, int] = Field(default_factory=dict)
+    by_root_cause_class: dict[str, int] = Field(default_factory=dict)
+
+class ScoreboardTotals(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    sample_size: int = Field(ge=0)
+    wins: int = Field(ge=0)
+    misses: int = Field(ge=0)
+    decided: int = Field(ge=0)
+    win_rate_pct: float | None = None
+    realized_pnl_sum: dict[str, float] = Field(default_factory=dict)
+    fx_pnl_krw_sum: float = 0.0
+    total_pnl_krw_sum: float = 0.0
+    excluded_no_fill_evidence: int = Field(ge=0)
+
+class ScoreboardResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    group_by: str
+    market: Literal["all","kr","us","crypto"]
+    kst_date_from: str | None = None
+    kst_date_to: str | None = None
+    count: int = Field(ge=0)
+    groups: list[ScoreboardGroupRow]
+    totals: ScoreboardTotals
+    as_of: datetime
+```
+- `RetrospectivesResponse`에 `outcome_filter/q/kst_date_from/kst_date_to` optional 추가.
+
+### Step 3 — 프런트 API/타입
+- `frontend/invest/src/types/scoreboard.ts` (신규): `ScoreboardGroupRow`, `ScoreboardTotals`,
+  `ScoreboardResponse`, `ScoreboardGroupBy = "strategy"|"day"|"trigger_type"|"root_cause"`.
+- `frontend/invest/src/api/scoreboard.ts` (신규): `fetchScoreboard({groupBy,market,accountMode,
+  strategyKey,dateFrom,dateTo})` → `/trading/api/invest/retrospectives/scoreboard`,
+  `credentials:"include"`, non-ok throw (기존 api 관례).
+- `api/retrospectives.ts` `RetrospectivesQuery`/`fetchRetrospectives` 확장:
+  `outcomeFilter?, q?, dateFrom?, dateTo?` → 쿼리스트링 `outcome_filter/q/kst_date_from/kst_date_to`.
+  `types/retrospectives.ts` `RetrospectivesResponse`에 echo 필드 추가.
+
+### Step 4 — `JudgmentScoreboardPanel.tsx` (신규, `components/insights/`)
+- `ForecastCalibrationPanel` 스타일 차용: `Card` + `Section` + `Pill` + `LoadState<T>` + 칩 토글.
+- 상단 **헤드라인 타일 4개**(항상 `group_by=strategy` 요청의 `totals`):
+  ① 승률(`win_rate_pct`, "결정 N건 중") ② 승/패(`wins`/`misses`, gain/loss Pill)
+  ③ 결정 표본(`decided`) + 증거부족 제외 각주 ④ 실현손익 통화별(`realized_pnl_sum` dict→행,
+  `SellHistoryPanel.profitByCurrency` 렌더 패턴 참조, `+`/부호·`toLocaleString`).
+- 컨트롤: 날짜범위(from/to `<input type="date">` 또는 30/90/전체 프리셋), 시장 칩(all/kr/us/crypto).
+- 하단 **브레이크다운 표**: group_by 토글(전략/일자/트리거/원인) → `fetchScoreboard(groupBy)` 그룹 행
+  (그룹·표본·승/패·승률·통화별 실현손익). trigger_type/root_cause 선택 시 "무증거 포함, 승률 참고용"
+  안내 배지.
+- 소표본·빈 상태·에러: 캘리브레이션 패널과 동일 UX. `onEmptyChange?` 콜백으로 페이지 누적 배너 연동.
+
+### Step 5 — 페이지 배선 (데스크톱 + 모바일 lockstep)
+- `DesktopInsightsPage.tsx` "판단 품질" Section(154-160): `<ForecastCalibrationPanel/>` **위**에
+  `<JudgmentScoreboardPanel onEmptyChange={setScoreboardEmpty}/>` 삽입. `allDataEmpty` 계산에 포함.
+- `MobileInsightsPage.tsx` 동일 위치(172-180)에 `compact`로 삽입(1:1 미러 유지; 헤더 주석 규칙 준수).
+
+### Step 6 — `RetrospectivesPanel.tsx` 필터 확장 (/insights·/my 공용)
+- 신규 컨트롤: **승패 칩**(전체/승/패/결정), **심볼검색 입력**(`q`, debounce), **날짜범위**(from/to).
+- `fetchRetrospectives`에 `outcomeFilter/q/dateFrom/dateTo` 전달. 기존 시장·트리거 칩과 공존.
+- compact 모드(모바일/홈)에서는 심볼검색·날짜범위 숨김(트리거 칩처럼 `!compact` 게이트) — 밀도 유지.
+
+---
+
+## 5) 테스트 계획
+
+### 백엔드 — 라우터 단위 (`tests/routers/test_invest_retrospectives_router.py` 확장)
+- `/scoreboard`: 파라미터 forwarding(group_by/market→None if all/date), `build_retrospective_aggregate`
+  monkeypatch로 그룹 fixture 주입 → **totals 롤업 정확성**(통화별 merge·승률) 검증.
+- `/scoreboard` 422: invalid group_by, invalid 날짜 형식.
+- `/scoreboard` 401: unauth 클라이언트.
+- 리스트 필터: `outcome_filter/q/kst_date_from/kst_date_to`가 `get_retrospectives`로 forward됨,
+  invalid `outcome_filter`·날짜 → 422, echo 필드 응답 확인.
+
+### 백엔드 — 서비스 통합 (`tests/test_trade_retrospective_aggregate.py` 또는 신규 list 테스트)
+- `save_retrospective`로 win(pnl>0)/loss(pnl<=0, 0 포함)/무증거/pnl_pct-only 시드.
+- `outcome_filter="win"|"loss"|"decided"` 각각 정확한 행 반환.
+- **병렬성 테스트**: 시드셋에서 `outcome_filter` SQL 결과 == Python `[r for r in rows if _is_win/_is_decided]`
+  (drift 가드, 0-동점 경계 포함).
+- `symbol_search` prefix ILIKE 매칭, `kst_date_from/to` 경계(일 시작/끝 포함) 검증.
+
+### 프런트 — vitest (`__tests__/`)
+- `scoreboard.api.test.ts`: `fetchScoreboard`가 쿼리스트링 정확 구성.
+- `retrospectives.api` 확장: 신규 필터 파라미터 매핑.
+- `JudgmentScoreboardPanel.test.tsx`: mock totals→타일 렌더(승률·승/패·통화별 실현손익), 소표본 경고,
+  빈/에러 상태.
+- `RetrospectivesPanel` 필터: 승패/심볼/날짜 입력 시 fetch 쿼리 반영.
+
+### 정적 가드
+- `make lint` / `make typecheck` / `uv run pytest tests/routers/test_invest_retrospectives_router.py`
+- `no_internal_llm_imports` 등 기존 가드 무영향(신규 provider import 없음).
+
+---
+
+## 6) 마이그레이션 노트 (0)
+
+- **Migration 0**. 스키마 변경 없음 — 신규 쿼리 파라미터 + 라우터 롤업 + 프런트뿐.
+- DB 접근은 전부 `SELECT`(기존 `get_retrospectives`/`build_retrospective_aggregate` 재사용, 신규 WHERE 절만).
+- **Mutation 도달 없음 확인**: 라우터는 read 서비스 함수만 호출, 서비스는 broker/order/watch/order-intent
+  코드 경로에 도달하지 않음(순수 `TradeRetrospective` SELECT). /insights 페이지의 `ReadOnlyGuardrailNote`
+  가드레일과 정합.
+- auth: 신규/확장 엔드포인트 모두 `Depends(get_authenticated_user)` → 미인증 401.
+
+---
+
+## 7) 리스크 · 스코프 밖
+
+**리스크**
+- **승패 SQL vs Python `_is_win` drift** (가장 큰 정합성 함정): 동점(0)=패, `pnl_pct` fallback,
+  NULL 처리가 정확히 일치해야 함 → §5 병렬 테스트 + 코드 cross-ref 주석으로 방지.
+- **totals 의미 희석**: `group_by ∈ {trigger_type,root_cause}`는 무증거 행 포함(`include_no_evidence`)
+  → 헤드라인 totals는 항상 strategy/day 그룹핑으로 요청(프런트 고정), 브레이크다운은 참고용 배지.
+- **표본 희소**: decided 회고가 적으면 승률 변동 큼 → 소표본 경고 UX로 완화.
+- **다통화 실현손익**: 단일 숫자로 환산하지 않고 통화별 dict 유지(FX 환산은 별도 `total_pnl_krw_sum`
+  존재 시만). 프런트가 통화별 행으로 표시.
+- **데스크톱/모바일 InsightsPage 중복**: 패널 삽입을 lockstep으로 하지 않으면 드리프트 → 두 파일 동시 수정.
+
+**스코프 밖**
+- 회고 작성/채점(save_retrospective, forecast_resolve) 등 write 경로.
+- fills(`invest_fills.py`) 이력의 승패/검색/날짜 필터(별도 이슈로 분리; 이번은 회고 이력에 집중).
+- 종목별 스코어보드 드릴다운, 신규 집계 차원(side별 등), CSV/export.
+- /my 회고 탭에 성적표 타일 중복 배치(1차 홈은 /insights).
+- 모바일 UX 재설계(데스크톱 미러 파리티까지만).

--- a/frontend/invest/src/__tests__/DesktopInsightsPage.test.tsx
+++ b/frontend/invest/src/__tests__/DesktopInsightsPage.test.tsx
@@ -131,7 +131,15 @@ test("shows the accumulating banner when all three data panels are empty (ROB-67
   const fetchMock = vi.fn(async (url: string) => {
     const u = String(url);
     let body: unknown = {};
-    if (u.includes("/calibration")) {
+    // ROB-691: /scoreboard must be checked before the generic "retrospectives"
+    // substring match below, since its URL also contains "retrospectives".
+    if (u.includes("/scoreboard")) {
+      body = {
+        group_by: "strategy", market: "all", kst_date_from: null, kst_date_to: null,
+        count: 0, groups: [], as_of: "2026-07-03T00:00:00Z",
+        totals: { sample_size: 0, wins: 0, misses: 0, decided: 0, win_rate_pct: null, realized_pnl_sum: {}, fx_pnl_krw_sum: 0, total_pnl_krw_sum: 0, excluded_no_fill_evidence: 0 },
+      };
+    } else if (u.includes("/calibration")) {
       body = { group_by: "created_by", created_by: null, symbol: null, instrument_type: null, days: null, count: 0, groups: [], as_of: "2026-07-03T00:00:00Z" };
     } else if (u.includes("/forecasts/open") || u.includes("/forecasts/closed")) {
       body = { kind: "open", symbol: null, created_by: null, instrument_type: null, count: 0, items: [], as_of: "2026-07-03T00:00:00Z" };
@@ -190,7 +198,15 @@ function buildCrosslinkFetchMock(retroSymbol: string) {
   return vi.fn(async (url: string) => {
     const u = String(url);
     let body: unknown = {};
-    if (u.includes("/calibration")) {
+    // ROB-691: /scoreboard must be checked before the generic "retrospectives"
+    // substring match below, since its URL also contains "retrospectives".
+    if (u.includes("/scoreboard")) {
+      body = {
+        group_by: "strategy", market: "all", kst_date_from: null, kst_date_to: null,
+        count: 0, groups: [], as_of: "2026-07-03T00:00:00Z",
+        totals: { sample_size: 0, wins: 0, misses: 0, decided: 0, win_rate_pct: null, realized_pnl_sum: {}, fx_pnl_krw_sum: 0, total_pnl_krw_sum: 0, excluded_no_fill_evidence: 0 },
+      };
+    } else if (u.includes("/calibration")) {
       body = { group_by: "created_by", created_by: null, symbol: null, instrument_type: null, days: null, count: 0, groups: [], as_of: "2026-07-03T00:00:00Z" };
     } else if (u.includes("/forecasts/open")) {
       body = { kind: "open", symbol: null, created_by: null, instrument_type: null, count: 0, items: [], as_of: "2026-07-03T00:00:00Z" };

--- a/frontend/invest/src/__tests__/JudgmentScoreboardPanel.test.tsx
+++ b/frontend/invest/src/__tests__/JudgmentScoreboardPanel.test.tsx
@@ -1,0 +1,147 @@
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { afterEach, expect, test, vi } from "vitest";
+import { JudgmentScoreboardPanel } from "../components/insights/JudgmentScoreboardPanel";
+import type { ScoreboardResponse } from "../types/scoreboard";
+
+const strategyResponse: ScoreboardResponse = {
+  group_by: "strategy",
+  market: "all",
+  kst_date_from: "2026-04-06",
+  kst_date_to: "2026-07-04",
+  count: 2,
+  as_of: "2026-07-04T00:00:00Z",
+  groups: [
+    {
+      group: "A", sample_size: 3, wins: 2, misses: 1, win_rate_pct: 66.7,
+      avg_pnl_pct: 1.1, realized_pnl_sum: { KRW: 50000 }, fx_pnl_krw_sum: 0,
+      total_pnl_krw_sum: 50000, by_outcome: {}, by_trigger_type: {}, by_root_cause_class: {},
+    },
+    {
+      group: "B", sample_size: 1, wins: 1, misses: 0, win_rate_pct: 100.0,
+      avg_pnl_pct: 2.0, realized_pnl_sum: { USD: 10 }, fx_pnl_krw_sum: 0,
+      total_pnl_krw_sum: 0, by_outcome: {}, by_trigger_type: {}, by_root_cause_class: {},
+    },
+  ],
+  totals: {
+    sample_size: 4, wins: 3, misses: 1, decided: 4, win_rate_pct: 75.0,
+    realized_pnl_sum: { KRW: 50000, USD: 10 }, fx_pnl_krw_sum: 0,
+    total_pnl_krw_sum: 50000, excluded_no_fill_evidence: 2,
+  },
+};
+
+const dayResponse: ScoreboardResponse = {
+  ...strategyResponse,
+  group_by: "day",
+  groups: [
+    {
+      group: "2026-07-04", sample_size: 4, wins: 3, misses: 1, win_rate_pct: 75.0,
+      avg_pnl_pct: 1.3, realized_pnl_sum: { KRW: 50000, USD: 10 }, fx_pnl_krw_sum: 0,
+      total_pnl_krw_sum: 50000, by_outcome: {}, by_trigger_type: {}, by_root_cause_class: {},
+    },
+  ],
+};
+
+const emptyResponse: ScoreboardResponse = {
+  group_by: "strategy", market: "all", kst_date_from: null, kst_date_to: null,
+  count: 0, as_of: "2026-07-04T00:00:00Z", groups: [],
+  totals: {
+    sample_size: 0, wins: 0, misses: 0, decided: 0, win_rate_pct: null,
+    realized_pnl_sum: {}, fx_pnl_krw_sum: 0, total_pnl_krw_sum: 0,
+    excluded_no_fill_evidence: 0,
+  },
+};
+
+afterEach(() => vi.unstubAllGlobals());
+
+test("renders headline totals + strategy breakdown", async () => {
+  const fetchMock = vi.fn((url: string) => {
+    const u = String(url);
+    const body = u.includes("group_by=day") ? dayResponse : strategyResponse;
+    return Promise.resolve({ ok: true, json: async () => body });
+  });
+  vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+  render(<JudgmentScoreboardPanel />);
+
+  // headline tiles (from totals, always group_by=strategy)
+  await waitFor(() => expect(screen.getByText("75.0%")).toBeInTheDocument());
+  const headline = within(screen.getByTestId("scoreboard-headline"));
+  expect(headline.getByText(/결정 4건 중/)).toBeInTheDocument();
+  expect(headline.getByText(/3승/)).toBeInTheDocument();
+  expect(headline.getByText(/1패/)).toBeInTheDocument();
+  expect(headline.getByText(/증거 부족 2건 제외/)).toBeInTheDocument();
+
+  // breakdown table (default group_by=strategy) shows both groups
+  const breakdown = within(screen.getByTestId("scoreboard-breakdown"));
+  expect(breakdown.getByText("A")).toBeInTheDocument();
+  expect(breakdown.getByText("B")).toBeInTheDocument();
+});
+
+test("group_by toggle refetches the breakdown with the new grouping", async () => {
+  const calls: string[] = [];
+  const fetchMock = vi.fn((url: string) => {
+    const u = String(url);
+    calls.push(u);
+    const body = u.includes("group_by=day") ? dayResponse : strategyResponse;
+    return Promise.resolve({ ok: true, json: async () => body });
+  });
+  vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+  render(<JudgmentScoreboardPanel />);
+  await waitFor(() => expect(screen.getByText("A")).toBeInTheDocument());
+
+  fireEvent.click(screen.getByRole("button", { name: "일자" }));
+  await waitFor(() => expect(screen.getByText("2026-07-04")).toBeInTheDocument());
+  expect(calls.some((u) => u.includes("group_by=day"))).toBe(true);
+});
+
+test("market chip refetches both headline and breakdown", async () => {
+  const calls: string[] = [];
+  const fetchMock = vi.fn((url: string) => {
+    const u = String(url);
+    calls.push(u);
+    const body = u.includes("group_by=day") ? dayResponse : strategyResponse;
+    return Promise.resolve({ ok: true, json: async () => body });
+  });
+  vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+  render(<JudgmentScoreboardPanel />);
+  await waitFor(() => expect(screen.getByText("A")).toBeInTheDocument());
+
+  fireEvent.click(screen.getByRole("button", { name: "국내" }));
+  await waitFor(() =>
+    expect(calls.some((u) => u.includes("market=kr"))).toBe(true),
+  );
+});
+
+test("small decided sample shows a warning pill", async () => {
+  const small: ScoreboardResponse = {
+    ...strategyResponse,
+    totals: { ...strategyResponse.totals, decided: 3, wins: 2, misses: 1 },
+  };
+  const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => small });
+  vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+  render(<JudgmentScoreboardPanel />);
+  await waitFor(() => {
+    const headline = within(screen.getByTestId("scoreboard-headline"));
+    expect(headline.getByText(/소표본/)).toBeInTheDocument();
+  });
+});
+
+test("empty totals reports emptiness via onEmptyChange", async () => {
+  const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => emptyResponse });
+  vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+  const onEmptyChange = vi.fn();
+
+  render(<JudgmentScoreboardPanel onEmptyChange={onEmptyChange} />);
+  await waitFor(() => expect(onEmptyChange).toHaveBeenCalledWith(true));
+});
+
+test("fetch error surfaces an error message", async () => {
+  const fetchMock = vi.fn().mockResolvedValue({ ok: false, status: 500 });
+  vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+  render(<JudgmentScoreboardPanel />);
+  await waitFor(() => expect(screen.getAllByRole("alert").length).toBeGreaterThan(0));
+});

--- a/frontend/invest/src/__tests__/RetrospectivesPanel.test.tsx
+++ b/frontend/invest/src/__tests__/RetrospectivesPanel.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { afterEach, expect, test, vi } from "vitest";
 import { RetrospectivesPanel } from "../components/my/RetrospectivesPanel";
@@ -6,6 +6,7 @@ import type { NextActionsResponse, RetrospectivesResponse } from "../types/retro
 
 const list: RetrospectivesResponse = {
   market: "all", trigger_type: null, root_cause_class: null, symbol: null,
+  outcome_filter: null, q: null, kst_date_from: null, kst_date_to: null,
   count: 1, total: 1, as_of: "2026-07-01T00:00:00Z",
   items: [{
     id: 1, correlation_id: "c", symbol: "005930", market: "kr",
@@ -73,4 +74,110 @@ test("retrospective crosslinks to its forecast by symbol key (ROB-682)", async (
   const link = await screen.findByRole("link", { name: "예측↑" });
   expect(link).toHaveAttribute("href", "#forecast-kr-005930");
   expect(document.getElementById("retro-kr-005930")).not.toBeNull();
+});
+
+test("outcome chip refetches with outcome_filter (ROB-691)", async () => {
+  const calls: string[] = [];
+  const fetchMock = vi.fn((url: string) => {
+    calls.push(String(url));
+    return Promise.resolve({
+      ok: true,
+      json: async () => (String(url).includes("next-actions") ? na : list),
+    });
+  });
+  vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+  render(
+    <MemoryRouter>
+      <RetrospectivesPanel />
+    </MemoryRouter>,
+  );
+  await waitFor(() => expect(screen.getByText(/분할 매수가 유효했다/)).toBeInTheDocument());
+
+  fireEvent.click(screen.getByRole("button", { name: "승" }));
+  await waitFor(() =>
+    expect(calls.some((u) => u.includes("outcome_filter=win"))).toBe(true),
+  );
+});
+
+test("symbol search input refetches with q (debounced, ROB-691)", async () => {
+  const calls: string[] = [];
+  const fetchMock = vi.fn((url: string) => {
+    calls.push(String(url));
+    return Promise.resolve({
+      ok: true,
+      json: async () => (String(url).includes("next-actions") ? na : list),
+    });
+  });
+  vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+  render(
+    <MemoryRouter>
+      <RetrospectivesPanel />
+    </MemoryRouter>,
+  );
+  await waitFor(() => expect(screen.getByText(/분할 매수가 유효했다/)).toBeInTheDocument());
+
+  fireEvent.change(screen.getByPlaceholderText("종목 검색"), {
+    target: { value: "005" },
+  });
+  await waitFor(() => expect(calls.some((u) => u.includes("q=005"))).toBe(true), {
+    timeout: 2000,
+  });
+});
+
+test("date range inputs refetch with kst_date_from/to (ROB-691)", async () => {
+  const calls: string[] = [];
+  const fetchMock = vi.fn((url: string) => {
+    calls.push(String(url));
+    return Promise.resolve({
+      ok: true,
+      json: async () => (String(url).includes("next-actions") ? na : list),
+    });
+  });
+  vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+  render(
+    <MemoryRouter>
+      <RetrospectivesPanel />
+    </MemoryRouter>,
+  );
+  await waitFor(() => expect(screen.getByText(/분할 매수가 유효했다/)).toBeInTheDocument());
+
+  fireEvent.change(screen.getByLabelText("시작일"), {
+    target: { value: "2026-07-01" },
+  });
+  fireEvent.change(screen.getByLabelText("종료일"), {
+    target: { value: "2026-07-04" },
+  });
+  await waitFor(() =>
+    expect(
+      calls.some(
+        (u) => u.includes("kst_date_from=2026-07-01") && u.includes("kst_date_to=2026-07-04"),
+      ),
+    ).toBe(true),
+  );
+});
+
+test("compact mode hides symbol search and date range controls", async () => {
+  const fetchMock = vi.fn((url: string) =>
+    Promise.resolve({
+      ok: true,
+      json: async () => (String(url).includes("next-actions") ? na : list),
+    }),
+  );
+  vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+  render(
+    <MemoryRouter>
+      <RetrospectivesPanel compact />
+    </MemoryRouter>,
+  );
+  await waitFor(() => expect(screen.getByText(/분할 매수가 유효했다/)).toBeInTheDocument());
+
+  expect(screen.queryByPlaceholderText("종목 검색")).not.toBeInTheDocument();
+  expect(screen.queryByLabelText("시작일")).not.toBeInTheDocument();
+  expect(screen.queryByLabelText("종료일")).not.toBeInTheDocument();
+  // outcome chips remain visible even in compact mode (small footprint, like market chips)
+  expect(screen.getByRole("button", { name: "승" })).toBeInTheDocument();
 });

--- a/frontend/invest/src/__tests__/retrospectives.api.test.ts
+++ b/frontend/invest/src/__tests__/retrospectives.api.test.ts
@@ -4,6 +4,7 @@ import type { NextActionsResponse, RetrospectivesResponse } from "../types/retro
 
 const listResponse: RetrospectivesResponse = {
   market: "kr", trigger_type: null, root_cause_class: null, symbol: null,
+  outcome_filter: null, q: null, kst_date_from: null, kst_date_to: null,
   count: 0, total: 0, items: [], as_of: "2026-07-01T00:00:00Z",
 };
 const naResponse: NextActionsResponse = {
@@ -33,6 +34,22 @@ test("fetchRetrospectives sends filters + pagination with credentials", async ()
   expect(params.get("symbol")).toBe("AAPL");
   expect(params.get("limit")).toBe("10");
   expect(params.get("offset")).toBe("20");
+});
+
+test("fetchRetrospectives sends outcome/symbol-search/date-range filters (ROB-691)", async () => {
+  const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => listResponse });
+  vi.stubGlobal("fetch", fetchMock);
+
+  await fetchRetrospectives({
+    outcomeFilter: "win", q: "005", dateFrom: "2026-07-01", dateTo: "2026-07-04",
+  });
+
+  const [url] = fetchMock.mock.calls[0]!;
+  const params = new URLSearchParams(String(url).split("?")[1]);
+  expect(params.get("outcome_filter")).toBe("win");
+  expect(params.get("q")).toBe("005");
+  expect(params.get("kst_date_from")).toBe("2026-07-01");
+  expect(params.get("kst_date_to")).toBe("2026-07-04");
 });
 
 test("fetchOpenNextActions hits next-actions with scope", async () => {

--- a/frontend/invest/src/api/retrospectives.ts
+++ b/frontend/invest/src/api/retrospectives.ts
@@ -1,6 +1,7 @@
 import type {
   NextActionsResponse,
   RetroMarket,
+  RetroOutcomeFilter,
   RetrospectivesResponse,
 } from "../types/retrospectives";
 
@@ -11,6 +12,10 @@ export interface RetrospectivesQuery {
   triggerType?: string;
   rootCauseClass?: string;
   symbol?: string;
+  outcomeFilter?: RetroOutcomeFilter;
+  q?: string;
+  dateFrom?: string;
+  dateTo?: string;
   days?: number;
   limit?: number;
   offset?: number;
@@ -23,6 +28,10 @@ export async function fetchRetrospectives(
   if (q.triggerType) params.set("trigger_type", q.triggerType);
   if (q.rootCauseClass) params.set("root_cause_class", q.rootCauseClass);
   if (q.symbol) params.set("symbol", q.symbol);
+  if (q.outcomeFilter) params.set("outcome_filter", q.outcomeFilter);
+  if (q.q) params.set("q", q.q);
+  if (q.dateFrom) params.set("kst_date_from", q.dateFrom);
+  if (q.dateTo) params.set("kst_date_to", q.dateTo);
   if (q.days != null) params.set("days", String(q.days));
   if (q.limit != null) params.set("limit", String(q.limit));
   if (q.offset != null) params.set("offset", String(q.offset));

--- a/frontend/invest/src/api/scoreboard.ts
+++ b/frontend/invest/src/api/scoreboard.ts
@@ -1,0 +1,30 @@
+import type { ScoreboardGroupBy, ScoreboardResponse } from "../types/scoreboard";
+
+const BASE = "/trading/api/invest/retrospectives/scoreboard";
+
+export interface ScoreboardQuery {
+  groupBy?: ScoreboardGroupBy;
+  market?: "all" | "kr" | "us" | "crypto";
+  accountMode?: string;
+  strategyKey?: string;
+  dateFrom?: string;
+  dateTo?: string;
+}
+
+export async function fetchScoreboard(
+  q: ScoreboardQuery = {},
+): Promise<ScoreboardResponse> {
+  const params = new URLSearchParams();
+  if (q.groupBy) params.set("group_by", q.groupBy);
+  if (q.market) params.set("market", q.market);
+  if (q.accountMode) params.set("account_mode", q.accountMode);
+  if (q.strategyKey) params.set("strategy_key", q.strategyKey);
+  if (q.dateFrom) params.set("kst_date_from", q.dateFrom);
+  if (q.dateTo) params.set("kst_date_to", q.dateTo);
+  const qs = params.toString();
+  const res = await fetch(`${BASE}${qs ? `?${qs}` : ""}`, {
+    credentials: "include",
+  });
+  if (!res.ok) throw new Error(`scoreboard ${res.status}`);
+  return res.json();
+}

--- a/frontend/invest/src/components/insights/JudgmentScoreboardPanel.tsx
+++ b/frontend/invest/src/components/insights/JudgmentScoreboardPanel.tsx
@@ -1,0 +1,392 @@
+// ROB-691 — judgment scoreboard (win-rate / realized-PnL / win-loss), the
+// existing deterministic `build_retrospective_aggregate` surfaced on the web
+// via GET /trading/api/invest/retrospectives/scoreboard. Style mirrors
+// ForecastCalibrationPanel (Card + Section + Pill + chip toggles + LoadState).
+import { useEffect, useState } from "react";
+
+import { fetchScoreboard } from "../../api/scoreboard";
+import { Card, Pill } from "../../ds";
+import type {
+  ScoreboardGroupBy,
+  ScoreboardGroupRow,
+  ScoreboardTotals,
+} from "../../types/scoreboard";
+
+type ScoreboardMarket = "all" | "kr" | "us" | "crypto";
+
+const MARKET_OPTIONS: { key: ScoreboardMarket; label: string }[] = [
+  { key: "all", label: "전체" },
+  { key: "kr", label: "국내" },
+  { key: "us", label: "미국" },
+  { key: "crypto", label: "코인" },
+];
+
+// "전체" omits the date-range params entirely, spanning full history — same
+// convention as ForecastCalibrationPanel's DAYS_OPTIONS.
+const DAYS_OPTIONS: { key: number | "all"; label: string }[] = [
+  { key: 30, label: "30일" },
+  { key: 90, label: "90일" },
+  { key: "all", label: "전체" },
+];
+
+const GROUP_BY_OPTIONS: { key: ScoreboardGroupBy; label: string }[] = [
+  { key: "strategy", label: "전략" },
+  { key: "day", label: "일자" },
+  { key: "trigger_type", label: "트리거" },
+  { key: "root_cause", label: "원인" },
+];
+
+// Process dims (trigger_type/root_cause) include no-fill-evidence rows
+// (see build_retrospective_aggregate's include_no_evidence) — win/loss there
+// is diluted, advisory-only.
+const PROCESS_GROUP_BYS = new Set<ScoreboardGroupBy>(["trigger_type", "root_cause"]);
+
+const SMALL_SAMPLE = 5;
+
+function kstDateString(daysAgo: number): string {
+  const d = new Date(Date.now() - daysAgo * 86400000);
+  return new Intl.DateTimeFormat("sv-SE", { timeZone: "Asia/Seoul" }).format(d);
+}
+
+function pct(x: number | null): string {
+  return x == null ? "—" : `${x.toFixed(1)}%`;
+}
+
+function formatSignedCurrency(amount: number, currency: string): string {
+  const sign = amount > 0 ? "+" : amount < 0 ? "-" : "";
+  const abs = Math.abs(amount);
+  if (currency === "USD") {
+    return `${sign}$${abs.toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+  }
+  if (currency === "KRW") {
+    return `${sign}₩${Math.round(abs).toLocaleString("ko-KR")}`;
+  }
+  return `${sign}${abs.toLocaleString("ko-KR")} ${currency}`;
+}
+
+function currencyColor(amount: number): string {
+  if (amount > 0) return "var(--gain)";
+  if (amount < 0) return "var(--danger)";
+  return "var(--fg-2)";
+}
+
+type LoadState<T> =
+  | { status: "loading" }
+  | { status: "ready"; data: T }
+  | { status: "error"; message: string };
+
+function Section({
+  title,
+  hint,
+  children,
+}: {
+  title: string;
+  hint?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div style={{ display: "grid", gap: 8 }}>
+      <div>
+        <h3 style={{ margin: 0, fontSize: 15 }}>{title}</h3>
+        {hint && <p style={{ margin: "2px 0 0", fontSize: 12, color: "var(--fg-3)" }}>{hint}</p>}
+      </div>
+      {children}
+    </div>
+  );
+}
+
+function ChipRow<T extends string | number>({
+  options,
+  value,
+  onChange,
+}: {
+  options: { key: T; label: string }[];
+  value: T;
+  onChange: (key: T) => void;
+}) {
+  return (
+    <div style={{ display: "flex", gap: 6, flexWrap: "wrap" }}>
+      {options.map((o) => (
+        <button
+          key={String(o.key)}
+          type="button"
+          onClick={() => onChange(o.key)}
+          style={{
+            border: "none",
+            borderRadius: 999,
+            padding: "4px 10px",
+            fontSize: 11,
+            fontWeight: 700,
+            cursor: "pointer",
+            fontFamily: "inherit",
+            background: value === o.key ? "var(--fg)" : "var(--surface-2)",
+            color: value === o.key ? "var(--bg)" : "var(--fg-2)",
+          }}
+        >
+          {o.label}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function RealizedPnlRows({ sums }: { sums: Record<string, number> }) {
+  const entries = Object.entries(sums);
+  if (entries.length === 0) {
+    return <span style={{ color: "var(--fg-3)" }}>—</span>;
+  }
+  return (
+    <div style={{ display: "grid", gap: 2 }}>
+      {entries.map(([currency, amount]) => (
+        <span
+          key={currency}
+          style={{ fontWeight: 900, fontFeatureSettings: '"tnum"', color: currencyColor(amount) }}
+        >
+          {formatSignedCurrency(amount, currency)}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+const tile: React.CSSProperties = {
+  borderRadius: 12,
+  background: "var(--surface-2)",
+  padding: "10px 12px",
+  display: "grid",
+  gap: 4,
+  minWidth: 0,
+};
+const tileLabel: React.CSSProperties = {
+  fontSize: 11,
+  color: "var(--fg-3)",
+  fontWeight: 700,
+  display: "flex",
+  alignItems: "center",
+  gap: 6,
+  flexWrap: "wrap",
+};
+const tileValue: React.CSSProperties = { fontSize: 20, fontWeight: 900, fontFeatureSettings: '"tnum"' };
+const tileHint: React.CSSProperties = { fontSize: 11, color: "var(--fg-3)" };
+
+function HeadlineTiles({ totals }: { totals: ScoreboardTotals }) {
+  const small = totals.decided > 0 && totals.decided < SMALL_SAMPLE;
+  return (
+    <div
+      data-testid="scoreboard-headline"
+      style={{
+        display: "grid",
+        gridTemplateColumns: "repeat(auto-fit, minmax(140px, 1fr))",
+        gap: 10,
+      }}
+    >
+      <div style={tile}>
+        <div style={tileLabel}>
+          승률
+          {small && <Pill tone="warn" size="sm">소표본</Pill>}
+        </div>
+        <div style={tileValue}>{pct(totals.win_rate_pct)}</div>
+        <div style={tileHint}>결정 {totals.decided}건 중</div>
+      </div>
+
+      <div style={tile}>
+        <div style={tileLabel}>승/패</div>
+        <div style={{ display: "flex", gap: 6, alignItems: "center" }}>
+          <Pill tone="gain">{totals.wins}승</Pill>
+          <Pill tone="loss">{totals.misses}패</Pill>
+        </div>
+      </div>
+
+      <div style={tile}>
+        <div style={tileLabel}>결정 표본</div>
+        <div style={tileValue}>{totals.decided}</div>
+        {totals.excluded_no_fill_evidence > 0 && (
+          <div style={tileHint}>증거 부족 {totals.excluded_no_fill_evidence}건 제외</div>
+        )}
+      </div>
+
+      <div style={tile}>
+        <div style={tileLabel}>실현손익</div>
+        <RealizedPnlRows sums={totals.realized_pnl_sum} />
+      </div>
+    </div>
+  );
+}
+
+const th: React.CSSProperties = {
+  padding: "8px 12px",
+  borderTop: "1px solid var(--divider)",
+  borderBottom: "1px solid var(--divider)",
+  fontWeight: 700,
+};
+const td: React.CSSProperties = {
+  padding: "9px 12px",
+  borderBottom: "1px solid var(--divider)",
+  fontSize: 13,
+};
+const tdNum: React.CSSProperties = { ...td, textAlign: "right", fontFeatureSettings: '"tnum"' };
+
+function BreakdownTable({
+  rows,
+  groupBy,
+}: {
+  rows: ScoreboardGroupRow[];
+  groupBy: ScoreboardGroupBy;
+}) {
+  if (rows.length === 0) {
+    return (
+      <div style={{ padding: 16, color: "var(--fg-3)", fontSize: 13, textAlign: "center" }}>
+        표시할 그룹이 없습니다.
+      </div>
+    );
+  }
+  return (
+    <div data-testid="scoreboard-breakdown" style={{ display: "grid", gap: 8 }}>
+      {PROCESS_GROUP_BYS.has(groupBy) && (
+        <Pill tone="paper" size="sm">무증거 포함, 승률 참고용</Pill>
+      )}
+      <div style={{ overflowX: "auto" }}>
+        <table style={{ width: "100%", borderCollapse: "collapse", minWidth: 560 }}>
+          <thead>
+            <tr style={{ color: "var(--fg-3)", fontSize: 11, textAlign: "left" }}>
+              <th style={th}>그룹</th>
+              <th style={{ ...th, textAlign: "right" }}>표본</th>
+              <th style={{ ...th, textAlign: "right" }}>승/패</th>
+              <th style={{ ...th, textAlign: "right" }}>승률</th>
+              <th style={{ ...th, textAlign: "right" }}>실현손익</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((r) => {
+              const small = r.sample_size < SMALL_SAMPLE;
+              return (
+                <tr key={r.group} style={small ? { background: "var(--surface-2)" } : undefined}>
+                  <td style={{ ...td, fontWeight: 700 }}>
+                    <span style={{ display: "inline-flex", gap: 6, alignItems: "center", flexWrap: "wrap" }}>
+                      {r.group}
+                      {small && <Pill tone="warn" size="sm">n={r.sample_size} 소표본</Pill>}
+                    </span>
+                  </td>
+                  <td style={tdNum}>{r.sample_size}</td>
+                  <td style={tdNum}>
+                    {r.wins}승 · {r.misses}패
+                  </td>
+                  <td style={tdNum}>{pct(r.win_rate_pct)}</td>
+                  <td style={tdNum}>
+                    <RealizedPnlRows sums={r.realized_pnl_sum} />
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+export function JudgmentScoreboardPanel({
+  compact = false,
+  onEmptyChange,
+}: {
+  compact?: boolean;
+  onEmptyChange?: (isEmpty: boolean) => void;
+} = {}) {
+  const [market, setMarket] = useState<ScoreboardMarket>("all");
+  const [days, setDays] = useState<number | "all">(90);
+  const [groupBy, setGroupBy] = useState<ScoreboardGroupBy>("strategy");
+  const [headline, setHeadline] = useState<LoadState<ScoreboardTotals>>({ status: "loading" });
+  const [breakdown, setBreakdown] = useState<LoadState<ScoreboardGroupRow[]>>({ status: "loading" });
+
+  const dateFrom = days === "all" ? undefined : kstDateString(days);
+  const dateTo = days === "all" ? undefined : kstDateString(0);
+
+  // Headline tile is always the strategy/day-oriented PnL grouping regardless
+  // of the breakdown toggle below (plan §3.4/§4 — totals from trigger_type/
+  // root_cause would be diluted by no-fill-evidence rows).
+  useEffect(() => {
+    let cancelled = false;
+    setHeadline({ status: "loading" });
+    fetchScoreboard({ groupBy: "strategy", market, dateFrom, dateTo })
+      .then((d) => {
+        if (!cancelled) setHeadline({ status: "ready", data: d.totals });
+      })
+      .catch((e: unknown) => {
+        if (!cancelled) setHeadline({ status: "error", message: e instanceof Error ? e.message : String(e) });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [market, dateFrom, dateTo]);
+
+  useEffect(() => {
+    let cancelled = false;
+    setBreakdown({ status: "loading" });
+    fetchScoreboard({ groupBy, market, dateFrom, dateTo })
+      .then((d) => {
+        if (!cancelled) setBreakdown({ status: "ready", data: d.groups });
+      })
+      .catch((e: unknown) => {
+        if (!cancelled) setBreakdown({ status: "error", message: e instanceof Error ? e.message : String(e) });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [groupBy, market, dateFrom, dateTo]);
+
+  useEffect(() => {
+    if (!onEmptyChange) return;
+    if (headline.status !== "ready") return;
+    onEmptyChange(headline.data.sample_size === 0);
+  }, [headline, onEmptyChange]);
+
+  return (
+    <Card>
+      <section data-testid="judgment-scoreboard-panel" style={{ display: "grid", gap: 16 }}>
+        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", gap: 12, flexWrap: "wrap" }}>
+          <div>
+            <h2 style={{ margin: 0, fontSize: compact ? 16 : 18 }}>판단 성적표</h2>
+            <p style={{ margin: "4px 0 0", fontSize: 12, color: "var(--fg-3)", lineHeight: 1.6, maxWidth: 520 }}>
+              체결·증거 기반 — 실제 체결과 PnL 증거가 있는 회고만 집계합니다(무증거·거부·취소
+              제외). 자기신고보다 강하지만 표본이 적을 수 있습니다.
+            </p>
+          </div>
+          <div style={{ display: "flex", flexDirection: "column", gap: 6, alignItems: "flex-end" }}>
+            <ChipRow options={MARKET_OPTIONS} value={market} onChange={setMarket} />
+            <ChipRow options={DAYS_OPTIONS} value={days} onChange={setDays} />
+          </div>
+        </div>
+
+        <Section title="핵심 지표">
+          {headline.status === "loading" && (
+            <div style={{ padding: 16, color: "var(--fg-3)", fontSize: 13, textAlign: "center" }}>불러오는 중…</div>
+          )}
+          {headline.status === "error" && (
+            <div role="alert" style={{ padding: 12, color: "var(--danger)", fontSize: 13 }}>
+              성적표를 불러오지 못했습니다. {headline.message}
+            </div>
+          )}
+          {headline.status === "ready" && <HeadlineTiles totals={headline.data} />}
+        </Section>
+
+        <Section
+          title="그룹별 상세"
+          hint="승률 정의: 실현손익 > 0 기준(동점은 패로 집계)."
+        >
+          <ChipRow options={GROUP_BY_OPTIONS} value={groupBy} onChange={setGroupBy} />
+          {breakdown.status === "loading" && (
+            <div style={{ padding: 16, color: "var(--fg-3)", fontSize: 13, textAlign: "center" }}>불러오는 중…</div>
+          )}
+          {breakdown.status === "error" && (
+            <div role="alert" style={{ padding: 12, color: "var(--danger)", fontSize: 13 }}>
+              그룹별 상세를 불러오지 못했습니다. {breakdown.message}
+            </div>
+          )}
+          {breakdown.status === "ready" && (
+            <BreakdownTable rows={compact ? breakdown.data.slice(0, 8) : breakdown.data} groupBy={groupBy} />
+          )}
+        </Section>
+      </section>
+    </Card>
+  );
+}

--- a/frontend/invest/src/components/my/RetrospectivesPanel.tsx
+++ b/frontend/invest/src/components/my/RetrospectivesPanel.tsx
@@ -8,6 +8,7 @@ import { stockDetailPath } from "../../stockDetailPath";
 import type {
   NextActionRow,
   RetroMarket,
+  RetroOutcomeFilter,
   RetrospectiveRow,
 } from "../../types/retrospectives";
 
@@ -30,6 +31,19 @@ const TRIGGER_OPTIONS: { key: string; label: string }[] = [
   { key: "stale_evidence", label: "증거부족" },
   { key: "guardrail_block", label: "가드레일" },
 ];
+
+// ROB-691 — win/loss/decided trade-history filter, forwarded as
+// outcome_filter. "" = no filter (all outcomes, decided or not).
+const OUTCOME_OPTIONS: { key: RetroOutcomeFilter | ""; label: string }[] = [
+  { key: "", label: "전체" },
+  { key: "win", label: "승" },
+  { key: "loss", label: "패" },
+  { key: "decided", label: "결정" },
+];
+
+// Debounce the free-text symbol search so every keystroke doesn't fire a
+// request; 300ms mirrors common UI debounce defaults elsewhere in the app.
+const SEARCH_DEBOUNCE_MS = 300;
 
 function pnlText(row: { realized_pnl: number | null; realized_pnl_currency: string | null }): string {
   if (row.realized_pnl == null) return "—";
@@ -82,6 +96,13 @@ export function RetrospectivesPanel({
 }) {
   const [market, setMarket] = useState<RetroMarket>("all");
   const [triggerType, setTriggerType] = useState<string>("");
+  const [outcomeFilter, setOutcomeFilter] = useState<RetroOutcomeFilter | "">("");
+  // Raw input vs. debounced value: the raw value drives the <input>, the
+  // debounced value drives the fetch (ROB-691 — avoid firing a request per keystroke).
+  const [symbolSearchInput, setSymbolSearchInput] = useState("");
+  const [symbolSearch, setSymbolSearch] = useState("");
+  const [dateFrom, setDateFrom] = useState("");
+  const [dateTo, setDateTo] = useState("");
   const [nextActions, setNextActions] = useState<NextActionRow[]>([]);
   const [state, setState] = useState<
     | { status: "loading" }
@@ -90,9 +111,22 @@ export function RetrospectivesPanel({
   >({ status: "loading" });
 
   useEffect(() => {
+    const timer = setTimeout(() => setSymbolSearch(symbolSearchInput.trim()), SEARCH_DEBOUNCE_MS);
+    return () => clearTimeout(timer);
+  }, [symbolSearchInput]);
+
+  useEffect(() => {
     let cancelled = false;
     setState({ status: "loading" });
-    fetchRetrospectives({ market, triggerType: triggerType || undefined, limit: compact ? 8 : 50 })
+    fetchRetrospectives({
+      market,
+      triggerType: triggerType || undefined,
+      outcomeFilter: outcomeFilter || undefined,
+      q: symbolSearch || undefined,
+      dateFrom: dateFrom || undefined,
+      dateTo: dateTo || undefined,
+      limit: compact ? 8 : 50,
+    })
       .then((data) => {
         if (!cancelled) setState({ status: "ready", items: data.items, total: data.total });
       })
@@ -100,7 +134,7 @@ export function RetrospectivesPanel({
         if (!cancelled) setState({ status: "error", message: err instanceof Error ? err.message : String(err) });
       });
     return () => { cancelled = true; };
-  }, [market, triggerType, compact]);
+  }, [market, triggerType, outcomeFilter, symbolSearch, dateFrom, dateTo, compact]);
 
   useEffect(() => {
     let cancelled = false;
@@ -146,6 +180,17 @@ export function RetrospectivesPanel({
               </button>
             ))}
           </div>
+          {/* ROB-691 — win/loss/decided filter: small footprint like the
+              market chips above, so it stays visible in compact mode too
+              (unlike the wider trigger/search/date-range controls below). */}
+          <div style={{ display: "flex", gap: 6, flexWrap: "wrap", alignSelf: "flex-end" }}>
+            {OUTCOME_OPTIONS.map((option) => (
+              <button key={option.key || "all"} type="button" onClick={() => setOutcomeFilter(option.key)}
+                style={{ border: "none", borderRadius: 999, padding: "4px 8px", fontSize: 11, fontWeight: 700, cursor: "pointer", fontFamily: "inherit", background: outcomeFilter === option.key ? "var(--fg)" : "var(--surface-2)", color: outcomeFilter === option.key ? "var(--bg)" : "var(--fg-2)" }}>
+                {option.label}
+              </button>
+            ))}
+          </div>
           {!compact && (
             <div style={{ display: "flex", gap: 6, flexWrap: "wrap", alignSelf: "flex-end" }}>
               {TRIGGER_OPTIONS.map((option) => (
@@ -154,6 +199,37 @@ export function RetrospectivesPanel({
                   {option.label}
                 </button>
               ))}
+            </div>
+          )}
+          {!compact && (
+            <div style={{ display: "flex", gap: 6, flexWrap: "wrap", alignSelf: "flex-end", alignItems: "center" }}>
+              <input
+                type="text"
+                placeholder="종목 검색"
+                value={symbolSearchInput}
+                onChange={(e) => setSymbolSearchInput(e.target.value)}
+                style={{ border: "1px solid var(--border)", borderRadius: 999, padding: "4px 10px", fontSize: 11, fontFamily: "inherit", background: "var(--surface)", color: "var(--fg-1)", width: 100 }}
+              />
+              <label style={{ display: "flex", alignItems: "center", gap: 4, fontSize: 11, color: "var(--fg-3)" }}>
+                시작일
+                <input
+                  type="date"
+                  aria-label="시작일"
+                  value={dateFrom}
+                  onChange={(e) => setDateFrom(e.target.value)}
+                  style={{ border: "1px solid var(--border)", borderRadius: 8, padding: "3px 6px", fontSize: 11, fontFamily: "inherit", background: "var(--surface)", color: "var(--fg-1)" }}
+                />
+              </label>
+              <label style={{ display: "flex", alignItems: "center", gap: 4, fontSize: 11, color: "var(--fg-3)" }}>
+                종료일
+                <input
+                  type="date"
+                  aria-label="종료일"
+                  value={dateTo}
+                  onChange={(e) => setDateTo(e.target.value)}
+                  style={{ border: "1px solid var(--border)", borderRadius: 8, padding: "3px 6px", fontSize: 11, fontFamily: "inherit", background: "var(--surface)", color: "var(--fg-1)" }}
+                />
+              </label>
             </div>
           )}
         </div>

--- a/frontend/invest/src/pages/desktop/DesktopInsightsPage.tsx
+++ b/frontend/invest/src/pages/desktop/DesktopInsightsPage.tsx
@@ -4,6 +4,7 @@ import { CommonPreferredDisparityCardView } from "../../components/CommonPreferr
 import { MarketParityStrip } from "../../components/home/MarketParityStrip";
 import { AnalysisArtifactPanel } from "../../components/insights/AnalysisArtifactPanel";
 import { ForecastCalibrationPanel } from "../../components/insights/ForecastCalibrationPanel";
+import { JudgmentScoreboardPanel } from "../../components/insights/JudgmentScoreboardPanel";
 import { SessionContextTimelinePanel } from "../../components/insights/SessionContextTimelinePanel";
 import { RetrospectivesPanel } from "../../components/my/RetrospectivesPanel";
 import { PageSafetyNote } from "../../components/PageSafetyNote";
@@ -118,11 +119,15 @@ export function DesktopInsightsPage() {
   // Emptiness is owned by each panel (self-fetch); they report up via
   // onEmptyChange so the page can show one accumulating banner instead of a
   // stack of empty boxes. null = not-yet-resolved.
+  const [scoreboardEmpty, setScoreboardEmpty] = useState<boolean | null>(null);
   const [forecastEmpty, setForecastEmpty] = useState<boolean | null>(null);
   const [artifactEmpty, setArtifactEmpty] = useState<boolean | null>(null);
   const [sessionEmpty, setSessionEmpty] = useState<boolean | null>(null);
   const allDataEmpty =
-    forecastEmpty === true && artifactEmpty === true && sessionEmpty === true;
+    scoreboardEmpty === true &&
+    forecastEmpty === true &&
+    artifactEmpty === true &&
+    sessionEmpty === true;
 
   // Crosslink closed forecasts ↔ retrospectives by normalized symbol key
   // (ROB-682): only the intersection (keys present on both sides) gets
@@ -152,6 +157,7 @@ export function DesktopInsightsPage() {
           </Section>
 
           <Section title="판단 품질">
+            <JudgmentScoreboardPanel onEmptyChange={setScoreboardEmpty} />
             <ForecastCalibrationPanel
               onEmptyChange={setForecastEmpty}
               onClosedSymbolKeys={setClosedForecastKeys}

--- a/frontend/invest/src/pages/mobile/MobileInsightsPage.tsx
+++ b/frontend/invest/src/pages/mobile/MobileInsightsPage.tsx
@@ -12,6 +12,7 @@ import { CommonPreferredDisparityCardView } from "../../components/CommonPreferr
 import { MarketParityStrip } from "../../components/home/MarketParityStrip";
 import { AnalysisArtifactPanel } from "../../components/insights/AnalysisArtifactPanel";
 import { ForecastCalibrationPanel } from "../../components/insights/ForecastCalibrationPanel";
+import { JudgmentScoreboardPanel } from "../../components/insights/JudgmentScoreboardPanel";
 import { SessionContextTimelinePanel } from "../../components/insights/SessionContextTimelinePanel";
 import { RetrospectivesPanel } from "../../components/my/RetrospectivesPanel";
 import { PageSafetyNote } from "../../components/PageSafetyNote";
@@ -126,11 +127,15 @@ export function MobileInsightsPage() {
   // Emptiness is owned by each panel (self-fetch); they report up via
   // onEmptyChange so the page can show one accumulating banner instead of a
   // stack of empty boxes. null = not-yet-resolved.
+  const [scoreboardEmpty, setScoreboardEmpty] = useState<boolean | null>(null);
   const [forecastEmpty, setForecastEmpty] = useState<boolean | null>(null);
   const [artifactEmpty, setArtifactEmpty] = useState<boolean | null>(null);
   const [sessionEmpty, setSessionEmpty] = useState<boolean | null>(null);
   const allDataEmpty =
-    forecastEmpty === true && artifactEmpty === true && sessionEmpty === true;
+    scoreboardEmpty === true &&
+    forecastEmpty === true &&
+    artifactEmpty === true &&
+    sessionEmpty === true;
 
   // Crosslink closed forecasts ↔ retrospectives by normalized symbol key
   // (ROB-682): only the intersection (keys present on both sides) gets
@@ -171,6 +176,7 @@ export function MobileInsightsPage() {
 
         <div style={{ padding: "0 16px" }}>
           <Section title="판단 품질">
+            <JudgmentScoreboardPanel compact onEmptyChange={setScoreboardEmpty} />
             <ForecastCalibrationPanel
               onEmptyChange={setForecastEmpty}
               onClosedSymbolKeys={setClosedForecastKeys}

--- a/frontend/invest/src/types/retrospectives.ts
+++ b/frontend/invest/src/types/retrospectives.ts
@@ -23,11 +23,17 @@ export interface RetrospectiveRow {
   created_at: string | null;
 }
 
+export type RetroOutcomeFilter = "win" | "loss" | "decided";
+
 export interface RetrospectivesResponse {
   market: RetroMarket;
   trigger_type: string | null;
   root_cause_class: string | null;
   symbol: string | null;
+  outcome_filter: string | null;
+  q: string | null;
+  kst_date_from: string | null;
+  kst_date_to: string | null;
   count: number;
   total: number;
   items: RetrospectiveRow[];

--- a/frontend/invest/src/types/scoreboard.ts
+++ b/frontend/invest/src/types/scoreboard.ts
@@ -1,0 +1,43 @@
+// Read-only judgment scoreboard surface (ROB-691).
+// Mirrors app/schemas/invest_retrospectives.py Scoreboard* models field-for-field
+// (snake_case preserved).
+
+export type ScoreboardGroupBy = "strategy" | "day" | "trigger_type" | "root_cause";
+
+export interface ScoreboardGroupRow {
+  group: string;
+  sample_size: number;
+  wins: number;
+  misses: number;
+  win_rate_pct: number | null;
+  avg_pnl_pct: number | null;
+  realized_pnl_sum: Record<string, number>;
+  fx_pnl_krw_sum: number;
+  total_pnl_krw_sum: number;
+  by_outcome: Record<string, number>;
+  by_trigger_type: Record<string, number>;
+  by_root_cause_class: Record<string, number>;
+}
+
+export interface ScoreboardTotals {
+  sample_size: number;
+  wins: number;
+  misses: number;
+  decided: number;
+  win_rate_pct: number | null;
+  realized_pnl_sum: Record<string, number>;
+  fx_pnl_krw_sum: number;
+  total_pnl_krw_sum: number;
+  excluded_no_fill_evidence: number;
+}
+
+export interface ScoreboardResponse {
+  group_by: string;
+  market: "all" | "kr" | "us" | "crypto";
+  kst_date_from: string | null;
+  kst_date_to: string | null;
+  count: number;
+  groups: ScoreboardGroupRow[];
+  totals: ScoreboardTotals;
+  as_of: string;
+}

--- a/tests/routers/test_invest_retrospectives_router.py
+++ b/tests/routers/test_invest_retrospectives_router.py
@@ -7,7 +7,9 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 
-def _make_client(monkeypatch, *, list_result=None, na_result=None):
+def _make_client(
+    monkeypatch, *, list_result=None, na_result=None, aggregate_result=None
+):
     from app.core.db import get_db
     from app.routers import invest_retrospectives
     from app.routers.dependencies import get_authenticated_user
@@ -22,11 +24,24 @@ def _make_client(monkeypatch, *, list_result=None, na_result=None):
         calls["na"] = kwargs
         return na_result or {"items": [], "count": 0, "scan_limit": 200}
 
+    async def _fake_aggregate(db, **kwargs):
+        calls["aggregate"] = kwargs
+        return aggregate_result or {
+            "group_by": kwargs.get("group_by", "strategy"),
+            "groups": [],
+            "excluded_no_fill_evidence": 0,
+        }
+
     monkeypatch.setattr(
         invest_retrospectives.retro_svc, "get_retrospectives", _fake_list
     )
     monkeypatch.setattr(
         invest_retrospectives.retro_svc, "get_open_next_actions", _fake_na
+    )
+    monkeypatch.setattr(
+        invest_retrospectives.retro_svc,
+        "build_retrospective_aggregate",
+        _fake_aggregate,
     )
 
     app = FastAPI()
@@ -156,6 +171,164 @@ def test_next_actions_status_csv_narrows(monkeypatch):
     )
     assert r.status_code == 200
     assert calls["na"]["statuses"] == frozenset({"open", "in_progress"})
+
+
+@pytest.mark.unit
+def test_list_forwards_new_filters(monkeypatch):
+    client, calls = _make_client(monkeypatch)
+    r = client.get(
+        "/trading/api/invest/retrospectives"
+        "?outcome_filter=win&q=005&kst_date_from=2026-07-01&kst_date_to=2026-07-04"
+    )
+    assert r.status_code == 200
+    assert calls["list"]["outcome_filter"] == "win"
+    assert calls["list"]["symbol_search"] == "005"
+    assert calls["list"]["kst_date_from"] == "2026-07-01"
+    assert calls["list"]["kst_date_to"] == "2026-07-04"
+    body = r.json()
+    assert body["outcome_filter"] == "win"
+    assert body["q"] == "005"
+    assert body["kst_date_from"] == "2026-07-01"
+    assert body["kst_date_to"] == "2026-07-04"
+
+
+@pytest.mark.unit
+def test_list_rejects_invalid_outcome_filter(monkeypatch):
+    client, _ = _make_client(monkeypatch)
+    r = client.get("/trading/api/invest/retrospectives?outcome_filter=bogus")
+    assert r.status_code == 422
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("param", ["kst_date_from", "kst_date_to"])
+def test_list_rejects_invalid_date_format(monkeypatch, param):
+    client, _ = _make_client(monkeypatch)
+    r = client.get(f"/trading/api/invest/retrospectives?{param}=2026/07/04")
+    assert r.status_code == 422
+
+
+@pytest.mark.unit
+def test_scoreboard_defaults_and_totals_rollup(monkeypatch):
+    groups = [
+        {
+            "group": "A",
+            "sample_size": 5,
+            "wins": 3,
+            "misses": 2,
+            "win_rate_pct": 60.0,
+            "avg_pnl_pct": 1.2,
+            "realized_pnl_sum": {"KRW": 100.0, "USD": 5.0},
+            "fx_pnl_krw_sum": 10.0,
+            "total_pnl_krw_sum": 110.0,
+            "by_outcome": {"filled": 5},
+            "by_trigger_type": {},
+            "by_root_cause_class": {},
+        },
+        {
+            "group": "B",
+            "sample_size": 2,
+            "wins": 1,
+            "misses": 1,
+            "win_rate_pct": 50.0,
+            "avg_pnl_pct": -0.5,
+            "realized_pnl_sum": {"KRW": 50.0},
+            "fx_pnl_krw_sum": 0.0,
+            "total_pnl_krw_sum": 50.0,
+            "by_outcome": {"filled": 2},
+            "by_trigger_type": {},
+            "by_root_cause_class": {},
+        },
+    ]
+    client, calls = _make_client(
+        monkeypatch,
+        aggregate_result={
+            "group_by": "strategy",
+            "groups": groups,
+            "excluded_no_fill_evidence": 3,
+        },
+    )
+    r = client.get("/trading/api/invest/retrospectives/scoreboard")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["group_by"] == "strategy"
+    assert body["market"] == "all"
+    assert calls["aggregate"]["market"] is None  # market="all" -> None
+    assert calls["aggregate"]["group_by"] == "strategy"
+    assert len(body["groups"]) == 2
+
+    totals = body["totals"]
+    assert totals["sample_size"] == 7
+    assert totals["wins"] == 4
+    assert totals["misses"] == 3
+    assert totals["decided"] == 7
+    assert totals["win_rate_pct"] == pytest.approx(4 / 7 * 100.0)
+    assert totals["realized_pnl_sum"] == {"KRW": 150.0, "USD": 5.0}
+    assert totals["fx_pnl_krw_sum"] == pytest.approx(10.0)
+    assert totals["total_pnl_krw_sum"] == pytest.approx(160.0)
+    assert totals["excluded_no_fill_evidence"] == 3
+
+
+@pytest.mark.unit
+def test_scoreboard_empty_groups_totals_are_zero_and_null_win_rate(monkeypatch):
+    client, _ = _make_client(monkeypatch)
+    r = client.get("/trading/api/invest/retrospectives/scoreboard")
+    assert r.status_code == 200
+    totals = r.json()["totals"]
+    assert totals["sample_size"] == 0
+    assert totals["decided"] == 0
+    assert totals["win_rate_pct"] is None
+    assert totals["realized_pnl_sum"] == {}
+
+
+@pytest.mark.unit
+def test_scoreboard_forwards_group_by_and_filters(monkeypatch):
+    client, calls = _make_client(monkeypatch)
+    r = client.get(
+        "/trading/api/invest/retrospectives/scoreboard"
+        "?group_by=day&market=kr&account_mode=kis_live&strategy_key=A"
+        "&kst_date_from=2026-07-01&kst_date_to=2026-07-04"
+    )
+    assert r.status_code == 200
+    assert calls["aggregate"]["group_by"] == "day"
+    assert calls["aggregate"]["market"] == "kr"
+    assert calls["aggregate"]["account_mode"] == "kis_live"
+    assert calls["aggregate"]["strategy_key"] == "A"
+    assert calls["aggregate"]["kst_date_from"] == "2026-07-01"
+    assert calls["aggregate"]["kst_date_to"] == "2026-07-04"
+    body = r.json()
+    assert body["market"] == "kr"
+    assert body["kst_date_from"] == "2026-07-01"
+    assert body["kst_date_to"] == "2026-07-04"
+
+
+@pytest.mark.unit
+def test_scoreboard_rejects_invalid_group_by(monkeypatch):
+    client, _ = _make_client(monkeypatch)
+    r = client.get("/trading/api/invest/retrospectives/scoreboard?group_by=bogus")
+    assert r.status_code == 422
+
+
+@pytest.mark.unit
+def test_scoreboard_rejects_invalid_market(monkeypatch):
+    client, _ = _make_client(monkeypatch)
+    r = client.get("/trading/api/invest/retrospectives/scoreboard?market=paper")
+    assert r.status_code == 422
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("param", ["kst_date_from", "kst_date_to"])
+def test_scoreboard_rejects_invalid_date_format(monkeypatch, param):
+    client, _ = _make_client(monkeypatch)
+    r = client.get(f"/trading/api/invest/retrospectives/scoreboard?{param}=07-04-2026")
+    assert r.status_code == 422
+
+
+@pytest.mark.unit
+def test_scoreboard_requires_authentication():
+    client = _make_unauth_client()
+    r = client.get("/trading/api/invest/retrospectives/scoreboard")
+    assert r.status_code == 401
+    assert r.json()["detail"] == "로그인이 필요합니다."
 
 
 def _make_unauth_client():

--- a/tests/test_trade_retrospective_aggregate.py
+++ b/tests/test_trade_retrospective_aggregate.py
@@ -275,6 +275,159 @@ async def test_aggregate_group_by_root_cause(db_session: AsyncSession):
     assert groups["policy"]["by_trigger_type"] == {"policy_violation": 1}
 
 
+# ---------------------------------------------------------------------------
+# ROB-691 — get_retrospectives filters: outcome_filter / symbol_search /
+# kst_date_from-to. The outcome_filter SQL predicates MUST match the Python
+# `_is_win`/`_is_decided` semantics used by build_retrospective_aggregate
+# (same win/loss/decided rules, tie=0 counted as loss) — this is the parallel
+# equivalence test the plan calls out as the biggest correctness risk.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_outcome_filter_matches_python_predicate(db_session: AsyncSession):
+    from sqlalchemy import select as sa_select
+
+    # win via realized_pnl
+    await _seed(db_session, strategy="A", pnl=100.0)
+    # loss via realized_pnl
+    await _seed(db_session, strategy="A", pnl=-50.0)
+    # tie (0) -> decided but NOT a win (loss bucket)
+    await _seed(db_session, strategy="A", pnl=0.0)
+    # win via pnl_pct fallback (realized_pnl absent)
+    await svc.save_retrospective(
+        db_session,
+        symbol="005930",
+        instrument_type="equity_kr",
+        account_mode="kis_mock",
+        outcome="filled",
+        strategy_key="B",
+        pnl_pct=1.5,
+    )
+    # loss via pnl_pct fallback, tie(0) included
+    await svc.save_retrospective(
+        db_session,
+        symbol="005930",
+        instrument_type="equity_kr",
+        account_mode="kis_mock",
+        outcome="filled",
+        strategy_key="B",
+        pnl_pct=0.0,
+    )
+    await svc.save_retrospective(
+        db_session,
+        symbol="005930",
+        instrument_type="equity_kr",
+        account_mode="kis_mock",
+        outcome="filled",
+        strategy_key="B",
+        pnl_pct=-2.0,
+    )
+    # no-evidence row: neither realized_pnl nor pnl_pct -> not decided at all
+    await svc.save_retrospective(
+        db_session,
+        symbol="005930",
+        instrument_type="equity_kr",
+        account_mode="kiwoom_mock",
+        outcome="unfilled",
+        strategy_key="C",
+    )
+    await db_session.commit()
+
+    # Ground truth computed in Python directly against the ORM rows, exactly
+    # mirroring what build_retrospective_aggregate uses internally.
+    all_rows = (await db_session.execute(sa_select(TradeRetrospective))).scalars().all()
+    expected_win_ids = {r.id for r in all_rows if svc._is_win(r)}
+    expected_decided_ids = {r.id for r in all_rows if svc._is_decided(r)}
+    expected_loss_ids = expected_decided_ids - expected_win_ids
+    # 7 rows seeded, 1 has no evidence at all (neither realized_pnl nor
+    # pnl_pct) -> 6 decided. Wins: pnl=100 (realized_pnl) + pnl_pct=1.5
+    # (fallback) = 2. Losses: pnl=-50, pnl=0 (tie), pnl_pct=0.0 (tie),
+    # pnl_pct=-2.0 = 4.
+    assert len(expected_decided_ids) == 6
+    assert len(expected_win_ids) == 2
+    assert len(expected_loss_ids) == 4
+
+    win_result = await svc.get_retrospectives(
+        db_session, outcome_filter="win", limit=100
+    )
+    assert {e["id"] for e in win_result["entries"]} == expected_win_ids
+
+    loss_result = await svc.get_retrospectives(
+        db_session, outcome_filter="loss", limit=100
+    )
+    assert {e["id"] for e in loss_result["entries"]} == expected_loss_ids
+
+    decided_result = await svc.get_retrospectives(
+        db_session, outcome_filter="decided", limit=100
+    )
+    assert {e["id"] for e in decided_result["entries"]} == expected_decided_ids
+
+
+@pytest.mark.asyncio
+async def test_outcome_filter_invalid_value_raises(db_session: AsyncSession):
+    with pytest.raises(svc.RetrospectiveValidationError):
+        await svc.get_retrospectives(db_session, outcome_filter="bogus")
+
+
+@pytest.mark.asyncio
+async def test_symbol_search_prefix_ilike(db_session: AsyncSession):
+    await svc.save_retrospective(
+        db_session,
+        symbol="005930",
+        instrument_type="equity_kr",
+        account_mode="kis_mock",
+        outcome="filled",
+        strategy_key="A",
+    )
+    await svc.save_retrospective(
+        db_session,
+        symbol="AAPL",
+        instrument_type="equity_us",
+        account_mode="kis_mock",
+        outcome="filled",
+        strategy_key="A",
+    )
+    await db_session.commit()
+
+    res = await svc.get_retrospectives(db_session, symbol_search="005")
+    assert {e["symbol"] for e in res["entries"]} == {"005930"}
+
+    res_lower = await svc.get_retrospectives(db_session, symbol_search="aap")
+    assert {e["symbol"] for e in res_lower["entries"]} == {"AAPL"}
+
+    res_none = await svc.get_retrospectives(db_session, symbol_search="ZZZ")
+    assert res_none["entries"] == []
+
+
+@pytest.mark.asyncio
+async def test_kst_date_from_to_boundaries(db_session: AsyncSession):
+    from datetime import timedelta
+
+    from app.core.timezone import now_kst
+
+    await _seed(db_session, strategy="A", pnl=100.0)
+    await db_session.commit()
+    today = now_kst().date().isoformat()
+    yesterday = (now_kst().date() - timedelta(days=1)).isoformat()
+    tomorrow = (now_kst().date() + timedelta(days=1)).isoformat()
+
+    in_window = await svc.get_retrospectives(
+        db_session, kst_date_from=today, kst_date_to=today
+    )
+    assert in_window["summary"]["count"] == 1
+
+    out_of_window = await svc.get_retrospectives(
+        db_session, kst_date_from=yesterday, kst_date_to=yesterday
+    )
+    assert out_of_window["summary"]["count"] == 0
+
+    range_window = await svc.get_retrospectives(
+        db_session, kst_date_from=yesterday, kst_date_to=tomorrow
+    )
+    assert range_window["summary"]["count"] == 1
+
+
 @pytest.mark.asyncio
 async def test_process_dims_include_no_fill_evidence_rows(db_session: AsyncSession):
     # kiwoom_mock has no fill evidence — excluded from PnL dims, INCLUDED in


### PR DESCRIPTION
## ROB-691 — 판단 성적표 + 거래이력 필터

이미 있는 결정론 집계 `build_retrospective_aggregate`(승률·실현손익·승패)를 웹에 표면화 + 거래이력 필터 추가. MCP에만 있던 걸 read 라우터로. **migration-0, read-only.**

### 변경
- `GET /trading/api/invest/retrospectives/scoreboard` (라우터-side totals 롤업) + 기존 리스트에 `outcome_filter(win|loss|decided)`·`symbol_search`·`kst_date_from/to`.
- 서비스에 `_sql_is_win/_sql_is_decided/_sql_is_loss`(Python 예측의 SQL 미러) + `_prefix_like`(ILIKE 이스케이프).
- 신규 `JudgmentScoreboardPanel`(/insights 판단품질) + RetrospectivesPanel 필터, Desktop/Mobile lockstep.

### 검증
- 승패 **SQL↔Python 동치 테스트**(realized/pnl_pct 양경로 win·loss·tie(0) seed) 포함 백엔드 재실행 pass. LLM 가드 1102 pass. frontend targeted 22 pass, tsc clean.
- semantics 라벨: 승패는 실 체결+PnL 증거 기반(_is_decided가 rejected/cancelled/무증거 제외).
- 미수행: `/insights` 실브라우저 QA(유닛/컴포넌트는 통과).

Linear: ROB-691

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WVqjyNQM5QvjfSjMog9sxR
