### PR TITLE
fix(ROB-753): KIS current-price rate limit + serialize /invest fallback

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -33,6 +33,18 @@ DEFAULT_KIS_API_RATE_LIMITS: ApiRateLimitMap = {
         "rate": 20,
         "period": 1.0,
     },
+    # ROB-753: batch /invest KIS fallback uses these current-price endpoints.
+    # Live measurement showed same-endpoint concurrent bursts can fail most US
+    # symbols, while sequential calls succeed. Keep the default process-local
+    # limiter conservative; operators can override with KIS_API_RATE_LIMITS.
+    "FHKST01010100|/uapi/domestic-stock/v1/quotations/inquire-price": {
+        "rate": 1,
+        "period": 0.2,
+    },
+    "HHDFS00000300|/uapi/overseas-price/v1/quotations/price": {
+        "rate": 1,
+        "period": 0.2,
+    },
     "TTTC8434R|/uapi/domestic-stock/v1/trading/inquire-balance": {
         "rate": 10,
         "period": 1.0,

--- a/app/services/invest_quote_service.py
+++ b/app/services/invest_quote_service.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-import asyncio
 import logging
+from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING
 
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -112,41 +112,43 @@ class InvestQuoteService:
             return {}
         return dict(found)
 
-    async def _kis_fetch_kr(self, symbols: list[str]) -> dict[str, float | None]:
+    async def _kis_fetch_serial(
+        self,
+        symbols: list[str],
+        fetch_one: Callable[[str], Awaitable[float | None]],
+        *,
+        market_label: str,
+    ) -> dict[str, float | None]:
         results: dict[str, float | None] = {}
-
-        async def _fetch(symbol: str) -> None:
+        for symbol in symbols:
             try:
-                df = await self._market_data.inquire_price(symbol, market="J")
-                results[symbol] = float(df.iloc[0]["close"]) if not df.empty else None
-            except Exception as exc:  # noqa: BLE001 — summarized by the resolver
-                logger.debug("KIS KR price miss %s: %s", symbol, exc)
+                results[symbol] = await fetch_one(symbol)
+            except Exception as exc:  # noqa: BLE001 - fail-open per symbol
+                logger.debug("KIS %s price miss %s: %s", market_label, symbol, exc)
                 results[symbol] = None
-
-        await asyncio.gather(*(_fetch(s) for s in symbols))
         return results
+
+    async def _kis_fetch_kr(self, symbols: list[str]) -> dict[str, float | None]:
+        async def _fetch(symbol: str) -> float | None:
+            df = await self._market_data.inquire_price(symbol, market="J")
+            return float(df.iloc[0]["close"]) if not df.empty else None
+
+        return await self._kis_fetch_serial(symbols, _fetch, market_label="KR")
 
     async def _kis_fetch_us(self, symbols: list[str]) -> dict[str, float | None]:
-        results: dict[str, float | None] = {}
+        async def _fetch(symbol: str) -> float | None:
+            exchange = await get_us_exchange_by_symbol(symbol, self._db)
+            # ROB-708: live last (HHDFS00000300), mirroring get_quote US, so
+            # KIS-resolved US prices agree with Toss-resolved live-last prices
+            # instead of silently mixing in a settled daily close (HHDFS76240000).
+            # _build_overseas_price_frame returns empty when last is None/<=0,
+            # so an empty frame -> None -> resolver falls through to Toss/snapshot.
+            df = await self._market_data.inquire_overseas_price(
+                symbol, exchange_code=exchange
+            )
+            return float(df.iloc[0]["close"]) if not df.empty else None
 
-        async def _fetch(symbol: str) -> None:
-            try:
-                exchange = await get_us_exchange_by_symbol(symbol, self._db)
-                # ROB-708: live last (HHDFS00000300), mirroring get_quote US, so
-                # KIS-resolved US prices agree with Toss-resolved live-last prices
-                # instead of silently mixing in a settled daily close (HHDFS76240000).
-                # _build_overseas_price_frame returns empty when last is None/<=0,
-                # so an empty frame -> None -> resolver falls through to Toss/snapshot.
-                df = await self._market_data.inquire_overseas_price(
-                    symbol, exchange_code=exchange
-                )
-                results[symbol] = float(df.iloc[0]["close"]) if not df.empty else None
-            except Exception as exc:  # noqa: BLE001 — summarized by the resolver
-                logger.debug("KIS US price miss %s: %s", symbol, exc)
-                results[symbol] = None
-
-        await asyncio.gather(*(_fetch(s) for s in symbols))
-        return results
+        return await self._kis_fetch_serial(symbols, _fetch, market_label="US")
 
     async def kis_only_kr_prices(self, symbols: list[str]) -> dict[str, float | None]:
         """ROB-709 shadow: RAW KIS KR batch layer (no fallback chain). Read-only."""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -27,6 +27,16 @@ EXPECTED_KIS_API_RATE_LIMITS = {
         "rate": 20,
         "period": 1.0,
     },
+    # ROB-753: current-price endpoints reject bursty same-endpoint fanout.
+    # Keep them serialized by default; operators can loosen via KIS_API_RATE_LIMITS.
+    "FHKST01010100|/uapi/domestic-stock/v1/quotations/inquire-price": {
+        "rate": 1,
+        "period": 0.2,
+    },
+    "HHDFS00000300|/uapi/overseas-price/v1/quotations/price": {
+        "rate": 1,
+        "period": 0.2,
+    },
     "TTTC8434R|/uapi/domestic-stock/v1/trading/inquire-balance": {
         "rate": 10,
         "period": 1.0,

--- a/tests/test_invest_quote_service.py
+++ b/tests/test_invest_quote_service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from unittest.mock import AsyncMock, MagicMock
 
 import pandas as pd
@@ -64,6 +65,96 @@ async def test_fetch_us_prices_uses_live_last_endpoint(
     )
     # The daily-close endpoint must no longer be used for a "current price".
     service._market_data.inquire_overseas_daily_price.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_kis_fetch_us_serializes_current_price_calls(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "app.services.invest_quote_service.settings.toss_api_enabled",
+        False,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "app.services.invest_quote_service.settings.invest_quotes_toss_first_us",
+        False,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "app.services.invest_quote_service.get_us_exchange_by_symbol",
+        AsyncMock(return_value="NASD"),
+    )
+
+    service = InvestQuoteService(MagicMock(), MagicMock())
+    service._snapshot_latest = AsyncMock(return_value={})
+    service._market_data = AsyncMock()
+
+    active = 0
+    max_active = 0
+    call_order: list[str] = []
+
+    async def _inquire(symbol: str, exchange_code: str = "NASD") -> pd.DataFrame:
+        nonlocal active, max_active
+        assert exchange_code == "NASD"
+        active += 1
+        max_active = max(max_active, active)
+        call_order.append(symbol)
+        await asyncio.sleep(0)
+        active -= 1
+        return pd.DataFrame([{"close": float(len(call_order))}])
+
+    service._market_data.inquire_overseas_price.side_effect = _inquire
+
+    out = await service.fetch_us_prices(["AAPL", "NVDA", "MSFT"])
+
+    assert out == pytest.approx({"AAPL": 1.0, "NVDA": 2.0, "MSFT": 3.0})
+    assert call_order == ["AAPL", "NVDA", "MSFT"]
+    assert max_active == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_kis_fetch_kr_serializes_current_price_calls(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "app.services.invest_quote_service.settings.toss_api_enabled",
+        False,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "app.services.invest_quote_service.settings.invest_quotes_toss_first_kr",
+        False,
+        raising=False,
+    )
+
+    service = InvestQuoteService(MagicMock(), MagicMock())
+    service._snapshot_latest = AsyncMock(return_value={})
+    service._market_data = AsyncMock()
+
+    active = 0
+    max_active = 0
+    call_order: list[str] = []
+
+    async def _inquire(symbol: str, market: str = "J") -> pd.DataFrame:
+        nonlocal active, max_active
+        assert market == "J"
+        active += 1
+        max_active = max(max_active, active)
+        call_order.append(symbol)
+        await asyncio.sleep(0)
+        active -= 1
+        return pd.DataFrame([{"close": float(len(call_order) * 10)}])
+
+    service._market_data.inquire_price.side_effect = _inquire
+
+    out = await service.fetch_kr_prices(["005930", "000660", "035420"])
+
+    assert out == pytest.approx({"005930": 10.0, "000660": 20.0, "035420": 30.0})
+    assert call_order == ["005930", "000660", "035420"]
+    assert max_active == 1
 
 
 @pytest.mark.asyncio

--- a/tests/test_services_kis_market_data.py
+++ b/tests/test_services_kis_market_data.py
@@ -1171,6 +1171,16 @@ class TestKISRateLimitLookup:
                 1.0,
             ),
             (
+                "FHKST01010100|/uapi/domestic-stock/v1/quotations/inquire-price",
+                1,
+                0.2,
+            ),
+            (
+                "HHDFS00000300|/uapi/overseas-price/v1/quotations/price",
+                1,
+                0.2,
+            ),
+            (
                 "TTTC8434R|/uapi/domestic-stock/v1/trading/inquire-balance",
                 10,
                 1.0,


### PR DESCRIPTION
## ROB-753 — KIS current-price fallback reliability

`/invest` KIS current-price fallback이 US/KR 심볼을 배치 조회할 때 신뢰성 있게 동작하도록 두 단계로 수정. Toss-first가 KIS로 폴백될 때 즉시 스냅샷으로 떨어지는 현상 방지.

### Changes

**1. Seed KIS current-price endpoint rate limits** (`app/core/config.py`)
- `FHKST01010100|/uapi/domestic-stock/v1/quotations/inquire-price` → `(1, 0.2)`
- `HHDFS00000300|/uapi/overseas-price/v1/quotations/price` → `(1, 0.2)`
- 모든 process-local caller가 unmapped 19/s burst 기본값 대신 이 보수적 전역 큐를 공유. 운영자는 기존 `KIS_API_RATE_LIMITS`로 완화 가능.

**2. Serialize `/invest` KIS fallback fanout** (`app/services/invest_quote_service.py`)
- `InvestQuoteService`의 직접 `asyncio.gather` fanout을 `_kis_fetch_serial` 헬퍼 기반 직렬 실행으로 교체
- 단일 `/invest` 요청이 동일 endpoint로 여러 KIS 호출을 동시에 열지 못하게 함
- per-symbol fail-open(`None` → `PriceFallbackResolver`가 Toss/snapshot으로 전달) 보존
- KR(`inquire_price` / market="J") / US(`inquire_overseas_price` / HHDFS00000300 live-last, ROB-708) 엔드포인트 선택 및 호출 시그니처 무결

### Scope
- 읽기 전용 quote 경로만. 주문 mutation/라우터/스키마/DB/MCP 변경 없음
- 환경 변수 추가 없음 (기존 `KIS_API_RATE_LIMITS` override 메커니즘 재사용)
- Toss-first 플래그 및 fallback 순서 동작 유지

### Test plan (TDD)
- [x] config 기대값 Red → 구현 → Green (`test_api_rate_limit_defaults_include_builtins` + `TestKISRateLimitLookup`)
- [x] KR/US 비-중첩 회귀테스트 Red → 직렬화 구현 → Green (`test_kis_fetch_{kr,us}_serializes_current_price_calls`, `max_active == 1` 검증)
- [x] 기존 fallback/Toss-first/live-last 회귀 12 passed
- [x] Ruff 5개 파일 전부 통과
- [x] partial env override 머지 회귀 없음
- [x] diff 범위: 플랜된 5개 파일 (+154/-29)

### Notes
- 라이브 스모크는 KIS 자격증명 + 장시간 필요해 본 PR 게이트에서 제외 — 유닛 테스트가 shipped regression gate (플랜 Task 3 Step 5 명시)
- 플랜: `docs/superpowers/plans/2026-07-07-rob-753-kis-current-price-rate-limit.md`