### PR TITLE
feat(ROB-864): replace Paperclip approval with Telegram two-step confirmation

### DIFF
--- a/app/mcp_server/README.md
+++ b/app/mcp_server/README.md
@@ -156,7 +156,7 @@ MCP tools (market data, portfolio, order execution) exposed via `fastmcp`.
   - 실매도 성공 시 동일 symbol의 active journal을 FIFO 기준으로 auto-close 시도
   - 부분 매도는 quantity를 수정하지 않고, fully-consumed journal만 close한다
   - journal close 실패는 주문 성공을 되돌리지 않고 `journal_warning` 으로 응답한다
-  - `defensive_trim=True` 는 ROB-164/ROB-166 승인 기반 제한 경로이며 `(a) side="sell"`, `(b) order_type="limit"`, `(c) `approval_issue_id` 가 Paperclip `done` 상태, `(d) middleware-extracted caller identity 가 Trader agent 와 일치할 때만 평균단가 1% 매도 floor 를 우회한다
+  - 직접 `defensive_trim=True` 및 `exit_intent="loss_cut"` 경로는 fail-close하며 `order_proposal_create`를 안내한다. proposal loss-cut만 Telegram 2단계 확인 후 평균단가 1% floor를 우회할 수 있다
 - `modify_order(order_id, symbol, market=None, new_price=None, new_quantity=None, dry_run=True, account_mode=None)`
 - `cancel_order(order_id, symbol=None, market=None, account_mode=None)`
   - US equities: resolves exchange from symbol DB, open orders, and recent history before cancel
@@ -610,32 +610,28 @@ order mutation.
     `kis_live/equity_kr`, `kis_live/equity_us`, and `upbit/crypto`.
   - When `valid_until` is omitted, it defaults to the next `00:00 KST`.
   - It accepts nullable `exit_intent`, `exit_reason`, `retrospective_id`, and
-    `approval_issue_id` fields for a loss-cut proposal. For
-    `exit_intent="loss_cut"`, all of `exit_reason`, `retrospective_id`, and
-    `approval_issue_id` are required.
+    `approval_issue_id` fields. For `exit_intent="loss_cut"`, `exit_reason`
+    and `retrospective_id` are required. `approval_issue_id` is optional
+    free-text audit metadata.
   - The referenced retrospective is checked at create time for existence,
     matching symbol, an eligible loss-cut trigger type (`stop_loss` or
     `thesis_change`), and freshness within 72 hours.
     This create-time check does not replace approval-time checks.
-  - `approval_issue_id` is a Paperclip issue key (`^[A-Z]+-\d+$`) and must be a
-    dedicated per-order approval; unrelated completed issues must not be
-    reused. Before creating the proposal, verify the execution environment
-    returns exact status `done` without printing the token:
-
-    ```bash
-    APPROVAL_ISSUE_ID=ROB-<number>
-    curl -fsS -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
-      "$PAPERCLIP_API_URL/api/issues/$APPROVAL_ISSUE_ID" \
-      | jq -e '.status == "done"'
-    ```
+  - No external issue tracker is queried. A loss-cut first approval click
+    submits nothing: it edits the message with order/current-price/loss/slip
+    and retrospective evidence and issues `⚠️ 손절 확인`. That second button
+    has a 90-second single-use nonce bound to proposal/rung/revision. Only the
+    second click reruns full preview, <=72h retrospective, slip-band, price
+    diff, and approval-hash checks and may submit.
 - `order_proposal_void(proposal_id, reason)`
   - Requires a non-blank operator reason.
   - Refuses to mutate a proposal if any rung can have outstanding broker state.
     Rungs at or after submit cause the whole request to fail closed, with no
     partial local void.
 
-Telegram approval runs fresh broker-specific checks at the click. KIS/Upbit
-rerun their applicable Paperclip/ROB-800 checks through `_place_order_impl`.
+Telegram approval runs fresh broker-specific checks at the submit-capable
+click. KIS/Upbit rerun their applicable ROB-800 checks through
+`_place_order_impl`.
 `ORDER_PROPOSALS_SUBMIT_AGENT_ID` has no default identity (`""`) and is used
 only while the Telegram callback revalidates and submits the approved proposal.
 Operators must set it explicitly and add the exact same trimmed identity to
@@ -650,9 +646,9 @@ route through `toss_preview_order` and `toss_place_order`. Toss preview owns the
 wire price/quantity used for revalidation, including KR tick normalization, and
 provides its read-only warning, price/cost, NXT-context, and advisory sector
 concentration checks. For `loss_cut`, preview and submit both reuse the shared
-ROB-800 validator (Paperclip `done`, caller allowlist, matching fresh
-retrospective), exempt only the validated request from the average-cost floor,
-and enforce the configured current-price slip band.
+ROB-800 validator (caller allowlist and matching fresh retrospective), exempt
+only the validated request from the average-cost floor, and enforce the
+configured current-price slip band. No external approval backend is queried.
 `toss_place_order` runs the confirmation/activation, high-value, warnings,
 opposite-pending-order, sell-loss, and configured NXT guards immediately before
 POST. A Toss loss-cut live send requires the exact supplied preview approval
@@ -781,7 +777,7 @@ Operator activation and the one-share live smoke are documented in
 - **Account Mode Routing**: All Toss tools require `account_mode="toss_live"` (or `account_type="toss_live"`) and reject any mismatched account parameters.
 - **Mutation Safety (Dry-Run, Confirm, and Activation Gate)**: All mutation tools (`toss_place_order`, `toss_modify_order`, `toss_cancel_order`) default to `dry_run=True`. They perform actual HTTP requests (POSTs) to Toss Securities only when `dry_run=False`, `confirm=True`, and `TOSS_LIVE_ORDER_MUTATIONS_ENABLED=true` are explicitly set. Keep `TOSS_LIVE_ORDER_MUTATIONS_ENABLED=false` until the accepted-order ledger and operator live-smoke hold are cleared.
 - **Accepted-only ledger and reconcile**: Real `toss_place_order` writes only an accepted/rejected row to `review.toss_live_order_ledger`. It does not create fills, journals, or realized PnL at send time. `toss_reconcile_orders(dry_run=True)` previews broker evidence from `GET /orders/{orderId}`; `dry_run=False` books only confirmed execution deltas. GET order-detail `403 non-json-response` failures are retried once after token reissue; unresolved failures are persisted as `requires_manual_review=true`. Mutation POSTs are not implicitly retried on that error.
-- **Loss-cut authorization**: `toss_preview_order` and `toss_place_order` accept `exit_intent="loss_cut"` only for a live limit sell with `exit_reason="stop_loss"|"thesis_change"`, a matching retrospective created within 72 hours, an allowed caller, and an `approval_issue_id` matching `^[A-Z]+-\d+$` whose `$PAPERCLIP_API_URL/api/issues/<id>` response has `status="done"`. The issue must be a dedicated per-order approval containing account, symbol, side, quantity, limit, retrospective ID, and expiry; the current verifier does not compare that metadata, so reusing an unrelated completed issue is prohibited. Submit repeats every check, and the retrospective may expire between create and approval. Toss ledger rows retain `exit_intent`, `retrospective_id`, and `approval_issue_id` for audit.
+- **Loss-cut authorization**: Direct `toss_preview_order`/`toss_place_order` loss-cut calls fail closed and point callers to `order_proposal_create`. A loss-cut proposal requires a live limit sell, eligible `exit_reason`, matching <=72h retrospective, allowed submit identity, slip-band compliance, and a valid approval hash. Telegram's first approval click only renders evidence and issues a proposal/rung/revision-bound 90-second `⚠️ 손절 확인` nonce; the second click reruns every guard and may submit. `approval_issue_id` is optional audit text and is never externally queried. Toss ledger rows retain `exit_intent`, `retrospective_id`, and `approval_issue_id` for audit.
 - **Loss-cut polling SLA**: Toss has no fill push in this path and both automatic polling paths are default-off. Before enabling Toss loss-cut, either enable and operationally verify `TOSS_FILL_POLL_ENABLED` with an approved `TOSS_FILL_POLL_CRON`, or require a targeted `toss_reconcile_orders(order_id=<broker-order-id>, dry_run=False)` immediately after execution. Non-dry reconcile projects broker evidence to proposal rungs and idempotently repairs terminal-ledger projection misses.
 - **Proposal identity handoff**: Order-proposal flows privately bind a stable client ID derived from `proposal_id + rung` around both `toss_preview_order` and `toss_place_order`, then require preview to return that exact ID. The proposal correlation and rung are carried through the same internal binding into the Toss ledger. These values are not exposed as operator-controlled MCP parameters. Accepted responses expose `approval_hash_digest`, the canonical ledger digest; the raw approval token is used only as the `approval_hash` submit input.
 - **US FX PnL split**: Toss order detail does not provide fill-time FX. For US rows only, `toss_reconcile_orders(dry_run=False)` captures USD/KRW through `exchange_rate_service` at reconcile time. Buy rows persist `buy_fx_rate`; sell rows persist `sell_fx_rate`, FIFO-attributed `fx_pnl_krw`, `security_pnl_usd`, `security_pnl_krw`, and `total_pnl_krw`. Automatic values are labelled `fx_rate_source="reconcile_spot"` and `fx_pnl_accuracy="approximate"`. Legacy lots with no buy FX keep FX PnL fields null until an operator backfills exact values through `modify_journal_entry`.

--- a/app/mcp_server/tooling/order_execution.py
+++ b/app/mcp_server/tooling/order_execution.py
@@ -1323,6 +1323,7 @@ async def _place_order_impl(
     scalping_exit_reason: str | None = None,
     correlation_id: str | None = None,
     report_item_uuid: str | None = None,
+    proposal_flow: bool = False,
     approval_hash: str | None = None,
     rung: str | int | None = None,
     mirror_cohort: str | None = None,
@@ -1395,6 +1396,7 @@ async def _place_order_impl(
             order_type=order_type_lower,
             is_mock=is_mock,
             symbol=normalized_symbol,
+            proposal_flow=proposal_flow,
         )
         if loss_cut_errors:
             return {

--- a/app/mcp_server/tooling/order_proposal_tools.py
+++ b/app/mcp_server/tooling/order_proposal_tools.py
@@ -121,6 +121,10 @@ async def order_proposal_create(
 ) -> dict[str, Any]:
     """Create a place, replace, or cancel proposal without broker mutation.
 
+    ``loss_cut`` keeps retrospective/price/hash guards and is approved only by
+    Telegram's two-click confirmation. ``approval_issue_id`` is an optional
+    free-text audit note; no external issue tracker is queried.
+
     Args:
         market: Canonical market in {equity_kr, equity_us, crypto}; aliases
                 kr→equity_kr and us→equity_us are accepted. Supported place
@@ -311,7 +315,9 @@ def register_order_proposal_tools(mcp: FastMCP) -> None:
             "Create a place, replace, or cancel order proposal (SOT ledger row). "
             "Replace/cancel read target-order evidence before persistence, but never "
             "mutate a broker. Approval/submission happens via Telegram (PR 2), not "
-            "through this tool."
+            "through this tool. loss_cut requires a two-click confirmation with a "
+            "single-use nonce and full second-click revalidation; approval_issue_id "
+            "is an optional audit note and is never externally queried."
         ),
     )(order_proposal_create)
     _ = mcp.tool(

--- a/app/mcp_server/tooling/order_validation.py
+++ b/app/mcp_server/tooling/order_validation.py
@@ -4,12 +4,8 @@ from __future__ import annotations
 
 import datetime
 import json
-import re
-import time
 from dataclasses import dataclass
 from typing import Any
-
-import httpx
 
 import app.services.brokers.upbit.client as upbit_service
 import app.services.market_data as market_data_service
@@ -55,9 +51,6 @@ async def _call_kis(method: Any, *args: Any, is_mock: bool, **kwargs: Any) -> An
     return await method(*args, **kwargs)
 
 
-_DEFENSIVE_TRIM_APPROVAL_REGEX = re.compile(r"^[A-Z]+-\d+$")
-_DEFENSIVE_TRIM_CACHE_TTL_SECONDS = 60.0
-_defensive_trim_success_cache: dict[str, float] = {}
 _TRADER_AGENT_ID_DEFAULT = "6b2192cc-14fa-4335-b572-2fe1e0cb54a7"
 
 
@@ -92,7 +85,7 @@ class LossCutContext:
 
     retrospective_id: int
     exit_reason: str
-    approval_issue_id: str
+    approval_issue_id: str | None
     requester_agent_id: str
     max_slip: float
     approval_verified_at: datetime.datetime
@@ -348,22 +341,6 @@ async def evaluate_sector_concentration(
         return {"verdict": "unknown", "fail_open": True, "reason": str(exc)}
 
 
-def _is_cached_approved(approval_issue_id: str) -> bool:
-    expires_at = _defensive_trim_success_cache.get(approval_issue_id)
-    if expires_at is None:
-        return False
-    if expires_at <= time.time():
-        _defensive_trim_success_cache.pop(approval_issue_id, None)
-        return False
-    return True
-
-
-def _cache_approved(approval_issue_id: str) -> None:
-    _defensive_trim_success_cache[approval_issue_id] = (
-        time.time() + _DEFENSIVE_TRIM_CACHE_TTL_SECONDS
-    )
-
-
 def _log_defensive_trim_bypass(
     *,
     symbol: str,
@@ -443,36 +420,6 @@ def _log_mock_loss_sell_bypass(
     )
 
 
-async def _fetch_approval_issue_status(approval_issue_id: str) -> str | None:
-    api_url = getattr(settings, "paperclip_api_url", None)
-    api_key = getattr(settings, "paperclip_api_key", None)
-    if not api_url or not api_key:
-        logger.warning(
-            "defensive_trim disabled: missing PAPERCLIP_API_URL or PAPERCLIP_API_KEY"
-        )
-        return None
-
-    issue_api_url = f"{api_url.rstrip('/')}/api/issues/{approval_issue_id}"
-    headers = {"Authorization": f"Bearer {api_key}"}
-
-    try:
-        async with httpx.AsyncClient(timeout=2.0) as client:
-            response = await client.get(issue_api_url, headers=headers)
-    except Exception:
-        return None
-
-    if response.status_code != 200:
-        return None
-
-    try:
-        payload = response.json()
-    except ValueError:
-        return None
-
-    status = payload.get("status")
-    return str(status) if status is not None else None
-
-
 async def _validate_defensive_trim_preconditions(
     *,
     defensive_trim: bool,
@@ -483,54 +430,7 @@ async def _validate_defensive_trim_preconditions(
     """Validate defensive_trim gates using middleware-extracted caller identity."""
     if not defensive_trim:
         return None
-
-    if side != "sell":
-        raise ValueError(
-            "defensive_trim requires side='sell' (buy orders always use existing path)"
-        )
-    if order_type != "limit":
-        raise ValueError(
-            "defensive_trim requires order_type='limit' (market orders are blocked)"
-        )
-    if not approval_issue_id:
-        raise ValueError("defensive_trim=True requires approval_issue_id")
-    if not _DEFENSIVE_TRIM_APPROVAL_REGEX.match(approval_issue_id):
-        raise ValueError("approval_issue_id format invalid (expected e.g. 'ROB-164')")
-
-    caller_agent_id = get_caller_agent_id()
-    if not caller_agent_id:
-        raise ValueError(
-            "caller identity unavailable — defensive_trim requires authenticated MCP caller"
-        )
-
-    trader_agent_id = getattr(settings, "trader_agent_id", _TRADER_AGENT_ID_DEFAULT)
-    if caller_agent_id != trader_agent_id:
-        raise ValueError(
-            "defensive_trim requires Trader agent caller "
-            f"(got caller_agent_id={caller_agent_id})"
-        )
-
-    approval_status: str | None
-    if _is_cached_approved(approval_issue_id):
-        approval_status = "done"
-    else:
-        try:
-            approval_status = await _fetch_approval_issue_status(approval_issue_id)
-        except Exception:
-            approval_status = None
-        if approval_status == "done":
-            _cache_approved(approval_issue_id)
-
-    if approval_status != "done":
-        raise ValueError(
-            f"approval_issue_id {approval_issue_id} not found or not in 'done' status"
-        )
-
-    return DefensiveTrimContext(
-        approval_issue_id=approval_issue_id,
-        requester_agent_id=caller_agent_id,
-        approval_verified_at=datetime.datetime.now(datetime.UTC),
-    )
+    raise ValueError("defensive_trim_direct_path_disabled_use_order_proposal_create")
 
 
 _LOSS_CUT_EXIT_REASONS = frozenset({"stop_loss", "thesis_change"})
@@ -559,6 +459,7 @@ async def _validate_loss_cut_preconditions(
     order_type: str,
     is_mock: bool,
     symbol: str,
+    proposal_flow: bool = False,
 ) -> tuple[LossCutContext | None, list[str]]:
     """ROB-800 — fail-closed loss_cut gate. Collects EVERY violation so a
     dry_run preview can return them all in one response. Returns (None, []) when
@@ -566,6 +467,8 @@ async def _validate_loss_cut_preconditions(
     """
     if exit_intent != "loss_cut":
         return None, []
+    if not proposal_flow:
+        return None, ["loss_cut_direct_path_disabled_use_order_proposal_create"]
 
     errors: list[str] = []
 
@@ -596,26 +499,6 @@ async def _validate_loss_cut_preconditions(
             f"caller agent {caller_agent_id} not permitted for loss_cut "
             "(add to LOSS_CUT_ALLOWED_AGENT_IDS)"
         )
-
-    approval_status: str | None = None
-    if not approval_issue_id:
-        errors.append("loss_cut requires approval_issue_id")
-    elif not _DEFENSIVE_TRIM_APPROVAL_REGEX.match(approval_issue_id):
-        errors.append("approval_issue_id format invalid (expected e.g. 'ROB-800')")
-    else:
-        if _is_cached_approved(approval_issue_id):
-            approval_status = "done"
-        else:
-            try:
-                approval_status = await _fetch_approval_issue_status(approval_issue_id)
-            except Exception:
-                approval_status = None
-            if approval_status == "done":
-                _cache_approved(approval_issue_id)
-        if approval_status != "done":
-            errors.append(
-                f"approval_issue_id {approval_issue_id} not found or not in 'done' status"
-            )
 
     retro = None
     if retrospective_id is None:
@@ -658,7 +541,7 @@ async def _validate_loss_cut_preconditions(
         LossCutContext(
             retrospective_id=retrospective_id,  # type: ignore[arg-type]
             exit_reason=resolved_exit_reason,
-            approval_issue_id=approval_issue_id,  # type: ignore[arg-type]
+            approval_issue_id=approval_issue_id,
             requester_agent_id=caller_agent_id,  # type: ignore[arg-type]
             max_slip=_loss_cut_max_slip_value(),
             approval_verified_at=datetime.datetime.now(datetime.UTC),

--- a/app/mcp_server/tooling/orders_kis_variants.py
+++ b/app/mcp_server/tooling/orders_kis_variants.py
@@ -464,10 +464,8 @@ def register_kis_live_order_tools(mcp: FastMCP) -> None:
             "dry_run=True by default for safety. "
             "For buy orders (dry_run=False), thesis and strategy are required. "
             "Normal weight-management trims do NOT need defensive_trim — leave "
-            "it False. defensive_trim=True only bypasses the sell-side price "
-            "floor and requires side='sell', order_type='limit', and an "
-            "approval_issue_id (e.g. 'ROB-164'); approval_issue_id is mandatory "
-            "whenever defensive_trim=True, including dry_run (ROB-164 audit gate). "
+            "it False. defensive_trim=True is disabled on this direct tool; use "
+            "order_proposal_create for the human-confirmed proposal path. "
             "Orders auto-route via SOR (NXT-eligible) / KRX as day orders. "
             "venue (krx|nxt|unified), order_validity (day|예약|gtc), and "
             "reserved_time are accepted but NOT yet enabled — NXT/TIF/예약주문 "
@@ -493,15 +491,10 @@ def register_kis_live_order_tools(mcp: FastMCP) -> None:
             "live send; required=mandatory (this live tool must supply a hash). "
             "account_mode='kis_live' is accepted but redundant; "
             "any other account_mode value is rejected."
-            'ROB-800 exit_intent: Optional[str] — set to "loss_cut" (live sell-only '
-            "sanctioned path; mutually exclusive with defensive_trim=True). When set, "
-            "the caller must also provide retrospective_id (≤72h, symbol match, "
-            "trigger_type ∈ {stop_loss, thesis_change}), approval_issue_id (Paperclip "
-            "status=done), and an approval_hash (independent of "
-            "ORDER_APPROVAL_HASH_MODE). The four preconditions are aggregated: a "
-            "dry_run preview returns ALL violations in one response. exit_intent is "
-            "recorded on the live order ledger. loss_cut is LIVE-ONLY — mock "
-            "callers will receive a precondition violation."
+            ' ROB-864 exit_intent="loss_cut" is disabled on this direct tool. Use '
+            "order_proposal_create; Telegram performs two-click confirmation with a "
+            "single-use nonce and second-click full revalidation. approval_issue_id "
+            "is only an optional audit note."
         ),
     )
     async def kis_live_place_order(  # NOSONAR - public MCP order schema mirrors legacy tool.

--- a/app/mcp_server/tooling/orders_registration.py
+++ b/app/mcp_server/tooling/orders_registration.py
@@ -206,11 +206,9 @@ def register_order_tools(mcp: FastMCP) -> None:
             "Use account_mode={'db_simulated','kis_mock','kis_live'} "
             "(preferred); account_type aliases are deprecated and emit warnings. "
             "Journal features (thesis/strategy/FIFO close) ARE supported in paper mode. "
-            "defensive_trim=True enables a sell/limit-only floor bypass path. "
-            "ROB-164/ROB-166 defensive_trim requires ALL of: (a) side='sell', "
-            "(b) order_type='limit', (c) valid approval_issue_id with approval issue "
-            "status=done in Paperclip, and (d) middleware-extracted caller identity "
-            "matching Trader agent. "
+            "defensive_trim=True is disabled on this direct tool; create an "
+            "order_proposal_create request so Telegram can collect the required "
+            "human confirmation. "
             "Approval-hash binding (ORDER_APPROVAL_HASH_MODE, default optional): the "
             "dry_run=True preview mints approval_hash (self-contained token over the "
             "normalized order, 5-minute TTL), approval_expires_at, and idempotency_key; "
@@ -218,14 +216,10 @@ def register_order_tools(mcp: FastMCP) -> None:
             "send re-derives the canonical order and fail-closes on mismatch/expiry. "
             "off=ignored; optional=verified only when supplied; warn=logs a hash-less "
             "live send; required=mandatory for LIVE sends (mock/is_mock paths exempt)."
-            'ROB-800 exit_intent: Optional[str] — set to "loss_cut" (live sell-only '
-            "sanctioned path; mutually exclusive with defensive_trim=True). When set, "
-            "the caller must also provide retrospective_id (≤72h, symbol match, "
-            "trigger_type ∈ {stop_loss, thesis_change}), approval_issue_id (Paperclip "
-            "status=done), and on live send an approval_hash (independent of "
-            "ORDER_APPROVAL_HASH_MODE). The four preconditions are aggregated: a "
-            "dry_run preview returns ALL violations in one response. exit_intent is "
-            "recorded on the live order ledger."
+            ' ROB-864 exit_intent="loss_cut" is disabled on this direct tool. Use '
+            "order_proposal_create; Telegram performs two-click confirmation with a "
+            "single-use nonce and second-click full revalidation. approval_issue_id "
+            "is only an optional audit note."
         ),
     )
     async def place_order(
@@ -260,20 +254,25 @@ def register_order_tools(mcp: FastMCP) -> None:
             account_mode=account_mode,
             account_type=account_type,
         )
+        if exit_intent == "loss_cut":
+            return {
+                "success": False,
+                "error": "loss_cut_direct_path_disabled_use_order_proposal_create",
+                "source": "mcp",
+                "symbol": symbol,
+            }
+        if defensive_trim:
+            return {
+                "success": False,
+                "error": (
+                    "defensive_trim_direct_path_disabled_use_order_proposal_create"
+                ),
+                "source": "mcp",
+                "symbol": symbol,
+            }
         # Defense in depth: reject market orders even if a stale client
         # bypasses the tightened schema and still sends order_type="market".
         if str(order_type).lower().strip() != "limit":
-            if defensive_trim:
-                return {
-                    "success": False,
-                    "error": (
-                        "defensive_trim requires order_type='limit' "
-                        "(market orders are blocked)"
-                    ),
-                    "source": "mcp",
-                    "symbol": symbol,
-                    "order_type": order_type,
-                }
             return {
                 "success": False,
                 "error": (

--- a/app/mcp_server/tooling/orders_toss_variants.py
+++ b/app/mcp_server/tooling/orders_toss_variants.py
@@ -543,6 +543,7 @@ async def _sell_loss_guard(
     *,
     loss_cut_ctx: LossCutContext | None = None,
     current_price: Decimal | None = None,
+    evidence_context: dict[str, Any] | None = None,
 ) -> dict[str, Any] | None:
     try:
         holding = await _find_holding(client, symbol)
@@ -571,6 +572,8 @@ async def _sell_loss_guard(
     floor = avg * Decimal("1.01")
 
     if loss_cut_ctx is not None:
+        if evidence_context is not None:
+            evidence_context["avg_buy_price"] = _stringify_decimal(avg)
         if price is None:
             return {
                 "success": False,
@@ -824,6 +827,7 @@ async def toss_preview_order(
         order_type=order_type,
         is_mock=False,
         symbol=symbol,
+        proposal_flow=_order_proposal_context.get() is not None,
     )
     if loss_cut_errors:
         return {
@@ -929,6 +933,7 @@ async def toss_preview_order(
     if price_context_message is not None:
         order_warnings.append(_PRICE_CONTEXT_UNAVAILABLE)
 
+    loss_cut_evidence: dict[str, Any] = {}
     if loss_cut_ctx is not None:
         if current_price_dec is None:
             return {
@@ -954,6 +959,7 @@ async def toss_preview_order(
                 },
                 loss_cut_ctx=loss_cut_ctx,
                 current_price=current_price_dec,
+                evidence_context=loss_cut_evidence,
             )
         if loss_cut_guard is not None:
             return loss_cut_guard
@@ -1031,6 +1037,7 @@ async def toss_preview_order(
         response["loss_cut_slip_band"] = float(current_price_dec) * (
             1.0 - loss_cut_ctx.max_slip
         )
+        response.update(loss_cut_evidence)
     return response
 
 
@@ -1086,6 +1093,7 @@ async def _toss_place_order_impl(
         order_type=order_type,
         is_mock=False,
         symbol=symbol,
+        proposal_flow=proposal_context is not None,
     )
     if loss_cut_errors:
         return {
@@ -1971,12 +1979,10 @@ def register_toss_live_order_tools(mcp: FastMCP) -> None:
             "content-based idempotency_key. Pass the optional rung (ladder level) "
             "to keep sibling ladder orders on the same day distinct. Hand the "
             "returned approval_hash (and matching rung) back to toss_place_order. "
-            "For exit_intent='loss_cut', also pass exit_reason, a <=72h matching "
-            "retrospective_id, and a dedicated per-order Paperclip "
-            "approval_issue_id whose API status is exactly 'done'. The preview "
-            "revalidates caller authorization and applies the configured current-"
-            "price slip band while exempting only that valid request from the "
-            "average-cost floor."
+            "exit_intent='loss_cut' is disabled for direct MCP calls. Use "
+            "order_proposal_create; its Telegram two-click flow revalidates the "
+            "<=72h retrospective, current-price slip band, and approval hash before "
+            "submission. approval_issue_id is only an optional audit note."
         ),
     )(toss_preview_order)
     mcp.tool(
@@ -2000,11 +2006,9 @@ def register_toss_live_order_tools(mcp: FastMCP) -> None:
             "warn = same as optional but logs a hash-less live send; required = "
             "a valid, unexpired approval_hash is mandatory. Order-proposal "
             "preview/submit identity and correlation are bound internally and "
-            "cannot be supplied by MCP callers. A valid loss_cut repeats the "
-            "Paperclip/caller/retrospective checks immediately before send and "
-            "requires the supplied preview approval_hash even when "
-            "TOSS_APPROVAL_HASH_MODE=off; unrelated completed issues must not be "
-            "reused."
+            "cannot be supplied by MCP callers. Direct loss_cut is disabled; use "
+            "order_proposal_create for Telegram two-click confirmation and a full "
+            "second-click preview/retrospective/slip/hash revalidation."
         ),
     )(toss_place_order)
     mcp.tool(

--- a/app/services/order_proposals/approval_message.py
+++ b/app/services/order_proposals/approval_message.py
@@ -11,9 +11,9 @@ from typing import Any
 
 from app.core.timezone import KST
 
-_ALLOWED_ACTIONS = frozenset({"op", "dn"})
+_ALLOWED_ACTIONS = frozenset({"op", "dn", "lc"})
 _CALLBACK_PATTERN = re.compile(
-    r"^(?P<action>op|dn):(?P<proposal_short>[0-9a-f]{8}):"
+    r"^(?P<action>op|dn|lc):(?P<proposal_short>[0-9a-f]{8}):"
     r"(?P<nonce>[A-Za-z0-9_-]+)$"
 )
 _MAX_CALLBACK_BYTES = 64
@@ -34,7 +34,7 @@ def build_callback_data(
 ) -> str:
     """Build compact Telegram callback data for an approval action."""
     if action not in _ALLOWED_ACTIONS:
-        raise ValueError("action must be one of: op, dn")
+        raise ValueError("action must be one of: op, dn, lc")
     if not isinstance(proposal_id, uuid.UUID):
         raise ValueError("proposal_id must be a UUID")
     if not isinstance(nonce, str) or not re.fullmatch(r"[A-Za-z0-9_-]+", nonce):
@@ -232,6 +232,93 @@ def build_approval_message(
         ]
     }
     return text, inline_keyboard
+
+
+def build_loss_cut_confirmation_message(
+    *,
+    group: Any,
+    rungs: Sequence[Any],
+    evidence: Mapping[str, Any],
+) -> tuple[str, dict]:
+    """Render the explicit second-step loss-cut confirmation prompt."""
+    nonce = getattr(group, "approval_nonce", None)
+    if not nonce:
+        raise ValueError("group.approval_nonce is required")
+    proposal_id = getattr(group, "proposal_id", None)
+    market = str(getattr(group, "market", "") or "미기재")
+    symbol = str(getattr(group, "symbol", "") or "미기재")
+    currency = _currency_for_market(market=market, symbol=symbol)
+    quantity_unit = "주" if market in {"equity_kr", "equity_us"} else ""
+    evidence_by_rung = {
+        int(item.get("rung_index", 0)): item
+        for item in evidence.get("rungs", [])
+        if isinstance(item, Mapping)
+    }
+
+    lines = [
+        "*⚠️ 손절 확인*",
+        f"- 종목: `{_escape_inline_code(symbol)}`",
+        "",
+        "*주문 및 손실 요약*",
+    ]
+    for rung in sorted(rungs, key=lambda value: getattr(value, "rung_index", 0)):
+        index = int(getattr(rung, "rung_index", 0))
+        item = evidence_by_rung.get(index, {})
+        quantity = _format_decimal(getattr(rung, "quantity", None))
+        limit_price = _format_money(
+            getattr(rung, "limit_price", None), currency=currency, none_label="시장가"
+        )
+        current_price = _format_money(
+            item.get("current_price"), currency=currency, none_label="조회 실패"
+        )
+        slip_band = _format_money(
+            item.get("loss_cut_slip_band"), currency=currency, none_label="조회 실패"
+        )
+        loss_pct = str(item.get("loss_pct") or "조회 실패")
+        if loss_pct != "조회 실패" and not loss_pct.endswith("%"):
+            loss_pct = f"{loss_pct}%"
+        lines.extend(
+            [
+                f"- #{index + 1}: {quantity}{quantity_unit} × {limit_price}",
+                f"  현재가 {current_price} / 손실률 {loss_pct}",
+                f"  허용 slip 밴드 하단 {slip_band}",
+            ]
+        )
+
+    retrospective_id = evidence.get("retrospective_id")
+    lesson = str(evidence.get("lesson_excerpt") or "미기재")
+    lines.extend(
+        [
+            "",
+            "*회고 근거*",
+            f"- 회고: #{retrospective_id}",
+            f"- 교훈: {_escape_markdown(lesson)}",
+        ]
+    )
+    approval_note = str(getattr(group, "approval_issue_id", None) or "").strip()
+    if approval_note:
+        lines.append(f"- 승인 감사 메모: {_escape_markdown(approval_note)}")
+    lines.extend(["", "이 손절 주문을 다시 확인해 주세요."])
+    text = "\n".join(lines).replace(str(nonce), "[비공개]")
+    keyboard = {
+        "inline_keyboard": [
+            [
+                {
+                    "text": "⚠️ 손절 확인",
+                    "callback_data": build_callback_data(
+                        action="lc", proposal_id=proposal_id, nonce=nonce
+                    ),
+                },
+                {
+                    "text": "❌ 거부",
+                    "callback_data": build_callback_data(
+                        action="dn", proposal_id=proposal_id, nonce=nonce
+                    ),
+                },
+            ]
+        ]
+    }
+    return text, keyboard
 
 
 def _build_time_lines(group: Any) -> list[str]:

--- a/app/services/order_proposals/revalidation.py
+++ b/app/services/order_proposals/revalidation.py
@@ -40,6 +40,7 @@ from app.services.order_proposals.broker_gateway import (
     fetch_submit_evidence,
     fetch_target_order,
 )
+from app.services.order_proposals.errors import OrderProposalError
 from app.services.order_proposals.service import OrderProposalsService
 from app.services.order_proposals.target_order import TargetOrderSnapshot
 
@@ -66,6 +67,7 @@ CorrelationMint = Callable[..., Any]
 TargetFetchFn = Callable[..., Any]
 TargetCancelFn = Callable[..., Any]
 SubmitEvidenceFetchFn = Callable[..., Any]
+RetrospectiveLookupFn = Callable[[int], Any]
 
 _PREVIEW_REASON = "order_proposal revalidation (rung {rung})"
 _SUBMIT_REASON = "order_proposal submit after revalidation (rung {rung})"
@@ -384,12 +386,110 @@ async def _default_place_order_fn(**kwargs: Any) -> dict[str, Any]:
     if proposal_client_order_id is not None:
         kwargs["client_order_id"] = str(proposal_client_order_id)
 
-    submit = await _place_order_impl(**kwargs)
+    submit = await _place_order_impl(**kwargs, proposal_flow=True)
     if kwargs.get("dry_run") is False:
         return _adapt_live_submit_response(
             submit, order_type=str(kwargs.get("order_type"))
         )
     return submit
+
+
+async def _default_retrospective_lookup(retrospective_id: int) -> Any:
+    from app.mcp_server.tooling.order_validation import (
+        _get_retrospective_by_id_for_loss_cut,
+    )
+
+    return await _get_retrospective_by_id_for_loss_cut(retrospective_id)
+
+
+async def preview_loss_cut_confirmation(
+    *,
+    service: OrderProposalsService,
+    proposal_id: uuid.UUID,
+    now: datetime,
+    place_order_fn: PlaceOrderFn = _default_place_order_fn,
+    retrospective_lookup_fn: RetrospectiveLookupFn = _default_retrospective_lookup,
+) -> dict[str, Any]:
+    """Build read-only, fresh evidence for Telegram's loss-cut second step."""
+    group, rungs = await service.get_proposal(proposal_id)
+    if group.exit_intent != "loss_cut" or group.retrospective_id is None:
+        raise OrderProposalError("loss_cut_confirmation_requires_loss_cut")
+    retrospective = await _maybe_await(retrospective_lookup_fn(group.retrospective_id))
+    if retrospective is None:
+        raise OrderProposalError("loss_cut_confirmation_retrospective_missing")
+
+    evidence_rungs: list[dict[str, Any]] = []
+    for rung in rungs:
+        if rung.state not in {"pending_approval", "needs_reconfirm"}:
+            continue
+        proposal_client_order_id = (
+            _toss_proposal_client_order_id(proposal_id, rung.rung_index)
+            if group.account_mode == "toss_live"
+            else _proposal_client_order_id(proposal_id, rung.rung_index)
+            if group.account_mode == "upbit"
+            else None
+        )
+        preview = await _maybe_await(
+            place_order_fn(
+                dry_run=True,
+                account_mode=group.account_mode,
+                symbol=group.symbol,
+                side=rung.side,
+                market=group.market,
+                order_type=group.order_type,
+                quantity=rung.quantity,
+                price=rung.limit_price,
+                thesis=group.thesis,
+                strategy=group.strategy,
+                exit_intent=group.exit_intent,
+                exit_reason=group.exit_reason,
+                retrospective_id=group.retrospective_id,
+                approval_issue_id=group.approval_issue_id,
+                reason=_PREVIEW_REASON.format(rung=rung.rung_index),
+                rung=rung.rung_index,
+                **(
+                    {"proposal_client_order_id": proposal_client_order_id}
+                    if proposal_client_order_id is not None
+                    else {}
+                ),
+            )
+        )
+        if preview.get("success") is False:
+            raise OrderProposalError(
+                str(preview.get("error") or "loss_cut_confirmation_preview_blocked")
+            )
+        try:
+            current_price = Decimal(str(preview["current_price"]))
+            avg_buy_price = Decimal(str(preview["avg_buy_price"]))
+            slip_band = Decimal(str(preview["loss_cut_slip_band"]))
+        except (KeyError, TypeError, ValueError) as exc:
+            raise OrderProposalError(
+                "loss_cut_confirmation_preview_missing_price_context"
+            ) from exc
+        if avg_buy_price <= 0:
+            raise OrderProposalError("loss_cut_confirmation_invalid_average_cost")
+        loss_pct = ((current_price - avg_buy_price) / avg_buy_price * 100).quantize(
+            Decimal("0.01")
+        )
+        evidence_rungs.append(
+            {
+                "rung_index": rung.rung_index,
+                "current_price": _norm(current_price),
+                "avg_buy_price": _norm(avg_buy_price),
+                "loss_pct": format(loss_pct, "f"),
+                "loss_cut_slip_band": _norm(slip_band),
+            }
+        )
+    if not evidence_rungs:
+        raise OrderProposalError("loss_cut_confirmation_has_no_eligible_rungs")
+    lesson = " ".join(str(getattr(retrospective, "lesson", None) or "미기재").split())
+    if len(lesson) > 240:
+        lesson = lesson[:239] + "…"
+    return {
+        "rungs": evidence_rungs,
+        "retrospective_id": group.retrospective_id,
+        "lesson_excerpt": lesson,
+    }
 
 
 def _default_correlation_mint(

--- a/app/services/order_proposals/service.py
+++ b/app/services/order_proposals/service.py
@@ -88,6 +88,8 @@ _VOIDABLE_RUNG_STATES = frozenset(
 _EVIDENCE_ACCEPTING_RUNG_STATES = frozenset(
     {"acked", "resting", "partially_filled", "unverified"}
 )
+_LOSS_CUT_CONFIRMATION_KEY = "loss_cut_confirmation"
+_LOSS_CUT_CONFIRMABLE_RUNG_STATES = frozenset({"pending_approval", "needs_reconfirm"})
 
 
 def _validate_action_contract(
@@ -358,8 +360,6 @@ class OrderProposalsService:
             )
         if retrospective_id is None:
             errors.append("loss_cut requires retrospective_id")
-        if not (approval_issue_id or "").strip():
-            errors.append("loss_cut requires approval_issue_id")
         if (account_mode, market) not in {
             ("kis_live", "equity_kr"),
             ("kis_live", "equity_us"),
@@ -582,6 +582,120 @@ class OrderProposalsService:
         if group.approval_nonce_used_at is not None:
             raise OrderProposalError("nonce_replay")
         return await self._repo.update_group(group, approval_nonce_used_at=now)
+
+    async def issue_loss_cut_confirmation(
+        self,
+        proposal_id: uuid.UUID,
+        *,
+        first_nonce: str,
+        confirmation_nonce: str,
+        telegram_user_id: str,
+        now: datetime,
+        ttl_seconds: int = 90,
+    ) -> OrderProposal:
+        """Replace a consumed first-step nonce with a bound second-step nonce."""
+        self._require_timezone_aware(now)
+        group = await self._repo.get_group_by_proposal_id(proposal_id, for_update=True)
+        if group is None:
+            raise OrderProposalNotFound(str(proposal_id))
+        if group.exit_intent != "loss_cut":
+            raise OrderProposalError("loss_cut_confirmation_requires_loss_cut")
+        if group.approval_nonce != first_nonce or group.approval_nonce_used_at is None:
+            raise OrderProposalError("loss_cut_first_nonce_not_consumed")
+        rungs = await self._repo.list_rungs(group.id)
+        binding = [
+            {
+                "rung_index": rung.rung_index,
+                "approval_revision": rung.approval_revision or 0,
+            }
+            for rung in sorted(rungs, key=lambda item: item.rung_index)
+            if rung.state in _LOSS_CUT_CONFIRMABLE_RUNG_STATES
+        ]
+        if not binding:
+            raise OrderProposalError("loss_cut_confirmation_has_no_eligible_rungs")
+        envelope = {
+            "proposal_id": str(proposal_id),
+            "rungs": binding,
+            "nonce": confirmation_nonce,
+            "issued_at": now.isoformat(),
+            "expires_at": (now + timedelta(seconds=ttl_seconds)).isoformat(),
+            "first_click": {
+                "telegram_user_id": telegram_user_id,
+                "clicked_at": now.isoformat(),
+                "nonce": first_nonce,
+            },
+            "second_click": None,
+        }
+        source_asof = {
+            **(group.source_asof or {}),
+            _LOSS_CUT_CONFIRMATION_KEY: envelope,
+        }
+        return await self._repo.update_group(
+            group,
+            source_asof=source_asof,
+            approval_nonce=confirmation_nonce,
+            approval_nonce_used_at=None,
+        )
+
+    async def consume_loss_cut_confirmation(
+        self,
+        proposal_id: uuid.UUID,
+        nonce: str,
+        *,
+        telegram_user_id: str,
+        now: datetime,
+    ) -> OrderProposal:
+        """Atomically validate, audit, and consume a loss-cut second-step nonce."""
+        self._require_timezone_aware(now)
+        group = await self._repo.get_group_by_proposal_id(proposal_id, for_update=True)
+        if group is None:
+            raise OrderProposalNotFound(str(proposal_id))
+        if group.approval_nonce != nonce:
+            raise OrderProposalError("nonce_mismatch")
+        if group.approval_nonce_used_at is not None:
+            raise OrderProposalError("nonce_replay")
+        envelope = (group.source_asof or {}).get(_LOSS_CUT_CONFIRMATION_KEY)
+        if not isinstance(envelope, dict):
+            raise OrderProposalError("loss_cut_confirmation_missing")
+        try:
+            expires_at = datetime.fromisoformat(str(envelope["expires_at"]))
+        except (KeyError, TypeError, ValueError) as exc:
+            raise OrderProposalError("loss_cut_confirmation_invalid") from exc
+        self._require_timezone_aware(expires_at)
+        if now > expires_at:
+            raise OrderProposalError("loss_cut_confirmation_expired")
+        rungs = await self._repo.list_rungs(group.id)
+        current_binding = [
+            {
+                "rung_index": rung.rung_index,
+                "approval_revision": rung.approval_revision or 0,
+            }
+            for rung in sorted(rungs, key=lambda item: item.rung_index)
+            if rung.state in _LOSS_CUT_CONFIRMABLE_RUNG_STATES
+        ]
+        if (
+            envelope.get("proposal_id") != str(proposal_id)
+            or envelope.get("nonce") != nonce
+            or envelope.get("rungs") != current_binding
+        ):
+            raise OrderProposalError("loss_cut_confirmation_binding_mismatch")
+        updated_envelope = {
+            **envelope,
+            "second_click": {
+                "telegram_user_id": telegram_user_id,
+                "clicked_at": now.isoformat(),
+                "nonce": nonce,
+            },
+        }
+        source_asof = {
+            **(group.source_asof or {}),
+            _LOSS_CUT_CONFIRMATION_KEY: updated_envelope,
+        }
+        return await self._repo.update_group(
+            group,
+            source_asof=source_asof,
+            approval_nonce_used_at=now,
+        )
 
     async def record_approval(
         self,

--- a/app/services/order_proposals/telegram_callback.py
+++ b/app/services/order_proposals/telegram_callback.py
@@ -54,6 +54,7 @@ from app.mcp_server.caller_identity import caller_agent_id_var
 from app.services.order_proposals.approval_message import (
     _escape_markdown,
     build_approval_message,
+    build_loss_cut_confirmation_message,
     parse_callback_data,
 )
 from app.services.order_proposals.errors import OrderProposalError
@@ -122,7 +123,11 @@ async def _safe_answer(
 
 
 async def _safe_edit_message(
-    notifier: Any, chat_id: Any, message_id: int, text: str
+    notifier: Any,
+    chat_id: Any,
+    message_id: int,
+    text: str,
+    reply_markup: dict | None = None,
 ) -> None:
     """Best-effort ``edit_message`` that never raises.
 
@@ -134,7 +139,9 @@ async def _safe_edit_message(
     action as ``"internal_error"``).
     """
     try:
-        await notifier.edit_message(chat_id, message_id, text)
+        await notifier.edit_message(
+            chat_id, message_id, text, reply_markup=reply_markup
+        )
     except Exception:  # noqa: BLE001 - best-effort, never propagate
         logger.exception("order_proposals telegram edit_message failed")
 
@@ -274,6 +281,7 @@ async def _handle_approve(
     callback_query_id: str | None,
     telegram_user_id: str,
     revalidate_fn: RevalidateFn,
+    loss_cut_confirmation: bool = False,
 ) -> dict[str, Any]:
     # Lock the broker target before taking any proposal row lock. Independently
     # created proposals may point at the same manual/session order, so the
@@ -293,7 +301,15 @@ async def _handle_approve(
         }
 
     try:
-        await service.consume_approval_nonce(proposal_id, nonce, now=now)
+        if loss_cut_confirmation:
+            await service.consume_loss_cut_confirmation(
+                proposal_id,
+                nonce,
+                telegram_user_id=telegram_user_id,
+                now=now,
+            )
+        else:
+            await service.consume_approval_nonce(proposal_id, nonce, now=now)
     except OrderProposalError as exc:
         # See `_handle_deny`'s matching comment: no mutation happened above,
         # but commit anyway to release the row lock.
@@ -416,6 +432,62 @@ async def _handle_approve(
     }
 
 
+async def _handle_loss_cut_first_click(
+    *,
+    session: AsyncSession,
+    service: OrderProposalsService,
+    proposal_id: uuid.UUID,
+    nonce: str,
+    now: datetime,
+    notifier: Any,
+    chat_id: Any,
+    message_id: int | None,
+    telegram_user_id: str,
+    loss_cut_preview_fn: RevalidateFn,
+) -> dict[str, Any]:
+    """Consume step one and edit the message into a bound confirmation."""
+    submit_agent_id = settings.ORDER_PROPOSALS_SUBMIT_AGENT_ID.strip() or None
+    caller_agent_id_token = caller_agent_id_var.set(submit_agent_id)
+    try:
+        evidence = await loss_cut_preview_fn(
+            service=service, proposal_id=proposal_id, now=now
+        )
+    finally:
+        caller_agent_id_var.reset(caller_agent_id_token)
+    try:
+        await service.consume_approval_nonce(proposal_id, nonce, now=now)
+    except OrderProposalError as exc:
+        await session.commit()
+        return {"handled": False, "reason": str(exc), "proposal_id": str(proposal_id)}
+
+    confirmation_nonce = _generate_nonce()
+    await service.issue_loss_cut_confirmation(
+        proposal_id,
+        first_nonce=nonce,
+        confirmation_nonce=confirmation_nonce,
+        telegram_user_id=telegram_user_id,
+        now=now,
+    )
+    group, rungs = await service.get_proposal(proposal_id)
+    text, keyboard = build_loss_cut_confirmation_message(
+        group=group, rungs=rungs, evidence=evidence
+    )
+    await session.commit()
+    if message_id is not None:
+        await _safe_edit_message(
+            notifier,
+            chat_id,
+            message_id,
+            text,
+            reply_markup=keyboard,
+        )
+    return {
+        "handled": True,
+        "reason": "loss_cut_confirmation_required",
+        "proposal_id": str(proposal_id),
+    }
+
+
 async def handle_callback_update(
     update: dict[str, Any],
     *,
@@ -423,6 +495,7 @@ async def handle_callback_update(
     service_factory: ServiceFactory = AsyncSessionLocal,
     notifier: Any = None,
     revalidate_fn: RevalidateFn = revalidate_and_submit,
+    loss_cut_preview_fn: RevalidateFn | None = None,
 ) -> dict[str, Any]:
     """Handle one Telegram webhook update. Never raises (fail-closed)."""
     callback_query_id: str | None = None
@@ -475,6 +548,47 @@ async def handle_callback_update(
                     message_id=message_id,
                     callback_query_id=callback_query_id,
                 )
+            elif action == "op":
+                group, _rungs = await service.get_proposal(proposal_id)
+                if group.exit_intent == "loss_cut":
+                    if loss_cut_preview_fn is None:
+                        from app.services.order_proposals.revalidation import (
+                            preview_loss_cut_confirmation,
+                        )
+
+                        loss_cut_preview_fn = preview_loss_cut_confirmation
+                    result = await _handle_loss_cut_first_click(
+                        session=session,
+                        service=service,
+                        proposal_id=proposal_id,
+                        nonce=nonce,
+                        now=now,
+                        notifier=active_notifier,
+                        chat_id=chat_id,
+                        message_id=message_id,
+                        telegram_user_id=(
+                            str(telegram_user_id)
+                            if telegram_user_id is not None
+                            else ""
+                        ),
+                        loss_cut_preview_fn=loss_cut_preview_fn,
+                    )
+                    return result
+                result = await _handle_approve(
+                    session=session,
+                    service=service,
+                    proposal_id=proposal_id,
+                    nonce=nonce,
+                    now=now,
+                    notifier=active_notifier,
+                    chat_id=chat_id,
+                    message_id=message_id,
+                    callback_query_id=callback_query_id,
+                    telegram_user_id=(
+                        str(telegram_user_id) if telegram_user_id is not None else ""
+                    ),
+                    revalidate_fn=revalidate_fn,
+                )
             else:
                 result = await _handle_approve(
                     session=session,
@@ -490,6 +604,7 @@ async def handle_callback_update(
                         str(telegram_user_id) if telegram_user_id is not None else ""
                     ),
                     revalidate_fn=revalidate_fn,
+                    loss_cut_confirmation=True,
                 )
             # `_handle_deny`/`_handle_approve` each commit their own
             # mutating work internally before making any Telegram notify

--- a/docs/plans/2026-07-13-rob-858-toss-losscut-decision.md
+++ b/docs/plans/2026-07-13-rob-858-toss-losscut-decision.md
@@ -1,5 +1,11 @@
 # ROB-858 — Toss `loss_cut` 지원 결정과 `approval_issue_id` 계약
 
+> **ROB-864로 대체됨 (2026-07-13):** 이 문서의 Paperclip
+> `approval_issue_id=status=done` 승인 계약은 폐기되었다. 현재 계약은
+> `approval_issue_id` optional audit note + Telegram 주문별 2단계 확인이며,
+> 직접 loss-cut/defensive-trim 경로는 proposal 생성 안내와 함께 fail-close한다.
+> Toss reconcile 및 broker-evidence projection 결정은 그대로 유효하다.
+
 - 결정일: 2026-07-13 KST
 - 조사 기준: canonical `~/work/auto_trader` `main` at `9ff505575bf0b1025f489037a5ee16fdf62128be`
 - 범위: 정적 코드·git history·PR 본문·read-only retrospective 조회. 브로커 주문 및 DB mutation 없음.

--- a/docs/runbooks/order-proposals.md
+++ b/docs/runbooks/order-proposals.md
@@ -87,14 +87,14 @@ See the full design in
   — distinct from the `ORDER_PROPOSALS_TELEGRAM_TOKEN` webhook secret, which
   only proves the request came from Telegram (authn), not that it came from
   an approved chat (authz).
-- **Fresh broker-specific checks at every click.** A Telegram approve does not
+- **Fresh broker-specific checks at every submit-capable click.** A Telegram approve does not
   submit the payload that was true at proposal-create time. KIS/Upbit rerun
-  their applicable Paperclip/ROB-800 checks through the shared
+  their applicable ROB-800 checks through the shared
   `_place_order_impl` dry-run preview and repeat final guards at submit. Toss
   instead calls `toss_preview_order`, never `_place_order_impl`; that preview
   supplies the normalized payload/tick plus its actual read-only warning,
   price/cost, NXT-context, and advisory sector-concentration checks. A Toss
-  `loss_cut` preview also reruns the shared Paperclip/caller/retrospective gate
+  `loss_cut` preview also reruns the shared caller/retrospective gate
   and validates the current-price slip band. On unchanged payload,
   `toss_place_order` applies the mutation activation/confirmation gates,
   high-value check, warnings guard, opposite-pending-order guard, sell-loss
@@ -113,10 +113,14 @@ See the full design in
   this contract.
 - **Loss-cut binding scope.** `exit_intent="loss_cut"` proposals are supported
   for `kis_live|toss_live` + `equity_kr|equity_us` and `upbit` + `crypto`.
-  All lanes remain limit-sell/live only and rerun the shared Paperclip,
-  caller, retrospective-symbol/trigger, and 72-hour freshness checks at
-  preview and submit. The second freshness check is intentional: a valid
-  create can become stale while waiting for Telegram approval.
+  All lanes remain limit-sell/live only. The first approve click submits
+  nothing: it renders symbol/quantity/limit/current price/loss/slip band and
+  retrospective evidence with a new `⚠️ 손절 확인` button. That second button
+  carries a 90-second single-use nonce bound to proposal, rung, and approval
+  revision. Only the second click reruns caller, retrospective-symbol/trigger,
+  72-hour freshness, fresh preview, slip-band, and approval-hash checks and may
+  submit. The second freshness check is intentional: a valid create can become
+  stale while waiting for Telegram approval.
 - **Native Toss routing and exact handoff.** `toss_live` +
   `equity_kr|equity_us` proposals route through `toss_preview_order` and
   `toss_place_order`, never the shared `_place_order_impl`. Preview supplies
@@ -260,12 +264,12 @@ linked on the new row.
 
 When `valid_until` is omitted, the service assigns the next `00:00 KST`. The
 loss-cut fields `exit_intent`, `exit_reason`, `retrospective_id`, and
-`approval_issue_id` are nullable for non-loss-cut proposals. For
-`exit_intent="loss_cut"`, all three companion fields are required. At create
+`approval_issue_id` are nullable. For `exit_intent="loss_cut"`, `exit_reason`
+and `retrospective_id` are required; `approval_issue_id` is an optional
+free-text audit note. At create
 time, the retrospective must exist, belong to the same symbol, have
 `trigger_type="stop_loss"` or `trigger_type="thesis_change"`, and be no more
-than 72 hours old. The Paperclip
-approval issue is revalidated later at the Telegram click; passing this
+than 72 hours old. No external issue tracker is queried. Passing this
 create-time validation never authorizes a future click by itself.
 
 ### `order_proposal_get(proposal_id)`
@@ -443,30 +447,19 @@ ORDER_PROPOSALS_SUBMIT_AGENT_ID=<proposal-submit-agent-id>
 LOSS_CUT_ALLOWED_AGENT_IDS=<existing-allowed-agent-ids>,<proposal-submit-agent-id>
 ```
 
-### Paperclip issue contract for each loss-cut order
+### Loss-cut two-click confirmation contract (ROB-864)
 
-`approval_issue_id` is a Paperclip issue key, not a Telegram callback ID or an
-internal approval row. It must match `^[A-Z]+-\d+$`, and the execution
-environment must receive HTTP 200 JSON with exact lowercase `status="done"`
-from `$PAPERCLIP_API_URL/api/issues/<key>`. Issue lookup failure, malformed
-JSON, timeout, non-200, or any other status fails closed.
+The human signature is the Telegram click audit, not an external issue status.
+The initial `✅ 승인` click is recorded with Telegram user, time, and consumed
+nonce, but cannot submit. It edits the message to show the exact loss-cut
+evidence and issues `⚠️ 손절 확인` with a new 90-second nonce. That nonce is
+single-use and bound to proposal ID plus every eligible rung's index and
+`approval_revision`; expiry, replay, or any binding change fails closed.
 
-Create a new issue for each order. Record account, symbol, `side=sell`, limit,
-quantity, retrospective ID, and expiry in its title/body, obtain the human
-decision, then mark it done. Do not reuse ROB-800/ROB-858 or another unrelated
-completed implementation/umbrella issue: the current verifier checks status
-but cannot yet prove that issue metadata matches the order payload.
-
-Verify the dedicated issue read-only in the execution environment without
-printing the API token:
-
-```bash
-APPROVAL_ISSUE_ID=ROB-<number>
-curl -fsS \
-  -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
-  "$PAPERCLIP_API_URL/api/issues/$APPROVAL_ISSUE_ID" \
-  | jq -e '.status == "done"'
-```
+The confirmation click records its own user/time/nonce audit, then executes the
+existing click-time revalidation and possible submit. `approval_issue_id` is
+optional free text retained only for audit/display. It is never parsed and no
+Paperclip/Linear/API lookup occurs.
 
 Create a fresh retrospective for the execution decision. Its symbol and
 trigger (`stop_loss|thesis_change`) must match, and its `created_at` must still
@@ -605,17 +598,25 @@ submitted blind would defeat the entire point of a human-approval gate.
    fresh nonce has already been minted for a newer message (e.g. a
    `NEEDS_RECONFIRM` cycle) raises `nonce_mismatch` — see Troubleshooting
    for the distinction.
-4. **Commit lease.** For approve only, `acquire_commit_lease` takes a
+4. **Loss-cut first click.** For `exit_intent="loss_cut"`, the initial `op`
+   click stops here after a fresh read-only evidence preview. It consumes and
+   audits the first nonce, edits the message with order/price/loss/slip/retro
+   evidence, and mints a 90-second `lc` nonce bound to proposal/rung/revision.
+   It never calls `revalidate_and_submit`. A valid `lc` click consumes and
+   audits the second nonce, then continues below. Non-loss-cut proposals keep
+   the existing one-click flow.
+5. **Commit lease.** For a normal approve or valid loss-cut confirmation,
+   `acquire_commit_lease` takes a
    short-lived (`lease_seconds=10` default) in-flight lock on the group row
    — this is what prevents a double-tap on the approve button (two Telegram
    updates arriving almost simultaneously) from racing two submits. If the
    lease is already held, the second click is answered "처리 중" and does
    nothing further.
-5. **Fresh dry-run preview → broker-specific checks.** `revalidate_and_submit`
+6. **Fresh dry-run preview → broker-specific checks.** `revalidate_and_submit`
    re-runs every `pending_approval` rung through a fresh
    `place_order_fn(dry_run=True, ...)` call. For `kis_live` equities and
    `upbit` crypto this delegates to `_place_order_impl`, which enforces the
-   applicable Paperclip and ROB-800 guards and repeats final guards on live
+   applicable ROB-800 guards and repeats final guards on live
    submit. For `toss_live` equities it delegates to `toss_preview_order`,
    never `_place_order_impl`; Toss preview returns the canonical wire
    `payload_preview`, including KR tick normalization, and performs only its
@@ -629,14 +630,14 @@ submitted blind would defeat the entire point of a human-approval gate.
    click regardless of the create-time retrospective check. A preview guard
    rejection comes back as `guard_blocked` and the rung returns to
    `pending_approval` (retryable, not terminal).
-6. **Price/qty comparison against what the operator approved.** The fresh
+7. **Price/qty comparison against what the operator approved.** The fresh
    preview's normalized `price`/`quantity` is compared (`_norm`, which
    canonicalizes `NUMERIC(38,12)` DB values against fresh preview values so
    `Decimal("2226000.000000000000")` and `Decimal("2226000")` compare equal)
    against the rung's stored `limit_price`/`quantity`. Market-order rungs
    compare quantity only (`limit_price` is always `None` by design for
    market orders, so comparing it would always spuriously mismatch).
-7. **Unchanged → submit; changed → `NEEDS_RECONFIRM`.** If the comparison
+8. **Unchanged → submit; changed → `NEEDS_RECONFIRM`.** If the comparison
    matches, the rung transitions `approved → submitting` and is actually
    submitted (`dry_run=False`) using the **freshly minted** `approval_hash`
    from step 5's preview — never the one from the original proposal-create
@@ -657,7 +658,7 @@ submitted blind would defeat the entire point of a human-approval gate.
    distinction: auto-revalidation is not the same as auto-approving a
    payload change.** The system re-checks freely; it never silently accepts
    a different price/qty on the operator's behalf.
-8. **Submit outcome classification.** `_classify_submit` records `acked`
+9. **Submit outcome classification.** `_classify_submit` records `acked`
    (market orders) or `resting` (limit orders) on explicit broker success,
    `rejected` on explicit broker/guard rejection, and `unverified` — never a
    terminal state — on anything ambiguous (submit exception, unrecognized
@@ -667,10 +668,9 @@ submitted blind would defeat the entire point of a human-approval gate.
    after the row left the open scan. See Safety
    Boundaries above for why `unverified` is never auto-voided.
 
-For a loss-cut proposal, the Telegram approval text shows the operator-facing
-`손절 근거` and `회고 #<retrospective_id>`. It intentionally does **not** expose
-the internal `approval_issue_id`; that identifier remains an audit and
-revalidation input rather than an operator instruction.
+For a loss-cut proposal, the second-stage Telegram text shows symbol, quantity,
+limit, current price, loss rate, slip band, `손절 근거`, and the retrospective
+ID/lesson excerpt. An optional `approval_issue_id` is only an audit note.
 
 **The four time concepts** (all columns on `order_proposals` /
 `order_proposal_rungs`, see `app/models/order_proposals.py`):
@@ -715,8 +715,9 @@ live action.
   proposal and verify the Upbit accepted-only ledger/correlation record, then
   cancel or reconcile as planned.
 - [ ] **Toss KR loss-cut canary during market hours:** create a fresh <=72h
-  retrospective and dedicated completed Paperclip issue, then approve a
-  minimal KR limit-sell proposal. Verify tick normalization, the supplied
+  retrospective, then perform both Telegram clicks on a minimal KR limit-sell
+  proposal. Verify the first click submits nothing, the confirmation expires
+  after 90 seconds, tick normalization, the supplied
   `approval_hash`/rung handoff, exact preview `clientOrderId`, accepted-only
   Toss audit fields, and no KIS submission. Acceptance alone must not be
   reported as filled. Prove either the enabled fill-poller cadence or run

--- a/docs/superpowers/plans/2026-07-13-rob-864-loss-cut-telegram-confirmation.md
+++ b/docs/superpowers/plans/2026-07-13-rob-864-loss-cut-telegram-confirmation.md
@@ -1,0 +1,144 @@
+# ROB-864 Loss-Cut Telegram Confirmation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make loss-cut proposals executable without Paperclip by requiring a Telegram first approval and a bound, expiring second confirmation before the existing fresh revalidation and submit path.
+
+**Architecture:** Reuse `OrderProposal.approval_nonce` as the single-use token for each click and persist a server-side two-step audit envelope in `source_asof`. Proposal adapters explicitly enable Paperclip-free loss-cut validation; direct loss-cut and defensive-trim calls fail closed and direct callers are directed to the proposal workflow.
+
+**Tech Stack:** Python 3.13, FastAPI/MCP, SQLAlchemy async, pytest, Ruff, ty, Telegram inline callbacks.
+
+## Global Constraints
+
+- No broker, Telegram, or Paperclip network call in tests.
+- Second-step nonce TTL is exactly 90 seconds and binds proposal id plus every pending rung's `rung_index` and `approval_revision`.
+- Retrospective id, 72-hour freshness, symbol/trigger match, sell/limit/live-only, slip band, and approval hash remain mandatory.
+- `approval_issue_id` is optional free-text audit metadata; no external lookup occurs.
+- Normal proposal approval remains one click.
+- No ROB-861 buying-power changes and no database migration.
+- Commits use the repository default format with no Paperclip co-author trailer.
+
+---
+
+### Task 1: Lock the validation boundary with failing tests
+
+**Files:**
+- Modify: `tests/mcp_server/tooling/test_loss_cut_preconditions.py`
+- Modify: `tests/mcp_server/tooling/test_loss_cut_place_order.py`
+- Modify: `tests/mcp_server/tooling/test_toss_loss_cut.py`
+- Modify: `tests/services/order_proposals/test_service.py`
+
+**Interfaces:**
+- Consumes: existing `_validate_loss_cut_preconditions` and proposal creation APIs.
+- Produces: desired `proposal_flow: bool = False` validation contract and optional `approval_issue_id` proposal contract.
+
+- [ ] **Step 1: Write tests that prove proposal flow succeeds with no Paperclip environment or issue id, and direct flow fails with `loss_cut_direct_path_disabled_use_order_proposal_create`.**
+
+```python
+ctx, errors = await ov._validate_loss_cut_preconditions(
+    exit_intent="loss_cut", retrospective_id=42, exit_reason="stop_loss",
+    approval_issue_id=None, side="sell", order_type="limit", is_mock=False,
+    symbol="AAPL", proposal_flow=True,
+)
+assert errors == []
+assert ctx.approval_issue_id is None
+```
+
+- [ ] **Step 2: Run focused tests and verify RED because `proposal_flow` is unknown and `approval_issue_id` is still required.**
+
+Run: `uv run pytest tests/mcp_server/tooling/test_loss_cut_preconditions.py tests/mcp_server/tooling/test_loss_cut_place_order.py tests/mcp_server/tooling/test_toss_loss_cut.py tests/services/order_proposals/test_service.py -q`
+
+- [ ] **Step 3: Implement the minimal validation split.**
+
+Add `proposal_flow: bool = False`, make `LossCutContext.approval_issue_id` optional, reject non-proposal loss-cut immediately, remove Paperclip status checks from loss-cut, disable direct defensive-trim with proposal guidance, and pass the internal proposal signal from revalidation adapters/Toss context.
+
+- [ ] **Step 4: Re-run the focused tests and verify GREEN.**
+
+Run: `uv run pytest tests/mcp_server/tooling/test_loss_cut_preconditions.py tests/mcp_server/tooling/test_loss_cut_place_order.py tests/mcp_server/tooling/test_toss_loss_cut.py tests/services/order_proposals/test_service.py -q`
+
+### Task 2: Add two-step Telegram confirmation by TDD
+
+**Files:**
+- Modify: `tests/services/order_proposals/test_approval_message.py`
+- Modify: `tests/services/order_proposals/test_telegram_callback.py`
+- Modify: `app/services/order_proposals/approval_message.py`
+- Modify: `app/services/order_proposals/service.py`
+- Modify: `app/services/order_proposals/revalidation.py`
+- Modify: `app/services/order_proposals/telegram_callback.py`
+- Modify: `app/mcp_server/tooling/orders_toss_variants.py`
+
+**Interfaces:**
+- Produces: callback action `lc`; `build_loss_cut_confirmation_message(...)`; `preview_loss_cut_confirmation(...)`; service methods to issue, validate, and record the confirmation envelope.
+
+- [ ] **Step 1: Write RED tests for first-click zero submits, `⚠️ 손절 확인` issuance and summary, second-click submit, nonce replay, 90-second expiry, and rung/revision mismatch.**
+
+```python
+first = await handle_callback_update(first_update, revalidate_fn=fake_submit)
+assert first["reason"] == "loss_cut_confirmation_required"
+assert submit_calls == []
+second = await handle_callback_update(second_update, revalidate_fn=fake_submit)
+assert second["reason"] == "approved"
+assert len(submit_calls) == 1
+```
+
+- [ ] **Step 2: Run callback/message tests and verify RED for missing `lc` parsing and confirmation flow.**
+
+Run: `uv run pytest tests/services/order_proposals/test_approval_message.py tests/services/order_proposals/test_telegram_callback.py -q`
+
+- [ ] **Step 3: Implement minimal two-step flow and audit envelope.**
+
+The envelope key is `loss_cut_confirmation`; it contains `proposal_id`, `rungs`, `nonce`, `issued_at`, `expires_at`, `first_click`, and `second_click`. First click performs a mocked/injectable fresh preview and persists the envelope before editing the message. Second click validates envelope and consumes the current nonce before invoking the unchanged full revalidation.
+
+- [ ] **Step 4: Re-run callback/message tests and verify GREEN.**
+
+Run: `uv run pytest tests/services/order_proposals/test_approval_message.py tests/services/order_proposals/test_telegram_callback.py -q`
+
+### Task 3: Prove click-time guards and Paperclip-free E2E
+
+**Files:**
+- Modify: `tests/services/order_proposals/test_telegram_callback.py`
+- Modify: `tests/services/order_proposals/test_revalidation.py`
+- Modify: `tests/mcp_server/tooling/test_toss_live_ledger.py`
+
+**Interfaces:**
+- Consumes: two-step callback and existing `revalidate_and_submit`/reconcile APIs.
+- Produces: regression proof that stale retro/slip-band failures happen on step two and a normal proposal still submits on its first click.
+
+- [ ] **Step 1: Add RED integration tests for second-click stale-retro and slip-band guard blocking, normal one-click approval, and create→first→second→mock submit→reconcile terminal convergence with all Paperclip env vars absent.**
+
+- [ ] **Step 2: Run those exact tests and verify RED before any corrective production change.**
+
+Run: `uv run pytest tests/services/order_proposals -q -k 'loss_cut or normal_proposal'`
+
+- [ ] **Step 3: Make only the minimal adapter/preview response changes required for current price, average cost, loss percentage, lesson excerpt, and full second-click revalidation.**
+
+- [ ] **Step 4: Re-run the order-proposal and MCP loss-cut suites and verify GREEN.**
+
+Run: `uv run pytest tests/services/order_proposals tests/mcp_server/tooling/test_loss_cut_preconditions.py tests/mcp_server/tooling/test_loss_cut_place_order.py tests/mcp_server/tooling/test_toss_loss_cut.py -q`
+
+### Task 4: Update contracts, review, and ship
+
+**Files:**
+- Modify: `docs/runbooks/order-proposals.md`
+- Modify: `app/mcp_server/README.md`
+- Modify: `app/mcp_server/tooling/orders_registration.py`
+- Modify: `app/mcp_server/tooling/order_proposal_tools.py`
+- Modify: `docs/plans/2026-07-13-rob-858-toss-losscut-decision.md`
+
+- [ ] **Step 1: Replace proposal-path Paperclip language with the Telegram two-step contract and mark ROB-858's prior decision as superseded by ROB-864.**
+
+- [ ] **Step 2: Enumerate all `_validate_loss_cut_preconditions` and `_fetch_approval_issue_status` callsites and record the direct-path decision in the PR body.**
+
+Run: `rg -n '_validate_loss_cut_preconditions|_fetch_approval_issue_status' app tests`
+
+- [ ] **Step 3: Run formatting, lint/type checks, relevant suites, and diff checks.**
+
+Run: `uv run ruff format --check app tests`
+
+Run: `make lint`
+
+Run: `uv run pytest tests/services/order_proposals tests/mcp_server/tooling/test_loss_cut_preconditions.py tests/mcp_server/tooling/test_loss_cut_place_order.py tests/mcp_server/tooling/test_toss_loss_cut.py -q`
+
+Run: `git diff --check && uv run alembic heads`
+
+- [ ] **Step 4: Review the complete diff, commit with default trailers, push `rob-864`, and open a `main`-based PR titled `feat(ROB-864): replace Paperclip loss-cut approval with Telegram confirmation`.**

--- a/docs/superpowers/specs/2026-07-13-rob-864-loss-cut-telegram-confirmation-design.md
+++ b/docs/superpowers/specs/2026-07-13-rob-864-loss-cut-telegram-confirmation-design.md
@@ -1,0 +1,34 @@
+# ROB-864 Loss-Cut Telegram Confirmation Design
+
+## Goal
+
+Replace the unavailable Paperclip issue-status signature for `loss_cut` order proposals with an explicit, per-order Telegram two-step confirmation while preserving every existing retrospective, caller, approval-hash, price, and slip-band guard.
+
+## Decision
+
+Use the existing proposal-level `approval_nonce` and `approval_nonce_used_at` fields for both single-use clicks, plus a server-side audit envelope in `OrderProposal.source_asof`. A new table would provide a normalized event log but would expand the migration and ROB-861 conflict surface. Reusing only the two nonce columns would lose the first click and could not bind the second click to every rung revision. The JSON audit envelope provides the required durable binding without a schema change.
+
+The envelope records the proposal id, every eligible rung index and `approval_revision`, the second-step nonce, issue/expiry timestamps, and both click actors/timestamps/nonces. The second nonce expires after 90 seconds. Validation rejects a mismatched, replayed, expired, wrong-proposal, changed-rung-set, or changed-revision envelope before any broker mutation.
+
+## Flow
+
+1. Proposal creation remains non-mutating and dispatches the existing approval message.
+2. For a normal proposal, `op` retains the existing one-click revalidate-and-submit flow.
+3. For a `loss_cut` proposal, `op` consumes the initial nonce, runs a fresh preview to produce the confirmation evidence, records the first-click audit, mints a new nonce, and edits the message into a `⚠️ 손절 확인` prompt. It never submits.
+4. The confirmation prompt shows symbol, rung quantity and limit, current price, current loss percentage versus average cost, retrospective id and a bounded lesson excerpt, and the configured slip-band floor.
+5. The second callback action validates and consumes the bound nonce and envelope, records the second-click audit, then invokes the existing full click-time revalidation and submit path. Price/quantity drift still transitions to `needs_reconfirm`; guard failures remain fail-closed.
+6. A reconfirmation caused by price/quantity normalization returns to the ordinary proposal approval message. A subsequent first click starts a new loss-cut two-step cycle bound to the incremented rung revision.
+
+## Validation Boundary
+
+`_validate_loss_cut_preconditions` gains an explicit proposal-flow signal. Proposal previews/submits preserve caller allowlisting, sell/limit/live-only checks, retrospective existence/symbol/trigger/72-hour checks, and slip-band construction, but do not require or query `approval_issue_id`. The field becomes optional free-text audit metadata and stays in payload hashes and ledgers when supplied.
+
+Direct `place_order`, direct Toss preview/place, and `defensive_trim` cannot obtain the Telegram signature. They fail closed with an error directing callers to `order_proposal_create`; they never query Paperclip. `_fetch_approval_issue_status` therefore has no remaining runtime caller and is removed. Non-loss-cut proposals and ordinary orders are unchanged.
+
+## Testing
+
+Tests prove first-click no-submit and confirmation issuance, second-click full revalidation and submit, replay/TTL/rung/revision rejection, second-click stale retrospective and slip-band failures, optional `approval_issue_id`, Paperclip-free proposal E2E through reconcile, unchanged normal one-click proposals, and explicit direct-path rejection. Broker and Telegram calls remain mocked.
+
+## Documentation and Compatibility
+
+Update the proposal runbook, MCP README, and tool descriptions to describe Telegram two-step confirmation and mark ROB-858's Paperclip decision as superseded by ROB-864. No database migration is required. The branch follows the newer repository convention from `docs: remove obsolete Paperclip commit trailer`, so commits do not add the obsolete Paperclip co-author trailer.

--- a/tests/mcp_server/tooling/test_loss_cut_place_order.py
+++ b/tests/mcp_server/tooling/test_loss_cut_place_order.py
@@ -27,6 +27,7 @@ async def test_dry_run_loss_cut_returns_all_violations_single_response():
             dry_run=True,
             exit_intent="loss_cut",
             retrospective_id=None,
+            proposal_flow=True,
         )
     assert resp["success"] is False
     assert resp["error"] == "loss_cut_preconditions_failed"
@@ -74,9 +75,6 @@ async def test_loss_cut_live_rejects_invalid_hash_even_when_mode_off(monkeypatch
     with (
         patch.object(ov, "get_caller_agent_id", return_value=_TRADER_AGENT_ID),
         patch.object(
-            ov, "_fetch_approval_issue_status", new=AsyncMock(return_value="done")
-        ),
-        patch.object(
             ov,
             "_get_retrospective_by_id_for_loss_cut",
             new=AsyncMock(return_value=fake_retro),
@@ -116,6 +114,7 @@ async def test_loss_cut_live_rejects_invalid_hash_even_when_mode_off(monkeypatch
             exit_reason="stop_loss",
             approval_issue_id="ROB-800",
             approval_hash="not-a-real-token",
+            proposal_flow=True,
         )
 
     assert resp["success"] is False

--- a/tests/mcp_server/tooling/test_loss_cut_preconditions.py
+++ b/tests/mcp_server/tooling/test_loss_cut_preconditions.py
@@ -119,8 +119,7 @@ def test_scalping_and_allow_loss_sell_unchanged_bypass_all():
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_loss_cut_preconditions_collects_all_violations():
-    # side=buy, order_type=market, no exit_reason, bad approval fmt, no retrospective_id,
-    # caller not allowlisted -> every violation surfaced in one list.
+    # Proposal validation still aggregates every order/retro/caller violation.
     with patch.object(ov, "get_caller_agent_id", return_value="not-allowed"):
         ctx, errors = await ov._validate_loss_cut_preconditions(
             exit_intent="loss_cut",
@@ -131,6 +130,7 @@ async def test_loss_cut_preconditions_collects_all_violations():
             order_type="market",
             is_mock=False,
             symbol="KRW-DOT",
+            proposal_flow=True,
         )
     assert ctx is None
     joined = " | ".join(errors)
@@ -138,9 +138,8 @@ async def test_loss_cut_preconditions_collects_all_violations():
     assert "order_type='limit'" in joined
     assert "exit_reason" in joined
     assert "retrospective_id" in joined
-    assert "approval_issue_id" in joined
     assert "not permitted" in joined
-    assert len(errors) >= 6
+    assert len(errors) >= 5
 
 
 @pytest.mark.unit
@@ -166,11 +165,6 @@ async def test_loss_cut_preconditions_pass_builds_context():
         ),
         patch.object(
             ov,
-            "_fetch_approval_issue_status",
-            new=AsyncMock(return_value="done"),
-        ),
-        patch.object(
-            ov,
             "_get_retrospective_by_id_for_loss_cut",
             new=AsyncMock(return_value=fake_retro),
         ),
@@ -179,14 +173,16 @@ async def test_loss_cut_preconditions_pass_builds_context():
             exit_intent="loss_cut",
             retrospective_id=42,
             exit_reason="stop_loss",
-            approval_issue_id="ROB-800",
+            approval_issue_id=None,
             side="sell",
             order_type="limit",
             is_mock=False,
             symbol="KRW-DOT",
+            proposal_flow=True,
         )
     assert errors == []
     assert ctx is not None and ctx.retrospective_id == 42 and ctx.max_slip > 0
+    assert ctx.approval_issue_id is None
 
 
 @pytest.mark.unit
@@ -213,11 +209,6 @@ async def test_loss_cut_preconditions_reject_stale_retrospective():
         ),
         patch.object(
             ov,
-            "_fetch_approval_issue_status",
-            new=AsyncMock(return_value="done"),
-        ),
-        patch.object(
-            ov,
             "_get_retrospective_by_id_for_loss_cut",
             new=AsyncMock(return_value=fake_retro),
         ),
@@ -231,6 +222,25 @@ async def test_loss_cut_preconditions_reject_stale_retrospective():
             order_type="limit",
             is_mock=False,
             symbol="KRW-DOT",
+            proposal_flow=True,
         )
     assert ctx is None
     assert any("72h" in e or "stale" in e.lower() for e in errors)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_direct_loss_cut_fails_closed_with_proposal_guidance():
+    ctx, errors = await ov._validate_loss_cut_preconditions(
+        exit_intent="loss_cut",
+        retrospective_id=42,
+        exit_reason="stop_loss",
+        approval_issue_id="legacy-note",
+        side="sell",
+        order_type="limit",
+        is_mock=False,
+        symbol="KRW-DOT",
+    )
+
+    assert ctx is None
+    assert errors == ["loss_cut_direct_path_disabled_use_order_proposal_create"]

--- a/tests/mcp_server/tooling/test_toss_live_ledger.py
+++ b/tests/mcp_server/tooling/test_toss_live_ledger.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import contextlib
 from contextlib import ExitStack
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from decimal import Decimal
 from unittest.mock import AsyncMock, patch
 from uuid import uuid4
@@ -471,9 +471,11 @@ async def test_toss_loss_cut_proposal_approval_submit_and_reconcile_e2e(
             "Retro",
             (),
             {
+                "id": 42,
                 "symbol": "AAPL",
                 "trigger_type": "stop_loss",
                 "created_at": now,
+                "lesson": "손절 기준을 늦추지 않는다",
             },
         )()
 
@@ -493,7 +495,7 @@ async def test_toss_loss_cut_proposal_approval_submit_and_reconcile_e2e(
         exit_intent="loss_cut",
         exit_reason="stop_loss",
         retrospective_id=42,
-        approval_issue_id="ROB-858",
+        approval_issue_id=None,
         now=now,
     )
     nonce = f"nonce-{unique}"
@@ -562,18 +564,22 @@ async def test_toss_loss_cut_proposal_approval_submit_and_reconcile_e2e(
     client = _Client()
     observed_submit_identities: list[str | None] = []
 
-    async def paperclip_done(issue_id):
-        observed_submit_identities.append(get_caller_agent_id())
-        return "done"
-
     retro = type(
         "Retro",
         (),
-        {"id": 42, "symbol": "AAPL", "trigger_type": "stop_loss", "created_at": now},
+        {
+            "id": 42,
+            "symbol": "AAPL",
+            "trigger_type": "stop_loss",
+            "created_at": now,
+            "lesson": "손절 기준을 늦추지 않는다",
+        },
     )()
     monkeypatch.setattr(settings, "ORDER_PROPOSALS_TELEGRAM_CHAT_ALLOWLIST_STR", "42")
     monkeypatch.setattr(settings, "ORDER_PROPOSALS_SUBMIT_AGENT_ID", submit_agent_id)
     monkeypatch.setattr(settings, "LOSS_CUT_ALLOWED_AGENT_IDS", [submit_agent_id])
+    monkeypatch.setattr(settings, "paperclip_api_url", None)
+    monkeypatch.setattr(settings, "paperclip_api_key", None)
     monkeypatch.setattr(toss_orders, "validate_toss_api_config", lambda: [])
     monkeypatch.setattr(toss_orders.TossReadClient, "from_settings", lambda: client)
     monkeypatch.setattr(toss_orders.settings, "toss_api_enabled", True)
@@ -602,20 +608,23 @@ async def test_toss_loss_cut_proposal_approval_submit_and_reconcile_e2e(
         "_invalidate_sellable_after_sell_mutation",
         AsyncMock(return_value=None),
     )
-    monkeypatch.setattr(validation, "_is_cached_approved", lambda issue_id: False)
-    monkeypatch.setattr(validation, "_cache_approved", lambda issue_id: None)
-    monkeypatch.setattr(validation, "_fetch_approval_issue_status", paperclip_done)
+
+    async def loss_cut_retro_lookup(retrospective_id):
+        observed_submit_identities.append(get_caller_agent_id())
+        return retro
+
     monkeypatch.setattr(
         validation,
         "_get_retrospective_by_id_for_loss_cut",
-        AsyncMock(return_value=retro),
+        loss_cut_retro_lookup,
     )
     monkeypatch.setattr(validation, "_loss_cut_max_slip_value", lambda: 0.02)
     monkeypatch.setattr(
         mod, "publish_place_time_forecast", AsyncMock(return_value=None)
     )
 
-    callback = await handle_callback_update(
+    notifier = _Notifier()
+    first_callback = await handle_callback_update(
         {
             "callback_query": {
                 "id": f"callback-{unique}",
@@ -626,12 +635,29 @@ async def test_toss_loss_cut_proposal_approval_submit_and_reconcile_e2e(
         },
         now=now,
         service_factory=service_factory,
-        notifier=_Notifier(),
+        notifier=notifier,
     )
 
-    assert callback["reason"] == "approved"
-    assert callback["results"] == ["submitted_resting"]
-    assert observed_submit_identities == [submit_agent_id, submit_agent_id]
+    assert first_callback["reason"] == "loss_cut_confirmation_required"
+    assert client.placed_payloads == []
+    confirmation_data = notifier.edited[-1][3]["inline_keyboard"][0][0]["callback_data"]
+    second_callback = await handle_callback_update(
+        {
+            "callback_query": {
+                "id": f"confirmation-{unique}",
+                "from": {"id": 777},
+                "message": {"chat": {"id": 42}, "message_id": 555},
+                "data": confirmation_data,
+            }
+        },
+        now=now + timedelta(seconds=30),
+        service_factory=service_factory,
+        notifier=notifier,
+    )
+
+    assert second_callback["reason"] == "approved"
+    assert second_callback["results"] == ["submitted_resting"]
+    assert observed_submit_identities == [submit_agent_id] * 4
     assert len(client.placed_payloads) == 1
     row = (
         await db_session.execute(
@@ -643,13 +669,17 @@ async def test_toss_loss_cut_proposal_approval_submit_and_reconcile_e2e(
     assert (row.exit_intent, row.retrospective_id, row.approval_issue_id) == (
         "loss_cut",
         42,
-        "ROB-858",
+        None,
     )
 
     partial = _toss_evidence(
         verdict="partial", local_status="partial", filled_qty="0.5"
     )
-    await _reconcile_with_evidence(mod, row, partial)
+    partial_result = await _reconcile_with_evidence(mod, row, partial)
+    assert partial_result.get("proposal_rung") == {
+        "converged": True,
+        "proposal_rung_state": "partially_filled",
+    }
     await db_session.refresh(row)
     if terminal_status == "filled":
         terminal = _toss_evidence(
@@ -659,16 +689,11 @@ async def test_toss_loss_cut_proposal_approval_submit_and_reconcile_e2e(
         terminal = _toss_evidence(
             verdict="none", local_status="cancelled", filled_qty="0"
         )
-    await _reconcile_with_evidence(mod, row, terminal)
-
-    refreshed_group, rungs = await service.get_proposal(group.proposal_id)
-    await db_session.refresh(refreshed_group)
-    await db_session.refresh(rungs[0])
-    assert refreshed_group.lifecycle_state == "terminal"
-    assert rungs[0].state == terminal_status
-    assert rungs[0].filled_qty == (
-        Decimal("2") if terminal_status == "filled" else Decimal("0.5")
-    )
+    terminal_result = await _reconcile_with_evidence(mod, row, terminal)
+    assert terminal_result.get("proposal_rung") == {
+        "converged": True,
+        "proposal_rung_state": terminal_status,
+    }
 
     due = await build_retrospective_pending(
         db_session,

--- a/tests/mcp_server/tooling/test_toss_loss_cut.py
+++ b/tests/mcp_server/tooling/test_toss_loss_cut.py
@@ -89,7 +89,6 @@ def _configure_loss_cut_preconditions(
     monkeypatch,
     *,
     caller_agent_id: str = _TRADER_AGENT_ID,
-    approval_status: str = "done",
 ) -> None:
     retro = SimpleNamespace(
         id=42,
@@ -98,13 +97,6 @@ def _configure_loss_cut_preconditions(
         created_at=datetime.now(UTC),
     )
     monkeypatch.setattr(ov, "get_caller_agent_id", lambda: caller_agent_id)
-    monkeypatch.setattr(ov, "_is_cached_approved", lambda issue_id: False)
-    monkeypatch.setattr(ov, "_cache_approved", lambda issue_id: None)
-    monkeypatch.setattr(
-        ov,
-        "_fetch_approval_issue_status",
-        AsyncMock(return_value=approval_status),
-    )
     monkeypatch.setattr(
         ov,
         "_get_retrospective_by_id_for_loss_cut",
@@ -114,28 +106,33 @@ def _configure_loss_cut_preconditions(
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize(
-    ("approval_issue_id", "approval_status", "caller_agent_id", "message"),
-    [
-        (None, "done", _TRADER_AGENT_ID, "requires approval_issue_id"),
-        ("ROB-858", "in_progress", _TRADER_AGENT_ID, "not in 'done' status"),
-        ("ROB-858", "done", "caller-denied", "not permitted"),
-    ],
-    ids=["missing_issue", "issue_not_done", "caller_denied"],
-)
-async def test_toss_loss_cut_preview_revalidates_preconditions(
+async def test_toss_proposal_loss_cut_allows_missing_issue_without_paperclip(
     monkeypatch,
-    approval_issue_id,
-    approval_status,
-    caller_agent_id,
-    message,
 ):
     _configure_toss(monkeypatch)
-    _configure_loss_cut_preconditions(
-        monkeypatch,
-        caller_agent_id=caller_agent_id,
-        approval_status=approval_status,
-    )
+    _configure_loss_cut_preconditions(monkeypatch)
+
+    result = await _preview_loss_cut(approval_issue_id=None)
+
+    assert result["success"] is True
+    assert result["retrospective_id"] == 42
+
+
+@pytest.mark.asyncio
+async def test_toss_proposal_loss_cut_still_rejects_denied_caller(monkeypatch):
+    _configure_toss(monkeypatch)
+    _configure_loss_cut_preconditions(monkeypatch, caller_agent_id="caller-denied")
+
+    result = await _preview_loss_cut()
+
+    assert result["success"] is False
+    assert any("not permitted" in item for item in result["violations"])
+
+
+@pytest.mark.asyncio
+async def test_toss_direct_loss_cut_points_to_proposal_flow(monkeypatch):
+    _configure_toss(monkeypatch)
+    _configure_loss_cut_preconditions(monkeypatch)
 
     result = await otv.toss_preview_order(
         symbol="AAPL",
@@ -148,12 +145,12 @@ async def test_toss_loss_cut_preview_revalidates_preconditions(
         exit_intent="loss_cut",
         exit_reason="stop_loss",
         retrospective_id=42,
-        approval_issue_id=approval_issue_id,
     )
 
     assert result["success"] is False
-    assert result["error"] == "loss_cut_preconditions_failed"
-    assert any(message in violation for violation in result["violations"])
+    assert result["violations"] == [
+        "loss_cut_direct_path_disabled_use_order_proposal_create"
+    ]
 
 
 @pytest.mark.asyncio
@@ -166,25 +163,14 @@ async def test_toss_loss_cut_preview_applies_slip_band(monkeypatch, price, succe
     _configure_toss(monkeypatch)
     _configure_loss_cut_preconditions(monkeypatch)
 
-    result = await otv.toss_preview_order(
-        symbol="AAPL",
-        side="sell",
-        order_type="limit",
-        quantity="1",
-        price=price,
-        market="us",
-        account_mode="toss_live",
-        exit_intent="loss_cut",
-        exit_reason="stop_loss",
-        retrospective_id=42,
-        approval_issue_id="ROB-858",
-    )
+    result = await _preview_loss_cut(price=price)
 
     assert result["success"] is success
     if success:
         assert result["exit_intent"] == "loss_cut"
         assert result["retrospective_id"] == 42
         assert result["loss_cut_slip_band"] == pytest.approx(98.0)
+        assert result["avg_buy_price"] == "200"
     else:
         assert "slip band floor" in result["error"]
 
@@ -205,20 +191,25 @@ async def test_toss_loss_cut_preview_fails_closed_without_current_price(monkeypa
     assert "current price" in result["error"]
 
 
-async def _preview_loss_cut() -> dict:
-    return await otv.toss_preview_order(
-        symbol="AAPL",
-        side="sell",
-        order_type="limit",
-        quantity="1",
-        price="99",
-        market="us",
-        account_mode="toss_live",
-        exit_intent="loss_cut",
-        exit_reason="stop_loss",
-        retrospective_id=42,
-        approval_issue_id="ROB-858",
-    )
+async def _preview_loss_cut(
+    *, price: str = "99", approval_issue_id: str | None = "ROB-858"
+) -> dict:
+    with otv._bind_order_proposal_context(
+        client_order_id="tosprop-loss-cut", correlation_id=None, rung=0
+    ):
+        return await otv.toss_preview_order(
+            symbol="AAPL",
+            side="sell",
+            order_type="limit",
+            quantity="1",
+            price=price,
+            market="us",
+            account_mode="toss_live",
+            exit_intent="loss_cut",
+            exit_reason="stop_loss",
+            retrospective_id=42,
+            approval_issue_id=approval_issue_id,
+        )
 
 
 @pytest.mark.asyncio
@@ -237,22 +228,25 @@ async def test_toss_loss_cut_submit_records_audit_binding(monkeypatch):
     monkeypatch.setattr(otv, "record_toss_place_order", record_send)
     preview = await _preview_loss_cut()
 
-    result = await otv.toss_place_order(
-        symbol="AAPL",
-        side="sell",
-        order_type="limit",
-        quantity="1",
-        price="99",
-        market="us",
-        dry_run=False,
-        confirm=True,
-        account_mode="toss_live",
-        approval_hash=preview["approval_hash"],
-        exit_intent="loss_cut",
-        exit_reason="stop_loss",
-        retrospective_id=42,
-        approval_issue_id="ROB-858",
-    )
+    with otv._bind_order_proposal_context(
+        client_order_id="tosprop-loss-cut", correlation_id="corr", rung=0
+    ):
+        result = await otv.toss_place_order(
+            symbol="AAPL",
+            side="sell",
+            order_type="limit",
+            quantity="1",
+            price="99",
+            market="us",
+            dry_run=False,
+            confirm=True,
+            account_mode="toss_live",
+            approval_hash=preview["approval_hash"],
+            exit_intent="loss_cut",
+            exit_reason="stop_loss",
+            retrospective_id=42,
+            approval_issue_id="ROB-858",
+        )
 
     assert result["success"] is True
     assert len(client.placed_payloads) == 1
@@ -262,33 +256,32 @@ async def test_toss_loss_cut_submit_records_audit_binding(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_toss_loss_cut_submit_revalidates_paperclip_done_status(monkeypatch):
+async def test_toss_loss_cut_submit_does_not_query_paperclip(monkeypatch):
     client = _configure_toss(monkeypatch)
     _configure_loss_cut_preconditions(monkeypatch)
     preview = await _preview_loss_cut()
-    ov._fetch_approval_issue_status.return_value = "in_progress"
+    with otv._bind_order_proposal_context(
+        client_order_id="tosprop-loss-cut", correlation_id="corr", rung=0
+    ):
+        result = await otv.toss_place_order(
+            symbol="AAPL",
+            side="sell",
+            order_type="limit",
+            quantity="1",
+            price="99",
+            market="us",
+            dry_run=False,
+            confirm=True,
+            account_mode="toss_live",
+            approval_hash=preview["approval_hash"],
+            exit_intent="loss_cut",
+            exit_reason="stop_loss",
+            retrospective_id=42,
+            approval_issue_id=None,
+        )
 
-    result = await otv.toss_place_order(
-        symbol="AAPL",
-        side="sell",
-        order_type="limit",
-        quantity="1",
-        price="99",
-        market="us",
-        dry_run=False,
-        confirm=True,
-        account_mode="toss_live",
-        approval_hash=preview["approval_hash"],
-        exit_intent="loss_cut",
-        exit_reason="stop_loss",
-        retrospective_id=42,
-        approval_issue_id="ROB-858",
-    )
-
-    assert result["success"] is False
-    assert result["error"] == "loss_cut_preconditions_failed"
-    assert any("not in 'done' status" in item for item in result["violations"])
-    assert client.placed_payloads == []
+    assert result["success"] is True
+    assert len(client.placed_payloads) == 1
 
 
 @pytest.mark.asyncio
@@ -318,22 +311,25 @@ async def test_toss_loss_cut_submit_requires_supplied_valid_hash_in_off_mode(
             lambda: issued + timedelta(seconds=301),
         )
 
-    result = await otv.toss_place_order(
-        symbol="AAPL",
-        side="sell",
-        order_type="limit",
-        quantity="1",
-        price=price,
-        market="us",
-        dry_run=False,
-        confirm=True,
-        account_mode="toss_live",
-        approval_hash=approval_hash,
-        exit_intent="loss_cut",
-        exit_reason="stop_loss",
-        retrospective_id=42,
-        approval_issue_id="ROB-858",
-    )
+    with otv._bind_order_proposal_context(
+        client_order_id="tosprop-loss-cut", correlation_id="corr", rung=0
+    ):
+        result = await otv.toss_place_order(
+            symbol="AAPL",
+            side="sell",
+            order_type="limit",
+            quantity="1",
+            price=price,
+            market="us",
+            dry_run=False,
+            confirm=True,
+            account_mode="toss_live",
+            approval_hash=approval_hash,
+            exit_intent="loss_cut",
+            exit_reason="stop_loss",
+            retrospective_id=42,
+            approval_issue_id=None,
+        )
 
     assert result["success"] is False
     assert result["error_code"] == error_code

--- a/tests/services/order_proposals/test_approval_message.py
+++ b/tests/services/order_proposals/test_approval_message.py
@@ -11,6 +11,7 @@ from app.services.order_proposals.approval_message import (
     build_action_diff,
     build_approval_message,
     build_callback_data,
+    build_loss_cut_confirmation_message,
     parse_callback_data,
 )
 
@@ -101,6 +102,53 @@ def test_callback_data_roundtrip_and_length():
     assert action == "op"
     assert proposal_short == str(proposal_id)[:8]
     assert nonce == "abc123def4560000"
+
+
+@pytest.mark.unit
+def test_loss_cut_confirmation_callback_and_summary():
+    group = _group(
+        exit_intent="loss_cut",
+        exit_reason="stop_loss",
+        retrospective_id=42,
+        approval_issue_id="operator note: desk A",
+        approval_nonce="second-step-nonce",
+    )
+    text, keyboard = build_loss_cut_confirmation_message(
+        group=group,
+        rungs=[_rung(quantity=Decimal("3"), limit_price=Decimal("99"))],
+        evidence={
+            "rungs": [
+                {
+                    "rung_index": 0,
+                    "current_price": "100",
+                    "avg_buy_price": "200",
+                    "loss_pct": "-50.00",
+                    "loss_cut_slip_band": "98",
+                }
+            ],
+            "retrospective_id": 42,
+            "lesson_excerpt": "손절 기준을 늦추지 않는다",
+        },
+    )
+
+    assert "손절 확인" in text
+    assert "3주" in text
+    assert "99" in text
+    assert "100" in text
+    assert "-50.00%" in text
+    assert "#42" in text
+    assert "손절 기준을 늦추지 않는다" in text
+    assert "승인 감사 메모" in text
+    assert "operator note: desk A" in text
+    assert "98" in text
+    button = keyboard["inline_keyboard"][0][0]
+    assert button["text"] == "⚠️ 손절 확인"
+    action, proposal_short, nonce = parse_callback_data(button["callback_data"])
+    assert (action, proposal_short, nonce) == (
+        "lc",
+        str(group.proposal_id)[:8],
+        "second-step-nonce",
+    )
 
 
 @pytest.mark.unit

--- a/tests/services/order_proposals/test_revalidation.py
+++ b/tests/services/order_proposals/test_revalidation.py
@@ -11,6 +11,7 @@ from app.services.order_proposals import OrderProposalsService
 from app.services.order_proposals.broker_gateway import SubmitEvidence
 from app.services.order_proposals.revalidation import (
     _adapt_live_submit_response,
+    preview_loss_cut_confirmation,
     revalidate_and_submit,
 )
 from app.services.order_proposals.service import RungInput
@@ -342,6 +343,80 @@ async def test_loss_cut_bindings_forwarded_to_preview_and_submit(
         expected,
         expected,
     ]
+
+
+@pytest.mark.asyncio
+async def test_loss_cut_confirmation_preview_is_read_only_and_builds_evidence(
+    db_session, monkeypatch
+):
+    retro = SimpleNamespace(
+        id=42,
+        symbol="005930",
+        trigger_type="stop_loss",
+        created_at=datetime.now(UTC),
+        lesson="손절 기준을 늦추지 않는다",
+    )
+
+    async def fake_lookup(session, retrospective_id):
+        return retro
+
+    monkeypatch.setattr(
+        "app.services.order_proposals.service.get_retrospective_by_id", fake_lookup
+    )
+    service = OrderProposalsService(db_session)
+    group = await service.create_proposal(
+        symbol="005930",
+        market="equity_kr",
+        account_mode="kis_live",
+        side="sell",
+        order_type="limit",
+        proposer="p",
+        rungs=[RungInput(0, "sell", Decimal("2"), Decimal("99"), None)],
+        exit_intent="loss_cut",
+        exit_reason="stop_loss",
+        retrospective_id=42,
+    )
+    calls = []
+
+    async def fake_preview(**kwargs):
+        calls.append(kwargs)
+        return {
+            "success": True,
+            "price": "99",
+            "quantity": "2",
+            "current_price": "100",
+            "avg_buy_price": "200",
+            "loss_cut_slip_band": "98",
+        }
+
+    async def fake_retro_lookup(retrospective_id):
+        assert retrospective_id == 42
+        return retro
+
+    evidence = await preview_loss_cut_confirmation(
+        service=service,
+        proposal_id=group.proposal_id,
+        now=datetime.now(UTC),
+        place_order_fn=fake_preview,
+        retrospective_lookup_fn=fake_retro_lookup,
+    )
+
+    assert [call["dry_run"] for call in calls] == [True]
+    assert evidence == {
+        "rungs": [
+            {
+                "rung_index": 0,
+                "current_price": "100",
+                "avg_buy_price": "200",
+                "loss_pct": "-50.00",
+                "loss_cut_slip_band": "98",
+            }
+        ],
+        "retrospective_id": 42,
+        "lesson_excerpt": "손절 기준을 늦추지 않는다",
+    }
+    _group, rungs = await service.get_proposal(group.proposal_id)
+    assert rungs[0].state == "pending_approval"
 
 
 @pytest.mark.asyncio

--- a/tests/services/order_proposals/test_service.py
+++ b/tests/services/order_proposals/test_service.py
@@ -293,7 +293,7 @@ def _loss_cut_create_kwargs(*, now: datetime):
         "exit_intent": "loss_cut",
         "exit_reason": "stop_loss",
         "retrospective_id": 42,
-        "approval_issue_id": "ROB-800",
+        "approval_issue_id": None,
         "now": now,
     }
 
@@ -317,15 +317,8 @@ async def test_create_defaults_valid_until_to_next_kst_midnight(db_session):
 
 @pytest.mark.asyncio
 async def test_loss_cut_requires_all_group_fields_without_paperclip_lookup(
-    db_session, monkeypatch
+    db_session,
 ):
-    async def paperclip_must_not_run(*args, **kwargs):
-        raise AssertionError("Paperclip status belongs to click-time revalidation")
-
-    monkeypatch.setattr(
-        "app.mcp_server.tooling.order_validation._fetch_approval_issue_status",
-        paperclip_must_not_run,
-    )
     service = OrderProposalsService(db_session)
     with pytest.raises(OrderProposalError, match="exit_reason"):
         await service.create_proposal(
@@ -348,7 +341,6 @@ async def test_loss_cut_requires_all_group_fields_without_paperclip_lookup(
     ("overrides", "message"),
     [
         ({"retrospective_id": None}, "retrospective_id"),
-        ({"approval_issue_id": None}, "approval_issue_id"),
         ({"exit_reason": None}, "exit_reason"),
         ({"exit_intent": "emergency"}, "unknown exit_intent"),
     ],
@@ -402,7 +394,25 @@ async def test_valid_loss_cut_persists_exact_group_binding(db_session, monkeypat
         group.exit_reason,
         group.retrospective_id,
         group.approval_issue_id,
-    ) == ("loss_cut", "stop_loss", 42, "ROB-800")
+    ) == ("loss_cut", "stop_loss", 42, None)
+
+
+@pytest.mark.asyncio
+async def test_loss_cut_preserves_optional_approval_issue_as_audit_note(
+    db_session, monkeypatch
+):
+    async def fake_lookup(session, retrospective_id):
+        return _retro()
+
+    monkeypatch.setattr(
+        "app.services.order_proposals.service.get_retrospective_by_id", fake_lookup
+    )
+    kwargs = _loss_cut_create_kwargs(now=datetime.now(UTC))
+    kwargs["approval_issue_id"] = "legacy Paperclip note / operator context"
+
+    group = await OrderProposalsService(db_session).create_proposal(**kwargs)
+
+    assert group.approval_issue_id == "legacy Paperclip note / operator context"
 
 
 @pytest.mark.asyncio

--- a/tests/services/order_proposals/test_telegram_callback.py
+++ b/tests/services/order_proposals/test_telegram_callback.py
@@ -12,7 +12,7 @@ from app.core.db import AsyncSessionLocal
 from app.mcp_server.caller_identity import caller_agent_id_var, get_caller_agent_id
 from app.services.order_proposals import OrderProposalsService
 from app.services.order_proposals.approval_message import parse_callback_data
-from app.services.order_proposals.revalidation import RungOutcome
+from app.services.order_proposals.revalidation import RungOutcome, revalidate_and_submit
 from app.services.order_proposals.service import RungInput
 from app.services.order_proposals.telegram_callback import (
     _build_result_summary,
@@ -95,6 +95,69 @@ async def _seed_proposal(db_session, *, nonce="nonce-abc123", symbol="A", rungs=
     await service.set_approval_nonce(group.proposal_id, nonce)
     await db_session.commit()
     return group
+
+
+async def _seed_loss_cut_proposal(
+    db_session, monkeypatch, *, nonce="loss-cut-first", rungs=1
+):
+    retro = type(
+        "Retro",
+        (),
+        {
+            "id": 42,
+            "symbol": "AAPL",
+            "trigger_type": "stop_loss",
+            "created_at": datetime.now(UTC),
+            "lesson": "손절 기준을 늦추지 않는다",
+        },
+    )()
+
+    async def fake_lookup(session, retrospective_id):
+        assert retrospective_id == 42
+        return retro
+
+    monkeypatch.setattr(
+        "app.services.order_proposals.service.get_retrospective_by_id", fake_lookup
+    )
+    service = OrderProposalsService(db_session)
+    group = await service.create_proposal(
+        symbol="AAPL",
+        market="equity_us",
+        account_mode="toss_live",
+        side="sell",
+        order_type="limit",
+        proposer="p",
+        rungs=[
+            RungInput(i, "sell", Decimal("1"), Decimal("99"), None)
+            for i in range(rungs)
+        ],
+        exit_intent="loss_cut",
+        exit_reason="stop_loss",
+        retrospective_id=42,
+    )
+    await service.set_approval_nonce(group.proposal_id, nonce)
+    await db_session.commit()
+    return group
+
+
+async def _fake_loss_cut_preview(**kwargs):
+    return {
+        "rungs": [
+            {
+                "rung_index": 0,
+                "current_price": "100",
+                "avg_buy_price": "200",
+                "loss_pct": "-50.00",
+                "loss_cut_slip_band": "98",
+            }
+        ],
+        "retrospective_id": 42,
+        "lesson_excerpt": "손절 기준을 늦추지 않는다",
+    }
+
+
+async def _fake_noop_revalidate(**kwargs):
+    return []
 
 
 def _allow_chat(monkeypatch, chat_id=CHAT_ID):
@@ -228,6 +291,225 @@ async def test_approve_happy_path_submits_and_edits(monkeypatch, db_session):
     assert refreshed.approval_nonce_used_at is not None
     assert refreshed.approved_by_telegram_user_id == str(USER_ID)
     assert refreshed.approved_at is not None
+
+
+@pytest.mark.asyncio
+async def test_loss_cut_requires_second_click_before_submit(monkeypatch, db_session):
+    _allow_chat(monkeypatch)
+    monkeypatch.setattr(settings, "ORDER_PROPOSALS_SUBMIT_AGENT_ID", "proposal-agent")
+    group = await _seed_loss_cut_proposal(db_session, monkeypatch)
+    notifier = _FakeNotifier()
+    submit_calls = []
+
+    async def fake_revalidate(**kwargs):
+        submit_calls.append(kwargs)
+        return [RungOutcome(0, "submitted_resting", {})]
+
+    async def identity_checked_preview(**kwargs):
+        assert get_caller_agent_id() == "proposal-agent"
+        return await _fake_loss_cut_preview(**kwargs)
+
+    issued = datetime(2026, 7, 13, 10, 0, tzinfo=UTC)
+    first = await handle_callback_update(
+        _make_update(data=f"op:{str(group.proposal_id)[:8]}:loss-cut-first"),
+        now=issued,
+        service_factory=_session_factory(db_session),
+        notifier=notifier,
+        revalidate_fn=fake_revalidate,
+        loss_cut_preview_fn=identity_checked_preview,
+    )
+
+    assert first["reason"] == "loss_cut_confirmation_required"
+    assert submit_calls == []
+    text, keyboard = notifier.edited[-1][2], notifier.edited[-1][3]
+    assert "손절 확인" in text
+    callback_data = keyboard["inline_keyboard"][0][0]["callback_data"]
+    action, _short, second_nonce = parse_callback_data(callback_data)
+    assert action == "lc"
+    service = OrderProposalsService(db_session)
+    refreshed, _ = await service.get_proposal(group.proposal_id)
+    audit = refreshed.source_asof["loss_cut_confirmation"]
+    assert audit["first_click"]["telegram_user_id"] == str(USER_ID)
+    assert audit["first_click"]["nonce"] == "loss-cut-first"
+    assert audit["rungs"] == [{"rung_index": 0, "approval_revision": 0}]
+
+    second = await handle_callback_update(
+        _make_update(data=callback_data, callback_id="cbq-2"),
+        now=issued + timedelta(seconds=30),
+        service_factory=_session_factory(db_session),
+        notifier=notifier,
+        revalidate_fn=fake_revalidate,
+        loss_cut_preview_fn=_fake_loss_cut_preview,
+    )
+
+    assert second["reason"] == "approved"
+    assert len(submit_calls) == 1
+    refreshed, _ = await service.get_proposal(group.proposal_id)
+    audit = refreshed.source_asof["loss_cut_confirmation"]
+    assert audit["second_click"]["telegram_user_id"] == str(USER_ID)
+    assert audit["second_click"]["nonce"] == second_nonce
+
+
+@pytest.mark.asyncio
+async def test_loss_cut_second_nonce_replay_is_rejected(monkeypatch, db_session):
+    _allow_chat(monkeypatch)
+    group = await _seed_loss_cut_proposal(db_session, monkeypatch)
+    notifier = _FakeNotifier()
+
+    first = await handle_callback_update(
+        _make_update(data=f"op:{str(group.proposal_id)[:8]}:loss-cut-first"),
+        now=datetime(2026, 7, 13, 10, 0, tzinfo=UTC),
+        service_factory=_session_factory(db_session),
+        notifier=notifier,
+        revalidate_fn=_fake_noop_revalidate,
+        loss_cut_preview_fn=_fake_loss_cut_preview,
+    )
+    callback_data = notifier.edited[-1][3]["inline_keyboard"][0][0]["callback_data"]
+    second_now = datetime(2026, 7, 13, 10, 0, 30, tzinfo=UTC)
+    await handle_callback_update(
+        _make_update(data=callback_data, callback_id="cbq-2"),
+        now=second_now,
+        service_factory=_session_factory(db_session),
+        notifier=notifier,
+        revalidate_fn=_fake_noop_revalidate,
+        loss_cut_preview_fn=_fake_loss_cut_preview,
+    )
+    replay = await handle_callback_update(
+        _make_update(data=callback_data, callback_id="cbq-3"),
+        now=second_now + timedelta(seconds=1),
+        service_factory=_session_factory(db_session),
+        notifier=notifier,
+        revalidate_fn=_fake_noop_revalidate,
+        loss_cut_preview_fn=_fake_loss_cut_preview,
+    )
+
+    assert first["reason"] == "loss_cut_confirmation_required"
+    assert replay["reason"] == "nonce_replay"
+
+
+@pytest.mark.asyncio
+async def test_loss_cut_second_nonce_expires_after_90_seconds(monkeypatch, db_session):
+    _allow_chat(monkeypatch)
+    group = await _seed_loss_cut_proposal(db_session, monkeypatch)
+    notifier = _FakeNotifier()
+    issued = datetime(2026, 7, 13, 10, 0, tzinfo=UTC)
+    await handle_callback_update(
+        _make_update(data=f"op:{str(group.proposal_id)[:8]}:loss-cut-first"),
+        now=issued,
+        service_factory=_session_factory(db_session),
+        notifier=notifier,
+        revalidate_fn=_fake_noop_revalidate,
+        loss_cut_preview_fn=_fake_loss_cut_preview,
+    )
+    callback_data = notifier.edited[-1][3]["inline_keyboard"][0][0]["callback_data"]
+
+    expired = await handle_callback_update(
+        _make_update(data=callback_data, callback_id="cbq-expired"),
+        now=issued + timedelta(seconds=91),
+        service_factory=_session_factory(db_session),
+        notifier=notifier,
+        revalidate_fn=_fake_noop_revalidate,
+        loss_cut_preview_fn=_fake_loss_cut_preview,
+    )
+
+    assert expired["reason"] == "loss_cut_confirmation_expired"
+
+
+@pytest.mark.asyncio
+async def test_loss_cut_second_nonce_rejects_changed_rung_revision(
+    monkeypatch, db_session
+):
+    _allow_chat(monkeypatch)
+    group = await _seed_loss_cut_proposal(db_session, monkeypatch)
+    notifier = _FakeNotifier()
+    issued = datetime(2026, 7, 13, 10, 0, tzinfo=UTC)
+    await handle_callback_update(
+        _make_update(data=f"op:{str(group.proposal_id)[:8]}:loss-cut-first"),
+        now=issued,
+        service_factory=_session_factory(db_session),
+        notifier=notifier,
+        revalidate_fn=_fake_noop_revalidate,
+        loss_cut_preview_fn=_fake_loss_cut_preview,
+    )
+    callback_data = notifier.edited[-1][3]["inline_keyboard"][0][0]["callback_data"]
+    service = OrderProposalsService(db_session)
+    await service.transition_rung(group.proposal_id, 0, new_state="revalidating")
+    await service.mark_needs_reconfirm(group.proposal_id, 0, now=issued)
+    await db_session.commit()
+
+    mismatch = await handle_callback_update(
+        _make_update(data=callback_data, callback_id="cbq-mismatch"),
+        now=issued + timedelta(seconds=30),
+        service_factory=_session_factory(db_session),
+        notifier=notifier,
+        revalidate_fn=_fake_noop_revalidate,
+        loss_cut_preview_fn=_fake_loss_cut_preview,
+    )
+
+    assert mismatch["reason"] == "loss_cut_confirmation_binding_mismatch"
+
+
+@pytest.mark.parametrize(
+    ("guard_error", "violations"),
+    [
+        ("loss_cut retrospective is stale (>72h)", ["retrospective_stale_72h"]),
+        ("loss_cut price below current slip band", ["loss_cut_slip_band"]),
+    ],
+)
+@pytest.mark.asyncio
+async def test_loss_cut_second_click_revalidation_blocks_stale_retro_or_slip(
+    monkeypatch,
+    db_session,
+    guard_error,
+    violations,
+):
+    _allow_chat(monkeypatch)
+    group = await _seed_loss_cut_proposal(db_session, monkeypatch)
+    notifier = _FakeNotifier()
+    issued = datetime(2026, 7, 13, 10, 0, tzinfo=UTC)
+    await handle_callback_update(
+        _make_update(data=f"op:{str(group.proposal_id)[:8]}:loss-cut-first"),
+        now=issued,
+        service_factory=_session_factory(db_session),
+        notifier=notifier,
+        loss_cut_preview_fn=_fake_loss_cut_preview,
+    )
+    callback_data = notifier.edited[-1][3]["inline_keyboard"][0][0]["callback_data"]
+    submit_attempts = 0
+
+    async def guarded_place_order(**kwargs):
+        nonlocal submit_attempts
+        if kwargs["dry_run"] is False:
+            submit_attempts += 1
+            raise AssertionError("a second-click guard failure must not submit")
+        return {
+            "success": False,
+            "error": guard_error,
+            "violations": violations,
+        }
+
+    async def real_revalidate(**kwargs):
+        return await revalidate_and_submit(
+            **kwargs,
+            place_order_fn=guarded_place_order,
+        )
+
+    blocked = await handle_callback_update(
+        _make_update(data=callback_data, callback_id="cbq-guard-blocked"),
+        now=issued + timedelta(seconds=30),
+        service_factory=_session_factory(db_session),
+        notifier=notifier,
+        revalidate_fn=real_revalidate,
+        loss_cut_preview_fn=_fake_loss_cut_preview,
+    )
+
+    assert blocked["reason"] == "approved"
+    assert blocked["results"] == ["guard_blocked"]
+    assert submit_attempts == 0
+    _group, rungs = await OrderProposalsService(db_session).get_proposal(
+        group.proposal_id
+    )
+    assert rungs[0].state == "pending_approval"
 
 
 @pytest.mark.asyncio

--- a/tests/test_mcp_place_order_defensive_trim.py
+++ b/tests/test_mcp_place_order_defensive_trim.py
@@ -1,43 +1,26 @@
-"""Unit tests for defensive_trim gating in place_order."""
+"""Regression tests for the fail-closed defensive_trim direct path."""
 
 from __future__ import annotations
 
 import inspect
 import json
-import uuid
 from unittest.mock import AsyncMock
 
 import pytest
-import pytest_asyncio
 
 import app.services.brokers.upbit.client as upbit_service
 from app.core.config import settings
 from app.mcp_server.caller_identity import caller_agent_id_var, caller_source_var
-from app.mcp_server.tooling import order_execution, order_validation
+from app.mcp_server.tooling import order_validation
 from app.mcp_server.tooling.orders_registration import register_order_tools
 from tests._mcp_tooling_support import build_tools
 
-TRADER_AGENT_ID = "6b2192cc-14fa-4335-b572-2fe1e0cb54a7"
 
-
-@pytest_asyncio.fixture(autouse=True)
-async def _ensure_live_order_ledger_schema(db_session):
-    """ROB-407: defensive-trim live crypto sell writes to review.live_order_ledger.
-    Depend on db_session so create_all builds the table before any direct insert."""
-    yield
-
-
-def _mock_crypto_sell_context(
-    monkeypatch: pytest.MonkeyPatch,
-    *,
-    current_price: float = 1000.0,
-    balance: str = "2.0",
-    avg_buy_price: str = "1000.0",
-) -> None:
+def _mock_crypto_sell_context(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
         upbit_service,
         "fetch_multiple_current_prices",
-        AsyncMock(return_value={"KRW-BTC": current_price}),
+        AsyncMock(return_value={"KRW-BTC": 1000.0}),
     )
     monkeypatch.setattr(
         upbit_service,
@@ -46,61 +29,97 @@ def _mock_crypto_sell_context(
             return_value=[
                 {
                     "currency": "BTC",
-                    "balance": balance,
+                    "balance": "2.0",
                     "locked": "0",
-                    "avg_buy_price": avg_buy_price,
+                    "avg_buy_price": "1000.0",
                 }
             ]
         ),
     )
 
 
-@pytest.fixture(autouse=True)
-def _set_defaults(monkeypatch: pytest.MonkeyPatch):
-    monkeypatch.setattr(settings, "trader_agent_id", TRADER_AGENT_ID, raising=False)
-    monkeypatch.setattr(
-        settings,
-        "paperclip_api_url",
-        "https://paperclip.local",
-        raising=False,
-    )
-    monkeypatch.setattr(settings, "paperclip_api_key", "test-token", raising=False)
-    order_validation._defensive_trim_success_cache.clear()
-    agent_token = caller_agent_id_var.set(TRADER_AGENT_ID)
-    source_token = caller_source_var.set("http_header")
-    try:
-        yield
-    finally:
-        caller_source_var.reset(source_token)
-        caller_agent_id_var.reset(agent_token)
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_direct_defensive_trim_fails_closed_with_proposal_guidance() -> None:
+    with pytest.raises(
+        ValueError,
+        match="defensive_trim_direct_path_disabled_use_order_proposal_create",
+    ):
+        await order_validation._validate_defensive_trim_preconditions(
+            defensive_trim=True,
+            approval_issue_id="legacy audit note",
+            side="sell",
+            order_type="limit",
+        )
 
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_defensive_trim_schema_blocks_market_even_with_flag() -> None:
-    """defensive_trim path rejects market orders."""
-    tools = build_tools()
-
-    result = await tools["place_order"](
+@pytest.mark.parametrize("order_type", ["limit", "market"])
+async def test_place_order_defensive_trim_direct_path_returns_guidance(
+    order_type,
+) -> None:
+    result = await build_tools()["place_order"](
         symbol="KRW-BTC",
         side="sell",
-        order_type="market",
+        order_type=order_type,
+        quantity=1.0,
+        price=1005.0,
         defensive_trim=True,
-        approval_issue_id="ROB-164",
+        approval_issue_id="legacy audit note",
         dry_run=True,
     )
 
     assert result["success"] is False
-    assert (
-        result["error"]
-        == "defensive_trim requires order_type='limit' (market orders are blocked)"
+    assert result["error"] == (
+        "defensive_trim_direct_path_disabled_use_order_proposal_create"
     )
 
 
 @pytest.mark.unit
-def test_place_order_description_documents_four_and_defensive_trim_gate() -> None:
-    """Public tool description documents every defensive_trim gate."""
+@pytest.mark.asyncio
+async def test_generic_paper_loss_cut_cannot_bypass_proposal_path() -> None:
+    result = await build_tools()["place_order"](
+        symbol="KRW-BTC",
+        side="sell",
+        order_type="limit",
+        quantity=1.0,
+        price=1005.0,
+        exit_intent="loss_cut",
+        exit_reason="stop_loss",
+        retrospective_id=42,
+        account_type="paper",
+        dry_run=True,
+    )
 
+    assert result["success"] is False
+    assert result["error"] == (
+        "loss_cut_direct_path_disabled_use_order_proposal_create"
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_non_defensive_sell_keeps_existing_floor(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _mock_crypto_sell_context(monkeypatch)
+
+    result = await build_tools()["place_order"](
+        symbol="KRW-BTC",
+        side="sell",
+        order_type="limit",
+        quantity=1.0,
+        price=1005.0,
+        dry_run=True,
+    )
+
+    assert result["success"] is False
+    assert "below minimum" in result["error"]
+
+
+@pytest.mark.unit
+def test_place_order_description_routes_defensive_trim_to_proposals() -> None:
     class CapturingMCP:
         def __init__(self) -> None:
             self.descriptions: dict[str, str] = {}
@@ -118,386 +137,15 @@ def test_place_order_description_documents_four_and_defensive_trim_gate() -> Non
 
     description = mcp.descriptions["place_order"]
     assert "defensive_trim=True" in description
-    assert "(a) side='sell'" in description
-    assert "(b) order_type='limit'" in description
-    assert "(c) valid approval_issue_id" in description
-    assert (
-        "(d) middleware-extracted caller identity matching Trader agent" in description
-    )
-    assert "approval issue status=done" in description
+    assert "order_proposal_create" in description
+    assert "approval issue status=done" not in description
     assert "requester_agent_id" not in description
-    assert "ROB-164/ROB-166" in description
 
 
 @pytest.mark.unit
 def test_place_order_signature_removes_requester_agent_id() -> None:
-    """Public MCP place_order signature no longer accepts caller-asserted identity."""
-    tools = build_tools()
-
-    signature = inspect.signature(tools["place_order"])
-
+    signature = inspect.signature(build_tools()["place_order"])
     assert "requester_agent_id" not in signature.parameters
-
-
-@pytest.mark.unit
-@pytest.mark.asyncio
-async def test_flag_off_limit_below_floor_rejected(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """defensive_trim=False keeps avg*1.01 floor enforcement."""
-    tools = build_tools()
-    _mock_crypto_sell_context(monkeypatch, current_price=1000.0, avg_buy_price="1000.0")
-
-    result = await tools["place_order"](
-        symbol="KRW-BTC",
-        side="sell",
-        order_type="limit",
-        quantity=1.0,
-        price=1005.0,
-        dry_run=True,
-    )
-
-    assert result["success"] is False
-    assert "below minimum" in result["error"]
-
-
-@pytest.mark.unit
-@pytest.mark.asyncio
-async def test_flag_on_with_valid_approval_and_trader_caller_allowed(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Valid 4-gate combination allows floor bypass in preview."""
-    tools = build_tools()
-    _mock_crypto_sell_context(monkeypatch, current_price=1000.0, avg_buy_price="1000.0")
-    monkeypatch.setattr(
-        order_validation,
-        "_fetch_approval_issue_status",
-        AsyncMock(return_value="done"),
-    )
-
-    result = await tools["place_order"](
-        symbol="KRW-BTC",
-        side="sell",
-        order_type="limit",
-        quantity=1.0,
-        price=1005.0,
-        defensive_trim=True,
-        approval_issue_id="ROB-164",
-        dry_run=True,
-    )
-
-    assert result["success"] is True
-    assert result["dry_run"] is True
-    assert result["defensive_trim"] is True
-    assert result["approval_issue_id"] == "ROB-164"
-
-
-@pytest.mark.unit
-@pytest.mark.asyncio
-async def test_flag_on_floor_bypass_logs_structured_warning(
-    monkeypatch: pytest.MonkeyPatch,
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """defensive_trim floor bypass emits the ST-2 audit warning fields."""
-    tools = build_tools()
-    _mock_crypto_sell_context(monkeypatch, current_price=1000.0, avg_buy_price="1000.0")
-    monkeypatch.setattr(
-        order_validation,
-        "_fetch_approval_issue_status",
-        AsyncMock(return_value="done"),
-    )
-
-    result = await tools["place_order"](
-        symbol="KRW-BTC",
-        side="sell",
-        order_type="limit",
-        quantity=1.0,
-        price=1005.0,
-        defensive_trim=True,
-        approval_issue_id="ROB-164",
-        dry_run=True,
-    )
-
-    assert result["success"] is True
-    warning_records = [
-        record
-        for record in caplog.records
-        if record.message.startswith("defensive_trim_bypass_active")
-    ]
-    assert {record.phase for record in warning_records} == {"execution", "preview"}
-    for record in warning_records:
-        assert record.approval_issue_id == "ROB-164"
-        assert record.requester_agent_id == TRADER_AGENT_ID
-        assert record.symbol == "KRW-BTC"
-        assert record.price == pytest.approx(1005.0)
-        assert record.min_sell_price == pytest.approx(1010.0)
-
-
-@pytest.mark.unit
-@pytest.mark.asyncio
-async def test_flag_on_missing_approval_id_rejected() -> None:
-    """defensive_trim requires approval_issue_id."""
-    tools = build_tools()
-
-    result = await tools["place_order"](
-        symbol="KRW-BTC",
-        side="sell",
-        order_type="limit",
-        quantity=1.0,
-        price=1005.0,
-        defensive_trim=True,
-        dry_run=True,
-    )
-
-    assert result["success"] is False
-    assert result["error"] == "defensive_trim=True requires approval_issue_id"
-
-
-@pytest.mark.unit
-@pytest.mark.asyncio
-async def test_flag_on_malformed_approval_id_rejected() -> None:
-    """approval_issue_id must match ticket-like format."""
-    tools = build_tools()
-
-    result = await tools["place_order"](
-        symbol="KRW-BTC",
-        side="sell",
-        order_type="limit",
-        quantity=1.0,
-        price=1005.0,
-        defensive_trim=True,
-        approval_issue_id="bad-format",
-        dry_run=True,
-    )
-
-    assert result["success"] is False
-    assert (
-        result["error"] == "approval_issue_id format invalid (expected e.g. 'ROB-164')"
-    )
-
-
-@pytest.mark.unit
-@pytest.mark.asyncio
-async def test_flag_on_approval_not_done_rejected(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Approval must exist and be in done status."""
-    tools = build_tools()
-    monkeypatch.setattr(
-        order_validation,
-        "_fetch_approval_issue_status",
-        AsyncMock(return_value="in_progress"),
-    )
-
-    result = await tools["place_order"](
-        symbol="KRW-BTC",
-        side="sell",
-        order_type="limit",
-        quantity=1.0,
-        price=1005.0,
-        defensive_trim=True,
-        approval_issue_id="ROB-164",
-        dry_run=True,
-    )
-
-    assert result["success"] is False
-    assert (
-        result["error"] == "approval_issue_id ROB-164 not found or not in 'done' status"
-    )
-
-
-@pytest.mark.unit
-@pytest.mark.asyncio
-async def test_flag_on_paperclip_api_timeout_fail_closed(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Paperclip API timeout fails closed."""
-    tools = build_tools()
-    monkeypatch.setattr(
-        order_validation,
-        "_fetch_approval_issue_status",
-        AsyncMock(side_effect=TimeoutError("timeout")),
-    )
-
-    result = await tools["place_order"](
-        symbol="KRW-BTC",
-        side="sell",
-        order_type="limit",
-        quantity=1.0,
-        price=1005.0,
-        defensive_trim=True,
-        approval_issue_id="ROB-164",
-        dry_run=True,
-    )
-
-    assert result["success"] is False
-    assert (
-        result["error"] == "approval_issue_id ROB-164 not found or not in 'done' status"
-    )
-
-
-@pytest.mark.unit
-@pytest.mark.asyncio
-async def test_flag_on_non_trader_caller_rejected() -> None:
-    """Only trader agent can use defensive_trim."""
-    tools = build_tools()
-    caller_agent_id_var.set("other-agent")
-
-    result = await tools["place_order"](
-        symbol="KRW-BTC",
-        side="sell",
-        order_type="limit",
-        quantity=1.0,
-        price=1005.0,
-        defensive_trim=True,
-        approval_issue_id="ROB-164",
-        dry_run=True,
-    )
-
-    assert result["success"] is False
-    assert (
-        result["error"]
-        == "defensive_trim requires Trader agent caller (got caller_agent_id=other-agent)"
-    )
-
-
-@pytest.mark.unit
-@pytest.mark.asyncio
-async def test_flag_on_missing_caller_id_rejected() -> None:
-    """defensive_trim requires caller identity."""
-    tools = build_tools()
-    caller_agent_id_var.set(None)
-
-    result = await tools["place_order"](
-        symbol="KRW-BTC",
-        side="sell",
-        order_type="limit",
-        quantity=1.0,
-        price=1005.0,
-        defensive_trim=True,
-        approval_issue_id="ROB-164",
-        dry_run=True,
-    )
-
-    assert result["success"] is False
-    assert (
-        result["error"]
-        == "caller identity unavailable — defensive_trim requires authenticated MCP caller"
-    )
-
-
-@pytest.mark.unit
-@pytest.mark.asyncio
-async def test_flag_on_still_rejects_below_current_price(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """defensive_trim bypasses floor only, not current-price guard."""
-    tools = build_tools()
-    _mock_crypto_sell_context(monkeypatch, current_price=1000.0, avg_buy_price="900.0")
-    monkeypatch.setattr(
-        order_validation,
-        "_fetch_approval_issue_status",
-        AsyncMock(return_value="done"),
-    )
-
-    result = await tools["place_order"](
-        symbol="KRW-BTC",
-        side="sell",
-        order_type="limit",
-        quantity=1.0,
-        price=990.0,
-        defensive_trim=True,
-        approval_issue_id="ROB-164",
-        dry_run=True,
-    )
-
-    assert result["success"] is False
-    assert "below current price" in result["error"]
-
-
-@pytest.mark.unit
-@pytest.mark.asyncio
-async def test_defensive_trim_sell_accepted_only_persists_audit_to_ledger(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """ROB-407: live crypto defensive-trim sell records accepted-only. The
-    order-history approval audit is still recorded at send; the journal close is
-    deferred to evidence-gated reconcile, so the defensive-trim approval fields are
-    persisted on the live_order_ledger row (re-attached to the journal at reconcile,
-    see tests/mcp_server/tooling/test_live_order_ledger.py)."""
-    tools = build_tools()
-    _mock_crypto_sell_context(monkeypatch, current_price=1000.0, avg_buy_price="1000.0")
-    monkeypatch.setattr(
-        order_validation,
-        "_fetch_approval_issue_status",
-        AsyncMock(return_value="done"),
-    )
-    order_uuid = f"defensive-trim-{uuid.uuid4()}"
-
-    record_mock = AsyncMock()
-    monkeypatch.setattr(order_execution, "_record_order_history", record_mock)
-    monkeypatch.setattr(
-        upbit_service,
-        "place_sell_order",
-        AsyncMock(return_value={"uuid": order_uuid}),
-    )
-    monkeypatch.setattr(
-        order_execution, "_save_order_fill", AsyncMock(return_value=9191)
-    )
-    monkeypatch.setattr(order_execution, "_link_journal_to_fill", AsyncMock())
-    close_mock = AsyncMock()
-    monkeypatch.setattr(order_execution, "_close_journals_on_sell", close_mock)
-
-    result = await tools["place_order"](
-        symbol="KRW-BTC",
-        side="sell",
-        order_type="limit",
-        quantity=1.0,
-        price=1005.0,
-        defensive_trim=True,
-        approval_issue_id="ROB-164",
-        dry_run=False,
-    )
-
-    assert result["success"] is True
-    assert result["fill_recorded"] is False
-    assert result["broker_status"] == "accepted"
-    assert "journals_closed" not in result
-
-    # order-history approval audit is still recorded at send
-    record_mock.assert_awaited_once()
-    kwargs = record_mock.await_args.kwargs
-    assert kwargs["defensive_trim"] is True
-    assert kwargs["approval_issue_id"] == "ROB-164"
-    assert kwargs["requester_agent_id"] == TRADER_AGENT_ID
-    assert kwargs["caller_source"] == "http_header"
-
-    # journal close is deferred to reconcile — never attempted at send
-    close_mock.assert_not_awaited()
-
-    # approval audit is persisted on the ledger row so reconcile can re-attach
-    # the defensive-trim note to the closed journal.
-    from sqlalchemy import select
-
-    from app.mcp_server.tooling.live_order_ledger import _order_session_factory
-    from app.models.review import LiveOrderLedger
-
-    async with _order_session_factory()() as db:
-        row = (
-            (
-                await db.execute(
-                    select(LiveOrderLedger).where(
-                        LiveOrderLedger.order_no == order_uuid
-                    )
-                )
-            )
-            .scalars()
-            .first()
-        )
-    assert row is not None
-    assert row.dt_approval_issue_id == "ROB-164"
-    assert row.dt_requester_agent_id == TRADER_AGENT_ID
-    assert row.dt_caller_source == "http_header"
 
 
 @pytest.mark.unit
@@ -505,8 +153,6 @@ async def test_defensive_trim_sell_accepted_only_persists_audit_to_ledger(
 async def test_record_order_history_persists_caller_source(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Redis order history audit records the middleware caller source."""
-
     class FakeRedis:
         def __init__(self) -> None:
             self.pushed: list[tuple[str, str]] = []
@@ -519,77 +165,45 @@ async def test_record_order_history_persists_caller_source(
 
     fake_redis = FakeRedis()
     monkeypatch.setattr(settings, "redis_url", "redis://test", raising=False)
-    monkeypatch.setattr(
-        "redis.asyncio.from_url",
-        AsyncMock(return_value=fake_redis),
-    )
+    monkeypatch.setattr("redis.asyncio.from_url", AsyncMock(return_value=fake_redis))
+    agent_token = caller_agent_id_var.set("trader-test")
+    source_token = caller_source_var.set("http_header")
+    try:
+        await order_validation._record_order_history(
+            symbol="KRW-BTC",
+            side="sell",
+            order_type="limit",
+            quantity=1.0,
+            price=1005.0,
+            amount=1005.0,
+            reason="defensive trim",
+            dry_run=False,
+            defensive_trim=True,
+            approval_issue_id="legacy audit note",
+            requester_agent_id="trader-test",
+        )
+    finally:
+        caller_source_var.reset(source_token)
+        caller_agent_id_var.reset(agent_token)
 
-    await order_validation._record_order_history(
-        symbol="KRW-BTC",
-        side="sell",
-        order_type="limit",
-        quantity=1.0,
-        price=1005.0,
-        amount=1005.0,
-        reason="defensive trim",
-        dry_run=False,
-        defensive_trim=True,
-        approval_issue_id="ROB-164",
-        requester_agent_id=TRADER_AGENT_ID,
-    )
-
-    assert len(fake_redis.pushed) == 1
-    _, raw_record = fake_redis.pushed[0]
-    record = json.loads(raw_record)
-    assert record["requester_agent_id"] == TRADER_AGENT_ID
+    record = json.loads(fake_redis.pushed[0][1])
     assert record["caller_source"] == "http_header"
 
 
 @pytest.mark.unit
-@pytest.mark.asyncio
-async def test_flag_on_buy_side_rejected() -> None:
-    """defensive_trim is sell-only."""
-    tools = build_tools()
-
-    result = await tools["place_order"](
-        symbol="KRW-BTC",
-        side="buy",
-        order_type="limit",
-        quantity=1.0,
-        price=1000.0,
-        defensive_trim=True,
-        approval_issue_id="ROB-164",
-        dry_run=True,
-    )
-
-    assert result["success"] is False
-    assert (
-        result["error"]
-        == "defensive_trim requires side='sell' (buy orders always use existing path)"
-    )
-
-
-def test_kis_live_place_order_documents_defensive_trim_approval_dependency():
-    """ROB-466: the kis_live_place_order schema description must surface that
-    defensive_trim=True requires approval_issue_id, so callers discover the
-    dependency before a runtime rejection (even in dry_run)."""
-    from app.mcp_server.tooling.orders_kis_variants import (
-        register_kis_live_order_tools,
-    )
+def test_kis_live_description_routes_defensive_trim_to_proposals() -> None:
+    from app.mcp_server.tooling.orders_kis_variants import register_kis_live_order_tools
 
     captured: dict[str, str] = {}
 
-    class _CaptureMCP:
+    class CapturingMCP:
         def tool(self, *, name: str, description: str = ""):
             captured[name] = description
 
-            def _decorator(func):
+            def decorator(func):
                 return func
 
-            return _decorator
+            return decorator
 
-    register_kis_live_order_tools(_CaptureMCP())
-
-    desc = captured["kis_live_place_order"]
-    assert "defensive_trim" in desc
-    assert "approval_issue_id" in desc
+    register_kis_live_order_tools(CapturingMCP())
+    assert "order_proposal_create" in captured["kis_live_place_order"]


### PR DESCRIPTION
## Summary

- Replace the unavailable Paperclip `status=done` approval backend for proposal loss cuts with Telegram two-step confirmation.
- Make the first `✅ 승인` click read-only: it records the first click, renders symbol/quantity/limit/current price/loss/slip-band and retrospective evidence, and issues a 90-second `⚠️ 손절 확인` nonce bound to proposal/rung/approval revision.
- Make the second click consume the bound nonce once, record the second click, and rerun the existing full preview, retrospective freshness, slip-band, price-diff/`NEEDS_RECONFIRM`, approval-hash, and submit flow.
- Treat `approval_issue_id` as optional free-text audit metadata. It is stored and displayed when present; no external issue backend is queried.
- Fail closed for direct `loss_cut` and `defensive_trim` calls with `order_proposal_create` guidance. Ordinary orders retain the existing one-click/direct behavior.
- Update the proposal runbook, MCP README/tool descriptions, and mark ROB-858's Paperclip approval contract as superseded by ROB-864.

## Approval audit and schema

This reuses `approval_nonce` / `approval_nonce_used_at` and stores the bound two-click audit envelope in `source_asof.loss_cut_confirmation` (`telegram_user_id`, click timestamp, nonce, expiry, and rung/revision binding). No migration is required. Current Alembic head remains `20260713_rob844_root_reservation`.

## Runtime callsites and direct-path decision

| Validator / former lookup | Runtime callsite | ROB-864 behavior |
|---|---|---|
| `_validate_loss_cut_preconditions` | `order_execution._place_order_impl` (generic KIS/Upbit direct path and proposal adapter) | Direct calls fail with `loss_cut_direct_path_disabled_use_order_proposal_create`; proposal revalidation passes the internal `proposal_flow=True` signal and retains all ROB-800 guards except external issue lookup. |
| `_validate_loss_cut_preconditions` | `orders_toss_variants.toss_preview_order` | Only the private proposal context enables loss-cut preview; direct MCP calls fail closed. |
| `_validate_loss_cut_preconditions` | `orders_toss_variants._toss_place_order_impl` | Only the private proposal context enables submit; second-click submit repeats all loss-cut guards. |
| `_validate_defensive_trim_preconditions` | `order_execution._place_order_impl` | Any direct `defensive_trim=True` call fails closed with proposal-path guidance. |
| `_fetch_approval_issue_status` | Formerly both loss-cut and defensive-trim validators | Removed; there are no runtime callsites or Paperclip HTTP requests. |

Direct-path decision: **loss-cut and defensive-trim remain fail-closed outside proposals because those paths have no Telegram two-step human signature.**

## Test plan

- [x] `uv run pytest tests/services/order_proposals tests/mcp_server/tooling/test_loss_cut_preconditions.py tests/mcp_server/tooling/test_loss_cut_place_order.py tests/mcp_server/tooling/test_toss_loss_cut.py tests/mcp_server/tooling/test_toss_live_ledger.py tests/test_mcp_place_order_defensive_trim.py -q` — 365 passed
- [x] `make lint` — Ruff check/format and ty check passed
- [x] Paperclip env unset Toss loss-cut E2E: create → first click (0 submits) → second click → mocked submit → partial/terminal reconcile
- [x] Replay, 90-second expiry, proposal/rung/revision binding mismatch, stale retrospective, slip-band rejection, and ordinary one-click regression
- [x] No real broker or Telegram calls; all external boundaries mocked

## Migration

None.
