### PR TITLE
feat(ROB-692): stock-detail recommendation card with R:R (reuses ROB-690 helper)

### DIFF
--- a/app/routers/invest_api.py
+++ b/app/routers/invest_api.py
@@ -59,6 +59,9 @@ from app.schemas.invest_stock_detail import (
     StockDetailOrdersResponse,
     StockDetailResponse,
 )
+from app.schemas.invest_stock_detail_recommendation import (
+    StockDetailRecommendationResponse,
+)
 from app.schemas.invest_stock_detail_research_consensus import (
     StockDetailResearchConsensusResponse,
 )
@@ -112,6 +115,9 @@ from app.services.invest_view_model.stock_detail_orders_service import (
 from app.services.invest_view_model.stock_detail_providers import (
     make_account_panel_holding_provider,
     stock_detail_candle_provider,
+)
+from app.services.invest_view_model.stock_detail_recommendation_service import (
+    build_stock_detail_recommendation,
 )
 from app.services.invest_view_model.stock_detail_research_consensus_service import (
     build_stock_detail_research_consensus,
@@ -470,6 +476,29 @@ async def get_stock_detail_research_consensus(
             market=market,
             symbol=symbol,
             db=db,
+        )
+    except SymbolNotFound as exc:
+        raise HTTPException(status_code=404, detail="symbol_not_found") from exc
+
+
+@router.get("/stock-detail/{market}/{symbol}/recommendation")
+async def get_stock_detail_recommendation(
+    market: StockDetailMarketParam,
+    symbol: str,
+    user: Annotated[Any, Depends(get_authenticated_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> StockDetailRecommendationResponse:
+    _ = user
+    _ = db
+    if market == "crypto":
+        raise HTTPException(
+            status_code=400,
+            detail="research_recommendation_supports_kr_us_only",
+        )
+    try:
+        return await build_stock_detail_recommendation(
+            market=market,
+            symbol=symbol,
         )
     except SymbolNotFound as exc:
         raise HTTPException(status_code=404, detail="symbol_not_found") from exc

--- a/app/schemas/invest_stock_detail_recommendation.py
+++ b/app/schemas/invest_stock_detail_recommendation.py
@@ -1,0 +1,66 @@
+"""ROB-692 — stock-detail deterministic recommendation transport schema.
+
+Read-only wire shape for `build_stock_detail_recommendation`
+(`app/services/invest_view_model/stock_detail_recommendation_service.py`).
+Mirrors the already-floored `build_recommendation_for_equity` dict
+(`app/mcp_server/tooling/shared.py`) verbatim (action/confidence/rsi14/
+buy_zones/sell_targets/stop_loss/reasoning/insufficient_inputs) plus an
+optional risk/reward chip (`RecoTradeSetup`) that reuses the ROB-690
+`risk_reward` helper (`app/services/investment_reports/risk_reward.py`).
+No new judgment is introduced here — this is a transport shape only.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+RecommendationAction = Literal["buy", "hold", "sell"]
+RecommendationConfidence = Literal["high", "medium", "low"]
+
+
+class RecoZone(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    price: float
+    type: str
+    reasoning: str
+
+
+class RecoTradeSetup(BaseModel):
+    """Mirrors `ingestion._serialise_trade_setup`'s headline shape (flattened).
+
+    Decimal-as-string on the wire (never a raw float) — same JSON-safety
+    convention as `evidence_snapshot["trade_setup"]`.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    direction: Literal["long", "short"]
+    entry: str
+    stop: str
+    target: str
+    risk_pct: str
+    reward_pct: str
+    rr_ratio: str
+
+
+class StockDetailRecommendationResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    market: Literal["kr", "us"]
+    symbol: str
+    name: str | None = None
+    as_of: datetime
+    current_price: float | None = None
+    action: RecommendationAction
+    confidence: RecommendationConfidence
+    rsi14: float | None = None
+    reasoning: str
+    insufficient_inputs: list[str] = Field(default_factory=list)
+    buy_zones: list[RecoZone] = Field(default_factory=list)
+    sell_targets: list[RecoZone] = Field(default_factory=list)
+    stop_loss: float | None = None
+    trade_setup: RecoTradeSetup | None = None

--- a/app/services/invest_view_model/stock_detail_recommendation_service.py
+++ b/app/services/invest_view_model/stock_detail_recommendation_service.py
@@ -1,0 +1,181 @@
+"""ROB-692 — read-only stock-detail deterministic recommendation + R:R.
+
+Reuses `analyze_stock_impl` (the only place that assembles the `analysis`
+dict `build_recommendation_for_equity` consumes: quote + indicators +
+support_resistance + opinions + valuation, then the ROB-486
+insufficient-inputs floor) instead of re-deriving that ~250-line fetch/floor
+pipeline. This module only composes and reshapes an already-computed,
+already-floored recommendation for the web transport.
+
+Fulfills ROB-690's deferred R:R "Step 4": the recommendation's
+entry(=current price, or top buy_zone)/stop(=stop_loss)/target(=nearest
+sell_target) triple is fed into `resolve_direction` / `build_trade_setup`
+(`app/services/investment_reports/risk_reward.py`) — the same helper wired
+in `app/services/investment_reports/ingestion.py`. Fail-closed: any
+non-`long` direction (sell/hold recommendations, since a hold/sell reco has
+no long entry to price) or a degenerate/mismatched price triangle omits the
+R:R chip entirely rather than showing a misleading ratio.
+
+No new judgment/model. No broker/order/watch mutation (read-only).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from decimal import Decimal, InvalidOperation
+from typing import Any, Literal
+
+from app.mcp_server.tooling.analysis_analyze import analyze_stock_impl
+from app.schemas.invest_stock_detail_recommendation import (
+    RecoTradeSetup,
+    RecoZone,
+    StockDetailRecommendationResponse,
+)
+from app.services.invest_view_model.stock_detail_symbol_resolver import SymbolNotFound
+from app.services.investment_reports.risk_reward import (
+    build_trade_setup,
+    resolve_direction,
+)
+
+RecommendationMarket = Literal["kr", "us"]
+AnalyzeStockImpl = Callable[..., Awaitable[dict[str, Any]]]
+
+_DEFAULT_RECOMMENDATION: dict[str, Any] = {
+    "action": "hold",
+    "confidence": "low",
+    "rsi14": None,
+    "buy_zones": [],
+    "sell_targets": [],
+    "stop_loss": None,
+    "reasoning": "",
+    "insufficient_inputs": [],
+}
+
+
+def _action_to_side(action: Any) -> str | None:
+    if action == "buy":
+        return "buy"
+    if action == "sell":
+        return "sell"
+    return None
+
+
+def _to_decimal(value: Any) -> Decimal | None:
+    if value is None:
+        return None
+    try:
+        return Decimal(str(value))
+    except (InvalidOperation, ValueError):
+        return None
+
+
+def _parse_as_of(raw: Any) -> datetime:
+    if isinstance(raw, str):
+        try:
+            return datetime.fromisoformat(raw)
+        except ValueError:
+            pass
+    return datetime.now(UTC)
+
+
+def _derive_trade_setup(
+    reco: dict[str, Any], current_price: Any
+) -> RecoTradeSetup | None:
+    """R:R for a `long` setup only — fail-closed on any other outcome.
+
+    Only `action == "buy"` resolves to `long` (via `resolve_direction`);
+    `sell` resolves to `exit` and `hold` resolves to `unknown` — both skip.
+    entry defaults to `current_price`; when that's missing, falls back to
+    the highest (topmost) `buy_zone` price. stop/target come straight off
+    the recommendation's `stop_loss` / nearest (`[0]`) `sell_target`.
+    """
+    direction = resolve_direction(
+        side=_action_to_side(reco.get("action")),
+        intent="",
+        item_kind="action",
+        explicit_direction=None,
+    )
+    if direction != "long":
+        return None
+
+    entry_value = current_price
+    if entry_value is None:
+        buy_zones = reco.get("buy_zones") or []
+        if buy_zones:
+            entry_value = buy_zones[-1].get("price")
+
+    entry = _to_decimal(entry_value)
+    stop = _to_decimal(reco.get("stop_loss"))
+    sell_targets = reco.get("sell_targets") or []
+    target = _to_decimal(sell_targets[0].get("price")) if sell_targets else None
+
+    if entry is None or stop is None or target is None:
+        return None
+
+    setup = build_trade_setup(
+        entry_levels=[entry],
+        quantities=[None],
+        stop=stop,
+        target=target,
+        direction="long",
+    )
+    if setup.status != "computed" or setup.headline is None:
+        return None
+
+    return RecoTradeSetup(
+        direction=setup.direction,
+        entry=str(setup.headline.entry),
+        stop=str(setup.stop),
+        target=str(setup.target),
+        risk_pct=str(setup.headline.risk_pct),
+        reward_pct=str(setup.headline.reward_pct),
+        rr_ratio=str(setup.headline.rr_ratio),
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class StockDetailRecommendationProviders:
+    analyze: AnalyzeStockImpl = analyze_stock_impl
+
+
+DEFAULT_RECOMMENDATION_PROVIDERS = StockDetailRecommendationProviders()
+
+
+async def build_stock_detail_recommendation(
+    *,
+    market: RecommendationMarket,
+    symbol: str,
+    providers: StockDetailRecommendationProviders = DEFAULT_RECOMMENDATION_PROVIDERS,
+) -> StockDetailRecommendationResponse:
+    try:
+        analysis = await providers.analyze(symbol, market=market)
+    except ValueError as exc:
+        raise SymbolNotFound(f"{market} symbol not found: {symbol}") from exc
+
+    reco: dict[str, Any] = analysis.get("recommendation") or _DEFAULT_RECOMMENDATION
+    quote = analysis.get("quote") or {}
+    current_price = quote.get("price") or quote.get("current_price")
+
+    trade_setup = _derive_trade_setup(reco, current_price)
+
+    profile = analysis.get("profile")
+    name = profile.get("name") if isinstance(profile, dict) else None
+
+    return StockDetailRecommendationResponse(
+        market=market,
+        symbol=analysis.get("symbol") or symbol,
+        name=name,
+        as_of=_parse_as_of(analysis.get("derived_as_of")),
+        current_price=current_price,
+        action=reco.get("action", "hold"),
+        confidence=reco.get("confidence", "low"),
+        rsi14=reco.get("rsi14"),
+        reasoning=reco.get("reasoning", ""),
+        insufficient_inputs=list(reco.get("insufficient_inputs") or []),
+        buy_zones=[RecoZone(**zone) for zone in (reco.get("buy_zones") or [])],
+        sell_targets=[RecoZone(**zone) for zone in (reco.get("sell_targets") or [])],
+        stop_loss=reco.get("stop_loss"),
+        trade_setup=trade_setup,
+    )

--- a/docs/plans/ROB-692-stock-detail-reco-card-plan.md
+++ b/docs/plans/ROB-692-stock-detail-reco-card-plan.md
@@ -1,0 +1,334 @@
+# ROB-692 — 종목상세 결정론 추천 카드 (action·신뢰도·진입/목표/손절 + R:R)
+
+> Implementation plan only. Source untouched. Worktree:
+> `/Users/mgh3326/work/auto_trader.rob-692` (branch
+> `feature/ROB-692-stock-detail-reco-card`, based on `main` which already
+> includes ROB-690 R:R helper + ROB-691 scoreboard).
+
+## 1. Goal
+
+Surface the **already-existing deterministic** recommendation
+(`build_recommendation_for_equity`) on the `/invest/stocks/:market/:symbol`
+web page as an **on-demand card**: action (buy/hold/sell), confidence,
+buy_zones / sell_targets / stop_loss, reasoning — and, for a buy setup, a
+**risk/reward (R:R) chip** derived by reusing ROB-690's now-merged
+`risk_reward` helper (`resolve_direction` / `build_trade_setup`).
+
+The recommendation is MCP-only today. ROB-692 adds a thin read endpoint +
+frontend card. **No new judgment/model** — the endpoint composes existing
+deterministic primitives. Wiring R:R onto this recommendation path also
+**fulfills ROB-690's deferred "Step 4"** (attach R:R where the entry/stop/
+target actually originate: `build_recommendation_for_equity`).
+
+## 2. Verified current state (file:line, with corrections)
+
+### Recommendation core — MCP-only (confirmed)
+- `build_recommendation_for_equity(analysis, market_type)` —
+  `app/mcp_server/tooling/shared.py:524-808`. Issue's "~524-808" is **exact**.
+  Return shape confirmed (dict, or `None` when `quote`/price absent):
+  ```
+  {"action": "buy"|"hold"|"sell", "confidence": "high"|"medium"|"low",
+   "rsi14": float|None, "buy_zones": [ {price,type,reasoning} ] (≤3, asc),
+   "sell_targets": [ {price,type,reasoning} ] (≤3, asc, all > current_price),
+   "stop_loss": float|None, "reasoning": str}
+  ```
+  - `sell_targets` sorted **ascending** → `[0]` is the **nearest** target
+    above current price ("first sell_target" in the issue).
+  - `stop_loss` derived from nearest support×0.98, else 52w-low, else
+    current×0.92; KR is tick-snapped. Always **< current_price**.
+- **Correction to issue wording**: the issue says the reco is "returned by
+  `analyze_stock`". Precisely: `analyze_stock_impl`
+  (`app/mcp_server/tooling/analysis_analyze.py:726`) runs the full fetch
+  pipeline (250 OHLCV bars + quote + indicators + support_resistance +
+  opinions + valuation + optional peers), then `_apply_recommendation(...)`
+  (`analysis_analyze.py:683-723`) calls `build_recommendation_for_equity`
+  (line 690), **floors** it via `insufficient_inputs`/`floored_action`, adds
+  `insufficient_inputs`, and attaches `analysis["recommendation"]`. Only
+  `equity_kr`/`equity_us` get a recommendation (line 687 early-return for
+  crypto).
+- **No FastAPI route exposes it** (confirmed): the only callers of
+  `build_recommendation_for_equity` and `analyze_stock_impl` live under
+  `app/mcp_server/tooling/**` (+ tests). `grep app/routers` → none.
+
+### ROB-690 R:R helper — in main (confirmed, path correct)
+- `app/services/investment_reports/risk_reward.py` — `resolve_direction`
+  (:78), `compute_leg` (:147), `build_trade_setup` (:200). stdlib+`decimal`
+  only; long-default / explicit-short; **fail-closed**
+  (`direction_price_mismatch` / `degenerate_risk` → empty legs / `None`).
+- `resolve_direction(side, intent, item_kind, explicit_direction)` returns
+  `"long"|"short"|"exit"|"unknown"` — `side="buy"`→`long`, `side="sell"`→
+  `exit` (skip R:R), else intent fallback, else `unknown` (skip).
+- **Correction/clarification**: `_serialise_trade_setup` (Decimal→str JSON
+  dict) is **not** in `risk_reward.py` — it lives at
+  `app/services/investment_reports/ingestion.py:41-67`. ROB-692 will
+  **mirror** that serialization shape (not import it) so the wire payload
+  matches what the frontend already knows how to parse.
+- Reference wiring precedent: `ingestion.py:561-585` — the exact
+  `resolve_direction → (long/short only) → build_trade_setup → (status
+  ==="computed") → _serialise_trade_setup` sequence to copy.
+
+### Frontend — no reco/confidence/setup panel today (confirmed)
+- `frontend/invest/src/pages/stock-detail/StockDetailPage.tsx` — `market`/
+  `symbol` from `useParams` (`:497-500`; `market` default `"us"`, type
+  `StockDetailMarket = "kr"|"us"|"crypto"`). Page eagerly fires ~8 fetches in
+  one `useEffect` (`:512-555`) and renders cards at `:586-609`
+  (`HeaderCard`, `TradeGuardrail`, `ChartCard`, `OrderLedgerCard`,
+  `WatchCard`, `RetrospectiveCard`, `NewsCard`, `InvestorFlowCard`…). **No
+  recommendation / confidence / entry-target-stop card exists.**
+- `frontend/invest/src/desktop/stock-detail/` today: `InvestorFlowCard`,
+  `OrderLedgerCard`, `RetrospectiveCard`, `WatchCard`. (No reco card.)
+- Confidence-chip style to match — `InvestmentReportBundleContent.tsx`
+  (`frontend/invest/src/components/investment-reports/`): `formatConfidence`
+  (:197), chip `Pill tone="accent" size="sm"` "신뢰도 {n}" (:310-314); R:R
+  chip pattern `Pill tone={long?"gain":"warn"}` + "손익비 R:R … 리스크 …%
+  리워드 …%" (:330-340). `Pill` is exported from the shared DS
+  (`import { Card, Pill } from "../../ds"`; `ds/atoms.tsx` →
+  `PillTone` includes `gain|warn|accent|paper`). ROB-692 reuses `Pill` from
+  `ds` directly — it does **not** import from or edit
+  `InvestmentReportBundleContent.tsx` (that file is ROB-693's; see §7).
+
+### Read-endpoint pattern to mirror (confirmed)
+- `app/routers/invest_api.py` — prefix `/trading/api/invest`;
+  `StockDetailMarketParam = Literal["kr","us","crypto"]` (:430); existing
+  siblings `GET /stock-detail/{market}/{symbol}` (:433) and
+  `.../research-consensus` (:455). Auth: `Depends(get_authenticated_user)`
+  + `Depends(get_db)`; `SymbolNotFound → HTTPException(404)`;
+  **research-consensus 400s for `crypto`** (`:463-467`,
+  `research_consensus_supports_kr_us_only`) — the exact equity-only guard
+  ROB-692 mirrors.
+- Frontend fetch base: `frontend/invest/src/api/stockDetail.ts:18`
+  `stockDetailPath` → `/invest/api/stock-detail/{market}/{symbol}` (proxy
+  rewrite of the `/trading/api/invest` prefix; existing fetchers all use it —
+  no correction, just mirror).
+- Service-layer precedent that imports MCP tooling into web code is
+  established (e.g. `stock_detail_research_consensus_service.py` imports
+  `app.mcp_server.tooling.fundamentals._valuation`; ~20 services import
+  `app.mcp_server.tooling`). Reusing `analyze_stock_impl` from a view-model
+  service is **in-pattern** and violates no boundary (it does deterministic
+  fetch+scoring, **no in-process LLM** — the ROB-501 guard only forbids LLM
+  providers).
+- Market map (`shared.normalize_market`, :113): `kr→equity_kr`,
+  `us→equity_us`, `crypto→crypto`. URL market feeds `analyze_stock_impl`
+  directly.
+
+## 3. Design decisions
+
+### 3a. Endpoint shape
+```
+GET /trading/api/invest/stock-detail/{market}/{symbol}/recommendation
+  auth: Depends(get_authenticated_user) + Depends(get_db)   # same as siblings
+  market: StockDetailMarketParam = Literal["kr","us","crypto"]
+  → 400 research_recommendation_supports_kr_us_only   when market=="crypto"
+  → 404 symbol_not_found                              on ValueError/SymbolNotFound
+  → 200 StockDetailRecommendationResponse
+```
+Response schema (`app/schemas/invest_stock_detail_recommendation.py`, NEW):
+```
+StockDetailRecommendationResponse:
+  market, symbol, name: str|None
+  as_of: datetime            # analysis derived_as_of / now(UTC)
+  current_price: float|None
+  action: Literal["buy","hold","sell"]
+  confidence: Literal["high","medium","low"]
+  rsi14: float|None
+  reasoning: str
+  insufficient_inputs: list[str]      # carried through from floor
+  buy_zones:   list[RecoZone]         # {price, type, reasoning}  (≤3)
+  sell_targets:list[RecoZone]         # {price, type, reasoning}  (≤3)
+  stop_loss: float|None
+  trade_setup: RecoTradeSetup | None  # R:R; None when not derivable (fail-closed)
+
+RecoTradeSetup:  # mirrors ingestion._serialise_trade_setup headline shape
+  direction: Literal["long","short"]
+  entry, stop, target: str           # Decimal-as-string
+  risk_pct, reward_pct, rr_ratio: str
+```
+
+### 3b. Equity-only scope
+`build_recommendation_for_equity` is equity-specific and
+`_apply_recommendation` no-ops for crypto. Mirror research-consensus:
+**crypto → 400** at the router; the frontend gates the card to
+`market !== "crypto"` (same guard the page already applies to
+`ResearchConsensusCard`). No crypto fallback synthesized (honest omission).
+
+### 3c. Service reuses `analyze_stock_impl` (no re-fetch reimplementation)
+New `app/services/invest_view_model/stock_detail_recommendation_service.py`:
+```
+async def build_stock_detail_recommendation(*, market, symbol) -> ...:
+    analysis = await analyze_stock_impl(symbol, market=market)   # MCP impl fn
+    reco = analysis.get("recommendation")            # already floored
+    quote = analysis.get("quote") or {}
+    current = quote.get("price")
+    setup = _derive_trade_setup(reco, current, market)  # §3d, may be None
+    return StockDetailRecommendationResponse(... reco fields ..., trade_setup=setup)
+```
+Rationale for reuse over reimplementation: `analyze_stock_impl` is the *only*
+place that assembles the full `analysis` dict (quote+indicators+S/R+opinions+
+valuation) that `build_recommendation_for_equity` consumes, **and** applies
+the ROB-486/insufficient-inputs floor. Re-deriving it would duplicate ~250
+lines of fetch/floor logic and drift. It already carries ROB-638 fetch-cache
+internally, so repeat calls are cheap-ish.
+
+### 3d. R:R reuse (fulfills ROB-690 Step 4) + direction guard + fail-closed
+`_derive_trade_setup(reco, current_price, market)`:
+1. `direction = resolve_direction(side=_action_to_side(reco["action"]),`
+   `intent=None-ish, item_kind="action", explicit_direction=None)`
+   where `_action_to_side`: `buy→"buy"` (→`long`), `sell→"sell"` (→`exit`),
+   `hold→None` (→`unknown`). **Only `long` proceeds**; `exit`/`unknown`/
+   `short` → return `None` (no R:R chip). (No live position here, so an
+   `exit`/sell reco has no realized frame to show — skip, per issue.)
+2. Build the triple (long): `entry = current_price` (answers "R:R if bought
+   at today's price"); `stop = reco["stop_loss"]`; `target =
+   reco["sell_targets"][0]["price"]` (nearest above current). If `current` is
+   missing but `buy_zones` exist, fall back `entry = buy_zones[-1]["price"]`
+   (top/highest buy_zone, still < current historically) — the issue's
+   "entry = current price **or** top buy_zone".
+3. Feed `build_trade_setup(entry_levels=[entry], quantities=[None],`
+   `stop=Decimal(stop), target=Decimal(target), direction="long")`. Any
+   missing leg (no stop / no target) → skip. `status != "computed"`
+   (`direction_price_mismatch` when the price ordering isn't
+   `stop < entry < target`, or `degenerate_risk`) → return `None`.
+   **Fail-closed**: the card simply omits the R:R chip rather than showing a
+   misleading ratio.
+4. Serialize headline → `RecoTradeSetup` (mirror
+   `ingestion._serialise_trade_setup`: Decimal→str). Single-leg is the
+   default; multi-leg over `buy_zones` is an **optional** follow-up (keep
+   single-entry for clarity + simplest fail-closed surface).
+
+Decimal hygiene: convert floats via `Decimal(str(x))` (the helper is
+Decimal-typed; never pass raw float).
+
+### 3e. On-demand, not eager
+The card fetches **on user action** (a "추천 실행 / R:R 보기" button inside
+the card), not in the page-load `useEffect`. Justification:
+- `analyze_stock_impl` is the heaviest call on the page (multi-provider:
+  OHLCV 250 bars + quote + indicators + opinions + valuation + optional
+  peers). The page already fires ~8 eager fetches; adding this to load would
+  measurably slow first paint and multiply provider/rate-limit pressure on
+  every view.
+- The recommendation is an explicit "compute me a fresh deterministic call"
+  action, not passive context — on-demand matches intent and keeps the
+  default page cheap. Card shows an idle CTA → loading → result/empty/error.
+
+### 3f. migration-0
+Read-only; no persistence, no new table/column. No caching row needed
+(`analyze_stock_impl` already memoizes fetches via ROB-638). `alembic
+heads` unchanged.
+
+## 4. Step-by-step
+
+### Backend
+1. **Schema** — `app/schemas/invest_stock_detail_recommendation.py` (NEW):
+   `RecoZone`, `RecoTradeSetup`, `StockDetailRecommendationResponse`
+   (Pydantic v2, `from __future__ import annotations`).
+2. **Service** —
+   `app/services/invest_view_model/stock_detail_recommendation_service.py`
+   (NEW): `build_stock_detail_recommendation(*, market, symbol)` calling
+   `analyze_stock_impl` + `_derive_trade_setup` (uses
+   `app.services.investment_reports.risk_reward.{resolve_direction,
+   build_trade_setup}`). Map `analyze_stock_impl` `ValueError` (unsupported
+   symbol) → raise `SymbolNotFound` (reuse the existing exception the router
+   already catches).
+3. **Router** — `app/routers/invest_api.py` (EDIT): add
+   `GET /stock-detail/{market}/{symbol}/recommendation` mirroring
+   `get_stock_detail_research_consensus` (crypto→400, SymbolNotFound→404).
+   Add the schema + service imports at top.
+
+### Frontend
+4. **Types** — `frontend/invest/src/types/stockDetail.ts` (EDIT): add
+   `StockDetailRecommendationResponse` (+ `RecoZone`, `RecoTradeSetup`).
+5. **API** — `frontend/invest/src/api/stockDetail.ts` (EDIT): add
+   `fetchStockDetailRecommendation({market, symbol})` using existing
+   `stockDetailPath(...) + "/recommendation"`.
+6. **Card** —
+   `frontend/invest/src/desktop/stock-detail/RecommendationCard.tsx` (NEW):
+   idle-CTA / loading / error / result states. Renders action badge,
+   confidence `Pill tone="accent" size="sm"` (matching the report-bundle
+   style), buy_zones / sell_targets / stop_loss list, reasoning, and — when
+   `trade_setup` present — the R:R chip (`Pill tone="gain"` "롱" + "손익비
+   R:R … · 리스크 …% · 리워드 …%", copying the bundle-card pattern).
+   `insufficient_inputs` → a muted note. **Self-contained** parse/format
+   (no import from `InvestmentReportBundleContent.tsx`). Import `Pill`,
+   `Card` from `../../ds`.
+7. **Page wiring** — `StockDetailPage.tsx` (EDIT): add
+   `recommendation`/`recoLoading`/`recoErr` state + a `loadRecommendation()`
+   callback (fetch on button click; reset on `market`/`symbol` change).
+   Render `{market !== "crypto" ? <RecommendationCard … onLoad={…}/> : null}`
+   in the center column near the top (e.g. after `TradeGuardrail`).
+
+### Tests (§5)
+
+## 5. Test plan
+Backend (`tests/test_invest_stock_detail_recommendation.py`, NEW):
+- Service: monkeypatch `analyze_stock_impl` to a canned `analysis` dict →
+  assert response fields pass through (action/confidence/zones/targets/
+  stop_loss/reasoning/insufficient_inputs).
+- R:R happy path (buy, `stop < current < target`) → `trade_setup.direction
+  == "long"`, `rr_ratio` matches `(target-entry)/(entry-stop)` quantized.
+- Fail-closed: (a) `action="sell"` → `trade_setup is None`; (b)
+  `action="hold"` → `None`; (c) buy but `sell_targets == []` → `None`;
+  (d) buy but `stop_loss >= current` (degenerate/mismatch) → `None`.
+- Router: crypto → 400 `research_recommendation_supports_kr_us_only`;
+  unknown symbol (service raises `SymbolNotFound`) → 404; unauthenticated →
+  401/403 (reuse existing auth-fixture pattern from sibling stock-detail
+  tests).
+- Reuse the real `risk_reward` helper in the R:R assertions (don't mock it)
+  to prove the ROB-690 reuse.
+
+Frontend (optional, if a sibling card test exists):
+`RecommendationCard.test.tsx` — idle→click→result render; R:R chip shows only
+when `trade_setup` present; crypto card not rendered.
+
+Commands: `uv run pytest tests/test_invest_stock_detail_recommendation.py -v`;
+`make lint`; (frontend) `cd frontend/invest && npm run test -- RecommendationCard`.
+
+## 6. Migration note
+**migration-0.** No ORM/schema/table changes. Pure read composition over
+existing deterministic functions. `uv run alembic heads` unchanged. No
+persistence, no new caching table (ROB-638 fetch-cache is internal to
+`analyze_stock_impl`).
+
+## 7. Risks / out-of-scope
+- **Parallel-safety vs ROB-693** — ROB-693 edits `app/schemas/
+  research_pipeline.py`, `app/schemas/investment_reports.py`,
+  `app/services/investment_stages/hermes_ingest.py`, and
+  `frontend/.../InvestmentReportBundleContent.tsx`. ROB-692 touches **none**
+  of those (see §8). Overlap-avoidance: ROB-692 puts its schema in a **new**
+  `invest_stock_detail_recommendation.py` and creates a **new**
+  `RecommendationCard.tsx` rather than editing the bundle card — fully
+  disjoint. Both may add to `app/schemas/` but never the same file.
+- **Latency / provider load** — mitigated by on-demand fetch (§3e); if even
+  on-demand is too heavy, a future follow-up could add a lighter "reco-only"
+  fetch path, but that's out of scope.
+- **Do NOT resurrect deprecated pages** — `/analysis-json`, `/stock-latest`
+  are 410 tombstones (`app/routers/deprecated_pages.py:16-17`). This card
+  lives only under the SPA `/invest/stocks/:market/:symbol`; the tombstone
+  router is untouched.
+- **Floor semantics** — the response carries `insufficient_inputs` and the
+  already-floored action/confidence verbatim; ROB-692 does not re-score or
+  re-floor. R:R never contradicts the floor (skips on non-`long`).
+- **Out of scope**: crypto recommendation, multi-leg R:R over all buy_zones
+  (single representative entry only), persisting the reco, any broker/order/
+  watch mutation (none reachable — read-only).
+
+## 8. Exact files touched (for ROB-693 disjointness check)
+**New (backend):**
+- `app/schemas/invest_stock_detail_recommendation.py`
+- `app/services/invest_view_model/stock_detail_recommendation_service.py`
+**Edit (backend):**
+- `app/routers/invest_api.py`  (add one GET route + 2 imports)
+**New (frontend):**
+- `frontend/invest/src/desktop/stock-detail/RecommendationCard.tsx`
+**Edit (frontend):**
+- `frontend/invest/src/types/stockDetail.ts`  (add response types)
+- `frontend/invest/src/api/stockDetail.ts`  (add fetcher)
+- `frontend/invest/src/pages/stock-detail/StockDetailPage.tsx`  (state + render)
+**New (tests):**
+- `tests/test_invest_stock_detail_recommendation.py`
+- (optional) `frontend/invest/src/__tests__/RecommendationCard.test.tsx`
+
+**Disjoint from ROB-693** (`app/schemas/research_pipeline.py`,
+`app/schemas/investment_reports.py`,
+`app/services/investment_stages/hermes_ingest.py`,
+`frontend/invest/src/components/investment-reports/InvestmentReportBundleContent.tsx`)
+— zero shared files.

--- a/frontend/invest/src/__tests__/RecommendationCard.test.tsx
+++ b/frontend/invest/src/__tests__/RecommendationCard.test.tsx
@@ -1,0 +1,113 @@
+// ROB-692 — on-demand deterministic recommendation card on the stock detail
+// page. Idle CTA -> click -> result render; R:R chip only when trade_setup
+// is present; card renders nothing for crypto (unsupported market).
+
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, test, vi } from "vitest";
+import { RecommendationCard } from "../desktop/stock-detail/RecommendationCard";
+import type { StockDetailRecommendationResponse } from "../types/stockDetail";
+
+function reco(
+  overrides: Partial<StockDetailRecommendationResponse> = {},
+): StockDetailRecommendationResponse {
+  return {
+    market: "us",
+    symbol: "AAPL",
+    name: "Apple Inc.",
+    as_of: "2026-07-04T09:00:00+09:00",
+    current_price: 100,
+    action: "buy",
+    confidence: "high",
+    rsi14: 28.5,
+    reasoning: "RSI 28.5 (oversold)",
+    insufficient_inputs: [],
+    buy_zones: [{ price: 95, type: "support", reasoning: "Support at 95" }],
+    sell_targets: [{ price: 120, type: "resistance", reasoning: "Resistance at 120" }],
+    stop_loss: 90,
+    trade_setup: {
+      direction: "long",
+      entry: "100.0",
+      stop: "90.0",
+      target: "120.0",
+      risk_pct: "10.00",
+      reward_pct: "20.00",
+      rr_ratio: "2.00",
+    },
+    ...overrides,
+  };
+}
+
+describe("RecommendationCard (ROB-692)", () => {
+  test("renders nothing for crypto market", () => {
+    const { container } = render(
+      <RecommendationCard market="crypto" data={undefined} loading={false} error={undefined} onLoad={vi.fn()} />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  test("idle state shows a CTA button and no result", () => {
+    render(<RecommendationCard market="us" data={undefined} loading={false} error={undefined} onLoad={vi.fn()} />);
+    expect(screen.getByText("추천 실행 / R:R 보기")).toBeInTheDocument();
+    expect(screen.queryByText("매수")).not.toBeInTheDocument();
+  });
+
+  test("clicking the CTA calls onLoad", async () => {
+    const user = userEvent.setup();
+    const onLoad = vi.fn();
+    render(<RecommendationCard market="us" data={undefined} loading={false} error={undefined} onLoad={onLoad} />);
+    await user.click(screen.getByText("추천 실행 / R:R 보기"));
+    expect(onLoad).toHaveBeenCalledTimes(1);
+  });
+
+  test("loading state shows a loading message", () => {
+    render(<RecommendationCard market="us" data={undefined} loading={true} error={undefined} onLoad={vi.fn()} />);
+    expect(screen.getByText("불러오는 중입니다…")).toBeInTheDocument();
+  });
+
+  test("error state shows the error and a retry button", () => {
+    render(<RecommendationCard market="us" data={undefined} loading={false} error="network down" onLoad={vi.fn()} />);
+    expect(screen.getByText(/network down/)).toBeInTheDocument();
+    expect(screen.getByText("다시 시도")).toBeInTheDocument();
+  });
+
+  test("renders action/confidence/zones/stop_loss and the R:R chip when trade_setup is present", () => {
+    render(<RecommendationCard market="us" data={reco()} loading={false} error={undefined} onLoad={vi.fn()} />);
+    expect(screen.getByText("매수")).toBeInTheDocument();
+    expect(screen.getByText(/신뢰도 높음/)).toBeInTheDocument();
+    expect(screen.getAllByText(/RSI 28.5/).length).toBeGreaterThan(0);
+    expect(screen.getByText(/Support at 95/)).toBeInTheDocument();
+    expect(screen.getByText(/Resistance at 120/)).toBeInTheDocument();
+    expect(screen.getByText("롱")).toBeInTheDocument();
+    expect(screen.getByText(/손익비 R:R 2\.00/)).toBeInTheDocument();
+  });
+
+  test("omits the R:R chip when trade_setup is null (e.g. sell/hold recommendation)", () => {
+    render(
+      <RecommendationCard
+        market="us"
+        data={reco({ action: "sell", trade_setup: null })}
+        loading={false}
+        error={undefined}
+        onLoad={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("매도")).toBeInTheDocument();
+    expect(screen.queryByText("롱")).not.toBeInTheDocument();
+    expect(screen.queryByText("숏")).not.toBeInTheDocument();
+    expect(screen.queryByText(/손익비/)).not.toBeInTheDocument();
+  });
+
+  test("shows the insufficient_inputs note when present", () => {
+    render(
+      <RecommendationCard
+        market="us"
+        data={reco({ insufficient_inputs: ["price", "consensus"] })}
+        loading={false}
+        error={undefined}
+        onLoad={vi.fn()}
+      />,
+    );
+    expect(screen.getByText(/데이터 부족: price, consensus/)).toBeInTheDocument();
+  });
+});

--- a/frontend/invest/src/api/stockDetail.ts
+++ b/frontend/invest/src/api/stockDetail.ts
@@ -3,6 +3,7 @@ import type {
   StockDetailMarket,
   StockDetailNewsResponse,
   StockDetailOrdersResponse,
+  StockDetailRecommendationResponse,
   StockDetailResearchConsensusResponse,
   StockDetailResponse,
 } from "../types/stockDetail";
@@ -31,6 +32,17 @@ export async function fetchStockDetailResearchConsensus(params: {
   symbol: string;
 }): Promise<StockDetailResearchConsensusResponse> {
   return getJson<StockDetailResearchConsensusResponse>(`${stockDetailPath(params.market, params.symbol)}/research-consensus`);
+}
+
+// ROB-692 — on-demand deterministic recommendation (action/confidence/
+// buy_zones/sell_targets/stop_loss/reasoning + optional R:R trade_setup).
+// Crypto is unsupported at the router (400) — callers should gate on
+// market !== "crypto" before calling, same as research-consensus.
+export async function fetchStockDetailRecommendation(params: {
+  market: StockDetailMarket;
+  symbol: string;
+}): Promise<StockDetailRecommendationResponse> {
+  return getJson<StockDetailRecommendationResponse>(`${stockDetailPath(params.market, params.symbol)}/recommendation`);
 }
 
 export async function fetchStockDetailCandles(params: {

--- a/frontend/invest/src/desktop/stock-detail/RecommendationCard.tsx
+++ b/frontend/invest/src/desktop/stock-detail/RecommendationCard.tsx
@@ -1,0 +1,163 @@
+// ROB-692 — on-demand deterministic recommendation card for the stock detail
+// page. Surfaces `build_recommendation_for_equity` (action/confidence/
+// buy_zones/sell_targets/stop_loss/reasoning) plus, for a buy setup, an R:R
+// chip that reuses the ROB-690 risk_reward helper server-side
+// (`StockDetailRecommendationResponse.trade_setup`).
+//
+// On-demand by design: the underlying `analyze_stock_impl` call is the
+// heaviest fetch on this page (OHLCV + quote + indicators + opinions +
+// valuation, optionally peers). It only runs when the operator clicks the
+// button below — never in the page's eager load effect.
+//
+// Self-contained parse/format — does NOT import from
+// InvestmentReportBundleContent.tsx (that file is ROB-693's; kept disjoint).
+
+import { Button, Card, Pill } from "../../ds";
+import type { RecoZone, StockDetailRecommendationResponse } from "../../types/stockDetail";
+
+const ACTION_LABELS: Record<StockDetailRecommendationResponse["action"], string> = {
+  buy: "매수",
+  hold: "관망",
+  sell: "매도",
+};
+
+const ACTION_TONES: Record<StockDetailRecommendationResponse["action"], "gain" | "loss" | "paper"> = {
+  buy: "gain",
+  hold: "paper",
+  sell: "loss",
+};
+
+const CONFIDENCE_LABELS: Record<StockDetailRecommendationResponse["confidence"], string> = {
+  high: "높음",
+  medium: "보통",
+  low: "낮음",
+};
+
+function fmtPrice(value: number | null | undefined): string {
+  if (value == null) return "−";
+  return value.toLocaleString("ko-KR", { maximumFractionDigits: 4 });
+}
+
+function ZoneList({ title, zones }: { title: string; zones: RecoZone[] }) {
+  if (zones.length === 0) return null;
+  return (
+    <div style={{ display: "grid", gap: 4 }}>
+      <strong style={{ fontSize: 12, color: "var(--fg-3)" }}>{title}</strong>
+      <ul style={{ margin: 0, paddingLeft: 18, display: "grid", gap: 2 }}>
+        {zones.map((zone, idx) => (
+          <li key={`${zone.type}-${idx}`} style={{ fontSize: 13 }}>
+            {fmtPrice(zone.price)}
+            <span style={{ color: "var(--fg-3)", marginLeft: 6, fontSize: 12 }}>{zone.reasoning}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export function RecommendationCard({
+  market,
+  data,
+  loading,
+  error,
+  onLoad,
+}: {
+  market: "kr" | "us" | "crypto";
+  data: StockDetailRecommendationResponse | undefined;
+  loading: boolean;
+  error: string | undefined;
+  onLoad: () => void;
+}) {
+  if (market === "crypto") return null;
+
+  return (
+    <Card data-testid="stock-detail-recommendation">
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline", gap: 8 }}>
+        <div>
+          <h2 style={{ margin: "0 0 4px", fontSize: 16 }}>추천</h2>
+          <p style={{ margin: 0, fontSize: 12, color: "var(--fg-3)" }}>
+            결정론적 규칙 기반 action · 신뢰도 · 진입/목표/손절 (요청 시 계산)
+          </p>
+        </div>
+        {data ? (
+          <Button size="sm" variant="secondary" onClick={onLoad} disabled={loading}>
+            {loading ? "계산 중…" : "다시 계산"}
+          </Button>
+        ) : null}
+      </div>
+
+      {!data && !loading && !error ? (
+        <div style={{ marginTop: 12 }}>
+          <Button size="sm" variant="primary" onClick={onLoad}>
+            추천 실행 / R:R 보기
+          </Button>
+        </div>
+      ) : null}
+
+      {loading && !data ? (
+        <p style={{ margin: "12px 0 0", color: "var(--fg-3)" }}>불러오는 중입니다…</p>
+      ) : null}
+
+      {error ? (
+        <div style={{ marginTop: 12, display: "grid", gap: 8 }}>
+          <span style={{ color: "var(--danger)", fontSize: 13 }}>오류: {error}</span>
+          <div>
+            <Button size="sm" variant="secondary" onClick={onLoad} disabled={loading}>
+              다시 시도
+            </Button>
+          </div>
+        </div>
+      ) : null}
+
+      {data ? (
+        <div style={{ marginTop: 12, display: "grid", gap: 10 }}>
+          <div style={{ display: "flex", gap: 6, flexWrap: "wrap", alignItems: "center" }}>
+            <Pill tone={ACTION_TONES[data.action]}>{ACTION_LABELS[data.action]}</Pill>
+            <Pill tone="accent" size="sm">
+              신뢰도 {CONFIDENCE_LABELS[data.confidence]}
+            </Pill>
+            {data.rsi14 != null ? (
+              <Pill tone="paper" size="sm">
+                RSI {data.rsi14.toFixed(1)}
+              </Pill>
+            ) : null}
+          </div>
+
+          {data.reasoning ? (
+            <p style={{ margin: 0, fontSize: 13, color: "var(--fg-2)", lineHeight: 1.5 }}>{data.reasoning}</p>
+          ) : null}
+
+          <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(140px, 1fr))", gap: 10 }}>
+            <ZoneList title="매수 구간" zones={data.buy_zones} />
+            <ZoneList title="목표가" zones={data.sell_targets} />
+          </div>
+
+          {data.stop_loss != null ? (
+            <div style={{ fontSize: 13 }}>
+              <strong style={{ color: "var(--fg-3)", fontWeight: 600, marginRight: 6 }}>손절가</strong>
+              {fmtPrice(data.stop_loss)}
+            </div>
+          ) : null}
+
+          {data.trade_setup ? (
+            <div style={{ display: "flex", gap: 6, flexWrap: "wrap", alignItems: "center" }}>
+              <Pill tone={data.trade_setup.direction === "long" ? "gain" : "warn"} size="sm">
+                {data.trade_setup.direction === "long" ? "롱" : "숏"}
+              </Pill>
+              <span style={{ fontSize: 12, color: "var(--fg-2)" }}>
+                손익비 R:R {data.trade_setup.rr_ratio} · 리스크 {data.trade_setup.risk_pct}% · 리워드{" "}
+                {data.trade_setup.reward_pct}%
+              </span>
+            </div>
+          ) : null}
+
+          {data.insufficient_inputs.length > 0 ? (
+            <p style={{ margin: 0, fontSize: 12, color: "var(--fg-3)" }}>
+              데이터 부족: {data.insufficient_inputs.join(", ")}
+            </p>
+          ) : null}
+        </div>
+      ) : null}
+    </Card>
+  );
+}

--- a/frontend/invest/src/pages/stock-detail/StockDetailPage.tsx
+++ b/frontend/invest/src/pages/stock-detail/StockDetailPage.tsx
@@ -8,12 +8,14 @@ import {
   fetchStockDetailNews,
   fetchStockDetailOrderLedger,
   fetchStockDetailOrders,
+  fetchStockDetailRecommendation,
   fetchStockDetailResearchConsensus,
 } from "../../api/stockDetail";
 import { fetchWatches } from "../../api/watches";
 import { fetchRetrospectives } from "../../api/retrospectives";
 import { InvestorFlowCard } from "../../desktop/stock-detail/InvestorFlowCard";
 import { OrderLedgerCard } from "../../desktop/stock-detail/OrderLedgerCard";
+import { RecommendationCard } from "../../desktop/stock-detail/RecommendationCard";
 import { WatchCard } from "../../desktop/stock-detail/WatchCard";
 import { RetrospectiveCard } from "../../desktop/stock-detail/RetrospectiveCard";
 import { accountSourceMeta } from "../../desktop/AccountSourceMeta";
@@ -25,6 +27,7 @@ import type {
   StockDetailMarket,
   StockDetailNewsResponse,
   StockDetailOrdersResponse,
+  StockDetailRecommendationResponse,
   StockDetailResearchConsensusResponse,
   StockDetailResponse,
   StockDetailHolding,
@@ -507,6 +510,9 @@ export function StockDetailPage() {
   const [news, setNews] = useState<StockDetailNewsResponse | undefined>();
   const [researchConsensus, setResearchConsensus] = useState<StockDetailResearchConsensusResponse | undefined>();
   const [researchErr, setResearchErr] = useState<string | undefined>();
+  const [recommendation, setRecommendation] = useState<StockDetailRecommendationResponse | undefined>();
+  const [recoLoading, setRecoLoading] = useState(false);
+  const [recoErr, setRecoErr] = useState<string | undefined>();
   const [err, setErr] = useState<string | undefined>();
 
   useEffect(() => {
@@ -520,6 +526,9 @@ export function StockDetailPage() {
     setNews(undefined);
     setResearchConsensus(undefined);
     setResearchErr(undefined);
+    setRecommendation(undefined);
+    setRecoLoading(false);
+    setRecoErr(undefined);
     setErr(undefined);
 
     fetchStockDetail({ market, symbol })
@@ -554,6 +563,24 @@ export function StockDetailPage() {
     };
   }, [market, symbol]);
 
+  // ROB-692 — on-demand only (never in the eager load effect above):
+  // analyze_stock_impl is the heaviest fetch on this page.
+  const loadRecommendation = () => {
+    if (market === "crypto") return;
+    setRecoLoading(true);
+    setRecoErr(undefined);
+    fetchStockDetailRecommendation({ market, symbol })
+      .then((r) => {
+        setRecommendation(r);
+      })
+      .catch((e) => {
+        setRecoErr(String(e?.message ?? e));
+      })
+      .finally(() => {
+        setRecoLoading(false);
+      });
+  };
+
   const sideDetails = useMemo(() => {
     if (!data) {
       return <MemoCard />;
@@ -587,6 +614,15 @@ export function StockDetailPage() {
             <>
               <HeaderCard data={data} />
               <TradeGuardrail data={data} />
+              {market !== "crypto" ? (
+                <RecommendationCard
+                  market={market}
+                  data={recommendation}
+                  loading={recoLoading}
+                  error={recoErr}
+                  onLoad={loadRecommendation}
+                />
+              ) : null}
               <HoldingCard data={data} />
               <FxSensitivityCard data={data.fxSensitivity} />
               <ChartCard candles={candles} />

--- a/frontend/invest/src/types/stockDetail.ts
+++ b/frontend/invest/src/types/stockDetail.ts
@@ -389,6 +389,39 @@ export interface StockDetailResearchConsensusResponse {
   freshness: StockDetailResearchFreshness;
 }
 
+export interface RecoZone {
+  price: number;
+  type: string;
+  reasoning: string;
+}
+
+export interface RecoTradeSetup {
+  direction: "long" | "short";
+  entry: string;
+  stop: string;
+  target: string;
+  risk_pct: string;
+  reward_pct: string;
+  rr_ratio: string;
+}
+
+export interface StockDetailRecommendationResponse {
+  market: "kr" | "us";
+  symbol: string;
+  name: string | null;
+  as_of: string;
+  current_price: number | null;
+  action: "buy" | "hold" | "sell";
+  confidence: "high" | "medium" | "low";
+  rsi14: number | null;
+  reasoning: string;
+  insufficient_inputs: string[];
+  buy_zones: RecoZone[];
+  sell_targets: RecoZone[];
+  stop_loss: number | null;
+  trade_setup: RecoTradeSetup | null;
+}
+
 export interface StockDetailCandlesResponse {
   symbol: string;
   market: StockDetailMarket;

--- a/tests/test_invest_stock_detail_recommendation.py
+++ b/tests/test_invest_stock_detail_recommendation.py
@@ -1,0 +1,390 @@
+"""ROB-692 — stock-detail deterministic recommendation card (service + router).
+
+Covers: pass-through of the already-floored `build_recommendation_for_equity`
+fields, the ROB-690 R:R reuse (fail-closed on non-`long`/degenerate/mismatched
+triangles, buy_zone entry fallback), and the router's crypto/404/auth
+behaviour mirroring the `research-consensus` sibling.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.core.db import get_db
+from app.routers import invest_api
+from app.routers.dependencies import get_authenticated_user
+from app.routers.invest_api import router as invest_api_router
+from app.schemas.invest_stock_detail_recommendation import (
+    StockDetailRecommendationResponse,
+)
+from app.services.invest_view_model.stock_detail_recommendation_service import (
+    StockDetailRecommendationProviders,
+    build_stock_detail_recommendation,
+)
+from app.services.invest_view_model.stock_detail_symbol_resolver import SymbolNotFound
+
+
+def _make_analyze(
+    *,
+    action: str,
+    confidence: str = "medium",
+    current_price: float | None = 100.0,
+    stop_loss: float | None = 90.0,
+    sell_targets: list[dict[str, Any]] | None = None,
+    buy_zones: list[dict[str, Any]] | None = None,
+    insufficient_inputs: list[str] | None = None,
+    rsi14: float | None = 55.2,
+    reasoning: str = "RSI 55.2 (neutral)",
+    symbol: str = "AAPL",
+    derived_as_of: str = "2026-07-04T09:00:00+09:00",
+):
+    async def _fake(
+        symbol_arg: str, market: str | None = None, **kwargs: Any
+    ) -> dict[str, Any]:
+        return {
+            "symbol": symbol,
+            "quote": {"price": current_price},
+            "recommendation": {
+                "action": action,
+                "confidence": confidence,
+                "rsi14": rsi14,
+                "buy_zones": buy_zones if buy_zones is not None else [],
+                "sell_targets": sell_targets if sell_targets is not None else [],
+                "stop_loss": stop_loss,
+                "reasoning": reasoning,
+                "insufficient_inputs": insufficient_inputs or [],
+            },
+            "profile": {},
+            "derived_as_of": derived_as_of,
+        }
+
+    return _fake
+
+
+# ---------------------------------------------------------------------------
+# Service — field pass-through
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_service_passes_through_recommendation_fields():
+    analyze = _make_analyze(
+        action="hold",
+        confidence="medium",
+        current_price=100.0,
+        stop_loss=90.0,
+        sell_targets=[
+            {"price": 120.0, "type": "resistance", "reasoning": "Resistance at 120.0"}
+        ],
+        buy_zones=[{"price": 95.0, "type": "support", "reasoning": "Support at 95.0"}],
+        insufficient_inputs=["consensus"],
+        rsi14=55.2,
+        reasoning="RSI 55.2 (neutral)",
+    )
+
+    response = await build_stock_detail_recommendation(
+        market="us",
+        symbol="AAPL",
+        providers=StockDetailRecommendationProviders(analyze=analyze),
+    )
+
+    assert response.market == "us"
+    assert response.symbol == "AAPL"
+    assert response.action == "hold"
+    assert response.confidence == "medium"
+    assert response.rsi14 == 55.2
+    assert response.reasoning == "RSI 55.2 (neutral)"
+    assert response.insufficient_inputs == ["consensus"]
+    assert response.current_price == 100.0
+    assert len(response.buy_zones) == 1
+    assert response.buy_zones[0].price == 95.0
+    assert response.buy_zones[0].type == "support"
+    assert len(response.sell_targets) == 1
+    assert response.sell_targets[0].price == 120.0
+    assert response.stop_loss == 90.0
+    # hold -> unknown direction -> no R:R chip
+    assert response.trade_setup is None
+
+
+# ---------------------------------------------------------------------------
+# R:R happy path (fulfills ROB-690 Step 4)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_buy_recommendation_computes_rr_via_shared_helper():
+    analyze = _make_analyze(
+        action="buy",
+        confidence="high",
+        current_price=100.0,
+        stop_loss=90.0,
+        sell_targets=[
+            {"price": 120.0, "type": "resistance", "reasoning": "Resistance at 120.0"}
+        ],
+    )
+
+    response = await build_stock_detail_recommendation(
+        market="us",
+        symbol="AAPL",
+        providers=StockDetailRecommendationProviders(analyze=analyze),
+    )
+
+    assert response.trade_setup is not None
+    setup = response.trade_setup
+    assert setup.direction == "long"
+    assert setup.entry == "100.0"
+    assert setup.stop == "90.0"
+    assert setup.target == "120.0"
+    assert setup.risk_pct == "10.00"
+    assert setup.reward_pct == "20.00"
+    assert setup.rr_ratio == "2.00"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_buy_recommendation_falls_back_to_top_buy_zone_when_price_missing():
+    analyze = _make_analyze(
+        action="buy",
+        current_price=None,
+        stop_loss=90.0,
+        sell_targets=[
+            {"price": 120.0, "type": "resistance", "reasoning": "Resistance at 120.0"}
+        ],
+        buy_zones=[
+            {"price": 92.0, "type": "support", "reasoning": "Support at 92.0"},
+            {"price": 98.0, "type": "bollinger_lower", "reasoning": "BB lower"},
+        ],
+    )
+
+    response = await build_stock_detail_recommendation(
+        market="us",
+        symbol="AAPL",
+        providers=StockDetailRecommendationProviders(analyze=analyze),
+    )
+
+    assert response.current_price is None
+    assert response.trade_setup is not None
+    # top (highest / last, since buy_zones sort ascending) buy_zone used as entry
+    assert response.trade_setup.entry == "98.0"
+
+
+# ---------------------------------------------------------------------------
+# Fail-closed cases
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_sell_recommendation_omits_rr_chip():
+    analyze = _make_analyze(
+        action="sell",
+        current_price=100.0,
+        stop_loss=90.0,
+        sell_targets=[{"price": 120.0, "type": "resistance", "reasoning": "r"}],
+    )
+
+    response = await build_stock_detail_recommendation(
+        market="us",
+        symbol="AAPL",
+        providers=StockDetailRecommendationProviders(analyze=analyze),
+    )
+
+    assert response.action == "sell"
+    assert response.trade_setup is None
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_hold_recommendation_omits_rr_chip():
+    analyze = _make_analyze(
+        action="hold",
+        current_price=100.0,
+        stop_loss=90.0,
+        sell_targets=[{"price": 120.0, "type": "resistance", "reasoning": "r"}],
+    )
+
+    response = await build_stock_detail_recommendation(
+        market="us",
+        symbol="AAPL",
+        providers=StockDetailRecommendationProviders(analyze=analyze),
+    )
+
+    assert response.action == "hold"
+    assert response.trade_setup is None
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_buy_recommendation_without_sell_targets_omits_rr_chip():
+    analyze = _make_analyze(
+        action="buy",
+        current_price=100.0,
+        stop_loss=90.0,
+        sell_targets=[],
+    )
+
+    response = await build_stock_detail_recommendation(
+        market="us",
+        symbol="AAPL",
+        providers=StockDetailRecommendationProviders(analyze=analyze),
+    )
+
+    assert response.action == "buy"
+    assert response.trade_setup is None
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_buy_recommendation_with_degenerate_stop_omits_rr_chip():
+    """stop_loss >= current_price violates the long triangle (stop < entry <
+    target) -> direction_price_mismatch -> fail-closed (no chip)."""
+    analyze = _make_analyze(
+        action="buy",
+        current_price=100.0,
+        stop_loss=105.0,
+        sell_targets=[{"price": 120.0, "type": "resistance", "reasoning": "r"}],
+    )
+
+    response = await build_stock_detail_recommendation(
+        market="us",
+        symbol="AAPL",
+        providers=StockDetailRecommendationProviders(analyze=analyze),
+    )
+
+    assert response.action == "buy"
+    assert response.trade_setup is None
+
+
+# ---------------------------------------------------------------------------
+# Service — unsupported symbol format maps to SymbolNotFound
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_service_maps_analyze_value_error_to_symbol_not_found():
+    async def _raise(symbol_arg: str, market: str | None = None, **kwargs: Any):
+        raise ValueError("Unsupported symbol format: '???'")
+
+    with pytest.raises(SymbolNotFound):
+        await build_stock_detail_recommendation(
+            market="us",
+            symbol="???",
+            providers=StockDetailRecommendationProviders(analyze=_raise),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Router
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def client(monkeypatch: pytest.MonkeyPatch) -> TestClient:
+    app = FastAPI()
+    app.include_router(invest_api_router)
+    app.dependency_overrides[get_authenticated_user] = lambda: SimpleNamespace(id=1)
+    app.dependency_overrides[get_db] = lambda: SimpleNamespace()
+
+    async def _stub_recommendation(**kwargs: Any):
+        assert kwargs["market"] == "us"
+        assert kwargs["symbol"] == "AAPL"
+        return StockDetailRecommendationResponse(
+            market="us",
+            symbol="AAPL",
+            name="Apple Inc.",
+            as_of="2026-07-04T09:00:00+09:00",
+            current_price=100.0,
+            action="buy",
+            confidence="high",
+            rsi14=28.5,
+            reasoning="RSI 28.5 (oversold)",
+            insufficient_inputs=[],
+            buy_zones=[],
+            sell_targets=[{"price": 120.0, "type": "resistance", "reasoning": "r"}],
+            stop_loss=90.0,
+            trade_setup={
+                "direction": "long",
+                "entry": "100.0",
+                "stop": "90.0",
+                "target": "120.0",
+                "risk_pct": "10.00",
+                "reward_pct": "20.00",
+                "rr_ratio": "2.00",
+            },
+        )
+
+    monkeypatch.setattr(
+        invest_api, "build_stock_detail_recommendation", _stub_recommendation
+    )
+    return TestClient(app)
+
+
+@pytest.mark.unit
+def test_recommendation_route_returns_read_only_contract(client: TestClient) -> None:
+    response = client.get("/invest/api/stock-detail/us/AAPL/recommendation")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["symbol"] == "AAPL"
+    assert body["market"] == "us"
+    assert body["action"] == "buy"
+    assert body["confidence"] == "high"
+    assert body["trade_setup"]["direction"] == "long"
+    assert body["trade_setup"]["rr_ratio"] == "2.00"
+
+
+@pytest.mark.unit
+def test_recommendation_route_rejects_crypto(client: TestClient) -> None:
+    response = client.get("/invest/api/stock-detail/crypto/KRW-BTC/recommendation")
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "research_recommendation_supports_kr_us_only"
+
+
+@pytest.mark.unit
+def test_recommendation_route_maps_symbol_not_found(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    async def _raise_not_found(**kwargs: Any):
+        raise SymbolNotFound("missing")
+
+    monkeypatch.setattr(
+        invest_api, "build_stock_detail_recommendation", _raise_not_found
+    )
+
+    response = client.get("/invest/api/stock-detail/us/MISSING/recommendation")
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "symbol_not_found"
+
+
+@pytest.mark.unit
+def test_recommendation_route_requires_authentication(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Without a session/state user, `get_authenticated_user` raises 401 — the
+    dependency stays wired (unlike the `client` fixture, this app does NOT
+    override `get_authenticated_user`)."""
+    from unittest.mock import AsyncMock
+
+    app = FastAPI()
+    app.include_router(invest_api_router)
+    app.dependency_overrides[get_db] = lambda: SimpleNamespace()
+
+    monkeypatch.setattr(
+        "app.routers.dependencies.get_current_user_from_session",
+        AsyncMock(return_value=None),
+    )
+
+    unauth_client = TestClient(app)
+    response = unauth_client.get("/invest/api/stock-detail/us/AAPL/recommendation")
+
+    assert response.status_code == 401


### PR DESCRIPTION
## ROB-692 — 종목상세 결정론 추천 카드 (+R:R)

이미 있는 결정론 추천(`build_recommendation_for_equity` via `analyze_stock_impl`)을 /invest/stocks/:market/:symbol 웹에 on-demand 카드로 노출. **ROB-690 R:R 헬퍼 재사용 → 690의 이연 Step 4까지 흡수.** read-only, migration-0.

### 변경
- `GET /trading/api/invest/stock-detail/{market}/{symbol}/recommendation` (research-consensus 형제 미러; crypto→400, unknown→404, unauth→401).
- 신규 `app/schemas/invest_stock_detail_recommendation.py`, `app/services/invest_view_model/stock_detail_recommendation_service.py`.
- R:R: entry=현재가(폴백 top buy_zone)/stop=stop_loss/target=sell_targets[0] → `resolve_direction`+`build_trade_setup`. **buy→long만**, sell/hold·mismatch·degenerate는 칩 생략(fail-closed).
- 프런트 신규 `RecommendationCard.tsx` + StockDetailPage 배선.

### 검증
- 백엔드 23 pass(R:R happy path rr 2.00·buy_zone폴백·fail-closed·crypto400·unknown404·unauth401). ruff/ty pass. 프런트 44/44, tsc clean. migration-0, LLM import 0.

Linear: ROB-692

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WVqjyNQM5QvjfSjMog9sxR
