### PR TITLE
fix(ROB-827): cache VTS tokens by credential scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed (ROB-827 — KIS VTS token cache; migration 0)
+- **VTS OAuth tokens now survive MCP client churn.** Mock KIS clients share a Redis token manager scoped by normalized VTS host and a non-secret SHA-256 appkey fingerprint, so cache and lock keys cannot collide with live KIS or another VTS credential scope.
+- **Slow VTS issuance remains single-flight.** The VTS-only OAuth request timeout is 10 seconds and VTS lock contenders wait 11 seconds, covering the observed 4–6 second issuance latency without changing the live KIS 5-second request timeout, 3-second contender wait, Redis keys, or order paths.
+
 ### Added (ROB-757 — Toss REST fill poller; migration 1)
 - **Default-off TaskIQ poller detects Toss fills without a websocket.** `toss_live.poll_fills_periodic` scans Toss `GET /orders` (read-only), seeds app-direct orders missing from `review.toss_live_order_ledger` as `accepted` rows, then reuses `toss_reconcile_orders_impl(dry_run=False)` to book confirmed fill deltas. Activation gates: `TOSS_FILL_POLL_ENABLED=true` (default `False`), `TOSS_API_ENABLED=true`, valid Toss credentials. The task never places, modifies, or cancels broker orders.
 - **Toss fills write to `review.execution_ledger`.** The reconcile booked branch now upserts Toss fill deltas via `ExecutionLedgerRepository` with `broker='toss'`, `account_mode='live'`, `source='reconciler'`, `venue='toss_kr'`/`'toss_us'`. `filled_qty` stores the newly discovered delta (not broker cumulative); `fill_seq` is derived from `(broker_order_id, previous_cumulative_qty, new_cumulative_qty)` so partial fills create distinct rows. ROB-755 triage reads these with `source='reconciler', broker='toss'`.

--- a/app/services/brokers/kis/base.py
+++ b/app/services/brokers/kis/base.py
@@ -263,6 +263,10 @@ class BaseKISClient:
             client_entered=client_entered,
         )
 
+    def _token_request_timeout(self) -> float:
+        """Return the OAuth token request timeout for this KIS environment."""
+        return 5.0
+
     async def _fetch_token(self) -> tuple[str, int]:
         """Fetch new OAuth2 token from KIS API.
 
@@ -290,7 +294,8 @@ class BaseKISClient:
         breaker = get_kis_circuit_breaker()
         breaker.before_request()  # OUTSIDE the classify try/except (ROB-699 invariant)
         try:
-            cli = await self._ensure_client(timeout=5.0)
+            token_timeout = self._token_request_timeout()
+            cli = await self._ensure_client(timeout=token_timeout)
             r = await cli.post(
                 self._kis_url("/oauth2/token"),
                 data={
@@ -298,7 +303,7 @@ class BaseKISClient:
                     "appkey": self._settings.kis_app_key,
                     "appsecret": self._settings.kis_app_secret,
                 },
-                timeout=5,
+                timeout=token_timeout,
             )
             response = r.json()
             access_token = response["access_token"]

--- a/app/services/brokers/kis/client.py
+++ b/app/services/brokers/kis/client.py
@@ -9,7 +9,7 @@ from pandas import DataFrame
 
 from app.core.async_rate_limiter import get_limiter
 from app.core.config import settings
-from app.services.redis_token_manager import RedisTokenManager
+from app.services.redis_token_manager import get_kis_mock_token_manager
 
 from .account import AccountClient, extract_domestic_cash_summary_from_integrated_margin
 from .base import BaseKISClient
@@ -106,7 +106,10 @@ class KISClient(BaseKISClient):
         self._settings_view = _KISSettingsView(is_mock=is_mock)
         super().__init__()
         if is_mock:
-            self._token_manager = RedisTokenManager("kis_mock")
+            self._token_manager = get_kis_mock_token_manager(
+                base_url=self._settings.kis_base_url,
+                app_key=self._settings.kis_app_key,
+            )
         parent: KISClientProtocol = cast(KISClientProtocol, cast(object, self))
         self._market_data: MarketDataClient = MarketDataClient(parent)
         self._account: AccountClient = AccountClient(parent)
@@ -119,6 +122,11 @@ class KISClient(BaseKISClient):
 
     async def _get_limiter(self, api_key: str, *, rate: int, period: float) -> Any:
         return await get_limiter("kis", api_key, rate=rate, period=period)
+
+    def _token_request_timeout(self) -> float:
+        if self._is_mock_client:
+            return 10.0
+        return super()._token_request_timeout()
 
     @staticmethod
     def _aggregate_intraday_to_hour(df: pd.DataFrame) -> pd.DataFrame:

--- a/app/services/invest_home_readers.py
+++ b/app/services/invest_home_readers.py
@@ -966,14 +966,16 @@ class SafeKISMockClient(BaseKISClient):
 
     def __init__(self) -> None:
         from app.core.config import settings as _settings
-        from app.services.redis_token_manager import RedisTokenManager
+        from app.services.redis_token_manager import get_kis_mock_token_manager
 
         self._mock_settings = _KISMockSettingsProxy(_settings)
         # Call super().__init__() — since _settings property is overridden,
         # _hdr_base will use mock app key/secret automatically.
         super().__init__()
-        # Override token manager to use separate Redis namespace for mock tokens.
-        self._token_manager = RedisTokenManager(namespace="kis_mock")
+        self._token_manager = get_kis_mock_token_manager(
+            base_url=str(self._mock_settings.kis_base_url),
+            app_key=str(self._mock_settings.kis_app_key or ""),
+        )
         self.account = AccountClient(self)
 
     @property
@@ -985,6 +987,9 @@ class SafeKISMockClient(BaseKISClient):
         if not base_url:
             base_url = "https://openapivts.koreainvestment.com:29443"
         return f"{base_url}{path}"
+
+    def _token_request_timeout(self) -> float:
+        return 10.0
 
 
 def _kis_mock_configured() -> bool:

--- a/app/services/redis_token_manager.py
+++ b/app/services/redis_token_manager.py
@@ -1,9 +1,13 @@
 import asyncio
+import hashlib
 import json
 import logging
+import math
 import os
 import time
 from collections.abc import Mapping
+from functools import cache
+from urllib.parse import urlsplit
 
 import redis.asyncio as redis
 
@@ -13,11 +17,17 @@ from app.core.config import settings
 class RedisTokenManager:
     """Redis 기반 토큰 관리 서비스 with 분산 락"""
 
-    def __init__(self, namespace: str = "kis"):
+    def __init__(
+        self,
+        namespace: str = "kis",
+        *,
+        lock_wait_timeout_seconds: float = 3.0,
+    ):
         self.redis_client: redis.Redis | None = None
         self._lock_key = f"{namespace}:token:lock"
         self._token_key = f"{namespace}:access_token"
         self._lock_timeout = 30  # 락 타임아웃 (초)
+        self._lock_wait_timeout_seconds = lock_wait_timeout_seconds
         self._token_expiry_buffer = 60  # 토큰 만료 전 버퍼 (초)
         self._current_lock_value: str | None = None  # 현재 획득한 락 값 저장
         self._local_token: str | None = None
@@ -271,9 +281,15 @@ class RedisTokenManager:
                 logging.info("대기 중 다른 프로세스가 KIS 토큰 발급 완료")
                 return existing_token
 
-            # 여전히 토큰이 없으면 락 대기 (더 긴 대기)
-            for i in range(30):  # 3초 대기 (0.1초 * 30)
-                await asyncio.sleep(0.1)
+            # 여전히 토큰이 없으면 락 대기. Live는 기존 3초를 유지하고,
+            # 느린 VTS 발급은 해당 manager에 더 긴 budget을 설정한다.
+            poll_interval_seconds = 0.1
+            poll_attempts = max(
+                1,
+                math.ceil(self._lock_wait_timeout_seconds / poll_interval_seconds),
+            )
+            for i in range(poll_attempts):
+                await asyncio.sleep(poll_interval_seconds)
                 existing_token = await self.get_token(force_redis_check=True)
                 if existing_token:
                     logging.info("대기 중 KIS 토큰 발견")
@@ -321,6 +337,28 @@ class RedisTokenManager:
         if self.redis_client:
             await self.redis_client.close()
             self.redis_client = None
+
+
+def _kis_mock_token_namespace(*, base_url: str, app_key: str) -> str:
+    """Build a non-secret Redis namespace for one VTS credential scope."""
+    host = urlsplit(base_url.rstrip("/")).netloc.lower()
+    if not host:
+        raise ValueError("KIS mock base URL must include a host")
+    app_key_fingerprint = hashlib.sha256(app_key.encode()).hexdigest()[:16]
+    return f"kis_mock:{host}:{app_key_fingerprint}"
+
+
+@cache
+def _get_kis_mock_token_manager(namespace: str) -> RedisTokenManager:
+    # VTS OAuth calls commonly take 4-6 seconds and may use the full 10-second
+    # request budget. Waiters must outlive the lock owner's request.
+    return RedisTokenManager(namespace=namespace, lock_wait_timeout_seconds=11.0)
+
+
+def get_kis_mock_token_manager(*, base_url: str, app_key: str) -> RedisTokenManager:
+    """Return the process-shared VTS manager for a normalized host/appkey pair."""
+    namespace = _kis_mock_token_namespace(base_url=base_url, app_key=app_key)
+    return _get_kis_mock_token_manager(namespace)
 
 
 # 전역 인스턴스

--- a/docs/plans/ROB-827-vts-token-cache.md
+++ b/docs/plans/ROB-827-vts-token-cache.md
@@ -1,0 +1,282 @@
+# ROB-827 VTS Token Cache Implementation Plan
+
+> **For agentic workers:** Execute this plan inline with strict red-green-refactor TDD. Every production change requires a test that was observed failing for the intended reason first.
+
+**Goal:** Make KIS VTS token acquisition complete once, persist in Redis, and remain single-flight across MCP-created clients, while isolating cache and lock keys by VTS host and appkey without changing live KIS token behavior or any order request path.
+
+**Architecture:** Keep `BaseKISClient._ensure_token()` as the only token-ensure seam and keep `RedisTokenManager` as the cache/lock implementation. Mock clients receive a process-shared `RedisTokenManager` selected by a non-secret namespace derived from the normalized VTS host plus a SHA-256 appkey fingerprint. The VTS token POST alone gets a 10-second timeout so the observed 4-6 second issuance can finish and be cached, and VTS lock contenders wait 11 seconds so they can observe that result instead of failing at the legacy 3-second live budget. Live keeps its existing singleton, Redis keys, 5-second request timeout, and 3-second lock-wait budget.
+
+**Tech Stack:** Python 3.13, asyncio, httpx, Redis, pytest/pytest-asyncio, Ruff, ty.
+
+## Global Constraints
+
+- Work only in `/Users/mgh3326/work/auto_trader.rob-827`; do not modify canonical `/Users/mgh3326/work/auto_trader`.
+- Write and observe failing tests before production changes.
+- Preserve the live `redis_token_manager` singleton and its keys (`kis:access_token`, `kis:token:lock`).
+- Never place the raw appkey or appsecret in a Redis key, log, assertion failure, or PR text.
+- Namespace VTS cache and lock keys by both normalized host and appkey fingerprint.
+- Keep order dispatch, order TR IDs, order payloads, and order endpoint timeouts unchanged.
+- No schema or data migration (`migration-0`).
+- KIS token issuance is rate-limited, so both Redis reuse and single-flight are correctness protections as well as latency optimizations.
+
+---
+
+## Root Cause Confirmation
+
+### MCP-to-token call path
+
+1. `get_available_capital_impl()` delegates to `get_cash_balance_impl()` at `app/mcp_server/tooling/portfolio_cash.py:347-364`.
+2. The KIS cash branch creates a fresh client for every tool call at `app/mcp_server/tooling/portfolio_cash.py:39-42` and `:206-219`; mock mode constructs `KISClient(is_mock=True)`.
+3. `get_holdings` follows the same pattern at `app/mcp_server/tooling/portfolio_holdings.py:293-304`, then runs KR and US balance reads at `:305-345`.
+4. Account reads call `_ensure_token()` before the broker request (`app/services/brokers/kis/account.py:221`, `:386`, and `:531`).
+5. `_ensure_token()` checks Redis and delegates a miss to `refresh_token_with_lock()` at `app/services/brokers/kis/base.py:316-334`.
+6. `refresh_token_with_lock()` performs cache rechecks, obtains the Redis lock, rechecks under the lock, fetches once, and saves the result at `app/services/redis_token_manager.py:243-307`.
+
+### Confirmed defect
+
+The mock path is not completely outside Redis, but its current integration is incomplete:
+
+- Every `KISClient(is_mock=True)` constructs a new manager at `app/services/brokers/kis/client.py:104-110`, discarding the manager's process-local token cache and local coordination on every MCP tool call.
+- Every VTS deployment/appkey uses the same `kis_mock:access_token` and `kis_mock:token:lock` keys because `RedisTokenManager.__init__()` only interpolates the literal namespace at `app/services/redis_token_manager.py:16-20`. This violates the required host/appkey boundary and permits stale or cross-credential tokens to trigger invalid-token clearing/reissuance.
+- The direct OAuth POST uses a hard-coded 5-second timeout at `app/services/brokers/kis/base.py:293-302`. Sentry trace `fd0bfb06bd084dac83573efec7ad225b` showed: Redis miss, lock acquired, VTS POST lasting 6.675 seconds, lock released without a save, then the same `get_holdings` call repeated the miss and made another 5.048-second VTS POST. Because both token attempts fail before `save_token()` (`app/services/redis_token_manager.py:294-300`), later tools correctly see another miss and reissue.
+- Pre-implementation review exposed a second timing defect at `app/services/redis_token_manager.py:278-287`: a contender waited only about 3 seconds for the lock owner. Once the VTS request budget became 10 seconds, a realistic 4-6 second issuance would succeed for the owner but still raise `RuntimeError` for the waiter. A separate-manager/shared-Redis test reproduced this with a 3.4-second POST before the wait-budget fix.
+- The positive control is Sentry trace `daef06d001e144c0a98be16908ec3965`: a 395ms VTS token POST succeeded, and the immediately following `get_holdings` trace had no token POST. This proves the existing Redis hit path works after a successful save and isolates the repeated issuance to cold-miss completion plus inadequate namespace ownership.
+
+**Root cause hypothesis verified:** VTS issuance frequently exceeds the live-oriented 5-second token timeout, so no token reaches Redis; fresh per-tool mock managers then retry the cold path. The only mock Redis keys are global literals rather than host/appkey-scoped keys, so the existing integration also cannot safely own a cached VTS token across credential rotations or parallel deployments.
+
+## Considered Approaches
+
+### A. Credential-scoped shared VTS manager plus VTS-only token timeout (selected)
+
+- Derive the manager namespace from `urlsplit(base_url).netloc.lower()` and the first 16 hex characters of `sha256(app_key)`.
+- Cache one manager per derived namespace in the process; Redis remains the cross-process source of truth and distributed lock.
+- Use 10 seconds only for mock OAuth issuance; live remains 5 seconds.
+- Give only VTS managers an 11-second contender wait; the live manager retains the existing 3-second default.
+- Covers the observed failure, the requested Redis/single-flight behavior, and host/appkey isolation with a narrow diff.
+
+### B. Change only `kis_mock` to a host/appkey-derived namespace
+
+- Fixes unsafe key collision.
+- Does not let the observed 4-6 second cold issuance finish, so the repeated miss pattern remains.
+
+### C. Add a cache in each MCP tool handler
+
+- Duplicates token ownership across `get_holdings`, `get_cash_balance`, `get_available_capital`, home readers, and order helpers.
+- Bypasses the existing Redis lock and increases the chance of live/mock routing drift.
+
+## File Structure
+
+| File | Change | Responsibility |
+|---|---|---|
+| `CHANGELOG.md` | Modify | Record the ROB-827 migration-0 operator-visible behavior change. |
+| `docs/plans/ROB-827-vts-token-cache.md` | Create | Root-cause record, design, TDD plan, and verification checklist. |
+| `tests/test_kis_vts_token_cache.py` | Create | Cache-hit, expiry refresh, single-flight, host/appkey key isolation, and live-timeout invariants. |
+| `app/services/redis_token_manager.py` | Modify | Build a non-secret VTS namespace, return one process-shared manager per host/appkey scope, and configure its contender wait beyond the VTS request budget. Existing live singleton and defaults stay untouched. |
+| `app/services/brokers/kis/client.py` | Modify | Route `KISClient(is_mock=True)` through the scoped manager factory and select the VTS-only OAuth timeout. |
+| `app/services/invest_home_readers.py` | Modify | Give `SafeKISMockClient` the same scoped manager and VTS-only OAuth timeout, preventing a second mock token ownership scheme. |
+| `app/services/brokers/kis/base.py` | Modify | Replace the two literal token timeout values with `_token_request_timeout()`; default remains 5 seconds. |
+
+No MCP request/response contract changes, so `app/mcp_server/README.md` does not require an interface update.
+
+---
+
+### Task 1: Lock the VTS cache contract with failing tests
+
+**Files:**
+- Create: `tests/test_kis_vts_token_cache.py`
+- Read only: `app/services/redis_token_manager.py:13-29,131-307`
+- Read only: `app/services/brokers/kis/base.py:266-334`
+- Read only: `app/services/brokers/kis/client.py:43-120`
+
+**Interfaces tested:**
+- Existing `KISClient(*, is_mock: bool = False)` constructor.
+- Existing `BaseKISClient._ensure_token() -> None` and `_fetch_token() -> tuple[str, int]`.
+- Redis protocol used by `RedisTokenManager`: async `get`, `set`, `delete`, and `execute_command`.
+
+- [x] **Step 1: Create a stateful fake Redis at the same abstraction as production Redis.**
+
+  Implement `_FakeRedis` with a `values: dict[str, str]`, atomic `set(..., nx=True)`, `get`, `delete`, and the lock-release `execute_command("EVAL", ...)` behavior. It must preserve the cache/lock side effects the tests depend on rather than mocking `get_token()` or `refresh_token_with_lock()`.
+
+- [x] **Step 2: Add a cache-hit test that proves token POST count is zero.**
+
+  Configure a unique mock host/appkey, construct `KISClient(is_mock=True)`, assert its token key equals `kis_mock:{host}:{sha256(appkey)[:16]}:access_token`, preload valid token JSON at that key, attach `_FakeRedis`, and call `await client._ensure_token()`. Assert the mock HTTP client and its `post` method were never awaited and `settings.kis_mock_access_token` equals the cached token.
+
+- [x] **Step 3: Add an expiry test that proves exactly one reissue and Redis replacement.**
+
+  Preload expired JSON at the expected scoped key, return `{"access_token": "fresh-vts-token", "expires_in": 7200}` from the fake HTTP response, call `_ensure_token()`, and assert one POST to `https://{mock-host}/oauth2/token`, one new token stored at the scoped key, and no write to `kis_mock:access_token`.
+
+- [x] **Step 4: Add the live/mock and host/appkey separation test.**
+
+  Construct live, mock-A, mock-B (same host, different appkey), and mock-C (different host, same appkey) clients. Assert the live key remains exactly `kis:access_token`; all mock keys differ from live and from each other; raw appkeys are absent from all keys. Also assert two clients with identical mock host/appkey reuse the same manager object.
+
+- [x] **Step 5: Add a concurrent single-flight test.**
+
+  Give two same-scope mock clients the same `_FakeRedis`, concurrently call both `_ensure_token()` methods, and assert the combined OAuth POST count is one and both clients receive the same token. This exercises the real Redis lock/cache code rather than asserting only on a mocked manager.
+
+- [x] **Step 6: Add timeout invariants.**
+
+  Call `_fetch_token()` on a mock and a live client with fake HTTP. Assert mock `_ensure_client` and `post` receive `10.0`, while live receives `5.0`. Do not invoke any order method.
+
+- [x] **Step 7: Run RED and inspect the failure reason.**
+
+  Run:
+
+  ```bash
+  uv run pytest tests/test_kis_vts_token_cache.py -v
+  ```
+
+  Expected current-code failures:
+
+  - mock key is `kis_mock:access_token`, not host/appkey-scoped;
+  - identical mock clients own different manager objects;
+  - mock token POST timeout is 5 seconds, not 10 seconds.
+
+  Existing cache-hit/expiry mechanics may reach later assertions only after the namespace assertion is satisfied. Collection errors, real network calls, or failures unrelated to these missing behaviors do not count as RED and must be corrected before implementation.
+
+### Task 2: Add host/appkey-scoped VTS Redis manager ownership
+
+**Files:**
+- Modify: `app/services/redis_token_manager.py:1-29,326-327`
+- Modify: `app/services/brokers/kis/client.py:10-12,104-110`
+- Modify: `app/services/invest_home_readers.py:960-977`
+- Test: `tests/test_kis_vts_token_cache.py`
+
+**Interfaces produced:**
+- `get_kis_mock_token_manager(*, base_url: str, app_key: str) -> RedisTokenManager`.
+- Redis namespace `kis_mock:{normalized_netloc}:{sha256(app_key)[:16]}`; `RedisTokenManager` appends `:access_token` and `:token:lock` exactly as today.
+
+- [x] **Step 1: Implement deterministic non-secret namespace construction.**
+
+  In `redis_token_manager.py`, use `urllib.parse.urlsplit` to normalize the lower-case network location and `hashlib.sha256` to fingerprint the appkey. Preserve construction-only test compatibility by hashing an empty appkey too; existing MCP config validation remains responsible for blocking a network call with missing credentials. Reject only an empty normalized host. Preserve the module-level live `redis_token_manager = RedisTokenManager()` and all of its defaults.
+
+- [x] **Step 2: Implement a process-shared mock manager factory.**
+
+  Cache `RedisTokenManager` instances by the derived namespace using `functools.cache`. Same host/appkey returns the same object/local cache; different scopes get different Redis cache and lock keys. The raw appkey must not appear in the cache key or logs.
+
+- [x] **Step 3: Wire both mock clients to the factory.**
+
+  Replace `RedisTokenManager("kis_mock")` in `KISClient.__init__()` and `SafeKISMockClient.__init__()` with `get_kis_mock_token_manager(base_url=..., app_key=...)`. Live construction must continue to inherit the unchanged global `redis_token_manager` from `BaseKISClient.__init__()`.
+
+- [x] **Step 4: Run the focused tests.**
+
+  ```bash
+  uv run pytest tests/test_kis_vts_token_cache.py tests/test_kis_mock_routing.py tests/test_redis_token_manager.py -v
+  ```
+
+  Expected: namespace, shared-manager, cache-hit, expiry, and concurrency tests pass; timeout test remains RED until Task 3.
+
+### Task 3: Let slow VTS token issuance finish without changing live
+
+**Files:**
+- Modify: `app/services/brokers/kis/base.py:266-302`
+- Modify: `app/services/brokers/kis/client.py:104-120`
+- Modify: `app/services/invest_home_readers.py:960-987`
+- Test: `tests/test_kis_vts_token_cache.py`
+
+**Interfaces produced:**
+- `BaseKISClient._token_request_timeout() -> float`, default `5.0`.
+- Mock overrides return `10.0`; no public API changes.
+
+- [x] **Step 1: Extract the existing live timeout behind a protected method.**
+
+  Add `_token_request_timeout()` to `BaseKISClient` returning `5.0`. In `_fetch_token()`, compute it once and pass it to both `_ensure_client(timeout=...)` and `cli.post(..., timeout=...)`. No retry, payload, breaker, or response parsing code changes.
+
+- [x] **Step 2: Override only mock clients.**
+
+  `KISClient._token_request_timeout()` returns `10.0` when `_is_mock_client` is true and delegates to `super()` otherwise. `SafeKISMockClient._token_request_timeout()` returns `10.0`. The data/order request timeouts in account and order clients remain untouched.
+
+- [x] **Step 3: Extend only the VTS lock-contender budget.**
+
+  Add a configurable wait budget to `RedisTokenManager` with the existing 3-second behavior as its default. Configure host/appkey-scoped VTS managers with 11 seconds so a contender outlives the 10-second VTS request. Prove it with two distinct managers sharing fake Redis and a 3.4-second token POST: both calls complete and the combined POST count is one. Live remains at 3 seconds.
+
+- [x] **Step 4: Run GREEN.**
+
+  ```bash
+  uv run pytest tests/test_kis_vts_token_cache.py tests/test_kis_mock_routing.py tests/test_redis_token_manager.py tests/test_kis_token_circuit_breaker.py tests/test_kis_token_circuit_open_propagation.py -v
+  ```
+
+  Expected: all selected tests pass, including live 5-second and VTS 10-second assertions.
+
+### Task 4: Verify relevant suites, lint, and scope
+
+**Files:**
+- Verify only; production edits are complete.
+
+- [x] **Step 1: Run KIS and MCP account-read regression suites.**
+
+  ```bash
+  uv run pytest \
+    tests/test_kis_vts_token_cache.py \
+    tests/test_kis_mock_routing.py \
+    tests/test_kis_settings_view_isolation.py \
+    tests/test_redis_token_manager.py \
+    tests/test_kis_token_circuit_breaker.py \
+    tests/test_kis_token_circuit_open_propagation.py \
+    tests/test_mcp_available_capital.py \
+    tests/test_mcp_portfolio_tools.py \
+    tests/test_mcp_account_modes.py \
+    -v
+  ```
+
+- [x] **Step 2: Run the complete unit suite.**
+
+  ```bash
+  make test-unit
+  ```
+
+- [x] **Step 3: Run lint and type checks through the project gate.**
+
+  ```bash
+  make lint
+  ```
+
+- [x] **Step 4: Confirm migration and order-path boundaries.**
+
+  ```bash
+  git diff --name-only origin/main...HEAD
+  git diff origin/main...HEAD -- alembic app/services/brokers/kis/domestic_orders.py app/services/brokers/kis/overseas_orders.py
+  ```
+
+  Expected: no Alembic files and no order-client changes.
+
+- [x] **Step 5: Review the final diff against every global constraint.**
+
+  Confirm cached hit = zero POST, expired entry = one POST then Redis replacement, concurrent cold starts = one POST, same VTS scope = one manager, different host/appkey = different cache+lock keys, live keys/timeouts unchanged, and no credential values in source/test output.
+
+### Task 5: Commit, push, and create the PR without merging
+
+**Files:**
+- Stage only the plan, focused tests, and token-management implementation files.
+
+- [x] **Step 1: Commit one coherent fix after fresh verification.**
+
+  ```bash
+  git add \
+    CHANGELOG.md \
+    docs/plans/ROB-827-vts-token-cache.md \
+    tests/test_kis_vts_token_cache.py \
+    app/services/redis_token_manager.py \
+    app/services/brokers/kis/base.py \
+    app/services/brokers/kis/client.py \
+    app/services/invest_home_readers.py
+  git commit -m "fix(ROB-827): cache VTS tokens by credential scope"
+  ```
+
+- [x] **Step 2: Push `rob-827` and create a PR targeting `main`.**
+
+  The PR body must include:
+
+  - root cause: VTS 5-second OAuth timeout prevented Redis save, plus literal `kis_mock` namespace and per-client manager ownership;
+  - fix: host/appkey-hashed Redis cache+lock namespace, shared manager, VTS-only 10-second token timeout and 11-second contender wait;
+  - proof: exact RED output, focused GREEN counts, complete unit-suite result, and `make lint` result;
+  - safety: live token keys/5-second timeout unchanged, order files unchanged, migration-0;
+  - `ROB-827` reference.
+
+  Do not merge the PR.
+
+## Self-Review
+
+- Spec coverage: cache-hit zero POST, expiry reissue, live/mock key separation, host/appkey separation, single-flight, rate-limit rationale, live/order immutability, migration-0, full relevant tests, lint, and PR-only delivery are each mapped to explicit steps.
+- Placeholder scan: no implementation placeholders remain.
+- Type consistency: the manager factory returns the existing `RedisTokenManager`; `_ensure_token()` and `_fetch_token()` signatures stay unchanged; the new timeout seam returns `float` in base and both mock clients.
+- Scope: one token-management subsystem, two existing mock client adapters, one focused test module, and this plan. No MCP schema, database, or order execution change.

--- a/tests/test_kis_vts_token_cache.py
+++ b/tests/test_kis_vts_token_cache.py
@@ -1,0 +1,314 @@
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import time
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.core.config import settings
+from app.services.brokers.kis.client import KISClient
+
+pytestmark = pytest.mark.unit
+
+
+class _FakeRedis:
+    """Minimal stateful Redis double for token cache and lock behavior."""
+
+    def __init__(self) -> None:
+        self.values: dict[str, str] = {}
+
+    async def get(self, key: str) -> str | None:
+        return self.values.get(key)
+
+    async def set(
+        self,
+        key: str,
+        value: str,
+        *,
+        nx: bool = False,
+        ex: int | None = None,
+    ) -> bool:
+        del ex
+        if nx and key in self.values:
+            return False
+        self.values[key] = value
+        return True
+
+    async def delete(self, key: str) -> int:
+        return int(self.values.pop(key, None) is not None)
+
+    async def execute_command(self, *args: Any) -> int:
+        command, _script, key_count, key, lock_value = args
+        assert command == "EVAL"
+        assert key_count == 1
+        if self.values.get(key) != lock_value:
+            return 0
+        del self.values[key]
+        return 1
+
+
+def _expected_mock_namespace(base_url: str, app_key: str) -> str:
+    host = base_url.removeprefix("https://").removeprefix("http://").rstrip("/")
+    fingerprint = hashlib.sha256(app_key.encode()).hexdigest()[:16]
+    return f"kis_mock:{host.lower()}:{fingerprint}"
+
+
+def _set_mock_credentials(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    base_url: str,
+    app_key: str,
+) -> None:
+    monkeypatch.setattr(settings, "kis_mock_base_url", base_url)
+    monkeypatch.setattr(settings, "kis_mock_app_key", app_key)
+    monkeypatch.setattr(settings, "kis_mock_app_secret", "test-vts-secret")
+    monkeypatch.setattr(settings, "kis_mock_access_token", None)
+
+
+def _token_response(token: str, *, expires_in: int = 7200) -> MagicMock:
+    response = MagicMock()
+    response.json.return_value = {
+        "access_token": token,
+        "expires_in": expires_in,
+    }
+    return response
+
+
+@pytest.mark.asyncio
+async def test_vts_cache_hit_skips_token_post(monkeypatch: pytest.MonkeyPatch) -> None:
+    base_url = "https://vts-cache-hit.example:29443"
+    app_key = "vts-cache-hit-app-key"
+    _set_mock_credentials(monkeypatch, base_url=base_url, app_key=app_key)
+
+    client = KISClient(is_mock=True)
+    expected_namespace = _expected_mock_namespace(base_url, app_key)
+    expected_key = f"{expected_namespace}:access_token"
+    assert client._token_manager._token_key == expected_key
+
+    fake_redis = _FakeRedis()
+    fake_redis.values[expected_key] = json.dumps(
+        {
+            "access_token": "cached-vts-token",
+            "expires_at": time.time() + 7200,
+            "created_at": time.time(),
+        }
+    )
+    client._token_manager.redis_client = fake_redis  # type: ignore[assignment]
+    http_client = AsyncMock()
+    ensure_client = AsyncMock(return_value=http_client)
+    monkeypatch.setattr(client, "_ensure_client", ensure_client)
+
+    await client._ensure_token()
+
+    assert settings.kis_mock_access_token == "cached-vts-token"
+    ensure_client.assert_not_awaited()
+    http_client.post.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_expired_vts_token_reissues_once_and_replaces_scoped_cache(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    base_url = "https://vts-expired.example:29443"
+    app_key = "vts-expired-app-key"
+    _set_mock_credentials(monkeypatch, base_url=base_url, app_key=app_key)
+
+    client = KISClient(is_mock=True)
+    expected_namespace = _expected_mock_namespace(base_url, app_key)
+    expected_key = f"{expected_namespace}:access_token"
+    assert client._token_manager._token_key == expected_key
+
+    fake_redis = _FakeRedis()
+    fake_redis.values[expected_key] = json.dumps(
+        {
+            "access_token": "expired-vts-token",
+            "expires_at": time.time() - 1,
+            "created_at": time.time() - 7200,
+        }
+    )
+    client._token_manager.redis_client = fake_redis  # type: ignore[assignment]
+    http_client = AsyncMock()
+    http_client.post.return_value = _token_response("fresh-vts-token")
+    monkeypatch.setattr(
+        client,
+        "_ensure_client",
+        AsyncMock(return_value=http_client),
+    )
+
+    await client._ensure_token()
+
+    http_client.post.assert_awaited_once()
+    assert http_client.post.await_args.args[0] == f"{base_url}/oauth2/token"
+    assert json.loads(fake_redis.values[expected_key])["access_token"] == (
+        "fresh-vts-token"
+    )
+    assert "kis_mock:access_token" not in fake_redis.values
+
+
+def test_vts_manager_is_shared_and_keys_are_scoped_by_host_and_appkey(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from app.services.invest_home_readers import SafeKISMockClient
+    from app.services.redis_token_manager import redis_token_manager
+
+    live = KISClient()
+
+    host_a = "https://vts-scope-a.example:29443"
+    app_key_a = "vts-scope-app-key-a"
+    _set_mock_credentials(monkeypatch, base_url=host_a, app_key=app_key_a)
+    mock_a = KISClient(is_mock=True)
+    mock_a_again = KISClient(is_mock=True)
+    safe_mock_a = SafeKISMockClient()
+    _set_mock_credentials(
+        monkeypatch,
+        base_url=f"{host_a}/",
+        app_key=app_key_a,
+    )
+    mock_a_trailing_slash = KISClient(is_mock=True)
+
+    app_key_b = "vts-scope-app-key-b"
+    _set_mock_credentials(monkeypatch, base_url=host_a, app_key=app_key_b)
+    mock_b = KISClient(is_mock=True)
+
+    host_c = "https://vts-scope-c.example:29443"
+    _set_mock_credentials(monkeypatch, base_url=host_c, app_key=app_key_a)
+    mock_c = KISClient(is_mock=True)
+
+    assert live._token_manager._token_key == "kis:access_token"
+    assert live._token_manager._lock_key == "kis:token:lock"
+    assert live._token_manager is redis_token_manager
+    assert live._token_manager._lock_wait_timeout_seconds == 3.0
+    assert mock_a._token_manager is mock_a_again._token_manager
+    assert mock_a._token_manager is safe_mock_a._token_manager
+    assert mock_a._token_manager is mock_a_trailing_slash._token_manager
+    assert mock_a._token_manager._lock_wait_timeout_seconds == 11.0
+    assert safe_mock_a._token_request_timeout() == 10.0
+
+    token_keys = {
+        live._token_manager._token_key,
+        mock_a._token_manager._token_key,
+        mock_b._token_manager._token_key,
+        mock_c._token_manager._token_key,
+    }
+    lock_keys = {
+        live._token_manager._lock_key,
+        mock_a._token_manager._lock_key,
+        mock_b._token_manager._lock_key,
+        mock_c._token_manager._lock_key,
+    }
+    assert len(token_keys) == 4
+    assert len(lock_keys) == 4
+    assert all(app_key_a not in key and app_key_b not in key for key in token_keys)
+    assert all(app_key_a not in key and app_key_b not in key for key in lock_keys)
+
+
+def test_vts_namespace_normalizes_host_without_exposing_empty_appkey() -> None:
+    from app.services.redis_token_manager import _kis_mock_token_namespace
+
+    expected_empty_fingerprint = hashlib.sha256(b"").hexdigest()[:16]
+
+    assert (
+        _kis_mock_token_namespace(
+            base_url="HTTPS://VTS-NAMESPACE.EXAMPLE:29443/oauth2/token?ignored=yes",
+            app_key="",
+        )
+        == f"kis_mock:vts-namespace.example:29443:{expected_empty_fingerprint}"
+    )
+    with pytest.raises(ValueError, match="must include a host"):
+        _kis_mock_token_namespace(base_url="not-a-url", app_key="test")
+
+
+@pytest.mark.asyncio
+async def test_same_scope_vts_cold_start_is_single_flight(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    base_url = "https://vts-single-flight.example:29443"
+    app_key = "vts-single-flight-app-key"
+    _set_mock_credentials(monkeypatch, base_url=base_url, app_key=app_key)
+    first = KISClient(is_mock=True)
+
+    # Model a second worker process: it has a different manager instance but
+    # shares the same Redis namespace and backing Redis service.
+    from app.services.redis_token_manager import _get_kis_mock_token_manager
+
+    _get_kis_mock_token_manager.cache_clear()
+    second = KISClient(is_mock=True)
+    assert first._token_manager is not second._token_manager
+    assert first._token_manager._token_key == second._token_manager._token_key
+
+    fake_redis = _FakeRedis()
+    first._token_manager.redis_client = fake_redis  # type: ignore[assignment]
+    second._token_manager.redis_client = fake_redis  # type: ignore[assignment]
+
+    fetch_started = asyncio.Event()
+
+    async def slow_vts_token_post(*args: Any, **kwargs: Any) -> MagicMock:
+        del args, kwargs
+        fetch_started.set()
+        # Longer than the legacy distributed-lock waiter budget (~3.2s), but
+        # within the VTS OAuth request budget (10s).
+        await asyncio.sleep(3.4)
+        return _token_response("single-flight-vts-token")
+
+    first_http = AsyncMock()
+    first_http.post.side_effect = slow_vts_token_post
+    second_http = AsyncMock()
+    second_http.post.return_value = _token_response("single-flight-vts-token")
+    monkeypatch.setattr(
+        first,
+        "_ensure_client",
+        AsyncMock(return_value=first_http),
+    )
+    monkeypatch.setattr(
+        second,
+        "_ensure_client",
+        AsyncMock(return_value=second_http),
+    )
+
+    first_task = asyncio.create_task(first._ensure_token())
+    await fetch_started.wait()
+    second_task = asyncio.create_task(second._ensure_token())
+    first_result, second_result = await asyncio.gather(first_task, second_task)
+
+    assert first_result is None
+    assert second_result is None
+    assert first_http.post.await_count + second_http.post.await_count == 1
+    assert settings.kis_mock_access_token == "single-flight-vts-token"
+    cached = json.loads(fake_redis.values[first._token_manager._token_key])
+    assert cached["access_token"] == "single-flight-vts-token"
+
+
+@pytest.mark.asyncio
+async def test_vts_token_timeout_is_longer_while_live_stays_unchanged(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _set_mock_credentials(
+        monkeypatch,
+        base_url="https://vts-timeout.example:29443",
+        app_key="vts-timeout-app-key",
+    )
+    mock_client = KISClient(is_mock=True)
+    mock_http = AsyncMock()
+    mock_http.post.return_value = _token_response("mock-timeout-token")
+    mock_ensure_client = AsyncMock(return_value=mock_http)
+    monkeypatch.setattr(mock_client, "_ensure_client", mock_ensure_client)
+
+    await mock_client._fetch_token()
+
+    mock_ensure_client.assert_awaited_once_with(timeout=10.0)
+    assert mock_http.post.await_args.kwargs["timeout"] == 10.0
+
+    live_client = KISClient()
+    live_http = AsyncMock()
+    live_http.post.return_value = _token_response("live-timeout-token")
+    live_ensure_client = AsyncMock(return_value=live_http)
+    monkeypatch.setattr(live_client, "_ensure_client", live_ensure_client)
+
+    await live_client._fetch_token()
+
+    live_ensure_client.assert_awaited_once_with(timeout=5.0)
+    assert live_http.post.await_args.kwargs["timeout"] == 5.0


### PR DESCRIPTION
## Summary

- Cache KIS VTS OAuth tokens in Redis under a namespace scoped by normalized VTS host plus a non-secret SHA-256 appkey fingerprint.
- Reuse one mock token manager per credential scope in each process while retaining Redis as the cross-process cache and distributed single-flight lock.
- Allow VTS OAuth issuance 10 seconds and VTS lock contenders 11 seconds; live KIS remains on its existing singleton, keys, 5-second OAuth timeout, and 3-second contender wait.

## Root cause

The VTS path nominally used `RedisTokenManager`, but each MCP-created mock client owned a fresh manager under the literal `kis_mock` namespace. More importantly, VTS OAuth issuance regularly took 4–6 seconds while `_fetch_token()` used the live-oriented 5-second timeout. Timed-out requests never reached `save_token()`, so the next MCP account read saw another Redis miss and issued another token. Sentry trace `fd0bfb06bd084dac83573efec7ad225b` showed this exact miss → slow POST → no save → second miss sequence; a fast positive-control issuance was cached and reused.

Review also exposed that the legacy lock contender waited only about 3 seconds. Once VTS requests could run for 10 seconds, concurrent cold-start callers could still fail before the owner saved its token. The VTS manager therefore receives an 11-second wait budget while the live default remains unchanged.

## Implementation

- `get_kis_mock_token_manager()` derives `kis_mock:{host}:{sha256(appkey)[:16]}` and shares the manager by normalized namespace.
- Both `KISClient(is_mock=True)` and `SafeKISMockClient` use the same factory.
- `BaseKISClient` keeps a 5-second token timeout by default; only mock clients override it to 10 seconds.
- `RedisTokenManager` keeps its 3-second contender default; only scoped VTS managers use 11 seconds.
- No Alembic or order-client files changed (`migration-0`).

## TDD and verification

- Initial RED: 5 intended failures for scoped keys, shared manager ownership, and VTS timeout.
- Concurrency RED: a separate-manager/shared-Redis test with a 3.4-second issuance reproduced the legacy waiter `RuntimeError` before the VTS wait-budget fix.
- Focused VTS contract: 6 passed.
- KIS/MCP regression selection: 220 passed, 3 warnings.
- Full unit gate: 13,350 passed, 10 skipped, 491 deselected, 40 warnings in 631.48s.
- `make lint`: Ruff check passed, 2,507 files formatted, ty passed.
- Independent review: no Critical, Important, or Minor findings; Ready-to-PR.
- Plan audit: complete, 4/4 implementation and verification tasks, no gaps.

## Safety

- Live Redis keys remain `kis:access_token` and `kis:token:lock`.
- Live OAuth timeout remains 5 seconds and live contender wait remains 3 seconds.
- Raw appkeys never appear in Redis keys.
- Order dispatch, TR IDs, payloads, endpoints, and order request timeouts are unchanged.
- PR only; do not merge pending separate-session validation.

Linear: ROB-827
