### PR TITLE
feat(ROB-697): A′ shadow replay harness (M1) — measure headless decision session-invariance

### DIFF
--- a/app/mcp_server/profiles.py
+++ b/app/mcp_server/profiles.py
@@ -16,6 +16,7 @@ class McpProfile(StrEnum):
     US_PAPER = "us-paper"
     DB_PAPER = "db-paper"
     KIWOOM = "kiwoom"
+    SHADOW_REPLAY = "shadow-replay"
 
 
 def resolve_mcp_profile(env: str | None) -> McpProfile:

--- a/app/mcp_server/tooling/investment_hermes_handlers.py
+++ b/app/mcp_server/tooling/investment_hermes_handlers.py
@@ -489,12 +489,41 @@ def register_investment_hermes_tools(mcp: FastMCP) -> None:
     )(investment_report_prepare_intraday_context_impl)
 
 
+HERMES_CONTEXT_READ_ONLY_TOOL_NAMES: set[str] = {"investment_report_get_hermes_context"}
+
+
+def register_hermes_context_read_only(mcp: FastMCP) -> None:
+    """Register ONLY the frozen-context read tool (ROB-697 shadow-replay).
+
+    Deliberately omits the 4 Hermes WRITE tools (prepare_bundle /
+    create_from_hermes_composition / ingest_from_hermes /
+    prepare_intraday_context) — a headless replay session must not be able to
+    prepare bundles, ingest stage artifacts, or persist reports. It may only
+    read the already-frozen context for a bundle a live session already
+    prepared. Not gated behind ``SNAPSHOT_BACKED_REPORT_GENERATOR_ENABLED`` at
+    registration time — the flag is still enforced at call time inside
+    ``investment_report_get_hermes_context_impl`` via ``_disabled_check``.
+    """
+    mcp.tool(
+        name="investment_report_get_hermes_context",
+        description=(
+            "ROB-697 shadow-replay — return the frozen HermesContextPayload "
+            "for a persisted bundle. Read-only; runs the deterministic v1 "
+            "stage set in-process and returns stage_inputs + cited snapshot "
+            "UUIDs + advisory-only constraint set. Gated by "
+            "SNAPSHOT_BACKED_REPORT_GENERATOR_ENABLED."
+        ),
+    )(investment_report_get_hermes_context_impl)
+
+
 __all__ = [
+    "HERMES_CONTEXT_READ_ONLY_TOOL_NAMES",
     "INVESTMENT_HERMES_TOOL_NAMES",
     "investment_report_create_from_hermes_composition_impl",
     "investment_report_get_hermes_context_impl",
     "investment_report_prepare_bundle_impl",
     "investment_stage_artifacts_ingest_from_hermes_impl",
     "investment_report_prepare_intraday_context_impl",
+    "register_hermes_context_read_only",
     "register_investment_hermes_tools",
 ]

--- a/app/mcp_server/tooling/registry.py
+++ b/app/mcp_server/tooling/registry.py
@@ -30,6 +30,15 @@ Profile → tool surface mapping
 "kiwoom" (McpProfile.KIWOOM):
   Default research/read-only surface plus typed kiwoom_mock_* variants.
 
+"shadow-replay" (McpProfile.SHADOW_REPLAY):
+  ROB-697 M1 — frozen-context replay ONLY. Registers EXACTLY
+  investment_report_get_hermes_context (read-only) + get_trading_policy +
+  route_request, then returns before the "Always" block. Deliberately omits
+  every live-fetch tool (market_data/analysis/news/fundamentals), every
+  mutation/order tool, and the 4 Hermes WRITE tools — this is the load-bearing
+  validity guard so a headless replay session cannot leak live market data or
+  persist anything.
+
 See app/mcp_server/profiles.py and docs in app/mcp_server/README.md.
 """
 
@@ -60,6 +69,7 @@ from app.mcp_server.tooling.analysis_registration import register_analysis_tools
 from app.mcp_server.tooling.forecast_registration import register_forecast_tools
 from app.mcp_server.tooling.fundamentals_registration import register_fundamentals_tools
 from app.mcp_server.tooling.investment_hermes_handlers import (
+    register_hermes_context_read_only,
     register_investment_hermes_tools,
 )
 from app.mcp_server.tooling.investment_reports_handlers import (
@@ -130,6 +140,17 @@ def register_all_tools(mcp: FastMCP, profile: McpProfile = McpProfile.DEFAULT) -
       - DEFAULT: legacy ambiguous tools + typed kis_live_* + typed kis_mock_*
       - HERMES_PAPER_KIS: typed kis_mock_* only (live surface absent)
     """
+    if profile is McpProfile.SHADOW_REPLAY:
+        # ROB-697 M1 — frozen-context replay ONLY: read the bundle + policy +
+        # lane procedure. Deliberately NO live-fetch (market_data/analysis/
+        # news), NO mutation, NO report-write. The agent returns its decision
+        # as JSON; it does not persist. This early return is the load-bearing
+        # validity guard, so it must come before the "Always" block below.
+        register_hermes_context_read_only(mcp)  # investment_report_get_hermes_context
+        register_trading_policy_tools(mcp)  # get_trading_policy (versioned thresholds)
+        register_route_request_tools(mcp)  # route_request (lane procedure)
+        return
+
     # Always: side-effect-free research + read-only tools
     register_market_data_tools(mcp)
     register_fundamentals_tools(mcp)

--- a/app/services/shadow_replay/corpus.py
+++ b/app/services/shadow_replay/corpus.py
@@ -1,0 +1,110 @@
+"""ROB-697 (M1) — read-only replay-corpus selection.
+
+ROB-501 guard: this module is SELECT-only DB access. NO writes, NO LLM,
+NO network. It picks which past bundle-backed report items are eligible
+to be replayed by the (later) ``claude -p`` A' driver.
+
+The corpus source (``claude_bundle`` / ``hermes_bundle`` / manual
+``operator_audit``) is decided by a one-time census against the real
+production DB — see ``docs/runbooks/shadow-replay.md`` §"P0 census
+(operator)". That census cannot run in this environment (no prod data),
+so ``operator_audit`` is intentionally not implemented as a code path
+here: if neither profile has enough coverage, ``select_replay_corpus``
+raises ``CorpusUnavailable`` and defers to the operator.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.investment_reports import InvestmentReport, InvestmentReportItem
+from app.services.shadow_replay.scoring import extract_decision
+
+_HUMAN_PROFILE = "CLAUDE_ADVISOR"
+_HERMES_PROFILE = "HERMES_ADVISOR"
+
+
+@dataclass(frozen=True)
+class CorpusItem:
+    snapshot_bundle_uuid: str
+    report_id: int
+    item_uuid: str
+    item_kind: str
+    intent: str
+    reference_decision: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class CorpusSelection:
+    source: str  # "claude_bundle" | "hermes_bundle" | "operator_audit"
+    items: list[CorpusItem]
+
+
+def _non_autoemit(item: Any) -> bool:
+    ev = item.evidence_snapshot or {}
+    if ev.get("source") == "auto_emit":
+        return False
+    proposer = str(ev.get("proposer", ""))
+    return not proposer.startswith("auto_emit/") and proposer != "intraday_floor"
+
+
+async def _bundle_items_for_profile(
+    session: AsyncSession, profile: str, limit: int
+) -> list[CorpusItem]:
+    stmt = (
+        select(InvestmentReportItem, InvestmentReport.snapshot_bundle_uuid)
+        .join(InvestmentReport, InvestmentReport.id == InvestmentReportItem.report_id)
+        .where(InvestmentReport.snapshot_bundle_uuid.isnot(None))
+        .where(InvestmentReport.created_by_profile == profile)
+        .order_by(InvestmentReport.id.desc())
+        .limit(limit * 4)  # over-fetch; auto_emit filter is in Python
+    )
+    rows = (await session.execute(stmt)).all()
+    out: list[CorpusItem] = []
+    for item, bundle_uuid in rows:
+        if not _non_autoemit(item):
+            continue
+        out.append(
+            CorpusItem(
+                snapshot_bundle_uuid=str(bundle_uuid),
+                report_id=item.report_id,
+                item_uuid=str(item.item_uuid),
+                item_kind=item.item_kind,
+                intent=item.intent,
+                reference_decision=extract_decision(item),
+            )
+        )
+        if len(out) >= limit:
+            break
+    return out
+
+
+def _covers_kinds(items: list[CorpusItem], min_per_kind: int) -> bool:
+    c = Counter(i.item_kind for i in items)
+    return all(c.get(k, 0) >= min_per_kind for k in ("action", "watch"))
+
+
+class CorpusUnavailable(RuntimeError):
+    pass
+
+
+async def select_replay_corpus(
+    session: AsyncSession, *, min_per_kind: int = 1, limit: int = 40
+) -> CorpusSelection:
+    claude = await _bundle_items_for_profile(session, _HUMAN_PROFILE, limit)
+    if _covers_kinds(claude, min_per_kind):
+        return CorpusSelection(source="claude_bundle", items=claude)
+    hermes = await _bundle_items_for_profile(session, _HERMES_PROFILE, limit)
+    if _covers_kinds(hermes, min_per_kind):
+        return CorpusSelection(source="hermes_bundle", items=hermes)
+    # operator_audit fallback intentionally raises for the human to decide
+    # (see docs/runbooks/shadow-replay.md §"P0 census (operator)" rule 3).
+    raise CorpusUnavailable(
+        "No bundle-backed non-auto_emit corpus with buy+sell+watch coverage; "
+        "run the P0 census and decide the corpus manually."
+    )

--- a/app/services/shadow_replay/scoring.py
+++ b/app/services/shadow_replay/scoring.py
@@ -1,0 +1,116 @@
+"""ROB-697 (M1) — pure-function A' shadow replay decision scorer.
+
+ROB-501 guard: stdlib + ``decimal.Decimal`` only. NO LLM, NO network, NO DB,
+NO file I/O. Consumed by the corpus builder and the ``claude -p`` replay
+driver (later tasks); this module has no dependency on either.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal, InvalidOperation
+from typing import Any
+
+
+def _dec(v: Any) -> Decimal | None:
+    if v is None:
+        return None
+    try:
+        return Decimal(str(v))
+    except (InvalidOperation, ValueError):
+        return None
+
+
+def _get(obj: Any, key: str) -> Any:
+    return obj.get(key) if isinstance(obj, dict) else getattr(obj, key, None)
+
+
+def extract_decision(item: Any) -> dict[str, Any]:
+    side = _get(item, "side")
+    max_action = _get(item, "max_action") or {}
+    ev = _get(item, "evidence_snapshot") or {}
+    setup = (ev.get("trade_setup") or {}) if isinstance(ev, dict) else {}
+    headline = setup.get("headline") or {}
+    triggers = _get(item, "trigger_checklist") or []
+    return {
+        "side": side if side in ("buy", "sell") else None,
+        "notional": _dec(max_action.get("notional")),
+        "quantity": _dec(max_action.get("quantity")),
+        "limit_price": _dec(max_action.get("limit_price")),
+        "entry": _dec(headline.get("entry")),
+        "stop": _dec(setup.get("stop")),
+        "target": _dec(setup.get("target")),
+        "triggers": frozenset(str(t) for t in triggers),
+        "proposer": (ev.get("proposer") if isinstance(ev, dict) else None),
+    }
+
+
+def _within(a: Decimal | None, b: Decimal | None, tol: Decimal) -> bool:
+    if a is None or b is None:
+        return a is None and b is None
+    return abs(a - b) <= tol
+
+
+def _size_band(a: dict, b: dict) -> bool:
+    # same order of magnitude on notional (or both None); size is coarse by design
+    an, bn = a.get("notional"), b.get("notional")
+    if an is None or bn is None:
+        return an is None and bn is None
+    hi, lo = max(an, bn), min(an, bn)
+    return lo > 0 and hi / lo <= Decimal("1.5")
+
+
+def agree(
+    a: dict, b: dict, *, tick: Decimal, atr: Decimal | None = None
+) -> dict[str, Any]:
+    side = a["side"] == b["side"]
+    limit_tol = (atr / Decimal(4)) if atr else (tick * 3)
+    limit = _within(a.get("limit_price"), b.get("limit_price"), limit_tol)
+    ta, tb = a["triggers"], b["triggers"]
+    jac = (len(ta & tb) / len(ta | tb)) if (ta or tb) else 1.0
+    size_band = _size_band(a, b)
+    same = side and size_band and limit and jac >= 0.6
+    return {
+        "side": side,
+        "size_band": size_band,
+        "limit": limit,
+        "triggers_jaccard": jac,
+        "same_decision": same,
+    }
+
+
+def summarize(
+    decisions: list[dict],
+    reference: dict | None,
+    *,
+    tick: Decimal,
+    atr: Decimal | None = None,
+) -> dict[str, Any]:
+    k = len(decisions)
+    no_action = sum(1 for d in decisions if d["side"] is None)
+    # self-consistency: pairwise same_decision vs the modal decision (decisions[0] as anchor)
+    anchor = decisions[0] if decisions else None
+    self_same = (
+        sum(
+            1
+            for d in decisions
+            if anchor and agree(anchor, d, tick=tick, atr=atr)["same_decision"]
+        )
+        / k
+        if k
+        else 0.0
+    )
+    fidelity = None
+    if reference is not None and k:
+        matches = [agree(reference, d, tick=tick, atr=atr) for d in decisions]
+        fidelity = {
+            "side_rate": sum(m["side"] for m in matches) / k,
+            "size_band_rate": sum(m["size_band"] for m in matches) / k,
+            "limit_rate": sum(m["limit"] for m in matches) / k,
+            "same_decision_rate": sum(m["same_decision"] for m in matches) / k,
+        }
+    return {
+        "k": k,
+        "no_action_rate": (no_action / k if k else 0.0),
+        "self_same_decision_rate": self_same,
+        "fidelity": fidelity,
+    }

--- a/docs/runbooks/shadow-replay.md
+++ b/docs/runbooks/shadow-replay.md
@@ -182,3 +182,88 @@ prompt (Task 4) must instruct the agent to base its call on
 **Status:** not yet run. Requires a real `bundle_uuid` from the P0
 corpus census above; run once that census has produced a usable
 corpus source.
+
+---
+
+## Headless `claude -p` driver (M1, implemented)
+
+`scripts/shadow_replay.py` ties the corpus selector (Task 0) and the
+scorer (Task 1) together into the actual A' batch: for each corpus
+item it spawns a headless `claude -p` subprocess `k` times (via
+`scripts/shadow_replay_mcp.json`, a stdio MCP config restricted to the
+`shadow-replay` profile — frozen-context read + policy + lane router
+only, nothing else reachable), scores each reply against the item's
+`reference_decision`, and writes a markdown report.
+
+- `_to_item_shape(raw) -> dict` — **shape adapter, load-bearing.** The
+  replay prompt instructs the agent to emit `trade_setup` at the TOP
+  level (a flatter contract for the agent to follow), but
+  `extract_decision` (Task 1) reads a *nested*
+  `evidence_snapshot.trade_setup` — the shape of a persisted
+  `InvestmentReportItem`. Calling `extract_decision` directly on a raw
+  claude reply would silently read `ev.get("trade_setup")` off `{}`
+  and drop entry/stop/target on every single replay. `run_batch` always
+  routes raw replies through this adapter before scoring; unit-tested
+  directly, including a round-trip (`raw.trade_setup.headline.entry` →
+  `_to_item_shape` → `extract_decision` recovers a non-None `entry`).
+- `_one_run(uuid, model) -> dict | None` — the only place `claude` is
+  invoked. Best-effort + defensive: ANY subprocess failure (missing
+  binary, timeout), non-zero exit, an MCP-reset stderr marker
+  (`get_hermes_context` / `connection error` / `tool not found`), or a
+  JSON-parse failure returns `None` — a **discarded** sample, not a
+  data point. The exact `claude -p --output-format json` envelope
+  shape is only verified at operator run-time (Step 6 below); the test
+  suite never spawns a real subprocess — `tests/test_shadow_replay_cli.py`
+  always monkeypatches `_one_run`.
+- `run_batch(corpus, *, k, model, tick) -> list[dict]` — one result row
+  per corpus item: `{item_uuid, item_kind, source, model, discarded,
+  summary}`. `discarded` counts `_one_run` calls that returned `None`
+  out of `k`; `summary` (`summarize(...)`, Task 1) is computed only
+  over the successfully-parsed decisions.
+- `write_report(results, path) -> str` — markdown table, one row per
+  corpus item: `side_rate / size_band_rate / limit_rate /
+  same_decision_rate / no_action_rate / discarded`, plus a header with
+  the corpus `source` and the pinned `model` (for longitudinal
+  comparison across runs).
+- `build_parser()` / `main()` — `--confirm` gate: without `--confirm`,
+  `main()` never spawns a `claude -p` subprocess. It only prints a dry
+  plan (`{source, corpus_size, would_run_claude_p_calls, model}`) and
+  exits 0. Only `--confirm` proceeds to `run_batch` + `write_report`.
+  `--model` defaults to a **pinned exact id**
+  (`claude-opus-4-8`, never a `-latest` alias) so replay fidelity stays
+  comparable across re-runs months apart — the model id is stamped
+  into every result row and the report header.
+
+Tests: `tests/test_shadow_replay_cli.py` (`@pytest.mark.unit`, no DB,
+no real subprocess — `_one_run` is always monkeypatched).
+
+Read-only / ROB-501: `scripts/shadow_replay.py` lives in `scripts/`,
+not `app/`. It shells out to the external `claude` binary via
+`subprocess.run` (an out-of-process CLI call, not an in-process LLM
+SDK import). M1 writes nothing — no orders, no watch mutation, no
+report persistence; the replayed agent returns JSON on stdout and this
+driver only scores + reports it (the markdown file is a local report
+artifact, not a DB write).
+
+### Step 6 — one real end-to-end batch (operator, not CI)
+
+Requires: a live DB with a usable corpus (see the P0 census above), the
+`claude` CLI on `PATH`, and `SNAPSHOT_BACKED_REPORT_GENERATOR_ENABLED`
+reachable by the MCP subprocess (already set in
+`scripts/shadow_replay_mcp.json`'s `env`).
+
+```bash
+# Dry plan only — always safe, spawns nothing:
+uv run python -m scripts.shadow_replay --k 5 --model claude-opus-4-8
+
+# Real batch (spawns k x corpus-size `claude -p` subprocesses):
+uv run python -m scripts.shadow_replay --k 5 --model claude-opus-4-8 --confirm
+```
+
+Expected: a markdown report (default `shadow_replay_report.md`, override
+with `--report`) with per-corpus-item `side_rate / size_band_rate /
+limit_rate / same_decision_rate` + `no_action_rate` + discard counts.
+This is the M1 deliverable number.
+
+**Status:** not yet run. Requires the P0 census to have produced a
+usable corpus first (see above).

--- a/docs/runbooks/shadow-replay.md
+++ b/docs/runbooks/shadow-replay.md
@@ -124,3 +124,61 @@ exercises `_bundle_items_for_profile` directly (not
 auto_emit exclusion has to go through the lower-level function. The
 pure-predicate tests (`_non_autoemit`, `_covers_kinds`) are
 `@pytest.mark.unit` and need no DB.
+
+---
+
+## P1 probe (operator)
+
+**Why this exists:** A′ replay is only meaningful if the same bundle
+yields the same decision-bearing context across calls. `get_hermes_
+context` emits no verbatim timestamp; `stage_inputs` + `cited_snapshots`
++ `policy_version` + `market` + `market_session` + `coverage_summary`
+are frozen from the persisted bundle. `dimension_evidence` /
+`dimension_reports` read LIVE tables and can drift between calls even
+for the same bundle.
+
+`scripts/shadow_replay_probe.py` calls
+`investment_report_get_hermes_context_impl` twice for one
+`bundle_uuid` and diffs the result:
+
+- `compare_frozen(a, b) -> dict` — pure function (dict in, dict out,
+  no I/O). Compares the frozen keys via
+  `json.dumps(..., sort_keys=True)` equality and lists which of
+  `dimension_evidence` / `dimension_reports` differ. Unit-tested in
+  `tests/test_shadow_replay_probe_cli.py` with no DB.
+- `probe(bundle_uuid) -> int` — the async two-call round trip. Requires
+  a live DB, a real `bundle_uuid` (from the Task 0 corpus), and
+  `SNAPSHOT_BACKED_REPORT_GENERATOR_ENABLED=true` on the process. Not
+  exercised by the test suite — run it manually as an operator step.
+
+Read-only: no stage_run / artifact rows are persisted, no broker /
+order / watch / order-intent mutation, no in-process LLM provider
+(ROB-501).
+
+### Run it
+
+```bash
+SNAPSHOT_BACKED_REPORT_GENERATOR_ENABLED=true \
+    uv run python -m scripts.shadow_replay_probe <bundle_uuid>
+```
+
+Expected for two calls seconds apart:
+
+```json
+{"frozen_identical": true, "live_section_drift": []}
+```
+
+Exit code `0` means the frozen sections matched; `1` means they
+drifted (investigate before trusting the K-replay batch, Task 4); `2`
+means the first call itself failed (`success=False` — bad
+`bundle_uuid`, or the feature flag isn't set).
+
+If `live_section_drift` is non-empty, record it here — it means the
+K-replay batch (Task 4) must run tight in time, and the decision
+prompt (Task 4) must instruct the agent to base its call on
+`stage_inputs` / `cited_snapshots` (the frozen sections), not on
+`dimension_evidence` / `dimension_reports`.
+
+**Status:** not yet run. Requires a real `bundle_uuid` from the P0
+corpus census above; run once that census has produced a usable
+corpus source.

--- a/docs/runbooks/shadow-replay.md
+++ b/docs/runbooks/shadow-replay.md
@@ -233,9 +233,18 @@ only, nothing else reachable), scores each reply against the item's
   (`claude-opus-4-8`, never a `-latest` alias) so replay fidelity stays
   comparable across re-runs months apart — the model id is stamped
   into every result row and the report header.
+- `all_samples_discarded(results) -> bool` — pure predicate: true iff at
+  least one sample was attempted and every attempted sample was
+  discarded. `_amain` checks this right after `write_report` and, if
+  true, prints a loud `WARNING:` to stderr and returns exit `3` instead
+  of `0` — see "Exit codes" in Step 6 below for why this is a distinct
+  signal from ordinary per-sample discards.
 
 Tests: `tests/test_shadow_replay_cli.py` (`@pytest.mark.unit`, no DB,
-no real subprocess — `_one_run` is always monkeypatched).
+no real subprocess — `_one_run` is always monkeypatched; `_amain` is
+unit-tested too, with `AsyncSessionLocal` and `select_replay_corpus`
+monkeypatched at their source-module attribute so no real DB is
+touched).
 
 Read-only / ROB-501: `scripts/shadow_replay.py` lives in `scripts/`,
 not `app/`. It shells out to the external `claude` binary via
@@ -264,6 +273,22 @@ Expected: a markdown report (default `shadow_replay_report.md`, override
 with `--report`) with per-corpus-item `side_rate / size_band_rate /
 limit_rate / same_decision_rate` + `no_action_rate` + discard counts.
 This is the M1 deliverable number.
+
+**Exit codes:** `0` = ran (dry plan, or a real batch with at least one
+scored sample). `2` = `CorpusUnavailable` (see the P0 census above). `3`
+= **all replay samples were discarded** — `all_samples_discarded(results)`
+is true iff at least one sample was attempted and every single one came
+back `None` from `_one_run` across every corpus item. This is a distinct
+failure mode from ordinary per-sample discards (MCP reset / flaky
+subprocess): if literally everything discarded, the far more likely
+explanation is that the `claude -p --output-format json` envelope
+assumption in `_one_run` is wrong (Step 6 is the first time that
+assumption is exercised against a real `claude` binary), not that the
+model coincidentally failed every single call. On exit 3 the driver still
+writes the (all-`discarded`) report and prints `"step": "done"`, but also
+prints a loud `WARNING:` to stderr — **do not read a `"step": "done"`
+report as a clean run without checking the exit code first**; treat exit
+3 as "fix the harness, then re-run" rather than "fidelity is just bad."
 
 **Status:** not yet run. Requires the P0 census to have produced a
 usable corpus first (see above).

--- a/docs/runbooks/shadow-replay.md
+++ b/docs/runbooks/shadow-replay.md
@@ -1,0 +1,126 @@
+# A′ shadow replay harness (ROB-697, M1)
+
+This runbook covers the "A′ shadow replay" harness: replaying past
+bundle-backed report-item decisions through a headless `claude -p`
+process to measure self-consistency and (when a reference decision
+exists) fidelity to what was actually decided. M1 builds the read-only
+corpus-selection layer only (`app/services/shadow_replay/`); the replay
+driver itself is a later task.
+
+> **Boundary**: this harness is read-only analysis tooling. No writes,
+> no broker/order/watch mutation, no in-process LLM (ROB-501). The
+> `claude -p` driver (later task) is an out-of-process subprocess, not
+> an in-process provider.
+
+---
+
+## P0 census (operator)
+
+**Why this exists:** the design initially assumed the reference corpus
+would be "my (Claude-authored) decisions with a frozen evidence
+bundle." Grounding found these are in tension: `investment_report_create`
+(plain human/API authoring) never sets `snapshot_bundle_uuid`; non-null
+bundles are only produced by `generate_from_bundle` / Hermes ingest. So
+`created_by_profile='CLAUDE_ADVISOR' AND snapshot_bundle_uuid IS NOT NULL`
+may be nearly empty in production. This section is the read-only census
+an operator runs against the **real** production DB (not the test DB)
+to decide which corpus source `select_replay_corpus` should actually
+return in practice.
+
+`app/services/shadow_replay/corpus.py` implements two of the three
+possible sources as executable code paths (`claude_bundle`,
+`hermes_bundle`); it raises `CorpusUnavailable` when neither has
+buy+sell+watch coverage, deferring to this census instead of guessing.
+The third source (`operator_audit`) is **not** implemented as a code
+path — see rule 3 below.
+
+### Step 1 — run the census SELECTs by hand (read-only)
+
+Point `DATABASE_URL` at the real DB (or a read replica / local mirror
+per your usual `docs/runbooks/` conventions) and run:
+
+```sql
+-- Census: bundle-backed items by authorship, minus auto_emit machine items
+SELECT r.created_by_profile,
+       COUNT(*) FILTER (WHERE r.snapshot_bundle_uuid IS NOT NULL)                                   AS with_bundle,
+       COUNT(*) FILTER (WHERE r.snapshot_bundle_uuid IS NOT NULL
+                        AND COALESCE(it.evidence_snapshot->>'source','') <> 'auto_emit'
+                        AND COALESCE(it.evidence_snapshot->>'proposer','') NOT LIKE 'auto_emit/%')  AS with_bundle_non_autoemit,
+       COUNT(*) FILTER (WHERE it.side IN ('buy','sell'))                                             AS actionable
+FROM review.investment_report_items it
+JOIN review.investment_reports r ON r.id = it.report_id
+GROUP BY r.created_by_profile
+ORDER BY with_bundle_non_autoemit DESC;
+
+-- Also count the truer "operator actually shipped this" signal
+SELECT decision, COUNT(*)
+FROM review.investment_report_item_decisions
+WHERE decision IN ('approve','partial_approve','reprice')
+GROUP BY decision;
+```
+
+### Step 2 — pick the corpus source (decision gate)
+
+Decision rule (record the chosen source + the census numbers in this
+file once run):
+
+1. If `CLAUDE_ADVISOR` has ≥ (3×`min_per_kind`) `with_bundle_non_autoemit`
+   rows spanning buy+sell+watch → **source = `claude_bundle`** (closest
+   to "my decision"). `select_replay_corpus` already returns this
+   automatically once the data exists — no code change needed.
+2. Else if `HERMES_ADVISOR` has enough such rows → **source =
+   `hermes_bundle`**. This still directly serves ROB-644's stated goal
+   ("different LLM models should reach the same result"): A′ then
+   measures headless-Claude vs. Hermes consistency on identical frozen
+   evidence. `select_replay_corpus` also already returns this
+   automatically as the fallback.
+3. Else → **source = `operator_audit`**: join
+   `investment_report_item_decisions`
+   (`decision IN ('approve','partial_approve','reprice')`,
+   `approved_payload_snapshot` is the verbatim shipped params) back to
+   items with a non-null bundle. This is the truest "shipped" signal,
+   but it requires the report to have a bundle. If operator-audit rows
+   also lack bundles, **STOP** — report to the user that no replayable
+   corpus exists yet; A′ can't run until bundle-backed decisions
+   accumulate. `operator_audit` is intentionally **not** implemented as
+   a `corpus.py` code path today (`select_replay_corpus` raises
+   `CorpusUnavailable` in this case) — implement it as a follow-up once
+   the census confirms it's the live path, rather than building a third
+   untested branch against a corpus that may not exist.
+
+**Status:** not yet run. `select_replay_corpus` will raise
+`CorpusUnavailable` against a fresh/empty DB (including the test DB)
+until real bundle-backed, non-auto_emit `CLAUDE_ADVISOR` or
+`HERMES_ADVISOR` items with buy+sell+watch coverage exist.
+
+---
+
+## Corpus selection (M1, implemented)
+
+`app/services/shadow_replay/corpus.py`:
+
+- `select_replay_corpus(session, *, min_per_kind=1, limit=40) -> CorpusSelection`
+  — tries `CLAUDE_ADVISOR` bundle-backed items first, then
+  `HERMES_ADVISOR`; returns whichever first covers `action` + `watch`
+  kinds at `min_per_kind` each. Raises `CorpusUnavailable` otherwise
+  (see Step 2 rule 3).
+- `_bundle_items_for_profile(session, profile, limit)` — the lower-level
+  query: bundle-backed items for one `created_by_profile`, filtered
+  through `_non_autoemit` (drops `evidence_snapshot.source == "auto_emit"`
+  and `evidence_snapshot.proposer` starting with `auto_emit/`, plus the
+  `intraday_floor` proposer). No coverage gate — useful directly when you
+  just want "what does this profile have," independent of the
+  action+watch minimum.
+- Each `CorpusItem.reference_decision` is `extract_decision(item)` from
+  `app/services/shadow_replay/scoring.py` (Task 1, already shipped) —
+  the pure-function decision scorer used later to compare replay output
+  against what was actually decided.
+
+Tests: `tests/services/shadow_replay/test_corpus.py`. The DB-touching
+test (`test_autoemit_item_excluded`) is `@pytest.mark.integration` and
+exercises `_bundle_items_for_profile` directly (not
+`select_replay_corpus`) — seeding just one `action` item can't satisfy
+`select_replay_corpus`'s action+watch coverage gate, so testing the
+auto_emit exclusion has to go through the lower-level function. The
+pure-predicate tests (`_non_autoemit`, `_covers_kinds`) are
+`@pytest.mark.unit` and need no DB.

--- a/docs/superpowers/plans/2026-07-04-a-prime-shadow-replay-m1.md
+++ b/docs/superpowers/plans/2026-07-04-a-prime-shadow-replay-m1.md
@@ -1,0 +1,686 @@
+# A′ Shadow Replay Harness (M1) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Measure whether a headless `claude -p` session, fed ONLY a frozen evidence bundle, reproduces a disciplined buy/sell decision — both across K repeats (self-consistency) and against the decision that was actually shipped for that bundle (ground-truth fidelity).
+
+**Architecture:** Three seams. (1) A new read-only MCP profile `shadow-replay` that exposes only the frozen-context read + policy/lane procedure tools and omits every live-fetch and mutation tool (so the replay can't leak live market data — the load-bearing validity guard). (2) A `scripts/` subprocess driver that launches a dedicated MCP server on that profile and drives `claude -p` K times per bundle, capturing each proposed decision as JSON. (3) A pure-function scorer in `app/services/` (no LLM, no I/O) that computes self-consistency + ground-truth diff. Linear: ROB-697. This is M1 only; M2 (Upbit shadow-sim) and M3 (kis_mock port) are out of scope.
+
+**Tech Stack:** Python 3.13, `uv`, FastMCP (existing MCP server), pytest (markers: unit/integration/slow/live only), ruff + ty, PostgreSQL (`review` schema). `claude -p` (Claude Code headless) as an out-of-process subprocess — the FIRST such driver in this repo, deliberately in `scripts/` not `app/`.
+
+## Global Constraints
+
+- **ROB-501 runtime LLM boundary:** no in-process/subprocess LLM in `app/**`. The `claude -p` driver lives in `scripts/`; the scorer in `app/services/` is pure deterministic functions with zero LLM/network. No `anthropic` SDK is added to `app/`.
+- **Read-only:** M1 places no orders and writes no reports. The `shadow-replay` profile exposes NO mutation/order/report-write tools; the headless agent returns its decision as JSON on stdout, it does not persist.
+- **`get_hermes_context` gate:** the tool only exists when `SNAPSHOT_BACKED_REPORT_GENERATOR_ENABLED=true` on the MCP host. The shadow-replay server must set it.
+- **Pytest markers are strict** (`--strict-markers --strict-config`); only `unit`, `integration`, `slow`, `live` are registered. Do not invent a marker.
+- **Lint/type gates:** `uv run ruff check app/ tests/` + `uv run ruff format --check app/ tests/` + `uv run ty check app/ --error-on-warning` (ty checks `app/` only). ruff line-length 88, target py313.
+- **Determinism caveat (documented, not fully solved in M1):** `HermesContextExporter.export()` reads `dimension_evidence` / `dimension_reports` / `market_session` from LIVE tables (screener/research/valuation/investor-flow snapshots + stage-run rows), NOT the frozen bundle. Only `stage_inputs` + `cited_snapshots` are fully frozen. M1 mitigates by running all K replays of a bundle in one tight batch; the clean fix (thread a fixed `now=` + freeze aux tables) is noted as M1-follow-up, not built here.
+
+---
+
+## File Structure
+
+- `app/mcp_server/profiles.py` — **modify**: add `SHADOW_REPLAY = "shadow-replay"` enum member.
+- `app/mcp_server/tooling/registry.py` — **modify**: add an early-return `shadow-replay` branch at the top of `register_all_tools` that registers ONLY the allowlist (frozen-context read + policy + route_request) and returns, skipping the Always block and all order surfaces.
+- `app/mcp_server/tooling/investment_hermes_handlers.py` — **modify**: add a narrow `register_hermes_context_read_only(mcp)` that registers ONLY `investment_report_get_hermes_context` (not the 4 Hermes write tools), reused by the shadow-replay branch.
+- `app/services/shadow_replay/__init__.py`, `app/services/shadow_replay/scoring.py` — **create**: pure-function scorer (decision extraction + agreement metrics). No I/O.
+- `app/services/shadow_replay/corpus.py` — **create**: read-only SQL/ORM helpers to census + select the replay corpus (bundle-backed items, authorship + auto_emit filters).
+- `scripts/shadow_replay.py` — **create**: the headless driver (launch server config, run `claude -p` K times, collect JSON, call scorer, emit report).
+- `scripts/shadow_replay_mcp.json` — **create**: the `--mcp-config` for `claude -p` (stdio server on the shadow-replay profile).
+- `tests/mcp_server/test_shadow_replay_profile.py` — **create**: profile registration allowlist/deny tests (DummyMCP).
+- `tests/services/shadow_replay/test_scoring.py` — **create**: pure-function scorer tests.
+- `tests/services/shadow_replay/test_corpus.py` — **create**: corpus filter tests (integration, DB).
+- `tests/test_shadow_replay_cli.py` — **create**: driver unit tests (monkeypatched subprocess).
+- `docs/runbooks/shadow-replay.md` — **create**: how to run P0 census + a replay batch.
+
+---
+
+## Task 0 (P0): Corpus census — decide what "reference decision" means BEFORE building
+
+**Why first:** the design assumed "my human-authored decisions with a frozen bundle." Grounding found these are in TENSION: `investment_report_create` (plain human authoring) NEVER sets `snapshot_bundle_uuid`; non-null bundles come only from `generate_from_bundle` / Hermes ingest. So `created_by_profile='CLAUDE_ADVISOR' AND snapshot_bundle_uuid IS NOT NULL` may be nearly empty. This task measures reality and picks the corpus. It is a read-only investigation, not TDD.
+
+**Files:**
+- Create: `app/services/shadow_replay/corpus.py`
+- Create: `tests/services/shadow_replay/test_corpus.py`
+- Reference (read-only): `app/models/investment_reports.py` (InvestmentReport `review.investment_reports`, InvestmentReportItem `review.investment_report_items`, InvestmentReportItemDecision `review.investment_report_item_decisions`), `app/services/investment_reports/repository.py:175`, `app/services/action_report/snapshot_backed/auto_emit.py:103`.
+
+**Interfaces:**
+- Produces: `select_replay_corpus(session, *, min_per_kind: int = 1, limit: int = 40) -> CorpusSelection` where `CorpusSelection = {"source": "claude_bundle"|"hermes_bundle"|"operator_audit", "items": list[CorpusItem]}` and `CorpusItem = {"snapshot_bundle_uuid": str, "report_id": int, "item_uuid": str, "item_kind": str, "intent": str, "reference_decision": dict}`. `reference_decision` is the output of `extract_decision(...)` from Task 3.
+
+- [ ] **Step 1: Run the census SELECT by hand (read-only) against the real DB to see what exists.**
+
+Run (adjust `DATABASE_URL` to the real read replica / local mirror per `docs/runbooks/` conventions):
+
+```sql
+-- Census: bundle-backed items by authorship, minus auto_emit machine items
+SELECT r.created_by_profile,
+       COUNT(*) FILTER (WHERE r.snapshot_bundle_uuid IS NOT NULL)                                   AS with_bundle,
+       COUNT(*) FILTER (WHERE r.snapshot_bundle_uuid IS NOT NULL
+                        AND COALESCE(it.evidence_snapshot->>'source','') <> 'auto_emit'
+                        AND COALESCE(it.evidence_snapshot->>'proposer','') NOT LIKE 'auto_emit/%')  AS with_bundle_non_autoemit,
+       COUNT(*) FILTER (WHERE it.side IN ('buy','sell'))                                             AS actionable
+FROM review.investment_report_items it
+JOIN review.investment_reports r ON r.id = it.report_id
+GROUP BY r.created_by_profile
+ORDER BY with_bundle_non_autoemit DESC;
+
+-- Also count the truer "operator actually shipped this" signal
+SELECT decision, COUNT(*)
+FROM review.investment_report_item_decisions
+WHERE decision IN ('approve','partial_approve','reprice')
+GROUP BY decision;
+```
+
+Expected: one of three outcomes decides the corpus source (Step 2).
+
+- [ ] **Step 2: Pick the corpus source from the census (decision gate — record the choice in `docs/runbooks/shadow-replay.md`).**
+
+Decision rule:
+1. If `CLAUDE_ADVISOR` has ≥ (3×`min_per_kind`) `with_bundle_non_autoemit` rows spanning buy+sell+watch → **source = `claude_bundle`** (closest to "my decision").
+2. Else if `HERMES_ADVISOR` has enough such rows → **source = `hermes_bundle`**. This still directly serves ROB-644's stated goal ("different LLM models should reach the same result"): A′ then measures headless-Claude vs Hermes consistency on identical frozen evidence. Note this framing explicitly in the report.
+3. Else → **source = `operator_audit`**: join `investment_report_item_decisions` (`decision IN ('approve','partial_approve','reprice')`, `approved_payload_snapshot` is the verbatim shipped params) back to items with a non-null bundle. Truest "shipped" signal but requires the report to have a bundle; if operator-audit rows also lack bundles, STOP and report to the user that no replayable corpus exists yet (A′ can't run until bundle-backed decisions accumulate).
+
+- [ ] **Step 3: Write `corpus.py` implementing the chosen selection (parameterized so all three sources are code paths; the census picks which one runs).**
+
+```python
+# app/services/shadow_replay/corpus.py
+from __future__ import annotations
+from dataclasses import dataclass
+from typing import Any
+from sqlalchemy import select, func
+from sqlalchemy.ext.asyncio import AsyncSession
+from app.models.investment_reports import (
+    InvestmentReport, InvestmentReportItem, InvestmentReportItemDecision,
+)
+from app.services.shadow_replay.scoring import extract_decision
+
+_HUMAN_PROFILE = "CLAUDE_ADVISOR"
+_HERMES_PROFILE = "HERMES_ADVISOR"
+
+
+@dataclass(frozen=True)
+class CorpusItem:
+    snapshot_bundle_uuid: str
+    report_id: int
+    item_uuid: str
+    item_kind: str
+    intent: str
+    reference_decision: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class CorpusSelection:
+    source: str  # "claude_bundle" | "hermes_bundle" | "operator_audit"
+    items: list[CorpusItem]
+
+
+def _non_autoemit(item: InvestmentReportItem) -> bool:
+    ev = item.evidence_snapshot or {}
+    if ev.get("source") == "auto_emit":
+        return False
+    proposer = str(ev.get("proposer", ""))
+    return not proposer.startswith("auto_emit/") and proposer != "intraday_floor"
+
+
+async def _bundle_items_for_profile(
+    session: AsyncSession, profile: str, limit: int
+) -> list[CorpusItem]:
+    stmt = (
+        select(InvestmentReportItem, InvestmentReport.snapshot_bundle_uuid)
+        .join(InvestmentReport, InvestmentReport.id == InvestmentReportItem.report_id)
+        .where(InvestmentReport.snapshot_bundle_uuid.isnot(None))
+        .where(InvestmentReport.created_by_profile == profile)
+        .order_by(InvestmentReport.id.desc())
+        .limit(limit * 4)  # over-fetch; auto_emit filter is in Python
+    )
+    rows = (await session.execute(stmt)).all()
+    out: list[CorpusItem] = []
+    for item, bundle_uuid in rows:
+        if not _non_autoemit(item):
+            continue
+        out.append(
+            CorpusItem(
+                snapshot_bundle_uuid=str(bundle_uuid),
+                report_id=item.report_id,
+                item_uuid=str(item.item_uuid),
+                item_kind=item.item_kind,
+                intent=item.intent,
+                reference_decision=extract_decision(item),
+            )
+        )
+        if len(out) >= limit:
+            break
+    return out
+
+
+async def select_replay_corpus(
+    session: AsyncSession, *, min_per_kind: int = 1, limit: int = 40
+) -> CorpusSelection:
+    claude = await _bundle_items_for_profile(session, _HUMAN_PROFILE, limit)
+    if _covers_kinds(claude, min_per_kind):
+        return CorpusSelection(source="claude_bundle", items=claude)
+    hermes = await _bundle_items_for_profile(session, _HERMES_PROFILE, limit)
+    if _covers_kinds(hermes, min_per_kind):
+        return CorpusSelection(source="hermes_bundle", items=hermes)
+    # operator_audit fallback intentionally raises for the human to decide (Step 2 rule 3)
+    raise CorpusUnavailable(
+        "No bundle-backed non-auto_emit corpus with buy+sell+watch coverage; "
+        "run the P0 census and decide the corpus manually."
+    )
+
+
+def _covers_kinds(items: list[CorpusItem], min_per_kind: int) -> bool:
+    from collections import Counter
+    c = Counter(i.item_kind for i in items)
+    return all(c.get(k, 0) >= min_per_kind for k in ("action", "watch"))
+
+
+class CorpusUnavailable(RuntimeError):
+    pass
+```
+
+- [ ] **Step 4: Write an integration test that seeds 1 bundle-backed CLAUDE_ADVISOR item + 1 auto_emit item and asserts only the former is selected.**
+
+```python
+# tests/services/shadow_replay/test_corpus.py
+import pytest
+from app.services.shadow_replay.corpus import select_replay_corpus, _non_autoemit
+
+@pytest.mark.integration
+async def test_autoemit_item_excluded(db_session, seed_report_item):
+    human = await seed_report_item(created_by_profile="CLAUDE_ADVISOR", with_bundle=True,
+                                   item_kind="action", side="buy", evidence={})
+    await seed_report_item(created_by_profile="CLAUDE_ADVISOR", with_bundle=True,
+                           item_kind="action", side="buy",
+                           evidence={"source": "auto_emit", "proposer": "auto_emit/buy_from_candidate"})
+    sel = await select_replay_corpus(db_session, min_per_kind=1, limit=10)
+    uuids = {i.item_uuid for i in sel.items}
+    assert str(human.item_uuid) in uuids
+    assert all(i.reference_decision.get("proposer") != "auto_emit/buy_from_candidate" for i in sel.items)
+
+@pytest.mark.unit
+def test_non_autoemit_predicate():
+    class _I: evidence_snapshot = {"source": "auto_emit"}
+    assert _non_autoemit(_I()) is False
+```
+
+- [ ] **Step 5: Run + commit.**
+
+Run: `uv run pytest tests/services/shadow_replay/test_corpus.py -v --no-cov`
+Expected: PASS (unit) / PASS (integration if DB reachable; else `-m unit` only).
+
+```bash
+git add app/services/shadow_replay/corpus.py tests/services/shadow_replay/test_corpus.py docs/runbooks/shadow-replay.md
+git commit -m "feat(ROB-697): P0 replay-corpus selection + census (bundle-backed, non-auto_emit)"
+```
+
+---
+
+## Task 1 (T3): Pure-function decision scorer
+
+**Why before the runner:** the scorer has zero external deps (stdlib only, mirror `app/services/brokers/kis/live_order_expiry.py`), so it is pure TDD and both the corpus (Task 0) and the runner (Task 4) consume it.
+
+**Files:**
+- Create: `app/services/shadow_replay/scoring.py`
+- Create: `tests/services/shadow_replay/test_scoring.py`
+- Reference: `app/services/investment_reports/ingestion.py:48` (trade_setup shape), `app/schemas/investment_reports.py:215` (max_action fields).
+
+**Interfaces:**
+- Produces:
+  - `extract_decision(item_or_dict) -> dict` → normalized `{"side": "buy"|"sell"|None, "notional": Decimal|None, "quantity": Decimal|None, "limit_price": Decimal|None, "entry": Decimal|None, "stop": Decimal|None, "target": Decimal|None, "triggers": frozenset[str], "proposer": str|None}`. Reads `side` column, `max_action` JSONB (quantity/notional/limit_price), `evidence_snapshot.trade_setup` (Decimals are STRINGS → cast), and `trigger_checklist`.
+  - `agree(a: dict, b: dict, *, tick: Decimal, atr: Decimal|None = None) -> dict` → `{"side": bool, "size_band": bool, "limit": bool, "triggers_jaccard": float, "same_decision": bool}`.
+  - `summarize(decisions: list[dict], reference: dict|None, *, tick, atr) -> dict` → `{"k": int, "no_action_rate": float, "self_same_decision_rate": float, "fidelity": dict|None}`.
+
+- [ ] **Step 1: Write failing tests for `extract_decision` (stringified Decimals + JSONB paths).**
+
+```python
+# tests/services/shadow_replay/test_scoring.py
+from decimal import Decimal
+import pytest
+from app.services.shadow_replay.scoring import extract_decision, agree, summarize
+
+@pytest.mark.unit
+def test_extract_reads_trade_setup_stringified_decimals():
+    item = {
+        "side": "buy",
+        "max_action": {"notional": "300000", "limit_price": "129600"},
+        "evidence_snapshot": {"trade_setup": {"stop": "125000", "target": "150000",
+                              "headline": {"entry": "129600"}}},
+        "trigger_checklist": ["support_129600_hold", "rsi_below_45"],
+    }
+    d = extract_decision(item)
+    assert d["side"] == "buy"
+    assert d["notional"] == Decimal("300000")
+    assert d["limit_price"] == Decimal("129600")
+    assert d["entry"] == Decimal("129600")
+    assert d["stop"] == Decimal("125000")
+    assert d["triggers"] == frozenset({"support_129600_hold", "rsi_below_45"})
+
+@pytest.mark.unit
+def test_extract_no_action_when_no_side():
+    d = extract_decision({"side": None, "max_action": {}, "evidence_snapshot": {}, "trigger_checklist": []})
+    assert d["side"] is None
+```
+
+- [ ] **Step 2: Run to verify fail.** Run: `uv run pytest tests/services/shadow_replay/test_scoring.py -v --no-cov` — Expected: FAIL (module missing).
+
+- [ ] **Step 3: Implement `scoring.py`.**
+
+```python
+# app/services/shadow_replay/scoring.py
+from __future__ import annotations
+from decimal import Decimal, InvalidOperation
+from typing import Any
+
+
+def _dec(v: Any) -> Decimal | None:
+    if v is None:
+        return None
+    try:
+        return Decimal(str(v))
+    except (InvalidOperation, ValueError):
+        return None
+
+
+def _get(obj: Any, key: str) -> Any:
+    return obj.get(key) if isinstance(obj, dict) else getattr(obj, key, None)
+
+
+def extract_decision(item: Any) -> dict[str, Any]:
+    side = _get(item, "side")
+    max_action = _get(item, "max_action") or {}
+    ev = _get(item, "evidence_snapshot") or {}
+    setup = (ev.get("trade_setup") or {}) if isinstance(ev, dict) else {}
+    headline = setup.get("headline") or {}
+    triggers = _get(item, "trigger_checklist") or []
+    return {
+        "side": side if side in ("buy", "sell") else None,
+        "notional": _dec(max_action.get("notional")),
+        "quantity": _dec(max_action.get("quantity")),
+        "limit_price": _dec(max_action.get("limit_price")),
+        "entry": _dec(headline.get("entry")),
+        "stop": _dec(setup.get("stop")),
+        "target": _dec(setup.get("target")),
+        "triggers": frozenset(str(t) for t in triggers),
+        "proposer": (ev.get("proposer") if isinstance(ev, dict) else None),
+    }
+
+
+def _within(a: Decimal | None, b: Decimal | None, tol: Decimal) -> bool:
+    if a is None or b is None:
+        return a is None and b is None
+    return abs(a - b) <= tol
+
+
+def _size_band(a: dict, b: dict) -> bool:
+    # same order of magnitude on notional (or both None); size is coarse by design
+    an, bn = a.get("notional"), b.get("notional")
+    if an is None or bn is None:
+        return an is None and bn is None
+    hi, lo = max(an, bn), min(an, bn)
+    return lo > 0 and hi / lo <= Decimal("1.5")
+
+
+def agree(a: dict, b: dict, *, tick: Decimal, atr: Decimal | None = None) -> dict[str, Any]:
+    side = a["side"] == b["side"]
+    limit_tol = (atr / Decimal(4)) if atr else (tick * 3)
+    limit = _within(a.get("limit_price"), b.get("limit_price"), limit_tol)
+    ta, tb = a["triggers"], b["triggers"]
+    jac = (len(ta & tb) / len(ta | tb)) if (ta or tb) else 1.0
+    size_band = _size_band(a, b)
+    same = side and size_band and limit and jac >= 0.6
+    return {"side": side, "size_band": size_band, "limit": limit,
+            "triggers_jaccard": jac, "same_decision": same}
+
+
+def summarize(decisions: list[dict], reference: dict | None, *, tick: Decimal,
+              atr: Decimal | None = None) -> dict[str, Any]:
+    k = len(decisions)
+    no_action = sum(1 for d in decisions if d["side"] is None)
+    # self-consistency: pairwise same_decision vs the modal decision (decisions[0] as anchor)
+    anchor = decisions[0] if decisions else None
+    self_same = (
+        sum(1 for d in decisions if anchor and agree(anchor, d, tick=tick, atr=atr)["same_decision"]) / k
+        if k else 0.0
+    )
+    fidelity = None
+    if reference is not None and k:
+        matches = [agree(reference, d, tick=tick, atr=atr) for d in decisions]
+        fidelity = {
+            "side_rate": sum(m["side"] for m in matches) / k,
+            "size_band_rate": sum(m["size_band"] for m in matches) / k,
+            "limit_rate": sum(m["limit"] for m in matches) / k,
+            "same_decision_rate": sum(m["same_decision"] for m in matches) / k,
+        }
+    return {"k": k, "no_action_rate": (no_action / k if k else 0.0),
+            "self_same_decision_rate": self_same, "fidelity": fidelity}
+```
+
+- [ ] **Step 4: Add tests for `agree` (tolerance + Jaccard + no-action) and `summarize` (no-action rate visible).**
+
+```python
+@pytest.mark.unit
+def test_agree_limit_tolerance_and_side():
+    a = {"side": "buy", "notional": Decimal("300000"), "limit_price": Decimal("129600"),
+         "triggers": frozenset({"x"})}
+    b = {"side": "buy", "notional": Decimal("320000"), "limit_price": Decimal("129700"),
+         "triggers": frozenset({"x"})}
+    r = agree(a, b, tick=Decimal("100"))
+    assert r["side"] and r["size_band"] and r["limit"] and r["same_decision"]
+
+@pytest.mark.unit
+def test_summarize_exposes_no_action_rate():
+    hold = {"side": None, "triggers": frozenset()}
+    s = summarize([hold, hold], reference=None, tick=Decimal("100"))
+    assert s["no_action_rate"] == 1.0
+    assert s["self_same_decision_rate"] == 1.0  # degenerate agreement is VISIBLE via no_action_rate
+```
+
+- [ ] **Step 5: Run + lint + commit.**
+
+Run: `uv run pytest tests/services/shadow_replay/test_scoring.py -v --no-cov` — Expected: PASS.
+Run: `uv run ruff check app/ tests/ && uv run ty check app/ --error-on-warning` — Expected: clean.
+
+```bash
+git add app/services/shadow_replay/scoring.py app/services/shadow_replay/__init__.py tests/services/shadow_replay/test_scoring.py
+git commit -m "feat(ROB-697): pure-function decision scorer (extract_decision/agree/summarize)"
+```
+
+---
+
+## Task 2 (T1): `shadow-replay` MCP profile (live-tool denial)
+
+**Files:**
+- Modify: `app/mcp_server/profiles.py:12` (enum) and `:21` (resolve auto-accepts).
+- Modify: `app/mcp_server/tooling/registry.py:125` (early-return branch).
+- Modify: `app/mcp_server/tooling/investment_hermes_handlers.py` (narrow read-only registrar).
+- Create: `tests/mcp_server/test_shadow_replay_profile.py`.
+- Reference: `tests/_mcp_tooling_support.py` (DummyMCP), `tests/test_mcp_profiles.py` (pattern, `TestResolveMcpProfile`, `TestOrderSurfaceMatrix`).
+
+**Interfaces:**
+- Produces: profile `McpProfile.SHADOW_REPLAY`; when active, the server registers EXACTLY `{investment_report_get_hermes_context, get_trading_policy, route_request}` and nothing else (no live-fetch, no news, no screeners, no orders, no report-write, no Hermes write tools).
+
+- [ ] **Step 1: Add the enum member.**
+
+```python
+# app/mcp_server/profiles.py — inside class McpProfile(StrEnum)
+    SHADOW_REPLAY = "shadow-replay"
+```
+
+- [ ] **Step 2: Add a narrow read-only Hermes-context registrar (avoid exposing the 4 Hermes WRITE tools).**
+
+In `app/mcp_server/tooling/investment_hermes_handlers.py`, add near `register_investment_hermes_tools`:
+
+```python
+def register_hermes_context_read_only(mcp) -> None:
+    """Register ONLY the frozen-context read tool (no prepare/compose/ingest write tools)."""
+    mcp.tool(
+        name="investment_report_get_hermes_context",
+        description="Return the frozen Hermes decision context for a snapshot bundle (read-only).",
+    )(investment_report_get_hermes_context_impl)
+```
+
+- [ ] **Step 3: Add the early-return branch at the TOP of `register_all_tools` (before the Always block).**
+
+```python
+# app/mcp_server/tooling/registry.py — first lines inside register_all_tools(mcp, profile)
+    if profile is McpProfile.SHADOW_REPLAY:
+        # Frozen-context replay ONLY: read the bundle + policy + lane procedure.
+        # Deliberately NO live-fetch (market_data/analysis/news), NO mutation,
+        # NO report-write. The agent returns its decision as JSON; it does not persist.
+        register_hermes_context_read_only(mcp)   # investment_report_get_hermes_context
+        register_trading_policy_tools(mcp)        # get_trading_policy (versioned thresholds)
+        register_route_request_tools(mcp)         # route_request (lane procedure)
+        return
+```
+
+(Import `register_hermes_context_read_only` at the top of registry.py alongside the other hermes imports.)
+
+- [ ] **Step 4: Write the profile registration test FIRST-style (allowlist ⊆, live-fetch disjoint).**
+
+```python
+# tests/mcp_server/test_shadow_replay_profile.py
+from typing import Any, cast
+import pytest
+from app.mcp_server.profiles import McpProfile, resolve_mcp_profile
+from app.mcp_server.tooling.registry import register_all_tools
+from tests._mcp_tooling_support import DummyMCP
+
+_ALLOWED = {"investment_report_get_hermes_context", "get_trading_policy", "route_request"}
+_FORBIDDEN = {"get_quote", "get_ohlcv", "get_orderbook", "screen_stocks", "get_news",
+              "investment_report_create", "place_order", "kis_mock_place_order",
+              "investment_report_create_from_hermes_composition"}
+
+@pytest.mark.unit
+def test_shadow_replay_exposes_only_allowlist(monkeypatch):
+    monkeypatch.setenv("SNAPSHOT_BACKED_REPORT_GENERATOR_ENABLED", "true")
+    mcp = DummyMCP()
+    register_all_tools(cast(Any, mcp), profile=McpProfile.SHADOW_REPLAY)
+    names = set(mcp.tools.keys())
+    assert names == _ALLOWED, f"unexpected tools: {names ^ _ALLOWED}"
+    assert _FORBIDDEN.isdisjoint(names)
+
+@pytest.mark.unit
+def test_resolve_shadow_replay():
+    assert resolve_mcp_profile("shadow-replay") is McpProfile.SHADOW_REPLAY
+```
+
+- [ ] **Step 5: Run to verify (fails until Steps 1-3 applied, then passes). Also update `TestOrderSurfaceMatrix`/`TestResolveMcpProfile` in `tests/test_mcp_profiles.py` so the set-equality matrix (parametrized over `list(McpProfile)`) knows shadow-replay registers zero order surfaces.**
+
+In `tests/test_mcp_profiles.py`, add `McpProfile.SHADOW_REPLAY: set()` to `_ORDER_SURFACE_MATRIX` (empty = no order tools).
+
+Run: `uv run pytest tests/mcp_server/test_shadow_replay_profile.py tests/test_mcp_profiles.py -v --no-cov`
+Expected: PASS (including the parametrized matrix — it fails on any drift).
+
+- [ ] **Step 6: Lint + commit.**
+
+Run: `uv run ruff check app/ tests/ && uv run ty check app/ --error-on-warning` — Expected: clean.
+
+```bash
+git add app/mcp_server/profiles.py app/mcp_server/tooling/registry.py \
+        app/mcp_server/tooling/investment_hermes_handlers.py \
+        tests/mcp_server/test_shadow_replay_profile.py tests/test_mcp_profiles.py
+git commit -m "feat(ROB-697): shadow-replay MCP profile (frozen-context read + policy + route_request only)"
+```
+
+---
+
+## Task 3 (P1): Frozen-context reproducibility check
+
+**Why:** A′ is only valid if the same bundle yields the same decision-bearing context across replays. Grounding: `get_hermes_context` emits no verbatim timestamp; `stage_inputs` + `cited_snapshots` are fully frozen; `dimension_evidence`/`dimension_reports`/`market_session` read LIVE tables and can drift. This task pins the reproducible surface an M1 batch relies on.
+
+**Files:**
+- Create: `scripts/shadow_replay_probe.py` (a tiny read-only probe that calls the tool twice and diffs).
+- Reference: `app/mcp_server/tooling/investment_hermes_handlers.py:162`, `app/schemas/hermes_composition.py:76`.
+
+- [ ] **Step 1: Add a probe function that calls the impl twice and diffs the FROZEN sections.**
+
+```python
+# scripts/shadow_replay_probe.py
+import asyncio, json, sys
+from app.mcp_server.tooling.investment_hermes_handlers import (
+    investment_report_get_hermes_context_impl as get_ctx,
+)
+
+_FROZEN_KEYS = ("stage_inputs", "cited_snapshots", "policy_version",
+                "market", "market_session", "coverage_summary")
+
+async def probe(bundle_uuid: str) -> int:
+    a = await get_ctx(bundle_uuid)
+    b = await get_ctx(bundle_uuid)
+    if not a.get("success"):
+        print(json.dumps({"error": a}, ensure_ascii=False)); return 2
+    frozen_a = {k: a.get(k) for k in _FROZEN_KEYS}
+    frozen_b = {k: b.get(k) for k in _FROZEN_KEYS}
+    identical = json.dumps(frozen_a, sort_keys=True) == json.dumps(frozen_b, sort_keys=True)
+    drift = {k: [a.get(k), b.get(k)] for k in ("dimension_evidence", "dimension_reports")
+             if json.dumps(a.get(k), sort_keys=True) != json.dumps(b.get(k), sort_keys=True)}
+    print(json.dumps({"frozen_identical": identical, "live_section_drift": list(drift)},
+                     ensure_ascii=False))
+    return 0 if identical else 1
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(probe(sys.argv[1])))
+```
+
+- [ ] **Step 2: Run against one bundle_uuid from Task 0's corpus (server env: SNAPSHOT_BACKED_REPORT_GENERATOR_ENABLED=true).**
+
+Run: `SNAPSHOT_BACKED_REPORT_GENERATOR_ENABLED=true uv run python -m scripts.shadow_replay_probe <bundle_uuid>`
+Expected: `{"frozen_identical": true, "live_section_drift": []}` for two calls seconds apart. If `live_section_drift` is non-empty, record it — it means the K-replay batch (Task 4) must run tight in time; the decision prompt (Task 4) must instruct the agent to base its call on `stage_inputs`/`cited_snapshots` (the frozen sections).
+
+- [ ] **Step 3: Commit the probe + record the P1 result in the runbook.**
+
+```bash
+git add scripts/shadow_replay_probe.py docs/runbooks/shadow-replay.md
+git commit -m "feat(ROB-697): P1 frozen-context reproducibility probe"
+```
+
+---
+
+## Task 4 (T2 + T4): Headless `claude -p` driver + report
+
+**Files:**
+- Create: `scripts/shadow_replay.py`, `scripts/shadow_replay_mcp.json`.
+- Create: `tests/test_shadow_replay_cli.py`.
+- Reference: `scripts/kiwoom_mock_smoke.py` (CLI/monkeypatch pattern), `app/mcp_server/main.py:108` (transport), the `.hermes/plans/*.md` `claude -p` invocation shape (planner precedent, docs only).
+
+**Interfaces:**
+- Consumes: `select_replay_corpus` (Task 0), `summarize`/`extract_decision` (Task 1), the `shadow-replay` profile (Task 2).
+- Produces: `run_batch(corpus, *, k: int, model: str, tick: Decimal) -> list[dict]` and a markdown report writer `write_report(results, path)`.
+
+- [ ] **Step 1: Author the stdio MCP config for `claude -p`.**
+
+```json
+// scripts/shadow_replay_mcp.json
+{
+  "mcpServers": {
+    "shadow-replay": {
+      "command": "uv",
+      "args": ["run", "python", "-m", "app.mcp_server.main"],
+      "env": {
+        "MCP_TYPE": "stdio",
+        "MCP_PROFILE": "shadow-replay",
+        "SNAPSHOT_BACKED_REPORT_GENERATOR_ENABLED": "true"
+      }
+    }
+  }
+}
+```
+
+(stdio avoids the HTTP `x-paperclip-agent-id` header requirement; DB creds come from the ambient `.env` the server already reads.)
+
+- [ ] **Step 2: Write the driver with a pinned model, JSON output contract, and MCP-reset discard.**
+
+```python
+# scripts/shadow_replay.py  (excerpt — full CLI mirrors scripts/kiwoom_mock_smoke.py)
+import argparse, json, subprocess
+from decimal import Decimal
+from pathlib import Path
+
+_MCP_CONFIG = str(Path(__file__).with_name("shadow_replay_mcp.json"))
+_RESET_MARKERS = ("get_hermes_context", "connection error", "tool not found")
+
+_PROMPT = (
+    "You are replaying a FROZEN trading-decision context. Call "
+    "investment_report_get_hermes_context with snapshot_bundle_uuid={uuid}. "
+    "Base your decision ONLY on its stage_inputs and cited_snapshots (the frozen "
+    "evidence) plus get_trading_policy thresholds and the route_request lane. Do NOT "
+    "call any other tool. Output ONLY a JSON object: "
+    '{{"side": "buy"|"sell"|null, "max_action": {{"notional": <num|null>, '
+    '"limit_price": <num|null>}}, "trade_setup": {{"stop": <num|null>, '
+    '"target": <num|null>, "headline": {{"entry": <num|null>}}}}, '
+    '"trigger_checklist": [<str>...]}}'
+)
+
+def _one_run(uuid: str, model: str) -> dict | None:
+    proc = subprocess.run(
+        ["claude", "-p", "--model", model, "--mcp-config", _MCP_CONFIG,
+         "--allowedTools", "mcp__shadow-replay__investment_report_get_hermes_context,"
+         "mcp__shadow-replay__get_trading_policy,mcp__shadow-replay__route_request",
+         "--max-turns", "8", "--output-format", "json"],
+        input=_PROMPT.format(uuid=uuid), text=True, capture_output=True, timeout=300,
+    )
+    if proc.returncode != 0 or any(m in proc.stderr.lower() for m in _RESET_MARKERS):
+        return None  # discarded sample (MCP reset / error) — NOT a data point
+    try:
+        # claude --output-format json wraps the assistant text; parse the inner JSON contract
+        outer = json.loads(proc.stdout)
+        return json.loads(outer["result"]) if isinstance(outer, dict) else json.loads(proc.stdout)
+    except (json.JSONDecodeError, KeyError):
+        return None
+
+def run_batch(corpus, *, k: int, model: str, tick: Decimal) -> list[dict]:
+    from app.services.shadow_replay.scoring import extract_decision, summarize
+    results = []
+    for item in corpus.items:
+        raw = [_one_run(item.snapshot_bundle_uuid, model) for _ in range(k)]
+        decisions = [extract_decision(r) for r in raw if r is not None]
+        results.append({
+            "item_uuid": item.item_uuid, "item_kind": item.item_kind,
+            "discarded": sum(1 for r in raw if r is None),
+            "summary": summarize(decisions, item.reference_decision, tick=tick),
+        })
+    return results
+```
+
+- [ ] **Step 3: Write CLI tests that monkeypatch `_one_run` (no real `claude -p` in CI) and assert discard + summary wiring.**
+
+```python
+# tests/test_shadow_replay_cli.py
+from decimal import Decimal
+import pytest
+from scripts import shadow_replay as sr
+from app.services.shadow_replay.corpus import CorpusItem, CorpusSelection
+
+@pytest.mark.unit
+def test_run_batch_counts_discards_and_summarizes(monkeypatch):
+    ref = {"side": "buy", "max_action": {"notional": "300000", "limit_price": "129600"},
+           "evidence_snapshot": {"trade_setup": {"headline": {"entry": "129600"}}},
+           "trigger_checklist": ["x"]}
+    from app.services.shadow_replay.scoring import extract_decision
+    item = CorpusItem("u1", 1, "i1", "action", "buy_review", extract_decision(ref))
+    corpus = CorpusSelection("claude_bundle", [item])
+    seq = iter([ref, None, ref])  # one MCP-reset discard in the middle
+    monkeypatch.setattr(sr, "_one_run", lambda uuid, model: next(seq))
+    out = sr.run_batch(corpus, k=3, model="claude-opus-4-8", tick=Decimal("100"))
+    assert out[0]["discarded"] == 1
+    assert out[0]["summary"]["fidelity"]["side_rate"] == 1.0
+    assert out[0]["summary"]["no_action_rate"] == 0.0
+
+@pytest.mark.unit
+def test_parser_defaults():
+    args = sr.build_parser().parse_args(["--k", "5"])
+    assert args.k == 5 and args.model  # model has a pinned default
+```
+
+- [ ] **Step 4: Add `build_parser`, `write_report` (markdown table: per-item side/size/limit/same-decision + no-action rate + discards), and a `main()` that requires `--confirm` before spawning any `claude -p` (default is a dry plan that only prints the corpus + would-run count).**
+
+- [ ] **Step 5: Run tests + lint + commit.**
+
+Run: `uv run pytest tests/test_shadow_replay_cli.py -v --no-cov` — Expected: PASS.
+Run: `uv run ruff check app/ tests/ && uv run ruff format --check app/ tests/ && uv run ty check app/ --error-on-warning` — Expected: clean.
+
+```bash
+git add scripts/shadow_replay.py scripts/shadow_replay_mcp.json tests/test_shadow_replay_cli.py docs/runbooks/shadow-replay.md
+git commit -m "feat(ROB-697): headless claude -p shadow-replay driver + markdown report"
+```
+
+- [ ] **Step 6: One real end-to-end batch (operator, not CI) once P0 corpus is confirmed.**
+
+Run: `uv run python -m scripts.shadow_replay --k 5 --model claude-opus-4-8 --confirm`
+Expected: a markdown report with per-decision-type `side_rate / size_band_rate / limit_rate / same_decision_rate` + `no_action_rate` + discard counts. This is the M1 deliverable number.
+
+---
+
+## Roadmap (out of scope — do NOT build in M1)
+
+- **M2:** Upbit shadow-sim live mock loop (crypto; live Upbit data → virtual fills; binance_demo dropped = ≠ Upbit exchange/currency). New `upbit-shadow` account_mode, forecast/retro auto-wiring, safety kit.
+- **M3:** kis_mock (KR) port — wire `KisMockBroker.confirm_fill` (holdings-delta) into `kis_mock_reconciliation_run_impl`; add kis_mock to the retro pending due-list scan (`_VALID_ACCOUNT_MODES` already includes kis_mock).
+
+## Self-Review notes
+
+- Spec coverage: P0→Task 0, P1→Task 3, T1→Task 2, T2→Task 4 (steps 1-3, 6), T3→Task 1, T4→Task 4 (step 4). ✓
+- The P0 tension (human-authored vs bundle presence) is handled explicitly with a census gate + 3 corpus sources, not assumed away.
+- The live-leakage validity risk is enforced structurally (profile allowlist), tested (deny set disjoint).
+- Determinism caveat is scoped to frozen sections + a tight batch; the clean `now=`-threading fix is named as M1-follow-up.

--- a/scripts/shadow_replay.py
+++ b/scripts/shadow_replay.py
@@ -29,6 +29,7 @@ import argparse
 import asyncio
 import json
 import subprocess
+import sys
 from decimal import Decimal
 from pathlib import Path
 from typing import Any
@@ -179,6 +180,38 @@ def run_batch(
     ]
 
 
+def all_samples_discarded(results: list[dict[str, Any]]) -> bool:
+    """True iff at least one sample was attempted and EVERY attempted sample
+    was discarded (`_one_run` returned `None` for every call, across every
+    corpus item).
+
+    Pure function: only reads the per-item result dicts `run_batch` returns
+    (`discarded` + `summary["k"]`) — no I/O, no subprocess calls.
+
+    Why this exists: `_one_run` is best-effort + defensive by design (ANY
+    subprocess failure, non-zero exit, MCP-reset marker, or JSON-parse
+    failure returns `None` rather than raising). That is the right behavior
+    for a single flaky sample. But if the `claude --output-format json`
+    envelope assumption is simply WRONG (verified only at operator
+    run-time), `_one_run` returns `None` for every single call, `run_batch`
+    still returns a normal-looking list of result rows (`discarded == k`,
+    `summary["k"] == 0` for every item), and the batch would otherwise exit
+    0 and print `"step": "done"` — an operator could easily read that as
+    "ran clean, fidelity is just bad" instead of "the harness itself is
+    broken." This predicate is the trigger `_amain` uses to turn that
+    silent-looking success into a loud, non-zero-exit warning.
+    """
+    total_attempted = 0
+    total_discarded = 0
+    for row in results:
+        summary = row.get("summary") or {}
+        discarded = row.get("discarded", 0)
+        attempted = discarded + summary.get("k", 0)
+        total_attempted += attempted
+        total_discarded += discarded
+    return total_attempted > 0 and total_discarded == total_attempted
+
+
 def _fmt_rate(value: float | None) -> str:
     return f"{value:.3f}" if value is not None else "n/a"
 
@@ -319,6 +352,21 @@ async def _amain(args: argparse.Namespace) -> int:
             {"step": "done", "report_path": str(args.report)}, ensure_ascii=False
         )
     )
+
+    if all_samples_discarded(results):
+        total_attempted = sum(
+            row.get("discarded", 0) + (row.get("summary") or {}).get("k", 0)
+            for row in results
+        )
+        print(
+            f"WARNING: all {total_attempted} replay samples were discarded — "
+            "this usually means the `claude -p` invocation or --output-format "
+            "parsing is broken, not that the model kept resetting. Check the "
+            "harness before trusting this report.",
+            file=sys.stderr,
+        )
+        return 3
+
     return 0
 
 

--- a/scripts/shadow_replay.py
+++ b/scripts/shadow_replay.py
@@ -1,0 +1,331 @@
+# scripts/shadow_replay.py
+"""Headless `claude -p` A' shadow-replay driver + markdown report (ROB-697, M1).
+
+Replays each corpus item (`select_replay_corpus`, Task 0) through a headless
+`claude -p` subprocess call `k` times, scores the replayed decisions against
+what was actually decided (`extract_decision` / `summarize`, Task 1), and
+writes a markdown report.
+
+ROB-501 guard: this is a `scripts/` CLI, not `app/` runtime code. It shells
+out to the external `claude` binary via `subprocess.run` (that's an
+out-of-process CLI call, not an in-process LLM SDK import) and imports no
+LLM provider. M1 is read-only: no orders, no watch mutation, no report
+persistence — the replayed agent returns JSON on stdout; this driver only
+scores and reports it.
+
+Usage (operator, requires a live DB + the `claude` CLI on PATH):
+    # Dry plan only (no `claude -p` spawned) — always safe to run:
+    uv run python -m scripts.shadow_replay --k 5
+
+    # Real batch (spawns `k` x corpus-size `claude -p` subprocesses):
+    uv run python -m scripts.shadow_replay --k 5 --model claude-opus-4-8 --confirm
+
+See docs/runbooks/shadow-replay.md for the full procedure.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import subprocess
+from decimal import Decimal
+from pathlib import Path
+from typing import Any
+
+from app.services.shadow_replay.corpus import CorpusItem, CorpusSelection
+from app.services.shadow_replay.scoring import extract_decision, summarize
+
+_MCP_CONFIG = str(Path(__file__).with_name("shadow_replay_mcp.json"))
+
+# MCP-session-churn markers: if the CLI's stderr mentions any of these, the
+# MCP connection reset mid-run (e.g. the stdio server bounced) rather than
+# the agent making a real decision. Treated as a discarded sample, not a
+# "no action" data point — counting it as data would understate fidelity.
+_RESET_MARKERS = ("get_hermes_context", "connection error", "tool not found")
+
+# Pinned to an EXACT model id, never a "-latest" alias: A' replay measures
+# longitudinal self-consistency / fidelity across repeated runs (this batch
+# today vs. a re-run next month). A "-latest" alias silently repoints to a
+# newer model over time, which would confound "did the decision drift"
+# with "did the model change" — the model id is recorded in every result
+# row and the report header specifically so results stay comparable.
+_DEFAULT_MODEL = "claude-opus-4-8"
+
+_PROMPT = (
+    "You are replaying a FROZEN trading-decision context. Call "
+    "investment_report_get_hermes_context with snapshot_bundle_uuid={uuid}. "
+    "Base your decision ONLY on its stage_inputs and cited_snapshots (the frozen "
+    "evidence) plus get_trading_policy thresholds and the route_request lane. Do NOT "
+    "call any other tool. Output ONLY a JSON object: "
+    '{{"side": "buy"|"sell"|null, "max_action": {{"notional": <num|null>, '
+    '"limit_price": <num|null>}}, "trade_setup": {{"stop": <num|null>, '
+    '"target": <num|null>, "headline": {{"entry": <num|null>}}}}, '
+    '"trigger_checklist": [<str>...]}}'
+)
+
+
+def _to_item_shape(raw: dict[str, Any]) -> dict[str, Any]:
+    """Adapt a raw `claude -p` JSON reply into the shape `extract_decision` expects.
+
+    `_PROMPT` instructs the replayed agent to output `trade_setup` at the TOP
+    level (a flat, easy-to-follow contract for the agent). `extract_decision`
+    (Task 1, already committed) instead reads a *nested*
+    `evidence_snapshot.trade_setup`, matching the shape of a persisted
+    `InvestmentReportItem`. Calling `extract_decision(raw)` directly on the
+    raw claude reply would silently read `ev.get("trade_setup")` off an empty
+    `{}` and drop entry/stop/target every time — a shape mismatch, not a
+    genuine "the model didn't propose a setup" result. This adapter is the
+    fix: it re-nests `trade_setup` under `evidence_snapshot` before scoring.
+
+    Pure function — dict in, dict out, no I/O.
+    """
+    return {
+        "side": raw.get("side"),
+        "max_action": raw.get("max_action") or {},
+        "evidence_snapshot": {"trade_setup": raw.get("trade_setup") or {}},
+        "trigger_checklist": raw.get("trigger_checklist") or [],
+    }
+
+
+def _one_run(uuid: str, model: str) -> dict[str, Any] | None:
+    """Invoke one headless `claude -p` replay call for `uuid`.
+
+    Best-effort + defensive by design: the exact `claude -p
+    --output-format json` envelope shape is only verified at operator
+    run-time (docs/runbooks/shadow-replay.md, Step 6 — requires a live DB,
+    the running MCP server, and the `claude` CLI). ANY subprocess failure
+    (missing binary, timeout), non-zero exit, an MCP-reset stderr marker, or
+    a JSON-parse failure returns None — a DISCARDED sample, NOT a data
+    point. `run_batch` counts discards separately and a single bad replay
+    call never crashes the batch.
+
+    NOTE: this is the ONLY place `claude` is invoked. Tests must always
+    monkeypatch `_one_run` — never let a real subprocess run in CI.
+    """
+    try:
+        proc = subprocess.run(
+            [
+                "claude",
+                "-p",
+                "--model",
+                model,
+                "--mcp-config",
+                _MCP_CONFIG,
+                "--allowedTools",
+                "mcp__shadow-replay__investment_report_get_hermes_context,"
+                "mcp__shadow-replay__get_trading_policy,"
+                "mcp__shadow-replay__route_request",
+                "--max-turns",
+                "8",
+                "--output-format",
+                "json",
+            ],
+            input=_PROMPT.format(uuid=uuid),
+            text=True,
+            capture_output=True,
+            timeout=300,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+
+    if proc.returncode != 0 or any(m in proc.stderr.lower() for m in _RESET_MARKERS):
+        return None  # discarded sample (MCP reset / error) — NOT a data point
+
+    try:
+        # `claude --output-format json` wraps the assistant text in an
+        # envelope; the decision contract JSON lives in the `result` field.
+        # Fall back to parsing stdout directly in case the CLI ever emits
+        # the contract JSON un-enveloped (verified only at operator run-time).
+        outer = json.loads(proc.stdout)
+        return (
+            json.loads(outer["result"])
+            if isinstance(outer, dict)
+            else json.loads(proc.stdout)
+        )
+    except (json.JSONDecodeError, KeyError, TypeError):
+        return None
+
+
+def _run_one_item(
+    item: CorpusItem, *, k: int, model: str, tick: Decimal, source: str
+) -> dict[str, Any]:
+    raw = [_one_run(item.snapshot_bundle_uuid, model) for _ in range(k)]
+    decisions = [extract_decision(_to_item_shape(r)) for r in raw if r is not None]
+    return {
+        "item_uuid": item.item_uuid,
+        "item_kind": item.item_kind,
+        "source": source,
+        "model": model,
+        "discarded": sum(1 for r in raw if r is None),
+        "summary": summarize(decisions, item.reference_decision, tick=tick),
+    }
+
+
+def run_batch(
+    corpus: CorpusSelection, *, k: int, model: str, tick: Decimal
+) -> list[dict[str, Any]]:
+    """Replay every corpus item `k` times and score the results.
+
+    One result row per `CorpusItem`: `{item_uuid, item_kind, source, model,
+    discarded, summary}`. `discarded` counts `_one_run` calls that returned
+    None (MCP reset / parse failure) out of `k`; `summary` is
+    `summarize(...)` over only the successfully-parsed decisions, so
+    discards never silently count as "no action" data points.
+    """
+    return [
+        _run_one_item(item, k=k, model=model, tick=tick, source=corpus.source)
+        for item in corpus.items
+    ]
+
+
+def _fmt_rate(value: float | None) -> str:
+    return f"{value:.3f}" if value is not None else "n/a"
+
+
+def write_report(results: list[dict[str, Any]], path: Path) -> str:
+    """Render `run_batch` results as a markdown table and write it to `path`.
+
+    Header records the corpus `source` and the pinned `model` (both stamped
+    onto every result row by `run_batch`, pulled here from the first row)
+    so the report file is self-describing for longitudinal comparison even
+    once separated from the invocation that produced it. Returns the
+    rendered markdown text (also used for stdout echo by `main`).
+    """
+    source = results[0]["source"] if results else "n/a"
+    model = results[0]["model"] if results else "n/a"
+    lines = [
+        "# A' Shadow Replay Report (ROB-697, M1)",
+        "",
+        f"- **Corpus source:** {source}",
+        f"- **Model:** {model}",
+        f"- **Items:** {len(results)}",
+        "",
+        "| item_uuid | item_kind | side_rate | size_band_rate | limit_rate | "
+        "same_decision_rate | no_action_rate | discarded |",
+        "|---|---|---|---|---|---|---|---|",
+    ]
+    for row in results:
+        summary = row["summary"]
+        fidelity = summary.get("fidelity") or {}
+        lines.append(
+            "| {uuid} | {kind} | {side} | {size} | {limit} | {same} | {noact} | {disc} |".format(
+                uuid=row["item_uuid"],
+                kind=row["item_kind"],
+                side=_fmt_rate(fidelity.get("side_rate")),
+                size=_fmt_rate(fidelity.get("size_band_rate")),
+                limit=_fmt_rate(fidelity.get("limit_rate")),
+                same=_fmt_rate(fidelity.get("same_decision_rate")),
+                noact=_fmt_rate(summary.get("no_action_rate")),
+                disc=row["discarded"],
+            )
+        )
+    text = "\n".join(lines) + "\n"
+    path.write_text(text)
+    return text
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="A' shadow replay: headless `claude -p` batch driver (ROB-697, M1)"
+    )
+    parser.add_argument(
+        "--k", type=int, default=5, help="Replay count per corpus item (default 5)."
+    )
+    parser.add_argument(
+        "--model",
+        default=_DEFAULT_MODEL,
+        help=(
+            "Pinned EXACT Claude model id (never a '-latest' alias) so replay "
+            f"results stay comparable across runs. Default: {_DEFAULT_MODEL}."
+        ),
+    )
+    parser.add_argument(
+        "--tick",
+        type=str,
+        default="0.01",
+        help="Price tick size (Decimal string) used for limit-price tolerance.",
+    )
+    parser.add_argument(
+        "--min-per-kind",
+        type=int,
+        default=1,
+        help="Forwarded to select_replay_corpus's action/watch coverage gate.",
+    )
+    parser.add_argument(
+        "--report",
+        type=Path,
+        default=Path("shadow_replay_report.md"),
+        help="Markdown report output path.",
+    )
+    parser.add_argument(
+        "--confirm",
+        action="store_true",
+        help=(
+            "Required to actually spawn any `claude -p` subprocess. Without "
+            "it, prints a dry plan (corpus size + would-run call count) and "
+            "exits 0 — nothing is spawned."
+        ),
+    )
+    return parser
+
+
+def _dry_plan_payload(corpus: CorpusSelection, *, k: int, model: str) -> dict[str, Any]:
+    return {
+        "step": "dry_plan",
+        "confirm": False,
+        "source": corpus.source,
+        "corpus_size": len(corpus.items),
+        "would_run_claude_p_calls": len(corpus.items) * k,
+        "model": model,
+    }
+
+
+async def _amain(args: argparse.Namespace) -> int:
+    # Deferred import: building the async engine needs DATABASE_URL, which a
+    # unit-test import of this module should never be coupled to.
+    from app.core.db import AsyncSessionLocal
+    from app.services.shadow_replay.corpus import (
+        CorpusUnavailable,
+        select_replay_corpus,
+    )
+
+    async with AsyncSessionLocal() as session:
+        try:
+            corpus = await select_replay_corpus(session, min_per_kind=args.min_per_kind)
+        except CorpusUnavailable as exc:
+            print(
+                json.dumps(
+                    {"step": "corpus_unavailable", "error": str(exc)},
+                    ensure_ascii=False,
+                )
+            )
+            return 2
+
+    if not args.confirm:
+        print(
+            json.dumps(
+                _dry_plan_payload(corpus, k=args.k, model=args.model),
+                ensure_ascii=False,
+            )
+        )
+        return 0
+
+    results = run_batch(corpus, k=args.k, model=args.model, tick=Decimal(args.tick))
+    report_text = write_report(results, args.report)
+    print(report_text)
+    print(
+        json.dumps(
+            {"step": "done", "report_path": str(args.report)}, ensure_ascii=False
+        )
+    )
+    return 0
+
+
+def main() -> None:
+    args = build_parser().parse_args()
+    raise SystemExit(asyncio.run(_amain(args)))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/shadow_replay_mcp.json
+++ b/scripts/shadow_replay_mcp.json
@@ -1,0 +1,13 @@
+{
+  "mcpServers": {
+    "shadow-replay": {
+      "command": "uv",
+      "args": ["run", "python", "-m", "app.mcp_server.main"],
+      "env": {
+        "MCP_TYPE": "stdio",
+        "MCP_PROFILE": "shadow-replay",
+        "SNAPSHOT_BACKED_REPORT_GENERATOR_ENABLED": "true"
+      }
+    }
+  }
+}

--- a/scripts/shadow_replay_probe.py
+++ b/scripts/shadow_replay_probe.py
@@ -1,0 +1,89 @@
+# scripts/shadow_replay_probe.py
+"""P1 frozen-context reproducibility probe for the A' shadow replay harness
+(ROB-697, M1).
+
+Calls `investment_report_get_hermes_context` twice for the same
+`snapshot_bundle_uuid` and checks that the FROZEN sections (`stage_inputs`,
+`cited_snapshots`, `policy_version`, `market`, `market_session`,
+`coverage_summary`) are byte-identical across the two calls, i.e. safe to
+treat as stable input for a later K-replay batch. `dimension_evidence` and
+`dimension_reports` read LIVE tables and are reported separately as
+"live_section_drift" rather than treated as a failure.
+
+Read-only: no stage_run / artifact rows are persisted, no broker / order /
+watch / order-intent mutation, no in-process LLM provider (ROB-501) — this
+only calls the existing read-only Hermes-context impl.
+
+Usage (operator, requires live DB + a real bundle_uuid):
+    SNAPSHOT_BACKED_REPORT_GENERATOR_ENABLED=true \\
+        uv run python -m scripts.shadow_replay_probe <bundle_uuid>
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+from typing import Any
+
+from app.mcp_server.tooling.investment_hermes_handlers import (
+    investment_report_get_hermes_context_impl as get_ctx,
+)
+
+_FROZEN_KEYS = (
+    "stage_inputs",
+    "cited_snapshots",
+    "policy_version",
+    "market",
+    "market_session",
+    "coverage_summary",
+)
+
+_LIVE_SECTION_KEYS = ("dimension_evidence", "dimension_reports")
+
+
+def compare_frozen(a: dict[str, Any], b: dict[str, Any]) -> dict[str, Any]:
+    """Diff two `get_hermes_context` payloads for the same bundle.
+
+    Pure (dict in, dict out) — no I/O. Compares the FROZEN keys via
+    `json.dumps(..., sort_keys=True)` equality and lists which of the
+    LIVE-reading keys differ.
+
+    Returns ``{"frozen_identical": bool, "live_section_drift": list[str]}``.
+    """
+    frozen_a = {k: a.get(k) for k in _FROZEN_KEYS}
+    frozen_b = {k: b.get(k) for k in _FROZEN_KEYS}
+    frozen_identical = json.dumps(frozen_a, sort_keys=True) == json.dumps(
+        frozen_b, sort_keys=True
+    )
+    live_section_drift = [
+        k
+        for k in _LIVE_SECTION_KEYS
+        if json.dumps(a.get(k), sort_keys=True) != json.dumps(b.get(k), sort_keys=True)
+    ]
+    return {
+        "frozen_identical": frozen_identical,
+        "live_section_drift": live_section_drift,
+    }
+
+
+async def probe(bundle_uuid: str) -> int:
+    """Call `get_hermes_context` twice for `bundle_uuid` and diff the result.
+
+    Prints the diff as JSON. Returns exit code 0 if the frozen sections are
+    identical, 1 if they drifted, 2 if the first call itself failed
+    (`success=False`, e.g. bundle not found or feature-flag disabled).
+    """
+    a = await get_ctx(bundle_uuid)
+    if not a.get("success"):
+        print(json.dumps({"error": a}, ensure_ascii=False))
+        return 2
+
+    b = await get_ctx(bundle_uuid)
+    result = compare_frozen(a, b)
+    print(json.dumps(result, ensure_ascii=False))
+    return 0 if result["frozen_identical"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(probe(sys.argv[1])))

--- a/tests/mcp_server/test_account_routing_tools.py
+++ b/tests/mcp_server/test_account_routing_tools.py
@@ -36,7 +36,14 @@ def test_account_routing_tool_names_register():
     assert set(mcp.tools) == {"suggest_order_account"}
 
 
-@pytest.mark.parametrize("profile", list(McpProfile))
+# ROB-697 M1 — shadow-replay early-returns before the "Always" block that
+# registers suggest_order_account, so it is deliberately excluded here (its
+# validity guard is that it carries ONLY the frozen-context read + policy +
+# route_request tools; see tests/mcp_server/test_shadow_replay_profile.py).
+_READ_PROFILES = [p for p in McpProfile if p is not McpProfile.SHADOW_REPLAY]
+
+
+@pytest.mark.parametrize("profile", _READ_PROFILES)
 def test_suggest_order_account_registered_on_all_read_profiles(profile):
     mcp = DummyMCP()
 

--- a/tests/mcp_server/test_shadow_replay_profile.py
+++ b/tests/mcp_server/test_shadow_replay_profile.py
@@ -1,0 +1,64 @@
+"""ROB-697 M1 — shadow-replay MCP profile (live-tool denial guard).
+
+The ``shadow-replay`` profile is the load-bearing validity guard for the A'
+shadow replay harness: a headless replay session must be able to read the
+frozen Hermes decision context, the versioned trading policy, and the
+advisory lane router — and NOTHING ELSE. No live-fetch tool
+(market_data/analysis/news/fundamentals), no order/mutation tool, and none
+of the 4 Hermes WRITE tools may be reachable through this profile, or a
+replay could leak live market data / persist state and invalidate the
+experiment.
+"""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+import pytest
+
+from app.mcp_server.profiles import McpProfile, resolve_mcp_profile
+from app.mcp_server.tooling.registry import register_all_tools
+from tests._mcp_tooling_support import DummyMCP
+
+_ALLOWED = {
+    "investment_report_get_hermes_context",
+    "get_trading_policy",
+    "route_request",
+}
+_FORBIDDEN = {
+    "get_quote",
+    "get_ohlcv",
+    "get_orderbook",
+    "screen_stocks",
+    "get_news",
+    "investment_report_create",
+    "place_order",
+    "kis_mock_place_order",
+    "investment_report_create_from_hermes_composition",
+}
+
+
+@pytest.mark.unit
+def test_shadow_replay_exposes_only_allowlist(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Registration is unconditional (Step 3 of the brief) — the flag is
+    # enforced at call time inside investment_report_get_hermes_context_impl,
+    # not at registration time — but set it anyway to prove the allowlist
+    # holds regardless of the flag's value.
+    monkeypatch.setenv("SNAPSHOT_BACKED_REPORT_GENERATOR_ENABLED", "true")
+    mcp = DummyMCP()
+    register_all_tools(cast(Any, mcp), profile=McpProfile.SHADOW_REPLAY)
+    names = set(mcp.tools.keys())
+    assert names == _ALLOWED, f"unexpected tools: {names ^ _ALLOWED}"
+
+
+@pytest.mark.unit
+def test_shadow_replay_disjoint_from_forbidden_surface() -> None:
+    mcp = DummyMCP()
+    register_all_tools(cast(Any, mcp), profile=McpProfile.SHADOW_REPLAY)
+    names = set(mcp.tools.keys())
+    assert _FORBIDDEN.isdisjoint(names)
+
+
+@pytest.mark.unit
+def test_resolve_shadow_replay() -> None:
+    assert resolve_mcp_profile("shadow-replay") is McpProfile.SHADOW_REPLAY

--- a/tests/services/shadow_replay/test_corpus.py
+++ b/tests/services/shadow_replay/test_corpus.py
@@ -64,6 +64,7 @@ def _item_payload(report_id: int, **overrides) -> dict:
 
 @pytest.mark.integration
 @pytest.mark.asyncio
+@pytest.mark.usefixtures("investment_reports_cleanup_lock")
 async def test_autoemit_item_excluded(db_session):
     """``_bundle_items_for_profile`` drops auto_emit-sourced items, keeps the human one.
 

--- a/tests/services/shadow_replay/test_corpus.py
+++ b/tests/services/shadow_replay/test_corpus.py
@@ -1,0 +1,154 @@
+"""ROB-697 (M1) — replay-corpus selection tests.
+
+The integration test seeds real ORM rows via the shared ``db_session``
+fixture (real PostgreSQL, see ``tests/conftest.py``); the unit tests
+exercise the pure predicates without touching the DB.
+
+No ``seed_report_item`` factory exists in this repo (checked
+``tests/conftest.py`` and ``tests/_investment_reports_helpers.py``), so
+rows are constructed inline here, mirroring the payload-builder pattern
+used by ``tests/test_investment_reports_model.py``
+(``_base_payload`` / ``_base_item_payload``).
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from app.models.investment_reports import InvestmentReport, InvestmentReportItem
+from app.services.shadow_replay.corpus import (
+    CorpusItem,
+    _bundle_items_for_profile,
+    _covers_kinds,
+    _non_autoemit,
+)
+
+
+def _report_payload(**overrides) -> dict:
+    payload: dict = {
+        "report_uuid": uuid.uuid4(),
+        "idempotency_key": f"rob697-report-{uuid.uuid4()}",
+        "report_type": "kr_morning",
+        "market": "kr",
+        "market_session": "regular",
+        "account_scope": "kis_mock",
+        "execution_mode": "mock_preview",
+        "created_by_profile": "CLAUDE_ADVISOR",
+        "title": "ROB-697 corpus test report",
+        "summary": "corpus test",
+        "status": "draft",
+        "snapshot_bundle_uuid": uuid.uuid4(),
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _item_payload(report_id: int, **overrides) -> dict:
+    payload: dict = {
+        "report_id": report_id,
+        "item_uuid": uuid.uuid4(),
+        "idempotency_key": f"rob697-item-{uuid.uuid4()}",
+        "item_kind": "action",
+        "symbol": "005930",
+        "side": "buy",
+        "intent": "buy_review",
+        "target_kind": "asset",
+        "rationale": "ROB-697 corpus test seed row",
+        "evidence_snapshot": {},
+    }
+    payload.update(overrides)
+    return payload
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_autoemit_item_excluded(db_session):
+    """``_bundle_items_for_profile`` drops auto_emit-sourced items, keeps the human one.
+
+    Task-0 resolution #3: the brief's original test called
+    ``select_replay_corpus``, but that requires action+watch coverage
+    (``_covers_kinds``), and a single seeded ``action`` item can't satisfy
+    that gate — the call would just raise ``CorpusUnavailable`` without
+    ever exercising the auto_emit filter. ``_bundle_items_for_profile`` is
+    the function that actually applies ``_non_autoemit`` with no coverage
+    gate, so it is the correct unit to exercise here.
+    """
+    human_report = InvestmentReport(**_report_payload())
+    db_session.add(human_report)
+    await db_session.flush()
+    human_item = InvestmentReportItem(**_item_payload(human_report.id))
+    db_session.add(human_item)
+
+    autoemit_report = InvestmentReport(**_report_payload())
+    db_session.add(autoemit_report)
+    await db_session.flush()
+    autoemit_item = InvestmentReportItem(
+        **_item_payload(
+            autoemit_report.id,
+            evidence_snapshot={
+                "source": "auto_emit",
+                "proposer": "auto_emit/buy_from_candidate",
+            },
+        )
+    )
+    db_session.add(autoemit_item)
+    await db_session.commit()
+    await db_session.refresh(human_item)
+
+    items = await _bundle_items_for_profile(db_session, "CLAUDE_ADVISOR", limit=10)
+
+    uuids = {i.item_uuid for i in items}
+    assert str(human_item.item_uuid) in uuids
+    assert all(
+        i.reference_decision.get("proposer") != "auto_emit/buy_from_candidate"
+        for i in items
+    )
+
+
+@pytest.mark.unit
+def test_non_autoemit_predicate():
+    class _I:
+        evidence_snapshot = {"source": "auto_emit"}
+
+    assert _non_autoemit(_I()) is False
+
+
+@pytest.mark.unit
+def test_non_autoemit_predicate_proposer_prefix():
+    class _I:
+        evidence_snapshot = {"proposer": "auto_emit/sell_from_held"}
+
+    assert _non_autoemit(_I()) is False
+
+
+@pytest.mark.unit
+def test_non_autoemit_predicate_human_item_passes():
+    class _I:
+        evidence_snapshot = {}
+
+    assert _non_autoemit(_I()) is True
+
+
+def _corpus_item(item_kind: str) -> CorpusItem:
+    return CorpusItem(
+        snapshot_bundle_uuid=str(uuid.uuid4()),
+        report_id=1,
+        item_uuid=str(uuid.uuid4()),
+        item_kind=item_kind,
+        intent="buy_review",
+        reference_decision={},
+    )
+
+
+@pytest.mark.unit
+def test_covers_kinds_action_and_watch_present():
+    items = [_corpus_item("action"), _corpus_item("watch")]
+    assert _covers_kinds(items, min_per_kind=1) is True
+
+
+@pytest.mark.unit
+def test_covers_kinds_action_only_is_false():
+    items = [_corpus_item("action"), _corpus_item("action")]
+    assert _covers_kinds(items, min_per_kind=1) is False

--- a/tests/services/shadow_replay/test_scoring.py
+++ b/tests/services/shadow_replay/test_scoring.py
@@ -1,0 +1,69 @@
+from decimal import Decimal
+
+import pytest
+
+from app.services.shadow_replay.scoring import agree, extract_decision, summarize
+
+
+@pytest.mark.unit
+def test_extract_reads_trade_setup_stringified_decimals():
+    item = {
+        "side": "buy",
+        "max_action": {"notional": "300000", "limit_price": "129600"},
+        "evidence_snapshot": {
+            "trade_setup": {
+                "stop": "125000",
+                "target": "150000",
+                "headline": {"entry": "129600"},
+            }
+        },
+        "trigger_checklist": ["support_129600_hold", "rsi_below_45"],
+    }
+    d = extract_decision(item)
+    assert d["side"] == "buy"
+    assert d["notional"] == Decimal("300000")
+    assert d["limit_price"] == Decimal("129600")
+    assert d["entry"] == Decimal("129600")
+    assert d["stop"] == Decimal("125000")
+    assert d["triggers"] == frozenset({"support_129600_hold", "rsi_below_45"})
+
+
+@pytest.mark.unit
+def test_extract_no_action_when_no_side():
+    d = extract_decision(
+        {
+            "side": None,
+            "max_action": {},
+            "evidence_snapshot": {},
+            "trigger_checklist": [],
+        }
+    )
+    assert d["side"] is None
+
+
+@pytest.mark.unit
+def test_agree_limit_tolerance_and_side():
+    a = {
+        "side": "buy",
+        "notional": Decimal("300000"),
+        "limit_price": Decimal("129600"),
+        "triggers": frozenset({"x"}),
+    }
+    b = {
+        "side": "buy",
+        "notional": Decimal("320000"),
+        "limit_price": Decimal("129700"),
+        "triggers": frozenset({"x"}),
+    }
+    r = agree(a, b, tick=Decimal("100"))
+    assert r["side"] and r["size_band"] and r["limit"] and r["same_decision"]
+
+
+@pytest.mark.unit
+def test_summarize_exposes_no_action_rate():
+    hold = {"side": None, "triggers": frozenset()}
+    s = summarize([hold, hold], reference=None, tick=Decimal("100"))
+    assert s["no_action_rate"] == 1.0
+    assert (
+        s["self_same_decision_rate"] == 1.0
+    )  # degenerate agreement is VISIBLE via no_action_rate

--- a/tests/test_mcp_fundamentals_tools.py
+++ b/tests/test_mcp_fundamentals_tools.py
@@ -2083,7 +2083,12 @@ class TestGetFxRateHandler:
 class TestGetFxRateToolRegistration:
     """Tests for get_fx_rate MCP registration."""
 
-    @pytest.mark.parametrize("profile", list(McpProfile))
+    # ROB-697 M1 — shadow-replay early-returns before the "Always" block that
+    # registers get_fx_rate (fundamentals tools), so it is deliberately
+    # excluded here; see tests/mcp_server/test_shadow_replay_profile.py.
+    @pytest.mark.parametrize(
+        "profile", [p for p in McpProfile if p is not McpProfile.SHADOW_REPLAY]
+    )
     def test_get_fx_rate_registered_on_all_profiles(self, profile: McpProfile):
         tools = _build_tools(profile=profile)
 

--- a/tests/test_mcp_profiles.py
+++ b/tests/test_mcp_profiles.py
@@ -235,6 +235,9 @@ _ORDER_SURFACE_MATRIX: dict[McpProfile, set[str]] = {
     McpProfile.US_PAPER: set(_ALPACA_MUTATING),
     McpProfile.DB_PAPER: set(),
     McpProfile.KIWOOM: set(KIWOOM_MOCK_TOOL_NAMES),
+    # ROB-697 M1 — shadow-replay registers zero order/mutation tools by design
+    # (frozen-context read + policy + route_request only, early-return).
+    McpProfile.SHADOW_REPLAY: set(),
 }
 _ALL_ORDER_TOOL_NAMES = (
     _LEGACY_ORDER_TOOL_NAMES
@@ -266,15 +269,28 @@ class TestOrderSurfaceMatrix:
         )
 
 
+# ROB-697 M1 — shadow-replay is a deliberate exception to the "every profile
+# has the full read-only research surface" invariant below: it early-returns
+# before the "Always" research-registration block, so it carries NO live-fetch
+# tool (crypto research included). ``TestShadowReplayIsResearchSurfaceException``
+# pins that omission explicitly.
+_PROFILES_WITH_RESEARCH_SURFACE = [
+    p for p in McpProfile if p is not McpProfile.SHADOW_REPLAY
+]
+
+
 class TestCryptoResearchToolsAllProfiles:
-    """ROB-503: crypto read-only research tools register on EVERY profile.
+    """ROB-503: crypto read-only research tools register on EVERY profile
+    that reaches the "Always" research block.
 
     ROB-488 had gated them to MCP_PROFILE=crypto, which broke single-server
     operation (crypto live trading runs on the DEFAULT server). Read-only
-    tools carry no order-surface risk, so profile isolation buys nothing.
+    tools carry no order-surface risk, so profile isolation buys nothing —
+    except for shadow-replay (ROB-697), whose validity guard is that it
+    carries NO live-fetch tool at all; see _PROFILES_WITH_RESEARCH_SURFACE.
     """
 
-    @pytest.mark.parametrize("profile", list(McpProfile))
+    @pytest.mark.parametrize("profile", _PROFILES_WITH_RESEARCH_SURFACE)
     def test_crypto_research_tools_registered(self, profile: McpProfile) -> None:
         mcp = _build_mcp(profile)
         missing = _CRYPTO_RESEARCH_TOOL_NAMES - mcp.tools.keys()
@@ -285,6 +301,16 @@ class TestCryptoResearchToolsAllProfiles:
         mcp = _build_mcp(profile)
         leaked = _REMOVED_GENERIC_TOOL_NAMES & mcp.tools.keys()
         assert not leaked, f"profile={profile.value} leaked old names: {sorted(leaked)}"
+
+
+class TestShadowReplayIsResearchSurfaceException:
+    """ROB-697 M1 — pin that shadow-replay is the ONE profile without the
+    default research surface (the load-bearing validity guard: a headless
+    replay must not be able to reach live market data)."""
+
+    def test_shadow_replay_has_no_crypto_research_tools(self) -> None:
+        mcp = _build_mcp(McpProfile.SHADOW_REPLAY)
+        assert _CRYPTO_RESEARCH_TOOL_NAMES.isdisjoint(mcp.tools.keys())
 
 
 class TestResolveMcpProfile:
@@ -314,6 +340,9 @@ class TestResolveMcpProfile:
 
     def test_kiwoom(self) -> None:
         assert resolve_mcp_profile("kiwoom") is McpProfile.KIWOOM
+
+    def test_shadow_replay(self) -> None:
+        assert resolve_mcp_profile("shadow-replay") is McpProfile.SHADOW_REPLAY
 
     def test_invalid_string_raises_value_error(self) -> None:
         with pytest.raises(ValueError, match="Unknown MCP_PROFILE"):

--- a/tests/test_shadow_replay_cli.py
+++ b/tests/test_shadow_replay_cli.py
@@ -219,3 +219,130 @@ def test_write_report_handles_empty_results(tmp_path):
 
     assert "n/a" in text
     assert "Items:** 0" in text
+
+
+# --- all_samples_discarded (ROB-697 M1 follow-up: the all-discarded signal) ---
+#
+# If the `claude --output-format json` envelope assumption is wrong,
+# `_one_run` returns `None` for EVERY call and `run_batch` produces a
+# normal-looking `discarded == k` row for every item. `all_samples_discarded`
+# is the pure predicate `_amain` uses to turn that silent-looking success
+# into a loud, non-zero exit (see the `_amain` tests below).
+
+
+@pytest.mark.unit
+def test_all_samples_discarded_true_when_every_attempted_sample_discarded():
+    results = [
+        {"discarded": 3, "summary": {"k": 0}},
+        {"discarded": 2, "summary": {"k": 0}},
+    ]
+
+    assert sr.all_samples_discarded(results) is True
+
+
+@pytest.mark.unit
+def test_all_samples_discarded_false_when_some_samples_scored():
+    results = [
+        {"discarded": 1, "summary": {"k": 2}},  # some scored here
+        {"discarded": 3, "summary": {"k": 0}},  # fully discarded here
+    ]
+
+    assert sr.all_samples_discarded(results) is False
+
+
+@pytest.mark.unit
+def test_all_samples_discarded_false_when_no_samples_attempted():
+    assert sr.all_samples_discarded([]) is False
+
+
+# --- _amain: --confirm gate + the all-discarded exit-3 signal ---
+#
+# `_amain` opens a DB session (`AsyncSessionLocal`) and calls
+# `select_replay_corpus` unconditionally (even in the dry-plan branch), so
+# both must be monkeypatched — no real DB, no real subprocess. `_amain`
+# imports both names via a DEFERRED `from ... import ...` specifically so a
+# unit test can monkeypatch the source module attribute before calling it
+# (see the "Deferred import" comment in `_amain`).
+
+
+class _FakeAsyncSession:
+    async def __aenter__(self) -> _FakeAsyncSession:
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> bool:
+        return False
+
+
+def _fake_session_local() -> _FakeAsyncSession:
+    return _FakeAsyncSession()
+
+
+def _fake_corpus() -> CorpusSelection:
+    ref = {
+        "side": "buy",
+        "max_action": {"notional": "300000", "limit_price": "129600"},
+        "evidence_snapshot": {"trade_setup": {"headline": {"entry": "129600"}}},
+        "trigger_checklist": ["x"],
+    }
+    item = CorpusItem("u1", 1, "i1", "action", "buy_review", extract_decision(ref))
+    return CorpusSelection("claude_bundle", [item])
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_amain_without_confirm_never_calls_run_batch(monkeypatch):
+    monkeypatch.setattr("app.core.db.AsyncSessionLocal", _fake_session_local)
+
+    async def _fake_select(session, *, min_per_kind):  # noqa: ARG001
+        return _fake_corpus()
+
+    monkeypatch.setattr(
+        "app.services.shadow_replay.corpus.select_replay_corpus", _fake_select
+    )
+
+    def _boom(*args, **kwargs):
+        raise AssertionError("run_batch must not be called without --confirm")
+
+    monkeypatch.setattr(sr, "run_batch", _boom)
+
+    args = sr.build_parser().parse_args([])  # confirm defaults to False
+
+    assert await sr._amain(args) == 0
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_amain_with_confirm_returns_3_when_all_samples_discarded(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setattr("app.core.db.AsyncSessionLocal", _fake_session_local)
+
+    async def _fake_select(session, *, min_per_kind):  # noqa: ARG001
+        return _fake_corpus()
+
+    monkeypatch.setattr(
+        "app.services.shadow_replay.corpus.select_replay_corpus", _fake_select
+    )
+
+    all_discarded_results = [
+        {
+            "item_uuid": "i1",
+            "item_kind": "action",
+            "source": "claude_bundle",
+            "model": "claude-opus-4-8",
+            "discarded": 3,
+            "summary": {
+                "k": 0,
+                "no_action_rate": 0.0,
+                "self_same_decision_rate": 0.0,
+                "fidelity": None,
+            },
+        }
+    ]
+    monkeypatch.setattr(sr, "run_batch", lambda *a, **kw: all_discarded_results)  # noqa: ARG005
+
+    args = sr.build_parser().parse_args(
+        ["--confirm", "--report", str(tmp_path / "report.md")]
+    )
+
+    assert await sr._amain(args) == 3

--- a/tests/test_shadow_replay_cli.py
+++ b/tests/test_shadow_replay_cli.py
@@ -1,0 +1,221 @@
+# tests/test_shadow_replay_cli.py
+"""Unit tests for the shadow-replay headless `claude -p` driver (ROB-697, M1).
+
+No real `claude -p` subprocess and no DB in these tests: `_one_run` is always
+monkeypatched (per resolution #5 — the exact `claude -p --output-format
+json` envelope is only verified at operator run-time, see
+docs/runbooks/shadow-replay.md).
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from app.services.shadow_replay.corpus import CorpusItem, CorpusSelection
+from app.services.shadow_replay.scoring import extract_decision
+from scripts import shadow_replay as sr
+
+
+@pytest.mark.unit
+def test_to_item_shape_maps_top_level_trade_setup_into_evidence_snapshot():
+    raw = {
+        "side": "buy",
+        "max_action": {"notional": "300000", "limit_price": "129600"},
+        "trade_setup": {
+            "stop": "125000",
+            "target": "135000",
+            "headline": {"entry": "129600"},
+        },
+        "trigger_checklist": ["x"],
+    }
+
+    shaped = sr._to_item_shape(raw)
+
+    assert shaped == {
+        "side": "buy",
+        "max_action": {"notional": "300000", "limit_price": "129600"},
+        "evidence_snapshot": {
+            "trade_setup": {
+                "stop": "125000",
+                "target": "135000",
+                "headline": {"entry": "129600"},
+            }
+        },
+        "trigger_checklist": ["x"],
+    }
+
+
+@pytest.mark.unit
+def test_to_item_shape_defaults_missing_fields_to_empty():
+    assert sr._to_item_shape({}) == {
+        "side": None,
+        "max_action": {},
+        "evidence_snapshot": {"trade_setup": {}},
+        "trigger_checklist": [],
+    }
+
+
+@pytest.mark.unit
+def test_to_item_shape_roundtrip_recovers_entry_via_extract_decision():
+    """The shape-adapter bug fix: `_PROMPT` instructs the replayed agent to
+    emit `trade_setup` at the TOP level, but `extract_decision` reads the
+    NESTED `evidence_snapshot.trade_setup`. Calling `extract_decision(raw)`
+    directly on a raw claude reply silently drops entry/stop/target because
+    `ev.get("trade_setup")` reads an empty `{}`. `_to_item_shape` must fix
+    this: after adapting, `entry` (and stop/target) must round-trip.
+    """
+    raw = {
+        "side": "buy",
+        "max_action": {"notional": "300000", "limit_price": "129600"},
+        "trade_setup": {
+            "stop": "125000",
+            "target": "135000",
+            "headline": {"entry": "129600"},
+        },
+        "trigger_checklist": ["earnings_beat"],
+    }
+
+    # Prove the bug: calling extract_decision directly on the raw reply
+    # (no adapter) drops entry/stop/target — they read off an empty dict.
+    unfixed = extract_decision(raw)
+    assert unfixed["entry"] is None
+    assert unfixed["stop"] is None
+
+    # The fix: adapt first, then score.
+    fixed = extract_decision(sr._to_item_shape(raw))
+    assert fixed["entry"] == Decimal("129600")
+    assert fixed["stop"] == Decimal("125000")
+    assert fixed["target"] == Decimal("135000")
+    assert fixed["side"] == "buy"
+    assert fixed["limit_price"] == Decimal("129600")
+
+
+@pytest.mark.unit
+def test_run_batch_counts_discards_and_summarizes(monkeypatch):
+    ref = {
+        "side": "buy",
+        "max_action": {"notional": "300000", "limit_price": "129600"},
+        "evidence_snapshot": {"trade_setup": {"headline": {"entry": "129600"}}},
+        "trigger_checklist": ["x"],
+    }
+    item = CorpusItem("u1", 1, "i1", "action", "buy_review", extract_decision(ref))
+    corpus = CorpusSelection("claude_bundle", [item])
+
+    # The replayed agent emits the TOP-LEVEL `trade_setup` shape (per
+    # `_PROMPT`), not the nested `evidence_snapshot.trade_setup` shape used
+    # for `reference_decision` above — `run_batch` must route each raw reply
+    # through `_to_item_shape` before scoring.
+    raw_reply = {
+        "side": "buy",
+        "max_action": {"notional": "300000", "limit_price": "129600"},
+        "trade_setup": {"headline": {"entry": "129600"}},
+        "trigger_checklist": ["x"],
+    }
+    seq = iter([raw_reply, None, raw_reply])  # one MCP-reset discard in the middle
+    monkeypatch.setattr(sr, "_one_run", lambda uuid, model: next(seq))  # noqa: ARG005
+
+    out = sr.run_batch(corpus, k=3, model="claude-opus-4-8", tick=Decimal("100"))
+
+    assert len(out) == 1
+    assert out[0]["item_uuid"] == "i1"
+    assert out[0]["source"] == "claude_bundle"
+    assert out[0]["model"] == "claude-opus-4-8"
+    assert out[0]["discarded"] == 1
+    assert out[0]["summary"]["k"] == 2  # 3 calls - 1 discard
+    assert out[0]["summary"]["fidelity"]["side_rate"] == 1.0
+    assert out[0]["summary"]["fidelity"]["same_decision_rate"] == 1.0
+    assert out[0]["summary"]["no_action_rate"] == 0.0
+
+
+@pytest.mark.unit
+def test_run_batch_never_calls_real_one_run_without_monkeypatch(monkeypatch):
+    """Defense-in-depth: if `_one_run` is monkeypatched to fail loudly on any
+    call, `run_batch` over an EMPTY corpus must never invoke it at all."""
+
+    def _boom(uuid, model):  # noqa: ARG001
+        raise AssertionError("must not be called for an empty corpus")
+
+    monkeypatch.setattr(sr, "_one_run", _boom)
+    corpus = CorpusSelection("claude_bundle", [])
+
+    out = sr.run_batch(corpus, k=3, model="claude-opus-4-8", tick=Decimal("100"))
+
+    assert out == []
+
+
+@pytest.mark.unit
+def test_parser_defaults_are_confirm_false_k5_pinned_model():
+    args = sr.build_parser().parse_args([])
+
+    assert args.k == 5
+    assert args.confirm is False
+    assert args.model == "claude-opus-4-8"
+    assert "latest" not in args.model  # must be an exact pinned id
+
+
+@pytest.mark.unit
+def test_parser_accepts_explicit_k():
+    args = sr.build_parser().parse_args(["--k", "5"])
+
+    assert args.k == 5
+    assert args.model  # model has a pinned default
+
+
+@pytest.mark.unit
+def test_write_report_produces_markdown_table(tmp_path):
+    results = [
+        {
+            "item_uuid": "i1",
+            "item_kind": "action",
+            "source": "claude_bundle",
+            "model": "claude-opus-4-8",
+            "discarded": 1,
+            "summary": {
+                "k": 2,
+                "no_action_rate": 0.0,
+                "self_same_decision_rate": 1.0,
+                "fidelity": {
+                    "side_rate": 1.0,
+                    "size_band_rate": 1.0,
+                    "limit_rate": 1.0,
+                    "same_decision_rate": 1.0,
+                },
+            },
+        },
+        {
+            "item_uuid": "i2",
+            "item_kind": "watch",
+            "source": "claude_bundle",
+            "model": "claude-opus-4-8",
+            "discarded": 0,
+            "summary": {
+                "k": 0,
+                "no_action_rate": 0.0,
+                "self_same_decision_rate": 0.0,
+                "fidelity": None,
+            },
+        },
+    ]
+    path = tmp_path / "report.md"
+
+    text = sr.write_report(results, path)
+
+    assert text  # non-empty
+    assert path.read_text() == text
+    assert "claude_bundle" in text
+    assert "claude-opus-4-8" in text
+    assert "i1" in text and "i2" in text
+    assert "1.000" in text  # side_rate / size_band_rate / etc. for i1
+    assert "n/a" in text  # i2 has no reference decision -> fidelity is None
+
+
+@pytest.mark.unit
+def test_write_report_handles_empty_results(tmp_path):
+    path = tmp_path / "empty.md"
+
+    text = sr.write_report([], path)
+
+    assert "n/a" in text
+    assert "Items:** 0" in text

--- a/tests/test_shadow_replay_probe_cli.py
+++ b/tests/test_shadow_replay_probe_cli.py
@@ -1,0 +1,83 @@
+# tests/test_shadow_replay_probe_cli.py
+"""Unit tests for the shadow-replay P1 reproducibility probe (ROB-697).
+
+`compare_frozen` is the pure diff logic extracted from the probe script so
+it can be exercised without a DB / MCP tool call. The async `probe()`
+wrapper (real two-call round trip against `investment_report_get_hermes_
+context_impl`) is intentionally NOT exercised here — it requires a live DB,
+a real bundle, and SNAPSHOT_BACKED_REPORT_GENERATOR_ENABLED=true, which is
+an operator step (see docs/runbooks/shadow-replay.md).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from scripts import shadow_replay_probe as probe
+
+
+@pytest.mark.unit
+def test_frozen_identical_true_when_only_live_section_ignored_key_differs():
+    a = {
+        "stage_inputs": [{"stage_type": "x"}],
+        "cited_snapshots": [{"snapshot_uuid": "u1"}],
+        "policy_version": "intraday_action_report_v1",
+        "market": "kr",
+        "market_session": "regular",
+        "coverage_summary": {"buy": 1},
+        "dimension_evidence": {"a": 1},
+    }
+    b = {
+        **a,
+        "dimension_evidence": {"a": 1},
+        # Non-frozen key differs (e.g. a verbatim-timestamp-free but
+        # otherwise irrelevant field); frozen keys are identical.
+        "some_other_field": "differs-across-calls",
+    }
+
+    result = probe.compare_frozen(a, b)
+
+    assert result == {"frozen_identical": True, "live_section_drift": []}
+
+
+@pytest.mark.unit
+def test_frozen_identical_false_when_stage_inputs_differ():
+    a = {
+        "stage_inputs": [{"stage_type": "x"}],
+        "cited_snapshots": [{"snapshot_uuid": "u1"}],
+        "policy_version": "intraday_action_report_v1",
+        "market": "kr",
+        "market_session": "regular",
+        "coverage_summary": {"buy": 1},
+    }
+    b = {
+        **a,
+        "stage_inputs": [{"stage_type": "y"}],
+    }
+
+    result = probe.compare_frozen(a, b)
+
+    assert result["frozen_identical"] is False
+
+
+@pytest.mark.unit
+def test_drift_lists_dimension_evidence_when_it_differs():
+    a = {
+        "stage_inputs": [{"stage_type": "x"}],
+        "cited_snapshots": [{"snapshot_uuid": "u1"}],
+        "policy_version": "intraday_action_report_v1",
+        "market": "kr",
+        "market_session": "regular",
+        "coverage_summary": {"buy": 1},
+        "dimension_evidence": {"a": 1},
+        "dimension_reports": [{"r": 1}],
+    }
+    b = {
+        **a,
+        "dimension_evidence": {"a": 2},
+    }
+
+    result = probe.compare_frozen(a, b)
+
+    assert result["frozen_identical"] is True
+    assert result["live_section_drift"] == ["dimension_evidence"]


### PR DESCRIPTION
## What

ROB-697 M1: a **read-only** harness that replays a frozen decision context (`investment_report_get_hermes_context`) to a headless `claude -p` K times and scores **self-consistency + ground-truth fidelity**. First milestone of automating the discretionary buy/sell routine via headless Claude, validated safely before any live/mock execution.

## Why

ROB-644's core problem: *"같은 프롬프트여도 방향/결과가 매번 다름."* M1 measures whether a fresh headless session reproduces a disciplined decision from **identical frozen evidence** — the prerequisite before automating anything. Success = a number like *"headless reproduces my decision side X% / size-band Y% / limit-within-tol Z%, no-action W%"*.

## Changes (8 commits · read-only · migration 0)

- **scorer** `app/services/shadow_replay/scoring.py` — pure `extract_decision` / `agree` / `summarize` (side exact, size-band bucketed, limit tick/ATR tolerance, watch-trigger Jaccard, **no-action rate reported separately** so degenerate all-HOLD agreement is visible).
- **corpus** `app/services/shadow_replay/corpus.py` — read-only selection of **bundle-backed, non-`auto_emit`** decisions. Census-gated source: `claude_bundle` → `hermes_bundle` (= cross-LLM consistency, ROB-644's goal) → `operator_audit`.
- **shadow-replay MCP profile** — new `McpProfile.SHADOW_REPLAY` exposing **only** `investment_report_get_hermes_context` + `get_trading_policy` + `route_request`; every live-fetch / mutation tool is **structurally omitted** (early-return in `register_all_tools` + set-equality guard). This is the live-data-leakage validity guard — without it the replay would absorb live-market noise.
- **P1 probe** `scripts/shadow_replay_probe.py` — frozen-section reproducibility check (frozen `stage_inputs`/`cited_snapshots` byte-identical; live `dimension_evidence` drift reported separately).
- **driver** `scripts/shadow_replay.py` + `scripts/shadow_replay_mcp.json` — headless `claude -p` K-runner (stdio profile), JSON output contract, MCP-reset sample discard, `--confirm` gate, markdown report. **Exit 3 + loud stderr warning if all samples discarded** (harness-suspect — prevents a silent false-success on the expensive real run).
- **runbook** `docs/runbooks/shadow-replay.md`.

## Safety / boundary

- **ROB-501:** driver + probe live in `scripts/` (subprocess to the `claude` binary, no LLM SDK import); scorer + corpus are pure/read-only `app/services`. No in-process LLM anywhere in `app/**` (static guard passes).
- **Read-only:** no orders, no report persistence, no migration, no broker/watch/order-intent mutation.

## Tests

**85 passed** (unit + the DB-backed corpus integration test); `ruff check` + `ruff format --check` + `ty check app/` clean; ROB-501 static import guard passes. Each task passed an adversarial per-task review (spec + quality); a whole-branch Opus review returned **Ready to merge** — 0 Critical/Important, 4 Minors triaged safe-to-defer.

## Operator follow-up (not code — documented in the runbook)

1. **P0 census** SELECT to decide the corpus source. Note: `investment_report_create` never sets a bundle, so `CLAUDE_ADVISOR + bundle` may be sparse → falls back to Hermes-composed (cross-LLM consistency) or the `investment_report_item_decisions` operator-audit.
2. **P1 real probe** against a real `snapshot_bundle_uuid`.
3. **Step-6 real `claude -p` batch** → the M1 deliverable number. Verify the `claude --output-format json` envelope at the first run (exit 3 fences a silent all-discard).

## Out of scope (roadmap — see design doc)

- **M2** = Upbit shadow-sim live mock loop (crypto; live Upbit data → virtual fills; `binance_demo` dropped = different exchange/currency).
- **M3** = `kis_mock` (KR) port.

Refs ROB-697 (parent ROB-644). Design doc: `~/.gstack/projects/mgh3326-auto_trader/mgh3326-main-design-20260704-101229.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0156muWEFi5wBRLSiwNWLpQz


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new shadow replay mode for read-only sessions.
  * Introduced a replay corpus selector, decision scoring, and a headless CLI to run and report replay batches.
  * Added a reproducibility probe to compare frozen context data across runs.

* **Bug Fixes**
  * Tightened tool availability for the new replay mode so only approved read-only actions are exposed.
  * Improved handling of discarded or invalid replay samples, including clearer failure signaling.

* **Documentation**
  * Added an operator runbook and implementation plan for the shadow replay workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->