### PR TITLE
deploy: ROB-700 (KIS token breaker) + ROB-701 (Toss sellable cache) → production

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -247,6 +247,14 @@ class Settings(BaseSettings):
     toss_api_base_url: str | None = None
     toss_live_order_mutations_enabled: bool = False
 
+    # ROB-701: process-global short-TTL cache for the per-symbol Toss
+    # sellable-quantity fanout on /invest home & account-panel. Collapses
+    # repeated loads to 0 ORDER_INFO (6 TPS) calls within the TTL; a fill
+    # naturally refreshes after ≤ttl (ROB-549 tolerates brief staleness).
+    # enabled=False => cache always misses => today's fanout-every-load.
+    toss_sellable_cache_enabled: bool = True
+    toss_sellable_cache_ttl_seconds: float = 45.0
+
     # ROB-576 — Toss fill notifications are inert until explicitly enabled by
     # the operator. Toss auto-reconcile gates live with the task flags below.
     toss_fill_notify_enabled: bool = False

--- a/app/services/brokers/kis/base.py
+++ b/app/services/brokers/kis/base.py
@@ -266,27 +266,50 @@ class BaseKISClient:
     async def _fetch_token(self) -> tuple[str, int]:
         """Fetch new OAuth2 token from KIS API.
 
+        ROB-700: the token POST is guarded by the SAME per-process circuit
+        breaker as the data dispatch (ROB-699). During a KIS maintenance window
+        the token fetch connect-times-out FIRST (before any data call), so
+        guarding it here is what lets the breaker open at all. After N
+        consecutive token connect-failures ``before_request`` fail-fasts with
+        ``KISCircuitOpen`` (zero HTTP, zero wait) and every KIS reader hits its
+        Toss fallback / warning immediately. A 401 / invalid-key / non-JSON
+        body means KIS RESPONDED (reachable) and must NOT trip the breaker.
+
+        The breaker check is per-attempt, inside this call, before the network
+        POST — the token single-flight (``refresh_token_with_lock``) and the
+        cached-token fast path in ``_ensure_token`` are unchanged.
+
         Returns:
             Tuple of (access_token, expires_in_seconds)
 
         Raises:
-            httpx.HTTPStatusError: On HTTP errors
-            KeyError: If response doesn't contain access_token
+            KISCircuitOpen: When the breaker is open (fail-fast, no HTTP).
+            httpx.HTTPStatusError / httpx.RequestError: On HTTP/transport errors.
+            KeyError: If response doesn't contain access_token.
         """
-        cli = await self._ensure_client(timeout=5.0)
-        r = await cli.post(
-            self._kis_url("/oauth2/token"),
-            data={
-                "grant_type": "client_credentials",
-                "appkey": self._settings.kis_app_key,
-                "appsecret": self._settings.kis_app_secret,
-            },
-            timeout=5,
-        )
-        response = r.json()
-        access_token = response["access_token"]
-        expires_in = response.get("expires_in", 3600)
-
+        breaker = get_kis_circuit_breaker()
+        breaker.before_request()  # OUTSIDE the classify try/except (ROB-699 invariant)
+        try:
+            cli = await self._ensure_client(timeout=5.0)
+            r = await cli.post(
+                self._kis_url("/oauth2/token"),
+                data={
+                    "grant_type": "client_credentials",
+                    "appkey": self._settings.kis_app_key,
+                    "appsecret": self._settings.kis_app_secret,
+                },
+                timeout=5,
+            )
+            response = r.json()
+            access_token = response["access_token"]
+            expires_in = response.get("expires_in", 3600)
+        except BaseException as exc:  # noqa: BLE001 — classify then re-raise unchanged
+            if is_kis_connect_failure(exc):
+                breaker.record_failure()  # connect/read outage -> trips after N
+            else:
+                breaker.record_reachable_error()  # KIS responded (401/KeyError/JSON) — no trip
+            raise
+        breaker.record_success()
         logging.info("KIS 새 토큰 발급 완료")
         return access_token, expires_in
 

--- a/app/services/invest_home_readers.py
+++ b/app/services/invest_home_readers.py
@@ -37,6 +37,7 @@ from app.services.invest_home_service import _SourceFetchResult
 from app.services.invest_quote_service import InvestQuoteService
 from app.services.manual_holdings_service import ManualHoldingsService
 from app.services.toss_portfolio_service import fetch_toss_portfolio_snapshot
+from app.services.toss_sellable_cache import get_shared_sellable_cache
 from app.services.upbit_symbol_universe_service import (
     get_active_upbit_markets,
     get_upbit_warning_markets,
@@ -552,7 +553,10 @@ class TossApiHomeReader:
                 name="invest.home.toss_api.snapshot",
             ) as span:
                 snapshot = await fetch_toss_portfolio_snapshot(
-                    need_sellable=mutations_enabled
+                    need_sellable=mutations_enabled,
+                    sellable_cache=(
+                        get_shared_sellable_cache() if mutations_enabled else None
+                    ),
                 )
                 span.set_data("position_count", len(snapshot.positions))
                 span.set_data("error_count", len(snapshot.errors))

--- a/app/services/toss_portfolio_service.py
+++ b/app/services/toss_portfolio_service.py
@@ -8,6 +8,8 @@ from typing import Any, Protocol
 import sentry_sdk
 
 from app.services.brokers.toss.client import TossReadClient
+from app.services.brokers.toss.dto import TossSellableQuantity
+from app.services.toss_sellable_cache import TossSellableCache
 
 
 class TossPortfolioClient(Protocol):
@@ -131,6 +133,7 @@ async def fetch_toss_cash_snapshot(
 async def fetch_toss_portfolio_snapshot(
     *,
     need_sellable: bool = True,
+    sellable_cache: TossSellableCache | None = None,
     client: TossPortfolioClient | None = None,
 ) -> TossPortfolioSnapshot:
     created_client = client is None
@@ -146,7 +149,51 @@ async def fetch_toss_portfolio_snapshot(
 
         errors: list[dict[str, Any]] = []
 
-        if need_sellable:
+        if need_sellable and sellable_cache is not None:
+            # ROB-701: only cache-MISS symbols hit the ORDER_INFO (6 TPS)
+            # /sellable-quantity endpoint; hits reuse the cached value. Re-wrap
+            # hits as TossSellableQuantity so the position-build loop below is
+            # unchanged.
+            hits: list[Decimal | None] = [
+                sellable_cache.get(item.symbol) for item in holdings.items
+            ]
+            miss_indices = [i for i, hit in enumerate(hits) if hit is None]
+            with sentry_sdk.start_span(
+                op="invest.home.toss_api.phase",
+                name="invest.home.toss_api.sellable_quantity",
+            ) as span:
+                span.set_data("position_count", len(holdings.items))
+                span.set_data("cache_miss_count", len(miss_indices))
+                fetched = await asyncio.gather(
+                    *[
+                        active_client.sellable_quantity(symbol=holdings.items[i].symbol)
+                        for i in miss_indices
+                    ],
+                    return_exceptions=True,
+                )
+                span.set_data(
+                    "error_count",
+                    sum(1 for result in fetched if isinstance(result, BaseException)),
+                )
+            fetched_by_index: dict[int, Any] = dict(
+                zip(miss_indices, fetched, strict=True)
+            )
+            for index, result in fetched_by_index.items():
+                if not isinstance(result, BaseException):
+                    # Cache ONLY successful fetches — a transient error must not
+                    # poison the cache (next load retries).
+                    sellable_cache.put(
+                        holdings.items[index].symbol, result.sellable_quantity
+                    )
+            paired: list[tuple[Any, Any]] = []
+            for index, item in enumerate(holdings.items):
+                if index in fetched_by_index:
+                    paired.append((item, fetched_by_index[index]))
+                else:
+                    paired.append(
+                        (item, TossSellableQuantity(sellable_quantity=hits[index]))
+                    )
+        elif need_sellable:
             with sentry_sdk.start_span(
                 op="invest.home.toss_api.phase",
                 name="invest.home.toss_api.sellable_quantity",
@@ -167,9 +214,7 @@ async def fetch_toss_portfolio_snapshot(
                         if isinstance(result, BaseException)
                     ),
                 )
-            paired: list[tuple[Any, Any]] = list(
-                zip(holdings.items, sellable_results, strict=True)
-            )
+            paired = list(zip(holdings.items, sellable_results, strict=True))
         else:
             # ROB-685: caller does not consume sellable_quantity — skip the
             # per-holding GET /sellable-quantity (ORDER_INFO, 6 TPS) fanout that

--- a/app/services/toss_sellable_cache.py
+++ b/app/services/toss_sellable_cache.py
@@ -1,0 +1,76 @@
+"""ROB-701 — process-global short-TTL cache for the Toss per-symbol
+sellable-quantity fanout on /invest home & account-panel.
+
+The Toss ``GET /api/v1/sellable-quantity`` endpoint is in the ORDER_INFO
+rate-limit group (6 TPS / 3 TPS peak), so fanning it out per holding serializes
+to ~N/6 s. This cache collapses repeated /invest loads to 0 calls within the TTL;
+only the invest_home reader opts in (the MCP / sell-classification path stays
+uncached and fresh). enabled=False => always miss => today's fanout-every-load.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable
+from decimal import Decimal
+
+from app.core.config import settings
+
+
+class TossSellableCache:
+    def __init__(
+        self,
+        *,
+        ttl_seconds: float,
+        now: Callable[[], float] = time.monotonic,
+        enabled: bool = True,
+    ) -> None:
+        self._ttl = float(ttl_seconds)
+        self._now = now
+        self._enabled = enabled
+        # symbol -> (expires_at_monotonic, value)
+        self._entries: dict[str, tuple[float, Decimal]] = {}
+
+    def get(self, symbol: str) -> Decimal | None:
+        if not self._enabled:
+            return None
+        entry = self._entries.get(symbol)
+        if entry is None:
+            return None
+        expires_at, value = entry
+        if self._now() >= expires_at:
+            # Expired — evict so the map does not grow unbounded on churn.
+            self._entries.pop(symbol, None)
+            return None
+        return value
+
+    def put(self, symbol: str, value: Decimal) -> None:
+        if not self._enabled:
+            return
+        self._entries[symbol] = (self._now() + self._ttl, value)
+
+    def clear(self) -> None:
+        self._entries.clear()
+
+
+_shared_sellable_cache: TossSellableCache | None = None
+
+
+def get_shared_sellable_cache() -> TossSellableCache:
+    """Process-global cache shared by every /invest reader in the process, so a
+    warm entry from one surface (home) serves the next (account-panel)."""
+    global _shared_sellable_cache
+    if _shared_sellable_cache is None:
+        _shared_sellable_cache = TossSellableCache(
+            ttl_seconds=float(
+                getattr(settings, "toss_sellable_cache_ttl_seconds", 45.0)
+            ),
+            enabled=bool(getattr(settings, "toss_sellable_cache_enabled", True)),
+        )
+    return _shared_sellable_cache
+
+
+def reset_shared_sellable_cache() -> None:
+    """Test hook: drop the process-global cache so suites start clean."""
+    global _shared_sellable_cache
+    _shared_sellable_cache = None

--- a/docs/plans/ROB-700-kis-token-breaker-guard.md
+++ b/docs/plans/ROB-700-kis-token-breaker-guard.md
@@ -1,0 +1,556 @@
+# ROB-700 — Guard the KIS OAuth token fetch with the circuit breaker
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (- [ ]) syntax.
+
+**Goal:** Extend the ROB-699 per-process KIS circuit breaker to also guard the OAuth **token** fetch. ROB-699 wired the breaker into the data dispatch (`_request_with_rate_limit_with_headers`, `app/services/brokers/kis/base.py:431`), but LIVE measurement during the 2026-07-04 KIS maintenance proved it **never opens**: the only KIS HTTP calls made were `POST /oauth2/token` (half timing out at ~5s = the connect timeout), and ZERO data calls (`dailyprice`/`inquire-price`/`inquire-balance`). The reason is that `_fetch_token` (`base.py:266`) calls `cli.post("/oauth2/token")` (`base.py:277`) **directly on httpx**, bypassing the breaker-guarded dispatch. During maintenance the token fetch connect-times-out **first**, so no token is ever obtained, so no data call is ever attempted, so the breaker sees no failures and never opens (0 circuit-breaker log lines confirmed this). This change guards the token POST with the **same** singleton breaker: after N consecutive token connect-failures the breaker OPENS, and subsequent data calls fail-fast with `KISCircuitOpen` at the dispatch gate (~0ms), while open-breaker token fetches fail-fast at `_fetch_token`'s `before_request` — which **eliminates the 5s connect timeout** (the token fail-fast still runs *inside* the single-flight, so on an empty token cache it pays `refresh_token_with_lock`'s pre-lock cache double-checks — ~100ms from `2×asyncio.sleep(0.05)` + a few Redis round-trips — but **never** the 5s connect wait). Either way `/invest` KIS readers hit their existing Toss fallback / warning promptly instead of each burning the 5s connect timeout. KIS-healthy = pure passthrough; the cached-token fast path is byte-identical (no breaker involvement); migration-0.
+
+## Architecture
+
+### Current token-ensure / fetch flow (real refs)
+
+Every KIS read/order call ensures a token before dispatch. The market-data read path calls `await self._parent._ensure_token()` before each request (`app/services/brokers/kis/_base_market_data.py:113`); order and account paths do the same (`domestic_orders.py:117`, `overseas_orders.py:97`, `account.py:221`, …).
+
+- `_ensure_token()` (`base.py:293`):
+  1. `token = await self._token_manager.get_token()` (`base.py:299`) — the **cache-hit fast path**. On a hit it sets `self._settings.kis_access_token = token` and `return`s (`base.py:300`–`:303`) **without ever calling `_fetch_token`**. No breaker involvement today, and none after this change.
+  2. On a miss it defines `token_fetcher()` wrapping `self._fetch_token()` (`base.py:305`–`:307`) and hands it to `self._token_manager.refresh_token_with_lock(token_fetcher)` (`base.py:309`–`:311`).
+- `refresh_token_with_lock(...)` (`app/services/redis_token_manager.py:243`) is the ROB-262 single-flight: it re-checks the cache up to 3× **before** the lock (`redis_token_manager.py:254`–`:260`), acquires the Redis distributed lock (`:264`), re-checks the cache **again after** acquiring the lock (`:289`–`:292`), and only THEN calls `token_fetcher()` (`:296`) — i.e. `_fetch_token` runs **exactly once per single-flight**, past all cache double-checks, under the lock. The surrounding `try/finally` (`:286`–`:307`) only **releases the lock** in `finally` and has **no `except`**, so an exception raised by `token_fetcher()` propagates out unswallowed.
+- `_fetch_token()` (`base.py:266`–`:291`) — has **no try/except today**:
+  ```
+  cli = await self._ensure_client(timeout=5.0)          # base.py:276 (builds httpx client, no KIS network)
+  r = await cli.post(self._kis_url("/oauth2/token"), data={...}, timeout=5)  # base.py:277–:285 — DIRECT httpx POST, bypasses the breaker
+  response = r.json()                                    # base.py:286
+  access_token = response["access_token"]               # base.py:287 — KeyError if KIS returns an error body
+  expires_in = response.get("expires_in", 3600)         # base.py:288
+  return access_token, expires_in                       # base.py:291
+  ```
+
+The breaker singleton and its API already exist (ROB-699, `app/services/brokers/kis/circuit_breaker.py`) and `get_kis_circuit_breaker` + `is_kis_connect_failure` are **already imported** in `base.py` (`base.py:21`–`:24`). No new import is needed.
+
+**Consumer propagation (unchanged wiring):** a data read → `_request_with_token_retry` (`_base_market_data.py:113`) → `_ensure_token()` → (cache miss) `refresh_token_with_lock` → `_fetch_token` → **`KISCircuitOpen`** → propagates up through `refresh_token_with_lock`'s `try/finally` and `_ensure_token`, then is caught by the **existing** broad `except Exception` at each consumer: `InvestQuoteService._kis_fetch_kr` / `_kis_fetch_us` per-symbol fetch (`app/services/invest_quote_service.py:108`, `:125` → `None`) → `PriceFallbackResolver._apply_layer` fail-open (`app/services/invest_price_fallback.py:59` → Toss layer fills) and `KISHomeReader.fetch` (`app/services/invest_home_readers.py:301` → warning). `KISCircuitOpen` is a plain `Exception` subclass (`circuit_breaker.py:50`), so **no new fallback wiring** is required — same three broad-except sinks ROB-699 verified.
+
+### Target breaker-guarded token flow
+
+Guard the **network POST inside `_fetch_token`** (not `_ensure_token`, so the cache-hit fast path stays byte-identical), mirroring the ROB-699 dispatch wrapper (`base.py:431`–`:473`):
+
+```
+_fetch_token():
+    breaker = get_kis_circuit_breaker()
+    breaker.before_request()      # OPEN & pre-cooldown -> raise KISCircuitOpen NOW (no _ensure_client, no POST)
+                                  # OUTSIDE the classify try/except (ROB-699 invariant)
+    try:
+        cli = await self._ensure_client(timeout=5.0)
+        r   = await cli.post("/oauth2/token", data={...}, timeout=5)
+        response = r.json()
+        access_token = response["access_token"]
+        expires_in   = response.get("expires_in", 3600)
+    except BaseException as exc:
+        if is_kis_connect_failure(exc):   # ConnectTimeout/ConnectError/PoolTimeout/ReadTimeout/ConnectionRefusedError
+            breaker.record_failure()      # Nth consecutive connect-failure -> OPEN
+        else:
+            breaker.record_reachable_error()  # 401/invalid-key (KeyError) / non-JSON (ValueError) = KIS responded, must NOT trip
+        raise                             # re-raise unchanged
+    breaker.record_success()              # normal 2xx return resets the failure count / closes a probe
+    logging.info("KIS 새 토큰 발급 완료")
+    return access_token, expires_in
+```
+
+Behavior during maintenance: each `/invest` load whose token cache is empty drives **one** single-flight `_fetch_token` (single-flight preserved — the breaker check is per-attempt, inside `_fetch_token`, before the POST). Each token connect-failure records one `record_failure()`; after N consecutive the breaker opens; from then on both `_fetch_token` **and** the data dispatch `before_request()` fail-fast with `KISCircuitOpen`. The data-dispatch gate fail-fasts in ~0ms; the open-breaker token fetch fail-fasts at `_fetch_token` **inside** the single-flight (so on an empty token cache it still pays `refresh_token_with_lock`'s ~100ms pre-lock cache double-checks, but **never** the 5s connect wait). Either way KIS readers fall to Toss / warning promptly. The token+data guards share the **one** module singleton, so a token success (or a reachable non-2xx) resets the failure count for both, and vice-versa.
+
+**Invariant (same as ROB-699):** `before_request()` MUST stay **outside** the classify `try/except`. If it were inside, a HALF_OPEN stampede `KISCircuitOpen` would be caught, classified "reachable" (`is_kis_connect_failure(KISCircuitOpen)` is `False`) and wrongly CLOSE the still-probing circuit. A dedicated stampede test locks this.
+
+## Tech Stack
+
+Python 3.13, uv, pytest + pytest-asyncio (`>=1.3`; explicit `@pytest.mark.asyncio`; markers `unit`/`asyncio`), httpx (transport exception hierarchy), the ROB-699 `KISCircuitBreaker` + module singleton (`app/services/brokers/kis/circuit_breaker.py`), stdlib `time.monotonic` / `logging`. No new dependency, no new config field, no Redis change, **migration-0** (no DB change).
+
+## Global Constraints
+
+Copied verbatim; every task implicitly includes these.
+
+- **Reuse the ROB-699 `circuit_breaker.py` module + singleton; do NOT create a second breaker.**
+- **`before_request()` for the token POST sits OUTSIDE the classify `try/except`** (ROB-699 invariant). Add a guard test.
+- **Trip ONLY on connect-level token failures** (`is_kis_connect_failure`: `ConnectTimeout`/`ConnectError`/`PoolTimeout`/`ReadTimeout`/`ConnectionRefusedError`); **401 / invalid-key / business token errors are reachable and must NOT trip** (test this).
+- **Cached-token fast path is byte-identical** (no breaker involvement on cache hit) — prove by test.
+- **KIS-healthy = passthrough** (breaker closed); flag `kis_circuit_breaker_enabled=False` = pure no-op. **migration-0.** No change to the token single-flight / Redis-cache semantics.
+- **Deterministic tests:** reuse the ROB-699 injected clock + singleton-reset conftest fixture (`tests/conftest.py:410` `_isolate_kis_circuit_breaker`); fake httpx; no real sleep / network.
+- Run tests: `uv run pytest <path> -v`. Lint: `make lint`. Do **NOT** commit unless the executing skill says so; each task lists its own commit message.
+
+## File Structure
+
+| File | Create/Modify | Responsibility (Task) |
+|------|---------------|------------------------|
+| `app/services/brokers/kis/base.py` | Modify | Task 1 — guard the `_fetch_token` (`:266`) network POST with `get_kis_circuit_breaker().before_request()` (outside the classify try) + `record_success`/`record_failure`/`record_reachable_error`. Reuses the existing import (`:21`–`:24`). |
+| `tests/test_kis_token_circuit_breaker.py` | Create | Task 1 tests — `_fetch_token` breaker behavior with faked httpx (connect trips, zero-HTTP-when-open, 401/non-JSON do not trip, success resets, disabled passthrough, half-open stampede invariant, cache-hit byte-identical). |
+| `tests/test_kis_token_circuit_open_propagation.py` | Create | Task 2 tests — `KISCircuitOpen` from `_fetch_token` survives the single-flight (`refresh_token_with_lock` re-raises + releases lock) and propagates through `_ensure_token` with ZERO token HTTP. |
+| `docs/runbooks/kis-circuit-breaker.md` | Modify | Task 3 — replace the now-wrong "OAuth token endpoint is not breaker-guarded" scope note; document the token guard, the maintenance sequence, and that single-flight/cache semantics are unchanged. |
+
+> **NOT touched:** the ROB-699 data dispatch guard (`_request_with_rate_limit_with_headers`, `base.py:431`) and the extracted `_dispatch_rate_limited_with_headers` (`base.py:475`) stay byte-for-byte. `_ensure_token`'s cache-hit fast path (`base.py:299`–`:303`) is unchanged — the guard is added strictly inside `_fetch_token`'s network branch, which the cache-hit path never reaches. `refresh_token_with_lock` / `RedisTokenManager` single-flight + Redis-cache semantics (`redis_token_manager.py`) are unchanged (the breaker check is per-attempt, inside `_fetch_token`, before the POST). No new config field — reuse `kis_circuit_breaker_*` (`app/core/config.py:336`–`:342`). The retry/rate-limit dispatch, `_execute_http_request`, `_parse_kis_response`, and every order/holdings/quote mutation path are unchanged. No caller gets new try/except — `PriceFallbackResolver`, `InvestQuoteService`, and `KISHomeReader` already catch broad `Exception`. migration-0.
+
+---
+
+## Task 1 — Guard the `_fetch_token` network POST with the circuit breaker (migration-0)
+
+**Files:**
+- Modify `app/services/brokers/kis/base.py` — wrap the body of `_fetch_token` (`:266`–`:291`). The breaker import (`get_kis_circuit_breaker`, `is_kis_connect_failure`) is **already present** at `base.py:21`–`:24`; no import change.
+- Test (create) `tests/test_kis_token_circuit_breaker.py`.
+
+**Interfaces:**
+- `_fetch_token(self) -> tuple[str, int]` keeps its **exact** signature and return type (`base.py:266`). It now calls `get_kis_circuit_breaker().before_request()` first (may raise `KISCircuitOpen` — a plain `Exception`), then runs `_ensure_client` + the POST + parse inside a `try/except BaseException` that calls `record_failure()` (connect) / `record_reachable_error()` (else) before re-raising, and `record_success()` on the normal return.
+- Reused breaker API (no change): `get_kis_circuit_breaker()` (`circuit_breaker.py:180`), `is_kis_connect_failure(exc)` (`circuit_breaker.py:65`), `KISCircuitBreaker.before_request` / `record_success` / `record_failure` / `record_reachable_error` (`circuit_breaker.py:115`–`:174`), `KISCircuitOpen` (`circuit_breaker.py:50`).
+
+Steps:
+
+- [ ] **Write the failing tests — token breaker behavior at the fetch seam.** Create `tests/test_kis_token_circuit_breaker.py`:
+```python
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+
+from app.services.brokers.kis import circuit_breaker as cb
+from app.services.brokers.kis.base import BaseKISClient
+from app.services.brokers.kis.circuit_breaker import KISCircuitBreaker, KISCircuitOpen
+
+pytestmark = pytest.mark.unit
+
+
+class _Clock:
+    def __init__(self, t: float = 1000.0) -> None:
+        self.t = t
+
+    def now(self) -> float:
+        return self.t
+
+    def advance(self, dt: float) -> None:
+        self.t += dt
+
+
+class _FakeSettings:
+    def __init__(self) -> None:
+        self.kis_app_key = "key"
+        self.kis_app_secret = "secret"
+        self.kis_access_token = "token"
+        self.kis_base_url = "https://openapi.koreainvestment.com:9443"
+
+
+class _FakeClient(BaseKISClient):
+    def __init__(self) -> None:  # type: ignore[override]
+        type(self)._shared_client_lock = None
+        self._fake_settings = _FakeSettings()
+
+    @property  # type: ignore[override]
+    def _settings(self):  # type: ignore[override]
+        return self._fake_settings
+
+
+class _BreakerSettings:
+    kis_circuit_breaker_enabled = True
+    kis_circuit_breaker_failure_threshold = 3
+    kis_circuit_breaker_cooldown_seconds = 45
+
+
+@pytest.fixture
+def clock():
+    return _Clock()
+
+
+@pytest.fixture(autouse=True)
+def _install_breaker(clock):
+    # Inject a deterministic-clock, ENABLED breaker as THE process singleton.
+    # (conftest._isolate_kis_circuit_breaker disables the GLOBAL settings flag,
+    # but this breaker reads its own settings_obj, so it stays enabled here.)
+    cb._breaker = KISCircuitBreaker(now=clock.now, settings_obj=_BreakerSettings())
+    yield
+    cb.reset_kis_circuit_breaker()
+
+
+def _client_with_post(post):
+    client = _FakeClient()
+    fake_http = MagicMock()
+    fake_http.post = post
+    client._ensure_client = AsyncMock(return_value=fake_http)  # type: ignore[method-assign]
+    return client
+
+
+def _json_response(payload):
+    r = MagicMock()
+    r.json.return_value = payload
+    return r
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "exc",
+    [
+        httpx.ConnectTimeout(""),
+        httpx.ConnectError(""),
+        httpx.PoolTimeout(""),
+        httpx.ReadTimeout(""),
+        ConnectionRefusedError(),
+    ],
+)
+async def test_token_connect_failures_open_breaker(exc):
+    post = AsyncMock(side_effect=exc)
+    client = _client_with_post(post)
+    for _ in range(3):  # threshold
+        with pytest.raises(type(exc)):
+            await client._fetch_token()
+    assert cb.get_kis_circuit_breaker().state == "open"
+
+
+@pytest.mark.asyncio
+async def test_open_breaker_token_fetch_zero_http():
+    post = AsyncMock(side_effect=httpx.ConnectError(""))
+    client = _client_with_post(post)
+    for _ in range(3):
+        with pytest.raises(httpx.ConnectError):
+            await client._fetch_token()
+    assert cb.get_kis_circuit_breaker().state == "open"
+    post.reset_mock()
+    client._ensure_client.reset_mock()
+    with pytest.raises(KISCircuitOpen):
+        await client._fetch_token()
+    post.assert_not_awaited()  # ZERO HTTP
+    client._ensure_client.assert_not_awaited()  # not even the client build
+
+
+@pytest.mark.asyncio
+async def test_token_401_invalid_key_does_not_open():
+    # KIS responded with an error body lacking access_token -> KeyError (reachable).
+    post = AsyncMock(return_value=_json_response({"error": "invalid_client"}))
+    client = _client_with_post(post)
+    for _ in range(6):  # well past threshold
+        with pytest.raises(KeyError):
+            await client._fetch_token()
+    assert cb.get_kis_circuit_breaker().state == "closed"
+    assert cb.get_kis_circuit_breaker().failure_count == 0
+
+
+@pytest.mark.asyncio
+async def test_token_non_json_body_does_not_open():
+    r = MagicMock()
+    r.json.side_effect = ValueError("not json")
+    post = AsyncMock(return_value=r)
+    client = _client_with_post(post)
+    for _ in range(6):
+        with pytest.raises(ValueError):
+            await client._fetch_token()
+    assert cb.get_kis_circuit_breaker().state == "closed"
+
+
+@pytest.mark.asyncio
+async def test_token_success_returns_and_keeps_closed():
+    post = AsyncMock(return_value=_json_response({"access_token": "T", "expires_in": 100}))
+    client = _client_with_post(post)
+    token, expires = await client._fetch_token()
+    assert token == "T"
+    assert expires == 100
+    assert cb.get_kis_circuit_breaker().state == "closed"
+
+
+@pytest.mark.asyncio
+async def test_token_success_after_failures_resets_count():
+    post = AsyncMock(
+        side_effect=[
+            httpx.ConnectTimeout(""),
+            httpx.ConnectTimeout(""),
+            _json_response({"access_token": "T", "expires_in": 100}),
+        ]
+    )
+    client = _client_with_post(post)
+    for _ in range(2):
+        with pytest.raises(httpx.ConnectTimeout):
+            await client._fetch_token()
+    assert cb.get_kis_circuit_breaker().failure_count == 2
+    await client._fetch_token()  # success resets the counter
+    assert cb.get_kis_circuit_breaker().failure_count == 0
+    assert cb.get_kis_circuit_breaker().state == "closed"
+
+
+@pytest.mark.asyncio
+async def test_disabled_flag_token_passthrough():
+    class _Disabled(_BreakerSettings):
+        kis_circuit_breaker_enabled = False
+
+    cb._breaker = KISCircuitBreaker(settings_obj=_Disabled())
+    post = AsyncMock(side_effect=httpx.ConnectTimeout(""))
+    client = _client_with_post(post)
+    for _ in range(10):
+        with pytest.raises(httpx.ConnectTimeout):
+            await client._fetch_token()
+    # never opens; every call still reached the network (passthrough)
+    assert cb.get_kis_circuit_breaker().state == "closed"
+    assert post.await_count == 10
+
+
+@pytest.mark.asyncio
+async def test_half_open_probe_stampede_does_not_close(clock):
+    # Locks "before_request() OUTSIDE the classify try/except": once a half-open
+    # probe is in flight, a stampede caller must raise KISCircuitOpen WITHOUT
+    # that raise being reclassified reachable (which would wrongly close the
+    # still-probing circuit).
+    post = AsyncMock(side_effect=httpx.ConnectTimeout(""))
+    client = _client_with_post(post)
+    for _ in range(3):
+        with pytest.raises(httpx.ConnectTimeout):
+            await client._fetch_token()
+    breaker = cb.get_kis_circuit_breaker()
+    assert breaker.state == "open"
+    clock.advance(45)
+    breaker.before_request()  # hands out THE probe -> half_open, in flight
+    assert breaker.state == "half_open"
+    with pytest.raises(KISCircuitOpen):
+        await client._fetch_token()  # stampede caller: must fail-fast
+    assert breaker.state == "half_open"  # still probing, NOT closed
+
+
+@pytest.mark.asyncio
+async def test_cached_token_path_no_breaker_involvement():
+    # _ensure_token cache-hit must be byte-identical: _fetch_token never called,
+    # breaker never touched (a pre-loaded failure count is preserved).
+    breaker = cb.get_kis_circuit_breaker()
+    breaker.record_failure()
+    breaker.record_failure()
+    assert breaker.failure_count == 2
+
+    client = _FakeClient()
+    client._token_manager = MagicMock()
+    client._token_manager.get_token = AsyncMock(return_value="cached-tok")
+    client._fetch_token = AsyncMock(  # type: ignore[method-assign]
+        side_effect=AssertionError("cache hit must not fetch")
+    )
+
+    await client._ensure_token()
+    assert client._settings.kis_access_token == "cached-tok"
+    client._fetch_token.assert_not_awaited()
+    assert breaker.failure_count == 2  # untouched
+    assert breaker.state == "closed"
+```
+
+- [ ] **Run it — fails.** `uv run pytest tests/test_kis_token_circuit_breaker.py -v`
+  Expected: the connect-trip, zero-HTTP, success-resets and stampede tests FAIL (`_fetch_token` has no breaker calls yet — the breaker never opens, `KISCircuitOpen` is never raised). The 401 / non-JSON / disabled / cache-hit tests pass coincidentally (closed passthrough / cache-hit already skips fetch). Keep them to lock the boundaries.
+
+- [ ] **Minimal impl — guard `_fetch_token`.** In `app/services/brokers/kis/base.py`, replace the body of `_fetch_token` (`:266`–`:291`) with the guarded version (the `def`/signature and the POST payload are unchanged; only the breaker calls + `try/except` are added). `before_request()` is placed **before** the `try` (so an open circuit does zero work); `_ensure_client` + POST + parse go **inside** the `try`:
+```python
+    async def _fetch_token(self) -> tuple[str, int]:
+        """Fetch new OAuth2 token from KIS API.
+
+        ROB-700: the token POST is guarded by the SAME per-process circuit
+        breaker as the data dispatch (ROB-699). During a KIS maintenance window
+        the token fetch connect-times-out FIRST (before any data call), so
+        guarding it here is what lets the breaker open at all. After N
+        consecutive token connect-failures ``before_request`` fail-fasts with
+        ``KISCircuitOpen`` (zero HTTP, zero wait) and every KIS reader hits its
+        Toss fallback / warning immediately. A 401 / invalid-key / non-JSON
+        body means KIS RESPONDED (reachable) and must NOT trip the breaker.
+
+        The breaker check is per-attempt, inside this call, before the network
+        POST — the token single-flight (``refresh_token_with_lock``) and the
+        cached-token fast path in ``_ensure_token`` are unchanged.
+
+        Returns:
+            Tuple of (access_token, expires_in_seconds)
+
+        Raises:
+            KISCircuitOpen: When the breaker is open (fail-fast, no HTTP).
+            httpx.HTTPStatusError / httpx.RequestError: On HTTP/transport errors.
+            KeyError: If response doesn't contain access_token.
+        """
+        breaker = get_kis_circuit_breaker()
+        breaker.before_request()  # OUTSIDE the classify try/except (ROB-699 invariant)
+        try:
+            cli = await self._ensure_client(timeout=5.0)
+            r = await cli.post(
+                self._kis_url("/oauth2/token"),
+                data={
+                    "grant_type": "client_credentials",
+                    "appkey": self._settings.kis_app_key,
+                    "appsecret": self._settings.kis_app_secret,
+                },
+                timeout=5,
+            )
+            response = r.json()
+            access_token = response["access_token"]
+            expires_in = response.get("expires_in", 3600)
+        except BaseException as exc:  # noqa: BLE001 — classify then re-raise unchanged
+            if is_kis_connect_failure(exc):
+                breaker.record_failure()  # connect/read outage -> trips after N
+            else:
+                breaker.record_reachable_error()  # KIS responded (401/KeyError/JSON) — no trip
+            raise
+        breaker.record_success()
+        logging.info("KIS 새 토큰 발급 완료")
+        return access_token, expires_in
+```
+**Critical invariant:** `breaker.before_request()` MUST stay **outside** the `try/except BaseException`. If a refactor moves it inside, a HALF_OPEN stampede `KISCircuitOpen` gets caught, classified "reachable" (`is_kis_connect_failure(KISCircuitOpen)` is `False`), and `record_reachable_error()` would wrongly CLOSE the still-probing circuit. `test_half_open_probe_stampede_does_not_close` locks this.
+
+- [ ] **Run it — passes.** `uv run pytest tests/test_kis_token_circuit_breaker.py -v` → all pass.
+
+- [ ] **Regression — the existing token/dispatch surface stays green.** `uv run pytest tests/test_services_kis_client.py tests/test_kis_circuit_breaker_dispatch.py tests/services/brokers/kis/test_circuit_breaker.py tests/test_redis_token_manager.py tests/test_kis_base_rate_limit.py -v`
+  Expected: all pass unchanged — the conftest `_isolate_kis_circuit_breaker` fixture (`tests/conftest.py:410`) forces the breaker OFF for every existing test, so the token guard is a pure no-op there and `_fetch_token` behaves byte-identically.
+
+- [ ] **Lint.** `make lint`.
+
+- [ ] **Commit.** `git add -A && git commit -m "feat(ROB-700): guard KIS OAuth token fetch with the circuit breaker (fail-fast on token connect outage)"`
+
+---
+
+## Task 2 — Single-flight propagation regression: `KISCircuitOpen` survives the token lock (test-only, migration-0)
+
+**Files:**
+- Test (create) `tests/test_kis_token_circuit_open_propagation.py` — proves (a) `refresh_token_with_lock` re-raises a fetcher `KISCircuitOpen` and still releases the lock, and (b) an open breaker makes `_ensure_token` fail-fast with `KISCircuitOpen` and **zero** token HTTP, exercising the REAL single-flight.
+- **No source change** — `refresh_token_with_lock` (`redis_token_manager.py:286`–`:307`) has no `except` that swallows, `KISCircuitOpen` is a plain `Exception` (`circuit_breaker.py:50`), and the three consumer fallbacks already catch broad `Exception` (ROB-699-verified). The resolver-layer catch is additionally locked by the existing `tests/test_invest_price_fallback_circuit_open.py` (source-agnostic — any `KISCircuitOpen`, including a token-origin one, fails through to Toss).
+
+**Interfaces:** none produced. Consumes `RedisTokenManager.refresh_token_with_lock`, `BaseKISClient._ensure_token`, `KISCircuitBreaker`, `KISCircuitOpen`.
+
+Steps:
+
+- [ ] **Write the regression tests.** Create `tests/test_kis_token_circuit_open_propagation.py`:
+```python
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+
+from app.services.brokers.kis import circuit_breaker as cb
+from app.services.brokers.kis.base import BaseKISClient
+from app.services.brokers.kis.circuit_breaker import KISCircuitBreaker, KISCircuitOpen
+from app.services.redis_token_manager import RedisTokenManager
+
+pytestmark = [pytest.mark.unit, pytest.mark.asyncio]
+
+
+class _FakeSettings:
+    def __init__(self) -> None:
+        self.kis_app_key = "key"
+        self.kis_app_secret = "secret"
+        self.kis_access_token = "token"
+        self.kis_base_url = "https://openapi.koreainvestment.com:9443"
+
+
+class _FakeClient(BaseKISClient):
+    def __init__(self) -> None:  # type: ignore[override]
+        type(self)._shared_client_lock = None
+        self._fake_settings = _FakeSettings()
+
+    @property  # type: ignore[override]
+    def _settings(self):  # type: ignore[override]
+        return self._fake_settings
+
+
+class _EnabledBreakerSettings:
+    kis_circuit_breaker_enabled = True
+    kis_circuit_breaker_failure_threshold = 1  # 1 failure -> open
+    kis_circuit_breaker_cooldown_seconds = 45
+
+
+@pytest.fixture(autouse=True)
+def _install_breaker():
+    cb._breaker = KISCircuitBreaker(settings_obj=_EnabledBreakerSettings())
+    yield
+    cb.reset_kis_circuit_breaker()
+
+
+async def test_refresh_token_with_lock_reraises_circuit_open_and_releases_lock(
+    monkeypatch,
+):
+    # The token single-flight must NOT swallow KISCircuitOpen and must still
+    # release the distributed lock. Stub the cache/lock probes so the real
+    # try/finally body runs with no real sleep / no real Redis.
+    monkeypatch.setattr(
+        "app.services.redis_token_manager.asyncio.sleep", AsyncMock()
+    )
+    manager = RedisTokenManager()
+    manager.get_token = AsyncMock(return_value=None)  # type: ignore[method-assign]
+    manager._acquire_lock = AsyncMock(return_value=True)  # type: ignore[method-assign]
+    manager._release_lock = AsyncMock()  # type: ignore[method-assign]
+    manager.save_token = AsyncMock()  # type: ignore[method-assign]
+
+    fetcher = AsyncMock(side_effect=KISCircuitOpen(45.0))
+
+    with pytest.raises(KISCircuitOpen):
+        await manager.refresh_token_with_lock(fetcher)
+
+    fetcher.assert_awaited_once()  # single-flight: exactly one fetch attempt
+    manager._release_lock.assert_awaited()  # lock released on the error path
+    manager.save_token.assert_not_awaited()  # no token persisted on failure
+
+
+async def test_open_breaker_ensure_token_fails_fast_zero_http(monkeypatch):
+    # End-to-end: open breaker -> _ensure_token (cache miss) -> single-flight ->
+    # _fetch_token.before_request() -> KISCircuitOpen, with ZERO token POST.
+    monkeypatch.setattr(
+        "app.services.redis_token_manager.asyncio.sleep", AsyncMock()
+    )
+    breaker = cb.get_kis_circuit_breaker()
+    breaker.record_failure()  # threshold=1 -> OPEN
+    assert breaker.state == "open"
+
+    manager = RedisTokenManager()
+    manager.get_token = AsyncMock(return_value=None)  # cache miss everywhere
+    manager._acquire_lock = AsyncMock(return_value=True)
+    manager._release_lock = AsyncMock()
+    manager.save_token = AsyncMock()
+
+    client = _FakeClient()
+    client._token_manager = manager
+    post = AsyncMock(side_effect=httpx.ConnectTimeout(""))
+    fake_http = MagicMock()
+    fake_http.post = post
+    client._ensure_client = AsyncMock(return_value=fake_http)  # type: ignore[method-assign]
+
+    with pytest.raises(KISCircuitOpen):
+        await client._ensure_token()
+
+    post.assert_not_awaited()  # ZERO token HTTP — failed fast at before_request
+    client._ensure_client.assert_not_awaited()
+    manager._release_lock.assert_awaited()  # single-flight lock still released
+```
+
+- [ ] **Run it — passes on first run (contract lock).** `uv run pytest tests/test_kis_token_circuit_open_propagation.py -v`
+  Both tests are GREEN immediately (Task 2 runs **after** Task 1's `_fetch_token` guard is already in place): the first (`test_refresh_token_with_lock_reraises_circuit_open_and_releases_lock`) passes because `refresh_token_with_lock` already re-raises via its `try/finally` and `KISCircuitOpen` is a plain `Exception`; the second (`test_open_breaker_ensure_token_fails_fast_zero_http`) additionally exercises the Task 1 `before_request` guard end-to-end through the real `_ensure_token` (it would FAIL if run before Task 1's impl — the token POST would be awaited and raise `ConnectTimeout` instead of `KISCircuitOpen`). Their job is to LOCK the "single-flight does not swallow the fail-fast + lock is still released" guarantee and the "open breaker => zero token HTTP through the real `_ensure_token`" behavior. (If either is unexpectedly red, stop and reconcile — do not add wiring blindly.)
+
+- [ ] **Cross-check the resolver hop already covered.** `uv run pytest tests/test_invest_price_fallback_circuit_open.py -v`
+  Expected: all pass unchanged — the ROB-699 resolver test already proves a `KISCircuitOpen` (regardless of origin) fails through the KIS layer to Toss/snapshot, so the token-origin case needs no new resolver test.
+
+- [ ] **Lint.** `make lint`.
+
+- [ ] **Commit.** `git add -A && git commit -m "test(ROB-700): lock KISCircuitOpen propagation through the token single-flight"`
+
+---
+
+## Task 3 — Update the operator runbook (docs, migration-0)
+
+**Files:**
+- Modify `docs/runbooks/kis-circuit-breaker.md` — the ROB-699 runbook currently states (`:99`–`:101`) "**The OAuth token endpoint is not breaker-guarded.**" That is now **wrong**; update it and add the ROB-700 rationale.
+
+**Interfaces:** none.
+
+Steps:
+
+- [ ] **Update "What it does".** Note that the breaker now guards **both** the data dispatch seam **and** the OAuth token POST (`_fetch_token`, `app/services/brokers/kis/base.py`), sharing the one module singleton.
+
+- [ ] **Add a "Why the token fetch is also guarded (ROB-700)" subsection.** Document the LIVE finding: during the 2026-07-04 KIS maintenance the ROB-699 data guard never opened (0 circuit logs) because the ONLY KIS HTTP calls were `POST /oauth2/token` (half timing out at ~5s) and ZERO data calls — the token fetch connect-times-out **first**, so no token → no data call → no data-dispatch failure → breaker never trips. Guarding `_fetch_token` fixes this: N consecutive **token** connect-failures now open the breaker, after which both token fetches and data calls fail-fast.
+
+- [ ] **Replace the scope note.** Remove "The OAuth token endpoint is not breaker-guarded" (`:99`–`:101`) and replace with: the OAuth token POST **is** guarded (ROB-700); the **cached-token fast path is byte-identical** (a cache hit in `_ensure_token` never calls `_fetch_token`, so the breaker is never touched); the token **single-flight / Redis-cache semantics are unchanged** (the breaker check is per-attempt, inside `_fetch_token`, before the POST); and **401 / invalid-key / non-JSON** token errors are *reachable* and do **not** trip (only transport connect/read-hang failures do). Also note that because token and data share one singleton, a token success (or reachable non-2xx) resets the failure count for both surfaces.
+
+- [ ] **Confirm the classifier / defaults / log-line sections still read correctly** — they already apply verbatim to the token POST (same `is_kis_connect_failure` set, same `kis_circuit_breaker_*` defaults at `app/core/config.py:336`–`:342`, same WARNING/INFO log lines). No change needed beyond the token-scope additions above.
+
+- [ ] **Full regression sweep.** `uv run pytest tests/test_kis_token_circuit_breaker.py tests/test_kis_token_circuit_open_propagation.py tests/test_kis_circuit_breaker_dispatch.py tests/services/brokers/kis/test_circuit_breaker.py tests/test_invest_price_fallback_circuit_open.py tests/test_services_kis_client.py tests/test_redis_token_manager.py -v`
+  Expected: all pass — new token suites green, ROB-699 breaker + dispatch + fallback + existing KIS client/token-manager suites unaffected.
+
+- [ ] **Lint.** `make lint`.
+
+- [ ] **Commit.** `git add -A && git commit -m "docs(ROB-700): runbook — OAuth token fetch is now breaker-guarded"`
+
+---
+
+## Rollout / verification notes (non-blocking)
+
+- **No new config / defaults reused.** ROB-700 reuses `kis_circuit_breaker_enabled` / `_failure_threshold` (5) / `_cooldown_seconds` (45) unchanged (`app/core/config.py:336`–`:342`). `KIS_CIRCUIT_BREAKER_ENABLED=false` disables both the data and token guards with zero deploy.
+- **First-load caveat still holds.** Opening the breaker requires N consecutive token connect-failures; because the token single-flight collapses a concurrent `/invest` burst into ONE `_fetch_token`, it takes ~N separate refresh cycles (loads) to open. This is the intended steady-state behavior — the breaker is a steady-state fail-fast guard, not a first-request guard.
+- **Token+data share one breaker (intended).** During real KIS maintenance both the token host and the data host are down together, so a token failure count and a data failure count reinforce each other, and any proof of reachability (token success OR a data 2xx) resets both. Revisit only if false-coupling is observed in practice.
+- **Live re-measure after rollout.** The ROB-699 outage produced 0 circuit logs; after ROB-700 the next KIS-maintenance window should show `WARNING "KIS circuit OPEN after N consecutive connect-failures"` once token connect-failures cross the threshold, then `/invest` KIS readers falling to Toss in ~0ms. Confirm from production before closing ROB-700.

--- a/docs/plans/ROB-701-toss-sellable-quantity-fanout.md
+++ b/docs/plans/ROB-701-toss-sellable-quantity-fanout.md
@@ -1,0 +1,645 @@
+# ROB-701 — Toss `sellable_quantity` N+1 Fanout on `/invest` Home (Short-TTL Cache) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (- [ ]) syntax.
+
+**Goal:** Kill the dominant `/invest/api/home` bottleneck — the `invest.home.toss_api` reader spends ~15–17s serially fanning out one `GET /api/v1/sellable-quantity` per holding (Sentry 24h: 2659 calls, sum 344s). Root cause: `fetch_toss_portfolio_snapshot` (`app/services/toss_portfolio_service.py:131`) `asyncio.gather`s `sellable_quantity(symbol=...)` per position (`:155-161`), but that call is in the Toss `ORDER_INFO` rate-limit group capped at **6 TPS** (3 TPS in the 09:00–09:10 KST peak) (`app/services/brokers/toss/rate_limiter.py:35,52-55`), so the fanout serializes to ~6/sec → N positions ≈ N/6 s (30≈5s, 60≈10s). ROB-685 added a `need_sellable=False` skip (`:173-177`), but the `/invest` home reader passes `need_sellable=mutations_enabled` (`app/services/invest_home_readers.py:554-556`) and prod runs `TOSS_LIVE_ORDER_MUTATIONS_ENABLED=true` (ROB-549 sellable-accuracy gate), so the fanout runs on **every** load. We add a **process-global short-TTL (default 45s) per-symbol sellable cache** and thread it into `fetch_toss_portfolio_snapshot` as an opt-in parameter. The invest_home reader (the sole hot caller with mutations armed) passes the shared cache: the first load populates it (still one bounded fanout), and every subsequent `/invest` home / account-panel load within the TTL reuses cached values → **0** `sellable-quantity` calls. A short TTL naturally refreshes after order fills, and ROB-549 tolerates that brief staleness (the actual sell path re-validates at the broker, unchanged). The MCP collect chain (`portfolio_holdings.py:559`) passes **no** cache and stays byte-for-byte identical; the ROB-685 `need_sellable=False` fast path is untouched.
+
+## Architecture
+
+### Current (slow) flow — real refs
+
+- `TossApiHomeReader.fetch` (`app/services/invest_home_readers.py:539`) reads `mutations_enabled = settings.toss_live_order_mutations_enabled` (`:547-549`) and calls `fetch_toss_portfolio_snapshot(need_sellable=mutations_enabled)` (`:554-556`). In prod `mutations_enabled` is `True`.
+- `fetch_toss_portfolio_snapshot(*, need_sellable=True, client=None)` (`toss_portfolio_service.py:131`):
+  - `holdings = await active_client.holdings()` (`:144`).
+  - When `need_sellable`: opens the `invest.home.toss_api.sellable_quantity` span and `asyncio.gather`s `active_client.sellable_quantity(symbol=item.symbol)` **for every holding** (`:149-169`), then `zip`s into `paired` (`:170-172`).
+  - When `not need_sellable` (ROB-685): `paired = [(item, None) for item in holdings.items]` (`:173-177`) — no fanout.
+  - The position-build loop (`:179-213`) unwraps `sellable_result.sellable_quantity` (`:191-192`) into `TossPortfolioPosition.sellable_quantity`.
+- Each `sellable_quantity` call → `TossReadClient.sellable_quantity(*, symbol)` (`app/services/brokers/toss/client.py:310-319`), `group=TossApiGroup.ORDER_INFO`.
+- The shared `TossRateLimiter.acquire` (`rate_limiter.py:57-73`) admits `_BASE_LIMITS[ORDER_INFO]=6` per sliding second (`:35`), dropping to `3` in 09:00–09:10 (`:52-55`). The limiter is a process-global singleton (`get_shared_rate_limiter`, `:79-85`) shared by every `from_settings` client (`client.py:72`), so N gathered calls serialize to ~N/6 s of pure wall time.
+- Downstream: `_toss_sellable_quantity(position, mutations_enabled)` (`invest_home_readers.py:516-524`) returns `float(position.sellable_quantity)` (falling back to full quantity) when mutations are armed → `Holding.sellableQuantity` / `pendingSellQuantity` (`:657-663`).
+
+**Why not Option 1 (reuse a holdings field):** `TossHoldingItem` (`app/services/brokers/toss/dto.py:64-77`) carries `symbol/name/marketCountry/currency/quantity/lastPrice/averagePurchasePrice/marketValue/profitLoss/dailyProfitLoss/cost` — **no** sellable/orderable/tradable field — and `parse_holdings` (`:154-175`) only reads those keys (`raw_overview` at `:174` captures portfolio-level top keys, not per-item extras). Toss deliberately exposes a **separate** `GET /api/v1/sellable-quantity` endpoint precisely because *sellable* differs from *held* quantity (pending sells / unsettled state), so `item.quantity` is **not** a safe substitute. Option 1 is unavailable. (Recorded in key_decisions.)
+
+### Target (cached) flow
+
+New process-global `TossSellableCache` (new module `app/services/toss_sellable_cache.py`): a per-symbol TTL map with an **injected clock** (`now: Callable[[], float] = time.monotonic`), keyed by symbol, storing the `Decimal` value with an expiry. `get(symbol)` returns the value only while fresh (evicts on expiry); `put(symbol, value)` stamps `now() + ttl`. Module singleton `get_shared_sellable_cache()` / `reset_shared_sellable_cache()` mirrors the existing `get_shared_rate_limiter` / `reset_shared_rate_limiter` pattern (`rate_limiter.py:76-91`). A `toss_sellable_cache_enabled=False` kill-switch makes `get()`/`put()` no-ops (cache always misses → today's fanout-every-load behavior).
+
+`fetch_toss_portfolio_snapshot(*, need_sellable=True, sellable_cache: TossSellableCache | None = None, client=None)`:
+
+```
+if need_sellable and sellable_cache is not None:      # ROB-701 cache-aware fanout
+    hits = [sellable_cache.get(item.symbol) for item in holdings.items]   # index-aligned Decimal|None
+    miss_indices = [i for i, h in enumerate(hits) if h is None]
+    with span("invest.home.toss_api.sellable_quantity"):
+        fetched = await asyncio.gather(*[client.sellable_quantity(symbol=items[i].symbol) for i in miss_indices], return_exceptions=True)
+    for i, result in zip(miss_indices, fetched):
+        if not isinstance(result, BaseException):
+            sellable_cache.put(items[i].symbol, result.sellable_quantity)   # only SUCCESS cached
+    paired = per-item: fetched result for misses; TossSellableQuantity(hits[i]) re-wrap for hits
+elif need_sellable:                                    # ROB-685 default fanout (VERBATIM)
+    <today's gather + span + zip>
+else:                                                  # ROB-685 skip (VERBATIM)
+    paired = [(item, None) for item in holdings.items]
+```
+
+The position-build loop (`:179-213`) is **unchanged** — cache hits are re-wrapped into `TossSellableQuantity(sellable_quantity=cached)` so the downstream `.sellable_quantity` unwrap is uniform. `TossApiHomeReader.fetch` passes `sellable_cache=get_shared_sellable_cache()` when `mutations_enabled` (else `None`, which lands on the `need_sellable=False` skip anyway). Net: first `/invest` home load pays one bounded fanout (miss on every symbol); loads within the TTL reuse → 0 `sellable-quantity` calls; the 6-TPS cap is never touched, `sellable_quantity()` semantics/group are untouched, and the MCP path keeps the uncached default.
+
+## Tech Stack
+
+Python 3.13, uv, pytest + pytest-asyncio (`@pytest.mark.asyncio`, markers `unit`/`asyncio`), asyncio, dataclass DTOs (`TossSellableQuantity`), Sentry spans, stdlib `time.monotonic`, pydantic-settings `Settings` (`app/core/config.py:184`). No new dependency, **no Redis** (in-process singleton, matching `get_shared_rate_limiter`), **migration-0** (no DB change). Toss Open API `GET /api/v1/sellable-quantity` (`TossApiGroup.ORDER_INFO`, 6 TPS / 3 TPS peak) — call frequency reduced, never rate raised.
+
+## Global Constraints
+
+Copied verbatim; every task implicitly includes these.
+
+- **Do NOT regress ROB-549 sellable/tradeable display accuracy** — sellable shown when mutations armed must remain correct (a short cache TTL staleness window is acceptable; silently dropping accuracy is not).
+- **Preserve the existing `need_sellable=False` fast path (ROB-685) unchanged.**
+- **No order/mutation path change. No change to the `sellable_quantity()` semantics or its rate-limit group.**
+- **migration-0.**
+- **TDD:** cache-hit => 0 sellable-quantity calls (or Option-1: 0 calls at all); TTL expiry => refetch; accuracy preserved (the sellable value on the Holding matches source); the mutations-disabled skip path still skips.
+- **Deterministic tests:** inject/fake the Toss client + clock; assert call counts; no real network.
+- Run tests with `uv run pytest <path> -v`. Lint with `make lint`. Do NOT commit unless the executing skill says so; each task lists its own commit message.
+
+## Approach / decision note
+
+- **Option 2 (short-TTL per-symbol cache) chosen.** Option 1 (reuse a holdings-item sellable field) is unavailable — the holdings item has no sellable/orderable field and Toss splits it into a separate endpoint on purpose (`dto.py:64-77`). Option 3 (defer/lazy-load) is heavier UI surgery and not needed once the cache collapses repeated loads.
+- **Symbol-only cache key is safe because Toss is a single operator account, not per-user.** `TossApiHomeReader.fetch` discards its `user_id` (`invest_home_readers.py:540` `del user_id`) and `fetch_toss_portfolio_snapshot` always resolves `TossReadClient.from_settings()` (one `toss_api_account_seq`/`toss_api_client_id` from `Settings`, `client.py:68`), so there is exactly one account's sellable quantity per symbol process-wide — a `(user_id, symbol)` key is unnecessary and a `symbol` key cannot leak across accounts. **If Toss ever becomes multi-account, this cache key MUST be re-scoped.** (Recorded in key_decisions.)
+- **Cache is opt-in, threaded via a parameter — NOT read from a global flag inside the shared fetch, and NOT applied to the MCP path.** Only the invest_home reader passes the cache. ROB-685's approach note cautioned against a stateful cache *on the sell-sizing path* (MCP `_toss_api_position_to_mcp` / `sellable_quantity > 0 → sell_review`); scoping the cache to the display-only home reader sidesteps that entirely — the MCP collect chain (`portfolio_holdings.py:559`) still gets fresh values every call. (Recorded in key_decisions.)
+- **TTL-bounded staleness is the accepted tradeoff for ROB-549.** The home reader's `sellableQuantity`/`pendingSellQuantity` are display fields; a ≤45s stale value never sizes a real order (the Toss sell tools re-validate sellable at submit, unchanged). Only **successful** fetches are cached — a transient `sellable_quantity` error is never cached, so the next load retries. (Recorded in open_questions for reviewer sign-off on the exact TTL.)
+- **Both `/invest/api/home` and `/invest/api/account-panel` are served by `TossApiHomeReader.fetch`** (the single `fetch_toss_portfolio_snapshot` call site in `invest_home_readers.py` is at `:554`), so wiring the shared cache there fixes both surfaces with one change; the process-global singleton also lets the two surfaces share warm entries.
+
+## File Structure
+
+| File | Create/Modify | Responsibility (Task) |
+|------|---------------|------------------------|
+| `app/core/config.py` | Modify | Task 1 — add `toss_sellable_cache_enabled: bool = True` + `toss_sellable_cache_ttl_seconds: float = 45.0` to `Settings`, after `toss_live_order_mutations_enabled` (`:248`). |
+| `app/services/toss_sellable_cache.py` | Create | Task 2 — `TossSellableCache` (injected clock, per-symbol TTL, enable flag) + `get_shared_sellable_cache` / `reset_shared_sellable_cache` singleton. |
+| `app/services/toss_portfolio_service.py` | Modify | Task 3 — add `sellable_cache` param to `fetch_toss_portfolio_snapshot`; cache-aware fanout (miss-only) when provided; default + `need_sellable=False` paths unchanged. |
+| `app/services/invest_home_readers.py` | Modify | Task 4 — `TossApiHomeReader.fetch` passes `sellable_cache=get_shared_sellable_cache()` when mutations armed. |
+| `tests/test_toss_sellable_cache.py` | Create | Task 2 tests — TTL hit/expiry, disabled no-op, singleton identity/reset (fake clock). |
+| `tests/test_toss_portfolio_service.py` | Modify | Task 3 tests — cache-hit=0 calls, TTL expiry refetch, accuracy from cache, error-not-cached, default/`need_sellable=False` unchanged (fake client + fake clock). |
+| `tests/test_invest_home_readers.py` | Modify | Task 4 tests — reader passes a cache when mutations on / `None` when off; update the 4 existing Toss-reader fakes to accept the new kwarg. |
+
+> **NOT touched:**
+> - `app/services/brokers/toss/rate_limiter.py` and `.../client.py` — the 6-TPS `ORDER_INFO` cap and the `sellable_quantity` GET are unchanged; we reduce *how often* it is called, never *how fast*, and never change its rate-limit group.
+> - `app/services/brokers/toss/dto.py` — `TossHoldingItem` / `parse_holdings` / `TossSellableQuantity` are read as-is (Task 3 only *imports* `TossSellableQuantity` to re-wrap cache hits).
+> - `app/mcp_server/tooling/portfolio_holdings.py` (`_collect_toss_api_positions` → `fetch_toss_portfolio_snapshot(need_sellable=need_sellable)` at `:559`) and every MCP / action_report / sell-classification consumer — they pass **no** `sellable_cache`, so they keep the default uncached behavior byte-for-byte; sell classification (`sellable_quantity > 0`) still reads fresh values.
+> - The ROB-685 `need_sellable=False` branch (`toss_portfolio_service.py:173-177`) and the default `need_sellable=True` **no-cache** branch (`:149-172`) — both verbatim.
+> - Any order/mutation path (Toss preview/place/modify/cancel) — the cache is on a read-only GET only. No DB migration.
+
+---
+
+## Task 1 — Config flags for the Toss sellable cache (migration-0)
+
+**Files:**
+- Modify `app/core/config.py` — add two fields to `Settings` (`:184`) directly after `toss_live_order_mutations_enabled` (`:248`), before the `# ROB-576` block (`:250`).
+- Test (create) `tests/test_toss_sellable_cache.py` (config assertions live in the same new module used by Task 2; add the config test class now).
+
+**Interfaces:**
+- Produces `Settings.toss_sellable_cache_enabled: bool = True` and `Settings.toss_sellable_cache_ttl_seconds: float = 45.0` (mirrors the existing `bool` + `float` field style near `:248`).
+
+Steps:
+
+- [ ] **Write the failing test — defaults present and typed.** Create `tests/test_toss_sellable_cache.py` with this first block:
+```python
+from __future__ import annotations
+
+import pytest
+
+from app.core.config import Settings
+
+pytestmark = pytest.mark.unit
+
+
+class TestTossSellableCacheSettings:
+    def test_defaults(self):
+        s = Settings()
+        assert s.toss_sellable_cache_enabled is True
+        assert s.toss_sellable_cache_ttl_seconds == 45.0
+
+    def test_env_override(self, monkeypatch):
+        monkeypatch.setenv("TOSS_SELLABLE_CACHE_ENABLED", "false")
+        monkeypatch.setenv("TOSS_SELLABLE_CACHE_TTL_SECONDS", "30")
+        s = Settings()
+        assert s.toss_sellable_cache_enabled is False
+        assert s.toss_sellable_cache_ttl_seconds == 30.0
+```
+
+- [ ] **Run it — fails.** `uv run pytest tests/test_toss_sellable_cache.py -k TossSellableCacheSettings -v`
+  Expected: `AttributeError` — the two fields do not exist on `Settings` yet. (Confirm no clash: `grep -n "sellable_cache" app/core/config.py` returns nothing today.)
+
+- [ ] **Minimal impl — add the fields.** In `app/core/config.py`, immediately after line 248 (`toss_live_order_mutations_enabled: bool = False`), insert:
+```python
+
+    # ROB-701: process-global short-TTL cache for the per-symbol Toss
+    # sellable-quantity fanout on /invest home & account-panel. Collapses
+    # repeated loads to 0 ORDER_INFO (6 TPS) calls within the TTL; a fill
+    # naturally refreshes after ≤ttl (ROB-549 tolerates brief staleness).
+    # enabled=False => cache always misses => today's fanout-every-load.
+    toss_sellable_cache_enabled: bool = True
+    toss_sellable_cache_ttl_seconds: float = 45.0
+```
+
+- [ ] **Run it — passes.** `uv run pytest tests/test_toss_sellable_cache.py -k TossSellableCacheSettings -v` → 2 passed.
+
+- [ ] **Lint.** `make lint`.
+
+- [ ] **Commit.** `git add -A && git commit -m "feat(ROB-701): add toss_sellable_cache_{enabled,ttl_seconds} settings"`
+
+---
+
+## Task 2 — `TossSellableCache` + module singleton (migration-0)
+
+**Files:**
+- Create `app/services/toss_sellable_cache.py`.
+- Test (extend) `tests/test_toss_sellable_cache.py`.
+
+**Interfaces:**
+- `class TossSellableCache` — `__init__(self, *, ttl_seconds: float, now: Callable[[], float] = time.monotonic, enabled: bool = True)`. Methods: `get(symbol: str) -> Decimal | None` (fresh value or `None`; evicts on expiry; always `None` when disabled), `put(symbol: str, value: Decimal) -> None` (stamps `now() + ttl`; no-op when disabled), `clear() -> None`.
+- Module singleton: `def get_shared_sellable_cache() -> TossSellableCache` (built once from `settings.toss_sellable_cache_ttl_seconds` / `..._enabled`), `def reset_shared_sellable_cache() -> None` (test hook — drops the singleton; mirrors `reset_shared_rate_limiter`, `rate_limiter.py:88-91`).
+
+Steps:
+
+- [ ] **Write the failing tests — TTL semantics, disabled no-op, singleton, deterministic clock.** Append to `tests/test_toss_sellable_cache.py`:
+```python
+from decimal import Decimal
+
+from app.services import toss_sellable_cache as sc
+from app.services.toss_sellable_cache import (
+    TossSellableCache,
+    get_shared_sellable_cache,
+    reset_shared_sellable_cache,
+)
+
+
+class _Clock:
+    def __init__(self, t: float = 1000.0) -> None:
+        self.t = t
+
+    def now(self) -> float:
+        return self.t
+
+    def advance(self, dt: float) -> None:
+        self.t += dt
+
+
+@pytest.fixture(autouse=True)
+def _reset_singleton():
+    reset_shared_sellable_cache()
+    yield
+    reset_shared_sellable_cache()
+
+
+class TestTossSellableCache:
+    def test_hit_within_ttl(self):
+        clock = _Clock()
+        cache = TossSellableCache(ttl_seconds=45, now=clock.now)
+        assert cache.get("BRK.B") is None            # cold miss
+        cache.put("BRK.B", Decimal("1.25"))
+        clock.advance(44.9)
+        assert cache.get("BRK.B") == Decimal("1.25")  # still fresh
+
+    def test_miss_after_ttl_expiry(self):
+        clock = _Clock()
+        cache = TossSellableCache(ttl_seconds=45, now=clock.now)
+        cache.put("BRK.B", Decimal("1.25"))
+        clock.advance(45.0)                            # expiry boundary is exclusive
+        assert cache.get("BRK.B") is None
+
+    def test_per_symbol_isolation(self):
+        clock = _Clock()
+        cache = TossSellableCache(ttl_seconds=45, now=clock.now)
+        cache.put("AAA", Decimal("3"))
+        assert cache.get("BBB") is None
+        assert cache.get("AAA") == Decimal("3")
+
+    def test_disabled_is_complete_no_op(self):
+        clock = _Clock()
+        cache = TossSellableCache(ttl_seconds=45, now=clock.now, enabled=False)
+        cache.put("BRK.B", Decimal("1.25"))
+        assert cache.get("BRK.B") is None              # never stores => always miss
+
+
+class TestSingleton:
+    def test_shared_instance(self):
+        assert get_shared_sellable_cache() is get_shared_sellable_cache()
+
+    def test_reset_drops_instance(self):
+        first = get_shared_sellable_cache()
+        reset_shared_sellable_cache()
+        assert get_shared_sellable_cache() is not first
+```
+
+- [ ] **Run it — fails.** `uv run pytest tests/test_toss_sellable_cache.py -v`
+  Expected: `ModuleNotFoundError: app.services.toss_sellable_cache`.
+
+- [ ] **Minimal impl — create the module.** Create `app/services/toss_sellable_cache.py`:
+```python
+"""ROB-701 — process-global short-TTL cache for the Toss per-symbol
+sellable-quantity fanout on /invest home & account-panel.
+
+The Toss ``GET /api/v1/sellable-quantity`` endpoint is in the ORDER_INFO
+rate-limit group (6 TPS / 3 TPS peak), so fanning it out per holding serializes
+to ~N/6 s. This cache collapses repeated /invest loads to 0 calls within the TTL;
+only the invest_home reader opts in (the MCP / sell-classification path stays
+uncached and fresh). enabled=False => always miss => today's fanout-every-load.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable
+from decimal import Decimal
+
+from app.core.config import settings
+
+
+class TossSellableCache:
+    def __init__(
+        self,
+        *,
+        ttl_seconds: float,
+        now: Callable[[], float] = time.monotonic,
+        enabled: bool = True,
+    ) -> None:
+        self._ttl = float(ttl_seconds)
+        self._now = now
+        self._enabled = enabled
+        # symbol -> (expires_at_monotonic, value)
+        self._entries: dict[str, tuple[float, Decimal]] = {}
+
+    def get(self, symbol: str) -> Decimal | None:
+        if not self._enabled:
+            return None
+        entry = self._entries.get(symbol)
+        if entry is None:
+            return None
+        expires_at, value = entry
+        if self._now() >= expires_at:
+            # Expired — evict so the map does not grow unbounded on churn.
+            self._entries.pop(symbol, None)
+            return None
+        return value
+
+    def put(self, symbol: str, value: Decimal) -> None:
+        if not self._enabled:
+            return
+        self._entries[symbol] = (self._now() + self._ttl, value)
+
+    def clear(self) -> None:
+        self._entries.clear()
+
+
+_shared_sellable_cache: TossSellableCache | None = None
+
+
+def get_shared_sellable_cache() -> TossSellableCache:
+    """Process-global cache shared by every /invest reader in the process, so a
+    warm entry from one surface (home) serves the next (account-panel)."""
+    global _shared_sellable_cache
+    if _shared_sellable_cache is None:
+        _shared_sellable_cache = TossSellableCache(
+            ttl_seconds=float(
+                getattr(settings, "toss_sellable_cache_ttl_seconds", 45.0)
+            ),
+            enabled=bool(getattr(settings, "toss_sellable_cache_enabled", True)),
+        )
+    return _shared_sellable_cache
+
+
+def reset_shared_sellable_cache() -> None:
+    """Test hook: drop the process-global cache so suites start clean."""
+    global _shared_sellable_cache
+    _shared_sellable_cache = None
+```
+
+- [ ] **Run it — passes.** `uv run pytest tests/test_toss_sellable_cache.py -v` → all pass.
+
+- [ ] **Lint.** `make lint`.
+
+- [ ] **Commit.** `git add -A && git commit -m "feat(ROB-701): TossSellableCache short-TTL per-symbol cache + module singleton"`
+
+---
+
+## Task 3 — Cache-aware fanout in `fetch_toss_portfolio_snapshot` (migration-0)
+
+**Files:**
+- Modify `app/services/toss_portfolio_service.py` — imports (top, near `:10`); `fetch_toss_portfolio_snapshot` signature (`:131-135`); the `need_sellable` branch **including the shared `errors` accumulator** (`:147-177` — `errors: list[dict[str, Any]] = []` at `:147` through the ROB-685 `else` skip at `:177`). The position-build loop (`:179-213`), cash snapshot (`:215-216`), return (`:218-223`), and `finally` (`:224-226`) stay **unchanged**.
+- Test (modify) `tests/test_toss_portfolio_service.py` — add cache cases beside the existing `_FakeTossClient` (records `sellable_calls`, `:45-64`).
+
+**Interfaces:**
+- Produces `async def fetch_toss_portfolio_snapshot(*, need_sellable: bool = True, sellable_cache: TossSellableCache | None = None, client: TossPortfolioClient | None = None) -> TossPortfolioSnapshot`.
+  - `need_sellable=True, sellable_cache=None` → **today's behavior verbatim** (full fanout, span, zip).
+  - `need_sellable=True, sellable_cache=cache` → fetch `sellable_quantity` **only** for cache-miss symbols; `cache.put` on success (never on exception); re-wrap cache hits as `TossSellableQuantity(sellable_quantity=<cached>)` so the position-build loop is unchanged; the `invest.home.toss_api.sellable_quantity` span is still opened (now with a `cache_miss_count`).
+  - `need_sellable=False` → **today's ROB-685 skip verbatim** (`paired = [(item, None) ...]`), `sellable_cache` ignored.
+- Consumes: `TossPortfolioClient.sellable_quantity(*, symbol)` (misses only), `TossSellableCache.get/put`, `TossSellableQuantity` (`app/services/brokers/toss/dto.py:225-227`).
+
+Steps:
+
+- [ ] **Write the failing tests — cache-hit=0 calls, TTL refetch, accuracy from cache, error-not-cached; defaults locked.** Append to `tests/test_toss_portfolio_service.py` (top imports: add `from app.services.toss_sellable_cache import TossSellableCache`):
+```python
+class _Clock:
+    def __init__(self, t: float = 1000.0) -> None:
+        self.t = t
+
+    def now(self) -> float:
+        return self.t
+
+    def advance(self, dt: float) -> None:
+        self.t += dt
+
+
+@pytest.mark.asyncio
+async def test_snapshot_cache_hit_issues_zero_sellable_calls() -> None:
+    clock = _Clock()
+    cache = TossSellableCache(ttl_seconds=45, now=clock.now)
+    client = _FakeTossClient()
+
+    # Cold load: miss on every symbol => one fanout, cache populated.
+    snap1 = await fetch_toss_portfolio_snapshot(
+        client=client, need_sellable=True, sellable_cache=cache
+    )
+    assert client.sellable_calls == ["BRK.B"]
+    assert snap1.positions[0].sellable_quantity == Decimal("1.25")
+
+    # Warm load within TTL: ZERO new sellable calls, value served from cache.
+    snap2 = await fetch_toss_portfolio_snapshot(
+        client=client, need_sellable=True, sellable_cache=cache
+    )
+    assert client.sellable_calls == ["BRK.B"]  # unchanged => cache hit
+    assert snap2.positions[0].sellable_quantity == Decimal("1.25")  # accuracy preserved
+
+
+@pytest.mark.asyncio
+async def test_snapshot_cache_refetches_after_ttl_expiry() -> None:
+    clock = _Clock()
+    cache = TossSellableCache(ttl_seconds=45, now=clock.now)
+    client = _FakeTossClient()
+
+    await fetch_toss_portfolio_snapshot(
+        client=client, need_sellable=True, sellable_cache=cache
+    )
+    clock.advance(45.0)  # TTL boundary is exclusive => expired
+    await fetch_toss_portfolio_snapshot(
+        client=client, need_sellable=True, sellable_cache=cache
+    )
+    assert client.sellable_calls == ["BRK.B", "BRK.B"]  # refetched after expiry
+
+
+@pytest.mark.asyncio
+async def test_snapshot_cache_does_not_store_failed_fetch() -> None:
+    class ErrClient(_FakeTossClient):
+        async def sellable_quantity(self, *, symbol: str):
+            self.sellable_calls.append(symbol)
+            raise RuntimeError(f"boom {symbol}")
+
+    clock = _Clock()
+    cache = TossSellableCache(ttl_seconds=45, now=clock.now)
+    client = ErrClient()
+
+    snap1 = await fetch_toss_portfolio_snapshot(
+        client=client, need_sellable=True, sellable_cache=cache
+    )
+    assert snap1.positions[0].sellable_quantity is None
+    assert snap1.errors[0]["stage"] == "sellable_quantity"
+
+    # Error was NOT cached => next load within TTL retries the fetch.
+    await fetch_toss_portfolio_snapshot(
+        client=client, need_sellable=True, sellable_cache=cache
+    )
+    assert client.sellable_calls == ["BRK.B", "BRK.B"]
+
+
+@pytest.mark.asyncio
+async def test_snapshot_no_cache_default_still_fans_out() -> None:
+    client = _FakeTossClient()
+    # sellable_cache defaults to None => today's fanout path, unchanged.
+    await fetch_toss_portfolio_snapshot(client=client, need_sellable=True)
+    await fetch_toss_portfolio_snapshot(client=client, need_sellable=True)
+    assert client.sellable_calls == ["BRK.B", "BRK.B"]
+
+
+@pytest.mark.asyncio
+async def test_snapshot_need_sellable_false_ignores_cache() -> None:
+    clock = _Clock()
+    cache = TossSellableCache(ttl_seconds=45, now=clock.now)
+    client = _FakeTossClient()
+    snap = await fetch_toss_portfolio_snapshot(
+        client=client, need_sellable=False, sellable_cache=cache
+    )
+    # ROB-685 skip path is untouched: no fanout, no cache read/write.
+    assert client.sellable_calls == []
+    assert snap.positions[0].sellable_quantity is None
+```
+
+- [ ] **Run it — fails.** `uv run pytest tests/test_toss_portfolio_service.py -v -k "cache"`
+  Expected: the **four** tests that pass `sellable_cache=` (`..._cache_hit_issues_zero_sellable_calls`, `..._cache_refetches_after_ttl_expiry`, `..._cache_does_not_store_failed_fetch`, `..._need_sellable_false_ignores_cache`) FAIL — `fetch_toss_portfolio_snapshot` has no `sellable_cache` kwarg (`TypeError: unexpected keyword argument`). `test_snapshot_no_cache_default_still_fans_out` does **not** pass `sellable_cache`, so it PASSES today (it is a regression-lock for the unchanged default fanout and keeps passing after impl). After impl all five pass and the last four lock the new/unchanged paths.
+
+- [ ] **Minimal impl — signature + imports.** In `app/services/toss_portfolio_service.py`, add near the existing imports (`:10`):
+```python
+from app.services.brokers.toss.dto import TossSellableQuantity
+from app.services.toss_sellable_cache import TossSellableCache
+```
+Change the signature at `:131-135`:
+```python
+async def fetch_toss_portfolio_snapshot(
+    *,
+    need_sellable: bool = True,
+    sellable_cache: TossSellableCache | None = None,
+    client: TossPortfolioClient | None = None,
+) -> TossPortfolioSnapshot:
+```
+
+- [ ] **Minimal impl — cache-aware branch.** Replace `:147-177` — the shared `errors: list[dict[str, Any]] = []` accumulator at `:147` **through** the ROB-685 `else` skip at `:177` — with the three-way branch below. The block's leading `errors: list[dict[str, Any]] = []` line **is that same single declaration** (do NOT leave the original `:147` line in place, or you will declare `errors` twice). Keep the existing `need_sellable`-no-cache branch and the `else` (ROB-685 skip) **byte-for-byte**; insert the new cache branch first:
+```python
+        errors: list[dict[str, Any]] = []
+
+        if need_sellable and sellable_cache is not None:
+            # ROB-701: only cache-MISS symbols hit the ORDER_INFO (6 TPS)
+            # /sellable-quantity endpoint; hits reuse the cached value. Re-wrap
+            # hits as TossSellableQuantity so the position-build loop below is
+            # unchanged.
+            hits: list[Decimal | None] = [
+                sellable_cache.get(item.symbol) for item in holdings.items
+            ]
+            miss_indices = [i for i, hit in enumerate(hits) if hit is None]
+            with sentry_sdk.start_span(
+                op="invest.home.toss_api.phase",
+                name="invest.home.toss_api.sellable_quantity",
+            ) as span:
+                span.set_data("position_count", len(holdings.items))
+                span.set_data("cache_miss_count", len(miss_indices))
+                fetched = await asyncio.gather(
+                    *[
+                        active_client.sellable_quantity(
+                            symbol=holdings.items[i].symbol
+                        )
+                        for i in miss_indices
+                    ],
+                    return_exceptions=True,
+                )
+                span.set_data(
+                    "error_count",
+                    sum(1 for result in fetched if isinstance(result, BaseException)),
+                )
+            fetched_by_index: dict[int, Any] = dict(
+                zip(miss_indices, fetched, strict=True)
+            )
+            for index, result in fetched_by_index.items():
+                if not isinstance(result, BaseException):
+                    # Cache ONLY successful fetches — a transient error must not
+                    # poison the cache (next load retries).
+                    sellable_cache.put(
+                        holdings.items[index].symbol, result.sellable_quantity
+                    )
+            paired: list[tuple[Any, Any]] = []
+            for index, item in enumerate(holdings.items):
+                if index in fetched_by_index:
+                    paired.append((item, fetched_by_index[index]))
+                else:
+                    paired.append(
+                        (item, TossSellableQuantity(sellable_quantity=hits[index]))
+                    )
+        elif need_sellable:
+            with sentry_sdk.start_span(
+                op="invest.home.toss_api.phase",
+                name="invest.home.toss_api.sellable_quantity",
+            ) as span:
+                span.set_data("position_count", len(holdings.items))
+                sellable_results = await asyncio.gather(
+                    *[
+                        active_client.sellable_quantity(symbol=item.symbol)
+                        for item in holdings.items
+                    ],
+                    return_exceptions=True,
+                )
+                span.set_data(
+                    "error_count",
+                    sum(
+                        1
+                        for result in sellable_results
+                        if isinstance(result, BaseException)
+                    ),
+                )
+            paired = list(zip(holdings.items, sellable_results, strict=True))
+        else:
+            # ROB-685: caller does not consume sellable_quantity — skip the
+            # per-holding GET /sellable-quantity (ORDER_INFO, 6 TPS) fanout that
+            # otherwise serializes to ~6/sec and dominates wall time.
+            paired = [(item, None) for item in holdings.items]
+```
+(The `positions` build loop, cash snapshot, return, and `finally` are left exactly as-is at `:179-226`. Note `paired` is first annotated in the cache branch; the `elif`/`else` reuse the same name — matching how the current code names it at `:170`.)
+
+- [ ] **Run it — passes.** `uv run pytest tests/test_toss_portfolio_service.py -v` → all pass (5 new cache cases + the 6 pre-existing cases incl. `..._keeps_position_when_sellable_fails` and `..._skips_sellable_when_not_needed`, both untouched).
+
+- [ ] **Regression — phase-span + reader suites unaffected by the no-cache default.** `uv run pytest tests/test_invest_home_readers.py -v -k "toss"`
+  Expected: `test_toss_portfolio_snapshot_emits_phase_spans` (`:1712`) still asserts `invest.home.toss_api.sellable_quantity in started` — it calls the service with `client=...` and **no** cache, hitting the unchanged `elif need_sellable` branch. The 3 `test_toss_api_home_reader_*` fakes still pass (Task 4 not yet applied; the reader still calls with no `sellable_cache`).
+
+- [ ] **Lint.** `make lint`.
+
+- [ ] **Commit.** `git add -A && git commit -m "perf(ROB-701): fetch_toss_portfolio_snapshot cache-aware sellable fanout (miss-only) when sellable_cache passed"`
+
+---
+
+## Task 4 — invest_home reader passes the shared cache when mutations armed (migration-0)
+
+**Files:**
+- Modify `app/services/invest_home_readers.py` — import `get_shared_sellable_cache` (near `:39`, the existing `fetch_toss_portfolio_snapshot` import); `TossApiHomeReader.fetch` snapshot call at `:554-556`.
+- Test (modify) `tests/test_invest_home_readers.py` — add an assertion test AND update the 4 existing Toss-reader fakes (`fake_fetch_toss_snapshot` at `:1523`, `:1587`, `:1635`, `:1691`) to accept the new `sellable_cache` kwarg.
+
+**Interfaces:**
+- Consumes: `mutations_enabled` (already computed at `invest_home_readers.py:547-549`) and `get_shared_sellable_cache()`.
+- Produces: the sole `fetch_toss_portfolio_snapshot(...)` call at `:554-556` becomes:
+```python
+                snapshot = await fetch_toss_portfolio_snapshot(
+                    need_sellable=mutations_enabled,
+                    sellable_cache=(
+                        get_shared_sellable_cache() if mutations_enabled else None
+                    ),
+                )
+```
+  When mutations off (default): `need_sellable=False`, `sellable_cache=None` → ROB-685 skip, no cache. When mutations on (prod): `need_sellable=True`, `sellable_cache=<shared>` → cache-aware fanout; the reader still collapses toss sellable via `_toss_sellable_quantity(position, mutations_enabled)` (`:516-524`) so display output is unchanged aside from ≤TTL staleness.
+
+Steps:
+
+- [ ] **Write the failing test — reader passes a cache iff mutations armed.** Add to `tests/test_invest_home_readers.py`:
+```python
+@pytest.mark.asyncio
+@pytest.mark.unit
+@pytest.mark.parametrize("mutations", [False, True])
+async def test_toss_api_home_reader_passes_sellable_cache_when_mutations_on(
+    monkeypatch, mutations
+):
+    from decimal import Decimal
+
+    from app.core.config import settings as _cfg
+    from app.services import invest_home_readers as readers
+    from app.services.toss_portfolio_service import TossPortfolioSnapshot
+    from app.services.toss_sellable_cache import TossSellableCache
+
+    captured: dict[str, object] = {}
+
+    async def fake_fetch_toss_snapshot(*, need_sellable=True, sellable_cache=None):
+        captured["need_sellable"] = need_sellable
+        captured["sellable_cache"] = sellable_cache
+        return TossPortfolioSnapshot(
+            positions=[], cash_krw=Decimal("1"), cash_usd=Decimal("1")
+        )
+
+    monkeypatch.setattr(
+        readers, "fetch_toss_portfolio_snapshot", fake_fetch_toss_snapshot
+    )
+    monkeypatch.setattr(
+        _cfg, "toss_live_order_mutations_enabled", mutations, raising=False
+    )
+
+    await readers.TossApiHomeReader().fetch(user_id=1)
+
+    if mutations:
+        # mutations armed => cache is threaded so repeated loads reuse it.
+        assert isinstance(captured["sellable_cache"], TossSellableCache)
+        assert captured["need_sellable"] is True
+    else:
+        # mutations off => ROB-685 skip, no cache needed.
+        assert captured["sellable_cache"] is None
+        assert captured["need_sellable"] is False
+```
+
+- [ ] **Run it — fails.** `uv run pytest tests/test_invest_home_readers.py -v -k "passes_sellable_cache"`
+  Expected: FAILS — today `TossApiHomeReader.fetch` calls `fetch_toss_portfolio_snapshot(need_sellable=mutations_enabled)` with no `sellable_cache`, so the fake never receives it and (once the fake accepts the kwarg) `captured["sellable_cache"]` is always `None`; the `mutations=True` case fails the `isinstance(..., TossSellableCache)` assert.
+
+- [ ] **Minimal impl — import + thread the cache.** In `app/services/invest_home_readers.py`, add next to the `:39` import:
+```python
+from app.services.toss_sellable_cache import get_shared_sellable_cache
+```
+Change the fetch at `:554-556`:
+```python
+                snapshot = await fetch_toss_portfolio_snapshot(
+                    need_sellable=mutations_enabled,
+                    sellable_cache=(
+                        get_shared_sellable_cache() if mutations_enabled else None
+                    ),
+                )
+```
+(No other reader logic changes — `_toss_sellable_quantity` / `_toss_pending_sell_quantity` already gate on `mutations_enabled` at `:516-533`.)
+
+- [ ] **Update the 4 existing Toss-reader fakes to accept the kwarg.** In `tests/test_invest_home_readers.py`, change each `async def fake_fetch_toss_snapshot(*, need_sellable: bool = True):` (at `:1523`, `:1587`, `:1635`, and the gating test's at `:1691`) to `async def fake_fetch_toss_snapshot(*, need_sellable: bool = True, sellable_cache=None):`. Behavior is unchanged; this keeps them call-compatible with the new keyword. (The phase-span test at `:1712` calls the real service with `client=...` and no cache, so it is unaffected.)
+
+- [ ] **Run it — passes.** `uv run pytest tests/test_invest_home_readers.py -v -k "toss"` → all pass (new cache-threading test both params + the updated 4 fakes + gating test + phase-span test).
+
+- [ ] **Regression — full reader suite + service + cache.** `uv run pytest tests/test_invest_home_readers.py tests/test_toss_portfolio_service.py tests/test_toss_sellable_cache.py -q` → no failures.
+
+- [ ] **Lint.** `make lint`.
+
+- [ ] **Commit.** `git add -A && git commit -m "perf(ROB-701): invest_home toss reader threads shared sellable cache when mutations armed"`
+
+---
+
+## Done criteria
+
+- Repeated `/invest` home / account-panel loads (mutations armed) issue **0** `GET /sellable-quantity` calls within the cache TTL — the first load pays one bounded fanout, later loads hit the cache. Proven by `test_snapshot_cache_hit_issues_zero_sellable_calls`.
+- TTL expiry refetches (`test_snapshot_cache_refetches_after_ttl_expiry`); a failed fetch is never cached (`test_snapshot_cache_does_not_store_failed_fetch`).
+- Accuracy preserved: `TossPortfolioPosition.sellable_quantity` (→ `Holding.sellableQuantity`) equals the source value, with ≤TTL staleness. ROB-549 display + `_toss_sellable_quantity` gating unchanged.
+- The ROB-685 `need_sellable=False` fast path is byte-for-byte unchanged (`test_snapshot_need_sellable_false_ignores_cache`, plus the pre-existing skip test).
+- The default no-cache path (`sellable_cache=None`) — every MCP / sell-classification consumer — fans out exactly as today (`test_snapshot_no_cache_default_still_fans_out`); `sellable_quantity()` semantics and the `ORDER_INFO` 6-TPS group are untouched.
+- `make lint` clean; no alembic revision added (migration-0).

--- a/docs/runbooks/kis-circuit-breaker.md
+++ b/docs/runbooks/kis-circuit-breaker.md
@@ -1,14 +1,19 @@
-# KIS Client Circuit Breaker (ROB-699)
+# KIS Client Circuit Breaker (ROB-699 + ROB-700)
 
 ## What it does
 
-A per-process, in-process circuit breaker guards the single KIS HTTP dispatch
-seam (`BaseKISClient._request_with_rate_limit_with_headers`,
-`app/services/brokers/kis/base.py`). When the KIS host is unreachable (e.g. a
-maintenance window), the breaker opens after N consecutive transport
-connect-failures and fails fast with `KISCircuitOpen` — **zero HTTP call, zero
-rate-limit wait** — instead of every KIS-dependent `/invest` reader burning the
-full connect-timeout × retries on every request.
+A per-process, in-process circuit breaker guards **two** KIS HTTP seams,
+sharing the **one** module singleton:
+- the data dispatch (`BaseKISClient._request_with_rate_limit_with_headers`,
+  `app/services/brokers/kis/base.py`) — ROB-699.
+- the OAuth token POST (`BaseKISClient._fetch_token`,
+  `app/services/brokers/kis/base.py`) — ROB-700.
+
+When the KIS host is unreachable (e.g. a maintenance window), the breaker
+opens after N consecutive transport connect-failures on *either* seam and
+fails fast with `KISCircuitOpen` — **zero HTTP call, zero rate-limit wait** —
+instead of every KIS-dependent `/invest` reader burning the full
+connect-timeout × retries on every request.
 
 `KISCircuitOpen` is a plain `Exception` subclass, so it propagates through the
 **existing** broad `except Exception` fallbacks with no new wiring:
@@ -19,6 +24,29 @@ full connect-timeout × retries on every request.
 When KIS is healthy the breaker stays closed and is a pure passthrough — this
 change does not alter any broker mutation logic, retry classification, or
 response parsing.
+
+## Why the token fetch is also guarded (ROB-700)
+
+Live measurement during the 2026-07-04 KIS maintenance window proved the
+ROB-699 data-dispatch guard **never opened**: 0 circuit-breaker log lines. The
+only KIS HTTP calls made were `POST /oauth2/token` (half of them connect-timing
+out at ~5s) — **zero** data calls (`dailyprice`/`inquire-price`/
+`inquire-balance`) were ever attempted. The reason: `_fetch_token` called
+`httpx` directly, bypassing the breaker entirely, and the token fetch
+connect-times-out *first*, so no token is ever obtained, so no data call is
+ever dispatched, so the data-dispatch guard never sees a failure to record.
+
+ROB-700 closes this gap by guarding `_fetch_token`'s network POST with the
+**same** singleton: N consecutive **token** connect-failures now open the
+breaker, after which both the token fetch and the data dispatch fail-fast with
+`KISCircuitOpen`. The data-dispatch gate fail-fasts in ~0ms; the open-breaker
+token fetch fail-fasts inside `_fetch_token`, but the call still runs *inside*
+the token single-flight (`refresh_token_with_lock`), so on an empty token
+cache it still pays the single-flight's pre-lock cache double-checks (~100ms —
+2× `asyncio.sleep(0.05)` + a few Redis round-trips), never the full 5s connect
+wait. Either way, `/invest` KIS readers hit their existing Toss fallback /
+warning promptly instead of every reader independently burning the connect
+timeout.
 
 ## What trips it
 
@@ -75,9 +103,11 @@ with zero deploy.
 
 Set `KIS_CIRCUIT_BREAKER_ENABLED=false` and restart the process (or, in a
 context where settings are mutated at runtime, flip the flag directly). With
-the flag off, `before_request()` / `record_*()` are complete no-ops — every
-call passes straight through to the unmodified retry/rate-limit dispatch,
-byte-identical to pre-ROB-699 behavior.
+the flag off, `before_request()` / `record_*()` are complete no-ops on **both**
+guarded seams — every data call passes straight through to the unmodified
+retry/rate-limit dispatch, and every token fetch passes straight through to
+the unmodified `_fetch_token` network POST, byte-identical to pre-ROB-699/
+pre-ROB-700 behavior.
 
 ## Observability — log lines to grep
 
@@ -96,9 +126,19 @@ byte-identical to pre-ROB-699 behavior.
   KIS outage will also fail-fast KIS-mock calls in the same process, and vice
   versa. During real KIS maintenance both hosts are typically down together;
   revisit only if false-coupling is observed in practice.
-- **The OAuth token endpoint is not breaker-guarded.** `/oauth2/token` is a
-  different host path, and the Redis-cached token means the hot price/order
-  path does not hit it on every call.
+- **The OAuth token POST is breaker-guarded (ROB-700).** `_fetch_token`'s
+  network POST shares the same singleton as the data dispatch — see "Why the
+  token fetch is also guarded" above. The **cached-token fast path is
+  byte-identical**: a cache hit in `_ensure_token` never calls `_fetch_token`,
+  so the breaker is never touched on the hot, Redis-cached-token path. The
+  token **single-flight / Redis-cache semantics are unchanged** — the breaker
+  check is per-attempt, inside `_fetch_token`, before the POST, so
+  `refresh_token_with_lock` still collapses a concurrent `/invest` burst into
+  exactly one fetch attempt. **401 / invalid-key / non-JSON** token responses
+  are *reachable* (KIS responded) and do **not** trip the breaker — only
+  transport connect/read-hang failures do. Because token and data share one
+  singleton, a token success (or a reachable non-2xx) resets the failure count
+  for both surfaces, and vice versa.
 - **First post-outage load still pays the full timeout.** A single `/invest`
   load fires many KIS calls concurrently; they all pass the closed-breaker gate
   before the Nth failure opens it, so the *first* load after an outage begins

--- a/tests/test_invest_home_readers.py
+++ b/tests/test_invest_home_readers.py
@@ -1520,7 +1520,9 @@ async def test_toss_api_home_reader_maps_read_only_holdings_and_cash(monkeypatch
         TossPortfolioSnapshot,
     )
 
-    async def fake_fetch_toss_snapshot(*, need_sellable: bool = True):
+    async def fake_fetch_toss_snapshot(
+        *, need_sellable: bool = True, sellable_cache=None
+    ):
         return TossPortfolioSnapshot(
             positions=[
                 TossPortfolioPosition(
@@ -1584,7 +1586,9 @@ async def test_toss_api_home_reader_tradeable_when_mutations_enabled(monkeypatch
         TossPortfolioSnapshot,
     )
 
-    async def fake_fetch_toss_snapshot(*, need_sellable: bool = True):
+    async def fake_fetch_toss_snapshot(
+        *, need_sellable: bool = True, sellable_cache=None
+    ):
         return TossPortfolioSnapshot(
             positions=[
                 TossPortfolioPosition(
@@ -1632,7 +1636,9 @@ async def test_toss_api_home_reader_converts_us_holdings_to_krw(monkeypatch):
         TossPortfolioSnapshot,
     )
 
-    async def fake_fetch_toss_snapshot(*, need_sellable: bool = True):
+    async def fake_fetch_toss_snapshot(
+        *, need_sellable: bool = True, sellable_cache=None
+    ):
         return TossPortfolioSnapshot(
             positions=[
                 TossPortfolioPosition(
@@ -1688,7 +1694,9 @@ async def test_toss_api_home_reader_gates_sellable_fetch_on_mutations(
 
     captured: dict[str, bool] = {}
 
-    async def fake_fetch_toss_snapshot(*, need_sellable: bool = True):
+    async def fake_fetch_toss_snapshot(
+        *, need_sellable: bool = True, sellable_cache=None
+    ):
         captured["need_sellable"] = need_sellable
         return TossPortfolioSnapshot(
             positions=[], cash_krw=Decimal("1"), cash_usd=Decimal("1")
@@ -1705,6 +1713,47 @@ async def test_toss_api_home_reader_gates_sellable_fetch_on_mutations(
 
     # ROB-685: mutations off (default) => reader discards sellable anyway => skip fetch.
     assert captured["need_sellable"] is expected_need
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+@pytest.mark.parametrize("mutations", [False, True])
+async def test_toss_api_home_reader_passes_sellable_cache_when_mutations_on(
+    monkeypatch, mutations
+):
+    from decimal import Decimal
+
+    from app.core.config import settings as _cfg
+    from app.services import invest_home_readers as readers
+    from app.services.toss_portfolio_service import TossPortfolioSnapshot
+    from app.services.toss_sellable_cache import TossSellableCache
+
+    captured: dict[str, object] = {}
+
+    async def fake_fetch_toss_snapshot(*, need_sellable=True, sellable_cache=None):
+        captured["need_sellable"] = need_sellable
+        captured["sellable_cache"] = sellable_cache
+        return TossPortfolioSnapshot(
+            positions=[], cash_krw=Decimal("1"), cash_usd=Decimal("1")
+        )
+
+    monkeypatch.setattr(
+        readers, "fetch_toss_portfolio_snapshot", fake_fetch_toss_snapshot
+    )
+    monkeypatch.setattr(
+        _cfg, "toss_live_order_mutations_enabled", mutations, raising=False
+    )
+
+    await readers.TossApiHomeReader().fetch(user_id=1)
+
+    if mutations:
+        # mutations armed => cache is threaded so repeated loads reuse it.
+        assert isinstance(captured["sellable_cache"], TossSellableCache)
+        assert captured["need_sellable"] is True
+    else:
+        # mutations off => ROB-685 skip, no cache needed.
+        assert captured["sellable_cache"] is None
+        assert captured["need_sellable"] is False
 
 
 @pytest.mark.asyncio

--- a/tests/test_kis_token_circuit_breaker.py
+++ b/tests/test_kis_token_circuit_breaker.py
@@ -1,0 +1,227 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+
+from app.services.brokers.kis import circuit_breaker as cb
+from app.services.brokers.kis.base import BaseKISClient
+from app.services.brokers.kis.circuit_breaker import KISCircuitBreaker, KISCircuitOpen
+
+pytestmark = pytest.mark.unit
+
+
+class _Clock:
+    def __init__(self, t: float = 1000.0) -> None:
+        self.t = t
+
+    def now(self) -> float:
+        return self.t
+
+    def advance(self, dt: float) -> None:
+        self.t += dt
+
+
+class _FakeSettings:
+    def __init__(self) -> None:
+        self.kis_app_key = "key"
+        self.kis_app_secret = "secret"
+        self.kis_access_token = "token"
+        self.kis_base_url = "https://openapi.koreainvestment.com:9443"
+
+
+class _FakeClient(BaseKISClient):
+    def __init__(self) -> None:  # type: ignore[override]
+        type(self)._shared_client_lock = None
+        self._fake_settings = _FakeSettings()
+
+    @property  # type: ignore[override]
+    def _settings(self):  # type: ignore[override]
+        return self._fake_settings
+
+
+class _BreakerSettings:
+    kis_circuit_breaker_enabled = True
+    kis_circuit_breaker_failure_threshold = 3
+    kis_circuit_breaker_cooldown_seconds = 45
+
+
+@pytest.fixture
+def clock():
+    return _Clock()
+
+
+@pytest.fixture(autouse=True)
+def _install_breaker(clock):
+    # Inject a deterministic-clock, ENABLED breaker as THE process singleton.
+    # (conftest._isolate_kis_circuit_breaker disables the GLOBAL settings flag,
+    # but this breaker reads its own settings_obj, so it stays enabled here.)
+    cb._breaker = KISCircuitBreaker(now=clock.now, settings_obj=_BreakerSettings())
+    yield
+    cb.reset_kis_circuit_breaker()
+
+
+def _client_with_post(post):
+    client = _FakeClient()
+    fake_http = MagicMock()
+    fake_http.post = post
+    client._ensure_client = AsyncMock(return_value=fake_http)  # type: ignore[method-assign]
+    return client
+
+
+def _json_response(payload):
+    r = MagicMock()
+    r.json.return_value = payload
+    return r
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "exc",
+    [
+        httpx.ConnectTimeout(""),
+        httpx.ConnectError(""),
+        httpx.PoolTimeout(""),
+        httpx.ReadTimeout(""),
+        ConnectionRefusedError(),
+    ],
+)
+async def test_token_connect_failures_open_breaker(exc):
+    post = AsyncMock(side_effect=exc)
+    client = _client_with_post(post)
+    for _ in range(3):  # threshold
+        with pytest.raises(type(exc)):
+            await client._fetch_token()
+    assert cb.get_kis_circuit_breaker().state == "open"
+
+
+@pytest.mark.asyncio
+async def test_open_breaker_token_fetch_zero_http():
+    post = AsyncMock(side_effect=httpx.ConnectError(""))
+    client = _client_with_post(post)
+    for _ in range(3):
+        with pytest.raises(httpx.ConnectError):
+            await client._fetch_token()
+    assert cb.get_kis_circuit_breaker().state == "open"
+    post.reset_mock()
+    client._ensure_client.reset_mock()
+    with pytest.raises(KISCircuitOpen):
+        await client._fetch_token()
+    post.assert_not_awaited()  # ZERO HTTP
+    client._ensure_client.assert_not_awaited()  # not even the client build
+
+
+@pytest.mark.asyncio
+async def test_token_401_invalid_key_does_not_open():
+    # KIS responded with an error body lacking access_token -> KeyError (reachable).
+    post = AsyncMock(return_value=_json_response({"error": "invalid_client"}))
+    client = _client_with_post(post)
+    for _ in range(6):  # well past threshold
+        with pytest.raises(KeyError):
+            await client._fetch_token()
+    assert cb.get_kis_circuit_breaker().state == "closed"
+    assert cb.get_kis_circuit_breaker().failure_count == 0
+
+
+@pytest.mark.asyncio
+async def test_token_non_json_body_does_not_open():
+    r = MagicMock()
+    r.json.side_effect = ValueError("not json")
+    post = AsyncMock(return_value=r)
+    client = _client_with_post(post)
+    for _ in range(6):
+        with pytest.raises(ValueError):
+            await client._fetch_token()
+    assert cb.get_kis_circuit_breaker().state == "closed"
+
+
+@pytest.mark.asyncio
+async def test_token_success_returns_and_keeps_closed():
+    post = AsyncMock(
+        return_value=_json_response({"access_token": "T", "expires_in": 100})
+    )
+    client = _client_with_post(post)
+    token, expires = await client._fetch_token()
+    assert token == "T"
+    assert expires == 100
+    assert cb.get_kis_circuit_breaker().state == "closed"
+
+
+@pytest.mark.asyncio
+async def test_token_success_after_failures_resets_count():
+    post = AsyncMock(
+        side_effect=[
+            httpx.ConnectTimeout(""),
+            httpx.ConnectTimeout(""),
+            _json_response({"access_token": "T", "expires_in": 100}),
+        ]
+    )
+    client = _client_with_post(post)
+    for _ in range(2):
+        with pytest.raises(httpx.ConnectTimeout):
+            await client._fetch_token()
+    assert cb.get_kis_circuit_breaker().failure_count == 2
+    await client._fetch_token()  # success resets the counter
+    assert cb.get_kis_circuit_breaker().failure_count == 0
+    assert cb.get_kis_circuit_breaker().state == "closed"
+
+
+@pytest.mark.asyncio
+async def test_disabled_flag_token_passthrough():
+    class _Disabled(_BreakerSettings):
+        kis_circuit_breaker_enabled = False
+
+    cb._breaker = KISCircuitBreaker(settings_obj=_Disabled())
+    post = AsyncMock(side_effect=httpx.ConnectTimeout(""))
+    client = _client_with_post(post)
+    for _ in range(10):
+        with pytest.raises(httpx.ConnectTimeout):
+            await client._fetch_token()
+    # never opens; every call still reached the network (passthrough)
+    assert cb.get_kis_circuit_breaker().state == "closed"
+    assert post.await_count == 10
+
+
+@pytest.mark.asyncio
+async def test_half_open_probe_stampede_does_not_close(clock):
+    # Locks "before_request() OUTSIDE the classify try/except": once a half-open
+    # probe is in flight, a stampede caller must raise KISCircuitOpen WITHOUT
+    # that raise being reclassified reachable (which would wrongly close the
+    # still-probing circuit).
+    post = AsyncMock(side_effect=httpx.ConnectTimeout(""))
+    client = _client_with_post(post)
+    for _ in range(3):
+        with pytest.raises(httpx.ConnectTimeout):
+            await client._fetch_token()
+    breaker = cb.get_kis_circuit_breaker()
+    assert breaker.state == "open"
+    clock.advance(45)
+    breaker.before_request()  # hands out THE probe -> half_open, in flight
+    assert breaker.state == "half_open"
+    with pytest.raises(KISCircuitOpen):
+        await client._fetch_token()  # stampede caller: must fail-fast
+    assert breaker.state == "half_open"  # still probing, NOT closed
+
+
+@pytest.mark.asyncio
+async def test_cached_token_path_no_breaker_involvement():
+    # _ensure_token cache-hit must be byte-identical: _fetch_token never called,
+    # breaker never touched (a pre-loaded failure count is preserved).
+    breaker = cb.get_kis_circuit_breaker()
+    breaker.record_failure()
+    breaker.record_failure()
+    assert breaker.failure_count == 2
+
+    client = _FakeClient()
+    client._token_manager = MagicMock()
+    client._token_manager.get_token = AsyncMock(return_value="cached-tok")
+    client._fetch_token = AsyncMock(  # type: ignore[method-assign]
+        side_effect=AssertionError("cache hit must not fetch")
+    )
+
+    await client._ensure_token()
+    assert client._settings.kis_access_token == "cached-tok"
+    client._fetch_token.assert_not_awaited()
+    assert breaker.failure_count == 2  # untouched
+    assert breaker.state == "closed"

--- a/tests/test_kis_token_circuit_open_propagation.py
+++ b/tests/test_kis_token_circuit_open_propagation.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+
+from app.services.brokers.kis import circuit_breaker as cb
+from app.services.brokers.kis.base import BaseKISClient
+from app.services.brokers.kis.circuit_breaker import KISCircuitBreaker, KISCircuitOpen
+from app.services.redis_token_manager import RedisTokenManager
+
+pytestmark = [pytest.mark.unit, pytest.mark.asyncio]
+
+
+class _FakeSettings:
+    def __init__(self) -> None:
+        self.kis_app_key = "key"
+        self.kis_app_secret = "secret"
+        self.kis_access_token = "token"
+        self.kis_base_url = "https://openapi.koreainvestment.com:9443"
+
+
+class _FakeClient(BaseKISClient):
+    def __init__(self) -> None:  # type: ignore[override]
+        type(self)._shared_client_lock = None
+        self._fake_settings = _FakeSettings()
+
+    @property  # type: ignore[override]
+    def _settings(self):  # type: ignore[override]
+        return self._fake_settings
+
+
+class _EnabledBreakerSettings:
+    kis_circuit_breaker_enabled = True
+    kis_circuit_breaker_failure_threshold = 1  # 1 failure -> open
+    kis_circuit_breaker_cooldown_seconds = 45
+
+
+@pytest.fixture(autouse=True)
+def _install_breaker():
+    cb._breaker = KISCircuitBreaker(settings_obj=_EnabledBreakerSettings())
+    yield
+    cb.reset_kis_circuit_breaker()
+
+
+async def test_refresh_token_with_lock_reraises_circuit_open_and_releases_lock(
+    monkeypatch,
+):
+    # The token single-flight must NOT swallow KISCircuitOpen and must still
+    # release the distributed lock. Stub the cache/lock probes so the real
+    # try/finally body runs with no real sleep / no real Redis.
+    monkeypatch.setattr("app.services.redis_token_manager.asyncio.sleep", AsyncMock())
+    manager = RedisTokenManager()
+    manager.get_token = AsyncMock(return_value=None)  # type: ignore[method-assign]
+    manager._acquire_lock = AsyncMock(return_value=True)  # type: ignore[method-assign]
+    manager._release_lock = AsyncMock()  # type: ignore[method-assign]
+    manager.save_token = AsyncMock()  # type: ignore[method-assign]
+
+    fetcher = AsyncMock(side_effect=KISCircuitOpen(45.0))
+
+    with pytest.raises(KISCircuitOpen):
+        await manager.refresh_token_with_lock(fetcher)
+
+    fetcher.assert_awaited_once()  # single-flight: exactly one fetch attempt
+    manager._release_lock.assert_awaited()  # lock released on the error path
+    manager.save_token.assert_not_awaited()  # no token persisted on failure
+
+
+async def test_open_breaker_ensure_token_fails_fast_zero_http(monkeypatch):
+    # End-to-end: open breaker -> _ensure_token (cache miss) -> single-flight ->
+    # _fetch_token.before_request() -> KISCircuitOpen, with ZERO token POST.
+    monkeypatch.setattr("app.services.redis_token_manager.asyncio.sleep", AsyncMock())
+    breaker = cb.get_kis_circuit_breaker()
+    breaker.record_failure()  # threshold=1 -> OPEN
+    assert breaker.state == "open"
+
+    manager = RedisTokenManager()
+    manager.get_token = AsyncMock(return_value=None)  # cache miss everywhere
+    manager._acquire_lock = AsyncMock(return_value=True)
+    manager._release_lock = AsyncMock()
+    manager.save_token = AsyncMock()
+
+    client = _FakeClient()
+    client._token_manager = manager
+    post = AsyncMock(side_effect=httpx.ConnectTimeout(""))
+    fake_http = MagicMock()
+    fake_http.post = post
+    client._ensure_client = AsyncMock(return_value=fake_http)  # type: ignore[method-assign]
+
+    with pytest.raises(KISCircuitOpen):
+        await client._ensure_token()
+
+    post.assert_not_awaited()  # ZERO token HTTP — failed fast at before_request
+    client._ensure_client.assert_not_awaited()
+    manager._release_lock.assert_awaited()  # single-flight lock still released

--- a/tests/test_toss_portfolio_service.py
+++ b/tests/test_toss_portfolio_service.py
@@ -14,6 +14,7 @@ from app.services.toss_portfolio_service import (
     fetch_toss_cash_snapshot,
     fetch_toss_portfolio_snapshot,
 )
+from app.services.toss_sellable_cache import TossSellableCache
 
 
 def _holding(
@@ -173,3 +174,97 @@ async def test_fetch_toss_cash_snapshot_does_not_fetch_holdings_or_sellable() ->
     assert snapshot.cash_krw == Decimal("123456")
     assert snapshot.cash_usd == Decimal("789.01")
     assert snapshot.errors == []
+
+
+class _Clock:
+    def __init__(self, t: float = 1000.0) -> None:
+        self.t = t
+
+    def now(self) -> float:
+        return self.t
+
+    def advance(self, dt: float) -> None:
+        self.t += dt
+
+
+@pytest.mark.asyncio
+async def test_snapshot_cache_hit_issues_zero_sellable_calls() -> None:
+    clock = _Clock()
+    cache = TossSellableCache(ttl_seconds=45, now=clock.now)
+    client = _FakeTossClient()
+
+    # Cold load: miss on every symbol => one fanout, cache populated.
+    snap1 = await fetch_toss_portfolio_snapshot(
+        client=client, need_sellable=True, sellable_cache=cache
+    )
+    assert client.sellable_calls == ["BRK.B"]
+    assert snap1.positions[0].sellable_quantity == Decimal("1.25")
+
+    # Warm load within TTL: ZERO new sellable calls, value served from cache.
+    snap2 = await fetch_toss_portfolio_snapshot(
+        client=client, need_sellable=True, sellable_cache=cache
+    )
+    assert client.sellable_calls == ["BRK.B"]  # unchanged => cache hit
+    assert snap2.positions[0].sellable_quantity == Decimal("1.25")  # accuracy preserved
+
+
+@pytest.mark.asyncio
+async def test_snapshot_cache_refetches_after_ttl_expiry() -> None:
+    clock = _Clock()
+    cache = TossSellableCache(ttl_seconds=45, now=clock.now)
+    client = _FakeTossClient()
+
+    await fetch_toss_portfolio_snapshot(
+        client=client, need_sellable=True, sellable_cache=cache
+    )
+    clock.advance(45.0)  # TTL boundary is exclusive => expired
+    await fetch_toss_portfolio_snapshot(
+        client=client, need_sellable=True, sellable_cache=cache
+    )
+    assert client.sellable_calls == ["BRK.B", "BRK.B"]  # refetched after expiry
+
+
+@pytest.mark.asyncio
+async def test_snapshot_cache_does_not_store_failed_fetch() -> None:
+    class ErrClient(_FakeTossClient):
+        async def sellable_quantity(self, *, symbol: str):
+            self.sellable_calls.append(symbol)
+            raise RuntimeError(f"boom {symbol}")
+
+    clock = _Clock()
+    cache = TossSellableCache(ttl_seconds=45, now=clock.now)
+    client = ErrClient()
+
+    snap1 = await fetch_toss_portfolio_snapshot(
+        client=client, need_sellable=True, sellable_cache=cache
+    )
+    assert snap1.positions[0].sellable_quantity is None
+    assert snap1.errors[0]["stage"] == "sellable_quantity"
+
+    # Error was NOT cached => next load within TTL retries the fetch.
+    await fetch_toss_portfolio_snapshot(
+        client=client, need_sellable=True, sellable_cache=cache
+    )
+    assert client.sellable_calls == ["BRK.B", "BRK.B"]
+
+
+@pytest.mark.asyncio
+async def test_snapshot_no_cache_default_still_fans_out() -> None:
+    client = _FakeTossClient()
+    # sellable_cache defaults to None => today's fanout path, unchanged.
+    await fetch_toss_portfolio_snapshot(client=client, need_sellable=True)
+    await fetch_toss_portfolio_snapshot(client=client, need_sellable=True)
+    assert client.sellable_calls == ["BRK.B", "BRK.B"]
+
+
+@pytest.mark.asyncio
+async def test_snapshot_need_sellable_false_ignores_cache() -> None:
+    clock = _Clock()
+    cache = TossSellableCache(ttl_seconds=45, now=clock.now)
+    client = _FakeTossClient()
+    snap = await fetch_toss_portfolio_snapshot(
+        client=client, need_sellable=False, sellable_cache=cache
+    )
+    # ROB-685 skip path is untouched: no fanout, no cache read/write.
+    assert client.sellable_calls == []
+    assert snap.positions[0].sellable_quantity is None

--- a/tests/test_toss_sellable_cache.py
+++ b/tests/test_toss_sellable_cache.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from app.core.config import Settings
+from app.services.toss_sellable_cache import (
+    TossSellableCache,
+    get_shared_sellable_cache,
+    reset_shared_sellable_cache,
+)
+
+pytestmark = pytest.mark.unit
+
+
+class TestTossSellableCacheSettings:
+    def test_defaults(self):
+        s = Settings()
+        assert s.toss_sellable_cache_enabled is True
+        assert s.toss_sellable_cache_ttl_seconds == 45.0
+
+    def test_env_override(self, monkeypatch):
+        monkeypatch.setenv("TOSS_SELLABLE_CACHE_ENABLED", "false")
+        monkeypatch.setenv("TOSS_SELLABLE_CACHE_TTL_SECONDS", "30")
+        s = Settings()
+        assert s.toss_sellable_cache_enabled is False
+        assert s.toss_sellable_cache_ttl_seconds == 30.0
+
+
+class _Clock:
+    def __init__(self, t: float = 1000.0) -> None:
+        self.t = t
+
+    def now(self) -> float:
+        return self.t
+
+    def advance(self, dt: float) -> None:
+        self.t += dt
+
+
+@pytest.fixture(autouse=True)
+def _reset_singleton():
+    reset_shared_sellable_cache()
+    yield
+    reset_shared_sellable_cache()
+
+
+class TestTossSellableCache:
+    def test_hit_within_ttl(self):
+        clock = _Clock()
+        cache = TossSellableCache(ttl_seconds=45, now=clock.now)
+        assert cache.get("BRK.B") is None  # cold miss
+        cache.put("BRK.B", Decimal("1.25"))
+        clock.advance(44.9)
+        assert cache.get("BRK.B") == Decimal("1.25")  # still fresh
+
+    def test_miss_after_ttl_expiry(self):
+        clock = _Clock()
+        cache = TossSellableCache(ttl_seconds=45, now=clock.now)
+        cache.put("BRK.B", Decimal("1.25"))
+        clock.advance(45.0)  # expiry boundary is exclusive
+        assert cache.get("BRK.B") is None
+
+    def test_per_symbol_isolation(self):
+        clock = _Clock()
+        cache = TossSellableCache(ttl_seconds=45, now=clock.now)
+        cache.put("AAA", Decimal("3"))
+        assert cache.get("BBB") is None
+        assert cache.get("AAA") == Decimal("3")
+
+    def test_disabled_is_complete_no_op(self):
+        clock = _Clock()
+        cache = TossSellableCache(ttl_seconds=45, now=clock.now, enabled=False)
+        cache.put("BRK.B", Decimal("1.25"))
+        assert cache.get("BRK.B") is None  # never stores => always miss
+
+
+class TestSingleton:
+    def test_shared_instance(self):
+        assert get_shared_sellable_cache() is get_shared_sellable_cache()
+
+    def test_reset_drops_instance(self):
+        first = get_shared_sellable_cache()
+        reset_shared_sellable_cache()
+        assert get_shared_sellable_cache() is not first


### PR DESCRIPTION
## Deploy → production

Ships ROB-700 + ROB-701 (the two real causes of the /invest slowness during the KIS maintenance, found by live-measuring ROB-699).

- **ROB-700**: KIS circuit breaker now also guards the OAuth token fetch — during maintenance the token POST was the un-guarded 5s connect-timeout that fired FIRST (so no data calls, so ROB-699's breaker never opened). Now token connect-failures trip the breaker → token + data calls fail-fast.
- **ROB-701**: short-TTL (45s) per-symbol cache for the Toss `sellable-quantity` fanout (the `invest.home.toss_api` reader's ~15s / 2659 calls-per-24h N+1, 6 TPS serialized). Wired only on the /invest display path; the MCP sell-sizing path stays byte-identical/fresh.

Expected: `/invest/api/home` ~25s → ~5s while KIS maintenance is still active; no change when KIS is healthy. Read-only perf/resilience; no broker mutation change; migration 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015NC4CDLK3bbjDuCYxxzEc7
