### PR TITLE
feat(ROB-870): add Telegram batch approval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Added (ROB-870 — Telegram manual batch approval; migration 1)
+- **Operators can approve a burst of manual proposals from one Telegram summary.** Successfully delivered proposals collect by chat in a fixed ten-minute window; the summary appears at member two, retains every individual approve/deny message, and reports approved, reconfirmation, skipped, and failed members separately.
+- **Batching preserves every existing live-order safety boundary.** A single-use batch trigger still consumes each proposal's original nonce and audit, reruns fresh broker checks in an isolated transaction, excludes loss cuts/terminal/superseded/auto-approved rows at registration and click time, continues after member failures, and leaves ROB-861 buying-power misses independently reconfirmable.
+- **The batch ledger and operator contract are durable.** Additive migration `20260714_rob870_approval_batches` stores batches, immutable membership nonce snapshots, delivery claims, and bounded member results; the runbook records the 2026-07-13 manual 13-group/14-rung basis and its cap-independent structural floor.
+
 ### Fixed (ROB-868 — Upbit websocket proposal fill projection; migration 0)
 - **Committed Upbit websocket fills now converge proposal rungs immediately.** `trade` events project cumulative partial-fill evidence and `done` events project terminal fill evidence through an independent committed proposal-service session, matching both the broker UUID and Upbit client identifier while keeping projection failures best-effort. Individual ledger rows retain per-trade `volume`; terminal cumulative evidence is applied only after an existing durable fill is verified and is not double-counted as another fill.
 - **Matched proposal fills retain operator visibility at small notionals.** Proposal-rung fills bypass the ordinary notification threshold without changing unmatched-fill policy, and duplicate ledger deliveries remain notification-idempotent.

--- a/alembic/versions/20260714_rob870_approval_batches.py
+++ b/alembic/versions/20260714_rob870_approval_batches.py
@@ -1,0 +1,142 @@
+"""ROB-870 durable Telegram approval batches.
+
+Revision ID: 20260714_rob870_approval_batches
+Revises: 20260713_rob848_paper_validation
+Create Date: 2026-07-14
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "20260714_rob870_approval_batches"
+down_revision = "20260713_rob848_paper_validation"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "order_proposal_approval_batches",
+        sa.Column("id", sa.BigInteger(), nullable=False),
+        sa.Column("batch_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("chat_id", sa.Text(), nullable=False),
+        sa.Column(
+            "window_started_at", sa.TIMESTAMP(timezone=True), nullable=False
+        ),
+        sa.Column("window_closes_at", sa.TIMESTAMP(timezone=True), nullable=False),
+        sa.Column("expires_at", sa.TIMESTAMP(timezone=True), nullable=False),
+        sa.Column("approval_nonce", sa.Text(), nullable=False),
+        sa.Column(
+            "approval_nonce_used_at", sa.TIMESTAMP(timezone=True), nullable=True
+        ),
+        sa.Column("approved_by_telegram_user_id", sa.Text(), nullable=True),
+        sa.Column("approved_at", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("summary_message_id", sa.BigInteger(), nullable=True),
+        sa.Column(
+            "summary_dispatch_state",
+            sa.Text(),
+            nullable=False,
+            server_default="idle",
+        ),
+        sa.Column(
+            "summary_dispatch_lease_until",
+            sa.TIMESTAMP(timezone=True),
+            nullable=True,
+        ),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.PrimaryKeyConstraint(
+            "id", name=op.f("pk_order_proposal_approval_batches")
+        ),
+        sa.UniqueConstraint(
+            "batch_id", name="uq_order_proposal_approval_batches_batch_id"
+        ),
+        sa.CheckConstraint(
+            "summary_dispatch_state IN ('idle','sending','sent')",
+            name="order_proposal_approval_batches_summary_state",
+        ),
+        schema="review",
+    )
+    op.create_index(
+        "ix_order_proposal_approval_batches_chat_window",
+        "order_proposal_approval_batches",
+        ["chat_id", "window_closes_at"],
+        schema="review",
+    )
+
+    op.create_table(
+        "order_proposal_approval_batch_members",
+        sa.Column("id", sa.BigInteger(), nullable=False),
+        sa.Column("batch_pk", sa.BigInteger(), nullable=False),
+        sa.Column("proposal_pk", sa.BigInteger(), nullable=False),
+        sa.Column("approval_nonce_snapshot", sa.Text(), nullable=False),
+        sa.Column("approval_message_id", sa.BigInteger(), nullable=False),
+        sa.Column("result", sa.Text(), nullable=True),
+        sa.Column(
+            "result_detail",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=True,
+        ),
+        sa.Column("processed_at", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("added_at", sa.TIMESTAMP(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint(
+            "id", name=op.f("pk_order_proposal_approval_batch_members")
+        ),
+        sa.ForeignKeyConstraint(
+            ["batch_pk"],
+            ["review.order_proposal_approval_batches.id"],
+            name="fk_order_proposal_batch_members_batch",
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["proposal_pk"],
+            ["review.order_proposals.id"],
+            name="fk_order_proposal_batch_members_proposal",
+            ondelete="RESTRICT",
+        ),
+        sa.UniqueConstraint(
+            "batch_pk", "proposal_pk", name="uq_order_proposal_batch_member"
+        ),
+        sa.UniqueConstraint(
+            "proposal_pk",
+            "approval_nonce_snapshot",
+            name="uq_order_proposal_batch_member_nonce",
+        ),
+        schema="review",
+    )
+    op.create_index(
+        "ix_order_proposal_batch_members_batch_pk",
+        "order_proposal_approval_batch_members",
+        ["batch_pk"],
+        schema="review",
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_order_proposal_batch_members_batch_pk",
+        table_name="order_proposal_approval_batch_members",
+        schema="review",
+    )
+    op.drop_table("order_proposal_approval_batch_members", schema="review")
+    op.drop_index(
+        "ix_order_proposal_approval_batches_chat_window",
+        table_name="order_proposal_approval_batches",
+        schema="review",
+    )
+    op.drop_table("order_proposal_approval_batches", schema="review")

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -47,7 +47,12 @@ from .market_report import MarketReport
 from .market_valuation_snapshot import MarketValuationSnapshot
 from .naver_research_detail_cache import NaverResearchDetailCache
 from .news import NewsAnalysisResult, NewsArticle, NewsIngestionRun, Sentiment
-from .order_proposals import OrderProposal, OrderProposalRung
+from .order_proposals import (
+    OrderProposal,
+    OrderProposalApprovalBatch,
+    OrderProposalApprovalBatchMember,
+    OrderProposalRung,
+)
 from .paper_trading import PaperAccount, PaperPendingOrder, PaperPosition, PaperTrade
 from .paper_validation import (
     PaperValidationPostmortemReview,
@@ -197,6 +202,8 @@ __all__ = [
     "NewsIngestionRun",
     "Sentiment",
     "OrderProposal",
+    "OrderProposalApprovalBatch",
+    "OrderProposalApprovalBatchMember",
     "OrderProposalRung",
     "BrokerType",
     "MarketType",

--- a/app/models/order_proposals.py
+++ b/app/models/order_proposals.py
@@ -195,9 +195,7 @@ class OrderProposalApprovalBatch(Base):
     )
 
     id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
-    batch_id: Mapped[uuid.UUID] = mapped_column(
-        PG_UUID(as_uuid=True), nullable=False
-    )
+    batch_id: Mapped[uuid.UUID] = mapped_column(PG_UUID(as_uuid=True), nullable=False)
     chat_id: Mapped[str] = mapped_column(Text, nullable=False)
     window_started_at: Mapped[datetime] = mapped_column(
         TIMESTAMP(timezone=True), nullable=False
@@ -250,9 +248,7 @@ class OrderProposalApprovalBatchMember(Base):
     id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
     batch_pk: Mapped[int] = mapped_column(
         BigInteger,
-        ForeignKey(
-            "review.order_proposal_approval_batches.id", ondelete="CASCADE"
-        ),
+        ForeignKey("review.order_proposal_approval_batches.id", ondelete="CASCADE"),
         nullable=False,
     )
     proposal_pk: Mapped[int] = mapped_column(
@@ -264,9 +260,5 @@ class OrderProposalApprovalBatchMember(Base):
     approval_message_id: Mapped[int] = mapped_column(BigInteger, nullable=False)
     result: Mapped[str | None] = mapped_column(Text)
     result_detail: Mapped[dict | None] = mapped_column(JSONB)
-    processed_at: Mapped[datetime | None] = mapped_column(
-        TIMESTAMP(timezone=True)
-    )
-    added_at: Mapped[datetime] = mapped_column(
-        TIMESTAMP(timezone=True), nullable=False
-    )
+    processed_at: Mapped[datetime | None] = mapped_column(TIMESTAMP(timezone=True))
+    added_at: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=True), nullable=False)

--- a/app/models/order_proposals.py
+++ b/app/models/order_proposals.py
@@ -174,3 +174,99 @@ class OrderProposalRung(Base):
         server_default=func.now(),
         onupdate=func.now(),
     )
+
+
+class OrderProposalApprovalBatch(Base):
+    __tablename__ = "order_proposal_approval_batches"
+    __table_args__ = (
+        UniqueConstraint(
+            "batch_id", name="uq_order_proposal_approval_batches_batch_id"
+        ),
+        CheckConstraint(
+            "summary_dispatch_state IN ('idle','sending','sent')",
+            name="order_proposal_approval_batches_summary_state",
+        ),
+        Index(
+            "ix_order_proposal_approval_batches_chat_window",
+            "chat_id",
+            "window_closes_at",
+        ),
+        {"schema": "review"},
+    )
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    batch_id: Mapped[uuid.UUID] = mapped_column(
+        PG_UUID(as_uuid=True), nullable=False
+    )
+    chat_id: Mapped[str] = mapped_column(Text, nullable=False)
+    window_started_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=False
+    )
+    window_closes_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=False
+    )
+    expires_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=False
+    )
+    approval_nonce: Mapped[str] = mapped_column(Text, nullable=False)
+    approval_nonce_used_at: Mapped[datetime | None] = mapped_column(
+        TIMESTAMP(timezone=True)
+    )
+    approved_by_telegram_user_id: Mapped[str | None] = mapped_column(Text)
+    approved_at: Mapped[datetime | None] = mapped_column(TIMESTAMP(timezone=True))
+    summary_message_id: Mapped[int | None] = mapped_column(BigInteger)
+    summary_dispatch_state: Mapped[str] = mapped_column(
+        Text, nullable=False, server_default="idle"
+    )
+    summary_dispatch_lease_until: Mapped[datetime | None] = mapped_column(
+        TIMESTAMP(timezone=True)
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=False, server_default=func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+        onupdate=func.now(),
+    )
+
+
+class OrderProposalApprovalBatchMember(Base):
+    __tablename__ = "order_proposal_approval_batch_members"
+    __table_args__ = (
+        UniqueConstraint(
+            "batch_pk", "proposal_pk", name="uq_order_proposal_batch_member"
+        ),
+        UniqueConstraint(
+            "proposal_pk",
+            "approval_nonce_snapshot",
+            name="uq_order_proposal_batch_member_nonce",
+        ),
+        Index("ix_order_proposal_batch_members_batch_pk", "batch_pk"),
+        {"schema": "review"},
+    )
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    batch_pk: Mapped[int] = mapped_column(
+        BigInteger,
+        ForeignKey(
+            "review.order_proposal_approval_batches.id", ondelete="CASCADE"
+        ),
+        nullable=False,
+    )
+    proposal_pk: Mapped[int] = mapped_column(
+        BigInteger,
+        ForeignKey("review.order_proposals.id", ondelete="RESTRICT"),
+        nullable=False,
+    )
+    approval_nonce_snapshot: Mapped[str] = mapped_column(Text, nullable=False)
+    approval_message_id: Mapped[int] = mapped_column(BigInteger, nullable=False)
+    result: Mapped[str | None] = mapped_column(Text)
+    result_detail: Mapped[dict | None] = mapped_column(JSONB)
+    processed_at: Mapped[datetime | None] = mapped_column(
+        TIMESTAMP(timezone=True)
+    )
+    added_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=False
+    )

--- a/app/services/order_proposals/approval_message.py
+++ b/app/services/order_proposals/approval_message.py
@@ -24,6 +24,15 @@ _CASH_LABELS = (
     ("buffer_cash", "현금 버퍼"),
     ("utilization_pct", "사용률"),
 )
+_BATCH_RUNG_RESULT_LABELS = {
+    "submitted_acked": "체결 대기(접수)",
+    "submitted_resting": "주문 유지(대기)",
+    "guard_blocked": "가드에 의해 차단됨",
+    "unverified": "확인 불가(수동 확인 필요)",
+    "error": "오류",
+    "needs_reconfirm": "재확인 필요",
+    "cancelled": "취소 확인",
+}
 
 
 def build_callback_data(
@@ -154,15 +163,15 @@ def build_batch_approval_message(
             quantity = _safe_decimal(getattr(rung, "quantity", None))
             price = _safe_decimal(getattr(rung, "limit_price", None))
             explicit = _safe_decimal(getattr(rung, "notional", None))
-            notional = (
-                explicit
-                if explicit is not None
-                else (
-                    quantity * price
-                    if quantity is not None and price is not None
+            notional = None
+            if price is not None:
+                notional = (
+                    explicit
+                    if explicit is not None
+                    else quantity * price
+                    if quantity is not None
                     else None
                 )
-            )
             if notional is not None:
                 proposal_total += notional
                 has_notional = True
@@ -237,10 +246,21 @@ def build_batch_result_message(
             status = "failed"
         proposal_id = str(result.get("proposal_id") or "")
         symbol = symbols.get(proposal_id, proposal_id[:8] or "미기재")
+        details: list[str] = []
         reason = " ".join(str(result.get("reason") or "").split())
         if len(reason) > 160:
             reason = reason[:159] + "…"
-        suffix = f" — {_escape_markdown(reason)}" if reason else ""
+        if reason:
+            details.append(_escape_markdown(reason))
+        rung_results = result.get("rung_results")
+        if isinstance(rung_results, Sequence) and not isinstance(
+            rung_results, (str, bytes)
+        ):
+            details.extend(
+                f"#{index} {_escape_markdown(_BATCH_RUNG_RESULT_LABELS.get(str(value), str(value)))}"
+                for index, value in enumerate(rung_results, start=1)
+            )
+        suffix = f" — {'; '.join(details)}" if details else ""
         grouped[status].append(f"- `{_escape_inline_code(symbol)}`{suffix}")
 
     lines = ["*일괄 승인 결과*"]

--- a/app/services/order_proposals/approval_message.py
+++ b/app/services/order_proposals/approval_message.py
@@ -156,6 +156,9 @@ def build_batch_approval_message(
         market = str(getattr(group, "market", None) or "")
         currency = _currency_for_market(market=market, symbol=symbol) or "기타"
         account_label = _batch_account_label(group)
+        is_market_order = (
+            str(getattr(group, "order_type", "") or "").lower() == "market"
+        )
         rung_parts: list[str] = []
         proposal_total = Decimal("0")
         has_notional = False
@@ -164,7 +167,7 @@ def build_batch_approval_message(
             price = _safe_decimal(getattr(rung, "limit_price", None))
             explicit = _safe_decimal(getattr(rung, "notional", None))
             notional = None
-            if price is not None:
+            if not is_market_order and price is not None:
                 notional = (
                     explicit
                     if explicit is not None
@@ -178,7 +181,7 @@ def build_batch_approval_message(
             rung_parts.append(
                 f"#{int(getattr(rung, 'rung_index', 0)) + 1} "
                 f"{_format_decimal(getattr(rung, 'quantity', None))} × "
-                f"{_format_money(getattr(rung, 'limit_price', None), currency=currency, none_label='시장가')}"
+                f"{_format_money(None if is_market_order else getattr(rung, 'limit_price', None), currency=currency, none_label='시장가')}"
             )
         lines.append(
             f"- `{_escape_inline_code(symbol)}` "
@@ -256,10 +259,18 @@ def build_batch_result_message(
         if isinstance(rung_results, Sequence) and not isinstance(
             rung_results, (str, bytes)
         ):
-            details.extend(
-                f"#{index} {_escape_markdown(_BATCH_RUNG_RESULT_LABELS.get(str(value), str(value)))}"
-                for index, value in enumerate(rung_results, start=1)
-            )
+            for fallback_index, value in enumerate(rung_results, start=1):
+                if isinstance(value, Mapping):
+                    try:
+                        display_index = int(value.get("rung_index", 0)) + 1
+                    except (TypeError, ValueError):
+                        display_index = fallback_index
+                    result_value = str(value.get("result") or "unknown")
+                else:
+                    display_index = fallback_index
+                    result_value = str(value)
+                label = _BATCH_RUNG_RESULT_LABELS.get(result_value, result_value)
+                details.append(f"#{display_index} {_escape_markdown(label)}")
         suffix = f" — {'; '.join(details)}" if details else ""
         grouped[status].append(f"- `{_escape_inline_code(symbol)}`{suffix}")
 

--- a/app/services/order_proposals/approval_message.py
+++ b/app/services/order_proposals/approval_message.py
@@ -11,9 +11,9 @@ from typing import Any
 
 from app.core.timezone import KST
 
-_ALLOWED_ACTIONS = frozenset({"op", "dn", "lc", "vc"})
+_ALLOWED_ACTIONS = frozenset({"op", "dn", "lc", "vc", "ba"})
 _CALLBACK_PATTERN = re.compile(
-    r"^(?P<action>op|dn|lc|vc):(?P<proposal_short>[0-9a-f]{8}):"
+    r"^(?P<action>op|dn|lc|vc|ba):(?P<proposal_short>[0-9a-f]{8}):"
     r"(?P<nonce>[A-Za-z0-9_-]+)$"
 )
 _MAX_CALLBACK_BYTES = 64
@@ -34,7 +34,7 @@ def build_callback_data(
 ) -> str:
     """Build compact Telegram callback data for an approval action."""
     if action not in _ALLOWED_ACTIONS:
-        raise ValueError("action must be one of: op, dn, lc, vc")
+        raise ValueError("action must be one of: op, dn, lc, vc, ba")
     if not isinstance(proposal_id, uuid.UUID):
         raise ValueError("proposal_id must be a UUID")
     if not isinstance(nonce, str) or not re.fullmatch(r"[A-Za-z0-9_-]+", nonce):
@@ -44,6 +44,11 @@ def build_callback_data(
     if len(data.encode("utf-8")) > _MAX_CALLBACK_BYTES:
         raise ValueError("callback data must not exceed 64 bytes")
     return data
+
+
+def build_batch_callback_data(*, batch_id: uuid.UUID, nonce: str) -> str:
+    """Build compact callback data for a batch-only approval trigger."""
+    return build_callback_data(action="ba", proposal_id=batch_id, nonce=nonce)
 
 
 def parse_callback_data(data: str) -> tuple[str, str, str]:
@@ -113,6 +118,138 @@ def build_buying_power_shortfall_text(detail: Mapping[str, Any]) -> str | None:
         f"부족 {_format_shortfall_money(shortfall, currency=currency)} "
         "— 입금 후 재승인"
     )
+
+
+def build_batch_approval_message(
+    *,
+    batch: Any,
+    proposals: Sequence[tuple[Any, Sequence[Any]]],
+) -> tuple[str, dict]:
+    """Render a pending manual-approval batch without exposing raw nonces."""
+    if len(proposals) < 2:
+        raise ValueError("batch summary requires at least two proposals")
+    batch_id = getattr(batch, "batch_id", None)
+    nonce = getattr(batch, "approval_nonce", None)
+    if not isinstance(batch_id, uuid.UUID) or not nonce:
+        raise ValueError("batch_id and approval_nonce are required")
+
+    totals: dict[str, Decimal] = {}
+    account_totals: dict[tuple[str, str], Decimal] = {}
+    lines = [
+        "*일괄 승인 대기*",
+        f"- 제안: {len(proposals)}건",
+        "",
+        "*주문 목록*",
+    ]
+    for group, rungs in proposals:
+        symbol = str(getattr(group, "symbol", None) or "미기재")
+        side = str(getattr(group, "side", None) or "미기재")
+        market = str(getattr(group, "market", None) or "")
+        currency = _currency_for_market(market=market, symbol=symbol) or "기타"
+        account_label = _batch_account_label(group)
+        rung_parts: list[str] = []
+        proposal_total = Decimal("0")
+        has_notional = False
+        for rung in sorted(rungs, key=lambda item: getattr(item, "rung_index", 0)):
+            quantity = _safe_decimal(getattr(rung, "quantity", None))
+            price = _safe_decimal(getattr(rung, "limit_price", None))
+            explicit = _safe_decimal(getattr(rung, "notional", None))
+            notional = (
+                explicit
+                if explicit is not None
+                else (
+                    quantity * price
+                    if quantity is not None and price is not None
+                    else None
+                )
+            )
+            if notional is not None:
+                proposal_total += notional
+                has_notional = True
+            rung_parts.append(
+                f"#{int(getattr(rung, 'rung_index', 0)) + 1} "
+                f"{_format_decimal(getattr(rung, 'quantity', None))} × "
+                f"{_format_money(getattr(rung, 'limit_price', None), currency=currency, none_label='시장가')}"
+            )
+        lines.append(
+            f"- `{_escape_inline_code(symbol)}` "
+            f"`{_escape_inline_code(side)}` · "
+            f"{_escape_markdown(account_label)} · " + "; ".join(rung_parts)
+        )
+        if has_notional:
+            totals[currency] = totals.get(currency, Decimal("0")) + proposal_total
+            account_key = (account_label, currency)
+            account_totals[account_key] = (
+                account_totals.get(account_key, Decimal("0")) + proposal_total
+            )
+
+    lines.extend(["", "*금액 요약*"])
+    for currency, amount in sorted(totals.items()):
+        lines.append(f"- 합계: {_format_money(amount, currency=currency)}")
+    for (account_label, currency), amount in sorted(account_totals.items()):
+        lines.append(
+            f"- {_escape_markdown(account_label)}: "
+            f"{_format_money(amount, currency=currency)}"
+        )
+    lines.extend(
+        [
+            "",
+            f"- 승인 기한: {_format_datetime(getattr(batch, 'expires_at', None), approximate=False)}",
+        ]
+    )
+    keyboard = {
+        "inline_keyboard": [
+            [
+                {
+                    "text": "전체 승인",
+                    "callback_data": build_batch_callback_data(
+                        batch_id=batch_id, nonce=str(nonce)
+                    ),
+                }
+            ]
+        ]
+    }
+    return "\n".join(lines), keyboard
+
+
+def build_batch_result_message(
+    *,
+    proposals: Sequence[tuple[Any, Sequence[Any]]],
+    results: Sequence[Mapping[str, Any]],
+) -> str:
+    """Render terminal batch results grouped by operator-relevant status."""
+    symbols = {
+        str(getattr(group, "proposal_id", "")): str(
+            getattr(group, "symbol", None) or "미기재"
+        )
+        for group, _rungs in proposals
+    }
+    headings = (
+        ("approved", "승인 완료"),
+        ("needs_reconfirm", "재확인 필요"),
+        ("skipped", "제외/건너뜀"),
+        ("failed", "실패"),
+    )
+    grouped: dict[str, list[str]] = {status: [] for status, _label in headings}
+    for result in results:
+        status = str(result.get("status") or "failed")
+        if status not in grouped:
+            status = "failed"
+        proposal_id = str(result.get("proposal_id") or "")
+        symbol = symbols.get(proposal_id, proposal_id[:8] or "미기재")
+        reason = " ".join(str(result.get("reason") or "").split())
+        if len(reason) > 160:
+            reason = reason[:159] + "…"
+        suffix = f" — {_escape_markdown(reason)}" if reason else ""
+        grouped[status].append(f"- `{_escape_inline_code(symbol)}`{suffix}")
+
+    lines = ["*일괄 승인 결과*"]
+    for status, label in headings:
+        if grouped[status]:
+            lines.extend(["", f"*{label}*", *grouped[status]])
+    if len(lines) == 1:
+        lines.extend(["", "- 처리 결과 없음"])
+    return "\n".join(lines)
 
 
 def build_approval_message(
@@ -425,6 +562,24 @@ def _currency_for_market(*, market: str, symbol: str) -> str | None:
     if market == "equity_us":
         return "USD"
     return None
+
+
+def _batch_account_label(group: Any) -> str:
+    account_mode = str(getattr(group, "account_mode", None) or "미기재")
+    broker_account_id = str(getattr(group, "broker_account_id", None) or "")
+    if not broker_account_id:
+        return account_mode
+    return f"{account_mode} ···{broker_account_id[-4:]}"
+
+
+def _safe_decimal(value: object) -> Decimal | None:
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        parsed = Decimal(str(value))
+    except (InvalidOperation, ValueError):
+        return None
+    return parsed if parsed.is_finite() else None
 
 
 def _supported_currency(value: object) -> str | None:

--- a/app/services/order_proposals/dispatch.py
+++ b/app/services/order_proposals/dispatch.py
@@ -8,11 +8,10 @@ and committed, and (b) calls the Telegram notifier, which
 ``OrderProposalsService``/``OrderProposalRepository`` never do (they only
 flush -- see ``service.py``'s module docstring).
 
-Commit-before-notify is not a live risk here the way it is in
-``telegram_callback.py`` (there is no notify call *after* this function's
-mutating work), but the nonce mint + ``source_asof`` merge are still
-committed explicitly before returning, matching that module's established
-discipline rather than relying on implicit ``async with`` behavior.
+The initial individual message necessarily precedes persistence of its Telegram
+message ID. For the derived batch summary, however, membership and the summary
+claim are committed before the summary is sent or edited, so an operator never
+sees a batch button whose second member exists only in an uncommitted session.
 """
 
 from __future__ import annotations
@@ -24,6 +23,8 @@ from collections.abc import Callable
 from datetime import datetime
 from decimal import Decimal
 from typing import Any
+
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import settings
 from app.core.db import AsyncSessionLocal
@@ -67,6 +68,7 @@ def _generate_nonce() -> str:
 
 async def _register_and_publish_batch_summary(
     *,
+    session: AsyncSession,
     service: OrderProposalsService,
     proposal_id: uuid.UUID,
     message_id: int,
@@ -87,6 +89,9 @@ async def _register_and_publish_batch_summary(
         registration.batch.batch_id
     )
     text, keyboard = build_batch_approval_message(batch=batch, proposals=proposals)
+    # Make the frozen membership and summary-delivery claim visible before
+    # publishing a button that depends on both rows.
+    await session.commit()
     if registration.summary_action == "send":
         try:
             summary_id = await notifier.send_approval_message(
@@ -156,6 +161,7 @@ async def send_proposal_for_approval(
                 proposal_id, message_id=message_id, chat_id=chat_id, now=now
             )
             await _register_and_publish_batch_summary(
+                session=session,
                 service=service,
                 proposal_id=proposal_id,
                 message_id=message_id,

--- a/app/services/order_proposals/dispatch.py
+++ b/app/services/order_proposals/dispatch.py
@@ -27,7 +27,10 @@ from typing import Any
 
 from app.core.config import settings
 from app.core.db import AsyncSessionLocal
-from app.services.order_proposals.approval_message import build_approval_message
+from app.services.order_proposals.approval_message import (
+    build_approval_message,
+    build_batch_approval_message,
+)
 from app.services.order_proposals.auto_approve import (
     build_auto_approved_message,
     evaluate_auto_approve_eligibility,
@@ -60,6 +63,57 @@ def _generate_nonce() -> str:
     # than imported -- that name is `_`-prefixed/module-private, and this
     # module is a peer top-level caller, not a consumer of that module.
     return secrets.token_urlsafe(12)
+
+
+async def _register_and_publish_batch_summary(
+    *,
+    service: OrderProposalsService,
+    proposal_id: uuid.UUID,
+    message_id: int,
+    chat_id: str,
+    now: datetime,
+    notifier: Any,
+) -> None:
+    """Best-effort batch registration after the individual message succeeds."""
+    registration = await service.register_approval_batch_member(
+        proposal_id,
+        chat_id=chat_id,
+        approval_message_id=message_id,
+        now=now,
+    )
+    if registration is None or registration.summary_action == "none":
+        return
+    batch, proposals = await service.get_approval_batch_display(
+        registration.batch.batch_id
+    )
+    text, keyboard = build_batch_approval_message(batch=batch, proposals=proposals)
+    if registration.summary_action == "send":
+        try:
+            summary_id = await notifier.send_approval_message(
+                text, keyboard, chat_id=chat_id
+            )
+        except Exception:  # noqa: BLE001 - individual dispatch remains valid
+            logger.exception("order proposal batch summary send failed")
+            await service.release_approval_batch_summary_claim(batch.batch_id, now=now)
+            return
+        if summary_id is None:
+            await service.release_approval_batch_summary_claim(batch.batch_id, now=now)
+            return
+        await service.record_approval_batch_summary(
+            batch.batch_id, message_id=summary_id, now=now
+        )
+        return
+    if batch.summary_message_id is None:
+        return
+    try:
+        await notifier.edit_message(
+            chat_id,
+            batch.summary_message_id,
+            text,
+            reply_markup=keyboard,
+        )
+    except Exception:  # noqa: BLE001 - summary is a best-effort surface
+        logger.exception("order proposal batch summary edit failed")
 
 
 async def send_proposal_for_approval(
@@ -100,6 +154,14 @@ async def send_proposal_for_approval(
         if message_id is not None:
             await service.record_approval_dispatch(
                 proposal_id, message_id=message_id, chat_id=chat_id, now=now
+            )
+            await _register_and_publish_batch_summary(
+                service=service,
+                proposal_id=proposal_id,
+                message_id=message_id,
+                chat_id=chat_id,
+                now=now,
+                notifier=notifier,
             )
 
         # Commit explicitly before returning -- see module docstring. The

--- a/app/services/order_proposals/repository.py
+++ b/app/services/order_proposals/repository.py
@@ -16,7 +16,12 @@ from sqlalchemy import TIMESTAMP, Text, cast, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm.attributes import flag_modified
 
-from app.models.order_proposals import OrderProposal, OrderProposalRung
+from app.models.order_proposals import (
+    OrderProposal,
+    OrderProposalApprovalBatch,
+    OrderProposalApprovalBatchMember,
+    OrderProposalRung,
+)
 
 
 class OrderProposalRepository:
@@ -193,3 +198,122 @@ class OrderProposalRepository:
                 flag_modified(rung, k)
         await self._session.flush()
         return rung
+
+    async def acquire_approval_batch_chat_lock(self, chat_id: str) -> None:
+        await self._session.execute(
+            select(
+                func.pg_advisory_xact_lock(
+                    func.hashtextextended(
+                        f"order_proposals:approval_batch:{chat_id}", 0
+                    )
+                )
+            )
+        )
+
+    async def get_open_approval_batch(
+        self, *, chat_id: str, now: datetime, for_update: bool = False
+    ) -> OrderProposalApprovalBatch | None:
+        stmt = (
+            select(OrderProposalApprovalBatch)
+            .where(
+                OrderProposalApprovalBatch.chat_id == chat_id,
+                OrderProposalApprovalBatch.approval_nonce_used_at.is_(None),
+                OrderProposalApprovalBatch.window_closes_at > now,
+            )
+            .order_by(OrderProposalApprovalBatch.id.desc())
+            .limit(1)
+        )
+        if for_update:
+            stmt = stmt.with_for_update()
+        return (await self._session.execute(stmt)).scalar_one_or_none()
+
+    async def insert_approval_batch(self, **cols: Any) -> OrderProposalApprovalBatch:
+        row = OrderProposalApprovalBatch(**cols)
+        self._session.add(row)
+        await self._session.flush()
+        await self._session.refresh(row)
+        return row
+
+    async def insert_approval_batch_member(
+        self, **cols: Any
+    ) -> OrderProposalApprovalBatchMember:
+        row = OrderProposalApprovalBatchMember(**cols)
+        self._session.add(row)
+        await self._session.flush()
+        await self._session.refresh(row)
+        return row
+
+    async def get_approval_batch_member_by_nonce(
+        self, *, proposal_pk: int, approval_nonce: str
+    ) -> OrderProposalApprovalBatchMember | None:
+        stmt = select(OrderProposalApprovalBatchMember).where(
+            OrderProposalApprovalBatchMember.proposal_pk == proposal_pk,
+            OrderProposalApprovalBatchMember.approval_nonce_snapshot == approval_nonce,
+        )
+        return (await self._session.execute(stmt)).scalar_one_or_none()
+
+    async def get_approval_batch_member_by_id(
+        self, member_id: int, *, for_update: bool = False
+    ) -> OrderProposalApprovalBatchMember | None:
+        stmt = select(OrderProposalApprovalBatchMember).where(
+            OrderProposalApprovalBatchMember.id == member_id
+        )
+        if for_update:
+            stmt = stmt.with_for_update()
+        return (await self._session.execute(stmt)).scalar_one_or_none()
+
+    async def list_approval_batch_members(
+        self, batch_pk: int
+    ) -> list[OrderProposalApprovalBatchMember]:
+        stmt = (
+            select(OrderProposalApprovalBatchMember)
+            .where(OrderProposalApprovalBatchMember.batch_pk == batch_pk)
+            .order_by(
+                OrderProposalApprovalBatchMember.added_at,
+                OrderProposalApprovalBatchMember.id,
+            )
+        )
+        return list((await self._session.execute(stmt)).scalars().all())
+
+    async def get_group_by_pk(self, proposal_pk: int) -> OrderProposal | None:
+        stmt = select(OrderProposal).where(OrderProposal.id == proposal_pk)
+        return (await self._session.execute(stmt)).scalar_one_or_none()
+
+    async def get_approval_batch_by_id(
+        self, batch_id: uuid.UUID, *, for_update: bool = False
+    ) -> OrderProposalApprovalBatch | None:
+        stmt = select(OrderProposalApprovalBatch).where(
+            OrderProposalApprovalBatch.batch_id == batch_id
+        )
+        if for_update:
+            stmt = stmt.with_for_update()
+        return (await self._session.execute(stmt)).scalar_one_or_none()
+
+    async def resolve_approval_batch_id_prefix(
+        self, batch_short: str
+    ) -> uuid.UUID | None:
+        stmt = (
+            select(OrderProposalApprovalBatch.batch_id)
+            .where(
+                cast(OrderProposalApprovalBatch.batch_id, Text).like(f"{batch_short}%")
+            )
+            .limit(2)
+        )
+        matches = list((await self._session.execute(stmt)).scalars().all())
+        return matches[0] if len(matches) == 1 else None
+
+    async def update_approval_batch(
+        self, batch: OrderProposalApprovalBatch, **fields: Any
+    ) -> OrderProposalApprovalBatch:
+        for key, value in fields.items():
+            setattr(batch, key, value)
+        await self._session.flush()
+        return batch
+
+    async def update_approval_batch_member(
+        self, member: OrderProposalApprovalBatchMember, **fields: Any
+    ) -> OrderProposalApprovalBatchMember:
+        for key, value in fields.items():
+            setattr(member, key, value)
+        await self._session.flush()
+        return member

--- a/app/services/order_proposals/repository.py
+++ b/app/services/order_proposals/repository.py
@@ -219,6 +219,7 @@ class OrderProposalRepository:
                 OrderProposalApprovalBatch.chat_id == chat_id,
                 OrderProposalApprovalBatch.approval_nonce_used_at.is_(None),
                 OrderProposalApprovalBatch.window_closes_at > now,
+                OrderProposalApprovalBatch.expires_at > now,
             )
             .order_by(OrderProposalApprovalBatch.id.desc())
             .limit(1)

--- a/app/services/order_proposals/service.py
+++ b/app/services/order_proposals/service.py
@@ -7,6 +7,7 @@ and never commits — callers own the transaction (see global-constraints.md).
 from __future__ import annotations
 
 import inspect
+import secrets
 import uuid
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
@@ -18,7 +19,12 @@ from sqlalchemy import or_, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.timezone import KST
-from app.models.order_proposals import OrderProposal, OrderProposalRung
+from app.models.order_proposals import (
+    OrderProposal,
+    OrderProposalApprovalBatch,
+    OrderProposalApprovalBatchMember,
+    OrderProposalRung,
+)
 from app.models.review import TossLiveOrderLedger
 from app.services.order_proposals import state_machine as sm
 from app.services.order_proposals.broker_gateway import SUPPORTED_TARGET_ACTIONS
@@ -47,6 +53,21 @@ class RungInput:
     quantity: Decimal
     limit_price: Decimal | None
     notional: Decimal | None
+
+
+@dataclass(frozen=True)
+class BatchMemberSnapshot:
+    member_id: int
+    proposal_id: uuid.UUID
+    approval_nonce: str
+    approval_message_id: int
+
+
+@dataclass(frozen=True)
+class BatchRegistration:
+    batch: OrderProposalApprovalBatch
+    member_count: int
+    summary_action: Literal["none", "send", "edit"]
 
 
 # (account_mode, market) combinations the submit path
@@ -108,6 +129,31 @@ def proposal_approval_block_reason(group: OrderProposal) -> str | None:
         return "proposal_superseded_by:unknown"
     if group.lifecycle_state in _APPROVAL_TERMINAL_GROUP_STATES:
         return f"proposal_terminal:{group.lifecycle_state}"
+    return None
+
+
+def batch_member_block_reason(
+    group: OrderProposal,
+    rungs: list[OrderProposalRung],
+    *,
+    now: datetime,
+) -> str | None:
+    """Return why a proposal cannot be represented by a batch trigger."""
+    block_reason = proposal_approval_block_reason(group)
+    if block_reason is not None:
+        return block_reason
+    if group.exit_intent == "loss_cut":
+        return "loss_cut_excluded"
+    if isinstance((group.source_asof or {}).get("auto_approved"), dict):
+        return "auto_approved_excluded"
+    if group.valid_until is not None and now >= group.valid_until:
+        return "proposal_expired"
+    if not group.approval_nonce:
+        return "approval_nonce_missing"
+    if group.approval_nonce_used_at is not None:
+        return "approval_nonce_used"
+    if not any(rung.state == "pending_approval" for rung in rungs):
+        return "no_pending_approval_rungs"
     return None
 
 
@@ -977,6 +1023,230 @@ class OrderProposalsService:
             "approval_sent_at": now.isoformat(),
         }
         return await self._repo.update_group(group, source_asof=merged)
+
+    async def register_approval_batch_member(
+        self,
+        proposal_id: uuid.UUID,
+        *,
+        chat_id: str,
+        approval_message_id: int,
+        now: datetime,
+        window_seconds: int = 600,
+        ttl_seconds: int = 600,
+    ) -> BatchRegistration | None:
+        """Register one still-manual proposal in the chat's open batch."""
+        self._require_timezone_aware(now)
+        await self._repo.acquire_approval_batch_chat_lock(chat_id)
+        group = await self._repo.get_group_by_proposal_id(proposal_id, for_update=True)
+        if group is None:
+            raise OrderProposalNotFound(str(proposal_id))
+        rungs = await self._repo.list_rungs(group.id)
+        if batch_member_block_reason(group, rungs, now=now) is not None:
+            return None
+        if await self._repo.get_approval_batch_member_by_nonce(
+            proposal_pk=group.id,
+            approval_nonce=str(group.approval_nonce),
+        ):
+            return None
+
+        batch = await self._repo.get_open_approval_batch(
+            chat_id=chat_id, now=now, for_update=True
+        )
+        if batch is None:
+            batch = await self._repo.insert_approval_batch(
+                batch_id=uuid.uuid4(),
+                chat_id=chat_id,
+                window_started_at=now,
+                window_closes_at=now + timedelta(seconds=window_seconds),
+                expires_at=self._bounded_batch_expiry(
+                    now=now,
+                    ttl_seconds=ttl_seconds,
+                    validity_deadlines=[group.valid_until],
+                ),
+                approval_nonce=secrets.token_urlsafe(12),
+                summary_dispatch_state="idle",
+            )
+
+        await self._repo.insert_approval_batch_member(
+            batch_pk=batch.id,
+            proposal_pk=group.id,
+            approval_nonce_snapshot=str(group.approval_nonce),
+            approval_message_id=approval_message_id,
+            added_at=now,
+        )
+        members = await self._repo.list_approval_batch_members(batch.id)
+        validity_deadlines: list[datetime | None] = []
+        for member in members:
+            member_group = await self._repo.get_group_by_pk(member.proposal_pk)
+            if member_group is not None:
+                validity_deadlines.append(member_group.valid_until)
+        await self._repo.update_approval_batch(
+            batch,
+            expires_at=self._bounded_batch_expiry(
+                now=now,
+                ttl_seconds=ttl_seconds,
+                validity_deadlines=validity_deadlines,
+            ),
+        )
+
+        member_count = len(members)
+        summary_action: Literal["none", "send", "edit"] = "none"
+        if member_count >= 2:
+            if batch.summary_message_id is not None:
+                summary_action = "edit"
+            elif batch.summary_dispatch_state == "idle" or (
+                batch.summary_dispatch_state == "sending"
+                and batch.summary_dispatch_lease_until is not None
+                and batch.summary_dispatch_lease_until <= now
+            ):
+                await self._repo.update_approval_batch(
+                    batch,
+                    summary_dispatch_state="sending",
+                    summary_dispatch_lease_until=now + timedelta(seconds=30),
+                )
+                summary_action = "send"
+        return BatchRegistration(
+            batch=batch,
+            member_count=member_count,
+            summary_action=summary_action,
+        )
+
+    @staticmethod
+    def _bounded_batch_expiry(
+        *,
+        now: datetime,
+        ttl_seconds: int,
+        validity_deadlines: list[datetime | None],
+    ) -> datetime:
+        expiry = now + timedelta(seconds=ttl_seconds)
+        bounded = [deadline for deadline in validity_deadlines if deadline is not None]
+        return min([expiry, *bounded]) if bounded else expiry
+
+    async def resolve_approval_batch_id_prefix(
+        self, batch_short: str
+    ) -> uuid.UUID | None:
+        return await self._repo.resolve_approval_batch_id_prefix(batch_short)
+
+    async def consume_approval_batch_nonce(
+        self,
+        batch_id: uuid.UUID,
+        nonce: str,
+        *,
+        chat_id: str,
+        telegram_user_id: str,
+        now: datetime,
+    ) -> tuple[OrderProposalApprovalBatch, list[BatchMemberSnapshot]]:
+        """Atomically consume a batch trigger and freeze its ordered members."""
+        self._require_timezone_aware(now)
+        batch = await self._repo.get_approval_batch_by_id(batch_id, for_update=True)
+        if batch is None:
+            raise OrderProposalError("approval_batch_not_found")
+        if batch.chat_id != chat_id:
+            raise OrderProposalError("approval_batch_chat_mismatch")
+        if batch.approval_nonce != nonce:
+            raise OrderProposalError("approval_batch_nonce_mismatch")
+        if batch.approval_nonce_used_at is not None:
+            raise OrderProposalError("approval_batch_nonce_replay")
+        if now > batch.expires_at:
+            raise OrderProposalError("approval_batch_expired")
+        members = await self._repo.list_approval_batch_members(batch.id)
+        if len(members) < 2:
+            raise OrderProposalError("approval_batch_too_small")
+
+        await self._repo.update_approval_batch(
+            batch,
+            approval_nonce_used_at=now,
+            approved_by_telegram_user_id=telegram_user_id,
+            approved_at=now,
+        )
+        snapshots: list[BatchMemberSnapshot] = []
+        for member in members:
+            group = await self._repo.get_group_by_pk(member.proposal_pk)
+            if group is None:
+                continue
+            snapshots.append(
+                BatchMemberSnapshot(
+                    member_id=member.id,
+                    proposal_id=group.proposal_id,
+                    approval_nonce=member.approval_nonce_snapshot,
+                    approval_message_id=member.approval_message_id,
+                )
+            )
+        return batch, snapshots
+
+    async def record_approval_batch_summary(
+        self,
+        batch_id: uuid.UUID,
+        *,
+        message_id: int,
+        now: datetime,
+    ) -> OrderProposalApprovalBatch:
+        self._require_timezone_aware(now)
+        batch = await self._repo.get_approval_batch_by_id(batch_id, for_update=True)
+        if batch is None:
+            raise OrderProposalError("approval_batch_not_found")
+        return await self._repo.update_approval_batch(
+            batch,
+            summary_message_id=message_id,
+            summary_dispatch_state="sent",
+            summary_dispatch_lease_until=None,
+            updated_at=now,
+        )
+
+    async def release_approval_batch_summary_claim(
+        self, batch_id: uuid.UUID, *, now: datetime
+    ) -> OrderProposalApprovalBatch:
+        self._require_timezone_aware(now)
+        batch = await self._repo.get_approval_batch_by_id(batch_id, for_update=True)
+        if batch is None:
+            raise OrderProposalError("approval_batch_not_found")
+        return await self._repo.update_approval_batch(
+            batch,
+            summary_dispatch_state="idle",
+            summary_dispatch_lease_until=None,
+            updated_at=now,
+        )
+
+    async def get_approval_batch_display(
+        self, batch_id: uuid.UUID
+    ) -> tuple[
+        OrderProposalApprovalBatch,
+        list[tuple[OrderProposal, list[OrderProposalRung]]],
+    ]:
+        batch = await self._repo.get_approval_batch_by_id(batch_id)
+        if batch is None:
+            raise OrderProposalError("approval_batch_not_found")
+        proposals: list[tuple[OrderProposal, list[OrderProposalRung]]] = []
+        for member in await self._repo.list_approval_batch_members(batch.id):
+            group = await self._repo.get_group_by_pk(member.proposal_pk)
+            if group is None:
+                continue
+            proposals.append((group, await self._repo.list_rungs(group.id)))
+        return batch, proposals
+
+    async def record_approval_batch_member_result(
+        self,
+        member_id: int,
+        *,
+        result: str,
+        detail: dict[str, Any],
+        now: datetime,
+    ) -> OrderProposalApprovalBatchMember:
+        self._require_timezone_aware(now)
+        member = await self._repo.get_approval_batch_member_by_id(
+            member_id, for_update=True
+        )
+        if member is None:
+            raise OrderProposalError("approval_batch_member_not_found")
+        bounded_detail = {
+            str(key)[:80]: str(value)[:500] for key, value in detail.items()
+        }
+        return await self._repo.update_approval_batch_member(
+            member,
+            result=result[:40],
+            result_detail=bounded_detail,
+            processed_at=now,
+        )
 
     async def record_auto_approval(
         self,

--- a/app/services/order_proposals/service.py
+++ b/app/services/order_proposals/service.py
@@ -1080,10 +1080,20 @@ class OrderProposalsService:
         )
         members = await self._repo.list_approval_batch_members(batch.id)
         validity_deadlines: list[datetime | None] = []
+        # The two-member summary threshold must count only members that are
+        # still batch-eligible right now. A replacement created via supersede
+        # registers into the same window as the proposal it just invalidated;
+        # counting that dead member would announce an "전체 승인" batch whose
+        # live membership is a single proposal.
+        live_member_count = 0
         for member in members:
             member_group = await self._repo.get_group_by_pk(member.proposal_pk)
-            if member_group is not None:
-                validity_deadlines.append(member_group.valid_until)
+            if member_group is None:
+                continue
+            validity_deadlines.append(member_group.valid_until)
+            member_rungs = await self._repo.list_rungs(member_group.id)
+            if batch_member_block_reason(member_group, member_rungs, now=now) is None:
+                live_member_count += 1
         await self._repo.update_approval_batch(
             batch,
             expires_at=self._bounded_batch_expiry(
@@ -1093,7 +1103,7 @@ class OrderProposalsService:
             ),
         )
 
-        member_count = len(members)
+        member_count = live_member_count
         summary_action: Literal["none", "send", "edit"] = "none"
         if member_count >= 2:
             if batch.summary_message_id is not None:

--- a/app/services/order_proposals/service.py
+++ b/app/services/order_proposals/service.py
@@ -1067,6 +1067,10 @@ class OrderProposalsService:
                 summary_dispatch_state="idle",
             )
 
+        existing_members = await self._repo.list_approval_batch_members(batch.id)
+        if any(member.proposal_pk == group.id for member in existing_members):
+            return None
+
         await self._repo.insert_approval_batch_member(
             batch_pk=batch.id,
             proposal_pk=group.id,
@@ -1147,7 +1151,7 @@ class OrderProposalsService:
             raise OrderProposalError("approval_batch_nonce_mismatch")
         if batch.approval_nonce_used_at is not None:
             raise OrderProposalError("approval_batch_nonce_replay")
-        if now > batch.expires_at:
+        if now >= batch.expires_at:
             raise OrderProposalError("approval_batch_expired")
         members = await self._repo.list_approval_batch_members(batch.id)
         if len(members) < 2:

--- a/app/services/order_proposals/telegram_callback.py
+++ b/app/services/order_proposals/telegram_callback.py
@@ -618,6 +618,11 @@ async def _handle_batch_approve(
                         telegram_user_id=telegram_user_id,
                         revalidate_fn=revalidate_fn,
                     )
+                    rung_results = approval_result.get("results")
+                    if isinstance(rung_results, list):
+                        member_result["rung_results"] = [
+                            str(value) for value in rung_results
+                        ]
                     status, reason = _classify_batch_approval_result(approval_result)
                     member_result["status"] = status
                     if reason is not None:
@@ -646,6 +651,7 @@ async def _handle_batch_approve(
                     detail={
                         "proposal_id": member_result["proposal_id"],
                         "reason": member_result.get("reason", ""),
+                        "rung_results": ",".join(member_result.get("rung_results", [])),
                     },
                     now=now,
                 )

--- a/app/services/order_proposals/telegram_callback.py
+++ b/app/services/order_proposals/telegram_callback.py
@@ -103,6 +103,11 @@ _RESULT_LABELS: dict[str, str] = {
     "cancelled": "취소 확인",
 }
 
+_BATCH_SUCCESS_RESULTS = frozenset(
+    {"submitted_acked", "submitted_resting", "cancelled"}
+)
+_BATCH_SKIP_RESULTS = frozenset({"guard_blocked", "approval_required"})
+
 
 def _outcome_error_summary(outcome: RungOutcome, *, limit: int = 240) -> str | None:
     error = str((outcome.detail or {}).get("error") or "").strip()
@@ -201,6 +206,28 @@ def _build_result_summary(outcomes: list[RungOutcome]) -> str:
             label = f"{label} — {reason}"
         lines.append(f"- #{outcome.rung_index + 1}: {label}")
     return "\n".join(lines)
+
+
+def _classify_batch_approval_result(
+    approval_result: dict[str, Any],
+) -> tuple[str, str | None]:
+    """Map the reused single-approval result without hiding rung failures."""
+    if not approval_result.get("handled"):
+        return "skipped", str(approval_result.get("reason") or "approval_skipped")
+    if approval_result.get("reason") == "needs_reconfirm":
+        return "needs_reconfirm", None
+
+    outcomes = [str(value) for value in approval_result.get("results") or []]
+    if outcomes and all(value in _BATCH_SUCCESS_RESULTS for value in outcomes):
+        return "approved", None
+    if outcomes and all(value in _BATCH_SKIP_RESULTS for value in outcomes):
+        return "skipped", ",".join(dict.fromkeys(outcomes))
+    if outcomes:
+        non_success = [
+            value for value in outcomes if value not in _BATCH_SUCCESS_RESULTS
+        ]
+        return "failed", ",".join(dict.fromkeys(non_success or outcomes))
+    return "skipped", "no_rung_outcomes"
 
 
 def _build_extra_reconfirm_block(reconfirm_outcomes: list[RungOutcome]) -> str:
@@ -546,6 +573,14 @@ async def _handle_batch_approve(
             )
         except OrderProposalError as exc:
             await session.commit()
+            if str(exc) == "approval_batch_expired" and message_id is not None:
+                await _safe_edit_message(
+                    notifier,
+                    chat_id,
+                    message_id,
+                    "⌛ 일괄 승인 만료",
+                    reply_markup={"inline_keyboard": []},
+                )
             return {"handled": False, "reason": str(exc)}
 
         # Commit the single-use batch trigger before touching any member. A
@@ -583,18 +618,11 @@ async def _handle_batch_approve(
                         telegram_user_id=telegram_user_id,
                         revalidate_fn=revalidate_fn,
                     )
-                    if approval_result.get("handled"):
-                        reason = str(approval_result.get("reason") or "approved")
-                        member_result["status"] = (
-                            "needs_reconfirm"
-                            if reason == "needs_reconfirm"
-                            else "approved"
-                        )
-                    else:
-                        reason = str(
-                            approval_result.get("reason") or "approval_skipped"
-                        )
-                        member_result.update(status="skipped", reason=reason)
+                    status, reason = _classify_batch_approval_result(approval_result)
+                    member_result["status"] = status
+                    if reason is not None:
+                        member_result["reason"] = reason
+                    if not approval_result.get("handled"):
                         member_message = (
                             f"⚠️ 일괄 승인 제외 — {_escape_markdown(reason)}"
                         )
@@ -611,16 +639,23 @@ async def _handle_batch_approve(
 
             # Record the member outcome before any batch-owned Telegram edit.
             # `_handle_approve` already commits its own broker/proposal work.
-            await member_service.record_approval_batch_member_result(
-                member.member_id,
-                result=str(member_result["status"]),
-                detail={
-                    "proposal_id": member_result["proposal_id"],
-                    "reason": member_result.get("reason", ""),
-                },
-                now=now,
-            )
-            await member_session.commit()
+            try:
+                await member_service.record_approval_batch_member_result(
+                    member.member_id,
+                    result=str(member_result["status"]),
+                    detail={
+                        "proposal_id": member_result["proposal_id"],
+                        "reason": member_result.get("reason", ""),
+                    },
+                    now=now,
+                )
+                await member_session.commit()
+            except Exception:  # noqa: BLE001 - observation must not stop the batch
+                logger.exception(
+                    "order_proposals batch member result audit failed",
+                    extra={"proposal_id": str(member.proposal_id)},
+                )
+                await member_session.rollback()
 
         if member_message is not None:
             await _safe_edit_message(

--- a/app/services/order_proposals/telegram_callback.py
+++ b/app/services/order_proposals/telegram_callback.py
@@ -54,6 +54,7 @@ from app.mcp_server.caller_identity import caller_agent_id_var
 from app.services.order_proposals.approval_message import (
     _escape_markdown,
     build_approval_message,
+    build_batch_result_message,
     build_buying_power_shortfall_text,
     build_loss_cut_confirmation_message,
     parse_callback_data,
@@ -73,7 +74,10 @@ from app.services.order_proposals.revalidation import (
     RungOutcome,
     revalidate_and_submit,
 )
-from app.services.order_proposals.service import OrderProposalsService
+from app.services.order_proposals.service import (
+    OrderProposalsService,
+    batch_member_block_reason,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -513,6 +517,141 @@ async def _handle_approve(
     }
 
 
+async def _handle_batch_approve(
+    *,
+    service_factory: ServiceFactory,
+    batch_short: str,
+    nonce: str,
+    now: datetime,
+    notifier: Any,
+    chat_id: Any,
+    message_id: int | None,
+    telegram_user_id: str,
+    revalidate_fn: RevalidateFn,
+) -> dict[str, Any]:
+    """Consume one batch trigger and process every frozen member independently."""
+    async with service_factory() as session:
+        service = OrderProposalsService(session)
+        batch_id = await service.resolve_approval_batch_id_prefix(batch_short)
+        if batch_id is None:
+            await session.commit()
+            return {"handled": False, "reason": "approval_batch_not_found"}
+        try:
+            _batch, members = await service.consume_approval_batch_nonce(
+                batch_id,
+                nonce,
+                chat_id=str(chat_id),
+                telegram_user_id=telegram_user_id,
+                now=now,
+            )
+        except OrderProposalError as exc:
+            await session.commit()
+            return {"handled": False, "reason": str(exc)}
+
+        # Commit the single-use batch trigger before touching any member. A
+        # crash or Telegram retry can then never execute the frozen set twice.
+        await session.commit()
+
+    results: list[dict[str, Any]] = []
+    for member in members:
+        member_result: dict[str, Any] = {
+            "proposal_id": str(member.proposal_id),
+            "status": "failed",
+        }
+        member_message: str | None = None
+        async with service_factory() as member_session:
+            member_service = OrderProposalsService(member_session)
+            try:
+                group, rungs = await member_service.get_proposal(member.proposal_id)
+                block_reason = batch_member_block_reason(group, rungs, now=now)
+                if block_reason is not None:
+                    member_result.update(status="skipped", reason=block_reason)
+                    member_message = (
+                        f"⚠️ 일괄 승인 제외 — {_escape_markdown(block_reason)}"
+                    )
+                else:
+                    approval_result = await _handle_approve(
+                        session=member_session,
+                        service=member_service,
+                        proposal_id=member.proposal_id,
+                        nonce=member.approval_nonce,
+                        now=now,
+                        notifier=notifier,
+                        chat_id=chat_id,
+                        message_id=member.approval_message_id,
+                        callback_query_id=None,
+                        telegram_user_id=telegram_user_id,
+                        revalidate_fn=revalidate_fn,
+                    )
+                    if approval_result.get("handled"):
+                        reason = str(approval_result.get("reason") or "approved")
+                        member_result["status"] = (
+                            "needs_reconfirm"
+                            if reason == "needs_reconfirm"
+                            else "approved"
+                        )
+                    else:
+                        reason = str(
+                            approval_result.get("reason") or "approval_skipped"
+                        )
+                        member_result.update(status="skipped", reason=reason)
+                        member_message = (
+                            f"⚠️ 일괄 승인 제외 — {_escape_markdown(reason)}"
+                        )
+            except Exception:  # noqa: BLE001 - isolate each batch member
+                logger.exception(
+                    "order_proposals batch member approval failed",
+                    extra={"proposal_id": str(member.proposal_id)},
+                )
+                await member_session.rollback()
+                member_result.update(status="failed", reason="internal_error")
+                member_message = (
+                    "❌ 일괄 승인 처리 실패 — 단건 승인을 다시 확인해 주세요."
+                )
+
+            # Record the member outcome before any batch-owned Telegram edit.
+            # `_handle_approve` already commits its own broker/proposal work.
+            await member_service.record_approval_batch_member_result(
+                member.member_id,
+                result=str(member_result["status"]),
+                detail={
+                    "proposal_id": member_result["proposal_id"],
+                    "reason": member_result.get("reason", ""),
+                },
+                now=now,
+            )
+            await member_session.commit()
+
+        if member_message is not None:
+            await _safe_edit_message(
+                notifier,
+                chat_id,
+                member.approval_message_id,
+                member_message,
+                reply_markup={"inline_keyboard": []},
+            )
+        results.append(member_result)
+
+    async with service_factory() as display_session:
+        display_service = OrderProposalsService(display_session)
+        _batch, proposals = await display_service.get_approval_batch_display(batch_id)
+        await display_session.commit()
+    if message_id is not None:
+        await _safe_edit_message(
+            notifier,
+            chat_id,
+            message_id,
+            build_batch_result_message(proposals=proposals, results=results),
+            reply_markup={"inline_keyboard": []},
+        )
+    return {
+        "handled": True,
+        "reason": "batch_approved",
+        "batch_id": str(batch_id),
+        "results": results,
+    }
+
+
 async def _handle_loss_cut_first_click(
     *,
     session: AsyncSession,
@@ -608,13 +747,28 @@ async def handle_callback_update(
             return {"handled": False, "reason": "chat_not_allowed"}
 
         try:
-            action, proposal_short, nonce = parse_callback_data(data)
+            action, subject_short, nonce = parse_callback_data(data)
         except ValueError:
             return {"handled": False, "reason": "malformed_callback_data"}
 
+        if action == "ba":
+            return await _handle_batch_approve(
+                service_factory=service_factory,
+                batch_short=subject_short,
+                nonce=nonce,
+                now=now,
+                notifier=active_notifier,
+                chat_id=chat_id,
+                message_id=message_id,
+                telegram_user_id=(
+                    str(telegram_user_id) if telegram_user_id is not None else ""
+                ),
+                revalidate_fn=revalidate_fn,
+            )
+
         async with service_factory() as session:
             service = OrderProposalsService(session)
-            proposal_id = await _resolve_proposal_id(service, proposal_short)
+            proposal_id = await _resolve_proposal_id(service, subject_short)
             if proposal_id is None:
                 await session.commit()
                 return {"handled": False, "reason": "proposal_not_found"}

--- a/app/services/order_proposals/telegram_callback.py
+++ b/app/services/order_proposals/telegram_callback.py
@@ -42,7 +42,7 @@ from __future__ import annotations
 import logging
 import secrets
 import uuid
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from datetime import datetime
 from typing import Any
 
@@ -107,6 +107,28 @@ _BATCH_SUCCESS_RESULTS = frozenset(
     {"submitted_acked", "submitted_resting", "cancelled"}
 )
 _BATCH_SKIP_RESULTS = frozenset({"guard_blocked", "approval_required"})
+
+
+def _serialize_rung_outcomes(outcomes: list[RungOutcome]) -> list[dict[str, Any]]:
+    """Preserve the original rung index for batch summaries and audits."""
+    return [
+        {"rung_index": outcome.rung_index, "result": outcome.result}
+        for outcome in outcomes
+    ]
+
+
+def _batch_result_values(approval_result: Mapping[str, Any]) -> list[str]:
+    """Read structured rung results, falling back to the legacy value list."""
+    structured = approval_result.get("rung_results")
+    if isinstance(structured, list):
+        values = [
+            str(item.get("result"))
+            for item in structured
+            if isinstance(item, Mapping) and item.get("result") is not None
+        ]
+        if values:
+            return values
+    return [str(value) for value in approval_result.get("results") or []]
 
 
 def _outcome_error_summary(outcome: RungOutcome, *, limit: int = 240) -> str | None:
@@ -217,7 +239,7 @@ def _classify_batch_approval_result(
     if approval_result.get("reason") == "needs_reconfirm":
         return "needs_reconfirm", None
 
-    outcomes = [str(value) for value in approval_result.get("results") or []]
+    outcomes = _batch_result_values(approval_result)
     if outcomes and all(value in _BATCH_SUCCESS_RESULTS for value in outcomes):
         return "approved", None
     if outcomes and all(value in _BATCH_SKIP_RESULTS for value in outcomes):
@@ -525,6 +547,8 @@ async def _handle_approve(
             "reason": "needs_reconfirm",
             "proposal_id": str(proposal_id),
             "new_message_id": new_message_id,
+            "results": [outcome.result for outcome in outcomes],
+            "rung_results": _serialize_rung_outcomes(outcomes),
         }
 
     summary = _build_result_summary(outcomes)
@@ -541,6 +565,7 @@ async def _handle_approve(
         "reason": "approved",
         "proposal_id": str(proposal_id),
         "results": [outcome.result for outcome in outcomes],
+        "rung_results": _serialize_rung_outcomes(outcomes),
     }
 
 
@@ -618,10 +643,17 @@ async def _handle_batch_approve(
                         telegram_user_id=telegram_user_id,
                         revalidate_fn=revalidate_fn,
                     )
-                    rung_results = approval_result.get("results")
+                    rung_results = approval_result.get("rung_results")
                     if isinstance(rung_results, list):
                         member_result["rung_results"] = [
-                            str(value) for value in rung_results
+                            {
+                                "rung_index": int(value["rung_index"]),
+                                "result": str(value["result"]),
+                            }
+                            for value in rung_results
+                            if isinstance(value, Mapping)
+                            and "rung_index" in value
+                            and "result" in value
                         ]
                     status, reason = _classify_batch_approval_result(approval_result)
                     member_result["status"] = status
@@ -651,7 +683,10 @@ async def _handle_batch_approve(
                     detail={
                         "proposal_id": member_result["proposal_id"],
                         "reason": member_result.get("reason", ""),
-                        "rung_results": ",".join(member_result.get("rung_results", [])),
+                        "rung_results": ",".join(
+                            f"{value['rung_index']}:{value['result']}"
+                            for value in member_result.get("rung_results", [])
+                        ),
                     },
                     now=now,
                 )

--- a/docs/runbooks/order-proposals.md
+++ b/docs/runbooks/order-proposals.md
@@ -37,6 +37,10 @@ proposal execution and ROB-858 Toss loss-cut/reconcile convergence:
   adding shared ROB-800 guards, Toss audit fields, broker-evidence projection,
   and a terminal-row repair sweep. The canonical GO rationale and risks are in
   [`docs/plans/2026-07-13-rob-858-toss-losscut-decision.md`](../plans/2026-07-13-rob-858-toss-losscut-decision.md).
+- **ROB-870** — adds a durable Telegram `전체 승인` summary for eligible
+  manual proposals. It preserves every proposal's individual buttons, nonce,
+  audit, fresh revalidation, and result message; a batch is only a single-use
+  trigger over those existing approval paths.
 
 There is still **no**
 `order_proposal_approve` / `order_proposal_submit` MCP tool in any slice —
@@ -81,6 +85,12 @@ See the full design in
   callback) — so neither a stale cached message nor a duplicate callback can
   ever re-trigger approval/deny. See Troubleshooting for the two error
   strings.
+- **Batch nonce is not proposal authorization.** ROB-870 atomically consumes a
+  separate batch nonce before processing its frozen member list. It then
+  consumes each member's snapshotted proposal nonce through the same single-
+  proposal approval path. Replaying the batch trigger cannot run the list
+  twice, and a stale or already-used member nonce is skipped rather than
+  bypassed.
 - **Chat allowlist (authz, separate from the webhook secret).**
   `handle_callback_update` rejects any callback whose `chat.id` is not in
   `settings.order_proposals_telegram_chat_allowlist`
@@ -421,6 +431,19 @@ WHERE root_proposal_id = (
   SELECT root_proposal_id FROM review.order_proposals WHERE proposal_id = '<PROPOSAL_UUID>'
 )
 ORDER BY revision;
+
+-- A batch, its members, and per-member outcomes (nonce values remain secret)
+SELECT
+  b.batch_id, b.chat_id, b.window_started_at, b.window_closes_at,
+  b.expires_at, b.approval_nonce_used_at, b.approved_at,
+  b.approved_by_telegram_user_id, b.summary_message_id,
+  p.proposal_id, p.symbol, m.approval_message_id,
+  m.result, m.result_detail, m.processed_at, m.added_at
+FROM review.order_proposal_approval_batches b
+JOIN review.order_proposal_approval_batch_members m ON m.batch_pk = b.id
+JOIN review.order_proposals p ON p.id = m.proposal_pk
+WHERE b.batch_id = '<BATCH_UUID>'
+ORDER BY m.added_at, m.id;
 ```
 
 No SQL INSERT/UPDATE/DELETE against these tables is supported outside
@@ -474,6 +497,41 @@ Canary sequence: deploy with the flag off; enable only the smallest checked-in
 caps and confirm one resting order plus veto; verify DB/broker convergence;
 then raise caps in a reviewed policy PR. Never enable by changing both the env
 gate and caps broadly in the same operational step.
+
+### Manual batch approval (ROB-870)
+
+ROB-870 has no separate activation flag. When the existing proposal Telegram
+surface is enabled, every successfully delivered, eligible manual approval
+message is registered into a batch for that destination chat. The first member
+opens a fixed ten-minute collection window; later members do not move the
+window boundary. A summary with `전체 승인` appears at member two and is edited
+as more eligible messages arrive. The batch click expires ten minutes after
+the latest member, capped by the earliest non-null member `valid_until`.
+
+Registration and click-time checks both exclude loss cuts, terminal or
+superseded proposals, already auto-approved proposals, expired proposals,
+used/missing proposal nonces, and groups with no pending approval rung. Loss
+cuts keep their mandatory two-click evidence flow. Market orders and explicit
+replace/cancel actions remain human-gated and may use the batch surface; the
+batch does not weaken any action-specific fresh broker checks.
+
+Clicking `전체 승인` performs these steps:
+
+1. Consume and commit the batch nonce once, freezing the ordered members.
+2. Re-read each proposal and rerun the eligibility checks at click time.
+3. Process each remaining member in its own transaction through the normal
+   single-proposal nonce, approval audit, commit lease, fresh preview, guards,
+   and submit path.
+4. Continue after a skipped or failed member and edit each individual message
+   with its own outcome.
+5. Replace the summary with grouped `승인 완료`, `재확인 필요`,
+   `제외/건너뜀`, and `실패` results.
+
+The individual `✅ 승인` / `❌ 거부` messages remain available. A ROB-861
+buying-power shortfall affects only that member: it receives the existing new
+nonce and reconfirmation message, while later batch members continue. A
+member-level unexpected error is recorded as `failed`; it does not roll back
+already committed members or stop the rest of the batch.
 
 For a deployment that will approve loss cuts, configure both sides of the
 identity binding with an operator-managed identity (placeholder shown; do not
@@ -621,8 +679,9 @@ submitted blind would defeat the entire point of a human-approval gate.
    `chat.id` against `settings.order_proposals_telegram_chat_allowlist`
    first, before parsing anything else about the callback.
 2. **Callback-data parse + proposal resolution.** `parse_callback_data`
-   extracts `(action, proposal_short, nonce)` from the compact
-   `op:<8-char-prefix>:<nonce>` / `dn:<8-char-prefix>:<nonce>` string (no raw
+   extracts `(action, subject_short, nonce)` from the compact
+   `op:<8-char-prefix>:<nonce>` / `dn:<8-char-prefix>:<nonce>` /
+   `ba:<8-char-batch-prefix>:<nonce>` string (no raw
    `approval_hash` ever appears in a Telegram message —
    `build_approval_message` explicitly redacts `payload_hash`,
    `approval_hash`, the nonce, and every rung's `approval_hash_digest` from
@@ -928,6 +987,12 @@ The ROB-816 migration (`20260710_rob816_order_proposals`) is additive-only
 `20260710_rob800_exit_intent`. `downgrade()` drops indexes then tables in
 reverse order and is safe in non-production environments.
 
+ROB-870 adds the equally additive
+`20260714_rob870_approval_batches` head with
+`review.order_proposal_approval_batches` and
+`review.order_proposal_approval_batch_members`. Apply it before enabling the
+updated runtime; its downgrade drops the member table before the batch table.
+
 ### `403 Telegram callback token not configured`
 
 `AuthMiddleware` returns this when `ORDER_PROPOSALS_TELEGRAM_TOKEN` is unset
@@ -991,6 +1056,27 @@ nonce on that message, so its buttons remain clickable but inert). If
 neither explains it, check whether something outside the Telegram flow
 called `set_approval_nonce`/`consume_approval_nonce` directly (should never
 happen outside `dispatch.py`/`telegram_callback.py`).
+
+### `approval_batch_nonce_replay` / `approval_batch_expired`
+
+`approval_batch_nonce_replay` means the `전체 승인` trigger was already
+consumed. The original execution may still be processing or may already have
+finished; inspect the summary and the batch DB query above instead of clicking
+again. `approval_batch_expired` means its click TTL or a member's earlier
+`valid_until` boundary passed. Use the still-current individual messages, or
+create/dispatch fresh proposals where their individual approval window also
+expired. `approval_batch_not_found` means the compact batch prefix resolves to
+no unique durable batch; fail closed and use individual approvals.
+
+### Batch summary contains `제외/건너뜀` or `실패`
+
+`제외/건너뜀` is an expected click-time race outcome: the member became
+terminal/superseded/auto-approved/expired, its proposal nonce was already used,
+or it no longer has a pending approval rung. `실패` is an isolated unexpected
+member error. Later members still run in both cases. Check the individual
+message, `result_detail` in the batch DB query, and the proposal/rung state;
+retry only through a current individual approval button or a newly dispatched
+proposal. Never replay the batch callback.
 
 ### `NEEDS_RECONFIRM` loop (a rung keeps coming back needs_reconfirm)
 

--- a/docs/runbooks/order-proposals.md
+++ b/docs/runbooks/order-proposals.md
@@ -500,6 +500,25 @@ gate and caps broadly in the same operational step.
 
 ### Manual batch approval (ROB-870)
 
+The production DB source of truth for the 2026-07-13 US session is: raw 19
+groups/20 rungs, minus 3/3 superseded by ROB-869, leaving 16/17 valid. The
+ROB-871 counterfactual classifies 3/3 as automatic candidates, so the manual
+remainder is 13 groups/14 rungs:
+
+| Exclusive manual reason | Groups | Rungs | Operational interpretation |
+|---|---:|---:|---|
+| Per-order cap above the $150 US canary seed | 9 | 9 | Temporary rollout policy; expected to shrink as the reviewed cap rises. |
+| Resting distance below 3% | 3 | 3 | Structurally human-gated at the current resting policy. |
+| Action type (`replace` / `cancel`) | 0 | 0 | Structurally human-gated even though this session had no such rows. |
+| Other: multi-rung all-or-human fallback | 1 | 2 | Structurally human-gated until atomic ladder execution exists. |
+| **Total manual remainder** | **13** | **14** | |
+
+Excluding the temporary cap leaves a structural floor of 4 groups/5 rungs in
+this session. The implementation value is based on that structural manual work
+(immediate/non-resting proposals, replace/cancel, multi-rung all-or-human) and
+on gate-off periods where all valid proposals fall back to human approval, not
+on treating the conservative $150 canary cap as permanent demand.
+
 ROB-870 has no separate activation flag. When the existing proposal Telegram
 surface is enabled, every successfully delivered, eligible manual approval
 message is registered into a batch for that destination chat. The first member

--- a/docs/runbooks/order-proposals.md
+++ b/docs/runbooks/order-proposals.md
@@ -40,7 +40,9 @@ proposal execution and ROB-858 Toss loss-cut/reconcile convergence:
 - **ROB-870** — adds a durable Telegram `전체 승인` summary for eligible
   manual proposals. It preserves every proposal's individual buttons, nonce,
   audit, fresh revalidation, and result message; a batch is only a single-use
-  trigger over those existing approval paths.
+  trigger over those existing approval paths. See the
+  [ROB-870 design](../superpowers/specs/2026-07-14-rob-870-telegram-batch-approval-design.md)
+  and [implementation plan](../superpowers/plans/2026-07-14-rob-870-telegram-batch-approval.md).
 
 There is still **no**
 `order_proposal_approve` / `order_proposal_submit` MCP tool in any slice —

--- a/docs/superpowers/plans/2026-07-14-rob-870-telegram-batch-approval.md
+++ b/docs/superpowers/plans/2026-07-14-rob-870-telegram-batch-approval.md
@@ -1,0 +1,922 @@
+# ROB-870 Telegram Batch Approval Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a durable Telegram “approve all” surface for manual order proposals while preserving every proposal's existing nonce, approval audit, revalidation, and individual message behavior.
+
+**Architecture:** Add relational batch and membership records in the `review` schema, register successfully dispatched manual proposals into a ten-minute same-chat collection window, and render a summary after the second member. A batch click consumes only the batch trigger nonce, then processes each snapshotted proposal nonce through the existing `_handle_approve` path in an independent transaction so failures remain isolated.
+
+**Tech Stack:** Python 3.13, SQLAlchemy 2 async ORM, PostgreSQL advisory/row locks, Alembic, FastAPI Telegram webhook integration, pytest/pytest-asyncio, Ruff, ty.
+
+## Global Constraints
+
+- Runtime baseline is Python 3.13+ and all Python commands use `uv run`.
+- Batch collection window is ten minutes from the first eligible member; new members do not extend it.
+- Batch click TTL is ten minutes after the latest member, bounded by the earliest non-null member `valid_until`.
+- Batch summary appears only at two or more members and is scoped to one Telegram chat.
+- `loss_cut`, superseded/terminal, and already auto-approved proposals are excluded at registration and click time.
+- A batch nonce is a single-use trigger only; every member's existing proposal nonce and approval audit remain mandatory.
+- Each proposal executes in an independent transaction through existing `revalidate_and_submit`; one failure never stops later members.
+- Existing individual approve/deny buttons and callbacks remain unchanged.
+- ROB-861 shortfalls remain per-rung `needs_reconfirm` results with the existing fresh nonce/message behavior.
+- Do not modify ROB-868 websocket or ROB-877 broker-gateway behavior.
+- Keep repository imports internal to `service.py`; callers use `OrderProposalsService` only.
+- Final gates are `uv run pytest tests/services/order_proposals/ -q` and `make lint`.
+
+---
+
+## File Map
+
+- Create `alembic/versions/20260714_rob870_approval_batches.py`: additive batch tables, constraints, and indexes from the current head.
+- Modify `app/models/order_proposals.py`: ORM rows for approval batches and members.
+- Modify `app/models/__init__.py`: export the two new ORM types.
+- Modify `tests/_schema_bootstrap.py`: bump persistent test-schema version for the new ORM tables.
+- Modify `tests/services/order_proposals/test_models_smoke.py`: assert schema, columns, foreign keys, and uniqueness.
+- Modify `app/services/order_proposals/approval_message.py`: `ba` callback support plus pending/final batch renderers.
+- Modify `tests/services/order_proposals/test_approval_message.py`: pure callback/summary formatting tests.
+- Modify `app/services/order_proposals/repository.py`: private CRUD, locked lookup, prefix resolution, membership, and update primitives.
+- Modify `app/services/order_proposals/service.py`: eligibility rules, registration, TTL, nonce consumption, member snapshots/results, and summary audit.
+- Modify `tests/services/order_proposals/test_service.py`: batch lifecycle and concurrency-facing invariants.
+- Modify `app/services/order_proposals/dispatch.py`: register after individual send and send/edit the batch summary.
+- Modify `tests/services/order_proposals/test_dispatch.py`: grouping windows, exclusions, summary send/edit, gate-off, and auto-approved behavior.
+- Modify `app/services/order_proposals/telegram_callback.py`: batch callback orchestration over independent member sessions.
+- Modify `tests/services/order_proposals/test_telegram_callback.py`: replay, TTL, partial failure, stale exclusion, individual edits, and ROB-861 mixture.
+- Modify `docs/runbooks/order-proposals.md`: operator-facing batch contract and failure semantics.
+
+---
+
+### Task 1: Persist Approval Batches and Membership
+
+**Files:**
+- Create: `alembic/versions/20260714_rob870_approval_batches.py`
+- Modify: `app/models/order_proposals.py`
+- Modify: `app/models/__init__.py`
+- Modify: `tests/_schema_bootstrap.py`
+- Test: `tests/services/order_proposals/test_models_smoke.py`
+
+**Interfaces:**
+- Produces: `OrderProposalApprovalBatch` and `OrderProposalApprovalBatchMember` ORM models.
+- Produces: database uniqueness on `batch_id`, `(batch_pk, proposal_pk)`, and `(proposal_pk, approval_nonce_snapshot)`.
+- Consumes: existing `review.order_proposals.id` as the member foreign key.
+
+- [ ] **Step 1: Write failing ORM contract tests**
+
+Add imports and a test that asserts the exact table contracts:
+
+```python
+from app.models.order_proposals import (
+    OrderProposalApprovalBatch,
+    OrderProposalApprovalBatchMember,
+)
+
+
+@pytest.mark.unit
+def test_approval_batch_models_are_durable_and_bound_to_proposals():
+    batch = OrderProposalApprovalBatch.__table__
+    member = OrderProposalApprovalBatchMember.__table__
+    assert batch.schema == member.schema == "review"
+    assert batch.name == "order_proposal_approval_batches"
+    assert member.name == "order_proposal_approval_batch_members"
+    assert {
+        "batch_id", "chat_id", "window_started_at", "window_closes_at",
+        "expires_at", "approval_nonce", "approval_nonce_used_at",
+        "approved_by_telegram_user_id", "approved_at", "summary_message_id",
+        "summary_dispatch_state", "summary_dispatch_lease_until",
+    } <= set(batch.columns)
+    assert {
+        "batch_pk", "proposal_pk", "approval_nonce_snapshot",
+        "approval_message_id", "result", "result_detail", "processed_at",
+        "added_at",
+    } <= set(member.columns)
+    unique_names = {c.name for c in member.constraints if c.__class__.__name__ == "UniqueConstraint"}
+    assert "uq_order_proposal_batch_member" in unique_names
+    assert "uq_order_proposal_batch_member_nonce" in unique_names
+```
+
+- [ ] **Step 2: Run the model test and verify RED**
+
+Run: `uv run pytest tests/services/order_proposals/test_models_smoke.py::test_approval_batch_models_are_durable_and_bound_to_proposals -q`
+
+Expected: collection fails because the two model classes do not exist.
+
+- [ ] **Step 3: Add the ORM models and exports**
+
+Add these model shapes after `OrderProposalRung`, using existing `Base`, `Mapped`, `mapped_column`, `JSONB`, `PG_UUID`, and timestamp conventions:
+
+```python
+class OrderProposalApprovalBatch(Base):
+    __tablename__ = "order_proposal_approval_batches"
+    __table_args__ = (
+        UniqueConstraint("batch_id", name="uq_order_proposal_approval_batches_batch_id"),
+        CheckConstraint(
+            "summary_dispatch_state IN ('idle','sending','sent')",
+            name="order_proposal_approval_batches_summary_state",
+        ),
+        Index("ix_order_proposal_approval_batches_chat_window", "chat_id", "window_closes_at"),
+        {"schema": "review"},
+    )
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    batch_id: Mapped[uuid.UUID] = mapped_column(PG_UUID(as_uuid=True), nullable=False)
+    chat_id: Mapped[str] = mapped_column(Text, nullable=False)
+    window_started_at: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=True), nullable=False)
+    window_closes_at: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=True), nullable=False)
+    expires_at: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=True), nullable=False)
+    approval_nonce: Mapped[str] = mapped_column(Text, nullable=False)
+    approval_nonce_used_at: Mapped[datetime | None] = mapped_column(TIMESTAMP(timezone=True))
+    approved_by_telegram_user_id: Mapped[str | None] = mapped_column(Text)
+    approved_at: Mapped[datetime | None] = mapped_column(TIMESTAMP(timezone=True))
+    summary_message_id: Mapped[int | None] = mapped_column(BigInteger)
+    summary_dispatch_state: Mapped[str] = mapped_column(Text, nullable=False, server_default="idle")
+    summary_dispatch_lease_until: Mapped[datetime | None] = mapped_column(TIMESTAMP(timezone=True))
+    created_at: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=True), nullable=False, server_default=func.now())
+    updated_at: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=True), nullable=False, server_default=func.now(), onupdate=func.now())
+
+
+class OrderProposalApprovalBatchMember(Base):
+    __tablename__ = "order_proposal_approval_batch_members"
+    __table_args__ = (
+        UniqueConstraint("batch_pk", "proposal_pk", name="uq_order_proposal_batch_member"),
+        UniqueConstraint(
+            "proposal_pk", "approval_nonce_snapshot",
+            name="uq_order_proposal_batch_member_nonce",
+        ),
+        Index("ix_order_proposal_batch_members_batch_pk", "batch_pk"),
+        {"schema": "review"},
+    )
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    batch_pk: Mapped[int] = mapped_column(
+        BigInteger,
+        ForeignKey("review.order_proposal_approval_batches.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    proposal_pk: Mapped[int] = mapped_column(
+        BigInteger,
+        ForeignKey("review.order_proposals.id", ondelete="RESTRICT"),
+        nullable=False,
+    )
+    approval_nonce_snapshot: Mapped[str] = mapped_column(Text, nullable=False)
+    approval_message_id: Mapped[int] = mapped_column(BigInteger, nullable=False)
+    result: Mapped[str | None] = mapped_column(Text)
+    result_detail: Mapped[dict | None] = mapped_column(JSONB)
+    processed_at: Mapped[datetime | None] = mapped_column(TIMESTAMP(timezone=True))
+    added_at: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=True), nullable=False)
+```
+
+Export both from `app/models/__init__.py`.
+
+- [ ] **Step 4: Add the Alembic migration and bootstrap version bump**
+
+Create revision `20260714_rob870_approval_batches` with
+`down_revision = "20260713_rob848_paper_validation"`. Mirror the ORM types,
+foreign keys, check, unique constraints, and indexes exactly. Downgrade in
+reverse dependency order:
+
+```python
+def downgrade() -> None:
+    op.drop_index(
+        "ix_order_proposal_batch_members_batch_pk",
+        table_name="order_proposal_approval_batch_members",
+        schema="review",
+    )
+    op.drop_table("order_proposal_approval_batch_members", schema="review")
+    op.drop_index(
+        "ix_order_proposal_approval_batches_chat_window",
+        table_name="order_proposal_approval_batches",
+        schema="review",
+    )
+    op.drop_table("order_proposal_approval_batches", schema="review")
+```
+
+Increment `SCHEMA_BOOTSTRAP_VERSION` from `14` to `15` and document ROB-870 in
+the adjacent version comments so persistent test databases rerun
+`Base.metadata.create_all`.
+
+- [ ] **Step 5: Run model and migration graph checks**
+
+Run: `uv run pytest tests/services/order_proposals/test_models_smoke.py -q`
+
+Expected: all tests pass.
+
+Run: `uv run alembic heads`
+
+Expected: exactly `20260714_rob870_approval_batches (head)`.
+
+- [ ] **Step 6: Commit the persistence slice**
+
+```bash
+git add alembic/versions/20260714_rob870_approval_batches.py app/models/order_proposals.py app/models/__init__.py tests/_schema_bootstrap.py tests/services/order_proposals/test_models_smoke.py
+git commit -m "feat(ROB-870): persist approval batches"
+```
+
+---
+
+### Task 2: Define Batch Callback and Message Contracts
+
+**Files:**
+- Modify: `app/services/order_proposals/approval_message.py`
+- Test: `tests/services/order_proposals/test_approval_message.py`
+
+**Interfaces:**
+- Produces: `build_batch_callback_data(*, batch_id: UUID, nonce: str) -> str`.
+- Extends: `parse_callback_data(data: str) -> tuple[str, str, str]` with action `ba`.
+- Produces: `build_batch_approval_message(*, batch, proposals) -> tuple[str, dict]`.
+- Produces: `build_batch_result_message(*, proposals, results) -> str`.
+
+- [ ] **Step 1: Write failing pure tests**
+
+Add tests that use `SimpleNamespace` groups/rungs and assert:
+
+```python
+def test_batch_callback_round_trip_and_telegram_limit():
+    batch_id = uuid.UUID("aaaaaaaa-1111-4111-8111-111111111111")
+    data = build_batch_callback_data(batch_id=batch_id, nonce="batch_nonce-1")
+    assert parse_callback_data(data) == ("ba", "aaaaaaaa", "batch_nonce-1")
+    assert len(data.encode()) <= 64
+
+
+def test_batch_summary_lists_notional_and_account_subtotals():
+    text, keyboard = build_batch_approval_message(
+        batch=SimpleNamespace(
+            batch_id=uuid.UUID("aaaaaaaa-1111-4111-8111-111111111111"),
+            approval_nonce="batch-nonce",
+            expires_at=datetime(2026, 7, 14, 1, 30, tzinfo=UTC),
+        ),
+        proposals=[
+            (_group("AAPL", "buy", "kis_live"), [_rung("1", "100")]),
+            (_group("MSFT", "sell", "toss_live"), [_rung("2", "50")]),
+        ],
+    )
+    assert "AAPL" in text and "MSFT" in text
+    assert "kis_live" in text and "toss_live" in text
+    assert "$200" in text
+    assert keyboard["inline_keyboard"][0][0]["text"] == "전체 승인"
+```
+
+Add a result-render test with one approved, one `needs_reconfirm`, one stale,
+and one error entry; assert all four categories appear and the keyboard is not
+present in the result renderer.
+
+- [ ] **Step 2: Run the pure tests and verify RED**
+
+Run: `uv run pytest tests/services/order_proposals/test_approval_message.py -q -k batch`
+
+Expected: collection fails because the batch builders do not exist.
+
+- [ ] **Step 3: Implement the callback parser extension**
+
+Change `_ALLOWED_ACTIONS` and `_CALLBACK_PATTERN` to include `ba`, retain all
+existing actions, and add a semantic wrapper:
+
+```python
+def build_batch_callback_data(*, batch_id: uuid.UUID, nonce: str) -> str:
+    return build_callback_data(action="ba", proposal_id=batch_id, nonce=nonce)
+```
+
+Update `build_callback_data`'s validation message to list `ba` without changing
+the existing compact `action:8-char-prefix:nonce` format.
+
+- [ ] **Step 4: Implement pending and terminal renderers**
+
+Use existing `_escape_markdown`, `_escape_inline_code`, `_format_decimal`, and
+`_format_money`. Calculate notional as explicit rung `notional` when present,
+otherwise `quantity * limit_price`; omit market orders from numeric totals.
+Group subtotals by a redacted label consisting of `account_mode` plus the final
+four characters of `broker_account_id` when present.
+
+The pending renderer must produce:
+
+```python
+lines = ["*일괄 승인 대기*", f"- 제안: {len(proposals)}건", "", "*주문 목록*"]
+# one escaped line per proposal and rung
+# append total and account subtotal blocks
+# append KST expiry line
+keyboard = {"inline_keyboard": [[{
+    "text": "전체 승인",
+    "callback_data": build_batch_callback_data(
+        batch_id=batch.batch_id,
+        nonce=batch.approval_nonce,
+    ),
+}]]}
+```
+
+The terminal renderer groups result dictionaries by `approved`,
+`needs_reconfirm`, `skipped`, and `failed`, includes symbol and rung result
+labels, and returns text only so callers clear the button with an empty keyboard.
+
+- [ ] **Step 5: Run message tests and full parser regressions**
+
+Run: `uv run pytest tests/services/order_proposals/test_approval_message.py -q`
+
+Expected: all tests pass, including existing `op`, `dn`, `lc`, and `vc` cases.
+
+- [ ] **Step 6: Commit the pure contract slice**
+
+```bash
+git add app/services/order_proposals/approval_message.py tests/services/order_proposals/test_approval_message.py
+git commit -m "feat(ROB-870): render batch approval messages"
+```
+
+---
+
+### Task 3: Implement the Batch Lifecycle Service
+
+**Files:**
+- Modify: `app/services/order_proposals/repository.py`
+- Modify: `app/services/order_proposals/service.py`
+- Test: `tests/services/order_proposals/test_service.py`
+
+**Interfaces:**
+- Produces: `BatchRegistration` and `BatchMemberSnapshot` frozen dataclasses.
+- Produces: `register_approval_batch_member(proposal_id: UUID, *, chat_id: str, approval_message_id: int, now: datetime, window_seconds: int = 600, ttl_seconds: int = 600) -> BatchRegistration | None`.
+- Produces: `consume_approval_batch_nonce(batch_id: UUID, nonce: str, *, chat_id: str, telegram_user_id: str, now: datetime) -> tuple[OrderProposalApprovalBatch, list[BatchMemberSnapshot]]`.
+- Produces: `record_approval_batch_summary(batch_id: UUID, *, message_id: int, now: datetime) -> OrderProposalApprovalBatch`.
+- Produces: `release_approval_batch_summary_claim(batch_id: UUID, *, now: datetime) -> OrderProposalApprovalBatch`.
+- Produces: `record_approval_batch_member_result(member_id: int, *, result: str, detail: dict[str, Any], now: datetime) -> OrderProposalApprovalBatchMember`.
+- Produces: `get_approval_batch_display(batch_id: UUID) -> tuple[OrderProposalApprovalBatch, list[tuple[OrderProposal, list[OrderProposalRung]]]]`.
+- Produces: `batch_member_block_reason(group, rungs, *, now) -> str | None`.
+
+- [ ] **Step 1: Write failing service tests for registration and exclusions**
+
+Cover these exact cases:
+
+```python
+registration = await service.register_approval_batch_member(
+    group.proposal_id,
+    chat_id="42",
+    approval_message_id=1001,
+    now=now,
+)
+assert registration is not None
+assert registration.member_count == 1
+assert registration.summary_action == "none"
+
+second = await service.register_approval_batch_member(
+    second_group.proposal_id,
+    chat_id="42",
+    approval_message_id=1002,
+    now=now + timedelta(minutes=1),
+)
+assert second.batch.batch_id == registration.batch.batch_id
+assert second.member_count == 2
+assert second.summary_action == "send"
+```
+
+Add separate assertions that loss-cut, superseded, terminal, auto-approved,
+used-nonce, no-pending-rung, expired-valid-until, and a different chat/window
+do not join the first batch. Verify a proposal with a fresh replacement nonce
+can join a later batch but the same nonce snapshot cannot be duplicated.
+
+- [ ] **Step 2: Run registration tests and verify RED**
+
+Run: `uv run pytest tests/services/order_proposals/test_service.py -q -k approval_batch`
+
+Expected: failures because lifecycle interfaces are absent.
+
+- [ ] **Step 3: Add repository primitives**
+
+Import the new models only in `repository.py`. Add methods with these exact
+responsibilities:
+
+```python
+async def acquire_approval_batch_chat_lock(self, chat_id: str) -> None:
+    await self._session.execute(
+        select(func.pg_advisory_xact_lock(
+            func.hashtextextended(f"order_proposals:approval_batch:{chat_id}", 0)
+        ))
+    )
+
+async def get_open_approval_batch(
+    self, *, chat_id: str, now: datetime, for_update: bool = False
+) -> OrderProposalApprovalBatch | None:
+    stmt = (
+        select(OrderProposalApprovalBatch)
+        .where(
+            OrderProposalApprovalBatch.chat_id == chat_id,
+            OrderProposalApprovalBatch.approval_nonce_used_at.is_(None),
+            OrderProposalApprovalBatch.window_closes_at > now,
+        )
+        .order_by(OrderProposalApprovalBatch.id.desc())
+        .limit(1)
+    )
+    if for_update:
+        stmt = stmt.with_for_update()
+    return (await self._session.execute(stmt)).scalar_one_or_none()
+
+async def insert_approval_batch(self, **cols: Any) -> OrderProposalApprovalBatch:
+    row = OrderProposalApprovalBatch(**cols)
+    self._session.add(row)
+    await self._session.flush()
+    await self._session.refresh(row)
+    return row
+
+async def insert_approval_batch_member(
+    self, **cols: Any
+) -> OrderProposalApprovalBatchMember:
+    row = OrderProposalApprovalBatchMember(**cols)
+    self._session.add(row)
+    await self._session.flush()
+    await self._session.refresh(row)
+    return row
+
+async def list_approval_batch_members(
+    self, batch_pk: int
+) -> list[OrderProposalApprovalBatchMember]:
+    stmt = (
+        select(OrderProposalApprovalBatchMember)
+        .where(OrderProposalApprovalBatchMember.batch_pk == batch_pk)
+        .order_by(
+            OrderProposalApprovalBatchMember.added_at,
+            OrderProposalApprovalBatchMember.id,
+        )
+    )
+    return list((await self._session.execute(stmt)).scalars().all())
+
+async def get_approval_batch_by_id(
+    self, batch_id: uuid.UUID, *, for_update: bool = False
+) -> OrderProposalApprovalBatch | None:
+    stmt = select(OrderProposalApprovalBatch).where(
+        OrderProposalApprovalBatch.batch_id == batch_id
+    )
+    if for_update:
+        stmt = stmt.with_for_update()
+    return (await self._session.execute(stmt)).scalar_one_or_none()
+
+async def resolve_approval_batch_id_prefix(
+    self, batch_short: str
+) -> uuid.UUID | None:
+    stmt = (
+        select(OrderProposalApprovalBatch.batch_id)
+        .where(cast(OrderProposalApprovalBatch.batch_id, Text).like(f"{batch_short}%"))
+        .limit(2)
+    )
+    matches = list((await self._session.execute(stmt)).scalars().all())
+    return matches[0] if len(matches) == 1 else None
+
+async def update_approval_batch(
+    self, batch: OrderProposalApprovalBatch, **fields: Any
+) -> OrderProposalApprovalBatch:
+    for key, value in fields.items():
+        setattr(batch, key, value)
+    await self._session.flush()
+    return batch
+
+async def update_approval_batch_member(
+    self, member: OrderProposalApprovalBatchMember, **fields: Any
+) -> OrderProposalApprovalBatchMember:
+    for key, value in fields.items():
+        setattr(member, key, value)
+    await self._session.flush()
+    return member
+```
+
+`get_open_approval_batch` filters matching chat, unused nonce,
+`window_closes_at > now`, and orders newest first. Prefix resolution casts UUID
+to text and fails closed unless exactly one row matches.
+
+- [ ] **Step 4: Implement service dataclasses and eligibility**
+
+Add:
+
+```python
+@dataclass(frozen=True)
+class BatchMemberSnapshot:
+    member_id: int
+    proposal_id: uuid.UUID
+    approval_nonce: str
+    approval_message_id: int
+
+
+@dataclass(frozen=True)
+class BatchRegistration:
+    batch: OrderProposalApprovalBatch
+    member_count: int
+    summary_action: Literal["none", "send", "edit"]
+```
+
+`batch_member_block_reason` returns stable strings in this order:
+`proposal_approval_block_reason`, `loss_cut_excluded`, `auto_approved_excluded`,
+`proposal_expired`, `approval_nonce_missing`, `approval_nonce_used`, and
+`no_pending_approval_rungs`.
+
+Registration acquires the chat advisory lock, rechecks eligibility under the
+proposal row lock, creates or joins a batch, snapshots the current proposal
+nonce/message, recalculates `expires_at`, and returns `send` at member two,
+`edit` for later members when a summary ID exists, otherwise `none`.
+
+When a send is needed, registration atomically changes
+`summary_dispatch_state` from `idle` to `sending` and sets a 30-second lease.
+While that lease is live, concurrent registrants return `none`. An expired
+`sending` lease can be reclaimed. `record_approval_batch_summary` writes the
+message ID, changes state to `sent`, and clears the lease;
+`release_approval_batch_summary_claim` changes a failed claim back to `idle`
+and clears its lease. Existing summaries return `edit` while the batch window
+is open.
+
+- [ ] **Step 5: Write and run failing nonce/TTL tests**
+
+Test consumption with the exact batch nonce, matching chat, and two members.
+Then test replay, wrong nonce, wrong chat, expiry, ambiguous prefix, and fewer
+than two members. Expected error reasons:
+
+```text
+approval_batch_nonce_mismatch
+approval_batch_nonce_replay
+approval_batch_chat_mismatch
+approval_batch_expired
+approval_batch_not_found
+approval_batch_too_small
+```
+
+Run: `uv run pytest tests/services/order_proposals/test_service.py -q -k 'approval_batch and (nonce or expiry or prefix)'`
+
+Expected: RED until consumption is implemented.
+
+- [ ] **Step 6: Implement consumption, display, and result audit**
+
+`consume_approval_batch_nonce` locks the batch, validates chat/nonce/replay/TTL,
+loads at least two ordered members, writes approver/used timestamps, and returns
+immutable `BatchMemberSnapshot` values. `record_approval_batch_member_result`
+stores only JSON-safe bounded detail; it never mutates proposal/rung truth.
+`record_approval_batch_summary` records message ID and resets delivery lease.
+`release_approval_batch_summary_claim` makes a failed send retryable without
+deleting membership.
+`get_approval_batch_display` returns the batch plus ordered `(group, rungs)`
+pairs for pure rendering.
+
+- [ ] **Step 7: Run service tests**
+
+Run: `uv run pytest tests/services/order_proposals/test_service.py -q`
+
+Expected: all tests pass.
+
+- [ ] **Step 8: Commit the lifecycle slice**
+
+```bash
+git add app/services/order_proposals/repository.py app/services/order_proposals/service.py tests/services/order_proposals/test_service.py
+git commit -m "feat(ROB-870): manage approval batch lifecycle"
+```
+
+---
+
+### Task 4: Add Batch Summary Dispatch
+
+**Files:**
+- Modify: `app/services/order_proposals/dispatch.py`
+- Test: `tests/services/order_proposals/test_dispatch.py`
+
+**Interfaces:**
+- Consumes: `register_approval_batch_member`, `get_approval_batch_display`, `record_approval_batch_summary`.
+- Consumes: `build_batch_approval_message`.
+- Preserves: `send_proposal_for_approval(proposal_id: UUID, *, notifier: Any, now: datetime, service_factory: ServiceFactory = AsyncSessionLocal) -> int | None` return value as the individual message ID.
+
+- [ ] **Step 1: Extend the notifier fake and write failing dispatch tests**
+
+Add `edited_messages` and `edit_message` to `_FakeNotifier`, and make message IDs
+increment per send so individual and summary IDs differ.
+
+Test sequential dispatch:
+
+```python
+first_id = await send_proposal_for_approval(
+    first.proposal_id,
+    notifier=notifier,
+    now=now,
+    service_factory=_session_factory(db_session),
+)
+assert len(notifier.sent_messages) == 1  # individual only
+
+second_id = await send_proposal_for_approval(
+    second.proposal_id,
+    notifier=notifier,
+    now=now + timedelta(minutes=1),
+    service_factory=_session_factory(db_session),
+)
+assert second_id != first_id
+assert len(notifier.sent_messages) == 3  # second individual + batch summary
+assert "전체 승인" in str(notifier.sent_messages[-1][1])
+
+await send_proposal_for_approval(
+    third.proposal_id,
+    notifier=notifier,
+    now=now + timedelta(minutes=2),
+    service_factory=_session_factory(db_session),
+)
+assert notifier.edited_messages
+assert "3건" in notifier.edited_messages[-1][2]
+```
+
+Add tests for different chat/window, loss-cut, superseded/terminal,
+auto-approved, individual-send failure, and auto gate-off. Assert every
+individual message/button remains present and unchanged.
+
+- [ ] **Step 2: Run dispatch batch tests and verify RED**
+
+Run: `uv run pytest tests/services/order_proposals/test_dispatch.py -q -k batch`
+
+Expected: no batch summary is sent or edited.
+
+- [ ] **Step 3: Implement post-send registration and summary delivery**
+
+After a successful individual send and `record_approval_dispatch`, call a new
+private helper in the same transaction:
+
+```python
+async def _register_and_publish_batch_summary(
+    *, service, proposal_id, message_id, chat_id, now, notifier
+) -> None:
+    registration = await service.register_approval_batch_member(
+        proposal_id,
+        chat_id=str(chat_id),
+        approval_message_id=message_id,
+        now=now,
+    )
+    if registration is None or registration.summary_action == "none":
+        return
+    batch, proposals = await service.get_approval_batch_display(
+        registration.batch.batch_id
+    )
+    text, keyboard = build_batch_approval_message(batch=batch, proposals=proposals)
+    if registration.summary_action == "send":
+        summary_id = await notifier.send_approval_message(
+            text, keyboard, chat_id=str(chat_id)
+        )
+        if summary_id is not None:
+            await service.record_approval_batch_summary(
+                batch.batch_id, message_id=summary_id, now=now
+            )
+    elif batch.summary_message_id is not None:
+        await notifier.edit_message(
+            chat_id, batch.summary_message_id, text, reply_markup=keyboard
+        )
+```
+
+Catch Telegram exceptions, log them, clear a failed summary delivery claim,
+and still commit the individual dispatch plus membership. Do not change the
+function's individual message-ID return contract.
+
+- [ ] **Step 4: Run dispatch tests and ROB-871 regression tests**
+
+Run: `uv run pytest tests/services/order_proposals/test_dispatch.py -q`
+
+Expected: all tests pass; auto-submitted proposals still send only their veto
+notification and never join manual batches.
+
+- [ ] **Step 5: Commit the dispatch slice**
+
+```bash
+git add app/services/order_proposals/dispatch.py tests/services/order_proposals/test_dispatch.py
+git commit -m "feat(ROB-870): publish approval batch summaries"
+```
+
+---
+
+### Task 5: Execute Batch Clicks with Isolated Member Transactions
+
+**Files:**
+- Modify: `app/services/order_proposals/telegram_callback.py`
+- Test: `tests/services/order_proposals/test_telegram_callback.py`
+
+**Interfaces:**
+- Consumes: `parse_callback_data` action `ba`.
+- Consumes: `consume_approval_batch_nonce`, member snapshots, and result audit.
+- Reuses: `_handle_approve` without bypassing proposal nonce/audit/revalidation.
+- Produces: `_handle_batch_approve(*, batch_short: str, nonce: str, now: datetime, service_factory: ServiceFactory, notifier: Any, chat_id: Any, message_id: int | None, telegram_user_id: str, revalidate_fn: RevalidateFn) -> dict[str, Any]`.
+
+- [ ] **Step 1: Write failing replay/TTL and regression tests**
+
+Seed a two-member batch through the service and call `handle_callback_update`
+with its `ba` callback. Assert both proposal nonces become used and each
+proposal gets `approved_at`/`approved_by_telegram_user_id`. Call the same update
+again and assert `approval_batch_nonce_replay` with no extra revalidation.
+
+Seed an expired batch and assert no proposal nonce is consumed. Re-run one
+existing individual `op` test unchanged to guard callback regression.
+
+- [ ] **Step 2: Run targeted callback tests and verify RED**
+
+Run: `uv run pytest tests/services/order_proposals/test_telegram_callback.py -q -k 'batch or valid_approve'`
+
+Expected: `ba` resolves as a proposal callback or returns not found; batch
+members are not processed.
+
+- [ ] **Step 3: Add the top-level batch branch and nonce consumption**
+
+Branch immediately after callback parsing, before proposal prefix resolution:
+
+```python
+if action == "ba":
+    return await _handle_batch_approve(
+        batch_short=subject_short,
+        nonce=nonce,
+        now=now,
+        service_factory=service_factory,
+        notifier=active_notifier,
+        chat_id=chat_id,
+        message_id=message_id,
+        telegram_user_id=str(telegram_user_id or ""),
+        revalidate_fn=revalidate_fn,
+    )
+```
+
+`_handle_batch_approve` resolves and consumes the batch in an initial session,
+commits the trigger audit before any broker work, then closes that transaction.
+
+- [ ] **Step 4: Write failing partial-failure and stale-member tests**
+
+Use three members and an injected `revalidate_fn` that returns an error for the
+middle proposal but success for the first and third. Assert call order includes
+all three, member results are persisted, and all three individual message IDs
+are edited.
+
+Add click-time cases where one member is superseded, terminal, loss-cut, or
+already individually approved after batch creation. Assert only that member is
+`skipped`, later members continue, and the individual nonce audit is not forged.
+
+- [ ] **Step 5: Implement the isolated member loop**
+
+For each `BatchMemberSnapshot`, open a new `service_factory` context. Re-read
+the group/rungs and skip `loss_cut` or `auto_approved` before `_handle_approve`.
+Otherwise call:
+
+```python
+result = await _handle_approve(
+    session=member_session,
+    service=member_service,
+    proposal_id=member.proposal_id,
+    nonce=member.approval_nonce,
+    now=now,
+    notifier=notifier,
+    chat_id=chat_id,
+    message_id=member.approval_message_id,
+    callback_query_id=None,
+    telegram_user_id=telegram_user_id,
+    revalidate_fn=revalidate_fn,
+)
+```
+
+Map handled approved results to `approved`, existing `needs_reconfirm` to
+`needs_reconfirm`, nonce/lifecycle/eligibility misses to `skipped`, and
+unexpected exceptions to `failed`. Roll back a failed member session before
+recording its bounded failure detail, then continue.
+
+After every member, persist its batch-observation result and commit. Finally
+load display rows, render `build_batch_result_message`, and best-effort edit the
+batch summary with `reply_markup={"inline_keyboard": []}`.
+
+- [ ] **Step 6: Add the mixed ROB-861 test**
+
+Inject outcomes so one proposal yields `needs_reconfirm` with
+`reason="insufficient_buying_power"` while another yields
+`submitted_resting`. Assert:
+
+- the shortfall proposal has a fresh unused proposal nonce;
+- its original message and new reconfirm message follow existing behavior;
+- the other proposal completes;
+- the batch summary contains both `재확인 필요` and `승인 완료` categories.
+
+- [ ] **Step 7: Run the callback file**
+
+Run: `uv run pytest tests/services/order_proposals/test_telegram_callback.py -q`
+
+Expected: all batch and existing individual/loss-cut/veto tests pass.
+
+- [ ] **Step 8: Commit the callback slice**
+
+```bash
+git add app/services/order_proposals/telegram_callback.py tests/services/order_proposals/test_telegram_callback.py
+git commit -m "feat(ROB-870): execute batch approvals safely"
+```
+
+---
+
+### Task 6: Document the Operator Contract and Verify the Whole Feature
+
+**Files:**
+- Modify: `docs/runbooks/order-proposals.md`
+
+**Interfaces:**
+- Documents: grouping, TTL, exclusions, partial failure, ROB-861 interaction,
+  gate-off behavior, and unchanged individual path.
+- Verifies: the complete order-proposal service surface and repository quality gates.
+
+- [ ] **Step 1: Add the runbook section**
+
+Document these exact facts near the existing Telegram callback section:
+
+```markdown
+### Manual approval batches (ROB-870)
+
+- A successfully sent manual proposal joins the open batch for the same chat
+  for up to 10 minutes from the first member.
+- The summary appears at member two; individual messages and buttons remain.
+- The batch trigger expires 10 minutes after the latest member, bounded by the
+  earliest proposal validity deadline, and is single-use.
+- Loss cuts, superseded/terminal proposals, and already auto-approved proposals
+  are excluded. Gate-off manual fallback proposals may batch.
+- Clicking the batch consumes each member's original nonce and runs the normal
+  revalidation/submission transaction independently. Partial failure does not
+  stop later members.
+- ROB-861 buying-power misses stay `needs_reconfirm` only for affected rungs.
+```
+
+Also include the 2026-07-13 DB basis: valid 16 groups/17 rungs, manual 13/14,
+cap 9/9, distance 3/3, actions 0/0, other multi-rung 1/2; explicitly state that
+the structural value is not based on the temporary $150 canary cap.
+
+- [ ] **Step 2: Run focused batch tests**
+
+Run: `uv run pytest tests/services/order_proposals/test_models_smoke.py tests/services/order_proposals/test_approval_message.py tests/services/order_proposals/test_service.py tests/services/order_proposals/test_dispatch.py tests/services/order_proposals/test_telegram_callback.py -q -k 'batch or individual or approve or loss_cut or buying_power or auto'`
+
+Expected: all selected tests pass.
+
+- [ ] **Step 3: Run the complete order-proposal suite**
+
+Run: `uv run pytest tests/services/order_proposals/ -q`
+
+Expected: all tests pass with zero failures.
+
+- [ ] **Step 4: Run formatting, lint, and type checks**
+
+Run: `make lint`
+
+Expected: Ruff formatting/check and ty complete successfully.
+
+- [ ] **Step 5: Inspect the final diff and migration graph**
+
+Run: `git diff --check && uv run alembic heads && git status --short`
+
+Expected: no whitespace errors, exactly one ROB-870 Alembic head, and only
+intended ROB-870 files modified.
+
+- [ ] **Step 6: Commit documentation/final mechanical fixes**
+
+```bash
+git add docs/runbooks/order-proposals.md
+git add -u
+git commit -m "docs(ROB-870): document batch approval operations"
+```
+
+---
+
+### Task 7: Pre-PR Evidence and Shipping
+
+**Files:**
+- No product-code changes unless verification exposes a defect.
+- PR body assembled from `docs/superpowers/specs/2026-07-14-rob-870-telegram-batch-approval-design.md` and fresh command output.
+
+**Interfaces:**
+- Produces: pushed `rob-870` branch and PR against `main`.
+- Produces: PR evidence table separating cap from structural manual remainder.
+
+- [ ] **Step 1: Run fresh completion verification**
+
+Run:
+
+```bash
+uv run pytest tests/services/order_proposals/ -q
+make lint
+git diff "$(git merge-base origin/main HEAD)" HEAD --check
+```
+
+Expected: every command exits 0 with fresh output from this step.
+
+- [ ] **Step 2: Review the final diff for safety invariants**
+
+Confirm from the diff:
+
+- no loss-cut batch entry path;
+- batch nonce and proposal nonce are both consumed in their own scopes;
+- member transactions commit independently;
+- existing individual callback branches remain covered;
+- no websocket or broker-gateway edits;
+- no credentials, raw account IDs, or payload hashes are rendered.
+
+- [ ] **Step 3: Prepare the PR body evidence table**
+
+Include:
+
+| Manual reason | Groups | Rungs | Structural? |
+|---|---:|---:|---|
+| Per-order cap above $150 | 9 | 9 | No — canary seed may rise |
+| Distance below 3% | 3 | 3 | Yes |
+| Replace/cancel action | 0 | 0 | Yes, absent in sampled session |
+| Other: multi-rung fallback | 1 | 2 | Yes |
+| **Total** | **13** | **14** | **Structural floor: 4 groups/5 rungs** |
+
+State that raw DB count was 19/20, ROB-869 excluded 3/3, and the canonical
+valid denominator is 16/17. Mention that gate-off/rollback periods route all
+valid proposals through the manual batch-capable path.
+
+- [ ] **Step 4: Ship with the repository ship workflow**
+
+Use the `ship` skill to update the branch from `origin/main`, rerun required
+checks, review the diff, push `rob-870`, and create a PR with base `main` and a
+title beginning `feat(ROB-870):`.
+
+- [ ] **Step 5: Report completion**
+
+Report the proceed decision, canonical DB breakdown, test/lint results, commit
+range, and PR number/link. If shipping is blocked by external authentication,
+report the exact completed local state and command that failed.

--- a/docs/superpowers/specs/2026-07-14-rob-870-telegram-batch-approval-design.md
+++ b/docs/superpowers/specs/2026-07-14-rob-870-telegram-batch-approval-design.md
@@ -1,0 +1,268 @@
+# ROB-870 Telegram Batch Approval Design
+
+## Decision
+
+Proceed with a durable, additive Telegram batch-approval surface for manual
+order proposals. The feature does not replace ROB-871 auto-approval or the
+existing individual approval buttons. It reduces repeated clicks for proposals
+that still require a human decision.
+
+The batch owns only grouping metadata and its single-use trigger nonce. Every
+member proposal keeps and consumes its existing approval nonce, records its
+existing approval audit, and runs the existing `revalidate_and_submit` path.
+
+## Scope Revalidation
+
+The 2026-07-13 US-session production database is canonical:
+
+| Population | Groups | Rungs |
+|---|---:|---:|
+| Raw proposals in the session window | 19 | 20 |
+| ROB-869 superseded proposals excluded | 3 | 3 |
+| Valid population | 16 | 17 |
+| Counterfactual ROB-871 auto candidates | 3 | 3 |
+| Manual remainder | 13 | 14 |
+
+The manual remainder has this exclusive primary-reason breakdown:
+
+| Primary reason | Groups | Rungs | Long-term interpretation |
+|---|---:|---:|---|
+| US per-order cap above $150 | 9 | 9 | Canary seed; this share can shrink when the cap rises |
+| Distance below 3% | 3 | 3 | Structural immediate-execution-class manual work |
+| Replace/cancel action | 0 | 0 | Structural policy exclusion, absent from this session |
+| Multi-rung all-or-human fallback | 1 | 2 | Structural until atomic ladder auto-submit exists |
+| **Total** | **13** | **14** | |
+
+Even if the canary cap is raised enough to remove every cap-only case, this
+session leaves four groups and five rungs of structural manual work. During an
+intentional ROB-871 gate-off or rollback period, all valid proposals use the
+manual path. The feature's product justification is therefore the structural
+manual path and operational fallback, not the temporary $150 cap.
+
+The Linear ROB-870 description is updated with these corrected counts and the
+same breakdown.
+
+## Alternatives Considered
+
+### 1. Durable batch and membership tables — selected
+
+Persist batch lifecycle, nonce, TTL, summary message identity, and immutable
+membership in relational rows. Row locks and unique constraints make concurrent
+dispatch and replay behavior explicit and testable.
+
+Cost: one additive migration plus repository/service code.
+
+### 2. Anchor proposal `source_asof` envelope
+
+Store the batch on the first proposal and append member UUIDs to JSONB. This
+avoids a migration, but makes concurrency, membership constraints, querying,
+and operator audit depend on a mutable metadata blob.
+
+Rejected because the batch is a security-sensitive approval capability, not
+incidental display metadata.
+
+### 3. Stateless click-time time-window query
+
+Encode a time window in the callback and discover members when clicked.
+
+Rejected because the set displayed to the operator could differ from the set
+approved after late arrivals or state changes. A batch approval must have a
+durable displayed membership envelope.
+
+## Persistence Model
+
+Add two tables under the `review` schema.
+
+### `order_proposal_approval_batches`
+
+- `id`: bigint primary key.
+- `batch_id`: UUID, unique public identity used by callback prefix resolution.
+- `chat_id`: destination Telegram chat as text.
+- `window_started_at`: first eligible member dispatch time.
+- `window_closes_at`: fixed collection boundary, ten minutes after the first
+  member. New members never extend this boundary.
+- `expires_at`: click deadline, extended to ten minutes after the latest member
+  but bounded by the earliest non-null member `valid_until`.
+- `approval_nonce`: URL-safe token dedicated to the batch trigger.
+- `approval_nonce_used_at`: null until atomically consumed.
+- `approved_by_telegram_user_id`, `approved_at`: batch trigger audit.
+- `summary_message_id`: Telegram summary message identity, nullable until the
+  second member makes a summary useful and delivery succeeds.
+- `summary_dispatch_state`, `summary_dispatch_lease_until`: a short delivery
+  claim preventing concurrent member dispatches from sending duplicate summary
+  messages. A failed or expired claim is retryable by a later member.
+- `created_at`, `updated_at`.
+
+An open-batch lookup is serialized by a transaction-scoped advisory lock over
+`chat_id`. A new eligible proposal joins the newest batch whose collection
+window is still open and whose batch nonce is unused. Otherwise dispatch creates
+a new batch.
+
+### `order_proposal_approval_batch_members`
+
+- `id`: bigint primary key.
+- `batch_pk`: foreign key to the batch with cascade delete.
+- `proposal_pk`: foreign key to `review.order_proposals` with restrict delete.
+- `approval_nonce_snapshot`: the proposal approval nonce displayed by its
+  individual message and later consumed by batch execution.
+- `approval_message_id`: the individual Telegram message to edit with results.
+- `result`, `result_detail`, `processed_at`: batch-observation metadata written
+  after each independent proposal transaction. Proposal/rung state remains the
+  trading source of truth.
+- `added_at`.
+- Unique constraints on `(batch_pk, proposal_pk)` and
+  `(proposal_pk, approval_nonce_snapshot)`. A proposal with a newly issued
+  reconfirmation nonce may join a later batch, but the same displayed approval
+  capability cannot be registered twice.
+
+The membership snapshot binds the batch to exactly the same individual approval
+capabilities shown to the operator. Re-dispatch with a fresh individual nonce
+cannot silently inherit an old batch membership.
+
+## Eligibility and Grouping
+
+`send_proposal_for_approval` remains responsible for sending the individual
+message and minting its proposal nonce. After a successful individual send, it
+offers the proposal to the batch coordinator.
+
+A proposal may be registered only when all conditions hold:
+
+- destination `chat_id` matches the batch;
+- at least one rung is `pending_approval`;
+- `proposal_approval_block_reason` returns no superseded or terminal reason;
+- `exit_intent != "loss_cut"`;
+- `source_asof.auto_approved` is absent;
+- its individual approval nonce is present and unused.
+
+These checks run again at click time. Registration-time checks prevent bad
+summaries; click-time checks fail closed against later supersede, terminal, or
+individual-button activity.
+
+ROB-871-eligible proposals do not reach manual dispatch while its master gate is
+enabled. When the gate is intentionally off, manual proposals may batch because
+that is the operational fallback this feature is meant to support. A proposal
+already carrying `source_asof.auto_approved` is never batch eligible.
+
+The collection window is ten minutes from the first eligible member. The batch
+summary is sent when the second member joins and edited for later additions.
+Single-member batches remain internal and expose no redundant batch button.
+
+## Telegram Surface
+
+`approval_message.py` gains pure builders/parsers for batch callbacks and
+summaries. Batch callback data uses a distinct `ba` action, a short batch UUID
+prefix, and the batch nonce while staying below Telegram's 64-byte limit.
+
+The pending summary contains:
+
+- symbol, side, rung prices, and notional for every member;
+- total notional;
+- subtotals by `account_mode` and broker account identity when available;
+- expiry time;
+- one `전체 승인` button.
+
+Account identifiers follow existing redaction rules; the summary must not expose
+credentials, raw payload hashes, or unrestricted broker identifiers.
+
+Individual messages and their approve/deny buttons are unchanged.
+
+## Callback and Transaction Flow
+
+`telegram_callback.py` adds a batch branch without changing the existing `op`,
+`dn`, `lc`, or `vc` paths.
+
+1. Authenticate chat and parse `ba` callback data.
+2. Resolve the full batch UUID from its short prefix, failing closed on zero or
+   multiple matches.
+3. Lock and consume the batch nonce in one transaction. Validate TTL, chat,
+   replay status, and minimum two-member membership. Record batch approver and
+   approval time, snapshot ordered members, then commit before broker work.
+4. Process members sequentially. Each member gets a fresh DB session and calls
+   the existing single-proposal approval helper with its snapshotted individual
+   nonce and individual message ID.
+5. The helper consumes the proposal nonce, applies ROB-869 lifecycle guards,
+   records the existing proposal approval audit, obtains the existing commit
+   lease, and invokes the existing `revalidate_and_submit` function.
+6. Any exception or rejected member is recorded as that member's result and the
+   loop continues. No member transaction can roll back another member.
+7. Existing individual messages are edited by the reused approval helper. A
+   ROB-861 shortfall remains `needs_reconfirm`, receives the existing fresh
+   proposal nonce/message, and is marked as such in the batch result.
+8. After all members, edit the batch summary into a terminal result grouped by
+   approved, needs-reconfirm, skipped/stale, and failed. Remove the batch button.
+
+The batch nonce is only the trigger. It never substitutes for an individual
+proposal nonce or approval audit.
+
+## Failure and Race Semantics
+
+- **Batch replay:** rejected by `approval_nonce_used_at` before member work.
+- **Expired batch:** rejected before member work; summary button is removed when
+  Telegram editing succeeds.
+- **Individual approval wins race:** the member's snapshotted nonce is already
+  used, so that member is skipped while later members continue.
+- **Supersede/terminal wins race:** the existing ROB-869 approval guard rejects
+  that member; later members continue.
+- **Loss-cut appears through malformed data:** click-time eligibility excludes
+  it, preserving the two-step flow.
+- **ROB-861 insufficient buying power:** only affected rungs become
+  `needs_reconfirm`; other members still execute.
+- **Telegram edit/send failure:** DB broker outcomes remain committed first;
+  notifications are best effort and cannot rewrite trading truth.
+- **Concurrent dispatch:** advisory locking and membership uniqueness prevent a
+  proposal from appearing in two open batches.
+- **Process crash after batch nonce commit:** replay remains blocked. Completed
+  members preserve their own commits; untouched members keep their individual
+  buttons and can still be approved separately. The batch summary may be stale,
+  but no ambiguous broker retry occurs.
+
+## Components and File Boundaries
+
+- `app/models/order_proposals.py`: additive batch and membership ORM models.
+- `alembic/versions/*_rob870_approval_batches.py`: additive schema migration.
+- `app/services/order_proposals/repository.py`: locked batch lookup, creation,
+  membership, prefix resolution, and nonce consumption primitives.
+- `app/services/order_proposals/service.py`: batch invariants and audit methods.
+- `app/services/order_proposals/approval_message.py`: pure summary and callback
+  rendering/parsing.
+- `app/services/order_proposals/dispatch.py`: post-individual-send batch
+  registration and summary send/edit orchestration.
+- `app/services/order_proposals/telegram_callback.py`: batch callback
+  orchestration and reuse of single-proposal approval behavior.
+- `docs/runbooks/order-proposals.md`: operator contract, TTL, exclusions, and
+  fallback behavior.
+
+ROB-868 websocket code and ROB-877 broker-gateway code are outside the change
+surface.
+
+## Test Design
+
+Tests must cover:
+
+- batch callback render/parse and Telegram's 64-byte bound;
+- second-member summary creation and later summary edits;
+- same-chat and ten-minute collection boundaries;
+- batch nonce single use and TTL expiry;
+- immutable membership nonce binding;
+- partial member failure with later members still processed;
+- per-member individual message result edits;
+- loss-cut exclusion at registration and click time;
+- superseded and terminal exclusion at registration and click time;
+- auto-approved exclusion;
+- individual approval path regression with identical behavior;
+- mixed ROB-861 buying-power shortfall where only affected rungs remain
+  `needs_reconfirm` and the summary reports them;
+- concurrent registration does not duplicate membership;
+- migration upgrade/downgrade smoke coverage where the repository convention
+  requires it.
+
+The required final gates are the focused order-proposal tests, the full relevant
+suite, and `make lint`.
+
+## Non-goals
+
+- Changing ROB-871 policy thresholds or auto-approval eligibility.
+- Atomic broker submission of a multi-rung ladder.
+- Removing or weakening individual approval/deny buttons.
+- Batching loss cuts.
+- Changing broker gateway or websocket behavior.

--- a/tests/_schema_bootstrap.py
+++ b/tests/_schema_bootstrap.py
@@ -34,7 +34,9 @@ from sqlalchemy import text
 # replaces only a mismatched definition before CREATE IF NOT EXISTS.
 # v11 (ROB-866): review.toss_manual_activity_alerts (new ORM table) — create_all
 # builds it; bump forces a persistent local DB to re-bootstrap once.
-SCHEMA_BOOTSTRAP_VERSION = 14
+# v15 (ROB-870): review.order_proposal_approval_batches and membership rows are
+# new ORM tables; persistent local DBs need one create_all re-bootstrap.
+SCHEMA_BOOTSTRAP_VERSION = 15
 
 # ---- constraints + enums (moved verbatim from conftest.py) ----
 MARKET_VALUATION_SOURCE_CHECK_NAME = "ck_market_valuation_snapshots_source"

--- a/tests/services/order_proposals/test_approval_message.py
+++ b/tests/services/order_proposals/test_approval_message.py
@@ -132,11 +132,16 @@ def test_batch_summary_omits_market_order_notional_from_totals():
     )
     proposals = [
         (
-            _group(symbol="AAPL", market="equity_us", account_mode="kis_live"),
+            _group(
+                symbol="AAPL",
+                market="equity_us",
+                account_mode="kis_live",
+                order_type="market",
+            ),
             [
                 _rung(
                     quantity=Decimal("1"),
-                    limit_price=None,
+                    limit_price=Decimal("999"),
                     notional=Decimal("999"),
                 )
             ],
@@ -170,7 +175,7 @@ def test_batch_result_groups_each_member_outcome():
             {
                 "proposal_id": str(groups[0].proposal_id),
                 "status": "approved",
-                "rung_results": ["submitted_resting"],
+                "rung_results": [{"rung_index": 2, "result": "submitted_resting"}],
             },
             {
                 "proposal_id": str(groups[1].proposal_id),
@@ -185,7 +190,7 @@ def test_batch_result_groups_each_member_outcome():
                 "proposal_id": str(groups[3].proposal_id),
                 "status": "failed",
                 "reason": "broker unavailable",
-                "rung_results": ["unverified"],
+                "rung_results": [{"rung_index": 4, "result": "unverified"}],
             },
         ],
     )
@@ -194,8 +199,8 @@ def test_batch_result_groups_each_member_outcome():
     assert "재확인 필요" in text and "MSFT" in text
     assert "제외/건너뜀" in text and "NVDA" in text
     assert "실패" in text and "AMZN" in text
-    assert "#1 주문 유지(대기)" in text
-    assert "#1 확인 불가(수동 확인 필요)" in text
+    assert "#3 주문 유지(대기)" in text
+    assert "#5 확인 불가(수동 확인 필요)" in text
 
 
 @pytest.mark.unit

--- a/tests/services/order_proposals/test_approval_message.py
+++ b/tests/services/order_proposals/test_approval_message.py
@@ -7,6 +7,7 @@ from types import SimpleNamespace
 
 import pytest
 
+from app.services.order_proposals import approval_message as approval_messages
 from app.services.order_proposals.approval_message import (
     build_action_diff,
     build_approval_message,
@@ -71,6 +72,91 @@ def _snapshot_rung():
         quantity=Decimal("3.5"),
         limit_price=Decimal("42000"),
     )
+
+
+def test_batch_callback_round_trip_and_telegram_limit():
+    batch_id = uuid.UUID("aaaaaaaa-1111-4111-8111-111111111111")
+
+    data = approval_messages.build_batch_callback_data(
+        batch_id=batch_id, nonce="batch_nonce-1"
+    )
+
+    assert parse_callback_data(data) == ("ba", "aaaaaaaa", "batch_nonce-1")
+    assert len(data.encode()) <= 64
+
+
+def test_batch_summary_lists_notional_and_account_subtotals():
+    batch = SimpleNamespace(
+        batch_id=uuid.UUID("aaaaaaaa-1111-4111-8111-111111111111"),
+        approval_nonce="batch-nonce",
+        expires_at=datetime(2026, 7, 14, 1, 30, tzinfo=UTC),
+    )
+    proposals = [
+        (
+            _group(
+                symbol="AAPL",
+                market="equity_us",
+                side="buy",
+                account_mode="kis_live",
+                broker_account_id="account-1234",
+            ),
+            [_rung(quantity=Decimal("1"), limit_price=Decimal("100"))],
+        ),
+        (
+            _group(
+                symbol="MSFT",
+                market="equity_us",
+                side="sell",
+                account_mode="toss_live",
+                broker_account_id=None,
+            ),
+            [_rung(quantity=Decimal("2"), limit_price=Decimal("50"))],
+        ),
+    ]
+
+    text, keyboard = approval_messages.build_batch_approval_message(
+        batch=batch, proposals=proposals
+    )
+
+    assert "AAPL" in text and "MSFT" in text
+    assert r"kis\_live ···1234" in text and r"toss\_live" in text
+    assert "합계: $200" in text
+    assert keyboard["inline_keyboard"][0][0]["text"] == "전체 승인"
+
+
+def test_batch_result_groups_each_member_outcome():
+    groups = [
+        _group(symbol="AAPL"),
+        _group(symbol="MSFT"),
+        _group(symbol="NVDA"),
+        _group(symbol="AMZN"),
+    ]
+
+    text = approval_messages.build_batch_result_message(
+        proposals=[(group, [_rung()]) for group in groups],
+        results=[
+            {"proposal_id": str(groups[0].proposal_id), "status": "approved"},
+            {
+                "proposal_id": str(groups[1].proposal_id),
+                "status": "needs_reconfirm",
+            },
+            {
+                "proposal_id": str(groups[2].proposal_id),
+                "status": "skipped",
+                "reason": "nonce_replay",
+            },
+            {
+                "proposal_id": str(groups[3].proposal_id),
+                "status": "failed",
+                "reason": "broker unavailable",
+            },
+        ],
+    )
+
+    assert "승인 완료" in text and "AAPL" in text
+    assert "재확인 필요" in text and "MSFT" in text
+    assert "제외/건너뜀" in text and "NVDA" in text
+    assert "실패" in text and "AMZN" in text
 
 
 @pytest.mark.unit

--- a/tests/services/order_proposals/test_approval_message.py
+++ b/tests/services/order_proposals/test_approval_message.py
@@ -124,6 +124,38 @@ def test_batch_summary_lists_notional_and_account_subtotals():
     assert keyboard["inline_keyboard"][0][0]["text"] == "전체 승인"
 
 
+def test_batch_summary_omits_market_order_notional_from_totals():
+    batch = SimpleNamespace(
+        batch_id=uuid.uuid4(),
+        approval_nonce="batch-nonce",
+        expires_at=datetime(2026, 7, 14, 1, 30, tzinfo=UTC),
+    )
+    proposals = [
+        (
+            _group(symbol="AAPL", market="equity_us", account_mode="kis_live"),
+            [
+                _rung(
+                    quantity=Decimal("1"),
+                    limit_price=None,
+                    notional=Decimal("999"),
+                )
+            ],
+        ),
+        (
+            _group(symbol="MSFT", market="equity_us", account_mode="kis_live"),
+            [_rung(quantity=Decimal("1"), limit_price=Decimal("100"))],
+        ),
+    ]
+
+    text, _keyboard = approval_messages.build_batch_approval_message(
+        batch=batch, proposals=proposals
+    )
+
+    assert "합계: $100" in text
+    assert "$999" not in text
+    assert "$1,099" not in text
+
+
 def test_batch_result_groups_each_member_outcome():
     groups = [
         _group(symbol="AAPL"),
@@ -135,7 +167,11 @@ def test_batch_result_groups_each_member_outcome():
     text = approval_messages.build_batch_result_message(
         proposals=[(group, [_rung()]) for group in groups],
         results=[
-            {"proposal_id": str(groups[0].proposal_id), "status": "approved"},
+            {
+                "proposal_id": str(groups[0].proposal_id),
+                "status": "approved",
+                "rung_results": ["submitted_resting"],
+            },
             {
                 "proposal_id": str(groups[1].proposal_id),
                 "status": "needs_reconfirm",
@@ -149,6 +185,7 @@ def test_batch_result_groups_each_member_outcome():
                 "proposal_id": str(groups[3].proposal_id),
                 "status": "failed",
                 "reason": "broker unavailable",
+                "rung_results": ["unverified"],
             },
         ],
     )
@@ -157,6 +194,8 @@ def test_batch_result_groups_each_member_outcome():
     assert "재확인 필요" in text and "MSFT" in text
     assert "제외/건너뜀" in text and "NVDA" in text
     assert "실패" in text and "AMZN" in text
+    assert "#1 주문 유지(대기)" in text
+    assert "#1 확인 불가(수동 확인 필요)" in text
 
 
 @pytest.mark.unit

--- a/tests/services/order_proposals/test_dispatch.py
+++ b/tests/services/order_proposals/test_dispatch.py
@@ -7,7 +7,9 @@ from decimal import Decimal
 
 import pytest
 
+from app.core.db import AsyncSessionLocal
 from app.services.order_proposals import OrderProposalsService
+from app.services.order_proposals.approval_message import parse_callback_data
 from app.services.order_proposals.dispatch import (
     dispatch_proposal,
     send_proposal_for_approval,
@@ -39,6 +41,26 @@ class _FakeNotifier:
 class _RaisingNotifier:
     async def send_approval_message(self, text, inline_keyboard, *, chat_id):
         raise RuntimeError("telegram down")
+
+
+class _CommittedBatchNotifier(_FakeNotifier):
+    def __init__(self) -> None:
+        super().__init__(message_id=6500)
+        self.visible_member_counts: list[int] = []
+
+    async def send_approval_message(self, text, inline_keyboard, *, chat_id):
+        button = inline_keyboard["inline_keyboard"][0][0]
+        if button["text"] == "전체 승인":
+            _action, batch_short, _nonce = parse_callback_data(button["callback_data"])
+            async with AsyncSessionLocal() as session:
+                service = OrderProposalsService(session)
+                batch_id = await service.resolve_approval_batch_id_prefix(batch_short)
+                assert batch_id is not None
+                _batch, proposals = await service.get_approval_batch_display(batch_id)
+                self.visible_member_counts.append(len(proposals))
+        return await super().send_approval_message(
+            text, inline_keyboard, chat_id=chat_id
+        )
 
 
 def _session_factory(db_session):
@@ -161,6 +183,37 @@ async def test_manual_dispatch_sends_and_updates_same_chat_batch_summary(
     assert notifier.edited_messages
     assert notifier.edited_messages[-1][1] == 6002
     assert "제안: 3건" in notifier.edited_messages[-1][2]
+
+
+@pytest.mark.asyncio
+async def test_batch_summary_is_sent_only_after_membership_commit(
+    monkeypatch, db_session
+):
+    from app.core.config import settings
+
+    batch_chat_id = f"batch-{uuid.uuid4().hex}"
+    monkeypatch.setattr(
+        settings, "ORDER_PROPOSALS_TELEGRAM_CHAT_ALLOWLIST_STR", batch_chat_id
+    )
+    first = await _seed_proposal(db_session)
+    second = await _seed_proposal(db_session)
+    notifier = _CommittedBatchNotifier()
+    now = datetime(2026, 7, 14, 1, 0, tzinfo=UTC)
+
+    await send_proposal_for_approval(
+        first.proposal_id,
+        notifier=notifier,
+        now=now,
+        service_factory=_session_factory(db_session),
+    )
+    await send_proposal_for_approval(
+        second.proposal_id,
+        notifier=notifier,
+        now=now.replace(minute=1),
+        service_factory=_session_factory(db_session),
+    )
+
+    assert notifier.visible_member_counts == [2]
 
 
 @pytest.mark.asyncio

--- a/tests/services/order_proposals/test_dispatch.py
+++ b/tests/services/order_proposals/test_dispatch.py
@@ -21,11 +21,19 @@ CHAT_ID = "chat-99"
 class _FakeNotifier:
     def __init__(self, *, message_id: int | None = 5001) -> None:
         self.sent_messages: list[tuple[str, dict, str]] = []
+        self.edited_messages: list[tuple[str, int, str, dict | None]] = []
         self._message_id = message_id
 
     async def send_approval_message(self, text, inline_keyboard, *, chat_id):
         self.sent_messages.append((text, inline_keyboard, chat_id))
-        return self._message_id
+        message_id = self._message_id
+        if self._message_id is not None:
+            self._message_id += 1
+        return message_id
+
+    async def edit_message(self, chat_id, message_id, text, reply_markup=None):
+        self.edited_messages.append((chat_id, message_id, text, reply_markup))
+        return True
 
 
 class _RaisingNotifier:
@@ -103,6 +111,56 @@ async def test_send_proposal_for_approval_mints_nonce_and_sends(
     assert refreshed.source_asof["approval_message_id"] == 5001
     assert refreshed.source_asof["approval_chat_id"] == CHAT_ID
     assert refreshed.source_asof["approval_sent_at"] == now.isoformat()
+
+
+@pytest.mark.asyncio
+async def test_manual_dispatch_sends_and_updates_same_chat_batch_summary(
+    monkeypatch, db_session
+):
+    from app.core.config import settings
+
+    batch_chat_id = f"batch-{uuid.uuid4().hex}"
+    monkeypatch.setattr(
+        settings, "ORDER_PROPOSALS_TELEGRAM_CHAT_ALLOWLIST_STR", batch_chat_id
+    )
+    first = await _seed_proposal(db_session)
+    second = await _seed_proposal(db_session)
+    third = await _seed_proposal(db_session)
+    notifier = _FakeNotifier(message_id=6000)
+    now = datetime(2026, 7, 14, 1, 0, tzinfo=UTC)
+
+    first_id = await send_proposal_for_approval(
+        first.proposal_id,
+        notifier=notifier,
+        now=now,
+        service_factory=_session_factory(db_session),
+    )
+    assert first_id == 6000
+    assert len(notifier.sent_messages) == 1
+
+    second_id = await send_proposal_for_approval(
+        second.proposal_id,
+        notifier=notifier,
+        now=now.replace(minute=1),
+        service_factory=_session_factory(db_session),
+    )
+    assert second_id == 6001
+    assert len(notifier.sent_messages) == 3
+    summary_text, summary_keyboard, summary_chat = notifier.sent_messages[-1]
+    assert summary_chat == batch_chat_id
+    assert "제안: 2건" in summary_text
+    assert summary_keyboard["inline_keyboard"][0][0]["text"] == "전체 승인"
+
+    third_id = await send_proposal_for_approval(
+        third.proposal_id,
+        notifier=notifier,
+        now=now.replace(minute=2),
+        service_factory=_session_factory(db_session),
+    )
+    assert third_id == 6003
+    assert notifier.edited_messages
+    assert notifier.edited_messages[-1][1] == 6002
+    assert "제안: 3건" in notifier.edited_messages[-1][2]
 
 
 @pytest.mark.asyncio

--- a/tests/services/order_proposals/test_models_smoke.py
+++ b/tests/services/order_proposals/test_models_smoke.py
@@ -1,5 +1,6 @@
 import pytest
 
+from app.models import order_proposals as models
 from app.models.order_proposals import OrderProposal, OrderProposalRung
 from app.services.order_proposals.state_machine import RUNG_STATES
 
@@ -34,6 +35,48 @@ def test_order_proposal_has_action_columns():
     assert "action IS NULL" in str(check.sqltext)
     for action in ("place", "replace", "cancel"):
         assert f"'{action}'" in str(check.sqltext)
+
+
+@pytest.mark.unit
+def test_approval_batch_models_are_durable_and_bound_to_proposals():
+    batch = models.OrderProposalApprovalBatch.__table__
+    member = models.OrderProposalApprovalBatchMember.__table__
+
+    assert batch.schema == member.schema == "review"
+    assert batch.name == "order_proposal_approval_batches"
+    assert member.name == "order_proposal_approval_batch_members"
+    assert {
+        "batch_id",
+        "chat_id",
+        "window_started_at",
+        "window_closes_at",
+        "expires_at",
+        "approval_nonce",
+        "approval_nonce_used_at",
+        "approved_by_telegram_user_id",
+        "approved_at",
+        "summary_message_id",
+        "summary_dispatch_state",
+        "summary_dispatch_lease_until",
+    } <= set(batch.columns.keys())
+    assert {
+        "batch_pk",
+        "proposal_pk",
+        "approval_nonce_snapshot",
+        "approval_message_id",
+        "result",
+        "result_detail",
+        "processed_at",
+        "added_at",
+    } <= set(member.columns.keys())
+
+    unique_names = {
+        constraint.name
+        for constraint in member.constraints
+        if constraint.__class__.__name__ == "UniqueConstraint"
+    }
+    assert "uq_order_proposal_batch_member" in unique_names
+    assert "uq_order_proposal_batch_member_nonce" in unique_names
 
 
 @pytest.mark.unit

--- a/tests/services/order_proposals/test_service.py
+++ b/tests/services/order_proposals/test_service.py
@@ -2065,6 +2065,7 @@ async def _create_batch_candidate(
 @pytest.mark.asyncio
 async def test_approval_batch_registration_groups_same_chat_and_window(db_session):
     now = datetime(2026, 7, 14, 1, 0, tzinfo=UTC)
+    chat_id = f"batch-{uuid.uuid4().hex}"
     first = await _create_batch_candidate(
         db_session, symbol="AAPL", nonce="batch-member-1"
     )
@@ -2078,13 +2079,13 @@ async def test_approval_batch_registration_groups_same_chat_and_window(db_sessio
 
     one = await service.register_approval_batch_member(
         first.proposal_id,
-        chat_id="42",
+        chat_id=chat_id,
         approval_message_id=1001,
         now=now,
     )
     two = await service.register_approval_batch_member(
         second.proposal_id,
-        chat_id="42",
+        chat_id=chat_id,
         approval_message_id=1002,
         now=now + timedelta(minutes=1),
     )
@@ -2098,7 +2099,7 @@ async def test_approval_batch_registration_groups_same_chat_and_window(db_sessio
     )
     three = await service.register_approval_batch_member(
         third.proposal_id,
-        chat_id="42",
+        chat_id=chat_id,
         approval_message_id=1003,
         now=now + timedelta(minutes=2),
     )
@@ -2110,6 +2111,8 @@ async def test_approval_batch_registration_groups_same_chat_and_window(db_sessio
 @pytest.mark.asyncio
 async def test_approval_batch_registration_respects_chat_and_fixed_window(db_session):
     now = datetime(2026, 7, 14, 1, 0, tzinfo=UTC)
+    chat_id = f"batch-{uuid.uuid4().hex}"
+    other_chat_id = f"batch-{uuid.uuid4().hex}"
     first = await _create_batch_candidate(
         db_session, symbol="AAPL", nonce="window-member-1"
     )
@@ -2123,19 +2126,19 @@ async def test_approval_batch_registration_respects_chat_and_fixed_window(db_ses
 
     first_registration = await service.register_approval_batch_member(
         first.proposal_id,
-        chat_id="42",
+        chat_id=chat_id,
         approval_message_id=1001,
         now=now,
     )
     other_registration = await service.register_approval_batch_member(
         other_chat.proposal_id,
-        chat_id="99",
+        chat_id=other_chat_id,
         approval_message_id=1002,
         now=now + timedelta(minutes=1),
     )
     later_registration = await service.register_approval_batch_member(
         later.proposal_id,
-        chat_id="42",
+        chat_id=chat_id,
         approval_message_id=1003,
         now=now + timedelta(minutes=10),
     )
@@ -2158,6 +2161,7 @@ async def test_approval_batch_registration_respects_chat_and_fixed_window(db_ses
 @pytest.mark.asyncio
 async def test_approval_batch_registration_excludes_manual_safety_classes(db_session):
     now = datetime(2026, 7, 14, 1, 0, tzinfo=UTC)
+    chat_id = f"batch-{uuid.uuid4().hex}"
     loss_cut = await _create_batch_candidate(
         db_session, symbol="LOSS", nonce="excluded-loss"
     )
@@ -2182,7 +2186,7 @@ async def test_approval_batch_registration_excludes_manual_safety_classes(db_ses
     for index, group in enumerate((loss_cut, auto, terminal, superseded), start=1):
         registration = await service.register_approval_batch_member(
             group.proposal_id,
-            chat_id="42",
+            chat_id=chat_id,
             approval_message_id=1000 + index,
             now=now,
         )
@@ -2192,6 +2196,7 @@ async def test_approval_batch_registration_excludes_manual_safety_classes(db_ses
 @pytest.mark.asyncio
 async def test_approval_batch_nonce_is_single_use_and_bound_to_chat(db_session):
     now = datetime(2026, 7, 14, 1, 0, tzinfo=UTC)
+    chat_id = f"batch-{uuid.uuid4().hex}"
     first = await _create_batch_candidate(
         db_session, symbol="AAPL", nonce="consume-member-1"
     )
@@ -2201,13 +2206,13 @@ async def test_approval_batch_nonce_is_single_use_and_bound_to_chat(db_session):
     service = OrderProposalsService(db_session)
     registration = await service.register_approval_batch_member(
         first.proposal_id,
-        chat_id="42",
+        chat_id=chat_id,
         approval_message_id=1001,
         now=now,
     )
     await service.register_approval_batch_member(
         second.proposal_id,
-        chat_id="42",
+        chat_id=chat_id,
         approval_message_id=1002,
         now=now + timedelta(minutes=1),
     )
@@ -2215,7 +2220,7 @@ async def test_approval_batch_nonce_is_single_use_and_bound_to_chat(db_session):
     batch, members = await service.consume_approval_batch_nonce(
         registration.batch.batch_id,
         registration.batch.approval_nonce,
-        chat_id="42",
+        chat_id=chat_id,
         telegram_user_id="777",
         now=now + timedelta(minutes=2),
     )
@@ -2230,7 +2235,7 @@ async def test_approval_batch_nonce_is_single_use_and_bound_to_chat(db_session):
         await service.consume_approval_batch_nonce(
             batch.batch_id,
             batch.approval_nonce,
-            chat_id="42",
+            chat_id=chat_id,
             telegram_user_id="777",
             now=now + timedelta(minutes=3),
         )
@@ -2240,6 +2245,7 @@ async def test_approval_batch_nonce_is_single_use_and_bound_to_chat(db_session):
 @pytest.mark.asyncio
 async def test_approval_batch_nonce_expires_without_consuming_members(db_session):
     now = datetime(2026, 7, 14, 1, 0, tzinfo=UTC)
+    chat_id = f"batch-{uuid.uuid4().hex}"
     first = await _create_batch_candidate(
         db_session, symbol="AAPL", nonce="expiry-member-1"
     )
@@ -2249,13 +2255,13 @@ async def test_approval_batch_nonce_expires_without_consuming_members(db_session
     service = OrderProposalsService(db_session)
     registration = await service.register_approval_batch_member(
         first.proposal_id,
-        chat_id="42",
+        chat_id=chat_id,
         approval_message_id=1001,
         now=now,
     )
     await service.register_approval_batch_member(
         second.proposal_id,
-        chat_id="42",
+        chat_id=chat_id,
         approval_message_id=1002,
         now=now + timedelta(minutes=1),
     )
@@ -2267,7 +2273,7 @@ async def test_approval_batch_nonce_expires_without_consuming_members(db_session
         await service.consume_approval_batch_nonce(
             registration.batch.batch_id,
             registration.batch.approval_nonce,
-            chat_id="42",
+            chat_id=chat_id,
             telegram_user_id="777",
             now=now + timedelta(minutes=12),
         )

--- a/tests/services/order_proposals/test_service.py
+++ b/tests/services/order_proposals/test_service.py
@@ -2035,3 +2035,244 @@ async def test_create_proposal_rejection_leaves_no_partial_rows(db_session):
         .where(OrderProposal.symbol == symbol)
     )
     assert count == 0
+
+
+async def _create_batch_candidate(
+    db_session,
+    *,
+    symbol: str,
+    nonce: str,
+    source_asof: dict | None = None,
+    valid_until: datetime | None = None,
+):
+    service = OrderProposalsService(db_session)
+    group = await service.create_proposal(
+        symbol=symbol,
+        market="equity_us",
+        account_mode="kis_live",
+        side="buy",
+        order_type="limit",
+        proposer="batch-test",
+        rungs=[RungInput(0, "buy", Decimal("1"), Decimal("100"), None)],
+        source_asof=source_asof,
+        valid_until=valid_until,
+    )
+    await service.set_approval_nonce(group.proposal_id, nonce)
+    await db_session.commit()
+    return group
+
+
+@pytest.mark.asyncio
+async def test_approval_batch_registration_groups_same_chat_and_window(db_session):
+    now = datetime(2026, 7, 14, 1, 0, tzinfo=UTC)
+    first = await _create_batch_candidate(
+        db_session, symbol="AAPL", nonce="batch-member-1"
+    )
+    second = await _create_batch_candidate(
+        db_session, symbol="MSFT", nonce="batch-member-2"
+    )
+    third = await _create_batch_candidate(
+        db_session, symbol="NVDA", nonce="batch-member-3"
+    )
+    service = OrderProposalsService(db_session)
+
+    one = await service.register_approval_batch_member(
+        first.proposal_id,
+        chat_id="42",
+        approval_message_id=1001,
+        now=now,
+    )
+    two = await service.register_approval_batch_member(
+        second.proposal_id,
+        chat_id="42",
+        approval_message_id=1002,
+        now=now + timedelta(minutes=1),
+    )
+    assert one is not None and two is not None
+    assert one.batch.batch_id == two.batch.batch_id
+    assert one.member_count == 1 and one.summary_action == "none"
+    assert two.member_count == 2 and two.summary_action == "send"
+
+    await service.record_approval_batch_summary(
+        two.batch.batch_id, message_id=2001, now=now + timedelta(minutes=1)
+    )
+    three = await service.register_approval_batch_member(
+        third.proposal_id,
+        chat_id="42",
+        approval_message_id=1003,
+        now=now + timedelta(minutes=2),
+    )
+    assert three is not None
+    assert three.batch.batch_id == one.batch.batch_id
+    assert three.member_count == 3 and three.summary_action == "edit"
+
+
+@pytest.mark.asyncio
+async def test_approval_batch_registration_respects_chat_and_fixed_window(db_session):
+    now = datetime(2026, 7, 14, 1, 0, tzinfo=UTC)
+    first = await _create_batch_candidate(
+        db_session, symbol="AAPL", nonce="window-member-1"
+    )
+    other_chat = await _create_batch_candidate(
+        db_session, symbol="MSFT", nonce="window-member-2"
+    )
+    later = await _create_batch_candidate(
+        db_session, symbol="NVDA", nonce="window-member-3"
+    )
+    service = OrderProposalsService(db_session)
+
+    first_registration = await service.register_approval_batch_member(
+        first.proposal_id,
+        chat_id="42",
+        approval_message_id=1001,
+        now=now,
+    )
+    other_registration = await service.register_approval_batch_member(
+        other_chat.proposal_id,
+        chat_id="99",
+        approval_message_id=1002,
+        now=now + timedelta(minutes=1),
+    )
+    later_registration = await service.register_approval_batch_member(
+        later.proposal_id,
+        chat_id="42",
+        approval_message_id=1003,
+        now=now + timedelta(minutes=10),
+    )
+
+    assert first_registration is not None
+    assert other_registration is not None
+    assert later_registration is not None
+    assert (
+        len(
+            {
+                first_registration.batch.batch_id,
+                other_registration.batch.batch_id,
+                later_registration.batch.batch_id,
+            }
+        )
+        == 3
+    )
+
+
+@pytest.mark.asyncio
+async def test_approval_batch_registration_excludes_manual_safety_classes(db_session):
+    now = datetime(2026, 7, 14, 1, 0, tzinfo=UTC)
+    loss_cut = await _create_batch_candidate(
+        db_session, symbol="LOSS", nonce="excluded-loss"
+    )
+    auto = await _create_batch_candidate(
+        db_session,
+        symbol="AUTO",
+        nonce="excluded-auto",
+        source_asof={"auto_approved": {"approved_at": now.isoformat()}},
+    )
+    terminal = await _create_batch_candidate(
+        db_session, symbol="DONE", nonce="excluded-terminal"
+    )
+    superseded = await _create_batch_candidate(
+        db_session, symbol="OLD", nonce="excluded-superseded"
+    )
+    loss_cut.exit_intent = "loss_cut"
+    terminal.lifecycle_state = "terminal"
+    superseded.lifecycle_state = "superseded"
+    await db_session.commit()
+    service = OrderProposalsService(db_session)
+
+    for index, group in enumerate((loss_cut, auto, terminal, superseded), start=1):
+        registration = await service.register_approval_batch_member(
+            group.proposal_id,
+            chat_id="42",
+            approval_message_id=1000 + index,
+            now=now,
+        )
+        assert registration is None
+
+
+@pytest.mark.asyncio
+async def test_approval_batch_nonce_is_single_use_and_bound_to_chat(db_session):
+    now = datetime(2026, 7, 14, 1, 0, tzinfo=UTC)
+    first = await _create_batch_candidate(
+        db_session, symbol="AAPL", nonce="consume-member-1"
+    )
+    second = await _create_batch_candidate(
+        db_session, symbol="MSFT", nonce="consume-member-2"
+    )
+    service = OrderProposalsService(db_session)
+    registration = await service.register_approval_batch_member(
+        first.proposal_id,
+        chat_id="42",
+        approval_message_id=1001,
+        now=now,
+    )
+    await service.register_approval_batch_member(
+        second.proposal_id,
+        chat_id="42",
+        approval_message_id=1002,
+        now=now + timedelta(minutes=1),
+    )
+    assert registration is not None
+    batch, members = await service.consume_approval_batch_nonce(
+        registration.batch.batch_id,
+        registration.batch.approval_nonce,
+        chat_id="42",
+        telegram_user_id="777",
+        now=now + timedelta(minutes=2),
+    )
+    await db_session.commit()
+    assert batch.approval_nonce_used_at == now + timedelta(minutes=2)
+    assert [member.proposal_id for member in members] == [
+        first.proposal_id,
+        second.proposal_id,
+    ]
+
+    with pytest.raises(OrderProposalError, match="approval_batch_nonce_replay"):
+        await service.consume_approval_batch_nonce(
+            batch.batch_id,
+            batch.approval_nonce,
+            chat_id="42",
+            telegram_user_id="777",
+            now=now + timedelta(minutes=3),
+        )
+    await db_session.rollback()
+
+
+@pytest.mark.asyncio
+async def test_approval_batch_nonce_expires_without_consuming_members(db_session):
+    now = datetime(2026, 7, 14, 1, 0, tzinfo=UTC)
+    first = await _create_batch_candidate(
+        db_session, symbol="AAPL", nonce="expiry-member-1"
+    )
+    second = await _create_batch_candidate(
+        db_session, symbol="MSFT", nonce="expiry-member-2"
+    )
+    service = OrderProposalsService(db_session)
+    registration = await service.register_approval_batch_member(
+        first.proposal_id,
+        chat_id="42",
+        approval_message_id=1001,
+        now=now,
+    )
+    await service.register_approval_batch_member(
+        second.proposal_id,
+        chat_id="42",
+        approval_message_id=1002,
+        now=now + timedelta(minutes=1),
+    )
+    assert registration is not None
+    first_id = first.proposal_id
+    second_id = second.proposal_id
+
+    with pytest.raises(OrderProposalError, match="approval_batch_expired"):
+        await service.consume_approval_batch_nonce(
+            registration.batch.batch_id,
+            registration.batch.approval_nonce,
+            chat_id="42",
+            telegram_user_id="777",
+            now=now + timedelta(minutes=12),
+        )
+    await db_session.rollback()
+    first_after, _ = await service.get_proposal(first_id)
+    second_after, _ = await service.get_proposal(second_id)
+    assert first_after.approval_nonce_used_at is None
+    assert second_after.approval_nonce_used_at is None

--- a/tests/services/order_proposals/test_service.py
+++ b/tests/services/order_proposals/test_service.py
@@ -2159,6 +2159,46 @@ async def test_approval_batch_registration_respects_chat_and_fixed_window(db_ses
 
 
 @pytest.mark.asyncio
+async def test_approval_batch_registration_does_not_join_expired_open_window(
+    db_session,
+):
+    now = datetime.now(UTC)
+    chat_id = f"batch-{uuid.uuid4().hex}"
+    expiring = await _create_batch_candidate(
+        db_session,
+        symbol="AAPL",
+        nonce="expired-window-member-1",
+        valid_until=now + timedelta(minutes=2),
+    )
+    later = await _create_batch_candidate(
+        db_session,
+        symbol="MSFT",
+        nonce="expired-window-member-2",
+        valid_until=now + timedelta(hours=1),
+    )
+    service = OrderProposalsService(db_session)
+
+    first_registration = await service.register_approval_batch_member(
+        expiring.proposal_id,
+        chat_id=chat_id,
+        approval_message_id=1001,
+        now=now,
+    )
+    later_registration = await service.register_approval_batch_member(
+        later.proposal_id,
+        chat_id=chat_id,
+        approval_message_id=1002,
+        now=now + timedelta(minutes=3),
+    )
+
+    assert first_registration is not None
+    assert later_registration is not None
+    assert later_registration.batch.batch_id != first_registration.batch.batch_id
+    assert later_registration.member_count == 1
+    assert later_registration.summary_action == "none"
+
+
+@pytest.mark.asyncio
 async def test_approval_batch_registration_excludes_manual_safety_classes(db_session):
     now = datetime(2026, 7, 14, 1, 0, tzinfo=UTC)
     chat_id = f"batch-{uuid.uuid4().hex}"
@@ -2191,6 +2231,115 @@ async def test_approval_batch_registration_excludes_manual_safety_classes(db_ses
             now=now,
         )
         assert registration is None
+
+
+@pytest.mark.asyncio
+async def test_approval_batch_registration_excludes_transient_ineligible_members(
+    db_session,
+):
+    now = datetime(2026, 7, 14, 1, 0, tzinfo=UTC)
+    chat_id = f"batch-{uuid.uuid4().hex}"
+    missing_nonce = await _create_batch_candidate(
+        db_session, symbol="MISS", nonce="excluded-missing"
+    )
+    used_nonce = await _create_batch_candidate(
+        db_session, symbol="USED", nonce="excluded-used"
+    )
+    no_pending = await _create_batch_candidate(
+        db_session, symbol="NOPEND", nonce="excluded-no-pending"
+    )
+    expired = await _create_batch_candidate(
+        db_session, symbol="EXPIRE", nonce="excluded-expired"
+    )
+    missing_nonce.approval_nonce = None
+    used_nonce.approval_nonce_used_at = now
+    expired.valid_until = now
+    await db_session.commit()
+    service = OrderProposalsService(db_session)
+    await service.transition_rung(no_pending.proposal_id, 0, new_state="revalidating")
+
+    for index, group in enumerate(
+        (missing_nonce, used_nonce, no_pending, expired), start=1
+    ):
+        registration = await service.register_approval_batch_member(
+            group.proposal_id,
+            chat_id=chat_id,
+            approval_message_id=1100 + index,
+            now=now,
+        )
+        assert registration is None
+
+
+@pytest.mark.asyncio
+async def test_approval_batch_registration_keeps_fresh_nonce_out_of_same_batch(
+    db_session,
+):
+    now = datetime(2026, 7, 14, 1, 0, tzinfo=UTC)
+    chat_id = f"batch-{uuid.uuid4().hex}"
+    group = await _create_batch_candidate(
+        db_session, symbol="AAPL", nonce="membership-cycle-1"
+    )
+    service = OrderProposalsService(db_session)
+    first = await service.register_approval_batch_member(
+        group.proposal_id,
+        chat_id=chat_id,
+        approval_message_id=1201,
+        now=now,
+    )
+    await db_session.commit()
+    await service.set_approval_nonce(group.proposal_id, "membership-cycle-2")
+    await db_session.commit()
+
+    second = await service.register_approval_batch_member(
+        group.proposal_id,
+        chat_id=chat_id,
+        approval_message_id=1202,
+        now=now + timedelta(minutes=1),
+    )
+
+    assert first is not None
+    assert second is None
+
+
+@pytest.mark.asyncio
+async def test_approval_batch_nonce_rejects_wrong_chat_nonce_and_too_small(
+    db_session,
+):
+    now = datetime(2026, 7, 14, 1, 0, tzinfo=UTC)
+    chat_id = f"batch-{uuid.uuid4().hex}"
+    group = await _create_batch_candidate(
+        db_session, symbol="AAPL", nonce="validation-member"
+    )
+    service = OrderProposalsService(db_session)
+    registration = await service.register_approval_batch_member(
+        group.proposal_id,
+        chat_id=chat_id,
+        approval_message_id=1301,
+        now=now,
+    )
+    await db_session.commit()
+    assert registration is not None
+    batch_id = registration.batch.batch_id
+    batch_nonce = registration.batch.approval_nonce
+
+    for expected, supplied_chat, supplied_nonce in (
+        (
+            "approval_batch_chat_mismatch",
+            "wrong-chat",
+            batch_nonce,
+        ),
+        ("approval_batch_nonce_mismatch", chat_id, "wrong-nonce"),
+        ("approval_batch_too_small", chat_id, batch_nonce),
+    ):
+        with pytest.raises(OrderProposalError, match=expected):
+            await service.consume_approval_batch_nonce(
+                batch_id,
+                supplied_nonce,
+                chat_id=supplied_chat,
+                telegram_user_id="777",
+                now=now + timedelta(minutes=1),
+            )
+        await db_session.rollback()
 
 
 @pytest.mark.asyncio
@@ -2275,7 +2424,7 @@ async def test_approval_batch_nonce_expires_without_consuming_members(db_session
             registration.batch.approval_nonce,
             chat_id=chat_id,
             telegram_user_id="777",
-            now=now + timedelta(minutes=12),
+            now=registration.batch.expires_at,
         )
     await db_session.rollback()
     first_after, _ = await service.get_proposal(first_id)

--- a/tests/services/order_proposals/test_telegram_callback.py
+++ b/tests/services/order_proposals/test_telegram_callback.py
@@ -11,6 +11,7 @@ from app.core.config import settings
 from app.core.db import AsyncSessionLocal
 from app.mcp_server.caller_identity import caller_agent_id_var, get_caller_agent_id
 from app.services.order_proposals import OrderProposalsService
+from app.services.order_proposals import approval_message as approval_messages
 from app.services.order_proposals.approval_message import parse_callback_data
 from app.services.order_proposals.revalidation import RungOutcome, revalidate_and_submit
 from app.services.order_proposals.service import RungInput
@@ -202,6 +203,208 @@ def _allow_chat(monkeypatch, chat_id=CHAT_ID):
     monkeypatch.setattr(
         settings, "ORDER_PROPOSALS_TELEGRAM_CHAT_ALLOWLIST_STR", str(chat_id)
     )
+
+
+async def _seed_approval_batch(db_session, monkeypatch, *, member_count=2):
+    chat_id = int(uuid.uuid4().hex[:8], 16)
+    _allow_chat(monkeypatch, chat_id)
+    now = datetime(2026, 7, 14, 1, 0, tzinfo=UTC)
+    groups = []
+    service = OrderProposalsService(db_session)
+    registration = None
+    for index in range(member_count):
+        group = await _seed_proposal(
+            db_session,
+            nonce=f"batch-member-{uuid.uuid4().hex}",
+            symbol=f"B{index}",
+        )
+        groups.append(group)
+        registration = await service.register_approval_batch_member(
+            group.proposal_id,
+            chat_id=str(chat_id),
+            approval_message_id=7100 + index,
+            now=now + timedelta(seconds=index),
+        )
+    await db_session.commit()
+    assert registration is not None
+    batch = registration.batch
+    data = approval_messages.build_batch_callback_data(
+        batch_id=batch.batch_id,
+        nonce=batch.approval_nonce,
+    )
+    return chat_id, now, groups, batch, data
+
+
+@pytest.mark.asyncio
+async def test_batch_approve_consumes_each_member_nonce_and_rejects_replay(
+    monkeypatch, db_session
+):
+    chat_id, now, groups, _batch, data = await _seed_approval_batch(
+        db_session, monkeypatch
+    )
+    notifier = _FakeNotifier()
+    calls: list[uuid.UUID] = []
+
+    async def fake_revalidate(*, service, proposal_id, now):
+        calls.append(proposal_id)
+        return [RungOutcome(0, "submitted_resting", {})]
+
+    first = await handle_callback_update(
+        _make_update(data=data, chat_id=chat_id),
+        now=now + timedelta(minutes=1),
+        service_factory=_session_factory(db_session),
+        notifier=notifier,
+        revalidate_fn=fake_revalidate,
+    )
+
+    assert first["handled"] is True
+    assert first["reason"] == "batch_approved"
+    assert calls == [group.proposal_id for group in groups]
+    service = OrderProposalsService(db_session)
+    for group in groups:
+        refreshed, _ = await service.get_proposal(group.proposal_id)
+        assert refreshed.approval_nonce_used_at is not None
+        assert refreshed.approved_by_telegram_user_id == str(USER_ID)
+    edited_ids = {item[1] for item in notifier.edited}
+    assert {555, 7100, 7101} <= edited_ids
+
+    replay = await handle_callback_update(
+        _make_update(data=data, chat_id=chat_id, callback_id="batch-replay"),
+        now=now + timedelta(minutes=2),
+        service_factory=_session_factory(db_session),
+        notifier=notifier,
+        revalidate_fn=fake_revalidate,
+    )
+    assert replay == {
+        "handled": False,
+        "reason": "approval_batch_nonce_replay",
+    }
+    assert len(calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_batch_approve_continues_after_one_member_raises(monkeypatch, db_session):
+    chat_id, now, groups, _batch, data = await _seed_approval_batch(
+        db_session, monkeypatch, member_count=3
+    )
+    group_ids = [group.proposal_id for group in groups]
+    notifier = _FakeNotifier()
+    calls: list[uuid.UUID] = []
+
+    async def fake_revalidate(*, service, proposal_id, now):
+        calls.append(proposal_id)
+        if proposal_id == group_ids[1]:
+            raise RuntimeError("middle member failed")
+        return [RungOutcome(0, "submitted_resting", {})]
+
+    result = await handle_callback_update(
+        _make_update(data=data, chat_id=chat_id),
+        now=now + timedelta(minutes=1),
+        service_factory=_session_factory(db_session),
+        notifier=notifier,
+        revalidate_fn=fake_revalidate,
+    )
+
+    assert calls == group_ids
+    assert [item["status"] for item in result["results"]] == [
+        "approved",
+        "failed",
+        "approved",
+    ]
+    edited_ids = {item[1] for item in notifier.edited}
+    assert {555, 7100, 7101, 7102} <= edited_ids
+
+
+@pytest.mark.asyncio
+async def test_batch_click_rechecks_loss_cut_terminal_auto_and_superseded_exclusions(
+    monkeypatch, db_session
+):
+    chat_id, now, groups, _batch, data = await _seed_approval_batch(
+        db_session, monkeypatch, member_count=5
+    )
+    groups[0].exit_intent = "loss_cut"
+    groups[1].lifecycle_state = "terminal"
+    groups[2].source_asof = {
+        **(groups[2].source_asof or {}),
+        "auto_approved": {"approved_at": now.isoformat()},
+    }
+    groups[3].lifecycle_state = "superseded"
+    await db_session.commit()
+    notifier = _FakeNotifier()
+    calls: list[uuid.UUID] = []
+
+    async def fake_revalidate(*, service, proposal_id, now):
+        calls.append(proposal_id)
+        return [RungOutcome(0, "submitted_resting", {})]
+
+    result = await handle_callback_update(
+        _make_update(data=data, chat_id=chat_id),
+        now=now + timedelta(minutes=1),
+        service_factory=_session_factory(db_session),
+        notifier=notifier,
+        revalidate_fn=fake_revalidate,
+    )
+
+    assert calls == [groups[4].proposal_id]
+    assert [item["status"] for item in result["results"]] == [
+        "skipped",
+        "skipped",
+        "skipped",
+        "skipped",
+        "approved",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_batch_approve_keeps_rob861_reconfirm_member_independently_actionable(
+    monkeypatch, db_session
+):
+    chat_id, now, groups, _batch, data = await _seed_approval_batch(
+        db_session, monkeypatch
+    )
+    group_ids = [group.proposal_id for group in groups]
+    original_nonce = groups[0].approval_nonce
+    notifier = _FakeNotifier()
+    detail = {
+        "reason": "insufficient_buying_power",
+        "currency": "KRW",
+        "available": "50000",
+        "required": "100000",
+        "shortfall": "50000",
+        "before": {"limit_price": "100", "quantity": "10"},
+        "after": {"limit_price": "100", "quantity": "10"},
+    }
+
+    async def fake_revalidate(*, service, proposal_id, now):
+        if proposal_id == group_ids[0]:
+            await service.transition_rung(proposal_id, 0, new_state="revalidating")
+            await service.mark_needs_reconfirm(proposal_id, 0, now=now)
+            return [RungOutcome(0, "needs_reconfirm", detail)]
+        return [RungOutcome(0, "submitted_resting", {})]
+
+    result = await handle_callback_update(
+        _make_update(data=data, chat_id=chat_id),
+        now=now + timedelta(minutes=1),
+        service_factory=_session_factory(db_session),
+        notifier=notifier,
+        revalidate_fn=fake_revalidate,
+    )
+
+    assert [item["status"] for item in result["results"]] == [
+        "needs_reconfirm",
+        "approved",
+    ]
+    service = OrderProposalsService(db_session)
+    reconfirm_group, reconfirm_rungs = await service.get_proposal(group_ids[0])
+    approved_group, _ = await service.get_proposal(group_ids[1])
+    assert reconfirm_group.approval_nonce != original_nonce
+    assert reconfirm_group.approval_nonce_used_at is None
+    assert reconfirm_rungs[0].state == "needs_reconfirm"
+    assert approved_group.approval_nonce_used_at is not None
+    assert len(notifier.sent_messages) == 1
+    summary = next(text for _chat, mid, text, _markup in notifier.edited if mid == 555)
+    assert "재확인 필요" in summary
+    assert "승인 완료" in summary
 
 
 def test_result_summary_includes_bounded_escaped_guard_reason():

--- a/tests/services/order_proposals/test_telegram_callback.py
+++ b/tests/services/order_proposals/test_telegram_callback.py
@@ -283,6 +283,29 @@ async def test_batch_approve_consumes_each_member_nonce_and_rejects_replay(
 
 
 @pytest.mark.asyncio
+async def test_expired_batch_callback_removes_summary_button(monkeypatch, db_session):
+    chat_id, _now, _groups, batch, data = await _seed_approval_batch(
+        db_session, monkeypatch
+    )
+    notifier = _FakeNotifier()
+
+    result = await handle_callback_update(
+        _make_update(data=data, chat_id=chat_id),
+        now=batch.expires_at,
+        service_factory=_session_factory(db_session),
+        notifier=notifier,
+        revalidate_fn=_fake_noop_revalidate,
+    )
+
+    assert result == {"handled": False, "reason": "approval_batch_expired"}
+    assert notifier.edited[-1][1:] == (
+        555,
+        "⌛ 일괄 승인 만료",
+        {"inline_keyboard": []},
+    )
+
+
+@pytest.mark.asyncio
 async def test_batch_approve_continues_after_one_member_raises(monkeypatch, db_session):
     chat_id, now, groups, _batch, data = await _seed_approval_batch(
         db_session, monkeypatch, member_count=3
@@ -316,11 +339,56 @@ async def test_batch_approve_continues_after_one_member_raises(monkeypatch, db_s
 
 
 @pytest.mark.asyncio
-async def test_batch_click_rechecks_loss_cut_terminal_auto_and_superseded_exclusions(
+async def test_batch_approve_continues_after_member_result_audit_failure(
     monkeypatch, db_session
 ):
     chat_id, now, groups, _batch, data = await _seed_approval_batch(
-        db_session, monkeypatch, member_count=5
+        db_session, monkeypatch, member_count=3
+    )
+    group_ids = [group.proposal_id for group in groups]
+    notifier = _FakeNotifier()
+    revalidated: list[uuid.UUID] = []
+    audit_calls = 0
+    original_record = OrderProposalsService.record_approval_batch_member_result
+
+    async def flaky_record(self, member_id, **kwargs):
+        nonlocal audit_calls
+        audit_calls += 1
+        if audit_calls == 2:
+            raise RuntimeError("member result audit unavailable")
+        return await original_record(self, member_id, **kwargs)
+
+    monkeypatch.setattr(
+        OrderProposalsService, "record_approval_batch_member_result", flaky_record
+    )
+
+    async def fake_revalidate(*, service, proposal_id, now):
+        revalidated.append(proposal_id)
+        return [RungOutcome(0, "submitted_resting", {})]
+
+    result = await handle_callback_update(
+        _make_update(data=data, chat_id=chat_id),
+        now=now + timedelta(minutes=1),
+        service_factory=_session_factory(db_session),
+        notifier=notifier,
+        revalidate_fn=fake_revalidate,
+    )
+
+    assert result["handled"] is True
+    assert revalidated == group_ids
+    assert [item["status"] for item in result["results"]] == [
+        "approved",
+        "approved",
+        "approved",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_batch_click_rechecks_loss_terminal_auto_superseded_and_used_nonce(
+    monkeypatch, db_session
+):
+    chat_id, now, groups, _batch, data = await _seed_approval_batch(
+        db_session, monkeypatch, member_count=6
     )
     groups[0].exit_intent = "loss_cut"
     groups[1].lifecycle_state = "terminal"
@@ -329,6 +397,7 @@ async def test_batch_click_rechecks_loss_cut_terminal_auto_and_superseded_exclus
         "auto_approved": {"approved_at": now.isoformat()},
     }
     groups[3].lifecycle_state = "superseded"
+    groups[4].approval_nonce_used_at = now
     await db_session.commit()
     notifier = _FakeNotifier()
     calls: list[uuid.UUID] = []
@@ -345,8 +414,9 @@ async def test_batch_click_rechecks_loss_cut_terminal_auto_and_superseded_exclus
         revalidate_fn=fake_revalidate,
     )
 
-    assert calls == [groups[4].proposal_id]
+    assert calls == [groups[5].proposal_id]
     assert [item["status"] for item in result["results"]] == [
+        "skipped",
         "skipped",
         "skipped",
         "skipped",
@@ -405,6 +475,47 @@ async def test_batch_approve_keeps_rob861_reconfirm_member_independently_actiona
     summary = next(text for _chat, mid, text, _markup in notifier.edited if mid == 555)
     assert "재확인 필요" in summary
     assert "승인 완료" in summary
+
+
+@pytest.mark.asyncio
+async def test_batch_approve_classifies_rung_outcomes_without_false_success(
+    monkeypatch, db_session
+):
+    chat_id, now, groups, _batch, data = await _seed_approval_batch(
+        db_session, monkeypatch, member_count=4
+    )
+    group_ids = [group.proposal_id for group in groups]
+    notifier = _FakeNotifier()
+    outcomes = {
+        group_ids[0]: "guard_blocked",
+        group_ids[1]: "unverified",
+        group_ids[2]: "error",
+        group_ids[3]: "submitted_resting",
+    }
+
+    async def fake_revalidate(*, service, proposal_id, now):
+        return [RungOutcome(0, outcomes[proposal_id], {})]
+
+    result = await handle_callback_update(
+        _make_update(data=data, chat_id=chat_id),
+        now=now + timedelta(minutes=1),
+        service_factory=_session_factory(db_session),
+        notifier=notifier,
+        revalidate_fn=fake_revalidate,
+    )
+
+    assert [item["status"] for item in result["results"]] == [
+        "skipped",
+        "failed",
+        "failed",
+        "approved",
+    ]
+    assert [item.get("reason") for item in result["results"]] == [
+        "guard_blocked",
+        "unverified",
+        "error",
+        None,
+    ]
 
 
 def test_result_summary_includes_bounded_escaped_guard_reason():

--- a/tests/services/order_proposals/test_telegram_callback.py
+++ b/tests/services/order_proposals/test_telegram_callback.py
@@ -205,7 +205,7 @@ def _allow_chat(monkeypatch, chat_id=CHAT_ID):
     )
 
 
-async def _seed_approval_batch(db_session, monkeypatch, *, member_count=2):
+async def _seed_approval_batch(db_session, monkeypatch, *, member_count=2, rungs=1):
     chat_id = int(uuid.uuid4().hex[:8], 16)
     _allow_chat(monkeypatch, chat_id)
     now = datetime(2026, 7, 14, 1, 0, tzinfo=UTC)
@@ -217,6 +217,7 @@ async def _seed_approval_batch(db_session, monkeypatch, *, member_count=2):
             db_session,
             nonce=f"batch-member-{uuid.uuid4().hex}",
             symbol=f"B{index}",
+            rungs=rungs,
         )
         groups.append(group)
         registration = await service.register_approval_batch_member(
@@ -430,7 +431,7 @@ async def test_batch_approve_keeps_rob861_reconfirm_member_independently_actiona
     monkeypatch, db_session
 ):
     chat_id, now, groups, _batch, data = await _seed_approval_batch(
-        db_session, monkeypatch
+        db_session, monkeypatch, rungs=3
     )
     group_ids = [group.proposal_id for group in groups]
     original_nonce = groups[0].approval_nonce
@@ -447,10 +448,10 @@ async def test_batch_approve_keeps_rob861_reconfirm_member_independently_actiona
 
     async def fake_revalidate(*, service, proposal_id, now):
         if proposal_id == group_ids[0]:
-            await service.transition_rung(proposal_id, 0, new_state="revalidating")
-            await service.mark_needs_reconfirm(proposal_id, 0, now=now)
-            return [RungOutcome(0, "needs_reconfirm", detail)]
-        return [RungOutcome(0, "submitted_resting", {})]
+            await service.transition_rung(proposal_id, 2, new_state="revalidating")
+            await service.mark_needs_reconfirm(proposal_id, 2, now=now)
+            return [RungOutcome(2, "needs_reconfirm", detail)]
+        return [RungOutcome(1, "submitted_resting", {})]
 
     result = await handle_callback_update(
         _make_update(data=data, chat_id=chat_id),
@@ -464,17 +465,25 @@ async def test_batch_approve_keeps_rob861_reconfirm_member_independently_actiona
         "needs_reconfirm",
         "approved",
     ]
+    assert result["results"][0]["rung_results"] == [
+        {"rung_index": 2, "result": "needs_reconfirm"}
+    ]
+    assert result["results"][1]["rung_results"] == [
+        {"rung_index": 1, "result": "submitted_resting"}
+    ]
     service = OrderProposalsService(db_session)
     reconfirm_group, reconfirm_rungs = await service.get_proposal(group_ids[0])
     approved_group, _ = await service.get_proposal(group_ids[1])
     assert reconfirm_group.approval_nonce != original_nonce
     assert reconfirm_group.approval_nonce_used_at is None
-    assert reconfirm_rungs[0].state == "needs_reconfirm"
+    assert reconfirm_rungs[2].state == "needs_reconfirm"
     assert approved_group.approval_nonce_used_at is not None
     assert len(notifier.sent_messages) == 1
     summary = next(text for _chat, mid, text, _markup in notifier.edited if mid == 555)
     assert "재확인 필요" in summary
     assert "승인 완료" in summary
+    assert "#3 재확인 필요" in summary
+    assert "#2 주문 유지(대기)" in summary
 
 
 @pytest.mark.asyncio

--- a/tests/test_mcp_order_proposal_tools.py
+++ b/tests/test_mcp_order_proposal_tools.py
@@ -13,6 +13,12 @@ from app.services.order_proposals.errors import OrderProposalError
 from app.services.order_proposals.target_order import TargetOrderSnapshot
 
 
+def _unique_chat() -> str:
+    """Per-test chat id — batches scope by chat, so unique ids keep the
+    shared test DB's 10-minute batch windows from leaking across tests."""
+    return f"chat-{uuid.uuid4().hex[:10]}"
+
+
 class _FakeNotifier:
     def __init__(self, *, message_id: int | None = 4242) -> None:
         self.calls: list[tuple[str, dict, str]] = []
@@ -358,9 +364,8 @@ def test_create_docstring_documents_markets_aliases_and_account_modes():
 @pytest.mark.asyncio
 async def test_create_dispatches_telegram_when_enabled_and_allowlisted(monkeypatch):
     monkeypatch.setattr(settings, "ORDER_PROPOSALS_TELEGRAM_ENABLED", True)
-    monkeypatch.setattr(
-        settings, "ORDER_PROPOSALS_TELEGRAM_CHAT_ALLOWLIST_STR", "chat-1"
-    )
+    chat = _unique_chat()
+    monkeypatch.setattr(settings, "ORDER_PROPOSALS_TELEGRAM_CHAT_ALLOWLIST_STR", chat)
     fake_notifier = _FakeNotifier(message_id=9999)
     monkeypatch.setattr(
         "app.monitoring.trade_notifier.notifier.get_trade_notifier",
@@ -372,15 +377,14 @@ async def test_create_dispatches_telegram_when_enabled_and_allowlisted(monkeypat
     assert created["success"] is True
     assert len(fake_notifier.calls) == 1
     _, _, chat_id = fake_notifier.calls[0]
-    assert chat_id == "chat-1"
+    assert chat_id == chat
 
 
 @pytest.mark.asyncio
 async def test_supersede_edits_old_approval_message_and_removes_buttons(monkeypatch):
     monkeypatch.setattr(settings, "ORDER_PROPOSALS_TELEGRAM_ENABLED", True)
-    monkeypatch.setattr(
-        settings, "ORDER_PROPOSALS_TELEGRAM_CHAT_ALLOWLIST_STR", "chat-1"
-    )
+    chat = _unique_chat()
+    monkeypatch.setattr(settings, "ORDER_PROPOSALS_TELEGRAM_CHAT_ALLOWLIST_STR", chat)
     fake_notifier = _FakeNotifier(message_id=9999)
     monkeypatch.setattr(
         "app.monitoring.trade_notifier.notifier.get_trade_notifier",
@@ -407,7 +411,7 @@ async def test_supersede_edits_old_approval_message_and_removes_buttons(monkeypa
     assert replacement["success"] is True
     assert fake_notifier.edited == [
         (
-            "chat-1",
+            chat,
             9999,
             f"🔁 → {replacement['proposal_id'][:8]}로 대체됨",
             {"inline_keyboard": []},
@@ -418,9 +422,8 @@ async def test_supersede_edits_old_approval_message_and_removes_buttons(monkeypa
 @pytest.mark.asyncio
 async def test_supersede_message_edit_setup_failure_is_best_effort(monkeypatch):
     monkeypatch.setattr(settings, "ORDER_PROPOSALS_TELEGRAM_ENABLED", True)
-    monkeypatch.setattr(
-        settings, "ORDER_PROPOSALS_TELEGRAM_CHAT_ALLOWLIST_STR", "chat-1"
-    )
+    chat = _unique_chat()
+    monkeypatch.setattr(settings, "ORDER_PROPOSALS_TELEGRAM_CHAT_ALLOWLIST_STR", chat)
     fake_notifier = _FakeNotifier(message_id=9998)
     monkeypatch.setattr(
         "app.monitoring.trade_notifier.notifier.get_trade_notifier",
@@ -444,9 +447,8 @@ async def test_supersede_message_edit_setup_failure_is_best_effort(monkeypatch):
 @pytest.mark.asyncio
 async def test_create_does_not_dispatch_when_telegram_disabled(monkeypatch):
     monkeypatch.setattr(settings, "ORDER_PROPOSALS_TELEGRAM_ENABLED", False)
-    monkeypatch.setattr(
-        settings, "ORDER_PROPOSALS_TELEGRAM_CHAT_ALLOWLIST_STR", "chat-1"
-    )
+    chat = _unique_chat()
+    monkeypatch.setattr(settings, "ORDER_PROPOSALS_TELEGRAM_CHAT_ALLOWLIST_STR", chat)
     fake_notifier = _FakeNotifier()
     monkeypatch.setattr(
         "app.monitoring.trade_notifier.notifier.get_trade_notifier",
@@ -478,9 +480,8 @@ async def test_create_does_not_dispatch_when_allowlist_empty(monkeypatch):
 @pytest.mark.asyncio
 async def test_create_succeeds_even_when_notifier_raises(monkeypatch):
     monkeypatch.setattr(settings, "ORDER_PROPOSALS_TELEGRAM_ENABLED", True)
-    monkeypatch.setattr(
-        settings, "ORDER_PROPOSALS_TELEGRAM_CHAT_ALLOWLIST_STR", "chat-1"
-    )
+    chat = _unique_chat()
+    monkeypatch.setattr(settings, "ORDER_PROPOSALS_TELEGRAM_CHAT_ALLOWLIST_STR", chat)
     monkeypatch.setattr(
         "app.monitoring.trade_notifier.notifier.get_trade_notifier",
         lambda: _RaisingNotifier(),
@@ -615,6 +616,7 @@ async def test_void_unverified_uses_broker_evidence_and_disables_telegram_button
 ):
     from app.services.order_proposals.broker_gateway import OperatorVoidEvidence
 
+    chat = _unique_chat()
     created = await opt.order_proposal_create(
         **_create_kwargs(account_mode="toss_live")
     )
@@ -634,7 +636,7 @@ async def test_void_unverified_uses_broker_evidence_and_disables_telegram_button
         await service.record_approval_dispatch(
             proposal_id,
             message_id=4242,
-            chat_id="chat-1",
+            chat_id=chat,
             now=now,
         )
         await session.commit()
@@ -657,7 +659,7 @@ async def test_void_unverified_uses_broker_evidence_and_disables_telegram_button
     assert "outcome=absent" in result["void_reason"]
     assert notifier.edited == [
         (
-            "chat-1",
+            chat,
             4242,
             "🗑️ 제안 무효화됨\n사유: " + result["void_reason"].replace("_", "\\_"),
             {"inline_keyboard": []},


### PR DESCRIPTION
## Summary

- Add Telegram batch approval for eligible manual order proposals while preserving each proposal's existing nonce, audit, revalidation, and ROB-861 reconfirmation flow.
- Persist immutable batch membership and process members independently, so one failure does not stop the remaining proposals.
- Publish editable batch summaries with account subtotals, limit-order notional estimates, per-rung terminal results, and replay/expiry protection.
- Add the approval-batch migration, service/repository coverage, operator runbook, and an Unreleased changelog entry.

## Why this remains worth building

Production DB canonical for the 2026-07-13 US session, after ROB-869 supersession handling:

| Population / exclusive reason | Groups | Rungs | Interpretation |
| --- | ---: | ---: | --- |
| Raw proposals | 19 | 20 | Before ROB-869 cleanup |
| ROB-869 superseded exclusion | 3 | 3 | Removed from the valid population |
| Valid population | 16 | 17 | Source of truth for this PR |
| ROB-871 auto-approval candidates | 3 | 3 | Counterfactual automatic share |
| Per-order cap over $150 | 9 | 9 | Conservative canary seed; expected to shrink as the cap rises |
| Distance under 3% | 3 | 3 | Structural manual share |
| Replace/cancel action | 0 | 0 | Structural class, absent in this session |
| Other: multi-rung all-or-human | 1 | 2 | Structural manual share |
| **Manual remainder** | **13** | **14** | Exclusive-reason total |

The implementation value is not based on the temporary `$150` cap overflow. Excluding cap overflow still leaves a structural floor of **4 groups / 5 rungs** in this session, and gate-off periods return the entire valid population (**16 groups / 17 rungs**) to manual approval. The durable use cases are immediate/non-resting orders, replace/cancel actions, multi-rung all-or-human handling, and gate-off fallback.

## Safety contract

- A batch is scoped to one Telegram chat and a fixed 10-minute window, bounded by the earliest member validity.
- Membership snapshots the proposal approval nonce; the batch trigger is consumed atomically and cannot be replayed.
- Click-time exclusions cover terminal, superseded, auto-approved, expired, already-used, and no-longer-pending proposals.
- Each member still uses the single-proposal approval path and is independently revalidated/audited.
- Partial failures continue; terminal summaries distinguish approved, reconfirm-required, skipped, and failed outcomes.
- Summary membership/claims commit before Telegram publication; expired callbacks remove the keyboard.

## Test coverage

Focused ROB-870 path coverage audit: **88%**.

```text
manual dispatch
  ├─ first member ─────────────────── covered
  ├─ committed second-member summary covered
  └─ later summary edit ───────────── covered
                    │
                    ▼
batch callback → atomic trigger → isolated members → terminal summary
                    ├─ success ─────── covered
                    ├─ replay ──────── covered
                    ├─ TTL/boundary ── covered
                    ├─ exclusions ──── covered
                    ├─ partial error ─ covered
                    └─ ROB-861 ─────── covered
```

Non-blocking residual test gaps: forced Telegram summary-delivery lease retry, true two-session registration concurrency, ambiguous prefix/not-found callbacks, rotated-nonce persistence bounds, and migration upgrade/downgrade DDL smoke.

## Verification

- `uv run pytest tests/services/order_proposals/ -q` — 403 passed
- `make lint` — Ruff check, Ruff format check, and ty passed
- `uv run alembic heads` — single head: `20260714_rob870_approval_batches`
- Independent pre-landing review found no remaining Critical, Important, or Minor findings after the race/error-path fixes.

## Rollout

1. Apply Alembic migration `20260714_rob870_approval_batches`.
2. Deploy API/worker processes together.
3. Monitor batch creation, exclusion reasons, partial failures, and Telegram summary publication.
4. Keep per-order auto-approval cap tuning independent from this structural batch-approval path.

Linear: ROB-870


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Telegram manual batch approval for related order proposals within a fixed time window.
  * Added a single batch approval button with aggregated proposal details and totals.
  * Added per-proposal results for approved, reconfirmation, skipped, and failed items.
  * Batch processing continues independently when individual proposals fail.

* **Bug Fixes**
  * Added safeguards against expired or replayed batch approvals and preserves existing order validation checks.

* **Documentation**
  * Updated the order-proposals runbook with batch approval workflows, troubleshooting, and verification guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->