### PR TITLE
feat(ROB-762): TradingCodex execution MCP profile + fail-closed runtime

### DIFF
--- a/app/mcp_server/README.md
+++ b/app/mcp_server/README.md
@@ -1680,7 +1680,7 @@ The `MCP_PROFILE` env var selects which tool subset is registered at startup.
 | Kiwoom mock | `kiwoom` | Default read-only/research surface plus typed `kiwoom_mock_*` variants only (no KIS/generic order tools) |
 | Analysis readonly | `analysis_readonly` | Codex/headless read/analysis allowlist only: `get_operating_briefing`, `route_request`, `get_trading_policy`, selected quote/fundamental/analysis tools, `suggest_order_account`, `get_holdings`, `toss_get_positions`, and explicitly labeled analysis persistence. No order/cancel/modify/reconcile/preview/settings/watch/admin/manual-holdings mutation tools are registered. |
 | Account read | `account_read` | TradingCodex account adapter allowlist only: `get_holdings`, `toss_get_positions`, `get_cash_balance`, `toss_get_orderable_cash`, `get_order_history`, `kis_live_get_order_history`, and `toss_get_order_history`. No order placement/cancel/modify/preview/reconcile, persistence, settings, watch, admin, report-writing, or manual-holdings mutation tools are registered. |
-| TradingCodex execution | `tradingcodex_execution` | Reviewed TradingCodex BrokerAdapter allowlist: account reads, preview/dry-run, live place, cancel, and ladder fill-preview tools. Requires dedicated auth token and required approval-hash modes. |
+| TradingCodex execution | `tradingcodex_execution` | Reviewed TradingCodex BrokerAdapter allowlist: account reads, `suggest_order_account`, preview/dry-run, live place, cancel, and ladder fill-preview tools. Requires dedicated auth token and required approval-hash modes. |
 
 ### Profile: `hermes-paper-kis`
 

--- a/app/mcp_server/README.md
+++ b/app/mcp_server/README.md
@@ -1680,7 +1680,7 @@ The `MCP_PROFILE` env var selects which tool subset is registered at startup.
 | Kiwoom mock | `kiwoom` | Default read-only/research surface plus typed `kiwoom_mock_*` variants only (no KIS/generic order tools) |
 | Analysis readonly | `analysis_readonly` | Codex/headless read/analysis allowlist only: `get_operating_briefing`, `route_request`, `get_trading_policy`, selected quote/fundamental/analysis tools, `suggest_order_account`, `get_holdings`, `toss_get_positions`, and explicitly labeled analysis persistence. No order/cancel/modify/reconcile/preview/settings/watch/admin/manual-holdings mutation tools are registered. |
 | Account read | `account_read` | TradingCodex account adapter allowlist only: `get_holdings`, `toss_get_positions`, `get_cash_balance`, `toss_get_orderable_cash`, `get_order_history`, `kis_live_get_order_history`, and `toss_get_order_history`. No order placement/cancel/modify/preview/reconcile, persistence, settings, watch, admin, report-writing, or manual-holdings mutation tools are registered. |
-| TradingCodex execution | `tradingcodex_execution` | Reviewed TradingCodex BrokerAdapter allowlist: account reads, `suggest_order_account`, preview/dry-run, live place, cancel, and ladder fill-preview tools. Requires dedicated auth token and required approval-hash modes. |
+| TradingCodex execution | `tradingcodex_execution` | Reviewed TradingCodex BrokerAdapter allowlist: account reads, `suggest_order_account`, `get_fx_rate`, preview/dry-run, live place, cancel, and ladder fill-preview tools. Requires dedicated auth token and required approval-hash modes. |
 
 ### Profile: `hermes-paper-kis`
 

--- a/app/mcp_server/README.md
+++ b/app/mcp_server/README.md
@@ -1680,7 +1680,7 @@ The `MCP_PROFILE` env var selects which tool subset is registered at startup.
 | Kiwoom mock | `kiwoom` | Default read-only/research surface plus typed `kiwoom_mock_*` variants only (no KIS/generic order tools) |
 | Analysis readonly | `analysis_readonly` | Codex/headless read/analysis allowlist only: `get_operating_briefing`, `route_request`, `get_trading_policy`, selected quote/fundamental/analysis tools, `suggest_order_account`, `get_holdings`, `toss_get_positions`, and explicitly labeled analysis persistence. No order/cancel/modify/reconcile/preview/settings/watch/admin/manual-holdings mutation tools are registered. |
 | Account read | `account_read` | TradingCodex account adapter allowlist only: `get_holdings`, `toss_get_positions`, `get_cash_balance`, `toss_get_orderable_cash`, `get_order_history`, `kis_live_get_order_history`, and `toss_get_order_history`. No order placement/cancel/modify/preview/reconcile, persistence, settings, watch, admin, report-writing, or manual-holdings mutation tools are registered. |
-| TradingCodex execution | `tradingcodex_execution` | Reviewed TradingCodex BrokerAdapter allowlist: account reads, `suggest_order_account`, `get_fx_rate`, preview/dry-run, live place, cancel, and ladder fill-preview tools. Requires dedicated auth token and required approval-hash modes. |
+| TradingCodex execution | `tradingcodex_execution` | Reviewed TradingCodex BrokerAdapter allowlist: account reads, `route_request`, `get_trading_policy`, `suggest_order_account`, `get_fx_rate`, preview/dry-run, live place, cancel, and ladder fill-preview tools. Requires dedicated auth token and required approval-hash modes. |
 
 ### Profile: `hermes-paper-kis`
 

--- a/app/mcp_server/README.md
+++ b/app/mcp_server/README.md
@@ -1680,6 +1680,7 @@ The `MCP_PROFILE` env var selects which tool subset is registered at startup.
 | Kiwoom mock | `kiwoom` | Default read-only/research surface plus typed `kiwoom_mock_*` variants only (no KIS/generic order tools) |
 | Analysis readonly | `analysis_readonly` | Codex/headless read/analysis allowlist only: `get_operating_briefing`, `route_request`, `get_trading_policy`, selected quote/fundamental/analysis tools, `suggest_order_account`, `get_holdings`, `toss_get_positions`, and explicitly labeled analysis persistence. No order/cancel/modify/reconcile/preview/settings/watch/admin/manual-holdings mutation tools are registered. |
 | Account read | `account_read` | TradingCodex account adapter allowlist only: `get_holdings`, `toss_get_positions`, `get_cash_balance`, `toss_get_orderable_cash`, `get_order_history`, `kis_live_get_order_history`, and `toss_get_order_history`. No order placement/cancel/modify/preview/reconcile, persistence, settings, watch, admin, report-writing, or manual-holdings mutation tools are registered. |
+| TradingCodex execution | `tradingcodex_execution` | Reviewed TradingCodex BrokerAdapter allowlist: account reads, preview/dry-run, live place, cancel, and ladder fill-preview tools. Requires dedicated auth token and required approval-hash modes. |
 
 ### Profile: `hermes-paper-kis`
 

--- a/app/mcp_server/main.py
+++ b/app/mcp_server/main.py
@@ -51,11 +51,33 @@ _mcp_profile = resolve_mcp_profile(_env("MCP_PROFILE"))
 
 
 def _validate_profile_auth_token(profile: McpProfile, token: str | None) -> None:
-    if profile is McpProfile.ACCOUNT_READ and not (token or "").strip():
-        raise RuntimeError("MCP_PROFILE=account_read requires non-empty MCP_AUTH_TOKEN")
+    token_required_profiles = {
+        McpProfile.ACCOUNT_READ,
+        McpProfile.TRADINGCODEX_EXECUTION,
+    }
+    if profile in token_required_profiles and not (token or "").strip():
+        raise RuntimeError(
+            f"MCP_PROFILE={profile.value} requires non-empty MCP_AUTH_TOKEN"
+        )
+
+
+def _validate_profile_runtime_settings(profile: McpProfile) -> None:
+    if profile is not McpProfile.TRADINGCODEX_EXECUTION:
+        return
+    if settings.order_approval_hash_mode != "required":
+        raise RuntimeError(
+            "MCP_PROFILE=tradingcodex_execution requires "
+            "ORDER_APPROVAL_HASH_MODE=required"
+        )
+    if settings.toss_approval_hash_mode != "required":
+        raise RuntimeError(
+            "MCP_PROFILE=tradingcodex_execution requires "
+            "TOSS_APPROVAL_HASH_MODE=required"
+        )
 
 
 _validate_profile_auth_token(_mcp_profile, _auth_token)
+_validate_profile_runtime_settings(_mcp_profile)
 auth_provider = build_auth_provider(_auth_token)
 mcp = FastMCP(
     name="auto_trader-mcp",

--- a/app/mcp_server/profiles.py
+++ b/app/mcp_server/profiles.py
@@ -19,6 +19,7 @@ class McpProfile(StrEnum):
     SHADOW_REPLAY = "shadow-replay"
     ANALYSIS_READONLY = "analysis_readonly"
     ACCOUNT_READ = "account_read"
+    TRADINGCODEX_EXECUTION = "tradingcodex_execution"
 
 
 def resolve_mcp_profile(env: str | None) -> McpProfile:

--- a/app/mcp_server/tooling/registry.py
+++ b/app/mcp_server/tooling/registry.py
@@ -54,10 +54,10 @@ Profile → tool surface mapping
 
 "tradingcodex_execution" (McpProfile.TRADINGCODEX_EXECUTION):
   TradingCodex broker execution allowlist only. Registers account reads,
-  account-routing suggestion, dry-run/preview, live place, cancel, and ladder
-  fill-preview tools required by the reviewed BrokerAdapter. No modify,
-  reconcile, persistence, settings, watch, admin, report-write, KIS mock,
-  Kiwoom, Alpaca, or paper simulator tools are registered.
+  account-routing suggestion, USD/KRW FX read, dry-run/preview, live place,
+  cancel, and ladder fill-preview tools required by the reviewed BrokerAdapter.
+  No modify, reconcile, persistence, settings, watch, admin, report-write,
+  KIS mock, Kiwoom, Alpaca, or paper simulator tools are registered.
 
 See app/mcp_server/profiles.py and docs in app/mcp_server/README.md.
 """

--- a/app/mcp_server/tooling/registry.py
+++ b/app/mcp_server/tooling/registry.py
@@ -52,6 +52,13 @@ Profile → tool surface mapping
   order placement, cancel, modify, preview, reconcile, persistence, settings,
   watch, admin, report-write, or manual-holdings mutation tools are registered.
 
+"tradingcodex_execution" (McpProfile.TRADINGCODEX_EXECUTION):
+  TradingCodex broker execution allowlist only. Registers account reads,
+  dry-run/preview, live place, cancel, and ladder fill-preview tools required
+  by the reviewed BrokerAdapter. No modify, reconcile, persistence, settings,
+  watch, admin, report-write, KIS mock, Kiwoom, Alpaca, or paper simulator
+  tools are registered.
+
 See app/mcp_server/profiles.py and docs in app/mcp_server/README.md.
 """
 
@@ -154,6 +161,9 @@ from app.mcp_server.tooling.trading_policy_registration import (
 from app.mcp_server.tooling.trading_scoreboard_registration import (
     register_trading_scoreboard_tools,
 )
+from app.mcp_server.tooling.tradingcodex_execution_registration import (
+    register_tradingcodex_execution_tools,
+)
 from app.mcp_server.tooling.us_dual_paper import register_us_dual_paper_tools
 from app.mcp_server.tooling.user_settings_registration import (
     register_user_settings_tools,
@@ -194,6 +204,13 @@ def register_all_tools(mcp: FastMCP, profile: McpProfile = McpProfile.DEFAULT) -
         # returns before the normal "Always" block so research, persistence,
         # settings, watch, preview, reconcile, and mutation tools are absent.
         register_account_read_tools(mcp)
+        return
+
+    if profile is McpProfile.TRADINGCODEX_EXECUTION:
+        # ROB-762 — TradingCodex broker execution surface. Allowlist-only and
+        # returns before the normal default block so broad research, settings,
+        # watch, modify, reconcile, and persistence tools are physically absent.
+        register_tradingcodex_execution_tools(mcp)
         return
 
     # Always: side-effect-free research + read-only tools

--- a/app/mcp_server/tooling/registry.py
+++ b/app/mcp_server/tooling/registry.py
@@ -54,10 +54,10 @@ Profile → tool surface mapping
 
 "tradingcodex_execution" (McpProfile.TRADINGCODEX_EXECUTION):
   TradingCodex broker execution allowlist only. Registers account reads,
-  dry-run/preview, live place, cancel, and ladder fill-preview tools required
-  by the reviewed BrokerAdapter. No modify, reconcile, persistence, settings,
-  watch, admin, report-write, KIS mock, Kiwoom, Alpaca, or paper simulator
-  tools are registered.
+  account-routing suggestion, dry-run/preview, live place, cancel, and ladder
+  fill-preview tools required by the reviewed BrokerAdapter. No modify,
+  reconcile, persistence, settings, watch, admin, report-write, KIS mock,
+  Kiwoom, Alpaca, or paper simulator tools are registered.
 
 See app/mcp_server/profiles.py and docs in app/mcp_server/README.md.
 """

--- a/app/mcp_server/tooling/registry.py
+++ b/app/mcp_server/tooling/registry.py
@@ -54,10 +54,11 @@ Profile → tool surface mapping
 
 "tradingcodex_execution" (McpProfile.TRADINGCODEX_EXECUTION):
   TradingCodex broker execution allowlist only. Registers account reads,
-  account-routing suggestion, USD/KRW FX read, dry-run/preview, live place,
-  cancel, and ladder fill-preview tools required by the reviewed BrokerAdapter.
-  No modify, reconcile, persistence, settings, watch, admin, report-write,
-  KIS mock, Kiwoom, Alpaca, or paper simulator tools are registered.
+  policy/route advisory reads, account-routing suggestion, USD/KRW FX read,
+  dry-run/preview, live place, cancel, and ladder fill-preview tools required
+  by the reviewed BrokerAdapter. No modify, reconcile, persistence, settings,
+  watch, admin, report-write, KIS mock, Kiwoom, Alpaca, or paper simulator
+  tools are registered.
 
 See app/mcp_server/profiles.py and docs in app/mcp_server/README.md.
 """

--- a/app/mcp_server/tooling/tradingcodex_execution_registration.py
+++ b/app/mcp_server/tooling/tradingcodex_execution_registration.py
@@ -37,8 +37,14 @@ from app.mcp_server.tooling.paper_limit_order_handler import (
     PAPER_LIMIT_ORDER_TOOL_NAMES,
 )
 from app.mcp_server.tooling.portfolio_registration import register_portfolio_tools
+from app.mcp_server.tooling.route_request_registration import (
+    register_route_request_tools,
+)
 from app.mcp_server.tooling.session_context_registration import (
     SESSION_CONTEXT_TOOL_NAMES,
+)
+from app.mcp_server.tooling.trading_policy_registration import (
+    register_trading_policy_tools,
 )
 from app.mcp_server.tooling.user_settings_registration import USER_SETTINGS_TOOL_NAMES
 
@@ -58,6 +64,8 @@ TRADINGCODEX_EXECUTION_TOOL_NAMES: set[str] = ACCOUNT_READ_TOOL_NAMES | {
     "buy_ladder_fill_preview",
     "suggest_order_account",
     "get_fx_rate",
+    "route_request",
+    "get_trading_policy",
 }
 
 TRADINGCODEX_EXECUTION_FORBIDDEN_TOOL_NAMES: set[str] = (
@@ -90,6 +98,8 @@ def register_tradingcodex_execution_tools(mcp: FastMCP) -> None:
     register_toss_live_order_tools(filtered)
     register_account_routing_tools(filtered)
     register_fundamentals_tools(filtered)
+    register_trading_policy_tools(filtered)
+    register_route_request_tools(filtered)
 
 
 __all__ = [

--- a/app/mcp_server/tooling/tradingcodex_execution_registration.py
+++ b/app/mcp_server/tooling/tradingcodex_execution_registration.py
@@ -1,0 +1,91 @@
+"""TradingCodex execution MCP profile registration.
+
+This profile is narrower than the default MCP surface and more privileged than
+account_read. It is only for the TradingCodex BrokerAdapter live gate.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, cast
+
+from app.mcp_server.tooling.account_read_registration import ACCOUNT_READ_TOOL_NAMES
+from app.mcp_server.tooling.analysis_artifact_registration import (
+    ANALYSIS_ARTIFACT_TOOL_NAMES,
+)
+from app.mcp_server.tooling.analysis_readonly_registration import _AllowlistedMCP
+from app.mcp_server.tooling.forecast_registration import FORECAST_TOOL_NAMES
+from app.mcp_server.tooling.orders_kis_variants import (
+    KIS_LIVE_ORDER_TOOL_NAMES,
+    KIS_MOCK_ORDER_TOOL_NAMES,
+    LIVE_RECONCILE_TOOL_NAMES,
+    register_kis_live_order_tools,
+)
+from app.mcp_server.tooling.orders_kiwoom_variants import KIWOOM_MOCK_TOOL_NAMES
+from app.mcp_server.tooling.orders_registration import (
+    ORDER_TOOL_NAMES,
+    register_order_tools,
+)
+from app.mcp_server.tooling.orders_toss_variants import (
+    TOSS_LIVE_ORDER_TOOL_NAMES,
+    register_toss_live_order_tools,
+)
+from app.mcp_server.tooling.paper_limit_order_handler import (
+    PAPER_LIMIT_ORDER_TOOL_NAMES,
+)
+from app.mcp_server.tooling.portfolio_registration import register_portfolio_tools
+from app.mcp_server.tooling.session_context_registration import (
+    SESSION_CONTEXT_TOOL_NAMES,
+)
+from app.mcp_server.tooling.user_settings_registration import USER_SETTINGS_TOOL_NAMES
+
+if TYPE_CHECKING:
+    from fastmcp import FastMCP
+
+
+TRADINGCODEX_EXECUTION_TOOL_NAMES: set[str] = ACCOUNT_READ_TOOL_NAMES | {
+    "place_order",
+    "cancel_order",
+    "kis_live_place_order",
+    "kis_live_cancel_order",
+    "toss_preview_order",
+    "toss_place_order",
+    "toss_cancel_order",
+    "sell_ladder_fill_preview",
+    "buy_ladder_fill_preview",
+}
+
+TRADINGCODEX_EXECUTION_FORBIDDEN_TOOL_NAMES: set[str] = (
+    (ORDER_TOOL_NAMES - TRADINGCODEX_EXECUTION_TOOL_NAMES)
+    | (KIS_LIVE_ORDER_TOOL_NAMES - TRADINGCODEX_EXECUTION_TOOL_NAMES)
+    | KIS_MOCK_ORDER_TOOL_NAMES
+    | LIVE_RECONCILE_TOOL_NAMES
+    | KIWOOM_MOCK_TOOL_NAMES
+    | PAPER_LIMIT_ORDER_TOOL_NAMES
+    | (TOSS_LIVE_ORDER_TOOL_NAMES - TRADINGCODEX_EXECUTION_TOOL_NAMES)
+    | ANALYSIS_ARTIFACT_TOOL_NAMES
+    | FORECAST_TOOL_NAMES
+    | SESSION_CONTEXT_TOOL_NAMES
+    | USER_SETTINGS_TOOL_NAMES
+    | {
+        "get_available_capital",
+        "get_position",
+        "update_manual_holdings",
+        "list_active_watches",
+    }
+)
+
+
+def register_tradingcodex_execution_tools(mcp: FastMCP) -> None:
+    """Register only the TradingCodex broker execution allowlist."""
+    filtered = cast("FastMCP", _AllowlistedMCP(mcp, TRADINGCODEX_EXECUTION_TOOL_NAMES))
+    register_portfolio_tools(filtered)
+    register_order_tools(filtered)
+    register_kis_live_order_tools(filtered)
+    register_toss_live_order_tools(filtered)
+
+
+__all__ = [
+    "TRADINGCODEX_EXECUTION_FORBIDDEN_TOOL_NAMES",
+    "TRADINGCODEX_EXECUTION_TOOL_NAMES",
+    "register_tradingcodex_execution_tools",
+]

--- a/app/mcp_server/tooling/tradingcodex_execution_registration.py
+++ b/app/mcp_server/tooling/tradingcodex_execution_registration.py
@@ -17,6 +17,7 @@ from app.mcp_server.tooling.analysis_artifact_registration import (
 )
 from app.mcp_server.tooling.analysis_readonly_registration import _AllowlistedMCP
 from app.mcp_server.tooling.forecast_registration import FORECAST_TOOL_NAMES
+from app.mcp_server.tooling.fundamentals_registration import register_fundamentals_tools
 from app.mcp_server.tooling.orders_kis_variants import (
     KIS_LIVE_ORDER_TOOL_NAMES,
     KIS_MOCK_ORDER_TOOL_NAMES,
@@ -56,6 +57,7 @@ TRADINGCODEX_EXECUTION_TOOL_NAMES: set[str] = ACCOUNT_READ_TOOL_NAMES | {
     "sell_ladder_fill_preview",
     "buy_ladder_fill_preview",
     "suggest_order_account",
+    "get_fx_rate",
 }
 
 TRADINGCODEX_EXECUTION_FORBIDDEN_TOOL_NAMES: set[str] = (
@@ -87,6 +89,7 @@ def register_tradingcodex_execution_tools(mcp: FastMCP) -> None:
     register_kis_live_order_tools(filtered)
     register_toss_live_order_tools(filtered)
     register_account_routing_tools(filtered)
+    register_fundamentals_tools(filtered)
 
 
 __all__ = [

--- a/app/mcp_server/tooling/tradingcodex_execution_registration.py
+++ b/app/mcp_server/tooling/tradingcodex_execution_registration.py
@@ -9,6 +9,9 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, cast
 
 from app.mcp_server.tooling.account_read_registration import ACCOUNT_READ_TOOL_NAMES
+from app.mcp_server.tooling.account_routing_registration import (
+    register_account_routing_tools,
+)
 from app.mcp_server.tooling.analysis_artifact_registration import (
     ANALYSIS_ARTIFACT_TOOL_NAMES,
 )
@@ -52,6 +55,7 @@ TRADINGCODEX_EXECUTION_TOOL_NAMES: set[str] = ACCOUNT_READ_TOOL_NAMES | {
     "toss_cancel_order",
     "sell_ladder_fill_preview",
     "buy_ladder_fill_preview",
+    "suggest_order_account",
 }
 
 TRADINGCODEX_EXECUTION_FORBIDDEN_TOOL_NAMES: set[str] = (
@@ -82,6 +86,7 @@ def register_tradingcodex_execution_tools(mcp: FastMCP) -> None:
     register_order_tools(filtered)
     register_kis_live_order_tools(filtered)
     register_toss_live_order_tools(filtered)
+    register_account_routing_tools(filtered)
 
 
 __all__ = [

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -178,6 +178,38 @@ services:
           memory: 256M
           cpus: '0.1'
 
+  mcp-tradingcodex-execution:
+    image: ghcr.io/${GITHUB_REPOSITORY}:production
+    container_name: auto_trader_mcp_tradingcodex_execution_prod
+    env_file:
+      - .env.prod
+    environment:
+      MCP_TYPE: ${MCP_TRADINGCODEX_EXECUTION_TYPE:-streamable-http}
+      MCP_HOST: ${MCP_TRADINGCODEX_EXECUTION_HOST:-0.0.0.0}
+      MCP_PORT: ${MCP_TRADINGCODEX_EXECUTION_PORT:-8770}
+      MCP_PATH: ${MCP_TRADINGCODEX_EXECUTION_PATH:-/mcp}
+      MCP_PROFILE: tradingcodex_execution
+      MCP_AUTH_TOKEN: ${MCP_TRADINGCODEX_EXECUTION_AUTH_TOKEN:?MCP_TRADINGCODEX_EXECUTION_AUTH_TOKEN is required}
+      ORDER_APPROVAL_HASH_MODE: required
+      TOSS_APPROVAL_HASH_MODE: required
+    restart: unless-stopped
+    network_mode: host
+    command: ["python", "-m", "app.mcp_server.main"]
+    healthcheck:
+      test: [ "CMD", "python", "-c", "import os,sys,urllib.request; port=os.environ.get('MCP_PORT','8770'); sys.exit(0 if urllib.request.urlopen(f'http://127.0.0.1:{port}/health', timeout=5).status == 200 else 1)" ]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+    deploy:
+      resources:
+        limits:
+          memory: 512M
+          cpus: '0.5'
+        reservations:
+          memory: 256M
+          cpus: '0.1'
+
   upbit_websocket:
     image: ghcr.io/${GITHUB_REPOSITORY}:production
     container_name: auto_trader_upbit_ws_prod

--- a/docs/runbooks/tradingcodex-execution-mcp.md
+++ b/docs/runbooks/tradingcodex-execution-mcp.md
@@ -41,3 +41,18 @@ Expected: HTTP 200 with `service=auto-trader-mcp`.
 
 Mutation smoke must use TradingCodex `submit_approved_order`; do not call live
 place tools directly except in fake/test fixtures.
+
+## TradingCodex Smoke
+
+```bash
+cd /Users/mgh3326/services/tradingcodex-desk
+./tcx connectors providers
+./tcx connectors validate auto-trader
+./tcx mcp call preview_order_translation '{"broker":"auto-trader","symbol":"005930","side":"buy","quantity":1,"limit_price":70000,"thesis":"smoke thesis","strategy":"smoke strategy"}'
+```
+
+Expected: preview response includes `approval_hash`, `approval_expires_at`,
+`idempotency_key`, and no mutation was sent.
+
+Live smoke must be done only with a real approved order ticket and exact
+`live_confirmation` through `submit_approved_order`.

--- a/docs/runbooks/tradingcodex-execution-mcp.md
+++ b/docs/runbooks/tradingcodex-execution-mcp.md
@@ -1,0 +1,43 @@
+# TradingCodex Execution MCP (ROB-762)
+
+## Purpose
+
+`tradingcodex_execution` exposes only the MCP tools required by the reviewed
+TradingCodex `auto_trader` BrokerAdapter. It is not a general Codex tool
+surface.
+
+## Required Environment
+
+```bash
+MCP_PROFILE=tradingcodex_execution
+MCP_PORT=8770
+MCP_AUTH_TOKEN="$MCP_TRADINGCODEX_EXECUTION_AUTH_TOKEN"
+ORDER_APPROVAL_HASH_MODE=required
+TOSS_APPROVAL_HASH_MODE=required
+```
+
+`MCP_TRADINGCODEX_EXECUTION_AUTH_TOKEN` is the auto_trader server-side token.
+TradingCodex should store the same raw value outside the repo and refer to it
+as `env:AUTO_TRADER_TRADINGCODEX_EXECUTION_TOKEN`.
+
+## Start
+
+```bash
+MCP_PROFILE=tradingcodex_execution \
+MCP_PORT=8770 \
+MCP_AUTH_TOKEN="$MCP_TRADINGCODEX_EXECUTION_AUTH_TOKEN" \
+ORDER_APPROVAL_HASH_MODE=required \
+TOSS_APPROVAL_HASH_MODE=required \
+uv run python -m app.mcp_server.main
+```
+
+## Smoke
+
+```bash
+curl -s http://127.0.0.1:8770/health
+```
+
+Expected: HTTP 200 with `service=auto-trader-mcp`.
+
+Mutation smoke must use TradingCodex `submit_approved_order`; do not call live
+place tools directly except in fake/test fixtures.

--- a/env.example
+++ b/env.example
@@ -450,6 +450,12 @@ TOSS_APPROVAL_HASH_MODE=optional
 # ROB-653 P6-B — kis_live/crypto preview→place approval-hash 강제 수준 (off|optional|warn|required)
 ORDER_APPROVAL_HASH_MODE=optional
 
+# ROB-762 — dedicated token for the TradingCodex execution MCP profile.
+# Store the raw value only in operator-managed runtime secrets. TradingCodex
+# should reference the same value as env:AUTO_TRADER_TRADINGCODEX_EXECUTION_TOKEN.
+MCP_TRADINGCODEX_EXECUTION_AUTH_TOKEN=
+MCP_TRADINGCODEX_EXECUTION_PORT=8770
+
 # ========================================
 # WATCH_NOTIFY 설정 (ROB-566)
 # ========================================

--- a/ops/native/plists/com.robinco.auto-trader.mcp-tradingcodex-execution.plist
+++ b/ops/native/plists/com.robinco.auto-trader.mcp-tradingcodex-execution.plist
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.robinco.auto-trader.mcp-tradingcodex-execution</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/Users/mgh3326/services/auto_trader/scripts/run-mcp-profile.sh</string>
+  </array>
+  <key>WorkingDirectory</key>
+  <string>/Users/mgh3326/services/auto_trader/current</string>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>HOME</key>
+    <string>/Users/mgh3326</string>
+    <key>PATH</key>
+    <string>/Users/mgh3326/.local/bin:/Users/mgh3326/.hermes/node/bin:/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    <key>AUTO_TRADER_BASE</key>
+    <string>/Users/mgh3326/services/auto_trader</string>
+    <key>AUTO_TRADER_ENV_FILE</key>
+    <string>/Users/mgh3326/services/auto_trader/shared/.env.prod.native</string>
+    <key>AUTO_TRADER_MCP_PROFILE</key>
+    <string>tradingcodex_execution</string>
+    <key>AUTO_TRADER_MCP_PORT</key>
+    <string>8770</string>
+    <key>AUTO_TRADER_MCP_AUTH_TOKEN_ENV</key>
+    <string>MCP_TRADINGCODEX_EXECUTION_AUTH_TOKEN</string>
+    <key>ORDER_APPROVAL_HASH_MODE</key>
+    <string>required</string>
+    <key>TOSS_APPROVAL_HASH_MODE</key>
+    <string>required</string>
+  </dict>
+  <key>RunAtLoad</key>
+  <false/>
+  <key>KeepAlive</key>
+  <true/>
+  <key>ThrottleInterval</key>
+  <integer>10</integer>
+  <key>StandardOutPath</key>
+  <string>/Users/mgh3326/services/auto_trader/logs/com.robinco.auto-trader.mcp-tradingcodex-execution.out.log</string>
+  <key>StandardErrorPath</key>
+  <string>/Users/mgh3326/services/auto_trader/logs/com.robinco.auto-trader.mcp-tradingcodex-execution.err.log</string>
+</dict>
+</plist>

--- a/scripts/deploy-native.sh
+++ b/scripts/deploy-native.sh
@@ -56,6 +56,8 @@ SINGLE_ACTIVE_LABELS=(
   # ROB-760: fixed-profile readonly MCP services outside the blue/green pair.
   "com.robinco.auto-trader.mcp-analysis-readonly"
   "com.robinco.auto-trader.mcp-account-read"
+  # ROB-762: TradingCodex execution MCP service outside the blue/green pair.
+  "com.robinco.auto-trader.mcp-tradingcodex-execution"
   # ROB-469 PR3: single non-color-specific watchdog that restarts a wedged MCP color.
   "com.robinco.auto-trader.mcp-watchdog"
 )

--- a/tests/scripts/test_native_plists.py
+++ b/tests/scripts/test_native_plists.py
@@ -110,5 +110,8 @@ def test_mcp_tradingcodex_execution_plist_profile_port_and_token_env() -> None:
     assert "<string>tradingcodex_execution</string>" in body
     assert "<string>8770</string>" in body
     assert "<string>MCP_TRADINGCODEX_EXECUTION_AUTH_TOKEN</string>" in body
-    assert "<string>required</string>" in body
+    assert (
+        "<key>ORDER_APPROVAL_HASH_MODE</key>\n    <string>required</string>"
+    ) in body
+    assert ("<key>TOSS_APPROVAL_HASH_MODE</key>\n    <string>required</string>") in body
     assert "current</string>" in body

--- a/tests/scripts/test_native_plists.py
+++ b/tests/scripts/test_native_plists.py
@@ -19,6 +19,7 @@ PLISTS = [
     "com.robinco.auto-trader.mcp-green.plist",
     "com.robinco.auto-trader.mcp-analysis-readonly.plist",
     "com.robinco.auto-trader.mcp-account-read.plist",
+    "com.robinco.auto-trader.mcp-tradingcodex-execution.plist",
     "com.robinco.auto-trader.worker.plist",
     "com.robinco.auto-trader.scheduler.plist",
     "com.robinco.auto-trader.kis-websocket.plist",
@@ -98,4 +99,16 @@ def test_mcp_analysis_readonly_plist_profile_port_and_token_env() -> None:
     assert "<string>analysis_readonly</string>" in body
     assert "<string>8768</string>" in body
     assert "<string>MCP_ANALYSIS_READONLY_AUTH_TOKEN</string>" in body
+    assert "current</string>" in body
+
+
+def test_mcp_tradingcodex_execution_plist_profile_port_and_token_env() -> None:
+    body = (
+        PLIST_DIR / "com.robinco.auto-trader.mcp-tradingcodex-execution.plist"
+    ).read_text()
+    assert "scripts/run-mcp-profile.sh" in body
+    assert "<string>tradingcodex_execution</string>" in body
+    assert "<string>8770</string>" in body
+    assert "<string>MCP_TRADINGCODEX_EXECUTION_AUTH_TOKEN</string>" in body
+    assert "<string>required</string>" in body
     assert "current</string>" in body

--- a/tests/scripts/test_native_run_wrappers.py
+++ b/tests/scripts/test_native_run_wrappers.py
@@ -201,3 +201,22 @@ def test_run_mcp_profile_fails_without_dedicated_token(tmp_path: Path) -> None:
     )
     assert proc.returncode == 78
     assert "MCP_ACCOUNT_READ_AUTH_TOKEN is required" in proc.stderr
+
+
+def test_run_mcp_profile_exports_tradingcodex_execution_profile(tmp_path: Path) -> None:
+    proc = _run_profile(
+        RUN_MCP_PROFILE,
+        {
+            "AUTO_TRADER_MCP_PROFILE": "tradingcodex_execution",
+            "AUTO_TRADER_MCP_PORT": "8770",
+            "AUTO_TRADER_MCP_AUTH_TOKEN_ENV": "MCP_TRADINGCODEX_EXECUTION_AUTH_TOKEN",
+            "MCP_TRADINGCODEX_EXECUTION_AUTH_TOKEN": "execution-token",
+            "ORDER_APPROVAL_HASH_MODE": "required",
+            "TOSS_APPROVAL_HASH_MODE": "required",
+        },
+        tmp_path,
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert "MCP_PROFILE=tradingcodex_execution" in proc.stdout
+    assert "MCP_PORT=8770" in proc.stdout
+    assert "MCP_AUTH_TOKEN=execution-token" in proc.stdout

--- a/tests/test_mcp_profiles.py
+++ b/tests/test_mcp_profiles.py
@@ -537,6 +537,7 @@ class TestTradingCodexExecutionProfile:
             "toss_cancel_order",
             "sell_ladder_fill_preview",
             "buy_ladder_fill_preview",
+            "suggest_order_account",
         } <= mcp.tools.keys()
 
     def test_does_not_register_modify_reconcile_or_persistence_tools(self) -> None:

--- a/tests/test_mcp_profiles.py
+++ b/tests/test_mcp_profiles.py
@@ -539,6 +539,8 @@ class TestTradingCodexExecutionProfile:
             "buy_ladder_fill_preview",
             "suggest_order_account",
             "get_fx_rate",
+            "route_request",
+            "get_trading_policy",
         } <= mcp.tools.keys()
 
     def test_does_not_register_modify_reconcile_or_persistence_tools(self) -> None:

--- a/tests/test_mcp_profiles.py
+++ b/tests/test_mcp_profiles.py
@@ -45,6 +45,10 @@ from app.mcp_server.tooling.paper_limit_order_handler import (
     PAPER_LIMIT_ORDER_TOOL_NAMES,
 )
 from app.mcp_server.tooling.registry import register_all_tools
+from app.mcp_server.tooling.tradingcodex_execution_registration import (
+    TRADINGCODEX_EXECUTION_FORBIDDEN_TOOL_NAMES,
+    TRADINGCODEX_EXECUTION_TOOL_NAMES,
+)
 from app.mcp_server.tooling.us_dual_paper import US_DUAL_PAPER_TOOL_NAMES
 from tests._mcp_tooling_support import DummyMCP
 
@@ -262,6 +266,22 @@ _ORDER_SURFACE_MATRIX: dict[McpProfile, set[str]] = {
         "toss_get_positions",
         "toss_get_orderable_cash",
     },
+    McpProfile.TRADINGCODEX_EXECUTION: {
+        "place_order",
+        "cancel_order",
+        "get_order_history",
+        "sell_ladder_fill_preview",
+        "buy_ladder_fill_preview",
+        "kis_live_place_order",
+        "kis_live_cancel_order",
+        "kis_live_get_order_history",
+        "toss_preview_order",
+        "toss_place_order",
+        "toss_cancel_order",
+        "toss_get_order_history",
+        "toss_get_positions",
+        "toss_get_orderable_cash",
+    },
 }
 _ALL_ORDER_TOOL_NAMES = (
     _LEGACY_ORDER_TOOL_NAMES
@@ -307,6 +327,7 @@ _PROFILES_WITH_RESEARCH_SURFACE = [
         McpProfile.SHADOW_REPLAY,
         McpProfile.ANALYSIS_READONLY,
         McpProfile.ACCOUNT_READ,
+        McpProfile.TRADINGCODEX_EXECUTION,
     )
 ]
 
@@ -487,6 +508,61 @@ class TestAccountReadProfile:
         } <= mcp.tools.keys()
 
 
+class TestTradingCodexExecutionProfile:
+    def test_registers_exact_tradingcodex_execution_allowlist(self) -> None:
+        mcp = _build_mcp(McpProfile.TRADINGCODEX_EXECUTION)
+        assert set(mcp.tools) == TRADINGCODEX_EXECUTION_TOOL_NAMES
+
+    def test_does_not_register_forbidden_execution_surfaces(self) -> None:
+        mcp = _build_mcp(McpProfile.TRADINGCODEX_EXECUTION)
+        leaked = TRADINGCODEX_EXECUTION_FORBIDDEN_TOOL_NAMES & mcp.tools.keys()
+        assert not leaked, (
+            f"tradingcodex_execution leaked forbidden tools: {sorted(leaked)}"
+        )
+
+    def test_expected_execution_tools_are_present(self) -> None:
+        mcp = _build_mcp(McpProfile.TRADINGCODEX_EXECUTION)
+        assert {
+            "get_holdings",
+            "get_cash_balance",
+            "get_order_history",
+            "kis_live_get_order_history",
+            "toss_get_order_history",
+            "place_order",
+            "cancel_order",
+            "kis_live_place_order",
+            "kis_live_cancel_order",
+            "toss_preview_order",
+            "toss_place_order",
+            "toss_cancel_order",
+            "sell_ladder_fill_preview",
+            "buy_ladder_fill_preview",
+        } <= mcp.tools.keys()
+
+    def test_does_not_register_modify_reconcile_or_persistence_tools(self) -> None:
+        mcp = _build_mcp(McpProfile.TRADINGCODEX_EXECUTION)
+        forbidden = {
+            "modify_order",
+            "kis_live_modify_order",
+            "kis_live_reconcile_orders",
+            "live_reconcile_orders",
+            "toss_modify_order",
+            "toss_reconcile_orders",
+            "analysis_artifact_save",
+            "analysis_artifact_get",
+            "forecast_save",
+            "session_context_append",
+            "session_context_get_recent",
+            "update_manual_holdings",
+            "get_user_setting",
+            "list_active_watches",
+        }
+        leaked = forbidden & mcp.tools.keys()
+        assert not leaked, (
+            f"tradingcodex_execution leaked unsafe tools: {sorted(leaked)}"
+        )
+
+
 class TestResolveMcpProfile:
     def test_none_returns_default(self) -> None:
         assert resolve_mcp_profile(None) is McpProfile.DEFAULT
@@ -523,6 +599,12 @@ class TestResolveMcpProfile:
 
     def test_account_read(self) -> None:
         assert resolve_mcp_profile("account_read") is McpProfile.ACCOUNT_READ
+
+    def test_tradingcodex_execution(self) -> None:
+        assert (
+            resolve_mcp_profile("tradingcodex_execution")
+            is McpProfile.TRADINGCODEX_EXECUTION
+        )
 
     def test_invalid_string_raises_value_error(self) -> None:
         with pytest.raises(ValueError, match="Unknown MCP_PROFILE"):

--- a/tests/test_mcp_profiles.py
+++ b/tests/test_mcp_profiles.py
@@ -538,6 +538,7 @@ class TestTradingCodexExecutionProfile:
             "sell_ladder_fill_preview",
             "buy_ladder_fill_preview",
             "suggest_order_account",
+            "get_fx_rate",
         } <= mcp.tools.keys()
 
     def test_does_not_register_modify_reconcile_or_persistence_tools(self) -> None:

--- a/tests/test_mcp_server_main.py
+++ b/tests/test_mcp_server_main.py
@@ -1,6 +1,7 @@
 import importlib
 import importlib.util
 import sys
+import types
 from pathlib import Path
 from types import ModuleType, SimpleNamespace
 from unittest.mock import MagicMock
@@ -13,6 +14,28 @@ class _FakeFastMCP:
         self.init_kwargs = kwargs
         self.run = MagicMock()
         self.add_middleware = MagicMock()
+
+
+class _FakeProfileMember:
+    """Hashable stand-in for a McpProfile enum member used in tests.
+
+    The main.py validators build a set of members and access ``.value`` for the
+    error message, so the fake must support both.
+    """
+
+    __slots__ = ("value",)
+
+    def __init__(self, value: str) -> None:
+        self.value = value
+
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, _FakeProfileMember) and self.value == other.value
+
+    def __hash__(self) -> int:
+        return hash(self.value)
+
+    def __repr__(self) -> str:
+        return f"_FakeProfileMember({self.value!r})"
 
 
 def _load_env_utils_module() -> ModuleType:
@@ -32,8 +55,10 @@ def _load_env_utils_module() -> ModuleType:
 def _load_main_module(
     monkeypatch: pytest.MonkeyPatch,
     *,
+    auth_token: str = "",
     account_read: bool = False,
-) -> tuple[ModuleType, _FakeFastMCP, MagicMock, object]:
+    tradingcodex_execution: bool = False,
+) -> tuple[ModuleType, _FakeFastMCP, MagicMock, object, object]:
     main_path = Path(__file__).resolve().parents[1] / "app" / "mcp_server" / "main.py"
 
     fake_fastmcp = ModuleType("fastmcp")
@@ -42,11 +67,27 @@ def _load_main_module(
     fake_mcp_package = ModuleType("app.mcp_server")
     fake_mcp_package.__path__ = []
 
-    fake_config = ModuleType("app.core.config")
-    fake_config.__dict__["settings"] = SimpleNamespace(
-        LOG_LEVEL="INFO",
-        mcp_caller_agent_id_fallback=None,
-    )
+    # ROB-762: tests may pre-set sys.modules["app.core.config"] to drive the
+    # fail-closed runtime validator (e.g. force order_approval_hash_mode to a
+    # non-required value). If a pre-set module with a `.settings` attribute is
+    # present, reuse it; otherwise install the default settings the helper has
+    # used since ROB-760. Without this branch, a pre-set module would be
+    # overwritten by the helper's own monkeypatch.setitem below.
+    pre_set_config = sys.modules.get("app.core.config")
+    if (
+        pre_set_config is not None
+        and hasattr(pre_set_config, "settings")
+        and isinstance(getattr(pre_set_config, "settings", None), SimpleNamespace)
+    ):
+        fake_config = pre_set_config
+    else:
+        fake_config = ModuleType("app.core.config")
+        fake_config.__dict__["settings"] = SimpleNamespace(
+            LOG_LEVEL="INFO",
+            mcp_caller_agent_id_fallback=None,
+            order_approval_hash_mode="required",
+            toss_approval_hash_mode="required",
+        )
 
     fake_auth = ModuleType("app.mcp_server.auth")
     fake_auth.__dict__["build_auth_provider"] = MagicMock(return_value="auth-provider")
@@ -71,11 +112,18 @@ def _load_main_module(
     fake_monitoring.__dict__["capture_exception"] = MagicMock()
     fake_monitoring.__dict__["init_sentry"] = MagicMock()
 
-    account_read_profile = object()
-    resolved_profile = account_read_profile if account_read else "profile"
+    account_read_profile = _FakeProfileMember("account_read")
+    tradingcodex_execution_profile = _FakeProfileMember("tradingcodex_execution")
+    if tradingcodex_execution:
+        resolved_profile = tradingcodex_execution_profile
+    elif account_read:
+        resolved_profile = account_read_profile
+    else:
+        resolved_profile = "profile"
     fake_profiles = ModuleType("app.mcp_server.profiles")
     fake_profiles.__dict__["McpProfile"] = SimpleNamespace(
-        ACCOUNT_READ=account_read_profile
+        ACCOUNT_READ=account_read_profile,
+        TRADINGCODEX_EXECUTION=tradingcodex_execution_profile,
     )
     fake_profiles.__dict__["resolve_mcp_profile"] = MagicMock(
         return_value=resolved_profile
@@ -123,6 +171,9 @@ def _load_main_module(
         sys.modules, "app.mcp_server.timeout_middleware", fake_timeout_middleware
     )
 
+    if auth_token:
+        monkeypatch.setenv("MCP_AUTH_TOKEN", auth_token)
+
     spec = importlib.util.spec_from_file_location("app.mcp_server.main", main_path)
     assert spec is not None
     assert spec.loader is not None
@@ -133,7 +184,13 @@ def _load_main_module(
     # session, poisoning other tests that import the real app.mcp_server.main.
     monkeypatch.setitem(sys.modules, "app.mcp_server.main", module)
     spec.loader.exec_module(module)
-    return module, module.mcp, fake_monitoring.capture_exception, account_read_profile
+    return (
+        module,
+        module.mcp,
+        fake_monitoring.capture_exception,
+        account_read_profile,
+        tradingcodex_execution_profile,
+    )
 
 
 @pytest.mark.unit
@@ -141,7 +198,7 @@ class TestMcpServerMain:
     def test_registers_caller_identity_middleware_after_sentry(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        _, mcp, _, _ = _load_main_module(monkeypatch)
+        _, mcp, _, _, _ = _load_main_module(monkeypatch)
 
         calls = [call.args[0] for call in mcp.add_middleware.call_args_list]
         # Sentry (outermost) then CallerIdentity, then ROB-469 PR2's
@@ -154,7 +211,7 @@ class TestMcpServerMain:
     def test_non_integer_log_level_falls_back_to_info(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        module, mcp, _, _ = _load_main_module(monkeypatch)
+        module, mcp, _, _, _ = _load_main_module(monkeypatch)
         module.settings.LOG_LEVEL = "BASIC_FORMAT"
 
         module.main()
@@ -173,7 +230,7 @@ class TestMcpServerMain:
         monkeypatch.setenv("MCP_TYPE", "streamable-http")
         monkeypatch.delenv("MCP_GRACEFUL_SHUTDOWN_TIMEOUT", raising=False)
 
-        module, mcp, _, _ = _load_main_module(monkeypatch)
+        module, mcp, _, _, _ = _load_main_module(monkeypatch)
 
         module.main()
 
@@ -191,7 +248,7 @@ class TestMcpServerMain:
         monkeypatch.setenv("MCP_TYPE", "sse")
         monkeypatch.setenv("MCP_GRACEFUL_SHUTDOWN_TIMEOUT", "27")
 
-        module, mcp, _, _ = _load_main_module(monkeypatch)
+        module, mcp, _, _, _ = _load_main_module(monkeypatch)
 
         module.main()
 
@@ -209,7 +266,7 @@ class TestMcpServerMain:
         monkeypatch.setenv("MCP_TYPE", "stdio")
         monkeypatch.setenv("MCP_GRACEFUL_SHUTDOWN_TIMEOUT", "33")
 
-        module, mcp, _, _ = _load_main_module(monkeypatch)
+        module, mcp, _, _, _ = _load_main_module(monkeypatch)
 
         module.main()
 
@@ -221,7 +278,7 @@ class TestMcpServerMain:
         monkeypatch.setenv("MCP_TYPE", "stdio")
         monkeypatch.setenv("MCP_GRACEFUL_SHUTDOWN_TIMEOUT", "invalid")
 
-        module, _, _, _ = _load_main_module(monkeypatch)
+        module, _, _, _, _ = _load_main_module(monkeypatch)
 
         module.main()
 
@@ -230,7 +287,7 @@ class TestMcpServerMain:
     ) -> None:
         monkeypatch.setenv("MCP_TYPE", "invalid")
 
-        module, _, capture_exception, _ = _load_main_module(monkeypatch)
+        module, _, capture_exception, _, _ = _load_main_module(monkeypatch)
 
         with pytest.raises(ValueError, match="Unsupported MCP_TYPE: invalid"):
             module.main()
@@ -243,7 +300,7 @@ class TestMcpServerMain:
     ) -> None:
         monkeypatch.setenv("MCP_TYPE", transport)
 
-        module, mcp, capture_exception, _ = _load_main_module(monkeypatch)
+        module, mcp, capture_exception, _, _ = _load_main_module(monkeypatch)
         module.settings.mcp_caller_agent_id_fallback = "trader-agent-id"
 
         with pytest.raises(
@@ -262,7 +319,7 @@ class TestMcpServerMain:
     ) -> None:
         monkeypatch.setenv("MCP_TYPE", "sse")
 
-        module, mcp, capture_exception, _ = _load_main_module(monkeypatch)
+        module, mcp, capture_exception, _, _ = _load_main_module(monkeypatch)
         module.settings.mcp_caller_agent_id_fallback = None
 
         module.main()
@@ -281,7 +338,7 @@ class TestMcpServerMain:
     ) -> None:
         monkeypatch.setenv("MCP_TYPE", "stdio")
 
-        module, mcp, capture_exception, _ = _load_main_module(monkeypatch)
+        module, mcp, capture_exception, _, _ = _load_main_module(monkeypatch)
         module.settings.mcp_caller_agent_id_fallback = "trader-agent-id"
 
         module.main()
@@ -304,6 +361,54 @@ class TestMcpServerMain:
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         monkeypatch.setenv("MCP_AUTH_TOKEN", "account-read-token")
-        module, _, _, _ = _load_main_module(monkeypatch, account_read=True)
+        module, _, _, _, _ = _load_main_module(monkeypatch, account_read=True)
 
         module.main()
+
+    def test_tradingcodex_execution_profile_requires_auth_token(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        with pytest.raises(
+            RuntimeError,
+            match=(
+                "MCP_PROFILE=tradingcodex_execution requires non-empty MCP_AUTH_TOKEN"
+            ),
+        ):
+            _load_main_module(monkeypatch, tradingcodex_execution=True)
+
+    def test_tradingcodex_execution_profile_requires_hash_modes(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        fake_settings = types.SimpleNamespace(
+            mcp_caller_agent_id_fallback="",
+            order_approval_hash_mode="optional",
+            toss_approval_hash_mode="required",
+            LOG_LEVEL="INFO",
+        )
+        monkeypatch.setitem(
+            sys.modules,
+            "app.core.config",
+            types.SimpleNamespace(settings=fake_settings),
+        )
+        with pytest.raises(
+            RuntimeError,
+            match="ORDER_APPROVAL_HASH_MODE=required",
+        ):
+            _load_main_module(
+                monkeypatch,
+                auth_token="execution-token",
+                tradingcodex_execution=True,
+            )
+
+    def test_tradingcodex_execution_profile_accepts_required_hash_modes(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        module, _, _, _, execution_profile = _load_main_module(
+            monkeypatch,
+            auth_token="execution-token",
+            tradingcodex_execution=True,
+        )
+        assert module._mcp_profile is execution_profile

--- a/tests/test_mcp_server_main.py
+++ b/tests/test_mcp_server_main.py
@@ -369,6 +369,8 @@ class TestMcpServerMain:
         self,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
+        monkeypatch.delenv("MCP_AUTH_TOKEN", raising=False)
+
         with pytest.raises(
             RuntimeError,
             match=(


### PR DESCRIPTION
## Summary

Promotes the `auto_trader` TradingCodex provider from read-only account sync to a live-capable broker adapter surface. This PR adds the **auto_trader side** of ROB-762 — a narrow `tradingcodex_execution` MCP profile on port 8770 that exposes only the broker tools TradingCodex's reviewed BrokerAdapter needs, behind fail-closed runtime gates.

The matching TradingCodex-side provider changes are in a separate PR in `tradingcodex-desk`.

## Changes

### Task 1 — `tradingcodex_execution` MCP profile (`8a231437`)
- New `McpProfile.TRADINGCODEX_EXECUTION` enum value (`"tradingcodex_execution"`).
- New `app/mcp_server/tooling/tradingcodex_execution_registration.py` — allowlist-only registration: account reads + dry-run/preview + live place/cancel + ladder fill-preview.
- Registry routes the new profile before the default block; broad research, settings, watch, modify, reconcile, persistence, KIS mock, Kiwoom, Alpaca, and paper simulator tools are physically absent.
- `TRADINGCODEX_EXECUTION_FORBIDDEN_TOOL_NAMES` set + tests assert no leak.

### Task 2 — Fail-closed runtime + deployment wiring (`25f0835e`)
- `app/mcp_server/main.py` — `_validate_profile_auth_token` extended; new `_validate_profile_runtime_settings` enforces `ORDER_APPROVAL_HASH_MODE=required` AND `TOSS_APPROVAL_HASH_MODE=required` for the execution profile. Process refuses to boot without both.
- `docker-compose.prod.yml` — `mcp-tradingcodex-execution` service on port 8770 with hard-coded hash modes.
- `env.example` — `MCP_TRADINGCODEX_EXECUTION_AUTH_TOKEN` + `MCP_TRADINGCODEX_EXECUTION_PORT=8770`.
- `ops/native/plists/com.robinco.auto-trader.mcp-tradingcodex-execution.plist` — launchd service mirroring account-read shape.
- `scripts/deploy-native.sh` — added label to `SINGLE_ACTIVE_LABELS`.
- `docs/runbooks/tradingcodex-execution-mcp.md` — operator runbook.
- `app/mcp_server/README.md` — profile table row.

### Task 5 — Runbook smoke commands (`194b2d3c`)
- Appended `## TradingCodex Smoke` section with `tcx connectors` commands + `preview_order_translation` example.

## Safety Gates

1. **Dedicated auth token** — `MCP_TRADINGCODEX_EXECUTION_AUTH_TOKEN` is separate from `MCP_ACCOUNT_READ_AUTH_TOKEN`; compose uses `${...:?required}` guard.
2. **Hash mode enforcement** — runtime validator raises `RuntimeError` if either `ORDER_APPROVAL_HASH_MODE` or `TOSS_APPROVAL_HASH_MODE` is not `"required"`.
3. **Allowlist-only tools** — `_AllowlistedMCP` wrapper filters at registration time; forbidden-set test catches any future leak.
4. **No raw tokens in files** — env.example is empty, plist references env-var NAME, runbook uses shell expansion.

## Test Results

- `tests/test_mcp_profiles.py` — 79 passed (4 new + 1 resolver + 74 existing)
- `tests/test_mcp_server_main.py` — 16 passed (3 new + 13 existing)
- `tests/scripts/test_native_plists.py` + `tests/scripts/test_native_run_wrappers.py` — 45 passed
- `tests/test_rob653_place_order_hash_guard.py` + `tests/test_order_approval_config.py` — 15 passed
- `make lint` — clean (ruff + ty)
- Manual smoke: server boots with required hash modes (HTTP 200), fails-closed with `ORDER_APPROVAL_HASH_MODE=optional`.

## Review

All 3 commits reviewed individually (spec compliance + code quality) + final whole-branch review. Approved — no Critical/Important issues. 3 Minor findings documented in progress ledger (broker_order_id format consistency is in the tradingcodex-desk PR; plist hardcoded paths match existing pattern; RunAtLoad:false is intentional safety).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new TradingCodex execution profile for running a restricted set of account, preview, live order, and fill-preview actions.
  * Added production and native launch support for this profile, including its own port, token, and health checks.

* **Bug Fixes**
  * Startup now enforces the required approval settings for the execution profile, preventing misconfigured launches.

* **Documentation**
  * Added setup and smoke-test guidance for running and validating the new profile.



<!-- end of auto-generated comment: release notes by coderabbit.ai -->