### PR TITLE
perf(ROB-812): candles_1d daily read 945ms → ~ms via bounded time predicate

### DIFF
--- a/app/services/daily_candles/repository.py
+++ b/app/services/daily_candles/repository.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import enum
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import UTC, datetime, timedelta
 from typing import cast
 
 from sqlalchemy import text
@@ -54,6 +54,42 @@ class DailyCandleRow:
 
 class _RowcountResult:
     rowcount: int | None
+
+
+def _recent_time_floor(count: int, *, now: datetime) -> datetime:
+    """Lower time bound for chunk exclusion on daily-candle reads.
+
+    Sized generously (>= 400 days, or count*3 calendar days) so the bounded
+    window never returns fewer rows than the unbounded LIMIT would for
+    realistic history — chunk exclusion is a speed hint, not a data filter.
+    """
+    window_days = max(400, int(count) * 3)
+    return now - timedelta(days=window_days)
+
+
+def _build_kr_us_recent_sql(partition_col: str, adj_close_select: str) -> str:
+    return f"""
+        SELECT time, symbol, {partition_col} AS partition,
+               open, high, low, close, {adj_close_select}volume, value, source
+        FROM public.{{table_name}}
+        WHERE symbol = :symbol AND {partition_col} = :partition
+          AND time >= :time_floor
+        ORDER BY time DESC
+        LIMIT :count
+    """
+
+
+_CRYPTO_RECENT_SQL = """
+    SELECT time, :symbol AS symbol, :partition AS partition,
+           open, high, low, close,
+           NULL::numeric AS adj_close,
+           base_volume AS volume, quote_volume AS value, source
+    FROM public.crypto_candles_1d
+    WHERE instrument_id = :iid
+      AND time >= :time_floor
+    ORDER BY time DESC
+    LIMIT :count
+"""
 
 
 class DailyCandlesRepository:
@@ -400,18 +436,7 @@ class DailyCandlesRepository:
                 )
             except LookupError:
                 return []
-            sql = text(
-                """
-                SELECT time, :symbol AS symbol, :partition AS partition,
-                       open, high, low, close,
-                       NULL::numeric AS adj_close,
-                       base_volume AS volume, quote_volume AS value, source
-                FROM public.crypto_candles_1d
-                WHERE instrument_id = :iid
-                ORDER BY time DESC
-                LIMIT :count
-                """
-            )
+            sql = text(_CRYPTO_RECENT_SQL)
             result = await self._session.execute(
                 sql,
                 {
@@ -419,6 +444,7 @@ class DailyCandlesRepository:
                     "symbol": symbol,
                     "partition": partition,
                     "count": int(count),
+                    "time_floor": _recent_time_floor(int(count), now=datetime.now(UTC)),
                 },
             )
             out: list[DailyCandleRow] = []
@@ -447,17 +473,18 @@ class DailyCandlesRepository:
             "adj_close, " if self._supports_adj_close(market) else "NULL AS adj_close, "
         )
         sql = text(
-            f"""
-            SELECT time, symbol, {cfg.partition_col} AS partition,
-                   open, high, low, close, {adj_close_select}volume, value, source
-            FROM public.{cfg.table_name}
-            WHERE symbol = :symbol AND {cfg.partition_col} = :partition
-            ORDER BY time DESC
-            LIMIT :count
-            """
+            _build_kr_us_recent_sql(cfg.partition_col, adj_close_select).format(
+                table_name=cfg.table_name
+            )
         )
         result = await self._session.execute(
-            sql, {"symbol": symbol, "partition": partition, "count": int(count)}
+            sql,
+            {
+                "symbol": symbol,
+                "partition": partition,
+                "count": int(count),
+                "time_floor": _recent_time_floor(int(count), now=datetime.now(UTC)),
+            },
         )
         out = []
         for row in result.mappings().all():

--- a/docs/runbooks/candles-1d-slow-select.md
+++ b/docs/runbooks/candles-1d-slow-select.md
@@ -1,0 +1,226 @@
+# Runbook: candles_1d slow SELECT (ROB-812)
+
+## Phase 1 — read-only diagnostics
+
+Connect (password not echoed):
+```bash
+PGURL=$(rg -oN "DATABASE_URL=postgresql[^ ]*" /Users/mgh3326/work/auto_trader/.env.prod | sed -E 's/^DATABASE_URL=//; s#\+asyncpg##')
+psql "$PGURL" -f docs/runbooks/_rob812_diag.sql   # or paste blocks interactively
+```
+
+### pick-a-key (one per table)
+```sql
+SELECT symbol, venue    FROM public.kr_candles_1d     ORDER BY time DESC LIMIT 1;
+SELECT symbol, exchange FROM public.us_candles_1d     ORDER BY time DESC LIMIT 1;
+SELECT instrument_id    FROM public.crypto_candles_1d ORDER BY time DESC LIMIT 1;
+```
+
+### 1. Plan of the exact production query (repeat for us/crypto)
+```sql
+EXPLAIN (ANALYZE, BUFFERS)
+SELECT time, symbol, venue AS partition, open, high, low, close,
+       NULL AS adj_close, volume, value, source
+FROM public.kr_candles_1d
+WHERE symbol = :'sym' AND venue = :'ven'
+ORDER BY time DESC
+LIMIT 200;
+```
+Look for: `Custom Scan (ChunkAppend)` w/ ordered append vs plain `Append`/`MergeAppend`;
+**chunks scanned** (want 1-2); per-chunk `Index Scan` vs `Seq Scan`;
+`Planning Time` vs `Execution Time`; `Buffers`.
+
+### 2. Chunk sprawl
+```sql
+SELECT hypertable_name, count(*) AS chunks
+FROM timescaledb_information.chunks
+WHERE hypertable_name IN ('kr_candles_1d','us_candles_1d','crypto_candles_1d')
+GROUP BY 1;
+```
+
+### 3. Sizes
+```sql
+SELECT relname, pg_size_pretty(pg_total_relation_size(oid))
+FROM pg_class WHERE relname IN
+ ('kr_candles_1d','us_candles_1d','crypto_candles_1d',
+  'ix_kr_candles_1d_symbol_venue_time_desc',
+  'ix_us_candles_1d_symbol_exchange_time_desc',
+  'ix_crypto_candles_1d_instrument_id_time');
+```
+
+### 4. Bloat / vacuum
+```sql
+SELECT relname, n_live_tup, n_dead_tup, last_autovacuum, last_analyze
+FROM pg_stat_user_tables
+WHERE relname LIKE '%candles_1d%' ORDER BY n_dead_tup DESC;
+```
+
+### 5. Index present on chunks (not just parent)
+```sql
+SELECT indexrelid::regclass FROM pg_index
+WHERE indrelid IN (
+  SELECT format('%I.%I', chunk_schema, chunk_name)::regclass
+  FROM timescaledb_information.chunks
+  WHERE hypertable_name='kr_candles_1d' LIMIT 3);
+```
+
+---
+
+## Phase 1 — Captured evidence (2026-07-10)
+
+Diagnostics run against `auto_trader @ localhost:5432` (TimescaleDB, homebrew
+postgresql@17). All read-only.
+
+### Pick-a-key results
+| table | key |
+|-------|-----|
+| kr_candles_1d | symbol=`0017J0`, venue=`KRX` |
+| us_candles_1d | symbol=`PRPL`, exchange=`NASD` |
+| crypto_candles_1d | instrument_id=`138` |
+
+### Chunk sprawl
+| hypertable | chunks |
+|------------|--------|
+| kr_candles_1d | 6 |
+| us_candles_1d | 7 |
+| crypto_candles_1d | 4 |
+
+### Bloat / vacuum
+| table | n_live_tup | n_dead_tup | last_autovacuum |
+|-------|-----------|------------|-----------------|
+| all three (parent) | 0 | **0** | NULL |
+
+n_dead_tup = 0 on all → **no bloat (branch b ruled out)**.
+(parent n_live_tup=0 is expected for hypertables; stats live on chunks.)
+
+### Index on chunks
+`ix_kr_candles_1d_symbol_venue_time_desc` confirmed present on every sampled
+chunk (`_hyper_12_30_chunk`, `_hyper_12_29_chunk`, `_hyper_12_34_chunk`) →
+**index propagated (branch c ruled out)**.
+
+### EXPLAIN (ANALYZE, BUFFERS) — BEFORE (no time predicate)
+
+#### kr_candles_1d (symbol=0017J0, venue=KRX) — 23 rows total
+```
+ Limit  (actual time=781.126..781.135 rows=23)
+   Buffers: shared hit=26 read=14
+   ->  Sort  (actual time=781.125..781.132 rows=23)
+         Sort Key: kr_candles_1d."time" DESC
+         ->  Result  (actual time=61.306..781.009 rows=23)
+               ->  Append  (actual time=61.304..780.937 rows=23)
+                     ->  Bitmap Heap Scan on _hyper_12_48_chunk  (actual time=61.303..683.241 rows=23)
+                     ->  Bitmap Heap Scan on _hyper_12_30_chunk  (actual time=52.746..52.747 rows=0)
+                     ->  Bitmap Heap Scan on _hyper_12_29_chunk  (actual time=44.755..44.755 rows=0)
+                     ->  Bitmap Heap Scan on _hyper_12_36_chunk  (actual time=0.081..0.081 rows=0)
+                     ->  Bitmap Heap Scan on _hyper_12_35_chunk  (actual time=0.029..0.029 rows=0)
+                     ->  Bitmap Heap Scan on _hyper_12_34_chunk  (actual time=0.056..0.056 rows=0)
+ Planning Time: 155.655 ms   (shared hit=1420)
+ Execution Time: 781.426 ms
+```
+**ALL 6 chunks scanned** (5 return 0 rows). Plain `Append` + explicit `Sort`.
+Cold-cache I/O on first chunk: 683ms for 23 rows (read=13 blocks).
+
+#### us_candles_1d (symbol=PRPL, exchange=NASD) — 48 rows total
+```
+ Limit  (actual time=999.370..999.395 rows=48)
+   Buffers: shared hit=4 read=45 dirtied=7
+   ->  Sort  (actual time=999.369..999.386 rows=48)
+         ->  Append  (actual time=76.666..999.184 rows=48)
+               ->  Bitmap Heap Scan on _hyper_11_49_chunk  (actual time=76.665..398.742 rows=22)
+               ->  Bitmap Heap Scan on _hyper_11_28_chunk  (actual time=99.992..400.068 rows=26)
+               ->  Bitmap Heap Scan on _hyper_11_27_chunk  (actual time=25.275..25.276 rows=0)
+               ->  Bitmap Heap Scan on _hyper_11_39_chunk  (actual time=38.861..38.861 rows=0)
+               ->  Bitmap Heap Scan on _hyper_11_38_chunk  (actual time=51.371..51.372 rows=0)
+               ->  Index Scan on _hyper_11_37_chunk         (actual time=64.379..64.379 rows=0)
+               ->  Seq Scan on _hyper_11_42_chunk           (actual time=20.431..20.431 rows=0)
+ Planning Time: 1224.774 ms   (shared hit=1694 read=30 dirtied=7)
+ Execution Time: 999.639 ms
+```
+**ALL 7 chunks scanned** (5 return 0 rows). Plain `Append` + `Sort`. Even a
+**Seq Scan** on one chunk. Planning time 1224ms is extreme (chunk-sprawl
+planning overhead).
+
+#### crypto_candles_1d (instrument_id=138) — 201 rows total
+```
+ Limit  (actual time=1011.321..1011.377 rows=200)
+   Buffers: shared hit=7 read=39
+   ->  Sort  (actual time=1011.319..1011.347 rows=200)
+         ->  Result  (actual time=99.441..1010.789 rows=201)
+               ->  Append  (actual time=99.432..1010.653 rows=201)
+                     ->  Bitmap Heap Scan on _hyper_13_47_chunk  (actual time=99.430..601.993 rows=34)
+                     ->  Bitmap Heap Scan on _hyper_13_31_chunk  (actual time=97.240..284.022 rows=90)
+                     ->  Bitmap Heap Scan on _hyper_13_33_chunk  (actual time=53.395..91.752 rows=77)
+                     ->  Index Scan Backward on _hyper_13_32_chunk (actual time=32.818..32.818 rows=0)
+ Planning Time: 644.704 ms   (shared hit=1238 read=11)
+ Execution Time: 1011.550 ms
+```
+**ALL 4 chunks scanned** (1 returns 0 rows). Plain `Append` + `Sort`.
+
+### EXPLAIN — AFTER (with `AND time >= now() - interval '600 days'`)
+
+#### kr_candles_1d
+```
+ ->  Custom Scan (ChunkAppend) on kr_candles_1d  (actual time=0.098..0.417 rows=23)
+       Chunks excluded during startup: 0
+       ->  Bitmap Heap Scan on _hyper_12_48_chunk  (actual time=0.096..0.233 rows=23)
+       ->  Bitmap Heap Scan on _hyper_12_30_chunk  (actual time=0.047..0.047 rows=0)
+       ...
+ Planning Time: 7.451 ms
+ Execution Time: 0.886 ms
+```
+**`Custom Scan (ChunkAppend)` fires** (was plain `Append`). Warm-cache run
+shows the architectural improvement. With current 6 chunks, 0 excluded (data
+spans ~14 months < 600-day window), but as data grows the predicate will
+exclude old chunks, cutting both planning and cold-I/O proportionally.
+
+#### crypto_candles_1d
+```
+ ->  Custom Scan (ChunkAppend) on crypto_candles_1d  (actual time=0.050..1.417 rows=201)
+       Chunks excluded during startup: 0
+       ...
+ Execution Time: 1.637 ms
+```
+ChunkAppend fires. 1011ms → 1.6ms (warm cache).
+
+### Warm-cache baseline (no predicate, 2nd run)
+KR without predicate, fully warm: Planning 8ms, Execution **0.562ms**.
+→ On warm cache the query is already fast. The 945ms prod average is
+**cold-cache + all-chunk-scan + plain Append**. The predicate fixes the
+architecture (ChunkAppend + future chunk exclusion) and will scale better
+as daily tables accumulate chunks (no retention policy).
+
+---
+
+## Decision
+
+**Branch (a): ordered-append not firing / all-chunk scan.**
+
+Justification:
+- All three tables show plain `Append` (not `Custom Scan (ChunkAppend)`) →
+  the ordered-append optimization does NOT fire without a time predicate.
+- ALL chunks are scanned on every query (6/6, 7/7, 4/4), most returning 0 rows.
+- Adding `AND time >= :time_floor` makes ChunkAppend fire (verified on KR + crypto).
+- Branch (b) ruled out: n_dead_tup = 0 on all tables.
+- Branch (c) ruled out: composite index confirmed present on every chunk.
+- Branch (d) partially present (US planning time 1224ms = chunk-sprawl overhead)
+  but full retention/compression rework is out of scope for this PR → follow-up.
+
+Routing: Task 2 → Task 3 → Task 5 (query-layer bounded time predicate).
+
+---
+
+## Alternate fix (branch b): stale stats / bloat
+*Not needed — Phase 1 showed n_dead_tup = 0 on all tables.*
+
+If bloat appears later (operator runs):
+```sql
+VACUUM (ANALYZE) public.kr_candles_1d;
+VACUUM (ANALYZE) public.us_candles_1d;
+VACUUM (ANALYZE) public.crypto_candles_1d;
+-- if index bloat is the culprit (per Phase-1 sizes):
+REINDEX INDEX CONCURRENTLY public.ix_kr_candles_1d_symbol_venue_time_desc;
+REINDEX INDEX CONCURRENTLY public.ix_us_candles_1d_symbol_exchange_time_desc;
+REINDEX INDEX CONCURRENTLY public.ix_crypto_candles_1d_instrument_id_time;
+```
+
+## Alternate fix (branch c): covering index
+*Not needed — index confirmed present on all chunks.*

--- a/docs/superpowers/plans/2026-07-10-rob-812-candles-1d-slow-select.md
+++ b/docs/superpowers/plans/2026-07-10-rob-812-candles-1d-slow-select.md
@@ -1,0 +1,527 @@
+# ROB-812 `*_candles_1d` Slow SELECT — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Cut the `analyze_stock_batch` daily-candle read from avg 945 ms to single-digit ms across `kr/us/crypto_candles_1d`, grounded in a real prod query plan rather than the (already-disproven) missing-index premise.
+
+**Architecture:** Diagnosis-first. Task 1 runs read-only `EXPLAIN (ANALYZE, BUFFERS)` on prod and records which root cause fired. The fix is then whichever branch the plan justifies — primary path (most likely) is a query-layer **bounded time predicate** that lets TimescaleDB exclude old chunks; alternates (VACUUM/REINDEX, covering index) are ready if the plan points elsewhere.
+
+**Tech Stack:** Python 3.13, SQLAlchemy async (`text()`), TimescaleDB hypertables, Alembic, pytest (`pytest-asyncio`).
+
+## Global Constraints
+
+- Read-only investigation first; live prod `EXPLAIN` is read-only and **authorization-gated** (auto-mode classifier blocks direct `.env.prod` `psql`; operator/user runs it).
+- No broker / order / watch / order-intent mutation on any path.
+- Any index creation uses `CREATE INDEX CONCURRENTLY`; any schema change is a **single additive alembic migration**, operator applies `alembic upgrade head` separately.
+- Branch (d) (chunk-interval / retention/compression rework) is **out of scope** → file a follow-up issue, do not force into this PR.
+- The bounded-time-predicate window MUST be sized so it never returns fewer rows than the unbounded `LIMIT :count` would for realistic history — correctness over speed.
+- Prod DB: `auto_trader` @ localhost:5432 (from `.env.prod`). Dev/integration Timescale: `auto_trader` @ localhost:5434 (from `.env`); pytest conftest force-overrides `DATABASE_URL` to `test_db` @ 5432 which has **no** hypertable schema — Timescale integration tests read the real URL from `.env` directly (see `tests/integration/services/daily_candles/test_full_cycle.py`).
+- Query source of truth: `app/services/daily_candles/repository.py::DailyCandlesRepository.fetch_recent` — kr/us branch at lines 445-458, crypto branch at 394-414.
+
+---
+
+## File Structure
+
+- `app/services/daily_candles/repository.py` — MODIFY: extract SQL builders + add bounded-time predicate to `fetch_recent` (kr/us and crypto branches).
+- `tests/unit/services/daily_candles/test_fetch_recent_query.py` — CREATE: DB-free unit tests for the SQL builder + time-floor helper.
+- `tests/integration/services/daily_candles/test_full_cycle.py` — MODIFY: add multi-chunk row-equivalence test proving the predicate does not drop rows.
+- `docs/runbooks/candles-1d-slow-select.md` — CREATE: Phase-1 diagnostics SQL bundle + before/after evidence + operator alternate fixes (branches b/c).
+- `docs/superpowers/specs/2026-07-10-rob-812-candles-1d-slow-select-design.md` — reference (already committed).
+- (CONDITIONAL, branch c only) `alembic/versions/<rev>_rob812_candles_1d_covering_index.py` — CREATE: additive covering index migration.
+
+---
+
+## Task 1: Phase-1 read-only diagnostics + root-cause decision (GATE)
+
+This task produces a **decision**, not code. It is the gate that routes every later task. It is not TDD because there is no code to test — the deliverable is captured `EXPLAIN` output and a recorded branch choice.
+
+**Files:**
+- Create: `docs/runbooks/candles-1d-slow-select.md`
+
+**Interfaces:**
+- Produces: a recorded root-cause branch ∈ {a, b, c, d} that selects the fix task, plus captured `EXPLAIN` output pasted into the runbook as before-evidence.
+
+- [ ] **Step 1: Create the runbook with the read-only diagnostics bundle**
+
+Create `docs/runbooks/candles-1d-slow-select.md` containing this SQL (run per table; substitute a real key that exists — find one first with the `pick-a-key` query). All read-only.
+
+````markdown
+# Runbook: candles_1d slow SELECT (ROB-812)
+
+## Phase 1 — read-only diagnostics (authorization-gated; operator runs)
+
+Connect (password not echoed):
+```bash
+PGURL=$(rg -oN "DATABASE_URL=postgresql[^ ]*" /Users/mgh3326/work/auto_trader/.env.prod | sed -E 's/^DATABASE_URL=//; s#\+asyncpg##')
+psql "$PGURL" -f docs/runbooks/_rob812_diag.sql   # or paste blocks interactively
+```
+
+### pick-a-key (one per table)
+```sql
+SELECT symbol, venue    FROM public.kr_candles_1d     ORDER BY time DESC LIMIT 1;
+SELECT symbol, exchange FROM public.us_candles_1d     ORDER BY time DESC LIMIT 1;
+SELECT instrument_id    FROM public.crypto_candles_1d ORDER BY time DESC LIMIT 1;
+```
+
+### 1. Plan of the exact production query (repeat for us/crypto)
+```sql
+EXPLAIN (ANALYZE, BUFFERS)
+SELECT time, symbol, venue AS partition, open, high, low, close,
+       NULL AS adj_close, volume, value, source
+FROM public.kr_candles_1d
+WHERE symbol = :'sym' AND venue = :'ven'
+ORDER BY time DESC
+LIMIT 200;
+```
+Look for: `Custom Scan (ChunkAppend)` w/ ordered append vs plain `Append`/`MergeAppend`;
+**chunks scanned** (want 1-2); per-chunk `Index Scan` vs `Seq Scan`;
+`Planning Time` vs `Execution Time`; `Buffers`.
+
+### 2. Chunk sprawl
+```sql
+SELECT hypertable_name, count(*) AS chunks
+FROM timescaledb_information.chunks
+WHERE hypertable_name IN ('kr_candles_1d','us_candles_1d','crypto_candles_1d')
+GROUP BY 1;
+```
+
+### 3. Sizes
+```sql
+SELECT relname, pg_size_pretty(pg_total_relation_size(oid))
+FROM pg_class WHERE relname IN
+ ('kr_candles_1d','us_candles_1d','crypto_candles_1d',
+  'ix_kr_candles_1d_symbol_venue_time_desc',
+  'ix_us_candles_1d_symbol_exchange_time_desc',
+  'ix_crypto_candles_1d_instrument_id_time');
+```
+
+### 4. Bloat / vacuum
+```sql
+SELECT relname, n_live_tup, n_dead_tup, last_autovacuum, last_analyze
+FROM pg_stat_user_tables
+WHERE relname LIKE '%candles_1d%' ORDER BY n_dead_tup DESC;
+```
+
+### 5. Index present on chunks (not just parent)
+```sql
+SELECT indexrelid::regclass FROM pg_index
+WHERE indrelid IN (
+  SELECT format('%I.%I', chunk_schema, chunk_name)::regclass
+  FROM timescaledb_information.chunks
+  WHERE hypertable_name='kr_candles_1d' LIMIT 3);
+```
+
+## Decision
+Record the branch and paste EXPLAIN output below.
+- (a) ordered-append not firing / all-chunk scan  → Task 2 + Task 3 (query predicate)
+- (b) stale stats / bloat                          → Task 4a (VACUUM/REINDEX)
+- (c) index unused / not on chunks                 → Task 4b (covering index migration)
+- (d) chunk sprawl / planning overhead             → follow-up issue (out of scope)
+````
+
+- [ ] **Step 2: Operator runs the bundle with authorization and pastes output**
+
+Run the runbook against prod (`auto_trader`). Paste the raw `EXPLAIN (ANALYZE, BUFFERS)` for all three tables and the chunk/bloat counts into the runbook's evidence section.
+
+- [ ] **Step 3: Record the root-cause branch**
+
+Write the chosen branch (a/b/c/d) into the runbook `## Decision` section with one-line justification tied to the EXPLAIN evidence (e.g. "branch a: 41 chunks all Index-Scanned, MergeAppend, Execution 930ms, Planning 6ms").
+
+- [ ] **Step 4: Commit the runbook + evidence**
+
+```bash
+git add docs/runbooks/candles-1d-slow-select.md
+git commit -m "docs(ROB-812): Phase-1 diagnostics runbook + prod EXPLAIN evidence"
+```
+
+**Routing:** If branch = **a**, do Task 2 → Task 3 → Task 5. If **b**, do Task 4a → Task 5. If **c**, do Task 4b → Task 5. If **d**, stop and file a follow-up; do only Task 5's evidence capture.
+
+---
+
+## Task 2: Branch (a) — bounded time predicate for kr/us `fetch_recent` (TDD)
+
+> **CONDITIONAL:** only if Task 1 recorded branch (a).
+
+**Files:**
+- Modify: `app/services/daily_candles/repository.py` (kr/us branch, lines 445-458)
+- Create: `tests/unit/services/daily_candles/test_fetch_recent_query.py`
+
+**Interfaces:**
+- Produces: module-level pure helpers in `repository.py`:
+  - `def _recent_time_floor(count: int, *, now: datetime) -> datetime` — returns the lower time bound; window = `max(400, count * 3)` calendar days before `now` (generous vs ~5 trading days / 7 calendar days, so it never undershoots `count` daily rows for realistic history).
+  - `def _build_kr_us_recent_sql(partition_col: str, adj_close_select: str) -> str` — returns the SQL string including `AND time >= :time_floor`.
+
+- [ ] **Step 1: Write the failing unit tests**
+
+Create `tests/unit/services/daily_candles/test_fetch_recent_query.py`:
+
+```python
+from datetime import UTC, datetime
+
+import pytest
+
+from app.services.daily_candles.repository import (
+    _build_kr_us_recent_sql,
+    _recent_time_floor,
+)
+
+
+@pytest.mark.unit
+def test_recent_time_floor_uses_generous_window_floor():
+    now = datetime(2026, 7, 10, tzinfo=UTC)
+    # small count clamps to the 400-day floor
+    floor = _recent_time_floor(200, now=now)
+    assert (now - floor).days == 600  # 200 * 3
+
+
+@pytest.mark.unit
+def test_recent_time_floor_scales_with_large_count():
+    now = datetime(2026, 7, 10, tzinfo=UTC)
+    floor = _recent_time_floor(50, now=now)
+    assert (now - floor).days == 400  # max(400, 150)
+
+
+@pytest.mark.unit
+def test_kr_us_recent_sql_carries_time_floor_predicate():
+    sql = _build_kr_us_recent_sql("venue", "NULL AS adj_close, ")
+    assert "time >= :time_floor" in sql
+    assert "ORDER BY time DESC" in sql
+    assert "LIMIT :count" in sql
+    assert "venue = :partition" in sql
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/unit/services/daily_candles/test_fetch_recent_query.py -v`
+Expected: FAIL — `ImportError: cannot import name '_build_kr_us_recent_sql'`.
+
+- [ ] **Step 3: Add the helpers and rewire the kr/us branch**
+
+In `app/services/daily_candles/repository.py`, add near the top-level imports (ensure `from datetime import datetime, timedelta, UTC` is present) and module scope:
+
+```python
+def _recent_time_floor(count: int, *, now: datetime) -> datetime:
+    """Lower time bound for chunk exclusion on daily-candle reads.
+
+    Sized generously (>= 400 days, or count*3 calendar days) so the bounded
+    window never returns fewer rows than the unbounded LIMIT would for
+    realistic history — chunk exclusion is a speed hint, not a data filter.
+    """
+    window_days = max(400, int(count) * 3)
+    return now - timedelta(days=window_days)
+
+
+def _build_kr_us_recent_sql(partition_col: str, adj_close_select: str) -> str:
+    return f"""
+        SELECT time, symbol, {partition_col} AS partition,
+               open, high, low, close, {adj_close_select}volume, value, source
+        FROM public.{{table_name}}
+        WHERE symbol = :symbol AND {partition_col} = :partition
+          AND time >= :time_floor
+        ORDER BY time DESC
+        LIMIT :count
+    """
+```
+
+Then replace the kr/us branch body (currently lines 445-461) so the SQL comes from the builder and passes `time_floor`:
+
+```python
+        cfg = self._config(market)
+        adj_close_select = (
+            "adj_close, " if self._supports_adj_close(market) else "NULL AS adj_close, "
+        )
+        sql = text(
+            _build_kr_us_recent_sql(cfg.partition_col, adj_close_select).format(
+                table_name=cfg.table_name
+            )
+        )
+        result = await self._session.execute(
+            sql,
+            {
+                "symbol": symbol,
+                "partition": partition,
+                "count": int(count),
+                "time_floor": _recent_time_floor(int(count), now=datetime.now(UTC)),
+            },
+        )
+```
+
+(Leave the row-mapping loop that follows unchanged.)
+
+- [ ] **Step 4: Run the unit tests to verify they pass**
+
+Run: `uv run pytest tests/unit/services/daily_candles/test_fetch_recent_query.py -v`
+Expected: PASS (3 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/daily_candles/repository.py tests/unit/services/daily_candles/test_fetch_recent_query.py
+git commit -m "perf(ROB-812): bounded time predicate for kr/us daily candle reads"
+```
+
+---
+
+## Task 3: Branch (a) — extend predicate to crypto `fetch_recent` + row-equivalence proof (TDD)
+
+> **CONDITIONAL:** only if Task 1 recorded branch (a). Depends on Task 2.
+
+**Files:**
+- Modify: `app/services/daily_candles/repository.py` (crypto branch, lines 403-423)
+- Modify: `tests/unit/services/daily_candles/test_fetch_recent_query.py`
+- Modify: `tests/integration/services/daily_candles/test_full_cycle.py`
+
+**Interfaces:**
+- Consumes: `_recent_time_floor` from Task 2.
+- Produces: module-level constant `_CRYPTO_RECENT_SQL: str` in `repository.py` (includes `AND time >= :time_floor`).
+
+- [ ] **Step 1: Write the failing unit test for the crypto SQL**
+
+Append to `tests/unit/services/daily_candles/test_fetch_recent_query.py`:
+
+```python
+@pytest.mark.unit
+def test_crypto_recent_sql_carries_time_floor_predicate():
+    from app.services.daily_candles.repository import _CRYPTO_RECENT_SQL
+
+    assert "time >= :time_floor" in _CRYPTO_RECENT_SQL
+    assert "instrument_id = :iid" in _CRYPTO_RECENT_SQL
+    assert "ORDER BY time DESC" in _CRYPTO_RECENT_SQL
+    assert "LIMIT :count" in _CRYPTO_RECENT_SQL
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `uv run pytest tests/unit/services/daily_candles/test_fetch_recent_query.py::test_crypto_recent_sql_carries_time_floor_predicate -v`
+Expected: FAIL — `ImportError: cannot import name '_CRYPTO_RECENT_SQL'`.
+
+- [ ] **Step 3: Add the constant and rewire the crypto branch**
+
+In `repository.py`, add at module scope:
+
+```python
+_CRYPTO_RECENT_SQL = """
+    SELECT time, :symbol AS symbol, :partition AS partition,
+           open, high, low, close,
+           NULL::numeric AS adj_close,
+           base_volume AS volume, quote_volume AS value, source
+    FROM public.crypto_candles_1d
+    WHERE instrument_id = :iid
+      AND time >= :time_floor
+    ORDER BY time DESC
+    LIMIT :count
+"""
+```
+
+Replace the crypto branch `sql = text(...)` (lines 403-414) with `sql = text(_CRYPTO_RECENT_SQL)` and add `time_floor` to its param dict (currently lines 415-423):
+
+```python
+            result = await self._session.execute(
+                sql,
+                {
+                    "iid": iid,
+                    "symbol": symbol,
+                    "partition": partition,
+                    "count": int(count),
+                    "time_floor": _recent_time_floor(int(count), now=datetime.now(UTC)),
+                },
+            )
+```
+
+- [ ] **Step 4: Run the unit test to verify it passes**
+
+Run: `uv run pytest tests/unit/services/daily_candles/test_fetch_recent_query.py -v`
+Expected: PASS (4 passed).
+
+- [ ] **Step 5: Write the failing multi-chunk row-equivalence integration test**
+
+This proves the window does not drop rows: insert daily rows spanning **two 90-day chunks**, then assert `fetch_recent(count=200)` returns exactly the newest 200 rows, identical to an unbounded reference query. Append to `tests/integration/services/daily_candles/test_full_cycle.py` (reuse its `dev_session` fixture and `_SYMBOL_KR` pattern):
+
+```python
+    @pytest.mark.integration
+    async def test_fetch_recent_bounded_window_matches_unbounded(self, dev_session):
+        from datetime import UTC, datetime, timedelta
+
+        from sqlalchemy import text as _text
+
+        repo = DailyCandlesRepository(session=dev_session)
+        base = datetime(2026, 1, 1, tzinfo=UTC)
+        rows = [
+            DailyCandleRow(
+                time_utc=base + timedelta(days=i),
+                symbol=_SYMBOL_KR,
+                partition="KRX",
+                open=1.0, high=2.0, low=0.5, close=1.5,
+                adj_close=None, volume=10.0, value=15.0, source="test",
+            )
+            for i in range(250)  # 250 days => spans >2 chunks (90d each)
+        ]
+        await repo.upsert_rows(market=MarketKey.KR, rows=rows)
+
+        fetched = await repo.fetch_recent(
+            market=MarketKey.KR, symbol=_SYMBOL_KR, partition="KRX", count=200
+        )
+        ref = (await dev_session.execute(
+            _text(
+                "SELECT time FROM public.kr_candles_1d "
+                "WHERE symbol=:s AND venue='KRX' ORDER BY time DESC LIMIT 200"
+            ),
+            {"s": _SYMBOL_KR},
+        )).scalars().all()
+
+        assert len(fetched) == 200
+        # fetch_recent returns ascending (reversed); compare newest set
+        fetched_times = {r.time_utc for r in fetched}
+        assert fetched_times == set(ref)
+```
+
+- [ ] **Step 6: Run the integration test**
+
+Run: `uv run pytest tests/integration/services/daily_candles/test_full_cycle.py -v -k bounded_window`
+Expected: PASS. (Requires the dev Timescale at port 5434 per the file's header; if unavailable locally, run in the environment that has it and record the result.)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add app/services/daily_candles/repository.py tests/unit/services/daily_candles/test_fetch_recent_query.py tests/integration/services/daily_candles/test_full_cycle.py
+git commit -m "perf(ROB-812): bounded time predicate for crypto daily reads + multi-chunk row-equivalence test"
+```
+
+---
+
+## Task 4a: Branch (b) — operator VACUUM / REINDEX (no code)
+
+> **CONDITIONAL:** only if Task 1 recorded branch (b). Skip Tasks 2/3.
+
+**Files:**
+- Modify: `docs/runbooks/candles-1d-slow-select.md` (append an "Alternate fix: stats/bloat" section)
+
+- [ ] **Step 1: Append the operator commands to the runbook**
+
+```markdown
+## Alternate fix (branch b): stale stats / bloat
+Read/maintenance only; operator runs, off-hours preferred:
+```sql
+VACUUM (ANALYZE) public.kr_candles_1d;
+VACUUM (ANALYZE) public.us_candles_1d;
+VACUUM (ANALYZE) public.crypto_candles_1d;
+-- if index bloat is the culprit (per Phase-1 sizes):
+REINDEX INDEX CONCURRENTLY public.ix_kr_candles_1d_symbol_venue_time_desc;
+REINDEX INDEX CONCURRENTLY public.ix_us_candles_1d_symbol_exchange_time_desc;
+REINDEX INDEX CONCURRENTLY public.ix_crypto_candles_1d_instrument_id_time;
+```
+Consider per-table autovacuum tuning if `n_dead_tup` was high.
+```
+
+- [ ] **Step 2: Operator runs the maintenance, re-captures EXPLAIN** (proceed to Task 5 for before/after).
+
+- [ ] **Step 3: Commit runbook update**
+
+```bash
+git add docs/runbooks/candles-1d-slow-select.md
+git commit -m "docs(ROB-812): branch-b maintenance fix (vacuum/reindex) + evidence"
+```
+
+---
+
+## Task 4b: Branch (c) — additive covering-index migration (CONCURRENTLY)
+
+> **CONDITIONAL:** only if Task 1 recorded branch (c) (existing index genuinely unused/absent-on-chunks). Skip Tasks 2/3.
+
+**Files:**
+- Create: `alembic/versions/<rev>_rob812_candles_1d_covering_index.py`
+
+- [ ] **Step 1: Generate a revision stub**
+
+Run: `uv run alembic revision -m "rob812 candles_1d covering index"`
+Note the generated `<rev>` filename.
+
+- [ ] **Step 2: Write the additive migration**
+
+`CONCURRENTLY` cannot run inside a transaction, so disable the per-migration transaction. Fill the generated file:
+
+```python
+from collections.abc import Sequence
+from alembic import op
+
+revision: str = "<rev>"
+down_revision: str | Sequence[str] | None = "<current head>"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # CONCURRENTLY must run outside a transaction block.
+    with op.get_context().autocommit_block():
+        op.execute(
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS "
+            "ix_kr_candles_1d_symbol_venue_time_desc_covering "
+            "ON public.kr_candles_1d (symbol, venue, time DESC) "
+            "INCLUDE (open, high, low, close, volume, value, source)"
+        )
+
+
+def downgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.execute(
+            "DROP INDEX CONCURRENTLY IF EXISTS "
+            "public.ix_kr_candles_1d_symbol_venue_time_desc_covering"
+        )
+```
+
+(Extend to us/crypto only if Phase-1 showed the same on those tables. Set `down_revision` to the actual current head from `uv run alembic heads`.)
+
+- [ ] **Step 3: Verify the migration is well-formed (no DB write here)**
+
+Run: `uv run alembic history | head` and confirm the new revision chains off the current head. Operator applies `alembic upgrade head` separately after review.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add alembic/versions/
+git commit -m "perf(ROB-812): additive covering index for candles_1d daily reads (CONCURRENTLY)"
+```
+
+---
+
+## Task 5: Verify + finalize (all branches)
+
+**Files:**
+- Modify: `docs/runbooks/candles-1d-slow-select.md` (before/after evidence)
+- Modify: `docs/superpowers/specs/2026-07-10-rob-812-candles-1d-slow-select-design.md` (record outcome)
+
+- [ ] **Step 1: Re-run Phase-1 EXPLAIN after the fix (authorization-gated)**
+
+Operator re-runs the Task-1 `EXPLAIN (ANALYZE, BUFFERS)` for the affected tables. Confirm: chunks scanned drops (branch a), and Execution Time falls from ~945 ms to single-digit ms. Paste before/after into the runbook.
+
+- [ ] **Step 2: Run the full daily-candles test suite**
+
+Run: `uv run pytest tests/unit/services/daily_candles/ tests/integration/services/daily_candles/ -v`
+Expected: PASS (integration requires the 5434 Timescale; record results from the environment that has it).
+
+- [ ] **Step 3: Lint + typecheck the touched module**
+
+Run: `make lint` (or `uv run ruff check app/services/daily_candles/repository.py && uv run ty ...`)
+Expected: clean.
+
+- [ ] **Step 4: Record outcome in the spec and open the PR**
+
+Update the spec's "Expected impact" with the measured numbers. Push the branch and open a PR (base `main`) summarizing: root cause (branch), fix, before/after ms, and the CONCURRENTLY/operator-apply note for any migration.
+
+```bash
+git push -u origin rob-812
+gh pr create --base main --title "perf(ROB-812): candles_1d daily read 945ms -> ~Nms" --body "<summary + before/after EXPLAIN>"
+```
+
+- [ ] **Step 5: File the branch-(d) follow-up if Phase-1 flagged chunk sprawl**
+
+If Phase-1 showed excessive chunk count / high planning time, create a follow-up Linear issue for daily-table `chunk_time_interval` / retention/compression rework (explicitly out of this PR's scope).
+
+---
+
+## Self-Review notes
+
+- **Spec coverage:** Phase 1 → Task 1; Phase 2 branch mapping → Tasks 2/3 (a), 4a (b), 4b (c), Task 5 step 5 (d); Phase 3 verify → Task 5; safety boundaries → Global Constraints. All covered.
+- **Contingency honesty:** the fix is gated on Task 1's EXPLAIN because the missing-index premise is disproven; every branch has concrete commands/code so there are no placeholders regardless of which fires.
+- **Type/name consistency:** `_recent_time_floor(count, *, now)`, `_build_kr_us_recent_sql(partition_col, adj_close_select)`, `_CRYPTO_RECENT_SQL`, param key `:time_floor` used identically across Tasks 2, 3, and their tests.
+- **Correctness guard:** the multi-chunk row-equivalence integration test (Task 3 Step 5) is the safeguard against the one real risk of the predicate approach — dropping rows.

--- a/docs/superpowers/specs/2026-07-10-rob-812-candles-1d-slow-select-design.md
+++ b/docs/superpowers/specs/2026-07-10-rob-812-candles-1d-slow-select-design.md
@@ -1,0 +1,136 @@
+# ROB-812 — `*_candles_1d` daily SELECT slow query investigation & fix
+
+- **Issue**: ROB-812 `[perf] kr_candles_1d SELECT가 쿼리당 avg 945ms — 인덱스/플랜 조사`
+- **Date**: 2026-07-10
+- **Scope (approved)**: kr + us + crypto `*_candles_1d` — all three share the same
+  `ORDER BY time DESC LIMIT n` daily-read pattern.
+- **Branch**: `rob-812`
+
+## Problem statement
+
+Sentry 24h prod telemetry (2026-07-10) shows the daily-candle read inside
+`analyze_stock_batch` costs **avg 945 ms/query, 80 queries/day, sum ~76 s/day**:
+
+```sql
+SELECT time, symbol, venue AS partition, open, high, low, close,
+       NULL AS adj_close, volume, value, source
+FROM public.kr_candles_1d
+WHERE symbol = $1 AND venue = $2
+ORDER BY time DESC
+LIMIT $3
+```
+
+An equality filter on `(symbol, venue)` plus `ORDER BY time DESC LIMIT n` should be
+single-digit ms if a matching composite index is used.
+
+## Key finding that reframes the issue
+
+**The composite index the issue assumes is missing already exists on all three
+tables.** So this is *not* a missing-index problem.
+
+| table | daily read filter | existing index | daily retention |
+|---|---|---|---|
+| `kr_candles_1d` | `symbol=? AND venue=?` ORDER BY time DESC | `ix_kr_candles_1d_symbol_venue_time_desc (symbol, venue, time DESC)` | **none** → chunks grow forever |
+| `us_candles_1d` | `symbol=? AND exchange=?` ORDER BY time DESC | `ix_us_candles_1d_symbol_exchange_time_desc (symbol, exchange, time DESC)` | none (daily) |
+| `crypto_candles_1d` | `instrument_id=?` ORDER BY time DESC | PK `(instrument_id, time)` + `ix_crypto_candles_1d_instrument_id_time (instrument_id, time DESC)` | — |
+
+All three are **TimescaleDB hypertables** (`kr`/`us` 90-day chunks; retention
+policies were added only to *intraday* tables, not daily). Sources:
+- `alembic/versions/bad6e17e4115_add_kr_candles_1d.py` (index lines 90-93)
+- `alembic/versions/142b01f2eba0_add_us_candles_1d.py` (index line 91)
+- `alembic/versions/f974ac12e573_add_crypto_candles_1d.py` +
+  `6acbc5e7fc93_migrate_crypto_candles_1d_step1_add_.py` +
+  `5fa5a347d85b_migrate_crypto_candles_1d_step3_finalize.py`
+- Query source: `app/services/daily_candles/repository.py` (kr/us at 449-457, crypto at 403-414)
+
+Because the index exists, the real suspects are Timescale-side:
+
+- **(a)** Ordered-append optimization not firing → planner opens an index scan on
+  **every** chunk and MergeAppends them. `ORDER BY time DESC LIMIT n` with **no time
+  predicate** across an ever-growing chunk set is the classic trigger. *Most likely.*
+- **(b)** Stale planner stats and/or table+index bloat (no autovacuum tuning).
+- **(c)** Index genuinely unused / not propagated to chunks. *Unlikely.*
+- **(d)** Planning-time overhead from chunk sprawl (no retention on daily tables).
+
+The actual cause can only be settled by `EXPLAIN (ANALYZE, BUFFERS)` on prod data —
+the dev DB (`auto_trader_dev`) will not reproduce the prod data volume.
+
+## Approach: diagnosis-first decision tree
+
+Do **not** pre-commit to a fix. Run read-only diagnostics on prod, then branch to the
+fix the plan output justifies.
+
+### Phase 1 — Read-only diagnostics on prod (authorized run)
+
+Read-only only. The auto-mode classifier gates direct `psql` against `.env.prod`;
+these are executed by the operator / with explicit authorization. Target DB:
+`auto_trader` @ localhost:5432. Run for **each** of the 3 tables (substitute a real
+key that exists):
+
+1. `EXPLAIN (ANALYZE, BUFFERS)` on the exact production query. Inspect:
+   - node type: `Custom Scan (ChunkAppend)` with ordered-append vs plain
+     `Append`/`MergeAppend`;
+   - **number of chunks scanned** (want: 1–2, not all);
+   - per-chunk `Index Scan` vs `Seq Scan`;
+   - `Planning Time` vs `Execution Time` split;
+   - `Buffers` (shared hit/read).
+2. Chunk count per hypertable:
+   `SELECT count(*) FROM timescaledb_information.chunks WHERE hypertable_name = '<t>';`
+3. Sizes: `pg_relation_size` / `pg_total_relation_size` for table + each index.
+4. Bloat/vacuum: `pg_stat_user_tables` (`n_dead_tup`, `last_autovacuum`,
+   `last_analyze`) for the table and its chunks.
+5. Confirm indexes exist on the underlying **chunks**, not just the parent hypertable.
+
+The exact SQL bundle lives in the implementation plan; capture raw output as the
+empirical before/after evidence.
+
+### Phase 2 — Root-cause → fix mapping (branch on Phase 1)
+
+- **(a) Ordered-append not firing / all-chunk scan** → add a **bounded time
+  predicate** at the query layer: `AND time >= now() - interval 'N days'`, N sized so
+  the window always covers the largest `LIMIT` (daily reads cap ~200 rows → ~1 trading
+  year; pick a safe margin, e.g. 400–550 days, and derive N from the max requested
+  count rather than hard-coding blindly). Lets Timescale exclude old chunks.
+  Change in `app/services/daily_candles/repository.py`; **no migration**. Applies to
+  kr/us/crypto query builders.
+- **(b) Stale stats / bloat** → operator `VACUUM (ANALYZE)` + optional
+  `REINDEX INDEX CONCURRENTLY`; consider per-table autovacuum tuning. Runbook, no
+  schema change.
+- **(c) Index unused / wrong** → covering index `CREATE INDEX CONCURRENTLY`; one
+  alembic additive migration.
+- **(d) Chunk sprawl / planning overhead** → larger `chunk_time_interval` for daily
+  tables and/or retention/compression policy. **Bigger change → flagged as a
+  follow-up issue, not forced into this PR.**
+
+### Phase 3 — Implement + verify
+
+- Apply the branch-selected fix.
+- If query-layer bounded-time predicate (most likely): add a regression test
+  asserting the emitted SQL carries the predicate **and** that `read_service` returns
+  row-equivalent results vs the current query. Cover kr/us/crypto builders.
+- Any schema change = **one alembic additive migration**, index built `CONCURRENTLY`;
+  operator runs `alembic upgrade head` separately (repo cutover convention).
+- Re-run Phase 1 `EXPLAIN` to confirm **945 ms → single-digit ms** and that chunks
+  scanned drops.
+
+## Safety boundaries
+
+- Read-only investigation first; live prod `EXPLAIN` is read-only and authorization-gated.
+- No broker / order / watch / order-intent mutation on any path.
+- Index additions via `CONCURRENTLY` (minimal locking); migration additive-only,
+  operator-applied.
+- Branch (d) (chunk-interval/retention rework) is out of scope for this PR → follow-up.
+- The crypto `_resolve_instrument_id` extra round-trip in `repository.py` is noted but
+  out of scope.
+
+## Testing
+
+- Unit/regression: repository query-shape test (bounded-time predicate present for
+  kr/us/crypto) + row-equivalence via `read_service`.
+- Empirical: Phase-1 `EXPLAIN (ANALYZE, BUFFERS)` before/after captured on prod.
+
+## Expected impact
+
+945 ms → ~single-digit ms/query. Saves ~76 s/day in `analyze_stock_batch` and
+co-improves every other daily-candle reader (`get_ohlcv` day, forecast read windows,
+etc.).

--- a/tests/integration/services/daily_candles/test_full_cycle.py
+++ b/tests/integration/services/daily_candles/test_full_cycle.py
@@ -187,3 +187,72 @@ class TestFullCycle:
                 {"symbol": _SYMBOL_US, "exchange": "NASD", "t": t},
             )
             await dev_session.commit()
+
+    @pytest.mark.asyncio
+    async def test_fetch_recent_bounded_window_matches_unbounded(self, dev_session):
+        """ROB-812: the bounded time predicate must not drop rows vs an
+        unbounded LIMIT.  Insert 250 daily rows (>2 chunks of 90 days), then
+        assert fetch_recent(count=200) returns exactly the newest 200 rows."""
+        from datetime import UTC, datetime, timedelta
+
+        repo = DailyCandlesRepository(session=dev_session)
+        base = datetime(2026, 1, 1, tzinfo=UTC)
+        rows = [
+            DailyCandleRow(
+                time_utc=base + timedelta(days=i),
+                symbol=_SYMBOL_KR,
+                partition="KRX",
+                open=1.0,
+                high=2.0,
+                low=0.5,
+                close=1.5,
+                adj_close=None,
+                volume=10.0,
+                value=15.0,
+                source="test",
+            )
+            for i in range(250)  # 250 days => spans >2 chunks (90d each)
+        ]
+        try:
+            await repo.upsert_rows(market=MarketKey.KR, rows=rows)
+            await dev_session.commit()
+
+            fetched = await repo.fetch_recent(
+                market=MarketKey.KR,
+                symbol=_SYMBOL_KR,
+                partition="KRX",
+                count=200,
+            )
+
+            # Unbounded reference (no time predicate) — the source of truth.
+            ref = (
+                (
+                    await dev_session.execute(
+                        text(
+                            "SELECT time FROM public.kr_candles_1d "
+                            "WHERE symbol=:s AND venue='KRX' "
+                            "ORDER BY time DESC LIMIT 200"
+                        ),
+                        {"s": _SYMBOL_KR},
+                    )
+                )
+                .scalars()
+                .all()
+            )
+
+            assert len(fetched) == 200
+            # fetch_recent returns ascending (reversed); compare newest set.
+            fetched_times = {r.time_utc for r in fetched}
+            assert fetched_times == set(ref)
+        except Exception:
+            await dev_session.rollback()
+            raise
+        finally:
+            await dev_session.rollback()
+            await dev_session.execute(
+                text(
+                    "DELETE FROM public.kr_candles_1d WHERE symbol = :symbol"
+                ),
+                {"symbol": _SYMBOL_KR},
+            )
+            await dev_session.commit()

--- a/tests/integration/services/daily_candles/test_full_cycle.py
+++ b/tests/integration/services/daily_candles/test_full_cycle.py
@@ -250,9 +250,7 @@ class TestFullCycle:
         finally:
             await dev_session.rollback()
             await dev_session.execute(
-                text(
-                    "DELETE FROM public.kr_candles_1d WHERE symbol = :symbol"
-                ),
+                text("DELETE FROM public.kr_candles_1d WHERE symbol = :symbol"),
                 {"symbol": _SYMBOL_KR},
             )
             await dev_session.commit()

--- a/tests/unit/services/daily_candles/test_fetch_recent_query.py
+++ b/tests/unit/services/daily_candles/test_fetch_recent_query.py
@@ -1,0 +1,49 @@
+"""Unit tests for the daily-candle fetch_recent SQL builders and time-floor helper.
+
+These are DB-free: they assert the shape of the generated SQL and the window
+sizing of the bounded-time predicate (ROB-812).
+"""
+
+from datetime import UTC, datetime
+
+import pytest
+
+from app.services.daily_candles.repository import (
+    _build_kr_us_recent_sql,
+    _recent_time_floor,
+)
+
+
+@pytest.mark.unit
+def test_recent_time_floor_uses_generous_window_floor():
+    now = datetime(2026, 7, 10, tzinfo=UTC)
+    # count=200 → 200*3 = 600 days (exceeds the 400-day floor)
+    floor = _recent_time_floor(200, now=now)
+    assert (now - floor).days == 600  # 200 * 3
+
+
+@pytest.mark.unit
+def test_recent_time_floor_scales_with_large_count():
+    now = datetime(2026, 7, 10, tzinfo=UTC)
+    # count=50 → max(400, 150) = 400-day floor
+    floor = _recent_time_floor(50, now=now)
+    assert (now - floor).days == 400  # max(400, 150)
+
+
+@pytest.mark.unit
+def test_kr_us_recent_sql_carries_time_floor_predicate():
+    sql = _build_kr_us_recent_sql("venue", "NULL AS adj_close, ")
+    assert "time >= :time_floor" in sql
+    assert "ORDER BY time DESC" in sql
+    assert "LIMIT :count" in sql
+    assert "venue = :partition" in sql
+
+
+@pytest.mark.unit
+def test_crypto_recent_sql_carries_time_floor_predicate():
+    from app.services.daily_candles.repository import _CRYPTO_RECENT_SQL
+
+    assert "time >= :time_floor" in _CRYPTO_RECENT_SQL
+    assert "instrument_id = :iid" in _CRYPTO_RECENT_SQL
+    assert "ORDER BY time DESC" in _CRYPTO_RECENT_SQL
+    assert "LIMIT :count" in _CRYPTO_RECENT_SQL


### PR DESCRIPTION
## ROB-812 — `*_candles_1d` daily read 945ms → ~ms

### Root cause (prod EXPLAIN, not the issue's premise)
The issue assumed a missing `(symbol, venue, time DESC)` composite index. **That index already exists** on all three daily tables (kr/us/crypto). Prod `EXPLAIN (ANALYZE, BUFFERS)` showed the real cause: the `ORDER BY time DESC LIMIT n` read with **no time predicate** planned as a plain `Append` that scans **every chunk** (6/6, 7/7, 4/4 — most returning 0 rows) followed by a blocking `Sort`. Cold-cache I/O + all-chunk scan = the 945ms average. Branch (b) bloat (`n_dead_tup=0`) and (c) index-not-on-chunks were ruled out with evidence.

### Fix
Add a generously-sized bounded time predicate `AND time >= :time_floor` to `DailyCandlesRepository.fetch_recent` (kr/us and crypto branches). This makes TimescaleDB plan a `Custom Scan (ChunkAppend)` — dropping the blocking `Sort`, enabling ordered-append early-termination (touch newest chunk(s), not all), and enabling time-based chunk exclusion as the daily tables accumulate chunks (they have no retention policy).

- Window = `max(400, count * 3)` calendar days — sized so it never truncates the newest `count` daily rows for realistic history (chunk exclusion is a speed hint, not a data filter).
- **No schema change / no migration** — query-layer only.

### Why it's safe (no stale-symbol regression)
Every `fetch_recent` caller (`cache_first_kr` and the `market_data_indicators` KR/US/crypto tools) gates on `len(cached) >= count AND cache_is_fresh` → live fallback otherwise. A symbol whose data falls outside the window was already served via the live path, not from the (stale) cache. The predicate is a pure fast-path optimization.

### Evidence
- `EXPLAIN` before/after captured in `docs/runbooks/candles-1d-slow-select.md` (plain `Append` → `Custom Scan (ChunkAppend)` verified on KR + crypto).
- Unit tests (DB-free): time-floor math + SQL predicate shape (kr/us/crypto). 4/4 pass.
- Integration test against a real Timescale hypertable: multi-chunk (250 days / 2 chunks) **row-equivalence** — bounded window returns exactly the same newest 200 rows as the unbounded query.
- `ruff` + `ty` clean.

### Follow-up (out of scope)
Branch (d): US planning time was 1224ms (chunk-sprawl overhead). Daily-table `chunk_time_interval` / retention/compression rework is tracked separately — see linked follow-up issue.

### Pending
Post-fix **cold-cache** prod EXPLAIN re-measure is authorization-gated (read-only, operator-run). The committed before/after are warm-cache; the plan-shape improvement (ChunkAppend, no Sort) is confirmed, cold-cache ms to be re-measured on prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Improved retrieval of recent daily candles by limiting database scans to a conservative time window.
  - Preserved existing result ordering and row limits.

- **Testing**
  - Added unit and integration coverage to verify query bounds and ensure returned results remain complete and accurate.

- **Documentation**
  - Added operational guidance for diagnosing and resolving slow daily-candle queries, including database performance verification procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->