### PR TITLE
[codex] ROB-768 direct TradingCodex watch creation

### DIFF
--- a/.claude/settings.readonly.json
+++ b/.claude/settings.readonly.json
@@ -31,6 +31,7 @@
       "mcp__auto_trader_local__investment_report_update",
       "mcp__auto_trader_local__investment_report_decide_item",
       "mcp__auto_trader_local__investment_report_activate_watch",
+      "mcp__auto_trader_local__investment_watch_create",
       "mcp__auto_trader_local__investment_report_set_status",
       "mcp__auto_trader_local__investment_report_generate_from_bundle",
       "mcp__auto_trader_local__investment_report_create_from_hermes_composition",

--- a/app/mcp_server/README.md
+++ b/app/mcp_server/README.md
@@ -889,6 +889,34 @@ Parameters:
 
 Response includes `active_watches[]` with `symbol`, `operator`, `threshold`, `valid_until`, `rationale`, `source_report_uuid`, and `source_item_uuid`.
 
+### `investment_watch_create`
+
+Creates an active row in `review.investment_watch_alerts` without creating an
+investment report or report item.
+
+Parameters:
+- `created_by`: required provenance label. Use `tradingcodex` from the
+  `tradingcodex_execution` profile.
+- `market`: `kr`, `us`, or `crypto`.
+- `symbol`: exact symbol. US and crypto symbols are normalized uppercase.
+- `intent`: one of the investment report item intents, for scanner/event context.
+- `rationale`: operator-readable reason for the watch.
+- `watch_condition`: same normalized watch condition payload used by report items.
+  Flat `{metric, operator, threshold}` and v2 `conditions[]` are accepted.
+- `valid_until`: future timezone-aware ISO8601 timestamp.
+- `trigger_checklist`: optional list of operator checks.
+- `max_action`: optional planned-action envelope for downstream approval context.
+- `metadata`: optional audit metadata merged into alert `metadata`.
+- `idempotency_key`: optional caller key. Omit to use the deterministic direct-watch key.
+
+Response:
+- `success`
+- `idempotent`
+- `alert`, the created or existing `InvestmentWatchAlertResponse`.
+
+This tool never creates reports/items and never submits, previews, modifies,
+cancels, or reconciles broker orders.
+
 ### `get_operating_briefing`
 
 Read-only one-call bootstrap for a new operating session.
@@ -1680,7 +1708,7 @@ The `MCP_PROFILE` env var selects which tool subset is registered at startup.
 | Kiwoom mock | `kiwoom` | Default read-only/research surface plus typed `kiwoom_mock_*` variants only (no KIS/generic order tools) |
 | Analysis readonly | `analysis_readonly` | Codex/headless read/analysis allowlist only: `get_operating_briefing`, `route_request`, `get_trading_policy`, selected quote/fundamental/analysis tools, `suggest_order_account`, `get_holdings`, `toss_get_positions`, and explicitly labeled analysis persistence. No order/cancel/modify/reconcile/preview/settings/watch/admin/manual-holdings mutation tools are registered. |
 | Account read | `account_read` | TradingCodex account adapter allowlist only: `get_holdings`, `toss_get_positions`, `get_cash_balance`, `toss_get_orderable_cash`, `get_order_history`, `kis_live_get_order_history`, and `toss_get_order_history`. No order placement/cancel/modify/preview/reconcile, persistence, settings, watch, admin, report-writing, or manual-holdings mutation tools are registered. |
-| TradingCodex execution | `tradingcodex_execution` | Reviewed TradingCodex BrokerAdapter allowlist: account reads, `route_request`, `get_trading_policy`, `suggest_order_account`, `get_fx_rate`, watch read tools, `forecast_save`/`get_forecasts`, `save_trade_retrospective`/`get_trade_retrospectives`/`trade_retrospective_pending`, preview/dry-run, live place, cancel, and ladder fill-preview tools. Requires dedicated auth token and required approval-hash modes. |
+| TradingCodex execution | `tradingcodex_execution` | Reviewed TradingCodex BrokerAdapter allowlist: account reads, `route_request`, `get_trading_policy`, `suggest_order_account`, `get_fx_rate`, watch read tools, `investment_watch_create` (guarded `created_by`), `forecast_save`/`get_forecasts`, `save_trade_retrospective`/`get_trade_retrospectives`/`trade_retrospective_pending`, preview/dry-run, live place, cancel, and ladder fill-preview tools. Requires dedicated auth token and required approval-hash modes. |
 
 ### Profile: `hermes-paper-kis`
 
@@ -1821,10 +1849,12 @@ Allowed write/order tools:
 - `buy_ladder_fill_preview`
 - `forecast_save`
 - `save_trade_retrospective`
+- `investment_watch_create`
 
 Write provenance requirements:
 - pass `created_by="tradingcodex"` to `forecast_save`
 - pass `created_by_profile="tradingcodex"` to `save_trade_retrospective`
+- pass `created_by="tradingcodex"` to `investment_watch_create`
 - missing or blank labels return `{"success": false, "error": "created_by_required", ...}` before any database write
 
 Forbidden by physical non-registration:

--- a/app/mcp_server/tooling/investment_reports_handlers.py
+++ b/app/mcp_server/tooling/investment_reports_handlers.py
@@ -20,6 +20,7 @@ from app.core.db import AsyncSessionLocal
 from app.schemas.investment_reports import (
     ActivateWatchRequest,
     AddReportItemsRequest,
+    CreateInvestmentWatchRequest,
     IngestReportItem,
     IngestReportRequest,
     InvestmentReportActivateWatchResponse,
@@ -30,6 +31,7 @@ from app.schemas.investment_reports import (
     InvestmentReportItemResponse,
     InvestmentReportResponse,
     InvestmentWatchAlertResponse,
+    InvestmentWatchCreateResponse,
     InvestmentWatchEventResponse,
     PreviousReportContextResponse,
     RecordDecisionRequest,
@@ -54,6 +56,7 @@ from app.services.investment_reports.query_service import (
 )
 from app.services.investment_reports.repository import InvestmentReportsRepository
 from app.services.investment_reports.watch_activation import WatchActivationService
+from app.services.investment_reports.watch_create import DirectWatchCreateService
 from app.services.investment_reports.watch_recommendation_policy import (
     ATR_PERIOD,
     LOOKBACK_DAYS,
@@ -77,6 +80,8 @@ INVESTMENT_REPORT_TOOL_NAMES: set[str] = {
     "investment_report_set_status",
     "investment_report_add_items",
     "investment_report_update",
+    # ROB-768 — direct watch create (independent of report flow).
+    "investment_watch_create",
 }
 
 # ROB-352 — mirror of the generator's canonical market/account_scope pairs.
@@ -982,6 +987,54 @@ async def investment_watch_recommend_impl(
 
 
 # ---------------------------------------------------------------------------
+# investment_watch_create (ROB-768)
+# ---------------------------------------------------------------------------
+async def investment_watch_create_impl(
+    created_by: str,
+    market: str,
+    symbol: str,
+    intent: str,
+    rationale: str,
+    watch_condition: dict,
+    valid_until: str,
+    trigger_checklist: list[str] | None = None,
+    max_action: dict | None = None,
+    metadata: dict | None = None,
+    idempotency_key: str | None = None,
+) -> dict[str, Any]:
+    """ROB-768 — create an active watch alert directly, bypassing the
+    investment_report_create / investment_report_activate_watch flow.
+
+    Requires explicit ``created_by`` provenance; ``valid_until`` must be a
+    future timezone-aware ISO8601 string. The persisted alert is a
+    notify/approval watch only — never an automatic order instruction.
+    """
+    request = CreateInvestmentWatchRequest.model_validate(
+        {
+            "created_by": created_by,
+            "market": market,
+            "symbol": symbol,
+            "intent": intent,
+            "rationale": rationale,
+            "watch_condition": watch_condition,
+            "valid_until": valid_until,
+            "trigger_checklist": trigger_checklist or [],
+            "max_action": max_action or {},
+            "metadata": metadata or {},
+            "idempotency_key": idempotency_key,
+        }
+    )
+    async with AsyncSessionLocal() as db:
+        alert, idempotent = await DirectWatchCreateService(db).create(request)
+        await db.commit()
+        response = InvestmentWatchCreateResponse(
+            idempotent=idempotent,
+            alert=InvestmentWatchAlertResponse.model_validate(alert),
+        )
+    return response.model_dump(mode="json", by_alias=True)
+
+
+# ---------------------------------------------------------------------------
 # investment_report_context_get
 # ---------------------------------------------------------------------------
 async def investment_report_context_get_impl(
@@ -1457,6 +1510,16 @@ def register_investment_report_tools(
             "Read-only. 브로커/주문/감시 mutation 없음."
         ),
     )(investment_watch_events_list_recent_impl)
+    mcp.tool(
+        name="investment_watch_create",
+        description=(
+            "Create an active investment watch alert directly, without "
+            "investment_report_create or investment_report_activate_watch. "
+            "Requires explicit created_by provenance; valid_until must be "
+            "future timezone-aware ISO8601. This registers a notify/approval "
+            "watch only and never submits orders."
+        ),
+    )(investment_watch_create_impl)
 
 
 __all__ = [
@@ -1472,7 +1535,9 @@ __all__ = [
     "investment_report_list_impl",
     "investment_report_set_status_impl",
     "investment_report_update_impl",
+    "investment_watch_create_impl",
     "investment_watch_events_list_recent_impl",
     "investment_watch_recommend_impl",
     "register_investment_report_tools",
 ]
+

--- a/app/mcp_server/tooling/investment_reports_handlers.py
+++ b/app/mcp_server/tooling/investment_reports_handlers.py
@@ -1540,4 +1540,3 @@ __all__ = [
     "investment_watch_recommend_impl",
     "register_investment_report_tools",
 ]
-

--- a/app/mcp_server/tooling/route_request_lanes.py
+++ b/app/mcp_server/tooling/route_request_lanes.py
@@ -338,6 +338,7 @@ READ_ONLY_ADVISORY_TOOLS: frozenset[str] = frozenset(
         "investment_report_list",
         "investment_report_set_status",
         "investment_report_update",
+        "investment_watch_create",
         "investment_watch_recommend",
         "list_active_journals",
         "list_active_watches",

--- a/app/mcp_server/tooling/tradingcodex_execution_registration.py
+++ b/app/mcp_server/tooling/tradingcodex_execution_registration.py
@@ -26,6 +26,9 @@ from app.mcp_server.tooling.investment_reports_handlers import (
     INVESTMENT_REPORT_TOOL_NAMES,
     register_investment_report_tools,
 )
+from app.mcp_server.tooling.investment_reports_handlers import (
+    investment_watch_create_impl as _investment_watch_create,
+)
 from app.mcp_server.tooling.operating_briefing_registration import (
     OPERATING_BRIEFING_TOOL_NAMES,
     register_operating_briefing_tools,
@@ -95,6 +98,10 @@ _TRADINGCODEX_EXECUTION_WATCH_READ_TOOL_NAMES: set[str] = {
     "investment_watch_events_list_recent",
 }
 
+_TRADINGCODEX_EXECUTION_WATCH_WRITE_TOOL_NAMES: set[str] = {
+    "investment_watch_create",
+}
+
 _TRADINGCODEX_EXECUTION_LEARNING_READ_TOOL_NAMES: set[str] = {
     "get_forecasts",
     "get_trade_retrospectives",
@@ -111,6 +118,7 @@ TRADINGCODEX_EXECUTION_TOOL_NAMES: set[str] = (
     | _TRADINGCODEX_EXECUTION_ORDER_TOOL_NAMES
     | _TRADINGCODEX_EXECUTION_ADVISORY_TOOL_NAMES
     | _TRADINGCODEX_EXECUTION_WATCH_READ_TOOL_NAMES
+    | _TRADINGCODEX_EXECUTION_WATCH_WRITE_TOOL_NAMES
     | _TRADINGCODEX_EXECUTION_LEARNING_READ_TOOL_NAMES
     | _TRADINGCODEX_EXECUTION_LEARNING_WRITE_TOOL_NAMES
 )
@@ -118,6 +126,15 @@ TRADINGCODEX_EXECUTION_TOOL_NAMES: set[str] = (
 _INVESTMENT_REPORT_REGISTERED_TOOL_NAMES: set[str] = INVESTMENT_REPORT_TOOL_NAMES | {
     "investment_watch_events_list_recent",
 }
+
+# Narrow allowlist passed to register_investment_report_tools so the raw
+# investment_watch_create (no created_by guard) is NEVER registered through
+# the filtered pathway. Only watch read tools survive the filter — the
+# guarded investment_watch_create wrapper is registered directly on the
+# unfiltered mcp via _register_watch_write_tools below.
+_TRADINGCODEX_EXECUTION_INVESTMENT_REPORT_FILTER_TOOL_NAMES: set[str] = (
+    _TRADINGCODEX_EXECUTION_WATCH_READ_TOOL_NAMES
+)
 
 TRADINGCODEX_EXECUTION_FORBIDDEN_TOOL_NAMES: set[str] = (
     (ORDER_TOOL_NAMES - TRADINGCODEX_EXECUTION_TOOL_NAMES)
@@ -319,6 +336,57 @@ def _register_learning_write_tools(mcp: FastMCP) -> None:
         )
 
 
+def _register_watch_write_tools(mcp: FastMCP) -> None:
+    """Direct watch-create wrapper: ``created_by`` guard BEFORE DB write.
+
+    The underlying ``investment_watch_create_impl`` is a base MCP surface tool
+    (no guard). Registering it through the filtered pathway would leak the raw
+    impl onto ``tradingcodex_execution`` and defeat the write provenance gate.
+    This wrapper rejects missing/blank ``created_by`` and only then forwards to
+    the base impl.
+    """
+
+    @mcp.tool(
+        name="investment_watch_create",
+        description=(
+            "tradingcodex_execution: create an active support/resistance watch "
+            "without report-flow coupling. Requires explicit created_by such "
+            "as 'tradingcodex'."
+        ),
+    )
+    async def investment_watch_create(
+        created_by: str | None = None,
+        market: str = "",
+        symbol: str = "",
+        intent: str = "",
+        rationale: str = "",
+        watch_condition: dict | None = None,
+        valid_until: str = "",
+        trigger_checklist: list[str] | None = None,
+        max_action: dict | None = None,
+        metadata: dict | None = None,
+        idempotency_key: str | None = None,
+    ) -> dict[str, Any]:
+        label = _clean_label(created_by)
+        if label is None:
+            return _created_by_required(
+                "investment_watch_create", parameter="created_by"
+            )
+        return await _investment_watch_create(
+            created_by=label,
+            market=market,
+            symbol=symbol,
+            intent=intent,
+            rationale=rationale,
+            watch_condition=watch_condition or {},
+            valid_until=valid_until,
+            trigger_checklist=trigger_checklist,
+            max_action=max_action,
+            metadata=metadata,
+            idempotency_key=idempotency_key,
+        )
+
+
 def register_tradingcodex_execution_tools(mcp: FastMCP) -> None:
     """Register only the TradingCodex broker execution allowlist."""
     filtered = cast("FastMCP", _AllowlistedMCP(mcp, TRADINGCODEX_EXECUTION_TOOL_NAMES))
@@ -331,9 +399,21 @@ def register_tradingcodex_execution_tools(mcp: FastMCP) -> None:
     register_trading_policy_tools(filtered)
     register_route_request_tools(filtered)
     register_operating_briefing_tools(filtered)
-    register_investment_report_tools(filtered, include_snapshot_generator=False)
+    # Narrow allowlist so the raw (unguarded) investment_watch_create impl is
+    # NOT registered through the filtered pathway. The guarded wrapper is
+    # registered directly on ``mcp`` via _register_watch_write_tools below.
+    investment_report_filtered = cast(
+        "FastMCP",
+        _AllowlistedMCP(
+            mcp, _TRADINGCODEX_EXECUTION_INVESTMENT_REPORT_FILTER_TOOL_NAMES
+        ),
+    )
+    register_investment_report_tools(
+        investment_report_filtered, include_snapshot_generator=False
+    )
     _register_learning_read_tools(mcp)
     _register_learning_write_tools(mcp)
+    _register_watch_write_tools(mcp)
 
 
 __all__ = [

--- a/app/schemas/investment_reports.py
+++ b/app/schemas/investment_reports.py
@@ -65,7 +65,8 @@ ItemStatusLiteral = Literal[
 ]
 
 WatchMetricLiteral = Literal["price", "rsi", "trade_value"]
-WatchOperatorLiteral = Literal["above", "below"]
+WatchOperatorLiteral = Literal["above", "below", "between"]
+WatchFlatOperatorLiteral = Literal["above", "below"]
 WatchClauseOpLiteral = Literal["above", "below", "between"]
 WatchCombineLiteral = Literal["and"]
 WatchActionModeLiteral = Literal[
@@ -140,7 +141,7 @@ class WatchConditionPayload(BaseModel):
 
     # legacy flat (optional)
     metric: WatchMetricLiteral | None = None
-    operator: WatchOperatorLiteral | None = None
+    operator: WatchFlatOperatorLiteral | None = None
     threshold: Decimal | None = None
     threshold_key: str | None = None
     target_kind: TargetKindLiteral = "asset"
@@ -707,6 +708,47 @@ class ActivateWatchRequest(BaseModel):
     watch_condition: WatchConditionPayload | None = None
     valid_until: datetime | None = None
     attach_recommendation: bool = False
+
+
+class CreateInvestmentWatchRequest(BaseModel):
+    """Create an active watch alert without an investment_report/item source."""
+
+    market: MarketLiteral
+    symbol: str = Field(min_length=1)
+    intent: ItemIntentLiteral
+    watch_condition: WatchConditionPayload
+    rationale: str = Field(min_length=1)
+    valid_until: datetime
+    created_by: str = Field(min_length=1)
+    trigger_checklist: list[str] = Field(default_factory=list)
+    max_action: dict[str, Any] = Field(default_factory=dict)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+    idempotency_key: str | None = None
+
+    model_config = ConfigDict(extra="forbid")
+
+    @field_validator("created_by", "symbol", "rationale")
+    @classmethod
+    def _strip_non_empty(cls, value: str) -> str:
+        cleaned = value.strip()
+        if not cleaned:
+            raise ValueError("value must not be blank")
+        return cleaned
+
+    @field_validator("valid_until")
+    @classmethod
+    def _valid_until_must_be_aware(cls, value: datetime) -> datetime:
+        if value.tzinfo is None or value.utcoffset() is None:
+            raise ValueError("valid_until must be timezone-aware")
+        return value
+
+
+class InvestmentWatchCreateResponse(BaseModel):
+    """``investment_watch_create`` MCP return shape."""
+
+    success: bool = True
+    idempotent: bool
+    alert: InvestmentWatchAlertResponse
 
 
 # ---------------------------------------------------------------------------

--- a/app/services/investment_reports/idempotency.py
+++ b/app/services/investment_reports/idempotency.py
@@ -26,6 +26,7 @@ __all__ = [
     "watch_activation_key",
     "watch_event_key",
     "canonical_watch_condition_hash",
+    "direct_watch_key",
 ]
 
 _NONE_SLOT = "_"
@@ -138,3 +139,26 @@ def canonical_watch_condition_hash(payload: dict) -> str:
     """
     canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"))
     return hashlib.sha256(canonical.encode("utf-8")).hexdigest()[:16]
+
+
+def direct_watch_key(
+    *,
+    created_by: str,
+    market: str,
+    symbol: str,
+    intent: str,
+    valid_until: str,
+    watch_condition: dict,
+) -> str:
+    """Stable key for direct, report-flow-independent watch creation."""
+    return ":".join(
+        [
+            "direct-watch",
+            _slot(created_by),
+            _slot(market),
+            _slot(symbol),
+            _slot(intent),
+            _slot(valid_until),
+            canonical_watch_condition_hash(watch_condition),
+        ]
+    )

--- a/app/services/investment_reports/watch_create.py
+++ b/app/services/investment_reports/watch_create.py
@@ -48,12 +48,12 @@ class DirectWatchCreateService:
             watch_condition=condition,
         )
 
+        fields = _alert_fields(request, normalized_symbol, condition, key)
         existing = await self._repo.get_alert_by_idempotency_key(key)
         if existing is not None:
-            _assert_same_identity(existing, request, normalized_symbol)
+            _assert_same_identity(existing, fields)
             return existing, True
 
-        fields = _alert_fields(request, normalized_symbol, condition, key)
         alert = await self._repo.insert_alert(**fields)
         await self._session.flush()
         return alert, False
@@ -117,14 +117,38 @@ def _alert_fields(
 
 def _assert_same_identity(
     existing: InvestmentWatchAlert,
-    request: CreateInvestmentWatchRequest,
-    symbol: str,
+    expected_fields: dict[str, Any],
 ) -> None:
-    if (
-        existing.market != request.market
-        or existing.symbol != symbol
-        or existing.intent != request.intent
+    mismatched = [
+        field
+        for field in (
+            "market",
+            "target_kind",
+            "symbol",
+            "metric",
+            "operator",
+            "threshold_key",
+            "conditions",
+            "combine",
+            "intent",
+            "action_mode",
+            "rationale",
+            "trigger_checklist",
+            "max_action",
+            "valid_until",
+        )
+        if getattr(existing, field) != expected_fields[field]
+    ]
+    if _decimal_or_none(existing.threshold) != _decimal_or_none(
+        expected_fields["threshold"]
     ):
+        mismatched.append("threshold")
+    if _decimal_or_none(existing.threshold_high) != _decimal_or_none(
+        expected_fields["threshold_high"]
+    ):
+        mismatched.append("threshold_high")
+
+    if mismatched:
         raise ValueError(
             f"idempotency_key {existing.idempotency_key!r} already used for "
             "a different watch identity"
@@ -140,4 +164,12 @@ def _to_decimal(value: Any) -> Decimal:
         return value
     if value is None:
         raise ValueError("threshold is required in watch_condition")
+    return Decimal(str(value))
+
+
+def _decimal_or_none(value: Any) -> Decimal | None:
+    if value is None:
+        return None
+    if isinstance(value, Decimal):
+        return value
     return Decimal(str(value))

--- a/app/services/investment_reports/watch_create.py
+++ b/app/services/investment_reports/watch_create.py
@@ -1,0 +1,143 @@
+"""Direct watch-alert creation independent of investment report activation."""
+
+from __future__ import annotations
+
+import uuid
+from decimal import Decimal
+from typing import Any
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.timezone import now_kst
+from app.models.investment_reports import InvestmentWatchAlert
+from app.schemas.investment_reports import CreateInvestmentWatchRequest
+from app.services.investment_reports.idempotency import direct_watch_key
+from app.services.investment_reports.repository import InvestmentReportsRepository
+
+_DIRECT_WATCH_NAMESPACE = uuid.UUID("7d85169b-7e5d-4d53-87eb-1bb7ba8ecf60")
+
+
+class DirectWatchCreateService:
+    """Create active watch alerts without report/item source rows."""
+
+    def __init__(
+        self,
+        session: AsyncSession,
+        repository: InvestmentReportsRepository | None = None,
+    ) -> None:
+        self._session = session
+        self._repo = repository or InvestmentReportsRepository(session)
+
+    async def create(
+        self, request: CreateInvestmentWatchRequest
+    ) -> tuple[InvestmentWatchAlert, bool]:
+        if request.valid_until <= now_kst():
+            raise ValueError("valid_until must be in the future")
+
+        condition = request.watch_condition.model_dump(mode="json")
+        if condition.get("action_mode") == "auto_execute_mock":
+            raise ValueError("investment_watch_create does not allow auto_execute_mock")
+
+        normalized_symbol = _normalize_symbol(request.symbol, request.market)
+        key = request.idempotency_key or direct_watch_key(
+            created_by=request.created_by,
+            market=request.market,
+            symbol=normalized_symbol,
+            intent=request.intent,
+            valid_until=request.valid_until.isoformat(),
+            watch_condition=condition,
+        )
+
+        existing = await self._repo.get_alert_by_idempotency_key(key)
+        if existing is not None:
+            _assert_same_identity(existing, request, normalized_symbol)
+            return existing, True
+
+        fields = _alert_fields(request, normalized_symbol, condition, key)
+        alert = await self._repo.insert_alert(**fields)
+        await self._session.flush()
+        return alert, False
+
+
+def _normalize_symbol(symbol: str, market: str) -> str:
+    stripped = symbol.strip()
+    if market in {"us", "crypto"}:
+        return stripped.upper()
+    return stripped
+
+
+def _alert_fields(
+    request: CreateInvestmentWatchRequest,
+    symbol: str,
+    condition: dict[str, Any],
+    idempotency_key: str,
+) -> dict[str, Any]:
+    clauses = list(condition.get("conditions") or [])
+    primary = clauses[0]
+    operator = primary["op"]
+    if operator == "between":
+        threshold = _to_decimal(primary.get("low"))
+        threshold_high = _to_decimal(primary.get("high"))
+    else:
+        threshold = _to_decimal(primary.get("threshold"))
+        threshold_high = None
+
+    metadata = dict(request.metadata)
+    metadata.update(
+        {
+            "created_by": request.created_by,
+            "source_tool": "investment_watch_create",
+        }
+    )
+
+    return {
+        "idempotency_key": idempotency_key,
+        "source_report_uuid": _source_uuid(idempotency_key, "report"),
+        "source_item_uuid": _source_uuid(idempotency_key, "item"),
+        "market": request.market,
+        "target_kind": condition.get("target_kind", "asset"),
+        "symbol": symbol,
+        "metric": primary["metric"],
+        "operator": operator,
+        "threshold": threshold,
+        "threshold_high": threshold_high,
+        "threshold_key": condition["threshold_key"],
+        "conditions": clauses,
+        "combine": condition.get("combine", "and"),
+        "intent": request.intent,
+        "action_mode": condition.get("action_mode", "notify_only"),
+        "rationale": request.rationale,
+        "trigger_checklist": list(request.trigger_checklist),
+        "max_action": dict(request.max_action),
+        "valid_until": request.valid_until,
+        "status": "active",
+        "alert_metadata": metadata,
+    }
+
+
+def _assert_same_identity(
+    existing: InvestmentWatchAlert,
+    request: CreateInvestmentWatchRequest,
+    symbol: str,
+) -> None:
+    if (
+        existing.market != request.market
+        or existing.symbol != symbol
+        or existing.intent != request.intent
+    ):
+        raise ValueError(
+            f"idempotency_key {existing.idempotency_key!r} already used for "
+            "a different watch identity"
+        )
+
+
+def _source_uuid(idempotency_key: str, slot: str) -> uuid.UUID:
+    return uuid.uuid5(_DIRECT_WATCH_NAMESPACE, f"{slot}:{idempotency_key}")
+
+
+def _to_decimal(value: Any) -> Decimal:
+    if isinstance(value, Decimal):
+        return value
+    if value is None:
+        raise ValueError("threshold is required in watch_condition")
+    return Decimal(str(value))

--- a/docs/runbooks/tradingcodex-execution-mcp.md
+++ b/docs/runbooks/tradingcodex-execution-mcp.md
@@ -56,3 +56,28 @@ Expected: preview response includes `approval_hash`, `approval_expires_at`,
 
 Live smoke must be done only with a real approved order ticket and exact
 `live_confirmation` through `submit_approved_order`.
+
+## Watch Create Smoke
+
+Use this only against a test/staging database or with a deliberately harmless
+far-future paper watch.
+
+```bash
+./tcx mcp call auto-trader investment_watch_create '{
+  "created_by": "tradingcodex",
+  "market": "kr",
+  "symbol": "005930",
+  "intent": "trend_recovery_review",
+  "rationale": "smoke watch for TradingCodex direct watch surface",
+  "watch_condition": {"metric": "price", "operator": "above", "threshold": 1},
+  "valid_until": "2026-12-31T23:59:59+09:00",
+  "trigger_checklist": ["ignore smoke watch"],
+  "metadata": {"smoke": true}
+}'
+```
+
+Expected: `success=true`, `idempotent=false` on first call, and an `alert`
+payload whose `metadata.created_by` is `tradingcodex`.
+
+Forbidden provenance smoke: call the same tool with `created_by` omitted or
+blank. Expected: `success=false`, `error=created_by_required`, and no DB write.

--- a/tests/services/investment_reports/test_watch_create.py
+++ b/tests/services/investment_reports/test_watch_create.py
@@ -74,8 +74,9 @@ async def test_direct_watch_create_is_idempotent_for_same_key(
     session: AsyncSession,
 ) -> None:
     service = DirectWatchCreateService(session)
-    first, first_idempotent = await service.create(_request(idempotency_key="tcx:1"))
-    second, second_idempotent = await service.create(_request(idempotency_key="tcx:1"))
+    request = _request(idempotency_key="tcx:1")
+    first, first_idempotent = await service.create(request)
+    second, second_idempotent = await service.create(request)
 
     assert first_idempotent is False
     assert second_idempotent is True
@@ -93,6 +94,27 @@ async def test_direct_watch_create_rejects_idempotency_collision(
     with pytest.raises(ValueError, match="idempotency_key .* already used"):
         await service.create(
             _request(idempotency_key="tcx:collision", symbol="000660")
+        )
+
+
+@pytest.mark.asyncio
+async def test_direct_watch_create_rejects_idempotency_collision_for_different_condition(
+    session: AsyncSession,
+) -> None:
+    service = DirectWatchCreateService(session)
+    await service.create(_request(idempotency_key="tcx:condition-collision"))
+
+    with pytest.raises(ValueError, match="idempotency_key .* already used"):
+        await service.create(
+            _request(
+                idempotency_key="tcx:condition-collision",
+                watch_condition=WatchConditionPayload(
+                    metric="price",
+                    operator="above",
+                    threshold=71000,
+                    action_mode="approval_required",
+                ),
+            )
         )
 
 

--- a/tests/services/investment_reports/test_watch_create.py
+++ b/tests/services/investment_reports/test_watch_create.py
@@ -92,9 +92,7 @@ async def test_direct_watch_create_rejects_idempotency_collision(
     await service.create(_request(idempotency_key="tcx:collision"))
 
     with pytest.raises(ValueError, match="idempotency_key .* already used"):
-        await service.create(
-            _request(idempotency_key="tcx:collision", symbol="000660")
-        )
+        await service.create(_request(idempotency_key="tcx:collision", symbol="000660"))
 
 
 @pytest.mark.asyncio

--- a/tests/services/investment_reports/test_watch_create.py
+++ b/tests/services/investment_reports/test_watch_create.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+from datetime import timedelta
+
+import pytest
+import sqlalchemy as sa
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.timezone import now_kst
+from app.models.investment_reports import InvestmentReport, InvestmentReportItem
+from app.schemas.investment_reports import (
+    CreateInvestmentWatchRequest,
+    WatchConditionPayload,
+)
+from app.services.investment_reports.watch_create import DirectWatchCreateService
+
+
+def _request(**overrides) -> CreateInvestmentWatchRequest:
+    payload = {
+        "created_by": "tradingcodex",
+        "market": "kr",
+        "symbol": "005930",
+        "intent": "trend_recovery_review",
+        "rationale": "price reclaimed support",
+        "watch_condition": WatchConditionPayload(
+            metric="price",
+            operator="above",
+            threshold=70000,
+            action_mode="approval_required",
+        ),
+        "valid_until": now_kst() + timedelta(days=2),
+        "trigger_checklist": ["confirm fresh L1", "open approved ticket"],
+        "max_action": {"side": "buy", "cash_fraction": 0.1},
+        "metadata": {"ticket_hint": "support-reclaim"},
+    }
+    payload.update(overrides)
+    return CreateInvestmentWatchRequest.model_validate(payload)
+
+
+@pytest.mark.asyncio
+async def test_direct_watch_create_persists_alert_without_report_rows(
+    session: AsyncSession,
+) -> None:
+    alert, idempotent = await DirectWatchCreateService(session).create(_request())
+
+    assert idempotent is False
+    assert alert.status == "active"
+    assert alert.market == "kr"
+    assert alert.symbol == "005930"
+    assert alert.metric == "price"
+    assert alert.operator == "above"
+    assert str(alert.threshold) in {"70000", "70000.00000000"}
+    assert alert.threshold_key == "70000"
+    assert alert.intent == "trend_recovery_review"
+    assert alert.action_mode == "approval_required"
+    assert alert.trigger_checklist == ["confirm fresh L1", "open approved ticket"]
+    assert alert.max_action == {"side": "buy", "cash_fraction": 0.1}
+    assert alert.alert_metadata["created_by"] == "tradingcodex"
+    assert alert.alert_metadata["source_tool"] == "investment_watch_create"
+    assert alert.alert_metadata["ticket_hint"] == "support-reclaim"
+
+    report_count = await session.scalar(
+        sa.select(sa.func.count()).select_from(InvestmentReport)
+    )
+    item_count = await session.scalar(
+        sa.select(sa.func.count()).select_from(InvestmentReportItem)
+    )
+    assert report_count == 0
+    assert item_count == 0
+
+
+@pytest.mark.asyncio
+async def test_direct_watch_create_is_idempotent_for_same_key(
+    session: AsyncSession,
+) -> None:
+    service = DirectWatchCreateService(session)
+    first, first_idempotent = await service.create(_request(idempotency_key="tcx:1"))
+    second, second_idempotent = await service.create(_request(idempotency_key="tcx:1"))
+
+    assert first_idempotent is False
+    assert second_idempotent is True
+    assert second.id == first.id
+    assert second.alert_uuid == first.alert_uuid
+
+
+@pytest.mark.asyncio
+async def test_direct_watch_create_rejects_idempotency_collision(
+    session: AsyncSession,
+) -> None:
+    service = DirectWatchCreateService(session)
+    await service.create(_request(idempotency_key="tcx:collision"))
+
+    with pytest.raises(ValueError, match="idempotency_key .* already used"):
+        await service.create(
+            _request(idempotency_key="tcx:collision", symbol="000660")
+        )
+
+
+@pytest.mark.asyncio
+async def test_direct_watch_create_rejects_expired_valid_until(
+    session: AsyncSession,
+) -> None:
+    with pytest.raises(ValueError, match="valid_until must be in the future"):
+        await DirectWatchCreateService(session).create(
+            _request(valid_until=now_kst() - timedelta(minutes=1))
+        )
+
+
+@pytest.mark.asyncio
+async def test_direct_watch_create_rejects_auto_execute_mock(
+    session: AsyncSession,
+) -> None:
+    with pytest.raises(ValueError, match="auto_execute_mock"):
+        await DirectWatchCreateService(session).create(
+            _request(
+                watch_condition=WatchConditionPayload(
+                    metric="price",
+                    operator="above",
+                    threshold=70000,
+                    action_mode="auto_execute_mock",
+                )
+            )
+        )

--- a/tests/test_investment_reports_mcp.py
+++ b/tests/test_investment_reports_mcp.py
@@ -28,6 +28,7 @@ from app.mcp_server.tooling.investment_reports_handlers import (
     investment_report_list_impl,
     investment_report_set_status_impl,
     investment_report_update_impl,
+    investment_watch_create_impl,
     investment_watch_recommend_impl,
 )
 from app.services.investment_reports.ingestion import InvestmentReportIngestionService
@@ -130,7 +131,42 @@ def test_tool_names_match_registered_set() -> None:
         "investment_report_set_status",
         "investment_report_add_items",
         "investment_report_update",
+        # ROB-768 — direct watch create (independent of report flow).
+        "investment_watch_create",
     }
+
+
+# --------------------------------------------------------------------------- #
+# ROB-768 Task 2 — direct watch create MCP handler
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_investment_watch_create_direct_persists_active_alert(
+    session: AsyncSession,
+) -> None:
+    response = await investment_watch_create_impl(
+        created_by="tradingcodex",
+        market="kr",
+        symbol="005930",
+        intent="trend_recovery_review",
+        rationale="support reclaimed",
+        watch_condition={
+            "metric": "price",
+            "operator": "above",
+            "threshold": 70000,
+            "action_mode": "approval_required",
+        },
+        valid_until=future_datetime().isoformat(),
+        trigger_checklist=["confirm fresh L1"],
+        max_action={"side": "buy"},
+        metadata={"source": "tcx-smoke"},
+    )
+
+    assert response["success"] is True
+    assert response["idempotent"] is False
+    assert response["alert"]["symbol"] == "005930"
+    assert response["alert"]["metadata"]["created_by"] == "tradingcodex"
+    assert response["alert"]["metadata"]["source_tool"] == "investment_watch_create"
+    assert response["alert"]["metadata"]["source"] == "tcx-smoke"
 
 
 @pytest.mark.asyncio

--- a/tests/test_mcp_profiles.py
+++ b/tests/test_mcp_profiles.py
@@ -543,6 +543,7 @@ class TestTradingCodexExecutionProfile:
             "get_trading_policy",
             "list_active_watches",
             "investment_watch_events_list_recent",
+            "investment_watch_create",
             "forecast_save",
             "get_forecasts",
             "save_trade_retrospective",
@@ -628,6 +629,31 @@ class TestTradingCodexExecutionProfile:
             "error": "created_by_required",
             "tool": "save_trade_retrospective",
             "detail": "tradingcodex_execution write calls must pass explicit created_by_profile such as 'tradingcodex'.",
+        }
+
+    # ROB-768 Task 2 — direct watch create needs explicit created_by on the
+    # tradingcodex_execution profile. Blank/missing must fail closed BEFORE
+    # touching the DB.
+    @pytest.mark.asyncio
+    async def test_investment_watch_create_requires_explicit_created_by(self) -> None:
+        mcp = _build_mcp(McpProfile.TRADINGCODEX_EXECUTION)
+        tool = mcp.tools["investment_watch_create"]
+
+        result = await tool(
+            created_by=" ",
+            market="kr",
+            symbol="005930",
+            intent="trend_recovery_review",
+            rationale="missing provenance",
+            watch_condition={"metric": "price", "operator": "above", "threshold": 70000},
+            valid_until="2026-07-15T09:00:00+09:00",
+        )
+
+        assert result == {
+            "success": False,
+            "error": "created_by_required",
+            "tool": "investment_watch_create",
+            "detail": "tradingcodex_execution write calls must pass explicit created_by such as 'tradingcodex'.",
         }
 
 

--- a/tests/test_mcp_profiles.py
+++ b/tests/test_mcp_profiles.py
@@ -645,7 +645,11 @@ class TestTradingCodexExecutionProfile:
             symbol="005930",
             intent="trend_recovery_review",
             rationale="missing provenance",
-            watch_condition={"metric": "price", "operator": "above", "threshold": 70000},
+            watch_condition={
+                "metric": "price",
+                "operator": "above",
+                "threshold": 70000,
+            },
             valid_until="2026-07-15T09:00:00+09:00",
         )
 


### PR DESCRIPTION
## Summary
- Add a report-flow-independent `investment_watch_create` path that persists active watch alerts directly.
- Expose the tool on `tradingcodex_execution` only through a wrapper that requires explicit `created_by` provenance.
- Document the new surface and harden explicit idempotency-key collision checks so changed watch conditions are rejected instead of silently reusing an old alert.

## Impact
- TradingCodex can create support/resistance watches without creating an investment report/item first.
- The profile matrix keeps the raw unguarded handler out of `tradingcodex_execution`; only the guarded wrapper is registered.
- Direct watch creation still blocks `auto_execute_mock` and creates notify/approval-style active alerts only.

## Validation
- `uv run pytest tests/services/investment_reports/test_watch_create.py tests/test_investment_reports_mcp.py::test_investment_watch_create_direct_persists_active_alert tests/test_mcp_profiles.py::TestTradingCodexExecutionProfile -q`
- `uv run pytest tests/test_mcp_profiles.py tests/mcp_server/test_watch_events_list_recent_tool.py tests/mcp_server/test_operating_briefing_tools.py -q`
- `uv run ruff check app/schemas/investment_reports.py app/services/investment_reports/idempotency.py app/services/investment_reports/watch_create.py app/mcp_server/tooling/investment_reports_handlers.py app/mcp_server/tooling/tradingcodex_execution_registration.py tests/services/investment_reports/test_watch_create.py tests/test_investment_reports_mcp.py tests/test_mcp_profiles.py`
- `git diff --check origin/main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new investment watch creation action for creating active watch alerts directly.
  * Support now includes a richer watch condition format, including an additional range-based option.

* **Bug Fixes**
  * Improved idempotent handling so repeated submissions can return the same alert instead of creating duplicates.
  * Added stricter validation for required fields and date handling to prevent invalid watch requests.

* **Documentation**
  * Updated MCP and runbook guidance with the new watch creation workflow and required provenance fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->