### PR TITLE
deploy: ROB-718/719/722(+gate fix) 학습루프 후속 (6d46bdfb)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,16 +51,6 @@ auto_trader/
 - Keep task declarations in `app/tasks/`; job orchestration stays in `app/jobs/`.
 - Keep MCP behavior changes synchronized with `app/mcp_server/README.md` and tests.
 
-## MODEL-LANE REVIEW GUARDRAILS
-- Default engineering execution stays on `gpt-5.4` and should be tagged `keep_on_gpt54` when the task is routine implementation, focused bug fixing, test work, documentation, triage, or a narrow refactor with local blast radius.
-- Tag `candidate_for_sonnet` when the task needs steadier design or review judgment than routine execution but does not carry final high-risk approval authority.
-- Tag `candidate_for_opus` when the task needs reserved-lane review for high-cost decisions: architecture direction final decisions, auth / permission / security-sensitive changes, DB schema / migration, broad refactors, live order final approval, strategy policy changes, or deployment / operational automation boundary changes.
-- Tag `high_risk_change` on any issue or PR touching those high-risk categories, even when implementation is straightforward.
-- Tag `needs_stronger_model_review` when a `high_risk_change` needs Sonnet/Opus review before merge, approval, or operational use.
-- Tag `hold_for_final_review` when work is implemented but must not be merged, deployed, or used for live trading until the named stronger-model reviewer or CTO clears it.
-- Example issue comment: `Applying high_risk_change + needs_stronger_model_review for [ROB-275](/ROB/issues/ROB-275): this touches DB migration behavior. Holding merge until CTO/Opus review confirms rollback and data-safety assumptions.`
-- Example hold comment: `Implementation is ready for [ROB-275](/ROB/issues/ROB-275), but I am applying hold_for_final_review because this changes live order approval boundaries. No deploy or live execution until final review clears it.`
-
 ## ANTI-PATTERNS (THIS PROJECT)
 - Do not hardcode credentials/secrets in code or scripts.
 - Do not keep default/example secrets in production environments.

--- a/alembic/versions/20260706_rob719_report_item_uuid_indexes.py
+++ b/alembic/versions/20260706_rob719_report_item_uuid_indexes.py
@@ -1,0 +1,38 @@
+"""ROB-719 report_item_uuid indexes
+
+Revision ID: 20260706_rob719
+Revises: 20260705_rob714
+Create Date: 2026-07-06 00:00:00.000000
+
+Additive btree indexes on ``review.trade_forecasts(report_item_uuid)`` and
+``review.trade_retrospectives(report_item_uuid)`` so the ROB-715 report-detail
+bundle batch-map join (``item_loop_links.py`` ``.in_(...)``) stays cheap as
+ROB-714 place-time forecast volume grows. Purely additive — no column/constraint
+change.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "20260706_rob719"
+down_revision: str | Sequence[str] | None = "20260705_rob714"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_INDEXES = {
+    "trade_forecasts": "ix_trade_forecasts_report_item_uuid",
+    "trade_retrospectives": "ix_trade_retrospectives_report_item_uuid",
+}
+
+
+def upgrade() -> None:
+    for table, index in _INDEXES.items():
+        op.create_index(index, table, ["report_item_uuid"], schema="review")
+
+
+def downgrade() -> None:
+    for table, index in _INDEXES.items():
+        op.drop_index(index, table_name=table, schema="review")

--- a/app/mcp_server/tooling/analysis_tool_handlers.py
+++ b/app/mcp_server/tooling/analysis_tool_handlers.py
@@ -20,6 +20,7 @@ from app.mcp_server.tooling.analysis_screen_core import normalize_screen_request
 from app.mcp_server.tooling.earnings_context import (
     _kr_ingestion_freshness,
     build_earnings_context,
+    normalize_earnings_market,
 )
 from app.mcp_server.tooling.market_data_indicators import (
     _fetch_ohlcv_for_indicators,
@@ -908,7 +909,9 @@ async def _attach_earnings(
                 if not isinstance(result, dict) or "error" in result:
                     continue
                 mkt = result.get("market_type") or market
-                if str(mkt or "").strip().lower() == "kr" and kr_freshness is None:
+                if normalize_earnings_market(str(mkt or "")) == "kr" and (
+                    kr_freshness is None
+                ):
                     try:
                         kr_freshness = await _kr_ingestion_freshness(db)
                     except Exception:  # fail-open: freshness is advisory

--- a/app/mcp_server/tooling/analysis_tool_handlers.py
+++ b/app/mcp_server/tooling/analysis_tool_handlers.py
@@ -17,6 +17,10 @@ import yfinance as yf
 
 from app.mcp_server.tooling import analysis_screening, foreigners_liquidity
 from app.mcp_server.tooling.analysis_screen_core import normalize_screen_request
+from app.mcp_server.tooling.earnings_context import (
+    _kr_ingestion_freshness,
+    build_earnings_context,
+)
 from app.mcp_server.tooling.market_data_indicators import (
     _fetch_ohlcv_for_indicators,
 )
@@ -879,6 +883,49 @@ async def _attach_decision_history(
         logger.debug("decision_history injection skipped: %s", exc)
 
 
+async def _attach_earnings(
+    results: dict[str, Any],
+    *,
+    market: str | None,
+) -> None:
+    """ROB-722: inject per-symbol upcoming-earnings context (US live / KR DB).
+
+    Batched (one session), symbol-level fail-open. No-earnings is an explicit
+    signal (has_upcoming=False), so US/KR equity rows always receive an
+    ``earnings`` field; crypto/error rows are skipped. KR ingestion freshness is
+    computed at most once per batch and threaded into each build call.
+    """
+    if not any(
+        isinstance(row, dict) and "error" not in row for row in results.values()
+    ):
+        return
+    try:
+        from app.core.db import AsyncSessionLocal
+
+        async with AsyncSessionLocal() as db:
+            kr_freshness: tuple[str, str | None] | None = None
+            for sym, result in results.items():
+                if not isinstance(result, dict) or "error" in result:
+                    continue
+                mkt = result.get("market_type") or market
+                if str(mkt or "").strip().lower() == "kr" and kr_freshness is None:
+                    try:
+                        kr_freshness = await _kr_ingestion_freshness(db)
+                    except Exception:  # fail-open: freshness is advisory
+                        kr_freshness = ("unknown", None)
+                try:
+                    ctx = await build_earnings_context(
+                        str(sym), str(mkt or ""), kr_freshness=kr_freshness
+                    )
+                except Exception as exc:  # symbol-level fail-open (e.g. 429)
+                    logger.debug("earnings injection skipped for %s: %s", sym, exc)
+                    continue
+                if ctx is not None:
+                    result["earnings"] = ctx
+    except Exception as exc:  # fail-open: advisory-only
+        logger.debug("earnings injection skipped: %s", exc)
+
+
 async def analyze_stock_batch_impl(
     symbols: list[str | int],
     market: str | None = None,
@@ -940,6 +987,7 @@ async def analyze_stock_batch_impl(
     if quick:
         await _attach_fresh_artifact_hints(response.get("results", {}), market=market)
         await _attach_decision_history(response.get("results", {}), market=market)
+        await _attach_earnings(response.get("results", {}), market=market)
     return response
 
 

--- a/app/mcp_server/tooling/earnings_context.py
+++ b/app/mcp_server/tooling/earnings_context.py
@@ -124,7 +124,21 @@ async def _kr_ingestion_freshness(db: AsyncSession) -> tuple[str, str | None]:
     return (freshness, aware.date().isoformat())
 
 
-_EQUITY_MARKETS = {"kr", "us"}
+# Accept both the analyze_stock_batch row values (resolve_market_type →
+# equity_kr / equity_us / crypto) and the tool-level market params (kr / us).
+# The original {"kr", "us"}-only gate made injection a production no-op because
+# real compact rows always carry the equity_* form.
+_MARKET_ALIASES = {
+    "kr": "kr",
+    "equity_kr": "kr",
+    "us": "us",
+    "equity_us": "us",
+}
+
+
+def normalize_earnings_market(market: str | None) -> str | None:
+    """Map a market/market_type value to "kr"/"us", or None for non-equity."""
+    return _MARKET_ALIASES.get((market or "").strip().lower())
 
 
 async def build_earnings_context(
@@ -140,8 +154,8 @@ async def build_earnings_context(
     there. For US/KR equities it ALWAYS returns a dict (no-earnings is an
     explicit has_upcoming=False signal). US freshness is "live"; KR freshness is
     taken from ``kr_freshness`` (computed once per batch by the caller)."""
-    market_norm = (market or "").strip().lower()
-    if market_norm not in _EQUITY_MARKETS:
+    market_norm = normalize_earnings_market(market)
+    if market_norm is None:
         return None
 
     today = today or datetime.date.today()

--- a/app/mcp_server/tooling/earnings_context.py
+++ b/app/mcp_server/tooling/earnings_context.py
@@ -1,0 +1,161 @@
+"""ROB-722 — deterministic upcoming-earnings context for a symbol.
+
+Read-only. No LLM (ROB-501), no schema change. Reuses the validated
+handle_get_earnings_calendar dispatch (US live Finnhub / KR market_events DB)
+and shapes a compact "next earnings D-n / timing / consensus, or explicit
+no-earnings" signal. Attached to analyze_stock_batch compact responses so each
+fresh analysis session sees the symbol's earnings proximity.
+
+No-earnings is itself a signal (HCA: '30일 내 무실적' as an entry justification),
+so a zero-earnings window yields has_upcoming=False + note — NOT omission.
+Only crypto / non-equity symbols are omitted (no earnings concept).
+"""
+
+from __future__ import annotations
+
+import datetime
+from typing import Any
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.mcp_server.tooling.fundamentals._financials import (
+    handle_get_earnings_calendar,
+)
+from app.models.market_events import MarketEventIngestionPartition
+from app.services.market_events.freshness_service import _ensure_aware, _is_stale
+
+_WINDOW_DAYS = 30
+_TIMING_MAP = {"bmo": "BMO", "amc": "AMC", "dmh": "DMH"}
+
+
+def _map_timing(hour: str | None) -> str:
+    if not hour:
+        return "unknown"
+    return _TIMING_MAP.get(hour.strip().lower(), "unknown")
+
+
+def _compact_earnings(
+    tool_result: dict[str, Any],
+    *,
+    today: datetime.date,
+    freshness: str,
+    data_as_of: str | None,
+) -> dict[str, Any]:
+    source = tool_result.get("source")
+    market_label = (
+        "kr"
+        if (tool_result.get("market") == "kr" or source == "market_events")
+        else "us"
+    )
+
+    ctx: dict[str, Any] = {
+        "symbol": tool_result.get("symbol"),
+        "market": market_label,
+        "as_of": today.isoformat(),
+        "window_days": _WINDOW_DAYS,
+        "freshness": freshness,
+        "source": source,
+    }
+    if data_as_of is not None:
+        ctx["data_as_of"] = data_as_of
+
+    if tool_result.get("error"):
+        ctx["has_upcoming"] = False
+        ctx["next_earnings"] = None
+        ctx["note"] = f"earnings lookup degraded: {tool_result.get('error')}"
+        return ctx
+
+    upcoming: list[tuple[datetime.date, dict[str, Any]]] = []
+    for item in tool_result.get("earnings") or []:
+        raw = item.get("date")
+        if not raw:
+            continue
+        try:
+            edate = datetime.date.fromisoformat(raw)
+        except (ValueError, TypeError):
+            continue
+        if edate >= today:
+            upcoming.append((edate, item))
+
+    if not upcoming:
+        ctx["has_upcoming"] = False
+        ctx["next_earnings"] = None
+        ctx["note"] = f"no scheduled earnings within {_WINDOW_DAYS} days"
+        return ctx
+
+    upcoming.sort(key=lambda pair: pair[0])
+    edate, item = upcoming[0]
+    ctx["has_upcoming"] = True
+    ctx["next_earnings"] = {
+        "date": edate.isoformat(),
+        "d_minus": (edate - today).days,
+        "timing": _map_timing(item.get("hour") or item.get("time_hint")),
+        "eps_estimate": item.get("eps_estimate"),
+        "revenue_estimate": item.get("revenue_estimate"),
+        "quarter": item.get("quarter"),
+        "year": item.get("year"),
+        "status": item.get("status"),
+    }
+    return ctx
+
+
+async def _kr_ingestion_freshness(db: AsyncSession) -> tuple[str, str | None]:
+    """Newest succeeded KR earnings ingestion → (freshness, data_as_of ISO|None).
+
+    Global per (market=kr, category=earnings) — compute ONCE per batch, not per
+    symbol. Reuses the market_events STALE_AFTER_HOURS threshold. Fail-open at
+    the caller: a DB error leaves KR rows on ('unknown', None).
+    """
+    stmt = select(func.max(MarketEventIngestionPartition.finished_at)).where(
+        MarketEventIngestionPartition.market == "kr",
+        MarketEventIngestionPartition.category == "earnings",
+        MarketEventIngestionPartition.status == "succeeded",
+    )
+    finished_at = (await db.execute(stmt)).scalar_one_or_none()
+    if finished_at is None:
+        return ("unknown", None)
+    aware = _ensure_aware(finished_at)
+    freshness = (
+        "stale"
+        if _is_stale(aware, now=datetime.datetime.now(datetime.UTC))
+        else "fresh"
+    )
+    return (freshness, aware.date().isoformat())
+
+
+_EQUITY_MARKETS = {"kr", "us"}
+
+
+async def build_earnings_context(
+    symbol: str,
+    market: str,
+    *,
+    today: datetime.date | None = None,
+    kr_freshness: tuple[str, str | None] | None = None,
+) -> dict[str, Any] | None:
+    """Compact upcoming-earnings context for one symbol, or None to omit.
+
+    Omits (None) only for crypto / non-equity markets — earnings has no meaning
+    there. For US/KR equities it ALWAYS returns a dict (no-earnings is an
+    explicit has_upcoming=False signal). US freshness is "live"; KR freshness is
+    taken from ``kr_freshness`` (computed once per batch by the caller)."""
+    market_norm = (market or "").strip().lower()
+    if market_norm not in _EQUITY_MARKETS:
+        return None
+
+    today = today or datetime.date.today()
+    to_date = today + datetime.timedelta(days=_WINDOW_DAYS)
+
+    tool_result = await handle_get_earnings_calendar(
+        symbol, today.isoformat(), to_date.isoformat(), market_norm
+    )
+
+    if market_norm == "kr":
+        freshness, data_as_of = kr_freshness or ("unknown", None)
+    else:
+        freshness, data_as_of = "live", None
+
+    return _compact_earnings(
+        tool_result, today=today, freshness=freshness, data_as_of=data_as_of
+    )

--- a/app/models/review.py
+++ b/app/models/review.py
@@ -1024,6 +1024,7 @@ class TradeRetrospective(Base):
         Index("ix_trade_retrospectives_strategy_key", "strategy_key"),
         Index("ix_trade_retrospectives_symbol", "symbol"),
         Index("ix_trade_retrospectives_report_uuid", "report_uuid"),
+        Index("ix_trade_retrospectives_report_item_uuid", "report_item_uuid"),
         Index(
             "ix_trade_retrospectives_account_mode_created",
             "account_mode",
@@ -1142,6 +1143,7 @@ class TradeForecast(Base):
         Index("ix_trade_forecasts_symbol", "symbol"),
         Index("ix_trade_forecasts_created_by", "created_by"),
         Index("ix_trade_forecasts_correlation_id", "correlation_id"),
+        Index("ix_trade_forecasts_report_item_uuid", "report_item_uuid"),
         {"schema": "review"},
     )
 

--- a/app/routers/invest_artifacts.py
+++ b/app/routers/invest_artifacts.py
@@ -54,6 +54,7 @@ async def list_artifacts(
     symbol: Annotated[str | None, Query()] = None,
     include_stale: Annotated[bool, Query()] = False,
     limit: Annotated[int, Query(ge=1, le=100)] = 20,
+    correlation_id: Annotated[list[str] | None, Query()] = None,
 ) -> AnalysisArtifactListResponse:
     _validate("market", market, _VALID_MARKETS)
     _validate("kind", kind, _VALID_KINDS)
@@ -66,6 +67,7 @@ async def list_artifacts(
         symbol=symbol,
         include_stale=include_stale,
         limit=limit,
+        correlation_ids=correlation_id,
     )
     filters = AnalysisArtifactListRequest(
         market=market,
@@ -74,6 +76,7 @@ async def list_artifacts(
         symbol=symbol,
         include_stale=include_stale,
         limit=limit,
+        correlation_id=",".join(correlation_id) if correlation_id else None,
     )
     metas = [AnalysisArtifactMeta.model_validate(r) for r in rows]
     return AnalysisArtifactListResponse(

--- a/app/schemas/investment_reports.py
+++ b/app/schemas/investment_reports.py
@@ -803,6 +803,7 @@ class ForecastLinkResponse(BaseModel):
     probability: float
     brier_score: float | None = None
     resolution_source: str | None = None
+    correlation_id: str | None = None
 
 
 class RetrospectiveLinkResponse(BaseModel):
@@ -816,6 +817,7 @@ class RetrospectiveLinkResponse(BaseModel):
     trigger_type: str | None = None
     pnl_pct: float | None = None
     created_at: str | None = None
+    correlation_id: str | None = None
 
 
 class StockDetailOrderLedgerResponse(BaseModel):

--- a/app/services/analysis_artifact.py
+++ b/app/services/analysis_artifact.py
@@ -159,6 +159,7 @@ class AnalysisArtifactService:
         include_stale: bool = False,
         limit: int = 20,
         correlation_id: str | None = None,
+        correlation_ids: list[str] | None = None,
         account_scope: str | None = None,
         readiness_label: AnalysisArtifactReadinessLiteral | None = None,
     ) -> list[AnalysisArtifact]:
@@ -191,6 +192,8 @@ class AnalysisArtifactService:
             stmt = stmt.where(AnalysisArtifact.as_of >= since)
         if correlation_id is not None:
             stmt = stmt.where(AnalysisArtifact.correlation_id == correlation_id)
+        if correlation_ids:
+            stmt = stmt.where(AnalysisArtifact.correlation_id.in_(correlation_ids))
         if account_scope is not None:
             stmt = stmt.where(AnalysisArtifact.account_scope == account_scope)
         if readiness_label is not None:

--- a/app/services/investment_reports/item_loop_links.py
+++ b/app/services/investment_reports/item_loop_links.py
@@ -40,6 +40,7 @@ def _project_forecast(row: TradeForecast) -> ForecastLinkResponse:
         probability=float(row.probability),
         brier_score=(float(row.brier_score) if row.brier_score is not None else None),
         resolution_source=row.resolution_source,
+        correlation_id=row.correlation_id,
     )
 
 
@@ -53,6 +54,7 @@ def _project_retrospective(row: TradeRetrospective) -> RetrospectiveLinkResponse
         trigger_type=row.trigger_type,
         pnl_pct=float(row.pnl_pct) if row.pnl_pct is not None else None,
         created_at=_iso(row.created_at),
+        correlation_id=row.correlation_id,
     )
 
 

--- a/docs/plans/ROB-719-report-item-uuid-indexes-plan.md
+++ b/docs/plans/ROB-719-report-item-uuid-indexes-plan.md
@@ -1,0 +1,127 @@
+# ROB-719 — `report_item_uuid` 인덱스 추가 (715 조인 경로)
+
+**우선순위**: Low · **스코프**: additive index migration ×2 (인덱스 2개, 단일 파일) · **migration**: up/down 왕복 clean
+
+## 배경 / 문제
+
+ROB-715의 번들 배치맵(`app/services/investment_reports/item_loop_links.py`)이
+리포트 상세를 열 때마다 아래처럼 `report_item_uuid` 로 세트 조인한다:
+
+- `TradeForecast.report_item_uuid.in_(keys)` (`item_loop_links.py:70`)
+- `TradeRetrospective.report_item_uuid.in_(keys)` (`item_loop_links.py:93`)
+
+그런데 두 컬럼 모두 **인덱스 없는 plain `Text`** 이다:
+
+- `app/models/review.py:1041` — `TradeRetrospective.report_item_uuid`
+- `app/models/review.py:1161` — `TradeForecast.report_item_uuid`
+
+인덱스 목록(`1022-1032` / `1141-1145`)에 둘 다 빠져 있다. 현재는 테이블이 작아
+seq-scan 이 무해하나, **ROB-714 place-time 자동 forecast 발행**으로 주문마다
+forecast 볼륨이 쌓이면 리포트 상세를 열 때마다 스캔 비용이 커진다.
+
+`.in_(keys)` 는 순수 동등-집합 술어 → **btree 인덱스가 정확히 맞는 도구**.
+
+## 목표 / 비목표
+
+- **목표**: 두 컬럼에 btree 인덱스 추가 (모델 선언 + additive migration). 조인 경로가
+  인덱스 스캔 가능 상태가 되게 한다.
+- **비목표**: 코드/쿼리 변경 없음. FK·NOT NULL·CHECK 추가 없음. 컬럼 타입 변경 없음.
+  스케줄러/배포 게이트 변경 없음.
+
+## 확정 결정 (사용자 승인)
+
+1. **단일 마이그레이션 파일** 에 인덱스 2개 create/drop 대칭 (ROB-714 선례).
+2. **로컬 up/down 왕복 검증** 수행. 프로덕션 적용은 관례대로 operator.
+3. **plain `CREATE INDEX`** (소규모 테이블 · alembic 인-트랜잭션 기본). `CONCURRENTLY` 불필요.
+
+## 변경 사항
+
+### 1) 모델 선언 (`app/models/review.py`)
+
+기존 `Index(...)` 컨벤션(`ix_<full_table>_<col>`, full 테이블명)에 맞춰 추가:
+
+- `TradeRetrospective.__table_args__` (line 1026 `ix_trade_retrospectives_report_uuid` 다음):
+  ```python
+  Index("ix_trade_retrospectives_report_item_uuid", "report_item_uuid"),
+  ```
+- `TradeForecast.__table_args__` (line 1144 `ix_trade_forecasts_correlation_id` 다음):
+  ```python
+  Index("ix_trade_forecasts_report_item_uuid", "report_item_uuid"),
+  ```
+
+### 2) 마이그레이션 (`alembic/versions/20260706_rob719_report_item_uuid_indexes.py`)
+
+- `revision = "20260706_rob719"` (15자 ≤ 32 — `test_alembic_revision_ids.py` 통과)
+- `down_revision = "20260705_rob714"` (현재 단일 head)
+- ROB-714 구조 그대로: `op.create_index(name, table, ["report_item_uuid"], schema="review")` /
+  `op.drop_index(name, table_name=table, schema="review")` 대칭.
+
+```python
+"""ROB-719 report_item_uuid indexes
+
+Revision ID: 20260706_rob719
+Revises: 20260705_rob714
+Create Date: 2026-07-06 00:00:00.000000
+
+Additive btree indexes on ``review.trade_forecasts(report_item_uuid)`` and
+``review.trade_retrospectives(report_item_uuid)`` so the ROB-715 report-detail
+bundle batch-map join (``item_loop_links.py`` ``.in_(...)``) stays cheap as
+ROB-714 place-time forecast volume grows. Purely additive — no column/constraint
+change.
+"""
+from __future__ import annotations
+from collections.abc import Sequence
+from alembic import op
+
+revision: str = "20260706_rob719"
+down_revision: str | Sequence[str] | None = "20260705_rob714"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_INDEXES = {
+    "trade_forecasts": "ix_trade_forecasts_report_item_uuid",
+    "trade_retrospectives": "ix_trade_retrospectives_report_item_uuid",
+}
+
+
+def upgrade() -> None:
+    for table, index in _INDEXES.items():
+        op.create_index(index, table, ["report_item_uuid"], schema="review")
+
+
+def downgrade() -> None:
+    for table, index in _INDEXES.items():
+        op.drop_index(index, table_name=table, schema="review")
+```
+
+### double-prefix 함정 회피 (ROB-705 교훈)
+
+- 인덱스명을 **명시 문자열** `ix_<table>_report_item_uuid` 로 지정 (autogenerate가
+  리비전 접두어를 이름에 섞는 `20260705_rob705` 류 사고 방지).
+- 모델 `Index(...)` 이름과 migration `op.create_index` 이름을 **정확히 일치**시켜
+  autogenerate diff 가 비어 있게 한다.
+
+## 검증
+
+1. `uv run alembic upgrade head` — 인덱스 2개 생성
+2. `uv run alembic downgrade -1` — 2개 drop (clean)
+3. `uv run alembic upgrade head` — 재적용 clean (왕복 성공 기준)
+4. `uv run alembic check` (또는 `--autogenerate` 임시 리비전) — **모델↔DB diff 없음** 확인
+   → 모델 `Index` 선언과 migration 이름이 일치함을 증명
+5. `uv run pytest tests/test_alembic_revision_ids.py -q` — 리비전 ID/참조 규칙 통과
+6. (선택) `EXPLAIN` 로 조인 경로가 인덱스 사용 가능함 확인.
+   ⚠️ 소규모 테이블에서는 Postgres 플래너가 여전히 seq-scan 을 고를 수 있으므로,
+   `SET enable_seqscan = off;` 후 `EXPLAIN ... WHERE report_item_uuid IN (...)` 로
+   **인덱스가 존재하고 플래너가 쓸 수 있음**을 확인하는 것이 정직한 체크.
+   (실제 인덱스 스캔 선택은 볼륨이 커진 뒤에만 관측됨.)
+
+## 리스크
+
+- **매우 낮음.** 순수 additive, 코드/쿼리 미변경, 롤백 대칭. 소규모 테이블이라
+  인덱스 생성 락 시간도 무시할 수준.
+
+## 산출물
+
+- `app/models/review.py` (Index 선언 2줄)
+- `alembic/versions/20260706_rob719_report_item_uuid_indexes.py` (신규)
+- PR base `main`, migration 0개 스키마 파괴 없음 (additive only)

--- a/docs/superpowers/plans/2026-07-06-rob-722-earnings-auto-inject.md
+++ b/docs/superpowers/plans/2026-07-06-rob-722-earnings-auto-inject.md
@@ -1,0 +1,720 @@
+# ROB-722 Earnings Auto-Inject Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Auto-inject each US/KR equity symbol's upcoming-earnings context (or an explicit "no earnings" signal) into `analyze_stock_batch` compact responses, reusing the ROB-711 attach rail.
+
+**Architecture:** New tooling module `app/mcp_server/tooling/earnings_context.py` reuses the already-validated `handle_get_earnings_calendar` handler (US live Finnhub / KR market_events DB) plus a pure compact shaper. A new sibling `_attach_earnings` in `analysis_tool_handlers.py` runs as a batched, symbol-level fail-open post-pass right after `_attach_decision_history`. No new vendor/auth/schema. Migration 0.
+
+**Tech Stack:** Python 3.13, async SQLAlchemy, pytest (`pytest.mark.asyncio`), existing MCP tooling layer.
+
+## Global Constraints
+
+- **No LLM providers** — pure deterministic shaping (ROB-501 static guard scans `app/**`). No provider imports.
+- **Migration 0** — no schema/model changes.
+- **Fail-open always** — any earnings lookup failure MUST leave the analysis result untouched; never raise out of the attach pass.
+- **Compact contract only** — attach only when `quick=True` (mirrors decision_history scope). Skip crypto and error rows.
+- **Layer discipline** — `earnings_context.py` lives in the tooling layer (same as `analysis_tool_handlers` and `_financials`); no service→tooling inversion.
+- **Attached key name:** `earnings` (verified free of collision with `_summarize_analysis_result` output).
+- Commit message trailer on every commit:
+  ```
+  Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+  Claude-Session: https://claude.ai/code/session_01UG8sLTN1Kko1PuenppjvD8
+  ```
+
+## File Structure
+
+- **Create** `app/mcp_server/tooling/earnings_context.py` — `_map_timing`, `_compact_earnings` (pure), `_kr_ingestion_freshness` (DB), `build_earnings_context` (dispatch + crypto skip + shape).
+- **Create** `tests/mcp_server/test_earnings_context.py` — unit tests for shaper, freshness, build dispatch, crypto skip, no-earnings.
+- **Modify** `app/mcp_server/tooling/analysis_tool_handlers.py` — add `_attach_earnings`, import `build_earnings_context`, wire call after `_attach_decision_history` (~:942).
+- **Create** `tests/mcp_server/test_analyze_stock_batch_earnings.py` — attach-pass injection/fail-open/skip tests.
+
+---
+
+## Task 1: Pure compact shaper (`_map_timing` + `_compact_earnings`)
+
+**Files:**
+- Create: `app/mcp_server/tooling/earnings_context.py`
+- Test: `tests/mcp_server/test_earnings_context.py`
+
+**Interfaces:**
+- Consumes: earnings tool-result dicts shaped by `handle_get_earnings_calendar` (US finnhub: keys `symbol`, `source="finnhub"`, `earnings:[{date, hour, eps_estimate, revenue_estimate, quarter, year}]`; KR market_events: `market="kr"`, `source="market_events"`, items add `time_hint`, `status`; error payload: key `error`).
+- Produces:
+  - `_map_timing(hour: str | None) -> str` → `"BMO"|"AMC"|"DMH"|"unknown"`.
+  - `_compact_earnings(tool_result: dict, *, today: datetime.date, freshness: str, data_as_of: str | None) -> dict` → compact context (`symbol`, `market`, `as_of`, `window_days`, `has_upcoming`, `next_earnings`|`None`, `freshness`, `source`, optional `data_as_of`, optional `note`).
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/mcp_server/test_earnings_context.py
+"""ROB-722 — earnings auto-inject context builder."""
+
+from __future__ import annotations
+
+import datetime
+
+import pytest
+
+from app.mcp_server.tooling import earnings_context as ec
+
+TODAY = datetime.date(2026, 7, 6)
+
+
+def test_map_timing_variants():
+    assert ec._map_timing("bmo") == "BMO"
+    assert ec._map_timing("AMC") == "AMC"
+    assert ec._map_timing("dmh") == "DMH"
+    assert ec._map_timing("") == "unknown"
+    assert ec._map_timing(None) == "unknown"
+    assert ec._map_timing("weird") == "unknown"
+
+
+def test_compact_earnings_us_upcoming_picks_nearest_future():
+    tool_result = {
+        "symbol": "NVDA",
+        "source": "finnhub",
+        "earnings": [
+            {"date": "2026-01-01", "hour": "amc"},  # past — excluded
+            {"date": "2026-07-25", "hour": "bmo", "eps_estimate": 0.9},
+            {"date": "2026-07-18", "hour": "amc", "eps_estimate": 0.84,
+             "revenue_estimate": 26500000000, "quarter": 2, "year": 2026},
+        ],
+    }
+    ctx = ec._compact_earnings(tool_result, today=TODAY, freshness="live", data_as_of=None)
+    assert ctx["market"] == "us"
+    assert ctx["source"] == "finnhub"
+    assert ctx["freshness"] == "live"
+    assert ctx["window_days"] == 30
+    assert ctx["as_of"] == "2026-07-06"
+    assert "data_as_of" not in ctx
+    assert ctx["has_upcoming"] is True
+    ne = ctx["next_earnings"]
+    assert ne["date"] == "2026-07-18"       # nearest future, not the earlier past row
+    assert ne["d_minus"] == 12
+    assert ne["timing"] == "AMC"
+    assert ne["eps_estimate"] == 0.84
+    assert ne["quarter"] == 2
+
+
+def test_compact_earnings_no_upcoming_is_explicit_signal():
+    tool_result = {"symbol": "HCA", "source": "finnhub", "earnings": []}
+    ctx = ec._compact_earnings(tool_result, today=TODAY, freshness="live", data_as_of=None)
+    assert ctx["has_upcoming"] is False
+    assert ctx["next_earnings"] is None
+    assert ctx["note"] == "no scheduled earnings within 30 days"
+
+
+def test_compact_earnings_kr_carries_freshness_and_data_as_of():
+    tool_result = {
+        "symbol": "005930",
+        "market": "kr",
+        "source": "market_events",
+        "earnings": [
+            {"date": "2026-07-25", "time_hint": "unknown", "status": "scheduled",
+             "quarter": 2, "year": 2026},
+        ],
+    }
+    ctx = ec._compact_earnings(
+        tool_result, today=TODAY, freshness="stale", data_as_of="2026-07-01"
+    )
+    assert ctx["market"] == "kr"
+    assert ctx["source"] == "market_events"
+    assert ctx["freshness"] == "stale"
+    assert ctx["data_as_of"] == "2026-07-01"
+    assert ctx["next_earnings"]["timing"] == "unknown"
+    assert ctx["next_earnings"]["status"] == "scheduled"
+
+
+def test_compact_earnings_error_payload_degrades():
+    tool_result = {"symbol": "NVDA", "source": "finnhub", "error": "429 quota"}
+    ctx = ec._compact_earnings(tool_result, today=TODAY, freshness="live", data_as_of=None)
+    assert ctx["has_upcoming"] is False
+    assert ctx["next_earnings"] is None
+    assert "degraded" in ctx["note"]
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/mcp_server/test_earnings_context.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'app.mcp_server.tooling.earnings_context'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# app/mcp_server/tooling/earnings_context.py
+"""ROB-722 — deterministic upcoming-earnings context for a symbol.
+
+Read-only. No LLM (ROB-501), no schema change. Reuses the validated
+handle_get_earnings_calendar dispatch (US live Finnhub / KR market_events DB)
+and shapes a compact "next earnings D-n / timing / consensus, or explicit
+no-earnings" signal. Attached to analyze_stock_batch compact responses so each
+fresh analysis session sees the symbol's earnings proximity.
+
+No-earnings is itself a signal (HCA: '30일 내 무실적' as an entry justification),
+so a zero-earnings window yields has_upcoming=False + note — NOT omission.
+Only crypto / non-equity symbols are omitted (no earnings concept).
+"""
+
+from __future__ import annotations
+
+import datetime
+from typing import Any
+
+_WINDOW_DAYS = 30
+_TIMING_MAP = {"bmo": "BMO", "amc": "AMC", "dmh": "DMH"}
+
+
+def _map_timing(hour: str | None) -> str:
+    if not hour:
+        return "unknown"
+    return _TIMING_MAP.get(hour.strip().lower(), "unknown")
+
+
+def _compact_earnings(
+    tool_result: dict[str, Any],
+    *,
+    today: datetime.date,
+    freshness: str,
+    data_as_of: str | None,
+) -> dict[str, Any]:
+    source = tool_result.get("source")
+    market_label = "kr" if (
+        tool_result.get("market") == "kr" or source == "market_events"
+    ) else "us"
+
+    ctx: dict[str, Any] = {
+        "symbol": tool_result.get("symbol"),
+        "market": market_label,
+        "as_of": today.isoformat(),
+        "window_days": _WINDOW_DAYS,
+        "freshness": freshness,
+        "source": source,
+    }
+    if data_as_of is not None:
+        ctx["data_as_of"] = data_as_of
+
+    if tool_result.get("error"):
+        ctx["has_upcoming"] = False
+        ctx["next_earnings"] = None
+        ctx["note"] = f"earnings lookup degraded: {tool_result.get('error')}"
+        return ctx
+
+    upcoming: list[tuple[datetime.date, dict[str, Any]]] = []
+    for item in tool_result.get("earnings") or []:
+        raw = item.get("date")
+        if not raw:
+            continue
+        try:
+            edate = datetime.date.fromisoformat(raw)
+        except (ValueError, TypeError):
+            continue
+        if edate >= today:
+            upcoming.append((edate, item))
+
+    if not upcoming:
+        ctx["has_upcoming"] = False
+        ctx["next_earnings"] = None
+        ctx["note"] = f"no scheduled earnings within {_WINDOW_DAYS} days"
+        return ctx
+
+    upcoming.sort(key=lambda pair: pair[0])
+    edate, item = upcoming[0]
+    ctx["has_upcoming"] = True
+    ctx["next_earnings"] = {
+        "date": edate.isoformat(),
+        "d_minus": (edate - today).days,
+        "timing": _map_timing(item.get("hour") or item.get("time_hint")),
+        "eps_estimate": item.get("eps_estimate"),
+        "revenue_estimate": item.get("revenue_estimate"),
+        "quarter": item.get("quarter"),
+        "year": item.get("year"),
+        "status": item.get("status"),
+    }
+    return ctx
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/mcp_server/test_earnings_context.py -v`
+Expected: PASS (5 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/mcp_server/tooling/earnings_context.py tests/mcp_server/test_earnings_context.py
+git commit -m "feat(ROB-722): pure compact earnings shaper
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01UG8sLTN1Kko1PuenppjvD8"
+```
+
+---
+
+## Task 2: KR ingestion freshness (`_kr_ingestion_freshness`)
+
+**Files:**
+- Modify: `app/mcp_server/tooling/earnings_context.py`
+- Test: `tests/mcp_server/test_earnings_context.py`
+
+**Interfaces:**
+- Consumes: `MarketEventIngestionPartition` (columns `market`, `category`, `status`, `finished_at`); reuses `STALE_AFTER_HOURS` (36h) + `_is_stale` + `_ensure_aware` from `app.services.market_events.freshness_service` (DRY on threshold).
+- Produces: `async _kr_ingestion_freshness(db: AsyncSession) -> tuple[str, str | None]` → `(freshness, data_as_of)` where freshness ∈ `{"fresh","stale","unknown"}` and data_as_of is the newest succeeded `finished_at` date ISO (or None).
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# append to tests/mcp_server/test_earnings_context.py
+import datetime as _dt
+
+from app.services.market_events.freshness_service import STALE_AFTER_HOURS
+
+
+class _FakeScalarResult:
+    def __init__(self, value):
+        self._value = value
+
+    def scalar_one_or_none(self):
+        return self._value
+
+
+class _FakeDB:
+    def __init__(self, value):
+        self._value = value
+
+    async def execute(self, _stmt):
+        return _FakeScalarResult(self._value)
+
+
+@pytest.mark.asyncio
+async def test_kr_freshness_none_partition_is_unknown():
+    freshness, as_of = await ec._kr_ingestion_freshness(_FakeDB(None))
+    assert freshness == "unknown"
+    assert as_of is None
+
+
+@pytest.mark.asyncio
+async def test_kr_freshness_recent_is_fresh():
+    recent = _dt.datetime.now(_dt.UTC) - _dt.timedelta(hours=1)
+    freshness, as_of = await ec._kr_ingestion_freshness(_FakeDB(recent))
+    assert freshness == "fresh"
+    assert as_of == recent.date().isoformat()
+
+
+@pytest.mark.asyncio
+async def test_kr_freshness_old_is_stale():
+    old = _dt.datetime.now(_dt.UTC) - _dt.timedelta(hours=STALE_AFTER_HOURS + 5)
+    freshness, as_of = await ec._kr_ingestion_freshness(_FakeDB(old))
+    assert freshness == "stale"
+    assert as_of == old.date().isoformat()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/mcp_server/test_earnings_context.py -k kr_freshness -v`
+Expected: FAIL — `AttributeError: module ... has no attribute '_kr_ingestion_freshness'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add imports at the top of `earnings_context.py`:
+
+```python
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.market_events import MarketEventIngestionPartition
+from app.services.market_events.freshness_service import _ensure_aware, _is_stale
+```
+
+Add the function:
+
+```python
+async def _kr_ingestion_freshness(db: AsyncSession) -> tuple[str, str | None]:
+    """Newest succeeded KR earnings ingestion → (freshness, data_as_of ISO|None).
+
+    Global per (market=kr, category=earnings) — compute ONCE per batch, not per
+    symbol. Reuses the market_events STALE_AFTER_HOURS threshold. Fail-open at
+    the caller: a DB error leaves KR rows on ('unknown', None).
+    """
+    stmt = select(func.max(MarketEventIngestionPartition.finished_at)).where(
+        MarketEventIngestionPartition.market == "kr",
+        MarketEventIngestionPartition.category == "earnings",
+        MarketEventIngestionPartition.status == "succeeded",
+    )
+    finished_at = (await db.execute(stmt)).scalar_one_or_none()
+    if finished_at is None:
+        return ("unknown", None)
+    aware = _ensure_aware(finished_at)
+    freshness = "stale" if _is_stale(aware, now=datetime.datetime.now(datetime.UTC)) else "fresh"
+    return (freshness, aware.date().isoformat())
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/mcp_server/test_earnings_context.py -k kr_freshness -v`
+Expected: PASS (3 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/mcp_server/tooling/earnings_context.py tests/mcp_server/test_earnings_context.py
+git commit -m "feat(ROB-722): KR ingestion freshness derivation
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01UG8sLTN1Kko1PuenppjvD8"
+```
+
+---
+
+## Task 3: `build_earnings_context` dispatch + crypto skip
+
+**Files:**
+- Modify: `app/mcp_server/tooling/earnings_context.py`
+- Test: `tests/mcp_server/test_earnings_context.py`
+
+**Interfaces:**
+- Consumes: `handle_get_earnings_calendar(symbol, from_date, to_date, market) -> dict` (from `app.mcp_server.tooling.fundamentals._financials`); `_compact_earnings`; `_kr_ingestion_freshness`.
+- Produces: `async build_earnings_context(symbol: str, market: str, *, today: datetime.date | None = None, kr_freshness: tuple[str, str | None] | None = None) -> dict | None` — returns `None` for crypto/blank/non-equity market; else the compact context dict.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# append to tests/mcp_server/test_earnings_context.py
+
+
+@pytest.mark.asyncio
+async def test_build_earnings_context_crypto_returns_none():
+    ctx = await ec.build_earnings_context("BTC", "crypto", today=TODAY)
+    assert ctx is None
+
+
+@pytest.mark.asyncio
+async def test_build_earnings_context_us_calls_handler_and_shapes(monkeypatch):
+    async def _fake_handler(symbol, from_date, to_date, market):
+        assert symbol == "NVDA"
+        assert market == "us"
+        assert from_date == "2026-07-06"
+        assert to_date == "2026-08-05"  # today + 30d
+        return {
+            "symbol": "NVDA", "source": "finnhub",
+            "earnings": [{"date": "2026-07-18", "hour": "amc", "eps_estimate": 0.84}],
+        }
+
+    monkeypatch.setattr(ec, "handle_get_earnings_calendar", _fake_handler)
+    ctx = await ec.build_earnings_context("NVDA", "us", today=TODAY)
+    assert ctx["market"] == "us"
+    assert ctx["freshness"] == "live"
+    assert ctx["has_upcoming"] is True
+    assert ctx["next_earnings"]["d_minus"] == 12
+
+
+@pytest.mark.asyncio
+async def test_build_earnings_context_kr_uses_passed_freshness(monkeypatch):
+    async def _fake_handler(symbol, from_date, to_date, market):
+        return {
+            "symbol": "005930", "market": "kr", "source": "market_events",
+            "earnings": [{"date": "2026-07-25", "time_hint": "unknown"}],
+        }
+
+    monkeypatch.setattr(ec, "handle_get_earnings_calendar", _fake_handler)
+    ctx = await ec.build_earnings_context(
+        "005930", "kr", today=TODAY, kr_freshness=("stale", "2026-07-01")
+    )
+    assert ctx["freshness"] == "stale"
+    assert ctx["data_as_of"] == "2026-07-01"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/mcp_server/test_earnings_context.py -k build_earnings -v`
+Expected: FAIL — `AttributeError: module ... has no attribute 'build_earnings_context'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add import at the top of `earnings_context.py`:
+
+```python
+from app.mcp_server.tooling.fundamentals._financials import (
+    handle_get_earnings_calendar,
+)
+```
+
+Add the function:
+
+```python
+_EQUITY_MARKETS = {"kr", "us"}
+
+
+async def build_earnings_context(
+    symbol: str,
+    market: str,
+    *,
+    today: datetime.date | None = None,
+    kr_freshness: tuple[str, str | None] | None = None,
+) -> dict[str, Any] | None:
+    """Compact upcoming-earnings context for one symbol, or None to omit.
+
+    Omits (None) only for crypto / non-equity markets — earnings has no meaning
+    there. For US/KR equities it ALWAYS returns a dict (no-earnings is an
+    explicit has_upcoming=False signal). US freshness is "live"; KR freshness is
+    taken from ``kr_freshness`` (computed once per batch by the caller)."""
+    market_norm = (market or "").strip().lower()
+    if market_norm not in _EQUITY_MARKETS:
+        return None
+
+    today = today or datetime.date.today()
+    to_date = today + datetime.timedelta(days=_WINDOW_DAYS)
+
+    tool_result = await handle_get_earnings_calendar(
+        symbol, today.isoformat(), to_date.isoformat(), market_norm
+    )
+
+    if market_norm == "kr":
+        freshness, data_as_of = kr_freshness or ("unknown", None)
+    else:
+        freshness, data_as_of = "live", None
+
+    return _compact_earnings(
+        tool_result, today=today, freshness=freshness, data_as_of=data_as_of
+    )
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/mcp_server/test_earnings_context.py -v`
+Expected: PASS (all tests in file)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/mcp_server/tooling/earnings_context.py tests/mcp_server/test_earnings_context.py
+git commit -m "feat(ROB-722): build_earnings_context dispatch + crypto skip
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01UG8sLTN1Kko1PuenppjvD8"
+```
+
+---
+
+## Task 4: `_attach_earnings` batched fail-open pass + wiring
+
+**Files:**
+- Modify: `app/mcp_server/tooling/analysis_tool_handlers.py` (import ~:35, add `_attach_earnings` after `_attach_decision_history` ~:880, wire call ~:942)
+- Test: `tests/mcp_server/test_analyze_stock_batch_earnings.py`
+
+**Interfaces:**
+- Consumes: `build_earnings_context(symbol, market, *, today, kr_freshness) -> dict | None`, `_kr_ingestion_freshness(db) -> tuple[str, str|None]`, `AsyncSessionLocal`.
+- Produces: `async _attach_earnings(results: dict[str, Any], *, market: str | None) -> None` — mutates `results` in place, attaching `result["earnings"]` per non-error, non-crypto symbol.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/mcp_server/test_analyze_stock_batch_earnings.py
+"""ROB-722 — analyze_stock_batch earnings auto-inject attach pass."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.mcp_server.tooling import analysis_tool_handlers as h
+
+
+@pytest.mark.asyncio
+async def test_attach_earnings_injects_when_context_exists(monkeypatch):
+    async def _fake_build(symbol, market, *, today=None, kr_freshness=None):
+        return {"symbol": symbol, "market": market, "has_upcoming": False,
+                "next_earnings": None}
+
+    async def _fake_kr_fresh(db):
+        return ("fresh", "2026-07-06")
+
+    monkeypatch.setattr(h, "build_earnings_context", _fake_build, raising=False)
+    monkeypatch.setattr(h, "_kr_ingestion_freshness", _fake_kr_fresh, raising=False)
+
+    results = {"NVDA": {"symbol": "NVDA", "market_type": "us"}}
+    await h._attach_earnings(results, market="us")
+
+    assert results["NVDA"]["earnings"]["has_upcoming"] is False
+
+
+@pytest.mark.asyncio
+async def test_attach_earnings_fail_open_on_error(monkeypatch):
+    async def _boom(symbol, market, *, today=None, kr_freshness=None):
+        raise RuntimeError("finnhub down")
+
+    monkeypatch.setattr(h, "build_earnings_context", _boom, raising=False)
+
+    results = {"NVDA": {"symbol": "NVDA", "market_type": "us"}}
+    await h._attach_earnings(results, market="us")  # must not raise
+
+    assert "earnings" not in results["NVDA"]
+
+
+@pytest.mark.asyncio
+async def test_attach_earnings_skips_error_and_crypto_rows(monkeypatch):
+    # Mirrors real build: None for crypto (skip), dict for equities. Error rows
+    # are skipped by _attach_earnings before build is ever called.
+    async def _fake_build(symbol, market, *, today=None, kr_freshness=None):
+        if str(market).strip().lower() == "crypto":
+            return None
+        return {"symbol": symbol}
+
+    monkeypatch.setattr(h, "build_earnings_context", _fake_build, raising=False)
+
+    results = {
+        "BADSYM": {"error": "not found"},
+        "BTC": {"symbol": "BTC", "market_type": "crypto"},
+        "NVDA": {"symbol": "NVDA", "market_type": "us"},
+    }
+    await h._attach_earnings(results, market=None)
+
+    assert "earnings" not in results["BADSYM"]      # error row skipped pre-build
+    assert "earnings" not in results["BTC"]         # build returns None → omit
+    assert results["NVDA"]["earnings"] == {"symbol": "NVDA"}  # equity attached
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/mcp_server/test_analyze_stock_batch_earnings.py -v`
+Expected: FAIL — `AttributeError: module ... has no attribute '_attach_earnings'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add import near the existing decision_history import (~:35 in `analysis_tool_handlers.py`):
+
+```python
+from app.mcp_server.tooling.earnings_context import (
+    _kr_ingestion_freshness,
+    build_earnings_context,
+)
+```
+
+Add the function immediately after `_attach_decision_history` (after ~:879):
+
+```python
+async def _attach_earnings(
+    results: dict[str, Any],
+    *,
+    market: str | None,
+) -> None:
+    """ROB-722: inject per-symbol upcoming-earnings context (US live / KR DB).
+
+    Batched (one session), symbol-level fail-open. No-earnings is an explicit
+    signal (has_upcoming=False), so US/KR equity rows always receive an
+    ``earnings`` field; crypto/error rows are skipped. KR ingestion freshness is
+    computed at most once per batch and threaded into each build call.
+    """
+    if not any(
+        isinstance(row, dict) and "error" not in row for row in results.values()
+    ):
+        return
+    try:
+        from app.core.db import AsyncSessionLocal
+
+        async with AsyncSessionLocal() as db:
+            kr_freshness: tuple[str, str | None] | None = None
+            for sym, result in results.items():
+                if not isinstance(result, dict) or "error" in result:
+                    continue
+                mkt = result.get("market_type") or market
+                if str(mkt or "").strip().lower() == "kr" and kr_freshness is None:
+                    try:
+                        kr_freshness = await _kr_ingestion_freshness(db)
+                    except Exception:  # fail-open: freshness is advisory
+                        kr_freshness = ("unknown", None)
+                try:
+                    ctx = await build_earnings_context(
+                        str(sym), str(mkt or ""), kr_freshness=kr_freshness
+                    )
+                except Exception as exc:  # symbol-level fail-open (e.g. 429)
+                    logger.debug("earnings injection skipped for %s: %s", sym, exc)
+                    continue
+                if ctx is not None:
+                    result["earnings"] = ctx
+    except Exception as exc:  # fail-open: advisory-only
+        logger.debug("earnings injection skipped: %s", exc)
+```
+
+Wire the call in `analyze_stock_batch_impl` immediately after the `_attach_decision_history` line (~:942):
+
+```python
+    if quick:
+        await _attach_fresh_artifact_hints(response.get("results", {}), market=market)
+        await _attach_decision_history(response.get("results", {}), market=market)
+        await _attach_earnings(response.get("results", {}), market=market)
+    return response
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/mcp_server/test_analyze_stock_batch_earnings.py -v`
+Expected: PASS (3 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/mcp_server/tooling/analysis_tool_handlers.py tests/mcp_server/test_analyze_stock_batch_earnings.py
+git commit -m "feat(ROB-722): wire _attach_earnings into analyze_stock_batch
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01UG8sLTN1Kko1PuenppjvD8"
+```
+
+---
+
+## Task 5: Full-suite gate (lint + typecheck + LLM guard + regression)
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Run the two new test modules + the decision_history regression**
+
+Run:
+```bash
+uv run pytest tests/mcp_server/test_earnings_context.py \
+  tests/mcp_server/test_analyze_stock_batch_earnings.py \
+  tests/mcp_server/test_analyze_stock_batch_decision_history.py \
+  tests/test_mcp_earnings_calendar.py -v
+```
+Expected: PASS (all).
+
+- [ ] **Step 2: Static LLM-import guard (ROB-501) must still pass**
+
+Run: `uv run pytest tests/services/action_report/snapshot_backed/test_no_internal_llm_imports.py -v`
+Expected: PASS.
+
+- [ ] **Step 3: Lint + typecheck the touched files**
+
+Run: `make lint` (Ruff + ty). If unavailable, `uv run ruff check app/mcp_server/tooling/earnings_context.py app/mcp_server/tooling/analysis_tool_handlers.py`
+Expected: no new findings.
+
+- [ ] **Step 4: Confirm migration 0**
+
+Run: `git status --short` and confirm no files under `alembic/versions/` were added.
+Expected: only `app/mcp_server/tooling/earnings_context.py`, `app/mcp_server/tooling/analysis_tool_handlers.py`, and the two test files (plus docs) changed.
+
+- [ ] **Step 5: Commit (only if lint/format applied changes)**
+
+```bash
+git add -A
+git commit -m "chore(ROB-722): lint/format pass
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01UG8sLTN1Kko1PuenppjvD8"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- US live Finnhub path → Task 3 (`build_earnings_context` market="us", freshness="live") + Task 1 shaper. ✓
+- KR market_events DB path + stale marker → Task 2 (`_kr_ingestion_freshness`) + Task 3 (kr branch). ✓
+- No-earnings explicit signal (HCA) → Task 1 (`has_upcoming=False` + note). ✓
+- Attach rail sibling to `_attach_decision_history`, wired after it → Task 4. ✓
+- Symbol-level fail-open for US rate-limit → Task 4 inner try/except + handler's own 429→`_error_payload` degrade (Task 1 error branch). ✓
+- crypto skip → Task 3 (`_EQUITY_MARKETS` guard → None) + Task 4 (None → omit). ✓
+- Tests: US live-Finnhub + KR DB + no-earnings + fail-open + crypto → Tasks 1/3/4. ✓
+- migration 0, no LLM imports → Task 5 gates. ✓
+
+**Placeholder scan:** none — every code step shows complete code; no TBD/TODO. ✓
+
+**Type consistency:** `build_earnings_context(symbol, market, *, today, kr_freshness)` and `_kr_ingestion_freshness(db) -> tuple[str, str|None]` signatures identical across Tasks 2/3/4 and their tests. `_compact_earnings(tool_result, *, today, freshness, data_as_of)` identical in Tasks 1/3. Attached key `earnings` consistent. ✓

--- a/docs/superpowers/specs/2026-07-06-rob-722-earnings-auto-inject-design.md
+++ b/docs/superpowers/specs/2026-07-06-rob-722-earnings-auto-inject-design.md
@@ -1,0 +1,192 @@
+# ROB-722 — analyze_stock_batch 심볼별 다가오는 실적 auto-inject
+
+**날짜:** 2026-07-06
+**이슈:** ROB-722 (related: ROB-711 레일, ROB-721 스코핑 GO #2)
+**상태:** 설계 승인 대기
+
+## 배경
+
+`get_earnings_calendar` MCP 도구는 이미 배포되어 있다(US=live Finnhub, KR=market_events DB).
+그러나 분석 체인은 이를 자동 주입하지 않아, 오퍼레이터가 심볼 분석 때마다 실적 일정을 수기로
+조회한다. 검증된 코퍼스 사례(`review.investment_report_items` 330행):
+
+- **NVDA**: "Finnhub calendar shows earnings on 2026-05-20 AMC; avoid…" — 실적 임박이 진입 판단을 뒤집음.
+- **HCA**: "30일 내 실적 없음" — **무실적을 진입 정당화 근거로 인용**.
+- **JPM/BAC**: 실적 인접 trim watch.
+
+오퍼레이터가 이미 수기로 하는 검증된 행동을 auto-inject가 결정론적으로 체계화한다.
+신규 벤더/auth/스키마 0, migration 0.
+
+## 목표 / 비목표
+
+**목표**
+- `analyze_stock_batch`(compact 계약, `quick=True`)의 각 US/KR equity 심볼 결과에 "다가오는 실적
+  컨텍스트"를 결정론적으로 자동 첨부.
+- 무실적("향후 30일 무실적")도 명시적 신호로 첨부(HCA 사례).
+- US=live Finnhub, KR=market_events DB(+freshness 표기).
+- 완전 fail-open — 실적 조회 실패가 분석 결과를 절대 훼손하지 않음.
+
+**비목표**
+- KR live 소싱(DART/WiseFn 실시간) — 별도 이슈. 이번엔 DB + stale 표기.
+- crypto 실적(개념 없음) — skip.
+- `analyze_portfolio`(full 계약, quick=False) — 미대상(compact 계약만; decision_history와 동일 범위).
+- 스키마/마이그레이션 변경 — 없음.
+- LLM 판단 — 없음(ROB-501 가드). 순수 결정론 shaping.
+
+## 아키텍처
+
+ROB-711의 `_attach_decision_history` 레일을 1:1 미러하되, US 경로가 Finnhub fetch 디스패치를
+필요로 하므로 **서비스 계층에 병렬 구현을 새로 짓지 않고** 이미 검증된 MCP 핸들러
+`handle_get_earnings_calendar`를 재사용한다(둘 다 tooling 계층 → 레이어 역전 없음).
+그 핸들러가 이미 처리하는 것: US/KR 시장 디스패치, Finnhub fetch, KR DB shaping, crypto 거부,
+날짜 윈도우 정규화. **신규 코드 = compact shaper + `_attach_earnings` 배치 루프뿐.**
+
+### 컴포넌트
+
+**신규 `app/mcp_server/tooling/earnings_context.py`** (tooling 계층)
+
+```
+_TIMING_MAP = {"bmo": "BMO", "amc": "AMC", "dmh": "DMH"}
+_WINDOW_DAYS = 30
+_KR_STALE_THRESHOLD_DAYS = 2
+
+def _map_timing(hour: str | None) -> str          # bmo/amc/dmh → BMO/AMC/DMH, else "unknown"
+
+def _compact_earnings(
+    tool_result: dict, *, today: date, freshness: str, data_as_of: str | None,
+) -> dict:
+    """순수 shaper. tool_result(US finnhub / KR market_events)의 earnings[]에서
+       today 이후 최근접 upcoming 1건을 선택해 compact 컨텍스트 생성.
+       upcoming 없으면 has_upcoming=False + note."""
+
+async def _kr_ingestion_freshness(db) -> tuple[str, str | None]:
+    """MarketEventIngestionPartition 최신 finished_at(market=kr, category=earnings)로
+       (freshness ∈ {fresh, stale, unknown}, data_as_of ISO|None) 도출.
+       배치당 1회만 계산(심볼 무관 전역)."""
+
+async def build_earnings_context(
+    symbol: str, market: str, *, today: date | None = None,
+    kr_freshness: tuple[str, str | None] | None = None,
+) -> dict | None:
+    """crypto/비-equity → None(필드 생략). 그 외 handle_get_earnings_calendar(
+       symbol, from=today, to=today+30d, market) 호출 → _compact_earnings → 반환.
+       US freshness="live". KR freshness는 kr_freshness 인자(배치서 1회 계산) 사용."""
+```
+
+**`app/mcp_server/tooling/analysis_tool_handlers.py`** — `_attach_decision_history`(:850) 옆 sibling:
+
+```
+async def _attach_earnings(results, *, market) -> None:
+    """ROB-722: 심볼별 다가오는 실적 컨텍스트 auto-inject.
+       배치(단일 세션), 심볼별 fail-open. crypto/error 행 skip.
+       KR freshness는 세션당 1회 계산해 각 build 호출에 전달."""
+```
+
+호출 지점: `analyze_stock_batch_impl` `:942` `_attach_decision_history` **직후**
+(quick 분기 안, `_attach_fresh_artifact_hints` → `_attach_decision_history` → `_attach_earnings`).
+
+### 데이터 흐름
+
+1. `analyze_stock_batch_impl(quick=True)` → `_run_batch_analysis` → `_attach_fresh_artifact_hints`
+   → `_attach_decision_history` → **`_attach_earnings`**.
+2. `_attach_earnings`: 단일 `AsyncSessionLocal`. KR 심볼이 하나라도 있으면 `_kr_ingestion_freshness`
+   1회 계산. 각 non-error·non-crypto 심볼에 `build_earnings_context(sym, mkt, kr_freshness=...)`.
+3. `build_earnings_context`: crypto면 None. 아니면 `handle_get_earnings_calendar` 호출 →
+   `_compact_earnings` shaping → `result["earnings"]`에 첨부.
+4. 심볼별 try/except: 한 심볼의 Finnhub 429/에러가 배치 전체를 죽이지 않음(그 심볼만 필드 생략).
+
+## 첨부 페이로드 형태
+
+결과 dict의 `earnings` 키로 첨부(decision_history와 동일한 sibling 위치):
+
+```jsonc
+// upcoming 실적 있음 (NVDA류)
+"earnings": {
+  "symbol": "NVDA",
+  "market": "us",
+  "as_of": "2026-07-06",
+  "window_days": 30,
+  "has_upcoming": true,
+  "next_earnings": {
+    "date": "2026-05-20",
+    "d_minus": 12,               // (date - today).days
+    "timing": "AMC",             // BMO | AMC | DMH | unknown
+    "eps_estimate": 0.84,
+    "revenue_estimate": 26500000000,
+    "quarter": 1,
+    "year": 2026,
+    "status": "scheduled"        // KR만; US는 null
+  },
+  "freshness": "live",           // US=live
+  "source": "finnhub"
+}
+
+// 무실적 (HCA류) — 명시적 신호
+"earnings": {
+  "symbol": "HCA",
+  "market": "us",
+  "as_of": "2026-07-06",
+  "window_days": 30,
+  "has_upcoming": false,
+  "next_earnings": null,
+  "note": "no scheduled earnings within 30 days",
+  "freshness": "live",
+  "source": "finnhub"
+}
+
+// KR (DB + stale 표기)
+"earnings": {
+  "symbol": "005930",
+  "market": "kr",
+  "as_of": "2026-07-06",
+  "window_days": 30,
+  "has_upcoming": true,
+  "next_earnings": { "date": "2026-07-25", "d_minus": 19, "timing": "unknown", ... },
+  "freshness": "stale",          // fresh | stale | unknown (finished_at 기준 >2일=stale)
+  "data_as_of": "2026-07-01",    // KR 최신 인제스트 finished_at
+  "source": "market_events"
+}
+```
+
+- crypto/비-equity: `build`가 None → 필드 자체 생략(첨부 안 함).
+- `d_minus`는 `date.today()` 기준 단순 일수 차. (ET/KST 분리 미도입 — YAGNI. 30일 윈도우/일 단위라
+  경계 오차 무의미. 필요 시 후속.)
+
+## 결정 사항 (사용자 승인 완료)
+
+1. **KR 경로**: DB + stale 표기. `MarketEventIngestionPartition.finished_at`으로 freshness 도출.
+2. **US rate-limit**: 심볼별 fail-open, 캐시 없음(YAGNI). 배치 최대 10심볼 → 최대 10 Finnhub 콜,
+   무료 60/min 여유. 심볼별 try/except로 429 격리.
+3. **무실적 신호화**: `has_upcoming=false` + `note`로 명시 첨부(None 반환 아님). crypto만 생략.
+
+## 에러 처리 / fail-open 계층
+
+- `_attach_earnings` 전체를 try/except로 감싸 advisory-only(decision_history와 동일 패턴).
+- 심볼별로도 try/except — 한 심볼 실패가 나머지 심볼 첨부를 막지 않음.
+- `handle_get_earnings_calendar`가 `_error_payload`(dict with error/source)를 반환하면 shaper는
+  `has_upcoming=false` + 에러 note로 degrade(예외 아님). Finnhub 429는 `FinnhubQuotaExceededError`가
+  핸들러 내부에서 `_error_payload`로 잡힘 → 그 심볼만 degrade.
+- KR freshness 조회 실패 → `("unknown", None)`으로 fail-open.
+
+## 테스트
+
+**`tests/mcp_server/test_analyze_stock_batch_earnings.py`** (신규, decision_history 테스트 미러):
+- `_attach_earnings`가 build 컨텍스트 존재 시 `earnings` 첨부(build_earnings_context monkeypatch).
+- build 예외 시 fail-open(결과 untouched).
+- error 행 skip, crypto 행 skip.
+
+**`tests/mcp_server/test_earnings_context.py`** (신규):
+- US upcoming: `handle_get_earnings_calendar` monkeypatch → d_minus·timing(BMO/AMC/DMH) 매핑 검증.
+- US 무실적: earnings=[] → `has_upcoming=false` + note.
+- KR DB 경로: freshness=stale/fresh + data_as_of 표기(partition monkeypatch 또는 seed).
+- crypto/비-equity: `build_earnings_context` → None.
+- `_compact_earnings` 순수 함수: today 이후 최근접 선택, 과거 실적 제외, timing 매핑, no-upcoming.
+
+**정적 가드**: `test_no_internal_llm_imports.py` 영향 없음(LLM import 없음). migration 0.
+
+## 완료 기준
+
+- `analyze_stock_batch` compact 결과에 심볼별 실적 컨텍스트 결정론 포함(US live / KR DB).
+- 무실적 케이스도 명시 신호로 첨부.
+- 테스트: US live-Finnhub 경로 + KR DB 경로 + 무실적 케이스 + fail-open + crypto skip.
+- migration 0. 기존 decision_history/fresh_artifact 첨부 회귀 없음.

--- a/frontend/invest/src/__tests__/InvestmentReportBundleContent.loopSection.test.tsx
+++ b/frontend/invest/src/__tests__/InvestmentReportBundleContent.loopSection.test.tsx
@@ -152,4 +152,60 @@ describe("ROB-715 item loop section", () => {
     renderContent(bundle);
     expect(screen.queryByText("해소 대기 / 미연결")).not.toBeInTheDocument();
   });
+  it("renders a closed forecast with null outcome as neutral, not miss", () => {
+    const bundle = makeBundle(makeItem({}));
+    bundle.forecastsByItemUuid = {
+      u1: [
+        {
+          forecastId: "f-null",
+          status: "closed",
+          outcome: null,
+          reviewDate: null,
+          direction: "at_or_above",
+          targetPrice: 200000,
+          probability: 0.5,
+          brierScore: null,
+          resolutionSource: null,
+        },
+      ],
+    };
+    bundle.retrospectivesByItemUuid = {};
+    renderContent(bundle);
+    expect(screen.getByText("결과 미기록")).toBeInTheDocument();
+    expect(screen.queryByText("빗나감")).not.toBeInTheDocument();
+  });
+
+  it("still renders closed outcome=false as 빗나감 and outcome=true as 적중", () => {
+    const bundle = makeBundle(makeItem({}));
+    bundle.forecastsByItemUuid = {
+      u1: [
+        {
+          forecastId: "f-miss",
+          status: "closed",
+          outcome: false,
+          reviewDate: null,
+          direction: "at_or_above",
+          targetPrice: 200000,
+          probability: 0.5,
+          brierScore: null,
+          resolutionSource: null,
+        },
+        {
+          forecastId: "f-hit",
+          status: "closed",
+          outcome: true,
+          reviewDate: null,
+          direction: "at_or_above",
+          targetPrice: 200000,
+          probability: 0.5,
+          brierScore: null,
+          resolutionSource: null,
+        },
+      ],
+    };
+    bundle.retrospectivesByItemUuid = {};
+    renderContent(bundle);
+    expect(screen.getByText("빗나감")).toBeInTheDocument();
+    expect(screen.getByText("적중")).toBeInTheDocument();
+  });
 });

--- a/frontend/invest/src/__tests__/InvestmentReportBundleContent.planVsActual.test.tsx
+++ b/frontend/invest/src/__tests__/InvestmentReportBundleContent.planVsActual.test.tsx
@@ -138,4 +138,49 @@ describe("ROB-715 plan vs actual", () => {
     expect(pva).toHaveTextContent("70000"); // planned entry
     expect(pva).toHaveTextContent("69450"); // actual fill
   });
+  it("hides plan-vs-actual (체결 대기) on non-action items with a tradeSetup", () => {
+    const bundle = makeBundle(
+      makeItem({
+        itemKind: "watch",
+        evidenceSnapshot: {
+          trade_setup: {
+            direction: "long",
+            stop: "65000",
+            target: "78000",
+            headline: {
+              entry: "70000",
+              risk_pct: "7.14",
+              reward_pct: "11.43",
+              rr_ratio: "1.60",
+            },
+          },
+        },
+      }),
+    );
+    renderContent(bundle);
+    expect(screen.queryByTestId("item-plan-vs-actual")).not.toBeInTheDocument();
+  });
+
+  it("still shows plan-vs-actual on action items with a tradeSetup", () => {
+    const bundle = makeBundle(
+      makeItem({
+        itemKind: "action",
+        evidenceSnapshot: {
+          trade_setup: {
+            direction: "long",
+            stop: "65000",
+            target: "78000",
+            headline: {
+              entry: "70000",
+              risk_pct: "7.14",
+              reward_pct: "11.43",
+              rr_ratio: "1.60",
+            },
+          },
+        },
+      }),
+    );
+    renderContent(bundle);
+    expect(screen.getByTestId("item-plan-vs-actual")).toBeInTheDocument();
+  });
 });

--- a/frontend/invest/src/__tests__/ItemArtifactLinks.test.tsx
+++ b/frontend/invest/src/__tests__/ItemArtifactLinks.test.tsx
@@ -1,0 +1,106 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import * as api from "../api/analysisArtifacts";
+import ItemArtifactLinks from "../components/investment-reports/ItemArtifactLinks";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+const meta = (over = {}) => ({
+  id: 1,
+  artifact_uuid: "u1",
+  market: "us" as const,
+  kind: "support_resistance_map" as const,
+  title: "SR map",
+  symbols: ["NVDA"],
+  as_of: "2026-07-01T00:00:00Z",
+  valid_until: null,
+  session_label: null,
+  correlation_id: "live:kis_live:xyz",
+  account_scope: null,
+  content_hash: null,
+  version: 1,
+  readiness_label: "ready_for_order_review" as const,
+  is_stale: false,
+  created_by: "claude" as const,
+  created_at: "2026-07-01T00:00:00Z",
+  ...over,
+});
+
+const renderC = (props: Parameters<typeof ItemArtifactLinks>[0]) =>
+  render(
+    <MemoryRouter>
+      <ItemArtifactLinks {...props} />
+    </MemoryRouter>,
+  );
+
+describe("ItemArtifactLinks", () => {
+  it("fetches by correlationIds and labels '이 판단이 인용한 분석' when ids present", async () => {
+    const spy = vi.spyOn(api, "fetchArtifacts").mockResolvedValue({
+      success: true,
+      count: 1,
+      filters: {} as never,
+      artifacts: [meta()],
+    });
+    renderC({
+      symbol: "NVDA",
+      market: "us",
+      correlationIds: ["live:kis_live:xyz"],
+    });
+    fireEvent.click(screen.getByRole("button"));
+    await waitFor(() =>
+      expect(spy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          market: "us",
+          correlationIds: ["live:kis_live:xyz"],
+        }),
+      ),
+    );
+    expect(screen.getByText(/이 판단이 인용한 분석/)).toBeInTheDocument();
+    expect(screen.getByText("SR map")).toBeInTheDocument();
+  });
+
+  it("falls back to symbol fetch and labels '이 종목 최근' when no correlationIds", async () => {
+    const spy = vi.spyOn(api, "fetchArtifacts").mockResolvedValue({
+      success: true,
+      count: 1,
+      filters: {} as never,
+      artifacts: [meta()],
+    });
+    renderC({ symbol: "NVDA", market: "us", correlationIds: [] });
+    fireEvent.click(screen.getByRole("button"));
+    await waitFor(() =>
+      expect(spy).toHaveBeenCalledWith(
+        expect.objectContaining({ market: "us", symbol: "NVDA" }),
+      ),
+    );
+    expect(spy.mock.calls[0]?.[0]).not.toHaveProperty("correlationIds");
+    expect(screen.getByText(/이 종목 최근/)).toBeInTheDocument();
+  });
+
+  it("shows empty state when fetch returns no artifacts", async () => {
+    vi.spyOn(api, "fetchArtifacts").mockResolvedValue({
+      success: true,
+      count: 0,
+      filters: {} as never,
+      artifacts: [],
+    });
+    renderC({ symbol: "NVDA", market: "us", correlationIds: [] });
+    fireEvent.click(screen.getByRole("button"));
+    await waitFor(() =>
+      expect(screen.getByText("관련 아티팩트 없음")).toBeInTheDocument(),
+    );
+  });
+
+  it("renders nothing when there is neither a symbol nor correlationIds", () => {
+    const { container } = renderC({
+      symbol: null,
+      market: "us",
+      correlationIds: [],
+    });
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/frontend/invest/src/api/analysisArtifacts.ts
+++ b/frontend/invest/src/api/analysisArtifacts.ts
@@ -14,6 +14,7 @@ export interface ArtifactListQuery {
   symbol?: string;
   includeStale?: boolean;
   limit?: number;
+  correlationIds?: string[];
 }
 
 export async function fetchArtifacts(
@@ -25,6 +26,9 @@ export async function fetchArtifacts(
   if (params.readinessLabel) q.set("readiness_label", params.readinessLabel);
   if (params.symbol) q.set("symbol", params.symbol);
   if (params.includeStale) q.set("include_stale", "true");
+  if (params.correlationIds) {
+    for (const cid of params.correlationIds) q.append("correlation_id", cid);
+  }
   if (params.limit != null) q.set("limit", String(params.limit));
   const qs = q.toString();
   const res = await fetch(`${BASE}/${qs ? `?${qs}` : ""}`, {

--- a/frontend/invest/src/api/investmentReports.ts
+++ b/frontend/invest/src/api/investmentReports.ts
@@ -190,6 +190,7 @@ export function normalizeForecastLink(raw: ApiItem): ForecastLink {
     brierScore:
       raw.brier_score == null ? null : Number(raw.brier_score),
     resolutionSource: asOptionalString(raw.resolution_source) ?? null,
+    correlationId: asOptionalString(raw.correlation_id) ?? null,
   };
 }
 
@@ -205,6 +206,7 @@ export function normalizeRetrospectiveLink(
     triggerType: asOptionalString(raw.trigger_type) ?? null,
     pnlPct: raw.pnl_pct == null ? null : Number(raw.pnl_pct),
     createdAt: asOptionalString(raw.created_at) ?? null,
+    correlationId: asOptionalString(raw.correlation_id) ?? null,
   };
 }
 

--- a/frontend/invest/src/components/investment-reports/InvestmentReportBundleContent.tsx
+++ b/frontend/invest/src/components/investment-reports/InvestmentReportBundleContent.tsx
@@ -17,6 +17,7 @@ import type {
   InvestmentWatchAlert,
   InvestmentWatchEvent,
   NoActionSummary,
+  Market,
   ReportReviewSections,
   RetrospectiveLink,
   SnapshotFreshnessSummary,
@@ -24,6 +25,7 @@ import type {
 } from "../../types/investmentReports";
 import { ActionPacketView } from "./ActionPacketView";
 import { IntermediateAnalysisPanel } from "./IntermediateAnalysisPanel";
+import ItemArtifactLinks from "./ItemArtifactLinks";
 import { ProposalDiffPanel } from "./ProposalDiffPanel";
 import { ReportDiagnosticsPanel } from "./ReportDiagnosticsPanel";
 import { ReportSnapshotEvidencePanel } from "./ReportSnapshotEvidencePanel";
@@ -290,11 +292,13 @@ function ItemRow({
   decisions,
   forecastLinks,
   retrospectiveLinks,
+  market,
 }: {
   item: InvestmentReportItem;
   decisions: InvestmentReportItemDecision[];
   forecastLinks?: ForecastLink[];
   retrospectiveLinks?: RetrospectiveLink[];
+  market: Market;
 }) {
   const kindLabel = ITEM_KIND_LABELS[item.itemKind] ?? item.itemKind;
   const statusLabel = ITEM_STATUS_LABELS[item.status] ?? item.status;
@@ -416,7 +420,7 @@ function ItemRow({
           </span>
         </div>
       ) : null}
-      {tradeSetup ? (
+      {tradeSetup && item.itemKind === "action" ? (
         <div
           className="item-plan-vs-actual"
           data-testid="item-plan-vs-actual"
@@ -508,9 +512,11 @@ function ItemRow({
               >
                 <span>
                   {f.status === "closed"
-                    ? f.outcome
-                      ? "적중"
-                      : "빗나감"
+                    ? f.outcome == null
+                      ? "결과 미기록"
+                      : f.outcome
+                        ? "적중"
+                        : "빗나감"
                     : "해소 대기"}
                 </span>
                 {f.brierScore != null ? (
@@ -533,6 +539,18 @@ function ItemRow({
           )}
         </div>
       )}
+      <ItemArtifactLinks
+        symbol={item.symbol}
+        market={market}
+        correlationIds={Array.from(
+          new Set(
+            [
+              ...(forecastLinks ?? []).map((f) => f.correlationId),
+              ...(retrospectiveLinks ?? []).map((r) => r.correlationId),
+            ].filter((c): c is string => !!c),
+          ),
+        )}
+      />
       {item.watchCondition ? (
         <div
           style={{
@@ -754,12 +772,14 @@ function ReviewSectionsView({
   decisionsByItemUuid,
   forecastsByItemUuid,
   retrospectivesByItemUuid,
+  market,
 }: {
   review: ReportReviewSections;
   items: InvestmentReportItem[];
   decisionsByItemUuid: Record<string, InvestmentReportItemDecision[]>;
   forecastsByItemUuid: Record<string, ForecastLink[]>;
   retrospectivesByItemUuid: Record<string, RetrospectiveLink[]>;
+  market: Market;
 }) {
   const projectedUuids = new Set(
     review.sections.flatMap((section) => section.items.map((it) => it.itemUuid)),
@@ -788,6 +808,7 @@ function ReviewSectionsView({
                   retrospectiveLinks={
                     retrospectivesByItemUuid[item.itemUuid] ?? []
                   }
+                  market={market}
                 />
               ))
             ) : (
@@ -810,6 +831,7 @@ function ReviewSectionsView({
               retrospectiveLinks={
                 retrospectivesByItemUuid[item.itemUuid] ?? []
               }
+              market={market}
             />
           ))}
         </section>
@@ -943,6 +965,7 @@ export function InvestmentReportBundleContent({
           decisionsByItemUuid={bundle.decisionsByItemUuid}
           forecastsByItemUuid={bundle.forecastsByItemUuid ?? {}}
           retrospectivesByItemUuid={bundle.retrospectivesByItemUuid ?? {}}
+          market={bundle.report.market}
         />
       ) : (
         (["action", "watch", "risk"] as const).map((kind) =>
@@ -962,6 +985,7 @@ export function InvestmentReportBundleContent({
                   retrospectiveLinks={
                     bundle.retrospectivesByItemUuid?.[item.itemUuid] ?? []
                   }
+                  market={bundle.report.market}
                 />
               ))}
             </section>

--- a/frontend/invest/src/components/investment-reports/ItemArtifactLinks.tsx
+++ b/frontend/invest/src/components/investment-reports/ItemArtifactLinks.tsx
@@ -1,0 +1,147 @@
+import { useState } from "react";
+import { Link } from "react-router-dom";
+
+import { fetchArtifacts } from "../../api/analysisArtifacts";
+import { Pill } from "../../ds";
+import { stockDetailPath } from "../../stockDetailPath";
+import type { ArtifactMeta } from "../../types/analysisArtifacts";
+import type { Market } from "../../types/investmentReports";
+
+const KIND_LABEL: Record<string, string> = {
+  screening_ranking: "스크리닝 랭킹",
+  profit_taking_verdicts: "익절 판정",
+  support_resistance_map: "지지/저항",
+  flow_assessment: "수급 평가",
+  candidate_pool: "후보 풀",
+  session_summary: "세션 요약",
+  briefing: "브리핑",
+};
+
+type LoadState =
+  | { status: "idle" }
+  | { status: "loading" }
+  | { status: "ready"; rows: ArtifactMeta[] }
+  | { status: "error"; message: string };
+
+export default function ItemArtifactLinks({
+  symbol,
+  market,
+  correlationIds,
+}: {
+  symbol?: string | null;
+  market: Market;
+  correlationIds: string[];
+}) {
+  const [open, setOpen] = useState(false);
+  const [state, setState] = useState<LoadState>({ status: "idle" });
+
+  const byCorrelation = correlationIds.length > 0;
+  const hasTarget = byCorrelation || !!symbol;
+  if (!hasTarget) return null;
+
+  const headerLabel = byCorrelation
+    ? "이 판단이 인용한 분석"
+    : "이 종목 최근 분석 아티팩트";
+
+  async function load() {
+    setState({ status: "loading" });
+    try {
+      const res = await fetchArtifacts(
+        byCorrelation
+          ? { market, correlationIds, includeStale: true, limit: 10 }
+          : {
+              market,
+              symbol: symbol ?? undefined,
+              includeStale: true,
+              limit: 10,
+            },
+      );
+      setState({ status: "ready", rows: res.artifacts });
+    } catch (e) {
+      setState({
+        status: "error",
+        message: e instanceof Error ? e.message : String(e),
+      });
+    }
+  }
+
+  function toggle() {
+    const next = !open;
+    setOpen(next);
+    if (next && state.status === "idle") void load();
+  }
+
+  return (
+    <div className="item-artifact-links" data-testid="item-artifact-links">
+      <button
+        type="button"
+        onClick={toggle}
+        style={{
+          background: "none",
+          border: "none",
+          padding: 0,
+          fontSize: 12,
+          color: "var(--fg-2)",
+          cursor: "pointer",
+          fontWeight: 800,
+        }}
+      >
+        {open ? "▾" : "▸"} {headerLabel}
+      </button>
+      {open && state.status === "loading" ? (
+        <div style={{ fontSize: 12, color: "var(--fg-3)" }}>불러오는 중…</div>
+      ) : null}
+      {open && state.status === "error" ? (
+        <div style={{ fontSize: 12, color: "var(--fg-3)" }}>
+          아티팩트를 불러오지 못했습니다
+        </div>
+      ) : null}
+      {open && state.status === "ready" && state.rows.length === 0 ? (
+        <div style={{ fontSize: 12, color: "var(--fg-3)" }}>
+          관련 아티팩트 없음
+        </div>
+      ) : null}
+      {open && state.status === "ready" && state.rows.length > 0 ? (
+        <ul
+          style={{
+            margin: "4px 0 0",
+            paddingLeft: 0,
+            listStyle: "none",
+            display: "grid",
+            gap: 4,
+          }}
+        >
+          {state.rows.map((a) => (
+            <li
+              key={a.id}
+              style={{
+                fontSize: 12,
+                color: "var(--fg-2)",
+                display: "flex",
+                gap: 6,
+                alignItems: "center",
+                flexWrap: "wrap",
+              }}
+            >
+              <Pill size="sm" tone={a.is_stale ? "warn" : "paper"}>
+                {KIND_LABEL[a.kind] ?? a.kind}
+              </Pill>
+              <span>{a.title}</span>
+              <span style={{ color: "var(--fg-3)" }}>
+                {a.as_of.slice(0, 10)}
+              </span>
+              {a.symbols[0] ? (
+                <Link
+                  to={stockDetailPath(a.market, a.symbols[0]) ?? "#"}
+                  style={{ color: "var(--accent)" }}
+                >
+                  종목
+                </Link>
+              ) : null}
+            </li>
+          ))}
+        </ul>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/invest/src/types/investmentReports.ts
+++ b/frontend/invest/src/types/investmentReports.ts
@@ -253,6 +253,7 @@ export interface ForecastLink {
   probability: number;
   brierScore: number | null;
   resolutionSource: string | null;
+  correlationId?: string | null;
 }
 
 export interface RetrospectiveLink {
@@ -264,6 +265,7 @@ export interface RetrospectiveLink {
   triggerType: string | null;
   pnlPct: number | null;
   createdAt: string | null;
+  correlationId?: string | null;
 }
 
 export interface InvestmentReportItem {

--- a/tests/mcp_server/test_analyze_stock_batch_earnings.py
+++ b/tests/mcp_server/test_analyze_stock_batch_earnings.py
@@ -1,0 +1,65 @@
+"""ROB-722 — analyze_stock_batch earnings auto-inject attach pass."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.mcp_server.tooling import analysis_tool_handlers as h
+
+
+@pytest.mark.asyncio
+async def test_attach_earnings_injects_when_context_exists(monkeypatch):
+    async def _fake_build(symbol, market, *, today=None, kr_freshness=None):
+        return {
+            "symbol": symbol,
+            "market": market,
+            "has_upcoming": False,
+            "next_earnings": None,
+        }
+
+    async def _fake_kr_fresh(db):
+        return ("fresh", "2026-07-06")
+
+    monkeypatch.setattr(h, "build_earnings_context", _fake_build, raising=False)
+    monkeypatch.setattr(h, "_kr_ingestion_freshness", _fake_kr_fresh, raising=False)
+
+    results = {"NVDA": {"symbol": "NVDA", "market_type": "us"}}
+    await h._attach_earnings(results, market="us")
+
+    assert results["NVDA"]["earnings"]["has_upcoming"] is False
+
+
+@pytest.mark.asyncio
+async def test_attach_earnings_fail_open_on_error(monkeypatch):
+    async def _boom(symbol, market, *, today=None, kr_freshness=None):
+        raise RuntimeError("finnhub down")
+
+    monkeypatch.setattr(h, "build_earnings_context", _boom, raising=False)
+
+    results = {"NVDA": {"symbol": "NVDA", "market_type": "us"}}
+    await h._attach_earnings(results, market="us")  # must not raise
+
+    assert "earnings" not in results["NVDA"]
+
+
+@pytest.mark.asyncio
+async def test_attach_earnings_skips_error_and_crypto_rows(monkeypatch):
+    # Mirrors real build: None for crypto (skip), dict for equities. Error rows
+    # are skipped by _attach_earnings before build is ever called.
+    async def _fake_build(symbol, market, *, today=None, kr_freshness=None):
+        if str(market).strip().lower() == "crypto":
+            return None
+        return {"symbol": symbol}
+
+    monkeypatch.setattr(h, "build_earnings_context", _fake_build, raising=False)
+
+    results = {
+        "BADSYM": {"error": "not found"},
+        "BTC": {"symbol": "BTC", "market_type": "crypto"},
+        "NVDA": {"symbol": "NVDA", "market_type": "us"},
+    }
+    await h._attach_earnings(results, market=None)
+
+    assert "earnings" not in results["BADSYM"]  # error row skipped pre-build
+    assert "earnings" not in results["BTC"]  # build returns None → omit
+    assert results["NVDA"]["earnings"] == {"symbol": "NVDA"}  # equity attached

--- a/tests/mcp_server/test_analyze_stock_batch_earnings.py
+++ b/tests/mcp_server/test_analyze_stock_batch_earnings.py
@@ -1,10 +1,18 @@
-"""ROB-722 — analyze_stock_batch earnings auto-inject attach pass."""
+"""ROB-722 — analyze_stock_batch earnings auto-inject attach pass.
+
+Rows use the REAL ``market_type`` values that analyze_stock_batch produces
+(``resolve_market_type`` → equity_kr / equity_us / crypto). The original tests
+fabricated "us"/"kr" values that never occur in production, which let the
+{"kr","us"}-only market gate ship as a permanent no-op (post-merge
+verification blocker).
+"""
 
 from __future__ import annotations
 
 import pytest
 
 from app.mcp_server.tooling import analysis_tool_handlers as h
+from app.mcp_server.tooling import earnings_context as ec
 
 
 @pytest.mark.asyncio
@@ -23,7 +31,7 @@ async def test_attach_earnings_injects_when_context_exists(monkeypatch):
     monkeypatch.setattr(h, "build_earnings_context", _fake_build, raising=False)
     monkeypatch.setattr(h, "_kr_ingestion_freshness", _fake_kr_fresh, raising=False)
 
-    results = {"NVDA": {"symbol": "NVDA", "market_type": "us"}}
+    results = {"NVDA": {"symbol": "NVDA", "market_type": "equity_us"}}
     await h._attach_earnings(results, market="us")
 
     assert results["NVDA"]["earnings"]["has_upcoming"] is False
@@ -36,7 +44,7 @@ async def test_attach_earnings_fail_open_on_error(monkeypatch):
 
     monkeypatch.setattr(h, "build_earnings_context", _boom, raising=False)
 
-    results = {"NVDA": {"symbol": "NVDA", "market_type": "us"}}
+    results = {"NVDA": {"symbol": "NVDA", "market_type": "equity_us"}}
     await h._attach_earnings(results, market="us")  # must not raise
 
     assert "earnings" not in results["NVDA"]
@@ -44,22 +52,52 @@ async def test_attach_earnings_fail_open_on_error(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_attach_earnings_skips_error_and_crypto_rows(monkeypatch):
-    # Mirrors real build: None for crypto (skip), dict for equities. Error rows
-    # are skipped by _attach_earnings before build is ever called.
-    async def _fake_build(symbol, market, *, today=None, kr_freshness=None):
-        if str(market).strip().lower() == "crypto":
-            return None
-        return {"symbol": symbol}
+    # Real build_earnings_context with only the calendar fetch stubbed, so the
+    # market gate itself is under test (the false-green trap was mocking build
+    # entirely and feeding market values production never produces).
+    async def _fake_calendar(symbol, from_date, to_date, market):
+        return {"symbol": symbol, "source": "finnhub", "earnings": []}
 
-    monkeypatch.setattr(h, "build_earnings_context", _fake_build, raising=False)
+    monkeypatch.setattr(ec, "handle_get_earnings_calendar", _fake_calendar)
 
     results = {
         "BADSYM": {"error": "not found"},
-        "BTC": {"symbol": "BTC", "market_type": "crypto"},
-        "NVDA": {"symbol": "NVDA", "market_type": "us"},
+        "KRW-BTC": {"symbol": "KRW-BTC", "market_type": "crypto"},
+        "NVDA": {"symbol": "NVDA", "market_type": "equity_us"},
     }
     await h._attach_earnings(results, market=None)
 
     assert "earnings" not in results["BADSYM"]  # error row skipped pre-build
-    assert "earnings" not in results["BTC"]  # build returns None → omit
-    assert results["NVDA"]["earnings"] == {"symbol": "NVDA"}  # equity attached
+    assert "earnings" not in results["KRW-BTC"]  # non-equity → build returns None
+    earnings = results["NVDA"]["earnings"]  # real-gate regression (equity_us)
+    assert earnings["market"] == "us"
+    assert earnings["has_upcoming"] is False
+
+
+@pytest.mark.asyncio
+async def test_attach_earnings_equity_kr_triggers_freshness_once(monkeypatch):
+    # equity_kr rows must hit the KR freshness gate (normalized, not == "kr")
+    # and the batch must compute freshness at most once.
+    calls = {"fresh": 0}
+
+    async def _fake_calendar(symbol, from_date, to_date, market):
+        assert market == "kr"  # normalized before the calendar dispatch
+        return {"symbol": symbol, "source": "market_events", "earnings": []}
+
+    async def _fake_kr_fresh(db):
+        calls["fresh"] += 1
+        return ("stale", "2026-07-01")
+
+    monkeypatch.setattr(ec, "handle_get_earnings_calendar", _fake_calendar)
+    monkeypatch.setattr(h, "_kr_ingestion_freshness", _fake_kr_fresh, raising=False)
+
+    results = {
+        "005930": {"symbol": "005930", "market_type": "equity_kr"},
+        "000660": {"symbol": "000660", "market_type": "equity_kr"},
+    }
+    await h._attach_earnings(results, market="kr")
+
+    assert calls["fresh"] == 1
+    assert results["005930"]["earnings"]["market"] == "kr"
+    assert results["005930"]["earnings"]["freshness"] == "stale"
+    assert results["000660"]["earnings"]["data_as_of"] == "2026-07-01"

--- a/tests/mcp_server/test_earnings_context.py
+++ b/tests/mcp_server/test_earnings_context.py
@@ -1,0 +1,188 @@
+"""ROB-722 — earnings auto-inject context builder."""
+
+from __future__ import annotations
+
+import datetime
+
+import pytest
+
+from app.mcp_server.tooling import earnings_context as ec
+from app.services.market_events.freshness_service import STALE_AFTER_HOURS
+
+TODAY = datetime.date(2026, 7, 6)
+
+
+def test_map_timing_variants():
+    assert ec._map_timing("bmo") == "BMO"
+    assert ec._map_timing("AMC") == "AMC"
+    assert ec._map_timing("dmh") == "DMH"
+    assert ec._map_timing("") == "unknown"
+    assert ec._map_timing(None) == "unknown"
+    assert ec._map_timing("weird") == "unknown"
+
+
+def test_compact_earnings_us_upcoming_picks_nearest_future():
+    tool_result = {
+        "symbol": "NVDA",
+        "source": "finnhub",
+        "earnings": [
+            {"date": "2026-01-01", "hour": "amc"},  # past — excluded
+            {"date": "2026-07-25", "hour": "bmo", "eps_estimate": 0.9},
+            {
+                "date": "2026-07-18",
+                "hour": "amc",
+                "eps_estimate": 0.84,
+                "revenue_estimate": 26500000000,
+                "quarter": 2,
+                "year": 2026,
+            },
+        ],
+    }
+    ctx = ec._compact_earnings(
+        tool_result, today=TODAY, freshness="live", data_as_of=None
+    )
+    assert ctx["market"] == "us"
+    assert ctx["source"] == "finnhub"
+    assert ctx["freshness"] == "live"
+    assert ctx["window_days"] == 30
+    assert ctx["as_of"] == "2026-07-06"
+    assert "data_as_of" not in ctx
+    assert ctx["has_upcoming"] is True
+    ne = ctx["next_earnings"]
+    assert ne["date"] == "2026-07-18"  # nearest future, not the earlier past row
+    assert ne["d_minus"] == 12
+    assert ne["timing"] == "AMC"
+    assert ne["eps_estimate"] == 0.84
+    assert ne["quarter"] == 2
+
+
+def test_compact_earnings_no_upcoming_is_explicit_signal():
+    tool_result = {"symbol": "HCA", "source": "finnhub", "earnings": []}
+    ctx = ec._compact_earnings(
+        tool_result, today=TODAY, freshness="live", data_as_of=None
+    )
+    assert ctx["has_upcoming"] is False
+    assert ctx["next_earnings"] is None
+    assert ctx["note"] == "no scheduled earnings within 30 days"
+
+
+def test_compact_earnings_kr_carries_freshness_and_data_as_of():
+    tool_result = {
+        "symbol": "005930",
+        "market": "kr",
+        "source": "market_events",
+        "earnings": [
+            {
+                "date": "2026-07-25",
+                "time_hint": "unknown",
+                "status": "scheduled",
+                "quarter": 2,
+                "year": 2026,
+            },
+        ],
+    }
+    ctx = ec._compact_earnings(
+        tool_result, today=TODAY, freshness="stale", data_as_of="2026-07-01"
+    )
+    assert ctx["market"] == "kr"
+    assert ctx["source"] == "market_events"
+    assert ctx["freshness"] == "stale"
+    assert ctx["data_as_of"] == "2026-07-01"
+    assert ctx["next_earnings"]["timing"] == "unknown"
+    assert ctx["next_earnings"]["status"] == "scheduled"
+
+
+def test_compact_earnings_error_payload_degrades():
+    tool_result = {"symbol": "NVDA", "source": "finnhub", "error": "429 quota"}
+    ctx = ec._compact_earnings(
+        tool_result, today=TODAY, freshness="live", data_as_of=None
+    )
+    assert ctx["has_upcoming"] is False
+    assert ctx["next_earnings"] is None
+    assert "degraded" in ctx["note"]
+
+
+class _FakeScalarResult:
+    def __init__(self, value):
+        self._value = value
+
+    def scalar_one_or_none(self):
+        return self._value
+
+
+class _FakeDB:
+    def __init__(self, value):
+        self._value = value
+
+    async def execute(self, _stmt):
+        return _FakeScalarResult(self._value)
+
+
+@pytest.mark.asyncio
+async def test_kr_freshness_none_partition_is_unknown():
+    freshness, as_of = await ec._kr_ingestion_freshness(_FakeDB(None))
+    assert freshness == "unknown"
+    assert as_of is None
+
+
+@pytest.mark.asyncio
+async def test_kr_freshness_recent_is_fresh():
+    recent = datetime.datetime.now(datetime.UTC) - datetime.timedelta(hours=1)
+    freshness, as_of = await ec._kr_ingestion_freshness(_FakeDB(recent))
+    assert freshness == "fresh"
+    assert as_of == recent.date().isoformat()
+
+
+@pytest.mark.asyncio
+async def test_kr_freshness_old_is_stale():
+    old = datetime.datetime.now(datetime.UTC) - datetime.timedelta(
+        hours=STALE_AFTER_HOURS + 5
+    )
+    freshness, as_of = await ec._kr_ingestion_freshness(_FakeDB(old))
+    assert freshness == "stale"
+    assert as_of == old.date().isoformat()
+
+
+@pytest.mark.asyncio
+async def test_build_earnings_context_crypto_returns_none():
+    ctx = await ec.build_earnings_context("BTC", "crypto", today=TODAY)
+    assert ctx is None
+
+
+@pytest.mark.asyncio
+async def test_build_earnings_context_us_calls_handler_and_shapes(monkeypatch):
+    async def _fake_handler(symbol, from_date, to_date, market):
+        assert symbol == "NVDA"
+        assert market == "us"
+        assert from_date == "2026-07-06"
+        assert to_date == "2026-08-05"  # today + 30d
+        return {
+            "symbol": "NVDA",
+            "source": "finnhub",
+            "earnings": [{"date": "2026-07-18", "hour": "amc", "eps_estimate": 0.84}],
+        }
+
+    monkeypatch.setattr(ec, "handle_get_earnings_calendar", _fake_handler)
+    ctx = await ec.build_earnings_context("NVDA", "us", today=TODAY)
+    assert ctx["market"] == "us"
+    assert ctx["freshness"] == "live"
+    assert ctx["has_upcoming"] is True
+    assert ctx["next_earnings"]["d_minus"] == 12
+
+
+@pytest.mark.asyncio
+async def test_build_earnings_context_kr_uses_passed_freshness(monkeypatch):
+    async def _fake_handler(symbol, from_date, to_date, market):
+        return {
+            "symbol": "005930",
+            "market": "kr",
+            "source": "market_events",
+            "earnings": [{"date": "2026-07-25", "time_hint": "unknown"}],
+        }
+
+    monkeypatch.setattr(ec, "handle_get_earnings_calendar", _fake_handler)
+    ctx = await ec.build_earnings_context(
+        "005930", "kr", today=TODAY, kr_freshness=("stale", "2026-07-01")
+    )
+    assert ctx["freshness"] == "stale"
+    assert ctx["data_as_of"] == "2026-07-01"

--- a/tests/mcp_server/test_earnings_context.py
+++ b/tests/mcp_server/test_earnings_context.py
@@ -149,6 +149,33 @@ async def test_build_earnings_context_crypto_returns_none():
     assert ctx is None
 
 
+def test_normalize_earnings_market_accepts_real_market_type_values():
+    # resolve_market_type produces equity_kr/equity_us/crypto — the gate must
+    # accept the equity_* forms (the {"kr","us"}-only gate was a production
+    # no-op) while still taking the bare tool-param forms.
+    assert ec.normalize_earnings_market("equity_us") == "us"
+    assert ec.normalize_earnings_market("equity_kr") == "kr"
+    assert ec.normalize_earnings_market("us") == "us"
+    assert ec.normalize_earnings_market("kr") == "kr"
+    assert ec.normalize_earnings_market(" Equity_US ") == "us"
+    assert ec.normalize_earnings_market("crypto") is None
+    assert ec.normalize_earnings_market("") is None
+    assert ec.normalize_earnings_market(None) is None
+
+
+@pytest.mark.asyncio
+async def test_build_earnings_context_equity_us_passes_gate(monkeypatch):
+    async def _fake_handler(symbol, from_date, to_date, market):
+        assert market == "us"  # normalized before dispatch
+        return {"symbol": symbol, "source": "finnhub", "earnings": []}
+
+    monkeypatch.setattr(ec, "handle_get_earnings_calendar", _fake_handler)
+    ctx = await ec.build_earnings_context("NVDA", "equity_us", today=TODAY)
+    assert ctx is not None
+    assert ctx["market"] == "us"
+    assert ctx["has_upcoming"] is False
+
+
 @pytest.mark.asyncio
 async def test_build_earnings_context_us_calls_handler_and_shapes(monkeypatch):
     async def _fake_handler(symbol, from_date, to_date, market):

--- a/tests/routers/test_invest_artifacts_router.py
+++ b/tests/routers/test_invest_artifacts_router.py
@@ -129,3 +129,17 @@ def test_get_detail_includes_payload(monkeypatch):
 def test_get_detail_404(monkeypatch):
     client, _ = _make_client(monkeypatch, one=None)
     assert client.get("/trading/api/invest/artifacts/9").status_code == 404
+
+
+@pytest.mark.unit
+def test_list_forwards_correlation_ids(monkeypatch):
+    client, calls = _make_client(monkeypatch)
+    r = client.get(
+        "/trading/api/invest/artifacts/"
+        "?market=us&correlation_id=live:kis_live:abc&correlation_id=live:kis_live:def"
+    )
+    assert r.status_code == 200
+    assert calls["list"]["correlation_ids"] == [
+        "live:kis_live:abc",
+        "live:kis_live:def",
+    ]

--- a/tests/services/test_analysis_artifact_service.py
+++ b/tests/services/test_analysis_artifact_service.py
@@ -318,3 +318,62 @@ async def test_get_returns_none_for_missing(db_session: AsyncSession) -> None:
 
     assert await service.get(999_999_999) is None
     assert await service.get("not-a-uuid-or-int") is None
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_list_artifacts_filters_by_correlation_ids(
+    db_session: AsyncSession,
+) -> None:
+    service = AnalysisArtifactService(db_session)
+    sym = f"ZZ{uuid4().hex[:6].upper()}"
+    await service.save(
+        AnalysisArtifactSave.model_validate(
+            {
+                "market": "us",
+                "kind": "screening_ranking",
+                "title": "corr-a",
+                "symbols": [sym],
+                "payload": {"a": 1},
+                "as_of": "2026-07-02T01:00:00+00:00",
+                "created_by": "claude",
+                "correlation_id": "live:kis_live:aaa",
+            }
+        )
+    )
+    await service.save(
+        AnalysisArtifactSave.model_validate(
+            {
+                "market": "us",
+                "kind": "screening_ranking",
+                "title": "corr-b",
+                "symbols": [sym],
+                "payload": {"b": 2},
+                "as_of": "2026-07-02T01:00:00+00:00",
+                "created_by": "claude",
+                "correlation_id": "live:kis_live:bbb",
+            }
+        )
+    )
+    await service.save(
+        AnalysisArtifactSave.model_validate(
+            {
+                "market": "us",
+                "kind": "screening_ranking",
+                "title": "corr-c",
+                "symbols": [sym],
+                "payload": {"c": 3},
+                "as_of": "2026-07-02T01:00:00+00:00",
+                "created_by": "claude",
+                "correlation_id": "live:kis_live:ccc",
+            }
+        )
+    )
+    rows = await service.list_artifacts(
+        correlation_ids=["live:kis_live:aaa", "live:kis_live:bbb"],
+        include_stale=True,
+    )
+    assert {row.correlation_id for row in rows} == {
+        "live:kis_live:aaa",
+        "live:kis_live:bbb",
+    }

--- a/tests/test_investment_reports_item_loop_links.py
+++ b/tests/test_investment_reports_item_loop_links.py
@@ -114,6 +114,42 @@ async def test_retrospectives_grouped_by_item_uuid(db_session: AsyncSession) -> 
 
 
 @pytest.mark.asyncio
+async def test_forecast_projection_includes_correlation_id(
+    db_session: AsyncSession,
+) -> None:
+    item_uuid = uuid4()
+    db_session.add(
+        _forecast(
+            str(item_uuid),
+            correlation_id="live:kis_live:xyz",
+        )
+    )
+    await db_session.flush()
+
+    result = await list_forecasts_for_item_uuids(db_session, [item_uuid])
+
+    assert result[str(item_uuid)][0].correlation_id == "live:kis_live:xyz"
+
+
+@pytest.mark.asyncio
+async def test_retrospective_projection_includes_correlation_id(
+    db_session: AsyncSession,
+) -> None:
+    item_uuid = uuid4()
+    db_session.add(
+        _retro(
+            str(item_uuid),
+            correlation_id="live:kis_live:retro-1",
+        )
+    )
+    await db_session.flush()
+
+    result = await list_retrospectives_for_item_uuids(db_session, [item_uuid])
+
+    assert result[str(item_uuid)][0].correlation_id == "live:kis_live:retro-1"
+
+
+@pytest.mark.asyncio
 async def test_empty_input_returns_empty_dict(db_session: AsyncSession) -> None:
     assert await list_forecasts_for_item_uuids(db_session, []) == {}
     assert await list_retrospectives_for_item_uuids(db_session, []) == {}

--- a/tests/test_mcp_fundamentals_tools.py
+++ b/tests/test_mcp_fundamentals_tools.py
@@ -754,6 +754,19 @@ class TestAnalyzeStock:
 class TestAnalyzeStockBatch:
     """Test analyze_stock_batch tool."""
 
+    @pytest.fixture(autouse=True)
+    def _no_earnings_injection(self, monkeypatch):
+        # ROB-722 fix made the earnings attach actually fire for equity rows
+        # (the old {"kr","us"} gate never matched real equity_kr/equity_us
+        # market_type values). Left unstubbed it would mutate every compact
+        # contract here and reach live Finnhub for equity_us rows. Injection
+        # behavior is covered by tests/mcp_server/test_earnings_context.py and
+        # test_analyze_stock_batch_earnings.py.
+        async def _none(symbol, market, *, today=None, kr_freshness=None):
+            return None
+
+        _patch_runtime_attr(monkeypatch, "build_earnings_context", _none)
+
     async def test_analyze_stock_batch_registration(self):
         """Test that analyze_stock_batch is registered as an MCP tool."""
         tools = build_tools()


### PR DESCRIPTION
main → production 배포 머지.

포함: ROB-719(#1437) report_item_uuid 인덱스 migration×2 · ROB-718(#1438) 아이템별 artifacts 링크+표시 수정 · ROB-722(#1439) 실적 auto-inject · **#1440 722 게이트 수정**(equity_kr/equity_us 수용 — 미수정 시 no-op) · AGENTS docs.

전 커밋 main CI green + 머지후 적대검증(718/719/722 각 에이전트, 722 blocker는 #1440으로 수정 완료). 배포 시 alembic이 20260706_rob719 인덱스 적용.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Vo3Zcr43ktxA9jaZek5Gv