### PR TITLE
[codex] ROB-745 analysis readonly MCP profile

### DIFF
--- a/alembic/versions/20260706_rob745_allow_codex_created_by.py
+++ b/alembic/versions/20260706_rob745_allow_codex_created_by.py
@@ -1,0 +1,80 @@
+"""ROB-745 allow codex created_by labels.
+
+Revision ID: 20260706_rob745_codex_created_by
+Revises: 20260706_rob734
+Create Date: 2026-07-06
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+
+revision = "20260706_rob745_codex_created_by"
+down_revision = "20260706_rob734"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.drop_constraint(
+        "ck_analysis_artifacts_created_by",
+        "analysis_artifacts",
+        schema="review",
+        type_="check",
+    )
+    op.create_check_constraint(
+        "ck_analysis_artifacts_created_by",
+        "analysis_artifacts",
+        "created_by IN ('claude','operator','system','codex')",
+        schema="review",
+    )
+    op.drop_constraint(
+        "ck_operator_session_context_created_by",
+        "operator_session_context",
+        schema="review",
+        type_="check",
+    )
+    op.create_check_constraint(
+        "ck_operator_session_context_created_by",
+        "operator_session_context",
+        "created_by IN ('claude','operator','system','codex')",
+        schema="review",
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        "UPDATE review.analysis_artifacts "
+        "SET created_by = 'claude' "
+        "WHERE created_by = 'codex'"
+    )
+    op.execute(
+        "UPDATE review.operator_session_context "
+        "SET created_by = 'claude' "
+        "WHERE created_by = 'codex'"
+    )
+    op.drop_constraint(
+        "ck_analysis_artifacts_created_by",
+        "analysis_artifacts",
+        schema="review",
+        type_="check",
+    )
+    op.create_check_constraint(
+        "ck_analysis_artifacts_created_by",
+        "analysis_artifacts",
+        "created_by IN ('claude','operator','system')",
+        schema="review",
+    )
+    op.drop_constraint(
+        "ck_operator_session_context_created_by",
+        "operator_session_context",
+        schema="review",
+        type_="check",
+    )
+    op.create_check_constraint(
+        "ck_operator_session_context_created_by",
+        "operator_session_context",
+        "created_by IN ('claude','operator','system')",
+        schema="review",
+    )

--- a/alembic/versions/20260706_rob745_allow_codex_created_by.py
+++ b/alembic/versions/20260706_rob745_allow_codex_created_by.py
@@ -1,7 +1,7 @@
 """ROB-745 allow codex created_by labels.
 
 Revision ID: 20260706_rob745_codex_created_by
-Revises: 20260706_rob734
+Revises: 20260706_rob743
 Create Date: 2026-07-06
 """
 
@@ -11,7 +11,7 @@ from alembic import op
 
 
 revision = "20260706_rob745_codex_created_by"
-down_revision = "20260706_rob734"
+down_revision = "20260706_rob743"
 branch_labels = None
 depends_on = None
 

--- a/app/mcp_server/README.md
+++ b/app/mcp_server/README.md
@@ -1691,13 +1691,11 @@ Here is an example Codex config file to connect to the analysis-readonly MCP ser
 # ~/.codex/config.toml
 # Relaxed approval is scoped to the analysis-readonly MCP server only.
 [mcp_servers.auto_trader_analysis_readonly]
-type = "streamable_http"
 url = "http://127.0.0.1:8768/mcp"
-default_tools_approval_mode = "never"
+bearer_token_env_var = "MCP_ANALYSIS_READONLY_AUTH_TOKEN"
+default_tools_approval_mode = "auto"
 
-[mcp_servers.auto_trader_analysis_readonly.headers]
-Authorization = "Bearer ${MCP_ANALYSIS_READONLY_AUTH_TOKEN}"
-x-paperclip-agent-id = "codex-analysis-readonly"
+http_headers = { "x-paperclip-agent-id" = "codex-analysis-readonly" }
 ```
 
 ### Typed KIS order tools

--- a/app/mcp_server/README.md
+++ b/app/mcp_server/README.md
@@ -1628,6 +1628,7 @@ The `MCP_PROFILE` env var selects which tool subset is registered at startup.
 | US paper | `us-paper` | Default read-only/research surface plus Alpaca paper and `us_dual_paper_*` tools; no KIS/generic order tools |
 | DB paper simulator | `db-paper` | Default read-only/research surface plus internal `paper.paper_*` simulator account, analytics, and journal bridge tools; no KIS/generic order tools |
 | Kiwoom mock | `kiwoom` | Default read-only/research surface plus typed `kiwoom_mock_*` variants only (no KIS/generic order tools) |
+| Analysis readonly | `analysis_readonly` | Codex/headless read/analysis allowlist only: `get_operating_briefing`, `route_request`, `get_trading_policy`, selected quote/fundamental/analysis tools, `get_holdings`, `toss_get_positions`, and explicitly labeled analysis persistence. No order/cancel/modify/reconcile/preview/settings/watch/admin/manual-holdings mutation tools are registered. |
 
 ### Profile: `hermes-paper-kis`
 
@@ -1639,6 +1640,65 @@ Set `MCP_PROFILE=hermes-paper-kis` on paper-only deployments (e.g., where `KIS_M
 - Shared read-only research and portfolio tools remain available; split-profile-only tools such as Alpaca paper, crypto-only, and Kiwoom are absent.
 
 **Operator validation:** after deploying with `hermes-paper-kis`, check the MCP `/mcp` listing and confirm that none of `kis_live_*` or the legacy ambiguous order tools appear.
+
+### Profile: `analysis_readonly` (ROB-745)
+
+Use `MCP_PROFILE=analysis_readonly` for Codex/headless consumers that need market analysis tools but must not see the operator's full order-capable MCP surface.
+
+Allowed tools:
+- `get_operating_briefing`
+- `route_request`
+- `get_trading_policy`
+- `get_market_index`
+- `get_quote`
+- `analyze_stock_batch`
+- `get_support_resistance`
+- `get_indicators`
+- `screen_stocks`
+- `screen_stocks_snapshot`
+- `get_top_stocks`
+- `get_news`
+- `get_fx_rate`
+- `get_holdings`
+- `toss_get_positions`
+- `get_intraday_investor_flow`
+- `analysis_artifact_save`
+- `analysis_artifact_get`
+- `forecast_save`
+- `session_context_append`
+- `session_context_get_recent`
+
+Forbidden by physical non-registration:
+- order placement, cancel, modify, history, reconcile, and preview tools
+- KIS live/mock order variants
+- Kiwoom order variants
+- Alpaca/DB paper order surfaces
+- Toss place/modify/cancel/history/orderable-cash/reconcile/preview
+- manual holdings mutation
+- user settings tools
+- watch/admin/report-writing surfaces
+
+Persistence tools on this profile require explicit provenance:
+- pass `created_by="codex"` for `analysis_artifact_save`
+- pass `created_by="codex"` in every `session_context_append` entry
+- pass `created_by="codex"` to `forecast_save`
+
+### Codex Config Example
+
+Here is an example Codex config file to connect to the analysis-readonly MCP server with relaxed approval:
+
+```toml
+# ~/.codex/config.toml
+# Relaxed approval is scoped to the analysis-readonly MCP server only.
+[mcp_servers.auto_trader_analysis_readonly]
+type = "streamable_http"
+url = "http://127.0.0.1:8768/mcp"
+default_tools_approval_mode = "never"
+
+[mcp_servers.auto_trader_analysis_readonly.headers]
+Authorization = "Bearer ${MCP_ANALYSIS_READONLY_AUTH_TOKEN}"
+x-paperclip-agent-id = "codex-analysis-readonly"
+```
 
 ### Typed KIS order tools
 

--- a/app/mcp_server/README.md
+++ b/app/mcp_server/README.md
@@ -1628,7 +1628,7 @@ The `MCP_PROFILE` env var selects which tool subset is registered at startup.
 | US paper | `us-paper` | Default read-only/research surface plus Alpaca paper and `us_dual_paper_*` tools; no KIS/generic order tools |
 | DB paper simulator | `db-paper` | Default read-only/research surface plus internal `paper.paper_*` simulator account, analytics, and journal bridge tools; no KIS/generic order tools |
 | Kiwoom mock | `kiwoom` | Default read-only/research surface plus typed `kiwoom_mock_*` variants only (no KIS/generic order tools) |
-| Analysis readonly | `analysis_readonly` | Codex/headless read/analysis allowlist only: `get_operating_briefing`, `route_request`, `get_trading_policy`, selected quote/fundamental/analysis tools, `get_holdings`, `toss_get_positions`, and explicitly labeled analysis persistence. No order/cancel/modify/reconcile/preview/settings/watch/admin/manual-holdings mutation tools are registered. |
+| Analysis readonly | `analysis_readonly` | Codex/headless read/analysis allowlist only: `get_operating_briefing`, `route_request`, `get_trading_policy`, selected quote/fundamental/analysis tools, `suggest_order_account`, `get_holdings`, `toss_get_positions`, and explicitly labeled analysis persistence. No order/cancel/modify/reconcile/preview/settings/watch/admin/manual-holdings mutation tools are registered. |
 
 ### Profile: `hermes-paper-kis`
 
@@ -1659,6 +1659,7 @@ Allowed tools:
 - `get_top_stocks`
 - `get_news`
 - `get_fx_rate`
+- `suggest_order_account`
 - `get_holdings`
 - `toss_get_positions`
 - `get_intraday_investor_flow`

--- a/app/mcp_server/profiles.py
+++ b/app/mcp_server/profiles.py
@@ -17,6 +17,7 @@ class McpProfile(StrEnum):
     DB_PAPER = "db-paper"
     KIWOOM = "kiwoom"
     SHADOW_REPLAY = "shadow-replay"
+    ANALYSIS_READONLY = "analysis_readonly"
 
 
 def resolve_mcp_profile(env: str | None) -> McpProfile:

--- a/app/mcp_server/tooling/analysis_readonly_registration.py
+++ b/app/mcp_server/tooling/analysis_readonly_registration.py
@@ -203,7 +203,8 @@ def _register_persistence_tools(mcp: FastMCP) -> None:
             missing = [
                 idx
                 for idx, entry in enumerate(entries)
-                if not _clean_created_by(str(entry.get("created_by", "")))
+                if isinstance(entry, dict)
+                and not _clean_created_by(str(entry.get("created_by", "")))
             ]
             if missing:
                 return {

--- a/app/mcp_server/tooling/analysis_readonly_registration.py
+++ b/app/mcp_server/tooling/analysis_readonly_registration.py
@@ -1,0 +1,243 @@
+"""Read-only analysis MCP profile registration for Codex/headless consumers."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any, TypeVar, cast
+
+from app.mcp_server.tooling.analysis_artifact_tools import (
+    analysis_artifact_get as _analysis_artifact_get,
+)
+from app.mcp_server.tooling.analysis_artifact_tools import (
+    analysis_artifact_save as _analysis_artifact_save,
+)
+from app.mcp_server.tooling.analysis_registration import register_analysis_tools
+from app.mcp_server.tooling.forecast_registration import register_forecast_tools
+from app.mcp_server.tooling.fundamentals_registration import register_fundamentals_tools
+from app.mcp_server.tooling.market_data_registration import register_market_data_tools
+from app.mcp_server.tooling.operating_briefing_registration import (
+    register_operating_briefing_tools,
+)
+from app.mcp_server.tooling.orders_kis_variants import (
+    KIS_LIVE_ORDER_TOOL_NAMES,
+    KIS_MOCK_ORDER_TOOL_NAMES,
+    LIVE_RECONCILE_TOOL_NAMES,
+)
+from app.mcp_server.tooling.orders_kiwoom_variants import KIWOOM_MOCK_TOOL_NAMES
+from app.mcp_server.tooling.orders_registration import ORDER_TOOL_NAMES
+from app.mcp_server.tooling.orders_toss_variants import (
+    TOSS_LIVE_ORDER_TOOL_NAMES,
+    register_toss_live_order_tools,
+)
+from app.mcp_server.tooling.paper_limit_order_handler import (
+    PAPER_LIMIT_ORDER_TOOL_NAMES,
+)
+from app.mcp_server.tooling.portfolio_registration import register_portfolio_tools
+from app.mcp_server.tooling.route_request_registration import (
+    register_route_request_tools,
+)
+from app.mcp_server.tooling.session_context_tools import (
+    session_context_append as _session_context_append,
+)
+from app.mcp_server.tooling.session_context_tools import (
+    session_context_get_recent as _session_context_get_recent,
+)
+from app.mcp_server.tooling.trading_policy_registration import (
+    register_trading_policy_tools,
+)
+
+if TYPE_CHECKING:
+    from fastmcp import FastMCP
+
+_F = TypeVar("_F", bound=Callable[..., Any])
+
+
+ANALYSIS_READONLY_TOOL_NAMES: set[str] = {
+    "get_operating_briefing",
+    "route_request",
+    "get_trading_policy",
+    "get_market_index",
+    "get_quote",
+    "analyze_stock_batch",
+    "get_support_resistance",
+    "get_indicators",
+    "screen_stocks",
+    "screen_stocks_snapshot",
+    "get_top_stocks",
+    "get_news",
+    "get_fx_rate",
+    "get_holdings",
+    "toss_get_positions",
+    "get_intraday_investor_flow",
+    "analysis_artifact_save",
+    "analysis_artifact_get",
+    "forecast_save",
+    "session_context_append",
+    "session_context_get_recent",
+}
+
+ANALYSIS_READONLY_FORBIDDEN_TOOL_NAMES: set[str] = (
+    ORDER_TOOL_NAMES
+    | KIS_LIVE_ORDER_TOOL_NAMES
+    | KIS_MOCK_ORDER_TOOL_NAMES
+    | LIVE_RECONCILE_TOOL_NAMES
+    | KIWOOM_MOCK_TOOL_NAMES
+    | PAPER_LIMIT_ORDER_TOOL_NAMES
+    | (TOSS_LIVE_ORDER_TOOL_NAMES - {"toss_get_positions"})
+    | {
+        "analysis_artifact_list",
+        "forecast_resolve",
+        "get_forecasts",
+        "get_forecast_calibration",
+        "get_user_setting",
+        "update_manual_holdings",
+        "get_cash_balance",
+        "get_available_capital",
+        "get_order_history",
+        "toss_get_order_history",
+        "toss_get_orderable_cash",
+        "list_active_watches",
+    }
+)
+
+
+class _AllowlistedMCP:
+    """Proxy that makes existing group registrars physically register only allowed names."""
+
+    def __init__(self, inner: Any, allowed_names: set[str]) -> None:
+        self._inner = inner
+        self._allowed_names = allowed_names
+
+    def tool(self, *args: Any, **kwargs: Any) -> Callable[[_F], _F]:
+        name = kwargs.get("name")
+        if name is None and args:
+            name = args[0]
+        if str(name) in self._allowed_names:
+            return cast(Callable[[_F], _F], self._inner.tool(*args, **kwargs))
+
+        def decorator(func: _F) -> _F:
+            return func
+
+        return decorator
+
+    def list_tools(self) -> Any:
+        lister = getattr(self._inner, "list_tools", None)
+        if lister is None:
+            return []
+        return lister()
+
+
+def _created_by_required(tool_name: str) -> dict[str, Any]:
+    return {
+        "success": False,
+        "error": "created_by_required",
+        "tool": tool_name,
+        "detail": "analysis_readonly persistence calls must pass an explicit created_by label such as 'codex'.",
+    }
+
+
+def _clean_created_by(value: str | None) -> str | None:
+    cleaned = (value or "").strip()
+    return cleaned or None
+
+
+def _register_persistence_tools(mcp: FastMCP) -> None:
+    @mcp.tool(
+        name="analysis_artifact_save",
+        description=(
+            "analysis_readonly: persist a structured analysis artifact. "
+            "Requires explicit created_by such as 'codex'; no implicit caller label."
+        ),
+    )
+    async def analysis_artifact_save(
+        market: str,
+        kind: str,
+        title: str,
+        symbols: list[str] | None = None,
+        payload: dict[str, Any] | None = None,
+        as_of: str | None = None,
+        valid_until: str | None = None,
+        created_by: str | None = None,
+        session_label: str | None = None,
+        correlation_id: str | None = None,
+        account_scope: str | None = None,
+        readiness_label: str | None = None,
+    ) -> dict[str, Any]:
+        label = _clean_created_by(created_by)
+        if label is None:
+            return _created_by_required("analysis_artifact_save")
+        return await _analysis_artifact_save(
+            market=market,
+            kind=kind,
+            title=title,
+            symbols=symbols,
+            payload=payload,
+            as_of=as_of,
+            valid_until=valid_until,
+            created_by=label,
+            session_label=session_label,
+            correlation_id=correlation_id,
+            account_scope=account_scope,
+            readiness_label=readiness_label,
+        )
+
+    mcp.tool(
+        name="analysis_artifact_get",
+        description="analysis_readonly: fetch one persisted analysis artifact by id or UUID.",
+    )(_analysis_artifact_get)
+
+    # forecast_save already has a required created_by parameter and the service
+    # rejects blank values; register through the filter below.
+
+    @mcp.tool(
+        name="session_context_append",
+        description=(
+            "analysis_readonly: append session context entries. Every entry must "
+            "include explicit created_by such as 'codex'."
+        ),
+    )
+    async def session_context_append(
+        entries: list[dict[str, Any]] | None,
+    ) -> dict[str, Any]:
+        if entries:
+            missing = [
+                idx
+                for idx, entry in enumerate(entries)
+                if not _clean_created_by(str(entry.get("created_by", "")))
+            ]
+            if missing:
+                return {
+                    "success": False,
+                    "error": "created_by_required",
+                    "tool": "session_context_append",
+                    "entry_indexes": missing,
+                    "detail": "each analysis_readonly session context entry must pass created_by explicitly",
+                }
+        return await _session_context_append(entries)
+
+    mcp.tool(
+        name="session_context_get_recent",
+        description="analysis_readonly: read recent operator session context entries.",
+    )(_session_context_get_recent)
+
+
+def register_analysis_readonly_tools(mcp: FastMCP) -> None:
+    """Register the physically restricted Codex/headless analysis surface."""
+    filtered = cast("FastMCP", _AllowlistedMCP(mcp, ANALYSIS_READONLY_TOOL_NAMES))
+    register_operating_briefing_tools(filtered)
+    register_trading_policy_tools(filtered)
+    register_route_request_tools(filtered)
+    register_market_data_tools(filtered)
+    register_fundamentals_tools(filtered)
+    register_analysis_tools(filtered)
+    register_portfolio_tools(filtered)
+    register_toss_live_order_tools(filtered)
+    register_forecast_tools(filtered)
+    _register_persistence_tools(mcp)
+
+
+__all__ = [
+    "ANALYSIS_READONLY_FORBIDDEN_TOOL_NAMES",
+    "ANALYSIS_READONLY_TOOL_NAMES",
+    "register_analysis_readonly_tools",
+]

--- a/app/mcp_server/tooling/analysis_readonly_registration.py
+++ b/app/mcp_server/tooling/analysis_readonly_registration.py
@@ -5,6 +5,9 @@ from __future__ import annotations
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, TypeVar, cast
 
+from app.mcp_server.tooling.account_routing_registration import (
+    register_account_routing_tools,
+)
 from app.mcp_server.tooling.analysis_artifact_tools import (
     analysis_artifact_get as _analysis_artifact_get,
 )
@@ -66,6 +69,7 @@ ANALYSIS_READONLY_TOOL_NAMES: set[str] = {
     "get_top_stocks",
     "get_news",
     "get_fx_rate",
+    "suggest_order_account",
     "get_holdings",
     "toss_get_positions",
     "get_intraday_investor_flow",
@@ -232,6 +236,7 @@ def register_analysis_readonly_tools(mcp: FastMCP) -> None:
     register_fundamentals_tools(filtered)
     register_analysis_tools(filtered)
     register_portfolio_tools(filtered)
+    register_account_routing_tools(filtered)
     register_toss_live_order_tools(filtered)
     register_forecast_tools(filtered)
     _register_persistence_tools(mcp)

--- a/app/mcp_server/tooling/registry.py
+++ b/app/mcp_server/tooling/registry.py
@@ -39,6 +39,13 @@ Profile → tool surface mapping
   validity guard so a headless replay session cannot leak live market data or
   persist anything.
 
+"analysis_readonly" (McpProfile.ANALYSIS_READONLY):
+  Codex/headless read/analysis allowlist only. Registers operating briefing,
+  policy/route, selected market/fundamental/analysis/holdings tools,
+  toss_get_positions, and explicitly labeled analysis persistence. No order,
+  cancel, modify, reconcile, preview, settings, watch mutation, admin, or manual
+  holdings mutation tools are registered.
+
 See app/mcp_server/profiles.py and docs in app/mcp_server/README.md.
 """
 
@@ -64,6 +71,9 @@ from app.mcp_server.tooling.alpaca_paper_preview import (
 )
 from app.mcp_server.tooling.analysis_artifact_registration import (
     register_analysis_artifact_tools,
+)
+from app.mcp_server.tooling.analysis_readonly_registration import (
+    register_analysis_readonly_tools,
 )
 from app.mcp_server.tooling.analysis_registration import register_analysis_tools
 from app.mcp_server.tooling.forecast_registration import register_forecast_tools
@@ -158,6 +168,13 @@ def register_all_tools(mcp: FastMCP, profile: McpProfile = McpProfile.DEFAULT) -
         register_hermes_context_read_only(mcp)  # investment_report_get_hermes_context
         register_trading_policy_tools(mcp)  # get_trading_policy (versioned thresholds)
         register_route_request_tools(mcp)  # route_request (lane procedure)
+        return
+
+    if profile is McpProfile.ANALYSIS_READONLY:
+        # ROB-745 — Codex/headless analysis surface. Allowlist-only and returns
+        # before the normal "Always" block so unlisted research, account,
+        # settings, watch, report-write, and order tools are physically absent.
+        register_analysis_readonly_tools(mcp)
         return
 
     # Always: side-effect-free research + read-only tools

--- a/app/models/analysis_artifact.py
+++ b/app/models/analysis_artifact.py
@@ -46,7 +46,7 @@ class AnalysisArtifact(Base):
             name="kind",
         ),
         CheckConstraint(
-            "created_by IN ('claude','operator','system')",
+            "created_by IN ('claude','operator','system','codex')",
             name="created_by",
         ),
         CheckConstraint(

--- a/app/models/session_context.py
+++ b/app/models/session_context.py
@@ -48,7 +48,7 @@ class OperatorSessionContext(Base):
             name="entry_type",
         ),
         CheckConstraint(
-            "created_by IN ('claude','operator','system')",
+            "created_by IN ('claude','operator','system','codex')",
             name="created_by",
         ),
         CheckConstraint(

--- a/app/schemas/analysis_artifact.py
+++ b/app/schemas/analysis_artifact.py
@@ -19,7 +19,7 @@ AnalysisArtifactKindLiteral = Literal[
     "session_summary",
     "briefing",
 ]
-AnalysisArtifactCreatedByLiteral = Literal["claude", "operator", "system"]
+AnalysisArtifactCreatedByLiteral = Literal["claude", "operator", "system", "codex"]
 # ROB-648 reduced advisory readiness enum. tradingcodex-lane labels are
 # excluded; server-derived readiness gating is deferred (needs per-kind payload
 # schemas, P5+). Caller declares this; it is not a hard short-circuit gate.

--- a/app/schemas/session_context.py
+++ b/app/schemas/session_context.py
@@ -20,7 +20,7 @@ SessionContextEntryTypeLiteral = Literal[
     "next_action",
     "handoff_note",
 ]
-SessionContextCreatedByLiteral = Literal["claude", "operator", "system"]
+SessionContextCreatedByLiteral = Literal["claude", "operator", "system", "codex"]
 
 
 class SessionContextRefs(BaseModel):

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -118,6 +118,36 @@ services:
           memory: 256M
           cpus: '0.1'
 
+  mcp-analysis-readonly:
+    image: ghcr.io/${GITHUB_REPOSITORY}:production
+    container_name: auto_trader_mcp_analysis_readonly_prod
+    env_file:
+      - .env.prod
+    environment:
+      MCP_TYPE: ${MCP_ANALYSIS_READONLY_TYPE:-streamable-http}
+      MCP_HOST: ${MCP_ANALYSIS_READONLY_HOST:-0.0.0.0}
+      MCP_PORT: ${MCP_ANALYSIS_READONLY_PORT:-8768}
+      MCP_PATH: ${MCP_ANALYSIS_READONLY_PATH:-/mcp}
+      MCP_PROFILE: analysis_readonly
+      MCP_AUTH_TOKEN: ${MCP_ANALYSIS_READONLY_AUTH_TOKEN:-${MCP_AUTH_TOKEN:-}}
+    restart: unless-stopped
+    network_mode: host
+    command: ["python", "-m", "app.mcp_server.main"]
+    healthcheck:
+      test: [ "CMD", "python", "-c", "import os,sys,urllib.request; port=os.environ.get('MCP_ANALYSIS_READONLY_PORT','8768'); sys.exit(0 if urllib.request.urlopen(f'http://127.0.0.1:{port}/health', timeout=5).status == 200 else 1)" ]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+    deploy:
+      resources:
+        limits:
+          memory: 512M
+          cpus: '0.5'
+        reservations:
+          memory: 256M
+          cpus: '0.1'
+
   upbit_websocket:
     image: ghcr.io/${GITHUB_REPOSITORY}:production
     container_name: auto_trader_upbit_ws_prod

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -134,7 +134,7 @@ services:
     network_mode: host
     command: ["python", "-m", "app.mcp_server.main"]
     healthcheck:
-      test: [ "CMD", "python", "-c", "import os,sys,urllib.request; port=os.environ.get('MCP_ANALYSIS_READONLY_PORT','8768'); sys.exit(0 if urllib.request.urlopen(f'http://127.0.0.1:{port}/health', timeout=5).status == 200 else 1)" ]
+      test: [ "CMD", "python", "-c", "import os,sys,urllib.request; port=os.environ.get('MCP_PORT','8768'); sys.exit(0 if urllib.request.urlopen(f'http://127.0.0.1:{port}/health', timeout=5).status == 200 else 1)" ]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/docs/runbooks/analysis-readonly-mcp.md
+++ b/docs/runbooks/analysis-readonly-mcp.md
@@ -1,0 +1,50 @@
+# Analysis Readonly MCP (ROB-745)
+
+## Start
+
+Docker:
+
+```bash
+MCP_ANALYSIS_READONLY_PORT=8768 \
+docker compose -f docker-compose.prod.yml up -d mcp-analysis-readonly
+```
+
+Manual local:
+
+```bash
+MCP_PROFILE=analysis_readonly MCP_PORT=8768 uv run python -m app.mcp_server.main
+```
+
+## Health
+
+```bash
+curl -s http://127.0.0.1:8768/health
+```
+
+Expected: HTTP 200 with `service=auto-trader-mcp`.
+
+## Smoke
+
+Use the same JSON-RPC bridge pattern as the main MCP server, but point it at `8768` and use the analysis-readonly token.
+
+```bash
+export MCP_ENDPOINT="http://127.0.0.1:8768/mcp"
+export MCP_AUTH_TOKEN="$MCP_ANALYSIS_READONLY_AUTH_TOKEN"
+export MCP_SESSION_ID="<session id>"
+export PAPERCLIP_AGENT_ID="codex-analysis-readonly"
+envsubst '$MCP_ENDPOINT $MCP_AUTH_TOKEN $MCP_SESSION_ID $PAPERCLIP_AGENT_ID' \
+  < scripts/templates/mcp_call.sh.tmpl > /tmp/mcp_call_analysis_readonly.sh
+chmod 700 /tmp/mcp_call_analysis_readonly.sh
+
+/tmp/mcp_call_analysis_readonly.sh get_quote '{"symbol":"005930","market":"kr"}'
+```
+
+Expected: a tool payload, not 401/403.
+
+Forbidden smoke:
+
+```bash
+/tmp/mcp_call_analysis_readonly.sh place_order '{"symbol":"005930","side":"buy","quantity":1}'
+```
+
+Expected: MCP tool-not-found / unknown-tool response because `place_order` is not registered.

--- a/scripts/mcp_server.sh
+++ b/scripts/mcp_server.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
 cd "$(dirname "$0")/.." || exit 1
+# Operators may override MCP_PROFILE and MCP_PORT before invoking this wrapper,
+# e.g. MCP_PROFILE=analysis_readonly MCP_PORT=8768 scripts/mcp_server.sh.
 export ENV_FILE=.env.mcp
 exec uv run python -m app.mcp_server.main

--- a/tests/_schema_bootstrap.py
+++ b/tests/_schema_bootstrap.py
@@ -17,7 +17,7 @@ from sqlalchemy import text
 # Bump when adding an ORM table that has NO mirrored ALTER string below, so the
 # content hash changes and a persistent local DB re-bootstraps once. Adding a
 # mirrored ALTER already changes the hash automatically.
-SCHEMA_BOOTSTRAP_VERSION = 2
+SCHEMA_BOOTSTRAP_VERSION = 3
 
 # ---- constraints + enums (moved verbatim from conftest.py) ----
 MARKET_VALUATION_SOURCE_CHECK_NAME = "ck_market_valuation_snapshots_source"
@@ -540,6 +540,64 @@ async def _maybe_add_unique_constraint(
     )
 
 
+async def _ensure_analysis_artifacts_created_by_constraint(conn) -> None:
+    constraints = await conn.execute(
+        text(
+            "SELECT conname, pg_get_constraintdef(oid) AS definition "
+            "FROM pg_constraint "
+            "WHERE conrelid = 'review.analysis_artifacts'::regclass "
+            "AND conname = 'ck_analysis_artifacts_created_by' "
+            "AND contype = 'c'"
+        )
+    )
+    rows = list(constraints)
+    if rows and "codex" in (rows[0][1] or ""):
+        return
+
+    await conn.execute(
+        text(
+            "ALTER TABLE review.analysis_artifacts "
+            "DROP CONSTRAINT IF EXISTS ck_analysis_artifacts_created_by"
+        )
+    )
+    await conn.execute(
+        text(
+            "ALTER TABLE review.analysis_artifacts "
+            "ADD CONSTRAINT ck_analysis_artifacts_created_by "
+            "CHECK (created_by IN ('claude', 'operator', 'system', 'codex'))"
+        )
+    )
+
+
+async def _ensure_operator_session_context_created_by_constraint(conn) -> None:
+    constraints = await conn.execute(
+        text(
+            "SELECT conname, pg_get_constraintdef(oid) AS definition "
+            "FROM pg_constraint "
+            "WHERE conrelid = 'review.operator_session_context'::regclass "
+            "AND conname = 'ck_operator_session_context_created_by' "
+            "AND contype = 'c'"
+        )
+    )
+    rows = list(constraints)
+    if rows and "codex" in (rows[0][1] or ""):
+        return
+
+    await conn.execute(
+        text(
+            "ALTER TABLE review.operator_session_context "
+            "DROP CONSTRAINT IF EXISTS ck_operator_session_context_created_by"
+        )
+    )
+    await conn.execute(
+        text(
+            "ALTER TABLE review.operator_session_context "
+            "ADD CONSTRAINT ck_operator_session_context_created_by "
+            "CHECK (created_by IN ('claude', 'operator', 'system', 'codex'))"
+        )
+    )
+
+
 def schema_content_hash() -> str:
     """SHA256 hex of the bootstrap version + the DDL tuple.
 
@@ -637,6 +695,8 @@ async def apply_test_schema(conn) -> None:
 
     await _ensure_market_valuation_source_constraint(conn)
     await _ensure_investment_snapshot_kind_constraint(conn)
+    await _ensure_analysis_artifacts_created_by_constraint(conn)
+    await _ensure_operator_session_context_created_by_constraint(conn)
 
     for stmt in _DDL_STATEMENTS:
         await conn.execute(text(stmt))

--- a/tests/models/test_analysis_artifact_model.py
+++ b/tests/models/test_analysis_artifact_model.py
@@ -68,3 +68,10 @@ def test_analysis_artifact_model_contract() -> None:
         and index.dialect_options["postgresql"]["using"] == "gin"
         for index in indexes
     )
+
+    created_by_constraint = next(
+        constraint
+        for constraint in AnalysisArtifact.__table__.constraints
+        if constraint.name == "ck_analysis_artifacts_created_by"
+    )
+    assert "codex" in str(created_by_constraint.sqltext)

--- a/tests/models/test_operator_session_context_model.py
+++ b/tests/models/test_operator_session_context_model.py
@@ -54,3 +54,10 @@ def test_operator_session_context_model_contract() -> None:
         and index.dialect_options["postgresql"]["using"] == "gin"
         for index in indexes
     )
+
+    created_by_constraint = next(
+        constraint
+        for constraint in OperatorSessionContext.__table__.constraints
+        if constraint.name == "ck_operator_session_context_created_by"
+    )
+    assert "codex" in str(created_by_constraint.sqltext)

--- a/tests/services/investment_dimensions/test_sentiment_evidence.py
+++ b/tests/services/investment_dimensions/test_sentiment_evidence.py
@@ -1,6 +1,8 @@
 import datetime as dt
+import uuid
 
 import pytest
+import sqlalchemy as sa
 
 from app.models.investor_flow_snapshot import InvestorFlowSnapshot
 from app.services.investment_dimensions.sentiment_evidence import (
@@ -11,10 +13,13 @@ from app.services.investor_flow_snapshots.repository import (
 )
 
 
-async def _clear(db_session):
-    from sqlalchemy import text
-
-    await db_session.execute(text("DELETE FROM investor_flow_snapshots"))
+async def _clear(db_session, *symbols: str) -> None:
+    if symbols:
+        await db_session.execute(
+            sa.delete(InvestorFlowSnapshot).where(
+                InvestorFlowSnapshot.symbol.in_(symbols)
+            )
+        )
     await db_session.commit()
 
 
@@ -35,10 +40,12 @@ def _flow(symbol, *, snapshot_date, foreign_net, double_buy=False):
 
 @pytest.mark.asyncio
 async def test_build_sentiment_evidence_kr_covered(db_session):
-    await _clear(db_session)
+    symbol = f"TSD{uuid.uuid4().hex[:8].upper()}"
+    missing_symbol = f"TSM{uuid.uuid4().hex[:8].upper()}"
+    await _clear(db_session, symbol, missing_symbol)
     db_session.add(
         _flow(
-            "005930",
+            symbol,
             snapshot_date=dt.date(2026, 5, 23),
             foreign_net=120000,
             double_buy=True,
@@ -49,14 +56,14 @@ async def test_build_sentiment_evidence_kr_covered(db_session):
     bundle = await build_sentiment_evidence(
         InvestorFlowSnapshotsRepository(db_session),
         market="kr",
-        symbols={"005930", "000660"},
+        symbols={symbol, missing_symbol},
         now=dt.datetime(2026, 5, 24, tzinfo=dt.UTC),
     )
     assert bundle["market"] == "kr"
     assert bundle["data_health"] == {"requested": 2, "covered": 1}
     assert bundle["covered_count"] == 1
     row = bundle["per_symbol"][0]
-    assert row["symbol"] == "005930"
+    assert row["symbol"] == symbol
     assert row["foreign_net"] == 120000
     assert row["double_buy"] is True
     assert row["foreign_consecutive_buy_days"] == 3
@@ -81,11 +88,12 @@ async def test_build_sentiment_evidence_non_kr_is_unavailable(db_session):
 
 @pytest.mark.asyncio
 async def test_build_sentiment_evidence_empty_kr_is_unavailable(db_session):
-    await _clear(db_session)
+    symbol = f"TSE{uuid.uuid4().hex[:8].upper()}"
+    await _clear(db_session, symbol)
     bundle = await build_sentiment_evidence(
         InvestorFlowSnapshotsRepository(db_session),
         market="kr",
-        symbols={"005930"},
+        symbols={symbol},
         now=dt.datetime(2026, 5, 24, tzinfo=dt.UTC),
     )
     assert bundle["covered_count"] == 0

--- a/tests/services/investment_stages/test_hermes_context_sentiment_dimension.py
+++ b/tests/services/investment_stages/test_hermes_context_sentiment_dimension.py
@@ -16,19 +16,26 @@ from app.services.investment_snapshots.repository import InvestmentSnapshotsRepo
 from app.services.investment_stages.hermes_context import HermesContextExporter
 
 
-async def _clear(db_session):
+async def _clear(db_session, symbol: str) -> None:
     from sqlalchemy import text
 
-    await db_session.execute(text("DELETE FROM investor_flow_snapshots"))
-    await db_session.execute(text("DELETE FROM stock_info WHERE symbol = '005930'"))
+    await db_session.execute(
+        text("DELETE FROM investor_flow_snapshots WHERE symbol = :symbol"),
+        {"symbol": symbol},
+    )
+    await db_session.execute(
+        text("DELETE FROM stock_info WHERE symbol = :symbol"),
+        {"symbol": symbol},
+    )
     await db_session.commit()
 
 
 @pytest.mark.asyncio
 async def test_exporter_attaches_sentiment_evidence_bundle_kr(db_session) -> None:
-    await _clear(db_session)
+    symbol = f"TST{uuid.uuid4().hex[:8].upper()}"
+    await _clear(db_session, symbol)
 
-    # 1. Seed InvestmentSnapshotBundle + Snapshot + BundleItem (holding 005930)
+    # 1. Seed InvestmentSnapshotBundle + Snapshot + BundleItem (holding symbol)
     snapshots_repo = InvestmentSnapshotsRepository(db_session)
     now = dt.datetime.now(tz=dt.UTC)
 
@@ -53,7 +60,7 @@ async def test_exporter_attaches_sentiment_evidence_bundle_kr(db_session) -> Non
                 "primary_source": "kis",
                 "holdings": [
                     {
-                        "ticker": "005930",
+                        "ticker": symbol,
                         "quantity": 10,
                         "sellable_quantity": 10,
                         "source": "kis",
@@ -87,11 +94,11 @@ async def test_exporter_attaches_sentiment_evidence_bundle_kr(db_session) -> Non
         ),
     )
 
-    # 2. Seed an InvestorFlowSnapshot for 005930
+    # 2. Seed an InvestorFlowSnapshot for the held symbol
     db_session.add(
         InvestorFlowSnapshot(
             market="kr",
-            symbol="005930",
+            symbol=symbol,
             snapshot_date=now.date(),
             foreign_net=120000,
             institution_net=5000,
@@ -103,11 +110,11 @@ async def test_exporter_attaches_sentiment_evidence_bundle_kr(db_session) -> Non
         )
     )
 
-    # 3. Seed StockInfo for 005930
+    # 3. Seed StockInfo for the held symbol
     db_session.add(
         StockInfo(
-            symbol="005930",
-            name="Samsung Electronics",
+            symbol=symbol,
+            name="Sentiment Test Equity",
             instrument_type="equity_kr",
             sector="Technology",
             is_active=True,
@@ -140,10 +147,10 @@ async def test_exporter_attaches_sentiment_evidence_bundle_kr(db_session) -> Non
     assert sent["data_health"]["covered"] >= 1
     assert sent["covered_count"] >= 1
 
-    samsung_row = next(r for r in sent["per_symbol"] if r["symbol"] == "005930")
-    assert samsung_row["foreign_net"] == 120000
-    assert samsung_row["double_buy"] is True
-    assert samsung_row["foreign_consecutive_buy_days"] == 3
+    symbol_row = next(r for r in sent["per_symbol"] if r["symbol"] == symbol)
+    assert symbol_row["foreign_net"] == 120000
+    assert symbol_row["double_buy"] is True
+    assert symbol_row["foreign_consecutive_buy_days"] == 3
     assert sent["freshness"]["status"] == "fresh"
 
 
@@ -151,9 +158,10 @@ async def test_exporter_attaches_sentiment_evidence_bundle_kr(db_session) -> Non
 async def test_exporter_attaches_sentiment_evidence_bundle_us_unavailable(
     db_session,
 ) -> None:
-    await _clear(db_session)
+    symbol = f"TUS{uuid.uuid4().hex[:8].upper()}"
+    await _clear(db_session, symbol)
 
-    # 1. Seed InvestmentSnapshotBundle + Snapshot + BundleItem (holding AAPL)
+    # 1. Seed InvestmentSnapshotBundle + Snapshot + BundleItem (holding symbol)
     snapshots_repo = InvestmentSnapshotsRepository(db_session)
     now = dt.datetime.now(tz=dt.UTC)
 
@@ -178,7 +186,7 @@ async def test_exporter_attaches_sentiment_evidence_bundle_us_unavailable(
                 "primary_source": "kis",
                 "holdings": [
                     {
-                        "ticker": "AAPL",
+                        "ticker": symbol,
                         "quantity": 10,
                         "sellable_quantity": 10,
                         "source": "kis",
@@ -247,7 +255,8 @@ async def test_exporter_crypto_bundle_gets_dimensions_sentiment_unavailable(
     synthesis runs: all four dimension keys are present, and sentiment is
     honestly ``unavailable`` (investor-flow is KR-only) — never fabricated or
     KR-leaking."""
-    await _clear(db_session)
+    symbol = f"TCR{uuid.uuid4().hex[:8].upper()}"
+    await _clear(db_session, symbol)
     snapshots_repo = InvestmentSnapshotsRepository(db_session)
     now = dt.datetime.now(tz=dt.UTC)
 
@@ -269,7 +278,7 @@ async def test_exporter_crypto_bundle_gets_dimensions_sentiment_unavailable(
             source_kind="auto_trader_mcp",
             payload_json={
                 "primary_source": "upbit",
-                "holdings": [{"ticker": "BTC", "source": "upbit", "market": "CRYPTO"}],
+                "holdings": [{"ticker": symbol, "source": "upbit", "market": "CRYPTO"}],
                 "reference_holdings": [],
                 "count": 1,
                 "market": "crypto",

--- a/tests/test_analysis_artifact_mcp.py
+++ b/tests/test_analysis_artifact_mcp.py
@@ -394,3 +394,19 @@ async def test_stale_artifact_flagged_and_filtered(db_session: AsyncSession) -> 
     )
     assert with_stale["count"] == 1
     assert with_stale["artifacts"][0]["is_stale"] is True
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_save_accepts_codex_created_by(db_session: AsyncSession) -> None:
+    response = await analysis_artifact_save(
+        market="kr",
+        kind="session_summary",
+        title="Codex summary",
+        payload={"source": "analysis_readonly"},
+        as_of="2026-07-06T00:00:00+09:00",
+        created_by="codex",
+    )
+
+    assert response["success"] is True
+    assert response["artifact"]["created_by"] == "codex"

--- a/tests/test_mcp_profiles.py
+++ b/tests/test_mcp_profiles.py
@@ -382,6 +382,18 @@ class TestAnalysisReadonlyProfile:
         assert result["tool"] == "session_context_append"
         assert result["entry_indexes"] == [0]
 
+    @pytest.mark.asyncio
+    async def test_session_context_append_preserves_validation_for_non_dict_entry(
+        self,
+    ) -> None:
+        mcp = _build_mcp(McpProfile.ANALYSIS_READONLY)
+        tool = mcp.tools["session_context_append"]
+
+        result = await tool(entries=["not-a-dict"])
+
+        assert result["success"] is False
+        assert result["error"] == "invalid_request"
+
     def test_persistence_tools_are_registered_but_list_resolve_are_not(self) -> None:
         mcp = _build_mcp(McpProfile.ANALYSIS_READONLY)
         assert {"analysis_artifact_save", "analysis_artifact_get", "forecast_save"} <= mcp.tools.keys()

--- a/tests/test_mcp_profiles.py
+++ b/tests/test_mcp_profiles.py
@@ -285,7 +285,9 @@ class TestOrderSurfaceMatrix:
 # tool (crypto research included). ``TestShadowReplayIsResearchSurfaceException``
 # pins that omission explicitly.
 _PROFILES_WITH_RESEARCH_SURFACE = [
-    p for p in McpProfile if p not in (McpProfile.SHADOW_REPLAY, McpProfile.ANALYSIS_READONLY)
+    p
+    for p in McpProfile
+    if p not in (McpProfile.SHADOW_REPLAY, McpProfile.ANALYSIS_READONLY)
 ]
 
 
@@ -396,7 +398,11 @@ class TestAnalysisReadonlyProfile:
 
     def test_persistence_tools_are_registered_but_list_resolve_are_not(self) -> None:
         mcp = _build_mcp(McpProfile.ANALYSIS_READONLY)
-        assert {"analysis_artifact_save", "analysis_artifact_get", "forecast_save"} <= mcp.tools.keys()
+        assert {
+            "analysis_artifact_save",
+            "analysis_artifact_get",
+            "forecast_save",
+        } <= mcp.tools.keys()
         assert "analysis_artifact_list" not in mcp.tools
         assert "forecast_resolve" not in mcp.tools
         assert "get_forecasts" not in mcp.tools

--- a/tests/test_mcp_profiles.py
+++ b/tests/test_mcp_profiles.py
@@ -18,6 +18,10 @@ from app.mcp_server.tooling.alpaca_paper_orders import (
     ALPACA_PAPER_MUTATING_TOOL_NAMES,
 )
 from app.mcp_server.tooling.alpaca_paper_preview import ALPACA_PAPER_PREVIEW_TOOL_NAMES
+from app.mcp_server.tooling.analysis_readonly_registration import (
+    ANALYSIS_READONLY_FORBIDDEN_TOOL_NAMES,
+    ANALYSIS_READONLY_TOOL_NAMES,
+)
 from app.mcp_server.tooling.orders_kis_variants import (
     KIS_LIVE_ORDER_TOOL_NAMES,
     KIS_MOCK_ORDER_TOOL_NAMES,
@@ -242,6 +246,7 @@ _ORDER_SURFACE_MATRIX: dict[McpProfile, set[str]] = {
     # ROB-697 M1 — shadow-replay registers zero order/mutation tools by design
     # (frozen-context read + policy + route_request only, early-return).
     McpProfile.SHADOW_REPLAY: set(),
+    McpProfile.ANALYSIS_READONLY: {"toss_get_positions"},
 }
 _ALL_ORDER_TOOL_NAMES = (
     _LEGACY_ORDER_TOOL_NAMES
@@ -280,7 +285,7 @@ class TestOrderSurfaceMatrix:
 # tool (crypto research included). ``TestShadowReplayIsResearchSurfaceException``
 # pins that omission explicitly.
 _PROFILES_WITH_RESEARCH_SURFACE = [
-    p for p in McpProfile if p is not McpProfile.SHADOW_REPLAY
+    p for p in McpProfile if p not in (McpProfile.SHADOW_REPLAY, McpProfile.ANALYSIS_READONLY)
 ]
 
 
@@ -318,6 +323,74 @@ class TestShadowReplayIsResearchSurfaceException:
         assert _CRYPTO_RESEARCH_TOOL_NAMES.isdisjoint(mcp.tools.keys())
 
 
+class TestAnalysisReadonlyProfile:
+    def test_registers_exact_analysis_readonly_allowlist(self) -> None:
+        mcp = _build_mcp(McpProfile.ANALYSIS_READONLY)
+        assert set(mcp.tools) == ANALYSIS_READONLY_TOOL_NAMES
+
+    def test_does_not_register_forbidden_surfaces(self) -> None:
+        mcp = _build_mcp(McpProfile.ANALYSIS_READONLY)
+        leaked = ANALYSIS_READONLY_FORBIDDEN_TOOL_NAMES & mcp.tools.keys()
+        assert not leaked, f"analysis_readonly leaked forbidden tools: {sorted(leaked)}"
+
+    def test_keeps_route_request_inside_registered_surface(self) -> None:
+        mcp = _build_mcp(McpProfile.ANALYSIS_READONLY)
+        assert "route_request" in mcp.tools
+        assert "get_trading_policy" in mcp.tools
+        assert "get_quote" in mcp.tools
+        assert "place_order" not in mcp.tools
+        assert "toss_place_order" not in mcp.tools
+        assert "toss_get_positions" in mcp.tools
+
+    @pytest.mark.asyncio
+    async def test_analysis_artifact_save_requires_explicit_created_by(self) -> None:
+        mcp = _build_mcp(McpProfile.ANALYSIS_READONLY)
+        tool = mcp.tools["analysis_artifact_save"]
+
+        result = await tool(
+            market="kr",
+            kind="session_summary",
+            title="missing label",
+            payload={},
+        )
+
+        assert result == {
+            "success": False,
+            "error": "created_by_required",
+            "tool": "analysis_artifact_save",
+            "detail": "analysis_readonly persistence calls must pass an explicit created_by label such as 'codex'.",
+        }
+
+    @pytest.mark.asyncio
+    async def test_session_context_append_requires_created_by_per_entry(self) -> None:
+        mcp = _build_mcp(McpProfile.ANALYSIS_READONLY)
+        tool = mcp.tools["session_context_append"]
+
+        result = await tool(
+            entries=[
+                {
+                    "market": "kr",
+                    "entry_type": "handoff_note",
+                    "title": "missing label",
+                    "body": "body",
+                }
+            ]
+        )
+
+        assert result["success"] is False
+        assert result["error"] == "created_by_required"
+        assert result["tool"] == "session_context_append"
+        assert result["entry_indexes"] == [0]
+
+    def test_persistence_tools_are_registered_but_list_resolve_are_not(self) -> None:
+        mcp = _build_mcp(McpProfile.ANALYSIS_READONLY)
+        assert {"analysis_artifact_save", "analysis_artifact_get", "forecast_save"} <= mcp.tools.keys()
+        assert "analysis_artifact_list" not in mcp.tools
+        assert "forecast_resolve" not in mcp.tools
+        assert "get_forecasts" not in mcp.tools
+        assert "get_forecast_calibration" not in mcp.tools
+
+
 class TestResolveMcpProfile:
     def test_none_returns_default(self) -> None:
         assert resolve_mcp_profile(None) is McpProfile.DEFAULT
@@ -348,6 +421,9 @@ class TestResolveMcpProfile:
 
     def test_shadow_replay(self) -> None:
         assert resolve_mcp_profile("shadow-replay") is McpProfile.SHADOW_REPLAY
+
+    def test_analysis_readonly(self) -> None:
+        assert resolve_mcp_profile("analysis_readonly") is McpProfile.ANALYSIS_READONLY
 
     def test_invalid_string_raises_value_error(self) -> None:
         with pytest.raises(ValueError, match="Unknown MCP_PROFILE"):

--- a/tests/test_session_context_mcp.py
+++ b/tests/test_session_context_mcp.py
@@ -126,3 +126,22 @@ async def test_get_recent_returns_empty_list_when_no_match(
     assert response["success"] is True
     assert response["count"] == 0
     assert response["entries"] == []
+
+
+@pytest.mark.asyncio
+async def test_append_accepts_codex_created_by(db_session: AsyncSession) -> None:
+    response = await session_context_append(
+        entries=[
+            {
+                "kst_date": "2026-07-06",
+                "market": "kr",
+                "entry_type": "handoff_note",
+                "title": "Codex handoff",
+                "body": "analysis_readonly smoke",
+                "created_by": "codex",
+            }
+        ]
+    )
+
+    assert response["success"] is True
+    assert response["entries"][0]["created_by"] == "codex"


### PR DESCRIPTION
## Summary
- Add the ROB-745 analysis_readonly MCP profile and Codex support from the feature branch.
- Harden the release path with corrected Codex MCP config docs, production healthcheck port handling, and malformed session_context_append validation behavior.
- Keep the untracked implementation plan out of the PR scope.

## Validation
- uv run pytest tests/test_mcp_profiles.py tests/test_mcp_tool_registration_boot.py tests/test_analysis_artifact_mcp.py tests/test_session_context_mcp.py tests/models/test_analysis_artifact_model.py tests/models/test_operator_session_context_model.py -q
- uv run ruff check app/mcp_server/tooling/analysis_readonly_registration.py tests/test_mcp_profiles.py
- uv run ty check app/mcp_server/tooling/analysis_readonly_registration.py
- uv run python YAML parse for docker-compose.prod.yml

## Notes
- docker compose runtime rendering was not verified earlier because Docker CLI was unavailable in that session.