### PR TITLE
feat(ROB-861): gate approvals on buying power before submit

### DIFF
--- a/app/mcp_server/tooling/order_proposal_tools.py
+++ b/app/mcp_server/tooling/order_proposal_tools.py
@@ -22,6 +22,11 @@ from app.services.order_proposals.broker_gateway import (
     fetch_operator_void_evidence,
     fetch_target_order,
 )
+from app.services.order_proposals.buying_power import (
+    build_create_advisory,
+    currency_for_market,
+    default_buying_power_reader,
+)
 from app.services.order_proposals.dispatch import send_proposal_for_approval
 from app.services.order_proposals.errors import (
     OrderProposalError,
@@ -257,6 +262,31 @@ async def order_proposal_create(
                 else None,
                 "rungs": [_rung_dict(r) for r in saved_rungs],
             }
+
+        if (
+            normalized_action == "place"
+            and account_mode == "toss_live"
+            and side == "buy"
+        ):
+            try:
+                async with AsyncSessionLocal() as advisory_session:
+                    advisory = await build_create_advisory(
+                        advisory_session,
+                        account_mode=account_mode,
+                        broker_account_id=broker_account_id,
+                        currency=currency_for_market(market),
+                        buying_power_reader=default_buying_power_reader,
+                    )
+                result["buying_power_advisory"] = [advisory]
+                warning = advisory.get("warning")
+                if warning:
+                    result["warnings"] = [warning]
+            except Exception:  # noqa: BLE001 - advisory never blocks create
+                logger.exception(
+                    "order_proposal_create: buying-power advisory failed for "
+                    "proposal_id=%s",
+                    proposal_id,
+                )
 
         # Best-effort Telegram dispatch (ROB-816 PR 2). The proposal's own
         # session above is already closed/committed by this point --

--- a/app/services/order_proposals/approval_message.py
+++ b/app/services/order_proposals/approval_message.py
@@ -6,7 +6,7 @@ import re
 import uuid
 from collections.abc import Mapping, Sequence
 from datetime import datetime
-from decimal import Decimal, InvalidOperation
+from decimal import ROUND_CEILING, Decimal, InvalidOperation
 from typing import Any
 
 from app.core.timezone import KST
@@ -91,6 +91,30 @@ def build_action_diff(*, group: Any, rungs: Sequence[Any]) -> dict | None:
     }
 
 
+def build_buying_power_shortfall_text(detail: Mapping[str, Any]) -> str | None:
+    if detail.get("reason") != "insufficient_buying_power":
+        return None
+    currency = _supported_currency(detail.get("currency"))
+    if currency is None:
+        return None
+    values: list[Decimal] = []
+    for key in ("available", "required", "shortfall"):
+        try:
+            value = Decimal(str(detail[key]))
+        except (InvalidOperation, KeyError, TypeError, ValueError):
+            return None
+        if not value.is_finite():
+            return None
+        values.append(value)
+    available, required, shortfall = values
+    return (
+        f"매수가능 {_format_shortfall_money(available, currency=currency)} / "
+        f"필요 {_format_shortfall_money(required, currency=currency)} → "
+        f"부족 {_format_shortfall_money(shortfall, currency=currency)} "
+        "— 입금 후 재승인"
+    )
+
+
 def build_approval_message(
     *,
     group: Any,
@@ -125,8 +149,15 @@ def build_approval_message(
     quantity_unit = "주" if market in {"equity_kr", "equity_us"} else ""
     sorted_rungs = sorted(rungs, key=lambda rung: getattr(rung, "rung_index", 0))
     explicit_reconfirm = diff is not None
+    shortfall_text = (
+        build_buying_power_shortfall_text(diff) if isinstance(diff, Mapping) else None
+    )
     effective_diff = (
-        diff if explicit_reconfirm else build_action_diff(group=group, rungs=rungs)
+        None
+        if shortfall_text is not None
+        else diff
+        if explicit_reconfirm
+        else build_action_diff(group=group, rungs=rungs)
     )
 
     title = "*주문 제안 재확인*" if explicit_reconfirm else "*주문 제안 승인*"
@@ -191,6 +222,9 @@ def build_approval_message(
         cash_lines = _build_cash_lines(cash_stress, currency=currency)
         if cash_lines:
             lines.extend(["", "*현금 스트레스*", *cash_lines])
+
+    if shortfall_text is not None:
+        lines.extend(["", "*매수가능 금액 부족*", f"- {shortfall_text}"])
 
     if effective_diff is not None:
         before = (
@@ -415,6 +449,14 @@ def _format_money(
     if normalized_currency:
         return f"{amount} {_escape_markdown(normalized_currency)}"
     return amount
+
+
+def _format_shortfall_money(value: Decimal, *, currency: str) -> str:
+    if currency == "KRW":
+        rounded = value.quantize(Decimal("1"), rounding=ROUND_CEILING)
+        return f"{rounded:,.0f}원"
+    rounded = value.quantize(Decimal("0.01"), rounding=ROUND_CEILING)
+    return f"${rounded:,.2f}"
 
 
 def _format_decimal(value: object, *, grouping: bool = False) -> str:

--- a/app/services/order_proposals/buying_power.py
+++ b/app/services/order_proposals/buying_power.py
@@ -1,0 +1,257 @@
+"""Buying-power reads and calculations for order-proposal UX gates."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from collections import defaultdict
+from collections.abc import Awaitable, Callable, Mapping
+from dataclasses import dataclass
+from decimal import ROUND_CEILING, Decimal, InvalidOperation
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.order_proposals import OrderProposal, OrderProposalRung
+
+
+@dataclass(frozen=True)
+class BuyingPowerKey:
+    account_mode: str
+    broker_account_id: str | None
+    currency: str
+
+
+BuyingPowerLoader = Callable[[], Awaitable[Decimal]]
+BuyingPowerReader = Callable[..., Awaitable[Decimal | None]]
+BuyingPowerReserver = Callable[..., Awaitable[None]]
+
+
+class BuyingPowerCache:
+    """Short process-local cache with per-account single-flight loading."""
+
+    def __init__(
+        self,
+        *,
+        ttl_seconds: float = 1.0,
+        clock: Callable[[], float] = time.monotonic,
+    ) -> None:
+        self._ttl_seconds = ttl_seconds
+        self._clock = clock
+        self._entries: dict[BuyingPowerKey, tuple[float, Decimal]] = {}
+        self._locks: defaultdict[BuyingPowerKey, asyncio.Lock] = defaultdict(
+            asyncio.Lock
+        )
+
+    async def get_or_load(
+        self, key: BuyingPowerKey, loader: BuyingPowerLoader
+    ) -> Decimal:
+        async with self._locks[key]:
+            now = self._clock()
+            cached = self._entries.get(key)
+            if cached is not None and cached[0] > now:
+                return cached[1]
+
+            value = Decimal(await loader())
+            self._entries[key] = (now + self._ttl_seconds, value)
+            return value
+
+    async def reserve(self, key: BuyingPowerKey, amount: Decimal) -> None:
+        async with self._locks[key]:
+            cached = self._entries.get(key)
+            if cached is None or cached[0] <= self._clock():
+                return
+            self._entries[key] = (
+                cached[0],
+                max(cached[1] - Decimal(amount), Decimal("0")),
+            )
+
+
+def _optional_decimal(value: Any) -> Decimal | None:
+    if value is None:
+        return None
+    try:
+        return Decimal(str(value))
+    except (InvalidOperation, TypeError, ValueError):
+        return None
+
+
+def currency_for_market(market: str) -> str:
+    try:
+        return {
+            "equity_kr": "KRW",
+            "equity_us": "USD",
+            "crypto": "KRW",
+        }[market]
+    except KeyError as exc:
+        raise ValueError(f"unsupported buying-power market: {market}") from exc
+
+
+def required_cash(
+    *,
+    quantity: Decimal,
+    limit_price: Decimal,
+    preview: Mapping[str, Any],
+) -> Decimal:
+    """Use provider cost evidence when available, otherwise limit notional."""
+    notional = _optional_decimal(preview.get("estimated_value"))
+    if notional is None:
+        notional = Decimal(quantity) * Decimal(limit_price)
+    fee = _optional_decimal(preview.get("fee")) or Decimal("0")
+    return notional + fee
+
+
+def decimal_text(value: Decimal) -> str:
+    text = format(Decimal(value).normalize(), "f")
+    return "0" if text in {"-0", ""} else text
+
+
+def format_currency_amount(value: Decimal, *, currency: str) -> str:
+    amount = Decimal(value)
+    if currency == "KRW":
+        return f"{amount.quantize(Decimal('1'), rounding=ROUND_CEILING):,.0f}원"
+    if currency == "USD":
+        return f"${amount.quantize(Decimal('0.01'), rounding=ROUND_CEILING):,.2f}"
+    return f"{decimal_text(amount)} {currency}"
+
+
+_CACHE = BuyingPowerCache(ttl_seconds=1.0)
+
+
+async def default_buying_power_reader(
+    *,
+    account_mode: str,
+    broker_account_id: str | None,
+    currency: str,
+) -> Decimal | None:
+    """Read Toss buying power; unsupported brokers deliberately return unknown."""
+    if account_mode != "toss_live":
+        return None
+
+    key = BuyingPowerKey(account_mode, broker_account_id, currency)
+
+    async def load() -> Decimal:
+        from app.services.brokers.toss.client import TossReadClient
+
+        client = TossReadClient.from_settings()
+        try:
+            result = await client.buying_power(currency=currency)
+            return Decimal(result.cash_buying_power)
+        finally:
+            await client.aclose()
+
+    return await _CACHE.get_or_load(key, load)
+
+
+async def default_buying_power_reserver(
+    *,
+    account_mode: str,
+    broker_account_id: str | None,
+    currency: str,
+    amount: Decimal,
+) -> None:
+    if account_mode != "toss_live":
+        return
+    await _CACHE.reserve(
+        BuyingPowerKey(account_mode, broker_account_id, currency), Decimal(amount)
+    )
+
+
+def _markets_for_currency(currency: str) -> tuple[str, ...]:
+    if currency == "KRW":
+        return ("equity_kr", "crypto")
+    if currency == "USD":
+        return ("equity_us",)
+    return ()
+
+
+async def pending_buy_requirement(
+    session: AsyncSession,
+    *,
+    account_mode: str,
+    broker_account_id: str | None,
+    currency: str,
+) -> tuple[Decimal, int]:
+    """Sum pending limit-buy notionals for one broker account and currency."""
+    markets = _markets_for_currency(currency)
+    if not markets:
+        return Decimal("0"), 0
+
+    stmt = (
+        select(OrderProposalRung)
+        .join(OrderProposal, OrderProposal.id == OrderProposalRung.proposal_pk)
+        .where(
+            OrderProposal.account_mode == account_mode,
+            OrderProposal.broker_account_id == broker_account_id,
+            OrderProposal.market.in_(markets),
+            OrderProposal.action == "place",
+            OrderProposalRung.state == "pending_approval",
+            OrderProposalRung.side == "buy",
+        )
+    )
+    rungs = list((await session.execute(stmt)).scalars().all())
+    required = Decimal("0")
+    skipped_market_rungs = 0
+    for rung in rungs:
+        if rung.limit_price is None:
+            skipped_market_rungs += 1
+            continue
+        required += Decimal(rung.quantity) * Decimal(rung.limit_price)
+    return required, skipped_market_rungs
+
+
+async def build_create_advisory(
+    session: AsyncSession,
+    *,
+    account_mode: str,
+    broker_account_id: str | None,
+    currency: str,
+    buying_power_reader: BuyingPowerReader = default_buying_power_reader,
+) -> dict[str, Any]:
+    required, skipped = await pending_buy_requirement(
+        session,
+        account_mode=account_mode,
+        broker_account_id=broker_account_id,
+        currency=currency,
+    )
+    try:
+        buying_power = await buying_power_reader(
+            account_mode=account_mode,
+            broker_account_id=broker_account_id,
+            currency=currency,
+        )
+    except Exception:  # noqa: BLE001 - advisory remains unavailable, never blocking
+        buying_power = None
+
+    if buying_power is None:
+        return {
+            "status": "unavailable",
+            "currency": currency,
+            "buying_power": None,
+            "pending_required": decimal_text(required),
+            "shortfall": None,
+            "skipped_market_rungs": skipped,
+            "warning": None,
+        }
+
+    available = Decimal(buying_power)
+    shortfall = max(required - available, Decimal("0"))
+    insufficient = shortfall > 0
+    warning = None
+    if insufficient:
+        warning = (
+            f"매수가능 {format_currency_amount(available, currency=currency)} / "
+            "승인대기 필요 "
+            f"{format_currency_amount(required, currency=currency)} → 부족 "
+            f"{format_currency_amount(shortfall, currency=currency)}"
+        )
+    return {
+        "status": "insufficient" if insufficient else "sufficient",
+        "currency": currency,
+        "buying_power": decimal_text(available),
+        "pending_required": decimal_text(required),
+        "shortfall": decimal_text(shortfall),
+        "skipped_market_rungs": skipped,
+        "warning": warning,
+    }

--- a/app/services/order_proposals/buying_power.py
+++ b/app/services/order_proposals/buying_power.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import time
+import uuid
 from collections import defaultdict
 from collections.abc import Awaitable, Callable, Mapping
 from dataclasses import dataclass
@@ -24,9 +25,16 @@ class BuyingPowerKey:
     currency: str
 
 
+@dataclass(frozen=True)
+class BuyingPowerClaim:
+    available: Decimal
+    token: str | None
+
+
 BuyingPowerLoader = Callable[[], Awaitable[Decimal]]
 BuyingPowerReader = Callable[..., Awaitable[Decimal | None]]
-BuyingPowerReserver = Callable[..., Awaitable[None]]
+BuyingPowerClaimer = Callable[..., Awaitable[BuyingPowerClaim | Decimal | None]]
+BuyingPowerReleaser = Callable[..., Awaitable[None]]
 
 
 class BuyingPowerCache:
@@ -41,6 +49,9 @@ class BuyingPowerCache:
         self._ttl_seconds = ttl_seconds
         self._clock = clock
         self._entries: dict[BuyingPowerKey, tuple[float, Decimal]] = {}
+        self._claims: defaultdict[BuyingPowerKey, dict[str, tuple[float, Decimal]]] = (
+            defaultdict(dict)
+        )
         self._locks: defaultdict[BuyingPowerKey, asyncio.Lock] = defaultdict(
             asyncio.Lock
         )
@@ -52,21 +63,51 @@ class BuyingPowerCache:
             now = self._clock()
             cached = self._entries.get(key)
             if cached is not None and cached[0] > now:
-                return cached[1]
+                return max(cached[1] - self._active_claim_total(key, now), Decimal("0"))
 
             value = Decimal(await loader())
+            now = self._clock()
             self._entries[key] = (now + self._ttl_seconds, value)
-            return value
+            return max(value - self._active_claim_total(key, now), Decimal("0"))
 
-    async def reserve(self, key: BuyingPowerKey, amount: Decimal) -> None:
+    async def claim(
+        self,
+        key: BuyingPowerKey,
+        amount: Decimal,
+        loader: BuyingPowerLoader,
+    ) -> BuyingPowerClaim:
+        """Return current power and atomically reserve it when sufficient."""
         async with self._locks[key]:
+            now = self._clock()
             cached = self._entries.get(key)
-            if cached is None or cached[0] <= self._clock():
-                return
-            self._entries[key] = (
-                cached[0],
-                max(cached[1] - Decimal(amount), Decimal("0")),
+            if cached is None or cached[0] <= now:
+                value = Decimal(await loader())
+                now = self._clock()
+                cached = (now + self._ttl_seconds, value)
+                self._entries[key] = cached
+            available = max(
+                cached[1] - self._active_claim_total(key, now), Decimal("0")
             )
+            amount = Decimal(amount)
+            if available >= amount:
+                token = uuid.uuid4().hex
+                self._claims[key][token] = (now + self._ttl_seconds, amount)
+                return BuyingPowerClaim(available=available, token=token)
+            return BuyingPowerClaim(available=available, token=None)
+
+    async def release(self, key: BuyingPowerKey, token: str) -> None:
+        async with self._locks[key]:
+            self._active_claim_total(key, self._clock())
+            self._claims[key].pop(token, None)
+
+    def _active_claim_total(self, key: BuyingPowerKey, now: float) -> Decimal:
+        claims = self._claims[key]
+        expired = [
+            token for token, (expires_at, _) in claims.items() if expires_at <= now
+        ]
+        for token in expired:
+            claims.pop(token, None)
+        return sum((amount for _, amount in claims.values()), Decimal("0"))
 
 
 def _optional_decimal(value: Any) -> Decimal | None:
@@ -120,6 +161,17 @@ def format_currency_amount(value: Decimal, *, currency: str) -> str:
 _CACHE = BuyingPowerCache(ttl_seconds=1.0)
 
 
+async def _load_toss_buying_power(*, currency: str) -> Decimal:
+    from app.services.brokers.toss.client import TossReadClient
+
+    client = TossReadClient.from_settings()
+    try:
+        result = await client.buying_power(currency=currency)
+        return Decimal(result.cash_buying_power)
+    finally:
+        await client.aclose()
+
+
 async def default_buying_power_reader(
     *,
     account_mode: str,
@@ -134,30 +186,41 @@ async def default_buying_power_reader(
 
     key = BuyingPowerKey(account_mode, broker_account_id, currency)
 
-    async def load() -> Decimal:
-        from app.services.brokers.toss.client import TossReadClient
-
-        client = TossReadClient.from_settings()
-        try:
-            result = await client.buying_power(currency=currency)
-            return Decimal(result.cash_buying_power)
-        finally:
-            await client.aclose()
-
-    return await _CACHE.get_or_load(key, load)
+    return await _CACHE.get_or_load(
+        key, lambda: _load_toss_buying_power(currency=currency)
+    )
 
 
-async def default_buying_power_reserver(
+async def default_buying_power_claimer(
     *,
     account_mode: str,
     broker_account_id: str | None,
     currency: str,
     amount: Decimal,
-) -> None:
+) -> BuyingPowerClaim | None:
     if account_mode != "toss_live":
+        return None
+    if validate_toss_api_config():
+        return None
+    return await _CACHE.claim(
+        BuyingPowerKey(account_mode, broker_account_id, currency),
+        Decimal(amount),
+        lambda: _load_toss_buying_power(currency=currency),
+    )
+
+
+async def default_buying_power_releaser(
+    *,
+    account_mode: str,
+    broker_account_id: str | None,
+    currency: str,
+    claim_token: str | None,
+    amount: Decimal,
+) -> None:
+    if account_mode != "toss_live" or claim_token is None:
         return
-    await _CACHE.reserve(
-        BuyingPowerKey(account_mode, broker_account_id, currency), Decimal(amount)
+    await _CACHE.release(
+        BuyingPowerKey(account_mode, broker_account_id, currency), claim_token
     )
 
 

--- a/app/services/order_proposals/buying_power.py
+++ b/app/services/order_proposals/buying_power.py
@@ -13,6 +13,7 @@ from typing import Any
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.config import validate_toss_api_config
 from app.models.order_proposals import OrderProposal, OrderProposalRung
 
 
@@ -127,6 +128,8 @@ async def default_buying_power_reader(
 ) -> Decimal | None:
     """Read Toss buying power; unsupported brokers deliberately return unknown."""
     if account_mode != "toss_live":
+        return None
+    if validate_toss_api_config():
         return None
 
     key = BuyingPowerKey(account_mode, broker_account_id, currency)

--- a/app/services/order_proposals/revalidation.py
+++ b/app/services/order_proposals/revalidation.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import hashlib
 import inspect
+import logging
 import re
 import uuid
 from collections.abc import Callable
@@ -40,9 +41,20 @@ from app.services.order_proposals.broker_gateway import (
     fetch_submit_evidence,
     fetch_target_order,
 )
+from app.services.order_proposals.buying_power import (
+    BuyingPowerReader,
+    BuyingPowerReserver,
+    currency_for_market,
+    decimal_text,
+    default_buying_power_reader,
+    default_buying_power_reserver,
+    required_cash,
+)
 from app.services.order_proposals.errors import OrderProposalError
 from app.services.order_proposals.service import OrderProposalsService
 from app.services.order_proposals.target_order import TargetOrderSnapshot
+
+logger = logging.getLogger(__name__)
 
 RungOutcomeResult = Literal[
     "submitted_acked",
@@ -516,6 +528,8 @@ async def revalidate_and_submit(
     fetch_target_fn: TargetFetchFn = fetch_target_order,
     cancel_target_fn: TargetCancelFn = cancel_target_order,
     fetch_submit_evidence_fn: SubmitEvidenceFetchFn = fetch_submit_evidence,
+    buying_power_reader: BuyingPowerReader = default_buying_power_reader,
+    buying_power_reserver: BuyingPowerReserver = default_buying_power_reserver,
 ) -> list[RungOutcome]:
     """Revalidate + (maybe) submit every ``pending_approval`` rung.
 
@@ -559,6 +573,8 @@ async def revalidate_and_submit(
                 place_order_fn=place_order_fn,
                 correlation_mint=correlation_mint,
                 fetch_submit_evidence_fn=fetch_submit_evidence_fn,
+                buying_power_reader=buying_power_reader,
+                buying_power_reserver=buying_power_reserver,
             )
         outcomes.append(outcome)
     return outcomes
@@ -573,6 +589,8 @@ async def _revalidate_place_rung(
     place_order_fn: PlaceOrderFn,
     correlation_mint: CorrelationMint,
     fetch_submit_evidence_fn: SubmitEvidenceFetchFn,
+    buying_power_reader: BuyingPowerReader,
+    buying_power_reserver: BuyingPowerReserver,
 ) -> RungOutcome:
     proposal_id = group.proposal_id
     rung_index = rung.rung_index
@@ -675,6 +693,49 @@ async def _revalidate_place_rung(
             rung_index, "needs_reconfirm", {"before": before, "after": after}
         )
 
+    buying_power_reservation: tuple[str, Decimal] | None = None
+    if rung.side == "buy" and rung.limit_price is not None:
+        currency = currency_for_market(group.market)
+        required = required_cash(
+            quantity=Decimal(rung.quantity),
+            limit_price=Decimal(rung.limit_price),
+            preview=preview,
+        )
+        try:
+            available = await _maybe_await(
+                buying_power_reader(
+                    account_mode=group.account_mode,
+                    broker_account_id=group.broker_account_id,
+                    currency=currency,
+                )
+            )
+        except Exception:  # noqa: BLE001 - UX gate deliberately fails open
+            # This pre-submit comparison improves operator feedback; it is not
+            # the authoritative safety control. If the advisory read is down,
+            # preserve the existing submit path and let the broker make the
+            # final buying-power decision.
+            logger.warning(
+                "order proposal buying-power lookup failed; continuing fail-open",
+                exc_info=True,
+            )
+            available = None
+        if available is not None and Decimal(available) < required:
+            available_decimal = Decimal(available)
+            await service.mark_needs_reconfirm(proposal_id, rung_index, now=now)
+            return RungOutcome(
+                rung_index,
+                "needs_reconfirm",
+                {
+                    "reason": "insufficient_buying_power",
+                    "currency": currency,
+                    "available": decimal_text(available_decimal),
+                    "required": decimal_text(required),
+                    "shortfall": decimal_text(required - available_decimal),
+                },
+            )
+        if available is not None:
+            buying_power_reservation = (currency, required)
+
     await service.transition_rung(proposal_id, rung_index, new_state="approved")
     await service.transition_rung(proposal_id, rung_index, new_state="submitting")
 
@@ -710,7 +771,7 @@ async def _revalidate_place_rung(
         )
     except Exception as exc:  # noqa: BLE001 - broker call; ambiguous, not a void
         if group.account_mode == "upbit":
-            return await _classify_submit(
+            outcome = await _classify_submit(
                 service=service,
                 proposal_id=proposal_id,
                 rung_index=rung_index,
@@ -723,17 +784,24 @@ async def _revalidate_place_rung(
                 identifier=proposal_client_order_id,
                 fetch_submit_evidence_fn=fetch_submit_evidence_fn,
             )
-        await service.record_unverified(
-            proposal_id,
-            rung_index,
-            reason=f"submit_exception:{exc}",
-            now=now,
-            correlation_id=corr,
-            idempotency_key=preview.get("idempotency_key"),
+        else:
+            await service.record_unverified(
+                proposal_id,
+                rung_index,
+                reason=f"submit_exception:{exc}",
+                now=now,
+                correlation_id=corr,
+                idempotency_key=preview.get("idempotency_key"),
+            )
+            outcome = RungOutcome(rung_index, "unverified", {"error": str(exc)})
+        await _reserve_after_submit(
+            buying_power_reserver=buying_power_reserver,
+            group=group,
+            reservation=buying_power_reservation,
         )
-        return RungOutcome(rung_index, "unverified", {"error": str(exc)})
+        return outcome
 
-    return await _classify_submit(
+    outcome = await _classify_submit(
         service=service,
         proposal_id=proposal_id,
         rung_index=rung_index,
@@ -746,6 +814,38 @@ async def _revalidate_place_rung(
         identifier=proposal_client_order_id,
         fetch_submit_evidence_fn=fetch_submit_evidence_fn,
     )
+    if outcome.result in {"submitted_acked", "submitted_resting", "unverified"}:
+        await _reserve_after_submit(
+            buying_power_reserver=buying_power_reserver,
+            group=group,
+            reservation=buying_power_reservation,
+        )
+    return outcome
+
+
+async def _reserve_after_submit(
+    *,
+    buying_power_reserver: BuyingPowerReserver,
+    group: OrderProposal,
+    reservation: tuple[str, Decimal] | None,
+) -> None:
+    if reservation is None:
+        return
+    currency, amount = reservation
+    try:
+        await _maybe_await(
+            buying_power_reserver(
+                account_mode=group.account_mode,
+                broker_account_id=group.broker_account_id,
+                currency=currency,
+                amount=amount,
+            )
+        )
+    except Exception:  # noqa: BLE001 - cache adjustment never changes broker outcome
+        logger.warning(
+            "order proposal buying-power reservation failed; ignoring",
+            exc_info=True,
+        )
 
 
 def _target_mismatch_reason(

--- a/app/services/order_proposals/revalidation.py
+++ b/app/services/order_proposals/revalidation.py
@@ -42,12 +42,13 @@ from app.services.order_proposals.broker_gateway import (
     fetch_target_order,
 )
 from app.services.order_proposals.buying_power import (
-    BuyingPowerReader,
-    BuyingPowerReserver,
+    BuyingPowerClaim,
+    BuyingPowerClaimer,
+    BuyingPowerReleaser,
     currency_for_market,
     decimal_text,
-    default_buying_power_reader,
-    default_buying_power_reserver,
+    default_buying_power_claimer,
+    default_buying_power_releaser,
     required_cash,
 )
 from app.services.order_proposals.errors import OrderProposalError
@@ -528,8 +529,8 @@ async def revalidate_and_submit(
     fetch_target_fn: TargetFetchFn = fetch_target_order,
     cancel_target_fn: TargetCancelFn = cancel_target_order,
     fetch_submit_evidence_fn: SubmitEvidenceFetchFn = fetch_submit_evidence,
-    buying_power_reader: BuyingPowerReader = default_buying_power_reader,
-    buying_power_reserver: BuyingPowerReserver = default_buying_power_reserver,
+    buying_power_claimer: BuyingPowerClaimer = default_buying_power_claimer,
+    buying_power_releaser: BuyingPowerReleaser = default_buying_power_releaser,
 ) -> list[RungOutcome]:
     """Revalidate + (maybe) submit every ``pending_approval`` rung.
 
@@ -573,8 +574,8 @@ async def revalidate_and_submit(
                 place_order_fn=place_order_fn,
                 correlation_mint=correlation_mint,
                 fetch_submit_evidence_fn=fetch_submit_evidence_fn,
-                buying_power_reader=buying_power_reader,
-                buying_power_reserver=buying_power_reserver,
+                buying_power_claimer=buying_power_claimer,
+                buying_power_releaser=buying_power_releaser,
             )
         outcomes.append(outcome)
     return outcomes
@@ -589,8 +590,8 @@ async def _revalidate_place_rung(
     place_order_fn: PlaceOrderFn,
     correlation_mint: CorrelationMint,
     fetch_submit_evidence_fn: SubmitEvidenceFetchFn,
-    buying_power_reader: BuyingPowerReader,
-    buying_power_reserver: BuyingPowerReserver,
+    buying_power_claimer: BuyingPowerClaimer,
+    buying_power_releaser: BuyingPowerReleaser,
 ) -> RungOutcome:
     proposal_id = group.proposal_id
     rung_index = rung.rung_index
@@ -693,7 +694,7 @@ async def _revalidate_place_rung(
             rung_index, "needs_reconfirm", {"before": before, "after": after}
         )
 
-    buying_power_reservation: tuple[str, Decimal] | None = None
+    buying_power_reservation: tuple[str, Decimal, str | None] | None = None
     if rung.side == "buy" and rung.limit_price is not None:
         currency = currency_for_market(group.market)
         required = required_cash(
@@ -702,11 +703,16 @@ async def _revalidate_place_rung(
             preview=preview,
         )
         try:
-            available = await _maybe_await(
-                buying_power_reader(
+            # The default claimer reads and provisionally subtracts under one
+            # per-account/currency lock. This closes the gap where two rapid
+            # approvals could both observe the same cached balance before
+            # either broker POST was sent.
+            claim = await _maybe_await(
+                buying_power_claimer(
                     account_mode=group.account_mode,
                     broker_account_id=group.broker_account_id,
                     currency=currency,
+                    amount=required,
                 )
             )
         except Exception:  # noqa: BLE001 - UX gate deliberately fails open
@@ -718,7 +724,13 @@ async def _revalidate_place_rung(
                 "order proposal buying-power lookup failed; continuing fail-open",
                 exc_info=True,
             )
-            available = None
+            claim = None
+        claim_token: str | None = None
+        if isinstance(claim, BuyingPowerClaim):
+            available = claim.available
+            claim_token = claim.token
+        else:
+            available = claim
         if available is not None and Decimal(available) < required:
             available_decimal = Decimal(available)
             await service.mark_needs_reconfirm(proposal_id, rung_index, now=now)
@@ -734,7 +746,7 @@ async def _revalidate_place_rung(
                 },
             )
         if available is not None:
-            buying_power_reservation = (currency, required)
+            buying_power_reservation = (currency, required, claim_token)
 
     await service.transition_rung(proposal_id, rung_index, new_state="approved")
     await service.transition_rung(proposal_id, rung_index, new_state="submitting")
@@ -794,11 +806,6 @@ async def _revalidate_place_rung(
                 idempotency_key=preview.get("idempotency_key"),
             )
             outcome = RungOutcome(rung_index, "unverified", {"error": str(exc)})
-        await _reserve_after_submit(
-            buying_power_reserver=buying_power_reserver,
-            group=group,
-            reservation=buying_power_reservation,
-        )
         return outcome
 
     outcome = await _classify_submit(
@@ -814,36 +821,37 @@ async def _revalidate_place_rung(
         identifier=proposal_client_order_id,
         fetch_submit_evidence_fn=fetch_submit_evidence_fn,
     )
-    if outcome.result in {"submitted_acked", "submitted_resting", "unverified"}:
-        await _reserve_after_submit(
-            buying_power_reserver=buying_power_reserver,
+    if outcome.result == "error":
+        await _release_after_rejection(
+            buying_power_releaser=buying_power_releaser,
             group=group,
             reservation=buying_power_reservation,
         )
     return outcome
 
 
-async def _reserve_after_submit(
+async def _release_after_rejection(
     *,
-    buying_power_reserver: BuyingPowerReserver,
+    buying_power_releaser: BuyingPowerReleaser,
     group: OrderProposal,
-    reservation: tuple[str, Decimal] | None,
+    reservation: tuple[str, Decimal, str | None] | None,
 ) -> None:
     if reservation is None:
         return
-    currency, amount = reservation
+    currency, amount, claim_token = reservation
     try:
         await _maybe_await(
-            buying_power_reserver(
+            buying_power_releaser(
                 account_mode=group.account_mode,
                 broker_account_id=group.broker_account_id,
                 currency=currency,
+                claim_token=claim_token,
                 amount=amount,
             )
         )
     except Exception:  # noqa: BLE001 - cache adjustment never changes broker outcome
         logger.warning(
-            "order proposal buying-power reservation failed; ignoring",
+            "order proposal buying-power claim release failed; ignoring",
             exc_info=True,
         )
 

--- a/app/services/order_proposals/telegram_callback.py
+++ b/app/services/order_proposals/telegram_callback.py
@@ -54,6 +54,7 @@ from app.mcp_server.caller_identity import caller_agent_id_var
 from app.services.order_proposals.approval_message import (
     _escape_markdown,
     build_approval_message,
+    build_buying_power_shortfall_text,
     build_loss_cut_confirmation_message,
     parse_callback_data,
 )
@@ -218,6 +219,10 @@ def _build_extra_reconfirm_block(reconfirm_outcomes: list[RungOutcome]) -> str:
     lines = ["*추가 재확인 필요 단계*"]
     for outcome in reconfirm_outcomes:
         detail = outcome.detail or {}
+        shortfall_text = build_buying_power_shortfall_text(detail)
+        if shortfall_text is not None:
+            lines.append(f"- #{outcome.rung_index + 1}: {shortfall_text}")
+            continue
         before = detail.get("before")
         after = detail.get("after")
         lines.append(f"- #{outcome.rung_index + 1}: 변경 전 {before} → 변경 후 {after}")
@@ -384,11 +389,18 @@ async def _handle_approve(
         await session.commit()
 
         if message_id is not None:
+            shortfall_notice = build_buying_power_shortfall_text(
+                reconfirm_outcomes[0].detail or {}
+            )
             await _safe_edit_message(
                 notifier,
                 chat_id,
                 message_id,
-                "⚠️ 재확인 필요 — 아래 새 메시지를 확인해 주세요.",
+                (
+                    f"⚠️ 재확인 필요 — {shortfall_notice}"
+                    if shortfall_notice is not None
+                    else "⚠️ 재확인 필요 — 아래 새 메시지를 확인해 주세요."
+                ),
             )
         new_message_id = await _safe_send_approval_message(
             notifier, text, keyboard, chat_id=str(chat_id)

--- a/docs/superpowers/plans/2026-07-13-rob-861-buying-power-pre-submit-gate.md
+++ b/docs/superpowers/plans/2026-07-13-rob-861-buying-power-pre-submit-gate.md
@@ -4,7 +4,9 @@
 
 **Goal:** Block known-underfunded Toss buy proposals before broker POST, keep them retryable, show exact Telegram shortfall amounts, and add a non-blocking create-time pending-buy advisory.
 
-**Architecture:** Add a focused `buying_power.py` boundary for normalized cash calculations, a one-second single-flight Toss cache, reservation adjustment, and pending-rung advisory queries. Inject the reader/reserver into revalidation after successful preview matching, and carry structured shortage details through the existing `needs_reconfirm` Telegram flow. Keep `service.py` and `state_machine.py` unchanged.
+**Architecture:** Add a focused `buying_power.py` boundary for normalized cash calculations, a one-second single-flight Toss cache, atomic provisional claims, and pending-rung advisory queries. Inject the claimer/releaser into revalidation after successful preview matching, and carry structured shortage details through the existing `needs_reconfirm` Telegram flow. Keep `service.py` and `state_machine.py` unchanged.
+
+**Review amendment:** The initial reader-then-reserver plan left a concurrency window between the balance read and broker POST. The implemented boundary atomically reads/checks/provisionally subtracts per account and currency before POST, tracks each claim with its own TTL/token, releases that exact token after explicit rejection, and retains accepted or ambiguous claims until their TTL expires.
 
 **Tech Stack:** Python 3.13, asyncio, Decimal, SQLAlchemy async, pytest/pytest-asyncio, Ruff, ty, uv.
 

--- a/docs/superpowers/plans/2026-07-13-rob-861-buying-power-pre-submit-gate.md
+++ b/docs/superpowers/plans/2026-07-13-rob-861-buying-power-pre-submit-gate.md
@@ -1,0 +1,494 @@
+# ROB-861 Buying-Power Pre-Submit Gate Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Block known-underfunded Toss buy proposals before broker POST, keep them retryable, show exact Telegram shortfall amounts, and add a non-blocking create-time pending-buy advisory.
+
+**Architecture:** Add a focused `buying_power.py` boundary for normalized cash calculations, a one-second single-flight Toss cache, reservation adjustment, and pending-rung advisory queries. Inject the reader/reserver into revalidation after successful preview matching, and carry structured shortage details through the existing `needs_reconfirm` Telegram flow. Keep `service.py` and `state_machine.py` unchanged.
+
+**Tech Stack:** Python 3.13, asyncio, Decimal, SQLAlchemy async, pytest/pytest-asyncio, Ruff, ty, uv.
+
+## Global Constraints
+
+- Read Linear ROB-861 before implementation; its acceptance criteria are authoritative.
+- Never make a real broker request; every provider and submit path is mocked in tests.
+- Use strict TDD: add one behavior test, observe the expected failure, then write minimal production code.
+- Insufficient buying power must produce broker POST count zero and rung state `needs_reconfirm`.
+- Buying-power read failure must fail open to the existing broker submit path.
+- Sell rungs must not invoke the gate.
+- ROB-864 loss-cut confirmation must remain confirmation-first and gate-second.
+- Do not modify `app/services/order_proposals/service.py` or `state_machine.py`.
+- Implement Toss only; preserve broker-agnostic injected hook signatures for later KIS/Upbit support.
+- Final required commands are `uv run pytest tests/services/order_proposals/ -q` and `make lint`.
+
+---
+
+### Task 1: Buying-Power Domain Boundary and Toss Cache
+
+**Files:**
+- Create: `app/services/order_proposals/buying_power.py`
+- Create: `tests/services/order_proposals/test_buying_power.py`
+
+**Interfaces:**
+- Produces: `BuyingPowerKey`, `BuyingPowerCache`, `currency_for_market`, `required_cash`, `default_buying_power_reader`, `default_buying_power_reserver`, `pending_buy_requirement`, and `build_create_advisory`.
+- Consumes: `TossReadClient.from_settings`, `OrderProposal`, `OrderProposalRung`, and an injected `AsyncSession` for read-only pending-rung aggregation.
+
+- [ ] **Step 1: Write failing pure calculation and cache tests**
+
+```python
+def test_required_cash_prefers_preview_value_and_fee():
+    assert required_cash(
+        quantity=Decimal("3"),
+        limit_price=Decimal("71100"),
+        preview={"estimated_value": "213300", "fee": "32"},
+    ) == Decimal("213332")
+
+
+@pytest.mark.asyncio
+async def test_cache_single_flight_and_reservation_adjustment():
+    cache = BuyingPowerCache(ttl_seconds=1.0)
+    calls = 0
+
+    async def loader():
+        nonlocal calls
+        calls += 1
+        return Decimal("100000")
+
+    key = BuyingPowerKey("toss_live", None, "KRW")
+    first, second = await asyncio.gather(
+        cache.get_or_load(key, loader), cache.get_or_load(key, loader)
+    )
+    await cache.reserve(key, Decimal("30000"))
+
+    assert (first, second, calls) == (Decimal("100000"), Decimal("100000"), 1)
+    assert await cache.get_or_load(key, loader) == Decimal("70000")
+```
+
+- [ ] **Step 2: Run tests and verify RED**
+
+Run: `uv run pytest tests/services/order_proposals/test_buying_power.py -q`
+
+Expected: collection fails because `app.services.order_proposals.buying_power` does not exist.
+
+- [ ] **Step 3: Implement normalized calculations and cache**
+
+```python
+@dataclass(frozen=True)
+class BuyingPowerKey:
+    account_mode: str
+    broker_account_id: str | None
+    currency: str
+
+
+class BuyingPowerCache:
+    def __init__(self, *, ttl_seconds: float = 1.0, clock=time.monotonic):
+        self._ttl_seconds = ttl_seconds
+        self._clock = clock
+        self._entries: dict[BuyingPowerKey, tuple[float, Decimal]] = {}
+        self._locks: defaultdict[BuyingPowerKey, asyncio.Lock] = defaultdict(asyncio.Lock)
+
+    async def get_or_load(self, key, loader):
+        async with self._locks[key]:
+            cached = self._entries.get(key)
+            now = self._clock()
+            if cached is not None and cached[0] > now:
+                return cached[1]
+            value = Decimal(await loader())
+            self._entries[key] = (now + self._ttl_seconds, value)
+            return value
+
+    async def reserve(self, key, amount):
+        async with self._locks[key]:
+            cached = self._entries.get(key)
+            if cached is not None and cached[0] > self._clock():
+                self._entries[key] = (cached[0], max(cached[1] - amount, Decimal("0")))
+
+
+def required_cash(*, quantity, limit_price, preview):
+    notional = _optional_decimal(preview.get("estimated_value"))
+    if notional is None:
+        notional = Decimal(quantity) * Decimal(limit_price)
+    return notional + (_optional_decimal(preview.get("fee")) or Decimal("0"))
+```
+
+Implement `default_buying_power_reader` so only `toss_live` constructs a
+`TossReadClient`, calls `buying_power(currency=currency)`, closes the client,
+and loads through the process-global cache. Other account modes return `None`.
+Implement the reserver against the same cache key.
+
+- [ ] **Step 4: Add failing pending-advisory aggregation tests**
+
+Seed two same-account pending buy rungs and one different-account/sell rung.
+Assert `pending_buy_requirement(session, account_mode="toss_live",
+broker_account_id=None, currency="KRW")` returns only the two matching limit-buy
+notionals and reports the count of skipped market-price rungs. Inject a reader
+returning `Decimal("500000")` and assert `build_create_advisory` returns
+`status="insufficient"`, exact pending required cash, and exact shortfall.
+
+- [ ] **Step 5: Run aggregation tests and verify RED**
+
+Run: `uv run pytest tests/services/order_proposals/test_buying_power.py -q`
+
+Expected: calculation/cache tests pass and aggregation/advisory assertions fail
+because the SQL read functions are absent.
+
+- [ ] **Step 6: Implement read-only pending aggregation and advisory output**
+
+Use one SQLAlchemy `select(OrderProposal, OrderProposalRung)` join filtered by:
+
+```python
+OrderProposal.account_mode == account_mode
+OrderProposal.broker_account_id == broker_account_id
+OrderProposal.market.in_(markets_for_currency(currency))
+OrderProposalRung.state == "pending_approval"
+OrderProposalRung.side == "buy"
+```
+
+Sum `Decimal(rung.quantity) * Decimal(rung.limit_price)` only when the limit
+price exists. Return structured `sufficient`, `insufficient`, or `unavailable`
+advisory dictionaries without mutating the session.
+
+- [ ] **Step 7: Run Task 1 tests and verify GREEN**
+
+Run: `uv run pytest tests/services/order_proposals/test_buying_power.py -q`
+
+Expected: all tests pass with no provider network access.
+
+- [ ] **Step 8: Commit Task 1**
+
+```bash
+git add app/services/order_proposals/buying_power.py tests/services/order_proposals/test_buying_power.py
+git commit -m "feat(ROB-861): add buying-power domain boundary"
+```
+
+### Task 2: Click-Time Pre-Submit Gate
+
+**Files:**
+- Modify: `app/services/order_proposals/revalidation.py`
+- Modify: `tests/services/order_proposals/test_revalidation.py`
+
+**Interfaces:**
+- Consumes: Task 1 `required_cash`, reader, and reserver callables.
+- Produces: `revalidate_and_submit(*, service, proposal_id, now,
+  place_order_fn=_default_place_order_fn,
+  correlation_mint=_default_correlation_mint, fetch_target_fn=fetch_target_order,
+  cancel_target_fn=cancel_target_order,
+  fetch_submit_evidence_fn=fetch_submit_evidence,
+  buying_power_reader=default_buying_power_reader,
+  buying_power_reserver=default_buying_power_reserver)` with structured
+  `needs_reconfirm` shortage outcomes.
+
+- [ ] **Step 1: Write failing insufficient-buying-power test**
+
+Create a Toss limit-buy proposal. Inject a preview that returns matching
+quantity/price, valid Toss approval fields, `estimated_value="1070300"`, and
+`fee="0"`; inject a reader returning `Decimal("400000")`. The injected place
+function must raise if called with `dry_run=False`. Assert:
+
+```python
+assert outcomes == [
+    RungOutcome(0, "needs_reconfirm", {
+        "reason": "insufficient_buying_power",
+        "currency": "KRW",
+        "available": "400000",
+        "required": "1070300",
+        "shortfall": "670300",
+    })
+]
+assert submit_calls == 0
+assert refreshed_rung.state == "needs_reconfirm"
+```
+
+- [ ] **Step 2: Run the targeted test and verify RED**
+
+Run: `uv run pytest tests/services/order_proposals/test_revalidation.py -q -k insufficient_buying_power_prevents_submit`
+
+Expected: failure because `revalidate_and_submit` does not accept the injected reader and still submits.
+
+- [ ] **Step 3: Implement the minimal gate**
+
+Add reader/reserver callable aliases and default parameters. Propagate them to
+`_revalidate_place_rung`. After preview validation and before `approved`, run:
+
+```python
+required = required_cash(
+    quantity=Decimal(rung.quantity),
+    limit_price=Decimal(rung.limit_price),
+    preview=preview,
+)
+try:
+    available = await _maybe_await(buying_power_reader(
+        account_mode=group.account_mode,
+        broker_account_id=group.broker_account_id,
+        currency=currency_for_market(group.market),
+    ))
+except Exception:
+    logger.warning("buying-power pre-submit lookup failed; continuing fail-open", exc_info=True)
+    available = None
+if available is not None and Decimal(available) < required:
+    await service.mark_needs_reconfirm(proposal_id, rung_index, now=now)
+    return RungOutcome(rung_index, "needs_reconfirm", {
+        "reason": "insufficient_buying_power",
+        "currency": currency,
+        "available": format(Decimal(available).normalize(), "f"),
+        "required": format(required.normalize(), "f"),
+        "shortfall": format((required - Decimal(available)).normalize(), "f"),
+    })
+```
+
+Include the explicit comment that provider failure is fail-open because this is
+an operator UX aid and the broker is the authoritative final rejection gate.
+
+- [ ] **Step 4: Add failing sufficient, sell, failure, and deposit-retry tests**
+
+Add four focused tests:
+
+- sufficient reader value reaches the unchanged submitted-resting path;
+- sell rung never calls the reader;
+- reader exception still reaches submit;
+- first low read produces `needs_reconfirm`, transition it back to
+  `pending_approval`, second higher read succeeds on the same proposal.
+
+Also add a multi-rung test whose first accepted rung invokes the reserver and
+whose second read observes the adjusted cached amount.
+
+- [ ] **Step 5: Run the new tests and verify RED**
+
+Run: `uv run pytest tests/services/order_proposals/test_revalidation.py -q -k 'buying_power or deposit'`
+
+Expected: insufficient test passes; one or more reservation/retry assertions
+fail until outcome-aware reservation is implemented.
+
+- [ ] **Step 6: Reserve after accepted or ambiguous submit outcomes**
+
+Capture `_classify_submit` results before return. Call the injected reserver
+for `submitted_acked`, `submitted_resting`, and `unverified`; also reserve in a
+submit-exception branch because broker state is ambiguous. Do not reserve an
+explicit `error`/rejected outcome. Keep the reservation TTL-bound.
+
+- [ ] **Step 7: Run revalidation tests and verify GREEN**
+
+Run: `uv run pytest tests/services/order_proposals/test_revalidation.py -q`
+
+Expected: all tests pass; existing sell, KIS, Upbit, replace/cancel, and ROB-864
+tests remain unchanged.
+
+- [ ] **Step 8: Commit Task 2**
+
+```bash
+git add app/services/order_proposals/revalidation.py tests/services/order_proposals/test_revalidation.py
+git commit -m "feat(ROB-861): gate Toss submits on buying power"
+```
+
+### Task 3: Telegram Shortfall Copy and Retry UX
+
+**Files:**
+- Modify: `app/services/order_proposals/approval_message.py`
+- Modify: `app/services/order_proposals/telegram_callback.py`
+- Modify: `tests/services/order_proposals/test_approval_message.py`
+- Modify: `tests/services/order_proposals/test_telegram_callback.py`
+
+**Interfaces:**
+- Consumes: Task 2 shortage outcome detail.
+- Produces: `build_buying_power_shortfall_text(detail) -> str | None` and shortage-aware reconfirm rendering for one or many rungs.
+
+- [ ] **Step 1: Write failing KRW/USD formatter tests**
+
+```python
+assert build_buying_power_shortfall_text({
+    "reason": "insufficient_buying_power", "currency": "KRW",
+    "available": "400000", "required": "1070300", "shortfall": "670300",
+}) == "매수가능 400,000원 / 필요 1,070,300원 → 부족 670,300원 — 입금 후 재승인"
+
+assert build_buying_power_shortfall_text({
+    "reason": "insufficient_buying_power", "currency": "USD",
+    "available": "100", "required": "123.45", "shortfall": "23.45",
+}) == "매수가능 $100.00 / 필요 $123.45 → 부족 $23.45 — 입금 후 재승인"
+```
+
+Build an approval message with shortage detail and assert it contains the line,
+does not contain `변경 전`, and retains approve/deny callback buttons.
+
+- [ ] **Step 2: Run formatter tests and verify RED**
+
+Run: `uv run pytest tests/services/order_proposals/test_approval_message.py -q -k buying_power`
+
+Expected: import/attribute failure because the formatter does not exist.
+
+- [ ] **Step 3: Implement shortage-aware approval rendering**
+
+Add Decimal-safe currency formatting. In `build_approval_message`, identify
+`reason == "insufficient_buying_power"`, render a `*매수가능 금액 부족*`
+section, and skip the generic before/after diff section for that detail.
+
+- [ ] **Step 4: Add failing callback integration tests**
+
+Return one shortage `needs_reconfirm` outcome from the injected revalidator.
+Assert both the edited old-message notice and the new approval message include
+Z/Y/X copy, the new message has an approve button, and the database rung remains
+`needs_reconfirm`. Add a two-rung test and assert both shortage lines appear.
+
+- [ ] **Step 5: Run callback tests and verify RED**
+
+Run: `uv run pytest tests/services/order_proposals/test_telegram_callback.py -q -k buying_power`
+
+Expected: first shortage may render only in the new message while the old edit
+and/or second shortage remains generic.
+
+- [ ] **Step 6: Wire shortage text through callback branches**
+
+Use the formatter for the old-message edit notice. Update
+`_build_extra_reconfirm_block` so shortage outcomes render their localized
+line while existing price/quantity diffs retain their current rendering.
+
+- [ ] **Step 7: Run Telegram tests and verify GREEN**
+
+Run: `uv run pytest tests/services/order_proposals/test_approval_message.py tests/services/order_proposals/test_telegram_callback.py -q`
+
+Expected: all tests pass, including fresh nonce, repeated approval, mixed
+outcome, and ROB-864 two-click tests.
+
+- [ ] **Step 8: Commit Task 3**
+
+```bash
+git add app/services/order_proposals/approval_message.py app/services/order_proposals/telegram_callback.py tests/services/order_proposals/test_approval_message.py tests/services/order_proposals/test_telegram_callback.py
+git commit -m "feat(ROB-861): show buying-power shortfall in Telegram"
+```
+
+### Task 4: Create-Time Pending-Buy Advisory
+
+**Files:**
+- Modify: `app/mcp_server/tooling/order_proposal_tools.py`
+- Modify: `tests/test_mcp_order_proposal_tools.py`
+
+**Interfaces:**
+- Consumes: Task 1 `build_create_advisory`.
+- Produces: Toss buy create responses with `buying_power_advisory` and top-level insufficient `warnings`.
+
+- [ ] **Step 1: Write failing insufficient aggregate advisory test**
+
+Create an existing same-account Toss pending buy, then create another proposal
+with an injected/default reader monkeypatched to return `Decimal("500000")`.
+Assert the second response contains both proposal notionals:
+
+```python
+assert created["buying_power_advisory"] == [{
+    "status": "insufficient",
+    "currency": "KRW",
+    "buying_power": "500000",
+    "pending_required": "700000",
+    "shortfall": "200000",
+    "skipped_market_rungs": 0,
+    "warning": "매수가능 500,000원 / 승인대기 필요 700,000원 → 부족 200,000원",
+}]
+assert created["warnings"] == [created["buying_power_advisory"][0]["warning"]]
+```
+
+- [ ] **Step 2: Run the targeted test and verify RED**
+
+Run: `uv run pytest tests/test_mcp_order_proposal_tools.py -q -k buying_power_advisory`
+
+Expected: `buying_power_advisory` is absent.
+
+- [ ] **Step 3: Add best-effort post-commit advisory wiring**
+
+After the create transaction commits, open a fresh `AsyncSessionLocal` session,
+call `build_create_advisory` for Toss buy/place proposals, attach the structured
+list, and copy non-null insufficient warning strings to top-level `warnings`.
+Wrap the whole advisory in `except Exception` with logging; never change the
+already successful create result to failure.
+
+- [ ] **Step 4: Add sufficient and unavailable regression tests**
+
+Assert sufficient buying power returns `status="sufficient"` with no top-level
+warning. Assert a reader exception still returns `success=True` and an
+`unavailable` advisory. Assert KIS and sell creates do not call the reader and
+retain the existing response shape.
+
+- [ ] **Step 5: Run MCP create tests and verify GREEN**
+
+Run: `uv run pytest tests/test_mcp_order_proposal_tools.py -q`
+
+Expected: all tests pass and no Telegram or broker network calls occur.
+
+- [ ] **Step 6: Commit Task 4**
+
+```bash
+git add app/mcp_server/tooling/order_proposal_tools.py tests/test_mcp_order_proposal_tools.py
+git commit -m "feat(ROB-861): advise pending buys at proposal create"
+```
+
+### Task 5: Full Verification, Documentation, and PR
+
+**Files:**
+- Modify if needed: `docs/superpowers/specs/2026-07-13-rob-861-buying-power-pre-submit-gate-design.md`
+- Modify if needed: `docs/superpowers/plans/2026-07-13-rob-861-buying-power-pre-submit-gate.md`
+
+**Interfaces:**
+- Consumes: all prior task outputs.
+- Produces: verified branch, pushed commits, and a GitHub PR against `main`.
+
+- [ ] **Step 1: Run the requested focused suite**
+
+Run: `uv run pytest tests/services/order_proposals/ -q`
+
+Expected: all focused tests pass.
+
+- [ ] **Step 2: Run the external MCP create test file**
+
+Run: `uv run pytest tests/test_mcp_order_proposal_tools.py -q`
+
+Expected: all tests pass.
+
+- [ ] **Step 3: Run lint/type validation**
+
+Run: `make lint`
+
+Expected: Ruff formatting/check and ty checks pass.
+
+- [ ] **Step 4: Inspect the final diff and conflict-sensitive files**
+
+Run:
+
+```bash
+git diff origin/main...HEAD --check
+git diff --stat origin/main...HEAD
+git diff --name-only origin/main...HEAD
+git status --short
+```
+
+Expected: no whitespace errors; neither `service.py` nor `state_machine.py`
+appears in the changed-file list; worktree is clean after the final commit.
+
+- [ ] **Step 5: Run pre-landing review and fix verified findings with TDD**
+
+Use `superpowers:requesting-code-review`, then the project `review` skill. For
+each valid finding, write/adjust a failing test before changing production
+behavior and rerun the relevant verification.
+
+- [ ] **Step 6: Commit any review fixes**
+
+```bash
+git add -u
+git commit -m "fix(ROB-861): address pre-submit gate review"
+```
+
+Skip this commit only when there are no review fixes.
+
+- [ ] **Step 7: Push and create the PR**
+
+```bash
+git push -u origin rob-861
+gh pr create --base main --head rob-861 --title "feat(ROB-861): gate approvals on buying power before submit" --body-file /tmp/rob-861-pr.md
+```
+
+The PR body must include the problem, pre-submit/data-flow summary, fail-open
+rationale, cache/reservation behavior, test results, explicit Toss-only scope,
+KIS/Upbit deferral, and the fact that `service.py`/`state_machine.py` were not
+changed so no ROB-862 merge ordering is required.
+
+- [ ] **Step 8: Report completion**
+
+Report the PR number/link, focused pytest result, MCP pytest result, `make lint`
+result, and exactly one line stating: Toss included; KIS/Upbit deferred behind
+the broker-agnostic hook.

--- a/docs/superpowers/specs/2026-07-13-rob-861-buying-power-pre-submit-gate-design.md
+++ b/docs/superpowers/specs/2026-07-13-rob-861-buying-power-pre-submit-gate-design.md
@@ -14,7 +14,7 @@ buying power.
 This change implements the live buying-power reader for `toss_live` only.
 `kis_live` and `upbit` keep their existing submit behavior because their
 orderable-cash contracts differ by market and order type. The gate exposes a
-broker-agnostic injected reader/reservation boundary so those brokers can be
+broker-agnostic injected claim/release boundary so those brokers can be
 added later without changing the revalidation state flow.
 
 No real broker calls are allowed in tests. The existing `service.py` and
@@ -78,10 +78,12 @@ not supported for that account mode, the gate deliberately fails open and the
 existing broker submit path continues. This is an operator UX pre-check, not an
 authoritative safety control; the broker remains the final source of truth.
 
-After an accepted submit, the required amount is reserved in the short-lived
-cache. Ambiguous submits are also reserved conservatively until TTL expiry,
-because the broker may have accepted them. Explicit broker rejection does not
-reserve cash.
+Before broker POST, the required amount is provisionally claimed under the
+short-lived cache's per-account/currency lock. This prevents concurrent
+approvals from observing and spending the same cached balance. Each claim has
+its own TTL and opaque token, independent of snapshot refreshes. Accepted and
+ambiguous submits keep that claim until its TTL expires because the broker may
+have accepted them; an explicit broker rejection releases only its own token.
 
 ### Loss-cut ordering
 

--- a/docs/superpowers/specs/2026-07-13-rob-861-buying-power-pre-submit-gate-design.md
+++ b/docs/superpowers/specs/2026-07-13-rob-861-buying-power-pre-submit-gate-design.md
@@ -1,0 +1,174 @@
+# ROB-861 — Buying-Power Pre-Submit Gate Design
+
+## Goal
+
+Prevent a Toss live buy proposal from reaching the broker when click-time
+buying power is already known to be below the order's required cash, tell the
+operator the exact available/required/shortfall amounts in Telegram, and keep
+the proposal retryable after a deposit. Add a non-blocking create-time advisory
+that compares all pending buys for the same account and currency with current
+buying power.
+
+## Scope
+
+This change implements the live buying-power reader for `toss_live` only.
+`kis_live` and `upbit` keep their existing submit behavior because their
+orderable-cash contracts differ by market and order type. The gate exposes a
+broker-agnostic injected reader/reservation boundary so those brokers can be
+added later without changing the revalidation state flow.
+
+No real broker calls are allowed in tests. The existing `service.py` and
+`state_machine.py` files remain unchanged: `revalidating -> needs_reconfirm`
+and `needs_reconfirm -> pending_approval` are already legal, and Telegram's
+re-approval path already performs the latter transition.
+
+## Architecture
+
+### Buying-power boundary
+
+Add a focused order-proposal buying-power module that owns:
+
+- normalized `Decimal` results for available, required, and shortfall amounts;
+- market-to-currency mapping (`equity_kr -> KRW`, `equity_us -> USD`);
+- a default broker reader that calls Toss
+  `GET /api/v1/buying-power?currency=...` and returns unavailable for other
+  account modes;
+- a short process-local cache keyed by account mode, broker account, and
+  currency;
+- per-key single-flight reads and a one-second TTL;
+- temporary subtraction of successfully submitted or ambiguous predecessor
+  orders from the cached amount, so rapid multi-rung or multi-proposal approval
+  does not reuse the same unadjusted snapshot.
+
+The existing shared Toss limiter continues to serialize provider requests. The
+short cache avoids repeated account resolution and buying-power reads during a
+burst while expiring quickly enough for a deposit to become visible on retry.
+Failures are not cached.
+
+### Click-time gate
+
+`revalidation.py` runs the gate only when all of these are true:
+
+- action is `place`;
+- rung side is `buy`;
+- rung is a limit order with a positive quantity and limit price;
+- the preview succeeded and its normalized quantity/price still match the
+  approved rung.
+
+Required cash uses the preview's `estimated_value + fee` when both values are
+usable. It falls back to `quantity * limit_price` when the preview does not
+expose costs, preserving injected-test and future-broker compatibility. The
+gate then reads buying power through the injected boundary.
+
+If the read succeeds and available cash is below required cash, the rung moves
+from `revalidating` to `needs_reconfirm`; the result includes:
+
+```json
+{
+  "reason": "insufficient_buying_power",
+  "currency": "KRW",
+  "available": "500000",
+  "required": "1070300",
+  "shortfall": "570300"
+}
+```
+
+No submit function is invoked. If the read raises, returns unavailable, or is
+not supported for that account mode, the gate deliberately fails open and the
+existing broker submit path continues. This is an operator UX pre-check, not an
+authoritative safety control; the broker remains the final source of truth.
+
+After an accepted submit, the required amount is reserved in the short-lived
+cache. Ambiguous submits are also reserved conservatively until TTL expiry,
+because the broker may have accepted them. Explicit broker rejection does not
+reserve cash.
+
+### Loss-cut ordering
+
+ROB-864's first click remains read-only and only builds loss-cut evidence. Its
+second confirmation enters the normal `revalidate_and_submit` flow. Because
+the buying-power gate lives after the fresh preview inside that flow, any
+future buy-side two-step flow would run confirmation first and the gate second;
+existing loss-cut proposals are sells and therefore skip the gate.
+
+### Telegram rendering
+
+A buying-power `needs_reconfirm` outcome is not rendered as a price/quantity
+diff. `approval_message.py` recognizes the reason and emits the localized line:
+
+`매수가능 Z원 / 필요 Y원 → 부족 X원 — 입금 후 재승인`
+
+USD amounts use dollar formatting with two decimal places; KRW amounts use
+whole won with thousands separators. The callback keeps the established fresh
+nonce and new approval-message behavior, so the same proposal can be approved
+again after a deposit. Multi-rung outcomes render every shortage rather than
+only the first.
+
+### Create-time advisory
+
+After proposal persistence succeeds, the MCP create path performs a best-effort
+read-only advisory in a fresh session. For each buy currency in the new
+proposal, it sums `quantity * limit_price` for all `pending_approval` buy rungs
+on the same `account_mode` and `broker_account_id`, including the new proposal.
+Market orders without a stored limit price are omitted and reported in the
+advisory metadata.
+
+For Toss, the response adds a structured `buying_power_advisory` list with
+`status` (`sufficient`, `insufficient`, or `unavailable`), currency, buying
+power, pending required cash, shortfall, and an optional human-readable
+warning. Insufficient entries are also copied into the top-level `warnings`
+list for MCP callers. This advisory never rolls back or blocks the already
+created proposal. Non-Toss account modes do not add an advisory until their
+readers are implemented.
+
+## Error Handling
+
+- Buying-power lookup failure at submit time: log, skip the gate, continue to
+  the existing broker path.
+- Buying-power advisory/query failure at create time: log, return the successful
+  create response with an `unavailable` advisory when possible.
+- Telegram edit/send failure: retain the existing commit-before-notify and
+  best-effort behavior.
+- Invalid or missing preview cost fields: fall back to rung notional; never
+  reject solely because cost metadata is malformed.
+- Explicit insufficient buying power: never call broker POST and never use a
+  terminal rung state.
+
+## Testing
+
+Use strict red-green-refactor cycles and injected fakes only.
+
+- Insufficient Toss buying power: submit fake called zero times, rung becomes
+  `needs_reconfirm`, outcome carries exact Z/Y/X values.
+- Sufficient buying power: existing submit and classification behavior remains
+  unchanged.
+- Sell rung: no buying-power read and unchanged submit path.
+- Reader failure/unavailable: fail open and submit through the existing path.
+- Deposit retry: first click yields `needs_reconfirm`; second approval reads a
+  fresh higher value and succeeds.
+- Rapid approvals/multiple rungs: short cache and reservation prevent reuse of
+  the same available amount.
+- Telegram: KRW and USD shortfall copy renders exactly and buttons remain
+  retryable.
+- Create advisory: includes the new proposal plus existing same-account
+  `pending_approval` buys, reports sufficient/insufficient status, and never
+  blocks creation when the reader fails.
+- ROB-864 regression: loss-cut first click still makes zero submit attempts and
+  sell-side second click skips the buying-power gate.
+
+Run the focused order-proposal suite, then the repository lint gate:
+
+```bash
+uv run pytest tests/services/order_proposals/ -q
+make lint
+```
+
+Targeted MCP create tests are run as part of implementation verification even
+though they live outside the requested focused directory.
+
+## PR Coordination
+
+The PR body records that Toss is implemented while KIS/Upbit are deferred behind
+the broker-agnostic hook. It also records that no `service.py` or
+`state_machine.py` changes were needed, avoiding the ROB-862 conflict and any
+merge-order dependency.

--- a/tests/services/order_proposals/test_approval_message.py
+++ b/tests/services/order_proposals/test_approval_message.py
@@ -10,6 +10,7 @@ import pytest
 from app.services.order_proposals.approval_message import (
     build_action_diff,
     build_approval_message,
+    build_buying_power_shortfall_text,
     build_callback_data,
     build_loss_cut_confirmation_message,
     parse_callback_data,
@@ -85,6 +86,62 @@ def test_loss_cut_approval_message_shows_reason_and_retrospective():
     assert r"stop\_loss" in text
     assert "#42" in text
     assert "ROB-800" not in text
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("detail", "expected"),
+    [
+        (
+            {
+                "reason": "insufficient_buying_power",
+                "currency": "KRW",
+                "available": "400000",
+                "required": "1070300",
+                "shortfall": "670300",
+            },
+            ("매수가능 400,000원 / 필요 1,070,300원 → 부족 670,300원 — 입금 후 재승인"),
+        ),
+        (
+            {
+                "reason": "insufficient_buying_power",
+                "currency": "USD",
+                "available": "100",
+                "required": "123.45",
+                "shortfall": "23.45",
+            },
+            ("매수가능 $100.00 / 필요 $123.45 → 부족 $23.45 — 입금 후 재승인"),
+        ),
+    ],
+)
+def test_buying_power_shortfall_text_formats_currency(detail, expected):
+    assert build_buying_power_shortfall_text(detail) == expected
+
+
+@pytest.mark.unit
+def test_buying_power_reconfirm_message_shows_shortfall_without_fake_diff():
+    detail = {
+        "reason": "insufficient_buying_power",
+        "currency": "KRW",
+        "available": "400000",
+        "required": "1070300",
+        "shortfall": "670300",
+    }
+
+    text, keyboard = build_approval_message(
+        group=_group(side="buy"),
+        rungs=[_rung()],
+        diff=detail,
+    )
+
+    assert "매수가능 금액 부족" in text
+    assert "매수가능 400,000원 / 필요 1,070,300원" in text
+    assert "입금 후 재승인" in text
+    assert "변경 전" not in text
+    assert [button["text"] for button in keyboard["inline_keyboard"][0]] == [
+        "✅ 승인",
+        "❌ 거부",
+    ]
 
 
 @pytest.mark.unit

--- a/tests/services/order_proposals/test_buying_power.py
+++ b/tests/services/order_proposals/test_buying_power.py
@@ -3,11 +3,13 @@ from decimal import Decimal
 
 import pytest
 
+from app.core.config import settings
 from app.services.order_proposals.buying_power import (
     BuyingPowerCache,
     BuyingPowerKey,
     build_create_advisory,
     currency_for_market,
+    default_buying_power_reader,
     pending_buy_requirement,
     required_cash,
 )
@@ -86,6 +88,28 @@ async def test_cache_does_not_store_loader_failure():
 
     assert await cache.get_or_load(key, loader) == Decimal("50000")
     assert calls == 2
+
+
+@pytest.mark.asyncio
+async def test_default_toss_reader_skips_when_provider_is_disabled(monkeypatch):
+    monkeypatch.setattr(settings, "toss_api_enabled", False)
+
+    def forbidden_client():
+        raise AssertionError("disabled Toss provider must not construct a client")
+
+    monkeypatch.setattr(
+        "app.services.brokers.toss.client.TossReadClient.from_settings",
+        forbidden_client,
+    )
+
+    assert (
+        await default_buying_power_reader(
+            account_mode="toss_live",
+            broker_account_id=None,
+            currency="KRW",
+        )
+        is None
+    )
 
 
 async def _seed_proposal(

--- a/tests/services/order_proposals/test_buying_power.py
+++ b/tests/services/order_proposals/test_buying_power.py
@@ -1,0 +1,228 @@
+import asyncio
+from decimal import Decimal
+
+import pytest
+
+from app.services.order_proposals.buying_power import (
+    BuyingPowerCache,
+    BuyingPowerKey,
+    build_create_advisory,
+    currency_for_market,
+    pending_buy_requirement,
+    required_cash,
+)
+from app.services.order_proposals.service import OrderProposalsService, RungInput
+
+
+@pytest.mark.unit
+def test_required_cash_prefers_preview_value_and_fee():
+    assert required_cash(
+        quantity=Decimal("3"),
+        limit_price=Decimal("71100"),
+        preview={"estimated_value": "213300", "fee": "32"},
+    ) == Decimal("213332")
+
+
+@pytest.mark.unit
+def test_required_cash_falls_back_to_limit_notional():
+    assert required_cash(
+        quantity=Decimal("3"),
+        limit_price=Decimal("71100"),
+        preview={"estimated_value": None, "fee": None},
+    ) == Decimal("213300")
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("market", "currency"),
+    [("equity_kr", "KRW"), ("equity_us", "USD")],
+)
+def test_currency_for_supported_equity_market(market, currency):
+    assert currency_for_market(market) == currency
+
+
+@pytest.mark.asyncio
+async def test_cache_single_flight_and_reservation_adjustment():
+    cache = BuyingPowerCache(ttl_seconds=1.0)
+    calls = 0
+
+    async def loader():
+        nonlocal calls
+        calls += 1
+        await asyncio.sleep(0)
+        return Decimal("100000")
+
+    key = BuyingPowerKey("toss_live", None, "KRW")
+    first, second = await asyncio.gather(
+        cache.get_or_load(key, loader),
+        cache.get_or_load(key, loader),
+    )
+    await cache.reserve(key, Decimal("30000"))
+
+    assert (first, second, calls) == (
+        Decimal("100000"),
+        Decimal("100000"),
+        1,
+    )
+    assert await cache.get_or_load(key, loader) == Decimal("70000")
+    assert calls == 1
+
+
+@pytest.mark.asyncio
+async def test_cache_does_not_store_loader_failure():
+    cache = BuyingPowerCache(ttl_seconds=1.0)
+    key = BuyingPowerKey("toss_live", None, "KRW")
+    calls = 0
+
+    async def loader():
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise RuntimeError("temporary outage")
+        return Decimal("50000")
+
+    with pytest.raises(RuntimeError, match="temporary outage"):
+        await cache.get_or_load(key, loader)
+
+    assert await cache.get_or_load(key, loader) == Decimal("50000")
+    assert calls == 2
+
+
+async def _seed_proposal(
+    db_session,
+    *,
+    side: str,
+    quantity: str,
+    limit_price: str | None,
+    broker_account_id: str | None,
+):
+    return await OrderProposalsService(db_session).create_proposal(
+        symbol="005930",
+        market="equity_kr",
+        account_mode="toss_live",
+        side=side,
+        order_type="limit" if limit_price is not None else "market",
+        proposer="test",
+        broker_account_id=broker_account_id,
+        rungs=[
+            RungInput(
+                0,
+                side,
+                Decimal(quantity),
+                Decimal(limit_price) if limit_price is not None else None,
+                None,
+            )
+        ],
+    )
+
+
+@pytest.mark.asyncio
+async def test_pending_requirement_sums_only_same_account_pending_limit_buys(
+    db_session,
+):
+    await _seed_proposal(
+        db_session,
+        side="buy",
+        quantity="2",
+        limit_price="100000",
+        broker_account_id="account-a",
+    )
+    await _seed_proposal(
+        db_session,
+        side="buy",
+        quantity="5",
+        limit_price="100000",
+        broker_account_id="account-a",
+    )
+    await _seed_proposal(
+        db_session,
+        side="buy",
+        quantity="9",
+        limit_price="100000",
+        broker_account_id="account-b",
+    )
+    await _seed_proposal(
+        db_session,
+        side="sell",
+        quantity="9",
+        limit_price="100000",
+        broker_account_id="account-a",
+    )
+    await _seed_proposal(
+        db_session,
+        side="buy",
+        quantity="1",
+        limit_price=None,
+        broker_account_id="account-a",
+    )
+
+    required, skipped = await pending_buy_requirement(
+        db_session,
+        account_mode="toss_live",
+        broker_account_id="account-a",
+        currency="KRW",
+    )
+
+    assert required == Decimal("700000")
+    assert skipped == 1
+
+
+@pytest.mark.asyncio
+async def test_create_advisory_reports_exact_pending_shortfall(db_session):
+    await _seed_proposal(
+        db_session,
+        side="buy",
+        quantity="7",
+        limit_price="100000",
+        broker_account_id="account-a",
+    )
+
+    async def reader(**kwargs):
+        assert kwargs == {
+            "account_mode": "toss_live",
+            "broker_account_id": "account-a",
+            "currency": "KRW",
+        }
+        return Decimal("500000")
+
+    advisory = await build_create_advisory(
+        db_session,
+        account_mode="toss_live",
+        broker_account_id="account-a",
+        currency="KRW",
+        buying_power_reader=reader,
+    )
+
+    assert advisory == {
+        "status": "insufficient",
+        "currency": "KRW",
+        "buying_power": "500000",
+        "pending_required": "700000",
+        "shortfall": "200000",
+        "skipped_market_rungs": 0,
+        "warning": ("매수가능 500,000원 / 승인대기 필요 700,000원 → 부족 200,000원"),
+    }
+
+
+@pytest.mark.asyncio
+async def test_create_advisory_is_unavailable_when_reader_fails(db_session):
+    async def reader(**kwargs):
+        raise RuntimeError("account api unavailable")
+
+    advisory = await build_create_advisory(
+        db_session,
+        account_mode="toss_live",
+        broker_account_id="account-unavailable",
+        currency="KRW",
+        buying_power_reader=reader,
+    )
+
+    assert advisory == {
+        "status": "unavailable",
+        "currency": "KRW",
+        "buying_power": None,
+        "pending_required": "0",
+        "shortfall": None,
+        "skipped_market_rungs": 0,
+        "warning": None,
+    }

--- a/tests/services/order_proposals/test_buying_power.py
+++ b/tests/services/order_proposals/test_buying_power.py
@@ -59,13 +59,15 @@ async def test_cache_single_flight_and_reservation_adjustment():
         cache.get_or_load(key, loader),
         cache.get_or_load(key, loader),
     )
-    await cache.reserve(key, Decimal("30000"))
+    claim = await cache.claim(key, Decimal("30000"), loader)
 
     assert (first, second, calls) == (
         Decimal("100000"),
         Decimal("100000"),
         1,
     )
+    assert claim.available == Decimal("100000")
+    assert claim.token is not None
     assert await cache.get_or_load(key, loader) == Decimal("70000")
     assert calls == 1
 
@@ -88,6 +90,103 @@ async def test_cache_does_not_store_loader_failure():
 
     assert await cache.get_or_load(key, loader) == Decimal("50000")
     assert calls == 2
+
+
+@pytest.mark.asyncio
+async def test_cache_slow_loader_still_single_flights_waiters():
+    now = 0.0
+    cache = BuyingPowerCache(ttl_seconds=1.0, clock=lambda: now)
+    key = BuyingPowerKey("toss_live", None, "KRW")
+    calls = 0
+
+    async def loader():
+        nonlocal calls, now
+        calls += 1
+        await asyncio.sleep(0)
+        now = 2.0
+        return Decimal("100000")
+
+    first, second = await asyncio.gather(
+        cache.get_or_load(key, loader),
+        cache.get_or_load(key, loader),
+    )
+
+    assert (first, second) == (Decimal("100000"), Decimal("100000"))
+    assert calls == 1
+
+
+@pytest.mark.asyncio
+async def test_cache_claim_allows_only_one_concurrent_underfunded_submit():
+    cache = BuyingPowerCache(ttl_seconds=1.0)
+    key = BuyingPowerKey("toss_live", None, "KRW")
+    loader_calls = 0
+    submit_calls = 0
+
+    async def loader():
+        nonlocal loader_calls
+        loader_calls += 1
+        await asyncio.sleep(0)
+        return Decimal("100000")
+
+    async def submit_if_claimed():
+        nonlocal submit_calls
+        claim = await cache.claim(key, Decimal("60000"), loader)
+        if claim.token is not None:
+            submit_calls += 1
+            await asyncio.sleep(0)
+        return claim
+
+    claims = await asyncio.gather(submit_if_claimed(), submit_if_claimed())
+
+    assert sorted(claim.available for claim in claims) == [
+        Decimal("40000"),
+        Decimal("100000"),
+    ]
+    assert sum(claim.token is not None for claim in claims) == 1
+    assert loader_calls == 1
+    assert submit_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_expired_claim_release_cannot_erase_new_cache_generation_claim():
+    now = 0.0
+    cache = BuyingPowerCache(ttl_seconds=1.0, clock=lambda: now)
+    key = BuyingPowerKey("toss_live", None, "KRW")
+
+    async def loader():
+        return Decimal("100000")
+
+    old_claim = await cache.claim(key, Decimal("60000"), loader)
+    assert old_claim.token is not None
+
+    now = 2.0
+    new_claim = await cache.claim(key, Decimal("60000"), loader)
+    assert new_claim.token is not None
+    await cache.release(key, old_claim.token)
+
+    blocked = await cache.claim(key, Decimal("60000"), loader)
+    assert blocked.available == Decimal("40000")
+    assert blocked.token is None
+
+
+@pytest.mark.asyncio
+async def test_claim_ttl_starts_when_claim_is_created_not_snapshot_loaded():
+    now = 0.0
+    cache = BuyingPowerCache(ttl_seconds=1.0, clock=lambda: now)
+    key = BuyingPowerKey("toss_live", None, "KRW")
+
+    async def loader():
+        return Decimal("100000")
+
+    assert await cache.get_or_load(key, loader) == Decimal("100000")
+    now = 0.9
+    claim = await cache.claim(key, Decimal("60000"), loader)
+    assert claim.token is not None
+
+    now = 1.1
+    blocked = await cache.claim(key, Decimal("60000"), loader)
+    assert blocked.available == Decimal("40000")
+    assert blocked.token is None
 
 
 @pytest.mark.asyncio

--- a/tests/services/order_proposals/test_revalidation.py
+++ b/tests/services/order_proposals/test_revalidation.py
@@ -1514,11 +1514,12 @@ async def test_toss_insufficient_buying_power_prevents_submit(db_session):
         submit_calls += 1
         pytest.fail("broker POST must not run with known insufficient buying power")
 
-    async def buying_power_reader(**kwargs):
+    async def buying_power_claimer(**kwargs):
         assert kwargs == {
             "account_mode": "toss_live",
             "broker_account_id": None,
             "currency": "KRW",
+            "amount": Decimal("1070300"),
         }
         return Decimal("400000")
 
@@ -1527,7 +1528,7 @@ async def test_toss_insufficient_buying_power_prevents_submit(db_session):
         proposal_id=group.proposal_id,
         now=datetime.now(UTC),
         place_order_fn=place_order,
-        buying_power_reader=buying_power_reader,
+        buying_power_claimer=buying_power_claimer,
     )
 
     assert outcomes[0].result == "needs_reconfirm"
@@ -1598,7 +1599,7 @@ async def test_toss_sufficient_buying_power_preserves_submit_path(db_session):
         proposal_id=group.proposal_id,
         now=datetime.now(UTC),
         place_order_fn=place_order,
-        buying_power_reader=reader,
+        buying_power_claimer=reader,
     )
 
     assert [outcome.result for outcome in outcomes] == ["submitted_resting"]
@@ -1631,7 +1632,7 @@ async def test_toss_sell_rung_skips_buying_power_gate(db_session):
         proposal_id=group.proposal_id,
         now=datetime.now(UTC),
         place_order_fn=place_order,
-        buying_power_reader=forbidden_reader,
+        buying_power_claimer=forbidden_reader,
     )
 
     assert [outcome.result for outcome in outcomes] == ["submitted_resting"]
@@ -1662,7 +1663,7 @@ async def test_toss_buying_power_failure_fails_open_to_submit(db_session):
         proposal_id=group.proposal_id,
         now=datetime.now(UTC),
         place_order_fn=place_order,
-        buying_power_reader=failed_reader,
+        buying_power_claimer=failed_reader,
     )
 
     assert [outcome.result for outcome in outcomes] == ["submitted_resting"]
@@ -1694,7 +1695,7 @@ async def test_toss_deposit_then_same_proposal_reapproval_succeeds(db_session):
         proposal_id=group.proposal_id,
         now=datetime.now(UTC),
         place_order_fn=place_order,
-        buying_power_reader=reader,
+        buying_power_claimer=reader,
     )
     await service.transition_rung(group.proposal_id, 0, new_state="pending_approval")
     second = await revalidate_and_submit(
@@ -1702,7 +1703,7 @@ async def test_toss_deposit_then_same_proposal_reapproval_succeeds(db_session):
         proposal_id=group.proposal_id,
         now=datetime.now(UTC),
         place_order_fn=place_order,
-        buying_power_reader=reader,
+        buying_power_claimer=reader,
     )
 
     assert [outcome.result for outcome in first] == ["needs_reconfirm"]
@@ -1736,21 +1737,24 @@ async def test_toss_successful_rung_reserves_cached_power_for_next_rung(db_sessi
             "broker_order_id": f"toss-reserved-{kwargs['rung']}",
         }
 
-    async def reader(**kwargs):
-        return available
-
-    async def reserver(**kwargs):
+    async def claimer(**kwargs):
         nonlocal available
         reservations.append(kwargs["amount"])
-        available -= kwargs["amount"]
+        before = available
+        if before >= kwargs["amount"]:
+            available -= kwargs["amount"]
+        return before
+
+    async def forbidden_releaser(**kwargs):
+        pytest.fail(f"accepted claims must not be released: {kwargs}")
 
     outcomes = await revalidate_and_submit(
         service=service,
         proposal_id=group.proposal_id,
         now=datetime.now(UTC),
         place_order_fn=place_order,
-        buying_power_reader=reader,
-        buying_power_reserver=reserver,
+        buying_power_claimer=claimer,
+        buying_power_releaser=forbidden_releaser,
     )
 
     assert [outcome.result for outcome in outcomes] == [
@@ -1758,9 +1762,66 @@ async def test_toss_successful_rung_reserves_cached_power_for_next_rung(db_sessi
         "needs_reconfirm",
     ]
     assert submit_calls == 1
-    assert reservations == [Decimal("60000")]
+    assert reservations == [Decimal("60000"), Decimal("60000")]
     assert outcomes[1].detail["available"] == "40000"
     assert outcomes[1].detail["shortfall"] == "20000"
+
+
+@pytest.mark.asyncio
+async def test_toss_explicit_rejection_releases_provisional_power(db_session):
+    service, group = await _create_toss_gate_proposal(db_session)
+    released: list[Decimal] = []
+
+    async def place_order(**kwargs):
+        if kwargs["dry_run"]:
+            return _toss_gate_preview(kwargs)
+        return {"success": False, "error": "broker_rejected"}
+
+    async def claimer(**kwargs):
+        assert kwargs["amount"] == Decimal("100000")
+        return Decimal("150000")
+
+    async def releaser(**kwargs):
+        released.append(kwargs["amount"])
+
+    outcomes = await revalidate_and_submit(
+        service=service,
+        proposal_id=group.proposal_id,
+        now=datetime.now(UTC),
+        place_order_fn=place_order,
+        buying_power_claimer=claimer,
+        buying_power_releaser=releaser,
+    )
+
+    assert outcomes[0].result == "error"
+    assert released == [Decimal("100000")]
+
+
+@pytest.mark.asyncio
+async def test_toss_ambiguous_submit_keeps_provisional_power(db_session):
+    service, group = await _create_toss_gate_proposal(db_session)
+
+    async def place_order(**kwargs):
+        if kwargs["dry_run"]:
+            return _toss_gate_preview(kwargs)
+        raise TimeoutError("submit response lost")
+
+    async def claimer(**kwargs):
+        return Decimal("150000")
+
+    async def forbidden_releaser(**kwargs):
+        pytest.fail(f"ambiguous submission must keep its claim: {kwargs}")
+
+    outcomes = await revalidate_and_submit(
+        service=service,
+        proposal_id=group.proposal_id,
+        now=datetime.now(UTC),
+        place_order_fn=place_order,
+        buying_power_claimer=claimer,
+        buying_power_releaser=forbidden_releaser,
+    )
+
+    assert outcomes[0].result == "unverified"
 
 
 @pytest.mark.asyncio

--- a/tests/services/order_proposals/test_revalidation.py
+++ b/tests/services/order_proposals/test_revalidation.py
@@ -1480,6 +1480,290 @@ async def test_toss_kr_routes_preview_and_accepted_submit(db_session, monkeypatc
 
 
 @pytest.mark.asyncio
+async def test_toss_insufficient_buying_power_prevents_submit(db_session):
+    service = OrderProposalsService(db_session)
+    group = await service.create_proposal(
+        symbol="005930",
+        market="equity_kr",
+        account_mode="toss_live",
+        side="buy",
+        order_type="limit",
+        proposer="p",
+        rungs=[RungInput(0, "buy", Decimal("1"), Decimal("1070300"), None)],
+    )
+    await db_session.commit()
+    submit_calls = 0
+
+    async def place_order(**kwargs):
+        nonlocal submit_calls
+        if kwargs["dry_run"]:
+            client_order_id = kwargs["proposal_client_order_id"]
+            return {
+                "success": True,
+                "approval_hash": "preview-token",
+                "price": "1070300",
+                "quantity": "1",
+                "estimated_value": "1070300",
+                "fee": "0",
+                "payload_preview": {
+                    "clientOrderId": client_order_id,
+                    "price": "1070300",
+                    "quantity": "1",
+                },
+            }
+        submit_calls += 1
+        pytest.fail("broker POST must not run with known insufficient buying power")
+
+    async def buying_power_reader(**kwargs):
+        assert kwargs == {
+            "account_mode": "toss_live",
+            "broker_account_id": None,
+            "currency": "KRW",
+        }
+        return Decimal("400000")
+
+    outcomes = await revalidate_and_submit(
+        service=service,
+        proposal_id=group.proposal_id,
+        now=datetime.now(UTC),
+        place_order_fn=place_order,
+        buying_power_reader=buying_power_reader,
+    )
+
+    assert outcomes[0].result == "needs_reconfirm"
+    assert outcomes[0].detail == {
+        "reason": "insufficient_buying_power",
+        "currency": "KRW",
+        "available": "400000",
+        "required": "1070300",
+        "shortfall": "670300",
+    }
+    assert submit_calls == 0
+    _, rungs = await service.get_proposal(group.proposal_id)
+    assert rungs[0].state == "needs_reconfirm"
+
+
+async def _create_toss_gate_proposal(db_session, *, side="buy", rungs=None):
+    service = OrderProposalsService(db_session)
+    group = await service.create_proposal(
+        symbol="005930",
+        market="equity_kr",
+        account_mode="toss_live",
+        side=side,
+        order_type="limit",
+        proposer="p",
+        rungs=rungs or [RungInput(0, side, Decimal("1"), Decimal("100000"), None)],
+    )
+    await db_session.commit()
+    return service, group
+
+
+def _toss_gate_preview(kwargs, *, quantity="1", price="100000"):
+    return {
+        "success": True,
+        "approval_hash": "preview-token",
+        "price": price,
+        "quantity": quantity,
+        "estimated_value": str(Decimal(quantity) * Decimal(price)),
+        "fee": "0",
+        "payload_preview": {
+            "clientOrderId": kwargs["proposal_client_order_id"],
+            "price": price,
+            "quantity": quantity,
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_toss_sufficient_buying_power_preserves_submit_path(db_session):
+    service, group = await _create_toss_gate_proposal(db_session)
+    submit_calls = 0
+
+    async def place_order(**kwargs):
+        nonlocal submit_calls
+        if kwargs["dry_run"]:
+            return _toss_gate_preview(kwargs)
+        submit_calls += 1
+        return {
+            "success": True,
+            "status": "resting",
+            "broker_order_id": "toss-enough-1",
+        }
+
+    async def reader(**kwargs):
+        return Decimal("100001")
+
+    outcomes = await revalidate_and_submit(
+        service=service,
+        proposal_id=group.proposal_id,
+        now=datetime.now(UTC),
+        place_order_fn=place_order,
+        buying_power_reader=reader,
+    )
+
+    assert [outcome.result for outcome in outcomes] == ["submitted_resting"]
+    assert submit_calls == 1
+    _, rungs = await service.get_proposal(group.proposal_id)
+    assert rungs[0].state == "resting"
+
+
+@pytest.mark.asyncio
+async def test_toss_sell_rung_skips_buying_power_gate(db_session):
+    service, group = await _create_toss_gate_proposal(db_session, side="sell")
+    submit_calls = 0
+
+    async def place_order(**kwargs):
+        nonlocal submit_calls
+        if kwargs["dry_run"]:
+            return _toss_gate_preview(kwargs)
+        submit_calls += 1
+        return {
+            "success": True,
+            "status": "resting",
+            "broker_order_id": "toss-sell-1",
+        }
+
+    async def forbidden_reader(**kwargs):
+        pytest.fail(f"sell rung must not read buying power: {kwargs}")
+
+    outcomes = await revalidate_and_submit(
+        service=service,
+        proposal_id=group.proposal_id,
+        now=datetime.now(UTC),
+        place_order_fn=place_order,
+        buying_power_reader=forbidden_reader,
+    )
+
+    assert [outcome.result for outcome in outcomes] == ["submitted_resting"]
+    assert submit_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_toss_buying_power_failure_fails_open_to_submit(db_session):
+    service, group = await _create_toss_gate_proposal(db_session)
+    submit_calls = 0
+
+    async def place_order(**kwargs):
+        nonlocal submit_calls
+        if kwargs["dry_run"]:
+            return _toss_gate_preview(kwargs)
+        submit_calls += 1
+        return {
+            "success": True,
+            "status": "resting",
+            "broker_order_id": "toss-fail-open-1",
+        }
+
+    async def failed_reader(**kwargs):
+        raise RuntimeError("buying-power endpoint unavailable")
+
+    outcomes = await revalidate_and_submit(
+        service=service,
+        proposal_id=group.proposal_id,
+        now=datetime.now(UTC),
+        place_order_fn=place_order,
+        buying_power_reader=failed_reader,
+    )
+
+    assert [outcome.result for outcome in outcomes] == ["submitted_resting"]
+    assert submit_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_toss_deposit_then_same_proposal_reapproval_succeeds(db_session):
+    service, group = await _create_toss_gate_proposal(db_session)
+    buying_power = iter((Decimal("50000"), Decimal("150000")))
+    submit_calls = 0
+
+    async def place_order(**kwargs):
+        nonlocal submit_calls
+        if kwargs["dry_run"]:
+            return _toss_gate_preview(kwargs)
+        submit_calls += 1
+        return {
+            "success": True,
+            "status": "resting",
+            "broker_order_id": "toss-after-deposit-1",
+        }
+
+    async def reader(**kwargs):
+        return next(buying_power)
+
+    first = await revalidate_and_submit(
+        service=service,
+        proposal_id=group.proposal_id,
+        now=datetime.now(UTC),
+        place_order_fn=place_order,
+        buying_power_reader=reader,
+    )
+    await service.transition_rung(group.proposal_id, 0, new_state="pending_approval")
+    second = await revalidate_and_submit(
+        service=service,
+        proposal_id=group.proposal_id,
+        now=datetime.now(UTC),
+        place_order_fn=place_order,
+        buying_power_reader=reader,
+    )
+
+    assert [outcome.result for outcome in first] == ["needs_reconfirm"]
+    assert [outcome.result for outcome in second] == ["submitted_resting"]
+    assert submit_calls == 1
+    _, rungs = await service.get_proposal(group.proposal_id)
+    assert rungs[0].state == "resting"
+
+
+@pytest.mark.asyncio
+async def test_toss_successful_rung_reserves_cached_power_for_next_rung(db_session):
+    service, group = await _create_toss_gate_proposal(
+        db_session,
+        rungs=[
+            RungInput(0, "buy", Decimal("6"), Decimal("10000"), None),
+            RungInput(1, "buy", Decimal("6"), Decimal("10000"), None),
+        ],
+    )
+    available = Decimal("100000")
+    submit_calls = 0
+    reservations: list[Decimal] = []
+
+    async def place_order(**kwargs):
+        nonlocal submit_calls
+        if kwargs["dry_run"]:
+            return _toss_gate_preview(kwargs, quantity="6", price="10000")
+        submit_calls += 1
+        return {
+            "success": True,
+            "status": "resting",
+            "broker_order_id": f"toss-reserved-{kwargs['rung']}",
+        }
+
+    async def reader(**kwargs):
+        return available
+
+    async def reserver(**kwargs):
+        nonlocal available
+        reservations.append(kwargs["amount"])
+        available -= kwargs["amount"]
+
+    outcomes = await revalidate_and_submit(
+        service=service,
+        proposal_id=group.proposal_id,
+        now=datetime.now(UTC),
+        place_order_fn=place_order,
+        buying_power_reader=reader,
+        buying_power_reserver=reserver,
+    )
+
+    assert [outcome.result for outcome in outcomes] == [
+        "submitted_resting",
+        "needs_reconfirm",
+    ]
+    assert submit_calls == 1
+    assert reservations == [Decimal("60000")]
+    assert outcomes[1].detail["available"] == "40000"
+    assert outcomes[1].detail["shortfall"] == "20000"
+
+
+@pytest.mark.asyncio
 async def test_toss_retry_across_dates_reuses_proposal_client_id(
     db_session, monkeypatch
 ):

--- a/tests/services/order_proposals/test_telegram_callback.py
+++ b/tests/services/order_proposals/test_telegram_callback.py
@@ -804,6 +804,97 @@ async def test_needs_reconfirm_sends_new_diff_message(monkeypatch, db_session):
 
 
 @pytest.mark.asyncio
+async def test_buying_power_shortfall_edits_failure_and_sends_retry_button(
+    monkeypatch, db_session
+):
+    _allow_chat(monkeypatch)
+    group = await _seed_proposal(db_session, nonce="nonce-buying-power")
+    data = f"op:{str(group.proposal_id)[:8]}:nonce-buying-power"
+    notifier = _FakeNotifier()
+    detail = {
+        "reason": "insufficient_buying_power",
+        "currency": "KRW",
+        "available": "400000",
+        "required": "1070300",
+        "shortfall": "670300",
+    }
+
+    async def fake_revalidate(*, service, proposal_id, now):
+        await service.transition_rung(proposal_id, 0, new_state="revalidating")
+        await service.mark_needs_reconfirm(proposal_id, 0, now=now)
+        return [RungOutcome(0, "needs_reconfirm", detail)]
+
+    result = await handle_callback_update(
+        _make_update(data=data),
+        now=datetime.now(UTC),
+        service_factory=_session_factory(db_session),
+        notifier=notifier,
+        revalidate_fn=fake_revalidate,
+    )
+
+    expected = "매수가능 400,000원 / 필요 1,070,300원 → 부족 670,300원 — 입금 후 재승인"
+    assert result["reason"] == "needs_reconfirm"
+    assert expected in notifier.edited[0][2]
+    new_text, new_keyboard, _chat_id = notifier.sent_messages[0]
+    assert expected in new_text
+    approve = new_keyboard["inline_keyboard"][0][0]
+    assert approve["text"] == "✅ 승인"
+    action, proposal_short, nonce = parse_callback_data(approve["callback_data"])
+    assert action == "op"
+    assert proposal_short == str(group.proposal_id)[:8]
+    assert nonce != "nonce-buying-power"
+    _, rungs = await OrderProposalsService(db_session).get_proposal(group.proposal_id)
+    assert rungs[0].state == "needs_reconfirm"
+
+
+@pytest.mark.asyncio
+async def test_buying_power_multi_rung_reconfirm_shows_every_shortfall(
+    monkeypatch, db_session
+):
+    _allow_chat(monkeypatch)
+    group = await _seed_proposal(db_session, nonce="nonce-buying-power-multi", rungs=2)
+    data = f"op:{str(group.proposal_id)[:8]}:nonce-buying-power-multi"
+    notifier = _FakeNotifier()
+    details = [
+        {
+            "reason": "insufficient_buying_power",
+            "currency": "KRW",
+            "available": "400000",
+            "required": "600000",
+            "shortfall": "200000",
+        },
+        {
+            "reason": "insufficient_buying_power",
+            "currency": "KRW",
+            "available": "400000",
+            "required": "700000",
+            "shortfall": "300000",
+        },
+    ]
+
+    async def fake_revalidate(*, service, proposal_id, now):
+        outcomes = []
+        for index, detail in enumerate(details):
+            await service.transition_rung(proposal_id, index, new_state="revalidating")
+            await service.mark_needs_reconfirm(proposal_id, index, now=now)
+            outcomes.append(RungOutcome(index, "needs_reconfirm", detail))
+        return outcomes
+
+    result = await handle_callback_update(
+        _make_update(data=data),
+        now=datetime.now(UTC),
+        service_factory=_session_factory(db_session),
+        notifier=notifier,
+        revalidate_fn=fake_revalidate,
+    )
+
+    assert result["reason"] == "needs_reconfirm"
+    new_text = notifier.sent_messages[0][0]
+    assert "필요 600,000원 → 부족 200,000원" in new_text
+    assert "필요 700,000원 → 부족 300,000원" in new_text
+
+
+@pytest.mark.asyncio
 async def test_deny_transitions_all_rungs_to_rejected(monkeypatch, db_session):
     _allow_chat(monkeypatch)
     group = await _seed_proposal(db_session, nonce="nonce-deny1", rungs=2)

--- a/tests/test_mcp_order_proposal_tools.py
+++ b/tests/test_mcp_order_proposal_tools.py
@@ -1,5 +1,6 @@
 import uuid
 from datetime import UTC, datetime, timedelta
+from decimal import Decimal
 from types import SimpleNamespace
 
 import pytest
@@ -146,6 +147,155 @@ async def test_place_create_never_fetches_a_target(monkeypatch):
     assert result["success"] is True
     assert result["action"] == "place"
     assert result["target_broker_order_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_toss_create_warns_on_same_account_pending_buying_power_shortfall(
+    monkeypatch,
+):
+    broker_account_id = f"rob-861-{uuid.uuid4()}"
+
+    async def reader(**kwargs):
+        assert kwargs["account_mode"] == "toss_live"
+        assert kwargs["broker_account_id"] == broker_account_id
+        assert kwargs["currency"] == "KRW"
+        return Decimal("500000")
+
+    monkeypatch.setattr(opt, "default_buying_power_reader", reader, raising=False)
+    first = await opt.order_proposal_create(
+        **_create_kwargs(
+            account_mode="toss_live",
+            broker_account_id=broker_account_id,
+            rungs=[
+                {
+                    "rung_index": 0,
+                    "side": "buy",
+                    "quantity": "2",
+                    "limit_price": "100000",
+                    "notional": None,
+                }
+            ],
+        )
+    )
+    created = await opt.order_proposal_create(
+        **_create_kwargs(
+            account_mode="toss_live",
+            broker_account_id=broker_account_id,
+            rungs=[
+                {
+                    "rung_index": 0,
+                    "side": "buy",
+                    "quantity": "5",
+                    "limit_price": "100000",
+                    "notional": None,
+                }
+            ],
+        )
+    )
+
+    assert first["success"] is True
+    assert created["success"] is True
+    assert created["buying_power_advisory"] == [
+        {
+            "status": "insufficient",
+            "currency": "KRW",
+            "buying_power": "500000",
+            "pending_required": "700000",
+            "shortfall": "200000",
+            "skipped_market_rungs": 0,
+            "warning": (
+                "매수가능 500,000원 / 승인대기 필요 700,000원 → 부족 200,000원"
+            ),
+        }
+    ]
+    assert created["warnings"] == [
+        "매수가능 500,000원 / 승인대기 필요 700,000원 → 부족 200,000원"
+    ]
+
+
+@pytest.mark.asyncio
+async def test_toss_create_reports_sufficient_buying_power_without_warning(monkeypatch):
+    broker_account_id = f"rob-861-sufficient-{uuid.uuid4()}"
+
+    async def reader(**kwargs):
+        return Decimal("1000000")
+
+    monkeypatch.setattr(opt, "default_buying_power_reader", reader)
+    created = await opt.order_proposal_create(
+        **_create_kwargs(
+            account_mode="toss_live",
+            broker_account_id=broker_account_id,
+            rungs=[
+                {
+                    "rung_index": 0,
+                    "side": "buy",
+                    "quantity": "2",
+                    "limit_price": "100000",
+                    "notional": None,
+                }
+            ],
+        )
+    )
+
+    assert created["success"] is True
+    assert created["buying_power_advisory"][0]["status"] == "sufficient"
+    assert created["buying_power_advisory"][0]["pending_required"] == "200000"
+    assert created["buying_power_advisory"][0]["shortfall"] == "0"
+    assert created["buying_power_advisory"][0]["warning"] is None
+    assert "warnings" not in created
+
+
+@pytest.mark.asyncio
+async def test_toss_create_reader_failure_is_non_blocking_unavailable_advisory(
+    monkeypatch,
+):
+    broker_account_id = f"rob-861-unavailable-{uuid.uuid4()}"
+
+    async def failed_reader(**kwargs):
+        raise RuntimeError("buying-power unavailable")
+
+    monkeypatch.setattr(opt, "default_buying_power_reader", failed_reader)
+    created = await opt.order_proposal_create(
+        **_create_kwargs(
+            account_mode="toss_live",
+            broker_account_id=broker_account_id,
+        )
+    )
+
+    assert created["success"] is True
+    assert created["buying_power_advisory"][0]["status"] == "unavailable"
+    assert created["buying_power_advisory"][0]["buying_power"] is None
+    assert created["buying_power_advisory"][0]["pending_required"] == "700000"
+    assert "warnings" not in created
+
+
+@pytest.mark.asyncio
+async def test_create_advisory_skips_kis_and_sell_proposals(monkeypatch):
+    async def forbidden_reader(**kwargs):
+        pytest.fail(f"unsupported create advisory read: {kwargs}")
+
+    monkeypatch.setattr(opt, "default_buying_power_reader", forbidden_reader)
+    kis = await opt.order_proposal_create(**_create_kwargs())
+    toss_sell = await opt.order_proposal_create(
+        **_create_kwargs(
+            account_mode="toss_live",
+            side="sell",
+            rungs=[
+                {
+                    "rung_index": 0,
+                    "side": "sell",
+                    "quantity": "10",
+                    "limit_price": "70000",
+                    "notional": None,
+                }
+            ],
+        )
+    )
+
+    assert kis["success"] is True
+    assert toss_sell["success"] is True
+    assert "buying_power_advisory" not in kis
+    assert "buying_power_advisory" not in toss_sell
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Add a Toss live buy-only buying-power gate after successful preview revalidation and before broker POST.
- Return known shortfalls as retryable `needs_reconfirm` outcomes, with exact Telegram `매수가능 / 필요 / 부족 — 입금 후 재승인` guidance and the existing fresh-nonce approval button.
- Add a non-blocking create-time advisory comparing the new proposal plus same-account `pending_approval` buys against current buying power.
- Protect rapid approvals with a one-second single-flight snapshot cache and token-scoped atomic provisional claims. Explicit broker rejection releases only its own claim; accepted or ambiguous submits retain the claim until TTL expiry.

## Behavior and safety

- Insufficient known buying power prevents broker POST entirely.
- Buying-power lookup failures deliberately fail open to the existing broker path. This gate improves operator feedback; the broker remains the final authority.
- Sell rungs and unsupported providers keep their existing paths.
- ROB-864 loss-cut ordering remains confirmation-first: the gate runs only in normal revalidation after the second confirmation.
- No changes to `order_proposals/service.py` or `state_machine.py`, so this branch has no ROB-862 merge-order dependency.

## Provider scope

- Included: `toss_live`, using the existing `GET /api/v1/buying-power?currency=` client method.
- Deferred: `kis_live` and `upbit`. Revalidation exposes broker-agnostic claimer/releaser hooks so their market-specific orderable-cash contracts can be added without changing the state flow.

## Verification

- `uv run pytest tests/services/order_proposals/ -q` — 329 passed, 2 pre-existing Pydantic deprecation warnings.
- `uv run pytest tests/test_mcp_order_proposal_tools.py -q` — 20 passed, 2 pre-existing Pydantic deprecation warnings.
- `make lint` — Ruff check, Ruff format check, and ty passed.
- `git diff --check origin/main...HEAD` — passed.
- Independent pre-landing review — no remaining Critical or Important findings after concurrency regression fixes.

All broker, buying-power, and Telegram paths are mocked in tests; no real broker request was made.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added buying-power advisories when creating eligible buy proposals, including available, required, and shortfall amounts.
  * Added a pre-submit check that prevents underfunded Toss buy orders and supports retry after funds are added.
  * Added provisional buying-power reservations to coordinate concurrent approvals.
  * Enhanced Telegram approval and reconfirmation messages with localized shortfall details and next steps.

* **Bug Fixes**
  * Buying-power lookup failures no longer block order submission or proposal creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->