### PR TITLE
perf(ROB-829): answer Telegram callbacks before orders

### DIFF
--- a/app/services/order_proposals/telegram_callback.py
+++ b/app/services/order_proposals/telegram_callback.py
@@ -33,7 +33,8 @@ both the approve and deny branches.
 
 ``handle_callback_update`` never raises: Telegram's webhook contract expects a
 response for every update, so any unexpected exception is caught, logged, and
-turned into a best-effort ``answer_callback`` + a failure result dict.
+turned into a failure result dict. Callback queries are answered best-effort as
+soon as their metadata is available, before validation or order processing.
 """
 
 from __future__ import annotations
@@ -50,6 +51,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.config import settings
 from app.core.db import AsyncSessionLocal
 from app.services.order_proposals.approval_message import (
+    _escape_markdown,
     build_approval_message,
     parse_callback_data,
 )
@@ -169,7 +171,11 @@ def _build_result_summary(outcomes: list[RungOutcome]) -> str:
     lines = ["*처리 결과*"]
     for outcome in outcomes:
         label = _RESULT_LABELS.get(outcome.result, outcome.result)
-        lines.append(f"- #{outcome.rung_index + 1}: {label}")
+        reason = (outcome.detail or {}).get("error")
+        if outcome.result == "error" and not reason:
+            reason = "submit_rejected"
+        suffix = f" — {_escape_markdown(reason)}" if reason else ""
+        lines.append(f"- #{outcome.rung_index + 1}: {label}{suffix}")
     return "\n".join(lines)
 
 
@@ -212,12 +218,8 @@ async def _handle_deny(
     except OrderProposalError as exc:
         # No mutation happened above (mismatch/replay both raise before any
         # flush) -- commit anyway to release the row lock taken by
-        # `consume_approval_nonce`'s `for_update=True` SELECT before making
-        # the Telegram call below.
+        # `consume_approval_nonce`'s `for_update=True` SELECT.
         await session.commit()
-        await _safe_answer(
-            notifier, callback_query_id, "이미 처리되었거나 유효하지 않은 요청입니다"
-        )
         return {"handled": False, "reason": str(exc), "proposal_id": str(proposal_id)}
 
     _group, rungs = await service.get_proposal(proposal_id)
@@ -235,7 +237,6 @@ async def _handle_deny(
 
     if message_id is not None:
         await _safe_edit_message(notifier, chat_id, message_id, "❌ 거부됨")
-    await _safe_answer(notifier, callback_query_id, "거부되었습니다")
     return {
         "handled": True,
         "reason": "denied",
@@ -262,18 +263,14 @@ async def _handle_approve(
         await service.consume_approval_nonce(proposal_id, nonce, now=now)
     except OrderProposalError as exc:
         # See `_handle_deny`'s matching comment: no mutation happened above,
-        # but commit anyway to release the row lock before the Telegram call.
+        # but commit anyway to release the row lock.
         await session.commit()
-        await _safe_answer(
-            notifier, callback_query_id, "이미 처리되었거나 유효하지 않은 요청입니다"
-        )
         return {"handled": False, "reason": str(exc), "proposal_id": str(proposal_id)}
 
     acquired = await service.acquire_commit_lease(proposal_id, now=now)
     if not acquired:
-        # Same rationale -- release the `for_update=True` lock before notify.
+        # Same rationale -- release the `for_update=True` lock before return.
         await session.commit()
-        await _safe_answer(notifier, callback_query_id, "처리 중")
         return {
             "handled": False,
             "reason": "lease_held",
@@ -357,7 +354,6 @@ async def _handle_approve(
                 now=now,
             )
             await session.commit()
-        await _safe_answer(notifier, callback_query_id, "재확인이 필요합니다")
         return {
             "handled": True,
             "reason": "needs_reconfirm",
@@ -374,7 +370,6 @@ async def _handle_approve(
 
     if message_id is not None:
         await _safe_edit_message(notifier, chat_id, message_id, summary)
-    await _safe_answer(notifier, callback_query_id, "처리되었습니다")
     return {
         "handled": True,
         "reason": "approved",
@@ -413,14 +408,14 @@ async def handle_callback_update(
         telegram_user_id = from_user.get("id")
         data = callback_query.get("data")
 
+        await _safe_answer(active_notifier, callback_query_id, "처리 중")
+
         if str(chat_id) not in settings.order_proposals_telegram_chat_allowlist:
-            await _safe_answer(active_notifier, callback_query_id, "허용되지 않은 채팅")
             return {"handled": False, "reason": "chat_not_allowed"}
 
         try:
             action, proposal_short, nonce = parse_callback_data(data)
         except ValueError:
-            await _safe_answer(active_notifier, callback_query_id, "잘못된 요청입니다")
             return {"handled": False, "reason": "malformed_callback_data"}
 
         async with service_factory() as session:
@@ -428,9 +423,6 @@ async def handle_callback_update(
             proposal_id = await _resolve_proposal_id(service, proposal_short)
             if proposal_id is None:
                 await session.commit()
-                await _safe_answer(
-                    active_notifier, callback_query_id, "제안을 찾을 수 없습니다"
-                )
                 return {"handled": False, "reason": "proposal_not_found"}
 
             if action == "dn":
@@ -468,7 +460,4 @@ async def handle_callback_update(
             return result
     except Exception:  # noqa: BLE001 - fail-closed webhook contract
         logger.exception("order_proposals telegram callback handling failed")
-        await _safe_answer(
-            active_notifier, callback_query_id, "처리 중 오류가 발생했습니다"
-        )
         return {"handled": False, "reason": "internal_error"}

--- a/docs/plans/ROB-829-telegram-answer-first.md
+++ b/docs/plans/ROB-829-telegram-answer-first.md
@@ -1,0 +1,167 @@
+# ROB-829 Telegram Answer-First Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:test-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Telegram 주문 승인 버튼의 callback query를 주문 처리 전에 `"처리 중"`으로 선응답하고, 주문 처리 뒤 최종 메시지 edit에 성공 또는 실패 사유를 표시한다.
+
+**Architecture:** `handle_callback_update`가 callback query 메타데이터를 추출한 직후 기존 `_safe_answer`를 한 번 호출해 Telegram 스피너를 먼저 해제한다. 승인 해시, rung 전이, nonce/lease, 주문 제출, 원장 기록, commit-before-notify 흐름은 그대로 두고, 완료 후 `_safe_edit_message`가 렌더링하는 결과 요약에 주문 실패의 `detail["error"]`만 포함한다.
+
+**Tech Stack:** Python 3.13, FastAPI service layer, pytest/pytest-asyncio, Ruff, ty
+
+## Global Constraints
+
+- 실주문 실행 흐름과 `approval_hash`, rung, 원장 기록, nonce/lease/멱등 가드는 변경하지 않는다.
+- 텔레그램 응답 순서와 결과 메시지 렌더링만 변경한다.
+- 데이터베이스 모델과 Alembic revision은 변경하지 않는다 (`migration-0`).
+- `answerCallbackQuery`의 중립 텍스트는 정확히 `처리 중`이다.
+- PR 생성까지만 수행하고 머지하지 않는다.
+
+## Current-Flow Evidence
+
+- `app/services/order_proposals/telegram_callback.py:303-305`에서 `revalidate_fn`이 실제 재검증·주문 처리를 수행한다.
+- `app/services/order_proposals/telegram_callback.py:368-377`에서 결과 요약 생성, DB commit, `edit_message`, `answer_callback` 순으로 실행되어 callback answer가 마지막이다.
+- `app/services/order_proposals/telegram_callback.py:335-360`의 재확인 경로도 edit/send 뒤 callback answer를 호출한다.
+- `app/services/order_proposals/telegram_callback.py:261-305`의 nonce 소비, commit lease, 승인 기록, rung 전이, 주문 호출은 실주문 안전 경계이므로 수정 대상이 아니다.
+- `app/services/order_proposals/revalidation.py:337-345`는 명시적 주문 거절을 `RungOutcome(result="error", detail={"error": ...})`로 반환한다.
+- `app/monitoring/trade_notifier/notifier.py:90-92`는 Telegram 전송에 쓰는 공유 `httpx.AsyncClient`를 `timeout=10.0`으로 생성한다. `app/monitoring/trade_notifier/transports.py:93-99`와 `123-129`의 answer/edit 호출은 이 client를 사용하므로 API 콜 타임아웃이 이미 존재한다.
+
+## Files
+
+- Modify: `tests/services/order_proposals/test_telegram_callback.py` — answer/order/edit 호출 순서와 실패 사유 표시 회귀 테스트.
+- Modify: `app/services/order_proposals/telegram_callback.py` — callback 선응답 위치와 실패 결과 요약.
+- No migration files.
+
+### Task 1: Write the callback-order and failure-detail regression tests
+
+**Interfaces:**
+
+- Consumes: `handle_callback_update(update, now=..., service_factory=..., notifier=..., revalidate_fn=...)`.
+- Proves: notifier answer event occurs before `revalidate_fn`; final edit occurs after it; failed `RungOutcome.detail["error"]` is visible in the edited text.
+
+- [x] **Step 1: Add an event-order test**
+
+Add a notifier spy whose `answer_callback` and `edit_message` append `"answer"` and `"edit"` to a shared list. Have `fake_revalidate` append `"order"`, return a successful `RungOutcome`, invoke `handle_callback_update`, and assert:
+
+```python
+assert events == ["answer", "db", "order", "edit"]
+assert notifier.answered == [("cbq-1", "처리 중")]
+```
+
+- [x] **Step 2: Add an order-failure edit test**
+
+Return the same shape emitted by `revalidation._classify_submit` for a broker rejection:
+
+```python
+return [RungOutcome(0, "error", {"error": "broker_rejected"})]
+```
+
+Assert the handler remains handled as an approval result and the final edited text includes both the error label and the exact reason:
+
+```python
+assert result["reason"] == "approved"
+assert "오류" in notifier.edited[0][2]
+assert "broker\\_rejected" in notifier.edited[0][2]
+```
+
+- [x] **Step 3: Run the two tests and verify RED**
+
+Run:
+
+```bash
+uv run pytest \
+  tests/services/order_proposals/test_telegram_callback.py::test_approve_answers_before_order_processing_and_final_edit \
+  tests/services/order_proposals/test_telegram_callback.py::test_order_failure_final_edit_includes_reason -q
+```
+
+Expected: the order test fails because current events are `db, order, edit, answer`; the failure-detail test fails because `_build_result_summary` currently renders only `오류`.
+
+### Task 2: Move callback answer ahead of heavy work and render failure detail
+
+**Interfaces:**
+
+- Consumes: parsed Telegram callback query ID and existing `_safe_answer`/`_safe_edit_message` wrappers.
+- Produces: one early `answer_callback(callback_query_id, "처리 중")`; unchanged order-processing return contracts; error summary line `- #N: 오류 — <reason>` when a reason exists.
+
+- [x] **Step 1: Add the single early answer**
+
+In `handle_callback_update`, immediately after extracting callback metadata and before allowlist parsing, proposal lookup, DB mutation, or `revalidate_fn`, call:
+
+```python
+await _safe_answer(active_notifier, callback_query_id, "처리 중")
+```
+
+Remove later answer calls for the same callback so Telegram receives exactly one answer. Do not change any service/DB/order statements.
+
+- [x] **Step 2: Include explicit order failure reasons in the final summary**
+
+In `_build_result_summary`, preserve all existing result labels and append `detail["error"]` only when it is present:
+
+```python
+reason = (outcome.detail or {}).get("error")
+suffix = f" — {_escape_markdown(reason)}" if reason else ""
+lines.append(f"- #{outcome.rung_index + 1}: {label}{suffix}")
+```
+
+- [x] **Step 3: Run the focused tests and verify GREEN**
+
+Run the two-test command from Task 1. Expected: 2 passed.
+
+- [x] **Step 4: Run the complete callback service suite**
+
+Run:
+
+```bash
+uv run pytest tests/services/order_proposals/test_telegram_callback.py -q
+```
+
+Expected: all tests pass. Update existing assertions that expected late branch-specific answers so they instead require the single neutral early answer; do not weaken order/guard assertions.
+
+### Task 3: Verify transport coverage, quality gates, and scope
+
+- [x] **Step 1: Run Telegram transport tests**
+
+```bash
+uv run pytest tests/monitoring/test_trade_notifier_reply_markup.py tests/routers/test_telegram_callback_route.py -q
+```
+
+Expected: all tests pass and existing answer/edit transport contracts remain unchanged.
+
+- [x] **Step 2: Run lint/type quality gate**
+
+```bash
+make lint
+```
+
+Expected: Ruff and ty exit 0.
+
+- [x] **Step 3: Audit the diff against the live-order invariants**
+
+```bash
+git diff --check
+git diff -- app/services/order_proposals/telegram_callback.py tests/services/order_proposals/test_telegram_callback.py docs/plans/ROB-829-telegram-answer-first.md
+git status --short
+```
+
+Expected: only the plan, callback notification ordering/result rendering, and callback tests changed; no migration, order execution, approval hash, rung, ledger, or idempotency implementation changed.
+
+### Task 4: Create the unmerged PR
+
+- [x] **Step 1: Commit the scoped change**
+
+```bash
+git add docs/plans/ROB-829-telegram-answer-first.md \
+  app/services/order_proposals/telegram_callback.py \
+  tests/services/order_proposals/test_telegram_callback.py
+git commit -m "perf(ROB-829): answer Telegram callbacks before orders"
+```
+
+- [x] **Step 2: Push the feature branch and create a PR without merging**
+
+Use the repository ship workflow to push `rob-829` and open a PR against `main`. The PR body must state `migration-0`, list the RED/GREEN evidence and `make lint` result, and explicitly note that the order/guard/ledger/idempotency flow is unchanged.
+
+## Self-Review
+
+- Requirement coverage: early answer → Tasks 1–2; post-order edit and failure reason → Tasks 1–2; timeout confirmation → Current-Flow Evidence and Task 3; migration-0 → Global Constraints and Task 3; related suites/lint → Task 3; PR-only/no merge → Task 4.
+- Scope: one service module, one service test module, one plan document; no independent subsystem or refactor.
+- Placeholders: none.
+- Type/interface consistency: `RungOutcome.detail` is an optional dict at the existing service boundary; notifier method signatures are unchanged.

--- a/tests/services/order_proposals/test_telegram_callback.py
+++ b/tests/services/order_proposals/test_telegram_callback.py
@@ -43,6 +43,20 @@ class _FakeNotifier:
         return True
 
 
+class _EventNotifier(_FakeNotifier):
+    def __init__(self, events: list[str]) -> None:
+        super().__init__()
+        self.events = events
+
+    async def answer_callback(self, callback_query_id, text=None):
+        self.events.append("answer")
+        return await super().answer_callback(callback_query_id, text)
+
+    async def edit_message(self, chat_id, message_id, text, reply_markup=None):
+        self.events.append("edit")
+        return await super().edit_message(chat_id, message_id, text, reply_markup)
+
+
 def _session_factory(db_session):
     @contextlib.asynccontextmanager
     async def _factory():
@@ -124,7 +138,7 @@ async def test_chat_not_in_allowlist_rejected(monkeypatch, db_session):
 
     assert result == {"handled": False, "reason": "chat_not_allowed"}
     assert revalidate_calls == []
-    assert notifier.answered == [("cbq-1", "허용되지 않은 채팅")]
+    assert notifier.answered == [("cbq-1", "처리 중")]
     assert notifier.edited == []
 
 
@@ -170,6 +184,61 @@ async def test_approve_happy_path_submits_and_edits(monkeypatch, db_session):
     assert refreshed.approval_nonce_used_at is not None
     assert refreshed.approved_by_telegram_user_id == str(USER_ID)
     assert refreshed.approved_at is not None
+
+
+@pytest.mark.asyncio
+async def test_approve_answers_before_order_processing_and_final_edit(
+    monkeypatch, db_session
+):
+    _allow_chat(monkeypatch)
+    group = await _seed_proposal(db_session, nonce="nonce-answer-first")
+    data = f"op:{str(group.proposal_id)[:8]}:nonce-answer-first"
+    events: list[str] = []
+    notifier = _EventNotifier(events)
+
+    @contextlib.asynccontextmanager
+    async def event_session_factory():
+        events.append("db")
+        yield db_session
+
+    async def fake_revalidate(*, service, proposal_id, now):
+        events.append("order")
+        return [RungOutcome(0, "submitted_resting", {"submit": {}})]
+
+    result = await handle_callback_update(
+        _make_update(data=data),
+        now=datetime.now(UTC),
+        service_factory=event_session_factory,
+        notifier=notifier,
+        revalidate_fn=fake_revalidate,
+    )
+
+    assert result["reason"] == "approved"
+    assert events == ["answer", "db", "order", "edit"]
+    assert notifier.answered == [("cbq-1", "처리 중")]
+
+
+@pytest.mark.asyncio
+async def test_order_failure_final_edit_includes_reason(monkeypatch, db_session):
+    _allow_chat(monkeypatch)
+    group = await _seed_proposal(db_session, nonce="nonce-order-failure")
+    data = f"op:{str(group.proposal_id)[:8]}:nonce-order-failure"
+    notifier = _FakeNotifier()
+
+    async def fake_revalidate(*, service, proposal_id, now):
+        return [RungOutcome(0, "error", {"error": "broker_rejected"})]
+
+    result = await handle_callback_update(
+        _make_update(data=data),
+        now=datetime.now(UTC),
+        service_factory=_session_factory(db_session),
+        notifier=notifier,
+        revalidate_fn=fake_revalidate,
+    )
+
+    assert result["reason"] == "approved"
+    assert "오류" in notifier.edited[0][2]
+    assert "broker\\_rejected" in notifier.edited[0][2]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- acknowledge Telegram callback queries immediately with the neutral text `처리 중`, before allowlist parsing, DB access, nonce/lease checks, or order processing
- keep `editMessageText` after order processing and include escaped broker failure reasons in the final result message
- document the TDD flow and timeout evidence in `docs/plans/ROB-829-telegram-answer-first.md`

## Safety boundaries

- `migration-0`
- no changes to order execution, `approval_hash`, rung transitions, ledger recording, idempotency, nonce consumption, or commit lease behavior
- commit-before-final-edit ordering remains unchanged
- Telegram calls retain the existing `httpx.AsyncClient(timeout=10.0)` timeout

## TDD evidence

- RED: ordering was `order → edit → answer`; failure edit omitted `broker_rejected`
- GREEN: regression test proves `answer → DB session → order → edit`
- GREEN: rejected-order edit contains the Markdown-safe visible failure reason `broker_rejected`

## Test plan

- [x] `uv run pytest tests/services/order_proposals/test_telegram_callback.py -q` — 22 passed
- [x] `uv run pytest tests/monitoring/test_trade_notifier_reply_markup.py tests/routers/test_telegram_callback_route.py -q` — 14 passed
- [x] `make lint` — Ruff check, Ruff format check, and ty passed
- [x] `git diff --check`

## Review

- independent review: 0 critical; Markdown escaping finding fixed and reverified
- no frontend or prompt-related files changed
