### PR TITLE
[ROB-722] Earnings auto-inject into analyze_stock_batch compact responses

### DIFF
--- a/app/mcp_server/tooling/analysis_tool_handlers.py
+++ b/app/mcp_server/tooling/analysis_tool_handlers.py
@@ -33,6 +33,10 @@ from app.mcp_server.tooling.shared import (
 from app.monitoring import yfinance_tracing_session
 from app.services.brokers.kis.client import KISClient
 from app.services.decision_history import build_decision_context
+from app.mcp_server.tooling.earnings_context import (
+    _kr_ingestion_freshness,
+    build_earnings_context,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -879,6 +883,51 @@ async def _attach_decision_history(
         logger.debug("decision_history injection skipped: %s", exc)
 
 
+async def _attach_earnings(
+    results: dict[str, Any],
+    *,
+    market: str | None,
+) -> None:
+    """ROB-722: inject per-symbol upcoming-earnings context (US live / KR DB).
+
+    Batched (one session), symbol-level fail-open. No-earnings is an explicit
+    signal (has_upcoming=False), so US/KR equity rows always receive an
+    ``earnings`` field; crypto/error rows are skipped. KR ingestion freshness is
+    computed at most once per batch and threaded into each build call.
+    """
+    if not any(
+        isinstance(row, dict) and "error" not in row for row in results.values()
+    ):
+        return
+    try:
+        from app.core.db import AsyncSessionLocal
+
+        async with AsyncSessionLocal() as db:
+            kr_freshness: tuple[str, str | None] | None = None
+            for sym, result in results.items():
+                if not isinstance(result, dict) or "error" in result:
+                    continue
+                mkt = result.get("market_type") or market
+                if str(mkt or "").strip().lower() == "kr" and kr_freshness is None:
+                    try:
+                        kr_freshness = await _kr_ingestion_freshness(db)
+                    except Exception:  # fail-open: freshness is advisory
+                        kr_freshness = ("unknown", None)
+                try:
+                    ctx = await build_earnings_context(
+                        str(sym), str(mkt or ""), kr_freshness=kr_freshness
+                    )
+                except Exception as exc:  # symbol-level fail-open (e.g. 429)
+                    logger.debug("earnings injection skipped for %s: %s", sym, exc)
+                    continue
+                if ctx is not None:
+                    result["earnings"] = ctx
+    except Exception as exc:  # fail-open: advisory-only
+        logger.debug("earnings injection skipped: %s", exc)
+
+
+
+
 async def analyze_stock_batch_impl(
     symbols: list[str | int],
     market: str | None = None,
@@ -940,6 +989,7 @@ async def analyze_stock_batch_impl(
     if quick:
         await _attach_fresh_artifact_hints(response.get("results", {}), market=market)
         await _attach_decision_history(response.get("results", {}), market=market)
+        await _attach_earnings(response.get("results", {}), market=market)
     return response
 
 

--- a/app/mcp_server/tooling/analysis_tool_handlers.py
+++ b/app/mcp_server/tooling/analysis_tool_handlers.py
@@ -17,6 +17,10 @@ import yfinance as yf
 
 from app.mcp_server.tooling import analysis_screening, foreigners_liquidity
 from app.mcp_server.tooling.analysis_screen_core import normalize_screen_request
+from app.mcp_server.tooling.earnings_context import (
+    _kr_ingestion_freshness,
+    build_earnings_context,
+)
 from app.mcp_server.tooling.market_data_indicators import (
     _fetch_ohlcv_for_indicators,
 )
@@ -33,10 +37,6 @@ from app.mcp_server.tooling.shared import (
 from app.monitoring import yfinance_tracing_session
 from app.services.brokers.kis.client import KISClient
 from app.services.decision_history import build_decision_context
-from app.mcp_server.tooling.earnings_context import (
-    _kr_ingestion_freshness,
-    build_earnings_context,
-)
 
 logger = logging.getLogger(__name__)
 
@@ -924,8 +924,6 @@ async def _attach_earnings(
                     result["earnings"] = ctx
     except Exception as exc:  # fail-open: advisory-only
         logger.debug("earnings injection skipped: %s", exc)
-
-
 
 
 async def analyze_stock_batch_impl(

--- a/app/mcp_server/tooling/earnings_context.py
+++ b/app/mcp_server/tooling/earnings_context.py
@@ -21,6 +21,9 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.market_events import MarketEventIngestionPartition
 from app.services.market_events.freshness_service import _ensure_aware, _is_stale
+from app.mcp_server.tooling.fundamentals._financials import (
+    handle_get_earnings_calendar,
+)
 
 _WINDOW_DAYS = 30
 _TIMING_MAP = {"bmo": "BMO", "amc": "AMC", "dmh": "DMH"}
@@ -113,3 +116,39 @@ async def _kr_ingestion_freshness(db: AsyncSession) -> tuple[str, str | None]:
     aware = _ensure_aware(finished_at)
     freshness = "stale" if _is_stale(aware, now=datetime.datetime.now(datetime.UTC)) else "fresh"
     return (freshness, aware.date().isoformat())
+
+_EQUITY_MARKETS = {"kr", "us"}
+
+
+async def build_earnings_context(
+    symbol: str,
+    market: str,
+    *,
+    today: datetime.date | None = None,
+    kr_freshness: tuple[str, str | None] | None = None,
+) -> dict[str, Any] | None:
+    """Compact upcoming-earnings context for one symbol, or None to omit.
+
+    Omits (None) only for crypto / non-equity markets — earnings has no meaning
+    there. For US/KR equities it ALWAYS returns a dict (no-earnings is an
+    explicit has_upcoming=False signal). US freshness is "live"; KR freshness is
+    taken from ``kr_freshness`` (computed once per batch by the caller)."""
+    market_norm = (market or "").strip().lower()
+    if market_norm not in _EQUITY_MARKETS:
+        return None
+
+    today = today or datetime.date.today()
+    to_date = today + datetime.timedelta(days=_WINDOW_DAYS)
+
+    tool_result = await handle_get_earnings_calendar(
+        symbol, today.isoformat(), to_date.isoformat(), market_norm
+    )
+
+    if market_norm == "kr":
+        freshness, data_as_of = kr_freshness or ("unknown", None)
+    else:
+        freshness, data_as_of = "live", None
+
+    return _compact_earnings(
+        tool_result, today=today, freshness=freshness, data_as_of=data_as_of
+    )

--- a/app/mcp_server/tooling/earnings_context.py
+++ b/app/mcp_server/tooling/earnings_context.py
@@ -19,11 +19,11 @@ from typing import Any
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models.market_events import MarketEventIngestionPartition
-from app.services.market_events.freshness_service import _ensure_aware, _is_stale
 from app.mcp_server.tooling.fundamentals._financials import (
     handle_get_earnings_calendar,
 )
+from app.models.market_events import MarketEventIngestionPartition
+from app.services.market_events.freshness_service import _ensure_aware, _is_stale
 
 _WINDOW_DAYS = 30
 _TIMING_MAP = {"bmo": "BMO", "amc": "AMC", "dmh": "DMH"}
@@ -43,9 +43,11 @@ def _compact_earnings(
     data_as_of: str | None,
 ) -> dict[str, Any]:
     source = tool_result.get("source")
-    market_label = "kr" if (
-        tool_result.get("market") == "kr" or source == "market_events"
-    ) else "us"
+    market_label = (
+        "kr"
+        if (tool_result.get("market") == "kr" or source == "market_events")
+        else "us"
+    )
 
     ctx: dict[str, Any] = {
         "symbol": tool_result.get("symbol"),
@@ -114,8 +116,13 @@ async def _kr_ingestion_freshness(db: AsyncSession) -> tuple[str, str | None]:
     if finished_at is None:
         return ("unknown", None)
     aware = _ensure_aware(finished_at)
-    freshness = "stale" if _is_stale(aware, now=datetime.datetime.now(datetime.UTC)) else "fresh"
+    freshness = (
+        "stale"
+        if _is_stale(aware, now=datetime.datetime.now(datetime.UTC))
+        else "fresh"
+    )
     return (freshness, aware.date().isoformat())
+
 
 _EQUITY_MARKETS = {"kr", "us"}
 

--- a/app/mcp_server/tooling/earnings_context.py
+++ b/app/mcp_server/tooling/earnings_context.py
@@ -1,0 +1,89 @@
+"""ROB-722 — deterministic upcoming-earnings context for a symbol.
+
+Read-only. No LLM (ROB-501), no schema change. Reuses the validated
+handle_get_earnings_calendar dispatch (US live Finnhub / KR market_events DB)
+and shapes a compact "next earnings D-n / timing / consensus, or explicit
+no-earnings" signal. Attached to analyze_stock_batch compact responses so each
+fresh analysis session sees the symbol's earnings proximity.
+
+No-earnings is itself a signal (HCA: '30일 내 무실적' as an entry justification),
+so a zero-earnings window yields has_upcoming=False + note — NOT omission.
+Only crypto / non-equity symbols are omitted (no earnings concept).
+"""
+
+from __future__ import annotations
+
+import datetime
+from typing import Any
+
+_WINDOW_DAYS = 30
+_TIMING_MAP = {"bmo": "BMO", "amc": "AMC", "dmh": "DMH"}
+
+
+def _map_timing(hour: str | None) -> str:
+    if not hour:
+        return "unknown"
+    return _TIMING_MAP.get(hour.strip().lower(), "unknown")
+
+
+def _compact_earnings(
+    tool_result: dict[str, Any],
+    *,
+    today: datetime.date,
+    freshness: str,
+    data_as_of: str | None,
+) -> dict[str, Any]:
+    source = tool_result.get("source")
+    market_label = "kr" if (
+        tool_result.get("market") == "kr" or source == "market_events"
+    ) else "us"
+
+    ctx: dict[str, Any] = {
+        "symbol": tool_result.get("symbol"),
+        "market": market_label,
+        "as_of": today.isoformat(),
+        "window_days": _WINDOW_DAYS,
+        "freshness": freshness,
+        "source": source,
+    }
+    if data_as_of is not None:
+        ctx["data_as_of"] = data_as_of
+
+    if tool_result.get("error"):
+        ctx["has_upcoming"] = False
+        ctx["next_earnings"] = None
+        ctx["note"] = f"earnings lookup degraded: {tool_result.get('error')}"
+        return ctx
+
+    upcoming: list[tuple[datetime.date, dict[str, Any]]] = []
+    for item in tool_result.get("earnings") or []:
+        raw = item.get("date")
+        if not raw:
+            continue
+        try:
+            edate = datetime.date.fromisoformat(raw)
+        except (ValueError, TypeError):
+            continue
+        if edate >= today:
+            upcoming.append((edate, item))
+
+    if not upcoming:
+        ctx["has_upcoming"] = False
+        ctx["next_earnings"] = None
+        ctx["note"] = f"no scheduled earnings within {_WINDOW_DAYS} days"
+        return ctx
+
+    upcoming.sort(key=lambda pair: pair[0])
+    edate, item = upcoming[0]
+    ctx["has_upcoming"] = True
+    ctx["next_earnings"] = {
+        "date": edate.isoformat(),
+        "d_minus": (edate - today).days,
+        "timing": _map_timing(item.get("hour") or item.get("time_hint")),
+        "eps_estimate": item.get("eps_estimate"),
+        "revenue_estimate": item.get("revenue_estimate"),
+        "quarter": item.get("quarter"),
+        "year": item.get("year"),
+        "status": item.get("status"),
+    }
+    return ctx

--- a/app/mcp_server/tooling/earnings_context.py
+++ b/app/mcp_server/tooling/earnings_context.py
@@ -16,6 +16,12 @@ from __future__ import annotations
 import datetime
 from typing import Any
 
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.market_events import MarketEventIngestionPartition
+from app.services.market_events.freshness_service import _ensure_aware, _is_stale
+
 _WINDOW_DAYS = 30
 _TIMING_MAP = {"bmo": "BMO", "amc": "AMC", "dmh": "DMH"}
 
@@ -87,3 +93,23 @@ def _compact_earnings(
         "status": item.get("status"),
     }
     return ctx
+
+
+async def _kr_ingestion_freshness(db: AsyncSession) -> tuple[str, str | None]:
+    """Newest succeeded KR earnings ingestion → (freshness, data_as_of ISO|None).
+
+    Global per (market=kr, category=earnings) — compute ONCE per batch, not per
+    symbol. Reuses the market_events STALE_AFTER_HOURS threshold. Fail-open at
+    the caller: a DB error leaves KR rows on ('unknown', None).
+    """
+    stmt = select(func.max(MarketEventIngestionPartition.finished_at)).where(
+        MarketEventIngestionPartition.market == "kr",
+        MarketEventIngestionPartition.category == "earnings",
+        MarketEventIngestionPartition.status == "succeeded",
+    )
+    finished_at = (await db.execute(stmt)).scalar_one_or_none()
+    if finished_at is None:
+        return ("unknown", None)
+    aware = _ensure_aware(finished_at)
+    freshness = "stale" if _is_stale(aware, now=datetime.datetime.now(datetime.UTC)) else "fresh"
+    return (freshness, aware.date().isoformat())

--- a/docs/superpowers/plans/2026-07-06-rob-722-earnings-auto-inject.md
+++ b/docs/superpowers/plans/2026-07-06-rob-722-earnings-auto-inject.md
@@ -1,0 +1,720 @@
+# ROB-722 Earnings Auto-Inject Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Auto-inject each US/KR equity symbol's upcoming-earnings context (or an explicit "no earnings" signal) into `analyze_stock_batch` compact responses, reusing the ROB-711 attach rail.
+
+**Architecture:** New tooling module `app/mcp_server/tooling/earnings_context.py` reuses the already-validated `handle_get_earnings_calendar` handler (US live Finnhub / KR market_events DB) plus a pure compact shaper. A new sibling `_attach_earnings` in `analysis_tool_handlers.py` runs as a batched, symbol-level fail-open post-pass right after `_attach_decision_history`. No new vendor/auth/schema. Migration 0.
+
+**Tech Stack:** Python 3.13, async SQLAlchemy, pytest (`pytest.mark.asyncio`), existing MCP tooling layer.
+
+## Global Constraints
+
+- **No LLM providers** — pure deterministic shaping (ROB-501 static guard scans `app/**`). No provider imports.
+- **Migration 0** — no schema/model changes.
+- **Fail-open always** — any earnings lookup failure MUST leave the analysis result untouched; never raise out of the attach pass.
+- **Compact contract only** — attach only when `quick=True` (mirrors decision_history scope). Skip crypto and error rows.
+- **Layer discipline** — `earnings_context.py` lives in the tooling layer (same as `analysis_tool_handlers` and `_financials`); no service→tooling inversion.
+- **Attached key name:** `earnings` (verified free of collision with `_summarize_analysis_result` output).
+- Commit message trailer on every commit:
+  ```
+  Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+  Claude-Session: https://claude.ai/code/session_01UG8sLTN1Kko1PuenppjvD8
+  ```
+
+## File Structure
+
+- **Create** `app/mcp_server/tooling/earnings_context.py` — `_map_timing`, `_compact_earnings` (pure), `_kr_ingestion_freshness` (DB), `build_earnings_context` (dispatch + crypto skip + shape).
+- **Create** `tests/mcp_server/test_earnings_context.py` — unit tests for shaper, freshness, build dispatch, crypto skip, no-earnings.
+- **Modify** `app/mcp_server/tooling/analysis_tool_handlers.py` — add `_attach_earnings`, import `build_earnings_context`, wire call after `_attach_decision_history` (~:942).
+- **Create** `tests/mcp_server/test_analyze_stock_batch_earnings.py` — attach-pass injection/fail-open/skip tests.
+
+---
+
+## Task 1: Pure compact shaper (`_map_timing` + `_compact_earnings`)
+
+**Files:**
+- Create: `app/mcp_server/tooling/earnings_context.py`
+- Test: `tests/mcp_server/test_earnings_context.py`
+
+**Interfaces:**
+- Consumes: earnings tool-result dicts shaped by `handle_get_earnings_calendar` (US finnhub: keys `symbol`, `source="finnhub"`, `earnings:[{date, hour, eps_estimate, revenue_estimate, quarter, year}]`; KR market_events: `market="kr"`, `source="market_events"`, items add `time_hint`, `status`; error payload: key `error`).
+- Produces:
+  - `_map_timing(hour: str | None) -> str` → `"BMO"|"AMC"|"DMH"|"unknown"`.
+  - `_compact_earnings(tool_result: dict, *, today: datetime.date, freshness: str, data_as_of: str | None) -> dict` → compact context (`symbol`, `market`, `as_of`, `window_days`, `has_upcoming`, `next_earnings`|`None`, `freshness`, `source`, optional `data_as_of`, optional `note`).
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/mcp_server/test_earnings_context.py
+"""ROB-722 — earnings auto-inject context builder."""
+
+from __future__ import annotations
+
+import datetime
+
+import pytest
+
+from app.mcp_server.tooling import earnings_context as ec
+
+TODAY = datetime.date(2026, 7, 6)
+
+
+def test_map_timing_variants():
+    assert ec._map_timing("bmo") == "BMO"
+    assert ec._map_timing("AMC") == "AMC"
+    assert ec._map_timing("dmh") == "DMH"
+    assert ec._map_timing("") == "unknown"
+    assert ec._map_timing(None) == "unknown"
+    assert ec._map_timing("weird") == "unknown"
+
+
+def test_compact_earnings_us_upcoming_picks_nearest_future():
+    tool_result = {
+        "symbol": "NVDA",
+        "source": "finnhub",
+        "earnings": [
+            {"date": "2026-01-01", "hour": "amc"},  # past — excluded
+            {"date": "2026-07-25", "hour": "bmo", "eps_estimate": 0.9},
+            {"date": "2026-07-18", "hour": "amc", "eps_estimate": 0.84,
+             "revenue_estimate": 26500000000, "quarter": 2, "year": 2026},
+        ],
+    }
+    ctx = ec._compact_earnings(tool_result, today=TODAY, freshness="live", data_as_of=None)
+    assert ctx["market"] == "us"
+    assert ctx["source"] == "finnhub"
+    assert ctx["freshness"] == "live"
+    assert ctx["window_days"] == 30
+    assert ctx["as_of"] == "2026-07-06"
+    assert "data_as_of" not in ctx
+    assert ctx["has_upcoming"] is True
+    ne = ctx["next_earnings"]
+    assert ne["date"] == "2026-07-18"       # nearest future, not the earlier past row
+    assert ne["d_minus"] == 12
+    assert ne["timing"] == "AMC"
+    assert ne["eps_estimate"] == 0.84
+    assert ne["quarter"] == 2
+
+
+def test_compact_earnings_no_upcoming_is_explicit_signal():
+    tool_result = {"symbol": "HCA", "source": "finnhub", "earnings": []}
+    ctx = ec._compact_earnings(tool_result, today=TODAY, freshness="live", data_as_of=None)
+    assert ctx["has_upcoming"] is False
+    assert ctx["next_earnings"] is None
+    assert ctx["note"] == "no scheduled earnings within 30 days"
+
+
+def test_compact_earnings_kr_carries_freshness_and_data_as_of():
+    tool_result = {
+        "symbol": "005930",
+        "market": "kr",
+        "source": "market_events",
+        "earnings": [
+            {"date": "2026-07-25", "time_hint": "unknown", "status": "scheduled",
+             "quarter": 2, "year": 2026},
+        ],
+    }
+    ctx = ec._compact_earnings(
+        tool_result, today=TODAY, freshness="stale", data_as_of="2026-07-01"
+    )
+    assert ctx["market"] == "kr"
+    assert ctx["source"] == "market_events"
+    assert ctx["freshness"] == "stale"
+    assert ctx["data_as_of"] == "2026-07-01"
+    assert ctx["next_earnings"]["timing"] == "unknown"
+    assert ctx["next_earnings"]["status"] == "scheduled"
+
+
+def test_compact_earnings_error_payload_degrades():
+    tool_result = {"symbol": "NVDA", "source": "finnhub", "error": "429 quota"}
+    ctx = ec._compact_earnings(tool_result, today=TODAY, freshness="live", data_as_of=None)
+    assert ctx["has_upcoming"] is False
+    assert ctx["next_earnings"] is None
+    assert "degraded" in ctx["note"]
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/mcp_server/test_earnings_context.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'app.mcp_server.tooling.earnings_context'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# app/mcp_server/tooling/earnings_context.py
+"""ROB-722 — deterministic upcoming-earnings context for a symbol.
+
+Read-only. No LLM (ROB-501), no schema change. Reuses the validated
+handle_get_earnings_calendar dispatch (US live Finnhub / KR market_events DB)
+and shapes a compact "next earnings D-n / timing / consensus, or explicit
+no-earnings" signal. Attached to analyze_stock_batch compact responses so each
+fresh analysis session sees the symbol's earnings proximity.
+
+No-earnings is itself a signal (HCA: '30일 내 무실적' as an entry justification),
+so a zero-earnings window yields has_upcoming=False + note — NOT omission.
+Only crypto / non-equity symbols are omitted (no earnings concept).
+"""
+
+from __future__ import annotations
+
+import datetime
+from typing import Any
+
+_WINDOW_DAYS = 30
+_TIMING_MAP = {"bmo": "BMO", "amc": "AMC", "dmh": "DMH"}
+
+
+def _map_timing(hour: str | None) -> str:
+    if not hour:
+        return "unknown"
+    return _TIMING_MAP.get(hour.strip().lower(), "unknown")
+
+
+def _compact_earnings(
+    tool_result: dict[str, Any],
+    *,
+    today: datetime.date,
+    freshness: str,
+    data_as_of: str | None,
+) -> dict[str, Any]:
+    source = tool_result.get("source")
+    market_label = "kr" if (
+        tool_result.get("market") == "kr" or source == "market_events"
+    ) else "us"
+
+    ctx: dict[str, Any] = {
+        "symbol": tool_result.get("symbol"),
+        "market": market_label,
+        "as_of": today.isoformat(),
+        "window_days": _WINDOW_DAYS,
+        "freshness": freshness,
+        "source": source,
+    }
+    if data_as_of is not None:
+        ctx["data_as_of"] = data_as_of
+
+    if tool_result.get("error"):
+        ctx["has_upcoming"] = False
+        ctx["next_earnings"] = None
+        ctx["note"] = f"earnings lookup degraded: {tool_result.get('error')}"
+        return ctx
+
+    upcoming: list[tuple[datetime.date, dict[str, Any]]] = []
+    for item in tool_result.get("earnings") or []:
+        raw = item.get("date")
+        if not raw:
+            continue
+        try:
+            edate = datetime.date.fromisoformat(raw)
+        except (ValueError, TypeError):
+            continue
+        if edate >= today:
+            upcoming.append((edate, item))
+
+    if not upcoming:
+        ctx["has_upcoming"] = False
+        ctx["next_earnings"] = None
+        ctx["note"] = f"no scheduled earnings within {_WINDOW_DAYS} days"
+        return ctx
+
+    upcoming.sort(key=lambda pair: pair[0])
+    edate, item = upcoming[0]
+    ctx["has_upcoming"] = True
+    ctx["next_earnings"] = {
+        "date": edate.isoformat(),
+        "d_minus": (edate - today).days,
+        "timing": _map_timing(item.get("hour") or item.get("time_hint")),
+        "eps_estimate": item.get("eps_estimate"),
+        "revenue_estimate": item.get("revenue_estimate"),
+        "quarter": item.get("quarter"),
+        "year": item.get("year"),
+        "status": item.get("status"),
+    }
+    return ctx
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/mcp_server/test_earnings_context.py -v`
+Expected: PASS (5 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/mcp_server/tooling/earnings_context.py tests/mcp_server/test_earnings_context.py
+git commit -m "feat(ROB-722): pure compact earnings shaper
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01UG8sLTN1Kko1PuenppjvD8"
+```
+
+---
+
+## Task 2: KR ingestion freshness (`_kr_ingestion_freshness`)
+
+**Files:**
+- Modify: `app/mcp_server/tooling/earnings_context.py`
+- Test: `tests/mcp_server/test_earnings_context.py`
+
+**Interfaces:**
+- Consumes: `MarketEventIngestionPartition` (columns `market`, `category`, `status`, `finished_at`); reuses `STALE_AFTER_HOURS` (36h) + `_is_stale` + `_ensure_aware` from `app.services.market_events.freshness_service` (DRY on threshold).
+- Produces: `async _kr_ingestion_freshness(db: AsyncSession) -> tuple[str, str | None]` → `(freshness, data_as_of)` where freshness ∈ `{"fresh","stale","unknown"}` and data_as_of is the newest succeeded `finished_at` date ISO (or None).
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# append to tests/mcp_server/test_earnings_context.py
+import datetime as _dt
+
+from app.services.market_events.freshness_service import STALE_AFTER_HOURS
+
+
+class _FakeScalarResult:
+    def __init__(self, value):
+        self._value = value
+
+    def scalar_one_or_none(self):
+        return self._value
+
+
+class _FakeDB:
+    def __init__(self, value):
+        self._value = value
+
+    async def execute(self, _stmt):
+        return _FakeScalarResult(self._value)
+
+
+@pytest.mark.asyncio
+async def test_kr_freshness_none_partition_is_unknown():
+    freshness, as_of = await ec._kr_ingestion_freshness(_FakeDB(None))
+    assert freshness == "unknown"
+    assert as_of is None
+
+
+@pytest.mark.asyncio
+async def test_kr_freshness_recent_is_fresh():
+    recent = _dt.datetime.now(_dt.UTC) - _dt.timedelta(hours=1)
+    freshness, as_of = await ec._kr_ingestion_freshness(_FakeDB(recent))
+    assert freshness == "fresh"
+    assert as_of == recent.date().isoformat()
+
+
+@pytest.mark.asyncio
+async def test_kr_freshness_old_is_stale():
+    old = _dt.datetime.now(_dt.UTC) - _dt.timedelta(hours=STALE_AFTER_HOURS + 5)
+    freshness, as_of = await ec._kr_ingestion_freshness(_FakeDB(old))
+    assert freshness == "stale"
+    assert as_of == old.date().isoformat()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/mcp_server/test_earnings_context.py -k kr_freshness -v`
+Expected: FAIL — `AttributeError: module ... has no attribute '_kr_ingestion_freshness'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add imports at the top of `earnings_context.py`:
+
+```python
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.market_events import MarketEventIngestionPartition
+from app.services.market_events.freshness_service import _ensure_aware, _is_stale
+```
+
+Add the function:
+
+```python
+async def _kr_ingestion_freshness(db: AsyncSession) -> tuple[str, str | None]:
+    """Newest succeeded KR earnings ingestion → (freshness, data_as_of ISO|None).
+
+    Global per (market=kr, category=earnings) — compute ONCE per batch, not per
+    symbol. Reuses the market_events STALE_AFTER_HOURS threshold. Fail-open at
+    the caller: a DB error leaves KR rows on ('unknown', None).
+    """
+    stmt = select(func.max(MarketEventIngestionPartition.finished_at)).where(
+        MarketEventIngestionPartition.market == "kr",
+        MarketEventIngestionPartition.category == "earnings",
+        MarketEventIngestionPartition.status == "succeeded",
+    )
+    finished_at = (await db.execute(stmt)).scalar_one_or_none()
+    if finished_at is None:
+        return ("unknown", None)
+    aware = _ensure_aware(finished_at)
+    freshness = "stale" if _is_stale(aware, now=datetime.datetime.now(datetime.UTC)) else "fresh"
+    return (freshness, aware.date().isoformat())
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/mcp_server/test_earnings_context.py -k kr_freshness -v`
+Expected: PASS (3 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/mcp_server/tooling/earnings_context.py tests/mcp_server/test_earnings_context.py
+git commit -m "feat(ROB-722): KR ingestion freshness derivation
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01UG8sLTN1Kko1PuenppjvD8"
+```
+
+---
+
+## Task 3: `build_earnings_context` dispatch + crypto skip
+
+**Files:**
+- Modify: `app/mcp_server/tooling/earnings_context.py`
+- Test: `tests/mcp_server/test_earnings_context.py`
+
+**Interfaces:**
+- Consumes: `handle_get_earnings_calendar(symbol, from_date, to_date, market) -> dict` (from `app.mcp_server.tooling.fundamentals._financials`); `_compact_earnings`; `_kr_ingestion_freshness`.
+- Produces: `async build_earnings_context(symbol: str, market: str, *, today: datetime.date | None = None, kr_freshness: tuple[str, str | None] | None = None) -> dict | None` — returns `None` for crypto/blank/non-equity market; else the compact context dict.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# append to tests/mcp_server/test_earnings_context.py
+
+
+@pytest.mark.asyncio
+async def test_build_earnings_context_crypto_returns_none():
+    ctx = await ec.build_earnings_context("BTC", "crypto", today=TODAY)
+    assert ctx is None
+
+
+@pytest.mark.asyncio
+async def test_build_earnings_context_us_calls_handler_and_shapes(monkeypatch):
+    async def _fake_handler(symbol, from_date, to_date, market):
+        assert symbol == "NVDA"
+        assert market == "us"
+        assert from_date == "2026-07-06"
+        assert to_date == "2026-08-05"  # today + 30d
+        return {
+            "symbol": "NVDA", "source": "finnhub",
+            "earnings": [{"date": "2026-07-18", "hour": "amc", "eps_estimate": 0.84}],
+        }
+
+    monkeypatch.setattr(ec, "handle_get_earnings_calendar", _fake_handler)
+    ctx = await ec.build_earnings_context("NVDA", "us", today=TODAY)
+    assert ctx["market"] == "us"
+    assert ctx["freshness"] == "live"
+    assert ctx["has_upcoming"] is True
+    assert ctx["next_earnings"]["d_minus"] == 12
+
+
+@pytest.mark.asyncio
+async def test_build_earnings_context_kr_uses_passed_freshness(monkeypatch):
+    async def _fake_handler(symbol, from_date, to_date, market):
+        return {
+            "symbol": "005930", "market": "kr", "source": "market_events",
+            "earnings": [{"date": "2026-07-25", "time_hint": "unknown"}],
+        }
+
+    monkeypatch.setattr(ec, "handle_get_earnings_calendar", _fake_handler)
+    ctx = await ec.build_earnings_context(
+        "005930", "kr", today=TODAY, kr_freshness=("stale", "2026-07-01")
+    )
+    assert ctx["freshness"] == "stale"
+    assert ctx["data_as_of"] == "2026-07-01"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/mcp_server/test_earnings_context.py -k build_earnings -v`
+Expected: FAIL — `AttributeError: module ... has no attribute 'build_earnings_context'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add import at the top of `earnings_context.py`:
+
+```python
+from app.mcp_server.tooling.fundamentals._financials import (
+    handle_get_earnings_calendar,
+)
+```
+
+Add the function:
+
+```python
+_EQUITY_MARKETS = {"kr", "us"}
+
+
+async def build_earnings_context(
+    symbol: str,
+    market: str,
+    *,
+    today: datetime.date | None = None,
+    kr_freshness: tuple[str, str | None] | None = None,
+) -> dict[str, Any] | None:
+    """Compact upcoming-earnings context for one symbol, or None to omit.
+
+    Omits (None) only for crypto / non-equity markets — earnings has no meaning
+    there. For US/KR equities it ALWAYS returns a dict (no-earnings is an
+    explicit has_upcoming=False signal). US freshness is "live"; KR freshness is
+    taken from ``kr_freshness`` (computed once per batch by the caller)."""
+    market_norm = (market or "").strip().lower()
+    if market_norm not in _EQUITY_MARKETS:
+        return None
+
+    today = today or datetime.date.today()
+    to_date = today + datetime.timedelta(days=_WINDOW_DAYS)
+
+    tool_result = await handle_get_earnings_calendar(
+        symbol, today.isoformat(), to_date.isoformat(), market_norm
+    )
+
+    if market_norm == "kr":
+        freshness, data_as_of = kr_freshness or ("unknown", None)
+    else:
+        freshness, data_as_of = "live", None
+
+    return _compact_earnings(
+        tool_result, today=today, freshness=freshness, data_as_of=data_as_of
+    )
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/mcp_server/test_earnings_context.py -v`
+Expected: PASS (all tests in file)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/mcp_server/tooling/earnings_context.py tests/mcp_server/test_earnings_context.py
+git commit -m "feat(ROB-722): build_earnings_context dispatch + crypto skip
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01UG8sLTN1Kko1PuenppjvD8"
+```
+
+---
+
+## Task 4: `_attach_earnings` batched fail-open pass + wiring
+
+**Files:**
+- Modify: `app/mcp_server/tooling/analysis_tool_handlers.py` (import ~:35, add `_attach_earnings` after `_attach_decision_history` ~:880, wire call ~:942)
+- Test: `tests/mcp_server/test_analyze_stock_batch_earnings.py`
+
+**Interfaces:**
+- Consumes: `build_earnings_context(symbol, market, *, today, kr_freshness) -> dict | None`, `_kr_ingestion_freshness(db) -> tuple[str, str|None]`, `AsyncSessionLocal`.
+- Produces: `async _attach_earnings(results: dict[str, Any], *, market: str | None) -> None` — mutates `results` in place, attaching `result["earnings"]` per non-error, non-crypto symbol.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/mcp_server/test_analyze_stock_batch_earnings.py
+"""ROB-722 — analyze_stock_batch earnings auto-inject attach pass."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.mcp_server.tooling import analysis_tool_handlers as h
+
+
+@pytest.mark.asyncio
+async def test_attach_earnings_injects_when_context_exists(monkeypatch):
+    async def _fake_build(symbol, market, *, today=None, kr_freshness=None):
+        return {"symbol": symbol, "market": market, "has_upcoming": False,
+                "next_earnings": None}
+
+    async def _fake_kr_fresh(db):
+        return ("fresh", "2026-07-06")
+
+    monkeypatch.setattr(h, "build_earnings_context", _fake_build, raising=False)
+    monkeypatch.setattr(h, "_kr_ingestion_freshness", _fake_kr_fresh, raising=False)
+
+    results = {"NVDA": {"symbol": "NVDA", "market_type": "us"}}
+    await h._attach_earnings(results, market="us")
+
+    assert results["NVDA"]["earnings"]["has_upcoming"] is False
+
+
+@pytest.mark.asyncio
+async def test_attach_earnings_fail_open_on_error(monkeypatch):
+    async def _boom(symbol, market, *, today=None, kr_freshness=None):
+        raise RuntimeError("finnhub down")
+
+    monkeypatch.setattr(h, "build_earnings_context", _boom, raising=False)
+
+    results = {"NVDA": {"symbol": "NVDA", "market_type": "us"}}
+    await h._attach_earnings(results, market="us")  # must not raise
+
+    assert "earnings" not in results["NVDA"]
+
+
+@pytest.mark.asyncio
+async def test_attach_earnings_skips_error_and_crypto_rows(monkeypatch):
+    # Mirrors real build: None for crypto (skip), dict for equities. Error rows
+    # are skipped by _attach_earnings before build is ever called.
+    async def _fake_build(symbol, market, *, today=None, kr_freshness=None):
+        if str(market).strip().lower() == "crypto":
+            return None
+        return {"symbol": symbol}
+
+    monkeypatch.setattr(h, "build_earnings_context", _fake_build, raising=False)
+
+    results = {
+        "BADSYM": {"error": "not found"},
+        "BTC": {"symbol": "BTC", "market_type": "crypto"},
+        "NVDA": {"symbol": "NVDA", "market_type": "us"},
+    }
+    await h._attach_earnings(results, market=None)
+
+    assert "earnings" not in results["BADSYM"]      # error row skipped pre-build
+    assert "earnings" not in results["BTC"]         # build returns None → omit
+    assert results["NVDA"]["earnings"] == {"symbol": "NVDA"}  # equity attached
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/mcp_server/test_analyze_stock_batch_earnings.py -v`
+Expected: FAIL — `AttributeError: module ... has no attribute '_attach_earnings'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add import near the existing decision_history import (~:35 in `analysis_tool_handlers.py`):
+
+```python
+from app.mcp_server.tooling.earnings_context import (
+    _kr_ingestion_freshness,
+    build_earnings_context,
+)
+```
+
+Add the function immediately after `_attach_decision_history` (after ~:879):
+
+```python
+async def _attach_earnings(
+    results: dict[str, Any],
+    *,
+    market: str | None,
+) -> None:
+    """ROB-722: inject per-symbol upcoming-earnings context (US live / KR DB).
+
+    Batched (one session), symbol-level fail-open. No-earnings is an explicit
+    signal (has_upcoming=False), so US/KR equity rows always receive an
+    ``earnings`` field; crypto/error rows are skipped. KR ingestion freshness is
+    computed at most once per batch and threaded into each build call.
+    """
+    if not any(
+        isinstance(row, dict) and "error" not in row for row in results.values()
+    ):
+        return
+    try:
+        from app.core.db import AsyncSessionLocal
+
+        async with AsyncSessionLocal() as db:
+            kr_freshness: tuple[str, str | None] | None = None
+            for sym, result in results.items():
+                if not isinstance(result, dict) or "error" in result:
+                    continue
+                mkt = result.get("market_type") or market
+                if str(mkt or "").strip().lower() == "kr" and kr_freshness is None:
+                    try:
+                        kr_freshness = await _kr_ingestion_freshness(db)
+                    except Exception:  # fail-open: freshness is advisory
+                        kr_freshness = ("unknown", None)
+                try:
+                    ctx = await build_earnings_context(
+                        str(sym), str(mkt or ""), kr_freshness=kr_freshness
+                    )
+                except Exception as exc:  # symbol-level fail-open (e.g. 429)
+                    logger.debug("earnings injection skipped for %s: %s", sym, exc)
+                    continue
+                if ctx is not None:
+                    result["earnings"] = ctx
+    except Exception as exc:  # fail-open: advisory-only
+        logger.debug("earnings injection skipped: %s", exc)
+```
+
+Wire the call in `analyze_stock_batch_impl` immediately after the `_attach_decision_history` line (~:942):
+
+```python
+    if quick:
+        await _attach_fresh_artifact_hints(response.get("results", {}), market=market)
+        await _attach_decision_history(response.get("results", {}), market=market)
+        await _attach_earnings(response.get("results", {}), market=market)
+    return response
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/mcp_server/test_analyze_stock_batch_earnings.py -v`
+Expected: PASS (3 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/mcp_server/tooling/analysis_tool_handlers.py tests/mcp_server/test_analyze_stock_batch_earnings.py
+git commit -m "feat(ROB-722): wire _attach_earnings into analyze_stock_batch
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01UG8sLTN1Kko1PuenppjvD8"
+```
+
+---
+
+## Task 5: Full-suite gate (lint + typecheck + LLM guard + regression)
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Run the two new test modules + the decision_history regression**
+
+Run:
+```bash
+uv run pytest tests/mcp_server/test_earnings_context.py \
+  tests/mcp_server/test_analyze_stock_batch_earnings.py \
+  tests/mcp_server/test_analyze_stock_batch_decision_history.py \
+  tests/test_mcp_earnings_calendar.py -v
+```
+Expected: PASS (all).
+
+- [ ] **Step 2: Static LLM-import guard (ROB-501) must still pass**
+
+Run: `uv run pytest tests/services/action_report/snapshot_backed/test_no_internal_llm_imports.py -v`
+Expected: PASS.
+
+- [ ] **Step 3: Lint + typecheck the touched files**
+
+Run: `make lint` (Ruff + ty). If unavailable, `uv run ruff check app/mcp_server/tooling/earnings_context.py app/mcp_server/tooling/analysis_tool_handlers.py`
+Expected: no new findings.
+
+- [ ] **Step 4: Confirm migration 0**
+
+Run: `git status --short` and confirm no files under `alembic/versions/` were added.
+Expected: only `app/mcp_server/tooling/earnings_context.py`, `app/mcp_server/tooling/analysis_tool_handlers.py`, and the two test files (plus docs) changed.
+
+- [ ] **Step 5: Commit (only if lint/format applied changes)**
+
+```bash
+git add -A
+git commit -m "chore(ROB-722): lint/format pass
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01UG8sLTN1Kko1PuenppjvD8"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- US live Finnhub path → Task 3 (`build_earnings_context` market="us", freshness="live") + Task 1 shaper. ✓
+- KR market_events DB path + stale marker → Task 2 (`_kr_ingestion_freshness`) + Task 3 (kr branch). ✓
+- No-earnings explicit signal (HCA) → Task 1 (`has_upcoming=False` + note). ✓
+- Attach rail sibling to `_attach_decision_history`, wired after it → Task 4. ✓
+- Symbol-level fail-open for US rate-limit → Task 4 inner try/except + handler's own 429→`_error_payload` degrade (Task 1 error branch). ✓
+- crypto skip → Task 3 (`_EQUITY_MARKETS` guard → None) + Task 4 (None → omit). ✓
+- Tests: US live-Finnhub + KR DB + no-earnings + fail-open + crypto → Tasks 1/3/4. ✓
+- migration 0, no LLM imports → Task 5 gates. ✓
+
+**Placeholder scan:** none — every code step shows complete code; no TBD/TODO. ✓
+
+**Type consistency:** `build_earnings_context(symbol, market, *, today, kr_freshness)` and `_kr_ingestion_freshness(db) -> tuple[str, str|None]` signatures identical across Tasks 2/3/4 and their tests. `_compact_earnings(tool_result, *, today, freshness, data_as_of)` identical in Tasks 1/3. Attached key `earnings` consistent. ✓

--- a/docs/superpowers/specs/2026-07-06-rob-722-earnings-auto-inject-design.md
+++ b/docs/superpowers/specs/2026-07-06-rob-722-earnings-auto-inject-design.md
@@ -1,0 +1,192 @@
+# ROB-722 — analyze_stock_batch 심볼별 다가오는 실적 auto-inject
+
+**날짜:** 2026-07-06
+**이슈:** ROB-722 (related: ROB-711 레일, ROB-721 스코핑 GO #2)
+**상태:** 설계 승인 대기
+
+## 배경
+
+`get_earnings_calendar` MCP 도구는 이미 배포되어 있다(US=live Finnhub, KR=market_events DB).
+그러나 분석 체인은 이를 자동 주입하지 않아, 오퍼레이터가 심볼 분석 때마다 실적 일정을 수기로
+조회한다. 검증된 코퍼스 사례(`review.investment_report_items` 330행):
+
+- **NVDA**: "Finnhub calendar shows earnings on 2026-05-20 AMC; avoid…" — 실적 임박이 진입 판단을 뒤집음.
+- **HCA**: "30일 내 실적 없음" — **무실적을 진입 정당화 근거로 인용**.
+- **JPM/BAC**: 실적 인접 trim watch.
+
+오퍼레이터가 이미 수기로 하는 검증된 행동을 auto-inject가 결정론적으로 체계화한다.
+신규 벤더/auth/스키마 0, migration 0.
+
+## 목표 / 비목표
+
+**목표**
+- `analyze_stock_batch`(compact 계약, `quick=True`)의 각 US/KR equity 심볼 결과에 "다가오는 실적
+  컨텍스트"를 결정론적으로 자동 첨부.
+- 무실적("향후 30일 무실적")도 명시적 신호로 첨부(HCA 사례).
+- US=live Finnhub, KR=market_events DB(+freshness 표기).
+- 완전 fail-open — 실적 조회 실패가 분석 결과를 절대 훼손하지 않음.
+
+**비목표**
+- KR live 소싱(DART/WiseFn 실시간) — 별도 이슈. 이번엔 DB + stale 표기.
+- crypto 실적(개념 없음) — skip.
+- `analyze_portfolio`(full 계약, quick=False) — 미대상(compact 계약만; decision_history와 동일 범위).
+- 스키마/마이그레이션 변경 — 없음.
+- LLM 판단 — 없음(ROB-501 가드). 순수 결정론 shaping.
+
+## 아키텍처
+
+ROB-711의 `_attach_decision_history` 레일을 1:1 미러하되, US 경로가 Finnhub fetch 디스패치를
+필요로 하므로 **서비스 계층에 병렬 구현을 새로 짓지 않고** 이미 검증된 MCP 핸들러
+`handle_get_earnings_calendar`를 재사용한다(둘 다 tooling 계층 → 레이어 역전 없음).
+그 핸들러가 이미 처리하는 것: US/KR 시장 디스패치, Finnhub fetch, KR DB shaping, crypto 거부,
+날짜 윈도우 정규화. **신규 코드 = compact shaper + `_attach_earnings` 배치 루프뿐.**
+
+### 컴포넌트
+
+**신규 `app/mcp_server/tooling/earnings_context.py`** (tooling 계층)
+
+```
+_TIMING_MAP = {"bmo": "BMO", "amc": "AMC", "dmh": "DMH"}
+_WINDOW_DAYS = 30
+_KR_STALE_THRESHOLD_DAYS = 2
+
+def _map_timing(hour: str | None) -> str          # bmo/amc/dmh → BMO/AMC/DMH, else "unknown"
+
+def _compact_earnings(
+    tool_result: dict, *, today: date, freshness: str, data_as_of: str | None,
+) -> dict:
+    """순수 shaper. tool_result(US finnhub / KR market_events)의 earnings[]에서
+       today 이후 최근접 upcoming 1건을 선택해 compact 컨텍스트 생성.
+       upcoming 없으면 has_upcoming=False + note."""
+
+async def _kr_ingestion_freshness(db) -> tuple[str, str | None]:
+    """MarketEventIngestionPartition 최신 finished_at(market=kr, category=earnings)로
+       (freshness ∈ {fresh, stale, unknown}, data_as_of ISO|None) 도출.
+       배치당 1회만 계산(심볼 무관 전역)."""
+
+async def build_earnings_context(
+    symbol: str, market: str, *, today: date | None = None,
+    kr_freshness: tuple[str, str | None] | None = None,
+) -> dict | None:
+    """crypto/비-equity → None(필드 생략). 그 외 handle_get_earnings_calendar(
+       symbol, from=today, to=today+30d, market) 호출 → _compact_earnings → 반환.
+       US freshness="live". KR freshness는 kr_freshness 인자(배치서 1회 계산) 사용."""
+```
+
+**`app/mcp_server/tooling/analysis_tool_handlers.py`** — `_attach_decision_history`(:850) 옆 sibling:
+
+```
+async def _attach_earnings(results, *, market) -> None:
+    """ROB-722: 심볼별 다가오는 실적 컨텍스트 auto-inject.
+       배치(단일 세션), 심볼별 fail-open. crypto/error 행 skip.
+       KR freshness는 세션당 1회 계산해 각 build 호출에 전달."""
+```
+
+호출 지점: `analyze_stock_batch_impl` `:942` `_attach_decision_history` **직후**
+(quick 분기 안, `_attach_fresh_artifact_hints` → `_attach_decision_history` → `_attach_earnings`).
+
+### 데이터 흐름
+
+1. `analyze_stock_batch_impl(quick=True)` → `_run_batch_analysis` → `_attach_fresh_artifact_hints`
+   → `_attach_decision_history` → **`_attach_earnings`**.
+2. `_attach_earnings`: 단일 `AsyncSessionLocal`. KR 심볼이 하나라도 있으면 `_kr_ingestion_freshness`
+   1회 계산. 각 non-error·non-crypto 심볼에 `build_earnings_context(sym, mkt, kr_freshness=...)`.
+3. `build_earnings_context`: crypto면 None. 아니면 `handle_get_earnings_calendar` 호출 →
+   `_compact_earnings` shaping → `result["earnings"]`에 첨부.
+4. 심볼별 try/except: 한 심볼의 Finnhub 429/에러가 배치 전체를 죽이지 않음(그 심볼만 필드 생략).
+
+## 첨부 페이로드 형태
+
+결과 dict의 `earnings` 키로 첨부(decision_history와 동일한 sibling 위치):
+
+```jsonc
+// upcoming 실적 있음 (NVDA류)
+"earnings": {
+  "symbol": "NVDA",
+  "market": "us",
+  "as_of": "2026-07-06",
+  "window_days": 30,
+  "has_upcoming": true,
+  "next_earnings": {
+    "date": "2026-05-20",
+    "d_minus": 12,               // (date - today).days
+    "timing": "AMC",             // BMO | AMC | DMH | unknown
+    "eps_estimate": 0.84,
+    "revenue_estimate": 26500000000,
+    "quarter": 1,
+    "year": 2026,
+    "status": "scheduled"        // KR만; US는 null
+  },
+  "freshness": "live",           // US=live
+  "source": "finnhub"
+}
+
+// 무실적 (HCA류) — 명시적 신호
+"earnings": {
+  "symbol": "HCA",
+  "market": "us",
+  "as_of": "2026-07-06",
+  "window_days": 30,
+  "has_upcoming": false,
+  "next_earnings": null,
+  "note": "no scheduled earnings within 30 days",
+  "freshness": "live",
+  "source": "finnhub"
+}
+
+// KR (DB + stale 표기)
+"earnings": {
+  "symbol": "005930",
+  "market": "kr",
+  "as_of": "2026-07-06",
+  "window_days": 30,
+  "has_upcoming": true,
+  "next_earnings": { "date": "2026-07-25", "d_minus": 19, "timing": "unknown", ... },
+  "freshness": "stale",          // fresh | stale | unknown (finished_at 기준 >2일=stale)
+  "data_as_of": "2026-07-01",    // KR 최신 인제스트 finished_at
+  "source": "market_events"
+}
+```
+
+- crypto/비-equity: `build`가 None → 필드 자체 생략(첨부 안 함).
+- `d_minus`는 `date.today()` 기준 단순 일수 차. (ET/KST 분리 미도입 — YAGNI. 30일 윈도우/일 단위라
+  경계 오차 무의미. 필요 시 후속.)
+
+## 결정 사항 (사용자 승인 완료)
+
+1. **KR 경로**: DB + stale 표기. `MarketEventIngestionPartition.finished_at`으로 freshness 도출.
+2. **US rate-limit**: 심볼별 fail-open, 캐시 없음(YAGNI). 배치 최대 10심볼 → 최대 10 Finnhub 콜,
+   무료 60/min 여유. 심볼별 try/except로 429 격리.
+3. **무실적 신호화**: `has_upcoming=false` + `note`로 명시 첨부(None 반환 아님). crypto만 생략.
+
+## 에러 처리 / fail-open 계층
+
+- `_attach_earnings` 전체를 try/except로 감싸 advisory-only(decision_history와 동일 패턴).
+- 심볼별로도 try/except — 한 심볼 실패가 나머지 심볼 첨부를 막지 않음.
+- `handle_get_earnings_calendar`가 `_error_payload`(dict with error/source)를 반환하면 shaper는
+  `has_upcoming=false` + 에러 note로 degrade(예외 아님). Finnhub 429는 `FinnhubQuotaExceededError`가
+  핸들러 내부에서 `_error_payload`로 잡힘 → 그 심볼만 degrade.
+- KR freshness 조회 실패 → `("unknown", None)`으로 fail-open.
+
+## 테스트
+
+**`tests/mcp_server/test_analyze_stock_batch_earnings.py`** (신규, decision_history 테스트 미러):
+- `_attach_earnings`가 build 컨텍스트 존재 시 `earnings` 첨부(build_earnings_context monkeypatch).
+- build 예외 시 fail-open(결과 untouched).
+- error 행 skip, crypto 행 skip.
+
+**`tests/mcp_server/test_earnings_context.py`** (신규):
+- US upcoming: `handle_get_earnings_calendar` monkeypatch → d_minus·timing(BMO/AMC/DMH) 매핑 검증.
+- US 무실적: earnings=[] → `has_upcoming=false` + note.
+- KR DB 경로: freshness=stale/fresh + data_as_of 표기(partition monkeypatch 또는 seed).
+- crypto/비-equity: `build_earnings_context` → None.
+- `_compact_earnings` 순수 함수: today 이후 최근접 선택, 과거 실적 제외, timing 매핑, no-upcoming.
+
+**정적 가드**: `test_no_internal_llm_imports.py` 영향 없음(LLM import 없음). migration 0.
+
+## 완료 기준
+
+- `analyze_stock_batch` compact 결과에 심볼별 실적 컨텍스트 결정론 포함(US live / KR DB).
+- 무실적 케이스도 명시 신호로 첨부.
+- 테스트: US live-Finnhub 경로 + KR DB 경로 + 무실적 케이스 + fail-open + crypto skip.
+- migration 0. 기존 decision_history/fresh_artifact 첨부 회귀 없음.

--- a/tests/mcp_server/test_analyze_stock_batch_earnings.py
+++ b/tests/mcp_server/test_analyze_stock_batch_earnings.py
@@ -10,8 +10,12 @@ from app.mcp_server.tooling import analysis_tool_handlers as h
 @pytest.mark.asyncio
 async def test_attach_earnings_injects_when_context_exists(monkeypatch):
     async def _fake_build(symbol, market, *, today=None, kr_freshness=None):
-        return {"symbol": symbol, "market": market, "has_upcoming": False,
-                "next_earnings": None}
+        return {
+            "symbol": symbol,
+            "market": market,
+            "has_upcoming": False,
+            "next_earnings": None,
+        }
 
     async def _fake_kr_fresh(db):
         return ("fresh", "2026-07-06")
@@ -56,6 +60,6 @@ async def test_attach_earnings_skips_error_and_crypto_rows(monkeypatch):
     }
     await h._attach_earnings(results, market=None)
 
-    assert "earnings" not in results["BADSYM"]      # error row skipped pre-build
-    assert "earnings" not in results["BTC"]         # build returns None → omit
+    assert "earnings" not in results["BADSYM"]  # error row skipped pre-build
+    assert "earnings" not in results["BTC"]  # build returns None → omit
     assert results["NVDA"]["earnings"] == {"symbol": "NVDA"}  # equity attached

--- a/tests/mcp_server/test_analyze_stock_batch_earnings.py
+++ b/tests/mcp_server/test_analyze_stock_batch_earnings.py
@@ -1,0 +1,61 @@
+"""ROB-722 — analyze_stock_batch earnings auto-inject attach pass."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.mcp_server.tooling import analysis_tool_handlers as h
+
+
+@pytest.mark.asyncio
+async def test_attach_earnings_injects_when_context_exists(monkeypatch):
+    async def _fake_build(symbol, market, *, today=None, kr_freshness=None):
+        return {"symbol": symbol, "market": market, "has_upcoming": False,
+                "next_earnings": None}
+
+    async def _fake_kr_fresh(db):
+        return ("fresh", "2026-07-06")
+
+    monkeypatch.setattr(h, "build_earnings_context", _fake_build, raising=False)
+    monkeypatch.setattr(h, "_kr_ingestion_freshness", _fake_kr_fresh, raising=False)
+
+    results = {"NVDA": {"symbol": "NVDA", "market_type": "us"}}
+    await h._attach_earnings(results, market="us")
+
+    assert results["NVDA"]["earnings"]["has_upcoming"] is False
+
+
+@pytest.mark.asyncio
+async def test_attach_earnings_fail_open_on_error(monkeypatch):
+    async def _boom(symbol, market, *, today=None, kr_freshness=None):
+        raise RuntimeError("finnhub down")
+
+    monkeypatch.setattr(h, "build_earnings_context", _boom, raising=False)
+
+    results = {"NVDA": {"symbol": "NVDA", "market_type": "us"}}
+    await h._attach_earnings(results, market="us")  # must not raise
+
+    assert "earnings" not in results["NVDA"]
+
+
+@pytest.mark.asyncio
+async def test_attach_earnings_skips_error_and_crypto_rows(monkeypatch):
+    # Mirrors real build: None for crypto (skip), dict for equities. Error rows
+    # are skipped by _attach_earnings before build is ever called.
+    async def _fake_build(symbol, market, *, today=None, kr_freshness=None):
+        if str(market).strip().lower() == "crypto":
+            return None
+        return {"symbol": symbol}
+
+    monkeypatch.setattr(h, "build_earnings_context", _fake_build, raising=False)
+
+    results = {
+        "BADSYM": {"error": "not found"},
+        "BTC": {"symbol": "BTC", "market_type": "crypto"},
+        "NVDA": {"symbol": "NVDA", "market_type": "us"},
+    }
+    await h._attach_earnings(results, market=None)
+
+    assert "earnings" not in results["BADSYM"]      # error row skipped pre-build
+    assert "earnings" not in results["BTC"]         # build returns None → omit
+    assert results["NVDA"]["earnings"] == {"symbol": "NVDA"}  # equity attached

--- a/tests/mcp_server/test_earnings_context.py
+++ b/tests/mcp_server/test_earnings_context.py
@@ -1,0 +1,84 @@
+"""ROB-722 — earnings auto-inject context builder."""
+
+from __future__ import annotations
+
+import datetime
+
+import pytest
+
+from app.mcp_server.tooling import earnings_context as ec
+
+TODAY = datetime.date(2026, 7, 6)
+
+
+def test_map_timing_variants():
+    assert ec._map_timing("bmo") == "BMO"
+    assert ec._map_timing("AMC") == "AMC"
+    assert ec._map_timing("dmh") == "DMH"
+    assert ec._map_timing("") == "unknown"
+    assert ec._map_timing(None) == "unknown"
+    assert ec._map_timing("weird") == "unknown"
+
+
+def test_compact_earnings_us_upcoming_picks_nearest_future():
+    tool_result = {
+        "symbol": "NVDA",
+        "source": "finnhub",
+        "earnings": [
+            {"date": "2026-01-01", "hour": "amc"},  # past — excluded
+            {"date": "2026-07-25", "hour": "bmo", "eps_estimate": 0.9},
+            {"date": "2026-07-18", "hour": "amc", "eps_estimate": 0.84,
+             "revenue_estimate": 26500000000, "quarter": 2, "year": 2026},
+        ],
+    }
+    ctx = ec._compact_earnings(tool_result, today=TODAY, freshness="live", data_as_of=None)
+    assert ctx["market"] == "us"
+    assert ctx["source"] == "finnhub"
+    assert ctx["freshness"] == "live"
+    assert ctx["window_days"] == 30
+    assert ctx["as_of"] == "2026-07-06"
+    assert "data_as_of" not in ctx
+    assert ctx["has_upcoming"] is True
+    ne = ctx["next_earnings"]
+    assert ne["date"] == "2026-07-18"       # nearest future, not the earlier past row
+    assert ne["d_minus"] == 12
+    assert ne["timing"] == "AMC"
+    assert ne["eps_estimate"] == 0.84
+    assert ne["quarter"] == 2
+
+
+def test_compact_earnings_no_upcoming_is_explicit_signal():
+    tool_result = {"symbol": "HCA", "source": "finnhub", "earnings": []}
+    ctx = ec._compact_earnings(tool_result, today=TODAY, freshness="live", data_as_of=None)
+    assert ctx["has_upcoming"] is False
+    assert ctx["next_earnings"] is None
+    assert ctx["note"] == "no scheduled earnings within 30 days"
+
+
+def test_compact_earnings_kr_carries_freshness_and_data_as_of():
+    tool_result = {
+        "symbol": "005930",
+        "market": "kr",
+        "source": "market_events",
+        "earnings": [
+            {"date": "2026-07-25", "time_hint": "unknown", "status": "scheduled",
+             "quarter": 2, "year": 2026},
+        ],
+    }
+    ctx = ec._compact_earnings(
+        tool_result, today=TODAY, freshness="stale", data_as_of="2026-07-01"
+    )
+    assert ctx["market"] == "kr"
+    assert ctx["source"] == "market_events"
+    assert ctx["freshness"] == "stale"
+    assert ctx["data_as_of"] == "2026-07-01"
+    assert ctx["next_earnings"]["timing"] == "unknown"
+    assert ctx["next_earnings"]["status"] == "scheduled"
+
+
+def test_compact_earnings_error_payload_degrades():
+    tool_result = {"symbol": "NVDA", "source": "finnhub", "error": "429 quota"}
+    ctx = ec._compact_earnings(tool_result, today=TODAY, freshness="live", data_as_of=None)
+    assert ctx["has_upcoming"] is False
+    assert ctx["next_earnings"] is None
+    assert "degraded" in ctx["note"]

--- a/tests/mcp_server/test_earnings_context.py
+++ b/tests/mcp_server/test_earnings_context.py
@@ -124,3 +124,45 @@ async def test_kr_freshness_old_is_stale():
     freshness, as_of = await ec._kr_ingestion_freshness(_FakeDB(old))
     assert freshness == "stale"
     assert as_of == old.date().isoformat()
+
+
+@pytest.mark.asyncio
+async def test_build_earnings_context_crypto_returns_none():
+    ctx = await ec.build_earnings_context("BTC", "crypto", today=TODAY)
+    assert ctx is None
+
+
+@pytest.mark.asyncio
+async def test_build_earnings_context_us_calls_handler_and_shapes(monkeypatch):
+    async def _fake_handler(symbol, from_date, to_date, market):
+        assert symbol == "NVDA"
+        assert market == "us"
+        assert from_date == "2026-07-06"
+        assert to_date == "2026-08-05"  # today + 30d
+        return {
+            "symbol": "NVDA", "source": "finnhub",
+            "earnings": [{"date": "2026-07-18", "hour": "amc", "eps_estimate": 0.84}],
+        }
+
+    monkeypatch.setattr(ec, "handle_get_earnings_calendar", _fake_handler)
+    ctx = await ec.build_earnings_context("NVDA", "us", today=TODAY)
+    assert ctx["market"] == "us"
+    assert ctx["freshness"] == "live"
+    assert ctx["has_upcoming"] is True
+    assert ctx["next_earnings"]["d_minus"] == 12
+
+
+@pytest.mark.asyncio
+async def test_build_earnings_context_kr_uses_passed_freshness(monkeypatch):
+    async def _fake_handler(symbol, from_date, to_date, market):
+        return {
+            "symbol": "005930", "market": "kr", "source": "market_events",
+            "earnings": [{"date": "2026-07-25", "time_hint": "unknown"}],
+        }
+
+    monkeypatch.setattr(ec, "handle_get_earnings_calendar", _fake_handler)
+    ctx = await ec.build_earnings_context(
+        "005930", "kr", today=TODAY, kr_freshness=("stale", "2026-07-01")
+    )
+    assert ctx["freshness"] == "stale"
+    assert ctx["data_as_of"] == "2026-07-01"

--- a/tests/mcp_server/test_earnings_context.py
+++ b/tests/mcp_server/test_earnings_context.py
@@ -28,11 +28,19 @@ def test_compact_earnings_us_upcoming_picks_nearest_future():
         "earnings": [
             {"date": "2026-01-01", "hour": "amc"},  # past — excluded
             {"date": "2026-07-25", "hour": "bmo", "eps_estimate": 0.9},
-            {"date": "2026-07-18", "hour": "amc", "eps_estimate": 0.84,
-             "revenue_estimate": 26500000000, "quarter": 2, "year": 2026},
+            {
+                "date": "2026-07-18",
+                "hour": "amc",
+                "eps_estimate": 0.84,
+                "revenue_estimate": 26500000000,
+                "quarter": 2,
+                "year": 2026,
+            },
         ],
     }
-    ctx = ec._compact_earnings(tool_result, today=TODAY, freshness="live", data_as_of=None)
+    ctx = ec._compact_earnings(
+        tool_result, today=TODAY, freshness="live", data_as_of=None
+    )
     assert ctx["market"] == "us"
     assert ctx["source"] == "finnhub"
     assert ctx["freshness"] == "live"
@@ -41,7 +49,7 @@ def test_compact_earnings_us_upcoming_picks_nearest_future():
     assert "data_as_of" not in ctx
     assert ctx["has_upcoming"] is True
     ne = ctx["next_earnings"]
-    assert ne["date"] == "2026-07-18"       # nearest future, not the earlier past row
+    assert ne["date"] == "2026-07-18"  # nearest future, not the earlier past row
     assert ne["d_minus"] == 12
     assert ne["timing"] == "AMC"
     assert ne["eps_estimate"] == 0.84
@@ -50,7 +58,9 @@ def test_compact_earnings_us_upcoming_picks_nearest_future():
 
 def test_compact_earnings_no_upcoming_is_explicit_signal():
     tool_result = {"symbol": "HCA", "source": "finnhub", "earnings": []}
-    ctx = ec._compact_earnings(tool_result, today=TODAY, freshness="live", data_as_of=None)
+    ctx = ec._compact_earnings(
+        tool_result, today=TODAY, freshness="live", data_as_of=None
+    )
     assert ctx["has_upcoming"] is False
     assert ctx["next_earnings"] is None
     assert ctx["note"] == "no scheduled earnings within 30 days"
@@ -62,8 +72,13 @@ def test_compact_earnings_kr_carries_freshness_and_data_as_of():
         "market": "kr",
         "source": "market_events",
         "earnings": [
-            {"date": "2026-07-25", "time_hint": "unknown", "status": "scheduled",
-             "quarter": 2, "year": 2026},
+            {
+                "date": "2026-07-25",
+                "time_hint": "unknown",
+                "status": "scheduled",
+                "quarter": 2,
+                "year": 2026,
+            },
         ],
     }
     ctx = ec._compact_earnings(
@@ -79,7 +94,9 @@ def test_compact_earnings_kr_carries_freshness_and_data_as_of():
 
 def test_compact_earnings_error_payload_degrades():
     tool_result = {"symbol": "NVDA", "source": "finnhub", "error": "429 quota"}
-    ctx = ec._compact_earnings(tool_result, today=TODAY, freshness="live", data_as_of=None)
+    ctx = ec._compact_earnings(
+        tool_result, today=TODAY, freshness="live", data_as_of=None
+    )
     assert ctx["has_upcoming"] is False
     assert ctx["next_earnings"] is None
     assert "degraded" in ctx["note"]
@@ -140,7 +157,8 @@ async def test_build_earnings_context_us_calls_handler_and_shapes(monkeypatch):
         assert from_date == "2026-07-06"
         assert to_date == "2026-08-05"  # today + 30d
         return {
-            "symbol": "NVDA", "source": "finnhub",
+            "symbol": "NVDA",
+            "source": "finnhub",
             "earnings": [{"date": "2026-07-18", "hour": "amc", "eps_estimate": 0.84}],
         }
 
@@ -156,7 +174,9 @@ async def test_build_earnings_context_us_calls_handler_and_shapes(monkeypatch):
 async def test_build_earnings_context_kr_uses_passed_freshness(monkeypatch):
     async def _fake_handler(symbol, from_date, to_date, market):
         return {
-            "symbol": "005930", "market": "kr", "source": "market_events",
+            "symbol": "005930",
+            "market": "kr",
+            "source": "market_events",
             "earnings": [{"date": "2026-07-25", "time_hint": "unknown"}],
         }
 

--- a/tests/mcp_server/test_earnings_context.py
+++ b/tests/mcp_server/test_earnings_context.py
@@ -7,6 +7,7 @@ import datetime
 import pytest
 
 from app.mcp_server.tooling import earnings_context as ec
+from app.services.market_events.freshness_service import STALE_AFTER_HOURS
 
 TODAY = datetime.date(2026, 7, 6)
 
@@ -82,3 +83,44 @@ def test_compact_earnings_error_payload_degrades():
     assert ctx["has_upcoming"] is False
     assert ctx["next_earnings"] is None
     assert "degraded" in ctx["note"]
+
+
+class _FakeScalarResult:
+    def __init__(self, value):
+        self._value = value
+
+    def scalar_one_or_none(self):
+        return self._value
+
+
+class _FakeDB:
+    def __init__(self, value):
+        self._value = value
+
+    async def execute(self, _stmt):
+        return _FakeScalarResult(self._value)
+
+
+@pytest.mark.asyncio
+async def test_kr_freshness_none_partition_is_unknown():
+    freshness, as_of = await ec._kr_ingestion_freshness(_FakeDB(None))
+    assert freshness == "unknown"
+    assert as_of is None
+
+
+@pytest.mark.asyncio
+async def test_kr_freshness_recent_is_fresh():
+    recent = datetime.datetime.now(datetime.UTC) - datetime.timedelta(hours=1)
+    freshness, as_of = await ec._kr_ingestion_freshness(_FakeDB(recent))
+    assert freshness == "fresh"
+    assert as_of == recent.date().isoformat()
+
+
+@pytest.mark.asyncio
+async def test_kr_freshness_old_is_stale():
+    old = datetime.datetime.now(datetime.UTC) - datetime.timedelta(
+        hours=STALE_AFTER_HOURS + 5
+    )
+    freshness, as_of = await ec._kr_ingestion_freshness(_FakeDB(old))
+    assert freshness == "stale"
+    assert as_of == old.date().isoformat()


### PR DESCRIPTION
## Summary

Auto-inject each US/KR equity symbol's upcoming-earnings context into `analyze_stock_batch` compact responses, reusing the validated ROB-711 attach rail.

Each symbol in the response now carries an `earnings` field:

```json
{
  "earnings": {
    "symbol": "NVDA",
    "market": "us",
    "as_of": "2026-07-06",
    "window_days": 30,
    "has_upcoming": true,
    "next_earnings": {
      "date": "2026-07-18",
      "d_minus": 12,
      "timing": "AMC",
      "eps_estimate": 0.84,
      "revenue_estimate": 26500000000,
      "quarter": 2,
      "year": 2026,
      "status": "scheduled"
    },
    "freshness": "live",
    "source": "finnhub"
  }
}
```

No-earnings is an **explicit signal** (`has_upcoming=false` + `note: "no scheduled earnings within 30 days"`) rather than omission — important for symbols like HCA where '30일 내 무실적' is itself an entry justification.

## Source paths

- **US**: live Finnhub via `handle_get_earnings_calendar` → `freshness="live"`
- **KR**: `market_events` DB ingestion (WiseFn + DART) + KR partition freshness (`STALE_AFTER_HOURS=36h`) → `freshness ∈ {fresh, stale, unknown}`

## Architecture

New module `app/mcp_server/tooling/earnings_context.py`:
- `_map_timing(hour)` — BMO/AMC/DMH/unknown
- `_compact_earnings(tool_result, *, today, freshness, data_as_of)` — pure shaper
- `_kr_ingestion_freshness(db)` — reuses `_ensure_aware` / `_is_stale` from `market_events.freshness_service` (DRY on threshold)
- `build_earnings_context(symbol, market, *, today, kr_freshness)` — dispatch + crypto skip + shape

New sibling attach rail `_attach_earnings(results, *, market)` in `analysis_tool_handlers.py`:
- One `AsyncSessionLocal` per batch (KR freshness computed once for the batch)
- Symbol-level fail-open (`except Exception: logger.debug(...); continue`)
- Skips error rows pre-build; skips crypto (build returns None)
- Wired immediately after `_attach_decision_history` in `analyze_stock_batch_impl` (compact contract only)

## Global constraints honored

- **No LLM providers** — pure deterministic shaping (ROB-501 guard still 1127/1127 green)
- **Migration 0** — `git status` confirms no `alembic/versions/` changes
- **Fail-open always** — outer + per-symbol + per-freshness guards; analysis result never raised out
- **Compact contract only** — attach runs only when `quick=True` (mirrors decision_history scope); skips crypto + error rows
- **Layer discipline** — `earnings_context.py` stays in the tooling layer (same as `analysis_tool_handlers` and `_financials`); no service→tooling inversion
- **Key name verified** — `earnings` has no collision with `_summarize_analysis_result` output

## Verification

- `uv run pytest tests/mcp_server/test_earnings_context.py tests/mcp_server/test_analyze_stock_batch_earnings.py tests/mcp_server/test_analyze_stock_batch_decision_history.py tests/test_mcp_earnings_calendar.py` → **24/24 pass**
- `uv run pytest tests/mcp_server/ tests/test_mcp_earnings_calendar.py -m "not integration and not live"` → **438/438 pass** (no regressions)
- `uv run pytest tests/services/action_report/snapshot_backed/test_no_internal_llm_imports.py` → **1127/1127 pass** (ROB-501 guard)
- `make lint` → ruff + ruff format + ty all clean
- `git status --short -- alembic/versions/` → empty (migration 0)

## Files

- **NEW** `app/mcp_server/tooling/earnings_context.py` — shaper + freshness + dispatch
- **MODIFIED** `app/mcp_server/tooling/analysis_tool_handlers.py` — add import + `_attach_earnings` + wire call after `_attach_decision_history`
- **NEW** `tests/mcp_server/test_earnings_context.py` — 11 tests (shaper / freshness / build)
- **NEW** `tests/mcp_server/test_analyze_stock_batch_earnings.py` — 3 tests (inject / fail-open / skip)

## Commits

- `f836ac96` feat(ROB-722): pure compact earnings shaper
- `603000f3` feat(ROB-722): KR ingestion freshness derivation
- `3888907c` feat(ROB-722): build_earnings_context dispatch + crypto skip
- `fbb4f2f4` feat(ROB-722): wire _attach_earnings into analyze_stock_batch
- `44853b1d` chore(ROB-722): lint/format pass

Plan: docs/superpowers/plans/2026-07-06-rob-722-earnings-auto-inject.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Quick stock batch analysis now includes upcoming earnings context for eligible equities.
  * Earnings details are shown in a compact, consistent format, including whether upcoming earnings exist and relevant timing signals.
  * KR equities now include freshness/status context for earnings data, while non-equity markets are left unchanged.

* **Bug Fixes**
  * Improved resilience so earnings enrichment is skipped gracefully when data is unavailable or an error occurs, without breaking the overall analysis result.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->