### PR TITLE
feat(ROB-706): KR daily-200 OHLCV Toss 1d fallback on KIS exception/timeout

### DIFF
--- a/app/services/daily_candles/sync_service.py
+++ b/app/services/daily_candles/sync_service.py
@@ -90,16 +90,33 @@ class DailyCandleSyncService:
         return await self._sync_crypto(target, horizon_bars)
 
     async def _sync_kr(self, target: SyncTarget, horizon_bars: int) -> SyncOneResult:
-        frame = await self._kis_kr(code=target.symbol, n=horizon_bars)
-        rows = frame_to_rows(
-            frame, symbol=target.symbol, partition=target.partition, source="kis"
-        )
         fallback_used = False
-        if not rows and self._toss_kr is not None:
-            logger.warning(
-                "KIS returned no rows for KR symbol; attempting Toss fallback symbol=%s",
-                target.symbol,
+        rows: list[DailyCandleRow] = []
+        kis_errored = False
+        try:
+            frame = await self._kis_kr(code=target.symbol, n=horizon_bars)
+            rows = frame_to_rows(
+                frame, symbol=target.symbol, partition=target.partition, source="kis"
             )
+        except Exception as exc:
+            # ROB-706: a KIS exception/timeout is as much a fallback trigger as
+            # empty rows (the 2026-07-04 maintenance RAISED, it did not return []).
+            # Fall back only when a Toss fetcher is wired; otherwise preserve
+            # today's behavior and re-raise.
+            if self._toss_kr is None:
+                raise
+            kis_errored = True
+            logger.warning(
+                "KIS raised for KR symbol=%s; attempting Toss fallback: %s",
+                target.symbol,
+                exc,
+            )
+        if not rows and self._toss_kr is not None:
+            if not kis_errored:
+                logger.warning(
+                    "KIS returned no rows for KR symbol; attempting Toss fallback symbol=%s",
+                    target.symbol,
+                )
             toss_frame = await self._toss_kr(symbol=target.symbol, n=horizon_bars)
             rows = frame_to_rows(
                 toss_frame,

--- a/app/services/market_data/service.py
+++ b/app/services/market_data/service.py
@@ -687,20 +687,44 @@ async def get_ohlcv(
                         source="db",
                         period=resolved_period,
                     )
-            frame = await kis.inquire_daily_itemchartprice(
-                code=resolved_symbol,
-                market="J",
-                n=capped_count,
-                period=period_map[resolved_period],
-                end_date=(pd.Timestamp(end.date()) if end is not None else None),
-            )
+            try:
+                frame = await kis.inquire_daily_itemchartprice(
+                    code=resolved_symbol,
+                    market="J",
+                    n=capped_count,
+                    period=period_map[resolved_period],
+                    end_date=(pd.Timestamp(end.date()) if end is not None else None),
+                )
+                source = "kis"
+            except Exception as kis_exc:
+                # ROB-706: KIS is the authoritative adjusted KR daily source but a
+                # single point of failure on cache miss (2026-07-04 maintenance
+                # blanked /invest). Only `day` has a Toss 1d equivalent; week/month
+                # re-raise (same UpstreamUnavailableError as today). Toss 1d is
+                # adjusted=True — matches KIS adj=True already stored as source="kis".
+                if resolved_period != "day":
+                    raise
+                logger.warning(
+                    "KIS KR daily failed symbol=%s; Toss 1d fallback: %s",
+                    safe_log_value(resolved_symbol),
+                    kis_exc,
+                )
+                frame = await fetch_daily_toss_frame(
+                    symbol=resolved_symbol,
+                    count=capped_count,
+                    end_date=end,
+                )
+                source = "toss"
             if resolved_period == "day":
-                await write_back_kr(frame, symbol=resolved_symbol)
+                if source == "toss":
+                    await write_back_kr(frame, symbol=resolved_symbol, source="toss")
+                else:
+                    await write_back_kr(frame, symbol=resolved_symbol)
             return _to_candle_rows(
                 frame,
                 symbol=resolved_symbol,
                 market=resolved_market,
-                source="kis",
+                source=source,
                 period=resolved_period,
             )
 

--- a/tests/integration/test_kr_daily_kis_toss_equivalence.py
+++ b/tests/integration/test_kr_daily_kis_toss_equivalence.py
@@ -1,0 +1,60 @@
+"""ROB-706 pre-trust gate: KIS adj=True vs Toss adjusted=True KR daily closes must
+agree within tolerance for liquid symbols. Opt-in (hits real KIS + Toss); requires
+KIS creds + TOSS_API_ENABLED=true. Run ONCE before trusting the fallback in prod:
+
+    uv run pytest tests/integration/test_kr_daily_kis_toss_equivalence.py -v -m "integration and live" --run-live
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from app.core.config import settings
+from app.services.brokers.kis.client import KISClient
+from app.services.market_data.toss_ohlcv import fetch_daily_toss_frame
+
+# NOTE: the `live` marker is load-bearing for safety. The `integration` marker
+# alone does NOT exclude a test from the default suite — `make test` runs
+# `-m "not live"`, which INCLUDES integration tests. Only the `live` marker is
+# auto-skipped by the conftest hook (`tests/conftest.py:597-603`) unless
+# `--run-live` is passed. Without `live` this test would fire real KIS + Toss
+# HTTP whenever `make test` runs with TOSS_API_ENABLED=true.
+pytestmark = [pytest.mark.integration, pytest.mark.live, pytest.mark.asyncio]
+
+_SYMBOLS = ["005930", "000660", "035420"]  # Samsung Elec, SK hynix, NAVER
+_N = 60
+_REL_TOL = 0.005  # 0.5% — adjustment rounding, not raw/adjusted divergence
+
+
+@pytest.mark.skipif(
+    not settings.toss_api_enabled, reason="TOSS_API_ENABLED must be true"
+)
+@pytest.mark.parametrize("symbol", _SYMBOLS)
+async def test_kis_and_toss_daily_closes_agree(symbol):
+    kis = KISClient()
+    try:
+        kis_frame = await kis.inquire_daily_itemchartprice(
+            code=symbol, market="J", n=_N, period="D", end_date=None
+        )
+    finally:
+        await kis.close()
+    toss_frame = await fetch_daily_toss_frame(symbol=symbol, count=_N)
+
+    def _closes(frame: pd.DataFrame) -> dict[str, float]:
+        col = "date" if "date" in frame.columns else "datetime"
+        keyed = {
+            str(pd.Timestamp(r[col]).date()): float(r["close"])
+            for r in frame.to_dict("records")
+        }
+        return keyed
+
+    kis_closes, toss_closes = _closes(kis_frame), _closes(toss_frame)
+    common = sorted(set(kis_closes) & set(toss_closes))
+    assert len(common) >= 20, f"too few overlapping sessions: {len(common)}"
+    for day in common:
+        k, t = kis_closes[day], toss_closes[day]
+        assert abs(k - t) <= _REL_TOL * max(abs(k), 1.0), (
+            f"{symbol} {day}: KIS adj close {k} vs Toss adj close {t} "
+            f"exceed {_REL_TOL:.1%} — adjusted-series MISMATCH (do NOT enable fallback)"
+        )

--- a/tests/test_get_ohlcv_day_db_first.py
+++ b/tests/test_get_ohlcv_day_db_first.py
@@ -220,6 +220,69 @@ async def test_kr_day_db_miss_falls_back_to_kis_and_writes_back(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_kr_day_db_miss_kis_failure_uses_toss_and_writes_back(monkeypatch):
+    """ROB-706: DB miss AND KIS raises for KR day → Toss 1d fallback fires and
+    write-back runs with source='toss'. KIS stays primary; Toss only on error."""
+    monkeypatch.setattr(
+        market_data_service, "cache_first_kr", AsyncMock(return_value=None)
+    )
+
+    class _StubKIS:
+        async def inquire_daily_itemchartprice(self, **kwargs):
+            raise RuntimeError("kis maintenance")
+
+    monkeypatch.setattr(market_data_service, "KISClient", lambda: _StubKIS())
+
+    toss_frame = pd.DataFrame(
+        [
+            {
+                "datetime": pd.Timestamp("2026-07-01 15:30:00"),
+                "open": 70000.0,
+                "high": 70500.0,
+                "low": 69500.0,
+                "close": 70200.0,
+                "volume": 100000.0,
+                "value": 70200.0 * 100000.0,
+            }
+        ]
+    )
+    toss_mock = AsyncMock(return_value=toss_frame)
+    monkeypatch.setattr(market_data_service, "fetch_daily_toss_frame", toss_mock)
+    write_back_mock = AsyncMock(return_value=1)
+    monkeypatch.setattr(market_data_service, "write_back_kr", write_back_mock)
+
+    candles = await market_data_service.get_ohlcv("005930", "kr", "day", count=5)
+
+    assert candles[0].source == "toss"
+    toss_mock.assert_awaited_once_with(symbol="005930", count=5, end_date=None)
+    write_back_mock.assert_awaited_once_with(toss_frame, symbol="005930", source="toss")
+
+
+@pytest.mark.asyncio
+async def test_kr_week_kis_failure_does_not_use_toss(monkeypatch):
+    """week has no Toss 1d equivalent: a KIS failure must propagate as
+    UpstreamUnavailableError (v1 scope: day only), NOT fall back to Toss."""
+    from app.services.domain_errors import UpstreamUnavailableError
+
+    monkeypatch.setattr(
+        market_data_service, "cache_first_kr", AsyncMock(return_value=None)
+    )
+
+    class _StubKIS:
+        async def inquire_daily_itemchartprice(self, **kwargs):
+            raise RuntimeError("kis down")
+
+    monkeypatch.setattr(market_data_service, "KISClient", lambda: _StubKIS())
+    toss_mock = AsyncMock()
+    monkeypatch.setattr(market_data_service, "fetch_daily_toss_frame", toss_mock)
+
+    with pytest.raises(UpstreamUnavailableError):
+        await market_data_service.get_ohlcv("005930", "kr", "week", count=5)
+
+    toss_mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_us_day_db_miss_falls_back_to_yahoo_and_writes_back(monkeypatch):
     """When DB misses for US, get_ohlcv calls Yahoo, writes back, returns yahoo rows."""
     monkeypatch.setattr(

--- a/tests/unit/services/daily_candles/test_sync_service.py
+++ b/tests/unit/services/daily_candles/test_sync_service.py
@@ -272,3 +272,77 @@ async def test_us_empty_kis_and_yahoo_falls_back_to_toss_daily():
 
     assert result.fallback_used is True
     assert upserted_rows[0].source == "toss_fallback"
+
+
+@pytest.mark.asyncio
+async def test_kr_kis_exception_falls_back_to_toss_daily():
+    """ROB-706: a KIS exception (not just empty rows) triggers the KR Toss fallback."""
+    upserted_rows = []
+
+    class Repo:
+        session = AsyncMock()
+
+        async def upsert_rows(self, *, market, rows):
+            upserted_rows.extend(rows)
+            return len(rows)
+
+    Repo.session.commit = AsyncMock()
+    svc = DailyCandleSyncService(
+        repository=Repo(),
+        kis_kr_fetcher=AsyncMock(side_effect=TimeoutError("kis maintenance")),
+        kis_us_fetcher=AsyncMock(),
+        yahoo_us_fetcher=AsyncMock(),
+        upbit_crypto_fetcher=AsyncMock(),
+        toss_kr_fetcher=AsyncMock(
+            return_value=pd.DataFrame(
+                [
+                    {
+                        "date": "2026-06-12",
+                        "open": 1,
+                        "high": 2,
+                        "low": 1,
+                        "close": 2,
+                        "volume": 10,
+                        "value": 20,
+                    }
+                ]
+            )
+        ),
+    )
+
+    result = await svc.sync_one(
+        target=SyncTarget(market=MarketKey.KR, symbol="005930", partition="KRX"),
+        horizon_bars=1,
+    )
+
+    assert result.fallback_used is True
+    assert upserted_rows[0].source == "toss"
+
+
+@pytest.mark.asyncio
+async def test_kr_kis_exception_without_toss_fetcher_reraises():
+    """No Toss fetcher wired (TOSS_API_ENABLED off) → a KIS exception still
+    propagates (today's behavior); no upsert/commit runs."""
+    repo = MagicMock()
+    repo.upsert_rows = AsyncMock()
+    repo.session = MagicMock()
+    repo.session.commit = AsyncMock()
+    repo.session.rollback = AsyncMock()
+
+    svc = DailyCandleSyncService(
+        repository=repo,
+        kis_kr_fetcher=AsyncMock(side_effect=RuntimeError("kis down")),
+        kis_us_fetcher=AsyncMock(),
+        yahoo_us_fetcher=AsyncMock(),
+        upbit_crypto_fetcher=AsyncMock(),
+        # no toss_kr_fetcher
+    )
+
+    with pytest.raises(RuntimeError, match="kis down"):
+        await svc.sync_one(
+            target=SyncTarget(market=MarketKey.KR, symbol="005930", partition="KRX"),
+            horizon_bars=1,
+        )
+
+    repo.upsert_rows.assert_not_awaited()
+    repo.session.commit.assert_not_awaited()

--- a/tests/unit/services/daily_candles/test_toss_ohlcv_daily_adjusted.py
+++ b/tests/unit/services/daily_candles/test_toss_ohlcv_daily_adjusted.py
@@ -1,0 +1,56 @@
+"""ROB-706 data-equivalence guard: the KR-daily Toss fallback (fetch_daily_toss_frame)
+MUST request interval='1d' and adjusted=True so it matches the KIS adj=True series
+already stored as source='kis' in kr_candles_1d. An unadjusted Toss frame spliced
+into the daily series would corrupt it at every historical split/dividend."""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from app.services.market_data import toss_ohlcv
+
+pytestmark = pytest.mark.unit
+
+
+class _FakeClient:
+    async def aclose(self) -> None:
+        pass
+
+
+@pytest.mark.asyncio
+async def test_fetch_daily_toss_frame_requests_adjusted_1d(monkeypatch):
+    captured: dict[str, object] = {}
+
+    async def fake_fetch(
+        *, client, symbol, interval, count, before=None, adjusted=None, max_pages=20
+    ):
+        captured["interval"] = interval
+        captured["adjusted"] = adjusted
+        captured["symbol"] = symbol
+        return pd.DataFrame(
+            columns=[
+                "datetime",
+                "date",
+                "time",
+                "open",
+                "high",
+                "low",
+                "close",
+                "volume",
+                "value",
+            ]
+        )
+
+    monkeypatch.setattr(toss_ohlcv, "fetch_toss_candles_frame", fake_fetch)
+    monkeypatch.setattr(
+        toss_ohlcv.TossReadClient,
+        "from_settings",
+        classmethod(lambda cls: _FakeClient()),
+    )
+
+    await toss_ohlcv.fetch_daily_toss_frame(symbol="005930", count=200)
+
+    assert captured["symbol"] == "005930"
+    assert captured["interval"] == "1d"
+    assert captured["adjusted"] is True


### PR DESCRIPTION
## Summary

Implements [ROB-706](/ROB/issues/ROB-706) — KR daily-200 OHLCV (, the `app/analysis/pipeline.py` core input) gains a Toss 1d second fallback so a KIS outage no longer blanks the read path. The 2026-07-04 KIS maintenance exposed the single point of failure: on a `kr_candles_1d` cache miss, the KR daily read path called only KIS and a KIS error bubbled out as `UpstreamUnavailableError`.

### Target flow
```
KR day get_ohlcv:  cache_first_kr (DB) ─hit→ source="db"
                              │miss
                              ▼
                   KIS inquire_daily_itemchartprice ─ok→ write_back_kr(source="kis") → source="kis"
                              │raise  (period=="day" only; week/month re-raise)
                              ▼
                   fetch_daily_toss_frame(adjusted=True 1d) → write_back_kr(source="toss") → source="toss"
```

- **KIS stays PRIMARY and unchanged.** Toss is fallback/cache-warmer only, reached only when KIS errors (read path) or errors/returns-empty (batch-sync), and only for `period="day"`. Week/month have no Toss 1d equivalent — a KIS failure there still raises `UpstreamUnavailableError` exactly as today.
- **Batch-sync `_sync_kr`**: KIS exception/timeout now also triggers the existing Toss fallback (not only empty rows). No Toss fetcher wired (TOSS_API_ENABLED off) → KIS exception still propagates (today's behavior preserved).
- **Data-equivalence guard**: `fetch_daily_toss_frame` is locked to `interval="1d", adjusted=True` (`test_fetch_daily_toss_frame_requests_adjusted_1d`), matching KIS `adj=True` already stored as `source="kis"` in `kr_candles_1d`. Opt-in `integration + live` equivalence gate ships for the once-before-prod pre-trust check.
- **migration-0.** No alembic revision, no `kr_candles_1d` schema change, no Redis.

## Diff vs main (6 files, +309 / -15)
- `app/services/market_data/service.py` (+33 / -9) — KR daily block try/except + day-only Toss fallback
- `app/services/daily_candles/sync_service.py` (+23 / -6) — `_sync_kr` try/except, KIS exception treated like empty rows
- `tests/test_get_ohlcv_day_db_first.py` (+63 / 0) — 2 new tests (KR day fallback + KR week regression lock)
- `tests/unit/services/daily_candles/test_sync_service.py` (+74 / 0) — 2 new tests (KIS exception fallback + no-toss-fetcher re-raise)
- `tests/unit/services/daily_candles/test_toss_ohlcv_daily_adjusted.py` (new, 56 lines) — adjusted=1d contract guard
- `tests/integration/test_kr_daily_kis_toss_equivalence.py` (new, 60 lines) — opt-in KIS↔Toss adjusted equivalence gate

## Verification
- 114 tests pass, 3 rows SKIPPED (opt-in live integration test, gated by conftest `live` marker — safe under `make test` even with TOSS_API_ENABLED=true)
- `make lint` clean (ruff check + ruff format + ty)
- 6 changed files only — `toss_ohlcv.py`, `toss_daily_fetcher.py`, `cache_first_kr/us`, `write_back_kr/us`, `frame_to_rows`, the US day path, and `_sync_us` are all untouched
- Contract guard proven to bite: temporarily flipped `toss_ohlcv.py:68` `adjusted=True` → `adjusted=False`, `test_fetch_daily_toss_frame_requests_adjusted_1d` failed with `assert False is True`, reverted
- TDD followed end-to-end: new tests confirmed RED before the impl, GREEN after

## Plan
`docs/plans/ROB-706-kr-daily-ohlcv-toss-fallback.md` (3 task-by-task sections with TDD steps, interfaces, and acceptance criteria)

## Review tags
Applying `high_risk_change` + `needs_stronger_model_review` for ROB-706: this changes the daily OHLCV read path used by `app/analysis/pipeline.py` and the batch-sync DB populator — both feed live analysis and DB-stored series. The pre-trust equivalence gate (Task 3, opt-in) is the data-safety assumption that must be confirmed before merge.

## Hold
Applying `hold_for_final_review` per AGENTS.md model-lane template. Implementation + tests are complete and green locally, but this should not be merged to `main` or used in live trading until:
1. A stronger-model reviewer (Sonnet/Opus) confirms the read-path fallback semantics and the no-Toss-fetcher re-raise path
2. The opt-in equivalence gate (`uv run pytest tests/integration/test_kr_daily_kis_toss_equivalence.py -v -m "integration and live" --run-live`) has been run against real KIS + Toss on a representative symbol set (proposed: 005930 / 000660 / 035420, 0.5% tolerance) and the adjusted closes agree
3. CTO/Opus final clearance on data-safety assumptions and rollback plan