### PR TITLE
fix(ROB-837): converge Upbit proposal submits from broker evidence

### DIFF
--- a/app/mcp_server/tooling/order_execution.py
+++ b/app/mcp_server/tooling/order_execution.py
@@ -1216,6 +1216,7 @@ async def _place_order_impl(
     rung: str | int | None = None,
     mirror_cohort: str | None = None,
     mirror_source_bucket: str | None = None,
+    client_order_id: str | None = None,
 ) -> dict[str, Any]:
     symbol, side_lower, order_type_lower = _validate_inputs(
         symbol,
@@ -1227,6 +1228,18 @@ async def _place_order_impl(
     )
 
     market_type, normalized_symbol = _resolve_market_type(symbol, market)
+    source_map = {"crypto": "upbit", "equity_kr": "kis", "equity_us": "kis"}
+    source = source_map[market_type]
+
+    def _order_error(message: str) -> dict[str, Any]:
+        return _build_order_error(message, source, normalized_symbol, market_type)
+
+    if client_order_id is not None and (
+        not isinstance(client_order_id, str)
+        or not client_order_id.strip()
+        or len(client_order_id) > 40
+    ):
+        return _order_error("client_order_id must be non-blank and at most 40 characters")
 
     # Validate buy order journal requirements before any external API calls.
     # Skipped for KIS mock: mock orders write to kis_mock_order_ledger and
@@ -1247,12 +1260,6 @@ async def _place_order_impl(
                 "symbol": normalized_symbol,
                 "instrument_type": market_type,
             }
-
-    source_map = {"crypto": "upbit", "equity_kr": "kis", "equity_us": "kis"}
-    source = source_map[market_type]
-
-    def _order_error(message: str) -> dict[str, Any]:
-        return _build_order_error(message, source, normalized_symbol, market_type)
 
     if market_type == "crypto" and is_mock:
         return _order_error(_MOCK_CRYPTO_ERROR)
@@ -1433,8 +1440,11 @@ async def _place_order_impl(
         )
         now = now_kst()
         salt_market = order_approval.salt_market_for(market_type)
-        idempotency_key = order_approval.derive_client_order_id(
-            canonical, market=salt_market, now=now, rung=rung
+        idempotency_key = client_order_id or order_approval.derive_client_order_id(
+            canonical,
+            market=salt_market,
+            now=now,
+            rung=rung,
         )
 
         # Dry-run exit — the preview emits the approval token operators pass back.

--- a/app/mcp_server/tooling/order_execution.py
+++ b/app/mcp_server/tooling/order_execution.py
@@ -1239,7 +1239,9 @@ async def _place_order_impl(
         or not client_order_id.strip()
         or len(client_order_id) > 40
     ):
-        return _order_error("client_order_id must be non-blank and at most 40 characters")
+        return _order_error(
+            "client_order_id must be non-blank and at most 40 characters"
+        )
 
     # Validate buy order journal requirements before any external API calls.
     # Skipped for KIS mock: mock orders write to kis_mock_order_ledger and

--- a/app/services/brokers/upbit/__init__.py
+++ b/app/services/brokers/upbit/__init__.py
@@ -6,6 +6,7 @@ from app.services.brokers.upbit.orders import (  # noqa: F401
     cancel_orders,
     fetch_closed_orders,
     fetch_open_orders,
+    fetch_order_by_identifier,
     fetch_order_detail,
     place_buy_order,
     place_market_buy_order,

--- a/app/services/brokers/upbit/client.py
+++ b/app/services/brokers/upbit/client.py
@@ -118,7 +118,7 @@ async def _retry_with_backoff(
     retry_request_errors
         Whether to retry on ``httpx.RequestError`` (timeouts/network). ROB-645:
         order-creation POSTs pass ``False`` so a timed-out order is never re-sent
-        (429 rate-limit retries are unaffected and still apply).
+        (ROB-837 also gives order creation a zero retry budget, including 429).
     """
     if max_retries is None:
         max_retries = settings.api_rate_limit_retry_429_max

--- a/app/services/brokers/upbit/client.py
+++ b/app/services/brokers/upbit/client.py
@@ -913,6 +913,7 @@ def __getattr__(name: str) -> Any:
         "cancel_orders",
         "fetch_closed_orders",
         "fetch_open_orders",
+        "fetch_order_by_identifier",
         "fetch_order_detail",
         "place_buy_order",
         "place_market_buy_order",

--- a/app/services/brokers/upbit/client.py
+++ b/app/services/brokers/upbit/client.py
@@ -883,9 +883,9 @@ async def _request_with_auth(
             else:
                 raise ValueError(f"지원하지 않는 HTTP 메서드: {method}")
 
-    # ROB-645: order-creation POSTs (POST /v1/orders) must not retry RequestError —
-    # a timed-out order may have reached the broker, so a retry would double-submit.
-    # Reads (GET) and cancels (DELETE /order) keep the existing RequestError retry.
+    # ROB-645: order-creation POSTs (POST /v1/orders) must not retry transport
+    # errors or 429 responses — an order may have reached the broker, so a retry
+    # would double-submit. Reads (GET) and cancels (DELETE /order) keep retries.
     #
     # ROB-659 constraint note: submission is detected purely by the trailing
     # ``/orders`` path segment (method POST + api_path suffix). This holds because
@@ -897,7 +897,11 @@ async def _request_with_auth(
         "/orders"
     )
     return await _retry_with_backoff(
-        limiter, send, url=url, retry_request_errors=not is_order_submission
+        limiter,
+        send,
+        url=url,
+        max_retries=0 if is_order_submission else None,
+        retry_request_errors=not is_order_submission,
     )
 
 

--- a/app/services/brokers/upbit/orders.py
+++ b/app/services/brokers/upbit/orders.py
@@ -291,6 +291,18 @@ async def fetch_order_detail(order_uuid: str) -> dict[str, Any]:
     return await _client._request_with_auth("GET", url, query_params=params)
 
 
+async def fetch_order_by_identifier(identifier: str) -> dict[str, Any]:
+    """클라이언트 식별자로 단건 주문을 조회합니다."""
+    candidate = str(identifier or "").strip()
+    if not candidate:
+        raise ValueError("identifier is required")
+    return await _client._request_with_auth(
+        "GET",
+        f"{_client.UPBIT_REST}/order",
+        query_params={"identifier": candidate},
+    )
+
+
 def adjust_price_to_upbit_unit(price: float) -> float:
     """업비트 가격 단위에 맞게 가격을 조정합니다.
 

--- a/app/services/order_proposals/broker_gateway.py
+++ b/app/services/order_proposals/broker_gateway.py
@@ -85,9 +85,7 @@ async def fetch_submit_evidence(
     if (account_mode, market) != ("upbit", "crypto"):
         return SubmitEvidence(
             "unknown",
-            reason=(
-                f"submit evidence lookup unsupported for {account_mode}/{market}"
-            ),
+            reason=(f"submit evidence lookup unsupported for {account_mode}/{market}"),
         )
     if lookup_fn is None:
         from app.services.brokers.upbit.orders import fetch_order_by_identifier

--- a/app/services/order_proposals/broker_gateway.py
+++ b/app/services/order_proposals/broker_gateway.py
@@ -2,9 +2,13 @@ from __future__ import annotations
 
 import inspect
 from collections.abc import Callable
+from dataclasses import dataclass
 from datetime import datetime
-from typing import Any
+from typing import Any, Literal
 
+import httpx
+
+from app.core.exceptions import describe_exception
 from app.services.order_proposals.errors import OrderProposalError
 from app.services.order_proposals.target_order import TargetOrderSnapshot
 
@@ -15,6 +19,14 @@ SUPPORTED_TARGET_ACTIONS = frozenset(
         ("upbit", "crypto"),
     }
 )
+
+
+@dataclass(frozen=True)
+class SubmitEvidence:
+    outcome: Literal["found", "absent", "unknown"]
+    broker_order_id: str | None = None
+    broker_state: str | None = None
+    reason: str | None = None
 
 
 async def _maybe_await(value: Any) -> Any:
@@ -61,6 +73,43 @@ async def fetch_target_order(
     if len(matches) != 1:
         raise OrderProposalError("target broker order not found uniquely")
     return TargetOrderSnapshot.from_broker_order(matches[0], observed_at=now)
+
+
+async def fetch_submit_evidence(
+    *,
+    identifier: str,
+    account_mode: str,
+    market: str,
+    lookup_fn: Callable[..., Any] | None = None,
+) -> SubmitEvidence:
+    if (account_mode, market) != ("upbit", "crypto"):
+        return SubmitEvidence(
+            "unknown",
+            reason=(
+                f"submit evidence lookup unsupported for {account_mode}/{market}"
+            ),
+        )
+    if lookup_fn is None:
+        from app.services.brokers.upbit.orders import fetch_order_by_identifier
+
+        lookup_fn = fetch_order_by_identifier
+
+    try:
+        order = await _maybe_await(lookup_fn(identifier))
+        broker_order_id = str(order.get("uuid") or "").strip()
+        broker_state = str(order.get("state") or "").strip()
+        if not broker_order_id or not broker_state:
+            return SubmitEvidence(
+                "unknown",
+                reason="broker lookup returned incomplete order evidence",
+            )
+        return SubmitEvidence("found", broker_order_id, broker_state)
+    except httpx.HTTPStatusError as exc:
+        if exc.response.status_code == 404:
+            return SubmitEvidence("absent")
+        return SubmitEvidence("unknown", reason=describe_exception(exc))
+    except Exception as exc:
+        return SubmitEvidence("unknown", reason=describe_exception(exc))
 
 
 async def cancel_target_order(

--- a/app/services/order_proposals/revalidation.py
+++ b/app/services/order_proposals/revalidation.py
@@ -140,6 +140,11 @@ def _toss_proposal_client_order_id(proposal_id: uuid.UUID, rung_index: int) -> s
     return f"tosprop-{digest}"
 
 
+def _proposal_client_order_id(proposal_id: uuid.UUID, rung_index: int) -> str:
+    digest = hashlib.sha256(f"{proposal_id}:{rung_index}".encode()).hexdigest()[:32]
+    return f"oprop-{digest}"
+
+
 def _adapt_toss_preview_response(preview: dict[str, Any]) -> dict[str, Any]:
     """Expose Toss's normalized wire payload through the proposal contract."""
     payload = preview.get("payload_preview")
@@ -321,6 +326,8 @@ async def _default_place_order_fn(**kwargs: Any) -> dict[str, Any]:
     # activation smoke, KRW-BTC canary). Normalize at this caller boundary;
     # the impl's float contract stays unchanged for every other caller.
     kwargs = {k: (float(v) if isinstance(v, Decimal) else v) for k, v in kwargs.items()}
+    if proposal_client_order_id is not None:
+        kwargs["client_order_id"] = str(proposal_client_order_id)
 
     submit = await _place_order_impl(**kwargs)
     if kwargs.get("dry_run") is False:
@@ -410,9 +417,11 @@ async def _revalidate_place_rung(
 ) -> RungOutcome:
     proposal_id = group.proposal_id
     rung_index = rung.rung_index
-    toss_client_order_id = (
+    proposal_client_order_id = (
         _toss_proposal_client_order_id(proposal_id, rung_index)
         if group.account_mode == "toss_live"
+        else _proposal_client_order_id(proposal_id, rung_index)
+        if group.account_mode == "upbit"
         else None
     )
 
@@ -438,8 +447,8 @@ async def _revalidate_place_rung(
                 reason=_PREVIEW_REASON.format(rung=rung_index),
                 rung=rung_index,
                 **(
-                    {"proposal_client_order_id": toss_client_order_id}
-                    if toss_client_order_id is not None
+                    {"proposal_client_order_id": proposal_client_order_id}
+                    if proposal_client_order_id is not None
                     else {}
                 ),
             )
@@ -464,10 +473,10 @@ async def _revalidate_place_rung(
             {"error": preview.get("error"), "preview": preview},
         )
 
-    if toss_client_order_id is not None:
+    if group.account_mode == "toss_live":
         invalid_reason = _invalid_toss_preview_reason(
             preview,
-            expected_client_order_id=toss_client_order_id,
+            expected_client_order_id=proposal_client_order_id,
             order_type=group.order_type,
         )
         if invalid_reason is not None:
@@ -532,8 +541,8 @@ async def _revalidate_place_rung(
                 reason=_SUBMIT_REASON.format(rung=rung_index),
                 approval_hash=preview.get("approval_hash"),
                 **(
-                    {"proposal_client_order_id": toss_client_order_id}
-                    if toss_client_order_id is not None
+                    {"proposal_client_order_id": proposal_client_order_id}
+                    if proposal_client_order_id is not None
                     else {}
                 ),
                 rung=rung_index,

--- a/app/services/order_proposals/revalidation.py
+++ b/app/services/order_proposals/revalidation.py
@@ -386,6 +386,7 @@ async def revalidate_and_submit(
                 fetch_target_fn=fetch_target_fn,
                 cancel_target_fn=cancel_target_fn,
                 correlation_mint=correlation_mint,
+                fetch_submit_evidence_fn=fetch_submit_evidence_fn,
             )
         elif action == "cancel":
             outcome = await _revalidate_cancel_rung(
@@ -678,6 +679,7 @@ async def _revalidate_replace_preview(
     rung: OrderProposalRung,
     now: datetime,
     place_order_fn: PlaceOrderFn,
+    proposal_client_order_id: str | None,
 ) -> tuple[dict[str, Any] | None, RungOutcome | None]:
     proposal_id = group.proposal_id
     rung_index = rung.rung_index
@@ -699,6 +701,12 @@ async def _revalidate_replace_preview(
                 approval_issue_id=group.approval_issue_id,
                 reason=_PREVIEW_REASON.format(rung=rung_index),
                 rung=rung_index,
+                account_mode=group.account_mode,
+                **(
+                    {"proposal_client_order_id": proposal_client_order_id}
+                    if proposal_client_order_id is not None
+                    else {}
+                ),
             )
         )
     except Exception as exc:
@@ -832,7 +840,13 @@ async def _revalidate_replace_rung(
     fetch_target_fn: TargetFetchFn,
     cancel_target_fn: TargetCancelFn,
     correlation_mint: CorrelationMint,
+    fetch_submit_evidence_fn: SubmitEvidenceFetchFn,
 ) -> RungOutcome:
+    proposal_client_order_id = (
+        _proposal_client_order_id(group.proposal_id, rung.rung_index)
+        if group.account_mode == "upbit"
+        else None
+    )
     target_outcome = await _validate_target_action(
         service=service,
         group=group,
@@ -849,6 +863,7 @@ async def _revalidate_replace_rung(
         rung=rung,
         now=now,
         place_order_fn=place_order_fn,
+        proposal_client_order_id=proposal_client_order_id,
     )
     if preview_outcome is not None:
         return preview_outcome
@@ -889,9 +904,29 @@ async def _revalidate_replace_rung(
                 approval_hash=preview.get("approval_hash"),
                 rung=rung_index,
                 correlation_id=corr,
+                account_mode=group.account_mode,
+                **(
+                    {"proposal_client_order_id": proposal_client_order_id}
+                    if proposal_client_order_id is not None
+                    else {}
+                ),
             )
         )
     except Exception as exc:
+        if group.account_mode == "upbit":
+            return await _classify_submit(
+                service=service,
+                proposal_id=proposal_id,
+                rung_index=rung_index,
+                preview=preview,
+                submit={"success": False, "error": str(exc)},
+                corr=corr,
+                now=now,
+                account_mode=group.account_mode,
+                market=group.market,
+                identifier=proposal_client_order_id,
+                fetch_submit_evidence_fn=fetch_submit_evidence_fn,
+            )
         await service.record_unverified(
             proposal_id,
             rung_index,
@@ -911,8 +946,8 @@ async def _revalidate_replace_rung(
         now=now,
         account_mode=group.account_mode,
         market=group.market,
-        identifier=None,
-        fetch_submit_evidence_fn=fetch_submit_evidence,
+        identifier=proposal_client_order_id,
+        fetch_submit_evidence_fn=fetch_submit_evidence_fn,
     )
 
 
@@ -1074,7 +1109,9 @@ async def _classify_submit(
         now=now,
         correlation_id=corr,
         idempotency_key=(
-            submit.get("idempotency_key") or preview.get("idempotency_key")
+            identifier
+            or submit.get("idempotency_key")
+            or preview.get("idempotency_key")
         ),
     )
     return RungOutcome(rung_index, "unverified", {"submit": submit})

--- a/app/services/order_proposals/revalidation.py
+++ b/app/services/order_proposals/revalidation.py
@@ -987,12 +987,12 @@ async def _classify_submit(
             )
             if evidence.outcome == "found":
                 status = (
-                    "resting"
-                    if evidence.broker_state in {"wait", "watch"}
-                    else "acked"
+                    "resting" if evidence.broker_state in {"wait", "watch"} else "acked"
                 )
                 record_fn = (
-                    service.record_resting if status == "resting" else service.record_ack
+                    service.record_resting
+                    if status == "resting"
+                    else service.record_ack
                 )
                 await record_fn(
                     proposal_id,
@@ -1016,8 +1016,7 @@ async def _classify_submit(
                     proposal_id,
                     rung_index,
                     reason=(
-                        "submit_evidence_unknown:"
-                        f"{evidence.reason or original_error}"
+                        f"submit_evidence_unknown:{evidence.reason or original_error}"
                     ),
                     now=now,
                     correlation_id=corr,

--- a/app/services/order_proposals/revalidation.py
+++ b/app/services/order_proposals/revalidation.py
@@ -36,6 +36,7 @@ from app.models.order_proposals import OrderProposal, OrderProposalRung
 from app.services.live_correlation import live_correlation_id
 from app.services.order_proposals.broker_gateway import (
     cancel_target_order,
+    fetch_submit_evidence,
     fetch_target_order,
 )
 from app.services.order_proposals.service import OrderProposalsService
@@ -63,6 +64,7 @@ PlaceOrderFn = Callable[..., Any]
 CorrelationMint = Callable[..., Any]
 TargetFetchFn = Callable[..., Any]
 TargetCancelFn = Callable[..., Any]
+SubmitEvidenceFetchFn = Callable[..., Any]
 
 _PREVIEW_REASON = "order_proposal revalidation (rung {rung})"
 _SUBMIT_REASON = "order_proposal submit after revalidation (rung {rung})"
@@ -360,6 +362,7 @@ async def revalidate_and_submit(
     correlation_mint: CorrelationMint = _default_correlation_mint,
     fetch_target_fn: TargetFetchFn = fetch_target_order,
     cancel_target_fn: TargetCancelFn = cancel_target_order,
+    fetch_submit_evidence_fn: SubmitEvidenceFetchFn = fetch_submit_evidence,
 ) -> list[RungOutcome]:
     """Revalidate + (maybe) submit every ``pending_approval`` rung.
 
@@ -401,6 +404,7 @@ async def revalidate_and_submit(
                 now=now,
                 place_order_fn=place_order_fn,
                 correlation_mint=correlation_mint,
+                fetch_submit_evidence_fn=fetch_submit_evidence_fn,
             )
         outcomes.append(outcome)
     return outcomes
@@ -414,6 +418,7 @@ async def _revalidate_place_rung(
     now: datetime,
     place_order_fn: PlaceOrderFn,
     correlation_mint: CorrelationMint,
+    fetch_submit_evidence_fn: SubmitEvidenceFetchFn,
 ) -> RungOutcome:
     proposal_id = group.proposal_id
     rung_index = rung.rung_index
@@ -550,6 +555,20 @@ async def _revalidate_place_rung(
             )
         )
     except Exception as exc:  # noqa: BLE001 - broker call; ambiguous, not a void
+        if group.account_mode == "upbit":
+            return await _classify_submit(
+                service=service,
+                proposal_id=proposal_id,
+                rung_index=rung_index,
+                preview=preview,
+                submit={"success": False, "error": str(exc)},
+                corr=corr,
+                now=now,
+                account_mode=group.account_mode,
+                market=group.market,
+                identifier=proposal_client_order_id,
+                fetch_submit_evidence_fn=fetch_submit_evidence_fn,
+            )
         await service.record_unverified(
             proposal_id,
             rung_index,
@@ -568,6 +587,10 @@ async def _revalidate_place_rung(
         submit=submit,
         corr=corr,
         now=now,
+        account_mode=group.account_mode,
+        market=group.market,
+        identifier=proposal_client_order_id,
+        fetch_submit_evidence_fn=fetch_submit_evidence_fn,
     )
 
 
@@ -886,6 +909,10 @@ async def _revalidate_replace_rung(
         submit=submit,
         corr=corr,
         now=now,
+        account_mode=group.account_mode,
+        market=group.market,
+        identifier=None,
+        fetch_submit_evidence_fn=fetch_submit_evidence,
     )
 
 
@@ -941,15 +968,71 @@ async def _classify_submit(
     submit: dict[str, Any],
     corr: str,
     now: datetime,
+    account_mode: str,
+    market: str,
+    identifier: str | None,
+    fetch_submit_evidence_fn: SubmitEvidenceFetchFn,
 ) -> RungOutcome:
     success = submit.get("success")
 
     if success is False:
+        original_error = str(submit.get("error") or "submit_rejected")
+        if account_mode == "upbit" and identifier is not None:
+            evidence = await _maybe_await(
+                fetch_submit_evidence_fn(
+                    identifier=identifier,
+                    account_mode=account_mode,
+                    market=market,
+                )
+            )
+            if evidence.outcome == "found":
+                status = (
+                    "resting"
+                    if evidence.broker_state in {"wait", "watch"}
+                    else "acked"
+                )
+                record_fn = (
+                    service.record_resting if status == "resting" else service.record_ack
+                )
+                await record_fn(
+                    proposal_id,
+                    rung_index,
+                    broker_order_id=evidence.broker_order_id,
+                    correlation_id=corr,
+                    idempotency_key=identifier,
+                    approval_hash_digest=preview.get("approval_hash"),
+                    now=now,
+                )
+                result: RungOutcomeResult = (
+                    "submitted_resting" if status == "resting" else "submitted_acked"
+                )
+                return RungOutcome(
+                    rung_index,
+                    result,
+                    {"submit": submit, "submit_evidence": evidence},
+                )
+            if evidence.outcome == "unknown":
+                await service.record_unverified(
+                    proposal_id,
+                    rung_index,
+                    reason=(
+                        "submit_evidence_unknown:"
+                        f"{evidence.reason or original_error}"
+                    ),
+                    now=now,
+                    correlation_id=corr,
+                    idempotency_key=identifier,
+                )
+                return RungOutcome(
+                    rung_index,
+                    "unverified",
+                    {"error": original_error, "submit_evidence": evidence},
+                )
         # Explicit broker/guard rejection — not ambiguous, safe to terminalize.
         await service.record_rejected(
             proposal_id,
             rung_index,
-            reason=str(submit.get("error") or "submit_rejected"),
+            reason=original_error,
             now=now,
         )
         return RungOutcome(rung_index, "error", {"error": submit.get("error")})

--- a/docs/superpowers/plans/2026-07-12-rob-837-upbit-proposal-submit-convergence.md
+++ b/docs/superpowers/plans/2026-07-12-rob-837-upbit-proposal-submit-convergence.md
@@ -1,0 +1,582 @@
+# ROB-837 Upbit Proposal Submit Convergence Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make proposal-driven Upbit order creation single-send and converge submit errors to broker evidence instead of falsely recording live orders as rejected.
+
+**Architecture:** Disable every retry for `POST /v1/orders`, bind a stable proposal/rung identifier through preview and submit, and query Upbit by that identifier before classifying a failed submit. Add a dry-run-first, incident-specific repair CLI that reads the existing order and repairs only the measured rejected ledger row without submitting, cancelling, or replacing an order.
+
+**Tech Stack:** Python 3.13, asyncio, httpx, SQLAlchemy async ORM, pytest/pytest-asyncio, Ruff, ty, uv.
+
+## Global Constraints
+
+- Base commit is `047a88e73729ad53d4a03ee30408936b9a5764f3` (`main`); preserve unrelated user changes if the worktree later becomes dirty.
+- No live orders, cancels, replaces, or broker mutations in implementation or verification; all HTTP and broker calls in tests are mocks.
+- Upbit `POST /v1/orders` is sent at most once, including HTTP 429 and `httpx.RequestError` outcomes.
+- The proposal/rung identifier is stable across preview, submit, and broker lookup; a retry must never mint a new identifier.
+- `rejected` is recorded only after definitive evidence that no Upbit order exists; lookup ambiguity records `unverified` (Principle #4).
+- ROB-825 attempt/generation semantics and ROB-835 replace-cancel polling remain out of scope.
+- No Alembic migration and no public MCP tool parameter change.
+- The one-time repair keeps live order `35bee07f…` in place and must contain no resubmit path.
+- Run `make lint` clean; do not merge the PR.
+
+---
+
+### Task 1: Make Upbit order creation a one-shot transport operation
+
+**Files:**
+- Modify: `app/services/brokers/upbit/client.py:838-903`
+- Test: `tests/test_upbit_retry.py`
+
+**Interfaces:**
+- Consumes: `_retry_with_backoff(..., max_retries, retry_request_errors)`.
+- Produces: `_request_with_auth("POST", ".../v1/orders", ...)` calls `_retry_with_backoff(..., max_retries=0, retry_request_errors=False)`; other methods retain existing retry defaults.
+
+- [ ] **Step 1: Write the failing transport regression test**
+
+Add a test that executes the real retry helper with the order-path retry budget, returns a mocked 429, and proves no second send occurs:
+
+```python
+@pytest.mark.asyncio
+async def test_order_post_429_is_not_retried(monkeypatch):
+    from app.services.brokers.upbit.client import _retry_with_backoff
+
+    response = _make_response(429)
+    send = AsyncMock(return_value=response)
+    sleep = AsyncMock()
+    monkeypatch.setattr("app.services.brokers.upbit.client.asyncio.sleep", sleep)
+
+    with pytest.raises(RateLimitExceededError):
+        await _retry_with_backoff(
+            _make_limiter(),
+            send,
+            url="https://api.upbit.com/v1/orders",
+            max_retries=0,
+            retry_request_errors=False,
+        )
+
+    assert send.await_count == 1
+```
+
+Keep and extend `test_order_post_disables_request_error_retry` to assert both flags:
+
+```python
+assert captured["retry_request_errors"] is False
+assert captured["max_retries"] == 0
+```
+
+- [ ] **Step 2: Run RED tests**
+
+Run:
+
+```bash
+uv run pytest tests/test_upbit_retry.py::test_order_post_429_is_not_retried tests/test_upbit_retry.py::test_order_post_disables_request_error_retry -v -p no:cacheprovider
+```
+
+Expected: the one-shot helper test already demonstrates the desired zero-retry budget, while the `_request_with_auth` flag test fails because `max_retries` is absent. This is the RED proof that the order path has not yet selected the one-shot budget.
+
+- [ ] **Step 3: Apply the minimal single-send change**
+
+In `_request_with_auth`, preserve the existing ROB-645 predicate and pass zero retries only for order creation:
+
+```python
+    is_order_submission = method.upper() == "POST" and api_path.rstrip("/").endswith(
+        "/orders"
+    )
+    return await _retry_with_backoff(
+        limiter,
+        send,
+        url=url,
+        max_retries=0 if is_order_submission else None,
+        retry_request_errors=not is_order_submission,
+    )
+```
+
+Update the adjacent comment to state that both transport errors and 429 responses are non-retryable for creation requests.
+
+- [ ] **Step 4: Run GREEN transport tests**
+
+Run:
+
+```bash
+uv run pytest tests/test_upbit_retry.py -v -p no:cacheprovider
+```
+
+Expected: PASS; GET retry tests remain green and each order POST test observes one send.
+
+- [ ] **Step 5: Commit the transport fix**
+
+```bash
+git add app/services/brokers/upbit/client.py tests/test_upbit_retry.py
+git commit -m "fix(ROB-837): make Upbit order POST single-send"
+```
+
+---
+
+### Task 2: Thread a proposal-scoped identifier through preview and live submit
+
+**Files:**
+- Modify: `app/services/order_proposals/revalidation.py:251-330,347-570`
+- Modify: `app/mcp_server/tooling/order_execution.py:1187-1230,1425-1450`
+- Test: `tests/services/order_proposals/test_revalidation.py`
+- Test: `tests/test_mcp_place_order.py`
+
+**Interfaces:**
+- Produces: `_proposal_client_order_id(proposal_id: UUID, rung_index: int) -> str`.
+- Produces: `_place_order_impl(..., client_order_id: str | None = None) -> dict[str, Any]`.
+- Consumes: `_default_place_order_fn(proposal_client_order_id=...)`; the Upbit `identifier` is the override, while callers without an override keep ROB-653 canonical derivation.
+
+- [ ] **Step 1: Write failing proposal-ID tests**
+
+Add unit coverage beside the existing Toss ID tests:
+
+```python
+def test_upbit_proposal_client_ids_are_stable_and_rung_scoped():
+    from app.services.order_proposals import revalidation as mod
+
+    proposal_id = uuid.UUID("12345678-1234-5678-1234-567812345678")
+    first = mod._proposal_client_order_id(proposal_id, 0)
+    assert first == mod._proposal_client_order_id(proposal_id, 0)
+    assert first != mod._proposal_client_order_id(proposal_id, 1)
+    assert first != mod._proposal_client_order_id(uuid.uuid4(), 0)
+    assert first.startswith("oprop-")
+    assert len(first) <= 40
+```
+
+Add an async binding test that patches `_place_order_impl`, invokes `_default_place_order_fn` once for preview and once for live submit, and asserts both calls receive the same `client_order_id`:
+
+```python
+assert preview_seen["client_order_id"] == expected
+assert submit_seen["client_order_id"] == expected
+```
+
+Add `_place_order_impl` coverage that patches `_execute_and_record` and asserts its `idempotency_key` equals an explicit `client_order_id="oprop-fixed"`, while an existing no-override test continues to assert the ROB-653-derived key.
+
+- [ ] **Step 2: Run RED identifier tests**
+
+Run:
+
+```bash
+uv run pytest tests/services/order_proposals/test_revalidation.py -k 'proposal_client_id or default_place_order' -v -p no:cacheprovider
+uv run pytest tests/test_mcp_place_order.py -k 'client_order_id_override' -v -p no:cacheprovider
+```
+
+Expected: FAIL because `_proposal_client_order_id` and `_place_order_impl(client_order_id=...)` do not exist and the default binding currently discards non-Toss proposal IDs.
+
+- [ ] **Step 3: Implement the stable ID and override**
+
+In `revalidation.py`, derive a compact 128-bit identifier:
+
+```python
+def _proposal_client_order_id(proposal_id: uuid.UUID, rung_index: int) -> str:
+    digest = hashlib.sha256(f"{proposal_id}:{rung_index}".encode()).hexdigest()[:32]
+    return f"oprop-{digest}"
+```
+
+In `_revalidate_place_rung`, compute it only for Upbit proposals and pass it to both preview and submit:
+
+```python
+    proposal_client_order_id = (
+        _toss_proposal_client_order_id(proposal_id, rung_index)
+        if group.account_mode == "toss_live"
+        else _proposal_client_order_id(proposal_id, rung_index)
+        if group.account_mode == "upbit"
+        else None
+    )
+```
+
+Replace both Toss-only conditional kwargs blocks with the same generic `proposal_client_order_id` condition. In `_default_place_order_fn`, keep the Toss context behavior and pass the value to the shared implementation:
+
+```python
+    if proposal_client_order_id is not None:
+        kwargs["client_order_id"] = str(proposal_client_order_id)
+    submit = await _place_order_impl(**kwargs)
+```
+
+In `_place_order_impl`, add the trailing optional parameter and select the override after building the canonical payload:
+
+```python
+    idempotency_key = client_order_id or order_approval.derive_client_order_id(
+        canonical, market=salt_market, now=now, rung=rung
+    )
+```
+
+Validate a supplied value as non-blank and at most 40 characters before any broker mutation; return `_order_error` on invalid input.
+
+- [ ] **Step 4: Run GREEN identifier tests and adjacent Upbit execution tests**
+
+Run:
+
+```bash
+uv run pytest tests/services/order_proposals/test_revalidation.py tests/test_rob653_upbit_identifier.py tests/test_mcp_place_order.py -k 'proposal or identifier or client_order_id' -v -p no:cacheprovider
+```
+
+Expected: PASS; direct non-proposal callers still derive ROB-653 keys and proposal preview/submit use one stable value.
+
+- [ ] **Step 5: Commit identifier binding**
+
+```bash
+git add app/services/order_proposals/revalidation.py app/mcp_server/tooling/order_execution.py tests/services/order_proposals/test_revalidation.py tests/test_mcp_place_order.py
+git commit -m "fix(ROB-837): bind proposal ID to Upbit identifier"
+```
+
+---
+
+### Task 3: Add read-only Upbit lookup by identifier and normalized evidence
+
+**Files:**
+- Modify: `app/services/brokers/upbit/orders.py:279-291`
+- Modify: `app/services/brokers/upbit/__init__.py`
+- Modify: `app/services/brokers/upbit/client.py:905-920` (lazy re-export list)
+- Modify: `app/services/order_proposals/broker_gateway.py`
+- Test: `tests/test_upbit_orders.py`
+- Test: `tests/services/order_proposals/test_broker_gateway.py`
+
+**Interfaces:**
+- Produces: `fetch_order_by_identifier(identifier: str) -> dict[str, Any]`, issuing only `GET /v1/order?identifier=...`.
+- Produces: `SubmitEvidence(outcome: Literal["found", "absent", "unknown"], broker_order_id: str | None, broker_state: str | None, reason: str | None)`.
+- Produces: `fetch_submit_evidence(*, identifier, account_mode, market, lookup_fn=None) -> SubmitEvidence`.
+
+- [ ] **Step 1: Write failing broker lookup tests**
+
+Add to `tests/test_upbit_orders.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_fetch_order_by_identifier_uses_read_only_get(monkeypatch):
+    request = AsyncMock(return_value={"uuid": "35bee07f-full", "state": "wait"})
+    monkeypatch.setattr(orders._client, "_request_with_auth", request)
+
+    result = await orders.fetch_order_by_identifier("oprop-fixed")
+
+    assert result["uuid"] == "35bee07f-full"
+    request.assert_awaited_once_with(
+        "GET",
+        f"{orders._client.UPBIT_REST}/order",
+        query_params={"identifier": "oprop-fixed"},
+    )
+```
+
+Add gateway tests for found, definitive 404, and lookup failure:
+
+```python
+found = await fetch_submit_evidence(
+    identifier="oprop-fixed",
+    account_mode="upbit",
+    market="crypto",
+    lookup_fn=AsyncMock(return_value={"uuid": "35bee07f-full", "state": "wait"}),
+)
+assert found == SubmitEvidence("found", "35bee07f-full", "wait", None)
+```
+
+Build an `httpx.HTTPStatusError` with status 404 and assert outcome `absent`. Build a 403 and `httpx.ReadTimeout` and assert outcome `unknown`. Also assert blank UUID/state responses are `unknown`, never `absent`.
+
+- [ ] **Step 2: Run RED lookup tests**
+
+Run:
+
+```bash
+uv run pytest tests/test_upbit_orders.py::test_fetch_order_by_identifier_uses_read_only_get tests/services/order_proposals/test_broker_gateway.py -k 'submit_evidence' -v -p no:cacheprovider
+```
+
+Expected: FAIL because both lookup functions and `SubmitEvidence` are missing.
+
+- [ ] **Step 3: Implement read-only evidence lookup**
+
+In `orders.py`:
+
+```python
+async def fetch_order_by_identifier(identifier: str) -> dict[str, Any]:
+    candidate = str(identifier or "").strip()
+    if not candidate:
+        raise ValueError("identifier is required")
+    return await _client._request_with_auth(
+        "GET",
+        f"{_client.UPBIT_REST}/order",
+        query_params={"identifier": candidate},
+    )
+```
+
+Re-export it through `upbit/__init__.py` and `client.__getattr__`. In `broker_gateway.py`, add the frozen dataclass and classify only a 404 as definitive absence:
+
+```python
+@dataclass(frozen=True)
+class SubmitEvidence:
+    outcome: Literal["found", "absent", "unknown"]
+    broker_order_id: str | None = None
+    broker_state: str | None = None
+    reason: str | None = None
+```
+
+`fetch_submit_evidence` must return `unknown` for unsupported account/market tuples, import the Upbit lookup lazily, validate non-empty `uuid` and `state`, catch `httpx.HTTPStatusError` with 404 as `absent`, and convert every other exception to `unknown` with `describe_exception`.
+
+- [ ] **Step 4: Run GREEN lookup tests**
+
+Run:
+
+```bash
+uv run pytest tests/test_upbit_orders.py tests/services/order_proposals/test_broker_gateway.py -v -p no:cacheprovider
+```
+
+Expected: PASS; all calls are GET-only and only 404 proves absence.
+
+- [ ] **Step 5: Commit evidence lookup**
+
+```bash
+git add app/services/brokers/upbit/orders.py app/services/brokers/upbit/__init__.py app/services/brokers/upbit/client.py app/services/order_proposals/broker_gateway.py tests/test_upbit_orders.py tests/services/order_proposals/test_broker_gateway.py
+git commit -m "feat(ROB-837): query Upbit submit evidence by identifier"
+```
+
+---
+
+### Task 4: Gate proposal rejection on broker evidence
+
+**Files:**
+- Modify: `app/services/order_proposals/revalidation.py:347-570,926-989`
+- Test: `tests/services/order_proposals/test_revalidation.py`
+
+**Interfaces:**
+- Consumes: `fetch_submit_evidence` and `SubmitEvidence` from Task 3.
+- Produces: `revalidate_and_submit(..., fetch_submit_evidence_fn=fetch_submit_evidence)`.
+- Produces: `_classify_submit(..., account_mode, identifier, fetch_submit_evidence_fn)` with evidence-based Upbit failure handling.
+
+- [ ] **Step 1: Write the three required failing regression tests**
+
+Create an Upbit proposal fixture (`market="crypto"`, `account_mode="upbit"`, `symbol="KRW-BTC"`) and a placement fake that records live calls.
+
+Test accepted-first/retry-400 convergence by returning `success=False` from the single live call and returning found evidence from the lookup:
+
+```python
+assert live_calls == ["oprop-expected"]
+assert outcomes[0].result == "submitted_resting"
+_, rungs = await service.get_proposal(group.proposal_id)
+assert rungs[0].state == "resting"
+assert rungs[0].broker_order_id == "35bee07f-full"
+assert rungs[0].idempotency_key == "oprop-expected"
+```
+
+Test true rejection with `{"success": False, "error": "insufficient balance"}` and `SubmitEvidence(outcome="absent")`; assert rung `rejected` and one live placement call.
+
+Test evidence lookup failure with `SubmitEvidence(outcome="unknown", reason="timeout")`; assert rung `unverified`, identifier/correlation retained, and not rejected.
+
+Add an exception-form test where the live placement fake raises `httpx.ReadTimeout` and found evidence still converges to resting. This ensures the exception branch uses the same gate instead of immediately parking or rejecting.
+
+- [ ] **Step 2: Run RED classification tests**
+
+Run:
+
+```bash
+uv run pytest tests/services/order_proposals/test_revalidation.py -k 'submit_failure_found or true_rejection_absent or evidence_unknown or submit_exception_found' -v -p no:cacheprovider
+```
+
+Expected: FAIL because failed responses are immediately rejected and exceptions are immediately unverified without broker lookup.
+
+- [ ] **Step 3: Implement the evidence gate**
+
+Thread `fetch_submit_evidence_fn` from `revalidate_and_submit` into place and replace submit classification. For Upbit failures, call it exactly once with the proposal identifier.
+
+When evidence is found, normalize Upbit states as follows:
+
+```python
+status = "resting" if evidence.broker_state in {"wait", "watch"} else "acked"
+```
+
+Record the found UUID, correlation ID, proposal identifier, and preview approval digest using `record_resting` or `record_ack`; return `submitted_resting` or `submitted_acked`.
+
+When evidence is absent, call `record_rejected` with the original broker error. When evidence is unknown, call:
+
+```python
+await service.record_unverified(
+    proposal_id,
+    rung_index,
+    reason=f"submit_evidence_unknown:{evidence.reason or original_error}",
+    now=now,
+    correlation_id=corr,
+    idempotency_key=identifier,
+)
+```
+
+Convert a caught submit exception into the same classification input (`success=False`, original error detail) for Upbit. Preserve existing KIS/Toss behavior: definitive `success=False` remains rejected and non-Upbit exceptions remain unverified.
+
+- [ ] **Step 4: Run GREEN proposal suites**
+
+Run:
+
+```bash
+uv run pytest tests/services/order_proposals/test_revalidation.py tests/services/order_proposals/test_telegram_callback.py -v -p no:cacheprovider
+```
+
+Expected: PASS; the new tests observe one placement call, found evidence binds `35bee07f-full`, true rejection stays rejected, and ambiguity stays unverified.
+
+- [ ] **Step 5: Commit classification gate**
+
+```bash
+git add app/services/order_proposals/revalidation.py tests/services/order_proposals/test_revalidation.py
+git commit -m "fix(ROB-837): converge proposal submit errors from evidence"
+```
+
+---
+
+### Task 5: Add the guarded one-time ledger repair CLI
+
+**Files:**
+- Create: `scripts/rob837_reconcile_upbit_proposal.py`
+- Create: `tests/scripts/test_rob837_reconcile_upbit_proposal.py`
+
+**Interfaces:**
+- Produces: `repair_incident(session, *, proposal_id, rung_index, broker_order_id, commit, fetch_order_fn=fetch_order_detail) -> dict[str, Any]`.
+- Produces CLI: `uv run python -m scripts.rob837_reconcile_upbit_proposal --proposal-id <full-uuid-starting-b81ffd0e> --broker-order-id <full-uuid-starting-35bee07f> [--rung-index 0] [--commit]`.
+- The module imports only the read-side `fetch_order_detail`; it must not import any place/cancel/replace function.
+
+- [ ] **Step 1: Write failing dry-run, guard, and commit tests**
+
+Monkeypatch `app.services.order_proposals.service.uuid.uuid4` to return `UUID("b81ffd0e-0000-4000-8000-000000000000")`, seed a rejected Upbit BTC proposal through the service, then cover:
+
+```python
+result = await repair_incident(
+    db_session,
+    proposal_id=group.proposal_id,
+    rung_index=0,
+    broker_order_id="35bee07f-full",
+    commit=False,
+    fetch_order_fn=AsyncMock(return_value={
+        "uuid": "35bee07f-full",
+        "identifier": "oprop-fixed",
+        "market": "KRW-BTC",
+        "state": "wait",
+        "side": "bid",
+        "ord_type": "limit",
+        "price": "88800000",
+        "volume": "0.0004",
+    }),
+)
+assert result["mode"] == "dry-run"
+assert result["after"]["state"] == "resting"
+```
+
+Expire the session and reload to assert dry-run left the rung rejected. Repeat with `commit=True` and assert rung `resting`, `broker_order_id`, `idempotency_key`, cleared `void_reason`, and group lifecycle `submitted`.
+
+Parametrize failures for proposal prefix mismatch, broker prefix mismatch, non-`wait` broker state, symbol/side/type/price/volume mismatch, rung not rejected, duplicate broker ID already bound, and broker lookup exception. Every case must leave the DB unchanged.
+
+Add a static safety assertion:
+
+```python
+source = Path("scripts/rob837_reconcile_upbit_proposal.py").read_text()
+for forbidden in ("place_order", "cancel_order", "replace_order", "_execute_order"):
+    assert forbidden not in source
+```
+
+- [ ] **Step 2: Run RED repair tests**
+
+Run:
+
+```bash
+uv run pytest tests/scripts/test_rob837_reconcile_upbit_proposal.py -v -p no:cacheprovider
+```
+
+Expected: ERROR because the script module does not exist.
+
+- [ ] **Step 3: Implement the fail-closed repair**
+
+Use `argparse`, `AsyncSessionLocal`, `select(...).with_for_update()`, and direct ORM field updates. Validate:
+
+```python
+if proposal_id.hex[:8] != "b81ffd0e":
+    raise ValueError("proposal id is not the ROB-837 incident")
+if not broker_order_id.startswith("35bee07f"):
+    raise ValueError("broker order id is not the ROB-837 incident")
+```
+
+Require broker evidence `uuid == broker_order_id`, `market == "KRW-BTC"`, `state == "wait"`, `side == "bid"`, `ord_type == "limit"`, non-empty `identifier`, and exact decimal equality between broker `price`/`volume` and rung `limit_price`/`quantity`.
+
+Lock the group and target rung, require `account_mode="upbit"`, `market="crypto"`, target state `rejected`, and no other rung with that broker ID. Build a JSON-serializable before/after diff. If `commit=False`, return without mutating. If `commit=True`, apply exactly:
+
+```python
+rung.state = "resting"
+rung.broker_order_id = broker_order_id
+rung.idempotency_key = broker_order["identifier"]
+rung.void_reason = None
+rung.validated_at = now
+rung.updated_at = now
+group.lifecycle_state = "submitted"
+group.updated_at = now
+await session.commit()
+```
+
+On every exception, roll back. The CLI is dry-run by default; only explicit `--commit` mutates the ledger. Print the evidence and diff as sorted JSON.
+
+- [ ] **Step 4: Run GREEN repair tests and inspect CLI help**
+
+Run:
+
+```bash
+uv run pytest tests/scripts/test_rob837_reconcile_upbit_proposal.py -v -p no:cacheprovider
+uv run python -m scripts.rob837_reconcile_upbit_proposal --help
+```
+
+Expected: PASS; help states dry-run default, explicit `--commit`, and “never resubmits/cancels the live order.”
+
+- [ ] **Step 5: Commit the repair procedure**
+
+```bash
+git add scripts/rob837_reconcile_upbit_proposal.py tests/scripts/test_rob837_reconcile_upbit_proposal.py
+git commit -m "ops(ROB-837): add guarded proposal ledger repair"
+```
+
+---
+
+### Task 6: Run complete verification and prepare the unmerged PR
+
+**Files:**
+- Modify only if verification exposes a ROB-837 regression: files already listed in Tasks 1-5.
+- Verify: `app/mcp_server/README.md` needs no change because no public MCP parameter or response field changes.
+
+**Interfaces:**
+- Consumes all prior task deliverables.
+- Produces a clean branch, verification evidence, and a PR linked to ROB-837; no merge.
+
+- [ ] **Step 1: Run focused regression suites**
+
+```bash
+uv run pytest tests/test_upbit_retry.py tests/test_upbit_orders.py tests/test_rob653_upbit_identifier.py tests/services/order_proposals/test_broker_gateway.py tests/services/order_proposals/test_revalidation.py tests/services/order_proposals/test_telegram_callback.py tests/scripts/test_rob837_reconcile_upbit_proposal.py -v -p no:cacheprovider
+```
+
+Expected: PASS with no real-network access.
+
+- [ ] **Step 2: Run the MCP placement regression suite**
+
+```bash
+uv run pytest tests/test_mcp_place_order.py -v -p no:cacheprovider
+```
+
+Expected: PASS; direct KIS/Upbit placement contracts remain compatible.
+
+- [ ] **Step 3: Run lint and type gates**
+
+```bash
+make lint
+uv run ty check app/ scripts/rob837_reconcile_upbit_proposal.py
+```
+
+Expected: both exit 0 and Ruff formatting is clean.
+
+- [ ] **Step 4: Review the final diff and safety invariants**
+
+```bash
+git diff 047a88e73729ad53d4a03ee30408936b9a5764f3...HEAD --check
+git diff 047a88e73729ad53d4a03ee30408936b9a5764f3...HEAD --stat
+rg -n "place_order|cancel_order|replace_order|_execute_order" scripts/rob837_reconcile_upbit_proposal.py
+git status --short --branch
+```
+
+Expected: `diff --check` is empty; the script search has no matches; worktree is clean. Review must explicitly confirm: one Upbit POST, same identifier, found→resting, absent→rejected, unknown→unverified, and repair performs no broker mutation.
+
+- [ ] **Step 5: Push and create the PR without merging**
+
+Use the repository's `ship` workflow to push branch `rob-837` and create a PR whose title is:
+
+```text
+fix(ROB-837): converge Upbit proposal submits from broker evidence
+```
+
+The PR body must include the root cause (429 retry survived ROB-645), the same-identifier finding, the three classification outcomes, mocked test evidence, exact post-deploy dry-run/commit repair commands with full IDs supplied by the operator, and “Do not merge automatically.” Report the PR number and URL; do not invoke any merge command.

--- a/docs/superpowers/specs/2026-07-12-rob-837-upbit-proposal-submit-convergence-design.md
+++ b/docs/superpowers/specs/2026-07-12-rob-837-upbit-proposal-submit-convergence-design.md
@@ -1,0 +1,130 @@
+# ROB-837 Upbit Proposal Submit Convergence Design
+
+## Problem and evidence
+
+An approved crypto proposal can create an Upbit order and still finish locally as
+`rejected`. The measured incident was proposal `b81ffd0e`, whose BTC limit order
+`35bee07f` remained live at Upbit while the proposal rung was terminalized as
+rejected.
+
+The submit path is:
+
+`revalidate_and_submit` → `_revalidate_place_rung` → `_default_place_order_fn` →
+`_place_order_impl` → `_execute_and_record` → `_execute_crypto_order` → Upbit
+`orders.py` → `client._request_with_auth`.
+
+The proposal loop calls the live placement function once per eligible rung.
+Telegram callback replay is separately guarded by a row-locked nonce and commit
+lease. The remaining retry is inside Upbit transport: ROB-645 passes
+`retry_request_errors=False` for `POST /v1/orders`, but `_retry_with_backoff`
+still retries HTTP 429 responses. If Upbit has accepted the first request before
+returning 429, the retry reuses the ROB-653 deterministic identifier and Upbit
+returns 400 because identifiers cannot be reused. `_place_order_impl` converts
+that final error to `success=False`, and `_classify_submit` currently records
+`rejected` without querying the broker.
+
+This is the same identifier on both sends, not a newly generated identifier.
+The identifier prevents a second live order but does not make the response
+idempotent: Upbit rejects reuse instead of returning the original order.
+
+## Scope boundaries
+
+ROB-837 changes only proposal-driven Upbit placement and the shared Upbit POST
+retry policy needed to make that path single-send. It does not implement ROB-825
+terminal-attempt generations or ROB-835 replace cancellation polling. It does not
+change KIS submission semantics, add database migrations, or place any live order
+during tests or repair.
+
+## Design
+
+### Single-send Upbit creation
+
+`POST /v1/orders` will be passed to the retry helper with both request-error and
+response retry disabled. The helper retains 429 and RequestError retries for
+reads and other existing paths. The order-create test will model a first 429 and
+prove the send coroutine is invoked exactly once.
+
+### Proposal-scoped identifier
+
+Every proposal rung receives a stable identifier derived from the full proposal
+UUID and rung index. Preview and live submit use the same value. The proposal
+binding passes it into `_place_order_impl` as an explicit client-order-id
+override; `_place_order_impl` continues deriving the existing ROB-653 canonical
+key when no override is supplied. Only Upbit sends the value to a broker.
+
+This separates proposal identity from ROB-825's content-level attempt semantics:
+two different proposals do not accidentally share an Upbit identifier, while a
+re-entry of the same proposal/rung cannot create a second order.
+
+### Evidence-based classification gate
+
+The revalidation service receives an injectable submit-evidence lookup. The
+production lookup applies to `account_mode=upbit`, queries `GET /v1/order` by the
+proposal identifier, and returns one of:
+
+- found: normalized status plus broker UUID;
+- absent: a definitive Upbit not-found response;
+- unknown: lookup timeout, permission failure, malformed response, or other
+  inability to prove presence or absence.
+
+When submit returns `success=False`, classification consults that evidence before
+terminalizing the rung:
+
+- found `wait`/`watch`: record `resting` and bind `broker_order_id`;
+- found accepted market-order evidence: record `acked` where appropriate;
+- absent after a definitive broker rejection: record `rejected`;
+- unknown: record `unverified` with correlation and identifier evidence.
+
+A normal explicit rejection such as insufficient balance remains rejected when
+the identifier lookup definitively reports no order. `rejected` therefore means
+the broker has confirmed that no order exists; lookup ambiguity never becomes a
+terminal rejection.
+
+### One-time incident repair
+
+A dedicated CLI is dry-run by default and contains no order placement, replace,
+cancel, or resubmit call. It requires the operator to supply the full proposal
+UUID (accepted only when its first eight hexadecimal characters are `b81ffd0e`)
+and defaults the broker order UUID to `35bee07f` only if the full value is passed
+through the deployment secret/runbook channel.
+
+The CLI reads the Upbit order by UUID, verifies symbol `KRW-BTC`, state `wait`,
+and a non-empty identifier, then locks the proposal and its rung. It aborts unless
+there is exactly one matching proposal, the rung is `rejected`, the broker order
+ID is not already bound elsewhere, and the stored order fields match the broker
+evidence. Dry-run prints the guarded diff. `--commit` directly repairs the
+historically invalid terminal state to `resting`, binds the broker UUID and
+identifier, clears the rejection reason, recomputes the group lifecycle to
+`submitted`, and commits once. The script never invokes a submit function.
+
+Because `rejected` is intentionally terminal in the normal state machine, this
+incident-only correction uses a narrowly guarded repository/SQL update rather
+than widening legal runtime transitions.
+
+## Tests and verification
+
+All broker and HTTP behavior is mocked.
+
+- Upbit transport: a create-order 429 is returned once and the send count remains
+  one; read retries remain unchanged.
+- Proposal binding: preview and submit receive the same proposal-scoped ID, and
+  the Upbit order body uses it.
+- Convergence: submit failure followed by identifier lookup returning order
+  `35bee07f` in `wait` records `resting` and binds the broker ID.
+- True rejection: insufficient balance plus definitive identifier not-found
+  remains `rejected`.
+- Ambiguity: lookup failure records `unverified`, never `rejected`.
+- Repair CLI: dry-run performs no DB write, all guard mismatches abort, commit
+  updates only the intended rung/group, and no order mutation symbol is imported
+  or called.
+
+Verification gates are targeted pytest suites, `make lint`, and the repository's
+type check. No live credentials or real broker request is used.
+
+## Deployment procedure
+
+Deploy the code first. The operator then runs the repair CLI in dry-run mode,
+compares its broker evidence with Upbit order `35bee07f`, and reruns with
+`--commit` only when every guard passes. The live order remains untouched and is
+never resubmitted. The final output must show broker `wait`, proposal rung
+`resting`, and the bound broker order UUID.

--- a/scripts/rob837_reconcile_upbit_proposal.py
+++ b/scripts/rob837_reconcile_upbit_proposal.py
@@ -1,0 +1,254 @@
+"""Guarded, one-time local ledger repair for the ROB-837 Upbit incident.
+
+This command only reads the broker order and updates the local proposal ledger after
+all incident-specific guards pass. It never resubmits or cancels the live order.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import uuid
+from collections.abc import Awaitable, Callable
+from datetime import UTC, datetime
+from decimal import Decimal
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.db import AsyncSessionLocal
+from app.models.order_proposals import OrderProposal, OrderProposalRung
+from app.services.brokers.upbit import fetch_order_detail
+
+_INCIDENT_PROPOSAL_PREFIX = "b81ffd0e"
+_INCIDENT_BROKER_ORDER_PREFIX = "35bee07f"
+_EXPECTED_BROKER_FIELDS = {
+    "market": "KRW-BTC",
+    "state": "wait",
+    "side": "bid",
+    "ord_type": "limit",
+}
+
+
+def _serialize_timestamp(value: datetime | None) -> str | None:
+    return value.isoformat() if value is not None else None
+
+
+def _snapshot(group: OrderProposal, rung: OrderProposalRung) -> dict[str, Any]:
+    return {
+        "state": rung.state,
+        "broker_order_id": rung.broker_order_id,
+        "idempotency_key": rung.idempotency_key,
+        "void_reason": rung.void_reason,
+        "validated_at": _serialize_timestamp(rung.validated_at),
+        "updated_at": _serialize_timestamp(rung.updated_at),
+        "group_lifecycle_state": group.lifecycle_state,
+        "group_updated_at": _serialize_timestamp(group.updated_at),
+    }
+
+
+def _validate_incident_ids(proposal_id: uuid.UUID, broker_order_id: str) -> None:
+    if proposal_id.hex[:8] != _INCIDENT_PROPOSAL_PREFIX:
+        raise ValueError("proposal id is not the ROB-837 incident")
+    if not broker_order_id.startswith(_INCIDENT_BROKER_ORDER_PREFIX):
+        raise ValueError("broker order id is not the ROB-837 incident")
+
+
+def _validate_broker_order(
+    broker_order: dict[str, Any],
+    *,
+    broker_order_id: str,
+    rung: OrderProposalRung,
+) -> None:
+    if broker_order.get("uuid") != broker_order_id:
+        raise ValueError("broker order uuid does not match requested broker order id")
+    for field, expected in _EXPECTED_BROKER_FIELDS.items():
+        if broker_order.get(field) != expected:
+            raise ValueError(f"broker order {field} does not match ROB-837 evidence")
+    if not str(broker_order.get("identifier") or "").strip():
+        raise ValueError("broker order identifier is empty")
+    if Decimal(str(broker_order.get("price"))) != Decimal(str(rung.limit_price)):
+        raise ValueError("broker order price does not match proposal rung")
+    if Decimal(str(broker_order.get("volume"))) != Decimal(str(rung.quantity)):
+        raise ValueError("broker order volume does not match proposal rung")
+
+
+async def _get_locked_group_and_rung(
+    session: AsyncSession,
+    *,
+    proposal_id: uuid.UUID,
+    rung_index: int,
+) -> tuple[OrderProposal, OrderProposalRung]:
+    group = (
+        await session.execute(
+            select(OrderProposal)
+            .where(OrderProposal.proposal_id == proposal_id)
+            .with_for_update()
+        )
+    ).scalar_one_or_none()
+    if group is None:
+        raise ValueError("proposal was not found")
+    if group.account_mode != "upbit" or group.market != "crypto":
+        raise ValueError("proposal is not an Upbit crypto proposal")
+
+    rung = (
+        await session.execute(
+            select(OrderProposalRung)
+            .where(
+                OrderProposalRung.proposal_pk == group.id,
+                OrderProposalRung.rung_index == rung_index,
+            )
+            .with_for_update()
+        )
+    ).scalar_one_or_none()
+    if rung is None:
+        raise ValueError("proposal rung was not found")
+    if rung.state != "rejected":
+        raise ValueError("proposal rung state is not rejected")
+    return group, rung
+
+
+async def _assert_no_other_broker_binding(
+    session: AsyncSession,
+    *,
+    rung: OrderProposalRung,
+    broker_order_id: str,
+) -> None:
+    duplicate = (
+        (
+            await session.execute(
+                select(OrderProposalRung)
+                .where(
+                    OrderProposalRung.broker_order_id == broker_order_id,
+                    OrderProposalRung.id != rung.id,
+                )
+                .with_for_update()
+            )
+        )
+        .scalars()
+        .first()
+    )
+    if duplicate is not None:
+        raise ValueError("broker order id is already bound to another rung")
+
+
+async def repair_incident(
+    session: AsyncSession,
+    *,
+    proposal_id: uuid.UUID,
+    rung_index: int,
+    broker_order_id: str,
+    commit: bool,
+    fetch_order_fn: Callable[[str], Awaitable[dict[str, Any]]] = fetch_order_detail,
+) -> dict[str, Any]:
+    """Return the verified repair diff, applying it only when ``commit`` is true."""
+    try:
+        _validate_incident_ids(proposal_id, broker_order_id)
+        broker_order = await fetch_order_fn(broker_order_id)
+        group, rung = await _get_locked_group_and_rung(
+            session,
+            proposal_id=proposal_id,
+            rung_index=rung_index,
+        )
+        _validate_broker_order(
+            broker_order,
+            broker_order_id=broker_order_id,
+            rung=rung,
+        )
+        await _assert_no_other_broker_binding(
+            session,
+            rung=rung,
+            broker_order_id=broker_order_id,
+        )
+
+        now = datetime.now(UTC)
+        before = _snapshot(group, rung)
+        after = {
+            **before,
+            "state": "resting",
+            "broker_order_id": broker_order_id,
+            "idempotency_key": broker_order["identifier"],
+            "void_reason": None,
+            "validated_at": now.isoformat(),
+            "updated_at": now.isoformat(),
+            "group_lifecycle_state": "submitted",
+            "group_updated_at": now.isoformat(),
+        }
+        result = {
+            "mode": "commit" if commit else "dry-run",
+            "proposal_id": str(proposal_id),
+            "rung_index": rung_index,
+            "broker_order_id": broker_order_id,
+            "evidence": broker_order,
+            "before": before,
+            "after": after,
+        }
+        if not commit:
+            await session.rollback()
+            return result
+
+        rung.state = "resting"
+        rung.broker_order_id = broker_order_id
+        rung.idempotency_key = broker_order["identifier"]
+        rung.void_reason = None
+        rung.validated_at = now
+        rung.updated_at = now
+        group.lifecycle_state = "submitted"
+        group.updated_at = now
+        await session.commit()
+        return result
+    except Exception:
+        await session.rollback()
+        raise
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Repair only the ROB-837 local proposal ledger after exact read-only "
+            "broker evidence. Dry-run is the default; --commit is the explicit "
+            "mutation gate. Never resubmits or cancels the live order."
+        )
+    )
+    parser.add_argument(
+        "--proposal-id",
+        required=True,
+        type=uuid.UUID,
+        help="full ROB-837 proposal UUID beginning with b81ffd0e",
+    )
+    parser.add_argument(
+        "--broker-order-id",
+        required=True,
+        help="full ROB-837 broker order UUID beginning with 35bee07f",
+    )
+    parser.add_argument("--rung-index", type=int, default=0)
+    parser.add_argument(
+        "--commit",
+        action="store_true",
+        help="apply the verified local ledger repair; default is dry-run",
+    )
+    return parser.parse_args(argv)
+
+
+async def _main() -> int:
+    args = parse_args()
+    async with AsyncSessionLocal() as session:
+        result = await repair_incident(
+            session,
+            proposal_id=args.proposal_id,
+            rung_index=args.rung_index,
+            broker_order_id=args.broker_order_id,
+            commit=args.commit,
+        )
+    print(json.dumps(result, ensure_ascii=False, sort_keys=True, default=str))
+    return 0
+
+
+def main() -> int:
+    return asyncio.run(_main())
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/rob837_reconcile_upbit_proposal.py
+++ b/scripts/rob837_reconcile_upbit_proposal.py
@@ -21,6 +21,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.db import AsyncSessionLocal
 from app.models.order_proposals import OrderProposal, OrderProposalRung
 from app.services.brokers.upbit import fetch_order_detail
+from app.services.order_proposals.service import OrderProposalsService
 
 _INCIDENT_PROPOSAL_PREFIX = "b81ffd0e"
 _INCIDENT_BROKER_ORDER_PREFIX = "35bee07f"
@@ -60,6 +61,7 @@ def _validate_broker_order(
     broker_order: dict[str, Any],
     *,
     broker_order_id: str,
+    group: OrderProposal,
     rung: OrderProposalRung,
 ) -> None:
     if broker_order.get("uuid") != broker_order_id:
@@ -69,6 +71,15 @@ def _validate_broker_order(
             raise ValueError(f"broker order {field} does not match ROB-837 evidence")
     if not str(broker_order.get("identifier") or "").strip():
         raise ValueError("broker order identifier is empty")
+    if group.symbol != broker_order.get("market"):
+        raise ValueError("proposal symbol does not match broker order market")
+    if group.side != rung.side:
+        raise ValueError("proposal side does not match proposal rung side")
+    expected_broker_side = {"buy": "bid", "sell": "ask"}.get(rung.side)
+    if expected_broker_side != broker_order.get("side"):
+        raise ValueError("proposal side does not match broker order side")
+    if group.order_type != broker_order.get("ord_type"):
+        raise ValueError("proposal order type does not match broker order type")
     if Decimal(str(broker_order.get("price"))) != Decimal(str(rung.limit_price)):
         raise ValueError("broker order price does not match proposal rung")
     if Decimal(str(broker_order.get("volume"))) != Decimal(str(rung.quantity)):
@@ -80,7 +91,7 @@ async def _get_locked_group_and_rung(
     *,
     proposal_id: uuid.UUID,
     rung_index: int,
-) -> tuple[OrderProposal, OrderProposalRung]:
+) -> tuple[OrderProposal, OrderProposalRung, list[OrderProposalRung]]:
     group = (
         await session.execute(
             select(OrderProposal)
@@ -93,21 +104,22 @@ async def _get_locked_group_and_rung(
     if group.account_mode != "upbit" or group.market != "crypto":
         raise ValueError("proposal is not an Upbit crypto proposal")
 
-    rung = (
-        await session.execute(
-            select(OrderProposalRung)
-            .where(
-                OrderProposalRung.proposal_pk == group.id,
-                OrderProposalRung.rung_index == rung_index,
+    rungs = list(
+        (
+            await session.execute(
+                select(OrderProposalRung)
+                .where(OrderProposalRung.proposal_pk == group.id)
+                .order_by(OrderProposalRung.rung_index)
+                .with_for_update()
             )
-            .with_for_update()
-        )
-    ).scalar_one_or_none()
+        ).scalars()
+    )
+    rung = next((row for row in rungs if row.rung_index == rung_index), None)
     if rung is None:
         raise ValueError("proposal rung was not found")
     if rung.state != "rejected":
         raise ValueError("proposal rung state is not rejected")
-    return group, rung
+    return group, rung, rungs
 
 
 async def _assert_no_other_broker_binding(
@@ -147,7 +159,7 @@ async def repair_incident(
     try:
         _validate_incident_ids(proposal_id, broker_order_id)
         broker_order = await fetch_order_fn(broker_order_id)
-        group, rung = await _get_locked_group_and_rung(
+        group, rung, rungs = await _get_locked_group_and_rung(
             session,
             proposal_id=proposal_id,
             rung_index=rung_index,
@@ -155,6 +167,7 @@ async def repair_incident(
         _validate_broker_order(
             broker_order,
             broker_order_id=broker_order_id,
+            group=group,
             rung=rung,
         )
         await _assert_no_other_broker_binding(
@@ -165,17 +178,15 @@ async def repair_incident(
 
         now = datetime.now(UTC)
         before = _snapshot(group, rung)
-        after = {
-            **before,
-            "state": "resting",
-            "broker_order_id": broker_order_id,
-            "idempotency_key": broker_order["identifier"],
-            "void_reason": None,
-            "validated_at": now.isoformat(),
-            "updated_at": now.isoformat(),
-            "group_lifecycle_state": "submitted",
-            "group_updated_at": now.isoformat(),
-        }
+        rung.state = "resting"
+        rung.broker_order_id = broker_order_id
+        rung.idempotency_key = broker_order["identifier"]
+        rung.void_reason = None
+        rung.validated_at = now
+        rung.updated_at = now
+        group.lifecycle_state = OrderProposalsService._recompute_group_state(rungs)
+        group.updated_at = now
+        after = _snapshot(group, rung)
         result = {
             "mode": "commit" if commit else "dry-run",
             "proposal_id": str(proposal_id),
@@ -189,14 +200,6 @@ async def repair_incident(
             await session.rollback()
             return result
 
-        rung.state = "resting"
-        rung.broker_order_id = broker_order_id
-        rung.idempotency_key = broker_order["identifier"]
-        rung.void_reason = None
-        rung.validated_at = now
-        rung.updated_at = now
-        group.lifecycle_state = "submitted"
-        group.updated_at = now
         await session.commit()
         return result
     except Exception:

--- a/tests/scripts/test_rob837_reconcile_upbit_proposal.py
+++ b/tests/scripts/test_rob837_reconcile_upbit_proposal.py
@@ -1,0 +1,283 @@
+from __future__ import annotations
+
+import uuid
+from decimal import Decimal
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+from sqlalchemy import delete
+
+import scripts.rob837_reconcile_upbit_proposal as cli
+from app.models.order_proposals import OrderProposal, OrderProposalRung
+from app.services.order_proposals.service import OrderProposalsService, RungInput
+
+PROPOSAL_ID = uuid.UUID("b81ffd0e-0000-4000-8000-000000000000")
+BROKER_ORDER_ID = "35bee07f-full"
+
+
+def _broker_order(**overrides: str) -> dict[str, str]:
+    order = {
+        "uuid": BROKER_ORDER_ID,
+        "identifier": "oprop-fixed",
+        "market": "KRW-BTC",
+        "state": "wait",
+        "side": "bid",
+        "ord_type": "limit",
+        "price": "88800000",
+        "volume": "0.0004",
+    }
+    order.update(overrides)
+    return order
+
+
+async def _seed_rejected_proposal(db_session, monkeypatch):  # noqa: ANN001
+    await db_session.execute(
+        delete(OrderProposal).where(OrderProposal.proposal_id == PROPOSAL_ID)
+    )
+    await db_session.commit()
+    monkeypatch.setattr(
+        "app.services.order_proposals.service.uuid.uuid4", lambda: PROPOSAL_ID
+    )
+    service = OrderProposalsService(db_session)
+    group = await service.create_proposal(
+        symbol="KRW-BTC",
+        market="crypto",
+        account_mode="upbit",
+        side="buy",
+        order_type="limit",
+        proposer="rob837-test",
+        rungs=[RungInput(0, "buy", Decimal("0.0004"), Decimal("88800000"), None)],
+    )
+    _, [rung] = await service.get_proposal(group.proposal_id)
+    rung.state = "rejected"
+    rung.void_reason = "submit failed"
+    group.lifecycle_state = "rejected"
+    await db_session.commit()
+    return group, rung
+
+
+async def _reload(db_session, group_id: int, rung_id: int):  # noqa: ANN001
+    db_session.expire_all()
+    group = await db_session.get(OrderProposal, group_id)
+    rung = await db_session.get(OrderProposalRung, rung_id)
+    assert group is not None
+    assert rung is not None
+    return group, rung
+
+
+@pytest.mark.asyncio
+async def test_repair_dry_run_reports_resting_without_mutating(db_session, monkeypatch):
+    group, rung = await _seed_rejected_proposal(db_session, monkeypatch)
+    group_id, rung_id = group.id, rung.id
+
+    result = await cli.repair_incident(
+        db_session,
+        proposal_id=group.proposal_id,
+        rung_index=0,
+        broker_order_id=BROKER_ORDER_ID,
+        commit=False,
+        fetch_order_fn=AsyncMock(return_value=_broker_order()),
+    )
+
+    fresh_group, fresh_rung = await _reload(db_session, group_id, rung_id)
+    assert result["mode"] == "dry-run"
+    assert result["after"]["state"] == "resting"
+    assert result["after"]["group_lifecycle_state"] == "submitted"
+    assert result["evidence"] == _broker_order()
+    assert fresh_rung.state == "rejected"
+    assert fresh_rung.broker_order_id is None
+    assert fresh_rung.idempotency_key is None
+    assert fresh_rung.void_reason == "submit failed"
+    assert fresh_group.lifecycle_state == "rejected"
+
+
+@pytest.mark.asyncio
+async def test_repair_commit_updates_only_verified_ledger_fields(
+    db_session, monkeypatch
+):
+    group, rung = await _seed_rejected_proposal(db_session, monkeypatch)
+    group_id, rung_id = group.id, rung.id
+
+    result = await cli.repair_incident(
+        db_session,
+        proposal_id=group.proposal_id,
+        rung_index=0,
+        broker_order_id=BROKER_ORDER_ID,
+        commit=True,
+        fetch_order_fn=AsyncMock(return_value=_broker_order()),
+    )
+
+    fresh_group, fresh_rung = await _reload(db_session, group_id, rung_id)
+    assert result["mode"] == "commit"
+    assert fresh_rung.state == "resting"
+    assert fresh_rung.broker_order_id == BROKER_ORDER_ID
+    assert fresh_rung.idempotency_key == "oprop-fixed"
+    assert fresh_rung.void_reason is None
+    assert fresh_rung.validated_at is not None
+    assert fresh_rung.updated_at is not None
+    assert fresh_group.lifecycle_state == "submitted"
+    assert fresh_group.updated_at is not None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("proposal_id", "broker_order_id", "broker_order", "match"),
+    [
+        (
+            uuid.UUID("a81ffd0e-0000-4000-8000-000000000000"),
+            BROKER_ORDER_ID,
+            _broker_order(),
+            "proposal id is not the ROB-837 incident",
+        ),
+        (
+            PROPOSAL_ID,
+            "45bee07f-full",
+            _broker_order(uuid="45bee07f-full"),
+            "broker order id is not the ROB-837 incident",
+        ),
+        (PROPOSAL_ID, BROKER_ORDER_ID, _broker_order(state="done"), "state"),
+        (PROPOSAL_ID, BROKER_ORDER_ID, _broker_order(market="KRW-ETH"), "market"),
+        (PROPOSAL_ID, BROKER_ORDER_ID, _broker_order(side="ask"), "side"),
+        (PROPOSAL_ID, BROKER_ORDER_ID, _broker_order(ord_type="price"), "ord_type"),
+        (PROPOSAL_ID, BROKER_ORDER_ID, _broker_order(price="88800001"), "price"),
+        (PROPOSAL_ID, BROKER_ORDER_ID, _broker_order(volume="0.0005"), "volume"),
+    ],
+)
+async def test_repair_rejects_bad_incident_or_broker_evidence_without_mutation(
+    db_session,
+    monkeypatch,
+    proposal_id,
+    broker_order_id,
+    broker_order,
+    match,
+):
+    group, rung = await _seed_rejected_proposal(db_session, monkeypatch)
+    group_id, rung_id = group.id, rung.id
+
+    with pytest.raises(ValueError, match=match):
+        await cli.repair_incident(
+            db_session,
+            proposal_id=proposal_id,
+            rung_index=0,
+            broker_order_id=broker_order_id,
+            commit=True,
+            fetch_order_fn=AsyncMock(return_value=broker_order),
+        )
+
+    fresh_group, fresh_rung = await _reload(db_session, group_id, rung_id)
+    assert fresh_rung.state == "rejected"
+    assert fresh_rung.broker_order_id is None
+    assert fresh_rung.idempotency_key is None
+    assert fresh_rung.void_reason == "submit failed"
+    assert fresh_group.lifecycle_state == "rejected"
+
+
+@pytest.mark.asyncio
+async def test_repair_rejects_non_rejected_rung_without_mutation(
+    db_session, monkeypatch
+):
+    group, rung = await _seed_rejected_proposal(db_session, monkeypatch)
+    group_id, rung_id = group.id, rung.id
+    rung.state = "approved"
+    await db_session.commit()
+
+    with pytest.raises(ValueError, match="rung state is not rejected"):
+        await cli.repair_incident(
+            db_session,
+            proposal_id=group.proposal_id,
+            rung_index=0,
+            broker_order_id=BROKER_ORDER_ID,
+            commit=True,
+            fetch_order_fn=AsyncMock(return_value=_broker_order()),
+        )
+
+    _, fresh_rung = await _reload(db_session, group_id, rung_id)
+    assert fresh_rung.state == "approved"
+    assert fresh_rung.broker_order_id is None
+
+
+@pytest.mark.asyncio
+async def test_repair_rejects_duplicate_broker_order_id_without_mutation(
+    db_session, monkeypatch
+):
+    group, rung = await _seed_rejected_proposal(db_session, monkeypatch)
+    group_id, rung_id = group.id, rung.id
+    duplicate = OrderProposalRung(
+        proposal_pk=group.id,
+        rung_index=1,
+        side="buy",
+        quantity=Decimal("0.0004"),
+        limit_price=Decimal("88800000"),
+        state="rejected",
+        broker_order_id=BROKER_ORDER_ID,
+    )
+    db_session.add(duplicate)
+    await db_session.commit()
+
+    with pytest.raises(ValueError, match="already bound to another rung"):
+        await cli.repair_incident(
+            db_session,
+            proposal_id=group.proposal_id,
+            rung_index=0,
+            broker_order_id=BROKER_ORDER_ID,
+            commit=True,
+            fetch_order_fn=AsyncMock(return_value=_broker_order()),
+        )
+
+    _, fresh_rung = await _reload(db_session, group_id, rung_id)
+    assert fresh_rung.state == "rejected"
+    assert fresh_rung.broker_order_id is None
+
+
+@pytest.mark.asyncio
+async def test_repair_rolls_back_when_broker_lookup_fails(db_session, monkeypatch):
+    group, rung = await _seed_rejected_proposal(db_session, monkeypatch)
+    group_id, rung_id = group.id, rung.id
+
+    with pytest.raises(RuntimeError, match="lookup unavailable"):
+        await cli.repair_incident(
+            db_session,
+            proposal_id=group.proposal_id,
+            rung_index=0,
+            broker_order_id=BROKER_ORDER_ID,
+            commit=True,
+            fetch_order_fn=AsyncMock(side_effect=RuntimeError("lookup unavailable")),
+        )
+
+    fresh_group, fresh_rung = await _reload(db_session, group_id, rung_id)
+    assert fresh_rung.state == "rejected"
+    assert fresh_rung.broker_order_id is None
+    assert fresh_group.lifecycle_state == "rejected"
+
+
+def test_repair_source_never_imports_mutating_broker_operations():
+    source = (
+        Path(__file__).parents[2] / "scripts" / "rob837_reconcile_upbit_proposal.py"
+    ).read_text()
+
+    for forbidden in (
+        "place_order",
+        "cancel_order",
+        "replace_order",
+        "_execute_order",
+    ):
+        assert forbidden not in source
+
+
+def test_parse_args_is_dry_run_by_default(monkeypatch):
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "rob837_reconcile_upbit_proposal.py",
+            "--proposal-id",
+            str(PROPOSAL_ID),
+            "--broker-order-id",
+            BROKER_ORDER_ID,
+        ],
+    )
+
+    args = cli.parse_args()
+
+    assert args.commit is False
+    assert args.rung_index == 0

--- a/tests/scripts/test_rob837_reconcile_upbit_proposal.py
+++ b/tests/scripts/test_rob837_reconcile_upbit_proposal.py
@@ -174,6 +174,75 @@ async def test_repair_rejects_bad_incident_or_broker_evidence_without_mutation(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("field", "value", "match"),
+    [
+        ("symbol", "KRW-ETH", "symbol"),
+        ("side", "sell", "side"),
+        ("order_type", "market", "order type"),
+    ],
+)
+async def test_repair_rejects_local_order_mismatch_without_mutation(
+    db_session, monkeypatch, field, value, match
+):
+    group, rung = await _seed_rejected_proposal(db_session, monkeypatch)
+    group_id, rung_id = group.id, rung.id
+    if field == "side":
+        group.side = value
+        rung.side = value
+    else:
+        setattr(group, field, value)
+    await db_session.commit()
+
+    with pytest.raises(ValueError, match=match):
+        await cli.repair_incident(
+            db_session,
+            proposal_id=group.proposal_id,
+            rung_index=0,
+            broker_order_id=BROKER_ORDER_ID,
+            commit=True,
+            fetch_order_fn=AsyncMock(return_value=_broker_order()),
+        )
+
+    fresh_group, fresh_rung = await _reload(db_session, group_id, rung_id)
+    assert fresh_rung.state == "rejected"
+    assert fresh_rung.broker_order_id is None
+    assert fresh_group.lifecycle_state == "rejected"
+
+
+@pytest.mark.asyncio
+async def test_repair_recomputes_group_lifecycle_from_all_rungs(
+    db_session, monkeypatch
+):
+    group, rung = await _seed_rejected_proposal(db_session, monkeypatch)
+    group_id, rung_id = group.id, rung.id
+    db_session.add(
+        OrderProposalRung(
+            proposal_pk=group.id,
+            rung_index=1,
+            side="buy",
+            quantity=Decimal("0.0005"),
+            limit_price=Decimal("88000000"),
+            state="pending_approval",
+        )
+    )
+    await db_session.commit()
+
+    await cli.repair_incident(
+        db_session,
+        proposal_id=group.proposal_id,
+        rung_index=0,
+        broker_order_id=BROKER_ORDER_ID,
+        commit=True,
+        fetch_order_fn=AsyncMock(return_value=_broker_order()),
+    )
+
+    fresh_group, fresh_rung = await _reload(db_session, group_id, rung_id)
+    assert fresh_rung.state == "resting"
+    assert fresh_group.lifecycle_state == "partially_submitted"
+
+
+@pytest.mark.asyncio
 async def test_repair_rejects_non_rejected_rung_without_mutation(
     db_session, monkeypatch
 ):

--- a/tests/services/order_proposals/test_broker_gateway.py
+++ b/tests/services/order_proposals/test_broker_gateway.py
@@ -1,5 +1,7 @@
 from datetime import UTC, datetime
+from unittest.mock import AsyncMock
 
+import httpx
 import pytest
 
 from app.services.order_proposals.broker_gateway import (
@@ -215,3 +217,110 @@ async def test_cancel_rejects_unsupported_target_tuple():
             account_mode="kis_live",
             cancel_fn=lambda **_kwargs: pytest.fail("cancel must not be called"),
         )
+
+
+def _http_status_error(status_code: int) -> httpx.HTTPStatusError:
+    request = httpx.Request("GET", "https://api.upbit.com/v1/order")
+    response = httpx.Response(status_code, request=request)
+    return httpx.HTTPStatusError("broker lookup failed", request=request, response=response)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_fetch_submit_evidence_returns_found_order():
+    from app.services.order_proposals.broker_gateway import (
+        SubmitEvidence,
+        fetch_submit_evidence,
+    )
+
+    found = await fetch_submit_evidence(
+        identifier="oprop-fixed",
+        account_mode="upbit",
+        market="crypto",
+        lookup_fn=AsyncMock(return_value={"uuid": "35bee07f-full", "state": "wait"}),
+    )
+
+    assert found == SubmitEvidence("found", "35bee07f-full", "wait", None)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_fetch_submit_evidence_treats_only_404_as_absent():
+    from app.services.order_proposals.broker_gateway import fetch_submit_evidence
+
+    absent = await fetch_submit_evidence(
+        identifier="oprop-fixed",
+        account_mode="upbit",
+        market="crypto",
+        lookup_fn=AsyncMock(side_effect=_http_status_error(404)),
+    )
+    unknown = await fetch_submit_evidence(
+        identifier="oprop-fixed",
+        account_mode="upbit",
+        market="crypto",
+        lookup_fn=AsyncMock(side_effect=_http_status_error(403)),
+    )
+
+    assert absent.outcome == "absent"
+    assert absent.reason is None
+    assert unknown.outcome == "unknown"
+    assert unknown.reason == "broker lookup failed"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "lookup_result",
+    [
+        {"uuid": "", "state": "wait"},
+        {"uuid": "35bee07f-full", "state": " "},
+    ],
+)
+async def test_fetch_submit_evidence_treats_incomplete_broker_results_as_unknown(
+    lookup_result,
+):
+    from app.services.order_proposals.broker_gateway import fetch_submit_evidence
+
+    evidence = await fetch_submit_evidence(
+        identifier="oprop-fixed",
+        account_mode="upbit",
+        market="crypto",
+        lookup_fn=AsyncMock(return_value=lookup_result),
+    )
+
+    assert evidence.outcome == "unknown"
+    assert evidence.reason == "broker lookup returned incomplete order evidence"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_fetch_submit_evidence_treats_read_timeout_as_unknown():
+    from app.services.order_proposals.broker_gateway import fetch_submit_evidence
+
+    evidence = await fetch_submit_evidence(
+        identifier="oprop-fixed",
+        account_mode="upbit",
+        market="crypto",
+        lookup_fn=AsyncMock(side_effect=httpx.ReadTimeout("")),
+    )
+
+    assert evidence.outcome == "unknown"
+    assert evidence.reason == "ReadTimeout"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_fetch_submit_evidence_returns_unknown_for_unsupported_tuple():
+    from app.services.order_proposals.broker_gateway import fetch_submit_evidence
+
+    lookup = AsyncMock()
+    evidence = await fetch_submit_evidence(
+        identifier="oprop-fixed",
+        account_mode="kis_live",
+        market="crypto",
+        lookup_fn=lookup,
+    )
+
+    assert evidence.outcome == "unknown"
+    assert evidence.reason == "submit evidence lookup unsupported for kis_live/crypto"
+    lookup.assert_not_awaited()

--- a/tests/services/order_proposals/test_broker_gateway.py
+++ b/tests/services/order_proposals/test_broker_gateway.py
@@ -222,7 +222,9 @@ async def test_cancel_rejects_unsupported_target_tuple():
 def _http_status_error(status_code: int) -> httpx.HTTPStatusError:
     request = httpx.Request("GET", "https://api.upbit.com/v1/order")
     response = httpx.Response(status_code, request=request)
-    return httpx.HTTPStatusError("broker lookup failed", request=request, response=response)
+    return httpx.HTTPStatusError(
+        "broker lookup failed", request=request, response=response
+    )
 
 
 @pytest.mark.unit

--- a/tests/services/order_proposals/test_revalidation.py
+++ b/tests/services/order_proposals/test_revalidation.py
@@ -972,6 +972,96 @@ def test_toss_proposal_client_ids_are_stable_and_rung_scoped():
     assert same.startswith("tosprop-")
 
 
+def test_upbit_proposal_client_ids_are_stable_and_rung_scoped():
+    from app.services.order_proposals import revalidation as mod
+
+    proposal_id = uuid.UUID("12345678-1234-5678-1234-567812345678")
+    first = mod._proposal_client_order_id(proposal_id, 0)
+    assert first == mod._proposal_client_order_id(proposal_id, 0)
+    assert first != mod._proposal_client_order_id(proposal_id, 1)
+    assert first != mod._proposal_client_order_id(uuid.uuid4(), 0)
+    assert first.startswith("oprop-")
+    assert len(first) <= 40
+
+
+@pytest.mark.asyncio
+async def test_upbit_revalidation_binds_same_proposal_client_id_to_preview_and_submit(
+    db_session,
+):
+    service = OrderProposalsService(db_session)
+    group = await service.create_proposal(
+        symbol="KRW-BTC",
+        market="crypto",
+        account_mode="upbit",
+        side="buy",
+        order_type="limit",
+        proposer="p",
+        rungs=[RungInput(0, "buy", Decimal("0.01"), Decimal("70000000"), None)],
+    )
+    await db_session.commit()
+    calls: list[dict] = []
+
+    async def accepted(**kwargs):
+        calls.append(kwargs)
+        if kwargs["dry_run"]:
+            return {
+                "success": True,
+                "approval_hash": "upbit-token",
+                "price": "70000000",
+                "quantity": "0.01",
+            }
+        return {"success": True, "status": "resting", "broker_order_id": "upbit-1"}
+
+    outcomes = await revalidate_and_submit(
+        service=service,
+        proposal_id=group.proposal_id,
+        now=datetime.now(UTC),
+        place_order_fn=accepted,
+    )
+
+    from app.services.order_proposals import revalidation as mod
+
+    expected = mod._proposal_client_order_id(group.proposal_id, 0)
+    assert outcomes[0].result == "submitted_resting"
+    assert [call["proposal_client_order_id"] for call in calls] == [
+        expected,
+        expected,
+    ]
+
+
+@pytest.mark.asyncio
+async def test_default_place_order_forwards_proposal_client_id_to_preview_and_submit(
+    monkeypatch,
+):
+    from app.services.order_proposals import revalidation as mod
+    import app.mcp_server.tooling.order_execution as order_execution
+
+    calls: list[dict] = []
+
+    async def fake_impl(**kwargs):
+        calls.append(kwargs)
+        return {"success": True}
+
+    monkeypatch.setattr(order_execution, "_place_order_impl", fake_impl)
+    expected = mod._proposal_client_order_id(
+        uuid.UUID("12345678-1234-5678-1234-567812345678"), 0
+    )
+    for dry_run in (True, False):
+        await mod._default_place_order_fn(
+            dry_run=dry_run,
+            account_mode="upbit",
+            symbol="KRW-BTC",
+            side="buy",
+            market="crypto",
+            order_type="limit",
+            quantity=Decimal("0.01"),
+            price=Decimal("70000000"),
+            proposal_client_order_id=expected,
+        )
+
+    assert [call["client_order_id"] for call in calls] == [expected, expected]
+
+
 @pytest.mark.asyncio
 async def test_toss_kr_routes_preview_and_accepted_submit(db_session, monkeypatch):
     svc = OrderProposalsService(db_session)

--- a/tests/services/order_proposals/test_revalidation.py
+++ b/tests/services/order_proposals/test_revalidation.py
@@ -1618,6 +1618,8 @@ async def test_replace_confirmation_exception_returns_unverified_no_submit(db_se
 async def test_replace_submit_ambiguity_persists_reconcile_lineage(
     db_session, submit_result
 ):
+    from app.services.order_proposals import revalidation as mod
+
     service, group = await _create_target_proposal(db_session, action="replace")
     snapshots = iter([_target_snapshot(), _target_snapshot(status="cancelled")])
 
@@ -1637,6 +1639,9 @@ async def test_replace_submit_ambiguity_persists_reconcile_lineage(
             raise TimeoutError("submit outcome unknown")
         return {"success": True, "status": "unknown"}
 
+    async def evidence_fn(**kwargs):
+        return SubmitEvidence("unknown", reason="lookup unavailable")
+
     outcomes = await revalidate_and_submit(
         service=service,
         proposal_id=group.proposal_id,
@@ -1645,12 +1650,71 @@ async def test_replace_submit_ambiguity_persists_reconcile_lineage(
         fetch_target_fn=fetch_target_fn,
         cancel_target_fn=cancel_target_fn,
         correlation_mint=lambda **kwargs: "corr-replace-1",
+        fetch_submit_evidence_fn=evidence_fn,
     )
 
     assert outcomes[0].result == "unverified"
     _, rungs = await service.get_proposal(group.proposal_id)
     assert rungs[0].correlation_id == "corr-replace-1"
-    assert rungs[0].idempotency_key == "idem-replace-1"
+    assert rungs[0].idempotency_key == mod._proposal_client_order_id(
+        group.proposal_id, 0
+    )
+
+
+@pytest.mark.asyncio
+async def test_replace_submit_failure_found_evidence_converges_resting(
+    db_session, monkeypatch
+):
+    from app.services.order_proposals import revalidation as mod
+
+    service, group = await _create_target_proposal(db_session, action="replace")
+    monkeypatch.setattr(mod, "_proposal_client_order_id", lambda *_: "oprop-replace")
+    snapshots = iter([_target_snapshot(), _target_snapshot(status="cancelled")])
+    place_calls: list[dict] = []
+    evidence_calls: list[dict] = []
+
+    async def fetch_target_fn(**kwargs):
+        return next(snapshots)
+
+    async def cancel_target_fn(**kwargs):
+        return {"success": True}
+
+    async def place_order_fn(**kwargs):
+        place_calls.append(kwargs)
+        if kwargs["dry_run"]:
+            return await _matching_preview(**kwargs)
+        return {"success": False, "error": "duplicate identifier"}
+
+    async def evidence_fn(**kwargs):
+        evidence_calls.append(kwargs)
+        return SubmitEvidence("found", "replacement-order", "wait")
+
+    outcomes = await revalidate_and_submit(
+        service=service,
+        proposal_id=group.proposal_id,
+        now=datetime.now(UTC),
+        place_order_fn=place_order_fn,
+        fetch_target_fn=fetch_target_fn,
+        cancel_target_fn=cancel_target_fn,
+        fetch_submit_evidence_fn=evidence_fn,
+    )
+
+    assert outcomes[0].result == "submitted_resting"
+    assert [call["proposal_client_order_id"] for call in place_calls] == [
+        "oprop-replace",
+        "oprop-replace",
+    ]
+    assert evidence_calls == [
+        {
+            "identifier": "oprop-replace",
+            "account_mode": "upbit",
+            "market": "crypto",
+        }
+    ]
+    _, rungs = await service.get_proposal(group.proposal_id)
+    assert rungs[0].state == "resting"
+    assert rungs[0].broker_order_id == "replacement-order"
+    assert rungs[0].idempotency_key == "oprop-replace"
 
 
 @pytest.mark.asyncio

--- a/tests/services/order_proposals/test_revalidation.py
+++ b/tests/services/order_proposals/test_revalidation.py
@@ -1056,7 +1056,9 @@ def _upbit_preview() -> dict[str, str | bool]:
 
 
 @pytest.mark.asyncio
-async def test_upbit_submit_failure_found_evidence_converges_resting(db_session, monkeypatch):
+async def test_upbit_submit_failure_found_evidence_converges_resting(
+    db_session, monkeypatch
+):
     from app.services.order_proposals import revalidation as mod
 
     service, group = await _create_upbit_submit_proposal(db_session)
@@ -1092,7 +1094,9 @@ async def test_upbit_submit_failure_found_evidence_converges_resting(db_session,
 
 
 @pytest.mark.asyncio
-async def test_upbit_true_rejection_absent_evidence_is_rejected(db_session, monkeypatch):
+async def test_upbit_true_rejection_absent_evidence_is_rejected(
+    db_session, monkeypatch
+):
     from app.services.order_proposals import revalidation as mod
 
     service, group = await _create_upbit_submit_proposal(db_session)

--- a/tests/services/order_proposals/test_revalidation.py
+++ b/tests/services/order_proposals/test_revalidation.py
@@ -1033,8 +1033,8 @@ async def test_upbit_revalidation_binds_same_proposal_client_id_to_preview_and_s
 async def test_default_place_order_forwards_proposal_client_id_to_preview_and_submit(
     monkeypatch,
 ):
-    from app.services.order_proposals import revalidation as mod
     import app.mcp_server.tooling.order_execution as order_execution
+    from app.services.order_proposals import revalidation as mod
 
     calls: list[dict] = []
 

--- a/tests/services/order_proposals/test_revalidation.py
+++ b/tests/services/order_proposals/test_revalidation.py
@@ -3,9 +3,11 @@ from datetime import UTC, datetime
 from decimal import Decimal
 from types import SimpleNamespace
 
+import httpx
 import pytest
 
 from app.services.order_proposals import OrderProposalsService
+from app.services.order_proposals.broker_gateway import SubmitEvidence
 from app.services.order_proposals.revalidation import (
     _adapt_live_submit_response,
     revalidate_and_submit,
@@ -1027,6 +1029,179 @@ async def test_upbit_revalidation_binds_same_proposal_client_id_to_preview_and_s
         expected,
         expected,
     ]
+
+
+async def _create_upbit_submit_proposal(db_session):
+    service = OrderProposalsService(db_session)
+    group = await service.create_proposal(
+        symbol="KRW-BTC",
+        market="crypto",
+        account_mode="upbit",
+        side="buy",
+        order_type="limit",
+        proposer="p",
+        rungs=[RungInput(0, "buy", Decimal("0.01"), Decimal("70000000"), None)],
+    )
+    await db_session.commit()
+    return service, group
+
+
+def _upbit_preview() -> dict[str, str | bool]:
+    return {
+        "success": True,
+        "approval_hash": "upbit-approval",
+        "price": "70000000",
+        "quantity": "0.01",
+    }
+
+
+@pytest.mark.asyncio
+async def test_upbit_submit_failure_found_evidence_converges_resting(db_session, monkeypatch):
+    from app.services.order_proposals import revalidation as mod
+
+    service, group = await _create_upbit_submit_proposal(db_session)
+    monkeypatch.setattr(mod, "_proposal_client_order_id", lambda *_: "oprop-expected")
+    live_calls: list[str] = []
+    evidence_calls: list[dict] = []
+
+    async def place_order_fn(**kwargs):
+        if kwargs["dry_run"]:
+            return _upbit_preview()
+        live_calls.append(kwargs["proposal_client_order_id"])
+        return {"success": False}
+
+    async def evidence_fn(**kwargs):
+        evidence_calls.append(kwargs)
+        return SubmitEvidence("found", "35bee07f-full", "wait")
+
+    outcomes = await revalidate_and_submit(
+        service=service,
+        proposal_id=group.proposal_id,
+        now=datetime.now(UTC),
+        place_order_fn=place_order_fn,
+        fetch_submit_evidence_fn=evidence_fn,
+    )
+
+    assert live_calls == ["oprop-expected"]
+    assert len(evidence_calls) == 1
+    assert outcomes[0].result == "submitted_resting"
+    _, rungs = await service.get_proposal(group.proposal_id)
+    assert rungs[0].state == "resting"
+    assert rungs[0].broker_order_id == "35bee07f-full"
+    assert rungs[0].idempotency_key == "oprop-expected"
+
+
+@pytest.mark.asyncio
+async def test_upbit_true_rejection_absent_evidence_is_rejected(db_session, monkeypatch):
+    from app.services.order_proposals import revalidation as mod
+
+    service, group = await _create_upbit_submit_proposal(db_session)
+    monkeypatch.setattr(mod, "_proposal_client_order_id", lambda *_: "oprop-expected")
+    live_calls: list[str] = []
+    evidence_calls = 0
+
+    async def place_order_fn(**kwargs):
+        if kwargs["dry_run"]:
+            return _upbit_preview()
+        live_calls.append(kwargs["proposal_client_order_id"])
+        return {"success": False, "error": "insufficient balance"}
+
+    async def evidence_fn(**kwargs):
+        nonlocal evidence_calls
+        evidence_calls += 1
+        return SubmitEvidence("absent")
+
+    outcomes = await revalidate_and_submit(
+        service=service,
+        proposal_id=group.proposal_id,
+        now=datetime.now(UTC),
+        place_order_fn=place_order_fn,
+        fetch_submit_evidence_fn=evidence_fn,
+    )
+
+    assert outcomes[0].result == "error"
+    assert live_calls == ["oprop-expected"]
+    assert evidence_calls == 1
+    _, rungs = await service.get_proposal(group.proposal_id)
+    assert rungs[0].state == "rejected"
+    assert rungs[0].void_reason == "insufficient balance"
+
+
+@pytest.mark.asyncio
+async def test_upbit_submit_evidence_unknown_is_unverified(db_session, monkeypatch):
+    from app.services.order_proposals import revalidation as mod
+
+    service, group = await _create_upbit_submit_proposal(db_session)
+    monkeypatch.setattr(mod, "_proposal_client_order_id", lambda *_: "oprop-expected")
+    live_calls: list[str] = []
+    evidence_calls = 0
+
+    async def place_order_fn(**kwargs):
+        if kwargs["dry_run"]:
+            return _upbit_preview()
+        live_calls.append(kwargs["proposal_client_order_id"])
+        return {"success": False, "error": "submit not confirmed"}
+
+    async def evidence_fn(**kwargs):
+        nonlocal evidence_calls
+        evidence_calls += 1
+        return SubmitEvidence("unknown", reason="timeout")
+
+    outcomes = await revalidate_and_submit(
+        service=service,
+        proposal_id=group.proposal_id,
+        now=datetime.now(UTC),
+        place_order_fn=place_order_fn,
+        correlation_mint=lambda **_: "corr-expected",
+        fetch_submit_evidence_fn=evidence_fn,
+    )
+
+    assert outcomes[0].result == "unverified"
+    assert live_calls == ["oprop-expected"]
+    assert evidence_calls == 1
+    _, rungs = await service.get_proposal(group.proposal_id)
+    assert rungs[0].state == "unverified"
+    assert rungs[0].idempotency_key == "oprop-expected"
+    assert rungs[0].correlation_id == "corr-expected"
+    assert rungs[0].void_reason == "submit_evidence_unknown:timeout"
+
+
+@pytest.mark.asyncio
+async def test_upbit_submit_exception_found_evidence_converges_resting(
+    db_session, monkeypatch
+):
+    from app.services.order_proposals import revalidation as mod
+
+    service, group = await _create_upbit_submit_proposal(db_session)
+    monkeypatch.setattr(mod, "_proposal_client_order_id", lambda *_: "oprop-expected")
+    live_calls: list[str] = []
+    evidence_calls = 0
+
+    async def place_order_fn(**kwargs):
+        if kwargs["dry_run"]:
+            return _upbit_preview()
+        live_calls.append(kwargs["proposal_client_order_id"])
+        raise httpx.ReadTimeout("submit timeout")
+
+    async def evidence_fn(**kwargs):
+        nonlocal evidence_calls
+        evidence_calls += 1
+        return SubmitEvidence("found", "35bee07f-full", "watch")
+
+    outcomes = await revalidate_and_submit(
+        service=service,
+        proposal_id=group.proposal_id,
+        now=datetime.now(UTC),
+        place_order_fn=place_order_fn,
+        fetch_submit_evidence_fn=evidence_fn,
+    )
+
+    assert outcomes[0].result == "submitted_resting"
+    assert live_calls == ["oprop-expected"]
+    assert evidence_calls == 1
+    _, rungs = await service.get_proposal(group.proposal_id)
+    assert rungs[0].state == "resting"
+    assert rungs[0].broker_order_id == "35bee07f-full"
 
 
 @pytest.mark.asyncio

--- a/tests/test_mcp_place_order.py
+++ b/tests/test_mcp_place_order.py
@@ -3000,3 +3000,74 @@ async def test_place_order_impl_rejects_mock_crypto_before_upbit_reads(monkeypat
     market_buy.assert_not_awaited()
     place_sell.assert_not_awaited()
     market_sell.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_place_order_impl_client_order_id_override_reaches_execution(monkeypatch):
+    executed = AsyncMock(return_value={"success": True, "broker_status": "accepted"})
+    monkeypatch.setattr(
+        order_execution,
+        "_fetch_current_price",
+        AsyncMock(return_value=70_000_000.0),
+    )
+    monkeypatch.setattr(
+        order_execution,
+        "_build_preview",
+        AsyncMock(return_value={"estimated_value": 700_000.0}),
+    )
+    monkeypatch.setattr(
+        order_execution,
+        "_check_balance_and_warn",
+        AsyncMock(return_value=(None, None)),
+    )
+    monkeypatch.setattr(
+        order_execution,
+        "evaluate_sector_concentration",
+        AsyncMock(return_value={"verdict": "ok"}),
+    )
+    monkeypatch.setattr(
+        order_execution,
+        "_get_crypto_trade_cooldown_service",
+        lambda: type("Cooldown", (), {"is_in_cooldown": AsyncMock(return_value=False)})(),
+    )
+    monkeypatch.setattr(order_execution, "_execute_and_record", executed)
+
+    result = await order_execution._place_order_impl(
+        symbol="KRW-BTC",
+        side="buy",
+        market="crypto",
+        order_type="limit",
+        quantity=0.01,
+        price=70_000_000.0,
+        dry_run=False,
+        thesis="t",
+        strategy="s",
+        client_order_id="oprop-fixed",
+    )
+
+    assert result["success"] is True
+    assert executed.await_args.kwargs["idempotency_key"] == "oprop-fixed"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("client_order_id", ["", " ", "x" * 41])
+async def test_place_order_impl_rejects_invalid_client_order_id_before_execution(
+    monkeypatch, client_order_id
+):
+    executed = AsyncMock()
+    monkeypatch.setattr(order_execution, "_execute_and_record", executed)
+
+    result = await order_execution._place_order_impl(
+        symbol="KRW-BTC",
+        side="buy",
+        market="crypto",
+        order_type="limit",
+        quantity=0.01,
+        price=70_000_000.0,
+        dry_run=False,
+        client_order_id=client_order_id,
+    )
+
+    assert result["success"] is False
+    assert "client_order_id" in result["error"]
+    executed.assert_not_awaited()

--- a/tests/test_mcp_place_order.py
+++ b/tests/test_mcp_place_order.py
@@ -3028,7 +3028,9 @@ async def test_place_order_impl_client_order_id_override_reaches_execution(monke
     monkeypatch.setattr(
         order_execution,
         "_get_crypto_trade_cooldown_service",
-        lambda: type("Cooldown", (), {"is_in_cooldown": AsyncMock(return_value=False)})(),
+        lambda: type(
+            "Cooldown", (), {"is_in_cooldown": AsyncMock(return_value=False)}
+        )(),
     )
     monkeypatch.setattr(order_execution, "_execute_and_record", executed)
 

--- a/tests/test_upbit_orders.py
+++ b/tests/test_upbit_orders.py
@@ -95,3 +95,21 @@ class TestUpbitOrderIdempotencyIdentifier:
         await orders.place_buy_order("KRW-BTC", "1000", "0.5", "limit")
         second = request.await_args.kwargs["body_params"]["identifier"]
         assert first != second
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_fetch_order_by_identifier_uses_read_only_get(monkeypatch):
+    from app.services.brokers.upbit import orders
+
+    request = AsyncMock(return_value={"uuid": "35bee07f-full", "state": "wait"})
+    monkeypatch.setattr(orders._client, "_request_with_auth", request)
+
+    result = await orders.fetch_order_by_identifier("oprop-fixed")
+
+    assert result["uuid"] == "35bee07f-full"
+    request.assert_awaited_once_with(
+        "GET",
+        f"{orders._client.UPBIT_REST}/order",
+        query_params={"identifier": "oprop-fixed"},
+    )

--- a/tests/test_upbit_retry.py
+++ b/tests/test_upbit_retry.py
@@ -79,6 +79,27 @@ async def test_exhausts_retries_raises_rate_limit_error():
 
 
 @pytest.mark.asyncio
+async def test_order_post_429_is_not_retried(monkeypatch):
+    from app.services.brokers.upbit.client import _retry_with_backoff
+
+    response = _make_response(429)
+    send = AsyncMock(return_value=response)
+    sleep = AsyncMock()
+    monkeypatch.setattr("app.services.brokers.upbit.client.asyncio.sleep", sleep)
+
+    with pytest.raises(RateLimitExceededError):
+        await _retry_with_backoff(
+            _make_limiter(),
+            send,
+            url="https://api.upbit.com/v1/orders",
+            max_retries=0,
+            retry_request_errors=False,
+        )
+
+    assert send.await_count == 1
+
+
+@pytest.mark.asyncio
 async def test_retries_on_request_error_then_succeeds():
     from app.services.brokers.upbit.client import _retry_with_backoff
 
@@ -130,7 +151,7 @@ async def test_no_retry_on_request_error_when_disabled():
 
 @pytest.mark.asyncio
 async def test_order_post_disables_request_error_retry(monkeypatch):
-    """ROB-645: _request_with_auth POST /orders threads retry_request_errors=False."""
+    """ROB-837: _request_with_auth POST /orders selects one-shot transport."""
     from unittest.mock import MagicMock
 
     from app.services.brokers.upbit import client
@@ -151,6 +172,7 @@ async def test_order_post_disables_request_error_retry(monkeypatch):
     )
 
     assert captured["retry_request_errors"] is False
+    assert captured["max_retries"] == 0
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Root cause

ROB-645 disabled `httpx.RequestError` retries for `POST /v1/orders`, but explicitly left HTTP 429 retries enabled. The proposal path already passed a deterministic ROB-653 identifier into the Upbit request. `_request_with_auth` retried the same request body, so if the first POST created the order while returning a retryable 429, the next POST reused the same identifier and Upbit returned 400 instead of returning the original order.

The final 400 was adapted to `success=False`, and proposal classification recorded `rejected` without querying Upbit. This produced the measured mismatch: live Upbit order `35bee07f…` in `wait`, proposal `b81ffd0e…` rejected, and an operator-facing error.

## What this PR fixes (ROB-837)

1. **One-shot transport** — `POST /v1/orders` now passes `max_retries=0` and `retry_request_errors=False`. GET and DELETE retain their existing retry behavior.
2. **Stable proposal identifier** — both `place` and the new-order leg of `replace` bind the same `oprop-<32hex sha256>` identifier across preview and submit. No retry path mints a new identifier.
3. **Evidence-gated classification** — failed Upbit submits are queried by identifier before terminal classification:
   - `found` with `wait`/`watch` → `resting`, broker UUID bound;
   - other found states → `acked`, broker UUID bound for later lifecycle reconciliation;
   - `absent` (only broker 404) → `rejected`;
   - `unknown` → `unverified`, identifier/correlation retained.
4. **Guarded incident repair** — the one-time CLI verifies the exact incident prefixes, broker `wait` evidence, local/broker symbol, side, order type, price, and quantity. It recomputes group lifecycle from every rung and never places, cancels, replaces, or resubmits an order.

ROB-825 generation semantics and ROB-835 cancellation-confirmation polling remain out of scope.

## Test evidence (mocked, no live calls)

Local verification after review fixes:

```text
164 passed — focused Upbit/proposal/Telegram/repair suites
81 passed  — tests/test_mcp_place_order.py
make lint  — ruff check, format check, ty check all clean
uv run ty check app/ scripts/rob837_reconcile_upbit_proposal.py — clean
```

Regression coverage includes:

- Upbit order POST is invoked once for 429 and RequestError outcomes.
- Place and replace preview/submit use the same proposal identifier.
- Submit failure plus found broker evidence converges to `resting` with `broker_order_id`.
- True rejection plus definitive absence remains `rejected`.
- Lookup ambiguity remains `unverified`.
- Repair dry-run writes nothing; local/broker mismatches abort; multi-rung lifecycle is recomputed.
- Static safety test rejects mutating broker-operation imports in the repair script.

## Post-deploy repair

Use operator-supplied full UUIDs. The command is dry-run by default and keeps the live order untouched.

```bash
uv run python -m scripts.rob837_reconcile_upbit_proposal \
    --proposal-id <full-uuid-starting-b81ffd0e> \
    --broker-order-id <full-uuid-starting-35bee07f>

uv run python -m scripts.rob837_reconcile_upbit_proposal \
    --proposal-id <full-uuid-starting-b81ffd0e> \
    --broker-order-id <full-uuid-starting-35bee07f> \
    --commit
```

## Do not merge automatically

Operator review is required before merge. Deploy first, inspect the dry-run evidence against the ROB-837 incident, then execute `--commit` only when every guard passes.
