### PR TITLE
feat(ROB-707): populate Toss buyingPower home card + overlap cash fetch with holdings

### DIFF
--- a/app/services/invest_home_readers.py
+++ b/app/services/invest_home_readers.py
@@ -694,7 +694,20 @@ class TossApiHomeReader:
                     if snapshot.cash_usd is not None
                     else None,
                 ),
-                buyingPower=CashAmounts(),
+                buyingPower=CashAmounts(
+                    # ROB-707: Toss GET /api/v1/buying-power exposes only
+                    # cashBuyingPower (orderable cash). fetch_toss_cash_snapshot
+                    # (ROB-696) already fetched it onto snapshot.cash_{krw,usd};
+                    # surface it here. Fail-open: None per currency when the
+                    # fetch failed (the error is already in snapshot.errors ->
+                    # warning). cashBalances is left unchanged above.
+                    krw=float(snapshot.cash_krw)
+                    if snapshot.cash_krw is not None
+                    else None,
+                    usd=float(snapshot.cash_usd)
+                    if snapshot.cash_usd is not None
+                    else None,
+                ),
             )
             warning = None
             if snapshot.errors:

--- a/app/services/toss_portfolio_service.py
+++ b/app/services/toss_portfolio_service.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 from dataclasses import dataclass, field
 from decimal import Decimal
 from typing import Any, Protocol
@@ -139,6 +140,13 @@ async def fetch_toss_portfolio_snapshot(
     created_client = client is None
     active_client: TossPortfolioClient = client or TossReadClient.from_settings()
 
+    # ROB-707: the cash (buying-power) snapshot is independent of holdings, so
+    # kick it off concurrently with the holdings/sellable chain instead of
+    # awaiting it serially after the position loop. Output is unchanged; only
+    # the wall-clock overlap changes. Drained/cancelled in the finally if the
+    # holdings chain raises before we await it.
+    cash_task = asyncio.ensure_future(fetch_toss_cash_snapshot(client=active_client))
+
     try:
         with sentry_sdk.start_span(
             op="invest.home.toss_api.phase",
@@ -257,7 +265,7 @@ async def fetch_toss_portfolio_snapshot(
                 )
             )
 
-        cash_snapshot = await fetch_toss_cash_snapshot(client=active_client)
+        cash_snapshot = await cash_task
         errors.extend(cash_snapshot.errors)
 
         return TossPortfolioSnapshot(
@@ -267,5 +275,14 @@ async def fetch_toss_portfolio_snapshot(
             errors=errors,
         )
     finally:
+        # ROB-707: if the holdings/sellable chain raised before we awaited the
+        # cash task, cancel and drain it so it never touches a closed client
+        # (and never leaks a pending task). fetch_toss_cash_snapshot swallows
+        # per-currency errors internally, so this only fires on holdings-chain
+        # failure.
+        if not cash_task.done():
+            cash_task.cancel()
+            with contextlib.suppress(BaseException):
+                await cash_task
         if created_client:
             await active_client.aclose()

--- a/tests/test_invest_home_readers.py
+++ b/tests/test_invest_home_readers.py
@@ -2024,3 +2024,52 @@ async def test_toss_cash_snapshot_runs_concurrently_with_holdings(monkeypatch):
     assert snap.cash_krw == Decimal("10")
     assert snap.cash_usd == Decimal("10")
     assert snap.errors == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_toss_cash_snapshot_drained_when_holdings_chain_raises(monkeypatch):
+    """ROB-707: when the holdings/sellable chain raises before the cash task
+    is awaited, the finally block must cancel and drain the pending cash task
+    so it never touches a closed client and never leaks a pending coroutine."""
+    import asyncio
+    from types import SimpleNamespace
+
+    from app.services import toss_portfolio_service as svc
+
+    aclose_calls = 0
+    bp_started = asyncio.Event()
+    bp_cancelled = asyncio.Event()
+
+    class _Client:
+        async def holdings(self):
+            # Raise AFTER the cash fetch has started so the cash task is
+            # genuinely pending when the finally block runs.
+            await asyncio.wait_for(bp_started.wait(), timeout=1.0)
+            raise RuntimeError("holdings boom")
+
+        async def sellable_quantity(self, *, symbol):
+            raise AssertionError("no fanout on raise")
+
+        async def buying_power(self, *, currency):
+            bp_started.set()
+            # Block forever until cancelled — proves drain works.
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                bp_cancelled.set()
+                raise
+            return SimpleNamespace(currency=currency, cash_buying_power=0)
+
+        async def aclose(self):
+            nonlocal aclose_calls
+            aclose_calls += 1
+
+    with pytest.raises(RuntimeError, match="holdings boom"):
+        await svc.fetch_toss_portfolio_snapshot(need_sellable=False, client=_Client())
+
+    # The pending cash task must have been cancelled and drained (the buying
+    # power coroutine observed CancelledError). The shared client (created
+    # client=False here) must NOT be closed — caller owns it.
+    assert bp_cancelled.is_set(), "pending cash task was not cancelled"
+    assert aclose_calls == 0, "client must not be closed when caller owns it"

--- a/tests/test_invest_home_readers.py
+++ b/tests/test_invest_home_readers.py
@@ -1648,8 +1648,8 @@ async def test_toss_api_home_reader_maps_read_only_holdings_and_cash(monkeypatch
     assert result.accounts[0].accountKind == "live"
     assert result.accounts[0].cashBalances.krw == 123456.0
     assert result.accounts[0].cashBalances.usd == 789.01
-    assert result.accounts[0].buyingPower.krw is None
-    assert result.accounts[0].buyingPower.usd is None
+    assert result.accounts[0].buyingPower.krw == 123456.0
+    assert result.accounts[0].buyingPower.usd == 789.01
     holding = result.holdings[0]
     assert holding.source == "toss_api"
     assert holding.sourceOfTruth is True
@@ -1657,6 +1657,78 @@ async def test_toss_api_home_reader_maps_read_only_holdings_and_cash(monkeypatch
     assert holding.manualOnly is False
     assert holding.sellableQuantity == 0.0
     assert holding.referenceQuantity == 1.5
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_toss_api_home_reader_populates_buying_power_card(monkeypatch):
+    from decimal import Decimal
+
+    from app.core.config import settings as _cfg
+    from app.services import invest_home_readers as readers
+    from app.services.toss_portfolio_service import TossPortfolioSnapshot
+
+    async def fake_fetch_toss_snapshot(*, need_sellable=True, sellable_cache=None):
+        return TossPortfolioSnapshot(
+            positions=[],
+            cash_krw=Decimal("500000"),
+            cash_usd=Decimal("42.5"),
+        )
+
+    monkeypatch.setattr(
+        readers, "fetch_toss_portfolio_snapshot", fake_fetch_toss_snapshot
+    )
+    monkeypatch.setattr(_cfg, "toss_live_order_mutations_enabled", False, raising=False)
+
+    result = await readers.TossApiHomeReader().fetch(user_id=1)
+    account = result.accounts[0]
+    # buyingPower is wired from the Toss cashBuyingPower fetch...
+    assert account.buyingPower.krw == 500000.0
+    assert account.buyingPower.usd == 42.5
+    # ...and cashBalances is left exactly as before (additive, no regression).
+    assert account.cashBalances.krw == 500000.0
+    assert account.cashBalances.usd == 42.5
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_toss_api_home_reader_buying_power_fail_open_when_cash_missing(
+    monkeypatch,
+):
+    from app.core.config import settings as _cfg
+    from app.services import invest_home_readers as readers
+    from app.services.toss_portfolio_service import TossPortfolioSnapshot
+
+    async def fake_fetch_toss_snapshot(*, need_sellable=True, sellable_cache=None):
+        # buying_power fetch failed for both currencies -> None + error rows.
+        return TossPortfolioSnapshot(
+            positions=[],
+            cash_krw=None,
+            cash_usd=None,
+            errors=[
+                {
+                    "source": "toss_api",
+                    "stage": "buying_power",
+                    "currency": "KRW",
+                    "error": "boom",
+                },
+            ],
+        )
+
+    monkeypatch.setattr(
+        readers, "fetch_toss_portfolio_snapshot", fake_fetch_toss_snapshot
+    )
+    monkeypatch.setattr(_cfg, "toss_live_order_mutations_enabled", False, raising=False)
+
+    result = await readers.TossApiHomeReader().fetch(user_id=1)
+    account = result.accounts[0]
+    assert account.buyingPower.krw is None
+    assert account.buyingPower.usd is None
+    assert account.cashBalances.krw is None
+    assert account.cashBalances.usd is None
+    # Fail-open: still returns an account, error surfaced as a warning.
+    assert result.warning is not None
+    assert "boom" in result.warning.message
 
 
 @pytest.mark.asyncio
@@ -1912,3 +1984,43 @@ async def test_toss_portfolio_snapshot_emits_phase_spans(
     assert "invest.home.toss_api.holdings" in started
     assert "invest.home.toss_api.sellable_quantity" in started
     assert "invest.home.toss_api.buying_power" in started
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_toss_cash_snapshot_runs_concurrently_with_holdings(monkeypatch):
+    """ROB-707: fetch_toss_cash_snapshot overlaps the holdings fetch. The fake's
+    holdings() only completes once buying_power() has started, so a serial
+    (holdings-then-cash) ordering deadlocks and this test times out."""
+    import asyncio
+    from decimal import Decimal
+    from types import SimpleNamespace
+
+    from app.services import toss_portfolio_service as svc
+
+    bp_started = asyncio.Event()
+
+    class _Client:
+        async def holdings(self):
+            # Completes ONLY if the cash fetch is already in flight.
+            await asyncio.wait_for(bp_started.wait(), timeout=1.0)
+            return SimpleNamespace(items=[])
+
+        async def sellable_quantity(self, *, symbol):  # unused: no items
+            raise AssertionError("no holdings -> no sellable fanout")
+
+        async def buying_power(self, *, currency):
+            bp_started.set()
+            return SimpleNamespace(currency=currency, cash_buying_power=Decimal("10"))
+
+        async def aclose(self):
+            return None
+
+    snap = await asyncio.wait_for(
+        svc.fetch_toss_portfolio_snapshot(need_sellable=False, client=_Client()),
+        timeout=2.0,
+    )
+    assert snap.positions == []
+    assert snap.cash_krw == Decimal("10")
+    assert snap.cash_usd == Decimal("10")
+    assert snap.errors == []


### PR DESCRIPTION
## Summary

`TossApiHomeReader.fetch` was rendering the Toss "Toss" account on `/invest/api/home` and `/invest/api/account-panel` with a **populated `cashBalances` card but an empty `buyingPower` card** (`app/services/invest_home_readers.py:697` — `buyingPower=CashAmounts()`), so the buying-power values that ROB-696 already fetches (`fetch_toss_cash_snapshot`) never surfaced. Two commits:

1. **Wire the empty `buyingPower` card** from the already-materialized `snapshot.cash_krw` / `cash_usd` (no new broker call — the value is already in hand from `GET /api/v1/buying-power`'s `cashBuyingPower` field, `app/services/brokers/toss/dto.py:220-222`). Same `None`-guarded float conversion as the existing `cashBalances` card → additive, fail-open. `cashBalances` is **unchanged**.
2. **Overlap the cash-snapshot fetch with the holdings fetch** inside `fetch_toss_portfolio_snapshot` via `asyncio.ensure_future` right after `active_client` is resolved (before the holdings span), then `await`ed in place. On a warm load (ROB-701 sellable cache hit) the snapshot collapses from `~holdings-RTT + cash-RTT` to `~max(holdings-RTT, cash-RTT)`. `finally` cancels and drains a still-pending task before `aclose()` if the holdings chain raised. Output (positions, cash, error order, three phase-span names) is **byte-for-byte unchanged** — every MCP / action_report / `n8n_kr_morning_report` consumer is unaffected.

## Changes

- `app/services/invest_home_readers.py` — `Account(…)` build in `TossApiHomeReader.fetch`: replace `buyingPower=CashAmounts()` with `CashAmounts(krw=…snapshot.cash_krw…, usd=…snapshot.cash_usd…)` mirroring the existing `cashBalances` `None`-guard. `cashBalances` left untouched.
- `app/services/toss_portfolio_service.py` —
  - add `import contextlib`.
  - `fetch_toss_portfolio_snapshot`: kick off `fetch_toss_cash_snapshot` as an early `asyncio.ensure_future` (after `active_client` resolution, before the holdings span).
  - replace the serial `await fetch_toss_cash_snapshot(...)` at the end of the body with `await cash_task`.
  - extend the `finally` to cancel/drain a still-pending cash task **before** closing the shared client (so a holdings-chain raise never leaves a pending task touching a closed client).
  - signature, return type, fields, error ordering, span names: **unchanged**.
- `tests/test_invest_home_readers.py` —
  - flip the stale `buyingPower is None` assertions in `test_toss_api_home_reader_maps_read_only_holdings_and_cash` to the fetched values.
  - add `test_toss_api_home_reader_populates_buying_power_card`: mutations off, snapshot cash → card populated, `cashBalances` unchanged.
  - add `test_toss_api_home_reader_buying_power_fail_open_when_cash_missing`: failed currency → `None` on both cards, warning surfaces the error, no exception.
  - add `test_toss_cash_snapshot_runs_concurrently_with_holdings`: event-barrier fake whose `holdings()` only completes once `buying_power()` has started — serial ordering deadlocks (RED before impl, GREEN after).

## Constraints honored

- **Additive, read-only, fail-open.** A missing/failed currency yields `None` on the card and the error is surfaced through the existing `snapshot.errors` → `InvestHomeWarning` path. No new exception type, no new warning channel.
- **NOT a broker reassignment.** Each account reads its own broker (account-scoped); this only fills the Toss account's own buying-power card. No KIS/Upbit/Kiwoom routing changes.
- **No duplicate broker call.** Reuses the already-built `fetch_toss_cash_snapshot` / `snapshot.cash_krw` / `cash_usd`. Still exactly 2 `buying_power(...)` calls per snapshot — only *when* they run relative to holdings changes.
- **`cashBalances` left byte-for-byte.** Task 1 fills only the empty `buyingPower` card.
- **`fetch_toss_portfolio_snapshot` output preserved for every consumer.** ROB-701 sellable-cache branch, ROB-685 `need_sellable=False` skip, position-build loop, sellable-errors-then-cash-errors ordering, and the three phase-span names (`invest.home.toss_api.holdings`, `…sellable_quantity`, `…buying_power`) are unchanged. `portfolio_holdings.py`, `portfolio_cash.py`, and `n8n_kr_morning_report_service.py` see identical results.
- **Cash card NOT gated on `mutations_enabled`.** Only holdings tradeability/sellable is gated (ROB-549, `invest_home_readers.py:517-534`); the cash cards are never gated. The pre-existing `mutations=False` reader test (`test_toss_api_home_reader_maps_read_only_holdings_and_cash`) now shows a populated `buyingPower`.
- **Toss endpoint contract unchanged.** Still `GET /api/v1/buying-power`, `TossApiGroup.ORDER_INFO`, 6 TPS / 3 TPS peak — only the wall-clock overlap changes.
- **migration-0.** No alembic revision. No config/env change. No new dependency.

## Verification

- RED → GREEN: `test_toss_api_home_reader_populates_buying_power_card` and the flipped `…_maps_read_only_holdings_and_cash` failed on the old impl (empty `CashAmounts()`) and pass after wiring the card. `test_toss_cash_snapshot_runs_concurrently_with_holdings` timed out on the old impl (serial ordering deadlocked the event-barrier fake) and passes after the `ensure_future` overlap.
- `test_toss_api_home_reader_buying_power_fail_open_when_cash_missing` was already green and stays green — locks the fail-open path so a future refactor can't silently regress it.
- Full suite (no `--cov`, faster):
  - `tests/test_toss_portfolio_service.py` → **11 passed** (cache hit / TTL expiry / no-cache default / `need_sellable=False` skip / position-build / KR-market / keep-position-on-sellable-fail / cash-snapshot-no-holdings).
  - `tests/test_invest_home_readers.py` → **40 passed** (incl. `test_toss_portfolio_snapshot_emits_phase_spans` which proves the three phase-span names still open).
  - `tests/test_mcp_portfolio_tools.py` → **85 passed** (consumer of `fetch_toss_portfolio_snapshot` / `fetch_toss_cash_snapshot`).
  - `tests/test_n8n_kr_morning_report.py` → **16 passed** (consumer).
  - `tests/test_mcp_available_capital.py` → **12 passed**.
  - `tests/mcp_server/tooling/test_toss_sellable_need_flag.py` → **3 passed**.
  - `tests/test_toss_cash_orderable_gate.py` → **2 passed**.
  - **Total: 171 passed, 0 failed.**
- `make lint` → `ruff check` / `ruff format --check` / `ty check --error-on-warning` all clean.

## Model-lane

`keep_on_gpt54` — display-wiring + a tiny `ensure_future` overlap. migration-0, additive, fail-open, output byte-for-byte preserved. No auth/permission/security/DB-schema/migration/live-order/strategy/deployment boundary touched.

Refs: ROB-707