### PR TITLE
fix(ROB-733): overseas_orders 토큰만료 재전송 재귀 깊이 가드 (무한 재-POST 차단)

### DIFF
--- a/app/services/brokers/kis/overseas_orders.py
+++ b/app/services/brokers/kis/overseas_orders.py
@@ -32,6 +32,12 @@ _EXCHANGE_ALIAS_MAP = {
     "NYSEMKT": "AMEX",
 }
 
+# ROB-733: token-expiry (EGW00123/EGW00121) 재전송 캡. 이 값을 넘으면 재-POST 대신
+# fail-closed(RuntimeError). "정확히 1회 재전송"이 응답이 아니라 코드로 강제되도록
+# 세 mutation 경로(order/cancel/modify)가 공유한다. 무한 재-POST → 실 자금 다중
+# 제출 리스크를 차단한다.
+_MAX_TOKEN_REFRESH_RESUBMITS = 1
+
 
 def _normalize_kis_exchange_code(code: str) -> str:
     """Normalize exchange code to KIS format.
@@ -77,6 +83,8 @@ class OverseasOrderClient:
         quantity: int,
         price: float = 0.0,  # 0이면 시장가
         is_mock: bool = False,
+        *,
+        _token_retry_depth: int = 0,
     ) -> dict:
         """
         해외주식 주문 (매수/매도)
@@ -192,10 +200,39 @@ class OverseasOrderClient:
 
         if js.get("rt_cd") != "0":
             if js.get("msg_cd") in ["EGW00123", "EGW00121"]:
+                if _token_retry_depth >= _MAX_TOKEN_REFRESH_RESUBMITS:
+                    # ROB-733: 캡 초과 → 재-POST 대신 fail-closed. 실 자금 다중 제출 차단.
+                    error_msg = f"{js.get('msg_cd')} {js.get('msg1')}"
+                    logging.error(
+                        "해외주식 주문 토큰 재발급 재전송 캡(%d) 초과 - fail-closed: %s "
+                        "(symbol=%s, exchange=%s, order_type=%s)",
+                        _MAX_TOKEN_REFRESH_RESUBMITS,
+                        error_msg,
+                        symbol,
+                        exchange_code,
+                        order_type,
+                    )
+                    raise RuntimeError(error_msg)
+                logging.warning(
+                    "해외주식 주문 토큰 만료(%s) - 토큰 재발급 후 재전송(%d/%d) "
+                    "(symbol=%s, exchange=%s, order_type=%s)",
+                    js.get("msg_cd"),
+                    _token_retry_depth + 1,
+                    _MAX_TOKEN_REFRESH_RESUBMITS,
+                    symbol,
+                    exchange_code,
+                    order_type,
+                )
                 await self._parent._token_manager.clear_token()
                 await self._parent._ensure_token()
                 return await self.order_overseas_stock(
-                    symbol, exchange_code, order_type, quantity, price, is_mock
+                    symbol,
+                    exchange_code,
+                    order_type,
+                    quantity,
+                    price,
+                    is_mock,
+                    _token_retry_depth=_token_retry_depth + 1,
                 )
 
             error_msg = f"{js.get('msg_cd')} {js.get('msg1')}"
@@ -420,6 +457,8 @@ class OverseasOrderClient:
         exchange_code: str,
         quantity: int,
         is_mock: bool = False,
+        *,
+        _token_retry_depth: int = 0,
     ) -> dict:
         """
         해외주식 주문 취소
@@ -499,10 +538,38 @@ class OverseasOrderClient:
 
         if js.get("rt_cd") != "0":
             if js.get("msg_cd") in ["EGW00123", "EGW00121"]:
+                if _token_retry_depth >= _MAX_TOKEN_REFRESH_RESUBMITS:
+                    # ROB-733: 캡 초과 → 재-POST 대신 fail-closed.
+                    error_msg = (
+                        f"KIS cancel order failed: {js.get('msg_cd')} "
+                        f"{js.get('msg1')} (order_id={order_number}, "
+                        f"symbol={symbol}, exchange={normalized_exchange_code})"
+                    )
+                    logging.error(
+                        "해외주식 취소 토큰 재발급 재전송 캡(%d) 초과 - fail-closed: %s",
+                        _MAX_TOKEN_REFRESH_RESUBMITS,
+                        error_msg,
+                    )
+                    raise RuntimeError(error_msg)
+                logging.warning(
+                    "해외주식 취소 토큰 만료(%s) - 토큰 재발급 후 재전송(%d/%d) "
+                    "(order_id=%s, symbol=%s, exchange=%s)",
+                    js.get("msg_cd"),
+                    _token_retry_depth + 1,
+                    _MAX_TOKEN_REFRESH_RESUBMITS,
+                    order_number,
+                    symbol,
+                    normalized_exchange_code,
+                )
                 await self._parent._token_manager.clear_token()
                 await self._parent._ensure_token()
                 return await self.cancel_overseas_order(
-                    order_number, symbol, exchange_code, quantity, is_mock
+                    order_number,
+                    symbol,
+                    exchange_code,
+                    quantity,
+                    is_mock,
+                    _token_retry_depth=_token_retry_depth + 1,
                 )
 
             error_msg = (
@@ -705,6 +772,8 @@ class OverseasOrderClient:
         quantity: int,
         new_price: float,
         is_mock: bool = False,
+        *,
+        _token_retry_depth: int = 0,
     ) -> dict:
         """
         해외주식 주문 정정 (가격/수량 변경)
@@ -780,10 +849,39 @@ class OverseasOrderClient:
 
         if js.get("rt_cd") != "0":
             if js.get("msg_cd") in ["EGW00123", "EGW00121"]:
+                if _token_retry_depth >= _MAX_TOKEN_REFRESH_RESUBMITS:
+                    # ROB-733: 캡 초과 → 재-POST 대신 fail-closed.
+                    error_msg = f"{js.get('msg_cd')} {js.get('msg1')}"
+                    logging.error(
+                        "해외주식 정정 토큰 재발급 재전송 캡(%d) 초과 - fail-closed: %s "
+                        "(order_id=%s, symbol=%s, exchange=%s)",
+                        _MAX_TOKEN_REFRESH_RESUBMITS,
+                        error_msg,
+                        order_number,
+                        symbol,
+                        exchange_code,
+                    )
+                    raise RuntimeError(error_msg)
+                logging.warning(
+                    "해외주식 정정 토큰 만료(%s) - 토큰 재발급 후 재전송(%d/%d) "
+                    "(order_id=%s, symbol=%s, exchange=%s)",
+                    js.get("msg_cd"),
+                    _token_retry_depth + 1,
+                    _MAX_TOKEN_REFRESH_RESUBMITS,
+                    order_number,
+                    symbol,
+                    exchange_code,
+                )
                 await self._parent._token_manager.clear_token()
                 await self._parent._ensure_token()
                 return await self.modify_overseas_order(
-                    order_number, symbol, exchange_code, quantity, new_price, is_mock
+                    order_number,
+                    symbol,
+                    exchange_code,
+                    quantity,
+                    new_price,
+                    is_mock,
+                    _token_retry_depth=_token_retry_depth + 1,
                 )
 
             error_msg = f"{js.get('msg_cd')} {js.get('msg1')}"

--- a/tests/test_kis_overseas_orders_mutation_guards.py
+++ b/tests/test_kis_overseas_orders_mutation_guards.py
@@ -63,17 +63,43 @@ async def test_order_non_token_error_raises_no_resubmit(overseas):
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_order_egw00123_unbounded_recursion_is_a_known_gap(overseas):
-    """가드 부재 문서화: EGW00123가 계속 반환되면 재귀가 무한(RecursionError).
+async def test_order_egw00123_repeated_is_bounded_fail_closed(overseas):
+    """ROB-733: EGW00123가 계속 반환돼도 재전송은 캡을 넘지 않고 fail-closed.
 
-    소스에 재귀 깊이 캡이 없어 '정확히 1회'는 코드가 아니라 응답에 의존한다.
-    이 테스트는 이중전송/스택오버플로 리스크를 표면화하며, 실제 가드 추가는
-    별도 (behavior-change) 이슈로 분리한다.
+    이전(ROB-727)에는 재귀 깊이 캡이 없어 무한 재-POST(RecursionError)로 실
+    자금 다중 제출 리스크가 있었다. 이제 토큰 재발급 재전송은 정확히 1회로
+    바운드되고, 그 뒤에도 토큰 만료가 이어지면 재-POST 대신 RuntimeError로
+    fail-closed 한다. 실제 POST는 최초 1 + 재전송 1 = 2회를 넘지 않는다.
     """
     instance, parent = overseas
     parent._request_with_rate_limit = AsyncMock(return_value=_EGW)
-    with pytest.raises(RecursionError):
+    with pytest.raises(RuntimeError, match="EGW00123"):
         await instance.order_overseas_stock("AAPL", "NASD", "buy", 1, 100.0)
+    # 최초 POST + 재전송 1회 = 정확히 2회 (무한 재-POST 아님)
+    assert parent._request_with_rate_limit.call_count == 2
+    assert parent._token_manager.clear_token.await_count == 1
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_cancel_egw00123_repeated_is_bounded_fail_closed(overseas):
+    instance, parent = overseas
+    parent._request_with_rate_limit = AsyncMock(return_value=_EGW)
+    with pytest.raises(RuntimeError, match="EGW00123"):
+        await instance.cancel_overseas_order("0001", "AAPL", "NASD", 1)
+    assert parent._request_with_rate_limit.call_count == 2
+    assert parent._token_manager.clear_token.await_count == 1
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_modify_egw00123_repeated_is_bounded_fail_closed(overseas):
+    instance, parent = overseas
+    parent._request_with_rate_limit = AsyncMock(return_value=_EGW)
+    with pytest.raises(RuntimeError, match="EGW00123"):
+        await instance.modify_overseas_order("0001", "AAPL", "NASD", 1, 123.45)
+    assert parent._request_with_rate_limit.call_count == 2
+    assert parent._token_manager.clear_token.await_count == 1
 
 
 def _sent(parent):


### PR DESCRIPTION
## 문제

`app/services/brokers/kis/overseas_orders.py`의 세 mutation 경로(`order`/`cancel`/`modify_overseas_stock`)가 모두 `rt_cd != "0"` 이고 `msg_cd ∈ {EGW00123, EGW00121}`(토큰 만료)면 `clear_token()` + `_ensure_token()` 후 **자기 자신을 재귀 호출로 주문 재전송**했다. **재귀 깊이 캡/시도 카운터가 없어**, 브로커가 토큰 만료를 계속 반환하면 `RecursionError`까지 무한 재-POST → 동일 실 주문이 스택 깊이만큼 실제 제출될 수 있는 **실 자금 다중 제출 리스크**.

"정확히 1회 재전송"이 코드가 강제하는 게 아니라, 두 번째 응답이 성공(`rt_cd=0`)이기 때문에만 종료되던 상태 (ROB-727 적대검증 중 표면화, 문서화 테스트 `test_order_egw00123_unbounded_recursion_is_a_known_gap`로 증명).

## 변경

- 모듈 상수 `_MAX_TOKEN_REFRESH_RESUBMITS = 1` 도입, 세 경로가 공유.
- 각 메서드에 keyword-only `_token_retry_depth: int = 0` 파라미터 추가. 캡 초과 시 재-POST 대신 `RuntimeError`로 **fail-closed**. 재전송 직전 `warning` / 캡 초과 `error` 로깅으로 다중 POST 관측성 확보.
- "정확히 1회 재전송"이 이제 응답이 아니라 **코드로 강제**됨 (최초 1 + 재전송 1 = 최대 2 POST).

## 가드레일

- ROB-645(트랜스포트 no-re-POST 가드)와 **별개 레이어**(이건 애플리케이션 레벨 재귀). 둘 다 유지.
- keyword-only 파라미터라 기존 positional 호출부(`buy/sell_overseas_stock` 등) 영향 없음.

## 테스트

- 기존 무한재귀 문서화 테스트 → "캡 초과 시 `RuntimeError` + 정확히 2 POST"로 갱신.
- ROB-727의 재전송-1회 테스트(`order`/`cancel`/`modify`) 그대로 green.
- `cancel`/`modify`에도 동일 바운드 테스트 추가.
- overseas 관련 **247 tests pass**, ruff format/check clean.
- migration 0.

Closes ROB-733.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Overseas stock order, cancel, and modify actions now retry token refresh only once when a token-expiry response is returned.
  * If the token-expiry condition persists, the operation now fails safely with a clear error rather than continuing to re-submit.
  * This reduces repeated submission attempts and improves reliability during expired-auth scenarios.

* **Tests**
  * Added/updated coverage to verify the bounded single retry behavior and correct token-clear handling for order, cancel, and modify.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->