### PR TITLE
chore(ROB-865): remove dead Paperclip integrations

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -788,8 +788,6 @@ class Settings(BaseSettings):
     execution_ledger_reconcile_scheduler_window_hours: int = 24
 
     trader_agent_id: str = "6b2192cc-14fa-4335-b572-2fe1e0cb54a7"
-    paperclip_api_url: str | None = None
-    paperclip_api_key: str | None = None
 
     public_base_url: str = "https://mgh3326.duckdns.org"
 

--- a/app/mcp_server/README.md
+++ b/app/mcp_server/README.md
@@ -145,8 +145,8 @@ MCP tools (market data, portfolio, order execution) exposed via `fastmcp`.
   - `status="pending"` 만 symbol 없이 호출 가능
   - `status in {"all", "filled", "cancelled"}` 는 symbol 필요
   - filled/cancelled 조회는 시장별 historical endpoint 제약 때문에 symbol fan-out을 자동 수행하지 않음
-- `save_trade_journal(symbol, thesis, ..., paperclip_issue_id=None)` - Save the thesis, strategy, account context, and optional Paperclip issue link for a trade.
-- `get_trade_journal(symbol=None, status=None, ..., paperclip_issue_id=None)` - Query active journal entries by symbol/account or reverse-lookup a journal from a Paperclip issue ID.
+- `save_trade_journal(symbol, thesis, ..., paperclip_issue_id=None)` - Save the thesis, strategy, account context, and optional external issue key (legacy Paperclip name; current Linear ROB key) for a trade.
+- `get_trade_journal(symbol=None, status=None, ..., paperclip_issue_id=None)` - Query active journal entries by symbol/account or reverse-lookup an external issue key (legacy Paperclip name; current Linear ROB key).
 - `update_trade_journal(journal_id=None, symbol=None, ...)` - Activate, close, stop, or adjust the latest matching journal entry.
 - `get_latest_market_brief(symbols=None, market=None, limit=10)` - Return concise latest AI analysis context for recent or selected symbols.
 - `get_market_reports(symbol, days=7, limit=10)` - Return detailed AI analysis report history and decision trend for one symbol.
@@ -1825,9 +1825,10 @@ Behavior:
 ## Caller Identity Header (required)
 
 All MCP callers (Scout, Trader, CIO bridges, and any future client) MUST send
-`x-paperclip-agent-id: <calling agent's Paperclip agent id>` on every
-`tools/call` request. The value is the caller's Paperclip agent id, not the
-target trader agent id.
+`x-paperclip-agent-id: <calling agent id>` on every `tools/call` request. The
+header is a canonical legacy Paperclip-named compatibility surface and MUST NOT
+be renamed; its value is the current caller agent id, not the target trader
+agent id.
 
 - The `CallerIdentityMiddleware` added in ROB-214 (ST-3.1) reads this header,
   stores it in a request-scoped contextvar, and records the extraction source
@@ -1854,7 +1855,7 @@ their local `/tmp/mcp_call.sh` from that template so the header is present.
 export MCP_ENDPOINT="http://127.0.0.1:8765/mcp"
 export MCP_AUTH_TOKEN="<value from env.MCP_AUTH_TOKEN>"
 export MCP_SESSION_ID="<MCP session id>"
-export PAPERCLIP_AGENT_ID="<calling agent's Paperclip agent id>"
+export PAPERCLIP_AGENT_ID="<calling agent id>"
 envsubst '$MCP_ENDPOINT $MCP_AUTH_TOKEN $MCP_SESSION_ID $PAPERCLIP_AGENT_ID' \
   < scripts/templates/mcp_call.sh.tmpl > /tmp/mcp_call.sh
 # 0700 — owner-only. The rendered script bakes MCP_AUTH_TOKEN in plaintext,
@@ -1867,7 +1868,7 @@ chmod 700 /tmp/mcp_call.sh
 
 The rendered bridge intentionally calls curl with `-N --max-time 15` and sends
 `Connection: close`. It only consumes the first SSE `data:` line, so no-buffer
-mode and the timeout keep the helper from holding a completed Paperclip run open
+mode and the timeout keep the helper from holding a completed agent run open
 if the server keeps the stream alive.
 
 If the Trader adapter is later migrated to an in-process MCP client (for

--- a/app/mcp_server/caller_identity_middleware.py
+++ b/app/mcp_server/caller_identity_middleware.py
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
     from fastmcp.tools.tool import ToolResult
 
 
+# Canonical legacy Paperclip-named compatibility header; do not rename.
 CALLER_AGENT_ID_HEADER = "x-paperclip-agent-id"
 
 

--- a/app/mcp_server/main.py
+++ b/app/mcp_server/main.py
@@ -119,7 +119,7 @@ def _validate_caller_agent_id_fallback(mcp_type: str) -> None:
         raise RuntimeError(
             "MCP_CALLER_AGENT_ID is only allowed for stdio/local dev transports; "
             "unset it for production HTTP deployments and send "
-            "x-paperclip-agent-id explicitly."
+            "x-paperclip-agent-id explicitly (canonical legacy compatibility header)."
         )
 
 

--- a/app/mcp_server/tooling/trade_journal_registration.py
+++ b/app/mcp_server/tooling/trade_journal_registration.py
@@ -88,7 +88,7 @@ def register_trade_journal_tools(mcp: FastMCP) -> None:
             "status defaults to 'draft' — set to 'active' after fill confirmation. "
             "account_type='paper'|'mock' for paper/mock journals (paper requires account name). "
             "paper_trade_id links to the paper trade record. "
-            "paperclip_issue_id links to the Paperclip issue tracking this trade. "
+            "paperclip_issue_id stores the external issue key (legacy Paperclip name; current Linear ROB key). "
             "metadata is an optional JSON dict for extensible fields."
         ),
     )(save_trade_journal)
@@ -101,7 +101,7 @@ def register_trade_journal_tools(mcp: FastMCP) -> None:
             "Each entry includes hold_remaining_days and hold_expired. "
             "account_type defaults to None (all); set 'live'|'paper'|'mock' to filter. "
             "account (optional) filters to a specific account name. "
-            "paperclip_issue_id (optional) reverse lookup by Paperclip issue ID. "
+            "paperclip_issue_id (optional) reverse lookup by external issue key (legacy Paperclip name; current Linear ROB key). "
             "enrich_live (optional, default False): fetch live quotes to compute current_price/pnl_pct_live/target_reached/stop_reached and near_target/near_stop. Slower (one quote per returned entry); fail-open per entry."
         ),
     )(get_trade_journal)

--- a/app/mcp_server/tooling/trade_journal_tools.py
+++ b/app/mcp_server/tooling/trade_journal_tools.py
@@ -129,7 +129,7 @@ async def save_trade_journal(
     Warns if an active journal already exists for the same symbol.
     account_type='paper'|'mock' for paper/mock journals (paper requires account name).
     paper_trade_id links to the paper trade record.
-    paperclip_issue_id links to the Paperclip issue tracking this trade.
+    paperclip_issue_id stores the external issue key (legacy Paperclip name; current Linear ROB key).
     metadata is an optional JSON dict for extensible fields.
     """
     symbol = (symbol or "").strip()
@@ -256,7 +256,7 @@ async def get_trade_journal(
     Each entry includes hold_remaining_days, hold_expired for hold period checks.
     account_type defaults to None (all); set 'live'|'paper'|'mock' to filter.
     account (optional) filters to a specific account name.
-    paperclip_issue_id (optional) filters by Paperclip issue ID for reverse lookup.
+    paperclip_issue_id (optional) filters by external issue key (legacy Paperclip name; current Linear ROB key).
     """
     try:
         async with _session_factory()() as db:

--- a/app/models/trade_journal.py
+++ b/app/models/trade_journal.py
@@ -57,6 +57,7 @@ class TradeJournal(Base):
         Index("ix_trade_journals_symbol_status", "symbol", "status"),
         Index("ix_trade_journals_created", "created_at"),
         Index("ix_trade_journals_account_type", "account_type"),
+        # External issue key (legacy Paperclip name; current Linear ROB key).
         Index("ix_trade_journals_paperclip_issue_id", "paperclip_issue_id"),
         Index("ix_trade_journals_correlation_id", "correlation_id"),
         {"schema": "review"},
@@ -88,7 +89,7 @@ class TradeJournal(Base):
     # Indicator snapshot at entry
     indicators_snapshot: Mapped[dict | None] = mapped_column(JSONB)
 
-    # Extensible metadata (e.g. paperclip_issue_id linkage)
+    # Extensible metadata; the external issue key has a dedicated column below.
     extra_metadata: Mapped[dict | None] = mapped_column(
         "metadata", JSONB, nullable=True
     )
@@ -122,6 +123,7 @@ class TradeJournal(Base):
         Text, nullable=False, default="live", server_default="live"
     )
     paper_trade_id: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
+    # External issue key (legacy Paperclip name; current Linear ROB key).
     paperclip_issue_id: Mapped[str | None] = mapped_column(Text, nullable=True)
     correlation_id: Mapped[str | None] = mapped_column(Text)
     notes: Mapped[str | None] = mapped_column(Text)

--- a/app/schemas/trade_retrospective.py
+++ b/app/schemas/trade_retrospective.py
@@ -94,9 +94,9 @@ class IntendedVsHappened(BaseModel):
 class NextAction(BaseModel):
     """A follow-up action derived from the postmortem.
 
-    ``issue_id`` stores a Linear identifier ONLY (mirrors
-    trade_journal.paperclip_issue_id) — issue creation is the caller/session's
-    job; the repo never adds a Linear API client.
+    ``issue_id`` stores an external issue key (legacy Paperclip name; current
+    Linear ROB key) and mirrors ``trade_journal.paperclip_issue_id`` — issue
+    creation is the caller/session's job; the repo never adds a Linear API client.
     """
 
     model_config = ConfigDict(extra="forbid")

--- a/docs/runbooks/CIO_QUALITY_GATE.md
+++ b/docs/runbooks/CIO_QUALITY_GATE.md
@@ -12,17 +12,16 @@ uv run python scripts/cio_quality_gate.py path/to/scout_report.md
 
 # 표준입력 (Scout comment 본문 복붙)
 uv run python scripts/cio_quality_gate.py --stdin < scout.md
-
-# Paperclip 이슈에서 직접 (가장 큰 comment = Scout Report 가정)
-uv run python scripts/cio_quality_gate.py --paperclip-issue ROB-158
 ```
+
+입력은 로컬 Markdown 파일 경로 또는 표준입력을 통해 제공한다.
 
 Exit code:
 - `0` — 모든 gate pass
 - `1` — soft-gate만 fail (ACCEPT-WITH-FLAG)
 - `2` — hard-gate 위반 (REOPEN)
 
-`--json` 플래그로 머신리더블 출력 (CI/CD·Paperclip automation 편입 시 사용).
+`--json` 플래그로 머신리더블 출력 (CI/CD·자동화 워크플로 편입 시 사용).
 
 ## 2. Decision Flow
 

--- a/docs/superpowers/plans/2026-07-13-rob-865-paperclip-residue-cleanup.md
+++ b/docs/superpowers/plans/2026-07-13-rob-865-paperclip-residue-cleanup.md
@@ -32,6 +32,7 @@
 - Modify: `app/schemas/trade_retrospective.py`
 - Modify: `app/mcp_server/README.md`
 - Modify: `scripts/templates/mcp_call.sh.tmpl`
+- Modify: `tests/mcp_server/tooling/test_toss_live_ledger.py`
 - Local-only modify: `.env.prod`
 
 **Interfaces:**
@@ -41,6 +42,9 @@
 - [ ] **Step 1: Write the failing inventory regression test**
 
 ```python
+import os
+import subprocess
+from collections.abc import Iterator
 from pathlib import Path
 
 from app.core.config import settings
@@ -49,7 +53,6 @@ from app.models.trade_journal import TradeJournal
 
 
 ROOT = Path(__file__).resolve().parent.parent
-SOURCE_SUFFIXES = {".md", ".py", ".sh", ".tmpl"}
 DEAD_TOKENS = {
     "paperclip_api_url",
     "paperclip_api_key",
@@ -68,32 +71,56 @@ ALLOWED_REFERENCE_FILES = {
     "app/schemas/trade_retrospective.py",
     "scripts/templates/mcp_call.sh.tmpl",
 }
+COMPATIBILITY_MARKERS = {
+    "x-paperclip-agent-id",
+    "paperclip_agent_id",
+    "paperclip_issue_id",
+    "legacy paperclip",
+    "paperclip-named",
+}
+
+
+def _tracked_texts() -> Iterator[tuple[Path, str]]:
+    tracked = subprocess.run(
+        ["git", "ls-files", "-z", "--", "app", "scripts"],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+    ).stdout
+    for raw_path in tracked.split(b"\0"):
+        if not raw_path:
+            continue
+        path = ROOT / os.fsdecode(raw_path)
+        content = path.read_bytes()
+        if b"\0" not in content:
+            yield path, content.decode("utf-8", errors="ignore")
 
 
 def test_dead_paperclip_dependencies_are_removed() -> None:
-    for relative in ("app", "scripts"):
-        for path in (ROOT / relative).rglob("*"):
-            if path.is_file() and path.suffix in SOURCE_SUFFIXES:
-                text = path.read_text(encoding="utf-8", errors="ignore")
-                for token in DEAD_TOKENS:
-                    assert token not in text, f"dead token {token!r} remains in {path}"
+    for path, text in _tracked_texts():
+        for token in DEAD_TOKENS:
+            assert token not in text, f"dead token {token!r} remains in {path}"
     assert not hasattr(settings, "paperclip_api_url")
     assert not hasattr(settings, "paperclip_api_key")
 
 
 def test_remaining_paperclip_references_are_compatibility_surfaces() -> None:
-    paths = set()
-    for relative in ("app", "scripts"):
-        for path in (ROOT / relative).rglob("*"):
-            if (
-                path.is_file()
-                and path.suffix in SOURCE_SUFFIXES
-                and "paperclip" in path.read_text(
-                encoding="utf-8", errors="ignore"
-                ).lower()
-            ):
-                paths.add(path.relative_to(ROOT).as_posix())
-    assert paths <= ALLOWED_REFERENCE_FILES
+    for path, text in _tracked_texts():
+        paperclip_lines = [
+            (line_number, line)
+            for line_number, line in enumerate(text.splitlines(), start=1)
+            if "paperclip" in line.lower()
+        ]
+        if not paperclip_lines:
+            continue
+
+        relative_path = path.relative_to(ROOT).as_posix()
+        assert relative_path in ALLOWED_REFERENCE_FILES
+        for line_number, line in paperclip_lines:
+            normalized_line = line.lower()
+            assert any(marker in normalized_line for marker in COMPATIBILITY_MARKERS), (
+                f"unmarked Paperclip reference in {relative_path}:{line_number}: {line}"
+            )
 
 
 def test_legacy_named_compatibility_contracts_remain() -> None:
@@ -112,7 +139,7 @@ Expected: FAIL because the settings, CIO loader/option, and dead tokens still ex
 
 - [ ] **Step 3: Implement the minimal cleanup**
 
-Delete the two unused settings, the CIO Paperclip loader/CLI branch/imports/export, and the two matching lines from the local `.env.prod`. Preserve the header constant and shell header emission. Preserve the trade-journal column/index/arguments and update their nearby comments and current MCP documentation to say `external issue key (legacy Paperclip name; current Linear ROB key)`.
+Delete the two unused settings, the CIO Paperclip loader/CLI branch/imports/export, the two obsolete Toss ledger test monkeypatches for those settings, and the two matching lines from the local `.env.prod`. Preserve the header constant and shell header emission. Preserve the trade-journal column/index/arguments and update their nearby comments and current MCP documentation to say `external issue key (legacy Paperclip name; current Linear ROB key)`.
 
 - [ ] **Step 4: Run focused tests and verify GREEN**
 
@@ -139,6 +166,7 @@ git add app/core/config.py scripts/cio_quality_gate.py \
   app/mcp_server/tooling/trade_journal_registration.py \
   app/models/trade_journal.py app/schemas/trade_retrospective.py \
   app/mcp_server/README.md scripts/templates/mcp_call.sh.tmpl \
+  tests/mcp_server/tooling/test_toss_live_ledger.py \
   tests/test_paperclip_residue_inventory.py
 git commit -m "chore(ROB-865): remove dead Paperclip integrations"
 ```

--- a/docs/superpowers/plans/2026-07-13-rob-865-paperclip-residue-cleanup.md
+++ b/docs/superpowers/plans/2026-07-13-rob-865-paperclip-residue-cleanup.md
@@ -31,6 +31,7 @@
 - Modify: `app/models/trade_journal.py`
 - Modify: `app/schemas/trade_retrospective.py`
 - Modify: `app/mcp_server/README.md`
+- Modify: `docs/runbooks/CIO_QUALITY_GATE.md`
 - Modify: `scripts/templates/mcp_call.sh.tmpl`
 - Modify: `tests/mcp_server/tooling/test_toss_live_ledger.py`
 - Local-only modify: `.env.prod`
@@ -82,7 +83,15 @@ COMPATIBILITY_MARKERS = {
 
 def _tracked_texts() -> Iterator[tuple[Path, str]]:
     tracked = subprocess.run(
-        ["git", "ls-files", "-z", "--", "app", "scripts"],
+        [
+            "git",
+            "ls-files",
+            "-z",
+            "--",
+            "app",
+            "scripts",
+            "docs/runbooks/CIO_QUALITY_GATE.md",
+        ],
         cwd=ROOT,
         check=True,
         capture_output=True,
@@ -139,17 +148,17 @@ Expected: FAIL because the settings, CIO loader/option, and dead tokens still ex
 
 - [ ] **Step 3: Implement the minimal cleanup**
 
-Delete the two unused settings, the CIO Paperclip loader/CLI branch/imports/export, the two obsolete Toss ledger test monkeypatches for those settings, and the two matching lines from the local `.env.prod`. Preserve the header constant and shell header emission. Preserve the trade-journal column/index/arguments and update their nearby comments and current MCP documentation to say `external issue key (legacy Paperclip name; current Linear ROB key)`.
+Delete the two unused settings, the CIO Paperclip loader/CLI branch/imports/export, the two obsolete Toss ledger test monkeypatches for those settings, and the two matching lines from the local `.env.prod`. Update the current CIO quality-gate runbook to document only the supported file/stdin inputs and use generic automation wording. Preserve the header constant and shell header emission. Preserve the trade-journal column/index/arguments and update their nearby comments and current MCP documentation to say `external issue key (legacy Paperclip name; current Linear ROB key)`.
 
 - [ ] **Step 4: Run focused tests and verify GREEN**
 
-Run: `uv run pytest --no-cov -q tests/test_paperclip_residue_inventory.py tests/test_mcp_call_template.py tests/test_mcp_caller_identity_middleware.py tests/test_trade_journal_model.py tests/test_mcp_trade_journal.py tests/test_mcp_execution_tools.py tests/mcp_server/tooling/test_toss_live_ledger.py`
+Run: `uv run pytest --no-cov -q tests/test_paperclip_residue_inventory.py tests/test_cio_quality_gate.py tests/test_cio_quality_gate_e2e.py tests/test_mcp_call_template.py tests/test_mcp_caller_identity_middleware.py tests/test_trade_journal_model.py tests/test_mcp_trade_journal.py tests/test_mcp_execution_tools.py tests/mcp_server/tooling/test_toss_live_ledger.py`
 
 Expected: all selected tests pass; only pre-existing warnings may remain.
 
 - [ ] **Step 5: Verify acceptance and quality gates**
 
-Run: `git grep -in paperclip -- app scripts ':!docs/plans/**'`
+Run: `git grep -in paperclip -- app scripts docs/runbooks/CIO_QUALITY_GATE.md ':!docs/plans/**'`
 
 Expected: every result is either the canonical legacy caller header/template or the retained trade-journal external-issue compatibility surface, with an explanatory comment.
 
@@ -165,7 +174,8 @@ git add app/core/config.py scripts/cio_quality_gate.py \
   app/mcp_server/tooling/trade_journal_tools.py \
   app/mcp_server/tooling/trade_journal_registration.py \
   app/models/trade_journal.py app/schemas/trade_retrospective.py \
-  app/mcp_server/README.md scripts/templates/mcp_call.sh.tmpl \
+  app/mcp_server/README.md docs/runbooks/CIO_QUALITY_GATE.md \
+  scripts/templates/mcp_call.sh.tmpl \
   tests/mcp_server/tooling/test_toss_live_ledger.py \
   tests/test_paperclip_residue_inventory.py
 git commit -m "chore(ROB-865): remove dead Paperclip integrations"

--- a/docs/superpowers/plans/2026-07-13-rob-865-paperclip-residue-cleanup.md
+++ b/docs/superpowers/plans/2026-07-13-rob-865-paperclip-residue-cleanup.md
@@ -1,0 +1,144 @@
+# ROB-865 Paperclip Residue Cleanup Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove dead Paperclip integrations while preserving the canonical caller header and legacy trade-journal schema/API compatibility.
+
+**Architecture:** Encode the A-versus-B inventory boundary as a source-level regression test, then make the smallest deletions and documentation edits needed to satisfy it. Runtime data flow is unchanged except that the dead CIO CLI network input and unused settings disappear.
+
+**Tech Stack:** Python 3.13, pytest, Pydantic Settings, SQLAlchemy, Bash template, Ruff, ty
+
+## Global Constraints
+
+- Remove inventory A only.
+- Never delete or rename `x-paperclip-agent-id`; it remains the canonical MCP caller identity header.
+- Keep `trade_journal.paperclip_issue_id`, its index, MCP parameters, and behavior; change comments/documentation only.
+- Do not modify archived `docs/plans/**` files.
+- Use TDD: observe the new regression test fail before changing production code.
+
+---
+
+### Task 1: Lock the inventory boundary and remove dead dependencies
+
+**Files:**
+- Create: `tests/test_paperclip_residue_inventory.py`
+- Modify: `app/core/config.py`
+- Modify: `scripts/cio_quality_gate.py`
+- Modify: `app/mcp_server/caller_identity_middleware.py`
+- Modify: `app/mcp_server/main.py`
+- Modify: `app/mcp_server/tooling/trade_journal_tools.py`
+- Modify: `app/mcp_server/tooling/trade_journal_registration.py`
+- Modify: `app/models/trade_journal.py`
+- Modify: `app/schemas/trade_retrospective.py`
+- Modify: `app/mcp_server/README.md`
+- Modify: `scripts/templates/mcp_call.sh.tmpl`
+- Local-only modify: `.env.prod`
+
+**Interfaces:**
+- Consumes: ROB-864's Telegram two-step loss-cut authorization on `origin/main`.
+- Produces: unchanged `CALLER_AGENT_ID_HEADER == "x-paperclip-agent-id"`; unchanged `TradeJournal.paperclip_issue_id` column and `ix_trade_journals_paperclip_issue_id` index; CIO CLI inputs limited to file/stdin.
+
+- [ ] **Step 1: Write the failing inventory regression test**
+
+```python
+from pathlib import Path
+
+from app.core.config import settings
+from app.mcp_server.caller_identity_middleware import CALLER_AGENT_ID_HEADER
+from app.models.trade_journal import TradeJournal
+
+
+ROOT = Path(__file__).resolve().parent.parent
+SOURCE_SUFFIXES = {".md", ".py", ".sh", ".tmpl"}
+DEAD_TOKENS = {
+    "paperclip_api_url",
+    "paperclip_api_key",
+    "PAPERCLIP_API_URL",
+    "PAPERCLIP_API_KEY",
+    "load_from_paperclip",
+    "--paperclip-issue",
+}
+ALLOWED_REFERENCE_FILES = {
+    "app/mcp_server/README.md",
+    "app/mcp_server/caller_identity_middleware.py",
+    "app/mcp_server/main.py",
+    "app/mcp_server/tooling/trade_journal_registration.py",
+    "app/mcp_server/tooling/trade_journal_tools.py",
+    "app/models/trade_journal.py",
+    "app/schemas/trade_retrospective.py",
+    "scripts/templates/mcp_call.sh.tmpl",
+}
+
+
+def test_dead_paperclip_dependencies_are_removed() -> None:
+    for relative in ("app", "scripts"):
+        for path in (ROOT / relative).rglob("*"):
+            if path.is_file() and path.suffix in SOURCE_SUFFIXES:
+                text = path.read_text(encoding="utf-8", errors="ignore")
+                for token in DEAD_TOKENS:
+                    assert token not in text, f"dead token {token!r} remains in {path}"
+    assert not hasattr(settings, "paperclip_api_url")
+    assert not hasattr(settings, "paperclip_api_key")
+
+
+def test_remaining_paperclip_references_are_compatibility_surfaces() -> None:
+    paths = set()
+    for relative in ("app", "scripts"):
+        for path in (ROOT / relative).rglob("*"):
+            if (
+                path.is_file()
+                and path.suffix in SOURCE_SUFFIXES
+                and "paperclip" in path.read_text(
+                encoding="utf-8", errors="ignore"
+                ).lower()
+            ):
+                paths.add(path.relative_to(ROOT).as_posix())
+    assert paths <= ALLOWED_REFERENCE_FILES
+
+
+def test_legacy_named_compatibility_contracts_remain() -> None:
+    assert CALLER_AGENT_ID_HEADER == "x-paperclip-agent-id"
+    assert "paperclip_issue_id" in TradeJournal.__table__.columns
+    assert "ix_trade_journals_paperclip_issue_id" in {
+        index.name for index in TradeJournal.__table__.indexes
+    }
+```
+
+- [ ] **Step 2: Run the new test and verify RED**
+
+Run: `uv run pytest --no-cov -q tests/test_paperclip_residue_inventory.py`
+
+Expected: FAIL because the settings, CIO loader/option, and dead tokens still exist.
+
+- [ ] **Step 3: Implement the minimal cleanup**
+
+Delete the two unused settings, the CIO Paperclip loader/CLI branch/imports/export, and the two matching lines from the local `.env.prod`. Preserve the header constant and shell header emission. Preserve the trade-journal column/index/arguments and update their nearby comments and current MCP documentation to say `external issue key (legacy Paperclip name; current Linear ROB key)`.
+
+- [ ] **Step 4: Run focused tests and verify GREEN**
+
+Run: `uv run pytest --no-cov -q tests/test_paperclip_residue_inventory.py tests/test_mcp_call_template.py tests/test_mcp_caller_identity_middleware.py tests/test_trade_journal_model.py tests/test_mcp_trade_journal.py tests/test_mcp_execution_tools.py tests/mcp_server/tooling/test_toss_live_ledger.py`
+
+Expected: all selected tests pass; only pre-existing warnings may remain.
+
+- [ ] **Step 5: Verify acceptance and quality gates**
+
+Run: `git grep -in paperclip -- app scripts ':!docs/plans/**'`
+
+Expected: every result is either the canonical legacy caller header/template or the retained trade-journal external-issue compatibility surface, with an explanatory comment.
+
+Run: `make lint`
+
+Expected: Ruff checks, Ruff formatting checks, and ty checks all exit 0.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/core/config.py scripts/cio_quality_gate.py \
+  app/mcp_server/caller_identity_middleware.py app/mcp_server/main.py \
+  app/mcp_server/tooling/trade_journal_tools.py \
+  app/mcp_server/tooling/trade_journal_registration.py \
+  app/models/trade_journal.py app/schemas/trade_retrospective.py \
+  app/mcp_server/README.md scripts/templates/mcp_call.sh.tmpl \
+  tests/test_paperclip_residue_inventory.py
+git commit -m "chore(ROB-865): remove dead Paperclip integrations"
+```

--- a/docs/superpowers/specs/2026-07-13-rob-865-paperclip-residue-cleanup-design.md
+++ b/docs/superpowers/specs/2026-07-13-rob-865-paperclip-residue-cleanup-design.md
@@ -1,0 +1,21 @@
+# ROB-865 Paperclip Residue Cleanup Design
+
+## Goal
+
+Remove only the dead Paperclip integration inventory after ROB-864 while preserving every compatibility surface that still carries a legacy Paperclip name.
+
+## Scope
+
+- Remove `paperclip_api_url` and `paperclip_api_key` from runtime settings and remove the corresponding local production environment entries.
+- Remove `scripts/cio_quality_gate.py`'s `load_from_paperclip` function and `--paperclip-issue` input mode.
+- Preserve `x-paperclip-agent-id` as the canonical deployed MCP caller identity header. Keep the shell template's header and `PAPERCLIP_AGENT_ID` substitution variable for compatibility, and document why the legacy name remains.
+- Preserve `trade_journals.paperclip_issue_id`, its index, MCP arguments, filtering behavior, and schema references. Update comments and current documentation to describe it as an external issue key whose legacy name comes from Paperclip and whose current values are Linear ROB keys.
+- Do not edit archived `docs/plans/**` documents.
+
+## Verification Design
+
+A repository inventory test will make the acceptance boundary executable. It will reject the dead settings, environment tokens, CLI option, and loader symbol; allow remaining `paperclip` references only in the legacy-header and trade-journal compatibility surfaces; and assert that the canonical header, database column, and index remain unchanged. Existing caller-identity, MCP template, trade-journal, and ROB-864 tests will run alongside the new regression test.
+
+## Safety
+
+No database migration is created because the legacy column and index remain. No MCP caller header is renamed or aliased because the deployed canonical value is intentionally unchanged. The cleanup removes no active authorization mechanism; ROB-864 already replaced the former approval lookup with Telegram two-step confirmation.

--- a/scripts/cio_quality_gate.py
+++ b/scripts/cio_quality_gate.py
@@ -2,14 +2,12 @@
 """CIO Scout Report Quality Gate CLI.
 
 Thin wrapper around :mod:`app.services.cio_quality_gate_service`. Reads a
-Scout Report markdown from a file, stdin, or a Paperclip issue comment thread,
-runs the G1~G6 gate sweep, and prints either the CIO runbook-shaped markdown
-summary or a JSON payload.
+Scout Report markdown from a file or stdin, runs the G1~G6 gate sweep, and
+prints either the CIO runbook-shaped markdown summary or a JSON payload.
 
 Usage:
     uv run python scripts/cio_quality_gate.py path/to/scout_report.md
     uv run python scripts/cio_quality_gate.py --stdin < scout.md
-    uv run python scripts/cio_quality_gate.py --paperclip-issue ROB-158
 
 Exit codes:
     0 = all gates pass (ACCEPT)
@@ -21,8 +19,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import os
-import subprocess
 import sys
 from pathlib import Path
 
@@ -43,30 +39,6 @@ from app.services.cio_quality_gate_service import (  # noqa: E402
     render_report,
     run_gates,
 )
-
-
-def load_from_paperclip(issue_id: str) -> str:
-    api_url = os.environ.get("PAPERCLIP_API_URL")
-    api_key = os.environ.get("PAPERCLIP_API_KEY")
-    if not (api_url and api_key):
-        raise SystemExit(
-            "PAPERCLIP_API_URL and PAPERCLIP_API_KEY must be set to use "
-            "--paperclip-issue"
-        )
-    cmd = [
-        "curl",
-        "-sS",
-        "-H",
-        f"Authorization: Bearer {api_key}",
-        f"{api_url}/api/issues/{issue_id}/comments",
-    ]
-    result = subprocess.run(cmd, capture_output=True, text=True, check=True)
-    comments = json.loads(result.stdout)
-    if not isinstance(comments, list) or not comments:
-        raise SystemExit(f"No comments found on {issue_id}")
-    largest = max(comments, key=lambda c: len(c.get("body", "")))
-    return largest["body"]
-
 
 def _json_payload(report: QualityGateReport) -> dict:
     return {
@@ -107,11 +79,6 @@ def main(argv: list[str] | None = None) -> int:
     src = p.add_mutually_exclusive_group(required=True)
     src.add_argument("path", nargs="?", help="Path to Scout Report markdown file")
     src.add_argument("--stdin", action="store_true", help="Read markdown from stdin")
-    src.add_argument(
-        "--paperclip-issue",
-        dest="paperclip_issue",
-        help="Fetch largest comment from a Paperclip issue (e.g. ROB-158)",
-    )
     p.add_argument("--json", dest="as_json", action="store_true", help="Emit JSON")
     p.add_argument(
         "--cash",
@@ -130,8 +97,6 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.stdin:
         md = sys.stdin.read()
-    elif args.paperclip_issue:
-        md = load_from_paperclip(args.paperclip_issue)
     else:
         md = Path(args.path).read_text(encoding="utf-8")
 
@@ -161,7 +126,6 @@ __all__ = [
     "build_reopen_comment",
     "evaluate_scout_report",
     "extract_candidates",
-    "load_from_paperclip",
     "main",
     "render_report",
     "run_gates",

--- a/scripts/cio_quality_gate.py
+++ b/scripts/cio_quality_gate.py
@@ -40,6 +40,7 @@ from app.services.cio_quality_gate_service import (  # noqa: E402
     run_gates,
 )
 
+
 def _json_payload(report: QualityGateReport) -> dict:
     return {
         "candidates": [

--- a/scripts/templates/mcp_call.sh.tmpl
+++ b/scripts/templates/mcp_call.sh.tmpl
@@ -8,9 +8,11 @@
 #
 # Why this template exists:
 #   ST-3 (ROB-212) switches MCP caller identity from tool-arg self-assertion
-#   to middleware-extracted HTTP header. Every caller MUST send the
-#   `x-paperclip-agent-id` header; otherwise defensive_trim and future
-#   caller-identity-gated tools reject the call.
+#   to a middleware-extracted HTTP header. `PAPERCLIP_AGENT_ID` and
+#   `x-paperclip-agent-id` are canonical legacy Paperclip-named compatibility
+#   surfaces and MUST NOT be renamed. Every caller MUST send the header;
+#   otherwise defensive_trim and future caller-identity-gated tools reject the
+#   call.
 #   Do NOT set MCP_CALLER_AGENT_ID for this HTTP bridge. That env fallback is
 #   DEV/stdio only and MUST NOT be used in production HTTP deployments.
 #
@@ -18,7 +20,7 @@
 #   1. Export the three env vars below (values differ per host / session):
 #        export MCP_ENDPOINT="http://127.0.0.1:8765/mcp"
 #        export MCP_AUTH_TOKEN="<bearer token from env.MCP_AUTH_TOKEN>"
-#        export PAPERCLIP_AGENT_ID="<calling agent's Paperclip agent id>"
+#        export PAPERCLIP_AGENT_ID="<calling agent id>"
 #      Optional:
 #        export MCP_SESSION_ID="<MCP session id from session/init handshake>"
 #   2. Regenerate `/tmp/mcp_call.sh` from this template (pass an explicit

--- a/tests/mcp_server/tooling/test_toss_live_ledger.py
+++ b/tests/mcp_server/tooling/test_toss_live_ledger.py
@@ -578,8 +578,6 @@ async def test_toss_loss_cut_proposal_approval_submit_and_reconcile_e2e(
     monkeypatch.setattr(settings, "ORDER_PROPOSALS_TELEGRAM_CHAT_ALLOWLIST_STR", "42")
     monkeypatch.setattr(settings, "ORDER_PROPOSALS_SUBMIT_AGENT_ID", submit_agent_id)
     monkeypatch.setattr(settings, "LOSS_CUT_ALLOWED_AGENT_IDS", [submit_agent_id])
-    monkeypatch.setattr(settings, "paperclip_api_url", None)
-    monkeypatch.setattr(settings, "paperclip_api_key", None)
     monkeypatch.setattr(toss_orders, "validate_toss_api_config", lambda: [])
     monkeypatch.setattr(toss_orders.TossReadClient, "from_settings", lambda: client)
     monkeypatch.setattr(toss_orders.settings, "toss_api_enabled", True)

--- a/tests/test_paperclip_residue_inventory.py
+++ b/tests/test_paperclip_residue_inventory.py
@@ -1,0 +1,59 @@
+from pathlib import Path
+
+from app.core.config import settings
+from app.mcp_server.caller_identity_middleware import CALLER_AGENT_ID_HEADER
+from app.models.trade_journal import TradeJournal
+
+ROOT = Path(__file__).resolve().parent.parent
+SOURCE_SUFFIXES = {".md", ".py", ".sh", ".tmpl"}
+DEAD_TOKENS = {
+    "paperclip_api_url",
+    "paperclip_api_key",
+    "PAPERCLIP_API_URL",
+    "PAPERCLIP_API_KEY",
+    "load_from_paperclip",
+    "--paperclip-issue",
+}
+ALLOWED_REFERENCE_FILES = {
+    "app/mcp_server/README.md",
+    "app/mcp_server/caller_identity_middleware.py",
+    "app/mcp_server/main.py",
+    "app/mcp_server/tooling/trade_journal_registration.py",
+    "app/mcp_server/tooling/trade_journal_tools.py",
+    "app/models/trade_journal.py",
+    "app/schemas/trade_retrospective.py",
+    "scripts/templates/mcp_call.sh.tmpl",
+}
+
+
+def test_dead_paperclip_dependencies_are_removed() -> None:
+    for relative in ("app", "scripts"):
+        for path in (ROOT / relative).rglob("*"):
+            if path.is_file() and path.suffix in SOURCE_SUFFIXES:
+                text = path.read_text(encoding="utf-8", errors="ignore")
+                for token in DEAD_TOKENS:
+                    assert token not in text, f"dead token {token!r} remains in {path}"
+    assert not hasattr(settings, "paperclip_api_url")
+    assert not hasattr(settings, "paperclip_api_key")
+
+
+def test_remaining_paperclip_references_are_compatibility_surfaces() -> None:
+    paths = set()
+    for relative in ("app", "scripts"):
+        for path in (ROOT / relative).rglob("*"):
+            if (
+                path.is_file()
+                and path.suffix in SOURCE_SUFFIXES
+                and "paperclip"
+                in path.read_text(encoding="utf-8", errors="ignore").lower()
+            ):
+                paths.add(path.relative_to(ROOT).as_posix())
+    assert paths <= ALLOWED_REFERENCE_FILES
+
+
+def test_legacy_named_compatibility_contracts_remain() -> None:
+    assert CALLER_AGENT_ID_HEADER == "x-paperclip-agent-id"
+    assert "paperclip_issue_id" in TradeJournal.__table__.columns
+    assert "ix_trade_journals_paperclip_issue_id" in {
+        index.name for index in TradeJournal.__table__.indexes
+    }

--- a/tests/test_paperclip_residue_inventory.py
+++ b/tests/test_paperclip_residue_inventory.py
@@ -1,3 +1,6 @@
+import os
+import subprocess
+from collections.abc import Iterator
 from pathlib import Path
 
 from app.core.config import settings
@@ -5,7 +8,6 @@ from app.mcp_server.caller_identity_middleware import CALLER_AGENT_ID_HEADER
 from app.models.trade_journal import TradeJournal
 
 ROOT = Path(__file__).resolve().parent.parent
-SOURCE_SUFFIXES = {".md", ".py", ".sh", ".tmpl"}
 DEAD_TOKENS = {
     "paperclip_api_url",
     "paperclip_api_key",
@@ -24,31 +26,56 @@ ALLOWED_REFERENCE_FILES = {
     "app/schemas/trade_retrospective.py",
     "scripts/templates/mcp_call.sh.tmpl",
 }
+COMPATIBILITY_MARKERS = {
+    "x-paperclip-agent-id",
+    "paperclip_agent_id",
+    "paperclip_issue_id",
+    "legacy paperclip",
+    "paperclip-named",
+}
+
+
+def _tracked_texts() -> Iterator[tuple[Path, str]]:
+    tracked = subprocess.run(
+        ["git", "ls-files", "-z", "--", "app", "scripts"],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+    ).stdout
+    for raw_path in tracked.split(b"\0"):
+        if not raw_path:
+            continue
+        path = ROOT / os.fsdecode(raw_path)
+        content = path.read_bytes()
+        if b"\0" not in content:
+            yield path, content.decode("utf-8", errors="ignore")
 
 
 def test_dead_paperclip_dependencies_are_removed() -> None:
-    for relative in ("app", "scripts"):
-        for path in (ROOT / relative).rglob("*"):
-            if path.is_file() and path.suffix in SOURCE_SUFFIXES:
-                text = path.read_text(encoding="utf-8", errors="ignore")
-                for token in DEAD_TOKENS:
-                    assert token not in text, f"dead token {token!r} remains in {path}"
+    for path, text in _tracked_texts():
+        for token in DEAD_TOKENS:
+            assert token not in text, f"dead token {token!r} remains in {path}"
     assert not hasattr(settings, "paperclip_api_url")
     assert not hasattr(settings, "paperclip_api_key")
 
 
 def test_remaining_paperclip_references_are_compatibility_surfaces() -> None:
-    paths = set()
-    for relative in ("app", "scripts"):
-        for path in (ROOT / relative).rglob("*"):
-            if (
-                path.is_file()
-                and path.suffix in SOURCE_SUFFIXES
-                and "paperclip"
-                in path.read_text(encoding="utf-8", errors="ignore").lower()
-            ):
-                paths.add(path.relative_to(ROOT).as_posix())
-    assert paths <= ALLOWED_REFERENCE_FILES
+    for path, text in _tracked_texts():
+        paperclip_lines = [
+            (line_number, line)
+            for line_number, line in enumerate(text.splitlines(), start=1)
+            if "paperclip" in line.lower()
+        ]
+        if not paperclip_lines:
+            continue
+
+        relative_path = path.relative_to(ROOT).as_posix()
+        assert relative_path in ALLOWED_REFERENCE_FILES
+        for line_number, line in paperclip_lines:
+            normalized_line = line.lower()
+            assert any(marker in normalized_line for marker in COMPATIBILITY_MARKERS), (
+                f"unmarked Paperclip reference in {relative_path}:{line_number}: {line}"
+            )
 
 
 def test_legacy_named_compatibility_contracts_remain() -> None:

--- a/tests/test_paperclip_residue_inventory.py
+++ b/tests/test_paperclip_residue_inventory.py
@@ -37,7 +37,15 @@ COMPATIBILITY_MARKERS = {
 
 def _tracked_texts() -> Iterator[tuple[Path, str]]:
     tracked = subprocess.run(
-        ["git", "ls-files", "-z", "--", "app", "scripts"],
+        [
+            "git",
+            "ls-files",
+            "-z",
+            "--",
+            "app",
+            "scripts",
+            "docs/runbooks/CIO_QUALITY_GATE.md",
+        ],
         cwd=ROOT,
         check=True,
         capture_output=True,


### PR DESCRIPTION
## Summary
- remove dead Paperclip API settings and the CIO gate Paperclip issue loader/CLI path
- add a tracked-source inventory test that permits only intentional compatibility references
- update the current CIO runbook and clarify preserved legacy naming contracts

## Preserved compatibility surfaces
- `x-paperclip-agent-id` remains the canonical MCP caller identity header
- `trade_journal.paperclip_issue_id` remains intact, including model column, index, schemas, filters, and MCP API behavior; comments/documentation only changed

## Verification
- TDD RED: inventory assertions failed before implementation (2 failed, 1 passed)
- TDD GREEN: focused ROB-865/MCP/CIO coverage passed
- direct Ruff check + format check: passed
- `make lint`: passed (Ruff + ty)
- `make test`: 14,622 passed, 10 skipped; one unrelated ROB-844 Binance demo test failed because the shared local PostgreSQL is ahead of `origin/main` at missing revision `20260713_rob844_ack_scope`, whose broker-ACK unique index includes `instrument_id`. The test/service have no diff in this PR.

Linear: ROB-865