### PR TITLE
fix(ROB-859): auto-close no-claim forecasts without scoring

### DIFF
--- a/alembic/versions/20260713_rob859_forecast_no_claim_status.py
+++ b/alembic/versions/20260713_rob859_forecast_no_claim_status.py
@@ -1,0 +1,52 @@
+"""ROB-859 add an unscored terminal status for no-claim forecasts.
+
+Revision ID: 20260713_rob859_no_claim
+Revises: 20260712_rob846_experiments
+Create Date: 2026-07-13
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "20260713_rob859_no_claim"
+down_revision: str | Sequence[str] | None = "20260712_rob846_experiments"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.drop_constraint(
+        "ck_trade_forecasts_status",
+        "trade_forecasts",
+        schema="review",
+        type_="check",
+    )
+    op.create_check_constraint(
+        "ck_trade_forecasts_status",
+        "trade_forecasts",
+        "status IN ('open','closed','closed_no_claim')",
+        schema="review",
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        "UPDATE review.trade_forecasts "
+        "SET status = 'closed' "
+        "WHERE status = 'closed_no_claim'"
+    )
+    op.drop_constraint(
+        "ck_trade_forecasts_status",
+        "trade_forecasts",
+        schema="review",
+        type_="check",
+    )
+    op.create_check_constraint(
+        "ck_trade_forecasts_status",
+        "trade_forecasts",
+        "status IN ('open','closed')",
+        schema="review",
+    )

--- a/app/mcp_server/README.md
+++ b/app/mcp_server/README.md
@@ -2060,6 +2060,15 @@ Forbidden by physical non-registration:
 
 Authentication is mandatory for this profile. `MCP_PROFILE=tradingcodex_execution` fails at startup unless `MCP_AUTH_TOKEN` is non-empty, and the runtime also requires the TradingCodex approval-hash modes configured in `app/mcp_server/main.py`.
 
+### Forecast resolution semantics
+
+`forecast_resolve` auto-closes a due placeholder whose
+`forecast_target.kind` is `no_resolvable_forecast`. A dry run reports
+`would_close_no_claim`; a persisted run assigns `closed_no_claim`. These rows
+keep `outcome` and `brier_score` null and are excluded from calibration
+aggregates. Other non-price forecast kinds continue to require an explicit
+manual outcome and evidence.
+
 ### Typed KIS order tools
 
 The `default` and `hermes-paper-kis` profiles provide explicitly-named KIS

--- a/app/mcp_server/tooling/forecast_registration.py
+++ b/app/mcp_server/tooling/forecast_registration.py
@@ -49,6 +49,10 @@ def register_forecast_tools(mcp: Any) -> None:
             "without it, resolves every open forecast whose review_date has "
             "passed (up to limit). price_target forecasts resolve against loaded "
             "daily OHLCV (ROB-639 DB-first, equity_kr/equity_us/crypto). "
+            "Placeholder forecasts whose target kind is "
+            "'no_resolvable_forecast' auto-close without an outcome or Brier "
+            "score (dry-run reports 'would_close_no_claim'; persisted status is "
+            "'closed_no_claim'). "
             "Non-price kinds (or price forecasts you must override) require an "
             "explicit forecast_id plus manual_outcome (bool) and manual_evidence. "
             "Idempotent: a closed forecast is never re-scored. "
@@ -60,7 +64,7 @@ def register_forecast_tools(mcp: Any) -> None:
     _ = mcp.tool(
         name="get_forecasts",
         description=(
-            "List forecasts with filters (status open/closed, symbol, "
+            "List forecasts with filters (status open/closed/closed_no_claim, symbol, "
             "created_by, correlation_id). Read-only."
         ),
     )(get_forecasts)

--- a/app/mcp_server/tooling/forecast_tools.py
+++ b/app/mcp_server/tooling/forecast_tools.py
@@ -146,6 +146,7 @@ async def forecast_resolve(
                         "symbol": row.symbol,
                         "status": r["status"],
                         "changed": bool(r.get("changed")),
+                        "auto_close": bool(r.get("auto_close")),
                         "computed": r.get("computed"),
                         "reason": r.get("reason"),
                     }

--- a/app/models/review.py
+++ b/app/models/review.py
@@ -1174,7 +1174,7 @@ class TradeForecast(Base):
     __table_args__ = (
         UniqueConstraint("forecast_id", name="uq_trade_forecasts_forecast_id"),
         CheckConstraint(
-            "status IN ('open','closed')",
+            "status IN ('open','closed','closed_no_claim')",
             name="ck_trade_forecasts_status",
         ),
         CheckConstraint(

--- a/app/services/trade_journal/forecast_service.py
+++ b/app/services/trade_journal/forecast_service.py
@@ -81,6 +81,8 @@ _VALID_INSTRUMENTS = {t.value for t in InstrumentType}
 _AUTO_RESOLVABLE_INSTRUMENTS = {"equity_kr", "equity_us", "crypto"}
 _PRICE_DIRECTIONS = {"at_or_above", "at_or_below"}
 _GROUP_BY_FIELDS = {"created_by", "session_label", "model_label", "day"}
+_NO_RESOLVABLE_FORECAST_KIND = "no_resolvable_forecast"
+_CLOSED_NO_CLAIM_STATUS = "closed_no_claim"
 
 
 class ForecastValidationError(ValueError):
@@ -259,7 +261,7 @@ class ForecastRepository:
         if fid is not None:
             existing = await self.get_by_forecast_id(fid)
             if existing is not None:
-                if existing.status == "closed":
+                if existing.status != "open":
                     raise ForecastValidationError(
                         f"cannot modify a closed (resolved) forecast; forecast_id={fid}"
                     )
@@ -654,7 +656,7 @@ async def resolve_forecast(
     row = await repo.get_by_forecast_id(_coerce_forecast_id(forecast_id))
     if row is None:
         raise ForecastValidationError(f"forecast not found: {forecast_id}")
-    if row.status == "closed":
+    if row.status != "open":
         return {
             "status": "already_closed",
             "changed": False,
@@ -669,6 +671,36 @@ async def resolve_forecast(
         if hasattr(row.instrument_type, "value")
         else str(row.instrument_type)
     )
+
+    if kind == _NO_RESOLVABLE_FORECAST_KIND:
+        reason = "placeholder has no resolvable claim"
+        if not persist:
+            return {
+                "status": "would_close_no_claim",
+                "changed": False,
+                "auto_close": True,
+                "computed": None,
+                "reason": reason,
+                "forecast": serialize_forecast(row),
+            }
+
+        row.resolution_source = "not_applicable"
+        row.resolution_detail = {
+            "resolved_kind": kind,
+            "reason": reason,
+        }
+        row.resolved_at = resolved_now
+        row.status = _CLOSED_NO_CLAIM_STATUS
+        await db.flush()
+        await db.refresh(row)
+        return {
+            "status": _CLOSED_NO_CLAIM_STATUS,
+            "changed": True,
+            "auto_close": True,
+            "computed": None,
+            "reason": reason,
+            "forecast": serialize_forecast(row),
+        }
 
     if manual_outcome is not None:
         if not manual_evidence:

--- a/tests/_schema_bootstrap.py
+++ b/tests/_schema_bootstrap.py
@@ -26,7 +26,8 @@ from sqlalchemy import text
 # append-only immutability triggers are non-ORM DDL and are mirrored below.
 # v7 (ROB-846 review): trigger now blocks legacy->trial UPDATE conversion, plus
 # trial all-or-none + promotion identity-complete CHECK constraints (NOT VALID).
-SCHEMA_BOOTSTRAP_VERSION = 7
+# v8 (ROB-859): trade_forecasts accepts the unscored closed_no_claim status.
+SCHEMA_BOOTSTRAP_VERSION = 8
 
 # ---- constraints + enums (moved verbatim from conftest.py) ----
 MARKET_VALUATION_SOURCE_CHECK_NAME = "ck_market_valuation_snapshots_source"
@@ -58,6 +59,14 @@ SNAPSHOT_KIND_VALUES = (
     "kr_market_ranking",
     "investor_flow",
 )
+
+TRADE_FORECAST_STATUS_CHECK_NAME = "ck_trade_forecasts_status"
+TRADE_FORECAST_STATUS_MODEL_CHECK_NAME = "ck_trade_forecasts_ck_trade_forecasts_status"
+TRADE_FORECAST_STATUS_CHECK_NAMES = (
+    TRADE_FORECAST_STATUS_MODEL_CHECK_NAME,
+    TRADE_FORECAST_STATUS_CHECK_NAME,
+)
+TRADE_FORECAST_STATUS_VALUES = ("open", "closed", "closed_no_claim")
 
 
 def _quote_ident(identifier: str) -> str:
@@ -145,6 +154,40 @@ async def _ensure_investment_snapshot_kind_constraint(conn) -> None:
             "ALTER TABLE review.investment_snapshots "
             f"ADD CONSTRAINT {SNAPSHOT_KIND_CHECK_NAME} "
             f"{_check_constraint_sql('snapshot_kind', SNAPSHOT_KIND_VALUES)}"
+        )
+    )
+
+
+async def _ensure_trade_forecast_status_constraint(conn) -> None:
+    names_sql = ",".join(f"'{name}'" for name in TRADE_FORECAST_STATUS_CHECK_NAMES)
+    constraints = await conn.execute(
+        text(
+            "SELECT conname, pg_get_constraintdef(oid) AS definition "
+            "FROM pg_constraint "
+            "WHERE conrelid = 'review.trade_forecasts'::regclass "
+            f"AND conname IN ({names_sql}) "
+            "AND contype = 'c'"
+        )
+    )
+    rows = list(constraints)
+    if not _constraint_definitions_need_refresh(
+        [row[1] for row in rows],
+        TRADE_FORECAST_STATUS_VALUES,
+    ):
+        return
+
+    for name in TRADE_FORECAST_STATUS_CHECK_NAMES:
+        await conn.execute(
+            text(
+                "ALTER TABLE review.trade_forecasts "
+                f"DROP CONSTRAINT IF EXISTS {_quote_ident(name)}"
+            )
+        )
+    await conn.execute(
+        text(
+            "ALTER TABLE review.trade_forecasts "
+            f"ADD CONSTRAINT {TRADE_FORECAST_STATUS_CHECK_NAME} "
+            f"{_check_constraint_sql('status', TRADE_FORECAST_STATUS_VALUES)}"
         )
     )
 
@@ -833,6 +876,7 @@ async def apply_test_schema(conn) -> None:
 
     await _ensure_market_valuation_source_constraint(conn)
     await _ensure_investment_snapshot_kind_constraint(conn)
+    await _ensure_trade_forecast_status_constraint(conn)
     await _ensure_analysis_artifacts_created_by_constraint(conn)
     await _ensure_operator_session_context_created_by_constraint(conn)
 

--- a/tests/test_forecast_service.py
+++ b/tests/test_forecast_service.py
@@ -371,6 +371,72 @@ async def test_resolve_price_target_unresolved_no_data(
     assert row.status == "open"
 
 
+@pytest.mark.asyncio
+async def test_no_claim_placeholder_auto_closes_without_score_and_leaves_due_queue(
+    db_session: AsyncSession,
+):
+    _, row = await svc.save_forecast(
+        db_session,
+        created_by="claude",
+        symbol="005930",
+        instrument_type="equity_kr",
+        forecast_target={"kind": "no_resolvable_forecast"},
+        probability=0.0,
+        review_date="2020-01-01",
+    )
+    await db_session.commit()
+
+    result = await svc.resolve_forecast(
+        db_session,
+        forecast_id=str(row.forecast_id),
+        persist=True,
+    )
+    await db_session.commit()
+
+    assert result["status"] == "closed_no_claim"
+    assert result["changed"] is True
+    assert result["computed"] is None
+    await db_session.refresh(row)
+    assert row.status == "closed_no_claim"
+    assert row.outcome is None
+    assert row.observed_value is None
+    assert row.brier_score is None
+    assert row.resolved_at is not None
+    assert await svc.list_due_forecasts(db_session) == []
+    assert (await svc.build_forecast_calibration_aggregate(db_session))["groups"] == []
+
+
+@pytest.mark.asyncio
+async def test_non_placeholder_due_forecast_still_requires_manual_resolution(
+    db_session: AsyncSession,
+):
+    _, row = await svc.save_forecast(
+        db_session,
+        created_by="claude",
+        symbol="005930",
+        instrument_type="equity_kr",
+        forecast_target={"kind": "thesis_holds"},
+        probability=0.7,
+        review_date="2020-01-01",
+    )
+    await db_session.commit()
+
+    result = await svc.resolve_forecast(
+        db_session,
+        forecast_id=str(row.forecast_id),
+        persist=True,
+    )
+
+    assert result["status"] == "requires_manual"
+    assert result["changed"] is False
+    await db_session.refresh(row)
+    assert row.status == "open"
+    assert row.brier_score is None
+    assert [due.forecast_id for due in await svc.list_due_forecasts(db_session)] == [
+        row.forecast_id
+    ]
+
+
 # --------------------------------------------------------------------------- #
 # calibration aggregate
 # --------------------------------------------------------------------------- #

--- a/tests/test_forecast_tools.py
+++ b/tests/test_forecast_tools.py
@@ -170,6 +170,44 @@ async def test_save_and_resolve_envelope(_clean):
 
 @pytest.mark.integration
 @pytest.mark.asyncio
+async def test_due_batch_dry_run_distinguishes_no_claim_auto_close(_clean):
+    saved = await forecast_save(
+        created_by="claude",
+        symbol="005930",
+        instrument_type="equity_kr",
+        forecast_target={"kind": "no_resolvable_forecast"},
+        probability=0.0,
+        review_date="2020-01-01",
+    )
+    fid = saved["data"]["forecast_id"]
+
+    preview = await forecast_resolve(dry_run=True, backfill_missing=False)
+
+    assert preview["success"] is True
+    assert preview["dry_run"] is True
+    assert preview["by_status"] == {"would_close_no_claim": 1}
+    assert preview["results"] == [
+        {
+            "forecast_id": fid,
+            "symbol": "005930",
+            "status": "would_close_no_claim",
+            "changed": False,
+            "auto_close": True,
+            "computed": None,
+            "reason": "placeholder has no resolvable claim",
+        }
+    ]
+
+    committed = await forecast_resolve(dry_run=False, backfill_missing=False)
+    assert committed["by_status"] == {"closed_no_claim": 1}
+    assert committed["results"][0]["auto_close"] is True
+
+    due_after_close = await forecast_resolve(dry_run=True, backfill_missing=False)
+    assert due_after_close["due_count"] == 0
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
 async def test_save_validation_error_envelope(_clean):
     res = await forecast_save(
         created_by="claude",


### PR DESCRIPTION
## Summary

- Auto-close due `no_resolvable_forecast` placeholders as `closed_no_claim` without outcome or Brier score.
- Expose planned auto-closes distinctly in `forecast_resolve(dry_run=true)`.
- Add the database status constraint migration and keep the pytest schema bootstrap synchronized.
- Preserve normal non-price forecast resolution and exclude no-claim rows from `/insights` calibration.

## Test Coverage

- Placeholder due → unscored auto-close → absent from the next due scan.
- Normal probability > 0 forecast remains on the manual-resolution path.
- Dry-run and committed batch envelopes distinguish the auto-close.
- Calibration aggregation excludes `closed_no_claim` rows.

## Pre-Landing Review

No issues found.

## Design Review

No frontend files changed.

## Plan Completion

All ROB-859 acceptance items are covered.

## Test plan

- [x] `uv run pytest tests/test_forecast_service.py tests/test_forecast_service_pure.py tests/test_forecast_tools.py tests/test_forecast_web_read.py tests/routers/test_invest_forecasts_router.py tests/test_conftest_schema_patches.py tests/test_mcp_profiles.py -q` — 144 passed
- [x] `make lint`
- [x] `uv run alembic heads` — one head: `20260713_rob859_no_claim`
