### PR TITLE
fix(ROB-725): analyze_stock_batch KR 프리마켓/NXT 현재가 오버레이

### DIFF
--- a/app/mcp_server/tooling/analysis_analyze.py
+++ b/app/mcp_server/tooling/analysis_analyze.py
@@ -34,11 +34,13 @@ from app.mcp_server.tooling.market_data_indicators import (
     _split_support_resistance_levels,
 )
 from app.mcp_server.tooling.market_data_quotes import (
+    _apply_nxt_quote_overlay,
     _fetch_kr_live_quote,
     _fetch_quote_crypto,
     _fetch_quote_equity_kr,
     _fetch_quote_equity_us,
 )
+from app.mcp_server.tooling.market_session import kr_market_data_state
 from app.mcp_server.tooling.shared import (
     build_recommendation_for_equity as _build_recommendation_for_equity,
 )
@@ -114,6 +116,14 @@ async def _resolve_kr_quote(
         tradability = (await get_kr_nxt_tradability([symbol])).get(symbol)
         if tradability is not None:
             quote.update(tradability.public_fields())
+        # ROB-725: during NXT premarket/after-hours the KRX regular quote is the
+        # prior close — overlay the live NXT price so current_price + S/R
+        # distance_pct track the real market.
+        if await _apply_nxt_quote_overlay(
+            symbol, quote, data_state=kr_market_data_state()
+        ):
+            quote["is_stale_price"] = False
+            quote["price_as_of"] = now_kst().isoformat()
         return quote
 
     live = await _fetch_kr_live_quote(symbol)

--- a/app/mcp_server/tooling/analysis_tool_handlers.py
+++ b/app/mcp_server/tooling/analysis_tool_handlers.py
@@ -791,6 +791,12 @@ def _summarize_analysis_result(
         if _nxt_key in quote:
             summary[_nxt_key] = quote[_nxt_key]
 
+    # ROB-725: surface NXT price provenance so the agent knows current_price is
+    # an NXT-derived quote (not the stale KRX regular-session close).
+    for _px_key in ("price_source", "session", "data_state", "venue"):
+        if _px_key in quote:
+            summary[_px_key] = quote[_px_key]
+
     if position_index is not None:
         summary["position"] = _lookup_position_for_symbol(
             symbol=symbol,

--- a/app/mcp_server/tooling/market_data_quotes.py
+++ b/app/mcp_server/tooling/market_data_quotes.py
@@ -408,6 +408,29 @@ async def _fetch_nxt_quote_overlay(
     return overlay
 
 
+async def _apply_nxt_quote_overlay(
+    symbol: str, quote: dict[str, Any], *, data_state: str
+) -> bool:
+    """Overlay an NXT-derived price onto ``quote`` during NXT sessions (ROB-725).
+
+    In-place mutation: ``price`` becomes the NXT expected/mid/best price and
+    ``price_source``/``session``/``venue``/``data_state`` are tagged. Returns
+    ``True`` when applied. Returns ``False`` (no mutation) when not in an NXT
+    session or the NXT orderbook is empty. Never raises — fail-open to the base
+    quote.
+    """
+    session = await _nxt_quote_session(data_state)
+    if session is None:
+        return False
+    overlay = await _fetch_nxt_quote_overlay(symbol, session=session)
+    if overlay is None:
+        return False
+    quote.update(overlay)
+    quote["regular_session_data_state"] = data_state
+    quote["data_state"] = DATA_STATE_FRESH
+    return True
+
+
 def _build_orderbook_walls_for_side(
     levels: list[market_data_service.OrderbookLevel],
 ) -> list[dict[str, Any]]:
@@ -1227,14 +1250,8 @@ async def _get_quote_impl(
         tradability = (await get_kr_nxt_tradability([symbol])).get(symbol)
         if tradability is not None:
             quote.update(tradability.public_fields())
-        session = await _nxt_quote_session(data_state)
-        if session is not None:
-            overlay = await _fetch_nxt_quote_overlay(symbol, session=session)
-            if overlay is not None:
-                quote.update(overlay)
-                quote["regular_session_data_state"] = data_state
-                quote["data_state"] = DATA_STATE_FRESH
-                return quote
+        if await _apply_nxt_quote_overlay(symbol, quote, data_state=data_state):
+            return quote
 
         quote["data_state"] = data_state
         return quote

--- a/docs/superpowers/plans/2026-07-06-rob-725-analyze-batch-nxt-quote-overlay.md
+++ b/docs/superpowers/plans/2026-07-06-rob-725-analyze-batch-nxt-quote-overlay.md
@@ -1,0 +1,527 @@
+# ROB-725 analyze_stock_batch NXT Premarket Quote Overlay — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `analyze_stock_batch`'s KR `current_price` reflect the live NXT price during premarket/after-hours sessions (instead of the stale prior KRX close), so support/resistance `distance_pct` and order-price anchors track the real market.
+
+**Architecture:** The standalone `get_quote` tool already applies an NXT orderbook overlay during NXT sessions; the `analyze` KR quote path (`_fetch_kr_live_quote` → KIS `inquire_price(market="J")`) does not. Extract the overlay-application into a shared `_apply_nxt_quote_overlay` helper, refactor `get_quote` to use it (behavior-preserving), then wire it into `_resolve_kr_quote`. `distance_pct` self-corrects because `_recompute_intraday_support_resistance` re-anchors on `quote.price`. Surface `price_source`/`session`/`data_state`/`venue` in the compact batch formatter.
+
+**Tech Stack:** Python 3.13, pytest (`pytest-asyncio`), `uv run`, existing MCP tooling in `app/mcp_server/tooling/`.
+
+## Global Constraints
+
+- **read-only:** no broker/order/watch mutation; `get_orderbook(venue="nxt")` is a read call. — verbatim from spec.
+- **migration 0** — no DB/alembic changes.
+- **fail-open:** overlay failure (non-NXT session, empty orderbook, exception) always degrades to the existing KIS/OHLCV quote path — never raises.
+- **Behavior-preserving refactor:** existing `get_quote` NXT tests in `tests/test_mcp_quotes_tools.py` MUST stay green after Task 1.
+- Test run command prefix: `uv run pytest`. Lint/format before commit: `make format && make lint`.
+- Commit trailer on every commit:
+  `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`
+
+---
+
+### Task 1: Extract shared `_apply_nxt_quote_overlay` helper and refactor `get_quote`
+
+**Files:**
+- Modify: `app/mcp_server/tooling/market_data_quotes.py` — add helper after `_fetch_nxt_quote_overlay` (ends at line 408); refactor `_get_quote_impl` KR branch (lines 1219-1240).
+- Test: `tests/test_mcp_quotes_tools.py` (existing regression) + new unit test for the helper.
+
+**Interfaces:**
+- Produces: `async def _apply_nxt_quote_overlay(symbol: str, quote: dict[str, Any], *, data_state: str) -> bool` — mutates `quote` in place (sets `price`, `session`, `venue`, `venue_label`, `kis_market_code`, `source_endpoint`, `source_tr_id`, `price_source`, `regular_session_data_state`, `data_state`) and returns `True` when an NXT overlay was applied; returns `False` (no mutation) when not in an NXT session or the orderbook is empty. Never raises.
+- Consumes: existing module functions `_nxt_quote_session`, `_fetch_nxt_quote_overlay`, constant `DATA_STATE_FRESH` (all already in this module).
+
+- [ ] **Step 1: Write the failing unit test for the helper**
+
+Add to `tests/test_mcp_quotes_tools.py` (reuses the existing `_nxt_quote_book` helper at line 385):
+
+```python
+@pytest.mark.asyncio
+async def test_apply_nxt_quote_overlay_applies_in_premarket(monkeypatch):
+    from app.mcp_server.tooling import market_data_quotes
+
+    async def fake_session(data_state, *, now=None):
+        return "nxt_premarket"
+
+    async def fake_overlay(symbol, *, session):
+        return {
+            "price": 173500.0,
+            "session": session,
+            "venue": "nxt",
+            "price_source": "nxt_expected_price",
+        }
+
+    monkeypatch.setattr(market_data_quotes, "_nxt_quote_session", fake_session)
+    monkeypatch.setattr(market_data_quotes, "_fetch_nxt_quote_overlay", fake_overlay)
+
+    quote = {"symbol": "192820", "price": 168300.0, "source": "kis"}
+    applied = await market_data_quotes._apply_nxt_quote_overlay(
+        "192820", quote, data_state="premarket_unavailable"
+    )
+
+    assert applied is True
+    assert quote["price"] == 173500.0
+    assert quote["price_source"] == "nxt_expected_price"
+    assert quote["session"] == "nxt_premarket"
+    assert quote["data_state"] == "fresh"
+    assert quote["regular_session_data_state"] == "premarket_unavailable"
+
+
+@pytest.mark.asyncio
+async def test_apply_nxt_quote_overlay_noop_outside_session(monkeypatch):
+    from app.mcp_server.tooling import market_data_quotes
+
+    async def fake_session(data_state, *, now=None):
+        return None
+
+    monkeypatch.setattr(market_data_quotes, "_nxt_quote_session", fake_session)
+
+    quote = {"symbol": "192820", "price": 168300.0, "source": "kis"}
+    applied = await market_data_quotes._apply_nxt_quote_overlay(
+        "192820", quote, data_state="fresh"
+    )
+
+    assert applied is False
+    assert quote == {"symbol": "192820", "price": 168300.0, "source": "kis"}
+
+
+@pytest.mark.asyncio
+async def test_apply_nxt_quote_overlay_noop_on_empty_book(monkeypatch):
+    from app.mcp_server.tooling import market_data_quotes
+
+    async def fake_session(data_state, *, now=None):
+        return "nxt_premarket"
+
+    async def fake_overlay(symbol, *, session):
+        return None  # empty orderbook → _fetch_nxt_quote_overlay returns None
+
+    monkeypatch.setattr(market_data_quotes, "_nxt_quote_session", fake_session)
+    monkeypatch.setattr(market_data_quotes, "_fetch_nxt_quote_overlay", fake_overlay)
+
+    quote = {"symbol": "192820", "price": 168300.0}
+    applied = await market_data_quotes._apply_nxt_quote_overlay(
+        "192820", quote, data_state="premarket_unavailable"
+    )
+
+    assert applied is False
+    assert quote == {"symbol": "192820", "price": 168300.0}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_mcp_quotes_tools.py -k apply_nxt_quote_overlay -v`
+Expected: FAIL with `AttributeError: module ... has no attribute '_apply_nxt_quote_overlay'`.
+
+- [ ] **Step 3: Add the helper**
+
+In `app/mcp_server/tooling/market_data_quotes.py`, immediately after `_fetch_nxt_quote_overlay` (after its `return overlay` at line 408), add:
+
+```python
+async def _apply_nxt_quote_overlay(
+    symbol: str, quote: dict[str, Any], *, data_state: str
+) -> bool:
+    """Overlay an NXT-derived price onto ``quote`` during NXT sessions (ROB-725).
+
+    In-place mutation: ``price`` becomes the NXT expected/mid/best price and
+    ``price_source``/``session``/``venue``/``data_state`` are tagged. Returns
+    ``True`` when applied. Returns ``False`` (no mutation) when not in an NXT
+    session or the NXT orderbook is empty. Never raises — fail-open to the base
+    quote.
+    """
+    session = await _nxt_quote_session(data_state)
+    if session is None:
+        return False
+    overlay = await _fetch_nxt_quote_overlay(symbol, session=session)
+    if overlay is None:
+        return False
+    quote.update(overlay)
+    quote["regular_session_data_state"] = data_state
+    quote["data_state"] = DATA_STATE_FRESH
+    return True
+```
+
+- [ ] **Step 4: Refactor `_get_quote_impl` to use the helper (behavior-preserving)**
+
+Replace the KR branch in `_get_quote_impl` (current lines 1225-1240):
+
+```python
+        data_state = kr_market_data_state()
+        quote = await _fetch_quote_equity_kr(symbol)
+        tradability = (await get_kr_nxt_tradability([symbol])).get(symbol)
+        if tradability is not None:
+            quote.update(tradability.public_fields())
+        session = await _nxt_quote_session(data_state)
+        if session is not None:
+            overlay = await _fetch_nxt_quote_overlay(symbol, session=session)
+            if overlay is not None:
+                quote.update(overlay)
+                quote["regular_session_data_state"] = data_state
+                quote["data_state"] = DATA_STATE_FRESH
+                return quote
+
+        quote["data_state"] = data_state
+        return quote
+```
+
+with:
+
+```python
+        data_state = kr_market_data_state()
+        quote = await _fetch_quote_equity_kr(symbol)
+        tradability = (await get_kr_nxt_tradability([symbol])).get(symbol)
+        if tradability is not None:
+            quote.update(tradability.public_fields())
+        if await _apply_nxt_quote_overlay(symbol, quote, data_state=data_state):
+            return quote
+
+        quote["data_state"] = data_state
+        return quote
+```
+
+- [ ] **Step 5: Run helper tests + full get_quote regression suite**
+
+Run: `uv run pytest tests/test_mcp_quotes_tools.py -v`
+Expected: PASS — new `_apply_nxt_quote_overlay` tests pass AND all existing `test_get_quote_korean_equity_premarket_*` / `*_after_hours_*` / `*_empty_nxt_book_*` regression tests still pass.
+
+- [ ] **Step 6: Format, lint, commit**
+
+```bash
+make format && make lint
+git add app/mcp_server/tooling/market_data_quotes.py tests/test_mcp_quotes_tools.py
+git commit -m "refactor(ROB-725): extract _apply_nxt_quote_overlay shared helper
+
+Behavior-preserving extraction of the NXT overlay application from
+_get_quote_impl so the analyze path can reuse it (Task 2).
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Wire the NXT overlay into the analyze KR quote path
+
+**Files:**
+- Modify: `app/mcp_server/tooling/analysis_analyze.py` — imports (lines 36-41), `_resolve_kr_quote._annotate` (lines 113-117).
+- Test: `tests/test_analyze_stock_kr_live_price.py` (existing file for `_resolve_kr_quote`).
+
+**Interfaces:**
+- Consumes: `_apply_nxt_quote_overlay` (Task 1), `kr_market_data_state` (from `app.mcp_server.tooling.market_session`), `now_kst` (already imported at line 14).
+- Produces: `_resolve_kr_quote` now returns a quote whose `price` is NXT-derived during NXT sessions, with `is_stale_price=False` and `price_as_of=now_kst().isoformat()` on overlay; unchanged (KIS/OHLCV) otherwise.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/test_analyze_stock_kr_live_price.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_kr_quote_overlays_nxt_price_in_premarket(monkeypatch):
+    today = datetime.now(KST)
+
+    async def fake_live(symbol):
+        return {
+            "symbol": symbol,
+            "instrument_type": "equity_kr",
+            "price": 168300.0,  # stale KRX prior close
+            "source": "kis",
+            "price_as_of": (today - timedelta(days=1)).isoformat(),
+        }
+
+    async def fake_overlay(symbol, quote, *, data_state):
+        quote["price"] = 173500.0
+        quote["price_source"] = "nxt_expected_price"
+        quote["session"] = "nxt_premarket"
+        quote["data_state"] = "fresh"
+        return True
+
+    monkeypatch.setattr(analysis_analyze, "_fetch_kr_live_quote", fake_live)
+    monkeypatch.setattr(analysis_analyze, "_apply_nxt_quote_overlay", fake_overlay)
+    monkeypatch.setattr(analysis_analyze, "kr_market_data_state", lambda *a, **k: "premarket_unavailable")
+
+    quote = await analysis_analyze._resolve_kr_quote("192820", _ohlcv())
+
+    assert quote["price"] == 173500.0
+    assert quote["price_source"] == "nxt_expected_price"
+    assert quote["is_stale_price"] is False  # overlay price is fresh
+    # price_as_of refreshed to the live NXT fetch time (today, not yesterday)
+    assert quote["price_as_of"].startswith(str(today.date()))
+
+
+@pytest.mark.asyncio
+async def test_kr_quote_keeps_kis_price_when_no_overlay(monkeypatch):
+    today = datetime.now(KST)
+
+    async def fake_live(symbol):
+        return {
+            "symbol": symbol,
+            "instrument_type": "equity_kr",
+            "price": 168300.0,
+            "source": "kis",
+            "price_as_of": today.isoformat(),
+        }
+
+    async def fake_overlay(symbol, quote, *, data_state):
+        return False  # not an NXT session / empty book
+
+    monkeypatch.setattr(analysis_analyze, "_fetch_kr_live_quote", fake_live)
+    monkeypatch.setattr(analysis_analyze, "_apply_nxt_quote_overlay", fake_overlay)
+    monkeypatch.setattr(analysis_analyze, "kr_market_data_state", lambda *a, **k: "fresh")
+
+    quote = await analysis_analyze._resolve_kr_quote("192820", _ohlcv())
+
+    assert quote["price"] == 168300.0
+    assert "price_source" not in quote
+    assert quote["is_stale_price"] is False  # today's KIS as_of, unchanged
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_analyze_stock_kr_live_price.py -k "overlays_nxt or keeps_kis" -v`
+Expected: FAIL — `AttributeError` on `analysis_analyze._apply_nxt_quote_overlay` / `kr_market_data_state` (not yet imported).
+
+- [ ] **Step 3: Add imports**
+
+In `app/mcp_server/tooling/analysis_analyze.py`, extend the `market_data_quotes` import block (lines 36-41) to include the helper:
+
+```python
+from app.mcp_server.tooling.market_data_quotes import (
+    _apply_nxt_quote_overlay,
+    _fetch_kr_live_quote,
+    _fetch_quote_crypto,
+    _fetch_quote_equity_kr,
+    _fetch_quote_equity_us,
+)
+```
+
+Add a new import for the session classifier (place near the other `market_session`-adjacent imports, alphabetically within the tooling imports):
+
+```python
+from app.mcp_server.tooling.market_session import kr_market_data_state
+```
+
+- [ ] **Step 4: Apply overlay inside `_annotate`**
+
+In `_resolve_kr_quote`, replace the nested `_annotate` (current lines 113-117):
+
+```python
+    async def _annotate(quote: dict[str, Any]) -> dict[str, Any]:
+        tradability = (await get_kr_nxt_tradability([symbol])).get(symbol)
+        if tradability is not None:
+            quote.update(tradability.public_fields())
+        return quote
+```
+
+with:
+
+```python
+    async def _annotate(quote: dict[str, Any]) -> dict[str, Any]:
+        tradability = (await get_kr_nxt_tradability([symbol])).get(symbol)
+        if tradability is not None:
+            quote.update(tradability.public_fields())
+        # ROB-725: during NXT premarket/after-hours the KRX regular quote is the
+        # prior close — overlay the live NXT price so current_price + S/R
+        # distance_pct track the real market.
+        if await _apply_nxt_quote_overlay(
+            symbol, quote, data_state=kr_market_data_state()
+        ):
+            quote["is_stale_price"] = False
+            quote["price_as_of"] = now_kst().isoformat()
+        return quote
+```
+
+- [ ] **Step 5: Run the new tests + the existing `_resolve_kr_quote` suite**
+
+Run: `uv run pytest tests/test_analyze_stock_kr_live_price.py -v`
+Expected: PASS — new overlay tests pass AND existing `test_kr_live_price_today_is_not_stale` / `test_kr_prev_day_quote_is_stale` still pass (they monkeypatch `_fetch_kr_live_quote`; the real `_apply_nxt_quote_overlay` runs with `kr_market_data_state()` returning a non-NXT state in the test env → no-op).
+
+> Note: existing tests don't patch `_apply_nxt_quote_overlay`. If `kr_market_data_state()` in the test environment ever resolves to an NXT session and `_nxt_quote_session` hits the network, add `monkeypatch.setattr(analysis_analyze, "kr_market_data_state", lambda *a, **k: "market_closed")` to those two tests to keep them hermetic. Apply that only if the run in this step shows an unexpected overlay call.
+
+- [ ] **Step 6: Format, lint, commit**
+
+```bash
+make format && make lint
+git add app/mcp_server/tooling/analysis_analyze.py tests/test_analyze_stock_kr_live_price.py
+git commit -m "fix(ROB-725): overlay live NXT price in analyze_stock_batch KR quote
+
+_resolve_kr_quote now applies the shared NXT overlay so premarket/NXT
+current_price reflects the real NXT market instead of the prior KRX
+close. distance_pct self-corrects via _recompute_intraday_support_resistance.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Surface overlay provenance in the compact batch formatter
+
+**Files:**
+- Modify: `app/mcp_server/tooling/analysis_tool_handlers.py` — after the `nxt_tradable` passthrough loop (ends line 792, before `if position_index is not None:` at line 794).
+- Test: `tests/test_analyze_stock_batch_cache.py` (existing batch/formatter test file).
+
+**Interfaces:**
+- Consumes: `analysis["quote"]` fields set by Task 2 (`price_source`, `session`, `data_state`, `venue`).
+- Produces: compact summary rows carry `price_source`/`session`/`data_state`/`venue` when present on the quote.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/test_analyze_stock_batch_cache.py`:
+
+```python
+def test_summarize_surfaces_nxt_price_provenance():
+    from app.mcp_server.tooling.analysis_tool_handlers import (
+        _summarize_analysis_result,
+    )
+
+    analysis = {
+        "market_type": "equity_kr",
+        "source": "kis",
+        "quote": {
+            "price": 173500.0,
+            "price_source": "nxt_expected_price",
+            "session": "nxt_premarket",
+            "data_state": "fresh",
+            "venue": "nxt",
+        },
+        "support_resistance": {"supports": [], "resistances": []},
+    }
+
+    summary = _summarize_analysis_result("192820", analysis)
+
+    assert summary["current_price"] == 173500.0
+    assert summary["price_source"] == "nxt_expected_price"
+    assert summary["session"] == "nxt_premarket"
+    assert summary["data_state"] == "fresh"
+    assert summary["venue"] == "nxt"
+
+
+def test_summarize_omits_price_provenance_when_absent():
+    from app.mcp_server.tooling.analysis_tool_handlers import (
+        _summarize_analysis_result,
+    )
+
+    analysis = {
+        "market_type": "equity_kr",
+        "source": "kis",
+        "quote": {"price": 168300.0},
+        "support_resistance": {"supports": [], "resistances": []},
+    }
+
+    summary = _summarize_analysis_result("192820", analysis)
+
+    assert summary["current_price"] == 168300.0
+    assert "price_source" not in summary
+    assert "session" not in summary
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_analyze_stock_batch_cache.py -k "price_provenance" -v`
+Expected: FAIL — `KeyError`/`assert` on `summary["price_source"]` (not yet surfaced).
+
+- [ ] **Step 3: Add the passthrough loop**
+
+In `app/mcp_server/tooling/analysis_tool_handlers.py`, immediately after the existing `nxt_tradable` passthrough loop (after line 792, before `if position_index is not None:`), add:
+
+```python
+    # ROB-725: surface NXT price provenance so the agent knows current_price is
+    # an NXT-derived quote (not the stale KRX regular-session close).
+    for _px_key in ("price_source", "session", "data_state", "venue"):
+        if _px_key in quote:
+            summary[_px_key] = quote[_px_key]
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_analyze_stock_batch_cache.py -k "price_provenance" -v`
+Expected: PASS.
+
+- [ ] **Step 5: Format, lint, commit**
+
+```bash
+make format && make lint
+git add app/mcp_server/tooling/analysis_tool_handlers.py tests/test_analyze_stock_batch_cache.py
+git commit -m "feat(ROB-725): surface NXT price provenance in compact batch summary
+
+price_source/session/data_state/venue passthrough so agents can tell an
+NXT-derived current_price from the KRX regular close.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: End-to-end verification — distance_pct re-anchors on the NXT price
+
+**Files:**
+- Test: `tests/test_analyze_stock_batch_cache.py` (or the pipeline compat test file if better suited).
+
+**Interfaces:**
+- Consumes: the full `analyze_stock_impl` path with Task 2's overlay + `_recompute_intraday_support_resistance`.
+- Produces: proof that `support_resistance.distance_basis_price` equals the NXT price and `distance_pct` is computed against it.
+
+- [ ] **Step 1: Write the failing/verifying test**
+
+Add to `tests/test_analyze_stock_batch_cache.py`. Verify the intraday re-sign uses the overlaid price by calling the real `_recompute_intraday_support_resistance` with an NXT-overlaid quote:
+
+```python
+def test_intraday_sr_reanchors_on_nxt_overlay_price():
+    from app.mcp_server.tooling.analysis_analyze import (
+        _recompute_intraday_support_resistance,
+    )
+
+    analysis = {
+        "quote": {"price": 173500.0, "price_source": "nxt_expected_price"},
+        "support_resistance": {
+            # EOD levels computed against the stale 168300 close
+            "supports": [{"price": 170000.0, "distance_pct": 1.01}],
+            "resistances": [{"price": 171387.0, "distance_pct": 1.83}],
+        },
+    }
+
+    _recompute_intraday_support_resistance(analysis, "equity_kr")
+
+    sr = analysis["support_resistance"]
+    assert sr["distance_basis_price"] == 173500.0
+    assert sr["distance_basis"] == "live_quote"
+    # 170000 and 171387 are BELOW the 173500 NXT price → both become supports
+    support_prices = {s["price"] for s in sr["supports"]}
+    assert support_prices == {170000.0, 171387.0}
+    assert sr["resistances"] == []
+```
+
+- [ ] **Step 2: Run test**
+
+Run: `uv run pytest tests/test_analyze_stock_batch_cache.py -k "reanchors_on_nxt" -v`
+Expected: PASS immediately (Task 2 already fixed the quote; this test documents the end-to-end contract that no distance-recompute code change was needed). If it FAILS, `_recompute_intraday_support_resistance` is not reading `quote.price` as expected — stop and investigate before continuing.
+
+- [ ] **Step 3: Run the full affected suites**
+
+Run:
+```bash
+uv run pytest tests/test_analyze_stock_kr_live_price.py tests/test_mcp_quotes_tools.py tests/test_analyze_stock_batch_cache.py tests/mcp_server/test_analyze_stock_pipeline_compat.py -v
+```
+Expected: PASS (all green).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/test_analyze_stock_batch_cache.py
+git commit -m "test(ROB-725): assert intraday S/R distance re-anchors on NXT overlay price
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Spec §설계.1 (shared helper) → Task 1. ✓
+- Spec §설계.2 (wire into `_resolve_kr_quote`, `is_stale_price=False`, `price_as_of=now`) → Task 2. ✓
+- Spec §설계.2 (distance_pct auto-correction, no code change) → Task 4 verifies. ✓
+- Spec §설계.3 (compact formatter passthrough of `price_source`/`session`/`data_state`/`venue`) → Task 3. ✓
+- Spec §테스트 items 1-6 → Task 1 (helper apply/noop/empty = spec tests 1-3 at helper level), Task 2 (analyze wiring = spec tests 1-3 at `_resolve_kr_quote` level), Task 3 (spec test 5, compact surface), Task 4 (spec test 4, distance re-anchor), Task 1 Step 5 (spec test 6, `_get_quote_impl` regression). ✓
+- Spec §안전 경계 (read-only, migration 0, fail-open, session-gated network) → Global Constraints + helper fail-open in Task 1. ✓
+- Spec §범위 밖 (naver TTL, premarket_gap, quote_staleness_sec) → not planned. ✓
+
+**Placeholder scan:** No TBD/TODO; every code step shows full code. ✓
+
+**Type consistency:** `_apply_nxt_quote_overlay(symbol: str, quote: dict, *, data_state: str) -> bool` defined in Task 1 and called identically in Task 1 Step 4, Task 2 Step 4 (via `analysis_analyze` import), and monkeypatched with matching `(symbol, quote, *, data_state)` signature in Task 2 Step 1. `kr_market_data_state()` no-arg call consistent. `price_source`/`session`/`data_state`/`venue` key names consistent across Tasks 2, 3, 4. ✓

--- a/docs/superpowers/specs/2026-07-06-rob-725-analyze-batch-nxt-quote-overlay-design.md
+++ b/docs/superpowers/specs/2026-07-06-rob-725-analyze-batch-nxt-quote-overlay-design.md
@@ -1,0 +1,203 @@
+# ROB-725 — analyze_stock_batch KR 프리마켓/NXT 현재가 오버레이
+
+**날짜:** 2026-07-06
+**이슈:** ROB-725 (Medium)
+**범위:** 코어만 — NXT 오버레이 미러링 (TTL 단축·premarket_gap warning·quote_staleness_sec 제외)
+
+## 문제
+
+`analyze_stock_batch`의 KR `current_price`가 프리마켓(08:00~09:00 KST)·NXT
+세션에서 실시간 호가보다 지연된다. 에이전트가 이 지연된 가격 기준으로 저항/지지
+`distance_pct`를 계산해 매도/매수 지정가를 앵커하면 실시장과 괴리된 주문가가 나온다.
+
+**실측 (2026-07-06 프리마켓):** 08:05 `analyze_stock_batch(192820)` →
+`current_price 168300`, 저항 171,387. 이 값 기준 매도 지정가 171,000 접수 →
+08:10 실제 NXT 체결 173,500 (실시장이 조회 시세보다 +3.1% 위). 08:36 재조회도
+동일 168300.
+
+## 근본 원인 (조사 완료 — venue-stale, cache-stale 아님)
+
+두 경로가 독립적으로 응답을 채운다:
+
+1. **Quote 경로 (매 호출 재계산):** `analyze_stock_impl`
+   (`analysis_analyze.py:726`) → `_prepare_quote_tasks` → `_resolve_kr_quote`
+   (`analysis_analyze.py:106`) → `_fetch_kr_live_quote`
+   (`market_data_quotes.py:594`) → **`KISClient.inquire_price(code, market="J")`
+   단일 호출.** `market="J"`는 KRX **정규장** 마켓 코드다. 프리마켓엔 정규장이
+   닫혀 있어 KIS가 **전일 정규장 종가**를 반환한다. 이 경로엔 NXT 오버레이가 없다.
+
+2. **Fetch-cache 경로 (naver 스냅샷만):** `_fetch_kr_snapshot_cached` →
+   `analyze_cache` (TTL 15:35 KST까지, 세션-비인식) → `_apply_fetch_cache_metadata`
+   (`analysis_analyze.py:625`)가 `cache_hit=true` + 프리즌된 `derived_as_of`를 생성.
+
+**red herring:** 응답의 `cache_hit:true`/`derived_as_of:08:05`는 **naver
+펀더멘털 스냅샷** 캐시 메타데이터로 quote와 **무관**하다. 운영자가 이를 "가격이
+캐시됨"으로 오인했으나, 실제 quote는 매 호출 라이브 fetch되며 단지 **잘못된
+venue(KRX 정규장)**에서 온다.
+
+**대조 — 독립 `get_quote` 도구엔 이미 오버레이가 있다:** `_get_quote_impl`
+(`market_data_quotes.py:1202`)은 ROB-464/ROB-511로 NXT 세션 감지
+(`_nxt_quote_session`, `:324`)와 NXT 오버레이(`_fetch_nxt_quote_overlay`, `:379`
+→ NXT 호가창 expected_price → mid → best_ask → best_bid)를 이미 적용한다
+(`:1225-1237`). **analyze 경로만 이 오버레이가 누락됐다.**
+
+**추가 관측:** `_resolve_kr_quote`는 이미 `is_stale_price`를 태그하지만
+(`compute_is_stale`, `freshness.py:16`) **date-granularity**라서 오늘 날짜의 전일
+종가는 stale로 잡히지 않는다.
+
+## 수용 기준 (이슈)
+
+프리마켓 조회 시 `current_price`가 실 NXT 호가와 ±0.5% 내 일치하거나, 불일치 시
+staleness가 응답에 표기돼 에이전트가 보정 가능. → NXT 오버레이가 첫 번째 조건
+(정확한 NXT 가격)을 충족한다.
+
+## 설계
+
+### 1. 공유 오버레이 헬퍼 추출 (`market_data_quotes.py`)
+
+`_get_quote_impl`(`:1230-1237`)에 인라인된 오버레이 적용 로직을 헬퍼로 추출:
+
+```python
+async def _apply_nxt_quote_overlay(
+    symbol: str, quote: dict[str, Any], *, data_state: str
+) -> bool:
+    """NXT 세션이면 quote에 NXT 파생가를 오버레이한다. 적용 시 True.
+
+    quote를 in-place 수정: price → NXT expected/mid/best, price_source/session/
+    venue 태그, data_state=fresh. NXT 세션이 아니거나 호가창 empty면 no-op(False).
+    """
+    session = await _nxt_quote_session(data_state)
+    if session is None:
+        return False
+    overlay = await _fetch_nxt_quote_overlay(symbol, session=session)
+    if overlay is None:
+        return False
+    quote.update(overlay)
+    quote["regular_session_data_state"] = data_state
+    quote["data_state"] = DATA_STATE_FRESH
+    return True
+```
+
+`_get_quote_impl`은 이 헬퍼를 호출하도록 리팩터한다 (동작 불변 — 기존
+`get_quote` 테스트로 회귀 보증). 리팩터 후 `_get_quote_impl`:
+
+```python
+data_state = kr_market_data_state()
+quote = await _fetch_quote_equity_kr(symbol)
+tradability = (await get_kr_nxt_tradability([symbol])).get(symbol)
+if tradability is not None:
+    quote.update(tradability.public_fields())
+if await _apply_nxt_quote_overlay(symbol, quote, data_state=data_state):
+    return quote
+quote["data_state"] = data_state
+return quote
+```
+
+### 2. analyze KR quote에 배선 (`analysis_analyze.py::_resolve_kr_quote`)
+
+base quote(라이브 KIS `_fetch_kr_live_quote` 또는 일봉 fallback) + tradability
+annotate **후** 오버레이를 적용한다. `kr_market_data_state()`로 `data_state`를 구한다.
+오버레이 적용 시 가격이 NXT-fresh이므로 `is_stale_price=False`,
+`price_as_of=now_kst().isoformat()`(라이브 호가창 fetch 시각 — 정직한 quote_asof)로
+갱신한다. 세션 외/호가창 empty면 기존 KIS 경로 그대로(graceful).
+
+```python
+async def _resolve_kr_quote(symbol, ohlcv_df):
+    trading_date = datetime.now(_KST).date()
+
+    async def _finalize(quote):
+        # tradability annotate (기존 _annotate)
+        tradability = (await get_kr_nxt_tradability([symbol])).get(symbol)
+        if tradability is not None:
+            quote.update(tradability.public_fields())
+        # ROB-725: NXT 세션이면 NXT 파생가로 오버레이
+        if await _apply_nxt_quote_overlay(
+            symbol, quote, data_state=kr_market_data_state()
+        ):
+            quote["is_stale_price"] = False
+            quote["price_as_of"] = now_kst().isoformat()
+        return quote
+
+    live = await _fetch_kr_live_quote(symbol)
+    if live is not None:
+        as_of_dt = ...  # 기존 로직
+        live["is_stale_price"] = compute_is_stale("price", as_of_dt, trading_date=trading_date)
+        return await _finalize(live)
+
+    fallback = _build_kr_quote_from_ohlcv(symbol, ohlcv_df)
+    if fallback is None:
+        return None
+    ...  # 기존 fallback as_of/is_stale_price 세팅
+    return await _finalize(fallback)
+```
+
+`_apply_nxt_quote_overlay`, `_nxt_quote_session`, `kr_market_data_state`는
+`market_data_quotes` / `market_session`에서 import한다 (`market_data_quotes`는
+`analysis_analyze.py:36`에서 이미 import 중).
+
+**distance_pct 자동 보정:** `_recompute_intraday_support_resistance`
+(`analysis_analyze.py:536`, `:559`)가 `quote.get("price")`를 basis로 S/R distance를
+재산정한다. quote.price가 NXT가로 바뀌면 distance_pct는 **코드 변경 없이 자동
+보정**된다.
+
+### 3. compact 포맷터 노출 (`analysis_tool_handlers.py::_summarize_analysis_result`)
+
+기존 `nxt_tradable*` passthrough 루프(`:785-792`) 옆에 오버레이 필드 passthrough를
+추가한다 (존재할 때만):
+
+```python
+for _px_key in ("price_source", "session", "data_state", "venue"):
+    if _px_key in quote:
+        summary[_px_key] = quote[_px_key]
+```
+
+→ 에이전트가 `current_price`가 NXT 파생가(`price_source=nxt_expected_price` 등)임을
+compact 응답에서 인지한다.
+
+## 범위 밖 (의도적 제외)
+
+- **naver TTL 단축 (이슈 제안 #2):** quote와 무관한 red herring. 펀더멘털은
+  프리마켓에 안 변하므로 15:35 TTL이 정당하다.
+- **premarket_gap warning (제안 #4):** 별도 후속.
+- **quote_staleness_sec 명시 필드:** NXT 오버레이가 정확한 가격을 주므로 불필요.
+  KRX fallback 잔여 staleness는 기존 `is_stale_price`로 커버.
+
+## 데이터 흐름 (수정 후, KR 프리마켓)
+
+```
+_resolve_kr_quote
+  → _fetch_kr_live_quote (KIS market="J", 전일 종가)   [base]
+  → tradability annotate
+  → _apply_nxt_quote_overlay(data_state)
+       → _nxt_quote_session → "nxt_premarket"
+       → _fetch_nxt_quote_overlay → get_orderbook(venue="nxt")
+       → quote.price = NXT expected_price/mid, data_state=fresh, price_source=nxt_*
+       → is_stale_price=False, price_as_of=now
+  → quote → analysis["quote"]
+  → _recompute_intraday_support_resistance (quote.price 기준 distance_pct 재산정)
+  → _summarize_analysis_result (current_price + price_source/session 노출)
+```
+
+## 테스트
+
+1. **NXT 세션 오버레이:** `_nxt_quote_session`→"nxt_premarket",
+   `_fetch_nxt_quote_overlay`→NXT가 모킹. `_resolve_kr_quote` 결과
+   `quote.price == NXT가`, `price_source` set, `data_state=fresh`,
+   `is_stale_price=False`.
+2. **세션 외 유지:** `_nxt_quote_session`→None. quote.price == KIS price,
+   오버레이 필드 없음.
+3. **호가창 empty graceful:** `_fetch_nxt_quote_overlay`→None. KIS price 유지,
+   예외 없음.
+4. **distance_pct 재-앵커:** analyze 결과에서 S/R `distance_basis_price` ==
+   NXT가, distance_pct가 NXT가 기준.
+5. **compact 노출:** `_summarize_analysis_result`가 오버레이 있을 때
+   `price_source`/`session` surface.
+6. **`_get_quote_impl` 회귀:** 헬퍼 추출 후 기존 get_quote NXT 테스트 green.
+
+## 안전 경계
+
+- **read-only:** 브로커/주문/감시 mutation 없음. `get_orderbook`은 read.
+- **migration 0.**
+- **추가 네트워크:** NXT 세션(08:00-09:00, 15:30-20:00)에만 심볼당
+  `get_orderbook(venue="nxt")` 1콜 추가. 배치는 심볼별 concurrent. 세션 외 오버헤드 0.
+- **fail-open:** 오버레이 실패 시 항상 KIS 경로로 degrade.

--- a/tests/test_analyze_stock_batch_cache.py
+++ b/tests/test_analyze_stock_batch_cache.py
@@ -881,3 +881,28 @@ def test_summarize_omits_price_provenance_when_absent():
     assert summary["current_price"] == 168300.0
     assert "price_source" not in summary
     assert "session" not in summary
+
+
+def test_intraday_sr_reanchors_on_nxt_overlay_price():
+    from app.mcp_server.tooling.analysis_analyze import (
+        _recompute_intraday_support_resistance,
+    )
+
+    analysis = {
+        "quote": {"price": 173500.0, "price_source": "nxt_expected_price"},
+        "support_resistance": {
+            # EOD levels computed against the stale 168300 close
+            "supports": [{"price": 170000.0, "distance_pct": 1.01}],
+            "resistances": [{"price": 171387.0, "distance_pct": 1.83}],
+        },
+    }
+
+    _recompute_intraday_support_resistance(analysis, "equity_kr")
+
+    sr = analysis["support_resistance"]
+    assert sr["distance_basis_price"] == 173500.0
+    assert sr["distance_basis"] == "live_quote"
+    # 170000 and 171387 are BELOW the 173500 NXT price → both become supports
+    support_prices = {s["price"] for s in sr["supports"]}
+    assert support_prices == {170000.0, 171387.0}
+    assert sr["resistances"] == []

--- a/tests/test_analyze_stock_batch_cache.py
+++ b/tests/test_analyze_stock_batch_cache.py
@@ -835,3 +835,49 @@ async def test_batch_error_row_carries_cache_metadata(monkeypatch):
     assert "error" in row
     assert row["cache_hit"] is False
     assert row["derived_as_of"] is None
+
+
+def test_summarize_surfaces_nxt_price_provenance():
+    from app.mcp_server.tooling.analysis_tool_handlers import (
+        _summarize_analysis_result,
+    )
+
+    analysis = {
+        "market_type": "equity_kr",
+        "source": "kis",
+        "quote": {
+            "price": 173500.0,
+            "price_source": "nxt_expected_price",
+            "session": "nxt_premarket",
+            "data_state": "fresh",
+            "venue": "nxt",
+        },
+        "support_resistance": {"supports": [], "resistances": []},
+    }
+
+    summary = _summarize_analysis_result("192820", analysis)
+
+    assert summary["current_price"] == 173500.0
+    assert summary["price_source"] == "nxt_expected_price"
+    assert summary["session"] == "nxt_premarket"
+    assert summary["data_state"] == "fresh"
+    assert summary["venue"] == "nxt"
+
+
+def test_summarize_omits_price_provenance_when_absent():
+    from app.mcp_server.tooling.analysis_tool_handlers import (
+        _summarize_analysis_result,
+    )
+
+    analysis = {
+        "market_type": "equity_kr",
+        "source": "kis",
+        "quote": {"price": 168300.0},
+        "support_resistance": {"supports": [], "resistances": []},
+    }
+
+    summary = _summarize_analysis_result("192820", analysis)
+
+    assert summary["current_price"] == 168300.0
+    assert "price_source" not in summary
+    assert "session" not in summary

--- a/tests/test_analyze_stock_kr_live_price.py
+++ b/tests/test_analyze_stock_kr_live_price.py
@@ -10,6 +10,23 @@ from app.mcp_server.tooling import analysis_analyze
 KST = ZoneInfo("Asia/Seoul")
 
 
+@pytest.fixture(autouse=True)
+def _no_nxt_overlay_by_default(monkeypatch):
+    """ROB-725: keep _resolve_kr_quote tests hermetic.
+
+    Without this guard, tests that don't mock the overlay would trigger the REAL
+    _apply_nxt_quote_overlay during the 15:30–20:00 KST NXT-after wall-clock
+    window (session detection is wall-clock gated, not data_state gated), firing
+    a live get_orderbook network call that can overwrite the mocked price. Tests
+    that exercise the overlay set their own fake, which overrides this default.
+    """
+
+    async def _noop(symbol, quote, *, data_state):
+        return False
+
+    monkeypatch.setattr(analysis_analyze, "_apply_nxt_quote_overlay", _noop)
+
+
 def _ohlcv():
     # 전일 일봉(어제 날짜) — fallback 경로용
     yesterday = pd.Timestamp(datetime.now(KST).date() - timedelta(days=1))

--- a/tests/test_analyze_stock_kr_live_price.py
+++ b/tests/test_analyze_stock_kr_live_price.py
@@ -83,3 +83,69 @@ async def test_kr_live_failure_falls_back_to_ohlcv_stale(monkeypatch):
     assert quote["price"] == 105.0  # 일봉 종가 fallback
     assert quote["is_stale_price"] is True
     assert quote["price_as_of"] is not None
+
+
+@pytest.mark.asyncio
+async def test_kr_quote_overlays_nxt_price_in_premarket(monkeypatch):
+    today = datetime.now(KST)
+
+    async def fake_live(symbol):
+        return {
+            "symbol": symbol,
+            "instrument_type": "equity_kr",
+            "price": 168300.0,  # stale KRX prior close
+            "source": "kis",
+            "price_as_of": (today - timedelta(days=1)).isoformat(),
+        }
+
+    async def fake_overlay(symbol, quote, *, data_state):
+        quote["price"] = 173500.0
+        quote["price_source"] = "nxt_expected_price"
+        quote["session"] = "nxt_premarket"
+        quote["data_state"] = "fresh"
+        return True
+
+    monkeypatch.setattr(analysis_analyze, "_fetch_kr_live_quote", fake_live)
+    monkeypatch.setattr(analysis_analyze, "_apply_nxt_quote_overlay", fake_overlay)
+    monkeypatch.setattr(
+        analysis_analyze,
+        "kr_market_data_state",
+        lambda *a, **k: "premarket_unavailable",
+    )
+
+    quote = await analysis_analyze._resolve_kr_quote("192820", _ohlcv())
+
+    assert quote["price"] == 173500.0
+    assert quote["price_source"] == "nxt_expected_price"
+    assert quote["is_stale_price"] is False  # overlay price is fresh
+    # price_as_of refreshed to the live NXT fetch time (today, not yesterday)
+    assert quote["price_as_of"].startswith(str(today.date()))
+
+
+@pytest.mark.asyncio
+async def test_kr_quote_keeps_kis_price_when_no_overlay(monkeypatch):
+    today = datetime.now(KST)
+
+    async def fake_live(symbol):
+        return {
+            "symbol": symbol,
+            "instrument_type": "equity_kr",
+            "price": 168300.0,
+            "source": "kis",
+            "price_as_of": today.isoformat(),
+        }
+
+    async def fake_overlay(symbol, quote, *, data_state):
+        return False  # not an NXT session / empty book
+
+    monkeypatch.setattr(analysis_analyze, "_fetch_kr_live_quote", fake_live)
+    monkeypatch.setattr(analysis_analyze, "_apply_nxt_quote_overlay", fake_overlay)
+    monkeypatch.setattr(
+        analysis_analyze, "kr_market_data_state", lambda *a, **k: "fresh"
+    )
+
+    quote = await analysis_analyze._resolve_kr_quote("192820", _ohlcv())
+
+    assert quote["price"] == 168300.0
+    assert "price_source" not in quote
+    assert quote["is_stale_price"] is False  # today's KIS as_of, unchanged

--- a/tests/test_mcp_quotes_tools.py
+++ b/tests/test_mcp_quotes_tools.py
@@ -420,6 +420,77 @@ def _nxt_quote_book(
 
 
 @pytest.mark.asyncio
+async def test_apply_nxt_quote_overlay_applies_in_premarket(monkeypatch):
+    from app.mcp_server.tooling import market_data_quotes
+
+    async def fake_session(data_state, *, now=None):
+        return "nxt_premarket"
+
+    async def fake_overlay(symbol, *, session):
+        return {
+            "price": 173500.0,
+            "session": session,
+            "venue": "nxt",
+            "price_source": "nxt_expected_price",
+        }
+
+    monkeypatch.setattr(market_data_quotes, "_nxt_quote_session", fake_session)
+    monkeypatch.setattr(market_data_quotes, "_fetch_nxt_quote_overlay", fake_overlay)
+
+    quote = {"symbol": "192820", "price": 168300.0, "source": "kis"}
+    applied = await market_data_quotes._apply_nxt_quote_overlay(
+        "192820", quote, data_state="premarket_unavailable"
+    )
+
+    assert applied is True
+    assert quote["price"] == 173500.0
+    assert quote["price_source"] == "nxt_expected_price"
+    assert quote["session"] == "nxt_premarket"
+    assert quote["data_state"] == "fresh"
+    assert quote["regular_session_data_state"] == "premarket_unavailable"
+
+
+@pytest.mark.asyncio
+async def test_apply_nxt_quote_overlay_noop_outside_session(monkeypatch):
+    from app.mcp_server.tooling import market_data_quotes
+
+    async def fake_session(data_state, *, now=None):
+        return None
+
+    monkeypatch.setattr(market_data_quotes, "_nxt_quote_session", fake_session)
+
+    quote = {"symbol": "192820", "price": 168300.0, "source": "kis"}
+    applied = await market_data_quotes._apply_nxt_quote_overlay(
+        "192820", quote, data_state="fresh"
+    )
+
+    assert applied is False
+    assert quote == {"symbol": "192820", "price": 168300.0, "source": "kis"}
+
+
+@pytest.mark.asyncio
+async def test_apply_nxt_quote_overlay_noop_on_empty_book(monkeypatch):
+    from app.mcp_server.tooling import market_data_quotes
+
+    async def fake_session(data_state, *, now=None):
+        return "nxt_premarket"
+
+    async def fake_overlay(symbol, *, session):
+        return None  # empty orderbook → _fetch_nxt_quote_overlay returns None
+
+    monkeypatch.setattr(market_data_quotes, "_nxt_quote_session", fake_session)
+    monkeypatch.setattr(market_data_quotes, "_fetch_nxt_quote_overlay", fake_overlay)
+
+    quote = {"symbol": "192820", "price": 168300.0}
+    applied = await market_data_quotes._apply_nxt_quote_overlay(
+        "192820", quote, data_state="premarket_unavailable"
+    )
+
+    assert applied is False
+    assert quote == {"symbol": "192820", "price": 168300.0}
+
+
+@pytest.mark.asyncio
 async def test_get_quote_korean_equity_premarket_routes_to_nxt_expected_price(
     monkeypatch,
 ):


### PR DESCRIPTION
## 문제 (ROB-725)

`analyze_stock_batch`의 KR `current_price`가 프리마켓(08:00~09:00 KST)·NXT 세션에서 실시간 호가보다 지연된다. 에이전트가 이 지연된 가격 기준으로 저항/지지 `distance_pct`를 계산해 매도/매수 지정가를 앵커하면 실시장과 괴리된 주문가가 나온다.

**실측 (2026-07-06 프리마켓):** 08:05 `analyze_stock_batch(192820)` → `current_price 168300`, 저항 171,387. 이 값 기준 매도 지정가 171,000 접수 → 08:10 실제 NXT 체결 173,500 (실시장이 +3.1% 위).

## 근본 원인 (venue-stale, cache-stale 아님)

analyze의 KR 현재가는 `_resolve_kr_quote` → `_fetch_kr_live_quote` → `KISClient.inquire_price(market="J")` **단일 호출**. `market="J"`는 KRX **정규장** 코드라 프리마켓엔 **전일 정규장 종가**를 반환한다. 이 경로엔 NXT 오버레이가 없다.

반면 독립 `get_quote` 도구(`_get_quote_impl`)는 이미 ROB-464/511로 NXT 세션 감지 + NXT 호가창 오버레이를 적용한다. **analyze 경로만 누락**됐다.

응답의 `cache_hit:true`/`derived_as_of`는 **naver 펀더멘털 스냅샷** 캐시 메타데이터로 quote와 무관한 red herring.

## 수정 (코어만 — NXT 오버레이 미러링)

1. **공유 헬퍼 추출**: `_get_quote_impl`에 인라인돼 있던 오버레이 적용을 `_apply_nxt_quote_overlay(symbol, quote, *, data_state) -> bool` 헬퍼로 추출. `get_quote`는 이를 호출하도록 리팩터(동작 불변).
2. **analyze 배선**: `_resolve_kr_quote`가 base quote + tradability 후 오버레이 적용. 적용 시 `is_stale_price=False`, `price_as_of=now`. `distance_pct`는 `_recompute_intraday_support_resistance`가 `quote.price` 기준 재산정하므로 **코드 변경 없이 자동 보정**.
3. **provenance 노출**: compact 포맷터가 `price_source`/`session`/`data_state`/`venue`를 노출 → 에이전트가 NXT 파생가임을 인지.

**범위 밖 (의도적):** naver TTL 단축(quote 무관 red herring), premarket_gap warning, quote_staleness_sec 필드.

## 테스트 / 안전

- 8개 신규 테스트 + 기존 `get_quote` NXT 회귀 green. 총 92 passed (4개 관련 스위트).
- **CI flake 가드**: NXT-after 세션 판정은 wall-clock 게이트(15:30–20:00 KST)라, 기존 무가드 `_resolve_kr_quote` 테스트가 그 시간대엔 실 `get_orderbook`을 호출해 mocked price를 덮는 false-green이 있었음 → autouse fixture로 기본 no-op 처리.
- read-only (broker/order/watch mutation 없음), **migration 0**, fail-open (NXT 세션 외/호가창 empty → 기존 KIS 경로).

## 문서

- 스펙: `docs/superpowers/specs/2026-07-06-rob-725-analyze-batch-nxt-quote-overlay-design.md`
- 플랜: `docs/superpowers/plans/2026-07-06-rob-725-analyze-batch-nxt-quote-overlay.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
