### PR TITLE
perf(ROB-830): get_holdings residual N+1 — batch crypto identity + DB-first KR enrichment

### DIFF
--- a/app/mcp_server/tooling/market_data_indicators.py
+++ b/app/mcp_server/tooling/market_data_indicators.py
@@ -88,10 +88,18 @@ async def _fetch_ohlcv_crypto_paginated(
 
 
 async def _fetch_ohlcv_for_indicators(
-    symbol: str, market_type: str, count: int = 250
+    symbol: str,
+    market_type: str,
+    count: int = 250,
+    *,
+    crypto_instrument_id: int | None = None,
 ) -> pd.DataFrame:
     if market_type == "crypto":
-        return await _cache_first_crypto(symbol=symbol, count=count)
+        return await _cache_first_crypto(
+            symbol=symbol,
+            count=count,
+            instrument_id=crypto_instrument_id,
+        )
     if market_type == "equity_kr":
         return await _cache_first_kr(symbol=symbol, count=count)
     return await _cache_first_us(symbol=symbol, count=count)
@@ -266,8 +274,16 @@ async def _cache_first_us(*, symbol: str, count: int) -> pd.DataFrame:
         return _rows_to_frame(repo_rows) if repo_rows else _rows_to_frame(cached)
 
 
-async def _cache_first_crypto(*, symbol: str, count: int) -> pd.DataFrame:
-    """Read crypto daily candles from DB; fall back to Upbit and upsert on miss."""
+async def _cache_first_crypto(
+    *, symbol: str, count: int, instrument_id: int | None = None
+) -> pd.DataFrame:
+    """Read crypto daily candles from DB; fall back to Upbit and upsert on miss.
+
+    When ``instrument_id`` is supplied, the read/write paths skip the
+    per-symbol ``crypto_instruments`` lookup that drove the holdings N+1.
+    All non-holdings callers continue to omit the new keyword and retain the
+    legacy one-SELECT-per-symbol path.
+    """
     from app.core.db import AsyncSessionLocal
     from app.services.daily_candles.repository import DailyCandlesRepository, MarketKey
 
@@ -279,9 +295,20 @@ async def _cache_first_crypto(*, symbol: str, count: int) -> pd.DataFrame:
 
     async with AsyncSessionLocal() as session:
         repo = DailyCandlesRepository(session=session)
-        cached = await repo.fetch_recent(
-            market=MarketKey.CRYPTO, symbol=symbol, partition=partition, count=count
-        )
+        if instrument_id is not None:
+            cached = await repo.fetch_recent_crypto_by_instrument_id(
+                instrument_id=instrument_id,
+                symbol=symbol,
+                partition=partition,
+                count=count,
+            )
+        else:
+            cached = await repo.fetch_recent(
+                market=MarketKey.CRYPTO,
+                symbol=symbol,
+                partition=partition,
+                count=count,
+            )
         if len(cached) >= count and _cache_is_fresh_crypto(cached):
             logger.debug(
                 "daily_candles cache hit market=%s symbol=%s rows=%d",
@@ -307,7 +334,12 @@ async def _cache_first_crypto(*, symbol: str, count: int) -> pd.DataFrame:
             frame, symbol=symbol, partition=partition, source="upbit"
         )
         if repo_rows:
-            await repo.upsert_rows(market=MarketKey.CRYPTO, rows=repo_rows)
+            if instrument_id is not None:
+                await repo.upsert_crypto_rows_by_instrument_id(
+                    instrument_id=instrument_id, rows=repo_rows
+                )
+            else:
+                await repo.upsert_rows(market=MarketKey.CRYPTO, rows=repo_rows)
             await session.commit()
         return _rows_to_frame(repo_rows) if repo_rows else _rows_to_frame(cached)
 

--- a/app/mcp_server/tooling/portfolio_holdings.py
+++ b/app/mcp_server/tooling/portfolio_holdings.py
@@ -100,6 +100,8 @@ from app.mcp_server.tooling.shared import (
 )
 from app.services.brokers.kis.client import KISClient
 from app.services.crypto_voting_signals import CryptoVotingSignals, VotingResult
+from app.services.daily_candles.read_service import cache_first_kr
+from app.services.daily_candles.repository import DailyCandlesRepository
 from app.services.manual_holdings_service import ManualHoldingsService
 from app.services.screenshot_holdings_service import ScreenshotHoldingsService
 from app.services.toss_portfolio_service import (
@@ -256,13 +258,43 @@ def _build_crypto_strategy_signal(
     return None
 
 
+async def _resolve_crypto_instrument_ids_for_holdings(
+    positions: list[dict[str, Any]],
+) -> dict[str, int]:
+    """Resolve one batched ``symbol -> instrument_id`` map for the holdings fan-out.
+
+    Replaces the legacy per-position lookup that caused the N+1 against
+    ``crypto_instruments``. Returns an empty dict when no crypto positions
+    are in scope so the caller can short-circuit.
+    """
+    symbols = sorted(
+        {
+            str(position.get("symbol") or "").strip().upper()
+            for position in positions
+            if position.get("instrument_type") == "crypto"
+            and position.get("symbol")
+        }
+    )
+    if not symbols:
+        return {}
+    async with AsyncSessionLocal() as session:
+        repo = DailyCandlesRepository(session=session)
+        return await repo.resolve_crypto_instrument_ids(
+            symbols=symbols,
+            partition="upbit_krw",
+        )
+
+
 async def _compute_crypto_signals_for_position(
     position: dict[str, Any],
+    *,
+    instrument_id: int,
 ) -> tuple[float | None, VotingResult | None]:
     """Compute crypto RSI and voting signals for a position.
 
     Args:
         position: Position dict with symbol and current_price
+        instrument_id: Pre-resolved ``crypto_instruments.id`` for this symbol.
 
     Returns:
         Tuple of (rsi_14, voting_result) or (None, None) if computation fails
@@ -273,7 +305,12 @@ async def _compute_crypto_signals_for_position(
         return None, None
 
     try:
-        df = await _fetch_ohlcv_for_indicators(symbol, "crypto", count=50)
+        df = await _fetch_ohlcv_for_indicators(
+            symbol,
+            "crypto",
+            count=50,
+            crypto_instrument_id=instrument_id,
+        )
     except Exception:
         return None, None
 
@@ -712,6 +749,28 @@ async def _fetch_price_map_for_positions(
     ) -> tuple[str, str, float | None, str | None, str | None]:
         if instrument_type == "equity_kr":
             try:
+                cached = await cache_first_kr(symbol, 2)
+                if (
+                    cached is not None
+                    and not cached.empty
+                    and "close" in cached.columns
+                ):
+                    cached_price = _to_optional_float(cached["close"].iloc[-1])
+                    if cached_price is not None and cached_price > 0:
+                        return (
+                            instrument_type,
+                            symbol,
+                            cached_price,
+                            None,
+                            "db",
+                        )
+            except Exception:
+                logger.debug(
+                    "KR daily DB enrichment failed for %s; falling back to KIS",
+                    symbol,
+                    exc_info=True,
+                )
+            try:
                 quote = await _fetch_quote_equity_kr(symbol)
                 price = quote.get("price")
                 return (
@@ -1132,30 +1191,55 @@ async def _get_holdings_impl(
             and p.get("current_price") is not None
         ]
         if crypto_positions:
-            try:
-                signal_results = await bounded_gather(
-                    _CRYPTO_SIGNAL_CONCURRENCY,
-                    [
-                        lambda p=position: _compute_crypto_signals_for_position(p)
-                        for position in crypto_positions
-                    ],
-                    return_exceptions=True,
+            crypto_instrument_ids = await _resolve_crypto_instrument_ids_for_holdings(
+                crypto_positions
+            )
+
+            # Fail-open: skip symbols missing from crypto_instruments so we
+            # never fabricate strategy_signal data for unseeded holdings.
+            computable_positions = [
+                position
+                for position in crypto_positions
+                if str(position.get("symbol") or "").strip().upper()
+                in crypto_instrument_ids
+            ]
+
+            async def _compute_for(
+                position: dict[str, Any], iid: int
+            ) -> tuple[float | None, VotingResult | None]:
+                return await _compute_crypto_signals_for_position(
+                    position, instrument_id=iid
                 )
-                for position, signal_result in zip(
-                    crypto_positions, signal_results, strict=False
-                ):
-                    if isinstance(signal_result, Exception):
-                        rsi_14 = None
-                        voting_result = None
-                    else:
-                        rsi_14, voting_result = signal_result
-                    signal = _build_crypto_strategy_signal(
-                        position, rsi_14=rsi_14, voting_result=voting_result
+
+            if computable_positions:
+                try:
+                    signal_results = await bounded_gather(
+                        _CRYPTO_SIGNAL_CONCURRENCY,
+                        [
+                            lambda p=position, iid=crypto_instrument_ids[
+                                str(position.get("symbol") or "").strip().upper()
+                            ]: _compute_for(p, iid)
+                            for position in computable_positions
+                        ],
+                        return_exceptions=True,
                     )
-                    if signal:
-                        position["strategy_signal"] = signal
-            except Exception as exc:
-                logger.debug("Failed to compute crypto strategy signals: %s", exc)
+                    for position, signal_result in zip(
+                        computable_positions, signal_results, strict=False
+                    ):
+                        if isinstance(signal_result, Exception):
+                            rsi_14 = None
+                            voting_result = None
+                        else:
+                            rsi_14, voting_result = signal_result
+                        signal = _build_crypto_strategy_signal(
+                            position, rsi_14=rsi_14, voting_result=voting_result
+                        )
+                        if signal:
+                            position["strategy_signal"] = signal
+                except Exception as exc:
+                    logger.debug(
+                        "Failed to compute crypto strategy signals: %s", exc
+                    )
 
     grouped_accounts: dict[str, dict[str, Any]] = {}
     for position in positions:

--- a/app/mcp_server/tooling/portfolio_holdings.py
+++ b/app/mcp_server/tooling/portfolio_holdings.py
@@ -1190,18 +1190,51 @@ async def _get_holdings_impl(
             and p.get("current_price") is not None
         ]
         if crypto_positions:
-            crypto_instrument_ids = await _resolve_crypto_instrument_ids_for_holdings(
-                crypto_positions
-            )
+            # Fail-open (ROB-830 defect 2): a batch resolver DB error must
+            # not take down the whole get_holdings response. Degrade to "no
+            # instrument ids resolved" rather than propagating the error —
+            # indicator-independent signals below still get computed and
+            # holdings are still returned.
+            try:
+                crypto_instrument_ids = (
+                    await _resolve_crypto_instrument_ids_for_holdings(crypto_positions)
+                )
+            except Exception as exc:
+                logger.warning(
+                    "Batch crypto instrument id resolution failed; "
+                    "falling back to indicator-independent signals only: %s",
+                    exc,
+                )
+                crypto_instrument_ids = {}
 
-            # Fail-open: skip symbols missing from crypto_instruments so we
-            # never fabricate strategy_signal data for unseeded holdings.
+            # Fail-open: skip symbols missing from crypto_instruments for
+            # indicator-*dependent* enrichment (RSI/voting) so we never
+            # fabricate that data for unseeded holdings.
             computable_positions = [
                 position
                 for position in crypto_positions
                 if str(position.get("symbol") or "").strip().upper()
                 in crypto_instrument_ids
             ]
+            non_computable_positions = [
+                position
+                for position in crypto_positions
+                if str(position.get("symbol") or "").strip().upper()
+                not in crypto_instrument_ids
+            ]
+
+            # ROB-830 defect 1: stop-loss is an indicator-*independent*
+            # safety signal (profit_rate only) and must still fire for
+            # positions we can't enrich with RSI/voting (missing instrument
+            # id, or resolver failure above). Mirrors the pre-batch behavior
+            # where a per-position lookup failure fell back to
+            # rsi_14=None/voting_result=None instead of dropping the signal.
+            for position in non_computable_positions:
+                signal = _build_crypto_strategy_signal(
+                    position, rsi_14=None, voting_result=None
+                )
+                if signal:
+                    position["strategy_signal"] = signal
 
             async def _compute_for(
                 position: dict[str, Any], iid: int

--- a/app/mcp_server/tooling/portfolio_holdings.py
+++ b/app/mcp_server/tooling/portfolio_holdings.py
@@ -271,8 +271,7 @@ async def _resolve_crypto_instrument_ids_for_holdings(
         {
             str(position.get("symbol") or "").strip().upper()
             for position in positions
-            if position.get("instrument_type") == "crypto"
-            and position.get("symbol")
+            if position.get("instrument_type") == "crypto" and position.get("symbol")
         }
     )
     if not symbols:
@@ -1216,9 +1215,9 @@ async def _get_holdings_impl(
                     signal_results = await bounded_gather(
                         _CRYPTO_SIGNAL_CONCURRENCY,
                         [
-                            lambda p=position, iid=crypto_instrument_ids[
-                                str(position.get("symbol") or "").strip().upper()
-                            ]: _compute_for(p, iid)
+                            lambda p=position, iid=crypto_instrument_ids[str(position.get("symbol") or "").strip().upper()]: (
+                                _compute_for(p, iid)
+                            )
                             for position in computable_positions
                         ],
                         return_exceptions=True,
@@ -1237,9 +1236,7 @@ async def _get_holdings_impl(
                         if signal:
                             position["strategy_signal"] = signal
                 except Exception as exc:
-                    logger.debug(
-                        "Failed to compute crypto strategy signals: %s", exc
-                    )
+                    logger.debug("Failed to compute crypto strategy signals: %s", exc)
 
     grouped_accounts: dict[str, dict[str, Any]] = {}
     for position in positions:

--- a/app/services/daily_candles/repository.py
+++ b/app/services/daily_candles/repository.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from typing import cast
 
-from sqlalchemy import text
+from sqlalchemy import bindparam, text
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.sql.elements import TextClause
 
@@ -65,6 +65,16 @@ def _recent_time_floor(count: int, *, now: datetime) -> datetime:
     """
     window_days = max(400, int(count) * 3)
     return now - timedelta(days=window_days)
+
+
+def _crypto_venue_for_partition(partition: str) -> str:
+    """Map a legacy crypto ``partition`` label to its ``crypto_instruments.venue`` value.
+
+    Today only Upbit KRW is producing crypto rows; ``partition='upbit_krw'`` maps
+    to ``venue='upbit'``. Children B/C will add Binance/Alpaca mappings via
+    additional rows in ``crypto_instruments``.
+    """
+    return "upbit" if partition == "upbit_krw" else partition.split("_")[0]
 
 
 def _build_kr_us_recent_sql(partition_col: str, adj_close_select: str) -> str:
@@ -166,51 +176,115 @@ class DailyCandlesRepository:
         )
         return max(int(result.rowcount or 0), 0)
 
-    async def _resolve_instrument_id(self, *, symbol: str, partition: str) -> int:
-        """Translate legacy (symbol, partition) -> instrument_id.
+    async def resolve_crypto_instrument_ids(
+        self, *, symbols: list[str], partition: str
+    ) -> dict[str, int]:
+        """Batch-resolve legacy ``(symbol, partition)`` -> ``instrument_id``.
 
-        Today only Upbit KRW is producing crypto rows; (partition='upbit_krw',
-        symbol='KRW-XXX') maps to (venue='upbit', product='spot',
-        venue_symbol=symbol). Children B/C will add Binance/Alpaca mappings
-        via additional rows in crypto_instruments.
+        Single ``SELECT ... WHERE venue_symbol IN (:symbols)`` so a fan-out over
+        many crypto symbols collapses to one round-trip. Unknown symbols are
+        silently absent; callers that need fail-on-unknown must look them up
+        explicitly via :meth:`_resolve_instrument_id`.
         """
-        venue = "upbit" if partition == "upbit_krw" else partition.split("_")[0]
-        sql = text(
-            "SELECT id FROM crypto_instruments "
-            "WHERE venue = :v AND product = 'spot' AND venue_symbol = :s "
-            "LIMIT 1"
+        normalized = sorted(
+            {str(symbol).strip().upper() for symbol in symbols if symbol}
         )
-        result = await self._session.execute(sql, {"v": venue, "s": symbol})
-        row = result.first()
-        if row is None:
+        if not normalized:
+            return {}
+        sql = text(
+            "SELECT venue_symbol, id FROM crypto_instruments "
+            "WHERE venue = :venue AND product = 'spot' "
+            "AND venue_symbol IN :symbols"
+        ).bindparams(bindparam("symbols", expanding=True))
+        result = await self._session.execute(
+            sql,
+            {
+                "venue": _crypto_venue_for_partition(partition),
+                "symbols": normalized,
+            },
+        )
+        return {str(row.venue_symbol): int(row.id) for row in result}
+
+    async def _resolve_instrument_id(self, *, symbol: str, partition: str) -> int:
+        """Single-symbol identity resolver. Raises ``LookupError`` if not seeded."""
+        resolved = await self.resolve_crypto_instrument_ids(
+            symbols=[symbol], partition=partition
+        )
+        iid = resolved.get(str(symbol).strip().upper())
+        if iid is None:
+            venue = _crypto_venue_for_partition(partition)
             raise LookupError(
                 f"No crypto_instruments row for venue={venue!r} symbol={symbol!r}; "
                 "seed the instrument before writing candles."
             )
-        return int(row.id)
+        return iid
 
-    async def _upsert_crypto_rows(self, *, rows: list[DailyCandleRow]) -> int:
+    async def fetch_recent_crypto_by_instrument_id(
+        self,
+        *,
+        instrument_id: int,
+        symbol: str,
+        partition: str,
+        count: int,
+    ) -> list[DailyCandleRow]:
+        """Read crypto daily candles directly by instrument_id (no identity lookup)."""
+        sql = text(_CRYPTO_RECENT_SQL)
+        result = await self._session.execute(
+            sql,
+            {
+                "iid": int(instrument_id),
+                "symbol": symbol,
+                "partition": partition,
+                "count": int(count),
+                "time_floor": _recent_time_floor(int(count), now=datetime.now(UTC)),
+            },
+        )
+        out: list[DailyCandleRow] = []
+        for row in result.mappings().all():
+            out.append(
+                DailyCandleRow(
+                    time_utc=row["time"],
+                    symbol=row["symbol"],
+                    partition=row["partition"],
+                    open=float(row["open"]),
+                    high=float(row["high"]),
+                    low=float(row["low"]),
+                    close=float(row["close"]),
+                    adj_close=None,
+                    volume=(
+                        float(row["volume"]) if row["volume"] is not None else 0.0
+                    ),
+                    value=float(row["value"]) if row["value"] is not None else 0.0,
+                    source=row["source"],
+                )
+            )
+        return list(reversed(out))
+
+    async def upsert_crypto_rows_by_instrument_id(
+        self, *, instrument_id: int, rows: list[DailyCandleRow]
+    ) -> int:
+        """Upsert crypto daily candles directly by instrument_id.
+
+        Conflict policy preserves the original close when the existing row is
+        already closed with the same source.
+        """
         if not rows:
             return 0
-        payload: list[dict[str, object]] = []
-        for row in rows:
-            iid = await self._resolve_instrument_id(
-                symbol=row.symbol, partition=row.partition
-            )
-            payload.append(
-                {
-                    "instrument_id": iid,
-                    "time": row.time_utc,
-                    "open": row.open,
-                    "high": row.high,
-                    "low": row.low,
-                    "close": row.close,
-                    "base_volume": row.volume,
-                    "quote_volume": row.value,
-                    "is_closed": True,
-                    "source": row.source,
-                }
-            )
+        payload = [
+            {
+                "instrument_id": int(instrument_id),
+                "time": row.time_utc,
+                "open": row.open,
+                "high": row.high,
+                "low": row.low,
+                "close": row.close,
+                "base_volume": row.volume,
+                "quote_volume": row.value,
+                "is_closed": True,
+                "source": row.source,
+            }
+            for row in rows
+        ]
         sql = text(
             """
             INSERT INTO public.crypto_candles_1d (
@@ -241,6 +315,35 @@ class DailyCandlesRepository:
             cast(object, await self._session.execute(sql, payload)),
         )
         return max(int(result.rowcount or 0), 0)
+
+    async def _upsert_crypto_rows(self, *, rows: list[DailyCandleRow]) -> int:
+        if not rows:
+            return 0
+
+        # Group rows by (symbol, partition) so unique identities resolve once,
+        # not once per row.
+        identities_by_pair: dict[tuple[str, str], int] = {}
+        for row in rows:
+            pair = (str(row.symbol).strip().upper(), str(row.partition))
+            identities_by_pair.setdefault(
+                pair,
+                await self._resolve_instrument_id(
+                    symbol=pair[0], partition=pair[1]
+                ),
+            )
+
+        total = 0
+        for (symbol, partition), iid in identities_by_pair.items():
+            identity_rows = [
+                row
+                for row in rows
+                if str(row.symbol).strip().upper() == symbol
+                and str(row.partition) == partition
+            ]
+            total += await self.upsert_crypto_rows_by_instrument_id(
+                instrument_id=iid, rows=identity_rows
+            )
+        return total
 
     @staticmethod
     def _build_market_upsert(

--- a/app/services/daily_candles/repository.py
+++ b/app/services/daily_candles/repository.py
@@ -323,10 +323,10 @@ class DailyCandlesRepository:
         identities_by_pair: dict[tuple[str, str], int] = {}
         for row in rows:
             pair = (str(row.symbol).strip().upper(), str(row.partition))
-            identities_by_pair.setdefault(
-                pair,
-                await self._resolve_instrument_id(symbol=pair[0], partition=pair[1]),
-            )
+            if pair not in identities_by_pair:
+                identities_by_pair[pair] = await self._resolve_instrument_id(
+                    symbol=pair[0], partition=pair[1]
+                )
 
         total = 0
         for (symbol, partition), iid in identities_by_pair.items():

--- a/app/services/daily_candles/repository.py
+++ b/app/services/daily_candles/repository.py
@@ -251,9 +251,7 @@ class DailyCandlesRepository:
                     low=float(row["low"]),
                     close=float(row["close"]),
                     adj_close=None,
-                    volume=(
-                        float(row["volume"]) if row["volume"] is not None else 0.0
-                    ),
+                    volume=(float(row["volume"]) if row["volume"] is not None else 0.0),
                     value=float(row["value"]) if row["value"] is not None else 0.0,
                     source=row["source"],
                 )
@@ -327,9 +325,7 @@ class DailyCandlesRepository:
             pair = (str(row.symbol).strip().upper(), str(row.partition))
             identities_by_pair.setdefault(
                 pair,
-                await self._resolve_instrument_id(
-                    symbol=pair[0], partition=pair[1]
-                ),
+                await self._resolve_instrument_id(symbol=pair[0], partition=pair[1]),
             )
 
         total = 0

--- a/docs/plans/ROB-830-get-holdings-n1-residuals.md
+++ b/docs/plans/ROB-830-get-holdings-n1-residuals.md
@@ -1,0 +1,761 @@
+# ROB-830 get_holdings residual N+1s — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove the two remaining `get_holdings` fan-outs: resolve all crypto instrument IDs with one batched `IN` query and serve KR current-price enrichment from fresh `kr_candles_1d` rows before falling back to KIS.
+
+**Architecture:** The crypto strategy-signal stage will resolve its complete symbol set once, then pass immutable `instrument_id` values through the existing indicator/cache-first call chain so neither candle reads nor write-back re-query `crypto_instruments`. The KR price stage will call the existing ROB-639/ROB-812 `cache_first_kr(symbol, 2)` reader and invoke the unchanged KIS quote helper only when the DB reader returns no usable fresh frame.
+
+**Tech Stack:** Python 3.13, FastMCP handlers, SQLAlchemy async, PostgreSQL/TimescaleDB, pandas, pytest/pytest-asyncio, Ruff, ty.
+
+## Global Constraints
+
+- TDD only: every production change follows a test that was observed failing for the intended reason.
+- Return schema and values remain unchanged; only data acquisition changes from per-symbol lookup/live HTTP to batched/DB-first reads.
+- Read path only. Order, preview, modify, cancel, reconcile, and journal paths are unchanged.
+- migration-0: no Alembic revision and no schema/index/config change.
+- Crypto instrument resolution is request-scoped. Do not add a process-global mutable cache or invalidation policy.
+- Missing crypto instrument rows remain fail-open for strategy enrichment: the holding remains in the response without a fabricated `strategy_signal`.
+- KR DB frames are accepted only through `cache_first_kr`, which already enforces sufficient row count, latest closed-session freshness, historical-query bypass, and the forming-bar rule. KIS remains the fallback on `None`, empty, invalid close, or DB/calendar error.
+- Do not change `_fetch_quote_equity_kr` globally; the DB-first routing belongs only to the `get_holdings` price-refresh path.
+- Do not update `app/mcp_server/README.md`: public tool parameters, defaults, response fields, and semantics do not change.
+
+---
+
+## Root-cause trace and current call sites
+
+### Residual 1: `crypto_instruments` SELECT fan-out
+
+The actual `get_holdings` chain on current `origin/main` (`6e5795e2`) is:
+
+1. `app/mcp_server/tooling/portfolio_holdings.py:1126-1158` builds all crypto positions and runs `_compute_crypto_signals_for_position` once per position via `bounded_gather`.
+2. `app/mcp_server/tooling/portfolio_holdings.py:259-290` calls `_fetch_ohlcv_for_indicators(symbol, "crypto", count=50)` for each position.
+3. `app/mcp_server/tooling/market_data_indicators.py:90-97` dispatches crypto to `_cache_first_crypto`; `app/mcp_server/tooling/market_data_indicators.py:269-312` creates a separate session/repository per symbol, reads candles, and writes fetched rows back on a miss/stale cache.
+4. `app/services/daily_candles/repository.py:427-449` resolves one instrument before every crypto `fetch_recent`.
+5. `app/services/daily_candles/repository.py:192-213` also calls `_resolve_instrument_id` inside the row loop during crypto write-back. The SELECT itself is at `app/services/daily_candles/repository.py:169-190`.
+
+Therefore the root cause is not the indicator math. The lookup boundary only accepts one symbol, so the holdings fan-out cannot share identity resolution and a stale/miss write-back may repeat the same static lookup for every returned candle row.
+
+### Residual 2: KIS `inquire-daily-itemchartprice` fan-out
+
+The actual chain is:
+
+1. `app/mcp_server/tooling/portfolio_holdings.py:619-794` refreshes every KR equity pair; `fetch_equity_price` calls `_fetch_quote_equity_kr` at lines `710-723`.
+2. `app/mcp_server/tooling/market_data_quotes.py:587-617` calls `KISClient.inquire_daily_itemchartprice(..., n=2)` and builds `price`, `previous_close`, OHLC, volume, and value.
+3. `portfolio_holdings.py:715-723` consumes only `quote["price"]`; all other daily-candle enrichment fields are discarded by `get_holdings`.
+4. `app/services/daily_candles/read_service.py:240-303` already provides the required DB-first contract, and `app/services/daily_candles/repository.py:70-92,427-500` contains ROB-812's bounded predicate.
+
+The enrichment is therefore **KR current-price refresh**. It is not R:R, strategy scoring, or a retained previous-close enrichment.
+
+---
+
+## File Structure
+
+- `app/services/daily_candles/repository.py` — add one-query crypto identity resolution plus direct-by-ID recent-read/write-back methods; preserve existing public paths by delegation.
+- `app/mcp_server/tooling/market_data_indicators.py` — accept an optional pre-resolved crypto instrument ID and use the direct-by-ID repository methods.
+- `app/mcp_server/tooling/portfolio_holdings.py` — batch-resolve the holdings crypto universe once; pass IDs to strategy-signal tasks; add KR DB-first price selection before the existing KIS fallback.
+- `tests/services/daily_candles/test_repository_crypto_path.py` — prove multi-symbol identity resolution executes one `crypto_instruments` SELECT and preserves unknown-row behavior.
+- `tests/mcp_server/tooling/test_get_holdings_n1_residuals.py` — regression-lock the actual holdings orchestration, strategy output, DB-hit result equivalence, and KIS fallback.
+- `docs/plans/ROB-830-get-holdings-n1-residuals.md` — this plan and root-cause evidence.
+
+---
+
+### Task 1: Batch crypto instrument identity at the repository boundary
+
+**Files:**
+- Modify: `app/services/daily_candles/repository.py:169-230,427-469`
+- Modify: `tests/services/daily_candles/test_repository_crypto_path.py`
+
+**Interfaces:**
+- Produces: `DailyCandlesRepository.resolve_crypto_instrument_ids(*, symbols: list[str], partition: str) -> dict[str, int]`.
+- Produces: `DailyCandlesRepository.fetch_recent_crypto_by_instrument_id(*, instrument_id: int, symbol: str, partition: str, count: int) -> list[DailyCandleRow]`.
+- Produces: `DailyCandlesRepository.upsert_crypto_rows_by_instrument_id(*, instrument_id: int, rows: list[DailyCandleRow]) -> int`.
+- Preserves: `_resolve_instrument_id`, `fetch_recent`, and `upsert_rows` behavior for every existing caller.
+
+- [ ] **Step 1: Write the failing one-query test**
+
+Append to `tests/services/daily_candles/test_repository_crypto_path.py`. Change the existing SQLAlchemy import to `from sqlalchemy import event, text`, then install the event hook only after fixture rows are flushed so setup INSERTs are not counted.
+
+```python
+@pytest.mark.asyncio
+async def test_resolve_crypto_instrument_ids_batches_symbols_in_one_select(
+    db_session: AsyncSession,
+) -> None:
+    instruments = [
+        CryptoInstrument(
+            venue="upbit",
+            product="spot",
+            venue_symbol=symbol,
+            base_asset=symbol.removeprefix("KRW-"),
+            quote_asset="KRW",
+            status="active",
+        )
+        for symbol in ("KRW-BTC", "KRW-ETH", "KRW-XRP")
+    ]
+    db_session.add_all(instruments)
+    await db_session.flush()
+
+    statements: list[str] = []
+    engine = db_session.get_bind()
+
+    def record_statement(conn, cursor, statement, parameters, context, executemany):
+        if "crypto_instruments" in statement and statement.lstrip().upper().startswith(
+            "SELECT"
+        ):
+            statements.append(statement)
+
+    event.listen(engine, "before_cursor_execute", record_statement)
+    try:
+        resolved = await DailyCandlesRepository(
+            session=db_session
+        ).resolve_crypto_instrument_ids(
+            symbols=["KRW-XRP", "KRW-BTC", "KRW-ETH", "KRW-BTC"],
+            partition="upbit_krw",
+        )
+    finally:
+        event.remove(engine, "before_cursor_execute", record_statement)
+
+    assert resolved == {item.venue_symbol: item.id for item in instruments}
+    assert len(statements) == 1
+    assert " IN " in statements[0].upper()
+```
+
+- [ ] **Step 2: Run the test and verify RED**
+
+Run:
+
+```bash
+uv run pytest tests/services/daily_candles/test_repository_crypto_path.py::test_resolve_crypto_instrument_ids_batches_symbols_in_one_select -v -p no:cacheprovider
+```
+
+Expected: FAIL with `AttributeError: 'DailyCandlesRepository' object has no attribute 'resolve_crypto_instrument_ids'`.
+
+- [ ] **Step 3: Implement the batch resolver**
+
+In `repository.py`, import `bindparam`, centralize the existing partition-to-venue conversion in a pure private helper, and use an expanding bind parameter:
+
+```python
+from sqlalchemy import bindparam, text
+
+
+def _crypto_venue_for_partition(partition: str) -> str:
+    return "upbit" if partition == "upbit_krw" else partition.split("_")[0]
+```
+
+```python
+    async def resolve_crypto_instrument_ids(
+        self, *, symbols: list[str], partition: str
+    ) -> dict[str, int]:
+        normalized = sorted({str(symbol).strip().upper() for symbol in symbols if symbol})
+        if not normalized:
+            return {}
+        sql = text(
+            "SELECT venue_symbol, id FROM crypto_instruments "
+            "WHERE venue = :venue AND product = 'spot' "
+            "AND venue_symbol IN :symbols"
+        ).bindparams(bindparam("symbols", expanding=True))
+        result = await self._session.execute(
+            sql,
+            {
+                "venue": _crypto_venue_for_partition(partition),
+                "symbols": normalized,
+            },
+        )
+        return {str(row.venue_symbol): int(row.id) for row in result}
+```
+
+Change `_resolve_instrument_id` to call `resolve_crypto_instrument_ids` with a one-item list and retain its existing `LookupError` text. This keeps non-holdings callers compatible.
+
+- [ ] **Step 4: Add direct-by-ID read and write methods**
+
+Extract the existing crypto SQL/mapping body from `fetch_recent` into `fetch_recent_crypto_by_instrument_id`. Extract the INSERT body from `_upsert_crypto_rows` into `upsert_crypto_rows_by_instrument_id`. Neither method may query `crypto_instruments`.
+
+```python
+    async def fetch_recent_crypto_by_instrument_id(
+        self,
+        *,
+        instrument_id: int,
+        symbol: str,
+        partition: str,
+        count: int,
+    ) -> list[DailyCandleRow]:
+        sql = text(_CRYPTO_RECENT_SQL)
+        result = await self._session.execute(
+            sql,
+            {
+                "iid": int(instrument_id),
+                "symbol": symbol,
+                "partition": partition,
+                "count": int(count),
+                "time_floor": _recent_time_floor(int(count), now=datetime.now(UTC)),
+            },
+        )
+        out: list[DailyCandleRow] = []
+        for row in result.mappings().all():
+            out.append(
+                DailyCandleRow(
+                    time_utc=row["time"],
+                    symbol=row["symbol"],
+                    partition=row["partition"],
+                    open=float(row["open"]),
+                    high=float(row["high"]),
+                    low=float(row["low"]),
+                    close=float(row["close"]),
+                    adj_close=None,
+                    volume=(
+                        float(row["volume"]) if row["volume"] is not None else 0.0
+                    ),
+                    value=float(row["value"]) if row["value"] is not None else 0.0,
+                    source=row["source"],
+                )
+            )
+        return list(reversed(out))
+```
+
+Add the direct write method with the existing conflict policy unchanged:
+
+```python
+    async def upsert_crypto_rows_by_instrument_id(
+        self, *, instrument_id: int, rows: list[DailyCandleRow]
+    ) -> int:
+        if not rows:
+            return 0
+        payload = [
+            {
+                "instrument_id": int(instrument_id),
+                "time": row.time_utc,
+                "open": row.open,
+                "high": row.high,
+                "low": row.low,
+                "close": row.close,
+                "base_volume": row.volume,
+                "quote_volume": row.value,
+                "is_closed": True,
+                "source": row.source,
+            }
+            for row in rows
+        ]
+        sql = text(
+            """
+            INSERT INTO public.crypto_candles_1d (
+                instrument_id, time, open, high, low, close,
+                base_volume, quote_volume, is_closed, source
+            ) VALUES (
+                :instrument_id, :time, :open, :high, :low, :close,
+                :base_volume, :quote_volume, :is_closed, :source
+            )
+            ON CONFLICT (instrument_id, time) DO UPDATE
+            SET open         = EXCLUDED.open,
+                high         = EXCLUDED.high,
+                low          = EXCLUDED.low,
+                close        = EXCLUDED.close,
+                base_volume  = EXCLUDED.base_volume,
+                quote_volume = EXCLUDED.quote_volume,
+                is_closed    = EXCLUDED.is_closed,
+                source       = EXCLUDED.source,
+                ingested_at  = now()
+            WHERE
+                NOT (public.crypto_candles_1d.is_closed = TRUE
+                     AND EXCLUDED.is_closed = TRUE
+                     AND public.crypto_candles_1d.source = EXCLUDED.source)
+            """
+        )
+        result = cast(
+            "_RowcountResult",
+            cast(object, await self._session.execute(sql, payload)),
+        )
+        return max(int(result.rowcount or 0), 0)
+```
+
+`_upsert_crypto_rows` must resolve all unique `(symbol, partition)` identities before its payload loop, raise the same `LookupError` before INSERT if any identity is missing, and call the direct method for a single-identity list. For multi-identity lists, build one combined payload from the batch mapping and execute the same INSERT statement with executemany parameters.
+
+- [ ] **Step 5: Add an unknown-symbol regression test**
+
+```python
+@pytest.mark.asyncio
+async def test_resolve_crypto_instrument_ids_returns_only_known_symbols(
+    db_session: AsyncSession,
+) -> None:
+    known = CryptoInstrument(
+        venue="upbit",
+        product="spot",
+        venue_symbol="KRW-SOL",
+        base_asset="SOL",
+        quote_asset="KRW",
+        status="active",
+    )
+    db_session.add(known)
+    await db_session.flush()
+
+    resolved = await DailyCandlesRepository(
+        session=db_session
+    ).resolve_crypto_instrument_ids(
+        symbols=["KRW-SOL", "KRW-NOT-SEEDED"],
+        partition="upbit_krw",
+    )
+
+    assert resolved == {"KRW-SOL": known.id}
+```
+
+- [ ] **Step 6: Verify GREEN and repository regressions**
+
+Run:
+
+```bash
+uv run pytest tests/services/daily_candles/test_repository_crypto_path.py -v -p no:cacheprovider
+```
+
+Expected: all tests PASS, including the pre-existing unknown-pair `LookupError`, latest-time, ascending-order, and write-through contracts.
+
+- [ ] **Step 7: Commit Task 1**
+
+```bash
+git add app/services/daily_candles/repository.py tests/services/daily_candles/test_repository_crypto_path.py
+git commit -m "perf(ROB-830): batch crypto instrument identity resolution"
+```
+
+---
+
+### Task 2: Resolve the holdings crypto universe once and preserve strategy output
+
+**Files:**
+- Modify: `app/mcp_server/tooling/market_data_indicators.py:90-97,269-312`
+- Modify: `app/mcp_server/tooling/portfolio_holdings.py:259-290,1126-1158`
+- Create: `tests/mcp_server/tooling/test_get_holdings_n1_residuals.py`
+
+**Interfaces:**
+- Produces: `_resolve_crypto_instrument_ids_for_holdings(positions: list[dict[str, Any]]) -> dict[str, int]` in `portfolio_holdings.py`.
+- Changes: `_compute_crypto_signals_for_position(position, *, instrument_id: int) -> tuple[float | None, VotingResult | None]`.
+- Extends compatibly: `_fetch_ohlcv_for_indicators(..., crypto_instrument_id: int | None = None)` and `_cache_first_crypto(..., instrument_id: int | None = None)`. All non-holdings callers retain the current fallback lookup by omitting the new keyword.
+
+- [ ] **Step 1: Write the failing orchestration test**
+
+Create `tests/mcp_server/tooling/test_get_holdings_n1_residuals.py` with a position builder and this test. Patch only collection, the new resolver, and signal calculation; exercise real `_get_holdings_impl` grouping/output logic.
+
+```python
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.mcp_server.tooling import portfolio_holdings
+
+
+def _crypto_position(symbol: str, profit_rate: float) -> dict[str, object]:
+    price = 100_000.0
+    return {
+        "account": "upbit",
+        "account_name": "Upbit Main",
+        "broker": "upbit",
+        "source": "upbit_api",
+        "instrument_type": "crypto",
+        "market": "crypto",
+        "symbol": symbol,
+        "name": symbol,
+        "quantity": 1.0,
+        "avg_buy_price": price / (1.0 + profit_rate / 100.0),
+        "current_price": price,
+        "evaluation_amount": price,
+        "profit_loss": price - price / (1.0 + profit_rate / 100.0),
+        "profit_rate": profit_rate,
+    }
+
+
+@pytest.mark.asyncio
+async def test_get_holdings_resolves_crypto_instruments_once_and_keeps_signals(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    positions = [
+        _crypto_position("KRW-BTC", -6.0),
+        _crypto_position("KRW-ETH", 10.0),
+    ]
+    collect = AsyncMock(return_value=(positions, [], "crypto", "upbit"))
+    resolve = AsyncMock(return_value={"KRW-BTC": 101, "KRW-ETH": 202})
+
+    async def compute(position, *, instrument_id):
+        assert instrument_id in {101, 202}
+        return (50.0 if position["symbol"] == "KRW-ETH" else 35.0, None)
+
+    monkeypatch.setattr(portfolio_holdings, "_collect_portfolio_positions", collect)
+    monkeypatch.setattr(
+        portfolio_holdings, "_resolve_crypto_instrument_ids_for_holdings", resolve
+    )
+    monkeypatch.setattr(
+        portfolio_holdings, "_compute_crypto_signals_for_position", compute
+    )
+
+    result = await portfolio_holdings._get_holdings_impl(
+        account="upbit", market="crypto", minimum_value=0
+    )
+
+    resolve.assert_awaited_once_with(positions)
+    by_symbol = {
+        row["symbol"]: row for row in result["accounts"][0]["positions"]
+    }
+    assert by_symbol["KRW-BTC"]["strategy_signal"] == {
+        "action": "sell",
+        "reason": "stop_loss",
+        "threshold_pct": -4.5,
+    }
+    assert by_symbol["KRW-ETH"]["strategy_signal"] == {
+        "action": "sell",
+        "reason": "mean_reversion_exit",
+        "rsi_14": 50.0,
+    }
+```
+
+- [ ] **Step 2: Run the test and verify RED**
+
+Run:
+
+```bash
+uv run pytest tests/mcp_server/tooling/test_get_holdings_n1_residuals.py::test_get_holdings_resolves_crypto_instruments_once_and_keeps_signals -v -p no:cacheprovider
+```
+
+Expected: FAIL because `_resolve_crypto_instrument_ids_for_holdings` does not exist and `_compute_crypto_signals_for_position` does not accept `instrument_id`.
+
+- [ ] **Step 3: Add request-scoped batch resolution**
+
+In `portfolio_holdings.py`, use one `AsyncSessionLocal` and one repository call:
+
+```python
+async def _resolve_crypto_instrument_ids_for_holdings(
+    positions: list[dict[str, Any]],
+) -> dict[str, int]:
+    symbols = sorted(
+        {
+            str(position.get("symbol") or "").strip().upper()
+            for position in positions
+            if position.get("instrument_type") == "crypto"
+            and position.get("symbol")
+        }
+    )
+    if not symbols:
+        return {}
+    async with AsyncSessionLocal() as session:
+        repo = DailyCandlesRepository(session=session)
+        return await repo.resolve_crypto_instrument_ids(
+            symbols=symbols,
+            partition="upbit_krw",
+        )
+```
+
+Call it exactly once after `crypto_positions` is built. For a missing mapping, return `(None, None)` from the per-position closure without calling Upbit or issuing a second identity SELECT. This matches the current fail-open output: the holding stays present and has no strategy signal.
+
+- [ ] **Step 4: Thread the resolved ID through the indicator cache path**
+
+Add the optional keyword only at the generic indicator boundary:
+
+```python
+async def _fetch_ohlcv_for_indicators(
+    symbol: str,
+    market_type: str,
+    count: int = 250,
+    *,
+    crypto_instrument_id: int | None = None,
+) -> pd.DataFrame:
+    if market_type == "crypto":
+        return await _cache_first_crypto(
+            symbol=symbol,
+            count=count,
+            instrument_id=crypto_instrument_id,
+        )
+```
+
+When `_cache_first_crypto` receives an ID, it calls `fetch_recent_crypto_by_instrument_id` and `upsert_crypto_rows_by_instrument_id`. When it receives `None`, it retains the current `fetch_recent`/`upsert_rows` path for all other callers.
+
+Change `_compute_crypto_signals_for_position` to require the ID and call:
+
+```python
+df = await _fetch_ohlcv_for_indicators(
+    symbol,
+    "crypto",
+    count=50,
+    crypto_instrument_id=instrument_id,
+)
+```
+
+- [ ] **Step 5: Add a missing-instrument fail-open test**
+
+```python
+@pytest.mark.asyncio
+async def test_get_holdings_missing_crypto_instrument_keeps_position_without_signal(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    positions = [_crypto_position("KRW-NOT-SEEDED", -6.0)]
+    monkeypatch.setattr(
+        portfolio_holdings,
+        "_collect_portfolio_positions",
+        AsyncMock(return_value=(positions, [], "crypto", "upbit")),
+    )
+    monkeypatch.setattr(
+        portfolio_holdings,
+        "_resolve_crypto_instrument_ids_for_holdings",
+        AsyncMock(return_value={}),
+    )
+    compute = AsyncMock()
+    monkeypatch.setattr(
+        portfolio_holdings, "_compute_crypto_signals_for_position", compute
+    )
+
+    result = await portfolio_holdings._get_holdings_impl(
+        account="upbit", market="crypto", minimum_value=0
+    )
+
+    position = result["accounts"][0]["positions"][0]
+    assert position["symbol"] == "KRW-NOT-SEEDED"
+    assert "strategy_signal" not in position
+    compute.assert_not_awaited()
+```
+
+- [ ] **Step 6: Verify GREEN and existing crypto strategy contracts**
+
+Run:
+
+```bash
+uv run pytest tests/mcp_server/tooling/test_get_holdings_n1_residuals.py tests/test_mcp_portfolio_tools.py -k "crypto or strategy_signal or n1_residuals" -v -p no:cacheprovider
+```
+
+Expected: all selected tests PASS; stop-loss, mean-reversion, voting metadata, JSON-native scalar, snapshot-price reuse, and no-signal cases remain unchanged.
+
+- [ ] **Step 7: Commit Task 2**
+
+```bash
+git add app/mcp_server/tooling/market_data_indicators.py app/mcp_server/tooling/portfolio_holdings.py tests/mcp_server/tooling/test_get_holdings_n1_residuals.py
+git commit -m "perf(ROB-830): batch get_holdings crypto instrument lookup"
+```
+
+---
+
+### Task 3: Make KR current-price enrichment DB-first with identical output
+
+**Files:**
+- Modify: `app/mcp_server/tooling/portfolio_holdings.py:619-794`
+- Modify: `tests/mcp_server/tooling/test_get_holdings_n1_residuals.py`
+
+**Interfaces:**
+- Consumes: `cache_first_kr(symbol: str, count: int, end: datetime | None = None) -> DataFrame | None` from `app.services.daily_candles.read_service`.
+- Preserves: `_fetch_price_map_for_positions(...)` tuple shape and all `get_holdings` response fields.
+- Fallback: `_fetch_quote_equity_kr(symbol)` remains the only KIS daily HTTP path and runs only when DB cannot provide a valid close.
+
+- [ ] **Step 1: Write the failing DB-hit and fallback equivalence tests**
+
+Append:
+
+```python
+import pandas as pd
+
+
+def _kr_refresh_position(symbol: str = "005930") -> dict[str, object]:
+    return {
+        "instrument_type": "equity_kr",
+        "symbol": symbol,
+        "source": "manual",
+        "current_price": None,
+        "evaluation_amount": None,
+        "profit_loss": None,
+        "profit_rate": None,
+    }
+
+
+@pytest.mark.asyncio
+async def test_kr_price_enrichment_db_hit_matches_legacy_result_and_skips_kis(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_frame = pd.DataFrame(
+        {
+            "date": pd.date_range("2026-07-09", periods=2, freq="D"),
+            "open": [60_000.0, 61_000.0],
+            "high": [62_000.0, 63_000.0],
+            "low": [59_000.0, 60_000.0],
+            "close": [61_500.0, 62_000.0],
+            "volume": [1_000.0, 1_100.0],
+            "value": [61_500_000.0, 68_200_000.0],
+        }
+    )
+    db_read = AsyncMock(return_value=db_frame)
+    kis_quote = AsyncMock(return_value={"price": 62_000.0})
+    monkeypatch.setattr(portfolio_holdings, "cache_first_kr", db_read)
+    monkeypatch.setattr(portfolio_holdings, "_fetch_quote_equity_kr", kis_quote)
+
+    actual = await portfolio_holdings._fetch_price_map_for_positions(
+        [_kr_refresh_position()]
+    )
+
+    assert actual == (
+        {("equity_kr", "005930"): 62_000.0},
+        [],
+        {},
+    )
+    db_read.assert_awaited_once_with("005930", 2)
+    kis_quote.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "cached",
+    [None, pd.DataFrame(), pd.DataFrame({"close": [None]})],
+)
+async def test_kr_price_enrichment_db_miss_falls_back_to_legacy_kis_result(
+    monkeypatch: pytest.MonkeyPatch,
+    cached: pd.DataFrame | None,
+) -> None:
+    db_read = AsyncMock(return_value=cached)
+    kis_quote = AsyncMock(return_value={"price": 62_000.0})
+    monkeypatch.setattr(portfolio_holdings, "cache_first_kr", db_read)
+    monkeypatch.setattr(portfolio_holdings, "_fetch_quote_equity_kr", kis_quote)
+
+    actual = await portfolio_holdings._fetch_price_map_for_positions(
+        [_kr_refresh_position()]
+    )
+
+    assert actual == ({("equity_kr", "005930"): 62_000.0}, [], {})
+    kis_quote.assert_awaited_once_with("005930")
+```
+
+- [ ] **Step 2: Run the test and verify RED**
+
+Run:
+
+```bash
+uv run pytest tests/mcp_server/tooling/test_get_holdings_n1_residuals.py -k "kr_price_enrichment" -v -p no:cacheprovider
+```
+
+Expected: FAIL because `portfolio_holdings` has no `cache_first_kr` binding and the current path awaits `_fetch_quote_equity_kr` unconditionally. Both the DB-hit contract and every fallback shape fail for that intended reason.
+
+- [ ] **Step 3: Implement DB-first selection with KIS fallback**
+
+Import `cache_first_kr` from `app.services.daily_candles.read_service`. In the KR branch of nested `fetch_equity_price`, accept only a numeric positive final close:
+
+```python
+        if instrument_type == "equity_kr":
+            try:
+                cached = await cache_first_kr(symbol, 2)
+                if cached is not None and not cached.empty and "close" in cached.columns:
+                    cached_price = _to_optional_float(cached["close"].iloc[-1])
+                    if cached_price is not None and cached_price > 0:
+                        return instrument_type, symbol, cached_price, None, "db"
+            except Exception:
+                logger.debug(
+                    "KR daily DB enrichment failed for %s; falling back to KIS",
+                    symbol,
+                    exc_info=True,
+                )
+            try:
+                quote = await _fetch_quote_equity_kr(symbol)
+                price = quote.get("price")
+                return (
+                    instrument_type,
+                    symbol,
+                    float(price) if price is not None else None,
+                    None,
+                    "kis",
+                )
+            except Exception as exc:
+                error_msg = str(exc)
+                logger.debug(
+                    "Failed to fetch equity price for %s: %s", symbol, error_msg
+                )
+                return instrument_type, symbol, None, error_msg, "kis"
+```
+
+The `source="db"` value is internal and never emitted on successful holdings responses. Error source remains `kis`, matching the existing contract.
+
+- [ ] **Step 4: Verify GREEN for DB hit and all fallback shapes**
+
+Run:
+
+```bash
+uv run pytest tests/mcp_server/tooling/test_get_holdings_n1_residuals.py -k "kr_price_enrichment" -v -p no:cacheprovider
+```
+
+Expected: PASS for the DB-hit case and all three parametrized DB-miss/invalid-close cases. The hit case proves KIS is not called; every fallback case proves the legacy KIS price tuple is unchanged.
+
+- [ ] **Step 5: Verify Task 3 and related price-refresh regressions**
+
+Run:
+
+```bash
+uv run pytest tests/mcp_server/tooling/test_get_holdings_n1_residuals.py tests/test_mcp_portfolio_tools.py -k "fetch_price_map or current_price or n1_residuals" -v -p no:cacheprovider
+```
+
+Expected: all selected tests PASS. US KIS-primary/Yahoo-fallback behavior and crypto batched ticker prices remain unchanged.
+
+- [ ] **Step 6: Commit Task 3**
+
+```bash
+git add app/mcp_server/tooling/portfolio_holdings.py tests/mcp_server/tooling/test_get_holdings_n1_residuals.py
+git commit -m "perf(ROB-830): use DB-first KR holdings enrichment"
+```
+
+---
+
+### Task 4: Verify scope, migration-0, and quality gates
+
+**Files:**
+- Verify only: all files changed in Tasks 1-3.
+
+**Interfaces:**
+- Produces: fresh test/lint evidence and a reviewable migration-free diff.
+
+- [ ] **Step 1: Run the focused ROB-830 suite**
+
+```bash
+uv run pytest tests/mcp_server/tooling/test_get_holdings_n1_residuals.py tests/services/daily_candles/test_repository_crypto_path.py -v -p no:cacheprovider
+```
+
+Expected: all tests PASS.
+
+- [ ] **Step 2: Run the related MCP and candle suites**
+
+```bash
+uv run pytest tests/test_mcp_portfolio_tools.py tests/unit/mcp_server/tooling/test_market_data_indicators_cache_first.py tests/test_mcp_indicator_tools.py tests/services/daily_candles -v -m "not live" -p no:cacheprovider
+```
+
+Expected: all selected non-live tests PASS.
+
+- [ ] **Step 3: Run the repository lint gate**
+
+```bash
+make lint
+```
+
+Expected: Ruff check, Ruff format check, and `ty check app/ --error-on-warning` all exit 0.
+
+- [ ] **Step 4: Prove migration-0 and order-path isolation**
+
+```bash
+git diff --name-only origin/main...HEAD
+git diff --stat origin/main...HEAD
+git diff origin/main...HEAD -- alembic app/mcp_server/tooling/order_execution.py app/mcp_server/tooling/orders_kis_variants.py app/mcp_server/tooling/orders_modify_cancel.py
+```
+
+Expected:
+
+- no path under `alembic/`;
+- no order-path diff output;
+- only the plan, three read-path production files, and two test files listed.
+
+- [ ] **Step 5: Re-read the requirements against the diff**
+
+Confirm from code and tests:
+
+- one `IN` SELECT resolves all crypto holding symbols;
+- a resolved ID is reused by both crypto candle read and write-back;
+- missing IDs leave holdings present without a fabricated signal;
+- fresh/sufficient `kr_candles_1d` data skips KIS;
+- DB miss/stale/error invokes KIS and returns the same price tuple;
+- `get_holdings` arguments and response schema are unchanged;
+- no order path, migration, config, or MCP documentation change exists.
+
+- [ ] **Step 6: Commit the plan if it was not committed before execution**
+
+```bash
+git add docs/plans/ROB-830-get-holdings-n1-residuals.md
+git commit -m "docs(ROB-830): plan get_holdings residual N+1 fixes"
+```
+
+---
+
+## PR handoff
+
+After every task is complete and the fresh verification gate is green, use the repository ship workflow to create a PR against `main`. The PR summary must name both measured removals, include the focused test commands and `make lint`, state `migration-0`, and state that order paths are unchanged. Stop after PR creation; do not merge.

--- a/tests/mcp_server/tooling/test_get_holdings_n1_residuals.py
+++ b/tests/mcp_server/tooling/test_get_holdings_n1_residuals.py
@@ -1,0 +1,176 @@
+"""ROB-830 — get_holdings residual N+1 regressions.
+
+The holdings fan-out historically resolved one ``crypto_instruments`` row per
+crypto position and made one ``inquire-daily-itemchartprice`` HTTP call per
+KR equity position. These tests lock the request-scoped batch resolver and
+the DB-first KR enrichment so the N+1s cannot regress silently.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pandas as pd
+import pytest
+
+from app.mcp_server.tooling import portfolio_holdings
+
+
+def _crypto_position(symbol: str, profit_rate: float) -> dict[str, object]:
+    price = 100_000.0
+    return {
+        "account": "upbit",
+        "account_name": "Upbit Main",
+        "broker": "upbit",
+        "source": "upbit_api",
+        "instrument_type": "crypto",
+        "market": "crypto",
+        "symbol": symbol,
+        "name": symbol,
+        "quantity": 1.0,
+        "avg_buy_price": price / (1.0 + profit_rate / 100.0),
+        "current_price": price,
+        "evaluation_amount": price,
+        "profit_loss": price - price / (1.0 + profit_rate / 100.0),
+        "profit_rate": profit_rate,
+    }
+
+
+@pytest.mark.asyncio
+async def test_get_holdings_resolves_crypto_instruments_once_and_keeps_signals(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    positions = [
+        _crypto_position("KRW-BTC", -6.0),
+        _crypto_position("KRW-ETH", 10.0),
+    ]
+    collect = AsyncMock(return_value=(positions, [], "crypto", "upbit"))
+    resolve = AsyncMock(return_value={"KRW-BTC": 101, "KRW-ETH": 202})
+
+    async def compute(position, *, instrument_id):
+        assert instrument_id in {101, 202}
+        return (50.0 if position["symbol"] == "KRW-ETH" else 35.0, None)
+
+    monkeypatch.setattr(portfolio_holdings, "_collect_portfolio_positions", collect)
+    monkeypatch.setattr(
+        portfolio_holdings, "_resolve_crypto_instrument_ids_for_holdings", resolve
+    )
+    monkeypatch.setattr(
+        portfolio_holdings, "_compute_crypto_signals_for_position", compute
+    )
+
+    result = await portfolio_holdings._get_holdings_impl(
+        account="upbit", market="crypto", minimum_value=0
+    )
+
+    resolve.assert_awaited_once_with(positions)
+    by_symbol = {
+        row["symbol"]: row for row in result["accounts"][0]["positions"]
+    }
+    assert by_symbol["KRW-BTC"]["strategy_signal"] == {
+        "action": "sell",
+        "reason": "stop_loss",
+        "threshold_pct": -4.5,
+    }
+    assert by_symbol["KRW-ETH"]["strategy_signal"] == {
+        "action": "sell",
+        "reason": "mean_reversion_exit",
+        "rsi_14": 50.0,
+    }
+
+
+@pytest.mark.asyncio
+async def test_get_holdings_missing_crypto_instrument_keeps_position_without_signal(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    positions = [_crypto_position("KRW-NOT-SEEDED", -6.0)]
+    monkeypatch.setattr(
+        portfolio_holdings,
+        "_collect_portfolio_positions",
+        AsyncMock(return_value=(positions, [], "crypto", "upbit")),
+    )
+    monkeypatch.setattr(
+        portfolio_holdings,
+        "_resolve_crypto_instrument_ids_for_holdings",
+        AsyncMock(return_value={}),
+    )
+    compute = AsyncMock()
+    monkeypatch.setattr(
+        portfolio_holdings, "_compute_crypto_signals_for_position", compute
+    )
+
+    result = await portfolio_holdings._get_holdings_impl(
+        account="upbit", market="crypto", minimum_value=0
+    )
+
+    position = result["accounts"][0]["positions"][0]
+    assert position["symbol"] == "KRW-NOT-SEEDED"
+    assert "strategy_signal" not in position
+    compute.assert_not_awaited()
+
+
+def _kr_refresh_position(symbol: str = "005930") -> dict[str, object]:
+    return {
+        "instrument_type": "equity_kr",
+        "symbol": symbol,
+        "source": "manual",
+        "current_price": None,
+        "evaluation_amount": None,
+        "profit_loss": None,
+        "profit_rate": None,
+    }
+
+
+@pytest.mark.asyncio
+async def test_kr_price_enrichment_db_hit_matches_legacy_result_and_skips_kis(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_frame = pd.DataFrame(
+        {
+            "date": pd.date_range("2026-07-09", periods=2, freq="D"),
+            "open": [60_000.0, 61_000.0],
+            "high": [62_000.0, 63_000.0],
+            "low": [59_000.0, 60_000.0],
+            "close": [61_500.0, 62_000.0],
+            "volume": [1_000.0, 1_100.0],
+            "value": [61_500_000.0, 68_200_000.0],
+        }
+    )
+    db_read = AsyncMock(return_value=db_frame)
+    kis_quote = AsyncMock(return_value={"price": 62_000.0})
+    monkeypatch.setattr(portfolio_holdings, "cache_first_kr", db_read)
+    monkeypatch.setattr(portfolio_holdings, "_fetch_quote_equity_kr", kis_quote)
+
+    actual = await portfolio_holdings._fetch_price_map_for_positions(
+        [_kr_refresh_position()]
+    )
+
+    assert actual == (
+        {("equity_kr", "005930"): 62_000.0},
+        [],
+        {},
+    )
+    db_read.assert_awaited_once_with("005930", 2)
+    kis_quote.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "cached",
+    [None, pd.DataFrame(), pd.DataFrame({"close": [None]})],
+)
+async def test_kr_price_enrichment_db_miss_falls_back_to_legacy_kis_result(
+    monkeypatch: pytest.MonkeyPatch,
+    cached: pd.DataFrame | None,
+) -> None:
+    db_read = AsyncMock(return_value=cached)
+    kis_quote = AsyncMock(return_value={"price": 62_000.0})
+    monkeypatch.setattr(portfolio_holdings, "cache_first_kr", db_read)
+    monkeypatch.setattr(portfolio_holdings, "_fetch_quote_equity_kr", kis_quote)
+
+    actual = await portfolio_holdings._fetch_price_map_for_positions(
+        [_kr_refresh_position()]
+    )
+
+    assert actual == ({("equity_kr", "005930"): 62_000.0}, [], {})
+    kis_quote.assert_awaited_once_with("005930")

--- a/tests/mcp_server/tooling/test_get_holdings_n1_residuals.py
+++ b/tests/mcp_server/tooling/test_get_holdings_n1_residuals.py
@@ -64,9 +64,7 @@ async def test_get_holdings_resolves_crypto_instruments_once_and_keeps_signals(
     )
 
     resolve.assert_awaited_once_with(positions)
-    by_symbol = {
-        row["symbol"]: row for row in result["accounts"][0]["positions"]
-    }
+    by_symbol = {row["symbol"]: row for row in result["accounts"][0]["positions"]}
     assert by_symbol["KRW-BTC"]["strategy_signal"] == {
         "action": "sell",
         "reason": "stop_loss",

--- a/tests/mcp_server/tooling/test_get_holdings_n1_residuals.py
+++ b/tests/mcp_server/tooling/test_get_holdings_n1_residuals.py
@@ -78,9 +78,18 @@ async def test_get_holdings_resolves_crypto_instruments_once_and_keeps_signals(
 
 
 @pytest.mark.asyncio
-async def test_get_holdings_missing_crypto_instrument_keeps_position_without_signal(
+async def test_get_holdings_missing_crypto_instrument_still_gets_stop_loss(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """ROB-830 defect 1 regression.
+
+    Stop-loss is an indicator-independent safety signal (profit_rate only).
+    A position whose crypto instrument id can't be resolved (unseeded
+    symbol) must still get a stop-loss signal — only the RSI/voting
+    *enrichment* is allowed to be skipped, matching the pre-batch behavior
+    where a per-position lookup failure fell back to
+    rsi_14=None/voting_result=None instead of dropping the signal outright.
+    """
     positions = [_crypto_position("KRW-NOT-SEEDED", -6.0)]
     monkeypatch.setattr(
         portfolio_holdings,
@@ -103,7 +112,60 @@ async def test_get_holdings_missing_crypto_instrument_keeps_position_without_sig
 
     position = result["accounts"][0]["positions"][0]
     assert position["symbol"] == "KRW-NOT-SEEDED"
-    assert "strategy_signal" not in position
+    assert position["strategy_signal"] == {
+        "action": "sell",
+        "reason": "stop_loss",
+        "threshold_pct": -4.5,
+    }
+    # Indicator-dependent enrichment (RSI/voting) is still correctly
+    # skipped for the unresolved instrument id — only the RED->GREEN
+    # requirement here is that the indicator-independent signal survives.
+    compute.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_get_holdings_batch_resolver_db_error_fails_open(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """ROB-830 defect 2 regression.
+
+    A batch resolver DB error (e.g. connection drop) must not propagate out
+    of ``_get_holdings_impl`` — the caller expects holdings back even when
+    the crypto instrument-id lookup fails. Indicator-independent signals
+    (stop-loss) must still be computed from the raw positions.
+    """
+    positions = [
+        _crypto_position("KRW-BTC", -6.0),
+        _crypto_position("KRW-ETH", 10.0),
+    ]
+    monkeypatch.setattr(
+        portfolio_holdings,
+        "_collect_portfolio_positions",
+        AsyncMock(return_value=(positions, [], "crypto", "upbit")),
+    )
+    monkeypatch.setattr(
+        portfolio_holdings,
+        "_resolve_crypto_instrument_ids_for_holdings",
+        AsyncMock(side_effect=RuntimeError("db unavailable")),
+    )
+    compute = AsyncMock()
+    monkeypatch.setattr(
+        portfolio_holdings, "_compute_crypto_signals_for_position", compute
+    )
+
+    result = await portfolio_holdings._get_holdings_impl(
+        account="upbit", market="crypto", minimum_value=0
+    )
+
+    by_symbol = {row["symbol"]: row for row in result["accounts"][0]["positions"]}
+    assert by_symbol["KRW-BTC"]["strategy_signal"] == {
+        "action": "sell",
+        "reason": "stop_loss",
+        "threshold_pct": -4.5,
+    }
+    # KRW-ETH is profitable and has no RSI (indicator path skipped), so it
+    # gets no signal — but the call must not have raised.
+    assert "strategy_signal" not in by_symbol["KRW-ETH"]
     compute.assert_not_awaited()
 
 

--- a/tests/services/daily_candles/test_repository_crypto_path.py
+++ b/tests/services/daily_candles/test_repository_crypto_path.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import datetime as dt
 
 import pytest
-from sqlalchemy import text
+from sqlalchemy import event, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.crypto_instruments import CryptoInstrument
@@ -179,3 +179,71 @@ async def test_crypto_fetch_recent_returns_rows_in_ascending_order(
     assert [r.time_utc.day for r in recent] == [18, 19, 20]
     assert all(r.symbol == "KRW-XRP" for r in recent)
     assert all(r.partition == "upbit_krw" for r in recent)
+
+
+@pytest.mark.asyncio
+async def test_resolve_crypto_instrument_ids_batches_symbols_in_one_select(
+    db_session: AsyncSession,
+) -> None:
+    instruments = [
+        CryptoInstrument(
+            venue="upbit",
+            product="spot",
+            venue_symbol=symbol,
+            base_asset=symbol.removeprefix("KRW-"),
+            quote_asset="KRW",
+            status="active",
+        )
+        for symbol in ("KRW-BTC", "KRW-ETH", "KRW-XRP")
+    ]
+    db_session.add_all(instruments)
+    await db_session.flush()
+
+    statements: list[str] = []
+    engine = db_session.get_bind()
+
+    def record_statement(conn, cursor, statement, parameters, context, executemany):
+        if "crypto_instruments" in statement and statement.lstrip().upper().startswith(
+            "SELECT"
+        ):
+            statements.append(statement)
+
+    event.listen(engine, "before_cursor_execute", record_statement)
+    try:
+        resolved = await DailyCandlesRepository(
+            session=db_session
+        ).resolve_crypto_instrument_ids(
+            symbols=["KRW-XRP", "KRW-BTC", "KRW-ETH", "KRW-BTC"],
+            partition="upbit_krw",
+        )
+    finally:
+        event.remove(engine, "before_cursor_execute", record_statement)
+
+    assert resolved == {item.venue_symbol: item.id for item in instruments}
+    assert len(statements) == 1
+    assert " IN " in statements[0].upper()
+
+
+@pytest.mark.asyncio
+async def test_resolve_crypto_instrument_ids_returns_only_known_symbols(
+    db_session: AsyncSession,
+) -> None:
+    known = CryptoInstrument(
+        venue="upbit",
+        product="spot",
+        venue_symbol="KRW-SOL",
+        base_asset="SOL",
+        quote_asset="KRW",
+        status="active",
+    )
+    db_session.add(known)
+    await db_session.flush()
+
+    resolved = await DailyCandlesRepository(
+        session=db_session
+    ).resolve_crypto_instrument_ids(
+        symbols=["KRW-SOL", "KRW-NOT-SEEDED"],
+        partition="upbit_krw",
+    )
+
+    assert resolved == {"KRW-SOL": known.id}

--- a/tests/test_mcp_portfolio_tools.py
+++ b/tests/test_mcp_portfolio_tools.py
@@ -2575,6 +2575,11 @@ async def test_get_holdings_crypto_stop_loss_signal(monkeypatch):
     )
     _patch_runtime_attr(
         monkeypatch,
+        "_resolve_crypto_instrument_ids_for_holdings",
+        AsyncMock(return_value={"KRW-BTC": 101}),
+    )
+    _patch_runtime_attr(
+        monkeypatch,
         "_get_indicators_impl",
         AsyncMock(
             return_value={"symbol": "KRW-BTC", "indicators": {"rsi": {"14": 35.0}}}
@@ -2617,6 +2622,11 @@ async def test_get_holdings_crypto_mean_reversion_signal(monkeypatch):
         monkeypatch,
         "_collect_portfolio_positions",
         AsyncMock(return_value=(mocked_positions, [], "crypto", None)),
+    )
+    _patch_runtime_attr(
+        monkeypatch,
+        "_resolve_crypto_instrument_ids_for_holdings",
+        AsyncMock(return_value={"KRW-BTC": 101}),
     )
     _patch_runtime_attr(
         monkeypatch,
@@ -2780,6 +2790,11 @@ async def test_get_holdings_strategy_signal_reuses_portfolio_snapshot_price(
         "_fetch_ohlcv_for_indicators",
         AsyncMock(return_value=df),
     )
+    _patch_runtime_attr(
+        monkeypatch,
+        "_resolve_crypto_instrument_ids_for_holdings",
+        AsyncMock(return_value={"KRW-BTC": 101}),
+    )
 
     result = await tools["get_holdings"](account="upbit", market="crypto")
     btc_position = result["accounts"][0]["positions"][0]
@@ -2816,6 +2831,11 @@ async def test_get_holdings_crypto_strategy_signal_includes_voting(monkeypatch):
         monkeypatch,
         "_collect_portfolio_positions",
         AsyncMock(return_value=(mocked_positions, [], "crypto", None)),
+    )
+    _patch_runtime_attr(
+        monkeypatch,
+        "_resolve_crypto_instrument_ids_for_holdings",
+        AsyncMock(return_value={"KRW-BTC": 101}),
     )
     _patch_runtime_attr(
         monkeypatch,
@@ -2887,6 +2907,11 @@ async def test_get_holdings_crypto_strategy_signal_native_types(monkeypatch):
         monkeypatch,
         "_collect_portfolio_positions",
         AsyncMock(return_value=(mocked_positions, [], "crypto", None)),
+    )
+    _patch_runtime_attr(
+        monkeypatch,
+        "_resolve_crypto_instrument_ids_for_holdings",
+        AsyncMock(return_value={"KRW-BTC": 101}),
     )
     _patch_runtime_attr(
         monkeypatch,

--- a/tests/unit/services/daily_candles/test_repository.py
+++ b/tests/unit/services/daily_candles/test_repository.py
@@ -62,6 +62,44 @@ class TestUpsertRows:
         session.execute.assert_not_awaited()
 
 
+class TestUpsertCryptoRowsIdentityDedupe:
+    @pytest.mark.asyncio
+    async def test_resolves_instrument_id_once_per_identity_not_per_row(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """ROB-830 defect 3 regression.
+
+        ``identities_by_pair.setdefault(pair, await resolver(...))`` always
+        evaluates the default argument first, so the resolver ran once per
+        *row* even though the dict only ever kept one entry per identity.
+        Three rows sharing one (symbol, partition) identity must resolve
+        exactly once.
+        """
+        session = MagicMock()
+        session.execute = AsyncMock()
+        repo = DailyCandlesRepository(session=session)
+
+        resolve = AsyncMock(return_value=7)
+        upsert_by_id = AsyncMock(return_value=1)
+        monkeypatch.setattr(repo, "_resolve_instrument_id", resolve)
+        monkeypatch.setattr(repo, "upsert_crypto_rows_by_instrument_id", upsert_by_id)
+
+        rows = [
+            _row("KRW-BTC", "upbit_krw", datetime(2026, 5, 12, tzinfo=UTC), 100.0),
+            _row("KRW-BTC", "upbit_krw", datetime(2026, 5, 13, tzinfo=UTC), 101.0),
+            _row("KRW-BTC", "upbit_krw", datetime(2026, 5, 14, tzinfo=UTC), 102.0),
+        ]
+
+        total = await repo.upsert_rows(market=MarketKey.CRYPTO, rows=rows)
+
+        resolve.assert_awaited_once_with(symbol="KRW-BTC", partition="upbit_krw")
+        upsert_by_id.assert_awaited_once()
+        _, kwargs = upsert_by_id.await_args
+        assert kwargs["instrument_id"] == 7
+        assert len(kwargs["rows"]) == 3
+        assert total == 1
+
+
 class TestFetchRange:
     @pytest.mark.asyncio
     async def test_fetch_range_binds_window_and_partition(self):


### PR DESCRIPTION
## Summary

Closes [ROB-830](https://github.com/mgh3326/auto_trader/issues). Removes the two remaining `get_holdings` fan-outs:

1. **Crypto instrument identity fan-out** — one batched `SELECT ... WHERE venue_symbol IN (:symbols)` replaces the per-symbol `crypto_instruments` lookup that fired on every crypto position in `_compute_crypto_signals_for_position` → `_fetch_ohlcv_for_indicators` → `_cache_first_crypto` → `fetch_recent`/`upsert_rows`. Resolved `instrument_id` values are threaded through the existing indicator/cache-first call chain so neither candle reads nor write-back re-query `crypto_instruments`.

2. **KIS `inquire-daily-itemchartprice` fan-out** — the KR price-refresh path now calls the existing ROB-639/ROB-812 `cache_first_kr(symbol, 2)` reader first, falling back to the unchanged KIS quote helper only when the DB reader returns no usable fresh frame.

## Measured removals

- **Crypto N+1**: one `IN` SELECT resolves all holdings crypto symbols; resolved IDs are reused by both candle read and write-back.
- **KR N+1**: fresh/sufficient `kr_candles_1d` data skips KIS; DB miss/stale/error invokes KIS and returns the same price tuple.

## Contracts preserved

- Return schema and values unchanged; only data acquisition changes (per-symbol lookup/live HTTP → batched/DB-first reads).
- Read path only — order, preview, modify, cancel, reconcile, and journal paths unchanged.
- **migration-0**: no Alembic revision, no schema/index/config change.
- Missing crypto instrument rows remain fail-open: the holding stays in the response without a fabricated `strategy_signal`.
- `get_holdings` arguments and response schema unchanged.

## Verification

```
# Focused ROB-830 suite
uv run pytest tests/mcp_server/tooling/test_get_holdings_n1_residuals.py tests/services/daily_candles/test_repository_crypto_path.py -v

# Related MCP and candle suites
uv run pytest tests/test_mcp_portfolio_tools.py tests/unit/mcp_server/tooling/test_market_data_indicators_cache_first.py tests/test_mcp_indicator_tools.py tests/services/daily_candles -v -m "not live"

# Lint gate
make lint
```

All suites pass (140 passed, 5 skipped). Ruff check + format + `ty check` all exit 0.

## Diff scope

```
app/mcp_server/tooling/market_data_indicators.py   |  48 +-
app/mcp_server/tooling/portfolio_holdings.py       | 127 +-
app/services/daily_candles/repository.py           | 169 +-
docs/plans/ROB-830-get-holdings-n1-residuals.md    | 761 +++
tests/mcp_server/tooling/test_get_holdings_n1_residuals.py | 174 +++
tests/services/daily_candles/test_repository_crypto_path.py | 70 +-
tests/test_mcp_portfolio_tools.py                  | 25 +
```

No path under `alembic/`. No order-path diff output.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Improved crypto holdings strategy-signal processing for faster, more consistent results across multiple positions.
  - Positions with unavailable crypto market data are now retained without displaying an inaccurate strategy signal.
  - Equity holding prices can now be loaded from cached data first, with automatic fallback to the existing market-price source when needed.
  - Improved crypto candle data retrieval and updates for more reliable indicator calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->