### PR TITLE
feat(ROB-716): decision_history surface on stock detail (replace dead latestAnalysis)

### DIFF
--- a/app/schemas/invest_stock_detail.py
+++ b/app/schemas/invest_stock_detail.py
@@ -384,17 +384,71 @@ class StockDetailFxSensitivity(BaseModel):
         return self
 
 
-class StockDetailLatestAnalysis(BaseModel):
+class StockDetailDecisionHistoryPriorDecision(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    id: int
-    modelName: str | None = None
-    decision: AnalysisDecision | None = None
+    date: str | None = None
+    intent: str | None = None
+    side: str | None = None
+    decisionBucket: str | None = None
     confidence: float | None = None
-    appropriateBuyRange: tuple[float | None, float | None] | None = None
-    appropriateSellRange: tuple[float | None, float | None] | None = None
-    reasonsTop3: list[str] = Field(default_factory=list, max_length=3)
-    createdAt: datetime | None = None
+    rationale: str | None = None
+
+
+class StockDetailDecisionHistoryOutcome(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    date: str | None = None
+    side: str | None = None
+    outcome: str | None = None
+    triggerType: str | None = None
+    pnlPct: float | None = None
+    realizedPnl: float | None = None
+
+
+class StockDetailDecisionHistoryOpenClaim(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    probability: float | None = None
+    horizon: str | None = None
+    reviewDate: str | None = None
+    direction: str | None = None
+    targetPrice: float | None = None
+
+
+class StockDetailDecisionHistoryBrier(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    n: int = 0
+    meanBrier: float | None = None
+    flag: Literal["ok", "insufficient_sample"] = "insufficient_sample"
+
+
+class StockDetailDecisionHistory(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    symbol: str
+    market: str
+    linkQuality: str = "symbol_window"
+    priorDecisions: list[StockDetailDecisionHistoryPriorDecision] = Field(
+        default_factory=list
+    )
+    priorLessons: list[str] = Field(default_factory=list)
+    realizedOutcomes: list[StockDetailDecisionHistoryOutcome] = Field(
+        default_factory=list
+    )
+    openClaims: list[StockDetailDecisionHistoryOpenClaim] = Field(
+        default_factory=list
+    )
+    runningBrierSymbol: StockDetailDecisionHistoryBrier = Field(
+        default_factory=StockDetailDecisionHistoryBrier
+    )
+    runningBrierGlobal: StockDetailDecisionHistoryBrier = Field(
+        default_factory=StockDetailDecisionHistoryBrier
+    )
+    cautionLabel: str = (
+        "종목 기준 집계이며 특정 판단과 특정 결과의 직접 연결이 아닙니다."
+    )
 
 
 class StockDetailOrderbookLevel(BaseModel):
@@ -511,7 +565,7 @@ class StockDetailResponse(BaseModel):
     investorFlow: StockDetailInvestorFlow | None = None
     holding: StockDetailHolding | None = None
     fxSensitivity: StockDetailFxSensitivity | None = None
-    latestAnalysis: StockDetailLatestAnalysis | None = None
+    decisionHistory: StockDetailDecisionHistory | None = None
     orderbookSupport: StockDetailOrderbookSupport
     orderbook: StockDetailOrderbook | None = None
     capabilities: StockDetailCapabilities

--- a/app/schemas/invest_stock_detail.py
+++ b/app/schemas/invest_stock_detail.py
@@ -437,9 +437,7 @@ class StockDetailDecisionHistory(BaseModel):
     realizedOutcomes: list[StockDetailDecisionHistoryOutcome] = Field(
         default_factory=list
     )
-    openClaims: list[StockDetailDecisionHistoryOpenClaim] = Field(
-        default_factory=list
-    )
+    openClaims: list[StockDetailDecisionHistoryOpenClaim] = Field(default_factory=list)
     runningBrierSymbol: StockDetailDecisionHistoryBrier = Field(
         default_factory=StockDetailDecisionHistoryBrier
     )

--- a/app/services/invest_view_model/naver_stock_detail_poc.py
+++ b/app/services/invest_view_model/naver_stock_detail_poc.py
@@ -100,7 +100,7 @@ async def build_naver_stock_detail_poc(
                 url=f"https://stock.naver.com/worldstock/stock/{quoted}/investmentinfo",
                 status="needs_auth_or_contract_check",
                 payloadFields=["analyst/consensus-like widgets if available"],
-                mappedFields=["latestAnalysis", "valuation"],
+                mappedFields=["valuation"],
                 risk="May be personalized or contract-gated; do not depend on it in production without review.",
             ),
         ]

--- a/app/services/invest_view_model/stock_detail_providers.py
+++ b/app/services/invest_view_model/stock_detail_providers.py
@@ -6,12 +6,13 @@ from typing import Any
 
 from app.schemas.invest_feed_news import NewsMarket
 from app.schemas.invest_stock_detail import (
+    StockDetailDecisionHistory,
     StockDetailHolding,
-    StockDetailLatestAnalysis,
     StockDetailOrderbook,
     StockDetailQuote,
     StockDetailValuation,
 )
+from app.services.decision_history import build_decision_context
 
 
 def _period_for_market_data(period: str) -> str:
@@ -142,47 +143,62 @@ async def stock_detail_valuation_provider(
     )
 
 
-def _reasons_top3(value: Any) -> list[str]:
-    if isinstance(value, list):
-        return [str(item) for item in value if item][:3]
-    if isinstance(value, dict):
-        for key in ("reasons", "top3", "summary"):
-            nested = value.get(key)
-            if isinstance(nested, list):
-                return [str(item) for item in nested if item][:3]
-    return []
+def _brier(raw: Any) -> dict[str, Any]:
+    raw = raw if isinstance(raw, dict) else {}
+    return {
+        "n": raw.get("n", 0),
+        "meanBrier": raw.get("mean_brier"),
+        "flag": raw.get("flag", "insufficient_sample"),
+    }
 
 
-async def stock_detail_latest_analysis_provider(
+async def stock_detail_decision_history_provider(
     market: NewsMarket, symbol: str, db: Any
-) -> StockDetailLatestAnalysis | None:
-    from app.services.stock_info_service import StockAnalysisService
-
-    _ = market
+) -> StockDetailDecisionHistory | None:
     if not hasattr(db, "execute"):
         return None
-    analysis = await StockAnalysisService(db).get_latest_analysis_by_symbol(symbol)
-    if analysis is None:
+    ctx = await build_decision_context(db, symbol, market)
+    if ctx is None:
         return None
-    return StockDetailLatestAnalysis(
-        id=analysis.id,
-        modelName=analysis.model_name,
-        decision=analysis.decision,
-        confidence=(
-            float(analysis.confidence) / 100.0
-            if analysis.confidence is not None
-            else None
-        ),
-        appropriateBuyRange=(
-            analysis.appropriate_buy_min,
-            analysis.appropriate_buy_max,
-        ),
-        appropriateSellRange=(
-            analysis.appropriate_sell_min,
-            analysis.appropriate_sell_max,
-        ),
-        reasonsTop3=_reasons_top3(analysis.reasons),
-        createdAt=analysis.created_at,
+    return StockDetailDecisionHistory(
+        symbol=ctx.get("symbol", symbol),
+        market=ctx.get("market", market),
+        linkQuality=ctx.get("link_quality", "symbol_window"),
+        priorDecisions=[
+            {
+                "date": d.get("date"),
+                "intent": d.get("intent"),
+                "side": d.get("side"),
+                "decisionBucket": d.get("decision_bucket"),
+                "confidence": d.get("confidence"),
+                "rationale": d.get("rationale"),
+            }
+            for d in ctx.get("prior_decisions", [])
+        ],
+        priorLessons=list(ctx.get("prior_lessons", [])),
+        realizedOutcomes=[
+            {
+                "date": o.get("date"),
+                "side": o.get("side"),
+                "outcome": o.get("outcome"),
+                "triggerType": o.get("trigger_type"),
+                "pnlPct": o.get("pnl_pct"),
+                "realizedPnl": o.get("realized_pnl"),
+            }
+            for o in ctx.get("realized_outcomes", [])
+        ],
+        openClaims=[
+            {
+                "probability": c.get("probability"),
+                "horizon": c.get("horizon"),
+                "reviewDate": c.get("review_date"),
+                "direction": c.get("direction"),
+                "targetPrice": c.get("target_price"),
+            }
+            for c in ctx.get("open_claims", [])
+        ],
+        runningBrierSymbol=_brier(ctx.get("running_brier_symbol")),
+        runningBrierGlobal=_brier(ctx.get("running_brier_global")),
     )
 
 
@@ -228,7 +244,7 @@ def make_account_panel_holding_provider(home_service: Any) -> HoldingProvider:
 __all__ = [
     "make_account_panel_holding_provider",
     "stock_detail_candle_provider",
-    "stock_detail_latest_analysis_provider",
+    "stock_detail_decision_history_provider",
     "stock_detail_orderbook_provider",
     "stock_detail_quote_provider",
     "stock_detail_valuation_provider",

--- a/app/services/invest_view_model/stock_detail_service.py
+++ b/app/services/invest_view_model/stock_detail_service.py
@@ -22,6 +22,7 @@ from app.schemas.invest_stock_detail import (
     CryptoDetailProfile,
     CryptoRecentTradeItem,
     CryptoRecentTrades,
+    StockDetailDecisionHistory,
     StockDetailDiscussionSignal,
     StockDetailFxScenario,
     StockDetailFxSensitivity,
@@ -30,7 +31,6 @@ from app.schemas.invest_stock_detail import (
     StockDetailInvestorFlowBuyerDecomposition,
     StockDetailInvestorFlowDailyRow,
     StockDetailInvestorFlowPeriodSummary,
-    StockDetailLatestAnalysis,
     StockDetailMeta,
     StockDetailNaverEnrichment,
     StockDetailOrderbook,
@@ -53,7 +53,7 @@ from app.services.invest_view_model.naver_stock_detail_poc import (
     build_naver_stock_detail_poc,
 )
 from app.services.invest_view_model.stock_detail_providers import (
-    stock_detail_latest_analysis_provider,
+    stock_detail_decision_history_provider,
     stock_detail_orderbook_provider,
     stock_detail_quote_provider,
     stock_detail_valuation_provider,
@@ -438,7 +438,7 @@ class StockDetailProviders:
     screener: Provider = _none_provider
     valuation: Provider = stock_detail_valuation_provider
     holding: Provider = _none_provider
-    latest_analysis: Provider = stock_detail_latest_analysis_provider
+    decision_history: Provider = stock_detail_decision_history_provider
     orderbook: Provider = stock_detail_orderbook_provider
     fx_rate: Provider = get_usd_krw_quote
     naver_enrichment: Provider = build_naver_stock_detail_poc
@@ -487,9 +487,9 @@ async def build_stock_detail(
         warnings,
         timeout=_HOLDING_PROVIDER_TIMEOUT_SECONDS,
     )
-    latest_analysis_task = _run_optional_block(
-        "latest_analysis",
-        providers.latest_analysis(market, resolved.symbol_db, db),
+    decision_history_task = _run_optional_block(
+        "decision_history",
+        providers.decision_history(market, resolved.symbol_db, db),
         warnings,
     )
     naver_enrichment_task = _run_optional_block(
@@ -536,7 +536,7 @@ async def build_stock_detail(
         screener_snapshot,
         valuation,
         holding,
-        latest_analysis,
+        decision_history,
         naver_enrichment,
         discussion_signal,
         orderbook,
@@ -548,7 +548,7 @@ async def build_stock_detail(
         screener_task,
         valuation_task,
         holding_task,
-        latest_analysis_task,
+        decision_history_task,
         naver_enrichment_task,
         discussion_signal_task,
         orderbook_task,
@@ -575,10 +575,10 @@ async def build_stock_detail(
         quote = StockDetailQuote.model_validate(quote)
     if holding is not None and not isinstance(holding, StockDetailHolding):
         holding = StockDetailHolding.model_validate(holding)
-    if latest_analysis is not None and not isinstance(
-        latest_analysis, StockDetailLatestAnalysis
+    if decision_history is not None and not isinstance(
+        decision_history, StockDetailDecisionHistory
     ):
-        latest_analysis = StockDetailLatestAnalysis.model_validate(latest_analysis)
+        decision_history = StockDetailDecisionHistory.model_validate(decision_history)
     if naver_enrichment is not None and not isinstance(
         naver_enrichment, StockDetailNaverEnrichment
     ):
@@ -708,7 +708,7 @@ async def build_stock_detail(
         investorFlow=investor_flow,
         holding=holding,
         fxSensitivity=fx_sensitivity,
-        latestAnalysis=latest_analysis,
+        decisionHistory=decision_history,
         orderbookSupport=orderbook_support,
         orderbook=orderbook,
         capabilities=capabilities,

--- a/docs/superpowers/plans/2026-07-05-rob-716-decision-history-surface.md
+++ b/docs/superpowers/plans/2026-07-05-rob-716-decision-history-surface.md
@@ -1,0 +1,768 @@
+# ROB-716 Decision History Surface Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 종목상세 "최근 분석" 패널을 죽은 `stock_analysis_results` 대신 ROB-711 `build_decision_context`(라이브 판단→결과 학습루프)로 재연결한다.
+
+**Architecture:** 기존 `build_stock_detail` provider 패턴에 provider 1개 + 응답 필드(`decisionHistory`) + 프론트 카드(`DecisionHistoryCard`)를 추가하고, 죽은 `latestAnalysis` 계열(provider·스키마·프론트 타입·카드)을 제거한다. 데이터는 `app/services/decision_history.py::build_decision_context(db, symbol, market)`를 그대로 호출 — join 로직 재구현 없음.
+
+**Tech Stack:** Python 3.13 / FastAPI / Pydantic v2 (`ConfigDict(extra="forbid")`) / SQLAlchemy async / pytest (`@pytest.mark.unit`, `@pytest.mark.asyncio`) / React + TypeScript / vitest.
+
+## Global Constraints
+
+- Migration 0 — DB 스키마 변경 금지. read-only.
+- 브로커/주문/감시/order-intent mutation 무접촉.
+- In-process LLM provider import 금지 (ROB-501; `app/**` 정적 가드).
+- 모든 신규 Pydantic 모델은 `model_config = ConfigDict(extra="forbid")`.
+- 데이터 소스는 `build_decision_context` 재사용 — 새 join 로직 작성 금지.
+- 테스트 실행: `uv run pytest <path> -v`. 프론트: `cd frontend/invest && npm test`.
+- 커밋 트레일러: `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`.
+
+---
+
+## File Structure
+
+- `app/schemas/invest_stock_detail.py` — `StockDetailLatestAnalysis` 제거, `StockDetailDecisionHistory*` 5개 모델 추가, `StockDetailResponse` 필드 교체.
+- `app/services/invest_view_model/stock_detail_providers.py` — `stock_detail_latest_analysis_provider`+`_reasons_top3` 제거, `stock_detail_decision_history_provider` 추가.
+- `app/services/invest_view_model/stock_detail_service.py` — `StockDetailProviders`/`build_stock_detail` 배선 교체.
+- `frontend/invest/src/types/stockDetail.ts` — 타입 교체.
+- `frontend/invest/src/pages/stock-detail/StockDetailPage.tsx` — `AnalysisCard`→`DecisionHistoryCard`.
+- `frontend/invest/src/__tests__/StockDetailPage.test.tsx` — fixture 교체.
+- Tests: `tests/test_invest_stock_detail_schemas.py`, `tests/test_stock_detail_providers.py`, `tests/test_stock_detail_service.py`.
+
+Task 순서 = 의존 순서: 스키마(1) → provider(2) → 서비스 배선(3) → 프론트(4).
+
+---
+
+### Task 1: `decisionHistory` 스키마 (신규 모델 + 응답 필드 교체)
+
+**Files:**
+- Modify: `app/schemas/invest_stock_detail.py` (제거 `StockDetailLatestAnalysis` @387-397, 제거 `StockDetailResponse.latestAnalysis` @514; 신규 모델 추가)
+- Test: `tests/test_invest_stock_detail_schemas.py`
+
+**Interfaces:**
+- Produces:
+  - `StockDetailDecisionHistoryPriorDecision(date: str|None, intent: str|None, side: str|None, decisionBucket: str|None, confidence: float|None, rationale: str|None)`
+  - `StockDetailDecisionHistoryOutcome(date: str|None, side: str|None, outcome: str|None, triggerType: str|None, pnlPct: float|None, realizedPnl: float|None)`
+  - `StockDetailDecisionHistoryOpenClaim(probability: float|None, horizon: str|None, reviewDate: str|None, direction: str|None, targetPrice: float|None)`
+  - `StockDetailDecisionHistoryBrier(n: int, meanBrier: float|None, flag: Literal["ok","insufficient_sample"])`
+  - `StockDetailDecisionHistory(symbol: str, market: str, linkQuality: str, priorDecisions: list[...], priorLessons: list[str], realizedOutcomes: list[...], openClaims: list[...], runningBrierSymbol: Brier, runningBrierGlobal: Brier, cautionLabel: str)`
+  - `StockDetailResponse.decisionHistory: StockDetailDecisionHistory | None`
+
+- [ ] **Step 1: 실패 테스트 작성** — `tests/test_invest_stock_detail_schemas.py` 끝에 추가
+
+```python
+@pytest.mark.unit
+def test_decision_history_schema_forbids_extra_and_maps_sections():
+    from app.schemas.invest_stock_detail import (
+        StockDetailDecisionHistory,
+        StockDetailDecisionHistoryBrier,
+    )
+
+    model = StockDetailDecisionHistory(
+        symbol="000660",
+        market="kr",
+        linkQuality="symbol_window",
+        priorDecisions=[
+            {
+                "date": "2026-06-28",
+                "intent": "buy_review",
+                "side": "buy",
+                "decisionBucket": "new_buy_candidate",
+                "confidence": 0.7,
+                "rationale": "HBM 수요 지속",
+            }
+        ],
+        priorLessons=["과열 구간 추격 금지"],
+        realizedOutcomes=[
+            {
+                "date": "2026-06-20",
+                "side": "sell",
+                "outcome": "stop_loss",
+                "triggerType": "stop",
+                "pnlPct": -3.1,
+                "realizedPnl": -31000.0,
+            }
+        ],
+        openClaims=[
+            {
+                "probability": 0.7,
+                "horizon": "1w",
+                "reviewDate": "2026-07-10",
+                "direction": "up",
+                "targetPrice": 82000.0,
+            }
+        ],
+        runningBrierSymbol=StockDetailDecisionHistoryBrier(
+            n=12, meanBrier=0.18, flag="ok"
+        ),
+        runningBrierGlobal=StockDetailDecisionHistoryBrier(
+            n=4, meanBrier=None, flag="insufficient_sample"
+        ),
+    )
+    assert model.priorDecisions[0].confidence == 0.7
+    assert model.realizedOutcomes[0].outcome == "stop_loss"
+    assert model.openClaims[0].targetPrice == 82000.0
+    assert model.runningBrierGlobal.flag == "insufficient_sample"
+    assert "직접 연결" in model.cautionLabel  # default caution present
+
+    with pytest.raises(ValidationError):
+        StockDetailDecisionHistoryBrier(n=1, meanBrier=0.1, flag="ok", extra="x")
+```
+
+`ValidationError`/`pytest` import가 파일 상단에 없으면 추가.
+
+- [ ] **Step 2: 실패 확인**
+
+Run: `uv run pytest tests/test_invest_stock_detail_schemas.py::test_decision_history_schema_forbids_extra_and_maps_sections -v`
+Expected: FAIL — `ImportError: cannot import name 'StockDetailDecisionHistory'`.
+
+- [ ] **Step 3: 스키마 구현** — `app/schemas/invest_stock_detail.py`
+
+`StockDetailLatestAnalysis` 클래스(@387-397)를 아래 5개 모델로 **교체**(삭제 후 삽입):
+
+```python
+class StockDetailDecisionHistoryPriorDecision(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    date: str | None = None
+    intent: str | None = None
+    side: str | None = None
+    decisionBucket: str | None = None
+    confidence: float | None = None
+    rationale: str | None = None
+
+
+class StockDetailDecisionHistoryOutcome(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    date: str | None = None
+    side: str | None = None
+    outcome: str | None = None
+    triggerType: str | None = None
+    pnlPct: float | None = None
+    realizedPnl: float | None = None
+
+
+class StockDetailDecisionHistoryOpenClaim(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    probability: float | None = None
+    horizon: str | None = None
+    reviewDate: str | None = None
+    direction: str | None = None
+    targetPrice: float | None = None
+
+
+class StockDetailDecisionHistoryBrier(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    n: int = 0
+    meanBrier: float | None = None
+    flag: Literal["ok", "insufficient_sample"] = "insufficient_sample"
+
+
+class StockDetailDecisionHistory(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    symbol: str
+    market: str
+    linkQuality: str = "symbol_window"
+    priorDecisions: list[StockDetailDecisionHistoryPriorDecision] = Field(
+        default_factory=list
+    )
+    priorLessons: list[str] = Field(default_factory=list)
+    realizedOutcomes: list[StockDetailDecisionHistoryOutcome] = Field(
+        default_factory=list
+    )
+    openClaims: list[StockDetailDecisionHistoryOpenClaim] = Field(
+        default_factory=list
+    )
+    runningBrierSymbol: StockDetailDecisionHistoryBrier = Field(
+        default_factory=StockDetailDecisionHistoryBrier
+    )
+    runningBrierGlobal: StockDetailDecisionHistoryBrier = Field(
+        default_factory=StockDetailDecisionHistoryBrier
+    )
+    cautionLabel: str = (
+        "종목 기준 집계이며 특정 판단과 특정 결과의 직접 연결이 아닙니다."
+    )
+```
+
+`AnalysisDecision` 별칭(@44)은 그대로 둔다(Literal 별칭, 미사용이어도 lint 무해).
+
+`StockDetailResponse`(@495~)에서 `latestAnalysis: StockDetailLatestAnalysis | None = None` 라인을 다음으로 교체:
+
+```python
+    decisionHistory: StockDetailDecisionHistory | None = None
+```
+
+- [ ] **Step 4: 통과 확인**
+
+Run: `uv run pytest tests/test_invest_stock_detail_schemas.py -v`
+Expected: PASS (신규 테스트 + 기존 스키마 테스트 전부).
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add app/schemas/invest_stock_detail.py tests/test_invest_stock_detail_schemas.py
+git commit -m "feat(ROB-716): decisionHistory response schema, drop latestAnalysis
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: `stock_detail_decision_history_provider` (provider 교체)
+
+**Files:**
+- Modify: `app/services/invest_view_model/stock_detail_providers.py` (제거 `stock_detail_latest_analysis_provider`+`_reasons_top3`+`StockAnalysisService`/`StockDetailLatestAnalysis` import; 신규 provider + `build_decision_context` import + `__all__` 갱신)
+- Test: `tests/test_stock_detail_providers.py`
+
+**Interfaces:**
+- Consumes: `app.services.decision_history.build_decision_context(db, symbol, market) -> dict | None` (모듈에 import — 테스트가 `providers.build_decision_context`로 monkeypatch).
+- Produces: `stock_detail_decision_history_provider(market: NewsMarket, symbol: str, db) -> StockDetailDecisionHistory | None`.
+
+- [ ] **Step 1: 실패 테스트 작성** — `tests/test_stock_detail_providers.py`의 두 `latest_analysis` 테스트(@387-454)를 아래로 **교체**
+
+```python
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_decision_history_provider_maps_payload(monkeypatch):
+    from app.services.invest_view_model import stock_detail_providers as providers
+
+    payload = {
+        "symbol": "000660",
+        "market": "kr",
+        "link_quality": "symbol_window",
+        "prior_decisions": [
+            {
+                "date": "2026-06-28",
+                "intent": "buy_review",
+                "side": "buy",
+                "decision_bucket": "new_buy_candidate",
+                "confidence": 0.7,
+                "rationale": "HBM 수요",
+            }
+        ],
+        "prior_lessons": ["추격 금지"],
+        "realized_outcomes": [
+            {
+                "date": "2026-06-20",
+                "side": "sell",
+                "outcome": "stop_loss",
+                "trigger_type": "stop",
+                "pnl_pct": -3.1,
+                "realized_pnl": -31000.0,
+            }
+        ],
+        "recent_fills": [{"date": "2026-06-20", "side": "sell"}],  # 의도적 무시
+        "open_claims": [
+            {
+                "probability": 0.7,
+                "horizon": "1w",
+                "review_date": "2026-07-10",
+                "direction": "up",
+                "target_price": 82000.0,
+            }
+        ],
+        "running_brier_symbol": {"n": 12, "mean_brier": 0.18, "flag": "ok"},
+        "running_brier_global": {"n": 4, "mean_brier": None, "flag": "insufficient_sample"},
+    }
+
+    async def fake_build(db, symbol, market):
+        assert symbol == "000660"
+        assert market == "kr"
+        return payload
+
+    monkeypatch.setattr(providers, "build_decision_context", fake_build)
+
+    result = await providers.stock_detail_decision_history_provider(
+        "kr", "000660", SimpleNamespace(execute=object())
+    )
+
+    assert result is not None
+    assert result.linkQuality == "symbol_window"
+    assert result.priorDecisions[0].decisionBucket == "new_buy_candidate"
+    assert result.realizedOutcomes[0].triggerType == "stop"
+    assert result.realizedOutcomes[0].pnlPct == -3.1
+    assert result.openClaims[0].targetPrice == 82000.0
+    assert result.runningBrierSymbol.n == 12
+    assert result.runningBrierGlobal.flag == "insufficient_sample"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_decision_history_provider_returns_none(monkeypatch):
+    from app.services.invest_view_model import stock_detail_providers as providers
+
+    async def fake_build(db, symbol, market):
+        return None
+
+    monkeypatch.setattr(providers, "build_decision_context", fake_build)
+
+    # no db.execute → None (build_decision_context never called)
+    assert (
+        await providers.stock_detail_decision_history_provider("kr", "000660", object())
+        is None
+    )
+    # db present but no signal → None
+    assert (
+        await providers.stock_detail_decision_history_provider(
+            "kr", "000660", SimpleNamespace(execute=object())
+        )
+        is None
+    )
+```
+
+- [ ] **Step 2: 실패 확인**
+
+Run: `uv run pytest tests/test_stock_detail_providers.py -k decision_history -v`
+Expected: FAIL — `AttributeError: module ... has no attribute 'stock_detail_decision_history_provider'`.
+
+- [ ] **Step 3: provider 구현** — `stock_detail_providers.py`
+
+상단 import 교체: `StockDetailLatestAnalysis` 를 `StockDetailDecisionHistory`로 바꾸고, 파일 상단 import 블록에 추가:
+
+```python
+from app.services.decision_history import build_decision_context
+```
+
+`_reasons_top3`(@145-153) 및 `stock_detail_latest_analysis_provider`(@156-186) 전체를 아래로 **교체**:
+
+```python
+def _brier(raw: Any) -> dict[str, Any]:
+    raw = raw if isinstance(raw, dict) else {}
+    return {
+        "n": raw.get("n", 0),
+        "meanBrier": raw.get("mean_brier"),
+        "flag": raw.get("flag", "insufficient_sample"),
+    }
+
+
+async def stock_detail_decision_history_provider(
+    market: NewsMarket, symbol: str, db: Any
+) -> StockDetailDecisionHistory | None:
+    if not hasattr(db, "execute"):
+        return None
+    ctx = await build_decision_context(db, symbol, market)
+    if ctx is None:
+        return None
+    return StockDetailDecisionHistory(
+        symbol=ctx.get("symbol", symbol),
+        market=ctx.get("market", market),
+        linkQuality=ctx.get("link_quality", "symbol_window"),
+        priorDecisions=[
+            {
+                "date": d.get("date"),
+                "intent": d.get("intent"),
+                "side": d.get("side"),
+                "decisionBucket": d.get("decision_bucket"),
+                "confidence": d.get("confidence"),
+                "rationale": d.get("rationale"),
+            }
+            for d in ctx.get("prior_decisions", [])
+        ],
+        priorLessons=list(ctx.get("prior_lessons", [])),
+        realizedOutcomes=[
+            {
+                "date": o.get("date"),
+                "side": o.get("side"),
+                "outcome": o.get("outcome"),
+                "triggerType": o.get("trigger_type"),
+                "pnlPct": o.get("pnl_pct"),
+                "realizedPnl": o.get("realized_pnl"),
+            }
+            for o in ctx.get("realized_outcomes", [])
+        ],
+        openClaims=[
+            {
+                "probability": c.get("probability"),
+                "horizon": c.get("horizon"),
+                "reviewDate": c.get("review_date"),
+                "direction": c.get("direction"),
+                "targetPrice": c.get("target_price"),
+            }
+            for c in ctx.get("open_claims", [])
+        ],
+        runningBrierSymbol=_brier(ctx.get("running_brier_symbol")),
+        runningBrierGlobal=_brier(ctx.get("running_brier_global")),
+    )
+```
+
+(`recent_fills`는 의도적으로 매핑하지 않음 — YAGNI, 주문 카드가 이미 노출.)
+
+`__all__`에서 `"stock_detail_latest_analysis_provider"` 제거, `"stock_detail_decision_history_provider"` 추가(알파벳 순).
+
+- [ ] **Step 4: 통과 확인**
+
+Run: `uv run pytest tests/test_stock_detail_providers.py -v`
+Expected: PASS. 그리고 `uv run ruff check app/services/invest_view_model/stock_detail_providers.py` — 미사용 import 없음.
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add app/services/invest_view_model/stock_detail_providers.py tests/test_stock_detail_providers.py
+git commit -m "feat(ROB-716): decision_history provider reuses build_decision_context
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: 서비스 배선 (`StockDetailProviders` + `build_stock_detail`)
+
+**Files:**
+- Modify: `app/services/invest_view_model/stock_detail_service.py` (import, `StockDetailProviders`, `build_stock_detail` 본문, `StockDetailResponse(...)`)
+- Test: `tests/test_stock_detail_service.py`
+
+**Interfaces:**
+- Consumes: `stock_detail_decision_history_provider` (Task 2), `StockDetailDecisionHistory` (Task 1).
+- Produces: `StockDetailResponse.decisionHistory` 배선; warning key `decision_history_unavailable` / `decision_history_timeout` (기존 `_run_optional_block` 규약).
+
+- [ ] **Step 1: 실패 테스트 작성** — `tests/test_stock_detail_service.py`에 추가. **기존 모듈 헬퍼 `_resolve_kr`(symbol `005930`, @35-44)를 재사용**한다(직접 `ResolvedSymbol`을 만들지 말 것 — 필드 값 오류 방지). 파일 상단에 이미 `StockDetailProviders`, `build_stock_detail`, `SimpleNamespace` import 있음. `StockDetailDecisionHistory`만 로컬 import.
+
+```python
+@pytest.mark.asyncio
+async def test_build_stock_detail_wires_decision_history():
+    from app.schemas.invest_stock_detail import StockDetailDecisionHistory
+
+    async def decision_history(market, symbol, db):
+        assert symbol == "005930"
+        return StockDetailDecisionHistory(symbol="005930", market="kr")
+
+    providers = StockDetailProviders(
+        resolver=_resolve_kr, decision_history=decision_history
+    )
+
+    result = await build_stock_detail(
+        user_id=1,
+        market="kr",
+        symbol="005930",
+        db=SimpleNamespace(execute=object()),
+        providers=providers,
+    )
+
+    assert result.decisionHistory is not None
+    assert result.decisionHistory.symbol == "005930"
+    assert "decision_history_unavailable" not in result.meta.warnings
+
+
+@pytest.mark.asyncio
+async def test_build_stock_detail_isolates_decision_history_failure():
+    async def decision_history(market, symbol, db):
+        raise RuntimeError("boom")
+
+    providers = StockDetailProviders(
+        resolver=_resolve_kr, decision_history=decision_history
+    )
+
+    result = await build_stock_detail(
+        user_id=1,
+        market="kr",
+        symbol="005930",
+        db=SimpleNamespace(execute=object()),
+        providers=providers,
+    )
+
+    assert result.decisionHistory is None
+    assert "decision_history_unavailable" in result.meta.warnings
+```
+
+- [ ] **Step 2: 실패 확인**
+
+Run: `uv run pytest tests/test_stock_detail_service.py -k decision_history -v`
+Expected: FAIL — `TypeError: StockDetailProviders.__init__ got unexpected keyword 'decision_history'` (아직 `latest_analysis` 필드).
+
+- [ ] **Step 3: 서비스 배선** — `stock_detail_service.py`
+
+import 블록(@32, @55-60): `StockDetailLatestAnalysis` → `StockDetailDecisionHistory`, `stock_detail_latest_analysis_provider` → `stock_detail_decision_history_provider`.
+
+`StockDetailProviders`(@441): 
+```python
+    latest_analysis: Provider = stock_detail_latest_analysis_provider
+```
+→
+```python
+    decision_history: Provider = stock_detail_decision_history_provider
+```
+
+`build_stock_detail` 본문의 `latest_analysis_task`(@490-494)를:
+```python
+    decision_history_task = _run_optional_block(
+        "decision_history",
+        providers.decision_history(market, resolved.symbol_db, db),
+        warnings,
+    )
+```
+
+`asyncio.gather` 언팩(@534-558)에서 `latest_analysis` → `decision_history`, `latest_analysis_task` → `decision_history_task` (같은 위치).
+
+후처리 isinstance 변환(@578-581)을 교체:
+```python
+    if decision_history is not None and not isinstance(
+        decision_history, StockDetailDecisionHistory
+    ):
+        decision_history = StockDetailDecisionHistory.model_validate(decision_history)
+```
+
+`StockDetailResponse(...)`(@711)에서 `latestAnalysis=latest_analysis,` → `decisionHistory=decision_history,`.
+
+- [ ] **Step 4: 통과 확인**
+
+Run: `uv run pytest tests/test_stock_detail_service.py tests/test_invest_stock_detail_router.py -v`
+Expected: PASS. `uv run ruff check app/services/invest_view_model/stock_detail_service.py`.
+
+- [ ] **Step 5: 백엔드 회귀 + 커밋**
+
+Run: `uv run pytest tests/test_stock_detail_service.py tests/test_stock_detail_providers.py tests/test_invest_stock_detail_schemas.py tests/test_invest_stock_detail_router.py tests/services/test_decision_history.py -q`
+Expected: PASS (전부).
+
+```bash
+git add app/services/invest_view_model/stock_detail_service.py tests/test_stock_detail_service.py
+git commit -m "feat(ROB-716): wire decisionHistory into build_stock_detail
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: 프론트엔드 (타입 + DecisionHistoryCard + 테스트)
+
+**Files:**
+- Modify: `frontend/invest/src/types/stockDetail.ts` (@214-222 인터페이스 교체, @320 필드 교체)
+- Modify: `frontend/invest/src/pages/stock-detail/StockDetailPage.tsx` (`AnalysisCard`@425-444 → `DecisionHistoryCard`; 사용처 @600)
+- Modify: `frontend/invest/src/__tests__/StockDetailPage.test.tsx` (@125 fixture 교체)
+
+**Interfaces:**
+- Consumes: `StockDetailResponse.decisionHistory` (Task 1 wire 형식).
+
+- [ ] **Step 1: 타입 교체** — `types/stockDetail.ts`
+
+`StockDetailLatestAnalysis`(@214-222)를 교체:
+```typescript
+export interface StockDetailDecisionHistoryPriorDecision {
+  date: string | null;
+  intent: string | null;
+  side: string | null;
+  decisionBucket: string | null;
+  confidence: number | null;
+  rationale: string | null;
+}
+
+export interface StockDetailDecisionHistoryOutcome {
+  date: string | null;
+  side: string | null;
+  outcome: string | null;
+  triggerType: string | null;
+  pnlPct: number | null;
+  realizedPnl: number | null;
+}
+
+export interface StockDetailDecisionHistoryOpenClaim {
+  probability: number | null;
+  horizon: string | null;
+  reviewDate: string | null;
+  direction: string | null;
+  targetPrice: number | null;
+}
+
+export interface StockDetailDecisionHistoryBrier {
+  n: number;
+  meanBrier: number | null;
+  flag: "ok" | "insufficient_sample";
+}
+
+export interface StockDetailDecisionHistory {
+  symbol: string;
+  market: string;
+  linkQuality: string;
+  priorDecisions: StockDetailDecisionHistoryPriorDecision[];
+  priorLessons: string[];
+  realizedOutcomes: StockDetailDecisionHistoryOutcome[];
+  openClaims: StockDetailDecisionHistoryOpenClaim[];
+  runningBrierSymbol: StockDetailDecisionHistoryBrier;
+  runningBrierGlobal: StockDetailDecisionHistoryBrier;
+  cautionLabel: string;
+}
+```
+
+`StockDetailResponse`(@320) `latestAnalysis: StockDetailLatestAnalysis | null;` → `decisionHistory: StockDetailDecisionHistory | null;`.
+
+- [ ] **Step 2: 카드 교체** — `StockDetailPage.tsx`
+
+`AnalysisCard`(@425-444)를 교체:
+```tsx
+function DecisionHistoryCard({ data }: { data: StockDetailResponse }) {
+  const dh = data.decisionHistory;
+  return (
+    <Card data-testid="stock-detail-decision-history">
+      <h2 style={{ margin: "0 0 8px", fontSize: 16 }}>판단 이력</h2>
+      {!dh ? (
+        <p style={{ margin: 0, color: "var(--fg-3)" }}>이 종목의 과거 판단 기록이 없습니다.</p>
+      ) : (
+        <>
+          <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 10 }}>
+            <span style={{ fontWeight: 700 }}>
+              종목 Brier {dh.runningBrierSymbol.meanBrier == null ? "−" : dh.runningBrierSymbol.meanBrier.toFixed(2)}
+            </span>
+            <span style={{ color: "var(--fg-3)", fontSize: 12 }}>n={dh.runningBrierSymbol.n}</span>
+            {dh.runningBrierSymbol.flag === "insufficient_sample" ? (
+              <Pill tone="paper">표본 부족</Pill>
+            ) : null}
+          </div>
+
+          {dh.priorDecisions.length > 0 ? (
+            <div style={{ marginBottom: 10 }}>
+              <div style={{ fontSize: 12, color: "var(--fg-3)", marginBottom: 4 }}>과거 판단</div>
+              <ul style={{ listStyle: "none", margin: 0, padding: 0, display: "flex", flexDirection: "column", gap: 6 }}>
+                {dh.priorDecisions.map((d, i) => (
+                  <li key={`pd-${i}`} style={{ fontSize: 13 }}>
+                    <Pill tone={d.side === "buy" ? "gain" : d.side === "sell" ? "loss" : "paper"}>{d.side ?? d.intent ?? "판단"}</Pill>
+                    <span style={{ color: "var(--fg-3)", margin: "0 6px" }}>{d.date ?? "-"}</span>
+                    {d.confidence != null ? <span style={{ color: "var(--fg-3)" }}>conf {d.confidence.toFixed(2)}</span> : null}
+                    {d.rationale ? <div style={{ color: "var(--fg-2)" }}>{d.rationale}</div> : null}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ) : null}
+
+          {dh.realizedOutcomes.length > 0 ? (
+            <div style={{ marginBottom: 10 }}>
+              <div style={{ fontSize: 12, color: "var(--fg-3)", marginBottom: 4 }}>실현된 결과</div>
+              <ul style={{ listStyle: "none", margin: 0, padding: 0, display: "flex", flexDirection: "column", gap: 4 }}>
+                {dh.realizedOutcomes.map((o, i) => (
+                  <li key={`ro-${i}`} style={{ fontSize: 13, color: "var(--fg-2)" }}>
+                    {o.date ?? "-"} · {o.side ?? "-"} · {o.outcome ?? "-"}
+                    {o.pnlPct != null ? ` · ${o.pnlPct.toFixed(1)}%` : ""}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ) : null}
+
+          {dh.openClaims.length > 0 ? (
+            <div style={{ marginBottom: 10 }}>
+              <div style={{ fontSize: 12, color: "var(--fg-3)", marginBottom: 4 }}>진행중 예측</div>
+              <ul style={{ listStyle: "none", margin: 0, padding: 0, display: "flex", flexDirection: "column", gap: 4 }}>
+                {dh.openClaims.map((c, i) => (
+                  <li key={`oc-${i}`} style={{ fontSize: 13, color: "var(--fg-2)" }}>
+                    {c.direction ?? "-"}
+                    {c.probability != null ? ` P${c.probability.toFixed(2)}` : ""}
+                    {c.targetPrice != null ? ` · 목표 ${Math.round(c.targetPrice).toLocaleString("ko-KR")}` : ""}
+                    {c.reviewDate ? ` · ${c.reviewDate} 해소` : ""}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ) : null}
+
+          {dh.priorLessons.length > 0 ? (
+            <div style={{ marginBottom: 10 }}>
+              <div style={{ fontSize: 12, color: "var(--fg-3)", marginBottom: 4 }}>교훈</div>
+              <ul style={{ margin: 0, paddingLeft: 18, color: "var(--fg-2)", fontSize: 13 }}>
+                {dh.priorLessons.map((l, i) => <li key={`pl-${i}`}>{l}</li>)}
+              </ul>
+            </div>
+          ) : null}
+
+          <p style={{ margin: "6px 0 0", color: "var(--fg-3)", fontSize: 11 }}>{dh.cautionLabel}</p>
+        </>
+      )}
+    </Card>
+  );
+}
+```
+
+사용처(@600) `<AnalysisCard data={data} />` → `<DecisionHistoryCard data={data} />`.
+
+- [ ] **Step 3: 테스트 fixture 교체** — `StockDetailPage.test.tsx`
+
+`latestAnalysis: { ... }` 블록(@125~)을 교체:
+```tsx
+  decisionHistory: {
+    symbol: "000660",
+    market: "kr",
+    linkQuality: "symbol_window",
+    priorDecisions: [
+      { date: "2026-06-28", intent: "buy_review", side: "buy", decisionBucket: "new_buy_candidate", confidence: 0.7, rationale: "HBM 수요 지속" },
+    ],
+    priorLessons: ["과열 구간 추격 금지"],
+    realizedOutcomes: [
+      { date: "2026-06-20", side: "sell", outcome: "stop_loss", triggerType: "stop", pnlPct: -3.1, realizedPnl: -31000 },
+    ],
+    openClaims: [
+      { probability: 0.7, horizon: "1w", reviewDate: "2026-07-10", direction: "up", targetPrice: 82000 },
+    ],
+    runningBrierSymbol: { n: 12, meanBrier: 0.18, flag: "ok" },
+    runningBrierGlobal: { n: 4, meanBrier: null, flag: "insufficient_sample" },
+    cautionLabel: "종목 기준 집계이며 특정 판단과 특정 결과의 직접 연결이 아닙니다.",
+  },
+```
+
+이 파일에 `latestAnalysis` / `최근 분석` / `stock-detail-analysis`를 assert하는 부분이 있으면 새 카드 기준으로 교체:
+```tsx
+    expect(screen.getByTestId("stock-detail-decision-history")).toBeInTheDocument();
+    expect(screen.getByText("판단 이력")).toBeInTheDocument();
+    expect(screen.getByText("HBM 수요 지속")).toBeInTheDocument();
+```
+
+- [ ] **Step 4: 프론트 테스트 실행**
+
+Run: `cd frontend/invest && npm test -- StockDetailPage`
+Expected: PASS. 그리고 `cd frontend/invest && npx tsc --noEmit` — 타입 에러 없음(제거된 `StockDetailLatestAnalysis`/`latestAnalysis` 잔존 참조 0).
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add frontend/invest/src/types/stockDetail.ts frontend/invest/src/pages/stock-detail/StockDetailPage.tsx frontend/invest/src/__tests__/StockDetailPage.test.tsx
+git commit -m "feat(ROB-716): DecisionHistoryCard replaces dead latestAnalysis panel
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: 최종 검증 (grep 잔존 참조 + 전체 스위트)
+
+**Files:** 없음(검증 전용). 필요 시 잔존 참조 정리.
+
+- [ ] **Step 1: 죽은 참조 완전 제거 확인**
+
+Run: `grep -rn "latestAnalysis\|StockDetailLatestAnalysis\|stock_detail_latest_analysis_provider\|stock-detail-analysis" app/ frontend/invest/src/`
+Expected: 결과 없음(0 라인). 남아있으면 해당 파일 정리 후 재실행.
+
+- [ ] **Step 2: `stock_analysis_results` 의존 제거 확인 (stock detail 경로)**
+
+Run: `grep -rn "get_latest_analysis_by_symbol\|StockAnalysisService" app/services/invest_view_model/`
+Expected: 결과 없음.
+
+- [ ] **Step 3: 백엔드 관련 스위트**
+
+Run: `uv run pytest tests/test_stock_detail_service.py tests/test_stock_detail_providers.py tests/test_invest_stock_detail_schemas.py tests/test_invest_stock_detail_router.py tests/test_stock_detail_capability_contract.py tests/services/test_decision_history.py -q`
+Expected: PASS.
+
+- [ ] **Step 4: lint / typecheck**
+
+Run: `uv run ruff check app/ && cd frontend/invest && npx tsc --noEmit`
+Expected: clean.
+
+- [ ] **Step 5: (검증 커밋 불필요 — 코드 변경 없으면 skip)**
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- 패널 교체(dead→live) → Task 1(스키마)·2(provider)·3(서비스)·4(프론트). ✓
+- section-separated 렌더(과거판단/실현결과/진행중예측/Brier/교훈) → Task 4 Step 2. ✓
+- 전 시장 실행 → Task 3(시장 게이트 없이 항상 `decision_history_task` 실행); `build_decision_context`가 시장 정규화. ✓
+- `link_quality`/cautionLabel 정직 표기 → Task 1 default + Task 4 각주. ✓
+- `recent_fills` 제외(YAGNI) → Task 2 명시. ✓
+- migration 0 / read-only / LLM 무접촉 → Global Constraints; 신규 코드 DB write·broker·LLM import 없음. ✓
+- 성공 기준(죽은 테이블 의존 제거) → Task 5 Step 1-2 grep 게이트. ✓
+
+**Placeholder scan:** 모든 코드 스텝에 실제 코드 포함, TBD/TODO 없음. ✓
+
+**Type consistency:** `decision_history`(provider/필드), `decisionHistory`(응답/프론트), `StockDetailDecisionHistory`(모델) — Task 1 정의와 Task 2/3/4 사용 일치. `_brier` snake→camel(`meanBrier`) 매핑이 Task 1 Brier 모델 필드와 일치. ✓

--- a/docs/superpowers/specs/2026-07-05-rob-716-decision-history-surface-design.md
+++ b/docs/superpowers/specs/2026-07-05-rob-716-decision-history-surface-design.md
@@ -1,0 +1,91 @@
+# ROB-716 — 종목상세 판단→결과 학습루프 노출 (decision_history surface)
+
+- **Date**: 2026-07-05
+- **Linear**: ROB-716 (Medium, blocked by ROB-711 → **해소**: ROB-711 merged `99508870`)
+- **Branch**: `rob-716`
+- **Related**: ROB-715 (웹 형제), ROB-692 (추천 카드, merged), ROB-705 (correlation_id 스파인), ROB-490 (dead writer), ROB-714 (place-time provenance)
+
+## 문제
+
+종목상세 "최근 분석"(`AnalysisCard`) 패널은 front~back 완성돼 있으나 **죽은 저장소 `stock_analysis_results`를 읽어 비어있다**. 이 테이블은 openclaw HTTP 콜백/research pipeline만 쓰고 오퍼레이터 경로엔 안 돎(ROB-490 확정). 오퍼레이터의 실제 분석은 `investment_report_items` + `trade_forecasts` + `trade_retrospectives`(review 스키마)에 적재된다.
+
+오퍼레이터 요청(2026-07-05): "종목상세에서 분석할 때마다 분석 데이터가 잘 적재되고, 매수/매도 근거(뉴스 포함)와 맞았는지 평가가 보였으면 한다."
+
+## 접근
+
+죽은 "최근 분석" 패널을 **라이브 학습루프 소스로 교체**한다. 데이터는 ROB-711이 이미 배선한 `build_decision_context(db, symbol, market)`(`app/services/decision_history.py`)를 **그대로 재사용** — join 로직 재구현 없음(ROB-711 노트가 경고한 "세 번째 병렬 저장소" 발산 회피).
+
+기존 `build_stock_detail` provider 패턴에 **provider 1개 + 응답 필드 1개 + 프론트 카드 1개**를 추가하고, 죽은 `latestAnalysis` 계열(provider·스키마·프론트 타입·카드)을 제거한다.
+
+### 결정 사항 (brainstorm)
+
+1. **패널 처리 = 교체.** `AnalysisCard`(`stock_analysis_results`)를 제거하고 그 슬롯에 `DecisionHistoryCard`(판단 이력)를 렌더. `stock_analysis_results` 의존 완전 제거(성공 기준 직결).
+2. **결과 표현 = 섹션 분리 (정직).** `report_item_uuid`가 ledger/forecast/retro에 ~0% 채워져 `link_quality="symbol_window"` — 특정 판단↔특정 결과 직접 join 불가. 따라서 개별 판단 행에 `✓적중/✗빗나감` 인라인 배지를 달지 **않고**, `build_decision_context` payload를 섹션으로 렌더(과거 판단 / 실현된 결과 / 진행중 예측 / 종목 Brier / 교훈). "symbol 기준 집계" 명시.
+3. **시장 = 전 시장(kr/us/crypto).** `build_decision_context`가 시장별 symbol 정규화 + 무신호 None 처리. 추가 비용 미미(인덱스된 쿼리 몇 개).
+
+### 안전/제약
+
+- Migration 0, read-only. 브로커/주문/감시 무접촉. LLM 무접촉(ROB-501 결정론).
+- `latestAnalysis`는 프론트 view-model(`StockDetailResponse`) + 프론트 페이지 외 소비처 없음(MCP/타 백엔드 없음) — 제거 blast radius 국소.
+
+## 컴포넌트
+
+### 1. Provider — `app/services/invest_view_model/stock_detail_providers.py`
+
+신규 `stock_detail_decision_history_provider(market, symbol, db)`:
+- `hasattr(db, "execute")` 가드 → `build_decision_context(db, symbol, market)` 호출.
+- 반환 dict(snake_case) → `StockDetailDecisionHistory`(camelCase) 매핑. `None`이면 그대로 `None`(무신호 = 패널 빈 상태).
+
+제거: `stock_detail_latest_analysis_provider`, `_reasons_top3`, `StockAnalysisService` import, `StockDetailLatestAnalysis` import, `__all__`의 `stock_detail_latest_analysis_provider`.
+
+### 2. 스키마 — `app/schemas/invest_stock_detail.py`
+
+제거: `StockDetailLatestAnalysis`, `StockDetailResponse.latestAnalysis`.
+
+신규(모두 `extra="forbid"`):
+
+- `StockDetailDecisionHistoryPriorDecision`: `date: str | None`, `intent: str | None`, `side: str | None`, `decisionBucket: str | None`, `confidence: float | None`, `rationale: str | None`
+- `StockDetailDecisionHistoryOutcome`: `date`, `side`, `outcome`, `triggerType`, `pnlPct`, `realizedPnl` (모두 `| None`)
+- `StockDetailDecisionHistoryOpenClaim`: `probability`, `horizon`, `reviewDate`, `direction`, `targetPrice` (모두 `| None`)
+- `StockDetailDecisionHistoryBrier`: `n: int`, `meanBrier: float | None`, `flag: Literal["ok", "insufficient_sample"]`
+- `StockDetailDecisionHistory`: `symbol: str`, `market: str`, `linkQuality: str`, `priorDecisions: list[...]`, `priorLessons: list[str]`, `realizedOutcomes: list[...]`, `openClaims: list[...]`, `runningBrierSymbol: StockDetailDecisionHistoryBrier`, `runningBrierGlobal: StockDetailDecisionHistoryBrier`, `cautionLabel: str = "종목 기준 집계이며 특정 판단과 특정 결과의 직접 연결이 아닙니다."`
+- `StockDetailResponse.decisionHistory: StockDetailDecisionHistory | None = None`
+
+**YAGNI 컷**: `recent_fills`(payload에 있으나) 제외 — 체결 내역은 페이지의 주문 카드(ROB-559 by-symbol order history)가 이미 노출.
+
+### 3. 서비스 배선 — `app/services/invest_view_model/stock_detail_service.py`
+
+- `StockDetailProviders`의 `latest_analysis` 필드 → `decision_history: Provider = stock_detail_decision_history_provider`로 교체.
+- `latest_analysis_task` → `decision_history_task = _run_optional_block("decision_history", providers.decision_history(market, resolved.symbol_db, db), warnings)` (전 시장 실행, 실패 격리).
+- `asyncio.gather` 언팩 + 후처리 isinstance 변환(`StockDetailDecisionHistory.model_validate`) 교체.
+- `StockDetailResponse(... decisionHistory=decision_history ...)`, `latestAnalysis=` 제거.
+- import 정리(`StockDetailLatestAnalysis` 제거, 신규 `StockDetailDecisionHistory` 추가).
+
+### 4. 프론트 — `frontend/invest/src/`
+
+- `types/stockDetail.ts`: `StockDetailLatestAnalysis` 제거, `StockDetailResponse.latestAnalysis` 제거. 신규 `StockDetailDecisionHistory` 계열 인터페이스 + `decisionHistory: StockDetailDecisionHistory | null`.
+- `pages/stock-detail/StockDetailPage.tsx`: `AnalysisCard` → `DecisionHistoryCard`(제목 "판단 이력"). 섹션 렌더:
+  1. **종목 Brier**: `runningBrierSymbol` — `mean_brier` + `n`, `flag==="insufficient_sample"`면 배지.
+  2. **과거 판단**: `priorDecisions` — side/intent Pill + confidence + rationale(truncated).
+  3. **실현된 결과**: `realizedOutcomes` — date/side/outcome/pnlPct.
+  4. **진행중 예측**: `openClaims` — probability/direction/targetPrice/reviewDate.
+  5. **교훈**: `priorLessons` 리스트.
+  6. `cautionLabel` 각주.
+  - `decisionHistory == null`이면 "이 종목의 과거 판단 기록이 없습니다."
+- `__tests__/StockDetailPage.test.tsx`: `latestAnalysis` fixture → `decisionHistory` fixture 교체.
+
+## 테스트
+
+- **Provider 단위**: `build_decision_context` 반환 dict → `StockDetailDecisionHistory` 매핑 검증(모든 섹션); `None` 반환 시 `None`; `db` 무 execute 시 `None`.
+- **서비스**: `decisionHistory`가 응답에 배선됨; provider 예외 시 `decision_history_unavailable` warning + 페이지 렌더 유지; 전 시장(kr/us/crypto) 실행.
+- **스키마**: `extra="forbid"` 계약; `flag` Literal; Brier round-trip.
+- **프론트**: 섹션 렌더(과거 판단/결과/예측/교훈/Brier); 빈 상태; `insufficient_sample` 배지.
+
+## 성공 기준
+
+- 종목상세에서 해당 심볼의 과거 판단(근거/confidence) + 예측 결과(실현/미해결) + 회고 lesson이 클릭 없이 보인다.
+- 죽은 `stock_analysis_results` 의존 제거 — 재분석 심볼 80%+에서 패널이 비어있지 않다.
+
+## 참고
+
+- `docs/superpowers/specs/2026-07-05-symbol-analysis-capture-design.md` (write-loop 부분 SUPERSEDED; triggers 모델·Brier 채점·correlation_id 정합 근거만 유효).

--- a/frontend/invest/src/__tests__/StockDetailPage.test.tsx
+++ b/frontend/invest/src/__tests__/StockDetailPage.test.tsx
@@ -122,15 +122,23 @@ const aboveFold: StockDetailResponse = {
     ],
     caution: "환율 민감도는 USD/KRW 1% 변동을 보유 평가액에 단순 적용한 가정치입니다.",
   },
-  latestAnalysis: {
-    id: 11,
-    modelName: "committee",
-    decision: "hold",
-    confidence: 0.72,
-    appropriateBuyRange: [195, 205],
-    appropriateSellRange: [220, 230],
-    reasonsTop3: ["나스닥100 분산", "최근 5일 상승", "밸류에이션은 중립"],
-    createdAt: "2026-05-09T12:00:00Z",
+  decisionHistory: {
+    symbol: "000660",
+    market: "kr",
+    linkQuality: "symbol_window",
+    priorDecisions: [
+      { date: "2026-06-28", intent: "buy_review", side: "buy", decisionBucket: "new_buy_candidate", confidence: 0.7, rationale: "HBM 수요 지속" },
+    ],
+    priorLessons: ["과열 구간 추격 금지"],
+    realizedOutcomes: [
+      { date: "2026-06-20", side: "sell", outcome: "stop_loss", triggerType: "stop", pnlPct: -3.1, realizedPnl: -31000 },
+    ],
+    openClaims: [
+      { probability: 0.7, horizon: "1w", reviewDate: "2026-07-10", direction: "up", targetPrice: 82000 },
+    ],
+    runningBrierSymbol: { n: 12, meanBrier: 0.18, flag: "ok" },
+    runningBrierGlobal: { n: 4, meanBrier: null, flag: "insufficient_sample" },
+    cautionLabel: "종목 기준 집계이며 특정 판단과 특정 결과의 직접 연결이 아닙니다.",
   },
   orderbookSupport: { supported: false, reason: "us_unsupported" },
   orderbook: null,
@@ -294,7 +302,9 @@ test("renders the QQQM stock detail shell from the read-only backend contract", 
   expect(screen.getByTestId("stock-detail-fx-sensitivity")).toHaveTextContent("USD/KRW");
   expect(screen.getByTestId("stock-detail-fx-sensitivity")).toHaveTextContent("+₩5,748");
   expect(screen.getByTestId("stock-detail-profile")).toHaveTextContent("ETF");
-  expect(screen.getByTestId("stock-detail-analysis")).toHaveTextContent("hold");
+  expect(screen.getByTestId("stock-detail-decision-history")).toBeInTheDocument();
+  expect(screen.getByText("판단 이력")).toBeInTheDocument();
+  expect(screen.getByText("HBM 수요 지속")).toBeInTheDocument();
   expect(screen.getByTestId("stock-detail-naver-poc")).toHaveTextContent("Naver 원천 데이터 PoC");
   expect(screen.getByTestId("stock-detail-naver-poc")).toHaveTextContent("live fetch off");
 

--- a/frontend/invest/src/pages/stock-detail/StockDetailPage.tsx
+++ b/frontend/invest/src/pages/stock-detail/StockDetailPage.tsx
@@ -422,20 +422,82 @@ function ResearchConsensusCard({ data, error }: { data: StockDetailResearchConse
   );
 }
 
-function AnalysisCard({ data }: { data: StockDetailResponse }) {
-  const analysis = data.latestAnalysis;
+function DecisionHistoryCard({ data }: { data: StockDetailResponse }) {
+  const dh = data.decisionHistory;
   return (
-    <Card data-testid="stock-detail-analysis">
-      <h2 style={{ margin: "0 0 8px", fontSize: 16 }}>최근 분석</h2>
-      {analysis ? (
-        <>
-          <Pill tone={analysis.decision === "buy" ? "gain" : analysis.decision === "sell" ? "loss" : "paper"}>{analysis.decision ?? "hold"}</Pill>
-          <ul style={{ margin: "12px 0 0", paddingLeft: 18, color: "var(--fg-2)" }}>
-            {analysis.reasonsTop3.map((reason) => <li key={reason}>{reason}</li>)}
-          </ul>
-        </>
+    <Card data-testid="stock-detail-decision-history">
+      <h2 style={{ margin: "0 0 8px", fontSize: 16 }}>판단 이력</h2>
+      {!dh ? (
+        <p style={{ margin: 0, color: "var(--fg-3)" }}>이 종목의 과거 판단 기록이 없습니다.</p>
       ) : (
-        <p style={{ margin: 0, color: "var(--fg-3)" }}>최근 분석이 없습니다.</p>
+        <>
+          <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 10 }}>
+            <span style={{ fontWeight: 700 }}>
+              종목 Brier {dh.runningBrierSymbol.meanBrier == null ? "−" : dh.runningBrierSymbol.meanBrier.toFixed(2)}
+            </span>
+            <span style={{ color: "var(--fg-3)", fontSize: 12 }}>n={dh.runningBrierSymbol.n}</span>
+            {dh.runningBrierSymbol.flag === "insufficient_sample" ? (
+              <Pill tone="paper">표본 부족</Pill>
+            ) : null}
+          </div>
+
+          {dh.priorDecisions.length > 0 ? (
+            <div style={{ marginBottom: 10 }}>
+              <div style={{ fontSize: 12, color: "var(--fg-3)", marginBottom: 4 }}>과거 판단</div>
+              <ul style={{ listStyle: "none", margin: 0, padding: 0, display: "flex", flexDirection: "column", gap: 6 }}>
+                {dh.priorDecisions.map((d, i) => (
+                  <li key={`pd-${i}`} style={{ fontSize: 13 }}>
+                    <Pill tone={d.side === "buy" ? "gain" : d.side === "sell" ? "loss" : "paper"}>{d.side ?? d.intent ?? "판단"}</Pill>
+                    <span style={{ color: "var(--fg-3)", margin: "0 6px" }}>{d.date ?? "-"}</span>
+                    {d.confidence != null ? <span style={{ color: "var(--fg-3)" }}>conf {d.confidence.toFixed(2)}</span> : null}
+                    {d.rationale ? <div style={{ color: "var(--fg-2)" }}>{d.rationale}</div> : null}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ) : null}
+
+          {dh.realizedOutcomes.length > 0 ? (
+            <div style={{ marginBottom: 10 }}>
+              <div style={{ fontSize: 12, color: "var(--fg-3)", marginBottom: 4 }}>실현된 결과</div>
+              <ul style={{ listStyle: "none", margin: 0, padding: 0, display: "flex", flexDirection: "column", gap: 4 }}>
+                {dh.realizedOutcomes.map((o, i) => (
+                  <li key={`ro-${i}`} style={{ fontSize: 13, color: "var(--fg-2)" }}>
+                    {o.date ?? "-"} · {o.side ?? "-"} · {o.outcome ?? "-"}
+                    {o.pnlPct != null ? ` · ${o.pnlPct.toFixed(1)}%` : ""}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ) : null}
+
+          {dh.openClaims.length > 0 ? (
+            <div style={{ marginBottom: 10 }}>
+              <div style={{ fontSize: 12, color: "var(--fg-3)", marginBottom: 4 }}>진행중 예측</div>
+              <ul style={{ listStyle: "none", margin: 0, padding: 0, display: "flex", flexDirection: "column", gap: 4 }}>
+                {dh.openClaims.map((c, i) => (
+                  <li key={`oc-${i}`} style={{ fontSize: 13, color: "var(--fg-2)" }}>
+                    {c.direction ?? "-"}
+                    {c.probability != null ? ` P${c.probability.toFixed(2)}` : ""}
+                    {c.targetPrice != null ? ` · 목표 ${Math.round(c.targetPrice).toLocaleString("ko-KR")}` : ""}
+                    {c.reviewDate ? ` · ${c.reviewDate} 해소` : ""}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ) : null}
+
+          {dh.priorLessons.length > 0 ? (
+            <div style={{ marginBottom: 10 }}>
+              <div style={{ fontSize: 12, color: "var(--fg-3)", marginBottom: 4 }}>교훈</div>
+              <ul style={{ margin: 0, paddingLeft: 18, color: "var(--fg-2)", fontSize: 13 }}>
+                {dh.priorLessons.map((l, i) => <li key={`pl-${i}`}>{l}</li>)}
+              </ul>
+            </div>
+          ) : null}
+
+          <p style={{ margin: "6px 0 0", color: "var(--fg-3)", fontSize: 11 }}>{dh.cautionLabel}</p>
+        </>
       )}
     </Card>
   );
@@ -597,7 +659,7 @@ export function StockDetailPage() {
         <ProfileCard data={data} />
         {market !== "crypto" ? <ResearchConsensusCard data={researchConsensus} error={researchErr} /> : null}
         {market === "crypto" ? <CryptoDetailCard data={data} /> : null}
-        <AnalysisCard data={data} />
+        <DecisionHistoryCard data={data} />
         <NaverPocCard data={data} />
         <MemoCard />
       </div>

--- a/frontend/invest/src/types/stockDetail.ts
+++ b/frontend/invest/src/types/stockDetail.ts
@@ -20,7 +20,6 @@ export type NaverEndpointStatus =
   | "unsupported"
   | "error";
 export type OrderSide = "buy" | "sell" | string;
-export type AnalysisDecision = "buy" | "hold" | "sell";
 export type FxSensitivityStatus =
   | "available"
   | "not_applicable"
@@ -211,15 +210,49 @@ export interface StockDetailFxSensitivity {
   caution: string;
 }
 
-export interface StockDetailLatestAnalysis {
-  id: number;
-  modelName: string | null;
-  decision: AnalysisDecision | null;
+export interface StockDetailDecisionHistoryPriorDecision {
+  date: string | null;
+  intent: string | null;
+  side: string | null;
+  decisionBucket: string | null;
   confidence: number | null;
-  appropriateBuyRange: [number | null, number | null] | null;
-  appropriateSellRange: [number | null, number | null] | null;
-  reasonsTop3: string[];
-  createdAt: string | null;
+  rationale: string | null;
+}
+
+export interface StockDetailDecisionHistoryOutcome {
+  date: string | null;
+  side: string | null;
+  outcome: string | null;
+  triggerType: string | null;
+  pnlPct: number | null;
+  realizedPnl: number | null;
+}
+
+export interface StockDetailDecisionHistoryOpenClaim {
+  probability: number | null;
+  horizon: string | null;
+  reviewDate: string | null;
+  direction: string | null;
+  targetPrice: number | null;
+}
+
+export interface StockDetailDecisionHistoryBrier {
+  n: number;
+  meanBrier: number | null;
+  flag: "ok" | "insufficient_sample";
+}
+
+export interface StockDetailDecisionHistory {
+  symbol: string;
+  market: string;
+  linkQuality: string;
+  priorDecisions: StockDetailDecisionHistoryPriorDecision[];
+  priorLessons: string[];
+  realizedOutcomes: StockDetailDecisionHistoryOutcome[];
+  openClaims: StockDetailDecisionHistoryOpenClaim[];
+  runningBrierSymbol: StockDetailDecisionHistoryBrier;
+  runningBrierGlobal: StockDetailDecisionHistoryBrier;
+  cautionLabel: string;
 }
 
 export interface StockDetailOrderbookLevel {
@@ -317,7 +350,7 @@ export interface StockDetailResponse {
   investorFlow: StockDetailInvestorFlow | null;
   holding: StockDetailHolding | null;
   fxSensitivity: StockDetailFxSensitivity | null;
-  latestAnalysis: StockDetailLatestAnalysis | null;
+  decisionHistory: StockDetailDecisionHistory | null;
   orderbookSupport: StockDetailOrderbookSupport;
   orderbook: StockDetailOrderbook | null;
   capabilities: StockDetailCapabilities;

--- a/tests/test_invest_stock_detail_schemas.py
+++ b/tests/test_invest_stock_detail_schemas.py
@@ -36,7 +36,6 @@ def _base_response(**overrides):
         "discussionSignal": None,
         "holding": None,
         "fxSensitivity": None,
-        "latestAnalysis": None,
         "orderbookSupport": {"supported": False, "reason": "kr_unavailable"},
         "orderbook": None,
         "capabilities": default_capabilities_for_market("kr"),
@@ -201,7 +200,6 @@ def test_discussion_signal_null_for_crypto_in_response():
             "naverEnrichment": None,
             "discussionSignal": None,
             "holding": None,
-            "latestAnalysis": None,
             "orderbookSupport": {"supported": False, "reason": "crypto_deferred"},
             "orderbook": None,
             "capabilities": default_capabilities_for_market("crypto"),
@@ -365,3 +363,61 @@ def test_stock_detail_holding_exposes_tradeable_and_reference_quantities():
 
     assert holding.tradeableQuantity == 3
     assert holding.referenceQuantity == 2
+
+
+@pytest.mark.unit
+def test_decision_history_schema_forbids_extra_and_maps_sections():
+    from app.schemas.invest_stock_detail import (
+        StockDetailDecisionHistory,
+        StockDetailDecisionHistoryBrier,
+    )
+
+    model = StockDetailDecisionHistory(
+        symbol="000660",
+        market="kr",
+        linkQuality="symbol_window",
+        priorDecisions=[
+            {
+                "date": "2026-06-28",
+                "intent": "buy_review",
+                "side": "buy",
+                "decisionBucket": "new_buy_candidate",
+                "confidence": 0.7,
+                "rationale": "HBM 수요 지속",
+            }
+        ],
+        priorLessons=["과열 구간 추격 금지"],
+        realizedOutcomes=[
+            {
+                "date": "2026-06-20",
+                "side": "sell",
+                "outcome": "stop_loss",
+                "triggerType": "stop",
+                "pnlPct": -3.1,
+                "realizedPnl": -31000.0,
+            }
+        ],
+        openClaims=[
+            {
+                "probability": 0.7,
+                "horizon": "1w",
+                "reviewDate": "2026-07-10",
+                "direction": "up",
+                "targetPrice": 82000.0,
+            }
+        ],
+        runningBrierSymbol=StockDetailDecisionHistoryBrier(
+            n=12, meanBrier=0.18, flag="ok"
+        ),
+        runningBrierGlobal=StockDetailDecisionHistoryBrier(
+            n=4, meanBrier=None, flag="insufficient_sample"
+        ),
+    )
+    assert model.priorDecisions[0].confidence == 0.7
+    assert model.realizedOutcomes[0].outcome == "stop_loss"
+    assert model.openClaims[0].targetPrice == 82000.0
+    assert model.runningBrierGlobal.flag == "insufficient_sample"
+    assert "직접 연결" in model.cautionLabel  # default caution present
+
+    with pytest.raises(ValidationError):
+        StockDetailDecisionHistoryBrier(n=1, meanBrier=0.1, flag="ok", extra="x")

--- a/tests/test_stock_detail_providers.py
+++ b/tests/test_stock_detail_providers.py
@@ -415,7 +415,11 @@ async def test_decision_history_provider_maps_payload(monkeypatch):
             }
         ],
         "running_brier_symbol": {"n": 12, "mean_brier": 0.18, "flag": "ok"},
-        "running_brier_global": {"n": 4, "mean_brier": None, "flag": "insufficient_sample"},
+        "running_brier_global": {
+            "n": 4,
+            "mean_brier": None,
+            "flag": "insufficient_sample",
+        },
     }
 
     async def fake_build(db, symbol, market):

--- a/tests/test_stock_detail_providers.py
+++ b/tests/test_stock_detail_providers.py
@@ -376,79 +376,88 @@ async def test_valuation_provider_handles_unsupported_and_null_dividend(monkeypa
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-@pytest.mark.parametrize(
-    ("reasons", "expected"),
-    [
-        (["first", "second", "third", "fourth"], ["first", "second", "third"]),
-        ({"top3": ["one", "two", "three", "four"]}, ["one", "two", "three"]),
-        ({"summary": "not-a-list"}, []),
-    ],
-)
-async def test_latest_analysis_provider_maps_reason_shapes(
-    monkeypatch, reasons, expected
-):
+async def test_decision_history_provider_maps_payload(monkeypatch):
     from app.services.invest_view_model import stock_detail_providers as providers
 
-    created_at = dt.datetime(2026, 6, 15, tzinfo=dt.UTC)
+    payload = {
+        "symbol": "000660",
+        "market": "kr",
+        "link_quality": "symbol_window",
+        "prior_decisions": [
+            {
+                "date": "2026-06-28",
+                "intent": "buy_review",
+                "side": "buy",
+                "decision_bucket": "new_buy_candidate",
+                "confidence": 0.7,
+                "rationale": "HBM 수요",
+            }
+        ],
+        "prior_lessons": ["추격 금지"],
+        "realized_outcomes": [
+            {
+                "date": "2026-06-20",
+                "side": "sell",
+                "outcome": "stop_loss",
+                "trigger_type": "stop",
+                "pnl_pct": -3.1,
+                "realized_pnl": -31000.0,
+            }
+        ],
+        "recent_fills": [{"date": "2026-06-20", "side": "sell"}],  # 의도적 무시
+        "open_claims": [
+            {
+                "probability": 0.7,
+                "horizon": "1w",
+                "review_date": "2026-07-10",
+                "direction": "up",
+                "target_price": 82000.0,
+            }
+        ],
+        "running_brier_symbol": {"n": 12, "mean_brier": 0.18, "flag": "ok"},
+        "running_brier_global": {"n": 4, "mean_brier": None, "flag": "insufficient_sample"},
+    }
 
-    class FakeAnalysisService:
-        def __init__(self, db):
-            self.db = db
+    async def fake_build(db, symbol, market):
+        assert symbol == "000660"
+        assert market == "kr"
+        return payload
 
-        async def get_latest_analysis_by_symbol(self, symbol):
-            assert symbol == "005930"
-            return SimpleNamespace(
-                id=42,
-                model_name="test-model",
-                decision="buy",
-                confidence=85,
-                appropriate_buy_min=70000,
-                appropriate_buy_max=72000,
-                appropriate_sell_min=80000,
-                appropriate_sell_max=82000,
-                reasons=reasons,
-                created_at=created_at,
-            )
+    monkeypatch.setattr(providers, "build_decision_context", fake_build)
 
-    import app.services.stock_info_service as stock_info_service
-
-    monkeypatch.setattr(stock_info_service, "StockAnalysisService", FakeAnalysisService)
-
-    analysis = await providers.stock_detail_latest_analysis_provider(
-        "kr", "005930", SimpleNamespace(execute=object())
+    result = await providers.stock_detail_decision_history_provider(
+        "kr", "000660", SimpleNamespace(execute=object())
     )
 
-    assert analysis is not None
-    assert analysis.id == 42
-    assert analysis.confidence == pytest.approx(0.85)
-    assert analysis.reasonsTop3 == expected
+    assert result is not None
+    assert result.linkQuality == "symbol_window"
+    assert result.priorDecisions[0].decisionBucket == "new_buy_candidate"
+    assert result.realizedOutcomes[0].triggerType == "stop"
+    assert result.realizedOutcomes[0].pnlPct == -3.1
+    assert result.openClaims[0].targetPrice == 82000.0
+    assert result.runningBrierSymbol.n == 12
+    assert result.runningBrierGlobal.flag == "insufficient_sample"
 
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_latest_analysis_provider_returns_none_without_db_or_analysis(
-    monkeypatch,
-):
+async def test_decision_history_provider_returns_none(monkeypatch):
     from app.services.invest_view_model import stock_detail_providers as providers
 
-    class FakeAnalysisService:
-        def __init__(self, db):
-            self.db = db
+    async def fake_build(db, symbol, market):
+        return None
 
-        async def get_latest_analysis_by_symbol(self, symbol):
-            return None
+    monkeypatch.setattr(providers, "build_decision_context", fake_build)
 
-    import app.services.stock_info_service as stock_info_service
-
-    monkeypatch.setattr(stock_info_service, "StockAnalysisService", FakeAnalysisService)
-
+    # no db.execute → None (build_decision_context never called)
     assert (
-        await providers.stock_detail_latest_analysis_provider("kr", "005930", object())
+        await providers.stock_detail_decision_history_provider("kr", "000660", object())
         is None
     )
+    # db present but no signal → None
     assert (
-        await providers.stock_detail_latest_analysis_provider(
-            "kr", "005930", SimpleNamespace(execute=object())
+        await providers.stock_detail_decision_history_provider(
+            "kr", "000660", SimpleNamespace(execute=object())
         )
         is None
     )

--- a/tests/test_stock_detail_service.py
+++ b/tests/test_stock_detail_service.py
@@ -99,7 +99,7 @@ async def test_build_stock_detail_uses_extended_timeout_for_holding(monkeypatch)
             screener=none_provider,
             valuation=none_provider,
             holding=holding_provider,
-            latest_analysis=none_provider,
+            decision_history=none_provider,
             orderbook=none_provider,
             naver_enrichment=none_provider,
             discussion_signal=none_provider,
@@ -428,7 +428,7 @@ def test_build_stock_detail_crypto_orderbook_provider_unavailable_is_explicit():
 @pytest.mark.asyncio
 async def test_default_stock_detail_providers_are_not_noop_for_core_blocks():
     from app.services.invest_view_model.stock_detail_providers import (
-        stock_detail_latest_analysis_provider,
+        stock_detail_decision_history_provider,
         stock_detail_orderbook_provider,
         stock_detail_quote_provider,
         stock_detail_valuation_provider,
@@ -440,7 +440,52 @@ async def test_default_stock_detail_providers_are_not_noop_for_core_blocks():
     assert DEFAULT_STOCK_DETAIL_PROVIDERS.quote is stock_detail_quote_provider
     assert DEFAULT_STOCK_DETAIL_PROVIDERS.valuation is stock_detail_valuation_provider
     assert (
-        DEFAULT_STOCK_DETAIL_PROVIDERS.latest_analysis
-        is stock_detail_latest_analysis_provider
+        DEFAULT_STOCK_DETAIL_PROVIDERS.decision_history
+        is stock_detail_decision_history_provider
     )
     assert DEFAULT_STOCK_DETAIL_PROVIDERS.orderbook is stock_detail_orderbook_provider
+
+@pytest.mark.asyncio
+async def test_build_stock_detail_wires_decision_history():
+    from app.schemas.invest_stock_detail import StockDetailDecisionHistory
+
+    async def decision_history(market, symbol, db):
+        assert symbol == "005930"
+        return StockDetailDecisionHistory(symbol="005930", market="kr")
+
+    providers = StockDetailProviders(
+        resolver=_resolve_kr, decision_history=decision_history
+    )
+
+    result = await build_stock_detail(
+        user_id=1,
+        market="kr",
+        symbol="005930",
+        db=SimpleNamespace(execute=object()),
+        providers=providers,
+    )
+
+    assert result.decisionHistory is not None
+    assert result.decisionHistory.symbol == "005930"
+    assert "decision_history_unavailable" not in result.meta.warnings
+
+
+@pytest.mark.asyncio
+async def test_build_stock_detail_isolates_decision_history_failure():
+    async def decision_history(market, symbol, db):
+        raise RuntimeError("boom")
+
+    providers = StockDetailProviders(
+        resolver=_resolve_kr, decision_history=decision_history
+    )
+
+    result = await build_stock_detail(
+        user_id=1,
+        market="kr",
+        symbol="005930",
+        db=SimpleNamespace(execute=object()),
+        providers=providers,
+    )
+
+    assert result.decisionHistory is None
+    assert "decision_history_unavailable" in result.meta.warnings

--- a/tests/test_stock_detail_service.py
+++ b/tests/test_stock_detail_service.py
@@ -445,6 +445,7 @@ async def test_default_stock_detail_providers_are_not_noop_for_core_blocks():
     )
     assert DEFAULT_STOCK_DETAIL_PROVIDERS.orderbook is stock_detail_orderbook_provider
 
+
 @pytest.mark.asyncio
 async def test_build_stock_detail_wires_decision_history():
     from app.schemas.invest_stock_detail import StockDetailDecisionHistory


### PR DESCRIPTION
## ROB-716 — 종목상세 판단→결과 학습루프 노출 (decision_history surface)

종목상세 "최근 분석"(`AnalysisCard`) 패널을 **죽은** `stock_analysis_results` 대신, ROB-711 `build_decision_context` (라이브 판단→결과 학습루프)로 재연결한다. 오퍼레이터가 분석할 때마다 **근거/예측 결과/회고 lesson/Brier**가 클릭 없이 보이는 게 목표.

### 무엇을
- **스키마**: `StockDetailLatestAnalysis` 제거 → `StockDetailDecisionHistory*` 5개 모델(`extra="forbid"`) + `StockDetailResponse.decisionHistory: StockDetailDecisionHistory | None`. 기본 `cautionLabel = "종목 기준 집계이며 특정 판단과 특정 결과의 직접 연결이 아닙니다."`
- **Provider**: `stock_detail_latest_analysis_provider` 제거 → `stock_detail_decision_history_provider`. `app.services.decision_history.build_decision_context(db, symbol, market)` **재사용** (join 로직 재구현 없음, "세 번째 병렬 저장소" 발산 회피). `recent_fills`은 YAGNI 컷(주문 카드 ROB-559가 이미 노출).
- **서비스 배선**: `StockDetailProviders.latest_analysis` → `decision_history`. 전 시장(kr/us/crypto) 실행. 실패 격리: `decision_history_unavailable` warning.
- **프론트**: `types/stockDetail.ts` 타입 교체, `AnalysisCard`(`stock-detail-analysis`) → `DecisionHistoryCard`(`stock-detail-decision-history`, "판단 이력"). 6섹션 렌더: **종목 Brier(n+meanBrier+`insufficient_sample` 배지) / 과거 판단 / 실현된 결과 / 진행중 예측 / 교훈 / `cautionLabel`**.
- **테스트**: 백엔드 48 스톡디테일 테스트 + 프론트 13 vitest 모두 PASS.

### 왜
`stock_analysis_results`는 openclaw HTTP 콜백/research pipeline만 쓰고 오퍼레이터 경로엔 안 돎(ROB-490 확정). ROB-711(`#1428`)이 `build_decision_context`를 배선해뒀고, 이 PR이 그 결과를 **종목상세 read-only view-model**에 노출하는 두 번째 단계(키스톤은 ROB-711). 데이터 소스 재사용 — 단일 진실.

### 안전/제약 (모두 준수)
- Migration 0 — DB 스키마 변경 0건. read-only.
- 브로커/주문/감시/order-intent mutation **무접촉**.
- In-process LLM provider import 0건 (ROB-501 정적 가드 유지).
- 모든 신규 Pydantic 모델 `ConfigDict(extra="forbid")`.
- `link_quality="symbol_window"` 정직 표기 — 개별 판단 행에 ✓적중/✗빗나감 인라인 배지 **부착 안 함** (`report_item_uuid` 채움률 ~0%, 직접 join 불가).

### 검증
- `pytest tests/test_stock_detail_service.py tests/test_stock_detail_providers.py tests/test_invest_stock_detail_schemas.py tests/test_invest_stock_detail_router.py tests/test_stock_detail_capability_contract.py tests/services/test_decision_history.py` → **48 passed**
- `npm test -- StockDetailPage` → **13 passed**
- `ruff check app/` → OK
- `tsc --noEmit` (frontend/invest) → clean
- `grep -rn "latestAnalysis\|StockDetailLatestAnalysis\|stock_detail_latest_analysis_provider\|stock-detail-analysis" app/ frontend/invest/src/` → **0 hits**
- `grep -rn "get_latest_analysis_by_symbol\|StockAnalysisService" app/services/invest_view_model/` → **0 hits**

### 성공 기준
- 종목상세에서 해당 심볼의 과거 판단(근거/confidence) + 예측 결과(실현/미해결) + 회고 lesson이 클릭 없이 보인다.
- 죽은 `stock_analysis_results` 의존 제거 — 재분석 심볼 80%+에서 패널이 비어있지 않다 (배포 후 observability로 확인).

### 참고
- 디자인: `docs/superpowers/specs/2026-07-05-rob-716-decision-history-surface-design.md`
- 플랜: `docs/superpowers/plans/2026-07-05-rob-716-decision-history-surface.md`
- 선행: ROB-711 `#1428` (build_decision_context), ROB-714 `#1429` (live ledger correlation_id)
- 후속 후보: MCP/REST 다른 표면(symbol-search, watch)에서 동일 payload 재노출 (별도 ROB 예정)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new “Decision History” section on stock detail pages with prior decisions, outcomes, open claims, running Brier metrics, and a caution label.
  * Stock detail responses now return decision history data instead of the previous analysis summary.

* **Bug Fixes**
  * Improved handling for missing or unavailable history data by showing an empty-state message and warning status when needed.
  * Updated tests and fixtures to match the new stock detail content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->