### PR TITLE
feat(ROB-842): unify Alpaca Paper submit behind approval-packet + ledger atomic-claim boundary

### DIFF
--- a/.claude/settings.readonly.json
+++ b/.claude/settings.readonly.json
@@ -21,6 +21,7 @@
       "mcp__auto_trader_local__toss_cancel_order",
       "mcp__auto_trader_local__toss_reconcile_orders",
       "mcp__auto_trader_local__alpaca_paper_submit_order",
+      "mcp__auto_trader_local__alpaca_paper_automated_submit_order",
       "mcp__auto_trader_local__alpaca_paper_cancel_order",
       "mcp__auto_trader_local__kiwoom_mock_place_order",
       "mcp__auto_trader_local__kiwoom_mock_cancel_order",

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -803,6 +803,10 @@ class Settings(BaseSettings):
     # ROB-326 — US dual-paper premarket preview/preflight path (read-only, default off)
     us_dual_paper_preview_enabled: bool = False
 
+    # ROB-842 — automated Alpaca paper submit boundary (preview→claim→POST). The
+    # automated cohort broker mutation is fail-closed unless this gate is armed.
+    alpaca_paper_automated_submit_enabled: bool = False
+
     @field_validator("alpaca_paper_base_url", mode="before")
     @classmethod
     def validate_alpaca_paper_base_url(cls, v: Any) -> str:

--- a/app/mcp_server/README.md
+++ b/app/mcp_server/README.md
@@ -433,19 +433,33 @@ replay**. There is no direct-POST fallback, and this holds for `us-paper` only.
   `alpaca_paper_automated_submit_order` are the **automated cohort** tools —
   registered only under `MCP_PROFILE=us-paper` and **default-off** behind
   `ALPACA_PAPER_AUTOMATED_SUBMIT_ENABLED` (fail-closed when unset).
+- **Server-observed market evidence for every submit.** Both tools require an
+  opaque, server-issued `quote_snapshot_id` (a trusted `market_quote_snapshots`
+  row) at `confirm=True` — there is no origin-based bypass of market/freshness
+  checks. The caller never supplies correlation, snapshot, market-data as-of/
+  source, ceiling, `origin`, or `client_order_id`: the server loads identity,
+  market provenance and the trusted reference price from that row, and the ceiling
+  is the server **hard-cap** policy ($1,000 equity / $50 crypto). A market/qty
+  order's implied notional (trusted price × qty) is bounded by the same cap. A
+  missing / stale / symbol-mismatched / non-finite-priced snapshot fails closed
+  before any packet is built. Packet + policy hashes are recorded in the ledger
+  preview evidence.
+- **Replay before freshness.** Immutable token/key/hash/account binding is checked
+  first; a completed or terminally-failed order then replays its original result
+  even after the packet's freshness window has elapsed. Freshness / market-data /
+  live-position checks apply only to a not-yet-claimed new submit.
 - **Exactly once.** Duplicate intents (sequential or concurrent) produce exactly
   one broker HTTP submit; every other caller replays the winner's result.
-- **Server-owned identity/provenance/ceiling.** The caller never supplies
-  correlation, snapshot, market-data as-of/source, ceiling, `origin`, or
-  `client_order_id`. The idempotency key is server-derived; automated preview
-  loads identity + market provenance from a trusted `market_quote_snapshots` row
-  (opaque `quote_snapshot_id`) and takes the ceiling from hard-cap policy —
-  applying the more conservative of policy and any recommendation. A missing /
-  stale / symbol-mismatched snapshot fails closed before any packet is built. The
-  packet + policy hashes are recorded in the ledger preview evidence.
-- **Live sell eligibility.** A sell is verified against the **current** Alpaca
-  paper position re-read right before the POST (past fills are provenance only);
-  qty must be within both the live position and the ceiling, else fail-closed.
+- **Live sell eligibility + no oversell.** A sell is verified against the
+  **current** Alpaca paper position re-read right before the POST (past fills are
+  provenance only). Availability and the atomic claim are computed under an
+  account+symbol advisory lock, subtracting already-reserved open sells, so two
+  *different* sell intents cannot both consume the same shares. Automated sell is
+  **explicitly disabled** (reason `automated_sell_disabled`) until ROB-845 wires an
+  opaque buy/position source; manual sell is supported.
+- **Public success contract.** `success` is true only for
+  `submitted` / `replayed` / `recovered`; `failed`, `rejected` and
+  `idempotency_in_progress` are `success=false`.
 - **Deterministic failure vs uncertainty.** An HTTP 4xx/422 rejection is booked
   as a terminal outcome and replayed on retry (no re-POST). A 5xx/timeout/
   crash-after-send is reconciled via `get_order_by_client_order_id` — recovered

--- a/app/mcp_server/README.md
+++ b/app/mcp_server/README.md
@@ -451,12 +451,17 @@ replay**. There is no direct-POST fallback, and this holds for `us-paper` only.
 - **Exactly once.** Duplicate intents (sequential or concurrent) produce exactly
   one broker HTTP submit; every other caller replays the winner's result.
 - **Live sell eligibility + no oversell.** A sell is verified against the
-  **current** Alpaca paper position re-read right before the POST (past fills are
-  provenance only). Availability and the atomic claim are computed under an
-  account+symbol advisory lock, subtracting already-reserved open sells, so two
-  *different* sell intents cannot both consume the same shares. Automated sell is
-  **explicitly disabled** (reason `automated_sell_disabled`) until ROB-845 wires an
-  opaque buy/position source; manual sell is supported.
+  **current** Alpaca paper position re-read right before the POST, with
+  `qty_available` required as a broker-owned upper bound. Position evidence,
+  lifecycle reconciliation, local reservations, and the atomic claim are bound
+  under one account+symbol advisory lock. Every sell claim stores its `qty` /
+  `qty_available` baseline in the existing `position_snapshot` JSONB; a later
+  `filled` status releases the hold only after the position response proves the
+  fill is reflected. Unknown statuses and ambiguous/stale position evidence remain
+  reserved and return `position_reconciliation_pending`, so two *different* sell
+  intents cannot consume the same shares. Automated sell is **explicitly disabled**
+  (reason `automated_sell_disabled`) until ROB-845 wires an opaque buy/position
+  source; manual sell is supported.
 - **Public success contract.** `success` is true only for
   `submitted` / `replayed` / `recovered`; `failed`, `rejected` and
   `idempotency_in_progress` are `success=false`.

--- a/app/mcp_server/README.md
+++ b/app/mcp_server/README.md
@@ -456,10 +456,13 @@ replay**. There is no direct-POST fallback, and this holds for `us-paper` only.
   lifecycle reconciliation, local reservations, and the atomic claim are bound
   under one account+symbol advisory lock. Every sell claim stores its `qty` /
   `qty_available` baseline in the existing `position_snapshot` JSONB; a later
-  `filled` status releases the hold only after the position response proves the
-  fill is reflected. Unknown statuses and ambiguous/stale position evidence remain
-  reserved and return `position_reconciliation_pending`, so two *different* sell
-  intents cannot consume the same shares. Automated sell is **explicitly disabled**
+  immediate or crash-recovered open/partial, `filled`, and unknown/unparseable
+  statuses retain `submitted`; a `filled` status releases the hold only after the
+  position response proves the fill is reflected. Unknown statuses retain their
+  reservation, and ambiguous/stale fill evidence returns
+  `position_reconciliation_pending`, so two *different* sell intents cannot consume
+  the same shares. Cancel read-back syncs known broker truth while retaining the
+  hold for open/partial/filled. Automated sell is **explicitly disabled**
   (reason `automated_sell_disabled`) until ROB-845 wires an opaque buy/position
   source; manual sell is supported.
 - **Public success contract.** `success` is true only for

--- a/app/mcp_server/README.md
+++ b/app/mcp_server/README.md
@@ -421,6 +421,38 @@ estimated cost.
 There is still no Alpaca paper `place_order`, `replace_order`, `modify_order`,
 `cancel_all`, close-position/liquidate, or generic Alpaca order-routing surface.
 
+#### Unified submit boundary (ROB-842)
+
+Every real Alpaca Paper broker POST — manual and automated — passes through a
+single server-side boundary: **server-owned approval packet → existing
+`review.alpaca_paper_order_ledger` atomic claim → broker POST → stored-result
+replay**. There is no direct-POST fallback, and this holds for `us-paper` only.
+
+- **Roles.** `alpaca_paper_submit_order` is the **manual operator** tool
+  (confirm-gated $10-scale smoke). `alpaca_paper_automated_preview_order` +
+  `alpaca_paper_automated_submit_order` are the **automated cohort** tools —
+  registered only under `MCP_PROFILE=us-paper` and **default-off** behind
+  `ALPACA_PAPER_AUTOMATED_SUBMIT_ENABLED` (fail-closed when unset).
+- **Exactly once.** Duplicate intents (sequential or concurrent) produce exactly
+  one broker HTTP submit; every other caller replays the winner's result.
+- **Server-owned identity/provenance/ceiling.** The caller never supplies
+  correlation, snapshot, market-data as-of/source, ceiling, `origin`, or
+  `client_order_id`. The idempotency key is server-derived; automated preview
+  loads identity + market provenance from a trusted `market_quote_snapshots` row
+  (opaque `quote_snapshot_id`) and takes the ceiling from hard-cap policy —
+  applying the more conservative of policy and any recommendation. A missing /
+  stale / symbol-mismatched snapshot fails closed before any packet is built. The
+  packet + policy hashes are recorded in the ledger preview evidence.
+- **Live sell eligibility.** A sell is verified against the **current** Alpaca
+  paper position re-read right before the POST (past fills are provenance only);
+  qty must be within both the live position and the ceiling, else fail-closed.
+- **Deterministic failure vs uncertainty.** An HTTP 4xx/422 rejection is booked
+  as a terminal outcome and replayed on retry (no re-POST). A 5xx/timeout/
+  crash-after-send is reconciled via `get_order_by_client_order_id` — recovered
+  if the order exists, otherwise left in-flight — never re-POSTed.
+- **Paper only.** The only broker built is `AlpacaPaperBrokerService`
+  (paper-host-pinned); no live endpoint or live-credential path is imported.
+
 Read-only operator runbook: [`docs/runbooks/alpaca-paper-readonly-smoke.md`](../../docs/runbooks/alpaca-paper-readonly-smoke.md)
 Read-only smoke helper: `scripts/smoke/alpaca_paper_readonly_smoke.py` (argumentless, read-only, exits non-zero on failure)
 Dev submit/cancel smoke runbook: [`docs/runbooks/alpaca-paper-dev-smoke.md`](../../docs/runbooks/alpaca-paper-dev-smoke.md)

--- a/app/mcp_server/tooling/alpaca_paper_automated_orders.py
+++ b/app/mcp_server/tooling/alpaca_paper_automated_orders.py
@@ -1,0 +1,401 @@
+"""Automated Alpaca PAPER submit boundary MCP tools (ROB-842).
+
+Two-step, server-owned handshake that is the ONLY automated broker path:
+
+  alpaca_paper_automated_preview_order
+      Server validates the order, builds and *persists* the approval packet
+      (server-owned decision identity + preview hash + market-data as-of) as a
+      preview row in the existing Alpaca paper ledger, and returns an
+      ``approval_token``. No broker call.
+
+  alpaca_paper_automated_submit_order
+      Loads the server-persisted packet by ``approval_token`` (the caller never
+      supplies a canonical payload or client_order_id), then routes through the
+      ledger atomic-claim coordinator: exactly one broker POST for the winner;
+      replay / recovered / idempotency_in_progress for everyone else.
+
+Trust boundary:
+- The idempotency key is derived server-side from correlation_id + snapshot_id +
+  canonical; the caller cannot inject or overwrite it.
+- There is NO caller-selectable ``origin`` — this module *is* the automated
+  entrypoint, physically separate from the manual operator smoke tool.
+- Default-disabled behind ``settings.alpaca_paper_automated_submit_enabled``.
+- Paper-host pin preserved (the only broker built is AlpacaPaperBrokerService);
+  no live endpoint / live credential path is imported.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Callable
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+from typing import TYPE_CHECKING, Any
+
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from app.core.db import AsyncSessionLocal
+from app.mcp_server.tooling.alpaca_paper_preview import PreviewOrderInput
+from app.models.trading import InstrumentType
+from app.services.alpaca_paper_ledger_service import AlpacaPaperLedgerService
+from app.services.alpaca_paper_submit_service import (
+    AlpacaPaperSubmitCoordinator,
+    SubmitOutcome,
+    build_canonical_payload,
+    canonical_hash,
+    derive_automated_key,
+)
+from app.services.brokers.alpaca.service import AlpacaPaperBrokerService
+from app.services.paper_approval_packet import (
+    PaperApprovalPacket,
+    PaperApprovalPacketError,
+    verify_order_within_packet,
+    verify_packet_freshness,
+    verify_packet_market_data,
+)
+
+if TYPE_CHECKING:
+    from fastmcp import FastMCP
+
+ALPACA_PAPER_AUTOMATED_TOOL_NAMES: set[str] = {
+    "alpaca_paper_automated_preview_order",
+    "alpaca_paper_automated_submit_order",
+}
+
+DEFAULT_PREVIEW_TTL_SECONDS = 300
+_QUOTE_MAX_AGE = timedelta(minutes=5)
+
+SessionFactory = Callable[[], async_sessionmaker[AsyncSession]]
+BrokerFactory = Callable[[], AlpacaPaperBrokerService]
+
+
+def _default_session_factory() -> async_sessionmaker[AsyncSession]:
+    return AsyncSessionLocal  # type: ignore[return-value]
+
+
+def _default_broker_factory() -> AlpacaPaperBrokerService:
+    return AlpacaPaperBrokerService()
+
+
+_session_factory: SessionFactory = _default_session_factory
+_broker_factory: BrokerFactory = _default_broker_factory
+
+
+def set_alpaca_paper_automated_factories(
+    *,
+    session_factory: SessionFactory | None = None,
+    broker_factory: BrokerFactory | None = None,
+) -> None:
+    global _session_factory, _broker_factory
+    if session_factory is not None:
+        _session_factory = session_factory
+    if broker_factory is not None:
+        _broker_factory = broker_factory
+
+
+def reset_alpaca_paper_automated_factories() -> None:
+    global _session_factory, _broker_factory
+    _session_factory = _default_session_factory
+    _broker_factory = _default_broker_factory
+
+
+def _enabled() -> bool:
+    from app.core.config import settings
+
+    return bool(getattr(settings, "alpaca_paper_automated_submit_enabled", False))
+
+
+def _disabled_result(tool: str) -> dict[str, Any]:
+    return {
+        "success": False,
+        "account_mode": "alpaca_paper",
+        "source": "alpaca_paper",
+        "submitted": False,
+        "disabled": True,
+        "reason_code": "automated_submit_disabled",
+        "message": (
+            f"{tool} is disabled; set alpaca_paper_automated_submit_enabled=true to arm"
+        ),
+    }
+
+
+def _instrument_type_for(asset_class: str) -> InstrumentType:
+    return (
+        InstrumentType.crypto if asset_class == "crypto" else InstrumentType.equity_us
+    )
+
+
+def _parse_asof(value: str | datetime | None) -> datetime | None:
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value
+    text = str(value).strip()
+    if not text:
+        return None
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    return datetime.fromisoformat(text)
+
+
+def _rejected(coid: str | None, code: str, message: str) -> dict[str, Any]:
+    return {
+        "success": False,
+        "account_mode": "alpaca_paper",
+        "source": "alpaca_paper",
+        "submitted": False,
+        "status": "rejected",
+        "reason_code": code,
+        "client_order_id": coid,
+        "message": message,
+    }
+
+
+async def alpaca_paper_automated_preview_order(
+    symbol: str,
+    side: str,
+    type: str,  # noqa: A002
+    correlation_id: str,
+    snapshot_id: str,
+    market_data_asof: str,
+    market_data_source: str,
+    qty: Decimal | None = None,
+    notional: Decimal | None = None,
+    time_in_force: str | None = None,
+    limit_price: Decimal | None = None,
+    asset_class: str = "us_equity",
+    max_notional: Decimal | None = None,
+    max_qty: Decimal | None = None,
+    qty_source: str = "notional_estimate",
+    signal_symbol: str | None = None,
+    signal_venue: str = "upbit",
+    valid_for_seconds: int = DEFAULT_PREVIEW_TTL_SECONDS,
+) -> dict[str, Any]:
+    """Build and persist the server-owned approval packet for an automated submit.
+
+    Returns an ``approval_token`` bound to the persisted packet. No broker call.
+    """
+    if not _enabled():
+        return _disabled_result("alpaca_paper_automated_preview_order")
+
+    if not (correlation_id or "").strip() or not (snapshot_id or "").strip():
+        raise ValueError(
+            "correlation_id and snapshot_id are required (server identity)"
+        )
+
+    validated = PreviewOrderInput(
+        symbol=symbol,
+        side=side,
+        type=type,
+        qty=qty,
+        notional=notional,
+        time_in_force=time_in_force,
+        limit_price=limit_price,
+        stop_price=None,
+        client_order_id=None,
+        asset_class=asset_class,
+    )
+
+    if (max_notional is None) == (max_qty is None):
+        raise ValueError(
+            "exactly one approved ceiling is required: max_notional or max_qty"
+        )
+
+    canonical = build_canonical_payload(
+        symbol=validated.symbol,
+        side=validated.side,
+        type=validated.type,
+        time_in_force=validated.time_in_force,
+        qty=validated.qty,
+        notional=validated.notional,
+        limit_price=validated.limit_price,
+        asset_class=validated.asset_class,
+    )
+    coid = derive_automated_key(
+        correlation_id=correlation_id, snapshot_id=snapshot_id, canonical=canonical
+    )
+
+    now = datetime.now(UTC)
+    try:
+        asof = _parse_asof(market_data_asof)
+    except ValueError:
+        return _rejected(
+            coid, "invalid_source_timestamp", "market_data_asof is not ISO-8601"
+        )
+
+    try:
+        packet = PaperApprovalPacket(
+            signal_source="automated_preview",
+            artifact_id=uuid.uuid4(),
+            signal_symbol=signal_symbol or validated.symbol,
+            signal_venue=signal_venue,
+            execution_symbol=validated.symbol,
+            execution_venue="alpaca_paper",
+            execution_asset_class=validated.asset_class,
+            side=validated.side,
+            max_notional=max_notional,
+            max_qty=max_qty,
+            qty_source=qty_source,
+            expected_lifecycle_step="previewed",
+            lifecycle_correlation_id=correlation_id,
+            client_order_id=coid,
+            expires_at=now + timedelta(seconds=max(1, int(valid_for_seconds))),
+            account_mode="alpaca_paper",
+            origin="automated",
+            market_data_asof=asof,
+            market_data_source=market_data_source,
+            preview_payload_hash=canonical_hash(canonical),
+            snapshot_id=snapshot_id,
+            execution_order_type=validated.type,
+            execution_time_in_force=validated.time_in_force,
+        )
+    except ValueError as exc:
+        return _rejected(coid, "invalid_packet", str(exc))
+
+    # Fail-close the market-data + order-authority checks at preview time.
+    try:
+        verify_packet_market_data(packet, now=now, max_age=_QUOTE_MAX_AGE)
+        verify_order_within_packet(packet, canonical)
+    except PaperApprovalPacketError as exc:
+        return _rejected(coid, exc.code, str(exc))
+
+    async with _session_factory()() as db:
+        ledger = AlpacaPaperLedgerService(db)
+        await ledger.record_preview(
+            client_order_id=coid,
+            lifecycle_correlation_id=correlation_id,
+            execution_symbol=validated.symbol,
+            execution_venue="alpaca_paper",
+            instrument_type=_instrument_type_for(validated.asset_class),
+            side=validated.side,
+            order_type=validated.type,
+            time_in_force=validated.time_in_force,
+            requested_qty=validated.qty,
+            requested_notional=validated.notional,
+            requested_price=validated.limit_price,
+            preview_payload={
+                "canonical": canonical,
+                "approval_packet": packet.model_dump(mode="json"),
+            },
+        )
+
+    return {
+        "success": True,
+        "account_mode": "alpaca_paper",
+        "source": "alpaca_paper",
+        "submitted": False,
+        "preview": True,
+        "approval_token": coid,
+        "client_order_id": coid,
+        "expires_at": packet.expires_at.isoformat(),
+        "order_request": canonical,
+    }
+
+
+async def alpaca_paper_automated_submit_order(
+    approval_token: str,
+    confirm: bool = False,
+) -> dict[str, Any]:
+    """Submit an automated Alpaca paper order bound to a server-persisted preview.
+
+    The caller passes only the ``approval_token`` from preview; the server loads
+    its own packet and routes through the atomic-claim coordinator. Defaults to
+    ``confirm=False`` (no claim, no broker call).
+    """
+    if not _enabled():
+        return _disabled_result("alpaca_paper_automated_submit_order")
+
+    token = (approval_token or "").strip()
+    if not token:
+        raise ValueError("approval_token is required")
+
+    async with _session_factory()() as db:
+        ledger = AlpacaPaperLedgerService(db)
+        preview = await ledger.get_preview_by_client_order_id(token)
+        if preview is None:
+            return _rejected(
+                token, "no_preview_for_token", "no persisted preview for approval_token"
+            )
+
+        payload = preview.preview_payload or {}
+        canonical = payload.get("canonical")
+        packet_dict = payload.get("approval_packet")
+        if not isinstance(canonical, dict) or not isinstance(packet_dict, dict):
+            return _rejected(token, "malformed_preview", "preview payload is malformed")
+
+        try:
+            packet = PaperApprovalPacket(**packet_dict)
+        except ValueError as exc:
+            return _rejected(token, "malformed_preview", str(exc))
+
+        if confirm is not True:
+            # Re-validate freshness so a stale dry-run reports honestly.
+            reason = None
+            now = datetime.now(UTC)
+            try:
+                verify_packet_freshness(packet, now=now)
+                verify_packet_market_data(packet, now=now, max_age=_QUOTE_MAX_AGE)
+            except PaperApprovalPacketError as exc:
+                reason = exc.code
+            return {
+                "success": True,
+                "account_mode": "alpaca_paper",
+                "source": "alpaca_paper",
+                "submitted": False,
+                "blocked_reason": "confirmation_required",
+                "client_order_id": token,
+                "would_reject_reason": reason,
+                "order_request": canonical,
+            }
+
+        coordinator = AlpacaPaperSubmitCoordinator(ledger, _broker_factory)
+        outcome = await coordinator.submit(packet, submit_canonical=canonical)
+        return _outcome_to_result(outcome)
+
+
+def _outcome_to_result(outcome: SubmitOutcome) -> dict[str, Any]:
+    return {
+        "success": outcome.status != "rejected",
+        "account_mode": "alpaca_paper",
+        "source": "alpaca_paper",
+        "submitted": outcome.submitted,
+        "status": outcome.status,
+        "reason_code": outcome.reason_code,
+        "client_order_id": outcome.client_order_id,
+        "broker_called": outcome.broker_called,
+        "order": outcome.order,
+        "message": outcome.message,
+    }
+
+
+def register_alpaca_paper_automated_orders_tools(mcp: FastMCP) -> None:
+    _ = mcp.tool(
+        name="alpaca_paper_automated_preview_order",
+        description=(
+            "Automated Alpaca PAPER preview: server builds and persists the approval "
+            "packet (server-owned decision identity + preview hash + market-data "
+            "as-of) and returns an approval_token. No broker call. Requires "
+            "correlation_id, snapshot_id, market_data_asof, market_data_source, and "
+            "exactly one approved ceiling (max_notional or max_qty)."
+        ),
+    )(alpaca_paper_automated_preview_order)
+    _ = mcp.tool(
+        name="alpaca_paper_automated_submit_order",
+        description=(
+            "Automated Alpaca PAPER submit: bind to a server-persisted preview by "
+            "approval_token and route through the ledger atomic-claim boundary. "
+            "Exactly one broker POST for the winner; replay / recovered / "
+            "idempotency_in_progress otherwise. Defaults to confirm=False (no claim, "
+            "no broker call). The caller cannot supply a client_order_id or canonical."
+        ),
+    )(alpaca_paper_automated_submit_order)
+
+
+__all__ = [
+    "ALPACA_PAPER_AUTOMATED_TOOL_NAMES",
+    "alpaca_paper_automated_preview_order",
+    "alpaca_paper_automated_submit_order",
+    "register_alpaca_paper_automated_orders_tools",
+    "reset_alpaca_paper_automated_factories",
+    "set_alpaca_paper_automated_factories",
+]

--- a/app/mcp_server/tooling/alpaca_paper_automated_orders.py
+++ b/app/mcp_server/tooling/alpaca_paper_automated_orders.py
@@ -26,16 +26,22 @@ Trust boundary:
 
 from __future__ import annotations
 
+import hashlib
 import uuid
 from collections.abc import Callable
 from datetime import UTC, datetime, timedelta
 from decimal import Decimal
 from typing import TYPE_CHECKING, Any
 
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from app.core.db import AsyncSessionLocal
-from app.mcp_server.tooling.alpaca_paper_preview import PreviewOrderInput
+from app.mcp_server.tooling.alpaca_paper_preview import (
+    ALPACA_PAPER_CRYPTO_MAX_NOTIONAL_USD,
+    PreviewOrderInput,
+)
+from app.models.market_quote_snapshot import MarketQuoteSnapshot
 from app.models.trading import InstrumentType
 from app.services.alpaca_paper_ledger_service import AlpacaPaperLedgerService
 from app.services.alpaca_paper_submit_service import (
@@ -46,6 +52,10 @@ from app.services.alpaca_paper_submit_service import (
     derive_automated_key,
 )
 from app.services.brokers.alpaca.service import AlpacaPaperBrokerService
+from app.services.crypto_execution_mapping import (
+    CryptoExecutionMappingError,
+    map_upbit_to_alpaca_paper,
+)
 from app.services.paper_approval_packet import (
     PaperApprovalPacket,
     PaperApprovalPacketError,
@@ -53,6 +63,11 @@ from app.services.paper_approval_packet import (
     verify_packet_freshness,
     verify_packet_market_data,
 )
+
+# Server hard-cap policy ceiling for an automated per-order notional (never
+# caller-supplied). Equity uses the ROB-73 strict cap; crypto the narrow $50 cap.
+_HARD_NOTIONAL_CAP_USD = Decimal("1000")
+_HARD_EQUITY_MAX_QTY = Decimal("5")
 
 if TYPE_CHECKING:
     from fastmcp import FastMCP
@@ -125,19 +140,6 @@ def _instrument_type_for(asset_class: str) -> InstrumentType:
     )
 
 
-def _parse_asof(value: str | datetime | None) -> datetime | None:
-    if value is None:
-        return None
-    if isinstance(value, datetime):
-        return value
-    text = str(value).strip()
-    if not text:
-        return None
-    if text.endswith("Z"):
-        text = text[:-1] + "+00:00"
-    return datetime.fromisoformat(text)
-
-
 def _rejected(coid: str | None, code: str, message: str) -> dict[str, Any]:
     return {
         "success": False,
@@ -151,37 +153,79 @@ def _rejected(coid: str | None, code: str, message: str) -> dict[str, Any]:
     }
 
 
+def _hard_ceiling(
+    validated: PreviewOrderInput,
+) -> tuple[Decimal | None, Decimal | None]:
+    """Server policy ceiling (never caller-supplied) for an automated order."""
+    hard_notional = (
+        ALPACA_PAPER_CRYPTO_MAX_NOTIONAL_USD
+        if validated.asset_class == "crypto"
+        else _HARD_NOTIONAL_CAP_USD
+    )
+    if validated.side == "sell":
+        # Sell ceiling authority is the live position (checked at submit); the
+        # packet's max_qty mirrors the intent so order-within passes.
+        return None, validated.qty if validated.qty is not None else Decimal("0")
+    if validated.notional is not None or validated.limit_price is not None:
+        return hard_notional, None
+    if validated.qty is not None:
+        return None, _HARD_EQUITY_MAX_QTY
+    return hard_notional, None
+
+
+def _snapshot_content_hash(snap: MarketQuoteSnapshot) -> str:
+    blob = "|".join(
+        str(x)
+        for x in (
+            snap.id,
+            snap.market,
+            snap.symbol,
+            snap.source,
+            snap.snapshot_at.isoformat(),
+            snap.price,
+        )
+    ).encode("utf-8")
+    return hashlib.sha256(blob).hexdigest()[:16]
+
+
+def _snapshot_matches_order(
+    snap: MarketQuoteSnapshot, validated: PreviewOrderInput
+) -> bool:
+    if validated.asset_class == "crypto":
+        if snap.market != "crypto":
+            return False
+        try:
+            mapping = map_upbit_to_alpaca_paper(snap.symbol)
+        except CryptoExecutionMappingError:
+            return False
+        return mapping.execution_symbol == validated.symbol
+    return snap.market == "us" and (snap.symbol or "").upper() == validated.symbol
+
+
 async def alpaca_paper_automated_preview_order(
     symbol: str,
     side: str,
     type: str,  # noqa: A002
-    correlation_id: str,
-    snapshot_id: str,
-    market_data_asof: str,
-    market_data_source: str,
+    quote_snapshot_id: int,
     qty: Decimal | None = None,
     notional: Decimal | None = None,
     time_in_force: str | None = None,
     limit_price: Decimal | None = None,
     asset_class: str = "us_equity",
-    max_notional: Decimal | None = None,
-    max_qty: Decimal | None = None,
-    qty_source: str = "notional_estimate",
-    signal_symbol: str | None = None,
-    signal_venue: str = "upbit",
     valid_for_seconds: int = DEFAULT_PREVIEW_TTL_SECONDS,
 ) -> dict[str, Any]:
     """Build and persist the server-owned approval packet for an automated submit.
 
-    Returns an ``approval_token`` bound to the persisted packet. No broker call.
+    The caller supplies ONLY the order intent plus an opaque, server-issued
+    ``quote_snapshot_id`` referencing a trusted ``market_quote_snapshots`` row.
+    Identity (correlation/snapshot), market provenance (as-of/source) and the
+    signal symbol are loaded from that trusted artifact — never from the caller —
+    and the ceiling is the server hard-cap policy. A missing / stale / symbol-
+    mismatched snapshot fails closed before any packet is built. Returns an
+    ``approval_token`` bound to the persisted packet. No broker call.
     """
     if not _enabled():
         return _disabled_result("alpaca_paper_automated_preview_order")
-
-    if not (correlation_id or "").strip() or not (snapshot_id or "").strip():
-        raise ValueError(
-            "correlation_id and snapshot_id are required (server identity)"
-        )
 
     validated = PreviewOrderInput(
         symbol=symbol,
@@ -196,11 +240,6 @@ async def alpaca_paper_automated_preview_order(
         asset_class=asset_class,
     )
 
-    if (max_notional is None) == (max_qty is None):
-        raise ValueError(
-            "exactly one approved ceiling is required: max_notional or max_qty"
-        )
-
     canonical = build_canonical_payload(
         symbol=validated.symbol,
         side=validated.side,
@@ -211,55 +250,101 @@ async def alpaca_paper_automated_preview_order(
         limit_price=validated.limit_price,
         asset_class=validated.asset_class,
     )
-    coid = derive_automated_key(
-        correlation_id=correlation_id, snapshot_id=snapshot_id, canonical=canonical
-    )
 
     now = datetime.now(UTC)
-    try:
-        asof = _parse_asof(market_data_asof)
-    except ValueError:
-        return _rejected(
-            coid, "invalid_source_timestamp", "market_data_asof is not ISO-8601"
-        )
-
-    try:
-        packet = PaperApprovalPacket(
-            signal_source="automated_preview",
-            artifact_id=uuid.uuid4(),
-            signal_symbol=signal_symbol or validated.symbol,
-            signal_venue=signal_venue,
-            execution_symbol=validated.symbol,
-            execution_venue="alpaca_paper",
-            execution_asset_class=validated.asset_class,
-            side=validated.side,
-            max_notional=max_notional,
-            max_qty=max_qty,
-            qty_source=qty_source,
-            expected_lifecycle_step="previewed",
-            lifecycle_correlation_id=correlation_id,
-            client_order_id=coid,
-            expires_at=now + timedelta(seconds=max(1, int(valid_for_seconds))),
-            account_mode="alpaca_paper",
-            origin="automated",
-            market_data_asof=asof,
-            market_data_source=market_data_source,
-            preview_payload_hash=canonical_hash(canonical),
-            snapshot_id=snapshot_id,
-            execution_order_type=validated.type,
-            execution_time_in_force=validated.time_in_force,
-        )
-    except ValueError as exc:
-        return _rejected(coid, "invalid_packet", str(exc))
-
-    # Fail-close the market-data + order-authority checks at preview time.
-    try:
-        verify_packet_market_data(packet, now=now, max_age=_QUOTE_MAX_AGE)
-        verify_order_within_packet(packet, canonical)
-    except PaperApprovalPacketError as exc:
-        return _rejected(coid, exc.code, str(exc))
-
     async with _session_factory()() as db:
+        snap = (
+            await db.execute(
+                select(MarketQuoteSnapshot).where(
+                    MarketQuoteSnapshot.id == int(quote_snapshot_id)
+                )
+            )
+        ).scalar_one_or_none()
+
+        if snap is None:
+            return _rejected(
+                None, "no_trusted_snapshot", "no trusted market snapshot for reference"
+            )
+        if not _snapshot_matches_order(snap, validated):
+            return _rejected(
+                None,
+                "snapshot_symbol_mismatch",
+                f"trusted snapshot symbol {snap.symbol!r} does not map to order {validated.symbol!r}",
+            )
+        asof = snap.snapshot_at
+        if asof.tzinfo is None:
+            asof = asof.replace(tzinfo=UTC)
+        if now - asof > _QUOTE_MAX_AGE:
+            return _rejected(
+                None,
+                "stale_trusted_snapshot",
+                f"trusted snapshot as-of {asof.isoformat()} is stale",
+            )
+
+        # --- Server-owned identity + provenance derived from the trusted row ---
+        content_hash = _snapshot_content_hash(snap)
+        correlation_id = f"rob842dec-{content_hash}"
+        packet_snapshot_id = f"qs{snap.id}-{content_hash}"
+        signal_symbol = snap.symbol
+        max_notional, max_qty = _hard_ceiling(validated)
+        qty_source = (
+            "ledger_filled_qty" if validated.side == "sell" else "notional_estimate"
+        )
+
+        coid = derive_automated_key(
+            correlation_id=correlation_id,
+            snapshot_id=packet_snapshot_id,
+            canonical=canonical,
+        )
+
+        try:
+            packet = PaperApprovalPacket(
+                signal_source="automated_preview",
+                artifact_id=uuid.uuid4(),
+                signal_symbol=signal_symbol,
+                signal_venue="upbit",
+                execution_symbol=validated.symbol,
+                execution_venue="alpaca_paper",
+                execution_asset_class=validated.asset_class,
+                side=validated.side,
+                max_notional=max_notional,
+                max_qty=max_qty,
+                qty_source=qty_source,
+                expected_lifecycle_step="previewed",
+                lifecycle_correlation_id=correlation_id,
+                client_order_id=coid,
+                expires_at=now + timedelta(seconds=max(1, int(valid_for_seconds))),
+                account_mode="alpaca_paper",
+                origin="automated",
+                market_data_asof=asof,
+                market_data_source=snap.source,
+                preview_payload_hash=canonical_hash(canonical),
+                snapshot_id=packet_snapshot_id,
+                execution_order_type=validated.type,
+                execution_time_in_force=validated.time_in_force,
+            )
+        except ValueError as exc:
+            return _rejected(coid, "invalid_packet", str(exc))
+
+        # Fail-close market-data + order-authority (ceiling) checks at preview.
+        try:
+            verify_packet_market_data(packet, now=now, max_age=_QUOTE_MAX_AGE)
+            verify_order_within_packet(packet, canonical)
+        except PaperApprovalPacketError as exc:
+            return _rejected(coid, exc.code, str(exc))
+
+        packet_dict = packet.model_dump(mode="json")
+        provenance = {
+            "quote_snapshot_id": snap.id,
+            "snapshot_content_hash": content_hash,
+            "market_data_source": snap.source,
+            "policy_max_notional": str(max_notional)
+            if max_notional is not None
+            else None,
+            "policy_max_qty": str(max_qty) if max_qty is not None else None,
+            "packet_hash": _packet_hash(packet_dict),
+        }
+
         ledger = AlpacaPaperLedgerService(db)
         await ledger.record_preview(
             client_order_id=coid,
@@ -275,7 +360,8 @@ async def alpaca_paper_automated_preview_order(
             requested_price=validated.limit_price,
             preview_payload={
                 "canonical": canonical,
-                "approval_packet": packet.model_dump(mode="json"),
+                "approval_packet": packet_dict,
+                "provenance": provenance,
             },
         )
 
@@ -289,7 +375,17 @@ async def alpaca_paper_automated_preview_order(
         "client_order_id": coid,
         "expires_at": packet.expires_at.isoformat(),
         "order_request": canonical,
+        "provenance": provenance,
     }
+
+
+def _packet_hash(packet_dict: dict[str, Any]) -> str:
+    import json
+
+    blob = json.dumps(
+        packet_dict, sort_keys=True, separators=(",", ":"), default=str
+    ).encode("utf-8")
+    return hashlib.sha256(blob).hexdigest()[:16]
 
 
 async def alpaca_paper_automated_submit_order(

--- a/app/mcp_server/tooling/alpaca_paper_automated_orders.py
+++ b/app/mcp_server/tooling/alpaca_paper_automated_orders.py
@@ -33,17 +33,17 @@ from datetime import UTC, datetime, timedelta
 from decimal import Decimal
 from typing import TYPE_CHECKING, Any
 
-from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from app.core.db import AsyncSessionLocal
-from app.mcp_server.tooling.alpaca_paper_preview import (
-    ALPACA_PAPER_CRYPTO_MAX_NOTIONAL_USD,
-    PreviewOrderInput,
-)
-from app.models.market_quote_snapshot import MarketQuoteSnapshot
+from app.mcp_server.tooling.alpaca_paper_preview import PreviewOrderInput
 from app.models.trading import InstrumentType
 from app.services.alpaca_paper_ledger_service import AlpacaPaperLedgerService
+from app.services.alpaca_paper_market_evidence import (
+    MarketEvidenceError,
+    hard_notional_cap,
+    load_market_evidence,
+)
 from app.services.alpaca_paper_submit_service import (
     AlpacaPaperSubmitCoordinator,
     SubmitOutcome,
@@ -52,10 +52,6 @@ from app.services.alpaca_paper_submit_service import (
     derive_automated_key,
 )
 from app.services.brokers.alpaca.service import AlpacaPaperBrokerService
-from app.services.crypto_execution_mapping import (
-    CryptoExecutionMappingError,
-    map_upbit_to_alpaca_paper,
-)
 from app.services.paper_approval_packet import (
     PaperApprovalPacket,
     PaperApprovalPacketError,
@@ -63,11 +59,6 @@ from app.services.paper_approval_packet import (
     verify_packet_freshness,
     verify_packet_market_data,
 )
-
-# Server hard-cap policy ceiling for an automated per-order notional (never
-# caller-supplied). Equity uses the ROB-73 strict cap; crypto the narrow $50 cap.
-_HARD_NOTIONAL_CAP_USD = Decimal("1000")
-_HARD_EQUITY_MAX_QTY = Decimal("5")
 
 if TYPE_CHECKING:
     from fastmcp import FastMCP
@@ -153,55 +144,6 @@ def _rejected(coid: str | None, code: str, message: str) -> dict[str, Any]:
     }
 
 
-def _hard_ceiling(
-    validated: PreviewOrderInput,
-) -> tuple[Decimal | None, Decimal | None]:
-    """Server policy ceiling (never caller-supplied) for an automated order."""
-    hard_notional = (
-        ALPACA_PAPER_CRYPTO_MAX_NOTIONAL_USD
-        if validated.asset_class == "crypto"
-        else _HARD_NOTIONAL_CAP_USD
-    )
-    if validated.side == "sell":
-        # Sell ceiling authority is the live position (checked at submit); the
-        # packet's max_qty mirrors the intent so order-within passes.
-        return None, validated.qty if validated.qty is not None else Decimal("0")
-    if validated.notional is not None or validated.limit_price is not None:
-        return hard_notional, None
-    if validated.qty is not None:
-        return None, _HARD_EQUITY_MAX_QTY
-    return hard_notional, None
-
-
-def _snapshot_content_hash(snap: MarketQuoteSnapshot) -> str:
-    blob = "|".join(
-        str(x)
-        for x in (
-            snap.id,
-            snap.market,
-            snap.symbol,
-            snap.source,
-            snap.snapshot_at.isoformat(),
-            snap.price,
-        )
-    ).encode("utf-8")
-    return hashlib.sha256(blob).hexdigest()[:16]
-
-
-def _snapshot_matches_order(
-    snap: MarketQuoteSnapshot, validated: PreviewOrderInput
-) -> bool:
-    if validated.asset_class == "crypto":
-        if snap.market != "crypto":
-            return False
-        try:
-            mapping = map_upbit_to_alpaca_paper(snap.symbol)
-        except CryptoExecutionMappingError:
-            return False
-        return mapping.execution_symbol == validated.symbol
-    return snap.market == "us" and (snap.symbol or "").upper() == validated.symbol
-
-
 async def alpaca_paper_automated_preview_order(
     symbol: str,
     side: str,
@@ -218,10 +160,12 @@ async def alpaca_paper_automated_preview_order(
 
     The caller supplies ONLY the order intent plus an opaque, server-issued
     ``quote_snapshot_id`` referencing a trusted ``market_quote_snapshots`` row.
-    Identity (correlation/snapshot), market provenance (as-of/source) and the
-    signal symbol are loaded from that trusted artifact — never from the caller —
-    and the ceiling is the server hard-cap policy. A missing / stale / symbol-
-    mismatched snapshot fails closed before any packet is built. Returns an
+    Identity (correlation/snapshot), market provenance (as-of/source), the signal
+    symbol and the trusted reference price are loaded from that artifact — never
+    from the caller — and the ceiling is the server hard-cap policy. A missing /
+    stale / symbol-mismatched / non-finite-priced snapshot fails closed before any
+    packet is built. Automated SELL is explicitly disabled until ROB-845 wires an
+    opaque buy/position source (see reason ``automated_sell_disabled``). Returns an
     ``approval_token`` bound to the persisted packet. No broker call.
     """
     if not _enabled():
@@ -240,6 +184,16 @@ async def alpaca_paper_automated_preview_order(
         asset_class=asset_class,
     )
 
+    # ROB-842 F6: automated sell needs an opaque buy/position source identity that
+    # is not the quote-snapshot correlation. Until ROB-845 provides it, fail closed
+    # with a stable reason rather than a nominally-enabled always-missing-source.
+    if validated.side == "sell":
+        return _rejected(
+            None,
+            "automated_sell_disabled",
+            "automated sell is disabled until ROB-845 wires an opaque buy/position source",
+        )
+
     canonical = build_canonical_payload(
         symbol=validated.symbol,
         side=validated.side,
@@ -253,47 +207,22 @@ async def alpaca_paper_automated_preview_order(
 
     now = datetime.now(UTC)
     async with _session_factory()() as db:
-        snap = (
-            await db.execute(
-                select(MarketQuoteSnapshot).where(
-                    MarketQuoteSnapshot.id == int(quote_snapshot_id)
-                )
+        try:
+            evidence = await load_market_evidence(
+                db,
+                quote_snapshot_id,
+                execution_symbol=validated.symbol,
+                asset_class=validated.asset_class,
+                now=now,
+                max_age=_QUOTE_MAX_AGE,
             )
-        ).scalar_one_or_none()
+        except MarketEvidenceError as exc:
+            return _rejected(None, exc.code, str(exc))
 
-        if snap is None:
-            return _rejected(
-                None, "no_trusted_snapshot", "no trusted market snapshot for reference"
-            )
-        if not _snapshot_matches_order(snap, validated):
-            return _rejected(
-                None,
-                "snapshot_symbol_mismatch",
-                f"trusted snapshot symbol {snap.symbol!r} does not map to order {validated.symbol!r}",
-            )
-        asof = snap.snapshot_at
-        if asof.tzinfo is None:
-            asof = asof.replace(tzinfo=UTC)
-        if now - asof > _QUOTE_MAX_AGE:
-            return _rejected(
-                None,
-                "stale_trusted_snapshot",
-                f"trusted snapshot as-of {asof.isoformat()} is stale",
-            )
-
-        # --- Server-owned identity + provenance derived from the trusted row ---
-        content_hash = _snapshot_content_hash(snap)
-        correlation_id = f"rob842dec-{content_hash}"
-        packet_snapshot_id = f"qs{snap.id}-{content_hash}"
-        signal_symbol = snap.symbol
-        max_notional, max_qty = _hard_ceiling(validated)
-        qty_source = (
-            "ledger_filled_qty" if validated.side == "sell" else "notional_estimate"
-        )
-
+        max_notional = hard_notional_cap(validated.asset_class)
         coid = derive_automated_key(
-            correlation_id=correlation_id,
-            snapshot_id=packet_snapshot_id,
+            correlation_id=evidence.correlation_id,
+            snapshot_id=evidence.snapshot_id,
             canonical=canonical,
         )
 
@@ -301,32 +230,33 @@ async def alpaca_paper_automated_preview_order(
             packet = PaperApprovalPacket(
                 signal_source="automated_preview",
                 artifact_id=uuid.uuid4(),
-                signal_symbol=signal_symbol,
+                signal_symbol=evidence.signal_symbol,
                 signal_venue="upbit",
                 execution_symbol=validated.symbol,
                 execution_venue="alpaca_paper",
                 execution_asset_class=validated.asset_class,
                 side=validated.side,
                 max_notional=max_notional,
-                max_qty=max_qty,
-                qty_source=qty_source,
+                max_qty=None,
+                qty_source="notional_estimate",
                 expected_lifecycle_step="previewed",
-                lifecycle_correlation_id=correlation_id,
+                lifecycle_correlation_id=evidence.correlation_id,
                 client_order_id=coid,
                 expires_at=now + timedelta(seconds=max(1, int(valid_for_seconds))),
                 account_mode="alpaca_paper",
                 origin="automated",
-                market_data_asof=asof,
-                market_data_source=snap.source,
+                market_data_asof=evidence.market_data_asof,
+                market_data_source=evidence.market_data_source,
                 preview_payload_hash=canonical_hash(canonical),
-                snapshot_id=packet_snapshot_id,
+                snapshot_id=evidence.snapshot_id,
                 execution_order_type=validated.type,
                 execution_time_in_force=validated.time_in_force,
+                reference_price=evidence.price,
             )
         except ValueError as exc:
             return _rejected(coid, "invalid_packet", str(exc))
 
-        # Fail-close market-data + order-authority (ceiling) checks at preview.
+        # Fail-close market-data + order-authority (trusted-price notional) checks.
         try:
             verify_packet_market_data(packet, now=now, max_age=_QUOTE_MAX_AGE)
             verify_order_within_packet(packet, canonical)
@@ -335,20 +265,18 @@ async def alpaca_paper_automated_preview_order(
 
         packet_dict = packet.model_dump(mode="json")
         provenance = {
-            "quote_snapshot_id": snap.id,
-            "snapshot_content_hash": content_hash,
-            "market_data_source": snap.source,
-            "policy_max_notional": str(max_notional)
-            if max_notional is not None
-            else None,
-            "policy_max_qty": str(max_qty) if max_qty is not None else None,
+            "quote_snapshot_id": evidence.quote_snapshot_id,
+            "snapshot_content_hash": evidence.content_hash,
+            "market_data_source": evidence.market_data_source,
+            "reference_price": str(evidence.price),
+            "policy_max_notional": str(max_notional),
             "packet_hash": _packet_hash(packet_dict),
         }
 
         ledger = AlpacaPaperLedgerService(db)
         await ledger.record_preview(
             client_order_id=coid,
-            lifecycle_correlation_id=correlation_id,
+            lifecycle_correlation_id=evidence.correlation_id,
             execution_symbol=validated.symbol,
             execution_venue="alpaca_paper",
             instrument_type=_instrument_type_for(validated.asset_class),
@@ -365,6 +293,26 @@ async def alpaca_paper_automated_preview_order(
             },
         )
 
+        # ROB-842 F7: record_preview is ON CONFLICT DO NOTHING, so on a duplicate
+        # token this call kept the ORIGINAL persisted packet. Re-read it and answer
+        # from the persisted expiry/hash — never the locally-rebuilt values.
+        db.expire_all()
+        persisted = await ledger.get_preview_by_client_order_id(coid)
+        stored = (persisted.preview_payload or {}) if persisted is not None else {}
+        stored_packet = (
+            stored.get("approval_packet") if isinstance(stored, dict) else None
+        )
+        stored_prov = stored.get("provenance") if isinstance(stored, dict) else None
+        expires_at = (
+            stored_packet.get("expires_at")
+            if isinstance(stored_packet, dict)
+            else packet.expires_at.isoformat()
+        )
+        response_prov = stored_prov if isinstance(stored_prov, dict) else provenance
+        stored_canonical = (
+            stored.get("canonical") if isinstance(stored, dict) else canonical
+        )
+
     return {
         "success": True,
         "account_mode": "alpaca_paper",
@@ -373,9 +321,11 @@ async def alpaca_paper_automated_preview_order(
         "preview": True,
         "approval_token": coid,
         "client_order_id": coid,
-        "expires_at": packet.expires_at.isoformat(),
-        "order_request": canonical,
-        "provenance": provenance,
+        "expires_at": expires_at,
+        "order_request": stored_canonical
+        if isinstance(stored_canonical, dict)
+        else canonical,
+        "provenance": response_prov,
     }
 
 
@@ -451,7 +401,7 @@ async def alpaca_paper_automated_submit_order(
 
 def _outcome_to_result(outcome: SubmitOutcome) -> dict[str, Any]:
     return {
-        "success": outcome.status != "rejected",
+        "success": outcome.success,
         "account_mode": "alpaca_paper",
         "source": "alpaca_paper",
         "submitted": outcome.submitted,
@@ -468,11 +418,15 @@ def register_alpaca_paper_automated_orders_tools(mcp: FastMCP) -> None:
     _ = mcp.tool(
         name="alpaca_paper_automated_preview_order",
         description=(
-            "Automated Alpaca PAPER preview: server builds and persists the approval "
-            "packet (server-owned decision identity + preview hash + market-data "
-            "as-of) and returns an approval_token. No broker call. Requires "
-            "correlation_id, snapshot_id, market_data_asof, market_data_source, and "
-            "exactly one approved ceiling (max_notional or max_qty)."
+            "Automated Alpaca PAPER preview (buy only; automated sell is disabled "
+            "until ROB-845). The caller passes ONLY the order intent plus an opaque, "
+            "server-issued quote_snapshot_id (a trusted market_quote_snapshots row). "
+            "The server loads identity (correlation/snapshot), market-data as-of/"
+            "source, signal symbol and the trusted reference price from that row, "
+            "sets the ceiling from hard-cap policy, persists the packet, and returns "
+            "an approval_token. No broker call. A missing / stale / symbol-mismatched "
+            "/ non-finite-priced snapshot fails closed. There is NO caller-supplied "
+            "correlation, snapshot, market-data, ceiling, origin, or client_order_id."
         ),
     )(alpaca_paper_automated_preview_order)
     _ = mcp.tool(

--- a/app/mcp_server/tooling/alpaca_paper_orders.py
+++ b/app/mcp_server/tooling/alpaca_paper_orders.py
@@ -27,6 +27,11 @@ from app.mcp_server.tooling.alpaca_paper_preview import (
     PreviewOrderInput,
 )
 from app.services.alpaca_paper_ledger_service import AlpacaPaperLedgerService
+from app.services.alpaca_paper_market_evidence import (
+    MarketEvidence,
+    MarketEvidenceError,
+    load_market_evidence,
+)
 from app.services.alpaca_paper_submit_service import (
     AlpacaPaperSubmitCoordinator,
     build_canonical_payload,
@@ -51,6 +56,7 @@ SUBMIT_MAX_NOTIONAL_USD: Decimal = Decimal("1000")
 ORDER_ID_SAFE_SEGMENT_RE = re.compile(r"^[A-Za-z0-9_-]{1,128}$")
 ORDER_ID_RESERVED_VALUES = frozenset({"all", "order", "orders", "bulk", "cancel"})
 _MANUAL_PACKET_TTL_SECONDS = 120
+_MANUAL_QUOTE_MAX_AGE = timedelta(minutes=5)
 
 ServiceFactory = Callable[[], AlpacaPaperBrokerService]
 SessionFactory = Callable[[], async_sessionmaker[AsyncSession]]
@@ -151,9 +157,17 @@ def _manual_ceiling(
 
 
 def _build_manual_packet(
-    validated: PreviewOrderInput, canonical: dict[str, Any], coid: str
+    validated: PreviewOrderInput,
+    canonical: dict[str, Any],
+    coid: str,
+    evidence: MarketEvidence,
 ) -> PaperApprovalPacket:
-    """Server-built manual operator packet (origin='manual', server-derived key)."""
+    """Server-built manual operator packet (origin='manual', server-derived key).
+
+    Carries server-observed market evidence (as-of/source/reference price) from a
+    trusted snapshot, so the coordinator applies the same market/order checks it
+    applies to automated submits — no origin-based bypass.
+    """
     if validated.asset_class == "crypto":
         signal_symbol = map_alpaca_paper_to_upbit(validated.symbol)
     else:
@@ -177,9 +191,12 @@ def _build_manual_packet(
         expires_at=datetime.now(UTC) + timedelta(seconds=_MANUAL_PACKET_TTL_SECONDS),
         account_mode="alpaca_paper",
         origin="manual",
+        market_data_asof=evidence.market_data_asof,
+        market_data_source=evidence.market_data_source,
         preview_payload_hash=canonical_hash(canonical),
         execution_order_type=validated.type,
         execution_time_in_force=validated.time_in_force,
+        reference_price=evidence.price,
     )
 
 
@@ -187,6 +204,7 @@ async def alpaca_paper_submit_order(
     symbol: str,
     side: str,
     type: str,  # noqa: A002
+    quote_snapshot_id: int | None = None,
     qty: Decimal | None = None,
     notional: Decimal | None = None,
     time_in_force: str | None = None,
@@ -200,12 +218,14 @@ async def alpaca_paper_submit_order(
 
     This is the MANUAL operator tool. It carries no caller-selectable origin,
     client_order_id, or claim mode: the idempotency key is server-derived from the
-    canonical order. When ``confirm=True`` the real broker POST is routed through
-    the SAME durable packet + ledger atomic-claim coordinator as the automated
-    path (ROB-842) — duplicate manual intents POST exactly once, a deterministic
-    broker rejection is terminal, and an uncertain outcome is reconciled, never
-    re-POSTed. There is no direct-POST fallback and this behaviour does not depend
-    on the automated feature flag.
+    canonical order. ``confirm=True`` requires an opaque, server-issued
+    ``quote_snapshot_id`` (a trusted ``market_quote_snapshots`` row) so the real
+    broker POST — routed through the SAME durable packet + ledger atomic-claim
+    coordinator as the automated path — is validated against server-observed
+    market evidence and (for sells) the live position. Duplicate manual intents
+    POST exactly once, a deterministic broker rejection is terminal, and an
+    uncertain outcome is reconciled — never re-POSTed. There is no direct-POST
+    fallback and this behaviour does not depend on the automated feature flag.
     """
     validated = PreviewOrderInput(
         symbol=symbol,
@@ -259,15 +279,50 @@ async def alpaca_paper_submit_order(
             "client_order_id": coid,
         }
 
-    # confirm=True — route the real broker POST through the durable boundary.
-    packet = _build_manual_packet(validated, canonical, coid)
+    # confirm=True — route the real broker POST through the durable boundary. A
+    # server-observed market snapshot is REQUIRED (no origin bypass of market
+    # evidence).
+    if quote_snapshot_id is None:
+        return {
+            "success": False,
+            "account_mode": "alpaca_paper",
+            "source": "alpaca_paper",
+            "submitted": False,
+            "status": "rejected",
+            "reason_code": "missing_market_evidence",
+            "client_order_id": coid,
+            "message": "confirm=True requires a trusted quote_snapshot_id",
+        }
+
+    now = datetime.now(UTC)
     async with _session_factory()() as db:
+        try:
+            evidence = await load_market_evidence(
+                db,
+                quote_snapshot_id,
+                execution_symbol=validated.symbol,
+                asset_class=validated.asset_class,
+                now=now,
+                max_age=_MANUAL_QUOTE_MAX_AGE,
+            )
+        except MarketEvidenceError as exc:
+            return {
+                "success": False,
+                "account_mode": "alpaca_paper",
+                "source": "alpaca_paper",
+                "submitted": False,
+                "status": "rejected",
+                "reason_code": exc.code,
+                "client_order_id": coid,
+                "message": str(exc),
+            }
+        packet = _build_manual_packet(validated, canonical, coid, evidence)
         ledger = AlpacaPaperLedgerService(db)
         coordinator = AlpacaPaperSubmitCoordinator(ledger, _service_factory)
         outcome = await coordinator.submit(packet, submit_canonical=canonical)
 
     return {
-        "success": outcome.status != "rejected",
+        "success": outcome.success,
         "account_mode": "alpaca_paper",
         "source": "alpaca_paper",
         "submitted": outcome.submitted,
@@ -324,15 +379,18 @@ def register_alpaca_paper_orders_tools(mcp: FastMCP) -> None:
         description=(
             "MANUAL operator submit for a single Alpaca PAPER us_equity or narrow "
             "crypto order. Defaults to confirm=False which validates and returns "
-            "the request WITHOUT calling the broker. confirm=True routes the real "
-            "POST through the SAME server-owned packet + ledger atomic-claim "
-            "coordinator as the automated path: duplicate intents POST exactly "
-            "once, a deterministic broker rejection is terminal, an uncertain "
-            "outcome is reconciled (never re-POSTed). The idempotency key is "
-            "server-derived — there is no caller client_order_id or origin. Paper "
-            "endpoint only; live endpoint cannot be selected. Strict caps: "
-            "us_equity qty<=5/notional<=$1000/qty*limit_price<=$1000; crypto is "
-            "buy/sell limit-only, allowlisted, and capped at $50."
+            "the request WITHOUT calling the broker. confirm=True REQUIRES an "
+            "opaque, server-issued quote_snapshot_id (a trusted market_quote_"
+            "snapshots row) and routes the real POST through the SAME server-owned "
+            "packet + ledger atomic-claim coordinator as the automated path: market "
+            "evidence + (for sells) the live position are verified, duplicate "
+            "intents POST exactly once, a deterministic broker rejection is "
+            "terminal, and an uncertain outcome is reconciled (never re-POSTed). "
+            "The idempotency key is server-derived — there is no caller "
+            "client_order_id or origin. Paper endpoint only; live endpoint cannot "
+            "be selected. Strict caps: us_equity qty<=5/notional<=$1000/"
+            "qty*limit_price<=$1000; crypto is buy/sell limit-only, allowlisted, "
+            "and capped at $50."
         ),
     )(alpaca_paper_submit_order)
     _ = mcp.tool(

--- a/app/mcp_server/tooling/alpaca_paper_orders.py
+++ b/app/mcp_server/tooling/alpaca_paper_orders.py
@@ -12,22 +12,30 @@ switch the underlying service to the live endpoint.
 from __future__ import annotations
 
 import re
+import uuid
 from collections.abc import Callable
+from datetime import UTC, datetime, timedelta
 from decimal import Decimal
 from typing import TYPE_CHECKING, Any
 
 from pydantic import BaseModel
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
+from app.core.db import AsyncSessionLocal
 from app.mcp_server.tooling.alpaca_paper_preview import (
     ALPACA_PAPER_CRYPTO_MAX_NOTIONAL_USD,
     PreviewOrderInput,
 )
+from app.services.alpaca_paper_ledger_service import AlpacaPaperLedgerService
 from app.services.alpaca_paper_submit_service import (
+    AlpacaPaperSubmitCoordinator,
     build_canonical_payload,
+    canonical_hash,
     derive_client_order_id,
 )
-from app.services.brokers.alpaca.schemas import OrderRequest
 from app.services.brokers.alpaca.service import AlpacaPaperBrokerService
+from app.services.crypto_execution_mapping import map_alpaca_paper_to_upbit
+from app.services.paper_approval_packet import PaperApprovalPacket
 
 if TYPE_CHECKING:
     from fastmcp import FastMCP
@@ -42,15 +50,32 @@ SUBMIT_MAX_QTY: Decimal = Decimal("5")
 SUBMIT_MAX_NOTIONAL_USD: Decimal = Decimal("1000")
 ORDER_ID_SAFE_SEGMENT_RE = re.compile(r"^[A-Za-z0-9_-]{1,128}$")
 ORDER_ID_RESERVED_VALUES = frozenset({"all", "order", "orders", "bulk", "cancel"})
+_MANUAL_PACKET_TTL_SECONDS = 120
 
 ServiceFactory = Callable[[], AlpacaPaperBrokerService]
+SessionFactory = Callable[[], async_sessionmaker[AsyncSession]]
 
 
 def _default_service_factory() -> AlpacaPaperBrokerService:
     return AlpacaPaperBrokerService()
 
 
+def _default_session_factory() -> async_sessionmaker[AsyncSession]:
+    return AsyncSessionLocal  # type: ignore[return-value]
+
+
 _service_factory: ServiceFactory = _default_service_factory
+_session_factory: SessionFactory = _default_session_factory
+
+
+def set_alpaca_paper_orders_session_factory(factory: SessionFactory) -> None:
+    global _session_factory
+    _session_factory = factory
+
+
+def reset_alpaca_paper_orders_session_factory() -> None:
+    global _session_factory
+    _session_factory = _default_session_factory
 
 
 def set_alpaca_paper_orders_service_factory(factory: ServiceFactory) -> None:
@@ -109,6 +134,55 @@ def _validate_exact_order_id(order_id: str) -> str:
     return stripped
 
 
+def _manual_ceiling(
+    validated: PreviewOrderInput,
+) -> tuple[Decimal | None, Decimal | None]:
+    """Server hard-cap ceiling for a manual order (never caller-supplied)."""
+    hard_notional = (
+        ALPACA_PAPER_CRYPTO_MAX_NOTIONAL_USD
+        if validated.asset_class == "crypto"
+        else SUBMIT_MAX_NOTIONAL_USD
+    )
+    if validated.notional is not None or validated.limit_price is not None:
+        return hard_notional, None
+    if validated.qty is not None:
+        return None, SUBMIT_MAX_QTY
+    return hard_notional, None
+
+
+def _build_manual_packet(
+    validated: PreviewOrderInput, canonical: dict[str, Any], coid: str
+) -> PaperApprovalPacket:
+    """Server-built manual operator packet (origin='manual', server-derived key)."""
+    if validated.asset_class == "crypto":
+        signal_symbol = map_alpaca_paper_to_upbit(validated.symbol)
+    else:
+        signal_symbol = validated.symbol
+    max_notional, max_qty = _manual_ceiling(validated)
+    return PaperApprovalPacket(
+        signal_source="manual_operator",
+        artifact_id=uuid.uuid4(),
+        signal_symbol=signal_symbol,
+        signal_venue="upbit",
+        execution_symbol=validated.symbol,
+        execution_venue="alpaca_paper",
+        execution_asset_class=validated.asset_class,
+        side=validated.side,
+        max_notional=max_notional,
+        max_qty=max_qty,
+        qty_source="manual_operator",
+        expected_lifecycle_step="previewed",
+        lifecycle_correlation_id=coid,
+        client_order_id=coid,
+        expires_at=datetime.now(UTC) + timedelta(seconds=_MANUAL_PACKET_TTL_SECONDS),
+        account_mode="alpaca_paper",
+        origin="manual",
+        preview_payload_hash=canonical_hash(canonical),
+        execution_order_type=validated.type,
+        execution_time_in_force=validated.time_in_force,
+    )
+
+
 async def alpaca_paper_submit_order(
     symbol: str,
     side: str,
@@ -117,7 +191,6 @@ async def alpaca_paper_submit_order(
     notional: Decimal | None = None,
     time_in_force: str | None = None,
     limit_price: Decimal | None = None,
-    client_order_id: str | None = None,
     asset_class: str = "us_equity",
     confirm: bool = False,
 ) -> dict[str, Any]:
@@ -125,11 +198,14 @@ async def alpaca_paper_submit_order(
 
     Defaults to ``confirm=False`` which performs no broker call.
 
-    This is the MANUAL, operator-only smoke tool. It is NOT the automated
-    execution path and carries no caller-selectable origin switch: an automated
-    cohort must use the separate ``alpaca_paper_automated_preview_order`` /
-    ``alpaca_paper_automated_submit_order`` tools, which route through the
-    server-owned approval-packet + ledger-atomic-claim boundary (ROB-842).
+    This is the MANUAL operator tool. It carries no caller-selectable origin,
+    client_order_id, or claim mode: the idempotency key is server-derived from the
+    canonical order. When ``confirm=True`` the real broker POST is routed through
+    the SAME durable packet + ledger atomic-claim coordinator as the automated
+    path (ROB-842) — duplicate manual intents POST exactly once, a deterministic
+    broker rejection is terminal, and an uncertain outcome is reconciled, never
+    re-POSTed. There is no direct-POST fallback and this behaviour does not depend
+    on the automated feature flag.
     """
     validated = PreviewOrderInput(
         symbol=symbol,
@@ -140,7 +216,7 @@ async def alpaca_paper_submit_order(
         time_in_force=time_in_force,
         limit_price=limit_price,
         stop_price=None,
-        client_order_id=client_order_id,
+        client_order_id=None,
         asset_class=asset_class,
     )
 
@@ -170,7 +246,7 @@ async def alpaca_paper_submit_order(
         )
 
     canonical = _canonical_payload(validated)
-    coid = validated.client_order_id or _derive_client_order_id(canonical)
+    coid = _derive_client_order_id(canonical)
 
     if confirm is not True:
         return {
@@ -183,25 +259,23 @@ async def alpaca_paper_submit_order(
             "client_order_id": coid,
         }
 
-    request = OrderRequest(
-        symbol=validated.symbol,
-        side=validated.side,
-        type=validated.type,
-        qty=validated.qty,
-        notional=validated.notional,
-        time_in_force=validated.time_in_force,
-        limit_price=validated.limit_price,
-        stop_price=None,
-        client_order_id=coid,
-    )
-    order = await _service_factory().submit_order(request)
+    # confirm=True — route the real broker POST through the durable boundary.
+    packet = _build_manual_packet(validated, canonical, coid)
+    async with _session_factory()() as db:
+        ledger = AlpacaPaperLedgerService(db)
+        coordinator = AlpacaPaperSubmitCoordinator(ledger, _service_factory)
+        outcome = await coordinator.submit(packet, submit_canonical=canonical)
+
     return {
-        "success": True,
+        "success": outcome.status != "rejected",
         "account_mode": "alpaca_paper",
         "source": "alpaca_paper",
-        "submitted": True,
-        "order": _model_to_jsonable(order),
-        "client_order_id": coid,
+        "submitted": outcome.submitted,
+        "status": outcome.status,
+        "reason_code": outcome.reason_code,
+        "order": outcome.order,
+        "client_order_id": outcome.client_order_id,
+        "message": outcome.message,
     }
 
 
@@ -248,12 +322,17 @@ def register_alpaca_paper_orders_tools(mcp: FastMCP) -> None:
     _ = mcp.tool(
         name="alpaca_paper_submit_order",
         description=(
-            "Submit a single Alpaca PAPER us_equity or narrow crypto order. "
-            "Defaults to confirm=False which validates and returns the request "
-            "WITHOUT calling the broker. Use confirm=True to actually submit. "
-            "Paper endpoint only; live endpoint cannot be selected. "
-            "Strict caps: us_equity qty<=5/notional<=$1000/qty*limit_price<=$1000; "
-            "crypto is buy/sell limit-only, allowlisted, and capped at $50."
+            "MANUAL operator submit for a single Alpaca PAPER us_equity or narrow "
+            "crypto order. Defaults to confirm=False which validates and returns "
+            "the request WITHOUT calling the broker. confirm=True routes the real "
+            "POST through the SAME server-owned packet + ledger atomic-claim "
+            "coordinator as the automated path: duplicate intents POST exactly "
+            "once, a deterministic broker rejection is terminal, an uncertain "
+            "outcome is reconciled (never re-POSTed). The idempotency key is "
+            "server-derived — there is no caller client_order_id or origin. Paper "
+            "endpoint only; live endpoint cannot be selected. Strict caps: "
+            "us_equity qty<=5/notional<=$1000/qty*limit_price<=$1000; crypto is "
+            "buy/sell limit-only, allowlisted, and capped at $50."
         ),
     )(alpaca_paper_submit_order)
     _ = mcp.tool(

--- a/app/mcp_server/tooling/alpaca_paper_orders.py
+++ b/app/mcp_server/tooling/alpaca_paper_orders.py
@@ -356,40 +356,57 @@ async def alpaca_paper_cancel_order(
     service = _service_factory()
     await service.cancel_order(stripped)
 
+    # A DELETE 204 only ACCEPTS the cancel request; it is not a terminal
+    # `canceled`. Read the order back and act on its actual status (ROB-842 H1).
     order_payload: Any = None
     read_back_status = "ok"
-    cancelled_client_order_id: str | None = None
+    broker_status: str | None = None
+    client_order_id: str | None = None
     try:
         order = await service.get_order(stripped)
         order_payload = _model_to_jsonable(order)
         if isinstance(order_payload, dict):
-            cancelled_client_order_id = order_payload.get("client_order_id")
+            broker_status = order_payload.get("status")
+            client_order_id = order_payload.get("client_order_id")
     except Exception:  # noqa: BLE001 — read-back is best-effort
         read_back_status = "unavailable"
 
-    # Release any sell reservation this order held: mark the ledger execution row
-    # canceled so its qty stops counting against sellable position (ROB-842 G4).
+    # `canceled` is the ONLY status that confirms the cancel released the order.
+    # pending_cancel / new / accepted / any open state, and an unavailable/unknown
+    # read-back, keep the sell reservation. Terminal non-canceled states
+    # (filled/rejected/expired) are still recorded so the ledger reflects broker
+    # truth (a fill that raced the cancel converges to `filled`, not `canceled`).
+    cancel_confirmed = read_back_status == "ok" and broker_status == "canceled"
     reservation_released = False
-    if cancelled_client_order_id:
+    lifecycle_synced = False
+    if client_order_id and read_back_status == "ok" and broker_status is not None:
         try:
             async with _session_factory()() as db:
                 ledger = AlpacaPaperLedgerService(db)
-                await ledger.record_cancel(
-                    cancelled_client_order_id, cancel_status="canceled"
-                )
-                reservation_released = True
+                await ledger.record_status(client_order_id, order_payload)
+                if cancel_confirmed:
+                    await ledger.record_cancel(
+                        client_order_id, cancel_status="canceled"
+                    )
+                    reservation_released = True
+                lifecycle_synced = True
         except Exception:  # noqa: BLE001 — non-boundary orders have no ledger row
-            reservation_released = False
+            lifecycle_synced = False
 
     return {
         "success": True,
         "account_mode": "alpaca_paper",
         "source": "alpaca_paper",
-        "cancelled": True,
+        # honest: cancel_requested was accepted; cancelled is True only once the
+        # broker confirms the terminal `canceled` status.
+        "cancel_requested": True,
+        "cancelled": cancel_confirmed,
+        "order_status": broker_status,
         "cancelled_order_id": stripped,
         "order": order_payload,
         "read_back_status": read_back_status,
         "reservation_released": reservation_released,
+        "lifecycle_synced": lifecycle_synced,
     }
 
 

--- a/app/mcp_server/tooling/alpaca_paper_orders.py
+++ b/app/mcp_server/tooling/alpaca_paper_orders.py
@@ -384,18 +384,23 @@ async def alpaca_paper_cancel_order(
     cancel_confirmed = read_back_status == "ok" and normalized_status == "canceled"
     reservation_released = False
     lifecycle_synced = False
-    status_can_release = (
-        normalized_status is not None
-        and normalized_status not in KNOWN_OPEN_BROKER_STATUSES
-        and normalized_status != "filled"
-    )
-    if client_order_id and read_back_status == "ok" and status_can_release:
+    status_should_sync = normalized_status is not None
+    if client_order_id and read_back_status == "ok" and status_should_sync:
         try:
             async with _session_factory()() as db:
                 ledger = AlpacaPaperLedgerService(db)
                 normalized_payload = dict(order_payload)
                 normalized_payload["status"] = normalized_status
-                await ledger.record_status(client_order_id, normalized_payload)
+                await ledger.record_status(
+                    client_order_id,
+                    normalized_payload,
+                    lifecycle_state_override=(
+                        "submitted"
+                        if normalized_status in KNOWN_OPEN_BROKER_STATUSES
+                        or normalized_status == "filled"
+                        else None
+                    ),
+                )
                 if cancel_confirmed:
                     await ledger.record_cancel(
                         client_order_id, cancel_status="canceled"

--- a/app/mcp_server/tooling/alpaca_paper_orders.py
+++ b/app/mcp_server/tooling/alpaca_paper_orders.py
@@ -26,7 +26,11 @@ from app.mcp_server.tooling.alpaca_paper_preview import (
     ALPACA_PAPER_CRYPTO_MAX_NOTIONAL_USD,
     PreviewOrderInput,
 )
-from app.services.alpaca_paper_ledger_service import AlpacaPaperLedgerService
+from app.services.alpaca_paper_ledger_service import (
+    KNOWN_OPEN_BROKER_STATUSES,
+    AlpacaPaperLedgerService,
+    normalize_known_broker_order_status,
+)
 from app.services.alpaca_paper_market_evidence import (
     MarketEvidence,
     MarketEvidenceError,
@@ -373,17 +377,25 @@ async def alpaca_paper_cancel_order(
 
     # `canceled` is the ONLY status that confirms the cancel released the order.
     # pending_cancel / new / accepted / any open state, and an unavailable/unknown
-    # read-back, keep the sell reservation. Terminal non-canceled states
-    # (filled/rejected/expired) are still recorded so the ledger reflects broker
-    # truth (a fill that raced the cancel converges to `filled`, not `canceled`).
-    cancel_confirmed = read_back_status == "ok" and broker_status == "canceled"
+    # read-back, keep the sell reservation. A fill that raced the cancel is reported
+    # truthfully but also keeps its hold until a later position read proves that the
+    # fill is reflected. Other known terminal states can safely release the hold.
+    normalized_status = normalize_known_broker_order_status(broker_status)
+    cancel_confirmed = read_back_status == "ok" and normalized_status == "canceled"
     reservation_released = False
     lifecycle_synced = False
-    if client_order_id and read_back_status == "ok" and broker_status is not None:
+    status_can_release = (
+        normalized_status is not None
+        and normalized_status not in KNOWN_OPEN_BROKER_STATUSES
+        and normalized_status != "filled"
+    )
+    if client_order_id and read_back_status == "ok" and status_can_release:
         try:
             async with _session_factory()() as db:
                 ledger = AlpacaPaperLedgerService(db)
-                await ledger.record_status(client_order_id, order_payload)
+                normalized_payload = dict(order_payload)
+                normalized_payload["status"] = normalized_status
+                await ledger.record_status(client_order_id, normalized_payload)
                 if cancel_confirmed:
                     await ledger.record_cancel(
                         client_order_id, cancel_status="canceled"

--- a/app/mcp_server/tooling/alpaca_paper_orders.py
+++ b/app/mcp_server/tooling/alpaca_paper_orders.py
@@ -143,16 +143,18 @@ def _validate_exact_order_id(order_id: str) -> str:
 def _manual_ceiling(
     validated: PreviewOrderInput,
 ) -> tuple[Decimal | None, Decimal | None]:
-    """Server hard-cap ceiling for a manual order (never caller-supplied)."""
+    """Server hard-cap NOTIONAL ceiling for a manual order (never caller-supplied).
+
+    Always a max_notional so that qty/market orders are bounded by
+    ``packet.reference_price × qty`` (the trusted price), not merely a qty cap —
+    a qty order at a high reference price must still respect the notional hard cap
+    (ROB-842 G2). The separate qty<=5 equity cap is enforced by the tool itself.
+    """
     hard_notional = (
         ALPACA_PAPER_CRYPTO_MAX_NOTIONAL_USD
         if validated.asset_class == "crypto"
         else SUBMIT_MAX_NOTIONAL_USD
     )
-    if validated.notional is not None or validated.limit_price is not None:
-        return hard_notional, None
-    if validated.qty is not None:
-        return None, SUBMIT_MAX_QTY
     return hard_notional, None
 
 
@@ -356,11 +358,28 @@ async def alpaca_paper_cancel_order(
 
     order_payload: Any = None
     read_back_status = "ok"
+    cancelled_client_order_id: str | None = None
     try:
         order = await service.get_order(stripped)
         order_payload = _model_to_jsonable(order)
+        if isinstance(order_payload, dict):
+            cancelled_client_order_id = order_payload.get("client_order_id")
     except Exception:  # noqa: BLE001 — read-back is best-effort
         read_back_status = "unavailable"
+
+    # Release any sell reservation this order held: mark the ledger execution row
+    # canceled so its qty stops counting against sellable position (ROB-842 G4).
+    reservation_released = False
+    if cancelled_client_order_id:
+        try:
+            async with _session_factory()() as db:
+                ledger = AlpacaPaperLedgerService(db)
+                await ledger.record_cancel(
+                    cancelled_client_order_id, cancel_status="canceled"
+                )
+                reservation_released = True
+        except Exception:  # noqa: BLE001 — non-boundary orders have no ledger row
+            reservation_released = False
 
     return {
         "success": True,
@@ -370,6 +389,7 @@ async def alpaca_paper_cancel_order(
         "cancelled_order_id": stripped,
         "order": order_payload,
         "read_back_status": read_back_status,
+        "reservation_released": reservation_released,
     }
 
 

--- a/app/mcp_server/tooling/alpaca_paper_orders.py
+++ b/app/mcp_server/tooling/alpaca_paper_orders.py
@@ -11,8 +11,6 @@ switch the underlying service to the live endpoint.
 
 from __future__ import annotations
 
-import hashlib
-import json
 import re
 from collections.abc import Callable
 from decimal import Decimal
@@ -23,6 +21,10 @@ from pydantic import BaseModel
 from app.mcp_server.tooling.alpaca_paper_preview import (
     ALPACA_PAPER_CRYPTO_MAX_NOTIONAL_USD,
     PreviewOrderInput,
+)
+from app.services.alpaca_paper_submit_service import (
+    build_canonical_payload,
+    derive_client_order_id,
 )
 from app.services.brokers.alpaca.schemas import OrderRequest
 from app.services.brokers.alpaca.service import AlpacaPaperBrokerService
@@ -72,25 +74,22 @@ def _model_to_jsonable(value: Any) -> Any:
 
 
 def _canonical_payload(validated: PreviewOrderInput) -> dict[str, Any]:
-    return {
-        "symbol": validated.symbol,
-        "side": validated.side,
-        "type": validated.type,
-        "time_in_force": validated.time_in_force,
-        "qty": str(validated.qty) if validated.qty is not None else None,
-        "notional": str(validated.notional) if validated.notional is not None else None,
-        "limit_price": str(validated.limit_price)
-        if validated.limit_price is not None
-        else None,
-        "asset_class": validated.asset_class,
-    }
+    """Canonical submit payload — shared with the ROB-842 application service."""
+    return build_canonical_payload(
+        symbol=validated.symbol,
+        side=validated.side,
+        type=validated.type,
+        time_in_force=validated.time_in_force,
+        qty=validated.qty,
+        notional=validated.notional,
+        limit_price=validated.limit_price,
+        asset_class=validated.asset_class,
+    )
 
 
 def _derive_client_order_id(payload: dict[str, Any]) -> str:
-    blob = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
-    digest = hashlib.sha256(blob).hexdigest()[:16]
-    prefix = "rob74-crypto" if payload.get("asset_class") == "crypto" else "rob73"
-    return f"{prefix}-{digest}"
+    """Server-derived deterministic client_order_id (shared, single source)."""
+    return derive_client_order_id(payload)
 
 
 def _validate_exact_order_id(order_id: str) -> str:
@@ -125,6 +124,12 @@ async def alpaca_paper_submit_order(
     """Submit a single Alpaca PAPER order (us_equity or narrow crypto).
 
     Defaults to ``confirm=False`` which performs no broker call.
+
+    This is the MANUAL, operator-only smoke tool. It is NOT the automated
+    execution path and carries no caller-selectable origin switch: an automated
+    cohort must use the separate ``alpaca_paper_automated_preview_order`` /
+    ``alpaca_paper_automated_submit_order`` tools, which route through the
+    server-owned approval-packet + ledger-atomic-claim boundary (ROB-842).
     """
     validated = PreviewOrderInput(
         symbol=symbol,

--- a/app/mcp_server/tooling/registry.py
+++ b/app/mcp_server/tooling/registry.py
@@ -314,10 +314,15 @@ def register_all_tools(mcp: FastMCP, profile: McpProfile = McpProfile.DEFAULT) -
         register_kis_mock_order_tools(mcp)
         # Intentionally NOT: register_order_tools, register_kis_live_order_tools
     elif profile is McpProfile.US_PAPER:
+        from app.mcp_server.tooling.alpaca_paper_automated_orders import (
+            register_alpaca_paper_automated_orders_tools,
+        )
+
         register_alpaca_paper_tools(mcp)
         register_alpaca_paper_preview_tools(mcp)
         register_us_dual_paper_tools(mcp)
         register_alpaca_paper_orders_tools(mcp)
+        register_alpaca_paper_automated_orders_tools(mcp)
         register_alpaca_paper_ledger_read_tools(mcp)
     elif profile is McpProfile.DB_PAPER:
         register_paper_account_tools(mcp)

--- a/app/services/alpaca_paper_ledger_service.py
+++ b/app/services/alpaca_paper_ledger_service.py
@@ -14,7 +14,7 @@ from datetime import UTC, datetime
 from decimal import Decimal
 from typing import Any
 
-from sqlalchemy import select, text, update
+from sqlalchemy import func, select, text, update
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -247,6 +247,23 @@ class SubmitClaim:
     """
 
     won: bool
+    row: AlpacaPaperOrderLedger | None
+
+
+@dataclass
+class SellReservationClaim:
+    """Result of an advisory-locked sell reservation + atomic claim.
+
+    won:          True if this caller inserted the execution claim row.
+    insufficient: True if the requested qty exceeds the reservation-adjusted
+                  available position (no claim attempted); ``available`` is set.
+    available:    position qty minus already-reserved open sell qty (Decimal).
+    row:          the execution row for the client_order_id (for replay lookups).
+    """
+
+    won: bool
+    insufficient: bool
+    available: Decimal | None
     row: AlpacaPaperOrderLedger | None
 
 
@@ -504,6 +521,115 @@ class AlpacaPaperLedgerService:
         self._db.expire_all()
         row = await self._find_execution_row(client_order_id)
         return SubmitClaim(won=inserted_id is not None, row=row)
+
+    async def reserve_sell_and_claim(
+        self,
+        *,
+        client_order_id: str,
+        lifecycle_correlation_id: str | None = None,
+        execution_symbol: str,
+        execution_venue: str,
+        instrument_type: InstrumentType,
+        account_mode: str = "alpaca_paper",
+        requested_qty: Decimal,
+        position_qty: Decimal,
+        order_type: str = "limit",
+        time_in_force: str | None = None,
+        requested_price: Decimal | float | None = None,
+        currency: str = "USD",
+        preview_payload: dict[str, Any] | None = None,
+        provenance: ApprovalProvenance | None = None,
+    ) -> SellReservationClaim:
+        """Atomically reserve sellable qty and claim the submit under one lock.
+
+        Serializes concurrent sells for the same ``(account_mode, execution_symbol)``
+        across sessions/processes via a transaction-scoped PostgreSQL advisory lock,
+        so two *different* sell intents cannot each read the full position and both
+        POST. Within the lock: available = position_qty − Σ(open sell requested_qty
+        already reserved for this symbol/account) and, only if the request fits,
+        inserts the execution claim row (ON CONFLICT DO NOTHING). The inserted claim
+        itself counts as a reservation for the next caller. No new schema.
+        """
+        if not client_order_id or not client_order_id.strip():
+            raise ValueError("client_order_id must not be empty")
+
+        prov = provenance or ApprovalProvenance()
+        correlation_id = lifecycle_correlation_id or client_order_id
+        lock_key = f"alpaca_paper_sell:{account_mode}:{execution_symbol}"
+
+        # Transaction-scoped advisory lock (released on commit/rollback).
+        await self._db.execute(
+            text("SELECT pg_advisory_xact_lock(hashtext(:k))"), {"k": lock_key}
+        )
+
+        reserved_stmt = select(
+            func.coalesce(func.sum(AlpacaPaperOrderLedger.requested_qty), 0)
+        ).where(
+            AlpacaPaperOrderLedger.record_kind == RECORD_KIND_EXECUTION,
+            AlpacaPaperOrderLedger.side == "sell",
+            AlpacaPaperOrderLedger.execution_symbol == execution_symbol,
+            AlpacaPaperOrderLedger.account_mode == account_mode,
+            AlpacaPaperOrderLedger.lifecycle_state.in_(
+                [LIFECYCLE_SUBMITTED, LIFECYCLE_FILLED]
+            ),
+            AlpacaPaperOrderLedger.client_order_id != client_order_id,
+        )
+        reserved_raw = (await self._db.execute(reserved_stmt)).scalar_one()
+        reserved = Decimal(str(reserved_raw or 0))
+        available = Decimal(str(position_qty)) - reserved
+
+        if requested_qty > available:
+            # No write yet — end the txn to release the advisory lock immediately.
+            await self._db.rollback()
+            self._db.expire_all()
+            existing = await self._find_execution_row(client_order_id)
+            return SellReservationClaim(
+                won=False, insufficient=True, available=available, row=existing
+            )
+
+        values: dict[str, Any] = {
+            "client_order_id": client_order_id,
+            "lifecycle_correlation_id": correlation_id,
+            "record_kind": RECORD_KIND_EXECUTION,
+            "broker": "alpaca",
+            "account_mode": account_mode,
+            "lifecycle_state": LIFECYCLE_SUBMITTED,
+            "execution_symbol": execution_symbol,
+            "execution_venue": execution_venue,
+            "instrument_type": instrument_type,
+            "side": "sell",
+            "order_type": order_type,
+            "time_in_force": time_in_force,
+            "requested_qty": requested_qty,
+            "requested_price": requested_price,
+            "currency": currency,
+            "preview_payload": _redact_sensitive_keys(preview_payload)
+            if preview_payload
+            else None,
+            "broker_order_id": None,
+            "submitted_at": None,
+            "confirm_flag": True,
+            **self._build_provenance_values(prov),
+        }
+        stmt = (
+            pg_insert(AlpacaPaperOrderLedger)
+            .values(**values)
+            .on_conflict_do_nothing(
+                index_elements=["client_order_id", "record_kind"],
+                index_where=text("validation_attempt_no IS NULL"),
+            )
+            .returning(AlpacaPaperOrderLedger.id)
+        )
+        inserted_id = (await self._db.execute(stmt)).scalar_one_or_none()
+        await self._db.commit()  # releases the advisory lock
+        self._db.expire_all()
+        row = await self._find_execution_row(client_order_id)
+        return SellReservationClaim(
+            won=inserted_id is not None,
+            insufficient=False,
+            available=available,
+            row=row,
+        )
 
     async def _find_execution_row(
         self, client_order_id: str
@@ -1343,6 +1469,7 @@ __all__ = [
     "RECORD_KIND_PREVIEW",
     "RECORD_KIND_RECONCILE",
     "RECORD_KIND_VALIDATION_ATTEMPT",
+    "SellReservationClaim",
     "SubmitClaim",
     "_derive_lifecycle_state",
     "_redact_sensitive_keys",

--- a/app/services/alpaca_paper_ledger_service.py
+++ b/app/services/alpaca_paper_ledger_service.py
@@ -562,6 +562,10 @@ class AlpacaPaperLedgerService:
             text("SELECT pg_advisory_xact_lock(hashtext(:k))"), {"k": lock_key}
         )
 
+        # Only OPEN sells still consume sellable qty: a `filled` sell has already
+        # reduced the live position, and a canceled (`cancel_status` set) or
+        # `anomaly`/terminal sell releases its hold. Subtracting a filled sell would
+        # double-count it against the (already-reduced) live position.
         reserved_stmt = select(
             func.coalesce(func.sum(AlpacaPaperOrderLedger.requested_qty), 0)
         ).where(
@@ -569,9 +573,8 @@ class AlpacaPaperLedgerService:
             AlpacaPaperOrderLedger.side == "sell",
             AlpacaPaperOrderLedger.execution_symbol == execution_symbol,
             AlpacaPaperOrderLedger.account_mode == account_mode,
-            AlpacaPaperOrderLedger.lifecycle_state.in_(
-                [LIFECYCLE_SUBMITTED, LIFECYCLE_FILLED]
-            ),
+            AlpacaPaperOrderLedger.lifecycle_state == LIFECYCLE_SUBMITTED,
+            AlpacaPaperOrderLedger.cancel_status.is_(None),
             AlpacaPaperOrderLedger.client_order_id != client_order_id,
         )
         reserved_raw = (await self._db.execute(reserved_stmt)).scalar_one()

--- a/app/services/alpaca_paper_ledger_service.py
+++ b/app/services/alpaca_paper_ledger_service.py
@@ -634,6 +634,31 @@ class AlpacaPaperLedgerService:
             row=row,
         )
 
+    async def list_open_sells(
+        self, *, account_mode: str, execution_symbol: str
+    ) -> list[AlpacaPaperOrderLedger]:
+        """Return OPEN sell execution rows (lifecycle='submitted', not canceled).
+
+        These are the rows the reservation sum treats as still consuming sellable
+        position. Callers reconcile them against broker truth before computing
+        availability so a stale ``submitted`` row (actually filled/canceled at the
+        broker) is not double-counted.
+        """
+        stmt = (
+            select(AlpacaPaperOrderLedger)
+            .where(
+                AlpacaPaperOrderLedger.record_kind == RECORD_KIND_EXECUTION,
+                AlpacaPaperOrderLedger.side == "sell",
+                AlpacaPaperOrderLedger.execution_symbol == execution_symbol,
+                AlpacaPaperOrderLedger.account_mode == account_mode,
+                AlpacaPaperOrderLedger.lifecycle_state == LIFECYCLE_SUBMITTED,
+                AlpacaPaperOrderLedger.cancel_status.is_(None),
+            )
+            .order_by(AlpacaPaperOrderLedger.id.asc())
+        )
+        result = await self._db.execute(stmt)
+        return list(result.scalars().all())
+
     async def _find_execution_row(
         self, client_order_id: str
     ) -> AlpacaPaperOrderLedger | None:

--- a/app/services/alpaca_paper_ledger_service.py
+++ b/app/services/alpaca_paper_ledger_service.py
@@ -164,7 +164,7 @@ def normalize_known_broker_order_status(value: Any) -> str | None:
 
 
 def _derive_lifecycle_state(
-    order_status: str | None,
+    order_status: Any,
     filled_qty: Decimal | float | None = None,
 ) -> str:
     """Map broker order_status to ROB-90 canonical lifecycle state.
@@ -177,7 +177,7 @@ def _derive_lifecycle_state(
     - canceled → anomaly (ROB-90: no benign cancel state)
     - rejected/expired/suspended/unknown → anomaly
     """
-    if order_status is None:
+    if not isinstance(order_status, str):
         return LIFECYCLE_ANOMALY
     status = order_status.lower()
     if status == "filled":
@@ -1094,7 +1094,8 @@ class AlpacaPaperLedgerService:
         broker_order_id = (
             order.get("id") or order.get("order_id") or order.get("broker_order_id")
         )
-        order_status = order.get("status")
+        raw_order_status = order.get("status")
+        order_status = raw_order_status if isinstance(raw_order_status, str) else None
         filled_qty_raw = order.get("filled_qty") or order.get("filled_quantity")
         filled_avg_price_raw = order.get("filled_avg_price") or order.get(
             "avg_fill_price"
@@ -1115,7 +1116,7 @@ class AlpacaPaperLedgerService:
                 filled_avg_price = None
 
         lifecycle_state = lifecycle_state_override or _derive_lifecycle_state(
-            order_status, filled_qty
+            raw_order_status, filled_qty
         )
         raw_responses = None
         if raw_response is not None:
@@ -1191,8 +1192,11 @@ class AlpacaPaperLedgerService:
         raw_response: dict[str, Any] | None = None,
         *,
         commit: bool = True,
+        lifecycle_state_override: str | None = None,
     ) -> AlpacaPaperOrderLedger:
         """Update lifecycle state from a status-check response."""
+        if lifecycle_state_override not in {None, LIFECYCLE_SUBMITTED}:
+            raise ValueError("status lifecycle override may only retain submitted")
         target_row = await self._require_row(client_order_id)
 
         order_status = order.get("status")
@@ -1215,7 +1219,9 @@ class AlpacaPaperLedgerService:
             except Exception:
                 filled_avg_price = None
 
-        lifecycle_state = _derive_lifecycle_state(order_status, filled_qty)
+        lifecycle_state = lifecycle_state_override or _derive_lifecycle_state(
+            order_status, filled_qty
+        )
 
         update_vals: dict[str, Any] = {
             "lifecycle_state": lifecycle_state,

--- a/app/services/alpaca_paper_ledger_service.py
+++ b/app/services/alpaca_paper_ledger_service.py
@@ -524,6 +524,58 @@ class AlpacaPaperLedgerService:
         result = await self._db.execute(stmt)
         return result.scalar_one_or_none()
 
+    async def get_execution_by_client_order_id(
+        self, client_order_id: str
+    ) -> AlpacaPaperOrderLedger | None:
+        """Public: the execution row for a client_order_id in ANY lifecycle state.
+
+        Includes terminal ``anomaly`` rows (unlike ``find_executed_by_client_order_id``
+        which is scoped to executed states) so a deterministic broker failure is
+        replayed instead of re-attempted.
+        """
+        return await self._find_execution_row(client_order_id)
+
+    async def record_submit_failure(
+        self,
+        client_order_id: str,
+        *,
+        order_status: str = "rejected",
+        error_summary: str,
+    ) -> AlpacaPaperOrderLedger:
+        """Book a deterministic broker rejection as a terminal execution outcome.
+
+        Marks the existing execution (claim) row ``anomaly`` and stamps
+        ``submitted_at`` so it is no longer in-flight — a retry of the same key
+        replays this failure instead of re-POSTing. Reuses existing columns only
+        (no new schema). ``error_summary`` is redacted + length-bounded so no raw
+        broker body / token is persisted.
+        """
+        target = await self._find_execution_row(client_order_id)
+        if target is None:
+            raise LedgerNotFoundError(
+                f"No execution row to fail for client_order_id={client_order_id!r}"
+            )
+        safe_summary = (_redact_sensitive_text(error_summary) or "")[:300]
+        await self._db.execute(
+            update(AlpacaPaperOrderLedger)
+            .where(AlpacaPaperOrderLedger.id == target.id)
+            .values(
+                lifecycle_state=LIFECYCLE_ANOMALY,
+                order_status=order_status,
+                submitted_at=datetime.now(UTC),
+                confirm_flag=True,
+                error_summary=safe_summary,
+            )
+        )
+        await self._db.commit()
+        self._db.expire_all()
+        row = await self._find_execution_row(client_order_id)
+        if row is None:
+            raise LedgerNotFoundError(
+                f"No execution row for client_order_id={client_order_id!r}"
+            )
+        return row
+
     async def get_preview_by_client_order_id(
         self, client_order_id: str
     ) -> AlpacaPaperOrderLedger | None:

--- a/app/services/alpaca_paper_ledger_service.py
+++ b/app/services/alpaca_paper_ledger_service.py
@@ -146,6 +146,21 @@ _OPEN_STATUSES = frozenset(
     }
 )
 _ANOMALY_STATUSES = frozenset({"rejected", "expired", "suspended"})
+KNOWN_OPEN_BROKER_STATUSES = frozenset({*_OPEN_STATUSES, "partially_filled"})
+KNOWN_TERMINAL_BROKER_STATUSES = frozenset({*_ANOMALY_STATUSES, "filled", "canceled"})
+_KNOWN_BROKER_STATUSES = KNOWN_OPEN_BROKER_STATUSES | KNOWN_TERMINAL_BROKER_STATUSES
+
+
+def normalize_known_broker_order_status(value: Any) -> str | None:
+    """Return a normalized Alpaca status only when its semantics are known.
+
+    Unknown, blank, and non-string provider values are not terminal evidence and
+    must never release an open sell reservation.
+    """
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip().lower()
+    return normalized if normalized in _KNOWN_BROKER_STATUSES else None
 
 
 def _derive_lifecycle_state(
@@ -257,7 +272,8 @@ class SellReservationClaim:
     won:          True if this caller inserted the execution claim row.
     insufficient: True if the requested qty exceeds the reservation-adjusted
                   available position (no claim attempted); ``available`` is set.
-    available:    position qty minus already-reserved open sell qty (Decimal).
+    available:    conservative min of broker qty_available and position qty minus
+                  already-reserved open sell qty (Decimal).
     row:          the execution row for the client_order_id (for replay lookups).
     """
 
@@ -533,6 +549,7 @@ class AlpacaPaperLedgerService:
         account_mode: str = "alpaca_paper",
         requested_qty: Decimal,
         position_qty: Decimal,
+        position_available: Decimal,
         order_type: str = "limit",
         time_in_force: str | None = None,
         requested_price: Decimal | float | None = None,
@@ -546,20 +563,19 @@ class AlpacaPaperLedgerService:
         across sessions/processes via a transaction-scoped PostgreSQL advisory lock,
         so two *different* sell intents cannot each read the full position and both
         POST. Within the lock: available = position_qty − Σ(open sell requested_qty
-        already reserved for this symbol/account) and, only if the request fits,
-        inserts the execution claim row (ON CONFLICT DO NOTHING). The inserted claim
-        itself counts as a reservation for the next caller. No new schema.
+        already reserved for this symbol/account), bounded again by the broker's
+        qty_available, and only if the request fits inserts the execution claim row
+        (ON CONFLICT DO NOTHING). The claim stores its position baseline in the
+        existing position_snapshot JSONB and counts as a reservation for the next
+        caller. No new schema.
         """
         if not client_order_id or not client_order_id.strip():
             raise ValueError("client_order_id must not be empty")
 
         prov = provenance or ApprovalProvenance()
         correlation_id = lifecycle_correlation_id or client_order_id
-        lock_key = f"alpaca_paper_sell:{account_mode}:{execution_symbol}"
-
-        # Transaction-scoped advisory lock (released on commit/rollback).
-        await self._db.execute(
-            text("SELECT pg_advisory_xact_lock(hashtext(:k))"), {"k": lock_key}
+        await self.acquire_sell_reservation_lock(
+            account_mode=account_mode, execution_symbol=execution_symbol
         )
 
         # Only OPEN sells still consume sellable qty: a `filled` sell has already
@@ -579,7 +595,10 @@ class AlpacaPaperLedgerService:
         )
         reserved_raw = (await self._db.execute(reserved_stmt)).scalar_one()
         reserved = Decimal(str(reserved_raw or 0))
-        available = Decimal(str(position_qty)) - reserved
+        available = min(
+            Decimal(str(position_qty)) - reserved,
+            Decimal(str(position_available)),
+        )
 
         if requested_qty > available:
             # No write yet — end the txn to release the advisory lock immediately.
@@ -609,6 +628,12 @@ class AlpacaPaperLedgerService:
             "preview_payload": _redact_sensitive_keys(preview_payload)
             if preview_payload
             else None,
+            "position_snapshot": {
+                "snapshot_kind": "sell_claim_baseline",
+                "qty": str(position_qty),
+                "qty_available": str(position_available),
+                "fetched_at": datetime.now(UTC).isoformat(),
+            },
             "broker_order_id": None,
             "submitted_at": None,
             "confirm_flag": True,
@@ -632,6 +657,15 @@ class AlpacaPaperLedgerService:
             insufficient=False,
             available=available,
             row=row,
+        )
+
+    async def acquire_sell_reservation_lock(
+        self, *, account_mode: str, execution_symbol: str
+    ) -> None:
+        """Hold the account+symbol sell lock until the current transaction ends."""
+        lock_key = f"alpaca_paper_sell:{account_mode}:{execution_symbol}"
+        await self._db.execute(
+            text("SELECT pg_advisory_xact_lock(hashtext(:k))"), {"k": lock_key}
         )
 
     async def list_open_sells(
@@ -1051,6 +1085,8 @@ class AlpacaPaperLedgerService:
         client_order_id: str,
         order: dict[str, Any],
         raw_response: dict[str, Any] | None = None,
+        *,
+        lifecycle_state_override: str | None = None,
     ) -> AlpacaPaperOrderLedger:
         """Record a confirmed submit as a distinct execution row."""
         source_row = await self._require_row(client_order_id)
@@ -1078,7 +1114,9 @@ class AlpacaPaperLedgerService:
             except Exception:
                 filled_avg_price = None
 
-        lifecycle_state = _derive_lifecycle_state(order_status, filled_qty)
+        lifecycle_state = lifecycle_state_override or _derive_lifecycle_state(
+            order_status, filled_qty
+        )
         raw_responses = None
         if raw_response is not None:
             raw_responses = {"submit": _redact_sensitive_keys(raw_response)}
@@ -1151,6 +1189,8 @@ class AlpacaPaperLedgerService:
         client_order_id: str,
         order: dict[str, Any],
         raw_response: dict[str, Any] | None = None,
+        *,
+        commit: bool = True,
     ) -> AlpacaPaperOrderLedger:
         """Update lifecycle state from a status-check response."""
         target_row = await self._require_row(client_order_id)
@@ -1197,8 +1237,11 @@ class AlpacaPaperLedgerService:
         if raw_response is not None:
             await self._accumulate_raw_response(client_order_id, "status", raw_response)
 
-        await self._db.commit()
-        return await self._require_row(client_order_id)
+        if commit:
+            await self._db.commit()
+            return await self._require_row(client_order_id)
+        await self._db.flush()
+        return target_row
 
     async def record_cancel(
         self,
@@ -1490,6 +1533,8 @@ __all__ = [
     "LIFECYCLE_STALE_PREVIEW_CLEANUP_REQUIRED",
     "LIFECYCLE_SUBMITTED",
     "LIFECYCLE_VALIDATED",
+    "KNOWN_OPEN_BROKER_STATUSES",
+    "KNOWN_TERMINAL_BROKER_STATUSES",
     "LedgerNotFoundError",
     "RECORD_KIND_ANOMALY",
     "RECORD_KIND_EXECUTION",
@@ -1504,4 +1549,5 @@ __all__ = [
     "_redact_sensitive_text",
     "from_approval_bridge",
     "is_inflight_execution",
+    "normalize_known_broker_order_status",
 ]

--- a/app/services/alpaca_paper_ledger_service.py
+++ b/app/services/alpaca_paper_ledger_service.py
@@ -234,6 +234,47 @@ def from_approval_bridge(
 
 
 # ---------------------------------------------------------------------------
+# ROB-842: atomic submit-claim support
+# ---------------------------------------------------------------------------
+@dataclass
+class SubmitClaim:
+    """Result of an atomic submit claim on the existing execution unique slot.
+
+    won:  True if this caller inserted the execution claim row (owns the broker
+          POST); False if a concurrent/sequential caller already claimed it.
+    row:  the execution/lifecycle row for the client_order_id (winner's fresh claim
+          row, or the row a losing caller must inspect for replay vs in-flight).
+    """
+
+    won: bool
+    row: AlpacaPaperOrderLedger | None
+
+
+def is_inflight_execution(row: Any) -> bool:
+    """True when an execution row is a claimed-but-not-yet-recorded submit.
+
+    The winner inserts an execution row with ``submitted_at``/``broker_order_id``
+    NULL, then fills them in ``record_submit`` after the broker responds. An
+    execution row still missing both markers therefore denotes an in-flight (or
+    crashed-mid-flight) submit that must not be re-POSTed.
+    """
+    if row is None:
+        return False
+    if str(_get_attr(row, "record_kind") or "") != RECORD_KIND_EXECUTION:
+        return False
+    return (
+        _get_attr(row, "submitted_at") is None
+        and _get_attr(row, "broker_order_id") is None
+    )
+
+
+def _get_attr(row: Any, key: str, default: Any = None) -> Any:
+    if isinstance(row, dict):
+        return row.get(key, default)
+    return getattr(row, key, default)
+
+
+# ---------------------------------------------------------------------------
 # Errors
 # ---------------------------------------------------------------------------
 class LedgerNotFoundError(Exception):
@@ -252,6 +293,11 @@ class AlpacaPaperLedgerService:
 
     def __init__(self, db: AsyncSession) -> None:
         self._db = db
+
+    @property
+    def session(self) -> AsyncSession:
+        """Underlying async session (used to force a fresh READ COMMITTED snapshot)."""
+        return self._db
 
     # ------------------------------------------------------------------
     # Read helpers
@@ -364,6 +410,133 @@ class AlpacaPaperLedgerService:
                 AlpacaPaperOrderLedger.client_order_id == client_order_id,
                 AlpacaPaperOrderLedger.record_kind == RECORD_KIND_EXECUTION,
                 AlpacaPaperOrderLedger.lifecycle_state.in_(EXECUTED_LIFECYCLE_STATES),
+            )
+            .order_by(
+                AlpacaPaperOrderLedger.created_at.desc(),
+                AlpacaPaperOrderLedger.id.desc(),
+            )
+            .limit(1)
+        )
+        result = await self._db.execute(stmt)
+        return result.scalar_one_or_none()
+
+    # ------------------------------------------------------------------
+    # ROB-842: atomic submit claim
+    # ------------------------------------------------------------------
+
+    async def claim_submit(
+        self,
+        *,
+        client_order_id: str,
+        lifecycle_correlation_id: str | None = None,
+        execution_symbol: str,
+        execution_venue: str,
+        instrument_type: InstrumentType,
+        side: str,
+        order_type: str = "limit",
+        time_in_force: str | None = None,
+        requested_qty: Decimal | float | None = None,
+        requested_notional: Decimal | float | None = None,
+        requested_price: Decimal | float | None = None,
+        currency: str = "USD",
+        preview_payload: dict[str, Any] | None = None,
+        provenance: ApprovalProvenance | None = None,
+    ) -> SubmitClaim:
+        """Atomically claim submit ownership for ``client_order_id``.
+
+        Inserts the single execution row for this order (record_kind='execution',
+        lifecycle_state='submitted', broker_order_id/submitted_at NULL) using
+        ``INSERT ... ON CONFLICT DO NOTHING RETURNING id`` against the existing
+        partial-unique execution slot. The winner is whichever caller inserts the
+        row; every other concurrent/sequential caller conflicts and observes
+        ``won=False``. No new table/column/index is introduced — this reuses the
+        ROB-90 ``(client_order_id, record_kind)`` unique slot that
+        ``record_submit`` later updates in place.
+        """
+        if not client_order_id or not client_order_id.strip():
+            raise ValueError("client_order_id must not be empty")
+
+        prov = provenance or ApprovalProvenance()
+        correlation_id = lifecycle_correlation_id or client_order_id
+        sanitized_preview = (
+            _redact_sensitive_keys(preview_payload) if preview_payload else None
+        )
+
+        values: dict[str, Any] = {
+            "client_order_id": client_order_id,
+            "lifecycle_correlation_id": correlation_id,
+            "record_kind": RECORD_KIND_EXECUTION,
+            "broker": "alpaca",
+            "account_mode": "alpaca_paper",
+            "lifecycle_state": LIFECYCLE_SUBMITTED,
+            "execution_symbol": execution_symbol,
+            "execution_venue": execution_venue,
+            "instrument_type": instrument_type,
+            "side": side,
+            "order_type": order_type,
+            "time_in_force": time_in_force,
+            "requested_qty": requested_qty,
+            "requested_notional": requested_notional,
+            "requested_price": requested_price,
+            "currency": currency,
+            "preview_payload": sanitized_preview,
+            # In-flight markers: intentionally NULL until record_submit fills them.
+            "broker_order_id": None,
+            "submitted_at": None,
+            "confirm_flag": True,
+            **self._build_provenance_values(prov),
+        }
+
+        stmt = (
+            pg_insert(AlpacaPaperOrderLedger)
+            .values(**values)
+            .on_conflict_do_nothing(
+                index_elements=["client_order_id", "record_kind"],
+                index_where=text("validation_attempt_no IS NULL"),
+            )
+            .returning(AlpacaPaperOrderLedger.id)
+        )
+        result = await self._db.execute(stmt)
+        inserted_id = result.scalar_one_or_none()
+        await self._db.commit()
+
+        # Re-read from the committed state so a losing caller sees the winner's row.
+        self._db.expire_all()
+        row = await self._find_execution_row(client_order_id)
+        return SubmitClaim(won=inserted_id is not None, row=row)
+
+    async def _find_execution_row(
+        self, client_order_id: str
+    ) -> AlpacaPaperOrderLedger | None:
+        """Return the execution row for client_order_id regardless of lifecycle state."""
+        stmt = (
+            select(AlpacaPaperOrderLedger)
+            .where(
+                AlpacaPaperOrderLedger.client_order_id == client_order_id,
+                AlpacaPaperOrderLedger.record_kind == RECORD_KIND_EXECUTION,
+            )
+            .order_by(
+                AlpacaPaperOrderLedger.created_at.desc(),
+                AlpacaPaperOrderLedger.id.desc(),
+            )
+            .limit(1)
+        )
+        result = await self._db.execute(stmt)
+        return result.scalar_one_or_none()
+
+    async def get_preview_by_client_order_id(
+        self, client_order_id: str
+    ) -> AlpacaPaperOrderLedger | None:
+        """Return the persisted preview row for a client_order_id, if any.
+
+        Used by the automated submit path to bind the submit to the server-owned
+        packet built and persisted at preview time.
+        """
+        stmt = (
+            select(AlpacaPaperOrderLedger)
+            .where(
+                AlpacaPaperOrderLedger.client_order_id == client_order_id,
+                AlpacaPaperOrderLedger.record_kind == RECORD_KIND_PREVIEW,
             )
             .order_by(
                 AlpacaPaperOrderLedger.created_at.desc(),
@@ -1118,8 +1291,10 @@ __all__ = [
     "RECORD_KIND_PREVIEW",
     "RECORD_KIND_RECONCILE",
     "RECORD_KIND_VALIDATION_ATTEMPT",
+    "SubmitClaim",
     "_derive_lifecycle_state",
     "_redact_sensitive_keys",
     "_redact_sensitive_text",
     "from_approval_bridge",
+    "is_inflight_execution",
 ]

--- a/app/services/alpaca_paper_market_evidence.py
+++ b/app/services/alpaca_paper_market_evidence.py
@@ -28,6 +28,12 @@ from app.services.crypto_execution_mapping import (
 HARD_NOTIONAL_CAP_USD = Decimal("1000")
 CRYPTO_HARD_NOTIONAL_CAP_USD = Decimal("50")
 
+# raw_payload.provenance markers that identify a caller/order-derived (not
+# server-observed) snapshot — never usable as trusted evidence.
+_SYNTHETIC_PROVENANCE: frozenset[str] = frozenset(
+    {"smoke", "smoke_synthetic", "operator_synthetic", "order_derived"}
+)
+
 
 class MarketEvidenceError(Exception):
     """Raised with a stable reason code when trusted evidence is unusable."""
@@ -110,6 +116,18 @@ async def load_market_evidence(
     if snap is None:
         raise MarketEvidenceError(
             "no_trusted_snapshot", "no trusted market snapshot for reference"
+        )
+    # A caller/order-derived (smoke/operator) snapshot is NOT server-observed market
+    # evidence — reject it even though it lives in the trusted table under a real
+    # source, so a fabricated price can never back a production submit.
+    raw = snap.raw_payload if isinstance(snap.raw_payload, dict) else {}
+    if (
+        raw.get("synthetic") is True
+        or str(raw.get("provenance") or "") in _SYNTHETIC_PROVENANCE
+    ):
+        raise MarketEvidenceError(
+            "synthetic_snapshot",
+            "snapshot is caller/order-derived (synthetic) and cannot be trusted evidence",
         )
     if not _snapshot_matches(
         snap, execution_symbol=execution_symbol, asset_class=asset_class

--- a/app/services/alpaca_paper_market_evidence.py
+++ b/app/services/alpaca_paper_market_evidence.py
@@ -1,0 +1,162 @@
+"""Server-observed market evidence for Alpaca Paper submits (ROB-842).
+
+Both the manual and automated submit paths must attach server-observed / persisted
+market evidence to their approval packet — there is no origin-based bypass. This
+module loads a trusted ``market_quote_snapshots`` row by an opaque, server-issued
+id and derives the packet's market-data as-of/source, signal identity and trusted
+reference price. It never trusts a caller-supplied timestamp, source, correlation
+or ceiling.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal, InvalidOperation
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.market_quote_snapshot import MarketQuoteSnapshot
+from app.services.crypto_execution_mapping import (
+    CryptoExecutionMappingError,
+    map_upbit_to_alpaca_paper,
+)
+
+# Server hard-cap per-order notional policy (never caller-supplied).
+HARD_NOTIONAL_CAP_USD = Decimal("1000")
+CRYPTO_HARD_NOTIONAL_CAP_USD = Decimal("50")
+
+
+class MarketEvidenceError(Exception):
+    """Raised with a stable reason code when trusted evidence is unusable."""
+
+    def __init__(self, code: str, message: str) -> None:
+        self.code = code
+        super().__init__(message)
+
+
+@dataclass(frozen=True)
+class MarketEvidence:
+    quote_snapshot_id: int
+    content_hash: str
+    correlation_id: str
+    snapshot_id: str
+    market_data_asof: datetime
+    market_data_source: str
+    signal_symbol: str
+    price: Decimal
+
+
+def hard_notional_cap(asset_class: str) -> Decimal:
+    return (
+        CRYPTO_HARD_NOTIONAL_CAP_USD
+        if asset_class == "crypto"
+        else HARD_NOTIONAL_CAP_USD
+    )
+
+
+def _snapshot_content_hash(snap: MarketQuoteSnapshot) -> str:
+    blob = "|".join(
+        str(x)
+        for x in (
+            snap.id,
+            snap.market,
+            snap.symbol,
+            snap.source,
+            snap.snapshot_at.isoformat(),
+            snap.price,
+        )
+    ).encode("utf-8")
+    return hashlib.sha256(blob).hexdigest()[:16]
+
+
+def _snapshot_matches(
+    snap: MarketQuoteSnapshot, *, execution_symbol: str, asset_class: str
+) -> bool:
+    if asset_class == "crypto":
+        if snap.market != "crypto":
+            return False
+        try:
+            mapping = map_upbit_to_alpaca_paper(snap.symbol)
+        except CryptoExecutionMappingError:
+            return False
+        return mapping.execution_symbol == execution_symbol
+    return snap.market == "us" and (snap.symbol or "").upper() == execution_symbol
+
+
+async def load_market_evidence(
+    db: AsyncSession,
+    quote_snapshot_id: int,
+    *,
+    execution_symbol: str,
+    asset_class: str,
+    now: datetime,
+    max_age: timedelta,
+) -> MarketEvidence:
+    """Load + validate a trusted market snapshot into server-owned evidence.
+
+    Raises MarketEvidenceError(code=...) for: no_trusted_snapshot,
+    snapshot_symbol_mismatch, invalid_snapshot_price, stale_trusted_snapshot.
+    """
+    snap = (
+        await db.execute(
+            select(MarketQuoteSnapshot).where(
+                MarketQuoteSnapshot.id == int(quote_snapshot_id)
+            )
+        )
+    ).scalar_one_or_none()
+    if snap is None:
+        raise MarketEvidenceError(
+            "no_trusted_snapshot", "no trusted market snapshot for reference"
+        )
+    if not _snapshot_matches(
+        snap, execution_symbol=execution_symbol, asset_class=asset_class
+    ):
+        raise MarketEvidenceError(
+            "snapshot_symbol_mismatch",
+            f"trusted snapshot symbol {snap.symbol!r} does not map to {execution_symbol!r}",
+        )
+
+    try:
+        price = Decimal(str(snap.price))
+    except (InvalidOperation, TypeError, ValueError) as exc:
+        raise MarketEvidenceError(
+            "invalid_snapshot_price", f"snapshot price {snap.price!r} is not a number"
+        ) from exc
+    if not price.is_finite() or price <= 0:
+        raise MarketEvidenceError(
+            "invalid_snapshot_price", f"snapshot price {price} is not finite/positive"
+        )
+
+    asof = snap.snapshot_at
+    if asof.tzinfo is None:
+        asof = asof.replace(tzinfo=UTC)
+    if now - asof > max_age:
+        raise MarketEvidenceError(
+            "stale_trusted_snapshot",
+            f"trusted snapshot as-of {asof.isoformat()} is stale",
+        )
+
+    content_hash = _snapshot_content_hash(snap)
+    return MarketEvidence(
+        quote_snapshot_id=snap.id,
+        content_hash=content_hash,
+        correlation_id=f"rob842dec-{content_hash}",
+        snapshot_id=f"qs{snap.id}-{content_hash}",
+        market_data_asof=asof,
+        market_data_source=snap.source,
+        signal_symbol=snap.symbol,
+        price=price,
+    )
+
+
+__all__ = [
+    "CRYPTO_HARD_NOTIONAL_CAP_USD",
+    "HARD_NOTIONAL_CAP_USD",
+    "MarketEvidence",
+    "MarketEvidenceError",
+    "hard_notional_cap",
+    "load_market_evidence",
+]

--- a/app/services/alpaca_paper_submit_service.py
+++ b/app/services/alpaca_paper_submit_service.py
@@ -288,6 +288,19 @@ class AlpacaPaperSubmitCoordinator:
                 return await self._resolve_inflight(coid)
             return self._resolved_outcome(existing)
 
+        # --- (2b) Automated sell is disabled at the SUBMIT boundary (ROB-845) ----
+        # The persisted packet's own origin/side is re-checked here so a legacy
+        # automated-sell token cannot POST. Any prior terminal result was already
+        # replayed above; a brand-new automated sell fails closed with no claim.
+        if packet.origin == "automated" and packet.side == "sell":
+            return SubmitOutcome(
+                status="rejected",
+                client_order_id=coid,
+                broker_called=False,
+                reason_code="automated_sell_disabled",
+                message="automated sell is disabled at the submit boundary until ROB-845",
+            )
+
         # --- (3) Time-dependent evidence — NEW (not-yet-claimed) submits only ----
         # No origin bypass: every new submit must carry server-observed market
         # evidence and pass freshness. Sells additionally require live position.
@@ -328,7 +341,7 @@ class AlpacaPaperSubmitCoordinator:
                 return self._resolved_outcome(row)
             return await self._resolve_inflight(coid)
 
-        return await self._winner_submit(coid, submit_canonical)
+        return await self._winner_submit(packet, submit_canonical)
 
     async def _submit_sell(
         self, packet: PaperApprovalPacket, submit_canonical: dict[str, Any], coid: str
@@ -410,11 +423,39 @@ class AlpacaPaperSubmitCoordinator:
                 return self._resolved_outcome(row)
             return await self._resolve_inflight(coid)
 
-        return await self._winner_submit(coid, submit_canonical)
+        return await self._winner_submit(packet, submit_canonical)
 
     async def _winner_submit(
-        self, coid: str, submit_canonical: dict[str, Any]
+        self, packet: PaperApprovalPacket, submit_canonical: dict[str, Any]
     ) -> SubmitOutcome:
+        coid = packet.client_order_id
+
+        # --- Re-verify freshness at the moment of send --------------------------
+        # All the claim/position/DB awaits are done; the wall clock may have moved
+        # past the packet's freshness window since the initial check. Re-check with
+        # the CURRENT clock immediately before the broker POST. On failure, book a
+        # terminal outcome (no re-POST) and reject.
+        try:
+            now = self._now_fn()
+            verify_packet_freshness(packet, now=now)
+            verify_packet_market_data(packet, now=now, max_age=self._quote_max_age)
+        except PaperApprovalPacketError as exc:
+            try:
+                await self._ledger.record_submit_failure(
+                    coid,
+                    order_status="rejected",
+                    error_summary=f"stale_at_send: {exc.code}",
+                )
+            except Exception:  # noqa: BLE001 - best-effort; claim row still guards
+                pass
+            return SubmitOutcome(
+                status="rejected",
+                client_order_id=coid,
+                broker_called=False,
+                reason_code=exc.code,
+                message=f"stale at send: {exc}",
+            )
+
         broker = self._broker_factory()
         request = OrderRequest(
             symbol=submit_canonical["symbol"],

--- a/app/services/alpaca_paper_submit_service.py
+++ b/app/services/alpaca_paper_submit_service.py
@@ -1,0 +1,415 @@
+"""Single application service for Alpaca Paper submit (ROB-842).
+
+Routes every automated Alpaca Paper submit through one server-side boundary:
+
+    packet + hash verification  →  existing-ledger atomic claim  →  broker POST
+
+so that a stale/incomplete/mismatched intent can never reach the broker, and a
+sequential *or* concurrent duplicate of the same intent results in **exactly one**
+broker HTTP submit. The winner of the atomic claim performs the broker call; every
+other caller replays the winner's stored result or, while the winner is still
+in-flight, returns a structured ``idempotency_in_progress`` without re-POSTing.
+
+This module reuses the existing native ``AlpacaPaperLedgerService`` /
+``review.alpaca_paper_order_ledger`` unique lifecycle record — it introduces no new
+idempotency store, table, column, or Alembic migration. It never imports or calls a
+live Alpaca endpoint or live-credential resolver: the only broker surface it can
+build is ``AlpacaPaperBrokerService`` (paper-host-pinned in its constructor).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+from typing import TYPE_CHECKING, Any
+
+from app.models.trading import InstrumentType
+from app.services.alpaca_paper_ledger_service import (
+    AlpacaPaperLedgerService,
+    is_inflight_execution,
+)
+from app.services.brokers.alpaca.schemas import OrderRequest
+from app.services.paper_approval_packet import (
+    PaperApprovalPacket,
+    PaperApprovalPacketError,
+    verify_order_within_packet,
+    verify_packet_account_mode,
+    verify_packet_freshness,
+    verify_packet_market_data,
+    verify_preview_submit_hash,
+    verify_sell_packet_source,
+    verify_server_derived_key,
+)
+
+if TYPE_CHECKING:
+    from app.services.brokers.alpaca.service import AlpacaPaperBrokerService
+
+BrokerFactory = Callable[[], "AlpacaPaperBrokerService"]
+
+# Default bound on how old the market-data source timestamp may be at submit time.
+DEFAULT_QUOTE_MAX_AGE = timedelta(minutes=5)
+# Default bounded wait for an in-flight winner before returning in-progress.
+DEFAULT_INFLIGHT_MAX_POLLS = 3
+DEFAULT_INFLIGHT_POLL_INTERVAL_S = 0.05
+
+
+# ---------------------------------------------------------------------------
+# Shared canonical payload + server-derived key/hash helpers
+# ---------------------------------------------------------------------------
+def build_canonical_payload(
+    *,
+    symbol: str,
+    side: str,
+    type: str,  # noqa: A002
+    time_in_force: str | None,
+    qty: Decimal | None,
+    notional: Decimal | None,
+    limit_price: Decimal | None,
+    asset_class: str,
+) -> dict[str, Any]:
+    """Build the canonical, order-independent submit payload.
+
+    Identical shape to the historical ROB-73 canonical payload so derived
+    client_order_ids are stable across the preview and submit surfaces.
+    """
+    return {
+        "symbol": symbol,
+        "side": side,
+        "type": type,
+        "time_in_force": time_in_force,
+        "qty": str(qty) if qty is not None else None,
+        "notional": str(notional) if notional is not None else None,
+        "limit_price": str(limit_price) if limit_price is not None else None,
+        "asset_class": asset_class,
+    }
+
+
+def _canonical_blob(canonical: dict[str, Any]) -> bytes:
+    return json.dumps(canonical, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+def canonical_hash(canonical: dict[str, Any]) -> str:
+    """Full SHA-256 hex digest of the canonical payload (preview↔submit hash)."""
+    return hashlib.sha256(_canonical_blob(canonical)).hexdigest()
+
+
+def derive_client_order_id(canonical: dict[str, Any]) -> str:
+    """Deterministic server-derived client_order_id for a canonical payload.
+
+    Preserves the historical ``rob73-``/``rob74-crypto-`` prefixes and 16-char
+    digest so existing ledger rows and manual smoke ids remain compatible.
+
+    NOTE: this economics-only key is for the manual operator smoke tool. Automated
+    submits use ``derive_automated_key`` which folds in server-owned decision
+    identity so distinct decisions never collide on economics alone.
+    """
+    digest = canonical_hash(canonical)[:16]
+    prefix = "rob74-crypto" if canonical.get("asset_class") == "crypto" else "rob73"
+    return f"{prefix}-{digest}"
+
+
+def derive_automated_key(
+    *,
+    correlation_id: str,
+    snapshot_id: str | None,
+    canonical: dict[str, Any],
+) -> str:
+    """Server-owned idempotency key for an automated submit (ROB-842 blocker 4).
+
+    Folds the server-owned decision identity (correlation_id + snapshot_id) into
+    the key alongside the economic canonical. Two distinct decisions with identical
+    economics get different keys (no permanent collision); a retry of the *same*
+    decision gets the same key (dedup). The caller supplies correlation/snapshot as
+    decision identity but can never inject the final key directly.
+    """
+    identity = json.dumps(
+        {"c": correlation_id, "s": snapshot_id, "canonical": canonical},
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    digest = hashlib.sha256(identity).hexdigest()[:20]
+    prefix = "rob842a-crypto" if canonical.get("asset_class") == "crypto" else "rob842a"
+    return f"{prefix}-{digest}"
+
+
+_ASSET_CLASS_TO_INSTRUMENT: dict[str, InstrumentType] = {
+    "crypto": InstrumentType.crypto,
+    "us_equity": InstrumentType.equity_us,
+}
+
+
+def _instrument_type_for(asset_class: str | None) -> InstrumentType:
+    return _ASSET_CLASS_TO_INSTRUMENT.get(
+        asset_class or "us_equity", InstrumentType.equity_us
+    )
+
+
+# ---------------------------------------------------------------------------
+# Outcome
+# ---------------------------------------------------------------------------
+@dataclass(frozen=True)
+class SubmitOutcome:
+    """Result of routing one submit through the boundary.
+
+    status:
+        submitted                — this call won the claim and POSTed to the broker.
+        replayed                 — a prior completed submit's stored result is returned;
+                                   no broker call was made.
+        recovered                — an in-flight claim was reconciled from broker
+                                   evidence (submit had reached the broker but the DB
+                                   write was lost); booked without re-POSTing.
+        idempotency_in_progress  — another caller owns the in-flight submit; bounded
+                                   wait + broker reconcile found nothing to book; no
+                                   broker call.
+        rejected                 — packet/hash/key/order verification failed before any
+                                   claim; no broker call.
+    """
+
+    status: str
+    client_order_id: str
+    broker_called: bool
+    reason_code: str | None = None
+    order: dict[str, Any] | None = None
+    message: str | None = None
+
+    @property
+    def submitted(self) -> bool:
+        return self.status == "submitted"
+
+
+# ---------------------------------------------------------------------------
+# Coordinator
+# ---------------------------------------------------------------------------
+class AlpacaPaperSubmitCoordinator:
+    """Server-side submit boundary composing packet verify + claim + broker POST."""
+
+    def __init__(
+        self,
+        ledger: AlpacaPaperLedgerService,
+        broker_factory: BrokerFactory,
+        *,
+        now_fn: Callable[[], datetime] | None = None,
+        quote_max_age: timedelta = DEFAULT_QUOTE_MAX_AGE,
+        expected_account_mode: str = "alpaca_paper",
+        inflight_max_polls: int = DEFAULT_INFLIGHT_MAX_POLLS,
+        inflight_poll_interval_s: float = DEFAULT_INFLIGHT_POLL_INTERVAL_S,
+        sleep_fn: Callable[[float], Awaitable[None]] | None = None,
+    ) -> None:
+        self._ledger = ledger
+        self._broker_factory = broker_factory
+        self._now_fn = now_fn or (lambda: datetime.now(UTC))
+        self._quote_max_age = quote_max_age
+        self._expected_account_mode = expected_account_mode
+        self._inflight_max_polls = max(1, int(inflight_max_polls))
+        self._inflight_poll_interval_s = float(inflight_poll_interval_s)
+        self._sleep_fn = sleep_fn or asyncio.sleep
+
+    async def submit(
+        self,
+        packet: PaperApprovalPacket,
+        *,
+        submit_canonical: dict[str, Any],
+        caller_client_order_id: str | None = None,
+    ) -> SubmitOutcome:
+        """Verify, claim and (for the winner only) submit the packet's order."""
+        coid = packet.client_order_id
+
+        # --- Fail-close verification (all before any claim / broker call) -------
+        try:
+            server_key = derive_automated_key(
+                correlation_id=packet.lifecycle_correlation_id,
+                snapshot_id=packet.snapshot_id,
+                canonical=submit_canonical,
+            )
+            verify_server_derived_key(
+                packet,
+                server_key=server_key,
+                caller_client_order_id=caller_client_order_id,
+            )
+            verify_order_within_packet(packet, submit_canonical)
+            verify_preview_submit_hash(
+                packet, submit_hash=canonical_hash(submit_canonical)
+            )
+            now = self._now_fn()
+            verify_packet_freshness(packet, now=now)
+            verify_packet_market_data(packet, now=now, max_age=self._quote_max_age)
+            verify_packet_account_mode(packet, expected=self._expected_account_mode)
+            await verify_sell_packet_source(packet, ledger=self._ledger)
+        except PaperApprovalPacketError as exc:
+            return SubmitOutcome(
+                status="rejected",
+                client_order_id=coid,
+                broker_called=False,
+                reason_code=exc.code,
+                message=str(exc),
+            )
+
+        # --- Idempotency fast-path (avoid a claim attempt when possible) --------
+        # Force a fresh READ COMMITTED snapshot: the session uses
+        # expire_on_commit=False, so a prior same-session submit's committed row
+        # would otherwise be read back stale from the identity map.
+        self._ledger.session.expire_all()
+        existing = await self._ledger.find_executed_by_client_order_id(coid)
+        if existing is not None:
+            if is_inflight_execution(existing):
+                return await self._resolve_inflight(coid)
+            return self._replay_outcome(existing)
+
+        # --- Atomic claim: only the winner POSTs to the broker ------------------
+        claim = await self._ledger.claim_submit(
+            client_order_id=coid,
+            lifecycle_correlation_id=packet.lifecycle_correlation_id,
+            execution_symbol=packet.execution_symbol,
+            execution_venue=packet.execution_venue,
+            instrument_type=_instrument_type_for(packet.execution_asset_class),
+            side=packet.side,
+            order_type=str(submit_canonical.get("type") or "limit"),
+            time_in_force=submit_canonical.get("time_in_force"),
+            requested_qty=_to_decimal(submit_canonical.get("qty")),
+            requested_notional=_to_decimal(submit_canonical.get("notional")),
+            requested_price=_to_decimal(submit_canonical.get("limit_price")),
+            preview_payload=dict(submit_canonical),
+        )
+        if not claim.won:
+            row = claim.row
+            if row is not None and not is_inflight_execution(row):
+                return self._replay_outcome(row)
+            return await self._resolve_inflight(coid)
+
+        # --- Winner: exactly one broker HTTP submit -----------------------------
+        broker = self._broker_factory()
+        request = OrderRequest(
+            symbol=submit_canonical["symbol"],
+            side=submit_canonical["side"],
+            type=submit_canonical["type"],
+            qty=_to_decimal(submit_canonical.get("qty")),
+            notional=_to_decimal(submit_canonical.get("notional")),
+            time_in_force=submit_canonical.get("time_in_force") or "day",
+            limit_price=_to_decimal(submit_canonical.get("limit_price")),
+            stop_price=None,
+            client_order_id=coid,
+        )
+        order = await broker.submit_order(request)
+        order_dict = _order_to_dict(order)
+        await self._ledger.record_submit(coid, order_dict, raw_response=order_dict)
+        return SubmitOutcome(
+            status="submitted",
+            client_order_id=coid,
+            broker_called=True,
+            order=order_dict,
+        )
+
+    # ------------------------------------------------------------------
+    async def _resolve_inflight(self, client_order_id: str) -> SubmitOutcome:
+        """Resolve an in-flight claim without ever re-POSTing.
+
+        1. Bounded local wait for a concurrent winner's committed record_submit.
+        2. If still unresolved, reconcile against the broker by client_order_id —
+           a submit that reached the broker but crashed before the DB write is
+           recovered here (booked from broker evidence), so it never stays
+           permanently ``idempotency_in_progress``.
+        3. Only if the broker has no such order do we return in-progress.
+        """
+        for _ in range(self._inflight_max_polls):
+            # New READ COMMITTED snapshot each poll so a concurrent winner's
+            # committed record_submit becomes visible.
+            self._ledger.session.expire_all()
+            row = await self._ledger.find_executed_by_client_order_id(client_order_id)
+            if row is not None and not is_inflight_execution(row):
+                return self._replay_outcome(row)
+            await self._sleep_fn(self._inflight_poll_interval_s)
+
+        recovered = await self._reconcile_inflight_via_broker(client_order_id)
+        if recovered is not None:
+            return recovered
+
+        return SubmitOutcome(
+            status="idempotency_in_progress",
+            client_order_id=client_order_id,
+            broker_called=False,
+            reason_code="idempotency_in_progress",
+            message="another caller owns the in-flight submit for this intent",
+        )
+
+    async def _reconcile_inflight_via_broker(
+        self, client_order_id: str
+    ) -> SubmitOutcome | None:
+        """Book a crashed-after-success submit from broker evidence. Never POSTs.
+
+        Returns a ``recovered`` outcome if the broker has an order for this
+        client_order_id (submit succeeded but the DB write was lost), else None.
+        """
+        broker = self._broker_factory()
+        getter = getattr(broker, "get_order_by_client_order_id", None)
+        if getter is None:
+            return None
+        order = await getter(client_order_id)
+        if order is None:
+            return None
+        order_dict = _order_to_dict(order)
+        await self._ledger.record_submit(
+            client_order_id, order_dict, raw_response=order_dict
+        )
+        return SubmitOutcome(
+            status="recovered",
+            client_order_id=client_order_id,
+            broker_called=False,
+            reason_code="recovered_via_broker_lookup",
+            order=order_dict,
+            message="crashed-after-success submit recovered from broker evidence",
+        )
+
+    def _replay_outcome(self, row: Any) -> SubmitOutcome:
+        stored = None
+        raw = getattr(row, "raw_responses", None)
+        if isinstance(raw, dict):
+            stored = raw.get("submit")
+        return SubmitOutcome(
+            status="replayed",
+            client_order_id=str(getattr(row, "client_order_id", "")),
+            broker_called=False,
+            reason_code="duplicate_submit_replayed",
+            order=stored,
+            message=(
+                f"replayed stored submit result in state "
+                f"{getattr(row, 'lifecycle_state', None)!r}"
+            ),
+        )
+
+
+def _to_decimal(value: Any) -> Decimal | None:
+    if value is None:
+        return None
+    if isinstance(value, Decimal):
+        return value
+    try:
+        return Decimal(str(value))
+    except Exception:
+        return None
+
+
+def _order_to_dict(order: Any) -> dict[str, Any]:
+    if hasattr(order, "model_dump"):
+        return order.model_dump(mode="json")
+    if isinstance(order, dict):
+        return order
+    raise TypeError(f"unexpected broker order type: {type(order)!r}")
+
+
+__all__ = [
+    "AlpacaPaperSubmitCoordinator",
+    "BrokerFactory",
+    "DEFAULT_INFLIGHT_MAX_POLLS",
+    "DEFAULT_INFLIGHT_POLL_INTERVAL_S",
+    "DEFAULT_QUOTE_MAX_AGE",
+    "SubmitOutcome",
+    "build_canonical_payload",
+    "canonical_hash",
+    "derive_automated_key",
+    "derive_client_order_id",
+]

--- a/app/services/alpaca_paper_submit_service.py
+++ b/app/services/alpaca_paper_submit_service.py
@@ -30,8 +30,11 @@ from typing import TYPE_CHECKING, Any
 
 from app.models.trading import InstrumentType
 from app.services.alpaca_paper_ledger_service import (
+    KNOWN_OPEN_BROKER_STATUSES,
+    LIFECYCLE_SUBMITTED,
     AlpacaPaperLedgerService,
     is_inflight_execution,
+    normalize_known_broker_order_status,
 )
 from app.services.brokers.alpaca.exceptions import AlpacaPaperRequestError
 from app.services.brokers.alpaca.schemas import OrderRequest
@@ -366,71 +369,122 @@ class AlpacaPaperSubmitCoordinator:
                 packet, "position_unavailable", "broker cannot read positions"
             )
 
-        # H2: sync existing OPEN submitted sells to broker truth BEFORE computing
-        # availability, so a row that has since filled/canceled at the broker stops
-        # (or keeps) consuming sellable position correctly. Fail-close: a broker
-        # error / unknown / unparseable status leaves the reservation in place.
-        await self._reconcile_open_sells(packet, broker)
-
-        broker_symbol = _broker_position_symbol(packet.execution_symbol)
         try:
-            position = await getter(broker_symbol)
-        except AlpacaPaperRequestError as exc:
-            return self._sell_reject(
-                packet,
-                "position_unavailable",
-                f"position read failed (HTTP {getattr(exc, 'status_code', None)})",
-            )
-        if position is None:
-            return self._sell_reject(
-                packet, "position_flat", "no current position to sell"
-            )
-        if not _symbols_match(
-            getattr(position, "symbol", None), packet.execution_symbol
-        ):
-            return self._sell_reject(
-                packet,
-                "position_symbol_mismatch",
-                f"position symbol {getattr(position, 'symbol', None)!r} != {packet.execution_symbol!r}",
-            )
-        pos_qty = _to_decimal(getattr(position, "qty", None))
-        if pos_qty is None or not pos_qty.is_finite():
-            return self._sell_reject(
-                packet, "position_malformed", "position qty missing/non-finite"
-            )
-        if pos_qty <= 0:
-            return self._sell_reject(
-                packet, "position_flat", "current position qty is non-positive"
+            # Serialize broker evidence, lifecycle transitions, availability and
+            # the new claim under one account+symbol transaction lock.
+            await self._ledger.acquire_sell_reservation_lock(
+                account_mode=packet.account_mode,
+                execution_symbol=packet.execution_symbol,
             )
 
-        claim = await self._ledger.reserve_sell_and_claim(
-            client_order_id=coid,
-            lifecycle_correlation_id=packet.lifecycle_correlation_id,
-            execution_symbol=packet.execution_symbol,
-            execution_venue=packet.execution_venue,
-            instrument_type=_instrument_type_for(packet.execution_asset_class),
-            account_mode=packet.account_mode,
-            requested_qty=requested,
-            position_qty=pos_qty,
-            order_type=str(submit_canonical.get("type") or "limit"),
-            time_in_force=submit_canonical.get("time_in_force"),
-            requested_price=_to_decimal(submit_canonical.get("limit_price")),
-            preview_payload=dict(submit_canonical),
-        )
-        if claim.insufficient:
-            return self._sell_reject(
-                packet,
-                "qty_exceeds_available",
-                f"sell qty {requested} exceeds available {claim.available} "
-                f"(position {pos_qty} minus reserved open sells)",
-            )
-        if not claim.won:
-            row = claim.row
-            if row is not None and not is_inflight_execution(row):
-                return self._resolved_outcome(row)
-            return await self._resolve_inflight(coid)
+            status_evidence = await self._load_open_sell_statuses(packet, broker)
+            broker_symbol = _broker_position_symbol(packet.execution_symbol)
+            try:
+                position = await getter(broker_symbol)
+            except AlpacaPaperRequestError as exc:
+                return self._sell_reject(
+                    packet,
+                    "position_unavailable",
+                    f"position read failed (HTTP {getattr(exc, 'status_code', None)})",
+                )
+            if position is None:
+                causal = await self._stage_causally_safe_statuses(
+                    status_evidence,
+                    position_qty=Decimal("0"),
+                    position_available=Decimal("0"),
+                )
+                if not causal:
+                    return self._sell_reject(
+                        packet,
+                        "position_reconciliation_pending",
+                        "flat position cannot reconcile a filled sell without baseline evidence",
+                    )
+                await self._ledger.session.commit()
+                return self._sell_reject(
+                    packet, "position_flat", "no current position to sell"
+                )
+            if not _symbols_match(
+                getattr(position, "symbol", None), packet.execution_symbol
+            ):
+                return self._sell_reject(
+                    packet,
+                    "position_symbol_mismatch",
+                    f"position symbol {getattr(position, 'symbol', None)!r} != {packet.execution_symbol!r}",
+                )
+            pos_qty = _to_decimal(getattr(position, "qty", None))
+            if pos_qty is None or not pos_qty.is_finite():
+                return self._sell_reject(
+                    packet, "position_malformed", "position qty missing/non-finite"
+                )
+            if pos_qty <= 0:
+                return self._sell_reject(
+                    packet, "position_flat", "current position qty is non-positive"
+                )
 
-        return await self._winner_submit(packet, submit_canonical)
+            raw_available = getattr(position, "qty_available", None)
+            if raw_available is None:
+                return self._sell_reject(
+                    packet,
+                    "position_available_unavailable",
+                    "position qty_available is required for a sell",
+                )
+            pos_available = _to_decimal(raw_available)
+            if (
+                pos_available is None
+                or not pos_available.is_finite()
+                or pos_available < 0
+            ):
+                return self._sell_reject(
+                    packet,
+                    "position_available_malformed",
+                    "position qty_available is non-finite or negative",
+                )
+
+            causal = await self._stage_causally_safe_statuses(
+                status_evidence,
+                position_qty=pos_qty,
+                position_available=pos_available,
+            )
+            if not causal:
+                return self._sell_reject(
+                    packet,
+                    "position_reconciliation_pending",
+                    "filled sell is not yet reflected in broker position evidence",
+                )
+
+            claim = await self._ledger.reserve_sell_and_claim(
+                client_order_id=coid,
+                lifecycle_correlation_id=packet.lifecycle_correlation_id,
+                execution_symbol=packet.execution_symbol,
+                execution_venue=packet.execution_venue,
+                instrument_type=_instrument_type_for(packet.execution_asset_class),
+                account_mode=packet.account_mode,
+                requested_qty=requested,
+                position_qty=pos_qty,
+                position_available=pos_available,
+                order_type=str(submit_canonical.get("type") or "limit"),
+                time_in_force=submit_canonical.get("time_in_force"),
+                requested_price=_to_decimal(submit_canonical.get("limit_price")),
+                preview_payload=dict(submit_canonical),
+            )
+            if claim.insufficient:
+                return self._sell_reject(
+                    packet,
+                    "qty_exceeds_available",
+                    f"sell qty {requested} exceeds available {claim.available} "
+                    f"(position {pos_qty}, broker available {pos_available}, "
+                    "minus reserved open sells)",
+                )
+            if not claim.won:
+                row = claim.row
+                if row is not None and not is_inflight_execution(row):
+                    return self._resolved_outcome(row)
+                return await self._resolve_inflight(coid)
+
+            return await self._winner_submit(packet, submit_canonical)
+        finally:
+            if self._ledger.session.in_transaction():
+                await self._ledger.session.rollback()
 
     async def _winner_submit(
         self, packet: PaperApprovalPacket, submit_canonical: dict[str, Any]
@@ -510,7 +564,19 @@ class AlpacaPaperSubmitCoordinator:
             return await self._resolve_uncertain(coid)
 
         order_dict = _order_to_dict(order)
-        await self._ledger.record_submit(coid, order_dict, raw_response=order_dict)
+        normalized_status = normalize_known_broker_order_status(
+            order_dict.get("status")
+        )
+        await self._ledger.record_submit(
+            coid,
+            order_dict,
+            raw_response=order_dict,
+            lifecycle_state_override=(
+                LIFECYCLE_SUBMITTED
+                if packet.side == "sell" and normalized_status == "filled"
+                else None
+            ),
+        )
         return SubmitOutcome(
             status="submitted",
             client_order_id=coid,
@@ -518,22 +584,20 @@ class AlpacaPaperSubmitCoordinator:
             order=order_dict,
         )
 
-    async def _reconcile_open_sells(
+    async def _load_open_sell_statuses(
         self, packet: PaperApprovalPacket, broker: Any
-    ) -> None:
-        """Refresh OPEN submitted sells for this account+symbol from broker truth.
+    ) -> list[tuple[Any, dict[str, Any], str]]:
+        """Load only recognized broker statuses for currently reserved sells.
 
-        For each open sell, look it up by client_order_id and record the broker
-        status into the ledger. A terminal broker status (filled/canceled/rejected/
-        expired) transitions the row out of ``submitted`` (releasing its hold);
-        an open status keeps it reserved. Any broker error / missing / unparseable
-        status is skipped, leaving the reservation intact (fail-close). This runs
-        before the reservation lock and is idempotent, so concurrent sells converge
-        to the same truth without breaking the account+symbol serialization.
+        For each open sell, look it up by client_order_id and retain only explicitly
+        recognized statuses. Broker error / missing / unknown / unparseable status
+        is skipped, leaving the reservation intact. The caller later applies known
+        terminal transitions only after validating position evidence under the
+        account+symbol lock.
         """
         getter = getattr(broker, "get_order_by_client_order_id", None)
         if getter is None:
-            return
+            return []
         self._ledger.session.expire_all()
         try:
             open_rows = await self._ledger.list_open_sells(
@@ -541,7 +605,8 @@ class AlpacaPaperSubmitCoordinator:
                 execution_symbol=packet.execution_symbol,
             )
         except Exception:  # noqa: BLE001 - keep reservations on read failure
-            return
+            return []
+        evidence: list[tuple[Any, dict[str, Any], str]] = []
         for row in open_rows:
             coid = getattr(row, "client_order_id", None)
             if not coid:
@@ -552,13 +617,44 @@ class AlpacaPaperSubmitCoordinator:
                 continue  # broker error -> keep reserved (fail-close)
             if order is None:
                 continue  # unknown at broker -> keep reserved (fail-close)
-            order_dict = _order_to_dict(order)
-            if order_dict.get("status") is None:
-                continue  # unparseable status -> keep reserved
             try:
-                await self._ledger.record_status(coid, order_dict)
-            except Exception:  # noqa: BLE001 - keep reserved on write failure
+                order_dict = _order_to_dict(order)
+            except (TypeError, ValueError):
                 continue
+            normalized_status = normalize_known_broker_order_status(
+                order_dict.get("status")
+            )
+            if normalized_status is None:
+                continue  # unknown/unparseable status -> keep reserved
+            order_dict["status"] = normalized_status
+            evidence.append((row, order_dict, normalized_status))
+        return evidence
+
+    async def _stage_causally_safe_statuses(
+        self,
+        evidence: list[tuple[Any, dict[str, Any], str]],
+        *,
+        position_qty: Decimal,
+        position_available: Decimal,
+    ) -> bool:
+        """Stage terminal transitions without releasing an unreflected fill."""
+        for row, order_dict, status in evidence:
+            if status in KNOWN_OPEN_BROKER_STATUSES:
+                continue
+            if status == "filled" and not _filled_is_reflected(
+                row,
+                order_dict,
+                position_qty=position_qty,
+                position_available=position_available,
+            ):
+                return False
+            try:
+                await self._ledger.record_status(
+                    row.client_order_id, order_dict, commit=False
+                )
+            except Exception:  # noqa: BLE001 - rollback keeps every hold fail-closed
+                return False
+        return True
 
     def _sell_reject(
         self, packet: PaperApprovalPacket, code: str, message: str
@@ -690,6 +786,40 @@ def _to_decimal(value: Any) -> Decimal | None:
         return Decimal(str(value))
     except Exception:
         return None
+
+
+def _filled_is_reflected(
+    row: Any,
+    order: dict[str, Any],
+    *,
+    position_qty: Decimal,
+    position_available: Decimal,
+) -> bool:
+    """Prove a newly-filled sell is reflected relative to its claim baseline."""
+    filled_qty = _to_decimal(order.get("filled_qty") or order.get("filled_quantity"))
+    snapshot = getattr(row, "position_snapshot", None)
+    if (
+        filled_qty is None
+        or not filled_qty.is_finite()
+        or filled_qty <= 0
+        or not isinstance(snapshot, dict)
+        or snapshot.get("snapshot_kind") != "sell_claim_baseline"
+    ):
+        return False
+    baseline_qty = _to_decimal(snapshot.get("qty"))
+    baseline_available = _to_decimal(snapshot.get("qty_available"))
+    if (
+        baseline_qty is None
+        or baseline_available is None
+        or not baseline_qty.is_finite()
+        or not baseline_available.is_finite()
+    ):
+        return False
+    reflected_qty = baseline_qty - filled_qty
+    reflected_available = baseline_available - filled_qty
+    if reflected_qty < 0 or reflected_available < 0:
+        return False
+    return position_qty <= reflected_qty and position_available <= reflected_available
 
 
 def _normalize_symbol(symbol: str | None) -> str:

--- a/app/services/alpaca_paper_submit_service.py
+++ b/app/services/alpaca_paper_submit_service.py
@@ -365,6 +365,13 @@ class AlpacaPaperSubmitCoordinator:
             return self._sell_reject(
                 packet, "position_unavailable", "broker cannot read positions"
             )
+
+        # H2: sync existing OPEN submitted sells to broker truth BEFORE computing
+        # availability, so a row that has since filled/canceled at the broker stops
+        # (or keeps) consuming sellable position correctly. Fail-close: a broker
+        # error / unknown / unparseable status leaves the reservation in place.
+        await self._reconcile_open_sells(packet, broker)
+
         broker_symbol = _broker_position_symbol(packet.execution_symbol)
         try:
             position = await getter(broker_symbol)
@@ -510,6 +517,48 @@ class AlpacaPaperSubmitCoordinator:
             broker_called=True,
             order=order_dict,
         )
+
+    async def _reconcile_open_sells(
+        self, packet: PaperApprovalPacket, broker: Any
+    ) -> None:
+        """Refresh OPEN submitted sells for this account+symbol from broker truth.
+
+        For each open sell, look it up by client_order_id and record the broker
+        status into the ledger. A terminal broker status (filled/canceled/rejected/
+        expired) transitions the row out of ``submitted`` (releasing its hold);
+        an open status keeps it reserved. Any broker error / missing / unparseable
+        status is skipped, leaving the reservation intact (fail-close). This runs
+        before the reservation lock and is idempotent, so concurrent sells converge
+        to the same truth without breaking the account+symbol serialization.
+        """
+        getter = getattr(broker, "get_order_by_client_order_id", None)
+        if getter is None:
+            return
+        self._ledger.session.expire_all()
+        try:
+            open_rows = await self._ledger.list_open_sells(
+                account_mode=packet.account_mode,
+                execution_symbol=packet.execution_symbol,
+            )
+        except Exception:  # noqa: BLE001 - keep reservations on read failure
+            return
+        for row in open_rows:
+            coid = getattr(row, "client_order_id", None)
+            if not coid:
+                continue
+            try:
+                order = await getter(coid)
+            except AlpacaPaperRequestError:
+                continue  # broker error -> keep reserved (fail-close)
+            if order is None:
+                continue  # unknown at broker -> keep reserved (fail-close)
+            order_dict = _order_to_dict(order)
+            if order_dict.get("status") is None:
+                continue  # unparseable status -> keep reserved
+            try:
+                await self._ledger.record_status(coid, order_dict)
+            except Exception:  # noqa: BLE001 - keep reserved on write failure
+                continue
 
     def _sell_reject(
         self, packet: PaperApprovalPacket, code: str, message: str

--- a/app/services/alpaca_paper_submit_service.py
+++ b/app/services/alpaca_paper_submit_service.py
@@ -33,6 +33,7 @@ from app.services.alpaca_paper_ledger_service import (
     AlpacaPaperLedgerService,
     is_inflight_execution,
 )
+from app.services.brokers.alpaca.exceptions import AlpacaPaperRequestError
 from app.services.brokers.alpaca.schemas import OrderRequest
 from app.services.paper_approval_packet import (
     PaperApprovalPacket,
@@ -209,6 +210,22 @@ class AlpacaPaperSubmitCoordinator:
         self._inflight_poll_interval_s = float(inflight_poll_interval_s)
         self._sleep_fn = sleep_fn or asyncio.sleep
 
+    def _server_key_for(
+        self, packet: PaperApprovalPacket, canonical: dict[str, Any]
+    ) -> str:
+        """Origin-aware server-derived claim key.
+
+        Automated submits fold server-owned decision identity into the key;
+        manual operator submits use the economics-only key.
+        """
+        if packet.origin == "automated":
+            return derive_automated_key(
+                correlation_id=packet.lifecycle_correlation_id,
+                snapshot_id=packet.snapshot_id,
+                canonical=canonical,
+            )
+        return derive_client_order_id(canonical)
+
     async def submit(
         self,
         packet: PaperApprovalPacket,
@@ -216,16 +233,19 @@ class AlpacaPaperSubmitCoordinator:
         submit_canonical: dict[str, Any],
         caller_client_order_id: str | None = None,
     ) -> SubmitOutcome:
-        """Verify, claim and (for the winner only) submit the packet's order."""
+        """Verify, claim and (for the winner only) submit the packet's order.
+
+        This is the single boundary every real broker POST passes through —
+        manual and automated alike. Duplicate intents (sequential or concurrent)
+        POST exactly once; everyone else replays the winner's success, replays a
+        terminal failure, recovers a crashed-after-success submit, or ends
+        in-flight — never a second POST.
+        """
         coid = packet.client_order_id
 
-        # --- Fail-close verification (all before any claim / broker call) -------
+        # --- Fail-close pure verification (idempotent; safe for duplicates) -----
         try:
-            server_key = derive_automated_key(
-                correlation_id=packet.lifecycle_correlation_id,
-                snapshot_id=packet.snapshot_id,
-                canonical=submit_canonical,
-            )
+            server_key = self._server_key_for(packet, submit_canonical)
             verify_server_derived_key(
                 packet,
                 server_key=server_key,
@@ -237,9 +257,13 @@ class AlpacaPaperSubmitCoordinator:
             )
             now = self._now_fn()
             verify_packet_freshness(packet, now=now)
-            verify_packet_market_data(packet, now=now, max_age=self._quote_max_age)
+            if packet.origin == "automated":
+                verify_packet_market_data(packet, now=now, max_age=self._quote_max_age)
             verify_packet_account_mode(packet, expected=self._expected_account_mode)
-            await verify_sell_packet_source(packet, ledger=self._ledger)
+            if packet.origin == "automated":
+                # Ledger buy-source provenance is an automated-cohort gate. Manual
+                # operator sells rely on the fresh live-position check below.
+                await verify_sell_packet_source(packet, ledger=self._ledger)
         except PaperApprovalPacketError as exc:
             return SubmitOutcome(
                 status="rejected",
@@ -249,16 +273,27 @@ class AlpacaPaperSubmitCoordinator:
                 message=str(exc),
             )
 
-        # --- Idempotency fast-path (avoid a claim attempt when possible) --------
+        # --- Idempotency fast-path (resolve a prior outcome before any claim) ---
         # Force a fresh READ COMMITTED snapshot: the session uses
         # expire_on_commit=False, so a prior same-session submit's committed row
         # would otherwise be read back stale from the identity map.
         self._ledger.session.expire_all()
-        existing = await self._ledger.find_executed_by_client_order_id(coid)
+        existing = await self._ledger.get_execution_by_client_order_id(coid)
         if existing is not None:
             if is_inflight_execution(existing):
                 return await self._resolve_inflight(coid)
-            return self._replay_outcome(existing)
+            return self._resolved_outcome(existing)
+
+        # --- Sell preflight: fresh current-position evidence (NEW intent only) --
+        # Runs after the fast-path so a duplicate of a filled sell replays instead
+        # of being re-validated against a now-reduced position. Before the claim so
+        # a transient position issue never burns the idempotency key.
+        if packet.side == "sell":
+            sell_reject = await self._check_sell_current_position(
+                packet, submit_canonical
+            )
+            if sell_reject is not None:
+                return sell_reject
 
         # --- Atomic claim: only the winner POSTs to the broker ------------------
         claim = await self._ledger.claim_submit(
@@ -278,10 +313,15 @@ class AlpacaPaperSubmitCoordinator:
         if not claim.won:
             row = claim.row
             if row is not None and not is_inflight_execution(row):
-                return self._replay_outcome(row)
+                return self._resolved_outcome(row)
             return await self._resolve_inflight(coid)
 
         # --- Winner: exactly one broker HTTP submit -----------------------------
+        return await self._winner_submit(coid, submit_canonical)
+
+    async def _winner_submit(
+        self, coid: str, submit_canonical: dict[str, Any]
+    ) -> SubmitOutcome:
         broker = self._broker_factory()
         request = OrderRequest(
             symbol=submit_canonical["symbol"],
@@ -294,7 +334,40 @@ class AlpacaPaperSubmitCoordinator:
             stop_price=None,
             client_order_id=coid,
         )
-        order = await broker.submit_order(request)
+        try:
+            order = await broker.submit_order(request)
+        except AlpacaPaperRequestError as exc:
+            status = getattr(exc, "status_code", None)
+            if status is not None and 400 <= status < 500:
+                # Deterministic client rejection — terminal. Book it so retries
+                # replay the failure instead of re-POSTing.
+                try:
+                    await self._ledger.record_submit_failure(
+                        coid,
+                        order_status="rejected",
+                        error_summary=f"broker_rejected: HTTP {status}",
+                    )
+                except Exception:  # noqa: BLE001 - persistence best-effort
+                    # Even if we cannot persist the terminal outcome, the in-flight
+                    # claim row blocks any re-POST (retries end in-flight).
+                    return SubmitOutcome(
+                        status="failed",
+                        client_order_id=coid,
+                        broker_called=True,
+                        reason_code="broker_rejected_unpersisted",
+                        message=f"broker rejected (HTTP {status}); terminal record failed",
+                    )
+                return SubmitOutcome(
+                    status="failed",
+                    client_order_id=coid,
+                    broker_called=True,
+                    reason_code="broker_rejected",
+                    message=f"broker rejected the order (HTTP {status})",
+                )
+            # Uncertain outcome (5xx / connection): the order may or may not exist.
+            # Reconcile by client_order_id; never re-POST.
+            return await self._resolve_uncertain(coid)
+
         order_dict = _order_to_dict(order)
         await self._ledger.record_submit(coid, order_dict, raw_response=order_dict)
         return SubmitOutcome(
@@ -302,6 +375,98 @@ class AlpacaPaperSubmitCoordinator:
             client_order_id=coid,
             broker_called=True,
             order=order_dict,
+        )
+
+    async def _check_sell_current_position(
+        self, packet: PaperApprovalPacket, submit_canonical: dict[str, Any]
+    ) -> SubmitOutcome | None:
+        """Fail-close a sell unless a fresh Alpaca position covers the qty.
+
+        Past ledger fills are provenance only; the sellable quantity is the
+        broker's *current* position, re-read here right before the claim/POST.
+        Returns a rejected outcome, or None when the sell is covered.
+        """
+        requested = _to_decimal(submit_canonical.get("qty"))
+        if requested is None or not requested.is_finite() or requested <= 0:
+            return self._sell_reject(
+                packet, "sell_qty_invalid", "sell qty missing or non-positive"
+            )
+
+        broker = self._broker_factory()
+        getter = getattr(broker, "get_position", None)
+        if getter is None:  # pragma: no cover - defensive
+            return self._sell_reject(
+                packet, "position_unavailable", "broker cannot read positions"
+            )
+
+        broker_symbol = _broker_position_symbol(packet.execution_symbol)
+        try:
+            position = await getter(broker_symbol)
+        except AlpacaPaperRequestError as exc:
+            return self._sell_reject(
+                packet,
+                "position_unavailable",
+                f"position read failed (HTTP {getattr(exc, 'status_code', None)})",
+            )
+        if position is None:
+            return self._sell_reject(
+                packet, "position_flat", "no current position to sell"
+            )
+
+        if not _symbols_match(
+            getattr(position, "symbol", None), packet.execution_symbol
+        ):
+            return self._sell_reject(
+                packet,
+                "position_symbol_mismatch",
+                f"position symbol {getattr(position, 'symbol', None)!r} != {packet.execution_symbol!r}",
+            )
+
+        available = _to_decimal(getattr(position, "qty", None))
+        if available is None or not available.is_finite():
+            return self._sell_reject(
+                packet, "position_malformed", "position qty missing/non-finite"
+            )
+        if available <= 0:
+            return self._sell_reject(
+                packet, "position_flat", "current position qty is non-positive"
+            )
+        if requested > available:
+            return self._sell_reject(
+                packet,
+                "qty_exceeds_position",
+                f"sell qty {requested} exceeds current position {available}",
+            )
+        if packet.max_qty is not None and requested > packet.max_qty:
+            return self._sell_reject(
+                packet,
+                "qty_exceeds_max",
+                f"sell qty {requested} exceeds ceiling {packet.max_qty}",
+            )
+        return None
+
+    def _sell_reject(
+        self, packet: PaperApprovalPacket, code: str, message: str
+    ) -> SubmitOutcome:
+        return SubmitOutcome(
+            status="rejected",
+            client_order_id=packet.client_order_id,
+            broker_called=False,
+            reason_code=code,
+            message=message,
+        )
+
+    async def _resolve_uncertain(self, client_order_id: str) -> SubmitOutcome:
+        """Reconcile an uncertain winner outcome (5xx/timeout). Never re-POSTs."""
+        recovered = await self._reconcile_inflight_via_broker(client_order_id)
+        if recovered is not None:
+            return recovered
+        return SubmitOutcome(
+            status="idempotency_in_progress",
+            client_order_id=client_order_id,
+            broker_called=True,
+            reason_code="idempotency_in_progress",
+            message="submit outcome uncertain; broker has no order yet — not re-POSTing",
         )
 
     # ------------------------------------------------------------------
@@ -317,11 +482,11 @@ class AlpacaPaperSubmitCoordinator:
         """
         for _ in range(self._inflight_max_polls):
             # New READ COMMITTED snapshot each poll so a concurrent winner's
-            # committed record_submit becomes visible.
+            # committed record_submit / record_submit_failure becomes visible.
             self._ledger.session.expire_all()
-            row = await self._ledger.find_executed_by_client_order_id(client_order_id)
+            row = await self._ledger.get_execution_by_client_order_id(client_order_id)
             if row is not None and not is_inflight_execution(row):
-                return self._replay_outcome(row)
+                return self._resolved_outcome(row)
             await self._sleep_fn(self._inflight_poll_interval_s)
 
         recovered = await self._reconcile_inflight_via_broker(client_order_id)
@@ -364,6 +529,25 @@ class AlpacaPaperSubmitCoordinator:
             message="crashed-after-success submit recovered from broker evidence",
         )
 
+    def _resolved_outcome(self, row: Any) -> SubmitOutcome:
+        """Map an already-resolved execution row to a replay outcome.
+
+        A terminal ``anomaly`` row replays the deterministic broker failure; any
+        other resolved row replays the stored success.
+        """
+        state = str(getattr(row, "lifecycle_state", "") or "")
+        coid = str(getattr(row, "client_order_id", ""))
+        if state == "anomaly":
+            return SubmitOutcome(
+                status="failed",
+                client_order_id=coid,
+                broker_called=False,
+                reason_code="broker_rejected_replayed",
+                order=None,
+                message=str(getattr(row, "error_summary", None) or "terminal failure"),
+            )
+        return self._replay_outcome(row)
+
     def _replay_outcome(self, row: Any) -> SubmitOutcome:
         stored = None
         raw = getattr(row, "raw_responses", None)
@@ -391,6 +575,19 @@ def _to_decimal(value: Any) -> Decimal | None:
         return Decimal(str(value))
     except Exception:
         return None
+
+
+def _normalize_symbol(symbol: str | None) -> str:
+    return (symbol or "").replace("/", "").replace("-", "").strip().upper()
+
+
+def _symbols_match(a: str | None, b: str | None) -> bool:
+    return _normalize_symbol(a) == _normalize_symbol(b) and _normalize_symbol(a) != ""
+
+
+def _broker_position_symbol(execution_symbol: str) -> str:
+    """Alpaca positions key crypto by the slashless symbol (BTC/USD -> BTCUSD)."""
+    return (execution_symbol or "").replace("/", "").strip()
 
 
 def _order_to_dict(order: Any) -> dict[str, Any]:

--- a/app/services/alpaca_paper_submit_service.py
+++ b/app/services/alpaca_paper_submit_service.py
@@ -43,7 +43,6 @@ from app.services.paper_approval_packet import (
     verify_packet_freshness,
     verify_packet_market_data,
     verify_preview_submit_hash,
-    verify_sell_packet_source,
     verify_server_derived_key,
 )
 
@@ -57,6 +56,9 @@ DEFAULT_QUOTE_MAX_AGE = timedelta(minutes=5)
 # Default bounded wait for an in-flight winner before returning in-progress.
 DEFAULT_INFLIGHT_MAX_POLLS = 3
 DEFAULT_INFLIGHT_POLL_INTERVAL_S = 0.05
+
+# ROB-842 public success contract — only these statuses are a success.
+SUCCESS_STATUSES: frozenset[str] = frozenset({"submitted", "replayed", "recovered"})
 
 
 # ---------------------------------------------------------------------------
@@ -182,6 +184,13 @@ class SubmitOutcome:
     def submitted(self) -> bool:
         return self.status == "submitted"
 
+    @property
+    def success(self) -> bool:
+        """Public success contract: a real broker-side success or a faithful
+        replay/recovery of one. failed / rejected / idempotency_in_progress are
+        NOT success."""
+        return self.status in SUCCESS_STATUSES
+
 
 # ---------------------------------------------------------------------------
 # Coordinator
@@ -243,7 +252,10 @@ class AlpacaPaperSubmitCoordinator:
         """
         coid = packet.client_order_id
 
-        # --- Fail-close pure verification (idempotent; safe for duplicates) -----
+        # --- (1) Immutable binding checks — time-independent, run for ALL calls --
+        # token/key/hash/account binding must pass before we replay OR reject, so a
+        # tampered duplicate never replays and a valid duplicate never gets a
+        # time-dependent rejection.
         try:
             server_key = self._server_key_for(packet, submit_canonical)
             verify_server_derived_key(
@@ -255,15 +267,7 @@ class AlpacaPaperSubmitCoordinator:
             verify_preview_submit_hash(
                 packet, submit_hash=canonical_hash(submit_canonical)
             )
-            now = self._now_fn()
-            verify_packet_freshness(packet, now=now)
-            if packet.origin == "automated":
-                verify_packet_market_data(packet, now=now, max_age=self._quote_max_age)
             verify_packet_account_mode(packet, expected=self._expected_account_mode)
-            if packet.origin == "automated":
-                # Ledger buy-source provenance is an automated-cohort gate. Manual
-                # operator sells rely on the fresh live-position check below.
-                await verify_sell_packet_source(packet, ledger=self._ledger)
         except PaperApprovalPacketError as exc:
             return SubmitOutcome(
                 status="rejected",
@@ -273,10 +277,10 @@ class AlpacaPaperSubmitCoordinator:
                 message=str(exc),
             )
 
-        # --- Idempotency fast-path (resolve a prior outcome before any claim) ---
-        # Force a fresh READ COMMITTED snapshot: the session uses
-        # expire_on_commit=False, so a prior same-session submit's committed row
-        # would otherwise be read back stale from the identity map.
+        # --- (2) Replay a prior terminal/success BEFORE any time-dependent check-
+        # Force a fresh READ COMMITTED snapshot (session is expire_on_commit=False).
+        # A completed or terminally-failed order replays its ORIGINAL result even
+        # after the packet's freshness window has elapsed.
         self._ledger.session.expire_all()
         existing = await self._ledger.get_execution_by_client_order_id(coid)
         if existing is not None:
@@ -284,18 +288,26 @@ class AlpacaPaperSubmitCoordinator:
                 return await self._resolve_inflight(coid)
             return self._resolved_outcome(existing)
 
-        # --- Sell preflight: fresh current-position evidence (NEW intent only) --
-        # Runs after the fast-path so a duplicate of a filled sell replays instead
-        # of being re-validated against a now-reduced position. Before the claim so
-        # a transient position issue never burns the idempotency key.
-        if packet.side == "sell":
-            sell_reject = await self._check_sell_current_position(
-                packet, submit_canonical
+        # --- (3) Time-dependent evidence — NEW (not-yet-claimed) submits only ----
+        # No origin bypass: every new submit must carry server-observed market
+        # evidence and pass freshness. Sells additionally require live position.
+        try:
+            now = self._now_fn()
+            verify_packet_freshness(packet, now=now)
+            verify_packet_market_data(packet, now=now, max_age=self._quote_max_age)
+        except PaperApprovalPacketError as exc:
+            return SubmitOutcome(
+                status="rejected",
+                client_order_id=coid,
+                broker_called=False,
+                reason_code=exc.code,
+                message=str(exc),
             )
-            if sell_reject is not None:
-                return sell_reject
 
-        # --- Atomic claim: only the winner POSTs to the broker ------------------
+        if packet.side == "sell":
+            return await self._submit_sell(packet, submit_canonical, coid)
+
+        # --- (4) Buy: atomic claim; only the winner POSTs -----------------------
         claim = await self._ledger.claim_submit(
             client_order_id=coid,
             lifecycle_correlation_id=packet.lifecycle_correlation_id,
@@ -316,7 +328,88 @@ class AlpacaPaperSubmitCoordinator:
                 return self._resolved_outcome(row)
             return await self._resolve_inflight(coid)
 
-        # --- Winner: exactly one broker HTTP submit -----------------------------
+        return await self._winner_submit(coid, submit_canonical)
+
+    async def _submit_sell(
+        self, packet: PaperApprovalPacket, submit_canonical: dict[str, Any], coid: str
+    ) -> SubmitOutcome:
+        """Sell path: fresh live position + cross-process reservation, then claim.
+
+        The current position is re-read from the broker, then availability
+        (position minus already-reserved open sells) and the atomic claim are
+        computed under one account+symbol advisory lock so two *different* sell
+        intents cannot both consume the same shares.
+        """
+        requested = _to_decimal(submit_canonical.get("qty"))
+        if requested is None or not requested.is_finite() or requested <= 0:
+            return self._sell_reject(
+                packet, "sell_qty_invalid", "sell qty missing or non-positive"
+            )
+
+        broker = self._broker_factory()
+        getter = getattr(broker, "get_position", None)
+        if getter is None:  # pragma: no cover - defensive
+            return self._sell_reject(
+                packet, "position_unavailable", "broker cannot read positions"
+            )
+        broker_symbol = _broker_position_symbol(packet.execution_symbol)
+        try:
+            position = await getter(broker_symbol)
+        except AlpacaPaperRequestError as exc:
+            return self._sell_reject(
+                packet,
+                "position_unavailable",
+                f"position read failed (HTTP {getattr(exc, 'status_code', None)})",
+            )
+        if position is None:
+            return self._sell_reject(
+                packet, "position_flat", "no current position to sell"
+            )
+        if not _symbols_match(
+            getattr(position, "symbol", None), packet.execution_symbol
+        ):
+            return self._sell_reject(
+                packet,
+                "position_symbol_mismatch",
+                f"position symbol {getattr(position, 'symbol', None)!r} != {packet.execution_symbol!r}",
+            )
+        pos_qty = _to_decimal(getattr(position, "qty", None))
+        if pos_qty is None or not pos_qty.is_finite():
+            return self._sell_reject(
+                packet, "position_malformed", "position qty missing/non-finite"
+            )
+        if pos_qty <= 0:
+            return self._sell_reject(
+                packet, "position_flat", "current position qty is non-positive"
+            )
+
+        claim = await self._ledger.reserve_sell_and_claim(
+            client_order_id=coid,
+            lifecycle_correlation_id=packet.lifecycle_correlation_id,
+            execution_symbol=packet.execution_symbol,
+            execution_venue=packet.execution_venue,
+            instrument_type=_instrument_type_for(packet.execution_asset_class),
+            account_mode=packet.account_mode,
+            requested_qty=requested,
+            position_qty=pos_qty,
+            order_type=str(submit_canonical.get("type") or "limit"),
+            time_in_force=submit_canonical.get("time_in_force"),
+            requested_price=_to_decimal(submit_canonical.get("limit_price")),
+            preview_payload=dict(submit_canonical),
+        )
+        if claim.insufficient:
+            return self._sell_reject(
+                packet,
+                "qty_exceeds_available",
+                f"sell qty {requested} exceeds available {claim.available} "
+                f"(position {pos_qty} minus reserved open sells)",
+            )
+        if not claim.won:
+            row = claim.row
+            if row is not None and not is_inflight_execution(row):
+                return self._resolved_outcome(row)
+            return await self._resolve_inflight(coid)
+
         return await self._winner_submit(coid, submit_canonical)
 
     async def _winner_submit(
@@ -376,74 +469,6 @@ class AlpacaPaperSubmitCoordinator:
             broker_called=True,
             order=order_dict,
         )
-
-    async def _check_sell_current_position(
-        self, packet: PaperApprovalPacket, submit_canonical: dict[str, Any]
-    ) -> SubmitOutcome | None:
-        """Fail-close a sell unless a fresh Alpaca position covers the qty.
-
-        Past ledger fills are provenance only; the sellable quantity is the
-        broker's *current* position, re-read here right before the claim/POST.
-        Returns a rejected outcome, or None when the sell is covered.
-        """
-        requested = _to_decimal(submit_canonical.get("qty"))
-        if requested is None or not requested.is_finite() or requested <= 0:
-            return self._sell_reject(
-                packet, "sell_qty_invalid", "sell qty missing or non-positive"
-            )
-
-        broker = self._broker_factory()
-        getter = getattr(broker, "get_position", None)
-        if getter is None:  # pragma: no cover - defensive
-            return self._sell_reject(
-                packet, "position_unavailable", "broker cannot read positions"
-            )
-
-        broker_symbol = _broker_position_symbol(packet.execution_symbol)
-        try:
-            position = await getter(broker_symbol)
-        except AlpacaPaperRequestError as exc:
-            return self._sell_reject(
-                packet,
-                "position_unavailable",
-                f"position read failed (HTTP {getattr(exc, 'status_code', None)})",
-            )
-        if position is None:
-            return self._sell_reject(
-                packet, "position_flat", "no current position to sell"
-            )
-
-        if not _symbols_match(
-            getattr(position, "symbol", None), packet.execution_symbol
-        ):
-            return self._sell_reject(
-                packet,
-                "position_symbol_mismatch",
-                f"position symbol {getattr(position, 'symbol', None)!r} != {packet.execution_symbol!r}",
-            )
-
-        available = _to_decimal(getattr(position, "qty", None))
-        if available is None or not available.is_finite():
-            return self._sell_reject(
-                packet, "position_malformed", "position qty missing/non-finite"
-            )
-        if available <= 0:
-            return self._sell_reject(
-                packet, "position_flat", "current position qty is non-positive"
-            )
-        if requested > available:
-            return self._sell_reject(
-                packet,
-                "qty_exceeds_position",
-                f"sell qty {requested} exceeds current position {available}",
-            )
-        if packet.max_qty is not None and requested > packet.max_qty:
-            return self._sell_reject(
-                packet,
-                "qty_exceeds_max",
-                f"sell qty {requested} exceeds ceiling {packet.max_qty}",
-            )
-        return None
 
     def _sell_reject(
         self, packet: PaperApprovalPacket, code: str, message: str
@@ -604,6 +629,7 @@ __all__ = [
     "DEFAULT_INFLIGHT_MAX_POLLS",
     "DEFAULT_INFLIGHT_POLL_INTERVAL_S",
     "DEFAULT_QUOTE_MAX_AGE",
+    "SUCCESS_STATUSES",
     "SubmitOutcome",
     "build_canonical_payload",
     "canonical_hash",

--- a/app/services/alpaca_paper_submit_service.py
+++ b/app/services/alpaca_paper_submit_service.py
@@ -64,6 +64,23 @@ DEFAULT_INFLIGHT_POLL_INTERVAL_S = 0.05
 SUCCESS_STATUSES: frozenset[str] = frozenset({"submitted", "replayed", "recovered"})
 
 
+def _sell_submit_lifecycle_override(status: Any) -> str | None:
+    """Retain a sell hold until broker truth is safe to release.
+
+    Open/partial, filled-without-position-proof, and unknown/unparseable statuses
+    all remain submitted. Only a recognized non-fill terminal status may derive a
+    terminal lifecycle directly from submit/recovery evidence.
+    """
+    normalized = normalize_known_broker_order_status(status)
+    if (
+        normalized is None
+        or normalized in KNOWN_OPEN_BROKER_STATUSES
+        or normalized == "filled"
+    ):
+        return LIFECYCLE_SUBMITTED
+    return None
+
+
 # ---------------------------------------------------------------------------
 # Shared canonical payload + server-derived key/hash helpers
 # ---------------------------------------------------------------------------
@@ -416,11 +433,6 @@ class AlpacaPaperSubmitCoordinator:
                 return self._sell_reject(
                     packet, "position_malformed", "position qty missing/non-finite"
                 )
-            if pos_qty <= 0:
-                return self._sell_reject(
-                    packet, "position_flat", "current position qty is non-positive"
-                )
-
             raw_available = getattr(position, "qty_available", None)
             if raw_available is None:
                 return self._sell_reject(
@@ -450,6 +462,11 @@ class AlpacaPaperSubmitCoordinator:
                     packet,
                     "position_reconciliation_pending",
                     "filled sell is not yet reflected in broker position evidence",
+                )
+            if pos_qty <= 0:
+                await self._ledger.session.commit()
+                return self._sell_reject(
+                    packet, "position_flat", "current position qty is non-positive"
                 )
 
             claim = await self._ledger.reserve_sell_and_claim(
@@ -564,19 +581,28 @@ class AlpacaPaperSubmitCoordinator:
             return await self._resolve_uncertain(coid)
 
         order_dict = _order_to_dict(order)
-        normalized_status = normalize_known_broker_order_status(
-            order_dict.get("status")
+        sell_lifecycle_override = (
+            _sell_submit_lifecycle_override(order_dict.get("status"))
+            if packet.side == "sell"
+            else None
         )
         await self._ledger.record_submit(
             coid,
             order_dict,
             raw_response=order_dict,
-            lifecycle_state_override=(
-                LIFECYCLE_SUBMITTED
-                if packet.side == "sell" and normalized_status == "filled"
-                else None
-            ),
+            lifecycle_state_override=sell_lifecycle_override,
         )
+        if packet.side == "sell" and sell_lifecycle_override is None:
+            return SubmitOutcome(
+                status="failed",
+                client_order_id=coid,
+                broker_called=True,
+                reason_code="broker_terminal_status",
+                order=order_dict,
+                message=(
+                    f"broker returned terminal status {order_dict.get('status')!r}"
+                ),
+            )
         return SubmitOutcome(
             status="submitted",
             client_order_id=coid,
@@ -728,9 +754,31 @@ class AlpacaPaperSubmitCoordinator:
         if order is None:
             return None
         order_dict = _order_to_dict(order)
-        await self._ledger.record_submit(
-            client_order_id, order_dict, raw_response=order_dict
+        claim_row = await self._ledger.get_execution_by_client_order_id(client_order_id)
+        is_sell = claim_row is not None and claim_row.side == "sell"
+        sell_lifecycle_override = (
+            _sell_submit_lifecycle_override(order_dict.get("status"))
+            if is_sell
+            else None
         )
+        await self._ledger.record_submit(
+            client_order_id,
+            order_dict,
+            raw_response=order_dict,
+            lifecycle_state_override=sell_lifecycle_override,
+        )
+        if is_sell and sell_lifecycle_override is None:
+            return SubmitOutcome(
+                status="failed",
+                client_order_id=client_order_id,
+                broker_called=False,
+                reason_code="broker_terminal_status_recovered",
+                order=order_dict,
+                message=(
+                    "broker lookup returned terminal status "
+                    f"{order_dict.get('status')!r}"
+                ),
+            )
         return SubmitOutcome(
             status="recovered",
             client_order_id=client_order_id,

--- a/app/services/brokers/alpaca/schemas.py
+++ b/app/services/brokers/alpaca/schemas.py
@@ -21,6 +21,7 @@ class Position(BaseModel):
     asset_id: str
     symbol: str
     qty: Decimal
+    qty_available: Decimal | None = None
     avg_entry_price: Decimal
     current_price: Decimal | None = None
     market_value: Decimal | None = None

--- a/app/services/brokers/alpaca/service.py
+++ b/app/services/brokers/alpaca/service.py
@@ -99,6 +99,23 @@ class AlpacaPaperBrokerService:
             return []
         return [Position.model_validate(item) for item in data]
 
+    async def get_position(self, symbol: str) -> Position | None:
+        """Read-only current paper position for a symbol (None if flat / 404).
+
+        Used as the fresh sell-eligibility evidence right before a sell POST.
+        Never mutates. Alpaca positions use the slashless symbol for crypto
+        (e.g. BTC/USD -> BTCUSD); callers should pass the broker symbol form.
+        """
+        try:
+            data = await self._request("GET", f"/v2/positions/{symbol}")
+        except AlpacaPaperRequestError as exc:
+            if getattr(exc, "status_code", None) == 404:
+                return None
+            raise
+        if not data:
+            return None
+        return Position.model_validate(data)
+
     async def list_assets(
         self,
         *,

--- a/app/services/brokers/alpaca/service.py
+++ b/app/services/brokers/alpaca/service.py
@@ -143,6 +143,26 @@ class AlpacaPaperBrokerService:
         data = await self._request("GET", f"/v2/orders/{order_id}")
         return Order.model_validate(data)
 
+    async def get_order_by_client_order_id(self, client_order_id: str) -> Order | None:
+        """Read-only lookup of a paper order by client_order_id.
+
+        Returns None when no order exists for the id (HTTP 404). Used only for
+        crash-after-success reconciliation — this never mutates and never POSTs.
+        """
+        try:
+            data = await self._request(
+                "GET",
+                "/v2/orders:by_client_order_id",
+                params={"client_order_id": client_order_id},
+            )
+        except AlpacaPaperRequestError as exc:
+            if getattr(exc, "status_code", None) == 404:
+                return None
+            raise
+        if not data:
+            return None
+        return Order.model_validate(data)
+
     async def list_fills(
         self,
         *,

--- a/app/services/crypto_execution_mapping.py
+++ b/app/services/crypto_execution_mapping.py
@@ -73,6 +73,21 @@ _ALLOWED_SIGNAL_TO_EXECUTION = {
 }
 
 
+def map_alpaca_paper_to_upbit(execution_symbol: str) -> str:
+    """Reverse map an Alpaca Paper USD pair back to its Upbit KRW signal symbol.
+
+    Used only to fill the packet's nominal signal identity for manual operator
+    submits (where the operator specifies the execution symbol directly).
+    """
+    normalized = (execution_symbol or "").strip().upper()
+    for signal, execution in _ALLOWED_SIGNAL_TO_EXECUTION.items():
+        if execution == normalized:
+            return signal
+    raise CryptoExecutionMappingError(
+        f"no Upbit signal maps to execution symbol {execution_symbol!r}"
+    )
+
+
 def map_upbit_to_alpaca_paper(signal_symbol: str) -> CryptoSignalExecutionMapping:
     """Map an explicit Upbit KRW signal symbol to an Alpaca Paper USD pair."""
     normalized = (signal_symbol or "").strip().upper()
@@ -172,5 +187,6 @@ __all__ = [
     "build_alpaca_paper_crypto_preview_payload",
     "build_crypto_paper_approval_metadata",
     "build_operator_candidate_crypto_metadata",
+    "map_alpaca_paper_to_upbit",
     "map_upbit_to_alpaca_paper",
 ]

--- a/app/services/paper_approval_packet.py
+++ b/app/services/paper_approval_packet.py
@@ -163,6 +163,9 @@ class PaperApprovalPacket(BaseModel):
     snapshot_id: str | None = None
     execution_order_type: Literal["limit", "market"] | None = None
     execution_time_in_force: str | None = None
+    # ROB-842: trusted reference price (from the server-observed market snapshot),
+    # used to bound notional for qty/market orders that carry no limit price.
+    reference_price: Decimal | None = None
 
     @field_validator("expires_at")
     @classmethod
@@ -633,8 +636,12 @@ def verify_order_within_packet(
 
     if packet.max_notional is not None:
         effective_notional = notional
-        if effective_notional is None and qty is not None and limit_price is not None:
-            effective_notional = qty * limit_price
+        if effective_notional is None and qty is not None:
+            # Prefer the order's own limit price; fall back to the packet's trusted
+            # reference price so a market/qty order is still bounded by notional.
+            px = limit_price if limit_price is not None else packet.reference_price
+            if px is not None:
+                effective_notional = qty * px
         if effective_notional is None:
             raise PaperApprovalPacketError(
                 code="order_size_unverifiable",

--- a/app/services/paper_approval_packet.py
+++ b/app/services/paper_approval_packet.py
@@ -33,7 +33,7 @@ Usage pattern (pre-submit caller):
 from __future__ import annotations
 
 import uuid
-from datetime import datetime
+from datetime import datetime, timedelta
 from decimal import Decimal
 from typing import TYPE_CHECKING, Any, Literal
 
@@ -92,6 +92,25 @@ class PaperApprovalPacketError(ValueError):
         wrong_symbol              — execution_symbol doesn't match buy source row
         qty_exceeds_source        — sell max_qty > source buy filled_qty
         invalid_qty_source        — sell qty_source not in allowed ledger values
+        missing_source_timestamp  — market_data_asof absent on an automated packet
+        naive_source_timestamp    — market_data_asof is tz-naive
+        future_source_timestamp   — market_data_asof is in the future relative to now
+        missing_market_data_source — market_data_source label absent
+        stale_quote               — market_data_asof older than the allowed max age
+        account_mode_mismatch     — packet.account_mode != expected (alpaca_paper)
+        missing_preview_hash      — preview_payload_hash absent when a submit hash is checked
+        preview_hash_mismatch     — submit canonical hash != packet.preview_payload_hash
+        server_key_mismatch       — client_order_id != server-derived key for the canonical intent
+        caller_id_mismatch        — caller-supplied client_order_id != server-derived key
+        order_symbol_mismatch     — submit symbol != packet.execution_symbol
+        order_side_mismatch       — submit side != packet.side
+        order_asset_class_mismatch — submit asset_class != packet.execution_asset_class
+        order_type_mismatch       — submit order type != packet.execution_order_type
+        order_tif_mismatch        — submit TIF != packet.execution_time_in_force
+        order_missing_size        — submit has neither qty nor notional
+        notional_exceeds_max      — submit notional (or qty*limit) > packet.max_notional
+        qty_exceeds_max           — submit qty > packet.max_qty
+        source_filled_qty_unknown — sell source filled_qty missing/unparseable/non-positive
     """
 
     def __init__(self, code: str, message: str) -> None:
@@ -130,6 +149,20 @@ class PaperApprovalPacket(BaseModel):
     lifecycle_correlation_id: str
     client_order_id: str
     expires_at: datetime
+
+    # ROB-842: Alpaca-complete boundary fields. Optional so ROB-91 producers stay
+    # valid; the Alpaca submit coordinator requires the market-data + hash fields
+    # via its verifiers (missing values fail-close with a stable reason code).
+    account_mode: str = "alpaca_paper"
+    origin: Literal["manual", "automated"] = "manual"
+    market_data_asof: datetime | None = None
+    market_data_source: str | None = None
+    preview_payload_hash: str | None = None
+    # ROB-842 blocker 4: server-owned snapshot identity folded into the
+    # idempotency key so distinct decisions never collide on economics alone.
+    snapshot_id: str | None = None
+    execution_order_type: Literal["limit", "market"] | None = None
+    execution_time_in_force: str | None = None
 
     @field_validator("expires_at")
     @classmethod
@@ -332,27 +365,312 @@ async def verify_sell_packet_source(
             ),
         )
 
+    # ROB-842 blocker 5: only a confirmed real holding may back a sell. A source
+    # with missing / unparseable / non-positive filled_qty fails closed.
+    source_filled_qty_raw = _get_attr(source, "filled_qty")
+    if source_filled_qty_raw is None:
+        raise PaperApprovalPacketError(
+            code="source_filled_qty_unknown",
+            message=(
+                "sell source has no filled_qty; a confirmed holding is required "
+                "before selling"
+            ),
+        )
+    try:
+        source_filled_qty = Decimal(str(source_filled_qty_raw))
+    except Exception as exc:
+        raise PaperApprovalPacketError(
+            code="source_filled_qty_unknown",
+            message=f"sell source filled_qty is unparseable: {source_filled_qty_raw!r}",
+        ) from exc
+    if source_filled_qty <= 0:
+        raise PaperApprovalPacketError(
+            code="source_filled_qty_unknown",
+            message=f"sell source filled_qty is non-positive: {source_filled_qty}",
+        )
+    if packet.max_qty is not None and packet.max_qty > source_filled_qty:
+        raise PaperApprovalPacketError(
+            code="qty_exceeds_source",
+            message=(
+                f"sell max_qty {packet.max_qty} exceeds buy source filled_qty "
+                f"{source_filled_qty}"
+            ),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Verifier: market-data source freshness (ROB-842)
+# ---------------------------------------------------------------------------
+def verify_packet_market_data(
+    packet: PaperApprovalPacket,
+    *,
+    now: datetime,
+    max_age: timedelta,
+) -> None:
+    """Reject packets whose market-data source timestamp is missing or stale.
+
+    Distinct from ``verify_packet_freshness`` (which bounds ``expires_at``): this
+    guards the *as-of* time of the quote the decision was made against, so an
+    otherwise-unexpired packet built on a stale quote is fail-closed.
+
+    Raises:
+        PaperApprovalPacketError(code='naive_now')                if now is tz-naive.
+        PaperApprovalPacketError(code='missing_source_timestamp') if asof is None.
+        PaperApprovalPacketError(code='naive_source_timestamp')   if asof is tz-naive.
+        PaperApprovalPacketError(code='stale_quote')              if now - asof > max_age.
+    """
+    if now.tzinfo is None or now.tzinfo.utcoffset(now) is None:
+        raise PaperApprovalPacketError(
+            code="naive_now",
+            message="now must be timezone-aware; use a caller-supplied UTC clock",
+        )
+    asof = packet.market_data_asof
+    if asof is None:
+        raise PaperApprovalPacketError(
+            code="missing_source_timestamp",
+            message="market_data_asof is required for an automated submit packet",
+        )
+    if asof.tzinfo is None or asof.tzinfo.utcoffset(asof) is None:
+        raise PaperApprovalPacketError(
+            code="naive_source_timestamp",
+            message="market_data_asof must be timezone-aware",
+        )
+    if not (packet.market_data_source or "").strip():
+        raise PaperApprovalPacketError(
+            code="missing_market_data_source",
+            message="market_data_source label is required for an automated packet",
+        )
+    if asof > now:
+        raise PaperApprovalPacketError(
+            code="future_source_timestamp",
+            message=(
+                f"market_data_asof is in the future: asof={asof.isoformat()}, "
+                f"now={now.isoformat()}"
+            ),
+        )
+    if now - asof > max_age:
+        raise PaperApprovalPacketError(
+            code="stale_quote",
+            message=(
+                f"market data is stale: asof={asof.isoformat()}, now={now.isoformat()}, "
+                f"max_age={max_age}"
+            ),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Verifier: account mode (ROB-842)
+# ---------------------------------------------------------------------------
+def verify_packet_account_mode(
+    packet: PaperApprovalPacket,
+    *,
+    expected: str = "alpaca_paper",
+) -> None:
+    """Raise if the packet account_mode does not match the expected paper mode.
+
+    Raises:
+        PaperApprovalPacketError(code='account_mode_mismatch').
+    """
+    if packet.account_mode != expected:
+        raise PaperApprovalPacketError(
+            code="account_mode_mismatch",
+            message=(
+                f"packet account_mode {packet.account_mode!r} does not match "
+                f"expected {expected!r}"
+            ),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Verifier: preview↔submit payload hash (ROB-842)
+# ---------------------------------------------------------------------------
+def verify_preview_submit_hash(
+    packet: PaperApprovalPacket,
+    *,
+    submit_hash: str,
+) -> None:
+    """Raise if the submit canonical hash differs from the packet's preview hash.
+
+    Raises:
+        PaperApprovalPacketError(code='missing_preview_hash')  if packet has no hash.
+        PaperApprovalPacketError(code='preview_hash_mismatch') if hashes differ.
+    """
+    if not packet.preview_payload_hash:
+        raise PaperApprovalPacketError(
+            code="missing_preview_hash",
+            message="packet has no preview_payload_hash to verify against",
+        )
+    if packet.preview_payload_hash != submit_hash:
+        raise PaperApprovalPacketError(
+            code="preview_hash_mismatch",
+            message=(
+                "submit payload hash does not match the previewed payload hash: "
+                f"preview={packet.preview_payload_hash!r}, submit={submit_hash!r}"
+            ),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Verifier: server-derived client_order_id / caller-id bypass guard (ROB-842)
+# ---------------------------------------------------------------------------
+def verify_server_derived_key(
+    packet: PaperApprovalPacket,
+    *,
+    server_key: str,
+    caller_client_order_id: str | None = None,
+) -> None:
+    """Enforce the server-derived idempotency key for the canonical intent.
+
+    The packet's ``client_order_id`` must equal the server-derived key for the
+    canonical submit payload, and any caller-supplied client_order_id must equal
+    that same server-derived value — an automated request cannot inject an id that
+    bypasses the server-derived claim key.
+
+    Raises:
+        PaperApprovalPacketError(code='server_key_mismatch') if packet id != server key.
+        PaperApprovalPacketError(code='caller_id_mismatch')  if caller id != server key.
+    """
+    if packet.client_order_id != server_key:
+        raise PaperApprovalPacketError(
+            code="server_key_mismatch",
+            message=(
+                f"packet client_order_id {packet.client_order_id!r} is not the "
+                f"server-derived key {server_key!r} for this canonical intent"
+            ),
+        )
+    if caller_client_order_id is not None and caller_client_order_id != server_key:
+        raise PaperApprovalPacketError(
+            code="caller_id_mismatch",
+            message=(
+                f"caller-supplied client_order_id {caller_client_order_id!r} does not "
+                f"match the server-derived key {server_key!r}"
+            ),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Verifier: order-within-packet authority binding (ROB-842 blocker 3)
+# ---------------------------------------------------------------------------
+def _canonical_decimal(canonical: dict[str, Any], key: str) -> Decimal | None:
+    raw = canonical.get(key)
+    if raw is None:
+        return None
+    try:
+        return Decimal(str(raw))
+    except Exception as exc:
+        raise PaperApprovalPacketError(
+            code="order_size_unverifiable",
+            message=f"canonical {key!r} is not a parseable number: {raw!r}",
+        ) from exc
+
+
+def verify_order_within_packet(
+    packet: PaperApprovalPacket,
+    canonical: dict[str, Any],
+) -> None:
+    """Bind the submit order to the server-owned packet's authority.
+
+    Every economic field of the submit (symbol, side, asset class, order type,
+    TIF, qty/notional, limit price) must match the packet, and the order size must
+    fall within the packet's approved ceiling (``max_notional``/``max_qty``). This
+    is what stops a self-consistent caller-fabricated canonical (hash-matches
+    itself) from executing beyond the server-approved decision.
+
+    Raises PaperApprovalPacketError with one of the order_* / *_exceeds_max codes.
+    """
+    if str(canonical.get("symbol") or "") != packet.execution_symbol:
+        raise PaperApprovalPacketError(
+            code="order_symbol_mismatch",
+            message=(
+                f"submit symbol {canonical.get('symbol')!r} != packet "
+                f"execution_symbol {packet.execution_symbol!r}"
+            ),
+        )
+    if str(canonical.get("side") or "") != packet.side:
+        raise PaperApprovalPacketError(
+            code="order_side_mismatch",
+            message=f"submit side {canonical.get('side')!r} != packet side {packet.side!r}",
+        )
+    if str(canonical.get("asset_class") or "") != packet.execution_asset_class:
+        raise PaperApprovalPacketError(
+            code="order_asset_class_mismatch",
+            message=(
+                f"submit asset_class {canonical.get('asset_class')!r} != packet "
+                f"execution_asset_class {packet.execution_asset_class!r}"
+            ),
+        )
+    if (
+        packet.execution_order_type is not None
+        and str(canonical.get("type") or "") != packet.execution_order_type
+    ):
+        raise PaperApprovalPacketError(
+            code="order_type_mismatch",
+            message=(
+                f"submit order type {canonical.get('type')!r} != packet "
+                f"execution_order_type {packet.execution_order_type!r}"
+            ),
+        )
+    if (
+        packet.execution_time_in_force is not None
+        and str(canonical.get("time_in_force") or "") != packet.execution_time_in_force
+    ):
+        raise PaperApprovalPacketError(
+            code="order_tif_mismatch",
+            message=(
+                f"submit time_in_force {canonical.get('time_in_force')!r} != packet "
+                f"execution_time_in_force {packet.execution_time_in_force!r}"
+            ),
+        )
+
+    qty = _canonical_decimal(canonical, "qty")
+    notional = _canonical_decimal(canonical, "notional")
+    limit_price = _canonical_decimal(canonical, "limit_price")
+    if qty is None and notional is None:
+        raise PaperApprovalPacketError(
+            code="order_missing_size",
+            message="submit canonical has neither qty nor notional",
+        )
+
+    if packet.max_notional is not None:
+        effective_notional = notional
+        if effective_notional is None and qty is not None and limit_price is not None:
+            effective_notional = qty * limit_price
+        if effective_notional is None:
+            raise PaperApprovalPacketError(
+                code="order_size_unverifiable",
+                message="cannot bound order notional against packet.max_notional",
+            )
+        if effective_notional > packet.max_notional:
+            raise PaperApprovalPacketError(
+                code="notional_exceeds_max",
+                message=(
+                    f"submit notional {effective_notional} exceeds packet "
+                    f"max_notional {packet.max_notional}"
+                ),
+            )
+
     if packet.max_qty is not None:
-        source_filled_qty_raw = _get_attr(source, "filled_qty")
-        if source_filled_qty_raw is not None:
-            try:
-                source_filled_qty = Decimal(str(source_filled_qty_raw))
-            except Exception:
-                source_filled_qty = None
-            if source_filled_qty is not None and packet.max_qty > source_filled_qty:
-                raise PaperApprovalPacketError(
-                    code="qty_exceeds_source",
-                    message=(
-                        f"sell max_qty {packet.max_qty} exceeds buy source filled_qty "
-                        f"{source_filled_qty}"
-                    ),
-                )
+        if qty is None:
+            raise PaperApprovalPacketError(
+                code="order_size_unverifiable",
+                message="packet has a qty ceiling but submit provided no qty",
+            )
+        if qty > packet.max_qty:
+            raise PaperApprovalPacketError(
+                code="qty_exceeds_max",
+                message=f"submit qty {qty} exceeds packet max_qty {packet.max_qty}",
+            )
 
 
 __all__ = [
     "PaperApprovalPacket",
     "PaperApprovalPacketError",
+    "verify_order_within_packet",
+    "verify_packet_account_mode",
     "verify_packet_freshness",
     "verify_packet_idempotency",
+    "verify_packet_market_data",
+    "verify_preview_submit_hash",
     "verify_sell_packet_source",
+    "verify_server_derived_key",
 ]

--- a/docs/runbooks/alpaca-paper-ledger.md
+++ b/docs/runbooks/alpaca-paper-ledger.md
@@ -334,10 +334,13 @@ outcome store. No new table/column/migration was added.
   that same lock, broker order statuses and the current position are read, and
   `available = min(qty_available, live qty − Σ(open sell requested_qty))` is used
   before inserting the claim. The claim stores its `qty` / `qty_available` baseline
-  in the existing `position_snapshot` JSONB. A newly `filled` sell remains reserved
-  until current position evidence proves the fill is reflected; unknown status,
-  missing baseline, or stale cross-endpoint evidence fails closed with
-  `position_reconciliation_pending` and no broker POST.
+  in the existing `position_snapshot` JSONB. Immediate and crash-recovered sell
+  responses remain `submitted` for open/partial, `filled`, and unknown/unparseable
+  statuses. A `filled` sell is released only after current position evidence proves
+  the fill is reflected; missing baseline or stale cross-endpoint evidence fails
+  closed with `position_reconciliation_pending`, while an unknown status retains its
+  reservation. Cancel read-back persists known open/partial/filled broker truth but
+  retains the same `submitted` hold. None of these ambiguous paths sends a new POST.
 - **Preview binding.** `record_preview(...)` persists the server-owned approval
   packet + provenance (quote snapshot id, content/packet hashes) as the
   `record_kind='preview'` row; `get_preview_by_client_order_id(...)` re-reads it so

--- a/docs/runbooks/alpaca-paper-ledger.md
+++ b/docs/runbooks/alpaca-paper-ledger.md
@@ -330,10 +330,14 @@ outcome store. No new table/column/migration was added.
   before applying any time-dependent (freshness/position) check, so an expired
   packet never turns a completed order into `stale_packet`.
 - **Sell reservation (no oversell).** `reserve_sell_and_claim(...)` holds a
-  transaction-scoped advisory lock on `(account_mode, execution_symbol)`, computes
-  `available = live position − Σ(open sell requested_qty)` and inserts the claim in
-  the same transaction, so two different sell intents cannot both consume the same
-  shares.
+  transaction-scoped advisory lock on `(account_mode, execution_symbol)`. Under
+  that same lock, broker order statuses and the current position are read, and
+  `available = min(qty_available, live qty − Σ(open sell requested_qty))` is used
+  before inserting the claim. The claim stores its `qty` / `qty_available` baseline
+  in the existing `position_snapshot` JSONB. A newly `filled` sell remains reserved
+  until current position evidence proves the fill is reflected; unknown status,
+  missing baseline, or stale cross-endpoint evidence fails closed with
+  `position_reconciliation_pending` and no broker POST.
 - **Preview binding.** `record_preview(...)` persists the server-owned approval
   packet + provenance (quote snapshot id, content/packet hashes) as the
   `record_kind='preview'` row; `get_preview_by_client_order_id(...)` re-reads it so

--- a/docs/runbooks/alpaca-paper-ledger.md
+++ b/docs/runbooks/alpaca-paper-ledger.md
@@ -306,7 +306,42 @@ Excludes pre-submit (`planned/previewed/validated`) and `anomaly`.
 
 `find_executed_by_client_order_id(client_order_id)` — returns the execution row if `record_kind='execution'` and `lifecycle_state` is in `EXECUTED_LIFECYCLE_STATES`; else `None`.
 
-`list_by_correlation_id(lifecycle_correlation_id)` — returns all rows sharing the correlation ID, ordered oldest-first. Used by the sell-source verifier.
+`list_by_correlation_id(lifecycle_correlation_id)` — returns all rows sharing the correlation ID, ordered oldest-first.
+
+## ROB-842 Submit Boundary (packet + atomic claim + replay)
+
+Every real Alpaca Paper broker POST — manual (`alpaca_paper_submit_order`) and
+automated (`alpaca_paper_automated_submit_order`) — is routed through
+`AlpacaPaperSubmitCoordinator`, which uses this ledger as the single idempotency +
+outcome store. No new table/column/migration was added.
+
+- **Atomic claim.** `claim_submit(...)` inserts the single `record_kind='execution'`
+  row for a `client_order_id` (`lifecycle_state='submitted'`, `submitted_at`/
+  `broker_order_id` NULL) via `INSERT ... ON CONFLICT DO NOTHING RETURNING`. The
+  winner (the caller that inserted the row) is the only one that POSTs.
+- **In-flight marker.** An execution row with both `submitted_at` and
+  `broker_order_id` NULL is a claimed-but-not-yet-recorded submit (`is_inflight_execution`).
+- **Success / terminal failure.** After a broker response, `record_submit(...)`
+  fills the same row (success). A deterministic broker rejection (HTTP 4xx/422) is
+  booked terminal by `record_submit_failure(...)` (`lifecycle_state='anomaly'`,
+  `submitted_at` stamped, redacted `error_summary`). Both make the row non-in-flight.
+- **Replay.** `get_execution_by_client_order_id(...)` returns the execution row in
+  ANY state; the coordinator replays a completed submit or a terminal failure
+  before applying any time-dependent (freshness/position) check, so an expired
+  packet never turns a completed order into `stale_packet`.
+- **Sell reservation (no oversell).** `reserve_sell_and_claim(...)` holds a
+  transaction-scoped advisory lock on `(account_mode, execution_symbol)`, computes
+  `available = live position − Σ(open sell requested_qty)` and inserts the claim in
+  the same transaction, so two different sell intents cannot both consume the same
+  shares.
+- **Preview binding.** `record_preview(...)` persists the server-owned approval
+  packet + provenance (quote snapshot id, content/packet hashes) as the
+  `record_kind='preview'` row; `get_preview_by_client_order_id(...)` re-reads it so
+  a duplicate-token preview answers from the persisted expiry/hash.
+
+Market evidence for both paths is loaded from a trusted `market_quote_snapshots`
+row (`app.services.alpaca_paper_market_evidence.load_market_evidence`); the caller
+never supplies correlation/snapshot/market-data/ceiling.
 
 ---
 

--- a/scripts/smoke/alpaca_paper_dev_smoke.py
+++ b/scripts/smoke/alpaca_paper_dev_smoke.py
@@ -202,50 +202,36 @@ async def _side_effect_account_ready(lines: list[SMOKE_LINE]) -> bool:
         return False
 
 
-async def _ensure_market_snapshot(args: argparse.Namespace) -> int:
-    """Persist a server-observed market_quote_snapshots row for the smoke order.
-
-    ROB-842 requires server-observed market evidence for every confirm=True submit.
-    The smoke observes its own reference price (the far-below-market limit price)
-    and records it as a trusted snapshot, returning its opaque id.
-    """
-    from datetime import UTC, datetime
-
-    from app.core.db import AsyncSessionLocal
-    from app.models.market_quote_snapshot import MarketQuoteSnapshot
-    from app.services.crypto_execution_mapping import map_alpaca_paper_to_upbit
-
-    if args.asset_class == "crypto":
-        market, source = "crypto", "upbit"
-        symbol = map_alpaca_paper_to_upbit(args.symbol or DEFAULT_CRYPTO_SYMBOL)
-        price = args.limit_price if args.limit_price is not None else SMOKE_LIMIT_PRICE
-    else:
-        market, source = "us", "yahoo"
-        symbol = args.symbol or DEFAULT_EQUITY_SYMBOL
-        price = SMOKE_LIMIT_PRICE
-    async with AsyncSessionLocal() as db:
-        row = MarketQuoteSnapshot(
-            market=market,
-            symbol=symbol,
-            source=source,
-            snapshot_at=datetime.now(UTC),
-            price=Decimal(str(price)),
-        )
-        db.add(row)
-        await db.commit()
-        return row.id
-
-
 async def _side_effect_submit(
     lines: list[SMOKE_LINE], args: argparse.Namespace
 ) -> str | None:
+    # ROB-842 G5: the smoke never fabricates a trusted market snapshot from the
+    # order/limit price. A confirm=True submit needs a REAL, server-observed
+    # snapshot; the operator must reference it explicitly via --quote-snapshot-id.
+    if args.quote_snapshot_id is None:
+        lines.append(
+            (
+                "submit_order(confirm=True)",
+                False,
+                "BLOCKED: --quote-snapshot-id (a real server-observed snapshot) is required",
+            )
+        )
+        return None
     try:
-        snapshot_id = await _ensure_market_snapshot(args)
         submit_result = await alpaca_paper_submit_order(
             **_order_payload(args),
-            quote_snapshot_id=snapshot_id,
+            quote_snapshot_id=args.quote_snapshot_id,
             confirm=True,
         )
+        if not submit_result.get("submitted"):
+            lines.append(
+                (
+                    "submit_order(confirm=True)",
+                    False,
+                    f"BLOCKED reason={submit_result.get('reason_code')}",
+                )
+            )
+            return None
         submitted_id = submit_result["order"]["id"]
         lines.append(
             (
@@ -368,6 +354,15 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--qty", type=Decimal, default=SMOKE_QTY)
     parser.add_argument("--notional", type=Decimal)
     parser.add_argument("--limit-price", type=Decimal)
+    parser.add_argument(
+        "--quote-snapshot-id",
+        type=int,
+        help=(
+            "Opaque id of a REAL server-observed market_quote_snapshots row. "
+            "Required for a confirm=True side-effect submit; the smoke never "
+            "fabricates trusted market evidence from the order price."
+        ),
+    )
     parser.add_argument(
         "--time-in-force",
         choices=("day", "gtc", "ioc", "fok"),

--- a/scripts/smoke/alpaca_paper_dev_smoke.py
+++ b/scripts/smoke/alpaca_paper_dev_smoke.py
@@ -202,12 +202,48 @@ async def _side_effect_account_ready(lines: list[SMOKE_LINE]) -> bool:
         return False
 
 
+async def _ensure_market_snapshot(args: argparse.Namespace) -> int:
+    """Persist a server-observed market_quote_snapshots row for the smoke order.
+
+    ROB-842 requires server-observed market evidence for every confirm=True submit.
+    The smoke observes its own reference price (the far-below-market limit price)
+    and records it as a trusted snapshot, returning its opaque id.
+    """
+    from datetime import UTC, datetime
+
+    from app.core.db import AsyncSessionLocal
+    from app.models.market_quote_snapshot import MarketQuoteSnapshot
+    from app.services.crypto_execution_mapping import map_alpaca_paper_to_upbit
+
+    if args.asset_class == "crypto":
+        market, source = "crypto", "upbit"
+        symbol = map_alpaca_paper_to_upbit(args.symbol or DEFAULT_CRYPTO_SYMBOL)
+        price = args.limit_price if args.limit_price is not None else SMOKE_LIMIT_PRICE
+    else:
+        market, source = "us", "yahoo"
+        symbol = args.symbol or DEFAULT_EQUITY_SYMBOL
+        price = SMOKE_LIMIT_PRICE
+    async with AsyncSessionLocal() as db:
+        row = MarketQuoteSnapshot(
+            market=market,
+            symbol=symbol,
+            source=source,
+            snapshot_at=datetime.now(UTC),
+            price=Decimal(str(price)),
+        )
+        db.add(row)
+        await db.commit()
+        return row.id
+
+
 async def _side_effect_submit(
     lines: list[SMOKE_LINE], args: argparse.Namespace
 ) -> str | None:
     try:
+        snapshot_id = await _ensure_market_snapshot(args)
         submit_result = await alpaca_paper_submit_order(
             **_order_payload(args),
+            quote_snapshot_id=snapshot_id,
             confirm=True,
         )
         submitted_id = submit_result["order"]["id"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,9 @@ Pytest configuration and common fixtures for auto-trader tests.
 """
 
 import asyncio
+import contextlib
 import os
+import tempfile
 from collections.abc import Generator
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -11,6 +13,31 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pandas as pd
 import pytest
 import pytest_asyncio
+
+# Cross-worker mutex serialising the Alpaca-paper suites that mutate the shared
+# `market_quote_snapshots` / `alpaca_paper_order_ledger` tables. See
+# `_serialize_alpaca_paper_db_suites` below. Lives in the temp dir so every
+# `pytest -n auto` worker process (same machine, same DB) contends on one file.
+# Uses stdlib fcntl.flock (posix; the Linux CI + macOS dev boxes) — no extra
+# dependency — and no-ops on the rare non-posix host.
+_ALPACA_PAPER_DB_LOCK_PATH = (
+    Path(tempfile.gettempdir()) / "auto_trader_alpaca_paper_db_suite.lock"
+)
+
+
+@contextlib.contextmanager
+def _alpaca_paper_db_suite_lock() -> Generator[None]:
+    try:
+        import fcntl
+    except ImportError:  # non-posix: cannot cross-process lock, run unserialised
+        yield
+        return
+    with open(_ALPACA_PAPER_DB_LOCK_PATH, "w") as handle:
+        fcntl.flock(handle, fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(handle, fcntl.LOCK_UN)
 
 
 def _load_env_file(env_path: Path) -> None:
@@ -300,6 +327,36 @@ def _mock_kr_market_session_calendar(monkeypatch):
         "app.mcp_server.tooling.market_session._get_kr_calendar",
         lambda: _FastKrCalendar(),
     )
+
+
+@pytest.fixture(autouse=True)
+def _serialize_alpaca_paper_db_suites(request):
+    """Serialize Alpaca-paper suites that mutate shared DB tables across workers.
+
+    The Alpaca-paper test files seed committed rows into two globally shared
+    tables (`market_quote_snapshots`, `alpaca_paper_order_ledger`) and clean up
+    with broad committed DELETEs keyed on values that are IDENTICAL across every
+    such suite — the ``"AAPL"`` quote symbol and the server-derived
+    ``rob73-``/``rob74-crypto-`` ledger-key prefixes (which are server-owned, so
+    a test cannot make them unique). Under CI's ``pytest -n auto
+    --dist=loadfile`` these sibling files run in separate workers against one
+    database, so a peer's committed cleanup can delete another running suite's
+    live rows between insert and read — surfacing as flaky
+    ``no_trusted_snapshot`` / ``LedgerNotFoundError`` failures. (Latent on main;
+    duration-based ``--splits`` kept the hostile files in separate DB jobs.)
+
+    A cross-worker file lock lets only one such suite touch those tables at a
+    time. It is *outer* to each file's own ``_clean`` autouse fixture (conftest
+    autouse fixtures wrap module autouse fixtures), so a peer never runs while
+    another suite's committed cleanup is in flight. The intra-test
+    ``asyncio.gather`` concurrency the exactly-once claim tests rely on still
+    runs inside the lock (one process holds it for the whole test)."""
+    path = str(getattr(request.node, "fspath", "") or "")
+    if "alpaca_paper" not in path and "paper_approval_packet" not in path:
+        yield
+        return
+    with _alpaca_paper_db_suite_lock():
+        yield
 
 
 @pytest.fixture(autouse=True)

--- a/tests/mcp_server/test_alpaca_paper_automated_orders.py
+++ b/tests/mcp_server/test_alpaca_paper_automated_orders.py
@@ -1,21 +1,16 @@
 """ROB-842 real public-MCP-handler integration tests for the automated boundary.
 
-Drives the actual ``alpaca_paper_automated_preview_order`` /
-``alpaca_paper_automated_submit_order`` handlers (session-factory + broker-factory
-injected, gate armed) against the test DB with a counting fake broker. Proves:
-- automated submit is default-disabled;
-- the public handler produces exactly ONE broker submit for sequential AND
-  parallel duplicate calls;
-- caller cannot select origin or inject a client_order_id (no such params);
-- packet authority (max_notional=10 vs notional=50) and market-data freshness
-  fail-close at preview before any persistence/broker call.
+Post-3rd-round: the public preview takes ONLY order intent + an opaque, trusted
+``quote_snapshot_id``. Identity / market provenance / ceiling are server-owned
+(loaded from ``market_quote_snapshots`` + hard-cap policy); the caller cannot
+supply correlation, snapshot, market-data, ceiling, origin, or client_order_id.
 """
 
 from __future__ import annotations
 
 import asyncio
 import inspect
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from decimal import Decimal
 from typing import Any
 
@@ -32,12 +27,13 @@ from app.mcp_server.tooling.alpaca_paper_automated_orders import (
     reset_alpaca_paper_automated_factories,
     set_alpaca_paper_automated_factories,
 )
+from app.models.market_quote_snapshot import MarketQuoteSnapshot
 from app.models.review import AlpacaPaperOrderLedger
 from app.services.brokers.alpaca.schemas import Order
 
 pytestmark = [pytest.mark.asyncio]
 
-_CORR = "rob842-auto-it"
+_CORR = "rob842dec-"  # server-derived correlation prefix
 
 
 class CountingBroker:
@@ -64,26 +60,34 @@ class CountingBroker:
     async def get_order_by_client_order_id(self, client_order_id: str) -> Order | None:
         return None
 
+    async def get_position(self, symbol: str) -> Any:
+        return None
+
 
 @pytest_asyncio.fixture
 async def broker(monkeypatch) -> CountingBroker:
     monkeypatch.setattr(settings, "alpaca_paper_automated_submit_enabled", True)
     b = CountingBroker(delay_s=0.02)
     set_alpaca_paper_automated_factories(
-        session_factory=lambda: AsyncSessionLocal,
-        broker_factory=lambda: b,
+        session_factory=lambda: AsyncSessionLocal, broker_factory=lambda: b
     )
     yield b
     reset_alpaca_paper_automated_factories()
 
 
 @pytest_asyncio.fixture(autouse=True)
-async def _clean_rows():
+async def _clean():
     async with AsyncSessionLocal() as db:
-        stmt = delete(AlpacaPaperOrderLedger).where(
-            AlpacaPaperOrderLedger.lifecycle_correlation_id.like(f"{_CORR}%")
+        await db.execute(
+            delete(AlpacaPaperOrderLedger).where(
+                AlpacaPaperOrderLedger.lifecycle_correlation_id.like(f"{_CORR}%")
+            )
         )
-        await db.execute(stmt)
+        await db.execute(
+            delete(MarketQuoteSnapshot).where(
+                MarketQuoteSnapshot.symbol.in_(["KRW-BTC", "AAPL"])
+            )
+        )
         await db.commit()
     yield
     async with AsyncSessionLocal() as db:
@@ -92,24 +96,40 @@ async def _clean_rows():
                 AlpacaPaperOrderLedger.lifecycle_correlation_id.like(f"{_CORR}%")
             )
         )
+        await db.execute(
+            delete(MarketQuoteSnapshot).where(
+                MarketQuoteSnapshot.symbol.in_(["KRW-BTC", "AAPL"])
+            )
+        )
         await db.commit()
 
 
-def _preview_kwargs(corr: str, **overrides: Any) -> dict[str, Any]:
+async def _seed_snapshot(
+    *, market="crypto", symbol="KRW-BTC", source="upbit", age_s=10, price="50000"
+) -> int:
+    async with AsyncSessionLocal() as db:
+        row = MarketQuoteSnapshot(
+            market=market,
+            symbol=symbol,
+            source=source,
+            snapshot_at=datetime.now(UTC) - timedelta(seconds=age_s),
+            price=Decimal(price),
+        )
+        db.add(row)
+        await db.commit()
+        return row.id
+
+
+def _crypto_intent(snapshot_id: int, **overrides: Any) -> dict[str, Any]:
     kwargs: dict[str, Any] = {
         "symbol": "BTC/USD",
         "side": "buy",
         "type": "limit",
-        "correlation_id": corr,
-        "snapshot_id": f"{corr}-snap",
-        "signal_symbol": "KRW-BTC",
-        "market_data_asof": datetime.now(UTC).isoformat(),
-        "market_data_source": "upbit_ticker",
+        "quote_snapshot_id": snapshot_id,
         "notional": Decimal("10"),
         "limit_price": Decimal("50000"),
         "time_in_force": "gtc",
         "asset_class": "crypto",
-        "max_notional": Decimal("10"),
     }
     kwargs.update(overrides)
     return kwargs
@@ -119,16 +139,22 @@ def _preview_kwargs(corr: str, **overrides: Any) -> dict[str, Any]:
 # Default-disabled
 # ---------------------------------------------------------------------------
 async def test_automated_preview_disabled_by_default() -> None:
-    # No gate armed, factories default.
     result = await alpaca_paper_automated_preview_order(
-        **_preview_kwargs(f"{_CORR}-off")
+        symbol="BTC/USD",
+        side="buy",
+        type="limit",
+        quote_snapshot_id=1,
+        notional=Decimal("10"),
+        limit_price=Decimal("50000"),
+        time_in_force="gtc",
+        asset_class="crypto",
     )
     assert result["success"] is False
     assert result["reason_code"] == "automated_submit_disabled"
 
 
 async def test_automated_submit_disabled_by_default() -> None:
-    result = await alpaca_paper_automated_submit_order("any-token", confirm=True)
+    result = await alpaca_paper_automated_submit_order("any", confirm=True)
     assert result["success"] is False
     assert result["reason_code"] == "automated_submit_disabled"
 
@@ -136,11 +162,9 @@ async def test_automated_submit_disabled_by_default() -> None:
 # ---------------------------------------------------------------------------
 # Public-handler exactly-one broker submit
 # ---------------------------------------------------------------------------
-async def test_public_handler_sequential_duplicate_submits_once(
-    broker: CountingBroker,
-) -> None:
-    corr = f"{_CORR}-seq"
-    preview = await alpaca_paper_automated_preview_order(**_preview_kwargs(corr))
+async def test_public_handler_sequential_duplicate_submits_once(broker):
+    sid = await _seed_snapshot()
+    preview = await alpaca_paper_automated_preview_order(**_crypto_intent(sid))
     assert preview["success"] is True
     token = preview["approval_token"]
 
@@ -148,109 +172,131 @@ async def test_public_handler_sequential_duplicate_submits_once(
     second = await alpaca_paper_automated_submit_order(token, confirm=True)
 
     assert first["status"] == "submitted"
-    assert first["broker_called"] is True
     assert second["status"] in {"replayed", "recovered"}
     assert second["broker_called"] is False
     assert len(broker.submit_calls) == 1
 
 
-async def test_public_handler_parallel_duplicate_submits_once(
-    broker: CountingBroker,
-) -> None:
-    corr = f"{_CORR}-par"
-    preview = await alpaca_paper_automated_preview_order(**_preview_kwargs(corr))
-    token = preview["approval_token"]
-
+async def test_public_handler_parallel_duplicate_submits_once(broker):
+    sid = await _seed_snapshot()
+    token = (await alpaca_paper_automated_preview_order(**_crypto_intent(sid)))[
+        "approval_token"
+    ]
     results = await asyncio.gather(
         alpaca_paper_automated_submit_order(token, confirm=True),
         alpaca_paper_automated_submit_order(token, confirm=True),
     )
-
     assert len(broker.submit_calls) == 1
-    statuses = sorted(r["status"] for r in results)
-    assert statuses.count("submitted") == 1
-    other = [r for r in results if r["status"] != "submitted"][0]
-    assert other["status"] in {"replayed", "recovered", "idempotency_in_progress"}
-    assert other["broker_called"] is False
+    assert sorted(r["status"] for r in results).count("submitted") == 1
 
 
-async def test_confirm_false_is_dry_run_no_post(broker: CountingBroker) -> None:
-    corr = f"{_CORR}-dry"
-    preview = await alpaca_paper_automated_preview_order(**_preview_kwargs(corr))
-    token = preview["approval_token"]
-
+async def test_confirm_false_is_dry_run_no_post(broker):
+    sid = await _seed_snapshot()
+    token = (await alpaca_paper_automated_preview_order(**_crypto_intent(sid)))[
+        "approval_token"
+    ]
     dry = await alpaca_paper_automated_submit_order(token, confirm=False)
     assert dry["submitted"] is False
     assert dry["blocked_reason"] == "confirmation_required"
     assert broker.submit_calls == []
 
 
-async def test_submit_without_persisted_preview_rejected(
-    broker: CountingBroker,
-) -> None:
+async def test_submit_without_persisted_preview_rejected(broker):
     result = await alpaca_paper_automated_submit_order(
-        "rob842a-crypto-nonexistent", confirm=True
+        "rob842a-crypto-nope", confirm=True
     )
-    assert result["status"] == "rejected"
     assert result["reason_code"] == "no_preview_for_token"
     assert broker.submit_calls == []
 
 
 # ---------------------------------------------------------------------------
-# Packet authority fail-close at preview (blocker 3) — no persistence, no broker
+# Trusted-snapshot provenance fail-close (B2) — no persistence, no broker
 # ---------------------------------------------------------------------------
-async def test_preview_notional_exceeds_approved_ceiling_fails_close(
-    broker: CountingBroker,
-) -> None:
-    corr = f"{_CORR}-overmax"
+async def test_preview_missing_snapshot_fails_close(broker):
+    result = await alpaca_paper_automated_preview_order(**_crypto_intent(999999))
+    assert result["success"] is False
+    assert result["reason_code"] == "no_trusted_snapshot"
+
+
+async def test_preview_stale_snapshot_fails_close(broker):
+    sid = await _seed_snapshot(age_s=3600)  # 1h old
+    result = await alpaca_paper_automated_preview_order(**_crypto_intent(sid))
+    assert result["success"] is False
+    assert result["reason_code"] == "stale_trusted_snapshot"
+
+
+async def test_preview_symbol_mismatch_fails_close(broker):
+    # snapshot maps to BTC/USD but the order is for a different pair
+    sid = await _seed_snapshot(symbol="KRW-BTC")
     result = await alpaca_paper_automated_preview_order(
-        **_preview_kwargs(corr, notional=Decimal("50"), max_notional=Decimal("10"))
+        **_crypto_intent(sid, symbol="ETH/USD", limit_price=Decimal("3000"))
+    )
+    assert result["success"] is False
+    assert result["reason_code"] == "snapshot_symbol_mismatch"
+
+
+async def test_preview_order_exceeding_hard_cap_fails_close(broker):
+    # us_equity notional above the $1000 server hard cap — caller cannot raise it
+    sid = await _seed_snapshot(market="us", symbol="AAPL", source="yahoo", price="150")
+    result = await alpaca_paper_automated_preview_order(
+        symbol="AAPL",
+        side="buy",
+        type="market",
+        quote_snapshot_id=sid,
+        notional=Decimal("1500"),
+        asset_class="us_equity",
     )
     assert result["success"] is False
     assert result["reason_code"] == "notional_exceeds_max"
-    # No preview row persisted → submit finds nothing.
-    submit = await alpaca_paper_automated_submit_order(
-        result["client_order_id"], confirm=True
-    )
-    assert submit["reason_code"] == "no_preview_for_token"
-    assert broker.submit_calls == []
 
 
-async def test_preview_missing_market_data_source_fails_close(
-    broker: CountingBroker,
-) -> None:
-    result = await alpaca_paper_automated_preview_order(
-        **_preview_kwargs(f"{_CORR}-nosrc", market_data_source="")
-    )
-    assert result["success"] is False
-    assert result["reason_code"] == "missing_market_data_source"
+async def test_same_snapshot_same_key_different_snapshot_different_key(broker):
+    sid1 = await _seed_snapshot()
+    p1a = await alpaca_paper_automated_preview_order(**_crypto_intent(sid1))
+    p1b = await alpaca_paper_automated_preview_order(**_crypto_intent(sid1))
+    assert p1a["approval_token"] == p1b["approval_token"]  # same trusted decision
+
+    sid2 = await _seed_snapshot()  # a distinct trusted observation
+    p2 = await alpaca_paper_automated_preview_order(**_crypto_intent(sid2))
+    assert p2["approval_token"] != p1a["approval_token"]
 
 
-async def test_preview_future_asof_fails_close(broker: CountingBroker) -> None:
-    future = datetime(2999, 1, 1, tzinfo=UTC).isoformat()
-    result = await alpaca_paper_automated_preview_order(
-        **_preview_kwargs(f"{_CORR}-future", market_data_asof=future)
-    )
-    assert result["success"] is False
-    assert result["reason_code"] == "future_source_timestamp"
+async def test_preview_records_provenance_hashes(broker):
+    sid = await _seed_snapshot()
+    preview = await alpaca_paper_automated_preview_order(**_crypto_intent(sid))
+    prov = preview["provenance"]
+    assert prov["quote_snapshot_id"] == sid
+    assert prov["snapshot_content_hash"]
+    assert prov["packet_hash"]
+    assert prov["policy_max_notional"] == "50"  # crypto hard cap
 
 
 # ---------------------------------------------------------------------------
-# Trusted origin: no caller-selectable origin / client_order_id (blocker 2/4)
+# No caller-owned identity / provenance / ceiling / origin (B2/B4)
 # ---------------------------------------------------------------------------
-async def test_public_handlers_expose_no_origin_or_client_order_id() -> None:
-    preview_params = set(
-        inspect.signature(alpaca_paper_automated_preview_order).parameters
+async def test_preview_signature_exposes_no_caller_owned_trust_fields() -> None:
+    params = set(inspect.signature(alpaca_paper_automated_preview_order).parameters)
+    forbidden = {
+        "correlation_id",
+        "snapshot_id",
+        "market_data_asof",
+        "market_data_source",
+        "max_notional",
+        "max_qty",
+        "qty_source",
+        "origin",
+        "client_order_id",
+        "signal_venue",
+    }
+    assert forbidden.isdisjoint(params), (
+        f"caller-owned trust fields present: {forbidden & params}"
     )
-    submit_params = set(
-        inspect.signature(alpaca_paper_automated_submit_order).parameters
-    )
-    assert "origin" not in preview_params
-    assert "client_order_id" not in preview_params
-    assert "origin" not in submit_params
-    assert "client_order_id" not in submit_params
-    # Submit binds only to a server-issued token.
-    assert submit_params == {"approval_token", "confirm"}
+    assert "quote_snapshot_id" in params  # only an opaque server-issued reference
+
+
+async def test_submit_signature_is_token_and_confirm_only() -> None:
+    params = set(inspect.signature(alpaca_paper_automated_submit_order).parameters)
+    assert params == {"approval_token", "confirm"}
 
 
 async def test_manual_submit_tool_has_no_origin_param() -> None:
@@ -258,11 +304,11 @@ async def test_manual_submit_tool_has_no_origin_param() -> None:
 
     params = set(inspect.signature(alpaca_paper_submit_order).parameters)
     assert "origin" not in params
+    assert "client_order_id" not in params
 
 
 async def test_module_exposes_gate_and_factory_controls() -> None:
     assert callable(auto_mod.set_alpaca_paper_automated_factories)
-    assert callable(auto_mod.reset_alpaca_paper_automated_factories)
     assert auto_mod.ALPACA_PAPER_AUTOMATED_TOOL_NAMES == {
         "alpaca_paper_automated_preview_order",
         "alpaca_paper_automated_submit_order",

--- a/tests/mcp_server/test_alpaca_paper_automated_orders.py
+++ b/tests/mcp_server/test_alpaca_paper_automated_orders.py
@@ -29,6 +29,7 @@ from app.mcp_server.tooling.alpaca_paper_automated_orders import (
 )
 from app.models.market_quote_snapshot import MarketQuoteSnapshot
 from app.models.review import AlpacaPaperOrderLedger
+from app.services.brokers.alpaca.exceptions import AlpacaPaperRequestError
 from app.services.brokers.alpaca.schemas import Order
 
 pytestmark = [pytest.mark.asyncio]
@@ -313,3 +314,112 @@ async def test_module_exposes_gate_and_factory_controls() -> None:
         "alpaca_paper_automated_preview_order",
         "alpaca_paper_automated_submit_order",
     }
+
+
+# ---------------------------------------------------------------------------
+# F4 — trusted price × qty must not bypass the $1,000 hard cap
+# ---------------------------------------------------------------------------
+async def test_preview_market_qty_bypass_of_hard_cap_fails_close(broker):
+    # equity MARKET qty=5 at trusted price 100,000 => $500,000 implied notional.
+    sid = await _seed_snapshot(
+        market="us", symbol="AAPL", source="yahoo", price="100000"
+    )
+    result = await alpaca_paper_automated_preview_order(
+        symbol="AAPL",
+        side="buy",
+        type="market",
+        quote_snapshot_id=sid,
+        qty=Decimal("5"),
+        asset_class="us_equity",
+    )
+    assert result["success"] is False
+    assert result["reason_code"] == "notional_exceeds_max"
+
+
+async def test_preview_rejects_non_finite_snapshot_price(broker):
+    # A snapshot with a non-positive/zero price is not usable evidence.
+    sid = await _seed_snapshot(market="us", symbol="AAPL", source="yahoo", price="0")
+    result = await alpaca_paper_automated_preview_order(
+        symbol="AAPL",
+        side="buy",
+        type="market",
+        quote_snapshot_id=sid,
+        qty=Decimal("1"),
+        asset_class="us_equity",
+    )
+    assert result["success"] is False
+    assert result["reason_code"] == "invalid_snapshot_price"
+
+
+# ---------------------------------------------------------------------------
+# F6 — automated sell is explicitly disabled until ROB-845
+# ---------------------------------------------------------------------------
+async def test_automated_sell_is_explicitly_disabled(broker):
+    sid = await _seed_snapshot()
+    result = await alpaca_paper_automated_preview_order(
+        symbol="BTC/USD",
+        side="sell",
+        type="limit",
+        quote_snapshot_id=sid,
+        qty=Decimal("0.0001"),
+        limit_price=Decimal("50000"),
+        time_in_force="gtc",
+        asset_class="crypto",
+    )
+    assert result["success"] is False
+    assert result["reason_code"] == "automated_sell_disabled"
+
+
+# ---------------------------------------------------------------------------
+# F7 — a duplicate-token preview answers from the persisted packet
+# ---------------------------------------------------------------------------
+async def test_duplicate_preview_returns_persisted_expiry(broker):
+    sid = await _seed_snapshot()
+    first = await alpaca_paper_automated_preview_order(
+        **_crypto_intent(sid, valid_for_seconds=300)
+    )
+    # A second preview of the SAME trusted decision must echo the ORIGINAL
+    # persisted expiry/hash, not a locally rebuilt one.
+    second = await alpaca_paper_automated_preview_order(
+        **_crypto_intent(sid, valid_for_seconds=999)
+    )
+    assert first["approval_token"] == second["approval_token"]
+    assert second["expires_at"] == first["expires_at"]
+    assert second["provenance"]["packet_hash"] == first["provenance"]["packet_hash"]
+
+
+# ---------------------------------------------------------------------------
+# F3 — public success contract at the handler (422 => success=false, replay)
+# ---------------------------------------------------------------------------
+class _RaisingBroker(CountingBroker):
+    def __init__(self, exc: Exception) -> None:
+        super().__init__()
+        self._exc = exc
+
+    async def submit_order(self, request):  # type: ignore[override]
+        self.submit_calls.append(request)
+        raise self._exc
+
+
+async def test_handler_http_422_success_false_and_terminal_replay(monkeypatch):
+    monkeypatch.setattr(settings, "alpaca_paper_automated_submit_enabled", True)
+    raising = _RaisingBroker(AlpacaPaperRequestError("bad", status_code=422))
+    set_alpaca_paper_automated_factories(
+        session_factory=lambda: AsyncSessionLocal, broker_factory=lambda: raising
+    )
+    try:
+        sid = await _seed_snapshot()
+        token = (await alpaca_paper_automated_preview_order(**_crypto_intent(sid)))[
+            "approval_token"
+        ]
+        first = await alpaca_paper_automated_submit_order(token, confirm=True)
+        assert first["status"] == "failed"
+        assert first["success"] is False  # failed is NOT success
+
+        second = await alpaca_paper_automated_submit_order(token, confirm=True)
+        assert second["status"] == "failed"
+        assert second["success"] is False
+        assert second["reason_code"] == "broker_rejected_replayed"
+        assert len(raising.submit_calls) == 1  # terminal — no re-POST
+    finally:
+        reset_alpaca_paper_automated_factories()

--- a/tests/mcp_server/test_alpaca_paper_automated_orders.py
+++ b/tests/mcp_server/test_alpaca_paper_automated_orders.py
@@ -371,6 +371,92 @@ async def test_automated_sell_is_explicitly_disabled(broker):
 
 
 # ---------------------------------------------------------------------------
+# G1 — a LEGACY persisted automated-sell token is fail-closed at SUBMIT too
+# ---------------------------------------------------------------------------
+async def _persist_legacy_automated_sell_preview(sid_correlation: str) -> str:
+    """Directly persist an automated SELL preview (as a pre-fix token would look)."""
+    from app.services.alpaca_paper_ledger_service import AlpacaPaperLedgerService
+    from app.services.alpaca_paper_submit_service import (
+        build_canonical_payload,
+        canonical_hash,
+        derive_automated_key,
+    )
+    from app.services.paper_approval_packet import PaperApprovalPacket
+
+    canonical = build_canonical_payload(
+        symbol="BTC/USD",
+        side="sell",
+        type="limit",
+        time_in_force="gtc",
+        qty=Decimal("0.0001"),
+        notional=None,
+        limit_price=Decimal("50000"),
+        asset_class="crypto",
+    )
+    snap = f"{sid_correlation}-snap"
+    coid = derive_automated_key(
+        correlation_id=sid_correlation, snapshot_id=snap, canonical=canonical
+    )
+    packet = PaperApprovalPacket(
+        signal_source="automated_preview",
+        artifact_id=__import__("uuid").uuid4(),
+        signal_symbol="KRW-BTC",
+        signal_venue="upbit",
+        execution_symbol="BTC/USD",
+        execution_venue="alpaca_paper",
+        execution_asset_class="crypto",
+        side="sell",
+        max_notional=None,
+        max_qty=Decimal("0.0001"),
+        qty_source="ledger_filled_qty",
+        expected_lifecycle_step="previewed",
+        lifecycle_correlation_id=sid_correlation,
+        client_order_id=coid,
+        expires_at=datetime.now(UTC) + timedelta(hours=1),
+        account_mode="alpaca_paper",
+        origin="automated",
+        market_data_asof=datetime.now(UTC) - timedelta(seconds=10),
+        market_data_source="upbit_ticker",
+        preview_payload_hash=canonical_hash(canonical),
+        snapshot_id=snap,
+        execution_order_type="limit",
+        execution_time_in_force="gtc",
+        reference_price=Decimal("50000"),
+    )
+    async with AsyncSessionLocal() as db:
+        ledger = AlpacaPaperLedgerService(db)
+        await ledger.record_preview(
+            client_order_id=coid,
+            lifecycle_correlation_id=sid_correlation,
+            execution_symbol="BTC/USD",
+            execution_venue="alpaca_paper",
+            instrument_type=__import__(
+                "app.models.trading", fromlist=["InstrumentType"]
+            ).InstrumentType.crypto,
+            side="sell",
+            order_type="limit",
+            time_in_force="gtc",
+            requested_qty=Decimal("0.0001"),
+            requested_price=Decimal("50000"),
+            preview_payload={
+                "canonical": canonical,
+                "approval_packet": packet.model_dump(mode="json"),
+            },
+        )
+    return coid
+
+
+async def test_legacy_automated_sell_token_fail_closed_at_submit(broker):
+    corr = f"{_CORR}legacy-sell"
+    token = await _persist_legacy_automated_sell_preview(corr)
+    result = await alpaca_paper_automated_submit_order(token, confirm=True)
+    assert result["status"] == "rejected"
+    assert result["reason_code"] == "automated_sell_disabled"
+    assert result["success"] is False
+    assert broker.submit_calls == []  # never POSTed
+
+
+# ---------------------------------------------------------------------------
 # F7 — a duplicate-token preview answers from the persisted packet
 # ---------------------------------------------------------------------------
 async def test_duplicate_preview_returns_persisted_expiry(broker):

--- a/tests/mcp_server/test_alpaca_paper_automated_orders.py
+++ b/tests/mcp_server/test_alpaca_paper_automated_orders.py
@@ -1,0 +1,269 @@
+"""ROB-842 real public-MCP-handler integration tests for the automated boundary.
+
+Drives the actual ``alpaca_paper_automated_preview_order`` /
+``alpaca_paper_automated_submit_order`` handlers (session-factory + broker-factory
+injected, gate armed) against the test DB with a counting fake broker. Proves:
+- automated submit is default-disabled;
+- the public handler produces exactly ONE broker submit for sequential AND
+  parallel duplicate calls;
+- caller cannot select origin or inject a client_order_id (no such params);
+- packet authority (max_notional=10 vs notional=50) and market-data freshness
+  fail-close at preview before any persistence/broker call.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+from datetime import UTC, datetime
+from decimal import Decimal
+from typing import Any
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import delete
+
+from app.core.config import settings
+from app.core.db import AsyncSessionLocal
+from app.mcp_server.tooling import alpaca_paper_automated_orders as auto_mod
+from app.mcp_server.tooling.alpaca_paper_automated_orders import (
+    alpaca_paper_automated_preview_order,
+    alpaca_paper_automated_submit_order,
+    reset_alpaca_paper_automated_factories,
+    set_alpaca_paper_automated_factories,
+)
+from app.models.review import AlpacaPaperOrderLedger
+from app.services.brokers.alpaca.schemas import Order
+
+pytestmark = [pytest.mark.asyncio]
+
+_CORR = "rob842-auto-it"
+
+
+class CountingBroker:
+    def __init__(self, *, delay_s: float = 0.0) -> None:
+        self.submit_calls: list[Any] = []
+        self._delay_s = delay_s
+
+    async def submit_order(self, request: Any) -> Order:
+        self.submit_calls.append(request)
+        if self._delay_s:
+            await asyncio.sleep(self._delay_s)
+        return Order(
+            id=f"paper-{len(self.submit_calls)}",
+            client_order_id=getattr(request, "client_order_id", None),
+            symbol=getattr(request, "symbol", "BTC/USD"),
+            filled_qty=Decimal("0"),
+            side=getattr(request, "side", "buy"),
+            type=getattr(request, "type", "limit"),
+            time_in_force=getattr(request, "time_in_force", "gtc"),
+            status="accepted",
+            limit_price=getattr(request, "limit_price", None),
+        )
+
+    async def get_order_by_client_order_id(self, client_order_id: str) -> Order | None:
+        return None
+
+
+@pytest_asyncio.fixture
+async def broker(monkeypatch) -> CountingBroker:
+    monkeypatch.setattr(settings, "alpaca_paper_automated_submit_enabled", True)
+    b = CountingBroker(delay_s=0.02)
+    set_alpaca_paper_automated_factories(
+        session_factory=lambda: AsyncSessionLocal,
+        broker_factory=lambda: b,
+    )
+    yield b
+    reset_alpaca_paper_automated_factories()
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def _clean_rows():
+    async with AsyncSessionLocal() as db:
+        stmt = delete(AlpacaPaperOrderLedger).where(
+            AlpacaPaperOrderLedger.lifecycle_correlation_id.like(f"{_CORR}%")
+        )
+        await db.execute(stmt)
+        await db.commit()
+    yield
+    async with AsyncSessionLocal() as db:
+        await db.execute(
+            delete(AlpacaPaperOrderLedger).where(
+                AlpacaPaperOrderLedger.lifecycle_correlation_id.like(f"{_CORR}%")
+            )
+        )
+        await db.commit()
+
+
+def _preview_kwargs(corr: str, **overrides: Any) -> dict[str, Any]:
+    kwargs: dict[str, Any] = {
+        "symbol": "BTC/USD",
+        "side": "buy",
+        "type": "limit",
+        "correlation_id": corr,
+        "snapshot_id": f"{corr}-snap",
+        "signal_symbol": "KRW-BTC",
+        "market_data_asof": datetime.now(UTC).isoformat(),
+        "market_data_source": "upbit_ticker",
+        "notional": Decimal("10"),
+        "limit_price": Decimal("50000"),
+        "time_in_force": "gtc",
+        "asset_class": "crypto",
+        "max_notional": Decimal("10"),
+    }
+    kwargs.update(overrides)
+    return kwargs
+
+
+# ---------------------------------------------------------------------------
+# Default-disabled
+# ---------------------------------------------------------------------------
+async def test_automated_preview_disabled_by_default() -> None:
+    # No gate armed, factories default.
+    result = await alpaca_paper_automated_preview_order(
+        **_preview_kwargs(f"{_CORR}-off")
+    )
+    assert result["success"] is False
+    assert result["reason_code"] == "automated_submit_disabled"
+
+
+async def test_automated_submit_disabled_by_default() -> None:
+    result = await alpaca_paper_automated_submit_order("any-token", confirm=True)
+    assert result["success"] is False
+    assert result["reason_code"] == "automated_submit_disabled"
+
+
+# ---------------------------------------------------------------------------
+# Public-handler exactly-one broker submit
+# ---------------------------------------------------------------------------
+async def test_public_handler_sequential_duplicate_submits_once(
+    broker: CountingBroker,
+) -> None:
+    corr = f"{_CORR}-seq"
+    preview = await alpaca_paper_automated_preview_order(**_preview_kwargs(corr))
+    assert preview["success"] is True
+    token = preview["approval_token"]
+
+    first = await alpaca_paper_automated_submit_order(token, confirm=True)
+    second = await alpaca_paper_automated_submit_order(token, confirm=True)
+
+    assert first["status"] == "submitted"
+    assert first["broker_called"] is True
+    assert second["status"] in {"replayed", "recovered"}
+    assert second["broker_called"] is False
+    assert len(broker.submit_calls) == 1
+
+
+async def test_public_handler_parallel_duplicate_submits_once(
+    broker: CountingBroker,
+) -> None:
+    corr = f"{_CORR}-par"
+    preview = await alpaca_paper_automated_preview_order(**_preview_kwargs(corr))
+    token = preview["approval_token"]
+
+    results = await asyncio.gather(
+        alpaca_paper_automated_submit_order(token, confirm=True),
+        alpaca_paper_automated_submit_order(token, confirm=True),
+    )
+
+    assert len(broker.submit_calls) == 1
+    statuses = sorted(r["status"] for r in results)
+    assert statuses.count("submitted") == 1
+    other = [r for r in results if r["status"] != "submitted"][0]
+    assert other["status"] in {"replayed", "recovered", "idempotency_in_progress"}
+    assert other["broker_called"] is False
+
+
+async def test_confirm_false_is_dry_run_no_post(broker: CountingBroker) -> None:
+    corr = f"{_CORR}-dry"
+    preview = await alpaca_paper_automated_preview_order(**_preview_kwargs(corr))
+    token = preview["approval_token"]
+
+    dry = await alpaca_paper_automated_submit_order(token, confirm=False)
+    assert dry["submitted"] is False
+    assert dry["blocked_reason"] == "confirmation_required"
+    assert broker.submit_calls == []
+
+
+async def test_submit_without_persisted_preview_rejected(
+    broker: CountingBroker,
+) -> None:
+    result = await alpaca_paper_automated_submit_order(
+        "rob842a-crypto-nonexistent", confirm=True
+    )
+    assert result["status"] == "rejected"
+    assert result["reason_code"] == "no_preview_for_token"
+    assert broker.submit_calls == []
+
+
+# ---------------------------------------------------------------------------
+# Packet authority fail-close at preview (blocker 3) — no persistence, no broker
+# ---------------------------------------------------------------------------
+async def test_preview_notional_exceeds_approved_ceiling_fails_close(
+    broker: CountingBroker,
+) -> None:
+    corr = f"{_CORR}-overmax"
+    result = await alpaca_paper_automated_preview_order(
+        **_preview_kwargs(corr, notional=Decimal("50"), max_notional=Decimal("10"))
+    )
+    assert result["success"] is False
+    assert result["reason_code"] == "notional_exceeds_max"
+    # No preview row persisted → submit finds nothing.
+    submit = await alpaca_paper_automated_submit_order(
+        result["client_order_id"], confirm=True
+    )
+    assert submit["reason_code"] == "no_preview_for_token"
+    assert broker.submit_calls == []
+
+
+async def test_preview_missing_market_data_source_fails_close(
+    broker: CountingBroker,
+) -> None:
+    result = await alpaca_paper_automated_preview_order(
+        **_preview_kwargs(f"{_CORR}-nosrc", market_data_source="")
+    )
+    assert result["success"] is False
+    assert result["reason_code"] == "missing_market_data_source"
+
+
+async def test_preview_future_asof_fails_close(broker: CountingBroker) -> None:
+    future = datetime(2999, 1, 1, tzinfo=UTC).isoformat()
+    result = await alpaca_paper_automated_preview_order(
+        **_preview_kwargs(f"{_CORR}-future", market_data_asof=future)
+    )
+    assert result["success"] is False
+    assert result["reason_code"] == "future_source_timestamp"
+
+
+# ---------------------------------------------------------------------------
+# Trusted origin: no caller-selectable origin / client_order_id (blocker 2/4)
+# ---------------------------------------------------------------------------
+async def test_public_handlers_expose_no_origin_or_client_order_id() -> None:
+    preview_params = set(
+        inspect.signature(alpaca_paper_automated_preview_order).parameters
+    )
+    submit_params = set(
+        inspect.signature(alpaca_paper_automated_submit_order).parameters
+    )
+    assert "origin" not in preview_params
+    assert "client_order_id" not in preview_params
+    assert "origin" not in submit_params
+    assert "client_order_id" not in submit_params
+    # Submit binds only to a server-issued token.
+    assert submit_params == {"approval_token", "confirm"}
+
+
+async def test_manual_submit_tool_has_no_origin_param() -> None:
+    from app.mcp_server.tooling.alpaca_paper_orders import alpaca_paper_submit_order
+
+    params = set(inspect.signature(alpaca_paper_submit_order).parameters)
+    assert "origin" not in params
+
+
+async def test_module_exposes_gate_and_factory_controls() -> None:
+    assert callable(auto_mod.set_alpaca_paper_automated_factories)
+    assert callable(auto_mod.reset_alpaca_paper_automated_factories)
+    assert auto_mod.ALPACA_PAPER_AUTOMATED_TOOL_NAMES == {
+        "alpaca_paper_automated_preview_order",
+        "alpaca_paper_automated_submit_order",
+    }

--- a/tests/mcp_server/test_alpaca_paper_manual_boundary.py
+++ b/tests/mcp_server/test_alpaca_paper_manual_boundary.py
@@ -1,0 +1,114 @@
+"""ROB-842 blocker 1: manual alpaca_paper_submit_order routes every real broker
+POST through the durable packet + ledger atomic-claim coordinator.
+
+No direct-POST fallback; exactly-once for duplicate manual intents; behaviour is
+independent of the automated feature flag; dry-run mutates nothing.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from decimal import Decimal
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import delete, select
+
+from app.core.config import settings
+from app.core.db import AsyncSessionLocal
+from app.mcp_server.tooling.alpaca_paper_orders import (
+    alpaca_paper_submit_order,
+    reset_alpaca_paper_orders_service_factory,
+    set_alpaca_paper_orders_service_factory,
+)
+from app.models.review import AlpacaPaperOrderLedger
+from tests.test_alpaca_paper_orders_tools import FakeOrdersService
+
+pytestmark = [pytest.mark.asyncio]
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def _clean():
+    stmt = delete(AlpacaPaperOrderLedger).where(
+        AlpacaPaperOrderLedger.client_order_id.like("rob73-%")
+        | AlpacaPaperOrderLedger.client_order_id.like("rob74-crypto-%")
+    )
+    async with AsyncSessionLocal() as db:
+        await db.execute(stmt)
+        await db.commit()
+    yield
+    async with AsyncSessionLocal() as db:
+        await db.execute(stmt)
+        await db.commit()
+
+
+@pytest.fixture
+def fake_service() -> FakeOrdersService:
+    service = FakeOrdersService()
+    set_alpaca_paper_orders_service_factory(lambda: service)  # type: ignore[arg-type]
+    yield service
+    reset_alpaca_paper_orders_service_factory()
+
+
+_BUY = {
+    "symbol": "AAPL",
+    "side": "buy",
+    "type": "limit",
+    "qty": Decimal("1"),
+    "limit_price": Decimal("1.00"),
+}
+
+
+async def _count_rows(coid_prefix: str) -> int:
+    async with AsyncSessionLocal() as db:
+        rows = (
+            (
+                await db.execute(
+                    select(AlpacaPaperOrderLedger).where(
+                        AlpacaPaperOrderLedger.client_order_id.like(f"{coid_prefix}%")
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        return len(rows)
+
+
+async def test_manual_confirm_goes_through_claim_exactly_once_sequential(fake_service):
+    first = await alpaca_paper_submit_order(**_BUY, confirm=True)
+    second = await alpaca_paper_submit_order(**_BUY, confirm=True)
+
+    assert first["submitted"] is True
+    assert second["submitted"] is False
+    assert second["status"] in {"replayed", "recovered"}
+    submit_calls = [c for c in fake_service.calls if c[0] == "submit_order"]
+    assert len(submit_calls) == 1
+
+
+async def test_manual_confirm_exactly_once_parallel(fake_service):
+    results = await asyncio.gather(
+        alpaca_paper_submit_order(**_BUY, confirm=True),
+        alpaca_paper_submit_order(**_BUY, confirm=True),
+    )
+    submit_calls = [c for c in fake_service.calls if c[0] == "submit_order"]
+    assert len(submit_calls) == 1
+    assert sum(1 for r in results if r["submitted"]) == 1
+
+
+async def test_manual_works_with_automated_flag_off(fake_service, monkeypatch):
+    monkeypatch.setattr(settings, "alpaca_paper_automated_submit_enabled", False)
+    payload = await alpaca_paper_submit_order(**_BUY, confirm=True)
+    # Manual path does not depend on the automated flag; it still routes through
+    # the claim and POSTs exactly once.
+    assert payload["submitted"] is True
+    assert len([c for c in fake_service.calls if c[0] == "submit_order"]) == 1
+    assert await _count_rows("rob73-") == 1  # a claim/execution row exists
+
+
+async def test_manual_dry_run_mutates_nothing(fake_service):
+    payload = await alpaca_paper_submit_order(**_BUY, confirm=False)
+    assert payload["submitted"] is False
+    assert payload["blocked_reason"] == "confirmation_required"
+    assert fake_service.calls == []
+    assert await _count_rows("rob73-") == 0  # no ledger row written on dry-run

--- a/tests/mcp_server/test_alpaca_paper_manual_boundary.py
+++ b/tests/mcp_server/test_alpaca_paper_manual_boundary.py
@@ -47,7 +47,7 @@ async def _clean():
         await db.commit()
 
 
-async def _seed_snapshot() -> int:
+async def _seed_snapshot(price: str = "150") -> int:
     from datetime import UTC, datetime, timedelta
 
     from app.models.market_quote_snapshot import MarketQuoteSnapshot
@@ -58,7 +58,7 @@ async def _seed_snapshot() -> int:
             symbol="AAPL",
             source="yahoo",
             snapshot_at=datetime.now(UTC) - timedelta(seconds=10),
-            price=Decimal("150"),
+            price=Decimal(price),
         )
         db.add(row)
         await db.commit()
@@ -202,3 +202,109 @@ async def test_manual_http_422_success_false(monkeypatch):
         assert len([c for c in service.calls if c[0] == "submit_order"]) == 1
     finally:
         reset_alpaca_paper_orders_service_factory()
+
+
+# ---------------------------------------------------------------------------
+# G2 — manual equity market qty is bound by trusted reference_price × qty
+# ---------------------------------------------------------------------------
+async def test_manual_market_qty_bypass_of_hard_cap_fails_close(fake_service):
+    # AAPL market qty=5 at trusted price 100,000 => $500,000 implied notional.
+    sid = await _seed_snapshot(price="100000")
+    payload = await alpaca_paper_submit_order(
+        symbol="AAPL",
+        side="buy",
+        type="market",
+        qty=Decimal("5"),
+        quote_snapshot_id=sid,
+        confirm=True,
+    )
+    assert payload["success"] is False
+    assert payload["reason_code"] == "notional_exceeds_max"
+    assert [c for c in fake_service.calls if c[0] == "submit_order"] == []
+
+
+async def test_manual_notional_within_cap_still_posts(fake_service):
+    # Regression: a normal small order still goes through.
+    sid = await _seed_snapshot(price="150")
+    payload = await alpaca_paper_submit_order(
+        symbol="AAPL",
+        side="buy",
+        type="market",
+        notional=Decimal("300"),
+        quote_snapshot_id=sid,
+        confirm=True,
+    )
+    assert payload["submitted"] is True
+    assert len([c for c in fake_service.calls if c[0] == "submit_order"]) == 1
+
+
+# ---------------------------------------------------------------------------
+# G4c — the cancel tool releases a sell reservation via the ledger
+# ---------------------------------------------------------------------------
+async def test_cancel_tool_releases_sell_reservation(fake_service):
+    from datetime import UTC, datetime
+
+    from app.mcp_server.tooling.alpaca_paper_orders import alpaca_paper_cancel_order
+    from app.models.trading import InstrumentType
+    from app.services.alpaca_paper_ledger_service import AlpacaPaperLedgerService
+    from app.services.brokers.alpaca.schemas import Order
+
+    coid = "rob74-crypto-cxlreserve"
+    # Seed an OPEN (submitted) sell reservation row.
+    async with AsyncSessionLocal() as db:
+        db.add(
+            AlpacaPaperOrderLedger(
+                client_order_id=coid,
+                lifecycle_correlation_id=coid,
+                record_kind="execution",
+                broker="alpaca",
+                account_mode="alpaca_paper",
+                lifecycle_state="submitted",
+                execution_symbol="BTC/USD",
+                execution_venue="alpaca_paper",
+                instrument_type=InstrumentType.crypto,
+                side="sell",
+                order_type="limit",
+                currency="USD",
+                requested_qty=Decimal("0.5"),
+                submitted_at=datetime.now(UTC),
+                broker_order_id="paper-cxl-1",
+                confirm_flag=True,
+            )
+        )
+        await db.commit()
+
+    # The cancel read-back returns the order carrying the client_order_id.
+    async def _get_order(_id):
+        return Order(
+            id="paper-cxl-1",
+            client_order_id=coid,
+            symbol="BTC/USD",
+            filled_qty=Decimal("0"),
+            side="sell",
+            type="limit",
+            time_in_force="gtc",
+            status="canceled",
+        )
+
+    fake_service.get_order = _get_order  # type: ignore[assignment]
+    result = await alpaca_paper_cancel_order(order_id="paper-cxl-1", confirm=True)
+    assert result["reservation_released"] is True
+
+    # The row is now canceled -> no longer counts against sellable position.
+    from app.services.alpaca_paper_ledger_service import (
+        AlpacaPaperLedgerService as _L,
+    )
+
+    async with AsyncSessionLocal() as db:
+        claim = await _L(db).reserve_sell_and_claim(
+            client_order_id="rob74-crypto-afterc",
+            lifecycle_correlation_id="rob74-crypto-afterc",
+            execution_symbol="BTC/USD",
+            execution_venue="alpaca_paper",
+            instrument_type=InstrumentType.crypto,
+            requested_qty=Decimal("1"),
+            position_qty=Decimal("1"),
+        )
+        assert claim.insufficient is False  # reservation released -> full position free
+        _ = AlpacaPaperLedgerService  # keep import used

--- a/tests/mcp_server/test_alpaca_paper_manual_boundary.py
+++ b/tests/mcp_server/test_alpaca_paper_manual_boundary.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import asyncio
 from decimal import Decimal
+from types import SimpleNamespace
 
 import pytest
 import pytest_asyncio
@@ -239,6 +240,101 @@ async def test_manual_notional_within_cap_still_posts(fake_service):
     assert len([c for c in fake_service.calls if c[0] == "submit_order"]) == 1
 
 
+@pytest.mark.parametrize(
+    "qty_available, reason_code",
+    [
+        (None, "position_available_unavailable"),
+        (Decimal("NaN"), "position_available_malformed"),
+        (Decimal("Infinity"), "position_available_malformed"),
+        (Decimal("-1"), "position_available_malformed"),
+    ],
+)
+async def test_manual_sell_invalid_qty_available_fails_closed(
+    fake_service, qty_available, reason_code
+):
+    async def _get_position(_symbol):
+        return SimpleNamespace(
+            symbol="AAPL", qty=Decimal("1"), qty_available=qty_available
+        )
+
+    fake_service.get_position = _get_position  # type: ignore[assignment]
+    sid = await _seed_snapshot(price="100")
+
+    payload = await alpaca_paper_submit_order(
+        symbol="AAPL",
+        side="sell",
+        type="limit",
+        qty=Decimal("0.4"),
+        limit_price=Decimal("100"),
+        quote_snapshot_id=sid,
+        confirm=True,
+    )
+
+    assert payload["status"] == "rejected"
+    assert payload["reason_code"] == reason_code
+    assert [c for c in fake_service.calls if c[0] == "submit_order"] == []
+
+
+async def test_manual_sell_uses_broker_qty_available_as_hard_upper_bound(fake_service):
+    async def _get_position(_symbol):
+        return SimpleNamespace(
+            symbol="AAPL", qty=Decimal("1"), qty_available=Decimal("0.4")
+        )
+
+    fake_service.get_position = _get_position  # type: ignore[assignment]
+    sid = await _seed_snapshot(price="100")
+
+    payload = await alpaca_paper_submit_order(
+        symbol="AAPL",
+        side="sell",
+        type="limit",
+        qty=Decimal("0.7"),
+        limit_price=Decimal("100"),
+        quote_snapshot_id=sid,
+        confirm=True,
+    )
+
+    assert payload["status"] == "rejected"
+    assert payload["reason_code"] == "qty_exceeds_available"
+    assert [c for c in fake_service.calls if c[0] == "submit_order"] == []
+
+
+async def test_manual_sell_claim_persists_position_baseline(fake_service):
+    async def _get_position(_symbol):
+        return SimpleNamespace(
+            symbol="AAPL", qty=Decimal("1"), qty_available=Decimal("1")
+        )
+
+    fake_service.get_position = _get_position  # type: ignore[assignment]
+    sid = await _seed_snapshot(price="100")
+
+    payload = await alpaca_paper_submit_order(
+        symbol="AAPL",
+        side="sell",
+        type="limit",
+        qty=Decimal("0.4"),
+        limit_price=Decimal("100"),
+        quote_snapshot_id=sid,
+        confirm=True,
+    )
+
+    assert payload["submitted"] is True
+    async with AsyncSessionLocal() as db:
+        row = (
+            await db.execute(
+                select(AlpacaPaperOrderLedger).where(
+                    AlpacaPaperOrderLedger.client_order_id
+                    == payload["client_order_id"],
+                    AlpacaPaperOrderLedger.record_kind == "execution",
+                )
+            )
+        ).scalar_one()
+    assert row.position_snapshot["snapshot_kind"] == "sell_claim_baseline"
+    assert row.position_snapshot["qty"] == "1"
+    assert row.position_snapshot["qty_available"] == "1"
+    assert row.position_snapshot["fetched_at"]
+
+
 # ---------------------------------------------------------------------------
 # G4c — the cancel tool releases a sell reservation via the ledger
 # ---------------------------------------------------------------------------
@@ -306,6 +402,7 @@ async def test_cancel_tool_releases_sell_reservation(fake_service):
             instrument_type=InstrumentType.crypto,
             requested_qty=Decimal("1"),
             position_qty=Decimal("1"),
+            position_available=Decimal("1"),
         )
         assert claim.insufficient is False  # reservation released -> full position free
         _ = AlpacaPaperLedgerService  # keep import used
@@ -408,5 +505,35 @@ async def test_cancel_racing_fill_converges_to_filled_not_canceled(fake_service)
     assert result["cancelled"] is False
     assert result["order_status"] == "filled"
     assert result["reservation_released"] is False
-    # ...but the open reservation is cleared because the row is now `filled`.
-    assert await _open_reserved_qty() == Decimal("0")
+    assert result["lifecycle_synced"] is False
+    # Fill truth is returned, but the hold remains until position evidence proves
+    # the fill is reflected (the cancel read-back has no causal position snapshot).
+    assert await _open_reserved_qty() == Decimal("0.6")
+
+
+@pytest.mark.parametrize("unknown_status", ["pending_review", " ", 123])
+async def test_cancel_unknown_status_keeps_db_reservation(fake_service, unknown_status):
+    """An unrecognised broker status must not silently release a sell hold."""
+    coid = "rob74-crypto-unknowncxl"
+    await _seed_open_sell(coid, qty="0.6")
+
+    async def _get_order(_id):
+        return {
+            "id": "b-cxl",
+            "client_order_id": coid,
+            "symbol": "BTC/USD",
+            "filled_qty": "0",
+            "side": "sell",
+            "type": "limit",
+            "time_in_force": "gtc",
+            "status": unknown_status,
+        }
+
+    fake_service.get_order = _get_order  # type: ignore[assignment]
+
+    result = await alpaca_paper_cancel_order(order_id="b-cxl", confirm=True)
+
+    assert result["cancelled"] is False
+    assert result["reservation_released"] is False
+    assert result["lifecycle_synced"] is False
+    assert await _open_reserved_qty() == Decimal("0.6")

--- a/tests/mcp_server/test_alpaca_paper_manual_boundary.py
+++ b/tests/mcp_server/test_alpaca_paper_manual_boundary.py
@@ -17,6 +17,7 @@ from sqlalchemy import delete, select
 from app.core.config import settings
 from app.core.db import AsyncSessionLocal
 from app.mcp_server.tooling.alpaca_paper_orders import (
+    alpaca_paper_cancel_order,
     alpaca_paper_submit_order,
     reset_alpaca_paper_orders_service_factory,
     set_alpaca_paper_orders_service_factory,
@@ -308,3 +309,104 @@ async def test_cancel_tool_releases_sell_reservation(fake_service):
         )
         assert claim.insufficient is False  # reservation released -> full position free
         _ = AlpacaPaperLedgerService  # keep import used
+
+
+# ---------------------------------------------------------------------------
+# H1 — cancel releases the reservation ONLY on a confirmed terminal `canceled`
+# ---------------------------------------------------------------------------
+async def _seed_open_sell(coid: str, qty: str = "0.5") -> None:
+    from datetime import UTC, datetime
+
+    from app.models.trading import InstrumentType
+
+    async with AsyncSessionLocal() as db:
+        db.add(
+            AlpacaPaperOrderLedger(
+                client_order_id=coid,
+                lifecycle_correlation_id=coid,
+                record_kind="execution",
+                broker="alpaca",
+                account_mode="alpaca_paper",
+                lifecycle_state="submitted",
+                execution_symbol="BTC/USD",
+                execution_venue="alpaca_paper",
+                instrument_type=InstrumentType.crypto,
+                side="sell",
+                order_type="limit",
+                currency="USD",
+                requested_qty=Decimal(qty),
+                submitted_at=datetime.now(UTC),
+                broker_order_id=f"b-{coid}",
+                confirm_flag=True,
+            )
+        )
+        await db.commit()
+
+
+async def _open_reserved_qty() -> Decimal:
+    from app.services.alpaca_paper_ledger_service import AlpacaPaperLedgerService
+
+    async with AsyncSessionLocal() as db:
+        rows = await AlpacaPaperLedgerService(db).list_open_sells(
+            account_mode="alpaca_paper", execution_symbol="BTC/USD"
+        )
+        return sum((Decimal(str(r.requested_qty)) for r in rows), Decimal("0"))
+
+
+def _cancel_readback(coid: str, status: str):
+    from app.services.brokers.alpaca.schemas import Order
+
+    async def _get_order(_id):
+        return Order(
+            id="b-cxl",
+            client_order_id=coid,
+            symbol="BTC/USD",
+            filled_qty=Decimal("0"),
+            side="sell",
+            type="limit",
+            time_in_force="gtc",
+            status=status,
+        )
+
+    return _get_order
+
+
+async def test_cancel_pending_cancel_keeps_reservation(fake_service):
+    coid = "rob74-crypto-pendcxl"
+    await _seed_open_sell(coid, qty="0.6")
+    fake_service.get_order = _cancel_readback(coid, "pending_cancel")  # type: ignore[assignment]
+
+    result = await alpaca_paper_cancel_order(order_id="b-cxl", confirm=True)
+
+    assert result["cancel_requested"] is True
+    assert result["cancelled"] is False  # NOT terminal-canceled
+    assert result["order_status"] == "pending_cancel"
+    assert result["reservation_released"] is False
+    assert await _open_reserved_qty() == Decimal("0.6")  # still reserved
+
+
+async def test_cancel_confirmed_canceled_releases_reservation(fake_service):
+    coid = "rob74-crypto-realcxl"
+    await _seed_open_sell(coid, qty="0.6")
+    fake_service.get_order = _cancel_readback(coid, "canceled")  # type: ignore[assignment]
+
+    result = await alpaca_paper_cancel_order(order_id="b-cxl", confirm=True)
+
+    assert result["cancelled"] is True
+    assert result["reservation_released"] is True
+    assert await _open_reserved_qty() == Decimal("0")  # released
+
+
+async def test_cancel_racing_fill_converges_to_filled_not_canceled(fake_service):
+    coid = "rob74-crypto-racefill"
+    await _seed_open_sell(coid, qty="0.6")
+    fake_service.get_order = _cancel_readback(coid, "filled")  # type: ignore[assignment]
+
+    result = await alpaca_paper_cancel_order(order_id="b-cxl", confirm=True)
+
+    # A cancel that raced a fill converges to filled, not canceled.
+    assert result["cancelled"] is False
+    assert result["order_status"] == "filled"
+    assert result["reservation_released"] is False
+    # ...but the open reservation is cleared because the row is now `filled`.
+    assert await _open_reserved_qty() == Decimal("0")

--- a/tests/mcp_server/test_alpaca_paper_manual_boundary.py
+++ b/tests/mcp_server/test_alpaca_paper_manual_boundary.py
@@ -450,6 +450,17 @@ async def _open_reserved_qty() -> Decimal:
         return sum((Decimal(str(r.requested_qty)) for r in rows), Decimal("0"))
 
 
+async def _ledger_row(coid: str) -> AlpacaPaperOrderLedger:
+    async with AsyncSessionLocal() as db:
+        return (
+            await db.execute(
+                select(AlpacaPaperOrderLedger).where(
+                    AlpacaPaperOrderLedger.client_order_id == coid
+                )
+            )
+        ).scalar_one()
+
+
 def _cancel_readback(coid: str, status: str):
     from app.services.brokers.alpaca.schemas import Order
 
@@ -505,9 +516,57 @@ async def test_cancel_racing_fill_converges_to_filled_not_canceled(fake_service)
     assert result["cancelled"] is False
     assert result["order_status"] == "filled"
     assert result["reservation_released"] is False
-    assert result["lifecycle_synced"] is False
+    assert result["lifecycle_synced"] is True
     # Fill truth is returned, but the hold remains until position evidence proves
     # the fill is reflected (the cancel read-back has no causal position snapshot).
+    assert await _open_reserved_qty() == Decimal("0.6")
+
+    row = await _ledger_row(coid)
+    assert row.order_status == "filled"
+    assert row.filled_qty == Decimal("0")
+    assert row.lifecycle_state == "submitted"
+
+
+@pytest.mark.parametrize(
+    ("broker_status", "filled_qty"),
+    [
+        ("accepted", "0"),
+        ("partially_filled", "0.2"),
+        ("filled", "0.6"),
+    ],
+)
+async def test_cancel_known_hold_status_persists_truth_without_release(
+    fake_service, broker_status, filled_qty
+):
+    """Known open/partial/filled truth is synced while lifecycle stays held."""
+    coid = f"rob74-crypto-cancel-truth-{broker_status}"
+    await _seed_open_sell(coid, qty="0.6")
+
+    async def _get_order(_id):
+        from app.services.brokers.alpaca.schemas import Order
+
+        return Order(
+            id="b-cxl",
+            client_order_id=coid,
+            symbol="BTC/USD",
+            filled_qty=Decimal(filled_qty),
+            side="sell",
+            type="limit",
+            time_in_force="gtc",
+            status=broker_status,
+        )
+
+    fake_service.get_order = _get_order  # type: ignore[assignment]
+
+    result = await alpaca_paper_cancel_order(order_id="b-cxl", confirm=True)
+    row = await _ledger_row(coid)
+
+    assert result["cancelled"] is False
+    assert result["reservation_released"] is False
+    assert result["lifecycle_synced"] is True
+    assert row.order_status == broker_status
+    assert row.filled_qty == Decimal(filled_qty)
+    assert row.lifecycle_state == "submitted"
     assert await _open_reserved_qty() == Decimal("0.6")
 
 

--- a/tests/mcp_server/test_alpaca_paper_manual_boundary.py
+++ b/tests/mcp_server/test_alpaca_paper_manual_boundary.py
@@ -29,17 +29,40 @@ pytestmark = [pytest.mark.asyncio]
 
 @pytest_asyncio.fixture(autouse=True)
 async def _clean():
+    from app.models.market_quote_snapshot import MarketQuoteSnapshot
+
     stmt = delete(AlpacaPaperOrderLedger).where(
         AlpacaPaperOrderLedger.client_order_id.like("rob73-%")
         | AlpacaPaperOrderLedger.client_order_id.like("rob74-crypto-%")
     )
+    snap_stmt = delete(MarketQuoteSnapshot).where(MarketQuoteSnapshot.symbol == "AAPL")
     async with AsyncSessionLocal() as db:
         await db.execute(stmt)
+        await db.execute(snap_stmt)
         await db.commit()
     yield
     async with AsyncSessionLocal() as db:
         await db.execute(stmt)
+        await db.execute(snap_stmt)
         await db.commit()
+
+
+async def _seed_snapshot() -> int:
+    from datetime import UTC, datetime, timedelta
+
+    from app.models.market_quote_snapshot import MarketQuoteSnapshot
+
+    async with AsyncSessionLocal() as db:
+        row = MarketQuoteSnapshot(
+            market="us",
+            symbol="AAPL",
+            source="yahoo",
+            snapshot_at=datetime.now(UTC) - timedelta(seconds=10),
+            price=Decimal("150"),
+        )
+        db.add(row)
+        await db.commit()
+        return row.id
 
 
 @pytest.fixture
@@ -76,8 +99,11 @@ async def _count_rows(coid_prefix: str) -> int:
 
 
 async def test_manual_confirm_goes_through_claim_exactly_once_sequential(fake_service):
-    first = await alpaca_paper_submit_order(**_BUY, confirm=True)
-    second = await alpaca_paper_submit_order(**_BUY, confirm=True)
+    sid = await _seed_snapshot()
+    first = await alpaca_paper_submit_order(**_BUY, quote_snapshot_id=sid, confirm=True)
+    second = await alpaca_paper_submit_order(
+        **_BUY, quote_snapshot_id=sid, confirm=True
+    )
 
     assert first["submitted"] is True
     assert second["submitted"] is False
@@ -87,9 +113,10 @@ async def test_manual_confirm_goes_through_claim_exactly_once_sequential(fake_se
 
 
 async def test_manual_confirm_exactly_once_parallel(fake_service):
+    sid = await _seed_snapshot()
     results = await asyncio.gather(
-        alpaca_paper_submit_order(**_BUY, confirm=True),
-        alpaca_paper_submit_order(**_BUY, confirm=True),
+        alpaca_paper_submit_order(**_BUY, quote_snapshot_id=sid, confirm=True),
+        alpaca_paper_submit_order(**_BUY, quote_snapshot_id=sid, confirm=True),
     )
     submit_calls = [c for c in fake_service.calls if c[0] == "submit_order"]
     assert len(submit_calls) == 1
@@ -98,7 +125,10 @@ async def test_manual_confirm_exactly_once_parallel(fake_service):
 
 async def test_manual_works_with_automated_flag_off(fake_service, monkeypatch):
     monkeypatch.setattr(settings, "alpaca_paper_automated_submit_enabled", False)
-    payload = await alpaca_paper_submit_order(**_BUY, confirm=True)
+    sid = await _seed_snapshot()
+    payload = await alpaca_paper_submit_order(
+        **_BUY, quote_snapshot_id=sid, confirm=True
+    )
     # Manual path does not depend on the automated flag; it still routes through
     # the claim and POSTs exactly once.
     assert payload["submitted"] is True
@@ -112,3 +142,63 @@ async def test_manual_dry_run_mutates_nothing(fake_service):
     assert payload["blocked_reason"] == "confirmation_required"
     assert fake_service.calls == []
     assert await _count_rows("rob73-") == 0  # no ledger row written on dry-run
+
+
+# ---------------------------------------------------------------------------
+# F1 — manual confirm requires server-observed market evidence (no origin bypass)
+# ---------------------------------------------------------------------------
+async def test_manual_confirm_without_snapshot_fails_close(fake_service):
+    payload = await alpaca_paper_submit_order(**_BUY, confirm=True)
+    assert payload["success"] is False
+    assert payload["reason_code"] == "missing_market_evidence"
+    assert fake_service.calls == []
+    assert await _count_rows("rob73-") == 0
+
+
+async def test_manual_confirm_with_stale_snapshot_fails_close(fake_service):
+    from datetime import UTC, datetime, timedelta
+
+    from app.models.market_quote_snapshot import MarketQuoteSnapshot
+
+    async with AsyncSessionLocal() as db:
+        row = MarketQuoteSnapshot(
+            market="us",
+            symbol="AAPL",
+            source="yahoo",
+            snapshot_at=datetime.now(UTC) - timedelta(hours=1),
+            price=Decimal("150"),
+        )
+        db.add(row)
+        await db.commit()
+        sid = row.id
+    payload = await alpaca_paper_submit_order(
+        **_BUY, quote_snapshot_id=sid, confirm=True
+    )
+    assert payload["success"] is False
+    assert payload["reason_code"] == "stale_trusted_snapshot"
+    assert fake_service.calls == []
+
+
+# ---------------------------------------------------------------------------
+# F3 — public success contract for manual (422 => success=false)
+# ---------------------------------------------------------------------------
+async def test_manual_http_422_success_false(monkeypatch):
+    from app.services.brokers.alpaca.exceptions import AlpacaPaperRequestError
+
+    class _Raising(FakeOrdersService):
+        async def submit_order(self, request):  # type: ignore[override]
+            self.calls.append(("submit_order", {"request": request}))
+            raise AlpacaPaperRequestError("bad", status_code=422)
+
+    service = _Raising()
+    set_alpaca_paper_orders_service_factory(lambda: service)  # type: ignore[arg-type]
+    try:
+        sid = await _seed_snapshot()
+        payload = await alpaca_paper_submit_order(
+            **_BUY, quote_snapshot_id=sid, confirm=True
+        )
+        assert payload["status"] == "failed"
+        assert payload["success"] is False
+        assert len([c for c in service.calls if c[0] == "submit_order"]) == 1
+    finally:
+        reset_alpaca_paper_orders_service_factory()

--- a/tests/services/invest_view_model/test_watch_panel_service.py
+++ b/tests/services/invest_view_model/test_watch_panel_service.py
@@ -5,7 +5,6 @@ import uuid
 from decimal import Decimal
 
 import pytest
-from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.investment_reports import InvestmentWatchAlert, InvestmentWatchEvent
@@ -16,9 +15,21 @@ from tests._investment_reports_helpers import session  # noqa: F401
 
 @pytest.mark.asyncio
 async def test_watch_panel_service_list_watches(session: AsyncSession) -> None:  # noqa: F811
-    # Delete from market_quote_snapshots (which is not in the reports helper cleanup)
-    # We do NOT commit; the rollback at teardown will restore previous state.
-    await session.execute(text("DELETE FROM market_quote_snapshots"))
+    # Clear only the snapshot symbols this test reasons about. We do NOT commit;
+    # the rollback at teardown restores previous state.
+    #
+    # An unscoped `DELETE FROM market_quote_snapshots` cannot isolate us from
+    # *concurrently committed* foreign rows anyway (under `pytest --dist=loadfile`
+    # another file commits in a separate session, landing between our DELETE and
+    # our read under READ COMMITTED) and it needlessly row-locks the whole table,
+    # blocking peer suites. Instead the "must-have-no-snapshot" US alert below
+    # uses a test-unique ticker (`WPUSNOSNAP`) that no other suite ever commits a
+    # quote for — real tickers like AAPL collide with the Alpaca-paper suites.
+    await session.execute(
+        MarketQuoteSnapshot.__table__.delete().where(
+            MarketQuoteSnapshot.symbol.in_(["005930", "WPUSNOSNAP", "BTC"])
+        )
+    )
     await session.flush()
 
     now = dt.datetime(2026, 6, 17, 12, 0, tzinfo=dt.UTC)
@@ -54,7 +65,10 @@ async def test_watch_panel_service_list_watches(session: AsyncSession) -> None: 
         source_item_uuid=uuid.uuid4(),
         market="us",
         target_kind="asset",
-        symbol="AAPL",
+        # Test-unique ticker: this alert must stay price-less to drive the
+        # `degraded` data_state; a real ticker (AAPL) would race concurrently
+        # committed snapshots from the Alpaca-paper suites under --dist=loadfile.
+        symbol="WPUSNOSNAP",
         metric="price_above",
         operator="above",
         threshold=Decimal("200"),
@@ -130,7 +144,7 @@ async def test_watch_panel_service_list_watches(session: AsyncSession) -> None: 
     # Test list all
     resp = await service.list_watches(market="all", status="all")
     assert resp.count == 3
-    assert resp.data_state == "degraded"  # AAPL has no snapshot price
+    assert resp.data_state == "degraded"  # WPUSNOSNAP has no snapshot price
     assert len(resp.warnings) == 1
 
     # Check alert1 fields (kr, 005930)
@@ -142,8 +156,8 @@ async def test_watch_panel_service_list_watches(session: AsyncSession) -> None: 
     # String checklist round-trips (ROB-599 regression guard).
     assert row1.trigger_checklist == ["005930 현재가 조회 확인", "실주문 없음 확인"]
 
-    # Check alert2 fields (us, AAPL)
-    row2 = next(item for item in resp.items if item.symbol == "AAPL")
+    # Check alert2 fields (us, WPUSNOSNAP — intentionally price-less)
+    row2 = next(item for item in resp.items if item.symbol == "WPUSNOSNAP")
     assert row2.near_expiry is False
     assert row2.current_price is None
     assert row2.proximity_band is None

--- a/tests/services/test_alpaca_paper_coordinator_v3.py
+++ b/tests/services/test_alpaca_paper_coordinator_v3.py
@@ -23,7 +23,7 @@ from app.services.alpaca_paper_submit_service import (
     derive_automated_key,
 )
 from app.services.brokers.alpaca.exceptions import AlpacaPaperRequestError
-from app.services.brokers.alpaca.schemas import Order
+from app.services.brokers.alpaca.schemas import Order, Position
 
 pytestmark = [pytest.mark.asyncio]
 
@@ -199,13 +199,22 @@ async def test_sell_blocked_when_current_position_zero_despite_past_fill(db_sess
         db_session, corr, filled_qty="5"
     )  # past fill = provenance
     canonical, packet = _sell_packet(corr, qty="1")
-    broker = V3Broker(position=SimpleNamespace(symbol="BTCUSD", qty=Decimal("0")))
+    broker = V3Broker(
+        position=Position(
+            asset_id="btc",
+            symbol="BTCUSD",
+            qty=Decimal("0"),
+            qty_available=None,
+            avg_entry_price=Decimal("50000"),
+            side="long",
+        )
+    )
     coord = _coord(db_session, broker)
 
     outcome = await coord.submit(packet, submit_canonical=canonical)
 
     assert outcome.status == "rejected"
-    assert outcome.reason_code == "position_flat"
+    assert outcome.reason_code == "position_available_unavailable"
     assert broker.submit_calls == []  # never POSTed
 
 

--- a/tests/services/test_alpaca_paper_coordinator_v3.py
+++ b/tests/services/test_alpaca_paper_coordinator_v3.py
@@ -205,7 +205,7 @@ async def test_sell_blocked_when_qty_exceeds_current_position(db_session):
     outcome = await coord.submit(packet, submit_canonical=canonical)
 
     assert outcome.status == "rejected"
-    assert outcome.reason_code == "qty_exceeds_position"
+    assert outcome.reason_code == "qty_exceeds_available"
     assert broker.submit_calls == []
 
 

--- a/tests/services/test_alpaca_paper_coordinator_v3.py
+++ b/tests/services/test_alpaca_paper_coordinator_v3.py
@@ -213,7 +213,11 @@ async def test_sell_blocked_when_qty_exceeds_current_position(db_session):
     corr = f"{_CORR}-sellover"
     await _seed_reconciled_buy(db_session, corr, filled_qty="5")
     canonical, packet = _sell_packet(corr, qty="3")
-    broker = V3Broker(position=SimpleNamespace(symbol="BTCUSD", qty=Decimal("1")))
+    broker = V3Broker(
+        position=SimpleNamespace(
+            symbol="BTCUSD", qty=Decimal("1"), qty_available=Decimal("1")
+        )
+    )
     coord = _coord(db_session, broker)
 
     outcome = await coord.submit(packet, submit_canonical=canonical)
@@ -255,7 +259,11 @@ async def test_sell_succeeds_within_current_position(db_session):
     corr = f"{_CORR}-sellok"
     await _seed_reconciled_buy(db_session, corr, filled_qty="5")
     canonical, packet = _sell_packet(corr, qty="1")
-    broker = V3Broker(position=SimpleNamespace(symbol="BTCUSD", qty=Decimal("2")))
+    broker = V3Broker(
+        position=SimpleNamespace(
+            symbol="BTCUSD", qty=Decimal("2"), qty_available=Decimal("2")
+        )
+    )
     coord = _coord(db_session, broker)
 
     outcome = await coord.submit(packet, submit_canonical=canonical)

--- a/tests/services/test_alpaca_paper_coordinator_v3.py
+++ b/tests/services/test_alpaca_paper_coordinator_v3.py
@@ -36,6 +36,8 @@ _CORR = "rob842-v3"
 async def _clean(db_session):
     stmt = delete(AlpacaPaperOrderLedger).where(
         AlpacaPaperOrderLedger.lifecycle_correlation_id.like(f"{_CORR}%")
+        | AlpacaPaperOrderLedger.client_order_id.like("rob74-crypto-%")
+        | AlpacaPaperOrderLedger.client_order_id.like("rob73-%")
     )
     await db_session.execute(stmt)
     await db_session.commit()
@@ -97,10 +99,21 @@ def _canonical(side: str, *, qty=None, notional=None, limit="50000") -> dict[str
     )
 
 
-def _packet(canonical, corr, **overrides):
+def _packet(canonical, corr, *, origin="automated", **overrides):
+    from app.services.alpaca_paper_submit_service import derive_client_order_id
     from app.services.paper_approval_packet import PaperApprovalPacket
 
     snap = f"{corr}-snap"
+    if origin == "manual":
+        coid = derive_client_order_id(canonical)
+        corr_id = coid
+        snap_id = None
+    else:
+        coid = derive_automated_key(
+            correlation_id=corr, snapshot_id=snap, canonical=canonical
+        )
+        corr_id = corr
+        snap_id = snap
     defaults: dict[str, Any] = {
         "signal_source": "test",
         "artifact_id": uuid.uuid4(),
@@ -113,19 +126,18 @@ def _packet(canonical, corr, **overrides):
         "max_notional": Decimal("10"),
         "qty_source": "notional_estimate",
         "expected_lifecycle_step": "previewed",
-        "lifecycle_correlation_id": corr,
-        "client_order_id": derive_automated_key(
-            correlation_id=corr, snapshot_id=snap, canonical=canonical
-        ),
+        "lifecycle_correlation_id": corr_id,
+        "client_order_id": coid,
         "expires_at": _FUTURE,
         "account_mode": "alpaca_paper",
-        "origin": "automated",
+        "origin": origin,
         "market_data_asof": _NOW - timedelta(seconds=10),
         "market_data_source": "upbit_ticker",
         "preview_payload_hash": canonical_hash(canonical),
-        "snapshot_id": snap,
+        "snapshot_id": snap_id,
         "execution_order_type": canonical.get("type"),
         "execution_time_in_force": canonical.get("time_in_force"),
+        "reference_price": Decimal("50000"),
     }
     defaults.update(overrides)
     return PaperApprovalPacket(**defaults)
@@ -165,14 +177,16 @@ async def _seed_reconciled_buy(db_session, corr, *, filled_qty="5"):
 
 
 def _sell_packet(corr, *, qty="1", max_qty="5"):
+    # Sell path is manual-only now (automated sell is disabled at the boundary).
     canonical = _canonical("sell", qty=qty)
     return canonical, _packet(
         canonical,
         corr,
+        origin="manual",
         side="sell",
         max_notional=None,
         max_qty=Decimal(max_qty),
-        qty_source="ledger_filled_qty",
+        qty_source="manual_operator",
     )
 
 

--- a/tests/services/test_alpaca_paper_coordinator_v3.py
+++ b/tests/services/test_alpaca_paper_coordinator_v3.py
@@ -1,0 +1,371 @@
+"""ROB-842 3rd-round coordinator tests: live sell position (B3) + terminal/uncertain broker outcomes (B4)."""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import delete
+
+from app.models.review import AlpacaPaperOrderLedger
+from app.models.trading import InstrumentType
+from app.services.alpaca_paper_ledger_service import AlpacaPaperLedgerService
+from app.services.alpaca_paper_submit_service import (
+    AlpacaPaperSubmitCoordinator,
+    build_canonical_payload,
+    canonical_hash,
+    derive_automated_key,
+)
+from app.services.brokers.alpaca.exceptions import AlpacaPaperRequestError
+from app.services.brokers.alpaca.schemas import Order
+
+pytestmark = [pytest.mark.asyncio]
+
+_NOW = datetime(2026, 7, 12, 12, 0, 0, tzinfo=UTC)
+_FUTURE = datetime(2030, 1, 1, 12, 0, 0, tzinfo=UTC)
+_CORR = "rob842-v3"
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def _clean(db_session):
+    stmt = delete(AlpacaPaperOrderLedger).where(
+        AlpacaPaperOrderLedger.lifecycle_correlation_id.like(f"{_CORR}%")
+    )
+    await db_session.execute(stmt)
+    await db_session.commit()
+    yield
+    await db_session.execute(stmt)
+    await db_session.commit()
+
+
+class V3Broker:
+    def __init__(
+        self,
+        *,
+        position: Any = None,
+        submit_error: Exception | None = None,
+        lookup_order: Order | None = None,
+        delay_s: float = 0.0,
+    ) -> None:
+        self.submit_calls: list[Any] = []
+        self.position = position
+        self.submit_error = submit_error
+        self.lookup_order = lookup_order
+        self._delay_s = delay_s
+
+    async def submit_order(self, request: Any) -> Order:
+        self.submit_calls.append(request)
+        if self._delay_s:
+            await asyncio.sleep(self._delay_s)
+        if self.submit_error is not None:
+            raise self.submit_error
+        return Order(
+            id=f"paper-{len(self.submit_calls)}",
+            client_order_id=getattr(request, "client_order_id", None),
+            symbol=getattr(request, "symbol", "BTC/USD"),
+            filled_qty=Decimal("0"),
+            side=getattr(request, "side", "buy"),
+            type=getattr(request, "type", "limit"),
+            time_in_force=getattr(request, "time_in_force", "gtc"),
+            status="accepted",
+            limit_price=getattr(request, "limit_price", None),
+        )
+
+    async def get_position(self, symbol: str) -> Any:
+        return self.position
+
+    async def get_order_by_client_order_id(self, client_order_id: str) -> Order | None:
+        return self.lookup_order
+
+
+def _canonical(side: str, *, qty=None, notional=None, limit="50000") -> dict[str, Any]:
+    return build_canonical_payload(
+        symbol="BTC/USD",
+        side=side,
+        type="limit",
+        time_in_force="gtc",
+        qty=Decimal(str(qty)) if qty is not None else None,
+        notional=Decimal(str(notional)) if notional is not None else None,
+        limit_price=Decimal(limit),
+        asset_class="crypto",
+    )
+
+
+def _packet(canonical, corr, **overrides):
+    from app.services.paper_approval_packet import PaperApprovalPacket
+
+    snap = f"{corr}-snap"
+    defaults: dict[str, Any] = {
+        "signal_source": "test",
+        "artifact_id": uuid.uuid4(),
+        "signal_symbol": "KRW-BTC",
+        "signal_venue": "upbit",
+        "execution_symbol": "BTC/USD",
+        "execution_venue": "alpaca_paper",
+        "execution_asset_class": "crypto",
+        "side": canonical["side"],
+        "max_notional": Decimal("10"),
+        "qty_source": "notional_estimate",
+        "expected_lifecycle_step": "previewed",
+        "lifecycle_correlation_id": corr,
+        "client_order_id": derive_automated_key(
+            correlation_id=corr, snapshot_id=snap, canonical=canonical
+        ),
+        "expires_at": _FUTURE,
+        "account_mode": "alpaca_paper",
+        "origin": "automated",
+        "market_data_asof": _NOW - timedelta(seconds=10),
+        "market_data_source": "upbit_ticker",
+        "preview_payload_hash": canonical_hash(canonical),
+        "snapshot_id": snap,
+        "execution_order_type": canonical.get("type"),
+        "execution_time_in_force": canonical.get("time_in_force"),
+    }
+    defaults.update(overrides)
+    return PaperApprovalPacket(**defaults)
+
+
+def _coord(db_session, broker, **kw):
+    return AlpacaPaperSubmitCoordinator(
+        AlpacaPaperLedgerService(db_session), lambda: broker, now_fn=lambda: _NOW, **kw
+    )
+
+
+async def _seed_reconciled_buy(db_session, corr, *, filled_qty="5"):
+    ledger = AlpacaPaperLedgerService(db_session)
+    buy_coid = f"{corr}-buysrc"
+    await ledger.claim_submit(
+        client_order_id=buy_coid,
+        lifecycle_correlation_id=corr,
+        execution_symbol="BTC/USD",
+        execution_venue="alpaca_paper",
+        instrument_type=InstrumentType.crypto,
+        side="buy",
+        order_type="limit",
+        time_in_force="gtc",
+        requested_qty=Decimal(filled_qty),
+        requested_price=Decimal("50000"),
+    )
+    await ledger.record_submit(
+        buy_coid,
+        {
+            "id": "buy-1",
+            "status": "filled",
+            "filled_qty": filled_qty,
+            "filled_avg_price": "50000",
+        },
+    )
+    db_session.expire_all()
+
+
+def _sell_packet(corr, *, qty="1", max_qty="5"):
+    canonical = _canonical("sell", qty=qty)
+    return canonical, _packet(
+        canonical,
+        corr,
+        side="sell",
+        max_notional=None,
+        max_qty=Decimal(max_qty),
+        qty_source="ledger_filled_qty",
+    )
+
+
+# ---------------------------------------------------------------------------
+# B3 — sell must be backed by a FRESH current position
+# ---------------------------------------------------------------------------
+async def test_sell_blocked_when_current_position_zero_despite_past_fill(db_session):
+    corr = f"{_CORR}-sellzero"
+    await _seed_reconciled_buy(
+        db_session, corr, filled_qty="5"
+    )  # past fill = provenance
+    canonical, packet = _sell_packet(corr, qty="1")
+    broker = V3Broker(position=SimpleNamespace(symbol="BTCUSD", qty=Decimal("0")))
+    coord = _coord(db_session, broker)
+
+    outcome = await coord.submit(packet, submit_canonical=canonical)
+
+    assert outcome.status == "rejected"
+    assert outcome.reason_code == "position_flat"
+    assert broker.submit_calls == []  # never POSTed
+
+
+async def test_sell_blocked_when_qty_exceeds_current_position(db_session):
+    corr = f"{_CORR}-sellover"
+    await _seed_reconciled_buy(db_session, corr, filled_qty="5")
+    canonical, packet = _sell_packet(corr, qty="3")
+    broker = V3Broker(position=SimpleNamespace(symbol="BTCUSD", qty=Decimal("1")))
+    coord = _coord(db_session, broker)
+
+    outcome = await coord.submit(packet, submit_canonical=canonical)
+
+    assert outcome.status == "rejected"
+    assert outcome.reason_code == "qty_exceeds_position"
+    assert broker.submit_calls == []
+
+
+async def test_sell_blocked_when_position_malformed(db_session):
+    corr = f"{_CORR}-sellmalf"
+    await _seed_reconciled_buy(db_session, corr, filled_qty="5")
+    canonical, packet = _sell_packet(corr, qty="1")
+    broker = V3Broker(position=SimpleNamespace(symbol="BTCUSD", qty=None))
+    coord = _coord(db_session, broker)
+
+    outcome = await coord.submit(packet, submit_canonical=canonical)
+
+    assert outcome.status == "rejected"
+    assert outcome.reason_code == "position_malformed"
+    assert broker.submit_calls == []
+
+
+async def test_sell_blocked_on_symbol_mismatch(db_session):
+    corr = f"{_CORR}-sellsym"
+    await _seed_reconciled_buy(db_session, corr, filled_qty="5")
+    canonical, packet = _sell_packet(corr, qty="1")
+    broker = V3Broker(position=SimpleNamespace(symbol="ETHUSD", qty=Decimal("5")))
+    coord = _coord(db_session, broker)
+
+    outcome = await coord.submit(packet, submit_canonical=canonical)
+
+    assert outcome.status == "rejected"
+    assert outcome.reason_code == "position_symbol_mismatch"
+    assert broker.submit_calls == []
+
+
+async def test_sell_succeeds_within_current_position(db_session):
+    corr = f"{_CORR}-sellok"
+    await _seed_reconciled_buy(db_session, corr, filled_qty="5")
+    canonical, packet = _sell_packet(corr, qty="1")
+    broker = V3Broker(position=SimpleNamespace(symbol="BTCUSD", qty=Decimal("2")))
+    coord = _coord(db_session, broker)
+
+    outcome = await coord.submit(packet, submit_canonical=canonical)
+
+    assert outcome.status == "submitted"
+    assert len(broker.submit_calls) == 1
+
+
+# ---------------------------------------------------------------------------
+# B4 — deterministic broker failure is terminal + replayed; uncertain reconciles
+# ---------------------------------------------------------------------------
+async def test_http_422_is_terminal_and_replayed_no_second_post(db_session):
+    corr = f"{_CORR}-422"
+    canonical = _canonical("buy", notional="10")
+    packet = _packet(canonical, corr)
+    broker = V3Broker(submit_error=AlpacaPaperRequestError("bad", status_code=422))
+    coord = _coord(db_session, broker)
+
+    first = await coord.submit(packet, submit_canonical=canonical)
+    second = await coord.submit(packet, submit_canonical=canonical)
+
+    assert first.status == "failed"
+    assert first.reason_code == "broker_rejected"
+    assert second.status == "failed"
+    assert second.reason_code == "broker_rejected_replayed"
+    assert second.broker_called is False
+    assert len(broker.submit_calls) == 1  # exactly one POST total
+
+
+async def test_parallel_422_same_failure_single_post(db_session):
+    from app.core.db import AsyncSessionLocal
+
+    corr = f"{_CORR}-422par"
+    canonical = _canonical("buy", notional="10")
+    barrier = asyncio.Barrier(2)
+    shared = V3Broker(
+        submit_error=AlpacaPaperRequestError("bad", status_code=422), delay_s=0.02
+    )
+
+    async def _run():
+        async with AsyncSessionLocal() as s:
+            coord = AlpacaPaperSubmitCoordinator(
+                AlpacaPaperLedgerService(s),
+                lambda: shared,
+                now_fn=lambda: _NOW,
+                inflight_max_polls=20,
+                inflight_poll_interval_s=0.02,
+            )
+            await barrier.wait()
+            return await coord.submit(
+                _packet(canonical, corr), submit_canonical=canonical
+            )
+
+    outcomes = await asyncio.gather(_run(), _run())
+    assert len(shared.submit_calls) == 1
+    assert sum(1 for o in outcomes if o.broker_called) == 1
+    assert all(o.status in {"failed", "idempotency_in_progress"} for o in outcomes)
+    assert any(o.status == "failed" for o in outcomes)
+
+
+async def test_uncertain_500_with_broker_lookup_recovers_no_repost(db_session):
+    corr = f"{_CORR}-uncrec"
+    canonical = _canonical("buy", notional="10")
+    packet = _packet(canonical, corr)
+    recovered = Order(
+        id="paper-recovered",
+        client_order_id=packet.client_order_id,
+        symbol="BTC/USD",
+        filled_qty=Decimal("0"),
+        side="buy",
+        type="limit",
+        time_in_force="gtc",
+        status="accepted",
+    )
+    broker = V3Broker(
+        submit_error=AlpacaPaperRequestError("boom", status_code=500),
+        lookup_order=recovered,
+    )
+    coord = _coord(db_session, broker)
+
+    outcome = await coord.submit(packet, submit_canonical=canonical)
+
+    assert outcome.status == "recovered"
+    assert len(broker.submit_calls) == 1  # the failed attempt; no re-POST
+
+
+async def test_uncertain_500_without_lookup_stays_in_flight_no_repost(db_session):
+    corr = f"{_CORR}-uncflight"
+    canonical = _canonical("buy", notional="10")
+    packet = _packet(canonical, corr)
+    broker = V3Broker(
+        submit_error=AlpacaPaperRequestError("boom", status_code=500), lookup_order=None
+    )
+    coord = _coord(db_session, broker)
+
+    outcome = await coord.submit(packet, submit_canonical=canonical)
+
+    assert outcome.status == "idempotency_in_progress"
+    assert len(broker.submit_calls) == 1
+    # retry does not re-POST either
+    retry = await coord.submit(packet, submit_canonical=canonical)
+    assert retry.status == "idempotency_in_progress"
+    assert len(broker.submit_calls) == 1
+
+
+async def test_terminal_persistence_failure_still_no_duplicate_post(
+    db_session, monkeypatch
+):
+    corr = f"{_CORR}-persistfail"
+    canonical = _canonical("buy", notional="10")
+    packet = _packet(canonical, corr)
+    broker = V3Broker(submit_error=AlpacaPaperRequestError("bad", status_code=422))
+    ledger = AlpacaPaperLedgerService(db_session)
+
+    async def _boom(*a, **k):
+        raise RuntimeError("db down")
+
+    monkeypatch.setattr(ledger, "record_submit_failure", _boom)
+    coord = AlpacaPaperSubmitCoordinator(ledger, lambda: broker, now_fn=lambda: _NOW)
+
+    first = await coord.submit(packet, submit_canonical=canonical)
+    assert first.status == "failed"
+    assert first.reason_code == "broker_rejected_unpersisted"
+    # retry must not POST again (claim row still guards)
+    second = await coord.submit(packet, submit_canonical=canonical)
+    assert len(broker.submit_calls) == 1
+    assert second.broker_called is False

--- a/tests/services/test_alpaca_paper_final_review.py
+++ b/tests/services/test_alpaca_paper_final_review.py
@@ -1,0 +1,264 @@
+"""ROB-842 final-review coordinator blockers: replay-before-freshness (F2) and
+cross-process sell reservation / no-oversell (F5)."""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import delete
+
+from app.models.review import AlpacaPaperOrderLedger
+from app.services.alpaca_paper_ledger_service import AlpacaPaperLedgerService
+from app.services.alpaca_paper_submit_service import (
+    AlpacaPaperSubmitCoordinator,
+    build_canonical_payload,
+    canonical_hash,
+    derive_automated_key,
+)
+from app.services.brokers.alpaca.exceptions import AlpacaPaperRequestError
+from app.services.brokers.alpaca.schemas import Order
+
+pytestmark = [pytest.mark.asyncio]
+
+_NOW = datetime(2026, 7, 12, 12, 0, 0, tzinfo=UTC)
+_CORR = "rob842-final"
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def _clean(db_session):
+    stmt = delete(AlpacaPaperOrderLedger).where(
+        AlpacaPaperOrderLedger.lifecycle_correlation_id.like(f"{_CORR}%")
+    )
+    await db_session.execute(stmt)
+    await db_session.commit()
+    yield
+    await db_session.execute(stmt)
+    await db_session.commit()
+
+
+class FinalBroker:
+    def __init__(
+        self,
+        *,
+        position: Any = None,
+        submit_error: Exception | None = None,
+        delay_s: float = 0.0,
+    ):
+        self.submit_calls: list[Any] = []
+        self.position = position
+        self.submit_error = submit_error
+        self._delay_s = delay_s
+
+    async def submit_order(self, request: Any) -> Order:
+        self.submit_calls.append(request)
+        if self._delay_s:
+            await asyncio.sleep(self._delay_s)
+        if self.submit_error is not None:
+            raise self.submit_error
+        return Order(
+            id=f"paper-{len(self.submit_calls)}",
+            client_order_id=getattr(request, "client_order_id", None),
+            symbol=getattr(request, "symbol", "BTC/USD"),
+            filled_qty=Decimal("0"),
+            side=getattr(request, "side", "buy"),
+            type=getattr(request, "type", "limit"),
+            time_in_force=getattr(request, "time_in_force", "gtc"),
+            status="accepted",
+            limit_price=getattr(request, "limit_price", None),
+        )
+
+    async def get_position(self, symbol: str) -> Any:
+        return self.position
+
+    async def get_order_by_client_order_id(self, client_order_id: str) -> Order | None:
+        return None
+
+
+def _canonical(side="buy", *, qty=None, notional="10", limit="50000"):
+    return build_canonical_payload(
+        symbol="BTC/USD",
+        side=side,
+        type="limit",
+        time_in_force="gtc",
+        qty=Decimal(str(qty)) if qty is not None else None,
+        notional=Decimal(str(notional)) if notional is not None else None,
+        limit_price=Decimal(limit),
+        asset_class="crypto",
+    )
+
+
+def _packet(canonical, corr, *, expires_at, **overrides):
+    from app.services.paper_approval_packet import PaperApprovalPacket
+
+    snap = f"{corr}-snap"
+    defaults: dict[str, Any] = {
+        "signal_source": "test",
+        "artifact_id": uuid.uuid4(),
+        "signal_symbol": "KRW-BTC",
+        "signal_venue": "upbit",
+        "execution_symbol": "BTC/USD",
+        "execution_venue": "alpaca_paper",
+        "execution_asset_class": "crypto",
+        "side": canonical["side"],
+        "max_notional": Decimal("10"),
+        "qty_source": "notional_estimate",
+        "expected_lifecycle_step": "previewed",
+        "lifecycle_correlation_id": corr,
+        "client_order_id": derive_automated_key(
+            correlation_id=corr, snapshot_id=snap, canonical=canonical
+        ),
+        "expires_at": expires_at,
+        "account_mode": "alpaca_paper",
+        "origin": "automated",
+        "market_data_asof": _NOW - timedelta(seconds=10),
+        "market_data_source": "upbit_ticker",
+        "preview_payload_hash": canonical_hash(canonical),
+        "snapshot_id": snap,
+        "execution_order_type": canonical.get("type"),
+        "execution_time_in_force": canonical.get("time_in_force"),
+    }
+    defaults.update(overrides)
+    return PaperApprovalPacket(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# F2 — a completed/terminal order replays even after the packet expiry window
+# ---------------------------------------------------------------------------
+async def test_completed_order_replays_after_packet_expiry(db_session):
+    corr = f"{_CORR}-replay"
+    canonical = _canonical()
+    packet = _packet(canonical, corr, expires_at=_NOW + timedelta(seconds=60))
+    broker = FinalBroker()
+    ledger = AlpacaPaperLedgerService(db_session)
+
+    fresh = AlpacaPaperSubmitCoordinator(ledger, lambda: broker, now_fn=lambda: _NOW)
+    first = await fresh.submit(packet, submit_canonical=canonical)
+    assert first.status == "submitted"
+
+    # Same intent retried LONG after the packet's freshness window elapsed.
+    expired = AlpacaPaperSubmitCoordinator(
+        ledger, lambda: broker, now_fn=lambda: _NOW + timedelta(hours=2)
+    )
+    second = await expired.submit(packet, submit_canonical=canonical)
+    assert second.status == "replayed"  # not rejected/stale_packet
+    assert second.success is True
+    assert len(broker.submit_calls) == 1
+
+
+async def test_terminal_failure_replays_after_expiry_not_stale(db_session):
+    corr = f"{_CORR}-failreplay"
+    canonical = _canonical()
+    packet = _packet(canonical, corr, expires_at=_NOW + timedelta(seconds=60))
+    broker = FinalBroker(submit_error=AlpacaPaperRequestError("bad", status_code=422))
+    ledger = AlpacaPaperLedgerService(db_session)
+
+    fresh = AlpacaPaperSubmitCoordinator(ledger, lambda: broker, now_fn=lambda: _NOW)
+    first = await fresh.submit(packet, submit_canonical=canonical)
+    assert first.status == "failed"
+
+    expired = AlpacaPaperSubmitCoordinator(
+        ledger, lambda: broker, now_fn=lambda: _NOW + timedelta(hours=2)
+    )
+    second = await expired.submit(packet, submit_canonical=canonical)
+    assert second.status == "failed"
+    assert second.reason_code == "broker_rejected_replayed"
+    assert second.success is False
+    assert len(broker.submit_calls) == 1
+
+
+# ---------------------------------------------------------------------------
+# F5 — different sell tokens cannot both consume the same position (no oversell)
+# ---------------------------------------------------------------------------
+async def test_distinct_sells_do_not_oversell_position(db_session):
+    from app.core.db import AsyncSessionLocal
+
+    corr = f"{_CORR}-oversell"
+    # position = 1 share; two different intents want 0.6 and 0.7.
+    c06 = _canonical("sell", qty="0.6", notional=None)
+    c07 = _canonical("sell", qty="0.7", notional=None)
+    p06 = _packet(
+        c06,
+        corr,
+        expires_at=_NOW + timedelta(hours=1),
+        side="sell",
+        max_notional=None,
+        max_qty=Decimal("1"),
+        qty_source="ledger_filled_qty",
+    )
+    p07 = _packet(
+        c07,
+        corr,
+        expires_at=_NOW + timedelta(hours=1),
+        side="sell",
+        max_notional=None,
+        max_qty=Decimal("1"),
+        qty_source="ledger_filled_qty",
+    )
+    shared = FinalBroker(
+        position=SimpleNamespace(symbol="BTCUSD", qty=Decimal("1")), delay_s=0.02
+    )
+    barrier = asyncio.Barrier(2)
+
+    async def _run(packet, canonical):
+        async with AsyncSessionLocal() as s:
+            coord = AlpacaPaperSubmitCoordinator(
+                AlpacaPaperLedgerService(s),
+                lambda: shared,
+                now_fn=lambda: _NOW,
+                inflight_max_polls=20,
+                inflight_poll_interval_s=0.02,
+            )
+            await barrier.wait()
+            return await coord.submit(packet, submit_canonical=canonical)
+
+    outcomes = await asyncio.gather(_run(p06, c06), _run(p07, c07))
+
+    # Exactly one sell POSTs; the other is rejected for insufficient available qty.
+    assert len(shared.submit_calls) == 1, shared.submit_calls
+    submitted = [o for o in outcomes if o.status == "submitted"]
+    rejected = [o for o in outcomes if o.status == "rejected"]
+    assert len(submitted) == 1
+    assert len(rejected) == 1
+    assert rejected[0].reason_code == "qty_exceeds_available"
+
+
+async def test_sequential_distinct_sells_reserve_across_calls(db_session):
+    corr = f"{_CORR}-seqreserve"
+    c06 = _canonical("sell", qty="0.6", notional=None)
+    c07 = _canonical("sell", qty="0.7", notional=None)
+    p06 = _packet(
+        c06,
+        corr,
+        expires_at=_NOW + timedelta(hours=1),
+        side="sell",
+        max_notional=None,
+        max_qty=Decimal("1"),
+        qty_source="ledger_filled_qty",
+    )
+    p07 = _packet(
+        c07,
+        corr,
+        expires_at=_NOW + timedelta(hours=1),
+        side="sell",
+        max_notional=None,
+        max_qty=Decimal("1"),
+        qty_source="ledger_filled_qty",
+    )
+    broker = FinalBroker(position=SimpleNamespace(symbol="BTCUSD", qty=Decimal("1")))
+    ledger = AlpacaPaperLedgerService(db_session)
+    coord = AlpacaPaperSubmitCoordinator(ledger, lambda: broker, now_fn=lambda: _NOW)
+
+    first = await coord.submit(p06, submit_canonical=c06)
+    second = await coord.submit(p07, submit_canonical=c07)
+
+    assert first.status == "submitted"
+    assert second.status == "rejected"
+    assert second.reason_code == "qty_exceeds_available"  # 0.7 > (1 - 0.6)
+    assert len(broker.submit_calls) == 1

--- a/tests/services/test_alpaca_paper_final_review.py
+++ b/tests/services/test_alpaca_paper_final_review.py
@@ -219,7 +219,10 @@ async def test_distinct_sells_do_not_oversell_position(db_session):
         qty_source="manual_operator",
     )
     shared = FinalBroker(
-        position=SimpleNamespace(symbol="BTCUSD", qty=Decimal("1")), delay_s=0.02
+        position=SimpleNamespace(
+            symbol="BTCUSD", qty=Decimal("1"), qty_available=Decimal("1")
+        ),
+        delay_s=0.02,
     )
     barrier = asyncio.Barrier(2)
 
@@ -270,7 +273,11 @@ async def test_sequential_distinct_sells_reserve_across_calls(db_session):
         max_qty=Decimal("1"),
         qty_source="manual_operator",
     )
-    broker = FinalBroker(position=SimpleNamespace(symbol="BTCUSD", qty=Decimal("1")))
+    broker = FinalBroker(
+        position=SimpleNamespace(
+            symbol="BTCUSD", qty=Decimal("1"), qty_available=Decimal("1")
+        )
+    )
     ledger = AlpacaPaperLedgerService(db_session)
     coord = AlpacaPaperSubmitCoordinator(ledger, lambda: broker, now_fn=lambda: _NOW)
 

--- a/tests/services/test_alpaca_paper_final_review.py
+++ b/tests/services/test_alpaca_paper_final_review.py
@@ -33,8 +33,13 @@ _CORR = "rob842-final"
 
 @pytest_asyncio.fixture(autouse=True)
 async def _clean(db_session):
+    # Manual sell rows key their correlation on the derived manual coid
+    # (rob74-crypto-…), so also clear manual keys to avoid a leftover open sell
+    # polluting the account+symbol reservation across tests.
     stmt = delete(AlpacaPaperOrderLedger).where(
         AlpacaPaperOrderLedger.lifecycle_correlation_id.like(f"{_CORR}%")
+        | AlpacaPaperOrderLedger.client_order_id.like("rob74-crypto-%")
+        | AlpacaPaperOrderLedger.client_order_id.like("rob73-%")
     )
     await db_session.execute(stmt)
     await db_session.commit()
@@ -94,10 +99,21 @@ def _canonical(side="buy", *, qty=None, notional="10", limit="50000"):
     )
 
 
-def _packet(canonical, corr, *, expires_at, **overrides):
+def _packet(canonical, corr, *, expires_at, origin="automated", **overrides):
+    from app.services.alpaca_paper_submit_service import derive_client_order_id
     from app.services.paper_approval_packet import PaperApprovalPacket
 
     snap = f"{corr}-snap"
+    if origin == "manual":
+        coid = derive_client_order_id(canonical)
+        corr_id = coid
+        snap_id = None
+    else:
+        coid = derive_automated_key(
+            correlation_id=corr, snapshot_id=snap, canonical=canonical
+        )
+        corr_id = corr
+        snap_id = snap
     defaults: dict[str, Any] = {
         "signal_source": "test",
         "artifact_id": uuid.uuid4(),
@@ -110,19 +126,18 @@ def _packet(canonical, corr, *, expires_at, **overrides):
         "max_notional": Decimal("10"),
         "qty_source": "notional_estimate",
         "expected_lifecycle_step": "previewed",
-        "lifecycle_correlation_id": corr,
-        "client_order_id": derive_automated_key(
-            correlation_id=corr, snapshot_id=snap, canonical=canonical
-        ),
+        "lifecycle_correlation_id": corr_id,
+        "client_order_id": coid,
         "expires_at": expires_at,
         "account_mode": "alpaca_paper",
-        "origin": "automated",
+        "origin": origin,
         "market_data_asof": _NOW - timedelta(seconds=10),
         "market_data_source": "upbit_ticker",
         "preview_payload_hash": canonical_hash(canonical),
-        "snapshot_id": snap,
+        "snapshot_id": snap_id,
         "execution_order_type": canonical.get("type"),
         "execution_time_in_force": canonical.get("time_in_force"),
+        "reference_price": Decimal("50000"),
     }
     defaults.update(overrides)
     return PaperApprovalPacket(**defaults)
@@ -187,19 +202,21 @@ async def test_distinct_sells_do_not_oversell_position(db_session):
         c06,
         corr,
         expires_at=_NOW + timedelta(hours=1),
+        origin="manual",
         side="sell",
         max_notional=None,
         max_qty=Decimal("1"),
-        qty_source="ledger_filled_qty",
+        qty_source="manual_operator",
     )
     p07 = _packet(
         c07,
         corr,
         expires_at=_NOW + timedelta(hours=1),
+        origin="manual",
         side="sell",
         max_notional=None,
         max_qty=Decimal("1"),
-        qty_source="ledger_filled_qty",
+        qty_source="manual_operator",
     )
     shared = FinalBroker(
         position=SimpleNamespace(symbol="BTCUSD", qty=Decimal("1")), delay_s=0.02
@@ -237,19 +254,21 @@ async def test_sequential_distinct_sells_reserve_across_calls(db_session):
         c06,
         corr,
         expires_at=_NOW + timedelta(hours=1),
+        origin="manual",
         side="sell",
         max_notional=None,
         max_qty=Decimal("1"),
-        qty_source="ledger_filled_qty",
+        qty_source="manual_operator",
     )
     p07 = _packet(
         c07,
         corr,
         expires_at=_NOW + timedelta(hours=1),
+        origin="manual",
         side="sell",
         max_notional=None,
         max_qty=Decimal("1"),
-        qty_source="ledger_filled_qty",
+        qty_source="manual_operator",
     )
     broker = FinalBroker(position=SimpleNamespace(symbol="BTCUSD", qty=Decimal("1")))
     ledger = AlpacaPaperLedgerService(db_session)

--- a/tests/services/test_alpaca_paper_ledger_claim.py
+++ b/tests/services/test_alpaca_paper_ledger_claim.py
@@ -1,0 +1,135 @@
+"""ROB-842 atomic submit-claim on the existing Alpaca paper ledger (DB-backed).
+
+Exercises the real PostgreSQL partial-unique execution slot: a single winner,
+losing duplicates, the in-flight discriminator, and a genuine two-session /
+barrier concurrency race proving exactly one caller claims submit ownership.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from decimal import Decimal
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import delete
+
+from app.models.review import AlpacaPaperOrderLedger
+from app.models.trading import InstrumentType
+from app.services.alpaca_paper_ledger_service import (
+    AlpacaPaperLedgerService,
+    is_inflight_execution,
+)
+
+pytestmark = [pytest.mark.asyncio]
+
+_COIDS = (
+    "rob842-claim-winner",
+    "rob842-claim-dup-seq",
+    "rob842-claim-inflight",
+    "rob842-claim-barrier",
+)
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def _clean_rows(db_session):
+    await db_session.execute(
+        delete(AlpacaPaperOrderLedger).where(
+            AlpacaPaperOrderLedger.client_order_id.in_(_COIDS)
+        )
+    )
+    await db_session.commit()
+    yield
+    await db_session.execute(
+        delete(AlpacaPaperOrderLedger).where(
+            AlpacaPaperOrderLedger.client_order_id.in_(_COIDS)
+        )
+    )
+    await db_session.commit()
+
+
+def _claim_kwargs(coid: str) -> dict:
+    return {
+        "client_order_id": coid,
+        "lifecycle_correlation_id": coid,
+        "execution_symbol": "BTC/USD",
+        "execution_venue": "alpaca_paper",
+        "instrument_type": InstrumentType.crypto,
+        "side": "buy",
+        "order_type": "limit",
+        "time_in_force": "gtc",
+        "requested_notional": Decimal("10"),
+        "requested_price": Decimal("50000"),
+        "preview_payload": {"symbol": "BTC/USD", "side": "buy"},
+    }
+
+
+async def test_claim_submit_winner_inserts_inflight_execution_row(db_session):
+    svc = AlpacaPaperLedgerService(db_session)
+    claim = await svc.claim_submit(**_claim_kwargs("rob842-claim-winner"))
+
+    assert claim.won is True
+    assert claim.row is not None
+    assert claim.row.record_kind == "execution"
+    assert claim.row.lifecycle_state == "submitted"
+    assert is_inflight_execution(claim.row) is True
+
+
+async def test_claim_submit_sequential_duplicate_loses(db_session):
+    svc = AlpacaPaperLedgerService(db_session)
+    first = await svc.claim_submit(**_claim_kwargs("rob842-claim-dup-seq"))
+    second = await svc.claim_submit(**_claim_kwargs("rob842-claim-dup-seq"))
+
+    assert first.won is True
+    assert second.won is False
+    # Both resolve to the same single execution row.
+    assert second.row is not None
+    assert second.row.id == first.row.id
+
+
+async def test_record_submit_clears_inflight_marker(db_session):
+    svc = AlpacaPaperLedgerService(db_session)
+    claim = await svc.claim_submit(**_claim_kwargs("rob842-claim-inflight"))
+    assert is_inflight_execution(claim.row) is True
+
+    await svc.record_submit(
+        "rob842-claim-inflight",
+        {"id": "paper-xyz", "status": "accepted", "filled_qty": "0"},
+        raw_response={"id": "paper-xyz", "status": "accepted"},
+    )
+    # Fresh snapshot (session is expire_on_commit=False).
+    db_session.expire_all()
+    row = await svc.find_executed_by_client_order_id("rob842-claim-inflight")
+    assert row.broker_order_id == "paper-xyz"
+    assert row.submitted_at is not None
+    assert is_inflight_execution(row) is False
+
+
+async def test_two_session_barrier_exactly_one_winner(db_session):
+    """Two independent DB sessions race the same claim; exactly one wins."""
+    from app.core.db import AsyncSessionLocal
+
+    coid = "rob842-claim-barrier"
+    barrier = asyncio.Barrier(2)
+
+    async def _attempt() -> bool:
+        async with AsyncSessionLocal() as session:
+            svc = AlpacaPaperLedgerService(session)
+            # Align both inserts as closely as possible at the DB.
+            await barrier.wait()
+            claim = await svc.claim_submit(**_claim_kwargs(coid))
+            return claim.won
+
+    results = await asyncio.gather(_attempt(), _attempt())
+
+    assert sum(1 for won in results if won) == 1, results
+    # Exactly one execution row exists for the intent.
+    rows = (
+        await db_session.execute(
+            delete(AlpacaPaperOrderLedger)
+            .where(AlpacaPaperOrderLedger.client_order_id == coid)
+            .returning(AlpacaPaperOrderLedger.id)
+        )
+    ).all()
+    await db_session.commit()
+    assert len(rows) == 1

--- a/tests/services/test_alpaca_paper_market_evidence.py
+++ b/tests/services/test_alpaca_paper_market_evidence.py
@@ -1,0 +1,87 @@
+"""ROB-842 G5: a caller/order-derived (synthetic) snapshot cannot be trusted
+market evidence for a production submit."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import delete
+
+from app.core.db import AsyncSessionLocal
+from app.models.market_quote_snapshot import MarketQuoteSnapshot
+from app.services.alpaca_paper_market_evidence import (
+    MarketEvidenceError,
+    load_market_evidence,
+)
+
+pytestmark = [pytest.mark.asyncio]
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def _clean():
+    stmt = delete(MarketQuoteSnapshot).where(MarketQuoteSnapshot.symbol == "AAPL")
+    async with AsyncSessionLocal() as db:
+        await db.execute(stmt)
+        await db.commit()
+    yield
+    async with AsyncSessionLocal() as db:
+        await db.execute(stmt)
+        await db.commit()
+
+
+async def _seed(raw_payload) -> int:
+    async with AsyncSessionLocal() as db:
+        row = MarketQuoteSnapshot(
+            market="us",
+            symbol="AAPL",
+            source="yahoo",
+            snapshot_at=datetime.now(UTC),
+            price=Decimal("150"),
+            raw_payload=raw_payload,
+        )
+        db.add(row)
+        await db.commit()
+        return row.id
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        {"synthetic": True},
+        {"provenance": "smoke"},
+        {"provenance": "operator_synthetic"},
+        {"provenance": "order_derived"},
+    ],
+)
+async def test_synthetic_snapshot_rejected_as_evidence(raw):
+    sid = await _seed(raw)
+    async with AsyncSessionLocal() as db:
+        with pytest.raises(MarketEvidenceError) as exc:
+            await load_market_evidence(
+                db,
+                sid,
+                execution_symbol="AAPL",
+                asset_class="us_equity",
+                now=datetime.now(UTC),
+                max_age=timedelta(minutes=5),
+            )
+    assert exc.value.code == "synthetic_snapshot"
+
+
+async def test_genuine_snapshot_accepted_as_evidence():
+    # A real (unmarked / real-payload) snapshot is accepted.
+    sid = await _seed({"source_api": "yahoo", "regularMarketPrice": 150})
+    async with AsyncSessionLocal() as db:
+        evidence = await load_market_evidence(
+            db,
+            sid,
+            execution_symbol="AAPL",
+            asset_class="us_equity",
+            now=datetime.now(UTC),
+            max_age=timedelta(minutes=5),
+        )
+    assert evidence.price == Decimal("150")
+    assert evidence.market_data_source == "yahoo"

--- a/tests/services/test_alpaca_paper_review5.py
+++ b/tests/services/test_alpaca_paper_review5.py
@@ -178,7 +178,11 @@ async def test_freshness_rechecked_at_send_blocks_stale_sell(db_session):
         max_notional=None,
         max_qty=Decimal("1"),
     )
-    broker = Broker(position=SimpleNamespace(symbol="BTCUSD", qty=Decimal("1")))
+    broker = Broker(
+        position=SimpleNamespace(
+            symbol="BTCUSD", qty=Decimal("1"), qty_available=Decimal("1")
+        )
+    )
     clock = _Clock([_NOW + timedelta(seconds=299), _NOW + timedelta(seconds=301)])
     coord = AlpacaPaperSubmitCoordinator(
         AlpacaPaperLedgerService(db_session),
@@ -211,7 +215,14 @@ async def test_fresh_at_send_still_posts(db_session):
 # G4 — reservation lifecycle: only OPEN sells consume; filled already in position
 # ---------------------------------------------------------------------------
 async def _seed_sell_row(
-    db_session, *, coid, symbol, qty, lifecycle, cancel_status=None
+    db_session,
+    *,
+    coid,
+    symbol,
+    qty,
+    lifecycle,
+    cancel_status=None,
+    position_snapshot=None,
 ):
     """Directly insert an execution sell row in a chosen lifecycle."""
     row = AlpacaPaperOrderLedger(
@@ -229,6 +240,7 @@ async def _seed_sell_row(
         currency="USD",
         requested_qty=Decimal(str(qty)),
         cancel_status=cancel_status,
+        position_snapshot=position_snapshot,
         submitted_at=datetime.now(UTC),
         broker_order_id=f"b-{coid}",
         confirm_flag=True,
@@ -257,6 +269,7 @@ async def test_filled_sell_not_double_counted(db_session):
         instrument_type=InstrumentType.crypto,
         requested_qty=Decimal("0.4"),
         position_qty=Decimal("0.4"),
+        position_available=Decimal("0.4"),
     )
     assert claim.insufficient is False
     assert claim.won is True
@@ -280,6 +293,7 @@ async def test_open_submitted_sell_is_reserved(db_session):
         instrument_type=InstrumentType.crypto,
         requested_qty=Decimal("0.6"),
         position_qty=Decimal("1"),
+        position_available=Decimal("0.5"),
     )
     assert claim.insufficient is True  # 0.6 > (1 - 0.5 open)
     assert claim.available == Decimal("0.5")
@@ -303,6 +317,7 @@ async def test_canceled_sell_releases_reservation(db_session):
         instrument_type=InstrumentType.crypto,
         requested_qty=Decimal("0.6"),
         position_qty=Decimal("1"),
+        position_available=Decimal("0.5"),
     )
     assert blocked.insufficient is True
 
@@ -318,6 +333,7 @@ async def test_canceled_sell_releases_reservation(db_session):
         instrument_type=InstrumentType.crypto,
         requested_qty=Decimal("0.6"),
         position_qty=Decimal("1"),
+        position_available=Decimal("1"),
     )
     assert allowed.insufficient is False
     assert allowed.available == Decimal("1")  # full position free again
@@ -375,10 +391,22 @@ async def test_new_sell_reconciles_async_filled_open_sell(db_session):
     # A new 0.4 sell must be allowed once the stale submitted row is reconciled.
     open_coid = f"{_CORR}-async-open"
     await _seed_sell_row(
-        db_session, coid=open_coid, symbol="BTC/USD", qty="0.6", lifecycle="submitted"
+        db_session,
+        coid=open_coid,
+        symbol="BTC/USD",
+        qty="0.6",
+        lifecycle="submitted",
+        position_snapshot={
+            "snapshot_kind": "sell_claim_baseline",
+            "qty": "1",
+            "qty_available": "1",
+            "fetched_at": _NOW.isoformat(),
+        },
     )
     broker = ReconcileBroker(
-        position=SimpleNamespace(symbol="BTCUSD", qty=Decimal("0.4")),
+        position=SimpleNamespace(
+            symbol="BTCUSD", qty=Decimal("0.4"), qty_available=Decimal("0.4")
+        ),
         orders={open_coid: _order(open_coid, "filled", qty="0.6")},
     )
     canonical = _canonical("sell", qty="0.4", notional=None)
@@ -405,7 +433,9 @@ async def test_new_sell_keeps_reservation_when_open_still_open(db_session):
         db_session, coid=open_coid, symbol="BTC/USD", qty="0.6", lifecycle="submitted"
     )
     broker = ReconcileBroker(
-        position=SimpleNamespace(symbol="BTCUSD", qty=Decimal("1")),
+        position=SimpleNamespace(
+            symbol="BTCUSD", qty=Decimal("1"), qty_available=Decimal("0.4")
+        ),
         orders={open_coid: _order(open_coid, "accepted")},
     )
     canonical = _canonical("sell", qty="0.6", notional=None)
@@ -433,10 +463,22 @@ async def test_concurrent_reconcile_and_new_sells_no_oversell(db_session):
 
     open_coid = f"{_CORR}-conc-open"
     await _seed_sell_row(
-        db_session, coid=open_coid, symbol="BTC/USD", qty="0.6", lifecycle="submitted"
+        db_session,
+        coid=open_coid,
+        symbol="BTC/USD",
+        qty="0.6",
+        lifecycle="submitted",
+        position_snapshot={
+            "snapshot_kind": "sell_claim_baseline",
+            "qty": "1",
+            "qty_available": "1",
+            "fetched_at": _NOW.isoformat(),
+        },
     )
     shared = ReconcileBroker(
-        position=SimpleNamespace(symbol="BTCUSD", qty=Decimal("0.4")),
+        position=SimpleNamespace(
+            symbol="BTCUSD", qty=Decimal("0.4"), qty_available=Decimal("0.4")
+        ),
         orders={open_coid: _order(open_coid, "filled", qty="0.6")},
     )
     barrier = asyncio.Barrier(2)
@@ -476,7 +518,9 @@ async def test_new_sell_fail_closes_when_broker_lookup_fails(db_session):
         db_session, coid=open_coid, symbol="BTC/USD", qty="0.6", lifecycle="submitted"
     )
     broker = ReconcileBroker(
-        position=SimpleNamespace(symbol="BTCUSD", qty=Decimal("1")),
+        position=SimpleNamespace(
+            symbol="BTCUSD", qty=Decimal("1"), qty_available=Decimal("0.4")
+        ),
         raise_lookup={open_coid},
     )
     canonical = _canonical("sell", qty="0.6", notional=None)
@@ -494,3 +538,228 @@ async def test_new_sell_fail_closes_when_broker_lookup_fails(db_session):
     assert outcome.status == "rejected"
     assert outcome.reason_code == "qty_exceeds_available"
     assert broker.submit_calls == []
+
+
+async def test_new_sell_blocks_when_filled_precedes_position_snapshot(db_session):
+    """A filled order cannot release its hold while position evidence is stale."""
+    open_coid = f"{_CORR}-filled-stale-position"
+    await _seed_sell_row(
+        db_session,
+        coid=open_coid,
+        symbol="BTC/USD",
+        qty="0.6",
+        lifecycle="submitted",
+        position_snapshot={
+            "snapshot_kind": "sell_claim_baseline",
+            "qty": "1",
+            "qty_available": "1",
+            "fetched_at": _NOW.isoformat(),
+        },
+    )
+    broker = ReconcileBroker(
+        position=SimpleNamespace(
+            symbol="BTCUSD", qty=Decimal("1"), qty_available=Decimal("1")
+        ),
+        orders={open_coid: _order(open_coid, "filled", qty="0.6")},
+    )
+    canonical = _canonical("sell", qty="0.7", notional=None)
+    packet = _packet(
+        canonical,
+        f"{_CORR}-filled-stale-new",
+        origin="manual",
+        max_notional=None,
+        max_qty=Decimal("1"),
+    )
+    coord = AlpacaPaperSubmitCoordinator(
+        AlpacaPaperLedgerService(db_session), lambda: broker, now_fn=lambda: _NOW
+    )
+
+    outcome = await coord.submit(packet, submit_canonical=canonical)
+
+    assert outcome.status == "rejected"
+    assert outcome.reason_code == "position_reconciliation_pending"
+    assert broker.submit_calls == []
+    db_session.expire_all()
+    rows = await AlpacaPaperLedgerService(db_session).list_open_sells(
+        account_mode="alpaca_paper", execution_symbol="BTC/USD"
+    )
+    assert {row.client_order_id for row in rows} == {open_coid}
+
+
+async def test_immediate_filled_submit_keeps_hold_until_position_reflects(db_session):
+    """A POST response of filled is not itself causal position evidence."""
+
+    class ImmediateFillBroker(ReconcileBroker):
+        def __init__(self):
+            super().__init__(
+                position=SimpleNamespace(
+                    symbol="BTCUSD", qty=Decimal("1"), qty_available=Decimal("1")
+                )
+            )
+            self.filled_orders = {}
+
+        async def submit_order(self, request):
+            self.submit_calls.append(request)
+            order = _order(request.client_order_id, "filled", qty=str(request.qty))
+            self.filled_orders[request.client_order_id] = order
+            return order
+
+        async def get_order_by_client_order_id(self, client_order_id):
+            return self.filled_orders.get(client_order_id)
+
+    broker = ImmediateFillBroker()
+    first_canonical = _canonical("sell", qty="0.6", notional=None)
+    first_packet = _packet(
+        first_canonical,
+        f"{_CORR}-immediate-first",
+        origin="manual",
+        max_notional=None,
+        max_qty=Decimal("1"),
+    )
+    second_canonical = _canonical("sell", qty="0.7", notional=None)
+    second_packet = _packet(
+        second_canonical,
+        f"{_CORR}-immediate-second",
+        origin="manual",
+        max_notional=None,
+        max_qty=Decimal("1"),
+    )
+    coord = AlpacaPaperSubmitCoordinator(
+        AlpacaPaperLedgerService(db_session), lambda: broker, now_fn=lambda: _NOW
+    )
+
+    first = await coord.submit(first_packet, submit_canonical=first_canonical)
+    second = await coord.submit(second_packet, submit_canonical=second_canonical)
+
+    assert first.status == "submitted"
+    assert second.status == "rejected"
+    assert second.reason_code == "position_reconciliation_pending"
+    assert len(broker.submit_calls) == 1
+
+
+async def test_new_sell_blocks_filled_legacy_row_without_baseline(db_session):
+    """A legacy submitted sell without claim baseline is causally ambiguous."""
+    open_coid = f"{_CORR}-filled-no-baseline"
+    await _seed_sell_row(
+        db_session,
+        coid=open_coid,
+        symbol="BTC/USD",
+        qty="0.6",
+        lifecycle="submitted",
+    )
+    broker = ReconcileBroker(
+        position=SimpleNamespace(
+            symbol="BTCUSD", qty=Decimal("0.4"), qty_available=Decimal("0.4")
+        ),
+        orders={open_coid: _order(open_coid, "filled", qty="0.6")},
+    )
+    canonical = _canonical("sell", qty="0.4", notional=None)
+    packet = _packet(
+        canonical,
+        f"{_CORR}-filled-no-baseline-new",
+        origin="manual",
+        max_notional=None,
+        max_qty=Decimal("1"),
+    )
+    coord = AlpacaPaperSubmitCoordinator(
+        AlpacaPaperLedgerService(db_session), lambda: broker, now_fn=lambda: _NOW
+    )
+
+    outcome = await coord.submit(packet, submit_canonical=canonical)
+
+    assert outcome.status == "rejected"
+    assert outcome.reason_code == "position_reconciliation_pending"
+    assert broker.submit_calls == []
+
+
+async def test_full_fill_flat_position_commits_causal_reconciliation(db_session):
+    """A flat position is causal zero evidence and should finalize the old fill."""
+    open_coid = f"{_CORR}-filled-flat"
+    await _seed_sell_row(
+        db_session,
+        coid=open_coid,
+        symbol="BTC/USD",
+        qty="0.6",
+        lifecycle="submitted",
+        position_snapshot={
+            "snapshot_kind": "sell_claim_baseline",
+            "qty": "0.6",
+            "qty_available": "0.6",
+            "fetched_at": _NOW.isoformat(),
+        },
+    )
+    broker = ReconcileBroker(
+        position=None,
+        orders={open_coid: _order(open_coid, "filled", qty="0.6")},
+    )
+    canonical = _canonical("sell", qty="0.1", notional=None)
+    packet = _packet(
+        canonical,
+        f"{_CORR}-filled-flat-new",
+        origin="manual",
+        max_notional=None,
+        max_qty=Decimal("1"),
+    )
+    coord = AlpacaPaperSubmitCoordinator(
+        AlpacaPaperLedgerService(db_session), lambda: broker, now_fn=lambda: _NOW
+    )
+
+    outcome = await coord.submit(packet, submit_canonical=canonical)
+
+    assert outcome.status == "rejected"
+    assert outcome.reason_code == "position_flat"
+    db_session.expire_all()
+    rows = await AlpacaPaperLedgerService(db_session).list_open_sells(
+        account_mode="alpaca_paper", execution_symbol="BTC/USD"
+    )
+    assert rows == []
+
+
+@pytest.mark.parametrize("unknown_status", ["pending_review", " ", 123])
+async def test_new_sell_keeps_reservation_for_unknown_broker_status(
+    db_session, unknown_status
+):
+    """Unknown/blank/non-string statuses are not terminal reservation evidence."""
+    open_coid = f"{_CORR}-unknown-{unknown_status!r}"
+    await _seed_sell_row(
+        db_session, coid=open_coid, symbol="BTC/USD", qty="0.6", lifecycle="submitted"
+    )
+    broker = ReconcileBroker(
+        position=SimpleNamespace(
+            symbol="BTCUSD", qty=Decimal("1"), qty_available=Decimal("1")
+        ),
+        orders={
+            open_coid: {
+                "id": f"b-{open_coid}",
+                "client_order_id": open_coid,
+                "symbol": "BTC/USD",
+                "filled_qty": "0",
+                "side": "sell",
+                "type": "limit",
+                "time_in_force": "gtc",
+                "status": unknown_status,
+            }
+        },
+    )
+    canonical = _canonical("sell", qty="0.6", notional=None)
+    packet = _packet(
+        canonical,
+        f"{_CORR}-unknown-new-{unknown_status!r}",
+        origin="manual",
+        max_notional=None,
+        max_qty=Decimal("1"),
+    )
+    coord = AlpacaPaperSubmitCoordinator(
+        AlpacaPaperLedgerService(db_session), lambda: broker, now_fn=lambda: _NOW
+    )
+
+    outcome = await coord.submit(packet, submit_canonical=canonical)
+
+    assert outcome.status == "rejected"
+    assert outcome.reason_code == "qty_exceeds_available"
+    assert broker.submit_calls == []
+    db_session.expire_all()
+    rows = await AlpacaPaperLedgerService(db_session).list_open_sells(
+        account_mode="alpaca_paper", execution_symbol="BTC/USD"
+    )
+    assert {row.client_order_id for row in rows} == {open_coid}

--- a/tests/services/test_alpaca_paper_review5.py
+++ b/tests/services/test_alpaca_paper_review5.py
@@ -25,7 +25,7 @@ from app.services.alpaca_paper_submit_service import (
     derive_client_order_id,
 )
 from app.services.brokers.alpaca.exceptions import AlpacaPaperRequestError
-from app.services.brokers.alpaca.schemas import Order
+from app.services.brokers.alpaca.schemas import Order, Position
 
 pytestmark = [pytest.mark.asyncio]
 
@@ -635,6 +635,309 @@ async def test_immediate_filled_submit_keeps_hold_until_position_reflects(db_ses
     assert second.status == "rejected"
     assert second.reason_code == "position_reconciliation_pending"
     assert len(broker.submit_calls) == 1
+
+
+@pytest.mark.parametrize("broker_status", ["pending_review", " "])
+async def test_immediate_unknown_sell_status_holds_and_replays_truthfully(
+    db_session, broker_status
+):
+    """Unknown Pydantic broker status is success truth, not release evidence."""
+
+    class UnknownStatusBroker(ReconcileBroker):
+        async def submit_order(self, request):
+            self.submit_calls.append(request)
+            return _order(request.client_order_id, broker_status)
+
+    broker = UnknownStatusBroker(
+        position=Position(
+            asset_id="btc",
+            symbol="BTCUSD",
+            qty=Decimal("1"),
+            qty_available=Decimal("1"),
+            avg_entry_price=Decimal("50000"),
+            side="long",
+        )
+    )
+    canonical = _canonical("sell", qty="0.6", notional=None)
+    packet = _packet(
+        canonical,
+        f"{_CORR}-immediate-unknown-{broker_status!r}",
+        origin="manual",
+        max_notional=None,
+        max_qty=Decimal("1"),
+    )
+    ledger = AlpacaPaperLedgerService(db_session)
+    coord = AlpacaPaperSubmitCoordinator(ledger, lambda: broker, now_fn=lambda: _NOW)
+
+    first = await coord.submit(packet, submit_canonical=canonical)
+    db_session.expire_all()
+    row = await ledger.get_execution_by_client_order_id(packet.client_order_id)
+    replay = await coord.submit(packet, submit_canonical=canonical)
+
+    assert first.status == "submitted"
+    assert first.success is True
+    assert row is not None
+    assert row.lifecycle_state == "submitted"
+    assert row.order_status == broker_status
+    assert replay.status == "replayed"
+    assert replay.success is True
+    assert len(broker.submit_calls) == 1
+
+
+async def test_immediate_non_string_sell_status_holds_and_replays(db_session):
+    """A raw unparseable status cannot turn a successful sell into anomaly."""
+
+    class NonStringStatusBroker(ReconcileBroker):
+        async def submit_order(self, request):
+            self.submit_calls.append(request)
+            return {
+                "id": f"b-{request.client_order_id}",
+                "client_order_id": request.client_order_id,
+                "symbol": "BTC/USD",
+                "filled_qty": "0",
+                "side": "sell",
+                "type": "limit",
+                "time_in_force": "gtc",
+                "status": 123,
+            }
+
+    broker = NonStringStatusBroker(
+        position=Position(
+            asset_id="btc",
+            symbol="BTCUSD",
+            qty=Decimal("1"),
+            qty_available=Decimal("1"),
+            avg_entry_price=Decimal("50000"),
+            side="long",
+        )
+    )
+    canonical = _canonical("sell", qty="0.6", notional=None)
+    packet = _packet(
+        canonical,
+        f"{_CORR}-immediate-non-string",
+        origin="manual",
+        max_notional=None,
+        max_qty=Decimal("1"),
+    )
+    ledger = AlpacaPaperLedgerService(db_session)
+    coord = AlpacaPaperSubmitCoordinator(ledger, lambda: broker, now_fn=lambda: _NOW)
+
+    first = await coord.submit(packet, submit_canonical=canonical)
+    db_session.expire_all()
+    row = await ledger.get_execution_by_client_order_id(packet.client_order_id)
+    replay = await coord.submit(packet, submit_canonical=canonical)
+
+    assert first.status == "submitted"
+    assert row is not None
+    assert row.lifecycle_state == "submitted"
+    assert row.order_status is None
+    assert replay.status == "replayed"
+    assert len(broker.submit_calls) == 1
+
+
+async def test_immediate_rejected_sell_matches_terminal_replay(db_session):
+    """A known releasable terminal response is failure on first call and replay."""
+
+    class RejectedStatusBroker(ReconcileBroker):
+        async def submit_order(self, request):
+            self.submit_calls.append(request)
+            return _order(request.client_order_id, "rejected")
+
+    broker = RejectedStatusBroker(
+        position=Position(
+            asset_id="btc",
+            symbol="BTCUSD",
+            qty=Decimal("1"),
+            qty_available=Decimal("1"),
+            avg_entry_price=Decimal("50000"),
+            side="long",
+        )
+    )
+    canonical = _canonical("sell", qty="0.6", notional=None)
+    packet = _packet(
+        canonical,
+        f"{_CORR}-immediate-rejected",
+        origin="manual",
+        max_notional=None,
+        max_qty=Decimal("1"),
+    )
+    coord = AlpacaPaperSubmitCoordinator(
+        AlpacaPaperLedgerService(db_session), lambda: broker, now_fn=lambda: _NOW
+    )
+
+    first = await coord.submit(packet, submit_canonical=canonical)
+    replay = await coord.submit(packet, submit_canonical=canonical)
+
+    assert first.status == "failed"
+    assert first.success is False
+    assert first.broker_called is True
+    assert replay.status == "failed"
+    assert replay.success is False
+    assert len(broker.submit_calls) == 1
+
+
+@pytest.mark.parametrize(
+    ("recovered_status", "filled_qty", "second_reason"),
+    [
+        ("filled", "0.6", "position_reconciliation_pending"),
+        ("pending_review", "0", "qty_exceeds_available"),
+    ],
+)
+async def test_recovered_sell_status_keeps_hold_before_causal_position_evidence(
+    db_session, recovered_status, filled_qty, second_reason
+):
+    """Crash recovery must inspect claim side and retain ambiguous sell holds."""
+
+    first_canonical = _canonical("sell", qty="0.6", notional=None)
+    first_packet = _packet(
+        first_canonical,
+        f"{_CORR}-recover-{recovered_status}-first",
+        origin="manual",
+        max_notional=None,
+        max_qty=Decimal("1"),
+    )
+
+    class RecoveringSellBroker(ReconcileBroker):
+        async def submit_order(self, request):
+            self.submit_calls.append(request)
+            raise AlpacaPaperRequestError("uncertain", status_code=500)
+
+        async def get_order_by_client_order_id(self, client_order_id):
+            if client_order_id != first_packet.client_order_id:
+                return None
+            return _order(client_order_id, recovered_status, qty=filled_qty)
+
+    broker = RecoveringSellBroker(
+        position=Position(
+            asset_id="btc",
+            symbol="BTCUSD",
+            qty=Decimal("1"),
+            qty_available=Decimal("1"),
+            avg_entry_price=Decimal("50000"),
+            side="long",
+        )
+    )
+    ledger = AlpacaPaperLedgerService(db_session)
+    coord = AlpacaPaperSubmitCoordinator(ledger, lambda: broker, now_fn=lambda: _NOW)
+
+    recovered = await coord.submit(first_packet, submit_canonical=first_canonical)
+
+    second_canonical = _canonical("sell", qty="0.7", notional=None)
+    second_packet = _packet(
+        second_canonical,
+        f"{_CORR}-recover-{recovered_status}-second",
+        origin="manual",
+        max_notional=None,
+        max_qty=Decimal("1"),
+    )
+    second = await coord.submit(second_packet, submit_canonical=second_canonical)
+    db_session.expire_all()
+    recovered_row = await ledger.get_execution_by_client_order_id(
+        first_packet.client_order_id
+    )
+
+    assert recovered.status == "recovered"
+    assert recovered.success is True
+    assert recovered_row is not None
+    assert recovered_row.side == "sell"
+    assert recovered_row.lifecycle_state == "submitted"
+    assert second.status == "rejected"
+    assert second.reason_code == second_reason
+    assert len(broker.submit_calls) == 1
+
+
+async def test_zero_position_object_commits_causally_reflected_fill(db_session):
+    """qty=0 is causal evidence only after qty_available and baseline checks."""
+    open_coid = f"{_CORR}-zero-causal-open"
+    await _seed_sell_row(
+        db_session,
+        coid=open_coid,
+        symbol="BTC/USD",
+        qty="0.6",
+        lifecycle="submitted",
+        position_snapshot={
+            "snapshot_kind": "sell_claim_baseline",
+            "qty": "0.6",
+            "qty_available": "0.6",
+            "fetched_at": _NOW.isoformat(),
+        },
+    )
+    broker = ReconcileBroker(
+        position=Position(
+            asset_id="btc",
+            symbol="BTCUSD",
+            qty=Decimal("0"),
+            qty_available=Decimal("0"),
+            avg_entry_price=Decimal("50000"),
+            side="long",
+        ),
+        orders={open_coid: _order(open_coid, "filled", qty="0.6")},
+    )
+    canonical = _canonical("sell", qty="0.1", notional=None)
+    packet = _packet(
+        canonical,
+        f"{_CORR}-zero-causal-new",
+        origin="manual",
+        max_notional=None,
+        max_qty=Decimal("1"),
+    )
+    ledger = AlpacaPaperLedgerService(db_session)
+    coord = AlpacaPaperSubmitCoordinator(ledger, lambda: broker, now_fn=lambda: _NOW)
+
+    outcome = await coord.submit(packet, submit_canonical=canonical)
+    db_session.expire_all()
+    rows = await ledger.list_open_sells(
+        account_mode="alpaca_paper", execution_symbol="BTC/USD"
+    )
+
+    assert outcome.status == "rejected"
+    assert outcome.reason_code == "position_flat"
+    assert rows == []
+    assert broker.submit_calls == []
+
+
+async def test_zero_position_object_without_baseline_stays_pending(db_session):
+    """A legacy filled sell cannot be released merely because qty is zero."""
+    open_coid = f"{_CORR}-zero-legacy-open"
+    await _seed_sell_row(
+        db_session,
+        coid=open_coid,
+        symbol="BTC/USD",
+        qty="0.6",
+        lifecycle="submitted",
+    )
+    broker = ReconcileBroker(
+        position=Position(
+            asset_id="btc",
+            symbol="BTCUSD",
+            qty=Decimal("0"),
+            qty_available=Decimal("0"),
+            avg_entry_price=Decimal("50000"),
+            side="long",
+        ),
+        orders={open_coid: _order(open_coid, "filled", qty="0.6")},
+    )
+    canonical = _canonical("sell", qty="0.1", notional=None)
+    packet = _packet(
+        canonical,
+        f"{_CORR}-zero-legacy-new",
+        origin="manual",
+        max_notional=None,
+        max_qty=Decimal("1"),
+    )
+    ledger = AlpacaPaperLedgerService(db_session)
+    coord = AlpacaPaperSubmitCoordinator(ledger, lambda: broker, now_fn=lambda: _NOW)
+
+    outcome = await coord.submit(packet, submit_canonical=canonical)
+    db_session.expire_all()
+    rows = await ledger.list_open_sells(
+        account_mode="alpaca_paper", execution_symbol="BTC/USD"
+    )
+
+    assert outcome.status == "rejected"
+    assert outcome.reason_code == "position_reconciliation_pending"
+    assert {row.client_order_id for row in rows} == {open_coid}
+    assert broker.submit_calls == []
 
 
 async def test_new_sell_blocks_filled_legacy_row_without_baseline(db_session):

--- a/tests/services/test_alpaca_paper_review5.py
+++ b/tests/services/test_alpaca_paper_review5.py
@@ -24,6 +24,7 @@ from app.services.alpaca_paper_submit_service import (
     derive_automated_key,
     derive_client_order_id,
 )
+from app.services.brokers.alpaca.exceptions import AlpacaPaperRequestError
 from app.services.brokers.alpaca.schemas import Order
 
 pytestmark = [pytest.mark.asyncio]
@@ -320,3 +321,176 @@ async def test_canceled_sell_releases_reservation(db_session):
     )
     assert allowed.insufficient is False
     assert allowed.available == Decimal("1")  # full position free again
+
+
+# ---------------------------------------------------------------------------
+# H2 — a NEW sell reconciles OPEN submitted sells to broker truth first
+# ---------------------------------------------------------------------------
+class ReconcileBroker:
+    """Broker whose get_order_by_client_order_id is keyed per client_order_id."""
+
+    def __init__(self, *, position, orders=None, raise_lookup=None):
+        self.submit_calls: list[Any] = []
+        self.position = position
+        self._orders = orders or {}
+        self._raise_lookup = raise_lookup or set()
+
+    async def submit_order(self, request: Any) -> Order:
+        self.submit_calls.append(request)
+        return Order(
+            id=f"paper-{len(self.submit_calls)}",
+            client_order_id=getattr(request, "client_order_id", None),
+            symbol="BTC/USD",
+            filled_qty=Decimal("0"),
+            side="sell",
+            type="limit",
+            time_in_force="gtc",
+            status="accepted",
+        )
+
+    async def get_position(self, symbol):
+        return self.position
+
+    async def get_order_by_client_order_id(self, client_order_id):
+        if client_order_id in self._raise_lookup:
+            raise AlpacaPaperRequestError("boom", status_code=500)
+        return self._orders.get(client_order_id)
+
+
+def _order(coid, status, qty="0"):
+    return Order(
+        id=f"b-{coid}",
+        client_order_id=coid,
+        symbol="BTC/USD",
+        filled_qty=Decimal(qty),
+        side="sell",
+        type="limit",
+        time_in_force="gtc",
+        status=status,
+    )
+
+
+async def test_new_sell_reconciles_async_filled_open_sell(db_session):
+    # Open sell 0.6 was accepted, then asynchronously FILLED -> live position 0.4.
+    # A new 0.4 sell must be allowed once the stale submitted row is reconciled.
+    open_coid = f"{_CORR}-async-open"
+    await _seed_sell_row(
+        db_session, coid=open_coid, symbol="BTC/USD", qty="0.6", lifecycle="submitted"
+    )
+    broker = ReconcileBroker(
+        position=SimpleNamespace(symbol="BTCUSD", qty=Decimal("0.4")),
+        orders={open_coid: _order(open_coid, "filled", qty="0.6")},
+    )
+    canonical = _canonical("sell", qty="0.4", notional=None)
+    packet = _packet(
+        canonical,
+        f"{_CORR}-async",
+        origin="manual",
+        max_notional=None,
+        max_qty=Decimal("1"),
+    )
+    coord = AlpacaPaperSubmitCoordinator(
+        AlpacaPaperLedgerService(db_session), lambda: broker, now_fn=lambda: _NOW
+    )
+    outcome = await coord.submit(packet, submit_canonical=canonical)
+    assert outcome.status == "submitted"
+    assert len(broker.submit_calls) == 1
+
+
+async def test_new_sell_keeps_reservation_when_open_still_open(db_session):
+    # Open sell 0.6 still OPEN at the broker -> stays reserved; a 0.6 new sell is
+    # blocked (position 1 minus 0.6 open = 0.4).
+    open_coid = f"{_CORR}-still-open"
+    await _seed_sell_row(
+        db_session, coid=open_coid, symbol="BTC/USD", qty="0.6", lifecycle="submitted"
+    )
+    broker = ReconcileBroker(
+        position=SimpleNamespace(symbol="BTCUSD", qty=Decimal("1")),
+        orders={open_coid: _order(open_coid, "accepted")},
+    )
+    canonical = _canonical("sell", qty="0.6", notional=None)
+    packet = _packet(
+        canonical,
+        f"{_CORR}-stillopen",
+        origin="manual",
+        max_notional=None,
+        max_qty=Decimal("1"),
+    )
+    coord = AlpacaPaperSubmitCoordinator(
+        AlpacaPaperLedgerService(db_session), lambda: broker, now_fn=lambda: _NOW
+    )
+    outcome = await coord.submit(packet, submit_canonical=canonical)
+    assert outcome.status == "rejected"
+    assert outcome.reason_code == "qty_exceeds_available"
+    assert broker.submit_calls == []
+
+
+async def test_concurrent_reconcile_and_new_sells_no_oversell(db_session):
+    # A stale open sell 0.6 has actually FILLED (position -> 0.4). Two concurrent
+    # DISTINCT new sells (0.4 and 0.35) both reconcile it, then serialize on the
+    # account+symbol lock: their sum 0.75 > 0.4 so exactly one POSTs.
+    from app.core.db import AsyncSessionLocal
+
+    open_coid = f"{_CORR}-conc-open"
+    await _seed_sell_row(
+        db_session, coid=open_coid, symbol="BTC/USD", qty="0.6", lifecycle="submitted"
+    )
+    shared = ReconcileBroker(
+        position=SimpleNamespace(symbol="BTCUSD", qty=Decimal("0.4")),
+        orders={open_coid: _order(open_coid, "filled", qty="0.6")},
+    )
+    barrier = asyncio.Barrier(2)
+
+    async def _run(qty):
+        canonical = _canonical("sell", qty=qty, notional=None)
+        packet = _packet(
+            canonical,
+            f"{_CORR}-conc-{qty}",
+            origin="manual",
+            max_notional=None,
+            max_qty=Decimal("1"),
+        )
+        async with AsyncSessionLocal() as s:
+            coord = AlpacaPaperSubmitCoordinator(
+                AlpacaPaperLedgerService(s),
+                lambda: shared,
+                now_fn=lambda: _NOW,
+                inflight_max_polls=20,
+                inflight_poll_interval_s=0.02,
+            )
+            await barrier.wait()
+            return await coord.submit(packet, submit_canonical=canonical)
+
+    outcomes = await asyncio.gather(_run("0.4"), _run("0.35"))
+    assert len(shared.submit_calls) == 1, shared.submit_calls
+    assert sum(1 for o in outcomes if o.status == "submitted") == 1
+    other = [o for o in outcomes if o.status != "submitted"][0]
+    assert other.reason_code == "qty_exceeds_available"
+
+
+async def test_new_sell_fail_closes_when_broker_lookup_fails(db_session):
+    # Broker lookup raises -> keep the open reservation (fail-close): the 0.6 open
+    # sell is NOT released, so a 0.6 new sell is blocked.
+    open_coid = f"{_CORR}-lookupfail"
+    await _seed_sell_row(
+        db_session, coid=open_coid, symbol="BTC/USD", qty="0.6", lifecycle="submitted"
+    )
+    broker = ReconcileBroker(
+        position=SimpleNamespace(symbol="BTCUSD", qty=Decimal("1")),
+        raise_lookup={open_coid},
+    )
+    canonical = _canonical("sell", qty="0.6", notional=None)
+    packet = _packet(
+        canonical,
+        f"{_CORR}-lf",
+        origin="manual",
+        max_notional=None,
+        max_qty=Decimal("1"),
+    )
+    coord = AlpacaPaperSubmitCoordinator(
+        AlpacaPaperLedgerService(db_session), lambda: broker, now_fn=lambda: _NOW
+    )
+    outcome = await coord.submit(packet, submit_canonical=canonical)
+    assert outcome.status == "rejected"
+    assert outcome.reason_code == "qty_exceeds_available"
+    assert broker.submit_calls == []

--- a/tests/services/test_alpaca_paper_review5.py
+++ b/tests/services/test_alpaca_paper_review5.py
@@ -1,0 +1,322 @@
+"""ROB-842 5th-round: freshness re-check at broker send (G3) and sell reservation
+lifecycle — only OPEN sells consume position; cancel releases (G4)."""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import delete
+
+from app.models.review import AlpacaPaperOrderLedger
+from app.models.trading import InstrumentType
+from app.services.alpaca_paper_ledger_service import AlpacaPaperLedgerService
+from app.services.alpaca_paper_submit_service import (
+    AlpacaPaperSubmitCoordinator,
+    build_canonical_payload,
+    canonical_hash,
+    derive_automated_key,
+    derive_client_order_id,
+)
+from app.services.brokers.alpaca.schemas import Order
+
+pytestmark = [pytest.mark.asyncio]
+
+_NOW = datetime(2026, 7, 12, 12, 0, 0, tzinfo=UTC)
+_CORR = "rob842-r5"
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def _clean(db_session):
+    stmt = delete(AlpacaPaperOrderLedger).where(
+        AlpacaPaperOrderLedger.lifecycle_correlation_id.like(f"{_CORR}%")
+        | AlpacaPaperOrderLedger.client_order_id.like("rob74-crypto-%")
+        | AlpacaPaperOrderLedger.client_order_id.like("rob73-%")
+    )
+    await db_session.execute(stmt)
+    await db_session.commit()
+    yield
+    await db_session.execute(stmt)
+    await db_session.commit()
+
+
+class Broker:
+    def __init__(self, *, position: Any = None, delay_s: float = 0.0):
+        self.submit_calls: list[Any] = []
+        self.position = position
+        self._delay_s = delay_s
+
+    async def submit_order(self, request: Any) -> Order:
+        self.submit_calls.append(request)
+        if self._delay_s:
+            await asyncio.sleep(self._delay_s)
+        return Order(
+            id=f"paper-{len(self.submit_calls)}",
+            client_order_id=getattr(request, "client_order_id", None),
+            symbol="BTC/USD",
+            filled_qty=Decimal("0"),
+            side=getattr(request, "side", "buy"),
+            type="limit",
+            time_in_force="gtc",
+            status="accepted",
+        )
+
+    async def get_position(self, symbol: str) -> Any:
+        return self.position
+
+    async def get_order_by_client_order_id(self, client_order_id: str) -> Order | None:
+        return None
+
+
+def _canonical(side="buy", *, qty=None, notional="10"):
+    return build_canonical_payload(
+        symbol="BTC/USD",
+        side=side,
+        type="limit",
+        time_in_force="gtc",
+        qty=Decimal(str(qty)) if qty is not None else None,
+        notional=Decimal(str(notional)) if notional is not None else None,
+        limit_price=Decimal("50000"),
+        asset_class="crypto",
+    )
+
+
+def _packet(canonical, corr, *, origin="automated", now_ref=None, max_age_s=300, **ov):
+    from app.services.paper_approval_packet import PaperApprovalPacket
+
+    snap = f"{corr}-snap"
+    if origin == "manual":
+        coid, corr_id, snap_id = derive_client_order_id(canonical), None, None
+        coid = derive_client_order_id(canonical)
+        corr_id = coid
+    else:
+        coid = derive_automated_key(
+            correlation_id=corr, snapshot_id=snap, canonical=canonical
+        )
+        corr_id, snap_id = corr, snap
+    asof = now_ref if now_ref is not None else _NOW - timedelta(seconds=10)
+    d: dict[str, Any] = {
+        "signal_source": "test",
+        "artifact_id": uuid.uuid4(),
+        "signal_symbol": "KRW-BTC",
+        "signal_venue": "upbit",
+        "execution_symbol": "BTC/USD",
+        "execution_venue": "alpaca_paper",
+        "execution_asset_class": "crypto",
+        "side": canonical["side"],
+        "max_notional": Decimal("10"),
+        "qty_source": "notional_estimate"
+        if canonical["side"] == "buy"
+        else "manual_operator",
+        "expected_lifecycle_step": "previewed",
+        "lifecycle_correlation_id": corr_id,
+        "client_order_id": coid,
+        "expires_at": _NOW + timedelta(hours=1),
+        "account_mode": "alpaca_paper",
+        "origin": origin,
+        "market_data_asof": asof,
+        "market_data_source": "upbit_ticker",
+        "preview_payload_hash": canonical_hash(canonical),
+        "snapshot_id": snap_id,
+        "execution_order_type": "limit",
+        "execution_time_in_force": "gtc",
+        "reference_price": Decimal("50000"),
+    }
+    d.update(ov)
+    return PaperApprovalPacket(**d)
+
+
+class _Clock:
+    def __init__(self, values):
+        self.values = list(values)
+        self.i = 0
+
+    def __call__(self):
+        v = self.values[min(self.i, len(self.values) - 1)]
+        self.i += 1
+        return v
+
+
+# ---------------------------------------------------------------------------
+# G3 — freshness re-checked at the moment of the broker POST
+# ---------------------------------------------------------------------------
+async def test_freshness_rechecked_at_send_blocks_stale_buy(db_session):
+    corr = f"{_CORR}-fresh-buy"
+    canonical = _canonical("buy")
+    # market_data as-of = _NOW; passes at +299s, stale at +301s (max_age=300s).
+    packet = _packet(canonical, corr, now_ref=_NOW, max_age_s=300)
+    broker = Broker()
+    # now_fn: initial check +299s (fresh), then at-send +301s (stale).
+    clock = _Clock([_NOW + timedelta(seconds=299), _NOW + timedelta(seconds=301)])
+    coord = AlpacaPaperSubmitCoordinator(
+        AlpacaPaperLedgerService(db_session),
+        lambda: broker,
+        now_fn=clock,
+        quote_max_age=timedelta(seconds=300),
+    )
+    outcome = await coord.submit(packet, submit_canonical=canonical)
+    assert outcome.status == "rejected"
+    assert outcome.reason_code == "stale_quote"
+    assert broker.submit_calls == []  # POST 0 despite passing the initial check
+
+
+async def test_freshness_rechecked_at_send_blocks_stale_sell(db_session):
+    corr = f"{_CORR}-fresh-sell"
+    canonical = _canonical("sell", qty="0.5", notional=None)
+    packet = _packet(
+        canonical,
+        corr,
+        origin="manual",
+        now_ref=_NOW,
+        max_notional=None,
+        max_qty=Decimal("1"),
+    )
+    broker = Broker(position=SimpleNamespace(symbol="BTCUSD", qty=Decimal("1")))
+    clock = _Clock([_NOW + timedelta(seconds=299), _NOW + timedelta(seconds=301)])
+    coord = AlpacaPaperSubmitCoordinator(
+        AlpacaPaperLedgerService(db_session),
+        lambda: broker,
+        now_fn=clock,
+        quote_max_age=timedelta(seconds=300),
+    )
+    outcome = await coord.submit(packet, submit_canonical=canonical)
+    assert outcome.status == "rejected"
+    assert outcome.reason_code == "stale_quote"
+    assert broker.submit_calls == []
+
+
+async def test_fresh_at_send_still_posts(db_session):
+    corr = f"{_CORR}-fresh-ok"
+    canonical = _canonical("buy")
+    packet = _packet(canonical, corr, now_ref=_NOW)
+    broker = Broker()
+    coord = AlpacaPaperSubmitCoordinator(
+        AlpacaPaperLedgerService(db_session),
+        lambda: broker,
+        now_fn=lambda: _NOW,
+    )
+    outcome = await coord.submit(packet, submit_canonical=canonical)
+    assert outcome.status == "submitted"
+    assert len(broker.submit_calls) == 1
+
+
+# ---------------------------------------------------------------------------
+# G4 — reservation lifecycle: only OPEN sells consume; filled already in position
+# ---------------------------------------------------------------------------
+async def _seed_sell_row(
+    db_session, *, coid, symbol, qty, lifecycle, cancel_status=None
+):
+    """Directly insert an execution sell row in a chosen lifecycle."""
+    row = AlpacaPaperOrderLedger(
+        client_order_id=coid,
+        lifecycle_correlation_id=coid,
+        record_kind="execution",
+        broker="alpaca",
+        account_mode="alpaca_paper",
+        lifecycle_state=lifecycle,
+        execution_symbol=symbol,
+        execution_venue="alpaca_paper",
+        instrument_type=InstrumentType.crypto,
+        side="sell",
+        order_type="limit",
+        currency="USD",
+        requested_qty=Decimal(str(qty)),
+        cancel_status=cancel_status,
+        submitted_at=datetime.now(UTC),
+        broker_order_id=f"b-{coid}",
+        confirm_flag=True,
+    )
+    db_session.add(row)
+    await db_session.commit()
+    db_session.expire_all()
+
+
+async def test_filled_sell_not_double_counted(db_session):
+    # A filled sell 0.6 has already reduced the live position to 0.4; a new 0.4
+    # sell must be allowed (available = 0.4, not 0.4 - 0.6).
+    ledger = AlpacaPaperLedgerService(db_session)
+    await _seed_sell_row(
+        db_session,
+        coid=f"{_CORR}-filled",
+        symbol="BTC/USD",
+        qty="0.6",
+        lifecycle="filled",
+    )
+    claim = await ledger.reserve_sell_and_claim(
+        client_order_id=f"{_CORR}-new04",
+        lifecycle_correlation_id=f"{_CORR}-new04",
+        execution_symbol="BTC/USD",
+        execution_venue="alpaca_paper",
+        instrument_type=InstrumentType.crypto,
+        requested_qty=Decimal("0.4"),
+        position_qty=Decimal("0.4"),
+    )
+    assert claim.insufficient is False
+    assert claim.won is True
+    assert claim.available == Decimal("0.4")
+
+
+async def test_open_submitted_sell_is_reserved(db_session):
+    ledger = AlpacaPaperLedgerService(db_session)
+    await _seed_sell_row(
+        db_session,
+        coid=f"{_CORR}-open05",
+        symbol="BTC/USD",
+        qty="0.5",
+        lifecycle="submitted",
+    )
+    claim = await ledger.reserve_sell_and_claim(
+        client_order_id=f"{_CORR}-new06",
+        lifecycle_correlation_id=f"{_CORR}-new06",
+        execution_symbol="BTC/USD",
+        execution_venue="alpaca_paper",
+        instrument_type=InstrumentType.crypto,
+        requested_qty=Decimal("0.6"),
+        position_qty=Decimal("1"),
+    )
+    assert claim.insufficient is True  # 0.6 > (1 - 0.5 open)
+    assert claim.available == Decimal("0.5")
+
+
+async def test_canceled_sell_releases_reservation(db_session):
+    ledger = AlpacaPaperLedgerService(db_session)
+    # open sell holds 0.5; a 0.6 sell is blocked...
+    await _seed_sell_row(
+        db_session,
+        coid=f"{_CORR}-cxl",
+        symbol="BTC/USD",
+        qty="0.5",
+        lifecycle="submitted",
+    )
+    blocked = await ledger.reserve_sell_and_claim(
+        client_order_id=f"{_CORR}-b1",
+        lifecycle_correlation_id=f"{_CORR}-b1",
+        execution_symbol="BTC/USD",
+        execution_venue="alpaca_paper",
+        instrument_type=InstrumentType.crypto,
+        requested_qty=Decimal("0.6"),
+        position_qty=Decimal("1"),
+    )
+    assert blocked.insufficient is True
+
+    # ...cancel it (sets cancel_status) => reservation released...
+    await ledger.record_cancel(f"{_CORR}-cxl", cancel_status="canceled")
+    db_session.expire_all()
+
+    allowed = await ledger.reserve_sell_and_claim(
+        client_order_id=f"{_CORR}-b2",
+        lifecycle_correlation_id=f"{_CORR}-b2",
+        execution_symbol="BTC/USD",
+        execution_venue="alpaca_paper",
+        instrument_type=InstrumentType.crypto,
+        requested_qty=Decimal("0.6"),
+        position_qty=Decimal("1"),
+    )
+    assert allowed.insufficient is False
+    assert allowed.available == Decimal("1")  # full position free again

--- a/tests/services/test_alpaca_paper_submit_coordinator.py
+++ b/tests/services/test_alpaca_paper_submit_coordinator.py
@@ -43,6 +43,8 @@ _CORR_PREFIX = "rob842-coord"
 async def _clean_rows(db_session):
     stmt = delete(AlpacaPaperOrderLedger).where(
         AlpacaPaperOrderLedger.lifecycle_correlation_id.like(f"{_CORR_PREFIX}%")
+        | AlpacaPaperOrderLedger.client_order_id.like("rob74-crypto-%")
+        | AlpacaPaperOrderLedger.client_order_id.like("rob73-%")
     )
     await db_session.execute(stmt)
     await db_session.commit()
@@ -106,11 +108,24 @@ def _packet(
     canonical: dict[str, Any],
     corr: str,
     snapshot_id: str | None = None,
+    *,
+    origin: str = "automated",
     **overrides: Any,
 ):
+    from app.services.alpaca_paper_submit_service import derive_client_order_id
     from app.services.paper_approval_packet import PaperApprovalPacket
 
     snap = snapshot_id if snapshot_id is not None else f"{corr}-snap"
+    if origin == "manual":
+        coid = derive_client_order_id(canonical)
+        corr_id = coid
+        snap_id = None
+    else:
+        coid = derive_automated_key(
+            correlation_id=corr, snapshot_id=snap, canonical=canonical
+        )
+        corr_id = corr
+        snap_id = snap
     defaults: dict[str, Any] = {
         "signal_source": "test",
         "artifact_id": uuid.uuid4(),
@@ -123,19 +138,18 @@ def _packet(
         "max_notional": Decimal("10"),
         "qty_source": "notional_estimate",
         "expected_lifecycle_step": "previewed",
-        "lifecycle_correlation_id": corr,
-        "client_order_id": derive_automated_key(
-            correlation_id=corr, snapshot_id=snap, canonical=canonical
-        ),
+        "lifecycle_correlation_id": corr_id,
+        "client_order_id": coid,
         "expires_at": _FUTURE,
         "account_mode": "alpaca_paper",
-        "origin": "automated",
+        "origin": origin,
         "market_data_asof": _NOW - timedelta(seconds=10),
         "market_data_source": "upbit_ticker",
         "preview_payload_hash": canonical_hash(canonical),
-        "snapshot_id": snap,
+        "snapshot_id": snap_id,
         "execution_order_type": canonical.get("type"),
         "execution_time_in_force": canonical.get("time_in_force"),
+        "reference_price": Decimal("50000"),
     }
     defaults.update(overrides)
     return PaperApprovalPacket(**defaults)
@@ -249,10 +263,11 @@ async def test_sell_without_current_position_rejected_before_broker(db_session):
     packet = _packet(
         canonical,
         f"{_CORR_PREFIX}-sell",
+        origin="manual",
         side="sell",
         max_notional=None,
         max_qty=Decimal("0.0001"),
-        qty_source="ledger_filled_qty",
+        qty_source="manual_operator",
     )
     coord = _coordinator(db_session, broker)
 

--- a/tests/services/test_alpaca_paper_submit_coordinator.py
+++ b/tests/services/test_alpaca_paper_submit_coordinator.py
@@ -1,0 +1,415 @@
+"""ROB-842 AlpacaPaperSubmitCoordinator — the single application submit boundary.
+
+DB-backed integration + concurrency tests proving:
+- packet/hash/key fail-close BEFORE any broker call (AC#1,#2,#4,#5),
+- exactly one broker HTTP submit for sequential AND concurrent duplicates (AC#3),
+- winner submits, losers replay the stored result or return idempotency_in_progress,
+- an in-flight/crash-recovered claim never triggers a second POST.
+
+The broker is a counting fake — no live/paper HTTP is issued.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+from typing import Any
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import delete
+
+from app.models.review import AlpacaPaperOrderLedger
+from app.models.trading import InstrumentType
+from app.services.alpaca_paper_ledger_service import AlpacaPaperLedgerService
+from app.services.alpaca_paper_submit_service import (
+    AlpacaPaperSubmitCoordinator,
+    build_canonical_payload,
+    canonical_hash,
+    derive_automated_key,
+)
+from app.services.brokers.alpaca.schemas import Order
+
+pytestmark = [pytest.mark.asyncio]
+
+_NOW = datetime(2026, 7, 12, 12, 0, 0, tzinfo=UTC)
+_FUTURE = datetime(2030, 1, 1, 12, 0, 0, tzinfo=UTC)
+_CORR_PREFIX = "rob842-coord"
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def _clean_rows(db_session):
+    stmt = delete(AlpacaPaperOrderLedger).where(
+        AlpacaPaperOrderLedger.lifecycle_correlation_id.like(f"{_CORR_PREFIX}%")
+    )
+    await db_session.execute(stmt)
+    await db_session.commit()
+    yield
+    await db_session.execute(stmt)
+    await db_session.commit()
+
+
+# ---------------------------------------------------------------------------
+# Counting fake broker (no HTTP; records submit calls)
+# ---------------------------------------------------------------------------
+class CountingBroker:
+    def __init__(
+        self, *, delay_s: float = 0.0, lookup_order: Order | None = None
+    ) -> None:
+        self.submit_calls: list[Any] = []
+        self.lookup_calls: list[str] = []
+        self._delay_s = delay_s
+        self._lookup_order = lookup_order
+
+    async def submit_order(self, request: Any) -> Order:
+        self.submit_calls.append(request)
+        if self._delay_s:
+            await asyncio.sleep(self._delay_s)
+        return Order(
+            id=f"paper-{len(self.submit_calls)}",
+            client_order_id=getattr(request, "client_order_id", None),
+            symbol=getattr(request, "symbol", "BTC/USD"),
+            qty=getattr(request, "qty", None),
+            notional=getattr(request, "notional", None),
+            filled_qty=Decimal("0"),
+            side=getattr(request, "side", "buy"),
+            type=getattr(request, "type", "limit"),
+            time_in_force=getattr(request, "time_in_force", "gtc"),
+            status="accepted",
+            limit_price=getattr(request, "limit_price", None),
+        )
+
+    async def get_order_by_client_order_id(self, client_order_id: str) -> Order | None:
+        self.lookup_calls.append(client_order_id)
+        return self._lookup_order
+
+
+def _canonical(limit_price: str = "50000") -> dict[str, Any]:
+    return build_canonical_payload(
+        symbol="BTC/USD",
+        side="buy",
+        type="limit",
+        time_in_force="gtc",
+        qty=None,
+        notional=Decimal("10"),
+        limit_price=Decimal(limit_price),
+        asset_class="crypto",
+    )
+
+
+def _packet(
+    canonical: dict[str, Any],
+    corr: str,
+    snapshot_id: str | None = None,
+    **overrides: Any,
+):
+    from app.services.paper_approval_packet import PaperApprovalPacket
+
+    snap = snapshot_id if snapshot_id is not None else f"{corr}-snap"
+    defaults: dict[str, Any] = {
+        "signal_source": "test",
+        "artifact_id": uuid.uuid4(),
+        "signal_symbol": "KRW-BTC",
+        "signal_venue": "upbit",
+        "execution_symbol": "BTC/USD",
+        "execution_venue": "alpaca_paper",
+        "execution_asset_class": "crypto",
+        "side": "buy",
+        "max_notional": Decimal("10"),
+        "qty_source": "notional_estimate",
+        "expected_lifecycle_step": "previewed",
+        "lifecycle_correlation_id": corr,
+        "client_order_id": derive_automated_key(
+            correlation_id=corr, snapshot_id=snap, canonical=canonical
+        ),
+        "expires_at": _FUTURE,
+        "account_mode": "alpaca_paper",
+        "origin": "automated",
+        "market_data_asof": _NOW - timedelta(seconds=10),
+        "market_data_source": "upbit_ticker",
+        "preview_payload_hash": canonical_hash(canonical),
+        "snapshot_id": snap,
+        "execution_order_type": canonical.get("type"),
+        "execution_time_in_force": canonical.get("time_in_force"),
+    }
+    defaults.update(overrides)
+    return PaperApprovalPacket(**defaults)
+
+
+def _coordinator(
+    db_session, broker: CountingBroker, **kwargs: Any
+) -> AlpacaPaperSubmitCoordinator:
+    return AlpacaPaperSubmitCoordinator(
+        AlpacaPaperLedgerService(db_session),
+        lambda: broker,
+        now_fn=lambda: _NOW,
+        **kwargs,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Happy path + exact-one-submit (sequential)
+# ---------------------------------------------------------------------------
+async def test_winner_posts_once_and_records(db_session):
+    broker = CountingBroker()
+    canonical = _canonical()
+    packet = _packet(canonical, f"{_CORR_PREFIX}-win")
+    coord = _coordinator(db_session, broker)
+
+    outcome = await coord.submit(packet, submit_canonical=canonical)
+
+    assert outcome.status == "submitted"
+    assert outcome.broker_called is True
+    assert len(broker.submit_calls) == 1
+    # Broker received the server-derived client_order_id.
+    assert broker.submit_calls[0].client_order_id == packet.client_order_id
+
+
+async def test_sequential_duplicate_replays_without_second_post(db_session):
+    broker = CountingBroker()
+    canonical = _canonical("50001")
+    packet = _packet(canonical, f"{_CORR_PREFIX}-seq")
+    coord = _coordinator(db_session, broker)
+
+    first = await coord.submit(packet, submit_canonical=canonical)
+    second = await coord.submit(packet, submit_canonical=canonical)
+
+    assert first.status == "submitted"
+    assert second.status == "replayed"
+    assert second.broker_called is False
+    assert second.order is not None  # stored broker result replayed
+    assert len(broker.submit_calls) == 1
+
+
+# ---------------------------------------------------------------------------
+# Fail-close rejections (never reach the broker)
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    ("mutate", "expected_code"),
+    [
+        ({"market_data_asof": None}, "missing_source_timestamp"),
+        ({"market_data_asof": _NOW - timedelta(minutes=30)}, "stale_quote"),
+        ({"account_mode": "alpaca_live"}, "account_mode_mismatch"),
+        ({"expires_at": datetime(2020, 1, 1, tzinfo=UTC)}, "stale_packet"),
+        ({"preview_payload_hash": "deadbeef"}, "preview_hash_mismatch"),
+        ({"client_order_id": "rob74-crypto-tampered000000"}, "server_key_mismatch"),
+    ],
+)
+async def test_packet_rejections_fail_close_before_broker(
+    db_session, mutate, expected_code
+):
+    broker = CountingBroker()
+    canonical = _canonical("50002")
+    packet = _packet(canonical, f"{_CORR_PREFIX}-rej", **mutate)
+    coord = _coordinator(db_session, broker)
+
+    outcome = await coord.submit(packet, submit_canonical=canonical)
+
+    assert outcome.status == "rejected"
+    assert outcome.reason_code == expected_code
+    assert outcome.broker_called is False
+    assert broker.submit_calls == []
+
+
+async def test_caller_supplied_id_cannot_bypass_server_key(db_session):
+    broker = CountingBroker()
+    canonical = _canonical("50003")
+    packet = _packet(canonical, f"{_CORR_PREFIX}-caller")
+    coord = _coordinator(db_session, broker)
+
+    outcome = await coord.submit(
+        packet,
+        submit_canonical=canonical,
+        caller_client_order_id="attacker-chosen-id",
+    )
+
+    assert outcome.status == "rejected"
+    assert outcome.reason_code == "caller_id_mismatch"
+    assert broker.submit_calls == []
+
+
+async def test_sell_packet_without_source_rejected_before_broker(db_session):
+    broker = CountingBroker()
+    canonical = build_canonical_payload(
+        symbol="BTC/USD",
+        side="sell",
+        type="limit",
+        time_in_force="gtc",
+        qty=Decimal("0.0001"),
+        notional=None,
+        limit_price=Decimal("50000"),
+        asset_class="crypto",
+    )
+    packet = _packet(
+        canonical,
+        f"{_CORR_PREFIX}-sell",
+        side="sell",
+        max_notional=None,
+        max_qty=Decimal("0.0001"),
+        qty_source="ledger_filled_qty",
+    )
+    coord = _coordinator(db_session, broker)
+
+    outcome = await coord.submit(packet, submit_canonical=canonical)
+
+    assert outcome.status == "rejected"
+    assert outcome.reason_code == "missing_source_order"
+    assert broker.submit_calls == []
+
+
+# ---------------------------------------------------------------------------
+# In-flight / crash recovery: never a second POST
+# ---------------------------------------------------------------------------
+async def test_inflight_claim_recovery_returns_in_progress_no_post(db_session):
+    broker = CountingBroker()
+    canonical = _canonical("50004")
+    packet = _packet(canonical, f"{_CORR_PREFIX}-inflight")
+
+    # Simulate a winner that claimed but crashed before record_submit.
+    ledger = AlpacaPaperLedgerService(db_session)
+    claim = await ledger.claim_submit(
+        client_order_id=packet.client_order_id,
+        lifecycle_correlation_id=packet.lifecycle_correlation_id,
+        execution_symbol="BTC/USD",
+        execution_venue="alpaca_paper",
+        instrument_type=InstrumentType.crypto,
+        side="buy",
+        order_type="limit",
+        time_in_force="gtc",
+        requested_notional=Decimal("10"),
+        requested_price=Decimal("50000"),
+    )
+    assert claim.won is True
+
+    coord = _coordinator(
+        db_session, broker, inflight_max_polls=2, inflight_poll_interval_s=0.0
+    )
+    outcome = await coord.submit(packet, submit_canonical=canonical)
+
+    assert outcome.status == "idempotency_in_progress"
+    assert outcome.broker_called is False
+    assert broker.submit_calls == []
+
+
+# ---------------------------------------------------------------------------
+# Concurrency: two independent sessions, exactly one broker submit (AC#3)
+# ---------------------------------------------------------------------------
+async def test_concurrent_two_coordinators_exactly_one_submit(db_session):
+    from app.core.db import AsyncSessionLocal
+
+    broker = CountingBroker(delay_s=0.02)
+    canonical = _canonical("50005")
+    corr = f"{_CORR_PREFIX}-concurrent"
+    barrier = asyncio.Barrier(2)
+
+    async def _run():
+        async with AsyncSessionLocal() as session:
+            coord = AlpacaPaperSubmitCoordinator(
+                AlpacaPaperLedgerService(session),
+                lambda: broker,
+                now_fn=lambda: _NOW,
+                inflight_max_polls=20,
+                inflight_poll_interval_s=0.02,
+            )
+            packet = _packet(canonical, corr)
+            await barrier.wait()
+            return await coord.submit(packet, submit_canonical=canonical)
+
+    outcomes = await asyncio.gather(_run(), _run())
+
+    # Exactly one broker HTTP submit regardless of the race.
+    assert len(broker.submit_calls) == 1
+    statuses = sorted(o.status for o in outcomes)
+    assert statuses.count("submitted") == 1
+    other = [o for o in outcomes if o.status != "submitted"][0]
+    assert other.status in {"replayed", "idempotency_in_progress", "recovered"}
+    assert other.broker_called is False
+
+
+# ---------------------------------------------------------------------------
+# Order-within-packet authority binding (blocker 3)
+# ---------------------------------------------------------------------------
+async def test_order_notional_exceeds_packet_max_rejected(db_session):
+    broker = CountingBroker()
+    canonical = build_canonical_payload(
+        symbol="BTC/USD",
+        side="buy",
+        type="limit",
+        time_in_force="gtc",
+        qty=None,
+        notional=Decimal("50"),
+        limit_price=Decimal("50000"),
+        asset_class="crypto",
+    )
+    packet = _packet(canonical, f"{_CORR_PREFIX}-overmax", max_notional=Decimal("10"))
+    coord = _coordinator(db_session, broker)
+
+    outcome = await coord.submit(packet, submit_canonical=canonical)
+
+    assert outcome.status == "rejected"
+    assert outcome.reason_code == "notional_exceeds_max"
+    assert broker.submit_calls == []
+
+
+async def test_order_type_mismatch_rejected(db_session):
+    broker = CountingBroker()
+    canonical = _canonical("50008")  # type=limit
+    packet = _packet(
+        canonical, f"{_CORR_PREFIX}-typemis", execution_order_type="market"
+    )
+    coord = _coordinator(db_session, broker)
+
+    outcome = await coord.submit(packet, submit_canonical=canonical)
+
+    assert outcome.status == "rejected"
+    assert outcome.reason_code == "order_type_mismatch"
+    assert broker.submit_calls == []
+
+
+# ---------------------------------------------------------------------------
+# Crash-after-success recovery: reconcile from broker, never re-POST (blocker 5)
+# ---------------------------------------------------------------------------
+async def test_crash_after_success_recovered_without_repost(db_session):
+    canonical = _canonical("50009")
+    packet = _packet(canonical, f"{_CORR_PREFIX}-recover")
+
+    # Winner claimed but crashed before record_submit → in-flight execution row.
+    ledger = AlpacaPaperLedgerService(db_session)
+    claim = await ledger.claim_submit(
+        client_order_id=packet.client_order_id,
+        lifecycle_correlation_id=packet.lifecycle_correlation_id,
+        execution_symbol="BTC/USD",
+        execution_venue="alpaca_paper",
+        instrument_type=InstrumentType.crypto,
+        side="buy",
+        order_type="limit",
+        time_in_force="gtc",
+        requested_notional=Decimal("10"),
+        requested_price=Decimal("50000"),
+    )
+    assert claim.won is True
+
+    # ...but the submit HAD reached the broker before the crash.
+    recovered_order = Order(
+        id="paper-recovered",
+        client_order_id=packet.client_order_id,
+        symbol="BTC/USD",
+        filled_qty=Decimal("0"),
+        side="buy",
+        type="limit",
+        time_in_force="gtc",
+        status="accepted",
+    )
+    broker = CountingBroker(lookup_order=recovered_order)
+    coord = _coordinator(
+        db_session, broker, inflight_max_polls=1, inflight_poll_interval_s=0.0
+    )
+
+    outcome = await coord.submit(packet, submit_canonical=canonical)
+
+    assert outcome.status == "recovered"
+    assert outcome.broker_called is False
+    assert broker.submit_calls == []  # NO re-POST
+    assert broker.lookup_calls == [packet.client_order_id]

--- a/tests/services/test_alpaca_paper_submit_coordinator.py
+++ b/tests/services/test_alpaca_paper_submit_coordinator.py
@@ -85,6 +85,9 @@ class CountingBroker:
         self.lookup_calls.append(client_order_id)
         return self._lookup_order
 
+    async def get_position(self, symbol: str) -> Any:
+        return None
+
 
 def _canonical(limit_price: str = "50000") -> dict[str, Any]:
     return build_canonical_payload(
@@ -230,7 +233,8 @@ async def test_caller_supplied_id_cannot_bypass_server_key(db_session):
     assert broker.submit_calls == []
 
 
-async def test_sell_packet_without_source_rejected_before_broker(db_session):
+async def test_sell_without_current_position_rejected_before_broker(db_session):
+    # No live position (broker.get_position -> None) => fail closed before POST.
     broker = CountingBroker()
     canonical = build_canonical_payload(
         symbol="BTC/USD",
@@ -255,7 +259,7 @@ async def test_sell_packet_without_source_rejected_before_broker(db_session):
     outcome = await coord.submit(packet, submit_canonical=canonical)
 
     assert outcome.status == "rejected"
-    assert outcome.reason_code == "missing_source_order"
+    assert outcome.reason_code == "position_flat"
     assert broker.submit_calls == []
 
 

--- a/tests/services/test_paper_approval_packet_rob842.py
+++ b/tests/services/test_paper_approval_packet_rob842.py
@@ -1,0 +1,419 @@
+"""ROB-842 packet-contract verifiers: market-data, account-mode, hash, server key.
+
+Pure/side-effect-free tests for the Alpaca-complete additions to
+``app.services.paper_approval_packet``.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.services.alpaca_paper_submit_service import (
+    build_canonical_payload,
+    canonical_hash,
+    derive_automated_key,
+    derive_client_order_id,
+)
+from app.services.paper_approval_packet import (
+    PaperApprovalPacket,
+    PaperApprovalPacketError,
+    verify_order_within_packet,
+    verify_packet_account_mode,
+    verify_packet_market_data,
+    verify_preview_submit_hash,
+    verify_server_derived_key,
+)
+
+_NOW = datetime(2026, 7, 12, 12, 0, 0, tzinfo=UTC)
+_FUTURE = datetime(2030, 1, 1, 12, 0, 0, tzinfo=UTC)
+
+_CANONICAL = build_canonical_payload(
+    symbol="BTC/USD",
+    side="buy",
+    type="limit",
+    time_in_force="gtc",
+    qty=None,
+    notional=Decimal("10"),
+    limit_price=Decimal("50000"),
+    asset_class="crypto",
+)
+_COID = derive_client_order_id(_CANONICAL)
+_HASH = canonical_hash(_CANONICAL)
+
+
+def _make_packet(**overrides: Any) -> PaperApprovalPacket:
+    defaults: dict[str, Any] = {
+        "signal_source": "test_signal",
+        "artifact_id": uuid.uuid4(),
+        "signal_symbol": "KRW-BTC",
+        "signal_venue": "upbit",
+        "execution_symbol": "BTC/USD",
+        "execution_venue": "alpaca_paper",
+        "execution_asset_class": "crypto",
+        "side": "buy",
+        "max_notional": Decimal("10"),
+        "qty_source": "notional_estimate",
+        "expected_lifecycle_step": "previewed",
+        "lifecycle_correlation_id": "corr-842",
+        "client_order_id": _COID,
+        "expires_at": _FUTURE,
+        "account_mode": "alpaca_paper",
+        "origin": "automated",
+        "market_data_asof": _NOW - timedelta(seconds=30),
+        "market_data_source": "upbit_ticker",
+        "preview_payload_hash": _HASH,
+    }
+    defaults.update(overrides)
+    return PaperApprovalPacket(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# Backward-compat: ROB-91 producers without the new fields still validate.
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+def test_new_fields_are_optional_backward_compatible() -> None:
+    packet = PaperApprovalPacket(
+        signal_source="s",
+        artifact_id=uuid.uuid4(),
+        signal_symbol="KRW-BTC",
+        signal_venue="upbit",
+        execution_symbol="BTC/USD",
+        execution_venue="alpaca_paper",
+        execution_asset_class="crypto",
+        side="buy",
+        max_notional=Decimal("10"),
+        qty_source="notional_estimate",
+        expected_lifecycle_step="previewed",
+        lifecycle_correlation_id="corr",
+        client_order_id="buy-1",
+        expires_at=_FUTURE,
+    )
+    assert packet.account_mode == "alpaca_paper"
+    assert packet.origin == "manual"
+    assert packet.market_data_asof is None
+    assert packet.preview_payload_hash is None
+
+
+# ---------------------------------------------------------------------------
+# Market-data source freshness
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+def test_market_data_fresh_passes() -> None:
+    verify_packet_market_data(_make_packet(), now=_NOW, max_age=timedelta(minutes=5))
+
+
+@pytest.mark.unit
+def test_market_data_missing_source_timestamp() -> None:
+    with pytest.raises(PaperApprovalPacketError) as exc:
+        verify_packet_market_data(
+            _make_packet(market_data_asof=None), now=_NOW, max_age=timedelta(minutes=5)
+        )
+    assert exc.value.code == "missing_source_timestamp"
+
+
+@pytest.mark.unit
+def test_market_data_naive_source_timestamp() -> None:
+    with pytest.raises(PaperApprovalPacketError) as exc:
+        verify_packet_market_data(
+            _make_packet(market_data_asof=datetime(2026, 7, 12, 12, 0, 0)),
+            now=_NOW,
+            max_age=timedelta(minutes=5),
+        )
+    assert exc.value.code == "naive_source_timestamp"
+
+
+@pytest.mark.unit
+def test_market_data_stale_quote() -> None:
+    with pytest.raises(PaperApprovalPacketError) as exc:
+        verify_packet_market_data(
+            _make_packet(market_data_asof=_NOW - timedelta(minutes=30)),
+            now=_NOW,
+            max_age=timedelta(minutes=5),
+        )
+    assert exc.value.code == "stale_quote"
+
+
+@pytest.mark.unit
+def test_market_data_naive_now_rejected() -> None:
+    with pytest.raises(PaperApprovalPacketError) as exc:
+        verify_packet_market_data(
+            _make_packet(),
+            now=datetime(2026, 7, 12, 12, 0, 0),
+            max_age=timedelta(minutes=5),
+        )
+    assert exc.value.code == "naive_now"
+
+
+# ---------------------------------------------------------------------------
+# Account mode
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+def test_account_mode_match_passes() -> None:
+    verify_packet_account_mode(_make_packet(), expected="alpaca_paper")
+
+
+@pytest.mark.unit
+def test_account_mode_mismatch_rejected() -> None:
+    with pytest.raises(PaperApprovalPacketError) as exc:
+        verify_packet_account_mode(
+            _make_packet(account_mode="alpaca_live"), expected="alpaca_paper"
+        )
+    assert exc.value.code == "account_mode_mismatch"
+
+
+# ---------------------------------------------------------------------------
+# Preview↔submit hash
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+def test_preview_hash_match_passes() -> None:
+    verify_preview_submit_hash(_make_packet(), submit_hash=_HASH)
+
+
+@pytest.mark.unit
+def test_preview_hash_mismatch_rejected() -> None:
+    with pytest.raises(PaperApprovalPacketError) as exc:
+        verify_preview_submit_hash(_make_packet(), submit_hash="deadbeef")
+    assert exc.value.code == "preview_hash_mismatch"
+
+
+@pytest.mark.unit
+def test_preview_hash_missing_rejected() -> None:
+    with pytest.raises(PaperApprovalPacketError) as exc:
+        verify_preview_submit_hash(
+            _make_packet(preview_payload_hash=None), submit_hash=_HASH
+        )
+    assert exc.value.code == "missing_preview_hash"
+
+
+# ---------------------------------------------------------------------------
+# Server-derived key / caller-id bypass guard
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+def test_server_key_match_passes() -> None:
+    verify_server_derived_key(_make_packet(), server_key=_COID)
+
+
+@pytest.mark.unit
+def test_server_key_mismatch_rejected() -> None:
+    with pytest.raises(PaperApprovalPacketError) as exc:
+        verify_server_derived_key(
+            _make_packet(client_order_id="rob74-crypto-tampered0000000"),
+            server_key=_COID,
+        )
+    assert exc.value.code == "server_key_mismatch"
+
+
+@pytest.mark.unit
+def test_caller_supplied_id_matching_server_key_passes() -> None:
+    verify_server_derived_key(
+        _make_packet(), server_key=_COID, caller_client_order_id=_COID
+    )
+
+
+@pytest.mark.unit
+def test_caller_supplied_id_bypass_rejected() -> None:
+    with pytest.raises(PaperApprovalPacketError) as exc:
+        verify_server_derived_key(
+            _make_packet(),
+            server_key=_COID,
+            caller_client_order_id="attacker-chosen-id",
+        )
+    assert exc.value.code == "caller_id_mismatch"
+
+
+# ---------------------------------------------------------------------------
+# Market-data future timestamp / missing source (blocker 3)
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+def test_market_data_future_source_timestamp_rejected() -> None:
+    with pytest.raises(PaperApprovalPacketError) as exc:
+        verify_packet_market_data(
+            _make_packet(market_data_asof=_NOW + timedelta(minutes=1)),
+            now=_NOW,
+            max_age=timedelta(minutes=5),
+        )
+    assert exc.value.code == "future_source_timestamp"
+
+
+@pytest.mark.unit
+def test_market_data_missing_source_label_rejected() -> None:
+    with pytest.raises(PaperApprovalPacketError) as exc:
+        verify_packet_market_data(
+            _make_packet(market_data_source=None),
+            now=_NOW,
+            max_age=timedelta(minutes=5),
+        )
+    assert exc.value.code == "missing_market_data_source"
+
+
+# ---------------------------------------------------------------------------
+# Order-within-packet authority binding (blocker 3)
+# ---------------------------------------------------------------------------
+def _bound_packet(**overrides: Any) -> PaperApprovalPacket:
+    return _make_packet(
+        execution_order_type="limit",
+        execution_time_in_force="gtc",
+        **overrides,
+    )
+
+
+@pytest.mark.unit
+def test_order_within_packet_passes_for_matching_order() -> None:
+    verify_order_within_packet(_bound_packet(), _CANONICAL)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("bad", "code"),
+    [
+        ({"symbol": "ETH/USD"}, "order_symbol_mismatch"),
+        ({"side": "sell"}, "order_side_mismatch"),
+        ({"asset_class": "us_equity"}, "order_asset_class_mismatch"),
+        ({"type": "market"}, "order_type_mismatch"),
+        ({"time_in_force": "ioc"}, "order_tif_mismatch"),
+    ],
+)
+def test_order_within_packet_field_mismatches(bad: dict[str, Any], code: str) -> None:
+    canonical = dict(_CANONICAL)
+    canonical.update(bad)
+    with pytest.raises(PaperApprovalPacketError) as exc:
+        verify_order_within_packet(_bound_packet(), canonical)
+    assert exc.value.code == code
+
+
+@pytest.mark.unit
+def test_order_within_packet_notional_exceeds_max() -> None:
+    canonical = dict(_CANONICAL)
+    canonical["notional"] = "50"
+    with pytest.raises(PaperApprovalPacketError) as exc:
+        verify_order_within_packet(_bound_packet(max_notional=Decimal("10")), canonical)
+    assert exc.value.code == "notional_exceeds_max"
+
+
+@pytest.mark.unit
+def test_order_within_packet_qty_exceeds_max() -> None:
+    canonical = build_canonical_payload(
+        symbol="BTC/USD",
+        side="buy",
+        type="limit",
+        time_in_force="gtc",
+        qty=Decimal("2"),
+        notional=None,
+        limit_price=Decimal("5"),
+        asset_class="crypto",
+    )
+    packet = _bound_packet(max_notional=None, max_qty=Decimal("1"))
+    with pytest.raises(PaperApprovalPacketError) as exc:
+        verify_order_within_packet(packet, canonical)
+    assert exc.value.code == "qty_exceeds_max"
+
+
+# ---------------------------------------------------------------------------
+# Server-owned idempotency scope (blocker 4)
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+def test_automated_key_stable_for_same_intent() -> None:
+    a = derive_automated_key(
+        correlation_id="run-1", snapshot_id="s1", canonical=_CANONICAL
+    )
+    b = derive_automated_key(
+        correlation_id="run-1", snapshot_id="s1", canonical=_CANONICAL
+    )
+    assert a == b
+
+
+@pytest.mark.unit
+def test_automated_key_differs_across_runs_with_identical_economics() -> None:
+    a = derive_automated_key(
+        correlation_id="run-1", snapshot_id="s1", canonical=_CANONICAL
+    )
+    b = derive_automated_key(
+        correlation_id="run-2", snapshot_id="s1", canonical=_CANONICAL
+    )
+    c = derive_automated_key(
+        correlation_id="run-1", snapshot_id="s2", canonical=_CANONICAL
+    )
+    assert a != b
+    assert a != c
+    # economics-only manual key would have collided:
+    assert derive_client_order_id(_CANONICAL) == derive_client_order_id(_CANONICAL)
+
+
+# ---------------------------------------------------------------------------
+# Sell source fail-close: only a confirmed real holding may back a sell (blocker 5)
+# ---------------------------------------------------------------------------
+def _sell_packet(**overrides: Any) -> PaperApprovalPacket:
+    return _make_packet(
+        side="sell",
+        max_notional=None,
+        max_qty=Decimal("0.001"),
+        qty_source="ledger_filled_qty",
+        **overrides,
+    )
+
+
+def _sell_ledger(source_row: Any) -> Any:
+    ledger = MagicMock()
+    ledger.list_by_correlation_id = AsyncMock(return_value=[source_row])
+    return ledger
+
+
+def _reconciled_buy(**overrides: Any) -> Any:
+    defaults: dict[str, Any] = {
+        "side": "buy",
+        "record_kind": "execution",
+        "lifecycle_state": "position_reconciled",
+        "execution_symbol": "BTC/USD",
+        "filled_qty": Decimal("0.002"),
+    }
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_sell_source_missing_filled_qty_fails_close() -> None:
+    from app.services.paper_approval_packet import verify_sell_packet_source
+
+    ledger = _sell_ledger(_reconciled_buy(filled_qty=None))
+    with pytest.raises(PaperApprovalPacketError) as exc:
+        await verify_sell_packet_source(_sell_packet(), ledger=ledger)
+    assert exc.value.code == "source_filled_qty_unknown"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_sell_source_unparseable_filled_qty_fails_close() -> None:
+    from app.services.paper_approval_packet import verify_sell_packet_source
+
+    ledger = _sell_ledger(_reconciled_buy(filled_qty="not-a-number"))
+    with pytest.raises(PaperApprovalPacketError) as exc:
+        await verify_sell_packet_source(_sell_packet(), ledger=ledger)
+    assert exc.value.code == "source_filled_qty_unknown"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_sell_source_nonpositive_filled_qty_fails_close() -> None:
+    from app.services.paper_approval_packet import verify_sell_packet_source
+
+    ledger = _sell_ledger(_reconciled_buy(filled_qty=Decimal("0")))
+    with pytest.raises(PaperApprovalPacketError) as exc:
+        await verify_sell_packet_source(_sell_packet(), ledger=ledger)
+    assert exc.value.code == "source_filled_qty_unknown"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_sell_source_confirmed_holding_passes() -> None:
+    from app.services.paper_approval_packet import verify_sell_packet_source
+
+    ledger = _sell_ledger(_reconciled_buy(filled_qty=Decimal("0.002")))
+    await verify_sell_packet_source(_sell_packet(), ledger=ledger)  # must not raise

--- a/tests/services/test_paper_approval_packet_rob842.py
+++ b/tests/services/test_paper_approval_packet_rob842.py
@@ -298,6 +298,32 @@ def test_order_within_packet_notional_exceeds_max() -> None:
 
 
 @pytest.mark.unit
+def test_order_within_packet_market_qty_bounded_by_reference_price() -> None:
+    # A market qty order (no limit price) is bounded via the packet's trusted
+    # reference price so it cannot bypass max_notional (ROB-842 F4).
+    canonical = build_canonical_payload(
+        symbol="BTC/USD",
+        side="buy",
+        type="market",
+        time_in_force="gtc",
+        qty=Decimal("5"),
+        notional=None,
+        limit_price=None,
+        asset_class="crypto",
+    )
+    packet = _make_packet(
+        execution_order_type="market",
+        execution_time_in_force="gtc",
+        max_notional=Decimal("1000"),
+        max_qty=None,
+        reference_price=Decimal("100000"),  # 5 * 100000 = 500000 > 1000
+    )
+    with pytest.raises(PaperApprovalPacketError) as exc:
+        verify_order_within_packet(packet, canonical)
+    assert exc.value.code == "notional_exceeds_max"
+
+
+@pytest.mark.unit
 def test_order_within_packet_qty_exceeds_max() -> None:
     canonical = build_canonical_payload(
         symbol="BTC/USD",

--- a/tests/test_alpaca_paper_dev_smoke_safety.py
+++ b/tests/test_alpaca_paper_dev_smoke_safety.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import ast
 import importlib.util
+from decimal import Decimal
 from pathlib import Path
 
 import pytest
@@ -44,6 +45,26 @@ async def _clean_smoke_rows():
         await db.execute(led)
         await db.execute(snap)
         await db.commit()
+
+
+async def _seed_real_snapshot() -> int:
+    """A REAL (unmarked) server-observed snapshot the smoke can reference."""
+    from datetime import UTC, datetime
+
+    from app.core.db import AsyncSessionLocal
+    from app.models.market_quote_snapshot import MarketQuoteSnapshot
+
+    async with AsyncSessionLocal() as db:
+        row = MarketQuoteSnapshot(
+            market="us",
+            symbol="AAPL",
+            source="yahoo",
+            snapshot_at=datetime.now(UTC),
+            price=Decimal("150"),
+        )
+        db.add(row)
+        await db.commit()
+        return row.id
 
 
 SCRIPT_PATH = (
@@ -101,6 +122,18 @@ def test_dev_smoke_script_no_raw_payload_print() -> None:
                             f"smoke script calls print({arg.id}) "
                             "which would dump a raw broker payload"
                         )
+
+
+@pytest.mark.unit
+def test_dev_smoke_script_does_not_fabricate_trusted_snapshots() -> None:
+    """ROB-842 G5: the smoke must never write a market_quote_snapshots row (which
+    would masquerade an order/limit price as trusted server-observed evidence)."""
+    text = SCRIPT_PATH.read_text(encoding="utf-8")
+    assert "MarketQuoteSnapshot" not in text, (
+        "smoke script must not construct/persist a market_quote_snapshots row"
+    )
+    # It requires the operator to reference a real snapshot instead.
+    assert "--quote-snapshot-id" in text
 
 
 @pytest.mark.unit
@@ -402,9 +435,14 @@ async def test_dev_smoke_both_gates_runs_submit_then_cancel(
     set_alpaca_paper_service_factory(lambda: ro)  # type: ignore[arg-type]
     set_alpaca_paper_orders_service_factory(lambda: orders)  # type: ignore[arg-type]
     monkeypatch.setenv("ALPACA_PAPER_SMOKE_ALLOW_SIDE_EFFECTS", "1")
+    # The smoke no longer fabricates evidence; the operator points it at a REAL
+    # server-observed snapshot (here seeded as an unmarked yahoo row).
+    sid = await _seed_real_snapshot()
     try:
         module = _load_module()
-        args = module.build_parser().parse_args(["--confirm-paper-side-effect"])
+        args = module.build_parser().parse_args(
+            ["--confirm-paper-side-effect", "--quote-snapshot-id", str(sid)]
+        )
         rc = await module._async_main(args)
     finally:
         reset_alpaca_paper_service_factory()

--- a/tests/test_alpaca_paper_dev_smoke_safety.py
+++ b/tests/test_alpaca_paper_dev_smoke_safety.py
@@ -7,6 +7,8 @@ import importlib.util
 from pathlib import Path
 
 import pytest
+import pytest_asyncio
+from sqlalchemy import delete
 
 from app.mcp_server.tooling.alpaca_paper import (
     reset_alpaca_paper_service_factory,
@@ -16,6 +18,33 @@ from app.mcp_server.tooling.alpaca_paper_orders import (
     reset_alpaca_paper_orders_service_factory,
     set_alpaca_paper_orders_service_factory,
 )
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def _clean_smoke_rows():
+    """The smoke side-effect submit now persists a snapshot + a durable manual
+    claim; keep the deterministic manual keys and smoke snapshots clean."""
+    from app.core.db import AsyncSessionLocal
+    from app.models.market_quote_snapshot import MarketQuoteSnapshot
+    from app.models.review import AlpacaPaperOrderLedger
+
+    led = delete(AlpacaPaperOrderLedger).where(
+        AlpacaPaperOrderLedger.client_order_id.like("rob73-%")
+        | AlpacaPaperOrderLedger.client_order_id.like("rob74-crypto-%")
+    )
+    snap = delete(MarketQuoteSnapshot).where(
+        MarketQuoteSnapshot.symbol.in_(["AAPL", "KRW-BTC"])
+    )
+    async with AsyncSessionLocal() as db:
+        await db.execute(led)
+        await db.execute(snap)
+        await db.commit()
+    yield
+    async with AsyncSessionLocal() as db:
+        await db.execute(led)
+        await db.execute(snap)
+        await db.commit()
+
 
 SCRIPT_PATH = (
     Path(__file__).resolve().parents[1]

--- a/tests/test_alpaca_paper_isolation.py
+++ b/tests/test_alpaca_paper_isolation.py
@@ -45,6 +45,8 @@ def test_only_explicit_readonly_mcp_tool_imports_alpaca_paper():
         mcp_dir / "tooling" / "alpaca_paper.py",
         mcp_dir / "tooling" / "alpaca_paper_preview.py",
         mcp_dir / "tooling" / "alpaca_paper_orders.py",  # ROB-73 guarded submit/cancel
+        # ROB-842 automated submit boundary (paper-pinned broker factory only)
+        mcp_dir / "tooling" / "alpaca_paper_automated_orders.py",
     }
     offenders = [
         p

--- a/tests/test_alpaca_paper_orders_tools.py
+++ b/tests/test_alpaca_paper_orders_tools.py
@@ -609,7 +609,7 @@ async def test_cancel_signature_has_no_bulk_or_filter_params() -> None:
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_cancel_read_back_failure_marks_unavailable_but_succeeds(
+async def test_cancel_read_back_failure_is_honest_and_keeps_reservation(
     fake_orders_service: FakeOrdersService,
 ) -> None:
     from app.services.brokers.alpaca.exceptions import AlpacaPaperRequestError
@@ -623,7 +623,11 @@ async def test_cancel_read_back_failure_marks_unavailable_but_succeeds(
         order_id="paper-order-123",
         confirm=True,
     )
-    assert payload["cancelled"] is True
+    # ROB-842 H1: an unavailable read-back cannot confirm the terminal cancel, so
+    # the tool reports honestly and does NOT release any reservation.
+    assert payload["cancel_requested"] is True
+    assert payload["cancelled"] is False
+    assert payload["reservation_released"] is False
     assert payload["read_back_status"] == "unavailable"
     assert payload["order"] is None
 

--- a/tests/test_alpaca_paper_orders_tools.py
+++ b/tests/test_alpaca_paper_orders_tools.py
@@ -3,9 +3,12 @@
 from __future__ import annotations
 
 from decimal import Decimal
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
+import pytest_asyncio
+from sqlalchemy import delete
 
 from app.mcp_server.profiles import McpProfile
 from app.mcp_server.tooling import alpaca_paper_orders as _orders_mod
@@ -19,9 +22,29 @@ from app.mcp_server.tooling.alpaca_paper_orders import (
     set_alpaca_paper_orders_service_factory,
 )
 from app.mcp_server.tooling.registry import register_all_tools
+from app.models.review import AlpacaPaperOrderLedger
 from app.services.brokers.alpaca.schemas import Order
 from tests._mcp_tooling_support import DummyMCP
 from tests.test_mcp_alpaca_paper_tools import FakeAlpacaPaperService
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def _clean_manual_ledger_rows():
+    """Manual submits now route through the durable ledger claim; keep the
+    server-derived manual keys (rob73-/rob74-crypto-) clean between tests."""
+    from app.core.db import AsyncSessionLocal
+
+    stmt = delete(AlpacaPaperOrderLedger).where(
+        AlpacaPaperOrderLedger.client_order_id.like("rob73-%")
+        | AlpacaPaperOrderLedger.client_order_id.like("rob74-crypto-%")
+    )
+    async with AsyncSessionLocal() as db:
+        await db.execute(stmt)
+        await db.commit()
+    yield
+    async with AsyncSessionLocal() as db:
+        await db.execute(stmt)
+        await db.commit()
 
 
 def test_module_exposes_expected_surface() -> None:
@@ -58,6 +81,14 @@ class FakeOrdersService(FakeAlpacaPaperService):
 
     async def cancel_order(self, order_id: str) -> None:  # type: ignore[override]
         self.calls.append(("cancel_order", {"order_id": order_id}))
+
+    async def get_position(self, symbol: str) -> Any:  # type: ignore[override]
+        # A covering current position so manual sells pass the live-position gate.
+        self.calls.append(("get_position", {"symbol": symbol}))
+        return SimpleNamespace(symbol=symbol, qty=Decimal("100"))
+
+    async def get_order_by_client_order_id(self, client_order_id: str) -> Order | None:  # type: ignore[override]
+        return None
 
     async def get_order(self, order_id: str) -> Order:  # type: ignore[override]
         self.calls.append(("get_order", {"order_id": order_id}))
@@ -256,7 +287,6 @@ async def test_crypto_sell_limit_submit_is_confirm_gated_and_single_order(
         type="limit",
         qty=Decimal("0.0001"),
         limit_price=Decimal("50000"),
-        client_order_id="rob86-sell-test",
         asset_class="crypto",
         confirm=False,
     )
@@ -271,13 +301,13 @@ async def test_crypto_sell_limit_submit_is_confirm_gated_and_single_order(
         type="limit",
         qty=Decimal("0.0001"),
         limit_price=Decimal("50000"),
-        client_order_id="rob86-sell-test",
         asset_class="crypto",
         confirm=True,
     )
 
     assert submitted["submitted"] is True
-    assert submitted["client_order_id"] == "rob86-sell-test"
+    # server-derived key, not a caller-chosen id
+    assert submitted["client_order_id"].startswith("rob74-crypto-")
     submit_calls = [
         call for call in fake_orders_service.calls if call[0] == "submit_order"
     ]
@@ -290,23 +320,30 @@ async def test_crypto_sell_limit_submit_is_confirm_gated_and_single_order(
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_submit_caller_client_order_id_passes_through(
+async def test_submit_has_no_caller_client_order_id_param(
     fake_orders_service: FakeOrdersService,
 ) -> None:
+    """Manual submit exposes no client_order_id — the claim key is server-derived
+    and cannot be injected by the caller (ROB-842 blocker 1/2)."""
+    import inspect
+
+    params = set(inspect.signature(alpaca_paper_submit_order).parameters)
+    assert "client_order_id" not in params
+    assert "origin" not in params
+
     payload = await alpaca_paper_submit_order(
         symbol="AAPL",
         side="buy",
         type="limit",
         qty=Decimal("1"),
         limit_price=Decimal("1.00"),
-        client_order_id="dev-smoke-001",
         confirm=True,
     )
-    assert payload["client_order_id"] == "dev-smoke-001"
+    assert payload["client_order_id"].startswith("rob73-")
     sent = [c for c in fake_orders_service.calls if c[0] == "submit_order"][0][1][
         "request"
     ]
-    assert sent.client_order_id == "dev-smoke-001"
+    assert sent.client_order_id.startswith("rob73-")
 
 
 @pytest.mark.unit

--- a/tests/test_alpaca_paper_orders_tools.py
+++ b/tests/test_alpaca_paper_orders_tools.py
@@ -33,18 +33,46 @@ async def _clean_manual_ledger_rows():
     """Manual submits now route through the durable ledger claim; keep the
     server-derived manual keys (rob73-/rob74-crypto-) clean between tests."""
     from app.core.db import AsyncSessionLocal
+    from app.models.market_quote_snapshot import MarketQuoteSnapshot
 
     stmt = delete(AlpacaPaperOrderLedger).where(
         AlpacaPaperOrderLedger.client_order_id.like("rob73-%")
         | AlpacaPaperOrderLedger.client_order_id.like("rob74-crypto-%")
     )
+    snap_stmt = delete(MarketQuoteSnapshot).where(
+        MarketQuoteSnapshot.symbol.in_(["KRW-BTC", "AAPL"])
+    )
     async with AsyncSessionLocal() as db:
         await db.execute(stmt)
+        await db.execute(snap_stmt)
         await db.commit()
     yield
     async with AsyncSessionLocal() as db:
         await db.execute(stmt)
+        await db.execute(snap_stmt)
         await db.commit()
+
+
+async def _seed_quote_snapshot(
+    *, market="us", symbol="AAPL", source="yahoo", price="150", age_s=10
+) -> int:
+    """Seed a trusted market_quote_snapshots row and return its id."""
+    from datetime import UTC, datetime, timedelta
+
+    from app.core.db import AsyncSessionLocal
+    from app.models.market_quote_snapshot import MarketQuoteSnapshot
+
+    async with AsyncSessionLocal() as db:
+        row = MarketQuoteSnapshot(
+            market=market,
+            symbol=symbol,
+            source=source,
+            snapshot_at=datetime.now(UTC) - timedelta(seconds=age_s),
+            price=Decimal(price),
+        )
+        db.add(row)
+        await db.commit()
+        return row.id
 
 
 def test_module_exposes_expected_surface() -> None:
@@ -142,12 +170,14 @@ async def test_submit_without_confirm_is_blocked_no_op(
 async def test_submit_with_confirm_calls_service_once(
     fake_orders_service: FakeOrdersService,
 ) -> None:
+    sid = await _seed_quote_snapshot(market="us", symbol="AAPL", source="yahoo")
     payload = await alpaca_paper_submit_order(
         symbol="AAPL",
         side="buy",
         type="limit",
         qty=Decimal("1"),
         limit_price=Decimal("1.00"),
+        quote_snapshot_id=sid,
         confirm=True,
     )
     assert payload["submitted"] is True
@@ -227,6 +257,7 @@ async def test_crypto_submit_rejects_invalid_time_in_force_before_service_call(
 async def test_crypto_submit_with_confirm_calls_service_once(
     fake_orders_service: FakeOrdersService,
 ) -> None:
+    sid = await _seed_quote_snapshot(market="crypto", symbol="KRW-BTC", source="upbit")
     payload = await alpaca_paper_submit_order(
         symbol="BTC/USD",
         side="buy",
@@ -235,6 +266,7 @@ async def test_crypto_submit_with_confirm_calls_service_once(
         limit_price=Decimal("50000"),
         time_in_force="gtc",
         asset_class="crypto",
+        quote_snapshot_id=sid,
         confirm=True,
     )
     assert payload["submitted"] is True
@@ -295,6 +327,7 @@ async def test_crypto_sell_limit_submit_is_confirm_gated_and_single_order(
     assert dry_run["blocked_reason"] == "confirmation_required"
     assert fake_orders_service.calls == []
 
+    sid = await _seed_quote_snapshot(market="crypto", symbol="KRW-BTC", source="upbit")
     submitted = await alpaca_paper_submit_order(
         symbol="BTC/USD",
         side="sell",
@@ -302,6 +335,7 @@ async def test_crypto_sell_limit_submit_is_confirm_gated_and_single_order(
         qty=Decimal("0.0001"),
         limit_price=Decimal("50000"),
         asset_class="crypto",
+        quote_snapshot_id=sid,
         confirm=True,
     )
 
@@ -331,12 +365,14 @@ async def test_submit_has_no_caller_client_order_id_param(
     assert "client_order_id" not in params
     assert "origin" not in params
 
+    sid = await _seed_quote_snapshot(market="us", symbol="AAPL", source="yahoo")
     payload = await alpaca_paper_submit_order(
         symbol="AAPL",
         side="buy",
         type="limit",
         qty=Decimal("1"),
         limit_price=Decimal("1.00"),
+        quote_snapshot_id=sid,
         confirm=True,
     )
     assert payload["client_order_id"].startswith("rob73-")
@@ -619,6 +655,7 @@ async def test_submit_fails_closed_on_live_endpoint(
     )
     mod.reset_alpaca_paper_orders_service_factory()
 
+    sid = await _seed_quote_snapshot(market="us", symbol="AAPL", source="yahoo")
     with pytest.raises(AlpacaPaperEndpointError):
         await alpaca_paper_submit_order(
             symbol="AAPL",
@@ -626,6 +663,7 @@ async def test_submit_fails_closed_on_live_endpoint(
             type="limit",
             qty=Decimal("1"),
             limit_price=Decimal("1.00"),
+            quote_snapshot_id=sid,
             confirm=True,
         )
 

--- a/tests/test_alpaca_paper_orders_tools.py
+++ b/tests/test_alpaca_paper_orders_tools.py
@@ -113,7 +113,9 @@ class FakeOrdersService(FakeAlpacaPaperService):
     async def get_position(self, symbol: str) -> Any:  # type: ignore[override]
         # A covering current position so manual sells pass the live-position gate.
         self.calls.append(("get_position", {"symbol": symbol}))
-        return SimpleNamespace(symbol=symbol, qty=Decimal("100"))
+        return SimpleNamespace(
+            symbol=symbol, qty=Decimal("100"), qty_available=Decimal("100")
+        )
 
     async def get_order_by_client_order_id(self, client_order_id: str) -> Order | None:  # type: ignore[override]
         return None

--- a/tests/test_alpaca_paper_service_methods.py
+++ b/tests/test_alpaca_paper_service_methods.py
@@ -56,6 +56,7 @@ POSITION_DATA = [
         "asset_id": "asset-1",
         "symbol": "AAPL",
         "qty": "10",
+        "qty_available": "4",
         "avg_entry_price": "150.00",
         "current_price": "155.00",
         "market_value": "1550.00",
@@ -66,6 +67,7 @@ POSITION_DATA = [
         "asset_id": "asset-2",
         "symbol": "TSLA",
         "qty": "5",
+        "qty_available": "3",
         "avg_entry_price": "200.00",
         "current_price": "210.00",
         "market_value": "1050.00",
@@ -159,7 +161,9 @@ async def test_list_positions_parses_array():
 
     assert len(positions) == 2
     assert positions[0].symbol == "AAPL"
+    assert positions[0].qty_available == Decimal("4")
     assert positions[1].symbol == "TSLA"
+    assert positions[1].qty_available == Decimal("3")
 
 
 @pytest.mark.unit

--- a/tests/test_alpaca_paper_submit_boundary_safety.py
+++ b/tests/test_alpaca_paper_submit_boundary_safety.py
@@ -1,0 +1,198 @@
+"""ROB-842 safety guards for the unified Alpaca paper submit boundary.
+
+- paper-host pin preserved; no live endpoint / live-credential import or reference
+  in the new application-service or packet modules (AST/text scan);
+- no new idempotency store/table/column/migration — the existing native
+  ``review.alpaca_paper_order_ledger`` remains the sole lifecycle/result source.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SUBMIT_SERVICE = REPO_ROOT / "app/services/alpaca_paper_submit_service.py"
+PACKET = REPO_ROOT / "app/services/paper_approval_packet.py"
+LEDGER = REPO_ROOT / "app/services/alpaca_paper_ledger_service.py"
+AUTOMATED_TOOLS = REPO_ROOT / "app/mcp_server/tooling/alpaca_paper_automated_orders.py"
+
+_LIVE_MARKERS = (
+    "api.alpaca.markets",
+    "LIVE_TRADING_BASE_URL",
+    "alpaca_live",
+)
+
+
+# ---------------------------------------------------------------------------
+# Paper-host pin / no live endpoint or credential reference
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+@pytest.mark.parametrize("path", [SUBMIT_SERVICE, PACKET, AUTOMATED_TOOLS])
+def test_new_modules_have_no_live_endpoint_or_credential_reference(path: Path) -> None:
+    text = path.read_text(encoding="utf-8")
+    for marker in _LIVE_MARKERS:
+        assert marker not in text, (
+            f"{path.name} references live marker {marker!r}; paper boundary only"
+        )
+
+
+@pytest.mark.unit
+def test_submit_service_only_broker_surface_is_paper_service() -> None:
+    """The only broker service the coordinator can name is the paper-pinned one."""
+    text = SUBMIT_SERVICE.read_text(encoding="utf-8")
+    assert "AlpacaPaperBrokerService" in text
+    # No live service/class name variants.
+    assert "AlpacaLiveBrokerService" not in text
+    assert "LiveBrokerService" not in text
+
+
+@pytest.mark.unit
+def test_paper_broker_service_still_rejects_live_base_url() -> None:
+    """The injected broker remains paper-host-pinned (fail-closed on live)."""
+    from app.services.brokers.alpaca.config import AlpacaPaperSettings
+    from app.services.brokers.alpaca.endpoints import LIVE_TRADING_BASE_URL
+    from app.services.brokers.alpaca.exceptions import AlpacaPaperEndpointError
+    from app.services.brokers.alpaca.service import AlpacaPaperBrokerService
+
+    with pytest.raises(AlpacaPaperEndpointError):
+        AlpacaPaperBrokerService(
+            settings=AlpacaPaperSettings(
+                api_key="pk", api_secret="sk", base_url=LIVE_TRADING_BASE_URL
+            )
+        )
+
+
+@pytest.mark.unit
+def test_coordinator_never_builds_broker_on_rejected_packet() -> None:
+    """A rejected packet must not even construct the broker (no host touch)."""
+    import asyncio
+    import uuid
+    from datetime import UTC, datetime
+    from decimal import Decimal
+
+    from app.services.alpaca_paper_submit_service import (
+        AlpacaPaperSubmitCoordinator,
+        build_canonical_payload,
+        canonical_hash,
+        derive_automated_key,
+    )
+    from app.services.paper_approval_packet import PaperApprovalPacket
+
+    canonical = build_canonical_payload(
+        symbol="BTC/USD",
+        side="buy",
+        type="limit",
+        time_in_force="gtc",
+        qty=None,
+        notional=Decimal("10"),
+        limit_price=Decimal("50000"),
+        asset_class="crypto",
+    )
+
+    def _explode():
+        raise AssertionError("broker factory must not be called on a rejected packet")
+
+    coord = AlpacaPaperSubmitCoordinator(
+        ledger=_UnusedLedger(),
+        broker_factory=_explode,
+        now_fn=lambda: datetime(2026, 7, 12, 12, 0, 0, tzinfo=UTC),
+    )
+    packet = PaperApprovalPacket(
+        signal_source="s",
+        artifact_id=uuid.uuid4(),
+        signal_symbol="KRW-BTC",
+        signal_venue="upbit",
+        execution_symbol="BTC/USD",
+        execution_venue="alpaca_paper",
+        execution_asset_class="crypto",
+        side="buy",
+        max_notional=Decimal("10"),
+        qty_source="notional_estimate",
+        expected_lifecycle_step="previewed",
+        lifecycle_correlation_id="corr",
+        client_order_id=derive_automated_key(
+            correlation_id="corr", snapshot_id="snap", canonical=canonical
+        ),
+        expires_at=datetime(2030, 1, 1, tzinfo=UTC),
+        account_mode="alpaca_live",  # <- rejection trigger (after key/order checks)
+        origin="automated",
+        market_data_asof=datetime(2026, 7, 12, 11, 59, 50, tzinfo=UTC),
+        market_data_source="upbit_ticker",
+        preview_payload_hash=canonical_hash(canonical),
+        snapshot_id="snap",
+        execution_order_type="limit",
+        execution_time_in_force="gtc",
+    )
+    outcome = asyncio.run(coord.submit(packet, submit_canonical=canonical))
+    assert outcome.status == "rejected"
+    assert outcome.reason_code == "account_mode_mismatch"
+    assert outcome.broker_called is False
+
+
+class _UnusedLedger:
+    """Ledger stub whose methods must never be reached for a rejected packet."""
+
+    @property
+    def session(self):  # pragma: no cover - defensive
+        raise AssertionError("ledger must not be touched on a rejected packet")
+
+
+# ---------------------------------------------------------------------------
+# No new idempotency store / table / column / migration
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+def test_no_idempotency_table_in_metadata() -> None:
+    from app.models.base import Base
+
+    names = set(Base.metadata.tables.keys())
+    offenders = [n for n in names if "idempotency" in n.lower()]
+    assert not offenders, f"unexpected idempotency table(s): {offenders}"
+
+
+@pytest.mark.unit
+def test_alpaca_paper_ledger_gained_no_new_columns() -> None:
+    """The hash/idempotency key live on the packet, never as a new ledger column."""
+    from app.models.review import AlpacaPaperOrderLedger
+
+    cols = {c.name for c in AlpacaPaperOrderLedger.__table__.columns}
+    forbidden = {
+        "idempotency_key",
+        "preview_payload_hash",
+        "submit_hash",
+        "claim_key",
+        "approval_hash",
+    }
+    assert forbidden.isdisjoint(cols), (
+        f"ROB-842 must add no ledger columns; found {forbidden & cols}"
+    )
+
+
+@pytest.mark.unit
+def test_submit_service_defines_no_schema_and_no_raw_writes() -> None:
+    """The application service owns no schema and issues no direct table writes."""
+    tree = ast.parse(SUBMIT_SERVICE.read_text(encoding="utf-8"))
+    banned_calls = {"create_table", "add_column", "pg_insert", "insert"}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef):
+            for base in node.bases:
+                base_name = getattr(base, "id", getattr(base, "attr", ""))
+                assert base_name != "Base", "submit service must not define ORM models"
+        if isinstance(node, ast.Call):
+            func = node.func
+            name = getattr(func, "attr", getattr(func, "id", ""))
+            assert name not in banned_calls, (
+                f"submit service must delegate persistence, not call {name!r}"
+            )
+
+
+@pytest.mark.unit
+def test_atomic_claim_targets_existing_ledger_table_only() -> None:
+    """claim_submit writes only the existing alpaca_paper_order_ledger table."""
+    from app.models.review import AlpacaPaperOrderLedger
+    from app.services.alpaca_paper_ledger_service import AlpacaPaperLedgerService
+
+    assert AlpacaPaperOrderLedger.__tablename__ == "alpaca_paper_order_ledger"
+    assert hasattr(AlpacaPaperLedgerService, "claim_submit")

--- a/tests/test_alpaca_paper_submit_boundary_safety.py
+++ b/tests/test_alpaca_paper_submit_boundary_safety.py
@@ -189,6 +189,33 @@ def test_submit_service_defines_no_schema_and_no_raw_writes() -> None:
 
 
 @pytest.mark.unit
+def test_no_alpaca_tooling_calls_broker_submit_directly() -> None:
+    """Only the coordinator service may call broker.submit_order.
+
+    Every Alpaca paper MCP tooling module must delegate the actual POST to the
+    AlpacaPaperSubmitCoordinator — no direct ``.submit_order(`` fallback that
+    would bypass the packet + atomic-claim boundary (ROB-842 blocker 1).
+    """
+    tooling_dir = REPO_ROOT / "app/mcp_server/tooling"
+    offenders = []
+    for path in tooling_dir.rglob("alpaca_paper*.py"):
+        text = path.read_text(encoding="utf-8")
+        if ".submit_order(" in text:
+            offenders.append(path.name)
+    assert not offenders, (
+        f"Alpaca paper tooling calls broker.submit_order directly (must route "
+        f"through the coordinator): {offenders}"
+    )
+
+
+@pytest.mark.unit
+def test_only_coordinator_service_posts_orders() -> None:
+    """The submit-service coordinator is the single module that POSTs orders."""
+    text = SUBMIT_SERVICE.read_text(encoding="utf-8")
+    assert "broker.submit_order(" in text  # the one and only POST site
+
+
+@pytest.mark.unit
 def test_atomic_claim_targets_existing_ledger_table_only() -> None:
     """claim_submit writes only the existing alpaca_paper_order_ledger table."""
     from app.models.review import AlpacaPaperOrderLedger

--- a/tests/test_mcp_profiles.py
+++ b/tests/test_mcp_profiles.py
@@ -19,6 +19,9 @@ from app.mcp_server.tooling.account_read_registration import (
     ACCOUNT_READ_TOOL_NAMES,
 )
 from app.mcp_server.tooling.alpaca_paper import ALPACA_PAPER_READONLY_TOOL_NAMES
+from app.mcp_server.tooling.alpaca_paper_automated_orders import (
+    ALPACA_PAPER_AUTOMATED_TOOL_NAMES,
+)
 from app.mcp_server.tooling.alpaca_paper_orders import (
     ALPACA_PAPER_MUTATING_TOOL_NAMES,
 )
@@ -250,7 +253,7 @@ _ORDER_SURFACE_MATRIX: dict[McpProfile, set[str]] = {
     ),
     McpProfile.HERMES_PAPER_KIS: set(KIS_MOCK_ORDER_TOOL_NAMES),
     McpProfile.CRYPTO: _LEGACY_ORDER_TOOL_NAMES | LIVE_RECONCILE_TOOL_NAMES,
-    McpProfile.US_PAPER: set(_ALPACA_MUTATING),
+    McpProfile.US_PAPER: set(_ALPACA_MUTATING) | ALPACA_PAPER_AUTOMATED_TOOL_NAMES,
     McpProfile.DB_PAPER: set(),
     McpProfile.KIWOOM: set(KIWOOM_MOCK_TOOL_NAMES),
     # ROB-697 M1 — shadow-replay registers zero order/mutation tools by design
@@ -292,6 +295,7 @@ _ALL_ORDER_TOOL_NAMES = (
     | LIVE_RECONCILE_TOOL_NAMES
     | KIWOOM_MOCK_TOOL_NAMES
     | _ALPACA_MUTATING
+    | ALPACA_PAPER_AUTOMATED_TOOL_NAMES
     | TOSS_LIVE_ORDER_TOOL_NAMES
     | PAPER_LIMIT_ORDER_TOOL_NAMES
 )

--- a/tests/test_watch_triage_readonly_settings.py
+++ b/tests/test_watch_triage_readonly_settings.py
@@ -37,6 +37,7 @@ KNOWN_MUTATION_TOOLS = frozenset(
         "toss_cancel_order",
         "toss_reconcile_orders",
         "alpaca_paper_submit_order",
+        "alpaca_paper_automated_submit_order",
         "alpaca_paper_cancel_order",
         "kiwoom_mock_place_order",
         "kiwoom_mock_cancel_order",


### PR DESCRIPTION
## ROB-842 — Alpaca Paper submit을 approval packet + 기존 native ledger atomic-claim/replay 단일 서버 경계로 일원화

자동 cohort를 켜기 전에, **모든 Alpaca Paper 실주문(manual·automated)**이 하나의 서버측 경계를 통과하도록 만든다: **server-owned approval packet 검증 → 기존 `review.alpaca_paper_order_ledger` atomic claim → broker POST → stored-result replay**. 새 idempotency store/table/column/Alembic migration **없음** (기존 execution 슬롯 재사용).

### 핵심 계약
- **Exactly-once**: 동일 intent 순차·병렬 중복이라도 broker HTTP submit 정확히 1회. 나머지는 원 결과 replay / recovered / idempotency_in_progress.
- **Server-owned identity/provenance/ceiling**: caller는 주문 intent + 불투명 `quote_snapshot_id`(trusted `market_quote_snapshots`)만 제공. correlation/snapshot/market-data as-of·source/ceiling/origin/client_order_id 주입 불가.
- **Replay-before-freshness**: immutable token/key/hash/account 검증 → terminal/success replay → (신규만) freshness/market/position. 완료 주문은 packet 만료 후에도 stale_packet 아닌 원 결과 replay.
- **Freshness-at-send**: 실제 `broker.submit_order` 직전 현재 시각으로 freshness+market_data 재검증.
- **Hard cap**: snapshot price finite/positive 검증 + `reference_price × qty`로 market/qty 주문도 $1,000(equity)/$50(crypto) cap에 결속.
- **Terminal vs uncertain**: HTTP 4xx/422는 terminal 기록 후 replay(재POST 없음), 5xx/timeout/crash는 `get_order_by_client_order_id` reconcile(있으면 recovered, 없으면 in-flight).
- **Sell 안전**: 실제 broker POST 직전 라이브 포지션 재조회 + `(account_mode, symbol)` advisory-lock reservation(open sell만 차감, filled 이중차감 금지)으로 서로 다른 sell intent의 oversell 방지. availability 계산 전 open submitted sell을 broker truth와 대조(filled→해제·open→유지·조회실패→유지 fail-close).
- **Cancel 정직성**: DELETE 204(요청 접수)만으로 예약 해제하지 않고, immediate GET status=`canceled` 확정 시에만 해제(pending_cancel/open/readback실패=유지, filled 경쟁=filled로 수렴).
- **Automated sell 비활성화**: preview·submit 양단에서 `automated_sell_disabled`(ROB-845 대기). manual sell은 라이브 포지션+예약으로 지원.
- **Smoke provenance**: dev smoke는 order-price로 trusted snapshot을 조작하지 않고 operator `--quote-snapshot-id` 요구. loader는 synthetic raw_payload snapshot을 거절.
- **안전 경계**: paper host pin 유지, live Alpaca endpoint/credential import 0, automated default-off(`ALPACA_PAPER_AUTOMATED_SUBMIT_ENABLED`), schema/migration 변경 0.

### 구성
- `app/services/alpaca_paper_submit_service.py` — `AlpacaPaperSubmitCoordinator`(단일 POST site) + 공유 canonical/derive/hash
- `app/services/alpaca_paper_market_evidence.py` — trusted `market_quote_snapshots` 로더(synthetic 거절)
- `app/services/alpaca_paper_ledger_service.py` — `claim_submit` / `reserve_sell_and_claim` / `list_open_sells` / `record_submit_failure`
- `app/services/paper_approval_packet.py` — packet 계약 + 검증자
- `app/mcp_server/tooling/alpaca_paper_orders.py`(manual, cancel) · `alpaca_paper_automated_orders.py`(automated preview/submit, US_PAPER·default-off)
- 문서: `app/mcp_server/README.md`, `docs/runbooks/alpaca-paper-ledger.md`

### 검증
- **전체 Alpaca 관련 suite `1677 passed`** (packet/ledger/coordinator/handler + 기존 회귀 + registry/profile boot + `test_no_internal_llm_imports`)
- 동시성(2-세션 barrier·concurrent coordinator·distinct-sell oversell·concurrent reconcile no-oversell·parallel manual/automated) 5회 반복 flake 0
- `ruff check`/`ruff format --check`/`ty check`/`git diff --check origin/main..HEAD` clean
- migration 0 · live Alpaca import 0(isolation guard) · alpaca tooling 직접 `submit_order` 0(coordinator 단일 POST site) · automated default-off · paper host pin

### 남은 위험/후속
- **automated sell 전면 비활성화** — 라이브 매도 자동화는 ROB-845(opaque buy/position source) 후. manual sell만 지원.
- reservation 직렬화는 단일 Postgres advisory-lock 가정. reconcile/cancel의 broker 조회 실패는 항상 예약 유지(fail-close) — 일시 장애 시 신규 sell 보수적 차단.
- H2 reconcile은 open sell당 broker GET 1회 추가.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a gated, two-step automated Alpaca Paper order workflow with preview and confirmation.
  * Added trusted quote validation, order limits, approval tokens, and server-derived identifiers.
  * Added exactly-once submission, duplicate replay, crash recovery, and broker status reconciliation.
  * Added safeguards for sell quantities, current positions, and reservation tracking.
  * Automated order tools are now available in the US Paper profile.

* **Bug Fixes**
  * Manual submissions now fail safely without trusted market evidence and prevent duplicate broker requests.
  * Cancel results more accurately reflect broker status and reservation release.

* **Documentation**
  * Added guidance covering submission boundaries, replay behavior, market evidence, and sell protections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->