### PR TITLE
feat(ROB-846): immutable strategy experiment registry + complete trial accounting

### DIFF
--- a/alembic/versions/20260712_rob846_strategy_experiment_registry.py
+++ b/alembic/versions/20260712_rob846_strategy_experiment_registry.py
@@ -1,0 +1,310 @@
+"""ROB-846 immutable strategy experiment registry + complete trial accounting.
+
+Additive, research-schema only. Adds an immutable ``strategy_experiments``
+parent, extends ``backtest_runs`` with append-only trial-child fields, and adds
+run/config/data hash linkage to ``promotion_candidates``. Row-level
+immutability (append-only) is enforced by BEFORE UPDATE/DELETE triggers:
+
+* ``strategy_experiments`` — every UPDATE/DELETE is rejected.
+* ``backtest_runs`` — UPDATE/DELETE is rejected only for trial rows
+  (``strategy_experiment_id IS NOT NULL``); legacy summary rows ingested via
+  ``upsert_backtest_run`` keep ``strategy_experiment_id`` NULL and stay mutable.
+
+Revision ID: 20260712_rob846_experiments
+Revises: 20260711_rob832_actions
+Create Date: 2026-07-12
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "20260712_rob846_experiments"
+down_revision: str | Sequence[str] | None = "20260711_rob832_actions"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+_HASH_COLUMNS: tuple[str, ...] = (
+    "strategy_hash",
+    "code_hash",
+    "params_hash",
+    "dataset_manifest_hash",
+    "universe_hash",
+    "pit_hash",
+    "frozen_config_hash",
+    "policy_hash",
+    "benchmark_hash",
+    "cost_hash",
+    "mdd_hash",
+)
+
+
+# --- append-only immutability triggers (mirrored in tests/_schema_bootstrap) ---
+_IMMUTABILITY_DDL: tuple[str, ...] = (
+    """
+    CREATE OR REPLACE FUNCTION research.reject_strategy_experiment_mutation()
+    RETURNS trigger AS $$
+    BEGIN
+        RAISE EXCEPTION
+            'research.strategy_experiments is append-only/immutable; % rejected',
+            TG_OP
+            USING ERRCODE = 'restrict_violation';
+    END;
+    $$ LANGUAGE plpgsql
+    """,
+    "DROP TRIGGER IF EXISTS trg_strategy_experiments_immutable "
+    "ON research.strategy_experiments",
+    """
+    CREATE TRIGGER trg_strategy_experiments_immutable
+        BEFORE UPDATE OR DELETE ON research.strategy_experiments
+        FOR EACH ROW
+        EXECUTE FUNCTION research.reject_strategy_experiment_mutation()
+    """,
+    """
+    CREATE OR REPLACE FUNCTION research.reject_backtest_trial_mutation()
+    RETURNS trigger AS $$
+    BEGIN
+        IF OLD.strategy_experiment_id IS NOT NULL THEN
+            RAISE EXCEPTION
+                'research.backtest_runs trial rows are append-only; % rejected on id=%',
+                TG_OP, OLD.id
+                USING ERRCODE = 'restrict_violation';
+        END IF;
+        IF TG_OP = 'DELETE' THEN
+            RETURN OLD;
+        END IF;
+        RETURN NEW;
+    END;
+    $$ LANGUAGE plpgsql
+    """,
+    "DROP TRIGGER IF EXISTS trg_backtest_runs_trial_immutable "
+    "ON research.backtest_runs",
+    """
+    CREATE TRIGGER trg_backtest_runs_trial_immutable
+        BEFORE UPDATE OR DELETE ON research.backtest_runs
+        FOR EACH ROW
+        EXECUTE FUNCTION research.reject_backtest_trial_mutation()
+    """,
+)
+
+
+def upgrade() -> None:
+    op.execute("CREATE SCHEMA IF NOT EXISTS research")
+
+    op.create_table(
+        "strategy_experiments",
+        sa.Column("id", sa.BigInteger(), primary_key=True, autoincrement=True),
+        sa.Column("experiment_id", sa.String(length=64), nullable=False),
+        sa.Column("strategy_key", sa.String(length=128), nullable=False),
+        sa.Column("strategy_version", sa.String(length=128), nullable=False),
+        sa.Column("hypothesis", sa.Text(), nullable=True),
+        *[
+            sa.Column(name, sa.String(length=64), nullable=False)
+            for name in _HASH_COLUMNS
+        ],
+        sa.Column(
+            "benchmark_definition",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=True,
+        ),
+        sa.Column(
+            "cost_definition", postgresql.JSONB(astext_type=sa.Text()), nullable=True
+        ),
+        sa.Column(
+            "mdd_definition", postgresql.JSONB(astext_type=sa.Text()), nullable=True
+        ),
+        sa.Column("manifest", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column("supersedes_experiment_id", sa.String(length=64), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.UniqueConstraint(
+            "experiment_id", name="uq_research_strategy_experiments_experiment_id"
+        ),
+        sa.ForeignKeyConstraint(
+            ["supersedes_experiment_id"],
+            ["research.strategy_experiments.experiment_id"],
+            ondelete="RESTRICT",
+            name="fk_research_strategy_experiments_supersedes",
+        ),
+        schema="research",
+    )
+    op.create_index(
+        "ix_research_strategy_experiments_strategy_key",
+        "strategy_experiments",
+        ["strategy_key", "strategy_version"],
+        schema="research",
+    )
+    op.create_index(
+        "ix_research_strategy_experiments_supersedes",
+        "strategy_experiments",
+        ["supersedes_experiment_id"],
+        schema="research",
+    )
+
+    # ---- backtest_runs: append-only trial-child fields ----
+    op.add_column(
+        "backtest_runs",
+        sa.Column("strategy_experiment_id", sa.BigInteger(), nullable=True),
+        schema="research",
+    )
+    op.add_column(
+        "backtest_runs",
+        sa.Column("trial_index", sa.Integer(), nullable=True),
+        schema="research",
+    )
+    op.add_column(
+        "backtest_runs",
+        sa.Column("seed", sa.BigInteger(), nullable=True),
+        schema="research",
+    )
+    op.add_column(
+        "backtest_runs",
+        sa.Column("information_cutoff", sa.TIMESTAMP(timezone=True), nullable=True),
+        schema="research",
+    )
+    op.add_column(
+        "backtest_runs",
+        sa.Column("trial_status", sa.String(length=16), nullable=True),
+        schema="research",
+    )
+    op.add_column(
+        "backtest_runs",
+        sa.Column("gate_artifact_hash", sa.String(length=64), nullable=True),
+        schema="research",
+    )
+    op.add_column(
+        "backtest_runs",
+        sa.Column("trial_idempotency_key", sa.String(length=128), nullable=True),
+        schema="research",
+    )
+    op.create_foreign_key(
+        "fk_research_backtest_runs_experiment_id",
+        "backtest_runs",
+        "strategy_experiments",
+        ["strategy_experiment_id"],
+        ["id"],
+        source_schema="research",
+        referent_schema="research",
+        ondelete="RESTRICT",
+    )
+    op.create_unique_constraint(
+        "uq_research_backtest_runs_experiment_trial_index",
+        "backtest_runs",
+        ["strategy_experiment_id", "trial_index"],
+        schema="research",
+    )
+    op.create_unique_constraint(
+        "uq_research_backtest_runs_experiment_idempotency",
+        "backtest_runs",
+        ["strategy_experiment_id", "trial_idempotency_key"],
+        schema="research",
+    )
+    op.create_check_constraint(
+        "ck_research_backtest_runs_trial_status",
+        "backtest_runs",
+        "trial_status IS NULL OR trial_status IN "
+        "('completed','rejected','crashed','timeout')",
+        schema="research",
+    )
+    op.create_index(
+        "ix_research_backtest_runs_experiment",
+        "backtest_runs",
+        ["strategy_experiment_id", "trial_index"],
+        schema="research",
+    )
+
+    # ---- promotion_candidates: exact run/config/data linkage ----
+    op.add_column(
+        "promotion_candidates",
+        sa.Column("experiment_id", sa.String(length=64), nullable=True),
+        schema="research",
+    )
+    op.add_column(
+        "promotion_candidates",
+        sa.Column("run_config_hash", sa.String(length=64), nullable=True),
+        schema="research",
+    )
+    op.add_column(
+        "promotion_candidates",
+        sa.Column("run_data_hash", sa.String(length=64), nullable=True),
+        schema="research",
+    )
+
+    for stmt in _IMMUTABILITY_DDL:
+        op.execute(stmt)
+
+
+def downgrade() -> None:
+    op.execute(
+        "DROP TRIGGER IF EXISTS trg_backtest_runs_trial_immutable "
+        "ON research.backtest_runs"
+    )
+    op.execute(
+        "DROP TRIGGER IF EXISTS trg_strategy_experiments_immutable "
+        "ON research.strategy_experiments"
+    )
+    op.execute("DROP FUNCTION IF EXISTS research.reject_backtest_trial_mutation()")
+    op.execute("DROP FUNCTION IF EXISTS research.reject_strategy_experiment_mutation()")
+
+    op.drop_column("promotion_candidates", "run_data_hash", schema="research")
+    op.drop_column("promotion_candidates", "run_config_hash", schema="research")
+    op.drop_column("promotion_candidates", "experiment_id", schema="research")
+
+    op.drop_index(
+        "ix_research_backtest_runs_experiment",
+        table_name="backtest_runs",
+        schema="research",
+    )
+    op.drop_constraint(
+        "ck_research_backtest_runs_trial_status",
+        "backtest_runs",
+        type_="check",
+        schema="research",
+    )
+    op.drop_constraint(
+        "uq_research_backtest_runs_experiment_idempotency",
+        "backtest_runs",
+        type_="unique",
+        schema="research",
+    )
+    op.drop_constraint(
+        "uq_research_backtest_runs_experiment_trial_index",
+        "backtest_runs",
+        type_="unique",
+        schema="research",
+    )
+    op.drop_constraint(
+        "fk_research_backtest_runs_experiment_id",
+        "backtest_runs",
+        type_="foreignkey",
+        schema="research",
+    )
+    op.drop_column("backtest_runs", "trial_idempotency_key", schema="research")
+    op.drop_column("backtest_runs", "gate_artifact_hash", schema="research")
+    op.drop_column("backtest_runs", "trial_status", schema="research")
+    op.drop_column("backtest_runs", "information_cutoff", schema="research")
+    op.drop_column("backtest_runs", "seed", schema="research")
+    op.drop_column("backtest_runs", "trial_index", schema="research")
+    op.drop_column("backtest_runs", "strategy_experiment_id", schema="research")
+
+    op.drop_index(
+        "ix_research_strategy_experiments_supersedes",
+        table_name="strategy_experiments",
+        schema="research",
+    )
+    op.drop_index(
+        "ix_research_strategy_experiments_strategy_key",
+        table_name="strategy_experiments",
+        schema="research",
+    )
+    op.drop_table("strategy_experiments", schema="research")

--- a/alembic/versions/20260712_rob846_strategy_experiment_registry.py
+++ b/alembic/versions/20260712_rob846_strategy_experiment_registry.py
@@ -70,14 +70,25 @@ _IMMUTABILITY_DDL: tuple[str, ...] = (
     CREATE OR REPLACE FUNCTION research.reject_backtest_trial_mutation()
     RETURNS trigger AS $$
     BEGIN
-        IF OLD.strategy_experiment_id IS NOT NULL THEN
-            RAISE EXCEPTION
-                'research.backtest_runs trial rows are append-only; % rejected on id=%',
-                TG_OP, OLD.id
-                USING ERRCODE = 'restrict_violation';
-        END IF;
         IF TG_OP = 'DELETE' THEN
+            IF OLD.strategy_experiment_id IS NOT NULL THEN
+                RAISE EXCEPTION
+                    'research.backtest_runs trial rows are append-only; DELETE rejected on id=%',
+                    OLD.id
+                    USING ERRCODE = 'restrict_violation';
+            END IF;
             RETURN OLD;
+        END IF;
+        -- UPDATE: reject when the row is (OLD) or would become (NEW) a trial.
+        -- This blocks both mutating an existing trial and the legacy->trial
+        -- conversion bypass. Only legacy->legacy (null->null) edits are allowed.
+        IF OLD.strategy_experiment_id IS NOT NULL
+           OR NEW.strategy_experiment_id IS NOT NULL THEN
+            RAISE EXCEPTION
+                'research.backtest_runs trial rows are append-only; '
+                'UPDATE/convert rejected on id=%',
+                OLD.id
+                USING ERRCODE = 'restrict_violation';
         END IF;
         RETURN NEW;
     END;
@@ -222,6 +233,20 @@ def upgrade() -> None:
         ["strategy_experiment_id", "trial_index"],
         schema="research",
     )
+    # Trial all-or-none integrity: a row is either a legacy summary (no trial
+    # fields at all) or a fully-formed trial (experiment + index + status). Added
+    # NOT VALID so pre-existing legacy summary rows are never retro-invalidated
+    # while every new INSERT/UPDATE is enforced.
+    op.execute(
+        "ALTER TABLE research.backtest_runs "
+        "ADD CONSTRAINT ck_research_backtest_runs_trial_all_or_none CHECK ("
+        "(strategy_experiment_id IS NULL AND trial_index IS NULL "
+        "AND trial_status IS NULL AND trial_idempotency_key IS NULL "
+        "AND seed IS NULL AND information_cutoff IS NULL "
+        "AND gate_artifact_hash IS NULL) "
+        "OR (strategy_experiment_id IS NOT NULL AND trial_index IS NOT NULL "
+        "AND trial_status IS NOT NULL)) NOT VALID"
+    )
 
     # ---- promotion_candidates: exact run/config/data linkage ----
     op.add_column(
@@ -239,6 +264,16 @@ def upgrade() -> None:
         sa.Column("run_data_hash", sa.String(length=64), nullable=True),
         schema="research",
     )
+    # AC#5 boundary: a NEW promotion candidate must carry a full exact identity
+    # (experiment/config/data hashes). NOT VALID keeps legacy null-identity rows
+    # for migration compatibility while blocking any new incomplete write at the
+    # DB boundary; the service layer no longer writes identity-less candidates.
+    op.execute(
+        "ALTER TABLE research.promotion_candidates "
+        "ADD CONSTRAINT ck_research_promotion_candidates_identity_complete CHECK ("
+        "experiment_id IS NOT NULL AND run_config_hash IS NOT NULL "
+        "AND run_data_hash IS NOT NULL) NOT VALID"
+    )
 
     for stmt in _IMMUTABILITY_DDL:
         op.execute(stmt)
@@ -255,6 +290,15 @@ def downgrade() -> None:
     )
     op.execute("DROP FUNCTION IF EXISTS research.reject_backtest_trial_mutation()")
     op.execute("DROP FUNCTION IF EXISTS research.reject_strategy_experiment_mutation()")
+
+    op.execute(
+        "ALTER TABLE research.promotion_candidates "
+        "DROP CONSTRAINT IF EXISTS ck_research_promotion_candidates_identity_complete"
+    )
+    op.execute(
+        "ALTER TABLE research.backtest_runs "
+        "DROP CONSTRAINT IF EXISTS ck_research_backtest_runs_trial_all_or_none"
+    )
 
     op.drop_column("promotion_candidates", "run_data_hash", schema="research")
     op.drop_column("promotion_candidates", "run_config_hash", schema="research")

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -55,6 +55,7 @@ from .research_backtest import (
     ResearchBacktestPair,
     ResearchBacktestRun,
     ResearchPromotionCandidate,
+    ResearchStrategyExperiment,
     ResearchSyncJob,
 )
 from .research_pipeline import (
@@ -146,6 +147,7 @@ __all__ = [
     "ResearchBacktestRun",
     "ResearchBacktestPair",
     "ResearchPromotionCandidate",
+    "ResearchStrategyExperiment",
     "ResearchSyncJob",
     "AssetProfile",
     "TierRuleParam",

--- a/app/models/research_backtest.py
+++ b/app/models/research_backtest.py
@@ -5,8 +5,10 @@ from decimal import Decimal
 
 from sqlalchemy import (
     BigInteger,
+    CheckConstraint,
     ForeignKey,
     Index,
+    Integer,
     Numeric,
     String,
     Text,
@@ -18,6 +20,82 @@ from sqlalchemy.sql import func
 
 from app.models.base import Base
 
+# ROB-846 — every attempted trial (invocation) is recorded under one of these
+# terminal outcomes. No winner-only filtering: crashed/timeout/rejected trials
+# each occupy a monotonic trial_index just like completed ones.
+TRIAL_STATUSES: tuple[str, ...] = ("completed", "rejected", "crashed", "timeout")
+
+
+class ResearchStrategyExperiment(Base):
+    """ROB-846 — immutable strategy experiment parent.
+
+    Registers a strategy *version* by its canonical SHA-256 identity
+    (strategy/code/params/dataset/PIT/frozen-config/policy/benchmark/cost/MDD).
+    Rows are append-only and immutable: corrections create a new version linked
+    by ``supersedes_experiment_id`` (a new lineage) rather than mutating hashes.
+    DB triggers reject UPDATE/DELETE (see migration + test schema mirror).
+    """
+
+    __tablename__ = "strategy_experiments"
+    __table_args__ = (
+        UniqueConstraint(
+            "experiment_id", name="uq_research_strategy_experiments_experiment_id"
+        ),
+        Index(
+            "ix_research_strategy_experiments_strategy_key",
+            "strategy_key",
+            "strategy_version",
+        ),
+        Index(
+            "ix_research_strategy_experiments_supersedes",
+            "supersedes_experiment_id",
+        ),
+        {"schema": "research"},
+    )
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    # Canonical identity digest (derive_experiment_id). Immutable, unique.
+    experiment_id: Mapped[str] = mapped_column(String(64), nullable=False)
+    strategy_key: Mapped[str] = mapped_column(String(128), nullable=False)
+    strategy_version: Mapped[str] = mapped_column(String(128), nullable=False)
+    hypothesis: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    strategy_hash: Mapped[str] = mapped_column(String(64), nullable=False)
+    code_hash: Mapped[str] = mapped_column(String(64), nullable=False)
+    params_hash: Mapped[str] = mapped_column(String(64), nullable=False)
+    dataset_manifest_hash: Mapped[str] = mapped_column(String(64), nullable=False)
+    universe_hash: Mapped[str] = mapped_column(String(64), nullable=False)
+    pit_hash: Mapped[str] = mapped_column(String(64), nullable=False)
+    frozen_config_hash: Mapped[str] = mapped_column(String(64), nullable=False)
+    policy_hash: Mapped[str] = mapped_column(String(64), nullable=False)
+    benchmark_hash: Mapped[str] = mapped_column(String(64), nullable=False)
+    cost_hash: Mapped[str] = mapped_column(String(64), nullable=False)
+    mdd_hash: Mapped[str] = mapped_column(String(64), nullable=False)
+
+    # Raw definitions kept for audit/reproduction (the source of the hashes).
+    benchmark_definition: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+    cost_definition: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+    mdd_definition: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+    manifest: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+
+    # Lineage: a correction supersedes an earlier immutable version.
+    supersedes_experiment_id: Mapped[str | None] = mapped_column(
+        String(64),
+        ForeignKey(
+            "research.strategy_experiments.experiment_id",
+            ondelete="RESTRICT",
+            name="fk_research_strategy_experiments_supersedes",
+        ),
+        nullable=True,
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        nullable=False, server_default=func.now()
+    )
+
+    trials: Mapped[list[ResearchBacktestRun]] = relationship(
+        back_populates="experiment",
+    )
+
 
 class ResearchBacktestRun(Base):
     __tablename__ = "backtest_runs"
@@ -25,6 +103,29 @@ class ResearchBacktestRun(Base):
         UniqueConstraint("run_id", name="uq_research_backtest_runs_run_id"),
         Index("ix_research_backtest_runs_runner", "runner"),
         Index("ix_research_backtest_runs_strategy", "strategy_name"),
+        # ROB-846 trial accounting: one monotonic index per experiment, and
+        # idempotency dedup per experiment. NULLs (legacy summary rows) are
+        # distinct in Postgres, so pre-ROB-846 rows never collide here.
+        UniqueConstraint(
+            "strategy_experiment_id",
+            "trial_index",
+            name="uq_research_backtest_runs_experiment_trial_index",
+        ),
+        UniqueConstraint(
+            "strategy_experiment_id",
+            "trial_idempotency_key",
+            name="uq_research_backtest_runs_experiment_idempotency",
+        ),
+        CheckConstraint(
+            "trial_status IS NULL OR trial_status IN "
+            "('completed','rejected','crashed','timeout')",
+            name="ck_research_backtest_runs_trial_status",
+        ),
+        Index(
+            "ix_research_backtest_runs_experiment",
+            "strategy_experiment_id",
+            "trial_index",
+        ),
         {"schema": "research"},
     )
 
@@ -57,6 +158,31 @@ class ResearchBacktestRun(Base):
     )
     updated_at: Mapped[datetime] = mapped_column(
         nullable=False, server_default=func.now()
+    )
+
+    # ROB-846 append-only trial-child fields (nullable → legacy summary rows
+    # ingested via upsert_backtest_run leave these NULL and stay mutable; rows
+    # with a non-null strategy_experiment_id are immutable trials).
+    strategy_experiment_id: Mapped[int | None] = mapped_column(
+        BigInteger,
+        ForeignKey(
+            "research.strategy_experiments.id",
+            ondelete="RESTRICT",
+            name="fk_research_backtest_runs_experiment_id",
+        ),
+        nullable=True,
+    )
+    trial_index: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    seed: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
+    information_cutoff: Mapped[datetime | None] = mapped_column(nullable=True)
+    trial_status: Mapped[str | None] = mapped_column(String(16), nullable=True)
+    gate_artifact_hash: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    trial_idempotency_key: Mapped[str | None] = mapped_column(
+        String(128), nullable=True
+    )
+
+    experiment: Mapped[ResearchStrategyExperiment | None] = relationship(
+        back_populates="trials",
     )
 
     pairs: Mapped[list[ResearchBacktestPair]] = relationship(
@@ -121,6 +247,12 @@ class ResearchPromotionCandidate(Base):
     reason_code: Mapped[str] = mapped_column(String(64), nullable=False)
     thresholds: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
     metrics: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+    # ROB-846 — a promotion candidate is a deterministic evaluation output
+    # linked to an EXACT experiment/config/data identity. The registry refuses
+    # to link a candidate whose hashes are missing or mismatch the experiment.
+    experiment_id: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    run_config_hash: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    run_data_hash: Mapped[str | None] = mapped_column(String(64), nullable=True)
     evaluated_at: Mapped[datetime] = mapped_column(
         nullable=False, server_default=func.now()
     )

--- a/app/schemas/research_backtest.py
+++ b/app/schemas/research_backtest.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from decimal import Decimal
 from typing import Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from app.services.research_canonical_hash import IDENTITY_COMPONENTS
 
@@ -15,30 +15,47 @@ TrialStatus = Literal["completed", "rejected", "crashed", "timeout"]
 class StrategyExperimentIdentity(BaseModel):
     """Immutable identity of a strategy version to register (ROB-846).
 
-    Each of the identity components is hashed into a canonical SHA-256 digest;
-    the combination derives the experiment_id. Unknown keys are rejected so the
-    identity contract cannot silently drift.
+    Each identity component is hashed into a canonical SHA-256 digest; the
+    combination derives the experiment_id. Unknown keys are rejected so the
+    contract cannot silently drift.
+
+    Reproducibility contract: every component is **required and non-null** — an
+    all-null identity cannot be registered. A component that a strategy
+    genuinely does not use must be stated explicitly with an empty sentinel
+    (e.g. ``benchmark={}`` or ``cost=[]``), not omitted or set to ``None``, so
+    "no benchmark" is a deliberate, hashable fact rather than missing data.
+    ``hypothesis`` and ``supersedes_experiment_id`` are the only optional fields.
     """
 
     strategy_key: str = Field(min_length=1)
     strategy_version: str = Field(min_length=1)
     hypothesis: str | None = None
 
-    strategy: Any = None
-    code: Any = None
-    params: Any = None
-    dataset_manifest: Any = None
-    universe: Any = None
-    pit: Any = None
-    frozen_config: Any = None
-    policy: Any = None
-    benchmark: Any = None
-    cost: Any = None
-    mdd: Any = None
+    strategy: Any
+    code: Any
+    params: Any
+    dataset_manifest: Any
+    universe: Any
+    pit: Any
+    frozen_config: Any
+    policy: Any
+    benchmark: Any
+    cost: Any
+    mdd: Any
 
     supersedes_experiment_id: str | None = None
 
     model_config = ConfigDict(extra="forbid")
+
+    @model_validator(mode="after")
+    def _require_non_null_components(self) -> StrategyExperimentIdentity:
+        missing = [name for name in IDENTITY_COMPONENTS if getattr(self, name) is None]
+        if missing:
+            raise ValueError(
+                "identity components must be non-null (use an explicit empty "
+                f"sentinel like {{}} for unused ones): {missing}"
+            )
+        return self
 
     def components(self) -> dict[str, Any]:
         """Ordered identity components fed to ``compute_identity_hashes``."""

--- a/app/schemas/research_backtest.py
+++ b/app/schemas/research_backtest.py
@@ -6,7 +6,7 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
-from app.services.research_canonical_hash import IDENTITY_COMPONENTS, to_jsonable
+from app.services.research_canonical_hash import IDENTITY_COMPONENTS, encode_canonical
 
 # ROB-846 — terminal trial outcomes; every invocation records exactly one.
 TrialStatus = Literal["completed", "rejected", "crashed", "timeout"]
@@ -55,13 +55,13 @@ class StrategyExperimentIdentity(BaseModel):
                 "identity components must be non-null (use an explicit empty "
                 f"sentinel like {{}} for unused ones): {missing}"
             )
-        # Each component must reduce to a collision-free, JSON-safe canonical
-        # form (no NaN/Inf, str-only dict keys, unambiguous sets) so hashing and
-        # JSONB persistence cannot diverge. Reject invalid identities here, with
-        # the offending component named, long before any DB work.
+        # Each component must reduce to a closed, collision-free typed canonical
+        # AST (no NaN/Inf, str-only dict keys, unambiguous sets, no unsupported
+        # types) so hashing and JSONB persistence cannot diverge. Reject invalid
+        # identities here, with the offending component named, before any DB work.
         for name in IDENTITY_COMPONENTS:
             try:
-                to_jsonable(getattr(self, name))
+                encode_canonical(getattr(self, name))
             except (TypeError, ValueError) as exc:
                 raise ValueError(
                     f"identity component {name!r} is not canonical/JSON-safe: {exc}"

--- a/app/schemas/research_backtest.py
+++ b/app/schemas/research_backtest.py
@@ -2,8 +2,135 @@ from __future__ import annotations
 
 from datetime import datetime
 from decimal import Decimal
+from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field
+
+from app.services.research_canonical_hash import IDENTITY_COMPONENTS
+
+# ROB-846 — terminal trial outcomes; every invocation records exactly one.
+TrialStatus = Literal["completed", "rejected", "crashed", "timeout"]
+
+
+class StrategyExperimentIdentity(BaseModel):
+    """Immutable identity of a strategy version to register (ROB-846).
+
+    Each of the identity components is hashed into a canonical SHA-256 digest;
+    the combination derives the experiment_id. Unknown keys are rejected so the
+    identity contract cannot silently drift.
+    """
+
+    strategy_key: str = Field(min_length=1)
+    strategy_version: str = Field(min_length=1)
+    hypothesis: str | None = None
+
+    strategy: Any = None
+    code: Any = None
+    params: Any = None
+    dataset_manifest: Any = None
+    universe: Any = None
+    pit: Any = None
+    frozen_config: Any = None
+    policy: Any = None
+    benchmark: Any = None
+    cost: Any = None
+    mdd: Any = None
+
+    supersedes_experiment_id: str | None = None
+
+    model_config = ConfigDict(extra="forbid")
+
+    def components(self) -> dict[str, Any]:
+        """Ordered identity components fed to ``compute_identity_hashes``."""
+        return {name: getattr(self, name) for name in IDENTITY_COMPONENTS}
+
+
+class StrategyExperimentRecord(BaseModel):
+    """Read-model of a registered immutable experiment (ROB-846)."""
+
+    experiment_id: str
+    strategy_key: str
+    strategy_version: str
+    hypothesis: str | None = None
+    strategy_hash: str
+    code_hash: str
+    params_hash: str
+    dataset_manifest_hash: str
+    universe_hash: str
+    pit_hash: str
+    frozen_config_hash: str
+    policy_hash: str
+    benchmark_hash: str
+    cost_hash: str
+    mdd_hash: str
+    supersedes_experiment_id: str | None = None
+    created_at: datetime | None = None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class BacktestTrialRequest(BaseModel):
+    """One append-only trial invocation under an experiment (ROB-846).
+
+    ``status`` may be any terminal outcome — completed/rejected/crashed/timeout
+    all record a trial and occupy a monotonic ``trial_index``.
+    """
+
+    status: TrialStatus
+    strategy_name: str = Field(min_length=1)
+    timeframe: str = Field(min_length=1)
+    runner: str = Field(min_length=1)
+    run_id: str | None = None
+    seed: int | None = None
+    information_cutoff: datetime | None = None
+    gate_artifact_hash: str | None = None
+    idempotency_key: str | None = None
+    exchange: str = "binance"
+    market: str = "spot"
+    timerange: str | None = None
+    started_at: datetime | None = None
+    ended_at: datetime | None = None
+    total_trades: int = Field(default=0, ge=0)
+    profit_factor: Decimal = Field(default=Decimal("0"))
+    max_drawdown: Decimal = Field(default=Decimal("0"))
+    win_rate: Decimal | None = None
+    expectancy: Decimal | None = None
+    total_return: Decimal | None = None
+    artifact_path: str | None = None
+    artifact_hash: str | None = None
+    raw_payload: dict | None = None
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class TrialAccounting(BaseModel):
+    """Complete trial accounting for an experiment (ROB-846 AC#4).
+
+    ``outcome_counts`` is always zero-filled for every terminal status — there
+    is no winner-only filtering.
+    """
+
+    experiment_id: str
+    total_trials: int
+    outcome_counts: dict[str, int]
+
+
+class PromotionLinkRequest(BaseModel):
+    """Link a promotion candidate to an EXACT run/config/data identity.
+
+    The registry rejects the link unless the experiment behind the run matches
+    all three expected hashes (ROB-846 AC#5).
+    """
+
+    expected_experiment_id: str = Field(min_length=1)
+    expected_config_hash: str = Field(min_length=1)
+    expected_data_hash: str = Field(min_length=1)
+    status: str = Field(min_length=1)
+    reason_code: str = Field(min_length=1)
+    thresholds: dict | None = None
+    metrics: dict | None = None
+
+    model_config = ConfigDict(extra="forbid")
 
 
 class BacktestPairSummary(BaseModel):

--- a/app/schemas/research_backtest.py
+++ b/app/schemas/research_backtest.py
@@ -6,7 +6,7 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
-from app.services.research_canonical_hash import IDENTITY_COMPONENTS
+from app.services.research_canonical_hash import IDENTITY_COMPONENTS, to_jsonable
 
 # ROB-846 — terminal trial outcomes; every invocation records exactly one.
 TrialStatus = Literal["completed", "rejected", "crashed", "timeout"]
@@ -48,13 +48,24 @@ class StrategyExperimentIdentity(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     @model_validator(mode="after")
-    def _require_non_null_components(self) -> StrategyExperimentIdentity:
+    def _validate_components(self) -> StrategyExperimentIdentity:
         missing = [name for name in IDENTITY_COMPONENTS if getattr(self, name) is None]
         if missing:
             raise ValueError(
                 "identity components must be non-null (use an explicit empty "
                 f"sentinel like {{}} for unused ones): {missing}"
             )
+        # Each component must reduce to a collision-free, JSON-safe canonical
+        # form (no NaN/Inf, str-only dict keys, unambiguous sets) so hashing and
+        # JSONB persistence cannot diverge. Reject invalid identities here, with
+        # the offending component named, long before any DB work.
+        for name in IDENTITY_COMPONENTS:
+            try:
+                to_jsonable(getattr(self, name))
+            except (TypeError, ValueError) as exc:
+                raise ValueError(
+                    f"identity component {name!r} is not canonical/JSON-safe: {exc}"
+                ) from exc
         return self
 
     def components(self) -> dict[str, Any]:

--- a/app/services/research_canonical_hash.py
+++ b/app/services/research_canonical_hash.py
@@ -1,0 +1,113 @@
+"""ROB-846 — canonical SHA-256 identity helpers for the strategy experiment registry.
+
+Deterministic, order-independent hashing so a strategy version's identity
+(strategy/code/params/dataset/PIT/frozen-config/policy/benchmark/cost/MDD) can
+be pinned once and reproduced exactly.
+
+Intentionally stdlib-only. This module must never import broker/order/fill
+surfaces (see ``tests/services/research/test_no_broker_import_guard.py``).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import date, datetime
+from decimal import Decimal
+from typing import Any
+
+__all__ = [
+    "IDENTITY_COMPONENTS",
+    "canonical_json",
+    "canonical_sha256",
+    "compute_identity_hashes",
+    "derive_experiment_id",
+]
+
+# Ordered identity components. Each maps to a ``<name>_hash`` column on
+# ``research.strategy_experiments``. The order is stable and part of the
+# public contract — appending is safe; reordering/removing is not.
+IDENTITY_COMPONENTS: tuple[str, ...] = (
+    "strategy",
+    "code",
+    "params",
+    "dataset_manifest",
+    "universe",
+    "pit",
+    "frozen_config",
+    "policy",
+    "benchmark",
+    "cost",
+    "mdd",
+)
+
+
+def _default(value: Any) -> Any:
+    """Deterministic fallback for non-JSON-native identity payloads.
+
+    Decimals serialize as their canonical string form (never a lossy float),
+    and datetimes/dates as ISO-8601. This keeps the hash stable across
+    processes and Python builds.
+    """
+    if isinstance(value, Decimal):
+        return f"__decimal__:{value!s}"
+    if isinstance(value, datetime | date):
+        return f"__datetime__:{value.isoformat()}"
+    if isinstance(value, frozenset | set):
+        return sorted(
+            _default(v) if isinstance(v, Decimal | datetime | date) else v
+            for v in value
+        )
+    raise TypeError(f"Unhashable identity value of type {type(value).__name__!r}")
+
+
+def canonical_json(payload: Any) -> str:
+    """Canonical JSON text: sorted keys, compact separators, UTF-8 safe."""
+    return json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        default=_default,
+    )
+
+
+def canonical_sha256(payload: Any) -> str:
+    """Lowercase 64-hex SHA-256 of the canonical JSON of ``payload``."""
+    return hashlib.sha256(canonical_json(payload).encode("utf-8")).hexdigest()
+
+
+def compute_identity_hashes(components: dict[str, Any]) -> dict[str, str]:
+    """Return ``{"<component>_hash": sha256}`` for every identity component.
+
+    A missing component is hashed as ``null`` so the mapping is always complete
+    and deterministic; callers that require full identity enforce presence at
+    the schema layer.
+    """
+    return {
+        f"{name}_hash": canonical_sha256(components.get(name))
+        for name in IDENTITY_COMPONENTS
+    }
+
+
+def derive_experiment_id(
+    strategy_key: str,
+    strategy_version: str,
+    component_hashes: dict[str, str],
+) -> str:
+    """Derive the immutable canonical experiment identity.
+
+    The identity is a function of the strategy key/version plus every component
+    hash. Any change to code, params, dataset, config, policy, cost, benchmark
+    or MDD definition yields a new experiment_id (a new lineage version),
+    leaving prior rows' hashes untouched.
+    """
+    identity = {
+        "strategy_key": strategy_key,
+        "strategy_version": strategy_version,
+        "component_hashes": {
+            f"{name}_hash": component_hashes[f"{name}_hash"]
+            for name in IDENTITY_COMPONENTS
+        },
+    }
+    return canonical_sha256(identity)

--- a/app/services/research_canonical_hash.py
+++ b/app/services/research_canonical_hash.py
@@ -93,7 +93,13 @@ def encode_canonical(value: Any) -> list[Any]:
     if isinstance(value, float):
         if not math.isfinite(value):
             raise ValueError(f"non-finite float is not JSON/JSONB safe: {value!r}")
-        return ["float", value]
+        # Store the float as its exact hex string, NOT a JSON number: Postgres
+        # JSONB normalises numeric literals (``-0.0`` → ``0.0``, ``1e20`` → a big
+        # integer, max-finite → a 300-digit integer), which would change the
+        # canonical hash across a store/read round-trip and cause false
+        # ``CanonicalIdentityCollision`` on replay. ``float.hex()`` is exact,
+        # sign-preserving, and JSONB-stable (it is a plain string).
+        return ["float", value.hex()]
     if isinstance(value, Decimal):
         if not value.is_finite():
             raise ValueError(f"non-finite Decimal is not JSON/JSONB safe: {value!r}")

--- a/app/services/research_canonical_hash.py
+++ b/app/services/research_canonical_hash.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import math
 from datetime import date, datetime
 from decimal import Decimal
 from typing import Any
@@ -48,28 +49,66 @@ def to_jsonable(value: Any) -> Any:
 
     This is the single canonical representation used for BOTH hashing and DB
     (JSONB) persistence, so a value that was hashed can be stored, read back,
-    and re-hashed to the identical digest. Non-JSON-native types are mapped to
-    deterministic, lossless string forms:
+    and re-hashed to the identical digest. The result contains only
+    ``dict``/``list``/``str``/``int``/``float``/``bool``/``None`` and therefore
+    always serialises to Postgres JSONB.
 
-    * ``Decimal`` → ``"__decimal__:<canonical str>"`` (never a lossy float)
-    * ``datetime``/``date`` → ``"__datetime__:<ISO-8601>"``
-    * ``set``/``frozenset`` → sorted list of json-safe members
+    Type mapping and fail-closed rules:
 
-    The result contains only ``dict``/``list``/``str``/``int``/``float``/
-    ``bool``/``None`` and therefore serialises cleanly to JSONB.
+    * ``Decimal`` → ``"__decimal__:<canonical str>"`` (never a lossy float);
+      non-finite Decimals (NaN/Inf) are rejected.
+    * ``float`` → passed through, but NaN/±Inf are rejected (JSONB has no
+      representation for them).
+    * ``datetime``/``date`` → ``"__datetime__:<ISO-8601>"``.
+    * ``dict`` → keys MUST be ``str``. A non-string key (e.g. ``1`` vs ``"1"``)
+      is rejected rather than coerced with ``str(key)``, which would collapse
+      distinct identities onto the same manifest/hash.
+    * ``set``/``frozenset`` → list ordered by each member's canonical JSON (not
+      the members' Python natural order, which is undefined across types).
+      Members that collide to the same canonical form are rejected as
+      ambiguous.
+
+    Raises ``ValueError``/``TypeError`` for any value that cannot be represented
+    as a collision-free, JSON-safe canonical form.
     """
-    if value is None or isinstance(value, str | bool | int | float):
+    if value is None or isinstance(value, str | bool):
+        return value
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise ValueError(f"non-finite float is not JSON/JSONB safe: {value!r}")
         return value
     if isinstance(value, Decimal):
+        if not value.is_finite():
+            raise ValueError(f"non-finite Decimal is not JSON/JSONB safe: {value!r}")
         return f"__decimal__:{value!s}"
     if isinstance(value, datetime | date):
         return f"__datetime__:{value.isoformat()}"
     if isinstance(value, dict):
-        return {str(key): to_jsonable(item) for key, item in value.items()}
+        result: dict[str, Any] = {}
+        for key, item in value.items():
+            if not isinstance(key, str):
+                raise TypeError(
+                    "identity dict keys must be str to stay collision-free; got "
+                    f"{type(key).__name__} key {key!r}"
+                )
+            result[key] = to_jsonable(item)
+        return result
     if isinstance(value, list | tuple):
         return [to_jsonable(item) for item in value]
     if isinstance(value, frozenset | set):
-        return sorted(to_jsonable(item) for item in value)
+        keyed = sorted(
+            ((canonical_json(to_jsonable(item)), to_jsonable(item)) for item in value),
+            key=lambda pair: pair[0],
+        )
+        for earlier, later in zip(keyed, keyed[1:], strict=False):
+            if earlier[0] == later[0]:
+                raise ValueError(
+                    "ambiguous set: members collide to the same canonical form "
+                    f"{later[0]!r}"
+                )
+        return [member for _, member in keyed]
     raise TypeError(f"Unhashable identity value of type {type(value).__name__!r}")
 
 
@@ -78,12 +117,16 @@ def canonical_json(payload: Any) -> str:
 
     Operates on the json-safe form (:func:`to_jsonable`) so the exact bytes
     that are hashed equal the bytes derived from the persisted JSONB manifest.
+    ``allow_nan=False`` is the last line of defence — ``to_jsonable`` already
+    rejects non-finite numbers, but this guarantees no ``NaN``/``Infinity``
+    token can ever reach the wire even via an unforeseen path.
     """
     return json.dumps(
         to_jsonable(payload),
         sort_keys=True,
         separators=(",", ":"),
         ensure_ascii=False,
+        allow_nan=False,
     )
 
 

--- a/app/services/research_canonical_hash.py
+++ b/app/services/research_canonical_hash.py
@@ -1,8 +1,24 @@
-"""ROB-846 — canonical SHA-256 identity helpers for the strategy experiment registry.
+"""ROB-846 — canonical identity helpers for the strategy experiment registry.
 
-Deterministic, order-independent hashing so a strategy version's identity
-(strategy/code/params/dataset/PIT/frozen-config/policy/benchmark/cost/MDD) can
-be pinned once and reproduced exactly.
+The identity of a strategy version must have ONE canonical, collision-free,
+JSON-safe representation used for both hashing and JSONB persistence, so a
+version can be reproduced exactly and two genuinely different identities can
+never share an ``experiment_id``.
+
+Design: every value — leaf AND container, including plain strings — is encoded
+into a **closed, typed canonical AST** made only of JSON-native types. Each node
+is a 2-element ``[tag, payload]`` list, e.g. ``["decimal", "1.0"]``,
+``["str", "x"]``, ``["list", [...]]``, ``["tuple", [...]]``, ``["set", [...]]``,
+``["dict", [[key, node], ...]]``. Because raw ``list``/``dict`` inputs are
+themselves wrapped in a typed node and their members are recursively encoded, a
+user cannot forge a tag: a raw string ``"__decimal__:1.0"`` encodes to
+``["str", "__decimal__:1.0"]`` which can never equal ``["decimal", "1.0"]``, and
+a ``list`` (``["list", ...]``) can never equal a ``tuple``/``set``.
+
+Two entry points are kept deliberately separate (ROB-846 review): one encodes a
+RAW Python value into an AST, the other hashes an ALREADY-encoded AST. A
+persisted JSONB manifest is hashed directly and never re-encoded, so a
+round-trip reproduces identical digests.
 
 Intentionally stdlib-only. This module must never import broker/order/fill
 surfaces (see ``tests/services/research/test_no_broker_import_guard.py``).
@@ -19,11 +35,15 @@ from typing import Any
 
 __all__ = [
     "IDENTITY_COMPONENTS",
+    "canonical_ast_json",
     "canonical_json",
     "canonical_sha256",
     "compute_identity_hashes",
+    "compute_identity_hashes_from_ast",
     "derive_experiment_id",
-    "to_jsonable",
+    "encode_canonical",
+    "encode_manifest",
+    "hash_canonical_ast",
 ]
 
 # Ordered identity components. Each maps to a ``<name>_hash`` column on
@@ -43,86 +63,87 @@ IDENTITY_COMPONENTS: tuple[str, ...] = (
     "mdd",
 )
 
+# The null AST node — the canonical encoding of ``None`` (also the default used
+# when a persisted manifest is missing a component).
+_NULL_NODE: list[Any] = ["null", None]
 
-def to_jsonable(value: Any) -> Any:
-    """Recursively convert an identity payload into a JSON-safe structure.
 
-    This is the single canonical representation used for BOTH hashing and DB
-    (JSONB) persistence, so a value that was hashed can be stored, read back,
-    and re-hashed to the identical digest. The result contains only
-    ``dict``/``list``/``str``/``int``/``float``/``bool``/``None`` and therefore
-    always serialises to Postgres JSONB.
+def encode_canonical(value: Any) -> list[Any]:
+    """Encode a raw identity value into a closed, forgery-proof typed AST.
 
-    Type mapping and fail-closed rules:
+    Returns a JSON-native ``[tag, payload]`` node. Fail-closed rules:
 
-    * ``Decimal`` → ``"__decimal__:<canonical str>"`` (never a lossy float);
-      non-finite Decimals (NaN/Inf) are rejected.
-    * ``float`` → passed through, but NaN/±Inf are rejected (JSONB has no
-      representation for them).
-    * ``datetime``/``date`` → ``"__datetime__:<ISO-8601>"``.
-    * ``dict`` → keys MUST be ``str``. A non-string key (e.g. ``1`` vs ``"1"``)
-      is rejected rather than coerced with ``str(key)``, which would collapse
-      distinct identities onto the same manifest/hash.
-    * ``set``/``frozenset`` → list ordered by each member's canonical JSON (not
-      the members' Python natural order, which is undefined across types).
-      Members that collide to the same canonical form are rejected as
-      ambiguous.
-
-    Raises ``ValueError``/``TypeError`` for any value that cannot be represented
-    as a collision-free, JSON-safe canonical form.
+    * ``float`` NaN/±Inf and non-finite ``Decimal`` are rejected — JSONB cannot
+      represent them.
+    * ``dict`` keys must be ``str`` (a non-string key would otherwise need a
+      lossy ``str()`` coercion that collapses distinct identities).
+    * ``set``/``frozenset`` members are ordered by their canonical AST bytes
+      (never Python natural order, which is undefined across types); members
+      that encode to the same node are rejected as ambiguous.
+    * Any unsupported type raises ``TypeError`` (rejected at the schema boundary,
+      before any DB work).
     """
-    if value is None or isinstance(value, str | bool):
-        return value
+    if value is None:
+        return ["null", None]
+    # bool is a subclass of int — handle it first.
+    if isinstance(value, bool):
+        return ["bool", value]
     if isinstance(value, int):
-        return value
+        return ["int", value]
     if isinstance(value, float):
         if not math.isfinite(value):
             raise ValueError(f"non-finite float is not JSON/JSONB safe: {value!r}")
-        return value
+        return ["float", value]
     if isinstance(value, Decimal):
         if not value.is_finite():
             raise ValueError(f"non-finite Decimal is not JSON/JSONB safe: {value!r}")
-        return f"__decimal__:{value!s}"
-    if isinstance(value, datetime | date):
-        return f"__datetime__:{value.isoformat()}"
+        return ["decimal", str(value)]
+    # datetime is a subclass of date — handle it first.
+    if isinstance(value, datetime):
+        return ["datetime", value.isoformat()]
+    if isinstance(value, date):
+        return ["date", value.isoformat()]
+    if isinstance(value, str):
+        return ["str", value]
     if isinstance(value, dict):
-        result: dict[str, Any] = {}
+        entries: list[list[Any]] = []
         for key, item in value.items():
             if not isinstance(key, str):
                 raise TypeError(
                     "identity dict keys must be str to stay collision-free; got "
                     f"{type(key).__name__} key {key!r}"
                 )
-            result[key] = to_jsonable(item)
-        return result
-    if isinstance(value, list | tuple):
-        return [to_jsonable(item) for item in value]
+            entries.append([key, encode_canonical(item)])
+        entries.sort(key=lambda pair: pair[0])
+        return ["dict", entries]
+    if isinstance(value, tuple):
+        return ["tuple", [encode_canonical(item) for item in value]]
+    if isinstance(value, list):
+        return ["list", [encode_canonical(item) for item in value]]
     if isinstance(value, frozenset | set):
-        keyed = sorted(
-            ((canonical_json(to_jsonable(item)), to_jsonable(item)) for item in value),
-            key=lambda pair: pair[0],
+        members = sorted(
+            (encode_canonical(item) for item in value), key=canonical_ast_json
         )
-        for earlier, later in zip(keyed, keyed[1:], strict=False):
-            if earlier[0] == later[0]:
+        for earlier, later in zip(members, members[1:], strict=False):
+            if canonical_ast_json(earlier) == canonical_ast_json(later):
                 raise ValueError(
-                    "ambiguous set: members collide to the same canonical form "
-                    f"{later[0]!r}"
+                    "ambiguous set: members encode to the same canonical node "
+                    f"{canonical_ast_json(later)!r}"
                 )
-        return [member for _, member in keyed]
-    raise TypeError(f"Unhashable identity value of type {type(value).__name__!r}")
+        return ["set", members]
+    raise TypeError(f"unsupported identity value of type {type(value).__name__!r}")
 
 
-def canonical_json(payload: Any) -> str:
-    """Canonical JSON text: sorted keys, compact separators, UTF-8 safe.
+def canonical_ast_json(ast: Any) -> str:
+    """Deterministic JSON text of an ALREADY-encoded canonical AST.
 
-    Operates on the json-safe form (:func:`to_jsonable`) so the exact bytes
-    that are hashed equal the bytes derived from the persisted JSONB manifest.
-    ``allow_nan=False`` is the last line of defence — ``to_jsonable`` already
-    rejects non-finite numbers, but this guarantees no ``NaN``/``Infinity``
-    token can ever reach the wire even via an unforeseen path.
+    The AST contains only JSON-native types produced by :func:`encode_canonical`.
+    A top-level manifest mapping (component name → AST) may also be passed, so
+    ``sort_keys=True`` normalises those keys; ``allow_nan=False`` is a final
+    guard against any stray non-finite number reaching the wire.
     """
     return json.dumps(
-        to_jsonable(payload),
+        ast,
         sort_keys=True,
         separators=(",", ":"),
         ensure_ascii=False,
@@ -130,20 +151,45 @@ def canonical_json(payload: Any) -> str:
     )
 
 
+def hash_canonical_ast(ast: Any) -> str:
+    """Lowercase 64-hex SHA-256 of an already-encoded canonical AST."""
+    return hashlib.sha256(canonical_ast_json(ast).encode("utf-8")).hexdigest()
+
+
+def canonical_json(payload: Any) -> str:
+    """Canonical JSON text of a RAW value (encode then serialise)."""
+    return canonical_ast_json(encode_canonical(payload))
+
+
 def canonical_sha256(payload: Any) -> str:
-    """Lowercase 64-hex SHA-256 of the canonical JSON of ``payload``."""
-    return hashlib.sha256(canonical_json(payload).encode("utf-8")).hexdigest()
+    """Lowercase 64-hex SHA-256 of a RAW value's canonical AST."""
+    return hash_canonical_ast(encode_canonical(payload))
+
+
+def encode_manifest(components: dict[str, Any]) -> dict[str, Any]:
+    """Encode identity components into their persisted AST (name → AST node)."""
+    return {
+        name: encode_canonical(components.get(name)) for name in IDENTITY_COMPONENTS
+    }
 
 
 def compute_identity_hashes(components: dict[str, Any]) -> dict[str, str]:
-    """Return ``{"<component>_hash": sha256}`` for every identity component.
-
-    A missing component is hashed as ``null`` so the mapping is always complete
-    and deterministic; callers that require full identity enforce presence at
-    the schema layer.
-    """
+    """Per-component SHA-256 from RAW components (encode then hash)."""
     return {
         f"{name}_hash": canonical_sha256(components.get(name))
+        for name in IDENTITY_COMPONENTS
+    }
+
+
+def compute_identity_hashes_from_ast(manifest: dict[str, Any]) -> dict[str, str]:
+    """Per-component SHA-256 from a PERSISTED AST manifest (hash directly).
+
+    The manifest maps component name → already-encoded AST node. It is hashed
+    without re-encoding, so a JSONB round-trip reproduces identical digests —
+    this is the separate hashing entry point required by ROB-846 review.
+    """
+    return {
+        f"{name}_hash": hash_canonical_ast(manifest.get(name, _NULL_NODE))
         for name in IDENTITY_COMPONENTS
     }
 

--- a/app/services/research_canonical_hash.py
+++ b/app/services/research_canonical_hash.py
@@ -22,6 +22,7 @@ __all__ = [
     "canonical_sha256",
     "compute_identity_hashes",
     "derive_experiment_id",
+    "to_jsonable",
 ]
 
 # Ordered identity components. Each maps to a ``<name>_hash`` column on
@@ -42,33 +43,47 @@ IDENTITY_COMPONENTS: tuple[str, ...] = (
 )
 
 
-def _default(value: Any) -> Any:
-    """Deterministic fallback for non-JSON-native identity payloads.
+def to_jsonable(value: Any) -> Any:
+    """Recursively convert an identity payload into a JSON-safe structure.
 
-    Decimals serialize as their canonical string form (never a lossy float),
-    and datetimes/dates as ISO-8601. This keeps the hash stable across
-    processes and Python builds.
+    This is the single canonical representation used for BOTH hashing and DB
+    (JSONB) persistence, so a value that was hashed can be stored, read back,
+    and re-hashed to the identical digest. Non-JSON-native types are mapped to
+    deterministic, lossless string forms:
+
+    * ``Decimal`` → ``"__decimal__:<canonical str>"`` (never a lossy float)
+    * ``datetime``/``date`` → ``"__datetime__:<ISO-8601>"``
+    * ``set``/``frozenset`` → sorted list of json-safe members
+
+    The result contains only ``dict``/``list``/``str``/``int``/``float``/
+    ``bool``/``None`` and therefore serialises cleanly to JSONB.
     """
+    if value is None or isinstance(value, str | bool | int | float):
+        return value
     if isinstance(value, Decimal):
         return f"__decimal__:{value!s}"
     if isinstance(value, datetime | date):
         return f"__datetime__:{value.isoformat()}"
+    if isinstance(value, dict):
+        return {str(key): to_jsonable(item) for key, item in value.items()}
+    if isinstance(value, list | tuple):
+        return [to_jsonable(item) for item in value]
     if isinstance(value, frozenset | set):
-        return sorted(
-            _default(v) if isinstance(v, Decimal | datetime | date) else v
-            for v in value
-        )
+        return sorted(to_jsonable(item) for item in value)
     raise TypeError(f"Unhashable identity value of type {type(value).__name__!r}")
 
 
 def canonical_json(payload: Any) -> str:
-    """Canonical JSON text: sorted keys, compact separators, UTF-8 safe."""
+    """Canonical JSON text: sorted keys, compact separators, UTF-8 safe.
+
+    Operates on the json-safe form (:func:`to_jsonable`) so the exact bytes
+    that are hashed equal the bytes derived from the persisted JSONB manifest.
+    """
     return json.dumps(
-        payload,
+        to_jsonable(payload),
         sort_keys=True,
         separators=(",", ":"),
         ensure_ascii=False,
-        default=_default,
     )
 
 

--- a/app/services/research_ingestion_service.py
+++ b/app/services/research_ingestion_service.py
@@ -10,7 +10,6 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.models.research_backtest import (
     ResearchBacktestPair,
     ResearchBacktestRun,
-    ResearchPromotionCandidate,
     ResearchSyncJob,
 )
 from app.schemas.research_backtest import BacktestRunSummary
@@ -134,28 +133,29 @@ async def replace_backtest_pairs(
     await session.flush()
 
 
-async def upsert_promotion_candidate(
-    session: AsyncSession,
-    *,
-    backtest_run: ResearchBacktestRun,
-    gate_result: GateResult,
-) -> ResearchPromotionCandidate:
-    existing = await session.execute(
-        select(ResearchPromotionCandidate).where(
-            ResearchPromotionCandidate.backtest_run_id == backtest_run.id
-        )
-    )
-    row = existing.scalar_one_or_none()
-    if row is None:
-        row = ResearchPromotionCandidate(backtest_run_id=backtest_run.id)
-        session.add(row)
+def _non_promotion_outcome(gate_result: GateResult) -> dict[str, Any]:
+    """Structured, fail-closed non-promotion result for identity-less ingest.
 
-    row.status = gate_result.status
-    row.reason_code = gate_result.reason_code
-    row.thresholds = gate_result.thresholds
-    row.metrics = gate_result.metrics
-    await session.flush()
-    return row
+    ROB-846: a ``promotion_candidates`` row must reference an exact
+    experiment/config/data identity (see
+    ``strategy_experiment_registry.link_promotion_candidate``). The legacy
+    Freqtrade summary ingest has no experiment identity, so it must NOT write a
+    promotion candidate — doing so previously produced null-identity rows that
+    bypassed AC#5. Instead the deterministic gate evaluation is preserved here,
+    on the sync job, explicitly marked as not promoted.
+    """
+    return {
+        "promotion": {
+            "status": "not_promoted",
+            "reason": "no_experiment_identity",
+            "gate": {
+                "status": gate_result.status,
+                "reason_code": gate_result.reason_code,
+                "thresholds": gate_result.thresholds,
+                "metrics": gate_result.metrics,
+            },
+        }
+    }
 
 
 async def ingest_summary_payload(
@@ -198,16 +198,14 @@ async def ingest_summary_payload(
             else None,
             config=effective_gate_config,
         )
-        await upsert_promotion_candidate(
-            session,
-            backtest_run=run_row,
-            gate_result=gate_result,
-        )
+        # ROB-846: identity-less ingest never writes a promotion candidate; the
+        # gate evaluation is preserved as a structured non-promotion result.
         await update_sync_job_status(
             session,
             sync_job,
             status="completed",
             backtest_run_id=run_row.id,
+            error_payload=_non_promotion_outcome(gate_result),
         )
         await session.commit()
         return parsed.run_id

--- a/app/services/strategy_experiment_registry.py
+++ b/app/services/strategy_experiment_registry.py
@@ -35,6 +35,7 @@ from app.schemas.research_backtest import (
 from app.services.research_canonical_hash import (
     compute_identity_hashes,
     derive_experiment_id,
+    to_jsonable,
 )
 
 # Bounded retry for the monotonic trial_index allocation race. Two concurrent
@@ -104,28 +105,34 @@ async def register_experiment(
                 "is not registered"
             )
 
+    # Persist the manifest/definitions in the SAME json-safe representation that
+    # was hashed, so a DB read-back re-hashes to the identical identity.
     row = ResearchStrategyExperiment(
         experiment_id=experiment_id,
         strategy_key=identity.strategy_key,
         strategy_version=identity.strategy_version,
         hypothesis=identity.hypothesis,
         supersedes_experiment_id=identity.supersedes_experiment_id,
-        benchmark_definition=_as_json(identity.benchmark),
-        cost_definition=_as_json(identity.cost),
-        mdd_definition=_as_json(identity.mdd),
-        manifest=identity.components(),
+        benchmark_definition=to_jsonable(identity.benchmark),
+        cost_definition=to_jsonable(identity.cost),
+        mdd_definition=to_jsonable(identity.mdd),
+        manifest=to_jsonable(identity.components()),
         **component_hashes,
     )
-    session.add(row)
-    await session.flush()
+    try:
+        async with session.begin_nested():
+            session.add(row)
+            await session.flush()
+    except IntegrityError as exc:
+        # Concurrent registration of the SAME identity won the race and
+        # committed. Idempotent contract: return that original row unchanged.
+        if "experiment_id" not in _constraint_name(exc):
+            raise
+        winner = await _get_experiment(session, experiment_id)
+        if winner is None:  # pragma: no cover - conflict without a visible row
+            raise
+        return winner
     return row
-
-
-def _as_json(value: object) -> object | None:
-    """Only persist dict/list definitions in the JSONB definition columns."""
-    if isinstance(value, dict | list):
-        return value
-    return None
 
 
 def _build_trial_row(

--- a/app/services/strategy_experiment_registry.py
+++ b/app/services/strategy_experiment_registry.py
@@ -1,0 +1,354 @@
+"""ROB-846 — immutable strategy experiment registry + complete trial accounting.
+
+This service is the *only* write path for the immutable registry. It is
+deliberately append-only: it exposes registration + trial recording + read
+helpers and NO update/delete methods. Corrections are a new lineage version
+(``supersedes_experiment_id``), never an in-place edit. DB triggers enforce the
+same immutability at the row level.
+
+Boundary (ROB-846 AC#6): this module must never import or write a broker/order/
+fill ledger. It touches only the ``research`` schema. The AST guard in
+``tests/services/research/test_no_broker_import_guard.py`` enforces this.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from uuid import uuid4
+
+from sqlalchemy import func, select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.research_backtest import (
+    TRIAL_STATUSES,
+    ResearchBacktestRun,
+    ResearchPromotionCandidate,
+    ResearchStrategyExperiment,
+)
+from app.schemas.research_backtest import (
+    BacktestTrialRequest,
+    PromotionLinkRequest,
+    StrategyExperimentIdentity,
+    TrialAccounting,
+)
+from app.services.research_canonical_hash import (
+    compute_identity_hashes,
+    derive_experiment_id,
+)
+
+# Bounded retry for the monotonic trial_index allocation race. Two concurrent
+# trials with *different* idempotency keys can compute the same next index; the
+# UNIQUE(experiment, trial_index) constraint rejects the loser, which retries.
+_MAX_INDEX_ALLOCATION_ATTEMPTS = 8
+
+
+class StrategyExperimentRegistryError(Exception):
+    """Base error for the immutable experiment registry."""
+
+
+class ExperimentNotFound(StrategyExperimentRegistryError):
+    """A trial/promotion referenced an experiment_id that is not registered."""
+
+
+class SupersedesNotFound(StrategyExperimentRegistryError):
+    """A registration supersedes an experiment_id that does not exist."""
+
+
+class InvalidTrialStatus(StrategyExperimentRegistryError):
+    """A trial was recorded with a status outside the terminal outcome set."""
+
+
+class PromotionHashMismatch(StrategyExperimentRegistryError):
+    """A promotion candidate referenced missing/mismatched experiment hashes."""
+
+
+async def _get_experiment(
+    session: AsyncSession, experiment_id: str
+) -> ResearchStrategyExperiment | None:
+    return await session.scalar(
+        select(ResearchStrategyExperiment).where(
+            ResearchStrategyExperiment.experiment_id == experiment_id
+        )
+    )
+
+
+async def register_experiment(
+    session: AsyncSession,
+    identity: StrategyExperimentIdentity,
+) -> ResearchStrategyExperiment:
+    """Register (or return the existing) immutable strategy experiment.
+
+    Idempotent by canonical identity: registering the same identity twice
+    returns the original row without mutating it. A different identity (any
+    component changed) is a new experiment_id — corrections link back via
+    ``supersedes_experiment_id``.
+    """
+    component_hashes = compute_identity_hashes(identity.components())
+    experiment_id = derive_experiment_id(
+        identity.strategy_key,
+        identity.strategy_version,
+        component_hashes,
+    )
+
+    existing = await _get_experiment(session, experiment_id)
+    if existing is not None:
+        # Immutable: never rewrite. Same identity → same row.
+        return existing
+
+    if identity.supersedes_experiment_id is not None:
+        parent = await _get_experiment(session, identity.supersedes_experiment_id)
+        if parent is None:
+            raise SupersedesNotFound(
+                f"supersedes_experiment_id {identity.supersedes_experiment_id!r} "
+                "is not registered"
+            )
+
+    row = ResearchStrategyExperiment(
+        experiment_id=experiment_id,
+        strategy_key=identity.strategy_key,
+        strategy_version=identity.strategy_version,
+        hypothesis=identity.hypothesis,
+        supersedes_experiment_id=identity.supersedes_experiment_id,
+        benchmark_definition=_as_json(identity.benchmark),
+        cost_definition=_as_json(identity.cost),
+        mdd_definition=_as_json(identity.mdd),
+        manifest=identity.components(),
+        **component_hashes,
+    )
+    session.add(row)
+    await session.flush()
+    return row
+
+
+def _as_json(value: object) -> object | None:
+    """Only persist dict/list definitions in the JSONB definition columns."""
+    if isinstance(value, dict | list):
+        return value
+    return None
+
+
+def _build_trial_row(
+    *,
+    experiment_pk: int,
+    experiment_id: str,
+    trial_index: int,
+    request: BacktestTrialRequest,
+) -> ResearchBacktestRun:
+    # A derived run_id carries a uuid suffix so two concurrent trials that
+    # momentarily compute the same trial_index never collide on the run_id
+    # unique index — the (experiment, trial_index) index is the real arbiter.
+    run_id = (
+        request.run_id or f"exp-{experiment_id[:12]}-t{trial_index}-{uuid4().hex[:8]}"
+    )
+    return ResearchBacktestRun(
+        run_id=run_id,
+        strategy_name=request.strategy_name,
+        strategy_version=None,
+        exchange=request.exchange,
+        market=request.market,
+        timeframe=request.timeframe,
+        timerange=request.timerange,
+        runner=request.runner,
+        started_at=request.started_at,
+        ended_at=request.ended_at,
+        total_trades=request.total_trades,
+        profit_factor=request.profit_factor or Decimal("0"),
+        max_drawdown=request.max_drawdown or Decimal("0"),
+        win_rate=request.win_rate,
+        expectancy=request.expectancy,
+        total_return=request.total_return,
+        artifact_path=request.artifact_path,
+        artifact_hash=request.artifact_hash,
+        raw_payload=request.raw_payload,
+        strategy_experiment_id=experiment_pk,
+        trial_index=trial_index,
+        seed=request.seed,
+        information_cutoff=request.information_cutoff,
+        trial_status=request.status,
+        gate_artifact_hash=request.gate_artifact_hash,
+        trial_idempotency_key=request.idempotency_key,
+    )
+
+
+async def _find_trial_by_idempotency(
+    session: AsyncSession, experiment_pk: int, idempotency_key: str
+) -> ResearchBacktestRun | None:
+    return await session.scalar(
+        select(ResearchBacktestRun).where(
+            ResearchBacktestRun.strategy_experiment_id == experiment_pk,
+            ResearchBacktestRun.trial_idempotency_key == idempotency_key,
+        )
+    )
+
+
+async def record_trial(
+    session: AsyncSession,
+    *,
+    experiment_id: str,
+    request: BacktestTrialRequest,
+) -> ResearchBacktestRun:
+    """Append one trial (invocation) under an experiment.
+
+    * Every terminal outcome (completed/rejected/crashed/timeout) records a
+      trial and consumes exactly one monotonic ``trial_index``.
+    * A duplicate ``idempotency_key`` returns the original row — no second
+      trial, even under a concurrent race (guaranteed by the DB unique index).
+    * Never updates an existing trial row (append-only).
+    """
+    if request.status not in TRIAL_STATUSES:
+        raise InvalidTrialStatus(f"unknown trial status {request.status!r}")
+
+    experiment = await _get_experiment(session, experiment_id)
+    if experiment is None:
+        raise ExperimentNotFound(f"experiment_id {experiment_id!r} is not registered")
+    experiment_pk = experiment.id
+
+    if request.idempotency_key is not None:
+        replay = await _find_trial_by_idempotency(
+            session, experiment_pk, request.idempotency_key
+        )
+        if replay is not None:
+            return replay
+
+    for _ in range(_MAX_INDEX_ALLOCATION_ATTEMPTS):
+        next_index = await session.scalar(
+            select(
+                func.coalesce(func.max(ResearchBacktestRun.trial_index), 0) + 1
+            ).where(ResearchBacktestRun.strategy_experiment_id == experiment_pk)
+        )
+        row = _build_trial_row(
+            experiment_pk=experiment_pk,
+            experiment_id=experiment_id,
+            trial_index=int(next_index),
+            request=request,
+        )
+        try:
+            async with session.begin_nested():
+                session.add(row)
+                await session.flush()
+            return row
+        except IntegrityError as exc:
+            constraint = _constraint_name(exc)
+            if request.idempotency_key is not None:
+                # A concurrent insert with the same idempotency key may have won
+                # the race and committed; if so, return that original row.
+                replay = await _find_trial_by_idempotency(
+                    session, experiment_pk, request.idempotency_key
+                )
+                if replay is not None:
+                    return replay
+            if "trial_index" in constraint:
+                # Another trial grabbed this index first — recompute and retry.
+                continue
+            raise
+
+    raise StrategyExperimentRegistryError(
+        "could not allocate a monotonic trial_index after "
+        f"{_MAX_INDEX_ALLOCATION_ATTEMPTS} attempts"
+    )
+
+
+def _constraint_name(exc: IntegrityError) -> str:
+    orig = getattr(exc, "orig", None)
+    name = getattr(orig, "constraint_name", None)
+    if name:
+        return name
+    # asyncpg may nest the driver error; fall back to the string form.
+    return str(orig or exc)
+
+
+async def list_trials(
+    session: AsyncSession, experiment_id: str
+) -> list[ResearchBacktestRun]:
+    """All trials for an experiment in index order — no winner-only filter."""
+    experiment = await _get_experiment(session, experiment_id)
+    if experiment is None:
+        raise ExperimentNotFound(f"experiment_id {experiment_id!r} is not registered")
+    result = await session.execute(
+        select(ResearchBacktestRun)
+        .where(ResearchBacktestRun.strategy_experiment_id == experiment.id)
+        .order_by(ResearchBacktestRun.trial_index)
+    )
+    return list(result.scalars().all())
+
+
+async def get_trial_accounting(
+    session: AsyncSession, experiment_id: str
+) -> TrialAccounting:
+    """Total trials + per-outcome counts (every status zero-filled)."""
+    experiment = await _get_experiment(session, experiment_id)
+    if experiment is None:
+        raise ExperimentNotFound(f"experiment_id {experiment_id!r} is not registered")
+
+    result = await session.execute(
+        select(ResearchBacktestRun.trial_status, func.count())
+        .where(ResearchBacktestRun.strategy_experiment_id == experiment.id)
+        .group_by(ResearchBacktestRun.trial_status)
+    )
+    outcome_counts = dict.fromkeys(TRIAL_STATUSES, 0)
+    total = 0
+    for status, count in result.all():
+        total += int(count)
+        if status is not None:
+            outcome_counts[status] = int(count)
+    return TrialAccounting(
+        experiment_id=experiment_id,
+        total_trials=total,
+        outcome_counts=outcome_counts,
+    )
+
+
+async def link_promotion_candidate(
+    session: AsyncSession,
+    *,
+    backtest_run_id: int,
+    request: PromotionLinkRequest,
+) -> ResearchPromotionCandidate:
+    """Create a promotion candidate bound to an EXACT run/config/data identity.
+
+    Fails closed (``PromotionHashMismatch``) when the run has no experiment or
+    when the experiment's experiment_id / frozen-config hash / dataset-manifest
+    hash do not match the promoter's expected hashes.
+    """
+    run = await session.get(ResearchBacktestRun, backtest_run_id)
+    if run is None:
+        raise PromotionHashMismatch(f"backtest_run {backtest_run_id} does not exist")
+    if run.strategy_experiment_id is None:
+        raise PromotionHashMismatch(
+            f"backtest_run {backtest_run_id} is not linked to an experiment"
+        )
+
+    experiment = await session.get(
+        ResearchStrategyExperiment, run.strategy_experiment_id
+    )
+    if experiment is None:  # pragma: no cover - FK guarantees this
+        raise PromotionHashMismatch(
+            f"experiment for backtest_run {backtest_run_id} is missing"
+        )
+
+    mismatches: list[str] = []
+    if experiment.experiment_id != request.expected_experiment_id:
+        mismatches.append("experiment_id")
+    if experiment.frozen_config_hash != request.expected_config_hash:
+        mismatches.append("config_hash")
+    if experiment.dataset_manifest_hash != request.expected_data_hash:
+        mismatches.append("data_hash")
+    if mismatches:
+        raise PromotionHashMismatch(
+            "promotion candidate hash mismatch on: " + ", ".join(mismatches)
+        )
+
+    candidate = ResearchPromotionCandidate(
+        backtest_run_id=run.id,
+        status=request.status,
+        reason_code=request.reason_code,
+        thresholds=request.thresholds,
+        metrics=request.metrics,
+        experiment_id=experiment.experiment_id,
+        run_config_hash=experiment.frozen_config_hash,
+        run_data_hash=experiment.dataset_manifest_hash,
+    )
+    session.add(candidate)
+    await session.flush()
+    return candidate

--- a/app/services/strategy_experiment_registry.py
+++ b/app/services/strategy_experiment_registry.py
@@ -59,6 +59,10 @@ class SupersedesNotFound(StrategyExperimentRegistryError):
     """A registration supersedes an experiment_id that does not exist."""
 
 
+class SupersedesStrategyMismatch(StrategyExperimentRegistryError):
+    """A registration tried to supersede a different strategy's experiment."""
+
+
 class InvalidTrialStatus(StrategyExperimentRegistryError):
     """A trial was recorded with a status outside the terminal outcome set."""
 
@@ -152,6 +156,11 @@ async def register_experiment(
             raise SupersedesNotFound(
                 f"supersedes_experiment_id {identity.supersedes_experiment_id!r} "
                 "is not registered"
+            )
+        if parent.strategy_key != identity.strategy_key:
+            raise SupersedesStrategyMismatch(
+                f"supersedes_experiment_id {identity.supersedes_experiment_id!r} "
+                f"belongs to a different strategy_key {parent.strategy_key!r}"
             )
 
     existing = await _get_experiment(session, experiment_id)

--- a/app/services/strategy_experiment_registry.py
+++ b/app/services/strategy_experiment_registry.py
@@ -33,9 +33,11 @@ from app.schemas.research_backtest import (
     TrialAccounting,
 )
 from app.services.research_canonical_hash import (
+    canonical_ast_json,
     compute_identity_hashes,
     derive_experiment_id,
-    to_jsonable,
+    encode_canonical,
+    encode_manifest,
 )
 
 # Bounded retry for the monotonic trial_index allocation race. Two concurrent
@@ -62,6 +64,12 @@ class InvalidTrialStatus(StrategyExperimentRegistryError):
 
 class PromotionHashMismatch(StrategyExperimentRegistryError):
     """A promotion candidate referenced missing/mismatched experiment hashes."""
+
+
+class CanonicalIdentityCollision(StrategyExperimentRegistryError):
+    """An incoming identity derived an existing experiment_id but its canonical
+    manifest differs from the stored one — an experiment_id collision. Registry
+    refuses to replay the stored immutable row under a different identity."""
 
 
 async def _get_experiment(
@@ -91,10 +99,21 @@ async def register_experiment(
         identity.strategy_version,
         component_hashes,
     )
+    incoming_manifest = encode_manifest(identity.components())
 
     existing = await _get_experiment(session, experiment_id)
     if existing is not None:
-        # Immutable: never rewrite. Same identity → same row.
+        # Idempotent replay — but only for the SAME identity. Compare the stored
+        # canonical manifest with the incoming one exactly; if they differ this
+        # experiment_id was reached by a different identity (a hash collision),
+        # so refuse to replay the immutable row under it (ROB-846 review).
+        if canonical_ast_json(existing.manifest) != canonical_ast_json(
+            incoming_manifest
+        ):
+            raise CanonicalIdentityCollision(
+                f"experiment_id {experiment_id!r} already exists with a different "
+                "canonical manifest; refusing to replay under a colliding identity"
+            )
         return existing
 
     if identity.supersedes_experiment_id is not None:
@@ -105,18 +124,19 @@ async def register_experiment(
                 "is not registered"
             )
 
-    # Persist the manifest/definitions in the SAME json-safe representation that
-    # was hashed, so a DB read-back re-hashes to the identical identity.
+    # Persist the SAME typed canonical AST that was hashed, so a JSONB read-back
+    # re-hashes (via hash_canonical_ast, without re-encoding) to the identical
+    # identity — no double-encode of the persisted form.
     row = ResearchStrategyExperiment(
         experiment_id=experiment_id,
         strategy_key=identity.strategy_key,
         strategy_version=identity.strategy_version,
         hypothesis=identity.hypothesis,
         supersedes_experiment_id=identity.supersedes_experiment_id,
-        benchmark_definition=to_jsonable(identity.benchmark),
-        cost_definition=to_jsonable(identity.cost),
-        mdd_definition=to_jsonable(identity.mdd),
-        manifest=to_jsonable(identity.components()),
+        benchmark_definition=encode_canonical(identity.benchmark),
+        cost_definition=encode_canonical(identity.cost),
+        mdd_definition=encode_canonical(identity.mdd),
+        manifest=incoming_manifest,
         **component_hashes,
     )
     try:

--- a/app/services/strategy_experiment_registry.py
+++ b/app/services/strategy_experiment_registry.py
@@ -95,8 +95,11 @@ def _assert_same_identity(
     Guards every replay of an existing immutable row (both the initial
     existing-row lookup and the concurrent unique-conflict winner re-read).
     Compares the FULL identity — strategy key/version, the canonical manifest,
-    and every persisted component hash — so a row reached under a colliding
-    ``experiment_id`` (different key/version/params/manifest) is never replayed.
+    every persisted component hash, AND the immutable provenance metadata
+    (``hypothesis`` and ``supersedes_experiment_id``). The metadata does not feed
+    the experiment_id hash, but it is immutable lineage truth (AC#3) that DB
+    triggers forbid amending, so a replay under a different hypothesis or lineage
+    must fail closed rather than silently return the original row.
     """
     mismatches: list[str] = []
     if stored.strategy_key != identity.strategy_key:
@@ -109,6 +112,10 @@ def _assert_same_identity(
             mismatches.append(column)
     if canonical_ast_json(stored.manifest) != canonical_ast_json(incoming_manifest):
         mismatches.append("manifest")
+    if stored.hypothesis != identity.hypothesis:
+        mismatches.append("hypothesis")
+    if stored.supersedes_experiment_id != identity.supersedes_experiment_id:
+        mismatches.append("supersedes_experiment_id")
     if mismatches:
         raise CanonicalIdentityCollision(
             f"experiment_id {stored.experiment_id!r} already exists with a different "
@@ -136,17 +143,9 @@ async def register_experiment(
     )
     incoming_manifest = encode_manifest(identity.components())
 
-    existing = await _get_experiment(session, experiment_id)
-    if existing is not None:
-        # Idempotent replay — but only for the SAME complete identity.
-        _assert_same_identity(
-            existing,
-            identity=identity,
-            component_hashes=component_hashes,
-            incoming_manifest=incoming_manifest,
-        )
-        return existing
-
+    # Validate the supersedes parent BEFORE the existing fast path: an unknown
+    # lineage parent must always fail closed (SupersedesNotFound), even when the
+    # canonical components already resolved to an existing experiment_id.
     if identity.supersedes_experiment_id is not None:
         parent = await _get_experiment(session, identity.supersedes_experiment_id)
         if parent is None:
@@ -154,6 +153,17 @@ async def register_experiment(
                 f"supersedes_experiment_id {identity.supersedes_experiment_id!r} "
                 "is not registered"
             )
+
+    existing = await _get_experiment(session, experiment_id)
+    if existing is not None:
+        # Idempotent replay — but only for the SAME complete identity + metadata.
+        _assert_same_identity(
+            existing,
+            identity=identity,
+            component_hashes=component_hashes,
+            incoming_manifest=incoming_manifest,
+        )
+        return existing
 
     # Persist the SAME typed canonical AST that was hashed, so a JSONB read-back
     # re-hashes (via hash_canonical_ast, without re-encoding) to the identical

--- a/app/services/strategy_experiment_registry.py
+++ b/app/services/strategy_experiment_registry.py
@@ -33,6 +33,7 @@ from app.schemas.research_backtest import (
     TrialAccounting,
 )
 from app.services.research_canonical_hash import (
+    IDENTITY_COMPONENTS,
     canonical_ast_json,
     compute_identity_hashes,
     derive_experiment_id,
@@ -82,6 +83,40 @@ async def _get_experiment(
     )
 
 
+def _assert_same_identity(
+    stored: ResearchStrategyExperiment,
+    *,
+    identity: StrategyExperimentIdentity,
+    component_hashes: dict[str, str],
+    incoming_manifest: dict[str, object],
+) -> None:
+    """Fail closed unless ``stored`` is the SAME identity as the incoming one.
+
+    Guards every replay of an existing immutable row (both the initial
+    existing-row lookup and the concurrent unique-conflict winner re-read).
+    Compares the FULL identity — strategy key/version, the canonical manifest,
+    and every persisted component hash — so a row reached under a colliding
+    ``experiment_id`` (different key/version/params/manifest) is never replayed.
+    """
+    mismatches: list[str] = []
+    if stored.strategy_key != identity.strategy_key:
+        mismatches.append("strategy_key")
+    if stored.strategy_version != identity.strategy_version:
+        mismatches.append("strategy_version")
+    for name in IDENTITY_COMPONENTS:
+        column = f"{name}_hash"
+        if getattr(stored, column) != component_hashes[column]:
+            mismatches.append(column)
+    if canonical_ast_json(stored.manifest) != canonical_ast_json(incoming_manifest):
+        mismatches.append("manifest")
+    if mismatches:
+        raise CanonicalIdentityCollision(
+            f"experiment_id {stored.experiment_id!r} already exists with a different "
+            f"identity (mismatch: {', '.join(mismatches)}); refusing to replay the "
+            "immutable row under a colliding identity"
+        )
+
+
 async def register_experiment(
     session: AsyncSession,
     identity: StrategyExperimentIdentity,
@@ -103,17 +138,13 @@ async def register_experiment(
 
     existing = await _get_experiment(session, experiment_id)
     if existing is not None:
-        # Idempotent replay — but only for the SAME identity. Compare the stored
-        # canonical manifest with the incoming one exactly; if they differ this
-        # experiment_id was reached by a different identity (a hash collision),
-        # so refuse to replay the immutable row under it (ROB-846 review).
-        if canonical_ast_json(existing.manifest) != canonical_ast_json(
-            incoming_manifest
-        ):
-            raise CanonicalIdentityCollision(
-                f"experiment_id {experiment_id!r} already exists with a different "
-                "canonical manifest; refusing to replay under a colliding identity"
-            )
+        # Idempotent replay — but only for the SAME complete identity.
+        _assert_same_identity(
+            existing,
+            identity=identity,
+            component_hashes=component_hashes,
+            incoming_manifest=incoming_manifest,
+        )
         return existing
 
     if identity.supersedes_experiment_id is not None:
@@ -144,13 +175,21 @@ async def register_experiment(
             session.add(row)
             await session.flush()
     except IntegrityError as exc:
-        # Concurrent registration of the SAME identity won the race and
-        # committed. Idempotent contract: return that original row unchanged.
+        # A concurrent registration won the unique-experiment_id race and
+        # committed. Re-read the winner and apply the SAME full-identity check as
+        # the initial path: only replay it when the identity matches exactly,
+        # otherwise fail closed (a collision must not silently replay).
         if "experiment_id" not in _constraint_name(exc):
             raise
         winner = await _get_experiment(session, experiment_id)
         if winner is None:  # pragma: no cover - conflict without a visible row
             raise
+        _assert_same_identity(
+            winner,
+            identity=identity,
+            component_hashes=component_hashes,
+            incoming_manifest=incoming_manifest,
+        )
         return winner
     return row
 

--- a/tests/_schema_bootstrap.py
+++ b/tests/_schema_bootstrap.py
@@ -24,7 +24,9 @@ from sqlalchemy import text
 # Task 4 landed never got these tables until this bump forces one re-run.
 # v6 (ROB-846): research.strategy_experiments / research.backtest_runs
 # append-only immutability triggers are non-ORM DDL and are mirrored below.
-SCHEMA_BOOTSTRAP_VERSION = 6
+# v7 (ROB-846 review): trigger now blocks legacy->trial UPDATE conversion, plus
+# trial all-or-none + promotion identity-complete CHECK constraints (NOT VALID).
+SCHEMA_BOOTSTRAP_VERSION = 7
 
 # ---- constraints + enums (moved verbatim from conftest.py) ----
 MARKET_VALUATION_SOURCE_CHECK_NAME = "ck_market_valuation_snapshots_source"
@@ -528,12 +530,33 @@ _DDL_STATEMENTS: tuple[str, ...] = (
     "('completed','rejected','crashed','timeout')); END IF; END $$",
     "CREATE INDEX IF NOT EXISTS ix_research_backtest_runs_experiment "
     "ON research.backtest_runs (strategy_experiment_id, trial_index)",
+    # trial all-or-none integrity (NOT VALID: enforce new rows, skip legacy)
+    "DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_constraint "
+    "WHERE conname='ck_research_backtest_runs_trial_all_or_none' "
+    "AND conrelid='research.backtest_runs'::regclass) THEN "
+    "ALTER TABLE research.backtest_runs "
+    "ADD CONSTRAINT ck_research_backtest_runs_trial_all_or_none CHECK ("
+    "(strategy_experiment_id IS NULL AND trial_index IS NULL "
+    "AND trial_status IS NULL AND trial_idempotency_key IS NULL "
+    "AND seed IS NULL AND information_cutoff IS NULL "
+    "AND gate_artifact_hash IS NULL) "
+    "OR (strategy_experiment_id IS NOT NULL AND trial_index IS NOT NULL "
+    "AND trial_status IS NOT NULL)) NOT VALID; END IF; END $$",
     "ALTER TABLE research.promotion_candidates "
     "ADD COLUMN IF NOT EXISTS experiment_id VARCHAR(64)",
     "ALTER TABLE research.promotion_candidates "
     "ADD COLUMN IF NOT EXISTS run_config_hash VARCHAR(64)",
     "ALTER TABLE research.promotion_candidates "
     "ADD COLUMN IF NOT EXISTS run_data_hash VARCHAR(64)",
+    # AC#5: new promotion candidates must carry full identity (NOT VALID keeps
+    # any legacy null-identity rows for compat, blocks new incomplete writes)
+    "DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_constraint "
+    "WHERE conname='ck_research_promotion_candidates_identity_complete' "
+    "AND conrelid='research.promotion_candidates'::regclass) THEN "
+    "ALTER TABLE research.promotion_candidates "
+    "ADD CONSTRAINT ck_research_promotion_candidates_identity_complete CHECK ("
+    "experiment_id IS NOT NULL AND run_config_hash IS NOT NULL "
+    "AND run_data_hash IS NOT NULL) NOT VALID; END IF; END $$",
     # ---- ROB-846: append-only immutability triggers (mirror of the migration)
     # research.strategy_experiments rows are fully immutable; research.backtest_runs
     # rows are immutable only when they are trials (strategy_experiment_id NOT NULL),
@@ -551,12 +574,19 @@ _DDL_STATEMENTS: tuple[str, ...] = (
     "FOR EACH ROW EXECUTE FUNCTION research.reject_strategy_experiment_mutation()",
     "CREATE OR REPLACE FUNCTION research.reject_backtest_trial_mutation() "
     "RETURNS trigger AS $$ BEGIN "
+    "IF TG_OP = 'DELETE' THEN "
     "IF OLD.strategy_experiment_id IS NOT NULL THEN "
     "RAISE EXCEPTION "
-    "'research.backtest_runs trial rows are append-only; % rejected on id=%', "
-    "TG_OP, OLD.id USING ERRCODE = 'restrict_violation'; "
+    "'research.backtest_runs trial rows are append-only; DELETE rejected on id=%', "
+    "OLD.id USING ERRCODE = 'restrict_violation'; "
+    "END IF; RETURN OLD; "
     "END IF; "
-    "IF TG_OP = 'DELETE' THEN RETURN OLD; END IF; "
+    "IF OLD.strategy_experiment_id IS NOT NULL "
+    "OR NEW.strategy_experiment_id IS NOT NULL THEN "
+    "RAISE EXCEPTION "
+    "'research.backtest_runs trial rows are append-only; UPDATE/convert rejected on id=%', "
+    "OLD.id USING ERRCODE = 'restrict_violation'; "
+    "END IF; "
     "RETURN NEW; "
     "END; $$ LANGUAGE plpgsql",
     "DROP TRIGGER IF EXISTS trg_backtest_runs_trial_immutable "

--- a/tests/_schema_bootstrap.py
+++ b/tests/_schema_bootstrap.py
@@ -22,7 +22,9 @@ from sqlalchemy import text
 # have no mirrored ALTER string below — they rely solely on
 # Base.metadata.create_all. Persistent local test DBs bootstrapped before
 # Task 4 landed never got these tables until this bump forces one re-run.
-SCHEMA_BOOTSTRAP_VERSION = 5
+# v6 (ROB-846): research.strategy_experiments / research.backtest_runs
+# append-only immutability triggers are non-ORM DDL and are mirrored below.
+SCHEMA_BOOTSTRAP_VERSION = 6
 
 # ---- constraints + enums (moved verbatim from conftest.py) ----
 MARKET_VALUATION_SOURCE_CHECK_NAME = "ck_market_valuation_snapshots_source"
@@ -481,6 +483,87 @@ _DDL_STATEMENTS: tuple[str, ...] = (
     "ADD CONSTRAINT order_proposals_action "
     "CHECK (action IS NULL OR action IN ('place','replace','cancel')); "
     "END IF; END $$",
+    # ---- ROB-846: append-only trial-child columns on research.backtest_runs +
+    # run/config/data hash linkage on research.promotion_candidates. create_all
+    # skips existing tables, so a persistent test DB needs these ALTERs (they
+    # are no-ops on a fresh DB where create_all already built the ORM shape).
+    "ALTER TABLE research.backtest_runs "
+    "ADD COLUMN IF NOT EXISTS strategy_experiment_id BIGINT",
+    "ALTER TABLE research.backtest_runs ADD COLUMN IF NOT EXISTS trial_index INTEGER",
+    "ALTER TABLE research.backtest_runs ADD COLUMN IF NOT EXISTS seed BIGINT",
+    "ALTER TABLE research.backtest_runs "
+    "ADD COLUMN IF NOT EXISTS information_cutoff TIMESTAMPTZ",
+    "ALTER TABLE research.backtest_runs "
+    "ADD COLUMN IF NOT EXISTS trial_status VARCHAR(16)",
+    "ALTER TABLE research.backtest_runs "
+    "ADD COLUMN IF NOT EXISTS gate_artifact_hash VARCHAR(64)",
+    "ALTER TABLE research.backtest_runs "
+    "ADD COLUMN IF NOT EXISTS trial_idempotency_key VARCHAR(128)",
+    "DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_constraint "
+    "WHERE conname='fk_research_backtest_runs_experiment_id' "
+    "AND conrelid='research.backtest_runs'::regclass) THEN "
+    "ALTER TABLE research.backtest_runs "
+    "ADD CONSTRAINT fk_research_backtest_runs_experiment_id "
+    "FOREIGN KEY (strategy_experiment_id) "
+    "REFERENCES research.strategy_experiments(id) ON DELETE RESTRICT; "
+    "END IF; END $$",
+    "DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_constraint "
+    "WHERE conname='uq_research_backtest_runs_experiment_trial_index' "
+    "AND conrelid='research.backtest_runs'::regclass) THEN "
+    "ALTER TABLE research.backtest_runs "
+    "ADD CONSTRAINT uq_research_backtest_runs_experiment_trial_index "
+    "UNIQUE (strategy_experiment_id, trial_index); END IF; END $$",
+    "DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_constraint "
+    "WHERE conname='uq_research_backtest_runs_experiment_idempotency' "
+    "AND conrelid='research.backtest_runs'::regclass) THEN "
+    "ALTER TABLE research.backtest_runs "
+    "ADD CONSTRAINT uq_research_backtest_runs_experiment_idempotency "
+    "UNIQUE (strategy_experiment_id, trial_idempotency_key); END IF; END $$",
+    "DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_constraint "
+    "WHERE conrelid='research.backtest_runs'::regclass AND contype='c' "
+    "AND pg_get_constraintdef(oid) LIKE '%trial_status%') THEN "
+    "ALTER TABLE research.backtest_runs "
+    "ADD CONSTRAINT ck_research_backtest_runs_trial_status "
+    "CHECK (trial_status IS NULL OR trial_status IN "
+    "('completed','rejected','crashed','timeout')); END IF; END $$",
+    "CREATE INDEX IF NOT EXISTS ix_research_backtest_runs_experiment "
+    "ON research.backtest_runs (strategy_experiment_id, trial_index)",
+    "ALTER TABLE research.promotion_candidates "
+    "ADD COLUMN IF NOT EXISTS experiment_id VARCHAR(64)",
+    "ALTER TABLE research.promotion_candidates "
+    "ADD COLUMN IF NOT EXISTS run_config_hash VARCHAR(64)",
+    "ALTER TABLE research.promotion_candidates "
+    "ADD COLUMN IF NOT EXISTS run_data_hash VARCHAR(64)",
+    # ---- ROB-846: append-only immutability triggers (mirror of the migration)
+    # research.strategy_experiments rows are fully immutable; research.backtest_runs
+    # rows are immutable only when they are trials (strategy_experiment_id NOT NULL),
+    # so legacy summary upserts still work.
+    "CREATE OR REPLACE FUNCTION research.reject_strategy_experiment_mutation() "
+    "RETURNS trigger AS $$ BEGIN "
+    "RAISE EXCEPTION "
+    "'research.strategy_experiments is append-only/immutable; % rejected', TG_OP "
+    "USING ERRCODE = 'restrict_violation'; "
+    "END; $$ LANGUAGE plpgsql",
+    "DROP TRIGGER IF EXISTS trg_strategy_experiments_immutable "
+    "ON research.strategy_experiments",
+    "CREATE TRIGGER trg_strategy_experiments_immutable "
+    "BEFORE UPDATE OR DELETE ON research.strategy_experiments "
+    "FOR EACH ROW EXECUTE FUNCTION research.reject_strategy_experiment_mutation()",
+    "CREATE OR REPLACE FUNCTION research.reject_backtest_trial_mutation() "
+    "RETURNS trigger AS $$ BEGIN "
+    "IF OLD.strategy_experiment_id IS NOT NULL THEN "
+    "RAISE EXCEPTION "
+    "'research.backtest_runs trial rows are append-only; % rejected on id=%', "
+    "TG_OP, OLD.id USING ERRCODE = 'restrict_violation'; "
+    "END IF; "
+    "IF TG_OP = 'DELETE' THEN RETURN OLD; END IF; "
+    "RETURN NEW; "
+    "END; $$ LANGUAGE plpgsql",
+    "DROP TRIGGER IF EXISTS trg_backtest_runs_trial_immutable "
+    "ON research.backtest_runs",
+    "CREATE TRIGGER trg_backtest_runs_trial_immutable "
+    "BEFORE UPDATE OR DELETE ON research.backtest_runs "
+    "FOR EACH ROW EXECUTE FUNCTION research.reject_backtest_trial_mutation()",
 )
 
 

--- a/tests/services/research/test_no_broker_import_guard.py
+++ b/tests/services/research/test_no_broker_import_guard.py
@@ -1,0 +1,89 @@
+"""ROB-846 AC#6 — the experiment registry must not import broker/order/fill surfaces.
+
+The immutable strategy experiment registry is deterministic research
+bookkeeping in the ``research`` schema only. It must never reach a broker,
+order, or fill ledger — neither to import one nor (transitively) to write one.
+This static guard scans the registry's own modules and fails if a forbidden
+surface is imported.
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
+
+# The ROB-846 registry surface.
+GUARDED_FILES: tuple[pathlib.Path, ...] = (
+    REPO_ROOT / "app" / "services" / "strategy_experiment_registry.py",
+    REPO_ROOT / "app" / "services" / "research_canonical_hash.py",
+    REPO_ROOT / "app" / "models" / "research_backtest.py",
+    REPO_ROOT / "app" / "schemas" / "research_backtest.py",
+)
+
+# Module import prefixes that indicate a broker/order/fill surface.
+FORBIDDEN_MODULE_PREFIXES: tuple[str, ...] = (
+    "app.services.brokers",
+    "app.services.kis",
+    "app.services.upbit",
+    "app.services.order_service",
+    "app.services.execution_event",
+    "app.services.fill_notification",
+    "app.services.alpaca_paper_ledger_service",
+    "app.services.toss_live_order_ledger_service",
+    "app.models.paper_trading",
+    "app.models.order_proposals",
+    "app.models.review",
+    "app.mcp_server.tooling.orders",
+    "app.monitoring.trade_notifier",
+)
+
+# Substrings that indicate an order/fill ledger regardless of package path.
+FORBIDDEN_MODULE_SUBSTRINGS: tuple[str, ...] = (
+    "order_ledger",
+    "_ledger",
+    "broker",
+    "order_intent",
+    "trade_notifier",
+)
+
+
+def _imported_modules(tree: ast.AST) -> set[str]:
+    modules: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                modules.add(alias.name)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            modules.add(node.module)
+            for alias in node.names:
+                modules.add(f"{node.module}.{alias.name}")
+    return modules
+
+
+def _is_forbidden(module: str) -> bool:
+    if any(
+        module == p or module.startswith(p + ".") for p in FORBIDDEN_MODULE_PREFIXES
+    ):
+        return True
+    return any(token in module for token in FORBIDDEN_MODULE_SUBSTRINGS)
+
+
+def test_registry_files_exist() -> None:
+    missing = [str(path) for path in GUARDED_FILES if not path.exists()]
+    assert not missing, f"guarded registry files missing: {missing}"
+
+
+@pytest.mark.parametrize("path", GUARDED_FILES, ids=lambda p: p.name)
+def test_registry_module_has_no_broker_or_ledger_import(path: pathlib.Path) -> None:
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    offending = sorted(m for m in _imported_modules(tree) if _is_forbidden(m))
+    assert not offending, (
+        f"{path.relative_to(REPO_ROOT)} imports forbidden broker/order/fill "
+        f"surface(s): {offending}"
+    )

--- a/tests/services/research/test_research_canonical_hash.py
+++ b/tests/services/research/test_research_canonical_hash.py
@@ -1,15 +1,15 @@
-"""ROB-846 — canonical SHA-256 identity helpers (unit).
+"""ROB-846 — canonical identity helpers (unit).
 
 The experiment registry pins strategy/code/params/dataset/PIT/frozen-config/
-policy/benchmark/cost/MDD to a canonical, order-independent SHA-256 identity so
-a strategy version can be reproduced exactly. These tests lock the canonical
-form down.
+policy/benchmark/cost/MDD to ONE closed, typed, collision-free canonical AST so
+a strategy version can be reproduced exactly and two different identities can
+never share an experiment_id. These tests lock the canonical form down.
 """
 
 from __future__ import annotations
 
 import json
-from datetime import UTC, datetime
+from datetime import UTC, date, datetime
 from decimal import Decimal
 
 import pytest
@@ -19,8 +19,11 @@ from app.services.research_canonical_hash import (
     canonical_json,
     canonical_sha256,
     compute_identity_hashes,
+    compute_identity_hashes_from_ast,
     derive_experiment_id,
-    to_jsonable,
+    encode_canonical,
+    encode_manifest,
+    hash_canonical_ast,
 )
 
 pytestmark = pytest.mark.unit
@@ -59,19 +62,30 @@ def test_canonical_json_is_key_order_independent() -> None:
     assert canonical_sha256({"a": 1, "b": 2}) == canonical_sha256({"b": 2, "a": 1})
 
 
-def test_canonical_json_uses_compact_separators_and_sorted_keys() -> None:
-    assert canonical_json({"b": 1, "a": 2}) == '{"a":2,"b":1}'
+def test_encode_canonical_is_a_closed_typed_ast() -> None:
+    # Every value becomes a tagged [tag, payload] node built of JSON-native types.
+    assert encode_canonical("x") == ["str", "x"]
+    assert encode_canonical(5) == ["int", 5]
+    assert encode_canonical(True) == ["bool", True]
+    assert encode_canonical(None) == ["null", None]
+    assert encode_canonical(Decimal("1.0")) == ["decimal", "1.0"]
+    assert encode_canonical(["a"]) == ["list", [["str", "a"]]]
+    assert encode_canonical(("a",)) == ["tuple", [["str", "a"]]]
+    assert encode_canonical({"a"}) == ["set", [["str", "a"]]]
+    assert encode_canonical({"k": 1}) == ["dict", [["k", ["int", 1]]]]
+    # The AST is JSON-serialisable (JSONB-safe) by construction.
+    json.dumps(encode_canonical(_identity_components()))
 
 
 def test_distinct_payloads_hash_differently() -> None:
     assert canonical_sha256({"roi": 0.05}) != canonical_sha256({"roi": 0.06})
 
 
-def test_decimal_and_datetime_are_hashed_deterministically() -> None:
+def test_decimal_hashes_deterministically_as_typed_node() -> None:
     payload = {"pf": Decimal("1.30"), "at": datetime(2026, 1, 1, tzinfo=UTC)}
     assert canonical_sha256(payload) == canonical_sha256(payload)
-    # Decimal serializes as canonical string, not float, so 1.30 != 1.3 text.
-    assert "1.30" in canonical_json(payload)
+    # Decimal is a typed "decimal" node carrying its exact text (1.30 != 1.3).
+    assert '["decimal","1.30"]' in canonical_json(payload)
 
 
 def test_compute_identity_hashes_covers_every_component() -> None:
@@ -91,80 +105,128 @@ def test_identity_hashes_are_independent_per_component() -> None:
     mutated_hashes = compute_identity_hashes(mutated)
 
     assert mutated_hashes["params_hash"] != base_hashes["params_hash"]
-    # Only the mutated component's hash changes.
     for name in IDENTITY_COMPONENTS:
         if name == "params":
             continue
         assert mutated_hashes[f"{name}_hash"] == base_hashes[f"{name}_hash"]
 
 
-def test_to_jsonable_is_json_safe_and_hash_consistent() -> None:
-    from datetime import date
+# --------------------------------------------------------------------------- #
+# Cross-type collision resistance (the review blocker)                         #
+# --------------------------------------------------------------------------- #
 
-    payload = {
-        "pf": Decimal("1.30"),
-        "at": datetime(2026, 1, 1, tzinfo=UTC),
-        "on": date(2026, 1, 2),
-        "tags": {"b", "a", "c"},
-        "nested": {"levels": [Decimal("2.5"), {"deep": Decimal("0.10")}]},
-    }
-    jsonable = to_jsonable(payload)
-    # Must serialise to JSON (what JSONB storage requires).
-    reparsed = json.loads(json.dumps(jsonable))
-    # Hashing the raw payload, the json-safe form, and the DB roundtrip all match.
-    assert canonical_sha256(payload) == canonical_sha256(jsonable)
-    assert canonical_sha256(payload) == canonical_sha256(reparsed)
-    # Decimal is preserved losslessly as canonical text, not a float.
-    assert jsonable["pf"] == "__decimal__:1.30"
-    assert jsonable["tags"] == ["a", "b", "c"]
+
+def test_decimal_never_collides_with_its_prefix_string() -> None:
+    assert canonical_sha256(Decimal("1.0")) != canonical_sha256("__decimal__:1.0")
+
+
+def test_datetime_and_date_never_collide_with_iso_strings() -> None:
+    dt = datetime(2026, 1, 1, tzinfo=UTC)
+    d = date(2026, 1, 2)
+    assert canonical_sha256(dt) != canonical_sha256(dt.isoformat())
+    assert canonical_sha256(dt) != canonical_sha256(f"__datetime__:{dt.isoformat()}")
+    assert canonical_sha256(d) != canonical_sha256(d.isoformat())
+    # A date and a datetime are also distinct from each other.
+    assert canonical_sha256(d) != canonical_sha256(dt)
+
+
+def test_list_tuple_and_set_are_distinct_containers() -> None:
+    assert canonical_sha256([1, 2]) != canonical_sha256((1, 2))
+    assert canonical_sha256([1, 2]) != canonical_sha256({1, 2})
+    assert canonical_sha256((1, 2)) != canonical_sha256({1, 2})
+
+
+def test_forged_tag_shaped_input_cannot_impersonate_special_nodes() -> None:
+    # A raw list/dict/string that mimics a tag shape is re-wrapped, so it can
+    # never equal the special node it imitates.
+    assert canonical_sha256(["decimal", "1.0"]) != canonical_sha256(Decimal("1.0"))
+    assert canonical_sha256(["str", "x"]) != canonical_sha256("x")
+    assert canonical_sha256(
+        {"__type__": "decimal", "value": "1.0"}
+    ) != canonical_sha256(Decimal("1.0"))
+
+
+# --------------------------------------------------------------------------- #
+# JSON-safety / fail-closed rules                                             #
+# --------------------------------------------------------------------------- #
 
 
 @pytest.mark.parametrize("bad", [float("nan"), float("inf"), float("-inf")])
 def test_non_finite_float_is_rejected(bad: float) -> None:
     with pytest.raises((ValueError, TypeError)):
-        to_jsonable({"x": bad})
+        encode_canonical({"x": bad})
     with pytest.raises((ValueError, TypeError)):
         canonical_json({"x": bad})
 
 
 @pytest.mark.parametrize("text", ["NaN", "Infinity", "-Infinity", "sNaN"])
 def test_non_finite_decimal_is_rejected(text: str) -> None:
-    bad = Decimal(text)
     with pytest.raises((ValueError, TypeError)):
-        to_jsonable({"x": bad})
+        encode_canonical({"x": Decimal(text)})
 
 
 def test_finite_decimal_still_roundtrips() -> None:
-    assert to_jsonable(Decimal("-0.0001")) == "__decimal__:-0.0001"
+    assert encode_canonical(Decimal("-0.0001")) == ["decimal", "-0.0001"]
 
 
 def test_int_and_string_key_do_not_collide() -> None:
-    # {1: ..., "1": ...} must not silently collapse to a single "1" key.
     with pytest.raises((TypeError, ValueError)):
-        to_jsonable({1: "int", "1": "str"})
+        encode_canonical({1: "int", "1": "str"})
 
 
 def test_non_string_key_rejected_even_when_nested() -> None:
     with pytest.raises((TypeError, ValueError)):
-        to_jsonable({"outer": {2: "deep"}})
+        encode_canonical({"outer": {2: "deep"}})
     with pytest.raises((TypeError, ValueError)):
-        to_jsonable({"outer": [{"ok": 1}, {3: "bad"}]})
+        encode_canonical({"outer": [{"ok": 1}, {3: "bad"}]})
+
+
+def test_unsupported_type_is_rejected() -> None:
+    with pytest.raises((TypeError, ValueError)):
+        encode_canonical({"blob": b"bytes"})
 
 
 def test_heterogeneous_set_is_deterministic_not_a_typeerror() -> None:
-    # Previously sorting {1, "1"} raised TypeError; now it is deterministic.
     payload = {1, "1", "a", 2}
-    first = to_jsonable(payload)
-    assert isinstance(first, list)
-    assert first == to_jsonable({2, "a", "1", 1})  # order-independent input
+    first = encode_canonical(payload)
+    assert first[0] == "set"
+    assert first == encode_canonical({2, "a", "1", 1})  # order-independent input
     assert canonical_sha256(payload) == canonical_sha256({2, "a", "1", 1})
+    # 1 and "1" are now distinguished (typed), not merged.
+    assert canonical_sha256({1}) != canonical_sha256({"1"})
 
 
-def test_set_members_that_collide_to_same_canonical_form_fail_close() -> None:
-    # A raw Decimal and a hand-crafted string that mimics its encoded form must
-    # not silently map to the same canonical member.
-    with pytest.raises((ValueError, TypeError)):
-        to_jsonable({Decimal("1.0"), "__decimal__:1.0"})
+def test_formerly_colliding_set_members_are_now_distinguished() -> None:
+    # Decimal("1.0") and the hand-crafted string that mimicked its old encoding
+    # are now distinct typed nodes, so the set is unambiguous (no fail-close).
+    encoded = encode_canonical({Decimal("1.0"), "__decimal__:1.0"})
+    assert encoded[0] == "set"
+    assert len(encoded[1]) == 2
+    assert ["decimal", "1.0"] in encoded[1]
+    assert ["str", "__decimal__:1.0"] in encoded[1]
+
+
+# --------------------------------------------------------------------------- #
+# AST hashing entry point (persisted manifest, no double-encode)              #
+# --------------------------------------------------------------------------- #
+
+
+def test_ast_manifest_rehashes_to_same_component_hashes() -> None:
+    components = _identity_components()
+    raw_hashes = compute_identity_hashes(components)
+    manifest = encode_manifest(components)
+    # Simulate a JSONB round-trip (tuple->list normalisation, etc.).
+    roundtripped = json.loads(json.dumps(manifest))
+    ast_hashes = compute_identity_hashes_from_ast(roundtripped)
+    assert ast_hashes == raw_hashes
+
+
+def test_hash_canonical_ast_does_not_re_encode() -> None:
+    # Hashing an already-encoded node must not wrap it again.
+    ast = encode_canonical({"roi": Decimal("0.05")})
+    assert hash_canonical_ast(ast) == canonical_sha256({"roi": Decimal("0.05")})
+    # Double-encoding would change the digest.
+    assert hash_canonical_ast(encode_canonical(ast)) != hash_canonical_ast(ast)
 
 
 def test_derive_experiment_id_is_deterministic_and_identity_sensitive() -> None:
@@ -172,11 +234,8 @@ def test_derive_experiment_id_is_deterministic_and_identity_sensitive() -> None:
     exp_id = derive_experiment_id("NFIX", "v1", hashes)
     assert len(exp_id) == _HEX64
     assert exp_id == derive_experiment_id("NFIX", "v1", hashes)
-
-    # A different version is a different identity.
     assert exp_id != derive_experiment_id("NFIX", "v2", hashes)
 
-    # A different code hash (same version) is a different identity.
     mutated = _identity_components()
     mutated["code"] = "def populate_entry_trend(): return 1"
     assert exp_id != derive_experiment_id(

--- a/tests/services/research/test_research_canonical_hash.py
+++ b/tests/services/research/test_research_canonical_hash.py
@@ -8,6 +8,7 @@ form down.
 
 from __future__ import annotations
 
+import json
 from datetime import UTC, datetime
 from decimal import Decimal
 
@@ -19,6 +20,7 @@ from app.services.research_canonical_hash import (
     canonical_sha256,
     compute_identity_hashes,
     derive_experiment_id,
+    to_jsonable,
 )
 
 pytestmark = pytest.mark.unit
@@ -94,6 +96,27 @@ def test_identity_hashes_are_independent_per_component() -> None:
         if name == "params":
             continue
         assert mutated_hashes[f"{name}_hash"] == base_hashes[f"{name}_hash"]
+
+
+def test_to_jsonable_is_json_safe_and_hash_consistent() -> None:
+    from datetime import date
+
+    payload = {
+        "pf": Decimal("1.30"),
+        "at": datetime(2026, 1, 1, tzinfo=UTC),
+        "on": date(2026, 1, 2),
+        "tags": {"b", "a", "c"},
+        "nested": {"levels": [Decimal("2.5"), {"deep": Decimal("0.10")}]},
+    }
+    jsonable = to_jsonable(payload)
+    # Must serialise to JSON (what JSONB storage requires).
+    reparsed = json.loads(json.dumps(jsonable))
+    # Hashing the raw payload, the json-safe form, and the DB roundtrip all match.
+    assert canonical_sha256(payload) == canonical_sha256(jsonable)
+    assert canonical_sha256(payload) == canonical_sha256(reparsed)
+    # Decimal is preserved losslessly as canonical text, not a float.
+    assert jsonable["pf"] == "__decimal__:1.30"
+    assert jsonable["tags"] == ["a", "b", "c"]
 
 
 def test_derive_experiment_id_is_deterministic_and_identity_sensitive() -> None:

--- a/tests/services/research/test_research_canonical_hash.py
+++ b/tests/services/research/test_research_canonical_hash.py
@@ -1,0 +1,113 @@
+"""ROB-846 — canonical SHA-256 identity helpers (unit).
+
+The experiment registry pins strategy/code/params/dataset/PIT/frozen-config/
+policy/benchmark/cost/MDD to a canonical, order-independent SHA-256 identity so
+a strategy version can be reproduced exactly. These tests lock the canonical
+form down.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from decimal import Decimal
+
+import pytest
+
+from app.services.research_canonical_hash import (
+    IDENTITY_COMPONENTS,
+    canonical_json,
+    canonical_sha256,
+    compute_identity_hashes,
+    derive_experiment_id,
+)
+
+pytestmark = pytest.mark.unit
+
+_HEX64 = 64
+
+
+def _identity_components() -> dict[str, object]:
+    return {
+        "strategy": {"name": "NostalgiaForInfinity", "class": "NFIX"},
+        "code": "def populate_entry_trend(): ...",
+        "params": {"roi": {"0": 0.05}, "stoploss": -0.1},
+        "dataset_manifest": {"pairs": ["BTC/USDT"], "candles": 200_000},
+        "universe": ["BTC/USDT", "ETH/USDT"],
+        "pit": {"information_cutoff": "2026-01-01T00:00:00Z"},
+        "frozen_config": {"max_open_trades": 5, "timeframe": "5m"},
+        "policy": {"gate": "honest_offline_v1"},
+        "benchmark": {"symbol": "BTC/USDT", "kind": "buy_and_hold"},
+        "cost": {"maker_bps": 2, "taker_bps": 4, "slippage_bps": 3},
+        "mdd": {"definition": "peak_to_trough", "window": "full"},
+    }
+
+
+def test_canonical_sha256_is_deterministic_lowercase_hex() -> None:
+    digest = canonical_sha256({"b": 2, "a": 1})
+    assert digest == canonical_sha256({"b": 2, "a": 1})
+    assert len(digest) == _HEX64
+    assert digest == digest.lower()
+    assert all(c in "0123456789abcdef" for c in digest)
+
+
+def test_canonical_json_is_key_order_independent() -> None:
+    assert canonical_json({"a": 1, "b": {"x": 1, "y": 2}}) == canonical_json(
+        {"b": {"y": 2, "x": 1}, "a": 1}
+    )
+    assert canonical_sha256({"a": 1, "b": 2}) == canonical_sha256({"b": 2, "a": 1})
+
+
+def test_canonical_json_uses_compact_separators_and_sorted_keys() -> None:
+    assert canonical_json({"b": 1, "a": 2}) == '{"a":2,"b":1}'
+
+
+def test_distinct_payloads_hash_differently() -> None:
+    assert canonical_sha256({"roi": 0.05}) != canonical_sha256({"roi": 0.06})
+
+
+def test_decimal_and_datetime_are_hashed_deterministically() -> None:
+    payload = {"pf": Decimal("1.30"), "at": datetime(2026, 1, 1, tzinfo=UTC)}
+    assert canonical_sha256(payload) == canonical_sha256(payload)
+    # Decimal serializes as canonical string, not float, so 1.30 != 1.3 text.
+    assert "1.30" in canonical_json(payload)
+
+
+def test_compute_identity_hashes_covers_every_component() -> None:
+    hashes = compute_identity_hashes(_identity_components())
+    expected_keys = {f"{name}_hash" for name in IDENTITY_COMPONENTS}
+    assert set(hashes) == expected_keys
+    for value in hashes.values():
+        assert len(value) == _HEX64
+
+
+def test_identity_hashes_are_independent_per_component() -> None:
+    base = _identity_components()
+    base_hashes = compute_identity_hashes(base)
+
+    mutated = _identity_components()
+    mutated["params"] = {"roi": {"0": 0.99}, "stoploss": -0.1}
+    mutated_hashes = compute_identity_hashes(mutated)
+
+    assert mutated_hashes["params_hash"] != base_hashes["params_hash"]
+    # Only the mutated component's hash changes.
+    for name in IDENTITY_COMPONENTS:
+        if name == "params":
+            continue
+        assert mutated_hashes[f"{name}_hash"] == base_hashes[f"{name}_hash"]
+
+
+def test_derive_experiment_id_is_deterministic_and_identity_sensitive() -> None:
+    hashes = compute_identity_hashes(_identity_components())
+    exp_id = derive_experiment_id("NFIX", "v1", hashes)
+    assert len(exp_id) == _HEX64
+    assert exp_id == derive_experiment_id("NFIX", "v1", hashes)
+
+    # A different version is a different identity.
+    assert exp_id != derive_experiment_id("NFIX", "v2", hashes)
+
+    # A different code hash (same version) is a different identity.
+    mutated = _identity_components()
+    mutated["code"] = "def populate_entry_trend(): return 1"
+    assert exp_id != derive_experiment_id(
+        "NFIX", "v1", compute_identity_hashes(mutated)
+    )

--- a/tests/services/research/test_research_canonical_hash.py
+++ b/tests/services/research/test_research_canonical_hash.py
@@ -119,6 +119,54 @@ def test_to_jsonable_is_json_safe_and_hash_consistent() -> None:
     assert jsonable["tags"] == ["a", "b", "c"]
 
 
+@pytest.mark.parametrize("bad", [float("nan"), float("inf"), float("-inf")])
+def test_non_finite_float_is_rejected(bad: float) -> None:
+    with pytest.raises((ValueError, TypeError)):
+        to_jsonable({"x": bad})
+    with pytest.raises((ValueError, TypeError)):
+        canonical_json({"x": bad})
+
+
+@pytest.mark.parametrize("text", ["NaN", "Infinity", "-Infinity", "sNaN"])
+def test_non_finite_decimal_is_rejected(text: str) -> None:
+    bad = Decimal(text)
+    with pytest.raises((ValueError, TypeError)):
+        to_jsonable({"x": bad})
+
+
+def test_finite_decimal_still_roundtrips() -> None:
+    assert to_jsonable(Decimal("-0.0001")) == "__decimal__:-0.0001"
+
+
+def test_int_and_string_key_do_not_collide() -> None:
+    # {1: ..., "1": ...} must not silently collapse to a single "1" key.
+    with pytest.raises((TypeError, ValueError)):
+        to_jsonable({1: "int", "1": "str"})
+
+
+def test_non_string_key_rejected_even_when_nested() -> None:
+    with pytest.raises((TypeError, ValueError)):
+        to_jsonable({"outer": {2: "deep"}})
+    with pytest.raises((TypeError, ValueError)):
+        to_jsonable({"outer": [{"ok": 1}, {3: "bad"}]})
+
+
+def test_heterogeneous_set_is_deterministic_not_a_typeerror() -> None:
+    # Previously sorting {1, "1"} raised TypeError; now it is deterministic.
+    payload = {1, "1", "a", 2}
+    first = to_jsonable(payload)
+    assert isinstance(first, list)
+    assert first == to_jsonable({2, "a", "1", 1})  # order-independent input
+    assert canonical_sha256(payload) == canonical_sha256({2, "a", "1", 1})
+
+
+def test_set_members_that_collide_to_same_canonical_form_fail_close() -> None:
+    # A raw Decimal and a hand-crafted string that mimics its encoded form must
+    # not silently map to the same canonical member.
+    with pytest.raises((ValueError, TypeError)):
+        to_jsonable({Decimal("1.0"), "__decimal__:1.0"})
+
+
 def test_derive_experiment_id_is_deterministic_and_identity_sensitive() -> None:
     hashes = compute_identity_hashes(_identity_components())
     exp_id = derive_experiment_id("NFIX", "v1", hashes)

--- a/tests/services/research/test_research_canonical_hash.py
+++ b/tests/services/research/test_research_canonical_hash.py
@@ -169,6 +169,25 @@ def test_finite_decimal_still_roundtrips() -> None:
     assert encode_canonical(Decimal("-0.0001")) == ["decimal", "-0.0001"]
 
 
+@pytest.mark.parametrize(
+    "value",
+    [-0.0, 0.0, 1e20, 5e-324, 1.7976931348623157e308, 0.1, -0.1],
+    ids=["neg0", "pos0", "e20", "min-subnormal", "max-finite", "0.1", "-0.1"],
+)
+def test_float_encodes_as_exact_stable_hex_string(value: float) -> None:
+    encoded = encode_canonical(value)
+    assert encoded == ["float", value.hex()]
+    # Payload is a string (JSONB-stable), not a JSON number.
+    assert isinstance(encoded[1], str)
+    # A JSON round-trip (what JSONB does) reproduces the identical digest.
+    roundtripped = json.loads(json.dumps(encoded))
+    assert hash_canonical_ast(roundtripped) == canonical_sha256(value)
+
+
+def test_signed_zero_floats_are_distinguished() -> None:
+    assert canonical_sha256(-0.0) != canonical_sha256(0.0)
+
+
 def test_int_and_string_key_do_not_collide() -> None:
     with pytest.raises((TypeError, ValueError)):
         encode_canonical({1: "int", "1": "str"})

--- a/tests/services/research/test_strategy_experiment_registry.py
+++ b/tests/services/research/test_strategy_experiment_registry.py
@@ -1,0 +1,444 @@
+"""ROB-846 — strategy experiment registry: unit + DB integration.
+
+Covers the acceptance criteria:
+* Canonical identity + idempotent registration (AC#1).
+* Monotonic complete trial accounting incl crash/timeout/reject, idempotency
+  replay + race (AC#2, AC#4).
+* Append-only / no-update: DB mutation of experiment & trial rows fails, and
+  corrections create new lineage without changing old hashes (AC#3).
+* Promotion candidate hash matching (AC#5).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from unittest.mock import AsyncMock
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import func, select, text
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import async_sessionmaker
+
+from app.models.research_backtest import ResearchBacktestRun
+from app.schemas.research_backtest import (
+    BacktestTrialRequest,
+    PromotionLinkRequest,
+    StrategyExperimentIdentity,
+)
+from app.services import strategy_experiment_registry as reg
+
+
+def _identity(**overrides) -> StrategyExperimentIdentity:
+    base = {
+        "strategy_key": "NFIX",
+        "strategy_version": "v-" + uuid.uuid4().hex[:10],
+        "hypothesis": "mean reversion on 5m",
+        "strategy": {"name": "NostalgiaForInfinity"},
+        "code": "def populate_entry_trend(): ...",
+        "params": {"roi": {"0": 0.05}, "stoploss": -0.1},
+        "dataset_manifest": {"pairs": ["BTC/USDT"], "candles": 200_000},
+        "universe": ["BTC/USDT", "ETH/USDT"],
+        "pit": {"information_cutoff": "2026-01-01T00:00:00Z"},
+        "frozen_config": {"max_open_trades": 5, "timeframe": "5m"},
+        "policy": {"gate": "honest_offline_v1"},
+        "benchmark": {"symbol": "BTC/USDT", "kind": "buy_and_hold"},
+        "cost": {"maker_bps": 2, "taker_bps": 4},
+        "mdd": {"definition": "peak_to_trough"},
+    }
+    base.update(overrides)
+    return StrategyExperimentIdentity(**base)
+
+
+def _trial(status: str = "completed", **overrides) -> BacktestTrialRequest:
+    base = {
+        "status": status,
+        "strategy_name": "NFIX",
+        "timeframe": "5m",
+        "runner": "mac",
+    }
+    base.update(overrides)
+    return BacktestTrialRequest(**base)
+
+
+# --------------------------------------------------------------------------- #
+# Unit (no DB) — status validation guard                                       #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_record_trial_rejects_unknown_status_before_touching_db() -> None:
+    session = AsyncMock()
+    # Bypass schema validation to hit the service-layer guard directly.
+    bad = BacktestTrialRequest.model_construct(
+        status="winner", strategy_name="k", timeframe="5m", runner="mac"
+    )
+    with pytest.raises(reg.InvalidTrialStatus):
+        await reg.record_trial(session, experiment_id="e", request=bad)
+    session.scalar.assert_not_called()
+
+
+# --------------------------------------------------------------------------- #
+# DB integration                                                               #
+# --------------------------------------------------------------------------- #
+
+
+@pytest_asyncio.fixture
+async def registry_tables(db_session):
+    exists = await db_session.scalar(
+        text("SELECT to_regclass('research.strategy_experiments')")
+    )
+    if exists is None:
+        pytest.skip("ROB-846 registry tables are not migrated in this DB")
+    return db_session
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_register_experiment_is_idempotent_by_identity(registry_tables) -> None:
+    session = registry_tables
+    identity = _identity()
+
+    first = await reg.register_experiment(session, identity)
+    await session.flush()
+    second = await reg.register_experiment(session, identity)
+
+    assert first.id == second.id
+    assert first.experiment_id == second.experiment_id
+    assert len(first.experiment_id) == 64
+    # Component identities recorded (AC#1).
+    assert first.params_hash and first.frozen_config_hash
+    assert first.dataset_manifest_hash and first.code_hash
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_component_change_yields_new_experiment_id(registry_tables) -> None:
+    session = registry_tables
+    key = "NFIX-" + uuid.uuid4().hex[:8]
+    a = await reg.register_experiment(
+        session, _identity(strategy_key=key, strategy_version="v1")
+    )
+    await session.flush()
+    b = await reg.register_experiment(
+        session,
+        _identity(
+            strategy_key=key,
+            strategy_version="v1",
+            params={"roi": {"0": 0.99}, "stoploss": -0.1},
+        ),
+    )
+    assert a.experiment_id != b.experiment_id
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_every_invocation_gets_monotonic_index_all_statuses(
+    registry_tables,
+) -> None:
+    session = registry_tables
+    exp = await reg.register_experiment(session, _identity())
+    await session.flush()
+
+    statuses = ["completed", "rejected", "crashed", "timeout", "completed"]
+    indices = []
+    for status in statuses:
+        row = await reg.record_trial(
+            session, experiment_id=exp.experiment_id, request=_trial(status)
+        )
+        indices.append(row.trial_index)
+
+    assert indices == [1, 2, 3, 4, 5]
+
+    accounting = await reg.get_trial_accounting(session, exp.experiment_id)
+    assert accounting.total_trials == 5
+    # No winner-only filter: crash/timeout/reject are all counted (AC#4).
+    assert accounting.outcome_counts == {
+        "completed": 2,
+        "rejected": 1,
+        "crashed": 1,
+        "timeout": 1,
+    }
+
+    trials = await reg.list_trials(session, exp.experiment_id)
+    assert [t.trial_index for t in trials] == [1, 2, 3, 4, 5]
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_duplicate_idempotency_returns_original_row(registry_tables) -> None:
+    session = registry_tables
+    exp = await reg.register_experiment(session, _identity())
+    await session.flush()
+
+    key = "idem-" + uuid.uuid4().hex[:8]
+    first = await reg.record_trial(
+        session,
+        experiment_id=exp.experiment_id,
+        request=_trial("completed", idempotency_key=key),
+    )
+    second = await reg.record_trial(
+        session,
+        experiment_id=exp.experiment_id,
+        request=_trial("crashed", idempotency_key=key),
+    )
+
+    assert first.id == second.id
+    assert second.trial_index == first.trial_index
+    # Original status preserved — the replay did not overwrite anything.
+    assert second.trial_status == "completed"
+
+    total = await session.scalar(
+        select(func.count())
+        .select_from(ResearchBacktestRun)
+        .where(ResearchBacktestRun.strategy_experiment_id == exp.id)
+    )
+    assert total == 1
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_record_trial_rejects_unregistered_experiment(registry_tables) -> None:
+    session = registry_tables
+    with pytest.raises(reg.ExperimentNotFound):
+        await reg.record_trial(session, experiment_id="deadbeef" * 8, request=_trial())
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_supersedes_unknown_experiment_fails(registry_tables) -> None:
+    session = registry_tables
+    with pytest.raises(reg.SupersedesNotFound):
+        await reg.register_experiment(
+            session,
+            _identity(supersedes_experiment_id="00" * 32),
+        )
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_correction_creates_new_lineage_without_changing_old_hashes(
+    registry_tables,
+) -> None:
+    session = registry_tables
+    key = "NFIX-" + uuid.uuid4().hex[:8]
+    base = await reg.register_experiment(
+        session, _identity(strategy_key=key, strategy_version="v1")
+    )
+    await session.flush()
+    base_hashes = (base.params_hash, base.frozen_config_hash, base.code_hash)
+
+    corrected = await reg.register_experiment(
+        session,
+        _identity(
+            strategy_key=key,
+            strategy_version="v2",
+            params={"roi": {"0": 0.07}, "stoploss": -0.08},
+            supersedes_experiment_id=base.experiment_id,
+        ),
+    )
+    await session.flush()
+
+    assert corrected.supersedes_experiment_id == base.experiment_id
+    assert corrected.experiment_id != base.experiment_id
+    # Old row's persisted hashes are untouched by the amendment (AC#3).
+    persisted = (
+        await session.execute(
+            text(
+                "SELECT params_hash, frozen_config_hash, code_hash "
+                "FROM research.strategy_experiments WHERE id = :id"
+            ),
+            {"id": base.id},
+        )
+    ).one()
+    assert tuple(persisted) == base_hashes
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_experiment_row_update_is_rejected_by_db(registry_tables) -> None:
+    session = registry_tables
+    exp = await reg.register_experiment(session, _identity())
+    await session.flush()
+
+    with pytest.raises(IntegrityError):
+        await session.execute(
+            text(
+                "UPDATE research.strategy_experiments "
+                "SET hypothesis = 'tampered' WHERE id = :id"
+            ),
+            {"id": exp.id},
+        )
+    await session.rollback()
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_trial_row_update_is_rejected_by_db(registry_tables) -> None:
+    session = registry_tables
+    exp = await reg.register_experiment(session, _identity())
+    await session.flush()
+    trial = await reg.record_trial(
+        session, experiment_id=exp.experiment_id, request=_trial("completed")
+    )
+    await session.flush()
+
+    with pytest.raises(IntegrityError):
+        await session.execute(
+            text("UPDATE research.backtest_runs SET total_trades = 99 WHERE id = :id"),
+            {"id": trial.id},
+        )
+    await session.rollback()
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_promotion_candidate_requires_matching_hashes(registry_tables) -> None:
+    session = registry_tables
+    exp = await reg.register_experiment(session, _identity())
+    await session.flush()
+    trial = await reg.record_trial(
+        session, experiment_id=exp.experiment_id, request=_trial("completed")
+    )
+    await session.flush()
+
+    good = PromotionLinkRequest(
+        expected_experiment_id=exp.experiment_id,
+        expected_config_hash=exp.frozen_config_hash,
+        expected_data_hash=exp.dataset_manifest_hash,
+        status="PASS",
+        reason_code="OK",
+    )
+    candidate = await reg.link_promotion_candidate(
+        session, backtest_run_id=trial.id, request=good
+    )
+    assert candidate.experiment_id == exp.experiment_id
+    assert candidate.run_config_hash == exp.frozen_config_hash
+
+    bad = PromotionLinkRequest(
+        expected_experiment_id=exp.experiment_id,
+        expected_config_hash="00" * 32,  # mismatched config hash
+        expected_data_hash=exp.dataset_manifest_hash,
+        status="PASS",
+        reason_code="OK",
+    )
+    with pytest.raises(reg.PromotionHashMismatch):
+        await reg.link_promotion_candidate(
+            session, backtest_run_id=trial.id, request=bad
+        )
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_promotion_candidate_rejects_run_without_experiment(
+    registry_tables,
+) -> None:
+    session = registry_tables
+    # A legacy summary run (no experiment linkage) cannot back a promotion.
+    legacy = ResearchBacktestRun(
+        run_id="legacy-" + uuid.uuid4().hex[:8],
+        strategy_name="NFIX",
+        timeframe="5m",
+        runner="mac",
+    )
+    session.add(legacy)
+    await session.flush()
+
+    req = PromotionLinkRequest(
+        expected_experiment_id="ab" * 32,
+        expected_config_hash="cd" * 32,
+        expected_data_hash="ef" * 32,
+        status="PASS",
+        reason_code="OK",
+    )
+    with pytest.raises(reg.PromotionHashMismatch):
+        await reg.link_promotion_candidate(
+            session, backtest_run_id=legacy.id, request=req
+        )
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_idempotency_race_never_creates_duplicate_trial(registry_tables) -> None:
+    # Two concurrent record_trial calls (separate committed transactions) with
+    # the same idempotency key must converge to one row (AC#2 race).
+    from app.core.db import engine
+
+    Session = async_sessionmaker(bind=engine, expire_on_commit=False)
+
+    async with Session() as setup:
+        exp = await reg.register_experiment(setup, _identity())
+        await setup.commit()
+        experiment_id = exp.experiment_id
+        exp_pk = exp.id
+
+    key = "race-" + uuid.uuid4().hex[:8]
+
+    async def worker() -> int:
+        async with Session() as s:
+            row = await reg.record_trial(
+                s,
+                experiment_id=experiment_id,
+                request=_trial("completed", idempotency_key=key),
+            )
+            index = row.trial_index
+            await s.commit()
+            return index
+
+    left, right = await asyncio.gather(worker(), worker())
+    assert left == right
+
+    async with Session() as check:
+        count = await check.scalar(
+            select(func.count())
+            .select_from(ResearchBacktestRun)
+            .where(
+                ResearchBacktestRun.strategy_experiment_id == exp_pk,
+                ResearchBacktestRun.trial_idempotency_key == key,
+            )
+        )
+    assert count == 1
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_concurrent_distinct_trials_get_distinct_indices(
+    registry_tables,
+) -> None:
+    # Different idempotency keys → two trials with distinct monotonic indices;
+    # the trial_index UNIQUE constraint drives the allocation retry.
+    from app.core.db import engine
+
+    Session = async_sessionmaker(bind=engine, expire_on_commit=False)
+
+    async with Session() as setup:
+        exp = await reg.register_experiment(setup, _identity())
+        await setup.commit()
+        experiment_id = exp.experiment_id
+        exp_pk = exp.id
+
+    async def worker(tag: str) -> int:
+        async with Session() as s:
+            row = await reg.record_trial(
+                s,
+                experiment_id=experiment_id,
+                request=_trial(
+                    "completed", idempotency_key=f"{tag}-{uuid.uuid4().hex}"
+                ),
+            )
+            index = row.trial_index
+            await s.commit()
+            return index
+
+    indices = sorted(await asyncio.gather(worker("a"), worker("b")))
+    assert indices == [1, 2]
+
+    async with Session() as check:
+        total = await check.scalar(
+            select(func.count())
+            .select_from(ResearchBacktestRun)
+            .where(ResearchBacktestRun.strategy_experiment_id == exp_pk)
+        )
+    assert total == 2

--- a/tests/services/research/test_strategy_experiment_registry.py
+++ b/tests/services/research/test_strategy_experiment_registry.py
@@ -31,7 +31,7 @@ from app.schemas.research_backtest import (
 )
 from app.services import strategy_experiment_registry as reg
 from app.services.research_canonical_hash import (
-    compute_identity_hashes,
+    compute_identity_hashes_from_ast,
     derive_experiment_id,
 )
 
@@ -508,7 +508,7 @@ async def test_manifest_roundtrip_rehashes_to_same_identity(registry_tables) -> 
     ).one()
     manifest, params_hash, cost_hash, experiment_id = stored
 
-    recomputed = compute_identity_hashes(manifest)
+    recomputed = compute_identity_hashes_from_ast(manifest)
     assert recomputed["params_hash"] == params_hash
     assert recomputed["cost_hash"] == cost_hash
     assert (
@@ -687,7 +687,7 @@ async def test_heterogeneous_set_identity_roundtrips(registry_tables) -> None:
         )
     ).one()
     manifest, universe_hash, experiment_id = stored
-    recomputed = compute_identity_hashes(manifest)
+    recomputed = compute_identity_hashes_from_ast(manifest)
     assert recomputed["universe_hash"] == universe_hash
     assert (
         derive_experiment_id(
@@ -718,3 +718,65 @@ async def test_promotion_null_identity_row_rejected_by_db(registry_tables) -> No
             {"rid": trial.id},
         )
     await session.rollback()
+
+
+# --------------------------------------------------------------------------- #
+# Canonical-collision blocker (typed AST)                                      #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("a_value", "b_value"),
+    [
+        (Decimal("1.0"), "__decimal__:1.0"),  # Decimal vs prefix string
+        ([1, 2], (1, 2)),  # list vs tuple
+        ([1, 2], {1, 2}),  # list vs set
+    ],
+    ids=["decimal-vs-str", "list-vs-tuple", "list-vs-set"],
+)
+async def test_formerly_colliding_identities_register_as_distinct_rows(
+    registry_tables, a_value, b_value
+) -> None:
+    session = registry_tables
+    key = "COLL-" + uuid.uuid4().hex[:8]
+    exp_a = await reg.register_experiment(
+        session, _identity(strategy_key=key, params={"p": a_value})
+    )
+    await session.flush()
+    exp_b = await reg.register_experiment(
+        session, _identity(strategy_key=key, params={"p": b_value})
+    )
+    await session.flush()
+
+    # Distinct canonical identities → distinct experiment_ids and two rows.
+    assert exp_a.experiment_id != exp_b.experiment_id
+    assert exp_a.params_hash != exp_b.params_hash
+    count = await session.scalar(
+        select(func.count())
+        .select_from(reg.ResearchStrategyExperiment)
+        .where(reg.ResearchStrategyExperiment.strategy_key == key)
+    )
+    assert count == 2
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_experiment_id_collision_with_different_manifest_fails_closed(
+    registry_tables, monkeypatch
+) -> None:
+    # Defensive replay guard: if a different identity ever derived an existing
+    # experiment_id (a hash collision), the registry must NOT replay the stored
+    # immutable row — it fails closed after comparing canonical manifests.
+    session = registry_tables
+    first = await reg.register_experiment(session, _identity(params={"p": "first"}))
+    await session.flush()
+
+    monkeypatch.setattr(
+        reg,
+        "derive_experiment_id",
+        lambda *args, **kwargs: first.experiment_id,
+    )
+    with pytest.raises(reg.CanonicalIdentityCollision):
+        await reg.register_experiment(session, _identity(params={"p": "second"}))

--- a/tests/services/research/test_strategy_experiment_registry.py
+++ b/tests/services/research/test_strategy_experiment_registry.py
@@ -619,6 +619,84 @@ async def test_trial_all_or_none_check_rejects_partial_trial(registry_tables) ->
     await session.rollback()
 
 
+@pytest.mark.unit
+def test_identity_rejects_non_json_safe_components() -> None:
+    # Canonical-safety is enforced at schema validation (before any DB work).
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        _identity(params={"x": float("nan")})
+    with pytest.raises(ValidationError):
+        _identity(params={1: "int", "1": "str"})
+    with pytest.raises(ValidationError):
+        _identity(cost={"maker_bps": Decimal("Infinity")})
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_invalid_identity_creates_no_experiment_row(registry_tables) -> None:
+    # Even when schema validation is bypassed, the service must fail before any
+    # DB flush — no partial/invalid experiment row is ever persisted.
+    session = registry_tables
+    bad = StrategyExperimentIdentity.model_construct(
+        strategy_key="BAD-" + uuid.uuid4().hex[:8],
+        strategy_version="v1",
+        hypothesis=None,
+        strategy={"ok": 1},
+        code="x",
+        params={"nan": float("nan")},
+        dataset_manifest={},
+        universe=[],
+        pit={},
+        frozen_config={},
+        policy={},
+        benchmark={},
+        cost={},
+        mdd={},
+        supersedes_experiment_id=None,
+    )
+    before = await session.scalar(
+        select(func.count()).select_from(reg.ResearchStrategyExperiment)
+    )
+    with pytest.raises((ValueError, TypeError)):
+        await reg.register_experiment(session, bad)
+    await session.rollback()
+    after = await session.scalar(
+        select(func.count()).select_from(reg.ResearchStrategyExperiment)
+    )
+    assert after == before
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_heterogeneous_set_identity_roundtrips(registry_tables) -> None:
+    # A heterogeneous set component registers, persists as JSONB, and re-hashes
+    # to the identical identity on read-back.
+    session = registry_tables
+    identity = _identity(universe={"BTC/USDT", "ETH/USDT", 1, 2})
+    exp = await reg.register_experiment(session, identity)
+    await session.commit()
+
+    stored = (
+        await session.execute(
+            text(
+                "SELECT manifest, universe_hash, experiment_id "
+                "FROM research.strategy_experiments WHERE id = :id"
+            ),
+            {"id": exp.id},
+        )
+    ).one()
+    manifest, universe_hash, experiment_id = stored
+    recomputed = compute_identity_hashes(manifest)
+    assert recomputed["universe_hash"] == universe_hash
+    assert (
+        derive_experiment_id(
+            identity.strategy_key, identity.strategy_version, recomputed
+        )
+        == experiment_id
+    )
+
+
 @pytest.mark.integration
 @pytest.mark.asyncio
 async def test_promotion_null_identity_row_rejected_by_db(registry_tables) -> None:

--- a/tests/services/research/test_strategy_experiment_registry.py
+++ b/tests/services/research/test_strategy_experiment_registry.py
@@ -917,3 +917,161 @@ async def test_concurrent_forced_collision_fails_closed_on_winner_path(
             .where(reg.ResearchStrategyExperiment.experiment_id == fixed_id)
         )
     assert count == 1
+
+
+# --------------------------------------------------------------------------- #
+# Immutable provenance metadata (hypothesis / supersedes) replay              #
+# --------------------------------------------------------------------------- #
+
+
+def _fixed_components(**overrides) -> dict[str, object]:
+    # Same canonical components across calls → same experiment_id; only metadata
+    # (hypothesis / supersedes) varies.
+    base = {
+        "strategy_key": "META-" + uuid.uuid4().hex[:8],
+        "strategy_version": "v-" + uuid.uuid4().hex[:8],
+        "params": {"roi": {"0": 0.05}},
+    }
+    base.update(overrides)
+    return base
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_replay_rejects_hypothesis_change(registry_tables) -> None:
+    session = registry_tables
+    common = _fixed_components()
+    await reg.register_experiment(session, _identity(**common, hypothesis="H1"))
+    await session.flush()
+    with pytest.raises(reg.CanonicalIdentityCollision):
+        await reg.register_experiment(session, _identity(**common, hypothesis="H2"))
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_unknown_supersedes_fails_before_existing_fast_path(
+    registry_tables,
+) -> None:
+    session = registry_tables
+    common = _fixed_components()
+    # Register the base row first so its experiment_id already exists.
+    await reg.register_experiment(session, _identity(**common))
+    await session.flush()
+    # Re-register identical components but pointing at an unknown lineage parent
+    # (random id, guaranteed absent from the shared test DB): SupersedesNotFound
+    # must win over the existing fast path.
+    unknown_parent = uuid.uuid4().hex + uuid.uuid4().hex
+    with pytest.raises(reg.SupersedesNotFound):
+        await reg.register_experiment(
+            session,
+            _identity(**common, supersedes_experiment_id=unknown_parent),
+        )
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_replay_rejects_valid_but_different_supersedes(registry_tables) -> None:
+    session = registry_tables
+    # A real parent to supersede.
+    parent = await reg.register_experiment(
+        session, _identity(strategy_key="PARENT-" + uuid.uuid4().hex[:8])
+    )
+    await session.flush()
+
+    common = _fixed_components()
+    await reg.register_experiment(session, _identity(**common))  # supersedes=None
+    await session.flush()
+    # Same components, but now claiming a (valid) different lineage parent.
+    with pytest.raises(reg.CanonicalIdentityCollision):
+        await reg.register_experiment(
+            session,
+            _identity(**common, supersedes_experiment_id=parent.experiment_id),
+        )
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_identical_metadata_replay_returns_same_row(registry_tables) -> None:
+    session = registry_tables
+    # Build a real parent, then an identity with BOTH hypothesis and supersedes.
+    parent = await reg.register_experiment(
+        session, _identity(strategy_key="PARENT-" + uuid.uuid4().hex[:8])
+    )
+    await session.flush()
+    ident = _identity(
+        **_fixed_components(),
+        hypothesis="stable thesis",
+        supersedes_experiment_id=parent.experiment_id,
+    )
+    first = await reg.register_experiment(session, ident)
+    await session.flush()
+    second = await reg.register_experiment(session, ident)
+    assert first.id == second.id
+    assert second.hypothesis == "stable thesis"
+    assert second.supersedes_experiment_id == parent.experiment_id
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_concurrent_hypothesis_mismatch_fails_closed(registry_tables) -> None:
+    # Two concurrent registrations of the same components but different
+    # hypothesis: exactly one succeeds, one fails closed, single row persisted.
+    from app.core.db import engine
+
+    Session = async_sessionmaker(bind=engine, expire_on_commit=False)
+    common = _fixed_components()
+    ident_a = _identity(**common, hypothesis="HA")
+    ident_b = _identity(**common, hypothesis="HB")
+
+    async def worker(ident) -> str:
+        async with Session() as s:
+            try:
+                await reg.register_experiment(s, ident)
+                await s.commit()
+                return "ok"
+            except reg.CanonicalIdentityCollision:
+                await s.rollback()
+                return "collision"
+
+    results = sorted(await asyncio.gather(worker(ident_a), worker(ident_b)))
+    assert results == ["collision", "ok"]
+
+    async with Session() as check:
+        count = await check.scalar(
+            select(func.count())
+            .select_from(reg.ResearchStrategyExperiment)
+            .where(
+                reg.ResearchStrategyExperiment.strategy_key == common["strategy_key"]
+            )
+        )
+    assert count == 1
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_concurrent_identical_metadata_replay_converges(registry_tables) -> None:
+    from app.core.db import engine
+
+    Session = async_sessionmaker(bind=engine, expire_on_commit=False)
+    async with Session() as setup:
+        parent = await reg.register_experiment(
+            setup, _identity(strategy_key="PARENT-" + uuid.uuid4().hex[:8])
+        )
+        await setup.commit()
+        parent_id = parent.experiment_id
+
+    ident = _identity(
+        **_fixed_components(),
+        hypothesis="thesis",
+        supersedes_experiment_id=parent_id,
+    )
+
+    async def worker() -> str:
+        async with Session() as s:
+            row = await reg.register_experiment(s, ident)
+            experiment_id = row.experiment_id
+            await s.commit()
+            return experiment_id
+
+    left, right = await asyncio.gather(worker(), worker())
+    assert left == right

--- a/tests/services/research/test_strategy_experiment_registry.py
+++ b/tests/services/research/test_strategy_experiment_registry.py
@@ -13,6 +13,8 @@ from __future__ import annotations
 
 import asyncio
 import uuid
+from datetime import UTC, datetime
+from decimal import Decimal
 from unittest.mock import AsyncMock
 
 import pytest
@@ -28,6 +30,10 @@ from app.schemas.research_backtest import (
     StrategyExperimentIdentity,
 )
 from app.services import strategy_experiment_registry as reg
+from app.services.research_canonical_hash import (
+    compute_identity_hashes,
+    derive_experiment_id,
+)
 
 
 def _identity(**overrides) -> StrategyExperimentIdentity:
@@ -442,3 +448,195 @@ async def test_concurrent_distinct_trials_get_distinct_indices(
             .where(ResearchBacktestRun.strategy_experiment_id == exp_pk)
         )
     assert total == 2
+
+
+# --------------------------------------------------------------------------- #
+# Review blockers                                                              #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.unit
+def test_identity_rejects_all_null_components() -> None:
+    # B2: an all-null identity (or any null component) cannot be constructed.
+    with pytest.raises(ValueError):
+        StrategyExperimentIdentity(strategy_key="k", strategy_version="v")
+    # A single null component is also rejected (explicit sentinel required).
+    with pytest.raises(ValueError):
+        StrategyExperimentIdentity(
+            strategy_key="k",
+            strategy_version="v",
+            strategy=None,
+            code={},
+            params={},
+            dataset_manifest={},
+            universe=[],
+            pit={},
+            frozen_config={},
+            policy={},
+            benchmark={},
+            cost={},
+            mdd={},
+        )
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_manifest_roundtrip_rehashes_to_same_identity(registry_tables) -> None:
+    # B3: register with Decimal/datetime/set/nested payloads, read the manifest
+    # back from JSONB, and recompute the hashes → identical identity.
+    session = registry_tables
+    identity = _identity(
+        params={
+            "roi": {"0": Decimal("0.055")},
+            "stoploss": Decimal("-0.10"),
+            "flags": {"b", "a"},
+            "opened_at": datetime(2026, 1, 1, tzinfo=UTC),
+        },
+        cost={"maker_bps": Decimal("2.5"), "taker_bps": Decimal("4.0")},
+    )
+    exp = await reg.register_experiment(session, identity)
+    await session.commit()
+
+    stored = (
+        await session.execute(
+            text(
+                "SELECT manifest, params_hash, cost_hash, experiment_id "
+                "FROM research.strategy_experiments WHERE id = :id"
+            ),
+            {"id": exp.id},
+        )
+    ).one()
+    manifest, params_hash, cost_hash, experiment_id = stored
+
+    recomputed = compute_identity_hashes(manifest)
+    assert recomputed["params_hash"] == params_hash
+    assert recomputed["cost_hash"] == cost_hash
+    assert (
+        derive_experiment_id(
+            identity.strategy_key, identity.strategy_version, recomputed
+        )
+        == experiment_id
+    )
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_concurrent_register_same_identity_returns_one_row(
+    registry_tables,
+) -> None:
+    # B4: two independent DB sessions registering the same identity concurrently
+    # both return the same original row; exactly one row is persisted.
+    from app.core.db import engine
+
+    Session = async_sessionmaker(bind=engine, expire_on_commit=False)
+    identity = _identity(strategy_key="RACE-" + uuid.uuid4().hex[:8])
+
+    async def worker() -> str:
+        async with Session() as s:
+            row = await reg.register_experiment(s, identity)
+            experiment_id = row.experiment_id
+            await s.commit()
+            return experiment_id
+
+    left, right = await asyncio.gather(worker(), worker())
+    assert left == right
+
+    async with Session() as check:
+        count = await check.scalar(
+            select(func.count())
+            .select_from(reg.ResearchStrategyExperiment)
+            .where(reg.ResearchStrategyExperiment.experiment_id == left)
+        )
+    assert count == 1
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_legacy_row_cannot_be_converted_to_trial_by_update(
+    registry_tables,
+) -> None:
+    # B5: a legacy (null-experiment) row cannot be UPDATE-converted into a trial
+    # — the trigger inspects NEW as well as OLD.
+    session = registry_tables
+    exp = await reg.register_experiment(session, _identity())
+    await session.flush()
+    legacy = ResearchBacktestRun(
+        run_id="legacy-" + uuid.uuid4().hex[:8],
+        strategy_name="NFIX",
+        timeframe="5m",
+        runner="mac",
+    )
+    session.add(legacy)
+    await session.flush()
+
+    with pytest.raises(IntegrityError):
+        await session.execute(
+            text(
+                "UPDATE research.backtest_runs SET strategy_experiment_id = :eid, "
+                "trial_index = 1, trial_status = 'completed' WHERE id = :id"
+            ),
+            {"eid": exp.id, "id": legacy.id},
+        )
+    await session.rollback()
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_legacy_to_legacy_update_is_allowed(registry_tables) -> None:
+    # B5: a legacy row stays mutable as long as it stays legacy (null → null).
+    session = registry_tables
+    legacy = ResearchBacktestRun(
+        run_id="legacy-" + uuid.uuid4().hex[:8],
+        strategy_name="NFIX",
+        timeframe="5m",
+        runner="mac",
+    )
+    session.add(legacy)
+    await session.flush()
+    await session.execute(
+        text("UPDATE research.backtest_runs SET total_trades = 7 WHERE id = :id"),
+        {"id": legacy.id},
+    )
+    await session.rollback()
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_trial_all_or_none_check_rejects_partial_trial(registry_tables) -> None:
+    # B5: a row with an experiment but no trial_index/status violates all-or-none.
+    session = registry_tables
+    exp = await reg.register_experiment(session, _identity())
+    await session.flush()
+    with pytest.raises(IntegrityError):
+        await session.execute(
+            text(
+                "INSERT INTO research.backtest_runs "
+                "(run_id, strategy_name, timeframe, runner, strategy_experiment_id) "
+                "VALUES (:rid, 'NFIX', '5m', 'mac', :eid)"
+            ),
+            {"rid": "partial-" + uuid.uuid4().hex[:8], "eid": exp.id},
+        )
+    await session.rollback()
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_promotion_null_identity_row_rejected_by_db(registry_tables) -> None:
+    # B1: the DB boundary blocks a new promotion candidate with null identity.
+    session = registry_tables
+    exp = await reg.register_experiment(session, _identity())
+    await session.flush()
+    trial = await reg.record_trial(
+        session, experiment_id=exp.experiment_id, request=_trial("completed")
+    )
+    await session.flush()
+    with pytest.raises(IntegrityError):
+        await session.execute(
+            text(
+                "INSERT INTO research.promotion_candidates "
+                "(backtest_run_id, status, reason_code) "
+                "VALUES (:rid, 'PASS', 'OK')"
+            ),
+            {"rid": trial.id},
+        )
+    await session.rollback()

--- a/tests/services/research/test_strategy_experiment_registry.py
+++ b/tests/services/research/test_strategy_experiment_registry.py
@@ -780,3 +780,140 @@ async def test_experiment_id_collision_with_different_manifest_fails_closed(
     )
     with pytest.raises(reg.CanonicalIdentityCollision):
         await reg.register_experiment(session, _identity(params={"p": "second"}))
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+@pytest.mark.parametrize("diff", ["strategy_key", "strategy_version"])
+async def test_replay_rejects_key_or_version_mismatch_even_if_manifest_matches(
+    registry_tables, monkeypatch, diff
+) -> None:
+    # The manifest does NOT carry strategy_key/version, so a manifest-only check
+    # would miss these. The full-identity guard must still fail closed.
+    session = registry_tables
+    common_version = "v-" + uuid.uuid4().hex[:8]
+    common_key = "K-" + uuid.uuid4().hex[:8]
+    common_params = {"roi": 0.05}
+
+    first = await reg.register_experiment(
+        session,
+        _identity(
+            strategy_key=common_key,
+            strategy_version=common_version,
+            params=common_params,
+        ),
+    )
+    await session.flush()
+
+    overrides: dict[str, str] = {
+        "strategy_key": common_key,
+        "strategy_version": common_version,
+    }
+    overrides[diff] = overrides[diff] + "-DIFFERENT"
+
+    monkeypatch.setattr(
+        reg, "derive_experiment_id", lambda *a, **k: first.experiment_id
+    )
+    with pytest.raises(reg.CanonicalIdentityCollision):
+        await reg.register_experiment(
+            session,
+            _identity(params=common_params, **overrides),
+        )
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_edge_floats_roundtrip_and_replay_without_false_collision(
+    registry_tables,
+) -> None:
+    # Blocker 1: edge floats must survive a real Postgres JSONB store/read and
+    # replay from a FRESH session without a false CanonicalIdentityCollision.
+    from app.core.db import engine
+    from app.services.research_canonical_hash import compute_identity_hashes_from_ast
+
+    Session = async_sessionmaker(bind=engine, expire_on_commit=False)
+    edge = {
+        "neg_zero": -0.0,
+        "pos_zero": 0.0,
+        "e20": 1e20,
+        "max_fin": 1.7976931348623157e308,
+        "min_sub": 5e-324,
+        "point1": 0.1,
+    }
+    ident = _identity(
+        strategy_key="FLOAT-" + uuid.uuid4().hex[:8], params={"edge": edge}
+    )
+
+    async with Session() as writer:
+        exp = await reg.register_experiment(writer, ident)
+        await writer.commit()
+        experiment_id = exp.experiment_id
+        params_hash = exp.params_hash
+
+    async with Session() as reader:
+        # Replay the identical identity against the persisted (JSONB-roundtripped)
+        # row — must return the same row, not raise.
+        replay = await reg.register_experiment(reader, ident)
+        assert replay.experiment_id == experiment_id
+
+        stored = (
+            await reader.execute(
+                text(
+                    "SELECT manifest, params_hash "
+                    "FROM research.strategy_experiments WHERE experiment_id = :e"
+                ),
+                {"e": experiment_id},
+            )
+        ).one()
+        manifest, stored_params_hash = stored
+        assert stored_params_hash == params_hash
+        # AST re-hash of the persisted manifest reproduces the same digest.
+        assert compute_identity_hashes_from_ast(manifest)["params_hash"] == params_hash
+
+    async with Session() as check:
+        count = await check.scalar(
+            select(func.count())
+            .select_from(reg.ResearchStrategyExperiment)
+            .where(reg.ResearchStrategyExperiment.experiment_id == experiment_id)
+        )
+    assert count == 1
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_concurrent_forced_collision_fails_closed_on_winner_path(
+    registry_tables, monkeypatch
+) -> None:
+    # Two different identities forced to the same experiment_id, registered
+    # concurrently: exactly one wins the unique race and one fails closed
+    # (whether it catches the collision at the initial SELECT or the winner
+    # re-read after the IntegrityError). Never two rows, never a wrong replay.
+    from app.core.db import engine
+
+    Session = async_sessionmaker(bind=engine, expire_on_commit=False)
+    fixed_id = uuid.uuid4().hex + uuid.uuid4().hex  # 64-hex, unique per run
+    monkeypatch.setattr(reg, "derive_experiment_id", lambda *a, **k: fixed_id)
+
+    ident_a = _identity(strategy_key="A-" + uuid.uuid4().hex[:8], params={"p": "A"})
+    ident_b = _identity(strategy_key="B-" + uuid.uuid4().hex[:8], params={"p": "B"})
+
+    async def worker(ident) -> str:
+        async with Session() as s:
+            try:
+                await reg.register_experiment(s, ident)
+                await s.commit()
+                return "ok"
+            except reg.CanonicalIdentityCollision:
+                await s.rollback()
+                return "collision"
+
+    results = sorted(await asyncio.gather(worker(ident_a), worker(ident_b)))
+    assert results == ["collision", "ok"]
+
+    async with Session() as check:
+        count = await check.scalar(
+            select(func.count())
+            .select_from(reg.ResearchStrategyExperiment)
+            .where(reg.ResearchStrategyExperiment.experiment_id == fixed_id)
+        )
+    assert count == 1

--- a/tests/services/research/test_strategy_experiment_registry.py
+++ b/tests/services/research/test_strategy_experiment_registry.py
@@ -225,6 +225,45 @@ async def test_supersedes_unknown_experiment_fails(registry_tables) -> None:
 
 @pytest.mark.integration
 @pytest.mark.asyncio
+async def test_supersedes_different_strategy_fails_before_child_insert(
+    registry_tables,
+) -> None:
+    session = registry_tables
+    parent = await reg.register_experiment(
+        session,
+        _identity(
+            strategy_key="PARENT-" + uuid.uuid4().hex[:8],
+            strategy_version="v1",
+        ),
+    )
+    await session.flush()
+    child_key = "CHILD-" + uuid.uuid4().hex[:8]
+
+    with pytest.raises(
+        reg.StrategyExperimentRegistryError,
+        match="different strategy_key",
+    ) as exc_info:
+        await reg.register_experiment(
+            session,
+            _identity(
+                strategy_key=child_key,
+                strategy_version="v2",
+                params={"roi": {"0": 0.07}, "stoploss": -0.08},
+                supersedes_experiment_id=parent.experiment_id,
+            ),
+        )
+
+    assert type(exc_info.value) is reg.SupersedesStrategyMismatch
+    child_count = await session.scalar(
+        select(func.count())
+        .select_from(reg.ResearchStrategyExperiment)
+        .where(reg.ResearchStrategyExperiment.strategy_key == child_key)
+    )
+    assert child_count == 0
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
 async def test_correction_creates_new_lineage_without_changing_old_hashes(
     registry_tables,
 ) -> None:
@@ -655,16 +694,15 @@ async def test_invalid_identity_creates_no_experiment_row(registry_tables) -> No
         mdd={},
         supersedes_experiment_id=None,
     )
-    before = await session.scalar(
-        select(func.count()).select_from(reg.ResearchStrategyExperiment)
-    )
     with pytest.raises((ValueError, TypeError)):
         await reg.register_experiment(session, bad)
     await session.rollback()
     after = await session.scalar(
-        select(func.count()).select_from(reg.ResearchStrategyExperiment)
+        select(func.count())
+        .select_from(reg.ResearchStrategyExperiment)
+        .where(reg.ResearchStrategyExperiment.strategy_key == bad.strategy_key)
     )
-    assert after == before
+    assert after == 0
 
 
 @pytest.mark.integration
@@ -972,13 +1010,13 @@ async def test_unknown_supersedes_fails_before_existing_fast_path(
 @pytest.mark.asyncio
 async def test_replay_rejects_valid_but_different_supersedes(registry_tables) -> None:
     session = registry_tables
+    common = _fixed_components()
     # A real parent to supersede.
     parent = await reg.register_experiment(
-        session, _identity(strategy_key="PARENT-" + uuid.uuid4().hex[:8])
+        session, _identity(strategy_key=common["strategy_key"])
     )
     await session.flush()
 
-    common = _fixed_components()
     await reg.register_experiment(session, _identity(**common))  # supersedes=None
     await session.flush()
     # Same components, but now claiming a (valid) different lineage parent.
@@ -993,13 +1031,14 @@ async def test_replay_rejects_valid_but_different_supersedes(registry_tables) ->
 @pytest.mark.asyncio
 async def test_identical_metadata_replay_returns_same_row(registry_tables) -> None:
     session = registry_tables
+    common = _fixed_components()
     # Build a real parent, then an identity with BOTH hypothesis and supersedes.
     parent = await reg.register_experiment(
-        session, _identity(strategy_key="PARENT-" + uuid.uuid4().hex[:8])
+        session, _identity(strategy_key=common["strategy_key"])
     )
     await session.flush()
     ident = _identity(
-        **_fixed_components(),
+        **common,
         hypothesis="stable thesis",
         supersedes_experiment_id=parent.experiment_id,
     )
@@ -1053,15 +1092,16 @@ async def test_concurrent_identical_metadata_replay_converges(registry_tables) -
     from app.core.db import engine
 
     Session = async_sessionmaker(bind=engine, expire_on_commit=False)
+    common = _fixed_components()
     async with Session() as setup:
         parent = await reg.register_experiment(
-            setup, _identity(strategy_key="PARENT-" + uuid.uuid4().hex[:8])
+            setup, _identity(strategy_key=common["strategy_key"])
         )
         await setup.commit()
         parent_id = parent.experiment_id
 
     ident = _identity(
-        **_fixed_components(),
+        **common,
         hypothesis="thesis",
         supersedes_experiment_id=parent_id,
     )

--- a/tests/test_research_ingestion_service.py
+++ b/tests/test_research_ingestion_service.py
@@ -34,17 +34,12 @@ async def test_ingest_summary_payload_returns_run_id(
 
     run_row = SimpleNamespace(id=100, run_id=parsed.run_id)
     upsert_backtest_run = AsyncMock(return_value=run_row)
-    upsert_promotion_candidate = AsyncMock()
     replace_backtest_pairs = AsyncMock()
     create_sync_job = AsyncMock(return_value=SimpleNamespace(id=1, status="running"))
     update_sync_job_status = AsyncMock()
     monkeypatch.setattr(
         "app.services.research_ingestion_service.upsert_backtest_run",
         upsert_backtest_run,
-    )
-    monkeypatch.setattr(
-        "app.services.research_ingestion_service.upsert_promotion_candidate",
-        upsert_promotion_candidate,
     )
     monkeypatch.setattr(
         "app.services.research_ingestion_service.replace_backtest_pairs",
@@ -77,10 +72,16 @@ async def test_ingest_summary_payload_returns_run_id(
 
     assert run_id == "run-20260219-01"
     upsert_backtest_run.assert_awaited_once()
-    upsert_promotion_candidate.assert_awaited_once()
     create_sync_job.assert_awaited_once()
     update_sync_job_status.assert_awaited_once()
     session.commit.assert_awaited_once()
+
+    # ROB-846: identity-less ingest writes NO promotion candidate; the gate
+    # evaluation is preserved as a structured non-promotion result instead.
+    outcome = update_sync_job_status.await_args.kwargs["error_payload"]
+    assert outcome["promotion"]["status"] == "not_promoted"
+    assert outcome["promotion"]["reason"] == "no_experiment_identity"
+    assert outcome["promotion"]["gate"]["status"] == "PASS"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
Adds an **immutable strategy experiment registry** with complete trial accounting (ROB-846), so every backtest/optimization attempt is a canonical, reproducible, append-only record and selection bias becomes measurable.

- **`research.strategy_experiments`** — immutable parent keyed by a canonical SHA-256 identity over strategy/code/params/dataset-manifest/universe/PIT/frozen-config/policy/benchmark/cost/MDD. `experiment_id` is derived deterministically; `supersedes_experiment_id` is self-FK lineage (corrections = new version, never in-place edits).
- **`research.backtest_runs`** — extended into append-only trial children: `strategy_experiment_id`, monotonic `trial_index`, `seed`, `information_cutoff`, `trial_status` (completed/rejected/crashed/timeout), `gate_artifact_hash`, `trial_idempotency_key`. Every invocation records exactly one trial (incl. crash/timeout/reject); idempotency duplicates return the original row.
- **`promotion_candidates`** — bound to an exact run/config/data identity; the identity-less legacy ingest path no longer writes it.
- **Append-only enforced by DB triggers** (experiments fully immutable; backtest_runs trial rows immutable, incl. blocking legacy→trial UPDATE conversion) + `NOT VALID` integrity CHECKs, mirrored into the test-schema bootstrap.
- **Registry service** (`app/services/strategy_experiment_registry.py`) — register / record_trial / trial accounting / validated promotion-link, with NO update/delete path. No broker/order/fill import (AST guard).

## Canonical identity (collision-safe, JSONB-stable)
- Closed **typed canonical AST** (`encode_canonical`): every leaf and container — including strings — is a `[tag, payload]` node, so Decimal/str, list/tuple/set, and date/datetime never collide and raw input cannot forge a tag.
- Raw-encode vs persisted-AST hashing are separate entry points (no double-encode); persisted JSONB re-hashes identically.
- Finite floats stored as exact `float.hex()` strings (JSONB-stable across `-0.0`, `1e20`, subnormal, max-finite).
- `_assert_same_identity` compares strategy_key, version, canonical manifest, **all component hashes**, and immutable provenance (`hypothesis`, `supersedes_experiment_id`) on both the existing-row and concurrent-conflict replay paths; supersedes parent is validated before the fast path and must share the same `strategy_key`.

## Testing
- `tests/services/research/` (+ `tests/test_research_ingestion_service.py`): **81 passed** — canonical identity, monotonic trial accounting, idempotency replay + race, append-only DB enforcement, FK/hash mismatch, promotion boundary, cross-type collision resistance, float JSONB round-trip, full-identity + metadata replay guards, concurrency (5× stable), no-broker AST guard.
- Adjacent regression (parser/gate/models/freqtrade ingest): 11 passed.
- Migration `20260712_rob846_experiments` (down_revision `20260711_rob832_actions`) — single Alembic head; upgrade/downgrade/upgrade verified. Ruff + ty clean.

## Rollout
Registration surface is default-off (service/schema only; no MCP/HTTP wiring). Additive immutable rows; no existing backtest row is rewritten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added immutable strategy experiment registration with deterministic identity and lineage tracking.
  * Added append-only trial recording, idempotent replay handling, terminal outcome tracking, and trial accounting summaries.
  * Added provenance links connecting promotion candidates to exact experiment, configuration, and dataset identities.
  * Added validation to ensure experiment metadata and promotion links remain consistent.

* **Bug Fixes**
  * Identity-free backtest summaries no longer create promotion candidates and now report a structured non-promotion result.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->