### PR TITLE
feat(ROB-862): allow evidence-gated unverified proposal void

### DIFF
--- a/app/mcp_server/README.md
+++ b/app/mcp_server/README.md
@@ -625,9 +625,20 @@ order mutation.
     diff, and approval-hash checks and may submit.
 - `order_proposal_void(proposal_id, reason)`
   - Requires a non-blank operator reason.
-  - Refuses to mutate a proposal if any rung can have outstanding broker state.
-    Rungs at or after submit cause the whole request to fail closed, with no
-    partial local void.
+  - Pre-submit rungs retain the existing local `voided` path. An `unverified`
+    rung is eligible only after a five-minute broker settlement grace and a
+    fresh account-scoped lookup prove the order absent; it then becomes
+    `voided_local_stale`, with the lookup scope and result appended to
+    `void_reason`.
+  - A found broker order, incomplete lookup, timeout, provider error, or local
+    accepted-only Toss ledger row rejects the whole request without partial
+    mutation. Timeout-to-`unverified` is never auto-voided.
+  - Toss order-list `clientOrderId` is optional: when a rung has no broker order
+    ID, any non-empty response that omits it is inconclusive. KIS US empty
+    history is also inconclusive because the shared history adapter cannot prove
+    every exchange inquiry completed. Both cases fail closed.
+  - After a successful void, the recorded Telegram approval message is edited
+    without an inline keyboard so stale approval buttons no longer remain live.
 
 Telegram approval runs fresh broker-specific checks at the submit-capable
 click. KIS/Upbit rerun their applicable ROB-800 checks through

--- a/app/mcp_server/tooling/order_proposal_tools.py
+++ b/app/mcp_server/tooling/order_proposal_tools.py
@@ -8,6 +8,7 @@ row; it performs NO broker mutation.
 from __future__ import annotations
 
 import logging
+import re
 import uuid
 from datetime import datetime
 from decimal import Decimal, InvalidOperation
@@ -17,7 +18,10 @@ from app.core.config import settings
 from app.core.db import AsyncSessionLocal
 from app.core.timezone import now_kst
 from app.services.order_proposals import OrderProposalsService
-from app.services.order_proposals.broker_gateway import fetch_target_order
+from app.services.order_proposals.broker_gateway import (
+    fetch_operator_void_evidence,
+    fetch_target_order,
+)
 from app.services.order_proposals.dispatch import send_proposal_for_approval
 from app.services.order_proposals.errors import (
     OrderProposalError,
@@ -95,6 +99,52 @@ def _rung_dict(r: Any) -> dict[str, Any]:
         "broker_order_id": r.broker_order_id,
         "correlation_id": r.correlation_id,
     }
+
+
+def _get_trade_notifier() -> Any:
+    from app.monitoring.trade_notifier.notifier import get_trade_notifier
+
+    return get_trade_notifier()
+
+
+def _escape_telegram_markdown(value: str) -> str:
+    escaped = value.replace("\\", "\\\\")
+    return re.sub(r"([_*`\[])", r"\\\1", escaped)
+
+
+async def _fetch_void_evidence(*, group: Any, rungs: list[Any], now: datetime) -> Any:
+    return await fetch_operator_void_evidence(
+        account_mode=group.account_mode,
+        market=group.market,
+        symbol=group.symbol,
+        rungs=rungs,
+        now=now,
+    )
+
+
+async def _edit_voided_approval_message(
+    *, chat_id: Any, message_id: Any, void_reason: str
+) -> None:
+    if chat_id is None or message_id is None:
+        return
+    try:
+        edited = await _get_trade_notifier().edit_message(
+            str(chat_id),
+            int(message_id),
+            f"🗑️ 제안 무효화됨\n사유: {_escape_telegram_markdown(void_reason)}",
+            reply_markup={"inline_keyboard": []},
+        )
+        if edited is False:
+            logger.error(
+                "order_proposal_void: telegram message edit returned false "
+                "for message_id=%s",
+                message_id,
+            )
+    except Exception:  # noqa: BLE001 - DB void is already committed
+        logger.exception(
+            "order_proposal_void: telegram message edit failed for message_id=%s",
+            message_id,
+        )
 
 
 async def order_proposal_create(
@@ -289,16 +339,31 @@ async def order_proposal_void(proposal_id: str, reason: str) -> dict[str, Any]:
             raise ValueError("void reason is required")
         async with AsyncSessionLocal() as session:
             service = OrderProposalsService(session)
-            await service.void_proposal(pid, reason=normalized_reason, now=now_kst())
+            now = now_kst()
+            await service.void_proposal(
+                pid,
+                reason=normalized_reason,
+                now=now,
+                broker_evidence=_fetch_void_evidence,
+            )
             group, rungs = await service.get_proposal(pid)
+            source_asof = group.source_asof or {}
+            approval_chat_id = source_asof.get("approval_chat_id")
+            approval_message_id = source_asof.get("approval_message_id")
             await session.commit()
-            return {
+            result = {
                 "success": True,
                 "proposal_id": proposal_id,
                 "lifecycle_state": group.lifecycle_state,
                 "void_reason": group.void_reason,
                 "rungs": [_rung_dict(rung) for rung in rungs],
             }
+        await _edit_voided_approval_message(
+            chat_id=approval_chat_id,
+            message_id=approval_message_id,
+            void_reason=result["void_reason"],
+        )
+        return result
     except (ValueError, OrderProposalError) as exc:
         return {"success": False, "error": str(exc)}
 
@@ -334,8 +399,10 @@ def register_order_proposal_tools(mcp: FastMCP) -> None:
     _ = mcp.tool(
         name="order_proposal_void",
         description=(
-            "Void an unsubmitted order proposal with a required operator reason. "
-            "NOT a broker mutation."
+            "Void an order proposal with a required operator reason. Unverified "
+            "rungs require a five-minute settlement grace plus a fresh, conclusive "
+            "broker-absence lookup and become voided_local_stale; found or "
+            "inconclusive broker evidence fails closed. NOT a broker mutation."
         ),
     )(order_proposal_void)
 

--- a/app/services/brokers/toss/dto.py
+++ b/app/services/brokers/toss/dto.py
@@ -97,6 +97,7 @@ class TossOrder:
     ordered_at: str
     canceled_at: str | None
     execution: dict[str, Any]
+    client_order_id: str | None = None
 
 
 @dataclass(frozen=True)
@@ -207,6 +208,11 @@ def parse_orders(raw: dict[str, Any]) -> TossOrdersPage:
                 ordered_at=str(row["orderedAt"]),
                 canceled_at=row.get("canceledAt"),
                 execution=_parse_execution(dict(row.get("execution") or {})),
+                client_order_id=(
+                    str(row["clientOrderId"])
+                    if row.get("clientOrderId") is not None
+                    else None
+                ),
             )
         )
     return TossOrdersPage(

--- a/app/services/order_proposals/broker_gateway.py
+++ b/app/services/order_proposals/broker_gateway.py
@@ -29,6 +29,18 @@ class SubmitEvidence:
     reason: str | None = None
 
 
+@dataclass(frozen=True)
+class OperatorVoidEvidence:
+    outcome: Literal["found", "absent", "unknown"]
+    lookup_scope: str
+    broker_order_id: str | None = None
+    broker_state: str | None = None
+    reason: str | None = None
+
+
+_TOSS_CLOSED_PAGE_CAP = 20
+
+
 async def _maybe_await(value: Any) -> Any:
     return await value if inspect.isawaitable(value) else value
 
@@ -108,6 +120,277 @@ async def fetch_submit_evidence(
         return SubmitEvidence("unknown", reason=describe_exception(exc))
     except Exception as exc:
         return SubmitEvidence("unknown", reason=describe_exception(exc))
+
+
+async def fetch_operator_void_evidence(
+    *,
+    account_mode: str,
+    market: str,
+    symbol: str,
+    rungs: list[Any],
+    now: datetime,
+    toss_client: Any | None = None,
+    history_fn: Callable[..., Any] | None = None,
+    upbit_identifier_lookup_fn: Callable[..., Any] | None = None,
+    upbit_order_lookup_fn: Callable[..., Any] | None = None,
+) -> dict[int, OperatorVoidEvidence]:
+    """Prove broker-order absence for explicit operator voids.
+
+    Toss is scanned once for OPEN orders and through a bounded CLOSED window.
+    An incomplete scan or any broker exception is ``unknown`` so callers fail
+    closed instead of treating missing evidence as cancellation evidence.
+    """
+    if account_mode == "kis_live" and market in {"equity_kr", "equity_us"}:
+        if history_fn is None:
+            from app.mcp_server.tooling.orders_history import get_order_history_impl
+
+            history_fn = get_order_history_impl
+        lookup_days = max(
+            1,
+            (now.date() - min(rung.created_at for rung in rungs).date()).days + 1,
+        )
+        scope = f"kis order history status=all days={lookup_days}"
+        try:
+            history = await _maybe_await(
+                history_fn(
+                    symbol=symbol,
+                    status="all",
+                    market=market,
+                    days=lookup_days,
+                    limit=-1,
+                    is_mock=False,
+                )
+            )
+            if history.get("truncated"):
+                reason = "broker history lookup truncated"
+                return {
+                    rung.rung_index: OperatorVoidEvidence(
+                        "unknown", scope, reason=reason
+                    )
+                    for rung in rungs
+                }
+            if history.get("errors"):
+                reason = f"broker history errors: {history['errors']}"
+                return {
+                    rung.rung_index: OperatorVoidEvidence(
+                        "unknown", scope, reason=reason
+                    )
+                    for rung in rungs
+                }
+            orders = history.get("orders", [])
+            result = {}
+            for rung in rungs:
+                order_id = str(rung.broker_order_id or "").strip()
+                match = next(
+                    (
+                        order
+                        for order in orders
+                        if str(order.get("order_id") or "").strip() == order_id
+                    ),
+                    None,
+                )
+                if match is not None:
+                    result[rung.rung_index] = OperatorVoidEvidence(
+                        "found",
+                        scope,
+                        broker_order_id=order_id,
+                        broker_state=str(match.get("status") or "unknown"),
+                    )
+                elif order_id and market == "equity_kr":
+                    result[rung.rung_index] = OperatorVoidEvidence("absent", scope)
+                elif order_id:
+                    # The shared KIS US history adapter can return partial
+                    # results when an exchange's open-order inquiry fails.
+                    # A match is still positive evidence, but an empty result
+                    # is not complete enough to prove absence.
+                    result[rung.rung_index] = OperatorVoidEvidence(
+                        "unknown",
+                        scope,
+                        reason="KIS US history absence cannot be proven complete",
+                    )
+                else:
+                    result[rung.rung_index] = OperatorVoidEvidence(
+                        "unknown",
+                        scope,
+                        reason="KIS rung has no broker_order_id",
+                    )
+            return result
+        except Exception as exc:
+            return {
+                rung.rung_index: OperatorVoidEvidence(
+                    "unknown", scope, reason=describe_exception(exc)
+                )
+                for rung in rungs
+            }
+
+    if account_mode == "upbit" and market == "crypto":
+        if upbit_identifier_lookup_fn is None or upbit_order_lookup_fn is None:
+            from app.services.brokers.upbit.orders import (
+                fetch_order_by_identifier,
+                fetch_order_detail,
+            )
+
+            upbit_identifier_lookup_fn = (
+                upbit_identifier_lookup_fn or fetch_order_by_identifier
+            )
+            upbit_order_lookup_fn = upbit_order_lookup_fn or fetch_order_detail
+        result = {}
+        for rung in rungs:
+            identifier = str(rung.idempotency_key or "").strip()
+            order_id = str(rung.broker_order_id or "").strip()
+            key_kind = "identifier" if identifier else "broker_order_id"
+            key = identifier or order_id
+            scope = f"upbit GET /order by {key_kind}"
+            if not key:
+                result[rung.rung_index] = OperatorVoidEvidence(
+                    "unknown", scope, reason="rung has no broker lookup identifier"
+                )
+                continue
+            lookup_fn = (
+                upbit_identifier_lookup_fn if identifier else upbit_order_lookup_fn
+            )
+            try:
+                order = await _maybe_await(lookup_fn(key))
+                found_id = str(order.get("uuid") or "").strip()
+                state = str(order.get("state") or "").strip()
+                if not found_id or not state:
+                    result[rung.rung_index] = OperatorVoidEvidence(
+                        "unknown",
+                        scope,
+                        reason="broker lookup returned incomplete order evidence",
+                    )
+                else:
+                    result[rung.rung_index] = OperatorVoidEvidence(
+                        "found", scope, found_id, state
+                    )
+            except httpx.HTTPStatusError as exc:
+                if exc.response.status_code == 404:
+                    result[rung.rung_index] = OperatorVoidEvidence("absent", scope)
+                else:
+                    result[rung.rung_index] = OperatorVoidEvidence(
+                        "unknown", scope, reason=describe_exception(exc)
+                    )
+            except Exception as exc:
+                result[rung.rung_index] = OperatorVoidEvidence(
+                    "unknown", scope, reason=describe_exception(exc)
+                )
+        return result
+
+    if account_mode != "toss_live" or market not in {"equity_kr", "equity_us"}:
+        scope = f"unsupported {account_mode}/{market}"
+        return {
+            rung.rung_index: OperatorVoidEvidence(
+                "unknown", scope, reason="operator void lookup unsupported"
+            )
+            for rung in rungs
+        }
+
+    from app.core.timezone import KST
+    from app.services.brokers.toss.client import TossReadClient
+
+    window_from = (
+        min(rung.created_at for rung in rungs).astimezone(KST).date().isoformat()
+    )
+    window_to = now.astimezone(KST).date().isoformat()
+    owns_client = toss_client is None
+    client = toss_client or TossReadClient.from_settings()
+    orders: list[Any] = []
+    closed_pages = 0
+    incomplete_reason: str | None = None
+    try:
+        open_page = await client.list_orders(status="OPEN", symbol=symbol)
+        orders.extend(open_page.orders)
+
+        cursor: str | None = None
+        seen_cursors: set[str] = set()
+        while True:
+            page = await client.list_orders(
+                status="CLOSED",
+                symbol=symbol,
+                from_date=window_from,
+                to_date=window_to,
+                cursor=cursor,
+                limit=100,
+            )
+            orders.extend(page.orders)
+            closed_pages += 1
+            if not page.has_next:
+                break
+            if not page.next_cursor:
+                incomplete_reason = "CLOSED order scan missing next cursor"
+                break
+            if page.next_cursor == cursor or page.next_cursor in seen_cursors:
+                incomplete_reason = "CLOSED order scan repeated cursor"
+                break
+            if closed_pages >= _TOSS_CLOSED_PAGE_CAP:
+                incomplete_reason = "CLOSED order scan page cap reached"
+                break
+            seen_cursors.add(page.next_cursor)
+            cursor = page.next_cursor
+
+        scope = (
+            "toss GET /orders OPEN + CLOSED "
+            f"{window_from}..{window_to} pages={closed_pages} "
+            f"complete={str(incomplete_reason is None).lower()}"
+        )
+        result: dict[int, OperatorVoidEvidence] = {}
+        for rung in rungs:
+            broker_order_id = str(rung.broker_order_id or "").strip()
+            idempotency_key = str(rung.idempotency_key or "").strip()
+            match = next(
+                (
+                    order
+                    for order in orders
+                    if (broker_order_id and str(order.order_id) == broker_order_id)
+                    or (
+                        idempotency_key
+                        and str(getattr(order, "client_order_id", "") or "")
+                        == idempotency_key
+                    )
+                ),
+                None,
+            )
+            if match is not None:
+                result[rung.rung_index] = OperatorVoidEvidence(
+                    "found",
+                    scope,
+                    broker_order_id=str(match.order_id),
+                    broker_state=str(match.status),
+                )
+            elif not broker_order_id and not idempotency_key:
+                result[rung.rung_index] = OperatorVoidEvidence(
+                    "unknown", scope, reason="rung has no broker lookup identifier"
+                )
+            elif (
+                idempotency_key
+                and not broker_order_id
+                and any(
+                    getattr(order, "client_order_id", None) is None for order in orders
+                )
+            ):
+                result[rung.rung_index] = OperatorVoidEvidence(
+                    "unknown",
+                    scope,
+                    reason="broker order list omitted clientOrderId",
+                )
+            elif incomplete_reason is not None:
+                result[rung.rung_index] = OperatorVoidEvidence(
+                    "unknown", scope, reason=incomplete_reason
+                )
+            else:
+                result[rung.rung_index] = OperatorVoidEvidence("absent", scope)
+        return result
+    except Exception as exc:
+        scope = f"toss GET /orders OPEN + CLOSED {window_from}..{window_to} incomplete"
+        return {
+            rung.rung_index: OperatorVoidEvidence(
+                "unknown", scope, reason=describe_exception(exc)
+            )
+            for rung in rungs
+        }
+    finally:
+        if owns_client:
+            await client.aclose()
 
 
 async def cancel_target_order(

--- a/app/services/order_proposals/errors.py
+++ b/app/services/order_proposals/errors.py
@@ -24,7 +24,8 @@ class OrderProposalInvalidStateTransition(OrderProposalError):
         acked            -> {filled, partially_filled, cancelled, unverified}
         resting          -> {filled, partially_filled, cancelled, expired, unverified}
         partially_filled -> {filled, cancelled, expired, unverified}
-        unverified       -> {filled, partially_filled, cancelled, expired, rejected}
+        unverified       -> {filled, partially_filled, cancelled, expired, rejected,
+                             voided_local_stale}
         draft            -> {pending_approval, voided}
         (terminal: filled, cancelled, expired, rejected, voided,
                    voided_local_stale, superseded)

--- a/app/services/order_proposals/service.py
+++ b/app/services/order_proposals/service.py
@@ -14,11 +14,12 @@ from datetime import UTC, datetime, timedelta
 from decimal import Decimal
 from typing import Any, Literal
 
-from sqlalchemy import text
+from sqlalchemy import or_, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.timezone import KST
 from app.models.order_proposals import OrderProposal, OrderProposalRung
+from app.models.review import TossLiveOrderLedger
 from app.services.order_proposals import state_machine as sm
 from app.services.order_proposals.broker_gateway import SUPPORTED_TARGET_ACTIONS
 from app.services.order_proposals.errors import (
@@ -78,6 +79,7 @@ _ALLOWED_ACTION_CONTRACT_MESSAGE = (
 _LOSS_CUT_EXIT_REASONS = frozenset({"stop_loss", "thesis_change"})
 _LOSS_CUT_TRIGGER_TYPES = frozenset({"stop_loss", "thesis_change"})
 _LOSS_CUT_MAX_AGE = timedelta(hours=72)
+_UNVERIFIED_VOID_SETTLEMENT_GRACE = timedelta(minutes=5)
 _VOIDABLE_RUNG_STATES = frozenset(
     {"draft", "pending_approval", "revalidating", "needs_reconfirm", "approved"}
 )
@@ -525,7 +527,12 @@ class OrderProposalsService:
         return True
 
     async def void_proposal(
-        self, proposal_id: uuid.UUID, *, reason: str, now: datetime
+        self,
+        proposal_id: uuid.UUID,
+        *,
+        reason: str,
+        now: datetime,
+        broker_evidence: Callable[..., Any] | None = None,
     ) -> list[OrderProposalRung]:
         self._require_timezone_aware(now)
         reason = reason.strip()
@@ -536,8 +543,9 @@ class OrderProposalsService:
         if group is None:
             raise OrderProposalNotFound(str(proposal_id))
         rungs = await self._repo.list_rungs(group.id)
+        allowed_states = _VOIDABLE_RUNG_STATES | {"unverified"}
         invalid_rung = next(
-            (rung for rung in rungs if rung.state not in _VOIDABLE_RUNG_STATES), None
+            (rung for rung in rungs if rung.state not in allowed_states), None
         )
         if invalid_rung is not None:
             raise OrderProposalError(
@@ -545,16 +553,159 @@ class OrderProposalsService:
                 f"in state {invalid_rung.state!r}"
             )
 
+        unverified_rungs = [rung for rung in rungs if rung.state == "unverified"]
+        evidence_summary = ""
+        if unverified_rungs:
+            if broker_evidence is None:
+                invalid_rung = unverified_rungs[0]
+                raise OrderProposalError(
+                    f"cannot void proposal with rung {invalid_rung.rung_index} "
+                    "in state 'unverified' without broker absence evidence"
+                )
+            # The submit path records ``unverified`` only after its broker call
+            # has returned or raised. A successful Toss response commits its
+            # accepted-only ledger row before that path can transition the
+            # proposal. The grace interval covers broker-side visibility after
+            # an ambiguous timeout; the proposal row lock then prevents submit
+            # state changes while the remote scan and final ledger read run.
+            recent_rung = next(
+                (
+                    rung
+                    for rung in unverified_rungs
+                    if now - rung.updated_at < _UNVERIFIED_VOID_SETTLEMENT_GRACE
+                ),
+                None,
+            )
+            if recent_rung is not None:
+                raise OrderProposalError(
+                    "cannot void proposal: broker settlement grace has not elapsed "
+                    f"for unverified rung {recent_rung.rung_index} "
+                    f"(required={int(_UNVERIFIED_VOID_SETTLEMENT_GRACE.total_seconds())}s)"
+                )
+            try:
+                evidence_by_rung = broker_evidence(
+                    group=group,
+                    rungs=unverified_rungs,
+                    now=now,
+                )
+                if inspect.isawaitable(evidence_by_rung):
+                    evidence_by_rung = await evidence_by_rung
+            except Exception as exc:
+                raise OrderProposalError(
+                    f"broker evidence lookup failed; refusing void: {exc}"
+                ) from exc
+
+            toss_ledger_rows: list[TossLiveOrderLedger] = []
+            if group.account_mode == "toss_live":
+                client_order_ids = [
+                    str(rung.idempotency_key).strip()
+                    for rung in unverified_rungs
+                    if rung.idempotency_key
+                ]
+                broker_order_ids = [
+                    str(rung.broker_order_id).strip()
+                    for rung in unverified_rungs
+                    if rung.broker_order_id
+                ]
+                predicates = []
+                if client_order_ids:
+                    predicates.append(
+                        TossLiveOrderLedger.client_order_id.in_(client_order_ids)
+                    )
+                if broker_order_ids:
+                    predicates.append(
+                        TossLiveOrderLedger.broker_order_id.in_(broker_order_ids)
+                    )
+                if predicates:
+                    toss_ledger_rows = list(
+                        (
+                            await self._session.execute(
+                                select(TossLiveOrderLedger).where(or_(*predicates))
+                            )
+                        )
+                        .scalars()
+                        .all()
+                    )
+
+            summaries = []
+            for rung in unverified_rungs:
+                evidence = evidence_by_rung.get(rung.rung_index)
+                if evidence is None:
+                    raise OrderProposalError(
+                        "broker evidence lookup incomplete; refusing void for "
+                        f"unverified rung {rung.rung_index}"
+                    )
+                outcome = str(getattr(evidence, "outcome", "unknown"))
+                scope = " ".join(str(getattr(evidence, "lookup_scope", "")).split())
+                if outcome == "found":
+                    broker_state = getattr(evidence, "broker_state", None)
+                    broker_order_id = getattr(evidence, "broker_order_id", None)
+                    raise OrderProposalError(
+                        f"cannot void proposal: broker order exists for rung "
+                        f"{rung.rung_index} (state={broker_state!r}, "
+                        f"broker_order_id={broker_order_id!r}, scope={scope!r}); "
+                        "run reconcile"
+                    )
+                if outcome != "absent":
+                    evidence_reason = getattr(evidence, "reason", None)
+                    raise OrderProposalError(
+                        f"cannot void proposal: broker absence is unverified for rung "
+                        f"{rung.rung_index} (outcome={outcome!r}, "
+                        f"reason={evidence_reason!r}, scope={scope!r})"
+                    )
+                matching_ledger_rows = [
+                    row
+                    for row in toss_ledger_rows
+                    if (row.broker_order_id is not None or row.status != "rejected")
+                    and (
+                        (
+                            rung.idempotency_key
+                            and row.client_order_id == rung.idempotency_key
+                        )
+                        or (
+                            rung.broker_order_id
+                            and row.broker_order_id == rung.broker_order_id
+                        )
+                    )
+                ]
+                if matching_ledger_rows:
+                    ledger_row = matching_ledger_rows[0]
+                    raise OrderProposalError(
+                        "cannot void proposal: toss_live_order_ledger contains "
+                        f"broker evidence for rung {rung.rung_index} "
+                        f"(status={ledger_row.status!r}, "
+                        f"broker_order_id={ledger_row.broker_order_id!r})"
+                    )
+                ledger_summary = (
+                    " toss_live_order_ledger rows=0"
+                    if group.account_mode == "toss_live"
+                    else ""
+                )
+                summaries.append(
+                    f"rung={rung.rung_index} outcome=absent "
+                    f"scope={scope!r}{ledger_summary}"
+                )
+            evidence_summary = " | broker_evidence: " + "; ".join(summaries)
+
+        audit_reason = reason + evidence_summary
+
         voided_rungs = []
         for rung in rungs:
-            sm.assert_rung_transition(rung.state, "voided")
-            voided_rungs.append(
-                await self._repo.update_rung(rung, state="voided", updated_at=now)
+            target_state = (
+                "voided_local_stale" if rung.state == "unverified" else "voided"
             )
+            sm.assert_rung_transition(rung.state, target_state)
+            audit_fields: dict[str, Any] = {
+                "state": target_state,
+                "updated_at": now,
+            }
+            if target_state == "voided_local_stale":
+                audit_fields["void_reason"] = audit_reason
+            voided_rungs.append(await self._repo.update_rung(rung, **audit_fields))
         await self._repo.update_group(
             group,
             lifecycle_state=self._recompute_group_state(voided_rungs),
-            void_reason=reason,
+            void_reason=audit_reason,
             no_resubmit=True,
             approval_nonce=None,
             approval_nonce_used_at=now,

--- a/app/services/order_proposals/state_machine.py
+++ b/app/services/order_proposals/state_machine.py
@@ -45,7 +45,14 @@ _ALLOWED: dict[str, frozenset[str]] = {
     ),
     "partially_filled": frozenset({"filled", "cancelled", "expired", "unverified"}),
     "unverified": frozenset(
-        {"filled", "partially_filled", "cancelled", "expired", "rejected"}
+        {
+            "filled",
+            "partially_filled",
+            "cancelled",
+            "expired",
+            "rejected",
+            "voided_local_stale",
+        }
     ),
     # terminals
     "filled": frozenset(),

--- a/tests/services/brokers/toss/test_dto.py
+++ b/tests/services/brokers/toss/test_dto.py
@@ -97,6 +97,7 @@ def test_parse_orders_converts_execution_decimals() -> None:
             "orders": [
                 {
                     "orderId": "ord-1",
+                    "clientOrderId": "tosprop-legacy-1",
                     "symbol": "AAPL",
                     "side": "BUY",
                     "orderType": "LIMIT",
@@ -125,6 +126,7 @@ def test_parse_orders_converts_execution_decimals() -> None:
     )
 
     assert orders.orders[0].status == "FUTURE_STATUS"
+    assert orders.orders[0].client_order_id == "tosprop-legacy-1"
     assert orders.orders[0].execution["commission"] == Decimal("0.10")
 
 

--- a/tests/services/order_proposals/test_broker_gateway.py
+++ b/tests/services/order_proposals/test_broker_gateway.py
@@ -1,4 +1,5 @@
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import httpx
@@ -326,3 +327,325 @@ async def test_fetch_submit_evidence_returns_unknown_for_unsupported_tuple():
     assert evidence.outcome == "unknown"
     assert evidence.reason == "submit evidence lookup unsupported for kis_live/crypto"
     lookup.assert_not_awaited()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_operator_void_toss_scan_proves_absence_across_open_and_closed():
+    from app.services.order_proposals import broker_gateway
+
+    calls = []
+
+    class FakeTossClient:
+        async def list_orders(self, **kwargs):
+            calls.append(kwargs)
+            return SimpleNamespace(orders=[], has_next=False, next_cursor=None)
+
+    rung = SimpleNamespace(
+        rung_index=0,
+        idempotency_key="tosprop-legacy-1",
+        broker_order_id=None,
+        created_at=NOW - timedelta(days=2),
+    )
+    evidence = await broker_gateway.fetch_operator_void_evidence(
+        account_mode="toss_live",
+        market="equity_kr",
+        symbol="005930",
+        rungs=[rung],
+        now=NOW,
+        toss_client=FakeTossClient(),
+    )
+
+    assert evidence[0].outcome == "absent"
+    assert "OPEN" in evidence[0].lookup_scope
+    assert "CLOSED" in evidence[0].lookup_scope
+    assert [call["status"] for call in calls] == ["OPEN", "CLOSED"]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@pytest.mark.parametrize("broker_state", ["OPEN", "FILLED"])
+async def test_operator_void_toss_scan_exposes_found_broker_state(broker_state):
+    from app.services.order_proposals import broker_gateway
+
+    found = SimpleNamespace(
+        order_id="broker-1",
+        client_order_id="tosprop-legacy-1",
+        status=broker_state,
+    )
+
+    class FakeTossClient:
+        async def list_orders(self, **kwargs):
+            orders = (
+                [found]
+                if kwargs["status"] == ("OPEN" if broker_state == "OPEN" else "CLOSED")
+                else []
+            )
+            return SimpleNamespace(orders=orders, has_next=False, next_cursor=None)
+
+    rung = SimpleNamespace(
+        rung_index=0,
+        idempotency_key="tosprop-legacy-1",
+        broker_order_id=None,
+        created_at=NOW,
+    )
+    evidence = await broker_gateway.fetch_operator_void_evidence(
+        account_mode="toss_live",
+        market="equity_kr",
+        symbol="005930",
+        rungs=[rung],
+        now=NOW,
+        toss_client=FakeTossClient(),
+    )
+
+    assert evidence[0].outcome == "found"
+    assert evidence[0].broker_order_id == "broker-1"
+    assert evidence[0].broker_state == broker_state
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_operator_void_toss_scan_fails_closed_on_timeout():
+    from app.services.order_proposals import broker_gateway
+
+    class FakeTossClient:
+        async def list_orders(self, **_kwargs):
+            raise httpx.ReadTimeout("")
+
+    rung = SimpleNamespace(
+        rung_index=0,
+        idempotency_key="tosprop-legacy-1",
+        broker_order_id=None,
+        created_at=NOW,
+    )
+    evidence = await broker_gateway.fetch_operator_void_evidence(
+        account_mode="toss_live",
+        market="equity_kr",
+        symbol="005930",
+        rungs=[rung],
+        now=NOW,
+        toss_client=FakeTossClient(),
+    )
+
+    assert evidence[0].outcome == "unknown"
+    assert evidence[0].reason == "ReadTimeout"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_operator_void_toss_scan_requires_client_id_field_for_absence():
+    from app.services.order_proposals import broker_gateway
+
+    order_without_client_id = SimpleNamespace(
+        order_id="unrelated-order",
+        client_order_id=None,
+        status="OPEN",
+    )
+
+    class FakeTossClient:
+        async def list_orders(self, **kwargs):
+            orders = [order_without_client_id] if kwargs["status"] == "OPEN" else []
+            return SimpleNamespace(orders=orders, has_next=False, next_cursor=None)
+
+    rung = SimpleNamespace(
+        rung_index=0,
+        idempotency_key="tosprop-legacy-1",
+        broker_order_id=None,
+        created_at=NOW,
+    )
+    evidence = await broker_gateway.fetch_operator_void_evidence(
+        account_mode="toss_live",
+        market="equity_kr",
+        symbol="005930",
+        rungs=[rung],
+        now=NOW,
+        toss_client=FakeTossClient(),
+    )
+
+    assert evidence[0].outcome == "unknown"
+    assert evidence[0].reason == "broker order list omitted clientOrderId"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@pytest.mark.parametrize("cursor", [None, "cursor-1"])
+async def test_operator_void_toss_scan_fails_closed_on_invalid_pagination(cursor):
+    from app.services.order_proposals import broker_gateway
+
+    class FakeTossClient:
+        async def list_orders(self, **kwargs):
+            if kwargs["status"] == "OPEN":
+                return SimpleNamespace(orders=[], has_next=False, next_cursor=None)
+            return SimpleNamespace(orders=[], has_next=True, next_cursor=cursor)
+
+    rung = SimpleNamespace(
+        rung_index=0,
+        idempotency_key="tosprop-legacy-1",
+        broker_order_id=None,
+        created_at=NOW,
+    )
+    evidence = await broker_gateway.fetch_operator_void_evidence(
+        account_mode="toss_live",
+        market="equity_kr",
+        symbol="005930",
+        rungs=[rung],
+        now=NOW,
+        toss_client=FakeTossClient(),
+    )
+
+    assert evidence[0].outcome == "unknown"
+    assert "cursor" in (evidence[0].reason or "")
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_operator_void_kis_history_distinguishes_absent_and_filled():
+    from app.services.order_proposals import broker_gateway
+
+    rung = SimpleNamespace(
+        rung_index=0,
+        idempotency_key=None,
+        broker_order_id="kis-order-1",
+        created_at=NOW - timedelta(days=1),
+    )
+
+    async def absent_history(**_kwargs):
+        return {"orders": [], "errors": []}
+
+    absent = await broker_gateway.fetch_operator_void_evidence(
+        account_mode="kis_live",
+        market="equity_kr",
+        symbol="005930",
+        rungs=[rung],
+        now=NOW,
+        history_fn=absent_history,
+    )
+
+    async def filled_history(**_kwargs):
+        return {
+            "orders": [{"order_id": "kis-order-1", "status": "filled"}],
+            "errors": [],
+        }
+
+    found = await broker_gateway.fetch_operator_void_evidence(
+        account_mode="kis_live",
+        market="equity_kr",
+        symbol="005930",
+        rungs=[rung],
+        now=NOW,
+        history_fn=filled_history,
+    )
+
+    assert absent[0].outcome == "absent"
+    assert found[0].outcome == "found"
+    assert found[0].broker_state == "filled"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_operator_void_kis_us_empty_history_is_not_absence_proof():
+    from app.services.order_proposals import broker_gateway
+
+    rung = SimpleNamespace(
+        rung_index=0,
+        idempotency_key=None,
+        broker_order_id="kis-us-order-1",
+        created_at=NOW - timedelta(days=1),
+    )
+
+    async def empty_history(**_kwargs):
+        return {"orders": [], "errors": [], "truncated": False}
+
+    evidence = await broker_gateway.fetch_operator_void_evidence(
+        account_mode="kis_live",
+        market="equity_us",
+        symbol="AAPL",
+        rungs=[rung],
+        now=NOW,
+        history_fn=empty_history,
+    )
+
+    assert evidence[0].outcome == "unknown"
+    assert "cannot be proven complete" in (evidence[0].reason or "")
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("history_result", "reason_fragment"),
+    [
+        ({"orders": [], "errors": [], "truncated": True}, "truncated"),
+        (
+            {
+                "orders": [],
+                "errors": [{"market": "equity_us", "error": "page 2 failed"}],
+                "truncated": False,
+            },
+            "page 2 failed",
+        ),
+    ],
+)
+async def test_operator_void_kis_history_fails_closed_when_incomplete(
+    history_result, reason_fragment
+):
+    from app.services.order_proposals import broker_gateway
+
+    captured = {}
+
+    async def incomplete_history(**kwargs):
+        captured.update(kwargs)
+        return history_result
+
+    rung = SimpleNamespace(
+        rung_index=0,
+        idempotency_key=None,
+        broker_order_id="kis-order-1",
+        created_at=NOW - timedelta(days=1),
+    )
+    evidence = await broker_gateway.fetch_operator_void_evidence(
+        account_mode="kis_live",
+        market="equity_us",
+        symbol="AAPL",
+        rungs=[rung],
+        now=NOW,
+        history_fn=incomplete_history,
+    )
+
+    assert captured["limit"] == -1
+    assert evidence[0].outcome == "unknown"
+    assert reason_fragment in (evidence[0].reason or "")
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_operator_void_upbit_identifier_distinguishes_absent_and_open():
+    from app.services.order_proposals import broker_gateway
+
+    rung = SimpleNamespace(
+        rung_index=0,
+        idempotency_key="oprop-legacy-1",
+        broker_order_id=None,
+        created_at=NOW,
+    )
+    absent = await broker_gateway.fetch_operator_void_evidence(
+        account_mode="upbit",
+        market="crypto",
+        symbol="KRW-BTC",
+        rungs=[rung],
+        now=NOW,
+        upbit_identifier_lookup_fn=AsyncMock(side_effect=_http_status_error(404)),
+    )
+    found = await broker_gateway.fetch_operator_void_evidence(
+        account_mode="upbit",
+        market="crypto",
+        symbol="KRW-BTC",
+        rungs=[rung],
+        now=NOW,
+        upbit_identifier_lookup_fn=AsyncMock(
+            return_value={"uuid": "upbit-order-1", "state": "wait"}
+        ),
+    )
+
+    assert absent[0].outcome == "absent"
+    assert found[0].outcome == "found"
+    assert found[0].broker_state == "wait"

--- a/tests/services/order_proposals/test_service.py
+++ b/tests/services/order_proposals/test_service.py
@@ -5,9 +5,11 @@ from decimal import Decimal
 from types import SimpleNamespace
 
 import pytest
+from sqlalchemy import func, select
 
 from app.core.db import AsyncSessionLocal
 from app.core.timezone import KST
+from app.models.review import TossLiveOrderLedger
 from app.services.order_proposals import OrderProposalsService
 from app.services.order_proposals.errors import (
     OrderProposalError,
@@ -220,12 +222,18 @@ async def test_replace_persists_target_snapshot_and_allows_independent_proposals
     assert first.payload_hash != second.payload_hash
 
 
-async def _create_single_rung(db_session, *, symbol: str = "A"):
+async def _create_single_rung(
+    db_session,
+    *,
+    symbol: str = "A",
+    account_mode: str = "kis_live",
+    market: str = "equity_kr",
+):
     service = OrderProposalsService(db_session)
     group = await service.create_proposal(
         symbol=symbol,
-        market="equity_kr",
-        account_mode="kis_live",
+        market=market,
+        account_mode=account_mode,
         side="buy",
         order_type="limit",
         proposer="p",
@@ -704,6 +712,260 @@ async def test_void_refuses_unverified_rung_without_partial_mutation(db_session)
     with pytest.raises(OrderProposalError, match="cannot void"):
         await service.void_proposal(
             group.proposal_id, reason="operator cleanup", now=datetime.now(UTC)
+        )
+
+
+@pytest.mark.asyncio
+async def test_void_unverified_with_absent_broker_evidence_records_audit(db_session):
+    from app.services.order_proposals.broker_gateway import OperatorVoidEvidence
+
+    service, group = await _create_single_rung(db_session, account_mode="toss_live")
+    now = datetime(2026, 7, 13, 9, 0, tzinfo=UTC)
+    await _drive_to_submitting(service, group.proposal_id)
+    await service.record_unverified(
+        group.proposal_id,
+        0,
+        reason="legacy_timeout",
+        idempotency_key="tosprop-legacy-1",
+        now=now - timedelta(minutes=6),
+    )
+    ledger_count = (
+        await db_session.execute(
+            select(func.count())
+            .select_from(TossLiveOrderLedger)
+            .where(TossLiveOrderLedger.client_order_id == "tosprop-legacy-1")
+        )
+    ).scalar_one()
+    assert ledger_count == 0
+
+    async def broker_evidence(**kwargs):
+        assert [rung.rung_index for rung in kwargs["rungs"]] == [0]
+        return {
+            0: OperatorVoidEvidence(
+                "absent", "toss GET /orders OPEN + CLOSED 2026-07-11..2026-07-13"
+            )
+        }
+
+    rows = await service.void_proposal(
+        group.proposal_id,
+        reason="operator cleanup",
+        now=now,
+        broker_evidence=broker_evidence,
+    )
+    refreshed, rungs = await service.get_proposal(group.proposal_id)
+
+    assert [row.state for row in rows] == ["voided_local_stale"]
+    assert rungs[0].state == "voided_local_stale"
+    assert "operator cleanup" in refreshed.void_reason
+    assert "outcome=absent" in refreshed.void_reason
+    assert "toss_live_order_ledger rows=0" in refreshed.void_reason
+    assert "GET /orders OPEN + CLOSED" in refreshed.void_reason
+    assert rungs[0].void_reason == refreshed.void_reason
+
+
+@pytest.mark.asyncio
+async def test_void_unverified_refuses_when_accepted_toss_ledger_row_exists(db_session):
+    from app.services.order_proposals.broker_gateway import OperatorVoidEvidence
+
+    service, group = await _create_single_rung(db_session, account_mode="toss_live")
+    now = datetime(2026, 7, 13, 9, 0, tzinfo=UTC)
+    await _drive_to_submitting(service, group.proposal_id)
+    await service.record_unverified(
+        group.proposal_id,
+        0,
+        reason="legacy_timeout",
+        idempotency_key="tosprop-ledger-1",
+        now=now - timedelta(minutes=6),
+    )
+    db_session.add(
+        TossLiveOrderLedger(
+            trade_date=now,
+            operation_kind="place",
+            market="kr",
+            symbol="A",
+            side="buy",
+            order_type="limit",
+            quantity=Decimal("1"),
+            price=Decimal("100"),
+            client_order_id="tosprop-ledger-1",
+            broker_order_id="broker-ledger-1",
+            status="accepted",
+        )
+    )
+    await db_session.flush()
+
+    async def broker_evidence(**_kwargs):
+        return {
+            0: OperatorVoidEvidence(
+                "absent", "toss GET /orders OPEN + CLOSED 2026-07-13..2026-07-13"
+            )
+        }
+
+    with pytest.raises(OrderProposalError, match="toss_live_order_ledger"):
+        await service.void_proposal(
+            group.proposal_id,
+            reason="operator cleanup",
+            now=now,
+            broker_evidence=broker_evidence,
+        )
+    _, rungs = await service.get_proposal(group.proposal_id)
+    assert rungs[0].state == "unverified"
+
+
+@pytest.mark.asyncio
+async def test_void_unverified_ignores_rejected_toss_ledger_without_order_id(
+    db_session,
+):
+    from app.services.order_proposals.broker_gateway import OperatorVoidEvidence
+
+    service, group = await _create_single_rung(db_session, account_mode="toss_live")
+    now = datetime(2026, 7, 13, 9, 0, tzinfo=UTC)
+    await _drive_to_submitting(service, group.proposal_id)
+    await service.record_unverified(
+        group.proposal_id,
+        0,
+        reason="legacy_timeout",
+        idempotency_key="tosprop-rejected-ledger-1",
+        now=now - timedelta(minutes=6),
+    )
+    db_session.add(
+        TossLiveOrderLedger(
+            trade_date=now,
+            operation_kind="place",
+            market="kr",
+            symbol="A",
+            side="buy",
+            order_type="limit",
+            quantity=Decimal("1"),
+            price=Decimal("100"),
+            client_order_id="tosprop-rejected-ledger-1",
+            broker_order_id=None,
+            status="rejected",
+        )
+    )
+    await db_session.flush()
+
+    async def broker_evidence(**_kwargs):
+        return {
+            0: OperatorVoidEvidence(
+                "absent", "toss GET /orders OPEN + CLOSED 2026-07-13..2026-07-13"
+            )
+        }
+
+    rows = await service.void_proposal(
+        group.proposal_id,
+        reason="operator cleanup",
+        now=now,
+        broker_evidence=broker_evidence,
+    )
+
+    assert [row.state for row in rows] == ["voided_local_stale"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("broker_state", ["OPEN", "FILLED"])
+async def test_void_unverified_refuses_existing_broker_order(db_session, broker_state):
+    from app.services.order_proposals.broker_gateway import OperatorVoidEvidence
+
+    service, group = await _create_single_rung(db_session)
+    now = datetime(2026, 7, 13, 9, 0, tzinfo=UTC)
+    await _drive_to_submitting(service, group.proposal_id)
+    await service.record_unverified(
+        group.proposal_id,
+        0,
+        reason="legacy_timeout",
+        now=now - timedelta(minutes=6),
+    )
+
+    async def broker_evidence(**_kwargs):
+        return {
+            0: OperatorVoidEvidence(
+                "found",
+                "toss GET /orders OPEN + CLOSED",
+                broker_order_id="broker-1",
+                broker_state=broker_state,
+            )
+        }
+
+    with pytest.raises(OrderProposalError, match=broker_state):
+        await service.void_proposal(
+            group.proposal_id,
+            reason="operator cleanup",
+            now=now,
+            broker_evidence=broker_evidence,
+        )
+    _, rungs = await service.get_proposal(group.proposal_id)
+    assert rungs[0].state == "unverified"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("error", [TimeoutError(), RuntimeError("broker down")])
+async def test_void_unverified_refuses_broker_lookup_failure(db_session, error):
+    service, group = await _create_single_rung(db_session)
+    now = datetime(2026, 7, 13, 9, 0, tzinfo=UTC)
+    await _drive_to_submitting(service, group.proposal_id)
+    await service.record_unverified(
+        group.proposal_id,
+        0,
+        reason="legacy_timeout",
+        now=now - timedelta(minutes=6),
+    )
+
+    async def broker_evidence(**_kwargs):
+        raise error
+
+    with pytest.raises(OrderProposalError, match="broker evidence lookup failed"):
+        await service.void_proposal(
+            group.proposal_id,
+            reason="operator cleanup",
+            now=now,
+            broker_evidence=broker_evidence,
+        )
+    _, rungs = await service.get_proposal(group.proposal_id)
+    assert rungs[0].state == "unverified"
+
+
+@pytest.mark.asyncio
+async def test_void_unverified_refuses_during_broker_settlement_grace(db_session):
+    service, group = await _create_single_rung(db_session, account_mode="toss_live")
+    now = datetime(2026, 7, 13, 9, 0, tzinfo=UTC)
+    await _drive_to_submitting(service, group.proposal_id)
+    await service.record_unverified(
+        group.proposal_id,
+        0,
+        reason="recent_timeout",
+        idempotency_key="tosprop-recent-1",
+        now=now - timedelta(minutes=1),
+    )
+
+    async def broker_evidence(**_kwargs):
+        pytest.fail("broker lookup must wait until the settlement grace elapses")
+
+    with pytest.raises(OrderProposalError, match="settlement grace"):
+        await service.void_proposal(
+            group.proposal_id,
+            reason="operator cleanup",
+            now=now,
+            broker_evidence=broker_evidence,
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("terminal_state", ["rejected", "filled"])
+async def test_void_terminal_rung_still_refused(db_session, terminal_state):
+    service, group = await _create_single_rung(db_session)
+    now = datetime(2026, 7, 13, 9, 0, tzinfo=UTC)
+    if terminal_state == "rejected":
+        await service.record_rejected(
+            group.proposal_id, 0, reason="broker rejected", now=now
+        )
+    else:
+        await _record_ack(service, group.proposal_id, now=now)
+        await service.transition_rung(group.proposal_id, 0, new_state="filled")
+
+    with pytest.raises(OrderProposalError, match="cannot void proposal"):
+        await service.void_proposal(
+            group.proposal_id, reason="operator cleanup", now=now
         )
 
 

--- a/tests/services/order_proposals/test_state_machine.py
+++ b/tests/services/order_proposals/test_state_machine.py
@@ -35,9 +35,13 @@ def test_timeout_never_auto_voids():
     with pytest.raises(OrderProposalInvalidStateTransition):
         sm.assert_rung_transition("submitting", "voided_local_stale")
 
+    # ROB-862: only an explicit operator path may use this transition after
+    # separately proving that no broker order exists.
+    sm.assert_rung_transition("unverified", "voided_local_stale")
+
 
 @pytest.mark.unit
-def test_local_stale_only_from_pending():
+def test_pending_can_be_marked_local_stale():
     sm.assert_rung_transition("pending_approval", "voided_local_stale")
 
 

--- a/tests/test_mcp_order_proposal_tools.py
+++ b/tests/test_mcp_order_proposal_tools.py
@@ -1,11 +1,13 @@
 import uuid
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
 
 import pytest
 
 from app.core.config import settings
+from app.core.db import AsyncSessionLocal
 from app.mcp_server.tooling import order_proposal_tools as opt
+from app.services.order_proposals import OrderProposalsService
 from app.services.order_proposals.errors import OrderProposalError
 from app.services.order_proposals.target_order import TargetOrderSnapshot
 
@@ -13,11 +15,16 @@ from app.services.order_proposals.target_order import TargetOrderSnapshot
 class _FakeNotifier:
     def __init__(self, *, message_id: int | None = 4242) -> None:
         self.calls: list[tuple[str, dict, str]] = []
+        self.edited: list[tuple[str, int, str, object]] = []
         self._message_id = message_id
 
     async def send_approval_message(self, text, inline_keyboard, *, chat_id):
         self.calls.append((text, inline_keyboard, chat_id))
         return self._message_id
+
+    async def edit_message(self, chat_id, message_id, text, reply_markup=None):
+        self.edited.append((chat_id, message_id, text, reply_markup))
+        return True
 
 
 class _RaisingNotifier:
@@ -355,6 +362,62 @@ async def test_void_requires_reason_and_terminalizes_proposal():
     assert result["success"] is True
     assert result["lifecycle_state"] == "voided"
     assert result["void_reason"] == "superseded thesis"
+
+
+@pytest.mark.asyncio
+async def test_void_unverified_uses_broker_evidence_and_disables_telegram_buttons(
+    monkeypatch,
+):
+    from app.services.order_proposals.broker_gateway import OperatorVoidEvidence
+
+    created = await opt.order_proposal_create(
+        **_create_kwargs(account_mode="toss_live")
+    )
+    now = datetime.now(UTC)
+    async with AsyncSessionLocal() as session:
+        service = OrderProposalsService(session)
+        proposal_id = uuid.UUID(created["proposal_id"])
+        for state in ("revalidating", "approved", "submitting"):
+            await service.transition_rung(proposal_id, 0, new_state=state)
+        await service.record_unverified(
+            proposal_id,
+            0,
+            reason="legacy_timeout",
+            idempotency_key="tosprop-legacy-1",
+            now=now - timedelta(minutes=6),
+        )
+        await service.record_approval_dispatch(
+            proposal_id,
+            message_id=4242,
+            chat_id="chat-1",
+            now=now,
+        )
+        await session.commit()
+
+    async def absent_evidence(**_kwargs):
+        return {
+            0: OperatorVoidEvidence(
+                "absent", "toss GET /orders OPEN + CLOSED 2026-07-13..2026-07-13"
+            )
+        }
+
+    notifier = _FakeNotifier()
+    monkeypatch.setattr(opt, "fetch_operator_void_evidence", absent_evidence)
+    monkeypatch.setattr(opt, "_get_trade_notifier", lambda: notifier)
+
+    result = await opt.order_proposal_void(created["proposal_id"], "operator cleanup")
+
+    assert result["success"] is True
+    assert result["rungs"][0]["state"] == "voided_local_stale"
+    assert "outcome=absent" in result["void_reason"]
+    assert notifier.edited == [
+        (
+            "chat-1",
+            4242,
+            "🗑️ 제안 무효화됨\n사유: " + result["void_reason"].replace("_", "\\_"),
+            {"inline_keyboard": []},
+        )
+    ]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- allow explicit operator void of `unverified` rungs only after a five-minute settlement grace and conclusive account-scoped broker absence evidence
- scan Toss OPEN once plus the complete CLOSED date window, reuse KIS/Upbit lookups, and fail closed on found orders, timeouts, provider errors, truncation, malformed pagination, or incomplete identifiers
- require zero positive Toss accepted-order ledger evidence, persist the operator reason plus lookup scope/result, and remove the Telegram approval keyboard after commit

## Safety invariants

- timeout/ambiguity still transitions only to `unverified`; there is no auto-void path
- a broker order found in OPEN/FILLED/other states rejects the void and returns its state/order ID with reconcile guidance
- recent, incomplete, failed, or contract-inconclusive lookups reject the void without partial mutation
- Toss `clientOrderId` is treated as optional/undocumented: a non-empty response omitting it is inconclusive; KIS US empty history is likewise inconclusive and fails closed
- the proposal row lock, submit/ledger ordering, five-minute grace, remote evidence scan, and final accepted-only ledger read protect the local transition; the grace is an operational delayed-visibility bound rather than a provider SLA

## State machine / ROB-861 coordination

- **State machine changed:** adds the explicit `unverified -> voided_local_stale` transition. `submitting -> voided_local_stale` remains forbidden.
- This PR does not modify `revalidation.py` or `approval_message.py`. Coordinate merge order with ROB-861 if that branch also touches the transition graph or shared proposal tests.

## Verification

- `uv run pytest tests/services/order_proposals/ tests/test_mcp_order_proposal_tools.py -q` — 341 passed
- `uv run pytest tests/services/brokers/toss/test_dto.py tests/monitoring/test_trade_notifier_reply_markup.py -q` — 19 passed
- `make lint` — Ruff check/format and ty passed
- independent focused review: merge-ready; no critical findings
- no production DB or broker endpoint was accessed

## Post-deploy operator verification (procedure only; not run in this session)

1. In the production operator session, process each of the 12 legacy ROB-856 proposal IDs individually with `order_proposal_void(proposal_id, reason)`.
2. Stop and reconcile instead of retrying if the tool reports a found order or inconclusive broker evidence.
3. After each success, verify the affected rung is `voided_local_stale`, the group/rung `void_reason` contains the operator reason and broker lookup scope/result, and `no_resubmit=true`.
4. Verify the associated Telegram approval message no longer has an inline keyboard.

Linear: ROB-862
