### PR TITLE
feat(ROB-712): negative-class recording convention (lazy candle backfill + advisory warnings + buy/discovery constraint)

### DIFF
--- a/app/mcp_server/tooling/forecast_registration.py
+++ b/app/mcp_server/tooling/forecast_registration.py
@@ -51,7 +51,11 @@ def register_forecast_tools(mcp: Any) -> None:
             "daily OHLCV (ROB-639 DB-first, equity_kr/equity_us/crypto). "
             "Non-price kinds (or price forecasts you must override) require an "
             "explicit forecast_id plus manual_outcome (bool) and manual_evidence. "
-            "Idempotent: a closed forecast is never re-scored."
+            "Idempotent: a closed forecast is never re-scored. "
+            "Missing daily candles for a not-yet-loaded symbol are lazily "
+            "fetched+persisted once, then re-read (backfill_missing=true "
+            "default; set false for a fast peek that skips the fetch)."
+
         ),
     )(forecast_resolve)
     _ = mcp.tool(

--- a/app/mcp_server/tooling/forecast_registration.py
+++ b/app/mcp_server/tooling/forecast_registration.py
@@ -55,7 +55,6 @@ def register_forecast_tools(mcp: Any) -> None:
             "Missing daily candles for a not-yet-loaded symbol are lazily "
             "fetched+persisted once, then re-read (backfill_missing=true "
             "default; set false for a fast peek that skips the fetch)."
-
         ),
     )(forecast_resolve)
     _ = mcp.tool(

--- a/app/mcp_server/tooling/forecast_tools.py
+++ b/app/mcp_server/tooling/forecast_tools.py
@@ -101,7 +101,9 @@ async def forecast_resolve(
     manual_observed_value: float | None = None,
     manual_evidence: Any | None = None,
     limit: int = 25,
+    backfill_missing: bool = True,
 ) -> dict[str, Any]:
+
     persist = not dry_run
     try:
         async with _session_factory()() as db:
@@ -113,7 +115,9 @@ async def forecast_resolve(
                     manual_outcome=manual_outcome,
                     manual_observed_value=manual_observed_value,
                     manual_evidence=manual_evidence,
+                    backfill_missing=backfill_missing,
                 )
+
                 if persist and result.get("changed"):
                     await db.commit()
                 return {"success": True, "dry_run": dry_run, "mode": "single", **result}
@@ -129,8 +133,12 @@ async def forecast_resolve(
             changed_any = False
             for row in due:
                 r = await resolve_forecast(
-                    db, forecast_id=row.forecast_id, persist=persist
+                    db,
+                    forecast_id=row.forecast_id,
+                    persist=persist,
+                    backfill_missing=backfill_missing,
                 )
+
                 changed_any = changed_any or bool(r.get("changed"))
                 results.append(
                     {

--- a/app/mcp_server/tooling/investment_reports_handlers.py
+++ b/app/mcp_server/tooling/investment_reports_handlers.py
@@ -451,7 +451,6 @@ def _negative_class_warnings(validated_items: list[Any]) -> list[str]:
         return []
 
 
-
 # ---------------------------------------------------------------------------
 # investment_report_create
 # ---------------------------------------------------------------------------
@@ -488,7 +487,6 @@ async def investment_report_create_impl(
     # confidence so the negative class stays calibratable. The helper never
     # raises; an empty list is the no-op default.
     warnings = _negative_class_warnings(validated_items)
-
 
     payload: dict[str, Any] = {
         "report_type": report_type,

--- a/app/mcp_server/tooling/investment_reports_handlers.py
+++ b/app/mcp_server/tooling/investment_reports_handlers.py
@@ -428,6 +428,30 @@ def _maybe_attach_lite_quality(
     )
 
 
+def _negative_class_warnings(validated_items: list[Any]) -> list[str]:
+    """Advisory (never blocks): flag deferred_no_action items missing confidence
+    so the negative class stays calibratable (ROB-712). Fail-open — any error
+    yields no warnings rather than failing report creation. NOTE: forecast
+    presence is NOT checked here (forecast_save is a separate subsystem, unknown
+    at create time); the message reminds the caller to also leave a forecast."""
+    try:
+        out: list[str] = []
+        for item in validated_items or []:
+            bucket = getattr(item, "decision_bucket", None)
+            confidence = getattr(item, "confidence", None)
+            if bucket == "deferred_no_action" and confidence is None:
+                key = getattr(item, "client_item_key", "?")
+                out.append(
+                    f"deferred_no_action item {key!r}: confidence missing — record "
+                    "confidence + a resolvable forecast_save so the negative class "
+                    "stays calibratable (ROB-712)."
+                )
+        return out
+    except Exception:  # noqa: BLE001 — advisory must never break create
+        return []
+
+
+
 # ---------------------------------------------------------------------------
 # investment_report_create
 # ---------------------------------------------------------------------------
@@ -460,6 +484,11 @@ async def investment_report_create_impl(
     validated_items, item_error = _validate_report_items(items)
     if item_error is not None:
         return item_error
+    # ROB-712 — fail-open advisory: flag deferred_no_action items missing
+    # confidence so the negative class stays calibratable. The helper never
+    # raises; an empty list is the no-op default.
+    warnings = _negative_class_warnings(validated_items)
+
 
     payload: dict[str, Any] = {
         "report_type": report_type,
@@ -515,7 +544,9 @@ async def investment_report_create_impl(
         response = InvestmentReportCreateResponse(
             idempotent=not is_new,
             report=InvestmentReportResponse.model_validate(report),
+            warnings=warnings,
         )
+
     return response.model_dump(mode="json", by_alias=True)
 
 

--- a/app/mcp_server/tooling/route_request_lanes.py
+++ b/app/mcp_server/tooling/route_request_lanes.py
@@ -136,8 +136,13 @@ HARD_CONSTRAINTS: dict[str, list[str]] = {
         "no two-sided (buy+sell) resting orders on same Toss symbol",
         "over-concentration cap: portfolio.sector_cluster_cap_pct per sector cluster",
         "portfolio.max_symbols_per_theme per theme; add-not-cut (average down, no stop-loss)",
+        "negative class: record each reviewed-but-rejected candidate as a "
+        "decision_bucket=deferred_no_action item with confidence + rejection "
+        "reason, and leave a resolvable forecast_save (price_target, e.g. "
+        "'no +X% within N days') so calibration isn't censored (ROB-712)",
     ],
     "sell": [
+
         "loss guard: sell price >= avg * sell.loss_guard_min_multiple",
         "KRX tick rounding",
         "no two-sided (buy+sell) resting orders on same Toss symbol",
@@ -151,7 +156,12 @@ HARD_CONSTRAINTS: dict[str, list[str]] = {
         "portfolio.max_symbols_per_theme per theme",
         "rights-issue / overhang filter before ranking",
         "per-symbol sizing: buy.per_symbol_notional_krw_range",
+        "negative class: record each reviewed-but-rejected candidate as a "
+        "decision_bucket=deferred_no_action item with confidence + rejection "
+        "reason, and leave a resolvable forecast_save (price_target, e.g. "
+        "'no +X% within N days') so calibration isn't censored (ROB-712)",
     ],
+
     "bootstrap": [
         "context-load only; no order mutation in this lane",
         "recovery gate frame: recovery_gate.min_conditions_met of 4",

--- a/app/mcp_server/tooling/route_request_lanes.py
+++ b/app/mcp_server/tooling/route_request_lanes.py
@@ -142,7 +142,6 @@ HARD_CONSTRAINTS: dict[str, list[str]] = {
         "'no +X% within N days') so calibration isn't censored (ROB-712)",
     ],
     "sell": [
-
         "loss guard: sell price >= avg * sell.loss_guard_min_multiple",
         "KRX tick rounding",
         "no two-sided (buy+sell) resting orders on same Toss symbol",
@@ -161,7 +160,6 @@ HARD_CONSTRAINTS: dict[str, list[str]] = {
         "reason, and leave a resolvable forecast_save (price_target, e.g. "
         "'no +X% within N days') so calibration isn't censored (ROB-712)",
     ],
-
     "bootstrap": [
         "context-load only; no order mutation in this lane",
         "recovery gate frame: recovery_gate.min_conditions_met of 4",

--- a/app/schemas/investment_reports.py
+++ b/app/schemas/investment_reports.py
@@ -1163,7 +1163,9 @@ class InvestmentReportCreateResponse(BaseModel):
     success: bool = True
     idempotent: bool
     report: InvestmentReportResponse
-
+    # ROB-712 — advisory, fail-open. Non-empty when a deferred_no_action item
+    # omits confidence (negative-class calibration needs confidence + forecast).
+    warnings: list[str] = Field(default_factory=list)
 
 class InvestmentReportDecideItemResponse(BaseModel):
     """``investment_report_decide_item`` MCP return shape."""

--- a/app/schemas/investment_reports.py
+++ b/app/schemas/investment_reports.py
@@ -1167,6 +1167,7 @@ class InvestmentReportCreateResponse(BaseModel):
     # omits confidence (negative-class calibration needs confidence + forecast).
     warnings: list[str] = Field(default_factory=list)
 
+
 class InvestmentReportDecideItemResponse(BaseModel):
     """``investment_report_decide_item`` MCP return shape."""
 

--- a/app/services/trade_journal/forecast_service.py
+++ b/app/services/trade_journal/forecast_service.py
@@ -11,7 +11,10 @@ apart from the DB write.
 from __future__ import annotations
 
 import datetime as dt
+import logging
 import uuid
+
+
 from datetime import date, datetime, timedelta
 from decimal import Decimal
 from typing import Any
@@ -31,6 +34,9 @@ from app.services.daily_candles.repository import (
     MarketKey,
 )
 from app.services.trading_policy_service import policy_version_stamp
+
+logger = logging.getLogger(__name__)
+
 
 # Fail-open fallback policy stamp. ROB-659: the default now comes from the ROB-646
 # trading-policy YAML single source via ``_default_policy_version`` (below); this
@@ -552,6 +558,43 @@ async def _resolve_candle_partition(
     return None
 
 
+async def _backfill_daily_candles(
+    *,
+    symbol: str,
+    market: MarketKey,
+    partition: str,
+    horizon_bars: int = _BACKFILL_HORIZON_BARS,
+) -> int:
+    """Best-effort one-symbol daily-candle fetch+persist for a not-yet-loaded
+    (typically rejected/non-held) symbol so its price_target forecast can
+    resolve. Uses the shared sync service on its OWN session (commits+closes via
+    close_callbacks). Never raises — returns 0 on any failure so resolve stays
+    graceful (unresolved_no_data). ROB-712.
+    """
+    from app.services.daily_candles.sync_service import (
+        SyncTarget,
+        _build_default_service,
+    )
+
+    try:
+        service = await _build_default_service()
+    except Exception:
+        logger.exception("ROB-712 backfill: service build failed symbol=%s", symbol)
+        return 0
+    try:
+        result = await service.sync_one(
+            target=SyncTarget(market=market, symbol=symbol, partition=partition),
+            horizon_bars=horizon_bars,
+        )
+        return result.rows_upserted
+    except Exception:
+        logger.exception("ROB-712 backfill: sync_one failed symbol=%s", symbol)
+        return 0
+    finally:
+        await service.close()
+
+
+
 async def _read_window_candles(
     db: AsyncSession,
     *,
@@ -602,6 +645,7 @@ async def resolve_forecast(
     manual_observed_value: float | None = None,
     manual_evidence: Any | None = None,
     now: datetime | None = None,
+    backfill_missing: bool = True,
 ) -> dict[str, Any]:
     """Resolve one forecast. Idempotent: a closed forecast is never re-scored.
 
@@ -661,6 +705,27 @@ async def resolve_forecast(
             start_date=start_date,
             review_date=row.review_date,
         )
+        # ROB-712: rejected (non-held) symbols usually have no daily OHLCV in
+        # the DB yet. Lazily fetch+persist once via the shared sync service, then
+        # re-read. Never raises — backfill returns 0 on failure and the existing
+        # unresolved_no_data branch still runs below.
+        if not candles and backfill_missing:
+            resolved = await _resolve_candle_partition(
+                db, symbol=row.symbol, instrument_type=instrument
+            )
+            if resolved is not None:
+                market, partition = resolved
+                rows = await _backfill_daily_candles(
+                    symbol=row.symbol, market=market, partition=partition
+                )
+                if rows:
+                    candles = await _read_window_candles(
+                        db,
+                        symbol=row.symbol,
+                        instrument_type=instrument,
+                        start_date=start_date,
+                        review_date=row.review_date,
+                    )
         if not candles:
             return {
                 "status": "unresolved_no_data",
@@ -668,6 +733,7 @@ async def resolve_forecast(
                 "reason": "no loaded daily candles in the resolution window",
                 "forecast": serialize_forecast(row),
             }
+
         direction = target.get("direction")
         target_price = float(target.get("target_price"))
         outcome, observed = classify_price_target_outcome(

--- a/app/services/trade_journal/forecast_service.py
+++ b/app/services/trade_journal/forecast_service.py
@@ -521,6 +521,37 @@ async def list_closed_forecasts(
     )
 
 
+_BACKFILL_HORIZON_BARS = 200
+
+
+async def _resolve_candle_partition(
+    db: AsyncSession, *, symbol: str, instrument_type: str
+) -> tuple[MarketKey, str] | None:
+    """Resolve (market, partition) for the daily-candle store.
+
+    Single source of truth so the resolution read (_read_window_candles) and the
+    lazy backfill (_backfill_daily_candles) always use the SAME partition string
+    — crypto in particular must be "upbit_krw" so both sides resolve the same
+    crypto_instruments row (repository.py:141). Returns None when the US exchange
+    lookup fails or the instrument has no daily store. ROB-712.
+    """
+    if instrument_type == "equity_kr":
+        return MarketKey.KR, "KRX"
+    if instrument_type == "crypto":
+        return MarketKey.CRYPTO, "upbit_krw"
+    if instrument_type == "equity_us":
+        from app.services.us_symbol_universe_service import get_us_exchange_by_symbol
+
+        try:
+            partition = await get_us_exchange_by_symbol(symbol, db=db)
+        except Exception:
+            return None
+        if not partition:
+            return None
+        return MarketKey.US, partition
+    return None
+
+
 async def _read_window_candles(
     db: AsyncSession,
     *,
@@ -535,22 +566,12 @@ async def _read_window_candles(
     exchange lookup failure) so the caller can mark the forecast unresolved
     rather than scoring against an empty window.
     """
-    if instrument_type == "equity_kr":
-        market, partition = MarketKey.KR, "KRX"
-    elif instrument_type == "crypto":
-        market, partition = MarketKey.CRYPTO, "upbit_krw"
-    elif instrument_type == "equity_us":
-        from app.services.us_symbol_universe_service import get_us_exchange_by_symbol
-
-        try:
-            partition = await get_us_exchange_by_symbol(symbol, db=db)
-        except Exception:
-            return None
-        if not partition:
-            return None
-        market = MarketKey.US
-    else:
+    resolved = await _resolve_candle_partition(
+        db, symbol=symbol, instrument_type=instrument_type
+    )
+    if resolved is None:
         return None
+    market, partition = resolved
 
     # Pad the UTC window by 2 days each side to absorb tz/session boundary skew,
     # then filter by the candle's calendar date for a clean inclusive window.
@@ -569,6 +590,7 @@ async def _read_window_candles(
         end=end_dt,
     )
     return [r for r in rows if start_date <= _row_date(r) <= review_date]
+
 
 
 async def resolve_forecast(

--- a/app/services/trade_journal/forecast_service.py
+++ b/app/services/trade_journal/forecast_service.py
@@ -13,8 +13,6 @@ from __future__ import annotations
 import datetime as dt
 import logging
 import uuid
-
-
 from datetime import date, datetime, timedelta
 from decimal import Decimal
 from typing import Any
@@ -594,7 +592,6 @@ async def _backfill_daily_candles(
         await service.close()
 
 
-
 async def _read_window_candles(
     db: AsyncSession,
     *,
@@ -633,7 +630,6 @@ async def _read_window_candles(
         end=end_dt,
     )
     return [r for r in rows if start_date <= _row_date(r) <= review_date]
-
 
 
 async def resolve_forecast(

--- a/docs/playbooks/trading-decision-playbook.md
+++ b/docs/playbooks/trading-decision-playbook.md
@@ -122,6 +122,13 @@ lanes:
 6. Foreign-cascade names (e.g. semis): no market order until **price band
    reached AND foreign selling stops** — until both, only a small deep rung.
 
+7. **Negative-class recording (ROB-712):** every reviewed-but-rejected candidate
+   leaves a `decision_bucket=deferred_no_action` item with `confidence` +
+   rejection reason, plus a resolvable `forecast_save(kind="price_target", …)`
+   (e.g. "no +X% within N days") so calibration isn't censored. The
+   `investment_report_create` response surfaces a `warnings` advisory when an
+   item is missing `confidence`.
+
 ```yaml
 # playbook-machine-readable: buy lane (ROB-649 source)
 lanes:
@@ -224,6 +231,13 @@ recurring new-buy discovery-and-ranking round. It has no code definition yet;
    freshness (newly pulled back).
 5. **Execute:** winners only, support-line limit, `buy.per_symbol_notional_krw_range`
    per symbol.
+
+6. **Negative-class recording (ROB-712):** every reviewed-but-rejected candidate
+   leaves a `decision_bucket=deferred_no_action` item with `confidence` +
+   rejection reason, plus a resolvable `forecast_save(kind="price_target", …)`
+   (e.g. "no +X% within N days") so calibration isn't censored. The
+   `investment_report_create` response surfaces a `warnings` advisory when an
+   item is missing `confidence`.
 
 ```yaml
 # playbook-machine-readable: discovery lane / candidate tournament (ROB-649 source)

--- a/tests/test_forecast_service.py
+++ b/tests/test_forecast_service.py
@@ -520,15 +520,16 @@ async def test_resolve_candle_partition_kr_us_crypto(db_session: AsyncSession):
     assert await svc._resolve_candle_partition(
         db_session, symbol="KRW-BTC", instrument_type="crypto"
     ) == (MarketKey.CRYPTO, "upbit_krw")
-    assert await svc._resolve_candle_partition(
-        db_session, symbol="X", instrument_type="bond"
-    ) is None
-
+    assert (
+        await svc._resolve_candle_partition(
+            db_session, symbol="X", instrument_type="bond"
+        )
+        is None
+    )
 
 
 @pytest.mark.asyncio
 async def test_resolve_backfills_missing_candles_then_scores(
-
     db_session: AsyncSession, monkeypatch
 ):
     # ROB-712: when the resolution window has no candles, resolve_forecast must
@@ -552,6 +553,7 @@ async def test_resolve_backfills_missing_candles_then_scores(
 
     async def fake_backfill(*, symbol, market, partition, horizon_bars=200):
         calls["n"] += 1
+
         # Mirror the real-world effect: after the backfill a subsequent read
         # of the same window returns candles.
         async def seeded_read(*_a, **_k):

--- a/tests/test_forecast_service.py
+++ b/tests/test_forecast_service.py
@@ -504,3 +504,22 @@ async def test_list_forecasts_symbol_filter_normalizes_equity_us(
     matched = await svc.list_forecasts(db_session, symbol="BRK-B")
     assert matched["summary"]["count"] == 1
     assert matched["entries"][0]["symbol"] == "BRK.B"
+
+
+# --------------------------------------------------------------------------- #
+# ROB-712: shared _resolve_candle_partition mapping
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_resolve_candle_partition_kr_us_crypto(db_session: AsyncSession):
+    from app.services.daily_candles.repository import MarketKey
+
+    assert await svc._resolve_candle_partition(
+        db_session, symbol="005930", instrument_type="equity_kr"
+    ) == (MarketKey.KR, "KRX")
+    # crypto MUST use the resolve-canonical partition so read/write are symmetric
+    assert await svc._resolve_candle_partition(
+        db_session, symbol="KRW-BTC", instrument_type="crypto"
+    ) == (MarketKey.CRYPTO, "upbit_krw")
+    assert await svc._resolve_candle_partition(
+        db_session, symbol="X", instrument_type="bond"
+    ) is None

--- a/tests/test_forecast_service.py
+++ b/tests/test_forecast_service.py
@@ -523,3 +523,132 @@ async def test_resolve_candle_partition_kr_us_crypto(db_session: AsyncSession):
     assert await svc._resolve_candle_partition(
         db_session, symbol="X", instrument_type="bond"
     ) is None
+
+
+
+@pytest.mark.asyncio
+async def test_resolve_backfills_missing_candles_then_scores(
+
+    db_session: AsyncSession, monkeypatch
+):
+    # ROB-712: when the resolution window has no candles, resolve_forecast must
+    # call _backfill_daily_candles once, then re-read the window. The fake
+    # backfill swaps _read_window_candles to return canned candles on the
+    # second read (mirroring what a real fetch+persist would yield).
+    _, row = await svc.save_forecast(
+        db_session,
+        created_by="claude",
+        symbol="005930",
+        instrument_type="equity_kr",
+        forecast_target=_price_target(direction="at_or_above", target_price=100.0),
+        probability=0.7,
+        forecast_start_date="2026-06-01",
+        review_date="2026-06-05",
+    )
+    await db_session.commit()
+
+    real_read = svc._read_window_candles
+    calls = {"n": 0}
+
+    async def fake_backfill(*, symbol, market, partition, horizon_bars=200):
+        calls["n"] += 1
+        # Mirror the real-world effect: after the backfill a subsequent read
+        # of the same window returns candles.
+        async def seeded_read(*_a, **_k):
+            return _candles([120.0, 131.0])
+
+        monkeypatch.setattr(svc, "_read_window_candles", seeded_read)
+        return 7
+
+    monkeypatch.setattr(svc, "_backfill_daily_candles", fake_backfill)
+
+    # First read returns empty so the backfill branch runs (the test DB lacks
+    # the kr_candles_1d table so we cannot call the real reader here).
+    async def empty_read(*_a, **_k):
+        return []
+
+    monkeypatch.setattr(svc, "_read_window_candles", empty_read)
+
+    result = await svc.resolve_forecast(
+        db_session, forecast_id=str(row.forecast_id), persist=False
+    )
+    await db_session.commit()
+
+    assert calls["n"] == 1
+    assert result["status"] == "previewed"
+    assert result["computed"]["outcome"] is True
+    assert result["computed"]["resolution_source"] == "ohlcv_day"
+    # restore so the autouse cleanup fixture can run unaffected
+    monkeypatch.setattr(svc, "_read_window_candles", real_read)
+
+
+@pytest.mark.asyncio
+async def test_resolve_backfill_failure_is_graceful(
+    db_session: AsyncSession, monkeypatch
+):
+    # ROB-712: backfill returns 0 on failure (helper swallows exceptions) and
+    # resolve must fall through to unresolved_no_data — never raise.
+    _, row = await svc.save_forecast(
+        db_session,
+        created_by="claude",
+        symbol="005930",
+        instrument_type="equity_kr",
+        forecast_target=_price_target(direction="at_or_above", target_price=100.0),
+        probability=0.6,
+        forecast_start_date="2026-06-01",
+        review_date="2026-06-05",
+    )
+    await db_session.commit()
+
+    async def empty_read(*_a, **_k):
+        return []
+
+    async def boom(*, symbol, market, partition, horizon_bars=200):
+        return 0
+
+    monkeypatch.setattr(svc, "_read_window_candles", empty_read)
+    monkeypatch.setattr(svc, "_backfill_daily_candles", boom)
+
+    result = await svc.resolve_forecast(
+        db_session, forecast_id=str(row.forecast_id), persist=False
+    )
+    assert result["status"] == "unresolved_no_data"
+
+
+@pytest.mark.asyncio
+async def test_resolve_backfill_missing_false_skips_fetch(
+    db_session: AsyncSession, monkeypatch
+):
+    # ROB-712: backfill_missing=False must skip the fetch+persist entirely.
+    _, row = await svc.save_forecast(
+        db_session,
+        created_by="claude",
+        symbol="005930",
+        instrument_type="equity_kr",
+        forecast_target=_price_target(direction="at_or_above", target_price=100.0),
+        probability=0.6,
+        forecast_start_date="2026-06-01",
+        review_date="2026-06-05",
+    )
+    await db_session.commit()
+
+    async def empty_read(*_a, **_k):
+        return []
+
+    called = {"n": 0}
+
+    async def spy(*, symbol, market, partition, horizon_bars=200):
+        called["n"] += 1
+        return 0
+
+    monkeypatch.setattr(svc, "_read_window_candles", empty_read)
+    monkeypatch.setattr(svc, "_backfill_daily_candles", spy)
+
+    result = await svc.resolve_forecast(
+        db_session,
+        forecast_id=str(row.forecast_id),
+        persist=False,
+        backfill_missing=False,
+    )
+    assert called["n"] == 0
+    assert result["status"] == "unresolved_no_data"

--- a/tests/test_forecast_tools.py
+++ b/tests/test_forecast_tools.py
@@ -111,11 +111,7 @@ async def test_forecast_resolve_passes_backfill_flag(monkeypatch):
 
     monkeypatch.setattr(forecast_tools, "_session_factory", _factory)
 
-
-
-    res = await forecast_resolve(
-        forecast_id="x", dry_run=True, backfill_missing=False
-    )
+    res = await forecast_resolve(forecast_id="x", dry_run=True, backfill_missing=False)
     assert res["success"] is True
     assert seen["backfill_missing"] is False
     assert seen["forecast_id"] == "x"

--- a/tests/test_forecast_tools.py
+++ b/tests/test_forecast_tools.py
@@ -77,6 +77,50 @@ async def test_save_missing_symbol_envelope():
     assert "symbol" in res["error"]
 
 
+# ROB-712 — forecast_resolve must expose backfill_missing and forward it to
+# resolve_forecast on both the single and the batch path.
+@pytest.mark.asyncio
+async def test_forecast_resolve_passes_backfill_flag(monkeypatch):
+    from app.mcp_server.tooling import forecast_tools
+
+    seen: dict[str, object] = {}
+
+    async def fake_resolve(db, *, forecast_id, persist, backfill_missing=True, **kw):
+        seen["backfill_missing"] = backfill_missing
+        seen["forecast_id"] = forecast_id
+        return {"status": "unresolved_no_data", "changed": False}
+
+    monkeypatch.setattr(forecast_tools, "resolve_forecast", fake_resolve)
+
+    # Stub the session factory so the test never opens a DB connection.
+    # Production shape: _session_factory() -> sessionmaker; () -> session;
+    # the session is an async context manager that yields the AsyncSession.
+    class _StubSession:
+        async def __aenter__(self):
+            return None
+
+        async def __aexit__(self, *_a):
+            return False
+
+    class _StubSessionMaker:
+        def __call__(self) -> _StubSession:
+            return _StubSession()
+
+    def _factory():
+        return _StubSessionMaker()
+
+    monkeypatch.setattr(forecast_tools, "_session_factory", _factory)
+
+
+
+    res = await forecast_resolve(
+        forecast_id="x", dry_run=True, backfill_missing=False
+    )
+    assert res["success"] is True
+    assert seen["backfill_missing"] is False
+    assert seen["forecast_id"] == "x"
+
+
 # --------------------------------------------------------------------------- #
 # DB-backed envelope tests (opt-in: request the _clean fixture explicitly so
 # the wiring tests above stay DB-free)

--- a/tests/test_investment_reports_mcp.py
+++ b/tests/test_investment_reports_mcp.py
@@ -146,6 +146,58 @@ async def test_create_returns_idempotent_false_on_first_call(
     assert response["report"]["market"] == "kr"
 
 
+# --------------------------------------------------------------------------- #
+# ROB-712 — fail-open advisory warnings on investment_report_create
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_create_warns_on_deferred_item_without_confidence(
+    session: AsyncSession,
+) -> None:
+    # ROB-712: a deferred_no_action item without confidence is a calibration
+    # dead-zone. The response must surface a non-empty warning so the operator
+    # knows to backfill confidence + a resolvable forecast_save.
+    response = await investment_report_create_impl(
+        items=[
+            {
+                "client_item_key": "k1",
+                "item_kind": "watch",
+                "operation": "review",
+                "symbol": "005930",
+                "intent": "buy_review",
+                "rationale": "rejected: RSI too high",
+                "decision_bucket": "deferred_no_action",
+                # confidence intentionally omitted
+            }
+        ],
+        **_create_kwargs(),
+    )
+    assert response["success"] is True
+    assert any("confidence" in w for w in response["warnings"])
+
+
+@pytest.mark.asyncio
+async def test_create_no_warning_when_deferred_has_confidence(
+    session: AsyncSession,
+) -> None:
+    response = await investment_report_create_impl(
+        items=[
+            {
+                "client_item_key": "k1",
+                "item_kind": "watch",
+                "operation": "review",
+                "symbol": "005930",
+                "intent": "buy_review",
+                "rationale": "rejected",
+                "decision_bucket": "deferred_no_action",
+                "confidence": 42,
+            }
+        ],
+        **_create_kwargs(),
+    )
+    assert response["success"] is True
+    assert response["warnings"] == []
+
+
 @pytest.mark.asyncio
 async def test_create_returns_idempotent_true_on_replay(
     session: AsyncSession,

--- a/tests/test_route_request_lanes.py
+++ b/tests/test_route_request_lanes.py
@@ -208,6 +208,17 @@ def test_hard_constraints_reference_policy_keys_not_numbers():
     assert "1.01" not in joined
 
 
+def test_buy_discovery_have_negative_class_constraint():
+    # ROB-712 — buy + discovery lanes must encode the negative-class recording
+    # convention: deferred_no_action items keep confidence + a resolvable
+    # forecast so calibration isn't censored.
+    for lane in ("buy", "discovery"):
+        joined = " ".join(L.HARD_CONSTRAINTS[lane]).lower()
+        assert "deferred_no_action" in joined
+        assert "confidence" in joined
+        assert "forecast" in joined
+
+
 # --- ROB-660: sell lane account routing ---------------------------------------
 
 


### PR DESCRIPTION
## ROB-712 Negative-Class Recording Convention

Stage 2 of the learning-loop roadmap (stage 1 / ROB-711 merged at `99508870`).

Rejects (reviewed-but-not-bought candidates) must leave a *resolvable* negative-class record: `decision_bucket=deferred_no_action` + `confidence` + rejection rationale + a `forecast_save(kind="price_target", ...)` so calibration isn't censored. The real gap that made those records dead was that rejected (non-held) symbols had no daily OHLCV in the DB — `resolve_forecast` returned `unresolved_no_data`. This PR closes that gap.

### Changes

1. **Lazy candle backfill in `resolve_forecast`** (`app/services/trade_journal/forecast_service.py`)
   - Extracts shared `_resolve_candle_partition(db, *, symbol, instrument_type)` so the resolution read and the backfill always agree on partition (esp. crypto: `"upbit_krw"`, not the universe-sync's `"KRW"`).
   - Adds `_backfill_daily_candles(*, symbol, market, partition, horizon_bars=200)` that uses the existing `DailyCandleSyncService` on its own session; never raises (returns 0 on failure).
   - `resolve_forecast(..., backfill_missing: bool = True)` — new keyword-only param. On the empty-candle branch, calls backfill once, re-reads, then falls through to `unresolved_no_data` if still empty.
   - Refactored `_read_window_candles` to use the shared resolver (no behavior change).

2. **`backfill_missing` on `forecast_resolve` tool** (`app/mcp_server/tooling/forecast_tools.py` + `forecast_registration.py`)
   - Plumbed through both single + batch paths.
   - Documented in the tool description: "Missing daily candles for a not-yet-loaded symbol are lazily fetched+persisted once, then re-read (`backfill_missing=true` default; set false for a fast peek that skips the fetch)."

3. **Fail-open advisory `warnings` on `investment_report_create`** (`app/schemas/investment_reports.py` + `app/mcp_server/tooling/investment_reports_handlers.py`)
   - New `InvestmentReportCreateResponse.warnings: list[str]` (defaulted; back-compat).
   - New `_negative_class_warnings(validated_items)` helper that flags any `decision_bucket=deferred_no_action` item missing `confidence`. Wraps all logic in `try/except` so the advisory never blocks report creation (mirrors `_maybe_attach_lite_quality`).
   - Wired into `investment_report_create_impl` after validation.

4. **Buy/discovery hard-constraint + playbook prose** (`app/mcp_server/tooling/route_request_lanes.py` + `docs/playbooks/trading-decision-playbook.md`)
   - Adds the same negative-class recording line to `HARD_CONSTRAINTS["buy"]` and `HARD_CONSTRAINTS["discovery"]`. The `LANE_SEQUENCES` `tool:` lists are untouched, so the registry-diff test stays green.
   - Mirrors the constraint as a human-readable step 7/6 in the buy and discovery lane prose. YAML `lanes:` blocks untouched.

### Companion change (out-of-repo)

`/Users/mgh3326/services/auto_trader-operator/CLAUDE.md` §7 extended with the negative-class protocol + the >70% confidence+forecast recording target. (Not in this PR diff.)

### Global constraints

- **Migration 0** — `git diff --name-only origin/main...HEAD -- alembic/` is empty. `decision_bucket=deferred_no_action`, item `confidence`, item `rationale`, and `forecast_save(kind="price_target")` all already existed.
- **Order hot path stays no-network** — the only network seam is `_backfill_daily_candles`, which lives exclusively in the *resolution* path. `forecast_save`, `investment_report_create`, `route_request`, and order-placement tools are untouched.
- **Fail-open advisories never block** — `_negative_class_warnings` swallows all exceptions and returns `[]`.
- **Registry-diff stays green** — `tests/test_route_request_registry_diff.py::test_lane_sequences_match_playbook` compares only the *set* of `tool:` names; this PR only touches `purpose` strings and `HARD_CONSTRAINTS` prose.

### Tests

- `tests/test_forecast_service.py`: 4 new tests (`_resolve_candle_partition` mapping, backfill-then-resolve, graceful failure, opt-out). 23/23 pass.
- `tests/test_forecast_tools.py`: 1 new test (plumb through). 8/8 pass.
- `tests/test_investment_reports_mcp.py`: 2 new tests (warning on missing confidence, no warning when present). 43/43 pass.
- `tests/test_route_request_lanes.py`: 1 new test (buy/discovery have the constraint). 18/18 pass.
- `tests/test_route_request_registry_diff.py`: still 6/6 pass.

Combined: 98/98 touched tests pass.

### Lint + typecheck

- `uv run ruff check …` (touched files) — all checks passed.
- `uv run ruff format --check …` — all already formatted.
- `uv run ty check app/` — all checks passed.

### Commits (6)

- `08456423` refactor(ROB-712): extract shared `_resolve_candle_partition` for forecast resolve
- `21a4d6ad` feat(ROB-712): resolve-time lazy candle backfill for rejected-symbol forecasts
- `64829603` feat(ROB-712): expose `backfill_missing` on `forecast_resolve` tool
- `4a549f70` feat(ROB-712): advisory warning for `deferred_no_action` items missing confidence
- `fb408143` feat(ROB-712): buy/discovery hard-constraint for negative-class recording
- `d78e1557` style(ROB-712): apply ruff format to touched files

### Reference

- Plan: `docs/superpowers/plans/2026-07-05-rob-712-negative-class-recording.md`
