### PR TITLE
feat(ROB-730): kis_mock 학습루프 이식(M3) — fill-evidence 게이트 + provenance 척추 + 회고 due-list

### DIFF
--- a/app/mcp_server/tooling/kis_mock_ledger.py
+++ b/app/mcp_server/tooling/kis_mock_ledger.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import uuid
 from decimal import Decimal, InvalidOperation
 from typing import Any
 from typing import cast as typing_cast
@@ -17,6 +18,8 @@ from app.mcp_server.tooling.shared import logger
 from app.mcp_server.tooling.shared import to_float as _to_float
 from app.models.review import KISMockOrderLedger
 from app.services.kis_mock_lifecycle_service import KISMockLifecycleService
+from app.services.live_correlation import live_correlation_id
+from app.services.live_place_provenance import publish_place_time_forecast
 
 KIS_MOCK_SHADOW_PENDING_SOURCE = "kis_mock_ledger_shadow"
 KIS_MOCK_SHADOW_PENDING_CONFIDENCE = "db_shadow_pending"
@@ -322,6 +325,9 @@ async def _record_kis_mock_order(
     notes: str | None,
     holdings_baseline_qty: Decimal | None = None,
     correlation_id: str | None = None,
+    target_price: float | None = None,
+    min_hold_days: int | None = None,
+    report_item_uuid: uuid.UUID | None = None,
 ) -> dict[str, Any]:
     """Build ledger row from execution result and return the mock-order response dict."""
     price_val = _to_float(dry_run_result.get("price"), default=0.0)
@@ -344,6 +350,21 @@ async def _record_kis_mock_order(
         status = "rejected"
     else:
         status = "accepted" if order_no else "unknown"
+
+    # ROB-730 provenance spine: mint a deterministic place-time correlation_id so
+    # this mock order joins forecast → fill → journal → retrospective, mirroring
+    # the kis_live path verbatim. Preserve an explicit id (ROB-402 scalping
+    # entry/exit pairing passes one) rather than overwriting it.
+    if correlation_id is None:
+        correlation_id = live_correlation_id(
+            account_scope="kis_mock",
+            symbol=normalized_symbol,
+            side=side,
+            price=Decimal(str(price_val)),
+            quantity=Decimal(str(qty_val)),
+            kst_trade_day=now_kst().strftime("%Y-%m-%d"),
+            rung=0,
+        )
 
     ledger_id = await _save_kis_mock_order_ledger(
         symbol=normalized_symbol,
@@ -370,6 +391,23 @@ async def _record_kis_mock_order(
         correlation_id=correlation_id,
     )
 
+    # ROB-730: emit the place-time forecast only for accepted orders (mirrors
+    # kis_live). publish_place_time_forecast is itself buy+target-gated and runs
+    # in its own isolated session, swallowing errors — a forecast hiccup never
+    # affects the recorded order.
+    if status == "accepted":
+        await publish_place_time_forecast(
+            correlation_id=correlation_id,
+            symbol=normalized_symbol,
+            instrument_type=market_type,
+            side=side,
+            target_price=target_price,
+            min_hold_days=min_hold_days,
+            session_label="kis_mock_place",
+            created_by="auto_place_mock",
+            report_item_uuid=str(report_item_uuid) if report_item_uuid else None,
+        )
+
     return {
         "success": True,
         "dry_run": False,
@@ -386,6 +424,7 @@ async def _record_kis_mock_order(
         "status": status,
         "response_code": rt_cd,
         "response_message": msg,
+        "correlation_id": correlation_id,
         "fill_recorded": False,
         "journal_created": False,
         "message": (

--- a/app/mcp_server/tooling/order_execution.py
+++ b/app/mcp_server/tooling/order_execution.py
@@ -812,6 +812,9 @@ async def _execute_and_record(
             notes=notes,
             holdings_baseline_qty=kis_mock_baseline_qty,
             correlation_id=correlation_id,
+            target_price=target_price,
+            min_hold_days=min_hold_days,
+            report_item_uuid=report_item_uuid,
         )
 
     # ROB-395: live KR orders record accepted-only to the live ledger; fills,

--- a/app/mcp_server/tooling/trade_retrospective_registration.py
+++ b/app/mcp_server/tooling/trade_retrospective_registration.py
@@ -68,18 +68,20 @@ def register_trade_retrospective_tools(mcp: Any) -> None:
     _ = mcp.tool(
         name="trade_retrospective_pending",
         description=(
-            "List lifecycle-terminal live orders across the 3 live ledgers "
-            "(kis_live KR, generic live US/crypto, toss_live) that still lack a "
-            "trade retrospective, over a KST trade_date window (default: last 14 "
-            "days). Defaults to actionable terminals only: filled / rejected / "
-            "anomaly. Cancel-family rows (cancelled — which includes DAY expiry "
-            "and strategic cancels — plus toss cancel_rejected/replace_rejected) "
-            "are hidden by default and their count is reported in "
-            "excluded_by_filter; pass include_cancelled=true to surface them. "
-            "Each row carries a suggested_correlation_id to pass to "
-            "save_trade_retrospective so it is marked covered next scan. Optional "
-            "account_mode filter in {kis_live, upbit_live, toss_live}. Read-only "
-            "due-list — no broker/order mutation. (ROB-647, ROB-661)"
+            "List lifecycle-terminal orders across the live ledgers (kis_live KR, "
+            "generic live US/crypto, toss_live), paper_trades, and the kis_mock "
+            "ledger (ROB-730 counterfactual loop) that still lack a trade "
+            "retrospective, over a KST trade_date window (default: last 14 days). "
+            "Defaults to actionable terminals only: filled / rejected / anomaly "
+            "(kis_mock: fill/reconciled/failed/anomaly). Cancel-family rows "
+            "(cancelled — which includes DAY expiry and strategic cancels — plus "
+            "toss cancel_rejected/replace_rejected and kis_mock stale) are hidden "
+            "by default and their count is reported in excluded_by_filter; pass "
+            "include_cancelled=true to surface them. Each row carries a "
+            "suggested_correlation_id to pass to save_trade_retrospective so it is "
+            "marked covered next scan. Optional account_mode filter in "
+            "{kis_live, upbit_live, toss_live, paper, kis_mock}. Read-only "
+            "due-list — no broker/order mutation. (ROB-647, ROB-661, ROB-730)"
         ),
     )(trade_retrospective_pending)
 

--- a/app/services/kis_mock_holdings_reconciler.py
+++ b/app/services/kis_mock_holdings_reconciler.py
@@ -29,6 +29,7 @@ ReasonCode = Literal[
     "holdings_mismatch",
     "holdings_snapshot_missing",
     "baseline_missing",
+    "attribution_unconfirmed",
 ]
 
 
@@ -210,6 +211,22 @@ def _proposal_for(
     # is the authoritative apportioned quantity.
     per_order_delta = snapshot.quantity - order.holdings_baseline_qty  # type: ignore[operator]
 
+    # ROB-730 per-order fill-evidence gate: apportionment can hand budget to a
+    # lower-priority order whose OWN directional holdings delta shows no fill
+    # (a same-symbol sibling's fill spilled over). Before booking any fill/partial
+    # from apportioned ``take``, require the order's own baseline-vs-snapshot delta
+    # to independently confirm a fill in its direction — the exact evidence kernel
+    # ROB-341's synchronous confirm uses. No own-evidence ⇒ fail-closed: veto the
+    # fill and keep the order pending/stale with attributed_fill_qty=0. This never
+    # fabricates a fill and never weakens the existing zero/wrong-direction guard.
+    own_evidence = classify_fill_by_delta(
+        side=order.side,
+        ordered_qty=order.ordered_qty,
+        baseline_qty=order.holdings_baseline_qty,  # type: ignore[arg-type]
+        observed_qty=snapshot.quantity,
+    )
+
+    attributed = take
     if order.lifecycle_state == "fill":
         if take >= order.ordered_qty:
             next_state: OrderLifecycleState = "reconciled"
@@ -217,6 +234,13 @@ def _proposal_for(
         else:
             next_state = "anomaly"
             reason = "holdings_mismatch"
+    elif take > 0 and own_evidence.verdict == "none":
+        # Apportioned budget but this order's own holdings did not move in its
+        # direction — fail-closed, do not book the fill. Keep the age-based
+        # pending/stale target but flag the distinct cause for observability.
+        next_state, _ = _pending_or_stale(order, now, thresholds)
+        reason = "attribution_unconfirmed"
+        attributed = Decimal("0")
     elif take >= order.ordered_qty:
         next_state, reason = "fill", "fill_detected"
     elif take > 0:
@@ -232,7 +256,7 @@ def _proposal_for(
         reason_code=reason,
         observed_holdings_qty=snapshot.quantity,
         observed_delta=per_order_delta,
-        attributed_fill_qty=take,
+        attributed_fill_qty=attributed,
     )
 
 

--- a/app/services/trade_journal/trade_retrospective_service.py
+++ b/app/services/trade_journal/trade_retrospective_service.py
@@ -22,6 +22,7 @@ from app.core.timezone import now_kst
 from app.models.paper_trading import PaperTrade
 from app.models.review import (
     KISLiveOrderLedger,
+    KISMockOrderLedger,
     LiveOrderLedger,
     TossLiveOrderLedger,
     TradeRetrospective,
@@ -830,16 +831,27 @@ _GENERIC_LIVE_DEFAULT_TERMINAL = frozenset({"filled", "rejected", "anomaly"})
 _GENERIC_LIVE_CANCEL_TERMINAL = frozenset({"cancelled"})
 _TOSS_DEFAULT_TERMINAL = frozenset({"filled", "rejected", "anomaly"})
 _TOSS_CANCEL_TERMINAL = frozenset({"cancelled", "cancel_rejected", "replace_rejected"})
+# ROB-730: kis_mock terminality lives in `lifecycle_state` (not `status`, which is
+# constrained to accepted/rejected/unknown). A holdings-delta fill lands as
+# `fill`/`reconciled`; a send reject as `failed`; ambiguity as `anomaly`.
+# `cancelled`/`stale` (never-confirmed timeout / operator cancel) are cancel-family
+# churn, hidden by default like live expiry.
+_KIS_MOCK_DEFAULT_TERMINAL = frozenset({"fill", "reconciled", "failed", "anomaly"})
+_KIS_MOCK_CANCEL_TERMINAL = frozenset({"cancelled", "stale"})
 
 _KIS_LIVE_TERMINAL = _KIS_LIVE_DEFAULT_TERMINAL | _KIS_LIVE_CANCEL_TERMINAL
 _GENERIC_LIVE_TERMINAL = _GENERIC_LIVE_DEFAULT_TERMINAL | _GENERIC_LIVE_CANCEL_TERMINAL
 _TOSS_TERMINAL = _TOSS_DEFAULT_TERMINAL | _TOSS_CANCEL_TERMINAL
+_KIS_MOCK_TERMINAL = _KIS_MOCK_DEFAULT_TERMINAL | _KIS_MOCK_CANCEL_TERMINAL
 
 # Statuses hidden from `pending` unless include_cancelled=True. Disjoint from the
 # DEFAULT statuses (note: `rejected` is DEFAULT; `cancel_rejected` /
 # `replace_rejected` are cancel-family).
 _CANCEL_FAMILY_STATUSES = (
-    _KIS_LIVE_CANCEL_TERMINAL | _GENERIC_LIVE_CANCEL_TERMINAL | _TOSS_CANCEL_TERMINAL
+    _KIS_LIVE_CANCEL_TERMINAL
+    | _GENERIC_LIVE_CANCEL_TERMINAL
+    | _TOSS_CANCEL_TERMINAL
+    | _KIS_MOCK_CANCEL_TERMINAL
 )
 # Bound per-ledger scan so a wide window cannot load unbounded rows.
 _PENDING_LEDGER_FETCH_CAP = 1000
@@ -913,13 +925,16 @@ async def build_retrospective_pending(
     limit: int = 100,
     include_cancelled: bool = False,
 ) -> dict[str, Any]:
-    """List terminal live-ledger orders (3 ledgers) lacking a retrospective.
+    """List terminal ledger orders lacking a retrospective.
 
     Read-only. Scans review.{kis_live_order_ledger, live_order_ledger,
-    toss_live_order_ledger} for lifecycle-terminal rows in the KST trade_date
-    window, then subtracts rows already covered by a retrospective (matched on
-    report_item_uuid or the suggested correlation_id). Mirrors the ROB-120
-    coverage pattern (terminal-without-artifact).
+    toss_live_order_ledger, kis_mock_order_ledger} plus paper_trades for
+    lifecycle-terminal rows in the KST trade_date window, then subtracts rows
+    already covered by a retrospective (matched on report_item_uuid or the
+    suggested correlation_id). Mirrors the ROB-120 coverage pattern
+    (terminal-without-artifact). Filter to one source with account_mode
+    (e.g. "kis_mock" for the counterfactual mock loop, "kis_live"/"toss_live"/
+    "upbit_live"/"paper" otherwise); None scans all.
 
     Cancel-family rows (cancelled / cancel_rejected / replace_rejected) are
     hidden unless include_cancelled=True; the hidden count is reported in
@@ -1071,6 +1086,42 @@ async def build_retrospective_pending(
                 row_id=r.id,
                 suggested_correlation_id=(r.correlation_id or f"paper_trade:{r.id}"),
                 suggested_trigger_type=trig,
+            )
+            if not _is_covered(entry, covered_cids, covered_uuids):
+                pending.append(entry)
+
+    # 5. KIS mock ledger (ROB-730) — counterfactual learning loop. Terminality is
+    # keyed on lifecycle_state (the mock `status` column only holds the send-time
+    # accepted/rejected/unknown). No report_item_uuid column: coverage matches on
+    # the place-time correlation_id (ROB-730 spine) only.
+    if account_mode in (None, "kis_mock"):
+        stmt = (
+            select(KISMockOrderLedger)
+            .where(
+                KISMockOrderLedger.lifecycle_state.in_(_KIS_MOCK_TERMINAL),
+                KISMockOrderLedger.trade_date >= window_start,
+                KISMockOrderLedger.trade_date <= window_end,
+            )
+            .order_by(KISMockOrderLedger.trade_date.desc())
+            .limit(_PENDING_LEDGER_FETCH_CAP)
+        )
+        for row in (await db.execute(stmt)).scalars().all():
+            scanned += 1
+            itype = row.instrument_type.value
+            market = "crypto" if itype == "crypto" else itype.removeprefix("equity_")
+            entry = _pending_entry(
+                ledger="kis_mock",
+                account_mode="kis_mock",
+                market=market,
+                instrument_type=itype,
+                symbol=row.symbol,
+                side=row.side,
+                status=row.lifecycle_state,
+                order_ref=row.order_no,
+                report_item_uuid=None,
+                trade_date=row.trade_date,
+                row_id=row.id,
+                suggested_correlation_id=row.correlation_id,
             )
             if not _is_covered(entry, covered_cids, covered_uuids):
                 pending.append(entry)

--- a/tests/services/test_kis_mock_holdings_reconciler.py
+++ b/tests/services/test_kis_mock_holdings_reconciler.py
@@ -396,6 +396,87 @@ def test_already_fill_pair_only_one_reconciles_other_anomaly():
 
 
 @pytest.mark.unit
+def test_apportioned_budget_without_own_evidence_fails_closed():
+    """ROB-730: a lower-priority order can be handed apportioned budget while its
+    OWN directional holdings delta shows no fill (mis-attribution / spillover).
+    The per-order fill-evidence gate must veto that fill and keep it pending —
+    fail-closed, no fabricated fill.
+    """
+    orders = [
+        # A: aggressive price, own baseline 0 -> snapshot 15 = +15 (real fill)
+        _buy(ledger_id=80, price=Decimal("15900"), baseline=Decimal("0")),
+        # B: own baseline 20 -> snapshot 15 = -5 (holdings DROPPED, no own fill)
+        _buy(ledger_id=81, price=Decimal("15500"), baseline=Decimal("20")),
+    ]
+    proposals = classify_orders(
+        orders=orders,
+        holdings={
+            "0148J0": HoldingsSnapshot(
+                symbol="0148J0", quantity=Decimal("15"), taken_at=_now()
+            )
+        },  # reference=min(0,20)=0, budget=15: A takes 10, B would take 5
+        thresholds=ReconcilerThresholds(),
+        now=_now(),
+    )
+    by_id = {p.ledger_id: p for p in proposals}
+    # A has own-evidence -> books full fill
+    assert by_id[80].next_state == "fill"
+    assert by_id[80].reason_code == "fill_detected"
+    assert by_id[80].attributed_fill_qty == Decimal("10")
+    # B lacks own-evidence -> vetoed, stays pending with attributed 0
+    assert by_id[81].next_state == "pending"
+    assert by_id[81].reason_code == "attribution_unconfirmed"
+    assert by_id[81].attributed_fill_qty == Decimal("0")
+
+
+@pytest.mark.unit
+def test_own_evidence_veto_downgrades_to_stale_when_old():
+    """The evidence veto respects age: an old order without own-evidence becomes
+    stale (not pending), still with the attribution_unconfirmed reason."""
+    orders = [
+        _buy(ledger_id=90, price=Decimal("15900"), baseline=Decimal("0")),
+        _buy(
+            ledger_id=91,
+            price=Decimal("15500"),
+            baseline=Decimal("20"),
+            accepted_age_sec=3600,
+        ),
+    ]
+    proposals = classify_orders(
+        orders=orders,
+        holdings={
+            "0148J0": HoldingsSnapshot(
+                symbol="0148J0", quantity=Decimal("15"), taken_at=_now()
+            )
+        },
+        thresholds=ReconcilerThresholds(
+            pending_threshold_sec=60, stale_threshold_sec=1800
+        ),
+        now=_now(),
+    )
+    by_id = {p.ledger_id: p for p in proposals}
+    assert by_id[91].next_state == "stale"
+    assert by_id[91].reason_code == "attribution_unconfirmed"
+    assert by_id[91].attributed_fill_qty == Decimal("0")
+
+
+@pytest.mark.unit
+def test_partial_own_evidence_still_books_partial():
+    """Positive control: when the order's OWN delta confirms a partial fill (not
+    just apportioned budget), the partial is still booked (partial-booked-like-live).
+    """
+    proposals = classify_orders(
+        orders=[_order(baseline=Decimal("5"))],  # ordered 10
+        holdings={"005930": _snap(Decimal("9"))},  # own delta +4 -> partial
+        thresholds=ReconcilerThresholds(),
+        now=_now(),
+    )
+    assert proposals[0].next_state == "fill"
+    assert proposals[0].reason_code == "partial_fill_detected"
+    assert proposals[0].attributed_fill_qty == Decimal("4")
+
+
+@pytest.mark.unit
 def test_sell_lower_price_wins_budget():
     def _sell(ledger_id, price):
         return LedgerOrderInput(

--- a/tests/services/test_kis_mock_retrospective_pending.py
+++ b/tests/services/test_kis_mock_retrospective_pending.py
@@ -1,0 +1,187 @@
+"""ROB-730 — kis_mock source branch in build_retrospective_pending.
+
+Mock terminal ledger events (fill/reconciled/failed/anomaly) must surface in the
+retrospective due-list, tagged account_mode='kis_mock' and filterable separately
+from live. cancel-family (cancelled/stale) is hidden unless include_cancelled.
+"""
+
+from __future__ import annotations
+
+import uuid
+from decimal import Decimal
+from typing import Any
+
+import pytest
+
+from app.core.timezone import now_kst
+from app.models.review import KISMockOrderLedger
+from app.models.trading import InstrumentType
+from app.services.trade_journal.trade_retrospective_service import (
+    build_retrospective_pending,
+)
+
+
+def _uniq(prefix: str) -> str:
+    return f"{prefix}-{uuid.uuid4().hex[:8]}"
+
+
+async def _pending_with_retry(db: Any, **kwargs: Any) -> Any:
+    """Call build_retrospective_pending, retrying on deadlock.
+
+    It scans the live order ledgers too, which on the shared xdist test DB can
+    deadlock with the parallel live-ledger tests. A deadlock victim is a
+    read-only query here, safe to rollback + retry.
+    """
+    from sqlalchemy.exc import DBAPIError
+
+    last: Exception | None = None
+    for _ in range(6):
+        try:
+            return await build_retrospective_pending(db, **kwargs)
+        except DBAPIError as exc:
+            if "deadlock" not in str(exc).lower():
+                raise
+            last = exc
+            await db.rollback()
+    assert last is not None
+    raise last
+
+
+async def _make_mock_order(
+    db: Any,
+    *,
+    symbol: str,
+    side: str,
+    lifecycle_state: str,
+    status: str = "accepted",
+    correlation_id: str | None = None,
+) -> KISMockOrderLedger:
+    row = KISMockOrderLedger(
+        trade_date=now_kst(),
+        symbol=symbol,
+        instrument_type=InstrumentType.equity_kr,
+        side=side,
+        order_type="limit",
+        quantity=Decimal("10"),
+        price=Decimal("70000"),
+        amount=Decimal("700000"),
+        fee=Decimal("0"),
+        currency="KRW",
+        order_no=_uniq("MOCK"),
+        account_mode="kis_mock",
+        broker="kis",
+        status=status,
+        lifecycle_state=lifecycle_state,
+        correlation_id=correlation_id,
+    )
+    db.add(row)
+    # COMMIT (not flush): the pending scan touches the live ledgers too; an
+    # uncommitted write here would hold locks during that broad scan and
+    # deadlock with parallel live-ledger tests (xdist + shared DB).
+    await db.commit()
+    return row
+
+
+@pytest.mark.asyncio
+async def test_mock_fill_surfaces_as_pending(db_session: Any) -> None:
+    symbol = _uniq("005930")
+    cid = _uniq("live:kis_mock:buy")
+    await _make_mock_order(
+        db_session,
+        symbol=symbol,
+        side="buy",
+        lifecycle_state="fill",
+        correlation_id=cid,
+    )
+    today = now_kst().strftime("%Y-%m-%d")
+    result = await _pending_with_retry(
+        db_session, kst_date_from=today, kst_date_to=today, include_cancelled=False
+    )
+    mock = [
+        e
+        for e in result["pending"]
+        if e.get("account_mode") == "kis_mock" and e.get("symbol") == symbol
+    ]
+    assert mock, result["pending"]
+    assert mock[0]["ledger"] == "kis_mock"
+    assert mock[0]["status"] == "fill"
+    assert mock[0]["market"] == "kr"
+    assert mock[0]["suggested_correlation_id"] == cid
+
+
+@pytest.mark.asyncio
+async def test_mock_filter_isolates_from_live(db_session: Any) -> None:
+    symbol = _uniq("005930")
+    await _make_mock_order(
+        db_session, symbol=symbol, side="buy", lifecycle_state="reconciled"
+    )
+    today = now_kst().strftime("%Y-%m-%d")
+    # account_mode="kis_mock" -> mock present
+    only_mock = await _pending_with_retry(
+        db_session, kst_date_from=today, kst_date_to=today, account_mode="kis_mock"
+    )
+    assert any(e.get("symbol") == symbol for e in only_mock["pending"])
+    assert all(e.get("account_mode") == "kis_mock" for e in only_mock["pending"])
+    # account_mode="kis_live" -> mock absent (separately filterable)
+    only_live = await _pending_with_retry(
+        db_session, kst_date_from=today, kst_date_to=today, account_mode="kis_live"
+    )
+    assert not any(e.get("symbol") == symbol for e in only_live["pending"])
+
+
+@pytest.mark.asyncio
+async def test_mock_failed_and_anomaly_surface_by_default(db_session: Any) -> None:
+    failed_sym = _uniq("FAILT")
+    anomaly_sym = _uniq("ANOM")
+    await _make_mock_order(
+        db_session,
+        symbol=failed_sym,
+        side="buy",
+        lifecycle_state="failed",
+        status="rejected",
+    )
+    await _make_mock_order(
+        db_session, symbol=anomaly_sym, side="buy", lifecycle_state="anomaly"
+    )
+    today = now_kst().strftime("%Y-%m-%d")
+    result = await _pending_with_retry(
+        db_session, kst_date_from=today, kst_date_to=today, account_mode="kis_mock"
+    )
+    syms = {e.get("symbol") for e in result["pending"]}
+    assert failed_sym in syms
+    assert anomaly_sym in syms
+
+
+@pytest.mark.asyncio
+async def test_mock_cancel_family_hidden_unless_included(db_session: Any) -> None:
+    cancelled_sym = _uniq("CANC")
+    stale_sym = _uniq("STAL")
+    await _make_mock_order(
+        db_session, symbol=cancelled_sym, side="buy", lifecycle_state="cancelled"
+    )
+    await _make_mock_order(
+        db_session, symbol=stale_sym, side="buy", lifecycle_state="stale"
+    )
+    today = now_kst().strftime("%Y-%m-%d")
+    # default: hidden
+    default = await _pending_with_retry(
+        db_session,
+        kst_date_from=today,
+        kst_date_to=today,
+        account_mode="kis_mock",
+        include_cancelled=False,
+    )
+    default_syms = {e.get("symbol") for e in default["pending"]}
+    assert cancelled_sym not in default_syms
+    assert stale_sym not in default_syms
+    # include_cancelled=True: surfaced
+    included = await _pending_with_retry(
+        db_session,
+        kst_date_from=today,
+        kst_date_to=today,
+        account_mode="kis_mock",
+        include_cancelled=True,
+    )
+    included_syms = {e.get("symbol") for e in included["pending"]}
+    assert cancelled_sym in included_syms
+    assert stale_sym in included_syms

--- a/tests/test_kis_mock_order_ledger.py
+++ b/tests/test_kis_mock_order_ledger.py
@@ -718,6 +718,120 @@ async def test_shadow_exposure_unknown_on_db_error(monkeypatch):
     assert "db unavailable" in result["error"]
 
 
+# ---------------------------------------------------------------------------
+# ROB-730: place-time provenance spine — mint correlation_id + emit forecast
+# ---------------------------------------------------------------------------
+
+
+def _mock_exec_result(rt_cd: str = "0", odno: str = "0001234567") -> dict:
+    return {"odno": odno, "ord_tmd": "091500", "msg": "정상처리", "rt_cd": rt_cd}
+
+
+def _mock_preview() -> dict:
+    return {"price": 70000, "quantity": 10, "estimated_value": 700000}
+
+
+@pytest.mark.asyncio
+async def test_record_mints_correlation_id_and_publishes_forecast(monkeypatch):
+    """ROB-730: the tool path passes no correlation_id, so the mock record path
+    mints a deterministic namespaced id, stores it on the ledger row, and emits a
+    place-time forecast for an accepted buy with a target — mirroring kis_live."""
+    from app.mcp_server.tooling import kis_mock_ledger
+
+    save = AsyncMock(return_value=5)
+    monkeypatch.setattr(kis_mock_ledger, "_save_kis_mock_order_ledger", save)
+    pub = AsyncMock(return_value="fc-1")
+    monkeypatch.setattr(kis_mock_ledger, "publish_place_time_forecast", pub)
+
+    result = await kis_mock_ledger._record_kis_mock_order(
+        normalized_symbol="005930",
+        market_type="equity_kr",
+        side="buy",
+        order_type="limit",
+        dry_run_result=_mock_preview(),
+        execution_result=_mock_exec_result(),
+        reason="t",
+        thesis=None,
+        strategy=None,
+        notes=None,
+        target_price=80000.0,
+        min_hold_days=5,
+    )
+
+    cid = result["correlation_id"]
+    assert cid is not None
+    assert cid.startswith("live:kis_mock:")
+    # stored on the ledger row
+    assert save.await_args.kwargs["correlation_id"] == cid
+    # forecast published for the accepted buy, tagged for mock provenance
+    pub.assert_awaited_once()
+    assert pub.await_args.kwargs["correlation_id"] == cid
+    assert pub.await_args.kwargs["session_label"] == "kis_mock_place"
+    assert pub.await_args.kwargs["created_by"] == "auto_place_mock"
+    assert pub.await_args.kwargs["target_price"] == 80000.0
+
+
+@pytest.mark.asyncio
+async def test_record_preserves_explicit_correlation_id(monkeypatch):
+    """ROB-730: an explicit correlation_id (ROB-402 scalping entry/exit pairing)
+    must be preserved, never overwritten by a freshly minted one."""
+    from app.mcp_server.tooling import kis_mock_ledger
+
+    save = AsyncMock(return_value=5)
+    monkeypatch.setattr(kis_mock_ledger, "_save_kis_mock_order_ledger", save)
+    pub = AsyncMock(return_value="fc-1")
+    monkeypatch.setattr(kis_mock_ledger, "publish_place_time_forecast", pub)
+
+    result = await kis_mock_ledger._record_kis_mock_order(
+        normalized_symbol="005930",
+        market_type="equity_kr",
+        side="buy",
+        order_type="limit",
+        dry_run_result=_mock_preview(),
+        execution_result=_mock_exec_result(),
+        reason="t",
+        thesis=None,
+        strategy=None,
+        notes=None,
+        correlation_id="scalp-pair-1",
+    )
+
+    assert result["correlation_id"] == "scalp-pair-1"
+    assert save.await_args.kwargs["correlation_id"] == "scalp-pair-1"
+    assert pub.await_args.kwargs["correlation_id"] == "scalp-pair-1"
+
+
+@pytest.mark.asyncio
+async def test_record_rejected_order_mints_but_does_not_publish(monkeypatch):
+    """ROB-730: a rejected order still gets a correlation_id (spine), but no
+    place-time forecast is emitted (mirrors live: publish only when accepted)."""
+    from app.mcp_server.tooling import kis_mock_ledger
+
+    save = AsyncMock(return_value=5)
+    monkeypatch.setattr(kis_mock_ledger, "_save_kis_mock_order_ledger", save)
+    pub = AsyncMock(return_value=None)
+    monkeypatch.setattr(kis_mock_ledger, "publish_place_time_forecast", pub)
+
+    result = await kis_mock_ledger._record_kis_mock_order(
+        normalized_symbol="005930",
+        market_type="equity_kr",
+        side="buy",
+        order_type="limit",
+        dry_run_result=_mock_preview(),
+        execution_result=_mock_exec_result(rt_cd="40", odno=""),
+        reason="t",
+        thesis=None,
+        strategy=None,
+        notes=None,
+        target_price=80000.0,
+    )
+
+    assert result["status"] == "rejected"
+    assert result["correlation_id"] is not None
+    assert save.await_args.kwargs["correlation_id"] == result["correlation_id"]
+    pub.assert_not_awaited()
+
+
 @pytest.mark.asyncio
 async def test_place_order_impl_threads_correlation_id(db_session, monkeypatch):
     from unittest.mock import AsyncMock

--- a/tests/test_trade_retrospective_pending.py
+++ b/tests/test_trade_retrospective_pending.py
@@ -15,6 +15,7 @@ from app.core.timezone import now_kst
 from app.models.paper_trading import PaperTrade
 from app.models.review import (
     KISLiveOrderLedger,
+    KISMockOrderLedger,
     LiveOrderLedger,
     TossLiveOrderLedger,
     TradeRetrospective,
@@ -37,6 +38,9 @@ async def _cleanup(
         LiveOrderLedger,
         TossLiveOrderLedger,
         PaperTrade,
+        # ROB-730: the pending scan now also reads the kis_mock ledger, so this
+        # exact-equality suite must clear it too or leaked mock rows pollute it.
+        KISMockOrderLedger,
     ):
         await db_session.execute(delete(model))
     await db_session.commit()


### PR DESCRIPTION
## 요약 (ROB-730 · M3)

승인된 headless 재량 자동화 설계의 **M3** — kis_mock counterfactual 학습루프 플럼빙. M1 shadow replay(ROB-697)·M2 Upbit shadow-sim(ROB-703)에 이어 kis_mock에 fill-evidence reconcile 게이트 + provenance 척추 + 회고 due-list를 이식한다. **ROB-734**(미러모드 무승인 풀플랜 집행 + 승인게이트 델타)의 전제 플럼빙.

- **mock 전용, live 주문 경로 무접촉. 정책/게이트 변경 없음. migration 0.**

## 변경 (3 스코프)

### 1. Reconcile per-order fill-evidence 게이트
`app/services/kis_mock_holdings_reconciler.py::_proposal_for`

배치 apportionment(`classify_orders`)은 (symbol,side) 그룹 budget을 우선순위로 분배하는데, **하위 우선순위 주문이 apportioned budget을 받더라도 그 주문 자신의 baseline 대비 방향성 홀딩스 델타가 fill을 확증하지 못하는 mis-attribution/spillover 케이스**가 있었다. 부킹 전에 주문 자신의 델타를 `classify_fill_by_delta`(ROB-341 동기 confirm이 쓰는 **동일 커널**)로 독립 확증하고, own-evidence가 `none`이면 **fail-closed로 veto** → `pending`/`stale`, `attributed_fill_qty=0`, `reason=attribution_unconfirmed`.

- ROB-395/407 evidence-first 패턴 준수. 기존 zero/wrong-direction 가드를 약화시키지 않는 **순수 강화** — 그룹 내 동일 baseline(기존 테스트 전부)은 무변경.
- 부분체결은 own-evidence가 positive면 live처럼 그대로 부킹(운영자 결정).

### 2. Provenance 척추 (place-time correlation_id + forecast)
`app/mcp_server/tooling/kis_mock_ledger.py::_record_kis_mock_order`, `order_execution.py`

`kis_live` 경로(ROB-705/714) **verbatim 미러**: place-time에 결정적 `correlation_id`를 mint(`live_correlation_id(account_scope="kis_mock", ...)`)하고, accepted 주문이면 `publish_place_time_forecast`(session_label=`kis_mock_place`, created_by=`auto_place_mock`) 발행. 응답에 `correlation_id` 노출.

- **명시적 correlation_id(ROB-402 스캘핑 entry/exit 페어링)는 mint-if-absent로 보존** — 덮어쓰지 않음.
- `correlation_id` 컬럼은 이미 존재(ROB-321) → **migration 0**.
- `target_price`/`min_hold_days`/`report_item_uuid`를 mock fork에서 `_record_kis_mock_order`로 배선.

### 3. 회고 due-list
`app/services/trade_journal/trade_retrospective_service.py::build_retrospective_pending`

kis_mock 레저를 5번째 소스로 추가. terminality는 **`lifecycle_state` 기준**(mock `status`는 accepted/rejected/unknown만 담음): default-actionable=`{fill, reconciled, failed, anomaly}`, cancel-family=`{cancelled, stale}`(include_cancelled로만 노출). `account_mode="kis_mock"`로 live와 **분리 필터 가능**. coverage는 correlation_id로만 매칭(report_item_uuid 컬럼 없음). MCP tool 설명 갱신.

## 테스트

- `tests/services/test_kis_mock_holdings_reconciler.py`(+3): 게이트 veto/stale-downgrade/partial-positive-control. 기존 19건 무회귀.
- `tests/test_kis_mock_order_ledger.py`(+3): mint/preserve-explicit/rejected-no-publish.
- `tests/services/test_kis_mock_retrospective_pending.py`(신규 4): surface/isolation/failed·anomaly/cancel-family.
- 기존 `test_trade_retrospective_pending.py`의 exact-equality autouse cleanup에 `KISMockOrderLedger` 추가(신규 스캔 대상 → 누출 방지).
- 급소 스윕 154 passed + LLM-import 가드 1122 passed.
- 무관 pre-existing 플레이크 1건(`test_kis_live_kr_path_...`): 공유 test_db `order_send_intents` 잔존 행에 의한 격리 이슈로, clean main(변경 stash)에서도 동일 재현 확인. CI는 fresh DB라 무영향.

## 운영 체크 (수용 기준 — 후속 라이브 확인 필요)

- [ ] KIS 모의계좌 유효기간/리셋 주기 확인·기록
- [ ] 모의서버 점검시간이 08:00–08:50 프리마켓 미러 집행 시점과 겹치는지 확인
- [ ] 모의계좌 잔고 시드 기록 (미러 실험 사이징 기준은 live 플랜 notional — ROB-734)

## 관련
ROB-728(발원) · ROB-697(M1) · ROB-703/705(M2+척추) · ROB-341(holdings-delta confirm) · **blocks ROB-734**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
