### PR TITLE
fix(ROB-741): fail closed for KIS mock crypto routing

### DIFF
--- a/app/mcp_server/README.md
+++ b/app/mcp_server/README.md
@@ -303,6 +303,7 @@ full payload, by numeric `id` or `artifact_uuid` string. Missing ids return
 
 - `investment_report_add_items(report_uuid, items, actor=None)` - Append new proposal items to an existing draft investment report. The item payload contract matches `investment_report_create`. Duplicate `client_item_key` rows are returned as existing items and are not rewritten. Non-draft reports return `error="not_draft"`. No broker, order, or watch mutation is performed.
 - `investment_report_update(report_uuid, title=None, summary=None, risk_summary=None, thesis_text=None, no_action_note=None, market_snapshot=None, portfolio_snapshot=None, metadata=None, valid_until=None, actor=None, reason=None)` - Update draft report header fields without changing report identity, lifecycle status, predecessor chain, account scope, generator version, or items. Each successful update appends an audit entry to `report.metadata.draft_updates`. Non-draft reports return `error="not_draft"`.
+- `kis_mock_mirror_execute_report(report_uuid, dry_run=True, min_rung_quantity=1.0)` - Execute ROB-734 mirror counterfactual orders through KIS mock only. The planner mirrors only KR report items with `target_kind="asset"` and a six-digit numeric symbol. Non-KR, US, crypto, index, and FX items are skipped with `reason="non_kr_equity_out_of_mirror_scope"` and counted in `plan_skipped_count`; they are never submitted to `place_order`.
 
 ### Alpaca paper read-only smoke tools
 
@@ -456,6 +457,10 @@ official KIS mock, and KIS live account paths:
   `KIS_MOCK_APP_SECRET`, or `KIS_MOCK_ACCOUNT_NO` are missing. HTTP requests
   use `KIS_MOCK_BASE_URL`, which defaults to the official KIS mock host
   `https://openapivts.koreainvestment.com:29443`.
+  KIS mock is a KIS venue only. It does not simulate Upbit crypto orders:
+  symbols that resolve to crypto, such as `KRW-BTC`, fail closed with
+  `error: "crypto has no mock venue"` before Upbit balance reads or order
+  mutation calls.
 - `account_mode="kis_live"` or omitted: existing live KIS behavior. For
   `place_order`, `dry_run=True` remains the default. KR live buy paths query
   Toss stock warnings before order submission; active `LIQUIDATION_TRADING`

--- a/app/mcp_server/tooling/order_execution.py
+++ b/app/mcp_server/tooling/order_execution.py
@@ -78,6 +78,7 @@ def _coerce_report_item_uuid(value: str | None) -> uuid.UUID | None:
 
 # Phase 2 strategy constants
 CRYPTO_STOP_LOSS_PCT = 0.045
+_MOCK_CRYPTO_ERROR = "crypto has no mock venue"
 
 # Crypto trade cooldown service singleton
 _order_cooldown_service: CryptoTradeCooldownService | None = None
@@ -138,6 +139,8 @@ async def _execute_order(
     identifier: str | None = None,
 ) -> dict[str, Any]:
     if market_type == "crypto":
+        if is_mock:
+            raise ValueError(_MOCK_CRYPTO_ERROR)
         return await _execute_crypto_order(
             symbol, side, order_type, quantity, price, identifier=identifier
         )
@@ -1130,6 +1133,9 @@ async def _place_order_impl(
 
     def _order_error(message: str) -> dict[str, Any]:
         return _build_order_error(message, source, normalized_symbol, market_type)
+
+    if market_type == "crypto" and is_mock:
+        return _order_error(_MOCK_CRYPTO_ERROR)
 
     try:
         defensive_trim_ctx = await _validate_defensive_trim_preconditions(

--- a/app/services/trade_journal/mirror_counterfactual.py
+++ b/app/services/trade_journal/mirror_counterfactual.py
@@ -24,7 +24,24 @@ _PRICE_RE = re.compile(
     r"([0-9][0-9,]*(?:\.[0-9]+)?)\s*원"
 )
 
+_KR_EQUITY_SYMBOL_RE = re.compile(r"^\d{6}$")
+_NON_KR_EQUITY_REASON = "non_kr_equity_out_of_mirror_scope"
+
 PlaceOrderCallable = Callable[..., Awaitable[dict[str, Any]]]
+
+
+def _mirror_scope_skip_reason(
+    report_market: str,
+    item: InvestmentReportItem,
+) -> str | None:
+    symbol = str(item.symbol or "").strip()
+    if report_market != "kr":
+        return _NON_KR_EQUITY_REASON
+    if item.target_kind != "asset":
+        return _NON_KR_EQUITY_REASON
+    if _KR_EQUITY_SYMBOL_RE.fullmatch(symbol) is None:
+        return _NON_KR_EQUITY_REASON
+    return None
 
 
 @dataclass(frozen=True)
@@ -224,12 +241,18 @@ def _min_hold_days_from_item(item: InvestmentReportItem) -> int | None:
 
 
 def _plan_for_item(
+    report_market: str,
     report_uuid: UUID,
     item: InvestmentReportItem,
     min_rung_quantity: Decimal,
 ) -> tuple[MirrorOrderPlan | None, str | None]:
     if not item.symbol:
         return None, "missing_symbol"
+
+    symbol = item.symbol.strip()
+    scope_skip_reason = _mirror_scope_skip_reason(report_market, item)
+    if scope_skip_reason is not None:
+        return None, scope_skip_reason
 
     source_bucket: MirrorSourceBucket | None = None
     side = _side_from_item(item)
@@ -265,7 +288,7 @@ def _plan_for_item(
         item_uuid=item.item_uuid,
         source_bucket=source_bucket,
         correlation_id=correlation_id,
-        symbol=item.symbol,
+        symbol=symbol,
         side=side,
         quantity=qty,
         amount=amount,
@@ -309,6 +332,7 @@ async def build_mirror_order_plans(
     skipped: list[dict[str, str]] = []
     for item in rows:
         plan, reason = _plan_for_item(
+            report_market=report.market,
             report_uuid=report.report_uuid,
             item=item,
             min_rung_quantity=min_rung_quantity,
@@ -508,4 +532,5 @@ async def execute_mirror_for_report(
         db, plans=plans, dry_run=dry_run, place_order=place_order
     )
     exec_res["skipped_plans"] = plans_res["skipped"]
+    exec_res["plan_skipped_count"] = len(plans_res["skipped"])
     return exec_res

--- a/tests/services/test_mirror_counterfactual_plans.py
+++ b/tests/services/test_mirror_counterfactual_plans.py
@@ -10,7 +10,6 @@ from app.services.trade_journal.mirror_counterfactual import (
     build_mirror_order_plans,
     execute_mirror_for_report,
 )
-from unittest.mock import AsyncMock
 
 pytestmark = [pytest.mark.usefixtures("investment_reports_cleanup_lock")]
 
@@ -210,4 +209,3 @@ async def test_crypto_report_item_is_skipped_before_dry_run_false_submit(db_sess
         }
     ]
     assert calls == []
-

--- a/tests/services/test_mirror_counterfactual_plans.py
+++ b/tests/services/test_mirror_counterfactual_plans.py
@@ -6,7 +6,11 @@ from uuid import uuid4
 import pytest
 
 from app.models.investment_reports import InvestmentReport, InvestmentReportItem
-from app.services.trade_journal.mirror_counterfactual import build_mirror_order_plans
+from app.services.trade_journal.mirror_counterfactual import (
+    build_mirror_order_plans,
+    execute_mirror_for_report,
+)
+from unittest.mock import AsyncMock
 
 pytestmark = [pytest.mark.usefixtures("investment_reports_cleanup_lock")]
 
@@ -131,3 +135,79 @@ async def test_item_without_price_is_skipped_with_reason(db_session):
     assert result["plans"] == []
     assert result["skipped"][0]["item_uuid"] == str(item.item_uuid)
     assert result["skipped"][0]["reason"] == "missing_limit_price"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("market", "symbol", "account_scope"),
+    [
+        ("crypto", "KRW-BTC", "upbit_live"),
+        ("kr", "KRW-BTC", "kis_live"),
+        ("us", "AAPL", "kis_live"),
+    ],
+)
+async def test_non_kr_equity_items_are_skipped_with_scope_reason(
+    db_session, market, symbol, account_scope
+):
+    report = await _report(db_session, market=market, account_scope=account_scope)
+    item = await _item(
+        db_session,
+        report,
+        symbol=symbol,
+        max_action={"quantity": "1", "limit_price": "50000000"},
+        evidence_snapshot={"price": "50000000"},
+    )
+    await db_session.commit()
+
+    result = await build_mirror_order_plans(db_session, report_uuid=report.report_uuid)
+
+    assert result["plans"] == []
+    assert result["count"] == 0
+    assert result["skipped"] == [
+        {
+            "item_uuid": str(item.item_uuid),
+            "reason": "non_kr_equity_out_of_mirror_scope",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_crypto_report_item_is_skipped_before_dry_run_false_submit(db_session):
+    report = await _report(
+        db_session,
+        market="crypto",
+        account_scope="upbit_live",
+    )
+    item = await _item(
+        db_session,
+        report,
+        symbol="KRW-BTC",
+        max_action={"quantity": "0.001", "limit_price": "50000000"},
+        evidence_snapshot={"price": "50000000"},
+    )
+    await db_session.commit()
+    calls: list[dict[str, object]] = []
+
+    async def fake_place_order(**kwargs):
+        calls.append(kwargs)
+        return {"success": True, "dry_run": False, "ledger_id": 123}
+
+    result = await execute_mirror_for_report(
+        db_session,
+        report_uuid=report.report_uuid,
+        dry_run=False,
+        place_order=fake_place_order,
+    )
+
+    assert result["success"] is True
+    assert result["planned_count"] == 0
+    assert result["submitted_count"] == 0
+    assert result["plan_skipped_count"] == 1
+    assert result["skipped_plans"] == [
+        {
+            "item_uuid": str(item.item_uuid),
+            "reason": "non_kr_equity_out_of_mirror_scope",
+        }
+    ]
+    assert calls == []
+

--- a/tests/test_mcp_place_order.py
+++ b/tests/test_mcp_place_order.py
@@ -2910,3 +2910,94 @@ async def test_place_order_readtimeout_surfaces_class_name(monkeypatch):
     assert result["source"] == "kis"
     # :1128 — order-history record also gets the concrete reason, not ""
     assert recorded.await_args.kwargs["error"] == "ReadTimeout"
+
+
+@pytest.mark.asyncio
+async def test_execute_order_rejects_mock_crypto_before_upbit_send(monkeypatch):
+    from app.mcp_server.tooling import order_execution
+
+    place_buy = AsyncMock()
+    market_buy = AsyncMock()
+    place_sell = AsyncMock()
+    market_sell = AsyncMock()
+    monkeypatch.setattr(order_execution.upbit_service, "place_buy_order", place_buy)
+    monkeypatch.setattr(
+        order_execution.upbit_service,
+        "place_market_buy_order",
+        market_buy,
+    )
+    monkeypatch.setattr(order_execution.upbit_service, "place_sell_order", place_sell)
+    monkeypatch.setattr(
+        order_execution.upbit_service,
+        "place_market_sell_order",
+        market_sell,
+    )
+
+    with pytest.raises(ValueError, match="crypto has no mock venue"):
+        await order_execution._execute_order(
+            symbol="KRW-BTC",
+            side="buy",
+            order_type="limit",
+            quantity=0.001,
+            price=50000000.0,
+            market_type="crypto",
+            is_mock=True,
+        )
+
+    place_buy.assert_not_awaited()
+    market_buy.assert_not_awaited()
+    place_sell.assert_not_awaited()
+    market_sell.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_place_order_impl_rejects_mock_crypto_before_upbit_reads(monkeypatch):
+    from app.mcp_server.tooling import order_execution
+
+    fetch_prices = AsyncMock()
+    fetch_coins = AsyncMock()
+    place_buy = AsyncMock()
+    market_buy = AsyncMock()
+    place_sell = AsyncMock()
+    market_sell = AsyncMock()
+    monkeypatch.setattr(
+        order_execution.upbit_service,
+        "fetch_multiple_current_prices",
+        fetch_prices,
+    )
+    monkeypatch.setattr(order_execution.upbit_service, "fetch_my_coins", fetch_coins)
+    monkeypatch.setattr(order_execution.upbit_service, "place_buy_order", place_buy)
+    monkeypatch.setattr(
+        order_execution.upbit_service,
+        "place_market_buy_order",
+        market_buy,
+    )
+    monkeypatch.setattr(order_execution.upbit_service, "place_sell_order", place_sell)
+    monkeypatch.setattr(
+        order_execution.upbit_service,
+        "place_market_sell_order",
+        market_sell,
+    )
+
+    result = await order_execution._place_order_impl(
+        symbol="KRW-BTC",
+        side="buy",
+        order_type="limit",
+        quantity=0.001,
+        price=50000000.0,
+        dry_run=False,
+        is_mock=True,
+    )
+
+    assert result["success"] is False
+    assert result["error"] == "crypto has no mock venue"
+    assert result["source"] == "upbit"
+    assert result["symbol"] == "KRW-BTC"
+    assert result["instrument_type"] == "crypto"
+    fetch_prices.assert_not_awaited()
+    fetch_coins.assert_not_awaited()
+    place_buy.assert_not_awaited()
+    market_buy.assert_not_awaited()
+    place_sell.assert_not_awaited()
+    market_sell.assert_not_awaited()
+

--- a/tests/test_mcp_place_order.py
+++ b/tests/test_mcp_place_order.py
@@ -3000,4 +3000,3 @@ async def test_place_order_impl_rejects_mock_crypto_before_upbit_reads(monkeypat
     market_buy.assert_not_awaited()
     place_sell.assert_not_awaited()
     market_sell.assert_not_awaited()
-


### PR DESCRIPTION
## Summary
- Restrict kis_mock_mirror_execute_report planning to KR six-digit equity report items
- Fail closed for is_mock=True + crypto in _place_order_impl before Upbit reads and in _execute_order dispatch
- Document the KIS mock crypto boundary in the MCP README

## Verification
- uv run pytest tests/services/test_mirror_counterfactual_plans.py tests/services/test_mirror_counterfactual_execution.py tests/mcp_server/test_mirror_counterfactual_tool.py tests/test_mcp_place_order.py::test_execute_order_rejects_mock_crypto_before_upbit_send tests/test_mcp_place_order.py::test_place_order_impl_rejects_mock_crypto_before_upbit_reads tests/test_mcp_place_order.py::TestPlaceOrderHighAmount::test_place_order_high_amount_crypto_dry_run_false -v
- uv run ruff check app/services/trade_journal/mirror_counterfactual.py app/mcp_server/tooling/order_execution.py tests/services/test_mirror_counterfactual_plans.py tests/test_mcp_place_order.py
- uv run ruff format --check app/services/trade_journal/mirror_counterfactual.py app/mcp_server/tooling/order_execution.py tests/services/test_mirror_counterfactual_plans.py tests/test_mcp_place_order.py
- uv run ty check app/ --error-on-warning
- git diff origin/main...HEAD --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Mirror report execution now clearly reports how many items were skipped during planning.

* **Bug Fixes**
  * Crypto orders are now rejected in mock mode with a clear error message.
  * Mirror planning now skips unsupported report items and non-KR equity symbols instead of attempting to process them.
  * Mock crypto handling now fails earlier, before any exchange data lookup or order submission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->