### PR TITLE
fix(ROB-856): bound Toss proposal clientOrderId to API limit

### DIFF
--- a/app/services/order_proposals/revalidation.py
+++ b/app/services/order_proposals/revalidation.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import hashlib
 import inspect
+import re
 import uuid
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -82,6 +83,8 @@ _GUARD_ERROR_MARKERS = (
     "stop-loss cooldown",
     "opposite pending order",
 )
+_TOSS_CLIENT_ORDER_ID_MAX_LENGTH = 36
+_TOSS_CLIENT_ORDER_ID_PATTERN = re.compile(r"[a-zA-Z0-9\-_]+")
 
 
 async def _maybe_await(value: Any) -> Any:
@@ -138,8 +141,16 @@ def _toss_decimal_arg(value: Decimal | None) -> str | int | None:
 
 def _toss_proposal_client_order_id(proposal_id: uuid.UUID, rung_index: int) -> str:
     """Return a proposal/rung-stable, Toss-safe private idempotency key."""
-    digest = hashlib.sha256(f"{proposal_id}:{rung_index}".encode()).hexdigest()[:32]
+    digest = hashlib.sha256(f"{proposal_id}:{rung_index}".encode()).hexdigest()[:24]
     return f"tosprop-{digest}"
+
+
+def _is_valid_toss_client_order_id(value: Any) -> bool:
+    return (
+        isinstance(value, str)
+        and len(value) <= _TOSS_CLIENT_ORDER_ID_MAX_LENGTH
+        and _TOSS_CLIENT_ORDER_ID_PATTERN.fullmatch(value) is not None
+    )
 
 
 def _proposal_client_order_id(proposal_id: uuid.UUID, rung_index: int) -> str:
@@ -298,6 +309,16 @@ async def _default_place_order_fn(**kwargs: Any) -> dict[str, Any]:
             return _adapt_toss_preview_response(preview)
 
         approval_hash = kwargs.get("approval_hash")
+        if not _is_valid_toss_client_order_id(proposal_client_order_id):
+            return {
+                "success": False,
+                "mutation_sent": False,
+                "error_code": "invalid_toss_client_order_id",
+                "error": (
+                    "Toss clientOrderId must be at most 36 characters and match "
+                    "[a-zA-Z0-9\\-_]+"
+                ),
+            }
         with _bind_order_proposal_context(
             client_order_id=str(proposal_client_order_id),
             correlation_id=kwargs.get("correlation_id"),

--- a/tests/services/order_proposals/test_revalidation.py
+++ b/tests/services/order_proposals/test_revalidation.py
@@ -1,3 +1,4 @@
+import re
 import uuid
 from datetime import UTC, datetime
 from decimal import Decimal
@@ -966,12 +967,50 @@ def test_toss_decimal_args_are_exact_and_canonical():
 def test_toss_proposal_client_ids_are_stable_and_rung_scoped():
     from app.services.order_proposals import revalidation as mod
 
+    # Toss OpenAPI OrderCreateRequest.clientOrderId (openapi.json).
+    toss_client_order_id_max_length = 36
     proposal_id = uuid.UUID("12345678-1234-5678-1234-567812345678")
     same = mod._toss_proposal_client_order_id(proposal_id, 0)
     assert same == mod._toss_proposal_client_order_id(proposal_id, 0)
     assert same != mod._toss_proposal_client_order_id(proposal_id, 1)
     assert same != mod._toss_proposal_client_order_id(uuid.uuid4(), 0)
     assert same.startswith("tosprop-")
+    assert len(same) <= toss_client_order_id_max_length
+    assert re.fullmatch(r"[a-zA-Z0-9\-_]+", same)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "invalid_client_order_id",
+    ["x" * 37, "invalid@client-order-id"],
+)
+async def test_toss_submit_rejects_invalid_client_order_id_before_broker_call(
+    monkeypatch, invalid_client_order_id
+):
+    import app.mcp_server.tooling.orders_toss_variants as toss
+    from app.services.order_proposals import revalidation as mod
+
+    async def forbidden_broker_call(**kwargs):
+        pytest.fail(f"broker POST must not be called: {kwargs}")
+
+    monkeypatch.setattr(toss, "toss_place_order", forbidden_broker_call)
+
+    result = await mod._default_place_order_fn(
+        dry_run=False,
+        account_mode="toss_live",
+        symbol="000660",
+        side="buy",
+        market="equity_kr",
+        order_type="limit",
+        quantity=Decimal("1"),
+        price=Decimal("222600"),
+        proposal_client_order_id=invalid_client_order_id,
+        approval_hash="preview-token",
+    )
+
+    assert result["success"] is False
+    assert result["mutation_sent"] is False
+    assert result["error_code"] == "invalid_toss_client_order_id"
 
 
 def test_upbit_proposal_client_ids_are_stable_and_rung_scoped():


### PR DESCRIPTION
## Summary

- Shorten proposal-scoped Toss clientOrderId from 40 to 32 characters while preserving proposal/rung determinism.
- Fail closed before toss_place_order when clientOrderId exceeds 36 characters or violates the Toss character pattern.
- Add regression coverage for length, pattern, determinism, rung scoping, and no-broker-call validation.

## Production evidence

On 2026-07-13, all 12 toss_live x equity_kr proposals across two rounds passed server revalidation (HTTP 200) but received HTTP 400 from POST /api/v1/orders. Concurrent kis_live submission succeeded, and the live-order ledger remained at 0 rows. The proposal override generated tosprop- plus 32 digest characters (40 total), violating Toss OrderCreateRequest.clientOrderId maxLength 36; the direct Toss path already uses a compliant 23-character key.

No order using the old proposal key scheme was accepted (all attempts returned 400), so changing this key scheme has no idempotency or replay impact on successful broker orders.

## Verification

- uv run pytest tests/services/order_proposals/ -x -q: 285 passed
- make lint: Ruff, format check, and ty passed

Linear: https://linear.app/mgh3326/issue/ROB-856