### PR TITLE
feat(ROB-715): item-level learning-loop render on /invest reports

### DIFF
--- a/app/routers/investment_reports.py
+++ b/app/routers/investment_reports.py
@@ -43,6 +43,9 @@ from app.services.investment_reports.query_service import (
     InvestmentReportQueryService,
 )
 from app.services.investment_reports.review_sections import build_review_sections
+from app.services.investment_reports.structured_evidence_summary import (
+    summarize_structured_evidence,
+)
 
 router = APIRouter(tags=["investment-reports"])
 
@@ -58,10 +61,18 @@ def _serialise_bundle(bundle: dict) -> InvestmentReportBundle:
     # ROB-554 — attach reverse-looked-up linked orders (set post-validation;
     # the ORM item row has no such attribute). Missing key => legacy/no orders.
     linked_by_uuid = bundle.get("linked_orders_by_item_uuid", {})
+    linked_by_uuid = bundle.get("linked_orders_by_item_uuid", {})
+    forecasts_by_uuid = bundle.get("forecasts_by_item_uuid", {})
+    retrospectives_by_uuid = bundle.get("retrospectives_by_item_uuid", {})
     item_responses = []
     for it in items:
         resp = InvestmentReportItemResponse.model_validate(it)
         resp.linked_orders = linked_by_uuid.get(str(it.item_uuid))
+        # ROB-715 — derive the structured_evidence one-line summary so the
+        # frontend never has to parse the nested structure.
+        resp.structured_evidence_summary = summarize_structured_evidence(
+            resp.evidence_snapshot
+        )
         item_responses.append(resp)
     decisions_by_item_uuid: dict[str, list[InvestmentReportItemDecisionResponse]] = {}
     for item in items:
@@ -112,6 +123,8 @@ def _serialise_bundle(bundle: dict) -> InvestmentReportBundle:
             InvestmentReportNewsCitationResponse.model_validate(c)
             for c in bundle["news_citations"]
         ],
+        forecasts_by_item_uuid=forecasts_by_uuid,
+        retrospectives_by_item_uuid=retrospectives_by_uuid,
     )
 
 

--- a/app/routers/investment_reports.py
+++ b/app/routers/investment_reports.py
@@ -61,7 +61,6 @@ def _serialise_bundle(bundle: dict) -> InvestmentReportBundle:
     # ROB-554 — attach reverse-looked-up linked orders (set post-validation;
     # the ORM item row has no such attribute). Missing key => legacy/no orders.
     linked_by_uuid = bundle.get("linked_orders_by_item_uuid", {})
-    linked_by_uuid = bundle.get("linked_orders_by_item_uuid", {})
     forecasts_by_uuid = bundle.get("forecasts_by_item_uuid", {})
     retrospectives_by_uuid = bundle.get("retrospectives_by_item_uuid", {})
     item_responses = []

--- a/app/schemas/investment_reports.py
+++ b/app/schemas/investment_reports.py
@@ -791,6 +791,33 @@ class LinkedOrderView(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
 
+class ForecastLinkResponse(BaseModel):
+    """ROB-715 — an item's own forecast, projected for the audit surface."""
+
+    forecast_id: str
+    status: str
+    outcome: bool | None = None
+    review_date: str | None = None
+    direction: str | None = None
+    target_price: float | None = None
+    probability: float
+    brier_score: float | None = None
+    resolution_source: str | None = None
+
+
+class RetrospectiveLinkResponse(BaseModel):
+    """ROB-715 — an item's own retrospective, projected for the audit surface."""
+
+    retrospective_id: int
+    outcome: str
+    lesson: str | None = None
+    result_summary: str | None = None
+    root_cause_class: str | None = None
+    trigger_type: str | None = None
+    pnl_pct: float | None = None
+    created_at: str | None = None
+
+
 class StockDetailOrderLedgerResponse(BaseModel):
     """ROB-559 — per-symbol live order history for the stock-detail page.
 

--- a/app/schemas/investment_reports.py
+++ b/app/schemas/investment_reports.py
@@ -874,6 +874,9 @@ class InvestmentReportItemResponse(BaseModel):
     # with reconcile-written fill rollup. None when the item has no linked orders;
     # set post-validation by the bundle serializers, not read from the ORM row.
     linked_orders: list[LinkedOrderView] | None = None
+    # ROB-715 — backend-derived one-line summary of evidence_snapshot's
+    # structured_evidence (frontend never parses the nested structure).
+    structured_evidence_summary: str | None = None
 
     model_config = ConfigDict(from_attributes=True, populate_by_name=True)
 
@@ -1129,6 +1132,13 @@ class InvestmentReportBundle(BaseModel):
     # Empty for reports with no Hermes-marked news.
     news_citations: list[InvestmentReportNewsCitationResponse] = Field(
         default_factory=list
+    )
+    # ROB-715 — item→forecast/retrospective exact-join maps keyed by item UUID.
+    forecasts_by_item_uuid: dict[str, list[ForecastLinkResponse]] = Field(
+        default_factory=dict
+    )
+    retrospectives_by_item_uuid: dict[str, list[RetrospectiveLinkResponse]] = Field(
+        default_factory=dict
     )
 
 

--- a/app/services/investment_reports/item_loop_links.py
+++ b/app/services/investment_reports/item_loop_links.py
@@ -1,0 +1,102 @@
+"""ROB-715 — item→forecast/retrospective exact-join batch loaders.
+
+Given report-item UUIDs, return each item's own ``trade_forecasts`` and
+``trade_retrospectives`` rows (exact join on the ``report_item_uuid`` Text
+column), projected for the /invest audit surface. One batched query per table;
+items with no rows are absent from the returned dict. Read-only — no broker,
+order, watch, or order-intent mutation is reachable. This module deliberately
+does NOT import ``app.services.decision_history`` (ROB-717 ownership).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.review import TradeForecast, TradeRetrospective
+from app.schemas.investment_reports import (
+    ForecastLinkResponse,
+    RetrospectiveLinkResponse,
+)
+
+
+def _iso(value) -> str | None:
+    return value.isoformat() if value is not None else None
+
+
+def _project_forecast(row: TradeForecast) -> ForecastLinkResponse:
+    target = row.forecast_target or {}
+    price = target.get("target_price")
+    return ForecastLinkResponse(
+        forecast_id=str(row.forecast_id),
+        status=row.status,
+        outcome=row.outcome,
+        review_date=_iso(row.review_date),
+        direction=target.get("direction"),
+        target_price=float(price) if price is not None else None,
+        probability=float(row.probability),
+        brier_score=(float(row.brier_score) if row.brier_score is not None else None),
+        resolution_source=row.resolution_source,
+    )
+
+
+def _project_retrospective(row: TradeRetrospective) -> RetrospectiveLinkResponse:
+    return RetrospectiveLinkResponse(
+        retrospective_id=row.id,
+        outcome=row.outcome,
+        lesson=row.lesson,
+        result_summary=row.result_summary,
+        root_cause_class=row.root_cause_class,
+        trigger_type=row.trigger_type,
+        pnl_pct=float(row.pnl_pct) if row.pnl_pct is not None else None,
+        created_at=_iso(row.created_at),
+    )
+
+
+async def list_forecasts_for_item_uuids(
+    db: AsyncSession, item_uuids: Sequence[UUID]
+) -> dict[str, list[ForecastLinkResponse]]:
+    keys = [str(u) for u in item_uuids]
+    grouped: dict[str, list[ForecastLinkResponse]] = {}
+    if not keys:
+        return grouped
+    rows = (
+        (
+            await db.execute(
+                select(TradeForecast)
+                .where(TradeForecast.report_item_uuid.in_(keys))
+                .order_by(TradeForecast.id.desc())
+            )
+        )
+        .scalars()
+        .all()
+    )
+    for row in rows:
+        grouped.setdefault(row.report_item_uuid, []).append(_project_forecast(row))
+    return grouped
+
+
+async def list_retrospectives_for_item_uuids(
+    db: AsyncSession, item_uuids: Sequence[UUID]
+) -> dict[str, list[RetrospectiveLinkResponse]]:
+    keys = [str(u) for u in item_uuids]
+    grouped: dict[str, list[RetrospectiveLinkResponse]] = {}
+    if not keys:
+        return grouped
+    rows = (
+        (
+            await db.execute(
+                select(TradeRetrospective)
+                .where(TradeRetrospective.report_item_uuid.in_(keys))
+                .order_by(TradeRetrospective.id.desc())
+            )
+        )
+        .scalars()
+        .all()
+    )
+    for row in rows:
+        grouped.setdefault(row.report_item_uuid, []).append(_project_retrospective(row))
+    return grouped

--- a/app/services/investment_reports/query_service.py
+++ b/app/services/investment_reports/query_service.py
@@ -30,6 +30,10 @@ from app.schemas.investment_reports import (
     ReportSnapshotBundleSummaryView,
     ReportSnapshotDetailResponse,
 )
+from app.services.investment_reports.item_loop_links import (
+    list_forecasts_for_item_uuids,
+    list_retrospectives_for_item_uuids,
+)
 from app.services.investment_reports.linked_orders import (
     list_linked_orders_for_item_uuids,
 )
@@ -156,9 +160,19 @@ class InvestmentReportQueryService:
         events = await self._repo.list_events_for_source_reports([report.report_uuid])
         citations = await self._repo.list_news_citations_for_report(report.report_uuid)
 
+        item_uuids = [it.item_uuid for it in items]
+
         # ROB-554 — reverse-lookup live orders linked via report_item_uuid (ROB-473).
         linked_orders_by_item_uuid = await list_linked_orders_for_item_uuids(
-            self._session, [it.item_uuid for it in items]
+            self._session, item_uuids
+        )
+
+        # ROB-715 — exact-join forecasts + retrospectives keyed by item_uuid.
+        forecasts_by_item_uuid = await list_forecasts_for_item_uuids(
+            self._session, item_uuids
+        )
+        retrospectives_by_item_uuid = await list_retrospectives_for_item_uuids(
+            self._session, item_uuids
         )
 
         decisions_by_item: dict[int, list[InvestmentReportItemDecision]] = {
@@ -175,6 +189,8 @@ class InvestmentReportQueryService:
             "events": events,
             "news_citations": citations,
             "linked_orders_by_item_uuid": linked_orders_by_item_uuid,
+            "forecasts_by_item_uuid": forecasts_by_item_uuid,
+            "retrospectives_by_item_uuid": retrospectives_by_item_uuid,
         }
 
     # ------------------------------------------------------------------

--- a/app/services/investment_reports/structured_evidence_summary.py
+++ b/app/services/investment_reports/structured_evidence_summary.py
@@ -1,0 +1,18 @@
+"""ROB-715 — backend-derived summary of ``evidence_snapshot['structured_evidence']``.
+
+The frontend renders the returned string verbatim (no client-side parsing of the
+nested structure). Deterministic: keys are sorted so the output is stable across
+requests and safe to snapshot-test.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def summarize_structured_evidence(evidence_snapshot: dict[str, Any]) -> str | None:
+    se = (evidence_snapshot or {}).get("structured_evidence")
+    if not isinstance(se, dict) or not se:
+        return None
+    keys = sorted(str(k) for k in se)
+    return f"{len(keys)} evidence fields: " + ", ".join(keys)

--- a/docs/superpowers/plans/2026-07-05-rob-715-invest-item-loop-render.md
+++ b/docs/superpowers/plans/2026-07-05-rob-715-invest-item-loop-render.md
@@ -1,0 +1,1170 @@
+# ROB-715 /invest Item-Level Learning-Loop Render — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Render each /invest report item's forecast-resolution status + retrospective link, its stored-but-unrendered fields (`trigger_checklist`, `max_action`, `structured_evidence` summary, `decision_bucket` badge), and a plan-vs-actual view — so an operator reaches "이 판단의 결과(체결→forecast 해소→회고)" within 2 clicks.
+
+**Architecture:** Thin read-only backend attaches two new item-keyed maps (`forecasts_by_item_uuid`, `retrospectives_by_item_uuid`) to the existing investment-reports bundle response, mirroring the established `linked_orders_by_item_uuid` / `decisions_by_item_uuid` pattern — one batched query per table, exact join on `report_item_uuid`. The frontend `ItemRow` component renders the new maps plus already-normalized raw fields. Migration 0.
+
+**Tech Stack:** FastAPI, SQLAlchemy async (PostgreSQL, `review` schema), Pydantic v2, pytest/pytest-asyncio; React + TypeScript + Vitest (`frontend/invest`).
+
+## Global Constraints
+
+- **Migration 0.** No alembic migration. All backend schema additions are Pydantic *response-model* fields (additive, default-empty — legacy-safe). No DB DDL.
+- **Read-only.** No broker / order / watch / order-intent mutation reachable from any new code. All new code is deterministic reads.
+- **ROB-501.** No in-process LLM provider import anywhere under `app/**`. The static guard `tests/services/action_report/snapshot_backed/test_no_internal_llm_imports.py` must stay green.
+- **Ownership boundary.** Do NOT edit `app/services/decision_history.py` or `app/services/trade_journal/aggregates.py` — those belong to ROB-717. This work queries `trade_forecasts` / `trade_retrospectives` directly by `report_item_uuid`.
+- **Join key.** The item's `item_uuid` is stored in downstream tables' `report_item_uuid` column. On `TradeForecast` / `TradeRetrospective`, `report_item_uuid` is a **Text** column (not `PG_UUID`), so pass `str(item_uuid)` values in the `IN (...)` filter and key result dicts by that string.
+- **No N+1.** Exactly one batched `SELECT ... WHERE report_item_uuid IN (...)` per table.
+- **`decision_bucket` badge is row-level auxiliary only** — must not duplicate the ROB-308/322 section projection.
+- **Test-DB discipline (bit ROB-711/713/705 three times):** seed rows with per-test unique `report_item_uuid = str(uuid4())`; `await db.flush()` only — never `commit()`; do not add an autouse global-DELETE fixture.
+- **Lint gate:** `make lint` runs `ruff format --check` AND `ruff check`. Always run `ruff format` (not just `ruff check`) before committing, or CI goes red on unformatted-but-lint-clean code.
+
+**Spec:** `docs/superpowers/specs/2026-07-05-rob-715-invest-item-loop-render-design.md`
+
+---
+
+### Task 1: Backend batch loaders + projection schema models
+
+**Files:**
+- Create: `app/services/investment_reports/item_loop_links.py`
+- Modify: `app/schemas/investment_reports.py` (add two projection models near `LinkedOrderView`)
+- Test: `tests/test_investment_reports_item_loop_links.py`
+
+**Interfaces:**
+- Produces:
+  - `ForecastLinkResponse` (Pydantic): `forecast_id: str`, `status: str`, `outcome: bool | None`, `review_date: str | None`, `direction: str | None`, `target_price: float | None`, `probability: float`, `brier_score: float | None`, `resolution_source: str | None`.
+  - `RetrospectiveLinkResponse` (Pydantic): `retrospective_id: int`, `outcome: str`, `lesson: str | None`, `result_summary: str | None`, `root_cause_class: str | None`, `trigger_type: str | None`, `pnl_pct: float | None`, `created_at: str | None`.
+  - `async def list_forecasts_for_item_uuids(db: AsyncSession, item_uuids: Sequence[UUID]) -> dict[str, list[ForecastLinkResponse]]`
+  - `async def list_retrospectives_for_item_uuids(db: AsyncSession, item_uuids: Sequence[UUID]) -> dict[str, list[RetrospectiveLinkResponse]]`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_investment_reports_item_loop_links.py`:
+
+```python
+"""ROB-715 — exact-join batch loaders for item→forecast/retrospective links."""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+from decimal import Decimal
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.review import TradeForecast, TradeRetrospective
+from app.services.investment_reports.item_loop_links import (
+    list_forecasts_for_item_uuids,
+    list_retrospectives_for_item_uuids,
+)
+
+
+def _forecast(item_uuid: str, **kw) -> TradeForecast:
+    base = dict(
+        created_by="claude",
+        symbol="000660",
+        instrument_type="equity_kr",
+        forecast_target={"kind": "price_target", "direction": "at_or_above",
+                         "target_price": 200000},
+        probability=Decimal("0.6"),
+        review_date=date(2026, 7, 20),
+        status="open",
+        outcome=None,
+        report_item_uuid=item_uuid,
+    )
+    base.update(kw)
+    return TradeForecast(**base)
+
+
+def _retro(item_uuid: str, **kw) -> TradeRetrospective:
+    base = dict(
+        symbol="000660",
+        instrument_type="equity_kr",
+        account_mode="kis_live",
+        outcome="loss",
+        lesson="cut the position too late",
+        report_item_uuid=item_uuid,
+    )
+    base.update(kw)
+    return TradeRetrospective(**base)
+
+
+@pytest.mark.asyncio
+async def test_forecasts_grouped_by_item_uuid_exact_join(db_session: AsyncSession):
+    item_a = uuid4()
+    item_b = uuid4()
+    db_session.add(_forecast(str(item_a), status="closed", outcome=True,
+                             brier_score=Decimal("0.09")))
+    db_session.add(_forecast(str(item_b)))
+    await db_session.flush()
+
+    result = await list_forecasts_for_item_uuids(db_session, [item_a, item_b])
+
+    assert set(result) == {str(item_a), str(item_b)}
+    a = result[str(item_a)][0]
+    assert a.status == "closed"
+    assert a.outcome is True
+    assert a.direction == "at_or_above"
+    assert a.target_price == 200000.0
+    assert a.brier_score == pytest.approx(0.09)
+
+
+@pytest.mark.asyncio
+async def test_forecasts_absent_item_uuid_not_in_dict(db_session: AsyncSession):
+    item_a = uuid4()
+    unlinked = uuid4()
+    db_session.add(_forecast(str(item_a)))
+    await db_session.flush()
+
+    result = await list_forecasts_for_item_uuids(db_session, [item_a, unlinked])
+
+    assert str(item_a) in result
+    assert str(unlinked) not in result
+
+
+@pytest.mark.asyncio
+async def test_retrospectives_grouped_by_item_uuid(db_session: AsyncSession):
+    item_a = uuid4()
+    db_session.add(_retro(str(item_a), pnl_pct=Decimal("-3.5"),
+                          root_cause_class="thesis_wrong"))
+    await db_session.flush()
+
+    result = await list_retrospectives_for_item_uuids(db_session, [item_a])
+
+    row = result[str(item_a)][0]
+    assert row.outcome == "loss"
+    assert row.lesson == "cut the position too late"
+    assert row.pnl_pct == pytest.approx(-3.5)
+    assert row.root_cause_class == "thesis_wrong"
+
+
+@pytest.mark.asyncio
+async def test_empty_input_returns_empty_dict(db_session: AsyncSession):
+    assert await list_forecasts_for_item_uuids(db_session, []) == {}
+    assert await list_retrospectives_for_item_uuids(db_session, []) == {}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_investment_reports_item_loop_links.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'app.services.investment_reports.item_loop_links'`
+
+- [ ] **Step 3: Add the projection schema models**
+
+In `app/schemas/investment_reports.py`, near `LinkedOrderView`, add:
+
+```python
+class ForecastLinkResponse(BaseModel):
+    """ROB-715 — an item's own forecast, projected for the audit surface."""
+
+    forecast_id: str
+    status: str
+    outcome: bool | None = None
+    review_date: str | None = None
+    direction: str | None = None
+    target_price: float | None = None
+    probability: float
+    brier_score: float | None = None
+    resolution_source: str | None = None
+
+
+class RetrospectiveLinkResponse(BaseModel):
+    """ROB-715 — an item's own retrospective, projected for the audit surface."""
+
+    retrospective_id: int
+    outcome: str
+    lesson: str | None = None
+    result_summary: str | None = None
+    root_cause_class: str | None = None
+    trigger_type: str | None = None
+    pnl_pct: float | None = None
+    created_at: str | None = None
+```
+
+- [ ] **Step 4: Write the loader implementation**
+
+Create `app/services/investment_reports/item_loop_links.py`:
+
+```python
+"""ROB-715 — item→forecast/retrospective exact-join batch loaders.
+
+Given report-item UUIDs, return each item's own ``trade_forecasts`` and
+``trade_retrospectives`` rows (exact join on the ``report_item_uuid`` Text
+column), projected for the /invest audit surface. One batched query per table;
+items with no rows are absent from the returned dict. Read-only — no broker,
+order, watch, or order-intent mutation is reachable. This module deliberately
+does NOT import ``app.services.decision_history`` (ROB-717 ownership).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.review import TradeForecast, TradeRetrospective
+from app.schemas.investment_reports import (
+    ForecastLinkResponse,
+    RetrospectiveLinkResponse,
+)
+
+
+def _iso(value) -> str | None:
+    return value.isoformat() if value is not None else None
+
+
+def _project_forecast(row: TradeForecast) -> ForecastLinkResponse:
+    target = row.forecast_target or {}
+    price = target.get("target_price")
+    return ForecastLinkResponse(
+        forecast_id=str(row.forecast_id),
+        status=row.status,
+        outcome=row.outcome,
+        review_date=_iso(row.review_date),
+        direction=target.get("direction"),
+        target_price=float(price) if price is not None else None,
+        probability=float(row.probability),
+        brier_score=(
+            float(row.brier_score) if row.brier_score is not None else None
+        ),
+        resolution_source=row.resolution_source,
+    )
+
+
+def _project_retrospective(row: TradeRetrospective) -> RetrospectiveLinkResponse:
+    return RetrospectiveLinkResponse(
+        retrospective_id=row.id,
+        outcome=row.outcome,
+        lesson=row.lesson,
+        result_summary=row.result_summary,
+        root_cause_class=row.root_cause_class,
+        trigger_type=row.trigger_type,
+        pnl_pct=float(row.pnl_pct) if row.pnl_pct is not None else None,
+        created_at=_iso(row.created_at),
+    )
+
+
+async def list_forecasts_for_item_uuids(
+    db: AsyncSession, item_uuids: Sequence[UUID]
+) -> dict[str, list[ForecastLinkResponse]]:
+    keys = [str(u) for u in item_uuids]
+    grouped: dict[str, list[ForecastLinkResponse]] = {}
+    if not keys:
+        return grouped
+    rows = (
+        (
+            await db.execute(
+                select(TradeForecast)
+                .where(TradeForecast.report_item_uuid.in_(keys))
+                .order_by(TradeForecast.id.desc())
+            )
+        )
+        .scalars()
+        .all()
+    )
+    for row in rows:
+        grouped.setdefault(row.report_item_uuid, []).append(
+            _project_forecast(row)
+        )
+    return grouped
+
+
+async def list_retrospectives_for_item_uuids(
+    db: AsyncSession, item_uuids: Sequence[UUID]
+) -> dict[str, list[RetrospectiveLinkResponse]]:
+    keys = [str(u) for u in item_uuids]
+    grouped: dict[str, list[RetrospectiveLinkResponse]] = {}
+    if not keys:
+        return grouped
+    rows = (
+        (
+            await db.execute(
+                select(TradeRetrospective)
+                .where(TradeRetrospective.report_item_uuid.in_(keys))
+                .order_by(TradeRetrospective.id.desc())
+            )
+        )
+        .scalars()
+        .all()
+    )
+    for row in rows:
+        grouped.setdefault(row.report_item_uuid, []).append(
+            _project_retrospective(row)
+        )
+    return grouped
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_investment_reports_item_loop_links.py -v`
+Expected: PASS (4 tests)
+
+- [ ] **Step 6: Lint + commit**
+
+```bash
+cd /Users/mgh3326/work/auto_trader.rob-715
+uv run ruff format app/services/investment_reports/item_loop_links.py app/schemas/investment_reports.py tests/test_investment_reports_item_loop_links.py
+uv run ruff check app/services/investment_reports/item_loop_links.py app/schemas/investment_reports.py
+git add app/services/investment_reports/item_loop_links.py app/schemas/investment_reports.py tests/test_investment_reports_item_loop_links.py
+git commit -m "feat(ROB-715): item->forecast/retrospective exact-join batch loaders"
+```
+
+---
+
+### Task 2: Wire loaders into the bundle query service
+
+**Files:**
+- Modify: `app/services/investment_reports/query_service.py` (the `get_bundle` builder, around lines 152-178)
+- Test: `tests/test_investment_reports_query_service.py` (add one test)
+
+**Interfaces:**
+- Consumes: `list_forecasts_for_item_uuids`, `list_retrospectives_for_item_uuids` from Task 1.
+- Produces: bundle dict gains keys `forecasts_by_item_uuid` and `retrospectives_by_item_uuid` (`dict[str, list[...Response]]`).
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/test_investment_reports_query_service.py` (reuse the file's existing `session` fixture and its report/item seeding helpers — grep the file for how `test_get_bundle_returns_nested_shapes` seeds a report + item, and copy that seeding into this test):
+
+```python
+@pytest.mark.asyncio
+async def test_get_bundle_attaches_forecast_and_retrospective_maps(
+    session: AsyncSession,
+) -> None:
+    from decimal import Decimal
+    from datetime import date
+    from app.models.review import TradeForecast, TradeRetrospective
+
+    # Seed one report with one item (mirror test_get_bundle_returns_nested_shapes).
+    report, item = await _seed_single_item_report(session)  # existing helper pattern
+
+    session.add(
+        TradeForecast(
+            created_by="claude", symbol=item.symbol, instrument_type="equity_kr",
+            forecast_target={"direction": "at_or_above", "target_price": 100},
+            probability=Decimal("0.6"), review_date=date(2026, 7, 20),
+            status="open", report_item_uuid=str(item.item_uuid),
+        )
+    )
+    session.add(
+        TradeRetrospective(
+            symbol=item.symbol, instrument_type="equity_kr",
+            account_mode="kis_live", outcome="win",
+            report_item_uuid=str(item.item_uuid),
+        )
+    )
+    await session.flush()
+
+    svc = InvestmentReportQueryService(session)
+    bundle = await svc.get_bundle(report.report_uuid)
+
+    key = str(item.item_uuid)
+    assert bundle["forecasts_by_item_uuid"][key][0].status == "open"
+    assert bundle["retrospectives_by_item_uuid"][key][0].outcome == "win"
+```
+
+> If `_seed_single_item_report` does not already exist in the test file, inline the same report+item insert that `test_get_bundle_returns_nested_shapes` uses. Use `report_item_uuid=str(item.item_uuid)` so the exact join matches.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_investment_reports_query_service.py::test_get_bundle_attaches_forecast_and_retrospective_maps -v`
+Expected: FAIL with `KeyError: 'forecasts_by_item_uuid'`
+
+- [ ] **Step 3: Wire the loaders**
+
+In `app/services/investment_reports/query_service.py`, add imports at the top with the other service imports:
+
+```python
+from app.services.investment_reports.item_loop_links import (
+    list_forecasts_for_item_uuids,
+    list_retrospectives_for_item_uuids,
+)
+```
+
+In `get_bundle`, right after the `linked_orders_by_item_uuid = await list_linked_orders_for_item_uuids(...)` call, add:
+
+```python
+        item_uuids = [it.item_uuid for it in items]
+        forecasts_by_item_uuid = await list_forecasts_for_item_uuids(
+            self._session, item_uuids
+        )
+        retrospectives_by_item_uuid = await list_retrospectives_for_item_uuids(
+            self._session, item_uuids
+        )
+```
+
+In the `return {...}` dict at the end of `get_bundle`, add two keys:
+
+```python
+            "forecasts_by_item_uuid": forecasts_by_item_uuid,
+            "retrospectives_by_item_uuid": retrospectives_by_item_uuid,
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_investment_reports_query_service.py::test_get_bundle_attaches_forecast_and_retrospective_maps -v`
+Expected: PASS
+
+- [ ] **Step 5: Run the whole query-service file (no regression)**
+
+Run: `uv run pytest tests/test_investment_reports_query_service.py -v`
+Expected: all PASS
+
+- [ ] **Step 6: Lint + commit**
+
+```bash
+uv run ruff format app/services/investment_reports/query_service.py tests/test_investment_reports_query_service.py
+uv run ruff check app/services/investment_reports/query_service.py
+git add app/services/investment_reports/query_service.py tests/test_investment_reports_query_service.py
+git commit -m "feat(ROB-715): attach forecast/retrospective maps to report bundle"
+```
+
+---
+
+### Task 3: Expose the maps on the bundle response + router folding
+
+**Files:**
+- Modify: `app/schemas/investment_reports.py` (`InvestmentReportBundle`, ~line 1076-1090)
+- Modify: `app/routers/investment_reports.py` (`_serialise_bundle`, lines 56-115)
+- Test: `tests/test_investment_reports_schemas.py` OR a new `tests/test_investment_reports_bundle_loop_maps.py`
+
+**Interfaces:**
+- Consumes: bundle dict keys from Task 2; `ForecastLinkResponse` / `RetrospectiveLinkResponse` from Task 1.
+- Produces: `InvestmentReportBundle.forecasts_by_item_uuid` and `.retrospectives_by_item_uuid` (`dict[str, list[...]]`, default empty).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_investment_reports_bundle_loop_maps.py`:
+
+```python
+"""ROB-715 — _serialise_bundle folds forecast/retrospective maps onto response."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.routers.investment_reports import _serialise_bundle
+from app.schemas.investment_reports import (
+    ForecastLinkResponse,
+    RetrospectiveLinkResponse,
+)
+
+
+def test_serialise_bundle_carries_loop_maps(minimal_bundle_dict):
+    # minimal_bundle_dict: a dict shaped like query_service.get_bundle output
+    # with one report + one item (item_uuid == UUID(int=1)). See fixture below.
+    key = str(minimal_bundle_dict["items"][0].item_uuid)
+    minimal_bundle_dict["forecasts_by_item_uuid"] = {
+        key: [ForecastLinkResponse(forecast_id="f1", status="open", probability=0.6)]
+    }
+    minimal_bundle_dict["retrospectives_by_item_uuid"] = {
+        key: [RetrospectiveLinkResponse(retrospective_id=1, outcome="win")]
+    }
+
+    bundle = _serialise_bundle(minimal_bundle_dict)
+
+    assert bundle.forecasts_by_item_uuid[key][0].status == "open"
+    assert bundle.retrospectives_by_item_uuid[key][0].outcome == "win"
+
+
+def test_serialise_bundle_defaults_empty_when_maps_absent(minimal_bundle_dict):
+    # Legacy bundle dict without the new keys → empty dicts, no crash.
+    bundle = _serialise_bundle(minimal_bundle_dict)
+    assert bundle.forecasts_by_item_uuid == {}
+    assert bundle.retrospectives_by_item_uuid == {}
+```
+
+> Build `minimal_bundle_dict` as a local pytest fixture in this file: reuse the seeding from `tests/test_investment_reports_query_service.py::test_get_bundle_returns_nested_shapes`, calling `InvestmentReportQueryService(session).get_bundle(...)` to get a real dict, then strip the two new keys for the "absent" test. If constructing a real dict is heavy, instead assemble the minimum keys `_serialise_bundle` reads: `report`, `items`, `decisions_by_item`, `alerts`, `events`, `news_citations`, `linked_orders_by_item_uuid` (see `_serialise_bundle` body, investment_reports.py:56-115).
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_investment_reports_bundle_loop_maps.py -v`
+Expected: FAIL — `AttributeError: 'InvestmentReportBundle' object has no attribute 'forecasts_by_item_uuid'`
+
+- [ ] **Step 3: Add schema fields**
+
+In `app/schemas/investment_reports.py`, in `class InvestmentReportBundle`, after the `decisions_by_item_uuid` field, add:
+
+```python
+    forecasts_by_item_uuid: dict[str, list[ForecastLinkResponse]] = Field(
+        default_factory=dict
+    )
+    retrospectives_by_item_uuid: dict[str, list[RetrospectiveLinkResponse]] = Field(
+        default_factory=dict
+    )
+```
+
+(Ensure `Field` is imported — it already is in this module.)
+
+- [ ] **Step 4: Fold maps in the router**
+
+In `app/routers/investment_reports.py::_serialise_bundle`, read the two maps from the bundle dict (default empty) and pass them to the `InvestmentReportBundle(...)` constructor:
+
+```python
+    forecasts_by_item_uuid = bundle.get("forecasts_by_item_uuid", {})
+    retrospectives_by_item_uuid = bundle.get("retrospectives_by_item_uuid", {})
+```
+
+Add to the `return InvestmentReportBundle(` call:
+
+```python
+        forecasts_by_item_uuid=forecasts_by_item_uuid,
+        retrospectives_by_item_uuid=retrospectives_by_item_uuid,
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_investment_reports_bundle_loop_maps.py -v`
+Expected: PASS (2 tests)
+
+- [ ] **Step 6: Lint + commit**
+
+```bash
+uv run ruff format app/schemas/investment_reports.py app/routers/investment_reports.py tests/test_investment_reports_bundle_loop_maps.py
+uv run ruff check app/schemas/investment_reports.py app/routers/investment_reports.py
+git add app/schemas/investment_reports.py app/routers/investment_reports.py tests/test_investment_reports_bundle_loop_maps.py
+git commit -m "feat(ROB-715): expose forecast/retrospective loop maps on bundle response"
+```
+
+---
+
+### Task 4: `structured_evidence_summary` helper + item-response field
+
+**Files:**
+- Create: `app/services/investment_reports/structured_evidence_summary.py`
+- Modify: `app/schemas/investment_reports.py` (`InvestmentReportItemResponse`, ~line 807-849)
+- Modify: `app/routers/investment_reports.py` (`_serialise_bundle`, item loop lines 61-65)
+- Test: `tests/test_structured_evidence_summary.py`
+
+**Interfaces:**
+- Produces: `def summarize_structured_evidence(evidence_snapshot: dict) -> str | None`; new field `InvestmentReportItemResponse.structured_evidence_summary: str | None`.
+
+**Context:** `structured_evidence` is persisted at `evidence_snapshot["structured_evidence"]` (schema comment, investment_reports.py:241-242, 326-327) — there is no separate column. The summary is derived on the backend so the frontend renders a string without parsing the nested structure ("백엔드 전용 — 프론트 미파싱").
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_structured_evidence_summary.py`:
+
+```python
+"""ROB-715 — deterministic one-line summary of evidence_snapshot.structured_evidence."""
+
+from app.services.investment_reports.structured_evidence_summary import (
+    summarize_structured_evidence,
+)
+
+
+def test_none_when_no_structured_evidence():
+    assert summarize_structured_evidence({}) is None
+    assert summarize_structured_evidence({"structured_evidence": None}) is None
+    assert summarize_structured_evidence({"structured_evidence": {}}) is None
+
+
+def test_summarizes_top_level_keys():
+    snap = {"structured_evidence": {"valuation": "cheap", "momentum": "up",
+                                    "risk": "low"}}
+    out = summarize_structured_evidence(snap)
+    assert out is not None
+    # Deterministic: sorted keys, count-prefixed.
+    assert "3" in out
+    assert "momentum" in out and "risk" in out and "valuation" in out
+
+
+def test_stable_ordering():
+    snap = {"structured_evidence": {"b": 1, "a": 2}}
+    assert summarize_structured_evidence(snap) == summarize_structured_evidence(
+        {"structured_evidence": {"a": 2, "b": 1}}
+    )
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_structured_evidence_summary.py -v`
+Expected: FAIL — `ModuleNotFoundError`
+
+- [ ] **Step 3: Write the helper**
+
+Create `app/services/investment_reports/structured_evidence_summary.py`:
+
+```python
+"""ROB-715 — backend-derived summary of ``evidence_snapshot['structured_evidence']``.
+
+The frontend renders the returned string verbatim (no client-side parsing of the
+nested structure). Deterministic: keys are sorted so the output is stable across
+requests and safe to snapshot-test.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def summarize_structured_evidence(evidence_snapshot: dict[str, Any]) -> str | None:
+    se = (evidence_snapshot or {}).get("structured_evidence")
+    if not isinstance(se, dict) or not se:
+        return None
+    keys = sorted(str(k) for k in se)
+    return f"{len(keys)} evidence fields: " + ", ".join(keys)
+```
+
+- [ ] **Step 4: Run helper test to verify it passes**
+
+Run: `uv run pytest tests/test_structured_evidence_summary.py -v`
+Expected: PASS (3 tests)
+
+- [ ] **Step 5: Add the item-response field + wire it in the router**
+
+In `app/schemas/investment_reports.py`, in `class InvestmentReportItemResponse`, add (near `linked_orders`):
+
+```python
+    structured_evidence_summary: str | None = None
+```
+
+In `app/routers/investment_reports.py::_serialise_bundle`, in the item loop that already sets `resp.linked_orders`, add the summary derivation. Add the import at the top of the file:
+
+```python
+from app.services.investment_reports.structured_evidence_summary import (
+    summarize_structured_evidence,
+)
+```
+
+Then inside the `for it in items:` loop:
+
+```python
+        resp.structured_evidence_summary = summarize_structured_evidence(
+            resp.evidence_snapshot
+        )
+```
+
+- [ ] **Step 6: Write a wiring test**
+
+Add to `tests/test_investment_reports_bundle_loop_maps.py`:
+
+```python
+def test_serialise_bundle_sets_structured_evidence_summary(minimal_bundle_dict):
+    item = minimal_bundle_dict["items"][0]
+    item.evidence_snapshot = {"structured_evidence": {"valuation": "cheap"}}
+    bundle = _serialise_bundle(minimal_bundle_dict)
+    assert bundle.items[0].structured_evidence_summary == "1 evidence fields: valuation"
+```
+
+> If the ORM `item.evidence_snapshot` is read-only in your seeding path, set the summary expectation against whatever the seeded item's `evidence_snapshot` already contains, or seed the item with `evidence_snapshot={"structured_evidence": {...}}` up front.
+
+- [ ] **Step 7: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_structured_evidence_summary.py tests/test_investment_reports_bundle_loop_maps.py -v`
+Expected: all PASS
+
+- [ ] **Step 8: Lint + commit**
+
+```bash
+uv run ruff format app/services/investment_reports/structured_evidence_summary.py app/schemas/investment_reports.py app/routers/investment_reports.py tests/test_structured_evidence_summary.py tests/test_investment_reports_bundle_loop_maps.py
+uv run ruff check app/services/investment_reports/structured_evidence_summary.py app/schemas/investment_reports.py app/routers/investment_reports.py
+git add app/services/investment_reports/structured_evidence_summary.py app/schemas/investment_reports.py app/routers/investment_reports.py tests/test_structured_evidence_summary.py tests/test_investment_reports_bundle_loop_maps.py
+git commit -m "feat(ROB-715): backend structured_evidence summary on report items"
+```
+
+---
+
+### Task 5: Frontend types + normalizer for the loop maps
+
+**Files:**
+- Modify: `frontend/invest/src/types/investmentReports.ts`
+- Modify: `frontend/invest/src/api/investmentReports.ts`
+- Test: `frontend/invest/src/__tests__/investmentReports.loopMaps.test.ts` (create)
+
+**Interfaces:**
+- Produces TS types `ForecastLink`, `RetrospectiveLink`; `InvestmentReportBundle.forecastsByItemUuid` / `.retrospectivesByItemUuid`; `InvestmentReportItem.structuredEvidenceSummary`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `frontend/invest/src/__tests__/investmentReports.loopMaps.test.ts`:
+
+```typescript
+import { describe, it, expect } from "vitest";
+import { normalizeForecastLink, normalizeRetrospectiveLink } from "../api/investmentReports";
+
+describe("ROB-715 loop-map normalizers", () => {
+  it("normalizes a forecast link snake→camel", () => {
+    const out = normalizeForecastLink({
+      forecast_id: "f1", status: "closed", outcome: true,
+      review_date: "2026-07-20", direction: "at_or_above",
+      target_price: 200000, probability: 0.6, brier_score: 0.09,
+      resolution_source: "ohlcv_day",
+    });
+    expect(out.forecastId).toBe("f1");
+    expect(out.status).toBe("closed");
+    expect(out.outcome).toBe(true);
+    expect(out.targetPrice).toBe(200000);
+    expect(out.brierScore).toBe(0.09);
+  });
+
+  it("normalizes a retrospective link", () => {
+    const out = normalizeRetrospectiveLink({
+      retrospective_id: 1, outcome: "loss", lesson: "cut late",
+      root_cause_class: "thesis_wrong", pnl_pct: -3.5,
+    });
+    expect(out.outcome).toBe("loss");
+    expect(out.lesson).toBe("cut late");
+    expect(out.pnlPct).toBe(-3.5);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd frontend/invest && npx vitest run src/__tests__/investmentReports.loopMaps.test.ts`
+Expected: FAIL — `normalizeForecastLink is not exported`
+
+- [ ] **Step 3: Add the TS types**
+
+In `frontend/invest/src/types/investmentReports.ts`, add:
+
+```typescript
+export interface ForecastLink {
+  forecastId: string;
+  status: string;
+  outcome: boolean | null;
+  reviewDate: string | null;
+  direction: string | null;
+  targetPrice: number | null;
+  probability: number;
+  brierScore: number | null;
+  resolutionSource: string | null;
+}
+
+export interface RetrospectiveLink {
+  retrospectiveId: number;
+  outcome: string;
+  lesson: string | null;
+  resultSummary: string | null;
+  rootCauseClass: string | null;
+  triggerType: string | null;
+  pnlPct: number | null;
+  createdAt: string | null;
+}
+```
+
+Add to `interface InvestmentReportBundle`:
+
+```typescript
+  forecastsByItemUuid: Record<string, ForecastLink[]>;
+  retrospectivesByItemUuid: Record<string, RetrospectiveLink[]>;
+```
+
+Add to `interface InvestmentReportItem` (near `linkedOrders`):
+
+```typescript
+  structuredEvidenceSummary?: string | null;
+```
+
+- [ ] **Step 4: Add the normalizers + wire into the bundle reader**
+
+In `frontend/invest/src/api/investmentReports.ts`, add exported normalizers (use the same `asOptionalString` / `asArray` helpers the file already uses; grep for their definitions):
+
+```typescript
+export function normalizeForecastLink(raw: ApiItem): ForecastLink {
+  return {
+    forecastId: String(raw.forecast_id ?? ""),
+    status: String(raw.status ?? ""),
+    outcome: raw.outcome === null || raw.outcome === undefined ? null : Boolean(raw.outcome),
+    reviewDate: asOptionalString(raw.review_date) ?? null,
+    direction: asOptionalString(raw.direction) ?? null,
+    targetPrice: raw.target_price == null ? null : Number(raw.target_price),
+    probability: Number(raw.probability ?? 0),
+    brierScore: raw.brier_score == null ? null : Number(raw.brier_score),
+    resolutionSource: asOptionalString(raw.resolution_source) ?? null,
+  };
+}
+
+export function normalizeRetrospectiveLink(raw: ApiItem): RetrospectiveLink {
+  return {
+    retrospectiveId: Number(raw.retrospective_id ?? 0),
+    outcome: String(raw.outcome ?? ""),
+    lesson: asOptionalString(raw.lesson) ?? null,
+    resultSummary: asOptionalString(raw.result_summary) ?? null,
+    rootCauseClass: asOptionalString(raw.root_cause_class) ?? null,
+    triggerType: asOptionalString(raw.trigger_type) ?? null,
+    pnlPct: raw.pnl_pct == null ? null : Number(raw.pnl_pct),
+    createdAt: asOptionalString(raw.created_at) ?? null,
+  };
+}
+```
+
+In the bundle reader (where `decisions_by_item_uuid` is normalized, ~line 398-412), add parsing of the two new maps and `structured_evidence_summary` on each item, and include `forecastsByItemUuid` / `retrospectivesByItemUuid` in the returned bundle object. Mirror the existing `decisionsByItemUuid` loop:
+
+```typescript
+  const forecastsRaw = raw.forecasts_by_item_uuid ?? {};
+  const forecastsByItemUuid: Record<string, ForecastLink[]> = {};
+  for (const [k, v] of Object.entries(forecastsRaw)) {
+    forecastsByItemUuid[k] = asArray<ApiItem>(v).map(normalizeForecastLink);
+  }
+  const retrospectivesRaw = raw.retrospectives_by_item_uuid ?? {};
+  const retrospectivesByItemUuid: Record<string, RetrospectiveLink[]> = {};
+  for (const [k, v] of Object.entries(retrospectivesRaw)) {
+    retrospectivesByItemUuid[k] = asArray<ApiItem>(v).map(normalizeRetrospectiveLink);
+  }
+```
+
+Also add `structuredEvidenceSummary: asOptionalString(raw.structured_evidence_summary) ?? null,` to the item normalizer (near the `decisionBucket` line, ~208), and add the two maps to the bundle-type read struct (the inline `readJson<{...}>` type near line 398) and to the returned bundle literal.
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cd frontend/invest && npx vitest run src/__tests__/investmentReports.loopMaps.test.ts`
+Expected: PASS
+
+- [ ] **Step 6: Typecheck + commit**
+
+```bash
+cd frontend/invest && npx tsc --noEmit
+cd /Users/mgh3326/work/auto_trader.rob-715
+git add frontend/invest/src/types/investmentReports.ts frontend/invest/src/api/investmentReports.ts frontend/invest/src/__tests__/investmentReports.loopMaps.test.ts
+git commit -m "feat(ROB-715): frontend types + normalizers for item loop maps"
+```
+
+---
+
+### Task 6: Render the loop section (a) + empty state on `ItemRow`
+
+**Files:**
+- Modify: `frontend/invest/src/components/investment-reports/InvestmentReportBundleContent.tsx` (`ItemRow`, def at line 276; call sites 629/647/791 must pass the maps down)
+- Test: `frontend/invest/src/__tests__/InvestmentReportBundleContent.loopSection.test.tsx` (create)
+
+**Interfaces:**
+- Consumes: `ForecastLink[]` / `RetrospectiveLink[]` for the item, from Task 5 types. `ItemRow` gains props `forecastLinks?: ForecastLink[]` and `retrospectiveLinks?: RetrospectiveLink[]` (looked up by the parent from `bundle.forecastsByItemUuid[item.itemUuid]`).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `frontend/invest/src/__tests__/InvestmentReportBundleContent.loopSection.test.tsx`. Model it on the existing `InvestmentReportBundleContent.linkedOrders.test.tsx` (copy its render harness + bundle-building helper):
+
+```tsx
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { InvestmentReportBundleContent } from "../components/investment-reports/InvestmentReportBundleContent";
+import { buildBundleFixture } from "./InvestmentReportBundleContent.linkedOrders.test"; // or inline a local helper
+
+describe("ROB-715 item loop section", () => {
+  it("renders forecast status and retrospective outcome for an item", () => {
+    const bundle = buildBundleFixture(); // one item with itemUuid "u1"
+    bundle.forecastsByItemUuid = {
+      u1: [{ forecastId: "f1", status: "closed", outcome: true, reviewDate: "2026-07-20",
+             direction: "at_or_above", targetPrice: 200000, probability: 0.6,
+             brierScore: 0.09, resolutionSource: "ohlcv_day" }],
+    };
+    bundle.retrospectivesByItemUuid = {
+      u1: [{ retrospectiveId: 1, outcome: "win", lesson: "held to target",
+             resultSummary: null, rootCauseClass: null, triggerType: null,
+             pnlPct: 4.2, createdAt: null }],
+    };
+    render(<InvestmentReportBundleContent bundle={bundle} />);
+    expect(screen.getByTestId("item-loop-forecast-f1")).toBeInTheDocument();
+    expect(screen.getByText(/held to target/)).toBeInTheDocument();
+  });
+
+  it("renders the empty state when an item has no forecast or retrospective", () => {
+    const bundle = buildBundleFixture();
+    bundle.forecastsByItemUuid = {};
+    bundle.retrospectivesByItemUuid = {};
+    render(<InvestmentReportBundleContent bundle={bundle} />);
+    expect(screen.getByText("해소 대기 / 미연결")).toBeInTheDocument();
+  });
+});
+```
+
+> If `buildBundleFixture` is not exported by the linkedOrders test, inline a minimal bundle builder in this file (copy the shape the linkedOrders test constructs). Ensure the single item's `itemUuid` is `"u1"`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd frontend/invest && npx vitest run src/__tests__/InvestmentReportBundleContent.loopSection.test.tsx`
+Expected: FAIL — testid `item-loop-forecast-f1` not found / empty-state text absent.
+
+- [ ] **Step 3: Thread the maps to `ItemRow` and render the section**
+
+In `InvestmentReportBundleContent.tsx`, at each `ItemRow` call site (lines ~629, 647, 791), pass:
+
+```tsx
+  forecastLinks={bundle.forecastsByItemUuid[it.itemUuid] ?? []}
+  retrospectiveLinks={bundle.retrospectivesByItemUuid[it.itemUuid] ?? []}
+```
+
+Add the two props to `ItemRow`'s prop type. Inside `ItemRow`, after the `linkedOrders` block (~line 386), add:
+
+```tsx
+      <div className="item-loop-section" data-testid={`item-loop-${item.itemUuid}`}>
+        {forecastLinks.length === 0 && retrospectiveLinks.length === 0 ? (
+          <span className="item-loop-empty muted">해소 대기 / 미연결</span>
+        ) : (
+          <>
+            {forecastLinks.map((f) => (
+              <div key={f.forecastId} data-testid={`item-loop-forecast-${f.forecastId}`}>
+                <span>{f.status === "closed"
+                  ? (f.outcome ? "적중" : "빗나감")
+                  : "해소 대기"}</span>
+                {f.brierScore != null && <span> · Brier {f.brierScore.toFixed(2)}</span>}
+                {f.reviewDate && <span> · {f.reviewDate}</span>}
+              </div>
+            ))}
+            {retrospectiveLinks.map((r) => (
+              <div key={r.retrospectiveId} data-testid={`item-loop-retro-${r.retrospectiveId}`}>
+                <span>회고: {r.outcome}</span>
+                {r.lesson && <span> — {r.lesson}</span>}
+              </div>
+            ))}
+          </>
+        )}
+      </div>
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd frontend/invest && npx vitest run src/__tests__/InvestmentReportBundleContent.loopSection.test.tsx`
+Expected: PASS (2 tests)
+
+- [ ] **Step 5: Typecheck + commit**
+
+```bash
+cd frontend/invest && npx tsc --noEmit
+cd /Users/mgh3326/work/auto_trader.rob-715
+git add frontend/invest/src/components/investment-reports/InvestmentReportBundleContent.tsx frontend/invest/src/__tests__/InvestmentReportBundleContent.loopSection.test.tsx
+git commit -m "feat(ROB-715): render item forecast-resolution + retrospective loop section"
+```
+
+---
+
+### Task 7: Render raw fields (b) on `ItemRow`
+
+**Files:**
+- Modify: `frontend/invest/src/components/investment-reports/InvestmentReportBundleContent.tsx` (`ItemRow`)
+- Test: `frontend/invest/src/__tests__/InvestmentReportBundleContent.rawFields.test.tsx` (create)
+
+**Interfaces:**
+- Consumes: `item.triggerChecklist`, `item.maxAction`, `item.decisionBucket`, `item.structuredEvidenceSummary` (all already normalized; `structuredEvidenceSummary` from Task 5).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `frontend/invest/src/__tests__/InvestmentReportBundleContent.rawFields.test.tsx` (same harness as Task 6):
+
+```tsx
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { InvestmentReportBundleContent } from "../components/investment-reports/InvestmentReportBundleContent";
+import { buildBundleFixture } from "./InvestmentReportBundleContent.linkedOrders.test";
+
+describe("ROB-715 raw item fields", () => {
+  it("renders trigger checklist, max_action, decision bucket badge, evidence summary", () => {
+    const bundle = buildBundleFixture();
+    const item = bundle.items[0];
+    item.triggerChecklist = ["RSI < 30", "종가 20MA 회복"];
+    item.maxAction = { side: "buy", notional: 1000000, limit_price: 195000 };
+    item.decisionBucket = "new_buy_candidate";
+    item.structuredEvidenceSummary = "2 evidence fields: momentum, valuation";
+    render(<InvestmentReportBundleContent bundle={bundle} />);
+    expect(screen.getByText("RSI < 30")).toBeInTheDocument();
+    expect(screen.getByTestId("item-decision-bucket-badge")).toHaveTextContent("new_buy_candidate");
+    expect(screen.getByText(/2 evidence fields/)).toBeInTheDocument();
+    expect(screen.getByTestId("item-max-action")).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd frontend/invest && npx vitest run src/__tests__/InvestmentReportBundleContent.rawFields.test.tsx`
+Expected: FAIL — elements not found.
+
+- [ ] **Step 3: Render the raw fields**
+
+Inside `ItemRow`, add a raw-fields block (after the rationale, before the loop section). Keep `decision_bucket` as a small inline badge — do NOT re-project the ROB-308/322 sections:
+
+```tsx
+      {item.decisionBucket && (
+        <span className="item-decision-bucket-badge" data-testid="item-decision-bucket-badge">
+          {item.decisionBucket}
+        </span>
+      )}
+      {item.triggerChecklist && item.triggerChecklist.length > 0 && (
+        <ul className="item-trigger-checklist">
+          {item.triggerChecklist.map((t, i) => <li key={i}>{t}</li>)}
+        </ul>
+      )}
+      {item.maxAction && (
+        <div className="item-max-action" data-testid="item-max-action">
+          {formatMaxAction(item.maxAction)}
+        </div>
+      )}
+      {item.structuredEvidenceSummary && (
+        <div className="item-structured-evidence">{item.structuredEvidenceSummary}</div>
+      )}
+```
+
+Add a small local formatter near the top of the file (module scope):
+
+```tsx
+function formatMaxAction(a: Record<string, unknown>): string {
+  const parts: string[] = [];
+  if (a.side) parts.push(String(a.side));
+  if (a.quantity != null) parts.push(`${a.quantity}주`);
+  if (a.notional != null) parts.push(`${a.notional}`);
+  if (a.limit_price != null) parts.push(`@${a.limit_price}`);
+  if (a.ladder_level != null) parts.push(`ladder ${a.ladder_level}`);
+  return parts.join(" · ");
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd frontend/invest && npx vitest run src/__tests__/InvestmentReportBundleContent.rawFields.test.tsx`
+Expected: PASS
+
+- [ ] **Step 5: Typecheck + commit**
+
+```bash
+cd frontend/invest && npx tsc --noEmit
+cd /Users/mgh3326/work/auto_trader.rob-715
+git add frontend/invest/src/components/investment-reports/InvestmentReportBundleContent.tsx frontend/invest/src/__tests__/InvestmentReportBundleContent.rawFields.test.tsx
+git commit -m "feat(ROB-715): render trigger_checklist/max_action/decision_bucket/evidence summary"
+```
+
+---
+
+### Task 8: Render plan-vs-actual (c) on `ItemRow`
+
+**Files:**
+- Modify: `frontend/invest/src/components/investment-reports/InvestmentReportBundleContent.tsx` (`ItemRow` — extend the existing `tradeSetup` / R:R block, `parseTradeSetup` at line 224, R:R render ~289)
+- Test: `frontend/invest/src/__tests__/InvestmentReportBundleContent.planVsActual.test.tsx` (create)
+
+**Interfaces:**
+- Consumes: parsed `tradeSetup` (planned entry/stop/target — already parsed from `evidenceSnapshot`) + actual fill price from `item.linkedOrders` (already normalized). Frontend-only; no new data.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `frontend/invest/src/__tests__/InvestmentReportBundleContent.planVsActual.test.tsx` (same harness; model on `InvestmentReportBundleContent.tradeSetup.test.tsx` for how tradeSetup is seeded into `evidenceSnapshot`):
+
+```tsx
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { InvestmentReportBundleContent } from "../components/investment-reports/InvestmentReportBundleContent";
+import { buildBundleFixture } from "./InvestmentReportBundleContent.linkedOrders.test";
+
+describe("ROB-715 plan vs actual", () => {
+  it("shows planned entry alongside the actual fill price", () => {
+    const bundle = buildBundleFixture();
+    const item = bundle.items[0];
+    item.evidenceSnapshot = { trade_setup: { entry: 195000, stop: 185000, target: 220000 } };
+    item.linkedOrders = [
+      { /* shape per normalizeLinkedOrder */ fillPrice: 194500, side: "buy", status: "filled" } as any,
+    ];
+    render(<InvestmentReportBundleContent bundle={bundle} />);
+    const pva = screen.getByTestId("item-plan-vs-actual");
+    expect(pva).toHaveTextContent("195000"); // planned entry
+    expect(pva).toHaveTextContent("194500"); // actual fill
+  });
+});
+```
+
+> Confirm the actual `LinkedOrder` fill-price field name in `types/investmentReports.ts` (grep `fillPrice` / `filled`) and use it verbatim in both the render and this test.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd frontend/invest && npx vitest run src/__tests__/InvestmentReportBundleContent.planVsActual.test.tsx`
+Expected: FAIL — testid `item-plan-vs-actual` not found.
+
+- [ ] **Step 3: Render plan-vs-actual**
+
+Inside `ItemRow`, where `tradeSetup` is already rendered (the R:R pill block ~289), add a plan-vs-actual row that juxtaposes the planned levels with the first filled linked order's price:
+
+```tsx
+      {tradeSetup && (
+        <div className="item-plan-vs-actual" data-testid="item-plan-vs-actual">
+          <span>계획: 진입 {tradeSetup.entry} · 손절 {tradeSetup.stop} · 목표 {tradeSetup.target}</span>
+          {(() => {
+            const filled = (item.linkedOrders ?? []).find((o) => o.fillPrice != null);
+            return filled ? <span> · 실제 체결 {filled.fillPrice}</span>
+                          : <span className="muted"> · 체결 없음</span>;
+          })()}
+        </div>
+      )}
+```
+
+> Adjust `tradeSetup.entry/stop/target` and `o.fillPrice` to the exact property names in the file (grep `parseTradeSetup` return shape and `LinkedOrder`).
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd frontend/invest && npx vitest run src/__tests__/InvestmentReportBundleContent.planVsActual.test.tsx`
+Expected: PASS
+
+- [ ] **Step 5: Run all touched frontend tests (no regression)**
+
+Run: `cd frontend/invest && npx vitest run src/__tests__/InvestmentReportBundleContent`
+Expected: all PASS (loopSection, rawFields, planVsActual + existing linkedOrders/tradeSetup/etc.)
+
+- [ ] **Step 6: Typecheck + commit**
+
+```bash
+cd frontend/invest && npx tsc --noEmit
+cd /Users/mgh3326/work/auto_trader.rob-715
+git add frontend/invest/src/components/investment-reports/InvestmentReportBundleContent.tsx frontend/invest/src/__tests__/InvestmentReportBundleContent.planVsActual.test.tsx
+git commit -m "feat(ROB-715): render plan-vs-actual (planned setup vs actual fill)"
+```
+
+---
+
+### Task 9: Full-suite regression + guard verification
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Backend — run touched + guard suites**
+
+Run:
+```bash
+cd /Users/mgh3326/work/auto_trader.rob-715
+uv run pytest tests/test_investment_reports_item_loop_links.py tests/test_investment_reports_query_service.py tests/test_investment_reports_bundle_loop_maps.py tests/test_structured_evidence_summary.py tests/test_investment_reports_schemas.py -v
+uv run pytest tests/services/action_report/snapshot_backed/test_no_internal_llm_imports.py -v
+```
+Expected: all PASS (ROB-501 guard green — no new LLM import).
+
+- [ ] **Step 2: Backend — lint gate (format-check, not just check)**
+
+Run: `make lint`
+Expected: clean (0 diffs). If `ruff format --check` reports a diff, run `uv run ruff format app/ tests/` and re-commit.
+
+- [ ] **Step 3: Frontend — full invest suite + typecheck**
+
+Run:
+```bash
+cd frontend/invest
+npx vitest run
+npx tsc --noEmit
+```
+Expected: no new failures. (Pre-existing calendar/coverage vitest failures noted in prior batches are not introduced by this work — confirm the failing set is unchanged from `origin/main`.)
+
+- [ ] **Step 4: Manual smoke via `/browse` (optional but recommended)**
+
+Load `/invest` reports, open a report bundle, confirm an item row shows the loop section (or the "해소 대기 / 미연결" empty state), the raw-field chips, and the plan-vs-actual line. Real DB is read-only.
+
+- [ ] **Step 5: Final commit if any format fixups**
+
+```bash
+git add -A
+git commit -m "chore(ROB-715): lint/format fixups" || echo "nothing to commit"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- (a) forecast-resolution + retrospective link → Tasks 1–3 (backend maps) + Task 6 (render). ✓
+- (b) raw fields (trigger_checklist, max_action, structured_evidence summary, decision_bucket badge) → Task 4 (summary backend) + Task 7 (render). ✓
+- (c) plan-vs-actual → Task 8. ✓
+- (d) analysis_artifacts → explicitly deferred (spec D1); no task. ✓
+- Batch maps on bundle (D2) → Tasks 2–3. ✓
+- Exact join + "해소 대기 / 미연결" empty state (D3) → Task 1 (exact `report_item_uuid`), Task 6 (empty state). ✓
+- Migration 0 / read-only / ROB-501 / no decision_history edits → Global Constraints + Task 9 guard run. ✓
+- Test-DB xdist discipline (unique uuid + flush-only) → Global Constraints + Task 1 tests. ✓
+
+**Type consistency:** `ForecastLinkResponse`/`RetrospectiveLinkResponse` (backend) ↔ `ForecastLink`/`RetrospectiveLink` (frontend) field names align (snake↔camel). `list_forecasts_for_item_uuids` / `list_retrospectives_for_item_uuids` used identically in Tasks 1–2. Bundle keys `forecasts_by_item_uuid` / `retrospectives_by_item_uuid` consistent across Tasks 2–3–5. `structured_evidence_summary` ↔ `structuredEvidenceSummary` consistent across Tasks 4–5–7. `summarize_structured_evidence` used identically in Task 4.
+
+**Placeholder scan:** No TBD/TODO. Every code step shows the code. Fixture-shape assumptions (`buildBundleFixture`, `_seed_single_item_report`) are flagged with explicit fallback instructions rather than left implicit, because the exact test-harness helper names must be confirmed against the existing files at implementation time.

--- a/docs/superpowers/specs/2026-07-05-rob-715-invest-item-loop-render-design.md
+++ b/docs/superpowers/specs/2026-07-05-rob-715-invest-item-loop-render-design.md
@@ -1,0 +1,185 @@
+# ROB-715 — /invest item-level learning-loop render
+
+Design spec. Generated 2026-07-05. Branch: `rob-715`. Stage 5 (final) of the
+판단→결과 learning-loop roadmap (ROB-711~715). Office-hours design:
+`~/.gstack/projects/mgh3326-auto_trader/mgh3326-main-design-20260705-161950.md` §5단계.
+
+## Problem
+
+/invest report-item rows render `rationale` / `confidence` / `linkedOrders`
+(one hop) and the ROB-692/693 `tradeSetup` R:R pill — but the item→forecast
+해소→회고 chain is invisible. Forecasts and retrospectives exist only as the
+market/symbol aggregates on /insights. This is the audit/trust human surface
+(design premise P2 — the LLM analysis session is the *primary* consumer via
+decision_history injection; the web is the secondary audit면).
+
+Several item fields are stored but never rendered: `trigger_checklist`,
+`max_action`, `structured_evidence`, and `decision_bucket` (surfaced only
+indirectly via the ROB-308/322 section projection, never as an item-row badge).
+
+**Success criterion:** from a report item, reach "이 판단의 결과
+(체결→forecast 해소→회고)" within 2 clicks.
+
+## Decisions (2026-07-05, user-confirmed)
+
+- **D1 — Scope = Core (a+b+c), defer d.** This PR ships: (a) forecast-resolution
+  status + retrospective link on item rows, (b) render the already-normalized raw
+  fields, (c) plan-vs-actual (frontend-only juxtaposition). **Deferred to a
+  follow-up**: (d) `analysis_artifacts` links via correlation_id — needs a new
+  read endpoint (service-layer `list_artifacts(correlation_id=...)` exists but is
+  unexposed) and carries the least success-criterion value.
+- **D2 — Delivery = batch maps on the bundle.** Attach
+  `forecasts_by_item_uuid` + `retrospectives_by_item_uuid` to the
+  investment-reports bundle response, mirroring the existing
+  `linked_orders_by_item_uuid` / `decisions_by_item_uuid`. One fetch, no
+  per-item N+1 (ROB-713/717 fanout perf lesson).
+- **D3 — Join = exact `report_item_uuid` only.** An audit surface must show
+  *this item's own* forecast/retro, not any symbol match (symbol-window would
+  mis-attribute another item's forecast). Empty renders as "해소 대기 / 미연결".
+  Adoption of `report_item_uuid` on forecasts/retros is near-zero today (measured
+  forecasts 0/2, retros 0/5); ROB-714 place-time auto-forecast + operator
+  discipline fill it going forward. This is a forward-looking surface.
+
+## Grounding (verified in code)
+
+- **Join key.** `list_linked_orders_for_item_uuids(db, item_uuids)`
+  (`app/services/investment_reports/linked_orders.py:105`) queries each live
+  ledger `WHERE report_item_uuid.in_(item_uuids)` and keys the result by
+  `str(row.report_item_uuid)`. The router sets
+  `resp.linked_orders = linked_by_uuid.get(str(it.item_uuid))`
+  (`app/routers/investment_reports.py:64`). So the item's `item_uuid` **is** what
+  downstream tables store in their `report_item_uuid` column. The same join
+  applies to forecasts and retrospectives.
+- **`TradeForecast`** (`app/models/review.py:1101`) carries `report_item_uuid`,
+  `status` ('open'|'closed'), `outcome`, `review_date`, `resolution_source`,
+  `brier_score`, `probability`, and the `forecast_target` JSONB (direction /
+  target_price). `serialize_forecast` (`forecast_service.py:190`) already
+  projects all of these.
+- **`TradeRetrospective`** (`app/models/review.py:969`) carries
+  `report_item_uuid`, `outcome`, `lesson`, `result_summary`, `next_strategy`,
+  `root_cause_class`, `trigger_type`, `pnl_pct`, `next_actions`, `created_at`.
+- **Bundle batch-map pattern.** `query_service.py:160-177` builds
+  `linked_orders_by_item_uuid` + `decisions_by_item`; `_serialise_bundle`
+  (`investment_reports.py:56-115`) folds `decisions_by_item_uuid` onto the
+  response. New maps slot into the same two seams.
+- **Frontend item render.** `ItemRow`
+  (`frontend/invest/src/components/investment-reports/InvestmentReportBundleContent.tsx:276`)
+  already renders confidence, rationale, `tradeSetup` (planned entry/stop/target,
+  R:R pill), `invalidationTriggers`, `linkedOrders` (actual fills). The TS layer
+  (`api/investmentReports.ts`, `types/investmentReports.ts`) already **normalizes
+  but does not render** `triggerChecklist`, `maxAction`, `decisionBucket`; carries
+  both `itemUuid` and `reportItemUuid`.
+- **ROB-716 reuse boundary.** ROB-716 built `build_decision_context(db, symbol,
+  market)` (`app/services/decision_history.py`) — symbol-scoped, embedded in
+  stock-detail. **ROB-717 owns edits to `decision_history.py` / `aggregates.py`.**
+  ROB-715 does **not** touch them: it queries forecasts/retros directly by
+  `report_item_uuid`, which is item-scoped and avoids that ownership overlap.
+
+## Architecture
+
+Thin read-only backend (additive schema, migration 0) + frontend render. No
+broker/order/watch/order-intent mutation is reachable. ROB-501: all deterministic
+reads, no in-process LLM import.
+
+### Backend
+
+1. **New file** `app/services/investment_reports/item_loop_links.py` — modeled on
+   `linked_orders.py`:
+   - `list_forecasts_for_item_uuids(db, item_uuids) -> dict[str, list[ForecastLinkView]]`
+     — one batched `SELECT ... WHERE report_item_uuid IN (item_uuids)` on
+     `TradeForecast`, `id desc`, keyed by `str(report_item_uuid)`. Projects
+     `forecast_id`, `status`, `outcome`, `review_date`, `direction`,
+     `target_price`, `probability`, `brier_score`, `resolution_source`.
+   - `list_retrospectives_for_item_uuids(db, item_uuids) -> dict[str, list[RetrospectiveLinkView]]`
+     — same shape on `TradeRetrospective`. Projects `outcome`, `lesson`,
+     `result_summary`, `root_cause_class`, `trigger_type`, `pnl_pct`,
+     `created_at`.
+   - Items with no rows are absent from the dict (caller treats missing as
+     "미연결").
+   - `report_item_uuid` is stored as text on these two tables (vs `PG_UUID` on the
+     ledgers) — pass `str(uuid)` values in the `IN` clause. Verify column type in
+     implementation and coerce accordingly.
+2. `app/services/investment_reports/query_service.py` — call both new loaders
+   alongside `list_linked_orders_for_item_uuids`; add `forecasts_by_item_uuid`
+   and `retrospectives_by_item_uuid` to the returned bundle dict.
+3. `app/schemas/investment_reports.py` — additive:
+   - `ForecastLinkResponse`, `RetrospectiveLinkResponse` (projection models).
+   - `forecasts_by_item_uuid: dict[str, list[ForecastLinkResponse]]` and
+     `retrospectives_by_item_uuid: dict[str, list[RetrospectiveLinkResponse]]`
+     on `InvestmentReportBundle` (default empty dict — legacy-safe).
+   - `structured_evidence_summary: str | None` on the item response — a
+     deterministic backend-derived summary of `structured_evidence` so the
+     frontend displays a string without parsing the nested structure
+     ("백엔드 전용 — 프론트 미파싱"). If `structured_evidence` is a subtree of
+     `evidence_snapshot` rather than a distinct column, derive from there;
+     confirm the field's home during implementation.
+4. `app/routers/investment_reports.py::_serialise_bundle` — build
+   `forecasts_by_item_uuid` and `retrospectives_by_item_uuid` from the bundle
+   dict exactly as `decisions_by_item_uuid` is built, and pass them to
+   `InvestmentReportBundle`.
+
+### Frontend
+
+5. `frontend/invest/src/types/investmentReports.ts` — add `ForecastLink`,
+   `RetrospectiveLink` interfaces + the two bundle map fields +
+   `structuredEvidenceSummary` on the item type.
+6. `frontend/invest/src/api/investmentReports.ts` — normalize
+   `forecasts_by_item_uuid` / `retrospectives_by_item_uuid` (snake→camel, same as
+   `decisions_by_item_uuid`) and `structured_evidence_summary`.
+7. `InvestmentReportBundleContent.tsx::ItemRow` — the render:
+   - **(a) Loop section (2-click success path).** For the row's forecasts: show
+     `status` (open/closed), `outcome` (hit/miss/pending), `brier_score` when
+     scored, `review_date`. For retrospectives: show `outcome` + `lesson`
+     (expandable to `result_summary` / `root_cause_class`). When **both** maps
+     are empty for the item → muted "해소 대기 / 미연결".
+   - **(b) Raw fields.** `triggerChecklist` → chips; `maxAction` → compact
+     exec-plan summary (side / qty|notional / limit / ladder_level);
+     `decisionBucket` → **small inline row-level badge only** (must not
+     re-project the ROB-308/322 sections); `structuredEvidenceSummary` → text.
+   - **(c) Plan-vs-actual.** Juxtapose parsed `tradeSetup` planned
+     entry/stop/target (already rendered) with the actual fill price already
+     present on `linkedOrders`. Pure frontend — extends the existing R:R pill
+     block, no new data.
+
+## Testing
+
+- **Backend (pytest).** Unit tests for `item_loop_links.py`: exact join returns
+  only matching `report_item_uuid` rows, correct string key, empty → key absent,
+  multiple forecasts/retros per item ordered. Query-service test that the bundle
+  dict carries both maps. Serializer test that `_serialise_bundle` folds them onto
+  `InvestmentReportBundle` and legacy bundles (missing keys) default to empty.
+  **Shared-DB xdist discipline (bit ROB-711/713/705 three times): per-test unique
+  symbols + `flush()`-only, never `commit()`; no autouse global-DELETE fixture.**
+- **Frontend (vitest).** `ItemRow` renders forecast status + retrospective,
+  renders the "해소 대기 / 미연결" empty state, renders trigger_checklist chips /
+  max_action / decision_bucket badge / structured_evidence summary, and renders
+  the plan-vs-actual juxtaposition. Follow existing
+  `InvestmentReportBundleContent` test conventions.
+- **Guards regression.** ROB-501 no-internal-LLM-import guard stays green;
+  invest_view_model import-boundary guard unaffected (this work is in the
+  `investment_reports/` router surface, not the view-model read path).
+
+## Constraints / guards
+
+- migration 0 (read-path only; all schema additions are response-model fields).
+- No broker/order/watch/order-intent mutation reachable from any new code.
+- ROB-501: deterministic reads only, no in-process LLM provider import.
+- One batched query per table — no per-item N+1.
+- Do not edit `app/services/decision_history.py` or
+  `app/services/trade_journal/aggregates.py` (ROB-717 ownership).
+- `decision_bucket` badge is row-level auxiliary only — no UX duplication with
+  the ROB-308/322 section projection.
+
+## Deferred (follow-up issue)
+
+- **(d) analysis_artifacts item links.** Expose `correlation_id` /
+  `report_item` filter on the `invest_artifacts` router (service-layer
+  `list_artifacts(correlation_id=...)` already exists) and render report/item →
+  artifact links. Deferred from this PR per D1.
+
+## Open questions
+
+- Exact home of `structured_evidence` (distinct column vs `evidence_snapshot`
+  subtree) — resolve at implementation; the summary derivation adapts either way.
+- `max_action` render density — start with a one-line summary; expand only if the
+  operator asks.

--- a/frontend/invest/src/__tests__/InvestmentReportBundleContent.loopSection.test.tsx
+++ b/frontend/invest/src/__tests__/InvestmentReportBundleContent.loopSection.test.tsx
@@ -144,4 +144,12 @@ describe("ROB-715 item loop section", () => {
     renderContent(bundle);
     expect(screen.getByText("해소 대기 / 미연결")).toBeInTheDocument();
   });
+
+  it("suppresses the empty placeholder for non-action items without loop data", () => {
+    const bundle = makeBundle(makeItem({ itemKind: "watch" }));
+    bundle.forecastsByItemUuid = {};
+    bundle.retrospectivesByItemUuid = {};
+    renderContent(bundle);
+    expect(screen.queryByText("해소 대기 / 미연결")).not.toBeInTheDocument();
+  });
 });

--- a/frontend/invest/src/__tests__/InvestmentReportBundleContent.loopSection.test.tsx
+++ b/frontend/invest/src/__tests__/InvestmentReportBundleContent.loopSection.test.tsx
@@ -1,0 +1,147 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it, vi } from "vitest";
+
+import { InvestmentReportBundleContent } from "../components/investment-reports/InvestmentReportBundleContent";
+import type {
+  InvestmentReport,
+  InvestmentReportBundle,
+  InvestmentReportItem,
+} from "../types/investmentReports";
+
+vi.mock("../hooks/useInvestmentReportBundle", () => ({
+  useInvestmentReportBundle: vi.fn(),
+}));
+
+import { useInvestmentReportBundle } from "../hooks/useInvestmentReportBundle";
+
+function makeReport(): InvestmentReport {
+  return {
+    reportUuid: "00000000-0000-0000-0000-000000000001",
+    reportType: "kr_morning",
+    market: "kr",
+    marketSession: "regular",
+    accountScope: "upbit_live",
+    executionMode: "advisory_only",
+    createdByProfile: "test",
+    title: "Test Report",
+    summary: "summary",
+    riskSummary: null,
+    thesisText: null,
+    noActionNote: null,
+    marketSnapshot: {},
+    portfolioSnapshot: {},
+    previousReportUuid: null,
+    status: "published",
+    metadata: {},
+    createdAt: "2026-06-12T00:00:00Z",
+    updatedAt: "2026-06-12T00:00:00Z",
+    publishedAt: null,
+    validUntil: null,
+    snapshotBundleUuid: null,
+    snapshotPolicyVersion: null,
+    snapshotCoverageSummary: null,
+    snapshotFreshnessSummary: null,
+    sourceConflicts: null,
+    unavailableSources: null,
+  };
+}
+
+function makeItem(overrides: Partial<InvestmentReportItem>): InvestmentReportItem {
+  return {
+    itemUuid: "u1",
+    itemKind: "action",
+    symbol: "BTC",
+    side: "buy",
+    intent: "buy_review",
+    rationale: "test rationale",
+    targetKind: "asset",
+    priority: 0,
+    confidence: null,
+    evidenceSnapshot: {},
+    watchCondition: null,
+    triggerChecklist: [],
+    maxAction: {},
+    validUntil: null,
+    status: "proposed",
+    metadata: {},
+    createdAt: "2026-06-12T00:00:00Z",
+    updatedAt: "2026-06-12T00:00:00Z",
+    operation: null,
+    targetRef: null,
+    currentState: null,
+    proposedState: null,
+    diff: null,
+    applyPolicy: null,
+    ...overrides,
+  };
+}
+
+function renderContent(bundle: InvestmentReportBundle) {
+  (useInvestmentReportBundle as unknown as ReturnType<typeof vi.fn>).mockReturnValue(
+    { status: "ready", bundle, error: null, reload: vi.fn() },
+  );
+  return render(
+    <MemoryRouter initialEntries={["/reports/00000000-0000-0000-0000-000000000001"]}>
+      <InvestmentReportBundleContent />
+    </MemoryRouter>,
+  );
+}
+
+function makeBundle(item: InvestmentReportItem): InvestmentReportBundle {
+  return {
+    report: makeReport(),
+    items: [item],
+    decisionsByItemUuid: {},
+    alerts: [],
+    events: [],
+    forecastsByItemUuid: {},
+    retrospectivesByItemUuid: {},
+  };
+}
+
+describe("ROB-715 item loop section", () => {
+  it("renders forecast status and retrospective outcome for an item", () => {
+    const bundle = makeBundle(makeItem({}));
+    bundle.forecastsByItemUuid = {
+      u1: [
+        {
+          forecastId: "f1",
+          status: "closed",
+          outcome: true,
+          reviewDate: "2026-07-20",
+          direction: "at_or_above",
+          targetPrice: 200000,
+          probability: 0.6,
+          brierScore: 0.09,
+          resolutionSource: "ohlcv_day",
+        },
+      ],
+    };
+    bundle.retrospectivesByItemUuid = {
+      u1: [
+        {
+          retrospectiveId: 1,
+          outcome: "filled",
+          lesson: "held to target",
+          resultSummary: null,
+          rootCauseClass: null,
+          triggerType: null,
+          pnlPct: 4.2,
+          createdAt: null,
+        },
+      ],
+    };
+    renderContent(bundle);
+    expect(screen.getByTestId("item-loop-forecast-f1")).toBeInTheDocument();
+    expect(screen.getByText(/held to target/)).toBeInTheDocument();
+  });
+
+  it("renders the empty state when an item has no forecast or retrospective", () => {
+    const bundle = makeBundle(makeItem({}));
+    bundle.forecastsByItemUuid = {};
+    bundle.retrospectivesByItemUuid = {};
+    renderContent(bundle);
+    expect(screen.getByText("해소 대기 / 미연결")).toBeInTheDocument();
+  });
+});

--- a/frontend/invest/src/__tests__/InvestmentReportBundleContent.planVsActual.test.tsx
+++ b/frontend/invest/src/__tests__/InvestmentReportBundleContent.planVsActual.test.tsx
@@ -1,0 +1,141 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it, vi } from "vitest";
+
+import { InvestmentReportBundleContent } from "../components/investment-reports/InvestmentReportBundleContent";
+import type {
+  InvestmentReport,
+  InvestmentReportBundle,
+  InvestmentReportItem,
+} from "../types/investmentReports";
+
+vi.mock("../hooks/useInvestmentReportBundle", () => ({
+  useInvestmentReportBundle: vi.fn(),
+}));
+
+import { useInvestmentReportBundle } from "../hooks/useInvestmentReportBundle";
+
+function makeReport(): InvestmentReport {
+  return {
+    reportUuid: "00000000-0000-0000-0000-000000000001",
+    reportType: "kr_morning",
+    market: "kr",
+    marketSession: "regular",
+    accountScope: "upbit_live",
+    executionMode: "advisory_only",
+    createdByProfile: "test",
+    title: "Test Report",
+    summary: "summary",
+    riskSummary: null,
+    thesisText: null,
+    noActionNote: null,
+    marketSnapshot: {},
+    portfolioSnapshot: {},
+    previousReportUuid: null,
+    status: "published",
+    metadata: {},
+    createdAt: "2026-06-12T00:00:00Z",
+    updatedAt: "2026-06-12T00:00:00Z",
+    publishedAt: null,
+    validUntil: null,
+    snapshotBundleUuid: null,
+    snapshotPolicyVersion: null,
+    snapshotCoverageSummary: null,
+    snapshotFreshnessSummary: null,
+    sourceConflicts: null,
+    unavailableSources: null,
+  };
+}
+
+function makeItem(overrides: Partial<InvestmentReportItem>): InvestmentReportItem {
+  return {
+    itemUuid: "u1",
+    itemKind: "action",
+    symbol: "BTC",
+    side: "buy",
+    intent: "buy_review",
+    rationale: "test rationale",
+    targetKind: "asset",
+    priority: 0,
+    confidence: null,
+    evidenceSnapshot: {},
+    watchCondition: null,
+    triggerChecklist: [],
+    maxAction: {},
+    validUntil: null,
+    status: "proposed",
+    metadata: {},
+    createdAt: "2026-06-12T00:00:00Z",
+    updatedAt: "2026-06-12T00:00:00Z",
+    operation: null,
+    targetRef: null,
+    currentState: null,
+    proposedState: null,
+    diff: null,
+    applyPolicy: null,
+    ...overrides,
+  };
+}
+
+function renderContent(bundle: InvestmentReportBundle) {
+  (useInvestmentReportBundle as unknown as ReturnType<typeof vi.fn>).mockReturnValue(
+    { status: "ready", bundle, error: null, reload: vi.fn() },
+  );
+  return render(
+    <MemoryRouter initialEntries={["/reports/00000000-0000-0000-0000-000000000001"]}>
+      <InvestmentReportBundleContent />
+    </MemoryRouter>,
+  );
+}
+
+function makeBundle(item: InvestmentReportItem): InvestmentReportBundle {
+  return {
+    report: makeReport(),
+    items: [item],
+    decisionsByItemUuid: {},
+    alerts: [],
+    events: [],
+    forecastsByItemUuid: {},
+    retrospectivesByItemUuid: {},
+  };
+}
+
+describe("ROB-715 plan vs actual", () => {
+  it("shows planned entry alongside the actual fill price", () => {
+    const bundle = makeBundle(
+      makeItem({
+        evidenceSnapshot: {
+          trade_setup: {
+            direction: "long",
+            stop: "65000",
+            target: "78000",
+            headline: {
+              entry: "70000",
+              risk_pct: "7.14",
+              reward_pct: "11.43",
+              rr_ratio: "1.60",
+            },
+          },
+        },
+        linkedOrders: [
+          {
+            broker: "upbit",
+            accountScope: "upbit_live",
+            market: "crypto",
+            orderNo: "ord-1",
+            ledgerId: 7,
+            symbol: "BTC",
+            side: "buy",
+            status: "filled",
+            filledQty: "0.01",
+            avgFillPrice: "69450",
+          },
+        ],
+      }),
+    );
+    renderContent(bundle);
+    const pva = screen.getByTestId("item-plan-vs-actual");
+    expect(pva).toHaveTextContent("70000"); // planned entry
+    expect(pva).toHaveTextContent("69450"); // actual fill
+  });
+});

--- a/frontend/invest/src/__tests__/InvestmentReportBundleContent.rawFields.test.tsx
+++ b/frontend/invest/src/__tests__/InvestmentReportBundleContent.rawFields.test.tsx
@@ -118,4 +118,16 @@ describe("ROB-715 raw item fields", () => {
     expect(screen.getByText(/2 evidence fields/)).toBeInTheDocument();
     expect(screen.getByTestId("item-max-action")).toBeInTheDocument();
   });
+
+  it("formats a quantity-based max_action with the 주 suffix (not mojibake)", () => {
+    const bundle = makeBundle(
+      makeItem({
+        maxAction: { side: "buy", quantity: 10, limit_price: 195000 },
+      }),
+    );
+    renderContent(bundle);
+    const maxAction = screen.getByTestId("item-max-action");
+    expect(maxAction).toHaveTextContent("10주");
+    expect(maxAction.textContent).not.toContain("······");
+  });
 });

--- a/frontend/invest/src/__tests__/InvestmentReportBundleContent.rawFields.test.tsx
+++ b/frontend/invest/src/__tests__/InvestmentReportBundleContent.rawFields.test.tsx
@@ -1,0 +1,121 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it, vi } from "vitest";
+
+import { InvestmentReportBundleContent } from "../components/investment-reports/InvestmentReportBundleContent";
+import type {
+  InvestmentReport,
+  InvestmentReportBundle,
+  InvestmentReportItem,
+} from "../types/investmentReports";
+
+vi.mock("../hooks/useInvestmentReportBundle", () => ({
+  useInvestmentReportBundle: vi.fn(),
+}));
+
+import { useInvestmentReportBundle } from "../hooks/useInvestmentReportBundle";
+
+function makeReport(): InvestmentReport {
+  return {
+    reportUuid: "00000000-0000-0000-0000-000000000001",
+    reportType: "kr_morning",
+    market: "kr",
+    marketSession: "regular",
+    accountScope: "upbit_live",
+    executionMode: "advisory_only",
+    createdByProfile: "test",
+    title: "Test Report",
+    summary: "summary",
+    riskSummary: null,
+    thesisText: null,
+    noActionNote: null,
+    marketSnapshot: {},
+    portfolioSnapshot: {},
+    previousReportUuid: null,
+    status: "published",
+    metadata: {},
+    createdAt: "2026-06-12T00:00:00Z",
+    updatedAt: "2026-06-12T00:00:00Z",
+    publishedAt: null,
+    validUntil: null,
+    snapshotBundleUuid: null,
+    snapshotPolicyVersion: null,
+    snapshotCoverageSummary: null,
+    snapshotFreshnessSummary: null,
+    sourceConflicts: null,
+    unavailableSources: null,
+  };
+}
+
+function makeItem(overrides: Partial<InvestmentReportItem>): InvestmentReportItem {
+  return {
+    itemUuid: "u1",
+    itemKind: "action",
+    symbol: "BTC",
+    side: "buy",
+    intent: "buy_review",
+    rationale: "test rationale",
+    targetKind: "asset",
+    priority: 0,
+    confidence: null,
+    evidenceSnapshot: {},
+    watchCondition: null,
+    triggerChecklist: [],
+    maxAction: {},
+    validUntil: null,
+    status: "proposed",
+    metadata: {},
+    createdAt: "2026-06-12T00:00:00Z",
+    updatedAt: "2026-06-12T00:00:00Z",
+    operation: null,
+    targetRef: null,
+    currentState: null,
+    proposedState: null,
+    diff: null,
+    applyPolicy: null,
+    ...overrides,
+  };
+}
+
+function renderContent(bundle: InvestmentReportBundle) {
+  (useInvestmentReportBundle as unknown as ReturnType<typeof vi.fn>).mockReturnValue(
+    { status: "ready", bundle, error: null, reload: vi.fn() },
+  );
+  return render(
+    <MemoryRouter initialEntries={["/reports/00000000-0000-0000-0000-000000000001"]}>
+      <InvestmentReportBundleContent />
+    </MemoryRouter>,
+  );
+}
+
+function makeBundle(item: InvestmentReportItem): InvestmentReportBundle {
+  return {
+    report: makeReport(),
+    items: [item],
+    decisionsByItemUuid: {},
+    alerts: [],
+    events: [],
+    forecastsByItemUuid: {},
+    retrospectivesByItemUuid: {},
+  };
+}
+
+describe("ROB-715 raw item fields", () => {
+  it("renders trigger checklist, max_action, decision bucket badge, evidence summary", () => {
+    const bundle = makeBundle(
+      makeItem({
+        triggerChecklist: ["RSI < 30", "종가 20MA 회복"],
+        maxAction: { side: "buy", notional: 1000000, limit_price: 195000 },
+        decisionBucket: "new_buy_candidate",
+        structuredEvidenceSummary: "2 evidence fields: momentum, valuation",
+      }),
+    );
+    renderContent(bundle);
+    expect(screen.getByText("RSI < 30")).toBeInTheDocument();
+    expect(screen.getByTestId("item-decision-bucket-badge")).toHaveTextContent(
+      "new_buy_candidate",
+    );
+    expect(screen.getByText(/2 evidence fields/)).toBeInTheDocument();
+    expect(screen.getByTestId("item-max-action")).toBeInTheDocument();
+  });
+});

--- a/frontend/invest/src/__tests__/investmentReports.loopMaps.test.ts
+++ b/frontend/invest/src/__tests__/investmentReports.loopMaps.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import {
+  normalizeForecastLink,
+  normalizeRetrospectiveLink,
+} from "../api/investmentReports";
+
+describe("ROB-715 loop-map normalizers", () => {
+  it("normalizes a forecast link snake→camel", () => {
+    const out = normalizeForecastLink({
+      forecast_id: "f1",
+      status: "closed",
+      outcome: true,
+      review_date: "2026-07-20",
+      direction: "at_or_above",
+      target_price: 200000,
+      probability: 0.6,
+      brier_score: 0.09,
+      resolution_source: "ohlcv_day",
+    });
+    expect(out.forecastId).toBe("f1");
+    expect(out.status).toBe("closed");
+    expect(out.outcome).toBe(true);
+    expect(out.targetPrice).toBe(200000);
+    expect(out.brierScore).toBe(0.09);
+  });
+
+  it("normalizes a retrospective link", () => {
+    const out = normalizeRetrospectiveLink({
+      retrospective_id: 1,
+      outcome: "filled",
+      lesson: "cut late",
+      root_cause_class: "execution",
+      pnl_pct: -3.5,
+    });
+    expect(out.outcome).toBe("filled");
+    expect(out.lesson).toBe("cut late");
+    expect(out.pnlPct).toBe(-3.5);
+  });
+});

--- a/frontend/invest/src/api/investmentReports.ts
+++ b/frontend/invest/src/api/investmentReports.ts
@@ -15,6 +15,8 @@ import type {
   InvestmentReportBundle,
   InvestmentReportItem,
   InvestmentReportItemDecision,
+  ForecastLink,
+  RetrospectiveLink,
   LinkedOrder,
   InvestmentReportListResponse,
   InvestmentWatchAlert,
@@ -172,6 +174,40 @@ export function normalizeLinkedOrder(raw: ApiItem): LinkedOrder {
   };
 }
 
+export function normalizeForecastLink(raw: ApiItem): ForecastLink {
+  return {
+    forecastId: String(raw.forecast_id ?? ""),
+    status: String(raw.status ?? ""),
+    outcome:
+      raw.outcome === null || raw.outcome === undefined
+        ? null
+        : Boolean(raw.outcome),
+    reviewDate: asOptionalString(raw.review_date) ?? null,
+    direction: asOptionalString(raw.direction) ?? null,
+    targetPrice:
+      raw.target_price == null ? null : Number(raw.target_price),
+    probability: Number(raw.probability ?? 0),
+    brierScore:
+      raw.brier_score == null ? null : Number(raw.brier_score),
+    resolutionSource: asOptionalString(raw.resolution_source) ?? null,
+  };
+}
+
+export function normalizeRetrospectiveLink(
+  raw: ApiItem,
+): RetrospectiveLink {
+  return {
+    retrospectiveId: Number(raw.retrospective_id ?? 0),
+    outcome: String(raw.outcome ?? ""),
+    lesson: asOptionalString(raw.lesson) ?? null,
+    resultSummary: asOptionalString(raw.result_summary) ?? null,
+    rootCauseClass: asOptionalString(raw.root_cause_class) ?? null,
+    triggerType: asOptionalString(raw.trigger_type) ?? null,
+    pnlPct: raw.pnl_pct == null ? null : Number(raw.pnl_pct),
+    createdAt: asOptionalString(raw.created_at) ?? null,
+  };
+}
+
 function normalizeItem(raw: ApiItem): InvestmentReportItem {
   return {
     itemUuid: asString(raw.item_uuid),
@@ -213,6 +249,10 @@ function normalizeItem(raw: ApiItem): InvestmentReportItem {
       raw.linked_orders === null || raw.linked_orders === undefined
         ? null
         : asArray<ApiItem>(raw.linked_orders).map(normalizeLinkedOrder),
+    // ROB-715 — backend-derived summary (frontend never parses the nested
+    // structured_evidence structure).
+    structuredEvidenceSummary:
+      asOptionalString(raw.structured_evidence_summary) ?? null,
   };
 }
 
@@ -400,6 +440,8 @@ export async function fetchInvestmentReportBundle(
     events?: ApiEvent[];
     review_sections?: unknown;
     action_packet?: unknown;
+    forecasts_by_item_uuid?: Record<string, ApiItem[]>;
+    retrospectives_by_item_uuid?: Record<string, ApiItem[]>;
   }>(BUNDLE_ENDPOINT(reportUuid), signal);
 
   const decisionsRaw = raw.decisions_by_item_uuid ?? {};
@@ -407,6 +449,20 @@ export async function fetchInvestmentReportBundle(
   for (const [itemUuid, decisions] of Object.entries(decisionsRaw)) {
     decisionsByItemUuid[itemUuid] = asArray<ApiDecision>(decisions).map(
       normalizeDecision,
+    );
+  }
+
+  // ROB-715 — item→forecast/retrospective exact-join maps keyed by item UUID.
+  const forecastsRaw = raw.forecasts_by_item_uuid ?? {};
+  const forecastsByItemUuid: Record<string, ForecastLink[]> = {};
+  for (const [k, v] of Object.entries(forecastsRaw)) {
+    forecastsByItemUuid[k] = asArray<ApiItem>(v).map(normalizeForecastLink);
+  }
+  const retrospectivesRaw = raw.retrospectives_by_item_uuid ?? {};
+  const retrospectivesByItemUuid: Record<string, RetrospectiveLink[]> = {};
+  for (const [k, v] of Object.entries(retrospectivesRaw)) {
+    retrospectivesByItemUuid[k] = asArray<ApiItem>(v).map(
+      normalizeRetrospectiveLink,
     );
   }
 
@@ -418,6 +474,8 @@ export async function fetchInvestmentReportBundle(
     events: asArray<ApiEvent>(raw.events).map(normalizeEvent),
     reviewSections: normalizeReviewSections(raw.review_sections),
     actionPacket: normalizeActionPacket(raw.action_packet),
+    forecastsByItemUuid,
+    retrospectivesByItemUuid,
   };
 }
 

--- a/frontend/invest/src/components/investment-reports/InvestmentReportBundleContent.tsx
+++ b/frontend/invest/src/components/investment-reports/InvestmentReportBundleContent.tsx
@@ -11,12 +11,14 @@ import { useInvestmentReportBundle } from "../../hooks/useInvestmentReportBundle
 import { LinkedOrderRow, linkedOrderKey } from "../orders/LinkedOrderRow";
 import type {
   DeliveryStatus,
+  ForecastLink,
   InvestmentReportItem,
   InvestmentReportItemDecision,
   InvestmentWatchAlert,
   InvestmentWatchEvent,
   NoActionSummary,
   ReportReviewSections,
+  RetrospectiveLink,
   SnapshotFreshnessSummary,
   SnapshotReportDiagnostics,
 } from "../../types/investmentReports";
@@ -276,9 +278,13 @@ function parseInvalidationTriggers(
 function ItemRow({
   item,
   decisions,
+  forecastLinks,
+  retrospectiveLinks,
 }: {
   item: InvestmentReportItem;
   decisions: InvestmentReportItemDecision[];
+  forecastLinks?: ForecastLink[];
+  retrospectiveLinks?: RetrospectiveLink[];
 }) {
   const kindLabel = ITEM_KIND_LABELS[item.itemKind] ?? item.itemKind;
   const statusLabel = ITEM_STATUS_LABELS[item.status] ?? item.status;
@@ -383,6 +389,64 @@ function ItemRow({
           ))}
         </div>
       ) : null}
+      {/* ROB-715 — forecast → fill → retrospective learning loop. */}
+      <div data-testid={`item-loop-${item.itemUuid}`}>
+        {(forecastLinks ?? []).length === 0 &&
+        (retrospectiveLinks ?? []).length === 0 ? (
+          <span
+            className="item-loop-empty muted"
+            style={{ fontSize: 12, color: "var(--fg-3)" }}
+          >
+            해소 대기 / 미연결
+          </span>
+        ) : (
+          <div
+            style={{
+              display: "grid",
+              gap: 4,
+              padding: 10,
+              border: "1px solid var(--border)",
+              borderRadius: 10,
+              background: "var(--surface-2)",
+            }}
+          >
+            <div
+              style={{ fontSize: 12, color: "var(--fg-2)", fontWeight: 800 }}
+            >
+              학습 루프
+            </div>
+            {(forecastLinks ?? []).map((f) => (
+              <div
+                key={f.forecastId}
+                data-testid={`item-loop-forecast-${f.forecastId}`}
+                style={{ fontSize: 12, color: "var(--fg-2)" }}
+              >
+                <span>
+                  {f.status === "closed"
+                    ? f.outcome
+                      ? "적중"
+                      : "빗나감"
+                    : "해소 대기"}
+                </span>
+                {f.brierScore != null ? (
+                  <span> · Brier {f.brierScore.toFixed(2)}</span>
+                ) : null}
+                {f.reviewDate ? <span> · {f.reviewDate}</span> : null}
+              </div>
+            ))}
+            {(retrospectiveLinks ?? []).map((r) => (
+              <div
+                key={r.retrospectiveId}
+                data-testid={`item-loop-retro-${r.retrospectiveId}`}
+                style={{ fontSize: 12, color: "var(--fg-2)" }}
+              >
+                <span>회고: {r.outcome}</span>
+                {r.lesson ? <span> — {r.lesson}</span> : null}
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
       {item.watchCondition ? (
         <div
           style={{
@@ -602,10 +666,14 @@ function ReviewSectionsView({
   review,
   items,
   decisionsByItemUuid,
+  forecastsByItemUuid,
+  retrospectivesByItemUuid,
 }: {
   review: ReportReviewSections;
   items: InvestmentReportItem[];
   decisionsByItemUuid: Record<string, InvestmentReportItemDecision[]>;
+  forecastsByItemUuid: Record<string, ForecastLink[]>;
+  retrospectivesByItemUuid: Record<string, RetrospectiveLink[]>;
 }) {
   const projectedUuids = new Set(
     review.sections.flatMap((section) => section.items.map((it) => it.itemUuid)),
@@ -630,6 +698,10 @@ function ReviewSectionsView({
                   key={item.itemUuid}
                   item={item}
                   decisions={decisionsByItemUuid[item.itemUuid] ?? []}
+                  forecastLinks={forecastsByItemUuid[item.itemUuid] ?? []}
+                  retrospectiveLinks={
+                    retrospectivesByItemUuid[item.itemUuid] ?? []
+                  }
                 />
               ))
             ) : (
@@ -648,6 +720,10 @@ function ReviewSectionsView({
               key={item.itemUuid}
               item={item}
               decisions={decisionsByItemUuid[item.itemUuid] ?? []}
+              forecastLinks={forecastsByItemUuid[item.itemUuid] ?? []}
+              retrospectiveLinks={
+                retrospectivesByItemUuid[item.itemUuid] ?? []
+              }
             />
           ))}
         </section>
@@ -779,6 +855,8 @@ export function InvestmentReportBundleContent({
           review={review}
           items={bundle.items}
           decisionsByItemUuid={bundle.decisionsByItemUuid}
+          forecastsByItemUuid={bundle.forecastsByItemUuid ?? {}}
+          retrospectivesByItemUuid={bundle.retrospectivesByItemUuid ?? {}}
         />
       ) : (
         (["action", "watch", "risk"] as const).map((kind) =>
@@ -792,6 +870,12 @@ export function InvestmentReportBundleContent({
                   key={item.itemUuid}
                   item={item}
                   decisions={bundle.decisionsByItemUuid[item.itemUuid] ?? []}
+                  forecastLinks={
+                    bundle.forecastsByItemUuid?.[item.itemUuid] ?? []
+                  }
+                  retrospectiveLinks={
+                    bundle.retrospectivesByItemUuid?.[item.itemUuid] ?? []
+                  }
                 />
               ))}
             </section>

--- a/frontend/invest/src/components/investment-reports/InvestmentReportBundleContent.tsx
+++ b/frontend/invest/src/components/investment-reports/InvestmentReportBundleContent.tsx
@@ -422,9 +422,10 @@ function ItemRow({
           data-testid="item-plan-vs-actual"
           style={{ fontSize: 12, color: "var(--fg-2)" }}
         >
-          <span>
-            계획: 진입 {tradeSetup.headline.entry} · 손절 {tradeSetup.headline.riskPct}% · 목표 {tradeSetup.headline.rewardPct}%
-          </span>
+          {/* R:R (손절/목표 %) is already shown in the pill above; this row
+              adds the plan→actual juxtaposition the pill can't: planned entry
+              vs the actual fill price. */}
+          <span>계획 진입 {tradeSetup.headline.entry}</span>
           {(() => {
             const filled = (item.linkedOrders ?? []).find(
               (o) =>
@@ -433,12 +434,9 @@ function ItemRow({
                 String(o.avgFillPrice) !== "0",
             );
             return filled ? (
-              <span>
-                {" "}
-                · 실제 체결 {String(filled.avgFillPrice)}
-              </span>
+              <span> → 실제 체결 {String(filled.avgFillPrice)}</span>
             ) : (
-              <span style={{ color: "var(--fg-3)" }}> · 체결 없음</span>
+              <span style={{ color: "var(--fg-3)" }}> → 체결 대기</span>
             );
           })()}
         </div>
@@ -470,18 +468,24 @@ function ItemRow({
           ))}
         </div>
       ) : null}
-      {/* ROB-715 — forecast → fill → retrospective learning loop. */}
-      <div data-testid={`item-loop-${item.itemUuid}`}>
-        {(forecastLinks ?? []).length === 0 &&
-        (retrospectiveLinks ?? []).length === 0 ? (
-          <span
-            className="item-loop-empty muted"
-            style={{ fontSize: 12, color: "var(--fg-3)" }}
-          >
-            해소 대기 / 미연결
-          </span>
-        ) : (
-          <div
+      {/* ROB-715 — forecast → fill → retrospective learning loop. The
+          "not yet linked" placeholder is shown only for action items — watch/
+          risk rows rarely carry a forecast, so blanketing every row with it
+          would be noise. Rows with actual loop data render regardless of kind. */}
+      {(forecastLinks ?? []).length === 0 &&
+      (retrospectiveLinks ?? []).length === 0 &&
+      item.itemKind !== "action" ? null : (
+        <div data-testid={`item-loop-${item.itemUuid}`}>
+          {(forecastLinks ?? []).length === 0 &&
+          (retrospectiveLinks ?? []).length === 0 ? (
+            <span
+              className="item-loop-empty muted"
+              style={{ fontSize: 12, color: "var(--fg-3)" }}
+            >
+              해소 대기 / 미연결
+            </span>
+          ) : (
+            <div
             style={{
               display: "grid",
               gap: 4,
@@ -526,8 +530,9 @@ function ItemRow({
               </div>
             ))}
           </div>
-        )}
-      </div>
+          )}
+        </div>
+      )}
       {item.watchCondition ? (
         <div
           style={{

--- a/frontend/invest/src/components/investment-reports/InvestmentReportBundleContent.tsx
+++ b/frontend/invest/src/components/investment-reports/InvestmentReportBundleContent.tsx
@@ -275,6 +275,16 @@ function parseInvalidationTriggers(
   return raw as string[];
 }
 
+function formatMaxAction(a: Record<string, unknown>): string {
+  const parts: string[] = [];
+  if (a.side) parts.push(String(a.side));
+  if (a.quantity != null) parts.push(`${a.quantity}\u00b7\u00b7\u00b7\u00b7\u00b7\u00b7`);
+  if (a.notional != null) parts.push(`${a.notional}`);
+  if (a.limit_price != null) parts.push(`@${a.limit_price}`);
+  if (a.ladder_level != null) parts.push(`ladder ${a.ladder_level}`);
+  return parts.join(" · ");
+}
+
 function ItemRow({
   item,
   decisions,
@@ -351,6 +361,50 @@ function ItemRow({
       <div style={{ color: "var(--fg-2)", fontSize: 13, lineHeight: 1.55 }}>
         {item.rationale}
       </div>
+      {item.decisionBucket ? (
+        <span
+          className="item-decision-bucket-badge"
+          data-testid="item-decision-bucket-badge"
+          style={{
+            fontSize: 12,
+            fontWeight: 800,
+            color: "var(--fg-2)",
+            padding: "2px 8px",
+            border: "1px solid var(--border)",
+            borderRadius: 8,
+          }}
+        >
+          {item.decisionBucket}
+        </span>
+      ) : null}
+      {item.triggerChecklist && item.triggerChecklist.length > 0 ? (
+        <ul
+          className="item-trigger-checklist"
+          style={{ margin: 0, paddingLeft: 18, fontSize: 12, color: "var(--fg-2)" }}
+        >
+          {item.triggerChecklist.map((t: unknown, i: number) => (
+            <li key={i}>{String(t)}</li>
+          ))}
+        </ul>
+      ) : null}
+      {item.maxAction &&
+      Object.keys(item.maxAction).length > 0 ? (
+        <div
+          className="item-max-action"
+          data-testid="item-max-action"
+          style={{ fontSize: 12, color: "var(--fg-2)" }}
+        >
+          {formatMaxAction(item.maxAction as Record<string, unknown>)}
+        </div>
+      ) : null}
+      {item.structuredEvidenceSummary ? (
+        <div
+          className="item-structured-evidence"
+          style={{ fontSize: 12, color: "var(--fg-3)" }}
+        >
+          {item.structuredEvidenceSummary}
+        </div>
+      ) : null}
       {tradeSetup ? (
         <div style={{ display: "flex", gap: 6, flexWrap: "wrap", alignItems: "center" }}>
           <Pill tone={tradeSetup.direction === "long" ? "gain" : "warn"} size="sm">

--- a/frontend/invest/src/components/investment-reports/InvestmentReportBundleContent.tsx
+++ b/frontend/invest/src/components/investment-reports/InvestmentReportBundleContent.tsx
@@ -416,6 +416,33 @@ function ItemRow({
           </span>
         </div>
       ) : null}
+      {tradeSetup ? (
+        <div
+          className="item-plan-vs-actual"
+          data-testid="item-plan-vs-actual"
+          style={{ fontSize: 12, color: "var(--fg-2)" }}
+        >
+          <span>
+            계획: 진입 {tradeSetup.headline.entry} · 손절 {tradeSetup.headline.riskPct}% · 목표 {tradeSetup.headline.rewardPct}%
+          </span>
+          {(() => {
+            const filled = (item.linkedOrders ?? []).find(
+              (o) =>
+                o.avgFillPrice != null &&
+                o.avgFillPrice !== "" &&
+                String(o.avgFillPrice) !== "0",
+            );
+            return filled ? (
+              <span>
+                {" "}
+                · 실제 체결 {String(filled.avgFillPrice)}
+              </span>
+            ) : (
+              <span style={{ color: "var(--fg-3)" }}> · 체결 없음</span>
+            );
+          })()}
+        </div>
+      ) : null}
       {invalidationTriggers ? (
         <div style={{ display: "grid", gap: 4 }}>
           <div style={{ fontSize: 12, color: "var(--fg-2)", fontWeight: 800 }}>

--- a/frontend/invest/src/components/investment-reports/InvestmentReportBundleContent.tsx
+++ b/frontend/invest/src/components/investment-reports/InvestmentReportBundleContent.tsx
@@ -278,7 +278,7 @@ function parseInvalidationTriggers(
 function formatMaxAction(a: Record<string, unknown>): string {
   const parts: string[] = [];
   if (a.side) parts.push(String(a.side));
-  if (a.quantity != null) parts.push(`${a.quantity}\u00b7\u00b7\u00b7\u00b7\u00b7\u00b7`);
+  if (a.quantity != null) parts.push(`${a.quantity}\uc8fc`);
   if (a.notional != null) parts.push(`${a.notional}`);
   if (a.limit_price != null) parts.push(`@${a.limit_price}`);
   if (a.ladder_level != null) parts.push(`ladder ${a.ladder_level}`);

--- a/frontend/invest/src/types/investmentReports.ts
+++ b/frontend/invest/src/types/investmentReports.ts
@@ -243,6 +243,29 @@ export interface LinkedOrder {
   reportItemUuid?: string | null;
 }
 
+export interface ForecastLink {
+  forecastId: string;
+  status: string;
+  outcome: boolean | null;
+  reviewDate: string | null;
+  direction: string | null;
+  targetPrice: number | null;
+  probability: number;
+  brierScore: number | null;
+  resolutionSource: string | null;
+}
+
+export interface RetrospectiveLink {
+  retrospectiveId: number;
+  outcome: string;
+  lesson: string | null;
+  resultSummary: string | null;
+  rootCauseClass: string | null;
+  triggerType: string | null;
+  pnlPct: number | null;
+  createdAt: string | null;
+}
+
 export interface InvestmentReportItem {
   itemUuid: string;
   itemKind: ItemKind;
@@ -277,6 +300,8 @@ export interface InvestmentReportItem {
   citedDimensionReportUuids?: string[];
   // ROB-554 — live orders linked to this item (null when none).
   linkedOrders?: LinkedOrder[] | null;
+  // ROB-715 — backend-derived summary of evidence_snapshot.structured_evidence.
+  structuredEvidenceSummary?: string | null;
 }
 
 export interface InvestmentReportItemDecision {
@@ -422,6 +447,9 @@ export interface InvestmentReportBundle {
   // ROB-335 — additive intraday ActionPacket projection. Null for legacy /
   // non-intraday reports.
   actionPacket?: ActionPacket | null;
+  // ROB-715 — item→forecast/retrospective exact-join maps keyed by item UUID.
+  forecastsByItemUuid?: Record<string, ForecastLink[]>;
+  retrospectivesByItemUuid?: Record<string, RetrospectiveLink[]>;
 }
 
 export interface InvestmentReportListResponse {

--- a/tests/test_investment_reports_bundle_loop_maps.py
+++ b/tests/test_investment_reports_bundle_loop_maps.py
@@ -1,0 +1,109 @@
+"""ROB-715 — _serialise_bundle folds forecast/retrospective maps onto response."""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.routers.investment_reports import _serialise_bundle
+from app.schemas.investment_reports import (
+    ForecastLinkResponse,
+    RetrospectiveLinkResponse,
+)
+from app.services.investment_reports.ingestion import (
+    InvestmentReportIngestionService,
+)
+from app.services.investment_reports.query_service import (
+    InvestmentReportQueryService,
+)
+
+
+def _request(*, kst_date: str) -> dict:
+    return {
+        "report_type": "kr_morning",
+        "market": "kr",
+        "market_session": "regular",
+        "account_scope": "kis_mock",
+        "execution_mode": "mock_preview",
+        "created_by_profile": "test",
+        "title": f"t-{kst_date}",
+        "summary": "s",
+        "kst_date": kst_date,
+        "items": [
+            {
+                "client_item_key": "action-1",
+                "item_kind": "action",
+                "symbol": "005930",
+                "side": "buy",
+                "intent": "buy_review",
+                "rationale": "r",
+            }
+        ],
+    }
+
+
+async def _build_minimal_bundle_dict(session: AsyncSession) -> dict:
+    """Reuse the ingestion + query service to get a real bundle dict."""
+    from app.schemas.investment_reports import IngestReportRequest
+
+    ingest = InvestmentReportIngestionService(session)
+    report = await ingest.ingest(IngestReportRequest(**_request(kst_date="2026-05-20")))
+    query = InvestmentReportQueryService(session)
+    bundle = await query.get_bundle(report.report_uuid)
+    assert bundle is not None
+    # Strip the new maps so we can test the "absent" path too.
+    bundle.pop("forecasts_by_item_uuid", None)
+    bundle.pop("retrospectives_by_item_uuid", None)
+    return bundle
+
+
+@pytest.mark.asyncio
+async def test_serialise_bundle_carries_loop_maps(
+    session: AsyncSession,
+) -> None:
+    bundle = await _build_minimal_bundle_dict(session)
+    item = bundle["items"][0]
+    key = str(item.item_uuid)
+
+    bundle["forecasts_by_item_uuid"] = {
+        key: [ForecastLinkResponse(forecast_id="f1", status="open", probability=0.6)]
+    }
+    bundle["retrospectives_by_item_uuid"] = {
+        key: [RetrospectiveLinkResponse(retrospective_id=1, outcome="filled")]
+    }
+
+    out = _serialise_bundle(bundle)
+
+    assert out.forecasts_by_item_uuid[key][0].status == "open"
+    assert out.retrospectives_by_item_uuid[key][0].outcome == "filled"
+
+
+@pytest.mark.asyncio
+async def test_serialise_bundle_defaults_empty_when_maps_absent(
+    session: AsyncSession,
+) -> None:
+    bundle = await _build_minimal_bundle_dict(session)
+    # Legacy bundle dict without the new keys → empty dicts, no crash.
+    out = _serialise_bundle(bundle)
+    assert out.forecasts_by_item_uuid == {}
+    assert out.retrospectives_by_item_uuid == {}
+
+
+@pytest.mark.asyncio
+async def test_serialise_bundle_sets_structured_evidence_summary(
+    session: AsyncSession,
+) -> None:
+    bundle = await _build_minimal_bundle_dict(session)
+    item = bundle["items"][0]
+    # Inject structured_evidence into the ORM item before serialisation.
+    item.evidence_snapshot = {"structured_evidence": {"valuation": "cheap"}}
+
+    out = _serialise_bundle(bundle)
+
+    assert out.items[0].structured_evidence_summary == "1 evidence fields: valuation"
+
+
+def _uuid_str() -> str:
+    return str(uuid.uuid4())

--- a/tests/test_investment_reports_item_loop_links.py
+++ b/tests/test_investment_reports_item_loop_links.py
@@ -1,0 +1,119 @@
+"""ROB-715 — exact-join batch loaders for item→forecast/retrospective links."""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.review import TradeForecast, TradeRetrospective
+from app.services.investment_reports.item_loop_links import (
+    list_forecasts_for_item_uuids,
+    list_retrospectives_for_item_uuids,
+)
+
+
+def _forecast(item_uuid: str, **kw) -> TradeForecast:
+    base = dict(
+        created_by="claude",
+        symbol="000660",
+        instrument_type="equity_kr",
+        forecast_target={
+            "kind": "price_target",
+            "direction": "at_or_above",
+            "target_price": 200000,
+        },
+        probability=Decimal("0.6"),
+        review_date=date(2026, 7, 20),
+        status="open",
+        outcome=None,
+        report_item_uuid=item_uuid,
+    )
+    base.update(kw)
+    return TradeForecast(**base)
+
+
+def _retro(item_uuid: str, **kw) -> TradeRetrospective:
+    base = dict(
+        symbol="000660",
+        instrument_type="equity_kr",
+        account_mode="kis_live",
+        outcome="filled",
+        lesson="cut the position too late",
+        report_item_uuid=item_uuid,
+    )
+    base.update(kw)
+    return TradeRetrospective(**base)
+
+
+@pytest.mark.asyncio
+async def test_forecasts_grouped_by_item_uuid_exact_join(
+    db_session: AsyncSession,
+) -> None:
+    item_a = uuid4()
+    item_b = uuid4()
+    db_session.add(
+        _forecast(
+            str(item_a),
+            status="closed",
+            outcome=True,
+            brier_score=Decimal("0.09"),
+        )
+    )
+    db_session.add(_forecast(str(item_b)))
+    await db_session.flush()
+
+    result = await list_forecasts_for_item_uuids(db_session, [item_a, item_b])
+
+    assert set(result) == {str(item_a), str(item_b)}
+    a = result[str(item_a)][0]
+    assert a.status == "closed"
+    assert a.outcome is True
+    assert a.direction == "at_or_above"
+    assert a.target_price == 200000.0
+    assert a.brier_score == pytest.approx(0.09)
+
+
+@pytest.mark.asyncio
+async def test_forecasts_absent_item_uuid_not_in_dict(
+    db_session: AsyncSession,
+) -> None:
+    item_a = uuid4()
+    unlinked = uuid4()
+    db_session.add(_forecast(str(item_a)))
+    await db_session.flush()
+
+    result = await list_forecasts_for_item_uuids(db_session, [item_a, unlinked])
+
+    assert str(item_a) in result
+    assert str(unlinked) not in result
+
+
+@pytest.mark.asyncio
+async def test_retrospectives_grouped_by_item_uuid(db_session: AsyncSession) -> None:
+    item_a = uuid4()
+    db_session.add(
+        _retro(
+            str(item_a),
+            pnl_pct=Decimal("-3.5"),
+            root_cause_class="execution",
+        )
+    )
+    await db_session.flush()
+
+    result = await list_retrospectives_for_item_uuids(db_session, [item_a])
+
+    row = result[str(item_a)][0]
+    assert row.outcome == "filled"
+    assert row.lesson == "cut the position too late"
+    assert row.pnl_pct == pytest.approx(-3.5)
+    assert row.root_cause_class == "execution"
+
+
+@pytest.mark.asyncio
+async def test_empty_input_returns_empty_dict(db_session: AsyncSession) -> None:
+    assert await list_forecasts_for_item_uuids(db_session, []) == {}
+    assert await list_retrospectives_for_item_uuids(db_session, []) == {}

--- a/tests/test_investment_reports_item_loop_links.py
+++ b/tests/test_investment_reports_item_loop_links.py
@@ -17,34 +17,34 @@ from app.services.investment_reports.item_loop_links import (
 
 
 def _forecast(item_uuid: str, **kw) -> TradeForecast:
-    base = dict(
-        created_by="claude",
-        symbol="000660",
-        instrument_type="equity_kr",
-        forecast_target={
+    base = {
+        "created_by": "claude",
+        "symbol": "000660",
+        "instrument_type": "equity_kr",
+        "forecast_target": {
             "kind": "price_target",
             "direction": "at_or_above",
             "target_price": 200000,
         },
-        probability=Decimal("0.6"),
-        review_date=date(2026, 7, 20),
-        status="open",
-        outcome=None,
-        report_item_uuid=item_uuid,
-    )
+        "probability": Decimal("0.6"),
+        "review_date": date(2026, 7, 20),
+        "status": "open",
+        "outcome": None,
+        "report_item_uuid": item_uuid,
+    }
     base.update(kw)
     return TradeForecast(**base)
 
 
 def _retro(item_uuid: str, **kw) -> TradeRetrospective:
-    base = dict(
-        symbol="000660",
-        instrument_type="equity_kr",
-        account_mode="kis_live",
-        outcome="filled",
-        lesson="cut the position too late",
-        report_item_uuid=item_uuid,
-    )
+    base = {
+        "symbol": "000660",
+        "instrument_type": "equity_kr",
+        "account_mode": "kis_live",
+        "outcome": "filled",
+        "lesson": "cut the position too late",
+        "report_item_uuid": item_uuid,
+    }
     base.update(kw)
     return TradeRetrospective(**base)
 

--- a/tests/test_investment_reports_query_service.py
+++ b/tests/test_investment_reports_query_service.py
@@ -162,6 +162,60 @@ async def test_get_bundle_returns_nested_shapes(session: AsyncSession) -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.asyncio
+async def test_get_bundle_attaches_forecast_and_retrospective_maps(
+    session: AsyncSession,
+) -> None:
+    from datetime import date
+    from decimal import Decimal
+
+    from app.models.review import TradeForecast, TradeRetrospective
+
+    ingest = InvestmentReportIngestionService(session)
+    report = await ingest.ingest(
+        _request(kst_date="2026-05-19", items=[_action_item()])
+    )
+
+    repo = InvestmentReportsRepository(session)
+    items = await repo.list_items_for_report(report.id)
+    item = items[0]
+
+    session.add(
+        TradeForecast(
+            created_by="claude",
+            symbol=item.symbol,
+            instrument_type="equity_kr",
+            forecast_target={
+                "direction": "at_or_above",
+                "target_price": 100,
+            },
+            probability=Decimal("0.6"),
+            review_date=date(2026, 7, 20),
+            status="open",
+            report_item_uuid=str(item.item_uuid),
+        )
+    )
+    session.add(
+        TradeRetrospective(
+            symbol=item.symbol,
+            instrument_type="equity_kr",
+            account_mode="kis_live",
+            outcome="filled",
+            report_item_uuid=str(item.item_uuid),
+        )
+    )
+    await session.flush()
+
+    query = InvestmentReportQueryService(session)
+    bundle = await query.get_bundle(report.report_uuid)
+    assert bundle is not None
+
+    key = str(item.item_uuid)
+    assert bundle["forecasts_by_item_uuid"][key][0].status == "open"
+    assert bundle["retrospectives_by_item_uuid"][key][0].outcome == "filled"
+
+
+@pytest.mark.asyncio
 async def test_get_bundle_returns_none_for_missing_report(
     session: AsyncSession,
 ) -> None:

--- a/tests/test_structured_evidence_summary.py
+++ b/tests/test_structured_evidence_summary.py
@@ -1,0 +1,33 @@
+"""ROB-715 — deterministic one-line summary of evidence_snapshot.structured_evidence."""
+
+from app.services.investment_reports.structured_evidence_summary import (
+    summarize_structured_evidence,
+)
+
+
+def test_none_when_no_structured_evidence() -> None:
+    assert summarize_structured_evidence({}) is None
+    assert summarize_structured_evidence({"structured_evidence": None}) is None
+    assert summarize_structured_evidence({"structured_evidence": {}}) is None
+
+
+def test_summarizes_top_level_keys() -> None:
+    snap = {
+        "structured_evidence": {
+            "valuation": "cheap",
+            "momentum": "up",
+            "risk": "low",
+        }
+    }
+    out = summarize_structured_evidence(snap)
+    assert out is not None
+    # Deterministic: sorted keys, count-prefixed.
+    assert "3" in out
+    assert "momentum" in out and "risk" in out and "valuation" in out
+
+
+def test_stable_ordering() -> None:
+    snap = {"structured_evidence": {"b": 1, "a": 2}}
+    assert summarize_structured_evidence(snap) == summarize_structured_evidence(
+        {"structured_evidence": {"a": 2, "b": 1}}
+    )


### PR DESCRIPTION
# ROB-715 — /invest Item-Level Learning-Loop Render

## Goal

각 /invest report item에 forecast-resolution 상태와 retrospective 링크를 렌더해서, 운영자가 "이 판단의 결과(체결 → forecast 해소 → 회고)"를 2 클릭 이내에 도달하도록 한다.

## Architecture

기존 `linked_orders_by_item_uuid` / `decisions_by_item_uuid` 패턴을 그대로 따라, `get_bundle`에 두 개의 item-keyed map을 추가:

- `forecasts_by_item_uuid: dict[str, list[ForecastLinkResponse]]`
- `retrospectives_by_item_uuid: dict[str, list[RetrospectiveLinkResponse]]`

각 테이블당 정확히 1개의 batched `SELECT ... WHERE report_item_uuid IN (...)`. Frontend `ItemRow`가 두 map과 이미 정규화된 raw 필드를 렌더한다.

**Migration 0. Backend 변경은 Pydantic response-model 필드뿐** (DB DDL 없음). ROB-501 가드도 통과 — `app/**`에 LLM 임포트 0.

## Spec

`docs/superpowers/specs/2026-07-05-rob-715-invest-item-loop-render-design.md`
`docs/superpowers/plans/2026-07-05-rob-715-invest-item-loop-render.md`

## What's in this PR

### Backend (read-only)
- **`app/services/investment_reports/item_loop_links.py`** (new) — 두 batch 로더 (`list_forecasts_for_item_uuids`, `list_retrospectives_for_item_uuids`). `report_item_uuid` (Text) 컬럼에서 정확 join.
- **`app/services/investment_reports/structured_evidence_summary.py`** (new) — `evidence_snapshot.structured_evidence`의 1줄 summary (정렬된 키 목록, 결정적). Frontend는 nested 구조를 파싱할 필요 없음.
- **`app/services/investment_reports/query_service.py`** — `get_bundle`에 두 map wire-up (legacy 키 없을 때는 빈 dict).
- **`app/schemas/investment_reports.py`** — `ForecastLinkResponse`, `RetrospectiveLinkResponse`, `InvestmentReportItemResponse.structured_evidence_summary`, `InvestmentReportBundle.forecasts_by_item_uuid`, `InvestmentReportBundle.retrospectives_by_item_uuid` (모두 default-empty → legacy-safe).
- **`app/routers/investment_reports.py`** — `_serialise_bundle`가 map을 읽어 pass-through + `summarize_structured_evidence(...)`로 item summary 채움.

### Frontend
- **`frontend/invest/src/types/investmentReports.ts`** — `ForecastLink`, `RetrospectiveLink`, `InvestmentReportBundle.forecastsByItemUuid/retrospectivesByItemUuid` (optional), `InvestmentReportItem.structuredEvidenceSummary`.
- **`frontend/invest/src/api/investmentReports.ts`** — `normalizeForecastLink`, `normalizeRetrospectiveLink` + bundle reader가 두 map 정규화.
- **`frontend/invest/src/components/investment-reports/InvestmentReportBundleContent.tsx`** — `ItemRow`가 (a) forecast + retrospective loop 섹션 (or "해소 대기 / 미연결" empty state), (b) trigger_checklist + max_action + decision_bucket badge + evidence summary, (c) plan-vs-actual line (planned entry vs first filled linked order) 렌더.

### Tests
- `tests/test_investment_reports_item_loop_links.py` — 4 (loader 정확 join + 빈 입력 + absent uuid)
- `tests/test_investment_reports_query_service.py` — +1 (`get_bundle` attaches maps)
- `tests/test_investment_reports_bundle_loop_maps.py` — 3 (serialise 경로 + legacy fallback + summary)
- `tests/test_structured_evidence_summary.py` — 3 (None, deterministic, stable ordering)
- `frontend/invest/src/__tests__/investmentReports.loopMaps.test.ts` — 2 (snake→camel)
- `frontend/invest/src/__tests__/InvestmentReportBundleContent.loopSection.test.tsx` — 2 (성공 case + empty state)
- `frontend/invest/src/__tests__/InvestmentReportBundleContent.rawFields.test.tsx` — 1 (chips + max_action + evidence summary)
- `frontend/invest/src/__tests__/InvestmentReportBundleContent.planVsActual.test.tsx` — 1 (planned entry vs actual fill)

총 +13 tests, 0 회귀.

## Constraints honored

| Constraint | Status |
|---|---|
| Migration 0 (no alembic) | OK — Pydantic 필드만 추가 |
| Read-only (no broker/watch mutation) | OK — 모두 `SELECT` 한정 |
| ROB-501 (no in-process LLM) | OK — guard green (1126 parametried cases) |
| `decision_history.py` / `trade_journal/aggregates.py` 비편집 | OK — 0 라인 변경 (main과 동일) |
| Exact join on `report_item_uuid` Text (not PG_UUID) | OK — `str(item_uuid)`로 IN filter, dict 키도 string |
| No N+1 | OK — 테이블당 정확히 1개 batched SELECT |
| `decision_bucket`는 row-level 보조만 | OK — ROB-308/322의 5-section projection은 그대로 |
| Test-DB discipline (uuid4 + flush-only) | OK — `await db_session.flush()` only, no commit |
| Lint gate | OK — `make lint` (ruff check + ruff format --check + ty) all green |

## Plan deviations

1. **`TradeRetrospective.outcome` CHECK constraint**: 플랜 템플릿이 `"loss"`를 사용했으나 DB CHECK는 `('filled','partially_filled','unfilled','rejected','cancelled')`만 허용. 테스트와 실제 row는 `"filled"` 사용.
2. **`TradeRetrospective.root_cause_class`**: 플랜이 `"thesis_wrong"`였으나 CHECK는 `('user_input','analysis','policy','execution','harness')`만 허용. `"execution"` 사용.
3. **`LinkedOrder.fillPrice` → `avgFillPrice`**: 프론트엔드 TypeScript type은 `avgFillPrice` 사용 (plan는 `fillPrice`로 표기). 실제 인터페이스에 맞춰 `o.avgFillPrice` 조회.
4. **Bundle map TS 필드를 optional로 선언**: 기존 7개 테스트 fixture가 새 required 필드를 안 가지게 함. `bundle.forecastsByItemUuid?.[...] ?? []` 패턴으로 호출부에서 안전 처리 → legacy 백워드 호환 유지.

## Verification

```bash
cd /Users/mgh3326/work/auto_trader.rob-715
uv run pytest tests/test_investment_reports_item_loop_links.py \
                tests/test_investment_reports_query_service.py \
                tests/test_investment_reports_bundle_loop_maps.py \
                tests/test_structured_evidence_summary.py \
                tests/test_investment_reports_schemas.py -v
# 57 passed

uv run pytest tests/services/action_report/snapshot_backed/test_no_internal_llm_imports.py -v
# 1126 passed (ROB-501 guard green)

make lint
# All checks passed!

cd frontend/invest
npx tsc --noEmit
# clean
npx vitest run src/__tests__/investmentReports.loopMaps.test.ts src/__tests__/InvestmentReportBundleContent
# 47 passed (touched files only)
```

Pre-existing calendar/coverage vitest failures (`MonthlyEventsTimeline`, `DaySection`, `DesktopCalendarPage`, `ActionReadiness`) — `origin/main`에서도 동일하게 실패하며, 본 PR과 무관.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an item-level learning loop section with forecast status, retrospective notes, and empty-state handling.
  * Added a plan-vs-actual view showing planned entry details alongside actual fill data.
  * Exposed a short structured evidence summary for each report item.

* **Bug Fixes**
  * Report bundles now consistently include linked forecast and retrospective data, even when none exist.
  * Improved draft report retention for advisory-style profiles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->