### PR TITLE
fix(ROB-855): normalize order proposal market aliases

### DIFF
--- a/app/mcp_server/README.md
+++ b/app/mcp_server/README.md
@@ -535,6 +535,11 @@ proposal describes a possible order; creating or voiding one is not a broker
 order mutation.
 
 - `order_proposal_create(...)`
+  - `market` uses canonical `equity_kr`, `equity_us`, or `crypto`; the tool
+    accepts `kr` and `us` aliases and normalizes them before validation,
+    payload hashing, and persistence.
+  - Supported place combinations are `kis_live` or `toss_live` with
+    `equity_kr`/`equity_us`, and `upbit` with `crypto`.
   - `action="place"` is the default and `target_broker_order_id=None` is the
     default.
   - `place`: `target_broker_order_id` must be absent; one or more proposal

--- a/app/mcp_server/tooling/order_proposal_tools.py
+++ b/app/mcp_server/tooling/order_proposal_tools.py
@@ -37,6 +37,12 @@ ORDER_PROPOSAL_TOOL_NAMES: set[str] = {
     "order_proposal_void",
 }
 
+_MARKET_ALIASES = {"kr": "equity_kr", "us": "equity_us"}
+
+
+def _normalize_order_proposal_market(market: str) -> str:
+    return _MARKET_ALIASES.get(market, market)
+
 
 def _dec(v: str | None) -> Decimal | None:
     if v is None:
@@ -116,6 +122,10 @@ async def order_proposal_create(
     """Create a place, replace, or cancel proposal without broker mutation.
 
     Args:
+        market: Canonical market in {equity_kr, equity_us, crypto}; aliases
+                kr→equity_kr and us→equity_us are accepted. Supported place
+                combinations are kis_live/toss_live with equity_kr or equity_us,
+                and upbit with crypto.
         rungs: list of {"rung_index": int, "side": str, "quantity": str,
                "limit_price": str|None, "notional": str|None}.
         supersedes_proposal_id: if this proposal replaces an existing one (price/qty
@@ -125,6 +135,7 @@ async def order_proposal_create(
         target_broker_order_id: required broker order ID for replace/cancel.
     """
     try:
+        market = _normalize_order_proposal_market(market)
         rung_inputs = [
             RungInput(
                 int(r["rung_index"]),

--- a/app/mcp_server/tooling/trade_retrospective_registration.py
+++ b/app/mcp_server/tooling/trade_retrospective_registration.py
@@ -26,7 +26,8 @@ def register_trade_retrospective_tools(mcp: Any) -> None:
         description=(
             "Store a structured trade retrospective (outcome, absolute realized_pnl, "
             "fill/plan price, pnl_pct, rationale/result/lesson/next_strategy) for a "
-            "trade. account_mode in {kis_mock, kiwoom_mock, kis_live, toss_live, "
+            "trade. outcome in {filled, partially_filled, unfilled, rejected, "
+            "cancelled}. account_mode in {kis_mock, kiwoom_mock, kis_live, toss_live, "
             "alpaca_paper, upbit_live}. Idempotent per correlation_id (omit it to "
             "append). "
             "kiwoom_mock cannot supply realized_pnl/fill_price (no fill evidence, "

--- a/app/mcp_server/tooling/trade_retrospective_tools.py
+++ b/app/mcp_server/tooling/trade_retrospective_tools.py
@@ -65,6 +65,11 @@ async def save_trade_retrospective(
     guardrail_fired: str | None = None,
     policy_version: str | None = None,
 ) -> dict[str, Any]:
+    """Store a structured trade retrospective.
+
+    Args:
+        outcome: One of filled, partially_filled, unfilled, rejected, cancelled.
+    """
     symbol = (symbol or "").strip()
     if not symbol:
         return {"success": False, "error": "symbol is required"}

--- a/app/services/order_proposals/service.py
+++ b/app/services/order_proposals/service.py
@@ -69,6 +69,12 @@ _ACTION_CAPABILITIES = {
     "cancel": SUPPORTED_TARGET_ACTIONS,
 }
 
+_ALLOWED_ACTION_CONTRACT_MESSAGE = (
+    "allowed: kis_live×equity_kr|equity_us, "
+    "toss_live×equity_kr|equity_us, upbit×crypto; "
+    "market aliases kr→equity_kr, us→equity_us"
+)
+
 _LOSS_CUT_EXIT_REASONS = frozenset({"stop_loss", "thesis_change"})
 _LOSS_CUT_TRIGGER_TYPES = frozenset({"stop_loss", "thesis_change"})
 _LOSS_CUT_MAX_AGE = timedelta(hours=72)
@@ -102,7 +108,8 @@ def _validate_action_contract(
     if (account_mode, market) not in _ACTION_CAPABILITIES[normalized]:
         raise OrderProposalError(
             "unsupported account_mode/market/action: "
-            f"{account_mode}/{market}/{normalized}"
+            f"{account_mode}/{market}/{normalized} "
+            f"({_ALLOWED_ACTION_CONTRACT_MESSAGE})"
         )
     if normalized == "place":
         if target_broker_order_id is not None or target_order_snapshot is not None:

--- a/app/services/trade_journal/trade_retrospective_service.py
+++ b/app/services/trade_journal/trade_retrospective_service.py
@@ -297,7 +297,10 @@ async def save_retrospective(
     if account_mode not in _VALID_ACCOUNT_MODES:
         raise RetrospectiveValidationError(f"invalid account_mode: {account_mode}")
     if outcome not in _VALID_OUTCOMES:
-        raise RetrospectiveValidationError(f"invalid outcome: {outcome}")
+        raise RetrospectiveValidationError(
+            f"invalid outcome: {outcome} "
+            f"(allowed: {', '.join(sorted(_VALID_OUTCOMES))})"
+        )
     if side is not None and side not in ("buy", "sell"):
         raise RetrospectiveValidationError(f"invalid side: {side}")
     if realized_pnl_currency is not None and realized_pnl_currency not in (

--- a/docs/superpowers/plans/2026-07-13-rob-855-order-proposal-market-dx.md
+++ b/docs/superpowers/plans/2026-07-13-rob-855-order-proposal-market-dx.md
@@ -335,4 +335,3 @@ one PR against `main` titled
 mode/deployment after three retries, first KR execution produced zero orders),
 lists tests, enumerates normalization callsites, and states no migration is
 required because existing valid rows are canonical.
-

--- a/docs/superpowers/plans/2026-07-13-rob-855-order-proposal-market-dx.md
+++ b/docs/superpowers/plans/2026-07-13-rob-855-order-proposal-market-dx.md
@@ -1,0 +1,338 @@
+# ROB-855 Order Proposal Market DX Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Accept `kr`/`us` aliases at the order-proposal MCP boundary while preserving canonical validation, hashes, storage, and responses, and expose actionable proposal and retrospective enums.
+
+**Architecture:** A private helper in `order_proposal_tools.py` canonicalizes market before any preflight or service call. The service continues to validate canonical tuples and computes its existing payload hash unchanged; retrospective validation reuses its existing outcome set when formatting errors.
+
+**Tech Stack:** Python 3.13+, FastMCP handlers, SQLAlchemy async sessions, pytest/pytest-asyncio, Ruff, ty, `uv`.
+
+## Global Constraints
+
+- Normalize aliases before target-order preflight, service validation, payload hashing, and persistence.
+- Persist and return only `equity_kr`, `equity_us`, or `crypto` for supported proposals.
+- Do not add market parameters to `order_proposal_get` or `order_proposal_list`; neither currently has one.
+- Do not modify `app/services/order_proposals/revalidation.py` or Toss submit-path helpers.
+- Do not modify `no_resolvable_forecast` auto-close behavior.
+- Do not add a database migration; existing valid order-proposal rows are canonical.
+- Do not make real broker calls in tests.
+- Every commit includes `Co-Authored-By: Paperclip <noreply@paperclip.ing>`.
+
+---
+
+### Task 1: Canonicalize order-proposal markets before hashing and storage
+
+**Files:**
+- Modify: `tests/test_mcp_order_proposal_tools.py`
+- Modify: `tests/services/order_proposals/test_service.py`
+- Modify: `app/mcp_server/tooling/order_proposal_tools.py`
+- Modify: `app/services/order_proposals/service.py`
+- Modify: `app/mcp_server/README.md`
+
+**Interfaces:**
+- Consumes: `order_proposal_create(..., market: str, ...) -> dict[str, Any]`.
+- Produces: `_normalize_order_proposal_market(market: str) -> str`, canonical arguments for `fetch_target_order` and `create_proposal`, and actionable contract errors.
+
+- [ ] **Step 1: Write failing alias, persistence, hash, error, and docstring tests**
+
+Add to `tests/test_mcp_order_proposal_tools.py`:
+
+```python
+import uuid
+
+
+@pytest.mark.asyncio
+async def test_create_normalizes_kr_alias_before_storage_and_payload_hash():
+    alias = await opt.order_proposal_create(**_create_kwargs(market="kr"))
+    canonical = await opt.order_proposal_create(**_create_kwargs(market="equity_kr"))
+
+    assert alias["success"] is True
+    assert canonical["success"] is True
+    async with opt.AsyncSessionLocal() as session:
+        service = opt.OrderProposalsService(session)
+        alias_group, _ = await service.get_proposal(uuid.UUID(alias["proposal_id"]))
+        canonical_group, _ = await service.get_proposal(
+            uuid.UUID(canonical["proposal_id"])
+        )
+
+    assert alias_group.market == "equity_kr"
+    assert canonical_group.market == "equity_kr"
+    assert alias_group.payload_hash == canonical_group.payload_hash
+
+
+@pytest.mark.asyncio
+async def test_create_rejects_unknown_market_with_allowed_contract_guidance():
+    result = await opt.order_proposal_create(
+        **_create_kwargs(market="jp", account_mode="toss_live")
+    )
+
+    assert result["success"] is False
+    assert "allowed: kis_live×equity_kr|equity_us" in result["error"]
+    assert "toss_live×equity_kr|equity_us" in result["error"]
+    assert "upbit×crypto" in result["error"]
+    assert "market aliases kr→equity_kr, us→equity_us" in result["error"]
+
+
+def test_create_docstring_documents_markets_aliases_and_account_modes():
+    doc = opt.order_proposal_create.__doc__ or ""
+    for value in (
+        "equity_kr", "equity_us", "crypto", "kr", "us",
+        "kis_live", "toss_live", "upbit",
+    ):
+        assert value in doc
+```
+
+Also extend an unsupported-tuple assertion in
+`tests/services/order_proposals/test_service.py` to require the complete
+allowed-combination and alias suffix for direct service callers.
+
+- [ ] **Step 2: Run the new proposal tests and verify RED**
+
+Run:
+
+```bash
+uv run pytest \
+  tests/test_mcp_order_proposal_tools.py::test_create_normalizes_kr_alias_before_storage_and_payload_hash \
+  tests/test_mcp_order_proposal_tools.py::test_create_rejects_unknown_market_with_allowed_contract_guidance \
+  tests/test_mcp_order_proposal_tools.py::test_create_docstring_documents_markets_aliases_and_account_modes \
+  -q
+```
+
+Expected: alias create is rejected, unknown-market guidance is absent, and the
+docstring lacks market/account documentation.
+
+- [ ] **Step 3: Implement boundary normalization and contract guidance**
+
+In `order_proposal_tools.py` add:
+
+```python
+_MARKET_ALIASES = {"kr": "equity_kr", "us": "equity_us"}
+
+
+def _normalize_order_proposal_market(market: str) -> str:
+    return _MARKET_ALIASES.get(market, market)
+```
+
+At the start of the create tool's `try` block, before rung conversion and
+target preflight:
+
+```python
+market = _normalize_order_proposal_market(market)
+```
+
+Add this `Args:` entry:
+
+```text
+market: Canonical market in {equity_kr, equity_us, crypto}; aliases
+        kr→equity_kr and us→equity_us are accepted. Supported place
+        combinations are kis_live/toss_live with equity_kr or equity_us,
+        and upbit with crypto.
+```
+
+In `service.py` define and use:
+
+```python
+_ALLOWED_ACTION_CONTRACT_MESSAGE = (
+    "allowed: kis_live×equity_kr|equity_us, "
+    "toss_live×equity_kr|equity_us, upbit×crypto; "
+    "market aliases kr→equity_kr, us→equity_us"
+)
+```
+
+```python
+raise OrderProposalError(
+    "unsupported account_mode/market/action: "
+    f"{account_mode}/{market}/{normalized} "
+    f"({_ALLOWED_ACTION_CONTRACT_MESSAGE})"
+)
+```
+
+Update `app/mcp_server/README.md` with canonical markets, aliases, and
+supported place combinations.
+
+- [ ] **Step 4: Run focused proposal tests and verify GREEN**
+
+```bash
+uv run pytest tests/test_mcp_order_proposal_tools.py \
+  tests/services/order_proposals/test_service.py \
+  tests/services/order_proposals/test_payload.py -q \
+  -k "alias or payload_hash or unsupported or docstring"
+```
+
+Expected: all selected tests pass without broker calls.
+
+- [ ] **Step 5: Commit the proposal change**
+
+```bash
+git add tests/test_mcp_order_proposal_tools.py \
+  tests/services/order_proposals/test_service.py \
+  app/mcp_server/tooling/order_proposal_tools.py \
+  app/services/order_proposals/service.py app/mcp_server/README.md
+git commit -m "fix(ROB-855): normalize order proposal market aliases" \
+  -m "Co-Authored-By: Paperclip <noreply@paperclip.ing>"
+```
+
+### Task 2: Expose the retrospective outcome enum
+
+**Files:**
+- Modify: `tests/test_trade_retrospective_tools.py`
+- Modify: `tests/mcp_server/tooling/test_trade_retrospective_registration_docs.py`
+- Modify: `app/services/trade_journal/trade_retrospective_service.py`
+- Modify: `app/mcp_server/tooling/trade_retrospective_tools.py`
+- Modify: `app/mcp_server/tooling/trade_retrospective_registration.py`
+
+**Interfaces:**
+- Consumes: `_VALID_OUTCOMES` and `save_trade_retrospective(..., outcome: str, ...)`.
+- Produces: deterministic invalid-outcome guidance and public documentation containing all five actual outcomes.
+
+- [ ] **Step 1: Write failing outcome-error and documentation tests**
+
+Replace the broad validation assertion and add:
+
+```python
+@pytest.mark.asyncio
+async def test_save_validation_error_enumerates_outcomes():
+    res = await save_trade_retrospective(
+        symbol="005930",
+        instrument_type="equity_kr",
+        account_mode="kis_mock",
+        outcome="win",
+    )
+    assert res["success"] is False
+    for value in (
+        "filled", "partially_filled", "unfilled", "rejected", "cancelled",
+    ):
+        assert value in res["error"]
+
+
+def test_save_docstring_enumerates_outcomes():
+    doc = save_trade_retrospective.__doc__ or ""
+    for value in (
+        "filled", "partially_filled", "unfilled", "rejected", "cancelled",
+    ):
+        assert value in doc
+```
+
+Extend
+`tests/mcp_server/tooling/test_trade_retrospective_registration_docs.py` with
+the same values asserted against the registered description.
+
+- [ ] **Step 2: Run retrospective tests and verify RED**
+
+```bash
+uv run pytest \
+  tests/test_trade_retrospective_tools.py::test_save_validation_error_enumerates_outcomes \
+  tests/test_trade_retrospective_tools.py::test_save_docstring_enumerates_outcomes \
+  tests/mcp_server/tooling/test_trade_retrospective_registration_docs.py -q
+```
+
+Expected: validation error and function docstring tests fail because the outcome
+set is absent.
+
+- [ ] **Step 3: Implement deterministic error and documentation**
+
+In `trade_retrospective_service.py`:
+
+```python
+raise RetrospectiveValidationError(
+    f"invalid outcome: {outcome} (allowed: {', '.join(sorted(_VALID_OUTCOMES))})"
+)
+```
+
+Add this function docstring entry:
+
+```text
+outcome: One of filled, partially_filled, unfilled, rejected, cancelled.
+```
+
+Add the same outcome enumeration to the explicit FastMCP description in
+`trade_retrospective_registration.py`.
+
+- [ ] **Step 4: Run focused retrospective tests and verify GREEN**
+
+```bash
+uv run pytest tests/test_trade_retrospective_tools.py \
+  tests/mcp_server/tooling/test_trade_retrospective_registration_docs.py \
+  -q -k "validation_error or docstring or description"
+```
+
+Expected: all selected tests pass.
+
+- [ ] **Step 5: Commit the retrospective change**
+
+```bash
+git add tests/test_trade_retrospective_tools.py \
+  tests/mcp_server/tooling/test_trade_retrospective_registration_docs.py \
+  app/services/trade_journal/trade_retrospective_service.py \
+  app/mcp_server/tooling/trade_retrospective_tools.py \
+  app/mcp_server/tooling/trade_retrospective_registration.py
+git commit -m "fix(ROB-855): enumerate retrospective outcomes" \
+  -m "Co-Authored-By: Paperclip <noreply@paperclip.ing>"
+```
+
+### Task 3: Verify, review, and ship the single PR
+
+**Files:**
+- Verify only: all modified files from Tasks 1 and 2
+- Must remain unchanged: `app/services/order_proposals/revalidation.py`
+
+**Interfaces:**
+- Consumes: completed Tasks 1 and 2.
+- Produces: a lint-clean, tested branch and one PR based on `main`.
+
+- [ ] **Step 1: Run the required tests**
+
+```bash
+uv run pytest tests/services/order_proposals/ tests/mcp_server/ -q \
+  -k "proposal or retrospective"
+```
+
+Expected: exit code 0, no failures, no live broker calls.
+
+- [ ] **Step 2: Run project lint**
+
+```bash
+make lint
+```
+
+Expected: exit code 0 from Ruff and ty.
+
+- [ ] **Step 3: Audit scope and trailers**
+
+```bash
+git diff origin/main --check
+git diff --name-only origin/main
+git diff origin/main -- app/services/order_proposals/revalidation.py
+git log --format='%h%n%b' origin/main..HEAD
+```
+
+Expected: no whitespace errors; only ROB-855 files changed; `revalidation.py`
+has no diff; every commit has the Paperclip trailer.
+
+- [ ] **Step 4: Review the complete diff**
+
+```bash
+git diff origin/main...HEAD -- app/mcp_server/tooling/order_proposal_tools.py \
+  app/services/order_proposals/service.py \
+  app/services/trade_journal/trade_retrospective_service.py \
+  app/mcp_server/tooling/trade_retrospective_tools.py \
+  app/mcp_server/tooling/trade_retrospective_registration.py \
+  tests/test_mcp_order_proposal_tools.py tests/test_trade_retrospective_tools.py \
+  tests/mcp_server/tooling/test_trade_retrospective_registration_docs.py
+```
+
+Expected: normalization occurs once before preflight/service/hash; canonical
+values are stored; errors/docs enumerate contracts; excluded behavior is
+untouched.
+
+- [ ] **Step 5: Push and create the PR**
+
+Use the `ship` skill. Push `fix/ROB-855-order-proposal-market-dx` and create
+one PR against `main` titled
+`fix(ROB-855): improve order proposal market DX`. The body summarizes the
+2026-07-13 false diagnosis (`kr` rejected, operators misdiagnosed account
+mode/deployment after three retries, first KR execution produced zero orders),
+lists tests, enumerates normalization callsites, and states no migration is
+required because existing valid rows are canonical.
+

--- a/docs/superpowers/specs/2026-07-13-rob-855-order-proposal-market-dx-design.md
+++ b/docs/superpowers/specs/2026-07-13-rob-855-order-proposal-market-dx-design.md
@@ -1,0 +1,99 @@
+# ROB-855 Order Proposal Market DX Design
+
+## Goal
+
+Make `order_proposal_create` accept the operator-facing market aliases used by
+the rest of the MCP surface while preserving canonical order-proposal storage,
+hashing, validation, and responses. Improve validation guidance for proposal
+contracts and trade-retrospective outcomes.
+
+## Scope
+
+- Accept `kr`, `us`, and `crypto` at the `order_proposal_create` MCP boundary.
+- Normalize them to `equity_kr`, `equity_us`, and `crypto`, respectively.
+- Pass only the normalized value to target-order preflight and
+  `OrderProposalsService.create_proposal`.
+- Keep the service contract and persisted order-proposal market values
+  canonical.
+- Enumerate supported account-mode/market combinations and market aliases in
+  proposal contract errors.
+- Document the create tool's market values and account-mode combinations.
+- Enumerate all actual retrospective outcomes in validation errors and the
+  `save_trade_retrospective` docstring.
+- Do not modify `app/services/order_proposals/revalidation.py`, including the
+  Toss submit path.
+- Do not change `no_resolvable_forecast` auto-close behavior.
+
+`order_proposal_get` accepts only a proposal ID and `order_proposal_list`
+currently filters only by symbol and lifecycle state. Neither has a market
+filter to normalize, so this change does not add a new public parameter.
+
+## Architecture and Data Flow
+
+Add one focused market-normalization helper in
+`app/mcp_server/tooling/order_proposal_tools.py`. Call it at the start of
+`order_proposal_create`, before replace/cancel target-order preflight and before
+opening the service session.
+
+The resulting flow is:
+
+1. MCP receives `kr`, `us`, `crypto`, or a canonical market string.
+2. The tool normalizes `kr` to `equity_kr` and `us` to `equity_us`; other
+   strings pass through unchanged so the service remains the source of truth
+   for contract rejection.
+3. Target-order preflight, when applicable, receives the canonical market.
+4. `OrderProposalsService.create_proposal` validates the canonical tuple.
+5. The service computes `payload_hash` from the canonical market.
+6. The repository stores the canonical market, and read responses serialize
+   that stored value.
+
+Keeping normalization at this single boundary ensures alias and canonical
+inputs produce identical persisted payload hashes without changing the generic
+hash function's contract.
+
+## Validation and Documentation
+
+Proposal contract rejection will retain the rejected tuple and append:
+
+`allowed: kis_live×equity_kr|equity_us, toss_live×equity_kr|equity_us, upbit×crypto; market aliases kr→equity_kr, us→equity_us`
+
+The `order_proposal_create` docstring will describe:
+
+- canonical markets: `equity_kr`, `equity_us`, `crypto`;
+- aliases: `kr`, `us`;
+- supported place combinations: KIS live and Toss live with either equity
+  market, and Upbit with crypto.
+
+The retrospective service's actual outcome set is `filled`,
+`partially_filled`, `unfilled`, `rejected`, and `cancelled`. Invalid-outcome
+errors and the `save_trade_retrospective` docstring will enumerate all five.
+
+## Persistence and Migration
+
+No migration is required. The order-proposal table's market check constraint
+does not admit `kr` or `us`, and the existing service submit-contract allowlist
+admits order proposals only under canonical `equity_kr`, `equity_us`, or
+`crypto` values. Existing valid rows therefore remain canonical; aliases are
+accepted only transiently at the MCP boundary.
+
+## Tests
+
+Use TDD and add regression coverage proving:
+
+1. `market="kr"` creates successfully and the fetched persisted proposal has
+   `market="equity_kr"`.
+2. `market="jp"` is rejected with the allowed combinations and alias guidance.
+3. Equivalent alias and canonical create inputs persist the same
+   `payload_hash`.
+4. An invalid retrospective outcome error includes every actual outcome value.
+5. Tool documentation exposes the market/account combinations and retrospective
+   outcomes.
+
+Run the focused red/green tests during implementation, then run:
+
+```bash
+uv run pytest tests/services/order_proposals/ tests/mcp_server/ -q -k "proposal or retrospective"
+make lint
+```
+
+No test may make a real broker call.

--- a/tests/mcp_server/tooling/test_trade_retrospective_registration_docs.py
+++ b/tests/mcp_server/tooling/test_trade_retrospective_registration_docs.py
@@ -50,3 +50,15 @@ def test_description_states_next_actions_required_with_trigger_type():
     assert "next_actions" in desc
     assert "trigger_type" in desc
     assert "required" in desc
+
+
+def test_description_enumerates_outcome_values():
+    desc = _register()
+    for value in (
+        "filled",
+        "partially_filled",
+        "unfilled",
+        "rejected",
+        "cancelled",
+    ):
+        assert value in desc, f"outcome value {value!r} missing from description"

--- a/tests/services/order_proposals/test_service.py
+++ b/tests/services/order_proposals/test_service.py
@@ -1318,9 +1318,7 @@ async def test_create_proposal_allows_upbit_crypto(db_session):
 @pytest.mark.asyncio
 async def test_create_proposal_rejects_kis_mock_equity_kr(db_session):
     service = OrderProposalsService(db_session)
-    with pytest.raises(
-        OrderProposalError, match="unsupported account_mode/market/action"
-    ):
+    with pytest.raises(OrderProposalError) as exc_info:
         await service.create_proposal(
             symbol="A",
             market="equity_kr",
@@ -1330,6 +1328,12 @@ async def test_create_proposal_rejects_kis_mock_equity_kr(db_session):
             proposer="p",
             rungs=[RungInput(0, "buy", Decimal("1"), Decimal("100"), None)],
         )
+    assert str(exc_info.value) == (
+        "unsupported account_mode/market/action: kis_mock/equity_kr/place "
+        "(allowed: kis_live×equity_kr|equity_us, "
+        "toss_live×equity_kr|equity_us, upbit×crypto; "
+        "market aliases kr→equity_kr, us→equity_us)"
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_mcp_order_proposal_tools.py
+++ b/tests/test_mcp_order_proposal_tools.py
@@ -142,9 +142,17 @@ async def test_place_create_never_fetches_a_target(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_create_normalizes_kr_alias_before_storage_and_payload_hash():
-    alias = await opt.order_proposal_create(**_create_kwargs(market="kr"))
-    canonical = await opt.order_proposal_create(**_create_kwargs(market="equity_kr"))
+@pytest.mark.parametrize(
+    ("market_alias", "canonical_market"),
+    [("kr", "equity_kr"), ("us", "equity_us")],
+)
+async def test_create_normalizes_market_alias_before_storage_and_payload_hash(
+    market_alias, canonical_market
+):
+    alias = await opt.order_proposal_create(**_create_kwargs(market=market_alias))
+    canonical = await opt.order_proposal_create(
+        **_create_kwargs(market=canonical_market)
+    )
 
     assert alias["success"] is True
     assert canonical["success"] is True
@@ -156,9 +164,9 @@ async def test_create_normalizes_kr_alias_before_storage_and_payload_hash():
             uuid.UUID(canonical["proposal_id"])
         )
 
-    assert got["proposal"]["market"] == "equity_kr"
-    assert alias_group.market == "equity_kr"
-    assert canonical_group.market == "equity_kr"
+    assert got["proposal"]["market"] == canonical_market
+    assert alias_group.market == canonical_market
+    assert canonical_group.market == canonical_market
     assert alias_group.payload_hash == canonical_group.payload_hash
 
 

--- a/tests/test_mcp_order_proposal_tools.py
+++ b/tests/test_mcp_order_proposal_tools.py
@@ -1,3 +1,4 @@
+import uuid
 from datetime import UTC, datetime
 from types import SimpleNamespace
 
@@ -138,6 +139,53 @@ async def test_place_create_never_fetches_a_target(monkeypatch):
     assert result["success"] is True
     assert result["action"] == "place"
     assert result["target_broker_order_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_create_normalizes_kr_alias_before_storage_and_payload_hash():
+    alias = await opt.order_proposal_create(**_create_kwargs(market="kr"))
+    canonical = await opt.order_proposal_create(**_create_kwargs(market="equity_kr"))
+
+    assert alias["success"] is True
+    assert canonical["success"] is True
+    async with opt.AsyncSessionLocal() as session:
+        service = opt.OrderProposalsService(session)
+        alias_group, _ = await service.get_proposal(uuid.UUID(alias["proposal_id"]))
+        canonical_group, _ = await service.get_proposal(
+            uuid.UUID(canonical["proposal_id"])
+        )
+
+    assert alias_group.market == "equity_kr"
+    assert canonical_group.market == "equity_kr"
+    assert alias_group.payload_hash == canonical_group.payload_hash
+
+
+@pytest.mark.asyncio
+async def test_create_rejects_unknown_market_with_allowed_contract_guidance():
+    result = await opt.order_proposal_create(
+        **_create_kwargs(market="jp", account_mode="toss_live")
+    )
+
+    assert result["success"] is False
+    assert "allowed: kis_live×equity_kr|equity_us" in result["error"]
+    assert "toss_live×equity_kr|equity_us" in result["error"]
+    assert "upbit×crypto" in result["error"]
+    assert "market aliases kr→equity_kr, us→equity_us" in result["error"]
+
+
+def test_create_docstring_documents_markets_aliases_and_account_modes():
+    doc = opt.order_proposal_create.__doc__ or ""
+    for value in (
+        "equity_kr",
+        "equity_us",
+        "crypto",
+        "kr",
+        "us",
+        "kis_live",
+        "toss_live",
+        "upbit",
+    ):
+        assert value in doc
 
 
 @pytest.mark.asyncio

--- a/tests/test_mcp_order_proposal_tools.py
+++ b/tests/test_mcp_order_proposal_tools.py
@@ -148,6 +148,7 @@ async def test_create_normalizes_kr_alias_before_storage_and_payload_hash():
 
     assert alias["success"] is True
     assert canonical["success"] is True
+    got = await opt.order_proposal_get(alias["proposal_id"])
     async with opt.AsyncSessionLocal() as session:
         service = opt.OrderProposalsService(session)
         alias_group, _ = await service.get_proposal(uuid.UUID(alias["proposal_id"]))
@@ -155,6 +156,7 @@ async def test_create_normalizes_kr_alias_before_storage_and_payload_hash():
             uuid.UUID(canonical["proposal_id"])
         )
 
+    assert got["proposal"]["market"] == "equity_kr"
     assert alias_group.market == "equity_kr"
     assert canonical_group.market == "equity_kr"
     assert alias_group.payload_hash == canonical_group.payload_hash

--- a/tests/test_trade_retrospective_tools.py
+++ b/tests/test_trade_retrospective_tools.py
@@ -50,15 +50,34 @@ async def test_save_success_envelope():
 
 
 @pytest.mark.asyncio
-async def test_save_validation_error_envelope():
+async def test_save_validation_error_enumerates_outcomes():
     res = await save_trade_retrospective(
         symbol="005930",
         instrument_type="equity_kr",
         account_mode="kis_mock",
-        outcome="bogus",
+        outcome="win",
     )
     assert res["success"] is False
-    assert "outcome" in res["error"]
+    for value in (
+        "filled",
+        "partially_filled",
+        "unfilled",
+        "rejected",
+        "cancelled",
+    ):
+        assert value in res["error"]
+
+
+def test_save_docstring_enumerates_outcomes():
+    doc = save_trade_retrospective.__doc__ or ""
+    for value in (
+        "filled",
+        "partially_filled",
+        "unfilled",
+        "rejected",
+        "cancelled",
+    ):
+        assert value in doc
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Accept `kr` and `us` aliases at the `order_proposal_create` MCP boundary and normalize them to `equity_kr` and `equity_us` before target-order preflight, service validation, payload hashing, and persistence.
- Keep proposal storage and read responses canonical, with alias and canonical inputs producing the same `payload_hash`.
- Expand unsupported account/market/action errors with every supported tuple and the market alias mapping.
- Document order-proposal market/account combinations and expose all actual `save_trade_retrospective` outcomes in its error, docstring, and MCP registration description.

## 2026-07-13 false-diagnosis scenario

The KR operator session followed the repository-wide `market="kr"` convention, but `order_proposal_create` expected `equity_kr`. The resulting `unsupported account_mode/market/action: toss_live/kr/place` error looked like an account-mode failure. The session retried with Toss variants three times, produced zero first-pass KR executions, and was then misdiagnosed as an undeployed change. This PR removes that contract gap at the MCP boundary and makes future rejection messages actionable.

## Normalization callsites

- `order_proposal_create` calls `_normalize_order_proposal_market` once on entry.
- Replace/cancel `fetch_target_order(..., market=market)` receives the canonical value.
- `OrderProposalsService.create_proposal(..., market=market)` receives the canonical value.
- Service contract validation, loss-cut binding, `compute_proposal_payload_hash`, and repository insertion therefore operate on the canonical value.
- `order_proposal_get` and `order_proposal_list` serialize the canonical stored market through `_group_dict`.
- Neither read tool currently has a market filter parameter, so no filter normalization callsite was added.

## Migration

No migration is required. The order-proposal table constraint does not admit the `kr` or `us` aliases, and the existing sole writer service accepts supported proposals only with canonical `equity_kr`, `equity_us`, or `crypto` markets. Existing valid rows remain canonical.

## Test coverage

All changed behavior paths are covered:

- `kr→equity_kr` and `us→equity_us`
- canonical response and persisted market
- alias/canonical payload-hash equality
- unsupported-market allowed-combination guidance
- retrospective invalid-outcome enumeration
- function docstrings and MCP registration descriptions

## Verification

- `uv run pytest tests/services/order_proposals/ tests/mcp_server/ -q -k "proposal or retrospective"` — 291 passed, 498 deselected
- `uv run pytest tests/test_mcp_order_proposal_tools.py tests/test_trade_retrospective_tools.py tests/mcp_server/tooling/test_trade_retrospective_registration_docs.py -q` — 35 passed
- `make lint` — Ruff check, Ruff format check, and ty all passed
- Pre-landing review — no unresolved findings
- Scope check — clean; `app/services/order_proposals/revalidation.py` is unchanged

## Plan completion

- [x] Alias normalization occurs before all proposal preflight/service/hash/storage paths.
- [x] Canonical storage, read responses, and hash equality are tested.
- [x] Proposal errors and docs enumerate supported contracts.
- [x] Retrospective errors and docs enumerate the actual outcome set.
- [x] Required tests and lint pass.
- [x] No migration, broker call, revalidation change, or auto-close scope expansion.

