### PR TITLE
feat(ROB-713): setup-tagged trade-journal aggregates from live-ledger fills

### DIFF
--- a/app/mcp_server/tooling/registry.py
+++ b/app/mcp_server/tooling/registry.py
@@ -126,13 +126,12 @@ from app.mcp_server.tooling.trade_retrospective_registration import (
 from app.mcp_server.tooling.trading_policy_registration import (
     register_trading_policy_tools,
 )
+from app.mcp_server.tooling.trading_scoreboard_registration import (
+    register_trading_scoreboard_tools,
+)
 from app.mcp_server.tooling.us_dual_paper import register_us_dual_paper_tools
 from app.mcp_server.tooling.user_settings_registration import (
     register_user_settings_tools,
-register_user_settings_tools,
-)
-from app.mcp_server.tooling.trading_scoreboard_registration import (
-    register_trading_scoreboard_tools,
 )
 
 if TYPE_CHECKING:

--- a/app/mcp_server/tooling/registry.py
+++ b/app/mcp_server/tooling/registry.py
@@ -129,6 +129,10 @@ from app.mcp_server.tooling.trading_policy_registration import (
 from app.mcp_server.tooling.us_dual_paper import register_us_dual_paper_tools
 from app.mcp_server.tooling.user_settings_registration import (
     register_user_settings_tools,
+register_user_settings_tools,
+)
+from app.mcp_server.tooling.trading_scoreboard_registration import (
+    register_trading_scoreboard_tools,
 )
 
 if TYPE_CHECKING:
@@ -197,6 +201,9 @@ def register_all_tools(mcp: FastMCP, profile: McpProfile = McpProfile.DEFAULT) -
     register_mock_loop_retro_tools(mcp)
     register_trade_retrospective_tools(mcp)
     register_forecast_tools(mcp)
+    register_trading_scoreboard_tools(mcp)
+    # ROB-713 — setup-tagged trade-journal aggregates; read-only, registered
+    # unconditionally like the forecast tools it parallels.
 
     # ROB-269 Phase 2 — investment-snapshot MCP surface. Gated by
     # ``settings.INVESTMENT_SNAPSHOTS_MCP_ENABLED`` so the 3 read tools are

--- a/app/mcp_server/tooling/route_request_lanes.py
+++ b/app/mcp_server/tooling/route_request_lanes.py
@@ -310,6 +310,7 @@ READ_ONLY_ADVISORY_TOOLS: frozenset[str] = frozenset(
         "get_trade_journal",
         "get_trade_retrospectives",
         "get_trading_policy",
+        "get_trading_scoreboard",
         "get_upbit_altseason",
         "get_upbit_index",
         "get_user_setting",

--- a/app/mcp_server/tooling/trading_scoreboard_registration.py
+++ b/app/mcp_server/tooling/trading_scoreboard_registration.py
@@ -1,0 +1,27 @@
+"""ROB-713 — MCP registration for the trading scoreboard read tool."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from app.mcp_server.tooling.trading_scoreboard_tools import get_trading_scoreboard
+
+TRADING_SCOREBOARD_TOOL_NAMES: set[str] = {"get_trading_scoreboard"}
+
+
+def register_trading_scoreboard_tools(mcp: Any) -> None:
+    _ = mcp.tool(
+        name="get_trading_scoreboard",
+        description=(
+            "Setup-tagged trade-journal aggregates over closed round-trips "
+            "reconstructed from live-order-ledger fills: per setup tag "
+            "(strategy_key -> intent -> untagged) win-rate, expectancy (% and "
+            "R-multiple), profit factor, average/worst MAE and MFE. Tags with "
+            "n<10 are flagged insufficient_sample. Filters: market, "
+            "account_mode, date_from/date_to (YYYY-MM-DD), setup_tag, "
+            "min_sample. Read-only; deterministic."
+        ),
+    )(get_trading_scoreboard)
+
+
+__all__ = ["TRADING_SCOREBOARD_TOOL_NAMES", "register_trading_scoreboard_tools"]

--- a/app/mcp_server/tooling/trading_scoreboard_tools.py
+++ b/app/mcp_server/tooling/trading_scoreboard_tools.py
@@ -43,4 +43,10 @@ async def get_trading_scoreboard(
             )
     except Exception as exc:  # noqa: BLE001
         logger.exception("get_trading_scoreboard failed")
-        return {"count": 0, "groups": [], "overall": None, "as_of": None, "error": str(exc)}
+        return {
+            "count": 0,
+            "groups": [],
+            "overall": None,
+            "as_of": None,
+            "error": str(exc),
+        }

--- a/app/mcp_server/tooling/trading_scoreboard_tools.py
+++ b/app/mcp_server/tooling/trading_scoreboard_tools.py
@@ -1,0 +1,46 @@
+"""ROB-713 — read-only MCP surface for setup-tagged trade-journal aggregates."""
+
+from __future__ import annotations
+
+import logging
+from datetime import date
+from typing import Any, cast
+
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from app.core.db import AsyncSessionLocal
+from app.services.trade_journal.aggregates import build_trading_scoreboard
+
+logger = logging.getLogger(__name__)
+
+
+def _session_factory() -> async_sessionmaker[AsyncSession]:
+    return cast(async_sessionmaker[AsyncSession], cast(object, AsyncSessionLocal))
+
+
+def _parse_date(value: str | None) -> date | None:
+    return date.fromisoformat(value) if value else None
+
+
+async def get_trading_scoreboard(
+    market: str | None = None,
+    account_mode: str | None = None,
+    date_from: str | None = None,
+    date_to: str | None = None,
+    setup_tag: str | None = None,
+    min_sample: int = 1,
+) -> dict[str, Any]:
+    try:
+        async with _session_factory()() as db:
+            return await build_trading_scoreboard(
+                db,
+                market=market,
+                account_mode=account_mode,
+                date_from=_parse_date(date_from),
+                date_to=_parse_date(date_to),
+                setup_tag=setup_tag,
+                min_sample=min_sample,
+            )
+    except Exception as exc:  # noqa: BLE001
+        logger.exception("get_trading_scoreboard failed")
+        return {"count": 0, "groups": [], "overall": None, "as_of": None, "error": str(exc)}

--- a/app/services/decision_history.py
+++ b/app/services/decision_history.py
@@ -80,7 +80,8 @@ async def build_decision_context(
 ) -> dict[str, Any] | None:
     """Build the decision_history payload for one symbol, or None if no signal.
 
-    """setup_tag, when supplied, selects which setup comes first in realized_r_by_tag."""
+    ``setup_tag``, when supplied, selects which setup comes first in
+    ``realized_r_by_tag`` (ROB-713). It is otherwise unused.
     """
     instrument_type = MARKET_TO_INSTRUMENT.get(market)
     norm = _normalize_symbol_for_filter(symbol, instrument_type)
@@ -133,15 +134,15 @@ def _fold_brier(agg: dict[str, Any]) -> dict[str, Any]:
         "mean_brier": round(mean, 4) if mean is not None else None,
         "flag": "insufficient_sample" if n < 10 else "ok",
     }
+
+
 async def _realized_r_by_tag(
     db: AsyncSession, market: str, setup_tag: str | None
 ) -> dict[str, dict[str, Any]]:
     """Bounded per-tag map for the ROB-713 scoreboard — portfolio-wide, not per-symbol."""
     board = await build_trading_scoreboard(db, market=market)
     groups = board.get("groups", [])
-    ordered = sorted(
-        groups, key=lambda g: (g["tag"] != setup_tag, -int(g["n"]))
-    )
+    ordered = sorted(groups, key=lambda g: (g["tag"] != setup_tag, -int(g["n"])))
     out: dict[str, dict[str, Any]] = {}
     for g in ordered[:_MAX_TAGS]:
         if g["tag"] == "untagged":

--- a/app/services/decision_history.py
+++ b/app/services/decision_history.py
@@ -26,7 +26,6 @@ from app.models.review import (
     TradeForecast,
     TradeRetrospective,
 )
-from app.services.trade_journal.aggregates import build_trading_scoreboard
 from app.services.trade_journal.forecast_service import (
     _normalize_symbol_for_filter,
     build_forecast_calibration_aggregate,
@@ -139,7 +138,15 @@ def _fold_brier(agg: dict[str, Any]) -> dict[str, Any]:
 async def _realized_r_by_tag(
     db: AsyncSession, market: str, setup_tag: str | None
 ) -> dict[str, dict[str, Any]]:
-    """Bounded per-tag map for the ROB-713 scoreboard — portfolio-wide, not per-symbol."""
+    """Bounded per-tag map for the ROB-713 scoreboard — portfolio-wide, not per-symbol.
+
+    Imported lazily so `import app.services.decision_history` stays free of the
+    market-data/broker import chain — `app.services.invest_view_model`
+    (ROB-716 stock-detail surface) imports this module and must not transitively
+    pull execution paths (`tests/test_invest_view_model_safety.py`).
+    """
+    from app.services.trade_journal.aggregates import build_trading_scoreboard
+
     board = await build_trading_scoreboard(db, market=market)
     groups = board.get("groups", [])
     ordered = sorted(groups, key=lambda g: (g["tag"] != setup_tag, -int(g["n"])))

--- a/app/services/decision_history.py
+++ b/app/services/decision_history.py
@@ -26,6 +26,7 @@ from app.models.review import (
     TradeForecast,
     TradeRetrospective,
 )
+from app.services.trade_journal.aggregates import build_trading_scoreboard
 from app.services.trade_journal.forecast_service import (
     _normalize_symbol_for_filter,
     build_forecast_calibration_aggregate,
@@ -40,6 +41,15 @@ MAX_FILLS = 6
 MAX_CLAIMS = 5
 _TRUNC = 220
 _SMOKE_TOKENS = ("smoke",)
+_MAX_TAGS = 3
+_R_KEYS = (
+    "n",
+    "expectancy_r",
+    "win_rate",
+    "profit_factor",
+    "avg_mae",
+    "insufficient_sample",
+)
 
 
 def _is_smoke(*values: str | None) -> bool:
@@ -70,7 +80,7 @@ async def build_decision_context(
 ) -> dict[str, Any] | None:
     """Build the decision_history payload for one symbol, or None if no signal.
 
-    setup_tag is reserved for realized_r_by_tag (ROB-713 stage 3); unused here.
+    """setup_tag, when supplied, selects which setup comes first in realized_r_by_tag."""
     """
     instrument_type = MARKET_TO_INSTRUMENT.get(market)
     norm = _normalize_symbol_for_filter(symbol, instrument_type)
@@ -90,6 +100,7 @@ async def build_decision_context(
         )
     )
     brier_global = _fold_brier(await build_forecast_calibration_aggregate(db))
+    realized_r = await _realized_r_by_tag(db, market, setup_tag)
 
     ctx: dict[str, Any] = {
         "symbol": norm,
@@ -102,6 +113,7 @@ async def build_decision_context(
         "open_claims": open_claims,
         "running_brier_symbol": brier_symbol,
         "running_brier_global": brier_global,
+        "realized_r_by_tag": realized_r,
     }
     return ctx
 
@@ -121,6 +133,21 @@ def _fold_brier(agg: dict[str, Any]) -> dict[str, Any]:
         "mean_brier": round(mean, 4) if mean is not None else None,
         "flag": "insufficient_sample" if n < 10 else "ok",
     }
+async def _realized_r_by_tag(
+    db: AsyncSession, market: str, setup_tag: str | None
+) -> dict[str, dict[str, Any]]:
+    """Bounded per-tag map for the ROB-713 scoreboard — portfolio-wide, not per-symbol."""
+    board = await build_trading_scoreboard(db, market=market)
+    groups = board.get("groups", [])
+    ordered = sorted(
+        groups, key=lambda g: (g["tag"] != setup_tag, -int(g["n"]))
+    )
+    out: dict[str, dict[str, Any]] = {}
+    for g in ordered[:_MAX_TAGS]:
+        if g["tag"] == "untagged":
+            continue
+        out[g["tag"]] = {k: g.get(k) for k in _R_KEYS}
+    return out
 
 
 async def _prior_decisions(db: AsyncSession, symbol: str) -> list[dict[str, Any]]:

--- a/app/services/trade_journal/aggregates.py
+++ b/app/services/trade_journal/aggregates.py
@@ -6,11 +6,11 @@ from __future__ import annotations
 import uuid
 from collections import defaultdict, deque
 from dataclasses import dataclass
-from datetime import date, datetime, timedelta
+from datetime import UTC, date, datetime, timedelta
+from statistics import fmean, median
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
-from app.services.market_data import get_ohlcv
 
 from app.core.symbol import to_db_symbol
 from app.models.investment_reports import InvestmentReportItem
@@ -20,6 +20,7 @@ from app.models.review import (
     TossLiveOrderLedger,
     TradeRetrospective,
 )
+from app.services.market_data import get_ohlcv
 from app.services.trade_journal.forecast_service import _normalize_symbol_for_filter
 
 _EPS = 1e-9
@@ -397,8 +398,6 @@ async def compute_excursions(
     mfe = (max(float(c.high) for c in window) - entry) / entry
     return mae, mfe, degraded
 
-from statistics import fmean, median
-from datetime import timezone
 
 _INSUFFICIENT_SAMPLE_N = 10
 _SCOREBOARD_TTL_SECONDS = 300
@@ -474,7 +473,7 @@ async def build_trading_scoreboard(
     production the orchestrator defaults to ``datetime.now(timezone.utc)``.
     """
     key = (market, account_mode, date_from, date_to, setup_tag, min_sample)
-    stamp = (now or datetime.now(timezone.utc)).timestamp()
+    stamp = (now or datetime.now(UTC)).timestamp()
     if use_cache:
         cached = _scoreboard_cache.get(key)
         if cached and stamp - cached[0] < _SCOREBOARD_TTL_SECONDS:
@@ -513,7 +512,7 @@ async def build_trading_scoreboard(
     result = {
         "groups": groups,
         "overall": _agg_one("__overall__", rows) if rows else None,
-        "as_of": (now or datetime.now(timezone.utc)).isoformat(),
+        "as_of": (now or datetime.now(UTC)).isoformat(),
         "count": len(rows),
     }
     if use_cache:

--- a/app/services/trade_journal/aggregates.py
+++ b/app/services/trade_journal/aggregates.py
@@ -3,22 +3,28 @@ MAE) over live-ledger fills. Read-only, no LLM (ROB-501), no schema change."""
 
 from __future__ import annotations
 
+import uuid
 from collections import defaultdict, deque
 from dataclasses import dataclass
-from datetime import date, datetime
+from datetime import date, datetime, timedelta
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.symbol import to_db_symbol
+from app.models.investment_reports import InvestmentReportItem
 from app.models.review import (
     KISLiveOrderLedger,
     LiveOrderLedger,
     TossLiveOrderLedger,
+    TradeRetrospective,
 )
+from app.services.trade_journal.forecast_service import _normalize_symbol_for_filter
 
 _EPS = 1e-9
 _SMOKE_TOKENS = ("smoke",)
+
+_MARKET_TO_INSTRUMENT = {"kr": "equity_kr", "us": "equity_us", "crypto": "crypto"}
 
 
 def _is_smoke(*values: str | None) -> bool:
@@ -49,6 +55,15 @@ def _account_of(source: str, row: object) -> str:
         or getattr(row, "broker", None)
         or source
     )
+
+
+def _coerce_uuid(value: str | None) -> uuid.UUID | None:
+    if not value:
+        return None
+    try:
+        return uuid.UUID(str(value))
+    except (ValueError, AttributeError):
+        return None
 
 
 @dataclass(frozen=True)
@@ -94,6 +109,13 @@ class _Lot:
     ts: datetime
     item_uuid: str | None
     correlation_id: str | None
+
+
+@dataclass(frozen=True)
+class TagInfo:
+    tag: str
+    tag_source: str
+    link_quality: str
 
 
 async def load_fills(
@@ -213,3 +235,79 @@ def pair_fills_fifo(fills: list[Fill]) -> list[ClosedTrade]:
                 )
             )
     return closed
+
+
+async def resolve_setup_tag(
+    db: AsyncSession, trade: ClosedTrade, *, window_days: int = 45
+) -> TagInfo:
+    """Resolve the setup tag for a closed round-trip.
+
+    Precedence: ``strategy_key`` (exact via correlation_id, then symbol_window) →
+    ``intent`` (exact via item_uuid, then symbol_window) → ``untagged``.
+    """
+    instrument = _MARKET_TO_INSTRUMENT.get(trade.market)
+    norm = _normalize_symbol_for_filter(trade.symbol, instrument)
+    window_start = trade.entry_ts - timedelta(days=window_days)
+
+    corr_ids = [c for c in (*trade.entry_correlation_ids, trade.exit_correlation_id) if c]
+    if corr_ids:
+        row = (
+            await db.execute(
+                select(TradeRetrospective.strategy_key)
+                .where(
+                    TradeRetrospective.correlation_id.in_(corr_ids),
+                    TradeRetrospective.strategy_key.isnot(None),
+                )
+                .order_by(TradeRetrospective.created_at.desc())
+                .limit(1)
+            )
+        ).scalar_one_or_none()
+        if row and not _is_smoke(row):
+            return TagInfo(row, "strategy_key", "exact")
+
+    retro_key = (
+        await db.execute(
+            select(TradeRetrospective.strategy_key)
+            .where(
+                TradeRetrospective.symbol == norm,
+                TradeRetrospective.strategy_key.isnot(None),
+                TradeRetrospective.created_at <= trade.exit_ts,
+                TradeRetrospective.created_at >= window_start,
+            )
+            .order_by(TradeRetrospective.created_at.desc())
+            .limit(1)
+        )
+    ).scalar_one_or_none()
+    if retro_key and not _is_smoke(retro_key):
+        return TagInfo(retro_key, "strategy_key", "symbol_window")
+
+    item_uuids_raw = [u for u in (*trade.entry_item_uuids, trade.exit_item_uuid) if u]
+    item_uuids = [u for u in (uid if isinstance(uid, uuid.UUID) else _coerce_uuid(uid) for uid in item_uuids_raw) if u is not None]
+    if item_uuids:
+        intent = (
+            await db.execute(
+                select(InvestmentReportItem.intent)
+                .where(InvestmentReportItem.item_uuid.in_(item_uuids))
+                .order_by(InvestmentReportItem.created_at.desc())
+                .limit(1)
+            )
+        ).scalar_one_or_none()
+        if intent:
+            return TagInfo(intent, "intent", "exact")
+
+    intent_win = (
+        await db.execute(
+            select(InvestmentReportItem.intent)
+            .where(
+                InvestmentReportItem.symbol == norm,
+                InvestmentReportItem.created_at <= trade.entry_ts,
+                InvestmentReportItem.created_at >= window_start,
+            )
+            .order_by(InvestmentReportItem.created_at.desc())
+            .limit(1)
+        )
+    ).scalar_one_or_none()
+    if intent_win:
+        return TagInfo(intent_win, "intent", "symbol_window")
+
+    return TagInfo("untagged", "untagged", "symbol_window")

--- a/app/services/trade_journal/aggregates.py
+++ b/app/services/trade_journal/aggregates.py
@@ -1,0 +1,119 @@
+"""ROB-713 — deterministic trade-journal aggregates (expectancy / R-multiple /
+MAE) over live-ledger fills. Read-only, no LLM (ROB-501), no schema change."""
+
+from __future__ import annotations
+
+from collections import defaultdict, deque
+from dataclasses import dataclass
+from datetime import datetime
+
+_EPS = 1e-9
+
+
+@dataclass(frozen=True)
+class Fill:
+    market: str
+    symbol: str
+    account: str
+    side: str
+    qty: float
+    price: float
+    fee: float
+    ts: datetime
+    item_uuid: str | None
+    correlation_id: str | None
+    source: str
+
+
+@dataclass(frozen=True)
+class ClosedTrade:
+    market: str
+    symbol: str
+    account: str
+    qty: float
+    entry_price: float
+    exit_price: float
+    entry_ts: datetime
+    exit_ts: datetime
+    pnl_abs: float
+    pnl_pct: float
+    fees: float
+    entry_item_uuids: tuple[str, ...]
+    exit_item_uuid: str | None
+    entry_correlation_ids: tuple[str, ...]
+    exit_correlation_id: str | None
+
+
+@dataclass
+class _Lot:
+    qty: float
+    orig_qty: float
+    price: float
+    fee: float
+    ts: datetime
+    item_uuid: str | None
+    correlation_id: str | None
+
+
+def pair_fills_fifo(fills: list[Fill]) -> list[ClosedTrade]:
+    groups: dict[tuple[str, str, str], list[Fill]] = defaultdict(list)
+    for f in fills:
+        groups[(f.market, f.account, f.symbol)].append(f)
+
+    closed: list[ClosedTrade] = []
+    for (market, account, symbol), group in groups.items():
+        group_sorted = sorted(group, key=lambda f: f.ts)
+        open_lots: deque[_Lot] = deque()
+        for f in group_sorted:
+            if f.side == "buy":
+                open_lots.append(
+                    _Lot(f.qty, f.qty, f.price, f.fee, f.ts, f.item_uuid, f.correlation_id)
+                )
+                continue
+            if f.side != "sell":
+                continue
+            remaining = f.qty
+            consumed: list[tuple[float, _Lot]] = []
+            while remaining > _EPS and open_lots:
+                lot = open_lots[0]
+                take = min(remaining, lot.qty)
+                consumed.append((take, lot))
+                lot.qty -= take
+                remaining -= take
+                if lot.qty <= _EPS:
+                    open_lots.popleft()
+            if not consumed:
+                continue  # oversell / no matching entry (long-only)
+            matched_qty = sum(t for t, _ in consumed)
+            entry_price = sum(t * lot.price for t, lot in consumed) / matched_qty
+            entry_ts = min(lot.ts for _, lot in consumed)
+            entry_fee = sum(lot.fee * (t / lot.orig_qty) for t, lot in consumed)
+            exit_fee = f.fee * (matched_qty / f.qty) if f.qty else 0.0
+            fees = entry_fee + exit_fee
+            gross = (f.price - entry_price) * matched_qty
+            closed.append(
+                ClosedTrade(
+                    market=market,
+                    symbol=symbol,
+                    account=account,
+                    qty=matched_qty,
+                    entry_price=entry_price,
+                    exit_price=f.price,
+                    entry_ts=entry_ts,
+                    exit_ts=f.ts,
+                    pnl_abs=gross - fees,
+                    pnl_pct=(f.price - entry_price) / entry_price if entry_price else 0.0,
+                    fees=fees,
+                    entry_item_uuids=tuple(
+                        dict.fromkeys(lot.item_uuid for _, lot in consumed if lot.item_uuid)
+                    ),
+                    exit_item_uuid=f.item_uuid,
+                    entry_correlation_ids=tuple(
+                        dict.fromkeys(
+                            lot.correlation_id for _, lot in consumed if lot.correlation_id
+                        )
+                    ),
+                    exit_correlation_id=f.correlation_id,
+                )
+            )
+    return closed

--- a/app/services/trade_journal/aggregates.py
+++ b/app/services/trade_journal/aggregates.py
@@ -5,9 +5,50 @@ from __future__ import annotations
 
 from collections import defaultdict, deque
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import date, datetime
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.symbol import to_db_symbol
+from app.models.review import (
+    KISLiveOrderLedger,
+    LiveOrderLedger,
+    TossLiveOrderLedger,
+)
 
 _EPS = 1e-9
+_SMOKE_TOKENS = ("smoke",)
+
+
+def _is_smoke(*values: str | None) -> bool:
+    return any(v and any(tok in v.lower() for tok in _SMOKE_TOKENS) for v in values)
+
+
+def _fee_of(row: object) -> float:
+    total = 0.0
+    for attr in ("fee", "commission", "tax"):
+        val = getattr(row, attr, None)
+        if val is not None:
+            total += float(val)
+    return total
+
+
+def _market_for(source: str, row: object) -> str:
+    if source == "kis":
+        return "kr"
+    raw = (getattr(row, "market", None) or "").lower()
+    if source == "toss":
+        return "us" if raw == "us" else "kr"
+    return "crypto" if raw == "crypto" else "us"  # live ledger
+
+
+def _account_of(source: str, row: object) -> str:
+    return (
+        getattr(row, "account_scope", None)
+        or getattr(row, "broker", None)
+        or source
+    )
 
 
 @dataclass(frozen=True)
@@ -53,6 +94,61 @@ class _Lot:
     ts: datetime
     item_uuid: str | None
     correlation_id: str | None
+
+
+async def load_fills(
+    db: AsyncSession,
+    *,
+    market: str | None = None,
+    account_mode: str | None = None,
+    date_from: date | None = None,
+    date_to: date | None = None,
+) -> list[Fill]:
+    """Read filled rows from the three live order ledgers and normalize to ``Fill``.
+
+    ``account_mode`` is accepted for API symmetry but not currently used for
+    filtering — the live ledgers store account via ``account_mode`` /
+    ``account_scope`` / ``broker`` (see ``_account_of``) and the FIFO pairing
+    downstream already segregates lots per account label.
+    """
+    fills: list[Fill] = []
+    for source, model in (
+        ("kis", KISLiveOrderLedger),
+        ("live", LiveOrderLedger),
+        ("toss", TossLiveOrderLedger),
+    ):
+        stmt = select(model).where(model.filled_qty.isnot(None), model.filled_qty > 0)
+        rows = (await db.execute(stmt)).scalars().all()
+        for r in rows:
+            row_market = _market_for(source, r)
+            if market and row_market != market:
+                continue
+            if r.trade_date is not None:
+                d = r.trade_date.date()
+                if date_from and d < date_from:
+                    continue
+                if date_to and d > date_to:
+                    continue
+            if _is_smoke(getattr(r, "correlation_id", None), getattr(r, "status", None)):
+                continue
+            corr = getattr(r, "correlation_id", None)
+            item_uuid = getattr(r, "report_item_uuid", None)
+            fills.append(
+                Fill(
+                    market=row_market,
+                    symbol=to_db_symbol(r.symbol),
+                    account=_account_of(source, r),
+                    side=r.side,
+                    qty=float(r.filled_qty),
+                    price=float(r.avg_fill_price) if r.avg_fill_price is not None else 0.0,
+                    fee=_fee_of(r),
+                    ts=r.trade_date,
+                    item_uuid=str(item_uuid) if item_uuid else None,
+                    correlation_id=corr,
+                    source=source,
+                )
+            )
+    return [f for f in fills if f.price > 0 and f.ts is not None]
 
 
 def pair_fills_fifo(fills: list[Fill]) -> list[ClosedTrade]:

--- a/app/services/trade_journal/aggregates.py
+++ b/app/services/trade_journal/aggregates.py
@@ -10,6 +10,7 @@ from datetime import date, datetime, timedelta
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
+from app.services.market_data import get_ohlcv
 
 from app.core.symbol import to_db_symbol
 from app.models.investment_reports import InvestmentReportItem
@@ -311,3 +312,87 @@ async def resolve_setup_tag(
         return TagInfo(intent_win, "intent", "symbol_window")
 
     return TagInfo("untagged", "untagged", "symbol_window")
+
+_MAX_OHLCV_BARS = 200
+
+
+def compute_r_multiple(trade: ClosedTrade, planned_stop: float | None) -> float | None:
+    if planned_stop is None:
+        return None
+    risk = abs(trade.entry_price - planned_stop)
+    if risk <= _EPS:
+        return None
+    return (trade.exit_price - trade.entry_price) / risk
+
+
+async def planned_stop_for(
+    db: AsyncSession, trade: ClosedTrade, *, window_days: int = 45
+) -> float | None:
+    instrument = _MARKET_TO_INSTRUMENT.get(trade.market)
+    norm = _normalize_symbol_for_filter(trade.symbol, instrument)
+    window_start = trade.entry_ts - timedelta(days=window_days)
+
+    item_uuids_raw = [u for u in (*trade.entry_item_uuids, trade.exit_item_uuid) if u]
+    item_uuids = [
+        u for u in (
+            x if isinstance(x, uuid.UUID) else _coerce_uuid(x)
+            for x in item_uuids_raw
+        )
+        if u is not None
+    ]
+    if item_uuids:
+        stmt = (
+            select(InvestmentReportItem.evidence_snapshot)
+            .where(InvestmentReportItem.item_uuid.in_(item_uuids))
+            .order_by(InvestmentReportItem.created_at.desc())
+            .limit(1)
+        )
+    else:
+        stmt = (
+            select(InvestmentReportItem.evidence_snapshot)
+            .where(
+                InvestmentReportItem.symbol == norm,
+                InvestmentReportItem.created_at <= trade.entry_ts,
+                InvestmentReportItem.created_at >= window_start,
+            )
+            .order_by(InvestmentReportItem.created_at.desc())
+            .limit(1)
+        )
+    snapshot = (await db.execute(stmt)).scalar_one_or_none()
+    if not isinstance(snapshot, dict):
+        return None
+    stop = (snapshot.get("trade_setup") or {}).get("stop")
+    try:
+        return float(stop) if stop is not None else None
+    except (TypeError, ValueError):
+        return None
+
+
+async def compute_excursions(
+    trade: ClosedTrade,
+) -> tuple[float | None, float | None, bool]:
+    """Compute MAE / MFE over daily candles spanning the trade.
+
+    Returns ``(mae, mfe, degraded)``. When the trade spans >200 trading days the
+    result carries ``degraded=True`` (we cap the candle fetch at 200 bars).
+    """
+
+    span_days = (trade.exit_ts.date() - trade.entry_ts.date()).days + 1
+    degraded = span_days > _MAX_OHLCV_BARS
+    count = min(max(span_days + 2, 2), _MAX_OHLCV_BARS)
+    candles = await get_ohlcv(
+        trade.symbol, trade.market, period="day", count=count, end=trade.exit_ts
+    )
+    window = [
+        c
+        for c in candles
+        if trade.entry_ts.date() <= c.timestamp.date() <= trade.exit_ts.date()
+    ]
+    if not window:
+        return None, None, degraded
+    entry = trade.entry_price
+    if entry <= _EPS:
+        return None, None, degraded
+    mae = (min(float(c.low) for c in window) - entry) / entry
+    mfe = (max(float(c.high) for c in window) - entry) / entry
+    return mae, mfe, degraded

--- a/app/services/trade_journal/aggregates.py
+++ b/app/services/trade_journal/aggregates.py
@@ -52,11 +52,7 @@ def _market_for(source: str, row: object) -> str:
 
 
 def _account_of(source: str, row: object) -> str:
-    return (
-        getattr(row, "account_scope", None)
-        or getattr(row, "broker", None)
-        or source
-    )
+    return getattr(row, "account_scope", None) or getattr(row, "broker", None) or source
 
 
 def _coerce_uuid(value: str | None) -> uuid.UUID | None:
@@ -153,7 +149,9 @@ async def load_fills(
                     continue
                 if date_to and d > date_to:
                     continue
-            if _is_smoke(getattr(r, "correlation_id", None), getattr(r, "status", None)):
+            if _is_smoke(
+                getattr(r, "correlation_id", None), getattr(r, "status", None)
+            ):
                 continue
             corr = getattr(r, "correlation_id", None)
             item_uuid = getattr(r, "report_item_uuid", None)
@@ -164,7 +162,9 @@ async def load_fills(
                     account=_account_of(source, r),
                     side=r.side,
                     qty=float(r.filled_qty),
-                    price=float(r.avg_fill_price) if r.avg_fill_price is not None else 0.0,
+                    price=float(r.avg_fill_price)
+                    if r.avg_fill_price is not None
+                    else 0.0,
                     fee=_fee_of(r),
                     ts=r.trade_date,
                     item_uuid=str(item_uuid) if item_uuid else None,
@@ -187,7 +187,15 @@ def pair_fills_fifo(fills: list[Fill]) -> list[ClosedTrade]:
         for f in group_sorted:
             if f.side == "buy":
                 open_lots.append(
-                    _Lot(f.qty, f.qty, f.price, f.fee, f.ts, f.item_uuid, f.correlation_id)
+                    _Lot(
+                        f.qty,
+                        f.qty,
+                        f.price,
+                        f.fee,
+                        f.ts,
+                        f.item_uuid,
+                        f.correlation_id,
+                    )
                 )
                 continue
             if f.side != "sell":
@@ -222,15 +230,21 @@ def pair_fills_fifo(fills: list[Fill]) -> list[ClosedTrade]:
                     entry_ts=entry_ts,
                     exit_ts=f.ts,
                     pnl_abs=gross - fees,
-                    pnl_pct=(f.price - entry_price) / entry_price if entry_price else 0.0,
+                    pnl_pct=(f.price - entry_price) / entry_price
+                    if entry_price
+                    else 0.0,
                     fees=fees,
                     entry_item_uuids=tuple(
-                        dict.fromkeys(lot.item_uuid for _, lot in consumed if lot.item_uuid)
+                        dict.fromkeys(
+                            lot.item_uuid for _, lot in consumed if lot.item_uuid
+                        )
                     ),
                     exit_item_uuid=f.item_uuid,
                     entry_correlation_ids=tuple(
                         dict.fromkeys(
-                            lot.correlation_id for _, lot in consumed if lot.correlation_id
+                            lot.correlation_id
+                            for _, lot in consumed
+                            if lot.correlation_id
                         )
                     ),
                     exit_correlation_id=f.correlation_id,
@@ -251,7 +265,9 @@ async def resolve_setup_tag(
     norm = _normalize_symbol_for_filter(trade.symbol, instrument)
     window_start = trade.entry_ts - timedelta(days=window_days)
 
-    corr_ids = [c for c in (*trade.entry_correlation_ids, trade.exit_correlation_id) if c]
+    corr_ids = [
+        c for c in (*trade.entry_correlation_ids, trade.exit_correlation_id) if c
+    ]
     if corr_ids:
         row = (
             await db.execute(
@@ -284,7 +300,14 @@ async def resolve_setup_tag(
         return TagInfo(retro_key, "strategy_key", "symbol_window")
 
     item_uuids_raw = [u for u in (*trade.entry_item_uuids, trade.exit_item_uuid) if u]
-    item_uuids = [u for u in (uid if isinstance(uid, uuid.UUID) else _coerce_uuid(uid) for uid in item_uuids_raw) if u is not None]
+    item_uuids = [
+        u
+        for u in (
+            uid if isinstance(uid, uuid.UUID) else _coerce_uuid(uid)
+            for uid in item_uuids_raw
+        )
+        if u is not None
+    ]
     if item_uuids:
         intent = (
             await db.execute(
@@ -314,6 +337,7 @@ async def resolve_setup_tag(
 
     return TagInfo("untagged", "untagged", "symbol_window")
 
+
 _MAX_OHLCV_BARS = 200
 
 
@@ -335,9 +359,9 @@ async def planned_stop_for(
 
     item_uuids_raw = [u for u in (*trade.entry_item_uuids, trade.exit_item_uuid) if u]
     item_uuids = [
-        u for u in (
-            x if isinstance(x, uuid.UUID) else _coerce_uuid(x)
-            for x in item_uuids_raw
+        u
+        for u in (
+            x if isinstance(x, uuid.UUID) else _coerce_uuid(x) for x in item_uuids_raw
         )
         if u is not None
     ]
@@ -501,9 +525,7 @@ async def build_trading_scoreboard(
             mae, mfe, _degraded = await compute_excursions(t)
         except Exception:
             mae, mfe = None, None
-        rows.append(
-            TradeMetrics(t, tag, compute_r_multiple(t, stop), mae, mfe)
-        )
+        rows.append(TradeMetrics(t, tag, compute_r_multiple(t, stop), mae, mfe))
 
     groups = aggregate_by_tag(rows)
     if setup_tag:

--- a/app/services/trade_journal/aggregates.py
+++ b/app/services/trade_journal/aggregates.py
@@ -396,3 +396,126 @@ async def compute_excursions(
     mae = (min(float(c.low) for c in window) - entry) / entry
     mfe = (max(float(c.high) for c in window) - entry) / entry
     return mae, mfe, degraded
+
+from statistics import fmean, median
+from datetime import timezone
+
+_INSUFFICIENT_SAMPLE_N = 10
+_SCOREBOARD_TTL_SECONDS = 300
+_scoreboard_cache: dict[tuple, tuple[float, dict]] = {}
+
+
+@dataclass
+class TradeMetrics:
+    trade: ClosedTrade
+    tag: TagInfo
+    r_multiple: float | None
+    mae: float | None
+    mfe: float | None
+
+
+def _agg_one(tag: str, rows: list[TradeMetrics]) -> dict:
+    pnls = [r.trade.pnl_pct for r in rows if r.trade.pnl_pct is not None]
+    wins = [p for p in pnls if p > 0]
+    losses = [p for p in pnls if p <= 0]
+    gross_win = sum(r.trade.pnl_abs for r in rows if r.trade.pnl_abs > 0)
+    gross_loss = abs(sum(r.trade.pnl_abs for r in rows if r.trade.pnl_abs < 0))
+    rs = [r.r_multiple for r in rows if r.r_multiple is not None]
+    maes = [r.mae for r in rows if r.mae is not None]
+    mfes = [r.mfe for r in rows if r.mfe is not None]
+    n = len(rows)
+    sources = {r.tag.tag_source for r in rows}
+    quals = {r.tag.link_quality for r in rows}
+    return {
+        "tag": tag,
+        "tag_source": next(iter(sources)) if len(sources) == 1 else "mixed",
+        "link_quality": "exact" if quals == {"exact"} else "symbol_window",
+        "n": n,
+        "wins": len(wins),
+        "losses": len(losses),
+        "win_rate": (len(wins) / len(pnls)) if pnls else None,
+        "expectancy_pct": fmean(pnls) if pnls else None,
+        "expectancy_r": fmean(rs) if rs else None,
+        "profit_factor": (gross_win / gross_loss) if gross_loss > _EPS else None,
+        "avg_r": fmean(rs) if rs else None,
+        "median_r": median(rs) if rs else None,
+        "r_coverage": (len(rs) / n) if n else None,
+        "avg_mae": fmean(maes) if maes else None,
+        "avg_mfe": fmean(mfes) if mfes else None,
+        "worst_mae": min(maes) if maes else None,
+        "insufficient_sample": n < _INSUFFICIENT_SAMPLE_N,
+    }
+
+
+def aggregate_by_tag(rows: list[TradeMetrics]) -> list[dict]:
+    by_tag: dict[str, list[TradeMetrics]] = defaultdict(list)
+    for r in rows:
+        by_tag[r.tag.tag].append(r)
+    groups = [_agg_one(tag, tag_rows) for tag, tag_rows in by_tag.items()]
+    groups.sort(key=lambda g: g["n"], reverse=True)
+    return groups
+
+
+async def build_trading_scoreboard(
+    db: AsyncSession,
+    *,
+    market: str | None = None,
+    account_mode: str | None = None,
+    date_from: date | None = None,
+    date_to: date | None = None,
+    setup_tag: str | None = None,
+    min_sample: int = 1,
+    use_cache: bool = True,
+    now: datetime | None = None,
+) -> dict:
+    """Compute per-tag setup aggregates from live-ledger fills.
+
+    ``now`` is exposed for tests so the TTL comparison is deterministic; in
+    production the orchestrator defaults to ``datetime.now(timezone.utc)``.
+    """
+    key = (market, account_mode, date_from, date_to, setup_tag, min_sample)
+    stamp = (now or datetime.now(timezone.utc)).timestamp()
+    if use_cache:
+        cached = _scoreboard_cache.get(key)
+        if cached and stamp - cached[0] < _SCOREBOARD_TTL_SECONDS:
+            return cached[1]
+
+    fills = await load_fills(
+        db,
+        market=market,
+        account_mode=account_mode,
+        date_from=date_from,
+        date_to=date_to,
+    )
+    trades = pair_fills_fifo(fills)
+    rows: list[TradeMetrics] = []
+    for t in trades:
+        try:
+            tag = await resolve_setup_tag(db, t)
+        except Exception:
+            tag = TagInfo("untagged", "untagged", "symbol_window")
+        try:
+            stop = await planned_stop_for(db, t)
+        except Exception:
+            stop = None
+        try:
+            mae, mfe, _degraded = await compute_excursions(t)
+        except Exception:
+            mae, mfe = None, None
+        rows.append(
+            TradeMetrics(t, tag, compute_r_multiple(t, stop), mae, mfe)
+        )
+
+    groups = aggregate_by_tag(rows)
+    if setup_tag:
+        groups = [g for g in groups if g["tag"] == setup_tag]
+    groups = [g for g in groups if g["n"] >= min_sample]
+    result = {
+        "groups": groups,
+        "overall": _agg_one("__overall__", rows) if rows else None,
+        "as_of": (now or datetime.now(timezone.utc)).isoformat(),
+        "count": len(rows),
+    }
+    if use_cache:
+        _scoreboard_cache[key] = (stamp, result)
+    return result

--- a/docs/superpowers/plans/2026-07-05-rob-713-trade-journal-aggregates.md
+++ b/docs/superpowers/plans/2026-07-05-rob-713-trade-journal-aggregates.md
@@ -1,0 +1,1238 @@
+# ROB-713 Trade Journal Aggregates Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Compute setup-tagged trading-journal aggregates (win-rate, expectancy, profit factor, R-multiple, MAE/MFE) from live-order-ledger fills, and expose them via a read-only MCP tool plus the ROB-711 `decision_history` injection.
+
+**Architecture:** New deterministic read module `app/services/trade_journal/aggregates.py` reconstructs closed round-trips FIFO from the three live order ledgers, resolves a setup tag per trade (`strategy_key` → `intent` → `untagged`), computes per-trade R-multiple (from the linked item's planned stop) and MAE/MFE (from daily OHLCV over the hold window), and folds them into per-tag `SetupAggregate` rows. Exposed as MCP `get_trading_scoreboard` (registered unconditionally) and as a `realized_r_by_tag` field on `build_decision_context`. On-demand compute + in-process TTL cache; no schema change.
+
+**Tech Stack:** Python 3.13, SQLAlchemy async, FastMCP tool registration, pytest (async). Reuses `app/services/market_data.get_ohlcv`, `app/services/trade_journal/forecast_service._normalize_symbol_for_filter`, `app/core/symbol.to_db_symbol`.
+
+## Global Constraints
+
+- **migration 0** — no new tables/columns. Aggregates are computed on read + cached in-process.
+- **ROB-501** — no in-process LLM imports anywhere under `app/**`; all code deterministic. (Existing static guard scans `app/**`.)
+- **read-path only** — never touches the order hot path; no broker calls.
+- **Sample honesty** — any tag with `n < 10` carries `insufficient_sample = True`; consumers must not over-read small samples.
+- **Fill source = the 3 live ledgers** (`KISLiveOrderLedger`, `LiveOrderLedger`, `TossLiveOrderLedger`) — NOT `review.trades` (which lacks provenance ids needed for tagging).
+- **Setup-tag precedence** — `strategy_key` (from `trade_retrospectives`) first, `intent` (from `investment_report_items`) fallback, else `untagged`. Exact provenance join is ~0% populated today (per `decision_history.py:8-12`), so symbol+recency-window join is the workhorse; label `link_quality ∈ {exact, symbol_window}`.
+- **Long-only** — pair buy→sell; shorts/options out of scope.
+- **Design doc:** `docs/superpowers/specs/2026-07-05-rob-713-trade-journal-aggregates-design.md`.
+
+---
+
+### Task 1: FIFO round-trip reconstruction (pure)
+
+**Files:**
+- Create: `app/services/trade_journal/aggregates.py`
+- Test: `tests/services/test_trade_journal_aggregates.py`
+
+**Interfaces:**
+- Produces:
+  - `@dataclass(frozen=True) class Fill` with fields: `market: str`, `symbol: str`, `account: str`, `side: str`, `qty: float`, `price: float`, `fee: float`, `ts: datetime`, `item_uuid: str | None`, `correlation_id: str | None`, `source: str`.
+  - `@dataclass(frozen=True) class ClosedTrade` with fields: `market: str`, `symbol: str`, `account: str`, `qty: float`, `entry_price: float`, `exit_price: float`, `entry_ts: datetime`, `exit_ts: datetime`, `pnl_abs: float`, `pnl_pct: float`, `fees: float`, `entry_item_uuids: tuple[str, ...]`, `exit_item_uuid: str | None`, `entry_correlation_ids: tuple[str, ...]`, `exit_correlation_id: str | None`.
+  - `def pair_fills_fifo(fills: list[Fill]) -> list[ClosedTrade]` — groups by `(market, account, symbol)`, FIFO-matches buys against later sells; each sell fill yields one `ClosedTrade` aggregating the buy lots it consumed. Unmatched sell qty (oversell / no prior buy) is dropped. Open residual buys produce no trade.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/services/test_trade_journal_aggregates.py
+from datetime import datetime, timezone
+
+import pytest
+
+from app.services.trade_journal.aggregates import Fill, pair_fills_fifo
+
+
+def _fill(side, qty, price, day, *, fee=0.0, item="i", corr="c"):
+    return Fill(
+        market="kr", symbol="005930", account="acct", side=side, qty=qty,
+        price=price, fee=fee, ts=datetime(2026, 6, day, tzinfo=timezone.utc),
+        item_uuid=item, correlation_id=corr, source="kis",
+    )
+
+
+def test_single_round_trip():
+    trades = pair_fills_fifo([_fill("buy", 10, 100.0, 1), _fill("sell", 10, 110.0, 3)])
+    assert len(trades) == 1
+    t = trades[0]
+    assert t.qty == 10
+    assert t.entry_price == 100.0
+    assert t.exit_price == 110.0
+    assert t.pnl_pct == pytest.approx(0.10)
+    assert t.pnl_abs == pytest.approx(100.0)
+    assert t.entry_ts.day == 1 and t.exit_ts.day == 3
+
+
+def test_two_buys_one_sell_weighted_entry():
+    trades = pair_fills_fifo([
+        _fill("buy", 10, 100.0, 1),
+        _fill("buy", 10, 120.0, 2),
+        _fill("sell", 20, 130.0, 3),
+    ])
+    assert len(trades) == 1
+    assert trades[0].entry_price == pytest.approx(110.0)  # qty-weighted
+    assert trades[0].qty == 20
+
+
+def test_partial_close_leaves_open_residual():
+    trades = pair_fills_fifo([_fill("buy", 10, 100.0, 1), _fill("sell", 4, 130.0, 3)])
+    assert len(trades) == 1
+    assert trades[0].qty == 4  # only closed portion counts
+
+
+def test_oversell_without_prior_buy_is_dropped():
+    assert pair_fills_fifo([_fill("sell", 5, 100.0, 1)]) == []
+
+
+def test_fees_reduce_pnl_abs():
+    trades = pair_fills_fifo([
+        _fill("buy", 10, 100.0, 1, fee=5.0),
+        _fill("sell", 10, 110.0, 3, fee=5.0),
+    ])
+    assert trades[0].fees == pytest.approx(10.0)
+    assert trades[0].pnl_abs == pytest.approx(90.0)  # 100 gross - 10 fees
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/services/test_trade_journal_aggregates.py -v`
+Expected: FAIL — `ImportError: cannot import name 'Fill'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# app/services/trade_journal/aggregates.py
+"""ROB-713 — deterministic trade-journal aggregates (expectancy / R-multiple /
+MAE) over live-ledger fills. Read-only, no LLM (ROB-501), no schema change."""
+
+from __future__ import annotations
+
+from collections import defaultdict, deque
+from dataclasses import dataclass
+from datetime import datetime
+
+_EPS = 1e-9
+
+
+@dataclass(frozen=True)
+class Fill:
+    market: str
+    symbol: str
+    account: str
+    side: str
+    qty: float
+    price: float
+    fee: float
+    ts: datetime
+    item_uuid: str | None
+    correlation_id: str | None
+    source: str
+
+
+@dataclass(frozen=True)
+class ClosedTrade:
+    market: str
+    symbol: str
+    account: str
+    qty: float
+    entry_price: float
+    exit_price: float
+    entry_ts: datetime
+    exit_ts: datetime
+    pnl_abs: float
+    pnl_pct: float
+    fees: float
+    entry_item_uuids: tuple[str, ...]
+    exit_item_uuid: str | None
+    entry_correlation_ids: tuple[str, ...]
+    exit_correlation_id: str | None
+
+
+@dataclass
+class _Lot:
+    qty: float
+    orig_qty: float
+    price: float
+    fee: float
+    ts: datetime
+    item_uuid: str | None
+    correlation_id: str | None
+
+
+def pair_fills_fifo(fills: list[Fill]) -> list[ClosedTrade]:
+    groups: dict[tuple[str, str, str], list[Fill]] = defaultdict(list)
+    for f in fills:
+        groups[(f.market, f.account, f.symbol)].append(f)
+
+    closed: list[ClosedTrade] = []
+    for (market, account, symbol), group in groups.items():
+        group_sorted = sorted(group, key=lambda f: f.ts)
+        open_lots: deque[_Lot] = deque()
+        for f in group_sorted:
+            if f.side == "buy":
+                open_lots.append(
+                    _Lot(f.qty, f.qty, f.price, f.fee, f.ts, f.item_uuid, f.correlation_id)
+                )
+                continue
+            if f.side != "sell":
+                continue
+            remaining = f.qty
+            consumed: list[tuple[float, _Lot]] = []
+            while remaining > _EPS and open_lots:
+                lot = open_lots[0]
+                take = min(remaining, lot.qty)
+                consumed.append((take, lot))
+                lot.qty -= take
+                remaining -= take
+                if lot.qty <= _EPS:
+                    open_lots.popleft()
+            if not consumed:
+                continue  # oversell / no matching entry (long-only)
+            matched_qty = sum(t for t, _ in consumed)
+            entry_price = sum(t * lot.price for t, lot in consumed) / matched_qty
+            entry_ts = min(lot.ts for _, lot in consumed)
+            entry_fee = sum(lot.fee * (t / lot.orig_qty) for t, lot in consumed)
+            exit_fee = f.fee * (matched_qty / f.qty) if f.qty else 0.0
+            fees = entry_fee + exit_fee
+            gross = (f.price - entry_price) * matched_qty
+            closed.append(
+                ClosedTrade(
+                    market=market,
+                    symbol=symbol,
+                    account=account,
+                    qty=matched_qty,
+                    entry_price=entry_price,
+                    exit_price=f.price,
+                    entry_ts=entry_ts,
+                    exit_ts=f.ts,
+                    pnl_abs=gross - fees,
+                    pnl_pct=(f.price - entry_price) / entry_price if entry_price else 0.0,
+                    fees=fees,
+                    entry_item_uuids=tuple(
+                        dict.fromkeys(lot.item_uuid for _, lot in consumed if lot.item_uuid)
+                    ),
+                    exit_item_uuid=f.item_uuid,
+                    entry_correlation_ids=tuple(
+                        dict.fromkeys(
+                            lot.correlation_id for _, lot in consumed if lot.correlation_id
+                        )
+                    ),
+                    exit_correlation_id=f.correlation_id,
+                )
+            )
+    return closed
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/services/test_trade_journal_aggregates.py -v`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/trade_journal/aggregates.py tests/services/test_trade_journal_aggregates.py
+git commit -m "feat(ROB-713): FIFO round-trip reconstruction for trade journal aggregates"
+```
+
+---
+
+### Task 2: Load fills from the three live ledgers
+
+**Files:**
+- Modify: `app/services/trade_journal/aggregates.py`
+- Test: `tests/services/test_trade_journal_aggregates_load.py`
+
+**Interfaces:**
+- Consumes: `Fill` (Task 1).
+- Produces: `async def load_fills(db: AsyncSession, *, market: str | None = None, account_mode: str | None = None, date_from: date | None = None, date_to: date | None = None) -> list[Fill]` — reads filled rows (`filled_qty > 0`) from `KISLiveOrderLedger`, `LiveOrderLedger`, `TossLiveOrderLedger`, normalizes symbol via `app.core.symbol.to_db_symbol`, maps each ledger to a market token in `{"kr","us","crypto"}`, drops smoke rows, returns `list[Fill]`.
+
+**Ledger field map (verified `app/models/review.py`):**
+- All three: `symbol`, `side`, `filled_qty`, `avg_fill_price`, `report_item_uuid`, `correlation_id`, `trade_date`.
+- Fees: `KISLiveOrderLedger.fee`; `LiveOrderLedger` — sum available fee columns if present else 0; `TossLiveOrderLedger.commission` + `.tax`.
+- Market token: `KISLiveOrderLedger` → `"kr"`; `TossLiveOrderLedger` → `"us"` if `.market == "us"` else `"kr"`; `LiveOrderLedger` → `"crypto"` if `.market == "crypto"` else `"us"`.
+- Account label: use `.account_scope`/`.broker` where present, else the source name — only used to segregate FIFO lots, not surfaced.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/services/test_trade_journal_aggregates_load.py
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+
+from app.models.review import KISLiveOrderLedger
+from app.services.trade_journal.aggregates import load_fills
+
+
+@pytest.mark.asyncio
+async def test_load_fills_reads_kis_filled_rows(db_session):
+    db_session.add(
+        KISLiveOrderLedger(
+            symbol="005930", side="buy", quantity=10, price=100,
+            filled_qty=10, avg_fill_price=100, status="filled",
+            trade_date=datetime(2026, 6, 1, tzinfo=timezone.utc),
+            correlation_id="corr-1", report_item_uuid=uuid.uuid4(),
+        )
+    )
+    await db_session.commit()
+
+    fills = await load_fills(db_session, market="kr")
+    assert len(fills) == 1
+    assert fills[0].symbol == "005930"
+    assert fills[0].side == "buy"
+    assert fills[0].filled_qty == fills[0].qty == 10
+    assert fills[0].market == "kr"
+
+
+@pytest.mark.asyncio
+async def test_load_fills_skips_unfilled_and_smoke(db_session):
+    db_session.add(
+        KISLiveOrderLedger(
+            symbol="005930", side="buy", quantity=10, price=100,
+            filled_qty=0, status="accepted",
+            trade_date=datetime(2026, 6, 1, tzinfo=timezone.utc),
+        )
+    )
+    await db_session.commit()
+    assert await load_fills(db_session, market="kr") == []
+```
+
+> **Note:** `db_session` is the project's async DB fixture (`conftest.py`, test DB enforced). Confirm the exact fixture name used by neighboring service tests in `tests/services/` and match it; do not hand-roll a session.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/services/test_trade_journal_aggregates_load.py -v`
+Expected: FAIL — `ImportError: cannot import name 'load_fills'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add to `aggregates.py`:
+
+```python
+from datetime import date
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.symbol import to_db_symbol
+from app.models.review import (
+    KISLiveOrderLedger,
+    LiveOrderLedger,
+    TossLiveOrderLedger,
+)
+
+_SMOKE_TOKENS = ("smoke",)
+
+
+def _is_smoke(*values: str | None) -> bool:
+    return any(v and any(tok in v.lower() for tok in _SMOKE_TOKENS) for v in values)
+
+
+def _fee_of(row: object) -> float:
+    total = 0.0
+    for attr in ("fee", "commission", "tax"):
+        val = getattr(row, attr, None)
+        if val is not None:
+            total += float(val)
+    return total
+
+
+def _market_for(source: str, row: object) -> str:
+    if source == "kis":
+        return "kr"
+    raw = (getattr(row, "market", None) or "").lower()
+    if source == "toss":
+        return "us" if raw == "us" else "kr"
+    return "crypto" if raw == "crypto" else "us"  # live ledger
+
+
+def _account_of(source: str, row: object) -> str:
+    return (
+        getattr(row, "account_scope", None)
+        or getattr(row, "broker", None)
+        or source
+    )
+
+
+async def load_fills(
+    db: AsyncSession,
+    *,
+    market: str | None = None,
+    account_mode: str | None = None,
+    date_from: date | None = None,
+    date_to: date | None = None,
+) -> list[Fill]:
+    fills: list[Fill] = []
+    for source, model in (
+        ("kis", KISLiveOrderLedger),
+        ("live", LiveOrderLedger),
+        ("toss", TossLiveOrderLedger),
+    ):
+        stmt = select(model).where(model.filled_qty.isnot(None), model.filled_qty > 0)
+        rows = (await db.execute(stmt)).scalars().all()
+        for r in rows:
+            row_market = _market_for(source, r)
+            if market and row_market != market:
+                continue
+            if r.trade_date is not None:
+                d = r.trade_date.date()
+                if date_from and d < date_from:
+                    continue
+                if date_to and d > date_to:
+                    continue
+            if _is_smoke(getattr(r, "correlation_id", None), getattr(r, "status", None)):
+                continue
+            corr = getattr(r, "correlation_id", None)
+            item_uuid = getattr(r, "report_item_uuid", None)
+            fills.append(
+                Fill(
+                    market=row_market,
+                    symbol=to_db_symbol(r.symbol),
+                    account=_account_of(source, r),
+                    side=r.side,
+                    qty=float(r.filled_qty),
+                    price=float(r.avg_fill_price) if r.avg_fill_price is not None else 0.0,
+                    fee=_fee_of(r),
+                    ts=r.trade_date,
+                    item_uuid=str(item_uuid) if item_uuid else None,
+                    correlation_id=corr,
+                    source=source,
+                )
+            )
+    return [f for f in fills if f.price > 0 and f.ts is not None]
+```
+
+> If `account_mode` filtering is meaningful for these live ledgers, wire it against the ledger's account/broker column; otherwise leave the param accepted-but-unused for API symmetry and note it in the docstring. Do not invent a column.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/services/test_trade_journal_aggregates_load.py -v`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/trade_journal/aggregates.py tests/services/test_trade_journal_aggregates_load.py
+git commit -m "feat(ROB-713): load fills from the three live order ledgers"
+```
+
+---
+
+### Task 3: Setup-tag resolution (strategy_key → intent → untagged)
+
+**Files:**
+- Modify: `app/services/trade_journal/aggregates.py`
+- Test: `tests/services/test_trade_journal_aggregates_tag.py`
+
+**Interfaces:**
+- Consumes: `ClosedTrade` (Task 1).
+- Produces:
+  - `@dataclass(frozen=True) class TagInfo` with `tag: str`, `tag_source: str` (`"strategy_key"|"intent"|"untagged"`), `link_quality: str` (`"exact"|"symbol_window"`).
+  - `async def resolve_setup_tag(db: AsyncSession, trade: ClosedTrade, *, window_days: int = 45) -> TagInfo`.
+- Resolution order per trade:
+  1. `strategy_key` exact: any `entry/exit_correlation_id` → `TradeRetrospective.strategy_key` (non-null).
+  2. `strategy_key` symbol_window: latest `TradeRetrospective` with matching symbol and `created_at <= exit_ts` (within `window_days` before), non-null `strategy_key`.
+  3. `intent` exact: any `entry/exit_item_uuid` → `InvestmentReportItem.item_uuid` → `intent`.
+  4. `intent` symbol_window: latest `InvestmentReportItem` with matching symbol and `created_at <= entry_ts` (within window), taking `intent`.
+  5. `untagged` (link_quality `"symbol_window"`).
+- Symbol matching uses `_normalize_symbol_for_filter(trade.symbol, instrument_type)` where `instrument_type` maps from `trade.market` via `{"kr":"equity_kr","us":"equity_us","crypto":"crypto"}`; retro/item `symbol` compared after the same normalization (mirror `decision_history` which compares on raw `symbol ==`; prefer the normalized helper for parity with forecast_service).
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/services/test_trade_journal_aggregates_tag.py
+from datetime import datetime, timezone
+
+import pytest
+
+from app.models.review import TradeRetrospective
+from app.services.trade_journal.aggregates import ClosedTrade, resolve_setup_tag
+
+
+def _trade(**kw):
+    base = dict(
+        market="kr", symbol="005930", account="acct", qty=10,
+        entry_price=100.0, exit_price=110.0,
+        entry_ts=datetime(2026, 6, 1, tzinfo=timezone.utc),
+        exit_ts=datetime(2026, 6, 5, tzinfo=timezone.utc),
+        pnl_abs=100.0, pnl_pct=0.1, fees=0.0,
+        entry_item_uuids=(), exit_item_uuid=None,
+        entry_correlation_ids=(), exit_correlation_id=None,
+    )
+    base.update(kw)
+    return ClosedTrade(**base)
+
+
+@pytest.mark.asyncio
+async def test_strategy_key_symbol_window(db_session):
+    db_session.add(
+        TradeRetrospective(
+            symbol="005930", side="sell", strategy_key="pullback_long",
+            created_at=datetime(2026, 6, 4, tzinfo=timezone.utc),
+        )
+    )
+    await db_session.commit()
+    info = await resolve_setup_tag(db_session, _trade())
+    assert info.tag == "pullback_long"
+    assert info.tag_source == "strategy_key"
+    assert info.link_quality == "symbol_window"
+
+
+@pytest.mark.asyncio
+async def test_untagged_when_no_signal(db_session):
+    info = await resolve_setup_tag(db_session, _trade(symbol="000660"))
+    assert info.tag == "untagged"
+    assert info.tag_source == "untagged"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/services/test_trade_journal_aggregates_tag.py -v`
+Expected: FAIL — `ImportError: cannot import name 'resolve_setup_tag'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add to `aggregates.py`:
+
+```python
+from datetime import timedelta
+
+from app.models.investment_reports import InvestmentReportItem
+from app.models.review import TradeForecast, TradeRetrospective
+from app.services.trade_journal.forecast_service import _normalize_symbol_for_filter
+
+_MARKET_TO_INSTRUMENT = {"kr": "equity_kr", "us": "equity_us", "crypto": "crypto"}
+
+
+@dataclass(frozen=True)
+class TagInfo:
+    tag: str
+    tag_source: str
+    link_quality: str
+
+
+async def resolve_setup_tag(
+    db: AsyncSession, trade: ClosedTrade, *, window_days: int = 45
+) -> TagInfo:
+    instrument = _MARKET_TO_INSTRUMENT.get(trade.market)
+    norm = _normalize_symbol_for_filter(trade.symbol, instrument)
+    window_start = trade.entry_ts - timedelta(days=window_days)
+
+    corr_ids = [c for c in (*trade.entry_correlation_ids, trade.exit_correlation_id) if c]
+    if corr_ids:
+        row = (
+            await db.execute(
+                select(TradeRetrospective.strategy_key)
+                .where(
+                    TradeRetrospective.correlation_id.in_(corr_ids),
+                    TradeRetrospective.strategy_key.isnot(None),
+                )
+                .order_by(TradeRetrospective.created_at.desc())
+                .limit(1)
+            )
+        ).scalar_one_or_none()
+        if row and not _is_smoke(row):
+            return TagInfo(row, "strategy_key", "exact")
+
+    retro_key = (
+        await db.execute(
+            select(TradeRetrospective.strategy_key)
+            .where(
+                TradeRetrospective.symbol == norm,
+                TradeRetrospective.strategy_key.isnot(None),
+                TradeRetrospective.created_at <= trade.exit_ts,
+                TradeRetrospective.created_at >= window_start,
+            )
+            .order_by(TradeRetrospective.created_at.desc())
+            .limit(1)
+        )
+    ).scalar_one_or_none()
+    if retro_key and not _is_smoke(retro_key):
+        return TagInfo(retro_key, "strategy_key", "symbol_window")
+
+    item_uuids = [u for u in (*trade.entry_item_uuids, trade.exit_item_uuid) if u]
+    if item_uuids:
+        intent = (
+            await db.execute(
+                select(InvestmentReportItem.intent)
+                .where(InvestmentReportItem.item_uuid.in_(item_uuids))
+                .order_by(InvestmentReportItem.created_at.desc())
+                .limit(1)
+            )
+        ).scalar_one_or_none()
+        if intent:
+            return TagInfo(intent, "intent", "exact")
+
+    intent_win = (
+        await db.execute(
+            select(InvestmentReportItem.intent)
+            .where(
+                InvestmentReportItem.symbol == norm,
+                InvestmentReportItem.created_at <= trade.entry_ts,
+                InvestmentReportItem.created_at >= window_start,
+            )
+            .order_by(InvestmentReportItem.created_at.desc())
+            .limit(1)
+        )
+    ).scalar_one_or_none()
+    if intent_win:
+        return TagInfo(intent_win, "intent", "symbol_window")
+
+    return TagInfo("untagged", "untagged", "symbol_window")
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/services/test_trade_journal_aggregates_tag.py -v`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/trade_journal/aggregates.py tests/services/test_trade_journal_aggregates_tag.py
+git commit -m "feat(ROB-713): setup-tag resolution (strategy_key -> intent -> untagged)"
+```
+
+---
+
+### Task 4: Per-trade metrics — R-multiple + MAE/MFE
+
+**Files:**
+- Modify: `app/services/trade_journal/aggregates.py`
+- Test: `tests/services/test_trade_journal_aggregates_metrics.py`
+
+**Interfaces:**
+- Consumes: `ClosedTrade` (Task 1), `get_ohlcv` (`app/services/market_data`).
+- Produces:
+  - `def compute_r_multiple(trade: ClosedTrade, planned_stop: float | None) -> float | None` — `None` when `planned_stop` is missing or `entry_price == planned_stop`; else `(exit_price - entry_price) / abs(entry_price - planned_stop)`.
+  - `async def planned_stop_for(db: AsyncSession, trade: ClosedTrade, *, window_days: int = 45) -> float | None` — reads the linked item's `evidence_snapshot["trade_setup"]["stop"]` (exact via item_uuid → symbol_window fallback); returns `float` or `None`.
+  - `async def compute_excursions(trade: ClosedTrade) -> tuple[float | None, float | None, bool]` — returns `(mae, mfe, degraded)`. `mae = (min(low) - entry)/entry`, `mfe = (max(high) - entry)/entry` over daily candles whose date ∈ `[entry_ts.date, exit_ts.date]`. `degraded=True` when the span exceeds 200 trading days (count cap). `(None, None, degraded)` when no candles.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/services/test_trade_journal_aggregates_metrics.py
+from dataclasses import dataclass
+from datetime import datetime, timezone
+
+import pytest
+
+from app.services.trade_journal import aggregates as agg
+from app.services.trade_journal.aggregates import ClosedTrade, compute_r_multiple
+
+
+def _trade(**kw):
+    base = dict(
+        market="kr", symbol="005930", account="acct", qty=10,
+        entry_price=100.0, exit_price=112.0,
+        entry_ts=datetime(2026, 6, 1, tzinfo=timezone.utc),
+        exit_ts=datetime(2026, 6, 5, tzinfo=timezone.utc),
+        pnl_abs=120.0, pnl_pct=0.12, fees=0.0,
+        entry_item_uuids=(), exit_item_uuid=None,
+        entry_correlation_ids=(), exit_correlation_id=None,
+    )
+    base.update(kw)
+    return ClosedTrade(**base)
+
+
+def test_r_multiple_with_stop():
+    # entry 100, stop 96 -> risk 4; exit 112 -> reward 12 -> R = 3.0
+    assert compute_r_multiple(_trade(), 96.0) == pytest.approx(3.0)
+
+
+def test_r_multiple_none_without_stop():
+    assert compute_r_multiple(_trade(), None) is None
+
+
+@pytest.mark.asyncio
+async def test_excursions_from_stubbed_ohlcv(monkeypatch):
+    @dataclass
+    class C:
+        timestamp: datetime
+        high: float
+        low: float
+
+    async def fake_get_ohlcv(symbol, market, period, count, end=None):
+        return [
+            C(datetime(2026, 6, 1, tzinfo=timezone.utc), 101, 95),   # low 95
+            C(datetime(2026, 6, 3, tzinfo=timezone.utc), 118, 99),   # high 118
+            C(datetime(2026, 6, 5, tzinfo=timezone.utc), 113, 108),
+        ]
+
+    monkeypatch.setattr(agg, "get_ohlcv", fake_get_ohlcv)
+    mae, mfe, degraded = await agg.compute_excursions(_trade())
+    assert mae == pytest.approx((95 - 100) / 100)   # -0.05
+    assert mfe == pytest.approx((118 - 100) / 100)   # +0.18
+    assert degraded is False
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/services/test_trade_journal_aggregates_metrics.py -v`
+Expected: FAIL — `ImportError: cannot import name 'compute_r_multiple'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add to `aggregates.py`:
+
+```python
+from app.services.market_data import get_ohlcv
+
+_MAX_OHLCV_BARS = 200
+
+
+def compute_r_multiple(trade: ClosedTrade, planned_stop: float | None) -> float | None:
+    if planned_stop is None:
+        return None
+    risk = abs(trade.entry_price - planned_stop)
+    if risk <= _EPS:
+        return None
+    return (trade.exit_price - trade.entry_price) / risk
+
+
+async def planned_stop_for(
+    db: AsyncSession, trade: ClosedTrade, *, window_days: int = 45
+) -> float | None:
+    instrument = _MARKET_TO_INSTRUMENT.get(trade.market)
+    norm = _normalize_symbol_for_filter(trade.symbol, instrument)
+    window_start = trade.entry_ts - timedelta(days=window_days)
+
+    item_uuids = [u for u in (*trade.entry_item_uuids, trade.exit_item_uuid) if u]
+    stmt = (
+        select(InvestmentReportItem.evidence_snapshot)
+        .where(InvestmentReportItem.item_uuid.in_(item_uuids))
+        .order_by(InvestmentReportItem.created_at.desc())
+        .limit(1)
+        if item_uuids
+        else select(InvestmentReportItem.evidence_snapshot)
+        .where(
+            InvestmentReportItem.symbol == norm,
+            InvestmentReportItem.created_at <= trade.entry_ts,
+            InvestmentReportItem.created_at >= window_start,
+        )
+        .order_by(InvestmentReportItem.created_at.desc())
+        .limit(1)
+    )
+    snapshot = (await db.execute(stmt)).scalar_one_or_none()
+    if not isinstance(snapshot, dict):
+        return None
+    stop = (snapshot.get("trade_setup") or {}).get("stop")
+    try:
+        return float(stop) if stop is not None else None
+    except (TypeError, ValueError):
+        return None
+
+
+async def compute_excursions(
+    trade: ClosedTrade,
+) -> tuple[float | None, float | None, bool]:
+    span_days = (trade.exit_ts.date() - trade.entry_ts.date()).days + 1
+    degraded = span_days > _MAX_OHLCV_BARS
+    count = min(max(span_days + 2, 2), _MAX_OHLCV_BARS)
+    candles = await get_ohlcv(
+        trade.symbol, trade.market, period="day", count=count, end=trade.exit_ts
+    )
+    window = [
+        c
+        for c in candles
+        if trade.entry_ts.date() <= c.timestamp.date() <= trade.exit_ts.date()
+    ]
+    if not window:
+        return None, None, degraded
+    entry = trade.entry_price
+    if entry <= _EPS:
+        return None, None, degraded
+    mae = (min(float(c.low) for c in window) - entry) / entry
+    mfe = (max(float(c.high) for c in window) - entry) / entry
+    return mae, mfe, degraded
+```
+
+> `get_ohlcv` is imported at module scope so tests can `monkeypatch.setattr(aggregates, "get_ohlcv", ...)`. Confirm `market="kr"|"us"|"crypto"` is accepted by `get_ohlcv._normalize_market`; if it expects `equity_us` etc., map via `_MARKET_TO_INSTRUMENT` before the call.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/services/test_trade_journal_aggregates_metrics.py -v`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/trade_journal/aggregates.py tests/services/test_trade_journal_aggregates_metrics.py
+git commit -m "feat(ROB-713): per-trade R-multiple + MAE/MFE metrics"
+```
+
+---
+
+### Task 5: Per-tag aggregate + scoreboard orchestrator + cache
+
+**Files:**
+- Modify: `app/services/trade_journal/aggregates.py`
+- Test: `tests/services/test_trade_journal_aggregates_scoreboard.py`
+
+**Interfaces:**
+- Consumes: everything from Tasks 1–4.
+- Produces:
+  - `@dataclass class TradeMetrics` bundling a `ClosedTrade` with `tag: TagInfo`, `r_multiple: float | None`, `mae: float | None`, `mfe: float | None`.
+  - `def aggregate_by_tag(rows: list[TradeMetrics]) -> list[dict]` — pure; one dict per tag with keys: `tag, tag_source, link_quality, n, wins, losses, win_rate, expectancy_pct, expectancy_r, profit_factor, avg_r, median_r, r_coverage, avg_mae, avg_mfe, worst_mae, insufficient_sample`. Sorted by `n` desc.
+  - `async def build_trading_scoreboard(db, *, market=None, account_mode=None, date_from=None, date_to=None, setup_tag=None, min_sample=1, use_cache=True) -> dict` — orchestrates load→pair→resolve→metrics→aggregate; returns `{"groups": [...], "overall": {...}, "as_of": iso, "count": n_trades}`. `overall` is `aggregate_by_tag` over all rows relabeled `tag="__overall__"`. Filters groups by `setup_tag` and `n >= min_sample` (overall always computed on the full set). In-process TTL cache keyed by the filter tuple.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/services/test_trade_journal_aggregates_scoreboard.py
+from datetime import datetime, timezone
+
+import pytest
+
+from app.services.trade_journal.aggregates import (
+    ClosedTrade, TagInfo, TradeMetrics, aggregate_by_tag,
+)
+
+
+def _tm(pnl_pct, r, tag="pullback_long"):
+    ct = ClosedTrade(
+        market="kr", symbol="005930", account="a", qty=10,
+        entry_price=100.0, exit_price=100.0 * (1 + pnl_pct),
+        entry_ts=datetime(2026, 6, 1, tzinfo=timezone.utc),
+        exit_ts=datetime(2026, 6, 2, tzinfo=timezone.utc),
+        pnl_abs=1000.0 * pnl_pct, pnl_pct=pnl_pct, fees=0.0,
+        entry_item_uuids=(), exit_item_uuid=None,
+        entry_correlation_ids=(), exit_correlation_id=None,
+    )
+    return TradeMetrics(
+        trade=ct, tag=TagInfo(tag, "strategy_key", "symbol_window"),
+        r_multiple=r, mae=-0.03, mfe=0.08,
+    )
+
+
+def test_aggregate_math():
+    rows = [_tm(0.10, 2.0), _tm(-0.05, -1.0), _tm(0.20, 3.0)]
+    [g] = aggregate_by_tag(rows)
+    assert g["tag"] == "pullback_long"
+    assert g["n"] == 3
+    assert g["wins"] == 2 and g["losses"] == 1
+    assert g["win_rate"] == pytest.approx(2 / 3)
+    assert g["expectancy_pct"] == pytest.approx((0.10 - 0.05 + 0.20) / 3)
+    assert g["expectancy_r"] == pytest.approx((2.0 - 1.0 + 3.0) / 3)
+    # profit factor = gross wins / |gross losses| = (100+200)/50
+    assert g["profit_factor"] == pytest.approx(300 / 50)
+    assert g["insufficient_sample"] is True  # n < 10
+
+
+def test_insufficient_sample_flag_clears_at_10():
+    rows = [_tm(0.01, 1.0) for _ in range(10)]
+    [g] = aggregate_by_tag(rows)
+    assert g["n"] == 10
+    assert g["insufficient_sample"] is False
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/services/test_trade_journal_aggregates_scoreboard.py -v`
+Expected: FAIL — `ImportError: cannot import name 'TradeMetrics'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add to `aggregates.py`:
+
+```python
+from statistics import fmean, median
+from datetime import datetime, timezone
+
+_INSUFFICIENT_SAMPLE_N = 10
+_SCOREBOARD_TTL_SECONDS = 300
+_scoreboard_cache: dict[tuple, tuple[float, dict]] = {}
+
+
+@dataclass
+class TradeMetrics:
+    trade: ClosedTrade
+    tag: TagInfo
+    r_multiple: float | None
+    mae: float | None
+    mfe: float | None
+
+
+def _agg_one(tag: str, rows: list[TradeMetrics]) -> dict:
+    pnls = [r.trade.pnl_pct for r in rows if r.trade.pnl_pct is not None]
+    wins = [p for p in pnls if p > 0]
+    losses = [p for p in pnls if p <= 0]
+    gross_win = sum(r.trade.pnl_abs for r in rows if r.trade.pnl_abs > 0)
+    gross_loss = abs(sum(r.trade.pnl_abs for r in rows if r.trade.pnl_abs < 0))
+    rs = [r.r_multiple for r in rows if r.r_multiple is not None]
+    maes = [r.mae for r in rows if r.mae is not None]
+    mfes = [r.mfe for r in rows if r.mfe is not None]
+    n = len(rows)
+    sources = {r.tag.tag_source for r in rows}
+    quals = {r.tag.link_quality for r in rows}
+    return {
+        "tag": tag,
+        "tag_source": next(iter(sources)) if len(sources) == 1 else "mixed",
+        "link_quality": "exact" if quals == {"exact"} else "symbol_window",
+        "n": n,
+        "wins": len(wins),
+        "losses": len(losses),
+        "win_rate": (len(wins) / len(pnls)) if pnls else None,
+        "expectancy_pct": fmean(pnls) if pnls else None,
+        "expectancy_r": fmean(rs) if rs else None,
+        "profit_factor": (gross_win / gross_loss) if gross_loss > _EPS else None,
+        "avg_r": fmean(rs) if rs else None,
+        "median_r": median(rs) if rs else None,
+        "r_coverage": (len(rs) / n) if n else None,
+        "avg_mae": fmean(maes) if maes else None,
+        "avg_mfe": fmean(mfes) if mfes else None,
+        "worst_mae": min(maes) if maes else None,
+        "insufficient_sample": n < _INSUFFICIENT_SAMPLE_N,
+    }
+
+
+def aggregate_by_tag(rows: list[TradeMetrics]) -> list[dict]:
+    by_tag: dict[str, list[TradeMetrics]] = defaultdict(list)
+    for r in rows:
+        by_tag[r.tag.tag].append(r)
+    groups = [_agg_one(tag, tag_rows) for tag, tag_rows in by_tag.items()]
+    groups.sort(key=lambda g: g["n"], reverse=True)
+    return groups
+
+
+async def build_trading_scoreboard(
+    db: AsyncSession,
+    *,
+    market: str | None = None,
+    account_mode: str | None = None,
+    date_from: date | None = None,
+    date_to: date | None = None,
+    setup_tag: str | None = None,
+    min_sample: int = 1,
+    use_cache: bool = True,
+    now: datetime | None = None,
+) -> dict:
+    key = (market, account_mode, date_from, date_to, setup_tag, min_sample)
+    stamp = (now or datetime.now(timezone.utc)).timestamp()
+    if use_cache:
+        cached = _scoreboard_cache.get(key)
+        if cached and stamp - cached[0] < _SCOREBOARD_TTL_SECONDS:
+            return cached[1]
+
+    fills = await load_fills(
+        db, market=market, account_mode=account_mode,
+        date_from=date_from, date_to=date_to,
+    )
+    trades = pair_fills_fifo(fills)
+    rows: list[TradeMetrics] = []
+    for t in trades:
+        tag = await resolve_setup_tag(db, t)
+        stop = await planned_stop_for(db, t)
+        mae, mfe, _degraded = await compute_excursions(t)
+        rows.append(
+            TradeMetrics(t, tag, compute_r_multiple(t, stop), mae, mfe)
+        )
+
+    groups = aggregate_by_tag(rows)
+    if setup_tag:
+        groups = [g for g in groups if g["tag"] == setup_tag]
+    groups = [g for g in groups if g["n"] >= min_sample]
+    result = {
+        "groups": groups,
+        "overall": _agg_one("__overall__", rows) if rows else None,
+        "as_of": (now or datetime.now(timezone.utc)).isoformat(),
+        "count": len(rows),
+    }
+    if use_cache:
+        _scoreboard_cache[key] = (stamp, result)
+    return result
+```
+
+> `compute_excursions` may raise on external OHLCV errors — wrap the per-trade metric calls in a `try/except` that degrades that trade's `mae/mfe/r_multiple` to `None` (fail-open) so one bad symbol never sinks the whole scoreboard. Add a test in Task 5 covering a raising `get_ohlcv`.
+
+- [ ] **Step 4: Add the fail-open test + run**
+
+```python
+# append to test_trade_journal_aggregates_scoreboard.py
+@pytest.mark.asyncio
+async def test_scoreboard_fail_open_on_ohlcv_error(db_session, monkeypatch):
+    from app.services.trade_journal import aggregates as agg
+
+    async def boom(*a, **k):
+        raise RuntimeError("provider down")
+
+    monkeypatch.setattr(agg, "get_ohlcv", boom)
+    # no fills seeded -> empty but must not raise
+    result = await agg.build_trading_scoreboard(db_session, use_cache=False)
+    assert result["count"] == 0
+    assert result["groups"] == []
+```
+
+Run: `uv run pytest tests/services/test_trade_journal_aggregates_scoreboard.py -v`
+Expected: PASS (3 tests). If the fail-open test fails, add the `try/except` around `compute_excursions`/`planned_stop_for` in `build_trading_scoreboard`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/trade_journal/aggregates.py tests/services/test_trade_journal_aggregates_scoreboard.py
+git commit -m "feat(ROB-713): per-tag aggregate + scoreboard orchestrator with TTL cache"
+```
+
+---
+
+### Task 6: MCP tool `get_trading_scoreboard`
+
+**Files:**
+- Create: `app/mcp_server/tooling/trading_scoreboard_tools.py`
+- Create: `app/mcp_server/tooling/trading_scoreboard_registration.py`
+- Modify: `app/mcp_server/tooling/registry.py` (Always block, ~line 197)
+- Test: `tests/mcp/test_trading_scoreboard.py`
+
+**Interfaces:**
+- Consumes: `build_trading_scoreboard` (Task 5).
+- Produces:
+  - `async def get_trading_scoreboard(market=None, account_mode=None, date_from=None, date_to=None, setup_tag=None, min_sample=1) -> dict` (opens its own session like sibling read tools).
+  - `TRADING_SCOREBOARD_TOOL_NAMES: set[str] = {"get_trading_scoreboard"}` and `register_trading_scoreboard_tools(mcp)`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/mcp/test_trading_scoreboard.py
+import pytest
+
+from app.mcp_server.tooling.trading_scoreboard_tools import get_trading_scoreboard
+
+
+@pytest.mark.asyncio
+async def test_scoreboard_tool_empty_db_shape():
+    result = await get_trading_scoreboard()
+    assert set(result) >= {"groups", "overall", "as_of", "count"}
+    assert result["count"] == 0
+    assert result["groups"] == []
+```
+
+> Match how sibling tools acquire a session in `forecast_tools.py` / `trade_retrospective_tools.py` (e.g. an `async with get_session()` / `AsyncSessionLocal()` context). Use the identical pattern; the test above assumes the tool self-manages its session against the test DB.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/mcp/test_trading_scoreboard.py -v`
+Expected: FAIL — module does not exist.
+
+- [ ] **Step 3: Write the tool + registration**
+
+```python
+# app/mcp_server/tooling/trading_scoreboard_tools.py
+"""ROB-713 — read-only MCP surface for setup-tagged trade-journal aggregates."""
+
+from __future__ import annotations
+
+from datetime import date
+from typing import Any
+
+from app.services.trade_journal.aggregates import build_trading_scoreboard
+# Use the SAME session accessor as forecast_tools.py / trade_retrospective_tools.py:
+from app.db.session import AsyncSessionLocal  # adjust import to match siblings
+
+
+def _parse_date(value: str | None) -> date | None:
+    return date.fromisoformat(value) if value else None
+
+
+async def get_trading_scoreboard(
+    market: str | None = None,
+    account_mode: str | None = None,
+    date_from: str | None = None,
+    date_to: str | None = None,
+    setup_tag: str | None = None,
+    min_sample: int = 1,
+) -> dict[str, Any]:
+    async with AsyncSessionLocal() as db:
+        return await build_trading_scoreboard(
+            db,
+            market=market,
+            account_mode=account_mode,
+            date_from=_parse_date(date_from),
+            date_to=_parse_date(date_to),
+            setup_tag=setup_tag,
+            min_sample=min_sample,
+        )
+```
+
+```python
+# app/mcp_server/tooling/trading_scoreboard_registration.py
+"""ROB-713 — MCP registration for the trading scoreboard read tool."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from app.mcp_server.tooling.trading_scoreboard_tools import get_trading_scoreboard
+
+TRADING_SCOREBOARD_TOOL_NAMES: set[str] = {"get_trading_scoreboard"}
+
+
+def register_trading_scoreboard_tools(mcp: Any) -> None:
+    _ = mcp.tool(
+        name="get_trading_scoreboard",
+        description=(
+            "Setup-tagged trade-journal aggregates over closed round-trips "
+            "reconstructed from live-order-ledger fills: per setup tag "
+            "(strategy_key -> intent -> untagged) win-rate, expectancy (% and "
+            "R-multiple), profit factor, average/worst MAE and MFE. Tags with "
+            "n<10 are flagged insufficient_sample. Filters: market, "
+            "account_mode, date_from/date_to (YYYY-MM-DD), setup_tag, "
+            "min_sample. Read-only; deterministic."
+        ),
+    )(get_trading_scoreboard)
+
+
+__all__ = ["TRADING_SCOREBOARD_TOOL_NAMES", "register_trading_scoreboard_tools"]
+```
+
+Modify `registry.py` — add import near the other tooling imports and register in the **Always** block (right after `register_forecast_tools(mcp)`):
+
+```python
+from app.mcp_server.tooling.trading_scoreboard_registration import (
+    register_trading_scoreboard_tools,
+)
+# ...
+    register_forecast_tools(mcp)
+    register_trading_scoreboard_tools(mcp)  # ROB-713: read-only, no profile gate
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/mcp/test_trading_scoreboard.py -v`
+Expected: PASS. Fix the `AsyncSessionLocal` import path to match siblings if it errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/mcp_server/tooling/trading_scoreboard_tools.py \
+        app/mcp_server/tooling/trading_scoreboard_registration.py \
+        app/mcp_server/tooling/registry.py tests/mcp/test_trading_scoreboard.py
+git commit -m "feat(ROB-713): get_trading_scoreboard read-only MCP tool"
+```
+
+---
+
+### Task 7: Inject `realized_r_by_tag` into decision_history
+
+**Files:**
+- Modify: `app/services/decision_history.py`
+- Test: `tests/services/test_decision_history_realized_r.py` (or extend the existing decision_history test module)
+
+**Interfaces:**
+- Consumes: `build_trading_scoreboard` (Task 5), the existing `build_decision_context` return dict.
+- Produces: `build_decision_context(...)` return dict gains a `realized_r_by_tag: dict[str, dict]` key — a bounded map (≤3 tags relevant to this symbol) of `{tag: {n, expectancy_r, win_rate, profit_factor, avg_mae, insufficient_sample}}`. When `setup_tag` is passed, that tag is included first if present.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/services/test_decision_history_realized_r.py
+import pytest
+
+from app.services import decision_history as dh
+
+
+@pytest.mark.asyncio
+async def test_realized_r_by_tag_present_and_bounded(db_session, monkeypatch):
+    async def fake_scoreboard(db, *, market=None, **kw):
+        return {
+            "groups": [
+                {"tag": f"t{i}", "n": 12, "expectancy_r": 1.0, "win_rate": 0.6,
+                 "profit_factor": 2.0, "avg_mae": -0.03, "insufficient_sample": False}
+                for i in range(5)
+            ],
+            "overall": None, "as_of": "2026-07-05T00:00:00+00:00", "count": 60,
+        }
+
+    monkeypatch.setattr(dh, "build_trading_scoreboard", fake_scoreboard)
+    # Seed at least one prior item so build_decision_context does not return None,
+    # or call the internal builder directly; match the existing test's seeding style.
+    ctx = await dh.build_decision_context(db_session, "005930", "kr")
+    assert ctx is not None
+    assert "realized_r_by_tag" in ctx
+    assert len(ctx["realized_r_by_tag"]) <= 3
+    first = next(iter(ctx["realized_r_by_tag"].values()))
+    assert set(first) == {
+        "n", "expectancy_r", "win_rate", "profit_factor",
+        "avg_mae", "insufficient_sample",
+    }
+```
+
+> Reuse the existing decision_history test's fixture/seeding approach so `build_decision_context` returns non-`None` (it returns `None` when there is no signal). Check `tests/` for the current ROB-711 test module and mirror its setup.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/services/test_decision_history_realized_r.py -v`
+Expected: FAIL — `KeyError: 'realized_r_by_tag'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `decision_history.py`, add the import and a helper, and add the key to the `ctx` dict (the block ending at `return ctx`, ~line 104-115):
+
+```python
+from app.services.trade_journal.aggregates import build_trading_scoreboard
+
+_MAX_TAGS = 3
+_R_KEYS = ("n", "expectancy_r", "win_rate", "profit_factor", "avg_mae", "insufficient_sample")
+
+
+async def _realized_r_by_tag(
+    db: AsyncSession, market: str, setup_tag: str | None
+) -> dict[str, dict[str, Any]]:
+    board = await build_trading_scoreboard(db, market=market)
+    groups = board.get("groups", [])
+    ordered = sorted(groups, key=lambda g: (g["tag"] != setup_tag, -int(g["n"])))
+    out: dict[str, dict[str, Any]] = {}
+    for g in ordered[:_MAX_TAGS]:
+        if g["tag"] == "untagged":
+            continue
+        out[g["tag"]] = {k: g.get(k) for k in _R_KEYS}
+    return out
+```
+
+Then in `build_decision_context`, before building `ctx`:
+
+```python
+    realized_r = await _realized_r_by_tag(db, market, setup_tag)
+```
+
+and add to the `ctx` dict literal:
+
+```python
+        "realized_r_by_tag": realized_r,
+```
+
+> Keep the injection cheap: `build_trading_scoreboard` is TTL-cached, so repeated symbol calls in one batch reuse the computed board. Do not thread per-symbol filters into the scoreboard call — the tag map is portfolio-wide, sliced to the tags with the largest samples (and `setup_tag` first).
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/services/test_decision_history_realized_r.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Run the full new-file suite + lint + commit**
+
+```bash
+uv run pytest tests/services/test_trade_journal_aggregates*.py tests/mcp/test_trading_scoreboard.py tests/services/test_decision_history_realized_r.py -v
+uv run pytest tests/services/action_report/snapshot_backed/test_no_internal_llm_imports.py -v   # ROB-501 guard
+make lint
+git add app/services/decision_history.py tests/services/test_decision_history_realized_r.py
+git commit -m "feat(ROB-713): inject realized_r_by_tag into decision_history"
+```
+
+---
+
+## Final Verification
+
+- [ ] `uv run pytest tests/services/test_trade_journal_aggregates*.py tests/mcp/test_trading_scoreboard.py tests/services/test_decision_history_realized_r.py -v` — all green.
+- [ ] `uv run pytest tests/services/action_report/snapshot_backed/test_no_internal_llm_imports.py` — ROB-501 static guard green (new module imports no LLM provider).
+- [ ] `make lint` + `make typecheck` clean on the new/modified files.
+- [ ] Manual MCP smoke against the dev DB: call `get_trading_scoreboard` and confirm it returns `{groups, overall, as_of, count}` without error; if any real closed round-trips exist, confirm at least the shape (n, expectancy_pct/expectancy_r, insufficient_sample) is sane.
+- [ ] Confirm `git grep -n "realized_r_by_tag"` shows the reserved hook (decision_history docstring `:75-76`) is now implemented.
+- [ ] No new alembic migration (`git status` shows nothing under `alembic/versions/`).
+
+## Out of scope (fast-follow issues)
+
+- Extend ROB-691 `JudgmentScoreboardPanel` with `group_by=setup` + expectancy/R/MAE columns (frontend + `invest_retrospectives.py` router/schema).
+- Snapshot table + scheduled builder (would be a migration) — only if on-demand compute proves too slow at scale.
+- Shorts/options/intraday MAE.

--- a/docs/superpowers/specs/2026-07-05-rob-713-trade-journal-aggregates-design.md
+++ b/docs/superpowers/specs/2026-07-05-rob-713-trade-journal-aggregates-design.md
@@ -1,0 +1,184 @@
+# Design: ROB-713 — 저널 집계 서비스 (setup별 expectancy · R-multiple · MAE)
+
+Date: 2026-07-05
+Branch: rob-713
+Linear: ROB-713 (학습 루프 3단계). Related: ROB-711 (decision_history, merged #1428), ROB-691 (JudgmentScoreboardPanel).
+Parent design: `~/.gstack/projects/mgh3326-auto_trader/mgh3326-main-design-20260705-161950.md` §3단계.
+
+## Problem
+
+시중 트레이딩 저널(TradeZella/Edgewonk)의 표준 집계 — setup별 승률/expectancy/profit
+factor, R-multiple, MAE(진입 후 최대 역행폭) — 이 시스템 어디에도 없다. provenance·Brier
+등 원천은 시중 저널보다 깊은데 기본기가 빠진 역전된 갭. 기존 `expectancy` 코드는
+research 백테스트 인제스트 전용(`research/nautilus_scalping/`, `research.backtest_runs`) —
+실거래 경로 아님(리뷰 검증됨). 실거래 expectancy는 라이브 레저 체결에서 새로 계산해야 한다.
+
+## Decisions (2026-07-05, 확정)
+
+- **D1 — setup 태그 canonical 소스 = `strategy_key` 우선 + `intent` 폴백.** 기존 ROB-691
+  성적표의 "strategy" 차원(`trade_retrospectives.strategy_key`, 세션 저작)과 일치. 없으면
+  5값 `intent` enum 폴백, 둘 다 없으면 `untagged`. 웹/MCP 두 표면이 같은 태그 축을 공유.
+- **D2 — 범위 = 백엔드 + MCP 먼저, ROB-691 웹 패널 확장은 fast-follow.** 설계 P2(주
+  소비자는 LLM=MCP 응답 주입, 웹은 감사/보조). 성공 기준(오퍼레이터가 표를 인용)도 MCP 경로.
+- **D3 — fill 소스 = provenance 있는 3 라이브 레저**(`review.trades` 아님). 태깅에
+  `correlation_id`/`report_item_uuid`가 필요하고 decision_history `recent_fills`와 일관.
+
+## Constraints
+
+- **migration 0.** 새 테이블/컬럼 없음. 배치 아님 — 조회 시 계산 + in-process TTL 캐시.
+- **ROB-501.** `app/**` in-process LLM 금지 — 전부 결정적 집계/read 코드. (정적 가드 기존 커버)
+- **read-path 전용.** 주문 hot path 무접촉.
+- **표본 수 명시.** n<10 태그는 `insufficient_sample` 라벨(과잉 해석 방지).
+
+## Grounding (코드 사실, 2026-07-05 Explore)
+
+- `investment_report_items` (`app/models/investment_reports.py:201`): `item_uuid`(레저가
+  `report_item_uuid`로 참조), `intent`(enum: buy_review/sell_review/risk_review/
+  trend_recovery_review/rebalance_review, `:234`), `evidence_snapshot` JSONB, `symbol`,
+  `side`, `confidence`. **`correlation_id`/`strategy_key` 없음.**
+- `evidence_snapshot["trade_setup"]` (`app/services/investment_reports/ingestion.py:48`):
+  `{direction: long|short, stop, target, headline{entry,risk_pct,reward_pct,rr_ratio},
+  legs[...]}`. 절대 risk/reward 필드 없음 — R-multiple 분모는 `|entry − stop|`로 계산.
+  sell/exit은 R:R 없음. 서버 계산만(caller 공급 거부).
+- 3 라이브 레저 (`app/models/review.py`): `KISLiveOrderLedger`(`:267`),
+  `LiveOrderLedger`(`:358`, US+crypto), `TossLiveOrderLedger`(`:499`). 모두 `symbol`,
+  `side`, `filled_qty`, `avg_fill_price`, `report_item_uuid`, **`correlation_id`(ROB-714,
+  이 브랜치에서 추가)**, fees, `reconciled_at`/`trade_date`. live/toss는 realized PnL
+  컬럼(`security_pnl_krw`, `total_pnl_krw`) 있음, kis_live(KR domestic)는 없음(journal 부기).
+  단 FIFO엔 side/price/qty/ts만 필요 → 세 레저 모두 충분.
+- `trade_retrospectives` (`app/models/review.py:979`): `strategy_key`(`:1050`, free text),
+  `correlation_id`, `report_item_uuid`, `symbol`. ROB-691 성적표 `group_by=strategy`가
+  `strategy_key or "no_strategy"`로 그룹핑(`trade_retrospective_service.py:752`).
+- `review.trades` (`app/models/review.py:36`): per-fill(side/price/qty/fee/account/order_id),
+  **round-trip 테이블 아님**. provenance id 없음 → 태깅 불가라 본 설계는 미사용.
+- `get_ohlcv` (`app/services/market_data/service.py:589`):
+  `async get_ohlcv(symbol, market, period, count, end=None) -> list[Candle]`. count≤200 cap.
+  `Candle{timestamp, open, high, low, close, ...}` (`contracts.py:22`). MAE/MFE용.
+- decision_history (`app/services/decision_history.py:66`):
+  `build_decision_context(db, symbol, market, setup_tag=None)`. docstring `:75-76` —
+  **"setup_tag is reserved for realized_r_by_tag (ROB-713 stage 3); unused here."** ← 주입 지점.
+  주입 호출부: `analysis_tool_handlers.py:850` `_attach_decision_history`.
+- MCP 등록 패턴: `forecast_registration.py:64` `register_forecast_tools` (2-file: tools +
+  registration), read 집계는 `registry.py:196-197` **"Always" 블록**에 무조건 등록(DEFAULT
+  프로파일 분기 아님).
+
+## Architecture
+
+신규 모듈 `app/services/trade_journal/aggregates.py` — 4 유닛, 각 독립 테스트 가능.
+
+### Unit 1 — Fills → ClosedTrade (FIFO)
+
+3 라이브 레저에서 체결 fill 행 로드(`filled_qty > 0`). `(account/broker, normalized
+symbol)`로 그룹, 시간순 정렬, buy fill을 이후 sell fill과 FIFO 매칭 → `ClosedTrade`:
+
+```
+ClosedTrade{
+  market, symbol, account,
+  entry_price,   # 매칭된 매수 fill들의 수량가중 평균
+  exit_price,    # 매도 fill avg_fill_price
+  qty,           # 매칭(청산)된 수량
+  entry_ts, exit_ts,
+  pnl_abs, pnl_pct, fees,
+  entry_item_uuids[], exit_item_uuid, entry_correlation_ids[], exit_correlation_id,
+}
+```
+
+- 미청산 잔여(open residual) 제외. 부분 청산은 청산분만 카운트.
+- long-only(buy→exit). 숏/옵션 out of scope.
+- 심볼 정규화는 `app/core/symbol.to_db_symbol` 사용(레저 간 동일 심볼 통합).
+
+### Unit 2 — Setup-tag 해소 (per ClosedTrade)
+
+우선순위(D1):
+1. **strategy_key(exact)**: exit/entry `correlation_id` → `trade_retrospectives.strategy_key`.
+2. **strategy_key(symbol_window)**: exit_ts 기준 심볼+시간창 최신 retrospective.
+3. **intent(exact)**: exit/entry `report_item_uuid` → `investment_report_items.intent`.
+4. **intent(symbol_window)**: entry_ts 기준 심볼+시간창 최신 item.
+5. **untagged**.
+
+각 그룹에 `tag`(문자열), `tag_source ∈ {strategy_key, intent, untagged}`,
+`link_quality ∈ {exact, symbol_window}` 기록. (link_quality는 decision_history 규약 재사용.)
+
+### Unit 3 — Per-trade 메트릭
+
+- **R-multiple**: `(exit_price − entry_price) / |entry_price − planned_stop|`.
+  `planned_stop` = 링크된 item의 `evidence_snapshot.trade_setup.stop`(report_item_uuid
+  exact → symbol_window 폴백). stop 없으면 R = null(해당 거래는 win_rate/expectancy_pct엔
+  포함, R 집계에서 제외). 그룹은 `r_coverage`(R 계산된 거래 수/전체) 보고.
+- **MAE/MFE**: `get_ohlcv(symbol, market, period="day", count, end=exit_ts)`로
+  `[entry_ts, exit_ts]` 구간 일봉. `MAE = (min(low) − entry)/entry`(long 기준 가장 음수),
+  `MFE = (max(high) − entry)/entry`. count는 거래일 기준 산정, ≤200 cap. 200일 초과 홀드는
+  degrade + `mae_degraded` 라벨. 데이터 없으면 MAE/MFE null(거래는 나머지 집계 유지).
+
+### Unit 4 — Per-tag 집계 (SetupAggregate)
+
+```
+SetupAggregate{
+  tag, tag_source, link_quality,
+  n, wins, losses, win_rate,
+  expectancy_pct,        # mean(pnl_pct)
+  expectancy_r,          # mean(R), R_coverage 거래만
+  profit_factor,         # sum(win pnl_abs) / |sum(loss pnl_abs)|
+  avg_r, median_r, r_coverage,
+  avg_mae, avg_mfe, worst_mae,
+  insufficient_sample,   # n < 10
+}
+```
+
+## Exposure (이번 이슈)
+
+### MCP `get_trading_scoreboard` (read-only)
+
+- 2-file 패턴: `app/mcp_server/tooling/trading_scoreboard_tools.py` +
+  `..._registration.py`. `registry.py` **"Always" 블록**(`:196` 부근)에 무조건 등록 —
+  DEFAULT 프로파일 분기 아님(부수효과 없는 순수 read).
+- 파라미터: `market?`, `account_mode?`, `date_from?`/`date_to?`(KST), `setup_tag?`(필터),
+  `min_sample?`(기본 1). 반환: `{groups: [SetupAggregate...], overall: SetupAggregate,
+  as_of, count}`. n<10 그룹도 반환하되 `insufficient_sample=true`.
+
+### decision_history `realized_r_by_tag` 주입
+
+- 예약된 훅 구현: `build_decision_context`가 심볼 이력에 등장하는 상위 ~3개 태그에 대해
+  aggregates를 호출, `realized_r_by_tag: {tag: {n, expectancy_r, win_rate, profit_factor,
+  avg_mae, insufficient_sample}}` 맵을 반환 dict에 추가. 페이로드 상한(태그 3개)으로 컨텍스트
+  bound. `setup_tag` 인자가 주어지면 그 태그를 우선 포함.
+- 호출부(`_attach_decision_history`)는 변경 최소 — build_decision_context 내부에서 처리.
+
+## Caching
+
+in-process TTL 캐시(테이블 없음 = migration 0):
+- (a) MAE/MFE per ClosedTrade window: exit_ts 과거면 불변 → 긴 TTL(모듈 dict, key=
+  (symbol, entry_ts, exit_ts)).
+- (b) 집계 결과 per (market, filters): 짧은 TTL(~5분; reconcile로만 변함).
+n이 작아 재계산 비용 낮음. 기존 on-demand 서비스의 모듈-레벨 dict+timestamp 패턴 따름.
+
+## Out of scope → fast-follow
+
+- ROB-691 `JudgmentScoreboardPanel` `group_by=setup` + expectancy/R/MAE 컬럼(프론트 칩/
+  타입/API group_by). 별도 후속 이슈.
+- 스냅샷 테이블 + 스케줄 빌더(= migration).
+- 숏/옵션/인트라데이 MAE.
+
+## Testing
+
+- **Unit(aggregates)**: FIFO(부분체결, 다중 매수→단일 매도, open residual 제외), R
+  계산(stop 있음/없음), expectancy/profit_factor 수식, MAE/MFE(합성 OHLCV), tag 해소
+  우선순위(strategy_key→intent→untagged, exact vs symbol_window), `insufficient_sample`
+  게이팅(n<10).
+- **Fixtures**: 3 레저 fill + retrospective(strategy_key) + item(intent, trade_setup.stop)
+  + stub OHLCV 시드. 기존 `tests/.../trade_journal/` 패턴 따름.
+- **MCP**: `get_trading_scoreboard` 스모크(빈 데이터 → 빈 groups + overall n=0; 시드
+  데이터 → n≥10 태그 1개 이상에서 expectancy 표 산출).
+- **decision_history**: `realized_r_by_tag`가 태그 상한 3개로 bound되고 n<10 시
+  insufficient_sample 라벨 확인.
+- ROB-501 정적 가드 기존 커버(app/services 스캔).
+
+## Success Criteria
+
+n≥10인 태그 1개 이상에서 expectancy 표 산출 + `get_trading_scoreboard`/decision_history를
+통해 오퍼레이터 세션이 이를 인용할 수 있는 경로 완성. (부모 설계 §Success Criteria 3단계.)
+
+## Rollout / Distribution
+
+기존 파이프라인(main → production, blue/green native). 신규 배포 채널·env 게이트 없음
+(read-only, 부수효과 0). MCP 도구는 "Always" 등록이라 프로파일 플래그 불필요.

--- a/tests/services/test_decision_history_realized_r.py
+++ b/tests/services/test_decision_history_realized_r.py
@@ -1,0 +1,89 @@
+import uuid
+from datetime import UTC, datetime
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.investment_reports import InvestmentReport, InvestmentReportItem
+from app.services import decision_history as dh
+from app.services.trade_journal.forecast_service import _normalize_symbol_for_filter
+
+
+def _digit_symbol() -> str:
+    return ("9" + uuid.uuid4().hex[:9])[:10].upper()
+
+
+async def _add_report_item(db: AsyncSession, symbol: str) -> None:
+    rep = InvestmentReport(
+        report_uuid=uuid.uuid4(),
+        idempotency_key=f"rob713-r-{uuid.uuid4()}",
+        report_type="kr_morning",
+        market="kr",
+        market_session="regular",
+        account_scope="kis_mock",
+        execution_mode="mock_preview",
+        created_by_profile="test",
+        title="t",
+        summary="s",
+        status="draft",
+    )
+    db.add(rep)
+    await db.flush()
+    db.add(
+        InvestmentReportItem(
+            report_id=rep.id,
+            item_uuid=uuid.uuid4(),
+            idempotency_key=f"rob713-item-{uuid.uuid4()}",
+            item_kind="action",
+            symbol=symbol,
+            intent="buy_review",
+            rationale="seed for realized_r_by_tag",
+            evidence_snapshot={},
+            created_at=datetime(2026, 6, 1, tzinfo=UTC),
+        )
+    )
+    await db.flush()
+
+
+@pytest.mark.asyncio
+async def test_realized_r_by_tag_present_and_bounded(db_session, monkeypatch):
+    async def fake_scoreboard(db, *, market=None, **kw):
+        return {
+            "groups": [
+                {
+                    "tag": f"t{i}",
+                    "n": 12,
+                    "expectancy_r": 1.0,
+                    "win_rate": 0.6,
+                    "profit_factor": 2.0,
+                    "avg_mae": -0.03,
+                    "insufficient_sample": False,
+                }
+                for i in range(5)
+            ],
+            "overall": None,
+            "as_of": "2026-07-05T00:00:00+00:00",
+            "count": 60,
+        }
+
+    monkeypatch.setattr(dh, "build_trading_scoreboard", fake_scoreboard)
+
+    sym = _digit_symbol()
+    norm = _normalize_symbol_for_filter(sym, "equity_kr")
+    await _add_report_item(db_session, norm)
+
+    ctx = await dh.build_decision_context(db_session, symbol=sym, market="kr")
+
+    assert ctx is not None
+    assert "realized_r_by_tag" in ctx
+    assert len(ctx["realized_r_by_tag"]) <= 3
+    if ctx["realized_r_by_tag"]:
+        first = next(iter(ctx["realized_r_by_tag"].values()))
+        assert set(first) == {
+            "n",
+            "expectancy_r",
+            "win_rate",
+            "profit_factor",
+            "avg_mae",
+            "insufficient_sample",
+        }

--- a/tests/services/test_decision_history_realized_r.py
+++ b/tests/services/test_decision_history_realized_r.py
@@ -66,7 +66,13 @@ async def test_realized_r_by_tag_present_and_bounded(db_session, monkeypatch):
             "count": 60,
         }
 
-    monkeypatch.setattr(dh, "build_trading_scoreboard", fake_scoreboard)
+    # build_trading_scoreboard is imported lazily inside _realized_r_by_tag
+    # (keeps decision_history free of the broker import chain), so patch it at
+    # its source module rather than on the decision_history namespace.
+    monkeypatch.setattr(
+        "app.services.trade_journal.aggregates.build_trading_scoreboard",
+        fake_scoreboard,
+    )
 
     sym = _digit_symbol()
     norm = _normalize_symbol_for_filter(sym, "equity_kr")

--- a/tests/services/test_trade_journal_aggregates.py
+++ b/tests/services/test_trade_journal_aggregates.py
@@ -1,0 +1,55 @@
+from datetime import datetime, timezone
+
+import pytest
+
+from app.services.trade_journal.aggregates import Fill, pair_fills_fifo
+
+
+def _fill(side, qty, price, day, *, fee=0.0, item="i", corr="c"):
+    return Fill(
+        market="kr", symbol="005930", account="acct", side=side, qty=qty,
+        price=price, fee=fee, ts=datetime(2026, 6, day, tzinfo=timezone.utc),
+        item_uuid=item, correlation_id=corr, source="kis",
+    )
+
+
+def test_single_round_trip():
+    trades = pair_fills_fifo([_fill("buy", 10, 100.0, 1), _fill("sell", 10, 110.0, 3)])
+    assert len(trades) == 1
+    t = trades[0]
+    assert t.qty == 10
+    assert t.entry_price == 100.0
+    assert t.exit_price == 110.0
+    assert t.pnl_pct == pytest.approx(0.10)
+    assert t.pnl_abs == pytest.approx(100.0)
+    assert t.entry_ts.day == 1 and t.exit_ts.day == 3
+
+
+def test_two_buys_one_sell_weighted_entry():
+    trades = pair_fills_fifo([
+        _fill("buy", 10, 100.0, 1),
+        _fill("buy", 10, 120.0, 2),
+        _fill("sell", 20, 130.0, 3),
+    ])
+    assert len(trades) == 1
+    assert trades[0].entry_price == pytest.approx(110.0)  # qty-weighted
+    assert trades[0].qty == 20
+
+
+def test_partial_close_leaves_open_residual():
+    trades = pair_fills_fifo([_fill("buy", 10, 100.0, 1), _fill("sell", 4, 130.0, 3)])
+    assert len(trades) == 1
+    assert trades[0].qty == 4  # only closed portion counts
+
+
+def test_oversell_without_prior_buy_is_dropped():
+    assert pair_fills_fifo([_fill("sell", 5, 100.0, 1)]) == []
+
+
+def test_fees_reduce_pnl_abs():
+    trades = pair_fills_fifo([
+        _fill("buy", 10, 100.0, 1, fee=5.0),
+        _fill("sell", 10, 110.0, 3, fee=5.0),
+    ])
+    assert trades[0].fees == pytest.approx(10.0)
+    assert trades[0].pnl_abs == pytest.approx(90.0)  # 100 gross - 10 fees

--- a/tests/services/test_trade_journal_aggregates.py
+++ b/tests/services/test_trade_journal_aggregates.py
@@ -7,9 +7,17 @@ from app.services.trade_journal.aggregates import Fill, pair_fills_fifo
 
 def _fill(side, qty, price, day, *, fee=0.0, item="i", corr="c"):
     return Fill(
-        market="kr", symbol="005930", account="acct", side=side, qty=qty,
-        price=price, fee=fee, ts=datetime(2026, 6, day, tzinfo=UTC),
-        item_uuid=item, correlation_id=corr, source="kis",
+        market="kr",
+        symbol="005930",
+        account="acct",
+        side=side,
+        qty=qty,
+        price=price,
+        fee=fee,
+        ts=datetime(2026, 6, day, tzinfo=UTC),
+        item_uuid=item,
+        correlation_id=corr,
+        source="kis",
     )
 
 
@@ -26,11 +34,13 @@ def test_single_round_trip():
 
 
 def test_two_buys_one_sell_weighted_entry():
-    trades = pair_fills_fifo([
-        _fill("buy", 10, 100.0, 1),
-        _fill("buy", 10, 120.0, 2),
-        _fill("sell", 20, 130.0, 3),
-    ])
+    trades = pair_fills_fifo(
+        [
+            _fill("buy", 10, 100.0, 1),
+            _fill("buy", 10, 120.0, 2),
+            _fill("sell", 20, 130.0, 3),
+        ]
+    )
     assert len(trades) == 1
     assert trades[0].entry_price == pytest.approx(110.0)  # qty-weighted
     assert trades[0].qty == 20
@@ -47,9 +57,11 @@ def test_oversell_without_prior_buy_is_dropped():
 
 
 def test_fees_reduce_pnl_abs():
-    trades = pair_fills_fifo([
-        _fill("buy", 10, 100.0, 1, fee=5.0),
-        _fill("sell", 10, 110.0, 3, fee=5.0),
-    ])
+    trades = pair_fills_fifo(
+        [
+            _fill("buy", 10, 100.0, 1, fee=5.0),
+            _fill("sell", 10, 110.0, 3, fee=5.0),
+        ]
+    )
     assert trades[0].fees == pytest.approx(10.0)
     assert trades[0].pnl_abs == pytest.approx(90.0)  # 100 gross - 10 fees

--- a/tests/services/test_trade_journal_aggregates.py
+++ b/tests/services/test_trade_journal_aggregates.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 import pytest
 
@@ -8,7 +8,7 @@ from app.services.trade_journal.aggregates import Fill, pair_fills_fifo
 def _fill(side, qty, price, day, *, fee=0.0, item="i", corr="c"):
     return Fill(
         market="kr", symbol="005930", account="acct", side=side, qty=qty,
-        price=price, fee=fee, ts=datetime(2026, 6, day, tzinfo=timezone.utc),
+        price=price, fee=fee, ts=datetime(2026, 6, day, tzinfo=UTC),
         item_uuid=item, correlation_id=corr, source="kis",
     )
 

--- a/tests/services/test_trade_journal_aggregates_load.py
+++ b/tests/services/test_trade_journal_aggregates_load.py
@@ -4,18 +4,33 @@ from decimal import Decimal
 
 import pytest
 
+from app.core.symbol import to_db_symbol
 from app.models.review import KISLiveOrderLedger
 from app.services.trade_journal.aggregates import load_fills
 
 
+def _digit_symbol() -> str:
+    """Per-test unique 6-12 digit-ish symbol, xdist-safe.
+
+    The ``db_session`` fixture commits to a SHARED database with no per-test
+    rollback (see tests/services/test_decision_history.py). Real symbols like
+    005930 leak across workers — and into the real-session decision_history
+    injection exercised by test_analyze_stock_batch_quick_summary. Seed under a
+    unique symbol and with ``flush()`` (visible to this session, never
+    committed) so nothing escapes the test.
+    """
+    return ("9" + uuid.uuid4().hex[:9])[:10].upper()
+
+
 @pytest.mark.asyncio
 async def test_load_fills_reads_kis_filled_rows(db_session):
+    sym = _digit_symbol()
     corr = "rob713-load-" + uuid.uuid4().hex[:8]
     item = uuid.uuid4()
     db_session.add(
         KISLiveOrderLedger(
             trade_date=datetime(2026, 6, 1, tzinfo=UTC),
-            symbol="005930",
+            symbol=sym,
             instrument_type="equity_kr",
             side="buy",
             order_type="limit",
@@ -30,13 +45,13 @@ async def test_load_fills_reads_kis_filled_rows(db_session):
             report_item_uuid=item,
         )
     )
-    await db_session.commit()
+    await db_session.flush()
 
     fills = await load_fills(db_session, market="kr")
     ours = [f for f in fills if f.correlation_id == corr]
     assert len(ours) == 1
     f = ours[0]
-    assert f.symbol == "005930"
+    assert f.symbol == to_db_symbol(sym)
     assert f.side == "buy"
     assert f.qty == 10
     assert f.market == "kr"
@@ -50,7 +65,7 @@ async def test_load_fills_skips_unfilled_and_smoke(db_session):
     db_session.add(
         KISLiveOrderLedger(
             trade_date=datetime(2026, 6, 1, tzinfo=UTC),
-            symbol="005930",
+            symbol=_digit_symbol(),
             instrument_type="equity_kr",
             side="buy",
             order_type="limit",
@@ -63,6 +78,6 @@ async def test_load_fills_skips_unfilled_and_smoke(db_session):
             correlation_id=corr,
         )
     )
-    await db_session.commit()
+    await db_session.flush()
     fills = await load_fills(db_session, market="kr")
     assert not any(f.correlation_id == corr for f in fills)

--- a/tests/services/test_trade_journal_aggregates_load.py
+++ b/tests/services/test_trade_journal_aggregates_load.py
@@ -1,0 +1,68 @@
+import uuid
+from datetime import UTC, datetime
+from decimal import Decimal
+
+import pytest
+
+from app.models.review import KISLiveOrderLedger
+from app.services.trade_journal.aggregates import load_fills
+
+
+@pytest.mark.asyncio
+async def test_load_fills_reads_kis_filled_rows(db_session):
+    corr = "rob713-load-" + uuid.uuid4().hex[:8]
+    item = uuid.uuid4()
+    db_session.add(
+        KISLiveOrderLedger(
+            trade_date=datetime(2026, 6, 1, tzinfo=UTC),
+            symbol="005930",
+            instrument_type="equity_kr",
+            side="buy",
+            order_type="limit",
+            account_mode="kis_live",
+            broker="kis",
+            status="filled",
+            lifecycle_state="filled",
+            quantity=Decimal("10"),
+            filled_qty=Decimal("10"),
+            avg_fill_price=Decimal("100"),
+            correlation_id=corr,
+            report_item_uuid=item,
+        )
+    )
+    await db_session.commit()
+
+    fills = await load_fills(db_session, market="kr")
+    ours = [f for f in fills if f.correlation_id == corr]
+    assert len(ours) == 1
+    f = ours[0]
+    assert f.symbol == "005930"
+    assert f.side == "buy"
+    assert f.qty == 10
+    assert f.market == "kr"
+    assert f.price == 100.0
+    assert f.item_uuid == str(item)
+
+
+@pytest.mark.asyncio
+async def test_load_fills_skips_unfilled_and_smoke(db_session):
+    corr = "rob713-unfilled-" + uuid.uuid4().hex[:8]
+    db_session.add(
+        KISLiveOrderLedger(
+            trade_date=datetime(2026, 6, 1, tzinfo=UTC),
+            symbol="005930",
+            instrument_type="equity_kr",
+            side="buy",
+            order_type="limit",
+            account_mode="kis_live",
+            broker="kis",
+            status="accepted",
+            lifecycle_state="accepted",
+            quantity=Decimal("10"),
+            filled_qty=Decimal("0"),
+            correlation_id=corr,
+        )
+    )
+    await db_session.commit()
+    fills = await load_fills(db_session, market="kr")
+    assert not any(f.correlation_id == corr for f in fills)

--- a/tests/services/test_trade_journal_aggregates_metrics.py
+++ b/tests/services/test_trade_journal_aggregates_metrics.py
@@ -8,15 +8,23 @@ from app.services.trade_journal.aggregates import ClosedTrade, compute_r_multipl
 
 
 def _trade(**kw):
-    base = dict(
-        market="kr", symbol="005930", account="acct", qty=10,
-        entry_price=100.0, exit_price=112.0,
-        entry_ts=datetime(2026, 6, 1, tzinfo=UTC),
-        exit_ts=datetime(2026, 6, 5, tzinfo=UTC),
-        pnl_abs=120.0, pnl_pct=0.12, fees=0.0,
-        entry_item_uuids=(), exit_item_uuid=None,
-        entry_correlation_ids=(), exit_correlation_id=None,
-    )
+    base = {
+        "market": "kr",
+        "symbol": "005930",
+        "account": "acct",
+        "qty": 10,
+        "entry_price": 100.0,
+        "exit_price": 112.0,
+        "entry_ts": datetime(2026, 6, 1, tzinfo=UTC),
+        "exit_ts": datetime(2026, 6, 5, tzinfo=UTC),
+        "pnl_abs": 120.0,
+        "pnl_pct": 0.12,
+        "fees": 0.0,
+        "entry_item_uuids": (),
+        "exit_item_uuid": None,
+        "entry_correlation_ids": (),
+        "exit_correlation_id": None,
+    }
     base.update(kw)
     return ClosedTrade(**base)
 

--- a/tests/services/test_trade_journal_aggregates_metrics.py
+++ b/tests/services/test_trade_journal_aggregates_metrics.py
@@ -48,13 +48,13 @@ async def test_excursions_from_stubbed_ohlcv(monkeypatch):
 
     async def fake_get_ohlcv(symbol, market, period, count, end=None):
         return [
-            C(datetime(2026, 6, 1, tzinfo=UTC), 101, 95),   # low 95
-            C(datetime(2026, 6, 3, tzinfo=UTC), 118, 99),   # high 118
+            C(datetime(2026, 6, 1, tzinfo=UTC), 101, 95),  # low 95
+            C(datetime(2026, 6, 3, tzinfo=UTC), 118, 99),  # high 118
             C(datetime(2026, 6, 5, tzinfo=UTC), 113, 108),
         ]
 
     monkeypatch.setattr(agg, "get_ohlcv", fake_get_ohlcv)
     mae, mfe, degraded = await agg.compute_excursions(_trade())
-    assert mae == pytest.approx((95 - 100) / 100)   # -0.05
-    assert mfe == pytest.approx((118 - 100) / 100)   # +0.18
+    assert mae == pytest.approx((95 - 100) / 100)  # -0.05
+    assert mfe == pytest.approx((118 - 100) / 100)  # +0.18
     assert degraded is False

--- a/tests/services/test_trade_journal_aggregates_metrics.py
+++ b/tests/services/test_trade_journal_aggregates_metrics.py
@@ -1,0 +1,52 @@
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+import pytest
+
+from app.services.trade_journal import aggregates as agg
+from app.services.trade_journal.aggregates import ClosedTrade, compute_r_multiple
+
+
+def _trade(**kw):
+    base = dict(
+        market="kr", symbol="005930", account="acct", qty=10,
+        entry_price=100.0, exit_price=112.0,
+        entry_ts=datetime(2026, 6, 1, tzinfo=UTC),
+        exit_ts=datetime(2026, 6, 5, tzinfo=UTC),
+        pnl_abs=120.0, pnl_pct=0.12, fees=0.0,
+        entry_item_uuids=(), exit_item_uuid=None,
+        entry_correlation_ids=(), exit_correlation_id=None,
+    )
+    base.update(kw)
+    return ClosedTrade(**base)
+
+
+def test_r_multiple_with_stop():
+    # entry 100, stop 96 -> risk 4; exit 112 -> reward 12 -> R = 3.0
+    assert compute_r_multiple(_trade(), 96.0) == pytest.approx(3.0)
+
+
+def test_r_multiple_none_without_stop():
+    assert compute_r_multiple(_trade(), None) is None
+
+
+@pytest.mark.asyncio
+async def test_excursions_from_stubbed_ohlcv(monkeypatch):
+    @dataclass
+    class C:
+        timestamp: datetime
+        high: float
+        low: float
+
+    async def fake_get_ohlcv(symbol, market, period, count, end=None):
+        return [
+            C(datetime(2026, 6, 1, tzinfo=UTC), 101, 95),   # low 95
+            C(datetime(2026, 6, 3, tzinfo=UTC), 118, 99),   # high 118
+            C(datetime(2026, 6, 5, tzinfo=UTC), 113, 108),
+        ]
+
+    monkeypatch.setattr(agg, "get_ohlcv", fake_get_ohlcv)
+    mae, mfe, degraded = await agg.compute_excursions(_trade())
+    assert mae == pytest.approx((95 - 100) / 100)   # -0.05
+    assert mfe == pytest.approx((118 - 100) / 100)   # +0.18
+    assert degraded is False

--- a/tests/services/test_trade_journal_aggregates_scoreboard.py
+++ b/tests/services/test_trade_journal_aggregates_scoreboard.py
@@ -1,0 +1,60 @@
+from datetime import UTC, datetime
+
+import pytest
+
+from app.services.trade_journal.aggregates import (
+    ClosedTrade,
+    TagInfo,
+    TradeMetrics,
+    aggregate_by_tag,
+)
+from app.services.trade_journal import aggregates as agg
+
+
+def _tm(pnl_pct, r, tag="pullback_long", tag_source="strategy_key", link="symbol_window"):
+    ct = ClosedTrade(
+        market="kr", symbol="005930", account="a", qty=10,
+        entry_price=100.0, exit_price=100.0 * (1 + pnl_pct),
+        entry_ts=datetime(2026, 6, 1, tzinfo=UTC),
+        exit_ts=datetime(2026, 6, 2, tzinfo=UTC),
+        pnl_abs=1000.0 * pnl_pct, pnl_pct=pnl_pct, fees=0.0,
+        entry_item_uuids=(), exit_item_uuid=None,
+        entry_correlation_ids=(), exit_correlation_id=None,
+    )
+    return TradeMetrics(
+        trade=ct,
+        tag=TagInfo(tag, tag_source, link),
+        r_multiple=r, mae=-0.03, mfe=0.08,
+    )
+
+
+def test_aggregate_math():
+    rows = [_tm(0.10, 2.0), _tm(-0.05, -1.0), _tm(0.20, 3.0)]
+    [g] = aggregate_by_tag(rows)
+    assert g["tag"] == "pullback_long"
+    assert g["n"] == 3
+    assert g["wins"] == 2 and g["losses"] == 1
+    assert g["win_rate"] == pytest.approx(2 / 3)
+    assert g["expectancy_pct"] == pytest.approx((0.10 - 0.05 + 0.20) / 3)
+    assert g["expectancy_r"] == pytest.approx((2.0 - 1.0 + 3.0) / 3)
+    # profit factor = gross wins / |gross losses| = (100+200)/50
+    assert g["profit_factor"] == pytest.approx(300 / 50)
+    assert g["insufficient_sample"] is True  # n < 10
+
+
+def test_insufficient_sample_flag_clears_at_10():
+    rows = [_tm(0.01, 1.0) for _ in range(10)]
+    [g] = aggregate_by_tag(rows)
+    assert g["n"] == 10
+    assert g["insufficient_sample"] is False
+
+
+@pytest.mark.asyncio
+async def test_scoreboard_fail_open_on_ohlcv_error(db_session, monkeypatch):
+    async def boom(*a, **k):
+        raise RuntimeError("provider down")
+
+    monkeypatch.setattr(agg, "get_ohlcv", boom)
+    result = await agg.build_trading_scoreboard(db_session, use_cache=False)
+    assert result["count"] == 0
+    assert result["groups"] == []

--- a/tests/services/test_trade_journal_aggregates_scoreboard.py
+++ b/tests/services/test_trade_journal_aggregates_scoreboard.py
@@ -11,20 +11,32 @@ from app.services.trade_journal.aggregates import (
 )
 
 
-def _tm(pnl_pct, r, tag="pullback_long", tag_source="strategy_key", link="symbol_window"):
+def _tm(
+    pnl_pct, r, tag="pullback_long", tag_source="strategy_key", link="symbol_window"
+):
     ct = ClosedTrade(
-        market="kr", symbol="005930", account="a", qty=10,
-        entry_price=100.0, exit_price=100.0 * (1 + pnl_pct),
+        market="kr",
+        symbol="005930",
+        account="a",
+        qty=10,
+        entry_price=100.0,
+        exit_price=100.0 * (1 + pnl_pct),
         entry_ts=datetime(2026, 6, 1, tzinfo=UTC),
         exit_ts=datetime(2026, 6, 2, tzinfo=UTC),
-        pnl_abs=1000.0 * pnl_pct, pnl_pct=pnl_pct, fees=0.0,
-        entry_item_uuids=(), exit_item_uuid=None,
-        entry_correlation_ids=(), exit_correlation_id=None,
+        pnl_abs=1000.0 * pnl_pct,
+        pnl_pct=pnl_pct,
+        fees=0.0,
+        entry_item_uuids=(),
+        exit_item_uuid=None,
+        entry_correlation_ids=(),
+        exit_correlation_id=None,
     )
     return TradeMetrics(
         trade=ct,
         tag=TagInfo(tag, tag_source, link),
-        r_multiple=r, mae=-0.03, mfe=0.08,
+        r_multiple=r,
+        mae=-0.03,
+        mfe=0.08,
     )
 
 

--- a/tests/services/test_trade_journal_aggregates_scoreboard.py
+++ b/tests/services/test_trade_journal_aggregates_scoreboard.py
@@ -2,13 +2,13 @@ from datetime import UTC, datetime
 
 import pytest
 
+from app.services.trade_journal import aggregates as agg
 from app.services.trade_journal.aggregates import (
     ClosedTrade,
     TagInfo,
     TradeMetrics,
     aggregate_by_tag,
 )
-from app.services.trade_journal import aggregates as agg
 
 
 def _tm(pnl_pct, r, tag="pullback_long", tag_source="strategy_key", link="symbol_window"):

--- a/tests/services/test_trade_journal_aggregates_tag.py
+++ b/tests/services/test_trade_journal_aggregates_tag.py
@@ -1,0 +1,65 @@
+import uuid
+from datetime import UTC, datetime
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.review import TradeRetrospective
+from app.services.trade_journal.aggregates import ClosedTrade, resolve_setup_tag
+from app.services.trade_journal.forecast_service import _normalize_symbol_for_filter
+
+
+def _trade(**kw):
+    base = dict(
+        market="kr", symbol="005930", account="acct", qty=10,
+        entry_price=100.0, exit_price=110.0,
+        entry_ts=datetime(2026, 6, 1, tzinfo=UTC),
+        exit_ts=datetime(2026, 6, 5, tzinfo=UTC),
+        pnl_abs=100.0, pnl_pct=0.1, fees=0.0,
+        entry_item_uuids=(), exit_item_uuid=None,
+        entry_correlation_ids=(), exit_correlation_id=None,
+    )
+    base.update(kw)
+    return ClosedTrade(**base)
+
+
+def _digit_symbol() -> str:
+    """Per-test unique 6-12 digit symbol stable across KR normalizers.
+
+    ``to_db_symbol`` keeps digits; ``_normalize_symbol_for_filter`` keeps
+    digit-only strings as-is (zfill to 6). So a digit-only synthetic symbol
+    is safe under both normalizations and xdist-collisions.
+    """
+    return ("9" + uuid.uuid4().hex[:9])[:10].upper()
+
+
+@pytest.mark.asyncio
+async def test_strategy_key_symbol_window(db_session: AsyncSession):
+    sym = _digit_symbol()
+    norm = _normalize_symbol_for_filter(sym, "equity_kr")
+    db_session.add(
+        TradeRetrospective(
+            symbol=norm,
+            instrument_type="equity_kr",
+            account_mode="kis_mock",
+            outcome="filled",
+            strategy_key="pullback_long",
+            created_at=datetime(2026, 6, 4, tzinfo=UTC),
+        )
+    )
+    await db_session.commit()
+
+    info = await resolve_setup_tag(db_session, _trade(symbol=sym))
+    assert info.tag == "pullback_long"
+    assert info.tag_source == "strategy_key"
+    assert info.link_quality == "symbol_window"
+
+
+@pytest.mark.asyncio
+async def test_untagged_when_no_signal(db_session: AsyncSession):
+    """When nothing matches the symbol, tag is untagged / link_quality symbol_window."""
+    sym = _digit_symbol()
+    info = await resolve_setup_tag(db_session, _trade(symbol=sym))
+    assert info.tag == "untagged"
+    assert info.tag_source == "untagged"
+    assert info.link_quality == "symbol_window"

--- a/tests/services/test_trade_journal_aggregates_tag.py
+++ b/tests/services/test_trade_journal_aggregates_tag.py
@@ -50,7 +50,7 @@ async def test_strategy_key_symbol_window(db_session: AsyncSession):
             created_at=datetime(2026, 6, 4, tzinfo=UTC),
         )
     )
-    await db_session.commit()
+    await db_session.flush()
 
     info = await resolve_setup_tag(db_session, _trade(symbol=sym))
     assert info.tag == "pullback_long"

--- a/tests/services/test_trade_journal_aggregates_tag.py
+++ b/tests/services/test_trade_journal_aggregates_tag.py
@@ -10,26 +10,29 @@ from app.services.trade_journal.forecast_service import _normalize_symbol_for_fi
 
 
 def _trade(**kw):
-    base = dict(
-        market="kr", symbol="005930", account="acct", qty=10,
-        entry_price=100.0, exit_price=110.0,
-        entry_ts=datetime(2026, 6, 1, tzinfo=UTC),
-        exit_ts=datetime(2026, 6, 5, tzinfo=UTC),
-        pnl_abs=100.0, pnl_pct=0.1, fees=0.0,
-        entry_item_uuids=(), exit_item_uuid=None,
-        entry_correlation_ids=(), exit_correlation_id=None,
-    )
+    base = {
+        "market": "kr",
+        "symbol": "005930",
+        "account": "acct",
+        "qty": 10,
+        "entry_price": 100.0,
+        "exit_price": 110.0,
+        "entry_ts": datetime(2026, 6, 1, tzinfo=UTC),
+        "exit_ts": datetime(2026, 6, 5, tzinfo=UTC),
+        "pnl_abs": 100.0,
+        "pnl_pct": 0.1,
+        "fees": 0.0,
+        "entry_item_uuids": (),
+        "exit_item_uuid": None,
+        "entry_correlation_ids": (),
+        "exit_correlation_id": None,
+    }
     base.update(kw)
     return ClosedTrade(**base)
 
 
 def _digit_symbol() -> str:
-    """Per-test unique 6-12 digit symbol stable across KR normalizers.
-
-    ``to_db_symbol`` keeps digits; ``_normalize_symbol_for_filter`` keeps
-    digit-only strings as-is (zfill to 6). So a digit-only synthetic symbol
-    is safe under both normalizations and xdist-collisions.
-    """
+    """Per-test unique 6-12 digit symbol stable across KR normalizers."""
     return ("9" + uuid.uuid4().hex[:9])[:10].upper()
 
 
@@ -57,7 +60,6 @@ async def test_strategy_key_symbol_window(db_session: AsyncSession):
 
 @pytest.mark.asyncio
 async def test_untagged_when_no_signal(db_session: AsyncSession):
-    """When nothing matches the symbol, tag is untagged / link_quality symbol_window."""
     sym = _digit_symbol()
     info = await resolve_setup_tag(db_session, _trade(symbol=sym))
     assert info.tag == "untagged"

--- a/tests/test_mcp_trading_scoreboard.py
+++ b/tests/test_mcp_trading_scoreboard.py
@@ -1,0 +1,11 @@
+import pytest
+
+from app.mcp_server.tooling.trading_scoreboard_tools import get_trading_scoreboard
+
+
+@pytest.mark.asyncio
+async def test_scoreboard_tool_empty_db_shape():
+    result = await get_trading_scoreboard()
+    assert set(result) >= {"groups", "overall", "as_of", "count"}
+    assert result["count"] == 0
+    assert result["groups"] == []


### PR DESCRIPTION
## Goal
Compute setup-tagged trading-journal aggregates (win-rate, expectancy, profit factor, R-multiple, MAE/MFE) from live-order-ledger fills, exposed via a read-only MCP tool plus the ROB-711 `decision_history` injection.

## Architecture
New deterministic read module `app/services/trade_journal/aggregates.py`:
- **`pair_fills_fifo`** — reconstructs closed round-trips FIFO from the three live ledgers (`KISLiveOrderLedger`, `LiveOrderLedger`, `TossLiveOrderLedger`).
- **`load_fills`** — normalizes filled rows (`filled_qty > 0`) from those ledgers, maps to market token `{kr, us, crypto}`, drops smoke rows.
- **`resolve_setup_tag`** — `strategy_key` (correlation_id exact → symbol window) → `intent` (item_uuid exact → symbol window) → `untagged`. `link_quality ∈ {exact, symbol_window}`.
- **`compute_r_multiple` / `planned_stop_for`** — R-multiple from the linked item's `evidence_snapshot["trade_setup"]["stop"]`.
- **`compute_excursions`** — MAE/MFE over daily candles spanning the hold window via `app.services.market_data.get_ohlcv`; `degraded=True` if span > 200 trading days.
- **`aggregate_by_tag`** — per-tag win/loss/expectancy/profit-factor/avg-R/median-R/MAE/MFE.
- **`build_trading_scoreboard`** — orchestrator with in-process TTL cache (300s).

MCP surface: read-only `get_trading_scoreboard`, registered unconditionally in the `Always` block (right after `register_forecast_tools(mcp)`). Also injected as `realized_r_by_tag` (≤3 tags, sorted by sample size, `setup_tag` first if supplied) on `build_decision_context` — implements the reserved hook from ROB-711.

## Global Constraints
- **migration 0** — no new tables/columns. Aggregates are computed on read + cached.
- **ROB-501** — no in-process LLM imports (1124-file static guard green).
- **read-path only** — never touches the order hot path; no broker calls.
- **sample honesty** — any tag with `n < 10` carries `insufficient_sample=True`.
- **Fill source = the 3 live ledgers** — NOT `review.trades` (no provenance ids).
- **Setup-tag precedence** as documented above.
- **Long-only** FIFO pairing; shorts/options out of scope.

## Files
- New: `app/services/trade_journal/aggregates.py` (542 lines)
- New: `app/mcp_server/tooling/trading_scoreboard_tools.py` + `trading_scoreboard_registration.py`
- New: 5 unit test files (17 cases) + 1 MCP integration test
- Modified: `app/mcp_server/tooling/registry.py` (registration, +6 lines)
- Modified: `app/services/decision_history.py` (inject `realized_r_by_tag`, +30 lines)

## Verification
- All new tests green (17 ROB-713 + 4 existing decision_history regression).
- ROB-501 LLM guard (1124 static checks) green.
- `make lint` + `ty check` clean.
- `realized_r_by_tag` reserved hook from ROB-711 implemented.
- No new alembic migrations.

```
14 files changed, 2512 insertions(+), 1 deletion(-)
```

Plan: `docs/superpowers/plans/2026-07-05-rob-713-trade-journal-aggregates.md`
Design: `docs/superpowers/specs/2026-07-05-rob-713-trade-journal-aggregates-design.md`