### PR TITLE
perf(ROB-702): parallelize manual reader KR/US price fetches (~7s -> ~3.5s)

### DIFF
--- a/app/services/invest_home_readers.py
+++ b/app/services/invest_home_readers.py
@@ -757,21 +757,36 @@ class ManualHomeReader:
             usd_krw_rate: float | None = None
 
             if self._quote_service:
-                with sentry_sdk.start_span(
-                    op="invest.home.manual.phase",
-                    name="invest.home.manual.fetch_kr_prices",
-                ) as span:
-                    span.set_data("ticker_count", len(kr_tickers))
-                    kr_prices = await self._quote_service.fetch_kr_prices(kr_tickers)
-                    span.set_data("price_count", len(kr_prices))
+                quote_service = self._quote_service
 
-                with sentry_sdk.start_span(
-                    op="invest.home.manual.phase",
-                    name="invest.home.manual.fetch_us_prices",
-                ) as span:
-                    span.set_data("ticker_count", len(us_tickers))
-                    us_prices = await self._quote_service.fetch_us_prices(us_tickers)
-                    span.set_data("price_count", len(us_prices))
+                async def _fetch_kr_prices() -> dict[str, float | None]:
+                    with sentry_sdk.start_span(
+                        op="invest.home.manual.phase",
+                        name="invest.home.manual.fetch_kr_prices",
+                    ) as span:
+                        span.set_data("ticker_count", len(kr_tickers))
+                        prices = await quote_service.fetch_kr_prices(kr_tickers)
+                        span.set_data("price_count", len(prices))
+                        return prices
+
+                async def _fetch_us_prices() -> dict[str, float | None]:
+                    with sentry_sdk.start_span(
+                        op="invest.home.manual.phase",
+                        name="invest.home.manual.fetch_us_prices",
+                    ) as span:
+                        span.set_data("ticker_count", len(us_tickers))
+                        prices = await quote_service.fetch_us_prices(us_tickers)
+                        span.set_data("price_count", len(prices))
+                        return prices
+
+                # ROB-702: KR and US price fetches are independent — run them
+                # concurrently so the manual reader's wall time is max(kr, us),
+                # not kr + us (~7s -> ~3.5s). Failure semantics unchanged: a
+                # raise from either fetch propagates (gather re-raises) to the
+                # outer try/except, exactly as the sequential awaits did.
+                kr_prices, us_prices = await asyncio.gather(
+                    _fetch_kr_prices(), _fetch_us_prices()
+                )
 
                 if us_tickers:
                     try:

--- a/tests/test_invest_home_readers.py
+++ b/tests/test_invest_home_readers.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
@@ -660,6 +661,91 @@ async def test_manual_reader_emits_load_quote_and_fx_spans(
     assert "invest.home.manual.load_holdings" in started
     assert "invest.home.manual.fetch_kr_prices" in started
     assert "invest.home.manual.fetch_us_prices" in started
+
+
+@pytest.mark.asyncio
+async def test_manual_reader_fetches_kr_and_us_prices_concurrently(monkeypatch):
+    """ROB-702: KR and US price fetches must run concurrently, not sequentially.
+
+    Each fake fetch signals it has started, then waits for the other to start.
+    Under the concurrent ``asyncio.gather`` both events fire and both proceed;
+    a sequential kr-then-us implementation would deadlock (us never starts while
+    kr awaits it) and time out — so a passing result proves concurrency.
+    """
+
+    class _Span:
+        def set_data(self, key: str, value: Any) -> None:
+            return None
+
+        def set_tag(self, key: str, value: Any) -> None:
+            return None
+
+    class _SpanContext:
+        def __enter__(self) -> _Span:
+            return _Span()
+
+        def __exit__(self, *exc: object) -> bool:
+            return False
+
+    def _start_span(*, op: str, name: str, **kwargs: Any) -> _SpanContext:
+        return _SpanContext()
+
+    class _BrokerAccount:
+        broker_type = "toss"
+
+    class _KRHolding:
+        id = 1
+        broker_account_id = 10
+        broker_account = _BrokerAccount()
+        ticker = "005930"
+        display_name = "삼성전자"
+        market_type = MarketType.KR
+        quantity = 2
+        avg_price = 70_000
+
+    class _USHolding:
+        id = 2
+        broker_account_id = 10
+        broker_account = _BrokerAccount()
+        ticker = "AAPL"
+        display_name = "Apple"
+        market_type = MarketType.US
+        quantity = 1
+        avg_price = 100
+
+    class _ManualHoldingsService:
+        def __init__(self, db: object) -> None:
+            self.db = db
+
+        async def get_holdings_by_user(self, user_id: int) -> list[Any]:
+            return [_KRHolding(), _USHolding()]
+
+    kr_started = asyncio.Event()
+    us_started = asyncio.Event()
+
+    class _QuoteService:
+        async def fetch_kr_prices(self, tickers: list[str]) -> dict[str, float | None]:
+            kr_started.set()
+            await asyncio.wait_for(us_started.wait(), timeout=1.0)
+            return dict.fromkeys(tickers, 72000.0)
+
+        async def fetch_us_prices(self, tickers: list[str]) -> dict[str, float | None]:
+            us_started.set()
+            await asyncio.wait_for(kr_started.wait(), timeout=1.0)
+            return dict.fromkeys(tickers, 190.0)
+
+    monkeypatch.setattr(readers.sentry_sdk, "start_span", _start_span)
+    monkeypatch.setattr(readers, "ManualHoldingsService", _ManualHoldingsService)
+    monkeypatch.setattr(readers, "get_usd_krw_rate", AsyncMock(return_value=1_350.0))
+
+    result = await readers.ManualHomeReader(
+        db=object(), quote_service=_QuoteService()
+    ).fetch(user_id=1)  # type: ignore[arg-type]
+
+    # Sequential fetches would deadlock on the cross-waits above; a clean result
+    # with both events set proves the two fetches were in flight simultaneously.
+    assert result.warning is None
+    assert kr_started.is_set() and us_started.is_set()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

After ROB-700 + ROB-701 dropped `/invest/api/home` from **~25s → ~10s**, the top remaining bottleneck was the `invest.home.manual` reader (**~7s**). Sentry phase breakdown: `fetch_kr_prices` (~3.5s) + `fetch_us_prices` (~3.5s) run **SEQUENTIALLY** — the two fetches are independent, so the reader's wall time was the sum, not the max.

## How

Run the two price fetches concurrently with `asyncio.gather` (each keeps its own Sentry span). Wall time → `max(kr, us)` ≈ 3.5s. **Failure semantics unchanged**: a raise from either fetch propagates (gather re-raises) to the reader's existing `try/except`, exactly as the sequential awaits did. The shared rate limiter still serializes the underlying KIS/Toss calls, so correctness is unaffected.

## Safety

`invest_home_readers.py` `ManualHomeReader` only. migration-0. No broker/order mutation change. Independent of KIS state (each fetch also gets faster once KIS recovers).

## Tests

`test_manual_reader_fetches_kr_and_us_prices_concurrently` — two fake fetches cross-wait on each other's start event; concurrent `gather` lets both proceed, a sequential kr-then-us impl deadlocks and times out. **Verified: the test fails on the pre-change sequential source and passes on the parallel one.** Existing manual-reader tests green (**39 passed**), `make lint` clean.

Expected: manual reader ~7s → ~3.5s, `/invest/api/home` ~10s → ~5-6s.

ROB-702

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015NC4CDLK3bbjDuCYxxzEc7
