### PR TITLE
feat(ROB-816): Telegram button approval flow (PR 2/2)

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -764,6 +764,21 @@ class Settings(BaseSettings):
     # ORDER PROPOSALS (ROB-816) — default-off SOT ledger + read/create MCP tools.
     # Gates MCP tool registration; the Telegram approval surface has its own gate (PR 2).
     ORDER_PROPOSALS_ENABLED: bool = False
+    # ROB-816 PR 2 — Telegram approval flow (default off)
+    ORDER_PROPOSALS_TELEGRAM_ENABLED: bool = False
+    ORDER_PROPOSALS_TELEGRAM_BOT_TOKEN: str = ""
+    ORDER_PROPOSALS_TELEGRAM_TOKEN: str = ""
+    ORDER_PROPOSALS_TELEGRAM_TOKEN_HEADER: str = "X-Telegram-Bot-Api-Secret-Token"
+    ORDER_PROPOSALS_TELEGRAM_CHAT_ALLOWLIST_STR: str = ""
+
+    @property
+    def order_proposals_telegram_chat_allowlist(self) -> list[str]:
+        return [
+            chat_id.strip()
+            for chat_id in self.ORDER_PROPOSALS_TELEGRAM_CHAT_ALLOWLIST_STR.split(",")
+            if chat_id.strip()
+        ]
+
     # ROB-214 — recurring reconciliation scheduler remains disabled unless explicitly enabled.
     execution_ledger_reconcile_scheduler_enabled: bool = False
     execution_ledger_reconcile_scheduler_cron: str = "*/30 * * * *"

--- a/app/main.py
+++ b/app/main.py
@@ -64,6 +64,7 @@ from app.routers import (
     screener,
     strategy_events,
     symbol_settings,
+    telegram_callback,
     test,
     trade_journals,
     user_defaults,
@@ -217,6 +218,12 @@ def create_app() -> FastAPI:
     app.include_router(research_reports.router)
     app.include_router(strategy_events.router)
     app.include_router(kospi200.router)
+    # ROB-816 PR 2 — flag-gated, same rationale as investment_snapshots
+    # above: default off keeps the router fully absent so unauthenticated
+    # probes against the Telegram webhook path return 404 at FastAPI's
+    # routing layer, not a 503 that reveals the feature exists.
+    if settings.ORDER_PROPOSALS_TELEGRAM_ENABLED:
+        app.include_router(telegram_callback.router)
     app.include_router(websocket.router)
     if settings.EXPOSE_MONITORING_TEST_ROUTES:
         app.include_router(test.router)

--- a/app/main.py
+++ b/app/main.py
@@ -219,9 +219,16 @@ def create_app() -> FastAPI:
     app.include_router(strategy_events.router)
     app.include_router(kospi200.router)
     # ROB-816 PR 2 — flag-gated, same rationale as investment_snapshots
-    # above: default off keeps the router fully absent so unauthenticated
-    # probes against the Telegram webhook path return 404 at FastAPI's
-    # routing layer, not a 503 that reveals the feature exists.
+    # above. The PRIMARY rejection layer for unauthenticated probes against
+    # the Telegram webhook path prefix is AuthMiddleware's
+    # TELEGRAM_CALLBACK_PATH_PREFIX branch (app/middleware/auth.py), which
+    # fires on the path prefix alone and fails closed (403 when the shared
+    # token isn't configured, 401 on a wrong token) independent of this flag
+    # -- middleware runs before routing, so that branch fires whether or not
+    # the router below is mounted. Keeping the router itself absent when the
+    # flag is off is a secondary, defense-in-depth layer (a 404 at FastAPI's
+    # routing layer if middleware were ever bypassed/misconfigured), not the
+    # reason probes are rejected today.
     if settings.ORDER_PROPOSALS_TELEGRAM_ENABLED:
         app.include_router(telegram_callback.router)
     app.include_router(websocket.router)

--- a/app/mcp_server/tooling/order_proposal_tools.py
+++ b/app/mcp_server/tooling/order_proposal_tools.py
@@ -7,13 +7,17 @@ performs NO broker mutation.
 
 from __future__ import annotations
 
+import logging
 import uuid
 from datetime import datetime
 from decimal import Decimal, InvalidOperation
 from typing import TYPE_CHECKING, Any
 
+from app.core.config import settings
 from app.core.db import AsyncSessionLocal
+from app.core.timezone import now_kst
 from app.services.order_proposals import OrderProposalsService
+from app.services.order_proposals.dispatch import send_proposal_for_approval
 from app.services.order_proposals.errors import (
     OrderProposalError,
     OrderProposalNotFound,
@@ -22,6 +26,8 @@ from app.services.order_proposals.service import RungInput
 
 if TYPE_CHECKING:
     from fastmcp import FastMCP
+
+logger = logging.getLogger(__name__)
 
 ORDER_PROPOSAL_TOOL_NAMES: set[str] = {
     "order_proposal_create",
@@ -134,12 +140,42 @@ async def order_proposal_create(
             )
             _, saved_rungs = await svc.get_proposal(group.proposal_id)
             await session.commit()
-            return {
+            proposal_id = group.proposal_id
+            result = {
                 "success": True,
-                "proposal_id": str(group.proposal_id),
+                "proposal_id": str(proposal_id),
                 "lifecycle_state": group.lifecycle_state,
                 "rungs": [_rung_dict(r) for r in saved_rungs],
             }
+
+        # Best-effort Telegram dispatch (ROB-816 PR 2). The proposal's own
+        # session above is already closed/committed by this point --
+        # `send_proposal_for_approval` opens a genuinely separate session, so
+        # this is intentional, not a nested-session bug. A dispatch failure
+        # (Telegram down, notifier misconfigured, etc.) must never fail this
+        # tool's contract -- the proposal has already persisted successfully.
+        if (
+            settings.ORDER_PROPOSALS_TELEGRAM_ENABLED
+            and settings.order_proposals_telegram_chat_allowlist
+        ):
+            try:
+                from app.monitoring.trade_notifier.notifier import (
+                    get_trade_notifier,
+                )
+
+                await send_proposal_for_approval(
+                    proposal_id,
+                    notifier=get_trade_notifier(),
+                    now=now_kst(),
+                )
+            except Exception:  # noqa: BLE001 - best-effort, never fail create
+                logger.exception(
+                    "order_proposal_create: telegram approval dispatch failed "
+                    "for proposal_id=%s",
+                    proposal_id,
+                )
+
+        return result
     except (ValueError, OrderProposalError) as exc:
         return {"success": False, "error": str(exc)}
 

--- a/app/middleware/auth.py
+++ b/app/middleware/auth.py
@@ -60,6 +60,7 @@ class AuthMiddleware:
     )
     HERMES_INGEST_PATH_PREFIX: ClassVar[str] = "/trading/api/investment-reports/hermes/"
     NEWS_RELEVANCE_PATH_PREFIX: ClassVar[str] = "/trading/api/news-relevance/"
+    TELEGRAM_CALLBACK_PATH_PREFIX: ClassVar[str] = "/trading/api/telegram/"
     LEGACY_DEPRECATED_PREFIXES: ClassVar[tuple[str, ...]] = LEGACY_PREFIXES
 
     def __init__(self, app: ASGIApp):
@@ -237,6 +238,33 @@ class AuthMiddleware:
                 return JSONResponse(
                     status_code=401,
                     content={"detail": "Invalid news relevance ingest token"},
+                )
+            return None
+
+        # ROB-816 PR 2 — Telegram webhook secret-token auth for the
+        # order-proposals approval callback. Same prefix-token shape as the
+        # Hermes / news-relevance branches above: Telegram's webhook
+        # "secret token" mechanism supplies this header on every request,
+        # so an unconfigured token or header name must fail closed (403)
+        # rather than silently accept unauthenticated webhook traffic.
+        if path.startswith(self.TELEGRAM_CALLBACK_PATH_PREFIX):
+            expected_token = settings.ORDER_PROPOSALS_TELEGRAM_TOKEN
+            if not expected_token:
+                return JSONResponse(
+                    status_code=403,
+                    content={"detail": "Telegram callback token not configured"},
+                )
+            header_name = settings.ORDER_PROPOSALS_TELEGRAM_TOKEN_HEADER.strip()
+            if not header_name:
+                return JSONResponse(
+                    status_code=403,
+                    content={"detail": "Telegram callback token header not configured"},
+                )
+            supplied_token = request.headers.get(header_name, "")
+            if not hmac.compare_digest(supplied_token, expected_token):
+                return JSONResponse(
+                    status_code=401,
+                    content={"detail": "Invalid Telegram callback token"},
                 )
             return None
 

--- a/app/monitoring/trade_notifier/notifier.py
+++ b/app/monitoring/trade_notifier/notifier.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from app.services.hermes_client import ReviewTriggerPayload
@@ -16,9 +16,12 @@ from app.services.fill_notification import FillEnrichment, FillOrder
 from . import formatters_discord as fmt_discord
 from . import formatters_telegram as fmt_telegram
 from .transports import (
+    answer_callback_query,
+    edit_message_text,
     send_discord_content_single,
     send_discord_embed_single,
     send_telegram,
+    send_telegram_message,
 )
 from .types import DiscordEmbed
 
@@ -165,6 +168,56 @@ class TradeNotifier:
             chat_ids=self._chat_ids,
             text=message,
             parse_mode=parse_mode,
+        )
+
+    async def send_approval_message(
+        self,
+        text: str,
+        inline_keyboard: dict[str, Any],
+        *,
+        chat_id: str,
+    ) -> int | None:
+        """Send a Telegram approval message using the singleton HTTP client."""
+        if not self._http_client or not self._bot_token:
+            return None
+        return await send_telegram_message(
+            http_client=self._http_client,
+            bot_token=self._bot_token,
+            chat_id=chat_id,
+            text=text,
+            reply_markup=inline_keyboard,
+        )
+
+    async def answer_callback(
+        self, callback_query_id: str, text: str | None = None
+    ) -> bool:
+        """Acknowledge a Telegram callback using the singleton HTTP client."""
+        if not self._http_client or not self._bot_token:
+            return False
+        return await answer_callback_query(
+            http_client=self._http_client,
+            bot_token=self._bot_token,
+            callback_query_id=callback_query_id,
+            text=text,
+        )
+
+    async def edit_message(
+        self,
+        chat_id: str,
+        message_id: int,
+        text: str,
+        reply_markup: dict[str, Any] | None = None,
+    ) -> bool:
+        """Edit a Telegram message using the singleton HTTP client."""
+        if not self._http_client or not self._bot_token:
+            return False
+        return await edit_message_text(
+            http_client=self._http_client,
+            bot_token=self._bot_token,
+            chat_id=chat_id,
+            message_id=message_id,
+            text=text,
+            reply_markup=reply_markup,
         )
 
     async def _send_to_discord_embed_single(

--- a/app/monitoring/trade_notifier/transports.py
+++ b/app/monitoring/trade_notifier/transports.py
@@ -18,6 +18,7 @@ async def send_telegram(
     chat_ids: list[str],
     text: str,
     parse_mode: str = "Markdown",
+    reply_markup: dict[str, Any] | None = None,
 ) -> bool:
     """Send a message to multiple Telegram chat IDs.
 
@@ -33,13 +34,99 @@ async def send_telegram(
                 "parse_mode": parse_mode,
                 "disable_web_page_preview": True,
             }
+            if reply_markup is not None:
+                payload["reply_markup"] = reply_markup
             response = await http_client.post(url, json=payload)
             response.raise_for_status()
             any_success = True
-            logger.info(f"Telegram message sent to chat {chat_id}")
+            logger.info("Telegram message sent")
         except Exception:
-            logger.error(f"Failed to send Telegram message to chat {chat_id}")
+            logger.error("Failed to send Telegram message")
     return any_success
+
+
+async def send_telegram_message(
+    *,
+    http_client: httpx.AsyncClient,
+    bot_token: str,
+    chat_id: str,
+    text: str,
+    parse_mode: str = "Markdown",
+    reply_markup: dict[str, Any] | None = None,
+) -> int | None:
+    """Send one Telegram message and return its message ID on success."""
+    url = f"https://api.telegram.org/bot{bot_token}/sendMessage"
+    payload: dict[str, Any] = {
+        "chat_id": chat_id,
+        "text": text,
+        "parse_mode": parse_mode,
+        "disable_web_page_preview": True,
+    }
+    if reply_markup is not None:
+        payload["reply_markup"] = reply_markup
+
+    try:
+        response = await http_client.post(url, json=payload)
+        response.raise_for_status()
+        message_id = response.json().get("result", {}).get("message_id")
+        if isinstance(message_id, int):
+            logger.info("Telegram message sent")
+            return message_id
+    except Exception:
+        logger.error("Failed to send Telegram message")
+    return None
+
+
+async def answer_callback_query(
+    *,
+    http_client: httpx.AsyncClient,
+    bot_token: str,
+    callback_query_id: str,
+    text: str | None = None,
+) -> bool:
+    """Acknowledge a Telegram callback query."""
+    url = f"https://api.telegram.org/bot{bot_token}/answerCallbackQuery"
+    payload: dict[str, Any] = {"callback_query_id": callback_query_id}
+    if text is not None:
+        payload["text"] = text
+
+    try:
+        response = await http_client.post(url, json=payload)
+        response.raise_for_status()
+        return True
+    except Exception:
+        logger.error("Failed to answer Telegram callback query")
+        return False
+
+
+async def edit_message_text(
+    *,
+    http_client: httpx.AsyncClient,
+    bot_token: str,
+    chat_id: str,
+    message_id: int,
+    text: str,
+    parse_mode: str = "Markdown",
+    reply_markup: dict[str, Any] | None = None,
+) -> bool:
+    """Edit one Telegram message."""
+    url = f"https://api.telegram.org/bot{bot_token}/editMessageText"
+    payload: dict[str, Any] = {
+        "chat_id": chat_id,
+        "message_id": message_id,
+        "text": text,
+        "parse_mode": parse_mode,
+    }
+    if reply_markup is not None:
+        payload["reply_markup"] = reply_markup
+
+    try:
+        response = await http_client.post(url, json=payload)
+        response.raise_for_status()
+        return True
+    except Exception:
+        logger.error("Failed to edit Telegram message")
+        return False
 
 
 async def send_discord_embed_single(

--- a/app/routers/telegram_callback.py
+++ b/app/routers/telegram_callback.py
@@ -1,0 +1,72 @@
+"""ROB-816 PR 2 — Telegram webhook HTTP transport for order-proposal approvals.
+
+Wires the single Telegram webhook endpoint to
+``app.services.order_proposals.telegram_callback.handle_callback_update``
+(Task 14). Auth is delegated entirely to :class:`AuthMiddleware`, which
+gates every path under ``/trading/api/telegram/`` on the
+``ORDER_PROPOSALS_TELEGRAM_TOKEN`` shared secret supplied via Telegram's
+``secret_token`` webhook mechanism (header name configurable via
+``ORDER_PROPOSALS_TELEGRAM_TOKEN_HEADER``) — see
+``AuthMiddleware.TELEGRAM_CALLBACK_PATH_PREFIX``.
+
+Hard invariants:
+
+* Auth-gated by ``ORDER_PROPOSALS_TELEGRAM_TOKEN`` at the middleware
+  layer; an unconfigured token responds ``403``.
+* When ``settings.ORDER_PROPOSALS_TELEGRAM_ENABLED`` is off, the endpoint
+  short-circuits with ``503`` and a structured body — same shape as the
+  Hermes HTTP transport's gate-off (``investment_hermes_http.py``).
+* The chat allowlist (authz) lives inside ``handle_callback_update``
+  itself, not here.
+* ``handle_callback_update`` never raises (Task 14's fail-closed
+  guarantee), so this endpoint always returns ``200 {"ok": True}`` once
+  past the enable gate — Telegram's webhook contract only cares about the
+  HTTP status, not the body.
+* No broker/order mutation reachable from this router directly; every
+  safety boundary is enforced inside ``handle_callback_update``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, HTTPException, status
+
+from app.core.config import settings
+from app.core.timezone import now_kst
+from app.services.order_proposals.telegram_callback import handle_callback_update
+
+router = APIRouter(prefix="/trading/api/telegram", tags=["telegram-approval"])
+
+
+def _gate_off_503() -> HTTPException:
+    return HTTPException(
+        status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+        detail={
+            "error": "order_proposals_telegram_disabled",
+            "hint": (
+                "Set ORDER_PROPOSALS_TELEGRAM_ENABLED=true on the host to "
+                "enable the Telegram approval webhook endpoint."
+            ),
+        },
+    )
+
+
+def _require_enabled() -> None:
+    if not settings.ORDER_PROPOSALS_TELEGRAM_ENABLED:
+        raise _gate_off_503()
+
+
+@router.post("/callback")
+async def telegram_callback(body: dict[str, Any]) -> dict[str, Any]:
+    """Telegram webhook entrypoint for order-proposal approve/deny callbacks.
+
+    Accepts the raw Telegram ``Update`` payload as a permissive ``dict``
+    (Telegram's ``Update`` schema is large and evolving; this endpoint must
+    not reject updates on unknown/new fields). Always returns
+    ``{"ok": True}`` on 200 regardless of ``handle_callback_update``'s
+    internal result — Telegram only inspects the HTTP status.
+    """
+    _require_enabled()
+    await handle_callback_update(body, now=now_kst())
+    return {"ok": True}

--- a/app/services/order_proposals/approval_message.py
+++ b/app/services/order_proposals/approval_message.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 import re
 import uuid
 from collections.abc import Mapping, Sequence
@@ -18,7 +17,6 @@ _CALLBACK_PATTERN = re.compile(
     r"(?P<nonce>[A-Za-z0-9_-]+)$"
 )
 _MAX_CALLBACK_BYTES = 64
-_SENSITIVE_KEY_PARTS = ("hash", "nonce", "digest")
 _CASH_LABELS = (
     ("available_cash", "가용현금"),
     ("required_cash", "필요현금"),
@@ -97,8 +95,9 @@ def build_approval_message(
     title = "*주문 제안 재확인*" if diff else "*주문 제안 승인*"
     lines = [
         title,
-        f"- 종목: `{_escape_markdown(symbol)}`",
-        f"- 시장/방향/유형: `{market} / {side} / {order_type}`",
+        f"- 종목: `{_escape_inline_code(symbol)}`",
+        "- 시장/방향/유형: "
+        f"`{_escape_inline_code(f'{market} / {side} / {order_type}')}`",
         "",
         "*주문 단계*",
     ]
@@ -192,33 +191,24 @@ def _build_time_lines(group: Any) -> list[str]:
 
 def _build_cash_lines(cash_stress: Mapping, *, currency: str | None) -> list[str]:
     lines: list[str] = []
-    rendered_keys: set[str] = set()
-    requested_currency = cash_stress.get("currency") or currency
+    requested_currency = _supported_currency(cash_stress.get("currency")) or currency
 
     for key, label in _CASH_LABELS:
         if key not in cash_stress or cash_stress[key] is None:
             continue
-        rendered_keys.add(key)
         value = cash_stress[key]
-        rendered = (
-            f"{_format_decimal(value)}%"
-            if key.endswith("_pct")
-            else _format_money(value, currency=requested_currency)
-        )
-        lines.append(f"- {label}: {rendered}")
-
-    for raw_key in sorted(cash_stress, key=str):
-        key = str(raw_key)
-        if (
-            key in rendered_keys
-            or key == "currency"
-            or _is_sensitive_key(key)
-            or cash_stress[raw_key] is None
-        ):
+        if key.endswith("_pct"):
+            numeric = _format_numeric(value)
+            rendered = f"{numeric}%" if numeric is not None else None
+        else:
+            rendered = _format_money(
+                value,
+                currency=requested_currency,
+                none_label="",
+            )
+        if not rendered:
             continue
-        lines.append(
-            f"- {_escape_markdown(key)}: {_format_generic(cash_stress[raw_key])}"
-        )
+        lines.append(f"- {label}: {rendered}")
     return lines
 
 
@@ -227,7 +217,6 @@ def _format_diff_side(value: object, *, currency: str | None) -> str:
         return "미기재"
 
     parts: list[str] = []
-    used_keys: set[object] = set()
     for keys, label, formatter in (
         (("quantity", "qty", "normalized_quantity"), "수량", _format_decimal),
         (
@@ -238,14 +227,9 @@ def _format_diff_side(value: object, *, currency: str | None) -> str:
     ):
         key = next((candidate for candidate in keys if candidate in value), None)
         if key is not None:
-            used_keys.add(key)
-            parts.append(f"{label} {formatter(value[key])}")
-
-    for raw_key in sorted(value, key=str):
-        key = str(raw_key)
-        if raw_key in used_keys or _is_sensitive_key(key) or value[raw_key] is None:
-            continue
-        parts.append(f"{_escape_markdown(key)} {_format_generic(value[raw_key])}")
+            rendered = formatter(value[key])
+            if rendered != "미기재":
+                parts.append(f"{label} {rendered}")
     return " / ".join(parts) if parts else "미기재"
 
 
@@ -257,16 +241,21 @@ def _currency_for_market(*, market: str, symbol: str) -> str | None:
     return None
 
 
+def _supported_currency(value: object) -> str | None:
+    normalized = str(value).upper() if isinstance(value, str) else None
+    return normalized if normalized in {"KRW", "USD"} else None
+
+
 def _format_money(
     value: object,
     *,
     currency: object | None,
     none_label: str = "미기재",
 ) -> str:
-    if value is None:
+    amount = _format_numeric(value, grouping=True)
+    if amount is None:
         return none_label
-    amount = _format_decimal(value, grouping=True)
-    normalized_currency = str(currency).upper() if currency else None
+    normalized_currency = _supported_currency(currency)
     if normalized_currency == "KRW":
         return f"₩{amount}"
     if normalized_currency == "USD":
@@ -277,14 +266,18 @@ def _format_money(
 
 
 def _format_decimal(value: object, *, grouping: bool = False) -> str:
-    if value is None:
-        return "미기재"
+    return _format_numeric(value, grouping=grouping) or "미기재"
+
+
+def _format_numeric(value: object, *, grouping: bool = False) -> str | None:
+    if value is None or isinstance(value, bool):
+        return None
     try:
         number = Decimal(str(value))
     except (InvalidOperation, ValueError):
-        return _escape_markdown(value)
+        return None
     if not number.is_finite():
-        return _escape_markdown(value)
+        return None
 
     text = format(number, "f")
     if "." in text:
@@ -327,25 +320,12 @@ def _format_datetime(value: object, *, approximate: bool) -> str:
     return f"{prefix}{parsed:%H:%M} KST ({parsed:%Y-%m-%d})"
 
 
-def _format_generic(value: object) -> str:
-    if isinstance(value, datetime):
-        return _format_datetime(value, approximate=False)
-    if isinstance(value, (Decimal, int, float)) and not isinstance(value, bool):
-        return _format_decimal(value)
-    if isinstance(value, (Mapping, list, tuple)):
-        return _escape_markdown(
-            json.dumps(value, ensure_ascii=False, sort_keys=True, default=str)
-        )
-    return _escape_markdown(value)
-
-
-def _is_sensitive_key(key: str) -> bool:
-    normalized = key.casefold()
-    return any(part in normalized for part in _SENSITIVE_KEY_PARTS)
-
-
 def _escape_markdown(value: object) -> str:
     text = str(value)
     for character in ("\\", "`", "*", "_", "[", "]"):
         text = text.replace(character, f"\\{character}")
     return text
+
+
+def _escape_inline_code(value: object) -> str:
+    return str(value).replace("\\", "\\\\").replace("`", "\\`")

--- a/app/services/order_proposals/approval_message.py
+++ b/app/services/order_proposals/approval_message.py
@@ -1,0 +1,351 @@
+"""Pure Telegram approval-message and callback-data builders."""
+
+from __future__ import annotations
+
+import json
+import re
+import uuid
+from collections.abc import Mapping, Sequence
+from datetime import datetime
+from decimal import Decimal, InvalidOperation
+from typing import Any
+
+from app.core.timezone import KST
+
+_ALLOWED_ACTIONS = frozenset({"op", "dn"})
+_CALLBACK_PATTERN = re.compile(
+    r"^(?P<action>op|dn):(?P<proposal_short>[0-9a-f]{8}):"
+    r"(?P<nonce>[A-Za-z0-9_-]+)$"
+)
+_MAX_CALLBACK_BYTES = 64
+_SENSITIVE_KEY_PARTS = ("hash", "nonce", "digest")
+_CASH_LABELS = (
+    ("available_cash", "가용현금"),
+    ("required_cash", "필요현금"),
+    ("remaining_cash", "잔여현금"),
+    ("buffer_cash", "현금 버퍼"),
+    ("utilization_pct", "사용률"),
+)
+
+
+def build_callback_data(
+    *,
+    action: str,
+    proposal_id: uuid.UUID,
+    nonce: str,
+) -> str:
+    """Build compact Telegram callback data for an approval action."""
+    if action not in _ALLOWED_ACTIONS:
+        raise ValueError("action must be one of: op, dn")
+    if not isinstance(proposal_id, uuid.UUID):
+        raise ValueError("proposal_id must be a UUID")
+    if not isinstance(nonce, str) or not re.fullmatch(r"[A-Za-z0-9_-]+", nonce):
+        raise ValueError("nonce must be a non-empty URL-safe token")
+
+    data = f"{action}:{str(proposal_id)[:8]}:{nonce}"
+    if len(data.encode("utf-8")) > _MAX_CALLBACK_BYTES:
+        raise ValueError("callback data must not exceed 64 bytes")
+    return data
+
+
+def parse_callback_data(data: str) -> tuple[str, str, str]:
+    """Parse and validate compact Telegram approval callback data."""
+    if not isinstance(data, str) or len(data.encode("utf-8")) > _MAX_CALLBACK_BYTES:
+        raise ValueError("malformed callback data")
+    match = _CALLBACK_PATTERN.fullmatch(data)
+    if match is None:
+        raise ValueError("malformed callback data")
+    return (
+        match.group("action"),
+        match.group("proposal_short"),
+        match.group("nonce"),
+    )
+
+
+def build_approval_message(
+    *,
+    group: Any,
+    rungs: Sequence[Any],
+    cash_stress: dict | None = None,
+    diff: dict | None = None,
+) -> tuple[str, dict]:
+    """Render a proposal and its Telegram inline keyboard without raw digests."""
+    nonce = getattr(group, "approval_nonce", None)
+    if not nonce:
+        raise ValueError("group.approval_nonce is required")
+
+    proposal_id = getattr(group, "proposal_id", None)
+    approve_data = build_callback_data(
+        action="op",
+        proposal_id=proposal_id,
+        nonce=nonce,
+    )
+    deny_data = build_callback_data(
+        action="dn",
+        proposal_id=proposal_id,
+        nonce=nonce,
+    )
+
+    market = str(getattr(group, "market", "") or "미기재")
+    symbol = str(getattr(group, "symbol", "") or "미기재")
+    side = str(getattr(group, "side", "") or "미기재")
+    order_type = str(getattr(group, "order_type", "") or "미기재")
+    currency = _currency_for_market(market=market, symbol=symbol)
+    quantity_unit = "주" if market in {"equity_kr", "equity_us"} else ""
+    sorted_rungs = sorted(rungs, key=lambda rung: getattr(rung, "rung_index", 0))
+
+    title = "*주문 제안 재확인*" if diff else "*주문 제안 승인*"
+    lines = [
+        title,
+        f"- 종목: `{_escape_markdown(symbol)}`",
+        f"- 시장/방향/유형: `{market} / {side} / {order_type}`",
+        "",
+        "*주문 단계*",
+    ]
+    if sorted_rungs:
+        for rung in sorted_rungs:
+            display_index = int(getattr(rung, "rung_index", 0)) + 1
+            quantity = _format_decimal(getattr(rung, "quantity", None))
+            price = _format_money(
+                getattr(rung, "limit_price", None),
+                currency=currency,
+                none_label="시장가",
+            )
+            lines.append(f"- #{display_index}: {quantity}{quantity_unit} × {price}")
+    else:
+        lines.append("- 없음")
+
+    thesis = getattr(group, "thesis", None) or "미기재"
+    strategy = getattr(group, "strategy", None) or "미기재"
+    lines.extend(
+        [
+            "",
+            "*근거*",
+            f"- 투자 논지: {_escape_markdown(thesis)}",
+            f"- 전략: {_escape_markdown(strategy)}",
+        ]
+    )
+
+    time_lines = _build_time_lines(group)
+    if time_lines:
+        lines.extend(["", "*시간*", *time_lines])
+
+    if cash_stress:
+        cash_lines = _build_cash_lines(cash_stress, currency=currency)
+        if cash_lines:
+            lines.extend(["", "*현금 스트레스*", *cash_lines])
+
+    if diff:
+        before = diff.get("before") if isinstance(diff, Mapping) else None
+        after = diff.get("after") if isinstance(diff, Mapping) else None
+        lines.extend(
+            [
+                "",
+                "*재확인 변경사항*",
+                f"- 변경 전: {_format_diff_side(before, currency=currency)}",
+                f"- 변경 후: {_format_diff_side(after, currency=currency)}",
+            ]
+        )
+
+    text = "\n".join(lines)
+    secrets = [
+        getattr(group, "payload_hash", None),
+        getattr(group, "approval_hash", None),
+        nonce,
+        *(getattr(rung, "approval_hash_digest", None) for rung in sorted_rungs),
+    ]
+    for secret in secrets:
+        if secret:
+            text = text.replace(_escape_markdown(secret), "[비공개]")
+            text = text.replace(str(secret), "[비공개]")
+
+    inline_keyboard = {
+        "inline_keyboard": [
+            [
+                {"text": "✅ 승인", "callback_data": approve_data},
+                {"text": "❌ 거부", "callback_data": deny_data},
+            ]
+        ]
+    }
+    return text, inline_keyboard
+
+
+def _build_time_lines(group: Any) -> list[str]:
+    source_asof = getattr(group, "source_asof", None)
+    resting_deadline = (
+        source_asof.get("resting_deadline")
+        if isinstance(source_asof, Mapping)
+        else None
+    )
+    fields = (
+        ("유효기간", getattr(group, "valid_until", None), True),
+        ("검증시각", getattr(group, "validated_at", None), False),
+        ("제출 임대", getattr(group, "commit_lease_until", None), True),
+        ("주문 유지기한", resting_deadline, True),
+    )
+    return [
+        f"- {label}: {_format_datetime(value, approximate=approximate)}"
+        for label, value, approximate in fields
+        if _coerce_datetime(value) is not None
+    ]
+
+
+def _build_cash_lines(cash_stress: Mapping, *, currency: str | None) -> list[str]:
+    lines: list[str] = []
+    rendered_keys: set[str] = set()
+    requested_currency = cash_stress.get("currency") or currency
+
+    for key, label in _CASH_LABELS:
+        if key not in cash_stress or cash_stress[key] is None:
+            continue
+        rendered_keys.add(key)
+        value = cash_stress[key]
+        rendered = (
+            f"{_format_decimal(value)}%"
+            if key.endswith("_pct")
+            else _format_money(value, currency=requested_currency)
+        )
+        lines.append(f"- {label}: {rendered}")
+
+    for raw_key in sorted(cash_stress, key=str):
+        key = str(raw_key)
+        if (
+            key in rendered_keys
+            or key == "currency"
+            or _is_sensitive_key(key)
+            or cash_stress[raw_key] is None
+        ):
+            continue
+        lines.append(
+            f"- {_escape_markdown(key)}: {_format_generic(cash_stress[raw_key])}"
+        )
+    return lines
+
+
+def _format_diff_side(value: object, *, currency: str | None) -> str:
+    if not isinstance(value, Mapping):
+        return "미기재"
+
+    parts: list[str] = []
+    used_keys: set[object] = set()
+    for keys, label, formatter in (
+        (("quantity", "qty", "normalized_quantity"), "수량", _format_decimal),
+        (
+            ("limit_price", "price", "normalized_price"),
+            "가격",
+            lambda item: _format_money(item, currency=currency),
+        ),
+    ):
+        key = next((candidate for candidate in keys if candidate in value), None)
+        if key is not None:
+            used_keys.add(key)
+            parts.append(f"{label} {formatter(value[key])}")
+
+    for raw_key in sorted(value, key=str):
+        key = str(raw_key)
+        if raw_key in used_keys or _is_sensitive_key(key) or value[raw_key] is None:
+            continue
+        parts.append(f"{_escape_markdown(key)} {_format_generic(value[raw_key])}")
+    return " / ".join(parts) if parts else "미기재"
+
+
+def _currency_for_market(*, market: str, symbol: str) -> str | None:
+    if market == "equity_kr" or "KRW" in symbol.upper():
+        return "KRW"
+    if market == "equity_us":
+        return "USD"
+    return None
+
+
+def _format_money(
+    value: object,
+    *,
+    currency: object | None,
+    none_label: str = "미기재",
+) -> str:
+    if value is None:
+        return none_label
+    amount = _format_decimal(value, grouping=True)
+    normalized_currency = str(currency).upper() if currency else None
+    if normalized_currency == "KRW":
+        return f"₩{amount}"
+    if normalized_currency == "USD":
+        return f"${amount}"
+    if normalized_currency:
+        return f"{amount} {_escape_markdown(normalized_currency)}"
+    return amount
+
+
+def _format_decimal(value: object, *, grouping: bool = False) -> str:
+    if value is None:
+        return "미기재"
+    try:
+        number = Decimal(str(value))
+    except (InvalidOperation, ValueError):
+        return _escape_markdown(value)
+    if not number.is_finite():
+        return _escape_markdown(value)
+
+    text = format(number, "f")
+    if "." in text:
+        text = text.rstrip("0").rstrip(".")
+    if text in {"-0", ""}:
+        text = "0"
+    if not grouping:
+        return text
+
+    sign = ""
+    if text.startswith("-"):
+        sign, text = "-", text[1:]
+    integer, separator, fractional = text.partition(".")
+    grouped = f"{int(integer or '0'):,}"
+    if separator:
+        grouped = f"{grouped}.{fractional}"
+    return f"{sign}{grouped}"
+
+
+def _coerce_datetime(value: object) -> datetime | None:
+    if isinstance(value, datetime):
+        parsed = value
+    elif isinstance(value, str):
+        try:
+            parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError:
+            return None
+    else:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=KST)
+    return parsed.astimezone(KST)
+
+
+def _format_datetime(value: object, *, approximate: bool) -> str:
+    parsed = _coerce_datetime(value)
+    if parsed is None:
+        return "미기재"
+    prefix = "~" if approximate else ""
+    return f"{prefix}{parsed:%H:%M} KST ({parsed:%Y-%m-%d})"
+
+
+def _format_generic(value: object) -> str:
+    if isinstance(value, datetime):
+        return _format_datetime(value, approximate=False)
+    if isinstance(value, (Decimal, int, float)) and not isinstance(value, bool):
+        return _format_decimal(value)
+    if isinstance(value, (Mapping, list, tuple)):
+        return _escape_markdown(
+            json.dumps(value, ensure_ascii=False, sort_keys=True, default=str)
+        )
+    return _escape_markdown(value)
+
+
+def _is_sensitive_key(key: str) -> bool:
+    normalized = key.casefold()
+    return any(part in normalized for part in _SENSITIVE_KEY_PARTS)
+
+
+def _escape_markdown(value: object) -> str:
+    text = str(value)
+    for character in ("\\", "`", "*", "_", "[", "]"):
+        text = text.replace(character, f"\\{character}")
+    return text

--- a/app/services/order_proposals/dispatch.py
+++ b/app/services/order_proposals/dispatch.py
@@ -1,0 +1,92 @@
+"""Send the initial Telegram approval message for a proposal (ROB-816 PR 2).
+
+``send_proposal_for_approval`` is a top-level caller module, same as
+``telegram_callback.py`` -- it opens and COMMITS its own DB session rather
+than being constructor-injected, because it (a) is invoked from
+``order_proposal_create`` after that tool's own session has already closed
+and committed, and (b) calls the Telegram notifier, which
+``OrderProposalsService``/``OrderProposalRepository`` never do (they only
+flush -- see ``service.py``'s module docstring).
+
+Commit-before-notify is not a live risk here the way it is in
+``telegram_callback.py`` (there is no notify call *after* this function's
+mutating work), but the nonce mint + ``source_asof`` merge are still
+committed explicitly before returning, matching that module's established
+discipline rather than relying on implicit ``async with`` behavior.
+"""
+
+from __future__ import annotations
+
+import logging
+import secrets
+import uuid
+from collections.abc import Callable
+from datetime import datetime
+from typing import Any
+
+from app.core.config import settings
+from app.core.db import AsyncSessionLocal
+from app.services.order_proposals.approval_message import build_approval_message
+from app.services.order_proposals.service import OrderProposalsService
+
+logger = logging.getLogger(__name__)
+
+ServiceFactory = Callable[[], Any]
+
+
+def _generate_nonce() -> str:
+    # Duplicated from telegram_callback.py::_generate_nonce (2 lines) rather
+    # than imported -- that name is `_`-prefixed/module-private, and this
+    # module is a peer top-level caller, not a consumer of that module.
+    return secrets.token_urlsafe(12)
+
+
+async def send_proposal_for_approval(
+    proposal_id: uuid.UUID,
+    *,
+    notifier: Any,
+    now: datetime,
+    service_factory: ServiceFactory = AsyncSessionLocal,
+) -> int | None:
+    """Mint a fresh approval nonce, render the message, and send it.
+
+    Sends to the FIRST entry in
+    ``settings.order_proposals_telegram_chat_allowlist`` -- the return type
+    is a single ``int | None`` message_id, which only makes sense for a
+    single-chat send, not a broadcast. An empty allowlist is a no-op (no
+    nonce mint, no send, returns ``None``) -- callers (the MCP wiring) should
+    already gate on a non-empty allowlist before calling this, but this
+    function defends independently.
+    """
+    allowlist = settings.order_proposals_telegram_chat_allowlist
+    if not allowlist:
+        return None
+    chat_id = allowlist[0]
+
+    async with service_factory() as session:
+        service = OrderProposalsService(session)
+
+        fresh_nonce = _generate_nonce()
+        await service.set_approval_nonce(proposal_id, fresh_nonce)
+
+        group, rungs = await service.get_proposal(proposal_id)
+        text, keyboard = build_approval_message(group=group, rungs=rungs)
+
+        message_id = await notifier.send_approval_message(
+            text, keyboard, chat_id=chat_id
+        )
+
+        if message_id is not None:
+            await service.record_approval_dispatch(
+                proposal_id, message_id=message_id, chat_id=chat_id, now=now
+            )
+
+        # Commit explicitly before returning -- see module docstring. The
+        # nonce mint above is committed even when message_id is None (send
+        # failed): a fresh nonce with no message sent is not a correctness
+        # problem, it just means the operator can't approve yet.
+        await session.commit()
+        return message_id
+
+
+__all__ = ["send_proposal_for_approval"]

--- a/app/services/order_proposals/repository.py
+++ b/app/services/order_proposals/repository.py
@@ -12,6 +12,7 @@ from typing import Any
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm.attributes import flag_modified
 
 from app.models.order_proposals import OrderProposal, OrderProposalRung
 
@@ -60,6 +61,52 @@ class OrderProposalRepository:
             stmt = stmt.where(OrderProposal.lifecycle_state == lifecycle_state)
         return list((await self._session.execute(stmt)).scalars().all())
 
+    async def find_rung_by_evidence(
+        self,
+        *,
+        correlation_id: str | None,
+        broker_order_id: str | None,
+    ) -> tuple[uuid.UUID, OrderProposalRung] | None:
+        evidence = (
+            (OrderProposalRung.correlation_id, correlation_id),
+            (OrderProposalRung.broker_order_id, broker_order_id),
+        )
+        for column, value in evidence:
+            if value is None:
+                continue
+            stmt = (
+                select(OrderProposal.proposal_id, OrderProposalRung)
+                .join(
+                    OrderProposalRung,
+                    OrderProposalRung.proposal_pk == OrderProposal.id,
+                )
+                .where(column == value)
+                .order_by(OrderProposalRung.id)
+                .limit(1)
+            )
+            row = (await self._session.execute(stmt)).one_or_none()
+            if row is not None:
+                return row[0], row[1]
+        return None
+
+    async def list_local_stale_candidates(
+        self,
+    ) -> list[tuple[uuid.UUID, OrderProposalRung]]:
+        stmt = (
+            select(OrderProposal.proposal_id, OrderProposalRung)
+            .join(
+                OrderProposalRung,
+                OrderProposalRung.proposal_pk == OrderProposal.id,
+            )
+            .where(
+                OrderProposalRung.state == "pending_approval",
+                OrderProposalRung.broker_order_id.is_(None),
+            )
+            .order_by(OrderProposalRung.id)
+        )
+        rows = (await self._session.execute(stmt)).all()
+        return [(row[0], row[1]) for row in rows]
+
     async def update_group(self, group: OrderProposal, **fields: Any) -> OrderProposal:
         for k, v in fields.items():
             setattr(group, k, v)
@@ -71,5 +118,7 @@ class OrderProposalRepository:
     ) -> OrderProposalRung:
         for k, v in fields.items():
             setattr(rung, k, v)
+            if k == "updated_at":
+                flag_modified(rung, k)
         await self._session.flush()
         return rung

--- a/app/services/order_proposals/revalidation.py
+++ b/app/services/order_proposals/revalidation.py
@@ -1,0 +1,312 @@
+"""Fresh re-validation + submit orchestration for order_proposals (ROB-816 PR-2).
+
+``revalidate_and_submit`` is the click-time orchestrator: it re-runs the full
+guard chain (loss-sell, market-sell-loss, sector cap) via a fresh dry-run
+preview, mints a brand-new ``approval_hash`` (age ~0s — this is the
+server-internalized TTL that resolves the human-round-trip concern from
+ROB-815), compares the normalized wire price/qty against what the operator
+approved, and only submits when nothing has moved. All writes go through
+``OrderProposalsService`` — this module never touches the DB directly and
+never calls ``commit()`` (the caller owns the transaction, per the
+service-layer convention in ``service.py``).
+
+Principle #6 (accepted != filled): a broker ACK/resting confirmation is
+recorded via ``record_ack``/``record_resting`` — never as a fill.
+``record_fill_evidence`` is out of scope here; fills are booked later from
+broker evidence (reconcile), not from this click-time path.
+
+Principle #4 (never auto-void on ambiguity): a submit that raises, times out,
+or returns a response this orchestrator cannot classify is recorded via
+``record_unverified`` — never a terminal state.
+"""
+
+from __future__ import annotations
+
+import inspect
+import uuid
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import datetime
+from decimal import Decimal
+from typing import Any, Literal
+
+from app.core.timezone import now_kst
+from app.models.order_proposals import OrderProposal, OrderProposalRung
+from app.services.live_correlation import live_correlation_id
+from app.services.order_proposals.service import OrderProposalsService
+
+RungOutcomeResult = Literal[
+    "submitted_acked",
+    "submitted_resting",
+    "needs_reconfirm",
+    "guard_blocked",
+    "unverified",
+    "error",
+]
+
+
+@dataclass
+class RungOutcome:
+    rung_index: int
+    result: RungOutcomeResult
+    detail: dict[str, Any]
+
+
+PlaceOrderFn = Callable[..., Any]
+CorrelationMint = Callable[..., Any]
+
+_PREVIEW_REASON = "order_proposal revalidation (rung {rung})"
+_SUBMIT_REASON = "order_proposal submit after revalidation (rung {rung})"
+
+
+async def _maybe_await(value: Any) -> Any:
+    if inspect.isawaitable(value):
+        return await value
+    return value
+
+
+def _norm(value: Any) -> str | None:
+    """Canonical string form for a price/quantity value.
+
+    ``rung.limit_price``/``rung.quantity`` round-trip through a
+    ``NUMERIC(38, 12)`` column, so a freshly-fetched value like
+    ``Decimal("2226000.000000000000")`` must compare equal (and render
+    identically in the reconfirm diff) to a dry-run preview's
+    ``Decimal("2226000")``/"2226000" — Postgres pads to the declared scale,
+    the preview does not. Strip both to the same canonical fixed-point form
+    (no scientific notation, no trailing zeros) before comparing.
+    """
+    if value is None:
+        return None
+    if not isinstance(value, Decimal):
+        try:
+            value = Decimal(str(value))
+        except Exception:
+            return str(value)
+    text = format(value.normalize(), "f")
+    if "." in text:
+        text = text.rstrip("0").rstrip(".")
+    return text
+
+
+async def _default_place_order_fn(**kwargs: Any) -> dict[str, Any]:
+    """Production binding — delegates to the real order-execution impl.
+
+    Not exercised by this task's test suite (every test injects a fake
+    ``place_order_fn``; real broker/httpx calls are always mocked in tests
+    per the ROB-816 global constraints). Known gap: the live-submit
+    (``dry_run=False``) response shape returned by ``_execute_and_record``
+    inside ``_place_order_impl`` has not been confirmed to carry the
+    ``{status, broker_order_id, correlation_id, idempotency_key,
+    approval_hash_digest}`` contract this orchestrator classifies against —
+    see the Task 13 report for the follow-up needed before this default
+    binding can be trusted against a real broker response.
+    """
+    from app.mcp_server.tooling.order_execution import _place_order_impl
+
+    return await _place_order_impl(**kwargs)
+
+
+def _default_correlation_mint(
+    *, group: OrderProposal, rung: OrderProposalRung, now: datetime
+) -> str:
+    return live_correlation_id(
+        account_scope=group.account_mode,
+        symbol=group.symbol,
+        side=rung.side,
+        price=rung.limit_price if rung.limit_price is not None else Decimal("0"),
+        quantity=rung.quantity,
+        kst_trade_day=now_kst().strftime("%Y-%m-%d"),
+        rung=rung.rung_index,
+    )
+
+
+async def revalidate_and_submit(
+    *,
+    service: OrderProposalsService,
+    proposal_id: uuid.UUID,
+    now: datetime,
+    place_order_fn: PlaceOrderFn = _default_place_order_fn,
+    correlation_mint: CorrelationMint = _default_correlation_mint,
+) -> list[RungOutcome]:
+    """Revalidate + (maybe) submit every ``pending_approval`` rung.
+
+    Rungs not currently in ``pending_approval`` (already submitted, already
+    terminal, etc.) are skipped — they are not eligible to re-enter the
+    revalidation cycle from this call.
+    """
+    group, rungs = await service.get_proposal(proposal_id)
+    outcomes: list[RungOutcome] = []
+    for rung in rungs:
+        if rung.state != "pending_approval":
+            continue
+        outcomes.append(
+            await _revalidate_rung(
+                service=service,
+                group=group,
+                rung=rung,
+                now=now,
+                place_order_fn=place_order_fn,
+                correlation_mint=correlation_mint,
+            )
+        )
+    return outcomes
+
+
+async def _revalidate_rung(
+    *,
+    service: OrderProposalsService,
+    group: OrderProposal,
+    rung: OrderProposalRung,
+    now: datetime,
+    place_order_fn: PlaceOrderFn,
+    correlation_mint: CorrelationMint,
+) -> RungOutcome:
+    proposal_id = group.proposal_id
+    rung_index = rung.rung_index
+
+    await service.transition_rung(proposal_id, rung_index, new_state="revalidating")
+
+    preview = await _maybe_await(
+        place_order_fn(
+            dry_run=True,
+            symbol=group.symbol,
+            side=rung.side,
+            market=group.market,
+            order_type=group.order_type,
+            quantity=rung.quantity,
+            price=rung.limit_price,
+            thesis=group.thesis,
+            strategy=group.strategy,
+            reason=_PREVIEW_REASON.format(rung=rung_index),
+            rung=rung_index,
+        )
+    )
+
+    if preview.get("success") is False:
+        # Fail-closed: the guard chain (loss-sell / market-sell-loss / sector
+        # cap) blocked this rung. Retryable — back to pending_approval, never
+        # submitted.
+        await service.transition_rung(
+            proposal_id, rung_index, new_state="pending_approval"
+        )
+        return RungOutcome(
+            rung_index,
+            "guard_blocked",
+            {"error": preview.get("error"), "preview": preview},
+        )
+
+    before = {
+        "limit_price": _norm(rung.limit_price),
+        "quantity": _norm(rung.quantity),
+    }
+    after = {
+        "limit_price": _norm(preview.get("price")),
+        "quantity": _norm(preview.get("quantity")),
+    }
+    if before != after:
+        await service.mark_needs_reconfirm(proposal_id, rung_index, now=now)
+        return RungOutcome(
+            rung_index, "needs_reconfirm", {"before": before, "after": after}
+        )
+
+    await service.transition_rung(proposal_id, rung_index, new_state="approved")
+    await service.transition_rung(proposal_id, rung_index, new_state="submitting")
+
+    corr = await _maybe_await(correlation_mint(group=group, rung=rung, now=now))
+
+    try:
+        submit = await _maybe_await(
+            place_order_fn(
+                dry_run=False,
+                symbol=group.symbol,
+                side=rung.side,
+                market=group.market,
+                order_type=group.order_type,
+                quantity=rung.quantity,
+                price=rung.limit_price,
+                thesis=group.thesis,
+                strategy=group.strategy,
+                reason=_SUBMIT_REASON.format(rung=rung_index),
+                approval_hash=preview.get("approval_hash"),
+                rung=rung_index,
+                correlation_id=corr,
+            )
+        )
+    except Exception as exc:  # noqa: BLE001 - broker call; ambiguous, not a void
+        await service.record_unverified(
+            proposal_id, rung_index, reason=f"submit_exception:{exc}", now=now
+        )
+        return RungOutcome(rung_index, "unverified", {"error": str(exc)})
+
+    return await _classify_submit(
+        service=service,
+        proposal_id=proposal_id,
+        rung_index=rung_index,
+        preview=preview,
+        submit=submit,
+        corr=corr,
+        now=now,
+    )
+
+
+async def _classify_submit(
+    *,
+    service: OrderProposalsService,
+    proposal_id: uuid.UUID,
+    rung_index: int,
+    preview: dict[str, Any],
+    submit: dict[str, Any],
+    corr: str,
+    now: datetime,
+) -> RungOutcome:
+    success = submit.get("success")
+
+    if success is False:
+        # Explicit broker/guard rejection — not ambiguous, safe to terminalize.
+        await service.record_rejected(
+            proposal_id,
+            rung_index,
+            reason=str(submit.get("error") or "submit_rejected"),
+            now=now,
+        )
+        return RungOutcome(rung_index, "error", {"error": submit.get("error")})
+
+    if success is True:
+        status = submit.get("status")
+        broker_order_id = submit.get("broker_order_id")
+        if broker_order_id is not None and status in ("acked", "resting"):
+            correlation_id = submit.get("correlation_id") or corr
+            idempotency_key = submit.get("idempotency_key") or preview.get(
+                "idempotency_key"
+            )
+            approval_hash_digest = submit.get("approval_hash_digest") or preview.get(
+                "approval_hash"
+            )
+            record_fn = (
+                service.record_ack if status == "acked" else service.record_resting
+            )
+            await record_fn(
+                proposal_id,
+                rung_index,
+                broker_order_id=broker_order_id,
+                correlation_id=correlation_id,
+                idempotency_key=idempotency_key,
+                approval_hash_digest=approval_hash_digest,
+                now=now,
+            )
+            result: RungOutcomeResult = (
+                "submitted_acked" if status == "acked" else "submitted_resting"
+            )
+            return RungOutcome(rung_index, result, {"submit": submit})
+
+    # success is True but unrecognized status/missing broker_order_id, or
+    # success is missing entirely (neither True nor False) — ambiguous.
+    # Never auto-void on ambiguity (Principle #4).
+    await service.record_unverified(
+        proposal_id,
+        rung_index,
+        reason=f"ambiguous_submit_response:status={submit.get('status')!r}",
+        now=now,
+    )
+    return RungOutcome(rung_index, "unverified", {"submit": submit})

--- a/app/services/order_proposals/revalidation.py
+++ b/app/services/order_proposals/revalidation.py
@@ -89,22 +89,65 @@ def _norm(value: Any) -> str | None:
     return text
 
 
+def _adapt_live_submit_response(
+    submit: dict[str, Any], *, order_type: str
+) -> dict[str, Any]:
+    """Translate a real live-submit response into ``_classify_submit``'s shape.
+
+    The real ``_place_order_impl(dry_run=False)`` response (see
+    ``_record_kis_live_order`` in ``kis_live_ledger.py`` and
+    ``_record_live_order`` in ``live_order_ledger.py``) is accepted-only at
+    send: it carries ``broker_status in ("accepted", "rejected")`` and
+    ``order_id``/``correlation_id`` — never a synchronous acked-vs-resting
+    distinction, because that distinction doesn't exist in the broker's
+    real-time API contract (it's an order_proposals-internal concept; fills
+    are booked later by reconcile from broker evidence, per the KIS Live
+    Order Fill-Evidence Gate / US & Crypto Live Order Fill-Evidence Gate
+    design). Adapt the real shape into ``{status, broker_order_id}`` here so
+    ``_classify_submit``'s existing tested contract stays untouched.
+    """
+    broker_status = submit.get("broker_status")
+    if broker_status == "rejected":
+        adapted = dict(submit)
+        adapted["success"] = False
+        adapted["error"] = (
+            submit.get("response_message") or submit.get("message") or "broker_rejected"
+        )
+        return adapted
+    if broker_status == "accepted":
+        adapted = dict(submit)
+        adapted["broker_order_id"] = submit.get("order_id")
+        adapted["status"] = "acked" if order_type == "market" else "resting"
+        return adapted
+    # Defensive: unknown/missing broker_status shouldn't happen given
+    # `_derive_live_send_status` only ever returns "accepted"/"rejected", but
+    # leave the response untouched rather than raise — `_classify_submit`'s
+    # existing ambiguous-response fallback (`record_unverified`) still
+    # applies to whatever shape falls through here.
+    return submit
+
+
 async def _default_place_order_fn(**kwargs: Any) -> dict[str, Any]:
     """Production binding — delegates to the real order-execution impl.
 
     Not exercised by this task's test suite (every test injects a fake
     ``place_order_fn``; real broker/httpx calls are always mocked in tests
-    per the ROB-816 global constraints). Known gap: the live-submit
-    (``dry_run=False``) response shape returned by ``_execute_and_record``
-    inside ``_place_order_impl`` has not been confirmed to carry the
-    ``{status, broker_order_id, correlation_id, idempotency_key,
-    approval_hash_digest}`` contract this orchestrator classifies against —
-    see the Task 13 report for the follow-up needed before this default
-    binding can be trusted against a real broker response.
+    per the ROB-816 global constraints). The dry-run preview response is
+    passed through unchanged — ``_revalidate_rung`` already reads its real
+    top-level keys (``price``/``quantity``/``success``/``approval_hash``).
+    The live-submit (``dry_run=False``) response is translated via
+    ``_adapt_live_submit_response`` before being handed to
+    ``_classify_submit`` — see that helper's docstring and Task 13 report
+    Finding 1 for why the raw response can't be classified directly.
     """
     from app.mcp_server.tooling.order_execution import _place_order_impl
 
-    return await _place_order_impl(**kwargs)
+    submit = await _place_order_impl(**kwargs)
+    if kwargs.get("dry_run") is False:
+        return _adapt_live_submit_response(
+            submit, order_type=str(kwargs.get("order_type"))
+        )
+    return submit
 
 
 def _default_correlation_mint(
@@ -167,21 +210,31 @@ async def _revalidate_rung(
 
     await service.transition_rung(proposal_id, rung_index, new_state="revalidating")
 
-    preview = await _maybe_await(
-        place_order_fn(
-            dry_run=True,
-            symbol=group.symbol,
-            side=rung.side,
-            market=group.market,
-            order_type=group.order_type,
-            quantity=rung.quantity,
-            price=rung.limit_price,
-            thesis=group.thesis,
-            strategy=group.strategy,
-            reason=_PREVIEW_REASON.format(rung=rung_index),
-            rung=rung_index,
+    try:
+        preview = await _maybe_await(
+            place_order_fn(
+                dry_run=True,
+                symbol=group.symbol,
+                side=rung.side,
+                market=group.market,
+                order_type=group.order_type,
+                quantity=rung.quantity,
+                price=rung.limit_price,
+                thesis=group.thesis,
+                strategy=group.strategy,
+                reason=_PREVIEW_REASON.format(rung=rung_index),
+                rung=rung_index,
+            )
         )
-    )
+    except Exception as exc:  # noqa: BLE001 - preview never reached the broker
+        # Unlike a submit-phase exception, a preview-phase exception carries
+        # no ambiguity about broker state (nothing was sent) — safe and
+        # correct to make this retryable rather than parking it in a
+        # non-revisitable holding state (see Task 13 review Finding 3).
+        await service.transition_rung(
+            proposal_id, rung_index, new_state="pending_approval"
+        )
+        return RungOutcome(rung_index, "error", {"error": str(exc)})
 
     if preview.get("success") is False:
         # Fail-closed: the guard chain (loss-sell / market-sell-loss / sector
@@ -196,14 +249,24 @@ async def _revalidate_rung(
             {"error": preview.get("error"), "preview": preview},
         )
 
-    before = {
-        "limit_price": _norm(rung.limit_price),
-        "quantity": _norm(rung.quantity),
-    }
-    after = {
-        "limit_price": _norm(preview.get("price")),
-        "quantity": _norm(preview.get("quantity")),
-    }
+    # Market-order rungs have no `limit_price` by design (it's always None),
+    # but `_build_preview` always backfills `preview["price"]` with the live
+    # current price for market orders — comparing that against the stored
+    # `None` would deterministically mismatch on every attempt. Degrade the
+    # comparison to quantity-only for market-order rungs (Task 13 review
+    # Finding 2); limit-order rungs keep the full price+quantity comparison.
+    if rung.limit_price is None:
+        before = {"limit_price": None, "quantity": _norm(rung.quantity)}
+        after = {"limit_price": None, "quantity": _norm(preview.get("quantity"))}
+    else:
+        before = {
+            "limit_price": _norm(rung.limit_price),
+            "quantity": _norm(rung.quantity),
+        }
+        after = {
+            "limit_price": _norm(preview.get("price")),
+            "quantity": _norm(preview.get("quantity")),
+        }
     if before != after:
         await service.mark_needs_reconfirm(proposal_id, rung_index, now=now)
         return RungOutcome(

--- a/app/services/order_proposals/service.py
+++ b/app/services/order_proposals/service.py
@@ -38,6 +38,25 @@ class RungInput:
     notional: Decimal | None
 
 
+# (account_mode, market) combinations the submit path
+# (revalidation.py's `_default_place_order_fn` -> `_place_order_impl`) actually
+# routes correctly today. `_place_order_impl` has no `account_mode` parameter
+# at all -- it routes purely by `market` (crypto -> upbit, equity_kr/equity_us
+# -> KIS) and always submits with `is_mock=False` (live). Any other
+# account_mode (`kis_mock`, `toss_live`, `db_simulated`) would therefore be
+# silently submitted to LIVE KIS regardless of what the operator intended, or
+# routed to the wrong broker entirely. Reject those combinations at create
+# time rather than let a mock/paper/wrong-broker proposal ever reach the
+# submit path. See ROB-816 final-review Finding 1.
+_SUBMITTABLE_ACCOUNT_MODE_MARKETS: frozenset[tuple[str, str]] = frozenset(
+    {
+        ("kis_live", "equity_kr"),
+        ("kis_live", "equity_us"),
+        ("upbit", "crypto"),
+    }
+)
+
+
 class OrderProposalsService:
     def __init__(self, session: AsyncSession) -> None:
         self._session = session
@@ -65,6 +84,12 @@ class OrderProposalsService:
     ) -> OrderProposal:
         if not rungs:
             raise ValueError("at least one rung required")
+        if (account_mode, market) not in _SUBMITTABLE_ACCOUNT_MODE_MARKETS:
+            raise OrderProposalError(
+                f"account_mode {account_mode!r} is not submittable for market "
+                f"{market!r} (submit path only supports kis_live/equity_kr|"
+                "equity_us and upbit/crypto)"
+            )
         proposal_id = uuid.uuid4()
         root_id = proposal_id
         superseded_group: OrderProposal | None = None

--- a/app/services/order_proposals/service.py
+++ b/app/services/order_proposals/service.py
@@ -248,6 +248,21 @@ class OrderProposalsService:
             raise OrderProposalError("nonce_replay")
         return await self._repo.update_group(group, approval_nonce_used_at=now)
 
+    async def record_approval(
+        self,
+        proposal_id: uuid.UUID,
+        *,
+        telegram_user_id: str,
+        now: datetime,
+    ) -> OrderProposal:
+        self._require_timezone_aware(now)
+        group = await self._repo.get_group_by_proposal_id(proposal_id, for_update=True)
+        if group is None:
+            raise OrderProposalNotFound(str(proposal_id))
+        return await self._repo.update_group(
+            group, approved_by_telegram_user_id=telegram_user_id, approved_at=now
+        )
+
     async def acquire_commit_lease(
         self,
         proposal_id: uuid.UUID,

--- a/app/services/order_proposals/service.py
+++ b/app/services/order_proposals/service.py
@@ -6,17 +6,22 @@ and never commits — callers own the transaction (see global-constraints.md).
 
 from __future__ import annotations
 
+import inspect
 import uuid
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timedelta
 from decimal import Decimal
-from typing import Any
+from typing import Any, Literal
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.order_proposals import OrderProposal, OrderProposalRung
 from app.services.order_proposals import state_machine as sm
-from app.services.order_proposals.errors import OrderProposalNotFound
+from app.services.order_proposals.errors import (
+    OrderProposalError,
+    OrderProposalNotFound,
+)
 from app.services.order_proposals.payload import (
     ProposalRungSpec,
     compute_proposal_payload_hash,
@@ -158,6 +163,14 @@ class OrderProposalsService:
         new_state: str,
         **audit_fields: Any,
     ) -> OrderProposalRung:
+        group, rung = await self._get_locked_rung(proposal_id, rung_index)
+        return await self._transition_locked_rung(
+            group, rung, new_state=new_state, **audit_fields
+        )
+
+    async def _get_locked_rung(
+        self, proposal_id: uuid.UUID, rung_index: int
+    ) -> tuple[OrderProposal, OrderProposalRung]:
         group = await self._repo.get_group_by_proposal_id(proposal_id, for_update=True)
         if group is None:
             raise OrderProposalNotFound(str(proposal_id))
@@ -165,9 +178,18 @@ class OrderProposalsService:
         rung = next((r for r in rungs if r.rung_index == rung_index), None)
         if rung is None:
             raise OrderProposalNotFound(f"{proposal_id}#{rung_index}")
+        return group, rung
+
+    async def _transition_locked_rung(
+        self,
+        group: OrderProposal,
+        rung: OrderProposalRung,
+        *,
+        new_state: str,
+        **audit_fields: Any,
+    ) -> OrderProposalRung:
         sm.assert_rung_transition(rung.state, new_state)
         rung = await self._repo.update_rung(rung, state=new_state, **audit_fields)
-        # refresh rung list then recompute group rollup
         rungs = await self._repo.list_rungs(group.id)
         await self._repo.update_group(
             group, lifecycle_state=self._recompute_group_state(rungs)
@@ -205,36 +227,202 @@ class OrderProposalsService:
         return "proposed"
 
     # -- PR-2 helpers -------------------------------------------------------
-    # Stubs only. Task 12 (PR 2) fills these in with the Telegram approval
-    # flow, callback-nonce binding, commit-lease, and fill-evidence recording.
-    # Deliberately unimplemented in PR 1 (no Telegram, no broker mutation).
-
-    async def set_approval_nonce(self, *args: Any, **kwargs: Any) -> Any:
-        raise NotImplementedError("set_approval_nonce is implemented in PR 2 (ROB-816)")
-
-    async def consume_approval_nonce(self, *args: Any, **kwargs: Any) -> Any:
-        raise NotImplementedError(
-            "consume_approval_nonce is implemented in PR 2 (ROB-816)"
+    async def set_approval_nonce(self, proposal_id: uuid.UUID, nonce: str) -> None:
+        group = await self._repo.get_group_by_proposal_id(proposal_id, for_update=True)
+        if group is None:
+            raise OrderProposalNotFound(str(proposal_id))
+        await self._repo.update_group(
+            group, approval_nonce=nonce, approval_nonce_used_at=None
         )
 
-    async def acquire_commit_lease(self, *args: Any, **kwargs: Any) -> Any:
-        raise NotImplementedError(
-            "acquire_commit_lease is implemented in PR 2 (ROB-816)"
+    async def consume_approval_nonce(
+        self, proposal_id: uuid.UUID, nonce: str, *, now: datetime
+    ) -> OrderProposal:
+        self._require_timezone_aware(now)
+        group = await self._repo.get_group_by_proposal_id(proposal_id, for_update=True)
+        if group is None:
+            raise OrderProposalNotFound(str(proposal_id))
+        if group.approval_nonce != nonce:
+            raise OrderProposalError("nonce_mismatch")
+        if group.approval_nonce_used_at is not None:
+            raise OrderProposalError("nonce_replay")
+        return await self._repo.update_group(group, approval_nonce_used_at=now)
+
+    async def acquire_commit_lease(
+        self,
+        proposal_id: uuid.UUID,
+        *,
+        now: datetime,
+        lease_seconds: int = 10,
+    ) -> bool:
+        self._require_timezone_aware(now)
+        group = await self._repo.get_group_by_proposal_id(proposal_id, for_update=True)
+        if group is None:
+            raise OrderProposalNotFound(str(proposal_id))
+        lease_until = group.commit_lease_until
+        if lease_until is not None:
+            self._require_timezone_aware(lease_until)
+            if lease_until > now:
+                return False
+        await self._repo.update_group(
+            group, commit_lease_until=now + timedelta(seconds=lease_seconds)
+        )
+        return True
+
+    async def record_ack(
+        self,
+        proposal_id: uuid.UUID,
+        rung_index: int,
+        *,
+        broker_order_id: str,
+        correlation_id: str,
+        idempotency_key: str,
+        approval_hash_digest: str,
+        now: datetime,
+    ) -> OrderProposalRung:
+        self._require_timezone_aware(now)
+        return await self.transition_rung(
+            proposal_id,
+            rung_index,
+            new_state="acked",
+            broker_order_id=broker_order_id,
+            correlation_id=correlation_id,
+            idempotency_key=idempotency_key,
+            approval_hash_digest=approval_hash_digest,
+            validated_at=now,
+            updated_at=now,
         )
 
-    async def record_ack(self, *args: Any, **kwargs: Any) -> Any:
-        raise NotImplementedError("record_ack is implemented in PR 2 (ROB-816)")
-
-    async def record_resting(self, *args: Any, **kwargs: Any) -> Any:
-        raise NotImplementedError("record_resting is implemented in PR 2 (ROB-816)")
-
-    async def record_unverified(self, *args: Any, **kwargs: Any) -> Any:
-        raise NotImplementedError("record_unverified is implemented in PR 2 (ROB-816)")
-
-    async def record_fill_evidence(self, *args: Any, **kwargs: Any) -> Any:
-        raise NotImplementedError(
-            "record_fill_evidence is implemented in PR 2 (ROB-816)"
+    async def record_resting(
+        self,
+        proposal_id: uuid.UUID,
+        rung_index: int,
+        *,
+        broker_order_id: str,
+        correlation_id: str,
+        idempotency_key: str,
+        approval_hash_digest: str,
+        now: datetime,
+    ) -> OrderProposalRung:
+        self._require_timezone_aware(now)
+        return await self.transition_rung(
+            proposal_id,
+            rung_index,
+            new_state="resting",
+            broker_order_id=broker_order_id,
+            correlation_id=correlation_id,
+            idempotency_key=idempotency_key,
+            approval_hash_digest=approval_hash_digest,
+            validated_at=now,
+            updated_at=now,
         )
 
-    async def sweep_local_stale(self, *args: Any, **kwargs: Any) -> Any:
-        raise NotImplementedError("sweep_local_stale is implemented in PR 2 (ROB-816)")
+    async def record_unverified(
+        self,
+        proposal_id: uuid.UUID,
+        rung_index: int,
+        *,
+        reason: str,
+        now: datetime,
+    ) -> OrderProposalRung:
+        self._require_timezone_aware(now)
+        return await self.transition_rung(
+            proposal_id,
+            rung_index,
+            new_state="unverified",
+            void_reason=reason,
+            validated_at=now,
+            updated_at=now,
+        )
+
+    async def record_fill_evidence(
+        self,
+        *,
+        correlation_id: str | None = None,
+        broker_order_id: str | None = None,
+        filled_qty: Decimal,
+        terminal_state: Literal["filled", "partially_filled"] = "filled",
+        now: datetime,
+    ) -> OrderProposalRung | None:
+        self._require_timezone_aware(now)
+        match = await self._repo.find_rung_by_evidence(
+            correlation_id=correlation_id, broker_order_id=broker_order_id
+        )
+        if match is None:
+            return None
+        proposal_id, rung = match
+        return await self.transition_rung(
+            proposal_id,
+            rung.rung_index,
+            new_state=terminal_state,
+            filled_qty=filled_qty,
+            updated_at=now,
+        )
+
+    async def mark_needs_reconfirm(
+        self, proposal_id: uuid.UUID, rung_index: int, *, now: datetime
+    ) -> OrderProposalRung:
+        self._require_timezone_aware(now)
+        group, rung = await self._get_locked_rung(proposal_id, rung_index)
+        return await self._transition_locked_rung(
+            group,
+            rung,
+            new_state="needs_reconfirm",
+            approval_revision=(rung.approval_revision or 0) + 1,
+            validated_at=now,
+            updated_at=now,
+        )
+
+    async def record_rejected(
+        self,
+        proposal_id: uuid.UUID,
+        rung_index: int,
+        *,
+        reason: str,
+        now: datetime,
+    ) -> OrderProposalRung:
+        self._require_timezone_aware(now)
+        return await self.transition_rung(
+            proposal_id,
+            rung_index,
+            new_state="rejected",
+            void_reason=reason,
+            updated_at=now,
+        )
+
+    async def sweep_local_stale(
+        self,
+        *,
+        now: datetime,
+        broker_evidence: Callable[[OrderProposalRung], str | Awaitable[str]],
+    ) -> list[uuid.UUID]:
+        self._require_timezone_aware(now)
+        candidates = await self._repo.list_local_stale_candidates()
+        swept: list[uuid.UUID] = []
+        swept_set: set[uuid.UUID] = set()
+        for proposal_id, candidate in candidates:
+            evidence = broker_evidence(candidate)
+            if inspect.isawaitable(evidence):
+                evidence = await evidence
+            if evidence != "no_broker_order":
+                continue
+
+            group, rung = await self._get_locked_rung(proposal_id, candidate.rung_index)
+            if rung.state != "pending_approval" or rung.broker_order_id is not None:
+                continue
+            await self._transition_locked_rung(
+                group,
+                rung,
+                new_state="voided_local_stale",
+                void_reason="no_broker_order",
+                updated_at=now,
+            )
+            if proposal_id not in swept_set:
+                swept.append(proposal_id)
+                swept_set.add(proposal_id)
+        return swept
+
+    @staticmethod
+    def _require_timezone_aware(value: datetime) -> None:
+        if value.tzinfo is None or value.utcoffset() is None:
+            raise ValueError("datetime must be timezone-aware")

--- a/app/services/order_proposals/service.py
+++ b/app/services/order_proposals/service.py
@@ -263,6 +263,37 @@ class OrderProposalsService:
             group, approved_by_telegram_user_id=telegram_user_id, approved_at=now
         )
 
+    async def record_approval_dispatch(
+        self,
+        proposal_id: uuid.UUID,
+        *,
+        message_id: int,
+        chat_id: str,
+        now: datetime,
+    ) -> OrderProposal:
+        """Record where the initial Telegram approval message was sent.
+
+        No new column exists for this (see ``dispatch.py``'s module docstring)
+        -- ``message_id``/``chat_id``/``sent_at`` are merged into the existing
+        ``source_asof`` JSONB column so a later Telegram ``edit_message`` call
+        can find them. This merges on top of whatever keys are already there
+        (e.g. ``resting_deadline``, read by
+        ``approval_message.py::_build_time_lines``) rather than overwriting
+        the column outright.
+        """
+        self._require_timezone_aware(now)
+        group = await self._repo.get_group_by_proposal_id(proposal_id, for_update=True)
+        if group is None:
+            raise OrderProposalNotFound(str(proposal_id))
+        existing = group.source_asof or {}
+        merged = {
+            **existing,
+            "approval_message_id": message_id,
+            "approval_chat_id": chat_id,
+            "approval_sent_at": now.isoformat(),
+        }
+        return await self._repo.update_group(group, source_asof=merged)
+
     async def acquire_commit_lease(
         self,
         proposal_id: uuid.UUID,

--- a/app/services/order_proposals/telegram_callback.py
+++ b/app/services/order_proposals/telegram_callback.py
@@ -284,6 +284,22 @@ async def _handle_approve(
         proposal_id, telegram_user_id=telegram_user_id, now=now
     )
 
+    # A rung that came back `needs_reconfirm` on a previous approve click is
+    # NOT `pending_approval` -- `revalidate_and_submit` only re-enters rungs
+    # currently in `pending_approval` (see revalidation.py's module
+    # docstring). Without this transition, a second Approve click on the
+    # reconfirm message would find every rung still parked in
+    # `needs_reconfirm`, skip all of them, and silently no-op forever (ROB-816
+    # final-review Finding 2). `needs_reconfirm -> pending_approval` is
+    # already a legal transition in state_machine.py; nothing before this fix
+    # ever triggered it.
+    _current_group, current_rungs = await service.get_proposal(proposal_id)
+    for current_rung in current_rungs:
+        if current_rung.state == "needs_reconfirm":
+            await service.transition_rung(
+                proposal_id, current_rung.rung_index, new_state="pending_approval"
+            )
+
     outcomes: list[RungOutcome] = await revalidate_fn(
         service=service, proposal_id=proposal_id, now=now
     )
@@ -326,6 +342,21 @@ async def _handle_approve(
         new_message_id = await _safe_send_approval_message(
             notifier, text, keyboard, chat_id=str(chat_id)
         )
+        if new_message_id is not None:
+            # Mirror dispatch.py's send_proposal_for_approval: keep
+            # source_asof.approval_message_id pointing at the NEWEST
+            # outstanding Telegram message, not the original one from
+            # dispatch.py -- otherwise a later reader of source_asof would
+            # see a stale/superseded message_id for this reconfirm cycle
+            # (ROB-816 final-review Finding 4). A failed send
+            # (new_message_id is None) has nothing to persist.
+            await service.record_approval_dispatch(
+                proposal_id,
+                message_id=new_message_id,
+                chat_id=str(chat_id),
+                now=now,
+            )
+            await session.commit()
         await _safe_answer(notifier, callback_query_id, "재확인이 필요합니다")
         return {
             "handled": True,

--- a/app/services/order_proposals/telegram_callback.py
+++ b/app/services/order_proposals/telegram_callback.py
@@ -11,6 +11,18 @@ This module owns the DB session it opens via ``service_factory`` (default
 this handler is the top-level caller, same as any MCP tool handler in this
 codebase.
 
+Commit-before-notify ordering (load-bearing): each branch (``_handle_deny``,
+both branches of ``_handle_approve``, and the early-return paths) calls
+``session.commit()`` for its mutating work *before* making any Telegram
+``edit_message``/``send_approval_message`` call. A Telegram API failure
+(rate limit, "message not found", network blip) must never roll back a
+DB-recorded broker-order outcome -- nonce consumption, the commit lease,
+``record_approval``, and any acked/resting/unverified/rejected rung state
+from ``revalidate_and_submit`` are all committed first. All notify calls
+(``edit_message``/``send_approval_message``, in addition to the existing
+``answer_callback``) are themselves best-effort and never raise, as
+belt-and-suspenders on top of the commit ordering.
+
 Every broker/Telegram/DB dependency is injectable (``notifier``,
 ``revalidate_fn``, ``service_factory``) so tests can supply fakes; real
 broker/Telegram/httpx calls are never exercised by this module's test suite.
@@ -32,6 +44,8 @@ import uuid
 from collections.abc import Callable
 from datetime import datetime
 from typing import Any
+
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import settings
 from app.core.db import AsyncSessionLocal
@@ -93,6 +107,38 @@ async def _safe_answer(
         logger.exception("order_proposals telegram answer_callback failed")
 
 
+async def _safe_edit_message(
+    notifier: Any, chat_id: Any, message_id: int, text: str
+) -> None:
+    """Best-effort ``edit_message`` that never raises.
+
+    Belt-and-suspenders alongside the commit-before-notify ordering in
+    ``_handle_deny``/``_handle_approve``: by the time this is called the
+    mutating DB work for this branch is already committed, so a Telegram
+    failure here must not surface as an uncaught exception (which would hit
+    the top-level ``except Exception`` and misreport a successful trade
+    action as ``"internal_error"``).
+    """
+    try:
+        await notifier.edit_message(chat_id, message_id, text)
+    except Exception:  # noqa: BLE001 - best-effort, never propagate
+        logger.exception("order_proposals telegram edit_message failed")
+
+
+async def _safe_send_approval_message(
+    notifier: Any, text: str, keyboard: dict, *, chat_id: str
+) -> int | None:
+    """Best-effort ``send_approval_message`` that never raises.
+
+    See ``_safe_edit_message`` docstring for why this must never propagate.
+    """
+    try:
+        return await notifier.send_approval_message(text, keyboard, chat_id=chat_id)
+    except Exception:  # noqa: BLE001 - best-effort, never propagate
+        logger.exception("order_proposals telegram send_approval_message failed")
+        return None
+
+
 async def _resolve_proposal_id(service: Any, proposal_short: str) -> uuid.UUID | None:
     """Resolve a full ``proposal_id`` from its 8-char callback-data prefix.
 
@@ -127,8 +173,31 @@ def _build_result_summary(outcomes: list[RungOutcome]) -> str:
     return "\n".join(lines)
 
 
+def _build_extra_reconfirm_block(reconfirm_outcomes: list[RungOutcome]) -> str:
+    """Render before/after diffs for reconfirming rungs beyond the first.
+
+    ``build_approval_message`` only accepts a single ``diff`` and renders an
+    explicit before/after highlight for it (see
+    ``app/services/order_proposals/approval_message.py``) -- when more than
+    one rung in the same ``revalidate_and_submit`` batch comes back
+    ``needs_reconfirm``, every rung after the first would otherwise have no
+    visible before/after in the outgoing message. This composes a
+    supplementary block (in ``telegram_callback.py``, not inside
+    ``build_approval_message``, to keep that function's single-diff contract
+    unchanged) listing each remaining reconfirming rung's before/after.
+    """
+    lines = ["*추가 재확인 필요 단계*"]
+    for outcome in reconfirm_outcomes:
+        detail = outcome.detail or {}
+        before = detail.get("before")
+        after = detail.get("after")
+        lines.append(f"- #{outcome.rung_index + 1}: 변경 전 {before} → 변경 후 {after}")
+    return "\n".join(lines)
+
+
 async def _handle_deny(
     *,
+    session: AsyncSession,
     service: OrderProposalsService,
     proposal_id: uuid.UUID,
     nonce: str,
@@ -141,6 +210,11 @@ async def _handle_deny(
     try:
         await service.consume_approval_nonce(proposal_id, nonce, now=now)
     except OrderProposalError as exc:
+        # No mutation happened above (mismatch/replay both raise before any
+        # flush) -- commit anyway to release the row lock taken by
+        # `consume_approval_nonce`'s `for_update=True` SELECT before making
+        # the Telegram call below.
+        await session.commit()
         await _safe_answer(
             notifier, callback_query_id, "이미 처리되었거나 유효하지 않은 요청입니다"
         )
@@ -155,8 +229,12 @@ async def _handle_deny(
             )
             rejected_rungs.append(rung.rung_index)
 
+    # Commit the reject transitions before any Telegram call -- a notify
+    # failure below must never roll back an already-recorded deny.
+    await session.commit()
+
     if message_id is not None:
-        await notifier.edit_message(chat_id, message_id, "❌ 거부됨")
+        await _safe_edit_message(notifier, chat_id, message_id, "❌ 거부됨")
     await _safe_answer(notifier, callback_query_id, "거부되었습니다")
     return {
         "handled": True,
@@ -168,6 +246,7 @@ async def _handle_deny(
 
 async def _handle_approve(
     *,
+    session: AsyncSession,
     service: OrderProposalsService,
     proposal_id: uuid.UUID,
     nonce: str,
@@ -182,6 +261,9 @@ async def _handle_approve(
     try:
         await service.consume_approval_nonce(proposal_id, nonce, now=now)
     except OrderProposalError as exc:
+        # See `_handle_deny`'s matching comment: no mutation happened above,
+        # but commit anyway to release the row lock before the Telegram call.
+        await session.commit()
         await _safe_answer(
             notifier, callback_query_id, "이미 처리되었거나 유효하지 않은 요청입니다"
         )
@@ -189,6 +271,8 @@ async def _handle_approve(
 
     acquired = await service.acquire_commit_lease(proposal_id, now=now)
     if not acquired:
+        # Same rationale -- release the `for_update=True` lock before notify.
+        await session.commit()
         await _safe_answer(notifier, callback_query_id, "처리 중")
         return {
             "handled": False,
@@ -212,12 +296,35 @@ async def _handle_approve(
         text, keyboard = build_approval_message(
             group=group, rungs=rungs, diff=reconfirm_outcomes[0].detail
         )
+        # `build_approval_message` only renders an explicit diff for the
+        # first reconfirming rung -- surface every other reconfirming rung's
+        # before/after here so a multi-rung reconfirm batch never silently
+        # drops a rung's change (Finding 2, gap #1).
+        if len(reconfirm_outcomes) > 1:
+            text = f"{text}\n\n{_build_extra_reconfirm_block(reconfirm_outcomes[1:])}"
+        # Rungs in the same batch that did NOT come back `needs_reconfirm`
+        # (e.g. one rung submitted while another needs reconfirmation) would
+        # otherwise never be reported anywhere, since this branch
+        # short-circuits before `_build_result_summary` runs below (Finding
+        # 2, gap #2).
+        other_outcomes = [o for o in outcomes if o.result != "needs_reconfirm"]
+        if other_outcomes:
+            text = f"{text}\n\n{_build_result_summary(other_outcomes)}"
+
+        # Commit the fresh nonce + record_approval + revalidate_and_submit's
+        # rung-state transitions before any Telegram call -- a notify
+        # failure below must never roll back real broker-order evidence.
+        await session.commit()
+
         if message_id is not None:
-            await notifier.edit_message(
-                chat_id, message_id, "⚠️ 재확인 필요 — 아래 새 메시지를 확인해 주세요."
+            await _safe_edit_message(
+                notifier,
+                chat_id,
+                message_id,
+                "⚠️ 재확인 필요 — 아래 새 메시지를 확인해 주세요.",
             )
-        new_message_id = await notifier.send_approval_message(
-            text, keyboard, chat_id=str(chat_id)
+        new_message_id = await _safe_send_approval_message(
+            notifier, text, keyboard, chat_id=str(chat_id)
         )
         await _safe_answer(notifier, callback_query_id, "재확인이 필요합니다")
         return {
@@ -228,8 +335,14 @@ async def _handle_approve(
         }
 
     summary = _build_result_summary(outcomes)
+
+    # Commit record_approval + revalidate_and_submit's rung-state
+    # transitions (acked/resting/unverified/rejected) before any Telegram
+    # call -- same rationale as the reconfirm branch above.
+    await session.commit()
+
     if message_id is not None:
-        await notifier.edit_message(chat_id, message_id, summary)
+        await _safe_edit_message(notifier, chat_id, message_id, summary)
     await _safe_answer(notifier, callback_query_id, "처리되었습니다")
     return {
         "handled": True,
@@ -291,6 +404,7 @@ async def handle_callback_update(
 
             if action == "dn":
                 result = await _handle_deny(
+                    session=session,
                     service=service,
                     proposal_id=proposal_id,
                     nonce=nonce,
@@ -302,6 +416,7 @@ async def handle_callback_update(
                 )
             else:
                 result = await _handle_approve(
+                    session=session,
                     service=service,
                     proposal_id=proposal_id,
                     nonce=nonce,
@@ -315,7 +430,10 @@ async def handle_callback_update(
                     ),
                     revalidate_fn=revalidate_fn,
                 )
-            await session.commit()
+            # `_handle_deny`/`_handle_approve` each commit their own
+            # mutating work internally before making any Telegram notify
+            # call (see module docstring: commit-before-notify ordering) --
+            # no end-of-function commit here.
             return result
     except Exception:  # noqa: BLE001 - fail-closed webhook contract
         logger.exception("order_proposals telegram callback handling failed")

--- a/app/services/order_proposals/telegram_callback.py
+++ b/app/services/order_proposals/telegram_callback.py
@@ -1,0 +1,325 @@
+"""Telegram callback-query handler for order_proposals approvals (ROB-816 PR 2).
+
+Orchestrates the whole click-to-submit flow for a single Telegram webhook
+update: chat-allowlist authz -> callback-data parse -> short-prefix proposal
+resolution -> nonce replay guard -> commit lease -> approve/deny dispatch ->
+fresh re-validate & submit -> Telegram message update.
+
+This module owns the DB session it opens via ``service_factory`` (default
+``AsyncSessionLocal``) and DOES commit -- unlike ``OrderProposalsService``/
+``OrderProposalRepository``, which only flush and never commit -- because
+this handler is the top-level caller, same as any MCP tool handler in this
+codebase.
+
+Every broker/Telegram/DB dependency is injectable (``notifier``,
+``revalidate_fn``, ``service_factory``) so tests can supply fakes; real
+broker/Telegram/httpx calls are never exercised by this module's test suite.
+
+Principle #5 (nonce replay prevention is load-bearing): ``consume_approval_nonce``
+is always called -- and its exceptions handled -- before any other mutation in
+both the approve and deny branches.
+
+``handle_callback_update`` never raises: Telegram's webhook contract expects a
+response for every update, so any unexpected exception is caught, logged, and
+turned into a best-effort ``answer_callback`` + a failure result dict.
+"""
+
+from __future__ import annotations
+
+import logging
+import secrets
+import uuid
+from collections.abc import Callable
+from datetime import datetime
+from typing import Any
+
+from app.core.config import settings
+from app.core.db import AsyncSessionLocal
+from app.services.order_proposals.approval_message import (
+    build_approval_message,
+    parse_callback_data,
+)
+from app.services.order_proposals.errors import OrderProposalError
+from app.services.order_proposals.revalidation import (
+    RungOutcome,
+    revalidate_and_submit,
+)
+from app.services.order_proposals.service import OrderProposalsService
+
+logger = logging.getLogger(__name__)
+
+ServiceFactory = Callable[[], Any]
+RevalidateFn = Callable[..., Any]
+
+# Rung states from which a direct transition to "rejected" is legal (see
+# app/services/order_proposals/state_machine.py). A Telegram deny only ever
+# acts on rungs that are still awaiting/undergoing submission -- rungs already
+# past "submitting" (acked/resting/partially_filled) cannot be rejected
+# directly and are left untouched by this handler.
+_DENY_REJECTABLE_STATES = frozenset(
+    {"pending_approval", "needs_reconfirm", "submitting", "unverified"}
+)
+
+_CANDIDATE_POOL_LIMIT = 200
+
+_RESULT_LABELS: dict[str, str] = {
+    "submitted_acked": "체결 대기(접수)",
+    "submitted_resting": "주문 유지(대기)",
+    "guard_blocked": "가드에 의해 차단됨",
+    "unverified": "확인 불가(수동 확인 필요)",
+    "error": "오류",
+    "needs_reconfirm": "재확인 필요",
+}
+
+
+def _generate_nonce() -> str:
+    return secrets.token_urlsafe(12)
+
+
+async def _safe_answer(
+    notifier: Any, callback_query_id: str | None, text: str | None = None
+) -> None:
+    """Best-effort ``answer_callback`` that never raises.
+
+    Used both on the happy/known-failure paths and from the top-level
+    exception handler, where a second failure (e.g. the notifier itself
+    raising) must not crash the handler.
+    """
+    if not callback_query_id:
+        return
+    try:
+        await notifier.answer_callback(callback_query_id, text)
+    except Exception:  # noqa: BLE001 - best-effort, never propagate
+        logger.exception("order_proposals telegram answer_callback failed")
+
+
+async def _resolve_proposal_id(service: Any, proposal_short: str) -> uuid.UUID | None:
+    """Resolve a full ``proposal_id`` from its 8-char callback-data prefix.
+
+    ``pending_approval``/``needs_reconfirm`` are rung-level states, not valid
+    group-level ``lifecycle_state`` values (see state_machine.GROUP_STATES) --
+    the group rollup currently buckets all of those (plus "unverified") into
+    "proposed" (see ``OrderProposalsService._recompute_group_state``). So the
+    candidate pool is fetched by group lifecycle_state="proposed" and then
+    filtered in Python by prefix. Zero or multiple matches are both treated
+    as an unresolved reference -- fail closed rather than guess.
+    """
+    candidates = await service.list_recent(
+        lifecycle_state="proposed", limit=_CANDIDATE_POOL_LIMIT
+    )
+    matches = [
+        group.proposal_id
+        for group, _rungs in candidates
+        if str(group.proposal_id).startswith(proposal_short)
+    ]
+    if len(matches) != 1:
+        return None
+    return matches[0]
+
+
+def _build_result_summary(outcomes: list[RungOutcome]) -> str:
+    if not outcomes:
+        return "처리할 대기 단계가 없습니다."
+    lines = ["*처리 결과*"]
+    for outcome in outcomes:
+        label = _RESULT_LABELS.get(outcome.result, outcome.result)
+        lines.append(f"- #{outcome.rung_index + 1}: {label}")
+    return "\n".join(lines)
+
+
+async def _handle_deny(
+    *,
+    service: OrderProposalsService,
+    proposal_id: uuid.UUID,
+    nonce: str,
+    now: datetime,
+    notifier: Any,
+    chat_id: Any,
+    message_id: int | None,
+    callback_query_id: str | None,
+) -> dict[str, Any]:
+    try:
+        await service.consume_approval_nonce(proposal_id, nonce, now=now)
+    except OrderProposalError as exc:
+        await _safe_answer(
+            notifier, callback_query_id, "이미 처리되었거나 유효하지 않은 요청입니다"
+        )
+        return {"handled": False, "reason": str(exc), "proposal_id": str(proposal_id)}
+
+    _group, rungs = await service.get_proposal(proposal_id)
+    rejected_rungs: list[int] = []
+    for rung in rungs:
+        if rung.state in _DENY_REJECTABLE_STATES:
+            await service.record_rejected(
+                proposal_id, rung.rung_index, reason="telegram_deny", now=now
+            )
+            rejected_rungs.append(rung.rung_index)
+
+    if message_id is not None:
+        await notifier.edit_message(chat_id, message_id, "❌ 거부됨")
+    await _safe_answer(notifier, callback_query_id, "거부되었습니다")
+    return {
+        "handled": True,
+        "reason": "denied",
+        "proposal_id": str(proposal_id),
+        "rejected_rungs": rejected_rungs,
+    }
+
+
+async def _handle_approve(
+    *,
+    service: OrderProposalsService,
+    proposal_id: uuid.UUID,
+    nonce: str,
+    now: datetime,
+    notifier: Any,
+    chat_id: Any,
+    message_id: int | None,
+    callback_query_id: str | None,
+    telegram_user_id: str,
+    revalidate_fn: RevalidateFn,
+) -> dict[str, Any]:
+    try:
+        await service.consume_approval_nonce(proposal_id, nonce, now=now)
+    except OrderProposalError as exc:
+        await _safe_answer(
+            notifier, callback_query_id, "이미 처리되었거나 유효하지 않은 요청입니다"
+        )
+        return {"handled": False, "reason": str(exc), "proposal_id": str(proposal_id)}
+
+    acquired = await service.acquire_commit_lease(proposal_id, now=now)
+    if not acquired:
+        await _safe_answer(notifier, callback_query_id, "처리 중")
+        return {
+            "handled": False,
+            "reason": "lease_held",
+            "proposal_id": str(proposal_id),
+        }
+
+    await service.record_approval(
+        proposal_id, telegram_user_id=telegram_user_id, now=now
+    )
+
+    outcomes: list[RungOutcome] = await revalidate_fn(
+        service=service, proposal_id=proposal_id, now=now
+    )
+
+    reconfirm_outcomes = [o for o in outcomes if o.result == "needs_reconfirm"]
+    if reconfirm_outcomes:
+        fresh_nonce = _generate_nonce()
+        await service.set_approval_nonce(proposal_id, fresh_nonce)
+        group, rungs = await service.get_proposal(proposal_id)
+        text, keyboard = build_approval_message(
+            group=group, rungs=rungs, diff=reconfirm_outcomes[0].detail
+        )
+        if message_id is not None:
+            await notifier.edit_message(
+                chat_id, message_id, "⚠️ 재확인 필요 — 아래 새 메시지를 확인해 주세요."
+            )
+        new_message_id = await notifier.send_approval_message(
+            text, keyboard, chat_id=str(chat_id)
+        )
+        await _safe_answer(notifier, callback_query_id, "재확인이 필요합니다")
+        return {
+            "handled": True,
+            "reason": "needs_reconfirm",
+            "proposal_id": str(proposal_id),
+            "new_message_id": new_message_id,
+        }
+
+    summary = _build_result_summary(outcomes)
+    if message_id is not None:
+        await notifier.edit_message(chat_id, message_id, summary)
+    await _safe_answer(notifier, callback_query_id, "처리되었습니다")
+    return {
+        "handled": True,
+        "reason": "approved",
+        "proposal_id": str(proposal_id),
+        "results": [outcome.result for outcome in outcomes],
+    }
+
+
+async def handle_callback_update(
+    update: dict[str, Any],
+    *,
+    now: datetime,
+    service_factory: ServiceFactory = AsyncSessionLocal,
+    notifier: Any = None,
+    revalidate_fn: RevalidateFn = revalidate_and_submit,
+) -> dict[str, Any]:
+    """Handle one Telegram webhook update. Never raises (fail-closed)."""
+    callback_query_id: str | None = None
+    active_notifier = notifier
+    try:
+        if active_notifier is None:
+            from app.monitoring.trade_notifier.notifier import get_trade_notifier
+
+            active_notifier = get_trade_notifier()
+
+        callback_query = update.get("callback_query")
+        if not isinstance(callback_query, dict):
+            return {"handled": False, "reason": "not_callback"}
+
+        callback_query_id = callback_query.get("id")
+        message = callback_query.get("message") or {}
+        chat = message.get("chat") or {}
+        chat_id = chat.get("id")
+        message_id = message.get("message_id")
+        from_user = callback_query.get("from") or {}
+        telegram_user_id = from_user.get("id")
+        data = callback_query.get("data")
+
+        if str(chat_id) not in settings.order_proposals_telegram_chat_allowlist:
+            await _safe_answer(active_notifier, callback_query_id, "허용되지 않은 채팅")
+            return {"handled": False, "reason": "chat_not_allowed"}
+
+        try:
+            action, proposal_short, nonce = parse_callback_data(data)
+        except ValueError:
+            await _safe_answer(active_notifier, callback_query_id, "잘못된 요청입니다")
+            return {"handled": False, "reason": "malformed_callback_data"}
+
+        async with service_factory() as session:
+            service = OrderProposalsService(session)
+            proposal_id = await _resolve_proposal_id(service, proposal_short)
+            if proposal_id is None:
+                await session.commit()
+                await _safe_answer(
+                    active_notifier, callback_query_id, "제안을 찾을 수 없습니다"
+                )
+                return {"handled": False, "reason": "proposal_not_found"}
+
+            if action == "dn":
+                result = await _handle_deny(
+                    service=service,
+                    proposal_id=proposal_id,
+                    nonce=nonce,
+                    now=now,
+                    notifier=active_notifier,
+                    chat_id=chat_id,
+                    message_id=message_id,
+                    callback_query_id=callback_query_id,
+                )
+            else:
+                result = await _handle_approve(
+                    service=service,
+                    proposal_id=proposal_id,
+                    nonce=nonce,
+                    now=now,
+                    notifier=active_notifier,
+                    chat_id=chat_id,
+                    message_id=message_id,
+                    callback_query_id=callback_query_id,
+                    telegram_user_id=(
+                        str(telegram_user_id) if telegram_user_id is not None else ""
+                    ),
+                    revalidate_fn=revalidate_fn,
+                )
+            await session.commit()
+            return result
+    except Exception:  # noqa: BLE001 - fail-closed webhook contract
+        logger.exception("order_proposals telegram callback handling failed")
+        await _safe_answer(
+            active_notifier, callback_query_id, "처리 중 오류가 발생했습니다"
+        )
+        return {"handled": False, "reason": "internal_error"}

--- a/docs/runbooks/order-proposals.md
+++ b/docs/runbooks/order-proposals.md
@@ -62,9 +62,12 @@ See the full design in
 - **Nonce replay defense.** Every Telegram button click must present the
   `approval_nonce` currently stored on the group row; `consume_approval_nonce`
   (`app/services/order_proposals/service.py`) takes a `for_update=True` row
-  lock and raises `OrderProposalError("nonce_replay")` on a stale/mismatched
-  nonce — so a double-tap, a stale cached message, or a replayed callback can
-  never re-trigger approval/deny.
+  lock and raises `OrderProposalError("nonce_mismatch")` on a stale nonce (a
+  newer message already minted a different one) or `OrderProposalError(
+  "nonce_replay")` on an already-consumed nonce (a double-tap or replayed
+  callback) — so neither a stale cached message nor a duplicate callback can
+  ever re-trigger approval/deny. See Troubleshooting for the two error
+  strings.
 - **Chat allowlist (authz, separate from the webhook secret).**
   `handle_callback_update` rejects any callback whose `chat.id` is not in
   `settings.order_proposals_telegram_chat_allowlist`
@@ -400,8 +403,10 @@ submitted blind would defeat the entire point of a human-approval gate.
    matches → unresolved) rather than guessing.
 3. **Nonce replay guard.** `consume_approval_nonce` takes a row lock
    (`for_update=True`) and marks the nonce used; a second click with the
-   same nonce, or a click after a fresh nonce has already been minted (e.g.
-   a `NEEDS_RECONFIRM` cycle), raises `nonce_replay`.
+   same already-consumed nonce raises `nonce_replay`, and a click after a
+   fresh nonce has already been minted for a newer message (e.g. a
+   `NEEDS_RECONFIRM` cycle) raises `nonce_mismatch` — see Troubleshooting
+   for the distinction.
 4. **Commit lease.** For approve only, `acquire_commit_lease` takes a
    short-lived (`lease_seconds=10` default) in-flight lock on the group row
    — this is what prevents a double-tap on the approve button (two Telegram
@@ -665,19 +670,30 @@ because the callback's `chat.id` is not in
 failure — the webhook secret token check already passed by the time this
 fires.
 
+### `nonce_mismatch`
+
+`consume_approval_nonce` raised `OrderProposalError("nonce_mismatch")` — the
+`nonce` embedded in the clicked button's callback data does not equal the
+row's *current* `order_proposals.approval_nonce` value. Expected and correct
+when clicking a button on a Telegram message that has since been superseded
+by a fresh message minting a new nonce — either a `NEEDS_RECONFIRM` resend
+(`telegram_callback.py`'s reconfirm branch) or a brand-new
+`send_proposal_for_approval` dispatch (`dispatch.py`) for the same proposal.
+The old message's buttons are stale by design; approve/deny only the most
+recent message for a given proposal.
+
 ### `nonce_replay`
 
 `consume_approval_nonce` raised `OrderProposalError("nonce_replay")` — the
-`nonce` embedded in the clicked button's callback data no longer matches
-`order_proposals.approval_nonce` on that row. Expected and correct in three
-cases: (1) a genuine double-tap/duplicate Telegram update for the same
-click, (2) clicking a button on a Telegram message that has since been
-superseded by a fresh `NEEDS_RECONFIRM` message (which mints a new nonce —
-the old message's buttons are now stale by design), (3) clicking an already-
-approved/denied proposal's old message again. If none of those explain it,
-check whether something outside the Telegram flow called
-`set_approval_nonce`/`consume_approval_nonce` directly (should never happen
-outside `dispatch.py`/`telegram_callback.py`).
+clicked nonce *does* match `order_proposals.approval_nonce`, but
+`approval_nonce_used_at` is already set (that nonce was already consumed).
+Expected and correct in two cases: (1) a genuine double-tap/duplicate
+Telegram update delivery for the same click, (2) clicking an already-
+approved/denied proposal's message again (approve/deny does not mint a new
+nonce on that message, so its buttons remain clickable but inert). If
+neither explains it, check whether something outside the Telegram flow
+called `set_approval_nonce`/`consume_approval_nonce` directly (should never
+happen outside `dispatch.py`/`telegram_callback.py`).
 
 ### `NEEDS_RECONFIRM` loop (a rung keeps coming back needs_reconfirm)
 

--- a/docs/runbooks/order-proposals.md
+++ b/docs/runbooks/order-proposals.md
@@ -10,12 +10,24 @@ persisted, replayable record: one `order_proposals` row per proposal group
 `order_proposal_rungs` child rows (one per execution ladder rung — price/qty
 pair) tracking each rung's own execution lifecycle independently.
 
-This is **PR 1** of ROB-816: data model + pure state machine + service +
-three read/create MCP tools. It intentionally ships with:
+This runbook covers both halves of ROB-816, currently split across two PRs:
 
-- No Telegram approval surface (PR 2).
-- No submit/approve MCP tool — there is no path from a proposal row to a live
-  broker order in this PR.
+- **PR 1** — data model + pure state machine + service + three read/create
+  MCP tools (`order_proposal_create`/`get`/`list`). OPEN at
+  [github.com/mgh3326/auto_trader/pull/1490](https://github.com/mgh3326/auto_trader/pull/1490),
+  **not yet merged.**
+- **PR 2** — the Telegram button-approval flow documented in the
+  "Telegram Approval" sections below (bot setup, webhook receiver,
+  click-time revalidation, safety boundaries, live smoke, troubleshooting,
+  evidence template). Opened as a follow-up PR off the same branch, also
+  **not yet merged.**
+
+Both PRs are pending plan-author review. Nothing described here is deployed
+or running in production yet — this runbook documents functionality that
+exists on the `rob-816` branch, not (yet) on `main`. There is still **no**
+`order_proposal_approve` / `order_proposal_submit` MCP tool in either PR —
+the only path from a proposal row to a live broker order is the Telegram
+button flow described below.
 
 See the full design in
 [`docs/plans/2026-07-10-rob-816-order-proposals-telegram-approval-implementation-plan.md`](../plans/2026-07-10-rob-816-order-proposals-telegram-approval-implementation-plan.md).
@@ -33,10 +45,38 @@ See the full design in
   persists a row describing an intended order; it never calls a broker
   client, never submits, and never touches `_place_order_impl` or any
   existing order-send path.
-- **No submit without Telegram approval (PR 2).** There is deliberately no
-  `order_proposal_approve` / `order_proposal_submit` MCP tool in this PR. The
-  only way a proposal reaches a live broker order is the Telegram
-  approve/deny flow shipped in PR 2 — not implemented yet.
+- **No submit without Telegram approval.** There is deliberately no
+  `order_proposal_approve` / `order_proposal_submit` MCP tool in either PR.
+  The only way a proposal reaches a live broker order is the Telegram
+  approve/deny flow shipped in PR 2 (`app/services/order_proposals/telegram_callback.py`
+  → `app/services/order_proposals/revalidation.py`). See "Telegram Approval
+  — Activation" below for how to turn it on.
+- **Accepted != filled.** A broker ACK (`record_ack`) or resting-order
+  confirmation (`record_resting`) is recorded on the rung as `acked` /
+  `resting` — never as a fill. `order_proposal_rungs` has no code path that
+  writes `filled`/`partially_filled` from the Telegram approval flow itself;
+  fills are booked later, out of this feature's scope, by the existing
+  broker-evidence reconcile tools (`kis_live_reconcile_orders` /
+  `live_reconcile_orders`) once real fill evidence exists. See
+  `revalidation.py`'s module docstring ("Principle #6").
+- **Nonce replay defense.** Every Telegram button click must present the
+  `approval_nonce` currently stored on the group row; `consume_approval_nonce`
+  (`app/services/order_proposals/service.py`) takes a `for_update=True` row
+  lock and raises `OrderProposalError("nonce_replay")` on a stale/mismatched
+  nonce — so a double-tap, a stale cached message, or a replayed callback can
+  never re-trigger approval/deny.
+- **Chat allowlist (authz, separate from the webhook secret).**
+  `handle_callback_update` rejects any callback whose `chat.id` is not in
+  `settings.order_proposals_telegram_chat_allowlist`
+  (`ORDER_PROPOSALS_TELEGRAM_CHAT_ALLOWLIST_STR`) before doing anything else
+  — distinct from the `ORDER_PROPOSALS_TELEGRAM_TOKEN` webhook secret, which
+  only proves the request came from Telegram (authn), not that it came from
+  an approved chat (authz).
+- **Fresh guard chain re-run at every click.** A Telegram approve does not
+  submit the payload that was true at proposal-create time — it re-runs the
+  full guard chain (loss-sell, market-sell-loss, sector cap) via a fresh
+  `dry_run=True` preview inside `revalidate_and_submit` before ever
+  submitting. See "Approval Flow" below.
 - **Default OFF.** `ORDER_PROPOSALS_ENABLED=false` by default
   (`app/core/config.py`). When off, the three MCP tools are not registered
   in either the default profile (`registry.py`) or the 8770 TradingCodex
@@ -232,15 +272,307 @@ No SQL INSERT/UPDATE/DELETE against these tables is supported outside
 
 ---
 
-## Telegram Approval
+## Telegram Approval — Activation
 
-Not implemented in this PR — see PR 2. Once shipped, proposal creation will
-optionally (behind `ORDER_PROPOSALS_TELEGRAM_ENABLED`, default off) dispatch
-an approval-table Telegram message with inline `[승인]`/`[거부]` buttons; a
-token-authed webhook will receive the callback, re-validate, and submit via
-the existing `approval_hash` place-order path. This runbook will be expanded
-with bot setup, webhook registration, operator activation steps, and an
-evidence template once PR 2 lands.
+PR 2 adds a second, independent env gate on top of `ORDER_PROPOSALS_ENABLED`
+(§ Activation above). Both must be true for a proposal to actually reach a
+Telegram chat and be approvable; `ORDER_PROPOSALS_ENABLED=true` alone still
+only gets you the read/create MCP tools with no approval surface.
+
+All four settings live in `app/core/config.py` (confirmed at lines 766–780
+on this branch):
+
+| Env var | Default | Purpose |
+|---|---|---|
+| `ORDER_PROPOSALS_TELEGRAM_ENABLED` | `false` | Master gate. When `false`: `order_proposal_create` never dispatches an approval message (best-effort no-op — see `order_proposal_tools.py`), and `POST /trading/api/telegram/callback` returns `503 {"error": "order_proposals_telegram_disabled", ...}` without touching the DB. |
+| `ORDER_PROPOSALS_TELEGRAM_BOT_TOKEN` | `""` | Defined in the config schema for this feature, but **not currently read by any runtime code path** — confirmed by repo-wide grep (only referenced in the plan doc and this config declaration). The Telegram Bot API calls that actually send/edit/answer approval messages go through the existing process-wide `TradeNotifier` singleton, which is configured from the **pre-existing** `TELEGRAM_TOKEN` / `TELEGRAM_CHAT_IDS_STR` settings (`app/monitoring/trade_notifier/runtime.py::configure_trade_notifier_from_settings`) — the same bot/token already used for every other trade notification in this repo (Task 10's "reuse `TradeNotifier`, no regression" design). **Set `TELEGRAM_TOKEN` (not this variable) to the BotFather token that should actually send approval messages.** |
+| `ORDER_PROPOSALS_TELEGRAM_TOKEN` | `""` | The webhook **secret token** — a value you choose, registered with Telegram via `setWebhook`'s `secret_token` param (see "Telegram Bot Setup" below). Distinct from the bot token. Gates every request under `/trading/api/telegram/` in `AuthMiddleware` (`TELEGRAM_CALLBACK_PATH_PREFIX`). |
+| `ORDER_PROPOSALS_TELEGRAM_TOKEN_HEADER` | `X-Telegram-Bot-Api-Secret-Token` | The HTTP header Telegram sends the secret token back in. Telegram's own webhook mechanism hard-codes this header name — only override if you're proxying through something that renames headers. |
+| `ORDER_PROPOSALS_TELEGRAM_CHAT_ALLOWLIST_STR` | `""` | Comma-separated Telegram chat IDs, parsed via `settings.order_proposals_telegram_chat_allowlist`. Does double duty: (1) `handle_callback_update` uses the full list as the approve/deny **authz allowlist** (any chat not in it gets `chat_not_allowed`); (2) `send_proposal_for_approval` (`dispatch.py`) sends the initial approval message to `allowlist[0]` only — the **first** entry. Empty means no chat is allowed to approve/deny and no message is ever dispatched (`dispatch.py` no-ops). This is a distinct setting from the pre-existing `TELEGRAM_CHAT_IDS_STR` (used by `TradeNotifier`'s other, non-approval notifications) — the two lists are not required to match. |
+
+Restart the process that serves both the MCP tools and the FastAPI app after
+changing any of these (same restart as § Activation above).
+
+---
+
+## Telegram Bot Setup
+
+1. **Create the bot.** In Telegram, message `@BotFather`, run `/newbot`,
+   follow the prompts. BotFather returns a bot token — set this as the
+   **pre-existing** `TELEGRAM_TOKEN` env var, not
+   `ORDER_PROPOSALS_TELEGRAM_BOT_TOKEN` (see the note in "Telegram Approval
+   — Activation" above: the latter is not currently read by any runtime
+   code — `TradeNotifier` is configured from `TELEGRAM_TOKEN`). Never
+   commit the token; place it in your operator secret store / `.env`.
+2. **Find your chat ID.** Send any message to the new bot (or add it to a
+   group), then call
+   `https://api.telegram.org/bot<BOT_TOKEN>/getUpdates` and read
+   `result[].message.chat.id`. Put that value in
+   `ORDER_PROPOSALS_TELEGRAM_CHAT_ALLOWLIST_STR` — this is both the
+   dispatch target (message goes to the first entry) and the approve/deny
+   authz allowlist (comma-separate additional approver chat IDs if more
+   than one person should be able to click approve/deny; only the first
+   entry receives the initial message).
+3. **Choose a webhook secret.** Generate a random string yourself (e.g.
+   `openssl rand -hex 32`) and set it as `ORDER_PROPOSALS_TELEGRAM_TOKEN`.
+   This is not issued by Telegram — you pick it and hand it to Telegram in
+   the next step.
+4. **Register the webhook** against your public HTTPS host:
+
+   ```bash
+   curl "https://api.telegram.org/bot<BOT_TOKEN>/setWebhook" \
+     -d "url=https://<host>/trading/api/telegram/callback" \
+     -d "secret_token=<ORDER_PROPOSALS_TELEGRAM_TOKEN>"
+   ```
+
+   Telegram will call this URL on every button click and echo the secret
+   token back on the `X-Telegram-Bot-Api-Secret-Token` header (the default
+   value of `ORDER_PROPOSALS_TELEGRAM_TOKEN_HEADER` — confirmed at
+   `app/core/config.py:771`), which `AuthMiddleware` compares against
+   `ORDER_PROPOSALS_TELEGRAM_TOKEN` via `hmac.compare_digest` before letting
+   the request reach the router.
+5. **Verify registration:**
+   ```bash
+   curl "https://api.telegram.org/bot<BOT_TOKEN>/getWebhookInfo"
+   ```
+   Confirm `url` matches your callback endpoint and `last_error_message` is
+   empty.
+
+---
+
+## Callback Receiver — Design
+
+**Implemented (default): webhook.** `POST /trading/api/telegram/callback`
+(`app/routers/telegram_callback.py`) is the only receiver that exists in
+this repo. It:
+
+- Is gated `503` when `ORDER_PROPOSALS_TELEGRAM_ENABLED=false` (checked in
+  the router, before any DB/service work).
+- Is auth-gated `403`/`401` at the middleware layer via the webhook secret
+  token (see "Telegram Approval — Activation" and Troubleshooting below) —
+  the router itself does no auth.
+- Accepts the raw Telegram `Update` payload as a permissive `dict` (Telegram's
+  schema is large/evolving; the endpoint must not reject on unknown fields).
+- Delegates everything else to
+  `app.services.order_proposals.telegram_callback.handle_callback_update`,
+  which never raises (fail-closed webhook contract — always returns
+  `200 {"ok": true}` once past the enable gate, regardless of what happened
+  inside).
+- Is driven purely by Telegram's own push (Telegram calls your server); there
+  is **no polling loop, no TaskIQ task, no cron, and no Prefect flow**
+  anywhere in this feature. "No standing scheduler in-repo" holds: the only
+  process touching `order_proposals`/`order_proposal_rungs` state outside a
+  synchronous MCP-tool or webhook-request call is a human clicking a Telegram
+  button.
+
+**NOT implemented — long-polling alternative (documented only, out of
+scope).** `scripts/order_proposals_telegram_poller.py` is referenced in the
+plan's "Out of Scope (PR 3)" section as the alternative receiver for
+deployments that lack a public HTTPS endpoint (e.g. local dev behind NAT). It
+does **not exist in this repo today** — do not attempt to run it, and do not
+assume any polling infrastructure is present. If you need this mode, it is a
+bounded follow-up PR, not a flag to flip.
+
+---
+
+## Approval Flow
+
+A Telegram approve click does **not** submit "whatever was true when the
+proposal was created." It re-validates from scratch, at click time, and only
+submits if nothing about the world has moved since. This is deliberate:
+proposals can sit unapproved for minutes-to-hours, and a stale price/qty
+submitted blind would defeat the entire point of a human-approval gate.
+
+**Step by step** (`app/services/order_proposals/telegram_callback.py` →
+`app/services/order_proposals/revalidation.py`):
+
+1. **Chat-allowlist authz.** `handle_callback_update` checks
+   `chat.id` against `settings.order_proposals_telegram_chat_allowlist`
+   first, before parsing anything else about the callback.
+2. **Callback-data parse + proposal resolution.** `parse_callback_data`
+   extracts `(action, proposal_short, nonce)` from the compact
+   `op:<8-char-prefix>:<nonce>` / `dn:<8-char-prefix>:<nonce>` string (no raw
+   `approval_hash` ever appears in a Telegram message —
+   `build_approval_message` explicitly redacts `payload_hash`,
+   `approval_hash`, the nonce, and every rung's `approval_hash_digest` from
+   the rendered text). `_resolve_proposal_id` then matches the 8-char prefix
+   against `proposed`-state candidates, failing closed (no match / multiple
+   matches → unresolved) rather than guessing.
+3. **Nonce replay guard.** `consume_approval_nonce` takes a row lock
+   (`for_update=True`) and marks the nonce used; a second click with the
+   same nonce, or a click after a fresh nonce has already been minted (e.g.
+   a `NEEDS_RECONFIRM` cycle), raises `nonce_replay`.
+4. **Commit lease.** For approve only, `acquire_commit_lease` takes a
+   short-lived (`lease_seconds=10` default) in-flight lock on the group row
+   — this is what prevents a double-tap on the approve button (two Telegram
+   updates arriving almost simultaneously) from racing two submits. If the
+   lease is already held, the second click is answered "처리 중" and does
+   nothing further.
+5. **Fresh dry-run preview → full guard chain re-run.** `revalidate_and_submit`
+   re-runs every `pending_approval` rung through a fresh `place_order_fn(dry_run=True, ...)`
+   call — this is the same preview path (`_place_order_impl`) that already
+   enforces the loss-sell guard, market-sell-loss guard, and sector
+   concentration cap. A guard rejection here comes back as `guard_blocked`
+   and the rung returns to `pending_approval` (retryable, not terminal).
+6. **Price/qty comparison against what the operator approved.** The fresh
+   preview's normalized `price`/`quantity` is compared (`_norm`, which
+   canonicalizes `NUMERIC(38,12)` DB values against fresh preview values so
+   `Decimal("2226000.000000000000")` and `Decimal("2226000")` compare equal)
+   against the rung's stored `limit_price`/`quantity`. Market-order rungs
+   compare quantity only (`limit_price` is always `None` by design for
+   market orders, so comparing it would always spuriously mismatch).
+7. **Unchanged → submit; changed → `NEEDS_RECONFIRM`.** If the comparison
+   matches, the rung transitions `approved → submitting` and is actually
+   submitted (`dry_run=False`) using the **freshly minted** `approval_hash`
+   from step 5's preview — never the one from the original proposal-create
+   preview. If it does *not* match, the rung transitions to
+   `needs_reconfirm` and a brand-new Telegram message is sent
+   (`build_approval_message(..., diff=...)`) showing an explicit
+   before/after, with a freshly minted `approval_nonce` — the operator must
+   click again to approve the *new* numbers. **This is the load-bearing
+   distinction: auto-revalidation is not the same as auto-approving a
+   payload change.** The system re-checks freely; it never silently accepts
+   a different price/qty on the operator's behalf.
+8. **Submit outcome classification.** `_classify_submit` records `acked`
+   (market orders) or `resting` (limit orders) on explicit broker success,
+   `rejected` on explicit broker/guard rejection, and `unverified` — never a
+   terminal state — on anything ambiguous (submit exception, unrecognized
+   response shape, missing `broker_order_id`). See Safety Boundaries above
+   for why `unverified` is never auto-voided.
+
+**The four time concepts** (all columns on `order_proposals` /
+`order_proposal_rungs`, see `app/models/order_proposals.py`):
+
+| Concept | Column | Scope | Meaning |
+|---|---|---|---|
+| `valid_until` | `order_proposals.valid_until` | proposal-level | When this operator-approval *offer* stops being worth acting on at all — a proposal an operator never got to in time should not be approvable indefinitely. |
+| `validated_at` | `order_proposal_rungs.validated_at` | rung-level | When this specific rung last completed a `revalidate_and_submit` pass — set by `record_ack`/`record_resting`/`record_unverified`/`mark_needs_reconfirm` in `service.py`. (`order_proposals.validated_at` exists as a group-level column in the model but is not written by any current PR-1/PR-2 code path — do not rely on it.) |
+| `commit_lease_until` | `order_proposals.commit_lease_until` | proposal-level | The short (~10s) in-flight lock from `acquire_commit_lease` that stops a double-click from double-submitting — not a business-meaningful deadline, purely a mutex with a TTL. |
+| *(resting deadline)* | rendered from `group.source_asof["resting_deadline"]` in `build_approval_message`'s `_build_time_lines` | proposal-level, optional | How long a resting (limit, unfilled) order is expected to stay open before it would be expected to expire/need attention — surfaced in the Telegram message when present, not a DB column of its own. |
+
+**Server-internalized TTL (Task 13's design).** The `_place_order_impl` path
+underneath `_default_place_order_fn` has its own `approval_hash` TTL (~300s,
+ROB-651/ROB-653) meant to bound the time between "operator saw this exact
+price/qty" and "it actually got submitted." Because `revalidate_and_submit`
+mints a **brand-new** `approval_hash` from a **fresh** preview at the moment
+of submission (step 5–7 above), that hash's age at submit time is always
+~0 seconds — the underlying 300s TTL is structurally never at risk of
+tripping from a slow *human* round-trip (an operator taking 20 minutes to
+click "approve" doesn't matter; what matters is the freshness of the preview
+taken *at the click*, not the freshness of the proposal's original numbers).
+
+---
+
+## Live Smoke (operator-only)
+
+**Not run in CI.** Every test in this repo's suite mocks the real
+Telegram Bot API, the real broker, and every `httpx` call — see the global
+ROB-816 constraint. This section is a manual, staged operator playbook
+against a real Telegram bot and a real (or KIS/Kiwoom **mock**) broker
+account. Never point this at a live-money account you are not prepared to
+place a real (small) order through.
+
+### Preflight
+
+1. Confirm both env gates are set in the target process's environment:
+   `ORDER_PROPOSALS_ENABLED=true` and `ORDER_PROPOSALS_TELEGRAM_ENABLED=true`.
+2. Confirm `TELEGRAM_TOKEN` (the actual bot token — not
+   `ORDER_PROPOSALS_TELEGRAM_BOT_TOKEN`, which is unused), `TELEGRAM_CHAT_IDS_STR`,
+   `ORDER_PROPOSALS_TELEGRAM_TOKEN`, and
+   `ORDER_PROPOSALS_TELEGRAM_CHAT_ALLOWLIST_STR` are all set (see
+   "Telegram Approval — Activation").
+3. `curl .../getWebhookInfo` (see "Telegram Bot Setup" step 5) and confirm
+   the registered `url` points at the target host and `last_error_message`
+   is empty.
+4. Restart the MCP process / FastAPI app so the new env values are loaded.
+
+### Staged run
+
+1. **Create a proposal** via `order_proposal_create` with a real (or mock)
+   `account_mode` and a deliberately small quantity/notional — treat this
+   like the first real order on a new integration, not a routine trade.
+   **What to check:** the tool returns `{success: true, proposal_id, ...}`,
+   and within a few seconds a Telegram message with `[✅ 승인]`/`[❌ 거부]`
+   buttons arrives in the allowlisted chat, rendering symbol/market/side/
+   order type/rungs/thesis/strategy/valid_until — and **no raw hash or nonce
+   text visible anywhere in the message** (redaction check).
+2. **Verify DB state matches the message** using the DB Verification
+   queries above: `lifecycle_state='proposed'`, rung `state='pending_approval'`,
+   `approval_nonce` set, `approval_nonce_used_at IS NULL`.
+3. **Click Deny on a throwaway proposal first** (cheapest path to exercise
+   the whole plumbing without touching a broker). **What to check:** the
+   Telegram message updates to "❌ 거부됨", the rung's `state` becomes
+   `rejected` in the DB, and a second click on the same (now-stale) buttons
+   answers "이미 처리되었거나 유효하지 않은 요청입니다" and changes nothing
+   (nonce-replay proof).
+4. **Click Approve on a real small-quantity proposal** against a mock/paper
+   account first (`kis_mock`, Binance Spot Demo, etc. per your broker
+   preference — never start this staged run against a live account).
+   **What to check:** the Telegram message updates with a per-rung result
+   summary (e.g. "체결 대기(접수)" / "주문 유지(대기)"), the rung transitions
+   through `revalidating → approved → submitting → acked|resting` in the DB,
+   `broker_order_id` and `correlation_id` are populated, and (for a market
+   order) `record_ack` fired / (for a limit order) `record_resting` fired —
+   confirm via the DB Verification query, not just the Telegram text.
+5. **Force a `NEEDS_RECONFIRM` cycle deliberately**: create a limit-order
+   proposal, then before approving, move the market away from the limit
+   price enough that a fresh preview would price it differently (or just
+   wait through a volatile few minutes on a liquid symbol). Click Approve.
+   **What to check:** a **new** Telegram message arrives with "재확인 필요"
+   framing and an explicit before/after diff, the original message is
+   edited to "⚠️ 재확인 필요...", the rung is `needs_reconfirm` in the DB,
+   and a fresh `approval_nonce` was minted (different from the original).
+6. **Only after 3–5 clean cycles on mock/paper**, repeat step 4 once against
+   a real live account with the smallest possible size, with a human
+   watching the whole way through — this is the actual bar for calling PR 2
+   "live-verified," not just "code review passed."
+7. **Confirm `UNVERIFIED` handling** by killing network connectivity (or
+   otherwise forcing a submit-phase exception) mid-approve on a mock/paper
+   proposal, if your test environment supports it. **What to check:** the
+   rung lands in `unverified` (never a terminal state), and
+   `kis_live_reconcile_orders` / `live_reconcile_orders` can later resolve
+   it from broker evidence — see Troubleshooting.
+
+Record the `proposal_id` and DB query output for every step you run (see
+"Evidence Template" below) so results are auditable, not just "it worked."
+
+---
+
+## Evidence Template
+
+Paste this block (filled in) when reporting an issue with the Telegram
+approval flow. Every field maps to a real, queryable column — pull the
+values from the DB Verification queries above (`review.order_proposals` /
+`review.order_proposal_rungs`), not from memory or the Telegram message
+text alone.
+
+```
+proposal_id:            <review.order_proposals.proposal_id>
+symbol / market:        <symbol> / <market>
+rung_index:             <order_proposal_rungs.rung_index>
+
+Timestamps:
+  created_at:            <order_proposals.created_at>
+  validated_at (rung):   <order_proposal_rungs.validated_at>
+  approved_at:           <order_proposals.approved_at>
+
+States:
+  rung state:             <order_proposal_rungs.state>
+  group lifecycle_state:  <order_proposals.lifecycle_state>
+
+Telegram chat_id:        <redact last digits if sharing outside the team>
+
+Broker evidence:
+  broker_order_id:       <order_proposal_rungs.broker_order_id>
+  correlation_id:        <order_proposal_rungs.correlation_id>
+  approval_hash_digest:  <order_proposal_rungs.approval_hash_digest>
+  idempotency_key:       <order_proposal_rungs.idempotency_key>
+
+What happened (free text):
+  <expected vs. actual behavior, exact Telegram button clicked, any
+   error text shown by Telegram (e.g. "이미 처리되었거나 유효하지 않은
+   요청입니다"), and whether this is reproducible>
+```
 
 ---
 
@@ -273,9 +605,16 @@ path).
 
 Raised by `assert_rung_transition` when a rung is asked to move to a state
 not in its allowed-next set (see the state diagram above). This should never
-surface in PR 1 since there is no transition-driving MCP tool yet — it is
-exercised directly by `tests/services/order_proposals/test_state_machine.py`
-and the service's internal `transition_rung` (PR-2 callers only).
+surface from the PR 1 read/create MCP tools (`order_proposal_create`/`get`/
+`list` never drive a transition). It is exercised directly by
+`tests/services/order_proposals/test_state_machine.py`, and in normal
+operation by the PR 2 Telegram approval flow's internal callers
+(`app/services/order_proposals/telegram_callback.py`,
+`app/services/order_proposals/revalidation.py`) via the service's
+`transition_rung`. If you see it surface from a live Telegram click, it
+means the click-time code attempted a transition the state machine
+considers illegal from the rung's current state — treat it as a bug report,
+not routine operator error.
 
 ### A proposal I expect to be `expired` at the group level shows `terminal`
 
@@ -294,3 +633,79 @@ The ROB-816 migration (`20260710_rob816_order_proposals`) is additive-only
 (two new tables, no existing table changes) and chains off
 `20260710_rob800_exit_intent`. `downgrade()` drops indexes then tables in
 reverse order and is safe in non-production environments.
+
+### `403 Telegram callback token not configured`
+
+`AuthMiddleware` returns this when `ORDER_PROPOSALS_TELEGRAM_TOKEN` is unset
+or empty on the process serving `/trading/api/telegram/*` — the webhook
+secret must be set fail-closed rather than accepted with a blank/missing
+value. Set `ORDER_PROPOSALS_TELEGRAM_TOKEN` (see "Telegram Approval —
+Activation") and restart. (The middleware also returns this same 403 shape,
+with a different detail string, if `ORDER_PROPOSALS_TELEGRAM_TOKEN_HEADER`
+is set to an empty string — don't blank that setting out.)
+
+### `401 Invalid Telegram callback token`
+
+`AuthMiddleware` returns this when the value in the
+`X-Telegram-Bot-Api-Secret-Token` header (or whatever
+`ORDER_PROPOSALS_TELEGRAM_TOKEN_HEADER` is set to) does not match
+`ORDER_PROPOSALS_TELEGRAM_TOKEN` (compared via `hmac.compare_digest`).
+Usually means the webhook was registered with a different secret than the
+one currently configured — re-run `setWebhook` with the current
+`ORDER_PROPOSALS_TELEGRAM_TOKEN` value (see "Telegram Bot Setup" step 4), or
+check `getWebhookInfo` for a stale registration.
+
+### `chat_not_allowed`
+
+`handle_callback_update` returned `{"handled": false, "reason": "chat_not_allowed"}`
+because the callback's `chat.id` is not in
+`settings.order_proposals_telegram_chat_allowlist`. Add the chat ID to
+`ORDER_PROPOSALS_TELEGRAM_CHAT_ALLOWLIST_STR` (see "Telegram Bot Setup" step
+2 for how to find it) and restart. This is an authz failure, not an authn
+failure — the webhook secret token check already passed by the time this
+fires.
+
+### `nonce_replay`
+
+`consume_approval_nonce` raised `OrderProposalError("nonce_replay")` — the
+`nonce` embedded in the clicked button's callback data no longer matches
+`order_proposals.approval_nonce` on that row. Expected and correct in three
+cases: (1) a genuine double-tap/duplicate Telegram update for the same
+click, (2) clicking a button on a Telegram message that has since been
+superseded by a fresh `NEEDS_RECONFIRM` message (which mints a new nonce —
+the old message's buttons are now stale by design), (3) clicking an already-
+approved/denied proposal's old message again. If none of those explain it,
+check whether something outside the Telegram flow called
+`set_approval_nonce`/`consume_approval_nonce` directly (should never happen
+outside `dispatch.py`/`telegram_callback.py`).
+
+### `NEEDS_RECONFIRM` loop (a rung keeps coming back needs_reconfirm)
+
+Each `NEEDS_RECONFIRM` cycle mints a fresh nonce and re-sends the message —
+a rung that needs reconfirmation on every approve attempt usually means the
+symbol is fast-moving or thin/illiquid enough that the price at click time
+never matches the price at the *original* proposal-create time (or the
+previous reconfirm's numbers). This is the guard chain working as intended,
+not a bug. Options: widen the operator's price tolerance before creating the
+next proposal revision, act manually through the normal order tools instead
+of via a proposal for that specific symbol, or accept the latest diff and
+click Approve again promptly (before the price moves further).
+
+### `UNVERIFIED` rung — never auto-voided
+
+A rung in `unverified` state means `revalidate_and_submit` could not
+classify the broker's response after a real submit attempt (network
+exception, ambiguous status, missing `broker_order_id` — see
+`revalidation.py`'s `_classify_submit`). By design this is a **holding**
+state, not terminal, and nothing in this feature auto-voids it. To resolve:
+run the existing broker-evidence reconcile tools —
+`kis_live_reconcile_orders` (KR) or `live_reconcile_orders` (US/crypto,
+see `docs/runbooks/kis-live-order-reconcile.md` /
+`docs/runbooks/live-order-reconcile.md`) — against the rung's
+`correlation_id`/`broker_order_id` (from the DB Verification query or the
+Evidence Template above) to pull real order-status evidence and determine
+whether it actually got submitted, filled, or rejected. `record_fill_evidence`
+(`service.py`) is the sink for that evidence once you have it, but wiring the
+existing reconcile tools to call it automatically is a documented follow-up
+(see the plan's "Out of Scope (PR 3)" section) — for now this is a manual
+step.

--- a/tests/core/test_config_order_proposals.py
+++ b/tests/core/test_config_order_proposals.py
@@ -16,5 +16,7 @@ def test_telegram_flags_default_off_and_allowlist_parses():
     assert s.ORDER_PROPOSALS_TELEGRAM_TOKEN == ""
     assert s.ORDER_PROPOSALS_TELEGRAM_TOKEN_HEADER == "X-Telegram-Bot-Api-Secret-Token"
     assert s.order_proposals_telegram_chat_allowlist == []
-    s2 = Settings(_env_file=None, ORDER_PROPOSALS_TELEGRAM_CHAT_ALLOWLIST_STR="111, 222")
+    s2 = Settings(
+        _env_file=None, ORDER_PROPOSALS_TELEGRAM_CHAT_ALLOWLIST_STR="111, 222"
+    )
     assert s2.order_proposals_telegram_chat_allowlist == ["111", "222"]

--- a/tests/core/test_config_order_proposals.py
+++ b/tests/core/test_config_order_proposals.py
@@ -7,3 +7,14 @@ from app.core.config import Settings
 def test_order_proposals_disabled_by_default():
     s = Settings(_env_file=None)
     assert s.ORDER_PROPOSALS_ENABLED is False
+
+
+@pytest.mark.unit
+def test_telegram_flags_default_off_and_allowlist_parses():
+    s = Settings(_env_file=None)
+    assert s.ORDER_PROPOSALS_TELEGRAM_ENABLED is False
+    assert s.ORDER_PROPOSALS_TELEGRAM_TOKEN == ""
+    assert s.ORDER_PROPOSALS_TELEGRAM_TOKEN_HEADER == "X-Telegram-Bot-Api-Secret-Token"
+    assert s.order_proposals_telegram_chat_allowlist == []
+    s2 = Settings(_env_file=None, ORDER_PROPOSALS_TELEGRAM_CHAT_ALLOWLIST_STR="111, 222")
+    assert s2.order_proposals_telegram_chat_allowlist == ["111", "222"]

--- a/tests/middleware/test_auth_telegram_branch.py
+++ b/tests/middleware/test_auth_telegram_branch.py
@@ -1,0 +1,158 @@
+"""ROB-816 PR 2 — AuthMiddleware secret-token gate for the Telegram
+order-proposals approval webhook (``/trading/api/telegram/*``).
+
+Same prefix-token shape as the Hermes / news-relevance branches
+(``test_investment_hermes_http_auth.py`` / ``test_news_relevance_auth.py``):
+
+* token unset -> 403 "not configured"
+* header name unset -> 403 "not configured" (header, not token)
+* wrong/missing supplied token -> 401 "invalid"
+* correct token -> middleware passes through (``None``); the downstream
+  ``ORDER_PROPOSALS_TELEGRAM_ENABLED`` gate-off 503 proves the request
+  actually reached the FastAPI route handler rather than being short
+  circuited earlier by an unrelated branch.
+"""
+
+from __future__ import annotations
+
+from typing import cast
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from app.core.config import settings
+from app.middleware.auth import AuthMiddleware
+from app.routers.telegram_callback import router as telegram_router
+
+_PATH = "/trading/api/telegram/callback"
+_BODY: dict = {"update_id": 1}
+
+
+def _build_app() -> FastAPI:
+    app = FastAPI()
+    app.include_router(telegram_router)
+    app.add_middleware(AuthMiddleware)
+    return app
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_unconfigured_token_returns_403(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(settings, "ORDER_PROPOSALS_TELEGRAM_TOKEN", "", raising=False)
+    app = _build_app()
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="https://test"
+    ) as client:
+        resp = await client.post(_PATH, json=_BODY)
+    assert resp.status_code == 403
+    assert "not configured" in cast(str, resp.json()["detail"]).lower()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_unconfigured_header_name_returns_403(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        settings, "ORDER_PROPOSALS_TELEGRAM_TOKEN", "secret", raising=False
+    )
+    monkeypatch.setattr(
+        settings, "ORDER_PROPOSALS_TELEGRAM_TOKEN_HEADER", "   ", raising=False
+    )
+    app = _build_app()
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="https://test"
+    ) as client:
+        resp = await client.post(
+            _PATH, json=_BODY, headers={"X-Telegram-Bot-Api-Secret-Token": "secret"}
+        )
+    assert resp.status_code == 403
+    assert "not configured" in cast(str, resp.json()["detail"]).lower()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_missing_or_wrong_token_returns_401(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        settings, "ORDER_PROPOSALS_TELEGRAM_TOKEN", "secret", raising=False
+    )
+    monkeypatch.setattr(
+        settings,
+        "ORDER_PROPOSALS_TELEGRAM_TOKEN_HEADER",
+        "X-Telegram-Bot-Api-Secret-Token",
+        raising=False,
+    )
+    app = _build_app()
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="https://test"
+    ) as client:
+        # No header at all.
+        resp = await client.post(_PATH, json=_BODY)
+        assert resp.status_code == 401, resp.text
+        assert "invalid" in cast(str, resp.json()["detail"]).lower()
+
+        # Wrong header value.
+        resp = await client.post(
+            _PATH,
+            json=_BODY,
+            headers={"X-Telegram-Bot-Api-Secret-Token": "nope"},
+        )
+        assert resp.status_code == 401, resp.text
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_correct_token_passes_through_to_handler(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Correct token -> middleware returns ``None`` (pass-through).
+
+    Downstream ``ORDER_PROPOSALS_TELEGRAM_ENABLED`` is left at its default
+    (off), so the request reaching the route handler is proven by the
+    structured 503 gate-off body rather than a 401/403 auth failure.
+    """
+    monkeypatch.setattr(
+        settings, "ORDER_PROPOSALS_TELEGRAM_TOKEN", "secret", raising=False
+    )
+    monkeypatch.setattr(
+        settings,
+        "ORDER_PROPOSALS_TELEGRAM_TOKEN_HEADER",
+        "X-Telegram-Bot-Api-Secret-Token",
+        raising=False,
+    )
+    monkeypatch.setattr(
+        settings, "ORDER_PROPOSALS_TELEGRAM_ENABLED", False, raising=False
+    )
+
+    app = _build_app()
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="https://test"
+    ) as client:
+        resp = await client.post(
+            _PATH, json=_BODY, headers={"X-Telegram-Bot-Api-Secret-Token": "secret"}
+        )
+    assert resp.status_code == 503
+    assert resp.json()["detail"]["error"] == "order_proposals_telegram_disabled"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_sibling_prefix_not_affected(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Sanity: the prefix match is anchored on ``/telegram/`` — a sibling
+    ``/trading/api/`` request should not pick up this token branch."""
+    monkeypatch.setattr(settings, "ORDER_PROPOSALS_TELEGRAM_TOKEN", "", raising=False)
+    app = _build_app()
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="https://test"
+    ) as client:
+        resp = await client.post(
+            "/trading/api/some-other-family/callback", json={"x": 1}
+        )
+    # 404 (route not registered) confirms we did NOT route through the
+    # Telegram token branch (which would have been 403 "not configured").
+    assert resp.status_code != 403

--- a/tests/monitoring/test_trade_notifier_reply_markup.py
+++ b/tests/monitoring/test_trade_notifier_reply_markup.py
@@ -1,0 +1,243 @@
+"""Tests for Telegram inline-keyboard transport and notifier helpers."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.monitoring.trade_notifier import TradeNotifier, transports
+
+
+def _telegram_response(*, message_id: int = 42) -> MagicMock:
+    response = MagicMock()
+    response.raise_for_status = MagicMock()
+    response.json = MagicMock(
+        return_value={"ok": True, "result": {"message_id": message_id}}
+    )
+    return response
+
+
+@pytest.fixture
+def notifier() -> TradeNotifier:
+    TradeNotifier._instance = None
+    TradeNotifier._initialized = False
+    instance = TradeNotifier()
+    yield instance
+    TradeNotifier._instance = None
+    TradeNotifier._initialized = False
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_send_telegram_without_markup_preserves_payload() -> None:
+    client = MagicMock()
+    client.post = AsyncMock(return_value=_telegram_response(message_id=5))
+
+    result = await transports.send_telegram(
+        http_client=client,
+        bot_token="T",
+        chat_ids=["1"],
+        text="hi",
+    )
+
+    assert result is True
+    _, kwargs = client.post.call_args
+    assert kwargs["json"] == {
+        "chat_id": "1",
+        "text": "hi",
+        "parse_mode": "Markdown",
+        "disable_web_page_preview": True,
+    }
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_send_telegram_forwards_reply_markup() -> None:
+    client = MagicMock()
+    client.post = AsyncMock(return_value=_telegram_response())
+    keyboard = {"inline_keyboard": [[{"text": "승인", "callback_data": "op:x:y"}]]}
+
+    result = await transports.send_telegram(
+        http_client=client,
+        bot_token="T",
+        chat_ids=["1"],
+        text="approve?",
+        reply_markup=keyboard,
+    )
+
+    assert result is True
+    _, kwargs = client.post.call_args
+    assert kwargs["json"]["reply_markup"] == keyboard
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_send_telegram_message_returns_message_id_with_markup() -> None:
+    client = MagicMock()
+    client.post = AsyncMock(return_value=_telegram_response(message_id=42))
+    keyboard = {"inline_keyboard": [[{"text": "승인", "callback_data": "op:x:y"}]]}
+
+    message_id = await transports.send_telegram_message(
+        http_client=client,
+        bot_token="T",
+        chat_id="1",
+        text="approve?",
+        reply_markup=keyboard,
+    )
+
+    assert message_id == 42
+    args, kwargs = client.post.call_args
+    assert args[0] == "https://api.telegram.org/botT/sendMessage"
+    assert kwargs["json"] == {
+        "chat_id": "1",
+        "text": "approve?",
+        "parse_mode": "Markdown",
+        "disable_web_page_preview": True,
+        "reply_markup": keyboard,
+    }
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_send_telegram_message_returns_none_on_failure() -> None:
+    client = MagicMock()
+    client.post = AsyncMock(side_effect=RuntimeError("network error"))
+
+    result = await transports.send_telegram_message(
+        http_client=client,
+        bot_token="T",
+        chat_id="1",
+        text="approve?",
+    )
+
+    assert result is None
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_answer_callback_query_omits_absent_text() -> None:
+    client = MagicMock()
+    client.post = AsyncMock(return_value=_telegram_response())
+
+    result = await transports.answer_callback_query(
+        http_client=client,
+        bot_token="T",
+        callback_query_id="callback-1",
+    )
+
+    assert result is True
+    args, kwargs = client.post.call_args
+    assert args[0] == "https://api.telegram.org/botT/answerCallbackQuery"
+    assert kwargs["json"] == {"callback_query_id": "callback-1"}
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_edit_message_text_forwards_reply_markup() -> None:
+    client = MagicMock()
+    client.post = AsyncMock(return_value=_telegram_response())
+    keyboard = {"inline_keyboard": []}
+
+    result = await transports.edit_message_text(
+        http_client=client,
+        bot_token="T",
+        chat_id="1",
+        message_id=42,
+        text="approved",
+        reply_markup=keyboard,
+    )
+
+    assert result is True
+    args, kwargs = client.post.call_args
+    assert args[0] == "https://api.telegram.org/botT/editMessageText"
+    assert kwargs["json"] == {
+        "chat_id": "1",
+        "message_id": 42,
+        "text": "approved",
+        "parse_mode": "Markdown",
+        "reply_markup": keyboard,
+    }
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@pytest.mark.parametrize("helper", ["answer", "edit"])
+async def test_boolean_transport_helpers_return_false_on_failure(helper: str) -> None:
+    client = MagicMock()
+    client.post = AsyncMock(side_effect=RuntimeError("network error"))
+
+    if helper == "answer":
+        result = await transports.answer_callback_query(
+            http_client=client,
+            bot_token="T",
+            callback_query_id="callback-1",
+        )
+    else:
+        result = await transports.edit_message_text(
+            http_client=client,
+            bot_token="T",
+            chat_id="1",
+            message_id=42,
+            text="approved",
+        )
+
+    assert result is False
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_notifier_helpers_reuse_singleton_resources(
+    notifier: TradeNotifier,
+) -> None:
+    client = MagicMock()
+    client.post = AsyncMock(
+        side_effect=[
+            _telegram_response(message_id=77),
+            _telegram_response(),
+            _telegram_response(),
+        ]
+    )
+    notifier._http_client = client
+    notifier._bot_token = "T"
+    keyboard = {"inline_keyboard": [[{"text": "승인", "callback_data": "op:x:y"}]]}
+
+    message_id = await notifier.send_approval_message("approve?", keyboard, chat_id="1")
+    answered = await notifier.answer_callback("callback-1", "received")
+    edited = await notifier.edit_message(
+        "1", 77, "approved", reply_markup={"inline_keyboard": []}
+    )
+
+    assert message_id == 77
+    assert answered is True
+    assert edited is True
+    first_call, second_call, third_call = client.post.call_args_list
+    assert "botT/sendMessage" in first_call.args[0]
+    assert first_call.kwargs["json"]["reply_markup"] == keyboard
+    assert "botT/answerCallbackQuery" in second_call.args[0]
+    assert second_call.kwargs["json"] == {
+        "callback_query_id": "callback-1",
+        "text": "received",
+    }
+    assert "botT/editMessageText" in third_call.args[0]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@pytest.mark.parametrize("missing", ["http_client", "bot_token"])
+async def test_notifier_helpers_fail_safely_when_resource_missing(
+    notifier: TradeNotifier,
+    missing: str,
+) -> None:
+    client = MagicMock()
+    client.post = AsyncMock()
+    notifier._http_client = None if missing == "http_client" else client
+    notifier._bot_token = None if missing == "bot_token" else "T"
+
+    assert (
+        await notifier.send_approval_message(
+            "approve?", {"inline_keyboard": []}, chat_id="1"
+        )
+        is None
+    )
+    assert await notifier.answer_callback("callback-1") is False
+    assert await notifier.edit_message("1", 42, "approved") is False
+    client.post.assert_not_awaited()

--- a/tests/routers/test_telegram_callback_route.py
+++ b/tests/routers/test_telegram_callback_route.py
@@ -1,0 +1,153 @@
+"""ROB-816 PR 2 — HTTP transport for the Telegram order-proposals webhook.
+
+Covers:
+
+* Gate-off behaviour (``ORDER_PROPOSALS_TELEGRAM_ENABLED``): the endpoint
+  short-circuits ``503`` with the structured
+  ``order_proposals_telegram_disabled`` body — same shape as the Hermes
+  HTTP transport's gate-off.
+* Happy path: gate on -> ``handle_callback_update`` is invoked with the
+  raw request body and a timezone-aware ``now``, and the endpoint always
+  answers ``200 {"ok": True}`` regardless of the handler's internal
+  result (Telegram's webhook contract only inspects the HTTP status).
+
+Token-auth handling via ``AuthMiddleware`` is exercised separately in
+``tests/middleware/test_auth_telegram_branch.py`` — this module focuses on
+the route/business-logic behaviour, with ``AuthMiddleware`` included only
+in the happy-path test to prove the secret-token header actually lets the
+request through end-to-end.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from app.core.config import settings
+from app.middleware.auth import AuthMiddleware
+from app.routers.telegram_callback import router as telegram_router
+
+_PATH = "/trading/api/telegram/callback"
+
+
+def _build_app(*, with_auth_middleware: bool = False) -> FastAPI:
+    app = FastAPI()
+    app.include_router(telegram_router)
+    if with_auth_middleware:
+        app.add_middleware(AuthMiddleware)
+    return app
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_gate_off_returns_503(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        settings, "ORDER_PROPOSALS_TELEGRAM_ENABLED", False, raising=False
+    )
+    app = _build_app()
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="https://test"
+    ) as client:
+        resp = await client.post(_PATH, json={"update_id": 1})
+    assert resp.status_code == 503
+    body = resp.json()
+    assert body["detail"]["error"] == "order_proposals_telegram_disabled"
+    assert "hint" in body["detail"]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_gate_on_valid_token_invokes_handler_and_returns_ok(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        settings, "ORDER_PROPOSALS_TELEGRAM_ENABLED", True, raising=False
+    )
+    monkeypatch.setattr(
+        settings, "ORDER_PROPOSALS_TELEGRAM_TOKEN", "secret", raising=False
+    )
+    monkeypatch.setattr(
+        settings,
+        "ORDER_PROPOSALS_TELEGRAM_TOKEN_HEADER",
+        "X-Telegram-Bot-Api-Secret-Token",
+        raising=False,
+    )
+
+    update_payload = {
+        "update_id": 123,
+        "callback_query": {
+            "id": "cbq-1",
+            "data": "ap:abcdef01:nonce123",
+            "from": {"id": 777},
+            "message": {"chat": {"id": 42}, "message_id": 555},
+        },
+    }
+
+    fake_handler = AsyncMock(return_value={"handled": True, "reason": "approved"})
+    app = _build_app(with_auth_middleware=True)
+
+    with patch("app.routers.telegram_callback.handle_callback_update", fake_handler):
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="https://test"
+        ) as client:
+            resp = await client.post(
+                _PATH,
+                json=update_payload,
+                headers={"X-Telegram-Bot-Api-Secret-Token": "secret"},
+            )
+
+    assert resp.status_code == 200
+    assert resp.json() == {"ok": True}
+
+    fake_handler.assert_awaited_once()
+    call_args, call_kwargs = fake_handler.call_args
+    assert call_args[0] == update_payload
+    now_arg = call_kwargs["now"]
+    assert isinstance(now_arg, datetime)
+    assert now_arg.tzinfo is not None  # must be timezone-aware, per Task 14
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_gate_on_valid_token_returns_ok_even_when_handler_reports_not_handled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The route always answers 200 {"ok": True} to Telegram regardless of
+    the handler's internal result dict -- Telegram's webhook contract only
+    inspects the HTTP status, and ``handle_callback_update`` never raises
+    (Task 14's fail-closed guarantee)."""
+    monkeypatch.setattr(
+        settings, "ORDER_PROPOSALS_TELEGRAM_ENABLED", True, raising=False
+    )
+    monkeypatch.setattr(
+        settings, "ORDER_PROPOSALS_TELEGRAM_TOKEN", "secret", raising=False
+    )
+    monkeypatch.setattr(
+        settings,
+        "ORDER_PROPOSALS_TELEGRAM_TOKEN_HEADER",
+        "X-Telegram-Bot-Api-Secret-Token",
+        raising=False,
+    )
+
+    fake_handler = AsyncMock(
+        return_value={"handled": False, "reason": "chat_not_allowed"}
+    )
+    app = _build_app(with_auth_middleware=True)
+
+    with patch("app.routers.telegram_callback.handle_callback_update", fake_handler):
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="https://test"
+        ) as client:
+            resp = await client.post(
+                _PATH,
+                json={"update_id": 999},
+                headers={"X-Telegram-Bot-Api-Secret-Token": "secret"},
+            )
+
+    assert resp.status_code == 200
+    assert resp.json() == {"ok": True}
+    fake_handler.assert_awaited_once()

--- a/tests/services/order_proposals/test_approval_message.py
+++ b/tests/services/order_proposals/test_approval_message.py
@@ -171,6 +171,74 @@ def test_message_includes_times_cash_and_reconfirm_diff_without_secrets():
 
 
 @pytest.mark.unit
+def test_message_omits_nested_and_non_numeric_sensitive_values():
+    group = SimpleNamespace(
+        proposal_id=uuid.uuid4(),
+        symbol="000660",
+        market="equity_kr",
+        side="buy",
+        order_type="limit",
+        thesis=None,
+        strategy=None,
+        valid_until=None,
+        validated_at=None,
+        commit_lease_until=None,
+        source_asof=None,
+        payload_hash=None,
+        approval_nonce="abc123def4560000",
+    )
+    rung = SimpleNamespace(
+        rung_index=0,
+        quantity=Decimal("10"),
+        limit_price=Decimal("70000"),
+        approval_hash_digest=None,
+    )
+    sensitive_values = {
+        "nested-payload-secret",
+        "nested-nonce-secret",
+        "known-cash-field-secret",
+        "nested-digest-secret",
+        "known-diff-field-secret",
+        "nested-approval-secret",
+    }
+    cash_stress = {
+        "available_cash": Decimal("5000000"),
+        "required_cash": {"approval_hash": "known-cash-field-secret"},
+        "details": {
+            "payload_hash": "nested-payload-secret",
+            "items": [{"nonce": "nested-nonce-secret"}],
+        },
+    }
+    diff = {
+        "before": {
+            "quantity": Decimal("10"),
+            "limit_price": Decimal("70000"),
+            "details": {"digest": "nested-digest-secret"},
+        },
+        "after": {
+            "quantity": {"nonce": "known-diff-field-secret"},
+            "limit_price": Decimal("70500"),
+            "metadata": [{"approval_hash": "nested-approval-secret"}],
+        },
+    }
+
+    text, _ = build_approval_message(
+        group=group,
+        rungs=[rung],
+        cash_stress=cash_stress,
+        diff=diff,
+    )
+
+    assert "가용현금: ₩5,000,000" in text
+    assert "변경 전: 수량 10 / 가격 ₩70,000" in text
+    assert "변경 후: 가격 ₩70,500" in text
+    for sensitive_value in sensitive_values:
+        assert sensitive_value not in text
+    for sensitive_key in ("payload_hash", "approval_hash", "nonce", "digest"):
+        assert sensitive_key not in text
+
+
+@pytest.mark.unit
 def test_message_formats_optional_market_order_fields_stably():
     group = SimpleNamespace(
         proposal_id=uuid.uuid4(),
@@ -202,6 +270,30 @@ def test_message_formats_optional_market_order_fields_stably():
     assert "*시간*" not in text
     assert "*현금 스트레스*" not in text
     assert "*재확인 변경사항*" not in text
+
+
+@pytest.mark.unit
+def test_message_escapes_inline_code_delimiters():
+    group = SimpleNamespace(
+        proposal_id=uuid.uuid4(),
+        symbol=r"A`\B",
+        market=r"equity`\kr",
+        side=r"b`\uy",
+        order_type=r"li`\mit",
+        thesis=None,
+        strategy=None,
+        valid_until=None,
+        validated_at=None,
+        commit_lease_until=None,
+        source_asof=None,
+        payload_hash=None,
+        approval_nonce="abc123def4560000",
+    )
+
+    text, _ = build_approval_message(group=group, rungs=[])
+
+    assert r"- 종목: `A\`\\B`" in text
+    assert r"- 시장/방향/유형: `equity\`\\kr / b\`\\uy / li\`\\mit`" in text
 
 
 @pytest.mark.unit

--- a/tests/services/order_proposals/test_approval_message.py
+++ b/tests/services/order_proposals/test_approval_message.py
@@ -1,0 +1,226 @@
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from decimal import Decimal
+from types import SimpleNamespace
+
+import pytest
+
+from app.services.order_proposals.approval_message import (
+    build_approval_message,
+    build_callback_data,
+    parse_callback_data,
+)
+
+
+@pytest.mark.unit
+def test_callback_data_roundtrip_and_length():
+    proposal_id = uuid.uuid4()
+
+    data = build_callback_data(
+        action="op",
+        proposal_id=proposal_id,
+        nonce="abc123def4560000",
+    )
+
+    assert len(data.encode("utf-8")) <= 64
+    action, proposal_short, nonce = parse_callback_data(data)
+    assert action == "op"
+    assert proposal_short == str(proposal_id)[:8]
+    assert nonce == "abc123def4560000"
+
+
+@pytest.mark.unit
+def test_callback_builder_rejects_invalid_action_and_oversized_data():
+    proposal_id = uuid.uuid4()
+
+    with pytest.raises(ValueError, match="action"):
+        build_callback_data(
+            action="approve",
+            proposal_id=proposal_id,
+            nonce="abc123def4560000",
+        )
+    with pytest.raises(ValueError, match="64 bytes"):
+        build_callback_data(
+            action="op",
+            proposal_id=proposal_id,
+            nonce="a" * 53,
+        )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "data",
+    [
+        "",
+        "op:deadbeef",
+        "op:deadbeef:nonce:extra",
+        "approve:deadbeef:nonce",
+        "op:deadbee:nonce",
+        "op:deadbeeg:nonce",
+        "op:deadbeef:",
+        "op:deadbeef:bad nonce",
+        f"op:deadbeef:{'a' * 53}",
+    ],
+)
+def test_callback_parser_rejects_malformed_data(data):
+    with pytest.raises(ValueError):
+        parse_callback_data(data)
+
+
+@pytest.mark.unit
+def test_message_includes_times_cash_and_reconfirm_diff_without_secrets():
+    proposal_id = uuid.UUID("12345678-1234-5678-9abc-123456789abc")
+    payload_hash = "payload-secret-digest-0123456789"
+    approval_hash = "approval-secret-digest-9876543210"
+    nonce = "abc123def4560000"
+    group = SimpleNamespace(
+        proposal_id=proposal_id,
+        symbol="000660",
+        market="equity_kr",
+        side="buy",
+        order_type="limit",
+        thesis="support bounce",
+        strategy="ladder",
+        valid_until=datetime(2026, 7, 10, 11, 0, tzinfo=UTC),
+        validated_at=datetime(2026, 7, 10, 10, 57, tzinfo=UTC),
+        commit_lease_until=datetime(2026, 7, 10, 10, 58, tzinfo=UTC),
+        source_asof={"resting_deadline": "2026-07-10T11:00:00+00:00"},
+        payload_hash=payload_hash,
+        approval_nonce=nonce,
+    )
+    rungs = [
+        SimpleNamespace(
+            rung_index=1,
+            quantity=Decimal("5.000000000000"),
+            limit_price=Decimal("68000.000000000000"),
+            approval_hash_digest="second-rung-secret",
+        ),
+        SimpleNamespace(
+            rung_index=0,
+            quantity=Decimal("10.000000000000"),
+            limit_price=Decimal("70000.000000000000"),
+            approval_hash_digest=approval_hash,
+        ),
+    ]
+    cash_stress = {
+        "available_cash": Decimal("5000000.0000"),
+        "required_cash": Decimal("700000.0000"),
+        "remaining_cash": Decimal("4300000.0000"),
+        "utilization_pct": Decimal("14.00"),
+        "payload_hash": payload_hash,
+    }
+    diff = {
+        "before": {
+            "quantity": Decimal("10.0000"),
+            "limit_price": Decimal("70000.0000"),
+            "approval_hash": approval_hash,
+        },
+        "after": {
+            "quantity": Decimal("9.0000"),
+            "limit_price": Decimal("70500.0000"),
+        },
+    }
+
+    text, inline_keyboard = build_approval_message(
+        group=group,
+        rungs=rungs,
+        cash_stress=cash_stress,
+        diff=diff,
+    )
+
+    assert "000660" in text
+    assert "equity_kr / buy / limit" in text
+    assert text.index("#1: 10주 × ₩70,000") < text.index("#2: 5주 × ₩68,000")
+    assert "투자 논지: support bounce" in text
+    assert "전략: ladder" in text
+    assert "유효기간: ~20:00 KST (2026-07-10)" in text
+    assert "검증시각: 19:57 KST (2026-07-10)" in text
+    assert "제출 임대: ~19:58 KST (2026-07-10)" in text
+    assert "주문 유지기한: ~20:00 KST (2026-07-10)" in text
+    assert "가용현금: ₩5,000,000" in text
+    assert "필요현금: ₩700,000" in text
+    assert "잔여현금: ₩4,300,000" in text
+    assert "사용률: 14%" in text
+    assert "변경 전: 수량 10 / 가격 ₩70,000" in text
+    assert "변경 후: 수량 9 / 가격 ₩70,500" in text
+
+    assert payload_hash not in text
+    assert approval_hash not in text
+    assert nonce not in text
+    assert "second-rung-secret" not in text
+    assert "payload_hash" not in text
+    assert "approval_hash" not in text
+    assert "nonce" not in text
+    assert "digest" not in text
+    assert inline_keyboard == {
+        "inline_keyboard": [
+            [
+                {
+                    "text": "✅ 승인",
+                    "callback_data": "op:12345678:abc123def4560000",
+                },
+                {
+                    "text": "❌ 거부",
+                    "callback_data": "dn:12345678:abc123def4560000",
+                },
+            ]
+        ]
+    }
+
+
+@pytest.mark.unit
+def test_message_formats_optional_market_order_fields_stably():
+    group = SimpleNamespace(
+        proposal_id=uuid.uuid4(),
+        symbol="BTC/KRW",
+        market="crypto",
+        side="buy",
+        order_type="market",
+        thesis=None,
+        strategy=None,
+        valid_until=None,
+        validated_at=None,
+        commit_lease_until=None,
+        source_asof=None,
+        payload_hash=None,
+        approval_nonce="abc123def4560000",
+    )
+    rung = SimpleNamespace(
+        rung_index=0,
+        quantity=Decimal("0.010000000000"),
+        limit_price=None,
+        approval_hash_digest=None,
+    )
+
+    text, _ = build_approval_message(group=group, rungs=[rung])
+
+    assert "#1: 0.01 × 시장가" in text
+    assert "투자 논지: 미기재" in text
+    assert "전략: 미기재" in text
+    assert "*시간*" not in text
+    assert "*현금 스트레스*" not in text
+    assert "*재확인 변경사항*" not in text
+
+
+@pytest.mark.unit
+def test_message_requires_group_approval_nonce():
+    group = SimpleNamespace(
+        proposal_id=uuid.uuid4(),
+        symbol="000660",
+        market="equity_kr",
+        side="buy",
+        order_type="limit",
+        thesis=None,
+        strategy=None,
+        valid_until=None,
+        validated_at=None,
+        commit_lease_until=None,
+        source_asof=None,
+        payload_hash=None,
+        approval_nonce=None,
+    )
+
+    with pytest.raises(ValueError, match="approval_nonce"):
+        build_approval_message(group=group, rungs=[])

--- a/tests/services/order_proposals/test_dispatch.py
+++ b/tests/services/order_proposals/test_dispatch.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+import contextlib
+from datetime import UTC, datetime
+from decimal import Decimal
+
+import pytest
+
+from app.services.order_proposals import OrderProposalsService
+from app.services.order_proposals.dispatch import send_proposal_for_approval
+from app.services.order_proposals.service import RungInput
+
+CHAT_ID = "chat-99"
+
+
+class _FakeNotifier:
+    def __init__(self, *, message_id: int | None = 5001) -> None:
+        self.sent_messages: list[tuple[str, dict, str]] = []
+        self._message_id = message_id
+
+    async def send_approval_message(self, text, inline_keyboard, *, chat_id):
+        self.sent_messages.append((text, inline_keyboard, chat_id))
+        return self._message_id
+
+
+class _RaisingNotifier:
+    async def send_approval_message(self, text, inline_keyboard, *, chat_id):
+        raise RuntimeError("telegram down")
+
+
+def _session_factory(db_session):
+    @contextlib.asynccontextmanager
+    async def _factory():
+        yield db_session
+
+    return _factory
+
+
+async def _seed_proposal(db_session, *, source_asof=None):
+    service = OrderProposalsService(db_session)
+    group = await service.create_proposal(
+        symbol="005930",
+        market="equity_kr",
+        account_mode="kis_live",
+        side="buy",
+        order_type="limit",
+        proposer="p",
+        rungs=[RungInput(0, "buy", Decimal("10"), Decimal("100"), None)],
+        source_asof=source_asof,
+    )
+    await db_session.commit()
+    return group
+
+
+@pytest.mark.asyncio
+async def test_send_proposal_for_approval_mints_nonce_and_sends(
+    monkeypatch, db_session
+):
+    from app.core.config import settings
+
+    monkeypatch.setattr(
+        settings, "ORDER_PROPOSALS_TELEGRAM_CHAT_ALLOWLIST_STR", CHAT_ID
+    )
+    group = await _seed_proposal(db_session)
+    notifier = _FakeNotifier(message_id=5001)
+    now = datetime(2026, 7, 10, 9, 20, tzinfo=UTC)
+
+    message_id = await send_proposal_for_approval(
+        group.proposal_id,
+        notifier=notifier,
+        now=now,
+        service_factory=_session_factory(db_session),
+    )
+
+    assert message_id == 5001
+    assert len(notifier.sent_messages) == 1
+    text, keyboard, chat_id = notifier.sent_messages[0]
+    assert chat_id == CHAT_ID
+    assert "승인" in text
+    assert keyboard["inline_keyboard"]
+
+    service = OrderProposalsService(db_session)
+    refreshed, _ = await service.get_proposal(group.proposal_id)
+    assert refreshed.approval_nonce is not None
+    assert refreshed.source_asof["approval_message_id"] == 5001
+    assert refreshed.source_asof["approval_chat_id"] == CHAT_ID
+    assert refreshed.source_asof["approval_sent_at"] == now.isoformat()
+
+
+@pytest.mark.asyncio
+async def test_send_proposal_for_approval_preserves_existing_source_asof(
+    monkeypatch, db_session
+):
+    from app.core.config import settings
+
+    monkeypatch.setattr(
+        settings, "ORDER_PROPOSALS_TELEGRAM_CHAT_ALLOWLIST_STR", CHAT_ID
+    )
+    group = await _seed_proposal(
+        db_session, source_asof={"resting_deadline": "2026-07-10T15:30:00+09:00"}
+    )
+    notifier = _FakeNotifier(message_id=7001)
+    now = datetime(2026, 7, 10, 9, 21, tzinfo=UTC)
+
+    await send_proposal_for_approval(
+        group.proposal_id,
+        notifier=notifier,
+        now=now,
+        service_factory=_session_factory(db_session),
+    )
+
+    service = OrderProposalsService(db_session)
+    refreshed, _ = await service.get_proposal(group.proposal_id)
+    assert refreshed.source_asof["resting_deadline"] == "2026-07-10T15:30:00+09:00"
+    assert refreshed.source_asof["approval_message_id"] == 7001
+
+
+@pytest.mark.asyncio
+async def test_send_proposal_for_approval_empty_allowlist_is_noop(
+    monkeypatch, db_session
+):
+    from app.core.config import settings
+
+    monkeypatch.setattr(settings, "ORDER_PROPOSALS_TELEGRAM_CHAT_ALLOWLIST_STR", "")
+    group = await _seed_proposal(db_session)
+    notifier = _FakeNotifier()
+    now = datetime(2026, 7, 10, 9, 22, tzinfo=UTC)
+
+    message_id = await send_proposal_for_approval(
+        group.proposal_id,
+        notifier=notifier,
+        now=now,
+        service_factory=_session_factory(db_session),
+    )
+
+    assert message_id is None
+    assert notifier.sent_messages == []
+
+    service = OrderProposalsService(db_session)
+    refreshed, _ = await service.get_proposal(group.proposal_id)
+    assert refreshed.approval_nonce is None
+
+
+@pytest.mark.asyncio
+async def test_send_proposal_for_approval_send_failure_returns_none_but_nonce_committed(
+    monkeypatch, db_session
+):
+    from app.core.config import settings
+
+    monkeypatch.setattr(
+        settings, "ORDER_PROPOSALS_TELEGRAM_CHAT_ALLOWLIST_STR", CHAT_ID
+    )
+    group = await _seed_proposal(db_session)
+    notifier = _FakeNotifier(message_id=None)
+    now = datetime(2026, 7, 10, 9, 23, tzinfo=UTC)
+
+    message_id = await send_proposal_for_approval(
+        group.proposal_id,
+        notifier=notifier,
+        now=now,
+        service_factory=_session_factory(db_session),
+    )
+
+    assert message_id is None
+
+    service = OrderProposalsService(db_session)
+    refreshed, _ = await service.get_proposal(group.proposal_id)
+    assert refreshed.approval_nonce is not None
+    assert refreshed.source_asof is None

--- a/tests/services/order_proposals/test_revalidation.py
+++ b/tests/services/order_proposals/test_revalidation.py
@@ -4,7 +4,10 @@ from decimal import Decimal
 import pytest
 
 from app.services.order_proposals import OrderProposalsService
-from app.services.order_proposals.revalidation import revalidate_and_submit
+from app.services.order_proposals.revalidation import (
+    _adapt_live_submit_response,
+    revalidate_and_submit,
+)
 from app.services.order_proposals.service import RungInput
 
 
@@ -336,3 +339,189 @@ async def test_only_pending_approval_rungs_are_revalidated(db_session):
     by_index = {r.rung_index: r for r in rungs}
     assert by_index[0].state == "resting"
     assert by_index[1].state == "acked"  # untouched
+
+
+# ---------------------------------------------------------------------------
+# Finding 1 — `_adapt_live_submit_response` unit tests (no network; adapts a
+# fixture dict shaped like the real `_record_kis_live_order`/
+# `_record_live_order` accepted-only-at-send response into the
+# `{status, broker_order_id}` shape `_classify_submit` expects).
+# ---------------------------------------------------------------------------
+
+
+def test_adapt_live_submit_response_accepted_market_is_acked():
+    submit = {
+        "success": True,
+        "broker_status": "accepted",
+        "order_id": "B-mkt",
+        "correlation_id": "c-mkt",
+    }
+    adapted = _adapt_live_submit_response(submit, order_type="market")
+    assert adapted["status"] == "acked"
+    assert adapted["broker_order_id"] == "B-mkt"
+    assert adapted["correlation_id"] == "c-mkt"
+    assert adapted["success"] is True
+
+
+def test_adapt_live_submit_response_accepted_limit_is_resting():
+    submit = {
+        "success": True,
+        "broker_status": "accepted",
+        "order_id": "B-lmt",
+        "correlation_id": "c-lmt",
+    }
+    adapted = _adapt_live_submit_response(submit, order_type="limit")
+    assert adapted["status"] == "resting"
+    assert adapted["broker_order_id"] == "B-lmt"
+
+
+def test_adapt_live_submit_response_rejected_flips_success_false():
+    submit = {
+        "success": True,  # the real ledger call always sets success=True...
+        "broker_status": "rejected",
+        "order_id": None,
+        "response_message": "insufficient balance",
+    }
+    adapted = _adapt_live_submit_response(submit, order_type="limit")
+    assert adapted["success"] is False
+    assert adapted["error"] == "insufficient balance"
+
+
+def test_adapt_live_submit_response_rejected_falls_back_to_message():
+    submit = {
+        "success": True,
+        "broker_status": "rejected",
+        "order_id": None,
+        "message": "Live order not accepted (broker_status=rejected)",
+    }
+    adapted = _adapt_live_submit_response(submit, order_type="market")
+    assert adapted["success"] is False
+    assert adapted["error"] == "Live order not accepted (broker_status=rejected)"
+
+
+def test_adapt_live_submit_response_unknown_broker_status_passes_through():
+    submit = {"success": True, "broker_status": None}
+    adapted = _adapt_live_submit_response(submit, order_type="limit")
+    assert adapted == submit
+
+
+# ---------------------------------------------------------------------------
+# Finding 2 — market-order rungs must not be permanently stuck in
+# needs_reconfirm just because the live preview backfills `price` with the
+# current market price (rung.limit_price is always None for market orders).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_market_order_unchanged_quantity_submits(db_session):
+    svc = OrderProposalsService(db_session)
+    g = await svc.create_proposal(
+        symbol="A",
+        market="equity_kr",
+        account_mode="kis_live",
+        side="buy",
+        order_type="market",
+        proposer="p",
+        rungs=[RungInput(0, "buy", Decimal("10"), None, None)],
+    )
+    await db_session.commit()
+
+    async def fn(**kw):
+        if kw.get("dry_run"):
+            return {
+                "success": True,
+                "approval_hash": "TESTTOKEN",
+                "price": "2226000",  # live current price, no stored limit_price
+                "quantity": "10",
+            }
+        return {
+            "success": True,
+            "status": "acked",
+            "broker_order_id": "B-mkt",
+            "correlation_id": "c-mkt",
+            "idempotency_key": "k-mkt",
+            "approval_hash_digest": "d-mkt",
+        }
+
+    out = await revalidate_and_submit(
+        service=svc,
+        proposal_id=g.proposal_id,
+        now=datetime.now(UTC),
+        place_order_fn=fn,
+    )
+    assert out[0].result == "submitted_acked"
+    _, rungs = await svc.get_proposal(g.proposal_id)
+    assert rungs[0].state == "acked"
+
+
+@pytest.mark.asyncio
+async def test_market_order_qty_change_still_needs_reconfirm(db_session):
+    svc = OrderProposalsService(db_session)
+    g = await svc.create_proposal(
+        symbol="A",
+        market="equity_kr",
+        account_mode="kis_live",
+        side="buy",
+        order_type="market",
+        proposer="p",
+        rungs=[RungInput(0, "buy", Decimal("10"), None, None)],
+    )
+    await db_session.commit()
+
+    async def fn(**kw):
+        if kw.get("dry_run"):
+            return {
+                "success": True,
+                "approval_hash": "TESTTOKEN",
+                "price": "2226000",
+                "quantity": "9",  # changed
+            }
+        return {"success": True}  # should never be reached for submit
+
+    out = await revalidate_and_submit(
+        service=svc,
+        proposal_id=g.proposal_id,
+        now=datetime.now(UTC),
+        place_order_fn=fn,
+    )
+    assert out[0].result == "needs_reconfirm"
+    assert out[0].detail["before"]["limit_price"] is None
+    assert out[0].detail["after"]["limit_price"] is None
+    _, rungs = await svc.get_proposal(g.proposal_id)
+    assert rungs[0].state == "needs_reconfirm"
+
+
+# ---------------------------------------------------------------------------
+# Finding 3 — a preview-phase exception must not orphan the rung in
+# "revalidating"; it should be retryable back in pending_approval.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_preview_exception_returns_to_pending_approval(db_session):
+    svc = OrderProposalsService(db_session)
+    g = await svc.create_proposal(
+        symbol="A",
+        market="equity_kr",
+        account_mode="kis_live",
+        side="buy",
+        order_type="limit",
+        proposer="p",
+        rungs=[RungInput(0, "buy", Decimal("10"), Decimal("2226000"), None)],
+    )
+    await db_session.commit()
+
+    async def preview_raises_fn(**kw):
+        if kw.get("dry_run"):
+            raise ValueError("quote fetch failed")
+        raise AssertionError("submit should never be reached")
+
+    out = await revalidate_and_submit(
+        service=svc,
+        proposal_id=g.proposal_id,
+        now=datetime.now(UTC),
+        place_order_fn=preview_raises_fn,
+    )
+    assert out[0].result == "error"
+    _, rungs = await svc.get_proposal(g.proposal_id)
+    assert rungs[0].state == "pending_approval"

--- a/tests/services/order_proposals/test_revalidation.py
+++ b/tests/services/order_proposals/test_revalidation.py
@@ -1,0 +1,338 @@
+from datetime import UTC, datetime
+from decimal import Decimal
+
+import pytest
+
+from app.services.order_proposals import OrderProposalsService
+from app.services.order_proposals.revalidation import revalidate_and_submit
+from app.services.order_proposals.service import RungInput
+
+
+def _fake_place_order(*, preview_price, preview_qty, submit_result):
+    async def _fn(**kw):
+        if kw.get("dry_run"):
+            return {
+                "success": True,
+                "approval_hash": "TESTTOKEN",
+                "price": str(preview_price),
+                "quantity": str(preview_qty),
+            }
+        return submit_result
+
+    return _fn
+
+
+@pytest.mark.asyncio
+async def test_unchanged_submits_resting(db_session):
+    svc = OrderProposalsService(db_session)
+    g = await svc.create_proposal(
+        symbol="A",
+        market="equity_kr",
+        account_mode="kis_live",
+        side="buy",
+        order_type="limit",
+        proposer="p",
+        rungs=[RungInput(0, "buy", Decimal("10"), Decimal("2226000"), None)],
+    )
+    await db_session.commit()
+    fn = _fake_place_order(
+        preview_price=Decimal("2226000"),
+        preview_qty=Decimal("10"),
+        submit_result={
+            "success": True,
+            "status": "resting",
+            "broker_order_id": "B1",
+            "correlation_id": "c1",
+            "idempotency_key": "k1",
+            "approval_hash_digest": "d1",
+        },
+    )
+    out = await revalidate_and_submit(
+        service=svc,
+        proposal_id=g.proposal_id,
+        now=datetime.now(UTC),
+        place_order_fn=fn,
+    )
+    assert out[0].result == "submitted_resting"
+    _, rungs = await svc.get_proposal(g.proposal_id)
+    assert rungs[0].state == "resting"
+    assert rungs[0].filled_qty is None  # accepted != filled
+
+
+@pytest.mark.asyncio
+async def test_unchanged_submits_acked(db_session):
+    svc = OrderProposalsService(db_session)
+    g = await svc.create_proposal(
+        symbol="A",
+        market="equity_kr",
+        account_mode="kis_live",
+        side="buy",
+        order_type="limit",
+        proposer="p",
+        rungs=[RungInput(0, "buy", Decimal("10"), Decimal("2226000"), None)],
+    )
+    await db_session.commit()
+    fn = _fake_place_order(
+        preview_price=Decimal("2226000"),
+        preview_qty=Decimal("10"),
+        submit_result={
+            "success": True,
+            "status": "acked",
+            "broker_order_id": "B2",
+            "correlation_id": "c2",
+            "idempotency_key": "k2",
+            "approval_hash_digest": "d2",
+        },
+    )
+    out = await revalidate_and_submit(
+        service=svc,
+        proposal_id=g.proposal_id,
+        now=datetime.now(UTC),
+        place_order_fn=fn,
+    )
+    assert out[0].result == "submitted_acked"
+    _, rungs = await svc.get_proposal(g.proposal_id)
+    assert rungs[0].state == "acked"
+    assert rungs[0].filled_qty is None  # accepted != filled
+
+
+@pytest.mark.asyncio
+async def test_price_change_needs_reconfirm_no_submit(db_session):
+    svc = OrderProposalsService(db_session)
+    g = await svc.create_proposal(
+        symbol="000660",
+        market="equity_kr",
+        account_mode="kis_live",
+        side="buy",
+        order_type="limit",
+        proposer="p",
+        rungs=[RungInput(0, "buy", Decimal("10"), Decimal("2226000"), None)],
+    )
+    await db_session.commit()
+    fn = _fake_place_order(
+        preview_price=Decimal("2340000"),
+        preview_qty=Decimal("10"),
+        submit_result={"success": True},  # should never be reached for submit
+    )
+    out = await revalidate_and_submit(
+        service=svc,
+        proposal_id=g.proposal_id,
+        now=datetime.now(UTC),
+        place_order_fn=fn,
+    )
+    assert out[0].result == "needs_reconfirm"
+    assert out[0].detail["before"]["limit_price"] == "2226000"
+    assert out[0].detail["after"]["limit_price"] == "2340000"
+    _, rungs = await svc.get_proposal(g.proposal_id)
+    assert rungs[0].state == "needs_reconfirm"
+
+
+@pytest.mark.asyncio
+async def test_qty_change_needs_reconfirm_no_submit(db_session):
+    svc = OrderProposalsService(db_session)
+    g = await svc.create_proposal(
+        symbol="067160",
+        market="equity_kr",
+        account_mode="kis_live",
+        side="buy",
+        order_type="limit",
+        proposer="p",
+        rungs=[RungInput(0, "buy", Decimal("10"), Decimal("2226000"), None)],
+    )
+    await db_session.commit()
+    fn = _fake_place_order(
+        preview_price=Decimal("2226000"),
+        preview_qty=Decimal("9"),
+        submit_result={"success": True},  # should never be reached for submit
+    )
+    out = await revalidate_and_submit(
+        service=svc,
+        proposal_id=g.proposal_id,
+        now=datetime.now(UTC),
+        place_order_fn=fn,
+    )
+    assert out[0].result == "needs_reconfirm"
+    assert out[0].detail["before"]["quantity"] == "10"
+    assert out[0].detail["after"]["quantity"] == "9"
+    _, rungs = await svc.get_proposal(g.proposal_id)
+    assert rungs[0].state == "needs_reconfirm"
+
+
+@pytest.mark.asyncio
+async def test_guard_block_fail_closed(db_session):
+    svc = OrderProposalsService(db_session)
+    g = await svc.create_proposal(
+        symbol="A",
+        market="equity_kr",
+        account_mode="kis_live",
+        side="sell",
+        order_type="limit",
+        proposer="p",
+        rungs=[RungInput(0, "sell", Decimal("1"), Decimal("50"), None)],
+    )
+    await db_session.commit()
+
+    async def blocked_fn(**kw):
+        return {"success": False, "error": "loss_sell_blocked"}
+
+    out = await revalidate_and_submit(
+        service=svc,
+        proposal_id=g.proposal_id,
+        now=datetime.now(UTC),
+        place_order_fn=blocked_fn,
+    )
+    assert out[0].result == "guard_blocked"
+    _, rungs = await svc.get_proposal(g.proposal_id)
+    assert rungs[0].state == "pending_approval"  # retryable, not submitted
+
+
+@pytest.mark.asyncio
+async def test_submit_rejected_records_rejected(db_session):
+    svc = OrderProposalsService(db_session)
+    g = await svc.create_proposal(
+        symbol="A",
+        market="equity_kr",
+        account_mode="kis_live",
+        side="buy",
+        order_type="limit",
+        proposer="p",
+        rungs=[RungInput(0, "buy", Decimal("10"), Decimal("2226000"), None)],
+    )
+    await db_session.commit()
+    fn = _fake_place_order(
+        preview_price=Decimal("2226000"),
+        preview_qty=Decimal("10"),
+        submit_result={"success": False, "error": "broker_rejected"},
+    )
+    out = await revalidate_and_submit(
+        service=svc,
+        proposal_id=g.proposal_id,
+        now=datetime.now(UTC),
+        place_order_fn=fn,
+    )
+    assert out[0].result == "error"
+    _, rungs = await svc.get_proposal(g.proposal_id)
+    assert rungs[0].state == "rejected"
+
+
+@pytest.mark.asyncio
+async def test_submit_ambiguous_records_unverified(db_session):
+    svc = OrderProposalsService(db_session)
+    g = await svc.create_proposal(
+        symbol="A",
+        market="equity_kr",
+        account_mode="kis_live",
+        side="buy",
+        order_type="limit",
+        proposer="p",
+        rungs=[RungInput(0, "buy", Decimal("10"), Decimal("2226000"), None)],
+    )
+    await db_session.commit()
+    fn = _fake_place_order(
+        preview_price=Decimal("2226000"),
+        preview_qty=Decimal("10"),
+        submit_result={"success": True, "status": "unknown"},
+    )
+    out = await revalidate_and_submit(
+        service=svc,
+        proposal_id=g.proposal_id,
+        now=datetime.now(UTC),
+        place_order_fn=fn,
+    )
+    assert out[0].result == "unverified"
+    _, rungs = await svc.get_proposal(g.proposal_id)
+    assert rungs[0].state == "unverified"
+
+
+@pytest.mark.asyncio
+async def test_submit_exception_records_unverified(db_session):
+    svc = OrderProposalsService(db_session)
+    g = await svc.create_proposal(
+        symbol="A",
+        market="equity_kr",
+        account_mode="kis_live",
+        side="buy",
+        order_type="limit",
+        proposer="p",
+        rungs=[RungInput(0, "buy", Decimal("10"), Decimal("2226000"), None)],
+    )
+    await db_session.commit()
+
+    async def flaky_fn(**kw):
+        if kw.get("dry_run"):
+            return {
+                "success": True,
+                "approval_hash": "TESTTOKEN",
+                "price": "2226000",
+                "quantity": "10",
+            }
+        raise TimeoutError("broker timeout")
+
+    out = await revalidate_and_submit(
+        service=svc,
+        proposal_id=g.proposal_id,
+        now=datetime.now(UTC),
+        place_order_fn=flaky_fn,
+    )
+    assert out[0].result == "unverified"
+    _, rungs = await svc.get_proposal(g.proposal_id)
+    assert rungs[0].state == "unverified"
+
+
+@pytest.mark.asyncio
+async def test_only_pending_approval_rungs_are_revalidated(db_session):
+    svc = OrderProposalsService(db_session)
+    g = await svc.create_proposal(
+        symbol="A",
+        market="equity_kr",
+        account_mode="kis_live",
+        side="buy",
+        order_type="limit",
+        proposer="p",
+        rungs=[
+            RungInput(0, "buy", Decimal("10"), Decimal("100"), None),
+            RungInput(1, "buy", Decimal("10"), Decimal("100"), None),
+        ],
+    )
+    await db_session.commit()
+    # rung 1 already moved on (e.g. previously submitted/acked) — simulate by
+    # driving it through the state machine directly.
+    await svc.transition_rung(g.proposal_id, 1, new_state="revalidating")
+    await svc.transition_rung(g.proposal_id, 1, new_state="approved")
+    await svc.transition_rung(g.proposal_id, 1, new_state="submitting")
+    await svc.record_ack(
+        g.proposal_id,
+        1,
+        broker_order_id="B-pre",
+        correlation_id="c-pre",
+        idempotency_key="k-pre",
+        approval_hash_digest="d-pre",
+        now=datetime.now(UTC),
+    )
+    await db_session.commit()
+
+    fn = _fake_place_order(
+        preview_price=Decimal("100"),
+        preview_qty=Decimal("10"),
+        submit_result={
+            "success": True,
+            "status": "resting",
+            "broker_order_id": "B0",
+            "correlation_id": "c0",
+            "idempotency_key": "k0",
+            "approval_hash_digest": "d0",
+        },
+    )
+    out = await revalidate_and_submit(
+        service=svc,
+        proposal_id=g.proposal_id,
+        now=datetime.now(UTC),
+        place_order_fn=fn,
+    )
+    assert len(out) == 1
+    assert out[0].rung_index == 0
+    assert out[0].result == "submitted_resting"
+    _, rungs = await svc.get_proposal(g.proposal_id)
+    by_index = {r.rung_index: r for r in rungs}
+    assert by_index[0].state == "resting"
+    assert by_index[1].state == "acked"  # untouched

--- a/tests/services/order_proposals/test_service.py
+++ b/tests/services/order_proposals/test_service.py
@@ -552,3 +552,45 @@ async def test_sweep_local_stale_accepts_sync_evidence_callback(db_session):
     assert group.proposal_id in swept
     _, rungs = await service.get_proposal(group.proposal_id)
     assert rungs[0].state == "voided_local_stale"
+
+
+@pytest.mark.asyncio
+async def test_record_approval_dispatch_merges_source_asof(db_session):
+    service = OrderProposalsService(db_session)
+    group = await service.create_proposal(
+        symbol="A",
+        market="equity_kr",
+        account_mode="kis_live",
+        side="buy",
+        order_type="limit",
+        proposer="p",
+        rungs=[RungInput(0, "buy", Decimal("1"), Decimal("100"), None)],
+        source_asof={"resting_deadline": "2026-07-10T15:30:00+09:00"},
+    )
+    await db_session.commit()
+    now = datetime(2026, 7, 10, 9, 15, tzinfo=UTC)
+
+    updated = await service.record_approval_dispatch(
+        group.proposal_id, message_id=4242, chat_id="chat-1", now=now
+    )
+
+    assert updated.source_asof["resting_deadline"] == "2026-07-10T15:30:00+09:00"
+    assert updated.source_asof["approval_message_id"] == 4242
+    assert updated.source_asof["approval_chat_id"] == "chat-1"
+    assert updated.source_asof["approval_sent_at"] == now.isoformat()
+
+    refreshed, _ = await service.get_proposal(group.proposal_id)
+    assert refreshed.source_asof["resting_deadline"] == "2026-07-10T15:30:00+09:00"
+    assert refreshed.source_asof["approval_message_id"] == 4242
+
+
+@pytest.mark.asyncio
+async def test_record_approval_dispatch_missing_proposal_raises(db_session):
+    service = OrderProposalsService(db_session)
+    with pytest.raises(OrderProposalNotFound):
+        await service.record_approval_dispatch(
+            uuid.uuid4(),
+            message_id=1,
+            chat_id="chat-1",
+            now=datetime(2026, 7, 10, 9, 15, tzinfo=UTC),
+        )

--- a/tests/services/order_proposals/test_service.py
+++ b/tests/services/order_proposals/test_service.py
@@ -594,3 +594,151 @@ async def test_record_approval_dispatch_missing_proposal_raises(db_session):
             chat_id="chat-1",
             now=datetime(2026, 7, 10, 9, 15, tzinfo=UTC),
         )
+
+
+# ---------------------------------------------------------------------------
+# Final-review Finding 1 — account_mode/market submit-routing allowlist.
+# `_place_order_impl` (the submit path's default binding) has no
+# `account_mode` param at all: it routes purely by `market` and always
+# submits `is_mock=False`. A proposal created with an account_mode the submit
+# path doesn't actually honor (kis_mock, toss_live, db_simulated) must be
+# rejected at create time -- never persisted -- rather than silently routed
+# to LIVE KIS on approval.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_proposal_allows_kis_live_equity_kr(db_session):
+    service = OrderProposalsService(db_session)
+    group = await service.create_proposal(
+        symbol="A",
+        market="equity_kr",
+        account_mode="kis_live",
+        side="buy",
+        order_type="limit",
+        proposer="p",
+        rungs=[RungInput(0, "buy", Decimal("1"), Decimal("100"), None)],
+    )
+    await db_session.commit()
+    assert group.account_mode == "kis_live"
+    assert group.market == "equity_kr"
+
+
+@pytest.mark.asyncio
+async def test_create_proposal_allows_kis_live_equity_us(db_session):
+    service = OrderProposalsService(db_session)
+    group = await service.create_proposal(
+        symbol="AAPL",
+        market="equity_us",
+        account_mode="kis_live",
+        side="buy",
+        order_type="limit",
+        proposer="p",
+        rungs=[RungInput(0, "buy", Decimal("1"), Decimal("100"), None)],
+    )
+    await db_session.commit()
+    assert group.account_mode == "kis_live"
+    assert group.market == "equity_us"
+
+
+@pytest.mark.asyncio
+async def test_create_proposal_allows_upbit_crypto(db_session):
+    service = OrderProposalsService(db_session)
+    group = await service.create_proposal(
+        symbol="BTC/KRW",
+        market="crypto",
+        account_mode="upbit",
+        side="buy",
+        order_type="limit",
+        proposer="p",
+        rungs=[RungInput(0, "buy", Decimal("0.01"), Decimal("100000000"), None)],
+    )
+    await db_session.commit()
+    assert group.account_mode == "upbit"
+    assert group.market == "crypto"
+
+
+@pytest.mark.asyncio
+async def test_create_proposal_rejects_kis_mock_equity_kr(db_session):
+    service = OrderProposalsService(db_session)
+    with pytest.raises(OrderProposalError, match="not submittable"):
+        await service.create_proposal(
+            symbol="A",
+            market="equity_kr",
+            account_mode="kis_mock",
+            side="buy",
+            order_type="limit",
+            proposer="p",
+            rungs=[RungInput(0, "buy", Decimal("1"), Decimal("100"), None)],
+        )
+
+
+@pytest.mark.asyncio
+async def test_create_proposal_rejects_toss_live_equity_kr(db_session):
+    service = OrderProposalsService(db_session)
+    with pytest.raises(OrderProposalError, match="not submittable"):
+        await service.create_proposal(
+            symbol="A",
+            market="equity_kr",
+            account_mode="toss_live",
+            side="buy",
+            order_type="limit",
+            proposer="p",
+            rungs=[RungInput(0, "buy", Decimal("1"), Decimal("100"), None)],
+        )
+
+
+@pytest.mark.asyncio
+async def test_create_proposal_rejects_db_simulated_and_upbit_wrong_market(db_session):
+    service = OrderProposalsService(db_session)
+    with pytest.raises(OrderProposalError, match="not submittable"):
+        await service.create_proposal(
+            symbol="A",
+            market="equity_kr",
+            account_mode="db_simulated",
+            side="buy",
+            order_type="limit",
+            proposer="p",
+            rungs=[RungInput(0, "buy", Decimal("1"), Decimal("100"), None)],
+        )
+    with pytest.raises(OrderProposalError, match="not submittable"):
+        await service.create_proposal(
+            symbol="A",
+            market="equity_kr",
+            account_mode="upbit",
+            side="buy",
+            order_type="limit",
+            proposer="p",
+            rungs=[RungInput(0, "buy", Decimal("1"), Decimal("100"), None)],
+        )
+
+
+@pytest.mark.asyncio
+async def test_create_proposal_rejection_leaves_no_partial_rows(db_session):
+    """Airtight: the reject must fire before any group/rung row is written --
+    even flushed-but-uncommitted -- so a query against this same session sees
+    zero matching rows for a rejected create_proposal call.
+    """
+    from sqlalchemy import func, select
+
+    from app.models.order_proposals import OrderProposal
+
+    service = OrderProposalsService(db_session)
+    symbol = f"REJECT-{uuid.uuid4().hex[:8]}"
+    with pytest.raises(OrderProposalError):
+        await service.create_proposal(
+            symbol=symbol,
+            market="equity_kr",
+            account_mode="kis_mock",
+            side="buy",
+            order_type="limit",
+            proposer="p",
+            rungs=[RungInput(0, "buy", Decimal("1"), Decimal("100"), None)],
+        )
+
+    count = await db_session.scalar(
+        select(func.count())
+        .select_from(OrderProposal)
+        .where(OrderProposal.symbol == symbol)
+    )
+    assert count == 0

--- a/tests/services/order_proposals/test_service.py
+++ b/tests/services/order_proposals/test_service.py
@@ -1,14 +1,49 @@
 import uuid
+from datetime import UTC, datetime, timedelta
 from decimal import Decimal
 
 import pytest
 
 from app.services.order_proposals import OrderProposalsService
 from app.services.order_proposals.errors import (
+    OrderProposalError,
     OrderProposalInvalidStateTransition,
     OrderProposalNotFound,
 )
 from app.services.order_proposals.service import RungInput
+
+
+async def _create_single_rung(db_session, *, symbol: str = "A"):
+    service = OrderProposalsService(db_session)
+    group = await service.create_proposal(
+        symbol=symbol,
+        market="equity_kr",
+        account_mode="kis_live",
+        side="buy",
+        order_type="limit",
+        proposer="p",
+        rungs=[RungInput(0, "buy", Decimal("1"), Decimal("100"), None)],
+    )
+    await db_session.commit()
+    return service, group
+
+
+async def _drive_to_submitting(service, proposal_id):
+    for state in ("revalidating", "approved", "submitting"):
+        await service.transition_rung(proposal_id, 0, new_state=state)
+
+
+async def _record_ack(service, proposal_id, *, now: datetime):
+    await _drive_to_submitting(service, proposal_id)
+    return await service.record_ack(
+        proposal_id,
+        0,
+        broker_order_id=f"B-ACK-{proposal_id}",
+        correlation_id=f"corr-ack-{proposal_id}",
+        idempotency_key=f"idem-ack-{proposal_id}",
+        approval_hash_digest=f"digest-ack-{proposal_id}",
+        now=now,
+    )
 
 
 @pytest.mark.asyncio
@@ -93,3 +128,399 @@ async def test_replacement_lineage_supersedes_original(db_session):
     assert orig_after.superseded_by_proposal_id == replacement.proposal_id
     assert replacement.root_proposal_id == original.root_proposal_id
     assert replacement.payload_hash != original.payload_hash
+
+
+@pytest.mark.asyncio
+async def test_approval_nonce_mismatch_and_reset(db_session):
+    service, group = await _create_single_rung(db_session)
+    now = datetime(2026, 7, 10, 9, 0, tzinfo=UTC)
+
+    result = await service.set_approval_nonce(group.proposal_id, "nonce-1")
+    assert result is None
+    await service.consume_approval_nonce(group.proposal_id, "nonce-1", now=now)
+
+    with pytest.raises(OrderProposalError, match="^nonce_mismatch$"):
+        await service.consume_approval_nonce(group.proposal_id, "wrong-nonce", now=now)
+
+    await service.set_approval_nonce(group.proposal_id, "nonce-2")
+    refreshed, _ = await service.get_proposal(group.proposal_id)
+    assert refreshed.approval_nonce == "nonce-2"
+    assert refreshed.approval_nonce_used_at is None
+
+
+@pytest.mark.asyncio
+async def test_approval_nonce_replay_blocked(db_session):
+    service, group = await _create_single_rung(db_session)
+    now = datetime(2026, 7, 10, 9, 1, tzinfo=UTC)
+    await service.set_approval_nonce(group.proposal_id, "nonce-1")
+    await db_session.commit()
+
+    consumed = await service.consume_approval_nonce(
+        group.proposal_id, "nonce-1", now=now
+    )
+    assert consumed.approval_nonce_used_at == now
+    await db_session.commit()
+
+    with pytest.raises(OrderProposalError, match="^nonce_replay$"):
+        await service.consume_approval_nonce(
+            group.proposal_id, "nonce-1", now=now + timedelta(seconds=1)
+        )
+
+
+@pytest.mark.asyncio
+async def test_commit_lease_blocks_active_and_reacquires_expired(db_session):
+    service, group = await _create_single_rung(db_session)
+    now = datetime(2026, 7, 10, 9, 2, tzinfo=UTC)
+
+    assert await service.acquire_commit_lease(
+        group.proposal_id, now=now, lease_seconds=10
+    )
+    assert not await service.acquire_commit_lease(
+        group.proposal_id, now=now + timedelta(seconds=9), lease_seconds=10
+    )
+    assert await service.acquire_commit_lease(
+        group.proposal_id, now=now + timedelta(seconds=10), lease_seconds=5
+    )
+
+    refreshed, _ = await service.get_proposal(group.proposal_id)
+    assert refreshed.commit_lease_until == now + timedelta(seconds=15)
+
+
+@pytest.mark.asyncio
+async def test_commit_lease_requires_timezone_aware_now(db_session):
+    service, group = await _create_single_rung(db_session)
+
+    with pytest.raises(ValueError, match="timezone-aware"):
+        await service.acquire_commit_lease(
+            group.proposal_id, now=datetime(2026, 7, 10, 9, 2)
+        )
+
+
+@pytest.mark.asyncio
+async def test_ack_is_accepted_not_filled_and_records_audit_fields(db_session):
+    service, group = await _create_single_rung(db_session)
+    now = datetime(2026, 7, 10, 9, 3, tzinfo=UTC)
+    await _drive_to_submitting(service, group.proposal_id)
+
+    rung = await service.record_ack(
+        group.proposal_id,
+        0,
+        broker_order_id="B1",
+        correlation_id="corr1",
+        idempotency_key="idem1",
+        approval_hash_digest="digest1",
+        now=now,
+    )
+
+    assert rung.state == "acked"
+    assert rung.broker_order_id == "B1"
+    assert rung.correlation_id == "corr1"
+    assert rung.idempotency_key == "idem1"
+    assert rung.approval_hash_digest == "digest1"
+    assert rung.validated_at == now
+    assert rung.updated_at == now
+    assert rung.filled_qty is None
+
+
+@pytest.mark.asyncio
+async def test_resting_is_not_filled_and_records_audit_fields(db_session):
+    service, group = await _create_single_rung(db_session)
+    now = datetime(2026, 7, 10, 9, 4, tzinfo=UTC)
+    await _drive_to_submitting(service, group.proposal_id)
+
+    rung = await service.record_resting(
+        group.proposal_id,
+        0,
+        broker_order_id="B2",
+        correlation_id="corr2",
+        idempotency_key="idem2",
+        approval_hash_digest="digest2",
+        now=now,
+    )
+
+    assert rung.state == "resting"
+    assert rung.broker_order_id == "B2"
+    assert rung.correlation_id == "corr2"
+    assert rung.idempotency_key == "idem2"
+    assert rung.approval_hash_digest == "digest2"
+    assert rung.validated_at == now
+    assert rung.updated_at == now
+    assert rung.filled_qty is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("source_state", ["submitting", "acked", "resting"])
+async def test_record_unverified_holds_for_later_evidence(db_session, source_state):
+    service, group = await _create_single_rung(db_session)
+    now = datetime(2026, 7, 10, 9, 5, tzinfo=UTC)
+    await _drive_to_submitting(service, group.proposal_id)
+    if source_state == "acked":
+        await service.record_ack(
+            group.proposal_id,
+            0,
+            broker_order_id="B3",
+            correlation_id="corr3",
+            idempotency_key="idem3",
+            approval_hash_digest="digest3",
+            now=now,
+        )
+    elif source_state == "resting":
+        await service.record_resting(
+            group.proposal_id,
+            0,
+            broker_order_id="B3",
+            correlation_id="corr3",
+            idempotency_key="idem3",
+            approval_hash_digest="digest3",
+            now=now,
+        )
+
+    rung = await service.record_unverified(
+        group.proposal_id,
+        0,
+        reason="broker_timeout",
+        now=now + timedelta(seconds=1),
+    )
+
+    assert rung.state == "unverified"
+    assert rung.void_reason == "broker_timeout"
+    assert rung.validated_at == now + timedelta(seconds=1)
+    assert rung.updated_at == now + timedelta(seconds=1)
+
+
+@pytest.mark.asyncio
+async def test_fill_evidence_books_by_correlation_id(db_session):
+    service, group = await _create_single_rung(db_session)
+    now = datetime(2026, 7, 10, 9, 6, tzinfo=UTC)
+    correlation_id = f"corr9-{group.proposal_id}"
+    await _drive_to_submitting(service, group.proposal_id)
+    await service.record_resting(
+        group.proposal_id,
+        0,
+        broker_order_id=f"B9-{group.proposal_id}",
+        correlation_id=correlation_id,
+        idempotency_key=f"idem9-{group.proposal_id}",
+        approval_hash_digest=f"digest9-{group.proposal_id}",
+        now=now,
+    )
+    await db_session.commit()
+
+    booked = await service.record_fill_evidence(
+        correlation_id=correlation_id, filled_qty=Decimal("1"), now=now
+    )
+
+    assert booked is not None
+    assert booked.state == "filled"
+    assert booked.filled_qty == Decimal("1")
+    assert booked.updated_at == now
+
+
+@pytest.mark.asyncio
+async def test_fill_evidence_books_partial_then_filled_by_broker_order_id(db_session):
+    service, group = await _create_single_rung(db_session)
+    now = datetime(2026, 7, 10, 9, 7, tzinfo=UTC)
+    acked = await _record_ack(service, group.proposal_id, now=now)
+    await db_session.commit()
+
+    partial = await service.record_fill_evidence(
+        broker_order_id=acked.broker_order_id,
+        filled_qty=Decimal("0.25"),
+        terminal_state="partially_filled",
+        now=now + timedelta(seconds=1),
+    )
+    assert partial is not None
+    assert partial.state == "partially_filled"
+    assert partial.filled_qty == Decimal("0.25")
+
+    filled = await service.record_fill_evidence(
+        broker_order_id=acked.broker_order_id,
+        filled_qty=Decimal("1"),
+        now=now + timedelta(seconds=2),
+    )
+    assert filled is not None
+    assert filled.state == "filled"
+    assert filled.filled_qty == Decimal("1")
+    assert filled.updated_at == now + timedelta(seconds=2)
+
+
+@pytest.mark.asyncio
+async def test_fill_evidence_resolves_unverified_rung(db_session):
+    service, group = await _create_single_rung(db_session)
+    now = datetime(2026, 7, 10, 9, 8, tzinfo=UTC)
+    acked = await _record_ack(service, group.proposal_id, now=now)
+    await service.record_unverified(
+        group.proposal_id, 0, reason="unknown", now=now + timedelta(seconds=1)
+    )
+    await db_session.commit()
+
+    booked = await service.record_fill_evidence(
+        correlation_id=acked.correlation_id,
+        filled_qty=Decimal("1"),
+        now=now + timedelta(seconds=2),
+    )
+
+    assert booked is not None
+    assert booked.state == "filled"
+    assert booked.filled_qty == Decimal("1")
+
+
+@pytest.mark.asyncio
+async def test_fill_evidence_missing_match_is_noop(db_session):
+    service, _ = await _create_single_rung(db_session)
+    now = datetime(2026, 7, 10, 9, 9, tzinfo=UTC)
+    missing = f"missing-{uuid.uuid4()}"
+
+    assert (
+        await service.record_fill_evidence(
+            correlation_id=missing, filled_qty=Decimal("1"), now=now
+        )
+        is None
+    )
+    assert (
+        await service.record_fill_evidence(
+            broker_order_id=missing, filled_qty=Decimal("1"), now=now
+        )
+        is None
+    )
+    assert await service.record_fill_evidence(filled_qty=Decimal("1"), now=now) is None
+
+
+@pytest.mark.asyncio
+async def test_mark_needs_reconfirm_bumps_revision(db_session):
+    service, group = await _create_single_rung(db_session)
+    now = datetime(2026, 7, 10, 9, 10, tzinfo=UTC)
+    await service.transition_rung(
+        group.proposal_id,
+        0,
+        new_state="revalidating",
+        approval_revision=2,
+    )
+
+    rung = await service.mark_needs_reconfirm(group.proposal_id, 0, now=now)
+
+    assert rung.state == "needs_reconfirm"
+    assert rung.approval_revision == 3
+    assert rung.validated_at == now
+    assert rung.updated_at == now
+
+
+@pytest.mark.asyncio
+async def test_record_rejected_records_reason_from_legal_state(db_session):
+    service, group = await _create_single_rung(db_session)
+    now = datetime(2026, 7, 10, 9, 11, tzinfo=UTC)
+
+    rung = await service.record_rejected(
+        group.proposal_id, 0, reason="operator_denied", now=now
+    )
+
+    assert rung.state == "rejected"
+    assert rung.void_reason == "operator_denied"
+    assert rung.updated_at == now
+
+
+@pytest.mark.asyncio
+async def test_record_rejected_does_not_bypass_state_machine(db_session):
+    service, group = await _create_single_rung(db_session)
+    now = datetime(2026, 7, 10, 9, 12, tzinfo=UTC)
+    await _record_ack(service, group.proposal_id, now=now)
+
+    with pytest.raises(OrderProposalInvalidStateTransition):
+        await service.record_rejected(
+            group.proposal_id, 0, reason="late_denial", now=now
+        )
+
+
+@pytest.mark.asyncio
+async def test_sweep_local_stale_only_voids_evidence_absent(db_session):
+    service = OrderProposalsService(db_session)
+    groups = []
+    rung_ids = []
+    for symbol in ("NO_ORDER", "TIMEOUT", "UNKNOWN"):
+        group = await service.create_proposal(
+            symbol=symbol,
+            market="equity_kr",
+            account_mode="kis_live",
+            side="buy",
+            order_type="limit",
+            proposer="p",
+            rungs=[RungInput(0, "buy", Decimal("1"), Decimal("100"), None)],
+        )
+        _, rungs = await service.get_proposal(group.proposal_id)
+        groups.append(group)
+        rung_ids.append(rungs[0].id)
+
+    with_broker = await service.create_proposal(
+        symbol="HAS_BROKER",
+        market="equity_kr",
+        account_mode="kis_live",
+        side="buy",
+        order_type="limit",
+        proposer="p",
+        rungs=[RungInput(0, "buy", Decimal("1"), Decimal("100"), None)],
+    )
+    await service.transition_rung(
+        with_broker.proposal_id,
+        0,
+        new_state="revalidating",
+        broker_order_id="B-present",
+    )
+    await service.transition_rung(
+        with_broker.proposal_id, 0, new_state="pending_approval"
+    )
+    _, with_broker_rungs = await service.get_proposal(with_broker.proposal_id)
+    not_pending = await service.create_proposal(
+        symbol="REVALIDATING",
+        market="equity_kr",
+        account_mode="kis_live",
+        side="buy",
+        order_type="limit",
+        proposer="p",
+        rungs=[RungInput(0, "buy", Decimal("1"), Decimal("100"), None)],
+    )
+    await service.transition_rung(not_pending.proposal_id, 0, new_state="revalidating")
+    _, not_pending_rungs = await service.get_proposal(not_pending.proposal_id)
+    await db_session.commit()
+
+    evidence_by_rung = dict(
+        zip(rung_ids, ("no_broker_order", "timeout", "unknown"), strict=True)
+    )
+    called = []
+
+    async def broker_evidence(rung):
+        called.append(rung.id)
+        return evidence_by_rung.get(rung.id, "unknown")
+
+    now = datetime(2026, 7, 10, 9, 13, tzinfo=UTC)
+    swept = await service.sweep_local_stale(now=now, broker_evidence=broker_evidence)
+
+    assert swept == [groups[0].proposal_id]
+    assert set(rung_ids).issubset(called)
+    assert with_broker_rungs[0].id not in called
+    assert not_pending_rungs[0].id not in called
+    states = []
+    for group in groups:
+        _, rungs = await service.get_proposal(group.proposal_id)
+        states.append(rungs[0].state)
+    assert states == ["voided_local_stale", "pending_approval", "pending_approval"]
+    _, swept_rungs = await service.get_proposal(groups[0].proposal_id)
+    assert swept_rungs[0].void_reason == "no_broker_order"
+    assert swept_rungs[0].updated_at == now
+
+
+@pytest.mark.asyncio
+async def test_sweep_local_stale_accepts_sync_evidence_callback(db_session):
+    service, group = await _create_single_rung(db_session, symbol="SYNC")
+    now = datetime(2026, 7, 10, 9, 14, tzinfo=UTC)
+    _, initial_rungs = await service.get_proposal(group.proposal_id)
+    target_rung_id = initial_rungs[0].id
+
+    swept = await service.sweep_local_stale(
+        now=now,
+        broker_evidence=lambda rung: (
+            "no_broker_order" if rung.id == target_rung_id else "unknown"
+        ),
+    )
+
+    assert group.proposal_id in swept
+    _, rungs = await service.get_proposal(group.proposal_id)
+    assert rungs[0].state == "voided_local_stale"

--- a/tests/services/order_proposals/test_service.py
+++ b/tests/services/order_proposals/test_service.py
@@ -168,6 +168,34 @@ async def test_approval_nonce_replay_blocked(db_session):
 
 
 @pytest.mark.asyncio
+async def test_record_approval_sets_telegram_user_and_timestamp(db_session):
+    service, group = await _create_single_rung(db_session)
+    now = datetime(2026, 7, 10, 9, 1, 30, tzinfo=UTC)
+
+    updated = await service.record_approval(
+        group.proposal_id, telegram_user_id="tg-12345", now=now
+    )
+
+    assert updated.approved_by_telegram_user_id == "tg-12345"
+    assert updated.approved_at == now
+
+    refreshed, _ = await service.get_proposal(group.proposal_id)
+    assert refreshed.approved_by_telegram_user_id == "tg-12345"
+    assert refreshed.approved_at == now
+
+
+@pytest.mark.asyncio
+async def test_record_approval_missing_proposal_raises(db_session):
+    service = OrderProposalsService(db_session)
+    with pytest.raises(OrderProposalNotFound):
+        await service.record_approval(
+            uuid.uuid4(),
+            telegram_user_id="tg-1",
+            now=datetime(2026, 7, 10, 9, 1, 31, tzinfo=UTC),
+        )
+
+
+@pytest.mark.asyncio
 async def test_commit_lease_blocks_active_and_reacquires_expired(db_session):
     service, group = await _create_single_rung(db_session)
     now = datetime(2026, 7, 10, 9, 2, tzinfo=UTC)

--- a/tests/services/order_proposals/test_telegram_callback.py
+++ b/tests/services/order_proposals/test_telegram_callback.py
@@ -8,6 +8,7 @@ from decimal import Decimal
 import pytest
 
 from app.core.config import settings
+from app.core.db import AsyncSessionLocal
 from app.services.order_proposals import OrderProposalsService
 from app.services.order_proposals.approval_message import parse_callback_data
 from app.services.order_proposals.revalidation import RungOutcome
@@ -395,6 +396,202 @@ async def test_never_raises_on_internal_error(monkeypatch, db_session):
     assert result["handled"] is False
     assert result["reason"] == "internal_error"
     assert notifier.answered  # best-effort answer still attempted
+
+
+# ---------------------------------------------------------------------------
+# Review Finding 1 — commit-before-notify ordering: a Telegram notify failure
+# must never roll back an already-committed DB mutation, and the returned
+# result must reflect the real outcome (not "internal_error").
+# ---------------------------------------------------------------------------
+
+
+class _EditRaisingNotifier(_FakeNotifier):
+    async def edit_message(self, chat_id, message_id, text, reply_markup=None):
+        raise RuntimeError("telegram edit_message boom")
+
+
+@pytest.mark.asyncio
+async def test_deny_survives_notify_failure_and_stays_committed(
+    monkeypatch, db_session
+):
+    _allow_chat(monkeypatch)
+    group = await _seed_proposal(db_session, nonce="nonce-notifyfail-dn", rungs=2)
+    data = f"dn:{str(group.proposal_id)[:8]}:nonce-notifyfail-dn"
+    notifier = _EditRaisingNotifier()
+
+    async def fake_revalidate(**kwargs):
+        raise AssertionError("deny must not revalidate")
+
+    result = await handle_callback_update(
+        _make_update(data=data),
+        now=datetime.now(UTC),
+        service_factory=_session_factory(db_session),
+        notifier=notifier,
+        revalidate_fn=fake_revalidate,
+    )
+
+    # The notify failure must not surface as an uncaught exception / be
+    # mis-reported as "internal_error" -- the real outcome (denied) is
+    # reflected in the result even though edit_message raised.
+    assert result["handled"] is True
+    assert result["reason"] == "denied"
+    assert sorted(result["rejected_rungs"]) == [0, 1]
+
+    # Prove the reject transitions were truly COMMITTED (not merely
+    # flushed-and-then-rolled-back by the notify exception) by reading them
+    # back through a brand-new, independent session against the same DB.
+    async with AsyncSessionLocal() as fresh_session:
+        fresh_service = OrderProposalsService(fresh_session)
+        _fresh_group, fresh_rungs = await fresh_service.get_proposal(group.proposal_id)
+    assert all(r.state == "rejected" for r in fresh_rungs)
+
+
+@pytest.mark.asyncio
+async def test_approve_survives_notify_failure_and_stays_committed(
+    monkeypatch, db_session
+):
+    _allow_chat(monkeypatch)
+    group = await _seed_proposal(db_session, nonce="nonce-notifyfail-op")
+    data = f"op:{str(group.proposal_id)[:8]}:nonce-notifyfail-op"
+    notifier = _EditRaisingNotifier()
+
+    async def fake_revalidate(*, service, proposal_id, now):
+        # Mimic what the real `revalidate_and_submit` does (transition
+        # through the full state chain and record via the service) so this
+        # test proves the rung's real, service-recorded "resting" state
+        # survives -- not just a returned-but-never-persisted RungOutcome.
+        await service.transition_rung(proposal_id, 0, new_state="revalidating")
+        await service.transition_rung(proposal_id, 0, new_state="approved")
+        await service.transition_rung(proposal_id, 0, new_state="submitting")
+        await service.record_resting(
+            proposal_id,
+            0,
+            broker_order_id="B1",
+            correlation_id="corr-1",
+            idempotency_key="idem-1",
+            approval_hash_digest="hash-1",
+            now=now,
+        )
+        return [
+            RungOutcome(
+                0,
+                "submitted_resting",
+                {"submit": {"broker_order_id": "B1"}},
+            )
+        ]
+
+    result = await handle_callback_update(
+        _make_update(data=data),
+        now=datetime.now(UTC),
+        service_factory=_session_factory(db_session),
+        notifier=notifier,
+        revalidate_fn=fake_revalidate,
+    )
+
+    assert result["handled"] is True
+    assert result["reason"] == "approved"
+    assert result["results"] == ["submitted_resting"]
+
+    # Prove record_approval + the rung's "resting" transition were truly
+    # committed before the (raising) edit_message call, via an independent
+    # session.
+    async with AsyncSessionLocal() as fresh_session:
+        fresh_service = OrderProposalsService(fresh_session)
+        fresh_group, fresh_rungs = await fresh_service.get_proposal(group.proposal_id)
+    assert fresh_group.approved_by_telegram_user_id == str(USER_ID)
+    assert fresh_group.approval_nonce_used_at is not None
+    assert fresh_rungs[0].state == "resting"
+
+
+# ---------------------------------------------------------------------------
+# Review Finding 2 — multi-rung `needs_reconfirm` must not silently drop
+# information: every reconfirming rung's before/after must be visible, and
+# any non-reconfirming outcome in the same batch must also be reported.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_needs_reconfirm_multi_rung_shows_every_diff(monkeypatch, db_session):
+    _allow_chat(monkeypatch)
+    group = await _seed_proposal(db_session, nonce="nonce-multi-recon", rungs=2)
+    data = f"op:{str(group.proposal_id)[:8]}:nonce-multi-recon"
+    notifier = _FakeNotifier()
+
+    diff0 = {
+        "before": {"limit_price": "100", "quantity": "10"},
+        "after": {"limit_price": "105", "quantity": "10"},
+    }
+    diff1 = {
+        "before": {"limit_price": "200", "quantity": "20"},
+        "after": {"limit_price": "222", "quantity": "20"},
+    }
+
+    async def fake_revalidate(*, service, proposal_id, now):
+        return [
+            RungOutcome(0, "needs_reconfirm", diff0),
+            RungOutcome(1, "needs_reconfirm", diff1),
+        ]
+
+    result = await handle_callback_update(
+        _make_update(data=data),
+        now=datetime.now(UTC),
+        service_factory=_session_factory(db_session),
+        notifier=notifier,
+        revalidate_fn=fake_revalidate,
+    )
+
+    assert result["handled"] is True
+    assert result["reason"] == "needs_reconfirm"
+    assert len(notifier.sent_messages) == 1
+    new_text, _new_keyboard, _sent_chat_id = notifier.sent_messages[0]
+
+    # Rung #1's diff (rendered by build_approval_message's base `diff=`).
+    assert "105" in new_text
+    # Rung #2's diff must ALSO be visible -- previously silently dropped.
+    assert "200" in new_text
+    assert "222" in new_text
+    assert "추가 재확인 필요" in new_text
+
+
+@pytest.mark.asyncio
+async def test_needs_reconfirm_mixed_batch_reports_other_outcome(
+    monkeypatch, db_session
+):
+    _allow_chat(monkeypatch)
+    group = await _seed_proposal(db_session, nonce="nonce-mixed-recon", rungs=2)
+    data = f"op:{str(group.proposal_id)[:8]}:nonce-mixed-recon"
+    notifier = _FakeNotifier()
+
+    diff1 = {
+        "before": {"limit_price": "200", "quantity": "20"},
+        "after": {"limit_price": "222", "quantity": "20"},
+    }
+
+    async def fake_revalidate(*, service, proposal_id, now):
+        return [
+            RungOutcome(0, "submitted_resting", {"submit": {"broker_order_id": "B1"}}),
+            RungOutcome(1, "needs_reconfirm", diff1),
+        ]
+
+    result = await handle_callback_update(
+        _make_update(data=data),
+        now=datetime.now(UTC),
+        service_factory=_session_factory(db_session),
+        notifier=notifier,
+        revalidate_fn=fake_revalidate,
+    )
+
+    assert result["handled"] is True
+    assert result["reason"] == "needs_reconfirm"
+    assert len(notifier.sent_messages) == 1
+    new_text, _new_keyboard, _sent_chat_id = notifier.sent_messages[0]
+
+    # Rung #2's reconfirm diff (base `diff=` from build_approval_message).
+    assert "222" in new_text
+    # Rung #1's submitted_resting outcome must ALSO be reported -- previously
+    # never surfaced anywhere because the reconfirm branch short-circuited.
+    assert "처리 결과" in new_text
+    assert "주문 유지" in new_text  # _RESULT_LABELS["submitted_resting"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/services/order_proposals/test_telegram_callback.py
+++ b/tests/services/order_proposals/test_telegram_callback.py
@@ -1,0 +1,440 @@
+from __future__ import annotations
+
+import contextlib
+import uuid
+from datetime import UTC, datetime
+from decimal import Decimal
+
+import pytest
+
+from app.core.config import settings
+from app.services.order_proposals import OrderProposalsService
+from app.services.order_proposals.approval_message import parse_callback_data
+from app.services.order_proposals.revalidation import RungOutcome
+from app.services.order_proposals.service import RungInput
+from app.services.order_proposals.telegram_callback import (
+    _resolve_proposal_id,
+    handle_callback_update,
+)
+
+CHAT_ID = 42
+USER_ID = 777
+
+
+class _FakeNotifier:
+    def __init__(self) -> None:
+        self.sent_messages: list[tuple[str, dict, str]] = []
+        self.answered: list[tuple[str, str | None]] = []
+        self.edited: list[tuple[str, int, str, dict | None]] = []
+        self._next_message_id = 9000
+
+    async def send_approval_message(self, text, inline_keyboard, *, chat_id):
+        self._next_message_id += 1
+        self.sent_messages.append((text, inline_keyboard, chat_id))
+        return self._next_message_id
+
+    async def answer_callback(self, callback_query_id, text=None):
+        self.answered.append((callback_query_id, text))
+        return True
+
+    async def edit_message(self, chat_id, message_id, text, reply_markup=None):
+        self.edited.append((chat_id, message_id, text, reply_markup))
+        return True
+
+
+def _session_factory(db_session):
+    @contextlib.asynccontextmanager
+    async def _factory():
+        yield db_session
+
+    return _factory
+
+
+def _make_update(*, data, chat_id=CHAT_ID, user_id=USER_ID, callback_id="cbq-1"):
+    return {
+        "callback_query": {
+            "id": callback_id,
+            "from": {"id": user_id},
+            "message": {"chat": {"id": chat_id}, "message_id": 555},
+            "data": data,
+        }
+    }
+
+
+async def _seed_proposal(db_session, *, nonce="nonce-abc123", symbol="A", rungs=1):
+    service = OrderProposalsService(db_session)
+    rung_inputs = [
+        RungInput(i, "buy", Decimal("10"), Decimal("100"), None) for i in range(rungs)
+    ]
+    group = await service.create_proposal(
+        symbol=symbol,
+        market="equity_kr",
+        account_mode="kis_live",
+        side="buy",
+        order_type="limit",
+        proposer="p",
+        rungs=rung_inputs,
+    )
+    await service.set_approval_nonce(group.proposal_id, nonce)
+    await db_session.commit()
+    return group
+
+
+def _allow_chat(monkeypatch, chat_id=CHAT_ID):
+    monkeypatch.setattr(
+        settings, "ORDER_PROPOSALS_TELEGRAM_CHAT_ALLOWLIST_STR", str(chat_id)
+    )
+
+
+@pytest.mark.asyncio
+async def test_not_a_callback_query_is_unhandled(monkeypatch, db_session):
+    notifier = _FakeNotifier()
+    result = await handle_callback_update(
+        {"message": {"text": "hi"}},
+        now=datetime.now(UTC),
+        service_factory=_session_factory(db_session),
+        notifier=notifier,
+    )
+    assert result == {"handled": False, "reason": "not_callback"}
+    assert notifier.answered == []
+
+
+@pytest.mark.asyncio
+async def test_chat_not_in_allowlist_rejected(monkeypatch, db_session):
+    # allowlist empty -> any chat rejected; assert no revalidation invoked.
+    monkeypatch.setattr(settings, "ORDER_PROPOSALS_TELEGRAM_CHAT_ALLOWLIST_STR", "")
+    group = await _seed_proposal(db_session)
+    data = f"op:{str(group.proposal_id)[:8]}:nonce-abc123"
+    notifier = _FakeNotifier()
+
+    revalidate_calls = []
+
+    async def fake_revalidate(**kwargs):
+        revalidate_calls.append(kwargs)
+        raise AssertionError("revalidate_fn must not be called")
+
+    result = await handle_callback_update(
+        _make_update(data=data),
+        now=datetime.now(UTC),
+        service_factory=_session_factory(db_session),
+        notifier=notifier,
+        revalidate_fn=fake_revalidate,
+    )
+
+    assert result == {"handled": False, "reason": "chat_not_allowed"}
+    assert revalidate_calls == []
+    assert notifier.answered == [("cbq-1", "허용되지 않은 채팅")]
+    assert notifier.edited == []
+
+
+@pytest.mark.asyncio
+async def test_approve_happy_path_submits_and_edits(monkeypatch, db_session):
+    # allowlist includes chat; nonce valid; revalidate_fn returns submitted_resting;
+    # assert edit_message called with a summary, answer_callback called,
+    # nonce consumed, approved_by_telegram_user_id recorded.
+    _allow_chat(monkeypatch)
+    group = await _seed_proposal(db_session, nonce="nonce-happy1")
+    data = f"op:{str(group.proposal_id)[:8]}:nonce-happy1"
+    notifier = _FakeNotifier()
+
+    async def fake_revalidate(*, service, proposal_id, now):
+        assert proposal_id == group.proposal_id
+        return [
+            RungOutcome(
+                0,
+                "submitted_resting",
+                {"submit": {"broker_order_id": "B1"}},
+            )
+        ]
+
+    result = await handle_callback_update(
+        _make_update(data=data),
+        now=datetime.now(UTC),
+        service_factory=_session_factory(db_session),
+        notifier=notifier,
+        revalidate_fn=fake_revalidate,
+    )
+
+    assert result["handled"] is True
+    assert result["reason"] == "approved"
+    assert len(notifier.edited) == 1
+    chat_id, message_id, text, _reply_markup = notifier.edited[0]
+    assert chat_id == CHAT_ID
+    assert message_id == 555
+    assert "주문 유지" in text or "resting" in text.lower() or text
+    assert notifier.answered  # answer_callback was invoked
+
+    service = OrderProposalsService(db_session)
+    refreshed, _rungs = await service.get_proposal(group.proposal_id)
+    assert refreshed.approval_nonce_used_at is not None
+    assert refreshed.approved_by_telegram_user_id == str(USER_ID)
+    assert refreshed.approved_at is not None
+
+
+@pytest.mark.asyncio
+async def test_replayed_nonce_does_not_resubmit(monkeypatch, db_session):
+    # second identical callback -> nonce_replay -> no second revalidate call.
+    _allow_chat(monkeypatch)
+    group = await _seed_proposal(db_session, nonce="nonce-replay1")
+    data = f"op:{str(group.proposal_id)[:8]}:nonce-replay1"
+    notifier = _FakeNotifier()
+
+    call_count = 0
+
+    async def fake_revalidate(*, service, proposal_id, now):
+        nonlocal call_count
+        call_count += 1
+        return [RungOutcome(0, "submitted_resting", {"submit": {}})]
+
+    first = await handle_callback_update(
+        _make_update(data=data, callback_id="cbq-first"),
+        now=datetime.now(UTC),
+        service_factory=_session_factory(db_session),
+        notifier=notifier,
+        revalidate_fn=fake_revalidate,
+    )
+    assert first["handled"] is True
+    assert call_count == 1
+
+    second = await handle_callback_update(
+        _make_update(data=data, callback_id="cbq-second"),
+        now=datetime.now(UTC),
+        service_factory=_session_factory(db_session),
+        notifier=notifier,
+        revalidate_fn=fake_revalidate,
+    )
+
+    assert call_count == 1  # no second submit
+    assert second["handled"] is False
+    assert second["reason"] == "nonce_replay"
+
+
+@pytest.mark.asyncio
+async def test_nonce_mismatch_rejected(monkeypatch, db_session):
+    _allow_chat(monkeypatch)
+    group = await _seed_proposal(db_session, nonce="nonce-real")
+    data = f"op:{str(group.proposal_id)[:8]}:nonce-wrong1"
+    notifier = _FakeNotifier()
+
+    async def fake_revalidate(**kwargs):
+        raise AssertionError("must not be reached")
+
+    result = await handle_callback_update(
+        _make_update(data=data),
+        now=datetime.now(UTC),
+        service_factory=_session_factory(db_session),
+        notifier=notifier,
+        revalidate_fn=fake_revalidate,
+    )
+
+    assert result["handled"] is False
+    assert result["reason"] == "nonce_mismatch"
+    assert notifier.answered
+
+
+@pytest.mark.asyncio
+async def test_needs_reconfirm_sends_new_diff_message(monkeypatch, db_session):
+    # revalidate_fn returns needs_reconfirm with a diff -> a NEW approval message
+    # (fresh nonce) is sent; original edited to "재확인 필요".
+    _allow_chat(monkeypatch)
+    group = await _seed_proposal(db_session, nonce="nonce-recon1")
+    data = f"op:{str(group.proposal_id)[:8]}:nonce-recon1"
+    notifier = _FakeNotifier()
+
+    diff = {
+        "before": {"limit_price": "100", "quantity": "10"},
+        "after": {"limit_price": "105", "quantity": "10"},
+    }
+
+    async def fake_revalidate(*, service, proposal_id, now):
+        return [RungOutcome(0, "needs_reconfirm", diff)]
+
+    result = await handle_callback_update(
+        _make_update(data=data),
+        now=datetime.now(UTC),
+        service_factory=_session_factory(db_session),
+        notifier=notifier,
+        revalidate_fn=fake_revalidate,
+    )
+
+    assert result["handled"] is True
+    assert result["reason"] == "needs_reconfirm"
+
+    assert len(notifier.edited) == 1
+    _chat_id, _message_id, edited_text, _markup = notifier.edited[0]
+    assert "재확인 필요" in edited_text
+
+    assert len(notifier.sent_messages) == 1
+    new_text, new_keyboard, sent_chat_id = notifier.sent_messages[0]
+    assert sent_chat_id == str(CHAT_ID)
+    assert "재확인 변경사항" in new_text
+    new_callback_data = new_keyboard["inline_keyboard"][0][0]["callback_data"]
+    new_action, new_short, new_nonce = parse_callback_data(new_callback_data)
+    assert new_action == "op"
+    assert new_short == str(group.proposal_id)[:8]
+    assert new_nonce != "nonce-recon1"
+
+    service = OrderProposalsService(db_session)
+    refreshed, _rungs = await service.get_proposal(group.proposal_id)
+    assert refreshed.approval_nonce == new_nonce
+    assert refreshed.approved_by_telegram_user_id == str(USER_ID)
+
+
+@pytest.mark.asyncio
+async def test_deny_transitions_all_rungs_to_rejected(monkeypatch, db_session):
+    _allow_chat(monkeypatch)
+    group = await _seed_proposal(db_session, nonce="nonce-deny1", rungs=2)
+    data = f"dn:{str(group.proposal_id)[:8]}:nonce-deny1"
+    notifier = _FakeNotifier()
+
+    async def fake_revalidate(**kwargs):
+        raise AssertionError("deny must not revalidate")
+
+    result = await handle_callback_update(
+        _make_update(data=data),
+        now=datetime.now(UTC),
+        service_factory=_session_factory(db_session),
+        notifier=notifier,
+        revalidate_fn=fake_revalidate,
+    )
+
+    assert result["handled"] is True
+    assert result["reason"] == "denied"
+    assert sorted(result["rejected_rungs"]) == [0, 1]
+
+    service = OrderProposalsService(db_session)
+    _group, rungs = await service.get_proposal(group.proposal_id)
+    assert all(r.state == "rejected" for r in rungs)
+    assert len(notifier.edited) == 1
+    assert "거부" in notifier.edited[0][2]
+    assert notifier.answered
+
+
+@pytest.mark.asyncio
+async def test_lease_held_blocks_second_approval(monkeypatch, db_session):
+    _allow_chat(monkeypatch)
+    group = await _seed_proposal(db_session, nonce="nonce-lease1")
+    data = f"op:{str(group.proposal_id)[:8]}:nonce-lease1"
+    notifier = _FakeNotifier()
+
+    service = OrderProposalsService(db_session)
+    assert await service.acquire_commit_lease(
+        group.proposal_id, now=datetime.now(UTC), lease_seconds=30
+    )
+    await db_session.commit()
+
+    async def fake_revalidate(**kwargs):
+        raise AssertionError("must not be reached while lease held")
+
+    result = await handle_callback_update(
+        _make_update(data=data),
+        now=datetime.now(UTC),
+        service_factory=_session_factory(db_session),
+        notifier=notifier,
+        revalidate_fn=fake_revalidate,
+    )
+
+    assert result["handled"] is False
+    assert result["reason"] == "lease_held"
+    assert notifier.answered == [("cbq-1", "처리 중")]
+
+
+@pytest.mark.asyncio
+async def test_malformed_callback_data_rejected(monkeypatch, db_session):
+    _allow_chat(monkeypatch)
+    notifier = _FakeNotifier()
+
+    result = await handle_callback_update(
+        _make_update(data="not-valid-data"),
+        now=datetime.now(UTC),
+        service_factory=_session_factory(db_session),
+        notifier=notifier,
+    )
+
+    assert result["handled"] is False
+    assert result["reason"] == "malformed_callback_data"
+    assert notifier.answered
+
+
+@pytest.mark.asyncio
+async def test_proposal_not_found_for_unknown_prefix(monkeypatch, db_session):
+    _allow_chat(monkeypatch)
+    notifier = _FakeNotifier()
+    data = "op:deadbeef:some-nonce-1"
+
+    result = await handle_callback_update(
+        _make_update(data=data),
+        now=datetime.now(UTC),
+        service_factory=_session_factory(db_session),
+        notifier=notifier,
+    )
+
+    assert result["handled"] is False
+    assert result["reason"] == "proposal_not_found"
+    assert notifier.answered
+
+
+@pytest.mark.asyncio
+async def test_never_raises_on_internal_error(monkeypatch, db_session):
+    _allow_chat(monkeypatch)
+    group = await _seed_proposal(db_session, nonce="nonce-boom1")
+    data = f"op:{str(group.proposal_id)[:8]}:nonce-boom1"
+    notifier = _FakeNotifier()
+
+    async def exploding_revalidate(**kwargs):
+        raise RuntimeError("boom")
+
+    result = await handle_callback_update(
+        _make_update(data=data),
+        now=datetime.now(UTC),
+        service_factory=_session_factory(db_session),
+        notifier=notifier,
+        revalidate_fn=exploding_revalidate,
+    )
+
+    assert result["handled"] is False
+    assert result["reason"] == "internal_error"
+    assert notifier.answered  # best-effort answer still attempted
+
+
+# ---------------------------------------------------------------------------
+# `_resolve_proposal_id` — short-prefix resolution edge cases (gap #2).
+# ---------------------------------------------------------------------------
+
+
+class _FakeGroup:
+    def __init__(self, proposal_id: uuid.UUID) -> None:
+        self.proposal_id = proposal_id
+
+
+class _FakeListRecentService:
+    def __init__(self, ids: list[uuid.UUID]) -> None:
+        self._ids = ids
+        self.calls: list[dict] = []
+
+    async def list_recent(self, *, lifecycle_state, limit):
+        self.calls.append({"lifecycle_state": lifecycle_state, "limit": limit})
+        return [(_FakeGroup(pid), []) for pid in self._ids]
+
+
+@pytest.mark.asyncio
+async def test_resolve_proposal_id_zero_matches_returns_none():
+    svc = _FakeListRecentService([])
+    assert await _resolve_proposal_id(svc, "deadbeef") is None
+    assert svc.calls[0]["lifecycle_state"] == "proposed"
+
+
+@pytest.mark.asyncio
+async def test_resolve_proposal_id_multiple_matches_returns_none():
+    pid1 = uuid.UUID("deadbeef-0000-0000-0000-000000000001")
+    pid2 = uuid.UUID("deadbeef-0000-0000-0000-000000000002")
+    svc = _FakeListRecentService([pid1, pid2])
+    assert await _resolve_proposal_id(svc, "deadbeef") is None
+
+
+@pytest.mark.asyncio
+async def test_resolve_proposal_id_unique_match_returns_id():
+    pid1 = uuid.UUID("deadbeef-0000-0000-0000-000000000001")
+    pid2 = uuid.UUID("cafebabe-0000-0000-0000-000000000002")
+    svc = _FakeListRecentService([pid1, pid2])
+    assert await _resolve_proposal_id(svc, "deadbeef") == pid1

--- a/tests/services/order_proposals/test_telegram_callback.py
+++ b/tests/services/order_proposals/test_telegram_callback.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import contextlib
 import uuid
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from decimal import Decimal
 
 import pytest
@@ -592,6 +592,157 @@ async def test_needs_reconfirm_mixed_batch_reports_other_outcome(
     # never surfaced anywhere because the reconfirm branch short-circuited.
     assert "처리 결과" in new_text
     assert "주문 유지" in new_text  # _RESULT_LABELS["submitted_resting"]
+
+
+# ---------------------------------------------------------------------------
+# Final-review Finding 2 — a rung stuck in `needs_reconfirm` must be
+# transitioned back to `pending_approval` before the second `revalidate_fn`
+# call, so a second Approve click on the reconfirm message actually
+# re-submits instead of silently no-op'ing forever.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_reconfirm_click_transitions_rung_and_reenters_revalidation(
+    monkeypatch, db_session
+):
+    _allow_chat(monkeypatch)
+    group = await _seed_proposal(db_session, nonce="nonce-cycle1")
+    data = f"op:{str(group.proposal_id)[:8]}:nonce-cycle1"
+    notifier = _FakeNotifier()
+
+    diff = {
+        "before": {"limit_price": "100", "quantity": "10"},
+        "after": {"limit_price": "105", "quantity": "10"},
+    }
+    observed_states: list[str] = []
+
+    async def fake_revalidate(*, service, proposal_id, now):
+        # Spy on the rung's state at the moment revalidate_fn is invoked --
+        # the fix under test transitions needs_reconfirm -> pending_approval
+        # BEFORE this call, so the first call sees pending_approval (initial
+        # create) and the second call must ALSO see pending_approval (post
+        # re-approve transition), never needs_reconfirm. Mimic the real
+        # `revalidate_and_submit`'s own DB transitions (not just a returned
+        # RungOutcome) so the rung's real state after each call matches what
+        # a genuine reconfirm cycle would leave behind.
+        _g, rungs = await service.get_proposal(proposal_id)
+        observed_states.append(rungs[0].state)
+        if len(observed_states) == 1:
+            await service.transition_rung(proposal_id, 0, new_state="revalidating")
+            await service.mark_needs_reconfirm(proposal_id, 0, now=now)
+            return [RungOutcome(0, "needs_reconfirm", diff)]
+        await service.transition_rung(proposal_id, 0, new_state="revalidating")
+        await service.transition_rung(proposal_id, 0, new_state="approved")
+        await service.transition_rung(proposal_id, 0, new_state="submitting")
+        await service.record_resting(
+            proposal_id,
+            0,
+            broker_order_id="B1",
+            correlation_id="corr-1",
+            idempotency_key="idem-1",
+            approval_hash_digest="hash-1",
+            now=now,
+        )
+        return [
+            RungOutcome(0, "submitted_resting", {"submit": {"broker_order_id": "B1"}})
+        ]
+
+    first_now = datetime.now(UTC)
+    first = await handle_callback_update(
+        _make_update(data=data, callback_id="cbq-1st"),
+        now=first_now,
+        service_factory=_session_factory(db_session),
+        notifier=notifier,
+        revalidate_fn=fake_revalidate,
+    )
+    assert first["handled"] is True
+    assert first["reason"] == "needs_reconfirm"
+    assert observed_states == ["pending_approval"]
+
+    service = OrderProposalsService(db_session)
+    _group, rungs = await service.get_proposal(group.proposal_id)
+    assert rungs[0].state == "needs_reconfirm"
+
+    _new_text, new_keyboard, _sent_chat_id = notifier.sent_messages[0]
+    new_callback_data = new_keyboard["inline_keyboard"][0][0]["callback_data"]
+    _new_action, _new_short, new_nonce = parse_callback_data(new_callback_data)
+    second_data = f"op:{str(group.proposal_id)[:8]}:{new_nonce}"
+
+    # `acquire_commit_lease`'s default 10s lease was taken by the first call
+    # -- advance `now` well past it so the second click isn't spuriously
+    # blocked by `lease_held` (a real second click would arrive well after
+    # 10s of human reaction time to the reconfirm message anyway).
+    second_now = first_now + timedelta(seconds=30)
+    second = await handle_callback_update(
+        _make_update(data=second_data, callback_id="cbq-2nd"),
+        now=second_now,
+        service_factory=_session_factory(db_session),
+        notifier=notifier,
+        revalidate_fn=fake_revalidate,
+    )
+
+    # The second click must actually reach revalidate_fn again (not be
+    # skipped because the rung was still parked in needs_reconfirm), and by
+    # the time it runs the rung must already be back in pending_approval.
+    assert observed_states == ["pending_approval", "pending_approval"]
+    assert second["handled"] is True
+    assert second["reason"] == "approved"
+    assert second["results"] == ["submitted_resting"]
+
+    _final_group, final_rungs = await service.get_proposal(group.proposal_id)
+    assert final_rungs[0].state == "resting"
+
+
+# ---------------------------------------------------------------------------
+# Final-review Finding 4 — a reconfirm resend must refresh
+# source_asof.approval_message_id to the NEW message id, not leave it
+# pointing at the original dispatch.py message.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_reconfirm_resend_refreshes_approval_message_id(monkeypatch, db_session):
+    _allow_chat(monkeypatch)
+    group = await _seed_proposal(db_session, nonce="nonce-msgid1")
+    seed_service = OrderProposalsService(db_session)
+    await seed_service.record_approval_dispatch(
+        group.proposal_id,
+        message_id=111,
+        chat_id=str(CHAT_ID),
+        now=datetime.now(UTC),
+    )
+    await db_session.commit()
+
+    data = f"op:{str(group.proposal_id)[:8]}:nonce-msgid1"
+    notifier = _FakeNotifier()
+
+    diff = {
+        "before": {"limit_price": "100", "quantity": "10"},
+        "after": {"limit_price": "105", "quantity": "10"},
+    }
+
+    async def fake_revalidate(*, service, proposal_id, now):
+        return [RungOutcome(0, "needs_reconfirm", diff)]
+
+    result = await handle_callback_update(
+        _make_update(data=data),
+        now=datetime.now(UTC),
+        service_factory=_session_factory(db_session),
+        notifier=notifier,
+        revalidate_fn=fake_revalidate,
+    )
+
+    assert result["handled"] is True
+    assert result["reason"] == "needs_reconfirm"
+    new_message_id = result["new_message_id"]
+    assert new_message_id is not None
+    assert new_message_id != 111
+
+    service = OrderProposalsService(db_session)
+    refreshed, _rungs = await service.get_proposal(group.proposal_id)
+    assert refreshed.source_asof["approval_message_id"] == new_message_id
+    assert refreshed.source_asof["approval_message_id"] != 111
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_mcp_order_proposal_tools.py
+++ b/tests/test_mcp_order_proposal_tools.py
@@ -1,6 +1,117 @@
 import pytest
 
+from app.core.config import settings
 from app.mcp_server.tooling import order_proposal_tools as opt
+
+
+class _FakeNotifier:
+    def __init__(self, *, message_id: int | None = 4242) -> None:
+        self.calls: list[tuple[str, dict, str]] = []
+        self._message_id = message_id
+
+    async def send_approval_message(self, text, inline_keyboard, *, chat_id):
+        self.calls.append((text, inline_keyboard, chat_id))
+        return self._message_id
+
+
+class _RaisingNotifier:
+    async def send_approval_message(self, text, inline_keyboard, *, chat_id):
+        raise RuntimeError("telegram down")
+
+
+def _create_kwargs(**overrides):
+    kwargs = {
+        "symbol": "005930",
+        "market": "equity_kr",
+        "account_mode": "kis_live",
+        "side": "buy",
+        "order_type": "limit",
+        "proposer": "operator:sess-dispatch",
+        "thesis": "t",
+        "strategy": "ladder",
+        "rungs": [
+            {
+                "rung_index": 0,
+                "side": "buy",
+                "quantity": "10",
+                "limit_price": "70000",
+                "notional": None,
+            }
+        ],
+    }
+    kwargs.update(overrides)
+    return kwargs
+
+
+@pytest.mark.asyncio
+async def test_create_dispatches_telegram_when_enabled_and_allowlisted(monkeypatch):
+    monkeypatch.setattr(settings, "ORDER_PROPOSALS_TELEGRAM_ENABLED", True)
+    monkeypatch.setattr(
+        settings, "ORDER_PROPOSALS_TELEGRAM_CHAT_ALLOWLIST_STR", "chat-1"
+    )
+    fake_notifier = _FakeNotifier(message_id=9999)
+    monkeypatch.setattr(
+        "app.monitoring.trade_notifier.notifier.get_trade_notifier",
+        lambda: fake_notifier,
+    )
+
+    created = await opt.order_proposal_create(**_create_kwargs())
+
+    assert created["success"] is True
+    assert len(fake_notifier.calls) == 1
+    _, _, chat_id = fake_notifier.calls[0]
+    assert chat_id == "chat-1"
+
+
+@pytest.mark.asyncio
+async def test_create_does_not_dispatch_when_telegram_disabled(monkeypatch):
+    monkeypatch.setattr(settings, "ORDER_PROPOSALS_TELEGRAM_ENABLED", False)
+    monkeypatch.setattr(
+        settings, "ORDER_PROPOSALS_TELEGRAM_CHAT_ALLOWLIST_STR", "chat-1"
+    )
+    fake_notifier = _FakeNotifier()
+    monkeypatch.setattr(
+        "app.monitoring.trade_notifier.notifier.get_trade_notifier",
+        lambda: fake_notifier,
+    )
+
+    created = await opt.order_proposal_create(**_create_kwargs())
+
+    assert created["success"] is True
+    assert fake_notifier.calls == []
+
+
+@pytest.mark.asyncio
+async def test_create_does_not_dispatch_when_allowlist_empty(monkeypatch):
+    monkeypatch.setattr(settings, "ORDER_PROPOSALS_TELEGRAM_ENABLED", True)
+    monkeypatch.setattr(settings, "ORDER_PROPOSALS_TELEGRAM_CHAT_ALLOWLIST_STR", "")
+    fake_notifier = _FakeNotifier()
+    monkeypatch.setattr(
+        "app.monitoring.trade_notifier.notifier.get_trade_notifier",
+        lambda: fake_notifier,
+    )
+
+    created = await opt.order_proposal_create(**_create_kwargs())
+
+    assert created["success"] is True
+    assert fake_notifier.calls == []
+
+
+@pytest.mark.asyncio
+async def test_create_succeeds_even_when_notifier_raises(monkeypatch):
+    monkeypatch.setattr(settings, "ORDER_PROPOSALS_TELEGRAM_ENABLED", True)
+    monkeypatch.setattr(
+        settings, "ORDER_PROPOSALS_TELEGRAM_CHAT_ALLOWLIST_STR", "chat-1"
+    )
+    monkeypatch.setattr(
+        "app.monitoring.trade_notifier.notifier.get_trade_notifier",
+        lambda: _RaisingNotifier(),
+    )
+
+    created = await opt.order_proposal_create(**_create_kwargs())
+
+    assert created["success"] is True
+    assert "proposal_id" in created
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## ROB-816 PR 2/2 — Telegram button approval flow

**Stacked on #1491 (PR 1/2)** — base is `rob-816-pr1`, so this PR's diff is only the Telegram approval surface. **Do not merge yet** — review PR 1/2 first.

Plan: `docs/plans/2026-07-10-rob-816-order-proposals-telegram-approval-implementation-plan.md`

### What this adds
- Inline-keyboard approval message (non-regressive `TradeNotifier`/`transports` extension) + `answer_callback` / `edit_message` helpers.
- Token-authed FastAPI **webhook** (`/trading/api/telegram/callback`) receiving `callback_query` updates; `AuthMiddleware` secret-token branch (403 unset / 401 wrong, `hmac.compare_digest`). Webhook chosen over long-polling (schedule-free, no standing process) — documented in runbook.
- **Callback handler**: chat allowlist → nonce replay guard → row lock → commit lease → **fresh click-time re-validation** (dry-run preview reruns the full guard chain + mints a ~0s-age `approval_hash` → server-internalized TTL, ROB-815 resolution) → submit via existing `_place_order_impl` approval-hash path only when price/qty unchanged, else `NEEDS_RECONFIRM` + before/after diff re-approval. Guard/revalidation failure → fail-closed. Commit-before-notify ordering throughout.
- Records up to `acked`/`resting` — **never marks filled** (accepted≠filled; fills booked later from broker evidence). correlation_id threads the learning-loop spine.
- All gated behind `ORDER_PROPOSALS_TELEGRAM_ENABLED` (default off).

### Notable safety catch (this PR)
`_SUBMITTABLE_ACCOUNT_MODE_MARKETS` in `service.create_proposal`: since `_place_order_impl` routes purely by `market` and always submits `is_mock=False`, a `kis_mock`/`toss_live` proposal would otherwise be silently submitted to LIVE KIS. Fail-closed reject at create-time.

### Known follow-ups (non-blocking)
- `record_fill_evidence` isn't yet wired to reconcile (PR-3 scope); when wired, short-circuit already-terminal rungs (`find_rung_by_evidence` doesn't filter by state).
- `_adapt_live_submit_response` assumes real `_place_order_impl(dry_run=False)` returns `broker_status ∈ {accepted,rejected}` + `order_id` — confirm via operator live/mock smoke.

### Verification
- `make lint` clean. Full order_proposals + telegram + auth + routers + notifier suites pass; 187-test adjacent regression check (place_order, loss-sell guard, profiles) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Telegram-based order-proposal approvals with inline approve/deny actions.
  * Enabled Telegram webhook routing and secret-token authentication, gated by an allowlisted chat configuration.
  * Added click-time revalidation and safe submission flow with replay protection, commit leases, reconfirmation, and broker status handling.
  * Order-proposal create now triggers best-effort approval dispatch when Telegram is enabled.
* **Bug Fixes**
  * Telegram delivery failures no longer block successful proposal creation or state updates.
* **Documentation**
  * Added a runbook covering proposal lifecycle and Telegram approval/troubleshooting.
* **Tests**
  * Expanded coverage for Telegram auth, dispatch, callback handling, and approval-message formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->