### PR TITLE
feat(ROB-717): decision_history→scoreboard fanout mitigation + minor cleanups

### DIFF
--- a/app/services/decision_history.py
+++ b/app/services/decision_history.py
@@ -147,9 +147,7 @@ async def _realized_r_by_tag(
     """
     from app.services.trade_journal.aggregates import build_trading_scoreboard
 
-    board = await build_trading_scoreboard(
-        db, market=market, include_excursions=False
-    )
+    board = await build_trading_scoreboard(db, market=market, include_excursions=False)
     groups = [g for g in board.get("groups", []) if g["tag"] != "untagged"]
     ordered = sorted(groups, key=lambda g: (g["tag"] != setup_tag, -int(g["n"])))
     return {g["tag"]: {k: g.get(k) for k in _R_KEYS} for g in ordered[:_MAX_TAGS]}

--- a/app/services/decision_history.py
+++ b/app/services/decision_history.py
@@ -147,15 +147,12 @@ async def _realized_r_by_tag(
     """
     from app.services.trade_journal.aggregates import build_trading_scoreboard
 
-    board = await build_trading_scoreboard(db, market=market)
-    groups = board.get("groups", [])
+    board = await build_trading_scoreboard(
+        db, market=market, include_excursions=False
+    )
+    groups = [g for g in board.get("groups", []) if g["tag"] != "untagged"]
     ordered = sorted(groups, key=lambda g: (g["tag"] != setup_tag, -int(g["n"])))
-    out: dict[str, dict[str, Any]] = {}
-    for g in ordered[:_MAX_TAGS]:
-        if g["tag"] == "untagged":
-            continue
-        out[g["tag"]] = {k: g.get(k) for k in _R_KEYS}
-    return out
+    return {g["tag"]: {k: g.get(k) for k in _R_KEYS} for g in ordered[:_MAX_TAGS]}
 
 
 async def _prior_decisions(db: AsyncSession, symbol: str) -> list[dict[str, Any]]:

--- a/app/services/trade_journal/aggregates.py
+++ b/app/services/trade_journal/aggregates.py
@@ -4,6 +4,7 @@ MAE) over live-ledger fills. Read-only, no LLM (ROB-501), no schema change."""
 from __future__ import annotations
 
 import uuid
+import copy
 from collections import defaultdict, deque
 from dataclasses import dataclass
 from datetime import UTC, date, datetime, timedelta
@@ -508,7 +509,7 @@ async def build_trading_scoreboard(
     if use_cache:
         cached = _scoreboard_cache.get(key)
         if cached and stamp - cached[0] < _SCOREBOARD_TTL_SECONDS:
-            return cached[1]
+            return copy.deepcopy(cached[1])
 
     fills = await load_fills(
         db,
@@ -550,5 +551,5 @@ async def build_trading_scoreboard(
         "count": len(rows),
     }
     if use_cache:
-        _scoreboard_cache[key] = (stamp, result)
+        _scoreboard_cache[key] = (stamp, copy.deepcopy(result))
     return result

--- a/app/services/trade_journal/aggregates.py
+++ b/app/services/trade_journal/aggregates.py
@@ -488,6 +488,7 @@ async def build_trading_scoreboard(
     date_to: date | None = None,
     setup_tag: str | None = None,
     min_sample: int = 1,
+    include_excursions: bool = True,
     use_cache: bool = True,
     now: datetime | None = None,
 ) -> dict:
@@ -496,7 +497,7 @@ async def build_trading_scoreboard(
     ``now`` is exposed for tests so the TTL comparison is deterministic; in
     production the orchestrator defaults to ``datetime.now(timezone.utc)``.
     """
-    key = (market, account_mode, date_from, date_to, setup_tag, min_sample)
+    key = (market, account_mode, date_from, date_to, setup_tag, min_sample, include_excursions)
     stamp = (now or datetime.now(UTC)).timestamp()
     if use_cache:
         cached = _scoreboard_cache.get(key)
@@ -521,10 +522,12 @@ async def build_trading_scoreboard(
             stop = await planned_stop_for(db, t)
         except Exception:
             stop = None
-        try:
-            mae, mfe, _degraded = await compute_excursions(t)
-        except Exception:
-            mae, mfe = None, None
+        mae, mfe = None, None
+        if include_excursions:
+            try:
+                mae, mfe, _degraded = await compute_excursions(t)
+            except Exception:
+                mae, mfe = None, None
         rows.append(TradeMetrics(t, tag, compute_r_multiple(t, stop), mae, mfe))
 
     groups = aggregate_by_tag(rows)

--- a/app/services/trade_journal/aggregates.py
+++ b/app/services/trade_journal/aggregates.py
@@ -150,7 +150,12 @@ async def load_fills(
                 if date_to and d > date_to:
                     continue
             if _is_smoke(
-                getattr(r, "correlation_id", None), getattr(r, "status", None)
+                getattr(r, "correlation_id", None),
+                getattr(r, "status", None),
+                getattr(r, "reason", None),
+                getattr(r, "thesis", None),
+                getattr(r, "strategy", None),
+                getattr(r, "notes", None),
             ):
                 continue
             corr = getattr(r, "correlation_id", None)

--- a/app/services/trade_journal/aggregates.py
+++ b/app/services/trade_journal/aggregates.py
@@ -440,7 +440,7 @@ class TradeMetrics:
     r_multiple: float | None
     mae: float | None
     mfe: float | None
-
+    degraded: bool = False
 
 def _agg_one(tag: str, rows: list[TradeMetrics]) -> dict:
     pnls = [r.trade.pnl_pct for r in rows if r.trade.pnl_pct is not None]
@@ -468,6 +468,7 @@ def _agg_one(tag: str, rows: list[TradeMetrics]) -> dict:
         "avg_r": fmean(rs) if rs else None,
         "median_r": median(rs) if rs else None,
         "r_coverage": (len(rs) / n) if n else None,
+        "excursions_degraded": sum(1 for r in rows if r.degraded),
         "avg_mae": fmean(maes) if maes else None,
         "avg_mfe": fmean(mfes) if mfes else None,
         "worst_mae": min(maes) if maes else None,
@@ -528,12 +529,15 @@ async def build_trading_scoreboard(
         except Exception:
             stop = None
         mae, mfe = None, None
+        degraded = False
         if include_excursions:
             try:
-                mae, mfe, _degraded = await compute_excursions(t)
+                mae, mfe, degraded = await compute_excursions(t)
             except Exception:
-                mae, mfe = None, None
-        rows.append(TradeMetrics(t, tag, compute_r_multiple(t, stop), mae, mfe))
+                mae, mfe, degraded = None, None, False
+        rows.append(
+            TradeMetrics(t, tag, compute_r_multiple(t, stop), mae, mfe, degraded)
+        )
 
     groups = aggregate_by_tag(rows)
     if setup_tag:

--- a/app/services/trade_journal/aggregates.py
+++ b/app/services/trade_journal/aggregates.py
@@ -3,8 +3,8 @@ MAE) over live-ledger fills. Read-only, no LLM (ROB-501), no schema change."""
 
 from __future__ import annotations
 
-import uuid
 import copy
+import uuid
 from collections import defaultdict, deque
 from dataclasses import dataclass
 from datetime import UTC, date, datetime, timedelta
@@ -443,6 +443,7 @@ class TradeMetrics:
     mfe: float | None
     degraded: bool = False
 
+
 def _agg_one(tag: str, rows: list[TradeMetrics]) -> dict:
     pnls = [r.trade.pnl_pct for r in rows if r.trade.pnl_pct is not None]
     wins = [p for p in pnls if p > 0]
@@ -504,7 +505,15 @@ async def build_trading_scoreboard(
     ``now`` is exposed for tests so the TTL comparison is deterministic; in
     production the orchestrator defaults to ``datetime.now(timezone.utc)``.
     """
-    key = (market, account_mode, date_from, date_to, setup_tag, min_sample, include_excursions)
+    key = (
+        market,
+        account_mode,
+        date_from,
+        date_to,
+        setup_tag,
+        min_sample,
+        include_excursions,
+    )
     stamp = (now or datetime.now(UTC)).timestamp()
     if use_cache:
         cached = _scoreboard_cache.get(key)

--- a/docs/superpowers/plans/2026-07-05-rob-717-decision-history-scoreboard-fanout.md
+++ b/docs/superpowers/plans/2026-07-05-rob-717-decision-history-scoreboard-fanout.md
@@ -1,0 +1,529 @@
+# ROB-717 decision_history→scoreboard 팬아웃 완화 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** decision_history 주입 경로가 3s timeout 안에 안정 수렴하도록 scoreboard 팬아웃에서 OHLCV/브로커 호출을 제거하고, ROB-713 검증 minor 5건을 정리한다.
+
+**Architecture:** `build_trading_scoreboard`에 `include_excursions` 플래그를 추가해 decision_history 경로(`_realized_r_by_tag`)가 `False`로 호출 → per-trade `compute_excursions`(→`get_ohlcv`) 호출을 완전히 스킵. scoreboard MCP·웹은 기본 `True`로 MAE 정확도를 유지한다. 나머지는 소유 파일(`decision_history.py`/`aggregates.py`) 내 국소 수정.
+
+**Tech Stack:** Python 3.13, SQLAlchemy async, pytest(asyncio), uv.
+
+## Global Constraints
+
+- 백엔드 전용, **migration 0** (스키마 변경 없음).
+- 소유 파일: `app/services/trade_journal/aggregates.py`, `app/services/decision_history.py` (+ 각 테스트), `tests/test_mcp_trading_scoreboard.py`. ROB-715는 소비만 — 웹/insights 컬럼 확장은 이 플랜 밖.
+- read-path(=decision_history)에서 브로커 네트워크 호출 **0**.
+- `compute_excursions`는 3-tuple `(mae, mfe, degraded)` 시그니처 유지 (기존 `test_excursions_from_stubbed_ohlcv` 의존).
+- `TradeMetrics.degraded`는 **기본값 `False`** — 기존 `_tm` 헬퍼가 degraded 없이 생성하므로 필수 필드로 만들면 안 됨.
+- 테스트 실행: `uv run pytest <path> -v`. 커밋 메시지 말미:
+  `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`
+
+---
+
+### Task 1: `include_excursions` 플래그 — scoreboard 팬아웃 스킵 + cache key
+
+**Files:**
+- Modify: `app/services/trade_journal/aggregates.py:482-542` (`build_trading_scoreboard` 시그니처·cache key·per-trade 루프)
+- Test: `tests/services/test_trade_journal_aggregates_scoreboard.py`
+
+**Interfaces:**
+- Produces: `build_trading_scoreboard(db, *, market=None, account_mode=None, date_from=None, date_to=None, setup_tag=None, min_sample=1, include_excursions=True, use_cache=True, now=None) -> dict`. `include_excursions=False`이면 어떤 trade에 대해서도 `compute_excursions`/`get_ohlcv`를 호출하지 않으며 그룹의 MAE/MFE 필드는 `None`. cache key에 `include_excursions`가 포함되어 True/False 결과가 분리 캐시된다.
+
+- [ ] **Step 1: 실패 테스트 작성** — `tests/services/test_trade_journal_aggregates_scoreboard.py` 끝에 추가
+
+```python
+@pytest.mark.asyncio
+async def test_include_excursions_false_skips_ohlcv(db_session, monkeypatch):
+    called = False
+
+    async def spy_get_ohlcv(*a, **k):
+        nonlocal called
+        called = True
+        return []
+
+    monkeypatch.setattr(agg, "get_ohlcv", spy_get_ohlcv)
+    # market=None, empty CI-owned rows are fine; the assertion is on the call, not counts
+    await agg.build_trading_scoreboard(
+        db_session, use_cache=False, include_excursions=False
+    )
+    assert called is False
+
+
+@pytest.mark.asyncio
+async def test_include_excursions_in_cache_key(db_session, monkeypatch):
+    from datetime import UTC, datetime
+
+    calls = {"n": 0}
+
+    async def counting_load_fills(*a, **k):
+        calls["n"] += 1
+        return []
+
+    monkeypatch.setattr(agg, "load_fills", counting_load_fills)
+    stamp = datetime(2026, 7, 5, tzinfo=UTC)
+    await agg.build_trading_scoreboard(
+        db_session, include_excursions=True, now=stamp
+    )
+    await agg.build_trading_scoreboard(
+        db_session, include_excursions=False, now=stamp
+    )
+    # distinct cache keys → load_fills ran twice, not served from one cache slot
+    assert calls["n"] == 2
+```
+
+- [ ] **Step 2: 실패 확인**
+
+Run: `uv run pytest tests/services/test_trade_journal_aggregates_scoreboard.py::test_include_excursions_false_skips_ohlcv tests/services/test_trade_journal_aggregates_scoreboard.py::test_include_excursions_in_cache_key -v`
+Expected: FAIL — `build_trading_scoreboard() got an unexpected keyword argument 'include_excursions'`
+
+- [ ] **Step 3: 구현** — `aggregates.py`의 `build_trading_scoreboard`
+
+시그니처에 `include_excursions: bool = True`를 `min_sample` 다음에 추가:
+
+```python
+async def build_trading_scoreboard(
+    db: AsyncSession,
+    *,
+    market: str | None = None,
+    account_mode: str | None = None,
+    date_from: date | None = None,
+    date_to: date | None = None,
+    setup_tag: str | None = None,
+    min_sample: int = 1,
+    include_excursions: bool = True,
+    use_cache: bool = True,
+    now: datetime | None = None,
+) -> dict:
+```
+
+cache key에 `include_excursions` 추가:
+
+```python
+    key = (market, account_mode, date_from, date_to, setup_tag, min_sample, include_excursions)
+```
+
+per-trade 루프의 excursions 블록을 조건부로 변경 (기존 라인 524-528):
+
+```python
+        mae, mfe = None, None
+        if include_excursions:
+            try:
+                mae, mfe, _degraded = await compute_excursions(t)
+            except Exception:
+                mae, mfe = None, None
+        rows.append(TradeMetrics(t, tag, compute_r_multiple(t, stop), mae, mfe))
+```
+
+- [ ] **Step 4: 통과 확인**
+
+Run: `uv run pytest tests/services/test_trade_journal_aggregates_scoreboard.py -v`
+Expected: PASS (신규 2건 + 기존 전부)
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add app/services/trade_journal/aggregates.py tests/services/test_trade_journal_aggregates_scoreboard.py
+git commit -m "feat(ROB-717): include_excursions flag skips OHLCV fanout in scoreboard
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: decision_history read-path 스킵 + minor (a) untagged-before-slice
+
+**Files:**
+- Modify: `app/services/decision_history.py:138-158` (`_realized_r_by_tag`)
+- Test: `tests/services/test_decision_history_realized_r.py`
+
+**Interfaces:**
+- Consumes: `build_trading_scoreboard(..., include_excursions=False)` from Task 1.
+- Produces: `_realized_r_by_tag`가 `untagged`를 top-3 슬라이스 **전에** 제거하고, `include_excursions=False`로 scoreboard를 호출한다.
+
+- [ ] **Step 1: 실패 테스트 작성** — `tests/services/test_decision_history_realized_r.py` 끝에 추가
+
+```python
+@pytest.mark.asyncio
+async def test_untagged_dominant_still_returns_real_tags(db_session, monkeypatch):
+    import app.services.decision_history as dh
+
+    async def fake_scoreboard(db, *, market=None, include_excursions=True, **kw):
+        assert include_excursions is False  # read-path must skip excursions
+        return {
+            "groups": [
+                {"tag": "untagged", "n": 99, "expectancy_r": 0.0, "win_rate": 0.0,
+                 "profit_factor": None, "avg_mae": None, "insufficient_sample": False},
+                {"tag": "pullback_long", "n": 5, "expectancy_r": 1.2, "win_rate": 0.6,
+                 "profit_factor": 2.0, "avg_mae": -0.02, "insufficient_sample": True},
+            ],
+            "overall": None, "as_of": "x", "count": 104,
+        }
+
+    monkeypatch.setattr(
+        "app.services.trade_journal.aggregates.build_trading_scoreboard",
+        fake_scoreboard,
+    )
+    out = await dh._realized_r_by_tag(db_session, "kr", None)
+    assert "untagged" not in out
+    assert "pullback_long" in out
+```
+
+- [ ] **Step 2: 실패 확인**
+
+Run: `uv run pytest tests/services/test_decision_history_realized_r.py::test_untagged_dominant_still_returns_real_tags -v`
+Expected: FAIL — `assert include_excursions is False` 또는 untagged가 슬라이스에 먹혀 pullback_long 누락
+
+- [ ] **Step 3: 구현** — `_realized_r_by_tag` 본문 교체 (라인 148-158)
+
+```python
+    from app.services.trade_journal.aggregates import build_trading_scoreboard
+
+    board = await build_trading_scoreboard(
+        db, market=market, include_excursions=False
+    )
+    groups = [g for g in board.get("groups", []) if g["tag"] != "untagged"]
+    ordered = sorted(groups, key=lambda g: (g["tag"] != setup_tag, -int(g["n"])))
+    return {g["tag"]: {k: g.get(k) for k in _R_KEYS} for g in ordered[:_MAX_TAGS]}
+```
+
+- [ ] **Step 4: 통과 확인**
+
+Run: `uv run pytest tests/services/test_decision_history_realized_r.py -v`
+Expected: PASS (신규 + 기존 `test_realized_r_by_tag_present_and_bounded` — fake는 `**kw`로 include_excursions 흡수)
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add app/services/decision_history.py tests/services/test_decision_history_realized_r.py
+git commit -m "fix(ROB-717): decision_history skips excursions + filter untagged before top-3 slice
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: minor (b) — `load_fills` smoke 필터 확장
+
+**Files:**
+- Modify: `app/services/trade_journal/aggregates.py:152-155` (`load_fills`의 `_is_smoke` 호출)
+- Test: `tests/services/test_trade_journal_aggregates_scoreboard.py`
+
+**Interfaces:**
+- Produces: `load_fills`가 `reason`/`thesis`/`strategy`/`notes` 중 하나라도 smoke 토큰을 담으면 해당 fill을 제외한다 (기존 `correlation_id`/`status`에 더해).
+
+- [ ] **Step 1: 실패 테스트 작성** — `tests/services/test_trade_journal_aggregates_scoreboard.py` 끝에 추가
+
+```python
+@pytest.mark.asyncio
+async def test_load_fills_excludes_smoke_marked_reason(db_session):
+    from datetime import UTC, datetime
+
+    from app.models.review import KISLiveOrderLedger
+
+    db_session.add(
+        KISLiveOrderLedger(
+            symbol="005930",
+            side="buy",
+            status="filled",
+            filled_qty=10,
+            avg_fill_price=100.0,
+            trade_date=datetime(2026, 6, 1, tzinfo=UTC),
+            reason="smoke-only probe do not journal",
+        )
+    )
+    await db_session.flush()
+    fills = await agg.load_fills(db_session, market="kr")
+    assert all("005930" not in f.symbol or f.price != 100.0 for f in fills)
+```
+
+Note: KISLiveOrderLedger의 다른 NOT NULL 컬럼이 있으면 최소값을 채운다 — 실패 시 에러 메시지의 컬럼명을 보고 `account_mode="kis_live"` 등 최소 필드를 추가.
+
+- [ ] **Step 2: 실패 확인**
+
+Run: `uv run pytest tests/services/test_trade_journal_aggregates_scoreboard.py::test_load_fills_excludes_smoke_marked_reason -v`
+Expected: FAIL — smoke row가 필터되지 않아 fill로 포함됨
+
+- [ ] **Step 3: 구현** — `load_fills`의 `_is_smoke` 호출 확장 (라인 152-155)
+
+```python
+            if _is_smoke(
+                getattr(r, "correlation_id", None),
+                getattr(r, "status", None),
+                getattr(r, "reason", None),
+                getattr(r, "thesis", None),
+                getattr(r, "strategy", None),
+                getattr(r, "notes", None),
+            ):
+                continue
+```
+
+- [ ] **Step 4: 통과 확인**
+
+Run: `uv run pytest tests/services/test_trade_journal_aggregates_scoreboard.py -v`
+Expected: PASS
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add app/services/trade_journal/aggregates.py tests/services/test_trade_journal_aggregates_scoreboard.py
+git commit -m "fix(ROB-717): load_fills smoke filter also checks reason/thesis/strategy/notes
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: minor (c) — `excursions_degraded` surface
+
+**Files:**
+- Modify: `app/services/trade_journal/aggregates.py:431-470` (`TradeMetrics`, `_agg_one`), `:515-528` (per-trade 루프)
+- Test: `tests/services/test_trade_journal_aggregates_scoreboard.py`
+
+**Interfaces:**
+- Consumes: Task 1의 조건부 excursions 루프.
+- Produces: `TradeMetrics(..., degraded: bool = False)`; scoreboard 그룹(및 `overall`) dict에 `excursions_degraded: int` (해당 tag에서 degraded=True인 trade 수).
+
+- [ ] **Step 1: 실패 테스트 작성** — `tests/services/test_trade_journal_aggregates_scoreboard.py` 끝에 추가
+
+```python
+def test_excursions_degraded_surfaced_in_group():
+    r1 = _tm(0.10, 2.0)
+    r2 = _tm(-0.05, -1.0)
+    r1.degraded = True  # TradeMetrics is @dataclass (not frozen) → mutable
+    [g] = aggregate_by_tag([r1, r2])
+    assert g["excursions_degraded"] == 1
+```
+
+(`TradeMetrics`는 `@dataclass`(frozen 아님)이므로 `r1.degraded = True` 가능.)
+
+- [ ] **Step 2: 실패 확인**
+
+Run: `uv run pytest tests/services/test_trade_journal_aggregates_scoreboard.py::test_excursions_degraded_surfaced_in_group -v`
+Expected: FAIL — `TradeMetrics`에 `degraded` 없음 / 그룹에 `excursions_degraded` 키 없음
+
+- [ ] **Step 3: 구현**
+
+`TradeMetrics`에 필드 추가 (라인 431-437):
+
+```python
+@dataclass
+class TradeMetrics:
+    trade: ClosedTrade
+    tag: TagInfo
+    r_multiple: float | None
+    mae: float | None
+    mfe: float | None
+    degraded: bool = False
+```
+
+`_agg_one`의 반환 dict에 카운트 추가 (`insufficient_sample` 앞):
+
+```python
+        "excursions_degraded": sum(1 for r in rows if r.degraded),
+        "insufficient_sample": n < _INSUFFICIENT_SAMPLE_N,
+```
+
+per-trade 루프에서 degraded를 잡아 저장 (Task 1이 만든 블록 교체):
+
+```python
+        mae, mfe = None, None
+        degraded = False
+        if include_excursions:
+            try:
+                mae, mfe, degraded = await compute_excursions(t)
+            except Exception:
+                mae, mfe, degraded = None, None, False
+        rows.append(
+            TradeMetrics(t, tag, compute_r_multiple(t, stop), mae, mfe, degraded)
+        )
+```
+
+- [ ] **Step 4: 통과 확인**
+
+Run: `uv run pytest tests/services/test_trade_journal_aggregates_scoreboard.py tests/services/test_trade_journal_aggregates_metrics.py -v`
+Expected: PASS (기존 `test_excursions_from_stubbed_ohlcv`도 3-tuple 유지되어 green)
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add app/services/trade_journal/aggregates.py tests/services/test_trade_journal_aggregates_scoreboard.py
+git commit -m "feat(ROB-717): surface excursions_degraded count per scoreboard group
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: minor (d) — 캐시 반환 격리(deep copy)
+
+**Files:**
+- Modify: `app/services/trade_journal/aggregates.py:1-30` (import), `:499-542` (cache hit/store)
+- Test: `tests/services/test_trade_journal_aggregates_scoreboard.py`
+
+**Interfaces:**
+- Produces: `build_trading_scoreboard`의 반환 dict를 호출자가 mutate해도 다음 호출(캐시 hit) 결과가 오염되지 않는다.
+
+- [ ] **Step 1: 실패 테스트 작성** — 파일 끝에 추가
+
+```python
+@pytest.mark.asyncio
+async def test_cache_returns_isolated_copies(db_session, monkeypatch):
+    from datetime import UTC, datetime
+
+    async def empty_load_fills(*a, **k):
+        return []
+
+    monkeypatch.setattr(agg, "load_fills", empty_load_fills)
+    stamp = datetime(2026, 7, 5, tzinfo=UTC)
+    first = await agg.build_trading_scoreboard(db_session, now=stamp)
+    first["groups"].append({"tag": "MUTANT"})
+    first["count"] = 999
+    second = await agg.build_trading_scoreboard(db_session, now=stamp)  # cache hit
+    assert second["groups"] == []
+    assert second["count"] == 0
+```
+
+- [ ] **Step 2: 실패 확인**
+
+Run: `uv run pytest tests/services/test_trade_journal_aggregates_scoreboard.py::test_cache_returns_isolated_copies -v`
+Expected: FAIL — 캐시가 동일 dict를 반환해 `second`에 MUTANT/999가 새어나옴
+
+- [ ] **Step 3: 구현**
+
+파일 상단 import에 `copy` 추가 (기존 `import uuid` 부근):
+
+```python
+import copy
+import uuid
+```
+
+cache hit 반환을 copy로 (라인 502-504):
+
+```python
+    if use_cache:
+        cached = _scoreboard_cache.get(key)
+        if cached and stamp - cached[0] < _SCOREBOARD_TTL_SECONDS:
+            return copy.deepcopy(cached[1])
+```
+
+store + 최종 반환도 격리 (라인 540-542 교체):
+
+```python
+    if use_cache:
+        _scoreboard_cache[key] = (stamp, copy.deepcopy(result))
+    return result
+```
+
+- [ ] **Step 4: 통과 확인**
+
+Run: `uv run pytest tests/services/test_trade_journal_aggregates_scoreboard.py -v`
+Expected: PASS
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add app/services/trade_journal/aggregates.py tests/services/test_trade_journal_aggregates_scoreboard.py
+git commit -m "fix(ROB-717): deep-copy scoreboard cache returns to isolate callers
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: minor (e) — 빈-DB 스코어보드 tool 테스트 hermetic화
+
+**Files:**
+- Modify: `tests/test_mcp_trading_scoreboard.py`
+
+**Interfaces:**
+- Consumes: `get_trading_scoreboard` (MCP tool, 시그니처 불변).
+- Produces: 테스트가 공유 CI DB 상태·네트워크(`get_ohlcv`)에 의존하지 않고 tool 응답 shape만 검증.
+
+- [ ] **Step 1: 테스트 재작성 (실패 상태로)** — `tests/test_mcp_trading_scoreboard.py` 전체 교체
+
+```python
+import pytest
+
+import app.mcp_server.tooling.trading_scoreboard_tools as tool
+
+
+@pytest.mark.asyncio
+async def test_scoreboard_tool_shape_hermetic(monkeypatch):
+    async def fake_board(db, **kw):
+        return {"groups": [], "overall": None, "as_of": "x", "count": 0}
+
+    monkeypatch.setattr(tool, "build_trading_scoreboard", fake_board)
+    result = await tool.get_trading_scoreboard()
+    assert set(result) >= {"groups", "overall", "as_of", "count"}
+    assert result["groups"] == []
+    assert result["count"] == 0
+```
+
+- [ ] **Step 2: 실패→통과 확인 (구현은 mock 배선뿐)**
+
+Run: `uv run pytest tests/test_mcp_trading_scoreboard.py -v`
+Expected: PASS (mock이 실 DB·네트워크를 차단; `build_trading_scoreboard`가 tool 모듈 네임스페이스에 import되어 있어 patch 가능)
+
+만약 `AttributeError: build_trading_scoreboard`가 나면 `trading_scoreboard_tools.py`가 이미 `from ... import build_trading_scoreboard`(라인 12)로 심볼을 모듈에 바인딩하므로 patch 대상은 `tool.build_trading_scoreboard`가 맞다 — 경로 확인.
+
+- [ ] **Step 3: 커밋**
+
+```bash
+git add tests/test_mcp_trading_scoreboard.py
+git commit -m "test(ROB-717): make empty-db scoreboard tool test hermetic (no shared DB / no network)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 7: 통합 검증 — 전체 스위트 + 안전 가드 + read-path 무네트워크 실측
+
+**Files:** (검증 전용, 코드 변경 없음)
+
+- [ ] **Step 1: 소유 파일 관련 스위트 전체**
+
+Run:
+```bash
+uv run pytest tests/services/test_trade_journal_aggregates_scoreboard.py \
+  tests/services/test_trade_journal_aggregates_metrics.py \
+  tests/services/test_decision_history_realized_r.py \
+  tests/test_mcp_trading_scoreboard.py -v
+```
+Expected: 전부 PASS
+
+- [ ] **Step 2: import-경계 가드 (ROB-716 안전 테스트) 회귀 확인**
+
+Run: `uv run pytest tests/test_invest_view_model_safety.py -v`
+Expected: PASS — `decision_history` import가 여전히 broker/market-data 체인을 끌어오지 않음 (lazy import 유지)
+
+- [ ] **Step 3: lint / typecheck**
+
+Run: `make lint`
+Expected: clean (Ruff + ty). 실패 시 해당 파일만 교정 후 재실행.
+
+- [ ] **Step 4: read-path 무네트워크 실측 (성공 기준)**
+
+decision_history가 `include_excursions=False`로 호출하는지 + `get_ohlcv`가 호출되지 않는지를 스위트로 이미 검증(Task 1·2). 추가로 `_realized_r_by_tag`가 실제로 excursions를 스킵함을 로컬에서 재확인:
+
+Run:
+```bash
+uv run pytest tests/services/test_decision_history_realized_r.py::test_untagged_dominant_still_returns_real_tags -v
+```
+Expected: PASS (fake_scoreboard의 `assert include_excursions is False`가 read-path 계약을 강제)
+
+- [ ] **Step 5: 최종 커밋 (필요 시)** — Step 3에서 교정이 있었다면만
+
+```bash
+git add -A && git commit -m "chore(ROB-717): lint/typecheck fixups
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Self-Review (작성자 체크)
+
+- **Spec coverage:** Part 1a/1b→Task 1, 1c→Task 2, 1d(MCP 기본 True 유지)→Task 1(불변)+Task 6. minor (a)→Task 2, (b)→Task 3, (c)→Task 4, (d)→Task 5, (e)→Task 6. 성공 기준(3s 수렴·네트워크 0)→Task 1·2 테스트 + Task 7 Step 4. 전부 매핑됨.
+- **Placeholder scan:** 모든 code step에 실제 코드 포함. "적절한 처리" 류 없음.
+- **Type consistency:** `include_excursions=True` 기본값이 Task 1·2·6에서 일관. `TradeMetrics.degraded: bool = False`가 Task 4에서 정의되고 기존 `_tm`(degraded 미지정)과 호환. `excursions_degraded: int` 키 이름이 Task 4 내에서 일관. `compute_excursions` 3-tuple 유지 — Global Constraints·Task 1·4에서 일관.

--- a/docs/superpowers/specs/2026-07-05-rob-717-decision-history-scoreboard-fanout-design.md
+++ b/docs/superpowers/specs/2026-07-05-rob-717-decision-history-scoreboard-fanout-design.md
@@ -1,0 +1,132 @@
+# ROB-717 — decision_history→scoreboard 팬아웃 성능 완화 + ROB-713 검증 minor 일괄
+
+**Date:** 2026-07-05
+**Status:** Design approved
+**Scope:** backend only, migration 0
+**Owned files:** `app/services/trade_journal/aggregates.py`, `app/services/decision_history.py` (+ tests), `tests/test_mcp_trading_scoreboard.py`
+
+## 배경
+
+ROB-711의 `build_decision_context`가 `realized_r_by_tag`를 채우려고 cache-miss마다
+`build_trading_scoreboard(market)`를 호출한다 (`decision_history.py:148-150`, lazy import).
+이 함수(`aggregates.py::build_trading_scoreboard`)는:
+
+1. 3개 라이브 레저 전체 스캔 (`load_fills`)
+2. closed-trade당 태그/스톱 쿼리 (`resolve_setup_tag`, `planned_stop_for` — 각 ~5 쿼리)
+3. closed-trade당 일봉 OHLCV 조회 (`compute_excursions` → `get_ohlcv`) — **DB miss 시 브로커
+   네트워크 폴백(Yahoo/Toss/KIS/Upbit)**
+
+decision_history는 /invest 종목상세에서 3.0s optional-block timeout 아래에 있다
+(`stock_detail_service.py:417-431`). 종결 거래가 쌓이면 TTL(300s) 만료 후 첫 호출이
+timeout을 초과 → `decision_history_timeout` 경고와 함께 블록이 5분마다 간헐 소실.
+MCP 주입 경로(`analyze_stock_batch`)도 같은 비용. 지금은 거래 수가 적어 안 터지지만 구조적
+(ROB-699~702 /invest 슬로우니스 계열의 잠복 병목).
+
+decision_history 주입에는 **realized R·expectancy만** 필요하고 MAE/MFE는 쓰지 않는다
+(MAE는 scoreboard MCP·웹 표면에서만 소비).
+
+## 결정 사항 (사용자 승인)
+
+- **팬아웃 완화: Option A** — `include_excursions` 파라미터로 decision_history 경로에서
+  excursions 계산 자체를 스킵. scoreboard MCP·웹은 기본 True 유지(MAE 정확도 보존).
+- **minor (c) degraded 플래그: Surface** — scoreboard 그룹에 `excursions_degraded` 카운트 추가.
+
+## Part 1 — 팬아웃 완화 (Option A)
+
+### 1a. `build_trading_scoreboard(..., include_excursions: bool = True)`
+
+- 새 keyword 파라미터, 기본 `True` (백컴팻).
+- `include_excursions=False`이면 per-trade 루프에서 `compute_excursions` 호출을 **완전히
+  생략** → `get_ohlcv` 호출 0. 해당 trade의 `mae`/`mfe`는 `None`.
+- `_agg_one`은 빈 MAE/MFE 리스트에서 자연히 `avg_mae=None`, `avg_mfe=None`, `worst_mae=None`,
+  `excursions_degraded=0`을 반환한다 (기존 `if maes else None` 가드가 이미 처리).
+
+### 1b. Cache key에 `include_excursions` 포함 (정합성 필수)
+
+- 현재 캐시 키: `(market, account_mode, date_from, date_to, setup_tag, min_sample)`.
+- `include_excursions`를 키에 추가한다. 그렇지 않으면 no-excursions 결과(MAE 없음)가
+  MCP 호출자(MAE 원함)에게 서빙되거나 그 반대가 발생.
+
+### 1c. `decision_history._realized_r_by_tag` 호출 변경
+
+- `build_trading_scoreboard(db, market=market, include_excursions=False)`로 호출.
+- 이 경로는 3s timeout 아래 read-path → **브로커 네트워크 호출 0, OHLCV 0**.
+- `_R_KEYS`의 `avg_mae`는 이제 항상 `None` (주입 목적상 허용 — MAE는 scoreboard 표면 전용).
+
+### 1d. MCP/웹 경로 불변
+
+- `get_trading_scoreboard` MCP tool (`trading_scoreboard_tools.py`)은 기본 `True` → MAE
+  그대로 계산·정확.
+
+## Part 2 — minor 체크리스트 5건 (전부 소유 파일 내)
+
+### (a) top-3 슬라이스 순서 교정 — `decision_history.py:151-158`
+
+현재: `sorted(...)` → `[:_MAX_TAGS]` 슬라이스 → 루프 안에서 `untagged` skip.
+→ untagged가 상위에 있으면 3개 미만/0개 반환 가능.
+**Fix:** untagged를 슬라이스 **전에** 제거하고, 그 다음 정렬·슬라이스.
+
+```python
+groups = [g for g in board.get("groups", []) if g["tag"] != "untagged"]
+ordered = sorted(groups, key=lambda g: (g["tag"] != setup_tag, -int(g["n"])))
+out = {g["tag"]: {k: g.get(k) for k in _R_KEYS} for g in ordered[:_MAX_TAGS]}
+```
+
+### (b) `load_fills` smoke 필터 확장 — `aggregates.py:152-155`
+
+현재 `_is_smoke(correlation_id, status)`만 검사. `toss_live_smoke.py:88`은 `reason`에 마킹.
+3개 레저 모델 모두 `reason`/`thesis`/`strategy`/`notes` 컬럼 보유 (review.py 확인).
+**Fix:** `_is_smoke(correlation_id, status, reason, thesis, strategy, notes)` (getattr 방어).
+fill-gated라 저위험이나 부분체결 스모크 누수 방지.
+
+### (c) `compute_excursions` degraded surface — `aggregates.py:396-528`
+
+현재 `mae, mfe, _degraded = await compute_excursions(t)` — `degraded` 계산되고 버려짐.
+**Fix (Surface):**
+- `TradeMetrics`에 `degraded: bool` 필드 추가.
+- 루프에서 `degraded`를 `TradeMetrics`에 저장 (스킵 시 `False`).
+- `_agg_one`에서 그룹별 `excursions_degraded = sum(1 for r in rows if r.degraded)` 노출.
+- `overall`에도 동일 반영 (`_agg_one("__overall__", rows)`가 이미 rows 전체를 받음).
+
+### (d) 모듈 캐시 공유 mutable dict — `aggregates.py:501-504, 540-542`
+
+현재 `_scoreboard_cache`가 동일 dict 객체를 반환 → 호출자가 mutate 시 캐시 오염.
+**Fix:** 캐시 hit·store 시 `copy.deepcopy`로 격리 (반환값도 매번 새 객체).
+
+### (e) `test_scoreboard_tool_empty_db_shape` hermetic화 — `tests/test_mcp_trading_scoreboard.py`
+
+현재 실 `AsyncSessionLocal` 사용 → 공유 CI DB에 다른 스위트가 fill을 commit하면
+`count==0`/`groups==[]` 가정이 flake + 실 `get_ohlcv` 발화(네트워크).
+**Fix:** `build_trading_scoreboard`를 tool 경계에서 mock하여 shape만 단언(`{"groups",
+"overall", "as_of", "count"}` 부분집합), DB·네트워크 비의존.
+
+## 테스트
+
+**신규 (aggregates):**
+- `include_excursions=False` 경로: `get_ohlcv`를 patch하여 **호출 0** 단언 + realized-R
+  그룹은 여전히 반환.
+- Cache key 분리: 동일 인자에 `include_excursions` True/False가 서로 오염 안 됨.
+- (b): `reason`에 smoke 마킹된 fill row가 필터됨.
+- (c): 200일 초과 span trade가 `excursions_degraded` 카운트에 반영.
+- (d): 반환 dict를 mutate해도 두 번째 호출 결과 불변.
+
+**신규 (decision_history):**
+- (a): untagged가 지배적일 때도 태그 맵이 실 태그를 반환(3개 미만이면 있는 만큼).
+- `_realized_r_by_tag`가 `include_excursions=False`로 호출하는지 확인(mock spy).
+
+**수정 (e):** hermetic 재작성.
+
+**로컬 성공 기준 검증:** 종목상세 cache-miss decision_history 호출이 3s 내 안정 수렴,
+read-path 브로커 네트워크 호출 0 (실측/로그 확인).
+
+## 성공 기준 (이슈)
+
+- [ ] /invest 종목상세 cache-miss 첫 호출이 3s timeout 안에 안정 수렴, read-path 브로커
+  네트워크 호출 0.
+- [ ] minor 체크리스트 5건 정리.
+
+## Non-goals
+
+- insights 판단성적표 group_by=setup 컬럼 확장 → ROB-715 계열(웹). 이 이슈 아님.
+- `decision_history.py`/`aggregates.py`는 이 이슈 소유; ROB-715는 소비만.
+- 스키마 변경 없음 (migration 0).

--- a/tests/services/test_decision_history_realized_r.py
+++ b/tests/services/test_decision_history_realized_r.py
@@ -93,3 +93,28 @@ async def test_realized_r_by_tag_present_and_bounded(db_session, monkeypatch):
             "avg_mae",
             "insufficient_sample",
         }
+
+
+@pytest.mark.asyncio
+async def test_untagged_dominant_still_returns_real_tags(db_session, monkeypatch):
+    import app.services.decision_history as dh
+
+    async def fake_scoreboard(db, *, market=None, include_excursions=True, **kw):
+        assert include_excursions is False  # read-path must skip excursions
+        return {
+            "groups": [
+                {"tag": "untagged", "n": 99, "expectancy_r": 0.0, "win_rate": 0.0,
+                 "profit_factor": None, "avg_mae": None, "insufficient_sample": False},
+                {"tag": "pullback_long", "n": 5, "expectancy_r": 1.2, "win_rate": 0.6,
+                 "profit_factor": 2.0, "avg_mae": -0.02, "insufficient_sample": True},
+            ],
+            "overall": None, "as_of": "x", "count": 104,
+        }
+
+    monkeypatch.setattr(
+        "app.services.trade_journal.aggregates.build_trading_scoreboard",
+        fake_scoreboard,
+    )
+    out = await dh._realized_r_by_tag(db_session, "kr", None)
+    assert "untagged" not in out
+    assert "pullback_long" in out

--- a/tests/services/test_decision_history_realized_r.py
+++ b/tests/services/test_decision_history_realized_r.py
@@ -103,12 +103,28 @@ async def test_untagged_dominant_still_returns_real_tags(db_session, monkeypatch
         assert include_excursions is False  # read-path must skip excursions
         return {
             "groups": [
-                {"tag": "untagged", "n": 99, "expectancy_r": 0.0, "win_rate": 0.0,
-                 "profit_factor": None, "avg_mae": None, "insufficient_sample": False},
-                {"tag": "pullback_long", "n": 5, "expectancy_r": 1.2, "win_rate": 0.6,
-                 "profit_factor": 2.0, "avg_mae": -0.02, "insufficient_sample": True},
+                {
+                    "tag": "untagged",
+                    "n": 99,
+                    "expectancy_r": 0.0,
+                    "win_rate": 0.0,
+                    "profit_factor": None,
+                    "avg_mae": None,
+                    "insufficient_sample": False,
+                },
+                {
+                    "tag": "pullback_long",
+                    "n": 5,
+                    "expectancy_r": 1.2,
+                    "win_rate": 0.6,
+                    "profit_factor": 2.0,
+                    "avg_mae": -0.02,
+                    "insufficient_sample": True,
+                },
             ],
-            "overall": None, "as_of": "x", "count": 104,
+            "overall": None,
+            "as_of": "x",
+            "count": 104,
         }
 
     monkeypatch.setattr(

--- a/tests/services/test_trade_journal_aggregates_scoreboard.py
+++ b/tests/services/test_trade_journal_aggregates_scoreboard.py
@@ -142,3 +142,20 @@ def test_excursions_degraded_surfaced_in_group():
     r1.degraded = True  # TradeMetrics is @dataclass (not frozen) → mutable
     [g] = aggregate_by_tag([r1, r2])
     assert g["excursions_degraded"] == 1
+
+
+@pytest.mark.asyncio
+async def test_cache_returns_isolated_copies(db_session, monkeypatch):
+    from datetime import UTC, datetime
+
+    async def empty_load_fills(*a, **k):
+        return []
+
+    monkeypatch.setattr(agg, "load_fills", empty_load_fills)
+    stamp = datetime(2026, 7, 5, tzinfo=UTC)
+    first = await agg.build_trading_scoreboard(db_session, now=stamp)
+    first["groups"].append({"tag": "MUTANT"})
+    first["count"] = 999
+    second = await agg.build_trading_scoreboard(db_session, now=stamp)  # cache hit
+    assert second["groups"] == []
+    assert second["count"] == 0

--- a/tests/services/test_trade_journal_aggregates_scoreboard.py
+++ b/tests/services/test_trade_journal_aggregates_scoreboard.py
@@ -109,3 +109,28 @@ async def test_include_excursions_in_cache_key(db_session, monkeypatch):
     )
     # distinct cache keys → load_fills ran twice, not served from one cache slot
     assert calls["n"] == 2
+
+
+@pytest.mark.asyncio
+async def test_load_fills_excludes_smoke_marked_reason(db_session):
+    from datetime import UTC, datetime
+
+    from app.models.review import KISLiveOrderLedger
+
+    db_session.add(
+        KISLiveOrderLedger(
+            symbol="005930",
+            instrument_type="equity_kr",
+            side="buy",
+            order_type="limit",
+            status="filled",
+            lifecycle_state="fill",
+            filled_qty=10,
+            avg_fill_price=100.0,
+            trade_date=datetime(2026, 6, 1, tzinfo=UTC),
+            reason="smoke-only probe do not journal",
+        )
+    )
+    await db_session.flush()
+    fills = await agg.load_fills(db_session, market="kr")
+    assert all("005930" not in f.symbol or f.price != 100.0 for f in fills)

--- a/tests/services/test_trade_journal_aggregates_scoreboard.py
+++ b/tests/services/test_trade_journal_aggregates_scoreboard.py
@@ -134,3 +134,11 @@ async def test_load_fills_excludes_smoke_marked_reason(db_session):
     await db_session.flush()
     fills = await agg.load_fills(db_session, market="kr")
     assert all("005930" not in f.symbol or f.price != 100.0 for f in fills)
+
+
+def test_excursions_degraded_surfaced_in_group():
+    r1 = _tm(0.10, 2.0)
+    r2 = _tm(-0.05, -1.0)
+    r1.degraded = True  # TradeMetrics is @dataclass (not frozen) → mutable
+    [g] = aggregate_by_tag([r1, r2])
+    assert g["excursions_degraded"] == 1

--- a/tests/services/test_trade_journal_aggregates_scoreboard.py
+++ b/tests/services/test_trade_journal_aggregates_scoreboard.py
@@ -70,3 +70,42 @@ async def test_scoreboard_fail_open_on_ohlcv_error(db_session, monkeypatch):
     result = await agg.build_trading_scoreboard(db_session, use_cache=False)
     assert result["count"] == 0
     assert result["groups"] == []
+
+
+@pytest.mark.asyncio
+async def test_include_excursions_false_skips_ohlcv(db_session, monkeypatch):
+    called = False
+
+    async def spy_get_ohlcv(*a, **k):
+        nonlocal called
+        called = True
+        return []
+
+    monkeypatch.setattr(agg, "get_ohlcv", spy_get_ohlcv)
+    # market=None, empty CI-owned rows are fine; the assertion is on the call, not counts
+    await agg.build_trading_scoreboard(
+        db_session, use_cache=False, include_excursions=False
+    )
+    assert called is False
+
+
+@pytest.mark.asyncio
+async def test_include_excursions_in_cache_key(db_session, monkeypatch):
+    from datetime import UTC, datetime
+
+    calls = {"n": 0}
+
+    async def counting_load_fills(*a, **k):
+        calls["n"] += 1
+        return []
+
+    monkeypatch.setattr(agg, "load_fills", counting_load_fills)
+    stamp = datetime(2026, 7, 5, tzinfo=UTC)
+    await agg.build_trading_scoreboard(
+        db_session, include_excursions=True, now=stamp
+    )
+    await agg.build_trading_scoreboard(
+        db_session, include_excursions=False, now=stamp
+    )
+    # distinct cache keys → load_fills ran twice, not served from one cache slot
+    assert calls["n"] == 2

--- a/tests/services/test_trade_journal_aggregates_scoreboard.py
+++ b/tests/services/test_trade_journal_aggregates_scoreboard.py
@@ -101,12 +101,8 @@ async def test_include_excursions_in_cache_key(db_session, monkeypatch):
 
     monkeypatch.setattr(agg, "load_fills", counting_load_fills)
     stamp = datetime(2026, 7, 5, tzinfo=UTC)
-    await agg.build_trading_scoreboard(
-        db_session, include_excursions=True, now=stamp
-    )
-    await agg.build_trading_scoreboard(
-        db_session, include_excursions=False, now=stamp
-    )
+    await agg.build_trading_scoreboard(db_session, include_excursions=True, now=stamp)
+    await agg.build_trading_scoreboard(db_session, include_excursions=False, now=stamp)
     # distinct cache keys → load_fills ran twice, not served from one cache slot
     assert calls["n"] == 2
 

--- a/tests/test_mcp_trading_scoreboard.py
+++ b/tests/test_mcp_trading_scoreboard.py
@@ -1,11 +1,15 @@
 import pytest
 
-from app.mcp_server.tooling.trading_scoreboard_tools import get_trading_scoreboard
+import app.mcp_server.tooling.trading_scoreboard_tools as tool
 
 
 @pytest.mark.asyncio
-async def test_scoreboard_tool_empty_db_shape():
-    result = await get_trading_scoreboard()
+async def test_scoreboard_tool_shape_hermetic(monkeypatch):
+    async def fake_board(db, **kw):
+        return {"groups": [], "overall": None, "as_of": "x", "count": 0}
+
+    monkeypatch.setattr(tool, "build_trading_scoreboard", fake_board)
+    result = await tool.get_trading_scoreboard()
     assert set(result) >= {"groups", "overall", "as_of", "count"}
-    assert result["count"] == 0
     assert result["groups"] == []
+    assert result["count"] == 0


### PR DESCRIPTION
## Summary

- **decision_history read-path가 3s timeout 안에 안정 수렴**하도록 scoreboard 팬아웃에서 OHLCV/브로커 호출을 제거
- ROB-713 검증 minor 5건 정리

## Changes

### Fanout mitigation (read-path network=0)
- `build_trading_scoreboard(..., include_excursions: bool = True)` — `False`면 per-trade `compute_excursions`/`get_ohlcv` 완전 스킵, cache key에 포함되어 True/False 결과 분리 캐시
- `_realized_r_by_tag`가 `include_excursions=False`로 호출 + `untagged`를 top-3 슬라이스 **전에** 제거 (slicing이 untagged를 먹어 real tag 누락되던 버그 차단)

### Minor cleanups
- `load_fills` smoke 필터: `reason`/`thesis`/`strategy`/`notes` 추가 검사
- `TradeMetrics.degraded: bool = False` 필드 + 그룹 dict에 `excursions_degraded: int` 표면화
- scoreboard 캐시 반환 deep copy (호출자 mutation 격리)
- MCP scoreboard tool 테스트 hermetic화 (공유 CI DB / 네트워크 의존 제거)

## Verification

- `tests/services/test_trade_journal_aggregates_scoreboard.py` — 8 passed (기존 3 + 신규 5)
- `tests/services/test_trade_journal_aggregates_metrics.py` — 3 passed (compute_excursions 3-tuple 시그니처 유지)
- `tests/services/test_decision_history_realized_r.py` — 2 passed
- `tests/test_mcp_trading_scoreboard.py` — 1 passed (hermetic)
- `tests/test_invest_view_model_safety.py` — 2 passed (lazy import 회귀 없음)
- `uv run ruff check app/ tests/` — clean
- `uv run ruff format --check app/ tests/` — clean
- `uv run ty check app/ --error-on-warning` — clean

## Migration

**None.** 백엔드 전용, schema 변경 0.

## Plan

- docs/superpowers/plans/2026-07-05-rob-717-decision-history-scoreboard-fanout.md (7 tasks, all completed)