### PR TITLE
feat(ROB-871): auto-approve resting order proposals

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -799,6 +799,9 @@ class Settings(BaseSettings):
     # ORDER PROPOSALS (ROB-816) — default-off SOT ledger + read/create MCP tools.
     # Gates MCP tool registration; the Telegram approval surface has its own gate (PR 2).
     ORDER_PROPOSALS_ENABLED: bool = False
+    # ROB-871 — master gate for resting-class automatic submission. Telegram
+    # approvals remain the fallback whenever this is off or eligibility fails.
+    ORDER_PROPOSALS_AUTO_APPROVE: bool = False
     # ROB-816 PR 2 — Telegram approval flow (default off)
     ORDER_PROPOSALS_TELEGRAM_ENABLED: bool = False
     ORDER_PROPOSALS_TELEGRAM_BOT_TOKEN: str = ""

--- a/app/mcp_server/README.md
+++ b/app/mcp_server/README.md
@@ -703,6 +703,8 @@ and write policy/version/eligibility evidence under
 `source_asof.auto_approved`. Their Telegram summary carries a single-use
 `취소` veto button; the callback uses the existing broker cancel adapter and a
 fresh status lookup to converge the rung to `cancelled` or report `체결됨`.
+Failure to deliver that post-submit summary triggers the same immediate
+cancel-and-confirm compensation and is audited in `source_asof`.
 `ORDER_PROPOSALS_SUBMIT_AGENT_ID` has no default identity (`""`) and is used
 only while the Telegram callback revalidates and submits the approved proposal.
 Operators must set it explicitly and add the exact same trimmed identity to

--- a/app/mcp_server/README.md
+++ b/app/mcp_server/README.md
@@ -668,6 +668,16 @@ order mutation.
     has a 90-second single-use nonce bound to proposal/rung/revision. Only the
     second click reruns full preview, <=72h retrospective, slip-band, price
     diff, and approval-hash checks and may submit.
+  - ROB-871 adds a separate default-off
+    `ORDER_PROPOSALS_AUTO_APPROVE` gate. When enabled, only `limit` + `place`
+    proposals with no `exit_intent` may auto-submit. The fresh preview price,
+    configured minimum resting distance, per-order cap, and account/KST-day
+    cumulative cap are checked immediately before the existing submit path.
+    Market orders, loss cuts, replace/cancel actions, guard failures, 861
+    buying-power reconfirmations, and policy misses fall back to the normal
+    Telegram approval message without being discarded. Account/market pairs
+    without the existing cancel adapter and multi-rung ladders also remain
+    human-gated so veto and all-or-human fallback are enforceable.
 - `order_proposal_void(proposal_id, reason)`
   - Requires a non-blank operator reason.
   - Pre-submit rungs retain the existing local `voided` path. An `unverified`
@@ -688,6 +698,11 @@ order mutation.
 Telegram approval runs fresh broker-specific checks at the submit-capable
 click. KIS/Upbit rerun their applicable ROB-800 checks through
 `_place_order_impl`.
+Successful automatic submissions retain `approved_by_telegram_user_id=NULL`
+and write policy/version/eligibility evidence under
+`source_asof.auto_approved`. Their Telegram summary carries a single-use
+`취소` veto button; the callback uses the existing broker cancel adapter and a
+fresh status lookup to converge the rung to `cancelled` or report `체결됨`.
 `ORDER_PROPOSALS_SUBMIT_AGENT_ID` has no default identity (`""`) and is used
 only while the Telegram callback revalidates and submits the approved proposal.
 Operators must set it explicitly and add the exact same trimmed identity to

--- a/app/mcp_server/tooling/order_proposal_tools.py
+++ b/app/mcp_server/tooling/order_proposal_tools.py
@@ -2,7 +2,9 @@
 
 READ + CREATE + VOID ONLY. There is deliberately no approve/submit tool —
 approval is Telegram-only (PR 2). ``order_proposal_create`` persists a proposal
-row; it performs NO broker mutation.
+row. Broker mutation remains behind Telegram dispatch; with ROB-871's separate
+default-off gate, a narrowly eligible resting order may submit only after the
+row has committed and the existing fresh revalidation path passes.
 """
 
 from __future__ import annotations
@@ -27,7 +29,7 @@ from app.services.order_proposals.buying_power import (
     currency_for_market,
     default_buying_power_reader,
 )
-from app.services.order_proposals.dispatch import send_proposal_for_approval
+from app.services.order_proposals.dispatch import dispatch_proposal
 from app.services.order_proposals.errors import (
     OrderProposalError,
     OrderProposalNotFound,
@@ -329,7 +331,7 @@ async def order_proposal_create(
 
         # Best-effort Telegram dispatch (ROB-816 PR 2). The proposal's own
         # session above is already closed/committed by this point --
-        # `send_proposal_for_approval` opens a genuinely separate session, so
+        # `dispatch_proposal` opens a genuinely separate session, so
         # this is intentional, not a nested-session bug. A dispatch failure
         # (Telegram down, notifier misconfigured, etc.) must never fail this
         # tool's contract -- the proposal has already persisted successfully.
@@ -342,7 +344,7 @@ async def order_proposal_create(
                     get_trade_notifier,
                 )
 
-                await send_proposal_for_approval(
+                await dispatch_proposal(
                     proposal_id,
                     notifier=get_trade_notifier(),
                     now=now_kst(),

--- a/app/schemas/trading_policy.py
+++ b/app/schemas/trading_policy.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 from typing import Literal
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 Lane = Literal["buy", "sell", "discovery"]
 Market = Literal["kr", "us", "crypto"]
@@ -112,6 +112,45 @@ class PolicyAuthority(BaseModel):
     does_not_govern: list[str]
 
 
+class OrderProposalAutoApprovePolicy(BaseModel):
+    """Default-off resting-order auto-approval thresholds (ROB-871).
+
+    Caps are denominated in each market's settlement currency: KRW for KR
+    equities and crypto, USD for US equities.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    min_distance_pct: float = Field(gt=0, le=100)
+    per_order_cap: dict[Market, float]
+    daily_cap: dict[Market, float]
+
+    @field_validator("per_order_cap", "daily_cap")
+    @classmethod
+    def validate_market_caps(cls, value: dict[Market, float]) -> dict[Market, float]:
+        required = {"kr", "us", "crypto"}
+        if set(value) != required:
+            raise ValueError(f"market caps must contain exactly {sorted(required)}")
+        if any(cap <= 0 for cap in value.values()):
+            raise ValueError("market caps must be positive")
+        return value
+
+    @model_validator(mode="after")
+    def validate_daily_caps(self) -> OrderProposalAutoApprovePolicy:
+        if any(
+            self.daily_cap[market] < per_order
+            for market, per_order in self.per_order_cap.items()
+        ):
+            raise ValueError("daily cap must be at least the per-order cap")
+        return self
+
+
+class OrderProposalsPolicy(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    auto_approve: OrderProposalAutoApprovePolicy
+
+
 class TradingPolicyDocument(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -119,6 +158,7 @@ class TradingPolicyDocument(BaseModel):
     captured_as_of: str
     source: str
     authority: PolicyAuthority
+    order_proposals: OrderProposalsPolicy
     sector_clusters: dict[str, list[str]]
     thresholds: dict[str, PolicyThreshold]
     decision_rules: dict[str, PolicyDecisionRule] = Field(default_factory=dict)

--- a/app/services/order_proposals/approval_message.py
+++ b/app/services/order_proposals/approval_message.py
@@ -11,9 +11,9 @@ from typing import Any
 
 from app.core.timezone import KST
 
-_ALLOWED_ACTIONS = frozenset({"op", "dn", "lc"})
+_ALLOWED_ACTIONS = frozenset({"op", "dn", "lc", "vc"})
 _CALLBACK_PATTERN = re.compile(
-    r"^(?P<action>op|dn|lc):(?P<proposal_short>[0-9a-f]{8}):"
+    r"^(?P<action>op|dn|lc|vc):(?P<proposal_short>[0-9a-f]{8}):"
     r"(?P<nonce>[A-Za-z0-9_-]+)$"
 )
 _MAX_CALLBACK_BYTES = 64
@@ -34,7 +34,7 @@ def build_callback_data(
 ) -> str:
     """Build compact Telegram callback data for an approval action."""
     if action not in _ALLOWED_ACTIONS:
-        raise ValueError("action must be one of: op, dn, lc")
+        raise ValueError("action must be one of: op, dn, lc, vc")
     if not isinstance(proposal_id, uuid.UUID):
         raise ValueError("proposal_id must be a UUID")
     if not isinstance(nonce, str) or not re.fullmatch(r"[A-Za-z0-9_-]+", nonce):

--- a/app/services/order_proposals/auto_approve.py
+++ b/app/services/order_proposals/auto_approve.py
@@ -1,0 +1,203 @@
+"""Resting-class auto-approval eligibility policy (ROB-871).
+
+This module is deliberately pure: it classifies one freshly previewed rung
+and never reads the database or calls a broker. The dispatch/revalidation
+boundary supplies the account's same-day cumulative auto-approved notional.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal, InvalidOperation
+from typing import Any
+
+from app.services.order_proposals.approval_message import (
+    _escape_inline_code,
+    _escape_markdown,
+    build_callback_data,
+)
+from app.services.order_proposals.broker_gateway import SUPPORTED_TARGET_ACTIONS
+from app.services.trading_policy_service import load_trading_policy
+
+_POLICY_MARKET = {
+    "equity_kr": "kr",
+    "equity_us": "us",
+    "crypto": "crypto",
+}
+
+
+@dataclass(frozen=True)
+class AutoApproveLimits:
+    min_distance_pct: Decimal
+    per_order_cap: Decimal
+    daily_cap: Decimal
+    policy_version: str
+
+
+@dataclass(frozen=True)
+class AutoApproveDecision:
+    eligible: bool
+    reason: str
+    details: dict[str, str]
+
+
+def _decimal(value: Any) -> Decimal | None:
+    try:
+        parsed = Decimal(str(value))
+    except (InvalidOperation, TypeError, ValueError):
+        return None
+    return parsed if parsed.is_finite() else None
+
+
+def _text(value: Decimal) -> str:
+    normalized = format(value.normalize(), "f")
+    return normalized.rstrip("0").rstrip(".") if "." in normalized else normalized
+
+
+def limits_for_market(market: str) -> AutoApproveLimits | None:
+    policy_market = _POLICY_MARKET.get(market)
+    if policy_market is None:
+        return None
+    document = load_trading_policy()
+    policy = document.order_proposals.auto_approve
+    return AutoApproveLimits(
+        min_distance_pct=Decimal(str(policy.min_distance_pct)),
+        per_order_cap=Decimal(str(policy.per_order_cap[policy_market])),
+        daily_cap=Decimal(str(policy.daily_cap[policy_market])),
+        policy_version=document.version,
+    )
+
+
+def evaluate_auto_approve_eligibility(
+    *,
+    group: Any,
+    rung: Any,
+    preview: dict[str, Any],
+    limits: AutoApproveLimits,
+    daily_notional: Decimal,
+) -> AutoApproveDecision:
+    """Classify a rung using the fresh submit-time preview, failing closed."""
+
+    base = {"policy_version": limits.policy_version}
+
+    def reject(reason: str, **details: str) -> AutoApproveDecision:
+        return AutoApproveDecision(False, reason, {**base, **details})
+
+    if (getattr(group, "action", None) or "place") != "place":
+        return reject("action_not_place")
+    if getattr(group, "order_type", None) != "limit":
+        return reject("order_type_not_limit")
+    if getattr(group, "exit_intent", None) is not None:
+        return reject("exit_intent_present")
+    if (
+        getattr(group, "account_mode", None),
+        getattr(group, "market", None),
+    ) not in SUPPORTED_TARGET_ACTIONS:
+        return reject("account_not_veto_capable")
+    if preview.get("success") is not True:
+        return reject("preview_guard_failed")
+
+    current_price = _decimal(preview.get("current_price"))
+    limit_price = _decimal(getattr(rung, "limit_price", None))
+    quantity = _decimal(getattr(rung, "quantity", None))
+    if (
+        current_price is None
+        or current_price <= 0
+        or limit_price is None
+        or limit_price <= 0
+        or quantity is None
+        or quantity <= 0
+    ):
+        return reject("price_or_quantity_missing")
+
+    # Use the executable price × quantity, never proposer-supplied advisory
+    # notional, so a stale or understated metadata field cannot bypass caps.
+    notional = limit_price * quantity
+    if notional > limits.per_order_cap:
+        return reject(
+            "per_order_cap_exceeded",
+            notional=_text(notional),
+            per_order_cap=_text(limits.per_order_cap),
+        )
+    daily_after = daily_notional + notional
+    if daily_after > limits.daily_cap:
+        return reject(
+            "daily_cap_exceeded",
+            daily_notional_after=_text(daily_after),
+            daily_cap=_text(limits.daily_cap),
+        )
+
+    min_fraction = limits.min_distance_pct / Decimal("100")
+    side = getattr(rung, "side", None)
+    if side == "buy":
+        threshold = current_price * (Decimal("1") - min_fraction)
+        distance_pct = (current_price - limit_price) / current_price * Decimal("100")
+        if limit_price > threshold:
+            return reject("distance_below_minimum")
+        loss_guard = "not_applicable"
+    elif side == "sell":
+        threshold = current_price * (Decimal("1") + min_fraction)
+        distance_pct = (limit_price - current_price) / current_price * Decimal("100")
+        if limit_price < threshold:
+            return reject("distance_below_minimum")
+        # A successful fresh sell preview means the existing avg-cost loss
+        # guard ran and passed. We record that provenance instead of
+        # reimplementing the guard with a potentially different threshold.
+        loss_guard = "preview_passed"
+    else:
+        return reject("side_not_supported")
+
+    return AutoApproveDecision(
+        True,
+        "eligible",
+        {
+            **base,
+            "current_price": _text(current_price),
+            "limit_price": _text(limit_price),
+            "distance_pct": _text(distance_pct),
+            "min_distance_pct": _text(limits.min_distance_pct),
+            "notional": _text(notional),
+            "daily_notional_before": _text(daily_notional),
+            "daily_notional_after": _text(daily_after),
+            "per_order_cap": _text(limits.per_order_cap),
+            "daily_cap": _text(limits.daily_cap),
+            "loss_guard": loss_guard,
+        },
+    )
+
+
+def build_auto_approved_message(
+    *, group: Any, rungs: list[Any], nonce: str, policy_version: str
+) -> tuple[str, dict[str, Any]]:
+    """Render a compact post-submit summary with a single-use veto button."""
+    callback = build_callback_data(
+        action="vc", proposal_id=group.proposal_id, nonce=nonce
+    )
+    lines = [
+        "✅ *자동 접수됨*",
+        f"- 종목: `{_escape_inline_code(group.symbol)}`",
+        f"- 방향: `{_escape_inline_code(group.side)}`",
+    ]
+    for rung in sorted(rungs, key=lambda item: item.rung_index):
+        lines.append(f"- #{rung.rung_index + 1}: {rung.quantity} × {rung.limit_price}")
+    rationale = " ".join(str(group.thesis or group.strategy or "근거 미기재").split())
+    if len(rationale) > 120:
+        rationale = rationale[:119] + "…"
+    lines.extend(
+        [
+            f"- 근거: {_escape_markdown(rationale)}",
+            f"- `auto:policy@{policy_version}`",
+        ]
+    )
+    return "\n".join(lines), {
+        "inline_keyboard": [[{"text": "취소", "callback_data": callback}]]
+    }
+
+
+__all__ = [
+    "AutoApproveDecision",
+    "AutoApproveLimits",
+    "evaluate_auto_approve_eligibility",
+    "build_auto_approved_message",
+    "limits_for_market",
+]

--- a/app/services/order_proposals/auto_veto.py
+++ b/app/services/order_proposals/auto_veto.py
@@ -1,0 +1,130 @@
+"""Shared broker-cancel convergence for ROB-871 auto-submission vetoes."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from datetime import datetime
+from decimal import Decimal
+from typing import Any
+
+from app.models.order_proposals import OrderProposal, OrderProposalRung
+from app.services.order_proposals.service import OrderProposalsService
+
+TargetCancelFn = Callable[..., Any]
+TargetFetchFn = Callable[..., Any]
+
+_CANCELLABLE_STATES = frozenset({"acked", "resting", "partially_filled", "unverified"})
+
+
+async def acquire_auto_veto_locks(
+    *,
+    service: OrderProposalsService,
+    group: OrderProposal,
+    rungs: Sequence[OrderProposalRung],
+) -> None:
+    """Lock broker targets in stable order before any proposal row lock."""
+    broker_order_ids = sorted(
+        {
+            str(rung.broker_order_id)
+            for rung in rungs
+            if rung.state in _CANCELLABLE_STATES and rung.broker_order_id
+        }
+    )
+    for broker_order_id in broker_order_ids:
+        await service.acquire_broker_order_mutation_lock(group, broker_order_id)
+
+
+async def cancel_auto_submitted_rungs(
+    *,
+    service: OrderProposalsService,
+    group: OrderProposal,
+    rungs: Sequence[OrderProposalRung],
+    now: datetime,
+    cancel_fn: TargetCancelFn,
+    fetch_fn: TargetFetchFn,
+) -> list[dict[str, Any]]:
+    """Request cancel, then converge each rung only from fresh broker status."""
+    outcomes: list[dict[str, Any]] = []
+    for rung in rungs:
+        if rung.state == "filled":
+            outcomes.append({"rung_index": rung.rung_index, "result": "filled"})
+            continue
+        if rung.state == "cancelled":
+            outcomes.append({"rung_index": rung.rung_index, "result": "cancelled"})
+            continue
+        if rung.state not in _CANCELLABLE_STATES or not rung.broker_order_id:
+            outcomes.append(
+                {"rung_index": rung.rung_index, "result": "not_cancellable"}
+            )
+            continue
+
+        cancel_error: str | None = None
+        try:
+            cancel_result = await cancel_fn(
+                order_id=rung.broker_order_id,
+                symbol=group.symbol,
+                market=group.market,
+                account_mode=group.account_mode,
+            )
+            if (
+                not isinstance(cancel_result, dict)
+                or cancel_result.get("success") is not True
+            ):
+                cancel_error = (
+                    str(cancel_result.get("error") or "cancel_rejected")
+                    if isinstance(cancel_result, dict)
+                    else "cancel_rejected"
+                )
+        except Exception as exc:  # noqa: BLE001 - confirm after ambiguity
+            cancel_error = str(exc)
+
+        try:
+            snapshot = await fetch_fn(
+                order_id=rung.broker_order_id,
+                symbol=group.symbol,
+                market=group.market,
+                account_mode=group.account_mode,
+                now=now,
+            )
+            status = snapshot.status
+        except Exception as exc:  # noqa: BLE001 - persist explicit uncertainty
+            status = None
+            cancel_error = cancel_error or str(exc)
+
+        if status == "cancelled":
+            await service.record_cancelled(
+                group.proposal_id,
+                rung.rung_index,
+                broker_order_id=rung.broker_order_id,
+                now=now,
+            )
+            outcomes.append({"rung_index": rung.rung_index, "result": "cancelled"})
+        elif status == "filled":
+            await service.transition_rung(
+                group.proposal_id,
+                rung.rung_index,
+                new_state="filled",
+                broker_order_id=rung.broker_order_id,
+                filled_qty=Decimal(rung.quantity),
+                validated_at=now,
+                updated_at=now,
+            )
+            outcomes.append({"rung_index": rung.rung_index, "result": "filled"})
+        else:
+            outcomes.append(
+                {
+                    "rung_index": rung.rung_index,
+                    "result": "cancel_failed",
+                    "broker_status": status,
+                    "error": cancel_error,
+                }
+            )
+    return outcomes
+
+
+__all__ = [
+    "TargetCancelFn",
+    "TargetFetchFn",
+    "acquire_auto_veto_locks",
+    "cancel_auto_submitted_rungs",
+]

--- a/app/services/order_proposals/dispatch.py
+++ b/app/services/order_proposals/dispatch.py
@@ -22,16 +22,27 @@ import secrets
 import uuid
 from collections.abc import Callable
 from datetime import datetime
+from decimal import Decimal
 from typing import Any
 
 from app.core.config import settings
 from app.core.db import AsyncSessionLocal
 from app.services.order_proposals.approval_message import build_approval_message
+from app.services.order_proposals.auto_approve import (
+    build_auto_approved_message,
+    evaluate_auto_approve_eligibility,
+    limits_for_market,
+)
+from app.services.order_proposals.revalidation import (
+    RungOutcome,
+    revalidate_and_submit,
+)
 from app.services.order_proposals.service import OrderProposalsService
 
 logger = logging.getLogger(__name__)
 
 ServiceFactory = Callable[[], Any]
+RevalidateFn = Callable[..., Any]
 
 
 def _generate_nonce() -> str:
@@ -89,4 +100,109 @@ async def send_proposal_for_approval(
         return message_id
 
 
-__all__ = ["send_proposal_for_approval"]
+async def dispatch_proposal(
+    proposal_id: uuid.UUID,
+    *,
+    notifier: Any,
+    now: datetime,
+    service_factory: ServiceFactory = AsyncSessionLocal,
+    revalidate_fn: RevalidateFn = revalidate_and_submit,
+) -> int | None:
+    """Auto-submit an eligible resting proposal, otherwise send for approval."""
+    if not settings.ORDER_PROPOSALS_AUTO_APPROVE:
+        return await send_proposal_for_approval(
+            proposal_id,
+            notifier=notifier,
+            now=now,
+            service_factory=service_factory,
+        )
+
+    auto_submitted = False
+    message: tuple[str, dict[str, Any]] | None = None
+    async with service_factory() as session:
+        service = OrderProposalsService(session)
+        group, initial_rungs = await service.get_proposal(proposal_id)
+        pending_count = sum(rung.state == "pending_approval" for rung in initial_rungs)
+        limits = limits_for_market(group.market)
+        decisions: list[dict[str, Any]] = []
+        if limits is not None:
+            daily_notional = await service.auto_approved_daily_notional(group, now=now)
+
+            async def eligibility_gate(**kwargs: Any) -> Any:
+                nonlocal daily_notional
+                decision = evaluate_auto_approve_eligibility(
+                    group=kwargs["group"],
+                    rung=kwargs["rung"],
+                    preview=kwargs["preview"],
+                    limits=limits,
+                    daily_notional=daily_notional,
+                )
+                decisions.append(
+                    {
+                        "rung_index": kwargs["rung"].rung_index,
+                        "eligible": decision.eligible,
+                        "reason": decision.reason,
+                        **decision.details,
+                    }
+                )
+                if decision.eligible:
+                    daily_notional = Decimal(decision.details["daily_notional_after"])
+                return decision
+
+            outcomes: list[RungOutcome] = await revalidate_fn(
+                service=service,
+                proposal_id=proposal_id,
+                now=now,
+                eligibility_gate=eligibility_gate,
+            )
+            submitted_results = {"submitted_acked", "submitted_resting"}
+            auto_submitted = (
+                bool(outcomes)
+                and len(outcomes) == pending_count
+                and all(outcome.result in submitted_results for outcome in outcomes)
+            )
+            if auto_submitted:
+                await service.record_auto_approval(
+                    proposal_id,
+                    policy_version=limits.policy_version,
+                    eligibility=decisions,
+                    outcomes=[outcome.result for outcome in outcomes],
+                    now=now,
+                )
+                veto_nonce = _generate_nonce()
+                await service.set_approval_nonce(proposal_id, veto_nonce)
+                group, rungs = await service.get_proposal(proposal_id)
+                message = build_auto_approved_message(
+                    group=group,
+                    rungs=rungs,
+                    nonce=veto_nonce,
+                    policy_version=limits.policy_version,
+                )
+        # Persist broker outcomes and the audit/nonce before Telegram I/O.
+        await session.commit()
+
+    if not auto_submitted or message is None:
+        return await send_proposal_for_approval(
+            proposal_id,
+            notifier=notifier,
+            now=now,
+            service_factory=service_factory,
+        )
+
+    allowlist = settings.order_proposals_telegram_chat_allowlist
+    if not allowlist:
+        return None
+    chat_id = allowlist[0]
+    text, keyboard = message
+    message_id = await notifier.send_approval_message(text, keyboard, chat_id=chat_id)
+    if message_id is not None:
+        async with service_factory() as session:
+            service = OrderProposalsService(session)
+            await service.record_approval_dispatch(
+                proposal_id, message_id=message_id, chat_id=chat_id, now=now
+            )
+            await session.commit()
+    return message_id
+
+
+__all__ = ["dispatch_proposal", "send_proposal_for_approval"]

--- a/app/services/order_proposals/dispatch.py
+++ b/app/services/order_proposals/dispatch.py
@@ -33,6 +33,16 @@ from app.services.order_proposals.auto_approve import (
     evaluate_auto_approve_eligibility,
     limits_for_market,
 )
+from app.services.order_proposals.auto_veto import (
+    TargetCancelFn,
+    TargetFetchFn,
+    acquire_auto_veto_locks,
+    cancel_auto_submitted_rungs,
+)
+from app.services.order_proposals.broker_gateway import (
+    cancel_target_order,
+    fetch_target_order,
+)
 from app.services.order_proposals.revalidation import (
     RungOutcome,
     revalidate_and_submit,
@@ -107,6 +117,8 @@ async def dispatch_proposal(
     now: datetime,
     service_factory: ServiceFactory = AsyncSessionLocal,
     revalidate_fn: RevalidateFn = revalidate_and_submit,
+    cancel_target_fn: TargetCancelFn = cancel_target_order,
+    fetch_target_fn: TargetFetchFn = fetch_target_order,
 ) -> int | None:
     """Auto-submit an eligible resting proposal, otherwise send for approval."""
     if not settings.ORDER_PROPOSALS_AUTO_APPROVE:
@@ -121,8 +133,12 @@ async def dispatch_proposal(
     message: tuple[str, dict[str, Any]] | None = None
     async with service_factory() as session:
         service = OrderProposalsService(session)
+        await service.acquire_auto_dispatch_lock(proposal_id)
         group, initial_rungs = await service.get_proposal(proposal_id)
         pending_count = sum(rung.state == "pending_approval" for rung in initial_rungs)
+        if pending_count == 0:
+            await session.commit()
+            return None
         limits = limits_for_market(group.market)
         decisions: list[dict[str, Any]] = []
         if limits is not None:
@@ -190,18 +206,50 @@ async def dispatch_proposal(
         )
 
     allowlist = settings.order_proposals_telegram_chat_allowlist
-    if not allowlist:
-        return None
-    chat_id = allowlist[0]
     text, keyboard = message
-    message_id = await notifier.send_approval_message(text, keyboard, chat_id=chat_id)
-    if message_id is not None:
+    notify_error = "telegram_allowlist_empty"
+    message_id = None
+    chat_id = allowlist[0] if allowlist else None
+    if chat_id is not None:
+        notify_error = "telegram_message_not_sent"
+        try:
+            message_id = await notifier.send_approval_message(
+                text, keyboard, chat_id=chat_id
+            )
+        except Exception as exc:  # noqa: BLE001 - compensate live order below
+            logger.exception("auto-approved proposal veto notification failed")
+            notify_error = str(exc)
+            message_id = None
+    if message_id is None:
         async with service_factory() as session:
             service = OrderProposalsService(session)
-            await service.record_approval_dispatch(
-                proposal_id, message_id=message_id, chat_id=chat_id, now=now
+            await service.acquire_auto_dispatch_lock(proposal_id)
+            group, rungs = await service.get_proposal(proposal_id)
+            await acquire_auto_veto_locks(service=service, group=group, rungs=rungs)
+            outcomes = await cancel_auto_submitted_rungs(
+                service=service,
+                group=group,
+                rungs=rungs,
+                now=now,
+                cancel_fn=cancel_target_fn,
+                fetch_fn=fetch_target_fn,
+            )
+            await service.record_auto_notification_failure(
+                proposal_id,
+                error=notify_error,
+                outcomes=outcomes,
+                now=now,
             )
             await session.commit()
+        return None
+    if chat_id is None:
+        raise AssertionError("a sent Telegram message requires a destination chat")
+    async with service_factory() as session:
+        service = OrderProposalsService(session)
+        await service.record_approval_dispatch(
+            proposal_id, message_id=message_id, chat_id=chat_id, now=now
+        )
+        await session.commit()
     return message_id
 
 

--- a/app/services/order_proposals/repository.py
+++ b/app/services/order_proposals/repository.py
@@ -78,6 +78,7 @@ class OrderProposalRepository:
         self,
         *,
         account_mode: str,
+        market: str,
         broker_account_id: str | None,
         start: datetime,
         end: datetime,
@@ -97,6 +98,7 @@ class OrderProposalRepository:
             )
             .where(
                 OrderProposal.account_mode == account_mode,
+                OrderProposal.market == market,
                 approved_at >= start,
                 approved_at < end,
                 OrderProposal.source_asof.op("?")("auto_approved"),
@@ -109,8 +111,8 @@ class OrderProposalRepository:
         value = (await self._session.execute(stmt)).scalar_one()
         return Decimal(value)
 
-    async def acquire_auto_approve_account_lock(self, lock_key: str) -> None:
-        """Serialize same-account/day cap checks until transaction commit."""
+    async def acquire_auto_approve_lock(self, lock_key: str) -> None:
+        """Serialize an auto-approval critical section until transaction commit."""
         await self._session.execute(
             select(func.pg_advisory_xact_lock(func.hashtextextended(lock_key, 0)))
         )

--- a/app/services/order_proposals/repository.py
+++ b/app/services/order_proposals/repository.py
@@ -8,9 +8,11 @@ Never commits — the caller owns the transaction.
 from __future__ import annotations
 
 import uuid
+from datetime import datetime
+from decimal import Decimal
 from typing import Any
 
-from sqlalchemy import Text, cast, select
+from sqlalchemy import TIMESTAMP, Text, cast, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm.attributes import flag_modified
 
@@ -71,6 +73,47 @@ class OrderProposalRepository:
         if lifecycle_state:
             stmt = stmt.where(OrderProposal.lifecycle_state == lifecycle_state)
         return list((await self._session.execute(stmt)).scalars().all())
+
+    async def auto_approved_notional_between(
+        self,
+        *,
+        account_mode: str,
+        broker_account_id: str | None,
+        start: datetime,
+        end: datetime,
+    ) -> Decimal:
+        """Sum rungs belonging to auto-approved groups in a time window."""
+        notional = OrderProposalRung.quantity * OrderProposalRung.limit_price
+        approved_at = cast(
+            OrderProposal.source_asof["auto_approved"]["approved_at"].astext,
+            TIMESTAMP(timezone=True),
+        )
+        stmt = (
+            select(func.coalesce(func.sum(notional), 0))
+            .select_from(OrderProposal)
+            .join(
+                OrderProposalRung,
+                OrderProposalRung.proposal_pk == OrderProposal.id,
+            )
+            .where(
+                OrderProposal.account_mode == account_mode,
+                approved_at >= start,
+                approved_at < end,
+                OrderProposal.source_asof.op("?")("auto_approved"),
+            )
+        )
+        if broker_account_id is None:
+            stmt = stmt.where(OrderProposal.broker_account_id.is_(None))
+        else:
+            stmt = stmt.where(OrderProposal.broker_account_id == broker_account_id)
+        value = (await self._session.execute(stmt)).scalar_one()
+        return Decimal(value)
+
+    async def acquire_auto_approve_account_lock(self, lock_key: str) -> None:
+        """Serialize same-account/day cap checks until transaction commit."""
+        await self._session.execute(
+            select(func.pg_advisory_xact_lock(func.hashtextextended(lock_key, 0)))
+        )
 
     async def find_rung_by_evidence(
         self,

--- a/app/services/order_proposals/revalidation.py
+++ b/app/services/order_proposals/revalidation.py
@@ -68,6 +68,7 @@ RungOutcomeResult = Literal[
     "unverified",
     "error",
     "cancelled",
+    "approval_required",
 ]
 
 
@@ -84,6 +85,7 @@ TargetFetchFn = Callable[..., Any]
 TargetCancelFn = Callable[..., Any]
 SubmitEvidenceFetchFn = Callable[..., Any]
 RetrospectiveLookupFn = Callable[[int], Any]
+EligibilityGate = Callable[..., Any]
 
 _PREVIEW_REASON = "order_proposal revalidation (rung {rung})"
 _SUBMIT_REASON = "order_proposal submit after revalidation (rung {rung})"
@@ -534,6 +536,7 @@ async def revalidate_and_submit(
     fetch_submit_evidence_fn: SubmitEvidenceFetchFn = fetch_submit_evidence,
     buying_power_claimer: BuyingPowerClaimer = default_buying_power_claimer,
     buying_power_releaser: BuyingPowerReleaser = default_buying_power_releaser,
+    eligibility_gate: EligibilityGate | None = None,
 ) -> list[RungOutcome]:
     """Revalidate + (maybe) submit every ``pending_approval`` rung.
 
@@ -547,6 +550,20 @@ async def revalidate_and_submit(
         return [
             RungOutcome(rung.rung_index, "error", {"error": block_reason})
             for rung in rungs
+        ]
+    pending_rungs = [rung for rung in rungs if rung.state == "pending_approval"]
+    if eligibility_gate is not None and len(pending_rungs) > 1:
+        # Auto-dispatch must be lossless: submitting one ladder rung before a
+        # later rung fails eligibility or buying-power checks would violate
+        # the all-or-human-fallback contract. Until the submit path supports a
+        # broker-side atomic ladder, multi-rung proposals stay human-gated.
+        return [
+            RungOutcome(
+                rung.rung_index,
+                "approval_required",
+                {"reason": "multi_rung_requires_approval"},
+            )
+            for rung in pending_rungs
         ]
     outcomes: list[RungOutcome] = []
     for rung in rungs:
@@ -585,6 +602,7 @@ async def revalidate_and_submit(
                 fetch_submit_evidence_fn=fetch_submit_evidence_fn,
                 buying_power_claimer=buying_power_claimer,
                 buying_power_releaser=buying_power_releaser,
+                eligibility_gate=eligibility_gate,
             )
         outcomes.append(outcome)
     return outcomes
@@ -601,6 +619,7 @@ async def _revalidate_place_rung(
     fetch_submit_evidence_fn: SubmitEvidenceFetchFn,
     buying_power_claimer: BuyingPowerClaimer,
     buying_power_releaser: BuyingPowerReleaser,
+    eligibility_gate: EligibilityGate | None,
 ) -> RungOutcome:
     proposal_id = group.proposal_id
     rung_index = rung.rung_index
@@ -702,6 +721,45 @@ async def _revalidate_place_rung(
         return RungOutcome(
             rung_index, "needs_reconfirm", {"before": before, "after": after}
         )
+
+    if eligibility_gate is not None:
+        try:
+            decision = await _maybe_await(
+                eligibility_gate(
+                    group=group,
+                    rung=rung,
+                    preview=preview,
+                    now=now,
+                )
+            )
+            eligible = (
+                decision.get("eligible")
+                if isinstance(decision, dict)
+                else getattr(decision, "eligible", False)
+            )
+            reason = (
+                decision.get("reason")
+                if isinstance(decision, dict)
+                else getattr(decision, "reason", "eligibility_unknown")
+            )
+            details = (
+                decision.get("details", {})
+                if isinstance(decision, dict)
+                else getattr(decision, "details", {})
+            )
+        except Exception as exc:  # noqa: BLE001 - auto path fails closed
+            eligible = False
+            reason = "eligibility_error"
+            details = {"error": str(exc)}
+        if eligible is not True:
+            await service.transition_rung(
+                proposal_id, rung_index, new_state="pending_approval"
+            )
+            return RungOutcome(
+                rung_index,
+                "approval_required",
+                {"reason": str(reason), **dict(details or {})},
+            )
 
     buying_power_reservation: tuple[str, Decimal, str | None] | None = None
     if rung.side == "buy" and rung.limit_price is not None:

--- a/app/services/order_proposals/service.py
+++ b/app/services/order_proposals/service.py
@@ -780,6 +780,28 @@ class OrderProposalsService:
             raise OrderProposalError("nonce_replay")
         return await self._repo.update_group(group, approval_nonce_used_at=now)
 
+    async def consume_auto_veto_nonce(
+        self, proposal_id: uuid.UUID, nonce: str, *, now: datetime
+    ) -> OrderProposal:
+        """Consume an auto-submit veto nonce, including after a broker fill."""
+        self._require_timezone_aware(now)
+        group = await self._repo.get_group_by_proposal_id(proposal_id, for_update=True)
+        if group is None:
+            raise OrderProposalNotFound(str(proposal_id))
+        if group.superseded_by_proposal_id is not None:
+            raise OrderProposalError(
+                f"proposal_superseded_by:{group.superseded_by_proposal_id}"
+            )
+        if group.lifecycle_state == "superseded":
+            raise OrderProposalError("proposal_superseded_by:unknown")
+        if not isinstance((group.source_asof or {}).get("auto_approved"), dict):
+            raise OrderProposalError("auto_veto_not_available")
+        if group.approval_nonce != nonce:
+            raise OrderProposalError("nonce_mismatch")
+        if group.approval_nonce_used_at is not None:
+            raise OrderProposalError("nonce_replay")
+        return await self._repo.update_group(group, approval_nonce_used_at=now)
+
     async def issue_loss_cut_confirmation(
         self,
         proposal_id: uuid.UUID,
@@ -942,6 +964,72 @@ class OrderProposalsService:
             "approval_sent_at": now.isoformat(),
         }
         return await self._repo.update_group(group, source_asof=merged)
+
+    async def record_auto_approval(
+        self,
+        proposal_id: uuid.UUID,
+        *,
+        policy_version: str,
+        eligibility: list[dict[str, Any]],
+        outcomes: list[str],
+        now: datetime,
+    ) -> OrderProposal:
+        """Persist machine approval provenance without impersonating a human."""
+        self._require_timezone_aware(now)
+        group = await self._repo.get_group_by_proposal_id(proposal_id, for_update=True)
+        if group is None:
+            raise OrderProposalNotFound(str(proposal_id))
+        source_asof = {
+            **(group.source_asof or {}),
+            "auto_approved": {
+                "policy_version": policy_version,
+                "approved_at": now.isoformat(),
+                "eligibility": eligibility,
+                "outcomes": outcomes,
+            },
+        }
+        return await self._repo.update_group(group, source_asof=source_asof)
+
+    async def record_auto_veto(
+        self,
+        proposal_id: uuid.UUID,
+        *,
+        telegram_user_id: str,
+        outcomes: list[dict[str, Any]],
+        now: datetime,
+    ) -> OrderProposal:
+        self._require_timezone_aware(now)
+        group = await self._repo.get_group_by_proposal_id(proposal_id, for_update=True)
+        if group is None:
+            raise OrderProposalNotFound(str(proposal_id))
+        source_asof = dict(group.source_asof or {})
+        auto = dict(source_asof.get("auto_approved") or {})
+        auto["veto"] = {
+            "telegram_user_id": telegram_user_id,
+            "clicked_at": now.isoformat(),
+            "outcomes": outcomes,
+        }
+        source_asof["auto_approved"] = auto
+        return await self._repo.update_group(group, source_asof=source_asof)
+
+    async def auto_approved_daily_notional(
+        self, group: OrderProposal, *, now: datetime
+    ) -> Decimal:
+        """Return this account's KST-day cumulative auto-approved notional."""
+        self._require_timezone_aware(now)
+        local = now.astimezone(KST)
+        start = local.replace(hour=0, minute=0, second=0, microsecond=0)
+        end = start + timedelta(days=1)
+        account_key = group.broker_account_id or "default"
+        await self._repo.acquire_auto_approve_account_lock(
+            f"order_proposals:auto_approve:{group.account_mode}:{account_key}:{start.date()}"
+        )
+        return await self._repo.auto_approved_notional_between(
+            account_mode=group.account_mode,
+            broker_account_id=group.broker_account_id,
+            start=start,
+            end=end,
+        )
 
     async def acquire_commit_lease(
         self,

--- a/app/services/order_proposals/service.py
+++ b/app/services/order_proposals/service.py
@@ -184,20 +184,31 @@ class OrderProposalsService:
         if not group.target_broker_order_id:
             raise OrderProposalError("target action requires target_broker_order_id")
 
+        await self.acquire_broker_order_mutation_lock(
+            group, group.target_broker_order_id
+        )
+        return True
+
+    async def acquire_broker_order_mutation_lock(
+        self, group: OrderProposal, broker_order_id: str
+    ) -> None:
+        """Serialize any mutation targeting one concrete broker order."""
+        if not broker_order_id.strip():
+            raise OrderProposalError("broker_order_id is required for mutation lock")
+
         lock_key = "|".join(
             (
                 "order_proposal_target",
                 group.account_mode,
                 group.market,
                 group.broker_account_id or "",
-                group.target_broker_order_id,
+                broker_order_id,
             )
         )
         await self._session.execute(
             text("SELECT pg_advisory_xact_lock(hashtextextended(:lock_key, 0))"),
             {"lock_key": lock_key},
         )
-        return True
 
     async def create_proposal(
         self,
@@ -774,6 +785,8 @@ class OrderProposalsService:
         block_reason = proposal_approval_block_reason(group)
         if block_reason is not None:
             raise OrderProposalError(block_reason)
+        if isinstance((group.source_asof or {}).get("auto_approved"), dict):
+            raise OrderProposalError("auto_veto_nonce_requires_vc")
         if group.approval_nonce != nonce:
             raise OrderProposalError("nonce_mismatch")
         if group.approval_nonce_used_at is not None:
@@ -1012,6 +1025,29 @@ class OrderProposalsService:
         source_asof["auto_approved"] = auto
         return await self._repo.update_group(group, source_asof=source_asof)
 
+    async def record_auto_notification_failure(
+        self,
+        proposal_id: uuid.UUID,
+        *,
+        error: str,
+        outcomes: list[dict[str, Any]],
+        now: datetime,
+    ) -> OrderProposal:
+        """Audit compensating cancellation after veto delivery failed."""
+        self._require_timezone_aware(now)
+        group = await self._repo.get_group_by_proposal_id(proposal_id, for_update=True)
+        if group is None:
+            raise OrderProposalNotFound(str(proposal_id))
+        source_asof = dict(group.source_asof or {})
+        auto = dict(source_asof.get("auto_approved") or {})
+        auto["notification_failure"] = {
+            "error": error,
+            "handled_at": now.isoformat(),
+            "outcomes": outcomes,
+        }
+        source_asof["auto_approved"] = auto
+        return await self._repo.update_group(group, source_asof=source_asof)
+
     async def auto_approved_daily_notional(
         self, group: OrderProposal, *, now: datetime
     ) -> Decimal:
@@ -1021,14 +1057,22 @@ class OrderProposalsService:
         start = local.replace(hour=0, minute=0, second=0, microsecond=0)
         end = start + timedelta(days=1)
         account_key = group.broker_account_id or "default"
-        await self._repo.acquire_auto_approve_account_lock(
-            f"order_proposals:auto_approve:{group.account_mode}:{account_key}:{start.date()}"
+        await self._repo.acquire_auto_approve_lock(
+            f"order_proposals:auto_approve:{group.account_mode}:{group.market}:"
+            f"{account_key}:{start.date()}"
         )
         return await self._repo.auto_approved_notional_between(
             account_mode=group.account_mode,
+            market=group.market,
             broker_account_id=group.broker_account_id,
             start=start,
             end=end,
+        )
+
+    async def acquire_auto_dispatch_lock(self, proposal_id: uuid.UUID) -> None:
+        """Serialize dispatch attempts for one proposal across processes."""
+        await self._repo.acquire_auto_approve_lock(
+            f"order_proposals:auto_dispatch:{proposal_id}"
         )
 
     async def acquire_commit_lease(

--- a/app/services/order_proposals/telegram_callback.py
+++ b/app/services/order_proposals/telegram_callback.py
@@ -44,6 +44,7 @@ import secrets
 import uuid
 from collections.abc import Callable
 from datetime import datetime
+from decimal import Decimal
 from typing import Any
 
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -58,6 +59,10 @@ from app.services.order_proposals.approval_message import (
     build_loss_cut_confirmation_message,
     parse_callback_data,
 )
+from app.services.order_proposals.broker_gateway import (
+    cancel_target_order,
+    fetch_target_order,
+)
 from app.services.order_proposals.errors import OrderProposalError
 from app.services.order_proposals.revalidation import (
     RungOutcome,
@@ -69,6 +74,8 @@ logger = logging.getLogger(__name__)
 
 ServiceFactory = Callable[[], Any]
 RevalidateFn = Callable[..., Any]
+TargetCancelFn = Callable[..., Any]
+TargetFetchFn = Callable[..., Any]
 
 # Rung states from which a direct transition to "rejected" is legal (see
 # app/services/order_proposals/state_machine.py). A Telegram deny only ever
@@ -256,6 +263,144 @@ async def _handle_deny(
         "reason": "denied",
         "proposal_id": str(proposal_id),
         "rejected_rungs": rejected_rungs,
+    }
+
+
+async def _handle_auto_veto(
+    *,
+    session: AsyncSession,
+    service: OrderProposalsService,
+    proposal_id: uuid.UUID,
+    nonce: str,
+    now: datetime,
+    notifier: Any,
+    chat_id: Any,
+    message_id: int | None,
+    telegram_user_id: str,
+    cancel_fn: TargetCancelFn,
+    fetch_fn: TargetFetchFn,
+) -> dict[str, Any]:
+    """Cancel every still-open auto-submitted rung and converge evidence."""
+    try:
+        await service.consume_auto_veto_nonce(proposal_id, nonce, now=now)
+    except OrderProposalError as exc:
+        await session.commit()
+        return {"handled": False, "reason": str(exc), "proposal_id": str(proposal_id)}
+
+    group, rungs = await service.get_proposal(proposal_id)
+    outcomes: list[dict[str, Any]] = []
+    saw_filled = False
+    saw_failure = False
+    cancellable = {"acked", "resting", "partially_filled", "unverified"}
+    for rung in rungs:
+        if rung.state == "filled":
+            saw_filled = True
+            outcomes.append({"rung_index": rung.rung_index, "result": "filled"})
+            continue
+        if rung.state == "cancelled":
+            outcomes.append({"rung_index": rung.rung_index, "result": "cancelled"})
+            continue
+        if rung.state not in cancellable or not rung.broker_order_id:
+            saw_failure = True
+            outcomes.append(
+                {"rung_index": rung.rung_index, "result": "not_cancellable"}
+            )
+            continue
+
+        cancel_error: str | None = None
+        try:
+            cancel_result = await cancel_fn(
+                order_id=rung.broker_order_id,
+                symbol=group.symbol,
+                market=group.market,
+                account_mode=group.account_mode,
+            )
+            if (
+                not isinstance(cancel_result, dict)
+                or cancel_result.get("success") is not True
+            ):
+                cancel_error = str(
+                    cancel_result.get("error") or "cancel_rejected"
+                    if isinstance(cancel_result, dict)
+                    else "cancel_rejected"
+                )
+        except Exception as exc:  # noqa: BLE001 - confirm state after ambiguity
+            cancel_error = str(exc)
+
+        try:
+            snapshot = await fetch_fn(
+                order_id=rung.broker_order_id,
+                symbol=group.symbol,
+                market=group.market,
+                account_mode=group.account_mode,
+                now=now,
+            )
+            status = snapshot.status
+        except Exception as exc:  # noqa: BLE001 - audit explicit uncertainty
+            status = None
+            cancel_error = cancel_error or str(exc)
+
+        if status == "cancelled":
+            await service.record_cancelled(
+                proposal_id,
+                rung.rung_index,
+                broker_order_id=rung.broker_order_id,
+                now=now,
+            )
+            outcomes.append({"rung_index": rung.rung_index, "result": "cancelled"})
+        elif status == "filled":
+            await service.transition_rung(
+                proposal_id,
+                rung.rung_index,
+                new_state="filled",
+                broker_order_id=rung.broker_order_id,
+                filled_qty=Decimal(rung.quantity),
+                validated_at=now,
+                updated_at=now,
+            )
+            saw_filled = True
+            outcomes.append({"rung_index": rung.rung_index, "result": "filled"})
+        else:
+            saw_failure = True
+            outcomes.append(
+                {
+                    "rung_index": rung.rung_index,
+                    "result": "cancel_failed",
+                    "broker_status": status,
+                    "error": cancel_error,
+                }
+            )
+
+    await service.record_auto_veto(
+        proposal_id,
+        telegram_user_id=telegram_user_id,
+        outcomes=outcomes,
+        now=now,
+    )
+    await session.commit()
+
+    if saw_filled:
+        reason = "auto_veto_filled"
+        text = "✅ 체결됨 — 취소 시점에 이미 체결된 주문입니다."
+    elif saw_failure:
+        reason = "auto_veto_failed"
+        text = "⚠️ 취소 실패 — 브로커 주문 상태를 확인해 주세요."
+    else:
+        reason = "auto_veto_cancelled"
+        text = "🛑 취소됨"
+    if message_id is not None:
+        await _safe_edit_message(
+            notifier,
+            chat_id,
+            message_id,
+            text,
+            reply_markup={"inline_keyboard": []},
+        )
+    return {
+        "handled": True,
+        "reason": reason,
+        "proposal_id": str(proposal_id),
+        "outcomes": outcomes,
     }
 
 
@@ -494,6 +639,8 @@ async def handle_callback_update(
     notifier: Any = None,
     revalidate_fn: RevalidateFn = revalidate_and_submit,
     loss_cut_preview_fn: RevalidateFn | None = None,
+    veto_cancel_fn: TargetCancelFn = cancel_target_order,
+    veto_fetch_fn: TargetFetchFn = fetch_target_order,
 ) -> dict[str, Any]:
     """Handle one Telegram webhook update. Never raises (fail-closed)."""
     callback_query_id: str | None = None
@@ -534,7 +681,23 @@ async def handle_callback_update(
                 await session.commit()
                 return {"handled": False, "reason": "proposal_not_found"}
 
-            if action == "dn":
+            if action == "vc":
+                result = await _handle_auto_veto(
+                    session=session,
+                    service=service,
+                    proposal_id=proposal_id,
+                    nonce=nonce,
+                    now=now,
+                    notifier=active_notifier,
+                    chat_id=chat_id,
+                    message_id=message_id,
+                    telegram_user_id=(
+                        str(telegram_user_id) if telegram_user_id is not None else ""
+                    ),
+                    cancel_fn=veto_cancel_fn,
+                    fetch_fn=veto_fetch_fn,
+                )
+            elif action == "dn":
                 result = await _handle_deny(
                     session=session,
                     service=service,

--- a/app/services/order_proposals/telegram_callback.py
+++ b/app/services/order_proposals/telegram_callback.py
@@ -44,7 +44,6 @@ import secrets
 import uuid
 from collections.abc import Callable
 from datetime import datetime
-from decimal import Decimal
 from typing import Any
 
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -58,6 +57,12 @@ from app.services.order_proposals.approval_message import (
     build_buying_power_shortfall_text,
     build_loss_cut_confirmation_message,
     parse_callback_data,
+)
+from app.services.order_proposals.auto_veto import (
+    TargetCancelFn,
+    TargetFetchFn,
+    acquire_auto_veto_locks,
+    cancel_auto_submitted_rungs,
 )
 from app.services.order_proposals.broker_gateway import (
     cancel_target_order,
@@ -74,8 +79,6 @@ logger = logging.getLogger(__name__)
 
 ServiceFactory = Callable[[], Any]
 RevalidateFn = Callable[..., Any]
-TargetCancelFn = Callable[..., Any]
-TargetFetchFn = Callable[..., Any]
 
 # Rung states from which a direct transition to "rejected" is legal (see
 # app/services/order_proposals/state_machine.py). A Telegram deny only ever
@@ -281,6 +284,10 @@ async def _handle_auto_veto(
     fetch_fn: TargetFetchFn,
 ) -> dict[str, Any]:
     """Cancel every still-open auto-submitted rung and converge evidence."""
+    group, rungs = await service.get_proposal(proposal_id)
+    # Match replace/cancel lock ordering: broker target advisory locks before
+    # the proposal-row nonce lock, with stable ordering for multi-rung groups.
+    await acquire_auto_veto_locks(service=service, group=group, rungs=rungs)
     try:
         await service.consume_auto_veto_nonce(proposal_id, nonce, now=now)
     except OrderProposalError as exc:
@@ -288,88 +295,19 @@ async def _handle_auto_veto(
         return {"handled": False, "reason": str(exc), "proposal_id": str(proposal_id)}
 
     group, rungs = await service.get_proposal(proposal_id)
-    outcomes: list[dict[str, Any]] = []
-    saw_filled = False
-    saw_failure = False
-    cancellable = {"acked", "resting", "partially_filled", "unverified"}
-    for rung in rungs:
-        if rung.state == "filled":
-            saw_filled = True
-            outcomes.append({"rung_index": rung.rung_index, "result": "filled"})
-            continue
-        if rung.state == "cancelled":
-            outcomes.append({"rung_index": rung.rung_index, "result": "cancelled"})
-            continue
-        if rung.state not in cancellable or not rung.broker_order_id:
-            saw_failure = True
-            outcomes.append(
-                {"rung_index": rung.rung_index, "result": "not_cancellable"}
-            )
-            continue
-
-        cancel_error: str | None = None
-        try:
-            cancel_result = await cancel_fn(
-                order_id=rung.broker_order_id,
-                symbol=group.symbol,
-                market=group.market,
-                account_mode=group.account_mode,
-            )
-            if (
-                not isinstance(cancel_result, dict)
-                or cancel_result.get("success") is not True
-            ):
-                cancel_error = str(
-                    cancel_result.get("error") or "cancel_rejected"
-                    if isinstance(cancel_result, dict)
-                    else "cancel_rejected"
-                )
-        except Exception as exc:  # noqa: BLE001 - confirm state after ambiguity
-            cancel_error = str(exc)
-
-        try:
-            snapshot = await fetch_fn(
-                order_id=rung.broker_order_id,
-                symbol=group.symbol,
-                market=group.market,
-                account_mode=group.account_mode,
-                now=now,
-            )
-            status = snapshot.status
-        except Exception as exc:  # noqa: BLE001 - audit explicit uncertainty
-            status = None
-            cancel_error = cancel_error or str(exc)
-
-        if status == "cancelled":
-            await service.record_cancelled(
-                proposal_id,
-                rung.rung_index,
-                broker_order_id=rung.broker_order_id,
-                now=now,
-            )
-            outcomes.append({"rung_index": rung.rung_index, "result": "cancelled"})
-        elif status == "filled":
-            await service.transition_rung(
-                proposal_id,
-                rung.rung_index,
-                new_state="filled",
-                broker_order_id=rung.broker_order_id,
-                filled_qty=Decimal(rung.quantity),
-                validated_at=now,
-                updated_at=now,
-            )
-            saw_filled = True
-            outcomes.append({"rung_index": rung.rung_index, "result": "filled"})
-        else:
-            saw_failure = True
-            outcomes.append(
-                {
-                    "rung_index": rung.rung_index,
-                    "result": "cancel_failed",
-                    "broker_status": status,
-                    "error": cancel_error,
-                }
-            )
+    outcomes = await cancel_auto_submitted_rungs(
+        service=service,
+        group=group,
+        rungs=rungs,
+        now=now,
+        cancel_fn=cancel_fn,
+        fetch_fn=fetch_fn,
+    )
+    saw_filled = any(outcome["result"] == "filled" for outcome in outcomes)
+    saw_failure = any(
+        outcome["result"] in {"cancel_failed", "not_cancellable"}
+        for outcome in outcomes
+    )
 
     await service.record_auto_veto(
         proposal_id,

--- a/config/trading_policy.yaml
+++ b/config/trading_policy.yaml
@@ -2,9 +2,9 @@
 # Seeded verbatim from docs/playbooks/trading-decision-playbook.md policy_keys
 # (captured 2026-07-02). Edited by operator PR ONLY — there is no write tool.
 # Repo is public; exposing these values is an accepted decision.
-version: "2026-07-12.1"
-captured_as_of: "2026-07-12"
-source: "ROB-643/751 baseline; ROB-839 crypto-recheck reports 2026-07-11/12 (sonnet, opus, fable)"
+version: "2026-07-14.1"
+captured_as_of: "2026-07-14"
+source: "ROB-643/751 baseline; ROB-839 crypto-recheck reports 2026-07-11/12; ROB-871 resting auto-approve seed"
 
 authority:
   scope: judgment_policy_only
@@ -16,6 +16,20 @@ authority:
     - "symbol_trade_settings — live per-symbol sizing (separate authority)"
     - "sell_conditions — dormant/test-only (not authoritative)"
     - "trade_profile — dead since ROB-488 (not revived)"
+
+# ROB-871 — master-gated by ORDER_PROPOSALS_AUTO_APPROVE=false. Caps use the
+# settlement currency for each market (KRW for kr/crypto, USD for us).
+order_proposals:
+  auto_approve:
+    min_distance_pct: 3
+    per_order_cap:
+      kr: 200000
+      us: 150
+      crypto: 100000
+    daily_cap:
+      kr: 500000
+      us: 400
+      crypto: 300000
 
 # Raw-sector -> cluster grouping for the concentration cap. A member matches a
 # symbol's symbol_sectors label (name_kr / name_en / source_key) when the member

--- a/docs/runbooks/order-proposals.md
+++ b/docs/runbooks/order-proposals.md
@@ -465,6 +465,10 @@ successful submit sends a summary tagged `auto:policy@<version>` with a
 single-use `취소` button. Veto invokes the existing broker cancellation adapter,
 re-fetches broker status, writes `source_asof.auto_approved.veto`, and edits the
 message to `취소됨`, `체결됨`, or an explicit failure.
+If the post-submit Telegram message cannot be delivered, dispatch immediately
+uses the same cancel-and-confirm routine and records its result under
+`source_asof.auto_approved.notification_failure`; it never silently leaves a
+resting order without attempting compensating cancellation.
 
 Canary sequence: deploy with the flag off; enable only the smallest checked-in
 caps and confirm one resting order plus veto; verify DB/broker convergence;

--- a/docs/runbooks/order-proposals.md
+++ b/docs/runbooks/order-proposals.md
@@ -3,8 +3,9 @@
 ## Purpose
 
 `review.order_proposals` + `review.order_proposal_rungs` is the SOT (source-of-truth)
-ledger for **proposed** orders awaiting human approval, prior to any broker
-submission. It replaces ad-hoc "propose in chat, submit blind" flows with a
+ledger for **proposed** orders awaiting human approval or the default-off
+ROB-871 resting-order policy, prior to any broker submission. It replaces
+ad-hoc "propose in chat, submit blind" flows with a
 persisted, replayable record: one `order_proposals` row per proposal group
 (symbol/side/market/account context + thesis/rationale), and one or more
 `order_proposal_rungs` child rows (one per execution ladder rung — price/qty
@@ -39,8 +40,8 @@ proposal execution and ROB-858 Toss loss-cut/reconcile convergence:
 
 There is still **no**
 `order_proposal_approve` / `order_proposal_submit` MCP tool in any slice —
-the only path from a proposal row to a live broker order is the Telegram
-button flow described below.
+the only paths from a proposal row to a live broker order are the Telegram
+button flow and ROB-871's independently default-off resting-class dispatch.
 
 See the full design in
 [`docs/plans/2026-07-10-rob-816-order-proposals-telegram-approval-implementation-plan.md`](../plans/2026-07-10-rob-816-order-proposals-telegram-approval-implementation-plan.md).
@@ -54,16 +55,16 @@ See the full design in
   AST guard test (`tests/services/order_proposals/test_no_repository_imports.py`)
   enforces this. Direct SQL INSERT/UPDATE/DELETE against `review.order_proposals`
   / `review.order_proposal_rungs` is not permitted.
-- **Proposal creation is NOT a broker mutation.** `order_proposal_create`
-  persists a row describing an intended order; it never calls a broker
-  client, never submits, and never touches `_place_order_impl` or any
-  existing order-send path.
-- **No submit without Telegram approval.** There is deliberately no
+- **Proposal persistence precedes every broker mutation.**
+  `order_proposal_create` first commits the intended order. With
+  `ORDER_PROPOSALS_AUTO_APPROVE=false` (default), creation does not submit.
+  When the independent ROB-871 gate is enabled, post-create dispatch may call
+  the same fresh revalidation path for a policy-qualified resting order.
+- **No public submit tool.** There is deliberately no
   `order_proposal_approve` / `order_proposal_submit` MCP tool in either PR.
-  The only way a proposal reaches a live broker order is the Telegram
-  approve/deny flow shipped in PR 2 (`app/services/order_proposals/telegram_callback.py`
-  → `app/services/order_proposals/revalidation.py`). See "Telegram Approval
-  — Activation" below for how to turn it on.
+  A proposal reaches a broker only through the Telegram approve flow or the
+  default-off ROB-871 resting-class dispatch; both reuse
+  `app/services/order_proposals/revalidation.py`.
 - **Accepted != filled.** A broker ACK (`record_ack`) or resting-order
   confirmation (`record_resting`) is recorded on the rung as `acked` /
   `resting` — never as a fill. The Telegram approval flow itself never writes
@@ -439,11 +440,36 @@ The approval settings live in `app/core/config.py`:
 | Env var | Default | Purpose |
 |---|---|---|
 | `ORDER_PROPOSALS_TELEGRAM_ENABLED` | `false` | Master gate. When `false`: `order_proposal_create` never dispatches an approval message (best-effort no-op — see `order_proposal_tools.py`), and `POST /trading/api/telegram/callback` returns `503 {"error": "order_proposals_telegram_disabled", ...}` without touching the DB. |
+| `ORDER_PROPOSALS_AUTO_APPROVE` | `false` | Independent ROB-871 master gate. When true, eligible `limit` + `place` + no-exit-intent proposals use the fresh revalidation/submit path before human dispatch. Any policy/guard/cap/reconfirmation miss falls back to the existing approval message. Thresholds come from `config/trading_policy.yaml::order_proposals.auto_approve`; the policy version and exact decision evidence are stored in `source_asof.auto_approved`. |
 | `ORDER_PROPOSALS_TELEGRAM_BOT_TOKEN` | `""` | Defined in the config schema for this feature, but **not currently read by any runtime code path** — confirmed by repo-wide grep (only referenced in the plan doc and this config declaration). The Telegram Bot API calls that actually send/edit/answer approval messages go through the existing process-wide `TradeNotifier` singleton, which is configured from the **pre-existing** `TELEGRAM_TOKEN` / `TELEGRAM_CHAT_IDS_STR` settings (`app/monitoring/trade_notifier/runtime.py::configure_trade_notifier_from_settings`) — the same bot/token already used for every other trade notification in this repo (Task 10's "reuse `TradeNotifier`, no regression" design). **Set `TELEGRAM_TOKEN` (not this variable) to the BotFather token that should actually send approval messages.** |
 | `ORDER_PROPOSALS_TELEGRAM_TOKEN` | `""` | The webhook **secret token** — a value you choose, registered with Telegram via `setWebhook`'s `secret_token` param (see "Telegram Bot Setup" below). Distinct from the bot token. Gates every request under `/trading/api/telegram/` in `AuthMiddleware` (`TELEGRAM_CALLBACK_PATH_PREFIX`). |
 | `ORDER_PROPOSALS_TELEGRAM_TOKEN_HEADER` | `X-Telegram-Bot-Api-Secret-Token` | The HTTP header Telegram sends the secret token back in. Telegram's own webhook mechanism hard-codes this header name — only override if you're proxying through something that renames headers. |
 | `ORDER_PROPOSALS_TELEGRAM_CHAT_ALLOWLIST_STR` | `""` | Comma-separated Telegram chat IDs, parsed via `settings.order_proposals_telegram_chat_allowlist`. Does double duty: (1) `handle_callback_update` uses the full list as the approve/deny **authz allowlist** (any chat not in it gets `chat_not_allowed`); (2) `send_proposal_for_approval` (`dispatch.py`) sends the initial approval message to `allowlist[0]` only — the **first** entry. Empty means no chat is allowed to approve/deny and no message is ever dispatched (`dispatch.py` no-ops). This is a distinct setting from the pre-existing `TELEGRAM_CHAT_IDS_STR` (used by `TradeNotifier`'s other, non-approval notifications) — the two lists are not required to match. |
 | `ORDER_PROPOSALS_SUBMIT_AGENT_ID` | `""` | Caller identity temporarily bound only during Telegram approval revalidation/submission. There is no default submit identity. The operator must set a non-blank value and add the exact same trimmed identity to `LOSS_CUT_ALLOWED_AGENT_IDS`. Missing or whitespace-only input becomes no identity and keeps `loss_cut` fail-closed. Never solve this with a hardcoded UUID. |
+
+### Resting-class automatic submission (ROB-871)
+
+The checked-in policy seed is 3% minimum distance. Per-order/daily settlement-
+currency caps are KR `200,000/500,000 KRW`, US `150/400 USD`, and crypto
+`100,000/300,000 KRW`. The env gate remains the master switch.
+
+Eligibility is evaluated from the fresh dry-run preview immediately before
+submit: buy limit at or below `current × (1-distance)`, or sell limit at or
+above `current × (1+distance)` after the existing average-cost loss guard.
+Only account/market pairs with the existing target-order cancel adapter are
+eligible (`kis_live` equities and `upbit` crypto); Toss and multi-rung ladders
+remain human-gated so the veto and all-or-human fallback stay lossless.
+Daily usage is the KST-day sum of DB rungs whose group already carries an
+`auto_approved` audit; the account/day check is transaction-serialized. A
+successful submit sends a summary tagged `auto:policy@<version>` with a
+single-use `취소` button. Veto invokes the existing broker cancellation adapter,
+re-fetches broker status, writes `source_asof.auto_approved.veto`, and edits the
+message to `취소됨`, `체결됨`, or an explicit failure.
+
+Canary sequence: deploy with the flag off; enable only the smallest checked-in
+caps and confirm one resting order plus veto; verify DB/broker convergence;
+then raise caps in a reviewed policy PR. Never enable by changing both the env
+gate and caps broadly in the same operational step.
 
 For a deployment that will approve loss cuts, configure both sides of the
 identity binding with an operator-managed identity (placeholder shown; do not

--- a/tests/mcp_server/test_operating_briefing_policy_version.py
+++ b/tests/mcp_server/test_operating_briefing_policy_version.py
@@ -51,5 +51,10 @@ async def test_briefing_includes_policy_version(monkeypatch):
 
     resp = await ob.get_operating_briefing_impl(market="kr")
     assert "policy_version" in resp
-    assert resp["policy_version"]["version"] == "2026-07-12.1"
+    # Compare against the loaded policy document (single source of truth) —
+    # a hardcoded version literal broke on every policy bump.
+    from app.services.trading_policy_service import load_trading_policy
+
+    document = load_trading_policy()
+    assert resp["policy_version"]["version"] == document.version
     assert resp["policy_version"]["content_hash"]

--- a/tests/mcp_server/test_trading_policy_tool.py
+++ b/tests/mcp_server/test_trading_policy_tool.py
@@ -12,7 +12,7 @@ from tests._mcp_tooling_support import DummyMCP
 async def test_get_trading_policy_returns_thresholds_and_version():
     out = await get_trading_policy(market="kr", lane="buy")
     assert out["success"] is True
-    assert out["version"] == "2026-07-12.1"
+    assert out["version"] == "2026-07-14.1"
     assert out["content_hash"]
     assert out["thresholds"]["portfolio.sector_cluster_cap_pct"]["value"] == 10
     assert out["decision_rules"] == {}
@@ -23,7 +23,7 @@ async def test_get_trading_policy_returns_crypto_market_rules_and_stamp():
     out = await get_trading_policy(market="crypto", lane="buy")
 
     assert out["success"] is True
-    assert out["version"] == "2026-07-12.1"
+    assert out["version"] == "2026-07-14.1"
     assert len(out["content_hash"]) == 12
     assert out["market_rules"]["recovery_gate"]["min_conditions_met"] == 2
     assert out["market_rules"]["no_chasing"]["daily_change_pct_threshold"] is None

--- a/tests/schemas/test_trading_policy_schema.py
+++ b/tests/schemas/test_trading_policy_schema.py
@@ -15,7 +15,7 @@ def _raw() -> dict:
 
 def test_shipped_config_validates():
     doc = TradingPolicyDocument.model_validate(_raw())
-    assert doc.version == "2026-07-12.1"
+    assert doc.version == "2026-07-14.1"
     # verbatim seed values from the playbook policy_keys
     assert doc.thresholds["portfolio.sector_cluster_cap_pct"].value == 10
     assert doc.thresholds["sell.loss_guard_min_multiple"].value == 1.01
@@ -33,6 +33,17 @@ def test_shipped_config_validates():
     ]
     assert trim_rule.tiers[1].conditions["resistance_near_pct_max"] == 2
     assert trim_rule.tie_breaks["sell.upside_place_max_pct"] == "size_limit_only"
+
+
+def test_auto_approve_policy_has_conservative_market_caps():
+    auto = TradingPolicyDocument.model_validate(_raw()).order_proposals.auto_approve
+
+    assert auto.min_distance_pct > 0
+    assert set(auto.per_order_cap) == {"kr", "us", "crypto"}
+    assert set(auto.daily_cap) == {"kr", "us", "crypto"}
+    for market, per_order in auto.per_order_cap.items():
+        assert per_order > 0
+        assert auto.daily_cap[market] >= per_order
 
 
 def test_crypto_market_rules_preserve_report_derived_and_null_thresholds():

--- a/tests/services/order_proposals/test_auto_approve.py
+++ b/tests/services/order_proposals/test_auto_approve.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+from types import SimpleNamespace
+
+import pytest
+
+from app.services.order_proposals import OrderProposalsService
+from app.services.order_proposals.auto_approve import (
+    AutoApproveLimits,
+    evaluate_auto_approve_eligibility,
+)
+from app.services.order_proposals.service import RungInput
+
+
+def _group(**overrides):
+    values = {
+        "market": "equity_kr",
+        "account_mode": "kis_live",
+        "broker_account_id": "acct-1",
+        "order_type": "limit",
+        "action": "place",
+        "exit_intent": None,
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def _rung(**overrides):
+    values = {
+        "side": "buy",
+        "limit_price": Decimal("97000"),
+        "quantity": Decimal("2"),
+        "notional": None,
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+_LIMITS = AutoApproveLimits(
+    min_distance_pct=Decimal("3"),
+    per_order_cap=Decimal("200000"),
+    daily_cap=Decimal("500000"),
+    policy_version="test-policy",
+)
+
+
+def test_buy_at_distance_and_daily_cap_boundary_is_eligible():
+    decision = evaluate_auto_approve_eligibility(
+        group=_group(),
+        rung=_rung(),
+        preview={"success": True, "current_price": "100000"},
+        limits=_LIMITS,
+        daily_notional=Decimal("306000"),
+    )
+
+    assert decision.eligible is True
+    assert decision.reason == "eligible"
+    assert decision.details["policy_version"] == "test-policy"
+    assert decision.details["daily_notional_after"] == "500000"
+
+
+def test_sell_requires_distance_and_previewed_loss_guard():
+    eligible = evaluate_auto_approve_eligibility(
+        group=_group(),
+        rung=_rung(side="sell", limit_price=Decimal("103000"), quantity=Decimal("1")),
+        preview={"success": True, "current_price": "100000"},
+        limits=_LIMITS,
+        daily_notional=Decimal("0"),
+    )
+    blocked = evaluate_auto_approve_eligibility(
+        group=_group(),
+        rung=_rung(side="sell", limit_price=Decimal("103000"), quantity=Decimal("1")),
+        preview={
+            "success": False,
+            "current_price": "100000",
+            "error": "sell price below average purchase price floor",
+        },
+        limits=_LIMITS,
+        daily_notional=Decimal("0"),
+    )
+
+    assert eligible.eligible is True
+    assert eligible.details["loss_guard"] == "preview_passed"
+    assert blocked.eligible is False
+    assert blocked.reason == "preview_guard_failed"
+
+
+@pytest.mark.parametrize(
+    ("group_overrides", "rung_overrides", "expected_reason"),
+    [
+        ({"order_type": "market"}, {}, "order_type_not_limit"),
+        ({"action": "replace"}, {}, "action_not_place"),
+        ({"action": "cancel"}, {}, "action_not_place"),
+        ({"exit_intent": "loss_cut"}, {"side": "sell"}, "exit_intent_present"),
+        ({"account_mode": "toss_live"}, {}, "account_not_veto_capable"),
+        ({}, {"limit_price": Decimal("98000")}, "distance_below_minimum"),
+        ({}, {"quantity": Decimal("3")}, "per_order_cap_exceeded"),
+    ],
+)
+def test_ineligible_orders_fail_closed(
+    group_overrides, rung_overrides, expected_reason
+):
+    decision = evaluate_auto_approve_eligibility(
+        group=_group(**group_overrides),
+        rung=_rung(**rung_overrides),
+        preview={"success": True, "current_price": "100000"},
+        limits=_LIMITS,
+        daily_notional=Decimal("0"),
+    )
+
+    assert decision.eligible is False
+    assert decision.reason == expected_reason
+
+
+def test_daily_cap_one_unit_over_boundary_is_ineligible():
+    decision = evaluate_auto_approve_eligibility(
+        group=_group(),
+        rung=_rung(),
+        preview={"success": True, "current_price": "100000"},
+        limits=_LIMITS,
+        daily_notional=Decimal("306001"),
+    )
+
+    assert decision.eligible is False
+    assert decision.reason == "daily_cap_exceeded"
+
+
+@pytest.mark.asyncio
+async def test_daily_notional_uses_auto_approval_time_not_create_time(db_session):
+    service = OrderProposalsService(db_session)
+    now = datetime.now(UTC)
+    account_id = f"daily-{uuid.uuid4()}"
+
+    for approved_at in (now, now - timedelta(days=1)):
+        await service.create_proposal(
+            symbol="005930",
+            market="equity_kr",
+            account_mode="kis_live",
+            broker_account_id=account_id,
+            side="buy",
+            order_type="limit",
+            proposer="p",
+            rungs=[RungInput(0, "buy", Decimal("1"), Decimal("200000"), None)],
+            source_asof={
+                "auto_approved": {
+                    "policy_version": "test-policy",
+                    "approved_at": approved_at.isoformat(),
+                    "eligibility": [],
+                    "outcomes": ["submitted_resting"],
+                }
+            },
+        )
+    await db_session.commit()
+    probe = await service.create_proposal(
+        symbol="000660",
+        market="equity_kr",
+        account_mode="kis_live",
+        broker_account_id=account_id,
+        side="buy",
+        order_type="limit",
+        proposer="p",
+        rungs=[RungInput(0, "buy", Decimal("1"), Decimal("1"), None)],
+    )
+
+    total = await service.auto_approved_daily_notional(probe, now=now)
+
+    assert total == Decimal("200000")

--- a/tests/services/order_proposals/test_auto_approve.py
+++ b/tests/services/order_proposals/test_auto_approve.py
@@ -153,6 +153,24 @@ async def test_daily_notional_uses_auto_approval_time_not_create_time(db_session
                 }
             },
         )
+    await service.create_proposal(
+        symbol="AAPL",
+        market="equity_us",
+        account_mode="kis_live",
+        broker_account_id=account_id,
+        side="buy",
+        order_type="limit",
+        proposer="p",
+        rungs=[RungInput(0, "buy", Decimal("1"), Decimal("100"), None)],
+        source_asof={
+            "auto_approved": {
+                "policy_version": "test-policy",
+                "approved_at": now.isoformat(),
+                "eligibility": [],
+                "outcomes": ["submitted_resting"],
+            }
+        },
+    )
     await db_session.commit()
     probe = await service.create_proposal(
         symbol="000660",

--- a/tests/services/order_proposals/test_dispatch.py
+++ b/tests/services/order_proposals/test_dispatch.py
@@ -7,7 +7,11 @@ from decimal import Decimal
 import pytest
 
 from app.services.order_proposals import OrderProposalsService
-from app.services.order_proposals.dispatch import send_proposal_for_approval
+from app.services.order_proposals.dispatch import (
+    dispatch_proposal,
+    send_proposal_for_approval,
+)
+from app.services.order_proposals.revalidation import RungOutcome
 from app.services.order_proposals.service import RungInput
 
 CHAT_ID = "chat-99"
@@ -44,6 +48,7 @@ async def _seed_proposal(
     target_broker_order_id=None,
     target_order_snapshot=None,
     rungs=None,
+    broker_account_id=None,
 ):
     service = OrderProposalsService(db_session)
     group = await service.create_proposal(
@@ -58,6 +63,7 @@ async def _seed_proposal(
         action=action,
         target_broker_order_id=target_broker_order_id,
         target_order_snapshot=target_order_snapshot,
+        broker_account_id=broker_account_id,
     )
     await db_session.commit()
     return group
@@ -220,3 +226,200 @@ async def test_send_proposal_for_approval_send_failure_returns_none_but_nonce_co
     refreshed, _ = await service.get_proposal(group.proposal_id)
     assert refreshed.approval_nonce is not None
     assert refreshed.source_asof is None
+
+
+@pytest.mark.asyncio
+async def test_dispatch_auto_gate_off_preserves_human_approval_flow(
+    monkeypatch, db_session
+):
+    from app.core.config import settings
+
+    monkeypatch.setattr(settings, "ORDER_PROPOSALS_AUTO_APPROVE", False)
+    monkeypatch.setattr(
+        settings, "ORDER_PROPOSALS_TELEGRAM_CHAT_ALLOWLIST_STR", CHAT_ID
+    )
+    group = await _seed_proposal(db_session)
+    notifier = _FakeNotifier()
+
+    async def must_not_revalidate(**kwargs):
+        raise AssertionError("auto revalidation must stay disabled")
+
+    await dispatch_proposal(
+        group.proposal_id,
+        notifier=notifier,
+        now=datetime.now(UTC),
+        service_factory=_session_factory(db_session),
+        revalidate_fn=must_not_revalidate,
+    )
+
+    assert "주문 제안 승인" in notifier.sent_messages[0][0]
+    _group, rungs = await OrderProposalsService(db_session).get_proposal(
+        group.proposal_id
+    )
+    assert rungs[0].state == "pending_approval"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("side", ["buy", "sell"])
+async def test_dispatch_auto_eligible_buy_or_sell_rests_without_approval(
+    monkeypatch, db_session, side
+):
+    from app.core.config import settings
+
+    monkeypatch.setattr(settings, "ORDER_PROPOSALS_AUTO_APPROVE", True)
+    monkeypatch.setattr(
+        settings, "ORDER_PROPOSALS_TELEGRAM_CHAT_ALLOWLIST_STR", CHAT_ID
+    )
+    service = OrderProposalsService(db_session)
+    limit_price = Decimal("97000") if side == "buy" else Decimal("103000")
+    group = await service.create_proposal(
+        symbol="005930",
+        market="equity_kr",
+        account_mode="kis_live",
+        side=side,
+        order_type="limit",
+        proposer="p",
+        thesis="resting entry",
+        broker_account_id=f"dispatch-auto-{side}",
+        rungs=[RungInput(0, side, Decimal("1"), limit_price, None)],
+    )
+    await db_session.commit()
+
+    async def fake_revalidate(*, service, proposal_id, now, eligibility_gate):
+        fresh_group, rungs = await service.get_proposal(proposal_id)
+        decision = await eligibility_gate(
+            group=fresh_group,
+            rung=rungs[0],
+            preview={
+                "success": True,
+                "current_price": "100000",
+                "price": str(limit_price),
+                "quantity": "1",
+            },
+            now=now,
+        )
+        assert decision.eligible is True
+        await service.transition_rung(proposal_id, 0, new_state="revalidating")
+        await service.transition_rung(proposal_id, 0, new_state="approved")
+        await service.transition_rung(proposal_id, 0, new_state="submitting")
+        await service.record_resting(
+            proposal_id,
+            0,
+            broker_order_id="broker-1",
+            correlation_id="corr-1",
+            idempotency_key="idem-1",
+            approval_hash_digest="digest-1",
+            now=now,
+        )
+        return [RungOutcome(0, "submitted_resting", {})]
+
+    notifier = _FakeNotifier(message_id=8123)
+    await dispatch_proposal(
+        group.proposal_id,
+        notifier=notifier,
+        now=datetime(2026, 7, 14, 1, 0, tzinfo=UTC),
+        service_factory=_session_factory(db_session),
+        revalidate_fn=fake_revalidate,
+    )
+
+    refreshed, rungs = await service.get_proposal(group.proposal_id)
+    assert rungs[0].state == "resting"
+    assert refreshed.approved_by_telegram_user_id is None
+    assert refreshed.source_asof["auto_approved"]["policy_version"] == "2026-07-14.1"
+    text, keyboard, _chat_id = notifier.sent_messages[0]
+    assert "자동 접수됨" in text
+    assert "auto:policy@2026-07-14.1" in text
+    assert keyboard["inline_keyboard"][0][0]["text"] == "취소"
+    assert keyboard["inline_keyboard"][0][0]["callback_data"].startswith("vc:")
+
+
+@pytest.mark.asyncio
+async def test_dispatch_auto_ineligible_degrades_to_human_approval(
+    monkeypatch, db_session
+):
+    from app.core.config import settings
+
+    monkeypatch.setattr(settings, "ORDER_PROPOSALS_AUTO_APPROVE", True)
+    monkeypatch.setattr(
+        settings, "ORDER_PROPOSALS_TELEGRAM_CHAT_ALLOWLIST_STR", CHAT_ID
+    )
+    group = await _seed_proposal(
+        db_session, broker_account_id="dispatch-auto-ineligible"
+    )
+
+    async def fake_revalidate(*, service, proposal_id, now, eligibility_gate):
+        fresh_group, rungs = await service.get_proposal(proposal_id)
+        decision = await eligibility_gate(
+            group=fresh_group,
+            rung=rungs[0],
+            preview={
+                "success": True,
+                "current_price": "101",
+                "price": "100",
+                "quantity": "10",
+            },
+            now=now,
+        )
+        assert decision.reason == "distance_below_minimum"
+        return [
+            RungOutcome(
+                0,
+                "approval_required",
+                {"reason": decision.reason},
+            )
+        ]
+
+    notifier = _FakeNotifier()
+    await dispatch_proposal(
+        group.proposal_id,
+        notifier=notifier,
+        now=datetime(2026, 7, 14, 1, 0, tzinfo=UTC),
+        service_factory=_session_factory(db_session),
+        revalidate_fn=fake_revalidate,
+    )
+
+    refreshed, rungs = await OrderProposalsService(db_session).get_proposal(
+        group.proposal_id
+    )
+    assert rungs[0].state == "pending_approval"
+    assert "auto_approved" not in (refreshed.source_asof or {})
+    assert "주문 제안 승인" in notifier.sent_messages[0][0]
+
+
+@pytest.mark.asyncio
+async def test_dispatch_auto_861_reconfirm_degrades_without_losing_state(
+    monkeypatch, db_session
+):
+    from app.core.config import settings
+
+    monkeypatch.setattr(settings, "ORDER_PROPOSALS_AUTO_APPROVE", True)
+    monkeypatch.setattr(
+        settings, "ORDER_PROPOSALS_TELEGRAM_CHAT_ALLOWLIST_STR", CHAT_ID
+    )
+    group = await _seed_proposal(db_session, broker_account_id="dispatch-auto-861")
+
+    async def fake_revalidate(*, service, proposal_id, now, eligibility_gate):
+        await service.transition_rung(proposal_id, 0, new_state="revalidating")
+        await service.mark_needs_reconfirm(proposal_id, 0, now=now)
+        return [
+            RungOutcome(
+                0,
+                "needs_reconfirm",
+                {"reason": "insufficient_buying_power"},
+            )
+        ]
+
+    notifier = _FakeNotifier()
+    await dispatch_proposal(
+        group.proposal_id,
+        notifier=notifier,
+        now=datetime(2026, 7, 14, 1, 0, tzinfo=UTC),
+        service_factory=_session_factory(db_session),
+        revalidate_fn=fake_revalidate,
+    )
+
+    _refreshed, rungs = await OrderProposalsService(db_session).get_proposal(
+        group.proposal_id
+    )
+    assert rungs[0].state == "needs_reconfirm"
+    assert notifier.sent_messages

--- a/tests/services/order_proposals/test_dispatch.py
+++ b/tests/services/order_proposals/test_dispatch.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import contextlib
+import uuid
 from datetime import UTC, datetime
 from decimal import Decimal
 
@@ -280,7 +281,7 @@ async def test_dispatch_auto_eligible_buy_or_sell_rests_without_approval(
         order_type="limit",
         proposer="p",
         thesis="resting entry",
-        broker_account_id=f"dispatch-auto-{side}",
+        broker_account_id=f"dispatch-auto-{side}-{uuid.uuid4()}",
         rungs=[RungInput(0, side, Decimal("1"), limit_price, None)],
     )
     await db_session.commit()
@@ -331,6 +332,19 @@ async def test_dispatch_auto_eligible_buy_or_sell_rests_without_approval(
     assert "auto:policy@2026-07-14.1" in text
     assert keyboard["inline_keyboard"][0][0]["text"] == "취소"
     assert keyboard["inline_keyboard"][0][0]["callback_data"].startswith("vc:")
+
+    async def duplicate_must_not_revalidate(**kwargs):
+        raise AssertionError("an already-submitted proposal must not dispatch twice")
+
+    duplicate = await dispatch_proposal(
+        group.proposal_id,
+        notifier=notifier,
+        now=datetime(2026, 7, 14, 1, 0, 1, tzinfo=UTC),
+        service_factory=_session_factory(db_session),
+        revalidate_fn=duplicate_must_not_revalidate,
+    )
+    assert duplicate is None
+    assert len(notifier.sent_messages) == 1
 
 
 @pytest.mark.asyncio
@@ -423,3 +437,96 @@ async def test_dispatch_auto_861_reconfirm_degrades_without_losing_state(
     )
     assert rungs[0].state == "needs_reconfirm"
     assert notifier.sent_messages
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("notify_failure", ["none", "raises"])
+async def test_auto_notify_failure_compensates_by_cancelling_live_order(
+    monkeypatch, db_session, notify_failure
+):
+    from app.core.config import settings
+    from app.services.order_proposals.target_order import TargetOrderSnapshot
+
+    monkeypatch.setattr(settings, "ORDER_PROPOSALS_AUTO_APPROVE", True)
+    monkeypatch.setattr(
+        settings, "ORDER_PROPOSALS_TELEGRAM_CHAT_ALLOWLIST_STR", CHAT_ID
+    )
+    service = OrderProposalsService(db_session)
+    group = await service.create_proposal(
+        symbol="005930",
+        market="equity_kr",
+        account_mode="kis_live",
+        broker_account_id=f"notify-failure-{uuid.uuid4()}",
+        side="buy",
+        order_type="limit",
+        proposer="p",
+        rungs=[RungInput(0, "buy", Decimal("1"), Decimal("97000"), None)],
+    )
+    await db_session.commit()
+
+    async def fake_revalidate(*, service, proposal_id, now, eligibility_gate):
+        fresh_group, rungs = await service.get_proposal(proposal_id)
+        decision = await eligibility_gate(
+            group=fresh_group,
+            rung=rungs[0],
+            preview={"success": True, "current_price": "100000"},
+            now=now,
+        )
+        assert decision.eligible is True
+        await service.transition_rung(proposal_id, 0, new_state="revalidating")
+        await service.transition_rung(proposal_id, 0, new_state="approved")
+        await service.transition_rung(proposal_id, 0, new_state="submitting")
+        await service.record_resting(
+            proposal_id,
+            0,
+            broker_order_id="broker-notify-failure",
+            correlation_id="corr",
+            idempotency_key="idem",
+            approval_hash_digest="digest",
+            now=now,
+        )
+        return [RungOutcome(0, "submitted_resting", {})]
+
+    cancel_calls = []
+
+    async def cancel_fn(**kwargs):
+        cancel_calls.append(kwargs)
+        return {"success": True}
+
+    async def fetch_fn(**kwargs):
+        return TargetOrderSnapshot(
+            broker_order_id="broker-notify-failure",
+            symbol="005930",
+            side="buy",
+            order_type="limit",
+            limit_price="97000",
+            remaining_quantity="1",
+            status="cancelled",
+            observed_at=kwargs["now"].isoformat(),
+        )
+
+    notifier = (
+        _FakeNotifier(message_id=None)
+        if notify_failure == "none"
+        else _RaisingNotifier()
+    )
+    result = await dispatch_proposal(
+        group.proposal_id,
+        notifier=notifier,
+        now=datetime.now(UTC),
+        service_factory=_session_factory(db_session),
+        revalidate_fn=fake_revalidate,
+        cancel_target_fn=cancel_fn,
+        fetch_target_fn=fetch_fn,
+    )
+
+    assert result is None
+    assert cancel_calls[0]["order_id"] == "broker-notify-failure"
+    refreshed, rungs = await service.get_proposal(group.proposal_id)
+    assert rungs[0].state == "cancelled"
+    assert (
+        refreshed.source_asof["auto_approved"]["notification_failure"]["outcomes"][0][
+            "result"
+        ]
+        == "cancelled"
+    )

--- a/tests/services/order_proposals/test_revalidation.py
+++ b/tests/services/order_proposals/test_revalidation.py
@@ -186,6 +186,82 @@ async def test_price_change_needs_reconfirm_no_submit(db_session):
 
 
 @pytest.mark.asyncio
+async def test_submit_time_eligibility_veto_degrades_to_pending_approval(db_session):
+    svc, group = await _create_proposal(db_session)
+    broker_calls = []
+
+    async def place_order(**kwargs):
+        broker_calls.append(kwargs)
+        assert kwargs["dry_run"] is True
+        return {
+            "success": True,
+            "approval_hash": "TESTTOKEN",
+            "price": "2226000",
+            "quantity": "10",
+            "current_price": "2250000",
+        }
+
+    async def eligibility_gate(**kwargs):
+        assert kwargs["preview"]["current_price"] == "2250000"
+        return {
+            "eligible": False,
+            "reason": "distance_below_minimum",
+            "details": {"policy_version": "test-policy"},
+        }
+
+    outcomes = await revalidate_and_submit(
+        service=svc,
+        proposal_id=group.proposal_id,
+        now=datetime.now(UTC),
+        place_order_fn=place_order,
+        eligibility_gate=eligibility_gate,
+    )
+
+    assert [call["dry_run"] for call in broker_calls] == [True]
+    assert outcomes[0].result == "approval_required"
+    assert outcomes[0].detail["reason"] == "distance_below_minimum"
+    _, rungs = await svc.get_proposal(group.proposal_id)
+    assert rungs[0].state == "pending_approval"
+
+
+@pytest.mark.asyncio
+async def test_auto_eligibility_multi_rung_degrades_before_any_preview(db_session):
+    svc = OrderProposalsService(db_session)
+    group = await svc.create_proposal(
+        symbol="A",
+        market="equity_kr",
+        account_mode="kis_live",
+        side="buy",
+        order_type="limit",
+        proposer="p",
+        rungs=[
+            RungInput(0, "buy", Decimal("1"), Decimal("97"), None),
+            RungInput(1, "buy", Decimal("1"), Decimal("96"), None),
+        ],
+    )
+    await db_session.commit()
+
+    async def must_not_preview(**kwargs):
+        raise AssertionError("multi-rung auto approval must degrade before preview")
+
+    outcomes = await revalidate_and_submit(
+        service=svc,
+        proposal_id=group.proposal_id,
+        now=datetime.now(UTC),
+        place_order_fn=must_not_preview,
+        eligibility_gate=lambda **kwargs: {"eligible": True},
+    )
+
+    assert [outcome.result for outcome in outcomes] == [
+        "approval_required",
+        "approval_required",
+    ]
+    assert {outcome.detail["reason"] for outcome in outcomes} == {
+        "multi_rung_requires_approval"
+    }
+
+
+@pytest.mark.asyncio
 async def test_qty_change_needs_reconfirm_no_submit(db_session):
     svc = OrderProposalsService(db_session)
     g = await svc.create_proposal(

--- a/tests/services/order_proposals/test_telegram_callback.py
+++ b/tests/services/order_proposals/test_telegram_callback.py
@@ -14,6 +14,7 @@ from app.services.order_proposals import OrderProposalsService
 from app.services.order_proposals.approval_message import parse_callback_data
 from app.services.order_proposals.revalidation import RungOutcome, revalidate_and_submit
 from app.services.order_proposals.service import RungInput
+from app.services.order_proposals.target_order import TargetOrderSnapshot
 from app.services.order_proposals.telegram_callback import (
     _build_result_summary,
     _resolve_proposal_id,
@@ -91,6 +92,43 @@ async def _seed_proposal(db_session, *, nonce="nonce-abc123", symbol="A", rungs=
         order_type="limit",
         proposer="p",
         rungs=rung_inputs,
+    )
+    await service.set_approval_nonce(group.proposal_id, nonce)
+    await db_session.commit()
+    return group
+
+
+async def _seed_auto_resting(db_session, *, nonce="veto-nonce"):
+    service = OrderProposalsService(db_session)
+    now = datetime.now(UTC)
+    group = await service.create_proposal(
+        symbol="005930",
+        market="equity_kr",
+        account_mode="kis_live",
+        side="buy",
+        order_type="limit",
+        proposer="p",
+        rungs=[RungInput(0, "buy", Decimal("1"), Decimal("97000"), None)],
+        source_asof={
+            "auto_approved": {
+                "policy_version": "test-policy",
+                "approved_at": now.isoformat(),
+                "eligibility": [],
+                "outcomes": ["submitted_resting"],
+            }
+        },
+    )
+    await service.transition_rung(group.proposal_id, 0, new_state="revalidating")
+    await service.transition_rung(group.proposal_id, 0, new_state="approved")
+    await service.transition_rung(group.proposal_id, 0, new_state="submitting")
+    await service.record_resting(
+        group.proposal_id,
+        0,
+        broker_order_id="broker-auto-1",
+        correlation_id="corr-auto-1",
+        idempotency_key="idem-auto-1",
+        approval_hash_digest="digest-auto-1",
+        now=now,
     )
     await service.set_approval_nonce(group.proposal_id, nonce)
     await db_session.commit()
@@ -179,6 +217,102 @@ def test_result_summary_includes_bounded_escaped_guard_reason():
 def test_result_summary_labels_confirmed_cancel():
     summary = _build_result_summary([RungOutcome(0, "cancelled", {})])
     assert "취소 확인" in summary
+
+
+@pytest.mark.asyncio
+async def test_auto_veto_cancels_broker_and_rung_once(monkeypatch, db_session):
+    _allow_chat(monkeypatch)
+    group = await _seed_auto_resting(db_session)
+    notifier = _FakeNotifier()
+    cancel_calls = []
+
+    async def cancel_fn(**kwargs):
+        cancel_calls.append(kwargs)
+        return {"success": True}
+
+    async def fetch_fn(**kwargs):
+        return TargetOrderSnapshot(
+            broker_order_id="broker-auto-1",
+            symbol="005930",
+            side="buy",
+            order_type="limit",
+            limit_price="97000",
+            remaining_quantity="1",
+            status="cancelled",
+            observed_at=kwargs["now"].isoformat(),
+        )
+
+    update = _make_update(data=f"vc:{str(group.proposal_id)[:8]}:veto-nonce")
+    result = await handle_callback_update(
+        update,
+        now=datetime.now(UTC),
+        service_factory=_session_factory(db_session),
+        notifier=notifier,
+        veto_cancel_fn=cancel_fn,
+        veto_fetch_fn=fetch_fn,
+    )
+
+    assert result["reason"] == "auto_veto_cancelled"
+    assert cancel_calls[0]["order_id"] == "broker-auto-1"
+    refreshed, rungs = await OrderProposalsService(db_session).get_proposal(
+        group.proposal_id
+    )
+    assert rungs[0].state == "cancelled"
+    assert refreshed.source_asof["auto_approved"]["veto"]["telegram_user_id"] == str(
+        USER_ID
+    )
+    assert "취소됨" in notifier.edited[-1][2]
+
+    replay = await handle_callback_update(
+        update,
+        now=datetime.now(UTC),
+        service_factory=_session_factory(db_session),
+        notifier=notifier,
+        veto_cancel_fn=cancel_fn,
+        veto_fetch_fn=fetch_fn,
+    )
+    assert replay["reason"] == "nonce_replay"
+    assert len(cancel_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_auto_veto_cancel_failure_that_is_filled_edits_filled(
+    monkeypatch, db_session
+):
+    _allow_chat(monkeypatch)
+    group = await _seed_auto_resting(db_session)
+    notifier = _FakeNotifier()
+
+    async def cancel_fn(**kwargs):
+        return {"success": False, "error": "already filled"}
+
+    async def fetch_fn(**kwargs):
+        return TargetOrderSnapshot(
+            broker_order_id="broker-auto-1",
+            symbol="005930",
+            side="buy",
+            order_type="limit",
+            limit_price="97000",
+            remaining_quantity="0",
+            status="filled",
+            observed_at=kwargs["now"].isoformat(),
+        )
+
+    result = await handle_callback_update(
+        _make_update(data=f"vc:{str(group.proposal_id)[:8]}:veto-nonce"),
+        now=datetime.now(UTC),
+        service_factory=_session_factory(db_session),
+        notifier=notifier,
+        veto_cancel_fn=cancel_fn,
+        veto_fetch_fn=fetch_fn,
+    )
+
+    assert result["reason"] == "auto_veto_filled"
+    _refreshed, rungs = await OrderProposalsService(db_session).get_proposal(
+        group.proposal_id
+    )
+    assert rungs[0].state == "filled"
+    assert "체결됨" in notifier.edited[-1][2]
 
 
 @pytest.mark.asyncio

--- a/tests/services/order_proposals/test_telegram_callback.py
+++ b/tests/services/order_proposals/test_telegram_callback.py
@@ -225,6 +225,19 @@ async def test_auto_veto_cancels_broker_and_rung_once(monkeypatch, db_session):
     group = await _seed_auto_resting(db_session)
     notifier = _FakeNotifier()
     cancel_calls = []
+    mutation_locks = []
+
+    original_lock = OrderProposalsService.acquire_broker_order_mutation_lock
+
+    async def recording_lock(self, group, broker_order_id):
+        mutation_locks.append(broker_order_id)
+        return await original_lock(self, group, broker_order_id)
+
+    monkeypatch.setattr(
+        OrderProposalsService,
+        "acquire_broker_order_mutation_lock",
+        recording_lock,
+    )
 
     async def cancel_fn(**kwargs):
         cancel_calls.append(kwargs)
@@ -243,6 +256,14 @@ async def test_auto_veto_cancels_broker_and_rung_once(monkeypatch, db_session):
         )
 
     update = _make_update(data=f"vc:{str(group.proposal_id)[:8]}:veto-nonce")
+    wrong_action = await handle_callback_update(
+        _make_update(data=f"op:{str(group.proposal_id)[:8]}:veto-nonce"),
+        now=datetime.now(UTC),
+        service_factory=_session_factory(db_session),
+        notifier=notifier,
+    )
+    assert wrong_action["reason"] == "auto_veto_nonce_requires_vc"
+
     result = await handle_callback_update(
         update,
         now=datetime.now(UTC),
@@ -253,6 +274,7 @@ async def test_auto_veto_cancels_broker_and_rung_once(monkeypatch, db_session):
     )
 
     assert result["reason"] == "auto_veto_cancelled"
+    assert mutation_locks == ["broker-auto-1"]
     assert cancel_calls[0]["order_id"] == "broker-auto-1"
     refreshed, rungs = await OrderProposalsService(db_session).get_proposal(
         group.proposal_id

--- a/tests/services/test_trading_policy_service.py
+++ b/tests/services/test_trading_policy_service.py
@@ -5,7 +5,7 @@ from app.services import trading_policy_service as svc
 
 def test_version_stamp_has_version_and_hash():
     stamp = svc.policy_version_stamp()
-    assert stamp["version"] == "2026-07-12.1"
+    assert stamp["version"] == "2026-07-14.1"
     assert len(stamp["content_hash"]) == 12
 
 
@@ -15,7 +15,7 @@ def test_content_hash_stable_across_calls():
 
 def test_get_policy_for_buy_kr_includes_cap_and_version():
     view = svc.get_policy_for("kr", "buy")
-    assert view["version"] == "2026-07-12.1"
+    assert view["version"] == "2026-07-14.1"
     assert view["content_hash"]
     t = view["thresholds"]
     # buy lane references these (playbook lane tags)
@@ -31,7 +31,7 @@ def test_get_policy_for_buy_kr_includes_cap_and_version():
 def test_get_policy_for_crypto_buy_exposes_report_derived_market_rules():
     view = svc.get_policy_for("crypto", "buy")
 
-    assert view["version"] == "2026-07-12.1"
+    assert view["version"] == "2026-07-14.1"
     assert set(view["market_rules"]) == {
         "recovery_gate",
         "support_resistance",


### PR DESCRIPTION
## Stack

- Stacked on #1529 (`fix/ROB-869-supersede-invalidation`)
- Review and merge #1529 first; this PR base is the ROB-869 branch, not `main`.
- Linear: ROB-871

## Summary

- add a default-off `ORDER_PROPOSALS_AUTO_APPROVE` path for single-rung resting limit `place` proposals with no exit intent
- evaluate distance, existing sell-loss guard evidence, per-order cap, and market/account/KST-day cumulative cap from the fresh revalidation preview immediately before submit
- reuse `revalidate_and_submit`; any eligibility, guard, buying-power/861, or policy miss remains pending/needs-reconfirm and falls back to the existing Telegram approval flow
- keep human approval columns empty and store policy version plus exact eligibility evidence in `source_asof.auto_approved`
- send a post-submit Telegram summary with a single-use `취소` veto; cancel and re-fetch broker state before recording `cancelled` or `filled`
- compensate immediately with the same cancel-and-confirm flow if the post-submit veto notification is not delivered

## Safety boundaries

- env gate defaults off
- market orders, loss cuts, replace/cancel proposals, Toss, unsupported account/market pairs, distance misses, and multi-rung ladders remain human-gated
- daily caps are transaction-serialized and separated by account mode, market/currency, broker account, and KST day
- auto dispatch and broker target mutations use transaction advisory locks
- veto nonce is action-bound: approval/deny actions cannot consume it
- no schema migration; audit remains in existing `source_asof`

## Policy seed

| Market | Min distance | Per order | Daily |
|---|---:|---:|---:|
| KR equities | 3% | 200,000 KRW | 500,000 KRW |
| US equities | 3% | 150 USD | 400 USD |
| Crypto | 3% | 100,000 KRW | 300,000 KRW |

Policy version: `2026-07-14.1`.

## Verification

- `make lint`
- `uv run pytest tests/services/order_proposals/ -q` — 380 passed
- `uv run pytest tests/test_mcp_order_proposal_tools.py tests/schemas/test_trading_policy_schema.py tests/services/test_trading_policy_service.py tests/mcp_server/test_trading_policy_tool.py -q` — 49 passed
- all broker and Telegram interactions in tests are injected fakes; no live calls

## Canary

1. Deploy with `ORDER_PROPOSALS_AUTO_APPROVE=false` and verify the existing approval path.
2. Enable the flag with the checked-in small caps only.
3. Submit one qualifying resting order, verify `source_asof.auto_approved`, Telegram summary, broker/ledger resting state, and the veto cancellation convergence.
4. Exercise an ineligible and an 861-insufficient proposal and verify human approval/reconfirmation fallback.
5. Raise caps only in a separate reviewed policy change after observing the small-cap canary.

---
Reopens #1530 (auto-closed when its stacked base branch was deleted by #1529's merge). Same two commits, rebased onto main after #1529 squash-merge. Verified post-rebase: order_proposals suite 380 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional automatic approval and submission for eligible resting orders.
  * Added policy-based distance and per-order/daily spending limits for supported markets.
  * Added Telegram cancellation controls for automatically submitted orders.
  * Orders requiring additional review continue through the standard Telegram approval flow.
  * Added safeguards to cancel automatically submitted orders if confirmation notifications fail.

* **Documentation**
  * Updated trading policy and operational guidance for automatic order proposal handling.

* **Tests**
  * Added coverage for eligibility limits, fallback approval, cancellation, replay protection, and notification-failure safeguards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->