### PR TITLE
feat(ROB-718): item-cited analysis_artifacts links on /invest report items + 2 loop-render minor fixes

### DIFF
--- a/app/routers/invest_artifacts.py
+++ b/app/routers/invest_artifacts.py
@@ -54,6 +54,7 @@ async def list_artifacts(
     symbol: Annotated[str | None, Query()] = None,
     include_stale: Annotated[bool, Query()] = False,
     limit: Annotated[int, Query(ge=1, le=100)] = 20,
+    correlation_id: Annotated[list[str] | None, Query()] = None,
 ) -> AnalysisArtifactListResponse:
     _validate("market", market, _VALID_MARKETS)
     _validate("kind", kind, _VALID_KINDS)
@@ -66,6 +67,7 @@ async def list_artifacts(
         symbol=symbol,
         include_stale=include_stale,
         limit=limit,
+        correlation_ids=correlation_id,
     )
     filters = AnalysisArtifactListRequest(
         market=market,
@@ -74,6 +76,7 @@ async def list_artifacts(
         symbol=symbol,
         include_stale=include_stale,
         limit=limit,
+        correlation_id=",".join(correlation_id) if correlation_id else None,
     )
     metas = [AnalysisArtifactMeta.model_validate(r) for r in rows]
     return AnalysisArtifactListResponse(

--- a/app/schemas/investment_reports.py
+++ b/app/schemas/investment_reports.py
@@ -803,6 +803,7 @@ class ForecastLinkResponse(BaseModel):
     probability: float
     brier_score: float | None = None
     resolution_source: str | None = None
+    correlation_id: str | None = None
 
 
 class RetrospectiveLinkResponse(BaseModel):
@@ -816,6 +817,7 @@ class RetrospectiveLinkResponse(BaseModel):
     trigger_type: str | None = None
     pnl_pct: float | None = None
     created_at: str | None = None
+    correlation_id: str | None = None
 
 
 class StockDetailOrderLedgerResponse(BaseModel):

--- a/app/services/analysis_artifact.py
+++ b/app/services/analysis_artifact.py
@@ -159,6 +159,7 @@ class AnalysisArtifactService:
         include_stale: bool = False,
         limit: int = 20,
         correlation_id: str | None = None,
+        correlation_ids: list[str] | None = None,
         account_scope: str | None = None,
         readiness_label: AnalysisArtifactReadinessLiteral | None = None,
     ) -> list[AnalysisArtifact]:
@@ -191,6 +192,8 @@ class AnalysisArtifactService:
             stmt = stmt.where(AnalysisArtifact.as_of >= since)
         if correlation_id is not None:
             stmt = stmt.where(AnalysisArtifact.correlation_id == correlation_id)
+        if correlation_ids:
+            stmt = stmt.where(AnalysisArtifact.correlation_id.in_(correlation_ids))
         if account_scope is not None:
             stmt = stmt.where(AnalysisArtifact.account_scope == account_scope)
         if readiness_label is not None:

--- a/app/services/investment_reports/item_loop_links.py
+++ b/app/services/investment_reports/item_loop_links.py
@@ -40,6 +40,7 @@ def _project_forecast(row: TradeForecast) -> ForecastLinkResponse:
         probability=float(row.probability),
         brier_score=(float(row.brier_score) if row.brier_score is not None else None),
         resolution_source=row.resolution_source,
+        correlation_id=row.correlation_id,
     )
 
 
@@ -53,6 +54,7 @@ def _project_retrospective(row: TradeRetrospective) -> RetrospectiveLinkResponse
         trigger_type=row.trigger_type,
         pnl_pct=float(row.pnl_pct) if row.pnl_pct is not None else None,
         created_at=_iso(row.created_at),
+        correlation_id=row.correlation_id,
     )
 
 

--- a/frontend/invest/src/__tests__/InvestmentReportBundleContent.loopSection.test.tsx
+++ b/frontend/invest/src/__tests__/InvestmentReportBundleContent.loopSection.test.tsx
@@ -152,4 +152,60 @@ describe("ROB-715 item loop section", () => {
     renderContent(bundle);
     expect(screen.queryByText("해소 대기 / 미연결")).not.toBeInTheDocument();
   });
+  it("renders a closed forecast with null outcome as neutral, not miss", () => {
+    const bundle = makeBundle(makeItem({}));
+    bundle.forecastsByItemUuid = {
+      u1: [
+        {
+          forecastId: "f-null",
+          status: "closed",
+          outcome: null,
+          reviewDate: null,
+          direction: "at_or_above",
+          targetPrice: 200000,
+          probability: 0.5,
+          brierScore: null,
+          resolutionSource: null,
+        },
+      ],
+    };
+    bundle.retrospectivesByItemUuid = {};
+    renderContent(bundle);
+    expect(screen.getByText("결과 미기록")).toBeInTheDocument();
+    expect(screen.queryByText("빗나감")).not.toBeInTheDocument();
+  });
+
+  it("still renders closed outcome=false as 빗나감 and outcome=true as 적중", () => {
+    const bundle = makeBundle(makeItem({}));
+    bundle.forecastsByItemUuid = {
+      u1: [
+        {
+          forecastId: "f-miss",
+          status: "closed",
+          outcome: false,
+          reviewDate: null,
+          direction: "at_or_above",
+          targetPrice: 200000,
+          probability: 0.5,
+          brierScore: null,
+          resolutionSource: null,
+        },
+        {
+          forecastId: "f-hit",
+          status: "closed",
+          outcome: true,
+          reviewDate: null,
+          direction: "at_or_above",
+          targetPrice: 200000,
+          probability: 0.5,
+          brierScore: null,
+          resolutionSource: null,
+        },
+      ],
+    };
+    bundle.retrospectivesByItemUuid = {};
+    renderContent(bundle);
+    expect(screen.getByText("빗나감")).toBeInTheDocument();
+    expect(screen.getByText("적중")).toBeInTheDocument();
+  });
 });

--- a/frontend/invest/src/__tests__/InvestmentReportBundleContent.planVsActual.test.tsx
+++ b/frontend/invest/src/__tests__/InvestmentReportBundleContent.planVsActual.test.tsx
@@ -138,4 +138,49 @@ describe("ROB-715 plan vs actual", () => {
     expect(pva).toHaveTextContent("70000"); // planned entry
     expect(pva).toHaveTextContent("69450"); // actual fill
   });
+  it("hides plan-vs-actual (체결 대기) on non-action items with a tradeSetup", () => {
+    const bundle = makeBundle(
+      makeItem({
+        itemKind: "watch",
+        evidenceSnapshot: {
+          trade_setup: {
+            direction: "long",
+            stop: "65000",
+            target: "78000",
+            headline: {
+              entry: "70000",
+              risk_pct: "7.14",
+              reward_pct: "11.43",
+              rr_ratio: "1.60",
+            },
+          },
+        },
+      }),
+    );
+    renderContent(bundle);
+    expect(screen.queryByTestId("item-plan-vs-actual")).not.toBeInTheDocument();
+  });
+
+  it("still shows plan-vs-actual on action items with a tradeSetup", () => {
+    const bundle = makeBundle(
+      makeItem({
+        itemKind: "action",
+        evidenceSnapshot: {
+          trade_setup: {
+            direction: "long",
+            stop: "65000",
+            target: "78000",
+            headline: {
+              entry: "70000",
+              risk_pct: "7.14",
+              reward_pct: "11.43",
+              rr_ratio: "1.60",
+            },
+          },
+        },
+      }),
+    );
+    renderContent(bundle);
+    expect(screen.getByTestId("item-plan-vs-actual")).toBeInTheDocument();
+  });
 });

--- a/frontend/invest/src/__tests__/ItemArtifactLinks.test.tsx
+++ b/frontend/invest/src/__tests__/ItemArtifactLinks.test.tsx
@@ -1,0 +1,106 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import * as api from "../api/analysisArtifacts";
+import ItemArtifactLinks from "../components/investment-reports/ItemArtifactLinks";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+const meta = (over = {}) => ({
+  id: 1,
+  artifact_uuid: "u1",
+  market: "us" as const,
+  kind: "support_resistance_map" as const,
+  title: "SR map",
+  symbols: ["NVDA"],
+  as_of: "2026-07-01T00:00:00Z",
+  valid_until: null,
+  session_label: null,
+  correlation_id: "live:kis_live:xyz",
+  account_scope: null,
+  content_hash: null,
+  version: 1,
+  readiness_label: "ready_for_order_review" as const,
+  is_stale: false,
+  created_by: "claude" as const,
+  created_at: "2026-07-01T00:00:00Z",
+  ...over,
+});
+
+const renderC = (props: Parameters<typeof ItemArtifactLinks>[0]) =>
+  render(
+    <MemoryRouter>
+      <ItemArtifactLinks {...props} />
+    </MemoryRouter>,
+  );
+
+describe("ItemArtifactLinks", () => {
+  it("fetches by correlationIds and labels '이 판단이 인용한 분석' when ids present", async () => {
+    const spy = vi.spyOn(api, "fetchArtifacts").mockResolvedValue({
+      success: true,
+      count: 1,
+      filters: {} as never,
+      artifacts: [meta()],
+    });
+    renderC({
+      symbol: "NVDA",
+      market: "us",
+      correlationIds: ["live:kis_live:xyz"],
+    });
+    fireEvent.click(screen.getByRole("button"));
+    await waitFor(() =>
+      expect(spy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          market: "us",
+          correlationIds: ["live:kis_live:xyz"],
+        }),
+      ),
+    );
+    expect(screen.getByText(/이 판단이 인용한 분석/)).toBeInTheDocument();
+    expect(screen.getByText("SR map")).toBeInTheDocument();
+  });
+
+  it("falls back to symbol fetch and labels '이 종목 최근' when no correlationIds", async () => {
+    const spy = vi.spyOn(api, "fetchArtifacts").mockResolvedValue({
+      success: true,
+      count: 1,
+      filters: {} as never,
+      artifacts: [meta()],
+    });
+    renderC({ symbol: "NVDA", market: "us", correlationIds: [] });
+    fireEvent.click(screen.getByRole("button"));
+    await waitFor(() =>
+      expect(spy).toHaveBeenCalledWith(
+        expect.objectContaining({ market: "us", symbol: "NVDA" }),
+      ),
+    );
+    expect(spy.mock.calls[0]?.[0]).not.toHaveProperty("correlationIds");
+    expect(screen.getByText(/이 종목 최근/)).toBeInTheDocument();
+  });
+
+  it("shows empty state when fetch returns no artifacts", async () => {
+    vi.spyOn(api, "fetchArtifacts").mockResolvedValue({
+      success: true,
+      count: 0,
+      filters: {} as never,
+      artifacts: [],
+    });
+    renderC({ symbol: "NVDA", market: "us", correlationIds: [] });
+    fireEvent.click(screen.getByRole("button"));
+    await waitFor(() =>
+      expect(screen.getByText("관련 아티팩트 없음")).toBeInTheDocument(),
+    );
+  });
+
+  it("renders nothing when there is neither a symbol nor correlationIds", () => {
+    const { container } = renderC({
+      symbol: null,
+      market: "us",
+      correlationIds: [],
+    });
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/frontend/invest/src/api/analysisArtifacts.ts
+++ b/frontend/invest/src/api/analysisArtifacts.ts
@@ -14,6 +14,7 @@ export interface ArtifactListQuery {
   symbol?: string;
   includeStale?: boolean;
   limit?: number;
+  correlationIds?: string[];
 }
 
 export async function fetchArtifacts(
@@ -25,6 +26,9 @@ export async function fetchArtifacts(
   if (params.readinessLabel) q.set("readiness_label", params.readinessLabel);
   if (params.symbol) q.set("symbol", params.symbol);
   if (params.includeStale) q.set("include_stale", "true");
+  if (params.correlationIds) {
+    for (const cid of params.correlationIds) q.append("correlation_id", cid);
+  }
   if (params.limit != null) q.set("limit", String(params.limit));
   const qs = q.toString();
   const res = await fetch(`${BASE}/${qs ? `?${qs}` : ""}`, {

--- a/frontend/invest/src/api/investmentReports.ts
+++ b/frontend/invest/src/api/investmentReports.ts
@@ -190,6 +190,7 @@ export function normalizeForecastLink(raw: ApiItem): ForecastLink {
     brierScore:
       raw.brier_score == null ? null : Number(raw.brier_score),
     resolutionSource: asOptionalString(raw.resolution_source) ?? null,
+    correlationId: asOptionalString(raw.correlation_id) ?? null,
   };
 }
 
@@ -205,6 +206,7 @@ export function normalizeRetrospectiveLink(
     triggerType: asOptionalString(raw.trigger_type) ?? null,
     pnlPct: raw.pnl_pct == null ? null : Number(raw.pnl_pct),
     createdAt: asOptionalString(raw.created_at) ?? null,
+    correlationId: asOptionalString(raw.correlation_id) ?? null,
   };
 }
 

--- a/frontend/invest/src/components/investment-reports/InvestmentReportBundleContent.tsx
+++ b/frontend/invest/src/components/investment-reports/InvestmentReportBundleContent.tsx
@@ -508,9 +508,11 @@ function ItemRow({
               >
                 <span>
                   {f.status === "closed"
-                    ? f.outcome
-                      ? "적중"
-                      : "빗나감"
+                    ? f.outcome == null
+                      ? "결과 미기록"
+                      : f.outcome
+                        ? "적중"
+                        : "빗나감"
                     : "해소 대기"}
                 </span>
                 {f.brierScore != null ? (

--- a/frontend/invest/src/components/investment-reports/InvestmentReportBundleContent.tsx
+++ b/frontend/invest/src/components/investment-reports/InvestmentReportBundleContent.tsx
@@ -416,7 +416,7 @@ function ItemRow({
           </span>
         </div>
       ) : null}
-      {tradeSetup ? (
+      {tradeSetup && item.itemKind === "action" ? (
         <div
           className="item-plan-vs-actual"
           data-testid="item-plan-vs-actual"

--- a/frontend/invest/src/components/investment-reports/InvestmentReportBundleContent.tsx
+++ b/frontend/invest/src/components/investment-reports/InvestmentReportBundleContent.tsx
@@ -17,6 +17,7 @@ import type {
   InvestmentWatchAlert,
   InvestmentWatchEvent,
   NoActionSummary,
+  Market,
   ReportReviewSections,
   RetrospectiveLink,
   SnapshotFreshnessSummary,
@@ -24,6 +25,7 @@ import type {
 } from "../../types/investmentReports";
 import { ActionPacketView } from "./ActionPacketView";
 import { IntermediateAnalysisPanel } from "./IntermediateAnalysisPanel";
+import ItemArtifactLinks from "./ItemArtifactLinks";
 import { ProposalDiffPanel } from "./ProposalDiffPanel";
 import { ReportDiagnosticsPanel } from "./ReportDiagnosticsPanel";
 import { ReportSnapshotEvidencePanel } from "./ReportSnapshotEvidencePanel";
@@ -290,11 +292,13 @@ function ItemRow({
   decisions,
   forecastLinks,
   retrospectiveLinks,
+  market,
 }: {
   item: InvestmentReportItem;
   decisions: InvestmentReportItemDecision[];
   forecastLinks?: ForecastLink[];
   retrospectiveLinks?: RetrospectiveLink[];
+  market: Market;
 }) {
   const kindLabel = ITEM_KIND_LABELS[item.itemKind] ?? item.itemKind;
   const statusLabel = ITEM_STATUS_LABELS[item.status] ?? item.status;
@@ -535,6 +539,18 @@ function ItemRow({
           )}
         </div>
       )}
+      <ItemArtifactLinks
+        symbol={item.symbol}
+        market={market}
+        correlationIds={Array.from(
+          new Set(
+            [
+              ...(forecastLinks ?? []).map((f) => f.correlationId),
+              ...(retrospectiveLinks ?? []).map((r) => r.correlationId),
+            ].filter((c): c is string => !!c),
+          ),
+        )}
+      />
       {item.watchCondition ? (
         <div
           style={{
@@ -756,12 +772,14 @@ function ReviewSectionsView({
   decisionsByItemUuid,
   forecastsByItemUuid,
   retrospectivesByItemUuid,
+  market,
 }: {
   review: ReportReviewSections;
   items: InvestmentReportItem[];
   decisionsByItemUuid: Record<string, InvestmentReportItemDecision[]>;
   forecastsByItemUuid: Record<string, ForecastLink[]>;
   retrospectivesByItemUuid: Record<string, RetrospectiveLink[]>;
+  market: Market;
 }) {
   const projectedUuids = new Set(
     review.sections.flatMap((section) => section.items.map((it) => it.itemUuid)),
@@ -790,6 +808,7 @@ function ReviewSectionsView({
                   retrospectiveLinks={
                     retrospectivesByItemUuid[item.itemUuid] ?? []
                   }
+                  market={market}
                 />
               ))
             ) : (
@@ -812,6 +831,7 @@ function ReviewSectionsView({
               retrospectiveLinks={
                 retrospectivesByItemUuid[item.itemUuid] ?? []
               }
+              market={market}
             />
           ))}
         </section>
@@ -945,6 +965,7 @@ export function InvestmentReportBundleContent({
           decisionsByItemUuid={bundle.decisionsByItemUuid}
           forecastsByItemUuid={bundle.forecastsByItemUuid ?? {}}
           retrospectivesByItemUuid={bundle.retrospectivesByItemUuid ?? {}}
+          market={bundle.report.market}
         />
       ) : (
         (["action", "watch", "risk"] as const).map((kind) =>
@@ -964,6 +985,7 @@ export function InvestmentReportBundleContent({
                   retrospectiveLinks={
                     bundle.retrospectivesByItemUuid?.[item.itemUuid] ?? []
                   }
+                  market={bundle.report.market}
                 />
               ))}
             </section>

--- a/frontend/invest/src/components/investment-reports/ItemArtifactLinks.tsx
+++ b/frontend/invest/src/components/investment-reports/ItemArtifactLinks.tsx
@@ -1,0 +1,147 @@
+import { useState } from "react";
+import { Link } from "react-router-dom";
+
+import { fetchArtifacts } from "../../api/analysisArtifacts";
+import { Pill } from "../../ds";
+import { stockDetailPath } from "../../stockDetailPath";
+import type { ArtifactMeta } from "../../types/analysisArtifacts";
+import type { Market } from "../../types/investmentReports";
+
+const KIND_LABEL: Record<string, string> = {
+  screening_ranking: "스크리닝 랭킹",
+  profit_taking_verdicts: "익절 판정",
+  support_resistance_map: "지지/저항",
+  flow_assessment: "수급 평가",
+  candidate_pool: "후보 풀",
+  session_summary: "세션 요약",
+  briefing: "브리핑",
+};
+
+type LoadState =
+  | { status: "idle" }
+  | { status: "loading" }
+  | { status: "ready"; rows: ArtifactMeta[] }
+  | { status: "error"; message: string };
+
+export default function ItemArtifactLinks({
+  symbol,
+  market,
+  correlationIds,
+}: {
+  symbol?: string | null;
+  market: Market;
+  correlationIds: string[];
+}) {
+  const [open, setOpen] = useState(false);
+  const [state, setState] = useState<LoadState>({ status: "idle" });
+
+  const byCorrelation = correlationIds.length > 0;
+  const hasTarget = byCorrelation || !!symbol;
+  if (!hasTarget) return null;
+
+  const headerLabel = byCorrelation
+    ? "이 판단이 인용한 분석"
+    : "이 종목 최근 분석 아티팩트";
+
+  async function load() {
+    setState({ status: "loading" });
+    try {
+      const res = await fetchArtifacts(
+        byCorrelation
+          ? { market, correlationIds, includeStale: true, limit: 10 }
+          : {
+              market,
+              symbol: symbol ?? undefined,
+              includeStale: true,
+              limit: 10,
+            },
+      );
+      setState({ status: "ready", rows: res.artifacts });
+    } catch (e) {
+      setState({
+        status: "error",
+        message: e instanceof Error ? e.message : String(e),
+      });
+    }
+  }
+
+  function toggle() {
+    const next = !open;
+    setOpen(next);
+    if (next && state.status === "idle") void load();
+  }
+
+  return (
+    <div className="item-artifact-links" data-testid="item-artifact-links">
+      <button
+        type="button"
+        onClick={toggle}
+        style={{
+          background: "none",
+          border: "none",
+          padding: 0,
+          fontSize: 12,
+          color: "var(--fg-2)",
+          cursor: "pointer",
+          fontWeight: 800,
+        }}
+      >
+        {open ? "▾" : "▸"} {headerLabel}
+      </button>
+      {open && state.status === "loading" ? (
+        <div style={{ fontSize: 12, color: "var(--fg-3)" }}>불러오는 중…</div>
+      ) : null}
+      {open && state.status === "error" ? (
+        <div style={{ fontSize: 12, color: "var(--fg-3)" }}>
+          아티팩트를 불러오지 못했습니다
+        </div>
+      ) : null}
+      {open && state.status === "ready" && state.rows.length === 0 ? (
+        <div style={{ fontSize: 12, color: "var(--fg-3)" }}>
+          관련 아티팩트 없음
+        </div>
+      ) : null}
+      {open && state.status === "ready" && state.rows.length > 0 ? (
+        <ul
+          style={{
+            margin: "4px 0 0",
+            paddingLeft: 0,
+            listStyle: "none",
+            display: "grid",
+            gap: 4,
+          }}
+        >
+          {state.rows.map((a) => (
+            <li
+              key={a.id}
+              style={{
+                fontSize: 12,
+                color: "var(--fg-2)",
+                display: "flex",
+                gap: 6,
+                alignItems: "center",
+                flexWrap: "wrap",
+              }}
+            >
+              <Pill size="sm" tone={a.is_stale ? "warn" : "paper"}>
+                {KIND_LABEL[a.kind] ?? a.kind}
+              </Pill>
+              <span>{a.title}</span>
+              <span style={{ color: "var(--fg-3)" }}>
+                {a.as_of.slice(0, 10)}
+              </span>
+              {a.symbols[0] ? (
+                <Link
+                  to={stockDetailPath(a.market, a.symbols[0]) ?? "#"}
+                  style={{ color: "var(--accent)" }}
+                >
+                  종목
+                </Link>
+              ) : null}
+            </li>
+          ))}
+        </ul>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/invest/src/types/investmentReports.ts
+++ b/frontend/invest/src/types/investmentReports.ts
@@ -253,6 +253,7 @@ export interface ForecastLink {
   probability: number;
   brierScore: number | null;
   resolutionSource: string | null;
+  correlationId?: string | null;
 }
 
 export interface RetrospectiveLink {
@@ -264,6 +265,7 @@ export interface RetrospectiveLink {
   triggerType: string | null;
   pnlPct: number | null;
   createdAt: string | null;
+  correlationId?: string | null;
 }
 
 export interface InvestmentReportItem {

--- a/tests/routers/test_invest_artifacts_router.py
+++ b/tests/routers/test_invest_artifacts_router.py
@@ -129,3 +129,17 @@ def test_get_detail_includes_payload(monkeypatch):
 def test_get_detail_404(monkeypatch):
     client, _ = _make_client(monkeypatch, one=None)
     assert client.get("/trading/api/invest/artifacts/9").status_code == 404
+
+
+@pytest.mark.unit
+def test_list_forwards_correlation_ids(monkeypatch):
+    client, calls = _make_client(monkeypatch)
+    r = client.get(
+        "/trading/api/invest/artifacts/"
+        "?market=us&correlation_id=live:kis_live:abc&correlation_id=live:kis_live:def"
+    )
+    assert r.status_code == 200
+    assert calls["list"]["correlation_ids"] == [
+        "live:kis_live:abc",
+        "live:kis_live:def",
+    ]

--- a/tests/services/test_analysis_artifact_service.py
+++ b/tests/services/test_analysis_artifact_service.py
@@ -318,3 +318,62 @@ async def test_get_returns_none_for_missing(db_session: AsyncSession) -> None:
 
     assert await service.get(999_999_999) is None
     assert await service.get("not-a-uuid-or-int") is None
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_list_artifacts_filters_by_correlation_ids(
+    db_session: AsyncSession,
+) -> None:
+    service = AnalysisArtifactService(db_session)
+    sym = f"ZZ{uuid4().hex[:6].upper()}"
+    await service.save(
+        AnalysisArtifactSave.model_validate(
+            {
+                "market": "us",
+                "kind": "screening_ranking",
+                "title": "corr-a",
+                "symbols": [sym],
+                "payload": {"a": 1},
+                "as_of": "2026-07-02T01:00:00+00:00",
+                "created_by": "claude",
+                "correlation_id": "live:kis_live:aaa",
+            }
+        )
+    )
+    await service.save(
+        AnalysisArtifactSave.model_validate(
+            {
+                "market": "us",
+                "kind": "screening_ranking",
+                "title": "corr-b",
+                "symbols": [sym],
+                "payload": {"b": 2},
+                "as_of": "2026-07-02T01:00:00+00:00",
+                "created_by": "claude",
+                "correlation_id": "live:kis_live:bbb",
+            }
+        )
+    )
+    await service.save(
+        AnalysisArtifactSave.model_validate(
+            {
+                "market": "us",
+                "kind": "screening_ranking",
+                "title": "corr-c",
+                "symbols": [sym],
+                "payload": {"c": 3},
+                "as_of": "2026-07-02T01:00:00+00:00",
+                "created_by": "claude",
+                "correlation_id": "live:kis_live:ccc",
+            }
+        )
+    )
+    rows = await service.list_artifacts(
+        correlation_ids=["live:kis_live:aaa", "live:kis_live:bbb"],
+        include_stale=True,
+    )
+    assert {row.correlation_id for row in rows} == {
+        "live:kis_live:aaa",
+        "live:kis_live:bbb",
+    }

--- a/tests/test_investment_reports_item_loop_links.py
+++ b/tests/test_investment_reports_item_loop_links.py
@@ -114,6 +114,42 @@ async def test_retrospectives_grouped_by_item_uuid(db_session: AsyncSession) -> 
 
 
 @pytest.mark.asyncio
+async def test_forecast_projection_includes_correlation_id(
+    db_session: AsyncSession,
+) -> None:
+    item_uuid = uuid4()
+    db_session.add(
+        _forecast(
+            str(item_uuid),
+            correlation_id="live:kis_live:xyz",
+        )
+    )
+    await db_session.flush()
+
+    result = await list_forecasts_for_item_uuids(db_session, [item_uuid])
+
+    assert result[str(item_uuid)][0].correlation_id == "live:kis_live:xyz"
+
+
+@pytest.mark.asyncio
+async def test_retrospective_projection_includes_correlation_id(
+    db_session: AsyncSession,
+) -> None:
+    item_uuid = uuid4()
+    db_session.add(
+        _retro(
+            str(item_uuid),
+            correlation_id="live:kis_live:retro-1",
+        )
+    )
+    await db_session.flush()
+
+    result = await list_retrospectives_for_item_uuids(db_session, [item_uuid])
+
+    assert result[str(item_uuid)][0].correlation_id == "live:kis_live:retro-1"
+
+
+@pytest.mark.asyncio
 async def test_empty_input_returns_empty_dict(db_session: AsyncSession) -> None:
     assert await list_forecasts_for_item_uuids(db_session, []) == {}
     assert await list_retrospectives_for_item_uuids(db_session, []) == {}


### PR DESCRIPTION
## Summary

Closes ROB-718: close the deferred ④ from ROB-715 (item-cited analysis_artifacts links on `/invest` report items) and fix the 2 loop-render display bugs from the ROB-715 post-merge review.

5 commits, migration 0, no broker/order/watch/order-intent mutation, ROB-501 deterministic-reads preserved.

## Changes

**Task 1 — Bug ②a** (`fe7780c2`): `frontend/invest/src/components/investment-reports/InvestmentReportBundleContent.tsx`
- `ForecastLink.outcome` is `boolean | null`; previous ternary fell through to "빗나감" for closed+null (resolved but outcome unrecorded). Now renders neutral "결과 미기록".

**Task 2 — Bug ②b** (`ba8fdeac`): same file
- Plan-vs-actual "체결 대기" row was gated only on `tradeSetup` existing, so a watch/risk item with a `tradeSetup` rendered execution-status noise. Now also gated on `item.itemKind === "action"` (mirrors loop-placeholder logic at `:475-477`). R:R pill block unchanged.

**Task 3 — Backend `correlation_id` filter** (`cf13ee48`): `app/routers/invest_artifacts.py`, `app/services/analysis_artifact.py`
- `list_artifacts` gains a plural `correlation_ids: list[str] | None` (IN filter) alongside the existing singular `correlation_id`. Router exposes a repeatable `?correlation_id=…&correlation_id=…` query param that maps to it. MCP singular path untouched.

**Task 4 — Backend `correlation_id` projection** (`e4741d1d`): `app/schemas/investment_reports.py`, `app/services/investment_reports/item_loop_links.py`
- `ForecastLinkResponse.correlation_id: str | None` and `RetrospectiveLinkResponse.correlation_id: str | None` — populated from `row.correlation_id` on `TradeForecast` / `TradeRetrospective`. Additive, back-compat (defaulted).

**Task 5 — Frontend hybrid `ItemArtifactLinks`** (`72e305d9`): new `frontend/invest/src/components/investment-reports/ItemArtifactLinks.tsx` + 5 wire-up files
- Lazy, expand-on-click compact list. Hybrid: when forecast/retro links carry `correlationId`s → fetch by those ("이 판단이 인용한 분석"); else if the item has a `symbol` → fetch by `symbol` + `market` ("이 종목 최근 분석 아티팩트"); else render nothing. Reuses `fetchArtifacts` + `ArtifactMeta`.
- New `ArtifactListQuery.correlationIds` emits repeated `correlation_id` query params.
- `Market` threaded into `ItemRow` (and `ReviewSectionsView`) so the component knows the report market for the symbol fallback. All 3 `ItemRow` call sites pass `market={...}`.

## Verification

```
# Backend — touched files
uv run pytest tests/routers/test_invest_artifacts_router.py \
                 tests/services/test_analysis_artifact_service.py \
                 tests/test_investment_reports_item_loop_links.py -v
# 23 passed

# Frontend — touched files
cd frontend/invest && npx vitest run \
  src/__tests__/ItemArtifactLinks.test.tsx \
  src/__tests__/InvestmentReportBundleContent.loopSection.test.tsx \
  src/__tests__/InvestmentReportBundleContent.planVsActual.test.tsx
# 12 passed (ItemArtifactLinks: 4/4, loop: 5/5, planVsActual: 3/3)

cd frontend/invest && npx tsc --noEmit
# clean

uv run ruff check app/                 # All checks passed!
uv run ruff format --check app/        # 1126 files already formatted

# ROB-501 guard (deterministic reads, no in-process LLM imports)
uv run pytest tests/services/action_report/snapshot_backed/test_no_internal_llm_imports.py -v
# 1126 passed

# Migration 0
git diff main --name-only --diff-filter=A -- alembic/
# (empty — no new alembic files added by this branch)
```

## Pre-existing test failures (NOT caused by this PR)

Confirmed by `git stash` + re-running the same test files on the pre-change tree:
- `src/__tests__/ActionReadiness.test.tsx`
- `src/__tests__/DaySection.test.tsx`
- `src/__tests__/DesktopCalendarPage.test.tsx`
- `src/__tests__/MonthlyEventsTimeline.test.tsx`

All four fail identically without my changes (calendar/coverage areas, unrelated to `/invest` reports). Out of scope for ROB-718.

## Plan coverage (per `docs/superpowers/plans/2026-07-06-rob-718-*.md`)

| Spec bullet | Tasks |
|---|---|
| ① item-cited analysis_artifacts (issue bullet 1) | 3 + 4 + 5 (hybrid, reuses existing router) |
| ②a closed+null outcome neutral | 1 |
| ②b plan-vs-actual on all items | 2 |
| "correlation_id 경유 조회, 신규 컬럼 금지" | Task 4 routes through existing forecast/retro `correlation_id`; no new column |
| "decision_history.py / aggregates.py 접근 금지" | ROB-717 files untouched |
| "per-test unique symbol + flush-only + ruff format" | Task 3 + 4 steps |

## Honest forward-looking caveat

correlation-exact adoption is near-zero today (ROB-715 D3: forecasts 0/2, retros 0/5 — artifacts must share the same place-time `correlation_id` for the exact match to fire). The hybrid symbol fallback is what has data now; the correlation tier fills in as ROB-714 auto-forecast + operator discipline land. Documented in the plan's Final Verification manual step.
