### PR TITLE
fix(ROB-868): project Upbit websocket fills to proposal rungs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Fixed (ROB-868 — Upbit websocket proposal fill projection; migration 0)
+- **Committed Upbit websocket fills now converge proposal rungs immediately.** `trade` events project cumulative partial-fill evidence and `done` events project terminal fill evidence through an independent committed proposal-service session, matching both the broker UUID and Upbit client identifier while keeping projection failures best-effort. Individual ledger rows retain per-trade `volume`; terminal cumulative evidence is applied only after an existing durable fill is verified and is not double-counted as another fill.
+- **Matched proposal fills retain operator visibility at small notionals.** Proposal-rung fills bypass the ordinary notification threshold without changing unmatched-fill policy, and duplicate ledger deliveries remain notification-idempotent.
+- **Upbit consumer health is observable.** Runtime health logs now include Upbit message/execution counters and last-seen timestamps alongside the existing KIS metrics. The single-active Upbit launchd service requires a restart after deployment; `scripts/deploy-native.sh` performs that restart.
+
 ### Added (ROB-867 — Kiwoom mock US lifecycle; migration 0)
 - **Kiwoom US mock orders now have an isolated, fail-closed MCP surface.** Dedicated credentials and account mode expose preview/place/modify/cancel plus order, position, and USD-deposit reads without falling back to the KR namespace; symbols resolve their exchange from the active US universe before any broker mutation.
 - **Only evidence-backed order types are public.** MCP accepts limit (`00`) and market (`03`) orders and rejects every other `trde_tp` before lookup or network access, while the low-level client preserves the documented advanced request fields for later promotion after mock-environment proof.

--- a/UPBIT_WEBSOCKET_README.md
+++ b/UPBIT_WEBSOCKET_README.md
@@ -1,11 +1,20 @@
-# 업비트 WebSocket MyOrder 자동 분석 시스템
+# 업비트 WebSocket MyOrder 모니터링
 
-업비트의 내 주문 및 체결 WebSocket을 이용해서 매수/매도가 발생할 때마다 `analyze_coin_json`으로 단일 코인 분석을 자동으로 수행하는 시스템입니다.
+업비트의 내 주문 및 체결 WebSocket을 소비하는 경로는 두 가지입니다. 운영 체결 경로는
+`websocket_monitor.py --mode upbit`이며, 체결 레저 기록·주문 제안 런(proposal rung) 상태
+반영·Discord/Telegram 알림을 담당합니다. `upbit_websocket_monitor.py`는 분석기가 제거된
+레거시 콜백 모니터이며, 현재 분석 콜백은 로그만 남기고 실제 분석을 실행하지 않습니다.
 
 ## 📋 주요 기능
 
 - **실시간 주문/체결 모니터링**: 업비트 WebSocket MyOrder API를 통해 실시간으로 주문 및 체결 데이터 수신
-- **자동 코인 분석**: 체결이 발생한 코인에 대해 자동으로 `analyze_coin_json` 함수 호출
+- **체결 증거 기록**: `trade` 이벤트의 건별 체결량을 `review.execution_ledger`에 멱등 기록
+- **주문 제안 상태 반영**: 업비트 UUID와 `identifier`로 런을 찾아 `trade`는 부분 체결,
+  `done`은 최종 체결로 누적 수량을 반영. 프로젝션 실패는 체결 레저를 롤백하지 않고 로그로 남김
+- **체결 알림**: 새 체결을 Discord/Telegram으로 전송. 제안 런이 매칭된 체결은 일반
+  소액 알림 임계치를 넘지 않아도 전송하며, 중복 레저 이벤트는 중복 알림을 만들지 않음
+- **운영 건강성 로그**: 수신 메시지/체결 이벤트 수, 마지막 수신/체결 시각,
+  알림 전송 수를 통합 건강성 로그에 표시
 - **재연결 기능**: 연결이 끊어져도 자동으로 재연결 시도
 - **로깅 시스템**: 상세한 로그를 통한 모니터링 상태 추적
 
@@ -14,38 +23,31 @@
 ### 1. 기본 실행
 
 ```bash
-# 모든 코인 페어 모니터링 및 자동 분석
+# 운영 체결 레저/제안 런/알림 모니터
+uv run python websocket_monitor.py --mode upbit
+
+# 레거시 no-op 분석 콜백 모니터
 python upbit_websocket_monitor.py
 ```
 
 ### 2. 테스트 실행
 
 ```bash
-# WebSocket 연결 및 서비스 테스트 (실제 분석 없이)
-python test_upbit_websocket.py
+# 외부 WebSocket/브로커를 사용하지 않는 서비스·운영 경로 테스트
+uv run pytest --no-cov \
+  tests/test_upbit_websocket_service.py \
+  tests/test_websocket_monitor.py -q
 ```
 
 ### 3. 프로그래밍 방식 사용
 
 ```python
 import asyncio
-from app.services.upbit_websocket import UpbitOrderAnalysisService
-from app.analysis.service_analyzers import UpbitAnalyzer
+from websocket_monitor import UnifiedWebSocketMonitor
 
 async def main():
-    # 분석기 초기화
-    analyzer = UpbitAnalyzer()
-    
-    # 분석 콜백 함수 정의
-    async def analyze_callback(coin_name: str):
-        await analyzer.analyze_coin_json(coin_name)
-    
-    # 서비스 시작
-    service = UpbitOrderAnalysisService(analyzer_callback=analyze_callback)
-    await service.start_monitoring()
-    
-    # 특정 코인만 모니터링하려면:
-    # await service.start_monitoring(["KRW-BTC", "KRW-ETH"])
+    monitor = UnifiedWebSocketMonitor(mode="upbit")
+    await monitor.start()
 
 if __name__ == "__main__":
     asyncio.run(main())
@@ -58,15 +60,21 @@ if __name__ == "__main__":
 - 실시간 주문/체결 데이터 수신
 - 자동 재연결 기능
 
-### 2. UpbitOrderAnalysisService
-- 주문/체결 데이터 기반 자동 분석 서비스
-- 체결 감지 시 분석 콜백 호출
-- 서비스 시작/중지 관리
+### 2. UnifiedWebSocketMonitor
+- Upbit/KIS 체결 소비자 오케스트레이션
+- execution ledger 커밋 후 제안 런 프로젝션
+- 알림, 심박 파일, 재연결, 건강성 로그 관리
+
+### 3. UpbitOrderAnalysisService (레거시)
+- `upbit_websocket_monitor.py`가 사용하는 콜백 래퍼
+- 현재 엔트리포인트의 분석 콜백은 no-op
 
 ## 📊 모니터링 대상
 
 - **모든 KRW 마켓 페어**: KRW-BTC, KRW-ETH, KRW-ADA 등
-- **체결 상태만**: `state: "trade"` 인 데이터만 처리
+- **운영 체결 상태**: `state: "trade"`와 `state: "done"` 처리. `done`은 같은 UUID의
+  영속 체결 레저 증거가 있을 때만 제안 런을 최종 체결로 종료
+- **레거시 콜백 상태**: `upbit_websocket_monitor.py`는 `state: "trade"`만 콜백으로 전달
 - **매수/매도 구분**: ASK(매도), BID(매수) 모두 처리
 
 ## ⚙️ 설정
@@ -85,29 +93,41 @@ UPBIT_SECRET_KEY=your_upbit_secret_key_here
 ## 🔄 동작 흐름
 
 1. **WebSocket 연결**: 업비트 WebSocket MyOrder API에 연결
-2. **구독 시작**: 지정된 코인 페어 또는 모든 페어 구독
-3. **데이터 수신**: 실시간 주문/체결 데이터 수신
-4. **체결 감지**: `state: "trade"` 상태의 데이터 필터링
-5. **코인명 추출**: 페어 코드를 한국 이름으로 변환 (예: KRW-BTC → 비트코인)
-6. **분석 실행**: `analyze_coin_json(coin_name)` 호출
-7. **로그 기록**: 분석 시작/완료 로그 출력
+2. **데이터 수신**: 수신 수와 마지막 메시지 시각을 즉시 갱신
+3. **`trade` 체결 기록**: 건별 `volume`을 execution ledger에 먼저 커밋
+4. **제안 런 프로젝션**: 별도 DB 세션에서 누적 `executed_volume`을 부분 체결로 반영
+5. **`done` 종료 반영**: 같은 주문의 커밋된 체결이 확인되면 누적 수량으로 최종 체결 처리
+6. **알림 전송**: 중복을 제외한 체결을 전송하고, 매칭된 제안 런 체결은 소액 임계치 면제
+7. **건강성 기록**: `messages_received`, `execution_events_received`, `fills_forwarded`,
+   `last_message_at`, `last_execution_at`을 주기적으로 로그
+
+## 🚀 운영 배포
+
+macOS 네이티브 배포의 업비트 소비자는
+`com.robinco.auto-trader.upbit-websocket` 단일 활성 launchd 서비스입니다. API/MCP처럼
+블루/그린으로 교체되지 않으므로 코드 배포 후 재시작해야 합니다.
+
+```bash
+# 표준 네이티브 배포: current 심볼릭 전환 후 서비스를 자동 재시작
+scripts/deploy-native.sh <commit-sha>
+
+# 수동/아웃오브밴드 배포 후 재시작 확인
+launchctl kickstart -k gui/$(id -u)/com.robinco.auto-trader.upbit-websocket
+```
 
 ## 🚨 주의사항
 
 - **API 키 필요**: 업비트 API 키가 반드시 설정되어 있어야 합니다
 - **실제 거래 데이터**: 실제 주문/체결이 발생할 때만 동작합니다
 - **네트워크 연결**: 안정적인 인터넷 연결이 필요합니다
-- **리소스 사용**: 분석이 자주 실행될 수 있으므로 시스템 리소스를 모니터링하세요
+- **데이터베이스 연결**: `done` 종료 반영과 제안 런 프로젝션은 영속 체결 증거를 사용합니다
 
 ## 🔍 로그 예시
 
 ```
-2025-01-27 10:30:15 - upbit_websocket - INFO - 업비트 MyOrder WebSocket 연결을 시작합니다...
-2025-01-27 10:30:16 - upbit_websocket - INFO - WebSocket 연결 성공
-2025-01-27 10:30:16 - upbit_websocket - INFO - 모든 코인 페어 구독
-2025-01-27 10:30:45 - upbit_websocket - INFO - 체결 감지 - 비트코인(KRW-BTC): BID 0.001개 @ 95000000원
-2025-01-27 10:30:45 - upbit_websocket - INFO - 비트코인 분석을 시작합니다...
-2025-01-27 10:30:50 - upbit_websocket - INFO - 비트코인 분석이 완료되었습니다.
+2026-07-14 10:30:45 - websocket_monitor - INFO - Execution ledger websocket upsert committed: broker=upbit ...
+2026-07-14 10:30:45 - websocket_monitor - INFO - Upbit proposal rung projected: order_id=... state=trade rung_state=partially_filled ...
+2026-07-14 10:35:00 - websocket_monitor - INFO - Unified WebSocket health: mode=upbit connected=True ... messages_received=12 execution_events_received=3 fills_forwarded=3 ...
 ```
 
 ## 🛠️ 트러블슈팅
@@ -127,12 +147,12 @@ UPBIT_SECRET_KEY=your_upbit_secret_key_here
 - 네트워크 연결 상태 확인
 - 방화벽 설정 확인
 
-### 분석 실행 오류
-- 데이터베이스 연결 상태 확인
-- Google API 키 할당량 확인
-- 시스템 리소스 확인
+### 제안 런 프로젝션 오류
+- `Upbit proposal rung projection failed` 로그와 데이터베이스 연결 상태 확인
+- 체결 레저 커밋은 유지되므로 이후 reconcile에서 상태가 수렴하는지 확인
+- `done` 스킵이 반복되면 같은 Upbit UUID의 체결 레저 행이 존재하는지 확인
 
 ### 재연결 문제
-- 기본적으로 최대 10회 재연결 시도
-- 재연결 간격: 5초
-- 필요시 코드에서 `max_reconnect_attempts`, `reconnect_delay` 값 조정
+- 통합 모니터는 연결 종료 후 슈퍼바이저 루프에서 재연결
+- 기본 재연결 간격: 5초
+- 필요 시 `WS_MONITOR_RECONNECT_DELAY_SECONDS`로 운영 재연결 간격 조정

--- a/app/mcp_server/tooling/toss_live_ledger.py
+++ b/app/mcp_server/tooling/toss_live_ledger.py
@@ -274,7 +274,7 @@ async def _converge_toss_proposal_rung(
             # Project that quantity first, then cancel with filled_qty=None so the
             # service preserves the partial audit value on the terminal rung.
             if ledger_status == "cancelled" and filled_qty and filled_qty > 0:
-                partial = await service.record_fill_evidence(
+                await service.record_fill_evidence(
                     correlation_id=getattr(row, "correlation_id", None),
                     broker_order_id=row.broker_order_id,
                     filled_qty=filled_qty,
@@ -282,9 +282,6 @@ async def _converge_toss_proposal_rung(
                     now=datetime.now(UTC),
                     account_mode="toss_live",
                 )
-                if partial is None:
-                    await db.commit()
-                    return None
 
             terminal_state = {
                 "partial": "partially_filled",

--- a/app/services/execution_ledger/repository.py
+++ b/app/services/execution_ledger/repository.py
@@ -89,6 +89,27 @@ class ExecutionLedgerRepository:
         )
         return result.scalar_one_or_none()
 
+    async def has_fill_for_order(
+        self,
+        *,
+        broker: str,
+        account_mode: str,
+        venue: str,
+        broker_order_id: str,
+    ) -> bool:
+        """Return whether durable fill evidence exists for one broker order."""
+        result = await self.db.execute(
+            select(ExecutionLedger.id)
+            .where(
+                ExecutionLedger.broker == broker,
+                ExecutionLedger.account_mode == account_mode,
+                ExecutionLedger.venue == venue,
+                ExecutionLedger.broker_order_id == broker_order_id,
+            )
+            .limit(1)
+        )
+        return result.scalar_one_or_none() is not None
+
     async def classify_fill(self, fill: ExecutionLedgerUpsert) -> UpsertStatus:
         existing = await self.get_by_key(
             fill.broker,

--- a/app/services/fill_notification.py
+++ b/app/services/fill_notification.py
@@ -310,8 +310,10 @@ def normalize_upbit_fill(raw: Mapping[str, Any]) -> FillOrder:
     symbol = str(_pick_first(raw, ["code", "market", "symbol"]) or "UNKNOWN")
     side = _normalize_side(str(_pick_first(raw, ["ask_bid", "side"]) or ""))
     filled_price = _safe_float(_pick_first(raw, ["trade_price", "price", "avg_price"]))
+    # Upbit myOrder uses ``volume`` for the current fill when state=trade;
+    # ``executed_volume`` is cumulative order evidence used by rung projection.
     filled_qty = _safe_float(
-        _pick_first(raw, ["trade_volume", "executed_volume", "volume"])
+        _pick_first(raw, ["trade_volume", "volume", "executed_volume"])
     )
     filled_amount = _safe_float(_pick_first(raw, ["trade_amount", "executed_amount"]))
     if filled_amount <= 0 and filled_price > 0 and filled_qty > 0:

--- a/app/services/order_proposals/repository.py
+++ b/app/services/order_proposals/repository.py
@@ -135,9 +135,9 @@ class OrderProposalRepository:
         no longer transition — see OrderProposalsService.record_fill_evidence.
         """
         evidence = (
-            (OrderProposalRung.correlation_id, correlation_id),
             (OrderProposalRung.broker_order_id, broker_order_id),
             (OrderProposalRung.idempotency_key, idempotency_key),
+            (OrderProposalRung.correlation_id, correlation_id),
         )
         for column, value in evidence:
             if value is None:

--- a/app/services/order_proposals/repository.py
+++ b/app/services/order_proposals/repository.py
@@ -122,10 +122,11 @@ class OrderProposalRepository:
         *,
         correlation_id: str | None,
         broker_order_id: str | None,
+        idempotency_key: str | None = None,
         states: frozenset[str] | None = None,
         account_mode: str | None = None,
     ) -> tuple[uuid.UUID, OrderProposalRung] | None:
-        """Locate a rung by broker evidence.
+        """Locate a rung by broker or client-order evidence.
 
         ``states``, when given, restricts the match to rungs currently in one of
         those states. Reconcile passes the evidence-accepting (non-terminal) set
@@ -136,6 +137,7 @@ class OrderProposalRepository:
         evidence = (
             (OrderProposalRung.correlation_id, correlation_id),
             (OrderProposalRung.broker_order_id, broker_order_id),
+            (OrderProposalRung.idempotency_key, idempotency_key),
         )
         for column, value in evidence:
             if value is None:

--- a/app/services/order_proposals/service.py
+++ b/app/services/order_proposals/service.py
@@ -1193,6 +1193,7 @@ class OrderProposalsService:
         *,
         correlation_id: str | None = None,
         broker_order_id: str | None = None,
+        idempotency_key: str | None = None,
         filled_qty: Decimal | None = None,
         terminal_state: Literal["filled", "partially_filled", "cancelled"] = "filled",
         now: datetime,
@@ -1211,11 +1212,14 @@ class OrderProposalsService:
         - ``cancelled`` carries no fill quantity (``filled_qty=None``) so a
           partial fill booked before a cancel is preserved, not zeroed.
         - No terminal state is ever inferred without matching broker evidence.
+        - Upbit client identifiers match the rung ``idempotency_key`` while
+          broker UUIDs continue to match ``broker_order_id``.
         """
         self._require_timezone_aware(now)
         match = await self._repo.find_rung_by_evidence(
             correlation_id=correlation_id,
             broker_order_id=broker_order_id,
+            idempotency_key=idempotency_key,
             states=_EVIDENCE_ACCEPTING_RUNG_STATES,
             account_mode=account_mode,
         )
@@ -1239,6 +1243,12 @@ class OrderProposalsService:
             # Repeated non-terminal evidence (e.g. a larger partial fill on an
             # already-partially_filled rung): refresh audit fields in place
             # rather than attempt an illegal self-transition.
+            if (
+                filled_qty is not None
+                and locked.filled_qty is not None
+                and filled_qty <= Decimal(str(locked.filled_qty))
+            ):
+                return None
             return await self._repo.update_rung(locked, **audit)
         return await self._transition_locked_rung(
             group, locked, new_state=terminal_state, **audit

--- a/docs/superpowers/plans/2026-07-14-rob-868-upbit-websocket-fill-projection.md
+++ b/docs/superpowers/plans/2026-07-14-rob-868-upbit-websocket-fill-projection.md
@@ -164,7 +164,9 @@ independent committed session and `account_mode="upbit"`, exceptions are
 swallowed, and `scripts/deploy-native.sh` restarts the single-active Upbit
 launchd service.
 
-- [ ] **Step 3: Commit, push, and create PR**
+- [x] **Step 3: Commit, push, and create PR**
 
 Commit with a ROB-868 message and the repository's standard trailer, push
 `rob-868`, then create a PR against `main` titled `fix(ROB-868): project Upbit websocket fills to proposal rungs`. The PR body must include test evidence and state that Upbit websocket is not blue/green and must be restarted after deployment (the native deploy workflow performs this restart).
+
+Delivered in commits `42727e4c` and `6d87f027`; PR #1534 targets `main`.

--- a/docs/superpowers/plans/2026-07-14-rob-868-upbit-websocket-fill-projection.md
+++ b/docs/superpowers/plans/2026-07-14-rob-868-upbit-websocket-fill-projection.md
@@ -1,0 +1,170 @@
+# ROB-868 Upbit WebSocket Fill Projection Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Converge Upbit proposal rungs directly from committed websocket fill evidence while repairing health metrics and notifying small matched-rung fills.
+
+**Architecture:** `websocket_monitor.py` projects a committed Upbit ledger fill through an independent proposal-service session and uses the match result to bypass the small-fill threshold. The proposal service adds optional `idempotency_key` evidence so Upbit `identifier` values match their persisted rung field, while the monitor consumer records Upbit runtime counters for health logs.
+
+**Tech Stack:** Python 3.13+, asyncio, SQLAlchemy async sessions, pytest/pytest-asyncio, Ruff, ty.
+
+## Global Constraints
+
+- Linear ROB-868 is the source of truth.
+- Do not contact brokers or real websockets in tests.
+- Projection failures are log-and-swallow and must not kill the websocket loop.
+- Pass `account_mode="upbit"` to `record_fill_evidence`.
+- Do not infer terminal state without `state="done"` broker evidence.
+- Preserve existing terminal short-circuit idempotency.
+- `make lint` and the related test suite must pass.
+
+---
+
+### Task 1: Proposal rung projection and notification policy
+
+**Files:**
+- Modify: `websocket_monitor.py:167-459`
+- Modify: `app/services/order_proposals/repository.py:120-159`
+- Modify: `app/services/order_proposals/service.py:1191-1221`
+- Test: `tests/test_websocket_monitor.py`
+- Test: `tests/services/order_proposals/test_service.py`
+
+**Interfaces:**
+- Consumes: Upbit `myOrder` fields `state`, `uuid`, `identifier`, `executed_volume`.
+- Produces: `record_fill_evidence(..., idempotency_key: str | None = None)`, `_project_upbit_proposal_fill(event) -> bool`, and `_send_fill_notification(..., proposal_rung_fill: bool = False)`.
+
+- [x] **Step 1: Write failing projection tests**
+
+Add async tests that inject `trade` and `done` events and assert the fake
+`OrderProposalsService.record_fill_evidence` receives respectively:
+
+```python
+{
+    "idempotency_key": "proposal-client-id",
+    "broker_order_id": "upbit-order-id",
+    "filled_qty": Decimal("0.0003"),
+    "terminal_state": "partially_filled",  # "filled" for done
+    "account_mode": "upbit",
+}
+```
+
+First add a service test proving an `idempotency_key`-only rung match converges.
+Also assert the independent fake session commits, no-match returns `False`, a DB
+exception is logged and returns `False`, duplicate ledger status skips the
+notification, and a small fill with `proposal_rung_fill=True` reaches the fake
+notifier.
+
+- [x] **Step 2: Verify RED**
+
+Run: `uv run pytest --no-cov tests/test_websocket_monitor.py -k 'upbit and (proposal or rung or done or duplicate)' -q`
+
+Expected: failures because the projection helper, `done` handling, and
+`proposal_rung_fill` notification argument do not exist.
+
+- [x] **Step 3: Implement minimal projection**
+
+Extend repository evidence lookup with
+`(OrderProposalRung.idempotency_key, idempotency_key)`, then add a helper with
+this service call in an independent session:
+
+```python
+rung = await OrderProposalsService(db).record_fill_evidence(
+    idempotency_key=identifier,
+    broker_order_id=broker_order_id,
+    filled_qty=Decimal(str(executed_volume)),
+    terminal_state="filled" if state == "done" else "partially_filled",
+    now=datetime.now(UTC),
+    account_mode="upbit",
+)
+await db.commit()
+return rung is not None
+```
+
+Call it after the execution-ledger upsert commit for `trade`. Catch broad
+projection exceptions inside the helper, log with UUID/identifier/state, and
+return `False`. Allow `trade` and `done` in `_on_upbit_order`; treat `done` as
+terminal cumulative evidence only after verifying an existing committed fill,
+without inserting a second ledger fill. Notify new ledger fills, plus a
+threshold-suppressed duplicate delivery when it is the first successful rung
+projection after a prior projection failure, and bypass `is_fill_notifiable`
+only when the helper returned `True`.
+
+- [x] **Step 4: Verify GREEN**
+
+Run: `uv run pytest --no-cov tests/test_websocket_monitor.py -q`
+
+Expected: all websocket monitor tests pass.
+
+### Task 2: Upbit runtime health counters
+
+**Files:**
+- Modify: `websocket_monitor.py:65-84,167-199,584-610`
+- Test: `tests/test_websocket_monitor.py`
+
+**Interfaces:**
+- Produces: monitor-owned Upbit counters and timestamps included by `UnifiedWebSocketMonitor._log_health_status()`.
+- Consumes: each decoded `myOrder` callback invocation.
+
+- [x] **Step 1: Write failing counter tests**
+
+Call `_on_upbit_order` with one `trade` event and assert:
+
+```python
+assert monitor.upbit_messages_received == 1
+assert monitor.upbit_execution_events_received == 1
+assert monitor.upbit_last_message_at is not None
+assert monitor.upbit_last_execution_at is not None
+```
+
+Add a monitor health-log test with an Upbit snapshot and assert the rendered
+`messages_received`, `execution_events_received`, and timestamps are non-zero.
+
+- [x] **Step 2: Verify RED**
+
+Run: `uv run pytest --no-cov tests/test_upbit_websocket_service.py tests/test_websocket_monitor.py -k 'runtime or health' -q`
+
+Expected: failures because Upbit runtime counters and snapshot aggregation do not exist.
+
+- [x] **Step 3: Implement minimal counters and aggregation**
+
+Initialize counters/timestamps in the monitor, update message state before
+filtering and execution state for `trade`/`done`, and aggregate Upbit and KIS
+values for the existing health log fields.
+
+- [x] **Step 4: Verify GREEN and regression suite**
+
+Run: `uv run pytest --no-cov tests/services/order_proposals/test_service.py tests/test_websocket_monitor.py -q`
+
+Expected: all related tests pass.
+
+### Task 3: Quality gate and delivery
+
+**Files:**
+- Verify all modified files.
+- PR base: `main`.
+
+**Interfaces:**
+- Produces: a pushed `rob-868` branch and `fix(ROB-868): ...` pull request.
+
+- [x] **Step 1: Run quality gates**
+
+Run:
+
+```bash
+make lint
+uv run pytest --no-cov tests/test_upbit_websocket_service.py tests/test_websocket_monitor.py -q
+```
+
+Expected: exit code 0 for both commands.
+
+- [x] **Step 2: Review the diff and deployment contract**
+
+Confirm the projection is after the ledger commit, the service call uses an
+independent committed session and `account_mode="upbit"`, exceptions are
+swallowed, and `scripts/deploy-native.sh` restarts the single-active Upbit
+launchd service.
+
+- [ ] **Step 3: Commit, push, and create PR**
+
+Commit with a ROB-868 message and the repository's standard trailer, push
+`rob-868`, then create a PR against `main` titled `fix(ROB-868): project Upbit websocket fills to proposal rungs`. The PR body must include test evidence and state that Upbit websocket is not blue/green and must be restarted after deployment (the native deploy workflow performs this restart).

--- a/docs/superpowers/specs/2026-07-14-rob-868-upbit-websocket-fill-projection-design.md
+++ b/docs/superpowers/specs/2026-07-14-rob-868-upbit-websocket-fill-projection-design.md
@@ -1,0 +1,65 @@
+# ROB-868 Upbit WebSocket Fill Projection Design
+
+## Source of truth
+
+Linear ROB-868 requires the Upbit `myOrder` websocket path to project committed
+fill evidence into proposal rungs without waiting for reconcile. The projection
+must be best-effort, idempotent, account-scoped to `upbit`, observable through
+runtime health counters, and exempt matched proposal fills from the ordinary
+small-fill notification threshold.
+
+## Architecture
+
+Keep orchestration in `websocket_monitor.py`, immediately after the execution
+ledger commit. A focused helper opens a new `AsyncSessionLocal`, calls
+`OrderProposalsService.record_fill_evidence`, commits that independent session,
+and returns whether a non-terminal Upbit rung matched. It passes the Upbit UUID
+as `broker_order_id`, the websocket `identifier` as `idempotency_key`, and
+`account_mode="upbit"` so evidence cannot cross account boundaries. The proposal
+repository and service gain this optional evidence key because Upbit submission
+stores the client identifier on `OrderProposalRung.idempotency_key`, not on
+`correlation_id`.
+
+`trade` means `partially_filled` and projects cumulative `executed_volume`, while
+its execution-ledger row and notification use the event's per-trade `volume`.
+`done` means `filled` and uses the same cumulative quantity. A `done` payload is
+order-level cumulative evidence rather than a new trade delta, so it closes the
+rung only after verifying that a durable ledger fill already exists for the
+same Upbit UUID, without inserting another execution-ledger row; the preceding
+`trade` event owns that row. Other states are ignored; no terminal state is
+inferred without broker evidence. Projection exceptions are logged and swallowed
+because the execution ledger remains authoritative and a later reconcile can
+converge the rung.
+
+The boolean match result is passed to `_send_fill_notification` as a
+`proposal_rung_fill` flag. Only matched proposal fills bypass the currency
+threshold; unmatched fills retain existing notification behavior. Duplicate
+ledger events skip duplicate notifications after a successful projection, while
+a redelivery may send the alert if it is the first attempt that successfully
+projects the rung after an earlier best-effort projection failure and the
+ordinary notification was suppressed by the small-fill threshold. Large fills
+are never notified twice during projection recovery.
+
+## Runtime health
+
+`UnifiedWebSocketMonitor._on_upbit_order` is the `myOrder` consumer boundary, so
+the monitor increments Upbit message/event counters and timestamps there before
+state filtering. Health logging combines those values with the existing KIS
+snapshot according to enabled mode and continues to report successful
+notification forwarding through `fills_forwarded`.
+
+## Tests
+
+All tests use fake sessions, repositories, services, websocket iterators, and
+notifiers. Coverage includes trade/done projection semantics, UUID/identifier
+matching, account scoping, independent commit, no-match behavior, exception
+swallowing, duplicate idempotency, small matched-rung notification delivery, and
+Upbit health counter/timestamp updates. No broker or real websocket is contacted.
+
+## Deployment
+
+`com.robinco.auto-trader.upbit-websocket` is a single-active launchd service,
+not part of the API/MCP blue/green pair. Deployment must restart that service;
+the repository's native deploy workflow does so in
+`restart_single_active_services`, while out-of-band deployment requires an
+explicit launchd restart.

--- a/tests/services/execution_ledger/test_repository.py
+++ b/tests/services/execution_ledger/test_repository.py
@@ -133,6 +133,45 @@ def test_values_differ_detects_changed_fill_price() -> None:
     assert _values_differ(row, changed) is True
 
 
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_has_fill_for_order_requires_exact_durable_scope(db_session) -> None:
+    fill = _fill(broker_order_id="ROB868-DONE-GATE", source="websocket")
+    repo = ExecutionLedgerRepository(db_session)
+    await repo.upsert_fill(fill)
+    await db_session.commit()
+
+    try:
+        assert await repo.has_fill_for_order(
+            broker="upbit",
+            account_mode="live",
+            venue="upbit_krw",
+            broker_order_id="ROB868-DONE-GATE",
+        )
+        assert not await repo.has_fill_for_order(
+            broker="upbit",
+            account_mode="live",
+            venue="upbit_krw",
+            broker_order_id="ROB868-MISSING",
+        )
+        for wrong_scope in (
+            {"broker": "kis", "account_mode": "live", "venue": "upbit_krw"},
+            {"broker": "upbit", "account_mode": "mock", "venue": "upbit_krw"},
+            {"broker": "upbit", "account_mode": "live", "venue": "upbit_usdt"},
+        ):
+            assert not await repo.has_fill_for_order(
+                **wrong_scope,
+                broker_order_id="ROB868-DONE-GATE",
+            )
+    finally:
+        await db_session.execute(
+            delete(ExecutionLedger).where(
+                ExecutionLedger.broker_order_id == "ROB868-DONE-GATE"
+            )
+        )
+        await db_session.commit()
+
+
 # --- Issue 4 regression: wider unique key (account_mode + venue) ---
 
 

--- a/tests/services/order_proposals/test_service.py
+++ b/tests/services/order_proposals/test_service.py
@@ -1355,6 +1355,79 @@ async def test_fill_evidence_books_by_correlation_id(db_session):
 
 
 @pytest.mark.asyncio
+async def test_fill_evidence_books_upbit_rung_by_identifier(db_session):
+    service, group = await _create_single_rung(
+        db_session,
+        symbol="BTC/KRW",
+        account_mode="upbit",
+        market="crypto",
+    )
+    now = datetime(2026, 7, 14, 9, 6, tzinfo=UTC)
+    identifier = f"rob868-{group.proposal_id}"
+    await _drive_to_submitting(service, group.proposal_id)
+    await service.record_resting(
+        group.proposal_id,
+        0,
+        broker_order_id=f"upbit-{group.proposal_id}",
+        correlation_id=f"corr-{group.proposal_id}",
+        idempotency_key=identifier,
+        approval_hash_digest=f"digest-{group.proposal_id}",
+        now=now,
+    )
+    await db_session.commit()
+
+    booked = await service.record_fill_evidence(
+        idempotency_key=identifier,
+        filled_qty=Decimal("0.0003"),
+        terminal_state="partially_filled",
+        now=now + timedelta(seconds=1),
+        account_mode="upbit",
+    )
+
+    assert booked is not None
+    assert booked.state == "partially_filled"
+    assert booked.filled_qty == Decimal("0.0003")
+
+    duplicate_partial = await service.record_fill_evidence(
+        idempotency_key=identifier,
+        filled_qty=Decimal("0.0003"),
+        terminal_state="partially_filled",
+        now=now + timedelta(milliseconds=1500),
+        account_mode="upbit",
+    )
+    stale_partial = await service.record_fill_evidence(
+        idempotency_key=identifier,
+        filled_qty=Decimal("0.0002"),
+        terminal_state="partially_filled",
+        now=now + timedelta(milliseconds=1750),
+        account_mode="upbit",
+    )
+
+    assert duplicate_partial is None
+    assert stale_partial is None
+    assert booked.filled_qty == Decimal("0.0003")
+
+    filled = await service.record_fill_evidence(
+        idempotency_key=identifier,
+        filled_qty=Decimal("0.0003"),
+        terminal_state="filled",
+        now=now + timedelta(seconds=2),
+        account_mode="upbit",
+    )
+    duplicate_reconcile = await service.record_fill_evidence(
+        broker_order_id=f"upbit-{group.proposal_id}",
+        filled_qty=Decimal("0.0003"),
+        terminal_state="filled",
+        now=now + timedelta(seconds=3),
+        account_mode="upbit",
+    )
+
+    assert filled is not None
+    assert filled.state == "filled"
+    assert duplicate_reconcile is None
+
+
+@pytest.mark.asyncio
 async def test_fill_evidence_books_partial_then_filled_by_broker_order_id(db_session):
     service, group = await _create_single_rung(db_session)
     now = datetime(2026, 7, 10, 9, 7, tzinfo=UTC)

--- a/tests/services/order_proposals/test_service.py
+++ b/tests/services/order_proposals/test_service.py
@@ -1355,6 +1355,49 @@ async def test_fill_evidence_books_by_correlation_id(db_session):
 
 
 @pytest.mark.asyncio
+async def test_fill_evidence_prefers_exact_broker_order_over_reused_correlation(
+    db_session,
+):
+    service, older_group = await _create_single_rung(db_session)
+    _, target_group = await _create_single_rung(db_session)
+    now = datetime(2026, 7, 14, 9, 6, tzinfo=UTC)
+    correlation_id = f"reused-correlation-{target_group.proposal_id}"
+    older_broker_order_id = f"older-{older_group.proposal_id}"
+    target_broker_order_id = f"target-{target_group.proposal_id}"
+
+    for group, broker_order_id in (
+        (older_group, older_broker_order_id),
+        (target_group, target_broker_order_id),
+    ):
+        await _drive_to_submitting(service, group.proposal_id)
+        await service.record_resting(
+            group.proposal_id,
+            0,
+            broker_order_id=broker_order_id,
+            correlation_id=correlation_id,
+            idempotency_key=f"idem-{group.proposal_id}",
+            approval_hash_digest=f"digest-{group.proposal_id}",
+            now=now,
+        )
+    await db_session.commit()
+
+    booked = await service.record_fill_evidence(
+        correlation_id=correlation_id,
+        broker_order_id=target_broker_order_id,
+        filled_qty=Decimal("0.5"),
+        terminal_state="partially_filled",
+        now=now + timedelta(seconds=1),
+    )
+    older_rung = (await service.get_proposal(older_group.proposal_id))[1][0]
+    target_rung = (await service.get_proposal(target_group.proposal_id))[1][0]
+
+    assert booked is not None
+    assert booked.id == target_rung.id
+    assert older_rung.state == "resting"
+    assert target_rung.state == "partially_filled"
+
+
+@pytest.mark.asyncio
 async def test_fill_evidence_books_upbit_rung_by_identifier(db_session):
     service, group = await _create_single_rung(
         db_session,

--- a/tests/test_fill_notification.py
+++ b/tests/test_fill_notification.py
@@ -52,6 +52,22 @@ class TestNormalizeUpbitFill:
         assert order.order_price == 3_001_500
         assert order.filled_at == "2026-02-14T18:15:22"
 
+    def test_myorder_trade_uses_trade_volume_before_cumulative_volume(self) -> None:
+        raw = {
+            "code": "KRW-BTC",
+            "ask_bid": "BID",
+            "state": "trade",
+            "price": 50_000_000,
+            "volume": "0.1",
+            "executed_volume": "0.3",
+            "trade_uuid": "trade-third-partial",
+        }
+
+        order = normalize_upbit_fill(raw)
+
+        assert order.filled_qty == pytest.approx(0.1)
+        assert order.filled_amount == pytest.approx(5_000_000)
+
 
 class TestNormalizeKisFill:
     """KIS 체결 데이터 정규화 테스트"""

--- a/tests/test_websocket_monitor.py
+++ b/tests/test_websocket_monitor.py
@@ -1,6 +1,7 @@
 """Tests for unified WebSocket monitor."""
 
 import asyncio
+from decimal import Decimal
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -177,6 +178,206 @@ class TestUnifiedWebSocketMonitor:
         assert call_order == ["ledger", "notify"]
 
     @pytest.mark.asyncio
+    async def test_on_upbit_trade_projects_committed_fill_before_notification(
+        self, mock_settings: None
+    ) -> None:
+        from websocket_monitor import UnifiedWebSocketMonitor
+
+        call_order: list[str] = []
+        monitor = UnifiedWebSocketMonitor(mode="upbit")
+
+        async def record_side_effect(*args, **kwargs):
+            call_order.append("ledger")
+            return "inserted"
+
+        async def project_side_effect(*args, **kwargs):
+            call_order.append("projection")
+            return True
+
+        async def send_side_effect(*args, **kwargs):
+            call_order.append("notify")
+
+        monitor._record_execution_ledger_fill = AsyncMock(
+            side_effect=record_side_effect
+        )
+        monitor._project_upbit_proposal_fill = AsyncMock(
+            side_effect=project_side_effect
+        )
+        monitor._send_fill_notification = AsyncMock(side_effect=send_side_effect)
+
+        event = {
+            "code": "KRW-BTC",
+            "uuid": "upbit-order-rob868",
+            "identifier": "rob868-proposal-rung",
+            "ask_bid": "BID",
+            "trade_price": 92_800_000,
+            "trade_volume": 0.0003,
+            "executed_volume": "0.0003",
+            "state": "trade",
+            "trade_timestamp": 1_752_409_595_000,
+        }
+
+        await monitor._on_upbit_order(event)
+
+        monitor._project_upbit_proposal_fill.assert_awaited_once_with(event)
+        assert monitor._send_fill_notification.await_args is not None
+        assert monitor._send_fill_notification.await_args.kwargs == {
+            "proposal_rung_fill": True
+        }
+        assert call_order == ["ledger", "projection", "notify"]
+
+    @pytest.mark.asyncio
+    async def test_on_upbit_done_projects_terminal_fill(
+        self, mock_settings: None
+    ) -> None:
+        from websocket_monitor import UnifiedWebSocketMonitor
+
+        monitor = UnifiedWebSocketMonitor(mode="upbit")
+        monitor._record_execution_ledger_fill = AsyncMock(return_value="inserted")
+        monitor._has_committed_upbit_execution_fill = AsyncMock(return_value=True)
+        monitor._project_upbit_proposal_fill = AsyncMock(return_value=True)
+        monitor._send_fill_notification = AsyncMock()
+        event = {
+            "code": "KRW-BTC",
+            "uuid": "upbit-order-done",
+            "identifier": "rob868-proposal-done",
+            "ask_bid": "BID",
+            "price": "92800000",
+            "executed_volume": "0.0003",
+            "state": "done",
+            "timestamp": 1_752_409_596_000,
+        }
+
+        await monitor._on_upbit_order(event)
+
+        monitor._record_execution_ledger_fill.assert_not_awaited()
+        monitor._has_committed_upbit_execution_fill.assert_awaited_once_with(event)
+        monitor._project_upbit_proposal_fill.assert_awaited_once_with(event)
+        monitor._send_fill_notification.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_on_upbit_done_without_committed_fill_skips_terminal_projection(
+        self, mock_settings: None
+    ) -> None:
+        from websocket_monitor import UnifiedWebSocketMonitor
+
+        monitor = UnifiedWebSocketMonitor(mode="upbit")
+        monitor._record_execution_ledger_fill = AsyncMock()
+        monitor._has_committed_upbit_execution_fill = AsyncMock(return_value=False)
+        monitor._project_upbit_proposal_fill = AsyncMock()
+        event = {
+            "code": "KRW-BTC",
+            "uuid": "upbit-order-no-ledger",
+            "identifier": "rob868-proposal-no-ledger",
+            "state": "done",
+            "executed_volume": "0.0003",
+        }
+
+        await monitor._on_upbit_order(event)
+
+        monitor._record_execution_ledger_fill.assert_not_awaited()
+        monitor._project_upbit_proposal_fill.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_on_upbit_duplicate_projects_idempotently_and_notifies_once(
+        self, mock_settings: None
+    ) -> None:
+        from websocket_monitor import UnifiedWebSocketMonitor
+
+        monitor = UnifiedWebSocketMonitor(mode="upbit")
+        monitor._record_execution_ledger_fill = AsyncMock(
+            side_effect=["inserted", "unchanged"]
+        )
+        monitor._project_upbit_proposal_fill = AsyncMock(side_effect=[True, False])
+        monitor._send_fill_notification = AsyncMock()
+        event = {
+            "code": "KRW-BTC",
+            "uuid": "upbit-order-duplicate-proposal",
+            "identifier": "rob868-proposal-duplicate",
+            "ask_bid": "BID",
+            "trade_price": 92_800_000,
+            "executed_volume": "0.0003",
+            "state": "trade",
+            "trade_timestamp": 1_752_409_595_000,
+        }
+
+        await monitor._on_upbit_order(event)
+        await monitor._on_upbit_order(event)
+
+        assert monitor._project_upbit_proposal_fill.await_count == 2
+        monitor._send_fill_notification.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_on_upbit_duplicate_recovers_projection_and_small_alert(
+        self, mock_settings: None
+    ) -> None:
+        from websocket_monitor import UnifiedWebSocketMonitor
+
+        monitor = UnifiedWebSocketMonitor(mode="upbit")
+        monitor._record_execution_ledger_fill = AsyncMock(
+            side_effect=["inserted", "unchanged"]
+        )
+        monitor._project_upbit_proposal_fill = AsyncMock(side_effect=[False, True])
+        notification_attempts: list[bool] = []
+
+        async def capture_notification(*args, **kwargs) -> None:
+            notification_attempts.append(bool(kwargs.get("proposal_rung_fill")))
+
+        monitor._send_fill_notification = AsyncMock(side_effect=capture_notification)
+        event = {
+            "code": "KRW-BTC",
+            "uuid": "upbit-order-projection-retry",
+            "identifier": "rob868-proposal-projection-retry",
+            "ask_bid": "BID",
+            "trade_price": 92_800_000,
+            "volume": "0.0003",
+            "executed_volume": "0.0003",
+            "state": "trade",
+            "trade_uuid": "upbit-trade-projection-retry",
+            "trade_timestamp": 1_752_409_595_000,
+        }
+
+        await monitor._on_upbit_order(event)
+        await monitor._on_upbit_order(event)
+
+        assert notification_attempts == [False, True]
+
+    @pytest.mark.asyncio
+    async def test_on_upbit_projection_recovery_does_not_repeat_large_fill_alert(
+        self, mock_settings: None
+    ) -> None:
+        from websocket_monitor import UnifiedWebSocketMonitor
+
+        monitor = UnifiedWebSocketMonitor(mode="upbit")
+        monitor._record_execution_ledger_fill = AsyncMock(
+            side_effect=["inserted", "unchanged"]
+        )
+        monitor._project_upbit_proposal_fill = AsyncMock(side_effect=[False, True])
+        notification_attempts: list[bool] = []
+
+        async def capture_notification(*args, **kwargs) -> None:
+            notification_attempts.append(bool(kwargs.get("proposal_rung_fill")))
+
+        monitor._send_fill_notification = AsyncMock(side_effect=capture_notification)
+        event = {
+            "code": "KRW-BTC",
+            "uuid": "upbit-order-large-projection-retry",
+            "identifier": "rob868-proposal-large-projection-retry",
+            "ask_bid": "BID",
+            "trade_price": 92_800_000,
+            "volume": "0.001",
+            "executed_volume": "0.001",
+            "state": "trade",
+            "trade_uuid": "upbit-trade-large-projection-retry",
+            "trade_timestamp": 1_752_409_595_000,
+        }
+
+        await monitor._on_upbit_order(event)
+        await monitor._on_upbit_order(event)
+
+        assert notification_attempts == [False]
+
+    @pytest.mark.asyncio
     async def test_on_kis_execution_skips_notification_for_unchanged_ledger_row(
         self, mock_settings: None
     ) -> None:
@@ -213,6 +414,7 @@ class TestUnifiedWebSocketMonitor:
         record_mock = AsyncMock(return_value="unchanged")
         send_mock = AsyncMock()
         monitor._record_execution_ledger_fill = record_mock
+        monitor._project_upbit_proposal_fill = AsyncMock(return_value=False)
         monitor._send_fill_notification = send_mock
 
         event = {
@@ -340,6 +542,229 @@ class TestUnifiedWebSocketMonitor:
         assert fill.correlation_id == "corr-kis-upsert"
         assert fill.source == "websocket"
         assert fill.raw_payload_json["token"] == "[REDACTED]"
+
+    @pytest.mark.asyncio
+    async def test_has_committed_upbit_execution_fill_uses_exact_scope(
+        self,
+        mock_settings: None,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        import websocket_monitor as mod
+        from websocket_monitor import UnifiedWebSocketMonitor
+
+        captured: dict[str, object] = {}
+
+        class FakeSession:
+            async def __aenter__(self) -> object:
+                captured["session"] = self
+                return self
+
+            async def __aexit__(
+                self, exc_type: object, exc: object, tb: object
+            ) -> None:
+                return None
+
+        class FakeRepository:
+            def __init__(self, db: object) -> None:
+                assert db is captured["session"]
+
+            async def has_fill_for_order(self, **kwargs: object) -> bool:
+                captured["lookup"] = kwargs
+                return True
+
+        monkeypatch.setattr(mod, "AsyncSessionLocal", lambda: FakeSession())
+        monkeypatch.setattr(mod, "ExecutionLedgerRepository", FakeRepository)
+        monitor = UnifiedWebSocketMonitor(mode="upbit")
+
+        exists = await monitor._has_committed_upbit_execution_fill(
+            {"uuid": "upbit-order-durable", "venue": "upbit_krw"}
+        )
+
+        assert exists is True
+        assert captured["lookup"] == {
+            "broker": "upbit",
+            "account_mode": "live",
+            "venue": "upbit_krw",
+            "broker_order_id": "upbit-order-durable",
+        }
+
+        unused_session_factory = MagicMock()
+        monkeypatch.setattr(mod, "AsyncSessionLocal", unused_session_factory)
+        assert not await monitor._has_committed_upbit_execution_fill({"uuid": ""})
+        unused_session_factory.assert_not_called()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("state", "terminal_state"),
+        [("trade", "partially_filled"), ("done", "filled")],
+    )
+    async def test_project_upbit_proposal_fill_uses_independent_committed_session(
+        self,
+        mock_settings: None,
+        monkeypatch: pytest.MonkeyPatch,
+        state: str,
+        terminal_state: str,
+    ) -> None:
+        import websocket_monitor as mod
+        from websocket_monitor import UnifiedWebSocketMonitor
+
+        captured: dict[str, object] = {}
+
+        class FakeSession:
+            async def __aenter__(self) -> object:
+                captured["session"] = self
+                return self
+
+            async def __aexit__(
+                self, exc_type: object, exc: object, tb: object
+            ) -> None:
+                return None
+
+            async def commit(self) -> None:
+                captured["committed"] = True
+
+        class FakeService:
+            def __init__(self, db: object) -> None:
+                assert db is captured["session"]
+
+            async def record_fill_evidence(self, **kwargs: object) -> object:
+                captured["evidence"] = kwargs
+                return MagicMock(state=terminal_state)
+
+        monkeypatch.setattr(mod, "AsyncSessionLocal", lambda: FakeSession())
+        monkeypatch.setattr(mod, "OrderProposalsService", FakeService, raising=False)
+        monitor = UnifiedWebSocketMonitor(mode="upbit")
+
+        matched = await monitor._project_upbit_proposal_fill(
+            {
+                "state": state,
+                "uuid": "upbit-order-id",
+                "identifier": "proposal-client-id",
+                "executed_volume": "0.0003",
+            }
+        )
+
+        evidence = captured["evidence"]
+        assert matched is True
+        assert captured["committed"] is True
+        assert evidence["idempotency_key"] == "proposal-client-id"
+        assert evidence["broker_order_id"] == "upbit-order-id"
+        assert evidence["filled_qty"] == Decimal("0.0003")
+        assert evidence["terminal_state"] == terminal_state
+        assert evidence["account_mode"] == "upbit"
+
+    @pytest.mark.asyncio
+    async def test_project_upbit_proposal_fill_logs_missing_match(
+        self,
+        mock_settings: None,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        import websocket_monitor as mod
+        from websocket_monitor import UnifiedWebSocketMonitor
+
+        class FakeSession:
+            async def __aenter__(self) -> object:
+                return self
+
+            async def __aexit__(
+                self, exc_type: object, exc: object, tb: object
+            ) -> None:
+                return None
+
+            async def commit(self) -> None:
+                return None
+
+        fake_service = MagicMock()
+        fake_service.record_fill_evidence = AsyncMock(return_value=None)
+        monkeypatch.setattr(mod, "AsyncSessionLocal", lambda: FakeSession())
+        monkeypatch.setattr(
+            mod,
+            "OrderProposalsService",
+            lambda _db: fake_service,
+            raising=False,
+        )
+        caplog.set_level("INFO")
+
+        matched = await UnifiedWebSocketMonitor(
+            mode="upbit"
+        )._project_upbit_proposal_fill(
+            {
+                "state": "trade",
+                "uuid": "missing-order",
+                "identifier": "missing-identifier",
+                "executed_volume": "0.1",
+            }
+        )
+
+        assert matched is False
+        assert "no matching proposal rung" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_project_upbit_proposal_fill_skips_non_positive_cumulative_quantity(
+        self,
+        mock_settings: None,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        import websocket_monitor as mod
+        from websocket_monitor import UnifiedWebSocketMonitor
+
+        session_factory = MagicMock()
+        monkeypatch.setattr(mod, "AsyncSessionLocal", session_factory)
+        caplog.set_level("INFO")
+
+        matched = await UnifiedWebSocketMonitor(
+            mode="upbit"
+        )._project_upbit_proposal_fill(
+            {
+                "state": "done",
+                "uuid": "upbit-order-zero",
+                "identifier": "proposal-zero",
+                "executed_volume": "0",
+            }
+        )
+
+        assert matched is False
+        session_factory.assert_not_called()
+        assert "missing cumulative fill" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_project_upbit_proposal_fill_logs_and_swallows_db_error(
+        self,
+        mock_settings: None,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        import websocket_monitor as mod
+        from websocket_monitor import UnifiedWebSocketMonitor
+
+        class FailingSession:
+            async def __aenter__(self) -> object:
+                raise RuntimeError("proposal db unavailable")
+
+            async def __aexit__(
+                self, exc_type: object, exc: object, tb: object
+            ) -> None:
+                return None
+
+        monkeypatch.setattr(mod, "AsyncSessionLocal", lambda: FailingSession())
+        caplog.set_level("ERROR")
+
+        matched = await UnifiedWebSocketMonitor(
+            mode="upbit"
+        )._project_upbit_proposal_fill(
+            {
+                "state": "trade",
+                "uuid": "upbit-order-error",
+                "identifier": "proposal-error",
+                "executed_volume": "0.1",
+            }
+        )
+
+        assert matched is False
+        assert "Upbit proposal rung projection failed" in caplog.text
+        assert "proposal db unavailable" in caplog.text
 
     @pytest.mark.asyncio
     async def test_on_kis_execution_forwards_us_currency_for_overseas_fill(
@@ -593,6 +1018,41 @@ class TestUnifiedWebSocketMonitor:
         fake_notifier.notify_fill.assert_not_awaited()
 
     @pytest.mark.asyncio
+    async def test_send_fill_notification_sends_small_proposal_rung_fill(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from websocket_monitor import UnifiedWebSocketMonitor
+
+        monitor = UnifiedWebSocketMonitor(mode="upbit")
+        fake_notifier = AsyncMock()
+        fake_notifier.notify_fill = AsyncMock(return_value=True)
+        monkeypatch.setattr(
+            "websocket_monitor.get_trade_notifier", lambda: fake_notifier
+        )
+        monkeypatch.setattr(
+            "websocket_monitor.fetch_fill_enrichment", AsyncMock(return_value=None)
+        )
+
+        await monitor._send_fill_notification(
+            FillOrder(
+                symbol="KRW-BTC",
+                side="bid",
+                filled_price=92_800_000.0,
+                filled_qty=0.0003,
+                filled_amount=27_840.0,
+                filled_at="2026-07-13T21:39:55+09:00",
+                account="upbit",
+                order_id="upbit-small-rung",
+                market_type="crypto",
+                currency="KRW",
+            ),
+            proposal_rung_fill=True,
+        )
+
+        fake_notifier.notify_fill.assert_awaited_once()
+        assert monitor.fills_forwarded == 1
+
+    @pytest.mark.asyncio
     async def test_enrichment_failure_does_not_block(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -660,6 +1120,58 @@ class TestUnifiedWebSocketMonitor:
         assert "fills_forwarded=3" in caplog.text
         assert "last_pingpong_at=2026-03-09T14:01:10+00:00" in caplog.text
         assert "last_agent_success_at=2026-03-09T14:00:00+00:00" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_upbit_consumer_updates_health_counters(
+        self, mock_settings: None
+    ) -> None:
+        from websocket_monitor import UnifiedWebSocketMonitor
+
+        monitor = UnifiedWebSocketMonitor(mode="upbit")
+        monitor._record_execution_ledger_fill = AsyncMock(return_value="unchanged")
+        monitor._project_upbit_proposal_fill = AsyncMock(return_value=False)
+        monitor._send_fill_notification = AsyncMock()
+
+        await monitor._on_upbit_order({"state": "wait", "code": "KRW-BTC"})
+        await monitor._on_upbit_order(
+            {
+                "state": "trade",
+                "code": "KRW-BTC",
+                "uuid": "upbit-health-order",
+                "trade_price": 92_800_000,
+                "executed_volume": "0.0003",
+            }
+        )
+
+        assert monitor.upbit_messages_received == 2
+        assert monitor.upbit_execution_events_received == 1
+        assert monitor.upbit_last_message_at is not None
+        assert monitor.upbit_last_execution_at is not None
+
+    @pytest.mark.asyncio
+    async def test_log_health_status_uses_upbit_consumer_counters(
+        self,
+        mock_settings: None,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        from websocket_monitor import UnifiedWebSocketMonitor
+
+        monitor = UnifiedWebSocketMonitor(mode="upbit")
+        monitor.is_running = True
+        monitor._started_at_monotonic = asyncio.get_running_loop().time() - 5
+        monitor.upbit_ws = MagicMock(is_connected=True)
+        monitor.upbit_messages_received = 7
+        monitor.upbit_execution_events_received = 3
+        monitor.upbit_last_message_at = "2026-07-13T12:39:55+00:00"
+        monitor.upbit_last_execution_at = "2026-07-13T12:39:56+00:00"
+
+        caplog.set_level("INFO")
+        monitor._log_health_status(force=True)
+
+        assert "messages_received=7" in caplog.text
+        assert "execution_events_received=3" in caplog.text
+        assert "last_message_at=2026-07-13T12:39:55+00:00" in caplog.text
+        assert "last_execution_at=2026-07-13T12:39:56+00:00" in caplog.text
 
     @pytest.mark.asyncio
     async def test_log_health_status_reports_mixed_backend_states_in_both_mode(

--- a/websocket_monitor.py
+++ b/websocket_monitor.py
@@ -37,6 +37,7 @@ from app.services.fill_notification import (
     normalize_upbit_fill,
 )
 from app.services.kis_websocket import KISAppKeyInUseError, KISExecutionWebSocket
+from app.services.order_proposals import OrderProposalsService
 from app.services.upbit_websocket import UpbitMyOrderWebSocket
 
 logger = logging.getLogger(__name__)
@@ -77,6 +78,10 @@ class UnifiedWebSocketMonitor:
         self._started_at_monotonic: float | None = None
         self.fills_forwarded = 0
         self.last_agent_success_at: str | None = None
+        self.upbit_messages_received = 0
+        self.upbit_execution_events_received = 0
+        self.upbit_last_message_at: str | None = None
+        self.upbit_last_execution_at: str | None = None
         self._kis_messages_received_closed = 0
         self._kis_execution_events_received_closed = 0
         self._kis_last_message_at_closed: str | None = None
@@ -168,14 +173,36 @@ class UnifiedWebSocketMonitor:
         """
         Upbit 주문/체결 이벤트 처리
 
-        state == "trade"인 체결만 알림 대상으로 필터링합니다.
+        state가 ``trade`` 또는 ``done``인 체결을 처리합니다.
         """
-        state = order_data.get("state")
-        if state != "trade":
+        received_at = datetime.now(UTC).isoformat()
+        self.upbit_messages_received += 1
+        self.upbit_last_message_at = received_at
+        state = str(order_data.get("state") or "")
+        if state not in {"trade", "done"}:
             logger.debug(f"Upbit non-trade state ignored: {state}")
             return
+        self.upbit_execution_events_received += 1
+        self.upbit_last_execution_at = received_at
 
         try:
+            if state == "done":
+                # ``done`` carries order-level cumulative executed_volume, not
+                # a new trade delta. The preceding ``trade`` event owns the
+                # execution-ledger row; terminal evidence only closes the rung.
+                if not await self._has_committed_upbit_execution_fill(order_data):
+                    logger.warning(
+                        "Upbit terminal projection skipped without committed fill: "
+                        "order_id=%s",
+                        order_data.get("uuid"),
+                    )
+                    return
+                await self._project_upbit_proposal_fill(order_data)
+                logger.info(
+                    "Upbit terminal fill evidence processed: order_id=%s",
+                    order_data.get("uuid"),
+                )
+                return
             fill_order = normalize_upbit_fill(order_data)
             upsert_status = await self._record_execution_ledger_fill(
                 order_data,
@@ -183,8 +210,20 @@ class UnifiedWebSocketMonitor:
                 broker="upbit",
                 correlation_id=str(order_data.get("uuid") or "n/a"),
             )
-            if upsert_status not in {"updated", "unchanged"}:
-                await self._send_fill_notification(fill_order)
+            proposal_rung_fill = False
+            if upsert_status is not None:
+                proposal_rung_fill = await self._project_upbit_proposal_fill(order_data)
+            duplicate_ledger_fill = upsert_status in {"updated", "unchanged"}
+            recover_suppressed_small_alert = (
+                duplicate_ledger_fill
+                and proposal_rung_fill
+                and not is_fill_notifiable(fill_order)
+            )
+            if not duplicate_ledger_fill or recover_suppressed_small_alert:
+                await self._send_fill_notification(
+                    fill_order,
+                    proposal_rung_fill=proposal_rung_fill,
+                )
             else:
                 logger.info(
                     "Upbit fill notification skipped for duplicate ledger row: symbol=%s status=%s",
@@ -197,6 +236,87 @@ class UnifiedWebSocketMonitor:
             )
         except Exception as e:
             logger.error(f"Upbit fill processing error: {e}", exc_info=True)
+
+    async def _has_committed_upbit_execution_fill(
+        self, order_data: dict[str, Any]
+    ) -> bool:
+        """Check the durable ledger before applying cumulative terminal evidence."""
+        broker_order_id = str(order_data.get("uuid") or "").strip()
+        if not broker_order_id:
+            return False
+        venue = str(order_data.get("venue") or "upbit_krw")
+        async with AsyncSessionLocal() as db:
+            return await ExecutionLedgerRepository(db).has_fill_for_order(
+                broker="upbit",
+                account_mode="live",
+                venue=venue,
+                broker_order_id=broker_order_id,
+            )
+
+    async def _project_upbit_proposal_fill(self, order_data: dict[str, Any]) -> bool:
+        """Best-effort projection of committed Upbit evidence into one rung."""
+        state = str(order_data.get("state") or "")
+        terminal_state = {
+            "trade": "partially_filled",
+            "done": "filled",
+        }.get(state)
+        if terminal_state is None:
+            return False
+
+        broker_order_id = str(order_data.get("uuid") or "").strip() or None
+        identifier = str(order_data.get("identifier") or "").strip() or None
+        try:
+            filled_qty = Decimal(str(order_data.get("executed_volume") or "0"))
+            if filled_qty <= 0:
+                logger.info(
+                    "Upbit proposal rung projection skipped: missing cumulative fill "
+                    "order_id=%s identifier=%s state=%s",
+                    broker_order_id,
+                    identifier,
+                    state,
+                )
+                return False
+            async with AsyncSessionLocal() as db:
+                rung = await OrderProposalsService(db).record_fill_evidence(
+                    idempotency_key=identifier,
+                    broker_order_id=broker_order_id,
+                    filled_qty=filled_qty,
+                    terminal_state=terminal_state,
+                    now=datetime.now(UTC),
+                    account_mode="upbit",
+                )
+                await db.commit()
+        except Exception as exc:  # noqa: BLE001 - ledger commit remains authoritative
+            logger.error(
+                "Upbit proposal rung projection failed: order_id=%s identifier=%s "
+                "state=%s error=%s",
+                broker_order_id,
+                identifier,
+                state,
+                exc,
+                exc_info=True,
+            )
+            return False
+
+        if rung is None:
+            logger.info(
+                "Upbit proposal rung projection found no matching proposal rung: "
+                "order_id=%s identifier=%s state=%s",
+                broker_order_id,
+                identifier,
+                state,
+            )
+            return False
+        logger.info(
+            "Upbit proposal rung projected: order_id=%s identifier=%s state=%s "
+            "rung_state=%s cumulative_filled_qty=%s",
+            broker_order_id,
+            identifier,
+            state,
+            rung.state,
+            filled_qty,
+        )
+        return True
 
     async def _on_kis_execution(self, event: dict[str, Any]) -> None:
         """
@@ -395,10 +515,14 @@ class UnifiedWebSocketMonitor:
         return status
 
     async def _send_fill_notification(
-        self, order: FillOrder, *, correlation_id: str | None = None
+        self,
+        order: FillOrder,
+        *,
+        correlation_id: str | None = None,
+        proposal_rung_fill: bool = False,
     ) -> None:
         """체결 알림: 통화 임계 → best-effort 보강 → TradeNotifier (fire-and-forget)."""
-        if not is_fill_notifiable(order):
+        if not proposal_rung_fill and not is_fill_notifiable(order):
             logger.info(
                 "Fill notification skipped: below threshold symbol=%s amount=%s currency=%s",
                 order.symbol,
@@ -589,7 +713,7 @@ class UnifiedWebSocketMonitor:
         uptime = 0.0
         if self._started_at_monotonic is not None:
             uptime = round(now - self._started_at_monotonic, 1)
-        kis_snapshot = self._current_kis_stats_snapshot()
+        runtime_snapshot = self._current_runtime_stats_snapshot()
         logger.info(
             "Unified WebSocket health: mode=%s connected=%s uptime=%s "
             "upbit_connected=%s kis_connected=%s "
@@ -601,12 +725,12 @@ class UnifiedWebSocketMonitor:
             uptime,
             upbit_connected,
             kis_connected,
-            kis_snapshot["messages_received"],
-            kis_snapshot["execution_events_received"],
+            runtime_snapshot["messages_received"],
+            runtime_snapshot["execution_events_received"],
             self.fills_forwarded,
-            kis_snapshot["last_message_at"],
-            kis_snapshot["last_execution_at"],
-            kis_snapshot["last_pingpong_at"],
+            runtime_snapshot["last_message_at"],
+            runtime_snapshot["last_execution_at"],
+            runtime_snapshot["last_pingpong_at"],
             self.last_agent_success_at,
         )
 
@@ -801,6 +925,38 @@ class UnifiedWebSocketMonitor:
                 if isinstance(current_snapshot["last_pingpong_at"], str)
                 else None,
             ),
+        }
+
+    def _current_runtime_stats_snapshot(self) -> dict[str, int | str | None]:
+        kis_snapshot = self._current_kis_stats_snapshot()
+        upbit_enabled = self.mode in {"upbit", "both"}
+        kis_enabled = self.mode in {"kis", "both"}
+        return {
+            "messages_received": (self.upbit_messages_received if upbit_enabled else 0)
+            + (int(kis_snapshot["messages_received"] or 0) if kis_enabled else 0),
+            "execution_events_received": (
+                self.upbit_execution_events_received if upbit_enabled else 0
+            )
+            + (
+                int(kis_snapshot["execution_events_received"] or 0)
+                if kis_enabled
+                else 0
+            ),
+            "last_message_at": self._latest_timestamp(
+                self.upbit_last_message_at if upbit_enabled else None,
+                kis_snapshot["last_message_at"]
+                if kis_enabled and isinstance(kis_snapshot["last_message_at"], str)
+                else None,
+            ),
+            "last_execution_at": self._latest_timestamp(
+                self.upbit_last_execution_at if upbit_enabled else None,
+                kis_snapshot["last_execution_at"]
+                if kis_enabled and isinstance(kis_snapshot["last_execution_at"], str)
+                else None,
+            ),
+            "last_pingpong_at": kis_snapshot["last_pingpong_at"]
+            if kis_enabled
+            else None,
         }
 
 


### PR DESCRIPTION
## Summary

- Project committed Upbit `myOrder` `trade` evidence into proposal rungs immediately using broker UUID and client `identifier`, with an independent committed proposal-service session scoped to `account_mode="upbit"`.
- Treat `trade` as cumulative `partially_filled` evidence and `done` as terminal `filled` evidence only after a durable ledger fill exists; repeated or stale cumulative evidence is a no-op.
- Preserve per-trade `volume` in execution-ledger rows, recover threshold-suppressed proposal alerts after a projection retry, avoid duplicate large-fill alerts, and expose real Upbit health counters/timestamps.

## Safety

- Projection failures are logged and swallowed; the committed execution ledger remains authoritative and later reconcile can converge the rung.
- `done` never inserts cumulative quantity as a second fill row and cannot terminalize a rung without an existing exact-scope durable Upbit fill.
- Tests use fake sessions/services/websocket payloads only; no broker or real websocket was contacted.

## Tests

- `make lint` — Ruff check/format and ty passed.
- `uv run ruff check websocket_monitor.py && uv run ruff format --check websocket_monitor.py` — passed.
- Related suite — 226 passed, 3 pre-existing warnings (Pydantic deprecations and one existing pytest mark warning).
- Full suite — 15,666 passed, 10 skipped, 7 deselected, 52 pre-existing warnings.

## Test Coverage

Coverage audit: 99%, 0 material gaps.

```text
Upbit myOrder
├─ trade delta → ledger → proposal projection ───── covered
├─ duplicate/stale partial idempotency ──────────── covered
├─ small-alert recovery / large-alert dedupe ────── covered
├─ done requires exact durable ledger evidence ─── covered
├─ UUID/identifier matching + independent commit ─ covered
└─ runtime health counters ──────────────────────── covered
```

## Review

Pre-Landing Review: No issues found after adversarial review fixes and final re-review.

## Deployment

The Upbit websocket consumer is the separate single-active launchd service `com.robinco.auto-trader.upbit-websocket`, not part of the API/MCP blue-green pair. 배포 후 해당 서비스 재시작 필요. `scripts/deploy-native.sh` automatically kickstarts it; manual or out-of-band deployment must restart it explicitly.

## Documentation

- `CHANGELOG.md`: recorded the ROB-868 behavior and restart contract.
- `UPBIT_WEBSOCKET_README.md`: documented the production `trade`/`done` flow, ledger-first proposal projection, matched-rung notification policy, health metrics, and single-active launchd restart.
- Added implementation design and plan documents under `docs/superpowers/`.

Coverage: ROB-868 has reference, operator how-to, and design explanation coverage; no remaining documentation debt identified.

## Plan Completion

- [x] Proposal projection and notification policy implemented and tested.
- [x] Upbit runtime health counters implemented and tested.
- [x] Quality gates, review, documentation, commits, push, and PR #1534 completed.
- [x] Single-active launchd restart contract documented; no external deployment action remains.

Plan completion audit: 11/11 done, 0 changed, 0 deferred, 0 unverifiable.
