### PR TITLE
test: stub nxt_tradability in KR analyze ohlcv-empty fallback test (fix shard-order flake)

### DIFF
--- a/tests/test_mcp_fundamentals_tools.py
+++ b/tests/test_mcp_fundamentals_tools.py
@@ -4450,6 +4450,16 @@ async def test_analyze_stock_kr_falls_back_to_quote_helper_when_ohlcv_empty(
 ):
     tools = build_tools()
 
+    async def _no_nxt_tradability(symbols):
+        # Same shared-DB shard-order flake as the golden-quote test above: the
+        # unstubbed enrich opens a real AsyncSessionLocal and any exception is
+        # swallowed by _gather_task_results(return_exceptions=True), dropping
+        # the "quote" key entirely (KeyError on main CI, run 28739101307).
+        _ = symbols
+        return {}
+
+    _patch_runtime_attr(monkeypatch, "get_kr_nxt_tradability", _no_nxt_tradability)
+
     async def mock_fetch_ohlcv(symbol, market_type, count):
         _ = symbol, market_type, count
         return pd.DataFrame(


### PR DESCRIPTION
## 배경

main CI run [28739101307](https://github.com/mgh3326/auto_trader/actions/runs/28739101307) (ROB-716 머지 커밋, shard 3)에서 `test_analyze_stock_kr_falls_back_to_quote_helper_when_ohlcv_empty`가 `KeyError: 'quote'`로 실패. 재실행 green, 로컬 단일/파일 실행 green — 코드 회귀가 아니라 **shard-order 플레이크**.

## 원인

이 테스트는 `get_kr_nxt_tradability`를 스텁하지 않아 실 `AsyncSessionLocal()` DB 세션을 연다. xdist 워커 DDL 경합 등으로 그 호출이 실패하면 `_gather_task_results(return_exceptions=True)`(analysis_analyze.py)가 예외를 삼켜 `quote` 키가 통째로 빠진다. **같은 파일의 golden-quote 형제 테스트는 fb96d4c8(ROB-703)에서 동일 원인으로 이미 스텁을 받았는데, 이 fallback 테스트만 누락**돼 있었다. ROB-712/716 테스트 추가로 샤드가 재분배되며 재노출.

## 변경

형제 테스트(:4300-4309)와 동일한 `_no_nxt_tradability` 스텁 10줄 추가. 테스트 전용, 프로덕션 코드 무접촉.

## 검증

- `pytest tests/test_mcp_fundamentals_tools.py -k 'falls_back_to_quote_helper or reuses_preloaded'` → 3 passed
- `ruff format --check` / `ruff check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Vo3Zcr43ktxA9jaZek5Gv

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test isolation for stock analysis fallback behavior.
  * Made the quote-related test more stable by using a stubbed response instead of shared runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->