### PR TITLE
fix(ROB-841): fail closed on invalid Binance Demo market conditions

### DIFF
--- a/app/mcp_server/README.md
+++ b/app/mcp_server/README.md
@@ -2034,3 +2034,30 @@ Each typed tool rejects any `account_mode` value other than its own pinned mode.
 ```
 
 With all mock vars missing, the `hermes-paper-kis` profile is effectively read-only KIS — the safe state for a misconfigured paper deployment.
+
+### Binance Demo scalping — server-derived market conditions (ROB-841)
+
+`binance_demo_scalping_submit_decision` (registered only when
+`settings.binance_demo_scalping_enabled` is true) accepts an LLM/MCP decision
+but **never** accepts caller-supplied spread or data-age. Before any risk check,
+the handler derives a `MarketConditions` snapshot **server-side** from the
+Demo-host bookTicker + latest 1m kline (`build_market_conditions`), and only that
+server-observed snapshot feeds the existing risk gates.
+
+- **Fail-closed**: if the bookTicker/kline provider fails, the kline is
+  empty/malformed, its timestamp is missing, or the quote is invalid (crossed or
+  non-positive), the tool returns `status="market_conditions_unavailable"` and
+  places **no order** — zero broker submit and zero ledger read/write. The
+  executor preflight also fails closed (`market_conditions_unavailable`) if a
+  caller omits the snapshot; the old `spread_bps=0`/`data_age_seconds=0`
+  synthesis (which silently disarmed the gates) is removed.
+- **Existing threshold reason codes are unchanged**: an over-threshold snapshot
+  is rejected as `stale_data` (`data_age_seconds > max_data_age_seconds`) or
+  `spread_too_wide` (`spread_bps > max_spread_bps`).
+- **Dry-run parity**: `dry_run=True` runs the same server-derived market/risk
+  preflight and returns the same judgment (`planned` / `blocked` /
+  `market_conditions_unavailable`, plus the observed `market_conditions`), but
+  performs no broker mutation and inserts no ledger row. A real Demo order still
+  requires `dry_run=false` **and** `confirm=true`.
+- Demo-host allowlist, notional/daily-loss/cooldown caps, and the broker-native
+  ledger/reconcile contract are unchanged.

--- a/app/mcp_server/tooling/binance_demo_scalping_handler.py
+++ b/app/mcp_server/tooling/binance_demo_scalping_handler.py
@@ -17,11 +17,15 @@ from decimal import Decimal
 from typing import Any, Literal
 
 from app.services.brokers.binance.demo_scalping.contract import ScalpingRiskLimits
+from app.services.brokers.binance.demo_scalping.market_data import (
+    MarketConditionsUnavailable,
+)
 from app.services.brokers.binance.demo_scalping.order_intent import OrderIntent
 
 logger = logging.getLogger(__name__)
 
 _ALLOWLIST = frozenset({"XRPUSDT", "DOGEUSDT", "SOLUSDT"})
+_PRODUCT = "usdm_futures"
 
 
 def _build_intent(
@@ -44,7 +48,7 @@ def _build_intent(
     )
 
 
-async def _execute_confirmed_round_trip(
+async def _build_conditions_and_run(
     *,
     symbol: str,
     side: str,
@@ -54,13 +58,21 @@ async def _execute_confirmed_round_trip(
     session_tag: str,
     signal_snapshot: dict[str, Any],
     now: dt.datetime,
-) -> Any:
-    """Construct the demo executor and run one monitored round-trip. Real Demo
-    order — only reached on confirm=True. Mirrors the confirmed execution path in
-    scripts/binance_demo_scalping_execute.py."""
+    confirm: bool,
+) -> tuple[Any, Any]:
+    """Collect a *server-derived* MarketConditions snapshot from the Demo host,
+    then run the executor preflight (``confirm=False`` → dry-run judgment) or the
+    full monitored round-trip (``confirm=True`` → real Demo order).
+
+    The snapshot is built BEFORE any session is opened or signed client is
+    constructed, so an unavailable snapshot (raised as
+    :class:`MarketConditionsUnavailable`) touches neither broker nor ledger
+    (ROB-841 AC1). ``confirm=False`` reads the ledger for the risk preflight but
+    inserts nothing and places no order (AC6). Returns ``(market, result)``."""
     from app.core.db import AsyncSessionLocal
     from app.services.brokers.binance.demo_scalping.market_data import (
         DemoScalpingMarketData,
+        build_market_conditions,
     )
     from app.services.brokers.binance.demo_scalping_exec.executor import (
         DemoScalpingExecutor,
@@ -73,13 +85,23 @@ async def _execute_confirmed_round_trip(
     )
 
     limits = ScalpingRiskLimits()
-    client = BinanceFuturesDemoExecutionClient.from_env()
     reference = DemoReferenceData()
     market_data = DemoScalpingMarketData()
+    client: Any = None
     try:
+        # Server-observed spread + data-age BEFORE any ledger/broker touch.
+        # The builder samples the clock after both observations complete, so
+        # fetch latency is counted toward staleness (no now_ms passed in).
+        market = await build_market_conditions(
+            market_data, product=_PRODUCT, symbol=symbol
+        )
+        # The signed client is constructed ONLY for a real order, and only
+        # after conditions are proven available.
+        if confirm:
+            client = BinanceFuturesDemoExecutionClient.from_env()
         async with AsyncSessionLocal() as session:
             executor = DemoScalpingExecutor(
-                product="usdm_futures",
+                product=_PRODUCT,
                 client=client,
                 session=session,
                 reference=reference,
@@ -92,20 +114,136 @@ async def _execute_confirmed_round_trip(
             )
             result = await executor.execute_monitored(
                 intent,
-                confirm=True,
+                confirm=confirm,
+                market=market,
                 tp_bps=tp_bps,
                 sl_bps=sl_bps,
                 session_tag=session_tag,
                 signal_snapshot=signal_snapshot,
             )
-            await session.commit()
-            return result
+            if confirm:
+                await session.commit()
+            return market, result
     finally:
         await reference.aclose()
         await market_data.aclose()
         aclose = getattr(client, "aclose", None)
         if aclose is not None:
             await aclose()
+
+
+async def _execute_confirmed_round_trip(
+    *,
+    symbol: str,
+    side: str,
+    tp_bps: Decimal,
+    sl_bps: Decimal,
+    notional_usdt: Decimal,
+    session_tag: str,
+    signal_snapshot: dict[str, Any],
+    now: dt.datetime,
+) -> Any:
+    """Real Demo order — only reached on confirm=True. Server-derived market
+    conditions are collected and handed to the executor; an unavailable snapshot
+    raises before any broker/ledger interaction."""
+    _market, result = await _build_conditions_and_run(
+        symbol=symbol,
+        side=side,
+        tp_bps=tp_bps,
+        sl_bps=sl_bps,
+        notional_usdt=notional_usdt,
+        session_tag=session_tag,
+        signal_snapshot=signal_snapshot,
+        now=now,
+        confirm=True,
+    )
+    return result
+
+
+async def _dry_run_preflight(
+    *,
+    symbol: str,
+    side: str,
+    tp_bps: Decimal,
+    sl_bps: Decimal,
+    notional_usdt: Decimal,
+    signal_snapshot: dict[str, Any],
+    now: dt.datetime,
+) -> tuple[Any, Any]:
+    """Same server-derived market/risk preflight as a real order, but with no
+    broker mutation and no ledger insert (ROB-841 AC6). Returns
+    ``(market, result)`` where ``result`` is a ``dry_run`` or ``blocked``
+    ExecutionResult."""
+    return await _build_conditions_and_run(
+        symbol=symbol,
+        side=side,
+        tp_bps=tp_bps,
+        sl_bps=sl_bps,
+        notional_usdt=notional_usdt,
+        session_tag="llm",
+        signal_snapshot=signal_snapshot,
+        now=now,
+        confirm=False,
+    )
+
+
+def _unavailable_response(
+    sym: str, side: str, exc: MarketConditionsUnavailable, *, dry_run: bool
+) -> dict[str, Any]:
+    """Fail-close response: no trustworthy server market snapshot, no order."""
+    return {
+        "status": "market_conditions_unavailable",
+        "dry_run": dry_run,
+        "symbol": sym,
+        "side": side,
+        "reason": exc.reason,
+        "note": (
+            "server could not derive a trustworthy market snapshot "
+            "(spread/data-age); no order placed and no ledger touched"
+        ),
+    }
+
+
+def _dry_run_response(
+    sym: str,
+    side: str,
+    rationale: str,
+    result: Any,
+    market: Any,
+    tp_bps: float,
+    sl_bps: float,
+) -> dict[str, Any]:
+    """Map a dry-run ExecutionResult (dry_run/blocked) to the tool response,
+    echoing the *server-observed* market snapshot for auditability."""
+    base: dict[str, Any] = {
+        "dry_run": True,
+        "symbol": sym,
+        "side": side,
+        "rationale": rationale,
+        "session_tag": "llm",
+        "tp_bps": str(tp_bps),
+        "sl_bps": str(sl_bps),
+        "market_conditions": {
+            "spread_bps": str(market.spread_bps),
+            "data_age_seconds": market.data_age_seconds,
+        },
+    }
+    if result.status == "blocked":
+        return {
+            **base,
+            "status": "blocked",
+            "reason_codes": list(result.reason_codes),
+            "note": "server-derived market/risk preflight blocked this order",
+        }
+    sized_notional = getattr(result, "sized_notional_usdt", None)
+    sized_qty = getattr(result, "sized_qty", None)
+    return {
+        **base,
+        "status": "planned",
+        "notional_usdt": None if sized_notional is None else str(sized_notional),
+        "sized_qty": None if sized_qty is None else str(sized_qty),
+        "note": "set dry_run=false AND confirm=true to place the real Demo order",
+    }
 
 
 async def binance_demo_scalping_submit_decision(
@@ -145,22 +283,34 @@ async def binance_demo_scalping_submit_decision(
         "tp_bps": str(tp_bps),
         "sl_bps": str(sl_bps),
     }
+    now = dt.datetime.now(dt.UTC)
 
     if dry_run or not confirm:
-        return {
-            "status": "planned",
-            "dry_run": True,
-            "symbol": sym,
-            "side": side,
-            "rationale": rationale.strip(),
-            "session_tag": "llm",
-            "notional_usdt": str(notional),
-            "tp_bps": str(tp_bps),
-            "sl_bps": str(sl_bps),
-            "note": "set dry_run=false AND confirm=true to place the real Demo order",
-        }
+        # ROB-841 AC6: run the SAME server-derived market/risk preflight as a
+        # real order, but place no order and insert no ledger row.
+        try:
+            market, result = await _dry_run_preflight(
+                symbol=sym,
+                side=side,
+                tp_bps=Decimal(str(tp_bps)),
+                sl_bps=Decimal(str(sl_bps)),
+                notional_usdt=notional,
+                signal_snapshot=signal_snapshot,
+                now=now,
+            )
+        except MarketConditionsUnavailable as exc:
+            return _unavailable_response(sym, side, exc, dry_run=True)
+        except Exception as exc:  # noqa: BLE001 — surface setup errors as data
+            logger.exception("binance demo scalping dry-run preflight failed")
+            return {
+                "status": "error",
+                "dry_run": True,
+                "error": f"{type(exc).__name__}: {exc}",
+            }
+        return _dry_run_response(
+            sym, side, rationale.strip(), result, market, tp_bps, sl_bps
+        )
 
-    now = dt.datetime.now(dt.UTC)
     try:
         result = await _execute_confirmed_round_trip(
             symbol=sym,
@@ -172,6 +322,8 @@ async def binance_demo_scalping_submit_decision(
             signal_snapshot=signal_snapshot,
             now=now,
         )
+    except MarketConditionsUnavailable as exc:
+        return _unavailable_response(sym, side, exc, dry_run=False)
     except Exception as exc:  # noqa: BLE001 — surface broker/setup errors as data
         logger.exception("binance demo scalping submit_decision failed")
         return {"status": "error", "error": f"{type(exc).__name__}: {exc}"}

--- a/app/services/brokers/binance/demo_scalping/contract.py
+++ b/app/services/brokers/binance/demo_scalping/contract.py
@@ -49,6 +49,10 @@ class ReasonCode:
     # Market-condition gates
     SPREAD_TOO_WIDE = "spread_too_wide"
     STALE_DATA = "stale_data"
+    # Fail-close when no trustworthy server-observed market snapshot exists
+    # (provider failure / empty|malformed kline / missing timestamp / bad quote).
+    # ROB-841: replaces the old 0/0 synthesis that silently disarmed the gates.
+    MARKET_CONDITIONS_UNAVAILABLE = "market_conditions_unavailable"
     # Sizing / notional
     NOTIONAL_ABOVE_CAP = "notional_above_cap"
     NOTIONAL_BELOW_MIN = "notional_below_min"

--- a/app/services/brokers/binance/demo_scalping/market_data.py
+++ b/app/services/brokers/binance/demo_scalping/market_data.py
@@ -13,12 +13,17 @@ No signing, no credentials, no order endpoints reachable from this module.
 
 from __future__ import annotations
 
+import time
+from collections.abc import Callable
 from dataclasses import dataclass
 from decimal import Decimal
 
 import httpx
 
-from app.services.brokers.binance.demo_scalping.contract import Product
+from app.services.brokers.binance.demo_scalping.contract import (
+    MarketConditions,
+    Product,
+)
 from app.services.brokers.binance.demo_scalping.signal import Candle
 
 DEMO_DATA_HOSTS: frozenset[str] = frozenset(
@@ -43,6 +48,20 @@ _BPS = Decimal("10000")
 
 class DemoDataHostBlocked(RuntimeError):
     """Raised when a request targets a host outside ``DEMO_DATA_HOSTS``."""
+
+
+class MarketConditionsUnavailable(RuntimeError):
+    """The server could not derive a trustworthy market snapshot.
+
+    Raised on provider failure, an empty/malformed kline, a missing/invalid
+    kline timestamp, or an invalid bid/ask quote. Callers MUST fail closed —
+    no broker submit, no ledger read/write — rather than synthesize a 0/0
+    snapshot that would silently disarm the spread/staleness gates (ROB-841).
+    """
+
+    def __init__(self, reason: str) -> None:
+        super().__init__(reason)
+        self.reason = reason
 
 
 def assert_demo_data_host(host: str) -> None:
@@ -74,6 +93,84 @@ def data_age_seconds(latest: Candle, *, now_ms: int) -> float:
     skew so the age is never negative.
     """
     return max(0.0, (now_ms - latest.open_time_ms) / 1000.0)
+
+
+def _default_clock_ms() -> int:
+    """Wall-clock epoch milliseconds. Injectable so tests can drive
+    fetch-latency scenarios deterministically."""
+    return int(time.time() * 1000)
+
+
+def _validate_quote(book: BookTicker) -> None:
+    """Reject non-finite (NaN / ±Inf), non-positive, or crossed (ask < bid)
+    quotes as unavailable. The finiteness check runs first: comparing a
+    ``Decimal('NaN')`` with ``<=`` raises ``InvalidOperation`` (which would
+    otherwise leak as a generic error), and a ``Decimal('Infinity')`` ask
+    slips past ``ask < bid`` yet poisons ``spread_bps`` with ``NaN`` — so a
+    non-finite value must never reach the risk gates."""
+    if not (book.bid.is_finite() and book.ask.is_finite()):
+        raise MarketConditionsUnavailable(
+            f"non_finite_quote: bid={book.bid} ask={book.ask}"
+        )
+    if book.bid <= 0 or book.ask <= 0 or book.ask < book.bid:
+        raise MarketConditionsUnavailable(
+            f"invalid_quote: bid={book.bid} ask={book.ask}"
+        )
+
+
+async def build_market_conditions(
+    market_data: DemoScalpingMarketData,
+    *,
+    product: Product,
+    symbol: str,
+    clock_ms: Callable[[], int] = _default_clock_ms,
+    spot_free_base_qty: Decimal = Decimal("0"),
+) -> MarketConditions:
+    """Derive a *server-observed* :class:`MarketConditions` from the Demo-host
+    bookTicker + latest 1m kline (ROB-841).
+
+    The ``spread_bps`` and ``data_age_seconds`` fields are always measured from
+    the exchange's own quote/kline — never supplied or influenced by the caller.
+    Fails closed via :class:`MarketConditionsUnavailable` on any provider error,
+    empty/malformed kline, missing/invalid timestamp, or invalid/non-finite
+    quote, so the caller can reject the order without touching broker or ledger.
+
+    Data age is measured from a clock sampled **after both observations
+    complete** (``clock_ms``, injectable), so real bookTicker + kline fetch
+    latency is counted toward staleness — a pre-fetch clock could under-count
+    the age by seconds and slip a stale feed past the ``stale_data`` gate.
+
+    ``spot_free_base_qty`` is passed through for the spot long-only SELL gate;
+    it is irrelevant to (and unused by) the futures path.
+    """
+    try:
+        book = await market_data.fetch_book_ticker(product, symbol)
+        candles = await market_data.fetch_klines(
+            product, symbol, interval="1m", limit=1
+        )
+    except MarketConditionsUnavailable:
+        raise
+    except Exception as exc:  # noqa: BLE001 — any provider/parse error fails closed
+        raise MarketConditionsUnavailable(
+            f"provider_error: {type(exc).__name__}: {exc}"
+        ) from exc
+
+    # Sample the clock only after BOTH observations complete so fetch latency
+    # is counted toward the kline's age (see docstring).
+    observed_ms = clock_ms()
+
+    if not candles:
+        raise MarketConditionsUnavailable("empty_kline")
+    latest = candles[-1]
+    if latest.open_time_ms is None or latest.open_time_ms <= 0:
+        raise MarketConditionsUnavailable("missing_kline_timestamp")
+    _validate_quote(book)
+
+    return MarketConditions(
+        spread_bps=spread_bps(book),
+        data_age_seconds=data_age_seconds(latest, now_ms=observed_ms),
+        spot_free_base_qty=spot_free_base_qty,
+    )
 
 
 async def _enforce_demo_host(request: httpx.Request) -> None:

--- a/app/services/brokers/binance/demo_scalping/market_data.py
+++ b/app/services/brokers/binance/demo_scalping/market_data.py
@@ -101,6 +101,42 @@ def _default_clock_ms() -> int:
     return int(time.time() * 1000)
 
 
+def _validate_candle(candle: Candle) -> None:
+    """Semantic sanity of the latest kline (ROB-841). A row can carry the right
+    number of fields yet hold NaN/±Inf, non-positive, or self-contradictory
+    OHLC (e.g. ``high < low``) — ``open_time``-only validation would pass such a
+    poisoned candle as healthy. Reject it as unavailable instead.
+
+    Finiteness is checked FIRST so a ``Decimal('NaN')`` never reaches a ``<``/
+    ``max``/``min`` comparison (which would raise ``InvalidOperation`` and leak
+    as a generic error). No new field (e.g. volume) is consulted."""
+    ohlc = (candle.open, candle.high, candle.low, candle.close)
+    if not all(v.is_finite() for v in ohlc):
+        raise MarketConditionsUnavailable(
+            "non_finite_kline: "
+            f"o={candle.open} h={candle.high} l={candle.low} c={candle.close}"
+        )
+    if any(v <= 0 for v in ohlc):
+        raise MarketConditionsUnavailable(
+            "non_positive_kline: "
+            f"o={candle.open} h={candle.high} l={candle.low} c={candle.close}"
+        )
+    if (
+        candle.high < candle.low
+        or candle.high < max(candle.open, candle.close)
+        or candle.low > min(candle.open, candle.close)
+    ):
+        raise MarketConditionsUnavailable(
+            "inconsistent_kline_ohlc: "
+            f"o={candle.open} h={candle.high} l={candle.low} c={candle.close}"
+        )
+    if candle.close_time_ms < candle.open_time_ms:
+        raise MarketConditionsUnavailable(
+            "kline_time_disorder: "
+            f"open={candle.open_time_ms} close={candle.close_time_ms}"
+        )
+
+
 def _validate_quote(book: BookTicker) -> None:
     """Reject non-finite (NaN / ±Inf), non-positive, or crossed (ask < bid)
     quotes as unavailable. The finiteness check runs first: comparing a
@@ -132,8 +168,10 @@ async def build_market_conditions(
     The ``spread_bps`` and ``data_age_seconds`` fields are always measured from
     the exchange's own quote/kline — never supplied or influenced by the caller.
     Fails closed via :class:`MarketConditionsUnavailable` on any provider error,
-    empty/malformed kline, missing/invalid timestamp, or invalid/non-finite
-    quote, so the caller can reject the order without touching broker or ledger.
+    empty kline, missing/invalid timestamp, a semantically invalid kline
+    (non-finite / non-positive / inconsistent OHLC or disordered timestamps),
+    or an invalid/non-finite quote — so the caller can reject the order without
+    touching broker or ledger.
 
     Data age is measured from a clock sampled **after both observations
     complete** (``clock_ms``, injectable), so real bookTicker + kline fetch
@@ -164,6 +202,7 @@ async def build_market_conditions(
     latest = candles[-1]
     if latest.open_time_ms is None or latest.open_time_ms <= 0:
         raise MarketConditionsUnavailable("missing_kline_timestamp")
+    _validate_candle(latest)
     _validate_quote(book)
 
     return MarketConditions(

--- a/app/services/brokers/binance/demo_scalping_exec/executor.py
+++ b/app/services/brokers/binance/demo_scalping_exec/executor.py
@@ -38,6 +38,7 @@ from app.services.brokers.binance.demo_scalping.contract import (
     DEMO_SCALPING_FEE_RATE_BPS,
     MarketConditions,
     Product,
+    ReasonCode,
     ScalpingRiskLimits,
     evaluate_risk,
 )
@@ -588,11 +589,23 @@ class DemoScalpingExecutor:
 
         ROB-315 0c / D4: the caller supplies the real ``market`` snapshot
         (spread + data age) so the ``SPREAD_TOO_WIDE`` / ``STALE_DATA`` gates
-        actually fire. When omitted the gates are inert (0/0) — the prior
-        behavior — so non-scheduler callers are unaffected."""
+        actually fire.
+
+        ROB-841: a missing snapshot now fails **closed** with
+        ``market_conditions_unavailable`` instead of synthesizing a 0/0
+        snapshot (which silently disarmed those gates). The fail-close returns
+        BEFORE the ledger read, so an unavailable snapshot touches neither
+        broker nor ledger."""
         # The spread@fill entry leg is the preflight spread (captured just
         # before the open). Reset per run so a blocked/early return is clean.
-        self._entry_spread_bps = market.spread_bps if market is not None else None
+        if market is None:
+            self._entry_spread_bps = None
+            return ExecutionResult(
+                intent=intent,
+                status="blocked",
+                reason_codes=(ReasonCode.MARKET_CONDITIONS_UNAVAILABLE,),
+            )
+        self._entry_spread_bps = market.spread_bps
         snapshot = await load_ledger_snapshot(
             self.ledger, product=intent.product, symbol=intent.symbol, now=self.now
         )
@@ -603,12 +616,7 @@ class DemoScalpingExecutor:
             target_notional_usdt=intent.target_notional_usdt,
             limits=self.limits,
             ledger=snapshot,
-            market=market
-            or MarketConditions(
-                spread_bps=Decimal("0"),
-                data_age_seconds=0.0,
-                spot_free_base_qty=Decimal("0"),
-            ),
+            market=market,
         )
         if not risk.allowed:
             return ExecutionResult(

--- a/docs/runbooks/binance-demo-scalping-llm-session.md
+++ b/docs/runbooks/binance-demo-scalping-llm-session.md
@@ -10,10 +10,23 @@
 1. **시장 읽기** — `get_crypto_*`(funding/OI/캔들) 및 최근 스캘핑 리뷰/벤치마크(`/invest/scalping`)와
    과거 결정·결과(이전 `signal_snapshot`/리뷰)를 검토한다.
 2. **결정** — symbol(XRPUSDT/DOGEUSDT/SOLUSDT 중)·side·근거(rationale)를 정한다.
-3. **dry-run 확인** — `binance_demo_scalping_submit_decision(symbol, side, rationale, dry_run=true)`로 계획 확인.
-4. **주입** — `...(dry_run=false, confirm=true)`로 실 데모 라운드트립 실행. 결과(status/realized_pnl)를 기록.
+3. **dry-run 예비판정** — `binance_demo_scalping_submit_decision(symbol, side, rationale, dry_run=true)`.
+   dry-run은 단순 계획 에코가 아니다: 실 주문과 **동일하게** Demo 호스트에서 bookTicker + 최신 1m
+   kline을 서버가 관측해 `MarketConditions`(spread/data-age)를 구성하고, DB 리스크 프리플라이트
+   (ledger 스냅샷 읽기 + 사이징)를 수행한다. 단, **broker mutation과 ledger insert는 하지 않는다**.
+   따라서 dry-run 응답 `status`는 다음 중 하나다:
+   - `planned` — 서버 관측 조건 통과 + 사이징 성공(주입 가능). `market_conditions`(관측 spread/age) 동봉.
+   - `blocked` — 기존 리스크 게이트 위반. `reason_codes`에 `spread_too_wide`/`stale_data`/
+     notional·cooldown 등 사유가 그대로 노출된다(신규 게이트 아님).
+   - `market_conditions_unavailable` — bookTicker/kline 수집 실패·빈/malformed·timestamp 부재·
+     비유한(NaN/±Inf)·crossed 호가. 이 경우 broker·ledger 접촉 0.
+   dry-run이 `blocked`/`market_conditions_unavailable`이면 주입을 시도하지 말고 조건을 재확인한다.
+4. **주입** — `...(dry_run=false, confirm=true)`로 실 데모 라운드트립 실행. confirm 경로도 dry-run과
+   동일한 server-derived 조건·리스크 프리플라이트를 거친 뒤에만 실 주문을 낸다. 결과(status/realized_pnl)를 기록.
 5. **회고** — 다음 세션에서 직전 결정의 결과(net vs buy&hold, LLM vs 규칙 baseline)를 보고 전략을 조정한다.
 
 ## 안전
 - 1x · notional<=10 USDT · 손실예산 게이트(Phase 1) · demo-fapi only — executor가 강제.
+- spread/data-age는 **서버 관측값만** 판정에 사용한다. caller/LLM이 spread·age를 입력할 수 없고,
+  관측 실패 시 0/0으로 합성하지 않고 `market_conditions_unavailable`로 fail-close 한다(ROB-841).
 - 같은 날 결과는 `session_tag="llm"`로 분리 집계(규칙 baseline과 비교; surfacing은 D-PR2).

--- a/docs/runbooks/binance-demo-scalping.md
+++ b/docs/runbooks/binance-demo-scalping.md
@@ -150,7 +150,12 @@ BINANCE_DEMO_SCALPING_ENABLED=true BINANCE_FUTURES_DEMO_ENABLED=true \
 ```
 
 Exit codes: `0` reconciled / dry-run / disabled, `1` blocked / operator
-misconfig, `2` anomaly / runtime.
+misconfig, `2` anomaly / runtime. An untrustworthy server market snapshot
+(bookTicker/kline unavailable, malformed, or non-finite; ROB-841) is a
+**blocked** outcome — the CLI emits a `demo_scalping_execute` evidence line
+with `status=blocked` and `reason_codes=[market_conditions_unavailable]` and
+exits `1` (never the generic exit `2`), before any DB session, executor, or
+broker submit.
 
 ### Running the real-order smoke (clean ledger DB)
 

--- a/scripts/binance_demo_scalping_execute.py
+++ b/scripts/binance_demo_scalping_execute.py
@@ -130,6 +130,7 @@ async def _run(args: argparse.Namespace) -> int:
     from app.core.db import AsyncSessionLocal
     from app.services.brokers.binance.demo_scalping.market_data import (
         DemoScalpingMarketData,
+        build_market_conditions,
     )
     from app.services.brokers.binance.demo_scalping_exec.executor import (
         DemoScalpingExecutor,
@@ -152,8 +153,17 @@ async def _run(args: argparse.Namespace) -> int:
         client = BinanceFuturesDemoExecutionClient.from_env()
 
     reference = DemoReferenceData()
-    market_data = DemoScalpingMarketData() if args.monitor else None
+    # ROB-841: the executor now fails closed without a server-derived market
+    # snapshot, so build one for BOTH the immediate and monitored paths.
+    market_data = DemoScalpingMarketData()
     try:
+        # ROB-841: the builder samples its own clock after both observations
+        # complete, so fetch latency counts toward staleness.
+        market = await build_market_conditions(
+            market_data,
+            product=args.product,
+            symbol=args.symbol,
+        )
         async with AsyncSessionLocal() as session:
             executor = DemoScalpingExecutor(
                 product=args.product,
@@ -173,15 +183,19 @@ async def _run(args: argparse.Namespace) -> int:
             )
             if args.monitor:
                 result = await executor.execute_monitored(
-                    intent, confirm=args.confirm, max_poll_count=args.max_poll_count
+                    intent,
+                    confirm=args.confirm,
+                    market=market,
+                    max_poll_count=args.max_poll_count,
                 )
             else:
-                result = await executor.execute(intent, confirm=args.confirm)
+                result = await executor.execute(
+                    intent, confirm=args.confirm, market=market
+                )
             await session.commit()
     finally:
         await reference.aclose()
-        if market_data is not None:
-            await market_data.aclose()
+        await market_data.aclose()
         aclose = getattr(client, "aclose", None)
         if aclose is not None:
             await aclose()

--- a/scripts/binance_demo_scalping_execute.py
+++ b/scripts/binance_demo_scalping_execute.py
@@ -130,10 +130,12 @@ async def _run(args: argparse.Namespace) -> int:
     from app.core.db import AsyncSessionLocal
     from app.services.brokers.binance.demo_scalping.market_data import (
         DemoScalpingMarketData,
+        MarketConditionsUnavailable,
         build_market_conditions,
     )
     from app.services.brokers.binance.demo_scalping_exec.executor import (
         DemoScalpingExecutor,
+        ExecutionResult,
     )
     from app.services.brokers.binance.demo_scalping_exec.reference import (
         DemoReferenceData,
@@ -156,14 +158,40 @@ async def _run(args: argparse.Namespace) -> int:
     # ROB-841: the executor now fails closed without a server-derived market
     # snapshot, so build one for BOTH the immediate and monitored paths.
     market_data = DemoScalpingMarketData()
+    # Built up-front (pure; no DB/broker) so an unavailable-market blocked
+    # result can carry the correct product/symbol/side in its evidence.
+    intent = build_manual_intent(
+        product=args.product,
+        symbol=args.symbol,
+        side=args.side,
+        now=now,
+        limits=limits,
+    )
     try:
-        # ROB-841: the builder samples its own clock after both observations
-        # complete, so fetch latency counts toward staleness.
-        market = await build_market_conditions(
-            market_data,
-            product=args.product,
-            symbol=args.symbol,
-        )
+        try:
+            # ROB-841: the builder samples its own clock after both observations
+            # complete, so fetch latency counts toward staleness.
+            market = await build_market_conditions(
+                market_data,
+                product=args.product,
+                symbol=args.symbol,
+            )
+        except MarketConditionsUnavailable as exc:
+            # CLI boundary: an untrustworthy server market snapshot is a
+            # blocked outcome (exit 1), NOT a runtime failure (exit 2). We
+            # return before opening a DB session or constructing the executor,
+            # so no broker submit / ledger touch occurs. Any OTHER exception
+            # keeps propagating to the top-level runtime guard (exit 2).
+            logger.warning(
+                "demo scalping market conditions unavailable: %s", exc.reason
+            )
+            result = ExecutionResult(
+                intent=intent,
+                status="blocked",
+                reason_codes=("market_conditions_unavailable",),
+            )
+            _evidence({"event": "demo_scalping_execute", **result.to_evidence_dict()})
+            return _EXIT_BY_STATUS["blocked"]
         async with AsyncSessionLocal() as session:
             executor = DemoScalpingExecutor(
                 product=args.product,
@@ -173,13 +201,6 @@ async def _run(args: argparse.Namespace) -> int:
                 now=now,
                 limits=limits,
                 market_data=market_data,
-            )
-            intent = build_manual_intent(
-                product=args.product,
-                symbol=args.symbol,
-                side=args.side,
-                now=now,
-                limits=limits,
             )
             if args.monitor:
                 result = await executor.execute_monitored(

--- a/tests/mcp_server/test_binance_demo_scalping_handler_integration.py
+++ b/tests/mcp_server/test_binance_demo_scalping_handler_integration.py
@@ -1,0 +1,236 @@
+"""ROB-841 review — real handler wiring integration tests.
+
+These drive the actual ``_build_conditions_and_run`` path (only the low-level
+Demo reader / signed client / DB session / executor are faked), rather than
+stubbing ``_dry_run_preflight`` / ``_execute_confirmed_round_trip`` wholesale.
+They prove:
+
+* a provider failure fails closed BEFORE the signed client or DB session is
+  ever constructed (both dry-run and confirm), and
+* the *server-derived* ``MarketConditions`` instance produced by the real
+  builder is handed to the executor unchanged (both dry-run and confirm).
+"""
+
+from __future__ import annotations
+
+import time
+from decimal import Decimal
+
+import pytest
+
+import app.core.db as dbmod
+import app.mcp_server.tooling.binance_demo_scalping_handler as mod
+import app.services.brokers.binance.demo_scalping.market_data as mdmod
+import app.services.brokers.binance.demo_scalping_exec.executor as exmod
+import app.services.brokers.binance.demo_scalping_exec.reference as refmod
+from app.services.brokers.binance.demo_scalping.contract import MarketConditions
+from app.services.brokers.binance.demo_scalping.market_data import (
+    BookTicker,
+    spread_bps,
+)
+from app.services.brokers.binance.demo_scalping.signal import Candle
+from app.services.brokers.binance.futures_demo.execution_client import (
+    BinanceFuturesDemoExecutionClient,
+)
+
+
+# --- low-level fakes ---------------------------------------------------------
+class _RaisingReader:
+    async def fetch_book_ticker(self, product, symbol):
+        raise RuntimeError("bookTicker HTTP 503")
+
+    async def fetch_klines(self, product, symbol, *, interval="1m", limit=50):
+        raise RuntimeError("klines HTTP 503")
+
+    async def aclose(self):
+        return None
+
+
+class _ValidReader:
+    async def fetch_book_ticker(self, product, symbol):
+        return BookTicker(bid=Decimal("100"), ask=Decimal("100.05"))
+
+    async def fetch_klines(self, product, symbol, *, interval="1m", limit=50):
+        now_ms = int(time.time() * 1000)
+        return [
+            Candle(
+                open_time_ms=now_ms - 1000,  # ~1s old → fresh
+                open=Decimal("100"),
+                high=Decimal("100"),
+                low=Decimal("100"),
+                close=Decimal("100"),
+                close_time_ms=now_ms + 59_999,
+            )
+        ]
+
+    async def aclose(self):
+        return None
+
+
+class _HarmlessRef:
+    async def aclose(self):
+        return None
+
+
+class _FakeSession:
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *a):
+        return False
+
+    async def commit(self):
+        return None
+
+
+class _FakeClient:
+    async def aclose(self):
+        return None
+
+
+class _Flag:
+    def __init__(self):
+        self.count = 0
+
+
+def _from_env_recorder(flag: _Flag):
+    def _fn(cls):
+        flag.count += 1
+        raise AssertionError("signed client from_env must not run on provider failure")
+
+    return classmethod(_fn)
+
+
+def _session_recorder(flag: _Flag):
+    def _factory():
+        flag.count += 1
+        raise AssertionError("AsyncSessionLocal must not run on provider failure")
+
+    return _factory
+
+
+def _dry_result():
+    return type(
+        "R",
+        (),
+        {
+            "status": "dry_run",
+            "reason_codes": (),
+            "sized_qty": Decimal("1"),
+            "sized_notional_usdt": Decimal("10"),
+        },
+    )()
+
+
+def _confirm_result():
+    return type(
+        "R",
+        (),
+        {
+            "status": "reconciled",
+            "open_client_order_id": "rob307-x",
+            "close_client_order_id": "rob307-y",
+            "exit_reason": "take_profit",
+            "to_evidence_dict": lambda self: {"status": "reconciled"},
+        },
+    )()
+
+
+def _capturing_executor(store: dict):
+    class _Exec:
+        def __init__(self, **kwargs):
+            store["ctor"] = kwargs
+
+        async def execute_monitored(self, intent, *, confirm, market, **kwargs):
+            store["market"] = market
+            store["confirm"] = confirm
+            return _confirm_result() if confirm else _dry_result()
+
+    return _Exec
+
+
+# --- provider-failure ordering (before signed client / DB session) -----------
+@pytest.mark.asyncio
+@pytest.mark.parametrize("dry_run,confirm", [(True, False), (False, True)])
+async def test_provider_failure_blocks_before_client_and_session(
+    monkeypatch, dry_run, confirm
+) -> None:
+    from_env_flag = _Flag()
+    session_flag = _Flag()
+    monkeypatch.setattr(mdmod, "DemoScalpingMarketData", lambda **k: _RaisingReader())
+    monkeypatch.setattr(refmod, "DemoReferenceData", lambda **k: _HarmlessRef())
+    monkeypatch.setattr(dbmod, "AsyncSessionLocal", _session_recorder(session_flag))
+    monkeypatch.setattr(
+        BinanceFuturesDemoExecutionClient, "from_env", _from_env_recorder(from_env_flag)
+    )
+    # If the executor were somehow reached, this would explode too.
+    monkeypatch.setattr(
+        exmod,
+        "DemoScalpingExecutor",
+        _capturing_executor({}),
+    )
+
+    result = await mod.binance_demo_scalping_submit_decision(
+        symbol="XRPUSDT",
+        side="BUY",
+        rationale="funding flip",
+        dry_run=dry_run,
+        confirm=confirm,
+    )
+    assert result["status"] == "market_conditions_unavailable"
+    assert result["dry_run"] is dry_run
+    assert "provider_error" in result["reason"]
+    assert from_env_flag.count == 0  # signed client never constructed
+    assert session_flag.count == 0  # DB session never opened
+
+
+# --- server-derived MarketConditions instance flows to the executor ----------
+@pytest.mark.asyncio
+async def test_dry_run_real_build_hands_server_market_to_executor(monkeypatch) -> None:
+    store: dict = {}
+    monkeypatch.setattr(mdmod, "DemoScalpingMarketData", lambda **k: _ValidReader())
+    monkeypatch.setattr(refmod, "DemoReferenceData", lambda **k: _HarmlessRef())
+    monkeypatch.setattr(dbmod, "AsyncSessionLocal", lambda: _FakeSession())
+    monkeypatch.setattr(exmod, "DemoScalpingExecutor", _capturing_executor(store))
+
+    result = await mod.binance_demo_scalping_submit_decision(
+        symbol="XRPUSDT", side="BUY", rationale="x", dry_run=True
+    )
+    assert result["status"] == "planned"
+    assert store["confirm"] is False
+    market = store["market"]
+    assert isinstance(market, MarketConditions)
+    # Spread is the server-observed value, computed from the reader's quote.
+    assert market.spread_bps == spread_bps(
+        BookTicker(bid=Decimal("100"), ask=Decimal("100.05"))
+    )
+    assert 0.0 <= market.data_age_seconds < 120.0
+
+
+@pytest.mark.asyncio
+async def test_confirm_real_build_hands_server_market_to_executor(monkeypatch) -> None:
+    store: dict = {}
+    monkeypatch.setattr(mdmod, "DemoScalpingMarketData", lambda **k: _ValidReader())
+    monkeypatch.setattr(refmod, "DemoReferenceData", lambda **k: _HarmlessRef())
+    monkeypatch.setattr(dbmod, "AsyncSessionLocal", lambda: _FakeSession())
+    monkeypatch.setattr(
+        BinanceFuturesDemoExecutionClient,
+        "from_env",
+        classmethod(lambda cls: _FakeClient()),
+    )
+    monkeypatch.setattr(exmod, "DemoScalpingExecutor", _capturing_executor(store))
+
+    result = await mod.binance_demo_scalping_submit_decision(
+        symbol="SOLUSDT",
+        side="SELL",
+        rationale="OI fade",
+        dry_run=False,
+        confirm=True,
+    )
+    assert result["status"] == "reconciled"
+    assert store["confirm"] is True
+    market = store["market"]
+    assert isinstance(market, MarketConditions)
+    assert market.spread_bps == spread_bps(
+        BookTicker(bid=Decimal("100"), ask=Decimal("100.05"))
+    )

--- a/tests/mcp_server/test_binance_demo_scalping_registry_gate.py
+++ b/tests/mcp_server/test_binance_demo_scalping_registry_gate.py
@@ -1,0 +1,40 @@
+"""ROB-841 — registry gate for the Binance Demo scalping submit tool.
+
+The ``binance_demo_scalping_submit_decision`` tool must be *physically absent*
+unless the operator opts in via ``settings.binance_demo_scalping_enabled``
+(default False). Gate-off means the tool cannot be reached at all — a
+defense-in-depth complement to the per-call dry_run + confirm gates.
+"""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+import pytest
+
+from app.mcp_server.profiles import McpProfile
+from app.mcp_server.tooling import registry as registry_mod
+from app.mcp_server.tooling.registry import register_all_tools
+from tests._mcp_tooling_support import DummyMCP
+
+_TOOL = "binance_demo_scalping_submit_decision"
+
+
+@pytest.mark.unit
+def test_tool_absent_when_gate_off(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        registry_mod.settings, "binance_demo_scalping_enabled", False, raising=False
+    )
+    mcp = DummyMCP()
+    register_all_tools(cast(Any, mcp), profile=McpProfile.DEFAULT)
+    assert _TOOL not in set(mcp.tools.keys())
+
+
+@pytest.mark.unit
+def test_tool_present_when_gate_on(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        registry_mod.settings, "binance_demo_scalping_enabled", True, raising=False
+    )
+    mcp = DummyMCP()
+    register_all_tools(cast(Any, mcp), profile=McpProfile.DEFAULT)
+    assert _TOOL in set(mcp.tools.keys())

--- a/tests/mcp_server/test_binance_demo_scalping_submit_decision.py
+++ b/tests/mcp_server/test_binance_demo_scalping_submit_decision.py
@@ -1,23 +1,94 @@
 from __future__ import annotations
 
+import inspect
+from decimal import Decimal
 from unittest.mock import AsyncMock, patch
 
 import pytest
 
 import app.mcp_server.tooling.binance_demo_scalping_handler as mod
+from app.services.brokers.binance.demo_scalping.contract import (
+    MarketConditions,
+    ReasonCode,
+)
+from app.services.brokers.binance.demo_scalping.market_data import (
+    MarketConditionsUnavailable,
+)
+
+_FRESH = MarketConditions(
+    spread_bps=Decimal("3"),
+    data_age_seconds=4.0,
+    spot_free_base_qty=Decimal("0"),
+)
+
+
+def _preflight_result(
+    status: str, *, reason_codes=(), sized_qty=None, sized_notional=None
+):
+    return type(
+        "R",
+        (),
+        {
+            "status": status,
+            "reason_codes": tuple(reason_codes),
+            "sized_qty": sized_qty,
+            "sized_notional_usdt": sized_notional,
+        },
+    )()
 
 
 @pytest.mark.asyncio
 async def test_dry_run_returns_plan_no_order() -> None:
-    result = await mod.binance_demo_scalping_submit_decision(
-        symbol="XRPUSDT", side="BUY", rationale="funding flip", dry_run=True
+    # ROB-841: dry-run now runs the SAME server-derived market/risk preflight,
+    # but places no order and inserts no ledger row. Seam is mocked so the unit
+    # test does no network / DB.
+    allowed = _preflight_result(
+        "dry_run", sized_qty=Decimal("7.3"), sized_notional=Decimal("10")
     )
+    with patch.object(
+        mod, "_dry_run_preflight", AsyncMock(return_value=(_FRESH, allowed))
+    ):
+        result = await mod.binance_demo_scalping_submit_decision(
+            symbol="XRPUSDT", side="BUY", rationale="funding flip", dry_run=True
+        )
     assert result["status"] == "planned"
     assert result["dry_run"] is True
     assert result["symbol"] == "XRPUSDT"
     assert result["side"] == "BUY"
     assert result["session_tag"] == "llm"
     assert "rationale" in result
+    # Server-observed market snapshot echoed back for auditability.
+    assert result["market_conditions"]["spread_bps"] == "3"
+    assert result["market_conditions"]["data_age_seconds"] == 4.0
+
+
+@pytest.mark.asyncio
+async def test_dry_run_blocked_surfaces_existing_reason_codes() -> None:
+    blocked = _preflight_result("blocked", reason_codes=(ReasonCode.SPREAD_TOO_WIDE,))
+    with patch.object(
+        mod, "_dry_run_preflight", AsyncMock(return_value=(_FRESH, blocked))
+    ):
+        result = await mod.binance_demo_scalping_submit_decision(
+            symbol="XRPUSDT", side="BUY", rationale="x", dry_run=True
+        )
+    assert result["status"] == "blocked"
+    assert ReasonCode.SPREAD_TOO_WIDE in result["reason_codes"]
+    assert result["dry_run"] is True
+
+
+@pytest.mark.asyncio
+async def test_dry_run_market_unavailable_fails_closed() -> None:
+    with patch.object(
+        mod,
+        "_dry_run_preflight",
+        AsyncMock(side_effect=MarketConditionsUnavailable("provider_error: boom")),
+    ):
+        result = await mod.binance_demo_scalping_submit_decision(
+            symbol="XRPUSDT", side="BUY", rationale="x", dry_run=True
+        )
+    assert result["status"] == "market_conditions_unavailable"
+    assert result["dry_run"] is True
+    assert "provider_error" in result["reason"]
 
 
 @pytest.mark.asyncio
@@ -77,10 +148,54 @@ async def test_confirm_executes_monitored_with_llm_tag() -> None:
 
 
 @pytest.mark.asyncio
+async def test_confirm_market_unavailable_fails_closed_no_order() -> None:
+    with patch.object(
+        mod,
+        "_execute_confirmed_round_trip",
+        AsyncMock(side_effect=MarketConditionsUnavailable("empty_kline")),
+    ):
+        result = await mod.binance_demo_scalping_submit_decision(
+            symbol="XRPUSDT",
+            side="BUY",
+            rationale="x",
+            dry_run=False,
+            confirm=True,
+        )
+    assert result["status"] == "market_conditions_unavailable"
+    assert result["dry_run"] is False
+    assert "empty_kline" in result["reason"]
+
+
+@pytest.mark.asyncio
 async def test_confirm_required_for_real_order() -> None:
-    # dry_run False but confirm False → still a plan, no execution.
-    result = await mod.binance_demo_scalping_submit_decision(
-        symbol="XRPUSDT", side="BUY", rationale="x", dry_run=False, confirm=False
+    # dry_run False but confirm False → still a plan (dry-run preflight), no order.
+    allowed = _preflight_result(
+        "dry_run", sized_qty=Decimal("7.3"), sized_notional=Decimal("10")
     )
+    with patch.object(
+        mod, "_dry_run_preflight", AsyncMock(return_value=(_FRESH, allowed))
+    ):
+        result = await mod.binance_demo_scalping_submit_decision(
+            symbol="XRPUSDT", side="BUY", rationale="x", dry_run=False, confirm=False
+        )
     assert result["status"] == "planned"
     assert result["dry_run"] is True
+
+
+def test_public_contract_has_no_caller_controlled_market_fields() -> None:
+    # AC5: spread / data-age must be server-observed only — the public tool
+    # signature must never accept them as inputs.
+    params = set(
+        inspect.signature(mod.binance_demo_scalping_submit_decision).parameters
+    )
+    forbidden = {
+        "spread",
+        "spread_bps",
+        "data_age",
+        "data_age_seconds",
+        "market",
+        "market_conditions",
+    }
+    assert params.isdisjoint(forbidden), (
+        f"caller-controlled market fields: {params & forbidden}"
+    )

--- a/tests/scripts/test_binance_demo_scalping_execute.py
+++ b/tests/scripts/test_binance_demo_scalping_execute.py
@@ -79,6 +79,22 @@ class _FakeReference:
         return None
 
 
+def _canned_market_conditions():
+    from app.services.brokers.binance.demo_scalping.contract import MarketConditions
+
+    return MarketConditions(
+        spread_bps=Decimal("2"),
+        data_age_seconds=5.0,
+        spot_free_base_qty=Decimal("0"),
+    )
+
+
+async def _fake_build_market_conditions(market_data, **kwargs):
+    # ROB-841: the CLI now derives a server market snapshot before executing.
+    # Stub it so the wiring tests stay hermetic (no network).
+    return _canned_market_conditions()
+
+
 class _FakeResult:
     def __init__(self, status: str = "dry_run") -> None:
         self.status = status
@@ -91,7 +107,7 @@ class _FakeExecutor:
     def __init__(self, **kwargs) -> None:
         pass
 
-    async def execute(self, intent, *, confirm: bool):
+    async def execute(self, intent, *, confirm: bool, **kwargs):
         return _FakeResult("dry_run")
 
     async def execute_monitored(self, intent, *, confirm: bool, **kwargs):
@@ -116,6 +132,7 @@ def _patch_wiring(monkeypatch) -> None:
     monkeypatch.setattr(dbmod, "AsyncSessionLocal", lambda: _FakeSession())
     monkeypatch.setattr(refmod, "DemoReferenceData", _FakeReference)
     monkeypatch.setattr(mdmod, "DemoScalpingMarketData", _FakeReference)
+    monkeypatch.setattr(mdmod, "build_market_conditions", _fake_build_market_conditions)
     monkeypatch.setattr(exmod, "DemoScalpingExecutor", _FakeExecutor)
 
 
@@ -126,6 +143,7 @@ def test_enabled_dry_run_wiring_does_not_await_sync_from_env(
     # full _run wiring with fakes (no creds, no DB, no network). If someone
     # re-adds `await ...from_env()`, awaiting _FakeClient() raises and rc != 0.
     import app.core.db as dbmod
+    import app.services.brokers.binance.demo_scalping.market_data as mdmod
     import app.services.brokers.binance.demo_scalping_exec.executor as exmod
     import app.services.brokers.binance.demo_scalping_exec.reference as refmod
     from app.services.brokers.binance.spot_demo.execution_client import (
@@ -140,6 +158,8 @@ def test_enabled_dry_run_wiring_does_not_await_sync_from_env(
     )
     monkeypatch.setattr(dbmod, "AsyncSessionLocal", lambda: _FakeSession())
     monkeypatch.setattr(refmod, "DemoReferenceData", _FakeReference)
+    monkeypatch.setattr(mdmod, "DemoScalpingMarketData", _FakeReference)
+    monkeypatch.setattr(mdmod, "build_market_conditions", _fake_build_market_conditions)
     monkeypatch.setattr(exmod, "DemoScalpingExecutor", _FakeExecutor)
 
     rc = main(["--product", "spot", "--symbol", "DOGEUSDT"])

--- a/tests/scripts/test_binance_demo_scalping_execute.py
+++ b/tests/scripts/test_binance_demo_scalping_execute.py
@@ -174,3 +174,80 @@ def test_monitor_flag_routes_to_execute_monitored(monkeypatch, capsys) -> None:
     )
     assert rc == 0  # reconciled (monitored, flat) -> success
     assert "reconciled" in capsys.readouterr().out
+
+
+class _CloseFlag:
+    def __init__(self) -> None:
+        self.closed = False
+
+    async def aclose(self) -> None:
+        self.closed = True
+
+
+def test_market_conditions_unavailable_exits_blocked_no_side_effects(
+    monkeypatch, capsys
+) -> None:
+    # ROB-841 CLI contract: an unavailable server market snapshot is a blocked
+    # outcome (exit 1) with structured evidence — NOT a generic runtime failure
+    # (exit 2). The DB session, executor, and broker submit are never reached,
+    # and the constructed client/reference/market-data resources are closed.
+    import json
+
+    import app.core.db as dbmod
+    import app.services.brokers.binance.demo_scalping.market_data as mdmod
+    import app.services.brokers.binance.demo_scalping_exec.executor as exmod
+    import app.services.brokers.binance.demo_scalping_exec.reference as refmod
+    from app.services.brokers.binance.demo_scalping.market_data import (
+        MarketConditionsUnavailable,
+    )
+    from app.services.brokers.binance.spot_demo.execution_client import (
+        BinanceSpotDemoExecutionClient,
+    )
+
+    monkeypatch.setenv("BINANCE_DEMO_SCALPING_ENABLED", "true")
+
+    client_flag = _CloseFlag()
+    reference_flag = _CloseFlag()
+    market_data_flag = _CloseFlag()
+
+    def _forbidden_session():
+        raise AssertionError("AsyncSessionLocal must not open on unavailable market")
+
+    class _ForbiddenExecutor:
+        def __init__(self, **kwargs):
+            raise AssertionError(
+                "executor must not be constructed on unavailable market"
+            )
+
+    async def _raise_build(market_data, **kwargs):
+        raise MarketConditionsUnavailable("provider_error: RuntimeError: boom")
+
+    monkeypatch.setattr(
+        BinanceSpotDemoExecutionClient,
+        "from_env",
+        classmethod(lambda cls: client_flag),
+    )
+    monkeypatch.setattr(refmod, "DemoReferenceData", lambda **k: reference_flag)
+    monkeypatch.setattr(mdmod, "DemoScalpingMarketData", lambda **k: market_data_flag)
+    monkeypatch.setattr(mdmod, "build_market_conditions", _raise_build)
+    monkeypatch.setattr(dbmod, "AsyncSessionLocal", _forbidden_session)
+    monkeypatch.setattr(exmod, "DemoScalpingExecutor", _ForbiddenExecutor)
+
+    rc = main(["--product", "spot", "--symbol", "XRPUSDT"])
+    assert rc == 1  # blocked, not the generic runtime exit 2
+
+    lines = [
+        line
+        for line in capsys.readouterr().out.splitlines()
+        if "demo_scalping_execute" in line
+    ]
+    assert lines, "expected an evidence line"
+    payload = json.loads(lines[-1])
+    assert payload["event"] == "demo_scalping_execute"
+    assert payload["status"] == "blocked"
+    assert "market_conditions_unavailable" in payload["reason_codes"]
+
+    # Resources created before the failure are closed; nothing downstream ran.
+    assert client_flag.closed is True
+    assert reference_flag.closed is True
+    assert market_data_flag.closed is True

--- a/tests/services/brokers/binance/demo_scalping/test_market_conditions_builder.py
+++ b/tests/services/brokers/binance/demo_scalping/test_market_conditions_builder.py
@@ -47,6 +47,27 @@ def _candle(open_time_ms: int = _OPEN_MS) -> Candle:
     )
 
 
+def _candle_ohlc(
+    o: str,
+    h: str,
+    low: str,
+    c: str,
+    *,
+    open_time_ms: int = _OPEN_MS,
+    close_time_ms: int | None = None,
+) -> Candle:
+    return Candle(
+        open_time_ms=open_time_ms,
+        open=Decimal(o),
+        high=Decimal(h),
+        low=Decimal(low),
+        close=Decimal(c),
+        close_time_ms=(
+            close_time_ms if close_time_ms is not None else open_time_ms + 59_999
+        ),
+    )
+
+
 class _FakeMD:
     """Scripted Demo-host reader. Either value may be an Exception to raise."""
 
@@ -305,6 +326,137 @@ async def test_fetch_latency_pushes_age_over_stale_boundary() -> None:
         market=market,
     )
     assert ReasonCode.STALE_DATA in decision.reason_codes
+
+
+@pytest.mark.asyncio
+async def test_full_shape_nan_ohlc_kline_from_reader_fails_closed(httpx_mock) -> None:
+    # ROB-841 review: a kline row with the CORRECT number of fields but a NaN
+    # OHLC value parses cleanly (Decimal('NaN')), so open_time-only validation
+    # let it through as a healthy snapshot. Semantic validation must reject it.
+    httpx_mock.add_response(
+        method="GET",
+        url=re.compile(
+            r"^https://demo-fapi\.binance\.com/fapi/v1/ticker/bookTicker\?.*$"
+        ),
+        json={"symbol": "XRPUSDT", "bidPrice": "1.35950000", "askPrice": "1.35960000"},
+    )
+    httpx_mock.add_response(
+        method="GET",
+        url=re.compile(r"^https://demo-fapi\.binance\.com/fapi/v1/klines\?.*$"),
+        json=[
+            [
+                _OPEN_MS,  # open_time (valid, > 0)
+                "1.35960000",  # open
+                "1.35980000",  # high
+                "1.35950000",  # low
+                "NaN",  # close — full shape, but not finite
+                "6136.00000000",  # volume
+                _OPEN_MS + 59_999,  # close_time
+                "8342.58965000",
+                46,
+                "2795.80000000",
+                "3801.21357000",
+                "0",
+            ]
+        ],
+    )
+    md = DemoScalpingMarketData()
+    try:
+        with pytest.raises(MarketConditionsUnavailable):
+            await build_market_conditions(
+                md,
+                product="usdm_futures",
+                symbol="XRPUSDT",
+                clock_ms=lambda: _OPEN_MS,
+            )
+    finally:
+        await md.aclose()
+
+
+@pytest.mark.parametrize("field", ["open", "high", "low", "close"])
+@pytest.mark.parametrize("bad", ["NaN", "Infinity", "-Infinity"])
+@pytest.mark.asyncio
+async def test_non_finite_ohlc_fails_closed(field: str, bad: str) -> None:
+    ohlc = {"open": "1.36", "high": "1.37", "low": "1.35", "close": "1.36"}
+    ohlc[field] = bad
+    md = _FakeMD(
+        book=BookTicker(bid=Decimal("100"), ask=Decimal("100.05")),
+        klines=[_candle_ohlc(ohlc["open"], ohlc["high"], ohlc["low"], ohlc["close"])],
+    )
+    with pytest.raises(MarketConditionsUnavailable):
+        await _build(md, now_ms=_OPEN_MS)
+
+
+@pytest.mark.parametrize("field", ["open", "high", "low", "close"])
+@pytest.mark.parametrize("bad", ["0", "-1"])
+@pytest.mark.asyncio
+async def test_non_positive_ohlc_fails_closed(field: str, bad: str) -> None:
+    ohlc = {"open": "1.36", "high": "1.37", "low": "1.35", "close": "1.36"}
+    ohlc[field] = bad
+    md = _FakeMD(
+        book=BookTicker(bid=Decimal("100"), ask=Decimal("100.05")),
+        klines=[_candle_ohlc(ohlc["open"], ohlc["high"], ohlc["low"], ohlc["close"])],
+    )
+    with pytest.raises(MarketConditionsUnavailable):
+        await _build(md, now_ms=_OPEN_MS)
+
+
+@pytest.mark.parametrize(
+    "o,h,low,c",
+    [
+        ("1.36", "1.34", "1.35", "1.36"),  # high < low
+        ("1.36", "1.355", "1.35", "1.36"),  # high < max(open, close)
+        ("1.36", "1.37", "1.365", "1.36"),  # low > min(open, close)
+    ],
+)
+@pytest.mark.asyncio
+async def test_inconsistent_ohlc_fails_closed(o, h, low, c) -> None:
+    md = _FakeMD(
+        book=BookTicker(bid=Decimal("100"), ask=Decimal("100.05")),
+        klines=[_candle_ohlc(o, h, low, c)],
+    )
+    with pytest.raises(MarketConditionsUnavailable):
+        await _build(md, now_ms=_OPEN_MS)
+
+
+@pytest.mark.asyncio
+async def test_close_before_open_time_fails_closed() -> None:
+    md = _FakeMD(
+        book=BookTicker(bid=Decimal("100"), ask=Decimal("100.05")),
+        klines=[
+            _candle_ohlc(
+                "1.36",
+                "1.37",
+                "1.35",
+                "1.36",
+                open_time_ms=_OPEN_MS,
+                close_time_ms=_OPEN_MS - 1,  # close_time before open_time
+            )
+        ],
+    )
+    with pytest.raises(MarketConditionsUnavailable):
+        await _build(md, now_ms=_OPEN_MS)
+
+
+@pytest.mark.asyncio
+async def test_semantically_valid_candle_is_allowed() -> None:
+    # Boundary-valid OHLC (high == max, low == min, close_time == open_time)
+    # must pass so the tightened validation does not over-reject.
+    md = _FakeMD(
+        book=BookTicker(bid=Decimal("100"), ask=Decimal("100.05")),
+        klines=[
+            _candle_ohlc(
+                "1.36",
+                "1.36",  # high == open == close
+                "1.36",  # low == open == close
+                "1.36",
+                open_time_ms=_OPEN_MS,
+                close_time_ms=_OPEN_MS,  # close_time == open_time
+            )
+        ],
+    )
+    market = await _build(md, now_ms=_OPEN_MS)
+    assert isinstance(market.data_age_seconds, float)
 
 
 def _empty_ledger():

--- a/tests/services/brokers/binance/demo_scalping/test_market_conditions_builder.py
+++ b/tests/services/brokers/binance/demo_scalping/test_market_conditions_builder.py
@@ -1,0 +1,319 @@
+"""ROB-841 — tests for the server-derived MarketConditions builder.
+
+``build_market_conditions`` reuses the read-only Demo-host bookTicker +
+latest 1m kline to construct a :class:`MarketConditions` snapshot whose
+spread / data-age fields are ALWAYS server-measured (never caller-supplied).
+It fails closed via :class:`MarketConditionsUnavailable` on any provider
+failure, empty/malformed kline, missing timestamp, or invalid quote — the
+caller must then reject the order without touching broker or ledger.
+
+The valid snapshot feeds the *existing* ``evaluate_risk`` gates, so the
+``stale_data`` / ``spread_too_wide`` / valid-boundary cases are exercised
+end-to-end here (reason codes unchanged).
+"""
+
+from __future__ import annotations
+
+import re
+from decimal import Decimal
+
+import pytest
+
+from app.services.brokers.binance.demo_scalping.contract import (
+    ReasonCode,
+    ScalpingRiskLimits,
+    evaluate_risk,
+)
+from app.services.brokers.binance.demo_scalping.market_data import (
+    BookTicker,
+    DemoScalpingMarketData,
+    MarketConditionsUnavailable,
+    build_market_conditions,
+)
+from app.services.brokers.binance.demo_scalping.signal import Candle
+
+# open_time anchor; now_ms is offset from it to drive data-age.
+_OPEN_MS = 1_779_608_160_000
+
+
+def _candle(open_time_ms: int = _OPEN_MS) -> Candle:
+    return Candle(
+        open_time_ms=open_time_ms,
+        open=Decimal("1.36"),
+        high=Decimal("1.37"),
+        low=Decimal("1.35"),
+        close=Decimal("1.36"),
+        close_time_ms=open_time_ms + 59_999,
+    )
+
+
+class _FakeMD:
+    """Scripted Demo-host reader. Either value may be an Exception to raise."""
+
+    def __init__(self, *, book=None, klines=None):
+        self._book = book
+        self._klines = klines
+        self.book_calls = 0
+        self.kline_calls = 0
+
+    async def fetch_book_ticker(self, product, symbol):
+        self.book_calls += 1
+        if isinstance(self._book, Exception):
+            raise self._book
+        return self._book
+
+    async def fetch_klines(self, product, symbol, *, interval="1m", limit=50):
+        self.kline_calls += 1
+        if isinstance(self._klines, Exception):
+            raise self._klines
+        return self._klines
+
+
+async def _build(md, *, now_ms):
+    # now_ms drives the injectable clock; the builder samples it post-fetch.
+    return await build_market_conditions(
+        md, product="usdm_futures", symbol="XRPUSDT", clock_ms=lambda: now_ms
+    )
+
+
+class _LatencyMD:
+    """Advances a shared wall-clock during each fetch to model HTTP latency."""
+
+    def __init__(self, *, book, candle, clock_holder, per_fetch_ms):
+        self._book = book
+        self._candle = candle
+        self._clock = clock_holder  # list[int]
+        self._per = per_fetch_ms
+
+    async def fetch_book_ticker(self, product, symbol):
+        self._clock[0] += self._per
+        return self._book
+
+    async def fetch_klines(self, product, symbol, *, interval="1m", limit=50):
+        self._clock[0] += self._per
+        return [self._candle]
+
+
+@pytest.mark.asyncio
+async def test_valid_snapshot_measures_server_spread_and_age() -> None:
+    md = _FakeMD(
+        book=BookTicker(bid=Decimal("100"), ask=Decimal("100.05")), klines=[_candle()]
+    )
+    market = await _build(md, now_ms=_OPEN_MS + 30_000)  # 30s old
+    # spread = 0.05 / 100.025 * 1e4 ≈ 4.9975 bps
+    assert market.spread_bps == pytest.approx(Decimal("4.9975"), rel=Decimal("0.001"))
+    assert market.data_age_seconds == 30.0
+    # A fresh, tight book passes every market gate.
+    decision = evaluate_risk(
+        product="usdm_futures",
+        symbol="XRPUSDT",
+        side="BUY",
+        target_notional_usdt=Decimal("10"),
+        limits=ScalpingRiskLimits(allowlist=frozenset({"XRPUSDT"})),
+        ledger=_empty_ledger(),
+        market=market,
+    )
+    assert decision.allowed
+
+
+@pytest.mark.asyncio
+async def test_provider_failure_fails_closed() -> None:
+    md = _FakeMD(book=RuntimeError("bookTicker HTTP 503"), klines=[_candle()])
+    with pytest.raises(MarketConditionsUnavailable):
+        await _build(md, now_ms=_OPEN_MS)
+
+
+@pytest.mark.asyncio
+async def test_empty_kline_fails_closed() -> None:
+    md = _FakeMD(book=BookTicker(bid=Decimal("100"), ask=Decimal("100.05")), klines=[])
+    with pytest.raises(MarketConditionsUnavailable):
+        await _build(md, now_ms=_OPEN_MS)
+
+
+@pytest.mark.asyncio
+async def test_kline_provider_error_fails_closed() -> None:
+    # A malformed raw kline surfaces as a parse error from the reader.
+    md = _FakeMD(
+        book=BookTicker(bid=Decimal("100"), ask=Decimal("100.05")),
+        klines=ValueError("could not parse kline row"),
+    )
+    with pytest.raises(MarketConditionsUnavailable):
+        await _build(md, now_ms=_OPEN_MS)
+
+
+@pytest.mark.asyncio
+async def test_missing_timestamp_fails_closed() -> None:
+    md = _FakeMD(
+        book=BookTicker(bid=Decimal("100"), ask=Decimal("100.05")),
+        klines=[_candle(open_time_ms=0)],
+    )
+    with pytest.raises(MarketConditionsUnavailable):
+        await _build(md, now_ms=_OPEN_MS)
+
+
+@pytest.mark.asyncio
+async def test_crossed_quote_fails_closed() -> None:
+    md = _FakeMD(
+        book=BookTicker(bid=Decimal("100.10"), ask=Decimal("100.00")),  # ask < bid
+        klines=[_candle()],
+    )
+    with pytest.raises(MarketConditionsUnavailable):
+        await _build(md, now_ms=_OPEN_MS)
+
+
+@pytest.mark.asyncio
+async def test_zero_quote_fails_closed() -> None:
+    md = _FakeMD(
+        book=BookTicker(bid=Decimal("0"), ask=Decimal("0")),
+        klines=[_candle()],
+    )
+    with pytest.raises(MarketConditionsUnavailable):
+        await _build(md, now_ms=_OPEN_MS)
+
+
+@pytest.mark.asyncio
+async def test_wide_spread_maps_to_existing_spread_too_wide() -> None:
+    # bid=100 ask=101 → ~99.5 bps ≫ 20 bps cap.
+    md = _FakeMD(
+        book=BookTicker(bid=Decimal("100"), ask=Decimal("101")), klines=[_candle()]
+    )
+    market = await _build(md, now_ms=_OPEN_MS)
+    decision = evaluate_risk(
+        product="usdm_futures",
+        symbol="XRPUSDT",
+        side="BUY",
+        target_notional_usdt=Decimal("10"),
+        limits=ScalpingRiskLimits(allowlist=frozenset({"XRPUSDT"})),
+        ledger=_empty_ledger(),
+        market=market,
+    )
+    assert ReasonCode.SPREAD_TOO_WIDE in decision.reason_codes
+
+
+@pytest.mark.asyncio
+async def test_stale_kline_maps_to_existing_stale_data() -> None:
+    md = _FakeMD(
+        book=BookTicker(bid=Decimal("100"), ask=Decimal("100.05")), klines=[_candle()]
+    )
+    market = await _build(md, now_ms=_OPEN_MS + 200_000)  # 200s > 120s cap
+    decision = evaluate_risk(
+        product="usdm_futures",
+        symbol="XRPUSDT",
+        side="BUY",
+        target_notional_usdt=Decimal("10"),
+        limits=ScalpingRiskLimits(allowlist=frozenset({"XRPUSDT"})),
+        ledger=_empty_ledger(),
+        market=market,
+    )
+    assert ReasonCode.STALE_DATA in decision.reason_codes
+
+
+@pytest.mark.asyncio
+async def test_data_age_boundary_is_allowed() -> None:
+    # age == max_data_age_seconds (120.0): the gate uses strict '>', so the
+    # boundary is allowed — proves the builder feeds an exact server value.
+    md = _FakeMD(
+        book=BookTicker(bid=Decimal("100"), ask=Decimal("100.05")), klines=[_candle()]
+    )
+    market = await _build(md, now_ms=_OPEN_MS + 120_000)
+    assert market.data_age_seconds == 120.0
+    decision = evaluate_risk(
+        product="usdm_futures",
+        symbol="XRPUSDT",
+        side="BUY",
+        target_notional_usdt=Decimal("10"),
+        limits=ScalpingRiskLimits(allowlist=frozenset({"XRPUSDT"})),
+        ledger=_empty_ledger(),
+        market=market,
+    )
+    assert decision.allowed
+
+
+@pytest.mark.asyncio
+async def test_malformed_raw_kline_from_reader_fails_closed(httpx_mock) -> None:
+    # End-to-end with the REAL Demo-host reader: a bookTicker OK but a kline
+    # row missing fields makes the parser raise → builder fails closed.
+    httpx_mock.add_response(
+        method="GET",
+        url=re.compile(
+            r"^https://demo-fapi\.binance\.com/fapi/v1/ticker/bookTicker\?.*$"
+        ),
+        json={"symbol": "XRPUSDT", "bidPrice": "1.35950000", "askPrice": "1.35960000"},
+    )
+    httpx_mock.add_response(
+        method="GET",
+        url=re.compile(r"^https://demo-fapi\.binance\.com/fapi/v1/klines\?.*$"),
+        json=[["only-one-field"]],  # malformed: index errors during parse
+    )
+    md = DemoScalpingMarketData()
+    try:
+        with pytest.raises(MarketConditionsUnavailable):
+            await build_market_conditions(
+                md,
+                product="usdm_futures",
+                symbol="XRPUSDT",
+                clock_ms=lambda: _OPEN_MS,
+            )
+    finally:
+        await md.aclose()
+
+
+@pytest.mark.parametrize("bad", ["NaN", "Infinity", "-Infinity"])
+@pytest.mark.asyncio
+async def test_non_finite_quote_fails_closed(bad: str) -> None:
+    # ROB-841 review: NaN / ±Infinity must normalize to
+    # MarketConditionsUnavailable, not leak as a generic error (NaN comparison
+    # raises InvalidOperation; +Inf silently poisons spread_bps). Both legs.
+    bid_bad = _FakeMD(
+        book=BookTicker(bid=Decimal(bad), ask=Decimal("100")), klines=[_candle()]
+    )
+    with pytest.raises(MarketConditionsUnavailable):
+        await _build(bid_bad, now_ms=_OPEN_MS)
+    ask_bad = _FakeMD(
+        book=BookTicker(bid=Decimal("100"), ask=Decimal(bad)), klines=[_candle()]
+    )
+    with pytest.raises(MarketConditionsUnavailable):
+        await _build(ask_bad, now_ms=_OPEN_MS)
+
+
+@pytest.mark.asyncio
+async def test_fetch_latency_pushes_age_over_stale_boundary() -> None:
+    # ROB-841 review: the candle is 115s old when fetching STARTS (< 120 cap),
+    # but 6s of bookTicker+kline fetch latency pushes the observed age to 121s.
+    # Sampling the clock AFTER both observations trips stale_data; a pre-fetch
+    # clock (115.0s) would have wrongly allowed it.
+    start = _OPEN_MS
+    clock = [start]
+    candle = _candle(open_time_ms=start - 115_000)
+    md = _LatencyMD(
+        book=BookTicker(bid=Decimal("100"), ask=Decimal("100.05")),
+        candle=candle,
+        clock_holder=clock,
+        per_fetch_ms=3_000,  # 2 fetches × 3s = 6s latency
+    )
+    market = await build_market_conditions(
+        md, product="usdm_futures", symbol="XRPUSDT", clock_ms=lambda: clock[0]
+    )
+    assert market.data_age_seconds == 121.0  # 115 + 6, not the pre-fetch 115
+    decision = evaluate_risk(
+        product="usdm_futures",
+        symbol="XRPUSDT",
+        side="BUY",
+        target_notional_usdt=Decimal("10"),
+        limits=ScalpingRiskLimits(allowlist=frozenset({"XRPUSDT"})),
+        ledger=_empty_ledger(),
+        market=market,
+    )
+    assert ReasonCode.STALE_DATA in decision.reason_codes
+
+
+def _empty_ledger():
+    from app.services.brokers.binance.demo_scalping.contract import LedgerSnapshot
+
+    return LedgerSnapshot(
+        has_open_lifecycle_for_symbol=False,
+        global_open_lifecycle_count=0,
+        orders_today=0,
+        realized_loss_today_usdt=Decimal("0"),
+        seconds_since_last_close_for_symbol=None,
+    )

--- a/tests/services/brokers/binance/demo_scalping_exec/test_executor.py
+++ b/tests/services/brokers/binance/demo_scalping_exec/test_executor.py
@@ -17,7 +17,10 @@ import pytest
 from sqlalchemy import select
 
 from app.models.crypto_instruments import CryptoInstrument
-from app.services.brokers.binance.demo_scalping.contract import ScalpingRiskLimits
+from app.services.brokers.binance.demo_scalping.contract import (
+    MarketConditions,
+    ScalpingRiskLimits,
+)
 from app.services.brokers.binance.demo_scalping.order_intent import OrderIntent
 from app.services.brokers.binance.demo_scalping_exec.executor import (
     DemoScalpingExecutor,
@@ -25,6 +28,14 @@ from app.services.brokers.binance.demo_scalping_exec.executor import (
 from app.services.brokers.binance.demo_scalping_exec.reference import SymbolReference
 
 _NOW = dt.datetime(2026, 5, 24, 12, 0, 0, tzinfo=dt.UTC)
+# ROB-841: the executor now fails closed without a server-derived market
+# snapshot, so every execute()/execute_monitored() call supplies a fresh,
+# tight one (spread/age well within the gates) unless it is testing the gates.
+_FRESH_MARKET = MarketConditions(
+    spread_bps=Decimal("2"),
+    data_age_seconds=5.0,
+    spot_free_base_qty=Decimal("0"),
+)
 
 
 # The shared db_session is never rolled back, so the 3 real allowlisted
@@ -245,7 +256,9 @@ async def test_spot_happy_path_reconciles_flat(db_session) -> None:
         now=_NOW,
         limits=_limits_for("EXESPOTAUSDT"),
     )
-    result = await executor.execute(_intent("spot", "EXESPOTAUSDT"), confirm=True)
+    result = await executor.execute(
+        _intent("spot", "EXESPOTAUSDT"), confirm=True, market=_FRESH_MARKET
+    )
     assert result.status == "reconciled"
     assert result.final_open_orders == 0
     # A BUY then a SELL were submitted with confirm=True.
@@ -265,7 +278,9 @@ async def test_dry_run_places_no_order(db_session) -> None:
         now=_NOW,
         limits=_limits_for("EXESPOTBUSDT"),
     )
-    result = await executor.execute(_intent("spot", "EXESPOTBUSDT"), confirm=False)
+    result = await executor.execute(
+        _intent("spot", "EXESPOTBUSDT"), confirm=False, market=_FRESH_MARKET
+    )
     assert result.status == "dry_run"
     assert client.submits == []  # zero broker mutation
 
@@ -281,7 +296,9 @@ async def test_risk_block_aborts_without_broker_call(db_session) -> None:
         reference=_FakeReference(_SPOT_REF),
         now=_NOW,
     )
-    result = await executor.execute(_intent("spot", "ETHUSDT"), confirm=True)
+    result = await executor.execute(
+        _intent("spot", "ETHUSDT"), confirm=True, market=_FRESH_MARKET
+    )
     assert result.status == "blocked"
     assert "symbol_not_allowlisted" in result.reason_codes
     assert client.submits == []
@@ -299,7 +316,7 @@ async def test_futures_happy_path_pins_leverage_and_reconciles_flat(db_session) 
         limits=_limits_for("EXEFUTAUSDT"),
     )
     result = await executor.execute(
-        _intent("usdm_futures", "EXEFUTAUSDT"), confirm=True
+        _intent("usdm_futures", "EXEFUTAUSDT"), confirm=True, market=_FRESH_MARKET
     )
     assert result.status == "reconciled"
     assert result.final_flat is True
@@ -321,7 +338,7 @@ async def test_futures_new_status_polls_to_filled(db_session) -> None:
         limits=_limits_for("EXEFUTBUSDT"),
     )
     result = await executor.execute(
-        _intent("usdm_futures", "EXEFUTBUSDT"), confirm=True
+        _intent("usdm_futures", "EXEFUTBUSDT"), confirm=True, market=_FRESH_MARKET
     )
     assert result.status == "reconciled"
     assert result.final_flat is True

--- a/tests/services/brokers/binance/demo_scalping_exec/test_executor_analytics.py
+++ b/tests/services/brokers/binance/demo_scalping_exec/test_executor_analytics.py
@@ -28,6 +28,15 @@ from app.services.brokers.binance.demo_scalping_exec.executor import (
 from app.services.brokers.binance.demo_scalping_exec.reference import SymbolReference
 
 _NOW = dt.datetime(2026, 5, 25, 12, 0, 0, tzinfo=dt.UTC)
+
+# ROB-841: the executor fails closed without a server market snapshot; supply a
+# fresh, tight one for calls that are not themselves testing the market gates.
+_FRESH_MARKET = MarketConditions(
+    spread_bps=Decimal("2"),
+    data_age_seconds=5.0,
+    spot_free_base_qty=Decimal("0"),
+)
+
 _REF = SymbolReference(
     price=Decimal("100"),
     step_size=Decimal("0.1"),
@@ -160,7 +169,7 @@ async def test_monitored_take_profit_writes_correct_analytics_row(db_session) ->
         poll_delay_seconds=0.0,
     )
     result = await ex.execute_monitored(
-        _intent("ANAFUTAUSDT"), confirm=True, max_poll_count=5
+        _intent("ANAFUTAUSDT"), confirm=True, market=_FRESH_MARKET, max_poll_count=5
     )
     assert result.status == "reconciled"
     assert result.exit_reason == "take_profit"
@@ -337,7 +346,7 @@ async def test_open_NEW_then_get_order_filled_uses_polled_entry_price(
         poll_delay_seconds=0.0,
     )
     result = await ex.execute_monitored(
-        _intent("POLLENTRYUSDT"), confirm=True, max_poll_count=5
+        _intent("POLLENTRYUSDT"), confirm=True, market=_FRESH_MARKET, max_poll_count=5
     )
     assert result.status == "reconciled"
     row = await ScalpTradeAnalyticsService(db_session).get_by_open_client_order_id(
@@ -368,7 +377,7 @@ async def test_close_NEW_then_get_order_filled_uses_polled_exit_price(
         poll_delay_seconds=0.0,
     )
     result = await ex.execute_monitored(
-        _intent("POLLEXITUSDT"), confirm=True, max_poll_count=5
+        _intent("POLLEXITUSDT"), confirm=True, market=_FRESH_MARKET, max_poll_count=5
     )
     assert result.status == "reconciled"
     row = await ScalpTradeAnalyticsService(db_session).get_by_open_client_order_id(
@@ -401,7 +410,7 @@ async def test_open_proven_by_position_without_price_records_partial_row(
         poll_delay_seconds=0.0,
     )
     result = await ex.execute_monitored(
-        _intent("NOPRICEUSDT"), confirm=True, max_poll_count=5
+        _intent("NOPRICEUSDT"), confirm=True, market=_FRESH_MARKET, max_poll_count=5
     )
     assert result.status == "reconciled"
     row = await ScalpTradeAnalyticsService(db_session).get_by_open_client_order_id(
@@ -565,7 +574,7 @@ async def test_dry_run_writes_no_analytics_row(db_session) -> None:
         poll_delay_seconds=0.0,
     )
     result = await ex.execute_monitored(
-        _intent("ANADRYUSDT"), confirm=False, max_poll_count=5
+        _intent("ANADRYUSDT"), confirm=False, market=_FRESH_MARKET, max_poll_count=5
     )
     assert result.status == "dry_run"
     # No open client order id on a dry run → no analytics row.

--- a/tests/services/brokers/binance/demo_scalping_exec/test_executor_market_conditions.py
+++ b/tests/services/brokers/binance/demo_scalping_exec/test_executor_market_conditions.py
@@ -1,0 +1,186 @@
+"""ROB-841 — executor preflight fail-closes without a server market snapshot.
+
+The prior behavior synthesized ``spread_bps=0``/``data_age_seconds=0`` when
+``market`` was omitted, silently disarming the SPREAD_TOO_WIDE / STALE_DATA
+gates. That 0/0 fallback is removed: a missing snapshot now returns a
+``blocked`` result with the ``market_conditions_unavailable`` reason code
+BEFORE any ledger read — so an unavailable snapshot touches neither broker
+nor ledger (ACs 1 & 4). A valid server-derived snapshot still flows into the
+existing risk gates; stale / wide-spread snapshots reuse the existing reason
+codes (ACs 2 & 3).
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from decimal import Decimal
+
+import pytest
+from sqlalchemy import func, select
+
+from app.models.binance_demo_order_ledger import BinanceDemoOrderLedger
+from app.services.brokers.binance.demo_scalping.contract import (
+    MarketConditions,
+    ReasonCode,
+    ScalpingRiskLimits,
+)
+from app.services.brokers.binance.demo_scalping.order_intent import OrderIntent
+from app.services.brokers.binance.demo_scalping_exec import executor as executor_mod
+from app.services.brokers.binance.demo_scalping_exec.executor import (
+    DemoScalpingExecutor,
+)
+from app.services.brokers.binance.demo_scalping_exec.reference import SymbolReference
+
+_NOW = dt.datetime(2026, 5, 24, 12, 0, 0, tzinfo=dt.UTC)
+_REF = SymbolReference(
+    price=Decimal("1.36"),
+    step_size=Decimal("0.1"),
+    min_notional=Decimal("5"),
+    tick_size=Decimal("0.0001"),
+)
+
+
+def _limits_for(symbol: str) -> ScalpingRiskLimits:
+    return ScalpingRiskLimits(
+        allowlist=frozenset({symbol}),
+        excluded=frozenset(),
+        global_open_lifecycle_cap=10_000,
+        daily_order_count_cap=10_000,
+        daily_loss_budget_usdt=Decimal("1000000"),
+    )
+
+
+def _intent(symbol: str, side: str = "BUY") -> OrderIntent:
+    return OrderIntent(
+        product="usdm_futures",
+        symbol=symbol,
+        side=side,
+        order_type="MARKET",
+        target_notional_usdt=Decimal("10"),
+        entry_reference_price=Decimal("1.36"),
+        tp_price=None,
+        sl_price=None,
+        confidence=Decimal("0.5"),
+        reason_codes=("enter_long_breakout",),
+        source_candle_close_time_ms=1_779_000_000_000,
+        evaluated_at_ms=1_779_000_001_000,
+    )
+
+
+class _FakeReference:
+    async def fetch(self, product, symbol):
+        return _REF
+
+    async def aclose(self):  # pragma: no cover - parity with real
+        return None
+
+
+class _ExplodingClient:
+    """Any broker call is a test failure — the fail-close must never reach it."""
+
+    def __getattr__(self, name):
+        async def _boom(*args, **kwargs):
+            raise AssertionError(f"broker call {name!r} must not happen on fail-close")
+
+        return _boom
+
+
+async def _ledger_rowcount(db_session) -> int:
+    return await db_session.scalar(select(func.count(BinanceDemoOrderLedger.id)))
+
+
+@pytest.mark.asyncio
+async def test_missing_market_fails_closed_no_ledger_no_broker(
+    db_session, monkeypatch
+) -> None:
+    # Spy: the fail-close must return BEFORE any ledger read.
+    def _no_ledger_read(*args, **kwargs):
+        raise AssertionError("ledger must not be read when market is unavailable")
+
+    monkeypatch.setattr(executor_mod, "load_ledger_snapshot", _no_ledger_read)
+
+    before = await _ledger_rowcount(db_session)
+    executor = DemoScalpingExecutor(
+        product="usdm_futures",
+        client=_ExplodingClient(),
+        session=db_session,
+        reference=_FakeReference(),
+        now=_NOW,
+        limits=_limits_for("MKTUNAVAILUSDT"),
+    )
+    # market omitted → must NOT synthesize 0/0; must fail closed.
+    result = await executor.execute(_intent("MKTUNAVAILUSDT"), confirm=True)
+    assert result.status == "blocked"
+    assert result.reason_codes == (ReasonCode.MARKET_CONDITIONS_UNAVAILABLE,)
+    after = await _ledger_rowcount(db_session)
+    assert after == before  # zero ledger writes
+
+
+@pytest.mark.asyncio
+async def test_stale_market_blocked_with_existing_stale_data(db_session) -> None:
+    executor = DemoScalpingExecutor(
+        product="usdm_futures",
+        client=_ExplodingClient(),
+        session=db_session,
+        reference=_FakeReference(),
+        now=_NOW,
+        limits=_limits_for("MKTSTALEUSDT"),
+    )
+    stale = MarketConditions(
+        spread_bps=Decimal("1"),
+        data_age_seconds=999.0,  # ≫ 120 cap
+        spot_free_base_qty=Decimal("0"),
+    )
+    result = await executor.execute(_intent("MKTSTALEUSDT"), confirm=True, market=stale)
+    assert result.status == "blocked"
+    assert ReasonCode.STALE_DATA in result.reason_codes
+
+
+@pytest.mark.asyncio
+async def test_wide_spread_market_blocked_with_existing_spread_too_wide(
+    db_session,
+) -> None:
+    executor = DemoScalpingExecutor(
+        product="usdm_futures",
+        client=_ExplodingClient(),
+        session=db_session,
+        reference=_FakeReference(),
+        now=_NOW,
+        limits=_limits_for("MKTWIDEUSDT"),
+    )
+    wide = MarketConditions(
+        spread_bps=Decimal("500"),  # ≫ 20 cap
+        data_age_seconds=1.0,
+        spot_free_base_qty=Decimal("0"),
+    )
+    result = await executor.execute(_intent("MKTWIDEUSDT"), confirm=True, market=wide)
+    assert result.status == "blocked"
+    assert ReasonCode.SPREAD_TOO_WIDE in result.reason_codes
+
+
+@pytest.mark.asyncio
+async def test_valid_market_dry_run_reads_ledger_but_writes_nothing(
+    db_session,
+) -> None:
+    # A valid server snapshot + confirm=False → dry_run judgment, no order,
+    # no ledger insert (AC6 at the executor layer).
+    executor = DemoScalpingExecutor(
+        product="usdm_futures",
+        client=_ExplodingClient(),
+        session=db_session,
+        reference=_FakeReference(),
+        now=_NOW,
+        limits=_limits_for("MKTVALIDUSDT"),
+    )
+    fresh = MarketConditions(
+        spread_bps=Decimal("2"),
+        data_age_seconds=5.0,
+        spot_free_base_qty=Decimal("0"),
+    )
+    before = await _ledger_rowcount(db_session)
+    result = await executor.execute(
+        _intent("MKTVALIDUSDT"), confirm=False, market=fresh
+    )
+    assert result.status == "dry_run"
+    after = await _ledger_rowcount(db_session)
+    assert after == before  # dry-run inserts no ledger rows

--- a/tests/services/brokers/binance/demo_scalping_exec/test_executor_monitored.py
+++ b/tests/services/brokers/binance/demo_scalping_exec/test_executor_monitored.py
@@ -13,7 +13,10 @@ from decimal import Decimal
 
 import pytest
 
-from app.services.brokers.binance.demo_scalping.contract import ScalpingRiskLimits
+from app.services.brokers.binance.demo_scalping.contract import (
+    MarketConditions,
+    ScalpingRiskLimits,
+)
 from app.services.brokers.binance.demo_scalping.market_data import BookTicker
 from app.services.brokers.binance.demo_scalping.order_intent import OrderIntent
 from app.services.brokers.binance.demo_scalping_exec.executor import (
@@ -27,6 +30,12 @@ _REF = SymbolReference(
     step_size=Decimal("0.1"),
     min_notional=Decimal("5"),
     tick_size=Decimal("0.01"),
+)
+# ROB-841: execute_monitored now fails closed without a server market snapshot.
+_FRESH_MARKET = MarketConditions(
+    spread_bps=Decimal("2"),
+    data_age_seconds=5.0,
+    spot_free_base_qty=Decimal("0"),
 )
 
 
@@ -190,7 +199,12 @@ async def test_spot_monitor_take_profit(db_session) -> None:
     client = _FakeSpot()
     result = await _executor(
         "spot", client, md, db_session, "MONSPOTAUSDT"
-    ).execute_monitored(_intent("spot", "MONSPOTAUSDT"), confirm=True, max_poll_count=5)
+    ).execute_monitored(
+        _intent("spot", "MONSPOTAUSDT"),
+        confirm=True,
+        market=_FRESH_MARKET,
+        max_poll_count=5,
+    )
     assert result.status == "reconciled"
     assert result.exit_reason == "take_profit"
     assert client.submits == ["BUY", "SELL"]
@@ -202,7 +216,12 @@ async def test_spot_monitor_stop_loss(db_session) -> None:
     client = _FakeSpot()
     result = await _executor(
         "spot", client, md, db_session, "MONSPOTBUSDT"
-    ).execute_monitored(_intent("spot", "MONSPOTBUSDT"), confirm=True, max_poll_count=5)
+    ).execute_monitored(
+        _intent("spot", "MONSPOTBUSDT"),
+        confirm=True,
+        market=_FRESH_MARKET,
+        max_poll_count=5,
+    )
     assert result.status == "reconciled"
     assert result.exit_reason == "stop_loss"
 
@@ -213,7 +232,12 @@ async def test_spot_monitor_timeout_failsafe_close(db_session) -> None:
     client = _FakeSpot()
     result = await _executor(
         "spot", client, md, db_session, "MONSPOTCUSDT"
-    ).execute_monitored(_intent("spot", "MONSPOTCUSDT"), confirm=True, max_poll_count=3)
+    ).execute_monitored(
+        _intent("spot", "MONSPOTCUSDT"),
+        confirm=True,
+        market=_FRESH_MARKET,
+        max_poll_count=3,
+    )
     assert result.status == "reconciled"
     assert result.exit_reason == "timeout"
     assert client.submits == ["BUY", "SELL"]  # failsafe close still flattens
@@ -226,7 +250,10 @@ async def test_futures_monitor_take_profit_flat(db_session) -> None:
     result = await _executor(
         "usdm_futures", client, md, db_session, "MONFUTAUSDT"
     ).execute_monitored(
-        _intent("usdm_futures", "MONFUTAUSDT"), confirm=True, max_poll_count=5
+        _intent("usdm_futures", "MONFUTAUSDT"),
+        confirm=True,
+        market=_FRESH_MARKET,
+        max_poll_count=5,
     )
     assert result.status == "reconciled"
     assert result.exit_reason == "take_profit"
@@ -240,7 +267,12 @@ async def test_monitor_dry_run_places_nothing(db_session) -> None:
     client = _FakeSpot()
     result = await _executor(
         "spot", client, md, db_session, "MONDRYUSDT"
-    ).execute_monitored(_intent("spot", "MONDRYUSDT"), confirm=False, max_poll_count=5)
+    ).execute_monitored(
+        _intent("spot", "MONDRYUSDT"),
+        confirm=False,
+        market=_FRESH_MARKET,
+        max_poll_count=5,
+    )
     assert result.status == "dry_run"
     assert client.submits == []
 
@@ -258,7 +290,10 @@ async def test_spot_monitor_error_still_closes_flat(db_session) -> None:
     result = await _executor(
         "spot", client, _RaisingMD(), db_session, "MONERRSPOTUSDT"
     ).execute_monitored(
-        _intent("spot", "MONERRSPOTUSDT"), confirm=True, max_poll_count=5
+        _intent("spot", "MONERRSPOTUSDT"),
+        confirm=True,
+        market=_FRESH_MARKET,
+        max_poll_count=5,
     )
     # Open succeeded, monitor raised -> still closed + reconciled flat.
     assert result.status == "reconciled"
@@ -273,7 +308,10 @@ async def test_futures_monitor_error_still_reduce_only_closes_flat(db_session) -
     result = await _executor(
         "usdm_futures", client, _RaisingMD(), db_session, "MONERRFUTUSDT"
     ).execute_monitored(
-        _intent("usdm_futures", "MONERRFUTUSDT"), confirm=True, max_poll_count=5
+        _intent("usdm_futures", "MONERRFUTUSDT"),
+        confirm=True,
+        market=_FRESH_MARKET,
+        max_poll_count=5,
     )
     assert result.status == "reconciled"
     assert result.exit_reason == "monitor_error"

--- a/tests/services/brokers/binance/demo_scalping_exec/test_executor_realized_pnl.py
+++ b/tests/services/brokers/binance/demo_scalping_exec/test_executor_realized_pnl.py
@@ -35,6 +35,15 @@ from app.services.brokers.binance.demo_scalping_exec.reference import SymbolRefe
 # ---------------------------------------------------------------------------
 
 _NOW = dt.datetime(2026, 5, 25, 12, 0, 0, tzinfo=dt.UTC)
+
+# ROB-841: the executor fails closed without a server market snapshot; supply a
+# fresh, tight one for calls that are not themselves testing the market gates.
+_FRESH_MARKET = MarketConditions(
+    spread_bps=Decimal("2"),
+    data_age_seconds=5.0,
+    spot_free_base_qty=Decimal("0"),
+)
+
 _REF = SymbolReference(
     price=Decimal("100"),
     step_size=Decimal("0.1"),
@@ -172,7 +181,7 @@ async def test_close_row_carries_realized_pnl_open_row_does_not(db_session) -> N
         poll_delay_seconds=0.0,
     )
     result = await ex.execute_monitored(
-        _intent("RPNLWINUSDT"), confirm=True, max_poll_count=5
+        _intent("RPNLWINUSDT"), confirm=True, market=_FRESH_MARKET, max_poll_count=5
     )
     assert result.status == "reconciled"
 
@@ -213,7 +222,7 @@ async def test_losing_round_trip_feeds_daily_loss_budget_gate(db_session) -> Non
         poll_delay_seconds=0.0,
     )
     result = await ex.execute(
-        _intent("RPNLLOSSUSDT"), confirm=True
+        _intent("RPNLLOSSUSDT"), confirm=True, market=_FRESH_MARKET
     )  # immediate open+close
     assert result.status == "reconciled"
 

--- a/tests/services/brokers/binance/demo_scalping_exec/test_executor_session_tag.py
+++ b/tests/services/brokers/binance/demo_scalping_exec/test_executor_session_tag.py
@@ -12,6 +12,7 @@ from decimal import Decimal
 import pytest
 
 from app.services.brokers.binance.demo_scalping.contract import (
+    MarketConditions,
     ScalpingRiskLimits,
 )
 from app.services.brokers.binance.demo_scalping.market_data import BookTicker
@@ -25,6 +26,15 @@ from app.services.brokers.binance.demo_scalping_exec.executor import (
 from app.services.brokers.binance.demo_scalping_exec.reference import SymbolReference
 
 _NOW = dt.datetime(2026, 5, 25, 12, 0, 0, tzinfo=dt.UTC)
+
+# ROB-841: the executor fails closed without a server market snapshot; supply a
+# fresh, tight one for calls that are not themselves testing the market gates.
+_FRESH_MARKET = MarketConditions(
+    spread_bps=Decimal("2"),
+    data_age_seconds=5.0,
+    spot_free_base_qty=Decimal("0"),
+)
+
 _REF = SymbolReference(
     price=Decimal("100"),
     step_size=Decimal("0.1"),
@@ -160,6 +170,7 @@ async def test_session_tag_and_signal_snapshot_recorded(db_session) -> None:
     result = await ex.execute_monitored(
         _intent("LLMTAGUSDT"),
         confirm=True,
+        market=_FRESH_MARKET,
         max_poll_count=5,
         session_tag="llm",
         signal_snapshot=snap,
@@ -188,7 +199,7 @@ async def test_session_tag_defaults_none_no_regression(db_session) -> None:
         poll_delay_seconds=0.0,
     )
     result = await ex.execute_monitored(
-        _intent("NOTAGUSDT"), confirm=True, max_poll_count=5
+        _intent("NOTAGUSDT"), confirm=True, market=_FRESH_MARKET, max_poll_count=5
     )
     row = await ScalpTradeAnalyticsService(db_session).get_by_open_client_order_id(
         result.open_client_order_id
@@ -215,6 +226,7 @@ async def test_execute_one_shot_records_session_tag(db_session) -> None:
     result = await ex.execute(
         _intent("ONESHOTTAGUSDT"),
         confirm=True,
+        market=_FRESH_MARKET,
         session_tag="llm",
         signal_snapshot=snap,
     )


### PR DESCRIPTION
## Summary
- derive Binance Demo bookTicker and latest 1m kline conditions on the server before the executor/ledger boundary
- fail closed on unavailable, stale, wide-spread, non-finite, crossed, or semantically malformed quote/candle data
- map CLI market observation failures to the same structured `blocked / market_conditions_unavailable` evidence contract and exit code 1
- keep dry-run on the same market/risk preflight with zero broker mutation and zero ledger insert

## Safety boundaries
- Binance Demo hosts and default-off gates are unchanged
- public MCP input has no caller-controlled spread or data-age fields
- CLI failure returns before DB session/executor creation and still closes created resources
- no schema or migration changes

## Verification
- CLI plus required market-condition/MCP suites: 58 passed
- all Binance test files: 649 passed
- Ruff check and format: passed
- ty: passed
- `git diff --check`: clean

## Pre-landing review
- no unresolved P1/P2 findings
- prior CodeRabbit CLI evidence-contract finding fixed in `32499ba9`
- no Greptile comments

Linear: https://linear.app/mgh3326/issue/ROB-841

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added server-derived market checks (live quote + latest 1m candle) for Demo scalping decisions.
  * Dry runs now execute the same preflight logic as real orders, returning consistent planned/blocked/unavailable outcomes without mutations.
  * Tool responses now include observed spread and data-age details.

* **Bug Fixes**
  * If market conditions can’t be validated, execution now fails closed with a dedicated “unavailable” block status (no order placement or DB/ledger activity).
  * Caller-supplied market metrics are no longer accepted.

* **Documentation**
  * Updated MCP tool docs and runbooks to reflect the new dry-run/confirm flow and safety behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->