### PR TITLE
fix(ROB-820): restore KIS mock data truthfulness

### DIFF
--- a/app/mcp_server/README.md
+++ b/app/mcp_server/README.md
@@ -71,6 +71,12 @@ MCP tools (market data, portfolio, order execution) exposed via `fastmcp`.
   - Default thresholds: KR 25 bps, US 40 bps. US is stricter because FX basis and overseas tax lots split by account.
   - Always returns `cost_comparison` for both candidate accounts and `position_consolidation` with either `foregone_savings_krw` or `distribution_warning`.
 - `get_orderbook(symbol, market="kr")`
+- KR quote responses expose `price_as_of`, `price_freshness`
+  (`fresh|stale|unavailable`), `price_usable`, and a stable
+  `price_unavailable_reason` when unusable. Missing timestamps and epoch-zero
+  values are unavailable; prior-date timestamps are stale. NXT tradability
+  similarly returns `nxt_tradable=null` plus the observed value and reason when
+  its as-of is missing or stale.
 - US equity quote price resolution uses KIS overseas current price first when `settings.us_quote_kis_primary` is enabled, then falls back to Yahoo `fast_info`.
   - US quote response keeps `source: "kis_overseas"` or `source: "yahoo"` and includes `previous_close/open/high/low/volume` when the provider supplies them.
   - US quote response includes `session` (`premarket`, `regular`, `afterhours`, `closed`), `data_state` (`fresh` during the extended-hours envelope, `stale` when closed), `price_source` (`kis_overseas_last` or `yahoo_fast_info_close`), `delayed: true`, and optional `quote_asof` when KIS supplies parseable quote date/time fields.
@@ -79,6 +85,12 @@ MCP tools (market data, portfolio, order execution) exposed via `fastmcp`.
 - `get_holdings(account=None, market=None, include_current_price=True, minimum_value=None, account_mode=None)`
   - Crypto positions may include optional `strategy_signal` field when Phase 2 exit logic triggers (4.5% stop-loss or RSI > 46 mean-reversion on profitable positions)
 - `get_position(symbol, market=None, account_mode=None)`
+- `get_financials(symbol, statement="income", freq="annual", market=None)`
+  - Provider payloads with no numeric financial values return
+    `status="unavailable"`, `scoreable=false`, the stable reason
+    `financial_metrics_unavailable`, and source/statement/frequency/period-count
+    evidence. The tool preserves the empty provider payload and does not invent
+    metrics.
 - `get_ohlcv(symbol, count=100, period="day", end_date=None, market=None, include_indicators=False)`
   - period: `day`, `week`, `month`, `1m`, `5m`, `15m`, `30m`, `4h`, `1h`
   - `include_indicators=True` adds `indicators_included` at the payload top level and appends `rsi_14`, `ema_20`, `bb_upper`, `bb_mid`, `bb_lower`, `vwap` to each row
@@ -1520,6 +1532,9 @@ Parameters:
 - `account`: optional account filter (`upbit`, `kis`, `kis_domestic`, `kis_overseas`)
 
 Broker-specific contract:
+- With `account_mode="kis_mock"`, this tool is a KIS-only data plane. It never
+  reads Upbit or Toss live cash, rejects non-KIS account selectors, and marks
+  KIS rows/errors with `account_mode="kis_mock"`.
 - **Upbit (`account="upbit"`)**
   - `balance`: total KRW (`balance + locked`)
   - `orderable`: orderable KRW (`balance`)
@@ -1552,6 +1567,8 @@ Behavior:
 - Converts USD orderable amounts to KRW equivalents using current exchange rate
 - Includes manual cash (Toss/non-API cash) when `include_manual=True`
 - Marks manual cash as stale when older than 3 days
+- With `account_mode="kis_mock"`, manual cash is not read or aggregated; the
+  result is derived only from the KIS mock cash response.
 
 Response shape:
 - `accounts`: per-account cash entries with `krw_equivalent` added for USD accounts
@@ -1569,6 +1586,9 @@ Parameters:
 - `minimum_value`: optional numeric threshold. When `None` (default), per-currency thresholds apply: KRW=5000, USD=10. Explicit number uses uniform threshold. Positions below threshold are excluded only when `include_current_price=True`
 
 Filtering rules:
+- With `account_mode="kis_mock"`, holdings collection is KIS-only. Upbit,
+  Toss API, and manual collectors are not called, and non-KIS account or crypto
+  selectors fail closed instead of returning a mixed-provenance response.
 - If `include_current_price=False`, `minimum_value` filtering is skipped
 - When `minimum_value=None`, per-currency thresholds are automatically applied based on `instrument_type`: `equity_kr` and `crypto` use 5000, `equity_us` uses 10
 - When `minimum_value` is a number, that uniform threshold is applied to all positions

--- a/app/mcp_server/tooling/analysis_analyze.py
+++ b/app/mcp_server/tooling/analysis_analyze.py
@@ -34,11 +34,13 @@ from app.mcp_server.tooling.market_data_indicators import (
     _split_support_resistance_levels,
 )
 from app.mcp_server.tooling.market_data_quotes import (
+    _annotate_kr_price_freshness,
     _apply_nxt_quote_overlay,
     _fetch_kr_live_quote,
     _fetch_quote_crypto,
     _fetch_quote_equity_kr,
     _fetch_quote_equity_us,
+    _kr_price_as_of_from_frame,
 )
 from app.mcp_server.tooling.market_session import kr_market_data_state
 from app.mcp_server.tooling.shared import (
@@ -51,7 +53,6 @@ from app.mcp_server.tooling.shared import resolve_market_type as _resolve_market
 from app.monitoring import build_yfinance_tracing_session, close_yfinance_session
 from app.services.kr_symbol_universe_service import get_kr_nxt_tradability
 from app.services.symbol_analysis.floor import floored_action, insufficient_inputs
-from app.services.symbol_analysis.freshness import compute_is_stale
 
 logger = logging.getLogger(__name__)
 
@@ -122,27 +123,23 @@ async def _resolve_kr_quote(
         if await _apply_nxt_quote_overlay(
             symbol, quote, data_state=kr_market_data_state()
         ):
-            quote["is_stale_price"] = False
-            quote["price_as_of"] = now_kst().isoformat()
+            _annotate_kr_price_freshness(quote, now_kst(), trading_date=trading_date)
         return quote
 
     live = await _fetch_kr_live_quote(symbol)
     if live is not None:
-        as_of_raw = live.get("price_as_of")
-        as_of_dt = datetime.fromisoformat(as_of_raw) if as_of_raw else None
-        live["is_stale_price"] = compute_is_stale(
-            "price", as_of_dt, trading_date=trading_date
+        _annotate_kr_price_freshness(
+            live, live.get("price_as_of"), trading_date=trading_date
         )
         return await _annotate(live)
 
     fallback = _build_kr_quote_from_ohlcv(symbol, ohlcv_df)
     if fallback is None:
         return None
-    last_idx = ohlcv_df.index[-1]
-    as_of_dt = pd.Timestamp(last_idx).to_pydatetime()
-    fallback["price_as_of"] = as_of_dt.isoformat()
-    fallback["is_stale_price"] = compute_is_stale(
-        "price", as_of_dt, trading_date=trading_date
+    _annotate_kr_price_freshness(
+        fallback,
+        _kr_price_as_of_from_frame(ohlcv_df),
+        trading_date=trading_date,
     )
     return await _annotate(fallback)
 

--- a/app/mcp_server/tooling/fundamentals/_financials.py
+++ b/app/mcp_server/tooling/fundamentals/_financials.py
@@ -34,6 +34,60 @@ from app.mcp_server.tooling.shared import (
 from app.services.market_events.query_service import MarketEventsQueryService
 
 
+def _has_financial_values(payload: dict[str, Any]) -> bool:
+    """Return true only when a provider supplied at least one real metric value."""
+
+    def _has_value(value: Any) -> bool:
+        if isinstance(value, dict):
+            return any(_has_value(item) for item in value.values())
+        if isinstance(value, (list, tuple)):
+            return any(_has_value(item) for item in value)
+        return value is not None
+
+    metrics = payload.get("metrics")
+    if isinstance(metrics, dict) and _has_value(metrics):
+        return True
+
+    reports = payload.get("reports")
+    if isinstance(reports, (list, tuple)):
+        return any(
+            isinstance(report, dict) and _has_value(report.get("data"))
+            for report in reports
+        )
+
+    data = payload.get("data")
+    return isinstance(data, dict) and _has_value(data)
+
+
+def _financial_period_count(payload: dict[str, Any]) -> int:
+    for key in ("periods", "reports", "data"):
+        value = payload.get(key)
+        if isinstance(value, (dict, list, tuple)):
+            return len(value)
+    return 0
+
+
+def _annotate_financial_availability(payload: dict[str, Any]) -> dict[str, Any]:
+    result = dict(payload)
+    if _has_financial_values(result):
+        result["status"] = "available"
+        result["scoreable"] = True
+        result.pop("reason", None)
+        result.pop("evidence", None)
+        return result
+
+    result["status"] = "unavailable"
+    result["scoreable"] = False
+    result["reason"] = "financial_metrics_unavailable"
+    result["evidence"] = {
+        "source": result.get("source"),
+        "statement": result.get("statement"),
+        "freq": result.get("freq"),
+        "period_count": _financial_period_count(result),
+    }
+    return result
+
+
 async def handle_get_financials(
     symbol: str,
     statement: str = "income",
@@ -65,11 +119,13 @@ async def handle_get_financials(
 
     try:
         if normalized_market == "kr":
-            return await _fetch_financials_naver(symbol, statement, freq)
+            payload = await _fetch_financials_naver(symbol, statement, freq)
+            return _annotate_financial_availability(payload)
         try:
-            return await _fetch_financials_finnhub(symbol, statement, freq)
+            payload = await _fetch_financials_finnhub(symbol, statement, freq)
         except (ValueError, Exception):
-            return await _fetch_financials_yfinance(symbol, statement, freq)
+            payload = await _fetch_financials_yfinance(symbol, statement, freq)
+        return _annotate_financial_availability(payload)
     except Exception as exc:
         source = "naver" if normalized_market == "kr" else "yfinance"
         instrument_type = "equity_kr" if normalized_market == "kr" else "equity_us"

--- a/app/mcp_server/tooling/market_data_quotes.py
+++ b/app/mcp_server/tooling/market_data_quotes.py
@@ -78,6 +78,7 @@ from app.services.market_data.toss_ohlcv import (
     fetch_daily_toss_frame,
     fetch_kr_intraday_toss_frame,
 )
+from app.services.symbol_analysis.freshness import compute_is_stale
 from app.services.upbit_symbol_universe_service import search_upbit_symbols
 from app.services.us_intraday_candles_read_service import read_us_intraday_candles
 from app.services.us_symbol_universe_service import (
@@ -431,6 +432,7 @@ async def _apply_nxt_quote_overlay(
     quote.update(overlay)
     quote["regular_session_data_state"] = data_state
     quote["data_state"] = DATA_STATE_FRESH
+    _annotate_kr_price_freshness(quote, now_kst())
     return True
 
 
@@ -570,6 +572,65 @@ async def _search_master_data(
 # ---------------------------------------------------------------------------
 
 
+def _parse_price_as_of(value: Any) -> datetime.datetime | None:
+    """Parse a provider timestamp without turning integer indexes into epoch data."""
+    if value is None:
+        return None
+    try:
+        timestamp = pd.Timestamp(value)
+    except (TypeError, ValueError, OverflowError):
+        return None
+    if pd.isna(timestamp) or timestamp.value <= 0:
+        return None
+    return timestamp.to_pydatetime()
+
+
+def _kr_price_as_of_from_frame(df: pd.DataFrame) -> datetime.datetime | None:
+    """Read a real candle date; RangeIndex values are not timestamps."""
+    if df.empty:
+        return None
+    row_value = df.iloc[-1].get("date")
+    if row_value is not None and not pd.isna(row_value):
+        return _parse_price_as_of(row_value)
+    if isinstance(df.index, pd.DatetimeIndex):
+        return _parse_price_as_of(df.index[-1])
+    return None
+
+
+def _annotate_kr_price_freshness(
+    quote: dict[str, Any],
+    as_of: Any,
+    *,
+    trading_date: datetime.date | None = None,
+) -> None:
+    """Expose whether a KR quote is safe to consume as a current price."""
+    parsed = _parse_price_as_of(as_of)
+    quote["price_as_of"] = parsed.isoformat() if parsed is not None else None
+    if parsed is None:
+        quote.update(
+            {
+                "is_stale_price": True,
+                "price_freshness": "unavailable",
+                "price_usable": False,
+                "price_unavailable_reason": "missing_price_asof",
+            }
+        )
+        return
+
+    stale = compute_is_stale(
+        "price",
+        parsed,
+        trading_date=trading_date or now_kst().date(),
+    )
+    quote["is_stale_price"] = stale
+    quote["price_freshness"] = "stale" if stale else "fresh"
+    quote["price_usable"] = not stale
+    if stale:
+        quote["price_unavailable_reason"] = "stale_price_asof"
+    else:
+        quote.pop("price_unavailable_reason", None)
+
+
 async def _fetch_quote_crypto(symbol: str) -> dict[str, Any]:
     """Fetch crypto quote from Upbit."""
     prices = await upbit_service.fetch_multiple_current_prices([symbol])
@@ -603,7 +664,7 @@ async def _fetch_quote_equity_kr(symbol: str) -> dict[str, Any]:
         prev_close_raw = df.iloc[-2].to_dict().get("close")
         if prev_close_raw is not None and not pd.isna(prev_close_raw):
             previous_close = float(prev_close_raw)
-    return {
+    quote = {
         "symbol": symbol,
         "instrument_type": "equity_kr",
         "price": last.get("close"),
@@ -615,6 +676,8 @@ async def _fetch_quote_equity_kr(symbol: str) -> dict[str, Any]:
         "value": last.get("value"),
         "source": "kis",
     }
+    _annotate_kr_price_freshness(quote, _kr_price_as_of_from_frame(df))
+    return quote
 
 
 async def _fetch_kr_live_quote(symbol: str) -> dict[str, Any] | None:

--- a/app/mcp_server/tooling/portfolio_cash.py
+++ b/app/mcp_server/tooling/portfolio_cash.py
@@ -30,6 +30,15 @@ from app.services.brokers.kis import (
 from app.services.exchange_rate_service import get_usd_krw_rate as _get_usd_krw_rate
 from app.services.toss_portfolio_service import fetch_toss_cash_snapshot
 
+_KIS_MOCK_CASH_ACCOUNTS = frozenset({"kis", "kis_domestic", "kis_overseas"})
+
+
+def _validate_kis_mock_cash_account(account_filter: str | None) -> None:
+    if account_filter is not None and account_filter not in _KIS_MOCK_CASH_ACCOUNTS:
+        raise ValueError(
+            f"account={account_filter!r} is incompatible with account_mode='kis_mock'"
+        )
+
 
 async def get_account_costs_setting() -> dict[str, Any] | None:
     value = await get_user_setting("account_costs")
@@ -107,6 +116,10 @@ async def get_cash_balance_impl(
         parse_paper_account_token,
     )
 
+    account_filter = _normalize_account_filter(account)
+    if is_mock:
+        _validate_kis_mock_cash_account(account_filter)
+
     if is_paper_account_token(account):
         selector = parse_paper_account_token(account)
         rows, errors = await collect_paper_cash_balances(selector=selector)
@@ -132,10 +145,9 @@ async def get_cash_balance_impl(
     total_krw = 0.0
     total_usd = 0.0
 
-    account_filter = _normalize_account_filter(account)
     strict_mode = account_filter is not None
 
-    if account_filter is None or account_filter == "toss":
+    if not is_mock and (account_filter is None or account_filter == "toss"):
         if bool(getattr(settings, "toss_api_enabled", False)):
             try:
                 # ROB-549: surface buying power as orderable only once Toss live
@@ -181,7 +193,7 @@ async def get_cash_balance_impl(
                 errors.append({"source": "toss_api", "market": "cash", "error": reason})
                 unavailable_sources["toss"] = reason
 
-    if account_filter is None or account_filter in ("upbit",):
+    if not is_mock and (account_filter is None or account_filter == "upbit"):
         try:
             summary = await upbit_service.fetch_krw_cash_summary()
             krw_balance = float(summary.get("balance", 0.0))
@@ -249,6 +261,7 @@ async def get_cash_balance_impl(
                         "balance": dncl_amt,
                         "orderable": orderable,
                         "formatted": f"{int(dncl_amt):,} KRW",
+                        **({"account_mode": "kis_mock"} if is_mock else {}),
                     }
                 )
                 total_krw += dncl_amt
@@ -258,13 +271,27 @@ async def get_cash_balance_impl(
                         f"KIS domestic cash balance query failed: {exc}"
                     ) from exc
                 reason = describe_exception(exc)
-                errors.append({"source": "kis", "market": "kr", "error": reason})
+                errors.append(
+                    {
+                        "source": "kis",
+                        "market": "kr",
+                        "error": reason,
+                        **({"account_mode": "kis_mock"} if is_mock else {}),
+                    }
+                )
                 unavailable_sources["kis_domestic"] = reason
 
         if account_filter is None or account_filter in ("kis", "kis_overseas"):
             if is_mock:
                 reason = "mock_unsupported: KIS overseas margin is not available in mock mode"
-                errors.append({"source": "kis", "market": "us", "error": reason})
+                errors.append(
+                    {
+                        "source": "kis",
+                        "market": "us",
+                        "error": reason,
+                        "account_mode": "kis_mock",
+                    }
+                )
                 unavailable_sources["kis_overseas"] = reason
             else:
                 try:
@@ -397,7 +424,7 @@ async def get_available_capital_impl(
     )
 
     manual_cash_result: dict[str, Any] | None = None
-    if include_manual and not is_paper_account_token(account):
+    if include_manual and not is_mock and not is_paper_account_token(account):
         try:
             manual_setting = await get_manual_cash_setting()
             if manual_setting is not None:

--- a/app/mcp_server/tooling/portfolio_holdings.py
+++ b/app/mcp_server/tooling/portfolio_holdings.py
@@ -869,6 +869,18 @@ async def _collect_portfolio_positions(
     )
 
     market_filter = _parse_holdings_market_filter(market)
+    account_filter = _normalize_account_filter(account)
+    if is_mock:
+        if account_filter not in (None, "kis"):
+            raise ValueError(
+                f"account={account_filter!r} is incompatible with "
+                "account_mode='kis_mock'"
+            )
+        if market_filter == "crypto":
+            raise ValueError(
+                "market='crypto' is incompatible with account_mode='kis_mock'"
+            )
+
     if is_paper_account_token(account):
         selector = parse_paper_account_token(account)
         positions, errors = await collect_paper_positions(
@@ -908,19 +920,18 @@ async def _collect_portfolio_positions(
         positions.sort(key=lambda p: (p["account"], p["market"], p["symbol"]))
         return positions, errors, market_filter, account
 
-    account_filter = _normalize_account_filter(account)
-
     tasks: list[Any] = []
     if market_filter != "crypto":
         if is_mock:
             tasks.append(_collect_kis_positions(market_filter, is_mock=True))
         else:
             tasks.append(_collect_kis_positions(market_filter))
-    if market_filter in (None, "crypto"):
-        tasks.append(_collect_upbit_positions(market_filter))
-    tasks.append(
-        _collect_manual_positions(user_id=user_id, market_filter=market_filter)
-    )
+    if not is_mock:
+        if market_filter in (None, "crypto"):
+            tasks.append(_collect_upbit_positions(market_filter))
+        tasks.append(
+            _collect_manual_positions(user_id=user_id, market_filter=market_filter)
+        )
 
     results = await asyncio.gather(*tasks, return_exceptions=True)
     positions: list[dict[str, Any]] = []
@@ -942,7 +953,7 @@ async def _collect_portfolio_positions(
     toss_api_positions: list[dict[str, Any]] = []
     toss_api_errors: list[dict[str, Any]] = []
     toss_api_succeeded = False
-    if bool(getattr(settings, "toss_api_enabled", False)):
+    if not is_mock and bool(getattr(settings, "toss_api_enabled", False)):
         (
             toss_api_positions,
             toss_api_errors,

--- a/app/services/nxt_preflight.py
+++ b/app/services/nxt_preflight.py
@@ -40,14 +40,21 @@ class NxtTradability:
         return (current - asof) > NXT_FLAG_STALE_AFTER
 
     def public_fields(self, *, now: dt.datetime | None = None) -> dict[str, Any]:
-        return {
-            "nxt_tradable": self.nxt_tradable,
+        stale = self.is_stale(now=now)
+        fields: dict[str, Any] = {
+            "nxt_tradable": None if stale else self.nxt_tradable,
             "nxt_tradable_source": self.source,
             "nxt_tradable_asof": self.asof.isoformat()
             if self.asof is not None
             else None,
-            "nxt_tradable_stale": self.is_stale(now=now),
+            "nxt_tradable_stale": stale,
         }
+        if stale:
+            fields["nxt_tradable_observed"] = self.nxt_tradable
+            fields["nxt_tradable_reason"] = (
+                "missing_asof" if self.asof is None else "stale_asof"
+            )
+        return fields
 
 
 @dataclass(frozen=True)

--- a/docs/superpowers/plans/2026-07-13-rob-820-mock-data-truthfulness.md
+++ b/docs/superpowers/plans/2026-07-13-rob-820-mock-data-truthfulness.md
@@ -1,0 +1,163 @@
+# ROB-820 Mock Data Truthfulness Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make KIS mock portfolio, quote, fundamentals, and failure envelopes truthful without adding a broker adapter or alternate account truth source.
+
+**Architecture:** Enforce KIS-only mock scope inside the existing portfolio implementation functions so holdings, cash, allocation, and position readers inherit one boundary. Add pure freshness/availability annotators at existing quote and financial handler seams, leaving provider clients and mutation paths unchanged.
+
+**Tech Stack:** Python 3.13, FastMCP handlers, pandas, pytest/pytest-asyncio, Ruff, ty, uv.
+
+## Global Constraints
+
+- Do not create a ROB-851 adapter or a separate holdings/cash truth source.
+- Do not absorb ROB-843/ROB-853 mutation boundaries or ROB-819 work.
+- Do not use real account data, credentials, live API calls, or live mutation.
+- Every unresolved gap must follow RED -> GREEN with the exact targeted command recorded.
+
+---
+
+### Task 1: Lock the KIS mock account/provenance boundary
+
+**Files:**
+- Modify: `app/mcp_server/tooling/portfolio_cash.py`
+- Modify: `app/mcp_server/tooling/portfolio_holdings.py`
+- Modify: `app/mcp_server/README.md`
+- Test: `tests/test_rob820_mock_data_truthfulness.py`
+
+**Interfaces:**
+- Consumes: existing `is_mock: bool`, normalized account filters, and routing metadata.
+- Produces: KIS-only rows for mock reads; stable `ValueError` for incompatible account/market selectors; nested mock cash provenance.
+
+- [ ] **Step 1: Write failing holdings and cash isolation tests**
+
+  Use provider fakes that raise if Upbit, Toss, or manual collectors are called;
+  call the real portfolio implementations with `is_mock=True`; assert only KIS
+  rows remain and incompatible selectors fail closed.
+
+- [ ] **Step 2: Run tests to verify RED**
+
+  Run: `uv run pytest tests/test_rob820_mock_data_truthfulness.py -k 'mock and (holdings or cash or selector)' -q`
+
+  Expected: failures show current Upbit/manual/Toss calls and accepted incompatible selectors.
+
+- [ ] **Step 3: Implement the minimal boundary**
+
+  Add a small selector validator in the portfolio layer. Skip all non-KIS
+  collection and manual cash reads when `is_mock=True`; annotate KIS mock cash
+  rows/errors with `account_mode="kis_mock"`.
+
+- [ ] **Step 4: Run tests to verify GREEN**
+
+  Run the Step 2 command and expect all selected tests to pass.
+
+- [ ] **Step 5: Commit**
+
+  `git add app/mcp_server/tooling/portfolio_cash.py app/mcp_server/tooling/portfolio_holdings.py app/mcp_server/README.md tests/test_rob820_mock_data_truthfulness.py && git commit -m "fix(ROB-820): isolate KIS mock account reads"`
+
+### Task 2: Make quote and NXT freshness non-scoreable when timestamps are invalid
+
+**Files:**
+- Modify: `app/mcp_server/tooling/market_data_quotes.py`
+- Modify: `app/mcp_server/tooling/analysis_analyze.py`
+- Modify: `app/services/nxt_preflight.py`
+- Test: `tests/test_rob820_mock_data_truthfulness.py`
+- Test: `tests/test_mcp_quotes_tools.py`
+- Test: `tests/test_mcp_fundamentals_tools.py`
+
+**Interfaces:**
+- Produces: `price_as_of: str | None`, `price_freshness`, `price_usable`, optional `price_unavailable_reason`; stale NXT public values become unavailable while preserving observed evidence.
+
+- [ ] **Step 1: Write failing epoch/missing/stale tests**
+
+  Cover RangeIndex OHLCV, explicit epoch zero, missing live as-of, old daily
+  as-of, missing NXT as-of, stale NXT as-of, and a fresh NXT control.
+
+- [ ] **Step 2: Run tests to verify RED**
+
+  Run: `uv run pytest tests/test_rob820_mock_data_truthfulness.py -k 'price or nxt' -q`
+
+  Expected: epoch is currently rendered as 1970 and stale NXT remains a usable boolean.
+
+- [ ] **Step 3: Implement pure timestamp parsing and annotations**
+
+  Parse the row `date` first and a datetime index only as fallback; reject
+  missing/NaT/epoch values. Annotate quote usability without deleting observed
+  prices. Change only stale/missing `NxtTradability.public_fields()` output;
+  leave `evaluate_nxt_preflight` unchanged.
+
+- [ ] **Step 4: Run tests to verify GREEN and update the obsolete 1970 assertion**
+
+  Run the Step 2 command plus the targeted existing analyze/quote tests.
+
+- [ ] **Step 5: Commit**
+
+  `git add app/mcp_server/tooling/market_data_quotes.py app/mcp_server/tooling/analysis_analyze.py app/services/nxt_preflight.py tests/test_rob820_mock_data_truthfulness.py tests/test_mcp_quotes_tools.py tests/test_mcp_fundamentals_tools.py && git commit -m "fix(ROB-820): fail closed stale quote evidence"`
+
+### Task 3: Expose empty fundamentals as unavailable
+
+**Files:**
+- Modify: `app/mcp_server/tooling/fundamentals/_financials.py`
+- Modify: `app/mcp_server/README.md`
+- Test: `tests/test_rob820_mock_data_truthfulness.py`
+
+**Interfaces:**
+- Consumes: provider payloads containing `metrics`, `reports`, or `data`.
+- Produces: additive `status`, `scoreable`, `reason`, and `evidence` fields without fabricating numeric values.
+
+- [ ] **Step 1: Write failing empty/non-empty provider-shape tests**
+
+  Assert empty KR metrics are unavailable/non-scoreable and real KR/US payloads
+  are available/scoreable.
+
+- [ ] **Step 2: Run tests to verify RED**
+
+  Run: `uv run pytest tests/test_rob820_mock_data_truthfulness.py -k financials -q`
+
+  Expected: current payload has no availability contract.
+
+- [ ] **Step 3: Add the minimal availability normalizer**
+
+  Implement one pure helper in `_financials.py` and apply it after each successful
+  provider fetch. Keep existing error payload behavior unchanged.
+
+- [ ] **Step 4: Run tests to verify GREEN**
+
+  Run the Step 2 command and expect all selected tests to pass.
+
+- [ ] **Step 5: Commit**
+
+  `git add app/mcp_server/tooling/fundamentals/_financials.py app/mcp_server/README.md tests/test_rob820_mock_data_truthfulness.py && git commit -m "fix(ROB-820): mark empty fundamentals unavailable"`
+
+### Task 4: Prove existing timeout/circuit behavior and run regressions
+
+**Files:**
+- Modify: `tests/test_rob820_mock_data_truthfulness.py`
+
+**Interfaces:**
+- Verifies: ROB-600 `ReadTimeout` reason plus `unavailable_sources`; current `KISCircuitOpen` reason plus source/market evidence.
+
+- [ ] **Step 1: Add regression tests for already-fixed behavior**
+
+  Use `httpx.ReadTimeout("")` and real `KISCircuitOpen(45.0)` exceptions at the
+  existing MCP catch boundaries.
+
+- [ ] **Step 2: Run and record that these tests are GREEN on unchanged main behavior**
+
+  Run: `uv run pytest tests/test_rob820_mock_data_truthfulness.py -k 'timeout or circuit' -q`
+
+- [ ] **Step 3: Run broad regressions and quality gates**
+
+  Run relevant portfolio/allocation/quotes/fundamentals/KIS read test files,
+  then `ruff check`, `ruff format --check`, `ty check`, and `git diff --check`.
+
+- [ ] **Step 4: Self-review the full diff against all five gaps**
+
+  Inspect `git diff origin/main...HEAD`, verify no adapter/mutation/ROB-819 code,
+  and rerun any test affected by review corrections.
+
+- [ ] **Step 5: Push and open a PR without merging**
+
+  Push `rob-820`, create a GitHub PR against `main`, and keep the worktree for
+  review iteration.
+

--- a/docs/superpowers/specs/2026-07-13-rob-820-mock-data-truthfulness-design.md
+++ b/docs/superpowers/specs/2026-07-13-rob-820-mock-data-truthfulness-design.md
@@ -1,0 +1,72 @@
+# ROB-820 Mock Data Truthfulness Design
+
+## Goal
+
+Restore the existing KIS MCP read plane so `account_mode="kis_mock"` cannot
+consume live/manual account truth, provider failures always carry a stable
+reason and evidence, stale or missing quote timestamps are never presented as
+fresh, and empty fundamentals are explicitly unavailable.
+
+## Scope boundaries
+
+- Keep the existing KIS client and MCP portfolio/quote/fundamentals handlers as
+  the only truth sources. Do not create a ROB-851 adapter or a second
+  holdings/cash source.
+- Do not change order mutation behavior owned by ROB-843/ROB-853.
+- Do not implement ROB-819 or ROB-826 terminal-history/US-cancel work.
+- Tests use deterministic fakes only; no credentials, real account data, or
+  live provider mutation.
+
+## Design
+
+### Mock account isolation
+
+The MCP portfolio server boundary will treat `is_mock=True` as a KIS-only
+scope. Holdings will collect only KIS positions, and cash will collect only KIS
+domestic cash plus the explicit KIS mock overseas unsupported diagnostic.
+Upbit, Toss API, manual holdings, and manual cash will not be queried. An
+explicit incompatible account (`upbit`, `toss`, `samsung_pension`, or `isa`) or
+`market="crypto"` combined with `kis_mock` will raise a stable `ValueError`
+instead of returning an apparently valid empty/mixed response. Nested KIS cash
+rows and errors will carry `account_mode="kis_mock"`; holdings already stamp
+that provenance through the routing metadata path.
+
+### Error truthfulness
+
+ROB-600 already routes KIS mock cash exceptions through
+`describe_exception`, records `ReadTimeout`, omits a fabricated zero row, and
+adds `summary.unavailable_sources`. The implementation remains unchanged and
+gets regression coverage. The current `KISCircuitOpen` exception already has a
+stable message; MCP holdings coverage will prove that the message plus
+source/market evidence survives the catch boundary. No retry or mutation
+behavior changes are in scope.
+
+### Quote and tradability freshness
+
+KR daily/live quote timestamps will be parsed only from a real date value or a
+datetime index. Missing/invalid timestamps and Unix epoch zero normalize to
+`None`, not 1970. Quote envelopes will add `price_freshness` (`fresh`, `stale`,
+or `unavailable`), `price_usable`, and a stable reason when unusable while
+retaining the observed price as diagnostic reference data. NXT overlays set a
+fresh current timestamp. Stale or missing NXT master timestamps will expose
+`nxt_tradable=None`, preserve the raw observation as
+`nxt_tradable_observed`, and provide `nxt_tradable_reason`; order preflight
+internals remain untouched.
+
+### Fundamentals availability
+
+`get_financials` will normalize all provider shapes (`metrics`, `reports`, or
+`data`). A payload containing no non-empty metric/report data will add
+`status="unavailable"`, `scoreable=false`,
+`reason="financial_metrics_unavailable"`, and compact evidence describing the
+provider, statement, frequency, and period count. Non-empty payloads receive
+`status="available"` and `scoreable=true`; no synthetic values are produced.
+
+## Verification
+
+Issue-focused tests cover the account/provenance matrix, KR mock timeout,
+circuit-open propagation, epoch/missing/stale quote timestamps, stale NXT
+metadata, and empty/non-empty fundamentals. Then run portfolio, allocation,
+quote, fundamentals, KIS circuit/read, and MCP broad regressions, followed by
+Ruff lint/format, ty, and `git diff --check`.
+

--- a/tests/test_kr_nxt_tradability_accessor.py
+++ b/tests/test_kr_nxt_tradability_accessor.py
@@ -57,7 +57,7 @@ async def test_search_rows_carry_nxt_fields(db_session):
             is_active=True,
             nxt_eligible=True,
             nxt_trading_suspended=False,
-            toss_master_updated_at=dt.datetime(2026, 7, 3, 6, 0, tzinfo=_KST),
+            toss_master_updated_at=dt.datetime.now(_KST),
         )
     )
     await db_session.flush()

--- a/tests/test_mcp_fundamentals_tools.py
+++ b/tests/test_mcp_fundamentals_tools.py
@@ -4598,8 +4598,11 @@ async def test_analyze_stock_kr_reuses_preloaded_ohlcv_and_bundled_naver(monkeyp
         "volume": 1000000,
         "value": 75000000000.0,
         "source": "kis",
-        "price_as_of": "1970-01-01T00:00:00",
+        "price_as_of": "2024-01-01T00:00:00",
         "is_stale_price": True,
+        "price_freshness": "stale",
+        "price_usable": False,
+        "price_unavailable_reason": "stale_price_asof",
     }
     assert result["valuation"]["instrument_type"] == "equity_kr"
     assert result["news"]["source"] == "naver"

--- a/tests/test_mcp_quotes_tools.py
+++ b/tests/test_mcp_quotes_tools.py
@@ -1306,7 +1306,10 @@ async def test_get_quote_kr_exposes_nxt_tradable(monkeypatch):
     monkeypatch.setattr(market_data_quotes, "get_kr_nxt_tradability", fake_tradability)
 
     result = await tools["get_quote"]("005930")
-    assert result["nxt_tradable"] is True
+    assert result["nxt_tradable"] is None
+    assert result["nxt_tradable_observed"] is True
+    assert result["nxt_tradable_stale"] is True
+    assert result["nxt_tradable_reason"] == "stale_asof"
     assert result["nxt_tradable_source"] == "kr_symbol_universe"
     assert result["nxt_tradable_asof"] is not None
 

--- a/tests/test_nxt_preflight_order_tools.py
+++ b/tests/test_nxt_preflight_order_tools.py
@@ -127,7 +127,9 @@ async def test_suggest_order_account_kr_carries_nxt_advisory(monkeypatch):
     result = await art.suggest_order_account_impl(
         symbol="005930", market="kr", side="buy", quantity=1
     )
-    assert result["nxt_tradable"] is False
+    assert result["nxt_tradable"] is None
+    assert result["nxt_tradable_observed"] is False
+    assert result["nxt_tradable_reason"] == "missing_asof"
     assert result["nxt_tradable_source"] == "kr_symbol_universe"
     assert result["nxt_preflight"]["block"] is True
     assert result["nxt_preflight"]["session"] == "nxt_premarket"

--- a/tests/test_rob820_mock_data_truthfulness.py
+++ b/tests/test_rob820_mock_data_truthfulness.py
@@ -1,0 +1,429 @@
+"""ROB-820 regression coverage for the KIS mock read data plane."""
+
+from __future__ import annotations
+
+import datetime as dt
+from unittest.mock import AsyncMock, MagicMock
+
+import pandas as pd
+import pytest
+
+from app.mcp_server.tooling import analysis_analyze, portfolio_cash, portfolio_holdings
+from app.mcp_server.tooling.fundamentals import _financials
+from app.services.brokers.kis.circuit_breaker import KISCircuitOpen
+from app.services.nxt_preflight import NxtTradability
+
+
+def _kis_position() -> dict[str, object]:
+    return {
+        "account": "kis",
+        "account_name": "기본 계좌",
+        "broker": "kis",
+        "source": "kis_api",
+        "instrument_type": "equity_kr",
+        "market": "kr",
+        "symbol": "005930",
+        "name": "삼성전자",
+        "quantity": 2.0,
+        "avg_buy_price": 70_000.0,
+        "current_price": 71_000.0,
+        "evaluation_amount": 142_000.0,
+        "profit_loss": 2_000.0,
+        "profit_rate": 1.43,
+    }
+
+
+@pytest.mark.asyncio
+async def test_kis_mock_cash_does_not_query_live_account_sources(monkeypatch):
+    fake_kis = MagicMock()
+    fake_kis.inquire_domestic_cash_balance = AsyncMock(
+        return_value={
+            "dnca_tot_amt": "1000000",
+            "stck_cash_ord_psbl_amt": "900000",
+        }
+    )
+    monkeypatch.setattr(
+        portfolio_cash, "_create_kis_client", lambda *, is_mock: fake_kis
+    )
+
+    upbit_read = AsyncMock(side_effect=AssertionError("upbit_live must be isolated"))
+    toss_read = AsyncMock(side_effect=AssertionError("toss_api must be isolated"))
+    monkeypatch.setattr(
+        portfolio_cash.upbit_service, "fetch_krw_cash_summary", upbit_read
+    )
+    monkeypatch.setattr(portfolio_cash, "fetch_toss_cash_snapshot", toss_read)
+    monkeypatch.setattr(portfolio_cash.settings, "toss_api_enabled", True)
+
+    result = await portfolio_cash.get_cash_balance_impl(is_mock=True)
+
+    upbit_read.assert_not_awaited()
+    toss_read.assert_not_awaited()
+    assert {row["account"] for row in result["accounts"]} == {"kis_domestic"}
+    assert all(row["broker"] == "kis" for row in result["accounts"])
+    assert all(row["account_mode"] == "kis_mock" for row in result["accounts"])
+    assert all(error["source"] == "kis" for error in result["errors"])
+    assert all(error["account_mode"] == "kis_mock" for error in result["errors"])
+
+
+@pytest.mark.asyncio
+async def test_kis_mock_available_capital_does_not_query_manual_cash(monkeypatch):
+    monkeypatch.setattr(
+        portfolio_cash,
+        "get_cash_balance_impl",
+        AsyncMock(
+            return_value={
+                "accounts": [
+                    {
+                        "account": "kis_domestic",
+                        "broker": "kis",
+                        "currency": "KRW",
+                        "balance": 1_000_000.0,
+                        "orderable": 900_000.0,
+                        "account_mode": "kis_mock",
+                    }
+                ],
+                "summary": {"unavailable_sources": {}},
+                "errors": [],
+            }
+        ),
+    )
+    manual_read = AsyncMock(
+        side_effect=AssertionError("manual cash must be isolated from kis_mock")
+    )
+    monkeypatch.setattr(portfolio_cash, "get_manual_cash_setting", manual_read)
+    monkeypatch.setattr(
+        portfolio_cash, "get_account_costs_setting", AsyncMock(return_value=None)
+    )
+
+    result = await portfolio_cash.get_available_capital_impl(is_mock=True)
+
+    manual_read.assert_not_awaited()
+    assert result["manual_cash"] is None
+    assert result["summary"]["total_orderable_krw"] == pytest.approx(900_000.0)
+
+
+@pytest.mark.asyncio
+async def test_kis_mock_holdings_do_not_query_live_or_manual_sources(monkeypatch):
+    kis_read = AsyncMock(return_value=([_kis_position()], []))
+    upbit_read = AsyncMock(return_value=([], []))
+    manual_read = AsyncMock(return_value=([], []))
+    toss_read = AsyncMock(return_value=([], [], True))
+    monkeypatch.setattr(portfolio_holdings, "_collect_kis_positions", kis_read)
+    monkeypatch.setattr(portfolio_holdings, "_collect_upbit_positions", upbit_read)
+    monkeypatch.setattr(portfolio_holdings, "_collect_manual_positions", manual_read)
+    monkeypatch.setattr(portfolio_holdings, "_collect_toss_api_positions", toss_read)
+    monkeypatch.setattr(portfolio_holdings.settings, "toss_api_enabled", True)
+
+    positions, errors, _, _ = await portfolio_holdings._collect_portfolio_positions(
+        account=None,
+        market=None,
+        include_current_price=False,
+        is_mock=True,
+    )
+
+    kis_read.assert_awaited_once_with(None, is_mock=True)
+    upbit_read.assert_not_awaited()
+    manual_read.assert_not_awaited()
+    toss_read.assert_not_awaited()
+    assert len(positions) == 1
+    assert positions[0]["source"] == "kis_api"
+    assert positions[0]["current_price"] is None
+    assert errors == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("account", "market"),
+    [
+        ("upbit", None),
+        ("toss", None),
+        ("samsung_pension", None),
+        ("isa", None),
+        ("paper", None),
+        (None, "crypto"),
+    ],
+)
+async def test_kis_mock_incompatible_portfolio_selector_fails_closed(
+    monkeypatch, account, market
+):
+    monkeypatch.setattr(
+        portfolio_holdings, "_collect_kis_positions", AsyncMock(return_value=([], []))
+    )
+    monkeypatch.setattr(
+        portfolio_holdings, "_collect_upbit_positions", AsyncMock(return_value=([], []))
+    )
+    monkeypatch.setattr(
+        portfolio_holdings,
+        "_collect_manual_positions",
+        AsyncMock(return_value=([], [])),
+    )
+
+    with pytest.raises(ValueError, match="kis_mock"):
+        await portfolio_holdings._collect_portfolio_positions(
+            account=account,
+            market=market,
+            include_current_price=False,
+            is_mock=True,
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "account", ["upbit", "toss", "samsung_pension", "isa", "paper"]
+)
+async def test_kis_mock_incompatible_cash_selector_fails_closed(account):
+    with pytest.raises(ValueError, match="kis_mock"):
+        await portfolio_cash.get_cash_balance_impl(account=account, is_mock=True)
+
+
+@pytest.mark.asyncio
+async def test_kis_mock_holdings_circuit_open_keeps_reason_and_evidence(monkeypatch):
+    class CircuitOpenKIS:
+        def __init__(self, *, is_mock: bool = False) -> None:
+            assert is_mock is True
+
+        async def fetch_my_stocks(self, *, is_mock: bool = False):
+            assert is_mock is True
+            raise KISCircuitOpen(45.0)
+
+    monkeypatch.setattr(portfolio_holdings, "KISClient", CircuitOpenKIS)
+
+    positions, errors = await portfolio_holdings._collect_kis_positions(
+        "equity_kr", is_mock=True
+    )
+
+    assert positions == []
+    assert errors == [
+        {
+            "source": "kis",
+            "market": "kr",
+            "error": "KIS circuit open — failing fast (retry in ~45.0s)",
+        }
+    ]
+
+
+def _ohlcv_frame(*, date_value: object = None, include_date: bool = False):
+    row: dict[str, object] = {
+        "open": 70_000.0,
+        "high": 72_000.0,
+        "low": 69_000.0,
+        "close": 71_000.0,
+        "volume": 1_000,
+        "value": 71_000_000.0,
+    }
+    if include_date:
+        row["date"] = date_value
+    return pd.DataFrame([row])
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "frame",
+    [
+        _ohlcv_frame(),
+        _ohlcv_frame(date_value=pd.Timestamp(0), include_date=True),
+    ],
+)
+async def test_kr_quote_missing_or_epoch_asof_is_unavailable(monkeypatch, frame):
+    monkeypatch.setattr(
+        analysis_analyze, "_fetch_kr_live_quote", AsyncMock(return_value=None)
+    )
+    monkeypatch.setattr(
+        analysis_analyze, "get_kr_nxt_tradability", AsyncMock(return_value={})
+    )
+    monkeypatch.setattr(
+        analysis_analyze, "_apply_nxt_quote_overlay", AsyncMock(return_value=False)
+    )
+
+    quote = await analysis_analyze._resolve_kr_quote("005930", frame)
+
+    assert quote is not None
+    assert quote["price_as_of"] is None
+    assert quote["is_stale_price"] is True
+    assert quote["price_freshness"] == "unavailable"
+    assert quote["price_usable"] is False
+    assert quote["price_unavailable_reason"] == "missing_price_asof"
+
+
+@pytest.mark.asyncio
+async def test_kr_quote_old_asof_is_stale_and_not_usable(monkeypatch):
+    frame = _ohlcv_frame(date_value="2024-01-02", include_date=True)
+    monkeypatch.setattr(
+        analysis_analyze, "_fetch_kr_live_quote", AsyncMock(return_value=None)
+    )
+    monkeypatch.setattr(
+        analysis_analyze, "get_kr_nxt_tradability", AsyncMock(return_value={})
+    )
+    monkeypatch.setattr(
+        analysis_analyze, "_apply_nxt_quote_overlay", AsyncMock(return_value=False)
+    )
+
+    quote = await analysis_analyze._resolve_kr_quote("005930", frame)
+
+    assert quote is not None
+    assert quote["price_as_of"].startswith("2024-01-02")
+    assert quote["is_stale_price"] is True
+    assert quote["price_freshness"] == "stale"
+    assert quote["price_usable"] is False
+    assert quote["price_unavailable_reason"] == "stale_price_asof"
+
+
+@pytest.mark.asyncio
+async def test_kr_live_quote_missing_asof_is_unavailable(monkeypatch):
+    monkeypatch.setattr(
+        analysis_analyze,
+        "_fetch_kr_live_quote",
+        AsyncMock(
+            return_value={
+                "symbol": "005930",
+                "instrument_type": "equity_kr",
+                "price": 71_000.0,
+                "price_as_of": None,
+                "source": "kis",
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        analysis_analyze, "get_kr_nxt_tradability", AsyncMock(return_value={})
+    )
+    monkeypatch.setattr(
+        analysis_analyze, "_apply_nxt_quote_overlay", AsyncMock(return_value=False)
+    )
+
+    quote = await analysis_analyze._resolve_kr_quote("005930", pd.DataFrame())
+
+    assert quote is not None
+    assert quote["price_freshness"] == "unavailable"
+    assert quote["price_usable"] is False
+    assert quote["price_unavailable_reason"] == "missing_price_asof"
+
+
+@pytest.mark.parametrize(
+    ("asof", "reason"),
+    [
+        (None, "missing_asof"),
+        (dt.datetime(2026, 6, 1, tzinfo=dt.UTC), "stale_asof"),
+    ],
+)
+def test_nxt_tradability_missing_or_stale_asof_is_unavailable(asof, reason):
+    fields = NxtTradability(
+        nxt_eligible=True,
+        nxt_trading_suspended=False,
+        asof=asof,
+    ).public_fields(now=dt.datetime(2026, 7, 13, tzinfo=dt.UTC))
+
+    assert fields["nxt_tradable"] is None
+    assert fields["nxt_tradable_observed"] is True
+    assert fields["nxt_tradable_stale"] is True
+    assert fields["nxt_tradable_reason"] == reason
+
+
+def test_nxt_tradability_fresh_asof_remains_available():
+    asof = dt.datetime(2026, 7, 13, tzinfo=dt.UTC)
+    fields = NxtTradability(
+        nxt_eligible=True,
+        nxt_trading_suspended=False,
+        asof=asof,
+    ).public_fields(now=asof + dt.timedelta(hours=1))
+
+    assert fields["nxt_tradable"] is True
+    assert fields["nxt_tradable_stale"] is False
+    assert "nxt_tradable_observed" not in fields
+    assert "nxt_tradable_reason" not in fields
+
+
+@pytest.mark.asyncio
+async def test_empty_kr_financials_are_explicitly_unavailable(monkeypatch):
+    monkeypatch.setattr(
+        _financials,
+        "_fetch_financials_naver",
+        AsyncMock(
+            return_value={
+                "symbol": "005930",
+                "instrument_type": "equity_kr",
+                "source": "naver",
+                "statement": "income",
+                "freq": "annual",
+                "currency": "KRW",
+                "periods": ["최근 연간 실적"],
+                "metrics": {},
+            }
+        ),
+    )
+
+    result = await _financials.handle_get_financials("005930", market="kr")
+
+    assert result["metrics"] == {}
+    assert result["status"] == "unavailable"
+    assert result["scoreable"] is False
+    assert result["reason"] == "financial_metrics_unavailable"
+    assert result["evidence"] == {
+        "source": "naver",
+        "statement": "income",
+        "freq": "annual",
+        "period_count": 1,
+    }
+
+
+@pytest.mark.asyncio
+async def test_nonempty_kr_financials_are_available_without_synthetic_values(
+    monkeypatch,
+):
+    metrics = {"매출액": [100_000_000]}
+    monkeypatch.setattr(
+        _financials,
+        "_fetch_financials_naver",
+        AsyncMock(
+            return_value={
+                "symbol": "005930",
+                "instrument_type": "equity_kr",
+                "source": "naver",
+                "statement": "income",
+                "freq": "annual",
+                "currency": "KRW",
+                "periods": ["2025/12"],
+                "metrics": metrics,
+            }
+        ),
+    )
+
+    result = await _financials.handle_get_financials("005930", market="kr")
+
+    assert result["metrics"] == metrics
+    assert result["status"] == "available"
+    assert result["scoreable"] is True
+    assert "reason" not in result
+    assert "evidence" not in result
+
+
+@pytest.mark.asyncio
+async def test_us_financial_report_metadata_without_metrics_is_unavailable(monkeypatch):
+    monkeypatch.setattr(
+        _financials,
+        "_fetch_financials_finnhub",
+        AsyncMock(
+            return_value={
+                "symbol": "AAPL",
+                "instrument_type": "equity_us",
+                "source": "finnhub",
+                "statement": "income",
+                "freq": "annual",
+                "reports": [
+                    {
+                        "year": 2025,
+                        "quarter": 0,
+                        "filed_date": "2026-02-01",
+                        "data": {},
+                    }
+                ],
+            }
+        ),
+    )
+
+    result = await _financials.handle_get_financials("AAPL", market="us")
+
+    assert result["reports"][0]["data"] == {}
+    assert result["status"] == "unavailable"
+    assert result["scoreable"] is False
+    assert result["reason"] == "financial_metrics_unavailable"
+    assert result["evidence"]["period_count"] == 1


### PR DESCRIPTION
## Summary
- isolate kis_mock holdings/cash from Upbit, Toss, manual, and paper provenance and fail closed on incompatible selectors
- expose truthful KR quote/NXT freshness and fundamentals availability contracts
- preserve existing ROB-600 timeout and circuit-open stable error behavior with regression coverage
- do not add a ROB-851 adapter or change mutation boundaries

## Red to green
- ROB-820 focused tests: 16 failed / 2 passed initially; final 25 passed
- paper selector audit: 2 failed, then passed after moving validation ahead of paper routing
- quote/fundamentals focused regression: 329 passed
- portfolio/account-mode focused regression: 148 passed
- full suite: 14,957 passed, 10 skipped, 7 deselected

## Quality
- make lint: passed (ruff check app/ tests/, ruff format --check app/ tests/, ty check app/ --error-on-warning)
- git diff --check: passed
- repository-wide ruff check . remains blocked by 11 pre-existing errors outside this diff; repository-wide format check lists 93 pre-existing files. CI-scoped lint is green.

## Scope guards
- no live credentials or mutations
- no ROB-851 adapter/alternate holdings or cash truth source
- no ROB-819 changes
- no ROB-843/ROB-853 mutation-boundary changes
