### PR TITLE
refactor(dead-code): prune market_context + stock_alias dead functions (ROB-726 PR-C)

### DIFF
--- a/app/services/market_context_service.py
+++ b/app/services/market_context_service.py
@@ -2,12 +2,9 @@
 
 from __future__ import annotations
 
-import asyncio
 import logging
-from datetime import datetime
 from typing import Any
 
-from app.core.timezone import now_kst
 from app.mcp_server.tooling.market_data_indicators import (
     _calculate_adx,
     _calculate_ema,
@@ -15,21 +12,6 @@ from app.mcp_server.tooling.market_data_indicators import (
     _calculate_stoch_rsi,
     _fetch_ohlcv_for_indicators,
 )
-from app.schemas.n8n.common import (
-    N8nEconomicEvent,
-    N8nFearGreedData,
-    N8nMarketOverview,
-)
-from app.schemas.n8n.market_context import (
-    N8nMarketContextSummary,
-    N8nSymbolContext,
-)
-from app.services.brokers.upbit.client import fetch_multiple_tickers
-from app.services.external.btc_dominance import fetch_btc_dominance
-from app.services.external.economic_calendar import fetch_economic_events_today
-from app.services.external.fear_greed import fetch_fear_greed
-from app.services.order_brief_formatting import fmt_gap, fmt_price
-from app.services.pending_orders_service import fetch_pending_orders
 
 logger = logging.getLogger(__name__)
 
@@ -67,19 +49,6 @@ def _classify_strength(adx: float | None) -> str:
         return "moderate"
     else:
         return "weak"
-
-
-def _fmt_volume_krw(volume_krw: float | None) -> str:
-    """Format volume in Korean units (억)."""
-    if volume_krw is None:
-        return "-"
-    if volume_krw == 0:
-        return "0"
-    if volume_krw >= 100_000_000:
-        return f"{volume_krw / 100_000_000:,.0f}억"
-    if volume_krw >= 10_000:
-        return f"{volume_krw / 10_000:,.1f}만"
-    return f"{volume_krw:,.0f}"
 
 
 async def _compute_symbol_indicators(symbol: str) -> dict[str, Any] | None:
@@ -137,205 +106,3 @@ async def _compute_symbol_indicators(symbol: str) -> dict[str, Any] | None:
     except Exception as exc:
         logger.warning(f"Failed to compute indicators for {symbol}: {exc}")
         return None
-
-
-async def _fetch_crypto_market_overview() -> dict[str, Any]:
-    """Fetch crypto market overview data (BTC dominance, market cap change)."""
-    try:
-        dominance_data = await fetch_btc_dominance()
-
-        if dominance_data:
-            return {
-                "btc_dominance": dominance_data.get("btc_dominance"),
-                "total_market_cap_change_24h": dominance_data.get(
-                    "total_market_cap_change_24h",
-                ),
-            }
-        return {
-            "btc_dominance": None,
-            "total_market_cap_change_24h": None,
-        }
-    except Exception as exc:
-        logger.warning(f"Failed to fetch market overview: {exc}")
-        return {
-            "btc_dominance": None,
-            "total_market_cap_change_24h": None,
-        }
-
-
-async def fetch_market_context(
-    market: str = "crypto",
-    symbols: list[str] | None = None,
-    include_fear_greed: bool = True,
-    include_economic_calendar: bool = True,
-    as_of: datetime | None = None,
-) -> dict[str, Any]:
-    """
-    Fetch comprehensive market context for given symbols.
-
-    Args:
-        market: Market type (crypto, kr, us, all)
-        symbols: List of symbols to analyze (if None, fetches from pending orders + holdings)
-        include_fear_greed: Whether to include Fear & Greed Index
-        include_economic_calendar: Whether to include economic events
-        as_of: Timestamp for the response
-
-    Returns:
-        Dict with market_overview, symbols list, summary, and errors
-    """
-    if as_of is None:
-        as_of = now_kst()
-
-    errors: list[dict[str, object]] = []
-
-    if symbols is None:
-        try:
-            pending_result = await fetch_pending_orders(
-                market=market,
-                min_amount=0,
-                include_current_price=False,
-                side=None,
-                as_of=as_of,
-            )
-            pending_symbols = [
-                order["symbol"]
-                for order in pending_result.get("orders", [])
-                if order.get("market") == "crypto"
-            ]
-        except Exception as exc:
-            logger.warning(f"Failed to fetch pending orders: {exc}")
-            pending_symbols = []
-            errors.append({"source": "pending_orders", "error": str(exc)})
-
-        symbols = list(set(pending_symbols)) if pending_symbols else ["BTC"]
-
-    if market != "crypto":
-        errors.append(
-            {
-                "source": "market",
-                "error": f"Market '{market}' not yet supported, using crypto",
-            }
-        )
-        market = "crypto"
-
-    fear_greed_task = fetch_fear_greed() if include_fear_greed else asyncio.sleep(0)
-    econ_calendar_task = (
-        fetch_economic_events_today() if include_economic_calendar else asyncio.sleep(0)
-    )
-    market_overview_task = _fetch_crypto_market_overview()
-
-    fear_greed_data, econ_events, market_overview = await asyncio.gather(
-        fear_greed_task,
-        econ_calendar_task,
-        market_overview_task,
-        return_exceptions=True,
-    )
-
-    if isinstance(fear_greed_data, Exception):
-        errors.append({"source": "fear_greed", "error": str(fear_greed_data)})
-        fear_greed_data = None
-
-    if isinstance(econ_events, Exception):
-        errors.append({"source": "economic_calendar", "error": str(econ_events)})
-        econ_events = []
-
-    if isinstance(market_overview, Exception):
-        errors.append({"source": "market_overview", "error": str(market_overview)})
-        market_overview = {"btc_dominance": None, "total_market_cap_change_24h": None}
-
-    raw_symbols = [_normalize_crypto_symbol(s) for s in symbols]
-
-    try:
-        tickers = await fetch_multiple_tickers(raw_symbols)
-        ticker_map = {t["market"]: t for t in tickers}
-    except Exception as exc:
-        logger.error(f"Failed to fetch tickers: {exc}")
-        errors.append({"source": "tickers", "error": str(exc)})
-        ticker_map = {}
-
-    symbol_contexts: list[N8nSymbolContext] = []
-
-    for symbol in symbols:
-        raw_symbol = _normalize_crypto_symbol(symbol)
-        ticker = ticker_map.get(raw_symbol, {})
-
-        if not ticker:
-            errors.append({"symbol": symbol, "error": "Failed to fetch ticker data"})
-            continue
-
-        indicators = await _compute_symbol_indicators(symbol)
-
-        if indicators is None:
-            errors.append({"symbol": symbol, "error": "Failed to compute indicators"})
-            continue
-
-        current_price = indicators["current_price"]
-        change_rate = ticker.get("signed_change_rate", 0) * 100
-        trade_price_24h = ticker.get("acc_trade_price_24h", 0)
-
-        context = N8nSymbolContext(
-            symbol=symbol.upper(),
-            raw_symbol=raw_symbol,
-            current_price=current_price,
-            current_price_fmt=fmt_price(current_price, "KRW"),
-            change_24h_pct=round(change_rate, 2) if change_rate else None,
-            change_24h_fmt=fmt_gap(change_rate) if change_rate else None,
-            volume_24h_krw=trade_price_24h,
-            volume_24h_fmt=_fmt_volume_krw(trade_price_24h),
-            rsi_14=indicators.get("rsi_14"),
-            rsi_7=indicators.get("rsi_7"),
-            stoch_rsi_k=indicators.get("stoch_rsi_k"),
-            adx=indicators.get("adx"),
-            ema_20_distance_pct=indicators.get("ema_20_distance_pct"),
-            trend=indicators.get("trend", "neutral"),
-            trend_strength=indicators.get("trend_strength", "weak"),
-        )
-        symbol_contexts.append(context)
-
-    bullish_count = sum(1 for s in symbol_contexts if s.trend == "bullish")
-    bearish_count = sum(1 for s in symbol_contexts if s.trend == "bearish")
-    neutral_count = sum(1 for s in symbol_contexts if s.trend == "neutral")
-
-    valid_rsis = [s.rsi_14 for s in symbol_contexts if s.rsi_14 is not None]
-    avg_rsi = round(sum(valid_rsis) / len(valid_rsis), 1) if valid_rsis else None
-
-    if bullish_count > bearish_count and bullish_count > neutral_count:
-        sentiment = "cautiously_bullish"
-    elif bearish_count > bullish_count and bearish_count > neutral_count:
-        sentiment = "cautiously_bearish"
-    else:
-        sentiment = "neutral"
-
-    summary = N8nMarketContextSummary(
-        total_symbols=len(symbol_contexts),
-        bullish_count=bullish_count,
-        bearish_count=bearish_count,
-        neutral_count=neutral_count,
-        avg_rsi=avg_rsi,
-        market_sentiment=sentiment,
-    )
-
-    fear_greed_model = None
-    if fear_greed_data and isinstance(fear_greed_data, dict):
-        fear_greed_model = N8nFearGreedData(**fear_greed_data)
-
-    economic_events_models = []
-    if econ_events and isinstance(econ_events, list):
-        for event in econ_events:
-            if isinstance(event, dict):
-                economic_events_models.append(N8nEconomicEvent(**event))
-
-    safe_overview = market_overview if isinstance(market_overview, dict) else {}
-    market_overview_obj = N8nMarketOverview(
-        fear_greed=fear_greed_model,
-        btc_dominance=safe_overview.get("btc_dominance"),
-        total_market_cap_change_24h=safe_overview.get("total_market_cap_change_24h"),
-        economic_events_today=economic_events_models,
-    )
-
-    return {
-        "market_overview": market_overview_obj,
-        "symbols": symbol_contexts,
-        "summary": summary,
-        "errors": errors,
-    }

--- a/app/services/stock_alias_service.py
+++ b/app/services/stock_alias_service.py
@@ -4,16 +4,10 @@ Stock Alias Service
 종목 별칭 관리 서비스
 """
 
-import logging
-import re
-from typing import Any
-
-from sqlalchemy import or_, select
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.manual_holdings import MarketType, StockAlias
-
-logger = logging.getLogger(__name__)
 
 
 class StockAliasService:
@@ -21,13 +15,6 @@ class StockAliasService:
 
     def __init__(self, db: AsyncSession):
         self.db = db
-
-    @staticmethod
-    def _sanitize_query(query: str) -> str:
-        """Remove wildcard and unsafe characters from search query."""
-        cleaned = re.sub(r"[%_]", "", query.strip())
-        cleaned = re.sub(r"[^0-9A-Za-z가-힣.\s-]", "", cleaned)
-        return cleaned[:50]
 
     @staticmethod
     def _get_default_ticker_by_alias(alias: str, market_type: MarketType) -> str | None:
@@ -44,33 +31,6 @@ class StockAliasService:
 
         return None
 
-    async def create_alias(
-        self,
-        ticker: str,
-        market_type: MarketType,
-        alias: str,
-        source: str = "user",
-    ) -> StockAlias:
-        """새 종목 별칭 등록"""
-        stock_alias = StockAlias(
-            ticker=ticker.upper(),
-            market_type=market_type,
-            alias=alias,
-            source=source,
-        )
-        self.db.add(stock_alias)
-        await self.db.commit()
-        await self.db.refresh(stock_alias)
-        logger.info(f"Created stock alias: ticker={ticker}, alias={alias}")
-        return stock_alias
-
-    async def get_alias_by_id(self, alias_id: int) -> StockAlias | None:
-        """ID로 별칭 조회"""
-        result = await self.db.execute(
-            select(StockAlias).where(StockAlias.id == alias_id)
-        )
-        return result.scalar_one_or_none()
-
     async def get_ticker_by_alias(
         self, alias: str, market_type: MarketType
     ) -> str | None:
@@ -85,120 +45,6 @@ class StockAliasService:
             return stock_alias.ticker
 
         return self._get_default_ticker_by_alias(alias, market_type)
-
-    async def search_by_alias(
-        self,
-        query: str,
-        market_type: MarketType | None = None,
-        limit: int = 20,
-    ) -> list[StockAlias]:
-        """별칭 검색 (부분 일치)"""
-        sanitized_query = self._sanitize_query(query)
-        if not sanitized_query:
-            return []
-
-        search_query = select(StockAlias).where(
-            or_(
-                StockAlias.alias.ilike(f"%{sanitized_query}%"),
-                StockAlias.ticker.ilike(f"%{sanitized_query}%"),
-            )
-        )
-
-        if market_type:
-            search_query = search_query.where(StockAlias.market_type == market_type)
-
-        result = await self.db.execute(
-            search_query.order_by(StockAlias.alias).limit(limit)
-        )
-        return list(result.scalars().all())
-
-    async def get_aliases_by_ticker(
-        self, ticker: str, market_type: MarketType | None = None
-    ) -> list[StockAlias]:
-        """티커의 모든 별칭 조회"""
-        query = select(StockAlias).where(StockAlias.ticker == ticker.upper())
-
-        if market_type:
-            query = query.where(StockAlias.market_type == market_type)
-
-        result = await self.db.execute(query.order_by(StockAlias.alias))
-        return list(result.scalars().all())
-
-    async def bulk_create_aliases(
-        self, aliases_data: list[dict[str, Any]]
-    ) -> list[StockAlias]:
-        """여러 별칭 일괄 등록 (중복 무시)"""
-        if not aliases_data:
-            return []
-
-        # 한 번의 조회로 이미 존재하는 (alias, market_type) 조합을 가져온다.
-        alias_pairs = {(data["alias"], data["market_type"]) for data in aliases_data}
-        existing_query = (
-            select(StockAlias.alias, StockAlias.market_type)
-            .where(StockAlias.alias.in_({alias for alias, _ in alias_pairs}))
-            .where(StockAlias.market_type.in_({mt for _, mt in alias_pairs}))
-        )
-        existing_results = await self.db.execute(existing_query)
-        existing_pairs = {
-            (alias, market_type) for alias, market_type in existing_results.all()
-        }
-
-        created: list[StockAlias] = []
-        pending_pairs: set[tuple[str, MarketType]] = set()
-
-        for data in aliases_data:
-            alias = data["alias"]
-            market_type = data["market_type"]
-            pair = (alias, market_type)
-
-            # 이미 DB에 있거나 같은 요청 내에서 중복된 경우 건너뜀
-            if pair in existing_pairs or pair in pending_pairs:
-                continue
-
-            ticker = data["ticker"].upper()
-            source = data.get("source", "user")
-
-            stock_alias = StockAlias(
-                ticker=ticker,
-                market_type=market_type,
-                alias=alias,
-                source=source,
-            )
-            self.db.add(stock_alias)
-            created.append(stock_alias)
-            pending_pairs.add(pair)
-
-        if created:
-            await self.db.commit()
-            for alias in created:
-                await self.db.refresh(alias)
-
-        return created
-
-    async def delete_alias(self, alias_id: int) -> bool:
-        """별칭 삭제"""
-        alias = await self.get_alias_by_id(alias_id)
-        if not alias:
-            return False
-
-        await self.db.delete(alias)
-        await self.db.commit()
-        logger.info(f"Deleted stock alias: id={alias_id}")
-        return True
-
-    async def resolve_ticker(
-        self,
-        name_or_ticker: str,
-        market_type: MarketType,
-    ) -> str:
-        """이름이나 티커를 정규 티커로 변환"""
-        # 1. 먼저 별칭에서 검색
-        ticker = await self.get_ticker_by_alias(name_or_ticker, market_type)
-        if ticker:
-            return ticker
-
-        # 2. 없으면 입력값을 대문자로 반환 (티커로 가정)
-        return name_or_ticker.upper()
 
 
 # 토스 종목명 -> 실제 티커 매핑 기본 데이터
@@ -268,10 +114,3 @@ TOSS_STOCK_ALIASES = [
         "source": "toss",
     },
 ]
-
-
-async def seed_toss_aliases(db: AsyncSession) -> int:
-    """토스 종목명 별칭 초기 데이터 시딩"""
-    service = StockAliasService(db)
-    created = await service.bulk_create_aliases(TOSS_STOCK_ALIASES)
-    return len(created)


### PR DESCRIPTION
## ROB-726 PR-C — `market_context_service.py` + `stock_alias_service.py` dead function prune

Track A round-2 (ROB-724 후속). Function-level dead-code 삭제. **migration 0, 브로커/주문 mutation 없음, 테스트 churn 0.**

### `market_context_service.py` (삭제 ~176L, caller 0)
`fetch_market_context` (L166→EOF), `_fetch_crypto_market_overview`, `_fmt_volume_krw`. 보너스: 미사용 top-of-file `app.schemas.n8n.*` import 제거(디커플).
**유지:** `_normalize_crypto_symbol`, `_compute_symbol_indicators`, `_classify_trend`, `_classify_strength` — `pending_orders_service` 경유 live.

### `stock_alias_service.py` (삭제 ~130L, caller 0)
`create_alias`, `get_alias_by_id`, `search_by_alias`, `_sanitize_query`, `get_aliases_by_ticker`, `bulk_create_aliases`, `delete_alias`, `resolve_ticker`, `seed_toss_aliases`.
**유지:** `get_ticker_by_alias` (screenshot_holdings 경유 live) + 내부 `_get_default_ticker_by_alias`/`TOSS_STOCK_ALIASES`.

### 검증
- `git grep` 재확인: 12 삭제 심볼 전부 caller 0; keep-심볼 live/내부소비
- `import app.main` OK · `make lint` (ruff + format + ty) clean
- 모듈 touching 테스트 148 pass/0 fail · full suite green

플랜: `docs/plans/ROB-726-trackA2-dead-code-prune-plan.md` (PR-B에 포함).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
