### PR TITLE
feat(ROB-816): order_proposals SOT ledger + read/create MCP tools (PR 1/2)

### DIFF
--- a/alembic/versions/20260710_rob816_order_proposals.py
+++ b/alembic/versions/20260710_rob816_order_proposals.py
@@ -1,0 +1,234 @@
+"""ROB-816 order_proposals + order_proposal_rungs (review schema, additive).
+
+Revision ID: 20260710_rob816_order_proposals
+Revises: 20260710_rob800_exit_intent
+Create Date: 2026-07-10
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "20260710_rob816_order_proposals"
+down_revision: Union[str, Sequence[str], None] = "20260710_rob800_exit_intent"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+_RUNG_STATES = (
+    "draft,pending_approval,revalidating,needs_reconfirm,approved,submitting,"
+    "acked,resting,partially_filled,unverified,filled,cancelled,expired,rejected,"
+    "voided,voided_local_stale,superseded"
+).split(",")
+_GROUP_STATES = (
+    "proposed,approved,partially_submitted,submitted,terminal,rejected,expired,"
+    "voided,superseded"
+).split(",")
+
+
+def _in(col: str, values) -> str:
+    return f"{col} IN (" + ",".join(f"'{v}'" for v in values) + ")"
+
+
+def upgrade() -> None:
+    op.create_table(
+        "order_proposals",
+        sa.Column("id", sa.BigInteger(), nullable=False),
+        sa.Column("proposal_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("root_proposal_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("revision", sa.Integer(), nullable=False, server_default="1"),
+        sa.Column(
+            "supersedes_proposal_id", postgresql.UUID(as_uuid=True), nullable=True
+        ),
+        sa.Column(
+            "superseded_by_proposal_id", postgresql.UUID(as_uuid=True), nullable=True
+        ),
+        sa.Column(
+            "no_resubmit", sa.Boolean(), nullable=False, server_default=sa.text("false")
+        ),
+        sa.Column("void_reason", sa.Text(), nullable=True),
+        sa.Column("payload_hash", sa.Text(), nullable=True),
+        sa.Column("symbol", sa.Text(), nullable=False),
+        sa.Column("market", sa.Text(), nullable=False),
+        sa.Column("account_mode", sa.Text(), nullable=False),
+        sa.Column("side", sa.Text(), nullable=False),
+        sa.Column("order_type", sa.Text(), nullable=False),
+        sa.Column("proposer", sa.Text(), nullable=False),
+        sa.Column("thesis", sa.Text(), nullable=True),
+        sa.Column("strategy", sa.Text(), nullable=True),
+        sa.Column(
+            "rationale", postgresql.JSONB(astext_type=sa.Text()), nullable=True
+        ),
+        sa.Column("broker_account_id", sa.Text(), nullable=True),
+        sa.Column(
+            "lot_context", postgresql.JSONB(astext_type=sa.Text()), nullable=True
+        ),
+        sa.Column(
+            "lifecycle_state", sa.Text(), nullable=False, server_default="proposed"
+        ),
+        sa.Column("correlation_id", sa.Text(), nullable=True),
+        sa.Column("valid_until", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("validated_at", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column(
+            "source_asof", postgresql.JSONB(astext_type=sa.Text()), nullable=True
+        ),
+        sa.Column("approval_nonce", sa.Text(), nullable=True),
+        sa.Column(
+            "approval_nonce_used_at", sa.TIMESTAMP(timezone=True), nullable=True
+        ),
+        sa.Column("approved_by_telegram_user_id", sa.Text(), nullable=True),
+        sa.Column("approved_at", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("commit_lease_until", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_order_proposals")),
+        sa.UniqueConstraint("proposal_id", name="uq_order_proposals_proposal_id"),
+        sa.CheckConstraint(
+            _in("market", ["equity_kr", "equity_us", "crypto", "forex", "index"]),
+            name="order_proposals_market",
+        ),
+        sa.CheckConstraint(
+            _in(
+                "account_mode",
+                ["kis_live", "kis_mock", "toss_live", "upbit", "db_simulated"],
+            ),
+            name="order_proposals_account_mode",
+        ),
+        sa.CheckConstraint("side IN ('buy','sell')", name="order_proposals_side"),
+        sa.CheckConstraint(
+            "order_type IN ('limit','market')", name="order_proposals_order_type"
+        ),
+        sa.CheckConstraint(
+            _in("lifecycle_state", _GROUP_STATES),
+            name="order_proposals_lifecycle_state",
+        ),
+        schema="review",
+    )
+    op.create_index(
+        "ix_order_proposals_root", "order_proposals", ["root_proposal_id"], schema="review"
+    )
+    op.create_index(
+        "ix_order_proposals_state", "order_proposals", ["lifecycle_state"], schema="review"
+    )
+    op.create_index(
+        "ix_order_proposals_symbol", "order_proposals", ["symbol"], schema="review"
+    )
+
+    op.create_table(
+        "order_proposal_rungs",
+        sa.Column("id", sa.BigInteger(), nullable=False),
+        sa.Column("proposal_pk", sa.BigInteger(), nullable=False),
+        sa.Column("rung_index", sa.Integer(), nullable=False),
+        sa.Column("side", sa.Text(), nullable=False),
+        sa.Column("quantity", sa.Numeric(38, 12), nullable=False),
+        sa.Column("limit_price", sa.Numeric(38, 12), nullable=True),
+        sa.Column("notional", sa.Numeric(38, 12), nullable=True),
+        sa.Column(
+            "state", sa.Text(), nullable=False, server_default="pending_approval"
+        ),
+        sa.Column("approval_hash_digest", sa.Text(), nullable=True),
+        sa.Column("approval_revision", sa.Integer(), nullable=True),
+        sa.Column("idempotency_key", sa.Text(), nullable=True),
+        sa.Column("broker_order_id", sa.Text(), nullable=True),
+        sa.Column("correlation_id", sa.Text(), nullable=True),
+        sa.Column("validated_at", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("filled_qty", sa.Numeric(38, 12), nullable=True),
+        sa.Column("void_reason", sa.Text(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_order_proposal_rungs")),
+        sa.ForeignKeyConstraint(
+            ["proposal_pk"],
+            ["review.order_proposals.id"],
+            name="fk_order_proposal_rungs_proposal",
+            ondelete="CASCADE",
+        ),
+        sa.UniqueConstraint(
+            "proposal_pk", "rung_index", name="uq_order_proposal_rungs_pk_index"
+        ),
+        sa.CheckConstraint("side IN ('buy','sell')", name="order_proposal_rungs_side"),
+        sa.CheckConstraint(
+            _in("state", _RUNG_STATES), name="order_proposal_rungs_state"
+        ),
+        schema="review",
+    )
+    op.create_index(
+        "ix_order_proposal_rungs_proposal_pk",
+        "order_proposal_rungs",
+        ["proposal_pk"],
+        schema="review",
+    )
+    op.create_index(
+        "ix_order_proposal_rungs_broker_order_id",
+        "order_proposal_rungs",
+        ["broker_order_id"],
+        schema="review",
+    )
+    op.create_index(
+        "ix_order_proposal_rungs_correlation_id",
+        "order_proposal_rungs",
+        ["correlation_id"],
+        schema="review",
+    )
+    op.create_index(
+        "ix_order_proposal_rungs_state",
+        "order_proposal_rungs",
+        ["state"],
+        schema="review",
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_order_proposal_rungs_state",
+        table_name="order_proposal_rungs",
+        schema="review",
+    )
+    op.drop_index(
+        "ix_order_proposal_rungs_correlation_id",
+        table_name="order_proposal_rungs",
+        schema="review",
+    )
+    op.drop_index(
+        "ix_order_proposal_rungs_broker_order_id",
+        table_name="order_proposal_rungs",
+        schema="review",
+    )
+    op.drop_index(
+        "ix_order_proposal_rungs_proposal_pk",
+        table_name="order_proposal_rungs",
+        schema="review",
+    )
+    op.drop_table("order_proposal_rungs", schema="review")
+    op.drop_index(
+        "ix_order_proposals_symbol", table_name="order_proposals", schema="review"
+    )
+    op.drop_index(
+        "ix_order_proposals_state", table_name="order_proposals", schema="review"
+    )
+    op.drop_index(
+        "ix_order_proposals_root", table_name="order_proposals", schema="review"
+    )
+    op.drop_table("order_proposals", schema="review")

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -761,6 +761,9 @@ class Settings(BaseSettings):
     # automated path against draft reports before activating the
     # stale-gate enforcement for the legacy create path.
     SNAPSHOT_BACKED_REPORT_GENERATOR_ENABLED: bool = False
+    # ORDER PROPOSALS (ROB-816) — default-off SOT ledger + read/create MCP tools.
+    # Gates MCP tool registration; the Telegram approval surface has its own gate (PR 2).
+    ORDER_PROPOSALS_ENABLED: bool = False
     # ROB-214 — recurring reconciliation scheduler remains disabled unless explicitly enabled.
     execution_ledger_reconcile_scheduler_enabled: bool = False
     execution_ledger_reconcile_scheduler_cron: str = "*/30 * * * *"

--- a/app/mcp_server/tooling/order_proposal_tools.py
+++ b/app/mcp_server/tooling/order_proposal_tools.py
@@ -1,0 +1,221 @@
+"""ROB-816 read/create MCP tools for order_proposals.
+
+READ + CREATE ONLY. There is deliberately no approve/submit tool — approval is
+Telegram-only (PR 2). ``order_proposal_create`` persists a proposal row; it
+performs NO broker mutation.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from decimal import Decimal, InvalidOperation
+from typing import TYPE_CHECKING, Any
+
+from app.core.db import AsyncSessionLocal
+from app.services.order_proposals import OrderProposalsService
+from app.services.order_proposals.errors import (
+    OrderProposalError,
+    OrderProposalNotFound,
+)
+from app.services.order_proposals.service import RungInput
+
+if TYPE_CHECKING:
+    from fastmcp import FastMCP
+
+ORDER_PROPOSAL_TOOL_NAMES: set[str] = {
+    "order_proposal_create",
+    "order_proposal_get",
+    "order_proposal_list",
+}
+
+
+def _dec(v: str | None) -> Decimal | None:
+    if v is None:
+        return None
+    try:
+        return Decimal(str(v))
+    except (InvalidOperation, ValueError) as exc:
+        raise ValueError(f"invalid decimal {v!r}") from exc
+
+
+def _group_dict(g: Any) -> dict[str, Any]:
+    return {
+        "proposal_id": str(g.proposal_id),
+        "root_proposal_id": str(g.root_proposal_id),
+        "revision": g.revision,
+        "symbol": g.symbol,
+        "market": g.market,
+        "account_mode": g.account_mode,
+        "side": g.side,
+        "order_type": g.order_type,
+        "proposer": g.proposer,
+        "lifecycle_state": g.lifecycle_state,
+        "thesis": g.thesis,
+        "strategy": g.strategy,
+        "supersedes_proposal_id": (
+            str(g.supersedes_proposal_id) if g.supersedes_proposal_id else None
+        ),
+        "superseded_by_proposal_id": (
+            str(g.superseded_by_proposal_id) if g.superseded_by_proposal_id else None
+        ),
+        "valid_until": g.valid_until.isoformat() if g.valid_until else None,
+        "created_at": g.created_at.isoformat() if g.created_at else None,
+    }
+
+
+def _rung_dict(r: Any) -> dict[str, Any]:
+    return {
+        "rung_index": r.rung_index,
+        "side": r.side,
+        "quantity": str(r.quantity),
+        "limit_price": str(r.limit_price) if r.limit_price is not None else None,
+        "notional": str(r.notional) if r.notional is not None else None,
+        "state": r.state,
+        "broker_order_id": r.broker_order_id,
+        "correlation_id": r.correlation_id,
+    }
+
+
+async def order_proposal_create(
+    symbol: str,
+    market: str,
+    account_mode: str,
+    side: str,
+    order_type: str,
+    proposer: str,
+    rungs: list[dict],
+    thesis: str | None = None,
+    strategy: str | None = None,
+    rationale: dict | None = None,
+    broker_account_id: str | None = None,
+    lot_context: dict | None = None,
+    valid_until: str | None = None,
+    supersedes_proposal_id: str | None = None,
+) -> dict[str, Any]:
+    """Create an order proposal (SOT ledger row). NOT a broker mutation — persists only.
+
+    Args:
+        rungs: list of {"rung_index": int, "side": str, "quantity": str,
+               "limit_price": str|None, "notional": str|None}.
+        supersedes_proposal_id: if this proposal replaces an existing one (price/qty
+               change), the original is marked superseded and lineage is linked.
+    """
+    try:
+        rung_inputs = [
+            RungInput(
+                int(r["rung_index"]),
+                str(r["side"]),
+                _dec(r["quantity"]),
+                _dec(r.get("limit_price")),
+                _dec(r.get("notional")),
+            )
+            for r in rungs
+        ]
+        vu = datetime.fromisoformat(valid_until) if valid_until else None
+        sup = uuid.UUID(supersedes_proposal_id) if supersedes_proposal_id else None
+        async with AsyncSessionLocal() as session:
+            svc = OrderProposalsService(session)
+            group = await svc.create_proposal(
+                symbol=symbol,
+                market=market,
+                account_mode=account_mode,
+                side=side,
+                order_type=order_type,
+                proposer=proposer,
+                rungs=rung_inputs,
+                thesis=thesis,
+                strategy=strategy,
+                rationale=rationale,
+                broker_account_id=broker_account_id,
+                lot_context=lot_context,
+                valid_until=vu,
+                supersedes_proposal_id=sup,
+            )
+            _, saved_rungs = await svc.get_proposal(group.proposal_id)
+            await session.commit()
+            return {
+                "success": True,
+                "proposal_id": str(group.proposal_id),
+                "lifecycle_state": group.lifecycle_state,
+                "rungs": [_rung_dict(r) for r in saved_rungs],
+            }
+    except (ValueError, OrderProposalError) as exc:
+        return {"success": False, "error": str(exc)}
+
+
+async def order_proposal_get(proposal_id: str) -> dict[str, Any]:
+    """Fetch a proposal + its rungs (read-only)."""
+    try:
+        pid = uuid.UUID(proposal_id)
+    except ValueError:
+        return {"success": False, "error": f"invalid proposal_id {proposal_id!r}"}
+    async with AsyncSessionLocal() as session:
+        svc = OrderProposalsService(session)
+        try:
+            group, rungs = await svc.get_proposal(pid)
+        except OrderProposalNotFound:
+            return {"success": False, "error": "not_found"}
+        return {
+            "success": True,
+            "proposal": _group_dict(group),
+            "rungs": [_rung_dict(r) for r in rungs],
+        }
+
+
+async def order_proposal_list(
+    limit: int = 50,
+    symbol: str | None = None,
+    lifecycle_state: str | None = None,
+) -> dict[str, Any]:
+    """List recent proposals (read-only). limit is clamped to 1..200."""
+    limit = max(1, min(int(limit), 200))
+    async with AsyncSessionLocal() as session:
+        svc = OrderProposalsService(session)
+        rows = await svc.list_recent(
+            limit=limit, symbol=symbol, lifecycle_state=lifecycle_state
+        )
+        return {
+            "success": True,
+            "count": len(rows),
+            "proposals": [
+                {**_group_dict(g), "rungs": [_rung_dict(r) for r in rs]}
+                for g, rs in rows
+            ],
+        }
+
+
+def register_order_proposal_tools(mcp: FastMCP) -> None:
+    """Register the order_proposals read/create MCP tools.
+
+    Deliberately excludes any approve/submit tool — approval is Telegram-only
+    (ROB-816 PR 2).
+    """
+    _ = mcp.tool(
+        name="order_proposal_create",
+        description=(
+            "Create an order proposal (SOT ledger row) with one or more rungs. "
+            "NOT a broker mutation — persists only. Approval/submission happens "
+            "via Telegram (PR 2), not through this tool."
+        ),
+    )(order_proposal_create)
+    _ = mcp.tool(
+        name="order_proposal_get",
+        description="Read-only fetch of a proposal and its rungs by proposal_id.",
+    )(order_proposal_get)
+    _ = mcp.tool(
+        name="order_proposal_list",
+        description=(
+            "Read-only list of recent order proposals, optionally filtered by "
+            "symbol and/or lifecycle_state."
+        ),
+    )(order_proposal_list)
+
+
+__all__ = [
+    "ORDER_PROPOSAL_TOOL_NAMES",
+    "order_proposal_create",
+    "order_proposal_get",
+    "order_proposal_list",
+    "register_order_proposal_tools",
+]

--- a/app/mcp_server/tooling/registry.py
+++ b/app/mcp_server/tooling/registry.py
@@ -124,6 +124,7 @@ from app.mcp_server.tooling.news_registration import register_news_tools
 from app.mcp_server.tooling.operating_briefing_registration import (
     register_operating_briefing_tools,
 )
+from app.mcp_server.tooling.order_proposal_tools import register_order_proposal_tools
 from app.mcp_server.tooling.orders_kis_variants import (
     register_kis_live_order_tools,
     register_kis_mock_order_tools,
@@ -271,6 +272,12 @@ def register_all_tools(mcp: FastMCP, profile: McpProfile = McpProfile.DEFAULT) -
     # physically absent unless the flag is flipped post-PR-merge.
     if settings.INVESTMENT_SNAPSHOTS_MCP_ENABLED:
         register_investment_snapshots_tools(mcp)
+
+    # ROB-816 — order_proposals SOT ledger read/create surface. Gated by
+    # ``settings.ORDER_PROPOSALS_ENABLED`` (default off). No approve/submit
+    # tool is registered anywhere — approval is Telegram-only (PR 2).
+    if settings.ORDER_PROPOSALS_ENABLED:
+        register_order_proposal_tools(mcp)
 
     # Profile-gated: side-effect order surfaces
     if profile is McpProfile.DEFAULT:

--- a/app/mcp_server/tooling/tradingcodex_execution_registration.py
+++ b/app/mcp_server/tooling/tradingcodex_execution_registration.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, cast
 
+from app.core.config import settings
 from app.mcp_server.tooling.account_read_registration import ACCOUNT_READ_TOOL_NAMES
 from app.mcp_server.tooling.account_routing_registration import (
     register_account_routing_tools,
@@ -32,6 +33,10 @@ from app.mcp_server.tooling.investment_reports_handlers import (
 from app.mcp_server.tooling.operating_briefing_registration import (
     OPERATING_BRIEFING_TOOL_NAMES,
     register_operating_briefing_tools,
+)
+from app.mcp_server.tooling.order_proposal_tools import (
+    ORDER_PROPOSAL_TOOL_NAMES,
+    register_order_proposal_tools,
 )
 from app.mcp_server.tooling.orders_kis_variants import (
     KIS_LIVE_ORDER_TOOL_NAMES,
@@ -113,6 +118,10 @@ _TRADINGCODEX_EXECUTION_LEARNING_WRITE_TOOL_NAMES: set[str] = {
     "save_trade_retrospective",
 }
 
+# ROB-816 — order_proposals SOT ledger read/create surface. No approve/submit
+# tool is included — approval is Telegram-only (PR 2).
+_TRADINGCODEX_EXECUTION_ORDER_PROPOSAL_TOOL_NAMES: set[str] = ORDER_PROPOSAL_TOOL_NAMES
+
 TRADINGCODEX_EXECUTION_TOOL_NAMES: set[str] = (
     ACCOUNT_READ_TOOL_NAMES
     | _TRADINGCODEX_EXECUTION_ORDER_TOOL_NAMES
@@ -121,6 +130,7 @@ TRADINGCODEX_EXECUTION_TOOL_NAMES: set[str] = (
     | _TRADINGCODEX_EXECUTION_WATCH_WRITE_TOOL_NAMES
     | _TRADINGCODEX_EXECUTION_LEARNING_READ_TOOL_NAMES
     | _TRADINGCODEX_EXECUTION_LEARNING_WRITE_TOOL_NAMES
+    | _TRADINGCODEX_EXECUTION_ORDER_PROPOSAL_TOOL_NAMES
 )
 
 _INVESTMENT_REPORT_REGISTERED_TOOL_NAMES: set[str] = INVESTMENT_REPORT_TOOL_NAMES | {
@@ -414,6 +424,11 @@ def register_tradingcodex_execution_tools(mcp: FastMCP) -> None:
     _register_learning_read_tools(mcp)
     _register_learning_write_tools(mcp)
     _register_watch_write_tools(mcp)
+    # ROB-816 — order_proposals SOT ledger read/create surface. Gated by
+    # ``settings.ORDER_PROPOSALS_ENABLED`` (default off), same flag as the
+    # default-profile registration in registry.py.
+    if settings.ORDER_PROPOSALS_ENABLED:
+        register_order_proposal_tools(filtered)
 
 
 __all__ = [

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -47,6 +47,7 @@ from .market_report import MarketReport
 from .market_valuation_snapshot import MarketValuationSnapshot
 from .naver_research_detail_cache import NaverResearchDetailCache
 from .news import NewsAnalysisResult, NewsArticle, NewsIngestionRun, Sentiment
+from .order_proposals import OrderProposal, OrderProposalRung
 from .paper_trading import PaperAccount, PaperPendingOrder, PaperPosition, PaperTrade
 from .portfolio_decision_run import PortfolioDecisionRun
 from .prompt import PromptResult
@@ -188,6 +189,8 @@ __all__ = [
     "NewsAnalysisResult",
     "NewsIngestionRun",
     "Sentiment",
+    "OrderProposal",
+    "OrderProposalRung",
     "BrokerType",
     "MarketType",
     "BrokerAccount",

--- a/app/models/order_proposals.py
+++ b/app/models/order_proposals.py
@@ -1,0 +1,166 @@
+"""ROB-816 order_proposals SOT ledger models (review schema).
+
+All writes go through app.services.order_proposals.OrderProposalsService.
+The DB CHECK constraints validate the string bag only; the transition graph is
+enforced in app.services.order_proposals.state_machine.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import (
+    TIMESTAMP,
+    BigInteger,
+    Boolean,
+    CheckConstraint,
+    ForeignKey,
+    Index,
+    Integer,
+    Numeric,
+    Text,
+    UniqueConstraint,
+)
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.dialects.postgresql import UUID as PG_UUID
+from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.sql import func
+
+from app.models.base import Base
+from app.services.order_proposals.state_machine import GROUP_STATES, RUNG_STATES
+
+_MARKETS = "'equity_kr','equity_us','crypto','forex','index'"
+_ACCOUNT_MODES = "'kis_live','kis_mock','toss_live','upbit','db_simulated'"
+_GROUP_STATES_SQL = ",".join(f"'{s}'" for s in sorted(GROUP_STATES))
+_RUNG_STATES_SQL = ",".join(f"'{s}'" for s in sorted(RUNG_STATES))
+
+
+class OrderProposal(Base):
+    __tablename__ = "order_proposals"
+    __table_args__ = (
+        UniqueConstraint("proposal_id", name="uq_order_proposals_proposal_id"),
+        CheckConstraint(f"market IN ({_MARKETS})", name="order_proposals_market"),
+        CheckConstraint(
+            f"account_mode IN ({_ACCOUNT_MODES})",
+            name="order_proposals_account_mode",
+        ),
+        CheckConstraint("side IN ('buy','sell')", name="order_proposals_side"),
+        CheckConstraint(
+            "order_type IN ('limit','market')", name="order_proposals_order_type"
+        ),
+        CheckConstraint(
+            f"lifecycle_state IN ({_GROUP_STATES_SQL})",
+            name="order_proposals_lifecycle_state",
+        ),
+        Index("ix_order_proposals_root", "root_proposal_id"),
+        Index("ix_order_proposals_state", "lifecycle_state"),
+        Index("ix_order_proposals_symbol", "symbol"),
+        {"schema": "review"},
+    )
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    proposal_id: Mapped[uuid.UUID] = mapped_column(
+        PG_UUID(as_uuid=True), nullable=False
+    )
+    root_proposal_id: Mapped[uuid.UUID] = mapped_column(
+        PG_UUID(as_uuid=True), nullable=False
+    )
+    revision: Mapped[int] = mapped_column(Integer, nullable=False, server_default="1")
+    supersedes_proposal_id: Mapped[uuid.UUID | None] = mapped_column(
+        PG_UUID(as_uuid=True)
+    )
+    superseded_by_proposal_id: Mapped[uuid.UUID | None] = mapped_column(
+        PG_UUID(as_uuid=True)
+    )
+    no_resubmit: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, server_default="false"
+    )
+    void_reason: Mapped[str | None] = mapped_column(Text)
+    payload_hash: Mapped[str | None] = mapped_column(Text)
+    symbol: Mapped[str] = mapped_column(Text, nullable=False)
+    market: Mapped[str] = mapped_column(Text, nullable=False)
+    account_mode: Mapped[str] = mapped_column(Text, nullable=False)
+    side: Mapped[str] = mapped_column(Text, nullable=False)
+    order_type: Mapped[str] = mapped_column(Text, nullable=False)
+    proposer: Mapped[str] = mapped_column(Text, nullable=False)
+    thesis: Mapped[str | None] = mapped_column(Text)
+    strategy: Mapped[str | None] = mapped_column(Text)
+    rationale: Mapped[dict | None] = mapped_column(JSONB)
+    broker_account_id: Mapped[str | None] = mapped_column(Text)
+    lot_context: Mapped[dict | None] = mapped_column(JSONB)
+    lifecycle_state: Mapped[str] = mapped_column(
+        Text, nullable=False, server_default="proposed"
+    )
+    correlation_id: Mapped[str | None] = mapped_column(Text)
+    valid_until: Mapped[datetime | None] = mapped_column(TIMESTAMP(timezone=True))
+    validated_at: Mapped[datetime | None] = mapped_column(TIMESTAMP(timezone=True))
+    source_asof: Mapped[dict | None] = mapped_column(JSONB)
+    approval_nonce: Mapped[str | None] = mapped_column(Text)
+    approval_nonce_used_at: Mapped[datetime | None] = mapped_column(
+        TIMESTAMP(timezone=True)
+    )
+    approved_by_telegram_user_id: Mapped[str | None] = mapped_column(Text)
+    approved_at: Mapped[datetime | None] = mapped_column(TIMESTAMP(timezone=True))
+    commit_lease_until: Mapped[datetime | None] = mapped_column(
+        TIMESTAMP(timezone=True)
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=False, server_default=func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+        onupdate=func.now(),
+    )
+
+
+class OrderProposalRung(Base):
+    __tablename__ = "order_proposal_rungs"
+    __table_args__ = (
+        UniqueConstraint(
+            "proposal_pk", "rung_index", name="uq_order_proposal_rungs_pk_index"
+        ),
+        CheckConstraint("side IN ('buy','sell')", name="order_proposal_rungs_side"),
+        CheckConstraint(
+            f"state IN ({_RUNG_STATES_SQL})", name="order_proposal_rungs_state"
+        ),
+        Index("ix_order_proposal_rungs_proposal_pk", "proposal_pk"),
+        Index("ix_order_proposal_rungs_broker_order_id", "broker_order_id"),
+        Index("ix_order_proposal_rungs_correlation_id", "correlation_id"),
+        Index("ix_order_proposal_rungs_state", "state"),
+        {"schema": "review"},
+    )
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    proposal_pk: Mapped[int] = mapped_column(
+        BigInteger,
+        ForeignKey("review.order_proposals.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    rung_index: Mapped[int] = mapped_column(Integer, nullable=False)
+    side: Mapped[str] = mapped_column(Text, nullable=False)
+    quantity: Mapped[object] = mapped_column(Numeric(38, 12), nullable=False)
+    limit_price: Mapped[object | None] = mapped_column(Numeric(38, 12))
+    notional: Mapped[object | None] = mapped_column(Numeric(38, 12))
+    state: Mapped[str] = mapped_column(
+        Text, nullable=False, server_default="pending_approval"
+    )
+    approval_hash_digest: Mapped[str | None] = mapped_column(Text)
+    approval_revision: Mapped[int | None] = mapped_column(Integer)
+    idempotency_key: Mapped[str | None] = mapped_column(Text)
+    broker_order_id: Mapped[str | None] = mapped_column(Text)
+    correlation_id: Mapped[str | None] = mapped_column(Text)
+    validated_at: Mapped[datetime | None] = mapped_column(TIMESTAMP(timezone=True))
+    filled_qty: Mapped[object | None] = mapped_column(Numeric(38, 12))
+    void_reason: Mapped[str | None] = mapped_column(Text)
+    created_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=False, server_default=func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+        onupdate=func.now(),
+    )

--- a/app/services/order_proposals/__init__.py
+++ b/app/services/order_proposals/__init__.py
@@ -1,0 +1,28 @@
+"""order_proposals package.
+
+Exports OrderProposalsService lazily (PEP 562 module __getattr__) to avoid a
+circular import: app.models.order_proposals imports
+app.services.order_proposals.state_machine at module level, which triggers
+this package's __init__ before the model classes are defined. Eagerly
+importing service.py here (which pulls in repository.py -> app.models.order_proposals)
+would re-enter the partially-initialized models module. Deferring the import
+until OrderProposalsService is actually accessed sidesteps the cycle while
+keeping the same public import surface.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from app.services.order_proposals.service import OrderProposalsService
+
+__all__ = ["OrderProposalsService"]
+
+
+def __getattr__(name: str):
+    if name == "OrderProposalsService":
+        from app.services.order_proposals.service import OrderProposalsService
+
+        return OrderProposalsService
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/app/services/order_proposals/errors.py
+++ b/app/services/order_proposals/errors.py
@@ -1,0 +1,39 @@
+"""ROB-816 order_proposals exception hierarchy.
+
+All writes go through OrderProposalsService; these are the domain errors it raises.
+"""
+
+from __future__ import annotations
+
+
+class OrderProposalError(Exception):
+    """Base for all order_proposals domain errors."""
+
+
+class OrderProposalInvalidStateTransition(OrderProposalError):
+    """Raised when a rung/group state change violates the locked transition graph.
+
+    The transition graph is defined in state_machine.py and duplicated in this
+    docstring for locality:
+
+        pending_approval -> {revalidating, rejected, voided, voided_local_stale, superseded}
+        revalidating     -> {approved, needs_reconfirm, pending_approval, superseded, voided}
+        needs_reconfirm  -> {pending_approval, rejected, superseded, voided}
+        approved         -> {submitting, superseded, voided}
+        submitting       -> {acked, resting, rejected, unverified}
+        acked            -> {filled, partially_filled, cancelled, unverified}
+        resting          -> {filled, partially_filled, cancelled, expired, unverified}
+        partially_filled -> {filled, cancelled, expired, unverified}
+        unverified       -> {filled, partially_filled, cancelled, expired, rejected}
+        draft            -> {pending_approval, voided}
+        (terminal: filled, cancelled, expired, rejected, voided,
+                   voided_local_stale, superseded)
+    """
+
+
+class OrderProposalNotFound(OrderProposalError):
+    """No order_proposals row for the given proposal_id."""
+
+
+class OrderProposalDuplicate(OrderProposalError):
+    """A proposal with the same proposal_id already exists."""

--- a/app/services/order_proposals/payload.py
+++ b/app/services/order_proposals/payload.py
@@ -1,0 +1,50 @@
+"""Immutable order_proposal payload hashing (ROB-816, principle #1).
+
+stdlib only. Prices/quantities are canonical strings (caller normalizes Decimals)
+so the hash never depends on float representation. Time/TTL fields are deliberately
+excluded: a TTL-only change must NOT change the payload hash (revalidate, not replace).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ProposalRungSpec:
+    rung_index: int
+    side: str
+    quantity: str
+    limit_price: str | None
+    notional: str | None
+
+
+def compute_proposal_payload_hash(
+    *,
+    symbol: str,
+    market: str,
+    account_mode: str,
+    order_type: str,
+    rungs: Sequence[ProposalRungSpec],
+) -> str:
+    canonical = {
+        "symbol": symbol,
+        "market": market,
+        "account_mode": account_mode,
+        "order_type": order_type,
+        "rungs": [
+            {
+                "rung_index": r.rung_index,
+                "side": r.side,
+                "quantity": r.quantity,
+                "limit_price": r.limit_price,
+                "notional": r.notional,
+            }
+            for r in sorted(rungs, key=lambda r: r.rung_index)
+        ],
+    }
+    blob = json.dumps(canonical, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(blob.encode("utf-8")).hexdigest()

--- a/app/services/order_proposals/repository.py
+++ b/app/services/order_proposals/repository.py
@@ -1,0 +1,75 @@
+"""Internal repository for order_proposals (ROB-816).
+
+INTERNAL ONLY. Imported solely by app/services/order_proposals/service.py
+(enforced by tests/services/order_proposals/test_no_repository_imports.py).
+Never commits — the caller owns the transaction.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.order_proposals import OrderProposal, OrderProposalRung
+
+
+class OrderProposalRepository:
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def insert_group(self, **cols: Any) -> OrderProposal:
+        row = OrderProposal(**cols)
+        self._session.add(row)
+        await self._session.flush()
+        await self._session.refresh(row)
+        return row
+
+    async def insert_rung(self, **cols: Any) -> OrderProposalRung:
+        row = OrderProposalRung(**cols)
+        self._session.add(row)
+        await self._session.flush()
+        await self._session.refresh(row)
+        return row
+
+    async def get_group_by_proposal_id(
+        self, proposal_id: uuid.UUID, *, for_update: bool = False
+    ) -> OrderProposal | None:
+        stmt = select(OrderProposal).where(OrderProposal.proposal_id == proposal_id)
+        if for_update:
+            stmt = stmt.with_for_update()
+        return (await self._session.execute(stmt)).scalar_one_or_none()
+
+    async def list_rungs(self, proposal_pk: int) -> list[OrderProposalRung]:
+        stmt = (
+            select(OrderProposalRung)
+            .where(OrderProposalRung.proposal_pk == proposal_pk)
+            .order_by(OrderProposalRung.rung_index)
+        )
+        return list((await self._session.execute(stmt)).scalars().all())
+
+    async def list_recent_groups(
+        self, *, limit: int, symbol: str | None, lifecycle_state: str | None
+    ) -> list[OrderProposal]:
+        stmt = select(OrderProposal).order_by(OrderProposal.id.desc()).limit(limit)
+        if symbol:
+            stmt = stmt.where(OrderProposal.symbol == symbol)
+        if lifecycle_state:
+            stmt = stmt.where(OrderProposal.lifecycle_state == lifecycle_state)
+        return list((await self._session.execute(stmt)).scalars().all())
+
+    async def update_group(self, group: OrderProposal, **fields: Any) -> OrderProposal:
+        for k, v in fields.items():
+            setattr(group, k, v)
+        await self._session.flush()
+        return group
+
+    async def update_rung(
+        self, rung: OrderProposalRung, **fields: Any
+    ) -> OrderProposalRung:
+        for k, v in fields.items():
+            setattr(rung, k, v)
+        await self._session.flush()
+        return rung

--- a/app/services/order_proposals/service.py
+++ b/app/services/order_proposals/service.py
@@ -1,12 +1,240 @@
-# app/services/order_proposals/service.py  (minimal — fleshed out in Task 6)
+"""OrderProposalsService — the ONLY writer surface for order_proposals (ROB-816).
+
+Sessions are constructor-injected; this service flush()es (via the repository)
+and never commits — callers own the transaction (see global-constraints.md).
+"""
+
 from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+from datetime import datetime
+from decimal import Decimal
+from typing import Any
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.models.order_proposals import OrderProposal, OrderProposalRung
+from app.services.order_proposals import state_machine as sm
+from app.services.order_proposals.errors import OrderProposalNotFound
+from app.services.order_proposals.payload import (
+    ProposalRungSpec,
+    compute_proposal_payload_hash,
+)
 from app.services.order_proposals.repository import OrderProposalRepository
+
+
+@dataclass
+class RungInput:
+    rung_index: int
+    side: str
+    quantity: Decimal
+    limit_price: Decimal | None
+    notional: Decimal | None
 
 
 class OrderProposalsService:
     def __init__(self, session: AsyncSession) -> None:
-        self._repo = OrderProposalRepository(session)
         self._session = session
+        self._repo = OrderProposalRepository(session)
+
+    async def create_proposal(
+        self,
+        *,
+        symbol: str,
+        market: str,
+        account_mode: str,
+        side: str,
+        order_type: str,
+        proposer: str,
+        rungs: list[RungInput],
+        thesis: str | None = None,
+        strategy: str | None = None,
+        rationale: dict | None = None,
+        broker_account_id: str | None = None,
+        lot_context: dict | None = None,
+        valid_until: datetime | None = None,
+        correlation_id: str | None = None,
+        source_asof: dict | None = None,
+        supersedes_proposal_id: uuid.UUID | None = None,
+    ) -> OrderProposal:
+        if not rungs:
+            raise ValueError("at least one rung required")
+        proposal_id = uuid.uuid4()
+        root_id = proposal_id
+        superseded_group: OrderProposal | None = None
+        if supersedes_proposal_id is not None:
+            superseded_group = await self._repo.get_group_by_proposal_id(
+                supersedes_proposal_id, for_update=True
+            )
+            if superseded_group is None:
+                raise OrderProposalNotFound(str(supersedes_proposal_id))
+            root_id = superseded_group.root_proposal_id
+
+        payload_hash = compute_proposal_payload_hash(
+            symbol=symbol,
+            market=market,
+            account_mode=account_mode,
+            order_type=order_type,
+            rungs=[
+                ProposalRungSpec(
+                    r.rung_index,
+                    r.side,
+                    str(r.quantity),
+                    None if r.limit_price is None else str(r.limit_price),
+                    None if r.notional is None else str(r.notional),
+                )
+                for r in rungs
+            ],
+        )
+
+        group = await self._repo.insert_group(
+            proposal_id=proposal_id,
+            root_proposal_id=root_id,
+            revision=1,
+            supersedes_proposal_id=supersedes_proposal_id,
+            no_resubmit=False,
+            payload_hash=payload_hash,
+            symbol=symbol,
+            market=market,
+            account_mode=account_mode,
+            side=side,
+            order_type=order_type,
+            proposer=proposer,
+            thesis=thesis,
+            strategy=strategy,
+            rationale=rationale,
+            broker_account_id=broker_account_id,
+            lot_context=lot_context,
+            lifecycle_state="proposed",
+            correlation_id=correlation_id,
+            valid_until=valid_until,
+            source_asof=source_asof,
+        )
+        for r in rungs:
+            await self._repo.insert_rung(
+                proposal_pk=group.id,
+                rung_index=r.rung_index,
+                side=r.side,
+                quantity=r.quantity,
+                limit_price=r.limit_price,
+                notional=r.notional,
+                state="pending_approval",
+            )
+        if superseded_group is not None:
+            await self._repo.update_group(
+                superseded_group,
+                lifecycle_state="superseded",
+                superseded_by_proposal_id=proposal_id,
+            )
+        return group
+
+    async def get_proposal(
+        self, proposal_id: uuid.UUID
+    ) -> tuple[OrderProposal, list[OrderProposalRung]]:
+        group = await self._repo.get_group_by_proposal_id(proposal_id)
+        if group is None:
+            raise OrderProposalNotFound(str(proposal_id))
+        rungs = await self._repo.list_rungs(group.id)
+        return group, rungs
+
+    async def list_recent(
+        self,
+        *,
+        limit: int = 50,
+        symbol: str | None = None,
+        lifecycle_state: str | None = None,
+    ) -> list[tuple[OrderProposal, list[OrderProposalRung]]]:
+        groups = await self._repo.list_recent_groups(
+            limit=limit, symbol=symbol, lifecycle_state=lifecycle_state
+        )
+        return [(g, await self._repo.list_rungs(g.id)) for g in groups]
+
+    async def transition_rung(
+        self,
+        proposal_id: uuid.UUID,
+        rung_index: int,
+        *,
+        new_state: str,
+        **audit_fields: Any,
+    ) -> OrderProposalRung:
+        group = await self._repo.get_group_by_proposal_id(proposal_id, for_update=True)
+        if group is None:
+            raise OrderProposalNotFound(str(proposal_id))
+        rungs = await self._repo.list_rungs(group.id)
+        rung = next((r for r in rungs if r.rung_index == rung_index), None)
+        if rung is None:
+            raise OrderProposalNotFound(f"{proposal_id}#{rung_index}")
+        sm.assert_rung_transition(rung.state, new_state)
+        rung = await self._repo.update_rung(rung, state=new_state, **audit_fields)
+        # refresh rung list then recompute group rollup
+        rungs = await self._repo.list_rungs(group.id)
+        await self._repo.update_group(
+            group, lifecycle_state=self._recompute_group_state(rungs)
+        )
+        return rung
+
+    @staticmethod
+    def _recompute_group_state(rungs: list[OrderProposalRung]) -> str:
+        states = {r.state for r in rungs}
+        if states <= {
+            "filled",
+            "cancelled",
+            "expired",
+            "rejected",
+            "voided",
+            "voided_local_stale",
+            "superseded",
+        }:
+            if states == {"rejected"}:
+                return "rejected"
+            if states <= {"voided", "voided_local_stale"}:
+                return "voided"
+            return "terminal"
+        if states & {"acked", "resting", "partially_filled", "filled", "submitting"}:
+            if states & {
+                "pending_approval",
+                "revalidating",
+                "approved",
+                "needs_reconfirm",
+            }:
+                return "partially_submitted"
+            return "submitted"
+        if states & {"approved"}:
+            return "approved"
+        return "proposed"
+
+    # -- PR-2 helpers -------------------------------------------------------
+    # Stubs only. Task 12 (PR 2) fills these in with the Telegram approval
+    # flow, callback-nonce binding, commit-lease, and fill-evidence recording.
+    # Deliberately unimplemented in PR 1 (no Telegram, no broker mutation).
+
+    async def set_approval_nonce(self, *args: Any, **kwargs: Any) -> Any:
+        raise NotImplementedError("set_approval_nonce is implemented in PR 2 (ROB-816)")
+
+    async def consume_approval_nonce(self, *args: Any, **kwargs: Any) -> Any:
+        raise NotImplementedError(
+            "consume_approval_nonce is implemented in PR 2 (ROB-816)"
+        )
+
+    async def acquire_commit_lease(self, *args: Any, **kwargs: Any) -> Any:
+        raise NotImplementedError(
+            "acquire_commit_lease is implemented in PR 2 (ROB-816)"
+        )
+
+    async def record_ack(self, *args: Any, **kwargs: Any) -> Any:
+        raise NotImplementedError("record_ack is implemented in PR 2 (ROB-816)")
+
+    async def record_resting(self, *args: Any, **kwargs: Any) -> Any:
+        raise NotImplementedError("record_resting is implemented in PR 2 (ROB-816)")
+
+    async def record_unverified(self, *args: Any, **kwargs: Any) -> Any:
+        raise NotImplementedError("record_unverified is implemented in PR 2 (ROB-816)")
+
+    async def record_fill_evidence(self, *args: Any, **kwargs: Any) -> Any:
+        raise NotImplementedError(
+            "record_fill_evidence is implemented in PR 2 (ROB-816)"
+        )
+
+    async def sweep_local_stale(self, *args: Any, **kwargs: Any) -> Any:
+        raise NotImplementedError("sweep_local_stale is implemented in PR 2 (ROB-816)")

--- a/app/services/order_proposals/service.py
+++ b/app/services/order_proposals/service.py
@@ -1,0 +1,12 @@
+# app/services/order_proposals/service.py  (minimal — fleshed out in Task 6)
+from __future__ import annotations
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.services.order_proposals.repository import OrderProposalRepository
+
+
+class OrderProposalsService:
+    def __init__(self, session: AsyncSession) -> None:
+        self._repo = OrderProposalRepository(session)
+        self._session = session

--- a/app/services/order_proposals/state_machine.py
+++ b/app/services/order_proposals/state_machine.py
@@ -1,0 +1,78 @@
+"""Pure, dependency-free state machine for order_proposal_rungs (ROB-816).
+
+stdlib only — no broker/DB/network imports. The service calls assert_rung_transition
+before every rung state mutation; the DB CheckConstraint only validates the string
+bag, the transition graph lives here.
+"""
+
+from __future__ import annotations
+
+from app.services.order_proposals.errors import OrderProposalInvalidStateTransition
+
+_ALLOWED: dict[str, frozenset[str]] = {
+    "draft": frozenset({"pending_approval", "voided"}),
+    "pending_approval": frozenset(
+        {"revalidating", "rejected", "voided", "voided_local_stale", "superseded"}
+    ),
+    "revalidating": frozenset(
+        {"approved", "needs_reconfirm", "pending_approval", "superseded", "voided"}
+    ),
+    "needs_reconfirm": frozenset(
+        {"pending_approval", "rejected", "superseded", "voided"}
+    ),
+    "approved": frozenset({"submitting", "superseded", "voided"}),
+    "submitting": frozenset({"acked", "resting", "rejected", "unverified"}),
+    "acked": frozenset({"filled", "partially_filled", "cancelled", "unverified"}),
+    "resting": frozenset(
+        {"filled", "partially_filled", "cancelled", "expired", "unverified"}
+    ),
+    "partially_filled": frozenset({"filled", "cancelled", "expired", "unverified"}),
+    "unverified": frozenset(
+        {"filled", "partially_filled", "cancelled", "expired", "rejected"}
+    ),
+    # terminals
+    "filled": frozenset(),
+    "cancelled": frozenset(),
+    "expired": frozenset(),
+    "rejected": frozenset(),
+    "voided": frozenset(),
+    "voided_local_stale": frozenset(),
+    "superseded": frozenset(),
+}
+
+RUNG_STATES: frozenset[str] = frozenset(_ALLOWED.keys())
+PROPOSAL_TERMINAL_STATES: frozenset[str] = frozenset(
+    s for s, nxt in _ALLOWED.items() if not nxt
+)
+
+# Group-level rollup states (order_proposals.lifecycle_state) — coarser than rung states.
+GROUP_STATES: frozenset[str] = frozenset(
+    {
+        "proposed",
+        "approved",
+        "partially_submitted",
+        "submitted",
+        "terminal",
+        "rejected",
+        "expired",
+        "voided",
+        "superseded",
+    }
+)
+
+
+def is_terminal(state: str) -> bool:
+    return state in PROPOSAL_TERMINAL_STATES
+
+
+def assert_rung_transition(current: str, new: str) -> None:
+    if current not in _ALLOWED:
+        raise OrderProposalInvalidStateTransition(f"unknown rung state {current!r}")
+    if new not in RUNG_STATES:
+        raise OrderProposalInvalidStateTransition(f"unknown target state {new!r}")
+    allowed = _ALLOWED[current]
+    if new not in allowed:
+        raise OrderProposalInvalidStateTransition(
+            f"{current!r} -> {new!r} not allowed "
+            f"(allowed from {current!r}: {sorted(allowed)})"
+        )

--- a/docs/runbooks/order-proposals.md
+++ b/docs/runbooks/order-proposals.md
@@ -1,0 +1,296 @@
+# Order Proposals Runbook (ROB-816)
+
+## Purpose
+
+`review.order_proposals` + `review.order_proposal_rungs` is the SOT (source-of-truth)
+ledger for **proposed** orders awaiting human approval, prior to any broker
+submission. It replaces ad-hoc "propose in chat, submit blind" flows with a
+persisted, replayable record: one `order_proposals` row per proposal group
+(symbol/side/market/account context + thesis/rationale), and one or more
+`order_proposal_rungs` child rows (one per execution ladder rung — price/qty
+pair) tracking each rung's own execution lifecycle independently.
+
+This is **PR 1** of ROB-816: data model + pure state machine + service +
+three read/create MCP tools. It intentionally ships with:
+
+- No Telegram approval surface (PR 2).
+- No submit/approve MCP tool — there is no path from a proposal row to a live
+  broker order in this PR.
+
+See the full design in
+[`docs/plans/2026-07-10-rob-816-order-proposals-telegram-approval-implementation-plan.md`](../plans/2026-07-10-rob-816-order-proposals-telegram-approval-implementation-plan.md).
+
+---
+
+## Safety Boundaries
+
+- **Writes only via `OrderProposalsService`** (`app/services/order_proposals/service.py`).
+  `OrderProposalRepository` is imported only by its owning service module — an
+  AST guard test (`tests/services/order_proposals/test_no_repository_imports.py`)
+  enforces this. Direct SQL INSERT/UPDATE/DELETE against `review.order_proposals`
+  / `review.order_proposal_rungs` is not permitted.
+- **Proposal creation is NOT a broker mutation.** `order_proposal_create`
+  persists a row describing an intended order; it never calls a broker
+  client, never submits, and never touches `_place_order_impl` or any
+  existing order-send path.
+- **No submit without Telegram approval (PR 2).** There is deliberately no
+  `order_proposal_approve` / `order_proposal_submit` MCP tool in this PR. The
+  only way a proposal reaches a live broker order is the Telegram
+  approve/deny flow shipped in PR 2 — not implemented yet.
+- **Default OFF.** `ORDER_PROPOSALS_ENABLED=false` by default
+  (`app/core/config.py`). When off, the three MCP tools are not registered
+  in either the default profile (`registry.py`) or the 8770 TradingCodex
+  execution profile allowlist (`tradingcodex_execution_registration.py`).
+- **Pure state machine.** `app/services/order_proposals/state_machine.py` is
+  stdlib-only (no broker/DB/network imports). The DB `CheckConstraint`s only
+  validate the string bag (`RUNG_STATES` / `GROUP_STATES`); the actual
+  transition graph is enforced by `assert_rung_transition(...)` in the
+  service layer, fail-closed via `OrderProposalInvalidStateTransition`.
+- **Immutable payload + replacement lineage.** A proposal is never mutated
+  in place for a price/qty change — a same-price/qty revalidation (e.g. TTL
+  refresh) is a new validation revision on the same row; an actual
+  price/qty change creates a new proposal row linked via
+  `supersedes_proposal_id` / `superseded_by_proposal_id`, and the original is
+  marked `superseded`.
+
+---
+
+## Activation
+
+```bash
+ORDER_PROPOSALS_ENABLED=true
+```
+
+Setting this env var (or config override) surfaces the three MCP tools
+(`order_proposal_create`, `order_proposal_get`, `order_proposal_list`) in:
+
+- The default MCP profile (`app/mcp_server/tooling/registry.py`).
+- The 8770 TradingCodex execution profile allowlist
+  (`app/mcp_server/tooling/tradingcodex_execution_registration.py`).
+
+With the flag off (default), none of the three tools are registered anywhere
+and the tables remain unused (migration is additive and applies regardless
+of the flag — `alembic upgrade head` is safe to run at any time).
+
+Restart the MCP process after changing the flag:
+
+```bash
+uv run python -m app.mcp_server.main
+```
+
+---
+
+## Lifecycle States
+
+### Rung state diagram (per-rung execution lifecycle)
+
+```
+DRAFT → PENDING_APPROVAL → REVALIDATING → APPROVED → SUBMITTING → ACKED | RESTING
+  → (FILLED | PARTIALLY_FILLED | CANCELLED | EXPIRED)
+```
+
+Branches:
+
+- `REVALIDATING → NEEDS_RECONFIRM` — payload changed; requires re-approval.
+- `REVALIDATING → PENDING_APPROVAL` — transient revalidation/guard failure,
+  retryable, fail-closed.
+- `PENDING_APPROVAL → REJECTED` — denied.
+- `SUBMITTING / ACKED / RESTING → UNVERIFIED` — broker timeout/unknown.
+  **Never auto-voided.**
+- `PENDING_APPROVAL → VOIDED_LOCAL_STALE` — evidence-absent local staleness
+  cleanup only.
+- `* → SUPERSEDED` — replacement lineage (new proposal supersedes this rung's
+  group).
+- `* → VOIDED` — explicit void.
+
+**Terminal rung states:** `FILLED, CANCELLED, EXPIRED, REJECTED, VOIDED,
+VOIDED_LOCAL_STALE, SUPERSEDED`.
+
+`UNVERIFIED` is a **holding** state, resolvable by later broker evidence —
+never terminal, never auto-voided (occupancy + evidence-based stale cleanup
+principle: a proposal only becomes `VOIDED_LOCAL_STALE` when broker evidence
+is **absent**, not merely delayed or unknown).
+
+### Group rollup (`order_proposals.lifecycle_state`)
+
+The group-level state is a coarser rollup over all sibling rungs, recomputed
+by `OrderProposalsService._recompute_group_state(rungs)` after every rung
+transition (`transition_rung(...)`):
+
+| Group state | When |
+|---|---|
+| `proposed` | Default; no rung has reached `approved` or later. |
+| `approved` | At least one rung `approved`, none submitting/executed yet. |
+| `partially_submitted` | Some rungs at/past `submitting` (acked/resting/partially_filled/filled/submitting) **and** some rungs still pre-submit (pending_approval/revalidating/approved/needs_reconfirm). |
+| `submitted` | All rungs at/past `submitting`, none still pre-submit. |
+| `terminal` | All rungs in a terminal state, and not fully `rejected` or fully `voided`/`voided_local_stale`. |
+| `rejected` | All rungs `rejected`. |
+| `voided` | All rungs `voided` or `voided_local_stale`. |
+| `superseded` | Set directly when this proposal is replaced by a newer revision. |
+| `expired` | *(member of the DB `GROUP_STATES` CHECK bag, but the current rollup never assigns it — see Known Item below.)* |
+
+**Known non-blocking item:** `_recompute_group_state` never rolls an
+all-`expired`-rung group up to the group-level `expired` state — an
+all-`expired` rung set falls into the generic `terminal` bucket instead
+(`expired` is a subset check that only special-cases `rejected` and
+`voided`/`voided_local_stale`, not `expired`). This is transcribed verbatim
+from the plan's own service logic and is a known item flagged for the plan
+author, not a bug fixed in this PR. **Rung-level state is still correctly
+recorded as `expired`** — only the group-level label is coarser than it
+could be. Do not rely on `lifecycle_state='expired'` at the group level to
+find all-expired proposal groups; query rung state instead (see DB
+Verification below).
+
+---
+
+## MCP Tools
+
+Read + create only — **no approve/submit tool exists in this PR.**
+
+### `order_proposal_create(symbol, market, account_mode, side, order_type, proposer, rungs, thesis=None, strategy=None, rationale=None, broker_account_id=None, lot_context=None, valid_until=None, supersedes_proposal_id=None)`
+
+Persists a new proposal group + its rungs. `rungs` is a list of
+`{"rung_index": int, "side": str, "quantity": str, "limit_price": str|None,
+"notional": str|None}`. NOT a broker mutation. Returns
+`{success, proposal_id, lifecycle_state, rungs}` on success or
+`{success: false, error}` on validation failure.
+
+If `supersedes_proposal_id` is given, the referenced proposal is marked
+`superseded` and lineage (`root_proposal_id`, `supersedes_proposal_id`) is
+linked on the new row.
+
+### `order_proposal_get(proposal_id)`
+
+Read-only fetch of a proposal group and its rungs by `proposal_id` (UUID).
+Returns `{success: false, error: "not_found"}` if missing.
+
+### `order_proposal_list(limit=50, symbol=None, lifecycle_state=None)`
+
+Read-only list of recent proposal groups, optionally filtered by `symbol`
+and/or group-level `lifecycle_state`. `limit` is clamped to `1..200`.
+
+---
+
+## DB Verification
+
+```sql
+-- A specific proposal group + its rungs
+SELECT
+  id, proposal_id, root_proposal_id, revision,
+  supersedes_proposal_id, superseded_by_proposal_id, no_resubmit, void_reason,
+  symbol, market, account_mode, side, order_type, proposer,
+  lifecycle_state, valid_until, validated_at, created_at, updated_at
+FROM review.order_proposals
+WHERE proposal_id = '<PROPOSAL_UUID>';
+
+SELECT
+  id, proposal_pk, rung_index, side, quantity, limit_price, notional,
+  state, approval_hash_digest, approval_revision, idempotency_key,
+  broker_order_id, correlation_id, filled_qty, void_reason,
+  created_at, updated_at
+FROM review.order_proposal_rungs
+WHERE proposal_pk = (
+  SELECT id FROM review.order_proposals WHERE proposal_id = '<PROPOSAL_UUID>'
+)
+ORDER BY rung_index;
+
+-- All groups with at least one rung stuck UNVERIFIED (needs operator attention)
+SELECT p.proposal_id, p.symbol, p.lifecycle_state, r.rung_index, r.state, r.broker_order_id
+FROM review.order_proposals p
+JOIN review.order_proposal_rungs r ON r.proposal_pk = p.id
+WHERE r.state = 'unverified'
+ORDER BY p.created_at DESC;
+
+-- All-expired rung groups (group-level lifecycle_state stays 'terminal',
+-- NOT 'expired' -- see Known Item above; query rung state directly)
+SELECT p.proposal_id, p.symbol, p.lifecycle_state AS group_state
+FROM review.order_proposals p
+WHERE p.id IN (
+  SELECT proposal_pk FROM review.order_proposal_rungs
+  GROUP BY proposal_pk
+  HAVING bool_and(state = 'expired')
+);
+
+-- Recent proposals by symbol
+SELECT proposal_id, symbol, side, lifecycle_state, created_at
+FROM review.order_proposals
+WHERE symbol = '<SYMBOL>'
+ORDER BY created_at DESC
+LIMIT 50;
+
+-- Replacement lineage for a superseded proposal
+SELECT proposal_id, revision, supersedes_proposal_id, superseded_by_proposal_id, lifecycle_state
+FROM review.order_proposals
+WHERE root_proposal_id = (
+  SELECT root_proposal_id FROM review.order_proposals WHERE proposal_id = '<PROPOSAL_UUID>'
+)
+ORDER BY revision;
+```
+
+No SQL INSERT/UPDATE/DELETE against these tables is supported outside
+`OrderProposalsService` — treat the above as read-only verification only.
+
+---
+
+## Telegram Approval
+
+Not implemented in this PR — see PR 2. Once shipped, proposal creation will
+optionally (behind `ORDER_PROPOSALS_TELEGRAM_ENABLED`, default off) dispatch
+an approval-table Telegram message with inline `[승인]`/`[거부]` buttons; a
+token-authed webhook will receive the callback, re-validate, and submit via
+the existing `approval_hash` place-order path. This runbook will be expanded
+with bot setup, webhook registration, operator activation steps, and an
+evidence template once PR 2 lands.
+
+---
+
+## Troubleshooting
+
+### MCP tools not visible
+
+Confirm `ORDER_PROPOSALS_ENABLED=true` is set in the MCP process environment
+(not just the shell you're running a script from), then restart:
+
+```bash
+uv run python -m app.mcp_server.main
+```
+
+Check both the default profile (`registry.py`) and, if using the 8770
+TradingCodex execution profile, that `ORDER_PROPOSAL_TOOL_NAMES` appears in
+`tradingcodex_execution_registration.py`'s allowlist.
+
+### `order_proposal_create` returns `{success: false, error: ...}`
+
+The error string comes from either a `ValueError` (bad decimal in a rung
+quantity/price/notional, malformed `valid_until` ISO timestamp, malformed
+`supersedes_proposal_id` UUID) or an `OrderProposalError` subclass raised by
+the service (e.g. an invalid rung transition, unknown market/account_mode/side
+value rejected by the DB `CheckConstraint`). Fix the input and retry — no
+partial row is left behind (the session is not committed on the exception
+path).
+
+### `OrderProposalInvalidStateTransition`
+
+Raised by `assert_rung_transition` when a rung is asked to move to a state
+not in its allowed-next set (see the state diagram above). This should never
+surface in PR 1 since there is no transition-driving MCP tool yet — it is
+exercised directly by `tests/services/order_proposals/test_state_machine.py`
+and the service's internal `transition_rung` (PR-2 callers only).
+
+### A proposal I expect to be `expired` at the group level shows `terminal`
+
+Expected — see the Known Item in Lifecycle States above. Check rung-level
+`state = 'expired'` directly; the group rollup does not (yet) special-case
+an all-expired rung set.
+
+### Migration state
+
+```bash
+uv run alembic current
+uv run alembic heads
+```
+
+The ROB-816 migration (`20260710_rob816_order_proposals`) is additive-only
+(two new tables, no existing table changes) and chains off
+`20260710_rob800_exit_intent`. `downgrade()` drops indexes then tables in
+reverse order and is safe in non-production environments.

--- a/tests/_schema_bootstrap.py
+++ b/tests/_schema_bootstrap.py
@@ -17,7 +17,12 @@ from sqlalchemy import text
 # Bump when adding an ORM table that has NO mirrored ALTER string below, so the
 # content hash changes and a persistent local DB re-bootstraps once. Adding a
 # mirrored ALTER already changes the hash automatically.
-SCHEMA_BOOTSTRAP_VERSION = 4
+#
+# v5 (ROB-816): review.order_proposals / review.order_proposal_rungs (Task 4)
+# have no mirrored ALTER string below — they rely solely on
+# Base.metadata.create_all. Persistent local test DBs bootstrapped before
+# Task 4 landed never got these tables until this bump forces one re-run.
+SCHEMA_BOOTSTRAP_VERSION = 5
 
 # ---- constraints + enums (moved verbatim from conftest.py) ----
 MARKET_VALUATION_SOURCE_CHECK_NAME = "ck_market_valuation_snapshots_source"

--- a/tests/core/test_config_order_proposals.py
+++ b/tests/core/test_config_order_proposals.py
@@ -1,0 +1,9 @@
+import pytest
+
+from app.core.config import Settings
+
+
+@pytest.mark.unit
+def test_order_proposals_disabled_by_default():
+    s = Settings(_env_file=None)
+    assert s.ORDER_PROPOSALS_ENABLED is False

--- a/tests/services/order_proposals/test_models_smoke.py
+++ b/tests/services/order_proposals/test_models_smoke.py
@@ -1,0 +1,34 @@
+import pytest
+
+from app.models.order_proposals import OrderProposal, OrderProposalRung
+from app.services.order_proposals.state_machine import RUNG_STATES
+
+
+@pytest.mark.unit
+def test_tables_in_review_schema():
+    assert OrderProposal.__table__.schema == "review"
+    assert OrderProposalRung.__table__.schema == "review"
+    assert OrderProposal.__tablename__ == "order_proposals"
+    assert OrderProposalRung.__tablename__ == "order_proposal_rungs"
+
+
+@pytest.mark.unit
+def test_rung_state_check_covers_all_states():
+    # The DB CHECK must list exactly the state-machine's RUNG_STATES.
+    # NOTE: Base.metadata's naming_convention (app/models/base.py) rewrites
+    # explicit CheckConstraint names to "ck_<table>_<given_name>" at the
+    # SQLAlchemy metadata level (this is standard SQLAlchemy behavior for
+    # CheckConstraint specifically, and matches the existing repo precedent
+    # in tests/test_invest_kr_fundamentals_snapshots_model.py). The Alembic
+    # migration below still creates the raw DB constraint literally named
+    # "order_proposal_rungs_state" since op.create_table doesn't route
+    # through this metadata's naming convention.
+    check = next(
+        c
+        for c in OrderProposalRung.__table__.constraints
+        if getattr(c, "name", None)
+        == "ck_order_proposal_rungs_order_proposal_rungs_state"
+    )
+    sqltext = str(check.sqltext)
+    for state in RUNG_STATES:
+        assert f"'{state}'" in sqltext

--- a/tests/services/order_proposals/test_no_repository_imports.py
+++ b/tests/services/order_proposals/test_no_repository_imports.py
@@ -1,0 +1,56 @@
+"""Enforce: order_proposals repository is imported ONLY by its service module.
+
+Model: tests/services/brokers/binance/demo/test_no_testnet_imports.py
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+
+import pytest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
+_BANNED = "app.services.order_proposals.repository"
+_ALLOWED = {pathlib.Path("app/services/order_proposals/service.py")}
+
+
+def _is_banned(module: str | None) -> bool:
+    if not module:
+        return False
+    return module == _BANNED or module.startswith(_BANNED + ".")
+
+
+def _imports_repo(path: pathlib.Path) -> bool:
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+    except SyntaxError:
+        return False
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and _is_banned(node.module):
+            return True
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if _is_banned(alias.name):
+                    return True
+    return False
+
+
+@pytest.mark.unit
+def test_repository_import_boundary_enforced():
+    offenders = []
+    for path in (REPO_ROOT / "app").rglob("*.py"):
+        rel = path.relative_to(REPO_ROOT)
+        if rel in _ALLOWED:
+            continue
+        if _imports_repo(path):
+            offenders.append(str(rel))
+    assert not offenders, f"repository imported outside its service: {offenders}"
+
+
+@pytest.mark.unit
+def test_service_actually_imports_repository():
+    svc = REPO_ROOT / "app/services/order_proposals/service.py"
+    assert _imports_repo(svc), (
+        "service.py must import the repository (guard would be vacuous)"
+    )

--- a/tests/services/order_proposals/test_payload.py
+++ b/tests/services/order_proposals/test_payload.py
@@ -1,0 +1,73 @@
+import pytest
+
+from app.services.order_proposals.payload import (
+    ProposalRungSpec,
+    compute_proposal_payload_hash,
+)
+
+
+def _rungs():
+    return [
+        ProposalRungSpec(0, "buy", "10", "2226000", None),
+        ProposalRungSpec(1, "buy", "5", "2200000", None),
+    ]
+
+
+@pytest.mark.unit
+def test_hash_is_deterministic_and_order_insensitive():
+    a = compute_proposal_payload_hash(
+        symbol="000660",
+        market="equity_kr",
+        account_mode="kis_live",
+        order_type="limit",
+        rungs=_rungs(),
+    )
+    b = compute_proposal_payload_hash(
+        symbol="000660",
+        market="equity_kr",
+        account_mode="kis_live",
+        order_type="limit",
+        rungs=list(reversed(_rungs())),
+    )
+    assert a == b
+    assert len(a) == 64
+
+
+@pytest.mark.unit
+def test_price_change_changes_hash():
+    base = compute_proposal_payload_hash(
+        symbol="000660",
+        market="equity_kr",
+        account_mode="kis_live",
+        order_type="limit",
+        rungs=_rungs(),
+    )
+    changed = compute_proposal_payload_hash(
+        symbol="000660",
+        market="equity_kr",
+        account_mode="kis_live",
+        order_type="limit",
+        rungs=[
+            ProposalRungSpec(0, "buy", "10", "2340000", None),
+            ProposalRungSpec(1, "buy", "5", "2200000", None),
+        ],
+    )
+    assert base != changed
+
+
+@pytest.mark.unit
+def test_ttl_only_change_keeps_hash_stable():
+    # Same price/qty; no TTL/timestamp participates in the hash.
+    assert compute_proposal_payload_hash(
+        symbol="A",
+        market="equity_kr",
+        account_mode="kis_live",
+        order_type="limit",
+        rungs=[ProposalRungSpec(0, "buy", "1", "100", None)],
+    ) == compute_proposal_payload_hash(
+        symbol="A",
+        market="equity_kr",
+        account_mode="kis_live",
+        order_type="limit",
+        rungs=[ProposalRungSpec(0, "buy", "1", "100", None)],
+    )

--- a/tests/services/order_proposals/test_service.py
+++ b/tests/services/order_proposals/test_service.py
@@ -1,0 +1,95 @@
+import uuid
+from decimal import Decimal
+
+import pytest
+
+from app.services.order_proposals import OrderProposalsService
+from app.services.order_proposals.errors import (
+    OrderProposalInvalidStateTransition,
+    OrderProposalNotFound,
+)
+from app.services.order_proposals.service import RungInput
+
+
+@pytest.mark.asyncio
+async def test_create_and_get_multi_rung(db_session):
+    svc = OrderProposalsService(db_session)
+    group = await svc.create_proposal(
+        symbol="000660",
+        market="equity_kr",
+        account_mode="kis_live",
+        side="buy",
+        order_type="limit",
+        proposer="operator:sess-1",
+        thesis="support bounce",
+        strategy="ladder",
+        rungs=[
+            RungInput(0, "buy", Decimal("10"), Decimal("2226000"), None),
+            RungInput(1, "buy", Decimal("5"), Decimal("2200000"), None),
+        ],
+    )
+    await db_session.commit()
+    assert group.lifecycle_state == "proposed"
+    assert group.root_proposal_id == group.proposal_id
+    assert group.payload_hash and len(group.payload_hash) == 64
+
+    fetched, rungs = await svc.get_proposal(group.proposal_id)
+    assert fetched.id == group.id
+    assert [r.rung_index for r in rungs] == [0, 1]
+    assert all(r.state == "pending_approval" for r in rungs)
+
+
+@pytest.mark.asyncio
+async def test_get_missing_raises(db_session):
+    svc = OrderProposalsService(db_session)
+    with pytest.raises(OrderProposalNotFound):
+        await svc.get_proposal(uuid.uuid4())
+
+
+@pytest.mark.asyncio
+async def test_rung_transition_enforces_state_machine(db_session):
+    svc = OrderProposalsService(db_session)
+    group = await svc.create_proposal(
+        symbol="A",
+        market="equity_kr",
+        account_mode="kis_live",
+        side="buy",
+        order_type="limit",
+        proposer="p",
+        rungs=[RungInput(0, "buy", Decimal("1"), Decimal("100"), None)],
+    )
+    await db_session.commit()
+    # illegal: pending_approval -> filled
+    with pytest.raises(OrderProposalInvalidStateTransition):
+        await svc.transition_rung(group.proposal_id, 0, new_state="filled")
+
+
+@pytest.mark.asyncio
+async def test_replacement_lineage_supersedes_original(db_session):
+    svc = OrderProposalsService(db_session)
+    original = await svc.create_proposal(
+        symbol="000660",
+        market="equity_kr",
+        account_mode="kis_live",
+        side="buy",
+        order_type="limit",
+        proposer="p",
+        rungs=[RungInput(0, "buy", Decimal("10"), Decimal("2226000"), None)],
+    )
+    await db_session.commit()
+    replacement = await svc.create_proposal(
+        symbol="000660",
+        market="equity_kr",
+        account_mode="kis_live",
+        side="buy",
+        order_type="limit",
+        proposer="p",
+        rungs=[RungInput(0, "buy", Decimal("10"), Decimal("2340000"), None)],
+        supersedes_proposal_id=original.proposal_id,
+    )
+    await db_session.commit()
+    orig_after, _ = await svc.get_proposal(original.proposal_id)
+    assert orig_after.lifecycle_state == "superseded"
+    assert orig_after.superseded_by_proposal_id == replacement.proposal_id
+    assert replacement.root_proposal_id == original.root_proposal_id
+    assert replacement.payload_hash != original.payload_hash

--- a/tests/services/order_proposals/test_state_machine.py
+++ b/tests/services/order_proposals/test_state_machine.py
@@ -1,0 +1,58 @@
+import pytest
+
+from app.services.order_proposals import state_machine as sm
+from app.services.order_proposals.errors import OrderProposalInvalidStateTransition
+
+
+@pytest.mark.unit
+def test_happy_path_allowed():
+    for a, b in [
+        ("pending_approval", "revalidating"),
+        ("revalidating", "approved"),
+        ("approved", "submitting"),
+        ("submitting", "resting"),
+        ("resting", "filled"),
+    ]:
+        sm.assert_rung_transition(a, b)  # no raise
+
+
+@pytest.mark.unit
+def test_accepted_is_not_filled():
+    # A rung may only reach filled via ACKED/RESTING — never straight from submitting-approved.
+    with pytest.raises(OrderProposalInvalidStateTransition):
+        sm.assert_rung_transition("approved", "filled")
+
+
+@pytest.mark.unit
+def test_timeout_never_auto_voids():
+    # submitting/acked/resting may go UNVERIFIED but not VOIDED_LOCAL_STALE.
+    sm.assert_rung_transition("submitting", "unverified")
+    with pytest.raises(OrderProposalInvalidStateTransition):
+        sm.assert_rung_transition("submitting", "voided_local_stale")
+
+
+@pytest.mark.unit
+def test_local_stale_only_from_pending():
+    sm.assert_rung_transition("pending_approval", "voided_local_stale")
+
+
+@pytest.mark.unit
+def test_needs_reconfirm_returns_to_pending():
+    sm.assert_rung_transition("revalidating", "needs_reconfirm")
+    sm.assert_rung_transition("needs_reconfirm", "pending_approval")
+
+
+@pytest.mark.unit
+def test_terminal_has_no_exits():
+    for term in (
+        "filled",
+        "cancelled",
+        "expired",
+        "rejected",
+        "voided",
+        "voided_local_stale",
+        "superseded",
+    ):
+        assert sm.is_terminal(term)
+        with pytest.raises(OrderProposalInvalidStateTransition):
+            sm.assert_rung_transition(term, "pending_approval")

--- a/tests/test_mcp_order_proposal_tools.py
+++ b/tests/test_mcp_order_proposal_tools.py
@@ -1,0 +1,43 @@
+import pytest
+
+from app.mcp_server.tooling import order_proposal_tools as opt
+
+
+@pytest.mark.asyncio
+async def test_create_then_get_then_list():
+    created = await opt.order_proposal_create(
+        symbol="000660", market="equity_kr", account_mode="kis_live",
+        side="buy", order_type="limit", proposer="operator:sess-x",
+        thesis="t", strategy="ladder",
+        rungs=[{"rung_index": 0, "side": "buy", "quantity": "10",
+                "limit_price": "2226000", "notional": None}])
+    assert created["success"] is True
+    pid = created["proposal_id"]
+
+    got = await opt.order_proposal_get(proposal_id=pid)
+    assert got["success"] is True
+    assert got["proposal"]["symbol"] == "000660"
+    assert len(got["rungs"]) == 1
+
+    listed = await opt.order_proposal_list(limit=10, symbol="000660")
+    assert listed["success"] is True
+    assert any(p["proposal_id"] == pid for p in listed["proposals"])
+
+
+@pytest.mark.asyncio
+async def test_create_rejects_empty_rungs():
+    res = await opt.order_proposal_create(
+        symbol="A", market="equity_kr", account_mode="kis_live", side="buy",
+        order_type="limit", proposer="p", rungs=[])
+    assert res["success"] is False
+    assert "rung" in res["error"].lower()
+
+
+@pytest.mark.unit
+def test_tools_registered_and_names_exported():
+    from fastmcp import FastMCP
+
+    mcp = FastMCP(name="t", on_duplicate="error")
+    opt.register_order_proposal_tools(mcp)
+    assert opt.ORDER_PROPOSAL_TOOL_NAMES == {
+        "order_proposal_create", "order_proposal_get", "order_proposal_list"}

--- a/tests/test_mcp_order_proposal_tools.py
+++ b/tests/test_mcp_order_proposal_tools.py
@@ -6,11 +6,24 @@ from app.mcp_server.tooling import order_proposal_tools as opt
 @pytest.mark.asyncio
 async def test_create_then_get_then_list():
     created = await opt.order_proposal_create(
-        symbol="000660", market="equity_kr", account_mode="kis_live",
-        side="buy", order_type="limit", proposer="operator:sess-x",
-        thesis="t", strategy="ladder",
-        rungs=[{"rung_index": 0, "side": "buy", "quantity": "10",
-                "limit_price": "2226000", "notional": None}])
+        symbol="000660",
+        market="equity_kr",
+        account_mode="kis_live",
+        side="buy",
+        order_type="limit",
+        proposer="operator:sess-x",
+        thesis="t",
+        strategy="ladder",
+        rungs=[
+            {
+                "rung_index": 0,
+                "side": "buy",
+                "quantity": "10",
+                "limit_price": "2226000",
+                "notional": None,
+            }
+        ],
+    )
     assert created["success"] is True
     pid = created["proposal_id"]
 
@@ -27,8 +40,14 @@ async def test_create_then_get_then_list():
 @pytest.mark.asyncio
 async def test_create_rejects_empty_rungs():
     res = await opt.order_proposal_create(
-        symbol="A", market="equity_kr", account_mode="kis_live", side="buy",
-        order_type="limit", proposer="p", rungs=[])
+        symbol="A",
+        market="equity_kr",
+        account_mode="kis_live",
+        side="buy",
+        order_type="limit",
+        proposer="p",
+        rungs=[],
+    )
     assert res["success"] is False
     assert "rung" in res["error"].lower()
 
@@ -40,4 +59,7 @@ def test_tools_registered_and_names_exported():
     mcp = FastMCP(name="t", on_duplicate="error")
     opt.register_order_proposal_tools(mcp)
     assert opt.ORDER_PROPOSAL_TOOL_NAMES == {
-        "order_proposal_create", "order_proposal_get", "order_proposal_list"}
+        "order_proposal_create",
+        "order_proposal_get",
+        "order_proposal_list",
+    }

--- a/tests/test_mcp_profiles.py
+++ b/tests/test_mcp_profiles.py
@@ -12,6 +12,7 @@ from typing import Any, cast
 
 import pytest
 
+from app.core.config import settings
 from app.mcp_server.profiles import McpProfile, resolve_mcp_profile
 from app.mcp_server.tooling.account_read_registration import (
     ACCOUNT_READ_FORBIDDEN_TOOL_NAMES,
@@ -26,6 +27,7 @@ from app.mcp_server.tooling.analysis_readonly_registration import (
     ANALYSIS_READONLY_FORBIDDEN_TOOL_NAMES,
     ANALYSIS_READONLY_TOOL_NAMES,
 )
+from app.mcp_server.tooling.order_proposal_tools import ORDER_PROPOSAL_TOOL_NAMES
 from app.mcp_server.tooling.orders_kis_variants import (
     KIS_LIVE_ORDER_TOOL_NAMES,
     KIS_MOCK_ORDER_TOOL_NAMES,
@@ -511,7 +513,15 @@ class TestAccountReadProfile:
 class TestTradingCodexExecutionProfile:
     def test_registers_exact_tradingcodex_execution_allowlist(self) -> None:
         mcp = _build_mcp(McpProfile.TRADINGCODEX_EXECUTION)
-        assert set(mcp.tools) == TRADINGCODEX_EXECUTION_TOOL_NAMES
+        # ROB-816: order_proposal_* tools are additionally gated by
+        # settings.ORDER_PROPOSALS_ENABLED (default off), unlike every other
+        # tool group in this allowlist which registers unconditionally. They
+        # are only present in the actually-registered surface when the flag
+        # is flipped on.
+        expected = TRADINGCODEX_EXECUTION_TOOL_NAMES
+        if not settings.ORDER_PROPOSALS_ENABLED:
+            expected = expected - ORDER_PROPOSAL_TOOL_NAMES
+        assert set(mcp.tools) == expected
 
     def test_does_not_register_forbidden_execution_surfaces(self) -> None:
         mcp = _build_mcp(McpProfile.TRADINGCODEX_EXECUTION)


### PR DESCRIPTION
## ROB-816 PR 1/2 — order_proposals SOT ledger + read/create MCP tools

First half of the trade-approval workflow auto_trader-native migration (tcx absorption). **Do not merge yet** — under review; PR 2/2 (Telegram approval) stacks on this.

Plan: `docs/plans/2026-07-10-rob-816-order-proposals-telegram-approval-implementation-plan.md`

### What this adds
- `review.order_proposals` (group) + `review.order_proposal_rungs` (per-rung) — additive migration, chains off `20260710_rob800_exit_intent`, round-trips clean.
- Pure rung **state machine** (`app/services/order_proposals/state_machine.py`) — DB CHECK validates the string bag; the transition graph is enforced in code.
- Immutable **payload hash** (principle #1: TTL-only change ≠ payload change).
- Write-guarded **repository** (AST test forbids importing it outside its service) + **`OrderProposalsService`** (the only writer; sessions injected, flush-not-commit).
- MCP tools **`order_proposal_create` / `_get` / `_list`** on the `tradingcodex_execution` (8770) profile — **read + create only, no approve/submit tool** (approval is Telegram-only, PR 2). Proposal creation is **not** a broker mutation.
- All gated behind `ORDER_PROPOSALS_ENABLED` (default off). Runbook draft in `docs/runbooks/order-proposals.md`.

### Safety boundaries
- No broker/order mutation on any path. All writes via `OrderProposalsService`.
- Six preservation principles wired at the data/state layer: immutable payload + replacement lineage, per-rung independence, account/lot context columns, evidence-based stale states, nonce/idempotency/audit columns, accepted≠filled state separation.

### Verification
- `make lint` clean (ruff + ty). `pytest tests/services/order_proposals/ tests/test_mcp_order_proposal_tools.py tests/test_mcp_profiles.py tests/core/test_config_order_proposals.py` → 103 passed. Alembic upgrade/downgrade/upgrade clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)