### PR TITLE
fix(ROB-708): /invest US price uses inquire_overseas_price (live last, HHDFS00000300) not daily close

### DIFF
--- a/app/services/invest_quote_service.py
+++ b/app/services/invest_quote_service.py
@@ -118,8 +118,13 @@ class InvestQuoteService:
         async def _fetch(symbol: str) -> None:
             try:
                 exchange = await get_us_exchange_by_symbol(symbol, self._db)
-                df = await self._market_data.inquire_overseas_daily_price(
-                    symbol, exchange_code=exchange, n=1, period="D"
+                # ROB-708: live last (HHDFS00000300), mirroring get_quote US, so
+                # KIS-resolved US prices agree with Toss-resolved live-last prices
+                # instead of silently mixing in a settled daily close (HHDFS76240000).
+                # _build_overseas_price_frame returns empty when last is None/<=0,
+                # so an empty frame -> None -> resolver falls through to Toss/snapshot.
+                df = await self._market_data.inquire_overseas_price(
+                    symbol, exchange_code=exchange
                 )
                 results[symbol] = float(df.iloc[0]["close"]) if not df.empty else None
             except Exception as exc:  # noqa: BLE001 — summarized by the resolver

--- a/tests/test_invest_quote_service.py
+++ b/tests/test_invest_quote_service.py
@@ -34,30 +34,36 @@ async def test_fetch_kr_prices() -> None:
 
 @pytest.mark.asyncio
 @pytest.mark.unit
-async def test_fetch_us_prices(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_fetch_us_prices_uses_live_last_endpoint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """ROB-708: US /invest price must come from inquire_overseas_price
+    (HHDFS00000300, live last) — NOT inquire_overseas_daily_price (daily close)."""
     kis_client = MagicMock()
     db = MagicMock()
 
     service = InvestQuoteService(kis_client, db)
 
-    # Mock get_us_exchange_by_symbol
     mock_get_exchange = AsyncMock(return_value="NASD")
     monkeypatch.setattr(
         "app.services.invest_quote_service.get_us_exchange_by_symbol", mock_get_exchange
     )
 
-    # Mock MarketDataClient.inquire_overseas_daily_price
     service._market_data = AsyncMock()
-    df = pd.DataFrame([{"close": 150.0}], index=[0])
-    service._market_data.inquire_overseas_daily_price.return_value = df
+    # inquire_overseas_price returns the single-row live-last frame
+    # ([close, previous_close, volume]); close == live `last`.
+    live_df = pd.DataFrame([{"close": 150.0, "previous_close": 148.0, "volume": 1000}])
+    service._market_data.inquire_overseas_price.return_value = live_df
 
     prices = await service.fetch_us_prices(["AAPL"])
 
     assert prices == pytest.approx({"AAPL": 150.0})
     mock_get_exchange.assert_called_once_with("AAPL", db)
-    service._market_data.inquire_overseas_daily_price.assert_called_once_with(
-        "AAPL", exchange_code="NASD", n=1, period="D"
+    service._market_data.inquire_overseas_price.assert_called_once_with(
+        "AAPL", exchange_code="NASD"
     )
+    # The daily-close endpoint must no longer be used for a "current price".
+    service._market_data.inquire_overseas_daily_price.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -112,9 +118,7 @@ async def test_fetch_us_prices_toss_disabled_uses_snapshot(monkeypatch):
     service = InvestQuoteService(kis_client, db)  # no toss_client, disabled
 
     service._market_data = AsyncMock()
-    service._market_data.inquire_overseas_daily_price.side_effect = RuntimeError(
-        "KIS down"
-    )
+    service._market_data.inquire_overseas_price.side_effect = RuntimeError("KIS down")
     monkeypatch.setattr(
         "app.services.invest_quote_service.get_us_exchange_by_symbol",
         AsyncMock(return_value="NASD"),
@@ -170,3 +174,37 @@ async def test_fetch_kr_prices_toss_enabled_but_misconfigured_is_fail_open(
     out = await service.fetch_kr_prices(["A"])
     assert out == pytest.approx({"A": 11.0})  # snapshot filled, never raised
     service._snapshot_latest.assert_awaited_once_with("kr", ["A"])
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_fetch_us_prices_empty_live_last_falls_through_to_snapshot(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """ROB-708: when KIS live-last has no price (market closed / after-hours),
+    inquire_overseas_price returns an EMPTY frame -> None -> the resolver must
+    fall through to snapshot rather than surfacing a stale daily close."""
+    monkeypatch.setattr(
+        "app.services.invest_quote_service.settings.toss_api_enabled",
+        False,
+        raising=False,
+    )
+    kis_client = MagicMock()
+    db = MagicMock()
+    service = InvestQuoteService(kis_client, db)  # toss disabled
+
+    monkeypatch.setattr(
+        "app.services.invest_quote_service.get_us_exchange_by_symbol",
+        AsyncMock(return_value="NASD"),
+    )
+    service._market_data = AsyncMock()
+    # Empty frame == _build_overseas_price_frame's "last is None / <= 0" case.
+    service._market_data.inquire_overseas_price.return_value = pd.DataFrame(
+        columns=["close", "previous_close", "volume"]
+    )
+    service._snapshot_latest = AsyncMock(return_value={"AAPL": 199.0})
+
+    out = await service.fetch_us_prices(["AAPL"])
+
+    assert out == pytest.approx({"AAPL": 199.0})  # from snapshot, not KIS daily
+    service._snapshot_latest.assert_awaited_once_with("us", ["AAPL"])


### PR DESCRIPTION
## Summary

Fixes a silent correctness bug on the `/invest` home + manual-holdings surface where US per-symbol "current price" was being read from a daily-close endpoint, silently mixed with live-last from the Toss fallback per symbol.

**Root cause:** `InvestQuoteService._kis_fetch_us` used `inquire_overseas_daily_price` (**HHDFS76240000**, `period="D", n=1`), whose `close` column is the daily bar's settled `clos` — not the live last trade. Meanwhile the ROB-696 resolver falls through to Toss (live last) for symbols KIS returns `None` for, and the UI presents all values as one live "current price." Result: per-symbol silent mix of daily-close (KIS-resolved) with live-last (Toss-resolved).

**Fix:** swap the endpoint to `inquire_overseas_price` (**HHDFS00000300**, `OVERSEAS_PRICE_TR`) — the exact endpoint `get_quote` US already uses. `_build_overseas_price_frame` reads `out.get("last")` into the `close` column and returns an empty frame when `last` is `None`/ `<= 0`. So:
- non-empty frame ⇒ `close` is a positive live last (`> 0` guaranteed by the broker layer; no extra guard needed, mirrors the KR sibling one-liner)
- empty frame ⇒ `None` ⇒ resolver falls through to Toss (live last) then snapshot — no more stale daily close masquerading as a live price when the market is closed / after-hours / delisted.

## Changes

- `app/services/invest_quote_service.py` — `_kis_fetch_us`: `inquire_overseas_daily_price(..., n=1, period="D")` → `inquire_overseas_price(symbol, exchange_code=exchange)`; read live-last `close`; empty ⇒ `None`.
- `tests/test_invest_quote_service.py` —
  - rename `test_fetch_us_prices` → `test_fetch_us_prices_uses_live_last_endpoint`: asserts `inquire_overseas_price` called once with the right args, **and `inquire_overseas_daily_price.assert_not_called()`**.
  - flip `test_fetch_us_prices_toss_disabled_uses_snapshot`'s KIS mock name to `inquire_overseas_price` (the rest of the test is unchanged — still proves a KIS error falls through to snapshot).
  - add `test_fetch_us_prices_empty_live_last_falls_through_to_snapshot`: locks the empty live-last frame → `None` → resolver → snapshot fall-through contract.

## Constraints honored

- **KIS stays primary and per-symbol** for US `/invest` prices. No batch conversion, no resolver reorder — only the TR and its price semantics change.
- Only the KIS US call inside `_kis_fetch_us` is touched. `_kis_fetch_kr`, `_resolve`, `_build_toss_fetch`, `_snapshot_latest`, the `get_us_exchange_by_symbol(symbol, self._db)` lookup, and the Toss/snapshot layers are verbatim.
- **No broker method changed.** `inquire_overseas_price`, `_build_overseas_price_frame`, `inquire_overseas_daily_price`, `_build_overseas_daily_frame` are read as-is. HHDFS76240000 stays the daily-200 adjusted-OHLCV source for every other caller.
- **Fail-open preserved**: `_kis_fetch_us` never raises; every per-symbol failure/empty resolves to `None` so the resolver falls through. Proven by the updated `test_fetch_us_prices_toss_disabled_uses_snapshot` (KIS error → snapshot) and the new `test_fetch_us_prices_empty_live_last_falls_through_to_snapshot` (empty live-last → snapshot).
- **migration-0** — no alembic revision, no model/schema change, no new config flag.

## Verification

- RED → GREEN: new `test_fetch_us_prices_uses_live_last_endpoint` fails on the old impl (`{'AAPL': None}` vs `150.0`), passes after the swap.
- Full suite: `uv run pytest tests/test_invest_quote_service.py tests/test_invest_price_fallback_circuit_open.py -v` → **10 passed, 0 failed**.
- `make lint` → ruff check / format / ty all clean.

## Out of scope (intentionally)

- KIS circuit breaker (ROB-699/700) and Toss sellable cache (ROB-701) wiring — not involved.
- Batching US reads into the existing Toss batch layer — separate policy issue; this issue is endpoint-semantics only.
- `app/mcp_server/tooling/market_data_quotes.py` — `get_quote` US is the parse reference, read-only.

Refs: ROB-708

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * US quote lookups now use the latest live price when available, improving consistency with other price sources.
  * If a live price is unavailable or returns no data, the app now falls back to the snapshot price instead of showing a stale daily close.
  * Quote resolution for US symbols is now more reliable when switching between live data and fallback sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->