### PR TITLE
fix(ROB-742): restore live tag matching and mock lesson routing

### DIFF
--- a/app/mcp_server/README.md
+++ b/app/mcp_server/README.md
@@ -190,7 +190,7 @@ MCP tools (market data, portfolio, order execution) exposed via `fastmcp`.
 - `get_upbit_altseason(include_constituents=false, constituents_limit=50)` - Upbit altseason ratio and 24h breadth. With constituents enabled, `breadth.constituents` lists KRW alts beating BTC with 24h change, vs-BTC relative strength, volume, and traded value.
 - ~~`recommend_stocks(...)`~~ — **DEPRECATED / registry-hidden (ROB-359).** No longer registered on the MCP tool surface. Use `screen_stocks` for candidate discovery. The implementation is retained in `analysis_tool_handlers.recommend_stocks_impl` for a possible future narrow `build_buy_plan` tool; do not call it from active report/operator prompts.
 
-- `analyze_stock_batch(symbols, market=None, include_peers=False, quick=True)`
+- `analyze_stock_batch(symbols, market=None, include_peers=False, quick=True, decision_history_account_mode=None)`
   - Legacy/deep-dive batch analysis for up to 10 symbols.
   - Do not use it as the routine follow-up after `screen_stocks_snapshot`; snapshot
     rows now expose consensus and RSI context directly.
@@ -203,6 +203,9 @@ MCP tools (market data, portfolio, order execution) exposed via `fastmcp`.
     (`{artifact_uuid, as_of, kind}`) so you can choose to reuse the persisted
     artifact via `analysis_artifact_get` instead of re-deriving. This is a soft
     hint only — the analysis still runs and is returned.
+  - `decision_history_account_mode="kis_mock"` switches only the advisory
+    `decision_history` block to the explicit mock/counterfactual branch. Leave it
+    unset for default live/default lesson context.
 
 ### Snapshot-backed report generation
 

--- a/app/mcp_server/tooling/analysis_registration.py
+++ b/app/mcp_server/tooling/analysis_registration.py
@@ -225,7 +225,11 @@ def register_analysis_tools(
             "non-stale analysis_artifact already covers a symbol, that compact "
             "summary also carries fresh_artifact_exists {artifact_uuid, as_of, "
             "kind} — a soft reuse hint (fetch via analysis_artifact_get); the "
-            "analysis still runs (ROB-648)."
+            "analysis still runs (ROB-648). "
+            "decision_history_account_mode='kis_mock' switches the advisory "
+            "decision_history block to the explicit mock/counterfactual branch; "
+            "the default keeps the live/default lesson corpus and excludes mirror "
+            "counterfactual rows."
         ),
     )
     async def analyze_stock_batch(
@@ -235,6 +239,7 @@ def register_analysis_tools(
         quick: bool = True,
         include_position: bool = True,
         refresh: bool = False,
+        decision_history_account_mode: Literal["kis_mock"] | None = None,
     ) -> dict[str, Any]:
         return await analyze_stock_batch_impl(
             symbols=symbols,
@@ -243,6 +248,7 @@ def register_analysis_tools(
             quick=quick,
             include_position=include_position,
             refresh=refresh,
+            decision_history_account_mode=decision_history_account_mode,
         )
 
     @mcp.tool(

--- a/app/mcp_server/tooling/analysis_tool_handlers.py
+++ b/app/mcp_server/tooling/analysis_tool_handlers.py
@@ -862,6 +862,7 @@ async def _attach_decision_history(
     results: dict[str, Any],
     *,
     market: str | None,
+    decision_history_account_mode: str | None = None,
 ) -> None:
     """ROB-711: inject per-symbol decision_history (past judgment→outcome).
 
@@ -882,7 +883,10 @@ async def _attach_decision_history(
                     continue
                 mkt = result.get("market_type") or market
                 ctx = await build_decision_context(
-                    db, symbol=str(sym), market=str(mkt or "")
+                    db,
+                    symbol=str(sym),
+                    market=str(mkt or ""),
+                    account_mode=decision_history_account_mode,
                 )
                 if ctx is not None:
                     result["decision_history"] = ctx
@@ -942,6 +946,7 @@ async def analyze_stock_batch_impl(
     quick: bool = True,
     include_position: bool = True,
     refresh: bool = False,
+    decision_history_account_mode: str | None = None,
 ) -> dict[str, Any]:
     """Analyze multiple symbols and return compact per-symbol summaries.
     Args:
@@ -955,6 +960,8 @@ async def analyze_stock_batch_impl(
         refresh: ROB-638 — when True, bypass the fetch-layer provider cache
             read (consensus/valuation/profile are re-fetched fresh and the
             fresh values are written back to the cache).
+        decision_history_account_mode: switches the advisory decision_history
+            block to the explicit mock/counterfactual branch.
     Returns:
         Dict with 'results' (symbol -> summary) and 'summary' keys
     """
@@ -995,7 +1002,11 @@ async def analyze_stock_batch_impl(
     # (soft reuse hint, fail-open). Only for the compact contract.
     if quick:
         await _attach_fresh_artifact_hints(response.get("results", {}), market=market)
-        await _attach_decision_history(response.get("results", {}), market=market)
+        await _attach_decision_history(
+            response.get("results", {}),
+            market=market,
+            decision_history_account_mode=decision_history_account_mode,
+        )
         await _attach_earnings(response.get("results", {}), market=market)
     return response
 

--- a/app/services/decision_history.py
+++ b/app/services/decision_history.py
@@ -21,6 +21,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.models.investment_reports import InvestmentReportItem
 from app.models.review import (
     KISLiveOrderLedger,
+    KISMockOrderLedger,
     LiveOrderLedger,
     TossLiveOrderLedger,
     TradeForecast,
@@ -195,6 +196,17 @@ async def _prior_decisions(db: AsyncSession, symbol: str) -> list[dict[str, Any]
     return out
 
 
+def _is_mock_counterfactual_retrospective_clause():
+    return (TradeRetrospective.account_mode == "kis_mock") & (
+        select(KISMockOrderLedger.id)
+        .where(
+            KISMockOrderLedger.correlation_id == TradeRetrospective.correlation_id,
+            KISMockOrderLedger.mirror_cohort == "mock_counterfactual",
+        )
+        .exists()
+    )
+
+
 async def _retrospectives(
     db: AsyncSession, symbol: str, account_mode: str | None = None
 ) -> tuple[list[str], list[dict[str, Any]]]:
@@ -202,10 +214,7 @@ async def _retrospectives(
     if account_mode == "kis_mock":
         stmt = stmt.where(TradeRetrospective.account_mode == "kis_mock")
     else:
-        stmt = stmt.where(
-            (TradeRetrospective.account_mode != "kis_mock")
-            | (TradeRetrospective.account_mode.is_(None))
-        )
+        stmt = stmt.where(~_is_mock_counterfactual_retrospective_clause())
     rows = (
         (await db.execute(stmt.order_by(TradeRetrospective.created_at.desc())))
         .scalars()

--- a/app/services/trade_journal/aggregates.py
+++ b/app/services/trade_journal/aggregates.py
@@ -55,8 +55,28 @@ def _market_for(source: str, row: object) -> str:
     return "crypto" if raw == "crypto" else "us"  # live ledger
 
 
+_ACCOUNT_MODE_ALIASES = {
+    "kis": "kis_live",
+    "toss": "toss_live",
+    "upbit": "upbit_live",
+}
+
+
+def _canonical_account_mode(value: str | None) -> str | None:
+    if value is None:
+        return None
+    raw = str(value)
+    return _ACCOUNT_MODE_ALIASES.get(raw, raw)
+
+
 def _account_of(source: str, row: object) -> str:
-    return getattr(row, "account_scope", None) or getattr(row, "broker", None) or source
+    raw = (
+        getattr(row, "account_scope", None)
+        or getattr(row, "account_mode", None)
+        or getattr(row, "broker", None)
+        or source
+    )
+    return _canonical_account_mode(str(raw)) or str(raw)
 
 
 def _coerce_uuid(value: str | None) -> uuid.UUID | None:
@@ -345,6 +365,7 @@ async def resolve_setup_tag(
     instrument = _MARKET_TO_INSTRUMENT.get(trade.market)
     norm = _normalize_symbol_for_filter(trade.symbol, instrument)
     window_start = trade.entry_ts - timedelta(days=window_days)
+    account_mode = _canonical_account_mode(trade.account)
 
     corr_ids = [
         c for c in (*trade.entry_correlation_ids, trade.exit_correlation_id) if c
@@ -356,7 +377,7 @@ async def resolve_setup_tag(
                 .where(
                     TradeRetrospective.correlation_id.in_(corr_ids),
                     TradeRetrospective.strategy_key.isnot(None),
-                    TradeRetrospective.account_mode == trade.account,
+                    TradeRetrospective.account_mode == account_mode,
                 )
                 .order_by(TradeRetrospective.created_at.desc())
                 .limit(1)
@@ -365,15 +386,18 @@ async def resolve_setup_tag(
         if row and not _is_smoke(row):
             return TagInfo(row, "strategy_key", "exact")
 
+    retro_filters = [
+        TradeRetrospective.symbol == norm,
+        TradeRetrospective.strategy_key.isnot(None),
+        TradeRetrospective.created_at <= trade.exit_ts,
+        TradeRetrospective.created_at >= window_start,
+    ]
+    if account_mode is not None:
+        retro_filters.append(TradeRetrospective.account_mode == account_mode)
     retro_key = (
         await db.execute(
             select(TradeRetrospective.strategy_key)
-            .where(
-                TradeRetrospective.symbol == norm,
-                TradeRetrospective.strategy_key.isnot(None),
-                TradeRetrospective.created_at <= trade.exit_ts,
-                TradeRetrospective.created_at >= window_start,
-            )
+            .where(*retro_filters)
             .order_by(TradeRetrospective.created_at.desc())
             .limit(1)
         )

--- a/tests/mcp_server/test_analyze_stock_batch_decision_history.py
+++ b/tests/mcp_server/test_analyze_stock_batch_decision_history.py
@@ -13,7 +13,7 @@ from app.mcp_server.tooling import analysis_tool_handlers as h
 
 @pytest.mark.asyncio
 async def test_attach_decision_history_injects_when_context_exists(monkeypatch):
-    async def _fake_build(db, symbol, market, setup_tag=None):
+    async def _fake_build(db, symbol, market, setup_tag=None, account_mode=None):
         return {"symbol": symbol, "market": market, "prior_decisions": [{"x": 1}]}
 
     monkeypatch.setattr(h, "build_decision_context", _fake_build, raising=False)
@@ -26,7 +26,7 @@ async def test_attach_decision_history_injects_when_context_exists(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_attach_decision_history_fail_open_on_error(monkeypatch):
-    async def _boom(db, symbol, market, setup_tag=None):
+    async def _boom(db, symbol, market, setup_tag=None, account_mode=None):
         raise RuntimeError("db down")
 
     monkeypatch.setattr(h, "build_decision_context", _boom, raising=False)
@@ -39,7 +39,7 @@ async def test_attach_decision_history_fail_open_on_error(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_attach_decision_history_skips_error_rows(monkeypatch):
-    async def _fake_build(db, symbol, market, setup_tag=None):
+    async def _fake_build(db, symbol, market, setup_tag=None, account_mode=None):
         return {"symbol": symbol}
 
     monkeypatch.setattr(h, "build_decision_context", _fake_build, raising=False)
@@ -48,3 +48,23 @@ async def test_attach_decision_history_skips_error_rows(monkeypatch):
     await h._attach_decision_history(results, market="kr")
 
     assert "decision_history" not in results["BADSYM"]
+
+
+@pytest.mark.asyncio
+async def test_attach_decision_history_passes_mock_account_mode(monkeypatch):
+    seen: list[str | None] = []
+
+    async def _fake_build(db, symbol, market, setup_tag=None, account_mode=None):
+        seen.append(account_mode)
+        return {"symbol": symbol, "market": market, "account_mode": account_mode}
+
+    monkeypatch.setattr(h, "build_decision_context", _fake_build, raising=False)
+
+    results = {"005930": {"symbol": "005930", "market_type": "kr"}}
+    await h._attach_decision_history(
+        results, market="kr", decision_history_account_mode="kis_mock"
+    )
+
+    assert seen == ["kis_mock"]
+    assert results["005930"]["decision_history"]["account_mode"] == "kis_mock"
+

--- a/tests/mcp_server/test_analyze_stock_batch_decision_history.py
+++ b/tests/mcp_server/test_analyze_stock_batch_decision_history.py
@@ -67,4 +67,3 @@ async def test_attach_decision_history_passes_mock_account_mode(monkeypatch):
 
     assert seen == ["kis_mock"]
     assert results["005930"]["decision_history"]["account_mode"] == "kis_mock"
-

--- a/tests/services/test_decision_history.py
+++ b/tests/services/test_decision_history.py
@@ -353,3 +353,90 @@ async def test_decision_history_supports_kis_mock_account_mode(
 
     assert len(ctx["realized_outcomes"]) == 1
     assert ctx["realized_outcomes"][0]["pnl_pct"] == 0.02
+
+
+@pytest.mark.asyncio
+async def test_default_decision_history_keeps_legacy_kis_mock_lessons(
+    db_session: AsyncSession,
+) -> None:
+    raw = _uniq_symbol()
+    sym = _normalize_symbol_for_filter(raw, "equity_kr")
+    await _add_retro(
+        db_session,
+        symbol=sym,
+        account_mode="kis_mock",
+        correlation_id=f"legacy-mock:{uuid.uuid4()}",
+        lesson="ROB-705 mock stop lesson remains visible",
+        created_at=datetime(2026, 7, 6, tzinfo=UTC),
+    )
+
+    ctx = await build_decision_context(db_session, symbol=raw, market="kr")
+
+    assert ctx is not None
+    assert "ROB-705 mock stop lesson remains visible" in ctx["prior_lessons"]
+
+
+@pytest.mark.asyncio
+async def test_default_decision_history_excludes_mock_counterfactual_by_cohort(
+    db_session: AsyncSession,
+) -> None:
+    from app.models.review import KISMockOrderLedger
+    from app.models.trading import InstrumentType
+
+    raw = _uniq_symbol()
+    sym = _normalize_symbol_for_filter(raw, "equity_kr")
+    keep_corr = f"legacy-mock:{uuid.uuid4()}"
+    drop_corr = f"mirror-mock:{uuid.uuid4()}"
+
+    db_session.add(
+        KISMockOrderLedger(
+            trade_date=datetime(2026, 7, 6, tzinfo=UTC),
+            symbol=sym,
+            instrument_type=InstrumentType.equity_kr,
+            side="buy",
+            order_type="limit",
+            quantity=Decimal("5"),
+            price=Decimal("1500"),
+            amount=Decimal("7500"),
+            fee=Decimal("0"),
+            currency="KRW",
+            order_no=f"MIRROR-{uuid.uuid4().hex[:8]}",
+            account_mode="kis_mock",
+            broker="kis",
+            status="accepted",
+            lifecycle_state="fill",
+            last_reconcile_detail={"attributed_fill_qty": "5"},
+            mirror_cohort="mock_counterfactual",
+            mirror_source_bucket="place_original",
+            correlation_id=drop_corr,
+        )
+    )
+    await _add_retro(
+        db_session,
+        symbol=sym,
+        account_mode="kis_mock",
+        correlation_id=keep_corr,
+        pnl_pct=Decimal("5.0"),
+        lesson="legacy mock lesson",
+        created_at=datetime(2026, 7, 6, 10, tzinfo=UTC),
+    )
+    await _add_retro(
+        db_session,
+        symbol=sym,
+        account_mode="kis_mock",
+        correlation_id=drop_corr,
+        lesson="mirror counterfactual lesson",
+        created_at=datetime(2026, 7, 6, 11, tzinfo=UTC),
+    )
+    await db_session.flush()
+
+    ctx = await build_decision_context(db_session, symbol=raw, market="kr")
+
+    assert ctx is not None
+    assert "legacy mock lesson" in ctx["prior_lessons"]
+    assert "mirror counterfactual lesson" not in ctx["prior_lessons"]
+    assert all(
+        outcome["pnl_pct"] != 11.9 or outcome["date"] != "2026-07-06"
+        for outcome in ctx["realized_outcomes"]
+    )
+

--- a/tests/services/test_decision_history.py
+++ b/tests/services/test_decision_history.py
@@ -439,4 +439,3 @@ async def test_default_decision_history_excludes_mock_counterfactual_by_cohort(
         outcome["pnl_pct"] != 11.9 or outcome["date"] != "2026-07-06"
         for outcome in ctx["realized_outcomes"]
     )
-

--- a/tests/services/test_trade_journal_aggregates_tag.py
+++ b/tests/services/test_trade_journal_aggregates_tag.py
@@ -139,4 +139,3 @@ async def test_symbol_window_uses_matching_live_account_not_kis_mock(
     assert info.tag == "live_pullback_tag"
     assert info.tag_source == "strategy_key"
     assert info.link_quality == "symbol_window"
-

--- a/tests/services/test_trade_journal_aggregates_tag.py
+++ b/tests/services/test_trade_journal_aggregates_tag.py
@@ -52,7 +52,7 @@ async def test_strategy_key_symbol_window(db_session: AsyncSession):
     )
     await db_session.flush()
 
-    info = await resolve_setup_tag(db_session, _trade(symbol=sym))
+    info = await resolve_setup_tag(db_session, _trade(symbol=sym, account="kis_mock"))
     assert info.tag == "pullback_long"
     assert info.tag_source == "strategy_key"
     assert info.link_quality == "symbol_window"
@@ -65,3 +65,78 @@ async def test_untagged_when_no_signal(db_session: AsyncSession):
     assert info.tag == "untagged"
     assert info.tag_source == "untagged"
     assert info.link_quality == "symbol_window"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("trade_account", "retro_account_mode"),
+    [("kis", "kis_live"), ("toss", "toss_live")],
+)
+async def test_strategy_key_exact_matches_live_account_aliases(
+    db_session: AsyncSession, trade_account: str, retro_account_mode: str
+) -> None:
+    sym = _digit_symbol()
+    norm = _normalize_symbol_for_filter(sym, "equity_kr")
+    corr = f"rob742-exact-{trade_account}-{uuid.uuid4()}"
+    db_session.add(
+        TradeRetrospective(
+            symbol=norm,
+            instrument_type="equity_kr",
+            account_mode=retro_account_mode,
+            outcome="filled",
+            strategy_key=f"{retro_account_mode}_breakout",
+            correlation_id=corr,
+            created_at=datetime(2026, 6, 6, tzinfo=UTC),
+        )
+    )
+    await db_session.flush()
+
+    info = await resolve_setup_tag(
+        db_session,
+        _trade(
+            symbol=sym,
+            account=trade_account,
+            entry_correlation_ids=(corr,),
+            exit_correlation_id=None,
+        ),
+    )
+
+    assert info.tag == f"{retro_account_mode}_breakout"
+    assert info.tag_source == "strategy_key"
+    assert info.link_quality == "exact"
+
+
+@pytest.mark.asyncio
+async def test_symbol_window_uses_matching_live_account_not_kis_mock(
+    db_session: AsyncSession,
+) -> None:
+    sym = _digit_symbol()
+    norm = _normalize_symbol_for_filter(sym, "equity_kr")
+    db_session.add_all(
+        [
+            TradeRetrospective(
+                symbol=norm,
+                instrument_type="equity_kr",
+                account_mode="kis_mock",
+                outcome="filled",
+                strategy_key="mock_counterfactual_tag",
+                created_at=datetime(2026, 6, 4, tzinfo=UTC),
+            ),
+            TradeRetrospective(
+                symbol=norm,
+                instrument_type="equity_kr",
+                account_mode="kis_live",
+                outcome="filled",
+                strategy_key="live_pullback_tag",
+                created_at=datetime(2026, 6, 3, tzinfo=UTC),
+            ),
+        ]
+    )
+    await db_session.flush()
+
+    info = await resolve_setup_tag(db_session, _trade(symbol=sym, account="kis"))
+
+    assert info.tag == "live_pullback_tag"
+    assert info.tag_source == "strategy_key"
+    assert info.link_quality == "symbol_window"
+

--- a/tests/test_mcp_fundamentals_tools.py
+++ b/tests/test_mcp_fundamentals_tools.py
@@ -777,7 +777,9 @@ class TestAnalyzeStockBatch:
         # build_decision_context DB query per symbol and injects a
         # "decision_history" key. Behavior is covered by
         # tests/mcp_server/test_analyze_stock_batch_decision_history.py.
-        async def _no_decision_history(results, *, market=None):
+        async def _no_decision_history(
+            results, *, market=None, decision_history_account_mode=None
+        ):
             return None
 
         monkeypatch.setattr(


### PR DESCRIPTION
## Summary
- Normalize live account labels so KIS/Toss live retrospectives match trade ledger labels in exact and symbol-window setup tag resolution.
- Narrow default decision_history filtering to exclude only mock counterfactual retrospectives by mirror cohort while preserving legacy KIS mock lessons.
- Add an explicit kis_mock decision_history path for analyze_stock_batch and document the new MCP argument.

## Tests
- `uv run --all-groups pytest tests/services/test_trade_journal_aggregates_tag.py tests/services/test_decision_history.py tests/services/test_decision_history_realized_r.py tests/mcp_server/test_analyze_stock_batch_decision_history.py tests/test_stock_detail_providers.py tests/services/test_mirror_counterfactual_plans.py tests/test_mcp_place_order.py -v --no-cov`
- `uv run ruff check app/services/trade_journal/aggregates.py app/services/decision_history.py app/mcp_server/tooling/analysis_tool_handlers.py app/mcp_server/tooling/analysis_registration.py tests/services/test_trade_journal_aggregates_tag.py tests/services/test_decision_history.py tests/mcp_server/test_analyze_stock_batch_decision_history.py`
- `uv run ruff format --check app/services/trade_journal/aggregates.py app/services/decision_history.py app/mcp_server/tooling/analysis_tool_handlers.py app/mcp_server/tooling/analysis_registration.py tests/services/test_trade_journal_aggregates_tag.py tests/services/test_decision_history.py tests/mcp_server/test_analyze_stock_batch_decision_history.py`
- `uv run ty check app/ --error-on-warning`
- `git diff origin/main...HEAD --check`

Linear: ROB-742