### PR TITLE
fix(ROB-877): recover Toss absence proof

### DIFF
--- a/app/mcp_server/README.md
+++ b/app/mcp_server/README.md
@@ -688,10 +688,17 @@ order mutation.
   - A found broker order, incomplete lookup, timeout, provider error, or local
     accepted-only Toss ledger row rejects the whole request without partial
     mutation. Timeout-to-`unverified` is never auto-voided.
-  - Toss order-list `clientOrderId` is optional: when a rung has no broker order
-    ID, any non-empty response that omits it is inconclusive. KIS US empty
-    history is also inconclusive because the shared history adapter cannot prove
-    every exchange inquiry completed. Both cases fail closed.
+  - For a Toss rung without a broker order ID, absence requires both zero
+    accepted-only `toss_live_order_ledger` rows and a complete OPEN+CLOSED scan
+    with no order matching the normalized symbol, side, quantity, and price.
+    Quantity and price use finite Decimal comparison rather than string equality.
+    The per-rung attempt window is inclusive from `created_at - 24h` through
+    `max(valid_until, updated_at) + 24h`; the broker scan covers the union of
+    those windows' KST dates. Provider errors, timeouts, malformed potential
+    matches, invalid pagination, and CLOSED page-cap exhaustion make the scan
+    incomplete and fail closed instead of proving absence. KIS and Upbit
+    operator-void behavior is unchanged, including inconclusive KIS US empty
+    history when the shared adapter cannot prove every exchange inquiry finished.
   - After a successful void, the recorded Telegram approval message is edited
     without an inline keyboard so stale approval buttons no longer remain live.
 

--- a/app/mcp_server/tooling/order_proposal_tools.py
+++ b/app/mcp_server/tooling/order_proposal_tools.py
@@ -127,6 +127,7 @@ async def _fetch_void_evidence(*, group: Any, rungs: list[Any], now: datetime) -
         symbol=group.symbol,
         rungs=rungs,
         now=now,
+        valid_until=group.valid_until,
     )
 
 

--- a/app/services/order_proposals/broker_gateway.py
+++ b/app/services/order_proposals/broker_gateway.py
@@ -387,6 +387,8 @@ async def fetch_operator_void_evidence(
             to_date=window_to,
         )
         orders.extend(open_page.orders)
+        if open_page.has_next:
+            incomplete_reason = "OPEN order scan unexpectedly paginated"
 
         cursor: str | None = None
         seen_cursors: set[str] = set()

--- a/app/services/order_proposals/broker_gateway.py
+++ b/app/services/order_proposals/broker_gateway.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 import inspect
 from collections.abc import Callable
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timedelta
+from decimal import Decimal, InvalidOperation
 from typing import Any, Literal
 
 import httpx
@@ -39,6 +40,70 @@ class OperatorVoidEvidence:
 
 
 _TOSS_CLOSED_PAGE_CAP = 20
+_TOSS_VOID_WINDOW_PAD = timedelta(hours=24)
+
+
+def _finite_decimal(value: Any) -> Decimal | None:
+    if value is None:
+        return None
+    try:
+        parsed = Decimal(str(value))
+    except (InvalidOperation, ValueError):
+        raise ValueError("invalid decimal order evidence") from None
+    if not parsed.is_finite():
+        raise ValueError("non-finite decimal order evidence")
+    return parsed
+
+
+def _toss_rung_window(
+    rung: Any, *, valid_until: datetime | None
+) -> tuple[datetime, datetime]:
+    start = rung.created_at - _TOSS_VOID_WINDOW_PAD
+    attempt_end = max(
+        value for value in (valid_until, rung.updated_at) if value is not None
+    )
+    return start, attempt_end + _TOSS_VOID_WINDOW_PAD
+
+
+def _aware_datetime(value: Any, *, field: str) -> datetime:
+    if (
+        not isinstance(value, datetime)
+        or value.tzinfo is None
+        or value.utcoffset() is None
+    ):
+        raise ValueError(f"{field} must be a timezone-aware datetime")
+    return value
+
+
+def _parse_aware_iso_datetime(value: Any, *, field: str) -> datetime:
+    try:
+        parsed = datetime.fromisoformat(str(value))
+    except (TypeError, ValueError):
+        raise ValueError(f"invalid {field} order evidence") from None
+    return _aware_datetime(parsed, field=field)
+
+
+def _normalize_order_text(value: Any) -> str:
+    return str(value or "").strip().upper()
+
+
+def _toss_lookup_scope(
+    *,
+    window_from: str,
+    window_to: str,
+    rung_window: tuple[datetime, datetime],
+    closed_pages: int,
+    complete: bool,
+    combination_matches: int,
+) -> str:
+    rung_start, rung_end = rung_window
+    return (
+        "toss GET /orders OPEN + CLOSED "
+        f"scan_kst={window_from}..{window_to} "
+        f"rung_window={rung_start.isoformat()}..{rung_end.isoformat()} "
+        f"closed_pages={closed_pages} complete={str(complete).lower()} "
+        f"combination_matches={combination_matches}"
+    )
 
 
 async def _maybe_await(value: Any) -> Any:
@@ -129,6 +194,7 @@ async def fetch_operator_void_evidence(
     symbol: str,
     rungs: list[Any],
     now: datetime,
+    valid_until: datetime | None = None,
     toss_client: Any | None = None,
     history_fn: Callable[..., Any] | None = None,
     upbit_identifier_lookup_fn: Callable[..., Any] | None = None,
@@ -288,17 +354,38 @@ async def fetch_operator_void_evidence(
     from app.core.timezone import KST
     from app.services.brokers.toss.client import TossReadClient
 
-    window_from = (
-        min(rung.created_at for rung in rungs).astimezone(KST).date().isoformat()
-    )
-    window_to = now.astimezone(KST).date().isoformat()
+    window_from: str | None = None
+    window_to: str | None = None
+    rung_windows: dict[int, tuple[datetime, datetime]] = {}
     owns_client = toss_client is None
-    client = toss_client or TossReadClient.from_settings()
+    client = toss_client
     orders: list[Any] = []
     closed_pages = 0
     incomplete_reason: str | None = None
     try:
-        open_page = await client.list_orders(status="OPEN", symbol=symbol)
+        _aware_datetime(now, field="now")
+        if valid_until is not None:
+            _aware_datetime(valid_until, field="valid_until")
+        for rung in rungs:
+            _aware_datetime(rung.created_at, field="rung.created_at")
+            if rung.updated_at is not None:
+                _aware_datetime(rung.updated_at, field="rung.updated_at")
+            rung_windows[rung.rung_index] = _toss_rung_window(
+                rung, valid_until=valid_until
+            )
+
+        scan_start = min(start for start, _end in rung_windows.values())
+        scan_end = max(end for _start, end in rung_windows.values())
+        window_from = scan_start.astimezone(KST).date().isoformat()
+        window_to = scan_end.astimezone(KST).date().isoformat()
+
+        client = client or TossReadClient.from_settings()
+        open_page = await client.list_orders(
+            status="OPEN",
+            symbol=symbol,
+            from_date=window_from,
+            to_date=window_to,
+        )
         orders.extend(open_page.orders)
 
         cursor: str | None = None
@@ -316,62 +403,126 @@ async def fetch_operator_void_evidence(
             closed_pages += 1
             if not page.has_next:
                 break
+            if closed_pages >= _TOSS_CLOSED_PAGE_CAP:
+                incomplete_reason = "CLOSED order scan page cap reached"
+                break
             if not page.next_cursor:
                 incomplete_reason = "CLOSED order scan missing next cursor"
                 break
             if page.next_cursor == cursor or page.next_cursor in seen_cursors:
                 incomplete_reason = "CLOSED order scan repeated cursor"
                 break
-            if closed_pages >= _TOSS_CLOSED_PAGE_CAP:
-                incomplete_reason = "CLOSED order scan page cap reached"
-                break
             seen_cursors.add(page.next_cursor)
             cursor = page.next_cursor
 
-        scope = (
-            "toss GET /orders OPEN + CLOSED "
-            f"{window_from}..{window_to} pages={closed_pages} "
-            f"complete={str(incomplete_reason is None).lower()}"
-        )
         result: dict[int, OperatorVoidEvidence] = {}
         for rung in rungs:
+            rung_window = rung_windows[rung.rung_index]
             broker_order_id = str(rung.broker_order_id or "").strip()
             idempotency_key = str(rung.idempotency_key or "").strip()
-            match = next(
+            identifier_match = next(
                 (
                     order
                     for order in orders
-                    if (broker_order_id and str(order.order_id) == broker_order_id)
+                    if (
+                        broker_order_id
+                        and str(getattr(order, "order_id", "") or "").strip()
+                        == broker_order_id
+                    )
                     or (
                         idempotency_key
-                        and str(getattr(order, "client_order_id", "") or "")
+                        and str(
+                            getattr(order, "client_order_id", "") or ""
+                        ).strip()
                         == idempotency_key
                     )
                 ),
                 None,
             )
-            if match is not None:
+            if identifier_match is not None:
+                scope = _toss_lookup_scope(
+                    window_from=window_from,
+                    window_to=window_to,
+                    rung_window=rung_window,
+                    closed_pages=closed_pages,
+                    complete=incomplete_reason is None,
+                    combination_matches=0,
+                )
                 result[rung.rung_index] = OperatorVoidEvidence(
                     "found",
                     scope,
-                    broker_order_id=str(match.order_id),
-                    broker_state=str(match.status),
+                    broker_order_id=str(identifier_match.order_id),
+                    broker_state=str(identifier_match.status),
                 )
-            elif not broker_order_id and not idempotency_key:
+                continue
+
+            malformed_reason: str | None = None
+            combination_match: Any | None = None
+            rung_quantity: Decimal | None = None
+            rung_price: Decimal | None = None
+            normalized_symbol = _normalize_order_text(symbol)
+            normalized_side = _normalize_order_text(rung.side)
+            if not normalized_symbol or not normalized_side:
+                malformed_reason = "invalid symbol or side order evidence"
+            else:
+                try:
+                    rung_quantity = _finite_decimal(rung.quantity)
+                    rung_price = _finite_decimal(rung.limit_price)
+                    if rung_quantity is None:
+                        raise ValueError("invalid decimal order evidence")
+                except (TypeError, ValueError) as exc:
+                    malformed_reason = describe_exception(exc)
+
+            if malformed_reason is None:
+                for order in orders:
+                    if (
+                        _normalize_order_text(getattr(order, "symbol", None))
+                        != normalized_symbol
+                        or _normalize_order_text(getattr(order, "side", None))
+                        != normalized_side
+                    ):
+                        continue
+                    try:
+                        order_quantity = _finite_decimal(
+                            getattr(order, "quantity", None)
+                        )
+                        order_price = _finite_decimal(getattr(order, "price", None))
+                        if order_quantity is None:
+                            raise ValueError("invalid decimal order evidence")
+                    except (TypeError, ValueError) as exc:
+                        malformed_reason = describe_exception(exc)
+                        continue
+                    if order_quantity != rung_quantity or order_price != rung_price:
+                        continue
+                    try:
+                        ordered_at = _parse_aware_iso_datetime(
+                            getattr(order, "ordered_at", None), field="ordered_at"
+                        )
+                    except ValueError as exc:
+                        malformed_reason = describe_exception(exc)
+                        continue
+                    if rung_window[0] <= ordered_at <= rung_window[1]:
+                        combination_match = order
+                        break
+
+            scope = _toss_lookup_scope(
+                window_from=window_from,
+                window_to=window_to,
+                rung_window=rung_window,
+                closed_pages=closed_pages,
+                complete=incomplete_reason is None,
+                combination_matches=int(combination_match is not None),
+            )
+            if combination_match is not None:
                 result[rung.rung_index] = OperatorVoidEvidence(
-                    "unknown", scope, reason="rung has no broker lookup identifier"
-                )
-            elif (
-                idempotency_key
-                and not broker_order_id
-                and any(
-                    getattr(order, "client_order_id", None) is None for order in orders
-                )
-            ):
-                result[rung.rung_index] = OperatorVoidEvidence(
-                    "unknown",
+                    "found",
                     scope,
-                    reason="broker order list omitted clientOrderId",
+                    broker_order_id=str(combination_match.order_id),
+                    broker_state=str(combination_match.status),
+                )
+            elif malformed_reason is not None:
+                result[rung.rung_index] = OperatorVoidEvidence(
+                    "unknown", scope, reason=malformed_reason
                 )
             elif incomplete_reason is not None:
                 result[rung.rung_index] = OperatorVoidEvidence(
@@ -381,15 +532,30 @@ async def fetch_operator_void_evidence(
                 result[rung.rung_index] = OperatorVoidEvidence("absent", scope)
         return result
     except Exception as exc:
-        scope = f"toss GET /orders OPEN + CLOSED {window_from}..{window_to} incomplete"
+        reason = describe_exception(exc)
+        if window_from is not None and window_to is not None:
+            return {
+                rung.rung_index: OperatorVoidEvidence(
+                    "unknown",
+                    _toss_lookup_scope(
+                        window_from=window_from,
+                        window_to=window_to,
+                        rung_window=rung_windows[rung.rung_index],
+                        closed_pages=closed_pages,
+                        complete=False,
+                        combination_matches=0,
+                    ),
+                    reason=reason,
+                )
+                for rung in rungs
+            }
+        scope = "toss GET /orders OPEN + CLOSED invalid temporal window"
         return {
-            rung.rung_index: OperatorVoidEvidence(
-                "unknown", scope, reason=describe_exception(exc)
-            )
+            rung.rung_index: OperatorVoidEvidence("unknown", scope, reason=reason)
             for rung in rungs
         }
     finally:
-        if owns_client:
+        if owns_client and client is not None:
             await client.aclose()
 
 

--- a/app/services/order_proposals/broker_gateway.py
+++ b/app/services/order_proposals/broker_gateway.py
@@ -431,9 +431,7 @@ async def fetch_operator_void_evidence(
                     )
                     or (
                         idempotency_key
-                        and str(
-                            getattr(order, "client_order_id", "") or ""
-                        ).strip()
+                        and str(getattr(order, "client_order_id", "") or "").strip()
                         == idempotency_key
                     )
                 ),

--- a/docs/superpowers/plans/2026-07-14-rob-877-toss-absence-proof.md
+++ b/docs/superpowers/plans/2026-07-14-rob-877-toss-absence-proof.md
@@ -1,0 +1,297 @@
+# ROB-877 Toss Absence-Proof Recovery Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let explicit operator voids prove legacy Toss orders absent using an accepted-only ledger zero-row check plus a complete, time-bounded symbol/side/quantity/price scan.
+
+**Architecture:** Keep `OrderProposalsService.void_proposal` unchanged and strengthen only the Toss branch of `fetch_operator_void_evidence`. The MCP adapter passes the group's `valid_until`; the gateway scans the union KST date range once, evaluates each rung's inclusive instant window with normalized `Decimal` tuple matching, and reports all ambiguity as `unknown`.
+
+**Tech Stack:** Python 3.13, async SQLAlchemy service boundary, `Decimal`, pytest/pytest-asyncio, Ruff, ty.
+
+## Global Constraints
+
+- `service.py` must remain unchanged.
+- Production broker access is prohibited; all Toss responses are mocked.
+- A rung window is `created_at - 24h` through `max(valid_until, updated_at) + 24h`, inclusive.
+- Toss `from`/`to` dates are derived in KST after timezone conversion.
+- Quantity and price comparisons use finite `Decimal` values, never string equality.
+- Request failure, timeout, malformed potential match, repeated/missing cursor, or CLOSED page-cap exhaustion returns `unknown`.
+- KIS, Upbit, and Toss 4xx-to-rejected behavior must not change.
+
+---
+
+### Task 1: Lock the composite Toss evidence contract with failing tests
+
+**Files:**
+- Modify: `tests/services/order_proposals/test_broker_gateway.py:332`
+
+**Interfaces:**
+- Consumes: current `fetch_operator_void_evidence(...)` Toss branch.
+- Produces: regression tests for the new optional `valid_until: datetime | None` input and exact `OperatorVoidEvidence` outcomes.
+
+- [ ] **Step 1: Add realistic Toss order and rung builders**
+
+```python
+def _toss_order(**overrides):
+    values = {
+        "order_id": "broker-1",
+        "client_order_id": None,
+        "status": "FILLED",
+        "symbol": "005930",
+        "side": "BUY",
+        "quantity": Decimal("1.00000000"),
+        "price": Decimal("100.00"),
+        "ordered_at": NOW.isoformat(),
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def _toss_rung(**overrides):
+    values = {
+        "rung_index": 0,
+        "idempotency_key": "tosprop-legacy-1",
+        "broker_order_id": None,
+        "side": "buy",
+        "quantity": Decimal("1"),
+        "limit_price": Decimal("100.0000"),
+        "created_at": NOW,
+        "updated_at": NOW + timedelta(hours=2),
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+```
+
+- [ ] **Step 2: Replace the client-ID-required expectation with composite absence**
+
+Use an unrelated order with `client_order_id=None` and a complete OPEN+CLOSED scan. Assert:
+
+```python
+assert evidence[0].outcome == "absent"
+assert "combination_matches=0" in evidence[0].lookup_scope
+```
+
+- [ ] **Step 3: Add Decimal-normalized tuple match and state exposure tests**
+
+Return `_toss_order(quantity=Decimal("1.00000000"), price=Decimal("100.00"))` for a rung holding `Decimal("1")` and `Decimal("100.0000")`. Assert `found`, `broker_order_id == "broker-1"`, and the returned broker state.
+
+- [ ] **Step 4: Add inclusive-window boundary tests**
+
+Parameterize orders at exactly `created_at - timedelta(hours=24)` and exactly `max(valid_until, updated_at) + timedelta(hours=24)` and assert `found`. Parameterize one microsecond outside either edge and assert `absent`.
+
+- [ ] **Step 5: Add KST request-date and attempt-anchor test**
+
+Use UTC timestamps whose KST dates differ, pass a `valid_until` later than `updated_at`, capture both list calls, and assert OPEN and CLOSED both receive:
+
+```python
+{
+    "from_date": expected_start.astimezone(KST).date().isoformat(),
+    "to_date": expected_end.astimezone(KST).date().isoformat(),
+}
+```
+
+- [ ] **Step 6: Add CLOSED page-cap exhaustion test**
+
+Mock CLOSED pages with unique cursors and `has_next=True` through `_TOSS_CLOSED_PAGE_CAP`. Assert `unknown`, reason `CLOSED order scan page cap reached`, and no absence result.
+
+- [ ] **Step 7: Run the focused tests and verify RED**
+
+Run:
+
+```bash
+uv sync --group dev
+uv run pytest tests/services/order_proposals/test_broker_gateway.py -q
+```
+
+Expected: the new composite-absence, tuple-match, date-window, or page-cap assertions fail against the current client-ID guard/window behavior. Existing import errors are setup failures and must be resolved before accepting RED.
+
+---
+
+### Task 2: Implement the time-bounded Decimal composite matcher
+
+**Files:**
+- Modify: `app/services/order_proposals/broker_gateway.py:1-393`
+- Modify: `app/mcp_server/tooling/order_proposal_tools.py:123-130`
+- Test: `tests/services/order_proposals/test_broker_gateway.py`
+
+**Interfaces:**
+- Consumes: `group.valid_until`, rung `created_at`, `updated_at`, `side`, `quantity`, and `limit_price`; Toss `TossOrder` fields.
+- Produces: `fetch_operator_void_evidence(..., valid_until: datetime | None = None) -> dict[int, OperatorVoidEvidence]`.
+
+- [ ] **Step 1: Add normalization and window helpers**
+
+Add `timedelta` and `Decimal, InvalidOperation` imports. Implement focused private helpers with these contracts:
+
+```python
+_TOSS_VOID_WINDOW_PAD = timedelta(hours=24)
+
+
+def _finite_decimal(value: Any) -> Decimal | None:
+    if value is None:
+        return None
+    try:
+        parsed = Decimal(str(value))
+    except (InvalidOperation, ValueError):
+        raise ValueError("invalid decimal order evidence") from None
+    if not parsed.is_finite():
+        raise ValueError("non-finite decimal order evidence")
+    return parsed
+
+
+def _toss_rung_window(
+    rung: Any, *, valid_until: datetime | None
+) -> tuple[datetime, datetime]:
+    start = rung.created_at - _TOSS_VOID_WINDOW_PAD
+    attempt_end = max(
+        value for value in (valid_until, rung.updated_at) if value is not None
+    )
+    return start, attempt_end + _TOSS_VOID_WINDOW_PAD
+```
+
+All temporal values must be timezone-aware; invalid values become `unknown` in the Toss branch.
+
+- [ ] **Step 2: Expand the function boundary without changing other brokers**
+
+Add the optional keyword argument:
+
+```python
+valid_until: datetime | None = None,
+```
+
+Do not use it in KIS or Upbit branches.
+
+- [ ] **Step 3: Build the shared KST scan envelope**
+
+Compute every rung window, take the minimum start and maximum end, convert each to KST, and pass the resulting inclusive dates as `from_date` and `to_date` to both OPEN and CLOSED `list_orders` calls.
+
+- [ ] **Step 4: Preserve complete pagination semantics**
+
+Keep missing/repeated cursor rejection and the 20-page cap. If a page at the cap still says `has_next`, set `incomplete_reason = "CLOSED order scan page cap reached"`; never emit `absent` afterward.
+
+- [ ] **Step 5: Evaluate strong identifiers, then the composite tuple**
+
+For each rung:
+
+1. Return `found` for an exact broker order ID or non-empty client order ID.
+2. Otherwise compare normalized symbol, side, finite Decimal quantity, and finite Decimal/`None` price.
+3. Parse an otherwise matching order's `ordered_at` as an aware ISO-8601 datetime.
+4. Count it only when `window_start <= ordered_at <= window_end`.
+5. Return `found` with state/ID for any in-window match.
+6. Return `unknown` for malformed data on a potential match.
+7. Return `absent` only after a complete scan with zero matches.
+
+The per-rung scope must include the KST scan dates, rung instant window, CLOSED page count, completeness, and `combination_matches=0` or `1`.
+
+- [ ] **Step 6: Forward group validity from the MCP adapter**
+
+Change `_fetch_void_evidence` to call:
+
+```python
+return await fetch_operator_void_evidence(
+    account_mode=group.account_mode,
+    market=group.market,
+    symbol=group.symbol,
+    rungs=rungs,
+    now=now,
+    valid_until=group.valid_until,
+)
+```
+
+Do not edit `app/services/order_proposals/service.py`.
+
+- [ ] **Step 7: Run focused tests and verify GREEN**
+
+Run:
+
+```bash
+uv run pytest tests/services/order_proposals/test_broker_gateway.py -q
+```
+
+Expected: all tests pass with zero failures.
+
+---
+
+### Task 3: Fix audit/documentation contracts and run regressions
+
+**Files:**
+- Modify: `tests/services/order_proposals/test_service.py:867-910` only if an assertion needs the richer injected scope; do not modify production `service.py`.
+- Modify: `tests/test_mcp_order_proposal_tools.py:600-635`
+- Modify: `app/mcp_server/README.md:681-696`
+
+**Interfaces:**
+- Consumes: existing service evidence-summary reuse and `_fetch_void_evidence` MCP adapter.
+- Produces: persisted `void_reason` proof text and documented operator behavior.
+
+- [ ] **Step 1: Assert successful audit evidence is persisted**
+
+Use the existing service-level zero-ledger test with an injected absent scope containing:
+
+```text
+scan_kst=2026-07-11..2026-07-15 combination_matches=0
+```
+
+Assert the group and rung `void_reason` contain the operator reason, scan dates, `combination_matches=0`, and `toss_live_order_ledger rows=0`.
+
+- [ ] **Step 2: Assert the MCP adapter forwards valid_until**
+
+Patch `fetch_operator_void_evidence`, call `_fetch_void_evidence` with a group carrying `valid_until`, and assert the captured keyword equals that datetime. Keep the public tool response unchanged.
+
+- [ ] **Step 3: Update the MCP operator documentation**
+
+Replace the obsolete “missing clientOrderId is inconclusive” Toss paragraph with the composite rule, inclusive attempt window, normalized Decimal match, accepted-ledger requirement, and fail-closed incomplete-scan behavior. Note that KIS/Upbit behavior is unchanged.
+
+- [ ] **Step 4: Run the required domain suite**
+
+Run:
+
+```bash
+uv run pytest tests/services/order_proposals/ -q
+```
+
+Expected: zero failures, including KIS/Upbit operator-void and Toss 4xx-to-rejected regressions.
+
+- [ ] **Step 5: Run MCP contract tests**
+
+Run:
+
+```bash
+uv run pytest tests/test_mcp_order_proposal_tools.py -q
+```
+
+Expected: zero failures and unchanged public response shape.
+
+- [ ] **Step 6: Run lint**
+
+Run:
+
+```bash
+make lint
+```
+
+Expected: Ruff formatting/check and ty checks exit 0.
+
+- [ ] **Step 7: Verify service.py is untouched**
+
+Run:
+
+```bash
+git diff origin/main -- app/services/order_proposals/service.py
+```
+
+Expected: no output.
+
+- [ ] **Step 8: Commit the implementation**
+
+```bash
+git add \
+  app/services/order_proposals/broker_gateway.py \
+  app/mcp_server/tooling/order_proposal_tools.py \
+  app/mcp_server/README.md \
+  tests/services/order_proposals/test_broker_gateway.py \
+  tests/services/order_proposals/test_service.py \
+  tests/test_mcp_order_proposal_tools.py \
+  docs/superpowers/plans/2026-07-14-rob-877-toss-absence-proof.md
+git commit -m "fix(ROB-877): recover Toss absence proof"
+```
+
+The final PR targets `main` and records the OpenAPI CLOSED-pagination contradiction plus the post-deploy 13-row operator verification requirement.

--- a/docs/superpowers/plans/2026-07-14-rob-877-toss-absence-proof.md
+++ b/docs/superpowers/plans/2026-07-14-rob-877-toss-absence-proof.md
@@ -99,7 +99,7 @@ Mock CLOSED pages with unique cursors and `has_next=True` through `_TOSS_CLOSED_
 Run:
 
 ```bash
-uv sync --group dev
+uv sync --all-groups
 uv run pytest tests/services/order_proposals/test_broker_gateway.py -q
 ```
 

--- a/docs/superpowers/specs/2026-07-14-rob-877-toss-absence-proof-design.md
+++ b/docs/superpowers/specs/2026-07-14-rob-877-toss-absence-proof-design.md
@@ -1,0 +1,133 @@
+# ROB-877 Toss Absence-Proof Recovery Design
+
+## Goal
+
+Allow an explicit operator void to converge legacy Toss `unverified` order
+proposal rungs to `voided_local_stale` only when two independent sources prove
+that Toss never accepted the order. Preserve fail-closed behavior for every
+incomplete, failed, or ambiguous lookup.
+
+## Source-of-Truth Finding
+
+The Toss `GET /api/v1/orders` list item schema (`Order`) does not contain
+`clientOrderId`; only order creation responses expose it. The current
+`requires_client_id_field` guard therefore cannot prove absence whenever the
+list contains an unrelated order whose parsed `client_order_id` is `None`.
+
+The same OpenAPI document is internally inconsistent about CLOSED history:
+the endpoint operation, parameters, response example, and pagination contract
+support `status=CLOSED`, while the `PaginatedOrderResponse` component
+description says CLOSED currently returns `400 closed-not-supported`. The
+implementation follows the endpoint operation contract and records the
+contradiction in ROB-877 and the PR. Tests remain fully mocked; this session
+does not access production.
+
+## Architecture
+
+### Evidence composition
+
+Keep `OrderProposalsService.void_proposal` unchanged. It already requires:
+
+1. conclusive broker evidence with outcome `absent`; and
+2. zero accepted/non-rejected Toss ledger rows matching the rung's
+   `client_order_id` or broker order ID.
+
+Only after both checks does the service write `voided_local_stale`. The
+existing evidence summary is retained in `void_reason`, so the gateway's
+lookup scope will carry the scan window and combination-match result while the
+service continues to append `toss_live_order_ledger rows=0`.
+
+### Scan window
+
+For each rung, define an inclusive instant window:
+
+- start: `rung.created_at - 24 hours`;
+- end: `max(group.valid_until, rung.updated_at) + 24 hours`, ignoring
+  `valid_until` only when it is null.
+
+This covers proposals created before the actual approval/submit attempt. The
+MCP adapter already receives the proposal group, so it passes `valid_until` to
+`fetch_operator_void_evidence` without changing `service.py`.
+
+The broker gateway scans OPEN and every CLOSED page once over the union of all
+rung windows. Toss `from` and `to` are inclusive KST calendar dates derived
+after timezone conversion. Both OPEN and CLOSED receive the same date range;
+CLOSED remains bounded by the existing 20-page cap.
+
+Each rung is evaluated against its own instant window after the shared scan.
+An order exactly at either boundary is inside the window. A matching order
+outside the boundary is not evidence for that rung.
+
+### Match semantics
+
+Existing exact broker-order-ID and `clientOrderId` matches remain positive
+evidence when those identifiers are available. When list items omit
+`clientOrderId`, the gateway falls back to the required tuple:
+
+- normalized symbol;
+- case-normalized side;
+- quantity parsed as finite `Decimal`;
+- price parsed as finite `Decimal`, or `None` for market orders.
+
+Decimal values are compared numerically, so `1`, `1.0`, and `1.00000000` are
+equivalent. String equality is never used for quantity or price.
+
+If the tuple matches and `orderedAt` lies inside the rung window, evidence is
+`found` with the broker order ID and broker state. If no tuple matches after a
+complete scan, evidence is `absent`. A malformed or timezone-naive
+`orderedAt` on an otherwise matching tuple is `unknown`, because the window
+membership cannot be proven.
+
+## Fail-Closed Rules
+
+The gateway returns `unknown` for:
+
+- any OPEN or CLOSED request exception, including timeouts;
+- `hasNext=true` without a cursor;
+- repeated cursors;
+- reaching the CLOSED page cap while another page remains;
+- malformed temporal or numeric data that prevents classifying a potential
+  tuple match.
+
+The absence outcome is never produced from a partial scan. KIS and Upbit
+branches are unchanged.
+
+## Audit Evidence
+
+Each Toss evidence scope includes:
+
+- the union scan's KST `from` and `to` dates;
+- the rung's inclusive instant window;
+- CLOSED page count and completeness;
+- `combination_matches=0` for successful absence, or the matching broker
+  order's state/ID through the existing found-order rejection.
+
+On success, `void_reason` therefore contains the operator reason, ledger
+zero-row proof, scan window, and zero combination-match result.
+
+## Tests
+
+Add or update mocked tests that fix these contracts:
+
+- missing `clientOrderId` plus zero tuple matches produces `absent`;
+- numerically equivalent Decimal quantity/price representations match;
+- a tuple match produces `found` and exposes broker state/order ID;
+- lower and upper instant boundaries are inclusive, and values just outside
+  are excluded;
+- `created_at`, `valid_until`, and `updated_at` produce the expected KST
+  `from`/`to` dates;
+- timeout, invalid pagination, and CLOSED page-cap exhaustion stay `unknown`;
+- an accepted Toss ledger row still blocks void;
+- successful composite absence writes the complete evidence summary;
+- existing KIS, Upbit, and Toss 4xx-to-rejected tests remain green.
+
+Verification uses:
+
+```bash
+uv run pytest tests/services/order_proposals/ -q
+make lint
+```
+
+After merge and deployment, an operator must retry the 13 legacy voids and
+confirm convergence to `voided_local_stale`; that production check is the
+final acceptance criterion and is outside this session.

--- a/tests/services/order_proposals/test_broker_gateway.py
+++ b/tests/services/order_proposals/test_broker_gateway.py
@@ -390,6 +390,36 @@ async def test_operator_void_toss_scan_proves_absence_across_open_and_closed():
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_operator_void_toss_scan_fails_closed_when_open_is_paginated():
+    from app.services.order_proposals import broker_gateway
+
+    calls = []
+
+    class FakeTossClient:
+        async def list_orders(self, **kwargs):
+            calls.append(kwargs)
+            if kwargs["status"] == "OPEN":
+                return SimpleNamespace(
+                    orders=[], has_next=True, next_cursor="unexpected-open-cursor"
+                )
+            return SimpleNamespace(orders=[], has_next=False, next_cursor=None)
+
+    evidence = await broker_gateway.fetch_operator_void_evidence(
+        account_mode="toss_live",
+        market="equity_kr",
+        symbol="005930",
+        rungs=[_toss_rung()],
+        now=NOW,
+        toss_client=FakeTossClient(),
+    )
+
+    assert [call["status"] for call in calls] == ["OPEN", "CLOSED"]
+    assert evidence[0].outcome == "unknown"
+    assert evidence[0].reason == "OPEN order scan unexpectedly paginated"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 @pytest.mark.parametrize("broker_state", ["OPEN", "FILLED"])
 async def test_operator_void_toss_scan_exposes_found_broker_state(broker_state):
     from app.services.order_proposals import broker_gateway
@@ -475,6 +505,45 @@ async def test_operator_void_toss_scan_proves_composite_absence_without_client_i
 
     assert evidence[0].outcome == "absent"
     assert "combination_matches=0" in evidence[0].lookup_scope
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("candidate_overrides", "expected_reason"),
+    [
+        ({"quantity": "not-a-decimal"}, "invalid decimal order evidence"),
+        ({"price": Decimal("Infinity")}, "non-finite decimal order evidence"),
+        ({"ordered_at": "not-a-datetime"}, "invalid ordered_at order evidence"),
+        (
+            {"ordered_at": NOW.replace(tzinfo=None).isoformat()},
+            "ordered_at must be a timezone-aware datetime",
+        ),
+    ],
+)
+async def test_operator_void_toss_scan_fails_closed_on_malformed_potential_candidate(
+    candidate_overrides, expected_reason
+):
+    from app.services.order_proposals import broker_gateway
+
+    candidate = _toss_order(**candidate_overrides)
+
+    class FakeTossClient:
+        async def list_orders(self, **kwargs):
+            orders = [candidate] if kwargs["status"] == "OPEN" else []
+            return SimpleNamespace(orders=orders, has_next=False, next_cursor=None)
+
+    evidence = await broker_gateway.fetch_operator_void_evidence(
+        account_mode="toss_live",
+        market="equity_kr",
+        symbol="005930",
+        rungs=[_toss_rung()],
+        now=NOW,
+        toss_client=FakeTossClient(),
+    )
+
+    assert evidence[0].outcome == "unknown"
+    assert evidence[0].reason == expected_reason
 
 
 @pytest.mark.unit

--- a/tests/services/order_proposals/test_broker_gateway.py
+++ b/tests/services/order_proposals/test_broker_gateway.py
@@ -579,9 +579,10 @@ async def test_operator_void_toss_scan_uses_kst_dates_and_attempt_anchor():
     }
     assert evidence[0].outcome == "absent"
     assert [call["status"] for call in calls] == ["OPEN", "CLOSED"]
-    assert [
-        {key: call[key] for key in ("from_date", "to_date")} for call in calls
-    ] == [expected_dates, expected_dates]
+    assert [{key: call[key] for key in ("from_date", "to_date")} for call in calls] == [
+        expected_dates,
+        expected_dates,
+    ]
 
 
 @pytest.mark.unit

--- a/tests/services/order_proposals/test_broker_gateway.py
+++ b/tests/services/order_proposals/test_broker_gateway.py
@@ -1,4 +1,5 @@
 from datetime import UTC, datetime, timedelta
+from decimal import Decimal
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
@@ -26,6 +27,36 @@ def _order_row(**overrides):
         "order_type": "limit",
         **overrides,
     }
+
+
+def _toss_order(**overrides):
+    values = {
+        "order_id": "broker-1",
+        "client_order_id": None,
+        "status": "FILLED",
+        "symbol": "005930",
+        "side": "BUY",
+        "quantity": Decimal("1.00000000"),
+        "price": Decimal("100.00"),
+        "ordered_at": NOW.isoformat(),
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def _toss_rung(**overrides):
+    values = {
+        "rung_index": 0,
+        "idempotency_key": "tosprop-legacy-1",
+        "broker_order_id": None,
+        "side": "buy",
+        "quantity": Decimal("1"),
+        "limit_price": Decimal("100.0000"),
+        "created_at": NOW,
+        "updated_at": NOW + timedelta(hours=2),
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
 
 
 @pytest.mark.unit
@@ -341,12 +372,7 @@ async def test_operator_void_toss_scan_proves_absence_across_open_and_closed():
             calls.append(kwargs)
             return SimpleNamespace(orders=[], has_next=False, next_cursor=None)
 
-    rung = SimpleNamespace(
-        rung_index=0,
-        idempotency_key="tosprop-legacy-1",
-        broker_order_id=None,
-        created_at=NOW - timedelta(days=2),
-    )
+    rung = _toss_rung(created_at=NOW - timedelta(days=2))
     evidence = await broker_gateway.fetch_operator_void_evidence(
         account_mode="toss_live",
         market="equity_kr",
@@ -368,10 +394,10 @@ async def test_operator_void_toss_scan_proves_absence_across_open_and_closed():
 async def test_operator_void_toss_scan_exposes_found_broker_state(broker_state):
     from app.services.order_proposals import broker_gateway
 
-    found = SimpleNamespace(
-        order_id="broker-1",
-        client_order_id="tosprop-legacy-1",
+    found = _toss_order(
         status=broker_state,
+        quantity=Decimal("1.00000000"),
+        price=Decimal("100.00"),
     )
 
     class FakeTossClient:
@@ -383,12 +409,7 @@ async def test_operator_void_toss_scan_exposes_found_broker_state(broker_state):
             )
             return SimpleNamespace(orders=orders, has_next=False, next_cursor=None)
 
-    rung = SimpleNamespace(
-        rung_index=0,
-        idempotency_key="tosprop-legacy-1",
-        broker_order_id=None,
-        created_at=NOW,
-    )
+    rung = _toss_rung()
     evidence = await broker_gateway.fetch_operator_void_evidence(
         account_mode="toss_live",
         market="equity_kr",
@@ -412,12 +433,7 @@ async def test_operator_void_toss_scan_fails_closed_on_timeout():
         async def list_orders(self, **_kwargs):
             raise httpx.ReadTimeout("")
 
-    rung = SimpleNamespace(
-        rung_index=0,
-        idempotency_key="tosprop-legacy-1",
-        broker_order_id=None,
-        created_at=NOW,
-    )
+    rung = _toss_rung()
     evidence = await broker_gateway.fetch_operator_void_evidence(
         account_mode="toss_live",
         market="equity_kr",
@@ -433,26 +449,21 @@ async def test_operator_void_toss_scan_fails_closed_on_timeout():
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_operator_void_toss_scan_requires_client_id_field_for_absence():
+async def test_operator_void_toss_scan_proves_composite_absence_without_client_id():
     from app.services.order_proposals import broker_gateway
 
-    order_without_client_id = SimpleNamespace(
+    unrelated_order = _toss_order(
         order_id="unrelated-order",
-        client_order_id=None,
+        symbol="000660",
         status="OPEN",
     )
 
     class FakeTossClient:
         async def list_orders(self, **kwargs):
-            orders = [order_without_client_id] if kwargs["status"] == "OPEN" else []
+            orders = [unrelated_order] if kwargs["status"] == "OPEN" else []
             return SimpleNamespace(orders=orders, has_next=False, next_cursor=None)
 
-    rung = SimpleNamespace(
-        rung_index=0,
-        idempotency_key="tosprop-legacy-1",
-        broker_order_id=None,
-        created_at=NOW,
-    )
+    rung = _toss_rung()
     evidence = await broker_gateway.fetch_operator_void_evidence(
         account_mode="toss_live",
         market="equity_kr",
@@ -462,8 +473,149 @@ async def test_operator_void_toss_scan_requires_client_id_field_for_absence():
         toss_client=FakeTossClient(),
     )
 
+    assert evidence[0].outcome == "absent"
+    assert "combination_matches=0" in evidence[0].lookup_scope
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@pytest.mark.parametrize("boundary", ["start", "end"])
+async def test_operator_void_toss_scan_includes_composite_window_boundaries(boundary):
+    from app.services.order_proposals import broker_gateway
+
+    rung = _toss_rung()
+    valid_until = NOW + timedelta(hours=4)
+    window_start = rung.created_at - timedelta(hours=24)
+    window_end = max(valid_until, rung.updated_at) + timedelta(hours=24)
+    ordered_at = window_start if boundary == "start" else window_end
+    found = _toss_order(ordered_at=ordered_at.isoformat())
+
+    class FakeTossClient:
+        async def list_orders(self, **kwargs):
+            orders = [found] if kwargs["status"] == "CLOSED" else []
+            return SimpleNamespace(orders=orders, has_next=False, next_cursor=None)
+
+    evidence = await broker_gateway.fetch_operator_void_evidence(
+        account_mode="toss_live",
+        market="equity_kr",
+        symbol="005930",
+        rungs=[rung],
+        now=window_end + timedelta(days=3),
+        valid_until=valid_until,
+        toss_client=FakeTossClient(),
+    )
+
+    assert evidence[0].outcome == "found"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@pytest.mark.parametrize("boundary", ["before_start", "after_end"])
+async def test_operator_void_toss_scan_excludes_orders_outside_composite_window(
+    boundary,
+):
+    from app.services.order_proposals import broker_gateway
+
+    rung = _toss_rung()
+    valid_until = NOW + timedelta(hours=4)
+    window_start = rung.created_at - timedelta(hours=24)
+    window_end = max(valid_until, rung.updated_at) + timedelta(hours=24)
+    ordered_at = (
+        window_start - timedelta(microseconds=1)
+        if boundary == "before_start"
+        else window_end + timedelta(microseconds=1)
+    )
+    outside_order = _toss_order(ordered_at=ordered_at.isoformat())
+
+    class FakeTossClient:
+        async def list_orders(self, **kwargs):
+            orders = [outside_order] if kwargs["status"] == "CLOSED" else []
+            return SimpleNamespace(orders=orders, has_next=False, next_cursor=None)
+
+    evidence = await broker_gateway.fetch_operator_void_evidence(
+        account_mode="toss_live",
+        market="equity_kr",
+        symbol="005930",
+        rungs=[rung],
+        now=window_end + timedelta(days=3),
+        valid_until=valid_until,
+        toss_client=FakeTossClient(),
+    )
+
+    assert evidence[0].outcome == "absent"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_operator_void_toss_scan_uses_kst_dates_and_attempt_anchor():
+    from app.core.timezone import KST
+    from app.services.order_proposals import broker_gateway
+
+    created_at = datetime(2026, 7, 10, 16, 30, tzinfo=UTC)
+    updated_at = datetime(2026, 7, 11, 16, 30, tzinfo=UTC)
+    valid_until = datetime(2026, 7, 12, 16, 30, tzinfo=UTC)
+    expected_start = created_at - timedelta(hours=24)
+    expected_end = max(valid_until, updated_at) + timedelta(hours=24)
+    calls = []
+
+    class FakeTossClient:
+        async def list_orders(self, **kwargs):
+            calls.append(kwargs)
+            return SimpleNamespace(orders=[], has_next=False, next_cursor=None)
+
+    evidence = await broker_gateway.fetch_operator_void_evidence(
+        account_mode="toss_live",
+        market="equity_kr",
+        symbol="005930",
+        rungs=[_toss_rung(created_at=created_at, updated_at=updated_at)],
+        now=expected_end + timedelta(days=3),
+        valid_until=valid_until,
+        toss_client=FakeTossClient(),
+    )
+
+    expected_dates = {
+        "from_date": expected_start.astimezone(KST).date().isoformat(),
+        "to_date": expected_end.astimezone(KST).date().isoformat(),
+    }
+    assert evidence[0].outcome == "absent"
+    assert [call["status"] for call in calls] == ["OPEN", "CLOSED"]
+    assert [
+        {key: call[key] for key in ("from_date", "to_date")} for call in calls
+    ] == [expected_dates, expected_dates]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_operator_void_toss_scan_fails_closed_at_closed_page_cap():
+    from app.services.order_proposals import broker_gateway
+
+    closed_pages = 0
+
+    class FakeTossClient:
+        async def list_orders(self, **kwargs):
+            nonlocal closed_pages
+            if kwargs["status"] == "OPEN":
+                return SimpleNamespace(orders=[], has_next=False, next_cursor=None)
+            closed_pages += 1
+            return SimpleNamespace(
+                orders=[],
+                has_next=True,
+                next_cursor=f"cursor-{closed_pages}",
+            )
+
+    evidence = await broker_gateway.fetch_operator_void_evidence(
+        account_mode="toss_live",
+        market="equity_kr",
+        symbol="005930",
+        rungs=[_toss_rung()],
+        now=NOW,
+        toss_client=FakeTossClient(),
+    )
+
+    assert closed_pages == broker_gateway._TOSS_CLOSED_PAGE_CAP
     assert evidence[0].outcome == "unknown"
-    assert evidence[0].reason == "broker order list omitted clientOrderId"
+    assert evidence[0].reason == "CLOSED order scan page cap reached"
+    assert all(item.outcome != "absent" for item in evidence.values())
 
 
 @pytest.mark.unit
@@ -478,12 +630,7 @@ async def test_operator_void_toss_scan_fails_closed_on_invalid_pagination(cursor
                 return SimpleNamespace(orders=[], has_next=False, next_cursor=None)
             return SimpleNamespace(orders=[], has_next=True, next_cursor=cursor)
 
-    rung = SimpleNamespace(
-        rung_index=0,
-        idempotency_key="tosprop-legacy-1",
-        broker_order_id=None,
-        created_at=NOW,
-    )
+    rung = _toss_rung()
     evidence = await broker_gateway.fetch_operator_void_evidence(
         account_mode="toss_live",
         market="equity_kr",

--- a/tests/services/order_proposals/test_service.py
+++ b/tests/services/order_proposals/test_service.py
@@ -887,7 +887,9 @@ async def test_void_unverified_with_absent_broker_evidence_records_audit(db_sess
         assert [rung.rung_index for rung in kwargs["rungs"]] == [0]
         return {
             0: OperatorVoidEvidence(
-                "absent", "toss GET /orders OPEN + CLOSED 2026-07-11..2026-07-13"
+                "absent",
+                "toss GET /orders OPEN + CLOSED "
+                "scan_kst=2026-07-11..2026-07-15 combination_matches=0",
             )
         }
 
@@ -901,10 +903,13 @@ async def test_void_unverified_with_absent_broker_evidence_records_audit(db_sess
 
     assert [row.state for row in rows] == ["voided_local_stale"]
     assert rungs[0].state == "voided_local_stale"
-    assert "operator cleanup" in refreshed.void_reason
-    assert "outcome=absent" in refreshed.void_reason
-    assert "toss_live_order_ledger rows=0" in refreshed.void_reason
-    assert "GET /orders OPEN + CLOSED" in refreshed.void_reason
+    for audit_reason in (refreshed.void_reason, rungs[0].void_reason):
+        assert "operator cleanup" in audit_reason
+        assert "outcome=absent" in audit_reason
+        assert "GET /orders OPEN + CLOSED" in audit_reason
+        assert "scan_kst=2026-07-11..2026-07-15" in audit_reason
+        assert "combination_matches=0" in audit_reason
+        assert "toss_live_order_ledger rows=0" in audit_reason
     assert rungs[0].void_reason == refreshed.void_reason
 
 

--- a/tests/test_mcp_order_proposal_tools.py
+++ b/tests/test_mcp_order_proposal_tools.py
@@ -581,6 +581,35 @@ async def test_void_requires_reason_and_terminalizes_proposal():
 
 
 @pytest.mark.asyncio
+async def test_fetch_void_evidence_forwards_group_valid_until(monkeypatch):
+    valid_until = datetime(2026, 7, 15, 15, 0, tzinfo=UTC)
+    now = datetime(2026, 7, 13, 9, 0, tzinfo=UTC)
+    rungs = [SimpleNamespace(rung_index=0)]
+    captured = {}
+    expected = object()
+
+    async def capture_evidence(**kwargs):
+        captured.update(kwargs)
+        return expected
+
+    monkeypatch.setattr(opt, "fetch_operator_void_evidence", capture_evidence)
+
+    result = await opt._fetch_void_evidence(
+        group=SimpleNamespace(
+            account_mode="toss_live",
+            market="equity_kr",
+            symbol="005930",
+            valid_until=valid_until,
+        ),
+        rungs=rungs,
+        now=now,
+    )
+
+    assert result is expected
+    assert captured["valid_until"] == valid_until
+
+
+@pytest.mark.asyncio
 async def test_void_unverified_uses_broker_evidence_and_disables_telegram_buttons(
     monkeypatch,
 ):


### PR DESCRIPTION
## Summary

- Restores Toss legacy-order absence proof without changing `app/services/order_proposals/service.py`: local accepted-ledger evidence remains authoritative, and a complete broker scan may prove only that the normalized order tuple is absent.
- Scans each rung's inclusive attempt window from `created_at - 24h` through `max(group.valid_until, rung.updated_at) + 24h`; converts the envelope to KST `orderedAt` dates for both OPEN and CLOSED queries.
- Compares symbol, side, quantity, and price as normalized finite `Decimal` values, so formatting differences such as trailing zeroes do not affect matching.
- Fails closed as `unknown` for malformed broker data, request errors, OPEN pagination anomalies, missing/repeated CLOSED cursors, and the CLOSED page cap.
- Reuses the existing audit/evidence path, recording accepted-ledger count, scan window, and match classification.

## Schema decision

The official Toss OpenAPI `Order` list-item schema does not expose `clientOrderId`, so identifier-only absence proof cannot work for the affected historical orders. This PR implements approved alternative 2: accepted-ledger count is zero **and** a complete, time-bounded OPEN+CLOSED tuple scan finds no match.

The OpenAPI is internally inconsistent: the endpoint operation documents CLOSED queries and cursor pagination, while the `PaginatedOrderResponse` component description still says CLOSED returns `400 closed-not-supported`. The implementation follows the endpoint contract but treats any incomplete or anomalous scan as `unknown`.

## Verification

- `uv run pytest tests/services/order_proposals/ -q` — 391 passed
- `uv run pytest tests/test_mcp_order_proposal_tools.py -q` — 24 passed
- `make lint` — Ruff formatting/check and ty passed
- Independent final review — ready to merge; no findings
- Contract coverage audit — 85% (23/27 grouped paths); focused changed-module run: 66 passed, 87%

All broker calls in tests are mocked. KIS, Upbit, and Toss typed-4xx fail-closed contracts remain covered.

## Scope and rollout

All repository implementation and automated verification items are complete. `service.py`, VERSION, and CHANGELOG are intentionally unchanged.

Production access is excluded from this work. After merge and deployment, an operator must retry the 13 affected legacy voids and confirm each reaches `voided_local_stale`; this remains the external acceptance criterion.

