### PR TITLE
[codex] expose TradingCodex watch learning tools

### DIFF
--- a/app/mcp_server/README.md
+++ b/app/mcp_server/README.md
@@ -1680,7 +1680,7 @@ The `MCP_PROFILE` env var selects which tool subset is registered at startup.
 | Kiwoom mock | `kiwoom` | Default read-only/research surface plus typed `kiwoom_mock_*` variants only (no KIS/generic order tools) |
 | Analysis readonly | `analysis_readonly` | Codex/headless read/analysis allowlist only: `get_operating_briefing`, `route_request`, `get_trading_policy`, selected quote/fundamental/analysis tools, `suggest_order_account`, `get_holdings`, `toss_get_positions`, and explicitly labeled analysis persistence. No order/cancel/modify/reconcile/preview/settings/watch/admin/manual-holdings mutation tools are registered. |
 | Account read | `account_read` | TradingCodex account adapter allowlist only: `get_holdings`, `toss_get_positions`, `get_cash_balance`, `toss_get_orderable_cash`, `get_order_history`, `kis_live_get_order_history`, and `toss_get_order_history`. No order placement/cancel/modify/preview/reconcile, persistence, settings, watch, admin, report-writing, or manual-holdings mutation tools are registered. |
-| TradingCodex execution | `tradingcodex_execution` | Reviewed TradingCodex BrokerAdapter allowlist: account reads, `route_request`, `get_trading_policy`, `suggest_order_account`, `get_fx_rate`, preview/dry-run, live place, cancel, and ladder fill-preview tools. Requires dedicated auth token and required approval-hash modes. |
+| TradingCodex execution | `tradingcodex_execution` | Reviewed TradingCodex BrokerAdapter allowlist: account reads, `route_request`, `get_trading_policy`, `suggest_order_account`, `get_fx_rate`, watch read tools, `forecast_save`/`get_forecasts`, `save_trade_retrospective`/`get_trade_retrospectives`/`trade_retrospective_pending`, preview/dry-run, live place, cancel, and ladder fill-preview tools. Requires dedicated auth token and required approval-hash modes. |
 
 ### Profile: `hermes-paper-kis`
 
@@ -1786,6 +1786,61 @@ default_tools_approval_mode = "auto"
 
 http_headers = { "x-paperclip-agent-id" = "tradingcodex-account-read" }
 ```
+
+### Profile: `tradingcodex_execution` (ROB-768, ROB-778)
+
+Use `MCP_PROFILE=tradingcodex_execution` for the reviewed TradingCodex BrokerAdapter surface. This profile is order-capable, but still allowlist-only and narrower than `default`.
+
+Allowed read/advisory tools:
+- `get_holdings`
+- `toss_get_positions`
+- `get_cash_balance`
+- `toss_get_orderable_cash`
+- `get_order_history`
+- `kis_live_get_order_history`
+- `toss_get_order_history`
+- `suggest_order_account`
+- `get_fx_rate`
+- `route_request`
+- `get_trading_policy`
+- `list_active_watches`
+- `investment_watch_events_list_recent`
+- `get_forecasts`
+- `get_trade_retrospectives`
+- `trade_retrospective_pending`
+
+Allowed write/order tools:
+- `place_order`
+- `cancel_order`
+- `kis_live_place_order`
+- `kis_live_cancel_order`
+- `toss_preview_order`
+- `toss_place_order`
+- `toss_cancel_order`
+- `sell_ladder_fill_preview`
+- `buy_ladder_fill_preview`
+- `forecast_save`
+- `save_trade_retrospective`
+
+Write provenance requirements:
+- pass `created_by="tradingcodex"` to `forecast_save`
+- pass `created_by_profile="tradingcodex"` to `save_trade_retrospective`
+- missing or blank labels return `{"success": false, "error": "created_by_required", ...}` before any database write
+
+Forbidden by physical non-registration:
+- modify and reconcile tools
+- KIS mock order variants
+- Kiwoom order variants
+- Alpaca/DB paper order surfaces
+- manual holdings mutation
+- user settings tools
+- analysis artifact and session context persistence
+- forecast resolution/calibration
+- retrospective aggregate
+- watch activation/mutation
+- report-writing and report-decision tools
+
+Authentication is mandatory for this profile. `MCP_PROFILE=tradingcodex_execution` fails at startup unless `MCP_AUTH_TOKEN` is non-empty, and the runtime also requires the TradingCodex approval-hash modes configured in `app/mcp_server/main.py`.
 
 ### Typed KIS order tools
 

--- a/app/mcp_server/tooling/registry.py
+++ b/app/mcp_server/tooling/registry.py
@@ -55,10 +55,12 @@ Profile → tool surface mapping
 "tradingcodex_execution" (McpProfile.TRADINGCODEX_EXECUTION):
   TradingCodex broker execution allowlist only. Registers account reads,
   policy/route advisory reads, account-routing suggestion, USD/KRW FX read,
-  dry-run/preview, live place, cancel, and ladder fill-preview tools required
-  by the reviewed BrokerAdapter. No modify, reconcile, persistence, settings,
-  watch, admin, report-write, KIS mock, Kiwoom, Alpaca, or paper simulator
-  tools are registered.
+  watch read tools (active watches + delivered watch events), learning-loop
+  reads/writes (forecasts + trade retrospectives with explicit created_by
+  provenance), dry-run/preview, live place, cancel, and ladder fill-preview
+  tools required by the reviewed BrokerAdapter. No modify, reconcile, settings,
+  watch mutation/activation, report-write, KIS mock, Kiwoom, Alpaca, or paper
+  simulator tools are registered.
 
 See app/mcp_server/profiles.py and docs in app/mcp_server/README.md.
 """

--- a/app/mcp_server/tooling/tradingcodex_execution_registration.py
+++ b/app/mcp_server/tooling/tradingcodex_execution_registration.py
@@ -6,7 +6,7 @@ account_read. It is only for the TradingCodex BrokerAdapter live gate.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from app.mcp_server.tooling.account_read_registration import ACCOUNT_READ_TOOL_NAMES
 from app.mcp_server.tooling.account_routing_registration import (
@@ -16,8 +16,20 @@ from app.mcp_server.tooling.analysis_artifact_registration import (
     ANALYSIS_ARTIFACT_TOOL_NAMES,
 )
 from app.mcp_server.tooling.analysis_readonly_registration import _AllowlistedMCP
-from app.mcp_server.tooling.forecast_registration import FORECAST_TOOL_NAMES
+from app.mcp_server.tooling.forecast_registration import (
+    FORECAST_TOOL_NAMES,
+    register_forecast_tools,
+)
+from app.mcp_server.tooling.forecast_tools import forecast_save as _forecast_save
 from app.mcp_server.tooling.fundamentals_registration import register_fundamentals_tools
+from app.mcp_server.tooling.investment_reports_handlers import (
+    INVESTMENT_REPORT_TOOL_NAMES,
+    register_investment_report_tools,
+)
+from app.mcp_server.tooling.operating_briefing_registration import (
+    OPERATING_BRIEFING_TOOL_NAMES,
+    register_operating_briefing_tools,
+)
 from app.mcp_server.tooling.orders_kis_variants import (
     KIS_LIVE_ORDER_TOOL_NAMES,
     KIS_MOCK_ORDER_TOOL_NAMES,
@@ -43,6 +55,13 @@ from app.mcp_server.tooling.route_request_registration import (
 from app.mcp_server.tooling.session_context_registration import (
     SESSION_CONTEXT_TOOL_NAMES,
 )
+from app.mcp_server.tooling.trade_retrospective_registration import (
+    TRADE_RETROSPECTIVE_TOOL_NAMES,
+    register_trade_retrospective_tools,
+)
+from app.mcp_server.tooling.trade_retrospective_tools import (
+    save_trade_retrospective as _save_trade_retrospective,
+)
 from app.mcp_server.tooling.trading_policy_registration import (
     register_trading_policy_tools,
 )
@@ -52,7 +71,7 @@ if TYPE_CHECKING:
     from fastmcp import FastMCP
 
 
-TRADINGCODEX_EXECUTION_TOOL_NAMES: set[str] = ACCOUNT_READ_TOOL_NAMES | {
+_TRADINGCODEX_EXECUTION_ORDER_TOOL_NAMES: set[str] = {
     "place_order",
     "cancel_order",
     "kis_live_place_order",
@@ -62,10 +81,42 @@ TRADINGCODEX_EXECUTION_TOOL_NAMES: set[str] = ACCOUNT_READ_TOOL_NAMES | {
     "toss_cancel_order",
     "sell_ladder_fill_preview",
     "buy_ladder_fill_preview",
+}
+
+_TRADINGCODEX_EXECUTION_ADVISORY_TOOL_NAMES: set[str] = {
     "suggest_order_account",
     "get_fx_rate",
     "route_request",
     "get_trading_policy",
+}
+
+_TRADINGCODEX_EXECUTION_WATCH_READ_TOOL_NAMES: set[str] = {
+    "list_active_watches",
+    "investment_watch_events_list_recent",
+}
+
+_TRADINGCODEX_EXECUTION_LEARNING_READ_TOOL_NAMES: set[str] = {
+    "get_forecasts",
+    "get_trade_retrospectives",
+    "trade_retrospective_pending",
+}
+
+_TRADINGCODEX_EXECUTION_LEARNING_WRITE_TOOL_NAMES: set[str] = {
+    "forecast_save",
+    "save_trade_retrospective",
+}
+
+TRADINGCODEX_EXECUTION_TOOL_NAMES: set[str] = (
+    ACCOUNT_READ_TOOL_NAMES
+    | _TRADINGCODEX_EXECUTION_ORDER_TOOL_NAMES
+    | _TRADINGCODEX_EXECUTION_ADVISORY_TOOL_NAMES
+    | _TRADINGCODEX_EXECUTION_WATCH_READ_TOOL_NAMES
+    | _TRADINGCODEX_EXECUTION_LEARNING_READ_TOOL_NAMES
+    | _TRADINGCODEX_EXECUTION_LEARNING_WRITE_TOOL_NAMES
+)
+
+_INVESTMENT_REPORT_REGISTERED_TOOL_NAMES: set[str] = INVESTMENT_REPORT_TOOL_NAMES | {
+    "investment_watch_events_list_recent",
 }
 
 TRADINGCODEX_EXECUTION_FORBIDDEN_TOOL_NAMES: set[str] = (
@@ -77,16 +128,195 @@ TRADINGCODEX_EXECUTION_FORBIDDEN_TOOL_NAMES: set[str] = (
     | PAPER_LIMIT_ORDER_TOOL_NAMES
     | (TOSS_LIVE_ORDER_TOOL_NAMES - TRADINGCODEX_EXECUTION_TOOL_NAMES)
     | ANALYSIS_ARTIFACT_TOOL_NAMES
-    | FORECAST_TOOL_NAMES
+    | (FORECAST_TOOL_NAMES - TRADINGCODEX_EXECUTION_TOOL_NAMES)
+    | (TRADE_RETROSPECTIVE_TOOL_NAMES - TRADINGCODEX_EXECUTION_TOOL_NAMES)
     | SESSION_CONTEXT_TOOL_NAMES
     | USER_SETTINGS_TOOL_NAMES
+    | (OPERATING_BRIEFING_TOOL_NAMES - TRADINGCODEX_EXECUTION_TOOL_NAMES)
+    | (_INVESTMENT_REPORT_REGISTERED_TOOL_NAMES - TRADINGCODEX_EXECUTION_TOOL_NAMES)
     | {
         "get_available_capital",
         "get_position",
         "update_manual_holdings",
-        "list_active_watches",
     }
 )
+
+
+def _clean_label(value: str | None) -> str | None:
+    cleaned = (value or "").strip()
+    return cleaned or None
+
+
+def _created_by_required(tool_name: str, *, parameter: str) -> dict[str, Any]:
+    return {
+        "success": False,
+        "error": "created_by_required",
+        "tool": tool_name,
+        "detail": (
+            "tradingcodex_execution write calls must pass explicit "
+            f"{parameter} such as 'tradingcodex'."
+        ),
+    }
+
+
+def _register_learning_read_tools(mcp: FastMCP) -> None:
+    filtered = cast(
+        "FastMCP",
+        _AllowlistedMCP(mcp, _TRADINGCODEX_EXECUTION_LEARNING_READ_TOOL_NAMES),
+    )
+    register_forecast_tools(filtered)
+    register_trade_retrospective_tools(filtered)
+
+
+def _register_learning_write_tools(mcp: FastMCP) -> None:
+    @mcp.tool(
+        name="forecast_save",
+        description=(
+            "tradingcodex_execution: record a resolvable forecast. Requires "
+            "explicit created_by such as 'tradingcodex'; no implicit caller label."
+        ),
+    )
+    async def forecast_save(
+        created_by: str | None = None,
+        symbol: str = "",
+        instrument_type: str = "",
+        forecast_target: dict | None = None,
+        probability: float = 0.0,
+        review_date: str = "",
+        forecast_id: str | None = None,
+        horizon: str | None = None,
+        probability_range_low: float | None = None,
+        probability_range_high: float | None = None,
+        evidence_ids: list | None = None,
+        contrary_evidence: str | None = None,
+        forecast_start_date: str | None = None,
+        resolution_source: str | None = None,
+        session_label: str | None = None,
+        model_label: str | None = None,
+        policy_version: str | None = None,
+        artifact_uuid: str | None = None,
+        journal_id: int | None = None,
+        report_uuid: str | None = None,
+        report_item_uuid: str | None = None,
+        correlation_id: str | None = None,
+    ) -> dict[str, Any]:
+        label = _clean_label(created_by)
+        if label is None:
+            return _created_by_required("forecast_save", parameter="created_by")
+        return await _forecast_save(
+            created_by=label,
+            symbol=symbol,
+            instrument_type=instrument_type,
+            forecast_target=forecast_target or {},
+            probability=probability,
+            review_date=review_date,
+            forecast_id=forecast_id,
+            horizon=horizon,
+            probability_range_low=probability_range_low,
+            probability_range_high=probability_range_high,
+            evidence_ids=evidence_ids,
+            contrary_evidence=contrary_evidence,
+            forecast_start_date=forecast_start_date,
+            resolution_source=resolution_source,
+            session_label=session_label,
+            model_label=model_label,
+            policy_version=policy_version,
+            artifact_uuid=artifact_uuid,
+            journal_id=journal_id,
+            report_uuid=report_uuid,
+            report_item_uuid=report_item_uuid,
+            correlation_id=correlation_id,
+        )
+
+    @mcp.tool(
+        name="save_trade_retrospective",
+        description=(
+            "tradingcodex_execution: store a structured trade retrospective. "
+            "Requires explicit created_by_profile such as 'tradingcodex'."
+        ),
+    )
+    async def save_trade_retrospective(
+        symbol: str = "",
+        instrument_type: str = "",
+        account_mode: str = "",
+        outcome: str = "",
+        side: str | None = None,
+        market: str | None = None,
+        strategy_key: str | None = None,
+        correlation_id: str | None = None,
+        journal_id: int | None = None,
+        report_uuid: str | None = None,
+        report_item_uuid: str | None = None,
+        plan_price: float | None = None,
+        fill_price: float | None = None,
+        realized_pnl: float | None = None,
+        realized_pnl_currency: str | None = None,
+        pnl_pct: float | None = None,
+        rationale: str | None = None,
+        result_summary: str | None = None,
+        lesson: str | None = None,
+        next_strategy: str | None = None,
+        evidence_snapshot: dict | None = None,
+        created_by_profile: str | None = None,
+        buy_fx_rate: float | None = None,
+        sell_fx_rate: float | None = None,
+        fx_pnl_krw: float | None = None,
+        security_pnl_usd: float | None = None,
+        security_pnl_krw: float | None = None,
+        total_pnl_krw: float | None = None,
+        fx_rate_source: str | None = None,
+        fx_pnl_accuracy: str | None = None,
+        trigger_type: str | None = None,
+        root_cause_class: str | None = None,
+        intended_vs_happened: dict | None = None,
+        next_actions: list | None = None,
+        guardrail_fired: str | None = None,
+        policy_version: str | None = None,
+    ) -> dict[str, Any]:
+        label = _clean_label(created_by_profile)
+        if label is None:
+            return _created_by_required(
+                "save_trade_retrospective",
+                parameter="created_by_profile",
+            )
+        return await _save_trade_retrospective(
+            symbol=symbol,
+            instrument_type=instrument_type,
+            account_mode=account_mode,
+            outcome=outcome,
+            side=side,
+            market=market,
+            strategy_key=strategy_key,
+            correlation_id=correlation_id,
+            journal_id=journal_id,
+            report_uuid=report_uuid,
+            report_item_uuid=report_item_uuid,
+            plan_price=plan_price,
+            fill_price=fill_price,
+            realized_pnl=realized_pnl,
+            realized_pnl_currency=realized_pnl_currency,
+            pnl_pct=pnl_pct,
+            rationale=rationale,
+            result_summary=result_summary,
+            lesson=lesson,
+            next_strategy=next_strategy,
+            evidence_snapshot=evidence_snapshot,
+            created_by_profile=label,
+            buy_fx_rate=buy_fx_rate,
+            sell_fx_rate=sell_fx_rate,
+            fx_pnl_krw=fx_pnl_krw,
+            security_pnl_usd=security_pnl_usd,
+            security_pnl_krw=security_pnl_krw,
+            total_pnl_krw=total_pnl_krw,
+            fx_rate_source=fx_rate_source,
+            fx_pnl_accuracy=fx_pnl_accuracy,
+            trigger_type=trigger_type,
+            root_cause_class=root_cause_class,
+            intended_vs_happened=intended_vs_happened,
+            next_actions=next_actions,
+            guardrail_fired=guardrail_fired,
+            policy_version=policy_version,
+        )
 
 
 def register_tradingcodex_execution_tools(mcp: FastMCP) -> None:
@@ -100,6 +330,10 @@ def register_tradingcodex_execution_tools(mcp: FastMCP) -> None:
     register_fundamentals_tools(filtered)
     register_trading_policy_tools(filtered)
     register_route_request_tools(filtered)
+    register_operating_briefing_tools(filtered)
+    register_investment_report_tools(filtered, include_snapshot_generator=False)
+    _register_learning_read_tools(mcp)
+    _register_learning_write_tools(mcp)
 
 
 __all__ = [

--- a/tests/test_mcp_profiles.py
+++ b/tests/test_mcp_profiles.py
@@ -541,9 +541,18 @@ class TestTradingCodexExecutionProfile:
             "get_fx_rate",
             "route_request",
             "get_trading_policy",
+            "list_active_watches",
+            "investment_watch_events_list_recent",
+            "forecast_save",
+            "get_forecasts",
+            "save_trade_retrospective",
+            "get_trade_retrospectives",
+            "trade_retrospective_pending",
         } <= mcp.tools.keys()
 
-    def test_does_not_register_modify_reconcile_or_persistence_tools(self) -> None:
+    def test_does_not_register_modify_reconcile_or_unsafe_persistence_tools(
+        self,
+    ) -> None:
         mcp = _build_mcp(McpProfile.TRADINGCODEX_EXECUTION)
         forbidden = {
             "modify_order",
@@ -554,17 +563,72 @@ class TestTradingCodexExecutionProfile:
             "toss_reconcile_orders",
             "analysis_artifact_save",
             "analysis_artifact_get",
-            "forecast_save",
+            "analysis_artifact_list",
+            "forecast_resolve",
+            "get_forecast_calibration",
+            "get_retrospective_aggregate",
             "session_context_append",
             "session_context_get_recent",
             "update_manual_holdings",
             "get_user_setting",
-            "list_active_watches",
+            "set_user_setting",
+            "investment_report_create",
+            "investment_report_add_items",
+            "investment_report_update",
+            "investment_report_decide_item",
+            "investment_report_activate_watch",
+            "investment_report_set_status",
+            "investment_watch_recommend",
         }
         leaked = forbidden & mcp.tools.keys()
         assert not leaked, (
             f"tradingcodex_execution leaked unsafe tools: {sorted(leaked)}"
         )
+
+    @pytest.mark.asyncio
+    async def test_forecast_save_requires_explicit_created_by(self) -> None:
+        mcp = _build_mcp(McpProfile.TRADINGCODEX_EXECUTION)
+        tool = mcp.tools["forecast_save"]
+
+        result = await tool(
+            created_by=" ",
+            symbol="005930",
+            instrument_type="equity_kr",
+            forecast_target={
+                "kind": "price_target",
+                "direction": "at_or_above",
+                "target_price": 75000.0,
+            },
+            probability=0.55,
+            review_date="2026-07-15",
+        )
+
+        assert result == {
+            "success": False,
+            "error": "created_by_required",
+            "tool": "forecast_save",
+            "detail": "tradingcodex_execution write calls must pass explicit created_by such as 'tradingcodex'.",
+        }
+
+    @pytest.mark.asyncio
+    async def test_save_trade_retrospective_requires_created_by_profile(self) -> None:
+        mcp = _build_mcp(McpProfile.TRADINGCODEX_EXECUTION)
+        tool = mcp.tools["save_trade_retrospective"]
+
+        result = await tool(
+            symbol="005930",
+            instrument_type="equity_kr",
+            account_mode="kis_live",
+            outcome="filled",
+            created_by_profile=" ",
+        )
+
+        assert result == {
+            "success": False,
+            "error": "created_by_required",
+            "tool": "save_trade_retrospective",
+            "detail": "tradingcodex_execution write calls must pass explicit created_by_profile such as 'tradingcodex'.",
+        }
 
 
 class TestResolveMcpProfile:


### PR DESCRIPTION
## Summary
- expand `tradingcodex_execution` with watch read tools for active watches and delivered watch events
- expose forecast and trade-retrospective learning-loop tools with explicit provenance guards
- pin the profile allowlist/forbidden matrix and document the updated profile surface

## Context
- Linear: ROB-768, ROB-778
- Keeps `tradingcodex_execution` as an allowlist-only profile while adding the TradingCodex-safe watch and learning-loop tools needed for approved execution flows.

## Validation
- `uv run pytest tests/test_mcp_profiles.py -q`
- `uv run pytest tests/test_forecast_tools.py tests/test_trade_retrospective_tools.py tests/mcp_server/test_watch_events_list_recent_tool.py tests/mcp_server/test_operating_briefing_tools.py -q`
- `uv run pytest tests/test_mcp_server_main.py tests/scripts/test_native_run_wrappers.py tests/scripts/test_native_plists.py -q`
- `uv run ruff check app/mcp_server/tooling/tradingcodex_execution_registration.py tests/test_mcp_profiles.py`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded the TradingCodex execution profile to include more read-only, advisory, and limited learning tools.
  * Added support for saving forecast and trade-retrospective entries with required caller attribution.

* **Bug Fixes**
  * Tightened profile restrictions so unsafe mutation, persistence, and report-management actions remain unavailable.
  * Calls to save learning entries now fail cleanly when required attribution fields are missing or blank.

* **Documentation**
  * Updated MCP profile documentation to better describe the available and restricted tool surface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->