### PR TITLE
fix(ROB-739): bound KR token-expiry order resubmits

### DIFF
--- a/app/services/brokers/kis/domestic_orders.py
+++ b/app/services/brokers/kis/domestic_orders.py
@@ -15,6 +15,12 @@ if TYPE_CHECKING:
     from .protocols import KISClientProtocol
 
 
+# ROB-739: token-expiry (EGW00123/EGW00121) 재전송 캡. 이 값을 넘으면 재-POST 대신
+# fail-closed(RuntimeError). KR live mutation 경로(order/cancel/modify)의 무한 재-POST
+# 및 실 주문 다중 제출 리스크를 차단한다.
+_MAX_TOKEN_REFRESH_RESUBMITS = 1
+
+
 class DomesticOrderClient:
     """Client for KIS domestic (Korean) stock order operations.
 
@@ -229,6 +235,8 @@ class DomesticOrderClient:
         quantity: int,
         price: int = 0,  # 0이면 시장가
         is_mock: bool = False,
+        *,
+        _token_retry_depth: int = 0,
     ) -> dict:
         """
         국내주식 주문 (매수/매도)
@@ -334,10 +342,35 @@ class DomesticOrderClient:
                 msg1=msg1,
             )
             if msg_cd in ["EGW00123", "EGW00121"]:
+                if _token_retry_depth >= _MAX_TOKEN_REFRESH_RESUBMITS:
+                    error_msg = f"{msg_cd} {msg1}"
+                    logging.error(
+                        "국내주식 주문 토큰 재발급 재전송 캡(%d) 초과 - fail-closed: %s "
+                        "(stock_code=%s, order_type=%s)",
+                        _MAX_TOKEN_REFRESH_RESUBMITS,
+                        error_msg,
+                        stock_code,
+                        order_type,
+                    )
+                    raise RuntimeError(error_msg)
+                logging.warning(
+                    "국내주식 주문 토큰 만료(%s) - 토큰 재발급 후 재전송(%d/%d) "
+                    "(stock_code=%s, order_type=%s)",
+                    msg_cd,
+                    _token_retry_depth + 1,
+                    _MAX_TOKEN_REFRESH_RESUBMITS,
+                    stock_code,
+                    order_type,
+                )
                 await self._parent._token_manager.clear_token()
                 await self._parent._ensure_token()
                 return await self.order_korea_stock(
-                    stock_code, order_type, quantity, price, is_mock
+                    stock_code,
+                    order_type,
+                    quantity,
+                    price,
+                    is_mock,
+                    _token_retry_depth=_token_retry_depth + 1,
                 )
 
             error_msg = f"{msg_cd} {msg1}"
@@ -389,6 +422,8 @@ class DomesticOrderClient:
         order_type: str,  # "buy" 또는 "sell"
         is_mock: bool = False,
         krx_fwdg_ord_orgno: str | None = None,
+        *,
+        _token_retry_depth: int = 0,
     ) -> dict:
         """
         국내주식 주문 취소
@@ -493,7 +528,29 @@ class DomesticOrderClient:
         )
 
         if js.get("rt_cd") != "0":
-            if js.get("msg_cd") in ["EGW00123", "EGW00121"]:
+            msg_cd = js.get("msg_cd", "")
+            msg1 = js.get("msg1", "")
+            if msg_cd in ["EGW00123", "EGW00121"]:
+                if _token_retry_depth >= _MAX_TOKEN_REFRESH_RESUBMITS:
+                    error_msg = f"{msg_cd} {msg1}"
+                    logging.error(
+                        "국내주식 취소 토큰 재발급 재전송 캡(%d) 초과 - fail-closed: %s "
+                        "(order_number=%s, stock_code=%s)",
+                        _MAX_TOKEN_REFRESH_RESUBMITS,
+                        error_msg,
+                        order_number,
+                        stock_code,
+                    )
+                    raise RuntimeError(error_msg)
+                logging.warning(
+                    "국내주식 취소 토큰 만료(%s) - 토큰 재발급 후 재전송(%d/%d) "
+                    "(order_number=%s, stock_code=%s)",
+                    msg_cd,
+                    _token_retry_depth + 1,
+                    _MAX_TOKEN_REFRESH_RESUBMITS,
+                    order_number,
+                    stock_code,
+                )
                 await self._parent._token_manager.clear_token()
                 await self._parent._ensure_token()
                 return await self.cancel_korea_order(
@@ -504,9 +561,10 @@ class DomesticOrderClient:
                     order_type,
                     is_mock,
                     resolved_kis_orgno,
+                    _token_retry_depth=_token_retry_depth + 1,
                 )
 
-            error_msg = f"{js.get('msg_cd')} {js.get('msg1')}"
+            error_msg = f"{msg_cd} {msg1}"
             logging.error(f"주문 취소 실패: {error_msg}")
             raise RuntimeError(error_msg)
 
@@ -720,6 +778,8 @@ class DomesticOrderClient:
         new_price: int,
         is_mock: bool = False,
         krx_fwdg_ord_orgno: str | None = None,
+        *,
+        _token_retry_depth: int = 0,
     ) -> dict:
         """
         국내주식 주문 정정 (가격/수량 변경)
@@ -813,7 +873,29 @@ class DomesticOrderClient:
         )
 
         if js.get("rt_cd") != "0":
-            if js.get("msg_cd") in ["EGW00123", "EGW00121"]:
+            msg_cd = js.get("msg_cd", "")
+            msg1 = js.get("msg1", "")
+            if msg_cd in ["EGW00123", "EGW00121"]:
+                if _token_retry_depth >= _MAX_TOKEN_REFRESH_RESUBMITS:
+                    error_msg = f"{msg_cd} {msg1}"
+                    logging.error(
+                        "국내주식 정정 토큰 재발급 재전송 캡(%d) 초과 - fail-closed: %s "
+                        "(order_number=%s, stock_code=%s)",
+                        _MAX_TOKEN_REFRESH_RESUBMITS,
+                        error_msg,
+                        order_number,
+                        stock_code,
+                    )
+                    raise RuntimeError(error_msg)
+                logging.warning(
+                    "국내주식 정정 토큰 만료(%s) - 토큰 재발급 후 재전송(%d/%d) "
+                    "(order_number=%s, stock_code=%s)",
+                    msg_cd,
+                    _token_retry_depth + 1,
+                    _MAX_TOKEN_REFRESH_RESUBMITS,
+                    order_number,
+                    stock_code,
+                )
                 await self._parent._token_manager.clear_token()
                 await self._parent._ensure_token()
                 return await self.modify_korea_order(
@@ -823,9 +905,10 @@ class DomesticOrderClient:
                     new_price,
                     is_mock,
                     resolved_kis_orgno,
+                    _token_retry_depth=_token_retry_depth + 1,
                 )
 
-            error_msg = f"{js.get('msg_cd')} {js.get('msg1')}"
+            error_msg = f"{msg_cd} {msg1}"
             logging.error(f"주문 정정 실패: {error_msg}")
             raise RuntimeError(error_msg)
 

--- a/tests/test_kis_domestic_orders_retry.py
+++ b/tests/test_kis_domestic_orders_retry.py
@@ -2,9 +2,35 @@
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+
+_NXT_ELIGIBLE_PATH = "app.services.brokers.kis.domestic_orders.is_nxt_eligible"
+
+
+def _token_error(error_code: str) -> dict[str, str]:
+    return {"rt_cd": "1", "msg_cd": error_code, "msg1": "token expired"}
+
+
+def _make_domestic_orders():
+    from app.services.brokers.kis.domestic_orders import DomesticOrderClient
+
+    parent = MagicMock()
+    parent._hdr_base = {"content-type": "application/json"}
+    parent._ensure_token = AsyncMock()
+    parent._kis_url = lambda path: f"https://host{path}"
+
+    token_manager = MagicMock()
+    token_manager.clear_token = AsyncMock()
+    parent._token_manager = token_manager
+
+    settings = MagicMock()
+    settings.kis_account_no = "1234567890"
+    settings.kis_access_token = "test-token"
+    parent._settings = settings
+
+    return DomesticOrderClient(parent), parent
 
 
 @pytest.mark.unit
@@ -13,20 +39,8 @@ class TestDomesticOrdersTransientRetry:
 
     @pytest.fixture
     def _mock_domestic_orders(self):
-        """Create DomesticOrders instance with mocked parent."""
-        from app.services.brokers.kis.domestic_orders import DomesticOrderClient
-
-        parent = MagicMock()
-        parent._hdr_base = {"content-type": "application/json"}
-        parent._ensure_token = AsyncMock()
-
-        settings = MagicMock()
-        settings.kis_account_no = "1234567890"
-        settings.kis_access_token = "test-token"
-        parent._settings = settings
-
-        instance = DomesticOrderClient(parent)
-        return instance, parent
+        """Create DomesticOrderClient with mocked parent."""
+        return _make_domestic_orders()
 
     @pytest.mark.asyncio
     async def test_retries_on_sydb0050_then_succeeds(self, _mock_domestic_orders):
@@ -122,3 +136,70 @@ class TestDomesticOrdersTransientRetry:
                 end_date="20260208",
                 max_pages=2,
             )
+
+
+@pytest.mark.unit
+class TestDomesticOrdersTokenExpiryMutationGuards:
+    """ROB-739: token-expiry mutation resubmits are bounded fail-closed."""
+
+    @pytest.mark.parametrize("error_code", ["EGW00123", "EGW00121"])
+    @pytest.mark.asyncio
+    async def test_order_token_expiry_repeated_is_bounded_fail_closed(self, error_code):
+        instance, parent = _make_domestic_orders()
+        parent._request_with_rate_limit = AsyncMock(
+            return_value=_token_error(error_code)
+        )
+
+        with patch(_NXT_ELIGIBLE_PATH, AsyncMock(return_value=False)):
+            with pytest.raises(RuntimeError, match=error_code):
+                await instance.order_korea_stock("005930", "buy", 1, 70000)
+
+        assert parent._request_with_rate_limit.call_count == 2
+        assert parent._token_manager.clear_token.await_count == 1
+
+    @pytest.mark.parametrize("error_code", ["EGW00123", "EGW00121"])
+    @pytest.mark.asyncio
+    async def test_cancel_token_expiry_repeated_is_bounded_fail_closed(
+        self, error_code
+    ):
+        instance, parent = _make_domestic_orders()
+        parent._request_with_rate_limit = AsyncMock(
+            return_value=_token_error(error_code)
+        )
+
+        with patch(_NXT_ELIGIBLE_PATH, AsyncMock(return_value=False)):
+            with pytest.raises(RuntimeError, match=error_code):
+                await instance.cancel_korea_order(
+                    order_number="0001",
+                    stock_code="005930",
+                    quantity=1,
+                    price=70000,
+                    order_type="buy",
+                    krx_fwdg_ord_orgno="00091",
+                )
+
+        assert parent._request_with_rate_limit.call_count == 2
+        assert parent._token_manager.clear_token.await_count == 1
+
+    @pytest.mark.parametrize("error_code", ["EGW00123", "EGW00121"])
+    @pytest.mark.asyncio
+    async def test_modify_token_expiry_repeated_is_bounded_fail_closed(
+        self, error_code
+    ):
+        instance, parent = _make_domestic_orders()
+        parent._request_with_rate_limit = AsyncMock(
+            return_value=_token_error(error_code)
+        )
+
+        with patch(_NXT_ELIGIBLE_PATH, AsyncMock(return_value=False)):
+            with pytest.raises(RuntimeError, match=error_code):
+                await instance.modify_korea_order(
+                    order_number="0001",
+                    stock_code="005930",
+                    quantity=1,
+                    new_price=71000,
+                    krx_fwdg_ord_orgno="00091",
+                )
+
+        assert parent._request_with_rate_limit.call_count == 2
+        assert parent._token_manager.clear_token.await_count == 1


### PR DESCRIPTION
Bounds KR live domestic order/cancel/modify token-expiry resubmits to exactly one refresh attempt, then fails closed before any further POST.

- Added module-level _MAX_TOKEN_REFRESH_RESUBMITS = 1 in domestic_orders.py
- Threaded keyword-only _token_retry_depth parameter through order_korea_stock, cancel_korea_order, and modify_korea_order
- Added unit tests in tests/test_kis_domestic_orders_retry.py to verify the bounded retry depth.
- Passed Ruff lint/format check and ty type checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of expired authentication during order, cancel, and modify actions.
  * These requests now retry token refresh only once, then fail clearly if the issue persists.
  * Added safeguards to prevent repeated resubmission loops when a token has expired.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->