### PR TITLE
ci(codecov): add codecov.yml for shard-based status hygiene (ROB-724 Track C)

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,16 @@
+codecov:
+  notify:
+    after_n_builds: 4          # 4 샤드 모두 업로드된 뒤에만 상태/코멘트
+  require_ci_to_pass: true
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 0.3%        # carryforward 노이즈 흡수, 실 하락은 표면화
+    patch: off                 # 현재 non-required 유지 (게이트 승격은 별도 결정)
+comment:
+  after_n_builds: 4
+flag_management:
+  default_rules:
+    carryforward: true         # 샤드 업로드 누락 시 이전 값 carry → 부분병합 dip 제거


### PR DESCRIPTION
## ROB-724 — Track C: Codecov 표시 위생

베이스: `origin/main` tip `7dc6720d`
Linear: [ROB-724](https://linear.app/mgh3326/issue/ROB-724) (Backlog, Medium)

> 참고: 이전 PR #1442는 dead-code 커밋이 함께 들어가 닫혔음. 이번 PR은 codecov.yml 변경만 포함.

### 목적
프로젝트 커버리지는 **역대 최고(main 85.74%)**로 이미 건강함. PR 코멘트의 per-shard flag가 44~56%로 "낮아 보이는" 착시와 샤드 업로드 누락 커밋의 부분병합 dip(6/11 58.8% · 6/16 59.3% · 7/2 70.7%)이 원인.

이 PR은 **표시 위생**만 다룸 — 실제 커버리지 측정/게이트 변경 없음.

### 변경
신설 파일 `codecov.yml`:

```yaml
codecov:
  notify:
    after_n_builds: 4          # 4샤드 모두 업로드된 뒤에만 상태/코멘트
  require_ci_to_pass: true
coverage:
  status:
    project:
      default:
        target: auto
        threshold: 0.3%        # carryforward 노이즈 흡수, 실 하락은 표면화
    patch: off                 # 현재 non-required 유지 (게이트 승격은 별도 결정)
comment:
  after_n_builds: 4
flag_management:
  default_rules:
    carryforward: true         # 샤드 업로드 누락 시 이전 값 carry → 부분병합 dip 제거
```

### 효과
- 부분 업로드 dip 제거 (carryforward)
- 4샤드 모두 모일 때까지 PR 코멘트/상태 억제 (after_n_builds=4)
- 실 하락은 0.3% threshold로 여전히 표면화

### 트레이드오프 (명시)
- carryforward는 실 하락을 가릴 수 있어 `project.threshold: 0.3%` 동반
- codecov status를 required로 승격할지는 **이 PR 범위 밖** (현재 non-required 유지)

### 검증
- `curl --data-binary @codecov.yml https://codecov.io/validate` → **Valid!**
- flag 이름은 `default_rules`로 전 flag 적용 → `shard1-4` 개별 열거 불필요

### 후속
- **Track A** ([#1443](https://github.com/mgh3326/auto_trader/pull/1443)): dead-code 삭제 스윕 — 별도 PR (머지 독립)
- **Track B** (별도 이슈): 급소 테스트 (`orders/service.py` 13% → `account/service.py` 30% → ...)

🤖 Generated with [GJC](https://github.com/Yeachan-Heo/gajae-code)