### PR TITLE
feat(ROB-816): converge proposal rungs from live reconcile evidence (PR-3c)

### DIFF
--- a/app/mcp_server/tooling/live_order_ledger.py
+++ b/app/mcp_server/tooling/live_order_ledger.py
@@ -231,6 +231,43 @@ async def _update_live_ledger_outcome(
         await db.commit()
 
 
+async def _converge_proposal_rung(
+    row: LiveOrderLedger,
+    *,
+    terminal_state: str,
+    filled_qty: Decimal | None,
+) -> dict[str, Any] | None:
+    """Project reconciled broker evidence onto the order_proposal rung (ROB-816).
+
+    The live ledger row is the booking source of truth; the proposal rung is a
+    downstream projection, so any failure here is logged and swallowed — it must
+    never turn a successful reconcile into an anomaly. Runs in its own committed
+    session (mirrors the other reconcile helpers). Returns a small summary for
+    the reconcile outcome dict, or ``None`` when no matching open rung exists.
+    """
+    from app.services.order_proposals import OrderProposalsService
+
+    try:
+        async with _order_session_factory()() as db:
+            service = OrderProposalsService(db)
+            rung = await service.record_fill_evidence(
+                correlation_id=getattr(row, "correlation_id", None),
+                broker_order_id=row.order_no,
+                filled_qty=filled_qty,
+                terminal_state=terminal_state,
+                now=datetime.now(UTC),
+            )
+            await db.commit()
+    except Exception as exc:  # noqa: BLE001 - projection is best-effort
+        logger.warning(
+            "proposal rung convergence failed order_no=%s: %s", row.order_no, exc
+        )
+        return {"converged": False, "error": str(exc) or exc.__class__.__name__}
+    if rung is None:
+        return None
+    return {"converged": True, "proposal_rung_state": rung.state}
+
+
 async def _reconcile_one_live_row(
     row: LiveOrderLedger, *, dry_run: bool
 ) -> dict[str, Any]:
@@ -253,6 +290,11 @@ async def _reconcile_one_live_row(
         base["action"] = "marked_cancelled"
         if not dry_run:
             await _update_live_ledger_outcome(ledger_id=row.id, status="cancelled")
+            converged = await _converge_proposal_rung(
+                row, terminal_state="cancelled", filled_qty=None
+            )
+            if converged is not None:
+                base["proposal_rung"] = converged
         return base
 
     # FILLED / PARTIAL — broker 확정값. 델타 멱등 booking.
@@ -265,6 +307,8 @@ async def _reconcile_one_live_row(
     base["avg_price"] = float(avg_price)
     base["delta_qty"] = float(delta)
 
+    rung_terminal = "filled" if new_status == "filled" else "partially_filled"
+
     if delta <= 0:
         base["action"] = "noop_already_booked"
         if not dry_run:
@@ -274,6 +318,11 @@ async def _reconcile_one_live_row(
                 filled_qty=broker_cum,
                 avg_fill_price=avg_price,
             )
+            converged = await _converge_proposal_rung(
+                row, terminal_state=rung_terminal, filled_qty=broker_cum
+            )
+            if converged is not None:
+                base["proposal_rung"] = converged
         return base
 
     if dry_run:
@@ -423,6 +472,11 @@ async def _reconcile_one_live_row(
     base["action"] = "booked"
     base["trade_id"] = trade_id
     base["journal_id"] = journal_id
+    converged = await _converge_proposal_rung(
+        row, terminal_state=rung_terminal, filled_qty=broker_cum
+    )
+    if converged is not None:
+        base["proposal_rung"] = converged
     return base
 
 

--- a/app/mcp_server/tooling/live_order_ledger.py
+++ b/app/mcp_server/tooling/live_order_ledger.py
@@ -241,9 +241,16 @@ async def _converge_proposal_rung(
 
     The live ledger row is the booking source of truth; the proposal rung is a
     downstream projection, so any failure here is logged and swallowed — it must
-    never turn a successful reconcile into an anomaly. Runs in its own committed
-    session (mirrors the other reconcile helpers). Returns a small summary for
-    the reconcile outcome dict, or ``None`` when no matching open rung exists.
+    never turn a successful reconcile into an anomaly, nor block the ledger from
+    booking. Runs in its own committed session (mirrors the other reconcile
+    helpers). Returns a small summary for the reconcile outcome dict, or ``None``
+    when no matching open rung exists.
+
+    Caveat: once a full-fill / cancel flips the ledger row to a terminal status
+    it drops out of ``_list_open_live_ledger_rows``, so a *swallowed* failure
+    here is not retried by a later reconcile pass. That is why the failure is
+    logged at ERROR with the ledger id (alertable) rather than silently. A
+    guaranteed-convergence proposal-rung reconcile sweep is tracked as follow-up.
     """
     from app.services.order_proposals import OrderProposalsService
 
@@ -259,8 +266,13 @@ async def _converge_proposal_rung(
             )
             await db.commit()
     except Exception as exc:  # noqa: BLE001 - projection is best-effort
-        logger.warning(
-            "proposal rung convergence failed order_no=%s: %s", row.order_no, exc
+        logger.error(
+            "proposal rung convergence failed ledger_id=%s order_no=%s "
+            "terminal_state=%s: %s",
+            row.id,
+            row.order_no,
+            terminal_state,
+            exc,
         )
         return {"converged": False, "error": str(exc) or exc.__class__.__name__}
     if rung is None:

--- a/app/services/order_proposals/repository.py
+++ b/app/services/order_proposals/repository.py
@@ -66,7 +66,16 @@ class OrderProposalRepository:
         *,
         correlation_id: str | None,
         broker_order_id: str | None,
+        states: frozenset[str] | None = None,
     ) -> tuple[uuid.UUID, OrderProposalRung] | None:
+        """Locate a rung by broker evidence.
+
+        ``states``, when given, restricts the match to rungs currently in one of
+        those states. Reconcile passes the evidence-accepting (non-terminal) set
+        so that re-delivered evidence for an already-terminal rung simply finds
+        nothing (a safe no-op) instead of matching a rung the state machine can
+        no longer transition — see OrderProposalsService.record_fill_evidence.
+        """
         evidence = (
             (OrderProposalRung.correlation_id, correlation_id),
             (OrderProposalRung.broker_order_id, broker_order_id),
@@ -81,9 +90,10 @@ class OrderProposalRepository:
                     OrderProposalRung.proposal_pk == OrderProposal.id,
                 )
                 .where(column == value)
-                .order_by(OrderProposalRung.id)
-                .limit(1)
             )
+            if states is not None:
+                stmt = stmt.where(OrderProposalRung.state.in_(states))
+            stmt = stmt.order_by(OrderProposalRung.id).limit(1)
             row = (await self._session.execute(stmt)).one_or_none()
             if row is not None:
                 return row[0], row[1]

--- a/app/services/order_proposals/service.py
+++ b/app/services/order_proposals/service.py
@@ -629,6 +629,12 @@ class OrderProposalsService:
             return None
         proposal_id, rung = match
         group, locked = await self._get_locked_rung(proposal_id, rung.rung_index)
+        # ``locked`` may be the same instance ``find_rung_by_evidence`` already
+        # loaded into this session's identity map; a plain re-SELECT would return
+        # it with its find-time ``state`` intact. Refresh it under the group lock
+        # so the terminality re-check below reads the state a concurrent reconcile
+        # committed, not a stale snapshot (which could regress a filled rung).
+        await self._session.refresh(locked)
         if sm.is_terminal(locked.state):
             # Converged by a concurrent reconcile between find and lock.
             return None

--- a/app/services/order_proposals/service.py
+++ b/app/services/order_proposals/service.py
@@ -66,6 +66,13 @@ _LOSS_CUT_MAX_AGE = timedelta(hours=72)
 _VOIDABLE_RUNG_STATES = frozenset(
     {"draft", "pending_approval", "revalidating", "needs_reconfirm", "approved"}
 )
+# Rung states that can legally absorb broker fill/cancel evidence. Every state
+# here has ``filled``/``partially_filled``/``cancelled`` reachable in the
+# transition graph (see state_machine._ALLOWED); terminal states are excluded so
+# re-delivered evidence short-circuits instead of raising.
+_EVIDENCE_ACCEPTING_RUNG_STATES = frozenset(
+    {"acked", "resting", "partially_filled", "unverified"}
+)
 
 
 class OrderProposalsService:
@@ -594,23 +601,47 @@ class OrderProposalsService:
         *,
         correlation_id: str | None = None,
         broker_order_id: str | None = None,
-        filled_qty: Decimal,
-        terminal_state: Literal["filled", "partially_filled"] = "filled",
+        filled_qty: Decimal | None = None,
+        terminal_state: Literal["filled", "partially_filled", "cancelled"] = "filled",
         now: datetime,
     ) -> OrderProposalRung | None:
+        """Converge a rung from broker fill/cancel evidence (ROB-816 PR-3c).
+
+        Called by the live reconcile kernel. Fail-safe by construction:
+
+        - Only rungs in an evidence-accepting (non-terminal) state are matched,
+          so re-delivered evidence for an already-terminal rung short-circuits
+          to ``None`` instead of raising ``OrderProposalInvalidStateTransition``
+          (which reconcile would otherwise mislabel as an anomaly).
+        - The matched rung is re-read under a row lock and re-checked for
+          terminality, closing the find→transition race with a concurrent pass.
+        - ``cancelled`` carries no fill quantity (``filled_qty=None``) so a
+          partial fill booked before a cancel is preserved, not zeroed.
+        - No terminal state is ever inferred without matching broker evidence.
+        """
         self._require_timezone_aware(now)
         match = await self._repo.find_rung_by_evidence(
-            correlation_id=correlation_id, broker_order_id=broker_order_id
+            correlation_id=correlation_id,
+            broker_order_id=broker_order_id,
+            states=_EVIDENCE_ACCEPTING_RUNG_STATES,
         )
         if match is None:
             return None
         proposal_id, rung = match
-        return await self.transition_rung(
-            proposal_id,
-            rung.rung_index,
-            new_state=terminal_state,
-            filled_qty=filled_qty,
-            updated_at=now,
+        group, locked = await self._get_locked_rung(proposal_id, rung.rung_index)
+        if sm.is_terminal(locked.state):
+            # Converged by a concurrent reconcile between find and lock.
+            return None
+        audit: dict[str, Any] = {"updated_at": now}
+        if filled_qty is not None:
+            audit["filled_qty"] = filled_qty
+        if locked.state == terminal_state:
+            # Repeated non-terminal evidence (e.g. a larger partial fill on an
+            # already-partially_filled rung): refresh audit fields in place
+            # rather than attempt an illegal self-transition.
+            return await self._repo.update_rung(locked, **audit)
+        return await self._transition_locked_rung(
+            group, locked, new_state=terminal_state, **audit
         )
 
     async def mark_needs_reconfirm(

--- a/tests/mcp_server/tooling/test_live_order_ledger.py
+++ b/tests/mcp_server/tooling/test_live_order_ledger.py
@@ -642,3 +642,212 @@ async def test_reconcile_buy_journal_backfills_correlation_id():
 
     m_buy.assert_awaited_once()
     assert m_buy.await_args.kwargs["correlation_id"] == "live:kis_live:reconcileUS"
+
+
+# --- ROB-816 PR-3c: proposal-rung convergence from the reconcile kernel -------
+
+
+async def _seed_resting_proposal(*, order_no: str, correlation_id: str):
+    """Create a committed order_proposal whose single rung is `resting`, wired to
+    the given broker order_no / correlation_id so reconcile evidence can find it.
+    """
+    from datetime import UTC, datetime
+    from decimal import Decimal
+
+    from app.mcp_server.tooling.live_order_ledger import _order_session_factory
+    from app.services.order_proposals import OrderProposalsService
+    from app.services.order_proposals.service import RungInput
+
+    now = datetime(2026, 7, 11, 0, 0, tzinfo=UTC)
+    async with _order_session_factory()() as db:
+        svc = OrderProposalsService(db)
+        group = await svc.create_proposal(
+            symbol="KRW-BTC",
+            market="crypto",
+            account_mode="upbit",
+            side="buy",
+            order_type="limit",
+            proposer="p",
+            rungs=[RungInput(0, "buy", Decimal("0.001"), Decimal("50000000"), None)],
+            now=now,
+        )
+        pid = group.proposal_id
+        for state in ("revalidating", "approved", "submitting"):
+            await svc.transition_rung(pid, 0, new_state=state)
+        await svc.record_resting(
+            pid,
+            0,
+            broker_order_id=order_no,
+            correlation_id=correlation_id,
+            idempotency_key=f"idem-{order_no}",
+            approval_hash_digest=f"digest-{order_no}",
+            now=now,
+        )
+        await db.commit()
+        return pid
+
+
+async def _read_rung_state(pid):
+    from app.mcp_server.tooling.live_order_ledger import _order_session_factory
+    from app.services.order_proposals import OrderProposalsService
+
+    async with _order_session_factory()() as db:
+        svc = OrderProposalsService(db)
+        _, rungs = await svc.get_proposal(pid)
+        return rungs[0].state
+
+
+async def _save_crypto_ledger(*, order_no: str, correlation_id: str, status="accepted"):
+    from app.mcp_server.tooling import live_order_ledger as ll
+
+    return await ll._save_live_order_ledger(
+        broker="upbit",
+        account_scope="upbit_live",
+        market="crypto",
+        symbol="KRW-BTC",
+        exchange=None,
+        market_symbol="KRW-BTC",
+        side="buy",
+        order_kind="limit",
+        quantity=0.001,
+        price=50000000.0,
+        amount=50000.0,
+        currency="KRW",
+        order_no=order_no,
+        order_time=None,
+        status=status,
+        response_code="0",
+        response_message=None,
+        raw_response=None,
+        reason=None,
+        thesis="t",
+        strategy="s",
+        target_price=None,
+        stop_loss=None,
+        min_hold_days=None,
+        notes=None,
+        exit_reason=None,
+        indicators_snapshot=None,
+        correlation_id=correlation_id,
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_reconcile_cancel_converges_proposal_rung(db_session):
+    """ROB-816 PR-3c regression (canary proposal fa0dab30): a resting proposal
+    rung whose broker order was cancelled converges to `cancelled` after
+    reconcile picks up the broker's NONE (cancelled) evidence."""
+    import uuid
+    from decimal import Decimal
+    from unittest.mock import AsyncMock, patch
+
+    from app.mcp_server.tooling import live_order_ledger as ll
+    from app.services.brokers.kis.mock_scalping_exec.fill_evidence import (
+        FillEvidence,
+        FillVerdict,
+    )
+
+    order_no = f"U-CXL-{uuid.uuid4()}"
+    corr = f"corr-{order_no}"
+    pid = await _seed_resting_proposal(order_no=order_no, correlation_id=corr)
+    lid = await _save_crypto_ledger(order_no=order_no, correlation_id=corr)
+    row = await ll._load_live_ledger_row(lid)
+    none_ev = FillEvidence(FillVerdict.NONE, Decimal("0"), None, None, "cancelled", "")
+
+    class _Adapter:
+        broker = "upbit"
+        fetch_evidence = AsyncMock(return_value=none_ev)
+
+    with patch.object(ll, "get_evidence_adapter", return_value=_Adapter()):
+        out = await ll._reconcile_one_live_row(row, dry_run=False)
+
+    assert out["verdict"] == "none"
+    assert await _read_rung_state(pid) == "cancelled"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_reconcile_fill_converges_proposal_rung_and_is_idempotent(db_session):
+    """Broker fill evidence converges a resting rung to `filled`; a second
+    reconcile pass over the already-booked ledger row is a no-op on the (now
+    terminal) rung and never raises."""
+    import uuid
+    from decimal import Decimal
+    from unittest.mock import AsyncMock, patch
+
+    from app.mcp_server.tooling import live_order_ledger as ll
+    from app.services.brokers.kis.mock_scalping_exec.fill_evidence import (
+        FillEvidence,
+        FillVerdict,
+    )
+
+    order_no = f"U-FILL-{uuid.uuid4()}"
+    corr = f"corr-{order_no}"
+    pid = await _seed_resting_proposal(order_no=order_no, correlation_id=corr)
+    lid = await _save_crypto_ledger(order_no=order_no, correlation_id=corr)
+    filled = FillEvidence(
+        FillVerdict.FILLED, Decimal("0.001"), Decimal("50000000"), None, "filled", ""
+    )
+
+    class _Adapter:
+        broker = "upbit"
+        fetch_evidence = AsyncMock(return_value=filled)
+
+    with (
+        patch.object(ll, "get_evidence_adapter", return_value=_Adapter()),
+        patch.object(ll, "_save_order_fill", new=AsyncMock(return_value=555)),
+        patch.object(
+            ll,
+            "_create_trade_journal_for_buy",
+            new=AsyncMock(return_value={"journal_id": 77}),
+        ),
+        patch.object(ll, "_link_journal_to_fill", new=AsyncMock(return_value=None)),
+    ):
+        out1 = await ll._reconcile_one_live_row(
+            row=await ll._load_live_ledger_row(lid), dry_run=False
+        )
+        assert out1["action"] == "booked"
+        assert await _read_rung_state(pid) == "filled"
+
+        # Second pass: ledger row is now `filled`, delta<=0 → convergence must
+        # short-circuit on the terminal rung rather than raise.
+        out2 = await ll._reconcile_one_live_row(
+            row=await ll._load_live_ledger_row(lid), dry_run=False
+        )
+        assert out2["action"] == "noop_already_booked"
+        assert await _read_rung_state(pid) == "filled"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_reconcile_dry_run_does_not_touch_proposal_rung(db_session):
+    """A dry-run reconcile is read-only — it never mutates proposal rung state."""
+    import uuid
+    from decimal import Decimal
+    from unittest.mock import AsyncMock, patch
+
+    from app.mcp_server.tooling import live_order_ledger as ll
+    from app.services.brokers.kis.mock_scalping_exec.fill_evidence import (
+        FillEvidence,
+        FillVerdict,
+    )
+
+    order_no = f"U-DRY-{uuid.uuid4()}"
+    corr = f"corr-{order_no}"
+    pid = await _seed_resting_proposal(order_no=order_no, correlation_id=corr)
+    lid = await _save_crypto_ledger(order_no=order_no, correlation_id=corr)
+    row = await ll._load_live_ledger_row(lid)
+    filled = FillEvidence(
+        FillVerdict.FILLED, Decimal("0.001"), Decimal("50000000"), None, "filled", ""
+    )
+
+    class _Adapter:
+        broker = "upbit"
+        fetch_evidence = AsyncMock(return_value=filled)
+
+    with patch.object(ll, "get_evidence_adapter", return_value=_Adapter()):
+        out = await ll._reconcile_one_live_row(row, dry_run=True)
+
+    assert out["action"] == "would_book"
+    assert await _read_rung_state(pid) == "resting"

--- a/tests/services/order_proposals/test_service.py
+++ b/tests/services/order_proposals/test_service.py
@@ -699,6 +699,49 @@ async def test_fill_evidence_on_terminal_rung_short_circuits(db_session):
 
 
 @pytest.mark.asyncio
+async def test_fill_evidence_rechecks_committed_state_under_lock(db_session):
+    """Concurrency invariant: once another session has committed a terminal fill,
+    late/partial evidence arriving on a session that observed the rung earlier
+    must short-circuit — it must never regress the already-`filled` rung back to
+    `partially_filled`. Guards the record_fill_evidence lock + refresh re-check."""
+    from app.mcp_server.tooling.live_order_ledger import _order_session_factory
+
+    service, group = await _create_single_rung(db_session)
+    now = datetime(2026, 7, 11, 9, 4, tzinfo=UTC)
+    acked = await _record_ack(service, group.proposal_id, now=now)
+    await db_session.commit()
+
+    # Prime THIS session's identity map with the rung while it is still 'acked'.
+    await service.get_proposal(group.proposal_id)
+
+    # A concurrent session commits the terminal fill.
+    async with _order_session_factory()() as db2:
+        other = OrderProposalsService(db2)
+        await other.record_fill_evidence(
+            broker_order_id=acked.broker_order_id,
+            filled_qty=Decimal("1"),
+            terminal_state="filled",
+            now=now + timedelta(seconds=1),
+        )
+        await db2.commit()
+
+    # Late partial evidence arriving on the stale session must short-circuit,
+    # never regress the committed `filled` rung back to `partially_filled`.
+    result = await service.record_fill_evidence(
+        broker_order_id=acked.broker_order_id,
+        filled_qty=Decimal("0.25"),
+        terminal_state="partially_filled",
+        now=now + timedelta(seconds=2),
+    )
+    assert result is None
+
+    async with _order_session_factory()() as db3:
+        _, rungs = await OrderProposalsService(db3).get_proposal(group.proposal_id)
+        assert rungs[0].state == "filled"
+        assert rungs[0].filled_qty == Decimal("1")
+
+
+@pytest.mark.asyncio
 async def test_fill_evidence_repeated_partial_refreshes_qty(db_session):
     """A second partial-fill evidence on an already-partially-filled rung
     refreshes the cumulative quantity without an (illegal) self-transition."""

--- a/tests/services/order_proposals/test_service.py
+++ b/tests/services/order_proposals/test_service.py
@@ -48,6 +48,19 @@ async def _record_ack(service, proposal_id, *, now: datetime):
     )
 
 
+async def _record_resting(service, proposal_id, *, now: datetime):
+    await _drive_to_submitting(service, proposal_id)
+    return await service.record_resting(
+        proposal_id,
+        0,
+        broker_order_id=f"B-REST-{proposal_id}",
+        correlation_id=f"corr-rest-{proposal_id}",
+        idempotency_key=f"idem-rest-{proposal_id}",
+        approval_hash_digest=f"digest-rest-{proposal_id}",
+        now=now,
+    )
+
+
 def _retro(*, symbol="005930", trigger_type="stop_loss", created_at=None):
     return SimpleNamespace(
         symbol=symbol,
@@ -606,6 +619,111 @@ async def test_fill_evidence_missing_match_is_noop(db_session):
         is None
     )
     assert await service.record_fill_evidence(filled_qty=Decimal("1"), now=now) is None
+
+
+@pytest.mark.asyncio
+async def test_fill_evidence_records_cancelled_terminal(db_session):
+    """ROB-816 PR-3c: broker cancel evidence converges a resting rung to
+    `cancelled` (the fa0dab30 canary scenario), with no filled_qty required."""
+    service, group = await _create_single_rung(db_session)
+    now = datetime(2026, 7, 11, 9, 0, tzinfo=UTC)
+    rested = await _record_resting(service, group.proposal_id, now=now)
+    await db_session.commit()
+
+    cancelled = await service.record_fill_evidence(
+        correlation_id=rested.correlation_id,
+        terminal_state="cancelled",
+        now=now + timedelta(seconds=1),
+    )
+
+    assert cancelled is not None
+    assert cancelled.state == "cancelled"
+    assert cancelled.updated_at == now + timedelta(seconds=1)
+
+
+@pytest.mark.asyncio
+async def test_fill_evidence_cancel_after_partial_keeps_filled_qty(db_session):
+    """A partially-filled rung that is later cancelled keeps the quantity that
+    actually filled — cancel evidence must not zero out the partial fill."""
+    service, group = await _create_single_rung(db_session)
+    now = datetime(2026, 7, 11, 9, 1, tzinfo=UTC)
+    acked = await _record_ack(service, group.proposal_id, now=now)
+    await db_session.commit()
+    await service.record_fill_evidence(
+        broker_order_id=acked.broker_order_id,
+        filled_qty=Decimal("0.25"),
+        terminal_state="partially_filled",
+        now=now + timedelta(seconds=1),
+    )
+
+    cancelled = await service.record_fill_evidence(
+        broker_order_id=acked.broker_order_id,
+        terminal_state="cancelled",
+        now=now + timedelta(seconds=2),
+    )
+
+    assert cancelled is not None
+    assert cancelled.state == "cancelled"
+    assert cancelled.filled_qty == Decimal("0.25")
+
+
+@pytest.mark.asyncio
+async def test_fill_evidence_on_terminal_rung_short_circuits(db_session):
+    """Re-evidence flowing into an already-terminal rung must short-circuit to a
+    no-op — never raise InvalidStateTransition (which the reconcile kernel would
+    otherwise mislabel as an anomaly)."""
+    service, group = await _create_single_rung(db_session)
+    now = datetime(2026, 7, 11, 9, 2, tzinfo=UTC)
+    rested = await _record_resting(service, group.proposal_id, now=now)
+    await db_session.commit()
+
+    first = await service.record_fill_evidence(
+        broker_order_id=rested.broker_order_id, terminal_state="cancelled", now=now
+    )
+    assert first is not None and first.state == "cancelled"
+
+    # A second reconcile pass re-delivers the same cancel evidence.
+    again = await service.record_fill_evidence(
+        broker_order_id=rested.broker_order_id, terminal_state="cancelled", now=now
+    )
+    assert again is None
+
+    # A late-arriving fill against the same terminal rung must also no-op.
+    late = await service.record_fill_evidence(
+        broker_order_id=rested.broker_order_id,
+        filled_qty=Decimal("1"),
+        terminal_state="filled",
+        now=now,
+    )
+    assert late is None
+
+
+@pytest.mark.asyncio
+async def test_fill_evidence_repeated_partial_refreshes_qty(db_session):
+    """A second partial-fill evidence on an already-partially-filled rung
+    refreshes the cumulative quantity without an (illegal) self-transition."""
+    service, group = await _create_single_rung(db_session)
+    now = datetime(2026, 7, 11, 9, 3, tzinfo=UTC)
+    acked = await _record_ack(service, group.proposal_id, now=now)
+    await db_session.commit()
+
+    await service.record_fill_evidence(
+        broker_order_id=acked.broker_order_id,
+        filled_qty=Decimal("0.25"),
+        terminal_state="partially_filled",
+        now=now + timedelta(seconds=1),
+    )
+    refreshed = await service.record_fill_evidence(
+        broker_order_id=acked.broker_order_id,
+        filled_qty=Decimal("0.5"),
+        terminal_state="partially_filled",
+        now=now + timedelta(seconds=2),
+    )
+
+    assert refreshed is not None
+    assert refreshed.state == "partially_filled"
+    assert refreshed.filled_qty == Decimal("0.5")
+    assert refreshed.updated_at == now + timedelta(seconds=2)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What / Why

ROB-816 PR-3c. After PR-1/2/3a, `order_proposals` rungs terminalized at
**submit** (`acked`/`resting`) but never advanced on actual broker
fill/cancel evidence — a resting rung that the broker later cancelled or
filled stayed `resting` forever. This wires the proposal ledger into the
existing **ROB-407 live reconcile kernel** (`live_reconcile_orders` /
`_reconcile_one_live_row`, US/crypto path) so broker evidence reaches rung
state.

## Changes

- **`_converge_proposal_rung`** in `live_order_ledger.py`, called from the
  three terminal branches of `_reconcile_one_live_row`:
  - verdict `NONE` (cancelled) → rung **`cancelled`** (prior partial fill is
    preserved — `filled_qty` is not zeroed)
  - verdict `FILLED` / `PARTIAL` → rung **`filled`** / **`partially_filled`**
  - Runs as a best-effort downstream projection in its own committed session.
    The live ledger row remains the booking source of truth, so a projection
    failure is **logged and swallowed** — it never turns a successful reconcile
    into an anomaly. `dry_run` reconcile stays read-only.
- **Required fix — `find_rung_by_evidence` gains a `states` filter.** Reconcile
  passes the evidence-accepting (non-terminal) set, so re-delivered evidence
  for an already-terminal rung **short-circuits to a no-op** instead of raising
  `OrderProposalInvalidStateTransition` (which the kernel would otherwise
  mislabel as an anomaly). `record_fill_evidence` additionally re-reads the
  matched rung under a row lock and re-checks terminality (closing the
  find→transition race), and refreshes cumulative qty in place on a repeated
  partial rather than an illegal self-transition.
- **No automatic terminal inference without evidence** — convergence fires only
  on real broker `FILLED`/`PARTIAL`/`NONE` verdicts; `PENDING` is a no-op.

## Tests (TDD, red→green)

- Service: cancelled-terminal convergence; cancel-after-partial keeps
  `filled_qty`; terminal-rung re-evidence short-circuits (no raise); repeated
  partial refreshes qty without self-transition.
- Reconcile integration: **cancel converges rung to `cancelled` (fa0dab30
  canary regression)**; fill converges to `filled` and is idempotent on a
  second pass over the already-booked row; dry-run leaves the rung untouched.

## Scope

ROB-407 US/crypto path only (`live_reconcile_orders`), which covers the Upbit
crypto canary. The KR/KIS reconcile path (`kis_live_reconcile_orders`,
ROB-395) is unchanged — a follow-up if proposal convergence is wanted there.

## Operator check (after merge + deploy)

Run `live_reconcile_orders` against the **2026-07-11 canary proposal
`fa0dab30`** (rung `resting`, cancelled at the broker) and confirm the rung /
group **converges to `cancelled` / `terminal`**. This is the live counterpart
of the `test_reconcile_cancel_converges_proposal_rung` regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Live order reconciliation now synchronizes proposal statuses with broker evidence, including filled, partially filled, and cancelled outcomes.
  * Reconciliation preserves cumulative filled quantities when processing cancellations or repeated partial-fill updates.

* **Bug Fixes**
  * Prevented repeated or late broker updates from changing proposals that are already in a final state.
  * Improved handling of duplicate reconciliation events so they safely become no-ops.
  * Dry-run reconciliation continues to leave proposal data unchanged.

* **Tests**
  * Added coverage for cancellation, fills, partial fills, duplicate evidence, concurrency, and dry-run behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->