### PR TITLE
fix(ROB-843): KIS mock executor final risk re-check + false-success paper-safety

### DIFF
--- a/app/mcp_server/tooling/kis_mock_ledger.py
+++ b/app/mcp_server/tooling/kis_mock_ledger.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import uuid
+from collections.abc import Mapping
 from decimal import Decimal, InvalidOperation
 from typing import Any
 from typing import cast as typing_cast
@@ -40,6 +41,17 @@ def _status_to_lifecycle_state(status: str | None) -> str:
     if status is None:
         return "anomaly"
     return _LEDGER_STATUS_TO_LIFECYCLE.get(status, "anomaly")
+
+
+def _accepted_or_failed_message(
+    accepted: bool, status: str, ledger_id: int | None
+) -> str:
+    """Human-readable outcome message for the normalized mock-order response."""
+    if not accepted:
+        return f"KIS mock order not accepted (status={status}); evidence recorded"
+    if ledger_id:
+        return "KIS mock order recorded to kis_mock_order_ledger"
+    return "KIS mock order accepted but ledger insert returned no id"
 
 
 def _to_decimal(val: Any) -> Decimal | None:
@@ -343,21 +355,53 @@ async def _record_kis_mock_order(
     amt_val = _to_float(dry_run_result.get("estimated_value"), default=0.0)
     currency = "KRW" if market_type != "equity_us" else "USD"
 
-    order_no = execution_result.get("odno") or execution_result.get("ord_no")
-    order_time = execution_result.get("ord_tmd")
-    raw_output = execution_result.get("output") or {}
-    krx_orgno = execution_result.get("krx_fwdg_ord_orgno") or raw_output.get(
-        "KRX_FWDG_ORD_ORGNO"
-    )
-    rt_cd = str(execution_result.get("rt_cd", "")) or None
-    msg = execution_result.get("msg") or execution_result.get("msg1")
+    # ROB-843: normalize the native submit response truthfully. A malformed
+    # (non-mapping) payload carries no order fields — treat as unknown and keep
+    # a redacted marker as evidence rather than crashing on ``.get``.
+    is_mapping = isinstance(execution_result, Mapping)
+    raw_exec: dict[str, Any]
+    if is_mapping:
+        raw_exec = dict(execution_result)
+    else:
+        raw_exec = {"_malformed": str(execution_result)[:500]}
 
-    if rt_cd == "0":
+    order_no = raw_exec.get("odno") or raw_exec.get("ord_no")
+    order_time = raw_exec.get("ord_tmd")
+    raw_output = raw_exec.get("output") or {}
+    krx_orgno = raw_exec.get("krx_fwdg_ord_orgno") or (
+        raw_output.get("KRX_FWDG_ORD_ORGNO")
+        if isinstance(raw_output, Mapping)
+        else None
+    )
+    rt_cd = str(raw_exec.get("rt_cd", "")) or None
+    msg = raw_exec.get("msg") or raw_exec.get("msg1")
+
+    # Accepted success REQUIRES all of: a mapping payload, provider success
+    # status (rt_cd == "0"), and a non-empty broker order ID. Anything else is
+    # rejected (provider error code) or unknown (id-less / malformed / no code).
+    accepted = is_mapping and rt_cd == "0" and bool(order_no)
+    if accepted:
         status = "accepted"
-    elif rt_cd and rt_cd != "0":
+    elif is_mapping and rt_cd and rt_cd != "0":
         status = "rejected"
     else:
-        status = "accepted" if order_no else "unknown"
+        status = "unknown"
+
+    if accepted:
+        failure_reason: str | None = None
+        failure_detail: str | None = None
+    elif not is_mapping:
+        failure_reason = "malformed_response"
+        failure_detail = raw_exec["_malformed"]
+    elif status == "rejected":
+        failure_reason = "broker_rejected"
+        failure_detail = msg or f"rt_cd={rt_cd}"
+    elif rt_cd == "0":
+        failure_reason = "missing_broker_order_id"
+        failure_detail = msg or "provider success without broker order id"
+    else:
+        failure_reason = "unknown_response"
+        failure_detail = msg or f"rt_cd={rt_cd} order_no={order_no}"
 
     # ROB-730 provenance spine: mint a deterministic place-time correlation_id so
     # this mock order joins forecast → fill → journal → retrospective, mirroring
@@ -389,7 +433,7 @@ async def _record_kis_mock_order(
         status=status,
         response_code=rt_cd,
         response_message=msg,
-        raw_response=execution_result,
+        raw_response=raw_exec,
         reason=reason,
         thesis=thesis,
         strategy=strategy,
@@ -420,7 +464,10 @@ async def _record_kis_mock_order(
         )
 
     return {
-        "success": True,
+        # ROB-843: success is truthful — accepted iff mapping + rt_cd==0 +
+        # non-empty broker order ID. Rejected/malformed/unknown/id-less never
+        # report success, and the native failure/unknown evidence is preserved.
+        "success": accepted,
         "dry_run": False,
         "preview": dry_run_result,
         "execution": execution_result,
@@ -435,14 +482,12 @@ async def _record_kis_mock_order(
         "status": status,
         "response_code": rt_cd,
         "response_message": msg,
+        "reason": failure_reason,
+        "detail": failure_detail,
         "correlation_id": correlation_id,
         "fill_recorded": False,
         "journal_created": False,
-        "message": (
-            "KIS mock order recorded to kis_mock_order_ledger"
-            if ledger_id
-            else "KIS mock order accepted but ledger insert returned no id"
-        ),
+        "message": (_accepted_or_failed_message(accepted, status, ledger_id)),
     }
 
 

--- a/app/mcp_server/tooling/kis_mock_ledger.py
+++ b/app/mcp_server/tooling/kis_mock_ledger.py
@@ -22,7 +22,6 @@ from app.mcp_server.tooling.shared import to_float as _to_float
 from app.models.review import KISMockOrderLedger
 from app.services.brokers.kis.mock_scalping_exec.tracking_state import (
     LedgerWriteError,
-    mark_ledger_tracking_unavailable,
 )
 from app.services.brokers.kis.order_id import normalize_broker_order_id
 from app.services.kis_mock_lifecycle_service import KISMockLifecycleService
@@ -403,90 +402,6 @@ async def _native_row_exists(order_no: str | None) -> bool:
         return False
 
 
-async def _persist_tracking_fallback(
-    *,
-    correlation_id: str | None,
-    side: str,
-    normalized_symbol: str,
-    market_type: str,
-) -> int | None:
-    """Write a durable fallback evidence row (correlation_id + side) so the daily
-    broker-order count still counts a submitted order whose native row was lost.
-
-    Keyed on the same correlation_id the synthetic scalping fill/exit row uses,
-    so native/fallback/synthetic evidence for one order de-dup to a single count.
-    """
-    currency = "KRW" if market_type != "equity_us" else "USD"
-    return await _save_kis_mock_order_ledger(
-        symbol=normalized_symbol,
-        instrument_type=market_type,
-        side=side,
-        order_type="limit",
-        quantity=0.0,
-        price=0.0,
-        amount=0.0,
-        currency=currency,
-        order_no=None,
-        order_time=None,
-        krx_fwdg_ord_orgno=None,
-        status="unknown",
-        response_code=None,
-        response_message="native ledger write lost; tracking fallback",
-        raw_response=None,
-        reason="ledger_tracking_fallback",
-        thesis=None,
-        strategy=None,
-        notes=None,
-        lifecycle_state="anomaly",
-        correlation_id=correlation_id,
-        scalping_role="native_fallback",
-    )
-
-
-async def _persist_tracking_degradation_marker(
-    *, correlation_id: str | None, side: str, market_type: str
-) -> int | None:
-    """Persist a DURABLE ledger-tracking degradation marker (ROB-843 P1-2).
-
-    Written when an accepted order's native AND fallback evidence are both lost.
-    It survives process restart / module reload; only an explicit reconciliation
-    (``clear_tracking_degradation``) resolves it. Returns the row id, or None if
-    even this write could not persist (then the caller falls back to the
-    process-local latch as a last resort).
-    """
-    from app.services.brokers.kis.mock_scalping_exec.ledger_state import (
-        _DEGRADATION_ROLE,
-        _DEGRADATION_SYMBOL,
-    )
-
-    currency = "KRW" if market_type != "equity_us" else "USD"
-    db_side = "buy" if str(side).lower() == "buy" else "sell"
-    return await _save_kis_mock_order_ledger(
-        symbol=_DEGRADATION_SYMBOL,
-        instrument_type=market_type,
-        side=db_side,
-        order_type="limit",
-        quantity=0.0,
-        price=0.0,
-        amount=0.0,
-        currency=currency,
-        order_no=None,
-        order_time=None,
-        krx_fwdg_ord_orgno=None,
-        status="unknown",
-        response_code=None,
-        response_message="ledger tracking degraded; native+fallback write lost",
-        raw_response=None,
-        reason="ledger_tracking_degraded",
-        thesis=None,
-        strategy=None,
-        notes=correlation_id,
-        lifecycle_state="anomaly",
-        correlation_id=correlation_id,
-        scalping_role=_DEGRADATION_ROLE,
-    )
-
-
 async def _record_kis_mock_order(
     *,
     normalized_symbol: str,
@@ -628,26 +543,15 @@ async def _record_kis_mock_order(
         ledger_id = None
 
     if accepted:
+        # ROB-843 P1: an accepted order whose native row is NOT durable (write
+        # error, and no existing row from a conflict) is "sent but not tracked".
+        # We do NOT write a control row here (that shared the native write's
+        # failure mode). Instead the caller keeps the write-ahead reservation
+        # unresolved — a durable, restart-safe fail-close resolved only by
+        # reconciliation. Signal that state to the caller.
         native_durable = ledger_id is not None or await _native_row_exists(order_no)
         if not native_durable:
-            fallback_id = await _persist_tracking_fallback(
-                correlation_id=correlation_id,
-                side=side,
-                normalized_symbol=normalized_symbol,
-                market_type=market_type,
-            )
-            if fallback_id is None:
-                # Neither native nor fallback evidence persisted: degrade tracking
-                # DURABLY (survives restart) so the next order fail-closes; the
-                # process-local latch is a last resort if even the marker is lost.
-                ledger_tracking_unavailable = True
-                marker_id = await _persist_tracking_degradation_marker(
-                    correlation_id=correlation_id,
-                    side=side,
-                    market_type=market_type,
-                )
-                if marker_id is None:
-                    mark_ledger_tracking_unavailable()
+            ledger_tracking_unavailable = True
 
     # ROB-730: emit the place-time forecast only for accepted orders (mirrors
     # kis_live). publish_place_time_forecast is itself buy+target-gated and runs

--- a/app/mcp_server/tooling/kis_mock_ledger.py
+++ b/app/mcp_server/tooling/kis_mock_ledger.py
@@ -443,6 +443,50 @@ async def _persist_tracking_fallback(
     )
 
 
+async def _persist_tracking_degradation_marker(
+    *, correlation_id: str | None, side: str, market_type: str
+) -> int | None:
+    """Persist a DURABLE ledger-tracking degradation marker (ROB-843 P1-2).
+
+    Written when an accepted order's native AND fallback evidence are both lost.
+    It survives process restart / module reload; only an explicit reconciliation
+    (``clear_tracking_degradation``) resolves it. Returns the row id, or None if
+    even this write could not persist (then the caller falls back to the
+    process-local latch as a last resort).
+    """
+    from app.services.brokers.kis.mock_scalping_exec.ledger_state import (
+        _DEGRADATION_ROLE,
+        _DEGRADATION_SYMBOL,
+    )
+
+    currency = "KRW" if market_type != "equity_us" else "USD"
+    db_side = "buy" if str(side).lower() == "buy" else "sell"
+    return await _save_kis_mock_order_ledger(
+        symbol=_DEGRADATION_SYMBOL,
+        instrument_type=market_type,
+        side=db_side,
+        order_type="limit",
+        quantity=0.0,
+        price=0.0,
+        amount=0.0,
+        currency=currency,
+        order_no=None,
+        order_time=None,
+        krx_fwdg_ord_orgno=None,
+        status="unknown",
+        response_code=None,
+        response_message="ledger tracking degraded; native+fallback write lost",
+        raw_response=None,
+        reason="ledger_tracking_degraded",
+        thesis=None,
+        strategy=None,
+        notes=correlation_id,
+        lifecycle_state="anomaly",
+        correlation_id=correlation_id,
+        scalping_role=_DEGRADATION_ROLE,
+    )
+
+
 async def _record_kis_mock_order(
     *,
     normalized_symbol: str,
@@ -593,8 +637,17 @@ async def _record_kis_mock_order(
                 market_type=market_type,
             )
             if fallback_id is None:
+                # Neither native nor fallback evidence persisted: degrade tracking
+                # DURABLY (survives restart) so the next order fail-closes; the
+                # process-local latch is a last resort if even the marker is lost.
                 ledger_tracking_unavailable = True
-                mark_ledger_tracking_unavailable()
+                marker_id = await _persist_tracking_degradation_marker(
+                    correlation_id=correlation_id,
+                    side=side,
+                    market_type=market_type,
+                )
+                if marker_id is None:
+                    mark_ledger_tracking_unavailable()
 
     # ROB-730: emit the place-time forecast only for accepted orders (mirrors
     # kis_live). publish_place_time_forecast is itself buy+target-gated and runs

--- a/app/mcp_server/tooling/kis_mock_ledger.py
+++ b/app/mcp_server/tooling/kis_mock_ledger.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 import uuid
 from collections.abc import Mapping
 from decimal import Decimal, InvalidOperation
@@ -18,9 +19,40 @@ from app.jobs.kis_mock_reconciliation_job import run_kis_mock_reconciliation
 from app.mcp_server.tooling.shared import logger
 from app.mcp_server.tooling.shared import to_float as _to_float
 from app.models.review import KISMockOrderLedger
+from app.services.brokers.kis.order_id import normalize_broker_order_id
 from app.services.kis_mock_lifecycle_service import KISMockLifecycleService
 from app.services.live_correlation import live_correlation_id
 from app.services.live_place_provenance import publish_place_time_forecast
+
+# ROB-843: sensitive-key fragments to redact from raw broker evidence before it
+# is persisted or returned. Matched case-insensitively as a substring of the key
+# (covers appkey/appsecret/approval_key/approval_hash/authorization/cookie/token).
+_SENSITIVE_KEY_RE = re.compile(
+    r"(token|authorization|cookie|secret|credential|password|passwd|"
+    r"api[_-]?key|app[_-]?key|approval|account[_-]?no)",
+    re.IGNORECASE,
+)
+_REDACTED = "[REDACTED]"
+
+
+def _redact_evidence(payload: Any) -> Any:
+    """Recursively redact sensitive keys from a mapping/list (non-mutating).
+
+    Returns a fresh structure; the original object is never modified. Only keys
+    are matched — scalar values under non-sensitive keys (order id, result code,
+    message) are preserved verbatim for diagnostics.
+    """
+    if isinstance(payload, Mapping):
+        return {
+            k: _REDACTED
+            if isinstance(k, str) and _SENSITIVE_KEY_RE.search(k)
+            else _redact_evidence(v)
+            for k, v in payload.items()
+        }
+    if isinstance(payload, (list, tuple)):
+        return [_redact_evidence(item) for item in payload]
+    return payload
+
 
 KIS_MOCK_SHADOW_PENDING_SOURCE = "kis_mock_ledger_shadow"
 KIS_MOCK_SHADOW_PENDING_CONFIDENCE = "db_shadow_pending"
@@ -269,6 +301,7 @@ async def _save_kis_mock_order_ledger(
     exit_reason: str | None = None,
     gross_pnl: Decimal | None = None,
     net_pnl: Decimal | None = None,
+    reconciled_at: Any | None = None,
     report_item_uuid: uuid.UUID | None = None,
     mirror_cohort: str | None = None,
     mirror_source_bucket: str | None = None,
@@ -278,6 +311,11 @@ async def _save_kis_mock_order_ledger(
     Returns the new primary-key id, or None on conflict / error.
     """
     resolved_lifecycle = lifecycle_state or _status_to_lifecycle_state(status)
+    # ROB-843: a row inserted directly as ``reconciled`` (e.g. a scalping exit
+    # close) must carry an authoritative ``reconciled_at`` so cooldown can key
+    # off the real close time; the reconciler sets it on job-driven transitions.
+    if reconciled_at is None and resolved_lifecycle == "reconciled":
+        reconciled_at = now_kst()
     try:
         async with _order_session_factory()() as db:
             stmt = (
@@ -313,6 +351,7 @@ async def _save_kis_mock_order_ledger(
                     exit_reason=exit_reason,
                     gross_pnl=gross_pnl,
                     net_pnl=net_pnl,
+                    reconciled_at=reconciled_at,
                     report_item_uuid=report_item_uuid,
                     mirror_cohort=mirror_cohort,
                     mirror_source_bucket=mirror_source_bucket,
@@ -365,7 +404,10 @@ async def _record_kis_mock_order(
     else:
         raw_exec = {"_malformed": str(execution_result)[:500]}
 
-    order_no = raw_exec.get("odno") or raw_exec.get("ord_no")
+    # ROB-843: normalize the broker order id (strip; reject blank/whitespace/
+    # malformed) so "   " is never treated as an accepted order. Domestic and
+    # overseas results share this helper.
+    order_no = normalize_broker_order_id(raw_exec.get("odno") or raw_exec.get("ord_no"))
     order_time = raw_exec.get("ord_tmd")
     raw_output = raw_exec.get("output") or {}
     krx_orgno = raw_exec.get("krx_fwdg_ord_orgno") or (
@@ -377,9 +419,9 @@ async def _record_kis_mock_order(
     msg = raw_exec.get("msg") or raw_exec.get("msg1")
 
     # Accepted success REQUIRES all of: a mapping payload, provider success
-    # status (rt_cd == "0"), and a non-empty broker order ID. Anything else is
-    # rejected (provider error code) or unknown (id-less / malformed / no code).
-    accepted = is_mapping and rt_cd == "0" and bool(order_no)
+    # status (rt_cd == "0"), and a valid (non-blank) broker order ID. Anything
+    # else is rejected (provider error code) or unknown (id-less / malformed).
+    accepted = is_mapping and rt_cd == "0" and order_no is not None
     if accepted:
         status = "accepted"
     elif is_mapping and rt_cd and rt_cd != "0":
@@ -418,6 +460,11 @@ async def _record_kis_mock_order(
             rung=0,
         )
 
+    # ROB-843: redact sensitive keys from the raw broker evidence before it is
+    # persisted or returned. Recursive, non-mutating; non-sensitive diagnostics
+    # (order id / result code / message) are preserved.
+    redacted_exec = _redact_evidence(raw_exec)
+
     ledger_id = await _save_kis_mock_order_ledger(
         symbol=normalized_symbol,
         instrument_type=market_type,
@@ -427,13 +474,13 @@ async def _record_kis_mock_order(
         price=price_val,
         amount=amt_val,
         currency=currency,
-        order_no=str(order_no) if order_no else None,
+        order_no=order_no,
         order_time=order_time,
         krx_fwdg_ord_orgno=krx_orgno,
         status=status,
         response_code=rt_cd,
         response_message=msg,
-        raw_response=raw_exec,
+        raw_response=redacted_exec,
         reason=reason,
         thesis=thesis,
         strategy=strategy,
@@ -470,12 +517,12 @@ async def _record_kis_mock_order(
         "success": accepted,
         "dry_run": False,
         "preview": dry_run_result,
-        "execution": execution_result,
+        "execution": redacted_exec,
         "account_mode": "kis_mock",
         "broker": "kis",
         "ledger_id": ledger_id,
-        "order_no": str(order_no) if order_no else None,
-        "odno": str(order_no) if order_no else None,
+        "order_no": order_no,
+        "odno": order_no,
         "order_time": order_time,
         "ord_tmd": order_time,
         "krx_fwdg_ord_orgno": krx_orgno,

--- a/app/mcp_server/tooling/kis_mock_ledger.py
+++ b/app/mcp_server/tooling/kis_mock_ledger.py
@@ -9,6 +9,7 @@ from decimal import Decimal, InvalidOperation
 from typing import Any
 from typing import cast as typing_cast
 
+from sqlalchemy import func, select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
@@ -19,6 +20,10 @@ from app.jobs.kis_mock_reconciliation_job import run_kis_mock_reconciliation
 from app.mcp_server.tooling.shared import logger
 from app.mcp_server.tooling.shared import to_float as _to_float
 from app.models.review import KISMockOrderLedger
+from app.services.brokers.kis.mock_scalping_exec.tracking_state import (
+    LedgerWriteError,
+    mark_ledger_tracking_unavailable,
+)
 from app.services.brokers.kis.order_id import normalize_broker_order_id
 from app.services.kis_mock_lifecycle_service import KISMockLifecycleService
 from app.services.live_correlation import live_correlation_id
@@ -305,10 +310,14 @@ async def _save_kis_mock_order_ledger(
     report_item_uuid: uuid.UUID | None = None,
     mirror_cohort: str | None = None,
     mirror_source_bucket: str | None = None,
+    raise_on_error: bool = False,
 ) -> int | None:
     """Insert one row into review.kis_mock_order_ledger.
 
-    Returns the new primary-key id, or None on conflict / error.
+    Returns the new primary-key id, or None on a benign on-conflict no-op. When
+    ``raise_on_error`` is set, a real DB error raises ``LedgerWriteError`` so the
+    caller can distinguish a conflict (row already durable) from a lost write
+    (ROB-843 P1-2); otherwise a DB error is swallowed and returns None (legacy).
     """
     resolved_lifecycle = lifecycle_state or _status_to_lifecycle_state(status)
     # ROB-843: a row inserted directly as ``reconciled`` (e.g. a scalping exit
@@ -365,7 +374,73 @@ async def _save_kis_mock_order_ledger(
             return None
     except Exception as exc:
         logger.warning("Failed to save kis_mock order ledger row: %s", exc)
+        if raise_on_error:
+            raise LedgerWriteError(str(exc) or exc.__class__.__name__) from exc
         return None
+
+
+async def _native_row_exists(order_no: str | None) -> bool:
+    """True if a durable native (non-scalping) row exists for ``order_no``.
+
+    Used after an on-conflict no-op to confirm the existing row is durable
+    (ROB-843 P1-2) rather than treating the write as lost.
+    """
+    if not order_no:
+        return False
+    try:
+        async with _order_session_factory()() as db:
+            found = await db.scalar(
+                select(func.count())
+                .select_from(KISMockOrderLedger)
+                .where(
+                    func.trim(KISMockOrderLedger.order_no) == order_no.strip(),
+                    KISMockOrderLedger.scalping_role.is_(None),
+                )
+            )
+        return bool(found or 0)
+    except Exception as exc:  # noqa: BLE001 — lookup failure => not durable
+        logger.warning("native row lookup failed for order_no=%s: %s", order_no, exc)
+        return False
+
+
+async def _persist_tracking_fallback(
+    *,
+    correlation_id: str | None,
+    side: str,
+    normalized_symbol: str,
+    market_type: str,
+) -> int | None:
+    """Write a durable fallback evidence row (correlation_id + side) so the daily
+    broker-order count still counts a submitted order whose native row was lost.
+
+    Keyed on the same correlation_id the synthetic scalping fill/exit row uses,
+    so native/fallback/synthetic evidence for one order de-dup to a single count.
+    """
+    currency = "KRW" if market_type != "equity_us" else "USD"
+    return await _save_kis_mock_order_ledger(
+        symbol=normalized_symbol,
+        instrument_type=market_type,
+        side=side,
+        order_type="limit",
+        quantity=0.0,
+        price=0.0,
+        amount=0.0,
+        currency=currency,
+        order_no=None,
+        order_time=None,
+        krx_fwdg_ord_orgno=None,
+        status="unknown",
+        response_code=None,
+        response_message="native ledger write lost; tracking fallback",
+        raw_response=None,
+        reason="ledger_tracking_fallback",
+        thesis=None,
+        strategy=None,
+        notes=None,
+        lifecycle_state="anomaly",
+        correlation_id=correlation_id,
+        scalping_role="native_fallback",
+    )
 
 
 async def _record_kis_mock_order(
@@ -465,33 +540,61 @@ async def _record_kis_mock_order(
     # (order id / result code / message) are preserved.
     redacted_exec = _redact_evidence(raw_exec)
 
-    ledger_id = await _save_kis_mock_order_ledger(
-        symbol=normalized_symbol,
-        instrument_type=market_type,
-        side=side,
-        order_type=order_type,
-        quantity=qty_val,
-        price=price_val,
-        amount=amt_val,
-        currency=currency,
-        order_no=order_no,
-        order_time=order_time,
-        krx_fwdg_ord_orgno=krx_orgno,
-        status=status,
-        response_code=rt_cd,
-        response_message=msg,
-        raw_response=redacted_exec,
-        reason=reason,
-        thesis=thesis,
-        strategy=strategy,
-        notes=notes,
-        lifecycle_state=_status_to_lifecycle_state(status),
-        holdings_baseline_qty=holdings_baseline_qty,
-        correlation_id=correlation_id,
-        report_item_uuid=report_item_uuid,
-        mirror_cohort=mirror_cohort,
-        mirror_source_bucket=mirror_source_bucket,
-    )
+    # ROB-843 P1-2: distinguish a benign on-conflict no-op from a lost write. A
+    # lost native write must not silently drop the order from the daily count —
+    # fall back to a durable evidence row, and if that also fails, degrade
+    # tracking so subsequent automated orders fail closed.
+    ledger_tracking_unavailable = False
+    try:
+        ledger_id = await _save_kis_mock_order_ledger(
+            symbol=normalized_symbol,
+            instrument_type=market_type,
+            side=side,
+            order_type=order_type,
+            quantity=qty_val,
+            price=price_val,
+            amount=amt_val,
+            currency=currency,
+            order_no=order_no,
+            order_time=order_time,
+            krx_fwdg_ord_orgno=krx_orgno,
+            status=status,
+            response_code=rt_cd,
+            response_message=msg,
+            raw_response=redacted_exec,
+            reason=reason,
+            thesis=thesis,
+            strategy=strategy,
+            notes=notes,
+            lifecycle_state=_status_to_lifecycle_state(status),
+            holdings_baseline_qty=holdings_baseline_qty,
+            correlation_id=correlation_id,
+            report_item_uuid=report_item_uuid,
+            mirror_cohort=mirror_cohort,
+            mirror_source_bucket=mirror_source_bucket,
+            raise_on_error=True,
+        )
+    except LedgerWriteError as exc:
+        logger.warning(
+            "native kis_mock ledger write lost (symbol=%s order_no=%s): %s",
+            normalized_symbol,
+            order_no,
+            exc,
+        )
+        ledger_id = None
+
+    if accepted:
+        native_durable = ledger_id is not None or await _native_row_exists(order_no)
+        if not native_durable:
+            fallback_id = await _persist_tracking_fallback(
+                correlation_id=correlation_id,
+                side=side,
+                normalized_symbol=normalized_symbol,
+                market_type=market_type,
+            )
+            if fallback_id is None:
+                ledger_tracking_unavailable = True
+                mark_ledger_tracking_unavailable()
 
     # ROB-730: emit the place-time forecast only for accepted orders (mirrors
     # kis_live). publish_place_time_forecast is itself buy+target-gated and runs
@@ -534,6 +637,9 @@ async def _record_kis_mock_order(
         "correlation_id": correlation_id,
         "fill_recorded": False,
         "journal_created": False,
+        # ROB-843 P1-2: broker success is preserved; this flags that durable
+        # bookkeeping was lost so the caller can fail-close the NEXT order.
+        "ledger_tracking_unavailable": ledger_tracking_unavailable,
         "message": (_accepted_or_failed_message(accepted, status, ledger_id)),
     }
 

--- a/app/mcp_server/tooling/order_execution.py
+++ b/app/mcp_server/tooling/order_execution.py
@@ -56,6 +56,7 @@ from app.mcp_server.tooling.shared import (
     to_float as _to_float,
 )
 from app.services.brokers.kis import KISClient
+from app.services.brokers.kis.pre_send import PreSendFreshnessError
 from app.services.crypto_trade_cooldown_service import CryptoTradeCooldownService
 from app.services.order_send_intent_service import (
     DuplicateOrderIntent,
@@ -139,6 +140,7 @@ async def _execute_order(
     market_type: str,
     is_mock: bool = False,
     identifier: str | None = None,
+    pre_send_hook: Callable[[], Awaitable[None]] | None = None,
 ) -> dict[str, Any]:
     if market_type == "crypto":
         if is_mock:
@@ -148,9 +150,17 @@ async def _execute_order(
         )
     if market_type == "equity_kr":
         return await _execute_kr_order(
-            symbol, side, order_type, quantity, price, is_mock=is_mock
+            symbol,
+            side,
+            order_type,
+            quantity,
+            price,
+            is_mock=is_mock,
+            pre_send_hook=pre_send_hook,
         )
-    return await _execute_us_order(symbol, side, quantity, price, is_mock=is_mock)
+    return await _execute_us_order(
+        symbol, side, quantity, price, is_mock=is_mock, pre_send_hook=pre_send_hook
+    )
 
 
 async def _execute_crypto_order(
@@ -197,6 +207,7 @@ async def _execute_kr_order(
     quantity: float | None,
     price: float | None,
     is_mock: bool = False,
+    pre_send_hook: Callable[[], Awaitable[None]] | None = None,
 ) -> dict[str, Any]:
     kis = _create_kis_client(is_mock=is_mock)
     stock_code = symbol
@@ -226,6 +237,9 @@ async def _execute_kr_order(
                 tick_size,
             )
 
+    # ROB-843 P1: only thread the hook when present (mock scalping). The live /
+    # normal path passes no callback at all → byte-for-byte identical behavior.
+    hook_kw = {"pre_send_hook": pre_send_hook} if pre_send_hook is not None else {}
     if side == "buy":
         result = await _call_kis(
             kis.order_korea_stock,
@@ -234,6 +248,7 @@ async def _execute_kr_order(
             quantity=order_quantity,
             price=order_price,
             is_mock=is_mock,
+            **hook_kw,
         )
     else:
         result = await _call_kis(
@@ -243,6 +258,7 @@ async def _execute_kr_order(
             quantity=order_quantity,
             price=order_price,
             is_mock=is_mock,
+            **hook_kw,
         )
 
     if original_price is not None and order_price != original_price:
@@ -258,10 +274,13 @@ async def _execute_us_order(
     quantity: float | None,
     price: float | None,
     is_mock: bool = False,
+    pre_send_hook: Callable[[], Awaitable[None]] | None = None,
 ) -> dict[str, Any]:
     kis = _create_kis_client(is_mock=is_mock)
     exchange_code = await get_us_exchange_by_symbol(symbol)
 
+    # ROB-843 P1: pass the hook only when present (live/normal path unchanged).
+    hook_kw = {"pre_send_hook": pre_send_hook} if pre_send_hook is not None else {}
     if side == "buy":
         return await _call_kis(
             kis.buy_overseas_stock,
@@ -270,6 +289,7 @@ async def _execute_us_order(
             quantity=int(quantity) if quantity else 0,
             price=price if price else 0.0,
             is_mock=is_mock,
+            **hook_kw,
         )
     return await _call_kis(
         kis.sell_overseas_stock,
@@ -278,6 +298,7 @@ async def _execute_us_order(
         quantity=int(quantity) if quantity else 0,
         price=price if price else 0.0,
         is_mock=is_mock,
+        **hook_kw,
     )
 
 
@@ -829,33 +850,12 @@ async def _execute_and_record(
             return True
         return False
 
-    # ROB-843 P1-1: final pre-send freshness re-check, invoked immediately
-    # before the real broker POST (after baseline/preflight). KIS-mock-scalping
-    # only — live callers pass no hook, so live behavior is unchanged. On a
-    # freshness violation the POST is skipped entirely (zero broker calls) and a
-    # structured pre_send_blocked result is returned.
-    if pre_send_hook is not None:
-        try:
-            await pre_send_hook()
-        except Exception as hook_exc:  # noqa: BLE001 — abort the send, never POST
-            reason_codes = list(getattr(hook_exc, "reason_codes", ()) or ())
-            logger.info(
-                "pre-send freshness block symbol=%s side=%s reasons=%s",
-                normalized_symbol,
-                side,
-                reason_codes,
-            )
-            await _release_reserved_mock_mirror_intent_after_send_failure(hook_exc)
-            return {
-                "success": False,
-                "pre_send_blocked": True,
-                "reason_codes": reason_codes,
-                "detail": f"{type(hook_exc).__name__}: {hook_exc}"[:200],
-                "account_mode": "kis_mock" if is_mock else market_type,
-                "dry_run": False,
-            }
-
     try:
+        # ROB-843 P1: the pre_send_hook (KIS-mock-scalping only) is threaded all
+        # the way into the transport and fired immediately before EACH real HTTP
+        # mutation (including token-refresh/retry re-sends), so a book that went
+        # stale during token/limiter/client/NXT preflight blocks the POST with
+        # zero broker calls. Live callers pass no hook → identical behavior.
         execution_result = await _execute_order(
             symbol=normalized_symbol,
             side=side,
@@ -865,7 +865,24 @@ async def _execute_and_record(
             market_type=market_type,
             is_mock=is_mock,
             identifier=idempotency_key if market_type == "crypto" else None,
+            pre_send_hook=pre_send_hook,
         )
+    except PreSendFreshnessError as fresh_exc:
+        await _release_reserved_mock_mirror_intent_after_send_failure(fresh_exc)
+        logger.info(
+            "pre-send freshness block symbol=%s side=%s reasons=%s",
+            normalized_symbol,
+            side,
+            list(fresh_exc.reason_codes),
+        )
+        return {
+            "success": False,
+            "pre_send_blocked": True,
+            "reason_codes": list(fresh_exc.reason_codes),
+            "detail": f"{type(fresh_exc).__name__}: {fresh_exc}"[:200],
+            "account_mode": "kis_mock" if is_mock else market_type,
+            "dry_run": False,
+        }
     except httpx.RequestError as send_exc:
         retry_allowed = await _release_reserved_mock_mirror_intent_after_send_failure(
             send_exc

--- a/app/mcp_server/tooling/order_execution.py
+++ b/app/mcp_server/tooling/order_execution.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import datetime
 import uuid
+from collections.abc import Awaitable, Callable
 from datetime import timedelta
 from decimal import Decimal
 from typing import Any, Literal
@@ -723,6 +724,7 @@ async def _execute_and_record(
     idempotency_key: str | None = None,
     mirror_cohort: str | None = None,
     mirror_source_bucket: str | None = None,
+    pre_send_hook: Callable[[], Awaitable[None]] | None = None,
 ) -> dict[str, Any]:
     """Execute a live order, record history, fills, and journals."""
     # ROB-102: capture pre-order KIS mock holdings as the reconciler baseline.
@@ -826,6 +828,32 @@ async def _execute_and_record(
             )
             return True
         return False
+
+    # ROB-843 P1-1: final pre-send freshness re-check, invoked immediately
+    # before the real broker POST (after baseline/preflight). KIS-mock-scalping
+    # only — live callers pass no hook, so live behavior is unchanged. On a
+    # freshness violation the POST is skipped entirely (zero broker calls) and a
+    # structured pre_send_blocked result is returned.
+    if pre_send_hook is not None:
+        try:
+            await pre_send_hook()
+        except Exception as hook_exc:  # noqa: BLE001 — abort the send, never POST
+            reason_codes = list(getattr(hook_exc, "reason_codes", ()) or ())
+            logger.info(
+                "pre-send freshness block symbol=%s side=%s reasons=%s",
+                normalized_symbol,
+                side,
+                reason_codes,
+            )
+            await _release_reserved_mock_mirror_intent_after_send_failure(hook_exc)
+            return {
+                "success": False,
+                "pre_send_blocked": True,
+                "reason_codes": reason_codes,
+                "detail": f"{type(hook_exc).__name__}: {hook_exc}"[:200],
+                "account_mode": "kis_mock" if is_mock else market_type,
+                "dry_run": False,
+            }
 
     try:
         execution_result = await _execute_order(
@@ -1217,6 +1245,7 @@ async def _place_order_impl(
     mirror_cohort: str | None = None,
     mirror_source_bucket: str | None = None,
     client_order_id: str | None = None,
+    pre_send_hook: Callable[[], Awaitable[None]] | None = None,
 ) -> dict[str, Any]:
     symbol, side_lower, order_type_lower = _validate_inputs(
         symbol,
@@ -1556,6 +1585,7 @@ async def _place_order_impl(
             idempotency_key=idempotency_key,
             mirror_cohort=mirror_cohort,
             mirror_source_bucket=mirror_source_bucket,
+            pre_send_hook=pre_send_hook,
         )
     except Exception as exc:
         logger.exception(

--- a/app/mcp_server/tooling/order_execution.py
+++ b/app/mcp_server/tooling/order_execution.py
@@ -57,6 +57,7 @@ from app.mcp_server.tooling.shared import (
 )
 from app.services.brokers.kis import KISClient
 from app.services.brokers.kis.pre_send import PreSendFreshnessError
+from app.services.brokers.kis.send_outcome import OrderSendOutcomeTracker
 from app.services.crypto_trade_cooldown_service import CryptoTradeCooldownService
 from app.services.order_send_intent_service import (
     DuplicateOrderIntent,
@@ -141,6 +142,7 @@ async def _execute_order(
     is_mock: bool = False,
     identifier: str | None = None,
     pre_send_hook: Callable[[], Awaitable[None]] | None = None,
+    send_outcome: OrderSendOutcomeTracker | None = None,
 ) -> dict[str, Any]:
     if market_type == "crypto":
         if is_mock:
@@ -157,6 +159,7 @@ async def _execute_order(
             price,
             is_mock=is_mock,
             pre_send_hook=pre_send_hook,
+            send_outcome=send_outcome,
         )
     return await _execute_us_order(
         symbol, side, quantity, price, is_mock=is_mock, pre_send_hook=pre_send_hook
@@ -208,6 +211,7 @@ async def _execute_kr_order(
     price: float | None,
     is_mock: bool = False,
     pre_send_hook: Callable[[], Awaitable[None]] | None = None,
+    send_outcome: OrderSendOutcomeTracker | None = None,
 ) -> dict[str, Any]:
     kis = _create_kis_client(is_mock=is_mock)
     stock_code = symbol
@@ -240,6 +244,8 @@ async def _execute_kr_order(
     # ROB-843 P1: only thread the hook when present (mock scalping). The live /
     # normal path passes no callback at all → byte-for-byte identical behavior.
     hook_kw = {"pre_send_hook": pre_send_hook} if pre_send_hook is not None else {}
+    if send_outcome is not None:
+        hook_kw["send_outcome"] = send_outcome
     if side == "buy":
         result = await _call_kis(
             kis.order_korea_stock,
@@ -746,6 +752,7 @@ async def _execute_and_record(
     mirror_cohort: str | None = None,
     mirror_source_bucket: str | None = None,
     pre_send_hook: Callable[[], Awaitable[None]] | None = None,
+    send_outcome: OrderSendOutcomeTracker | None = None,
 ) -> dict[str, Any]:
     """Execute a live order, record history, fills, and journals."""
     # ROB-102: capture pre-order KIS mock holdings as the reconciler baseline.
@@ -866,7 +873,12 @@ async def _execute_and_record(
             is_mock=is_mock,
             identifier=idempotency_key if market_type == "crypto" else None,
             pre_send_hook=pre_send_hook,
+            send_outcome=send_outcome,
         )
+        if send_outcome is not None:
+            # A transport response crossed the send boundary. Until the mock
+            # result normalizer proves accepted/rejected, the outcome is unknown.
+            send_outcome.mark_unknown()
     except PreSendFreshnessError as fresh_exc:
         await _release_reserved_mock_mirror_intent_after_send_failure(fresh_exc)
         logger.info(
@@ -884,6 +896,8 @@ async def _execute_and_record(
             "dry_run": False,
         }
     except httpx.RequestError as send_exc:
+        if send_outcome is not None:
+            send_outcome.mark_unknown()
         retry_allowed = await _release_reserved_mock_mirror_intent_after_send_failure(
             send_exc
         )
@@ -943,7 +957,7 @@ async def _execute_and_record(
     if is_mock:
         from app.mcp_server.tooling.kis_mock_ledger import _record_kis_mock_order
 
-        return await _record_kis_mock_order(
+        result = await _record_kis_mock_order(
             normalized_symbol=normalized_symbol,
             market_type=market_type,
             side=side,
@@ -962,6 +976,14 @@ async def _execute_and_record(
             mirror_cohort=mirror_cohort,
             mirror_source_bucket=mirror_source_bucket,
         )
+        if send_outcome is not None:
+            if result.get("success"):
+                send_outcome.mark_accepted()
+            elif result.get("reason") == "broker_rejected":
+                send_outcome.mark_provider_rejected()
+            else:
+                send_outcome.mark_unknown()
+        return result
 
     # ROB-395: live KR orders record accepted-only to the live ledger; fills,
     # journals, and realized_pnl are applied later by kis_live_reconcile_orders
@@ -1263,6 +1285,7 @@ async def _place_order_impl(
     mirror_source_bucket: str | None = None,
     client_order_id: str | None = None,
     pre_send_hook: Callable[[], Awaitable[None]] | None = None,
+    send_outcome: OrderSendOutcomeTracker | None = None,
 ) -> dict[str, Any]:
     symbol, side_lower, order_type_lower = _validate_inputs(
         symbol,
@@ -1603,6 +1626,7 @@ async def _place_order_impl(
             mirror_cohort=mirror_cohort,
             mirror_source_bucket=mirror_source_bucket,
             pre_send_hook=pre_send_hook,
+            send_outcome=send_outcome,
         )
     except Exception as exc:
         logger.exception(

--- a/app/mcp_server/tooling/order_execution.py
+++ b/app/mcp_server/tooling/order_execution.py
@@ -57,7 +57,10 @@ from app.mcp_server.tooling.shared import (
 )
 from app.services.brokers.kis import KISClient
 from app.services.brokers.kis.pre_send import PreSendFreshnessError
-from app.services.brokers.kis.send_outcome import OrderSendOutcomeTracker
+from app.services.brokers.kis.send_outcome import (
+    OrderSendDisposition,
+    OrderSendOutcomeTracker,
+)
 from app.services.crypto_trade_cooldown_service import CryptoTradeCooldownService
 from app.services.order_send_intent_service import (
     DuplicateOrderIntent,
@@ -896,11 +899,25 @@ async def _execute_and_record(
             "dry_run": False,
         }
     except httpx.RequestError as send_exc:
-        if send_outcome is not None:
-            send_outcome.mark_unknown()
+        # Preserve the transport boundary's explicit state: token/client setup
+        # can raise before dispatch (NOT_CREATED), while an actual send marks
+        # UNKNOWN immediately before crossing the HTTP boundary.
         retry_allowed = await _release_reserved_mock_mirror_intent_after_send_failure(
             send_exc
         )
+        if (
+            send_outcome is not None
+            and send_outcome.disposition is OrderSendDisposition.NOT_CREATED
+        ):
+            logger.error(
+                "execute_order failed before dispatch: market_type=%s, "
+                "symbol=%s, side=%s, error=%s",
+                market_type,
+                normalized_symbol,
+                side,
+                describe_exception(send_exc),
+            )
+            raise OrderSendNotCreated(send_exc) from send_exc
         # ROB-645: the order POST itself timed out / failed with no broker response.
         # Outcome is UNKNOWN for live orders (may have been accepted) — never re-send live; reconcile.
         # ROB-750: mock mirror has no live broker risk, so its scoped intent is released for retry.
@@ -933,6 +950,17 @@ async def _execute_and_record(
             exec_exc,
         )
         raise
+
+    if send_outcome is not None and send_outcome.has_untrusted_server_error_response:
+        # KIS sometimes carries a success-shaped provider body with HTTP 5xx.
+        # It is not accepted evidence: do not write an accepted ledger row or
+        # let the round trip advance before explicit reconciliation.
+        raise OrderSendOutcomeUnknown(
+            RuntimeError(
+                "KIS order response outcome unknown after HTTP "
+                f"{send_outcome.last_http_status}"
+            )
+        )
 
     await _record_order_history(
         symbol=normalized_symbol,
@@ -1192,6 +1220,14 @@ class OrderSendOutcomeUnknown(Exception):
         self.retry_hint = retry_hint
 
 
+class OrderSendNotCreated(Exception):
+    """A transport setup failed before the order crossed the HTTP boundary."""
+
+    def __init__(self, original: BaseException) -> None:
+        super().__init__(describe_exception(original))
+        self.original = original
+
+
 # ROB-645: reconcile tool to consult when an order's send outcome is unknown.
 # Only live paths have a reconcile tool (KR → kis_live_reconcile_orders,
 # US/crypto → live_reconcile_orders). Mock has none, so we never name a phantom.
@@ -1225,6 +1261,14 @@ def _augment_error_for_unknown_outcome(
     outcome-unknown failure (a definitive rejection, or a pre-send read timeout)
     is left unchanged: no order was created.
     """
+    if isinstance(exc, OrderSendNotCreated):
+        enriched = dict(base_error)
+        enriched["retry_allowed"] = True
+        enriched["error"] = (
+            "주문 전송 전 실패: "
+            f"{describe_exception(exc.original)}. 주문이 생성되지 않아 재시도할 수 있습니다."
+        )
+        return enriched
     if not isinstance(exc, OrderSendOutcomeUnknown):
         return base_error
 

--- a/app/services/brokers/kis/base.py
+++ b/app/services/brokers/kis/base.py
@@ -23,6 +23,7 @@ from app.services.brokers.kis.circuit_breaker import (
     is_kis_connect_failure,
 )
 from app.services.brokers.kis.pre_send import PreSendFreshnessError, PreSendHook
+from app.services.brokers.kis.send_outcome import OrderSendOutcomeTracker
 from app.services.redis_token_manager import redis_token_manager
 
 
@@ -419,6 +420,7 @@ class BaseKISClient:
         retry_request_errors: bool = True,
         max_retries_override: int | None = None,
         pre_send_hook: PreSendHook | None = None,
+        send_outcome: OrderSendOutcomeTracker | None = None,
     ) -> dict[str, Any]:
         """Make HTTP request with rate limiting and 429 retry logic.
 
@@ -456,6 +458,7 @@ class BaseKISClient:
             retry_request_errors=retry_request_errors,
             max_retries_override=max_retries_override,
             pre_send_hook=pre_send_hook,
+            send_outcome=send_outcome,
         )
         return data
 
@@ -473,6 +476,7 @@ class BaseKISClient:
         retry_request_errors: bool = True,
         max_retries_override: int | None = None,
         pre_send_hook: PreSendHook | None = None,
+        send_outcome: OrderSendOutcomeTracker | None = None,
     ) -> tuple[dict[str, Any], dict[str, str]]:
         """ROB-699 — breaker-guarded wrapper over the KIS dispatch.
 
@@ -495,6 +499,7 @@ class BaseKISClient:
                 retry_request_errors=retry_request_errors,
                 max_retries_override=max_retries_override,
                 pre_send_hook=pre_send_hook,
+                send_outcome=send_outcome,
             )
         except PreSendFreshnessError:
             # ROB-843 P1: a mock pre-send freshness block means NO HTTP happened —
@@ -523,6 +528,7 @@ class BaseKISClient:
         retry_request_errors: bool = True,
         max_retries_override: int | None = None,
         pre_send_hook: PreSendHook | None = None,
+        send_outcome: OrderSendOutcomeTracker | None = None,
     ) -> tuple[dict[str, Any], dict[str, str]]:
         """Like :meth:`_request_with_rate_limit` but also returns response headers.
 
@@ -569,6 +575,8 @@ class BaseKISClient:
                 # Error propagates cleanly (zero POST); live passes no hook.
                 if pre_send_hook is not None:
                     await pre_send_hook()
+                if send_outcome is not None:
+                    send_outcome.mark_dispatched()
                 response = await self._execute_http_request(
                     client,
                     method,
@@ -579,6 +587,8 @@ class BaseKISClient:
                     timeout=timeout,
                 )
                 status_code = _safe_status_code(response)
+                if send_outcome is not None:
+                    send_outcome.mark_http_response(status_code)
 
                 if status_code == 429:
                     retry_after = _safe_parse_retry_after(

--- a/app/services/brokers/kis/base.py
+++ b/app/services/brokers/kis/base.py
@@ -22,6 +22,7 @@ from app.services.brokers.kis.circuit_breaker import (
     get_kis_circuit_breaker,
     is_kis_connect_failure,
 )
+from app.services.brokers.kis.pre_send import PreSendFreshnessError, PreSendHook
 from app.services.redis_token_manager import redis_token_manager
 
 
@@ -417,6 +418,7 @@ class BaseKISClient:
         tr_id: str | None = None,
         retry_request_errors: bool = True,
         max_retries_override: int | None = None,
+        pre_send_hook: PreSendHook | None = None,
     ) -> dict[str, Any]:
         """Make HTTP request with rate limiting and 429 retry logic.
 
@@ -453,6 +455,7 @@ class BaseKISClient:
             tr_id=tr_id,
             retry_request_errors=retry_request_errors,
             max_retries_override=max_retries_override,
+            pre_send_hook=pre_send_hook,
         )
         return data
 
@@ -469,6 +472,7 @@ class BaseKISClient:
         tr_id: str | None = None,
         retry_request_errors: bool = True,
         max_retries_override: int | None = None,
+        pre_send_hook: PreSendHook | None = None,
     ) -> tuple[dict[str, Any], dict[str, str]]:
         """ROB-699 — breaker-guarded wrapper over the KIS dispatch.
 
@@ -490,7 +494,12 @@ class BaseKISClient:
                 tr_id=tr_id,
                 retry_request_errors=retry_request_errors,
                 max_retries_override=max_retries_override,
+                pre_send_hook=pre_send_hook,
             )
+        except PreSendFreshnessError:
+            # ROB-843 P1: a mock pre-send freshness block means NO HTTP happened —
+            # it is not a KIS reachability signal, so it must not move the breaker.
+            raise
         except BaseException as exc:  # noqa: BLE001 — classify then re-raise unchanged
             if is_kis_connect_failure(exc):
                 breaker.record_failure()
@@ -513,6 +522,7 @@ class BaseKISClient:
         tr_id: str | None = None,
         retry_request_errors: bool = True,
         max_retries_override: int | None = None,
+        pre_send_hook: PreSendHook | None = None,
     ) -> tuple[dict[str, Any], dict[str, str]]:
         """Like :meth:`_request_with_rate_limit` but also returns response headers.
 
@@ -552,6 +562,13 @@ class BaseKISClient:
 
             try:
                 client = await self._ensure_client(timeout=timeout)
+                # ROB-843 P1: the actual HTTP send boundary. Re-check freshness
+                # here — after token/limiter/client prep and rate-limit wait, and
+                # on EVERY retry/re-send — so a mock scalping BUY never POSTs on a
+                # book that went stale/crossed during those awaits. PreSendFreshness
+                # Error propagates cleanly (zero POST); live passes no hook.
+                if pre_send_hook is not None:
+                    await pre_send_hook()
                 response = await self._execute_http_request(
                     client,
                     method,

--- a/app/services/brokers/kis/client.py
+++ b/app/services/brokers/kis/client.py
@@ -9,6 +9,7 @@ from pandas import DataFrame
 
 from app.core.async_rate_limiter import get_limiter
 from app.core.config import settings
+from app.services.brokers.kis.pre_send import PreSendHook
 from app.services.redis_token_manager import get_kis_mock_token_manager
 
 from .account import AccountClient, extract_domestic_cash_summary_from_integrated_margin
@@ -374,9 +375,16 @@ class KISClient(BaseKISClient):
         quantity: int,
         price: int = 0,
         is_mock: bool = False,
+        *,
+        pre_send_hook: PreSendHook | None = None,
     ) -> dict[str, Any]:
         return await self._domestic_orders.order_korea_stock(
-            stock_code, order_type, quantity, price, is_mock
+            stock_code,
+            order_type,
+            quantity,
+            price,
+            is_mock,
+            pre_send_hook=pre_send_hook,
         )
 
     async def sell_korea_stock(
@@ -450,9 +458,17 @@ class KISClient(BaseKISClient):
         quantity: int,
         price: float = 0.0,
         is_mock: bool = False,
+        *,
+        pre_send_hook: PreSendHook | None = None,
     ) -> dict[str, Any]:
         return await self._overseas_orders.order_overseas_stock(
-            symbol, exchange_code, order_type, quantity, price, is_mock
+            symbol,
+            exchange_code,
+            order_type,
+            quantity,
+            price,
+            is_mock,
+            pre_send_hook=pre_send_hook,
         )
 
     async def buy_overseas_stock(
@@ -462,9 +478,11 @@ class KISClient(BaseKISClient):
         quantity: int,
         price: float = 0.0,
         is_mock: bool = False,
+        *,
+        pre_send_hook: PreSendHook | None = None,
     ) -> dict[str, Any]:
         return await self._overseas_orders.buy_overseas_stock(
-            symbol, exchange_code, quantity, price, is_mock
+            symbol, exchange_code, quantity, price, is_mock, pre_send_hook=pre_send_hook
         )
 
     async def sell_overseas_stock(
@@ -474,9 +492,11 @@ class KISClient(BaseKISClient):
         quantity: int,
         price: float = 0.0,
         is_mock: bool = False,
+        *,
+        pre_send_hook: PreSendHook | None = None,
     ) -> dict[str, Any]:
         return await self._overseas_orders.sell_overseas_stock(
-            symbol, exchange_code, quantity, price, is_mock
+            symbol, exchange_code, quantity, price, is_mock, pre_send_hook=pre_send_hook
         )
 
     async def inquire_overseas_orders(

--- a/app/services/brokers/kis/client.py
+++ b/app/services/brokers/kis/client.py
@@ -10,6 +10,7 @@ from pandas import DataFrame
 from app.core.async_rate_limiter import get_limiter
 from app.core.config import settings
 from app.services.brokers.kis.pre_send import PreSendHook
+from app.services.brokers.kis.send_outcome import OrderSendOutcomeTracker
 from app.services.redis_token_manager import get_kis_mock_token_manager
 
 from .account import AccountClient, extract_domestic_cash_summary_from_integrated_margin
@@ -377,6 +378,7 @@ class KISClient(BaseKISClient):
         is_mock: bool = False,
         *,
         pre_send_hook: PreSendHook | None = None,
+        send_outcome: OrderSendOutcomeTracker | None = None,
     ) -> dict[str, Any]:
         return await self._domestic_orders.order_korea_stock(
             stock_code,
@@ -385,6 +387,7 @@ class KISClient(BaseKISClient):
             price,
             is_mock,
             pre_send_hook=pre_send_hook,
+            send_outcome=send_outcome,
         )
 
     async def sell_korea_stock(

--- a/app/services/brokers/kis/domestic_orders.py
+++ b/app/services/brokers/kis/domestic_orders.py
@@ -382,6 +382,12 @@ class DomesticOrderClient:
             "odno": output.get("ODNO") or output.get("ORD_NO"),  # 주문번호
             "ord_tmd": output.get("ORD_TMD"),  # 주문시각
             "msg": js.get("msg1"),  # 응답메시지
+            # ROB-843: preserve the provider-verified accepted contract. This
+            # point is reached only when rt_cd == "0" (non-zero raised above);
+            # carrying it forward lets the kis_mock result boundary prove
+            # provider acceptance instead of inferring success from an ID alone.
+            "rt_cd": js.get("rt_cd"),
+            "msg_cd": js.get("msg_cd"),
         }
 
         logging.info(

--- a/app/services/brokers/kis/domestic_orders.py
+++ b/app/services/brokers/kis/domestic_orders.py
@@ -10,6 +10,7 @@ from app.services.kr_symbol_universe_service import is_nxt_eligible
 
 from . import constants
 from .base import _log_kis_api_failure
+from .pre_send import PreSendHook
 
 if TYPE_CHECKING:
     from .protocols import KISClientProtocol
@@ -236,6 +237,7 @@ class DomesticOrderClient:
         price: int = 0,  # 0이면 시장가
         is_mock: bool = False,
         *,
+        pre_send_hook: PreSendHook | None = None,
         _token_retry_depth: int = 0,
     ) -> dict:
         """
@@ -328,6 +330,9 @@ class DomesticOrderClient:
             # and 429 re-POSTs (throttle is pre-send wait only).
             retry_request_errors=False,
             max_retries_override=0,
+            # ROB-843 P1: mock-only freshness re-check fired at the actual HTTP
+            # send boundary (None for live → identical behavior).
+            pre_send_hook=pre_send_hook,
         )
 
         if js.get("rt_cd") != "0":
@@ -364,12 +369,15 @@ class DomesticOrderClient:
                 )
                 await self._parent._token_manager.clear_token()
                 await self._parent._ensure_token()
+                # ROB-843 P1: re-thread the hook so the token-refresh re-send
+                # re-checks freshness immediately before its own HTTP mutation.
                 return await self.order_korea_stock(
                     stock_code,
                     order_type,
                     quantity,
                     price,
                     is_mock,
+                    pre_send_hook=pre_send_hook,
                     _token_retry_depth=_token_retry_depth + 1,
                 )
 

--- a/app/services/brokers/kis/domestic_orders.py
+++ b/app/services/brokers/kis/domestic_orders.py
@@ -11,6 +11,7 @@ from app.services.kr_symbol_universe_service import is_nxt_eligible
 from . import constants
 from .base import _log_kis_api_failure
 from .pre_send import PreSendHook
+from .send_outcome import OrderSendOutcomeTracker
 
 if TYPE_CHECKING:
     from .protocols import KISClientProtocol
@@ -238,6 +239,7 @@ class DomesticOrderClient:
         is_mock: bool = False,
         *,
         pre_send_hook: PreSendHook | None = None,
+        send_outcome: OrderSendOutcomeTracker | None = None,
         _token_retry_depth: int = 0,
     ) -> dict:
         """
@@ -333,9 +335,12 @@ class DomesticOrderClient:
             # ROB-843 P1: mock-only freshness re-check fired at the actual HTTP
             # send boundary (None for live → identical behavior).
             pre_send_hook=pre_send_hook,
+            send_outcome=send_outcome,
         )
 
         if js.get("rt_cd") != "0":
+            if send_outcome is not None:
+                send_outcome.mark_provider_rejected()
             msg_cd = js.get("msg_cd", "")
             msg1 = js.get("msg1", "")
             _log_kis_api_failure(
@@ -378,6 +383,7 @@ class DomesticOrderClient:
                     price,
                     is_mock,
                     pre_send_hook=pre_send_hook,
+                    send_outcome=send_outcome,
                     _token_retry_depth=_token_retry_depth + 1,
                 )
 

--- a/app/services/brokers/kis/mock_scalping_exec/adapters.py
+++ b/app/services/brokers/kis/mock_scalping_exec/adapters.py
@@ -144,12 +144,15 @@ class KisMockBroker:
 
         return _hook
 
-    async def _safe_release_reservation(self, correlation_id: str) -> None:
+    async def _safe_release_reservation(self, correlation_id: str, side: str) -> None:
         try:
-            await release_entry(correlation_id=correlation_id)
+            await release_entry(correlation_id=correlation_id, side=side)
         except Exception as exc:  # noqa: BLE001 — a stale reservation is fail-safe
             logger.warning(
-                "scalping reservation release failed cid=%s: %s", correlation_id, exc
+                "scalping reservation release failed cid=%s side=%s: %s",
+                correlation_id,
+                side,
+                exc,
             )
 
     async def _submit_with_reservation(
@@ -197,17 +200,17 @@ class KisMockBroker:
             # Only an explicitly proven pre-send/definitive no-order exception
             # releases. Any post-dispatch exception leaves UNKNOWN and keeps it.
             if outcome.disposition is OrderSendDisposition.NOT_CREATED:
-                await self._safe_release_reservation(correlation_id)
+                await self._safe_release_reservation(correlation_id, side)
             raise
 
         if outcome.disposition is OrderSendDisposition.NOT_CREATED:
-            await self._safe_release_reservation(correlation_id)
+            await self._safe_release_reservation(correlation_id, side)
         elif outcome.disposition is OrderSendDisposition.ACCEPTED:
             tracked = bool(result.get("success")) and not result.get(
                 "ledger_tracking_unavailable"
             )
             if tracked:
-                await self._safe_release_reservation(correlation_id)
+                await self._safe_release_reservation(correlation_id, side)
         # UNKNOWN or accepted-but-untracked: KEEP until explicit reconciliation.
         return result
 

--- a/app/services/brokers/kis/mock_scalping_exec/adapters.py
+++ b/app/services/brokers/kis/mock_scalping_exec/adapters.py
@@ -30,7 +30,11 @@ from typing import Any
 
 from app.core.symbol import to_db_symbol
 from app.mcp_server.tooling.kis_mock_ledger import _save_kis_mock_order_ledger
-from app.mcp_server.tooling.order_execution import _create_kis_client, _place_order_impl
+from app.mcp_server.tooling.order_execution import (
+    OrderSendOutcomeUnknown,
+    _create_kis_client,
+    _place_order_impl,
+)
 from app.services.brokers.kis import KISClient
 from app.services.brokers.kis.mock_scalping.contract import (
     LedgerSnapshot,
@@ -58,11 +62,13 @@ from app.services.brokers.kis.mock_scalping_exec.ledger_state import (
     MockOrderHistory,
     load_kis_mock_order_history,
 )
-from app.services.brokers.kis.mock_scalping_exec.tracking_state import (
-    is_ledger_tracking_unavailable,
+from app.services.brokers.kis.mock_scalping_exec.reservation import (
+    release_entry,
+    reserve_entry,
 )
 from app.services.brokers.kis.mock_scalping_ws.state import MarketState
 from app.services.brokers.kis.pre_send import PreSendFreshnessError
+from app.services.order_send_intent_service import DuplicateOrderIntent
 
 logger = logging.getLogger("rob321.kis_mock_scalping_exec")
 
@@ -133,6 +139,14 @@ class KisMockBroker:
 
         return _hook
 
+    async def _safe_release_reservation(self, correlation_id: str) -> None:
+        try:
+            await release_entry(correlation_id=correlation_id)
+        except Exception as exc:  # noqa: BLE001 — a stale reservation is fail-safe
+            logger.warning(
+                "scalping reservation release failed cid=%s: %s", correlation_id, exc
+            )
+
     async def submit_buy(
         self,
         *,
@@ -151,24 +165,74 @@ class KisMockBroker:
             if confirm
             else None
         )
-        result = await _place_order_impl(
-            symbol=symbol,
-            side="buy",
-            market="kr",
-            order_type="limit",
-            quantity=float(quantity),
-            price=float(price),
-            dry_run=not confirm,
-            is_mock=True,
-            reason=f"scalp_entry:{correlation_id}",
-            strategy=self._strategy_id,
-            # Share the executor correlation_id so native + synthetic evidence
-            # link for the daily-count de-dup (ROB-843 P1-2).
-            correlation_id=correlation_id,
-            # Final freshness re-check right before the POST (entry only; an
-            # exit must always be allowed to close a live position).
-            pre_send_hook=self._make_pre_send_hook(symbol),
-        )
+        # ROB-843 P1: WRITE-AHEAD durable reservation, recorded BEFORE the POST.
+        # If this durable write cannot land, the broker POST must never happen
+        # (POST 0). An unresolved reservation is the durable in-flight/uncertain
+        # state that survives restart and fail-closes new orders until an
+        # explicit reconciliation releases it.
+        if confirm:
+            try:
+                await reserve_entry(
+                    correlation_id=correlation_id, symbol=symbol, side="buy"
+                )
+            except DuplicateOrderIntent:
+                return {
+                    "success": False,
+                    "reservation_blocked": True,
+                    "reason_codes": ["duplicate_send"],
+                    "detail": f"scalping entry already reserved: {correlation_id}",
+                    "dry_run": False,
+                }
+            except Exception as exc:  # noqa: BLE001 — durable write lost → POST 0
+                logger.warning("scalping reservation failed sym=%s: %s", symbol, exc)
+                return {
+                    "success": False,
+                    "reservation_blocked": True,
+                    "reason_codes": ["reservation_unavailable"],
+                    "detail": f"{type(exc).__name__}: {exc}"[:200],
+                    "dry_run": False,
+                }
+
+        try:
+            result = await _place_order_impl(
+                symbol=symbol,
+                side="buy",
+                market="kr",
+                order_type="limit",
+                quantity=float(quantity),
+                price=float(price),
+                dry_run=not confirm,
+                is_mock=True,
+                reason=f"scalp_entry:{correlation_id}",
+                strategy=self._strategy_id,
+                # Share the executor correlation_id so native + synthetic evidence
+                # link for the daily-count de-dup (ROB-843 P1-2).
+                correlation_id=correlation_id,
+                # Final freshness re-check right before the POST (entry only; an
+                # exit must always be allowed to close a live position).
+                pre_send_hook=self._make_pre_send_hook(symbol),
+            )
+        except OrderSendOutcomeUnknown:
+            # Uncertain send (timeout/network after the POST): KEEP the
+            # reservation so the order stays fail-closed until reconciliation.
+            raise
+        except Exception:
+            # Deterministic broker error before/at send (rejection, token cap,
+            # validation): no order was created — release the reservation.
+            if confirm:
+                await self._safe_release_reservation(correlation_id)
+            raise
+
+        if confirm:
+            tracked = bool(result.get("success")) and not result.get(
+                "ledger_tracking_unavailable"
+            )
+            if result.get("pre_send_blocked") or tracked:
+                # Certain no-order (POST 0) OR fully-tracked native row → release.
+                await self._safe_release_reservation(correlation_id)
+            # else: native write lost / unknown / malformed = uncertain → KEEP
+            # the reservation (durable fail-close until reconciliation).
+
         if isinstance(result, dict) and baseline is not None:
             result["_baseline"] = baseline
         return result
@@ -472,10 +536,9 @@ class KisMockRiskGate:
         return has_open, open_count
 
     async def load(self, *, symbol: str, side: Side) -> RiskInputs:
-        # ROB-843 P1-2: if a prior order's durable bookkeeping was lost, the
-        # daily count can no longer be trusted — fail-close the next order.
-        if is_ledger_tracking_unavailable():
-            raise RuntimeError("ledger_tracking_unavailable")
+        # ROB-843 P1: the durable fail-close (unresolved write-ahead reservation)
+        # is enforced inside the order-history load below, so it survives restart
+        # and a fresh gate instance.
         market = self._market(symbol)
         has_open, open_count = await self._position(symbol)
         history = await self._load_history(symbol=to_db_symbol(symbol))

--- a/app/services/brokers/kis/mock_scalping_exec/adapters.py
+++ b/app/services/brokers/kis/mock_scalping_exec/adapters.py
@@ -35,6 +35,8 @@ from app.services.brokers.kis import KISClient
 from app.services.brokers.kis.mock_scalping.contract import (
     LedgerSnapshot,
     MarketConditions,
+    ReasonCode,
+    ScalpingRiskLimits,
     Side,
 )
 from app.services.brokers.kis.mock_scalping_exec.executor import (
@@ -55,6 +57,9 @@ from app.services.brokers.kis.mock_scalping_exec.holdings_delta_confirm import (
 from app.services.brokers.kis.mock_scalping_exec.ledger_state import (
     MockOrderHistory,
     load_kis_mock_order_history,
+)
+from app.services.brokers.kis.mock_scalping_exec.tracking_state import (
+    is_ledger_tracking_unavailable,
 )
 from app.services.brokers.kis.mock_scalping_ws.state import MarketState
 
@@ -94,10 +99,38 @@ def _is_mock_unsupported(message: str) -> bool:
 class KisMockBroker:
     """BrokerPort over the KIS mock order path. Mock-only; confirm-gated HTTP."""
 
-    def __init__(self, *, get_state: StateProvider, strategy_id: str = "kis-mock-v1"):
+    def __init__(
+        self,
+        *,
+        get_state: StateProvider,
+        strategy_id: str = "kis-mock-v1",
+        limits: ScalpingRiskLimits | None = None,
+        clock: Callable[[], float] = time.monotonic,
+    ):
         self._get_state = get_state
         self._strategy_id = strategy_id
+        self._limits = limits or ScalpingRiskLimits()
+        self._clock = clock
         self._mock_client: KISClient | None = None
+
+    def _make_pre_send_hook(self, symbol: str):
+        """A pre-send freshness re-check bound to ``symbol`` (ROB-843 P1-1).
+
+        Invoked by ``_place_order_impl`` immediately before the real KIS POST —
+        after the risk gate's holdings/history awaits AND the broker's own
+        baseline/preflight awaits — so a book that went stale/crossed in between
+        blocks the send with ZERO POSTs.
+        """
+
+        async def _hook() -> None:
+            assert_market_fresh_for_send(
+                self._get_state(symbol),
+                now=self._clock(),
+                max_data_age_seconds=self._limits.max_data_age_seconds,
+                max_spread_bps=self._limits.max_spread_bps,
+            )
+
+        return _hook
 
     async def submit_buy(
         self,
@@ -128,6 +161,12 @@ class KisMockBroker:
             is_mock=True,
             reason=f"scalp_entry:{correlation_id}",
             strategy=self._strategy_id,
+            # Share the executor correlation_id so native + synthetic evidence
+            # link for the daily-count de-dup (ROB-843 P1-2).
+            correlation_id=correlation_id,
+            # Final freshness re-check right before the POST (entry only; an
+            # exit must always be allowed to close a live position).
+            pre_send_hook=self._make_pre_send_hook(symbol),
         )
         if isinstance(result, dict) and baseline is not None:
             result["_baseline"] = baseline
@@ -166,6 +205,9 @@ class KisMockBroker:
             scalping_exit=True,
             scalping_strategy_id=strategy_id,
             scalping_exit_reason=exit_reason,
+            # Link native + synthetic exit evidence (ROB-843 P1-2). No pre-send
+            # freshness gate on the exit: a live position must always be closable.
+            correlation_id=correlation_id,
         )
         if isinstance(result, dict) and baseline is not None:
             result["_baseline"] = baseline
@@ -319,6 +361,51 @@ def _is_finite_positive(x: float | None) -> bool:
     return x is not None and math.isfinite(x) and x > 0
 
 
+class PreSendFreshnessError(RuntimeError):
+    """Raised by the pre-send re-check when the live book is no longer tradeable
+    immediately before the broker POST (ROB-843 P1-1)."""
+
+    def __init__(self, reason_codes: tuple[str, ...]) -> None:
+        self.reason_codes = tuple(reason_codes)
+        super().__init__(",".join(self.reason_codes) or "pre_send_freshness")
+
+
+def assert_market_fresh_for_send(
+    state: MarketState | None,
+    *,
+    now: float,
+    max_data_age_seconds: float,
+    max_spread_bps: Decimal,
+) -> None:
+    """Re-validate the CURRENT live book immediately before the broker POST.
+
+    Raises :class:`PreSendFreshnessError` on a missing/stale/invalid quote so a
+    BUY that passed the earlier risk gate is not sent against a book that went
+    stale/crossed during the intervening holdings/history/baseline awaits.
+    """
+    if state is None:
+        raise PreSendFreshnessError(("no_market_state",))
+    book_age = state.book_age_seconds(now=now)
+    bid, ask = state.bid, state.ask
+    reasons: list[str] = []
+    if book_age is None or not math.isfinite(book_age) or book_age < 0:
+        reasons.append("invalid_book_timestamp")
+    elif book_age > max_data_age_seconds:
+        reasons.append(ReasonCode.STALE_DATA)
+    if not _is_finite_positive(bid) or not _is_finite_positive(ask):
+        reasons.append("invalid_quote")
+    elif ask < bid:
+        reasons.append("crossed_book")
+    else:
+        spread = state.spread_bps()
+        if spread is None or not math.isfinite(spread) or spread < 0:
+            reasons.append("invalid_spread")
+        elif Decimal(str(spread)) > max_spread_bps:
+            reasons.append(ReasonCode.SPREAD_TOO_WIDE)
+    if reasons:
+        raise PreSendFreshnessError(tuple(reasons))
+
+
 class KisMockRiskGate:
     """RiskGatePort: fresh position + market + order-history snapshot (ROB-843).
 
@@ -393,6 +480,10 @@ class KisMockRiskGate:
         return has_open, open_count
 
     async def load(self, *, symbol: str, side: Side) -> RiskInputs:
+        # ROB-843 P1-2: if a prior order's durable bookkeeping was lost, the
+        # daily count can no longer be trusted — fail-close the next order.
+        if is_ledger_tracking_unavailable():
+            raise RuntimeError("ledger_tracking_unavailable")
         market = self._market(symbol)
         has_open, open_count = await self._position(symbol)
         history = await self._load_history(symbol=to_db_symbol(symbol))

--- a/app/services/brokers/kis/mock_scalping_exec/adapters.py
+++ b/app/services/brokers/kis/mock_scalping_exec/adapters.py
@@ -22,8 +22,9 @@ from __future__ import annotations
 
 import datetime
 import logging
+import math
 import time
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Mapping
 from decimal import Decimal
 from typing import Any
 
@@ -52,14 +53,26 @@ from app.services.brokers.kis.mock_scalping_exec.holdings_delta_confirm import (
     confirm_fill_from_holdings_delta,
 )
 from app.services.brokers.kis.mock_scalping_exec.ledger_state import (
-    load_kis_mock_ledger_snapshot,
+    MockOrderHistory,
+    load_kis_mock_order_history,
 )
 from app.services.brokers.kis.mock_scalping_ws.state import MarketState
 
 logger = logging.getLogger("rob321.kis_mock_scalping_exec")
 
 StateProvider = Callable[[str], MarketState | None]
-LedgerSnapshotLoader = Callable[..., Awaitable[LedgerSnapshot]]
+OrderHistoryLoader = Callable[..., Awaitable[MockOrderHistory]]
+HoldingsProvider = Callable[[], Awaitable[Mapping[str, Any]]]
+
+
+async def _default_mock_holdings_snapshot() -> Mapping[str, Any]:
+    """Fresh KIS mock domestic balance snapshot ({holdings, cash}). Mock host only.
+
+    ``holdings`` is pre-filtered to ``hldg_qty > 0`` by the account reader, so
+    every entry is an actual position.
+    """
+    client = _create_kis_client(is_mock=True)
+    return await client.fetch_domestic_balance_snapshot(is_mock=True)
 
 
 def _to_decimal(value: Any) -> Decimal | None:
@@ -302,43 +315,96 @@ class KisMockBroker:
         )
 
 
-class KisMockRiskGate:
-    """RiskGatePort: fresh live-market + durable-ledger snapshot (ROB-843).
+def _is_finite_positive(x: float | None) -> bool:
+    return x is not None and math.isfinite(x) and x > 0
 
-    ``load`` raises on any missing/stale market field or ledger read fault so
-    the executor fail-closes to zero broker mutation. The market snapshot comes
-    from the live per-symbol ``MarketState`` (same source the broker reads); the
-    durable snapshot comes from ``review.kis_mock_order_ledger``.
+
+class KisMockRiskGate:
+    """RiskGatePort: fresh position + market + order-history snapshot (ROB-843).
+
+    ``load`` raises on any missing/stale/malformed market field, holdings read
+    fault, or order-history read fault so the executor fail-closes to zero
+    broker mutation. Sources:
+
+    * **Position** (has-open / open-count): a fresh KIS mock *holdings* snapshot
+      — the authoritative record of what is actually held. Order lifecycle rows
+      are NOT treated as positions (a filled buy later sold is flat).
+    * **Market** (spread / data age): the live per-symbol ``MarketState``.
+    * **Order history** (daily count / realized loss / cooldown): the mock
+      order ledger.
     """
 
     def __init__(
         self,
         *,
         get_state: StateProvider,
+        holdings_provider: HoldingsProvider = _default_mock_holdings_snapshot,
         clock: Callable[[], float] = time.monotonic,
-        snapshot_loader: LedgerSnapshotLoader = load_kis_mock_ledger_snapshot,
+        order_history_loader: OrderHistoryLoader = load_kis_mock_order_history,
     ) -> None:
         self._get_state = get_state
+        self._holdings = holdings_provider
         self._clock = clock
-        self._load_ledger = snapshot_loader
+        self._load_history = order_history_loader
 
-    async def load(self, *, symbol: str, side: Side) -> RiskInputs:
+    def _market(self, symbol: str) -> MarketConditions:
+        """Validate the live book and build ``MarketConditions``, else raise.
+
+        Fail-closes on a missing state, missing/negative/NaN/Inf book age,
+        non-positive or non-finite bid/ask, or a crossed book (ask < bid) — the
+        last would otherwise pass ``evaluate_risk`` as a negative spread.
+        """
         state = self._get_state(symbol)
         if state is None:
             raise RuntimeError(f"no live market state for {symbol}")
         now = self._clock()
         book_age = state.book_age_seconds(now=now)
-        spread = state.spread_bps()
-        if state.bid is None or state.ask is None or book_age is None or spread is None:
+        bid, ask = state.bid, state.ask
+        if book_age is None or not math.isfinite(book_age) or book_age < 0:
+            raise RuntimeError(f"missing/invalid book timestamp for {symbol}")
+        if not _is_finite_positive(bid) or not _is_finite_positive(ask):
             raise RuntimeError(
-                f"incomplete live market snapshot for {symbol} "
-                f"(bid={state.bid} ask={state.ask} book_age={book_age})"
+                f"non-positive/non-finite quote for {symbol} (bid={bid} ask={ask})"
             )
-        market = MarketConditions(
+        if ask < bid:  # crossed book — never trade a negative spread
+            raise RuntimeError(f"crossed book for {symbol} (bid={bid} ask={ask})")
+        spread = state.spread_bps()
+        if spread is None or not math.isfinite(spread) or spread < 0:
+            raise RuntimeError(f"invalid spread for {symbol} (spread={spread})")
+        return MarketConditions(
             spread_bps=Decimal(str(spread)),
             data_age_seconds=float(book_age),
         )
-        ledger = await self._load_ledger(symbol=to_db_symbol(symbol))
+
+    async def _position(self, symbol: str) -> tuple[bool, int]:
+        """(has_open_for_symbol, open_position_count) from fresh holdings."""
+        snap = await self._holdings()
+        holdings = snap.get("holdings") or []
+        target = to_db_symbol(symbol)
+        open_count = 0
+        has_open = False
+        for holding in holdings:
+            qty = _to_decimal(holding.get("hldg_qty")) or Decimal("0")
+            if qty <= 0:
+                continue
+            open_count += 1
+            if to_db_symbol(str(holding.get("pdno") or "")) == target:
+                has_open = True
+        return has_open, open_count
+
+    async def load(self, *, symbol: str, side: Side) -> RiskInputs:
+        market = self._market(symbol)
+        has_open, open_count = await self._position(symbol)
+        history = await self._load_history(symbol=to_db_symbol(symbol))
+        ledger = LedgerSnapshot(
+            has_open_position_for_symbol=has_open,
+            open_position_count=open_count,
+            orders_today=history.orders_today,
+            realized_loss_today_krw=history.realized_loss_today_krw,
+            seconds_since_last_close_for_symbol=(
+                history.seconds_since_last_close_for_symbol
+            ),
+        )
         return RiskInputs(ledger=ledger, market=market)
 
 

--- a/app/services/brokers/kis/mock_scalping_exec/adapters.py
+++ b/app/services/brokers/kis/mock_scalping_exec/adapters.py
@@ -68,6 +68,10 @@ from app.services.brokers.kis.mock_scalping_exec.reservation import (
 )
 from app.services.brokers.kis.mock_scalping_ws.state import MarketState
 from app.services.brokers.kis.pre_send import PreSendFreshnessError
+from app.services.brokers.kis.send_outcome import (
+    OrderSendDisposition,
+    OrderSendOutcomeTracker,
+)
 from app.services.order_send_intent_service import DuplicateOrderIntent
 
 logger = logging.getLogger("rob321.kis_mock_scalping_exec")
@@ -75,6 +79,7 @@ logger = logging.getLogger("rob321.kis_mock_scalping_exec")
 StateProvider = Callable[[str], MarketState | None]
 OrderHistoryLoader = Callable[..., Awaitable[MockOrderHistory]]
 HoldingsProvider = Callable[[], Awaitable[Mapping[str, Any]]]
+ReservedSubmit = Callable[[OrderSendOutcomeTracker | None], Awaitable[dict[str, Any]]]
 
 
 async def _default_mock_holdings_snapshot() -> Mapping[str, Any]:
@@ -147,6 +152,65 @@ class KisMockBroker:
                 "scalping reservation release failed cid=%s: %s", correlation_id, exc
             )
 
+    async def _submit_with_reservation(
+        self,
+        *,
+        symbol: str,
+        side: str,
+        correlation_id: str,
+        confirm: bool,
+        submit: ReservedSubmit,
+    ) -> dict[str, Any]:
+        """Apply one explicit reservation lifecycle to BUY and SELL mutations."""
+        if not confirm:
+            return await submit(None)
+
+        try:
+            await reserve_entry(correlation_id=correlation_id, symbol=symbol, side=side)
+        except DuplicateOrderIntent:
+            return {
+                "success": False,
+                "reservation_blocked": True,
+                "reason_codes": ["duplicate_send"],
+                "detail": f"scalping order already reserved: {correlation_id}",
+                "dry_run": False,
+            }
+        except Exception as exc:  # noqa: BLE001 — durable write lost → POST 0
+            logger.warning(
+                "scalping reservation failed sym=%s side=%s: %s", symbol, side, exc
+            )
+            return {
+                "success": False,
+                "reservation_blocked": True,
+                "reason_codes": ["reservation_unavailable"],
+                "detail": f"{type(exc).__name__}: {exc}"[:200],
+                "dry_run": False,
+            }
+
+        outcome = OrderSendOutcomeTracker()
+        try:
+            result = await submit(outcome)
+        except OrderSendOutcomeUnknown:
+            # A timeout/network failure after dispatch may have created an order.
+            raise
+        except Exception:
+            # Only an explicitly proven pre-send/definitive no-order exception
+            # releases. Any post-dispatch exception leaves UNKNOWN and keeps it.
+            if outcome.disposition is OrderSendDisposition.NOT_CREATED:
+                await self._safe_release_reservation(correlation_id)
+            raise
+
+        if outcome.disposition is OrderSendDisposition.NOT_CREATED:
+            await self._safe_release_reservation(correlation_id)
+        elif outcome.disposition is OrderSendDisposition.ACCEPTED:
+            tracked = bool(result.get("success")) and not result.get(
+                "ledger_tracking_unavailable"
+            )
+            if tracked:
+                await self._safe_release_reservation(correlation_id)
+        # UNKNOWN or accepted-but-untracked: KEEP until explicit reconciliation.
+        return result
+
     async def submit_buy(
         self,
         *,
@@ -165,36 +229,11 @@ class KisMockBroker:
             if confirm
             else None
         )
-        # ROB-843 P1: WRITE-AHEAD durable reservation, recorded BEFORE the POST.
-        # If this durable write cannot land, the broker POST must never happen
-        # (POST 0). An unresolved reservation is the durable in-flight/uncertain
-        # state that survives restart and fail-closes new orders until an
-        # explicit reconciliation releases it.
-        if confirm:
-            try:
-                await reserve_entry(
-                    correlation_id=correlation_id, symbol=symbol, side="buy"
-                )
-            except DuplicateOrderIntent:
-                return {
-                    "success": False,
-                    "reservation_blocked": True,
-                    "reason_codes": ["duplicate_send"],
-                    "detail": f"scalping entry already reserved: {correlation_id}",
-                    "dry_run": False,
-                }
-            except Exception as exc:  # noqa: BLE001 — durable write lost → POST 0
-                logger.warning("scalping reservation failed sym=%s: %s", symbol, exc)
-                return {
-                    "success": False,
-                    "reservation_blocked": True,
-                    "reason_codes": ["reservation_unavailable"],
-                    "detail": f"{type(exc).__name__}: {exc}"[:200],
-                    "dry_run": False,
-                }
 
-        try:
-            result = await _place_order_impl(
+        async def _submit(
+            send_outcome: OrderSendOutcomeTracker | None,
+        ) -> dict[str, Any]:
+            return await _place_order_impl(
                 symbol=symbol,
                 side="buy",
                 market="kr",
@@ -211,27 +250,16 @@ class KisMockBroker:
                 # Final freshness re-check right before the POST (entry only; an
                 # exit must always be allowed to close a live position).
                 pre_send_hook=self._make_pre_send_hook(symbol),
+                send_outcome=send_outcome,
             )
-        except OrderSendOutcomeUnknown:
-            # Uncertain send (timeout/network after the POST): KEEP the
-            # reservation so the order stays fail-closed until reconciliation.
-            raise
-        except Exception:
-            # Deterministic broker error before/at send (rejection, token cap,
-            # validation): no order was created — release the reservation.
-            if confirm:
-                await self._safe_release_reservation(correlation_id)
-            raise
 
-        if confirm:
-            tracked = bool(result.get("success")) and not result.get(
-                "ledger_tracking_unavailable"
-            )
-            if result.get("pre_send_blocked") or tracked:
-                # Certain no-order (POST 0) OR fully-tracked native row → release.
-                await self._safe_release_reservation(correlation_id)
-            # else: native write lost / unknown / malformed = uncertain → KEEP
-            # the reservation (durable fail-close until reconciliation).
+        result = await self._submit_with_reservation(
+            symbol=symbol,
+            side="buy",
+            correlation_id=correlation_id,
+            confirm=confirm,
+            submit=_submit,
+        )
 
         if isinstance(result, dict) and baseline is not None:
             result["_baseline"] = baseline
@@ -255,24 +283,37 @@ class KisMockBroker:
             if confirm
             else None
         )
-        result = await _place_order_impl(
+
+        async def _submit(
+            send_outcome: OrderSendOutcomeTracker | None,
+        ) -> dict[str, Any]:
+            return await _place_order_impl(
+                symbol=symbol,
+                side="sell",
+                market="kr",
+                order_type="limit",
+                quantity=float(quantity),
+                price=float(price),
+                dry_run=not confirm,
+                is_mock=True,
+                reason=f"scalp_exit:{correlation_id}",
+                exit_reason=exit_reason,
+                strategy=strategy_id,
+                scalping_exit=True,
+                scalping_strategy_id=strategy_id,
+                scalping_exit_reason=exit_reason,
+                # Link native + synthetic exit evidence (ROB-843 P1-2). No
+                # freshness hook on exits: a live position remains closable.
+                correlation_id=correlation_id,
+                send_outcome=send_outcome,
+            )
+
+        result = await self._submit_with_reservation(
             symbol=symbol,
             side="sell",
-            market="kr",
-            order_type="limit",
-            quantity=float(quantity),
-            price=float(price),
-            dry_run=not confirm,
-            is_mock=True,
-            reason=f"scalp_exit:{correlation_id}",
-            exit_reason=exit_reason,
-            strategy=strategy_id,
-            scalping_exit=True,
-            scalping_strategy_id=strategy_id,
-            scalping_exit_reason=exit_reason,
-            # Link native + synthetic exit evidence (ROB-843 P1-2). No pre-send
-            # freshness gate on the exit: a live position must always be closable.
             correlation_id=correlation_id,
+            confirm=confirm,
+            submit=_submit,
         )
         if isinstance(result, dict) and baseline is not None:
             result["_baseline"] = baseline

--- a/app/services/brokers/kis/mock_scalping_exec/adapters.py
+++ b/app/services/brokers/kis/mock_scalping_exec/adapters.py
@@ -22,7 +22,8 @@ from __future__ import annotations
 
 import datetime
 import logging
-from collections.abc import Callable
+import time
+from collections.abc import Awaitable, Callable
 from decimal import Decimal
 from typing import Any
 
@@ -30,7 +31,16 @@ from app.core.symbol import to_db_symbol
 from app.mcp_server.tooling.kis_mock_ledger import _save_kis_mock_order_ledger
 from app.mcp_server.tooling.order_execution import _create_kis_client, _place_order_impl
 from app.services.brokers.kis import KISClient
-from app.services.brokers.kis.mock_scalping_exec.executor import Fill, Quote
+from app.services.brokers.kis.mock_scalping.contract import (
+    LedgerSnapshot,
+    MarketConditions,
+    Side,
+)
+from app.services.brokers.kis.mock_scalping_exec.executor import (
+    Fill,
+    Quote,
+    RiskInputs,
+)
 from app.services.brokers.kis.mock_scalping_exec.fill_evidence import (
     EvidenceCategory,
     FillEvidence,
@@ -41,11 +51,15 @@ from app.services.brokers.kis.mock_scalping_exec.holdings_delta_confirm import (
     BaselineSnapshot,
     confirm_fill_from_holdings_delta,
 )
+from app.services.brokers.kis.mock_scalping_exec.ledger_state import (
+    load_kis_mock_ledger_snapshot,
+)
 from app.services.brokers.kis.mock_scalping_ws.state import MarketState
 
 logger = logging.getLogger("rob321.kis_mock_scalping_exec")
 
 StateProvider = Callable[[str], MarketState | None]
+LedgerSnapshotLoader = Callable[..., Awaitable[LedgerSnapshot]]
 
 
 def _to_decimal(value: Any) -> Decimal | None:
@@ -286,6 +300,46 @@ class KisMockBroker:
             ask=_to_decimal(state.ask),
             last=_to_decimal(state.last_price),
         )
+
+
+class KisMockRiskGate:
+    """RiskGatePort: fresh live-market + durable-ledger snapshot (ROB-843).
+
+    ``load`` raises on any missing/stale market field or ledger read fault so
+    the executor fail-closes to zero broker mutation. The market snapshot comes
+    from the live per-symbol ``MarketState`` (same source the broker reads); the
+    durable snapshot comes from ``review.kis_mock_order_ledger``.
+    """
+
+    def __init__(
+        self,
+        *,
+        get_state: StateProvider,
+        clock: Callable[[], float] = time.monotonic,
+        snapshot_loader: LedgerSnapshotLoader = load_kis_mock_ledger_snapshot,
+    ) -> None:
+        self._get_state = get_state
+        self._clock = clock
+        self._load_ledger = snapshot_loader
+
+    async def load(self, *, symbol: str, side: Side) -> RiskInputs:
+        state = self._get_state(symbol)
+        if state is None:
+            raise RuntimeError(f"no live market state for {symbol}")
+        now = self._clock()
+        book_age = state.book_age_seconds(now=now)
+        spread = state.spread_bps()
+        if state.bid is None or state.ask is None or book_age is None or spread is None:
+            raise RuntimeError(
+                f"incomplete live market snapshot for {symbol} "
+                f"(bid={state.bid} ask={state.ask} book_age={book_age})"
+            )
+        market = MarketConditions(
+            spread_bps=Decimal(str(spread)),
+            data_age_seconds=float(book_age),
+        )
+        ledger = await self._load_ledger(symbol=to_db_symbol(symbol))
+        return RiskInputs(ledger=ledger, market=market)
 
 
 class KisMockLedgerWriter:

--- a/app/services/brokers/kis/mock_scalping_exec/adapters.py
+++ b/app/services/brokers/kis/mock_scalping_exec/adapters.py
@@ -62,6 +62,7 @@ from app.services.brokers.kis.mock_scalping_exec.tracking_state import (
     is_ledger_tracking_unavailable,
 )
 from app.services.brokers.kis.mock_scalping_ws.state import MarketState
+from app.services.brokers.kis.pre_send import PreSendFreshnessError
 
 logger = logging.getLogger("rob321.kis_mock_scalping_exec")
 
@@ -361,15 +362,6 @@ def _is_finite_positive(x: float | None) -> bool:
     return x is not None and math.isfinite(x) and x > 0
 
 
-class PreSendFreshnessError(RuntimeError):
-    """Raised by the pre-send re-check when the live book is no longer tradeable
-    immediately before the broker POST (ROB-843 P1-1)."""
-
-    def __init__(self, reason_codes: tuple[str, ...]) -> None:
-        self.reason_codes = tuple(reason_codes)
-        super().__init__(",".join(self.reason_codes) or "pre_send_freshness")
-
-
 def assert_market_fresh_for_send(
     state: MarketState | None,
     *,
@@ -575,12 +567,17 @@ class KisMockLedgerWriter:
         )
 
     async def record_anomaly(
-        self, *, correlation_id: str, symbol: str, detail: str
+        self, *, correlation_id: str, symbol: str, side: Side, detail: str
     ) -> None:
+        # ROB-843 P2: persist the anomaly's real leg/side so it de-dups with the
+        # native row for the same order in the daily count (entry_unfilled=buy,
+        # exit_unconfirmed=sell) rather than counting as a phantom second order.
+        db_side = "buy" if side == "BUY" else "sell"
+        scalping_role = "entry" if side == "BUY" else "exit"
         await _save_kis_mock_order_ledger(
             symbol=symbol,
             instrument_type="equity_kr",
-            side="sell",
+            side=db_side,
             order_type="limit",
             quantity=0.0,
             price=0.0,
@@ -599,5 +596,5 @@ class KisMockLedgerWriter:
             notes=detail,
             lifecycle_state="anomaly",
             correlation_id=correlation_id,
-            scalping_role="exit",
+            scalping_role=scalping_role,
         )

--- a/app/services/brokers/kis/mock_scalping_exec/executor.py
+++ b/app/services/brokers/kis/mock_scalping_exec/executor.py
@@ -128,7 +128,7 @@ class LedgerPort(Protocol):
     ) -> None: ...
 
     async def record_anomaly(
-        self, *, correlation_id: str, symbol: str, detail: str
+        self, *, correlation_id: str, symbol: str, side: Side, detail: str
     ) -> None: ...
 
 
@@ -243,8 +243,13 @@ class MockScalpingExecutor:
         # 2. Confirm entry fill (bounded).
         entry_fill = await self._await_fill(buy)
         if entry_fill is None:
+            # ROB-843 P2: an entry-unfilled anomaly is the BUY leg (side=BUY) so
+            # it de-dups with the native BUY row in the daily count.
             await self._ledger.record_anomaly(
-                correlation_id=cid, symbol=intent.symbol, detail="entry_unfilled"
+                correlation_id=cid,
+                symbol=intent.symbol,
+                side="BUY",
+                detail="entry_unfilled",
             )
             return RoundTripResult(
                 correlation_id=cid,
@@ -276,8 +281,12 @@ class MockScalpingExecutor:
         exit_fill = await self._await_fill(sell)
         if exit_fill is None:
             # Failsafe: cannot prove the close — never report a clean success.
+            # The exit-unconfirmed anomaly is the SELL leg (side=SELL).
             await self._ledger.record_anomaly(
-                correlation_id=cid, symbol=intent.symbol, detail="exit_unconfirmed"
+                correlation_id=cid,
+                symbol=intent.symbol,
+                side="SELL",
+                detail="exit_unconfirmed",
             )
             return RoundTripResult(
                 correlation_id=cid,

--- a/app/services/brokers/kis/mock_scalping_exec/executor.py
+++ b/app/services/brokers/kis/mock_scalping_exec/executor.py
@@ -225,6 +225,17 @@ class MockScalpingExecutor:
             correlation_id=cid,
             confirm=confirm,
         )
+        # ROB-843 P1-1: the broker's final pre-send freshness re-check blocked the
+        # POST (book went stale/crossed after the risk gate). Zero broker calls,
+        # no fill, no ledger — surface as a clean blocked result.
+        if isinstance(buy, dict) and buy.get("pre_send_blocked"):
+            return RoundTripResult(
+                correlation_id=cid,
+                status="blocked",
+                quantity=qty,
+                reason_codes=tuple(buy.get("reason_codes") or ("pre_send_freshness",)),
+                detail=buy.get("detail"),
+            )
         if not confirm:
             logger.info("dry-run scalping entry symbol=%s qty=%s", intent.symbol, qty)
             return RoundTripResult(correlation_id=cid, status="dry_run", quantity=qty)

--- a/app/services/brokers/kis/mock_scalping_exec/executor.py
+++ b/app/services/brokers/kis/mock_scalping_exec/executor.py
@@ -225,10 +225,13 @@ class MockScalpingExecutor:
             correlation_id=cid,
             confirm=confirm,
         )
-        # ROB-843 P1-1: the broker's final pre-send freshness re-check blocked the
-        # POST (book went stale/crossed after the risk gate). Zero broker calls,
-        # no fill, no ledger — surface as a clean blocked result.
-        if isinstance(buy, dict) and buy.get("pre_send_blocked"):
+        # ROB-843 P1: the broker refused to POST — either the final pre-send
+        # freshness re-check blocked it (book went stale/crossed after the risk
+        # gate) or the write-ahead durable reservation could not be recorded
+        # (POST 0). Zero broker calls, no fill, no ledger — surface as blocked.
+        if isinstance(buy, dict) and (
+            buy.get("pre_send_blocked") or buy.get("reservation_blocked")
+        ):
             return RoundTripResult(
                 correlation_id=cid,
                 status="blocked",

--- a/app/services/brokers/kis/mock_scalping_exec/executor.py
+++ b/app/services/brokers/kis/mock_scalping_exec/executor.py
@@ -27,6 +27,13 @@ from dataclasses import dataclass, field
 from decimal import ROUND_DOWN, Decimal
 from typing import Any, Protocol
 
+from app.services.brokers.kis.mock_scalping.contract import (
+    LedgerSnapshot,
+    MarketConditions,
+    ScalpingRiskLimits,
+    Side,
+    evaluate_risk,
+)
 from app.services.brokers.kis.mock_scalping.order_intent import OrderIntent
 from app.services.brokers.kis.mock_scalping_exec.exit_policy import (
     TIME_STOP,
@@ -77,6 +84,24 @@ class BrokerPort(Protocol):
     async def confirm_fill(self, submit_result: dict[str, Any]) -> Fill | None: ...
 
     def quote(self, symbol: str) -> Quote | None: ...
+
+
+@dataclass(frozen=True)
+class RiskInputs:
+    """Fresh durable + market snapshot for the executor-owned final risk gate."""
+
+    ledger: LedgerSnapshot
+    market: MarketConditions
+
+
+class RiskGatePort(Protocol):
+    """Loads a fresh ledger/position + market snapshot immediately before send.
+
+    ``load`` MUST raise on any snapshot load/parse/freshness fault so the
+    executor can fail-close to zero broker mutation (ROB-843).
+    """
+
+    async def load(self, *, symbol: str, side: Side) -> RiskInputs: ...
 
 
 class LedgerPort(Protocol):
@@ -131,6 +156,7 @@ class RoundTripResult:
     net_pnl: Decimal | None = None
     fees: Decimal | None = None
     reason_codes: tuple[str, ...] = field(default_factory=tuple)
+    detail: str | None = None
 
 
 class MockScalpingExecutor:
@@ -142,6 +168,8 @@ class MockScalpingExecutor:
         config: ExecutorConfig | None = None,
         sleep: Callable[[float], Awaitable[None]] = asyncio.sleep,
         clock: Callable[[], float] = None,  # type: ignore[assignment]
+        risk: RiskGatePort | None = None,
+        limits: ScalpingRiskLimits | None = None,
     ) -> None:
         import time
 
@@ -150,6 +178,10 @@ class MockScalpingExecutor:
         self._config = config or ExecutorConfig()
         self._sleep = sleep
         self._clock = clock or time.monotonic
+        # ROB-843: executor-owned final risk re-check. Production wiring MUST
+        # inject a gate; a confirm-mode executor without one fail-closes.
+        self._risk = risk
+        self._limits = limits or ScalpingRiskLimits()
 
     def _new_correlation_id(self) -> str:
         return f"kis-mock-scalp-{uuid.uuid4().hex[:16]}"
@@ -176,6 +208,14 @@ class MockScalpingExecutor:
             )
         entry_ref = intent.entry_reference_price
         assert entry_ref is not None  # _size guards None/<=0
+
+        # 0. Executor-owned final risk re-check (ROB-843). Reloads a fresh
+        # ledger/position + market snapshot and runs evaluate_risk immediately
+        # before any submit. Caller-computed risk is advisory only; any denial
+        # or snapshot fault fail-closes here with ZERO broker calls.
+        blocked = await self._final_risk_gate(intent, cid=cid, confirm=confirm)
+        if blocked is not None:
+            return blocked
 
         # 1. Submit BUY (confirm-gated).
         buy = await self._broker.submit_buy(
@@ -269,6 +309,61 @@ class MockScalpingExecutor:
             net_pnl=net,
             fees=fees,
         )
+
+    async def _final_risk_gate(
+        self, intent: OrderIntent, *, cid: str, confirm: bool
+    ) -> RoundTripResult | None:
+        """Executor-owned pre-send risk gate. Returns a blocked ``RoundTripResult``
+        to short-circuit (zero broker calls), or ``None`` to proceed.
+
+        * No wired gate + ``confirm`` → fail-close (``risk_gate_unconfigured``);
+          the executor never mutates without owning the final check.
+        * No wired gate + dry-run → legacy passthrough (no mutation happens).
+        * Snapshot load/parse/freshness fault → ``risk_snapshot_unavailable``.
+        * Any risk denial → the accumulated stable reason codes.
+        """
+        if self._risk is None:
+            if confirm:
+                return RoundTripResult(
+                    correlation_id=cid,
+                    status="blocked",
+                    reason_codes=("risk_gate_unconfigured",),
+                )
+            return None
+
+        try:
+            inputs = await self._risk.load(symbol=intent.symbol, side=intent.side)
+        except Exception as exc:  # noqa: BLE001 — any snapshot fault fails closed
+            logger.warning(
+                "risk snapshot unavailable symbol=%s: %s", intent.symbol, exc
+            )
+            return RoundTripResult(
+                correlation_id=cid,
+                status="blocked",
+                reason_codes=("risk_snapshot_unavailable",),
+                detail=f"{type(exc).__name__}: {exc}"[:200],
+            )
+
+        decision = evaluate_risk(
+            symbol=intent.symbol,
+            side=intent.side,
+            target_notional_krw=intent.target_notional_krw,
+            limits=self._limits,
+            ledger=inputs.ledger,
+            market=inputs.market,
+        )
+        if not decision.allowed:
+            logger.info(
+                "scalping entry blocked by final risk gate symbol=%s reasons=%s",
+                intent.symbol,
+                decision.reason_codes,
+            )
+            return RoundTripResult(
+                correlation_id=cid,
+                status="blocked",
+                reason_codes=decision.reason_codes,
+            )
+        return None
 
     async def _monitor(self, intent: OrderIntent) -> str:
         assert intent.tp_price is not None and intent.sl_price is not None

--- a/app/services/brokers/kis/mock_scalping_exec/ledger_state.py
+++ b/app/services/brokers/kis/mock_scalping_exec/ledger_state.py
@@ -39,6 +39,29 @@ def _start_of_kst_day(now: datetime) -> datetime:
     return now.replace(hour=0, minute=0, second=0, microsecond=0)
 
 
+def daily_broker_order_count_stmt(*, since: datetime, symbol: str | None = None):
+    """Count DISTINCT actually-submitted broker orders since ``since``.
+
+    Counts one per unique (trimmed) broker order id, excluding synthetic
+    scalping audit rows (``scalping_role`` set — they mirror a native
+    submission) and rows with no valid broker order id (preview / blocked /
+    pre-submit failure / rejected / id-less never reached the broker). The
+    optional ``symbol`` scope is for deterministic per-symbol testing;
+    production passes ``None`` (account-wide daily cap).
+    """
+    stmt = select(
+        func.count(func.distinct(func.trim(KISMockOrderLedger.order_no)))
+    ).where(
+        KISMockOrderLedger.trade_date >= since,
+        KISMockOrderLedger.scalping_role.is_(None),
+        KISMockOrderLedger.order_no.is_not(None),
+        func.trim(KISMockOrderLedger.order_no) != "",
+    )
+    if symbol is not None:
+        stmt = stmt.where(KISMockOrderLedger.symbol == symbol)
+    return stmt
+
+
 async def load_kis_mock_order_history(
     *, symbol: str, now: datetime | None = None
 ) -> MockOrderHistory:
@@ -49,11 +72,7 @@ async def load_kis_mock_order_history(
     since = _start_of_kst_day(now)
 
     async with _order_session_factory()() as db:
-        orders_today = await db.scalar(
-            select(func.count())
-            .select_from(KISMockOrderLedger)
-            .where(KISMockOrderLedger.trade_date >= since)
-        )
+        orders_today = await db.scalar(daily_broker_order_count_stmt(since=since))
         realized_loss = await db.scalar(
             select(func.coalesce(func.sum(-KISMockOrderLedger.net_pnl), 0)).where(
                 KISMockOrderLedger.lifecycle_state == _CLOSED_STATE,
@@ -61,17 +80,29 @@ async def load_kis_mock_order_history(
                 KISMockOrderLedger.net_pnl < 0,
             )
         )
-        # Cooldown is measured from the actual close/reconcile time, so a held
-        # position (no reconciled close yet) imposes no cooldown.
-        last_close = await db.scalar(
-            select(func.max(KISMockOrderLedger.trade_date)).where(
-                KISMockOrderLedger.symbol == symbol,
-                KISMockOrderLedger.lifecycle_state == _CLOSED_STATE,
+        # Cooldown anchors on the actual position-closing SELL reconcile time.
+        # Only reconciled SELL rows count (BUY/preview/failed/rejected/no-fill
+        # are not closes). reconciled_at is the canonical reconcile timestamp;
+        # a legacy close row missing it must fail-close, never silently bypass.
+        close_ts_rows = (
+            await db.execute(
+                select(KISMockOrderLedger.reconciled_at).where(
+                    KISMockOrderLedger.symbol == symbol,
+                    KISMockOrderLedger.side == "sell",
+                    KISMockOrderLedger.lifecycle_state == _CLOSED_STATE,
+                )
             )
-        )
+        ).all()
 
     seconds_since_close: float | None = None
-    if last_close is not None:
+    if close_ts_rows:
+        reconciled_ats = [row[0] for row in close_ts_rows]
+        if any(ts is None for ts in reconciled_ats):
+            raise RuntimeError(
+                f"reconciled SELL close for {symbol} is missing reconciled_at; "
+                "cannot compute cooldown (fail-close)"
+            )
+        last_close = max(reconciled_ats)
         seconds_since_close = (now - last_close).total_seconds()
 
     return MockOrderHistory(

--- a/app/services/brokers/kis/mock_scalping_exec/ledger_state.py
+++ b/app/services/brokers/kis/mock_scalping_exec/ledger_state.py
@@ -39,27 +39,62 @@ def _start_of_kst_day(now: datetime) -> datetime:
     return now.replace(hour=0, minute=0, second=0, microsecond=0)
 
 
-def daily_broker_order_count_stmt(*, since: datetime, symbol: str | None = None):
-    """Count DISTINCT actually-submitted broker orders since ``since``.
+# Synthetic scalping rows count as durable submission evidence only once they
+# represent a real broker outcome (a fill / reconcile / anomaly), never a mere
+# audit placeholder.
+_SYNTHETIC_EVIDENCE_STATES: frozenset[str] = frozenset(
+    {"fill", "reconciled", "anomaly"}
+)
 
-    Counts one per unique (trimmed) broker order id, excluding synthetic
-    scalping audit rows (``scalping_role`` set — they mirror a native
-    submission) and rows with no valid broker order id (preview / blocked /
-    pre-submit failure / rejected / id-less never reached the broker). The
-    optional ``symbol`` scope is for deterministic per-symbol testing;
+
+async def count_daily_broker_orders(
+    db, *, since: datetime, symbol: str | None = None
+) -> int:
+    """Count actually-submitted broker orders since ``since`` (ROB-843 P1-2).
+
+    A submission is counted once, evidenced by EITHER a native ledger row (real
+    broker order id) OR — when the native write was lost — a synthetic
+    fill/anomaly/fallback row keyed by ``(correlation_id, side)``. Synthetic
+    evidence whose logical order already has a native row (matched by
+    ``(correlation_id, side)``) is not double-counted; rows that never reached
+    the broker (preview / blocked / pre-submit failure / rejected / id-less
+    native, or audit-only synthetic) are excluded.
+
+    The optional ``symbol`` scope is for deterministic per-symbol testing;
     production passes ``None`` (account-wide daily cap).
     """
-    stmt = select(
-        func.count(func.distinct(func.trim(KISMockOrderLedger.order_no)))
+    native_q = select(
+        KISMockOrderLedger.order_no,
+        KISMockOrderLedger.correlation_id,
+        KISMockOrderLedger.side,
     ).where(
         KISMockOrderLedger.trade_date >= since,
         KISMockOrderLedger.scalping_role.is_(None),
-        KISMockOrderLedger.order_no.is_not(None),
-        func.trim(KISMockOrderLedger.order_no) != "",
+    )
+    synthetic_q = select(
+        KISMockOrderLedger.correlation_id,
+        KISMockOrderLedger.side,
+    ).where(
+        KISMockOrderLedger.trade_date >= since,
+        KISMockOrderLedger.scalping_role.is_not(None),
+        KISMockOrderLedger.lifecycle_state.in_(_SYNTHETIC_EVIDENCE_STATES),
     )
     if symbol is not None:
-        stmt = stmt.where(KISMockOrderLedger.symbol == symbol)
-    return stmt
+        native_q = native_q.where(KISMockOrderLedger.symbol == symbol)
+        synthetic_q = synthetic_q.where(KISMockOrderLedger.symbol == symbol)
+
+    native_ids: set[str] = set()
+    native_pairs: set[tuple[str | None, str]] = set()
+    for order_no, corr_id, side in (await db.execute(native_q)).all():
+        native_pairs.add((corr_id, side))
+        if order_no is not None and order_no.strip():
+            native_ids.add(order_no.strip())
+
+    synthetic_pairs = {
+        (corr_id, side) for corr_id, side in (await db.execute(synthetic_q)).all()
+    }
+    orphaned = synthetic_pairs - native_pairs
+    return len(native_ids) + len(orphaned)
 
 
 async def load_kis_mock_order_history(
@@ -72,7 +107,7 @@ async def load_kis_mock_order_history(
     since = _start_of_kst_day(now)
 
     async with _order_session_factory()() as db:
-        orders_today = await db.scalar(daily_broker_order_count_stmt(since=since))
+        orders_today = await count_daily_broker_orders(db, since=since)
         realized_loss = await db.scalar(
             select(func.coalesce(func.sum(-KISMockOrderLedger.net_pnl), 0)).where(
                 KISMockOrderLedger.lifecycle_state == _CLOSED_STATE,

--- a/app/services/brokers/kis/mock_scalping_exec/ledger_state.py
+++ b/app/services/brokers/kis/mock_scalping_exec/ledger_state.py
@@ -1,0 +1,84 @@
+"""ROB-843 — durable ledger state for the KIS mock scalping final risk gate.
+
+Builds a :class:`LedgerSnapshot` from ``review.kis_mock_order_ledger`` so the
+executor's pre-send ``evaluate_risk`` re-check reads authoritative DB state
+(cooldown, single-position, daily order/loss caps) that survives a fresh
+process or scheduler run. Read-only: no writes, no broker/network I/O.
+
+Any DB/read fault propagates to the caller so the executor fail-closes to zero
+broker mutation rather than sizing against unknown exposure.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from decimal import Decimal
+
+from sqlalchemy import func, select
+
+from app.core.timezone import now_kst
+from app.models.review import KISMockOrderLedger
+from app.services.brokers.kis.mock_scalping.contract import LedgerSnapshot
+
+# Lifecycle states counted as a live/open position for the risk gate.
+_OPEN_STATES: frozenset[str] = frozenset({"accepted", "pending", "fill"})
+_CLOSED_STATE = "reconciled"
+
+
+def _start_of_kst_day(now: datetime) -> datetime:
+    return now.replace(hour=0, minute=0, second=0, microsecond=0)
+
+
+async def load_kis_mock_ledger_snapshot(
+    *, symbol: str, now: datetime | None = None
+) -> LedgerSnapshot:
+    """Read the durable scalping risk state for ``symbol`` from the mock ledger."""
+    from app.mcp_server.tooling.kis_mock_ledger import _order_session_factory
+
+    now = now or now_kst()
+    since = _start_of_kst_day(now)
+
+    async with _order_session_factory()() as db:
+        has_open = await db.scalar(
+            select(func.count())
+            .select_from(KISMockOrderLedger)
+            .where(
+                KISMockOrderLedger.symbol == symbol,
+                KISMockOrderLedger.lifecycle_state.in_(_OPEN_STATES),
+            )
+        )
+        open_symbols = await db.scalar(
+            select(func.count(func.distinct(KISMockOrderLedger.symbol))).where(
+                KISMockOrderLedger.lifecycle_state.in_(_OPEN_STATES)
+            )
+        )
+        orders_today = await db.scalar(
+            select(func.count())
+            .select_from(KISMockOrderLedger)
+            .where(KISMockOrderLedger.trade_date >= since)
+        )
+        realized_loss = await db.scalar(
+            select(func.coalesce(func.sum(-KISMockOrderLedger.net_pnl), 0)).where(
+                KISMockOrderLedger.lifecycle_state == _CLOSED_STATE,
+                KISMockOrderLedger.trade_date >= since,
+                KISMockOrderLedger.net_pnl < 0,
+            )
+        )
+        last_close = await db.scalar(
+            select(func.max(KISMockOrderLedger.trade_date)).where(
+                KISMockOrderLedger.symbol == symbol,
+                KISMockOrderLedger.lifecycle_state == _CLOSED_STATE,
+            )
+        )
+
+    seconds_since_close: float | None = None
+    if last_close is not None:
+        seconds_since_close = (now - last_close).total_seconds()
+
+    return LedgerSnapshot(
+        has_open_position_for_symbol=bool(has_open or 0),
+        open_position_count=int(open_symbols or 0),
+        orders_today=int(orders_today or 0),
+        realized_loss_today_krw=Decimal(str(realized_loss or 0)),
+        seconds_since_last_close_for_symbol=seconds_since_close,
+    )

--- a/app/services/brokers/kis/mock_scalping_exec/ledger_state.py
+++ b/app/services/brokers/kis/mock_scalping_exec/ledger_state.py
@@ -18,50 +18,49 @@ from dataclasses import dataclass
 from datetime import datetime
 from decimal import Decimal
 
-from sqlalchemy import func, select, update
+from sqlalchemy import and_, func, not_, or_, select
 
 from app.core.timezone import now_kst
 from app.models.review import KISMockOrderLedger
 
 _CLOSED_STATE = "reconciled"
 
-# ROB-843 P1-2: a durable ledger-tracking degradation latch. When an accepted
-# order's native AND fallback ledger writes are both lost, a marker row is
-# persisted so the block survives process restart / module reload / a fresh DB
-# session. Only an explicit reconciliation (clearing the marker) re-opens trading.
-_DEGRADATION_SYMBOL = "__ledger_tracking__"
-_DEGRADATION_ROLE = "tracking_degraded"
+# ROB-843 P2: control-only rows that must NEVER be treated as trades by any
+# ledger consumer (daily count, retrospective, journal bridge, holdings). The
+# durable in-flight/uncertain state now lives in the write-ahead reservation
+# (review.order_send_intents), so new code writes no control rows here; this
+# predicate defends against any legacy control rows from earlier revisions.
+_CONTROL_SYMBOL = "__ledger_tracking__"
+_CONTROL_ROLES: frozenset[str] = frozenset({"tracking_degraded", "native_fallback"})
+_CONTROL_REASONS: frozenset[str] = frozenset(
+    {"ledger_tracking_degraded", "ledger_tracking_fallback"}
+)
 
 
-async def is_tracking_degraded(db) -> bool:
-    """True while an unresolved durable degradation marker exists (any process)."""
-    found = await db.scalar(
-        select(func.count())
-        .select_from(KISMockOrderLedger)
-        .where(
-            KISMockOrderLedger.scalping_role == _DEGRADATION_ROLE,
-            KISMockOrderLedger.lifecycle_state != _CLOSED_STATE,
-        )
+def is_control_row(row: KISMockOrderLedger) -> bool:
+    """True for a non-trade control/reservation/degradation row (ROB-843 P2)."""
+    return (
+        row.symbol == _CONTROL_SYMBOL
+        or (row.scalping_role in _CONTROL_ROLES)
+        or (row.reason in _CONTROL_REASONS)
     )
-    return bool(found or 0)
 
 
-async def clear_tracking_degradation(db) -> int:
-    """Explicit reconciliation: resolve all degradation markers. Returns count.
-
-    This is the ONLY way the durable latch is released — order tracking must be
-    verified recovered before calling it.
-    """
-    result = await db.execute(
-        update(KISMockOrderLedger)
-        .where(
-            KISMockOrderLedger.scalping_role == _DEGRADATION_ROLE,
-            KISMockOrderLedger.lifecycle_state != _CLOSED_STATE,
-        )
-        .values(lifecycle_state=_CLOSED_STATE, reconciled_at=now_kst())
+def real_order_filter():
+    """SQLAlchemy predicate selecting only genuine order rows (excludes control
+    rows). Apply in every KISMockOrderLedger consumer so a control row is never
+    counted, retrospected, or journaled as a trade."""
+    return and_(
+        KISMockOrderLedger.symbol != _CONTROL_SYMBOL,
+        or_(
+            KISMockOrderLedger.scalping_role.is_(None),
+            not_(KISMockOrderLedger.scalping_role.in_(_CONTROL_ROLES)),
+        ),
+        or_(
+            KISMockOrderLedger.reason.is_(None),
+            not_(KISMockOrderLedger.reason.in_(_CONTROL_REASONS)),
+        ),
     )
-    await db.commit()
-    return int(result.rowcount or 0)
 
 
 @dataclass(frozen=True)
@@ -108,6 +107,7 @@ async def count_daily_broker_orders(
     ).where(
         KISMockOrderLedger.trade_date >= since,
         KISMockOrderLedger.scalping_role.is_(None),
+        real_order_filter(),  # never count a control row
     )
     synthetic_q = select(
         KISMockOrderLedger.correlation_id,
@@ -115,8 +115,7 @@ async def count_daily_broker_orders(
     ).where(
         KISMockOrderLedger.trade_date >= since,
         KISMockOrderLedger.scalping_role.is_not(None),
-        KISMockOrderLedger.scalping_role
-        != _DEGRADATION_ROLE,  # control row, not an order
+        real_order_filter(),  # excludes tracking_degraded / native_fallback
         KISMockOrderLedger.lifecycle_state.in_(_SYNTHETIC_EVIDENCE_STATES),
     )
     if symbol is not None:
@@ -147,10 +146,19 @@ async def load_kis_mock_order_history(
     since = _start_of_kst_day(now)
 
     async with _order_session_factory()() as db:
-        # ROB-843 P1-2: durable pre-send fail-close. A prior lost-write
-        # degradation latch (survives restart) blocks every new order until an
-        # explicit reconciliation clears it — never silently undercounts.
-        if await is_tracking_degraded(db):
+        # ROB-843 P1: durable pre-send fail-close. An UNRESOLVED write-ahead
+        # reservation (order_send_intents) means some automated order is
+        # in-flight/uncertain — a state that survives restart / a fresh session /
+        # a new gate instance — so block every new order until an explicit
+        # reconciliation releases it. Never silently undercounts.
+        from app.services.order_send_intent_service import (
+            KIS_MOCK_SCALPING_SCOPE,
+            OrderSendIntentService,
+        )
+
+        if await OrderSendIntentService(db).has_reservations(
+            account_scope=KIS_MOCK_SCALPING_SCOPE
+        ):
             raise RuntimeError("ledger_tracking_unavailable")
         orders_today = await count_daily_broker_orders(db, since=since)
         realized_loss = await db.scalar(

--- a/app/services/brokers/kis/mock_scalping_exec/ledger_state.py
+++ b/app/services/brokers/kis/mock_scalping_exec/ledger_state.py
@@ -1,16 +1,20 @@
-"""ROB-843 — durable ledger state for the KIS mock scalping final risk gate.
+"""ROB-843 — order-history state for the KIS mock scalping final risk gate.
 
-Builds a :class:`LedgerSnapshot` from ``review.kis_mock_order_ledger`` so the
-executor's pre-send ``evaluate_risk`` re-check reads authoritative DB state
-(cooldown, single-position, daily order/loss caps) that survives a fresh
-process or scheduler run. Read-only: no writes, no broker/network I/O.
+Reads *order-history* facts from ``review.kis_mock_order_ledger`` — daily order
+count, realized loss today, and time since the last close/reconcile (cooldown).
+It deliberately does **not** infer held positions from order lifecycle rows: an
+``accepted``/``pending``/``fill`` order row is an order, not proof of a durable
+position (a filled buy that is later sold is flat). The authoritative open
+position / position count comes from a fresh KIS mock holdings snapshot in the
+risk gate; this module only supplies order-history counters.
 
-Any DB/read fault propagates to the caller so the executor fail-closes to zero
-broker mutation rather than sizing against unknown exposure.
+Read-only: no writes, no broker/network I/O. Any DB fault propagates so the
+gate fail-closes to zero broker mutation.
 """
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from datetime import datetime
 from decimal import Decimal
 
@@ -18,40 +22,33 @@ from sqlalchemy import func, select
 
 from app.core.timezone import now_kst
 from app.models.review import KISMockOrderLedger
-from app.services.brokers.kis.mock_scalping.contract import LedgerSnapshot
 
-# Lifecycle states counted as a live/open position for the risk gate.
-_OPEN_STATES: frozenset[str] = frozenset({"accepted", "pending", "fill"})
 _CLOSED_STATE = "reconciled"
+
+
+@dataclass(frozen=True)
+class MockOrderHistory:
+    """Order-history counters for the risk gate (NOT position state)."""
+
+    orders_today: int
+    realized_loss_today_krw: Decimal
+    seconds_since_last_close_for_symbol: float | None
 
 
 def _start_of_kst_day(now: datetime) -> datetime:
     return now.replace(hour=0, minute=0, second=0, microsecond=0)
 
 
-async def load_kis_mock_ledger_snapshot(
+async def load_kis_mock_order_history(
     *, symbol: str, now: datetime | None = None
-) -> LedgerSnapshot:
-    """Read the durable scalping risk state for ``symbol`` from the mock ledger."""
+) -> MockOrderHistory:
+    """Read daily order count, realized loss, and cooldown basis for ``symbol``."""
     from app.mcp_server.tooling.kis_mock_ledger import _order_session_factory
 
     now = now or now_kst()
     since = _start_of_kst_day(now)
 
     async with _order_session_factory()() as db:
-        has_open = await db.scalar(
-            select(func.count())
-            .select_from(KISMockOrderLedger)
-            .where(
-                KISMockOrderLedger.symbol == symbol,
-                KISMockOrderLedger.lifecycle_state.in_(_OPEN_STATES),
-            )
-        )
-        open_symbols = await db.scalar(
-            select(func.count(func.distinct(KISMockOrderLedger.symbol))).where(
-                KISMockOrderLedger.lifecycle_state.in_(_OPEN_STATES)
-            )
-        )
         orders_today = await db.scalar(
             select(func.count())
             .select_from(KISMockOrderLedger)
@@ -64,6 +61,8 @@ async def load_kis_mock_ledger_snapshot(
                 KISMockOrderLedger.net_pnl < 0,
             )
         )
+        # Cooldown is measured from the actual close/reconcile time, so a held
+        # position (no reconciled close yet) imposes no cooldown.
         last_close = await db.scalar(
             select(func.max(KISMockOrderLedger.trade_date)).where(
                 KISMockOrderLedger.symbol == symbol,
@@ -75,9 +74,7 @@ async def load_kis_mock_ledger_snapshot(
     if last_close is not None:
         seconds_since_close = (now - last_close).total_seconds()
 
-    return LedgerSnapshot(
-        has_open_position_for_symbol=bool(has_open or 0),
-        open_position_count=int(open_symbols or 0),
+    return MockOrderHistory(
         orders_today=int(orders_today or 0),
         realized_loss_today_krw=Decimal(str(realized_loss or 0)),
         seconds_since_last_close_for_symbol=seconds_since_close,

--- a/app/services/brokers/kis/mock_scalping_exec/ledger_state.py
+++ b/app/services/brokers/kis/mock_scalping_exec/ledger_state.py
@@ -18,12 +18,50 @@ from dataclasses import dataclass
 from datetime import datetime
 from decimal import Decimal
 
-from sqlalchemy import func, select
+from sqlalchemy import func, select, update
 
 from app.core.timezone import now_kst
 from app.models.review import KISMockOrderLedger
 
 _CLOSED_STATE = "reconciled"
+
+# ROB-843 P1-2: a durable ledger-tracking degradation latch. When an accepted
+# order's native AND fallback ledger writes are both lost, a marker row is
+# persisted so the block survives process restart / module reload / a fresh DB
+# session. Only an explicit reconciliation (clearing the marker) re-opens trading.
+_DEGRADATION_SYMBOL = "__ledger_tracking__"
+_DEGRADATION_ROLE = "tracking_degraded"
+
+
+async def is_tracking_degraded(db) -> bool:
+    """True while an unresolved durable degradation marker exists (any process)."""
+    found = await db.scalar(
+        select(func.count())
+        .select_from(KISMockOrderLedger)
+        .where(
+            KISMockOrderLedger.scalping_role == _DEGRADATION_ROLE,
+            KISMockOrderLedger.lifecycle_state != _CLOSED_STATE,
+        )
+    )
+    return bool(found or 0)
+
+
+async def clear_tracking_degradation(db) -> int:
+    """Explicit reconciliation: resolve all degradation markers. Returns count.
+
+    This is the ONLY way the durable latch is released — order tracking must be
+    verified recovered before calling it.
+    """
+    result = await db.execute(
+        update(KISMockOrderLedger)
+        .where(
+            KISMockOrderLedger.scalping_role == _DEGRADATION_ROLE,
+            KISMockOrderLedger.lifecycle_state != _CLOSED_STATE,
+        )
+        .values(lifecycle_state=_CLOSED_STATE, reconciled_at=now_kst())
+    )
+    await db.commit()
+    return int(result.rowcount or 0)
 
 
 @dataclass(frozen=True)
@@ -77,6 +115,8 @@ async def count_daily_broker_orders(
     ).where(
         KISMockOrderLedger.trade_date >= since,
         KISMockOrderLedger.scalping_role.is_not(None),
+        KISMockOrderLedger.scalping_role
+        != _DEGRADATION_ROLE,  # control row, not an order
         KISMockOrderLedger.lifecycle_state.in_(_SYNTHETIC_EVIDENCE_STATES),
     )
     if symbol is not None:
@@ -107,6 +147,11 @@ async def load_kis_mock_order_history(
     since = _start_of_kst_day(now)
 
     async with _order_session_factory()() as db:
+        # ROB-843 P1-2: durable pre-send fail-close. A prior lost-write
+        # degradation latch (survives restart) blocks every new order until an
+        # explicit reconciliation clears it — never silently undercounts.
+        if await is_tracking_degraded(db):
+            raise RuntimeError("ledger_tracking_unavailable")
         orders_today = await count_daily_broker_orders(db, since=since)
         realized_loss = await db.scalar(
             select(func.coalesce(func.sum(-KISMockOrderLedger.net_pnl), 0)).where(

--- a/app/services/brokers/kis/mock_scalping_exec/reservation.py
+++ b/app/services/brokers/kis/mock_scalping_exec/reservation.py
@@ -8,6 +8,12 @@ survives process restart and fail-closes new orders until an explicit
 reconciliation releases it (unlike the old post-POST ledger marker, which shared
 the native write's failure mode). No writes to the order ledger — no control
 rows to leak into retrospective / journal / holdings consumers.
+
+ROB-853 remains the boundary for cross-process serialization: during a rolling
+deploy, an old raw-key writer and a new per-leg-key writer can race when the raw
+row is absent, and orders with different correlation IDs are not globally
+serialized here. Closing those gaps requires a canonical migration/deploy
+barrier or broader DB locking and is intentionally deferred to ROB-853.
 """
 
 from __future__ import annotations
@@ -18,6 +24,7 @@ from typing import Literal
 
 from app.services.order_send_intent_service import (
     KIS_MOCK_SCALPING_SCOPE,
+    OrderSendIntentReservation,
     OrderSendIntentService,
 )
 
@@ -100,6 +107,18 @@ async def _release_stored_key(stored_key: str) -> int:
         )
 
 
+async def _release_observed_reservation(
+    reservation: OrderSendIntentReservation,
+) -> int:
+    async with _session_factory()() as db:
+        return await OrderSendIntentService(db).release_if_matches(
+            account_scope=KIS_MOCK_SCALPING_SCOPE,
+            row_id=reservation.row_id,
+            idempotency_key=reservation.idempotency_key,
+            side=reservation.side,
+        )
+
+
 async def release_entry(*, correlation_id: str, side: str) -> int:
     return await _release_stored_key(_leg_key(correlation_id=correlation_id, side=side))
 
@@ -120,19 +139,21 @@ async def reconcile_entries(
     fail-closed. Returns the number released.
     """
     async with _session_factory()() as db:
-        reservations = await OrderSendIntentService(db).list_keys_and_sides(
+        reservations = await OrderSendIntentService(db).list_reservations(
             account_scope=KIS_MOCK_SCALPING_SCOPE
         )
     released = 0
-    for stored_key, stored_side in reservations:
+    for reservation in reservations:
         try:
             correlation_id, side = _decode_leg_key(
-                stored_key=stored_key, stored_side=stored_side
+                stored_key=reservation.idempotency_key,
+                stored_side=reservation.side,
             )
         except ValueError as exc:
             logger.warning("malformed scalping reservation kept unresolved: %s", exc)
             continue
         if await confirm(correlation_id, side):
-            await _release_stored_key(stored_key)
-            released += 1
+            deleted = await _release_observed_reservation(reservation)
+            if deleted:
+                released += 1
     return released

--- a/app/services/brokers/kis/mock_scalping_exec/reservation.py
+++ b/app/services/brokers/kis/mock_scalping_exec/reservation.py
@@ -12,12 +12,19 @@ rows to leak into retrospective / journal / holdings consumers.
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Awaitable, Callable
+from typing import Literal
 
 from app.services.order_send_intent_service import (
     KIS_MOCK_SCALPING_SCOPE,
     OrderSendIntentService,
 )
+
+logger = logging.getLogger("rob321.kis_mock_scalping_exec")
+
+ReservationSide = Literal["buy", "sell"]
+_LEG_KEY_PREFIX = "leg:v1:"
 
 
 def _session_factory():
@@ -26,27 +33,75 @@ def _session_factory():
     return _order_session_factory()
 
 
+def _normalize_side(side: str) -> ReservationSide:
+    normalized = side.strip().lower()
+    if normalized not in {"buy", "sell"}:
+        raise ValueError(f"unsupported reservation side: {side!r}")
+    return normalized  # type: ignore[return-value]
+
+
+def _leg_key(*, correlation_id: str, side: str) -> str:
+    if not correlation_id:
+        raise ValueError("correlation_id is required")
+    normalized_side = _normalize_side(side)
+    return f"{_LEG_KEY_PREFIX}{normalized_side}:{correlation_id}"
+
+
+def _decode_leg_key(
+    *, stored_key: str, stored_side: str | None
+) -> tuple[str, ReservationSide]:
+    """Decode a current leg key; retain reconciliation access to legacy raw keys."""
+    if stored_key.startswith(_LEG_KEY_PREFIX):
+        encoded_side, separator, correlation_id = stored_key[
+            len(_LEG_KEY_PREFIX) :
+        ].partition(":")
+        if not separator or not correlation_id:
+            raise ValueError(f"malformed reservation leg key: {stored_key!r}")
+        side = _normalize_side(encoded_side)
+        if stored_side is not None and _normalize_side(stored_side) != side:
+            raise ValueError(f"reservation side mismatch: {stored_key!r}")
+        return correlation_id, side
+
+    # A pre-leg-key reservation has its correlation ID as the raw key and its
+    # leg in the existing side column. Reconciliation can still identify it
+    # honestly and delete that exact stored key without a schema migration.
+    if stored_side is None:
+        raise ValueError(f"legacy reservation is missing side: {stored_key!r}")
+    return stored_key, _normalize_side(stored_side)
+
+
 async def reserve_entry(*, correlation_id: str, symbol: str, side: str) -> None:
     """Reserve a BUY or SELL leg BEFORE the POST.
 
     Raises ``DuplicateOrderIntent`` on a same-key
     resend and any other exception on a durable-write failure — both must abort
     the send (the caller returns before the broker POST)."""
+    normalized_side = _normalize_side(side)
     async with _session_factory()() as db:
         await OrderSendIntentService(db).reserve(
             account_scope=KIS_MOCK_SCALPING_SCOPE,
-            idempotency_key=correlation_id,
+            idempotency_key=_leg_key(
+                correlation_id=correlation_id, side=normalized_side
+            ),
             symbol=symbol,
-            side=side,
+            side=normalized_side,
+            # Compatibility with pre-leg-key rows from 9bb74194. Only the same
+            # normalized leg conflicts, so an unresolved legacy BUY still lets
+            # its safety-critical SELL close path reserve independently.
+            conflicting_key_sides=((correlation_id, normalized_side),),
         )
 
 
-async def release_entry(*, correlation_id: str) -> int:
+async def _release_stored_key(stored_key: str) -> int:
     async with _session_factory()() as db:
         return await OrderSendIntentService(db).release(
             account_scope=KIS_MOCK_SCALPING_SCOPE,
-            idempotency_key=correlation_id,
+            idempotency_key=stored_key,
         )
+
+
+async def release_entry(*, correlation_id: str, side: str) -> int:
+    return await _release_stored_key(_leg_key(correlation_id=correlation_id, side=side))
 
 
 async def has_unresolved_entries() -> bool:
@@ -56,17 +111,28 @@ async def has_unresolved_entries() -> bool:
         )
 
 
-async def reconcile_entries(*, confirm: Callable[[str], Awaitable[bool]]) -> int:
-    """Explicit reconciliation: release only reservations that ``confirm`` proves
-    resolved (broker evidence). Unconfirmed reservations stay, keeping trading
-    fail-closed. Returns the number released."""
+async def reconcile_entries(
+    *, confirm: Callable[[str, ReservationSide], Awaitable[bool]]
+) -> int:
+    """Release only the exact ``(correlation_id, side)`` leg broker confirms.
+
+    Unconfirmed or malformed reservations stay, keeping the global trading gate
+    fail-closed. Returns the number released.
+    """
     async with _session_factory()() as db:
-        keys = await OrderSendIntentService(db).list_keys(
+        reservations = await OrderSendIntentService(db).list_keys_and_sides(
             account_scope=KIS_MOCK_SCALPING_SCOPE
         )
     released = 0
-    for key in keys:
-        if await confirm(key):
-            await release_entry(correlation_id=key)
+    for stored_key, stored_side in reservations:
+        try:
+            correlation_id, side = _decode_leg_key(
+                stored_key=stored_key, stored_side=stored_side
+            )
+        except ValueError as exc:
+            logger.warning("malformed scalping reservation kept unresolved: %s", exc)
+            continue
+        if await confirm(correlation_id, side):
+            await _release_stored_key(stored_key)
             released += 1
     return released

--- a/app/services/brokers/kis/mock_scalping_exec/reservation.py
+++ b/app/services/brokers/kis/mock_scalping_exec/reservation.py
@@ -1,4 +1,4 @@
-"""ROB-843 P1 — write-ahead durable reservation for KIS mock scalping entries.
+"""ROB-843 P1 — write-ahead durable reservation for KIS mock scalping order legs.
 
 The reservation is inserted into ``review.order_send_intents`` BEFORE the broker
 POST, so a DB that cannot record the send never reaches the network. It is
@@ -27,7 +27,9 @@ def _session_factory():
 
 
 async def reserve_entry(*, correlation_id: str, symbol: str, side: str) -> None:
-    """Reserve BEFORE the POST. Raises ``DuplicateOrderIntent`` on a same-key
+    """Reserve a BUY or SELL leg BEFORE the POST.
+
+    Raises ``DuplicateOrderIntent`` on a same-key
     resend and any other exception on a durable-write failure — both must abort
     the send (the caller returns before the broker POST)."""
     async with _session_factory()() as db:

--- a/app/services/brokers/kis/mock_scalping_exec/reservation.py
+++ b/app/services/brokers/kis/mock_scalping_exec/reservation.py
@@ -1,0 +1,70 @@
+"""ROB-843 P1 — write-ahead durable reservation for KIS mock scalping entries.
+
+The reservation is inserted into ``review.order_send_intents`` BEFORE the broker
+POST, so a DB that cannot record the send never reaches the network. It is
+released only when the order is confirmed fully tracked or proven not sent; an
+UNRESOLVED reservation is the durable "in-flight / uncertain" state that
+survives process restart and fail-closes new orders until an explicit
+reconciliation releases it (unlike the old post-POST ledger marker, which shared
+the native write's failure mode). No writes to the order ledger — no control
+rows to leak into retrospective / journal / holdings consumers.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+
+from app.services.order_send_intent_service import (
+    KIS_MOCK_SCALPING_SCOPE,
+    OrderSendIntentService,
+)
+
+
+def _session_factory():
+    from app.mcp_server.tooling.kis_mock_ledger import _order_session_factory
+
+    return _order_session_factory()
+
+
+async def reserve_entry(*, correlation_id: str, symbol: str, side: str) -> None:
+    """Reserve BEFORE the POST. Raises ``DuplicateOrderIntent`` on a same-key
+    resend and any other exception on a durable-write failure — both must abort
+    the send (the caller returns before the broker POST)."""
+    async with _session_factory()() as db:
+        await OrderSendIntentService(db).reserve(
+            account_scope=KIS_MOCK_SCALPING_SCOPE,
+            idempotency_key=correlation_id,
+            symbol=symbol,
+            side=side,
+        )
+
+
+async def release_entry(*, correlation_id: str) -> int:
+    async with _session_factory()() as db:
+        return await OrderSendIntentService(db).release(
+            account_scope=KIS_MOCK_SCALPING_SCOPE,
+            idempotency_key=correlation_id,
+        )
+
+
+async def has_unresolved_entries() -> bool:
+    async with _session_factory()() as db:
+        return await OrderSendIntentService(db).has_reservations(
+            account_scope=KIS_MOCK_SCALPING_SCOPE
+        )
+
+
+async def reconcile_entries(*, confirm: Callable[[str], Awaitable[bool]]) -> int:
+    """Explicit reconciliation: release only reservations that ``confirm`` proves
+    resolved (broker evidence). Unconfirmed reservations stay, keeping trading
+    fail-closed. Returns the number released."""
+    async with _session_factory()() as db:
+        keys = await OrderSendIntentService(db).list_keys(
+            account_scope=KIS_MOCK_SCALPING_SCOPE
+        )
+    released = 0
+    for key in keys:
+        if await confirm(key):
+            await release_entry(correlation_id=key)
+            released += 1
+    return released

--- a/app/services/brokers/kis/mock_scalping_exec/tracking_state.py
+++ b/app/services/brokers/kis/mock_scalping_exec/tracking_state.py
@@ -1,12 +1,10 @@
-"""ROB-843 P1-2 — ledger-tracking degradation state + write-error signal.
+"""ROB-843 — durable ledger-write error signal.
 
-When an accepted broker order cannot be durably tracked (neither a native
-ledger row nor a synthetic fallback row persists), the daily broker-order count
-would silently undercount and let the cap be exceeded. We instead mark tracking
-as unavailable so the next automated order fails closed.
-
-Process-local only: cross-process reservation/tracking is ROB-853's scope. A
-single scalping daemon is one process, so this is sufficient here.
+The order-tracking fail-close is now a DURABLE write-ahead reservation
+(``review.order_send_intents``; see ``reservation.py``), not a process-local
+flag — so it survives restart and a fresh DB session. This module retains only
+the write-error type used to distinguish a benign on-conflict no-op from a lost
+native write.
 """
 
 from __future__ import annotations
@@ -15,21 +13,3 @@ from __future__ import annotations
 class LedgerWriteError(RuntimeError):
     """A durable ledger write failed with a real DB error (not a benign
     on-conflict no-op)."""
-
-
-_tracking_unavailable = False
-
-
-def mark_ledger_tracking_unavailable() -> None:
-    global _tracking_unavailable
-    _tracking_unavailable = True
-
-
-def is_ledger_tracking_unavailable() -> bool:
-    return _tracking_unavailable
-
-
-def reset_ledger_tracking_state() -> None:
-    """Test/operator hook to clear the degraded flag."""
-    global _tracking_unavailable
-    _tracking_unavailable = False

--- a/app/services/brokers/kis/mock_scalping_exec/tracking_state.py
+++ b/app/services/brokers/kis/mock_scalping_exec/tracking_state.py
@@ -1,0 +1,35 @@
+"""ROB-843 P1-2 — ledger-tracking degradation state + write-error signal.
+
+When an accepted broker order cannot be durably tracked (neither a native
+ledger row nor a synthetic fallback row persists), the daily broker-order count
+would silently undercount and let the cap be exceeded. We instead mark tracking
+as unavailable so the next automated order fails closed.
+
+Process-local only: cross-process reservation/tracking is ROB-853's scope. A
+single scalping daemon is one process, so this is sufficient here.
+"""
+
+from __future__ import annotations
+
+
+class LedgerWriteError(RuntimeError):
+    """A durable ledger write failed with a real DB error (not a benign
+    on-conflict no-op)."""
+
+
+_tracking_unavailable = False
+
+
+def mark_ledger_tracking_unavailable() -> None:
+    global _tracking_unavailable
+    _tracking_unavailable = True
+
+
+def is_ledger_tracking_unavailable() -> bool:
+    return _tracking_unavailable
+
+
+def reset_ledger_tracking_state() -> None:
+    """Test/operator hook to clear the degraded flag."""
+    global _tracking_unavailable
+    _tracking_unavailable = False

--- a/app/services/brokers/kis/order_id.py
+++ b/app/services/brokers/kis/order_id.py
@@ -1,0 +1,30 @@
+"""ROB-843 — canonical broker order-id normalization for KIS order results.
+
+Shared by the domestic and overseas KIS mock result boundary so a blank or
+whitespace-only ``odno`` is never mistaken for an accepted broker order. Pure,
+stdlib-only, no broker/DB/network imports.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def normalize_broker_order_id(value: Any) -> str | None:
+    """Return a stripped non-empty order id, else ``None``.
+
+    * ``str`` → stripped; empty/whitespace-only → ``None``.
+    * ``int`` → decimal string (but ``bool`` is rejected as malformed).
+    * ``None`` / any other type (dict, list, float, …) → ``None`` (malformed).
+
+    Used so ``accepted`` requires a *valid* broker order id, not merely a
+    truthy one (``"   "`` was previously accepted).
+    """
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        value = str(value)
+    if not isinstance(value, str):
+        return None
+    stripped = value.strip()
+    return stripped or None

--- a/app/services/brokers/kis/overseas_orders.py
+++ b/app/services/brokers/kis/overseas_orders.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any
 from app.core.symbol import to_kis_symbol
 
 from . import constants
+from .pre_send import PreSendHook
 
 if TYPE_CHECKING:
     from .protocols import KISClientProtocol
@@ -88,6 +89,7 @@ class OverseasOrderClient:
         price: float = 0.0,  # 0이면 시장가
         is_mock: bool = False,
         *,
+        pre_send_hook: PreSendHook | None = None,
         _token_retry_depth: int = 0,
     ) -> dict:
         """
@@ -200,6 +202,8 @@ class OverseasOrderClient:
             # ROB-645: never re-POST an order (see domestic order_korea_stock).
             retry_request_errors=False,
             max_retries_override=0,
+            # ROB-843 P1: mock-only freshness re-check at the HTTP send boundary.
+            pre_send_hook=pre_send_hook,
         )
 
         if js.get("rt_cd") != "0":
@@ -236,6 +240,7 @@ class OverseasOrderClient:
                     quantity,
                     price,
                     is_mock,
+                    pre_send_hook=pre_send_hook,
                     _token_retry_depth=_token_retry_depth + 1,
                 )
 
@@ -268,22 +273,18 @@ class OverseasOrderClient:
         quantity: int,
         price: float = 0.0,
         is_mock: bool = False,
+        *,
+        pre_send_hook: PreSendHook | None = None,
     ) -> dict:
-        """
-        해외주식 매수 주문 편의 메서드
-
-        Args:
-            symbol: 종목 심볼
-            exchange_code: 거래소 코드
-            quantity: 매수 수량
-            price: 매수 가격 (0이면 시장가)
-            is_mock: 모의투자 여부
-
-        Returns:
-            주문 결과
-        """
+        """해외주식 매수 주문 편의 메서드."""
         return await self.order_overseas_stock(
-            symbol, exchange_code, "buy", quantity, price, is_mock
+            symbol,
+            exchange_code,
+            "buy",
+            quantity,
+            price,
+            is_mock,
+            pre_send_hook=pre_send_hook,
         )
 
     async def sell_overseas_stock(
@@ -293,22 +294,18 @@ class OverseasOrderClient:
         quantity: int,
         price: float = 0.0,
         is_mock: bool = False,
+        *,
+        pre_send_hook: PreSendHook | None = None,
     ) -> dict:
-        """
-        해외주식 매도 주문 편의 메서드
-
-        Args:
-            symbol: 종목 심볼
-            exchange_code: 거래소 코드
-            quantity: 매도 수량
-            price: 매도 가격 (0이면 시장가)
-            is_mock: 모의투자 여부
-
-        Returns:
-            주문 결과
-        """
+        """해외주식 매도 주문 편의 메서드."""
         return await self.order_overseas_stock(
-            symbol, exchange_code, "sell", quantity, price, is_mock
+            symbol,
+            exchange_code,
+            "sell",
+            quantity,
+            price,
+            is_mock,
+            pre_send_hook=pre_send_hook,
         )
 
     async def inquire_overseas_orders(

--- a/app/services/brokers/kis/overseas_orders.py
+++ b/app/services/brokers/kis/overseas_orders.py
@@ -249,6 +249,10 @@ class OverseasOrderClient:
             "odno": output.get("ODNO"),  # 주문번호
             "ord_tmd": output.get("ORD_TMD"),  # 주문시각
             "msg": js.get("msg1"),  # 응답메시지
+            # ROB-843: preserve the provider-verified accepted contract (reached
+            # only when rt_cd == "0") for the kis_mock result boundary.
+            "rt_cd": js.get("rt_cd"),
+            "msg_cd": js.get("msg_cd"),
         }
 
         logging.info(

--- a/app/services/brokers/kis/pre_send.py
+++ b/app/services/brokers/kis/pre_send.py
@@ -1,0 +1,22 @@
+"""ROB-843 P1 — pre-send freshness abort signal.
+
+Dependency-free so both the KIS transport (``base.py``) and the order
+orchestrator (``order_execution.py``) can reference it without an import cycle.
+Raised by a mock-only pre-send callback invoked immediately before each real KIS
+HTTP mutation; the orchestrator converts it into a ``pre_send_blocked`` result.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+
+# A mock-only callback invoked immediately before each real KIS HTTP mutation.
+PreSendHook = Callable[[], Awaitable[None]]
+
+
+class PreSendFreshnessError(RuntimeError):
+    """The live book is no longer tradeable at the actual HTTP send boundary."""
+
+    def __init__(self, reason_codes: tuple[str, ...]) -> None:
+        self.reason_codes = tuple(reason_codes)
+        super().__init__(",".join(self.reason_codes) or "pre_send_freshness")

--- a/app/services/brokers/kis/protocols.py
+++ b/app/services/brokers/kis/protocols.py
@@ -10,6 +10,7 @@ from typing import Any, Protocol, runtime_checkable
 
 import httpx
 
+from app.services.brokers.kis.pre_send import PreSendHook
 from app.services.redis_token_manager import RedisTokenManager
 
 
@@ -56,6 +57,7 @@ class KISClientProtocol(Protocol):
         tr_id: str | None = None,
         retry_request_errors: bool = True,
         max_retries_override: int | None = None,
+        pre_send_hook: PreSendHook | None = None,
     ) -> dict[str, Any]:
         """Make HTTP request with rate limiting and retry logic."""
         ...
@@ -73,6 +75,7 @@ class KISClientProtocol(Protocol):
         tr_id: str | None = None,
         retry_request_errors: bool = True,
         max_retries_override: int | None = None,
+        pre_send_hook: PreSendHook | None = None,
     ) -> tuple[dict[str, Any], dict[str, str]]:
         """Make HTTP request with rate limiting and return parsed data plus headers."""
         ...

--- a/app/services/brokers/kis/protocols.py
+++ b/app/services/brokers/kis/protocols.py
@@ -11,6 +11,7 @@ from typing import Any, Protocol, runtime_checkable
 import httpx
 
 from app.services.brokers.kis.pre_send import PreSendHook
+from app.services.brokers.kis.send_outcome import OrderSendOutcomeTracker
 from app.services.redis_token_manager import RedisTokenManager
 
 
@@ -58,6 +59,7 @@ class KISClientProtocol(Protocol):
         retry_request_errors: bool = True,
         max_retries_override: int | None = None,
         pre_send_hook: PreSendHook | None = None,
+        send_outcome: OrderSendOutcomeTracker | None = None,
     ) -> dict[str, Any]:
         """Make HTTP request with rate limiting and retry logic."""
         ...
@@ -76,6 +78,7 @@ class KISClientProtocol(Protocol):
         retry_request_errors: bool = True,
         max_retries_override: int | None = None,
         pre_send_hook: PreSendHook | None = None,
+        send_outcome: OrderSendOutcomeTracker | None = None,
     ) -> tuple[dict[str, Any], dict[str, str]]:
         """Make HTTP request with rate limiting and return parsed data plus headers."""
         ...

--- a/app/services/brokers/kis/send_outcome.py
+++ b/app/services/brokers/kis/send_outcome.py
@@ -1,0 +1,48 @@
+"""Explicit KIS order-send outcome tracked at the real HTTP boundary.
+
+Only KIS mock scalping passes a tracker. Other KIS callers pass ``None`` and
+retain their existing behavior and response contracts.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+
+class OrderSendDisposition(StrEnum):
+    NOT_CREATED = "not_created"
+    ACCEPTED = "accepted"
+    UNKNOWN = "unknown"
+
+
+@dataclass
+class OrderSendOutcomeTracker:
+    disposition: OrderSendDisposition = OrderSendDisposition.NOT_CREATED
+    last_http_status: int | None = None
+
+    def mark_dispatched(self) -> None:
+        """A POST is crossing the HTTP boundary; its outcome is now uncertain."""
+        self.disposition = OrderSendDisposition.UNKNOWN
+        self.last_http_status = None
+
+    def mark_http_response(self, status_code: int) -> None:
+        self.last_http_status = status_code
+        if 400 <= status_code < 500:
+            self.disposition = OrderSendDisposition.NOT_CREATED
+        else:
+            # 2xx still needs the provider contract + order ID to prove accepted;
+            # 5xx never proves that the broker did not create an order.
+            self.disposition = OrderSendDisposition.UNKNOWN
+
+    def mark_provider_rejected(self) -> None:
+        # A business rejection in a normal (<500) response proves no order. A
+        # business-looking payload inside a 5xx response remains outcome-unknown.
+        if self.last_http_status is None or self.last_http_status < 500:
+            self.disposition = OrderSendDisposition.NOT_CREATED
+
+    def mark_accepted(self) -> None:
+        self.disposition = OrderSendDisposition.ACCEPTED
+
+    def mark_unknown(self) -> None:
+        self.disposition = OrderSendDisposition.UNKNOWN

--- a/app/services/brokers/kis/send_outcome.py
+++ b/app/services/brokers/kis/send_outcome.py
@@ -42,7 +42,14 @@ class OrderSendOutcomeTracker:
             self.disposition = OrderSendDisposition.NOT_CREATED
 
     def mark_accepted(self) -> None:
-        self.disposition = OrderSendDisposition.ACCEPTED
+        # Provider payloads carried by a 5xx response are not trusted evidence
+        # of a stable accepted outcome. Once a 5xx was observed, remain UNKNOWN.
+        if self.last_http_status is None or self.last_http_status < 500:
+            self.disposition = OrderSendDisposition.ACCEPTED
 
     def mark_unknown(self) -> None:
         self.disposition = OrderSendDisposition.UNKNOWN
+
+    @property
+    def has_untrusted_server_error_response(self) -> bool:
+        return self.last_http_status is not None and self.last_http_status >= 500

--- a/app/services/investment_reports/watch_auto_execute.py
+++ b/app/services/investment_reports/watch_auto_execute.py
@@ -9,9 +9,11 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Callable
+from dataclasses import dataclass
 from decimal import Decimal, InvalidOperation
 from typing import Any
 
+from sqlalchemy import update
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 
 from app.core.config import settings
@@ -32,6 +34,31 @@ def _to_decimal(v: Any) -> Decimal | None:
         return Decimal(str(v))
     except (InvalidOperation, TypeError, ValueError):
         return None
+
+
+@dataclass(frozen=True)
+class _PlaceOutcome:
+    executed: bool
+    reason: str | None = None
+    detail: str | None = None
+
+
+def _normalize_place_result(result: Any) -> _PlaceOutcome:
+    """Interpret the order function's normalized result truthfully (ROB-843).
+
+    A non-dict result or an explicit ``success=False`` is a failure — never a
+    silent executed=True. The stable reason/detail is preserved from the
+    normalized native contract so the watch intent records why it failed.
+    """
+    if not isinstance(result, dict):
+        return _PlaceOutcome(False, "malformed_result", str(result)[:200])
+    if result.get("success"):
+        return _PlaceOutcome(True)
+    reason = result.get("reason") or result.get("status") or "order_failed"
+    detail = (
+        result.get("detail") or result.get("response_message") or result.get("message")
+    )
+    return _PlaceOutcome(False, str(reason), str(detail) if detail else None)
 
 
 async def _default_place_order_fn(**kwargs):
@@ -134,7 +161,7 @@ async def maybe_auto_execute(
         return {"executed": False, "blocking_reasons": reasons}
 
     # 4) place the kis_mock order (executor hard-pinned is_mock=True).
-    await place_order_fn(
+    place_result = await place_order_fn(
         symbol=alert.symbol,
         side=side,
         order_type="limit",
@@ -145,4 +172,59 @@ async def maybe_auto_execute(
         is_mock=True,
         correlation_id=correlation_id,
     )
+
+    # 5) validate + persist the broker outcome truthfully (ROB-843). The result
+    # is never discarded: a failure flips the intent row to 'failed' with the
+    # stable reason/detail preserved, and returns executed=False.
+    outcome = _normalize_place_result(place_result)
+    if not outcome.executed:
+        logger.warning(
+            "auto_execute_mock order failed alert=%s reason=%s",
+            alert.alert_uuid,
+            outcome.reason,
+        )
+        await _mark_intent_failed(
+            db,
+            correlation_id=correlation_id,
+            reason=outcome.reason,
+            detail=outcome.detail,
+            preview_line=preview_line,
+        )
+        return {
+            "executed": False,
+            "reason": outcome.reason,
+            "detail": outcome.detail,
+            "correlation_id": correlation_id,
+        }
+
     return {"executed": True, "correlation_id": correlation_id}
+
+
+async def _mark_intent_failed(
+    db,
+    *,
+    correlation_id: str,
+    reason: str | None,
+    detail: str | None,
+    preview_line: dict[str, Any],
+) -> None:
+    """Flip the previewed intent row to 'failed', preserving reason/detail.
+
+    Reuses existing columns only (no schema migration): ``blocked_by`` /
+    ``blocking_reasons`` carry the reason and ``preview_line.failure_detail``
+    carries the redacted broker detail.
+    """
+    reason = reason or "order_failed"
+    failed_preview = {**preview_line, "failure_detail": detail}
+    await db.execute(
+        update(WatchOrderIntentLedger)
+        .where(WatchOrderIntentLedger.correlation_id == correlation_id)
+        .values(
+            lifecycle_state="failed",
+            execution_allowed=False,
+            blocked_by=reason,
+            blocking_reasons=[reason],
+            preview_line=failed_preview,
+        )
+    )
+    await db.commit()

--- a/app/services/investment_reports/watch_auto_execute.py
+++ b/app/services/investment_reports/watch_auto_execute.py
@@ -160,18 +160,26 @@ async def maybe_auto_execute(
     if not allowed:
         return {"executed": False, "blocking_reasons": reasons}
 
-    # 4) place the kis_mock order (executor hard-pinned is_mock=True).
-    place_result = await place_order_fn(
-        symbol=alert.symbol,
-        side=side,
-        order_type="limit",
-        quantity=float(quantity),
-        price=float(limit_price),
-        dry_run=False,
-        reason="watch auto_execute_mock",
-        is_mock=True,
-        correlation_id=correlation_id,
-    )
+    # 4) place the kis_mock order (executor hard-pinned is_mock=True). A raised
+    # exception is a failure too — never leave the intent 'previewed' (ROB-843).
+    try:
+        place_result: Any = await place_order_fn(
+            symbol=alert.symbol,
+            side=side,
+            order_type="limit",
+            quantity=float(quantity),
+            price=float(limit_price),
+            dry_run=False,
+            reason="watch auto_execute_mock",
+            is_mock=True,
+            correlation_id=correlation_id,
+        )
+    except Exception as exc:  # noqa: BLE001 — surface as a truthful failed outcome
+        place_result = {
+            "success": False,
+            "reason": "order_exception",
+            "detail": f"{type(exc).__name__}: {exc}"[:200],
+        }
 
     # 5) validate + persist the broker outcome truthfully (ROB-843). The result
     # is never discarded: a failure flips the intent row to 'failed' with the

--- a/app/services/order_send_intent_service.py
+++ b/app/services/order_send_intent_service.py
@@ -9,13 +9,20 @@ from __future__ import annotations
 
 import logging
 
-from sqlalchemy import delete
+from sqlalchemy import delete, func, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.review import OrderSendIntent
 
 logger = logging.getLogger(__name__)
+
+# ROB-843 P1: write-ahead reservation scope for automated KIS mock scalping
+# entries. A reservation is inserted BEFORE the broker POST (proving the DB is
+# writable) and released only when the order is confirmed fully tracked or
+# proven not sent. An UNRESOLVED reservation is a durable "in-flight / uncertain"
+# marker that survives restart and fail-closes new orders until reconciliation.
+KIS_MOCK_SCALPING_SCOPE = "kis_mock_scalping"
 
 
 class DuplicateOrderIntent(Exception):
@@ -66,3 +73,26 @@ class OrderSendIntentService:
         )
         await self._db.commit()
         return int(result.rowcount or 0)
+
+    async def has_reservations(self, *, account_scope: str) -> bool:
+        """True if ANY unresolved reservation exists in ``account_scope``.
+
+        Used as the durable fail-close signal (ROB-843 P1): while an automated
+        mock order is in-flight/uncertain its reservation is still present, so
+        new orders must fail-close until reconciliation releases it.
+        """
+        found = await self._db.scalar(
+            select(func.count())
+            .select_from(OrderSendIntent)
+            .where(OrderSendIntent.account_scope == account_scope)
+        )
+        return bool(found or 0)
+
+    async def list_keys(self, *, account_scope: str) -> list[str]:
+        """The idempotency keys of all unresolved reservations in ``account_scope``."""
+        rows = await self._db.execute(
+            select(OrderSendIntent.idempotency_key).where(
+                OrderSendIntent.account_scope == account_scope
+            )
+        )
+        return [k for (k,) in rows.all()]

--- a/app/services/order_send_intent_service.py
+++ b/app/services/order_send_intent_service.py
@@ -2,14 +2,15 @@
 """ROB-653 P6-B — KIS pre-send reservation service.
 
 Writes the sole double-send guard for KIS live orders (no broker idempotency
-key). All writes go through this service — no raw SQL. Never read by reconcile.
+key). All writes and explicit reservation reconciliation go through this
+service — no raw SQL.
 """
 
 from __future__ import annotations
 
 import logging
 
-from sqlalchemy import delete, func, select
+from sqlalchemy import and_, delete, func, or_, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -18,7 +19,7 @@ from app.models.review import OrderSendIntent
 logger = logging.getLogger(__name__)
 
 # ROB-843 P1: write-ahead reservation scope for automated KIS mock scalping
-# entries. A reservation is inserted BEFORE the broker POST (proving the DB is
+# order legs. A reservation is inserted BEFORE the broker POST (proving the DB is
 # writable) and released only when the order is confirmed fully tracked or
 # proven not sent. An UNRESOLVED reservation is a durable "in-flight / uncertain"
 # marker that survives restart and fail-closes new orders until reconciliation.
@@ -40,7 +41,34 @@ class OrderSendIntentService:
         idempotency_key: str,
         symbol: str | None = None,
         side: str | None = None,
+        conflicting_key_sides: tuple[tuple[str, str], ...] = (),
     ) -> int:
+        if conflicting_key_sides:
+            predicates = [
+                and_(
+                    OrderSendIntent.idempotency_key == key,
+                    or_(
+                        OrderSendIntent.side.is_(None),
+                        func.lower(func.trim(OrderSendIntent.side))
+                        == conflicting_side.strip().lower(),
+                    ),
+                )
+                for key, conflicting_side in conflicting_key_sides
+            ]
+            existing = await self._db.scalar(
+                select(OrderSendIntent.id)
+                .where(
+                    OrderSendIntent.account_scope == account_scope,
+                    or_(*predicates),
+                )
+                .with_for_update()
+                .limit(1)
+            )
+            if existing is not None:
+                raise DuplicateOrderIntent(
+                    f"conflicting order intent already reserved: {account_scope}"
+                )
+
         row = OrderSendIntent(
             account_scope=account_scope,
             idempotency_key=idempotency_key,
@@ -96,3 +124,14 @@ class OrderSendIntentService:
             )
         )
         return [k for (k,) in rows.all()]
+
+    async def list_keys_and_sides(
+        self, *, account_scope: str
+    ) -> list[tuple[str, str | None]]:
+        """Stored keys with side evidence for explicit leg reconciliation."""
+        rows = await self._db.execute(
+            select(OrderSendIntent.idempotency_key, OrderSendIntent.side).where(
+                OrderSendIntent.account_scope == account_scope
+            )
+        )
+        return list(rows.all())

--- a/app/services/order_send_intent_service.py
+++ b/app/services/order_send_intent_service.py
@@ -9,6 +9,7 @@ service — no raw SQL.
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass
 
 from sqlalchemy import and_, delete, func, or_, select
 from sqlalchemy.exc import IntegrityError
@@ -28,6 +29,13 @@ KIS_MOCK_SCALPING_SCOPE = "kis_mock_scalping"
 
 class DuplicateOrderIntent(Exception):
     """Raised when (account_scope, idempotency_key) is already reserved."""
+
+
+@dataclass(frozen=True)
+class OrderSendIntentReservation:
+    row_id: int
+    idempotency_key: str
+    side: str | None
 
 
 class OrderSendIntentService:
@@ -102,6 +110,31 @@ class OrderSendIntentService:
         await self._db.commit()
         return int(result.rowcount or 0)
 
+    async def release_if_matches(
+        self,
+        *,
+        account_scope: str,
+        row_id: int,
+        idempotency_key: str,
+        side: str | None,
+    ) -> int:
+        """Delete only the exact reservation row observed before external I/O."""
+        side_predicate = (
+            OrderSendIntent.side.is_(None)
+            if side is None
+            else OrderSendIntent.side == side
+        )
+        result = await self._db.execute(
+            delete(OrderSendIntent).where(
+                OrderSendIntent.id == row_id,
+                OrderSendIntent.account_scope == account_scope,
+                OrderSendIntent.idempotency_key == idempotency_key,
+                side_predicate,
+            )
+        )
+        await self._db.commit()
+        return int(result.rowcount or 0)
+
     async def has_reservations(self, *, account_scope: str) -> bool:
         """True if ANY unresolved reservation exists in ``account_scope``.
 
@@ -125,13 +158,22 @@ class OrderSendIntentService:
         )
         return [k for (k,) in rows.all()]
 
-    async def list_keys_and_sides(
+    async def list_reservations(
         self, *, account_scope: str
-    ) -> list[tuple[str, str | None]]:
-        """Stored keys with side evidence for explicit leg reconciliation."""
+    ) -> list[OrderSendIntentReservation]:
+        """Immutable row references used across external reconciliation I/O."""
         rows = await self._db.execute(
-            select(OrderSendIntent.idempotency_key, OrderSendIntent.side).where(
-                OrderSendIntent.account_scope == account_scope
-            )
+            select(
+                OrderSendIntent.id,
+                OrderSendIntent.idempotency_key,
+                OrderSendIntent.side,
+            ).where(OrderSendIntent.account_scope == account_scope)
         )
-        return list(rows.all())
+        return [
+            OrderSendIntentReservation(
+                row_id=row_id,
+                idempotency_key=idempotency_key,
+                side=side,
+            )
+            for row_id, idempotency_key, side in rows.all()
+        ]

--- a/app/services/trade_journal/mock_roundtrip_journal_bridge.py
+++ b/app/services/trade_journal/mock_roundtrip_journal_bridge.py
@@ -18,6 +18,7 @@ from sqlalchemy import select
 from app.core.config import settings
 from app.models.review import KISMockOrderLedger
 from app.models.trade_journal import TradeJournal
+from app.services.brokers.kis.mock_scalping_exec.ledger_state import real_order_filter
 
 logger = logging.getLogger(__name__)
 
@@ -37,6 +38,8 @@ async def sync_mock_roundtrip_journals(db, *, force: bool = False) -> dict[str, 
                     KISMockOrderLedger.account_mode == "kis_mock",
                     KISMockOrderLedger.correlation_id.is_not(None),
                     KISMockOrderLedger.lifecycle_state.in_(_RECONCILED_STATES),
+                    # ROB-843 P2: never journal a control/reservation row.
+                    real_order_filter(),
                 )
                 .order_by(
                     KISMockOrderLedger.trade_date.asc(), KISMockOrderLedger.id.asc()

--- a/app/services/trade_journal/trade_retrospective_service.py
+++ b/app/services/trade_journal/trade_retrospective_service.py
@@ -34,6 +34,7 @@ from app.schemas.trade_retrospective import (
     IntendedVsHappened,
     NextAction,
 )
+from app.services.brokers.kis.mock_scalping_exec.ledger_state import real_order_filter
 
 # Sentinel: distinguishes "caller did not provide this field" (preserve on
 # upsert) from "caller explicitly set None" (clear the field).
@@ -1133,6 +1134,8 @@ async def build_retrospective_pending(
                 KISMockOrderLedger.lifecycle_state.in_(_KIS_MOCK_TERMINAL),
                 KISMockOrderLedger.trade_date >= window_start,
                 KISMockOrderLedger.trade_date <= window_end,
+                # ROB-843 P2: never retrospect a control/reservation row.
+                real_order_filter(),
             )
             .order_by(KISMockOrderLedger.trade_date.desc())
             .limit(_PENDING_LEDGER_FETCH_CAP)

--- a/scripts/kis_mock_scalping_daemon.py
+++ b/scripts/kis_mock_scalping_daemon.py
@@ -74,9 +74,11 @@ async def run_daemon(args: argparse.Namespace) -> int:
 
     queue = QuoteEventQueue()
     supervisor = KisScalpingSupervisor(symbols=symbols)
-    broker = KisMockBroker(get_state=supervisor.market_state)
-    ledger = KisMockLedgerWriter()
     limits = ScalpingRiskLimits()
+    # ROB-843 P1-1: the broker owns the final pre-send freshness re-check, so it
+    # needs the same limits (age/spread caps) the risk gate uses.
+    broker = KisMockBroker(get_state=supervisor.market_state, limits=limits)
+    ledger = KisMockLedgerWriter()
     # ROB-843: the executor owns the final pre-send risk re-check. Wire a real
     # gate (fresh live-market + durable-ledger snapshot) so a confirmed entry
     # can never bypass it.

--- a/scripts/kis_mock_scalping_daemon.py
+++ b/scripts/kis_mock_scalping_daemon.py
@@ -33,6 +33,7 @@ from app.services.brokers.kis.mock_scalping.contract import ScalpingRiskLimits
 from app.services.brokers.kis.mock_scalping_exec.adapters import (
     KisMockBroker,
     KisMockLedgerWriter,
+    KisMockRiskGate,
 )
 from app.services.brokers.kis.mock_scalping_exec.executor import MockScalpingExecutor
 from app.services.brokers.kis.mock_scalping_exec.ws_bridge import WsExecutionBridge
@@ -75,10 +76,15 @@ async def run_daemon(args: argparse.Namespace) -> int:
     supervisor = KisScalpingSupervisor(symbols=symbols)
     broker = KisMockBroker(get_state=supervisor.market_state)
     ledger = KisMockLedgerWriter()
-    executor = MockScalpingExecutor(broker=broker, ledger=ledger)
-    bridge = WsExecutionBridge(
-        executor=executor, limits=ScalpingRiskLimits(), confirm=confirm
+    limits = ScalpingRiskLimits()
+    # ROB-843: the executor owns the final pre-send risk re-check. Wire a real
+    # gate (fresh live-market + durable-ledger snapshot) so a confirmed entry
+    # can never bypass it.
+    risk_gate = KisMockRiskGate(get_state=supervisor.market_state)
+    executor = MockScalpingExecutor(
+        broker=broker, ledger=ledger, risk=risk_gate, limits=limits
     )
+    bridge = WsExecutionBridge(executor=executor, limits=limits, confirm=confirm)
     ws = KISQuoteWebSocket(
         symbols=symbols,
         on_tick=queue.on_tick,

--- a/tests/brokers/kis/mock_scalping_exec/test_control_row_isolation.py
+++ b/tests/brokers/kis/mock_scalping_exec/test_control_row_isolation.py
@@ -1,0 +1,140 @@
+"""ROB-843 P2 — control/reservation rows must never be treated as trades.
+
+Any legacy control row in review.kis_mock_order_ledger (reserved symbol /
+scalping_role / reason) is excluded by a shared real-order predicate from the
+retrospective scan and the roundtrip journal bridge, while genuine entry/exit
+anomalies and reconciled trades stay included.
+"""
+
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import delete, select
+
+from app.core.timezone import now_kst
+from app.mcp_server.tooling.kis_mock_ledger import (
+    _order_session_factory,
+    _save_kis_mock_order_ledger,
+)
+from app.models.review import KISMockOrderLedger
+from app.models.trade_journal import TradeJournal
+from app.services.trade_journal.mock_roundtrip_journal_bridge import (
+    sync_mock_roundtrip_journals,
+)
+from app.services.trade_journal.trade_retrospective_service import (
+    build_retrospective_pending,
+)
+
+_CONTROL_SYMBOL = "__ledger_tracking__"
+
+
+async def _ins(**over) -> None:
+    kw = {
+        "symbol": "000000",
+        "instrument_type": "equity_kr",
+        "side": "buy",
+        "order_type": "limit",
+        "quantity": 1.0,
+        "price": 70000.0,
+        "amount": 70000.0,
+        "currency": "KRW",
+        "order_no": None,
+        "order_time": None,
+        "krx_fwdg_ord_orgno": None,
+        "status": "accepted",
+        "response_code": None,
+        "response_message": None,
+        "raw_response": None,
+        "reason": "t",
+        "thesis": None,
+        "strategy": None,
+        "notes": None,
+    }
+    kw.update(over)
+    await _save_kis_mock_order_ledger(**kw)
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def _clear_control_and_journals():
+    async def _c():
+        async with _order_session_factory()() as db:
+            await db.execute(
+                delete(KISMockOrderLedger).where(
+                    KISMockOrderLedger.symbol.in_([_CONTROL_SYMBOL, "900701", "900702"])
+                )
+            )
+            await db.execute(
+                delete(TradeJournal).where(
+                    TradeJournal.symbol.in_([_CONTROL_SYMBOL, "900701", "900702"])
+                )
+            )
+            await db.commit()
+
+    await _c()
+    yield
+    await _c()
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_control_anomaly_row_not_in_retrospective_pending(db_session) -> None:
+    day = now_kst().strftime("%Y-%m-%d")
+    # legacy control row (anomaly) + a genuine entry anomaly for a real symbol
+    await _ins(
+        symbol=_CONTROL_SYMBOL,
+        side="buy",
+        scalping_role="tracking_degraded",
+        reason="ledger_tracking_degraded",
+        status="unknown",
+        lifecycle_state="anomaly",
+        correlation_id="ctl-1",
+    )
+    await _ins(
+        symbol="900701",
+        side="buy",
+        scalping_role="entry",
+        status="unknown",
+        lifecycle_state="anomaly",
+        correlation_id="real-1",
+    )
+
+    result = await build_retrospective_pending(
+        db_session, kst_date_from=day, kst_date_to=day, account_mode="kis_mock"
+    )
+    symbols = {p["symbol"] for p in result["pending"]}
+    assert _CONTROL_SYMBOL not in symbols  # control row excluded
+    assert "900701" in symbols  # genuine anomaly still surfaced
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_control_reconciled_rows_make_no_journal(db_session) -> None:
+    # A pair of control reconciled rows (would otherwise pair into a fake
+    # __ledger_tracking__ journal) + a genuine reconciled roundtrip.
+    for side, role in (("buy", "tracking_degraded"), ("sell", "tracking_degraded")):
+        await _ins(
+            symbol=_CONTROL_SYMBOL,
+            side=side,
+            scalping_role=role,
+            reason="ledger_tracking_degraded",
+            status="unknown",
+            lifecycle_state="reconciled",
+            correlation_id="ctl-journal",
+        )
+    for side, role in (("buy", "entry"), ("sell", "exit")):
+        await _ins(
+            symbol="900702",
+            side=side,
+            scalping_role=role,
+            lifecycle_state="reconciled",
+            correlation_id="real-journal",
+        )
+
+    await sync_mock_roundtrip_journals(db_session, force=True)
+
+    journ_symbols = (
+        (await db_session.execute(select(TradeJournal.symbol))).scalars().all()
+    )
+    assert _CONTROL_SYMBOL not in journ_symbols  # no fake control journal
+    assert "900702" in journ_symbols  # genuine roundtrip journaled

--- a/tests/brokers/kis/mock_scalping_exec/test_executor.py
+++ b/tests/brokers/kis/mock_scalping_exec/test_executor.py
@@ -7,15 +7,36 @@ from typing import Any
 
 import pytest
 
+from app.services.brokers.kis.mock_scalping.contract import (
+    LedgerSnapshot,
+    MarketConditions,
+)
 from app.services.brokers.kis.mock_scalping.order_intent import OrderIntent
 from app.services.brokers.kis.mock_scalping_exec.executor import (
     ExecutorConfig,
     Fill,
     MockScalpingExecutor,
     Quote,
+    RiskInputs,
 )
 
 SYMBOL = "005930"
+
+
+class _PassRiskGate:
+    """Permissive executor-owned risk gate (all guards clear)."""
+
+    async def load(self, *, symbol: str, side: str) -> RiskInputs:
+        return RiskInputs(
+            ledger=LedgerSnapshot(
+                has_open_position_for_symbol=False,
+                open_position_count=0,
+                orders_today=0,
+                realized_loss_today_krw=Decimal("0"),
+                seconds_since_last_close_for_symbol=None,
+            ),
+            market=MarketConditions(spread_bps=Decimal("10"), data_age_seconds=1.0),
+        )
 
 
 def _intent(entry: Decimal | None = Decimal("70000")) -> OrderIntent:
@@ -78,7 +99,7 @@ class FakeLedger:
         return [c[0] for c in self.calls]
 
 
-def _executor(broker, ledger, **cfg):
+def _executor(broker, ledger, *, risk=_PassRiskGate(), **cfg):
     async def _no_sleep(_s: float) -> None:
         return None
 
@@ -88,6 +109,7 @@ def _executor(broker, ledger, **cfg):
         config=ExecutorConfig(**cfg) if cfg else ExecutorConfig(),
         sleep=_no_sleep,
         clock=lambda: 0.0,  # frozen clock -> no time-stop unless max_hold=0
+        risk=risk,
     )
 
 

--- a/tests/brokers/kis/mock_scalping_exec/test_executor_risk_gate.py
+++ b/tests/brokers/kis/mock_scalping_exec/test_executor_risk_gate.py
@@ -91,7 +91,9 @@ class FakeLedger:
 class FakeRiskGate:
     """Executor-owned snapshot provider. Records every load call."""
 
-    def __init__(self, *, inputs: RiskInputs | None = None, raises: Exception | None = None):
+    def __init__(
+        self, *, inputs: RiskInputs | None = None, raises: Exception | None = None
+    ):
         self._inputs = inputs
         self._raises = raises
         self.calls = 0

--- a/tests/brokers/kis/mock_scalping_exec/test_executor_risk_gate.py
+++ b/tests/brokers/kis/mock_scalping_exec/test_executor_risk_gate.py
@@ -1,0 +1,266 @@
+"""ROB-843 — executor-owned final risk re-check (WS scalping).
+
+The monitored executor must reload a fresh ledger/market snapshot and run
+``evaluate_risk`` immediately before any broker submit. Every risk denial and
+every snapshot load/parse/freshness failure fail-closes to ZERO broker calls.
+Caller-computed risk is advisory only — the executor never trusts it.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Any
+
+import pytest
+
+from app.services.brokers.kis.mock_scalping.contract import (
+    LedgerSnapshot,
+    MarketConditions,
+    ReasonCode,
+    ScalpingRiskLimits,
+)
+from app.services.brokers.kis.mock_scalping.order_intent import OrderIntent
+from app.services.brokers.kis.mock_scalping_exec.executor import (
+    ExecutorConfig,
+    Fill,
+    MockScalpingExecutor,
+    Quote,
+    RiskInputs,
+)
+
+SYMBOL = "005930"
+
+
+def _intent(entry: Decimal | None = Decimal("70000")) -> OrderIntent:
+    return OrderIntent(
+        symbol=SYMBOL,
+        side="BUY",
+        order_type="limit",
+        target_notional_krw=Decimal("100000"),
+        entry_reference_price=entry,
+        tp_price=Decimal("70210"),
+        sl_price=Decimal("69860"),
+        confidence=Decimal("0.5"),
+        reason_codes=("enter_long_breakout",),
+        source_candle_close_time_ms=1,
+        evaluated_at_ms=2,
+    )
+
+
+class FakeBroker:
+    def __init__(self, *, quotes=None, entry_fill=None, exit_fill=None):
+        self._quotes = list(quotes or [])
+        self._i = 0
+        self.entry_fill = entry_fill
+        self.exit_fill = exit_fill
+        self.submitted: list[tuple[str, dict]] = []
+
+    async def submit_buy(self, **kw: Any) -> dict:
+        self.submitted.append(("buy", kw))
+        return {"kind": "buy", **kw}
+
+    async def submit_exit_sell(self, **kw: Any) -> dict:
+        self.submitted.append(("sell", kw))
+        return {"kind": "sell", **kw}
+
+    async def confirm_fill(self, submit_result: dict) -> Fill | None:
+        return self.entry_fill if submit_result["kind"] == "buy" else self.exit_fill
+
+    def quote(self, symbol: str) -> Quote | None:
+        if not self._quotes:
+            return None
+        q = self._quotes[min(self._i, len(self._quotes) - 1)]
+        self._i += 1
+        return q
+
+
+class FakeLedger:
+    def __init__(self):
+        self.calls: list[tuple[str, dict]] = []
+
+    async def record_entry(self, **kw: Any) -> None:
+        self.calls.append(("entry", kw))
+
+    async def record_exit_reconciled(self, **kw: Any) -> None:
+        self.calls.append(("exit_reconciled", kw))
+
+    async def record_anomaly(self, **kw: Any) -> None:
+        self.calls.append(("anomaly", kw))
+
+
+class FakeRiskGate:
+    """Executor-owned snapshot provider. Records every load call."""
+
+    def __init__(self, *, inputs: RiskInputs | None = None, raises: Exception | None = None):
+        self._inputs = inputs
+        self._raises = raises
+        self.calls = 0
+
+    async def load(self, *, symbol: str, side: str) -> RiskInputs:
+        self.calls += 1
+        if self._raises is not None:
+            raise self._raises
+        assert self._inputs is not None
+        return self._inputs
+
+
+def _pass_inputs(
+    *,
+    has_open=False,
+    open_count=0,
+    orders_today=0,
+    realized_loss=Decimal("0"),
+    since_close: float | None = None,
+    spread_bps=Decimal("10"),
+    data_age=1.0,
+) -> RiskInputs:
+    return RiskInputs(
+        ledger=LedgerSnapshot(
+            has_open_position_for_symbol=has_open,
+            open_position_count=open_count,
+            orders_today=orders_today,
+            realized_loss_today_krw=realized_loss,
+            seconds_since_last_close_for_symbol=since_close,
+        ),
+        market=MarketConditions(spread_bps=spread_bps, data_age_seconds=data_age),
+    )
+
+
+def _executor(broker, ledger, *, risk=None, limits=None, **cfg):
+    async def _no_sleep(_s: float) -> None:
+        return None
+
+    return MockScalpingExecutor(
+        broker=broker,
+        ledger=ledger,
+        config=ExecutorConfig(**cfg) if cfg else ExecutorConfig(),
+        sleep=_no_sleep,
+        clock=lambda: 0.0,
+        risk=risk,
+        limits=limits or ScalpingRiskLimits(),
+    )
+
+
+# --- Five risk denials each place ZERO broker orders (AC1) --------------------
+
+_DENIALS = [
+    pytest.param(
+        {"realized_loss": Decimal("50000")},
+        ReasonCode.DAILY_LOSS_BUDGET_EXHAUSTED,
+        id="daily_loss",
+    ),
+    pytest.param(
+        {"open_count": 1},
+        ReasonCode.MAX_OPEN_POSITIONS_REACHED,
+        id="position_cap",
+    ),
+    pytest.param(
+        {"since_close": 10.0},
+        ReasonCode.COOLDOWN_ACTIVE,
+        id="cooldown",
+    ),
+    pytest.param(
+        {"data_age": 120.0},
+        ReasonCode.STALE_DATA,
+        id="stale_quote",
+    ),
+    pytest.param(
+        {"spread_bps": Decimal("50")},
+        ReasonCode.SPREAD_TOO_WIDE,
+        id="wide_spread",
+    ),
+]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@pytest.mark.parametrize("overrides,reason", _DENIALS)
+async def test_risk_denial_places_zero_broker_orders(overrides, reason) -> None:
+    broker = FakeBroker()
+    ledger = FakeLedger()
+    gate = FakeRiskGate(inputs=_pass_inputs(**overrides))
+    result = await _executor(broker, ledger, risk=gate).execute_monitored(
+        _intent(), confirm=True
+    )
+    assert result.status == "blocked"
+    assert reason in result.reason_codes
+    assert broker.submitted == []  # zero broker calls
+    assert ledger.calls == []
+    assert gate.calls == 1  # executor loaded its own fresh snapshot
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_snapshot_unavailable_fail_closes() -> None:
+    broker = FakeBroker()
+    ledger = FakeLedger()
+    gate = FakeRiskGate(raises=RuntimeError("db down"))
+    result = await _executor(broker, ledger, risk=gate).execute_monitored(
+        _intent(), confirm=True
+    )
+    assert result.status == "blocked"
+    assert result.reason_codes == ("risk_snapshot_unavailable",)
+    assert broker.submitted == []
+    assert result.detail  # exception detail preserved
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_confirm_without_risk_gate_fail_closes() -> None:
+    """A confirm-mode executor with no wired risk gate cannot mutate."""
+    broker = FakeBroker()
+    ledger = FakeLedger()
+    result = await _executor(broker, ledger, risk=None).execute_monitored(
+        _intent(), confirm=True
+    )
+    assert result.status == "blocked"
+    assert result.reason_codes == ("risk_gate_unconfigured",)
+    assert broker.submitted == []
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_risk_pass_proceeds_to_reconciled_round_trip() -> None:
+    broker = FakeBroker(
+        quotes=[
+            Quote(bid=Decimal("70000"), ask=None, last=None),
+            Quote(bid=Decimal("70300"), ask=None, last=None),
+        ],
+        entry_fill=Fill(Decimal("70000"), Decimal("1")),
+        exit_fill=Fill(Decimal("70300"), Decimal("1")),
+    )
+    ledger = FakeLedger()
+    gate = FakeRiskGate(inputs=_pass_inputs())
+    result = await _executor(broker, ledger, risk=gate).execute_monitored(
+        _intent(), confirm=True
+    )
+    assert result.status == "reconciled"
+    assert [s[0] for s in broker.submitted] == ["buy", "sell"]
+    assert gate.calls == 1
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_dry_run_with_gate_denial_previews_nothing() -> None:
+    broker = FakeBroker()
+    ledger = FakeLedger()
+    gate = FakeRiskGate(inputs=_pass_inputs(spread_bps=Decimal("50")))
+    result = await _executor(broker, ledger, risk=gate).execute_monitored(
+        _intent(), confirm=False
+    )
+    assert result.status == "blocked"
+    assert ReasonCode.SPREAD_TOO_WIDE in result.reason_codes
+    assert broker.submitted == []  # not even a dry-run preview
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_dry_run_without_gate_still_previews() -> None:
+    """Legacy dry-run with no gate keeps previewing (no mutation happens)."""
+    broker = FakeBroker(quotes=[Quote(bid=Decimal("70300"), ask=None, last=None)])
+    ledger = FakeLedger()
+    result = await _executor(broker, ledger, risk=None).execute_monitored(
+        _intent(), confirm=False
+    )
+    assert result.status == "dry_run"
+    assert [s[0] for s in broker.submitted] == ["buy"]

--- a/tests/brokers/kis/mock_scalping_exec/test_order_history_ledger.py
+++ b/tests/brokers/kis/mock_scalping_exec/test_order_history_ledger.py
@@ -1,0 +1,227 @@
+"""ROB-843 Blockers 1 & 4 — cooldown anchor + daily broker-order de-dup.
+
+Cooldown must key off the position-closing SELL's ``reconciled_at`` (not
+``trade_date``, not a BUY), and fail-close on a legacy close missing it. The
+daily broker-order count must count each actually-submitted order once,
+excluding synthetic scalping audit rows and non-submitted rows.
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+import pytest
+from sqlalchemy import delete, update
+
+from app.core.timezone import now_kst
+from app.mcp_server.tooling.kis_mock_ledger import (
+    _order_session_factory,
+    _save_kis_mock_order_ledger,
+)
+from app.models.review import KISMockOrderLedger
+from app.services.brokers.kis.mock_scalping_exec.ledger_state import (
+    _start_of_kst_day,
+    daily_broker_order_count_stmt,
+    load_kis_mock_order_history,
+)
+
+
+async def _reset(symbol: str) -> None:
+    """Clear a symbol's rows so tests are deterministic on the persistent
+    shared test DB (committed rows survive across runs and days)."""
+    async with _order_session_factory()() as db:
+        await db.execute(
+            delete(KISMockOrderLedger).where(KISMockOrderLedger.symbol == symbol)
+        )
+        await db.commit()
+
+
+async def _ins(**over) -> None:
+    kw = {
+        "symbol": "000000",
+        "instrument_type": "equity_kr",
+        "side": "buy",
+        "order_type": "limit",
+        "quantity": 1.0,
+        "price": 1000.0,
+        "amount": 1000.0,
+        "currency": "KRW",
+        "order_no": None,
+        "order_time": None,
+        "krx_fwdg_ord_orgno": None,
+        "status": "accepted",
+        "response_code": None,
+        "response_message": None,
+        "raw_response": None,
+        "reason": "t",
+        "thesis": None,
+        "strategy": None,
+        "notes": None,
+    }
+    kw.update(over)
+    await _save_kis_mock_order_ledger(**kw)
+
+
+async def _backdate(symbol: str, *, trade_date=None, reconciled_at="__keep__") -> None:
+    values: dict = {}
+    if trade_date is not None:
+        values["trade_date"] = trade_date
+    if reconciled_at != "__keep__":
+        values["reconciled_at"] = reconciled_at
+    async with _order_session_factory()() as db:
+        await db.execute(
+            update(KISMockOrderLedger)
+            .where(KISMockOrderLedger.symbol == symbol)
+            .values(**values)
+        )
+        await db.commit()
+
+
+# --- Blocker 1: cooldown anchor -----------------------------------------------
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_cooldown_uses_reconciled_at_not_trade_date(db_session) -> None:
+    sym = "900101"
+    await _reset(sym)
+    await _ins(
+        symbol=sym, side="sell", lifecycle_state="reconciled", order_no=f"c-{sym}"
+    )
+    # Backdate trade_date 30 days; reconciled_at stays ~now (auto-stamped).
+    await _backdate(sym, trade_date=now_kst() - timedelta(days=30))
+    hist = await load_kis_mock_order_history(symbol=sym)
+    # If trade_date were the anchor this would be ~2.6M seconds; reconciled_at
+    # (recent) keeps it small -> cooldown active off the real close time.
+    assert hist.seconds_since_last_close_for_symbol is not None
+    assert hist.seconds_since_last_close_for_symbol < 3600
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_reconciled_buy_is_not_a_close_anchor(db_session) -> None:
+    sym = "900102"
+    await _reset(sym)
+    await _ins(
+        symbol=sym, side="buy", lifecycle_state="reconciled", order_no=f"b-{sym}"
+    )
+    hist = await load_kis_mock_order_history(symbol=sym)
+    assert hist.seconds_since_last_close_for_symbol is None
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_failed_and_anomaly_sells_are_not_close_anchors(db_session) -> None:
+    sym = "900103"
+    await _reset(sym)
+    await _ins(
+        symbol=sym,
+        side="sell",
+        lifecycle_state="failed",
+        status="rejected",
+        order_no=f"f-{sym}",
+    )
+    await _ins(
+        symbol=sym,
+        side="sell",
+        lifecycle_state="anomaly",
+        status="unknown",
+        order_no=f"a-{sym}",
+    )
+    hist = await load_kis_mock_order_history(symbol=sym)
+    assert hist.seconds_since_last_close_for_symbol is None
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_latest_sell_reconciled_at_is_selected(db_session) -> None:
+    sym = "900104"
+    await _reset(sym)
+    await _ins(
+        symbol=sym, side="sell", lifecycle_state="reconciled", order_no=f"old-{sym}"
+    )
+    await _backdate(sym, reconciled_at=now_kst() - timedelta(hours=5))
+    await _ins(
+        symbol=sym, side="sell", lifecycle_state="reconciled", order_no=f"new-{sym}"
+    )
+    # newest row keeps auto reconciled_at ~ now; MAX(reconciled_at) -> small age
+    hist = await load_kis_mock_order_history(symbol=sym)
+    assert hist.seconds_since_last_close_for_symbol is not None
+    assert hist.seconds_since_last_close_for_symbol < 3600
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_legacy_close_missing_reconciled_at_fail_closes(db_session) -> None:
+    sym = "900105"
+    await _reset(sym)
+    await _ins(
+        symbol=sym, side="sell", lifecycle_state="reconciled", order_no=f"c-{sym}"
+    )
+    await _backdate(sym, reconciled_at=None)  # simulate legacy null
+    with pytest.raises(RuntimeError):
+        await load_kis_mock_order_history(symbol=sym)
+
+
+# --- Blocker 4: daily broker-order de-dup -------------------------------------
+
+
+async def _count(symbol: str) -> int:
+    since = _start_of_kst_day(now_kst())
+    async with _order_session_factory()() as db:
+        return int(
+            await db.scalar(daily_broker_order_count_stmt(since=since, symbol=symbol))
+            or 0
+        )
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_native_plus_synthetic_counts_once(db_session) -> None:
+    sym = "900201"
+    await _reset(sym)
+    await _ins(symbol=sym, order_no=f"N1-{sym}")  # native (scalping_role None)
+    await _ins(symbol=sym, order_no=f"N1-{sym}-entry", scalping_role="entry")
+    assert await _count(sym) == 1
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_two_distinct_broker_ids_count_two(db_session) -> None:
+    sym = "900202"
+    await _reset(sym)
+    await _ins(symbol=sym, order_no=f"B1-{sym}")
+    await _ins(symbol=sym, order_no=f"S1-{sym}")
+    assert await _count(sym) == 2
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_duplicate_trimmed_id_counts_once(db_session) -> None:
+    sym = "900203"
+    await _reset(sym)
+    await _ins(symbol=sym, order_no=f"D1-{sym}")
+    await _ins(symbol=sym, order_no=f" D1-{sym} ")  # whitespace variant, same id
+    assert await _count(sym) == 1
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_preview_blocked_and_synthetic_count_zero(db_session) -> None:
+    sym = "900204"
+    await _reset(sym)
+    # rejected native with no broker id (pre-submit failure / id-less)
+    await _ins(symbol=sym, order_no=None, status="rejected", lifecycle_state="failed")
+    # synthetic audit row (mirrors a submission; excluded)
+    await _ins(symbol=sym, order_no=f"X1-{sym}-exit", scalping_role="exit")
+    assert await _count(sym) == 0
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_buy_and_sell_submissions_each_count(db_session) -> None:
+    sym = "900205"
+    await _reset(sym)
+    await _ins(symbol=sym, side="buy", order_no=f"BUY1-{sym}")
+    await _ins(symbol=sym, side="sell", order_no=f"SELL1-{sym}")
+    assert await _count(sym) == 2

--- a/tests/brokers/kis/mock_scalping_exec/test_order_history_ledger.py
+++ b/tests/brokers/kis/mock_scalping_exec/test_order_history_ledger.py
@@ -38,24 +38,25 @@ async def _reset(symbol: str) -> None:
 
 
 @pytest_asyncio.fixture(autouse=True)
-async def _clear_degradation_markers():
-    """A durable degradation marker is global — clear it before/after every test
-    so a stray marker never fail-closes unrelated history loads on the shared DB.
-    """
-    from app.services.brokers.kis.mock_scalping_exec.ledger_state import (
-        clear_tracking_degradation,
-    )
-    from app.services.brokers.kis.mock_scalping_exec.tracking_state import (
-        reset_ledger_tracking_state,
-    )
+async def _clear_scalping_reservations():
+    """The scalping reservation is a global fail-close signal — clear it
+    before/after every test so a stray reservation never fail-closes unrelated
+    history loads on the shared DB."""
+    from app.models.review import OrderSendIntent
+    from app.services.order_send_intent_service import KIS_MOCK_SCALPING_SCOPE
 
-    async with _order_session_factory()() as db:
-        await clear_tracking_degradation(db)
-    reset_ledger_tracking_state()
+    async def _clear():
+        async with _order_session_factory()() as db:
+            await db.execute(
+                delete(OrderSendIntent).where(
+                    OrderSendIntent.account_scope == KIS_MOCK_SCALPING_SCOPE
+                )
+            )
+            await db.commit()
+
+    await _clear()
     yield
-    async with _order_session_factory()() as db:
-        await clear_tracking_degradation(db)
-    reset_ledger_tracking_state()
+    await _clear()
 
 
 async def _ins(**over) -> None:
@@ -277,11 +278,11 @@ async def test_synthetic_only_fill_is_counted_as_fallback(db_session) -> None:
 
 @pytest.mark.integration
 @pytest.mark.asyncio
-async def test_synthetic_anomaly_fallback_is_counted(db_session) -> None:
-    """P1-2: an unfilled/anomaly synthetic (native lost) still counts once."""
+async def test_legacy_control_fallback_row_is_not_counted(db_session) -> None:
+    """ROB-843 P2: a legacy `native_fallback` control row is never a trade — the
+    daily count excludes it (durability now lives in the reservation)."""
     sym = "900208"
     await _reset(sym)
-    cid = f"cid-{sym}"
     await _ins(
         symbol=sym,
         side="sell",
@@ -289,24 +290,25 @@ async def test_synthetic_anomaly_fallback_is_counted(db_session) -> None:
         scalping_role="native_fallback",
         lifecycle_state="anomaly",
         status="unknown",
-        correlation_id=cid,
+        reason="ledger_tracking_fallback",
+        correlation_id=f"cid-{sym}",
     )
-    assert await _count(sym) == 1
+    assert await _count(sym) == 0
 
 
 @pytest.mark.integration
 @pytest.mark.asyncio
-async def test_fallback_and_later_synthetic_dedupe(db_session) -> None:
-    """P1-2: a tracking-fallback row and the later synthetic fill share
-    (correlation_id, side) and de-dup to a single count."""
+async def test_two_synthetic_rows_same_pair_dedupe(db_session) -> None:
+    """P1-2: two synthetic evidence rows sharing (correlation_id, side) de-dup
+    to a single count."""
     sym = "900209"
     await _reset(sym)
     cid = f"cid-{sym}"
     await _ins(
         symbol=sym,
         side="buy",
-        order_no=None,
-        scalping_role="native_fallback",
+        order_no=f"L-{sym}-a",
+        scalping_role="entry",
         lifecycle_state="anomaly",
         status="unknown",
         correlation_id=cid,
@@ -314,7 +316,7 @@ async def test_fallback_and_later_synthetic_dedupe(db_session) -> None:
     await _ins(
         symbol=sym,
         side="buy",
-        order_no=f"L-{sym}-entry",
+        order_no=f"L-{sym}-b",
         scalping_role="entry",
         lifecycle_state="fill",
         correlation_id=cid,
@@ -423,62 +425,59 @@ async def test_entry_unfilled_buy_anomaly_dedups_with_native(db_session) -> None
 
 @pytest.mark.integration
 @pytest.mark.asyncio
-async def test_tracking_degradation_is_durable_across_new_gate(db_session) -> None:
-    """P1-2: a persisted degradation marker fail-closes a BRAND-NEW gate instance
-    (module-global reset), and only explicit reconciliation clears it."""
-    from app.mcp_server.tooling.kis_mock_ledger import (
-        _persist_tracking_degradation_marker,
-    )
+async def test_unresolved_reservation_fail_closes_new_gate(db_session) -> None:
+    """ROB-843 P1: an UNRESOLVED write-ahead reservation (in-flight/uncertain
+    order) fail-closes a fresh loader call AND a brand-new gate instance — it is
+    durable across restart/session — and only an explicit reconciliation that
+    confirms the order releases it."""
     from app.services.brokers.kis.mock_scalping_exec.adapters import KisMockRiskGate
-    from app.services.brokers.kis.mock_scalping_exec.ledger_state import (
-        clear_tracking_degradation,
+    from app.services.brokers.kis.mock_scalping_exec.reservation import (
+        reconcile_entries,
+        reserve_entry,
     )
-    from app.services.brokers.kis.mock_scalping_exec.tracking_state import (
-        reset_ledger_tracking_state,
-    )
+    from app.services.brokers.kis.mock_scalping_ws.state import MarketState
 
-    # Persist a durable marker (native+fallback both lost for some order).
-    await _persist_tracking_degradation_marker(
-        correlation_id="lost-order-1", side="buy", market_type="equity_kr"
-    )
-    # Prove the block is DURABLE, not process-local: clear the in-memory latch.
-    reset_ledger_tracking_state()
+    # An order was sent but its native write was lost -> reservation stays.
+    await reserve_entry(correlation_id="inflight-1", symbol="005930", side="buy")
 
-    # A fresh loader call on a NEW DB session fail-closes.
+    # A fresh loader call (new DB session) fail-closes.
     with pytest.raises(RuntimeError, match="ledger_tracking_unavailable"):
         await load_kis_mock_order_history(symbol="005930")
 
-    # A brand-new gate instance (new object) also fail-closes.
-    async def _holdings():
-        return {"holdings": [], "cash": {}}
-
+    # A brand-new gate instance also fail-closes (durable, not process-local).
     gate = KisMockRiskGate(
-        get_state=lambda _s: None,  # unreached: durable check is inside history load
-        holdings_provider=_holdings,
-        clock=lambda: 100.0,
-    )
-    # get_state returns None -> market check would raise first; assert it still
-    # fails closed (either market or durable). Use a valid state to reach history:
-    from app.services.brokers.kis.mock_scalping_ws.state import MarketState
-
-    gate2 = KisMockRiskGate(
         get_state=lambda _s: MarketState(
             symbol="005930", bid=70000.0, ask=70100.0, _book_updated_at=100.0
         ),
-        holdings_provider=_holdings,
+        holdings_provider=_empty_holdings_coro,
         clock=lambda: 100.5,
     )
-    with pytest.raises(RuntimeError):
-        await gate.load(symbol="005930", side="BUY")
     with pytest.raises(RuntimeError, match="ledger_tracking_unavailable"):
-        await gate2.load(symbol="005930", side="BUY")
+        await gate.load(symbol="005930", side="BUY")
 
-    # Explicit reconciliation clears the latch; trading re-opens.
-    async with _order_session_factory()() as db:
-        cleared = await clear_tracking_degradation(db)
-    assert cleared >= 1
+    # A reconciliation that does NOT confirm the order keeps the block.
+    released = await reconcile_entries(confirm=_never_confirm)
+    assert released == 0
+    with pytest.raises(RuntimeError, match="ledger_tracking_unavailable"):
+        await load_kis_mock_order_history(symbol="005930")
+
+    # Only an explicit reconciliation that confirms the order releases it.
+    released = await reconcile_entries(confirm=_always_confirm)
+    assert released == 1
     hist = await load_kis_mock_order_history(symbol="005930")
-    assert hist is not None  # no longer fail-closed
+    assert hist is not None  # trading re-opened
+
+
+async def _empty_holdings_coro():
+    return {"holdings": [], "cash": {}}
+
+
+async def _never_confirm(_key: str) -> bool:
+    return False
+
+
+async def _always_confirm(_key: str) -> bool:
+    return True
 
 
 @pytest.mark.integration

--- a/tests/brokers/kis/mock_scalping_exec/test_order_history_ledger.py
+++ b/tests/brokers/kis/mock_scalping_exec/test_order_history_ledger.py
@@ -472,11 +472,11 @@ async def _empty_holdings_coro():
     return {"holdings": [], "cash": {}}
 
 
-async def _never_confirm(_key: str) -> bool:
+async def _never_confirm(_correlation_id: str, _side: str) -> bool:
     return False
 
 
-async def _always_confirm(_key: str) -> bool:
+async def _always_confirm(_correlation_id: str, _side: str) -> bool:
     return True
 
 

--- a/tests/brokers/kis/mock_scalping_exec/test_order_history_ledger.py
+++ b/tests/brokers/kis/mock_scalping_exec/test_order_history_ledger.py
@@ -21,7 +21,7 @@ from app.mcp_server.tooling.kis_mock_ledger import (
 from app.models.review import KISMockOrderLedger
 from app.services.brokers.kis.mock_scalping_exec.ledger_state import (
     _start_of_kst_day,
-    daily_broker_order_count_stmt,
+    count_daily_broker_orders,
     load_kis_mock_order_history,
 )
 
@@ -169,10 +169,7 @@ async def test_legacy_close_missing_reconciled_at_fail_closes(db_session) -> Non
 async def _count(symbol: str) -> int:
     since = _start_of_kst_day(now_kst())
     async with _order_session_factory()() as db:
-        return int(
-            await db.scalar(daily_broker_order_count_stmt(since=since, symbol=symbol))
-            or 0
-        )
+        return await count_daily_broker_orders(db, since=since, symbol=symbol)
 
 
 @pytest.mark.integration
@@ -215,6 +212,92 @@ async def test_preview_blocked_and_synthetic_count_zero(db_session) -> None:
     # synthetic audit row (mirrors a submission; excluded)
     await _ins(symbol=sym, order_no=f"X1-{sym}-exit", scalping_role="exit")
     assert await _count(sym) == 0
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_native_plus_synthetic_fill_counts_once(db_session) -> None:
+    """P1-2: a native row + a real synthetic fill (shared correlation_id+side)
+    is one submission, not two."""
+    sym = "900206"
+    await _reset(sym)
+    cid = f"cid-{sym}"
+    await _ins(symbol=sym, side="buy", order_no=f"N-{sym}", correlation_id=cid)
+    await _ins(
+        symbol=sym,
+        side="buy",
+        order_no=f"N-{sym}-entry",
+        scalping_role="entry",
+        lifecycle_state="fill",
+        correlation_id=cid,
+    )
+    assert await _count(sym) == 1
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_synthetic_only_fill_is_counted_as_fallback(db_session) -> None:
+    """P1-2: native write lost — a synthetic fill is the only durable evidence,
+    so it still counts the submission (no undercount)."""
+    sym = "900207"
+    await _reset(sym)
+    cid = f"cid-{sym}"
+    await _ins(
+        symbol=sym,
+        side="buy",
+        order_no=f"S-{sym}-entry",
+        scalping_role="entry",
+        lifecycle_state="fill",
+        correlation_id=cid,
+    )
+    assert await _count(sym) == 1
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_synthetic_anomaly_fallback_is_counted(db_session) -> None:
+    """P1-2: an unfilled/anomaly synthetic (native lost) still counts once."""
+    sym = "900208"
+    await _reset(sym)
+    cid = f"cid-{sym}"
+    await _ins(
+        symbol=sym,
+        side="sell",
+        order_no=f"A-{sym}",
+        scalping_role="native_fallback",
+        lifecycle_state="anomaly",
+        status="unknown",
+        correlation_id=cid,
+    )
+    assert await _count(sym) == 1
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_fallback_and_later_synthetic_dedupe(db_session) -> None:
+    """P1-2: a tracking-fallback row and the later synthetic fill share
+    (correlation_id, side) and de-dup to a single count."""
+    sym = "900209"
+    await _reset(sym)
+    cid = f"cid-{sym}"
+    await _ins(
+        symbol=sym,
+        side="buy",
+        order_no=None,
+        scalping_role="native_fallback",
+        lifecycle_state="anomaly",
+        status="unknown",
+        correlation_id=cid,
+    )
+    await _ins(
+        symbol=sym,
+        side="buy",
+        order_no=f"L-{sym}-entry",
+        scalping_role="entry",
+        lifecycle_state="fill",
+        correlation_id=cid,
+    )
+    assert await _count(sym) == 1
 
 
 @pytest.mark.integration

--- a/tests/brokers/kis/mock_scalping_exec/test_order_history_ledger.py
+++ b/tests/brokers/kis/mock_scalping_exec/test_order_history_ledger.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 from datetime import timedelta
 
 import pytest
+import pytest_asyncio
 from sqlalchemy import delete, update
 
 from app.core.timezone import now_kst
@@ -34,6 +35,27 @@ async def _reset(symbol: str) -> None:
             delete(KISMockOrderLedger).where(KISMockOrderLedger.symbol == symbol)
         )
         await db.commit()
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def _clear_degradation_markers():
+    """A durable degradation marker is global — clear it before/after every test
+    so a stray marker never fail-closes unrelated history loads on the shared DB.
+    """
+    from app.services.brokers.kis.mock_scalping_exec.ledger_state import (
+        clear_tracking_degradation,
+    )
+    from app.services.brokers.kis.mock_scalping_exec.tracking_state import (
+        reset_ledger_tracking_state,
+    )
+
+    async with _order_session_factory()() as db:
+        await clear_tracking_degradation(db)
+    reset_ledger_tracking_state()
+    yield
+    async with _order_session_factory()() as db:
+        await clear_tracking_degradation(db)
+    reset_ledger_tracking_state()
 
 
 async def _ins(**over) -> None:
@@ -298,6 +320,165 @@ async def test_fallback_and_later_synthetic_dedupe(db_session) -> None:
         correlation_id=cid,
     )
     assert await _count(sym) == 1
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_entry_unfilled_buy_anomaly_dedups_with_native(db_session) -> None:
+    """ROB-843 P2: executor → real ledger writer → DB count. A native BUY and its
+    entry_unfilled anomaly (now side=buy) de-dup to ONE order (was 2 when the
+    anomaly was mis-recorded as sell)."""
+    from decimal import Decimal as _D
+
+    from app.services.brokers.kis.mock_scalping.contract import (
+        LedgerSnapshot,
+        MarketConditions,
+        ScalpingRiskLimits,
+    )
+    from app.services.brokers.kis.mock_scalping.order_intent import OrderIntent
+    from app.services.brokers.kis.mock_scalping_exec.adapters import KisMockLedgerWriter
+    from app.services.brokers.kis.mock_scalping_exec.executor import (
+        ExecutorConfig,
+        MockScalpingExecutor,
+        RiskInputs,
+    )
+
+    sym = "900301"
+    await _reset(sym)
+
+    class _NativeWritingBroker:
+        async def submit_buy(self, *, symbol, price, quantity, correlation_id, confirm):
+            # Emulate the native ledger row a real submit would leave behind.
+            await _save_kis_mock_order_ledger(
+                symbol=symbol,
+                instrument_type="equity_kr",
+                side="buy",
+                order_type="limit",
+                quantity=float(quantity),
+                price=float(price),
+                amount=float(price * quantity),
+                currency="KRW",
+                order_no=f"native-{correlation_id}",
+                order_time=None,
+                krx_fwdg_ord_orgno=None,
+                status="accepted",
+                response_code="0",
+                response_message="ok",
+                raw_response=None,
+                reason="scalp_entry",
+                thesis=None,
+                strategy=None,
+                notes=None,
+                lifecycle_state="accepted",
+                correlation_id=correlation_id,
+            )
+            return {"kind": "buy"}
+
+        async def submit_exit_sell(self, **kw):  # unreached (entry unfilled)
+            return {"kind": "sell"}
+
+        async def confirm_fill(self, submit_result):
+            return None  # entry never fills
+
+        def quote(self, symbol):
+            return None
+
+    class _PassGate:
+        async def load(self, *, symbol, side) -> RiskInputs:
+            return RiskInputs(
+                ledger=LedgerSnapshot(False, 0, 0, _D("0"), None),
+                market=MarketConditions(spread_bps=_D("10"), data_age_seconds=1.0),
+            )
+
+    async def _no_sleep(_s):
+        return None
+
+    executor = MockScalpingExecutor(
+        broker=_NativeWritingBroker(),
+        ledger=KisMockLedgerWriter(),
+        config=ExecutorConfig(max_fill_polls=1),
+        sleep=_no_sleep,
+        clock=lambda: 0.0,
+        risk=_PassGate(),
+        limits=ScalpingRiskLimits(allowlist=frozenset({sym})),
+    )
+    intent = OrderIntent(
+        symbol=sym,
+        side="BUY",
+        order_type="limit",
+        target_notional_krw=_D("100000"),
+        entry_reference_price=_D("70000"),
+        tp_price=_D("70210"),
+        sl_price=_D("69860"),
+        confidence=_D("0.5"),
+        reason_codes=("enter_long_breakout",),
+        source_candle_close_time_ms=1,
+        evaluated_at_ms=2,
+    )
+    result = await executor.execute_monitored(intent, confirm=True)
+    assert result.status == "entry_unfilled"
+    # native BUY + entry_unfilled anomaly (side=buy) -> exactly ONE submission.
+    assert await _count(sym) == 1
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_tracking_degradation_is_durable_across_new_gate(db_session) -> None:
+    """P1-2: a persisted degradation marker fail-closes a BRAND-NEW gate instance
+    (module-global reset), and only explicit reconciliation clears it."""
+    from app.mcp_server.tooling.kis_mock_ledger import (
+        _persist_tracking_degradation_marker,
+    )
+    from app.services.brokers.kis.mock_scalping_exec.adapters import KisMockRiskGate
+    from app.services.brokers.kis.mock_scalping_exec.ledger_state import (
+        clear_tracking_degradation,
+    )
+    from app.services.brokers.kis.mock_scalping_exec.tracking_state import (
+        reset_ledger_tracking_state,
+    )
+
+    # Persist a durable marker (native+fallback both lost for some order).
+    await _persist_tracking_degradation_marker(
+        correlation_id="lost-order-1", side="buy", market_type="equity_kr"
+    )
+    # Prove the block is DURABLE, not process-local: clear the in-memory latch.
+    reset_ledger_tracking_state()
+
+    # A fresh loader call on a NEW DB session fail-closes.
+    with pytest.raises(RuntimeError, match="ledger_tracking_unavailable"):
+        await load_kis_mock_order_history(symbol="005930")
+
+    # A brand-new gate instance (new object) also fail-closes.
+    async def _holdings():
+        return {"holdings": [], "cash": {}}
+
+    gate = KisMockRiskGate(
+        get_state=lambda _s: None,  # unreached: durable check is inside history load
+        holdings_provider=_holdings,
+        clock=lambda: 100.0,
+    )
+    # get_state returns None -> market check would raise first; assert it still
+    # fails closed (either market or durable). Use a valid state to reach history:
+    from app.services.brokers.kis.mock_scalping_ws.state import MarketState
+
+    gate2 = KisMockRiskGate(
+        get_state=lambda _s: MarketState(
+            symbol="005930", bid=70000.0, ask=70100.0, _book_updated_at=100.0
+        ),
+        holdings_provider=_holdings,
+        clock=lambda: 100.5,
+    )
+    with pytest.raises(RuntimeError):
+        await gate.load(symbol="005930", side="BUY")
+    with pytest.raises(RuntimeError, match="ledger_tracking_unavailable"):
+        await gate2.load(symbol="005930", side="BUY")
+
+    # Explicit reconciliation clears the latch; trading re-opens.
+    async with _order_session_factory()() as db:
+        cleared = await clear_tracking_degradation(db)
+    assert cleared >= 1
+    hist = await load_kis_mock_order_history(symbol="005930")
+    assert hist is not None  # no longer fail-closed
 
 
 @pytest.mark.integration

--- a/tests/brokers/kis/mock_scalping_exec/test_pre_send_freshness.py
+++ b/tests/brokers/kis/mock_scalping_exec/test_pre_send_freshness.py
@@ -132,19 +132,27 @@ async def test_submit_buy_hook_passes_when_fresh(monkeypatch) -> None:
     await captured["pre_send_hook"]()  # age 1s -> no raise
 
 
-# --- _execute_and_record aborts BEFORE the POST -------------------------------
+# --- _execute_and_record threads the hook and converts a block ----------------
 
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_execute_and_record_blocks_before_post(monkeypatch) -> None:
-    """A raising pre-send hook returns pre_send_blocked and NEVER calls the POST."""
-    from unittest.mock import AsyncMock
-
+async def test_execute_and_record_threads_hook_and_returns_blocked(monkeypatch) -> None:
+    """_execute_and_record threads the hook into _execute_order (which fires it at
+    the real send boundary) and converts a PreSendFreshnessError into a stable
+    pre_send_blocked result. The real send-boundary POST-0 proof lives in
+    test_pre_send_transport.py (through the actual domestic service + transport)."""
     from app.mcp_server.tooling import order_execution
 
-    post_spy = AsyncMock(return_value={"rt_cd": "0", "odno": "1"})
-    monkeypatch.setattr(order_execution, "_execute_order", post_spy)
+    received: dict[str, Any] = {}
+
+    async def _fake_execute_order(**kwargs):
+        received.update(kwargs)
+        # The transport fires the hook right before the POST; emulate that here.
+        await kwargs["pre_send_hook"]()
+        return {"rt_cd": "0", "odno": "1"}
+
+    monkeypatch.setattr(order_execution, "_execute_order", _fake_execute_order)
 
     async def _raise() -> None:
         raise PreSendFreshnessError((ReasonCode.STALE_DATA,))
@@ -174,9 +182,9 @@ async def test_execute_and_record_blocks_before_post(monkeypatch) -> None:
         is_mock=False,
         pre_send_hook=_raise,
     )
+    assert received["pre_send_hook"] is _raise  # threaded down, not invoked here
     assert result["pre_send_blocked"] is True
     assert ReasonCode.STALE_DATA in result["reason_codes"]
-    assert post_spy.await_count == 0  # ZERO broker POSTs
 
 
 # --- executor surfaces the block as a clean blocked round trip ----------------

--- a/tests/brokers/kis/mock_scalping_exec/test_pre_send_freshness.py
+++ b/tests/brokers/kis/mock_scalping_exec/test_pre_send_freshness.py
@@ -1,0 +1,265 @@
+"""ROB-843 P1-1 — final pre-send freshness re-check (immediately before POST).
+
+The risk gate samples quote age BEFORE awaiting holdings/history, and the broker
+awaits baseline/preflight before the POST. A book that was fresh at gate time
+(age 59s) can be stale by send time (age 61s). The pre-send hook re-reads the
+CURRENT MarketState right before the broker POST and blocks with ZERO POSTs.
+"""
+
+from __future__ import annotations
+
+import math
+from decimal import Decimal
+from typing import Any
+
+import pytest
+
+from app.services.brokers.kis.mock_scalping.contract import (
+    ReasonCode,
+    ScalpingRiskLimits,
+)
+from app.services.brokers.kis.mock_scalping.order_intent import OrderIntent
+from app.services.brokers.kis.mock_scalping_exec.adapters import (
+    KisMockBroker,
+    PreSendFreshnessError,
+    assert_market_fresh_for_send,
+)
+from app.services.brokers.kis.mock_scalping_exec.executor import (
+    MockScalpingExecutor,
+    RiskInputs,
+)
+from app.services.brokers.kis.mock_scalping_ws.state import MarketState
+
+LIMITS = ScalpingRiskLimits()  # max_data_age=60s, max_spread_bps=30
+
+
+def _state(*, bid=70000.0, ask=70100.0, book_at: float | None = 100.0) -> MarketState:
+    return MarketState(symbol="005930", bid=bid, ask=ask, _book_updated_at=book_at)
+
+
+# --- validator ----------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_fresh_book_passes() -> None:
+    assert_market_fresh_for_send(
+        _state(),
+        now=101.0,  # age 1s
+        max_data_age_seconds=LIMITS.max_data_age_seconds,
+        max_spread_bps=LIMITS.max_spread_bps,
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "state,now,reason",
+    [
+        (_state(), 100.0 + 61, ReasonCode.STALE_DATA),  # age 61 > 60
+        (_state(book_at=None), 101.0, "invalid_book_timestamp"),
+        (_state(bid=70200.0, ask=70000.0), 101.0, "crossed_book"),
+        (_state(bid=0.0), 101.0, "invalid_quote"),
+        (_state(bid=math.nan), 101.0, "invalid_quote"),
+        (_state(bid=70000.0, ask=71000.0), 101.0, ReasonCode.SPREAD_TOO_WIDE),  # ~142bp
+        (None, 101.0, "no_market_state"),
+    ],
+)
+def test_stale_or_invalid_book_fails(state, now, reason) -> None:
+    with pytest.raises(PreSendFreshnessError) as ei:
+        assert_market_fresh_for_send(
+            state,
+            now=now,
+            max_data_age_seconds=LIMITS.max_data_age_seconds,
+            max_spread_bps=LIMITS.max_spread_bps,
+        )
+    assert reason in ei.value.reason_codes
+
+
+# --- broker wires a pre-send hook + shared correlation_id ---------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_submit_buy_wires_pre_send_hook_and_correlation_id(monkeypatch) -> None:
+    from app.services.brokers.kis.mock_scalping_exec import adapters
+
+    captured: dict[str, Any] = {}
+
+    async def _fake_place(**kwargs):
+        captured.update(kwargs)
+        return {"rt_cd": "0", "odno": "1"}
+
+    monkeypatch.setattr(adapters, "_place_order_impl", _fake_place)
+
+    # clock returns 161 at send -> age 61 for a book stamped at 100 -> stale.
+    broker = KisMockBroker(
+        get_state=lambda _s: _state(book_at=100.0), limits=LIMITS, clock=lambda: 161.0
+    )
+    await broker.submit_buy(
+        symbol="005930",
+        price=Decimal("70000"),
+        quantity=Decimal("1"),
+        correlation_id="cid-1",
+        confirm=False,
+    )
+    assert captured["correlation_id"] == "cid-1"  # linked for P1-2 de-dup
+    hook = captured["pre_send_hook"]
+    with pytest.raises(PreSendFreshnessError):  # age 61 at send -> blocked
+        await hook()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_submit_buy_hook_passes_when_fresh(monkeypatch) -> None:
+    from app.services.brokers.kis.mock_scalping_exec import adapters
+
+    captured: dict[str, Any] = {}
+
+    async def _fake_place(**kwargs):
+        captured.update(kwargs)
+        return {"rt_cd": "0", "odno": "1"}
+
+    monkeypatch.setattr(adapters, "_place_order_impl", _fake_place)
+    broker = KisMockBroker(
+        get_state=lambda _s: _state(book_at=100.0), limits=LIMITS, clock=lambda: 101.0
+    )
+    await broker.submit_buy(
+        symbol="005930",
+        price=Decimal("70000"),
+        quantity=Decimal("1"),
+        correlation_id="cid-1",
+        confirm=False,
+    )
+    await captured["pre_send_hook"]()  # age 1s -> no raise
+
+
+# --- _execute_and_record aborts BEFORE the POST -------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_execute_and_record_blocks_before_post(monkeypatch) -> None:
+    """A raising pre-send hook returns pre_send_blocked and NEVER calls the POST."""
+    from unittest.mock import AsyncMock
+
+    from app.mcp_server.tooling import order_execution
+
+    post_spy = AsyncMock(return_value={"rt_cd": "0", "odno": "1"})
+    monkeypatch.setattr(order_execution, "_execute_order", post_spy)
+
+    async def _raise() -> None:
+        raise PreSendFreshnessError((ReasonCode.STALE_DATA,))
+
+    result = await order_execution._execute_and_record(
+        normalized_symbol="005930",
+        side="buy",
+        order_type="limit",
+        order_quantity=1.0,
+        price=70000.0,
+        market_type="equity_kr",
+        current_price=70000.0,
+        avg_price=0.0,
+        dry_run_result={"price": 70000, "quantity": 1, "estimated_value": 70000},
+        order_amount=70000.0,
+        reason="t",
+        exit_reason=None,
+        thesis=None,
+        strategy=None,
+        target_price=None,
+        stop_loss=None,
+        min_hold_days=None,
+        notes=None,
+        indicators_snapshot=None,
+        defensive_trim_ctx=None,
+        order_error_fn=lambda m: {"success": False, "error": m},
+        is_mock=False,
+        pre_send_hook=_raise,
+    )
+    assert result["pre_send_blocked"] is True
+    assert ReasonCode.STALE_DATA in result["reason_codes"]
+    assert post_spy.await_count == 0  # ZERO broker POSTs
+
+
+# --- executor surfaces the block as a clean blocked round trip ----------------
+
+
+class _BlockingBroker:
+    def __init__(self):
+        self.submitted: list[str] = []
+
+    async def submit_buy(self, **kw):
+        self.submitted.append("buy")
+        return {
+            "success": False,
+            "pre_send_blocked": True,
+            "reason_codes": [ReasonCode.STALE_DATA],
+            "detail": "stale",
+        }
+
+    async def submit_exit_sell(self, **kw):
+        self.submitted.append("sell")
+        return {"kind": "sell"}
+
+    async def confirm_fill(self, r):
+        return None
+
+    def quote(self, s):
+        return None
+
+
+class _NullLedger:
+    async def record_entry(self, **kw):
+        return None
+
+    async def record_exit_reconciled(self, **kw):
+        return None
+
+    async def record_anomaly(self, **kw):
+        return None
+
+
+class _PassGate:
+    async def load(self, *, symbol, side) -> RiskInputs:
+        from app.services.brokers.kis.mock_scalping.contract import (
+            LedgerSnapshot,
+            MarketConditions,
+        )
+
+        return RiskInputs(
+            ledger=LedgerSnapshot(False, 0, 0, Decimal("0"), None),
+            market=MarketConditions(spread_bps=Decimal("10"), data_age_seconds=1.0),
+        )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_executor_returns_blocked_on_pre_send_marker() -> None:
+    async def _no_sleep(_s):
+        return None
+
+    broker = _BlockingBroker()
+    ledger = _NullLedger()
+    ex = MockScalpingExecutor(
+        broker=broker,
+        ledger=ledger,
+        sleep=_no_sleep,
+        clock=lambda: 0.0,
+        risk=_PassGate(),
+        limits=LIMITS,
+    )
+    intent = OrderIntent(
+        symbol="005930",
+        side="BUY",
+        order_type="limit",
+        target_notional_krw=Decimal("100000"),
+        entry_reference_price=Decimal("70000"),
+        tp_price=Decimal("70210"),
+        sl_price=Decimal("69860"),
+        confidence=Decimal("0.5"),
+        reason_codes=("enter_long_breakout",),
+        source_candle_close_time_ms=1,
+        evaluated_at_ms=2,
+    )
+    result = await ex.execute_monitored(intent, confirm=True)
+    assert result.status == "blocked"
+    assert ReasonCode.STALE_DATA in result.reason_codes
+    assert broker.submitted == ["buy"]  # only the (aborted) submit; no sell/POST

--- a/tests/brokers/kis/mock_scalping_exec/test_pre_send_transport.py
+++ b/tests/brokers/kis/mock_scalping_exec/test_pre_send_transport.py
@@ -1,0 +1,148 @@
+"""ROB-843 P1 — pre-send freshness fires at the REAL KIS HTTP send boundary.
+
+These tests drive the actual domestic order service (`order_korea_stock`) and
+the real transport (`_request_with_rate_limit` → dispatch loop), monkeypatching
+only the lowest-level HTTP dispatch (`_execute_http_request`). They prove the
+hook fires immediately before every real POST — after token/limiter/client prep
+and on token-refresh re-sends — so a book that goes stale during those awaits
+blocks the POST with ZERO HTTP calls. Live callers pass no hook (unchanged).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import app.services.brokers.kis.circuit_breaker as cb
+from app.services.brokers.kis.base import BaseKISClient
+from app.services.brokers.kis.domestic_orders import DomesticOrderClient
+from app.services.brokers.kis.mock_scalping.contract import ReasonCode
+from app.services.brokers.kis.pre_send import PreSendFreshnessError
+
+_NXT = "app.services.brokers.kis.domestic_orders.is_nxt_eligible"
+
+
+class _Settings:
+    kis_app_key = "k"
+    kis_app_secret = "s"
+    kis_access_token = "t"
+    kis_account_no = "1234567890"
+    api_rate_limit_retry_429_max = 0
+    api_rate_limit_retry_429_base_delay = 0.0
+    kis_rate_limit_rate = 19
+    kis_rate_limit_period = 1.0
+
+
+class _Parent(BaseKISClient):
+    def __init__(self) -> None:  # type: ignore[override]
+        self._unmapped_rate_limit_keys_logged: set = set()
+        type(self)._shared_client_lock = None
+        self._hdr_base = {"content-type": "application/json"}
+        tok = MagicMock()
+        tok.clear_token = AsyncMock()
+        self._token_manager = tok
+
+    @property  # type: ignore[override]
+    def _settings(self):  # type: ignore[override]
+        return _Settings()
+
+    def _kis_url(self, path: str) -> str:
+        return f"https://mockhost{path}"
+
+    async def _ensure_token(self) -> None:
+        return None
+
+
+def _http_response(payload: dict) -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.headers = {}
+    resp.json = lambda: payload
+    return resp
+
+
+def _make(execute: AsyncMock) -> DomesticOrderClient:
+    parent = _Parent()
+    limiter = MagicMock()
+    limiter.acquire = AsyncMock()
+    parent._get_limiter = AsyncMock(return_value=limiter)  # type: ignore[method-assign]
+    parent._ensure_client = AsyncMock(return_value=MagicMock())  # type: ignore[method-assign]
+    parent._execute_http_request = execute  # type: ignore[method-assign]
+    return DomesticOrderClient(parent)
+
+
+@pytest.fixture(autouse=True)
+def _reset_breaker():
+    cb.reset_kis_circuit_breaker()
+    yield
+    cb.reset_kis_circuit_breaker()
+
+
+async def _stale_hook() -> None:
+    raise PreSendFreshnessError((ReasonCode.STALE_DATA,))
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_stale_hook_blocks_before_real_post(monkeypatch) -> None:
+    execute = AsyncMock(return_value=_http_response({"rt_cd": "0"}))
+    client = _make(execute)
+    monkeypatch.setattr(_NXT, AsyncMock(return_value=False))
+
+    with pytest.raises(PreSendFreshnessError):
+        await client.order_korea_stock(
+            "005930", "buy", 1, 70000, is_mock=True, pre_send_hook=_stale_hook
+        )
+    assert execute.await_count == 0  # ZERO real HTTP POSTs
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_fresh_hook_allows_single_post(monkeypatch) -> None:
+    execute = AsyncMock(
+        return_value=_http_response(
+            {"rt_cd": "0", "msg1": "ok", "output": {"ODNO": "1", "ORD_TMD": "0915"}}
+        )
+    )
+    client = _make(execute)
+    monkeypatch.setattr(_NXT, AsyncMock(return_value=False))
+
+    async def _fresh() -> None:
+        return None
+
+    result = await client.order_korea_stock(
+        "005930", "buy", 1, 70000, is_mock=True, pre_send_hook=_fresh
+    )
+    assert execute.await_count == 1
+    assert result["odno"] == "1"
+    assert result["rt_cd"] == "0"  # provider metadata preserved (ROB-843)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_hook_rechecked_on_token_refresh_resend(monkeypatch) -> None:
+    """The token-refresh re-send re-checks freshness before ITS own POST: the
+    first POST returns a token-expiry code, then the re-send is blocked (age went
+    stale in between), so the second POST never happens."""
+    execute = AsyncMock(
+        return_value=_http_response(
+            {"rt_cd": "1", "msg_cd": "EGW00123", "msg1": "token expired"}
+        )
+    )
+    client = _make(execute)
+    monkeypatch.setattr(_NXT, AsyncMock(return_value=False))
+
+    calls = {"n": 0}
+
+    async def _fresh_then_stale() -> None:
+        calls["n"] += 1
+        if calls["n"] >= 2:  # by the retry the book is stale
+            raise PreSendFreshnessError((ReasonCode.STALE_DATA,))
+
+    with pytest.raises(PreSendFreshnessError):
+        await client.order_korea_stock(
+            "005930", "buy", 1, 70000, is_mock=True, pre_send_hook=_fresh_then_stale
+        )
+    assert execute.await_count == 1  # first POST only; the re-send was blocked
+    assert client._parent._token_manager.clear_token.await_count == 1

--- a/tests/brokers/kis/mock_scalping_exec/test_reservation.py
+++ b/tests/brokers/kis/mock_scalping_exec/test_reservation.py
@@ -8,6 +8,7 @@ restart-safe fail-close signal.
 
 from __future__ import annotations
 
+import asyncio
 import time
 from decimal import Decimal
 from unittest.mock import AsyncMock, MagicMock
@@ -40,6 +41,7 @@ from app.services.brokers.kis.mock_scalping_exec.executor import (
 from app.services.brokers.kis.mock_scalping_exec.reservation import (
     has_unresolved_entries,
     reconcile_entries,
+    release_entry,
     reserve_entry,
 )
 from app.services.brokers.kis.mock_scalping_exec.tracking_state import LedgerWriteError
@@ -198,6 +200,20 @@ async def _ledger_rows(correlation_id: str) -> int:
             .where(KISMockOrderLedger.correlation_id == correlation_id)
         )
     return int(count or 0)
+
+
+async def _reservation_row(correlation_id: str, side: str) -> tuple[int, str] | None:
+    async with _order_session_factory()() as db:
+        row = (
+            await db.execute(
+                select(OrderSendIntent.id, OrderSendIntent.idempotency_key).where(
+                    OrderSendIntent.account_scope == KIS_MOCK_SCALPING_SCOPE,
+                    OrderSendIntent.idempotency_key.contains(correlation_id),
+                    func.lower(OrderSendIntent.side) == side.lower(),
+                )
+            )
+        ).one_or_none()
+    return (row.id, row.idempotency_key) if row is not None else None
 
 
 @pytest_asyncio.fixture(autouse=True)
@@ -684,6 +700,47 @@ async def test_explicit_reconcile_identifies_and_releases_only_confirmed_leg() -
     assert sorted(observed) == [(cid, "buy"), (cid, "sell")]
     assert await _has_key(cid, "buy") is True
     assert await _has_key(cid, "sell") is False
+    assert await has_unresolved_entries() is True
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_reconcile_aba_does_not_delete_replacement_row_or_count_release() -> None:
+    """A stale confirmation may release only the exact row it observed.
+
+    The reconciler lists row A, then pauses in the external broker confirmation.
+    A separate task/session deletes A and reserves the same leg as row B before
+    confirmation resumes. The stale reconciler must preserve B and report zero
+    releases.
+    """
+    cid = f"{_TEST_CID_PREFIX}reconcile-aba"
+    await reserve_entry(correlation_id=cid, symbol="005930", side="buy")
+    original = await _reservation_row(cid, "buy")
+    assert original is not None
+
+    confirm_started = asyncio.Event()
+    replacement_ready = asyncio.Event()
+
+    async def _confirm(correlation_id: str, side: str) -> bool:
+        assert (correlation_id, side) == (cid, "buy")
+        confirm_started.set()
+        await replacement_ready.wait()
+        return True
+
+    reconcile_task = asyncio.create_task(reconcile_entries(confirm=_confirm))
+    await confirm_started.wait()
+
+    await release_entry(correlation_id=cid, side="buy")
+    await reserve_entry(correlation_id=cid, symbol="005930", side="buy")
+    replacement = await _reservation_row(cid, "buy")
+    assert replacement is not None
+    assert replacement[0] != original[0]
+    replacement_ready.set()
+
+    released = await reconcile_task
+
+    assert released == 0
+    assert await _reservation_row(cid, "buy") == replacement
     assert await has_unresolved_entries() is True
 
 

--- a/tests/brokers/kis/mock_scalping_exec/test_reservation.py
+++ b/tests/brokers/kis/mock_scalping_exec/test_reservation.py
@@ -1,4 +1,4 @@
-"""ROB-843 P1 — write-ahead reservation lifecycle for KIS mock scalping entries.
+"""ROB-843 P1 — write-ahead reservation lifecycle for KIS mock scalping legs.
 
 A durable reservation is recorded BEFORE the broker POST. If the durable write
 fails the POST never happens; the reservation is released only when the order is
@@ -15,7 +15,7 @@ from unittest.mock import AsyncMock, MagicMock
 import httpx
 import pytest
 import pytest_asyncio
-from sqlalchemy import delete, select
+from sqlalchemy import delete, func, select
 
 import app.services.brokers.kis.circuit_breaker as cb
 from app.core.config import settings
@@ -25,14 +25,29 @@ from app.mcp_server.tooling.order_execution import OrderSendOutcomeUnknown
 from app.models.review import KISMockOrderLedger, OrderSendIntent
 from app.services.brokers.kis.base import BaseKISClient
 from app.services.brokers.kis.domestic_orders import DomesticOrderClient
+from app.services.brokers.kis.mock_scalping.contract import (
+    LedgerSnapshot,
+    MarketConditions,
+)
+from app.services.brokers.kis.mock_scalping.order_intent import OrderIntent
 from app.services.brokers.kis.mock_scalping_exec import adapters
+from app.services.brokers.kis.mock_scalping_exec.executor import (
+    ExecutorConfig,
+    Fill,
+    MockScalpingExecutor,
+    RiskInputs,
+)
 from app.services.brokers.kis.mock_scalping_exec.reservation import (
     has_unresolved_entries,
+    reconcile_entries,
     reserve_entry,
 )
 from app.services.brokers.kis.mock_scalping_exec.tracking_state import LedgerWriteError
 from app.services.brokers.kis.mock_scalping_ws.state import MarketState
-from app.services.order_send_intent_service import KIS_MOCK_SCALPING_SCOPE
+from app.services.order_send_intent_service import (
+    KIS_MOCK_SCALPING_SCOPE,
+    OrderSendIntentService,
+)
 
 _NXT = "app.services.brokers.kis.domestic_orders.is_nxt_eligible"
 _TEST_CID_PREFIX = "resv-test-"
@@ -50,7 +65,7 @@ class _Settings:
 
 
 class _Parent(BaseKISClient):
-    def __init__(self, execute) -> None:  # type: ignore[override]
+    def __init__(self, execute, *, token_error: Exception | None = None) -> None:  # type: ignore[override]
         self._unmapped_rate_limit_keys_logged: set = set()
         type(self)._shared_client_lock = None
         self._hdr_base = {"content-type": "application/json"}
@@ -62,6 +77,7 @@ class _Parent(BaseKISClient):
         self._get_limiter = AsyncMock(return_value=limiter)  # type: ignore[method-assign]
         self._ensure_client = AsyncMock(return_value=MagicMock())  # type: ignore[method-assign]
         self._execute_http_request = execute  # type: ignore[method-assign]
+        self._token_error = token_error
 
     @property  # type: ignore[override]
     def _settings(self):  # type: ignore[override]
@@ -71,6 +87,8 @@ class _Parent(BaseKISClient):
         return f"https://mockhost{path}"
 
     async def _ensure_token(self) -> None:
+        if self._token_error is not None:
+            raise self._token_error
         return None
 
 
@@ -101,8 +119,9 @@ def _patch_production_domestic_path(
     execute,
     side: str,
     balance_error: dict | None = None,
+    token_error: Exception | None = None,
 ) -> None:
-    domestic = DomesticOrderClient(_Parent(execute))
+    domestic = DomesticOrderClient(_Parent(execute, token_error=token_error))
     facade = _DomesticFacade(domestic)
     monkeypatch.setattr(order_execution, "_create_kis_client", lambda **_kw: facade)
     monkeypatch.setattr(_NXT, AsyncMock(return_value=False))
@@ -159,15 +178,26 @@ def _patch_production_domestic_path(
     monkeypatch.setattr(settings, "kis_mock_scalping_enabled", True, raising=False)
 
 
-async def _has_key(correlation_id: str) -> bool:
+async def _has_key(correlation_id: str, side: str | None = None) -> bool:
     async with _order_session_factory()() as db:
-        found = await db.scalar(
-            select(OrderSendIntent.id).where(
-                OrderSendIntent.account_scope == KIS_MOCK_SCALPING_SCOPE,
-                OrderSendIntent.idempotency_key == correlation_id,
-            )
+        stmt = select(OrderSendIntent.id).where(
+            OrderSendIntent.account_scope == KIS_MOCK_SCALPING_SCOPE,
+            OrderSendIntent.idempotency_key.contains(correlation_id),
         )
+        if side is not None:
+            stmt = stmt.where(func.lower(OrderSendIntent.side) == side.lower())
+        found = await db.scalar(stmt)
     return found is not None
+
+
+async def _ledger_rows(correlation_id: str) -> int:
+    async with _order_session_factory()() as db:
+        count = await db.scalar(
+            select(func.count())
+            .select_from(KISMockOrderLedger)
+            .where(KISMockOrderLedger.correlation_id == correlation_id)
+        )
+    return int(count or 0)
 
 
 @pytest_asyncio.fixture(autouse=True)
@@ -249,6 +279,30 @@ async def test_duplicate_reservation_blocks_post(monkeypatch) -> None:
     cid = "cid-dup"
     await reserve_entry(correlation_id=cid, symbol="005930", side="buy")
     result = await _submit(_broker(), cid)
+    assert result["reservation_blocked"] is True
+    assert "duplicate_send" in result["reason_codes"]
+    assert place.await_count == 0
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_legacy_raw_same_leg_reservation_blocks_new_leg_key_post(
+    monkeypatch,
+) -> None:
+    """A pre-leg-key unresolved BUY remains a same-leg double-send guard."""
+    cid = f"{_TEST_CID_PREFIX}legacy-buy"
+    async with _order_session_factory()() as db:
+        await OrderSendIntentService(db).reserve(
+            account_scope=KIS_MOCK_SCALPING_SCOPE,
+            idempotency_key=cid,
+            symbol="005930",
+            side="buy",
+        )
+    place = AsyncMock(return_value={"success": True})
+    monkeypatch.setattr(adapters, "_place_order_impl", place)
+
+    result = await _submit(_broker(), cid)
+
     assert result["reservation_blocked"] is True
     assert "duplicate_send" in result["reason_codes"]
     assert place.await_count == 0
@@ -500,7 +554,8 @@ async def test_sell_timeout_keeps_reservation(monkeypatch) -> None:
 
     assert result["success"] is False
     assert result.get("outcome_unknown") is True, result
-    assert await _has_key(cid) is True
+    assert execute.await_count == 1
+    assert await _has_key(cid, "sell") is True
 
 
 class _ProcessCrash(BaseException):
@@ -519,3 +574,165 @@ async def test_sell_crash_keeps_reservation(monkeypatch) -> None:
         await _submit_sell(_broker(), cid)
 
     assert await _has_key(cid) is True
+
+
+class _PassRiskGate:
+    async def load(self, *, symbol: str, side: str) -> RiskInputs:
+        return RiskInputs(
+            ledger=LedgerSnapshot(
+                has_open_position_for_symbol=False,
+                open_position_count=0,
+                orders_today=0,
+                realized_loss_today_krw=Decimal("0"),
+                seconds_since_last_close_for_symbol=None,
+            ),
+            market=MarketConditions(spread_bps=Decimal("1"), data_age_seconds=0.1),
+        )
+
+
+class _RoundTripLedger:
+    def __init__(self) -> None:
+        self.record_entry = AsyncMock()
+        self.record_exit_reconciled = AsyncMock()
+        self.record_anomaly = AsyncMock()
+
+
+def _round_trip_intent() -> OrderIntent:
+    return OrderIntent(
+        symbol="005930",
+        side="BUY",
+        order_type="limit",
+        target_notional_krw=Decimal("70000"),
+        entry_reference_price=Decimal("70000"),
+        tp_price=Decimal("70210"),
+        sl_price=Decimal("69860"),
+        confidence=Decimal("0.5"),
+        reason_codes=("enter_long_breakout",),
+        source_candle_close_time_ms=1,
+        evaluated_at_ms=2,
+    )
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_round_trip_sell_uses_independent_leg_reservation_when_buy_unresolved(
+    monkeypatch,
+) -> None:
+    """A BUY tracking loss must not consume the same-correlation SELL key.
+
+    This runs the real round-trip executor through the real broker adapter. The
+    BUY reservation intentionally remains unresolved while the SELL still
+    reaches the mutation boundary, then only its fully tracked leg is released.
+    """
+    cid = f"{_TEST_CID_PREFIX}round-trip-legs"
+    submitted_sides: list[str] = []
+
+    async def _place(**kwargs):
+        submitted_sides.append(kwargs["side"])
+        kwargs["send_outcome"].mark_accepted()
+        return {
+            "success": True,
+            "ledger_tracking_unavailable": kwargs["side"] == "buy",
+        }
+
+    monkeypatch.setattr(adapters, "_place_order_impl", AsyncMock(side_effect=_place))
+    broker = _broker()
+    broker.confirm_fill = AsyncMock(  # type: ignore[method-assign]
+        side_effect=[
+            Fill(price=Decimal("70000"), quantity=Decimal("1")),
+            Fill(price=Decimal("70000"), quantity=Decimal("1")),
+        ]
+    )
+
+    async def _no_sleep(_seconds: float) -> None:
+        return None
+
+    executor = MockScalpingExecutor(
+        broker=broker,
+        ledger=_RoundTripLedger(),
+        config=ExecutorConfig(max_hold_seconds=0, max_fill_polls=1),
+        sleep=_no_sleep,
+        clock=lambda: 0.0,
+        risk=_PassRiskGate(),
+    )
+    monkeypatch.setattr(executor, "_new_correlation_id", lambda: cid)
+
+    result = await executor.execute_monitored(_round_trip_intent(), confirm=True)
+
+    assert result.status == "reconciled"
+    assert submitted_sides == ["buy", "sell"]
+    assert await _has_key(cid, "buy") is True
+    assert await _has_key(cid, "sell") is False
+    assert await has_unresolved_entries() is True
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_explicit_reconcile_identifies_and_releases_only_confirmed_leg() -> None:
+    cid = f"{_TEST_CID_PREFIX}reconcile-legs"
+    await reserve_entry(correlation_id=cid, symbol="005930", side="BUY")
+    await reserve_entry(correlation_id=cid, symbol="005930", side=" sell ")
+    observed: list[tuple[str, str]] = []
+
+    async def _confirm(correlation_id: str, side: str) -> bool:
+        observed.append((correlation_id, side))
+        return side == "sell"
+
+    released = await reconcile_entries(confirm=_confirm)
+
+    assert released == 1
+    assert sorted(observed) == [(cid, "buy"), (cid, "sell")]
+    assert await _has_key(cid, "buy") is True
+    assert await _has_key(cid, "sell") is False
+    assert await has_unresolved_entries() is True
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_pre_dispatch_token_request_error_releases_reservation(
+    monkeypatch,
+) -> None:
+    cid = f"{_TEST_CID_PREFIX}token-before-dispatch"
+    execute = AsyncMock()
+    _patch_production_domestic_path(
+        monkeypatch,
+        execute=execute,
+        side="sell",
+        token_error=httpx.ConnectError("token endpoint unavailable"),
+    )
+
+    result = await _submit_sell(_broker(), cid)
+
+    assert result["success"] is False
+    assert result.get("outcome_unknown") is not True
+    assert result.get("retry_allowed") is True
+    assert execute.await_count == 0
+    assert await _has_key(cid, "sell") is False
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_http_500_success_shaped_payload_cannot_release_reservation(
+    monkeypatch,
+) -> None:
+    cid = f"{_TEST_CID_PREFIX}sell-500-success-payload"
+    execute = AsyncMock(
+        return_value=_http_response(
+            {
+                "rt_cd": "0",
+                "msg_cd": "0",
+                "msg1": "accepted-looking",
+                "output": {"ODNO": "UNTRUSTED-500", "ORD_TMD": "091500"},
+            },
+            status_code=500,
+        )
+    )
+    _patch_production_domestic_path(monkeypatch, execute=execute, side="sell")
+
+    result = await _submit_sell(_broker(), cid)
+
+    assert result["success"] is False, result
+    assert result.get("outcome_unknown") is True
+    assert execute.await_count == 1
+    assert await _has_key(cid, "sell") is True
+    assert await _ledger_rows(cid) == 0

--- a/tests/brokers/kis/mock_scalping_exec/test_reservation.py
+++ b/tests/brokers/kis/mock_scalping_exec/test_reservation.py
@@ -8,22 +8,166 @@ restart-safe fail-close signal.
 
 from __future__ import annotations
 
+import time
 from decimal import Decimal
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
+import httpx
 import pytest
 import pytest_asyncio
-from sqlalchemy import delete
+from sqlalchemy import delete, select
 
+import app.services.brokers.kis.circuit_breaker as cb
+from app.core.config import settings
+from app.mcp_server.tooling import kis_mock_ledger, order_execution, order_validation
 from app.mcp_server.tooling.kis_mock_ledger import _order_session_factory
 from app.mcp_server.tooling.order_execution import OrderSendOutcomeUnknown
-from app.models.review import OrderSendIntent
+from app.models.review import KISMockOrderLedger, OrderSendIntent
+from app.services.brokers.kis.base import BaseKISClient
+from app.services.brokers.kis.domestic_orders import DomesticOrderClient
 from app.services.brokers.kis.mock_scalping_exec import adapters
 from app.services.brokers.kis.mock_scalping_exec.reservation import (
     has_unresolved_entries,
     reserve_entry,
 )
+from app.services.brokers.kis.mock_scalping_exec.tracking_state import LedgerWriteError
+from app.services.brokers.kis.mock_scalping_ws.state import MarketState
 from app.services.order_send_intent_service import KIS_MOCK_SCALPING_SCOPE
+
+_NXT = "app.services.brokers.kis.domestic_orders.is_nxt_eligible"
+_TEST_CID_PREFIX = "resv-test-"
+
+
+class _Settings:
+    kis_app_key = "k"
+    kis_app_secret = "s"
+    kis_access_token = "t"
+    kis_account_no = "1234567890"
+    api_rate_limit_retry_429_max = 0
+    api_rate_limit_retry_429_base_delay = 0.0
+    kis_rate_limit_rate = 19
+    kis_rate_limit_period = 1.0
+
+
+class _Parent(BaseKISClient):
+    def __init__(self, execute) -> None:  # type: ignore[override]
+        self._unmapped_rate_limit_keys_logged: set = set()
+        type(self)._shared_client_lock = None
+        self._hdr_base = {"content-type": "application/json"}
+        token = MagicMock()
+        token.clear_token = AsyncMock()
+        self._token_manager = token
+        limiter = MagicMock()
+        limiter.acquire = AsyncMock()
+        self._get_limiter = AsyncMock(return_value=limiter)  # type: ignore[method-assign]
+        self._ensure_client = AsyncMock(return_value=MagicMock())  # type: ignore[method-assign]
+        self._execute_http_request = execute  # type: ignore[method-assign]
+
+    @property  # type: ignore[override]
+    def _settings(self):  # type: ignore[override]
+        return _Settings()
+
+    def _kis_url(self, path: str) -> str:
+        return f"https://mockhost{path}"
+
+    async def _ensure_token(self) -> None:
+        return None
+
+
+class _DomesticFacade:
+    def __init__(self, client: DomesticOrderClient) -> None:
+        self._client = client
+
+    async def order_korea_stock(self, **kwargs):
+        return await self._client.order_korea_stock(**kwargs)
+
+
+def _http_response(payload: dict, *, status_code: int = 200) -> MagicMock:
+    response = MagicMock()
+    response.status_code = status_code
+    response.headers = {}
+    response.json = lambda: payload
+    if status_code >= 400:
+        request = httpx.Request("POST", "https://mockhost/order")
+        response.raise_for_status.side_effect = httpx.HTTPStatusError(
+            f"HTTP {status_code}", request=request, response=response
+        )
+    return response
+
+
+def _patch_production_domestic_path(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    execute,
+    side: str,
+    balance_error: dict | None = None,
+) -> None:
+    domestic = DomesticOrderClient(_Parent(execute))
+    facade = _DomesticFacade(domestic)
+    monkeypatch.setattr(order_execution, "_create_kis_client", lambda **_kw: facade)
+    monkeypatch.setattr(_NXT, AsyncMock(return_value=False))
+    monkeypatch.setattr(
+        order_execution, "_fetch_current_price", AsyncMock(return_value=70000.0)
+    )
+    monkeypatch.setattr(
+        order_execution,
+        "_build_preview",
+        AsyncMock(
+            return_value={
+                "symbol": "005930",
+                "side": side,
+                "order_type": "limit",
+                "price": 70000.0,
+                "quantity": 1.0,
+                "estimated_value": 70000.0,
+                "fee": 0.0,
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        order_execution,
+        "_check_balance_and_warn",
+        AsyncMock(return_value=(None, balance_error)),
+    )
+    monkeypatch.setattr(
+        order_execution,
+        "evaluate_sector_concentration",
+        AsyncMock(return_value={"verdict": "ok"}),
+    )
+    monkeypatch.setattr(order_execution, "_record_order_history", AsyncMock())
+    monkeypatch.setattr(
+        kis_mock_ledger,
+        "_fetch_kis_mock_baseline_qty",
+        AsyncMock(return_value=Decimal("0")),
+    )
+    monkeypatch.setattr(
+        order_validation,
+        "_get_holdings_for_order",
+        AsyncMock(return_value={"avg_price": 70000.0, "quantity": 1.0}),
+    )
+    monkeypatch.setattr(
+        order_validation,
+        "_get_kis_mock_shadow_exposure",
+        AsyncMock(
+            return_value={
+                "confidence": "db_shadow_pending",
+                "sell_reserved_quantity": 0,
+                "buy_reserved_amount": 0,
+            }
+        ),
+    )
+    monkeypatch.setattr(settings, "kis_mock_scalping_enabled", True, raising=False)
+
+
+async def _has_key(correlation_id: str) -> bool:
+    async with _order_session_factory()() as db:
+        found = await db.scalar(
+            select(OrderSendIntent.id).where(
+                OrderSendIntent.account_scope == KIS_MOCK_SCALPING_SCOPE,
+                OrderSendIntent.idempotency_key == correlation_id,
+            )
+        )
+    return found is not None
 
 
 @pytest_asyncio.fixture(autouse=True)
@@ -35,15 +179,27 @@ async def _clear_reservations():
                     OrderSendIntent.account_scope == KIS_MOCK_SCALPING_SCOPE
                 )
             )
+            await db.execute(
+                delete(KISMockOrderLedger).where(
+                    KISMockOrderLedger.correlation_id.like(f"{_TEST_CID_PREFIX}%")
+                )
+            )
             await db.commit()
 
+    cb.reset_kis_circuit_breaker()
     await _c()
     yield
     await _c()
+    cb.reset_kis_circuit_breaker()
 
 
 def _broker():
-    b = adapters.KisMockBroker(get_state=lambda _s: None)
+    now = time.monotonic()
+    state = MarketState(symbol="005930", bid=69990.0, ask=70000.0, _book_updated_at=now)
+    b = adapters.KisMockBroker(
+        get_state=lambda _s: state,
+        clock=lambda: now + 0.1,
+    )
     # confirm=True normally reads the live mock balance; stub it for tests.
     b._capture_baseline = AsyncMock(return_value={"symbol": "005930"})  # type: ignore[method-assign]
     return b
@@ -54,6 +210,18 @@ async def _submit(broker, cid: str):
         symbol="005930",
         price=Decimal("70000"),
         quantity=Decimal("1"),
+        correlation_id=cid,
+        confirm=True,
+    )
+
+
+async def _submit_sell(broker, cid: str):
+    return await broker.submit_exit_sell(
+        symbol="005930",
+        price=Decimal("70000"),
+        quantity=Decimal("1"),
+        exit_reason="time_stop",
+        strategy_id="kis-mock-v1",
         correlation_id=cid,
         confirm=True,
     )
@@ -89,9 +257,11 @@ async def test_duplicate_reservation_blocks_post(monkeypatch) -> None:
 @pytest.mark.integration
 @pytest.mark.asyncio
 async def test_success_releases_reservation(monkeypatch) -> None:
-    monkeypatch.setattr(
-        adapters, "_place_order_impl", AsyncMock(return_value={"success": True})
-    )
+    async def _accepted(**kwargs):
+        kwargs["send_outcome"].mark_accepted()
+        return {"success": True}
+
+    monkeypatch.setattr(adapters, "_place_order_impl", AsyncMock(side_effect=_accepted))
     await _submit(_broker(), "cid-ok")
     assert await has_unresolved_entries() is False  # released — fully tracked
 
@@ -99,10 +269,14 @@ async def test_success_releases_reservation(monkeypatch) -> None:
 @pytest.mark.integration
 @pytest.mark.asyncio
 async def test_native_lost_keeps_reservation(monkeypatch) -> None:
+    async def _accepted_untracked(**kwargs):
+        kwargs["send_outcome"].mark_accepted()
+        return {"success": True, "ledger_tracking_unavailable": True}
+
     monkeypatch.setattr(
         adapters,
         "_place_order_impl",
-        AsyncMock(return_value={"success": True, "ledger_tracking_unavailable": True}),
+        AsyncMock(side_effect=_accepted_untracked),
     )
     await _submit(_broker(), "cid-native-lost")
     assert await has_unresolved_entries() is True  # kept — uncertain/lost
@@ -144,3 +318,204 @@ async def test_pre_send_block_releases_reservation(monkeypatch) -> None:
     )
     await _submit(_broker(), "cid-presend")
     assert await has_unresolved_entries() is False  # released — POST 0
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_production_domestic_rejection_releases_buy_reservation(
+    monkeypatch,
+) -> None:
+    """The real domestic service raises for provider rejection, then
+    _place_order_impl normalizes it to success=False. That production return shape
+    is still a definitive no-order and must release the write-ahead reservation."""
+    execute = AsyncMock(
+        return_value=_http_response(
+            {"rt_cd": "1", "msg_cd": "APBK0013", "msg1": "order rejected"}
+        )
+    )
+    _patch_production_domestic_path(monkeypatch, execute=execute, side="buy")
+
+    result = await _submit(_broker(), f"{_TEST_CID_PREFIX}buy-rejected")
+
+    assert result["success"] is False
+    assert result.get("error") == "APBK0013 order rejected", result
+    assert execute.await_count == 1
+    assert await has_unresolved_entries() is False
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_production_pre_send_validation_releases_buy_reservation(
+    monkeypatch,
+) -> None:
+    execute = AsyncMock()
+    _patch_production_domestic_path(
+        monkeypatch,
+        execute=execute,
+        side="buy",
+        balance_error={
+            "success": False,
+            "error": "insufficient balance",
+            "source": "kis",
+            "symbol": "005930",
+            "instrument_type": "equity_kr",
+        },
+    )
+
+    result = await _submit(_broker(), f"{_TEST_CID_PREFIX}buy-validation")
+
+    assert result["success"] is False
+    assert execute.await_count == 0
+    assert await has_unresolved_entries() is False
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_sell_reserve_failure_blocks_before_place(monkeypatch) -> None:
+    place = AsyncMock(return_value={"success": True})
+    monkeypatch.setattr(adapters, "_place_order_impl", place)
+    monkeypatch.setattr(
+        adapters, "reserve_entry", AsyncMock(side_effect=RuntimeError("db down"))
+    )
+
+    result = await _submit_sell(_broker(), f"{_TEST_CID_PREFIX}sell-reserve-fail")
+
+    assert result["reservation_blocked"] is True
+    assert "reservation_unavailable" in result["reason_codes"]
+    assert place.await_count == 0
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_sell_provider_rejection_reserved_before_post_then_released(
+    monkeypatch,
+) -> None:
+    cid = f"{_TEST_CID_PREFIX}sell-rejected"
+    observed = {"reserved_at_post": False}
+
+    async def execute(*_args, **_kwargs):
+        observed["reserved_at_post"] = await _has_key(cid)
+        return _http_response(
+            {"rt_cd": "1", "msg_cd": "APBK0013", "msg1": "order rejected"}
+        )
+
+    _patch_production_domestic_path(monkeypatch, execute=execute, side="sell")
+
+    result = await _submit_sell(_broker(), cid)
+
+    assert observed["reserved_at_post"] is True
+    assert result["success"] is False
+    assert await _has_key(cid) is False
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_sell_tracked_accept_reserved_before_post_then_released(
+    monkeypatch,
+) -> None:
+    cid = f"{_TEST_CID_PREFIX}sell-tracked"
+    observed = {"reserved_at_post": False}
+
+    async def execute(*_args, **_kwargs):
+        observed["reserved_at_post"] = await _has_key(cid)
+        return _http_response(
+            {
+                "rt_cd": "0",
+                "msg_cd": "0",
+                "msg1": "accepted",
+                "output": {"ODNO": "RESV-SELL-TRACKED", "ORD_TMD": "091500"},
+            }
+        )
+
+    _patch_production_domestic_path(monkeypatch, execute=execute, side="sell")
+
+    result = await _submit_sell(_broker(), cid)
+
+    assert observed["reserved_at_post"] is True
+    assert result["success"] is True, result
+    assert result["ledger_tracking_unavailable"] is False
+    assert await _has_key(cid) is False
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_sell_accepted_native_write_loss_keeps_reservation(
+    monkeypatch,
+) -> None:
+    cid = f"{_TEST_CID_PREFIX}sell-native-lost"
+    execute = AsyncMock(
+        return_value=_http_response(
+            {
+                "rt_cd": "0",
+                "msg_cd": "0",
+                "msg1": "accepted",
+                "output": {"ODNO": "RESV-SELL-LOST", "ORD_TMD": "091500"},
+            }
+        )
+    )
+    _patch_production_domestic_path(monkeypatch, execute=execute, side="sell")
+    monkeypatch.setattr(
+        kis_mock_ledger,
+        "_save_kis_mock_order_ledger",
+        AsyncMock(side_effect=LedgerWriteError("db write lost")),
+    )
+    monkeypatch.setattr(
+        kis_mock_ledger, "_native_row_exists", AsyncMock(return_value=False)
+    )
+
+    result = await _submit_sell(_broker(), cid)
+
+    assert result["success"] is True
+    assert result["ledger_tracking_unavailable"] is True
+    assert await _has_key(cid) is True
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status_code", [500, 503])
+async def test_sell_server_error_keeps_reservation(monkeypatch, status_code) -> None:
+    cid = f"{_TEST_CID_PREFIX}sell-{status_code}"
+    execute = AsyncMock(
+        return_value=_http_response(
+            {"rt_cd": "1", "msg_cd": "SERVER", "msg1": "server error"},
+            status_code=status_code,
+        )
+    )
+    _patch_production_domestic_path(monkeypatch, execute=execute, side="sell")
+
+    result = await _submit_sell(_broker(), cid)
+
+    assert result["success"] is False
+    assert await _has_key(cid) is True
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_sell_timeout_keeps_reservation(monkeypatch) -> None:
+    cid = f"{_TEST_CID_PREFIX}sell-timeout"
+    execute = AsyncMock(side_effect=httpx.ReadTimeout("timed out"))
+    _patch_production_domestic_path(monkeypatch, execute=execute, side="sell")
+
+    result = await _submit_sell(_broker(), cid)
+
+    assert result["success"] is False
+    assert result.get("outcome_unknown") is True, result
+    assert await _has_key(cid) is True
+
+
+class _ProcessCrash(BaseException):
+    pass
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_sell_crash_keeps_reservation(monkeypatch) -> None:
+    cid = f"{_TEST_CID_PREFIX}sell-crash"
+    monkeypatch.setattr(
+        adapters, "_place_order_impl", AsyncMock(side_effect=_ProcessCrash())
+    )
+
+    with pytest.raises(_ProcessCrash):
+        await _submit_sell(_broker(), cid)
+
+    assert await _has_key(cid) is True

--- a/tests/brokers/kis/mock_scalping_exec/test_reservation.py
+++ b/tests/brokers/kis/mock_scalping_exec/test_reservation.py
@@ -1,0 +1,146 @@
+"""ROB-843 P1 — write-ahead reservation lifecycle for KIS mock scalping entries.
+
+A durable reservation is recorded BEFORE the broker POST. If the durable write
+fails the POST never happens; the reservation is released only when the order is
+confirmed fully tracked or proven not sent, and an unresolved reservation is the
+restart-safe fail-close signal.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from unittest.mock import AsyncMock
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import delete
+
+from app.mcp_server.tooling.kis_mock_ledger import _order_session_factory
+from app.mcp_server.tooling.order_execution import OrderSendOutcomeUnknown
+from app.models.review import OrderSendIntent
+from app.services.brokers.kis.mock_scalping_exec import adapters
+from app.services.brokers.kis.mock_scalping_exec.reservation import (
+    has_unresolved_entries,
+    reserve_entry,
+)
+from app.services.order_send_intent_service import KIS_MOCK_SCALPING_SCOPE
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def _clear_reservations():
+    async def _c():
+        async with _order_session_factory()() as db:
+            await db.execute(
+                delete(OrderSendIntent).where(
+                    OrderSendIntent.account_scope == KIS_MOCK_SCALPING_SCOPE
+                )
+            )
+            await db.commit()
+
+    await _c()
+    yield
+    await _c()
+
+
+def _broker():
+    b = adapters.KisMockBroker(get_state=lambda _s: None)
+    # confirm=True normally reads the live mock balance; stub it for tests.
+    b._capture_baseline = AsyncMock(return_value={"symbol": "005930"})  # type: ignore[method-assign]
+    return b
+
+
+async def _submit(broker, cid: str):
+    return await broker.submit_buy(
+        symbol="005930",
+        price=Decimal("70000"),
+        quantity=Decimal("1"),
+        correlation_id=cid,
+        confirm=True,
+    )
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_reserve_failure_blocks_post(monkeypatch) -> None:
+    place = AsyncMock(return_value={"success": True})
+    monkeypatch.setattr(adapters, "_place_order_impl", place)
+    monkeypatch.setattr(
+        adapters, "reserve_entry", AsyncMock(side_effect=RuntimeError("db down"))
+    )
+    result = await _submit(_broker(), "cid-reserve-fail")
+    assert result["reservation_blocked"] is True
+    assert "reservation_unavailable" in result["reason_codes"]
+    assert place.await_count == 0  # POST 0 — durable write failed first
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_duplicate_reservation_blocks_post(monkeypatch) -> None:
+    place = AsyncMock(return_value={"success": True})
+    monkeypatch.setattr(adapters, "_place_order_impl", place)
+    cid = "cid-dup"
+    await reserve_entry(correlation_id=cid, symbol="005930", side="buy")
+    result = await _submit(_broker(), cid)
+    assert result["reservation_blocked"] is True
+    assert "duplicate_send" in result["reason_codes"]
+    assert place.await_count == 0
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_success_releases_reservation(monkeypatch) -> None:
+    monkeypatch.setattr(
+        adapters, "_place_order_impl", AsyncMock(return_value={"success": True})
+    )
+    await _submit(_broker(), "cid-ok")
+    assert await has_unresolved_entries() is False  # released — fully tracked
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_native_lost_keeps_reservation(monkeypatch) -> None:
+    monkeypatch.setattr(
+        adapters,
+        "_place_order_impl",
+        AsyncMock(return_value={"success": True, "ledger_tracking_unavailable": True}),
+    )
+    await _submit(_broker(), "cid-native-lost")
+    assert await has_unresolved_entries() is True  # kept — uncertain/lost
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_uncertain_send_keeps_reservation(monkeypatch) -> None:
+    monkeypatch.setattr(
+        adapters,
+        "_place_order_impl",
+        AsyncMock(side_effect=OrderSendOutcomeUnknown(TimeoutError("t"))),
+    )
+    with pytest.raises(OrderSendOutcomeUnknown):
+        await _submit(_broker(), "cid-uncertain")
+    assert await has_unresolved_entries() is True  # kept — outcome unknown
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_deterministic_rejection_releases_reservation(monkeypatch) -> None:
+    monkeypatch.setattr(
+        adapters,
+        "_place_order_impl",
+        AsyncMock(side_effect=RuntimeError("40 rejected")),
+    )
+    with pytest.raises(RuntimeError):
+        await _submit(_broker(), "cid-rejected")
+    assert await has_unresolved_entries() is False  # released — no order created
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_pre_send_block_releases_reservation(monkeypatch) -> None:
+    monkeypatch.setattr(
+        adapters,
+        "_place_order_impl",
+        AsyncMock(return_value={"success": False, "pre_send_blocked": True}),
+    )
+    await _submit(_broker(), "cid-presend")
+    assert await has_unresolved_entries() is False  # released — POST 0

--- a/tests/brokers/kis/mock_scalping_exec/test_risk_gate_adapter.py
+++ b/tests/brokers/kis/mock_scalping_exec/test_risk_gate_adapter.py
@@ -201,12 +201,26 @@ async def test_cooldown_and_daily_counters_come_from_order_history() -> None:
 async def test_order_history_loader_reads_ledger(db_session) -> None:
     """A reconciled loss row for a unique symbol drives cooldown basis + realized
     loss; open-order rows do NOT become positions (position isn't read here)."""
-    from app.mcp_server.tooling.kis_mock_ledger import _save_kis_mock_order_ledger
+    from sqlalchemy import delete
+
+    from app.mcp_server.tooling.kis_mock_ledger import (
+        _order_session_factory,
+        _save_kis_mock_order_ledger,
+    )
+    from app.models.review import KISMockOrderLedger
     from app.services.brokers.kis.mock_scalping_exec.ledger_state import (
         load_kis_mock_order_history,
     )
 
     symbol = "900843"
+    # Deterministic across re-runs of the persistent shared test DB (clear any
+    # prior-run rows, including legacy closes written before reconciled_at was
+    # stamped).
+    async with _order_session_factory()() as _db:
+        await _db.execute(
+            delete(KISMockOrderLedger).where(KISMockOrderLedger.symbol == symbol)
+        )
+        await _db.commit()
     await _save_kis_mock_order_ledger(
         symbol=symbol,
         instrument_type="equity_kr",

--- a/tests/brokers/kis/mock_scalping_exec/test_risk_gate_adapter.py
+++ b/tests/brokers/kis/mock_scalping_exec/test_risk_gate_adapter.py
@@ -69,6 +69,32 @@ def _gate(state, *, holdings=_empty_holdings, history=_no_history):
     )
 
 
+@pytest.fixture(autouse=True)
+def _reset_tracking_state():
+    """Keep the process-local ledger-tracking flag from leaking between tests."""
+    from app.services.brokers.kis.mock_scalping_exec.tracking_state import (
+        reset_ledger_tracking_state,
+    )
+
+    reset_ledger_tracking_state()
+    yield
+    reset_ledger_tracking_state()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_gate_fail_closes_when_tracking_unavailable() -> None:
+    """ROB-843 P1-2: a degraded ledger-tracking flag fail-closes the next order
+    before any market/holdings read."""
+    from app.services.brokers.kis.mock_scalping_exec.tracking_state import (
+        mark_ledger_tracking_unavailable,
+    )
+
+    mark_ledger_tracking_unavailable()
+    with pytest.raises(RuntimeError, match="ledger_tracking_unavailable"):
+        await _gate(_FakeState()).load(symbol="005930", side="BUY")
+
+
 # --- Market snapshot fail-close (Blocker 3) -----------------------------------
 
 

--- a/tests/brokers/kis/mock_scalping_exec/test_risk_gate_adapter.py
+++ b/tests/brokers/kis/mock_scalping_exec/test_risk_gate_adapter.py
@@ -71,7 +71,8 @@ def _gate(state, *, holdings=_empty_holdings, history=_no_history):
 
 @pytest.fixture(autouse=True)
 def _reset_tracking_state():
-    """Keep the process-local ledger-tracking flag from leaking between tests."""
+    """Keep the process-local ledger-tracking flag from leaking between tests
+    (this file mixes sync and async tests, so the fixture stays sync)."""
     from app.services.brokers.kis.mock_scalping_exec.tracking_state import (
         reset_ledger_tracking_state,
     )
@@ -235,18 +236,21 @@ async def test_order_history_loader_reads_ledger(db_session) -> None:
     )
     from app.models.review import KISMockOrderLedger
     from app.services.brokers.kis.mock_scalping_exec.ledger_state import (
+        clear_tracking_degradation,
         load_kis_mock_order_history,
     )
 
     symbol = "900843"
     # Deterministic across re-runs of the persistent shared test DB (clear any
     # prior-run rows, including legacy closes written before reconciled_at was
-    # stamped).
+    # stamped, and any stray durable degradation marker that would fail-close).
     async with _order_session_factory()() as _db:
         await _db.execute(
             delete(KISMockOrderLedger).where(KISMockOrderLedger.symbol == symbol)
         )
         await _db.commit()
+    async with _order_session_factory()() as _db:
+        await clear_tracking_degradation(_db)
     await _save_kis_mock_order_ledger(
         symbol=symbol,
         instrument_type="equity_kr",

--- a/tests/brokers/kis/mock_scalping_exec/test_risk_gate_adapter.py
+++ b/tests/brokers/kis/mock_scalping_exec/test_risk_gate_adapter.py
@@ -69,31 +69,8 @@ def _gate(state, *, holdings=_empty_holdings, history=_no_history):
     )
 
 
-@pytest.fixture(autouse=True)
-def _reset_tracking_state():
-    """Keep the process-local ledger-tracking flag from leaking between tests
-    (this file mixes sync and async tests, so the fixture stays sync)."""
-    from app.services.brokers.kis.mock_scalping_exec.tracking_state import (
-        reset_ledger_tracking_state,
-    )
-
-    reset_ledger_tracking_state()
-    yield
-    reset_ledger_tracking_state()
-
-
-@pytest.mark.unit
-@pytest.mark.asyncio
-async def test_gate_fail_closes_when_tracking_unavailable() -> None:
-    """ROB-843 P1-2: a degraded ledger-tracking flag fail-closes the next order
-    before any market/holdings read."""
-    from app.services.brokers.kis.mock_scalping_exec.tracking_state import (
-        mark_ledger_tracking_unavailable,
-    )
-
-    mark_ledger_tracking_unavailable()
-    with pytest.raises(RuntimeError, match="ledger_tracking_unavailable"):
-        await _gate(_FakeState()).load(symbol="005930", side="BUY")
+# (The durable reservation fail-close is enforced inside the real order-history
+# loader and is exercised end-to-end in test_order_history_ledger.py.)
 
 
 # --- Market snapshot fail-close (Blocker 3) -----------------------------------
@@ -234,23 +211,25 @@ async def test_order_history_loader_reads_ledger(db_session) -> None:
         _order_session_factory,
         _save_kis_mock_order_ledger,
     )
-    from app.models.review import KISMockOrderLedger
+    from app.models.review import KISMockOrderLedger, OrderSendIntent
     from app.services.brokers.kis.mock_scalping_exec.ledger_state import (
-        clear_tracking_degradation,
         load_kis_mock_order_history,
     )
+    from app.services.order_send_intent_service import KIS_MOCK_SCALPING_SCOPE
 
     symbol = "900843"
     # Deterministic across re-runs of the persistent shared test DB (clear any
-    # prior-run rows, including legacy closes written before reconciled_at was
-    # stamped, and any stray durable degradation marker that would fail-close).
+    # prior-run rows and any stray scalping reservation that would fail-close).
     async with _order_session_factory()() as _db:
         await _db.execute(
             delete(KISMockOrderLedger).where(KISMockOrderLedger.symbol == symbol)
         )
+        await _db.execute(
+            delete(OrderSendIntent).where(
+                OrderSendIntent.account_scope == KIS_MOCK_SCALPING_SCOPE
+            )
+        )
         await _db.commit()
-    async with _order_session_factory()() as _db:
-        await clear_tracking_degradation(_db)
     await _save_kis_mock_order_ledger(
         symbol=symbol,
         instrument_type="equity_kr",

--- a/tests/brokers/kis/mock_scalping_exec/test_risk_gate_adapter.py
+++ b/tests/brokers/kis/mock_scalping_exec/test_risk_gate_adapter.py
@@ -1,0 +1,153 @@
+"""ROB-843 — KisMockRiskGate adapter + durable ledger snapshot loader.
+
+The adapter must fail-close (raise) on any missing/stale live-market field so
+the executor records ``risk_snapshot_unavailable`` and mutates zero times. The
+durable loader must read authoritative per-symbol state from the mock ledger.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal
+
+import pytest
+
+from app.services.brokers.kis.mock_scalping.contract import LedgerSnapshot
+
+
+@dataclass
+class _FakeState:
+    bid: float | None = 70000.0
+    ask: float | None = 70100.0
+    _book_age: float | None = 1.0
+    _spread: float | None = 14.0
+
+    def book_age_seconds(self, *, now: float) -> float | None:
+        return self._book_age
+
+    def spread_bps(self) -> float | None:
+        return self._spread
+
+
+async def _stub_loader(*, symbol: str) -> LedgerSnapshot:
+    return LedgerSnapshot(
+        has_open_position_for_symbol=False,
+        open_position_count=0,
+        orders_today=0,
+        realized_loss_today_krw=Decimal("0"),
+        seconds_since_last_close_for_symbol=None,
+    )
+
+
+def _gate(state: _FakeState | None):
+    from app.services.brokers.kis.mock_scalping_exec.adapters import KisMockRiskGate
+
+    return KisMockRiskGate(
+        get_state=lambda _s: state,
+        clock=lambda: 100.0,
+        snapshot_loader=_stub_loader,
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_gate_builds_market_conditions_from_live_state() -> None:
+    gate = _gate(_FakeState())
+    inputs = await gate.load(symbol="005930", side="BUY")
+    assert inputs.market.spread_bps == Decimal("14.0")
+    assert inputs.market.data_age_seconds == 1.0
+    assert inputs.ledger.open_position_count == 0
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_gate_raises_when_no_state() -> None:
+    gate = _gate(None)
+    with pytest.raises(RuntimeError):
+        await gate.load(symbol="005930", side="BUY")
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "state",
+    [
+        _FakeState(bid=None),
+        _FakeState(ask=None),
+        _FakeState(_book_age=None),
+        _FakeState(_spread=None),
+    ],
+)
+async def test_gate_raises_on_incomplete_market_snapshot(state) -> None:
+    gate = _gate(state)
+    with pytest.raises(RuntimeError):
+        await gate.load(symbol="005930", side="BUY")
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_ledger_snapshot_reads_durable_state(db_session) -> None:
+    """Insert open + reconciled rows for a unique symbol; the loader reports
+    symbol-scoped open position + last-close, and lenient global counts."""
+    from app.mcp_server.tooling.kis_mock_ledger import _save_kis_mock_order_ledger
+    from app.services.brokers.kis.mock_scalping_exec.ledger_state import (
+        load_kis_mock_ledger_snapshot,
+    )
+
+    symbol = "900843"  # unique symbol to keep per-symbol asserts isolated
+
+    await _save_kis_mock_order_ledger(
+        symbol=symbol,
+        instrument_type="equity_kr",
+        side="buy",
+        order_type="limit",
+        quantity=1.0,
+        price=1000.0,
+        amount=1000.0,
+        currency="KRW",
+        order_no=f"ROB843-open-{symbol}",
+        order_time=None,
+        krx_fwdg_ord_orgno=None,
+        status="accepted",
+        response_code=None,
+        response_message=None,
+        raw_response=None,
+        reason="t",
+        thesis=None,
+        strategy=None,
+        notes=None,
+        lifecycle_state="fill",
+        correlation_id=f"c-open-{symbol}",
+    )
+    await _save_kis_mock_order_ledger(
+        symbol=symbol,
+        instrument_type="equity_kr",
+        side="sell",
+        order_type="limit",
+        quantity=1.0,
+        price=980.0,
+        amount=980.0,
+        currency="KRW",
+        order_no=f"ROB843-close-{symbol}",
+        order_time=None,
+        krx_fwdg_ord_orgno=None,
+        status="accepted",
+        response_code=None,
+        response_message=None,
+        raw_response=None,
+        reason="t",
+        thesis=None,
+        strategy=None,
+        notes=None,
+        lifecycle_state="reconciled",
+        net_pnl=Decimal("-20"),
+        correlation_id=f"c-close-{symbol}",
+    )
+
+    snap = await load_kis_mock_ledger_snapshot(symbol=symbol)
+
+    assert snap.has_open_position_for_symbol is True
+    assert snap.seconds_since_last_close_for_symbol is not None
+    assert snap.open_position_count >= 1
+    assert snap.orders_today >= 2
+    assert snap.realized_loss_today_krw >= Decimal("20")

--- a/tests/brokers/kis/mock_scalping_exec/test_risk_gate_adapter.py
+++ b/tests/brokers/kis/mock_scalping_exec/test_risk_gate_adapter.py
@@ -1,18 +1,28 @@
-"""ROB-843 — KisMockRiskGate adapter + durable ledger snapshot loader.
+"""ROB-843 — KisMockRiskGate adapter + order-history loader.
 
-The adapter must fail-close (raise) on any missing/stale live-market field so
-the executor records ``risk_snapshot_unavailable`` and mutates zero times. The
-durable loader must read authoritative per-symbol state from the mock ledger.
+The gate must:
+* build position (has-open / count) from a fresh **holdings** snapshot, never
+  from order lifecycle rows;
+* fail-close (raise) on any malformed live-market field — missing/stale
+  timestamp, non-positive/NaN/Inf bid or ask, or a crossed book (ask < bid);
+* read daily order count / realized loss / cooldown from the mock order ledger.
 """
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass
 from decimal import Decimal
+from typing import Any
 
 import pytest
 
-from app.services.brokers.kis.mock_scalping.contract import LedgerSnapshot
+from app.services.brokers.kis.mock_scalping.contract import (
+    MarketConditions,
+    ScalpingRiskLimits,
+    evaluate_risk,
+)
+from app.services.brokers.kis.mock_scalping_exec.ledger_state import MockOrderHistory
 
 
 @dataclass
@@ -29,42 +39,54 @@ class _FakeState:
         return self._spread
 
 
-async def _stub_loader(*, symbol: str) -> LedgerSnapshot:
-    return LedgerSnapshot(
-        has_open_position_for_symbol=False,
-        open_position_count=0,
+async def _empty_holdings() -> dict[str, Any]:
+    return {"holdings": [], "cash": {}}
+
+
+def _holdings(*entries: tuple[str, str]) -> Any:
+    async def _provider() -> dict[str, Any]:
+        return {"holdings": [{"pdno": s, "hldg_qty": q} for s, q in entries]}
+
+    return _provider
+
+
+async def _no_history(*, symbol: str) -> MockOrderHistory:
+    return MockOrderHistory(
         orders_today=0,
         realized_loss_today_krw=Decimal("0"),
         seconds_since_last_close_for_symbol=None,
     )
 
 
-def _gate(state: _FakeState | None):
+def _gate(state, *, holdings=_empty_holdings, history=_no_history):
     from app.services.brokers.kis.mock_scalping_exec.adapters import KisMockRiskGate
 
     return KisMockRiskGate(
         get_state=lambda _s: state,
+        holdings_provider=holdings,
         clock=lambda: 100.0,
-        snapshot_loader=_stub_loader,
+        order_history_loader=history,
     )
+
+
+# --- Market snapshot fail-close (Blocker 3) -----------------------------------
 
 
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_gate_builds_market_conditions_from_live_state() -> None:
-    gate = _gate(_FakeState())
-    inputs = await gate.load(symbol="005930", side="BUY")
+    inputs = await _gate(_FakeState()).load(symbol="005930", side="BUY")
     assert inputs.market.spread_bps == Decimal("14.0")
     assert inputs.market.data_age_seconds == 1.0
     assert inputs.ledger.open_position_count == 0
+    assert inputs.ledger.has_open_position_for_symbol is False
 
 
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_gate_raises_when_no_state() -> None:
-    gate = _gate(None)
     with pytest.raises(RuntimeError):
-        await gate.load(symbol="005930", side="BUY")
+        await _gate(None).load(symbol="005930", side="BUY")
 
 
 @pytest.mark.unit
@@ -76,26 +98,115 @@ async def test_gate_raises_when_no_state() -> None:
         _FakeState(ask=None),
         _FakeState(_book_age=None),
         _FakeState(_spread=None),
+        _FakeState(bid=0.0),  # non-positive
+        _FakeState(ask=-5.0),  # non-positive
+        _FakeState(bid=math.nan),  # NaN
+        _FakeState(ask=math.inf),  # Inf
+        _FakeState(_book_age=math.nan),  # NaN timestamp age
+        _FakeState(_book_age=-1.0),  # negative age
+        _FakeState(bid=70200.0, ask=70000.0),  # crossed book (ask < bid)
     ],
 )
-async def test_gate_raises_on_incomplete_market_snapshot(state) -> None:
-    gate = _gate(state)
+async def test_gate_fail_closes_on_malformed_market(state) -> None:
     with pytest.raises(RuntimeError):
-        await gate.load(symbol="005930", side="BUY")
+        await _gate(state).load(symbol="005930", side="BUY")
+
+
+@pytest.mark.unit
+def test_crossed_book_would_pass_evaluate_risk_as_negative_spread() -> None:
+    """Documents why the gate must reject a crossed book BEFORE evaluate_risk:
+    a negative spread slips past the SPREAD_TOO_WIDE guard."""
+    from app.services.brokers.kis.mock_scalping.contract import LedgerSnapshot
+
+    decision = evaluate_risk(
+        symbol="005930",
+        side="BUY",
+        target_notional_krw=Decimal("100000"),
+        limits=ScalpingRiskLimits(),
+        ledger=LedgerSnapshot(
+            has_open_position_for_symbol=False,
+            open_position_count=0,
+            orders_today=0,
+            realized_loss_today_krw=Decimal("0"),
+            seconds_since_last_close_for_symbol=None,
+        ),
+        market=MarketConditions(spread_bps=Decimal("-50"), data_age_seconds=1.0),
+    )
+    assert decision.allowed  # negative spread is NOT caught -> gate must reject
+
+
+# --- Position from holdings, not order lifecycle (Blocker 2) -------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_held_position_from_holdings_blocks_reentry() -> None:
+    gate = _gate(_FakeState(), holdings=_holdings(("005930", "3"), ("000660", "1")))
+    inputs = await gate.load(symbol="005930", side="BUY")
+    assert inputs.ledger.has_open_position_for_symbol is True
+    assert inputs.ledger.open_position_count == 2
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_flat_after_roundtrip_allows_reentry() -> None:
+    """Holdings empty (scalping entry+exit closed flat) -> no open position."""
+    gate = _gate(_FakeState(), holdings=_empty_holdings)
+    inputs = await gate.load(symbol="005930", side="BUY")
+    assert inputs.ledger.has_open_position_for_symbol is False
+    assert inputs.ledger.open_position_count == 0
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_zero_qty_holding_is_not_a_position() -> None:
+    gate = _gate(_FakeState(), holdings=_holdings(("005930", "0")))
+    inputs = await gate.load(symbol="005930", side="BUY")
+    assert inputs.ledger.has_open_position_for_symbol is False
+    assert inputs.ledger.open_position_count == 0
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_holdings_read_failure_fail_closes() -> None:
+    async def _boom() -> dict[str, Any]:
+        raise RuntimeError("balance read failed")
+
+    with pytest.raises(RuntimeError):
+        await _gate(_FakeState(), holdings=_boom).load(symbol="005930", side="BUY")
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_cooldown_and_daily_counters_come_from_order_history() -> None:
+    async def _hist(*, symbol: str) -> MockOrderHistory:
+        return MockOrderHistory(
+            orders_today=4,
+            realized_loss_today_krw=Decimal("1000"),
+            seconds_since_last_close_for_symbol=42.0,
+        )
+
+    gate = _gate(_FakeState(), history=_hist)
+    inputs = await gate.load(symbol="005930", side="BUY")
+    assert inputs.ledger.orders_today == 4
+    assert inputs.ledger.realized_loss_today_krw == Decimal("1000")
+    assert inputs.ledger.seconds_since_last_close_for_symbol == 42.0
+
+
+# --- Order-history loader reads durable order ledger (Blocker 2) ---------------
 
 
 @pytest.mark.integration
 @pytest.mark.asyncio
-async def test_ledger_snapshot_reads_durable_state(db_session) -> None:
-    """Insert open + reconciled rows for a unique symbol; the loader reports
-    symbol-scoped open position + last-close, and lenient global counts."""
+async def test_order_history_loader_reads_ledger(db_session) -> None:
+    """A reconciled loss row for a unique symbol drives cooldown basis + realized
+    loss; open-order rows do NOT become positions (position isn't read here)."""
     from app.mcp_server.tooling.kis_mock_ledger import _save_kis_mock_order_ledger
     from app.services.brokers.kis.mock_scalping_exec.ledger_state import (
-        load_kis_mock_ledger_snapshot,
+        load_kis_mock_order_history,
     )
 
-    symbol = "900843"  # unique symbol to keep per-symbol asserts isolated
-
+    symbol = "900843"
     await _save_kis_mock_order_ledger(
         symbol=symbol,
         instrument_type="equity_kr",
@@ -144,10 +255,7 @@ async def test_ledger_snapshot_reads_durable_state(db_session) -> None:
         correlation_id=f"c-close-{symbol}",
     )
 
-    snap = await load_kis_mock_ledger_snapshot(symbol=symbol)
-
-    assert snap.has_open_position_for_symbol is True
-    assert snap.seconds_since_last_close_for_symbol is not None
-    assert snap.open_position_count >= 1
-    assert snap.orders_today >= 2
-    assert snap.realized_loss_today_krw >= Decimal("20")
+    hist = await load_kis_mock_order_history(symbol=symbol)
+    assert hist.orders_today >= 2
+    assert hist.realized_loss_today_krw >= Decimal("20")
+    assert hist.seconds_since_last_close_for_symbol is not None

--- a/tests/brokers/kis/mock_scalping_exec/test_rob843_safety.py
+++ b/tests/brokers/kis/mock_scalping_exec/test_rob843_safety.py
@@ -1,0 +1,63 @@
+"""ROB-843 safety/architecture guards.
+
+* Automated KIS mock mutation stays default-off until ROB-853 lands.
+* The executor final-risk path (executor + risk gate + durable ledger loader)
+  imports no KIS-live execution/ledger module — mock stays isolated from live.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+from app.core.config import Settings
+
+# KIS-live execution/ledger/policy fragments that mock scalping must never reach.
+_FORBIDDEN_LIVE_FRAGMENTS = (
+    "kis_live_ledger",
+    "live_order_ledger",
+    "live_order_evidence",
+    "kis_live",
+)
+
+_MODULES_UNDER_GUARD = (
+    "app/services/brokers/kis/mock_scalping_exec/executor.py",
+    "app/services/brokers/kis/mock_scalping_exec/ledger_state.py",
+)
+
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+
+
+def _imported_modules(tree: ast.AST) -> list[str]:
+    modules: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            modules.extend(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            modules.append(node.module)
+    return modules
+
+
+@pytest.mark.unit
+def test_automated_kis_mock_mutation_defaults_off() -> None:
+    s = Settings()
+    assert s.kis_mock_scalping_ws_enabled is False
+    assert s.kis_mock_scalping_ws_confirm is False
+    assert s.WATCH_AUTO_EXECUTE_MOCK_ENABLED is False
+
+
+@pytest.mark.unit
+def test_executor_risk_path_imports_no_kis_live() -> None:
+    violations: list[str] = []
+    for rel in _MODULES_UNDER_GUARD:
+        path = _REPO_ROOT / rel
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for module in _imported_modules(tree):
+            for fragment in _FORBIDDEN_LIVE_FRAGMENTS:
+                if fragment in module:
+                    violations.append(f"{rel}: imports {module!r} ({fragment!r})")
+    assert not violations, "mock scalping reached KIS-live code:\n" + "\n".join(
+        violations
+    )

--- a/tests/brokers/kis/mock_scalping_exec/test_ws_bridge.py
+++ b/tests/brokers/kis/mock_scalping_exec/test_ws_bridge.py
@@ -7,7 +7,16 @@ from decimal import Decimal
 
 import pytest
 
+from app.services.brokers.kis.mock_scalping.contract import (
+    LedgerSnapshot,
+    MarketConditions,
+    ScalpingRiskLimits,
+)
 from app.services.brokers.kis.mock_scalping.signal import SignalDecision
+from app.services.brokers.kis.mock_scalping_exec.executor import (
+    MockScalpingExecutor,
+    RiskInputs,
+)
 from app.services.brokers.kis.mock_scalping_exec.ws_bridge import WsExecutionBridge
 from app.services.brokers.kis.mock_scalping_ws.supervisor import TriggerEvent
 
@@ -98,3 +107,104 @@ async def test_bridge_per_symbol_in_flight_guard() -> None:
     await first
 
     assert len(ex.calls) == 1
+
+
+# --- ROB-843 AC6: WS bridge cannot bypass the executor-owned risk gate --------
+
+
+class _RecordingBroker:
+    def __init__(self):
+        self.submitted: list[str] = []
+
+    async def submit_buy(self, **kw):
+        self.submitted.append("buy")
+        return {"kind": "buy"}
+
+    async def submit_exit_sell(self, **kw):
+        self.submitted.append("sell")
+        return {"kind": "sell"}
+
+    async def confirm_fill(self, submit_result):
+        return None
+
+    def quote(self, symbol):
+        return None
+
+
+class _NullLedger:
+    async def record_entry(self, **kw):
+        return None
+
+    async def record_exit_reconciled(self, **kw):
+        return None
+
+    async def record_anomaly(self, **kw):
+        return None
+
+
+class _StubRiskGate:
+    def __init__(self, *, inputs):
+        self._inputs = inputs
+        self.calls = 0
+
+    async def load(self, *, symbol, side):
+        self.calls += 1
+        return self._inputs
+
+
+def _inputs(*, spread_bps=Decimal("10"), data_age=1.0) -> RiskInputs:
+    return RiskInputs(
+        ledger=LedgerSnapshot(
+            has_open_position_for_symbol=False,
+            open_position_count=0,
+            orders_today=0,
+            realized_loss_today_krw=Decimal("0"),
+            seconds_since_last_close_for_symbol=None,
+        ),
+        market=MarketConditions(spread_bps=spread_bps, data_age_seconds=data_age),
+    )
+
+
+def _real_executor(broker, *, inputs):
+    async def _no_sleep(_s):
+        return None
+
+    gate = _StubRiskGate(inputs=inputs)
+    ex = MockScalpingExecutor(
+        broker=broker,
+        ledger=_NullLedger(),
+        sleep=_no_sleep,
+        clock=lambda: 0.0,
+        risk=gate,
+        limits=ScalpingRiskLimits(),
+    )
+    return ex, gate
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_ws_bridge_delegates_to_executor_risk_gate_and_blocks() -> None:
+    """A BUY trigger the caller deemed fine is still refused when the executor's
+    own fresh snapshot denies it — proving the bridge cannot bypass the gate."""
+    broker = _RecordingBroker()
+    # Wide spread from the executor's OWN snapshot -> deny, zero broker calls.
+    executor, gate = _real_executor(broker, inputs=_inputs(spread_bps=Decimal("99")))
+    bridge = WsExecutionBridge(executor=executor, confirm=True)
+
+    await bridge.on_trigger(_trigger())
+
+    assert gate.calls == 1  # executor reloaded its own snapshot
+    assert broker.submitted == []  # no order despite a "clean" trigger
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_ws_bridge_allows_when_executor_snapshot_clears() -> None:
+    broker = _RecordingBroker()
+    executor, gate = _real_executor(broker, inputs=_inputs())
+    bridge = WsExecutionBridge(executor=executor, confirm=True)
+
+    await bridge.on_trigger(_trigger())
+
+    assert gate.calls == 1
+    assert broker.submitted == ["buy"]  # proceeds past the gate to submit

--- a/tests/brokers/kis/test_broker_order_id.py
+++ b/tests/brokers/kis/test_broker_order_id.py
@@ -1,0 +1,40 @@
+"""ROB-843 — broker order-id normalization (whitespace/malformed fail-close)."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.services.brokers.kis.order_id import normalize_broker_order_id
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "value",
+    [
+        None,
+        "",
+        "   ",
+        "\t\n",
+        {"odno": "1"},  # malformed type
+        ["0001"],  # malformed type
+        3.14,  # malformed type
+        True,  # bool is not a valid order id
+    ],
+)
+def test_invalid_ids_normalize_to_none(value) -> None:
+    assert normalize_broker_order_id(value) is None
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        ("0001234567", "0001234567"),  # domestic
+        ("0009999999", "0009999999"),  # overseas
+        ("  0001234567  ", "0001234567"),  # leading/trailing whitespace stripped
+        ("\t0001\n", "0001"),
+        (123456, "123456"),  # int coerced
+    ],
+)
+def test_valid_ids_are_stripped_and_kept(value, expected) -> None:
+    assert normalize_broker_order_id(value) == expected

--- a/tests/test_kis_mock_order_ledger.py
+++ b/tests/test_kis_mock_order_ledger.py
@@ -1245,9 +1245,42 @@ async def test_record_native_error_writes_synthetic_fallback(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_record_all_evidence_lost_marks_tracking_unavailable(monkeypatch):
-    """ROB-843 P1-2: native AND fallback both fail to persist → tracking degraded
-    (subsequent orders fail-close) while broker success stays true."""
+async def test_record_all_evidence_lost_persists_durable_marker(monkeypatch):
+    """ROB-843 P1-2: native AND fallback both fail → a DURABLE degradation marker
+    is persisted (survives restart); broker success stays true."""
+    from app.mcp_server.tooling import kis_mock_ledger
+    from app.services.brokers.kis.mock_scalping_exec.tracking_state import (
+        LedgerWriteError,
+        reset_ledger_tracking_state,
+    )
+
+    reset_ledger_tracking_state()
+    monkeypatch.setattr(
+        kis_mock_ledger,
+        "_save_kis_mock_order_ledger",
+        AsyncMock(side_effect=LedgerWriteError("db down")),
+    )
+    monkeypatch.setattr(
+        kis_mock_ledger, "_native_row_exists", AsyncMock(return_value=False)
+    )
+    monkeypatch.setattr(
+        kis_mock_ledger, "_persist_tracking_fallback", AsyncMock(return_value=None)
+    )
+    marker = AsyncMock(return_value=123)  # durable marker persisted
+    monkeypatch.setattr(kis_mock_ledger, "_persist_tracking_degradation_marker", marker)
+    try:
+        result = await _record_accepted(monkeypatch)
+        assert result["success"] is True
+        assert result["ledger_tracking_unavailable"] is True
+        marker.assert_awaited_once()
+    finally:
+        reset_ledger_tracking_state()
+
+
+@pytest.mark.asyncio
+async def test_record_marker_lost_falls_back_to_process_latch(monkeypatch):
+    """ROB-843 P1-2: if even the durable marker cannot persist, the process-local
+    latch is set as a last resort so the next order still fail-closes."""
     from app.mcp_server.tooling import kis_mock_ledger
     from app.services.brokers.kis.mock_scalping_exec.tracking_state import (
         LedgerWriteError,
@@ -1267,9 +1300,13 @@ async def test_record_all_evidence_lost_marks_tracking_unavailable(monkeypatch):
     monkeypatch.setattr(
         kis_mock_ledger, "_persist_tracking_fallback", AsyncMock(return_value=None)
     )
+    monkeypatch.setattr(
+        kis_mock_ledger,
+        "_persist_tracking_degradation_marker",
+        AsyncMock(return_value=None),
+    )
     try:
         result = await _record_accepted(monkeypatch)
-        assert result["success"] is True
         assert result["ledger_tracking_unavailable"] is True
         assert is_ledger_tracking_unavailable() is True
     finally:

--- a/tests/test_kis_mock_order_ledger.py
+++ b/tests/test_kis_mock_order_ledger.py
@@ -1163,6 +1163,119 @@ async def test_record_redacts_sensitive_evidence(monkeypatch):
     assert "sid=abc" not in blob
 
 
+async def _record_accepted(monkeypatch, **over):
+    """Run _record_kis_mock_order for an accepted order with publish stubbed."""
+    from app.mcp_server.tooling import kis_mock_ledger
+
+    monkeypatch.setattr(
+        kis_mock_ledger, "publish_place_time_forecast", AsyncMock(return_value=None)
+    )
+    kw = {
+        "normalized_symbol": "005930",
+        "market_type": "equity_kr",
+        "side": "buy",
+        "order_type": "limit",
+        "dry_run_result": _mock_preview(),
+        "execution_result": {"rt_cd": "0", "odno": "0001234567"},
+        "reason": "t",
+        "thesis": None,
+        "strategy": None,
+        "notes": None,
+        "correlation_id": "cid-x",
+    }
+    kw.update(over)
+    return await kis_mock_ledger._record_kis_mock_order(**kw)
+
+
+@pytest.mark.asyncio
+async def test_record_native_conflict_requeries_existing_row(monkeypatch):
+    """ROB-843 P1-2: an on-conflict no-op with an existing native row is durable —
+    no fallback, tracking stays available, success preserved."""
+    from app.mcp_server.tooling import kis_mock_ledger
+    from app.services.brokers.kis.mock_scalping_exec.tracking_state import (
+        reset_ledger_tracking_state,
+    )
+
+    reset_ledger_tracking_state()
+    monkeypatch.setattr(
+        kis_mock_ledger, "_save_kis_mock_order_ledger", AsyncMock(return_value=None)
+    )
+    monkeypatch.setattr(
+        kis_mock_ledger, "_native_row_exists", AsyncMock(return_value=True)
+    )
+    fallback = AsyncMock(return_value=1)
+    monkeypatch.setattr(kis_mock_ledger, "_persist_tracking_fallback", fallback)
+    try:
+        result = await _record_accepted(monkeypatch)
+        assert result["success"] is True
+        assert result["ledger_tracking_unavailable"] is False
+        fallback.assert_not_awaited()  # existing row is durable, no fallback
+    finally:
+        reset_ledger_tracking_state()
+
+
+@pytest.mark.asyncio
+async def test_record_native_error_writes_synthetic_fallback(monkeypatch):
+    """ROB-843 P1-2: a lost native write falls back to a durable evidence row;
+    tracking stays available and broker success is preserved."""
+    from app.mcp_server.tooling import kis_mock_ledger
+    from app.services.brokers.kis.mock_scalping_exec.tracking_state import (
+        LedgerWriteError,
+        reset_ledger_tracking_state,
+    )
+
+    reset_ledger_tracking_state()
+    monkeypatch.setattr(
+        kis_mock_ledger,
+        "_save_kis_mock_order_ledger",
+        AsyncMock(side_effect=LedgerWriteError("db down")),
+    )
+    monkeypatch.setattr(
+        kis_mock_ledger, "_native_row_exists", AsyncMock(return_value=False)
+    )
+    fallback = AsyncMock(return_value=99)
+    monkeypatch.setattr(kis_mock_ledger, "_persist_tracking_fallback", fallback)
+    try:
+        result = await _record_accepted(monkeypatch)
+        assert result["success"] is True  # broker accepted; bookkeeping recovered
+        assert result["ledger_tracking_unavailable"] is False
+        fallback.assert_awaited_once()
+    finally:
+        reset_ledger_tracking_state()
+
+
+@pytest.mark.asyncio
+async def test_record_all_evidence_lost_marks_tracking_unavailable(monkeypatch):
+    """ROB-843 P1-2: native AND fallback both fail to persist → tracking degraded
+    (subsequent orders fail-close) while broker success stays true."""
+    from app.mcp_server.tooling import kis_mock_ledger
+    from app.services.brokers.kis.mock_scalping_exec.tracking_state import (
+        LedgerWriteError,
+        is_ledger_tracking_unavailable,
+        reset_ledger_tracking_state,
+    )
+
+    reset_ledger_tracking_state()
+    monkeypatch.setattr(
+        kis_mock_ledger,
+        "_save_kis_mock_order_ledger",
+        AsyncMock(side_effect=LedgerWriteError("db down")),
+    )
+    monkeypatch.setattr(
+        kis_mock_ledger, "_native_row_exists", AsyncMock(return_value=False)
+    )
+    monkeypatch.setattr(
+        kis_mock_ledger, "_persist_tracking_fallback", AsyncMock(return_value=None)
+    )
+    try:
+        result = await _record_accepted(monkeypatch)
+        assert result["success"] is True
+        assert result["ledger_tracking_unavailable"] is True
+        assert is_ledger_tracking_unavailable() is True
+    finally:
+        reset_ledger_tracking_state()
+
+
 @pytest.mark.asyncio
 async def test_record_rejected_order_mints_but_does_not_publish(monkeypatch):
     """ROB-730: a rejected order still gets a correlation_id (spine), but no

--- a/tests/test_kis_mock_order_ledger.py
+++ b/tests/test_kis_mock_order_ledger.py
@@ -1189,128 +1189,42 @@ async def _record_accepted(monkeypatch, **over):
 
 @pytest.mark.asyncio
 async def test_record_native_conflict_requeries_existing_row(monkeypatch):
-    """ROB-843 P1-2: an on-conflict no-op with an existing native row is durable —
-    no fallback, tracking stays available, success preserved."""
+    """ROB-843 P1: an on-conflict no-op with an existing native row is durable —
+    tracking stays available, success preserved, and NO control row is written."""
     from app.mcp_server.tooling import kis_mock_ledger
-    from app.services.brokers.kis.mock_scalping_exec.tracking_state import (
-        reset_ledger_tracking_state,
-    )
 
-    reset_ledger_tracking_state()
-    monkeypatch.setattr(
-        kis_mock_ledger, "_save_kis_mock_order_ledger", AsyncMock(return_value=None)
-    )
+    save = AsyncMock(return_value=None)  # on-conflict no-op
+    monkeypatch.setattr(kis_mock_ledger, "_save_kis_mock_order_ledger", save)
     monkeypatch.setattr(
         kis_mock_ledger, "_native_row_exists", AsyncMock(return_value=True)
     )
-    fallback = AsyncMock(return_value=1)
-    monkeypatch.setattr(kis_mock_ledger, "_persist_tracking_fallback", fallback)
-    try:
-        result = await _record_accepted(monkeypatch)
-        assert result["success"] is True
-        assert result["ledger_tracking_unavailable"] is False
-        fallback.assert_not_awaited()  # existing row is durable, no fallback
-    finally:
-        reset_ledger_tracking_state()
+    result = await _record_accepted(monkeypatch)
+    assert result["success"] is True
+    assert result["ledger_tracking_unavailable"] is False
+    # exactly one ledger write (the native insert) — no fallback/marker control row
+    assert save.await_count == 1
 
 
 @pytest.mark.asyncio
-async def test_record_native_error_writes_synthetic_fallback(monkeypatch):
-    """ROB-843 P1-2: a lost native write falls back to a durable evidence row;
-    tracking stays available and broker success is preserved."""
+async def test_record_native_error_signals_tracking_unavailable(monkeypatch):
+    """ROB-843 P1: a lost native write (and no conflict row) signals
+    ledger_tracking_unavailable so the caller KEEPS the write-ahead reservation
+    unresolved. Broker success is preserved and NO control row is written."""
     from app.mcp_server.tooling import kis_mock_ledger
     from app.services.brokers.kis.mock_scalping_exec.tracking_state import (
         LedgerWriteError,
-        reset_ledger_tracking_state,
     )
 
-    reset_ledger_tracking_state()
-    monkeypatch.setattr(
-        kis_mock_ledger,
-        "_save_kis_mock_order_ledger",
-        AsyncMock(side_effect=LedgerWriteError("db down")),
-    )
+    save = AsyncMock(side_effect=LedgerWriteError("db down"))
+    monkeypatch.setattr(kis_mock_ledger, "_save_kis_mock_order_ledger", save)
     monkeypatch.setattr(
         kis_mock_ledger, "_native_row_exists", AsyncMock(return_value=False)
     )
-    fallback = AsyncMock(return_value=99)
-    monkeypatch.setattr(kis_mock_ledger, "_persist_tracking_fallback", fallback)
-    try:
-        result = await _record_accepted(monkeypatch)
-        assert result["success"] is True  # broker accepted; bookkeeping recovered
-        assert result["ledger_tracking_unavailable"] is False
-        fallback.assert_awaited_once()
-    finally:
-        reset_ledger_tracking_state()
-
-
-@pytest.mark.asyncio
-async def test_record_all_evidence_lost_persists_durable_marker(monkeypatch):
-    """ROB-843 P1-2: native AND fallback both fail → a DURABLE degradation marker
-    is persisted (survives restart); broker success stays true."""
-    from app.mcp_server.tooling import kis_mock_ledger
-    from app.services.brokers.kis.mock_scalping_exec.tracking_state import (
-        LedgerWriteError,
-        reset_ledger_tracking_state,
-    )
-
-    reset_ledger_tracking_state()
-    monkeypatch.setattr(
-        kis_mock_ledger,
-        "_save_kis_mock_order_ledger",
-        AsyncMock(side_effect=LedgerWriteError("db down")),
-    )
-    monkeypatch.setattr(
-        kis_mock_ledger, "_native_row_exists", AsyncMock(return_value=False)
-    )
-    monkeypatch.setattr(
-        kis_mock_ledger, "_persist_tracking_fallback", AsyncMock(return_value=None)
-    )
-    marker = AsyncMock(return_value=123)  # durable marker persisted
-    monkeypatch.setattr(kis_mock_ledger, "_persist_tracking_degradation_marker", marker)
-    try:
-        result = await _record_accepted(monkeypatch)
-        assert result["success"] is True
-        assert result["ledger_tracking_unavailable"] is True
-        marker.assert_awaited_once()
-    finally:
-        reset_ledger_tracking_state()
-
-
-@pytest.mark.asyncio
-async def test_record_marker_lost_falls_back_to_process_latch(monkeypatch):
-    """ROB-843 P1-2: if even the durable marker cannot persist, the process-local
-    latch is set as a last resort so the next order still fail-closes."""
-    from app.mcp_server.tooling import kis_mock_ledger
-    from app.services.brokers.kis.mock_scalping_exec.tracking_state import (
-        LedgerWriteError,
-        is_ledger_tracking_unavailable,
-        reset_ledger_tracking_state,
-    )
-
-    reset_ledger_tracking_state()
-    monkeypatch.setattr(
-        kis_mock_ledger,
-        "_save_kis_mock_order_ledger",
-        AsyncMock(side_effect=LedgerWriteError("db down")),
-    )
-    monkeypatch.setattr(
-        kis_mock_ledger, "_native_row_exists", AsyncMock(return_value=False)
-    )
-    monkeypatch.setattr(
-        kis_mock_ledger, "_persist_tracking_fallback", AsyncMock(return_value=None)
-    )
-    monkeypatch.setattr(
-        kis_mock_ledger,
-        "_persist_tracking_degradation_marker",
-        AsyncMock(return_value=None),
-    )
-    try:
-        result = await _record_accepted(monkeypatch)
-        assert result["ledger_tracking_unavailable"] is True
-        assert is_ledger_tracking_unavailable() is True
-    finally:
-        reset_ledger_tracking_state()
+    result = await _record_accepted(monkeypatch)
+    assert result["success"] is True  # broker accepted (bookkeeping failed)
+    assert result["ledger_tracking_unavailable"] is True
+    # only the failed native insert was attempted — no control-row write follows
+    assert save.await_count == 1
 
 
 @pytest.mark.asyncio

--- a/tests/test_kis_mock_order_ledger.py
+++ b/tests/test_kis_mock_order_ledger.py
@@ -1019,6 +1019,151 @@ async def test_record_malformed_payload_returns_false(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_record_whitespace_order_id_is_not_accepted(monkeypatch):
+    """ROB-843 Blocker 2: a blank/whitespace odno is never an accepted order."""
+    from app.mcp_server.tooling import kis_mock_ledger
+
+    monkeypatch.setattr(
+        kis_mock_ledger, "_save_kis_mock_order_ledger", AsyncMock(return_value=5)
+    )
+    monkeypatch.setattr(
+        kis_mock_ledger, "publish_place_time_forecast", AsyncMock(return_value=None)
+    )
+    result = await kis_mock_ledger._record_kis_mock_order(
+        normalized_symbol="005930",
+        market_type="equity_kr",
+        side="buy",
+        order_type="limit",
+        dry_run_result=_mock_preview(),
+        execution_result={"rt_cd": "0", "odno": "   "},
+        reason="t",
+        thesis=None,
+        strategy=None,
+        notes=None,
+    )
+    assert result["success"] is False
+    assert result["status"] == "unknown"
+    assert result["reason"] == "missing_broker_order_id"
+    assert result["order_no"] is None
+
+
+@pytest.mark.asyncio
+async def test_record_strips_valid_order_id(monkeypatch):
+    """ROB-843 Blocker 2: a valid id with surrounding whitespace is normalized
+    (stripped) and stored/returned that way."""
+    from app.mcp_server.tooling import kis_mock_ledger
+
+    save = AsyncMock(return_value=5)
+    monkeypatch.setattr(kis_mock_ledger, "_save_kis_mock_order_ledger", save)
+    monkeypatch.setattr(
+        kis_mock_ledger, "publish_place_time_forecast", AsyncMock(return_value=None)
+    )
+    result = await kis_mock_ledger._record_kis_mock_order(
+        normalized_symbol="005930",
+        market_type="equity_kr",
+        side="buy",
+        order_type="limit",
+        dry_run_result=_mock_preview(),
+        execution_result={"rt_cd": "0", "odno": "  0001234567  "},
+        reason="t",
+        thesis=None,
+        strategy=None,
+        notes=None,
+    )
+    assert result["success"] is True
+    assert result["order_no"] == "0001234567"
+    assert result["odno"] == "0001234567"
+    assert save.await_args.kwargs["order_no"] == "0001234567"
+
+
+@pytest.mark.asyncio
+async def test_record_provider_failure_with_order_id_still_rejected(monkeypatch):
+    """ROB-843 Blocker 2: a valid order id does NOT rescue a provider failure."""
+    from app.mcp_server.tooling import kis_mock_ledger
+
+    monkeypatch.setattr(
+        kis_mock_ledger, "_save_kis_mock_order_ledger", AsyncMock(return_value=5)
+    )
+    monkeypatch.setattr(
+        kis_mock_ledger, "publish_place_time_forecast", AsyncMock(return_value=None)
+    )
+    result = await kis_mock_ledger._record_kis_mock_order(
+        normalized_symbol="005930",
+        market_type="equity_kr",
+        side="buy",
+        order_type="limit",
+        dry_run_result=_mock_preview(),
+        execution_result={"rt_cd": "40", "odno": "0001234567", "msg": "거부"},
+        reason="t",
+        thesis=None,
+        strategy=None,
+        notes=None,
+    )
+    assert result["success"] is False
+    assert result["status"] == "rejected"
+
+
+@pytest.mark.asyncio
+async def test_record_redacts_sensitive_evidence(monkeypatch):
+    """ROB-843 Blocker 3: sensitive keys are redacted (recursively, case-variant,
+    nested) from stored + returned evidence; original is not mutated; non-secret
+    diagnostics survive; no raw secret remains in the persisted payload."""
+    import copy
+    import json
+
+    from app.mcp_server.tooling import kis_mock_ledger
+
+    save = AsyncMock(return_value=5)
+    monkeypatch.setattr(kis_mock_ledger, "_save_kis_mock_order_ledger", save)
+    monkeypatch.setattr(
+        kis_mock_ledger, "publish_place_time_forecast", AsyncMock(return_value=None)
+    )
+    exec_result = {
+        "rt_cd": "0",
+        "odno": "0001234567",
+        "msg": "정상처리",
+        "AppKey": "SECRETKEY",
+        "approval_key": "APKEY-XYZ",
+        "headers": {"Authorization": "Bearer tok123", "Cookie": "sid=abc"},
+        "echoes": [{"api-key": "k1"}, {"safe": "keep-me"}],
+    }
+    original = copy.deepcopy(exec_result)
+    result = await kis_mock_ledger._record_kis_mock_order(
+        normalized_symbol="005930",
+        market_type="equity_kr",
+        side="buy",
+        order_type="limit",
+        dry_run_result=_mock_preview(),
+        execution_result=exec_result,
+        reason="t",
+        thesis=None,
+        strategy=None,
+        notes=None,
+    )
+    saved = save.await_args.kwargs["raw_response"]
+    assert saved["AppKey"] == "[REDACTED]"
+    assert saved["approval_key"] == "[REDACTED]"
+    assert saved["headers"]["Authorization"] == "[REDACTED]"
+    assert saved["headers"]["Cookie"] == "[REDACTED]"
+    assert saved["echoes"][0]["api-key"] == "[REDACTED]"
+    # non-sensitive diagnostics preserved
+    assert saved["echoes"][1]["safe"] == "keep-me"
+    assert saved["odno"] == "0001234567"
+    assert saved["rt_cd"] == "0"
+    assert saved["msg"] == "정상처리"
+    # returned execution is also redacted (no secret leaves the boundary)
+    assert result["execution"]["AppKey"] == "[REDACTED]"
+    # original object was not mutated
+    assert exec_result == original
+    # no raw secret string survives in the persisted payload
+    blob = json.dumps(saved, ensure_ascii=False)
+    assert "SECRETKEY" not in blob
+    assert "APKEY-XYZ" not in blob
+    assert "Bearer tok123" not in blob
+    assert "sid=abc" not in blob
+
+
+@pytest.mark.asyncio
 async def test_record_rejected_order_mints_but_does_not_publish(monkeypatch):
     """ROB-730: a rejected order still gets a correlation_id (spine), but no
     place-time forecast is emitted (mirrors live: publish only when accepted)."""

--- a/tests/test_kis_mock_order_ledger.py
+++ b/tests/test_kis_mock_order_ledger.py
@@ -828,6 +828,79 @@ async def test_record_preserves_explicit_correlation_id(monkeypatch):
     assert pub.await_args.kwargs["correlation_id"] == "scalp-pair-1"
 
 
+def _make_domestic_orders():
+    """DomesticOrderClient with a mocked parent (mirrors the retry-test harness)."""
+    from unittest.mock import MagicMock
+
+    from app.services.brokers.kis.domestic_orders import DomesticOrderClient
+
+    parent = MagicMock()
+    parent._hdr_base = {"content-type": "application/json"}
+    parent._ensure_token = AsyncMock()
+    parent._kis_url = lambda path: f"https://host{path}"
+    tok = MagicMock()
+    tok.clear_token = AsyncMock()
+    parent._token_manager = tok
+    settings = MagicMock()
+    settings.kis_account_no = "1234567890"
+    settings.kis_access_token = "test-token"
+    parent._settings = settings
+    return DomesticOrderClient(parent), parent
+
+
+@pytest.mark.asyncio
+async def test_record_accepts_real_domestic_order_shape(monkeypatch):
+    """ROB-843 Blocker 1: the accepted contract must survive the REAL domestic
+    order-service return shape (which the service builds after verifying
+    rt_cd==0), not a hand-fabricated rt_cd fixture. The service preserves the
+    provider-verified success metadata so the mock boundary can prove it."""
+    from unittest.mock import patch
+
+    from app.mcp_server.tooling import kis_mock_ledger
+
+    instance, parent = _make_domestic_orders()
+    # Realistic raw KIS accepted envelope (rt_cd at top level, ODNO in output).
+    parent._request_with_rate_limit = AsyncMock(
+        return_value={
+            "rt_cd": "0",
+            "msg_cd": "APBK0013",
+            "msg1": "주문 전송 완료 되었습니다.",
+            "output": {"ODNO": "0001234567", "ORD_TMD": "091500"},
+        }
+    )
+    with patch(
+        "app.services.brokers.kis.domestic_orders.is_nxt_eligible",
+        AsyncMock(return_value=False),
+    ):
+        exec_result = await instance.order_korea_stock("005930", "buy", 1, 70000)
+
+    # provider-verified success metadata is preserved to the boundary
+    assert exec_result["rt_cd"] == "0"
+    assert exec_result["odno"] == "0001234567"
+
+    monkeypatch.setattr(
+        kis_mock_ledger, "_save_kis_mock_order_ledger", AsyncMock(return_value=7)
+    )
+    monkeypatch.setattr(
+        kis_mock_ledger, "publish_place_time_forecast", AsyncMock(return_value=None)
+    )
+    result = await kis_mock_ledger._record_kis_mock_order(
+        normalized_symbol="005930",
+        market_type="equity_kr",
+        side="buy",
+        order_type="limit",
+        dry_run_result=_mock_preview(),
+        execution_result=exec_result,
+        reason="t",
+        thesis=None,
+        strategy=None,
+        notes=None,
+    )
+    assert result["success"] is True
+    assert result["status"] == "accepted"
+    assert result["order_no"] == "0001234567"
+
+
 @pytest.mark.asyncio
 async def test_record_accepted_returns_success_true(monkeypatch):
     """ROB-843: accepted requires provider success (rt_cd==0) AND broker order ID."""

--- a/tests/test_kis_mock_order_ledger.py
+++ b/tests/test_kis_mock_order_ledger.py
@@ -829,6 +829,123 @@ async def test_record_preserves_explicit_correlation_id(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_record_accepted_returns_success_true(monkeypatch):
+    """ROB-843: accepted requires provider success (rt_cd==0) AND broker order ID."""
+    from app.mcp_server.tooling import kis_mock_ledger
+
+    monkeypatch.setattr(
+        kis_mock_ledger, "_save_kis_mock_order_ledger", AsyncMock(return_value=5)
+    )
+    monkeypatch.setattr(
+        kis_mock_ledger, "publish_place_time_forecast", AsyncMock(return_value=None)
+    )
+    result = await kis_mock_ledger._record_kis_mock_order(
+        normalized_symbol="005930",
+        market_type="equity_kr",
+        side="buy",
+        order_type="limit",
+        dry_run_result=_mock_preview(),
+        execution_result=_mock_exec_result(rt_cd="0", odno="0001234567"),
+        reason="t",
+        thesis=None,
+        strategy=None,
+        notes=None,
+    )
+    assert result["success"] is True
+    assert result["status"] == "accepted"
+    assert result["order_no"] == "0001234567"
+
+
+@pytest.mark.asyncio
+async def test_record_rejected_returns_success_false(monkeypatch):
+    """ROB-843: a provider rejection (rt_cd != 0) is never a success."""
+    from app.mcp_server.tooling import kis_mock_ledger
+
+    save = AsyncMock(return_value=5)
+    monkeypatch.setattr(kis_mock_ledger, "_save_kis_mock_order_ledger", save)
+    monkeypatch.setattr(
+        kis_mock_ledger, "publish_place_time_forecast", AsyncMock(return_value=None)
+    )
+    exec_result = {"odno": "", "ord_tmd": None, "msg": "거부", "rt_cd": "40"}
+    result = await kis_mock_ledger._record_kis_mock_order(
+        normalized_symbol="005930",
+        market_type="equity_kr",
+        side="buy",
+        order_type="limit",
+        dry_run_result=_mock_preview(),
+        execution_result=exec_result,
+        reason="t",
+        thesis=None,
+        strategy=None,
+        notes=None,
+    )
+    assert result["success"] is False
+    assert result["status"] == "rejected"
+    assert result["reason"] == "broker_rejected"
+    # native lifecycle truth + raw evidence preserved
+    assert save.await_args.kwargs["status"] == "rejected"
+    assert result["execution"] == exec_result
+    assert result["response_message"] == "거부"
+
+
+@pytest.mark.asyncio
+async def test_record_idless_success_code_returns_unknown_false(monkeypatch):
+    """ROB-843: rt_cd==0 but no broker order ID is unknown, not success."""
+    from app.mcp_server.tooling import kis_mock_ledger
+
+    save = AsyncMock(return_value=5)
+    monkeypatch.setattr(kis_mock_ledger, "_save_kis_mock_order_ledger", save)
+    pub = AsyncMock(return_value=None)
+    monkeypatch.setattr(kis_mock_ledger, "publish_place_time_forecast", pub)
+    result = await kis_mock_ledger._record_kis_mock_order(
+        normalized_symbol="005930",
+        market_type="equity_kr",
+        side="buy",
+        order_type="limit",
+        dry_run_result=_mock_preview(),
+        execution_result={"rt_cd": "0", "odno": ""},
+        reason="t",
+        thesis=None,
+        strategy=None,
+        notes=None,
+        target_price=80000.0,
+    )
+    assert result["success"] is False
+    assert result["status"] == "unknown"
+    assert result["reason"] == "missing_broker_order_id"
+    assert result["order_no"] is None
+    pub.assert_not_awaited()  # no forecast for a non-accepted order
+
+
+@pytest.mark.asyncio
+async def test_record_malformed_payload_returns_false(monkeypatch):
+    """ROB-843: a non-mapping broker response is malformed, never success."""
+    from app.mcp_server.tooling import kis_mock_ledger
+
+    save = AsyncMock(return_value=5)
+    monkeypatch.setattr(kis_mock_ledger, "_save_kis_mock_order_ledger", save)
+    monkeypatch.setattr(
+        kis_mock_ledger, "publish_place_time_forecast", AsyncMock(return_value=None)
+    )
+    result = await kis_mock_ledger._record_kis_mock_order(
+        normalized_symbol="005930",
+        market_type="equity_kr",
+        side="buy",
+        order_type="limit",
+        dry_run_result=_mock_preview(),
+        execution_result="totally not a dict",  # type: ignore[arg-type]
+        reason="t",
+        thesis=None,
+        strategy=None,
+        notes=None,
+    )
+    assert result["success"] is False
+    assert result["status"] == "unknown"
+    assert result["reason"] == "malformed_response"
+    assert save.await_args.kwargs["status"] == "unknown"
+
+
+@pytest.mark.asyncio
 async def test_record_rejected_order_mints_but_does_not_publish(monkeypatch):
     """ROB-730: a rejected order still gets a correlation_id (spine), but no
     place-time forecast is emitted (mirrors live: publish only when accepted)."""

--- a/tests/test_watch_auto_execute.py
+++ b/tests/test_watch_auto_execute.py
@@ -203,6 +203,34 @@ async def test_failed_broker_result_persists_failed_outcome(db_session, monkeypa
 
 
 @pytest.mark.asyncio
+async def test_place_order_exception_persists_failed(db_session, monkeypatch):
+    """ROB-843 Blocker 4: a raised exception is a failure too — the intent must
+    become 'failed' (not left 'previewed') with reason/detail preserved."""
+    monkeypatch.setattr(
+        watch_auto_execute.settings, "WATCH_AUTO_EXECUTE_MOCK_ENABLED", True
+    )
+
+    async def _raise(**kwargs):
+        raise RuntimeError("broker POST blew up")
+
+    alert = _alert(_good_max_action())
+    cid = f"corr-{uuid.uuid4().hex}"
+    outcome = await watch_auto_execute.maybe_auto_execute(
+        db_session,
+        alert=alert,
+        correlation_id=cid,
+        kst_date="2026-06-01",
+        place_order_fn=_raise,
+    )
+    assert outcome["executed"] is False
+    assert outcome["reason"] == "order_exception"
+    assert "broker POST blew up" in (outcome["detail"] or "")
+    row = await _intent_for(db_session, cid)
+    assert row.lifecycle_state == "failed"
+    assert row.blocked_by == "order_exception"
+
+
+@pytest.mark.asyncio
 async def test_malformed_broker_result_persists_failed(db_session, monkeypatch):
     """ROB-843: a non-dict broker result is a failure, never executed=True."""
     monkeypatch.setattr(

--- a/tests/test_watch_auto_execute.py
+++ b/tests/test_watch_auto_execute.py
@@ -164,6 +164,70 @@ async def test_live_account_blocked_no_order(db_session, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_failed_broker_result_persists_failed_outcome(db_session, monkeypatch):
+    """ROB-843: a failed broker result must not be recorded as executed=True.
+    The intent row flips to 'failed' with the reason/detail preserved."""
+    monkeypatch.setattr(
+        watch_auto_execute.settings, "WATCH_AUTO_EXECUTE_MOCK_ENABLED", True
+    )
+    calls = []
+
+    async def _reject(**kwargs):
+        calls.append(kwargs)
+        return {
+            "success": False,
+            "status": "rejected",
+            "reason": "broker_rejected",
+            "detail": "거부",
+            "response_message": "거부",
+        }
+
+    alert = _alert(_good_max_action())
+    cid = f"corr-{uuid.uuid4().hex}"
+    outcome = await watch_auto_execute.maybe_auto_execute(
+        db_session,
+        alert=alert,
+        correlation_id=cid,
+        kst_date="2026-06-01",
+        place_order_fn=_reject,
+    )
+    assert outcome["executed"] is False
+    assert outcome["reason"] == "broker_rejected"
+    assert outcome["detail"] == "거부"
+    assert len(calls) == 1  # order WAS attempted
+    row = await _intent_for(db_session, cid)
+    assert row.lifecycle_state == "failed"
+    assert row.execution_allowed is False
+    assert row.blocked_by == "broker_rejected"
+    assert "broker_rejected" in (row.blocking_reasons or [])
+
+
+@pytest.mark.asyncio
+async def test_malformed_broker_result_persists_failed(db_session, monkeypatch):
+    """ROB-843: a non-dict broker result is a failure, never executed=True."""
+    monkeypatch.setattr(
+        watch_auto_execute.settings, "WATCH_AUTO_EXECUTE_MOCK_ENABLED", True
+    )
+
+    async def _weird(**kwargs):
+        return None
+
+    alert = _alert(_good_max_action())
+    cid = f"corr-{uuid.uuid4().hex}"
+    outcome = await watch_auto_execute.maybe_auto_execute(
+        db_session,
+        alert=alert,
+        correlation_id=cid,
+        kst_date="2026-06-01",
+        place_order_fn=_weird,
+    )
+    assert outcome["executed"] is False
+    assert outcome["reason"] == "malformed_result"
+    row = await _intent_for(db_session, cid)
+    assert row.lifecycle_state == "failed"
+
+
+@pytest.mark.asyncio
 async def test_missing_limit_price_blocks(db_session, monkeypatch):
     monkeypatch.setattr(
         watch_auto_execute.settings, "WATCH_AUTO_EXECUTE_MOCK_ENABLED", True


### PR DESCRIPTION
## ROB-843 — [P0][paper safety] KIS Mock executor risk re-check + false-success 기록 수정

KIS mock 자동 매매 경로의 paper-safety 결함을 복구. 여러 라운드의 독립 재검토를 거쳐 수렴. **migration 0, KIS live 정책 불변, mock automated mutation default-off, ROB-853 공통 boundary/idempotency 미흡수.**

### 핵심 변경
- **WS `MockScalpingExecutor` executor-owned final risk re-check** — submit 직전 fresh ledger/position(holdings)+market snapshot 재로드 후 `evaluate_risk()`. 5개 risk denial·snapshot 실패·crossed/NaN/stale quote 전부 broker 호출 0회 fail-close.
- **native KIS mock result 정규화** — accepted = mapping + provider success(`rt_cd==0`, order service가 검증한 metadata 보존) + **정규화된 non-empty broker order ID**. rejected/malformed/unknown/id-less/whitespace-id는 `success=False`+stable reason, raw evidence는 recursive redaction 후 보존.
- **watch false-success 수정** — `maybe_auto_execute`가 order 결과(예외 포함)를 검증·보존, 실패 시 intent를 `failed`로 기록하고 `executed=False`.
- **cooldown anchor** = position-closing SELL의 `reconciled_at`(legacy null fail-close). **daily count** = 실제 broker 제출 1건당 1회(native id + orphaned synthetic dedupe, control row 제외). **anomaly leg/side**(entry_unfilled=BUY / exit_unconfirmed=SELL).
- **freshness 재검증을 실제 KIS HTTP send 경계로 이동** — mock-only `pre_send_hook`을 domestic/overseas service→transport dispatch 루프의 매 `_execute_http_request` 직전(모든 retry·token-refresh 재전송 포함)에 발화. live는 hook 미전달로 동작 동일.
- **restart-safe durability = write-ahead reservation** — `review.order_send_intents`(scope=`kis_mock_scalping`)에 broker POST **이전** reserve(실패/중복 시 POST 0). 미해소 reservation이 재시작/새 session/새 gate에서 fail-close, 명시적 reconciliation만 해제. control row는 order ledger 밖으로 이동하고 공통 `real_order_filter()`로 count/retrospective/journal bridge에서 격리.

### 검증 (로컬)
- ROB-843 mock/order/journal 영역 464 passed + KIS live/transport 151 passed
- `ruff check` / `ruff format --check` / `ty check` / `git diff --check` clean
- migration 0

Linear: ROB-843

🤖 Generated with [Claude Code](https://claude.com/claude-code)