### PR TITLE
fix(ROB-814): don't cache anchor-missing Naver detail pages + sellable-cache docstring

### DIFF
--- a/app/services/naver_finance/investor.py
+++ b/app/services/naver_finance/investor.py
@@ -29,15 +29,21 @@ from app.services.naver_finance.parser import (
 from app.services.naver_finance.valuation import _parse_valuation_from_soups
 
 
-def _parse_report_detail_soup(soup: BeautifulSoup) -> dict[str, Any]:
+def _parse_report_detail_soup(soup: BeautifulSoup) -> dict[str, Any] | None:
+    info_div = soup.select_one("div.view_info_1")
+    if not info_div:
+        # ROB-814: the parse anchor itself is missing — a page-shape anomaly
+        # (anti-bot interstitial, deleted-post notice, Naver selector rot),
+        # NOT a report with a legitimately-absent target. Return None so the
+        # assembly treats it like a fetch failure: shown as no-detail but
+        # NEVER written to the insert-once ROB-811 cache, which would freeze
+        # the anomaly permanently (no update path) even after a parser fix.
+        return None
+
     result: dict[str, Any] = {
         "target_price": None,
         "rating": None,
     }
-
-    info_div = soup.select_one("div.view_info_1")
-    if not info_div:
-        return result
 
     target_elem = info_div.select_one("em.money strong")
     if target_elem:

--- a/app/services/toss_sellable_cache.py
+++ b/app/services/toss_sellable_cache.py
@@ -3,9 +3,14 @@ sellable-quantity fanout on /invest home & account-panel.
 
 The Toss ``GET /api/v1/sellable-quantity`` endpoint is in the ORDER_INFO
 rate-limit group (6 TPS / 3 TPS peak), so fanning it out per holding serializes
-to ~N/6 s. This cache collapses repeated /invest loads to 0 calls within the TTL;
-only the invest_home reader opts in (the MCP / sell-classification path stays
-uncached and fresh). enabled=False => always miss => today's fanout-every-load.
+to ~N/6 s. This cache collapses repeated loads to 0 calls within the TTL.
+
+Opt-in callers (ROB-701 + ROB-810): the invest_home reader (/invest home &
+account-panel) AND the MCP ``get_holdings`` path (default; bypass with
+``fresh_sellable=True``). Display/advisory surfaces only — real sell sizing is
+safe because order tools re-validate sellable at broker submit
+(``orders_toss_variants``), and KIS/Upbit sell validation reads its own broker
+live. enabled=False => always miss => fanout-every-load.
 """
 
 from __future__ import annotations

--- a/tests/services/naver_finance/test_investor_detail_cache_wiring.py
+++ b/tests/services/naver_finance/test_investor_detail_cache_wiring.py
@@ -137,3 +137,41 @@ async def test_wrapper_passes_cache_to_fetch_investment_opinions(
     monkeypatch.delenv("NAVER_RESEARCH_DETAIL_CACHE_ENABLED", raising=False)
     await fundamentals_sources_naver._fetch_investment_opinions_naver("005930", 10)
     assert seen["detail_cache"] is not None  # injected store
+
+
+# ---------------------------------------------------------------------------
+# ROB-814 — anchor-missing pages must NOT be cache-worthy
+# ---------------------------------------------------------------------------
+
+
+def test_parse_detail_anchor_missing_returns_none() -> None:
+    """ROB-814: a 200 page WITHOUT div.view_info_1 (anti-bot interstitial,
+    deleted-post notice, selector rot) is a page-shape anomaly, not a report
+    with a legitimately-absent target. The parser must return None so the
+    assembly treats it exactly like a fetch failure — shown as no-detail and
+    NEVER written to the insert-once cache (which would freeze the anomaly
+    permanently, surviving even a parser fix)."""
+    from bs4 import BeautifulSoup
+
+    from app.services.naver_finance.investor import _parse_report_detail_soup
+
+    soup = BeautifulSoup(
+        "<html><body><p>일시적으로 이용할 수 없습니다</p></body></html>",
+        "html.parser",
+    )
+    assert _parse_report_detail_soup(soup) is None
+
+
+def test_parse_detail_anchor_present_without_fields_stays_cacheworthy() -> None:
+    """ROB-814 regression lock: anchor present but money/coment absent is a
+    REAL report without a target — the all-None dict stays cache-worthy
+    (ROB-811 'success-with-no-target' rule preserved)."""
+    from bs4 import BeautifulSoup
+
+    from app.services.naver_finance.investor import _parse_report_detail_soup
+
+    soup = BeautifulSoup(
+        '<html><body><div class="view_info_1">의견 없음</div></body></html>',
+        "html.parser",
+    )
+    assert _parse_report_detail_soup(soup) == {"target_price": None, "rating": None}


### PR DESCRIPTION
ROB-810/811 적대검증 잔여 2건 (both non-blocking, now closed):

## 1. Anchor-missing 오염 가드 (the only real poisoning window)
`_parse_report_detail_soup`이 **앵커(`div.view_info_1`) 자체가 없는 이상 페이지**(안티봇/삭제글/셀렉터 rot)와 **정당한 target-부재 리포트**를 같은 all-None dict로 반환 → 둘 다 insert-once 캐시에 영구 동결(update 경로 없음, 파서 수정 후에도 잔존). 이제 앵커-부재는 `None` 반환 → 어셈블리의 기존 `isinstance(result, dict)` 게이트가 fetch 실패와 동일 취급(표시=no-detail, **미캐시**, 다음 호출 재시도). 앵커-존재+필드-부재는 cache-worthy dict 유지(ROB-811 규칙 보존, 회귀락 추가).

## 2. sellable-cache docstring 정정
ROB-810(#1486)이 MCP `get_holdings`도 opt-in시켰는데 모듈 docstring이 여전히 "MCP는 uncached" — 두 opt-in 호출자·`fresh_sellable=True` 우회·매도 사이징 안전 근거(submit 시 브로커 재검증)로 갱신.

## Tests
새 테스트 2(anchor-missing→None RED→GREEN·anchor-present-no-target 회귀락) + 기존 `test_fetch_failure_not_written`이 None→미캐시 락. **84 + 289 passed**, lint clean, migration-0.

ROB-814

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015NC4CDLK3bbjDuCYxxzEc7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved investor report parsing to recognize unavailable or unexpected report pages.
  * Prevented incomplete or invalid report details from being saved as valid cached results.
  * Preserved support for valid reports that do not include target price or rating information.
  * Improved the reliability of investor data displayed across supported finance features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->