### PR TITLE
ROB-743 mirror counterfactual execution hardening

### DIFF
--- a/alembic/versions/20260706_rob743_mirror_idempotency.py
+++ b/alembic/versions/20260706_rob743_mirror_idempotency.py
@@ -1,0 +1,38 @@
+"""ROB-743 mirror idempotency unique index
+
+Revision ID: 20260706_rob743_mirror_idempotency
+Revises: 20260706_rob734_mirror_counterfactual
+Create Date: 2026-07-06
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "20260706_rob743"
+down_revision = "20260706_rob734"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_index(
+        "ux_kis_mock_mirror_report_item_once",
+        "kis_mock_order_ledger",
+        ["mirror_cohort", "report_item_uuid"],
+        unique=True,
+        schema="review",
+        postgresql_where=sa.text(
+            "mirror_cohort = 'mock_counterfactual' AND report_item_uuid IS NOT NULL"
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ux_kis_mock_mirror_report_item_once",
+        table_name="kis_mock_order_ledger",
+        schema="review",
+    )

--- a/app/mcp_server/README.md
+++ b/app/mcp_server/README.md
@@ -306,7 +306,7 @@ full payload, by numeric `id` or `artifact_uuid` string. Missing ids return
 
 - `investment_report_add_items(report_uuid, items, actor=None)` - Append new proposal items to an existing draft investment report. The item payload contract matches `investment_report_create`. Duplicate `client_item_key` rows are returned as existing items and are not rewritten. Non-draft reports return `error="not_draft"`. No broker, order, or watch mutation is performed.
 - `investment_report_update(report_uuid, title=None, summary=None, risk_summary=None, thesis_text=None, no_action_note=None, market_snapshot=None, portfolio_snapshot=None, metadata=None, valid_until=None, actor=None, reason=None)` - Update draft report header fields without changing report identity, lifecycle status, predecessor chain, account scope, generator version, or items. Each successful update appends an audit entry to `report.metadata.draft_updates`. Non-draft reports return `error="not_draft"`.
-- `kis_mock_mirror_execute_report(report_uuid, dry_run=True, min_rung_quantity=1.0)` - Execute ROB-734 mirror counterfactual orders through KIS mock only. The planner mirrors only KR report items with `target_kind="asset"` and a six-digit numeric symbol. Non-KR, US, crypto, index, and FX items are skipped with `reason="non_kr_equity_out_of_mirror_scope"` and counted in `plan_skipped_count`; they are never submitted to `place_order`.
+- `kis_mock_mirror_execute_report(report_uuid, dry_run=True, min_rung_quantity=1.0, confirm=False)` - Execute ROB-734 mirror counterfactual orders through KIS mock only. `dry_run=True` returns per-item `plan` previews including symbol, side, quantity/amount, limit price, target/stop, correlation id, source bucket, and WATCH approximation notes. `dry_run=False` requires `confirm=True`; otherwise the tool fails closed with `error_code="mirror_confirm_required"`. The planner mirrors only KR report items with `target_kind="asset"` and a six-digit numeric symbol. Non-KR, US, crypto, index, and FX items are skipped with `reason="non_kr_equity_out_of_mirror_scope"` and counted in `plan_skipped_count`; they are never submitted to `place_order`. WATCH thresholds are used as prices only when `watch_condition.metric == "price"`; non-price metrics such as RSI are skipped with `reason="unsupported_watch_metric_for_limit_price"`. Breakout/above WATCH conditions are labeled as `watch_approximation=limit_at_threshold`.
 
 ### Alpaca paper read-only smoke tools
 
@@ -890,7 +890,7 @@ Parameters:
 - `setup_tag`: optional tag filter.
 - `min_sample`: default `1`.
 - `cohort`: default `live_gated`. Realized trade-journal cohort to load (e.g., `live_gated`, `mock_counterfactual`).
-- `include_counterfactual_delta`: default `false`. When `true`, returns aggregates delta scoreboard comparing `live_gated` and `mock_counterfactual` paired by entry correlation ID, falling back to `report_item_uuid` for report-linked mirror orders.
+- `include_counterfactual_delta`: default `false`. When `true`, returns aggregates delta scoreboard comparing `live_gated` and `mock_counterfactual` paired by entry correlation ID, falling back to `report_item_uuid` for report-linked mirror orders. When `include_counterfactual_delta=True`, `market`, `account_mode`, `date_from`, `date_to`, `setup_tag`, and `min_sample` are passed into the delta builder and echoed under `filters`.
 
 Returns Win-rate, expectancy (% and R-multiple), profit factor, average/worst MAE and MFE.
 

--- a/app/mcp_server/tooling/kis_mock_ledger.py
+++ b/app/mcp_server/tooling/kis_mock_ledger.py
@@ -406,7 +406,7 @@ async def _record_kis_mock_order(
     # kis_live). publish_place_time_forecast is itself buy+target-gated and runs
     # in its own isolated session, swallowing errors — a forecast hiccup never
     # affects the recorded order.
-    if status == "accepted":
+    if status == "accepted" and ledger_id is not None:
         await publish_place_time_forecast(
             correlation_id=correlation_id,
             symbol=normalized_symbol,

--- a/app/mcp_server/tooling/kis_mock_ledger.py
+++ b/app/mcp_server/tooling/kis_mock_ledger.py
@@ -258,6 +258,8 @@ async def _save_kis_mock_order_ledger(
     gross_pnl: Decimal | None = None,
     net_pnl: Decimal | None = None,
     report_item_uuid: uuid.UUID | None = None,
+    mirror_cohort: str | None = None,
+    mirror_source_bucket: str | None = None,
 ) -> int | None:
     """Insert one row into review.kis_mock_order_ledger.
 
@@ -300,6 +302,8 @@ async def _save_kis_mock_order_ledger(
                     gross_pnl=gross_pnl,
                     net_pnl=net_pnl,
                     report_item_uuid=report_item_uuid,
+                    mirror_cohort=mirror_cohort,
+                    mirror_source_bucket=mirror_source_bucket,
                 )
                 .on_conflict_do_nothing(constraint="uq_kis_mock_ledger_order_no")
             )
@@ -330,6 +334,8 @@ async def _record_kis_mock_order(
     target_price: float | None = None,
     min_hold_days: int | None = None,
     report_item_uuid: uuid.UUID | None = None,
+    mirror_cohort: str | None = None,
+    mirror_source_bucket: str | None = None,
 ) -> dict[str, Any]:
     """Build ledger row from execution result and return the mock-order response dict."""
     price_val = _to_float(dry_run_result.get("price"), default=0.0)
@@ -392,6 +398,8 @@ async def _record_kis_mock_order(
         holdings_baseline_qty=holdings_baseline_qty,
         correlation_id=correlation_id,
         report_item_uuid=report_item_uuid,
+        mirror_cohort=mirror_cohort,
+        mirror_source_bucket=mirror_source_bucket,
     )
 
     # ROB-730: emit the place-time forecast only for accepted orders (mirrors

--- a/app/mcp_server/tooling/mirror_counterfactual_tools.py
+++ b/app/mcp_server/tooling/mirror_counterfactual_tools.py
@@ -12,6 +12,7 @@ async def kis_mock_mirror_execute_report(
     report_uuid: str,
     dry_run: bool = True,
     min_rung_quantity: float = 1.0,
+    confirm: bool = False,
 ) -> dict[str, Any]:
     try:
         rid = UUID(str(report_uuid))
@@ -21,6 +22,16 @@ async def kis_mock_mirror_execute_report(
             "error": "invalid_report_uuid",
             "report_uuid": report_uuid,
         }
+
+    if not dry_run and not confirm:
+        return {
+            "success": False,
+            "status": "blocked",
+            "error": "dry_run=False requires confirm=True for mirror execution",
+            "error_code": "mirror_confirm_required",
+            "report_uuid": report_uuid,
+        }
+
     async with AsyncSessionLocal() as db:
         try:
             result = await execute_mirror_for_report(
@@ -29,8 +40,10 @@ async def kis_mock_mirror_execute_report(
                 dry_run=dry_run,
                 min_rung_quantity=Decimal(str(min_rung_quantity)),
             )
-            if not dry_run:
+            if not dry_run and result.get("success") is True:
                 await db.commit()
+            else:
+                await db.rollback()
             return result
         except ValueError as exc:
             return {"success": False, "error": str(exc), "report_uuid": report_uuid}

--- a/app/mcp_server/tooling/order_execution.py
+++ b/app/mcp_server/tooling/order_execution.py
@@ -721,25 +721,44 @@ async def _execute_and_record(
     # ROB-653 P6-B — KIS has no broker idempotency key; reserve a local intent
     # row before the send. A same-key send the same trading day fails closed.
     # Crypto/Upbit is excluded (it uses the broker-side content identifier).
+    intent_account_scope: str | None = None
+    intent_key: str | None = None
     if (
         not is_mock
         and idempotency_key is not None
+        and market_type
+        in (
+            "equity_kr",
+            "equity_us",
+        )
+    ):
+        intent_account_scope = "kis_live"
+        intent_key = idempotency_key
+    elif (
+        is_mock
+        and mirror_cohort == "mock_counterfactual"
+        and correlation_id is not None
         and market_type in ("equity_kr", "equity_us")
     ):
+        intent_account_scope = "kis_mock"
+        intent_key = correlation_id
+
+    if intent_account_scope is not None and intent_key is not None:
         async with _order_session_factory()() as intent_db:
             try:
                 await OrderSendIntentService(intent_db).reserve(
-                    account_scope="kis_live",
-                    idempotency_key=idempotency_key,
+                    account_scope=intent_account_scope,
+                    idempotency_key=intent_key,
                     symbol=normalized_symbol,
                     side=side,
                 )
             except DuplicateOrderIntent:
                 logger.warning(
-                    "KIS duplicate order intent blocked: symbol=%s side=%s key=%s",
+                    "KIS duplicate order intent blocked: scope=%s symbol=%s side=%s key=%s",
+                    intent_account_scope,
                     normalized_symbol,
                     side,
-                    idempotency_key,
+                    intent_key,
                 )
                 return order_error_fn(
                     "동일 주문이 오늘 이미 전송되어 중복 전송을 차단했습니다 "

--- a/app/mcp_server/tooling/order_execution.py
+++ b/app/mcp_server/tooling/order_execution.py
@@ -701,6 +701,8 @@ async def _execute_and_record(
     report_item_uuid: uuid.UUID | None = None,
     approval_hash_digest: str | None = None,
     idempotency_key: str | None = None,
+    mirror_cohort: str | None = None,
+    mirror_source_bucket: str | None = None,
 ) -> dict[str, Any]:
     """Execute a live order, record history, fills, and journals."""
     # ROB-102: capture pre-order KIS mock holdings as the reconciler baseline.
@@ -818,6 +820,8 @@ async def _execute_and_record(
             target_price=target_price,
             min_hold_days=min_hold_days,
             report_item_uuid=report_item_uuid,
+            mirror_cohort=mirror_cohort,
+            mirror_source_bucket=mirror_source_bucket,
         )
 
     # ROB-395: live KR orders record accepted-only to the live ledger; fills,
@@ -1096,6 +1100,8 @@ async def _place_order_impl(
     report_item_uuid: str | None = None,
     approval_hash: str | None = None,
     rung: str | int | None = None,
+    mirror_cohort: str | None = None,
+    mirror_source_bucket: str | None = None,
 ) -> dict[str, Any]:
     symbol, side_lower, order_type_lower = _validate_inputs(
         symbol,
@@ -1367,6 +1373,8 @@ async def _place_order_impl(
             report_item_uuid=_coerce_report_item_uuid(report_item_uuid),
             approval_hash_digest=approval_digest,
             idempotency_key=idempotency_key,
+            mirror_cohort=mirror_cohort,
+            mirror_source_bucket=mirror_source_bucket,
         )
     except Exception as exc:
         logger.exception(

--- a/app/mcp_server/tooling/trading_scoreboard_tools.py
+++ b/app/mcp_server/tooling/trading_scoreboard_tools.py
@@ -41,8 +41,11 @@ async def get_trading_scoreboard(
                 return await build_counterfactual_delta_scoreboard(
                     db,
                     market=market,
+                    account_mode=account_mode,
                     date_from=_parse_date(date_from),
                     date_to=_parse_date(date_to),
+                    setup_tag=setup_tag,
+                    min_sample=min_sample,
                 )
             return await build_trading_scoreboard(
                 db,

--- a/app/models/review.py
+++ b/app/models/review.py
@@ -206,6 +206,15 @@ class KISMockOrderLedger(Base):
         Index(
             "ix_kis_mock_ledger_mirror_cohort_created", "mirror_cohort", "created_at"
         ),
+        Index(
+            "ux_kis_mock_mirror_report_item_once",
+            "mirror_cohort",
+            "report_item_uuid",
+            unique=True,
+            postgresql_where=text(
+                "mirror_cohort = 'mock_counterfactual' AND report_item_uuid IS NOT NULL"
+            ),
+        ),
         CheckConstraint(
             "mirror_cohort IS NULL OR mirror_cohort IN ('mock_counterfactual')",
             name="ck_kis_mock_ledger_mirror_cohort",

--- a/app/services/trade_journal/aggregates.py
+++ b/app/services/trade_journal/aggregates.py
@@ -600,6 +600,7 @@ async def build_trading_scoreboard(
     use_cache: bool = True,
     now: datetime | None = None,
     cohort: str = "live_gated",
+    fills_override: list[Fill] | None = None,
 ) -> dict:
     """Compute per-tag setup aggregates from live-ledger fills.
 
@@ -617,19 +618,23 @@ async def build_trading_scoreboard(
         cohort,
     )
     stamp = (now or datetime.now(UTC)).timestamp()
-    if use_cache:
+    if use_cache and fills_override is None:
         cached = _scoreboard_cache.get(key)
         if cached and stamp - cached[0] < _SCOREBOARD_TTL_SECONDS:
             return copy.deepcopy(cached[1])
 
-    fills = await load_fills(
-        db,
-        market=market,
-        account_mode=account_mode,
-        date_from=date_from,
-        date_to=date_to,
-        cohort=cohort,
-    )
+    if fills_override is None:
+        fills = await load_fills(
+            db,
+            market=market,
+            account_mode=account_mode,
+            date_from=date_from,
+            date_to=date_to,
+            cohort=cohort,
+        )
+    else:
+        fills = [f for f in fills_override if f.cohort == cohort]
+
     trades = pair_fills_fifo(fills)
     rows: list[TradeMetrics] = []
     for t in trades:
@@ -662,7 +667,7 @@ async def build_trading_scoreboard(
         "as_of": (now or datetime.now(UTC)).isoformat(),
         "count": len(rows),
     }
-    if use_cache:
+    if use_cache and fills_override is None:
         _scoreboard_cache[key] = (stamp, copy.deepcopy(result))
     return result
 
@@ -734,50 +739,64 @@ async def build_counterfactual_delta_scoreboard(
     db: AsyncSession,
     *,
     market: str | None = None,
+    account_mode: str | None = None,
     date_from: date | None = None,
     date_to: date | None = None,
+    setup_tag: str | None = None,
+    min_sample: int = 1,
     include_excursions: bool = False,
     use_cache: bool = True,
 ) -> dict[str, Any]:
+    fills = await load_fills(
+        db,
+        market=market,
+        account_mode=account_mode,
+        date_from=date_from,
+        date_to=date_to,
+        cohort="all",
+    )
     board_live = await build_trading_scoreboard(
         db,
         market=market,
+        account_mode=account_mode,
         date_from=date_from,
         date_to=date_to,
+        setup_tag=setup_tag,
+        min_sample=min_sample,
         include_excursions=include_excursions,
         cohort="live_gated",
-        use_cache=use_cache,
+        use_cache=False,
+        fills_override=fills,
     )
     board_mock = await build_trading_scoreboard(
         db,
         market=market,
-        account_mode="kis_mock",
+        account_mode="kis_mock" if account_mode is None else account_mode,
         date_from=date_from,
         date_to=date_to,
+        setup_tag=setup_tag,
+        min_sample=min_sample,
         include_excursions=include_excursions,
         cohort="mock_counterfactual",
-        use_cache=use_cache,
+        use_cache=False,
+        fills_override=fills,
     )
-    live_trades = pair_fills_fifo(
-        await load_fills(
-            db, market=market, date_from=date_from, date_to=date_to, cohort="live_gated"
-        )
-    )
-    mock_trades = pair_fills_fifo(
-        await load_fills(
-            db,
-            market=market,
-            date_from=date_from,
-            date_to=date_to,
-            cohort="mock_counterfactual",
-        )
-    )
+    live_trades = pair_fills_fifo([f for f in fills if f.cohort == "live_gated"])
+    mock_trades = pair_fills_fifo([f for f in fills if f.cohort == "mock_counterfactual"])
     paired = _pair_by_entry_provenance(live_trades, mock_trades)
     return {
         "live_gated": board_live,
         "mock_counterfactual": board_mock,
         "paired_count": len(paired),
         "overall_delta": _paired_delta(paired),
+        "filters": {
+            "market": market,
+            "account_mode": account_mode,
+            "date_from": date_from.isoformat() if date_from else None,
+            "date_to": date_to.isoformat() if date_to else None,
+            "setup_tag": setup_tag,
+            "min_sample": min_sample,
+        },
         "caveats": [
             "KIS mock fills do not model queue priority, liquidity, slippage, or market impact; mock performance is upward biased."
         ],

--- a/app/services/trade_journal/aggregates.py
+++ b/app/services/trade_journal/aggregates.py
@@ -782,7 +782,9 @@ async def build_counterfactual_delta_scoreboard(
         fills_override=fills,
     )
     live_trades = pair_fills_fifo([f for f in fills if f.cohort == "live_gated"])
-    mock_trades = pair_fills_fifo([f for f in fills if f.cohort == "mock_counterfactual"])
+    mock_trades = pair_fills_fifo(
+        [f for f in fills if f.cohort == "mock_counterfactual"]
+    )
     paired = _pair_by_entry_provenance(live_trades, mock_trades)
     return {
         "live_gated": board_live,

--- a/app/services/trade_journal/aggregates.py
+++ b/app/services/trade_journal/aggregates.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import copy
 import uuid
-from collections import defaultdict, deque
+from collections import Counter, defaultdict, deque
 from dataclasses import dataclass
 from datetime import UTC, date, datetime, timedelta
 from statistics import fmean, median
@@ -705,6 +705,37 @@ def _pair_by_entry_provenance(
     return paired
 
 
+async def _filter_pairs_for_delta(
+    db: AsyncSession,
+    paired: list[tuple[ClosedTrade, ClosedTrade]],
+    *,
+    setup_tag: str | None,
+    min_sample: int,
+) -> list[tuple[ClosedTrade, ClosedTrade]]:
+    if not setup_tag and min_sample <= 1:
+        return paired
+
+    tagged_pairs: list[tuple[str, tuple[ClosedTrade, ClosedTrade]]] = []
+    tag_counts: Counter[str] = Counter()
+    for live_trade, mock_trade in paired:
+        try:
+            tag = await resolve_setup_tag(db, live_trade)
+        except Exception:
+            try:
+                tag = await resolve_setup_tag(db, mock_trade)
+            except Exception:
+                tag = TagInfo("untagged", "untagged", "symbol_window")
+
+        if setup_tag and tag.tag != setup_tag:
+            continue
+        tagged_pairs.append((tag.tag, (live_trade, mock_trade)))
+        tag_counts[tag.tag] += 1
+
+    if min_sample <= 1:
+        return [pair for _, pair in tagged_pairs]
+    return [pair for tag, pair in tagged_pairs if tag_counts[tag] >= min_sample]
+
+
 def _paired_delta(paired: list[tuple[ClosedTrade, ClosedTrade]]) -> dict[str, Any]:
     n = len(paired)
     if n == 0:
@@ -786,6 +817,9 @@ async def build_counterfactual_delta_scoreboard(
         [f for f in fills if f.cohort == "mock_counterfactual"]
     )
     paired = _pair_by_entry_provenance(live_trades, mock_trades)
+    paired = await _filter_pairs_for_delta(
+        db, paired, setup_tag=setup_tag, min_sample=min_sample
+    )
     return {
         "live_gated": board_live,
         "mock_counterfactual": board_mock,

--- a/app/services/trade_journal/mirror_counterfactual.py
+++ b/app/services/trade_journal/mirror_counterfactual.py
@@ -542,7 +542,9 @@ async def execute_mirror_order_plans(
                             or row.mirror_cohort != "mock_counterfactual"
                             or row.mirror_source_bucket != plan.source_bucket
                         ):
-                            await _stamp_mirror_ledger(db, ledger_id=ledger_id, plan=plan)
+                            await _stamp_mirror_ledger(
+                                db, ledger_id=ledger_id, plan=plan
+                            )
                         submitted_count += 1
                         results.append(
                             {

--- a/app/services/trade_journal/mirror_counterfactual.py
+++ b/app/services/trade_journal/mirror_counterfactual.py
@@ -240,6 +240,38 @@ def _min_hold_days_from_item(item: InvestmentReportItem) -> int | None:
     return None
 
 
+def _watch_metric(value: Any) -> str | None:
+    token = str(value or "").strip().lower()
+    return token or None
+
+
+def _watch_price_skip_reason(item: InvestmentReportItem) -> str | None:
+    if item.item_kind != "watch":
+        return None
+    watch_cond = item.watch_condition or {}
+    threshold = watch_cond.get("threshold")
+    if threshold in (None, ""):
+        return None
+    metric = _watch_metric(watch_cond.get("metric") or "price")
+    if metric != "price":
+        return "unsupported_watch_metric_for_limit_price"
+    return None
+
+
+def _watch_notes(item: InvestmentReportItem) -> list[str]:
+    if item.item_kind != "watch":
+        return []
+    watch_cond = item.watch_condition or {}
+    metric = _watch_metric(watch_cond.get("metric") or "price")
+    operator = str(watch_cond.get("operator") or "").strip().lower()
+    notes = [f"watch_metric={metric or 'unknown'}"]
+    if operator:
+        notes.append(f"watch_operator={operator}")
+    if metric == "price" and operator not in {"below", "at_or_below", "lte", "<="}:
+        notes.append("watch_approximation=limit_at_threshold")
+    return notes
+
+
 def _plan_for_item(
     report_market: str,
     report_uuid: UUID,
@@ -272,6 +304,10 @@ def _plan_for_item(
     if not side:
         return None, "missing_side"
 
+    watch_skip = _watch_price_skip_reason(item)
+    if watch_skip is not None:
+        return None, watch_skip
+
     price = _price_from_item(item)
     if price is None:
         return None, "missing_limit_price"
@@ -299,7 +335,7 @@ def _plan_for_item(
         reason=f"ROB-734 mirror counterfactual: {source_bucket}",
         thesis=item.rationale or "counterfactual mirror",
         strategy="mirror_counterfactual",
-        notes=f"source_bucket={source_bucket}",
+        notes=";".join([f"source_bucket={source_bucket}", *_watch_notes(item)]),
     )
     return plan, None
 
@@ -388,6 +424,43 @@ async def _stamp_mirror_ledger(
     await db.flush()
 
 
+def _decimal_str(value: Decimal | None) -> str | None:
+    return None if value is None else str(value)
+
+
+def _plan_summary(plan: MirrorOrderPlan) -> dict[str, Any]:
+    return {
+        "item_uuid": str(plan.item_uuid),
+        "source_bucket": plan.source_bucket,
+        "correlation_id": plan.correlation_id,
+        "symbol": plan.symbol,
+        "side": plan.side,
+        "quantity": _decimal_str(plan.quantity),
+        "amount": _decimal_str(plan.amount),
+        "price": _decimal_str(plan.price),
+        "target_price": _decimal_str(plan.target_price),
+        "stop_loss": _decimal_str(plan.stop_loss),
+        "min_hold_days": plan.min_hold_days,
+        "notes": plan.notes,
+    }
+
+
+def _execution_status(
+    *,
+    planned_count: int,
+    dry_run_count: int,
+    submitted_count: int,
+    skipped_count: int,
+    failed_count: int,
+) -> str:
+    if failed_count == 0:
+        return "ok"
+    non_failed = dry_run_count + submitted_count + skipped_count
+    if planned_count > 0 and non_failed == 0:
+        return "failed"
+    return "partial_failure"
+
+
 async def execute_mirror_order_plans(
     db: AsyncSession,
     *,
@@ -415,6 +488,7 @@ async def execute_mirror_order_plans(
                     "symbol": plan.symbol,
                     "success": False,
                     "reason": "already_mirrored",
+                    "plan": _plan_summary(plan),
                 }
             )
             skipped_count += 1
@@ -441,6 +515,8 @@ async def execute_mirror_order_plans(
                 is_mock=True,
                 correlation_id=plan.correlation_id,
                 report_item_uuid=str(plan.item_uuid),
+                mirror_cohort="mock_counterfactual",
+                mirror_source_bucket=plan.source_bucket,
             )
 
             success = result.get("success", False)
@@ -454,12 +530,19 @@ async def execute_mirror_order_plans(
                             "success": True,
                             "dry_run": True,
                             "approval_hash": result.get("approval_hash"),
+                            "plan": _plan_summary(plan),
                         }
                     )
                 else:
                     ledger_id = result.get("ledger_id")
                     if ledger_id is not None:
-                        await _stamp_mirror_ledger(db, ledger_id=ledger_id, plan=plan)
+                        row = await db.get(KISMockOrderLedger, ledger_id)
+                        if row and (
+                            row.report_item_uuid != plan.item_uuid
+                            or row.mirror_cohort != "mock_counterfactual"
+                            or row.mirror_source_bucket != plan.source_bucket
+                        ):
+                            await _stamp_mirror_ledger(db, ledger_id=ledger_id, plan=plan)
                         submitted_count += 1
                         results.append(
                             {
@@ -467,6 +550,7 @@ async def execute_mirror_order_plans(
                                 "symbol": plan.symbol,
                                 "success": True,
                                 "ledger_id": ledger_id,
+                                "plan": _plan_summary(plan),
                             }
                         )
                     else:
@@ -477,6 +561,7 @@ async def execute_mirror_order_plans(
                                 "symbol": plan.symbol,
                                 "success": False,
                                 "error": "missing_ledger_id",
+                                "plan": _plan_summary(plan),
                             }
                         )
             else:
@@ -487,6 +572,7 @@ async def execute_mirror_order_plans(
                         "symbol": plan.symbol,
                         "success": False,
                         "error": result.get("error") or "place_order_failed",
+                        "plan": _plan_summary(plan),
                     }
                 )
         except Exception as exc:
@@ -497,11 +583,20 @@ async def execute_mirror_order_plans(
                     "symbol": plan.symbol,
                     "success": False,
                     "error": str(exc),
+                    "plan": _plan_summary(plan),
                 }
             )
 
+    status = _execution_status(
+        planned_count=len(plans),
+        dry_run_count=dry_run_count,
+        submitted_count=submitted_count,
+        skipped_count=skipped_count,
+        failed_count=failed_count,
+    )
     return {
-        "success": True,
+        "success": failed_count == 0,
+        "status": status,
         "dry_run": dry_run,
         "cohort": "mock_counterfactual",
         "planned_count": len(plans),

--- a/tests/_schema_bootstrap.py
+++ b/tests/_schema_bootstrap.py
@@ -453,6 +453,7 @@ _DDL_STATEMENTS: tuple[str, ...] = (
     "ALTER TABLE review.kis_mock_order_ledger ADD CONSTRAINT ck_kis_mock_ledger_mirror_cohort CHECK (mirror_cohort IS NULL OR mirror_cohort IN ('mock_counterfactual'))",
     "ALTER TABLE review.kis_mock_order_ledger DROP CONSTRAINT IF EXISTS ck_kis_mock_ledger_mirror_source_bucket",
     "ALTER TABLE review.kis_mock_order_ledger ADD CONSTRAINT ck_kis_mock_ledger_mirror_source_bucket CHECK (mirror_source_bucket IS NULL OR mirror_source_bucket IN ('place_original','watch_trigger','deferred_min_rung'))",
+    "CREATE UNIQUE INDEX IF NOT EXISTS ux_kis_mock_mirror_report_item_once ON review.kis_mock_order_ledger (mirror_cohort, report_item_uuid) WHERE mirror_cohort = 'mock_counterfactual' AND report_item_uuid IS NOT NULL",
     "ALTER TABLE review.trade_retrospectives DROP CONSTRAINT IF EXISTS uq_trade_retrospectives_correlation_id",
     "ALTER TABLE review.trade_retrospectives DROP CONSTRAINT IF EXISTS uq_trade_retrospectives_correlation_account",
     "ALTER TABLE review.trade_retrospectives ADD CONSTRAINT uq_trade_retrospectives_correlation_account UNIQUE (correlation_id, account_mode)",

--- a/tests/mcp_server/test_mirror_counterfactual_tool.py
+++ b/tests/mcp_server/test_mirror_counterfactual_tool.py
@@ -73,7 +73,32 @@ async def test_mirror_counterfactual_tool_commits_apply_results(monkeypatch):
     result = await tool.kis_mock_mirror_execute_report(
         report_uuid="11111111-1111-1111-1111-111111111111",
         dry_run=False,
+        confirm=True,
     )
 
     assert result["success"] is True
     assert fake_db.commits == 1
+
+
+@pytest.mark.asyncio
+async def test_mirror_counterfactual_tool_requires_confirm_for_apply(monkeypatch):
+    from app.mcp_server.tooling import mirror_counterfactual_tools as tool
+
+    called = False
+
+    async def fake_execute(db, **kwargs):
+        nonlocal called
+        called = True
+        return {"success": True}
+
+    monkeypatch.setattr(tool, "execute_mirror_for_report", fake_execute)
+
+    result = await tool.kis_mock_mirror_execute_report(
+        report_uuid="11111111-1111-1111-1111-111111111111",
+        dry_run=False,
+    )
+
+    assert called is False
+    assert result["success"] is False
+    assert result["error_code"] == "mirror_confirm_required"
+

--- a/tests/mcp_server/test_mirror_counterfactual_tool.py
+++ b/tests/mcp_server/test_mirror_counterfactual_tool.py
@@ -101,4 +101,3 @@ async def test_mirror_counterfactual_tool_requires_confirm_for_apply(monkeypatch
     assert called is False
     assert result["success"] is False
     assert result["error_code"] == "mirror_confirm_required"
-

--- a/tests/models/test_rob743_mirror_idempotency_schema.py
+++ b/tests/models/test_rob743_mirror_idempotency_schema.py
@@ -11,7 +11,10 @@ def test_kis_mock_mirror_report_item_has_unique_partial_index():
     }
     idx = indexes["ux_kis_mock_mirror_report_item_once"]
     assert idx.unique is True
-    assert tuple(col.name for col in idx.columns) == ("mirror_cohort", "report_item_uuid")
+    assert tuple(col.name for col in idx.columns) == (
+        "mirror_cohort",
+        "report_item_uuid",
+    )
     where = str(idx.dialect_options["postgresql"]["where"])
     assert "mock_counterfactual" in where
     assert "report_item_uuid IS NOT NULL" in where

--- a/tests/models/test_rob743_mirror_idempotency_schema.py
+++ b/tests/models/test_rob743_mirror_idempotency_schema.py
@@ -1,0 +1,17 @@
+from sqlalchemy import Index
+
+from app.models.review import KISMockOrderLedger
+
+
+def test_kis_mock_mirror_report_item_has_unique_partial_index():
+    indexes = {
+        idx.name: idx
+        for idx in KISMockOrderLedger.__table__.indexes
+        if isinstance(idx, Index)
+    }
+    idx = indexes["ux_kis_mock_mirror_report_item_once"]
+    assert idx.unique is True
+    assert tuple(col.name for col in idx.columns) == ("mirror_cohort", "report_item_uuid")
+    where = str(idx.dialect_options["postgresql"]["where"])
+    assert "mock_counterfactual" in where
+    assert "report_item_uuid IS NOT NULL" in where

--- a/tests/services/test_mirror_counterfactual_execution.py
+++ b/tests/services/test_mirror_counterfactual_execution.py
@@ -103,7 +103,9 @@ async def test_execute_apply_stamps_mock_ledger_metadata(db_session):
 
 
 @pytest.mark.asyncio
-async def test_retry_after_crash_skips_existing_atomically_stamped_mirror_row(db_session):
+async def test_retry_after_crash_skips_existing_atomically_stamped_mirror_row(
+    db_session,
+):
     plan = _plan()
     calls = {"n": 0}
 
@@ -214,5 +216,3 @@ async def test_execute_reports_partial_failure_as_unsuccessful(db_session):
     assert result["failed_count"] == 1
     assert result["success"] is False
     assert result["status"] == "partial_failure"
-
-

--- a/tests/services/test_mirror_counterfactual_execution.py
+++ b/tests/services/test_mirror_counterfactual_execution.py
@@ -100,3 +100,119 @@ async def test_execute_apply_stamps_mock_ledger_metadata(db_session):
     assert refreshed.report_item_uuid == plan.item_uuid
     assert refreshed.mirror_cohort == "mock_counterfactual"
     assert refreshed.mirror_source_bucket == "place_original"
+
+
+@pytest.mark.asyncio
+async def test_retry_after_crash_skips_existing_atomically_stamped_mirror_row(db_session):
+    plan = _plan()
+    calls = {"n": 0}
+
+    async def crash_after_committed_mock_ledger(**kwargs):
+        calls["n"] += 1
+        row = KISMockOrderLedger(
+            trade_date=datetime(2026, 7, 6, tzinfo=UTC),
+            symbol=kwargs["symbol"],
+            instrument_type="equity_kr",
+            side=kwargs["side"],
+            order_type="limit",
+            quantity=Decimal(str(kwargs["quantity"])),
+            price=Decimal(str(kwargs["price"])),
+            amount=Decimal("70000"),
+            fee=Decimal("0"),
+            currency="KRW",
+            order_no=f"ROB743-{calls['n']}-{uuid4().hex[:6]}",
+            account_mode="kis_mock",
+            broker="kis",
+            status="accepted",
+            lifecycle_state="accepted",
+            correlation_id=kwargs["correlation_id"],
+            report_item_uuid=plan.item_uuid,
+            mirror_cohort=kwargs["mirror_cohort"],
+            mirror_source_bucket=kwargs["mirror_source_bucket"],
+        )
+        db_session.add(row)
+        await db_session.commit()
+        raise RuntimeError("crash after ledger commit")
+
+    first = await execute_mirror_order_plans(
+        db_session,
+        plans=[plan],
+        dry_run=False,
+        place_order=crash_after_committed_mock_ledger,
+    )
+
+    await db_session.rollback()
+
+    async def should_not_be_called(**kwargs):
+        raise AssertionError("retry should skip already mirrored item")
+
+    second = await execute_mirror_order_plans(
+        db_session,
+        plans=[plan],
+        dry_run=False,
+        place_order=should_not_be_called,
+    )
+
+    assert first["failed_count"] == 1
+    assert first["success"] is False
+    assert second["skipped_count"] == 1
+    assert second["results"][0]["reason"] == "already_mirrored"
+    assert calls["n"] == 1
+
+
+@pytest.mark.asyncio
+async def test_execute_dry_run_result_includes_full_plan_summary(db_session):
+    plan = _plan()
+
+    async def fake_place_order(**kwargs):
+        return {"success": True, "dry_run": True, "approval_hash": "p6a1.x"}
+
+    result = await execute_mirror_order_plans(
+        db_session,
+        plans=[plan],
+        dry_run=True,
+        place_order=fake_place_order,
+    )
+
+    item = result["results"][0]
+    assert item["plan"] == {
+        "item_uuid": str(plan.item_uuid),
+        "source_bucket": "place_original",
+        "correlation_id": plan.correlation_id,
+        "symbol": "005930",
+        "side": "buy",
+        "quantity": "2",
+        "amount": None,
+        "price": "70000",
+        "target_price": "76000",
+        "stop_loss": "68000",
+        "min_hold_days": 10,
+        "notes": "source_bucket=place_original",
+    }
+    assert result["status"] == "ok"
+    assert result["success"] is True
+
+
+@pytest.mark.asyncio
+async def test_execute_reports_partial_failure_as_unsuccessful(db_session):
+    good = _plan()
+    bad = _plan()
+
+    async def fake_place_order(**kwargs):
+        if kwargs["correlation_id"] == bad.correlation_id:
+            return {"success": False, "error": "broker rejected"}
+        return {"success": True, "dry_run": True, "approval_hash": "p6a1.x"}
+
+    result = await execute_mirror_order_plans(
+        db_session,
+        plans=[good, bad],
+        dry_run=True,
+        place_order=fake_place_order,
+    )
+
+    assert result["dry_run_count"] == 1
+    assert result["failed_count"] == 1
+    assert result["success"] is False
+    assert result["status"] == "partial_failure"
+
+

--- a/tests/services/test_mirror_counterfactual_plans.py
+++ b/tests/services/test_mirror_counterfactual_plans.py
@@ -238,7 +238,9 @@ async def test_watch_item_with_non_price_metric_threshold_is_skipped(db_session)
 
 
 @pytest.mark.asyncio
-async def test_watch_breakout_price_threshold_is_labeled_as_limit_approximation(db_session):
+async def test_watch_breakout_price_threshold_is_labeled_as_limit_approximation(
+    db_session,
+):
     report = await _report(db_session)
     await _item(
         db_session,
@@ -258,4 +260,3 @@ async def test_watch_breakout_price_threshold_is_labeled_as_limit_approximation(
     assert "watch_metric=price" in plan.notes
     assert "watch_operator=above" in plan.notes
     assert "watch_approximation=limit_at_threshold" in plan.notes
-

--- a/tests/services/test_mirror_counterfactual_plans.py
+++ b/tests/services/test_mirror_counterfactual_plans.py
@@ -209,3 +209,53 @@ async def test_crypto_report_item_is_skipped_before_dry_run_false_submit(db_sess
         }
     ]
     assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_watch_item_with_non_price_metric_threshold_is_skipped(db_session):
+    report = await _report(db_session)
+    item = await _item(
+        db_session,
+        report,
+        item_kind="watch",
+        operation="create",
+        watch_condition={"metric": "rsi", "operator": "below", "threshold": "30"},
+        valid_until=datetime(2026, 7, 7, tzinfo=UTC),
+        max_action={"side": "buy", "quantity": "2", "account_mode": "kis_mock"},
+        evidence_snapshot={"price": "70000"},
+    )
+    await db_session.commit()
+
+    result = await build_mirror_order_plans(db_session, report_uuid=report.report_uuid)
+
+    assert result["plans"] == []
+    assert result["skipped"] == [
+        {
+            "item_uuid": str(item.item_uuid),
+            "reason": "unsupported_watch_metric_for_limit_price",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_watch_breakout_price_threshold_is_labeled_as_limit_approximation(db_session):
+    report = await _report(db_session)
+    await _item(
+        db_session,
+        report,
+        item_kind="watch",
+        operation="create",
+        watch_condition={"metric": "price", "operator": "above", "threshold": "72000"},
+        valid_until=datetime(2026, 7, 7, tzinfo=UTC),
+        max_action={"side": "buy", "quantity": "2", "account_mode": "kis_mock"},
+    )
+    await db_session.commit()
+
+    result = await build_mirror_order_plans(db_session, report_uuid=report.report_uuid)
+    [plan] = result["plans"]
+
+    assert plan.price == Decimal("72000")
+    assert "watch_metric=price" in plan.notes
+    assert "watch_operator=above" in plan.notes
+    assert "watch_approximation=limit_at_threshold" in plan.notes
+

--- a/tests/services/test_trade_journal_aggregates_scoreboard.py
+++ b/tests/services/test_trade_journal_aggregates_scoreboard.py
@@ -185,3 +185,171 @@ async def test_counterfactual_delta_loads_fills_once(db_session, monkeypatch):
             "cohort": "all",
         }
     ]
+
+
+@pytest.mark.asyncio
+async def test_counterfactual_delta_setup_tag_filters_pairing(db_session, monkeypatch):
+    ts1 = datetime(2026, 7, 1, tzinfo=UTC)
+    ts2 = datetime(2026, 7, 2, tzinfo=UTC)
+
+    async def fake_load_fills(db, **kw):
+        return [
+            agg.Fill(
+                market="kr",
+                symbol="005930",
+                account="kis_live",
+                side="buy",
+                qty=1,
+                price=100,
+                fee=0,
+                ts=ts1,
+                item_uuid="item-1",
+                correlation_id="mirror:item-1",
+                source="kis",
+                cohort="live_gated",
+            ),
+            agg.Fill(
+                market="kr",
+                symbol="005930",
+                account="kis_live",
+                side="sell",
+                qty=1,
+                price=110,
+                fee=0,
+                ts=ts2,
+                item_uuid="item-1",
+                correlation_id="mirror:item-1",
+                source="kis",
+                cohort="live_gated",
+            ),
+            agg.Fill(
+                market="kr",
+                symbol="005930",
+                account="kis_mock",
+                side="buy",
+                qty=1,
+                price=100,
+                fee=0,
+                ts=ts1,
+                item_uuid="item-1",
+                correlation_id="mirror:item-1",
+                source="kis_mock",
+                cohort="mock_counterfactual",
+            ),
+            agg.Fill(
+                market="kr",
+                symbol="005930",
+                account="kis_mock",
+                side="sell",
+                qty=1,
+                price=120,
+                fee=0,
+                ts=ts2,
+                item_uuid="item-1",
+                correlation_id="mirror:item-1",
+                source="kis_mock",
+                cohort="mock_counterfactual",
+            ),
+        ]
+
+    async def fake_resolve_setup_tag(db, trade):
+        return TagInfo("mean_revert", "strategy_key", "exact")
+
+    monkeypatch.setattr(agg, "load_fills", fake_load_fills)
+    monkeypatch.setattr(agg, "resolve_setup_tag", fake_resolve_setup_tag)
+
+    result = await agg.build_counterfactual_delta_scoreboard(
+        db_session,
+        market="kr",
+        setup_tag="breakout",
+        min_sample=1,
+        use_cache=False,
+    )
+
+    assert result["live_gated"]["groups"] == []
+    assert result["mock_counterfactual"]["groups"] == []
+    assert result["paired_count"] == 0
+    assert result["overall_delta"]["paired_n"] == 0
+
+
+@pytest.mark.asyncio
+async def test_counterfactual_delta_min_sample_filters_pairing(db_session, monkeypatch):
+    ts1 = datetime(2026, 7, 1, tzinfo=UTC)
+    ts2 = datetime(2026, 7, 2, tzinfo=UTC)
+
+    async def fake_load_fills(db, **kw):
+        return [
+            agg.Fill(
+                "kr",
+                "005930",
+                "kis_live",
+                "buy",
+                1,
+                100,
+                0,
+                ts1,
+                "item-1",
+                "mirror:item-1",
+                "kis",
+                "live_gated",
+            ),
+            agg.Fill(
+                "kr",
+                "005930",
+                "kis_live",
+                "sell",
+                1,
+                110,
+                0,
+                ts2,
+                "item-1",
+                "mirror:item-1",
+                "kis",
+                "live_gated",
+            ),
+            agg.Fill(
+                "kr",
+                "005930",
+                "kis_mock",
+                "buy",
+                1,
+                100,
+                0,
+                ts1,
+                "item-1",
+                "mirror:item-1",
+                "kis_mock",
+                "mock_counterfactual",
+            ),
+            agg.Fill(
+                "kr",
+                "005930",
+                "kis_mock",
+                "sell",
+                1,
+                120,
+                0,
+                ts2,
+                "item-1",
+                "mirror:item-1",
+                "kis_mock",
+                "mock_counterfactual",
+            ),
+        ]
+
+    async def fake_resolve_setup_tag(db, trade):
+        return TagInfo("breakout", "strategy_key", "exact")
+
+    monkeypatch.setattr(agg, "load_fills", fake_load_fills)
+    monkeypatch.setattr(agg, "resolve_setup_tag", fake_resolve_setup_tag)
+
+    result = await agg.build_counterfactual_delta_scoreboard(
+        db_session,
+        market="kr",
+        setup_tag="breakout",
+        min_sample=2,
+        use_cache=False,
+    )
+
+    assert result["paired_count"] == 0
+    assert result["overall_delta"]["paired_n"] == 0

--- a/tests/services/test_trade_journal_aggregates_scoreboard.py
+++ b/tests/services/test_trade_journal_aggregates_scoreboard.py
@@ -155,3 +155,33 @@ async def test_cache_returns_isolated_copies(db_session, monkeypatch):
     second = await agg.build_trading_scoreboard(db_session, now=stamp)  # cache hit
     assert second["groups"] == []
     assert second["count"] == 0
+
+
+@pytest.mark.asyncio
+async def test_counterfactual_delta_loads_fills_once(db_session, monkeypatch):
+    calls = []
+
+    async def fake_load_fills(db, **kw):
+        calls.append(kw)
+        return []
+
+    monkeypatch.setattr(agg, "load_fills", fake_load_fills)
+
+    result = await agg.build_counterfactual_delta_scoreboard(
+        db_session,
+        market="kr",
+        setup_tag="breakout",
+        min_sample=2,
+        use_cache=False,
+    )
+
+    assert result["paired_count"] == 0
+    assert calls == [
+        {
+            "market": "kr",
+            "account_mode": None,
+            "date_from": None,
+            "date_to": None,
+            "cohort": "all",
+        }
+    ]

--- a/tests/services/test_trade_journal_mirror_aggregates.py
+++ b/tests/services/test_trade_journal_mirror_aggregates.py
@@ -114,7 +114,6 @@ async def test_delta_scoreboard_pairs_by_report_item_when_correlation_differs(
                 account_mode="kis_live",
                 broker="kis",
                 correlation_id="live-exit",
-                report_item_uuid=common["report_item_uuid"],
             ),
             KISMockOrderLedger(
                 trade_date=when,
@@ -158,7 +157,6 @@ async def test_delta_scoreboard_pairs_by_report_item_when_correlation_differs(
                 mirror_cohort="mock_counterfactual",
                 mirror_source_bucket="place_original",
                 correlation_id="mock-exit",
-                report_item_uuid=common["report_item_uuid"],
             ),
         ]
     )

--- a/tests/test_invest_view_model_double_buy_screener.py
+++ b/tests/test_invest_view_model_double_buy_screener.py
@@ -30,12 +30,60 @@ _TEST_SYMBOLS = [
 
 
 @pytest_asyncio.fixture(autouse=True)
-async def _clean_double_buy_test_rows(db_session):
+async def _clean_double_buy_test_rows(db_session, monkeypatch):
     """Wipe just the rows this test owns before and after each test.
 
     The persistent test DB is shared with other suites, so we never TRUNCATE —
     we only delete rows scoped to the synthetic symbols below.
     """
+    from app.services.invest_screener_snapshots import partition_health
+    from app.services.invest_screener_snapshots.partition_health import (
+        HealthyPartition,
+    )
+
+    async def _resolve_raw_latest_partition(
+        session,
+        *,
+        model,
+        date_col,
+        market_col,
+        market,
+        **_kwargs,
+    ):
+        # These loader tests assert double-buy filtering/join behavior. Partition
+        # health fallback is covered separately; using the raw latest partition
+        # keeps this file stable when other xdist workers seed an older healthy
+        # shared-DB partition.
+        newest = (
+            await session.execute(
+                sa.select(sa.func.max(date_col)).where(market_col == market)
+            )
+        ).scalar_one_or_none()
+        if newest is None:
+            return None
+        row_count = int(
+            (
+                await session.execute(
+                    sa.select(sa.func.count())
+                    .select_from(model)
+                    .where(market_col == market, date_col == newest)
+                )
+            ).scalar()
+            or 0
+        )
+        return HealthyPartition(
+            partition_date=newest,
+            row_count=row_count,
+            coverage_ratio=1.0,
+            is_fallback=False,
+            healthy=True,
+        )
+
+    monkeypatch.setattr(
+        partition_health,
+        "resolve_healthy_partition",
+        _resolve_raw_latest_partition,
+    )
 
     async def _purge() -> None:
         await db_session.execute(

--- a/tests/test_kis_mock_order_ledger.py
+++ b/tests/test_kis_mock_order_ledger.py
@@ -978,3 +978,42 @@ async def test_save_kis_mock_order_ledger_persists_report_item_uuid(db_session):
         )
     ).scalar_one()
     assert row.report_item_uuid == item_uuid
+
+
+@pytest.mark.asyncio
+async def test_record_kis_mock_order_threads_mirror_metadata(monkeypatch):
+    from unittest.mock import AsyncMock
+    from uuid import uuid4
+
+    from app.mcp_server.tooling import kis_mock_ledger
+
+    save = AsyncMock(return_value=123)
+    pub = AsyncMock(return_value="forecast-1")
+    monkeypatch.setattr(kis_mock_ledger, "_save_kis_mock_order_ledger", save)
+    monkeypatch.setattr(kis_mock_ledger, "publish_place_time_forecast", pub)
+
+    item_uuid = uuid4()
+    result = await kis_mock_ledger._record_kis_mock_order(
+        normalized_symbol="005930",
+        market_type="equity_kr",
+        side="buy",
+        order_type="limit",
+        dry_run_result={"price": 70000, "quantity": 1, "estimated_value": 70000},
+        execution_result={"rt_cd": "0", "odno": "ROB743-1"},
+        reason="ROB-743",
+        thesis="mirror",
+        strategy="mirror_counterfactual",
+        notes="source_bucket=place_original",
+        correlation_id=f"mirror:{item_uuid}",
+        target_price=76000,
+        min_hold_days=10,
+        report_item_uuid=item_uuid,
+        mirror_cohort="mock_counterfactual",
+        mirror_source_bucket="place_original",
+    )
+
+    assert result["ledger_id"] == 123
+    assert save.await_args.kwargs["report_item_uuid"] == item_uuid
+    assert save.await_args.kwargs["mirror_cohort"] == "mock_counterfactual"
+    assert save.await_args.kwargs["mirror_source_bucket"] == "place_original"
+

--- a/tests/test_kis_mock_order_ledger.py
+++ b/tests/test_kis_mock_order_ledger.py
@@ -1016,3 +1016,121 @@ async def test_record_kis_mock_order_threads_mirror_metadata(monkeypatch):
     assert save.await_args.kwargs["report_item_uuid"] == item_uuid
     assert save.await_args.kwargs["mirror_cohort"] == "mock_counterfactual"
     assert save.await_args.kwargs["mirror_source_bucket"] == "place_original"
+
+
+@pytest.mark.asyncio
+async def test_record_kis_mock_order_does_not_publish_forecast_without_ledger_id(
+    monkeypatch,
+):
+    from uuid import uuid4
+
+    from app.mcp_server.tooling import kis_mock_ledger
+
+    save = AsyncMock(return_value=None)
+    pub = AsyncMock(return_value="forecast-orphan")
+    monkeypatch.setattr(kis_mock_ledger, "_save_kis_mock_order_ledger", save)
+    monkeypatch.setattr(kis_mock_ledger, "publish_place_time_forecast", pub)
+
+    item_uuid = uuid4()
+    result = await kis_mock_ledger._record_kis_mock_order(
+        normalized_symbol="005930",
+        market_type="equity_kr",
+        side="buy",
+        order_type="limit",
+        dry_run_result={"price": 70000, "quantity": 1, "estimated_value": 70000},
+        execution_result={"rt_cd": "0", "odno": "ROB743-duplicate"},
+        reason="ROB-743",
+        thesis="mirror",
+        strategy="mirror_counterfactual",
+        notes="source_bucket=place_original",
+        correlation_id=f"mirror:{item_uuid}",
+        target_price=76000,
+        min_hold_days=10,
+        report_item_uuid=item_uuid,
+        mirror_cohort="mock_counterfactual",
+        mirror_source_bucket="place_original",
+    )
+
+    assert result["ledger_id"] is None
+    pub.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_mirror_mock_duplicate_intent_blocks_second_broker_send(
+    db_session,
+    monkeypatch,
+):
+    from unittest.mock import AsyncMock
+    from uuid import uuid4
+
+    from sqlalchemy import delete
+
+    from app.mcp_server.tooling import order_execution
+    from app.models.review import OrderSendIntent
+
+    await db_session.execute(delete(OrderSendIntent))
+    await db_session.commit()
+
+    monkeypatch.setattr(
+        "app.mcp_server.tooling.orders_registration.validate_kis_mock_config",
+        lambda *_, **__: [],
+    )
+    execute_order = AsyncMock(
+        return_value={
+            "odno": "ROB743-accepted",
+            "ord_tmd": "091500",
+            "msg": "정상처리",
+            "rt_cd": "0",
+        }
+    )
+    monkeypatch.setattr(order_execution, "_execute_order", execute_order)
+    monkeypatch.setattr(
+        order_execution,
+        "_fetch_current_price",
+        AsyncMock(return_value=70000.0),
+    )
+    monkeypatch.setattr(
+        order_execution,
+        "_build_preview",
+        AsyncMock(
+            return_value={
+                "symbol": "005930",
+                "side": "buy",
+                "order_type": "limit",
+                "price": 70000.0,
+                "quantity": 1,
+                "estimated_value": 70000.0,
+                "fee": 0,
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        order_execution,
+        "_check_balance_and_warn",
+        AsyncMock(return_value=(None, None)),
+    )
+    monkeypatch.setattr(order_execution, "_record_order_history", AsyncMock())
+
+    item_uuid = uuid4()
+    kwargs = {
+        "symbol": "005930",
+        "side": "buy",
+        "order_type": "limit",
+        "quantity": 1,
+        "price": 70000,
+        "dry_run": False,
+        "reason": "ROB-743 mirror",
+        "is_mock": True,
+        "correlation_id": f"mirror:{item_uuid}",
+        "report_item_uuid": str(item_uuid),
+        "mirror_cohort": "mock_counterfactual",
+        "mirror_source_bucket": "place_original",
+    }
+
+    first = await order_execution._place_order_impl(**kwargs)
+    second = await order_execution._place_order_impl(**kwargs)
+
+    assert first["success"] is True, first
+    assert second["success"] is False
+    assert "duplicate order intent" in second["error"]
+    assert execute_order.await_count == 1

--- a/tests/test_kis_mock_order_ledger.py
+++ b/tests/test_kis_mock_order_ledger.py
@@ -1016,4 +1016,3 @@ async def test_record_kis_mock_order_threads_mirror_metadata(monkeypatch):
     assert save.await_args.kwargs["report_item_uuid"] == item_uuid
     assert save.await_args.kwargs["mirror_cohort"] == "mock_counterfactual"
     assert save.await_args.kwargs["mirror_source_bucket"] == "place_original"
-

--- a/tests/test_mcp_trading_scoreboard.py
+++ b/tests/test_mcp_trading_scoreboard.py
@@ -22,9 +22,23 @@ async def test_scoreboard_tool_shape_hermetic(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_scoreboard_tool_calls_counterfactual_delta(monkeypatch):
+    seen = {}
+
     async def fake_delta(db, **kw):
+        seen.update(kw)
         return {"paired_count": 5, "overall_delta": {}, "caveats": []}
 
     monkeypatch.setattr(tool, "build_counterfactual_delta_scoreboard", fake_delta)
-    result = await tool.get_trading_scoreboard(include_counterfactual_delta=True)
+    result = await tool.get_trading_scoreboard(
+        market="kr",
+        account_mode="kis_mock",
+        setup_tag="breakout",
+        min_sample=3,
+        include_counterfactual_delta=True,
+    )
+
     assert result["paired_count"] == 5
+    assert seen["market"] == "kr"
+    assert seen["account_mode"] == "kis_mock"
+    assert seen["setup_tag"] == "breakout"
+    assert seen["min_sample"] == 3


### PR DESCRIPTION
## Summary
- harden KIS mirror mock idempotency by reserving mock counterfactual sends before broker execution
- avoid publishing place-time forecasts when mock ledger persistence does not return a ledger id
- apply setup_tag/min_sample filters to counterfactual delta pair counts and overall delta
- add regression coverage for duplicate mirror sends, ledger forecast gating, and delta filtering

## Verification
- uv run ruff format --check app/mcp_server/tooling/kis_mock_ledger.py app/mcp_server/tooling/order_execution.py app/services/trade_journal/aggregates.py tests/test_kis_mock_order_ledger.py tests/services/test_trade_journal_aggregates_scoreboard.py
- uv run ruff check app/mcp_server/tooling/kis_mock_ledger.py app/mcp_server/tooling/order_execution.py app/services/trade_journal/aggregates.py tests/test_kis_mock_order_ledger.py tests/services/test_trade_journal_aggregates_scoreboard.py
- uv run python -m py_compile alembic/versions/20260706_rob743_mirror_idempotency.py
- uv run alembic heads
- uv run pytest tests/models/test_rob743_mirror_idempotency_schema.py tests/test_kis_mock_order_ledger.py::test_record_kis_mock_order_threads_mirror_metadata tests/test_kis_mock_order_ledger.py::test_record_kis_mock_order_does_not_publish_forecast_without_ledger_id tests/test_kis_mock_order_ledger.py::test_mirror_mock_duplicate_intent_blocks_second_broker_send tests/services/test_mirror_counterfactual_plans.py tests/services/test_mirror_counterfactual_execution.py tests/mcp_server/test_mirror_counterfactual_tool.py tests/test_mcp_trading_scoreboard.py tests/services/test_trade_journal_aggregates_scoreboard.py -v

## Notes
- leaves the local untracked planning note out of the PR: docs/superpowers/plans/2026-07-06-rob-743-mirror-execution-hardening.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Mirror execution now requires explicit confirmation before applying changes, helping prevent accidental live runs.
  * Trading scoreboard results now support additional filtering and show the active filters in counterfactual delta output.

* **Bug Fixes**
  * Improved mirror execution idempotency so repeated runs avoid duplicating the same mirrored item.
  * Enhanced mirror handling for watch items, including clearer skip behavior and threshold-based approximations.
  * Added more detailed execution status reporting, including partial failures and per-item plan summaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->