### PR TITLE
feat(ROB-839): promote crypto judgment rules to policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Added (ROB-839 — crypto judgment rules policy promotion; migration 0)
+- **Crypto policy reads now return lane-filtered judgment rules.** `get_trading_policy(market="crypto", lane=...)` exposes an advisory `market_rules` block for the 2-of-4 recovery frame, support/resistance source priority, and no-chasing criteria while retaining the existing `{version, content_hash}` stamp.
+- **Missing report thresholds stay explicitly unknown.** Fear & Greed, kimchi premium, same-day gain, and 24-hour liquidity cutoffs remain `null`, so callers cannot invent model-specific numbers; the report-backed breadth (`>50%`) and BTC long/short (`<=1.5`) thresholds remain explicit.
+- **Execution safety boundaries are unchanged.** The new strict Pydantic/YAML contract is advisory only, does not alter loss-sale or ladder fail-closed guards, and requires no database migration.
+
 ### Added (ROB-832 — order proposal replace/cancel actions; migration 1)
 - **Operators can approve one-order replace or cancel proposals in Telegram.** Replace proposals bind one target broker-order snapshot to one new-order specification; cancel proposals bind one target snapshot to one cancel action. Existing place proposals keep multi-rung behavior and legacy `NULL` actions behave as `place`.
 - **Replace is fail-closed across cancel-and-new.** Approval re-fetches broker evidence, reruns preview/profit guards, confirms the old order cancellation, then submits the replacement. Any target drift, cancellation failure, missing confirmation, or ambiguous broker response prevents a new order and preserves reconciliation lineage.

--- a/app/mcp_server/README.md
+++ b/app/mcp_server/README.md
@@ -1506,7 +1506,8 @@ Response shape:
     and no-chasing criteria. A `null` threshold is intentional and callers must
     not replace it with an inferred number. These rules do not replace
     code-owned fail-closed order guards.
-  - Success returns `{market, lane, version, content_hash, thresholds, decision_rules}`.
+  - Success returns
+    `{market, lane, version, content_hash, thresholds, decision_rules, market_rules}`.
     `decision_rules` is lane-filtered and empty when no rule applies. For sell,
     `decision_rules["sell.trim_preplace"]` encodes the ROB-751 resistance-near
     vs upside-rich tie-break: RSI-confirmed resistance or ultra-near resistance

--- a/app/mcp_server/README.md
+++ b/app/mcp_server/README.md
@@ -1501,6 +1501,11 @@ Response shape:
   - Read-only, single source `config/trading_policy.yaml`, operator-PR-edited (no write tool).
   - Args `market ∈ {kr,us,crypto}` × `lane ∈ {buy,sell,discovery}`.
   - An unknown key maps to `success=false, error=unknown_key`.
+  - `market_rules` contains market-specific advisory judgment rules filtered by
+    lane. Crypto includes the recovery gate, support/resistance source priority,
+    and no-chasing criteria. A `null` threshold is intentional and callers must
+    not replace it with an inferred number. These rules do not replace
+    code-owned fail-closed order guards.
   - Success returns `{market, lane, version, content_hash, thresholds, decision_rules}`.
     `decision_rules` is lane-filtered and empty when no rule applies. For sell,
     `decision_rules["sell.trim_preplace"]` encodes the ROB-751 resistance-near

--- a/app/schemas/trading_policy.py
+++ b/app/schemas/trading_policy.py
@@ -17,6 +17,7 @@ Market = Literal["kr", "us", "crypto"]
 
 ThresholdValue = int | float | str | list[int | float]
 RuleConditionValue = int | float | str | bool | list[int | float | str | bool]
+PolicyComparison = Literal["gt", "gte", "lt", "lte", "eq"]
 
 
 class PolicyThreshold(BaseModel):
@@ -48,6 +49,61 @@ class PolicyDecisionRule(BaseModel):
     exclusions: list[str] = Field(default_factory=list)
 
 
+class PolicyRecoveryCondition(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    id: str
+    metric: str
+    sources: list[str]
+    operator: PolicyComparison | None
+    threshold: int | float | None
+    unit: str
+    semantics: str
+
+
+class PolicyRecoveryGate(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    lanes: list[Lane]
+    advisory: bool
+    semantics: str
+    min_conditions_met: int
+    of: int
+    missing_or_null_threshold: str
+    conditions: list[PolicyRecoveryCondition]
+
+
+class PolicySupportResistanceRule(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    lanes: list[Lane]
+    advisory: bool
+    semantics: str
+    selection_rule: str
+    source_priority: list[str]
+    confluence_examples: list[list[str]]
+
+
+class PolicyNoChasingRule(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    lanes: list[Lane]
+    advisory: bool
+    semantics: str
+    daily_change_pct_threshold: float | None
+    min_trade_value_24h_krw: int | None
+    criteria: list[str]
+    follow_up: str
+
+
+class CryptoMarketRules(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    recovery_gate: PolicyRecoveryGate
+    support_resistance: PolicySupportResistanceRule
+    no_chasing: PolicyNoChasingRule
+
+
 class PolicyAuthority(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -66,4 +122,5 @@ class TradingPolicyDocument(BaseModel):
     sector_clusters: dict[str, list[str]]
     thresholds: dict[str, PolicyThreshold]
     decision_rules: dict[str, PolicyDecisionRule] = Field(default_factory=dict)
+    market_rules: dict[Literal["crypto"], CryptoMarketRules]
     market_overrides: dict[Market, dict[str, ThresholdValue]]

--- a/app/services/trading_policy_service.py
+++ b/app/services/trading_policy_service.py
@@ -87,6 +87,13 @@ def get_policy_for(market: str, lane: str) -> dict[str, Any]:
         for key, spec in doc.decision_rules.items()
         if lane in spec.lanes
     }
+    market_rules: dict[str, Any] = {}
+    rules = doc.market_rules.get("crypto") if market == "crypto" else None
+    if rules is not None:
+        for key in type(rules).model_fields:
+            spec = getattr(rules, key)
+            if lane in spec.lanes:
+                market_rules[key] = spec.model_dump(exclude={"lanes"})
     return {
         "market": market,
         "lane": lane,
@@ -94,6 +101,7 @@ def get_policy_for(market: str, lane: str) -> dict[str, Any]:
         "content_hash": content_hash,
         "thresholds": thresholds,
         "decision_rules": decision_rules,
+        "market_rules": market_rules,
     }
 
 

--- a/config/trading_policy.yaml
+++ b/config/trading_policy.yaml
@@ -2,9 +2,9 @@
 # Seeded verbatim from docs/playbooks/trading-decision-playbook.md policy_keys
 # (captured 2026-07-02). Edited by operator PR ONLY — there is no write tool.
 # Repo is public; exposing these values is an accepted decision.
-version: "2026-07-07.1"
-captured_as_of: "2026-07-07"
-source: "ROB-643 playbook policy_keys (seed); ROB-751 sell.trim_preplace tie-break promoted"
+version: "2026-07-12.1"
+captured_as_of: "2026-07-12"
+source: "ROB-643/751 baseline; ROB-839 crypto-recheck reports 2026-07-11/12 (sonnet, opus, fable)"
 
 authority:
   scope: judgment_policy_only
@@ -151,6 +151,68 @@ decision_rules:
       - single_share_position
       - no_resistance_reference
       - composite_gates
+
+market_rules:
+  crypto:
+    recovery_gate:
+      lanes: [buy]
+      advisory: true
+      semantics: reserve deployment recovery frame; otherwise support-conditional only
+      min_conditions_met: 2
+      of: 4
+      missing_or_null_threshold: do_not_infer_or_count_as_met
+      conditions:
+        - id: fear_greed
+          metric: crypto_fear_greed_index
+          sources: [alternative_me]
+          operator: null
+          threshold: null
+          unit: index
+          semantics: reports cite a recovering trend but define no pass cutoff
+        - id: alt_breadth_24h
+          metric: upbit_alt_breadth_24h
+          sources: [upbit_open_api_ticker_derived]
+          operator: gt
+          threshold: 50
+          unit: percent
+          semantics: share of KRW alts outperforming BTC over 24h
+        - id: btc_long_short_ratio
+          metric: btc_long_short_ratio
+          sources: [binance_global_account, binance_top_trader_position]
+          operator: lte
+          threshold: 1.5
+          unit: ratio
+          semantics: both report inputs should remain at or below the threshold
+        - id: btc_kimchi_premium
+          metric: btc_kimchi_premium
+          sources: [upbit_binance_fx]
+          operator: null
+          threshold: null
+          unit: percent
+          semantics: reports interpret discount and domestic FOMO qualitatively; no pass cutoff
+    support_resistance:
+      lanes: [buy, sell, discovery]
+      advisory: true
+      semantics: rank fresh levels by independent-source confluence before source priority
+      selection_rule: confluence_first_then_source_priority
+      source_priority: [fibonacci, value_area, bb_lower, bb_middle, volume_poc]
+      confluence_examples:
+        - [fib_0, value_area_low, bb_lower]
+        - [bb_middle, fib_23_6]
+        - [bb_middle, volume_poc]
+    no_chasing:
+      lanes: [buy, discovery]
+      advisory: true
+      semantics: reject pump-like new entries without inventing numeric cutoffs
+      # Reports contain no numeric pump-gain or liquidity cutoff. Null is
+      # intentional: consumers must not infer a model-specific replacement.
+      daily_change_pct_threshold: null
+      min_trade_value_24h_krw: null
+      criteria:
+        - exclude low-liquidity rotation-pump candidates
+        - new alt candidates are ineligible when 24h alt breadth is below 50 percent
+        - exclude sharply rising candidates without support structure or decision history
+      follow_up: reports contain no quantitative cutoff; operator fills values after live-operation evidence in a follow-up PR
 
 market_overrides:
   kr: {}

--- a/config/trading_policy.yaml
+++ b/config/trading_policy.yaml
@@ -195,7 +195,7 @@ market_rules:
       advisory: true
       semantics: rank fresh levels by independent-source confluence before source priority
       selection_rule: confluence_first_then_source_priority
-      source_priority: [fibonacci, value_area, bb_lower, bb_middle, volume_poc]
+      source_priority: [fibonacci, value_area, bb_lower, bb_upper, bb_middle, volume_poc]
       confluence_examples:
         - [fib_0, value_area_low, bb_lower]
         - [bb_middle, fib_23_6]

--- a/docs/superpowers/plans/2026-07-12-rob-839-crypto-policy-rules.md
+++ b/docs/superpowers/plans/2026-07-12-rob-839-crypto-policy-rules.md
@@ -1,0 +1,415 @@
+# ROB-839 Crypto Policy Rules Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Expose report-derived crypto recovery, support/resistance, and no-chasing judgment rules through the versioned trading-policy contract without inventing absent numeric thresholds.
+
+**Architecture:** Add a strict typed `market_rules.crypto` YAML block beside the existing scalar `market_overrides`. The loader filters each rule by lane and returns it as an additive `market_rules` response field while preserving the existing version/hash stamp and all execution guards.
+
+**Tech Stack:** Python 3.13+, Pydantic v2, PyYAML, pytest, Ruff, ty, FastMCP tool wrapper.
+
+## Global Constraints
+
+- All new policy rules are advisory and read-only.
+- Do not change loss-sale or ladder fail-closed execution guards.
+- Use `null` for Fear & Greed, kimchi-premium, same-day-gain, and liquidity thresholds absent from the reports.
+- Keep `breadth > 50%`, `BTC L/S <= 1.5`, and `2 of 4` exactly as report-derived values.
+- Preserve `{version, content_hash}` where `content_hash` is the first 12 SHA-256 hex characters of raw YAML bytes.
+- Version the policy as `2026-07-12.1`.
+- No database changes or migrations.
+- Keep MCP documentation synchronized with the response contract.
+
+---
+
+### Task 1: Strict Crypto Market-Rule Schema and Seed YAML
+
+**Files:**
+- Modify: `tests/schemas/test_trading_policy_schema.py`
+- Modify: `app/schemas/trading_policy.py`
+- Modify: `config/trading_policy.yaml`
+
+**Interfaces:**
+- Consumes: `TradingPolicyDocument.model_validate(raw: object) -> TradingPolicyDocument`
+- Produces: `TradingPolicyDocument.market_rules: dict[Literal["crypto"], CryptoMarketRules]`
+- Produces: typed `recovery_gate`, `support_resistance`, and `no_chasing` rule objects with `lanes` and `advisory` fields.
+
+- [ ] **Step 1: Write failing shipped-config and nested-validation tests**
+
+Add assertions that version `2026-07-12.1` validates, crypto recovery condition IDs are exactly `fear_greed`, `alt_breadth_24h`, `btc_long_short_ratio`, and `btc_kimchi_premium`, breadth is `gt 50`, L/S is `lte 1.5`, F&G/kimchi thresholds are `None`, no-chasing numeric fields are `None`, and source priority is stable. Add a nested extra-key rejection test:
+
+```python
+def test_crypto_market_rules_preserve_report_derived_and_null_thresholds():
+    doc = TradingPolicyDocument.model_validate(_raw())
+    rules = doc.market_rules["crypto"]
+    gate = rules.recovery_gate
+    assert gate.min_conditions_met == 2
+    assert gate.of == 4
+    assert [condition.id for condition in gate.conditions] == [
+        "fear_greed",
+        "alt_breadth_24h",
+        "btc_long_short_ratio",
+        "btc_kimchi_premium",
+    ]
+    assert gate.conditions[0].threshold is None
+    assert (gate.conditions[1].operator, gate.conditions[1].threshold) == ("gt", 50)
+    assert (gate.conditions[2].operator, gate.conditions[2].threshold) == ("lte", 1.5)
+    assert gate.conditions[3].threshold is None
+    assert rules.no_chasing.daily_change_pct_threshold is None
+    assert rules.no_chasing.min_trade_value_24h_krw is None
+    assert rules.support_resistance.source_priority == [
+        "fibonacci",
+        "value_area",
+        "bb_lower",
+        "bb_middle",
+        "volume_poc",
+    ]
+
+
+def test_extra_crypto_market_rule_key_rejected():
+    raw = _raw()
+    raw["market_rules"]["crypto"]["no_chasing"]["bogus"] = True
+    with pytest.raises(ValidationError):
+        TradingPolicyDocument.model_validate(raw)
+```
+
+- [ ] **Step 2: Run schema tests and verify red**
+
+Run: `uv run pytest tests/schemas/test_trading_policy_schema.py -q`
+
+Expected: FAIL because version is still `2026-07-07.1` and `market_rules` is absent/forbidden.
+
+- [ ] **Step 3: Add strict Pydantic rule models**
+
+Implement models with `ConfigDict(extra="forbid")`:
+
+```python
+PolicyComparison = Literal["gt", "gte", "lt", "lte", "eq"]
+
+
+class PolicyRecoveryCondition(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    id: str
+    metric: str
+    sources: list[str]
+    operator: PolicyComparison | None
+    threshold: int | float | None
+    unit: str
+    semantics: str
+
+
+class PolicyRecoveryGate(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    lanes: list[Lane]
+    advisory: bool
+    semantics: str
+    min_conditions_met: int
+    of: int
+    missing_or_null_threshold: str
+    conditions: list[PolicyRecoveryCondition]
+
+
+class PolicySupportResistanceRule(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    lanes: list[Lane]
+    advisory: bool
+    semantics: str
+    selection_rule: str
+    source_priority: list[str]
+    confluence_examples: list[list[str]]
+
+
+class PolicyNoChasingRule(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    lanes: list[Lane]
+    advisory: bool
+    semantics: str
+    daily_change_pct_threshold: float | None
+    min_trade_value_24h_krw: int | None
+    criteria: list[str]
+    follow_up: str
+
+
+class CryptoMarketRules(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    recovery_gate: PolicyRecoveryGate
+    support_resistance: PolicySupportResistanceRule
+    no_chasing: PolicyNoChasingRule
+```
+
+Add to `TradingPolicyDocument`:
+
+```python
+market_rules: dict[Literal["crypto"], CryptoMarketRules]
+```
+
+- [ ] **Step 4: Seed the report-derived YAML**
+
+Update metadata to `version: "2026-07-12.1"`, `captured_as_of: "2026-07-12"`, and a source naming ROB-839 plus the four crypto recheck reports. Add `market_rules.crypto` using the exact constraints from the approved design:
+
+```yaml
+market_rules:
+  crypto:
+    recovery_gate:
+      lanes: [buy]
+      advisory: true
+      semantics: reserve deployment recovery frame; otherwise support-conditional only
+      min_conditions_met: 2
+      of: 4
+      missing_or_null_threshold: do_not_infer_or_count_as_met
+      conditions:
+        - id: fear_greed
+          metric: crypto_fear_greed_index
+          sources: [alternative_me]
+          operator: null
+          threshold: null
+          unit: index
+          semantics: reports cite a recovering trend but define no pass cutoff
+        - id: alt_breadth_24h
+          metric: upbit_alt_breadth_24h
+          sources: [upbit_open_api_ticker_derived]
+          operator: gt
+          threshold: 50
+          unit: percent
+          semantics: share of KRW alts outperforming BTC over 24h
+        - id: btc_long_short_ratio
+          metric: btc_long_short_ratio
+          sources: [binance_global_account, binance_top_trader_position]
+          operator: lte
+          threshold: 1.5
+          unit: ratio
+          semantics: both report inputs should remain at or below the threshold
+        - id: btc_kimchi_premium
+          metric: btc_kimchi_premium
+          sources: [upbit_binance_fx]
+          operator: null
+          threshold: null
+          unit: percent
+          semantics: reports interpret discount and domestic FOMO qualitatively; no pass cutoff
+    support_resistance:
+      lanes: [buy, sell, discovery]
+      advisory: true
+      semantics: rank fresh levels by independent-source confluence before source priority
+      selection_rule: confluence_first_then_source_priority
+      source_priority: [fibonacci, value_area, bb_lower, bb_middle, volume_poc]
+      confluence_examples:
+        - [fib_0, value_area_low, bb_lower]
+        - [bb_middle, fib_23_6]
+        - [bb_middle, volume_poc]
+    no_chasing:
+      lanes: [buy, discovery]
+      advisory: true
+      semantics: reject pump-like new entries without inventing numeric cutoffs
+      daily_change_pct_threshold: null
+      min_trade_value_24h_krw: null
+      criteria:
+        - exclude low-liquidity rotation-pump candidates
+        - new alt candidates are ineligible when 24h alt breadth is below 50 percent
+        - exclude sharply rising candidates without support structure or decision history
+      follow_up: reports contain no quantitative cutoff; operator fills values after live-operation evidence in a follow-up PR
+```
+
+Add an adjacent YAML comment explaining that both `null` values prohibit model inference.
+
+- [ ] **Step 5: Run schema tests and verify green**
+
+Run: `uv run pytest tests/schemas/test_trading_policy_schema.py -q`
+
+Expected: all tests PASS.
+
+- [ ] **Step 6: Commit schema and seed policy**
+
+```bash
+git add config/trading_policy.yaml app/schemas/trading_policy.py tests/schemas/test_trading_policy_schema.py
+git commit -m "feat(ROB-839): define crypto judgment policy rules"
+```
+
+### Task 2: Lane-Filtered Service Exposure and Version Stamp
+
+**Files:**
+- Modify: `tests/services/test_trading_policy_service.py`
+- Modify: `app/services/trading_policy_service.py`
+
+**Interfaces:**
+- Consumes: `CryptoMarketRules` instances loaded by `_load()`.
+- Produces: `get_policy_for(market: str, lane: str) -> dict[str, Any]` with additive `market_rules: dict[str, Any]`.
+- Preserves: `policy_version_stamp() -> dict[str, str]` and raw-YAML hash behavior.
+
+- [ ] **Step 1: Write failing lane-filter and stamp tests**
+
+Add tests with exact rule visibility:
+
+```python
+def test_get_policy_for_crypto_buy_exposes_report_derived_market_rules():
+    view = svc.get_policy_for("crypto", "buy")
+    assert view["version"] == "2026-07-12.1"
+    assert set(view["market_rules"]) == {
+        "recovery_gate",
+        "support_resistance",
+        "no_chasing",
+    }
+    gate = view["market_rules"]["recovery_gate"]
+    assert gate["min_conditions_met"] == 2
+    assert gate["of"] == 4
+    assert "lanes" not in gate
+    assert view["market_rules"]["no_chasing"]["daily_change_pct_threshold"] is None
+
+
+def test_get_policy_for_filters_crypto_market_rules_by_lane():
+    discovery = svc.get_policy_for("crypto", "discovery")["market_rules"]
+    assert set(discovery) == {"support_resistance", "no_chasing"}
+    sell = svc.get_policy_for("crypto", "sell")["market_rules"]
+    assert set(sell) == {"support_resistance"}
+    assert svc.get_policy_for("kr", "buy")["market_rules"] == {}
+```
+
+Update existing hard-coded version assertions to `2026-07-12.1`.
+
+- [ ] **Step 2: Run service tests and verify red**
+
+Run: `uv run pytest tests/services/test_trading_policy_service.py -q`
+
+Expected: FAIL because `get_policy_for` has no `market_rules` field.
+
+- [ ] **Step 3: Implement generic lane filtering**
+
+Before the return value in `get_policy_for`, build the additive view without mutating Pydantic models:
+
+```python
+    market_rules: dict[str, Any] = {}
+    rules = doc.market_rules.get(market)  # type: ignore[arg-type]
+    if rules is not None:
+        for key, spec in rules:
+            if lane not in spec.lanes:
+                continue
+            market_rules[key] = spec.model_dump(exclude={"lanes"})
+```
+
+Return it as:
+
+```python
+        "market_rules": market_rules,
+```
+
+If Pydantic model iteration does not preserve `(field_name, value)` typing under ty, use `for key in type(rules).model_fields` plus `getattr(rules, key)`; do not serialize and then re-parse the whole document.
+
+- [ ] **Step 4: Run service tests and verify green**
+
+Run: `uv run pytest tests/services/test_trading_policy_service.py -q`
+
+Expected: all tests PASS, including override and hash tests.
+
+- [ ] **Step 5: Commit service exposure**
+
+```bash
+git add app/services/trading_policy_service.py tests/services/test_trading_policy_service.py
+git commit -m "feat(ROB-839): expose crypto policy rules by lane"
+```
+
+### Task 3: MCP Contract and Documentation
+
+**Files:**
+- Modify: `tests/mcp_server/test_trading_policy_tool.py`
+- Modify: `app/mcp_server/README.md`
+
+**Interfaces:**
+- Consumes: `get_policy_for("crypto", "buy")` response including `market_rules`.
+- Produces: `await get_trading_policy(market="crypto", lane="buy")` with `success`, stamp, thresholds, decision rules, and market rules.
+
+- [ ] **Step 1: Write the failing MCP crypto exposure test**
+
+```python
+@pytest.mark.asyncio
+async def test_get_trading_policy_returns_crypto_market_rules_and_stamp():
+    out = await get_trading_policy(market="crypto", lane="buy")
+    assert out["success"] is True
+    assert out["version"] == "2026-07-12.1"
+    assert len(out["content_hash"]) == 12
+    assert out["market_rules"]["recovery_gate"]["min_conditions_met"] == 2
+    assert out["market_rules"]["no_chasing"]["daily_change_pct_threshold"] is None
+```
+
+Update the existing version assertion to `2026-07-12.1`.
+
+- [ ] **Step 2: Run MCP tests and verify the new assertion**
+
+Run: `uv run pytest tests/mcp_server/test_trading_policy_tool.py -q`
+
+Expected: PASS if Task 2 is correct; if it fails, the failure must identify a service-wrapper contract mismatch and be fixed without adding logic to the wrapper.
+
+- [ ] **Step 3: Document the additive field and advisory boundary**
+
+In the existing `get_trading_policy` section of `app/mcp_server/README.md`, add:
+
+```markdown
+- `market_rules`: market-specific advisory judgment rules filtered by lane.
+  Crypto includes the recovery gate, support/resistance source priority, and
+  no-chasing criteria. A `null` threshold is intentional and must not be
+  replaced by a caller-inferred number. These rules do not replace code-owned
+  fail-closed order guards.
+```
+
+- [ ] **Step 4: Run the complete targeted policy suite**
+
+Run:
+
+```bash
+uv run pytest \
+  tests/schemas/test_trading_policy_schema.py \
+  tests/services/test_trading_policy_service.py \
+  tests/mcp_server/test_trading_policy_tool.py -q
+```
+
+Expected: all tests PASS.
+
+- [ ] **Step 5: Commit MCP contract and docs**
+
+```bash
+git add tests/mcp_server/test_trading_policy_tool.py app/mcp_server/README.md
+git commit -m "docs(ROB-839): describe crypto policy rule exposure"
+```
+
+### Task 4: Final Verification
+
+**Files:**
+- Verify only; modify earlier files only if a check finds an in-scope defect.
+
+**Interfaces:**
+- Consumes: all contracts produced by Tasks 1-3.
+- Produces: evidence that tests and repository quality gates pass.
+
+- [ ] **Step 1: Run formatting and lint/type checks**
+
+Run: `make lint`
+
+Expected: exit code 0 with Ruff and ty clean.
+
+- [ ] **Step 2: Re-run targeted tests after formatter effects**
+
+Run:
+
+```bash
+uv run pytest \
+  tests/schemas/test_trading_policy_schema.py \
+  tests/services/test_trading_policy_service.py \
+  tests/mcp_server/test_trading_policy_tool.py -q
+```
+
+Expected: all tests PASS.
+
+- [ ] **Step 3: Validate the final diff and migration boundary**
+
+Run:
+
+```bash
+git diff --check origin/main...HEAD
+git diff --name-only origin/main...HEAD
+git status --short
+```
+
+Expected: no whitespace errors; only the policy, schema, service, tests, MCP README, and superpowers design/plan docs differ; no Alembic revision exists; worktree is clean.
+

--- a/docs/superpowers/plans/2026-07-12-rob-839-crypto-policy-rules.md
+++ b/docs/superpowers/plans/2026-07-12-rob-839-crypto-policy-rules.md
@@ -60,6 +60,7 @@ def test_crypto_market_rules_preserve_report_derived_and_null_thresholds():
         "fibonacci",
         "value_area",
         "bb_lower",
+        "bb_upper",
         "bb_middle",
         "volume_poc",
     ]
@@ -195,7 +196,7 @@ market_rules:
       advisory: true
       semantics: rank fresh levels by independent-source confluence before source priority
       selection_rule: confluence_first_then_source_priority
-      source_priority: [fibonacci, value_area, bb_lower, bb_middle, volume_poc]
+      source_priority: [fibonacci, value_area, bb_lower, bb_upper, bb_middle, volume_poc]
       confluence_examples:
         - [fib_0, value_area_low, bb_lower]
         - [bb_middle, fib_23_6]
@@ -412,4 +413,3 @@ git status --short
 ```
 
 Expected: no whitespace errors; only the policy, schema, service, tests, MCP README, and superpowers design/plan docs differ; no Alembic revision exists; worktree is clean.
-

--- a/docs/superpowers/specs/2026-07-12-rob-839-crypto-policy-rules-design.md
+++ b/docs/superpowers/specs/2026-07-12-rob-839-crypto-policy-rules-design.md
@@ -1,0 +1,184 @@
+# ROB-839 — Crypto Judgment Rules Policy Promotion
+
+## Goal
+
+Promote the crypto judgment rules that recent operator reports applied
+implicitly into `config/trading_policy.yaml`. The policy must reduce model
+discretion without inventing numeric cutoffs that the reports did not define.
+
+The change is advisory and read-only. It does not alter order execution,
+loss-sale guards, ladder guards, or database state.
+
+## Evidence
+
+The seed is limited to these operator reports:
+
+- `~/services/auto_trader-operator/reports/crypto-recheck-2026-07-11.md`
+- `~/services/auto_trader-operator/reports/crypto-recheck-2026-07-12.md`
+- `~/services/auto_trader-operator/reports/crypto-recheck-2026-07-12-opus.md`
+- `~/services/auto_trader-operator/reports/crypto-recheck-2026-07-12-fable.md`
+
+The reports explicitly support:
+
+- a four-input recovery frame using Fear & Greed, 24-hour alt breadth, BTC
+  global/top-trader long-short ratios, and BTC kimchi premium;
+- `2 of 4` as the minimum recovery-gate decision rule;
+- `breadth > 50%` and `BTC L/S <= 1.5` as numeric conditions;
+- support/resistance selection that favors multi-source confluence, repeatedly
+  using Fibonacci, value area, Bollinger lower/middle, and volume POC;
+- rejection of low-liquidity rotation-pump candidates, especially when alt
+  breadth is below 50%, and rejection of sharp movers without support structure
+  or decision history.
+
+The reports do not define a numeric Fear & Greed cutoff, kimchi-premium cutoff,
+same-day gain cutoff, or 24-hour traded-value floor for those judgments. These
+values must remain `null`; a model must not fill them by inference.
+
+## Policy Shape
+
+Add a typed top-level `market_rules` mapping. The crypto entry contains three
+named rules, each tagged with the lanes where it is relevant:
+
+```yaml
+market_rules:
+  crypto:
+    recovery_gate:
+      lanes: [buy]
+      advisory: true
+      min_conditions_met: 2
+      of: 4
+      conditions: [...]
+    support_resistance:
+      lanes: [buy, sell, discovery]
+      advisory: true
+      selection_rule: confluence_first_then_source_priority
+      source_priority: [...]
+      confluence_examples: [...]
+    no_chasing:
+      lanes: [buy, discovery]
+      advisory: true
+      daily_change_pct_threshold: null
+      min_trade_value_24h_krw: null
+      criteria: [...]
+      follow_up: ...
+```
+
+This is separate from `market_overrides`, which continues to override scalar
+threshold values. It is also separate from the existing global
+`decision_rules`, whose tier/action/sizing shape is specific to decisions such
+as `sell.trim_preplace` and does not fit evidence-source ranking or qualitative
+criteria.
+
+## Recovery Gate
+
+The four conditions are complete as inputs, even when their quantitative
+decision threshold is not yet defined:
+
+1. Fear & Greed: threshold `null`; retain the report language about a recovering
+   trend, but do not convert the observed value or streak into a cutoff.
+2. 24-hour alt breadth: `> 50 percent`.
+3. BTC long-short ratio: both global-account and top-trader-position inputs,
+   `<= 1.5 ratio`.
+4. BTC kimchi premium: threshold `null`; retain the report interpretation of a
+   discount/no-domestic-FOMO state without deciding whether it passes.
+
+The decision rule is `min_conditions_met: 2`, `of: 4`. A missing observation or
+a condition with no quantitative threshold is not guessed. The rule documents
+the advisory reserve-deployment frame; it does not enforce an order guard.
+
+## Support and Resistance Sources
+
+Selection is confluence-first. A level backed by multiple independent sources
+outranks a single-source level. When confluence count and reported strength do
+not settle the choice, use a stable source priority derived from the recurring
+report combinations:
+
+1. Fibonacci levels
+2. value-area levels
+3. Bollinger lower band
+4. Bollinger middle band
+5. volume POC
+
+The policy also records representative report-derived combinations, including
+`fib_0 + value_area_low + bb_lower`, `bb_middle + fib_23_6`, and
+`bb_middle + volume_poc`. These examples explain ranking; they do not calculate
+prices or replace fresh market analysis.
+
+## No-Chasing Rule
+
+The numeric fields intentionally remain `null`:
+
+- `daily_change_pct_threshold`
+- `min_trade_value_24h_krw`
+
+The fixed qualitative criteria are:
+
+- exclude low-liquidity rotation-pump candidates;
+- treat new alt entries as ineligible when 24-hour alt breadth is below 50%;
+- exclude sharply rising candidates that lack a support structure or decision
+  history.
+
+The YAML comment and a structured `follow_up` string state that operator
+experience must establish the numeric cutoffs in a later operator PR. Until
+then, consumers must cite the qualitative criteria and `null`, not substitute
+their own numbers.
+
+## Loader and Response Contract
+
+`TradingPolicyDocument` gains strict Pydantic models for the new mapping and its
+three crypto rule shapes. `extra="forbid"` remains in force at every new level.
+Nullable thresholds are explicitly typed rather than represented by missing
+keys.
+
+`get_policy_for(market, lane)` adds a `market_rules` object containing only the
+rules whose `lanes` include the requested lane. Existing response fields remain
+unchanged:
+
+- `market`
+- `lane`
+- `version`
+- `content_hash`
+- `thresholds`
+- `decision_rules`
+
+The MCP `get_trading_policy` wrapper continues to return the service response
+with `success: true`. The existing `{version, content_hash}` stamp remains the
+contract: version comes from YAML and content hash remains the first 12 hex
+characters of SHA-256 over the raw YAML bytes.
+
+The policy version becomes `2026-07-12.1`; `captured_as_of` and `source` are
+updated to identify ROB-839 and the four operator reports.
+
+## Boundaries
+
+- All new rules are `advisory: true`.
+- No execution path consumes these rules as a hard guard in this change.
+- Loss-sale and ladder fail-closed guards remain code-owned and unchanged.
+- Existing scalar threshold overrides remain unchanged.
+- No database model or migration changes.
+- No operator report or external operator workspace file is modified.
+
+## Test Strategy
+
+Implementation follows TDD:
+
+1. Schema tests first:
+   - shipped YAML validates;
+   - all four recovery inputs and explicit/null thresholds deserialize;
+   - support source priority and no-chasing nulls deserialize;
+   - unknown keys in nested market-rule objects fail validation.
+2. Service tests next:
+   - crypto buy exposes all three applicable rules plus the version stamp;
+   - crypto discovery exposes support/resistance and no-chasing, not the buy-only
+     recovery gate;
+   - crypto sell exposes support/resistance only;
+   - non-crypto markets expose no crypto market rules;
+   - existing thresholds, decision rules, overrides, and hash behavior remain
+     intact.
+3. MCP tests last:
+   - `get_trading_policy(market="crypto", lane="buy")` exposes the filtered rules
+     and `{version, content_hash}`.
+
+Targeted tests run after each red/green cycle. Final verification runs the
+relevant schema/service/MCP suites and `make lint`.
+

--- a/docs/superpowers/specs/2026-07-12-rob-839-crypto-policy-rules-design.md
+++ b/docs/superpowers/specs/2026-07-12-rob-839-crypto-policy-rules-design.md
@@ -96,8 +96,9 @@ report combinations:
 1. Fibonacci levels
 2. value-area levels
 3. Bollinger lower band
-4. Bollinger middle band
-5. volume POC
+4. Bollinger upper band
+5. Bollinger middle band
+6. volume POC
 
 The policy also records representative report-derived combinations, including
 `fib_0 + value_area_low + bb_lower`, `bb_middle + fib_23_6`, and
@@ -181,4 +182,3 @@ Implementation follows TDD:
 
 Targeted tests run after each red/green cycle. Final verification runs the
 relevant schema/service/MCP suites and `make lint`.
-

--- a/tests/mcp_server/test_operating_briefing_policy_version.py
+++ b/tests/mcp_server/test_operating_briefing_policy_version.py
@@ -51,5 +51,5 @@ async def test_briefing_includes_policy_version(monkeypatch):
 
     resp = await ob.get_operating_briefing_impl(market="kr")
     assert "policy_version" in resp
-    assert resp["policy_version"]["version"] == "2026-07-07.1"
+    assert resp["policy_version"]["version"] == "2026-07-12.1"
     assert resp["policy_version"]["content_hash"]

--- a/tests/mcp_server/test_trading_policy_tool.py
+++ b/tests/mcp_server/test_trading_policy_tool.py
@@ -12,10 +12,23 @@ from tests._mcp_tooling_support import DummyMCP
 async def test_get_trading_policy_returns_thresholds_and_version():
     out = await get_trading_policy(market="kr", lane="buy")
     assert out["success"] is True
-    assert out["version"] == "2026-07-07.1"
+    assert out["version"] == "2026-07-12.1"
     assert out["content_hash"]
     assert out["thresholds"]["portfolio.sector_cluster_cap_pct"]["value"] == 10
     assert out["decision_rules"] == {}
+
+
+@pytest.mark.asyncio
+async def test_get_trading_policy_returns_crypto_market_rules_and_stamp():
+    out = await get_trading_policy(market="crypto", lane="buy")
+
+    assert out["success"] is True
+    assert out["version"] == "2026-07-12.1"
+    assert len(out["content_hash"]) == 12
+    assert out["market_rules"]["recovery_gate"]["min_conditions_met"] == 2
+    assert (
+        out["market_rules"]["no_chasing"]["daily_change_pct_threshold"] is None
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/mcp_server/test_trading_policy_tool.py
+++ b/tests/mcp_server/test_trading_policy_tool.py
@@ -26,9 +26,7 @@ async def test_get_trading_policy_returns_crypto_market_rules_and_stamp():
     assert out["version"] == "2026-07-12.1"
     assert len(out["content_hash"]) == 12
     assert out["market_rules"]["recovery_gate"]["min_conditions_met"] == 2
-    assert (
-        out["market_rules"]["no_chasing"]["daily_change_pct_threshold"] is None
-    )
+    assert out["market_rules"]["no_chasing"]["daily_change_pct_threshold"] is None
 
 
 @pytest.mark.asyncio

--- a/tests/schemas/test_trading_policy_schema.py
+++ b/tests/schemas/test_trading_policy_schema.py
@@ -64,6 +64,7 @@ def test_crypto_market_rules_preserve_report_derived_and_null_thresholds():
         "fibonacci",
         "value_area",
         "bb_lower",
+        "bb_upper",
         "bb_middle",
         "volume_poc",
     ]

--- a/tests/schemas/test_trading_policy_schema.py
+++ b/tests/schemas/test_trading_policy_schema.py
@@ -15,7 +15,7 @@ def _raw() -> dict:
 
 def test_shipped_config_validates():
     doc = TradingPolicyDocument.model_validate(_raw())
-    assert doc.version == "2026-07-07.1"
+    assert doc.version == "2026-07-12.1"
     # verbatim seed values from the playbook policy_keys
     assert doc.thresholds["portfolio.sector_cluster_cap_pct"].value == 10
     assert doc.thresholds["sell.loss_guard_min_multiple"].value == 1.01
@@ -33,6 +33,40 @@ def test_shipped_config_validates():
     ]
     assert trim_rule.tiers[1].conditions["resistance_near_pct_max"] == 2
     assert trim_rule.tie_breaks["sell.upside_place_max_pct"] == "size_limit_only"
+
+
+def test_crypto_market_rules_preserve_report_derived_and_null_thresholds():
+    doc = TradingPolicyDocument.model_validate(_raw())
+    rules = doc.market_rules["crypto"]
+    gate = rules.recovery_gate
+
+    assert gate.min_conditions_met == 2
+    assert gate.of == 4
+    assert [condition.id for condition in gate.conditions] == [
+        "fear_greed",
+        "alt_breadth_24h",
+        "btc_long_short_ratio",
+        "btc_kimchi_premium",
+    ]
+    assert gate.conditions[0].threshold is None
+    assert (gate.conditions[1].operator, gate.conditions[1].threshold) == (
+        "gt",
+        50,
+    )
+    assert (gate.conditions[2].operator, gate.conditions[2].threshold) == (
+        "lte",
+        1.5,
+    )
+    assert gate.conditions[3].threshold is None
+    assert rules.no_chasing.daily_change_pct_threshold is None
+    assert rules.no_chasing.min_trade_value_24h_krw is None
+    assert rules.support_resistance.source_priority == [
+        "fibonacci",
+        "value_area",
+        "bb_lower",
+        "bb_middle",
+        "volume_poc",
+    ]
 
 
 def test_decision_rule_schema_accepts_sell_trim_preplace_block():
@@ -75,5 +109,12 @@ def test_extra_key_rejected():
 def test_extra_threshold_key_rejected():
     raw = _raw()
     raw["thresholds"]["screen.rsi_max"]["bogus"] = 1
+    with pytest.raises(ValidationError):
+        TradingPolicyDocument.model_validate(raw)
+
+
+def test_extra_crypto_market_rule_key_rejected():
+    raw = _raw()
+    raw["market_rules"]["crypto"]["no_chasing"]["bogus"] = True
     with pytest.raises(ValidationError):
         TradingPolicyDocument.model_validate(raw)

--- a/tests/services/test_trading_policy_service.py
+++ b/tests/services/test_trading_policy_service.py
@@ -5,7 +5,7 @@ from app.services import trading_policy_service as svc
 
 def test_version_stamp_has_version_and_hash():
     stamp = svc.policy_version_stamp()
-    assert stamp["version"] == "2026-07-07.1"
+    assert stamp["version"] == "2026-07-12.1"
     assert len(stamp["content_hash"]) == 12
 
 
@@ -15,7 +15,7 @@ def test_content_hash_stable_across_calls():
 
 def test_get_policy_for_buy_kr_includes_cap_and_version():
     view = svc.get_policy_for("kr", "buy")
-    assert view["version"] == "2026-07-07.1"
+    assert view["version"] == "2026-07-12.1"
     assert view["content_hash"]
     t = view["thresholds"]
     # buy lane references these (playbook lane tags)
@@ -26,6 +26,35 @@ def test_get_policy_for_buy_kr_includes_cap_and_version():
     # sell-only threshold must NOT appear in the buy lane
     assert "sell.rsi_place_min" not in t
     assert view["decision_rules"] == {}
+
+
+def test_get_policy_for_crypto_buy_exposes_report_derived_market_rules():
+    view = svc.get_policy_for("crypto", "buy")
+
+    assert view["version"] == "2026-07-12.1"
+    assert set(view["market_rules"]) == {
+        "recovery_gate",
+        "support_resistance",
+        "no_chasing",
+    }
+    gate = view["market_rules"]["recovery_gate"]
+    assert gate["min_conditions_met"] == 2
+    assert gate["of"] == 4
+    assert "lanes" not in gate
+    assert (
+        view["market_rules"]["no_chasing"]["daily_change_pct_threshold"]
+        is None
+    )
+
+
+def test_get_policy_for_filters_crypto_market_rules_by_lane():
+    discovery = svc.get_policy_for("crypto", "discovery")["market_rules"]
+    assert set(discovery) == {"support_resistance", "no_chasing"}
+
+    sell = svc.get_policy_for("crypto", "sell")["market_rules"]
+    assert set(sell) == {"support_resistance"}
+
+    assert svc.get_policy_for("kr", "buy")["market_rules"] == {}
 
 
 def test_get_policy_for_sell_lane_has_sell_keys():

--- a/tests/services/test_trading_policy_service.py
+++ b/tests/services/test_trading_policy_service.py
@@ -41,10 +41,7 @@ def test_get_policy_for_crypto_buy_exposes_report_derived_market_rules():
     assert gate["min_conditions_met"] == 2
     assert gate["of"] == 4
     assert "lanes" not in gate
-    assert (
-        view["market_rules"]["no_chasing"]["daily_change_pct_threshold"]
-        is None
-    )
+    assert view["market_rules"]["no_chasing"]["daily_change_pct_threshold"] is None
 
 
 def test_get_policy_for_filters_crypto_market_rules_by_lane():


### PR DESCRIPTION
## Summary

- Add strict, typed `market_rules.crypto` policy blocks for the advisory 2-of-4 recovery frame, support/resistance source priority, and no-chasing criteria.
- Filter market-specific rules by `buy` / `sell` / `discovery` in `get_policy_for` and expose them through `get_trading_policy(market="crypto", lane=...)` with the existing `{version, content_hash}` stamp.
- Preserve report gaps explicitly: Fear & Greed, kimchi premium, same-day gain, and 24-hour liquidity thresholds remain `null`; callers are told not to infer replacements.
- Keep execution safety separate: loss-sale and ladder fail-closed guards are unchanged, and this PR has no migration.
- Synchronize MCP documentation, operating-briefing stamp coverage, design/implementation docs, and the Unreleased changelog.

## Policy evidence

Seeded from the operator workspace reports for 2026-07-11 and the Sonnet, Opus, and Fable 2026-07-12 rechecks. Numeric policy values are limited to report-explicit values: alt breadth `> 50%`, BTC L/S `<= 1.5`, and `2 of 4` recovery conditions.

## Test Coverage

All new service branches are covered: crypto/non-crypto selection, buy/discovery/sell lane filtering, nullable thresholds, nested schema rejection, MCP passthrough, and operating-briefing version stamping.

## Pre-Landing Review

No unresolved issues. The review auto-fixed the MCP response-shape documentation, added the report-used `bb_upper` resistance source, and updated the operating-briefing policy-version assertion.

## Scope Drift

Scope Check: CLEAN. Judgment policy and read-only exposure only; no execution guard, broker mutation, model, or migration changes.

## Plan Completion

All implementation-plan items are addressed: strict schema/YAML, lane-filtered service exposure, MCP contract/docs, TDD coverage, and lint/type verification.

## Follow-up

- Keep `daily_change_pct_threshold` and `min_trade_value_24h_krw` as `null` until operator live evidence establishes quantitative no-chasing cutoffs; fill them only in a later operator PR.
- Fear & Greed and kimchi-premium pass thresholds are likewise intentionally `null` because the source reports provide qualitative interpretation but no decision cutoff.

## Verification Results

- `make lint` — Ruff check, Ruff format check, and ty all clean.
- 76 targeted policy/routing regression tests passed.
- `git diff --check origin/main...HEAD` passed.
- Alembic changes: 0.

## Test plan

- [x] Validate shipped YAML and strict nested schema.
- [x] Verify crypto rules are filtered for buy, sell, and discovery lanes.
- [x] Verify MCP and operating-briefing `{version, content_hash}` contracts.
- [x] Run policy, loss-cut-policy, and route-request regression suites.

Linear: ROB-839


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added crypto market rules to trading policy responses, including recovery, support/resistance, and no-chasing guidance.
  - Crypto rules are filtered according to the requested trading lane.
  - Explicitly preserved `null` thresholds without inferring missing values.

- **Documentation**
  - Updated the trading policy contract and changelog to describe the new response data and advisory rules.
  - Updated the policy version and source metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->