### PR TITLE
fix(ROB-722): accept real equity_kr/equity_us market_type in earnings gate (was production no-op)

### DIFF
--- a/app/mcp_server/tooling/analysis_tool_handlers.py
+++ b/app/mcp_server/tooling/analysis_tool_handlers.py
@@ -20,6 +20,7 @@ from app.mcp_server.tooling.analysis_screen_core import normalize_screen_request
 from app.mcp_server.tooling.earnings_context import (
     _kr_ingestion_freshness,
     build_earnings_context,
+    normalize_earnings_market,
 )
 from app.mcp_server.tooling.market_data_indicators import (
     _fetch_ohlcv_for_indicators,
@@ -908,7 +909,9 @@ async def _attach_earnings(
                 if not isinstance(result, dict) or "error" in result:
                     continue
                 mkt = result.get("market_type") or market
-                if str(mkt or "").strip().lower() == "kr" and kr_freshness is None:
+                if normalize_earnings_market(str(mkt or "")) == "kr" and (
+                    kr_freshness is None
+                ):
                     try:
                         kr_freshness = await _kr_ingestion_freshness(db)
                     except Exception:  # fail-open: freshness is advisory

--- a/app/mcp_server/tooling/earnings_context.py
+++ b/app/mcp_server/tooling/earnings_context.py
@@ -124,7 +124,21 @@ async def _kr_ingestion_freshness(db: AsyncSession) -> tuple[str, str | None]:
     return (freshness, aware.date().isoformat())
 
 
-_EQUITY_MARKETS = {"kr", "us"}
+# Accept both the analyze_stock_batch row values (resolve_market_type →
+# equity_kr / equity_us / crypto) and the tool-level market params (kr / us).
+# The original {"kr", "us"}-only gate made injection a production no-op because
+# real compact rows always carry the equity_* form.
+_MARKET_ALIASES = {
+    "kr": "kr",
+    "equity_kr": "kr",
+    "us": "us",
+    "equity_us": "us",
+}
+
+
+def normalize_earnings_market(market: str | None) -> str | None:
+    """Map a market/market_type value to "kr"/"us", or None for non-equity."""
+    return _MARKET_ALIASES.get((market or "").strip().lower())
 
 
 async def build_earnings_context(
@@ -140,8 +154,8 @@ async def build_earnings_context(
     there. For US/KR equities it ALWAYS returns a dict (no-earnings is an
     explicit has_upcoming=False signal). US freshness is "live"; KR freshness is
     taken from ``kr_freshness`` (computed once per batch by the caller)."""
-    market_norm = (market or "").strip().lower()
-    if market_norm not in _EQUITY_MARKETS:
+    market_norm = normalize_earnings_market(market)
+    if market_norm is None:
         return None
 
     today = today or datetime.date.today()

--- a/tests/mcp_server/test_analyze_stock_batch_earnings.py
+++ b/tests/mcp_server/test_analyze_stock_batch_earnings.py
@@ -1,10 +1,18 @@
-"""ROB-722 — analyze_stock_batch earnings auto-inject attach pass."""
+"""ROB-722 — analyze_stock_batch earnings auto-inject attach pass.
+
+Rows use the REAL ``market_type`` values that analyze_stock_batch produces
+(``resolve_market_type`` → equity_kr / equity_us / crypto). The original tests
+fabricated "us"/"kr" values that never occur in production, which let the
+{"kr","us"}-only market gate ship as a permanent no-op (post-merge
+verification blocker).
+"""
 
 from __future__ import annotations
 
 import pytest
 
 from app.mcp_server.tooling import analysis_tool_handlers as h
+from app.mcp_server.tooling import earnings_context as ec
 
 
 @pytest.mark.asyncio
@@ -23,7 +31,7 @@ async def test_attach_earnings_injects_when_context_exists(monkeypatch):
     monkeypatch.setattr(h, "build_earnings_context", _fake_build, raising=False)
     monkeypatch.setattr(h, "_kr_ingestion_freshness", _fake_kr_fresh, raising=False)
 
-    results = {"NVDA": {"symbol": "NVDA", "market_type": "us"}}
+    results = {"NVDA": {"symbol": "NVDA", "market_type": "equity_us"}}
     await h._attach_earnings(results, market="us")
 
     assert results["NVDA"]["earnings"]["has_upcoming"] is False
@@ -36,7 +44,7 @@ async def test_attach_earnings_fail_open_on_error(monkeypatch):
 
     monkeypatch.setattr(h, "build_earnings_context", _boom, raising=False)
 
-    results = {"NVDA": {"symbol": "NVDA", "market_type": "us"}}
+    results = {"NVDA": {"symbol": "NVDA", "market_type": "equity_us"}}
     await h._attach_earnings(results, market="us")  # must not raise
 
     assert "earnings" not in results["NVDA"]
@@ -44,22 +52,52 @@ async def test_attach_earnings_fail_open_on_error(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_attach_earnings_skips_error_and_crypto_rows(monkeypatch):
-    # Mirrors real build: None for crypto (skip), dict for equities. Error rows
-    # are skipped by _attach_earnings before build is ever called.
-    async def _fake_build(symbol, market, *, today=None, kr_freshness=None):
-        if str(market).strip().lower() == "crypto":
-            return None
-        return {"symbol": symbol}
+    # Real build_earnings_context with only the calendar fetch stubbed, so the
+    # market gate itself is under test (the false-green trap was mocking build
+    # entirely and feeding market values production never produces).
+    async def _fake_calendar(symbol, from_date, to_date, market):
+        return {"symbol": symbol, "source": "finnhub", "earnings": []}
 
-    monkeypatch.setattr(h, "build_earnings_context", _fake_build, raising=False)
+    monkeypatch.setattr(ec, "handle_get_earnings_calendar", _fake_calendar)
 
     results = {
         "BADSYM": {"error": "not found"},
-        "BTC": {"symbol": "BTC", "market_type": "crypto"},
-        "NVDA": {"symbol": "NVDA", "market_type": "us"},
+        "KRW-BTC": {"symbol": "KRW-BTC", "market_type": "crypto"},
+        "NVDA": {"symbol": "NVDA", "market_type": "equity_us"},
     }
     await h._attach_earnings(results, market=None)
 
     assert "earnings" not in results["BADSYM"]  # error row skipped pre-build
-    assert "earnings" not in results["BTC"]  # build returns None → omit
-    assert results["NVDA"]["earnings"] == {"symbol": "NVDA"}  # equity attached
+    assert "earnings" not in results["KRW-BTC"]  # non-equity → build returns None
+    earnings = results["NVDA"]["earnings"]  # real-gate regression (equity_us)
+    assert earnings["market"] == "us"
+    assert earnings["has_upcoming"] is False
+
+
+@pytest.mark.asyncio
+async def test_attach_earnings_equity_kr_triggers_freshness_once(monkeypatch):
+    # equity_kr rows must hit the KR freshness gate (normalized, not == "kr")
+    # and the batch must compute freshness at most once.
+    calls = {"fresh": 0}
+
+    async def _fake_calendar(symbol, from_date, to_date, market):
+        assert market == "kr"  # normalized before the calendar dispatch
+        return {"symbol": symbol, "source": "market_events", "earnings": []}
+
+    async def _fake_kr_fresh(db):
+        calls["fresh"] += 1
+        return ("stale", "2026-07-01")
+
+    monkeypatch.setattr(ec, "handle_get_earnings_calendar", _fake_calendar)
+    monkeypatch.setattr(h, "_kr_ingestion_freshness", _fake_kr_fresh, raising=False)
+
+    results = {
+        "005930": {"symbol": "005930", "market_type": "equity_kr"},
+        "000660": {"symbol": "000660", "market_type": "equity_kr"},
+    }
+    await h._attach_earnings(results, market="kr")
+
+    assert calls["fresh"] == 1
+    assert results["005930"]["earnings"]["market"] == "kr"
+    assert results["005930"]["earnings"]["freshness"] == "stale"
+    assert results["000660"]["earnings"]["data_as_of"] == "2026-07-01"

--- a/tests/mcp_server/test_earnings_context.py
+++ b/tests/mcp_server/test_earnings_context.py
@@ -149,6 +149,33 @@ async def test_build_earnings_context_crypto_returns_none():
     assert ctx is None
 
 
+def test_normalize_earnings_market_accepts_real_market_type_values():
+    # resolve_market_type produces equity_kr/equity_us/crypto — the gate must
+    # accept the equity_* forms (the {"kr","us"}-only gate was a production
+    # no-op) while still taking the bare tool-param forms.
+    assert ec.normalize_earnings_market("equity_us") == "us"
+    assert ec.normalize_earnings_market("equity_kr") == "kr"
+    assert ec.normalize_earnings_market("us") == "us"
+    assert ec.normalize_earnings_market("kr") == "kr"
+    assert ec.normalize_earnings_market(" Equity_US ") == "us"
+    assert ec.normalize_earnings_market("crypto") is None
+    assert ec.normalize_earnings_market("") is None
+    assert ec.normalize_earnings_market(None) is None
+
+
+@pytest.mark.asyncio
+async def test_build_earnings_context_equity_us_passes_gate(monkeypatch):
+    async def _fake_handler(symbol, from_date, to_date, market):
+        assert market == "us"  # normalized before dispatch
+        return {"symbol": symbol, "source": "finnhub", "earnings": []}
+
+    monkeypatch.setattr(ec, "handle_get_earnings_calendar", _fake_handler)
+    ctx = await ec.build_earnings_context("NVDA", "equity_us", today=TODAY)
+    assert ctx is not None
+    assert ctx["market"] == "us"
+    assert ctx["has_upcoming"] is False
+
+
 @pytest.mark.asyncio
 async def test_build_earnings_context_us_calls_handler_and_shapes(monkeypatch):
     async def _fake_handler(symbol, from_date, to_date, market):

--- a/tests/test_mcp_fundamentals_tools.py
+++ b/tests/test_mcp_fundamentals_tools.py
@@ -754,6 +754,19 @@ class TestAnalyzeStock:
 class TestAnalyzeStockBatch:
     """Test analyze_stock_batch tool."""
 
+    @pytest.fixture(autouse=True)
+    def _no_earnings_injection(self, monkeypatch):
+        # ROB-722 fix made the earnings attach actually fire for equity rows
+        # (the old {"kr","us"} gate never matched real equity_kr/equity_us
+        # market_type values). Left unstubbed it would mutate every compact
+        # contract here and reach live Finnhub for equity_us rows. Injection
+        # behavior is covered by tests/mcp_server/test_earnings_context.py and
+        # test_analyze_stock_batch_earnings.py.
+        async def _none(symbol, market, *, today=None, kr_freshness=None):
+            return None
+
+        _patch_runtime_attr(monkeypatch, "build_earnings_context", _none)
+
     async def test_analyze_stock_batch_registration(self):
         """Test that analyze_stock_batch is registered as an MCP tool."""
         tools = build_tools()


### PR DESCRIPTION
## 배경

ROB-722(#1439) 머지후 적대검증이 **blocker**를 적발: `_EQUITY_MARKETS = {"kr","us"}` 게이트가 실제 compact 행의 `market_type`(`resolve_market_type` → `equity_kr`/`equity_us`/`crypto`)과 절대 일치하지 않아 **실적 auto-inject가 프로덕션 영구 no-op**(fail-open이 조용히 삼킴). 실행으로 확증: `build_earnings_context("NVDA","equity_us") → None`. 테스트가 green이었던 이유 = 프로덕션에 존재하지 않는 `"us"`/`"kr"` 값을 지어낸 완전 모킹(false-green).

## 변경

- `normalize_earnings_market()` alias 맵 신설 — `equity_kr`/`equity_us` + bare `kr`/`us` 수용, crypto/기타는 None(생략).
- `_attach_earnings`의 KR freshness 게이트도 동일 정규화 사용(기존 `== "kr"` 도 dead).
- 테스트 재작성: 실값 market_type 사용 + **실 게이트 통과 회귀 테스트**(calendar fetch만 스텁) + equity_kr freshness once-per-batch 테스트.
- `TestAnalyzeStockBatch`에 autouse no-earnings 스텁: 게이트가 살아나면 equity 행마다 earnings가 붙어 exact-dict 계약이 전부 깨지고 equity_us 행은 **CI에서 라이브 Finnhub**를 치게 됨 — 주입 동작은 전용 테스트 파일이 커버.

## 검증

- `tests/mcp_server/test_earnings_context.py` + `test_analyze_stock_batch_earnings.py` → 17 passed
- `tests/test_mcp_fundamentals_tools.py` 전체 → 240 passed
- `make lint` 스코프(ruff check/format + ty) clean

## 잔여 (별도 후속, 이 PR 스코프 아님)

머지후 검증의 major — US 심볼당 Finnhub 1콜(벌크 range 콜/캐시 미사용, 이슈가 요구했던 항목). ROB-722에 코멘트로 기록 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Vo3Zcr43ktxA9jaZek5Gv