### PR TITLE
fix(ROB-816): Decimal→float coercion at revalidation place-order boundary

### DIFF
--- a/app/services/order_proposals/revalidation.py
+++ b/app/services/order_proposals/revalidation.py
@@ -142,6 +142,15 @@ async def _default_place_order_fn(**kwargs: Any) -> dict[str, Any]:
     """
     from app.mcp_server.tooling.order_execution import _place_order_impl
 
+    # The proposal ledger stores quantity/limit_price as Decimal, but
+    # `_place_order_impl`'s numeric paths assume the MCP tool layer's
+    # float/int inputs — e.g. `_preview_buy` computes the fee as
+    # `estimated_value * 0.0005`, which raises TypeError on Decimal and
+    # surfaced to the operator as a bogus "guard_blocked" (2026-07-11
+    # activation smoke, KRW-BTC canary). Normalize at this caller boundary;
+    # the impl's float contract stays unchanged for every other caller.
+    kwargs = {k: (float(v) if isinstance(v, Decimal) else v) for k, v in kwargs.items()}
+
     submit = await _place_order_impl(**kwargs)
     if kwargs.get("dry_run") is False:
         return _adapt_live_submit_response(

--- a/tests/services/order_proposals/test_revalidation.py
+++ b/tests/services/order_proposals/test_revalidation.py
@@ -525,3 +525,47 @@ async def test_preview_exception_returns_to_pending_approval(db_session):
     assert out[0].result == "error"
     _, rungs = await svc.get_proposal(g.proposal_id)
     assert rungs[0].state == "pending_approval"
+
+
+class TestDefaultPlaceOrderFnDecimalCoercion:
+    """2026-07-11 activation smoke regression: the proposal ledger hands
+    Decimal quantity/limit_price to the default place_order binding, but
+    `_place_order_impl`'s numeric paths (e.g. `_preview_buy` fee math)
+    assume float — Decimal raised TypeError which was mislabeled as
+    guard_blocked. The default fn must coerce Decimal kwargs to float."""
+
+    @pytest.mark.unit
+    @pytest.mark.asyncio
+    async def test_decimal_kwargs_coerced_to_float(self, monkeypatch):
+        from decimal import Decimal
+
+        from app.services.order_proposals import revalidation as mod
+
+        seen: dict = {}
+
+        async def fake_impl(**kwargs):
+            seen.update(kwargs)
+            return {
+                "success": True,
+                "price": kwargs["price"],
+                "quantity": kwargs["quantity"],
+            }
+
+        import app.mcp_server.tooling.order_execution as oe
+
+        monkeypatch.setattr(oe, "_place_order_impl", fake_impl)
+        result = await mod._default_place_order_fn(
+            dry_run=True,
+            symbol="KRW-BTC",
+            side="buy",
+            market="crypto",
+            order_type="limit",
+            quantity=Decimal("0.0001"),
+            price=Decimal("70000000"),
+            reason="regression",
+        )
+        assert result["success"] is True
+        assert isinstance(seen["quantity"], float)
+        assert isinstance(seen["price"], float)
+        assert seen["quantity"] == 0.0001
+        assert seen["price"] == 70000000.0


### PR DESCRIPTION
## 활성화 스모크 실측 버그 (2026-07-11)

텔레그램 승인 클릭 시 모든 crypto 제안이 "가드에 의해 차단됨" — 실제로는 가드가 아니라 `Decimal × float` TypeError (`_preview_buy`의 `estimated_value * 0.0005`, order_validation.py:1110)가 `success:false`로 삼켜져 오표시.

- 제안 레저는 Decimal 저장 → revalidation이 Decimal 그대로 `_place_order_impl`에 전달 (MCP 층은 float만 넘겨 잠복해 있던 경로)
- 수리: `_default_place_order_fn` 경계에서 Decimal→float 정규화 (impl 계약 무변경, 다른 호출자 무영향)
- 회귀 테스트: Decimal 입력 시 impl이 float를 받는지 고정
- 스위트: order_proposals 104 passed

후속(PR-3 기재 예정): ① 예외가 guard_blocked로 오분류되는 라벨링 분리 ② 거부 사유 텔레그램 표시 ③ 가드 차단 rung의 무기한 pending_approval 잔존 + void 도구 부재

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YSyQwBjVQ8kyvA5Hgo7tko