### PR TITLE
fix(ROB-857): converge Toss typed 4xx submits to rejected

### DIFF
--- a/app/services/order_proposals/revalidation.py
+++ b/app/services/order_proposals/revalidation.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import hashlib
 import inspect
+import re
 import uuid
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -82,6 +83,8 @@ _GUARD_ERROR_MARKERS = (
     "stop-loss cooldown",
     "opposite pending order",
 )
+_TOSS_CLIENT_ORDER_ID_MAX_LENGTH = 36
+_TOSS_CLIENT_ORDER_ID_PATTERN = re.compile(r"[a-zA-Z0-9\-_]+")
 
 
 async def _maybe_await(value: Any) -> Any:
@@ -138,8 +141,16 @@ def _toss_decimal_arg(value: Decimal | None) -> str | int | None:
 
 def _toss_proposal_client_order_id(proposal_id: uuid.UUID, rung_index: int) -> str:
     """Return a proposal/rung-stable, Toss-safe private idempotency key."""
-    digest = hashlib.sha256(f"{proposal_id}:{rung_index}".encode()).hexdigest()[:32]
+    digest = hashlib.sha256(f"{proposal_id}:{rung_index}".encode()).hexdigest()[:24]
     return f"tosprop-{digest}"
+
+
+def _is_valid_toss_client_order_id(value: Any) -> bool:
+    return (
+        isinstance(value, str)
+        and len(value) <= _TOSS_CLIENT_ORDER_ID_MAX_LENGTH
+        and _TOSS_CLIENT_ORDER_ID_PATTERN.fullmatch(value) is not None
+    )
 
 
 def _proposal_client_order_id(proposal_id: uuid.UUID, rung_index: int) -> str:
@@ -298,6 +309,16 @@ async def _default_place_order_fn(**kwargs: Any) -> dict[str, Any]:
             return _adapt_toss_preview_response(preview)
 
         approval_hash = kwargs.get("approval_hash")
+        if not _is_valid_toss_client_order_id(proposal_client_order_id):
+            return {
+                "success": False,
+                "mutation_sent": False,
+                "error_code": "invalid_toss_client_order_id",
+                "error": (
+                    "Toss clientOrderId must be at most 36 characters and match "
+                    "[a-zA-Z0-9\\-_]+"
+                ),
+            }
         with _bind_order_proposal_context(
             client_order_id=str(proposal_client_order_id),
             correlation_id=kwargs.get("correlation_id"),

--- a/app/services/order_proposals/revalidation.py
+++ b/app/services/order_proposals/revalidation.py
@@ -85,6 +85,7 @@ _GUARD_ERROR_MARKERS = (
 )
 _TOSS_CLIENT_ORDER_ID_MAX_LENGTH = 36
 _TOSS_CLIENT_ORDER_ID_PATTERN = re.compile(r"[a-zA-Z0-9\-_]+")
+_SUBMIT_DIAGNOSTIC_MAX_LENGTH = 240
 
 
 async def _maybe_await(value: Any) -> Any:
@@ -158,6 +159,23 @@ def _proposal_client_order_id(proposal_id: uuid.UUID, rung_index: int) -> str:
     return f"oprop-{digest}"
 
 
+def _truncate_submit_diagnostic(value: object) -> str:
+    compact = " ".join(str(value).split())
+    if len(compact) > _SUBMIT_DIAGNOSTIC_MAX_LENGTH:
+        return compact[: _SUBMIT_DIAGNOSTIC_MAX_LENGTH - 1] + "…"
+    return compact
+
+
+def _toss_submit_error_summary(submit: dict[str, Any]) -> str | None:
+    code = str(submit.get("code") or "").strip()
+    if not code:
+        return None
+    message = str(submit.get("message") or "").strip()
+    return _truncate_submit_diagnostic(
+        f"Toss {code}: {message}" if message else f"Toss {code}"
+    )
+
+
 def _adapt_toss_preview_response(preview: dict[str, Any]) -> dict[str, Any]:
     """Expose Toss's normalized wire payload through the proposal contract."""
     payload = preview.get("payload_preview")
@@ -200,28 +218,39 @@ def _adapt_toss_submit_response(
     submit: dict[str, Any], *, order_type: str
 ) -> dict[str, Any]:
     """Translate Toss accepted-only sends to the proposal submit contract."""
+    adapted = dict(submit)
+    diagnostic = _toss_submit_error_summary(submit)
+    if diagnostic is not None:
+        adapted["error"] = diagnostic
+
     if submit.get("success") is False and submit.get("mutation_sent") is True:
-        if submit.get("broker_status") != "rejected":
-            adapted = dict(submit)
+        status_code = submit.get("status_code")
+        typed_client_rejection = (
+            isinstance(status_code, int)
+            and 400 <= status_code < 500
+            and status_code != 429
+            and bool(str(submit.get("code") or "").strip())
+        )
+        if typed_client_rejection:
+            adapted["broker_status"] = "rejected"
+        elif submit.get("broker_status") != "rejected":
             adapted["success"] = None
             return adapted
-    if submit.get("success") is False or submit.get("broker_status") == "rejected":
-        adapted = dict(submit)
+    if adapted.get("success") is False or adapted.get("broker_status") == "rejected":
         adapted["success"] = False
         adapted["error"] = (
-            submit.get("error")
-            or submit.get("response_message")
-            or submit.get("message")
+            adapted.get("error")
+            or adapted.get("response_message")
+            or adapted.get("message")
             or "toss_order_rejected"
         )
         return adapted
     if (
-        submit.get("success") is not True
-        or submit.get("order_id") is None
-        or submit.get("approval_hash_digest") is None
+        adapted.get("success") is not True
+        or adapted.get("order_id") is None
+        or adapted.get("approval_hash_digest") is None
     ):
-        return submit
-    adapted = dict(submit)
+        return adapted
     adapted["status"] = "acked" if order_type == "market" else "resting"
     adapted["broker_order_id"] = submit.get("order_id")
     adapted["idempotency_key"] = submit.get("client_order_id")
@@ -1123,10 +1152,13 @@ async def _classify_submit(
     # success is True but unrecognized status/missing broker_order_id, or
     # success is missing entirely (neither True nor False) — ambiguous.
     # Never auto-void on ambiguity (Principle #4).
+    ambiguous_diagnostic = _truncate_submit_diagnostic(
+        submit.get("error") or f"status={submit.get('status')!r}"
+    )
     await service.record_unverified(
         proposal_id,
         rung_index,
-        reason=f"ambiguous_submit_response:status={submit.get('status')!r}",
+        reason=f"ambiguous_submit_response:{ambiguous_diagnostic}",
         now=now,
         correlation_id=corr,
         idempotency_key=(

--- a/tests/services/order_proposals/test_revalidation.py
+++ b/tests/services/order_proposals/test_revalidation.py
@@ -1,3 +1,4 @@
+import re
 import uuid
 from datetime import UTC, datetime
 from decimal import Decimal
@@ -966,12 +967,50 @@ def test_toss_decimal_args_are_exact_and_canonical():
 def test_toss_proposal_client_ids_are_stable_and_rung_scoped():
     from app.services.order_proposals import revalidation as mod
 
+    # Toss OpenAPI OrderCreateRequest.clientOrderId (openapi.json).
+    toss_client_order_id_max_length = 36
     proposal_id = uuid.UUID("12345678-1234-5678-1234-567812345678")
     same = mod._toss_proposal_client_order_id(proposal_id, 0)
     assert same == mod._toss_proposal_client_order_id(proposal_id, 0)
     assert same != mod._toss_proposal_client_order_id(proposal_id, 1)
     assert same != mod._toss_proposal_client_order_id(uuid.uuid4(), 0)
     assert same.startswith("tosprop-")
+    assert len(same) <= toss_client_order_id_max_length
+    assert re.fullmatch(r"[a-zA-Z0-9\-_]+", same)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "invalid_client_order_id",
+    ["x" * 37, "invalid@client-order-id"],
+)
+async def test_toss_submit_rejects_invalid_client_order_id_before_broker_call(
+    monkeypatch, invalid_client_order_id
+):
+    import app.mcp_server.tooling.orders_toss_variants as toss
+    from app.services.order_proposals import revalidation as mod
+
+    async def forbidden_broker_call(**kwargs):
+        pytest.fail(f"broker POST must not be called: {kwargs}")
+
+    monkeypatch.setattr(toss, "toss_place_order", forbidden_broker_call)
+
+    result = await mod._default_place_order_fn(
+        dry_run=False,
+        account_mode="toss_live",
+        symbol="000660",
+        side="buy",
+        market="equity_kr",
+        order_type="limit",
+        quantity=Decimal("1"),
+        price=Decimal("222600"),
+        proposal_client_order_id=invalid_client_order_id,
+        approval_hash="preview-token",
+    )
+
+    assert result["success"] is False
+    assert result["mutation_sent"] is False
+    assert result["error_code"] == "invalid_toss_client_order_id"
 
 
 def test_upbit_proposal_client_ids_are_stable_and_rung_scoped():

--- a/tests/services/order_proposals/test_revalidation.py
+++ b/tests/services/order_proposals/test_revalidation.py
@@ -2211,8 +2211,69 @@ async def test_toss_explicit_rejection_records_rejected(db_session, monkeypatch)
 
 
 @pytest.mark.asyncio
+async def test_toss_typed_400_rejection_converges_with_broker_diagnostics(
+    db_session, monkeypatch
+):
+    from app.services.order_proposals.telegram_callback import _build_result_summary
+
+    svc = OrderProposalsService(db_session)
+    group = await svc.create_proposal(
+        symbol="000660",
+        market="equity_kr",
+        account_mode="toss_live",
+        side="buy",
+        order_type="limit",
+        proposer="p",
+        rungs=[RungInput(0, "buy", Decimal("1"), Decimal("50000"), None)],
+    )
+    await db_session.commit()
+
+    async def fake_preview(**kwargs):
+        client_order_id = _bound_toss_context().client_order_id
+        return {
+            "success": True,
+            "approval_hash": "reject-token",
+            "payload_preview": {
+                "price": "50000",
+                "quantity": "1",
+                "clientOrderId": client_order_id,
+            },
+        }
+
+    async def fake_submit(**kwargs):
+        return {
+            "success": False,
+            "mutation_sent": True,
+            "status_code": 400,
+            "code": "invalid-client-order-id",
+            "message": "clientOrderId must be at most 36 characters " + ("x" * 400),
+            "error": "Toss API error status=400",
+        }
+
+    import app.mcp_server.tooling.orders_toss_variants as toss
+
+    monkeypatch.setattr(toss, "toss_preview_order", fake_preview)
+    monkeypatch.setattr(toss, "toss_place_order", fake_submit)
+    outcomes = await revalidate_and_submit(
+        service=svc,
+        proposal_id=group.proposal_id,
+        now=datetime.now(UTC),
+    )
+
+    assert outcomes[0].result == "error"
+    assert "invalid-client-order-id" in outcomes[0].detail["error"]
+    assert "clientOrderId must be at most 36 characters" in outcomes[0].detail["error"]
+    assert len(outcomes[0].detail["error"]) <= 240
+    _, rungs = await svc.get_proposal(group.proposal_id)
+    assert rungs[0].state == "rejected"
+    assert "invalid-client-order-id" in rungs[0].void_reason
+    assert "clientOrderId must be at most 36 characters" in rungs[0].void_reason
+    assert "invalid-client-order-id" in _build_result_summary(outcomes)
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ("submit_result", "expected_order_id"),
+    ("submit_result", "expected_order_id", "reason_fragments"),
     [
         (
             {
@@ -2221,6 +2282,19 @@ async def test_toss_explicit_rejection_records_rejected(db_session, monkeypatch)
                 "error": "broker timeout; order state unknown",
             },
             None,
+            ("broker timeout",),
+        ),
+        (
+            {
+                "success": False,
+                "mutation_sent": True,
+                "status_code": 500,
+                "code": "internal-error",
+                "message": "temporary upstream failure",
+                "error": "Toss API error status=500",
+            },
+            None,
+            ("internal-error", "temporary upstream failure"),
         ),
         (
             {
@@ -2231,12 +2305,13 @@ async def test_toss_explicit_rejection_records_rejected(db_session, monkeypatch)
                 "client_order_id": "ambiguous-client",
             },
             "preserved-broker-order",
+            ("ledger write failed",),
         ),
     ],
-    ids=["timeout_unknown", "ledger_failure_preserves_order_id"],
+    ids=["timeout_unknown", "server_500_unknown", "ledger_failure_preserves_order_id"],
 )
 async def test_toss_post_send_failure_records_unverified(
-    db_session, monkeypatch, submit_result, expected_order_id
+    db_session, monkeypatch, submit_result, expected_order_id, reason_fragments
 ):
     svc = OrderProposalsService(db_session)
     group = await svc.create_proposal(
@@ -2276,12 +2351,14 @@ async def test_toss_post_send_failure_records_unverified(
     )
 
     assert outcomes[0].result == "unverified"
-    assert outcomes[0].detail["submit"]["error"] == submit_result["error"]
+    assert outcomes[0].detail["submit"]["error"]
     assert outcomes[0].detail["submit"].get("order_id") == expected_order_id
     _, rungs = await svc.get_proposal(group.proposal_id)
     assert rungs[0].state == "unverified"
     assert rungs[0].state != "pending_approval"
     assert rungs[0].void_reason.startswith("ambiguous_submit_response:")
+    for fragment in reason_fragments:
+        assert fragment in rungs[0].void_reason
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Classify Toss typed non-retryable 4xx submit envelopes (excluding 429) with an error code as broker_status=rejected.
- Preserve a whitespace-normalized, 240-character Toss code/message diagnostic in rejected and unverified void_reason records.
- Keep timeout/network, 5xx, and other ambiguous post-send outcomes unverified; no evidence-free auto-void.
- Surface the preserved Toss error code in the Telegram approval-result edit.

## Safety boundary

Only a typed Toss 4xx envelope with status_code, a non-empty code, and mutation_sent=true is treated as broker evidence that the order was not accepted. Timeout/network failures, 5xx responses, 429 responses, and ledger failures remain unverified under the ROB-816 no-auto-void principle.

## Tests

- Typed HTTP 400 envelope converges the rung to rejected and preserves truncated code/message in void_reason and Telegram output.
- Timeout-shaped post-send failure remains unverified.
- Typed HTTP 500 envelope remains unverified and preserves code/message.

## Verification

- uv run pytest tests/services/order_proposals/ -x -q: 287 passed
- make lint: Ruff, format check, and ty passed

## PR replacement

Replaces #1511, which GitHub automatically closed when the merged PR1 base branch was deleted. The same ROB-857 head was updated with origin/main using a regular merge; the diff against main contains only the two intended order-proposal files.

Linear: https://linear.app/mgh3326/issue/ROB-857

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of order submission errors, including clearer diagnostics for invalid requests and upstream failures.
  * Typed client rejections now consistently appear as errors and are recorded with the correct rejected state.
  * Long error messages are safely shortened while preserving key details.
  * Ambiguous post-submission failures continue to be marked as unverified, with more useful reason information retained.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->