### PR TITLE
feat(ROB-866): Toss 수동 거래 감지 스윕 (감지+알림, read-only)

### DIFF
--- a/alembic/versions/20260713_rob866_toss_manual_activity_alerts.py
+++ b/alembic/versions/20260713_rob866_toss_manual_activity_alerts.py
@@ -1,0 +1,60 @@
+"""ROB-866 — additive review.toss_manual_activity_alerts idempotency marker.
+
+Alert-only marker for the Toss manual-activity detection sweep. Presence of a
+broker_order_id means "already alerted; do not re-alert". This is NOT a
+fill/bookkeeping ledger (that is stage 2). Additive-only; no existing table is
+touched. Operator runs ``alembic upgrade head`` separately at cutover.
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "20260713_rob866_toss_manual_activity"
+down_revision = "20260713_rob844_root_reservation"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "toss_manual_activity_alerts",
+        sa.Column("broker_order_id", sa.Text(), nullable=False),
+        sa.Column("symbol", sa.Text(), nullable=True),
+        sa.Column("side", sa.Text(), nullable=True),
+        sa.Column("status", sa.Text(), nullable=True),
+        sa.Column("market", sa.Text(), nullable=True),
+        sa.Column(
+            "is_open",
+            sa.Boolean(),
+            server_default=sa.text("false"),
+            nullable=False,
+        ),
+        sa.Column(
+            "alerted_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint(
+            "broker_order_id", name="pk_toss_manual_activity_alerts"
+        ),
+        schema="review",
+    )
+    op.create_index(
+        "ix_toss_manual_activity_alerts_alerted_at",
+        "toss_manual_activity_alerts",
+        ["alerted_at"],
+        schema="review",
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_toss_manual_activity_alerts_alerted_at",
+        table_name="toss_manual_activity_alerts",
+        schema="review",
+    )
+    op.drop_table("toss_manual_activity_alerts", schema="review")

--- a/alembic/versions/20260713_rob866_toss_manual_activity_alerts.py
+++ b/alembic/versions/20260713_rob866_toss_manual_activity_alerts.py
@@ -13,7 +13,7 @@ import sqlalchemy as sa
 from alembic import op
 
 revision = "20260713_rob866_toss_manual_activity"
-down_revision = "20260713_rob844_root_reservation"
+down_revision = "20260713_rob844_ack_scope"
 branch_labels = None
 depends_on = None
 

--- a/alembic/versions/20260713_rob866_toss_manual_activity_alerts.py
+++ b/alembic/versions/20260713_rob866_toss_manual_activity_alerts.py
@@ -12,7 +12,7 @@ import sqlalchemy as sa
 
 from alembic import op
 
-revision = "20260713_rob866_toss_manual_activity"
+revision = "20260713_rob866_manual_alerts"
 down_revision = "20260713_rob844_ack_scope"
 branch_labels = None
 depends_on = None

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -259,6 +259,12 @@ class Settings(BaseSettings):
     toss_api_base_url: str | None = None
     toss_live_order_mutations_enabled: bool = False
 
+    # ROB-866: gate for the scheduleless Toss manual-activity sweep TaskIQ task.
+    # Default off — the sweep runs manually (dry_run MCP tool) first; recurrence is
+    # a separate decision after manual reps. Only gates the auto-run task; the MCP
+    # tool itself is operator-driven and gated by TOSS_API_ENABLED for reads.
+    toss_manual_activity_sweep_enabled: bool = False
+
     # ROB-701/ROB-828: Redis cache-aside for the per-symbol Toss sellable-
     # quantity fanout on /invest home, account-panel, and MCP holdings.
     # Successful sell mutations and confirmed fills invalidate the symbol.

--- a/app/mcp_server/tooling/registry.py
+++ b/app/mcp_server/tooling/registry.py
@@ -156,6 +156,9 @@ from app.mcp_server.tooling.route_request_registration import (
 from app.mcp_server.tooling.session_context_registration import (
     register_session_context_tools,
 )
+from app.mcp_server.tooling.toss_manual_activity_tools import (
+    register_toss_manual_activity_tools,
+)
 from app.mcp_server.tooling.trade_journal_registration import (
     register_trade_journal_tools,
 )
@@ -295,6 +298,8 @@ def register_all_tools(mcp: FastMCP, profile: McpProfile = McpProfile.DEFAULT) -
         register_kis_mock_order_tools(mcp)
         register_live_reconcile_tools(mcp)
         register_toss_live_order_tools(mcp)
+        # ROB-866: Toss manual-activity detection sweep (read-only; alert-only).
+        register_toss_manual_activity_tools(mcp)
         # ROB-601: optionally surface kiwoom_mock_* in the operator DEFAULT
         # session so analyze→approval→order can run through kiwoom mock without
         # switching to the isolated KIWOOM profile (which drops every other

--- a/app/mcp_server/tooling/route_request_lanes.py
+++ b/app/mcp_server/tooling/route_request_lanes.py
@@ -360,6 +360,9 @@ READ_ONLY_ADVISORY_TOOLS: frozenset[str] = frozenset(
         "set_user_setting",
         "stage_analysis_get",
         "suggest_order_account",
+        # ROB-866: detection sweep (no broker order mutation; alert-only side effect
+        # like session_context_append, which is likewise advisory-classified).
+        "toss_detect_manual_activity",
         "trade_retrospective_pending",
         "update_manual_holdings",
         "update_trade_journal",

--- a/app/mcp_server/tooling/toss_manual_activity_tools.py
+++ b/app/mcp_server/tooling/toss_manual_activity_tools.py
@@ -1,0 +1,71 @@
+"""ROB-866 — MCP tool: detect Toss manual (unbooked) trading activity.
+
+Toss has no execution websocket, so operator app-side manual trades are invisible
+until reported. ``toss_detect_manual_activity`` diffs Toss GET /orders against the
+ledger + proposal rungs to surface manual orders. dry_run (default) returns findings
+only (zero writes); dry_run=False sends a Telegram alert + hands off to
+session_context and records an idempotency marker so the same order is not
+re-alerted. This is detection + alert only — no fill/journal bookkeeping (stage 2).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from app.core.config import validate_toss_api_config
+from app.services.toss_manual_activity import run_manual_activity_sweep
+
+if TYPE_CHECKING:
+    from fastmcp import FastMCP
+
+TOSS_MANUAL_ACTIVITY_TOOL_NAMES = frozenset({"toss_detect_manual_activity"})
+
+_MIN_WINDOW_HOURS = 1
+_MAX_WINDOW_HOURS = 168  # 7 days — bounds the CLOSED pagination cost.
+
+
+async def toss_detect_manual_activity(
+    window_hours: int = 24, dry_run: bool = True
+) -> dict[str, Any]:
+    """Surface Toss orders absent from the ledger + proposal rungs.
+
+    Args:
+        window_hours: lookback window for CLOSED orders (1–168h, default 24).
+        dry_run: when True (default), returns findings only — no Telegram, no
+            session_context, no marker writes. When False, alerts and records.
+    """
+
+    missing = validate_toss_api_config()
+    if missing:
+        return {
+            "success": False,
+            "source": "toss",
+            "error": (
+                "Toss Open API is disabled or missing required configuration: "
+                + ", ".join(missing)
+            ),
+            "missing_env": missing,
+        }
+
+    try:
+        window = int(window_hours)
+    except (TypeError, ValueError):
+        window = 24
+    window = max(_MIN_WINDOW_HOURS, min(window, _MAX_WINDOW_HOURS))
+
+    return await run_manual_activity_sweep(window_hours=window, dry_run=bool(dry_run))
+
+
+def register_toss_manual_activity_tools(mcp: FastMCP) -> None:
+    _ = mcp.tool(
+        name="toss_detect_manual_activity",
+        description=(
+            "Detect Toss manual (app-side) trades the system has not booked. Diffs "
+            "Toss GET /orders (CLOSED + OPEN) over a lookback window against the "
+            "toss_live_order_ledger and proposal rungs. dry_run=True (default) "
+            "returns findings only (zero writes). dry_run=False sends a Telegram "
+            "alert + session_context handoff and records an idempotency marker so "
+            "the same order is not re-alerted. Read-only against the broker; no fill "
+            "bookkeeping (that is a separate stage)."
+        ),
+    )(toss_detect_manual_activity)

--- a/app/models/review.py
+++ b/app/models/review.py
@@ -1263,3 +1263,36 @@ class TradeForecast(Base):
         onupdate=func.now(),
         nullable=False,
     )
+
+
+# ---------------------------------------------------------------------------
+# review.toss_manual_activity_alerts — ROB-866 idempotency marker
+# ---------------------------------------------------------------------------
+class TossManualActivityAlert(Base):
+    """ROB-866 — records Toss manual (unbooked) orders that have been alerted.
+
+    Toss has no execution websocket, so operator app-side trades are invisible to
+    the system until reported. The manual-activity sweep diffs GET /orders against
+    ``review.toss_live_order_ledger`` + proposal rungs to surface unbooked orders,
+    then alerts Telegram + session_context. This table is the alert-idempotency
+    marker only — it is NOT a fill/bookkeeping ledger (that is stage 2). Presence
+    of a ``broker_order_id`` here means "already alerted; do not re-alert".
+    """
+
+    __tablename__ = "toss_manual_activity_alerts"
+    __table_args__ = (
+        Index("ix_toss_manual_activity_alerts_alerted_at", "alerted_at"),
+        {"schema": "review"},
+    )
+
+    broker_order_id: Mapped[str] = mapped_column(Text, primary_key=True)
+    symbol: Mapped[str | None] = mapped_column(Text)
+    side: Mapped[str | None] = mapped_column(Text)
+    status: Mapped[str | None] = mapped_column(Text)
+    market: Mapped[str | None] = mapped_column(Text)
+    is_open: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, server_default=text("false"), default=False
+    )
+    alerted_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), server_default=func.now(), nullable=False
+    )

--- a/app/services/toss_manual_activity.py
+++ b/app/services/toss_manual_activity.py
@@ -1,0 +1,458 @@
+"""ROB-866 — Toss manual-activity detection sweep (stage 1: detect + alert only).
+
+Toss has no execution websocket, so KIS/Upbit-style fill triage never fires for
+Toss: an operator's app-side manual buy/sell is invisible to the system until they
+report it or the next session reads holdings (observed 2026-07-13: manual Peptron
+loss-cut, Hynix/Samsung manual buys). This module diffs Toss GET /orders against the
+persisted ledger + proposal rungs to surface **unbooked** orders, then (in execution
+mode) alerts Telegram and hands off to session_context.
+
+Scope boundaries:
+- Read-only against the broker: only ``list_orders`` (GET /orders) is ever called.
+- No auto-bookkeeping: nothing is written to ``review.toss_live_order_ledger`` here.
+  Stage 2 (fill/journal booking) is deliberately out of scope. The only write is the
+  idempotency marker in ``review.toss_manual_activity_alerts`` so the same manual
+  order is not re-alerted across sweeps.
+- The order_proposals module is read-only SELECT here (ROB-861/862 own its writes).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.ext.asyncio import AsyncSession
+
+KnownOrderIdsLookup = Callable[[set[str]], Awaitable[set[str]]]
+NotifyCallable = Callable[[str, str | None], Awaitable[Any]]
+AppendSessionContext = Callable[[list[dict[str, Any]]], Awaitable[Any]]
+
+# Toss closed-order statuses that represent an actual execution worth booking.
+_FILLED_STATUSES = frozenset({"FILLED", "PARTIAL_FILLED"})
+
+_DEFAULT_CLOSED_PAGE_CAP = 20
+_SIDE_KR = {"buy": "매수", "sell": "매도"}
+
+
+@dataclass(frozen=True)
+class ManualOrder:
+    """A Toss order that is absent from the ledger and proposal rungs."""
+
+    order_id: str
+    symbol: str
+    side: str
+    status: str
+    market: str | None
+    quantity: Decimal | None
+    filled_quantity: Decimal | None
+    avg_fill_price: Decimal | None
+    ordered_at: str
+    is_open: bool
+
+    def summary(self) -> dict[str, Any]:
+        return {
+            "order_id": self.order_id,
+            "symbol": self.symbol,
+            "side": self.side,
+            "status": self.status,
+            "market": self.market,
+            "quantity": _dec_str(self.quantity),
+            "filled_quantity": _dec_str(self.filled_quantity),
+            "avg_fill_price": _dec_str(self.avg_fill_price),
+            "ordered_at": self.ordered_at,
+            "is_open": self.is_open,
+        }
+
+
+@dataclass
+class ManualActivitySweep:
+    filled: list[ManualOrder] = field(default_factory=list)
+    open_orders: list[ManualOrder] = field(default_factory=list)
+    scanned_open: int = 0
+    scanned_closed: int = 0
+    window_hours: int = 24
+    closed_pages_capped: bool = False
+
+
+def _dec_str(value: Decimal | None) -> str | None:
+    return None if value is None else str(value)
+
+
+def _market_from_order(order: Any) -> str | None:
+    currency = str(getattr(order, "currency", "") or "").upper()
+    if currency == "KRW":
+        return "kr"
+    if currency == "USD":
+        return "us"
+    return None
+
+
+def _has_fill_evidence(order: Any) -> bool:
+    execution = dict(getattr(order, "execution", {}) or {})
+    try:
+        return float(execution.get("filledQuantity") or 0) > 0
+    except (TypeError, ValueError):
+        return False
+
+
+def _is_filled(order: Any) -> bool:
+    status = str(getattr(order, "status", "") or "").upper()
+    return status in _FILLED_STATUSES or _has_fill_evidence(order)
+
+
+def _to_manual(order: Any, *, is_open: bool) -> ManualOrder:
+    execution = dict(getattr(order, "execution", {}) or {})
+    return ManualOrder(
+        order_id=str(order.order_id),
+        symbol=str(order.symbol),
+        side=str(order.side),
+        status=str(order.status),
+        market=_market_from_order(order),
+        quantity=getattr(order, "quantity", None),
+        filled_quantity=execution.get("filledQuantity"),
+        avg_fill_price=execution.get("averageFilledPrice"),
+        ordered_at=str(getattr(order, "ordered_at", "") or ""),
+        is_open=is_open,
+    )
+
+
+async def _collect_orders(
+    client: Any,
+    *,
+    from_date: str,
+    to_date: str,
+    closed_page_cap: int,
+) -> tuple[list[Any], list[Any], bool]:
+    """Fetch OPEN (1 call) + paginated CLOSED orders for the window.
+
+    Every ``list_orders`` call spends the shared ORDER_HISTORY (5 TPS) budget inside
+    the client transport, so pagination is naturally rate-limited.
+    """
+
+    open_page = await client.list_orders(status="OPEN")
+    open_orders = list(open_page.orders)
+
+    closed_orders: list[Any] = []
+    cursor: str | None = None
+    seen_cursors: set[str] = set()
+    pages = 0
+    capped = False
+    while True:
+        page = await client.list_orders(
+            status="CLOSED",
+            from_date=from_date,
+            to_date=to_date,
+            cursor=cursor,
+            limit=100,
+        )
+        pages += 1
+        closed_orders.extend(page.orders)
+        if not page.has_next or not page.next_cursor:
+            break
+        if pages >= closed_page_cap:
+            capped = True
+            break
+        if page.next_cursor in seen_cursors:
+            break
+        seen_cursors.add(page.next_cursor)
+        cursor = page.next_cursor
+    return open_orders, closed_orders, capped
+
+
+async def detect_manual_activity(
+    *,
+    client: Any,
+    known_order_ids: KnownOrderIdsLookup,
+    now: datetime,
+    window_hours: int = 24,
+    closed_page_cap: int = _DEFAULT_CLOSED_PAGE_CAP,
+) -> ManualActivitySweep:
+    """Return Toss orders absent from the ledger + proposal rungs.
+
+    ``known_order_ids`` is given the set of every fetched broker order id and returns
+    the subset that is already known (ledger ∪ proposal rung). Everything else is a
+    manual order: closed FILLED/PARTIAL_FILLED go to ``filled``; OPEN go to
+    ``open_orders``.
+    """
+
+    from_date = (now - timedelta(hours=window_hours)).date().isoformat()
+    to_date = now.date().isoformat()
+
+    open_orders, closed_orders, capped = await _collect_orders(
+        client, from_date=from_date, to_date=to_date, closed_page_cap=closed_page_cap
+    )
+
+    all_ids = {str(o.order_id) for o in open_orders} | {
+        str(o.order_id) for o in closed_orders
+    }
+    known = await known_order_ids(all_ids) if all_ids else set()
+
+    manual_open = [
+        _to_manual(o, is_open=True) for o in open_orders if str(o.order_id) not in known
+    ]
+    manual_filled = [
+        _to_manual(o, is_open=False)
+        for o in closed_orders
+        if str(o.order_id) not in known and _is_filled(o)
+    ]
+    return ManualActivitySweep(
+        filled=manual_filled,
+        open_orders=manual_open,
+        scanned_open=len(open_orders),
+        scanned_closed=len(closed_orders),
+        window_hours=window_hours,
+        closed_pages_capped=capped,
+    )
+
+
+class TossManualActivityAlertStore:
+    """Idempotency marker store for ROB-866 (alert-only; NOT a fill ledger)."""
+
+    def __init__(self, db: AsyncSession) -> None:
+        self._db = db
+
+    async def existing_alerted_ids(self, order_ids: set[str]) -> set[str]:
+        if not order_ids:
+            return set()
+        from app.models.review import TossManualActivityAlert
+
+        rows = await self._db.execute(
+            select(TossManualActivityAlert.broker_order_id).where(
+                TossManualActivityAlert.broker_order_id.in_(order_ids)
+            )
+        )
+        return {row[0] for row in rows}
+
+    async def record_alerts(self, orders: list[ManualOrder]) -> int:
+        if not orders:
+            return 0
+        from app.models.review import TossManualActivityAlert
+
+        for order in orders:
+            stmt = (
+                pg_insert(TossManualActivityAlert)
+                .values(
+                    broker_order_id=order.order_id,
+                    symbol=order.symbol,
+                    side=order.side,
+                    status=order.status,
+                    market=order.market,
+                    is_open=order.is_open,
+                )
+                .on_conflict_do_nothing(index_elements=["broker_order_id"])
+            )
+            await self._db.execute(stmt)
+        await self._db.commit()
+        return len(orders)
+
+
+async def _proposal_broker_order_ids(db: AsyncSession, order_ids: set[str]) -> set[str]:
+    """Read-only SELECT of proposal-rung broker order ids (ROB-861/862 own writes)."""
+    if not order_ids:
+        return set()
+    from app.models.order_proposals import OrderProposalRung
+
+    rows = await db.execute(
+        select(OrderProposalRung.broker_order_id).where(
+            OrderProposalRung.broker_order_id.in_(order_ids)
+        )
+    )
+    return {row[0] for row in rows if row[0]}
+
+
+def _market_label(market: str | None) -> str:
+    return {"kr": "KR", "us": "US"}.get(market or "", "기타")
+
+
+def _order_line(order: ManualOrder) -> str:
+    side = _SIDE_KR.get(order.side, order.side)
+    qty = _dec_str(order.filled_quantity) or _dec_str(order.quantity) or "?"
+    price = _dec_str(order.avg_fill_price)
+    tail = f" @ {price}" if price else ""
+    return f"• {side} {order.symbol} {qty}{tail} [{order.status}]"
+
+
+def _format_alert(
+    market: str | None, fills: list[ManualOrder], opens: list[ManualOrder]
+) -> str:
+    lines = [f"🔔 토스 수동 거래 감지 ({_market_label(market)})"]
+    lines.extend(_order_line(o) for o in fills)
+    if opens:
+        lines.append("미결(OPEN):")
+        lines.extend(_order_line(o) for o in opens)
+    lines.append("→ 원장 미기록. 부기 필요.")
+    return "\n".join(lines)
+
+
+async def _default_notify(message: str, market: str | None) -> Any:
+    from app.monitoring.trade_notifier import get_trade_notifier
+
+    notifier = get_trade_notifier()
+    return await notifier.notify_agent_message(
+        message, market_type=market, skip_discord=True
+    )
+
+
+async def _default_append(entries: list[dict[str, Any]]) -> Any:
+    from app.mcp_server.tooling.session_context_tools import session_context_append
+
+    return await session_context_append(entries)
+
+
+async def _sweep_with_deps(
+    *,
+    client: Any,
+    known_order_ids: KnownOrderIdsLookup,
+    alert_store: Any,
+    notify: NotifyCallable | None,
+    append_session_context: AppendSessionContext | None,
+    now: datetime,
+    window_hours: int,
+    dry_run: bool,
+    closed_page_cap: int,
+) -> dict[str, Any]:
+    sweep = await detect_manual_activity(
+        client=client,
+        known_order_ids=known_order_ids,
+        now=now,
+        window_hours=window_hours,
+        closed_page_cap=closed_page_cap,
+    )
+
+    manual_all = sweep.filled + sweep.open_orders
+    manual_ids = {o.order_id for o in manual_all}
+    already = (
+        await alert_store.existing_alerted_ids(manual_ids) if manual_ids else set()
+    )
+    new_orders = [o for o in manual_all if o.order_id not in already]
+
+    response: dict[str, Any] = {
+        "success": True,
+        "source": "toss",
+        "dry_run": dry_run,
+        "mutation_sent": False,
+        "window_hours": window_hours,
+        "scanned": {
+            "open": sweep.scanned_open,
+            "closed": sweep.scanned_closed,
+            "closed_pages_capped": sweep.closed_pages_capped,
+        },
+        "manual_filled": [o.summary() for o in sweep.filled],
+        "manual_open": [o.summary() for o in sweep.open_orders],
+        "new_count": len(new_orders),
+        "already_alerted_count": len(manual_all) - len(new_orders),
+        "alerted": False,
+    }
+
+    if dry_run or not new_orders:
+        return response
+
+    notify = notify or _default_notify
+    append_session_context = append_session_context or _default_append
+
+    by_market: dict[str | None, list[ManualOrder]] = {}
+    for order in new_orders:
+        by_market.setdefault(order.market, []).append(order)
+
+    entries: list[dict[str, Any]] = []
+    for market, orders in by_market.items():
+        fills = [o for o in orders if not o.is_open]
+        opens = [o for o in orders if o.is_open]
+        message = _format_alert(market, fills, opens)
+        await notify(message, market)
+        if market in ("kr", "us"):
+            entries.append(
+                {
+                    "market": market,
+                    "entry_type": "handoff_note",
+                    "title": f"토스 수동 거래 {len(orders)}건 감지 — 부기 필요",
+                    "body": message,
+                    "created_by": "system",
+                    "refs": {"symbols": sorted({o.symbol for o in orders})},
+                }
+            )
+    if entries:
+        await append_session_context(entries)
+
+    await alert_store.record_alerts(new_orders)
+
+    response["alerted"] = True
+    response["alerted_count"] = len(new_orders)
+    return response
+
+
+async def run_manual_activity_sweep(
+    *,
+    window_hours: int = 24,
+    dry_run: bool = True,
+    closed_page_cap: int = _DEFAULT_CLOSED_PAGE_CAP,
+    now: datetime | None = None,
+    client: Any | None = None,
+    known_order_ids: KnownOrderIdsLookup | None = None,
+    alert_store: Any | None = None,
+    notify: NotifyCallable | None = None,
+    append_session_context: AppendSessionContext | None = None,
+    settings_obj: Any | None = None,
+) -> dict[str, Any]:
+    """Detect Toss manual activity and, in execution mode, alert + hand off.
+
+    Deps (client / known_order_ids / alert_store / notify / append) are injectable
+    for tests. When ``known_order_ids`` and ``alert_store`` are both omitted, a live
+    DB session is opened to wire the ledger + proposal-rung lookup and the marker
+    store.
+    """
+
+    if now is None:
+        now = datetime.now(UTC)
+
+    if client is None:
+        from app.core.config import settings as _settings
+        from app.services.brokers.toss import TossReadClient
+
+        client = TossReadClient.from_settings(settings_obj=settings_obj or _settings)
+
+    if known_order_ids is not None and alert_store is not None:
+        return await _sweep_with_deps(
+            client=client,
+            known_order_ids=known_order_ids,
+            alert_store=alert_store,
+            notify=notify,
+            append_session_context=append_session_context,
+            now=now,
+            window_hours=window_hours,
+            dry_run=dry_run,
+            closed_page_cap=closed_page_cap,
+        )
+
+    from app.core.db import AsyncSessionLocal
+    from app.services.toss_live_order_ledger_service import (
+        TossLiveOrderLedgerService,
+    )
+
+    async with AsyncSessionLocal() as db:
+        ledger = TossLiveOrderLedgerService(db)
+        store = TossManualActivityAlertStore(db)
+
+        async def known_lookup(ids: set[str]) -> set[str]:
+            if not ids:
+                return set()
+            in_ledger = await ledger.existing_broker_order_ids(ids)
+            in_props = await _proposal_broker_order_ids(db, ids)
+            return in_ledger | in_props
+
+        return await _sweep_with_deps(
+            client=client,
+            known_order_ids=known_lookup,
+            alert_store=store,
+            notify=notify,
+            append_session_context=append_session_context,
+            now=now,
+            window_hours=window_hours,
+            dry_run=dry_run,
+            closed_page_cap=closed_page_cap,
+        )

--- a/app/tasks/__init__.py
+++ b/app/tasks/__init__.py
@@ -23,6 +23,7 @@ from app.tasks import (
     research_reports_ingest_tasks,
     research_run_refresh_tasks,
     toss_live_reconcile_tasks,
+    toss_manual_activity_tasks,
     toss_warnings_sync_tasks,
     upbit_symbol_universe_tasks,
     us_candles_tasks,
@@ -61,5 +62,6 @@ TASKIQ_TASK_MODULES = (
     us_candles_tasks,
     us_symbol_universe_tasks,
     toss_live_reconcile_tasks,
+    toss_manual_activity_tasks,
     toss_warnings_sync_tasks,
 )

--- a/app/tasks/toss_manual_activity_tasks.py
+++ b/app/tasks/toss_manual_activity_tasks.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from app.core.config import settings
+from app.core.taskiq_broker import broker
+from app.services.toss_manual_activity import run_manual_activity_sweep
+
+logger = logging.getLogger(__name__)
+
+
+# ROB-866: shipped scheduleless. Production recurrence is a separate decision made
+# AFTER manual reps (operator/Prefect-registered, e.g. robin-prefect-automations) so
+# enabling TOSS_API_ENABLED does not silently auto-start a sweep that sends Telegram
+# alerts. Default off via TOSS_MANUAL_ACTIVITY_SWEEP_ENABLED. Suggested cadence when
+# registered: hourly during market hours.
+@broker.task(task_name="toss.manual_activity_sweep")
+async def toss_manual_activity_sweep_task(window_hours: int = 24) -> dict[str, Any]:
+    if not settings.toss_manual_activity_sweep_enabled:
+        return {"status": "disabled", "found": 0, "alerted": 0}
+    try:
+        result = await run_manual_activity_sweep(
+            window_hours=window_hours, dry_run=False
+        )
+    except Exception as exc:  # pragma: no cover - defensive logging path
+        logger.error("TaskIQ Toss manual-activity sweep failed: %s", exc, exc_info=True)
+        return {"status": "failed", "error": str(exc)}
+    found = len(result.get("manual_filled", [])) + len(result.get("manual_open", []))
+    return {
+        "status": "ok",
+        "found": found,
+        "alerted": result.get("alerted_count", 0),
+    }

--- a/docs/runbooks/toss-manual-activity-sweep.md
+++ b/docs/runbooks/toss-manual-activity-sweep.md
@@ -1,0 +1,46 @@
+# Toss 수동 거래 감지 스윕 (ROB-866)
+
+토스는 체결 웹소켓이 없어 운영자의 앱 수동 매매(직접 주문)를 시스템이 인지하지
+못한다(KIS/Upbit는 웹소켓 fill-트리아지가 자동 기동). 이 스윕은 토스 `GET
+/api/v1/orders`(CLOSED 페이지네이션 + OPEN 1콜)를 `review.toss_live_order_ledger`
+및 order_proposal rung `broker_order_id`와 대조해 **원장에 없는 = 수동 거래**를
+발견하고, 실행 모드에서 텔레그램 알림 + `session_context` 핸드오프를 남긴다.
+
+**1단계 스코프**: 감지 + 알림만. 자동 저널/체결 부기는 없다(2단계). 브로커 대상
+호출은 read-only(`list_orders`만).
+
+## 구성
+
+- **감지 커널**: `app/services/toss_manual_activity.py`
+  - `detect_manual_activity(...)` — 순수 감지(원장/proposal 대조).
+  - `run_manual_activity_sweep(...)` — DB/텔레그램/session_context 배선 + 멱등 필터.
+- **MCP 도구**: `toss_detect_manual_activity(window_hours=24, dry_run=True)`
+  (`app/mcp_server/tooling/toss_manual_activity_tools.py`).
+- **멱등 마커**: `review.toss_manual_activity_alerts` (broker_order_id PK).
+  이미 알린 주문 재알림 방지 전용 — **체결 원장 아님**.
+- **TaskIQ**: `toss.manual_activity_sweep` (scheduleless, `app/tasks/toss_manual_activity_tasks.py`).
+- **마이그레이션**: `20260713_rob866_toss_manual_activity` (additive).
+
+## 안전 경계 / env 게이트
+
+- 읽기는 `TOSS_API_ENABLED=true` + client id/secret 필요 (`validate_toss_api_config`).
+  미설정 시 MCP 도구는 `success=false` + `missing_env` 반환(네트워크 호출 없음).
+- `TOSS_MANUAL_ACTIVITY_SWEEP_ENABLED`(기본 false) — **auto-run TaskIQ task**만 arm.
+  MCP 도구(operator 직접 호출)는 이 플래그와 무관하며 dry_run으로 게이트.
+- 브로커 mutation 0. 멱등 마커/session_context 외 쓰기 없음.
+- 스케줄 연결 없음 — recurrence는 수동 reps 후 별도 결정(operator/Prefect 등록).
+
+## 수동 플레이북 (MCP)
+
+1. **발견만 (쓰기 0)**: `toss_detect_manual_activity(window_hours=24, dry_run=True)`
+   → `manual_filled`/`manual_open` 목록 확인. `new_count`는 아직 알리지 않은 건수.
+2. **알림 + 핸드오프**: `toss_detect_manual_activity(window_hours=24, dry_run=False)`
+   → 신규 수동 주문마다 텔레그램 발송 + 해당 market(kr/us) `session_context`
+   handoff_note 기록 + 멱등 마커 저장. 같은 주문은 다음 스윕에서 재알림 안 됨.
+3. **부기**: 알림은 "부기 필요" 신호일 뿐 — 실제 저널/체결 반영은 운영자/2단계가
+   수행(원장에 편입되면 이후 스윕에서 자동으로 오탐 0).
+
+## 활성화(auto-run) — 연기됨
+
+`TOSS_MANUAL_ACTIVITY_SWEEP_ENABLED=true` + operator/Prefect가 `toss.manual_activity_sweep`
+cadence 등록 시에만 자동 실행. 수동 reps로 감지 신뢰 확보 후 결정한다.

--- a/env.example
+++ b/env.example
@@ -444,6 +444,11 @@ TOSS_API_BASE_URL=https://openapi.tossinvest.com
 # Arms live order mutations (place/modify/cancel) AND the holdings sellability
 # / orderable-cash / tradeability surfaces (ROB-549). Keep false until cleared.
 TOSS_LIVE_ORDER_MUTATIONS_ENABLED=false
+# ROB-866 — arms the scheduleless toss.manual_activity_sweep TaskIQ task (auto-run
+# execution mode: Telegram alert + session_context handoff). Default off; the sweep
+# is run manually via the toss_detect_manual_activity MCP tool first. Read-only vs
+# the broker regardless of this flag.
+TOSS_MANUAL_ACTIVITY_SWEEP_ENABLED=false
 # ROB-651 P6-A — Toss preview→place approval-hash 강제 수준 (off|optional|warn|required)
 TOSS_APPROVAL_HASH_MODE=optional
 

--- a/tests/_schema_bootstrap.py
+++ b/tests/_schema_bootstrap.py
@@ -32,7 +32,9 @@ from sqlalchemy import text
 # v10 (ROB-844 review): broker-ack identity adds instrument_id. Persistent test
 # DBs may already have the same named 3-column index, so a shape-aware refresher
 # replaces only a mismatched definition before CREATE IF NOT EXISTS.
-SCHEMA_BOOTSTRAP_VERSION = 10
+# v11 (ROB-866): review.toss_manual_activity_alerts (new ORM table) — create_all
+# builds it; bump forces a persistent local DB to re-bootstrap once.
+SCHEMA_BOOTSTRAP_VERSION = 11
 
 # ---- constraints + enums (moved verbatim from conftest.py) ----
 MARKET_VALUATION_SOURCE_CHECK_NAME = "ck_market_valuation_snapshots_source"

--- a/tests/services/test_toss_manual_activity.py
+++ b/tests/services/test_toss_manual_activity.py
@@ -1,0 +1,465 @@
+"""ROB-866 — Toss manual-activity detection sweep tests.
+
+Toss has no execution websocket, so operator app-side manual trades are invisible
+until reported. This sweep diffs GET /orders against the ledger + proposal rungs to
+surface manual (unbooked) orders, then in execution mode alerts Telegram +
+session_context. Stage 1 = detect + alert only (no auto-bookkeeping).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from decimal import Decimal
+from unittest.mock import AsyncMock
+
+import pytest
+from sqlalchemy import delete
+
+from app.services.brokers.toss.dto import TossOrder, TossOrdersPage
+from app.services.toss_manual_activity import (
+    ManualOrder,
+    TossManualActivityAlertStore,
+    detect_manual_activity,
+    run_manual_activity_sweep,
+)
+
+pytestmark = pytest.mark.asyncio
+
+NOW = datetime(2026, 7, 13, 12, 0, 0, tzinfo=UTC)
+
+
+def _order(
+    order_id: str,
+    symbol: str,
+    side: str,
+    status: str,
+    *,
+    qty: str = "0",
+    filled: str | None = None,
+    avg: str | None = None,
+    currency: str = "KRW",
+) -> TossOrder:
+    execution: dict[str, object] = {}
+    if filled is not None:
+        execution["filledQuantity"] = Decimal(filled)
+    if avg is not None:
+        execution["averageFilledPrice"] = Decimal(avg)
+    return TossOrder(
+        order_id=order_id,
+        symbol=symbol,
+        side=side,
+        order_type="limit",
+        time_in_force="DAY",
+        status=status,
+        price=None,
+        quantity=Decimal(qty),
+        order_amount=None,
+        currency=currency,
+        ordered_at="2026-07-13T10:00:00",
+        canceled_at=None,
+        execution=execution,
+    )
+
+
+class FakeTossReadClient:
+    """Read-only fake — only exposes list_orders (the sweep must never mutate)."""
+
+    def __init__(
+        self,
+        *,
+        open_orders: list[TossOrder],
+        closed_pages: list[tuple[list[TossOrder], str | None, bool]],
+    ) -> None:
+        self._open = open_orders
+        self._closed_pages = closed_pages
+        self.calls: list[dict[str, object]] = []
+
+    async def list_orders(
+        self,
+        *,
+        status: str,
+        symbol: str | None = None,
+        from_date: str | None = None,
+        to_date: str | None = None,
+        cursor: str | None = None,
+        limit: int | None = None,
+    ) -> TossOrdersPage:
+        self.calls.append(
+            {
+                "status": status,
+                "cursor": cursor,
+                "from_date": from_date,
+                "to_date": to_date,
+                "limit": limit,
+            }
+        )
+        if status == "OPEN":
+            return TossOrdersPage(orders=self._open, next_cursor=None, has_next=False)
+        # CLOSED — resolve page by cursor position.
+        if cursor is None:
+            idx = 0
+        else:
+            idx = int(cursor)
+        orders, next_cursor, has_next = self._closed_pages[idx]
+        return TossOrdersPage(orders=orders, next_cursor=next_cursor, has_next=has_next)
+
+
+class FakeAlertStore:
+    def __init__(self) -> None:
+        self.recorded: list[str] = []
+
+    async def existing_alerted_ids(self, order_ids: set[str]) -> set[str]:
+        return set(self.recorded) & set(order_ids)
+
+    async def record_alerts(self, orders: list[ManualOrder]) -> int:
+        self.recorded.extend(o.order_id for o in orders)
+        return len(orders)
+
+
+async def _all_known(ids: set[str]) -> set[str]:
+    return set(ids)
+
+
+async def _none_known(ids: set[str]) -> set[str]:
+    return set()
+
+
+# --------------------------------------------------------------------------- #
+# Pure detection
+# --------------------------------------------------------------------------- #
+
+
+async def test_manual_filled_order_absent_from_ledger_is_reported() -> None:
+    manual = _order(
+        "m1", "005930", "sell", "FILLED", qty="10", filled="10", avg="70000"
+    )
+    known = _order("k1", "000660", "buy", "FILLED", qty="5", filled="5", avg="100000")
+    client = FakeTossReadClient(
+        open_orders=[], closed_pages=[([manual, known], None, False)]
+    )
+
+    async def known_lookup(ids: set[str]) -> set[str]:
+        return {"k1"} & ids
+
+    sweep = await detect_manual_activity(
+        client=client, known_order_ids=known_lookup, now=NOW, window_hours=24
+    )
+
+    assert [o.order_id for o in sweep.filled] == ["m1"]
+    assert sweep.filled[0].symbol == "005930"
+    assert sweep.filled[0].side == "sell"
+    assert sweep.filled[0].filled_quantity == Decimal("10")
+    assert sweep.filled[0].avg_fill_price == Decimal("70000")
+    assert sweep.filled[0].market == "kr"
+    assert sweep.open_orders == []
+
+
+async def test_no_false_positive_when_every_order_is_known() -> None:
+    filled = _order("k1", "005930", "buy", "FILLED", qty="5", filled="5", avg="70000")
+    open_order = _order("k2", "000660", "buy", "PENDING", qty="3")
+    client = FakeTossReadClient(
+        open_orders=[open_order], closed_pages=[([filled], None, False)]
+    )
+
+    sweep = await detect_manual_activity(
+        client=client, known_order_ids=_all_known, now=NOW, window_hours=24
+    )
+
+    assert sweep.filled == []
+    assert sweep.open_orders == []
+
+
+async def test_open_manual_order_listed_separately_from_fills() -> None:
+    open_order = _order("o1", "000660", "buy", "PENDING", qty="3", currency="KRW")
+    client = FakeTossReadClient(
+        open_orders=[open_order], closed_pages=[([], None, False)]
+    )
+
+    sweep = await detect_manual_activity(
+        client=client, known_order_ids=_none_known, now=NOW, window_hours=24
+    )
+
+    assert [o.order_id for o in sweep.open_orders] == ["o1"]
+    assert sweep.open_orders[0].is_open is True
+    assert sweep.filled == []
+
+
+async def test_cancelled_closed_manual_order_is_not_reported_as_fill() -> None:
+    cancelled = _order("c1", "005930", "buy", "CANCELLED", qty="10", filled="0")
+    client = FakeTossReadClient(
+        open_orders=[], closed_pages=[([cancelled], None, False)]
+    )
+
+    sweep = await detect_manual_activity(
+        client=client, known_order_ids=_none_known, now=NOW, window_hours=24
+    )
+
+    assert sweep.filled == []
+    assert sweep.open_orders == []
+
+
+async def test_partial_filled_closed_manual_order_is_reported() -> None:
+    partial = _order(
+        "p1", "005930", "sell", "PARTIAL_FILLED", qty="10", filled="4", avg="70000"
+    )
+    client = FakeTossReadClient(open_orders=[], closed_pages=[([partial], None, False)])
+
+    sweep = await detect_manual_activity(
+        client=client, known_order_ids=_none_known, now=NOW, window_hours=24
+    )
+
+    assert [o.order_id for o in sweep.filled] == ["p1"]
+
+
+async def test_closed_orders_are_paginated() -> None:
+    m1 = _order("m1", "005930", "buy", "FILLED", qty="1", filled="1", avg="70000")
+    m2 = _order("m2", "000660", "buy", "FILLED", qty="1", filled="1", avg="90000")
+    client = FakeTossReadClient(
+        open_orders=[],
+        closed_pages=[([m1], "1", True), ([m2], None, False)],
+    )
+
+    sweep = await detect_manual_activity(
+        client=client, known_order_ids=_none_known, now=NOW, window_hours=24
+    )
+
+    assert {o.order_id for o in sweep.filled} == {"m1", "m2"}
+    closed_calls = [c for c in client.calls if c["status"] == "CLOSED"]
+    assert len(closed_calls) == 2
+    # Window from/to are derived and passed on every CLOSED page.
+    assert all(c["from_date"] and c["to_date"] for c in closed_calls)
+    assert all(c["limit"] == 100 for c in closed_calls)
+
+
+async def test_detection_only_issues_read_calls() -> None:
+    m1 = _order("m1", "005930", "buy", "FILLED", qty="1", filled="1", avg="70000")
+    client = FakeTossReadClient(open_orders=[], closed_pages=[([m1], None, False)])
+
+    await detect_manual_activity(
+        client=client, known_order_ids=_none_known, now=NOW, window_hours=24
+    )
+
+    assert client.calls, "sweep must call the read API"
+    assert all(c["status"] in {"OPEN", "CLOSED"} for c in client.calls)
+
+
+# --------------------------------------------------------------------------- #
+# Orchestration (dry-run vs execution, idempotency)
+# --------------------------------------------------------------------------- #
+
+
+def _one_manual_client() -> FakeTossReadClient:
+    manual = _order(
+        "m1", "005930", "sell", "FILLED", qty="10", filled="10", avg="70000"
+    )
+    return FakeTossReadClient(open_orders=[], closed_pages=[([manual], None, False)])
+
+
+async def test_dry_run_lists_manual_without_any_write() -> None:
+    store = FakeAlertStore()
+    notify = AsyncMock()
+    append = AsyncMock()
+
+    res = await run_manual_activity_sweep(
+        dry_run=True,
+        client=_one_manual_client(),
+        known_order_ids=_none_known,
+        alert_store=store,
+        notify=notify,
+        append_session_context=append,
+        now=NOW,
+    )
+
+    assert res["success"] is True
+    assert res["dry_run"] is True
+    assert res["mutation_sent"] is False
+    assert res["new_count"] == 1
+    assert res["alerted"] is False
+    assert len(res["manual_filled"]) == 1
+    notify.assert_not_awaited()
+    append.assert_not_awaited()
+    assert store.recorded == []
+
+
+async def test_execution_mode_alerts_and_records_marker() -> None:
+    store = FakeAlertStore()
+    notify = AsyncMock()
+    append = AsyncMock()
+
+    res = await run_manual_activity_sweep(
+        dry_run=False,
+        client=_one_manual_client(),
+        known_order_ids=_none_known,
+        alert_store=store,
+        notify=notify,
+        append_session_context=append,
+        now=NOW,
+    )
+
+    assert res["alerted"] is True
+    assert res["alerted_count"] == 1
+    notify.assert_awaited()
+    append.assert_awaited()
+    # session_context entry carries the kr market handoff.
+    entries = append.await_args.args[0]
+    assert entries[0]["market"] == "kr"
+    assert entries[0]["entry_type"] == "handoff_note"
+    assert store.recorded == ["m1"]
+
+
+async def test_second_sweep_does_not_realert_same_order() -> None:
+    store = FakeAlertStore()
+
+    first_notify = AsyncMock()
+    await run_manual_activity_sweep(
+        dry_run=False,
+        client=_one_manual_client(),
+        known_order_ids=_none_known,
+        alert_store=store,
+        notify=first_notify,
+        append_session_context=AsyncMock(),
+        now=NOW,
+    )
+    assert first_notify.await_count == 1
+
+    second_notify = AsyncMock()
+    res = await run_manual_activity_sweep(
+        dry_run=False,
+        client=_one_manual_client(),
+        known_order_ids=_none_known,
+        alert_store=store,
+        notify=second_notify,
+        append_session_context=AsyncMock(),
+        now=NOW,
+    )
+
+    second_notify.assert_not_awaited()
+    assert res["new_count"] == 0
+    assert res["alerted"] is False
+    assert store.recorded == ["m1"]
+
+
+# --------------------------------------------------------------------------- #
+# Alert store — DB-backed idempotency marker
+# --------------------------------------------------------------------------- #
+
+
+def _manual(order_id: str) -> ManualOrder:
+    return ManualOrder(
+        order_id=order_id,
+        symbol="005930",
+        side="sell",
+        status="FILLED",
+        market="kr",
+        quantity=Decimal("10"),
+        filled_quantity=Decimal("10"),
+        avg_fill_price=Decimal("70000"),
+        ordered_at="2026-07-13T10:00:00",
+        is_open=False,
+    )
+
+
+async def test_alert_store_records_and_is_idempotent(db_session) -> None:
+    from app.models.review import TossManualActivityAlert
+
+    ids = {"rob866-a", "rob866-b"}
+    store = TossManualActivityAlertStore(db_session)
+    try:
+        assert await store.existing_alerted_ids(ids) == set()
+
+        await store.record_alerts([_manual("rob866-a")])
+        assert await store.existing_alerted_ids(ids) == {"rob866-a"}
+
+        # Re-recording the same order must not raise and must not duplicate.
+        await store.record_alerts([_manual("rob866-a")])
+        assert await store.existing_alerted_ids(ids) == {"rob866-a"}
+    finally:
+        await db_session.execute(
+            delete(TossManualActivityAlert).where(
+                TossManualActivityAlert.broker_order_id.in_(ids)
+            )
+        )
+        await db_session.commit()
+
+
+# --------------------------------------------------------------------------- #
+# MCP tool + TaskIQ task surface
+# --------------------------------------------------------------------------- #
+
+
+async def test_mcp_tool_reports_config_missing_when_toss_disabled(monkeypatch) -> None:
+    from app.mcp_server.tooling import toss_manual_activity_tools as mod
+
+    monkeypatch.setattr(
+        mod, "validate_toss_api_config", lambda *a, **k: ["TOSS_API_ENABLED"]
+    )
+
+    res = await mod.toss_detect_manual_activity()
+
+    assert res["success"] is False
+    assert "TOSS_API_ENABLED" in res["missing_env"]
+
+
+async def test_mcp_tool_passes_params_and_clamps_window(monkeypatch) -> None:
+    from app.mcp_server.tooling import toss_manual_activity_tools as mod
+
+    monkeypatch.setattr(mod, "validate_toss_api_config", lambda *a, **k: [])
+    captured: dict[str, object] = {}
+
+    async def fake_run(*, window_hours: int, dry_run: bool) -> dict[str, object]:
+        captured["window_hours"] = window_hours
+        captured["dry_run"] = dry_run
+        return {"success": True}
+
+    monkeypatch.setattr(mod, "run_manual_activity_sweep", fake_run)
+
+    await mod.toss_detect_manual_activity(window_hours=9999, dry_run=False)
+
+    assert captured["window_hours"] == 168  # clamped to the 7-day cap
+    assert captured["dry_run"] is False
+
+
+async def test_task_is_disabled_by_default(monkeypatch) -> None:
+    from app.tasks import toss_manual_activity_tasks as mod
+
+    monkeypatch.setattr(
+        mod.settings, "toss_manual_activity_sweep_enabled", False, raising=False
+    )
+
+    called = False
+
+    async def fake_run(**kwargs: object) -> dict[str, object]:
+        nonlocal called
+        called = True
+        return {}
+
+    monkeypatch.setattr(mod, "run_manual_activity_sweep", fake_run)
+
+    res = await mod.toss_manual_activity_sweep_task()
+
+    assert res["status"] == "disabled"
+    assert called is False
+
+
+async def test_task_runs_execution_sweep_when_enabled(monkeypatch) -> None:
+    from app.tasks import toss_manual_activity_tasks as mod
+
+    monkeypatch.setattr(
+        mod.settings, "toss_manual_activity_sweep_enabled", True, raising=False
+    )
+    captured: dict[str, object] = {}
+
+    async def fake_run(*, window_hours: int, dry_run: bool) -> dict[str, object]:
+        captured["window_hours"] = window_hours
+        captured["dry_run"] = dry_run
+        return {"manual_filled": [{}], "manual_open": [], "alerted_count": 1}
+
+    monkeypatch.setattr(mod, "run_manual_activity_sweep", fake_run)
+
+    res = await mod.toss_manual_activity_sweep_task(window_hours=12)
+
+    assert captured["dry_run"] is False
+    assert captured["window_hours"] == 12
+    assert res["status"] == "ok"
+    assert res["found"] == 1
+    assert res["alerted"] == 1


### PR DESCRIPTION
## 배경

토스는 체결 웹소켓이 없어 운영자의 앱 수동 매매(직접 주문)를 시스템이 인지하지 못한다(KIS/Upbit는 웹소켓 fill-트리아지가 자동 기동). 07-13 펩트론 수동 손절·하이닉스/삼전 수동 매수를 세션이 보고받기 전까지 몰랐음. 이 PR은 **1단계 = 감지 + 알림만**(자동 부기는 2단계).

## 구현

- **감지 커널** `app/services/toss_manual_activity.py`
  - `detect_manual_activity(...)` — 순수 감지. Toss `GET /orders`(CLOSED 페이지네이션 limit 100 + OPEN 1콜, 윈도우 기본 24h)를 `review.toss_live_order_ledger.broker_order_id` ∪ `order_proposal_rungs.broker_order_id`와 대조 → 원장 밖 주문 = 수동. CLOSED FILLED/PARTIAL_FILLED → `filled`, OPEN → `open_orders`.
  - `run_manual_activity_sweep(...)` — DB(ledger+proposal) 배선 + 멱등 필터 + 실행모드 알림.
- **MCP 도구** `toss_detect_manual_activity(window_hours=24, dry_run=True)`
  - `dry_run=True`(기본): 발견 목록만, 쓰기 0.
  - `dry_run=False`: 신규 수동 주문마다 텔레그램 + market별 `session_context_append(handoff_note)` + 멱등 마커 기록.
  - `TOSS_API_ENABLED` 미설정 시 `success=false` + `missing_env`(네트워크 호출 없음).
- **TaskIQ** `toss.manual_activity_sweep` — **scheduleless** 등록만, `TOSS_MANUAL_ACTIVITY_SWEEP_ENABLED`(기본 off) 게이트. recurrence는 수동 reps 후 별도 결정.
- **rate limit**: 모든 `list_orders`는 공유 ORDER_HISTORY(5 TPS) 버짓을 transport에서 소비 → 페이지네이션 자연 rate-limited.

## 멱등 마커 저장 방식

신규 additive 테이블 `review.toss_manual_activity_alerts`(`broker_order_id` PK). **알림 dedupe 전용이며 체결/부기 원장이 아니다** — 이렇게 분리해야 1단계(감지)와 2단계(부기)가 섞이지 않는다. 기존 `toss_live_order_ledger`에 쓰면 그 자체가 부기가 되어 스코프 위반. migration `20260713_rob866_toss_manual_activity`(additive-only, down_revision = 현재 head `20260713_rob844_root_reservation`).

## 충돌 주의

order_proposals 모듈은 **read-only SELECT만**(rung `broker_order_id`) — ROB-861/862와 병렬 안전.

## 테스트 (15 신규, 모두 green)

- 원장/proposal에 있는 주문 → 미보고(오탐 0). 원장 밖 FILLED/PARTIAL_FILLED → 보고. CANCELLED → 미보고.
- 멱등: 같은 주문 2회 스윕 → 1회만 알림.
- dry_run 쓰기 0 / 실행 모드 텔레그램 + session_context mock 검증(kr market handoff).
- read-only 계약(브로커 mutation 0 — `list_orders`만).
- MCP 도구 config-missing 가드 + window 클램프, TaskIQ disabled-by-default.
- governance: route_request registry 분류(READ_ONLY_ADVISORY) + MCP profile 스냅샷 green.

`make lint`(ruff+ty) green, LLM-import static guard green.

## 운영 수동 플레이북

1. 발견만(쓰기 0): `toss_detect_manual_activity(window_hours=24, dry_run=True)` → `manual_filled`/`manual_open` 확인.
2. 알림+핸드오프: `toss_detect_manual_activity(window_hours=24, dry_run=False)` → 신규건 텔레그램 + session_context + 멱등 마커.
3. 부기: 알림은 "부기 필요" 신호 — 실제 저널/체결은 운영자/2단계. 원장 편입 후엔 이후 스윕 자동 오탐 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)