### PR TITLE
feat(ROB-880): 회고 액션 canonical cutover — repository/save projection/read API

### DIFF
--- a/app/mcp_server/caller_identity.py
+++ b/app/mcp_server/caller_identity.py
@@ -15,6 +15,10 @@ caller_source_var: ContextVar[CallerSource] = ContextVar(
     "mcp_caller_source",
     default="none",
 )
+caller_argument_names_var: ContextVar[frozenset[str] | None] = ContextVar(
+    "mcp_caller_argument_names",
+    default=None,
+)
 
 
 def get_caller_agent_id() -> str | None:
@@ -25,3 +29,8 @@ def get_caller_agent_id() -> str | None:
 def get_caller_source() -> CallerSource:
     """Return the source used to resolve the current MCP caller identity."""
     return caller_source_var.get()
+
+
+def get_caller_argument_names() -> frozenset[str] | None:
+    """Return raw MCP argument names, preserving omitted-vs-explicit-null."""
+    return caller_argument_names_var.get()

--- a/app/mcp_server/caller_identity_middleware.py
+++ b/app/mcp_server/caller_identity_middleware.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from fastmcp.server.dependencies import get_http_request
 from fastmcp.server.middleware import Middleware
@@ -11,6 +11,7 @@ from app.core.config import settings
 from app.mcp_server.caller_identity import (
     CallerSource,
     caller_agent_id_var,
+    caller_argument_names_var,
     caller_source_var,
 )
 
@@ -62,8 +63,15 @@ class CallerIdentityMiddleware(Middleware):
         caller_agent_id, caller_source = _resolve_caller_identity()
         agent_id_token = caller_agent_id_var.set(caller_agent_id)
         source_token = caller_source_var.set(caller_source)
+        raw_arguments: Any = getattr(context.message, "arguments", None)
+        argument_names_token = caller_argument_names_var.set(
+            frozenset(raw_arguments.keys())
+            if isinstance(raw_arguments, dict)
+            else frozenset()
+        )
         try:
             return await call_next(context)
         finally:
+            caller_argument_names_var.reset(argument_names_token)
             caller_source_var.reset(source_token)
             caller_agent_id_var.reset(agent_id_token)

--- a/app/mcp_server/tooling/trade_retrospective_registration.py
+++ b/app/mcp_server/tooling/trade_retrospective_registration.py
@@ -41,8 +41,10 @@ def register_trade_retrospective_tools(mcp: Any) -> None:
             "expired, thesis_change, policy_violation, stale_evidence, "
             "guardrail_block, stop_loss}. When trigger_type is set, a non-empty next_actions "
             "list is required in the same call (each next_action needs a non-empty "
-            "action; optional owner/issue_id/status/due_kst_date, status in "
-            "{open, in_progress, done})."
+            "action; optional owner/issue_id/status/due_kst_date). New actions may start "
+            "only as open or in_progress. Echo action_id and version when retrying an "
+            "existing canonical action. To intentionally create a distinct occurrence, "
+            "pass force_new=true with a stable creation_key for idempotent retries."
         ),
     )(save_trade_retrospective)
     _ = mcp.tool(

--- a/app/mcp_server/tooling/trade_retrospective_tools.py
+++ b/app/mcp_server/tooling/trade_retrospective_tools.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import logging
+import os
 from datetime import timedelta
 from typing import Any, cast
 
@@ -11,6 +12,11 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from app.core.db import AsyncSessionLocal
 from app.core.timezone import now_kst
+from app.mcp_server.caller_identity import get_caller_argument_names
+from app.mcp_server.profiles import resolve_mcp_profile
+from app.services.trade_journal.retrospective_action_repository import (
+    RetrospectiveActionRepository,
+)
 from app.services.trade_journal.trade_retrospective_service import (
     RetrospectiveValidationError,
     build_retrospective_aggregate,
@@ -21,6 +27,16 @@ from app.services.trade_journal.trade_retrospective_service import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _mcp_argument_was_provided(name: str, value: Any) -> bool:
+    """Preserve omitted-vs-explicit-null at the FastMCP function boundary."""
+    argument_names = get_caller_argument_names()
+    if argument_names is None:
+        # Direct Python callers have no middleware context; retain the existing
+        # convention that None means omitted for those callers.
+        return value is not None
+    return name in argument_names
 
 
 def _session_factory() -> async_sessionmaker[AsyncSession]:
@@ -77,60 +93,75 @@ async def save_trade_retrospective(
     # an idempotent re-save that omits them preserves prior values (the service
     # distinguishes omitted from explicit-None via a sentinel).
     postmortem: dict[str, Any] = {}
-    if trigger_type is not None:
+    if _mcp_argument_was_provided("trigger_type", trigger_type):
         postmortem["trigger_type"] = trigger_type
-    if root_cause_class is not None:
+    if _mcp_argument_was_provided("root_cause_class", root_cause_class):
         postmortem["root_cause_class"] = root_cause_class
-    if intended_vs_happened is not None:
+    if _mcp_argument_was_provided("intended_vs_happened", intended_vs_happened):
         postmortem["intended_vs_happened"] = intended_vs_happened
-    if next_actions is not None:
+    if _mcp_argument_was_provided("next_actions", next_actions):
         postmortem["next_actions"] = next_actions
-    if guardrail_fired is not None:
+    if _mcp_argument_was_provided("guardrail_fired", guardrail_fired):
         postmortem["guardrail_fired"] = guardrail_fired
-    if policy_version is not None:
+    if _mcp_argument_was_provided("policy_version", policy_version):
         postmortem["policy_version"] = policy_version
+    save_kwargs: dict[str, Any] = {
+        "symbol": symbol,
+        "instrument_type": instrument_type,
+        "account_mode": account_mode,
+        "outcome": outcome,
+        "actor": f"mcp:{resolve_mcp_profile(os.getenv('MCP_PROFILE')).value}",
+    }
+    optional_values = {
+        "side": side,
+        "market": market,
+        "strategy_key": strategy_key,
+        "correlation_id": correlation_id,
+        "journal_id": journal_id,
+        "report_uuid": report_uuid,
+        "report_item_uuid": report_item_uuid,
+        "plan_price": plan_price,
+        "fill_price": fill_price,
+        "realized_pnl": realized_pnl,
+        "realized_pnl_currency": realized_pnl_currency,
+        "pnl_pct": pnl_pct,
+        "rationale": rationale,
+        "result_summary": result_summary,
+        "lesson": lesson,
+        "next_strategy": next_strategy,
+        "evidence_snapshot": evidence_snapshot,
+        "created_by_profile": created_by_profile,
+        "buy_fx_rate": buy_fx_rate,
+        "sell_fx_rate": sell_fx_rate,
+        "fx_pnl_krw": fx_pnl_krw,
+        "security_pnl_usd": security_pnl_usd,
+        "security_pnl_krw": security_pnl_krw,
+        "total_pnl_krw": total_pnl_krw,
+        "fx_rate_source": fx_rate_source,
+        "fx_pnl_accuracy": fx_pnl_accuracy,
+    }
+    save_kwargs.update(
+        {
+            key: value
+            for key, value in optional_values.items()
+            if _mcp_argument_was_provided(key, value)
+        }
+    )
+    save_kwargs.update(postmortem)
     try:
         async with _session_factory()() as db:
-            action, row = await save_retrospective(
-                db,
-                symbol=symbol,
-                instrument_type=instrument_type,
-                account_mode=account_mode,
-                outcome=outcome,
-                side=side,
-                market=market,
-                strategy_key=strategy_key,
-                correlation_id=correlation_id,
-                journal_id=journal_id,
-                report_uuid=report_uuid,
-                report_item_uuid=report_item_uuid,
-                plan_price=plan_price,
-                fill_price=fill_price,
-                realized_pnl=realized_pnl,
-                realized_pnl_currency=realized_pnl_currency,
-                pnl_pct=pnl_pct,
-                rationale=rationale,
-                result_summary=result_summary,
-                lesson=lesson,
-                next_strategy=next_strategy,
-                evidence_snapshot=evidence_snapshot,
-                created_by_profile=created_by_profile,
-                buy_fx_rate=buy_fx_rate,
-                sell_fx_rate=sell_fx_rate,
-                fx_pnl_krw=fx_pnl_krw,
-                security_pnl_usd=security_pnl_usd,
-                security_pnl_krw=security_pnl_krw,
-                total_pnl_krw=total_pnl_krw,
-                fx_rate_source=fx_rate_source,
-                fx_pnl_accuracy=fx_pnl_accuracy,
-                **postmortem,
-            )
+            action, row = await save_retrospective(db, **save_kwargs)
             await db.commit()
             await db.refresh(row)
+            next_actions_data = await RetrospectiveActionRepository(db).read_actions(
+                row.id
+            )
             return {
                 "success": True,
                 "action": action,
-                "data": serialize_retrospective(row),
+                "data": serialize_retrospective(
+                    row, next_actions_override=next_actions_data
+                ),
             }
     except RetrospectiveValidationError as exc:
         return {"success": False, "error": str(exc)}

--- a/app/mcp_server/tooling/trade_retrospective_tools.py
+++ b/app/mcp_server/tooling/trade_retrospective_tools.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import logging
-import os
 from datetime import timedelta
 from typing import Any, cast
 
@@ -13,6 +12,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from app.core.db import AsyncSessionLocal
 from app.core.timezone import now_kst
 from app.mcp_server.caller_identity import get_caller_argument_names
+from app.mcp_server.env_utils import _env
 from app.mcp_server.profiles import resolve_mcp_profile
 from app.services.trade_journal.retrospective_action_repository import (
     RetrospectiveActionRepository,
@@ -110,7 +110,7 @@ async def save_trade_retrospective(
         "instrument_type": instrument_type,
         "account_mode": account_mode,
         "outcome": outcome,
-        "actor": f"mcp:{resolve_mcp_profile(os.getenv('MCP_PROFILE')).value}",
+        "actor": f"mcp:{resolve_mcp_profile(_env('MCP_PROFILE')).value}",
     }
     optional_values = {
         "side": side,
@@ -151,17 +151,19 @@ async def save_trade_retrospective(
     try:
         async with _session_factory()() as db:
             action, row = await save_retrospective(db, **save_kwargs)
-            await db.commit()
             await db.refresh(row)
             next_actions_data = await RetrospectiveActionRepository(db).read_actions(
                 row.id
             )
+            data = serialize_retrospective(
+                row,
+                next_actions_override=next_actions_data,
+            )
+            await db.commit()
             return {
                 "success": True,
                 "action": action,
-                "data": serialize_retrospective(
-                    row, next_actions_override=next_actions_data
-                ),
+                "data": data,
             }
     except RetrospectiveValidationError as exc:
         return {"success": False, "error": str(exc)}

--- a/app/routers/invest_retrospectives.py
+++ b/app/routers/invest_retrospectives.py
@@ -31,10 +31,14 @@ from app.schemas.invest_retrospectives import (
     ScoreboardTotals,
 )
 from app.schemas.trade_retrospective import (
+    VALID_NEXT_ACTION_STATUSES,
     VALID_ROOT_CAUSE_CLASSES,
     VALID_TRIGGER_TYPES,
 )
 from app.services.trade_journal import trade_retrospective_service as retro_svc
+from app.services.trade_journal.retrospective_action_repository import (
+    ActionControlError,
+)
 from app.services.trade_journal.trade_retrospective_service import (
     VALID_OUTCOME_FILTERS,
 )
@@ -63,12 +67,49 @@ def _parse_kst_date(label: str, value: str | None) -> str | None:
     if value is None:
         return None
     try:
-        datetime.strptime(value, "%Y-%m-%d")
+        parsed = datetime.strptime(value, "%Y-%m-%d")
     except ValueError as exc:
         raise HTTPException(
             status_code=422, detail=f"invalid {label}: {value} (expected YYYY-MM-DD)"
         ) from exc
+    if parsed.date().isoformat() != value:
+        raise HTTPException(
+            status_code=422, detail=f"invalid {label}: {value} (expected YYYY-MM-DD)"
+        )
     return value
+
+
+def _parse_action_statuses(value: str | None) -> frozenset[str] | None:
+    if value is None:
+        return None
+    statuses = frozenset(part.strip() for part in value.split(",") if part.strip())
+    invalid = statuses - VALID_NEXT_ACTION_STATUSES
+    if not statuses or invalid:
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                f"invalid status: {value} "
+                f"(allowed: {sorted(VALID_NEXT_ACTION_STATUSES)})"
+            ),
+        )
+    return statuses
+
+
+def _parse_legacy_action_statuses(value: str | None) -> frozenset[str] | None:
+    """Translate the legacy alias vocabulary to canonical lifecycle states."""
+    if value is None:
+        return None
+    legacy_allowed = frozenset({"open", "in_progress", "done"})
+    requested = frozenset(part.strip() for part in value.split(",") if part.strip())
+    invalid = requested - legacy_allowed
+    if not requested or invalid:
+        raise HTTPException(
+            status_code=422,
+            detail=f"invalid status: {value} (allowed: {sorted(legacy_allowed)})",
+        )
+    if "done" in requested:
+        return (requested - {"done"}) | {"done", "obsolete", "expired"}
+    return requested
 
 
 @router.get("")
@@ -105,20 +146,23 @@ async def list_retrospectives(
     date_from = _parse_kst_date("kst_date_from", kst_date_from)
     date_to = _parse_kst_date("kst_date_to", kst_date_to)
     db_symbol = _normalize_symbol(symbol, market)
-    result = await retro_svc.get_retrospectives(
-        db,
-        market=None if market == "all" else market,
-        trigger_type=trigger_type,
-        root_cause_class=root_cause_class,
-        symbol=db_symbol,
-        outcome_filter=outcome_filter,
-        symbol_search=q,
-        kst_date_from=date_from,
-        kst_date_to=date_to,
-        days=days,
-        limit=limit,
-        offset=offset,
-    )
+    try:
+        result = await retro_svc.get_retrospectives(
+            db,
+            market=None if market == "all" else market,
+            trigger_type=trigger_type,
+            root_cause_class=root_cause_class,
+            symbol=db_symbol,
+            outcome_filter=outcome_filter,
+            symbol_search=q,
+            kst_date_from=date_from,
+            kst_date_to=date_to,
+            days=days,
+            limit=limit,
+            offset=offset,
+        )
+    except ActionControlError as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
     summary = result["summary"]
     return RetrospectivesResponse(
         market=market,
@@ -214,16 +258,17 @@ async def list_open_next_actions(
     symbol: Annotated[str | None, Query()] = None,
     status: Annotated[str | None, Query()] = None,
 ) -> NextActionsResponse:
-    statuses = (
-        frozenset(s.strip() for s in status.split(",") if s.strip()) if status else None
-    )
+    statuses = _parse_legacy_action_statuses(status)
     db_symbol = _normalize_symbol(symbol, market)
-    result = await retro_svc.get_open_next_actions(
-        db,
-        market=None if market == "all" else market,
-        symbol=db_symbol,
-        statuses=statuses,
-    )
+    try:
+        result = await retro_svc.get_open_next_actions(
+            db,
+            market=None if market == "all" else market,
+            symbol=db_symbol,
+            statuses=statuses,
+        )
+    except ActionControlError as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
     return NextActionsResponse(
         market=market,
         symbol=db_symbol,
@@ -248,6 +293,7 @@ async def list_canonical_actions(
     outcome_filter: Annotated[str | None, Query()] = None,
     kst_date_from: Annotated[str | None, Query()] = None,
     kst_date_to: Annotated[str | None, Query()] = None,
+    due_before: Annotated[str | None, Query()] = None,
     limit: Annotated[int, Query(ge=1, le=200)] = 50,
     offset: Annotated[int, Query(ge=0)] = 0,
 ) -> CanonicalActionsResponse:
@@ -266,28 +312,31 @@ async def list_canonical_actions(
         )
     date_from = _parse_kst_date("kst_date_from", kst_date_from)
     date_to = _parse_kst_date("kst_date_to", kst_date_to)
+    due_before_date = _parse_kst_date("due_before", due_before)
     db_symbol = _normalize_symbol(symbol, market)
 
-    statuses = (
-        frozenset(s.strip() for s in status.split(",") if s.strip()) if status else None
-    )
+    statuses = _parse_action_statuses(status)
 
-    result = await retro_svc.get_canonical_actions(
-        db,
-        statuses=statuses,
-        market=None if market == "all" else market,
-        symbol=db_symbol,
-        symbol_search=q,
-        owner=owner,
-        issue_id=issue_id,
-        overdue_only=overdue_only,
-        trigger_type=trigger_type,
-        outcome_filter=outcome_filter,
-        kst_date_from=date_from,
-        kst_date_to=date_to,
-        limit=limit,
-        offset=offset,
-    )
+    try:
+        result = await retro_svc.get_canonical_actions(
+            db,
+            statuses=statuses,
+            market=None if market == "all" else market,
+            symbol=db_symbol,
+            symbol_search=q,
+            owner=owner,
+            issue_id=issue_id,
+            overdue_only=overdue_only,
+            trigger_type=trigger_type,
+            outcome_filter=outcome_filter,
+            kst_date_from=date_from,
+            kst_date_to=date_to,
+            due_before=due_before_date,
+            limit=limit,
+            offset=offset,
+        )
+    except ActionControlError as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
     return CanonicalActionsResponse(
         total=result["total"],
         count=result["count"],

--- a/app/routers/invest_retrospectives.py
+++ b/app/routers/invest_retrospectives.py
@@ -20,6 +20,8 @@ from app.core.symbol import to_db_symbol
 from app.models.trading import User
 from app.routers.dependencies import get_authenticated_user
 from app.schemas.invest_retrospectives import (
+    CanonicalActionRow,
+    CanonicalActionsResponse,
     NextActionRow,
     NextActionsResponse,
     RetrospectiveRow,
@@ -228,4 +230,69 @@ async def list_open_next_actions(
         count=result["count"],
         scan_limit=result["scan_limit"],
         items=[NextActionRow(**i) for i in result["items"]],
+    )
+
+
+@router.get("/actions")
+async def list_canonical_actions(
+    _user: Annotated[User, Depends(get_authenticated_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
+    status: Annotated[str | None, Query()] = None,
+    market: Annotated[Market, Query()] = "all",
+    symbol: Annotated[str | None, Query()] = None,
+    q: Annotated[str | None, Query(max_length=32)] = None,
+    owner: Annotated[str | None, Query()] = None,
+    issue_id: Annotated[str | None, Query()] = None,
+    overdue_only: Annotated[bool, Query()] = False,
+    trigger_type: Annotated[str | None, Query()] = None,
+    outcome_filter: Annotated[str | None, Query()] = None,
+    kst_date_from: Annotated[str | None, Query()] = None,
+    kst_date_to: Annotated[str | None, Query()] = None,
+    limit: Annotated[int, Query(ge=1, le=200)] = 50,
+    offset: Annotated[int, Query(ge=0)] = 0,
+) -> CanonicalActionsResponse:
+    """Canonical paginated action list with overdue-first ordering.
+
+    Omitted status defaults to open,in_progress (active only).
+    Terminal history requires an explicit status filter.
+    """
+    if trigger_type is not None and trigger_type not in VALID_TRIGGER_TYPES:
+        raise HTTPException(
+            status_code=422, detail=f"invalid trigger_type: {trigger_type}"
+        )
+    if outcome_filter is not None and outcome_filter not in VALID_OUTCOME_FILTERS:
+        raise HTTPException(
+            status_code=422, detail=f"invalid outcome_filter: {outcome_filter}"
+        )
+    date_from = _parse_kst_date("kst_date_from", kst_date_from)
+    date_to = _parse_kst_date("kst_date_to", kst_date_to)
+    db_symbol = _normalize_symbol(symbol, market)
+
+    statuses = (
+        frozenset(s.strip() for s in status.split(",") if s.strip()) if status else None
+    )
+
+    result = await retro_svc.get_canonical_actions(
+        db,
+        statuses=statuses,
+        market=None if market == "all" else market,
+        symbol=db_symbol,
+        symbol_search=q,
+        owner=owner,
+        issue_id=issue_id,
+        overdue_only=overdue_only,
+        trigger_type=trigger_type,
+        outcome_filter=outcome_filter,
+        kst_date_from=date_from,
+        kst_date_to=date_to,
+        limit=limit,
+        offset=offset,
+    )
+    return CanonicalActionsResponse(
+        total=result["total"],
+        count=result["count"],
+        limit=result["limit"],
+        offset=result["offset"],
+        as_of=result["as_of"],
+        items=[CanonicalActionRow(**item) for item in result["items"]],
     )

--- a/app/schemas/invest_retrospectives.py
+++ b/app/schemas/invest_retrospectives.py
@@ -116,6 +116,8 @@ class NextActionRow(BaseModel):
     trigger_type: str | None = None
     realized_pnl: float | None = None
     created_at: str | None = None
+    action_id: str | None = None
+    version: int | None = None
 
 
 class NextActionsResponse(BaseModel):
@@ -126,3 +128,39 @@ class NextActionsResponse(BaseModel):
     count: int = Field(ge=0)
     scan_limit: int = Field(ge=0)
     items: list[NextActionRow]
+
+
+class CanonicalActionRow(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    action_id: str
+    version: int
+    action: str
+    owner: str | None = None
+    issue_id: str | None = None
+    status: str
+    due_kst_date: str | None = None
+    overdue: bool = False
+    status_changed_at: str | None = None
+    resolved_at: str | None = None
+    status_actor: str | None = None
+    status_source: str | None = None
+    retrospective_id: int
+    correlation_id: str | None = None
+    symbol: str | None = None
+    market: str | None = None
+    trigger_type: str | None = None
+    outcome: str | None = None
+    realized_pnl: float | None = None
+    created_at: str | None = None
+
+
+class CanonicalActionsResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    total: int = Field(ge=0)
+    count: int = Field(ge=0)
+    limit: int = Field(ge=1, le=200)
+    offset: int = Field(ge=0)
+    as_of: datetime
+    items: list[CanonicalActionRow]

--- a/app/schemas/invest_retrospectives.py
+++ b/app/schemas/invest_retrospectives.py
@@ -118,6 +118,8 @@ class NextActionRow(BaseModel):
     created_at: str | None = None
     action_id: str | None = None
     version: int | None = None
+    overdue: bool = False
+    terminal_status: str | None = None
 
 
 class NextActionsResponse(BaseModel):
@@ -145,6 +147,7 @@ class CanonicalActionRow(BaseModel):
     resolved_at: str | None = None
     status_actor: str | None = None
     status_source: str | None = None
+    status_reason: str | None = None
     retrospective_id: int
     correlation_id: str | None = None
     symbol: str | None = None

--- a/app/schemas/trade_retrospective.py
+++ b/app/schemas/trade_retrospective.py
@@ -11,7 +11,9 @@ through them and raises ``RetrospectiveValidationError`` on any violation.
 
 from __future__ import annotations
 
+from datetime import date, datetime
 from typing import Any
+from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
@@ -45,7 +47,9 @@ VALID_ROOT_CAUSE_CLASSES: frozenset[str] = frozenset(
     }
 )
 
-_VALID_NEXT_ACTION_STATUS: frozenset[str] = frozenset({"open", "in_progress", "done"})
+VALID_NEXT_ACTION_STATUSES: frozenset[str] = frozenset(
+    {"open", "in_progress", "done", "obsolete", "expired"}
+)
 
 
 class Deviation(BaseModel):
@@ -99,13 +103,32 @@ class NextAction(BaseModel):
     creation is the caller/session's job; the repo never adds a Linear API client.
     """
 
-    model_config = ConfigDict(extra="forbid")
+    # Historical next_action objects may carry extension keys. Canonical reads
+    # must preserve those keys so a fetched parent payload can be submitted
+    # unchanged. Canonical audit fields are accepted below but excluded from
+    # writes because they are repository-owned.
+    model_config = ConfigDict(extra="allow")
 
+    action_id: UUID | None = None
+    version: int | None = Field(default=None, ge=1)
     action: str
     owner: str | None = None
     issue_id: str | None = None
     status: str | None = None
-    due_kst_date: str | None = None
+    due_kst_date: date | None = None
+    force_new: bool = False
+    creation_key: UUID | None = None
+    position: int | None = Field(default=None, ge=0, exclude=True)
+    overdue: bool | None = Field(default=None, exclude=True)
+    terminal_status: str | None = Field(default=None, exclude=True)
+    status_changed_at: datetime | None = Field(default=None, exclude=True)
+    resolved_at: datetime | None = Field(default=None, exclude=True)
+    status_actor: str | None = Field(default=None, exclude=True)
+    status_source: str | None = Field(default=None, exclude=True)
+    status_reason: str | None = Field(default=None, exclude=True)
+    status_evidence: dict[str, Any] | None = Field(default=None, exclude=True)
+    created_at: datetime | None = Field(default=None, exclude=True)
+    updated_at: datetime | None = Field(default=None, exclude=True)
 
     @field_validator("action")
     @classmethod
@@ -120,8 +143,23 @@ class NextAction(BaseModel):
     def _status_allowed(cls, v: str | None) -> str | None:
         if v is None:
             return None
-        if v not in _VALID_NEXT_ACTION_STATUS:
+        if v not in VALID_NEXT_ACTION_STATUSES:
             raise ValueError(
-                f"invalid status: {v} (allowed: {sorted(_VALID_NEXT_ACTION_STATUS)})"
+                f"invalid status: {v} (allowed: {sorted(VALID_NEXT_ACTION_STATUSES)})"
             )
         return v
+
+    @model_validator(mode="after")
+    def _creation_controls_are_consistent(self) -> NextAction:
+        if self.action_id is not None:
+            if self.force_new:
+                raise ValueError("action_id cannot be combined with force_new")
+            # A persisted creation_key is echoed with action_id in canonical
+            # projections so a full parent payload can be safely round-tripped.
+            return self
+        if self.force_new and self.creation_key is None:
+            raise ValueError("creation_key is required when force_new is true")
+        # A shadow projection persists the stable key but strips the transient
+        # force_new intent. Allow that payload to round-trip; canonical
+        # reconciliation still requires force_new for key-only create requests.
+        return self

--- a/app/services/trade_journal/retrospective_action_repository.py
+++ b/app/services/trade_journal/retrospective_action_repository.py
@@ -1121,10 +1121,17 @@ async def _validate_cutover_input(conn: AsyncConnection) -> None:
             if not isinstance(action, str) or not action.strip():
                 raise CutoverParityError(f"{prefix}: blank action")
 
-            if "force_new" in item:
-                raise CutoverParityError(
-                    f"{prefix}: force_new is transport-only and must not be persisted"
-                )
+            for reserved_field in (
+                "force_new",
+                "terminal_status",
+                "action_id",
+                "version",
+            ):
+                if reserved_field in item:
+                    raise CutoverParityError(
+                        f"{prefix}: {reserved_field} is canonical/transport-only "
+                        "and must not be persisted in shadow mode"
+                    )
 
             raw_creation_key = item.get("creation_key")
             if "creation_key" in item:

--- a/app/services/trade_journal/retrospective_action_repository.py
+++ b/app/services/trade_journal/retrospective_action_repository.py
@@ -1,0 +1,909 @@
+"""ROB-878 child-2 — control-mode retrospective action repository.
+
+This module is the single boundary between the application and retrospective
+action storage. In ``shadow`` mode it delegates to the legacy JSONB
+reader/writer. In ``canonical`` mode it reads from the child ledger and writes
+the compatibility projection to parent JSONB under the GUC marker.
+
+Key contracts:
+- Control row is DB authority; missing/unknown mode fails closed.
+- Parent is locked before children (FOR UPDATE, ORDER BY id).
+- Projection starts from legacy_payload, overlays canonical fields, preserves
+  unknown keys and display order.
+- obsolete/expired project as legacy status=done + additive terminal_status.
+- Canonical new actions may only start as open/in_progress.
+- Actor is derived from authenticated identity, not caller payload.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import UTC, date, datetime
+from typing import Any
+
+from sqlalchemy import and_, func, select, text
+from sqlalchemy.ext.asyncio import AsyncConnection, AsyncSession
+
+from app.core.timezone import now_kst
+from app.models.review import (
+    TradeRetrospective,
+    TradeRetrospectiveAction,
+    TradeRetrospectiveActionControl,
+)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_ACTIVE_STATUSES = frozenset({"open", "in_progress"})
+_TERMINAL_STATUSES = frozenset({"done", "obsolete", "expired"})
+_VALID_INITIAL_STATUSES = frozenset({"open", "in_progress"})
+_GUC_MARKER = "app.retrospective_action_projection_writer"
+_GUC_VALUE = "v1"
+_CUTOVER_ADVISORY_LOCK_ID = 878_880_001
+
+# Fields that the projection overlays from canonical state onto legacy_payload.
+_CANONICAL_OVERLAY_FIELDS = (
+    "action",
+    "owner",
+    "issue_id",
+    "status",
+    "due_kst_date",
+)
+
+
+# ---------------------------------------------------------------------------
+# Errors
+# ---------------------------------------------------------------------------
+
+
+class ActionControlError(RuntimeError):
+    """Control row missing or invalid — writes fail closed."""
+
+
+class ActionReconcileError(ValueError):
+    """Save reconciliation contract violation (ownership, terminal, etc.)."""
+
+
+class CutoverParityError(RuntimeError):
+    """Cutover parity verification failed."""
+
+
+# ---------------------------------------------------------------------------
+# Control mode
+# ---------------------------------------------------------------------------
+
+
+async def get_control_mode(db: AsyncSession) -> str:
+    """Read the current control mode from the database.
+
+    Fails closed if the control row is missing or the mode is unknown.
+    """
+    result = await db.execute(
+        select(TradeRetrospectiveActionControl.mode).where(
+            TradeRetrospectiveActionControl.id == 1
+        )
+    )
+    row = result.scalar_one_or_none()
+    if row is None:
+        raise ActionControlError(
+            "retrospective action control row is missing; writes fail closed"
+        )
+    if row not in ("shadow", "canonical"):
+        raise ActionControlError(
+            f'retrospective action control mode "{row}" is invalid; writes fail closed'
+        )
+    return row
+
+
+# ---------------------------------------------------------------------------
+# Repository
+# ---------------------------------------------------------------------------
+
+
+class RetrospectiveActionRepository:
+    """Control-mode-aware repository for retrospective actions.
+
+    In shadow mode, reads come from parent JSONB and writes go directly to
+    parent JSONB (legacy behavior). In canonical mode, reads come from the
+    child ledger and writes update children + rebuild the projection.
+    """
+
+    def __init__(self, db: AsyncSession):
+        self.db = db
+
+    async def get_control_mode(self) -> str:
+        return await get_control_mode(self.db)
+
+    # -- Read ---------------------------------------------------------------
+
+    async def read_actions(self, retrospective_id: int) -> list[dict[str, Any]]:
+        """Mode-aware read of actions for a retrospective.
+
+        Shadow: reads parent JSONB next_actions.
+        Canonical: reads child ledger rows ordered by position.
+        """
+        mode = await self.get_control_mode()
+        if mode == "shadow":
+            return await self._read_shadow(retrospective_id)
+        return await self._read_canonical(retrospective_id)
+
+    async def _read_shadow(self, retrospective_id: int) -> list[dict[str, Any]]:
+        result = await self.db.execute(
+            select(TradeRetrospective.next_actions).where(
+                TradeRetrospective.id == retrospective_id
+            )
+        )
+        raw = result.scalar_one_or_none()
+        if raw is None:
+            return []
+        return list(raw) if isinstance(raw, list) else []
+
+    async def _read_canonical(self, retrospective_id: int) -> list[dict[str, Any]]:
+        result = await self.db.execute(
+            select(TradeRetrospectiveAction)
+            .where(TradeRetrospectiveAction.retrospective_id == retrospective_id)
+            .order_by(TradeRetrospectiveAction.position, TradeRetrospectiveAction.id)
+        )
+        rows = result.scalars().all()
+        return [self._action_to_dict(a) for a in rows]
+
+    def _action_to_dict(self, a: TradeRetrospectiveAction) -> dict[str, Any]:
+        return {
+            "action_id": a.id,
+            "action": a.action,
+            "owner": a.owner,
+            "issue_id": a.issue_id,
+            "status": a.status,
+            "due_kst_date": a.due_kst_date.isoformat() if a.due_kst_date else None,
+            "version": a.version,
+            "position": a.position,
+        }
+
+    # -- Reconcile (canonical save) -----------------------------------------
+
+    async def reconcile_actions(
+        self,
+        retrospective_id: int,
+        actions: list[dict[str, Any]] | None,
+        actor: str,
+    ) -> None:
+        """Reconcile incoming actions against canonical children.
+
+        If ``actions`` is None, no reconciliation is performed (field-presence
+        semantics: omitted next_actions means "don't touch children").
+        """
+        if actions is None:
+            return
+
+        mode = await self.get_control_mode()
+        if mode != "canonical":
+            # In shadow mode, reconcile is a no-op — the legacy writer
+            # already wrote next_actions to parent JSONB.
+            return
+
+        # Lock parent row first
+        parent_result = await self.db.execute(
+            select(TradeRetrospective)
+            .where(TradeRetrospective.id == retrospective_id)
+            .with_for_update()
+        )
+        parent = parent_result.scalar_one_or_none()
+        if parent is None:
+            raise ActionReconcileError(f"retrospective {retrospective_id} not found")
+
+        # Lock all children in stable ID order
+        children_result = await self.db.execute(
+            select(TradeRetrospectiveAction)
+            .where(TradeRetrospectiveAction.retrospective_id == retrospective_id)
+            .order_by(TradeRetrospectiveAction.id)
+            .with_for_update()
+        )
+        existing_children: list[TradeRetrospectiveAction] = list(
+            children_result.scalars().all()
+        )
+
+        # Build a lookup by id for action_id matching
+        children_by_id: dict[uuid.UUID, TradeRetrospectiveAction] = {
+            a.id: a for a in existing_children
+        }
+        # Track which children have been matched
+        matched_ids: set[uuid.UUID] = set()
+
+        # Track position assignments
+        next_position = 0
+        # Track creation_key → child for idempotent force_new
+        children_by_ckey: dict[uuid.UUID, TradeRetrospectiveAction] = {
+            a.creation_key: a for a in existing_children if a.creation_key is not None
+        }
+
+        for incoming in actions:
+            action_text = (incoming.get("action") or "").strip()
+            if not action_text:
+                raise ActionReconcileError("action must be a non-empty string")
+
+            incoming_action_id = incoming.get("action_id")
+            force_new = incoming.get("force_new", False)
+            creation_key_str = incoming.get("creation_key")
+
+            if incoming_action_id is not None:
+                # Match by action_id
+                aid = uuid.UUID(str(incoming_action_id))
+                child = children_by_id.get(aid)
+                if child is None:
+                    raise ActionReconcileError(
+                        f"action_id {aid} does not belong to parent {retrospective_id}"
+                    )
+                if child.retrospective_id != retrospective_id:
+                    raise ActionReconcileError(
+                        f"action_id {aid} does not belong to retrospective {retrospective_id}"
+                    )
+                matched_ids.add(aid)
+                # Status handling: omitted = preserve, explicit = validate
+                if "status" in incoming and incoming["status"] is not None:
+                    if incoming["status"] != child.status:
+                        raise ActionReconcileError(
+                            f"cannot change status from '{child.status}' to "
+                            f"'{incoming['status']}' through save; use the transition API"
+                        )
+                # Update position
+                child.position = next_position
+                next_position += 1
+                continue
+
+            if force_new and creation_key_str is not None:
+                ckey = uuid.UUID(str(creation_key_str))
+                # Idempotent: reuse existing child with this creation_key
+                existing = children_by_ckey.get(ckey)
+                if existing is not None:
+                    matched_ids.add(existing.id)
+                    existing.position = next_position
+                    next_position += 1
+                    continue
+                # Create new with creation_key
+                self._create_new_action(
+                    retrospective_id=retrospective_id,
+                    position=next_position,
+                    incoming=incoming,
+                    action_text=action_text,
+                    actor=actor,
+                    creation_key=ckey,
+                )
+                next_position += 1
+                continue
+
+            # Occurrence-aware matching: find first unmatched child with
+            # exact tuple (action, owner, issue_id, due_kst_date)
+            matched = self._find_match(
+                existing_children, matched_ids, incoming, action_text
+            )
+            if matched is not None:
+                matched_ids.add(matched.id)
+                # Status: omitted = preserve, explicit = validate
+                if "status" in incoming and incoming["status"] is not None:
+                    if incoming["status"] != matched.status:
+                        raise ActionReconcileError(
+                            f"cannot change status from '{matched.status}' to "
+                            f"'{incoming['status']}' through save; use the transition API"
+                        )
+                matched.position = next_position
+                next_position += 1
+            else:
+                # Create new action
+                self._create_new_action(
+                    retrospective_id=retrospective_id,
+                    position=next_position,
+                    incoming=incoming,
+                    action_text=action_text,
+                    actor=actor,
+                    creation_key=None,
+                )
+                next_position += 1
+
+        # Omitted children follow in their prior relative order
+        for child in existing_children:
+            if child.id not in matched_ids:
+                child.position = next_position
+                next_position += 1
+
+        await self.db.flush()
+
+        # Build and write projection
+        await self._rebuild_projection(retrospective_id)
+
+    def _find_match(
+        self,
+        children: list[TradeRetrospectiveAction],
+        matched_ids: set[uuid.UUID],
+        incoming: dict[str, Any],
+        action_text: str,
+    ) -> TradeRetrospectiveAction | None:
+        """Find first unmatched child with exact canonical tuple."""
+        incoming_owner = incoming.get("owner")
+        incoming_issue_id = incoming.get("issue_id")
+        incoming_due = incoming.get("due_kst_date")
+        incoming_due_date = date.fromisoformat(incoming_due) if incoming_due else None
+        for child in children:
+            if child.id in matched_ids:
+                continue
+            if child.action != action_text:
+                continue
+            if child.owner != incoming_owner:
+                continue
+            if child.issue_id != incoming_issue_id:
+                continue
+            if child.due_kst_date != incoming_due_date:
+                continue
+            return child
+        return None
+
+    def _create_new_action(
+        self,
+        *,
+        retrospective_id: int,
+        position: int,
+        incoming: dict[str, Any],
+        action_text: str,
+        actor: str,
+        creation_key: uuid.UUID | None,
+    ) -> TradeRetrospectiveAction:
+        """Create a new canonical action row."""
+        status = incoming.get("status")
+        if status is None:
+            status = "open"
+        if status not in _VALID_INITIAL_STATUSES:
+            raise ActionReconcileError(
+                f"cannot create action with terminal status '{status}'; "
+                f"initial status must be one of {sorted(_VALID_INITIAL_STATUSES)}"
+            )
+
+        due_str = incoming.get("due_kst_date")
+        due_date = date.fromisoformat(due_str) if due_str else None
+
+        # Build legacy_payload from incoming (preserves unknown keys)
+        legacy_payload: dict[str, Any] = {}
+        for k, v in incoming.items():
+            if k not in (
+                "action_id",
+                "force_new",
+                "creation_key",
+                "version",
+                "action",
+                "owner",
+                "issue_id",
+                "status",
+                "due_kst_date",
+            ):
+                legacy_payload[k] = v
+        # Also include the canonical fields in legacy_payload
+        legacy_payload["action"] = action_text
+        legacy_payload["owner"] = incoming.get("owner")
+        legacy_payload["issue_id"] = incoming.get("issue_id")
+        legacy_payload["status"] = status
+        legacy_payload["due_kst_date"] = due_str
+
+        row = TradeRetrospectiveAction(
+            retrospective_id=retrospective_id,
+            position=position,
+            action=action_text,
+            owner=incoming.get("owner"),
+            issue_id=incoming.get("issue_id"),
+            status=status,
+            due_kst_date=due_date,
+            version=1,
+            status_actor=actor,
+            status_source="retrospective_save",
+            legacy_payload=legacy_payload,
+            creation_key=creation_key,
+        )
+        self.db.add(row)
+        return row
+
+    # -- Projection ---------------------------------------------------------
+
+    async def _rebuild_projection(self, retrospective_id: int) -> None:
+        """Rebuild parent JSONB projection from canonical children.
+
+        Sets the GUC marker before writing so the write-fence trigger permits
+        the update in canonical mode.
+        """
+        # Read children (already locked by caller)
+        result = await self.db.execute(
+            select(TradeRetrospectiveAction)
+            .where(TradeRetrospectiveAction.retrospective_id == retrospective_id)
+            .order_by(TradeRetrospectiveAction.position, TradeRetrospectiveAction.id)
+        )
+        children = result.scalars().all()
+
+        projection = [self._build_projection_item(c) for c in children]
+
+        # Set GUC marker so the write-fence trigger permits this write
+        await self.db.execute(text(f"SET LOCAL {_GUC_MARKER} = '{_GUC_VALUE}'"))
+
+        # Update parent JSONB — only next_actions, nothing else
+        await self.db.execute(
+            text(
+                "UPDATE review.trade_retrospectives SET next_actions = "
+                "CAST(:proj AS jsonb) WHERE id = :rid"
+            ),
+            {"proj": json.dumps(projection), "rid": retrospective_id},
+        )
+
+    def _build_projection_item(self, child: TradeRetrospectiveAction) -> dict[str, Any]:
+        """Build a single projection item from a canonical child.
+
+        Starts from legacy_payload, overlays canonical fields, adds action_id
+        and version. Preserves unknown keys from legacy_payload.
+        """
+        # Start from legacy_payload (copy)
+        item: dict[str, Any] = {}
+        if child.legacy_payload and isinstance(child.legacy_payload, dict):
+            item.update(child.legacy_payload)
+
+        # Overlay canonical fields
+        item["action"] = child.action
+        item["owner"] = child.owner
+        item["issue_id"] = child.issue_id
+
+        # Map terminal states to legacy vocabulary
+        if child.status in _TERMINAL_STATUSES:
+            item["status"] = "done"
+            if child.status in ("obsolete", "expired"):
+                item["terminal_status"] = child.status
+        else:
+            item["status"] = child.status
+            # Remove terminal_status if it was in legacy_payload but child is active
+            item.pop("terminal_status", None)
+
+        item["due_kst_date"] = (
+            child.due_kst_date.isoformat() if child.due_kst_date else None
+        )
+
+        # Additive fields
+        item["action_id"] = str(child.id)
+        item["version"] = child.version
+
+        return item
+
+    # -- Canonical query ----------------------------------------------------
+
+    async def query_actions(
+        self,
+        *,
+        statuses: frozenset[str] | None = None,
+        market: str | None = None,
+        symbol: str | None = None,
+        symbol_search: str | None = None,
+        owner: str | None = None,
+        issue_id: str | None = None,
+        overdue_only: bool = False,
+        trigger_type: str | None = None,
+        outcome_filter: str | None = None,
+        kst_date_from: str | None = None,
+        kst_date_to: str | None = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> dict[str, Any]:
+        """Canonical action query with pagination, filters, and ordering.
+
+        Default status filter: open,in_progress (active only).
+        Ordering: overdue first, then in_progress, due_date ASC NULLS LAST,
+        updated_at DESC, id ASC.
+        """
+        # Active-default filter
+        if statuses is None:
+            statuses = _ACTIVE_STATUSES
+
+        # Build filters
+        filters = [
+            TradeRetrospectiveAction.status.in_(statuses),
+        ]
+
+        # Join with parent for context fields
+        parent_filters = []
+        if market is not None:
+            parent_filters.append(TradeRetrospective.market == market)
+        if symbol is not None:
+            parent_filters.append(TradeRetrospective.symbol == symbol.strip().upper())
+        if symbol_search is not None and symbol_search.strip():
+            escaped = (
+                symbol_search.strip()
+                .upper()
+                .replace("\\", "\\\\")
+                .replace("%", "\\%")
+                .replace("_", "\\_")
+            )
+            parent_filters.append(
+                TradeRetrospective.symbol.ilike(f"{escaped}%", escape="\\")
+            )
+        if trigger_type is not None:
+            parent_filters.append(TradeRetrospective.trigger_type == trigger_type)
+
+        if owner is not None:
+            filters.append(TradeRetrospectiveAction.owner == owner)
+        if issue_id is not None:
+            filters.append(TradeRetrospectiveAction.issue_id == issue_id)
+
+        # Overdue filter: active AND due_kst_date < today (KST)
+        today_kst = now_kst().date()
+        overdue_expr = and_(
+            TradeRetrospectiveAction.status.in_(("open", "in_progress")),
+            TradeRetrospectiveAction.due_kst_date.isnot(None),
+            TradeRetrospectiveAction.due_kst_date < today_kst,
+        )
+        if overdue_only:
+            filters.append(overdue_expr)
+
+        # Build the join
+        join_condition = (
+            TradeRetrospectiveAction.retrospective_id == TradeRetrospective.id
+        )
+
+        # Count total
+        count_stmt = (
+            select(func.count())
+            .select_from(TradeRetrospectiveAction)
+            .join(TradeRetrospective, join_condition)
+            .where(*filters, *parent_filters)
+        )
+        total = (await self.db.execute(count_stmt)).scalar_one()
+
+        today_kst = now_kst().date()
+        overdue_case = text(
+            "CASE WHEN trade_retrospective_actions.status IN ('open','in_progress') "
+            "AND trade_retrospective_actions.due_kst_date IS NOT NULL "
+            "AND trade_retrospective_actions.due_kst_date < :today_kst "
+            "THEN 0 ELSE 1 END"
+        ).bindparams(today_kst=today_kst)
+
+        progress_order = text(
+            "CASE WHEN trade_retrospective_actions.status = 'in_progress' "
+            "THEN 0 ELSE 1 END"
+        )
+
+        stmt = (
+            select(
+                TradeRetrospectiveAction,
+                TradeRetrospective.symbol,
+                TradeRetrospective.market,
+                TradeRetrospective.trigger_type,
+                TradeRetrospective.outcome,
+                TradeRetrospective.realized_pnl,
+                TradeRetrospective.correlation_id,
+                TradeRetrospective.created_at.label("parent_created_at"),
+            )
+            .join(TradeRetrospective, join_condition)
+            .where(*filters, *parent_filters)
+            .order_by(
+                overdue_case,
+                progress_order,
+                TradeRetrospectiveAction.due_kst_date.asc().nullslast(),
+                TradeRetrospectiveAction.updated_at.desc(),
+                TradeRetrospectiveAction.id.asc(),
+            )
+            .limit(limit)
+            .offset(offset)
+        )
+
+        rows = (await self.db.execute(stmt)).all()
+
+        items = []
+        for row in rows:
+            action = row[0]
+            parent_symbol = row[1]
+            parent_market = row[2]
+            parent_trigger = row[3]
+            parent_outcome = row[4]
+            parent_pnl = row[5]
+            parent_cid = row[6]
+            parent_created = row[7]
+
+            is_overdue = (
+                action.status in ("open", "in_progress")
+                and action.due_kst_date is not None
+                and action.due_kst_date < today_kst
+            )
+
+            items.append(
+                {
+                    "action_id": str(action.id),
+                    "version": action.version,
+                    "action": action.action,
+                    "owner": action.owner,
+                    "issue_id": action.issue_id,
+                    "status": action.status,
+                    "due_kst_date": (
+                        action.due_kst_date.isoformat() if action.due_kst_date else None
+                    ),
+                    "overdue": is_overdue,
+                    "status_changed_at": (
+                        action.status_changed_at.isoformat()
+                        if action.status_changed_at
+                        else None
+                    ),
+                    "resolved_at": (
+                        action.resolved_at.isoformat() if action.resolved_at else None
+                    ),
+                    "status_actor": action.status_actor,
+                    "status_source": action.status_source,
+                    "retrospective_id": action.retrospective_id,
+                    "correlation_id": parent_cid,
+                    "symbol": parent_symbol,
+                    "market": parent_market,
+                    "trigger_type": parent_trigger,
+                    "outcome": parent_outcome,
+                    "realized_pnl": (
+                        float(parent_pnl) if parent_pnl is not None else None
+                    ),
+                    "created_at": (
+                        parent_created.isoformat() if parent_created else None
+                    ),
+                }
+            )
+
+        return {
+            "total": int(total),
+            "count": len(items),
+            "limit": limit,
+            "offset": offset,
+            "as_of": datetime.now(UTC),
+            "items": items,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Cutover
+# ---------------------------------------------------------------------------
+
+
+async def run_cutover(
+    conn: AsyncConnection, *, if_shadow: bool = False
+) -> dict[str, Any]:
+    """Run the canonical cutover in the caller's transaction.
+
+    Steps:
+    1. Take transaction-scoped advisory lock.
+    2. LOCK TABLE parent IN SHARE ROW EXCLUSIVE MODE.
+    3. Read control row; if already canonical and if_shadow, return idempotent.
+    4. Delete all shadow children.
+    5. Rebuild from frozen parent JSON (same backfill as migration).
+    6. Verify full parity (count, ordinal, all canonical fields).
+    7. Switch mode to canonical atomically.
+
+    On parity failure, the entire transaction (including the mode switch) is
+    left for the caller to roll back.
+    """
+    # 1. Advisory lock (transaction-scoped)
+    await conn.execute(
+        text("SELECT pg_advisory_xact_lock(:lock_id)"),
+        {"lock_id": _CUTOVER_ADVISORY_LOCK_ID},
+    )
+
+    # 2. Lock tables in order: parent → control → actions
+    await conn.execute(
+        text("LOCK TABLE review.trade_retrospectives IN SHARE ROW EXCLUSIVE MODE")
+    )
+    await conn.execute(
+        text(
+            "LOCK TABLE review.trade_retrospective_action_control "
+            "IN SHARE ROW EXCLUSIVE MODE"
+        )
+    )
+    await conn.execute(
+        text(
+            "LOCK TABLE review.trade_retrospective_actions IN SHARE ROW EXCLUSIVE MODE"
+        )
+    )
+
+    # 3. Read control row
+    ctrl_result = await conn.execute(
+        text(
+            "SELECT mode, cutover_at, cutover_action_count "
+            "FROM review.trade_retrospective_action_control WHERE id = 1"
+        )
+    )
+    ctrl_row = ctrl_result.fetchone()
+    if ctrl_row is None:
+        raise ActionControlError(
+            "retrospective action control row is missing; cutover aborted"
+        )
+    current_mode = ctrl_row.mode
+
+    if current_mode == "canonical":
+        # Idempotent: already canonical
+        return {
+            "mode": "canonical",
+            "action_count": ctrl_row.cutover_action_count or 0,
+            "cutover_at": ctrl_row.cutover_at,
+            "idempotent": True,
+        }
+
+    if current_mode != "shadow":
+        raise ActionControlError(
+            f'cannot cutover from mode "{current_mode}"; expected shadow'
+        )
+
+    # 4. Delete all existing children
+    await conn.execute(text("DELETE FROM review.trade_retrospective_actions"))
+
+    # 5. Rebuild from frozen parent JSON (same backfill SQL as migration)
+    await conn.execute(
+        text(
+            """
+            INSERT INTO review.trade_retrospective_actions (
+                id, retrospective_id, creation_key, position, action,
+                owner, issue_id, status, due_kst_date, version,
+                status_changed_at, resolved_at,
+                status_actor, status_source, status_reason, status_evidence,
+                legacy_payload, created_at, updated_at
+            )
+            SELECT
+                gen_random_uuid(),
+                t.id,
+                NULL,
+                (elem.ordinality - 1)::integer,
+                btrim(elem.value->>'action'),
+                elem.value->>'owner',
+                elem.value->>'issue_id',
+                CASE
+                    WHEN btrim(COALESCE(elem.value->>'status', '')) = ''
+                        THEN 'open'
+                    ELSE elem.value->>'status'
+                END,
+                CASE
+                    WHEN btrim(COALESCE(elem.value->>'due_kst_date', '')) = ''
+                        THEN NULL
+                    ELSE (elem.value->>'due_kst_date')::date
+                END,
+                1,
+                t.updated_at,
+                CASE
+                    WHEN elem.value->>'status' = 'done' THEN t.updated_at
+                    ELSE NULL
+                END,
+                'migration:rob-878',
+                'migration',
+                NULL,
+                CASE
+                    WHEN elem.value->>'status' = 'done' THEN
+                        jsonb_build_object(
+                            'schema_version', 1,
+                            'kind', 'legacy_status',
+                            'source', 'migration',
+                            'reference', 'review.trade_retrospectives.next_actions',
+                            'observed_at', t.updated_at,
+                            'summary', 'historical done; exact completion time unavailable'
+                        )
+                    ELSE NULL
+                END,
+                elem.value,
+                t.created_at,
+                t.updated_at
+            FROM review.trade_retrospectives t
+            CROSS JOIN LATERAL jsonb_array_elements(
+                CASE
+                    WHEN jsonb_typeof(t.next_actions) = 'array'
+                        THEN t.next_actions
+                    ELSE '[]'::jsonb
+                END
+            ) WITH ORDINALITY AS elem(value, ordinality)
+            """
+        )
+    )
+
+    # 6. Verify full parity (count, ordinal, all canonical fields)
+    await _verify_parity(conn)
+
+    # Count actions
+    count_result = await conn.execute(
+        text("SELECT count(*) FROM review.trade_retrospective_actions")
+    )
+    action_count = count_result.scalar_one()
+
+    # 7. Switch mode to canonical atomically
+    await conn.execute(
+        text(
+            "UPDATE review.trade_retrospective_action_control "
+            "SET mode = 'canonical', cutover_at = now(), "
+            "    cutover_action_count = :count "
+            "WHERE id = 1"
+        ),
+        {"count": action_count},
+    )
+
+    return {
+        "mode": "canonical",
+        "action_count": action_count,
+        "cutover_at": datetime.now(UTC),
+        "idempotent": False,
+    }
+
+
+async def _verify_parity(conn: AsyncConnection) -> None:
+    """Verify count and full field parity between parent JSONB and children.
+
+    Raises CutoverParityError on any mismatch.
+    """
+    # Count parity
+    count_result = await conn.execute(
+        text(
+            """
+            SELECT
+                COALESCE(SUM(
+                    CASE
+                        WHEN jsonb_typeof(next_actions) = 'array'
+                        THEN jsonb_array_length(next_actions)
+                        ELSE 0
+                    END
+                ), 0) AS parent_count,
+                (SELECT count(*) FROM review.trade_retrospective_actions) AS child_count
+            FROM review.trade_retrospectives
+            """
+        )
+    )
+    counts = count_result.one()
+    if counts.parent_count != counts.child_count:
+        raise CutoverParityError(
+            f"count mismatch: parent has {counts.parent_count} actions, "
+            f"child has {counts.child_count}"
+        )
+
+    # Full field parity
+    mismatch_result = await conn.execute(
+        text(
+            """
+            WITH expected AS (
+                SELECT
+                    t.id AS retrospective_id,
+                    (elem.ordinality - 1)::integer AS position,
+                    btrim(elem.value->>'action') AS action,
+                    elem.value->>'owner' AS owner,
+                    elem.value->>'issue_id' AS issue_id,
+                    CASE
+                        WHEN btrim(COALESCE(elem.value->>'status', '')) = ''
+                            THEN 'open'
+                        ELSE elem.value->>'status'
+                    END AS status,
+                    CASE
+                        WHEN btrim(COALESCE(elem.value->>'due_kst_date', '')) = ''
+                            THEN NULL
+                        ELSE (elem.value->>'due_kst_date')::date
+                    END AS due_kst_date,
+                    elem.value AS legacy_payload
+                FROM review.trade_retrospectives t
+                CROSS JOIN LATERAL jsonb_array_elements(
+                    CASE
+                        WHEN jsonb_typeof(t.next_actions) = 'array'
+                            THEN t.next_actions
+                        ELSE '[]'::jsonb
+                    END
+                ) WITH ORDINALITY AS elem(value, ordinality)
+            )
+            SELECT e.retrospective_id, e.position
+            FROM expected e
+            LEFT JOIN review.trade_retrospective_actions a
+              ON a.retrospective_id = e.retrospective_id
+             AND a.position = e.position
+            WHERE a.id IS NULL
+               OR a.creation_key IS NOT NULL
+               OR a.action IS DISTINCT FROM e.action
+               OR a.owner IS DISTINCT FROM e.owner
+               OR a.issue_id IS DISTINCT FROM e.issue_id
+               OR a.status IS DISTINCT FROM e.status
+               OR a.due_kst_date IS DISTINCT FROM e.due_kst_date
+               OR a.version <> 1
+               OR a.status_actor <> 'migration:rob-878'
+               OR a.status_source <> 'migration'
+               OR a.legacy_payload IS DISTINCT FROM e.legacy_payload
+            ORDER BY e.retrospective_id, e.position
+            LIMIT 1
+            """
+        )
+    )
+    mismatch = mismatch_result.fetchone()
+    if mismatch is not None:
+        raise CutoverParityError(
+            f"parity mismatch: retrospective {mismatch.retrospective_id} "
+            f"action[{mismatch.position}] field/ordinal mismatch"
+        )

--- a/app/services/trade_journal/retrospective_action_repository.py
+++ b/app/services/trade_journal/retrospective_action_repository.py
@@ -228,16 +228,27 @@ class RetrospectiveActionRepository:
         retrospective_id: int,
         actions: list[dict[str, Any]] | None,
         actor: str,
+        *,
+        control_mode: str | None = None,
     ) -> None:
         """Reconcile incoming actions against canonical children.
 
         If ``actions`` is None, no reconciliation is performed (field-presence
         semantics: omitted next_actions means "don't touch children").
+        A caller that already validated the control mode may pass that snapshot
+        so one save operation cannot make routing decisions from two reads.
         """
         if actions is None:
             return
 
-        mode = await self.get_control_mode()
+        mode = (
+            control_mode if control_mode is not None else await self.get_control_mode()
+        )
+        if mode not in ("shadow", "canonical"):
+            raise ActionControlError(
+                f'retrospective action control mode "{mode}" is invalid; '
+                "writes fail closed"
+            )
         if mode != "canonical":
             # In shadow mode, reconcile is a no-op — the legacy writer
             # already wrote next_actions to parent JSONB.

--- a/app/services/trade_journal/retrospective_action_repository.py
+++ b/app/services/trade_journal/retrospective_action_repository.py
@@ -19,10 +19,12 @@ from __future__ import annotations
 
 import json
 import uuid
+from collections.abc import Sequence
 from datetime import UTC, date, datetime
 from typing import Any
 
-from sqlalchemy import and_, func, select, text
+from sqlalchemy import and_, case, func, select, text, true
+from sqlalchemy.exc import DBAPIError
 from sqlalchemy.ext.asyncio import AsyncConnection, AsyncSession
 
 from app.core.timezone import now_kst
@@ -30,6 +32,12 @@ from app.models.review import (
     TradeRetrospective,
     TradeRetrospectiveAction,
     TradeRetrospectiveActionControl,
+)
+from app.schemas.trade_retrospective import VALID_NEXT_ACTION_STATUSES
+from app.services.trade_journal.retrospective_query_filters import (
+    kst_day_end,
+    kst_day_start,
+    outcome_filter_predicate,
 )
 
 # ---------------------------------------------------------------------------
@@ -68,6 +76,10 @@ class ActionReconcileError(ValueError):
 
 class CutoverParityError(RuntimeError):
     """Cutover parity verification failed."""
+
+
+class CutoverLockError(RuntimeError):
+    """Cutover could not obtain its advisory/table locks within the bound."""
 
 
 # ---------------------------------------------------------------------------
@@ -149,17 +161,65 @@ class RetrospectiveActionRepository:
         rows = result.scalars().all()
         return [self._action_to_dict(a) for a in rows]
 
+    async def read_actions_many(
+        self, parents: Sequence[TradeRetrospective]
+    ) -> dict[int, list[dict[str, Any]] | None]:
+        """Mode-aware batch hydration without one query per parent."""
+        mode = await self.get_control_mode()
+        if mode == "shadow":
+            return {
+                parent.id: (
+                    list(parent.next_actions)
+                    if isinstance(parent.next_actions, list)
+                    else None
+                )
+                for parent in parents
+            }
+
+        by_parent = {parent.id: [] for parent in parents}
+        if not by_parent:
+            return by_parent
+        result = await self.db.execute(
+            select(TradeRetrospectiveAction)
+            .where(TradeRetrospectiveAction.retrospective_id.in_(by_parent))
+            .order_by(
+                TradeRetrospectiveAction.retrospective_id,
+                TradeRetrospectiveAction.position,
+                TradeRetrospectiveAction.id,
+            )
+        )
+        for action in result.scalars():
+            by_parent[action.retrospective_id].append(self._action_to_dict(action))
+        return by_parent
+
     def _action_to_dict(self, a: TradeRetrospectiveAction) -> dict[str, Any]:
-        return {
-            "action_id": a.id,
-            "action": a.action,
-            "owner": a.owner,
-            "issue_id": a.issue_id,
-            "status": a.status,
-            "due_kst_date": a.due_kst_date.isoformat() if a.due_kst_date else None,
-            "version": a.version,
-            "position": a.position,
-        }
+        payload = dict(a.legacy_payload or {})
+        # force_new is a write intent, never persisted/read back as state.
+        payload.pop("force_new", None)
+        payload.update(
+            {
+                "action_id": str(a.id),
+                "creation_key": str(a.creation_key) if a.creation_key else None,
+                "action": a.action,
+                "owner": a.owner,
+                "issue_id": a.issue_id,
+                "status": a.status,
+                "due_kst_date": a.due_kst_date.isoformat() if a.due_kst_date else None,
+                "version": a.version,
+                "position": a.position,
+                "status_changed_at": (
+                    a.status_changed_at.isoformat() if a.status_changed_at else None
+                ),
+                "resolved_at": a.resolved_at.isoformat() if a.resolved_at else None,
+                "status_actor": a.status_actor,
+                "status_source": a.status_source,
+                "status_reason": a.status_reason,
+                "status_evidence": a.status_evidence,
+                "created_at": a.created_at.isoformat() if a.created_at else None,
+                "updated_at": a.updated_at.isoformat() if a.updated_at else None,
+            }
+        )
+        return payload
 
     # -- Reconcile (canonical save) -----------------------------------------
 
@@ -203,6 +263,10 @@ class RetrospectiveActionRepository:
         existing_children: list[TradeRetrospectiveAction] = list(
             children_result.scalars().all()
         )
+        display_children = sorted(
+            existing_children,
+            key=lambda child: (child.position, child.id),
+        )
 
         # Build a lookup by id for action_id matching
         children_by_id: dict[uuid.UUID, TradeRetrospectiveAction] = {
@@ -217,6 +281,11 @@ class RetrospectiveActionRepository:
         children_by_ckey: dict[uuid.UUID, TradeRetrospectiveAction] = {
             a.creation_key: a for a in existing_children if a.creation_key is not None
         }
+        request_creation_keys: set[uuid.UUID] = set()
+        known_tuples = {
+            (child.action, child.owner, child.issue_id, child.due_kst_date)
+            for child in display_children
+        }
 
         for incoming in actions:
             action_text = (incoming.get("action") or "").strip()
@@ -227,9 +296,30 @@ class RetrospectiveActionRepository:
             force_new = incoming.get("force_new", False)
             creation_key_str = incoming.get("creation_key")
 
+            if incoming_action_id is None:
+                if force_new and creation_key_str is None:
+                    raise ActionReconcileError(
+                        "creation_key is required when force_new is true"
+                    )
+                if not force_new and creation_key_str is not None:
+                    raise ActionReconcileError(
+                        "creation_key requires force_new to be true"
+                    )
+
             if incoming_action_id is not None:
+                if force_new:
+                    raise ActionReconcileError(
+                        "action_id cannot be combined with force_new"
+                    )
                 # Match by action_id
-                aid = uuid.UUID(str(incoming_action_id))
+                try:
+                    aid = uuid.UUID(str(incoming_action_id))
+                except (TypeError, ValueError) as exc:
+                    raise ActionReconcileError(
+                        "action_id must be a valid UUID"
+                    ) from exc
+                if aid in matched_ids:
+                    raise ActionReconcileError(f"duplicate action_id {aid}")
                 child = children_by_id.get(aid)
                 if child is None:
                     raise ActionReconcileError(
@@ -238,6 +328,39 @@ class RetrospectiveActionRepository:
                 if child.retrospective_id != retrospective_id:
                     raise ActionReconcileError(
                         f"action_id {aid} does not belong to retrospective {retrospective_id}"
+                    )
+                if creation_key_str is not None:
+                    try:
+                        echoed_creation_key = uuid.UUID(str(creation_key_str))
+                    except (TypeError, ValueError) as exc:
+                        raise ActionReconcileError(
+                            "creation_key must be a valid UUID"
+                        ) from exc
+                    if echoed_creation_key != child.creation_key:
+                        raise ActionReconcileError(
+                            "action_id creation_key is immutable through save"
+                        )
+                incoming_due = incoming.get("due_kst_date")
+                if isinstance(incoming_due, date):
+                    incoming_due_date = incoming_due
+                else:
+                    incoming_due_date = (
+                        date.fromisoformat(str(incoming_due)) if incoming_due else None
+                    )
+                if (
+                    action_text,
+                    incoming.get("owner"),
+                    incoming.get("issue_id"),
+                    incoming_due_date,
+                ) != (
+                    child.action,
+                    child.owner,
+                    child.issue_id,
+                    child.due_kst_date,
+                ):
+                    raise ActionReconcileError(
+                        "action_id canonical tuple is immutable through save; "
+                        "create an amendment and use the transition API"
                     )
                 matched_ids.add(aid)
                 # Status handling: omitted = preserve, explicit = validate
@@ -253,10 +376,40 @@ class RetrospectiveActionRepository:
                 continue
 
             if force_new and creation_key_str is not None:
-                ckey = uuid.UUID(str(creation_key_str))
+                try:
+                    ckey = uuid.UUID(str(creation_key_str))
+                except (TypeError, ValueError) as exc:
+                    raise ActionReconcileError(
+                        "creation_key must be a valid UUID"
+                    ) from exc
+                if ckey in request_creation_keys:
+                    raise ActionReconcileError(f"duplicate creation_key {ckey}")
+                request_creation_keys.add(ckey)
                 # Idempotent: reuse existing child with this creation_key
                 existing = children_by_ckey.get(ckey)
                 if existing is not None:
+                    if existing.id in matched_ids:
+                        raise ActionReconcileError(
+                            f"creation_key {ckey} references an action already matched"
+                        )
+                    if self._canonical_tuple(incoming, action_text) != (
+                        existing.action,
+                        existing.owner,
+                        existing.issue_id,
+                        existing.due_kst_date,
+                    ):
+                        raise ActionReconcileError(
+                            "creation_key canonical tuple is immutable through save"
+                        )
+                    if (
+                        "status" in incoming
+                        and incoming["status"] is not None
+                        and incoming["status"] != existing.status
+                    ):
+                        raise ActionReconcileError(
+                            "creation_key status is immutable through save; "
+                            "use the transition API"
+                        )
                     matched_ids.add(existing.id)
                     existing.position = next_position
                     next_position += 1
@@ -270,13 +423,14 @@ class RetrospectiveActionRepository:
                     actor=actor,
                     creation_key=ckey,
                 )
+                known_tuples.add(self._canonical_tuple(incoming, action_text))
                 next_position += 1
                 continue
 
             # Occurrence-aware matching: find first unmatched child with
             # exact tuple (action, owner, issue_id, due_kst_date)
             matched = self._find_match(
-                existing_children, matched_ids, incoming, action_text
+                display_children, matched_ids, incoming, action_text
             )
             if matched is not None:
                 matched_ids.add(matched.id)
@@ -290,6 +444,12 @@ class RetrospectiveActionRepository:
                 matched.position = next_position
                 next_position += 1
             else:
+                canonical_tuple = self._canonical_tuple(incoming, action_text)
+                if canonical_tuple in known_tuples:
+                    raise ActionReconcileError(
+                        "an additional identical action occurrence requires "
+                        "force_new=true with a stable creation_key"
+                    )
                 # Create new action
                 self._create_new_action(
                     retrospective_id=retrospective_id,
@@ -299,10 +459,11 @@ class RetrospectiveActionRepository:
                     actor=actor,
                     creation_key=None,
                 )
+                known_tuples.add(canonical_tuple)
                 next_position += 1
 
         # Omitted children follow in their prior relative order
-        for child in existing_children:
+        for child in display_children:
             if child.id not in matched_ids:
                 child.position = next_position
                 next_position += 1
@@ -322,8 +483,7 @@ class RetrospectiveActionRepository:
         """Find first unmatched child with exact canonical tuple."""
         incoming_owner = incoming.get("owner")
         incoming_issue_id = incoming.get("issue_id")
-        incoming_due = incoming.get("due_kst_date")
-        incoming_due_date = date.fromisoformat(incoming_due) if incoming_due else None
+        incoming_due_date = self._incoming_due_date(incoming)
         for child in children:
             if child.id in matched_ids:
                 continue
@@ -337,6 +497,24 @@ class RetrospectiveActionRepository:
                 continue
             return child
         return None
+
+    @staticmethod
+    def _incoming_due_date(incoming: dict[str, Any]) -> date | None:
+        incoming_due = incoming.get("due_kst_date")
+        if isinstance(incoming_due, date):
+            return incoming_due
+        return date.fromisoformat(str(incoming_due)) if incoming_due else None
+
+    @classmethod
+    def _canonical_tuple(
+        cls, incoming: dict[str, Any], action_text: str
+    ) -> tuple[str, Any, Any, date | None]:
+        return (
+            action_text,
+            incoming.get("owner"),
+            incoming.get("issue_id"),
+            cls._incoming_due_date(incoming),
+        )
 
     def _create_new_action(
         self,
@@ -440,6 +618,7 @@ class RetrospectiveActionRepository:
         item: dict[str, Any] = {}
         if child.legacy_payload and isinstance(child.legacy_payload, dict):
             item.update(child.legacy_payload)
+        item.pop("force_new", None)
 
         # Overlay canonical fields
         item["action"] = child.action
@@ -463,6 +642,10 @@ class RetrospectiveActionRepository:
         # Additive fields
         item["action_id"] = str(child.id)
         item["version"] = child.version
+        if child.creation_key is not None:
+            item["creation_key"] = str(child.creation_key)
+        else:
+            item.pop("creation_key", None)
 
         return item
 
@@ -482,7 +665,8 @@ class RetrospectiveActionRepository:
         outcome_filter: str | None = None,
         kst_date_from: str | None = None,
         kst_date_to: str | None = None,
-        limit: int = 50,
+        due_before: str | None = None,
+        limit: int | None = 50,
         offset: int = 0,
     ) -> dict[str, Any]:
         """Canonical action query with pagination, filters, and ordering.
@@ -494,6 +678,9 @@ class RetrospectiveActionRepository:
         # Active-default filter
         if statuses is None:
             statuses = _ACTIVE_STATUSES
+        unknown_statuses = statuses - VALID_NEXT_ACTION_STATUSES
+        if unknown_statuses:
+            raise ValueError(f"invalid action statuses: {sorted(unknown_statuses)}")
 
         # Build filters
         filters = [
@@ -519,11 +706,25 @@ class RetrospectiveActionRepository:
             )
         if trigger_type is not None:
             parent_filters.append(TradeRetrospective.trigger_type == trigger_type)
+        if outcome_filter is not None:
+            parent_filters.append(outcome_filter_predicate(outcome_filter))
+        if kst_date_from is not None:
+            parent_filters.append(
+                TradeRetrospective.created_at >= kst_day_start(kst_date_from)
+            )
+        if kst_date_to is not None:
+            parent_filters.append(
+                TradeRetrospective.created_at <= kst_day_end(kst_date_to)
+            )
 
         if owner is not None:
             filters.append(TradeRetrospectiveAction.owner == owner)
         if issue_id is not None:
             filters.append(TradeRetrospectiveAction.issue_id == issue_id)
+        if due_before is not None:
+            filters.append(
+                TradeRetrospectiveAction.due_kst_date < date.fromisoformat(due_before)
+            )
 
         # Overdue filter: active AND due_kst_date < today (KST)
         today_kst = now_kst().date()
@@ -540,104 +741,120 @@ class RetrospectiveActionRepository:
             TradeRetrospectiveAction.retrospective_id == TradeRetrospective.id
         )
 
-        # Count total
-        count_stmt = (
-            select(func.count())
-            .select_from(TradeRetrospectiveAction)
-            .join(TradeRetrospective, join_condition)
-            .where(*filters, *parent_filters)
-        )
-        total = (await self.db.execute(count_stmt)).scalar_one()
-
-        today_kst = now_kst().date()
-        overdue_case = text(
-            "CASE WHEN trade_retrospective_actions.status IN ('open','in_progress') "
-            "AND trade_retrospective_actions.due_kst_date IS NOT NULL "
-            "AND trade_retrospective_actions.due_kst_date < :today_kst "
-            "THEN 0 ELSE 1 END"
-        ).bindparams(today_kst=today_kst)
-
-        progress_order = text(
-            "CASE WHEN trade_retrospective_actions.status = 'in_progress' "
-            "THEN 0 ELSE 1 END"
-        )
-
-        stmt = (
+        filtered = (
             select(
-                TradeRetrospectiveAction,
-                TradeRetrospective.symbol,
-                TradeRetrospective.market,
-                TradeRetrospective.trigger_type,
-                TradeRetrospective.outcome,
-                TradeRetrospective.realized_pnl,
-                TradeRetrospective.correlation_id,
+                TradeRetrospectiveAction.id.label("action_id"),
+                TradeRetrospectiveAction.version,
+                TradeRetrospectiveAction.action,
+                TradeRetrospectiveAction.owner,
+                TradeRetrospectiveAction.issue_id,
+                TradeRetrospectiveAction.status,
+                TradeRetrospectiveAction.due_kst_date,
+                TradeRetrospectiveAction.status_changed_at,
+                TradeRetrospectiveAction.resolved_at,
+                TradeRetrospectiveAction.status_actor,
+                TradeRetrospectiveAction.status_source,
+                TradeRetrospectiveAction.status_reason,
+                TradeRetrospectiveAction.retrospective_id,
+                TradeRetrospectiveAction.updated_at.label("action_updated_at"),
+                TradeRetrospective.symbol.label("symbol"),
+                TradeRetrospective.market.label("market"),
+                TradeRetrospective.trigger_type.label("trigger_type"),
+                TradeRetrospective.outcome.label("outcome"),
+                TradeRetrospective.realized_pnl.label("realized_pnl"),
+                TradeRetrospective.correlation_id.label("correlation_id"),
                 TradeRetrospective.created_at.label("parent_created_at"),
+                case((overdue_expr, 0), else_=1).label("overdue_rank"),
+                case(
+                    (TradeRetrospectiveAction.status == "in_progress", 0),
+                    else_=1,
+                ).label("progress_rank"),
             )
             .join(TradeRetrospective, join_condition)
             .where(*filters, *parent_filters)
-            .order_by(
-                overdue_case,
-                progress_order,
-                TradeRetrospectiveAction.due_kst_date.asc().nullslast(),
-                TradeRetrospectiveAction.updated_at.desc(),
-                TradeRetrospectiveAction.id.asc(),
-            )
-            .limit(limit)
-            .offset(offset)
+            .cte("filtered_actions")
         )
-
-        rows = (await self.db.execute(stmt)).all()
+        page_stmt = select(filtered).order_by(
+            filtered.c.overdue_rank,
+            filtered.c.progress_rank,
+            filtered.c.due_kst_date.asc().nullslast(),
+            filtered.c.action_updated_at.desc(),
+            filtered.c.action_id.asc(),
+        )
+        if limit is not None:
+            page_stmt = page_stmt.limit(limit)
+        if offset:
+            page_stmt = page_stmt.offset(offset)
+        page = page_stmt.cte("action_page")
+        totals = (
+            select(func.count().label("total"))
+            .select_from(filtered)
+            .cte("action_totals")
+        )
+        page_columns = list(page.c)
+        stmt = (
+            select(totals.c.total, *page_columns)
+            .select_from(totals.outerjoin(page, true()))
+            .order_by(
+                page.c.overdue_rank,
+                page.c.progress_rank,
+                page.c.due_kst_date.asc().nullslast(),
+                page.c.action_updated_at.desc(),
+                page.c.action_id.asc(),
+            )
+        )
+        rows = (await self.db.execute(stmt)).mappings().all()
+        total = int(rows[0]["total"]) if rows else 0
 
         items = []
         for row in rows:
-            action = row[0]
-            parent_symbol = row[1]
-            parent_market = row[2]
-            parent_trigger = row[3]
-            parent_outcome = row[4]
-            parent_pnl = row[5]
-            parent_cid = row[6]
-            parent_created = row[7]
+            if row["action_id"] is None:
+                continue
 
             is_overdue = (
-                action.status in ("open", "in_progress")
-                and action.due_kst_date is not None
-                and action.due_kst_date < today_kst
+                row["status"] in ("open", "in_progress")
+                and row["due_kst_date"] is not None
+                and row["due_kst_date"] < today_kst
             )
 
             items.append(
                 {
-                    "action_id": str(action.id),
-                    "version": action.version,
-                    "action": action.action,
-                    "owner": action.owner,
-                    "issue_id": action.issue_id,
-                    "status": action.status,
+                    "action_id": str(row["action_id"]),
+                    "version": row["version"],
+                    "action": row["action"],
+                    "owner": row["owner"],
+                    "issue_id": row["issue_id"],
+                    "status": row["status"],
                     "due_kst_date": (
-                        action.due_kst_date.isoformat() if action.due_kst_date else None
+                        row["due_kst_date"].isoformat() if row["due_kst_date"] else None
                     ),
                     "overdue": is_overdue,
                     "status_changed_at": (
-                        action.status_changed_at.isoformat()
-                        if action.status_changed_at
+                        row["status_changed_at"].isoformat()
+                        if row["status_changed_at"]
                         else None
                     ),
                     "resolved_at": (
-                        action.resolved_at.isoformat() if action.resolved_at else None
+                        row["resolved_at"].isoformat() if row["resolved_at"] else None
                     ),
-                    "status_actor": action.status_actor,
-                    "status_source": action.status_source,
-                    "retrospective_id": action.retrospective_id,
-                    "correlation_id": parent_cid,
-                    "symbol": parent_symbol,
-                    "market": parent_market,
-                    "trigger_type": parent_trigger,
-                    "outcome": parent_outcome,
+                    "status_actor": row["status_actor"],
+                    "status_source": row["status_source"],
+                    "status_reason": row["status_reason"],
+                    "retrospective_id": row["retrospective_id"],
+                    "correlation_id": row["correlation_id"],
+                    "symbol": row["symbol"],
+                    "market": row["market"],
+                    "trigger_type": row["trigger_type"],
+                    "outcome": row["outcome"],
                     "realized_pnl": (
-                        float(parent_pnl) if parent_pnl is not None else None
+                        float(row["realized_pnl"])
+                        if row["realized_pnl"] is not None
+                        else None
                     ),
                     "created_at": (
-                        parent_created.isoformat() if parent_created else None
+                        row["parent_created_at"].isoformat()
+                        if row["parent_created_at"]
+                        else None
                     ),
                 }
             )
@@ -658,14 +875,17 @@ class RetrospectiveActionRepository:
 
 
 async def run_cutover(
-    conn: AsyncConnection, *, if_shadow: bool = False
+    conn: AsyncConnection,
+    *,
+    if_shadow: bool = False,
+    lock_timeout_ms: int = 30_000,
 ) -> dict[str, Any]:
     """Run the canonical cutover in the caller's transaction.
 
     Steps:
-    1. Take transaction-scoped advisory lock.
-    2. LOCK TABLE parent IN SHARE ROW EXCLUSIVE MODE.
-    3. Read control row; if already canonical and if_shadow, return idempotent.
+    1. Take transaction-scoped advisory lock and read control mode.
+    2. If already canonical and if_shadow, return without heavy table locks.
+    3. In shadow mode, lock parent → control → actions and re-read control mode.
     4. Delete all shadow children.
     5. Rebuild from frozen parent JSON (same backfill as migration).
     6. Verify full parity (count, ordinal, all canonical fields).
@@ -674,55 +894,63 @@ async def run_cutover(
     On parity failure, the entire transaction (including the mode switch) is
     left for the caller to roll back.
     """
-    # 1. Advisory lock (transaction-scoped)
+    if lock_timeout_ms <= 0:
+        raise ValueError("lock_timeout_ms must be positive")
+
     await conn.execute(
-        text("SELECT pg_advisory_xact_lock(:lock_id)"),
-        {"lock_id": _CUTOVER_ADVISORY_LOCK_ID},
+        text("SELECT set_config('lock_timeout', :timeout, true)"),
+        {"timeout": f"{lock_timeout_ms}ms"},
     )
+
+    # 1. Advisory lock (transaction-scoped). Do not queue indefinitely behind
+    # another cutover; the deploy can retry safely while mode remains shadow.
+    try:
+        lock_result = await conn.execute(
+            text("SELECT pg_try_advisory_xact_lock(:lock_id)"),
+            {"lock_id": _CUTOVER_ADVISORY_LOCK_ID},
+        )
+    except DBAPIError as exc:
+        raise CutoverLockError("failed to acquire cutover advisory lock") from exc
+    if not lock_result.scalar_one():
+        raise CutoverLockError("cutover advisory lock is already held")
+
+    # Avoid blocking writers on every post-cutover deploy. The advisory lock
+    # serializes compliant cutovers; the second read after table locking closes
+    # the gap against an out-of-band control-row update.
+    ctrl_row = await _read_cutover_control(conn)
+    idempotent_result = _validate_cutover_mode(ctrl_row, if_shadow=if_shadow)
+    if idempotent_result is not None:
+        return idempotent_result
 
     # 2. Lock tables in order: parent → control → actions
-    await conn.execute(
-        text("LOCK TABLE review.trade_retrospectives IN SHARE ROW EXCLUSIVE MODE")
-    )
-    await conn.execute(
-        text(
-            "LOCK TABLE review.trade_retrospective_action_control "
-            "IN SHARE ROW EXCLUSIVE MODE"
+    try:
+        await conn.execute(
+            text("LOCK TABLE review.trade_retrospectives IN SHARE ROW EXCLUSIVE MODE")
         )
-    )
-    await conn.execute(
-        text(
-            "LOCK TABLE review.trade_retrospective_actions IN SHARE ROW EXCLUSIVE MODE"
+        await conn.execute(
+            text(
+                "LOCK TABLE review.trade_retrospective_action_control "
+                "IN SHARE ROW EXCLUSIVE MODE"
+            )
         )
-    )
+        await conn.execute(
+            text(
+                "LOCK TABLE review.trade_retrospective_actions "
+                "IN SHARE ROW EXCLUSIVE MODE"
+            )
+        )
+    except DBAPIError as exc:
+        raise CutoverLockError(
+            f"cutover table lock timed out after {lock_timeout_ms}ms"
+        ) from exc
 
-    # 3. Read control row
-    ctrl_result = await conn.execute(
-        text(
-            "SELECT mode, cutover_at, cutover_action_count "
-            "FROM review.trade_retrospective_action_control WHERE id = 1"
-        )
-    )
-    ctrl_row = ctrl_result.fetchone()
-    if ctrl_row is None:
-        raise ActionControlError(
-            "retrospective action control row is missing; cutover aborted"
-        )
-    current_mode = ctrl_row.mode
+    # 3. Re-read while the frozen table set is held.
+    ctrl_row = await _read_cutover_control(conn, for_update=True)
+    idempotent_result = _validate_cutover_mode(ctrl_row, if_shadow=if_shadow)
+    if idempotent_result is not None:
+        return idempotent_result
 
-    if current_mode == "canonical":
-        # Idempotent: already canonical
-        return {
-            "mode": "canonical",
-            "action_count": ctrl_row.cutover_action_count or 0,
-            "cutover_at": ctrl_row.cutover_at,
-            "idempotent": True,
-        }
-
-    if current_mode != "shadow":
-        raise ActionControlError(
-            f'cannot cutover from mode "{current_mode}"; expected shadow'
-        )
+    await _validate_cutover_input(conn)
 
     # 4. Delete all existing children
     await conn.execute(text("DELETE FROM review.trade_retrospective_actions"))
@@ -741,7 +969,11 @@ async def run_cutover(
             SELECT
                 gen_random_uuid(),
                 t.id,
-                NULL,
+                CASE
+                    WHEN elem.value ? 'creation_key'
+                        THEN (elem.value->>'creation_key')::uuid
+                    ELSE NULL
+                END,
                 (elem.ordinality - 1)::integer,
                 btrim(elem.value->>'action'),
                 elem.value->>'owner',
@@ -806,7 +1038,7 @@ async def run_cutover(
         text(
             "UPDATE review.trade_retrospective_action_control "
             "SET mode = 'canonical', cutover_at = now(), "
-            "    cutover_action_count = :count "
+            "    cutover_action_count = :count, updated_at = now() "
             "WHERE id = 1"
         ),
         {"count": action_count},
@@ -818,6 +1050,122 @@ async def run_cutover(
         "cutover_at": datetime.now(UTC),
         "idempotent": False,
     }
+
+
+async def _read_cutover_control(
+    conn: AsyncConnection, *, for_update: bool = False
+) -> Any:
+    suffix = " FOR UPDATE" if for_update else ""
+    result = await conn.execute(
+        text(
+            "SELECT mode, cutover_at, cutover_action_count "
+            "FROM review.trade_retrospective_action_control WHERE id = 1" + suffix
+        )
+    )
+    return result.fetchone()
+
+
+def _validate_cutover_mode(ctrl_row: Any, *, if_shadow: bool) -> dict[str, Any] | None:
+    if ctrl_row is None:
+        raise ActionControlError(
+            "retrospective action control row is missing; cutover aborted"
+        )
+    current_mode = ctrl_row.mode
+    if current_mode == "canonical":
+        if not if_shadow:
+            raise ActionControlError(
+                "retrospective action mode is already canonical; "
+                "use --if-shadow for an idempotent no-op"
+            )
+        if ctrl_row.cutover_at is None or ctrl_row.cutover_action_count is None:
+            raise ActionControlError(
+                "canonical control row is missing cutover metadata; "
+                "manual recovery is required"
+            )
+        return {
+            "mode": "canonical",
+            "action_count": ctrl_row.cutover_action_count,
+            "cutover_at": ctrl_row.cutover_at,
+            "idempotent": True,
+        }
+    if current_mode != "shadow":
+        raise ActionControlError(
+            f'cannot cutover from mode "{current_mode}"; expected shadow'
+        )
+    return None
+
+
+async def _validate_cutover_input(conn: AsyncConnection) -> None:
+    """Validate the locked parent JSON snapshot before destructive rebuild."""
+    result = await conn.execute(
+        text(
+            "SELECT id, next_actions FROM review.trade_retrospectives "
+            "WHERE next_actions IS NOT NULL ORDER BY id"
+        )
+    )
+    for row in result:
+        actions = row.next_actions
+        if actions is not None and not isinstance(actions, list):
+            raise CutoverParityError(
+                f"retrospective {row.id}: next_actions is not an array"
+            )
+        creation_keys: set[uuid.UUID] = set()
+        for index, item in enumerate(actions or []):
+            prefix = f"retrospective {row.id} action[{index}]"
+            if not isinstance(item, dict):
+                raise CutoverParityError(f"{prefix}: element is not an object")
+
+            action = item.get("action")
+            if action is not None and not isinstance(action, str):
+                raise CutoverParityError(f"{prefix}: action must be a string")
+            if not isinstance(action, str) or not action.strip():
+                raise CutoverParityError(f"{prefix}: blank action")
+
+            if "force_new" in item:
+                raise CutoverParityError(
+                    f"{prefix}: force_new is transport-only and must not be persisted"
+                )
+
+            raw_creation_key = item.get("creation_key")
+            if "creation_key" in item:
+                if not isinstance(raw_creation_key, str):
+                    raise CutoverParityError(f"{prefix}: invalid creation_key")
+                try:
+                    creation_key = uuid.UUID(raw_creation_key)
+                except ValueError as exc:
+                    raise CutoverParityError(f"{prefix}: invalid creation_key") from exc
+                if creation_key in creation_keys:
+                    raise CutoverParityError(
+                        f"{prefix}: duplicate creation_key {creation_key}"
+                    )
+                creation_keys.add(creation_key)
+
+            status = item.get("status")
+            if status is not None:
+                if not isinstance(status, str):
+                    raise CutoverParityError(f"{prefix}: unknown status {status!r}")
+                if status.strip(" ") and status not in {
+                    "open",
+                    "in_progress",
+                    "done",
+                }:
+                    raise CutoverParityError(f"{prefix}: unknown status {status!r}")
+
+            raw_due = item.get("due_kst_date")
+            if raw_due is None:
+                continue
+            if not isinstance(raw_due, str):
+                raise CutoverParityError(f"{prefix}: invalid due_kst_date {raw_due!r}")
+            if raw_due.strip(" ") == "":
+                continue
+            try:
+                parsed_due = date.fromisoformat(raw_due)
+            except ValueError as exc:
+                raise CutoverParityError(
+                    f"{prefix}: invalid due_kst_date {raw_due!r}"
+                ) from exc
+            if parsed_due.isoformat() != raw_due:
+                raise CutoverParityError(f"{prefix}: invalid due_kst_date {raw_due!r}")
 
 
 async def _verify_parity(conn: AsyncConnection) -> None:
@@ -857,6 +1205,11 @@ async def _verify_parity(conn: AsyncConnection) -> None:
                 SELECT
                     t.id AS retrospective_id,
                     (elem.ordinality - 1)::integer AS position,
+                    CASE
+                        WHEN elem.value ? 'creation_key'
+                            THEN (elem.value->>'creation_key')::uuid
+                        ELSE NULL
+                    END AS creation_key,
                     btrim(elem.value->>'action') AS action,
                     elem.value->>'owner' AS owner,
                     elem.value->>'issue_id' AS issue_id,
@@ -870,7 +1223,27 @@ async def _verify_parity(conn: AsyncConnection) -> None:
                             THEN NULL
                         ELSE (elem.value->>'due_kst_date')::date
                     END AS due_kst_date,
-                    elem.value AS legacy_payload
+                    t.updated_at AS status_changed_at,
+                    CASE
+                        WHEN elem.value->>'status' = 'done' THEN t.updated_at
+                        ELSE NULL
+                    END AS resolved_at,
+                    NULL::text AS status_reason,
+                    CASE
+                        WHEN elem.value->>'status' = 'done' THEN
+                            jsonb_build_object(
+                                'schema_version', 1,
+                                'kind', 'legacy_status',
+                                'source', 'migration',
+                                'reference', 'review.trade_retrospectives.next_actions',
+                                'observed_at', t.updated_at,
+                                'summary', 'historical done; exact completion time unavailable'
+                            )
+                        ELSE NULL
+                    END AS status_evidence,
+                    elem.value AS legacy_payload,
+                    t.created_at AS created_at,
+                    t.updated_at AS updated_at
                 FROM review.trade_retrospectives t
                 CROSS JOIN LATERAL jsonb_array_elements(
                     CASE
@@ -886,16 +1259,22 @@ async def _verify_parity(conn: AsyncConnection) -> None:
               ON a.retrospective_id = e.retrospective_id
              AND a.position = e.position
             WHERE a.id IS NULL
-               OR a.creation_key IS NOT NULL
+               OR a.creation_key IS DISTINCT FROM e.creation_key
                OR a.action IS DISTINCT FROM e.action
                OR a.owner IS DISTINCT FROM e.owner
                OR a.issue_id IS DISTINCT FROM e.issue_id
                OR a.status IS DISTINCT FROM e.status
                OR a.due_kst_date IS DISTINCT FROM e.due_kst_date
                OR a.version <> 1
+               OR a.status_changed_at IS DISTINCT FROM e.status_changed_at
+               OR a.resolved_at IS DISTINCT FROM e.resolved_at
                OR a.status_actor <> 'migration:rob-878'
                OR a.status_source <> 'migration'
+               OR a.status_reason IS DISTINCT FROM e.status_reason
+               OR a.status_evidence IS DISTINCT FROM e.status_evidence
                OR a.legacy_payload IS DISTINCT FROM e.legacy_payload
+               OR a.created_at IS DISTINCT FROM e.created_at
+               OR a.updated_at IS DISTINCT FROM e.updated_at
             ORDER BY e.retrospective_id, e.position
             LIMIT 1
             """

--- a/app/services/trade_journal/retrospective_query_filters.py
+++ b/app/services/trade_journal/retrospective_query_filters.py
@@ -1,0 +1,67 @@
+"""Shared SQL predicates for retrospective and canonical-action readers."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+from sqlalchemy import and_, or_
+from sqlalchemy.sql.elements import ColumnElement
+
+from app.models.review import TradeRetrospective
+
+VALID_OUTCOME_FILTERS: frozenset[str] = frozenset({"win", "loss", "decided"})
+_KST = ZoneInfo("Asia/Seoul")
+
+
+def kst_day_start(date_str: str) -> datetime:
+    day = datetime.strptime(date_str, "%Y-%m-%d").date()
+    return datetime(day.year, day.month, day.day, tzinfo=_KST)
+
+
+def kst_day_end(date_str: str) -> datetime:
+    day = datetime.strptime(date_str, "%Y-%m-%d").date()
+    return datetime(day.year, day.month, day.day, 23, 59, 59, 999999, tzinfo=_KST)
+
+
+def sql_is_decided() -> ColumnElement[bool]:
+    return or_(
+        TradeRetrospective.realized_pnl.isnot(None),
+        TradeRetrospective.pnl_pct.isnot(None),
+    )
+
+
+def sql_is_win() -> ColumnElement[bool]:
+    return or_(
+        TradeRetrospective.realized_pnl > 0,
+        and_(
+            TradeRetrospective.realized_pnl.is_(None),
+            TradeRetrospective.pnl_pct > 0,
+        ),
+    )
+
+
+def sql_is_loss() -> ColumnElement[bool]:
+    return or_(
+        and_(
+            TradeRetrospective.realized_pnl.isnot(None),
+            TradeRetrospective.realized_pnl <= 0,
+        ),
+        and_(
+            TradeRetrospective.realized_pnl.is_(None),
+            TradeRetrospective.pnl_pct.isnot(None),
+            TradeRetrospective.pnl_pct <= 0,
+        ),
+    )
+
+
+def outcome_filter_predicate(value: str) -> ColumnElement[bool]:
+    if value == "win":
+        return sql_is_win()
+    if value == "loss":
+        return sql_is_loss()
+    if value == "decided":
+        return sql_is_decided()
+    raise ValueError(
+        f"invalid outcome_filter: {value} (allowed: {sorted(VALID_OUTCOME_FILTERS)})"
+    )

--- a/app/services/trade_journal/trade_retrospective_service.py
+++ b/app/services/trade_journal/trade_retrospective_service.py
@@ -35,6 +35,10 @@ from app.schemas.trade_retrospective import (
     NextAction,
 )
 from app.services.brokers.kis.mock_scalping_exec.ledger_state import real_order_filter
+from app.services.trade_journal.retrospective_action_repository import (
+    RetrospectiveActionRepository,
+    get_control_mode,
+)
 
 # Sentinel: distinguishes "caller did not provide this field" (preserve on
 # upsert) from "caller explicitly set None" (clear the field).
@@ -293,6 +297,7 @@ async def save_retrospective(
     next_actions: Any = _UNSET,
     guardrail_fired: Any = _UNSET,
     policy_version: Any = _UNSET,
+    actor: str = "internal:save_retrospective",
 ) -> tuple[str, TradeRetrospective]:
     if account_mode not in _VALID_ACCOUNT_MODES:
         raise RetrospectiveValidationError(f"invalid account_mode: {account_mode}")
@@ -431,6 +436,15 @@ async def save_retrospective(
         "fx_pnl_accuracy": fx_pnl_accuracy,
     }
 
+    # ROB-880: In canonical mode the write-fence trigger rejects direct
+    # next_actions writes, so the payload excludes it and the repository
+    # reconciles children + writes the projection with the GUC marker.
+    try:
+        ctrl_mode = await get_control_mode(db)
+    except Exception:
+        ctrl_mode = "shadow"
+    _is_canonical = ctrl_mode == "canonical"
+
     # ROB-647 — only include provided postmortem fields so an idempotent
     # re-save that omits them does not clobber prior values (partial-update).
     if trigger_type is not _UNSET:
@@ -441,7 +455,7 @@ async def save_retrospective(
         payload["intended_vs_happened"] = (
             None if intended_vs_happened_value is _UNSET else intended_vs_happened_value
         )
-    if next_actions is not _UNSET:
+    if next_actions is not _UNSET and not _is_canonical:
         payload["next_actions"] = (
             None if next_actions_value is _UNSET else next_actions_value
         )
@@ -451,7 +465,17 @@ async def save_retrospective(
         payload["policy_version"] = policy_version
 
     repo = TradeRetrospectiveRepository(db)
-    return await repo.upsert(payload)
+    status, retro = await repo.upsert(payload)
+
+    if _is_canonical and next_actions is not _UNSET and next_actions is not None:
+        action_repo = RetrospectiveActionRepository(db)
+        await action_repo.reconcile_actions(
+            retro.id,
+            next_actions_value if next_actions_value is not _UNSET else [],
+            actor=actor,
+        )
+
+    return status, retro
 
 
 def _kst_day_start(date_str: str) -> datetime:
@@ -570,11 +594,19 @@ async def get_open_next_actions(
 ) -> dict[str, Any]:
     """Flatten incomplete next_actions across recent retrospectives.
 
-    Bounded scan (``limit`` most-recent rows) — NOT full history; the
-    ``scan_limit`` echo makes that explicit to callers. ``statuses=None``
-    means "not done" (open/in_progress/unset all surface); a set narrows to
-    exact status values.
+    In shadow mode: bounded scan of parent JSONB.
+    In canonical mode: queries the child ledger directly (no scan limit needed).
     """
+    try:
+        ctrl_mode = await get_control_mode(db)
+    except Exception:
+        ctrl_mode = "shadow"
+
+    if ctrl_mode == "canonical":
+        return await _get_open_next_actions_canonical(
+            db, market=market, symbol=symbol, statuses=statuses, limit=limit
+        )
+
     filters: list = []
     if market is not None:
         filters.append(TradeRetrospective.market == market)
@@ -646,6 +678,86 @@ async def get_open_next_actions(
                 }
             )
     return {"items": items, "count": len(items), "scan_limit": limit}
+
+
+async def _get_open_next_actions_canonical(
+    db: AsyncSession,
+    *,
+    market: str | None = None,
+    symbol: str | None = None,
+    statuses: frozenset[str] | None = None,
+    limit: int = 200,
+) -> dict[str, Any]:
+    """Canonical-mode implementation of get_open_next_actions.
+
+    Reads from the child ledger and formats results in the legacy response
+    shape, with action_id and version added additively.
+    """
+    repo = RetrospectiveActionRepository(db)
+    result = await repo.query_actions(
+        statuses=statuses,
+        market=market,
+        symbol=symbol,
+        limit=limit,
+        offset=0,
+    )
+    items: list[dict[str, Any]] = []
+    for item in result["items"]:
+        items.append(
+            {
+                "action": item["action"],
+                "owner": item.get("owner"),
+                "issue_id": item.get("issue_id"),
+                "status": item.get("status"),
+                "due_kst_date": item.get("due_kst_date"),
+                "symbol": item.get("symbol"),
+                "market": item.get("market"),
+                "retro_id": item.get("retrospective_id"),
+                "correlation_id": item.get("correlation_id"),
+                "trigger_type": item.get("trigger_type"),
+                "realized_pnl": item.get("realized_pnl"),
+                "created_at": item.get("created_at"),
+                "action_id": item.get("action_id"),
+                "version": item.get("version"),
+            }
+        )
+    return {"items": items, "count": len(items), "scan_limit": limit}
+
+
+async def get_canonical_actions(
+    db: AsyncSession,
+    *,
+    statuses: frozenset[str] | None = None,
+    market: str | None = None,
+    symbol: str | None = None,
+    symbol_search: str | None = None,
+    owner: str | None = None,
+    issue_id: str | None = None,
+    overdue_only: bool = False,
+    trigger_type: str | None = None,
+    outcome_filter: str | None = None,
+    kst_date_from: str | None = None,
+    kst_date_to: str | None = None,
+    limit: int = 50,
+    offset: int = 0,
+) -> dict[str, Any]:
+    """Canonical action query with pagination, filters, and overdue-first ordering."""
+    repo = RetrospectiveActionRepository(db)
+    return await repo.query_actions(
+        statuses=statuses,
+        market=market,
+        symbol=symbol,
+        symbol_search=symbol_search,
+        owner=owner,
+        issue_id=issue_id,
+        overdue_only=overdue_only,
+        trigger_type=trigger_type,
+        outcome_filter=outcome_filter,
+        kst_date_from=kst_date_from,
+        kst_date_to=kst_date_to,
+        limit=limit,
+        offset=offset,
+    )
 
 
 def _is_win(r: TradeRetrospective) -> bool:

--- a/app/services/trade_journal/trade_retrospective_service.py
+++ b/app/services/trade_journal/trade_retrospective_service.py
@@ -601,6 +601,7 @@ async def save_retrospective(
             retro.id,
             next_actions_value if next_actions_value is not _UNSET else [],
             actor=actor,
+            control_mode=ctrl_mode,
         )
 
     return status, retro

--- a/app/services/trade_journal/trade_retrospective_service.py
+++ b/app/services/trade_journal/trade_retrospective_service.py
@@ -13,9 +13,9 @@ from typing import Any
 from zoneinfo import ZoneInfo
 
 from pydantic import ValidationError
-from sqlalchemy import and_, func, or_, select, text
+from sqlalchemy import func, select, text
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.sql.elements import ColumnElement
 
 from app.core.symbol import to_db_symbol
 from app.core.timezone import now_kst
@@ -36,8 +36,27 @@ from app.schemas.trade_retrospective import (
 )
 from app.services.brokers.kis.mock_scalping_exec.ledger_state import real_order_filter
 from app.services.trade_journal.retrospective_action_repository import (
+    ActionControlError,
     RetrospectiveActionRepository,
     get_control_mode,
+)
+from app.services.trade_journal.retrospective_query_filters import (
+    VALID_OUTCOME_FILTERS,
+)
+from app.services.trade_journal.retrospective_query_filters import (
+    kst_day_end as _kst_day_end,
+)
+from app.services.trade_journal.retrospective_query_filters import (
+    kst_day_start as _kst_day_start,
+)
+from app.services.trade_journal.retrospective_query_filters import (
+    sql_is_decided as _sql_is_decided,
+)
+from app.services.trade_journal.retrospective_query_filters import (
+    sql_is_loss as _sql_is_loss,
+)
+from app.services.trade_journal.retrospective_query_filters import (
+    sql_is_win as _sql_is_win,
 )
 
 # Sentinel: distinguishes "caller did not provide this field" (preserve on
@@ -98,7 +117,9 @@ def _coerce_next_actions(raw: Any) -> list[dict[str, Any]]:
             raise RetrospectiveValidationError(
                 f"invalid next_actions[{i}]: {exc.errors(include_url=False)}"
             ) from exc
-        out.append(model.model_dump(exclude_none=True))
+        out.append(
+            model.model_dump(mode="json", exclude_none=True, exclude_defaults=True)
+        )
     return out
 
 
@@ -141,7 +162,9 @@ def _avg(values: list) -> float | None:
     return float(sum(nums) / len(nums))
 
 
-def serialize_retrospective(r: TradeRetrospective) -> dict[str, Any]:
+def serialize_retrospective(
+    r: TradeRetrospective, *, next_actions_override: Any = _UNSET
+) -> dict[str, Any]:
     return {
         "id": r.id,
         "correlation_id": r.correlation_id,
@@ -189,7 +212,9 @@ def serialize_retrospective(r: TradeRetrospective) -> dict[str, Any]:
         "trigger_type": r.trigger_type,
         "root_cause_class": r.root_cause_class,
         "intended_vs_happened": r.intended_vs_happened,
-        "next_actions": r.next_actions,
+        "next_actions": (
+            r.next_actions if next_actions_override is _UNSET else next_actions_override
+        ),
         "guardrail_fired": r.guardrail_fired,
         "policy_version": r.policy_version,
         "created_at": r.created_at.isoformat() if r.created_at else None,
@@ -204,30 +229,70 @@ class TradeRetrospectiveRepository:
         self.db = db
 
     async def get_by_correlation_id(
-        self, correlation_id: str, account_mode: str | None = None
+        self,
+        correlation_id: str,
+        account_mode: str | None = None,
+        *,
+        for_update: bool = False,
     ) -> TradeRetrospective | None:
         stmt = select(TradeRetrospective).where(
             TradeRetrospective.correlation_id == correlation_id
         )
         if account_mode is not None:
             stmt = stmt.where(TradeRetrospective.account_mode == account_mode)
+        if for_update:
+            stmt = stmt.with_for_update()
         result = await self.db.execute(stmt.limit(1))
         return result.scalar_one_or_none()
 
-    async def upsert(self, payload: dict[str, Any]) -> tuple[str, TradeRetrospective]:
+    async def upsert(
+        self,
+        payload: dict[str, Any],
+        *,
+        create_defaults: dict[str, Any] | None = None,
+    ) -> tuple[str, TradeRetrospective]:
         cid = payload.get("correlation_id")
         account_mode = payload.get("account_mode")
         if cid is not None:
-            existing = await self.get_by_correlation_id(cid, account_mode)
+            existing = await self.get_by_correlation_id(
+                cid, account_mode, for_update=True
+            )
             if existing is not None:
                 for key, value in payload.items():
                     setattr(existing, key, value)
                 await self.db.flush()
                 return "updated", existing
-        row = TradeRetrospective(**payload)
-        self.db.add(row)
-        await self.db.flush()
+        create_payload = dict(create_defaults or {})
+        create_payload.update(payload)
+        row = TradeRetrospective(**create_payload)
+        try:
+            async with self.db.begin_nested():
+                self.db.add(row)
+                await self.db.flush()
+        except IntegrityError as exc:
+            constraint = _integrity_constraint_name(exc)
+            if "uq_trade_retrospectives_correlation_account" not in constraint:
+                raise
+            if cid is None:
+                raise
+            existing = await self.get_by_correlation_id(
+                cid, account_mode, for_update=True
+            )
+            if existing is None:
+                raise
+            for key, value in payload.items():
+                setattr(existing, key, value)
+            await self.db.flush()
+            return "updated", existing
         return "created", row
+
+
+def _integrity_constraint_name(exc: IntegrityError) -> str:
+    orig = getattr(exc, "orig", None)
+    name = getattr(orig, "constraint_name", None)
+    if name:
+        return str(name)
+    return str(orig or exc)
 
 
 async def _load_trade_journal(
@@ -265,32 +330,32 @@ async def save_retrospective(
     instrument_type: str,
     account_mode: str,
     outcome: str,
-    side: str | None = None,
-    market: str | None = None,
-    strategy_key: str | None = None,
+    side: Any = _UNSET,
+    market: Any = _UNSET,
+    strategy_key: Any = _UNSET,
     correlation_id: str | None = None,
-    journal_id: int | None = None,
-    report_uuid: str | None = None,
-    report_item_uuid: str | None = None,
-    plan_price: float | None = None,
-    fill_price: float | None = None,
-    realized_pnl: float | None = None,
-    realized_pnl_currency: str | None = None,
-    pnl_pct: float | None = None,
-    rationale: str | None = None,
-    result_summary: str | None = None,
-    lesson: str | None = None,
-    next_strategy: str | None = None,
-    evidence_snapshot: dict | None = None,
-    created_by_profile: str | None = None,
-    buy_fx_rate: float | None = None,
-    sell_fx_rate: float | None = None,
-    fx_pnl_krw: float | None = None,
-    security_pnl_usd: float | None = None,
-    security_pnl_krw: float | None = None,
-    total_pnl_krw: float | None = None,
-    fx_rate_source: str | None = None,
-    fx_pnl_accuracy: str | None = None,
+    journal_id: Any = _UNSET,
+    report_uuid: Any = _UNSET,
+    report_item_uuid: Any = _UNSET,
+    plan_price: Any = _UNSET,
+    fill_price: Any = _UNSET,
+    realized_pnl: Any = _UNSET,
+    realized_pnl_currency: Any = _UNSET,
+    pnl_pct: Any = _UNSET,
+    rationale: Any = _UNSET,
+    result_summary: Any = _UNSET,
+    lesson: Any = _UNSET,
+    next_strategy: Any = _UNSET,
+    evidence_snapshot: Any = _UNSET,
+    created_by_profile: Any = _UNSET,
+    buy_fx_rate: Any = _UNSET,
+    sell_fx_rate: Any = _UNSET,
+    fx_pnl_krw: Any = _UNSET,
+    security_pnl_usd: Any = _UNSET,
+    security_pnl_krw: Any = _UNSET,
+    total_pnl_krw: Any = _UNSET,
+    fx_rate_source: Any = _UNSET,
+    fx_pnl_accuracy: Any = _UNSET,
     trigger_type: Any = _UNSET,
     root_cause_class: Any = _UNSET,
     intended_vs_happened: Any = _UNSET,
@@ -306,11 +371,12 @@ async def save_retrospective(
             f"invalid outcome: {outcome} "
             f"(allowed: {', '.join(sorted(_VALID_OUTCOMES))})"
         )
-    if side is not None and side not in ("buy", "sell"):
+    if side is not _UNSET and side is not None and side not in ("buy", "sell"):
         raise RetrospectiveValidationError(f"invalid side: {side}")
-    if realized_pnl_currency is not None and realized_pnl_currency not in (
-        "KRW",
-        "USD",
+    if (
+        realized_pnl_currency is not _UNSET
+        and realized_pnl_currency is not None
+        and realized_pnl_currency not in ("KRW", "USD")
     ):
         raise RetrospectiveValidationError(
             f"invalid realized_pnl_currency: {realized_pnl_currency}"
@@ -354,96 +420,158 @@ async def save_retrospective(
     # should be available.
     fill_evidence_available = account_mode != "kiwoom_mock"
     if not fill_evidence_available and (
-        realized_pnl is not None or fill_price is not None
+        (realized_pnl is not _UNSET and realized_pnl is not None)
+        or (fill_price is not _UNSET and fill_price is not None)
     ):
         raise RetrospectiveValidationError(
             f"{account_mode} cannot read fills (ROB-460); "
             "realized_pnl/fill_price not allowed"
         )
 
+    create_defaults: dict[str, Any] = {}
     journal_row = (
         await _load_trade_journal(db, journal_id)
-        if journal_id is not None and fill_evidence_available
+        if journal_id is not _UNSET
+        and journal_id is not None
+        and fill_evidence_available
         else None
     )
 
-    realized_pnl_value = _to_decimal(realized_pnl)
-    realized_pnl_source: str | None = None
-    if realized_pnl_value is not None:
-        realized_pnl_source = "caller_supplied"
-    elif journal_id is not None and fill_evidence_available:
-        derived = _realized_pnl_from_journal(journal_row, side)
+    realized_pnl_value: Any = _UNSET
+    realized_pnl_source: Any = _UNSET
+    derived_realized_pnl: Decimal | None = None
+    if realized_pnl is not _UNSET:
+        realized_pnl_value = _to_decimal(realized_pnl)
+        realized_pnl_source = (
+            "caller_supplied" if realized_pnl_value is not None else None
+        )
+    elif (
+        journal_id is not _UNSET and journal_id is not None and fill_evidence_available
+    ):
+        derived = _realized_pnl_from_journal(
+            journal_row, None if side is _UNSET else side
+        )
         if derived is not None:
-            realized_pnl_value = derived
-            realized_pnl_source = "derived_from_journal"
+            derived_realized_pnl = derived
+            create_defaults["realized_pnl"] = derived
+            create_defaults["realized_pnl_source"] = "derived_from_journal"
 
     if journal_row is not None:
-        if buy_fx_rate is None and journal_row.buy_fx_rate is not None:
-            buy_fx_rate = float(journal_row.buy_fx_rate)
-        if sell_fx_rate is None and journal_row.sell_fx_rate is not None:
-            sell_fx_rate = float(journal_row.sell_fx_rate)
-        if fx_pnl_krw is None and journal_row.fx_pnl_krw is not None:
-            fx_pnl_krw = float(journal_row.fx_pnl_krw)
-        if security_pnl_usd is None and journal_row.security_pnl_usd is not None:
-            security_pnl_usd = float(journal_row.security_pnl_usd)
-        if security_pnl_krw is None and journal_row.security_pnl_krw is not None:
-            security_pnl_krw = float(journal_row.security_pnl_krw)
-        if total_pnl_krw is None and journal_row.total_pnl_krw is not None:
-            total_pnl_krw = float(journal_row.total_pnl_krw)
-        fx_rate_source = fx_rate_source or journal_row.fx_rate_source
-        fx_pnl_accuracy = fx_pnl_accuracy or journal_row.fx_pnl_accuracy
+        if buy_fx_rate is _UNSET and journal_row.buy_fx_rate is not None:
+            create_defaults["buy_fx_rate"] = journal_row.buy_fx_rate
+        if sell_fx_rate is _UNSET and journal_row.sell_fx_rate is not None:
+            create_defaults["sell_fx_rate"] = journal_row.sell_fx_rate
+        if fx_pnl_krw is _UNSET and journal_row.fx_pnl_krw is not None:
+            create_defaults["fx_pnl_krw"] = journal_row.fx_pnl_krw
+        if security_pnl_usd is _UNSET and journal_row.security_pnl_usd is not None:
+            create_defaults["security_pnl_usd"] = journal_row.security_pnl_usd
+        if security_pnl_krw is _UNSET and journal_row.security_pnl_krw is not None:
+            create_defaults["security_pnl_krw"] = journal_row.security_pnl_krw
+        if total_pnl_krw is _UNSET and journal_row.total_pnl_krw is not None:
+            create_defaults["total_pnl_krw"] = journal_row.total_pnl_krw
+        if fx_rate_source is _UNSET and journal_row.fx_rate_source is not None:
+            create_defaults["fx_rate_source"] = journal_row.fx_rate_source
+        if fx_pnl_accuracy is _UNSET and journal_row.fx_pnl_accuracy is not None:
+            create_defaults["fx_pnl_accuracy"] = journal_row.fx_pnl_accuracy
 
-    if realized_pnl_value is not None and realized_pnl_currency is None:
+    if (
+        realized_pnl_value is not _UNSET
+        and realized_pnl_value is not None
+        and (realized_pnl_currency is _UNSET or realized_pnl_currency is None)
+    ):
         realized_pnl_currency = _infer_currency(instrument_type)
         if realized_pnl_currency is None:
             raise RetrospectiveValidationError(
                 "realized_pnl requires realized_pnl_currency "
                 f"(could not infer from instrument_type={instrument_type})"
             )
+    elif derived_realized_pnl is not None and (
+        realized_pnl_currency is _UNSET or realized_pnl_currency is None
+    ):
+        inferred_currency = _infer_currency(instrument_type)
+        if inferred_currency is None:
+            raise RetrospectiveValidationError(
+                "derived realized_pnl requires realized_pnl_currency "
+                f"(could not infer from instrument_type={instrument_type})"
+            )
+        create_defaults["realized_pnl_currency"] = inferred_currency
 
     payload: dict[str, Any] = {
         "symbol": _normalize_symbol(symbol, instrument_type),
         "instrument_type": instrument_type,
         "account_mode": account_mode,
         "outcome": outcome,
+        "correlation_id": correlation_id,
+        "fill_evidence_available": fill_evidence_available,
+    }
+    raw_optional_payload = {
         "side": side,
         "market": market,
         "strategy_key": strategy_key,
-        "correlation_id": correlation_id,
         "journal_id": journal_id,
         "report_uuid": report_uuid,
         "report_item_uuid": report_item_uuid,
-        "plan_price": _to_decimal(plan_price),
-        "fill_price": _to_decimal(fill_price),
         "realized_pnl": realized_pnl_value,
         "realized_pnl_currency": realized_pnl_currency,
         "realized_pnl_source": realized_pnl_source,
-        "pnl_pct": _to_decimal(pnl_pct),
-        "fill_evidence_available": fill_evidence_available,
         "rationale": rationale,
         "result_summary": result_summary,
         "lesson": lesson,
         "next_strategy": next_strategy,
         "evidence_snapshot": evidence_snapshot,
         "created_by_profile": created_by_profile,
-        "buy_fx_rate": _to_decimal(buy_fx_rate),
-        "sell_fx_rate": _to_decimal(sell_fx_rate),
-        "fx_pnl_krw": _to_decimal(fx_pnl_krw),
-        "security_pnl_usd": _to_decimal(security_pnl_usd),
-        "security_pnl_krw": _to_decimal(security_pnl_krw),
-        "total_pnl_krw": _to_decimal(total_pnl_krw),
         "fx_rate_source": fx_rate_source,
         "fx_pnl_accuracy": fx_pnl_accuracy,
     }
+    payload.update(
+        {
+            key: value
+            for key, value in raw_optional_payload.items()
+            if value is not _UNSET
+        }
+    )
+    decimal_optional_payload = {
+        "plan_price": plan_price,
+        "fill_price": fill_price,
+        "pnl_pct": pnl_pct,
+        "buy_fx_rate": buy_fx_rate,
+        "sell_fx_rate": sell_fx_rate,
+        "fx_pnl_krw": fx_pnl_krw,
+        "security_pnl_usd": security_pnl_usd,
+        "security_pnl_krw": security_pnl_krw,
+        "total_pnl_krw": total_pnl_krw,
+    }
+    payload.update(
+        {
+            key: _to_decimal(value)
+            for key, value in decimal_optional_payload.items()
+            if value is not _UNSET
+        }
+    )
 
     # ROB-880: In canonical mode the write-fence trigger rejects direct
     # next_actions writes, so the payload excludes it and the repository
     # reconciles children + writes the projection with the GUC marker.
-    try:
-        ctrl_mode = await get_control_mode(db)
-    except Exception:
-        ctrl_mode = "shadow"
+    ctrl_mode = await get_control_mode(db)
     _is_canonical = ctrl_mode == "canonical"
+
+    if next_actions_value is not _UNSET and not _is_canonical:
+        shadow_actions: list[dict[str, Any]] = []
+        for index, action_item in enumerate(next_actions_value):
+            if action_item.get("status") in {"obsolete", "expired"}:
+                raise RetrospectiveValidationError(
+                    f"next_actions[{index}] status is canonical-only in shadow mode"
+                )
+            if "action_id" in action_item or "version" in action_item:
+                raise RetrospectiveValidationError(
+                    f"next_actions[{index}] canonical identity is invalid in shadow mode"
+                )
+            stored_item = dict(action_item)
+            # force_new is request intent. Keep only the stable creation_key in
+            # the shadow JSON so cutover can preserve retry idempotency.
+            stored_item.pop("force_new", None)
+            shadow_actions.append(stored_item)
+        next_actions_value = shadow_actions
 
     # ROB-647 — only include provided postmortem fields so an idempotent
     # re-save that omits them does not clobber prior values (partial-update).
@@ -465,7 +593,7 @@ async def save_retrospective(
         payload["policy_version"] = policy_version
 
     repo = TradeRetrospectiveRepository(db)
-    status, retro = await repo.upsert(payload)
+    status, retro = await repo.upsert(payload, create_defaults=create_defaults)
 
     if _is_canonical and next_actions is not _UNSET and next_actions is not None:
         action_repo = RetrospectiveActionRepository(db)
@@ -476,16 +604,6 @@ async def save_retrospective(
         )
 
     return status, retro
-
-
-def _kst_day_start(date_str: str) -> datetime:
-    d = datetime.strptime(date_str, "%Y-%m-%d").date()
-    return datetime(d.year, d.month, d.day, 0, 0, 0, tzinfo=_KST)
-
-
-def _kst_day_end(date_str: str) -> datetime:
-    d = datetime.strptime(date_str, "%Y-%m-%d").date()
-    return datetime(d.year, d.month, d.day, 23, 59, 59, 999999, tzinfo=_KST)
 
 
 def _kst_date_str(dt: datetime) -> str:
@@ -565,11 +683,18 @@ async def get_retrospectives(
         .offset(offset)
     )
     rows = (await db.execute(stmt)).scalars().all()
+    actions_by_parent = await RetrospectiveActionRepository(db).read_actions_many(rows)
     by_outcome: dict[str, int] = {}
     for r in rows:
         by_outcome[r.outcome] = by_outcome.get(r.outcome, 0) + 1
     return {
-        "entries": [serialize_retrospective(r) for r in rows],
+        "entries": [
+            serialize_retrospective(
+                r,
+                next_actions_override=actions_by_parent[r.id],
+            )
+            for r in rows
+        ],
         "summary": {"count": len(rows), "by_outcome": by_outcome, "total": int(total)},
     }
 
@@ -597,10 +722,7 @@ async def get_open_next_actions(
     In shadow mode: bounded scan of parent JSONB.
     In canonical mode: queries the child ledger directly (no scan limit needed).
     """
-    try:
-        ctrl_mode = await get_control_mode(db)
-    except Exception:
-        ctrl_mode = "shadow"
+    ctrl_mode = await get_control_mode(db)
 
     if ctrl_mode == "canonical":
         return await _get_open_next_actions_canonical(
@@ -694,21 +816,37 @@ async def _get_open_next_actions_canonical(
     shape, with action_id and version added additively.
     """
     repo = RetrospectiveActionRepository(db)
+    canonical_statuses = statuses
+    if statuses is not None and "done" in statuses:
+        canonical_statuses = (statuses - {"done"}) | {
+            "done",
+            "obsolete",
+            "expired",
+        }
     result = await repo.query_actions(
-        statuses=statuses,
+        statuses=canonical_statuses,
         market=market,
         symbol=symbol,
-        limit=limit,
+        limit=None,
         offset=0,
     )
     items: list[dict[str, Any]] = []
     for item in result["items"]:
+        canonical_status = item.get("status")
+        legacy_status = (
+            "done" if canonical_status in {"obsolete", "expired"} else canonical_status
+        )
         items.append(
             {
                 "action": item["action"],
                 "owner": item.get("owner"),
                 "issue_id": item.get("issue_id"),
-                "status": item.get("status"),
+                "status": legacy_status,
+                "terminal_status": (
+                    canonical_status
+                    if canonical_status in {"obsolete", "expired"}
+                    else None
+                ),
                 "due_kst_date": item.get("due_kst_date"),
                 "symbol": item.get("symbol"),
                 "market": item.get("market"),
@@ -719,9 +857,10 @@ async def _get_open_next_actions_canonical(
                 "created_at": item.get("created_at"),
                 "action_id": item.get("action_id"),
                 "version": item.get("version"),
+                "overdue": item.get("overdue", False),
             }
         )
-    return {"items": items, "count": len(items), "scan_limit": limit}
+    return {"items": items, "count": len(items), "scan_limit": 0}
 
 
 async def get_canonical_actions(
@@ -738,10 +877,16 @@ async def get_canonical_actions(
     outcome_filter: str | None = None,
     kst_date_from: str | None = None,
     kst_date_to: str | None = None,
+    due_before: str | None = None,
     limit: int = 50,
     offset: int = 0,
 ) -> dict[str, Any]:
     """Canonical action query with pagination, filters, and overdue-first ordering."""
+    mode = await get_control_mode(db)
+    if mode != "canonical":
+        raise ActionControlError(
+            f"canonical action reader is unavailable while mode is {mode}"
+        )
     repo = RetrospectiveActionRepository(db)
     return await repo.query_actions(
         statuses=statuses,
@@ -755,6 +900,7 @@ async def get_canonical_actions(
         outcome_filter=outcome_filter,
         kst_date_from=kst_date_from,
         kst_date_to=kst_date_to,
+        due_before=due_before,
         limit=limit,
         offset=offset,
     )
@@ -768,58 +914,6 @@ def _is_win(r: TradeRetrospective) -> bool:
 
 def _is_decided(r: TradeRetrospective) -> bool:
     return r.realized_pnl is not None or r.pnl_pct is not None
-
-
-# ROB-691 — SQL-side mirrors of `_is_win`/`_is_decided` above, used by
-# get_retrospectives' `outcome_filter` query param. MUST be kept in lock-step
-# with the Python predicates (same tie=0-is-a-loss rule, same pnl_pct
-# fallback-only-when-realized_pnl-is-NULL semantics); see the parallel
-# equivalence test in tests/test_trade_retrospective_aggregate.py
-# (test_outcome_filter_matches_python_predicate) that guards against drift.
-VALID_OUTCOME_FILTERS: frozenset[str] = frozenset({"win", "loss", "decided"})
-
-
-def _sql_is_decided() -> ColumnElement[bool]:
-    """SQL predicate mirroring `_is_decided` — keep in lock-step."""
-    return or_(
-        TradeRetrospective.realized_pnl.isnot(None),
-        TradeRetrospective.pnl_pct.isnot(None),
-    )
-
-
-def _sql_is_win() -> ColumnElement[bool]:
-    """SQL predicate mirroring `_is_win` — keep in lock-step.
-
-    `_is_win`: if realized_pnl is not None -> realized_pnl > 0 (strict; a tie
-    at 0 is NOT a win); else -> pnl_pct is not None and pnl_pct > 0.
-    """
-    return or_(
-        TradeRetrospective.realized_pnl > 0,
-        and_(
-            TradeRetrospective.realized_pnl.is_(None),
-            TradeRetrospective.pnl_pct > 0,
-        ),
-    )
-
-
-def _sql_is_loss() -> ColumnElement[bool]:
-    """SQL predicate = decided AND NOT win, spelled out explicitly (rather
-    than `and_(_sql_is_decided(), not_(_sql_is_win()))`) to avoid SQL's
-    three-valued NULL logic silently mis-classifying NULL columns as "unknown"
-    instead of following the Python if/else short-circuit. Keep in lock-step
-    with `_is_win`/`_is_decided`.
-    """
-    return or_(
-        and_(
-            TradeRetrospective.realized_pnl.isnot(None),
-            TradeRetrospective.realized_pnl <= 0,
-        ),
-        and_(
-            TradeRetrospective.realized_pnl.is_(None),
-            TradeRetrospective.pnl_pct.isnot(None),
-            TradeRetrospective.pnl_pct <= 0,
-        ),
-    )
 
 
 def _prefix_like(raw: str) -> str:

--- a/scripts/deploy-native.sh
+++ b/scripts/deploy-native.sh
@@ -87,6 +87,8 @@ SWITCHED=0
 # whether it also needs to roll back the api/mcp half (color state, color
 # symlinks, color launchd jobs, HAProxy cfg).
 BLUEGREEN_COMMITTED=0
+RETROSPECTIVE_ACTION_CUTOVER_ATTEMPTED=0
+RETROSPECTIVE_ACTION_SAFE_PRECOMMIT_EXIT=10
 API_PRE_COLOR=""
 MCP_PRE_COLOR=""
 BLUE_PRE_TARGET=""
@@ -322,9 +324,31 @@ run_healthcheck() {
   return 1
 }
 
+run_retrospective_action_cutover() {
+  local rc
+
+  RETROSPECTIVE_ACTION_CUTOVER_ATTEMPTED=1
+  set +e
+  ENV_FILE="$SHARED_ENV" uv run python scripts/retrospective_action_cutover.py --if-shadow
+  rc=$?
+  set -e
+
+  if (( rc == RETROSPECTIVE_ACTION_SAFE_PRECOMMIT_EXIT )); then
+    # The CLI guarantees no canonical commit for this exit state, so the
+    # normal deploy rollback path remains safe and needs no roll-forward warning.
+    RETROSPECTIVE_ACTION_CUTOVER_ATTEMPTED=0
+  fi
+  return "$rc"
+}
+
 rollback() {
   local exit_code=$?
   echo "Deploy failed with exit code $exit_code" >&2
+
+  if (( RETROSPECTIVE_ACTION_CUTOVER_ATTEMPTED == 1 )); then
+    echo "WARNING: retrospective action cutover was attempted; the database may already be canonical." >&2
+    echo "Disable retrospective action mutation, roll forward, and do not schema-downgrade." >&2
+  fi
 
   # ROB-259 review: when deploy_bluegreen_flow committed but a later step
   # (restart_single_active_services, run_healthcheck) failed, the api/mcp
@@ -449,7 +473,7 @@ run_healthcheck
 # restarted, and healthcheck passed. --if-shadow makes it idempotent.
 if (( BLUEGREEN_COMMITTED == 1 )); then
   log "Running retrospective action canonical cutover (--if-shadow)"
-  uv run python scripts/retrospective_action_cutover.py --if-shadow
+  run_retrospective_action_cutover
 else
   log "Skipping retrospective action cutover (BLUEGREEN_COMMITTED != 1)"
 fi

--- a/scripts/deploy-native.sh
+++ b/scripts/deploy-native.sh
@@ -444,5 +444,15 @@ verify_mcp_profile_release_paths
 log "Running healthcheck"
 run_healthcheck
 
+# ROB-880: post-switch canonical cutover for retrospective actions.
+# Runs only after blue/green is committed, traffic switched, services
+# restarted, and healthcheck passed. --if-shadow makes it idempotent.
+if (( BLUEGREEN_COMMITTED == 1 )); then
+  log "Running retrospective action canonical cutover (--if-shadow)"
+  uv run python scripts/retrospective_action_cutover.py --if-shadow
+else
+  log "Skipping retrospective action cutover (BLUEGREEN_COMMITTED != 1)"
+fi
+
 trap - ERR
 log "Deploy complete: $SHA"

--- a/scripts/retrospective_action_cutover.py
+++ b/scripts/retrospective_action_cutover.py
@@ -36,7 +36,8 @@ Rollback / roll-forward procedure:
 
 Exit codes:
     0 — cutover succeeded (or idempotent no-op with --if-shadow)
-    1 — cutover failed (parity error, control error, or DB error)
+    10 — safe pre-commit failure; mode remains shadow and rollback is safe
+    20 — committed or commit-unknown failure; mutation-disable + roll-forward
     2 — invalid arguments
 """
 
@@ -53,15 +54,32 @@ from sqlalchemy.ext.asyncio import AsyncConnection
 from app.core.db import engine
 from app.services.trade_journal.retrospective_action_repository import (
     ActionControlError,
+    CutoverLockError,
     CutoverParityError,
     run_cutover,
 )
 
+EXIT_OK = 0
+EXIT_SAFE_PRECOMMIT = 10
+EXIT_COMMITTED_OR_UNKNOWN = 20
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    return argparse.ArgumentParser(
+        description="Canonical cutover for retrospective action ledger (ROB-878).",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Recovery and exit states:
+  exit 10  Safe rollback. The transaction did not commit and mode remains shadow.
+  exit 20  Commit succeeded or its outcome is unknown. Disable retrospective
+           action mutation, roll-forward the new release, and do not downgrade
+           the schema.
+""",
+    )
+
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
-    parser = argparse.ArgumentParser(
-        description="Canonical cutover for retrospective action ledger (ROB-878).",
-    )
+    parser = _build_parser()
     parser.add_argument(
         "--if-shadow",
         action="store_true",
@@ -89,6 +107,8 @@ async def _health_check(conn: AsyncConnection) -> dict[str, Any]:
         return {"healthy": False, "reason": "control row missing"}
     if ctrl.mode != "canonical":
         return {"healthy": False, "reason": f"mode is {ctrl.mode}, not canonical"}
+    if ctrl.cutover_at is None or ctrl.cutover_action_count is None:
+        return {"healthy": False, "reason": "canonical cutover metadata is missing"}
 
     # Quick count parity
     count_result = await conn.execute(
@@ -114,12 +134,61 @@ async def _health_check(conn: AsyncConnection) -> dict[str, Any]:
             "reason": f"count mismatch: parent={counts.parent_count}, "
             f"child={counts.child_count}",
         }
+    parity_result = await conn.execute(
+        text(
+            """
+            WITH parent_actions AS (
+                SELECT
+                    t.id AS retrospective_id,
+                    (elem.ordinality - 1)::integer AS position,
+                    elem.value AS payload
+                FROM review.trade_retrospectives t
+                CROSS JOIN LATERAL jsonb_array_elements(
+                    CASE
+                        WHEN jsonb_typeof(t.next_actions) = 'array'
+                            THEN t.next_actions
+                        ELSE '[]'::jsonb
+                    END
+                ) WITH ORDINALITY AS elem(value, ordinality)
+            )
+            SELECT COALESCE(p.retrospective_id, a.retrospective_id) AS retrospective_id,
+                   COALESCE(p.position, a.position) AS position
+            FROM parent_actions p
+            FULL JOIN review.trade_retrospective_actions a
+              ON a.retrospective_id = p.retrospective_id
+             AND a.position = p.position
+            WHERE p.retrospective_id IS NULL
+               OR a.id IS NULL
+               OR btrim(p.payload->>'action') IS DISTINCT FROM a.action
+               OR (p.payload->>'owner') IS DISTINCT FROM a.owner
+               OR (p.payload->>'issue_id') IS DISTINCT FROM a.issue_id
+               OR CASE
+                    WHEN btrim(COALESCE(p.payload->>'status', '')) = '' THEN 'open'
+                    ELSE p.payload->>'status'
+                  END IS DISTINCT FROM CASE
+                    WHEN a.status IN ('obsolete', 'expired') THEN 'done'
+                    ELSE a.status
+                  END
+               OR NULLIF(btrim(COALESCE(p.payload->>'due_kst_date', '')), '')
+                    IS DISTINCT FROM a.due_kst_date::text
+            LIMIT 1
+            """
+        )
+    )
+    mismatch = parity_result.fetchone()
+    if mismatch is not None:
+        return {
+            "healthy": False,
+            "reason": "field/ordinal mismatch: retrospective "
+            f"{mismatch.retrospective_id} action[{mismatch.position}]",
+        }
 
     return {
         "healthy": True,
         "mode": ctrl.mode,
         "cutover_at": ctrl.cutover_at.isoformat() if ctrl.cutover_at else None,
-        "action_count": ctrl.cutover_action_count,
+        "action_count": counts.child_count,
+        "cutover_action_count": ctrl.cutover_action_count,
     }
 
 
@@ -132,13 +201,21 @@ async def _async_main(if_shadow: bool) -> int:
             "Mode remains shadow. The deploy may safely roll back.",
             file=sys.stderr,
         )
-        return 1
+        return EXIT_SAFE_PRECOMMIT
+    except CutoverLockError as exc:
+        print(f"CUTOVER FAILED (lock): {exc}", file=sys.stderr)
+        print("Mode remains shadow. The deploy may safely roll back.", file=sys.stderr)
+        return EXIT_SAFE_PRECOMMIT
     except ActionControlError as exc:
         print(f"CUTOVER FAILED (control): {exc}", file=sys.stderr)
-        return 1
+        print(
+            "Recovery state is uncertain. Disable mutation and inspect the control row.",
+            file=sys.stderr,
+        )
+        return EXIT_COMMITTED_OR_UNKNOWN
     except Exception as exc:
         print(f"CUTOVER FAILED (unexpected): {exc}", file=sys.stderr)
-        return 1
+        return EXIT_COMMITTED_OR_UNKNOWN
 
     idempotent = result.get("idempotent", False)
     if idempotent:
@@ -147,10 +224,7 @@ async def _async_main(if_shadow: bool) -> int:
             f"action_count={result['action_count']}"
         )
     else:
-        print(
-            f"Cutover: shadow → canonical. "
-            f"action_count={result['action_count']}"
-        )
+        print(f"Cutover: shadow → canonical. action_count={result['action_count']}")
 
     # Post-cutover health check
     try:
@@ -165,11 +239,16 @@ async def _async_main(if_shadow: bool) -> int:
                 "Do NOT use schema downgrade.",
                 file=sys.stderr,
             )
-            return 1
+            return EXIT_COMMITTED_OR_UNKNOWN
     except Exception as exc:
-        print(f"Health check error (non-fatal): {exc}", file=sys.stderr)
+        print(f"Health check error: {exc}", file=sys.stderr)
+        print(
+            "Recovery: mutation-disable + roll-forward. Do NOT use schema downgrade.",
+            file=sys.stderr,
+        )
+        return EXIT_COMMITTED_OR_UNKNOWN
 
-    return 0
+    return EXIT_OK
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/scripts/retrospective_action_cutover.py
+++ b/scripts/retrospective_action_cutover.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python
+"""ROB-878 child-2 — canonical cutover command.
+
+Usage:
+    uv run python scripts/retrospective_action_cutover.py [--if-shadow]
+
+This command atomically switches the retrospective action control mode from
+``shadow`` to ``canonical``. It must be run AFTER all old-version processes
+have been drained and only new-version code is serving traffic.
+
+Steps (all in one transaction):
+    1. Transaction-scoped advisory lock.
+    2. LOCK TABLE parent → control → actions (SHARE ROW EXCLUSIVE).
+    3. Delete stale shadow children.
+    4. Rebuild children from frozen parent JSONB (deterministic backfill).
+    5. Verify full field/count/ordinal parity.
+    6. Switch control mode to canonical, record cutover_at/count.
+
+If parity fails, the entire transaction (including the mode switch) rolls
+back and the system remains in shadow mode.
+
+``--if-shadow`` makes the command idempotent: if the mode is already
+canonical, it reports the existing cutover state and exits 0 without
+rebuilding.
+
+Rollback / roll-forward procedure:
+    After a successful cutover, the control mode is canonical and the
+    write-fence trigger rejects direct parent JSONB writes from old code.
+    If a later failure requires returning traffic to old code:
+        - Old code can still READ parent JSONB (the projection is maintained).
+        - Old code CANNOT write next_actions (the trigger blocks it).
+        - Recovery is mutation-disable + roll-forward to new code.
+        - Schema downgrade is NOT a recovery path after cutover.
+    A failed cutover (parity error) leaves mode=shadow and all children
+    untouched; the deploy may safely roll back to the previous release.
+
+Exit codes:
+    0 — cutover succeeded (or idempotent no-op with --if-shadow)
+    1 — cutover failed (parity error, control error, or DB error)
+    2 — invalid arguments
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+from typing import Any
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncConnection
+
+from app.core.db import engine
+from app.services.trade_journal.retrospective_action_repository import (
+    ActionControlError,
+    CutoverParityError,
+    run_cutover,
+)
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Canonical cutover for retrospective action ledger (ROB-878).",
+    )
+    parser.add_argument(
+        "--if-shadow",
+        action="store_true",
+        help="Idempotent mode: no-op if already canonical.",
+    )
+    return parser.parse_args(argv)
+
+
+async def _run(if_shadow: bool) -> dict[str, Any]:
+    """Execute the cutover in a single transaction."""
+    async with engine.begin() as conn:
+        return await run_cutover(conn, if_shadow=if_shadow)
+
+
+async def _health_check(conn: AsyncConnection) -> dict[str, Any]:
+    """Post-cutover canonical health/parity check (read-only)."""
+    mode_result = await conn.execute(
+        text(
+            "SELECT mode, cutover_at, cutover_action_count "
+            "FROM review.trade_retrospective_action_control WHERE id = 1"
+        )
+    )
+    ctrl = mode_result.fetchone()
+    if ctrl is None:
+        return {"healthy": False, "reason": "control row missing"}
+    if ctrl.mode != "canonical":
+        return {"healthy": False, "reason": f"mode is {ctrl.mode}, not canonical"}
+
+    # Quick count parity
+    count_result = await conn.execute(
+        text(
+            """
+            SELECT
+                COALESCE(SUM(
+                    CASE
+                        WHEN jsonb_typeof(next_actions) = 'array'
+                        THEN jsonb_array_length(next_actions)
+                        ELSE 0
+                    END
+                ), 0) AS parent_count,
+                (SELECT count(*) FROM review.trade_retrospective_actions) AS child_count
+            FROM review.trade_retrospectives
+            """
+        )
+    )
+    counts = count_result.one()
+    if counts.parent_count != counts.child_count:
+        return {
+            "healthy": False,
+            "reason": f"count mismatch: parent={counts.parent_count}, "
+            f"child={counts.child_count}",
+        }
+
+    return {
+        "healthy": True,
+        "mode": ctrl.mode,
+        "cutover_at": ctrl.cutover_at.isoformat() if ctrl.cutover_at else None,
+        "action_count": ctrl.cutover_action_count,
+    }
+
+
+async def _async_main(if_shadow: bool) -> int:
+    try:
+        result = await _run(if_shadow)
+    except CutoverParityError as exc:
+        print(f"CUTOVER FAILED (parity): {exc}", file=sys.stderr)
+        print(
+            "Mode remains shadow. The deploy may safely roll back.",
+            file=sys.stderr,
+        )
+        return 1
+    except ActionControlError as exc:
+        print(f"CUTOVER FAILED (control): {exc}", file=sys.stderr)
+        return 1
+    except Exception as exc:
+        print(f"CUTOVER FAILED (unexpected): {exc}", file=sys.stderr)
+        return 1
+
+    idempotent = result.get("idempotent", False)
+    if idempotent:
+        print(
+            f"Cutover: already canonical (idempotent). "
+            f"action_count={result['action_count']}"
+        )
+    else:
+        print(
+            f"Cutover: shadow → canonical. "
+            f"action_count={result['action_count']}"
+        )
+
+    # Post-cutover health check
+    try:
+        async with engine.connect() as conn:
+            health = await _health_check(conn)
+        if health.get("healthy"):
+            print(f"Health: OK mode={health['mode']} count={health['action_count']}")
+        else:
+            print(f"Health: DEGRADED — {health.get('reason')}", file=sys.stderr)
+            print(
+                "Recovery: mutation-disable + roll-forward. "
+                "Do NOT use schema downgrade.",
+                file=sys.stderr,
+            )
+            return 1
+    except Exception as exc:
+        print(f"Health check error (non-fatal): {exc}", file=sys.stderr)
+
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    return asyncio.run(_async_main(args.if_shadow))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/retrospective_action_cutover.py
+++ b/scripts/retrospective_action_cutover.py
@@ -169,6 +169,15 @@ async def _health_check(conn: AsyncConnection) -> dict[str, Any]:
                     WHEN a.status IN ('obsolete', 'expired') THEN 'done'
                     ELSE a.status
                   END
+               OR (p.payload->>'terminal_status') IS DISTINCT FROM CASE
+                    WHEN a.status IN ('obsolete', 'expired') THEN a.status
+                    ELSE NULL
+                  END
+               OR CASE
+                    WHEN p.payload ? 'creation_key'
+                        THEN (p.payload->>'creation_key')::uuid
+                    ELSE NULL
+                  END IS DISTINCT FROM a.creation_key
                OR NULLIF(btrim(COALESCE(p.payload->>'due_kst_date', '')), '')
                     IS DISTINCT FROM a.due_kst_date::text
             LIMIT 1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -703,6 +703,37 @@ async def investment_reports_cleanup_lock(db_session):
 
 
 @pytest_asyncio.fixture
+async def retrospective_action_control_lock():
+    """Serialize tests that mutate the global retrospective-action authority.
+
+    The ROB-878/880 migration and cutover contracts intentionally change the
+    singleton control row and, in a few cases, rebuild its tables.  Xdist
+    workers share one PostgreSQL database, so those tests must not observe one
+    another's temporary canonical mode or DDL state.
+    """
+    from sqlalchemy import text
+
+    from app.core.db import engine
+
+    # Distinct from the production cutover lock (878_880_001), which the
+    # cutover contract tests must still be able to acquire while holding this
+    # outer test-isolation lock.
+    retrospective_action_control_test_lock_id = 878_880_999
+    async with engine.connect() as guard:
+        await guard.execute(
+            text("SELECT pg_advisory_lock(CAST(:lock_id AS bigint))"),
+            {"lock_id": retrospective_action_control_test_lock_id},
+        )
+        try:
+            yield
+        finally:
+            await guard.execute(
+                text("SELECT pg_advisory_unlock(CAST(:lock_id AS bigint))"),
+                {"lock_id": retrospective_action_control_test_lock_id},
+            )
+
+
+@pytest_asyncio.fixture
 async def user(db_session):
     """Create a test user."""
     from uuid import uuid4

--- a/tests/mcp_server/tooling/test_trade_retrospective_registration_docs.py
+++ b/tests/mcp_server/tooling/test_trade_retrospective_registration_docs.py
@@ -62,3 +62,17 @@ def test_description_enumerates_outcome_values():
         "cancelled",
     ):
         assert value in desc, f"outcome value {value!r} missing from description"
+
+
+def test_description_states_canonical_next_action_creation_statuses():
+    desc = _register().lower()
+
+    assert "new actions may start only as open or in_progress" in desc
+
+
+def test_description_states_canonical_next_action_retry_identity_contract():
+    desc = _register().lower()
+
+    assert "action_id and version" in desc
+    assert "force_new=true with a stable creation_key" in desc
+    assert "idempotent retries" in desc

--- a/tests/services/paper_cohort/test_migration.py
+++ b/tests/services/paper_cohort/test_migration.py
@@ -100,6 +100,7 @@ def test_migration_defines_full_lineage_reservation_fence_and_claim_states() -> 
 
 
 @pytest.mark.asyncio
+@pytest.mark.usefixtures("retrospective_action_control_lock")
 async def test_real_postgresql_upgrade_downgrade_upgrade_single_head() -> None:
     base_url = make_url(settings.DATABASE_URL)
     if base_url.get_backend_name() != "postgresql":

--- a/tests/services/paper_cohort/test_runner_shadow.py
+++ b/tests/services/paper_cohort/test_runner_shadow.py
@@ -64,13 +64,16 @@ class FakeCapture:
 @dataclass
 class FakeQuotes:
     session: AsyncSession
+    run_id: str
     calls: list[tuple[str, str]] = field(default_factory=list)
     decision_counts_at_call: list[int] = field(default_factory=list)
 
     async def get_quote(self, venue: str, symbol: str) -> VenueQuote:
         self.calls.append((venue, symbol))
         count = await self.session.scalar(
-            select(func.count()).select_from(PaperCohortDecision)
+            select(func.count())
+            .select_from(PaperCohortDecision)
+            .where(PaperCohortDecision.run_id == self.run_id)
         )
         self.decision_counts_at_call.append(int(count or 0))
         execution_symbol = (
@@ -116,8 +119,14 @@ async def _active_cohort(db_session: AsyncSession, nonce: str) -> str:
     return activation.cohort_id
 
 
-async def _count(db_session: AsyncSession, model: type) -> int:
-    value = await db_session.scalar(select(func.count()).select_from(model))
+async def _count_for_run(
+    db_session: AsyncSession,
+    model: type,
+    run_id: str,
+) -> int:
+    value = await db_session.scalar(
+        select(func.count()).select_from(model).where(model.run_id == run_id)
+    )
     return int(value or 0)
 
 
@@ -127,19 +136,11 @@ async def test_shadow_persists_signal_before_quotes_and_never_mutates_brokers(
 ) -> None:
     nonce = uuid4().hex
     cohort_id = await _active_cohort(db_session, nonce)
+    run_id = f"run-{nonce}"
     capture = FakeCapture()
-    quotes = FakeQuotes(db_session)
+    quotes = FakeQuotes(db_session, run_id)
     application_calls: list[str] = []
     native_calls: list[str] = []
-    baseline = {
-        model: await _count(db_session, model)
-        for model in (
-            CanonicalMarketSnapshot,
-            PaperCohortDecision,
-            PaperCohortVenueIntent,
-            PaperRunOrderLink,
-        )
-    }
     runner = PaperCohortRunner(
         db_session,
         capture=capture,
@@ -153,7 +154,7 @@ async def test_shadow_persists_signal_before_quotes_and_never_mutates_brokers(
     result = await runner.run(
         CohortRunInvocation(
             cohort_id=cohort_id,
-            run_id=f"run-{nonce}",
+            run_id=run_id,
             round_decision_id=f"round-{nonce}",
             mode=RunMode.SHADOW,
         )
@@ -166,19 +167,10 @@ async def test_shadow_persists_signal_before_quotes_and_never_mutates_brokers(
     assert all(count >= 2 for count in quotes.decision_counts_at_call)
     assert application_calls == []
     assert native_calls == []
-    assert (
-        await _count(db_session, CanonicalMarketSnapshot)
-        == baseline[CanonicalMarketSnapshot] + 1
-    )
-    assert (
-        await _count(db_session, PaperCohortDecision)
-        == baseline[PaperCohortDecision] + 2
-    )
-    assert (
-        await _count(db_session, PaperCohortVenueIntent)
-        == baseline[PaperCohortVenueIntent] + 4
-    )
-    assert await _count(db_session, PaperRunOrderLink) == baseline[PaperRunOrderLink]
+    assert await _count_for_run(db_session, CanonicalMarketSnapshot, run_id) == 1
+    assert await _count_for_run(db_session, PaperCohortDecision, run_id) == 2
+    assert await _count_for_run(db_session, PaperCohortVenueIntent, run_id) == 4
+    assert await _count_for_run(db_session, PaperRunOrderLink, run_id) == 0
     intents = (
         await db_session.scalars(
             select(PaperCohortVenueIntent)
@@ -209,19 +201,11 @@ async def test_capture_failure_leaves_no_snapshot_signal_quote_or_mutation(
 ) -> None:
     nonce = uuid4().hex
     cohort_id = await _active_cohort(db_session, nonce)
+    run_id = f"run-{nonce}"
     capture = FakeCapture(fail=True)
-    quotes = FakeQuotes(db_session)
+    quotes = FakeQuotes(db_session, run_id)
     application_calls: list[str] = []
     native_calls: list[str] = []
-    baseline = {
-        model: await _count(db_session, model)
-        for model in (
-            CanonicalMarketSnapshot,
-            PaperCohortDecision,
-            PaperCohortVenueIntent,
-            PaperRunOrderLink,
-        )
-    }
     runner = PaperCohortRunner(
         db_session,
         capture=capture,
@@ -236,7 +220,7 @@ async def test_capture_failure_leaves_no_snapshot_signal_quote_or_mutation(
         await runner.run(
             CohortRunInvocation(
                 cohort_id=cohort_id,
-                run_id=f"run-{nonce}",
+                run_id=run_id,
                 round_decision_id=f"round-{nonce}",
                 mode=RunMode.SHADOW,
             )
@@ -245,18 +229,10 @@ async def test_capture_failure_leaves_no_snapshot_signal_quote_or_mutation(
     assert quotes.calls == []
     assert application_calls == []
     assert native_calls == []
-    assert (
-        await _count(db_session, CanonicalMarketSnapshot)
-        == baseline[CanonicalMarketSnapshot]
-    )
-    assert (
-        await _count(db_session, PaperCohortDecision) == baseline[PaperCohortDecision]
-    )
-    assert (
-        await _count(db_session, PaperCohortVenueIntent)
-        == baseline[PaperCohortVenueIntent]
-    )
-    assert await _count(db_session, PaperRunOrderLink) == baseline[PaperRunOrderLink]
+    assert await _count_for_run(db_session, CanonicalMarketSnapshot, run_id) == 0
+    assert await _count_for_run(db_session, PaperCohortDecision, run_id) == 0
+    assert await _count_for_run(db_session, PaperCohortVenueIntent, run_id) == 0
+    assert await _count_for_run(db_session, PaperRunOrderLink, run_id) == 0
 
 
 @pytest.mark.asyncio
@@ -281,7 +257,8 @@ async def test_direct_runner_before_activation_fails_before_capture_or_quote(
     await PaperCohortService(db_session).activate(activation)
     await db_session.commit()
     capture = FakeCapture()
-    quotes = FakeQuotes(db_session)
+    run_id = f"future-run-{nonce}"
+    quotes = FakeQuotes(db_session, run_id)
 
     with pytest.raises(PaperCohortError) as exc_info:
         await PaperCohortRunner(
@@ -292,7 +269,7 @@ async def test_direct_runner_before_activation_fails_before_capture_or_quote(
         ).run(
             CohortRunInvocation(
                 cohort_id=activation.cohort_id,
-                run_id=f"future-run-{nonce}",
+                run_id=run_id,
                 round_decision_id=f"future-round-{nonce}",
                 mode=RunMode.SHADOW,
             )
@@ -305,7 +282,7 @@ async def test_direct_runner_before_activation_fails_before_capture_or_quote(
         await db_session.scalar(
             select(func.count())
             .select_from(PaperCohortRunClaim)
-            .where(PaperCohortRunClaim.run_id == f"future-run-{nonce}")
+            .where(PaperCohortRunClaim.run_id == run_id)
         )
         == 0
     )
@@ -325,8 +302,8 @@ async def test_stale_or_future_venue_quote_fails_before_intent_persistence(
 ) -> None:
     nonce = uuid4().hex
     cohort_id = await _active_cohort(db_session, nonce)
-    quotes = TimestampedFakeQuotes(db_session, fetched_at=fetched_at)
-    baseline = await _count(db_session, PaperCohortVenueIntent)
+    run_id = f"quote-run-{nonce}"
+    quotes = TimestampedFakeQuotes(db_session, run_id, fetched_at=fetched_at)
 
     with pytest.raises(PaperCohortError) as exc_info:
         await PaperCohortRunner(
@@ -337,11 +314,11 @@ async def test_stale_or_future_venue_quote_fails_before_intent_persistence(
         ).run(
             CohortRunInvocation(
                 cohort_id=cohort_id,
-                run_id=f"quote-run-{nonce}",
+                run_id=run_id,
                 round_decision_id=f"quote-round-{nonce}",
                 mode=RunMode.SHADOW,
             )
         )
 
     assert exc_info.value.reason_code == "venue_quote_provider_error"
-    assert await _count(db_session, PaperCohortVenueIntent) == baseline
+    assert await _count_for_run(db_session, PaperCohortVenueIntent, run_id) == 0

--- a/tests/services/paper_cohort/test_runner_shadow.py
+++ b/tests/services/paper_cohort/test_runner_shadow.py
@@ -64,17 +64,18 @@ class FakeCapture:
 @dataclass
 class FakeQuotes:
     session: AsyncSession
-    run_id: str
+    run_id: str | None = None
     calls: list[tuple[str, str]] = field(default_factory=list)
     decision_counts_at_call: list[int] = field(default_factory=list)
 
     async def get_quote(self, venue: str, symbol: str) -> VenueQuote:
         self.calls.append((venue, symbol))
-        count = await self.session.scalar(
-            select(func.count())
-            .select_from(PaperCohortDecision)
-            .where(PaperCohortDecision.run_id == self.run_id)
-        )
+        decision_count = select(func.count()).select_from(PaperCohortDecision)
+        if self.run_id is not None:
+            decision_count = decision_count.where(
+                PaperCohortDecision.run_id == self.run_id
+            )
+        count = await self.session.scalar(decision_count)
         self.decision_counts_at_call.append(int(count or 0))
         execution_symbol = (
             symbol

--- a/tests/test_mcp_caller_identity_middleware.py
+++ b/tests/test_mcp_caller_identity_middleware.py
@@ -10,8 +10,8 @@ import pytest
 from app.core.config import settings
 from app.mcp_server import caller_identity_middleware
 from app.mcp_server.caller_identity import (
-    caller_argument_names_var,
     caller_agent_id_var,
+    caller_argument_names_var,
     caller_source_var,
 )
 from app.mcp_server.caller_identity_middleware import (

--- a/tests/test_mcp_caller_identity_middleware.py
+++ b/tests/test_mcp_caller_identity_middleware.py
@@ -10,6 +10,7 @@ import pytest
 from app.core.config import settings
 from app.mcp_server import caller_identity_middleware
 from app.mcp_server.caller_identity import (
+    caller_argument_names_var,
     caller_agent_id_var,
     caller_source_var,
 )
@@ -51,6 +52,28 @@ def _clear_fallback_env(monkeypatch: pytest.MonkeyPatch) -> None:
 @pytest.mark.unit
 @pytest.mark.asyncio
 class TestCallerIdentityMiddleware:
+    async def test_raw_argument_names_preserve_explicit_null(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def _raise_no_http() -> None:
+            raise RuntimeError("no HTTP request in context")
+
+        monkeypatch.setattr(
+            caller_identity_middleware, "get_http_request", _raise_no_http
+        )
+        context = Mock()
+        context.message.arguments = {"symbol": "005930", "lesson": None}
+        observed: dict[str, Any] = {}
+
+        async def _capture(_ctx: Any) -> str:
+            observed["argument_names"] = caller_argument_names_var.get()
+            return "ok"
+
+        await CallerIdentityMiddleware().on_call_tool(context, _capture)
+
+        assert observed["argument_names"] == frozenset({"symbol", "lesson"})
+        assert caller_argument_names_var.get() is None
+
     async def test_http_header_resolves_caller_identity(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/test_rob878_canonical_cutover.py
+++ b/tests/test_rob878_canonical_cutover.py
@@ -642,8 +642,19 @@ async def test_shadow_save_rejects_canonical_only_action_state(
 
 
 @pytest.mark.asyncio
-async def test_cutover_rejects_persisted_transport_only_force_new(
+@pytest.mark.parametrize(
+    ("reserved_field", "reserved_value"),
+    [
+        ("force_new", True),
+        ("terminal_status", "obsolete"),
+        ("action_id", str(uuid.uuid4())),
+        ("version", 1),
+    ],
+)
+async def test_cutover_rejects_persisted_canonical_transport_fields(
     db_session: AsyncSession,
+    reserved_field: str,
+    reserved_value: Any,
 ):
     from app.services.trade_journal.retrospective_action_repository import (
         CutoverParityError,
@@ -656,15 +667,15 @@ async def test_cutover_rejects_persisted_transport_only_force_new(
         next_actions=[
             {
                 "action": "poisoned transport intent",
-                "force_new": True,
-                "creation_key": str(uuid.uuid4()),
+                "status": "done",
+                reserved_field: reserved_value,
             }
         ],
     )
 
     async with engine.connect() as conn:
         transaction = await conn.begin()
-        with pytest.raises(CutoverParityError, match="force_new"):
+        with pytest.raises(CutoverParityError, match=reserved_field):
             await run_cutover(conn, if_shadow=True)
         await transaction.rollback()
 
@@ -992,6 +1003,47 @@ async def test_post_cutover_health_detects_equal_count_field_drift(
         text(
             "UPDATE review.trade_retrospective_actions SET action = 'drifted' "
             "WHERE retrospective_id = 2009"
+        )
+    )
+    await db_session.commit()
+
+    async with engine.connect() as conn:
+        health = await _health_check(conn)
+
+    assert health["healthy"] is False
+    assert "field/ordinal" in health["reason"]
+
+
+@pytest.mark.asyncio
+async def test_post_cutover_health_validates_terminal_status_projection(
+    db_session: AsyncSession,
+):
+    from app.services.trade_journal.retrospective_action_repository import run_cutover
+    from scripts.retrospective_action_cutover import _health_check
+
+    await _insert_retrospective(
+        db_session,
+        retro_id=2014,
+        next_actions=[{"action": "terminal projection", "status": "open"}],
+    )
+    async with engine.begin() as conn:
+        await run_cutover(conn, if_shadow=True)
+
+    await db_session.execute(
+        text(
+            "UPDATE review.trade_retrospective_actions "
+            "SET status = 'obsolete', resolved_at = now(), "
+            "status_reason = 'superseded' WHERE retrospective_id = 2014"
+        )
+    )
+    await db_session.execute(
+        text("SET LOCAL app.retrospective_action_projection_writer = 'v1'")
+    )
+    await db_session.execute(
+        text(
+            "UPDATE review.trade_retrospectives "
+            'SET next_actions = \'[{"action":"terminal projection",'
+            '"status":"done"}]\'::jsonb WHERE id = 2014'
         )
     )
     await db_session.commit()

--- a/tests/test_rob878_canonical_cutover.py
+++ b/tests/test_rob878_canonical_cutover.py
@@ -2623,6 +2623,50 @@ async def test_canonical_mode_save_uses_repository(db_session: AsyncSession):
 
 
 @pytest.mark.asyncio
+async def test_canonical_save_reuses_validated_control_mode(
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Save and reconciliation must use one validated control-mode snapshot."""
+    from app.services.trade_journal import trade_retrospective_service as svc
+    from app.services.trade_journal.retrospective_action_repository import (
+        RetrospectiveActionRepository,
+    )
+
+    await _set_canonical_mode(db_session)
+
+    async def _unexpected_mode_reread(_repo):
+        raise AssertionError("reconciliation re-read the control mode")
+
+    monkeypatch.setattr(
+        RetrospectiveActionRepository,
+        "get_control_mode",
+        _unexpected_mode_reread,
+    )
+
+    _, retro = await svc.save_retrospective(
+        db_session,
+        symbol="005930",
+        instrument_type="equity_kr",
+        account_mode="kis_mock",
+        outcome="filled",
+        correlation_id="canonical-single-mode-read",
+        next_actions=[{"action": "single mode read"}],
+    )
+
+    count = (
+        await db_session.execute(
+            text(
+                "SELECT count(*) FROM review.trade_retrospective_actions "
+                "WHERE retrospective_id = :rid"
+            ),
+            {"rid": retro.id},
+        )
+    ).scalar_one()
+    assert count == 1
+
+
+@pytest.mark.asyncio
 async def test_canonical_action_retry_preserves_omitted_parent_fields(
     db_session: AsyncSession,
 ):

--- a/tests/test_rob878_canonical_cutover.py
+++ b/tests/test_rob878_canonical_cutover.py
@@ -1,0 +1,1351 @@
+"""ROB-878 child-2: canonical cutover — repository/save projection/read API tests.
+
+Tests cover:
+- Control-mode repository (shadow/canonical routing, fail-closed)
+- Canonical cutover command (advisory lock, parity, idempotency, rollback)
+- Save reconciliation (occurrence matching, field presence, idempotency, projection)
+- Canonical GET (pagination, filter, overdue-first ordering)
+- Legacy /next-actions alias compatibility
+- Deploy script post-switch cutover step
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import delete, text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.db import engine
+from app.models.review import (
+    TradeRetrospective,
+    TradeRetrospectiveAction,
+)
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.usefixtures("investment_reports_cleanup_lock"),
+]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+_KST_DATE_TODAY = datetime.now(UTC).astimezone().date().isoformat()
+
+
+async def _ensure_shadow_mode(db: AsyncSession) -> None:
+    """Reset control row to shadow mode (test isolation)."""
+    await db.execute(
+        text(
+            "ALTER TABLE review.trade_retrospective_action_control "
+            "DROP CONSTRAINT IF EXISTS ck_trade_retrospective_action_control_mode"
+        )
+    )
+    await db.execute(
+        text(
+            "ALTER TABLE review.trade_retrospective_action_control "
+            "DROP CONSTRAINT IF EXISTS mode"
+        )
+    )
+    await db.execute(
+        text(
+            "INSERT INTO review.trade_retrospective_action_control (id, mode) "
+            "VALUES (1, 'shadow') "
+            "ON CONFLICT (id) DO UPDATE SET "
+            "mode = 'shadow', cutover_at = NULL, cutover_action_count = NULL"
+        )
+    )
+    await db.execute(
+        text(
+            "ALTER TABLE review.trade_retrospective_action_control "
+            "ADD CONSTRAINT ck_trade_retrospective_action_control_mode "
+            "CHECK (mode IN ('shadow','canonical'))"
+        )
+    )
+    await db.commit()
+
+
+async def _set_canonical_mode(db: AsyncSession) -> None:
+    await db.execute(
+        text(
+            "UPDATE review.trade_retrospective_action_control "
+            "SET mode = 'canonical' WHERE id = 1"
+        )
+    )
+    await db.commit()
+
+
+async def _insert_retrospective(
+    db: AsyncSession,
+    *,
+    retro_id: int,
+    next_actions: list | None,
+    correlation_id: str | None = None,
+    symbol: str = "005930",
+    market: str = "kr",
+    trigger_type: str | None = "fill",
+    realized_pnl: Decimal | None = None,
+) -> TradeRetrospective:
+    """Insert a retrospective with the given next_actions JSONB."""
+    row = TradeRetrospective(
+        id=retro_id,
+        symbol=symbol,
+        instrument_type="equity_kr" if market == "kr" else "equity_us",
+        account_mode="kis_mock",
+        market=market,
+        outcome="filled",
+        trigger_type=trigger_type,
+        realized_pnl=realized_pnl,
+        correlation_id=correlation_id or f"test-{retro_id}",
+    )
+    if next_actions is not None:
+        row.next_actions = next_actions
+    db.add(row)
+    await db.commit()
+    return row
+
+
+async def _insert_canonical_action(
+    db: AsyncSession,
+    *,
+    retrospective_id: int,
+    position: int,
+    action: str,
+    owner: str | None = None,
+    issue_id: str | None = None,
+    status: str = "open",
+    due_kst_date=None,
+    version: int = 1,
+    status_actor: str = "migration:rob-878",
+    status_source: str = "migration",
+    legacy_payload: dict | None = None,
+) -> TradeRetrospectiveAction:
+    """Insert a canonical action row directly."""
+    row = TradeRetrospectiveAction(
+        retrospective_id=retrospective_id,
+        position=position,
+        action=action,
+        owner=owner,
+        issue_id=issue_id,
+        status=status,
+        due_kst_date=due_kst_date,
+        version=version,
+        status_actor=status_actor,
+        status_source=status_source,
+        legacy_payload=legacy_payload or {},
+    )
+    db.add(row)
+    await db.commit()
+    return row
+
+
+async def _clear_actions(db: AsyncSession) -> None:
+    await db.execute(delete(TradeRetrospectiveAction))
+    await db.commit()
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def _cleanup(db_session: AsyncSession):
+    """Clean up retrospectives, actions, and reset control mode before each test."""
+    await db_session.execute(delete(TradeRetrospectiveAction))
+    await db_session.execute(delete(TradeRetrospective))
+    await db_session.commit()
+    await _ensure_shadow_mode(db_session)
+    yield
+    await db_session.execute(delete(TradeRetrospectiveAction))
+    await db_session.execute(delete(TradeRetrospective))
+    await db_session.commit()
+    await _ensure_shadow_mode(db_session)
+
+
+# ---------------------------------------------------------------------------
+# Section 1: Control-mode repository
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_repository_shadow_mode_reads_legacy_json(db_session: AsyncSession):
+    """In shadow mode, read_actions returns parent JSONB next_actions."""
+    from app.services.trade_journal.retrospective_action_repository import (
+        RetrospectiveActionRepository,
+    )
+
+    await _insert_retrospective(
+        db_session,
+        retro_id=1001,
+        next_actions=[{"action": "check A", "status": "open"}],
+    )
+    repo = RetrospectiveActionRepository(db_session)
+    mode = await repo.get_control_mode()
+    assert mode == "shadow"
+
+    actions = await repo.read_actions(1001)
+    assert len(actions) == 1
+    assert actions[0]["action"] == "check A"
+
+
+@pytest.mark.asyncio
+async def test_repository_canonical_mode_reads_child_ledger(db_session: AsyncSession):
+    """In canonical mode, read_actions returns child ledger rows."""
+    from app.services.trade_journal.retrospective_action_repository import (
+        RetrospectiveActionRepository,
+    )
+
+    await _insert_retrospective(
+        db_session,
+        retro_id=1002,
+        next_actions=[{"action": "legacy action"}],
+    )
+    await _insert_canonical_action(
+        db_session,
+        retrospective_id=1002,
+        position=0,
+        action="legacy action",
+        legacy_payload={"action": "legacy action"},
+    )
+    await _set_canonical_mode(db_session)
+
+    repo = RetrospectiveActionRepository(db_session)
+    mode = await repo.get_control_mode()
+    assert mode == "canonical"
+
+    actions = await repo.read_actions(1002)
+    assert len(actions) == 1
+    assert actions[0]["action"] == "legacy action"
+
+
+@pytest.mark.asyncio
+async def test_repository_missing_control_row_fails_closed(db_session: AsyncSession):
+    """Absent control row must fail closed, not default to shadow."""
+    from app.services.trade_journal.retrospective_action_repository import (
+        ActionControlError,
+        RetrospectiveActionRepository,
+    )
+
+    await db_session.execute(
+        text("DELETE FROM review.trade_retrospective_action_control WHERE id = 1")
+    )
+    await db_session.commit()
+
+    repo = RetrospectiveActionRepository(db_session)
+    with pytest.raises(ActionControlError, match="control row"):
+        await repo.get_control_mode()
+
+
+@pytest.mark.asyncio
+async def test_repository_unknown_mode_fails_closed(db_session: AsyncSession):
+    """Unknown control mode must fail closed (defense-in-depth beyond DB CHECK)."""
+    from app.services.trade_journal.retrospective_action_repository import (
+        ActionControlError,
+        RetrospectiveActionRepository,
+    )
+
+    await db_session.execute(
+        text(
+            "ALTER TABLE review.trade_retrospective_action_control "
+            "DROP CONSTRAINT IF EXISTS ck_trade_retrospective_action_control_mode"
+        )
+    )
+    await db_session.execute(
+        text(
+            "UPDATE review.trade_retrospective_action_control "
+            "SET mode = 'bogus' WHERE id = 1"
+        )
+    )
+    await db_session.commit()
+
+    repo = RetrospectiveActionRepository(db_session)
+    with pytest.raises(ActionControlError, match="mode.*invalid"):
+        await repo.get_control_mode()
+
+
+# ---------------------------------------------------------------------------
+# Section 2: Canonical cutover
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cutover_shadow_to_canonical_succeeds(db_session: AsyncSession):
+    """Cutover switches shadow→canonical and verifies parity."""
+    from app.services.trade_journal.retrospective_action_repository import run_cutover
+
+    await _insert_retrospective(
+        db_session,
+        retro_id=2001,
+        next_actions=[
+            {"action": "action A", "status": "open"},
+            {"action": "action B", "status": "done", "owner": "alice"},
+        ],
+    )
+    await _clear_actions(db_session)
+
+    async with engine.connect() as conn:
+        trans = await conn.begin()
+        try:
+            result = await run_cutover(conn, if_shadow=True)
+            assert result["mode"] == "canonical"
+            assert result["action_count"] == 2
+            assert result["cutover_at"] is not None
+            await trans.commit()
+        except Exception:
+            await trans.rollback()
+            raise
+
+    # Verify mode switched
+    mode = (
+        await db_session.execute(
+            text(
+                "SELECT mode FROM review.trade_retrospective_action_control WHERE id = 1"
+            )
+        )
+    ).scalar_one()
+    assert mode == "canonical"
+
+    # Verify children exist
+    count = (
+        await db_session.execute(
+            text(
+                "SELECT count(*) FROM review.trade_retrospective_actions "
+                "WHERE retrospective_id = 2001"
+            )
+        )
+    ).scalar_one()
+    assert count == 2
+
+
+@pytest.mark.asyncio
+async def test_cutover_idempotent_if_shadow(db_session: AsyncSession):
+    """Re-running cutover with --if-shadow on already-canonical is a safe no-op."""
+    from app.services.trade_journal.retrospective_action_repository import run_cutover
+
+    await _insert_retrospective(
+        db_session,
+        retro_id=2002,
+        next_actions=[{"action": "single action"}],
+    )
+    await _clear_actions(db_session)
+
+    # First cutover
+    async with engine.connect() as conn:
+        trans = await conn.begin()
+        try:
+            await run_cutover(conn, if_shadow=True)
+            await trans.commit()
+        except Exception:
+            await trans.rollback()
+            raise
+
+    # Second cutover — should be no-op (already canonical)
+    async with engine.connect() as conn:
+        trans = await conn.begin()
+        try:
+            result = await run_cutover(conn, if_shadow=True)
+            assert result["mode"] == "canonical"
+            assert result["action_count"] == 1
+            assert result.get("idempotent") is True
+            await trans.commit()
+        except Exception:
+            await trans.rollback()
+            raise
+
+
+@pytest.mark.asyncio
+async def test_cutover_parity_failure_rolls_back(db_session: AsyncSession):
+    """If parity check fails, mode stays shadow and no children are committed."""
+    from app.services.trade_journal.retrospective_action_repository import (
+        CutoverParityError,
+        _verify_parity,
+    )
+
+    await _insert_retrospective(
+        db_session,
+        retro_id=2003,
+        next_actions=[{"action": "parity test"}],
+    )
+
+    async with engine.connect() as conn:
+        trans = await conn.begin()
+        try:
+            await conn.execute(
+                text(
+                    "INSERT INTO review.trade_retrospective_actions "
+                    "(id, retrospective_id, position, action, status, version, "
+                    " status_actor, status_source, legacy_payload) "
+                    "VALUES (gen_random_uuid(), 2003, 0, 'parity test', 'open', 1, "
+                    " 'migration:rob-878', 'migration', "
+                    ' \'{"action":"parity test"}\'::jsonb)'
+                )
+            )
+            await conn.execute(
+                text(
+                    "UPDATE review.trade_retrospective_actions "
+                    "SET action = 'corrupted' WHERE retrospective_id = 2003"
+                )
+            )
+            with pytest.raises(CutoverParityError, match="parity"):
+                await _verify_parity(conn)
+            await trans.rollback()
+        except Exception:
+            await trans.rollback()
+            raise
+
+    mode = (
+        await db_session.execute(
+            text(
+                "SELECT mode FROM review.trade_retrospective_action_control WHERE id = 1"
+            )
+        )
+    ).scalar_one()
+    assert mode == "shadow"
+
+
+@pytest.mark.asyncio
+async def test_cutover_rebuilds_from_frozen_parent_json(db_session: AsyncSession):
+    """Cutover deletes stale shadow children and rebuilds from current parent JSON."""
+    from app.services.trade_journal.retrospective_action_repository import run_cutover
+
+    await _insert_retrospective(
+        db_session,
+        retro_id=2004,
+        next_actions=[
+            {"action": "updated action", "status": "open"},
+            {"action": "second", "status": "in_progress", "owner": "bob"},
+        ],
+    )
+    # Seed stale shadow children (from old parent JSON)
+    await _clear_actions(db_session)
+    await _insert_canonical_action(
+        db_session,
+        retrospective_id=2004,
+        position=0,
+        action="OLD action text",
+    )
+
+    async with engine.connect() as conn:
+        trans = await conn.begin()
+        try:
+            result = await run_cutover(conn, if_shadow=True)
+            assert result["action_count"] == 2
+            await trans.commit()
+        except Exception:
+            await trans.rollback()
+            raise
+
+    # Children should match the CURRENT parent JSON, not the stale shadow
+    rows = (
+        await db_session.execute(
+            text(
+                "SELECT action, owner, status FROM review.trade_retrospective_actions "
+                "WHERE retrospective_id = 2004 ORDER BY position"
+            )
+        )
+    ).all()
+    assert len(rows) == 2
+    assert rows[0].action == "updated action"
+    assert rows[1].action == "second"
+    assert rows[1].owner == "bob"
+    assert rows[1].status == "in_progress"
+
+
+@pytest.mark.asyncio
+async def test_cutover_full_field_parity(db_session: AsyncSession):
+    """Cutover verifies ordinal, action, owner, issue_id, status, due_kst_date."""
+    from app.services.trade_journal.retrospective_action_repository import run_cutover
+
+    await _insert_retrospective(
+        db_session,
+        retro_id=2005,
+        next_actions=[
+            {
+                "action": "first",
+                "owner": "alice",
+                "issue_id": "ROB-100",
+                "status": "open",
+                "due_kst_date": "2026-08-01",
+            },
+            {
+                "action": "second",
+                "owner": None,
+                "issue_id": None,
+                "status": "done",
+            },
+        ],
+    )
+    await _clear_actions(db_session)
+
+    async with engine.connect() as conn:
+        trans = await conn.begin()
+        try:
+            result = await run_cutover(conn, if_shadow=True)
+            assert result["action_count"] == 2
+            await trans.commit()
+        except Exception:
+            await trans.rollback()
+            raise
+
+    rows = (
+        await db_session.execute(
+            text(
+                "SELECT position, action, owner, issue_id, status, due_kst_date, "
+                "version, status_actor, status_source, resolved_at "
+                "FROM review.trade_retrospective_actions "
+                "WHERE retrospective_id = 2005 ORDER BY position"
+            )
+        )
+    ).all()
+    assert len(rows) == 2
+
+    assert rows[0].position == 0
+    assert rows[0].action == "first"
+    assert rows[0].owner == "alice"
+    assert rows[0].issue_id == "ROB-100"
+    assert rows[0].status == "open"
+    assert str(rows[0].due_kst_date) == "2026-08-01"
+    assert rows[0].version == 1
+    assert rows[0].status_actor == "migration:rob-878"
+    assert rows[0].status_source == "migration"
+    assert rows[0].resolved_at is None
+
+    assert rows[1].position == 1
+    assert rows[1].action == "second"
+    assert rows[1].status == "done"
+    assert rows[1].resolved_at is not None
+
+
+# ---------------------------------------------------------------------------
+# Section 3: Save reconciliation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_canonical_save_creates_new_action(db_session: AsyncSession):
+    """In canonical mode, saving a new retrospective creates child actions."""
+    from app.services.trade_journal.retrospective_action_repository import (
+        RetrospectiveActionRepository,
+    )
+
+    await _set_canonical_mode(db_session)
+
+    repo = RetrospectiveActionRepository(db_session)
+    await _insert_retrospective(
+        db_session,
+        retro_id=3001,
+        next_actions=None,
+    )
+
+    await repo.reconcile_actions(
+        3001,
+        [
+            {"action": "new action", "status": "open"},
+        ],
+        actor="user:1",
+    )
+
+    actions = await repo.read_actions(3001)
+    assert len(actions) == 1
+    assert actions[0]["action"] == "new action"
+
+    # Projection should be written to parent JSONB
+    parent_na = (
+        await db_session.execute(
+            text("SELECT next_actions FROM review.trade_retrospectives WHERE id = 3001")
+        )
+    ).scalar_one()
+    assert parent_na is not None
+    assert len(parent_na) == 1
+    assert parent_na[0]["action"] == "new action"
+
+
+@pytest.mark.asyncio
+async def test_canonical_save_occurrence_aware_matching(db_session: AsyncSession):
+    """Duplicate action text is matched occurrence-aware (first unmatched)."""
+    from app.services.trade_journal.retrospective_action_repository import (
+        RetrospectiveActionRepository,
+    )
+
+    await _set_canonical_mode(db_session)
+    await _insert_retrospective(
+        db_session,
+        retro_id=3002,
+        next_actions=None,
+    )
+
+    repo = RetrospectiveActionRepository(db_session)
+    # Create two actions with identical text
+    await repo.reconcile_actions(
+        3002,
+        [
+            {"action": "same text", "status": "open"},
+            {"action": "same text", "status": "open"},
+        ],
+        actor="user:1",
+    )
+    actions = await repo.read_actions(3002)
+    assert len(actions) == 2
+    assert all(a["action"] == "same text" for a in actions)
+
+    # Re-save with the same two items — should match both, not create new
+    await repo.reconcile_actions(
+        3002,
+        [
+            {"action": "same text", "status": "open"},
+            {"action": "same text", "status": "open"},
+        ],
+        actor="user:1",
+    )
+    actions = await repo.read_actions(3002)
+    assert len(actions) == 2  # no new rows
+
+
+@pytest.mark.asyncio
+async def test_canonical_save_action_id_ownership_validation(db_session: AsyncSession):
+    """action_id belonging to another parent is rejected."""
+    from app.services.trade_journal.retrospective_action_repository import (
+        ActionReconcileError,
+        RetrospectiveActionRepository,
+    )
+
+    await _set_canonical_mode(db_session)
+    await _insert_retrospective(db_session, retro_id=3003, next_actions=None)
+    await _insert_retrospective(db_session, retro_id=3004, next_actions=None)
+
+    repo = RetrospectiveActionRepository(db_session)
+    await repo.reconcile_actions(
+        3003,
+        [{"action": "owned by 3003", "status": "open"}],
+        actor="user:1",
+    )
+    actions_3003 = await repo.read_actions(3003)
+    foreign_action_id = actions_3003[0]["action_id"]
+
+    # Try to use that action_id on a different parent
+    with pytest.raises(ActionReconcileError, match="action_id.*not.*parent"):
+        await repo.reconcile_actions(
+            3004,
+            [
+                {
+                    "action": "different action",
+                    "action_id": foreign_action_id,
+                    "status": "open",
+                }
+            ],
+            actor="user:1",
+        )
+
+
+@pytest.mark.asyncio
+async def test_canonical_save_force_new_creation_key_idempotency(
+    db_session: AsyncSession,
+):
+    """force_new + creation_key creates a new action and is idempotent on retry."""
+    from app.services.trade_journal.retrospective_action_repository import (
+        RetrospectiveActionRepository,
+    )
+
+    await _set_canonical_mode(db_session)
+    await _insert_retrospective(db_session, retro_id=3005, next_actions=None)
+
+    repo = RetrospectiveActionRepository(db_session)
+    ckey = uuid.uuid4()
+
+    # Create first action
+    await repo.reconcile_actions(
+        3005,
+        [{"action": "original", "status": "open"}],
+        actor="user:1",
+    )
+
+    # force_new with creation_key
+    await repo.reconcile_actions(
+        3005,
+        [
+            {"action": "original", "status": "open"},
+            {
+                "action": "original",
+                "status": "open",
+                "force_new": True,
+                "creation_key": str(ckey),
+            },
+        ],
+        actor="user:1",
+    )
+    actions = await repo.read_actions(3005)
+    assert len(actions) == 2
+
+    # Retry with same creation_key — should reuse, not create a third
+    await repo.reconcile_actions(
+        3005,
+        [
+            {"action": "original", "status": "open"},
+            {
+                "action": "original",
+                "status": "open",
+                "force_new": True,
+                "creation_key": str(ckey),
+            },
+        ],
+        actor="user:1",
+    )
+    actions = await repo.read_actions(3005)
+    assert len(actions) == 2  # idempotent
+
+
+@pytest.mark.asyncio
+async def test_canonical_save_omitted_status_preserved(db_session: AsyncSession):
+    """Omitted status means 'leave lifecycle unchanged', not 'reset to open'."""
+    from app.services.trade_journal.retrospective_action_repository import (
+        RetrospectiveActionRepository,
+    )
+
+    await _set_canonical_mode(db_session)
+    await _insert_retrospective(db_session, retro_id=3006, next_actions=None)
+
+    repo = RetrospectiveActionRepository(db_session)
+    # Create with in_progress
+    await repo.reconcile_actions(
+        3006,
+        [{"action": "in progress action", "status": "in_progress"}],
+        actor="user:1",
+    )
+
+    # Re-save without status — should stay in_progress
+    await repo.reconcile_actions(
+        3006,
+        [{"action": "in progress action"}],  # no status key
+        actor="user:1",
+    )
+    actions = await repo.read_actions(3006)
+    assert actions[0]["status"] == "in_progress"
+
+
+@pytest.mark.asyncio
+async def test_canonical_save_terminal_initial_rejected(db_session: AsyncSession):
+    """Creating a new action with terminal status (done/obsolete/expired) is rejected."""
+    from app.services.trade_journal.retrospective_action_repository import (
+        ActionReconcileError,
+        RetrospectiveActionRepository,
+    )
+
+    await _set_canonical_mode(db_session)
+    await _insert_retrospective(db_session, retro_id=3007, next_actions=None)
+
+    repo = RetrospectiveActionRepository(db_session)
+    with pytest.raises(ActionReconcileError, match="terminal.*initial"):
+        await repo.reconcile_actions(
+            3007,
+            [{"action": "done at creation", "status": "done"}],
+            actor="user:1",
+        )
+
+
+@pytest.mark.asyncio
+async def test_canonical_save_projection_preserves_unknown_keys(
+    db_session: AsyncSession,
+):
+    """Projection starts from legacy_payload and preserves unknown keys."""
+    from app.services.trade_journal.retrospective_action_repository import (
+        RetrospectiveActionRepository,
+    )
+
+    await _set_canonical_mode(db_session)
+    await _insert_retrospective(db_session, retro_id=3008, next_actions=None)
+
+    repo = RetrospectiveActionRepository(db_session)
+    await repo.reconcile_actions(
+        3008,
+        [
+            {
+                "action": "with custom",
+                "status": "open",
+                "custom_key": "custom_value",
+                "priority": 5,
+            }
+        ],
+        actor="user:1",
+    )
+
+    parent_na = (
+        await db_session.execute(
+            text("SELECT next_actions FROM review.trade_retrospectives WHERE id = 3008")
+        )
+    ).scalar_one()
+    assert len(parent_na) == 1
+    assert parent_na[0]["action"] == "with custom"
+    assert parent_na[0]["custom_key"] == "custom_value"
+    assert parent_na[0]["priority"] == 5
+    # action_id and version are additive
+    assert "action_id" in parent_na[0]
+    assert parent_na[0]["version"] == 1
+
+
+@pytest.mark.asyncio
+async def test_canonical_save_projection_obsolete_expired_to_done(
+    db_session: AsyncSession,
+):
+    """obsolete/expired project as status=done with additive terminal_status."""
+    from app.services.trade_journal.retrospective_action_repository import (
+        RetrospectiveActionRepository,
+    )
+
+    await _set_canonical_mode(db_session)
+    await _insert_retrospective(db_session, retro_id=3009, next_actions=None)
+
+    repo = RetrospectiveActionRepository(db_session)
+    # Create an open action first, then manually set it to obsolete via SQL
+    # (transition API is ROB-881, not this issue)
+    await repo.reconcile_actions(
+        3009,
+        [{"action": "to be obsoleted", "status": "open"}],
+        actor="user:1",
+    )
+    actions = await repo.read_actions(3009)
+    action_id = actions[0]["action_id"]
+
+    # Manually set to obsolete (simulating a future transition)
+    await db_session.execute(
+        text(
+            "UPDATE review.trade_retrospective_actions "
+            "SET status = 'obsolete', resolved_at = now(), "
+            "    status_reason = 'superseded', version = 2, "
+            "    status_changed_at = now(), status_source = 'web', "
+            "    status_actor = 'user:1' "
+            "WHERE id = :aid"
+        ),
+        {"aid": str(action_id)},
+    )
+    await db_session.commit()
+
+    # Trigger a projection rebuild by re-saving
+    await repo.reconcile_actions(
+        3009,
+        [{"action": "to be obsoleted"}],  # omitted status = preserve
+        actor="user:1",
+    )
+
+    parent_na = (
+        await db_session.execute(
+            text("SELECT next_actions FROM review.trade_retrospectives WHERE id = 3009")
+        )
+    ).scalar_one()
+    assert len(parent_na) == 1
+    assert parent_na[0]["status"] == "done"
+    assert parent_na[0].get("terminal_status") == "obsolete"
+
+
+@pytest.mark.asyncio
+async def test_canonical_save_omitted_next_actions_no_reconcile(
+    db_session: AsyncSession,
+):
+    """Omitted or null next_actions performs no child reconciliation."""
+    from app.services.trade_journal.retrospective_action_repository import (
+        RetrospectiveActionRepository,
+    )
+
+    await _set_canonical_mode(db_session)
+    await _insert_retrospective(db_session, retro_id=3010, next_actions=None)
+
+    repo = RetrospectiveActionRepository(db_session)
+    # Create an action
+    await repo.reconcile_actions(
+        3010,
+        [{"action": "existing", "status": "open"}],
+        actor="user:1",
+    )
+    actions_before = await repo.read_actions(3010)
+    assert len(actions_before) == 1
+
+    # Reconcile with None — should be a no-op
+    await repo.reconcile_actions(3010, None, actor="user:1")
+
+    actions_after = await repo.read_actions(3010)
+    assert len(actions_after) == 1
+    assert actions_after[0]["action"] == "existing"
+
+
+@pytest.mark.asyncio
+async def test_canonical_save_projection_no_unrelated_parent_field_changes(
+    db_session: AsyncSession,
+):
+    """Projection update does not change unrelated parent fields."""
+    from app.services.trade_journal.retrospective_action_repository import (
+        RetrospectiveActionRepository,
+    )
+
+    await _set_canonical_mode(db_session)
+    await _insert_retrospective(
+        db_session,
+        retro_id=3011,
+        next_actions=None,
+        realized_pnl=Decimal("1234.56"),
+    )
+
+    repo = RetrospectiveActionRepository(db_session)
+    await repo.reconcile_actions(
+        3011,
+        [{"action": "test", "status": "open"}],
+        actor="user:1",
+    )
+
+    updated_retro = (
+        await db_session.execute(
+            text(
+                "SELECT realized_pnl, lesson, rationale, trigger_type "
+                "FROM review.trade_retrospectives WHERE id = 3011"
+            )
+        )
+    ).one()
+    assert updated_retro.realized_pnl == Decimal("1234.56")
+    assert updated_retro.lesson is None
+    assert updated_retro.rationale is None
+    assert updated_retro.trigger_type == "fill"
+
+
+@pytest.mark.asyncio
+async def test_canonical_save_actor_from_identity(db_session: AsyncSession):
+    """Actor is from authenticated identity, not caller payload."""
+    from app.services.trade_journal.retrospective_action_repository import (
+        RetrospectiveActionRepository,
+    )
+
+    await _set_canonical_mode(db_session)
+    await _insert_retrospective(db_session, retro_id=3012, next_actions=None)
+
+    repo = RetrospectiveActionRepository(db_session)
+    await repo.reconcile_actions(
+        3012,
+        [{"action": "actor test", "status": "open"}],
+        actor="user:42",
+    )
+
+    row = (
+        await db_session.execute(
+            text(
+                "SELECT status_actor, status_source "
+                "FROM review.trade_retrospective_actions "
+                "WHERE retrospective_id = 3012"
+            )
+        )
+    ).one()
+    assert row.status_actor == "user:42"
+    assert row.status_source == "retrospective_save"
+
+
+# ---------------------------------------------------------------------------
+# Section 4: Canonical GET
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_canonical_get_response_shape(db_session: AsyncSession):
+    """Canonical GET returns {total, count, limit, offset, as_of, items}."""
+    from app.services.trade_journal.retrospective_action_repository import (
+        RetrospectiveActionRepository,
+    )
+
+    await _set_canonical_mode(db_session)
+    await _insert_retrospective(
+        db_session,
+        retro_id=4001,
+        next_actions=None,
+    )
+    repo = RetrospectiveActionRepository(db_session)
+    await repo.reconcile_actions(
+        4001,
+        [{"action": "action 1", "status": "open"}],
+        actor="user:1",
+    )
+
+    result = await repo.query_actions(limit=50, offset=0)
+
+    assert "total" in result
+    assert "count" in result
+    assert "limit" in result
+    assert "offset" in result
+    assert "as_of" in result
+    assert "items" in result
+    assert result["count"] == len(result["items"])
+    assert result["limit"] == 50
+    assert result["offset"] == 0
+    assert result["total"] >= 1
+
+
+@pytest.mark.asyncio
+async def test_canonical_get_active_default_filter(db_session: AsyncSession):
+    """Omitted status defaults to open,in_progress (active only)."""
+    from app.services.trade_journal.retrospective_action_repository import (
+        RetrospectiveActionRepository,
+    )
+
+    await _set_canonical_mode(db_session)
+    await _insert_retrospective(db_session, retro_id=4002, next_actions=None)
+
+    repo = RetrospectiveActionRepository(db_session)
+    await repo.reconcile_actions(
+        4002,
+        [
+            {"action": "open action", "status": "open"},
+            {"action": "in_progress action", "status": "in_progress"},
+        ],
+        actor="user:1",
+    )
+    # Manually set one to done
+    actions = await repo.read_actions(4002)
+    done_id = [a for a in actions if a["action"] == "open action"][0]["action_id"]
+    await db_session.execute(
+        text(
+            "UPDATE review.trade_retrospective_actions "
+            "SET status = 'done', resolved_at = now(), version = 2 "
+            "WHERE id = :aid"
+        ),
+        {"aid": str(done_id)},
+    )
+    await db_session.commit()
+
+    # Default filter should return only active (in_progress)
+    result = await repo.query_actions()
+    statuses = {item["status"] for item in result["items"]}
+    assert "done" not in statuses
+    assert "in_progress" in statuses
+
+
+@pytest.mark.asyncio
+async def test_canonical_get_overdue_first_ordering(db_session: AsyncSession):
+    """Overdue actions come first, then in_progress, then by due date."""
+    from app.services.trade_journal.retrospective_action_repository import (
+        RetrospectiveActionRepository,
+    )
+
+    await _set_canonical_mode(db_session)
+    await _insert_retrospective(db_session, retro_id=4003, next_actions=None)
+
+    repo = RetrospectiveActionRepository(db_session)
+    # Create actions with different statuses and due dates
+    await repo.reconcile_actions(
+        4003,
+        [
+            {"action": "no due date", "status": "open"},
+            {"action": "overdue", "status": "open", "due_kst_date": "2020-01-01"},
+            {
+                "action": "future due",
+                "status": "in_progress",
+                "due_kst_date": "2099-12-31",
+            },
+            {"action": "in_progress no due", "status": "in_progress"},
+        ],
+        actor="user:1",
+    )
+
+    result = await repo.query_actions()
+    items = result["items"]
+    # First item should be overdue
+    assert items[0]["action"] == "overdue"
+    assert items[0]["overdue"] is True
+    # in_progress should come before open (excluding overdue)
+    # The exact ordering: overdue → in_progress → due_date asc → updated_at → id
+    actions_list = [item["action"] for item in items]
+    assert "overdue" in actions_list
+    assert len(actions_list) == 4
+
+
+@pytest.mark.asyncio
+async def test_canonical_get_pagination_consistency(db_session: AsyncSession):
+    """total is consistent across pages; count == len(items) per page."""
+    from app.services.trade_journal.retrospective_action_repository import (
+        RetrospectiveActionRepository,
+    )
+
+    await _set_canonical_mode(db_session)
+    await _insert_retrospective(db_session, retro_id=4004, next_actions=None)
+
+    repo = RetrospectiveActionRepository(db_session)
+    await repo.reconcile_actions(
+        4004,
+        [{"action": f"action {i}", "status": "open"} for i in range(5)],
+        actor="user:1",
+    )
+
+    page1 = await repo.query_actions(limit=2, offset=0)
+    page2 = await repo.query_actions(limit=2, offset=2)
+    page3 = await repo.query_actions(limit=2, offset=4)
+
+    assert page1["total"] == page2["total"] == page3["total"]
+    assert page1["count"] == 2
+    assert page2["count"] == 2
+    assert page3["count"] == 1  # last page has 1 item
+
+
+# ---------------------------------------------------------------------------
+# Section 5: Legacy /next-actions alias compatibility
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_next_actions_alias_preserves_contract(db_session: AsyncSession):
+    """Legacy /next-actions still returns {market, symbol, count, scan_limit, items}."""
+    from app.services.trade_journal import trade_retrospective_service as svc
+
+    await _insert_retrospective(
+        db_session,
+        retro_id=5001,
+        next_actions=[{"action": "legacy alias", "status": "open"}],
+        market="kr",
+    )
+
+    result = await svc.get_open_next_actions(db_session)
+    assert "count" in result
+    assert "scan_limit" in result
+    assert "items" in result
+    assert result["count"] >= 1
+    item = next(i for i in result["items"] if i["action"] == "legacy alias")
+    assert item["symbol"] == "005930"
+    assert item["market"] == "kr"
+
+
+@pytest.mark.asyncio
+async def test_next_actions_alias_additive_action_id_version(db_session: AsyncSession):
+    """In canonical mode, /next-actions items gain action_id and version."""
+    from app.services.trade_journal import trade_retrospective_service as svc
+    from app.services.trade_journal.retrospective_action_repository import (
+        RetrospectiveActionRepository,
+    )
+
+    await _set_canonical_mode(db_session)
+    await _insert_retrospective(db_session, retro_id=5002, next_actions=None)
+
+    repo = RetrospectiveActionRepository(db_session)
+    await repo.reconcile_actions(
+        5002,
+        [{"action": "canonical alias", "status": "open"}],
+        actor="user:1",
+    )
+
+    result = await svc.get_open_next_actions(db_session)
+    item = next(i for i in result["items"] if i["action"] == "canonical alias")
+    assert "action_id" in item
+    assert "version" in item
+    assert item["version"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Section 6: Deploy script post-switch cutover step
+# ---------------------------------------------------------------------------
+
+
+def test_deploy_native_script_has_cutover_after_bluegreen_committed():
+    """deploy-native.sh calls cutover only after BLUEGREEN_COMMITTED=1."""
+    script_path = (
+        Path(__file__).resolve().parent.parent / "scripts" / "deploy-native.sh"
+    )
+    content = script_path.read_text()
+
+    # BLUEGREEN_COMMITTED=1 must appear before the cutover call
+    bg_idx = content.find("BLUEGREEN_COMMITTED=1")
+    assert bg_idx != -1, "BLUEGREEN_COMMITTED=1 not found in deploy-native.sh"
+
+    cutover_idx = content.find("retrospective_action_cutover")
+    assert cutover_idx != -1, (
+        "retrospective_action_cutover not found in deploy-native.sh"
+    )
+
+    assert bg_idx < cutover_idx, (
+        "BLUEGREEN_COMMITTED=1 must appear before retrospective_action_cutover"
+    )
+
+
+def test_deploy_native_script_cutover_uses_if_shadow():
+    """deploy-native.sh uses --if-shadow for idempotent cutover."""
+    script_path = (
+        Path(__file__).resolve().parent.parent / "scripts" / "deploy-native.sh"
+    )
+    content = script_path.read_text()
+
+    assert "--if-shadow" in content, (
+        "deploy-native.sh must use --if-shadow for idempotent cutover"
+    )
+
+
+def test_deploy_native_script_cutover_conditional_on_committed():
+    """Cutover is conditional on BLUEGREEN_COMMITTED=1."""
+    script_path = (
+        Path(__file__).resolve().parent.parent / "scripts" / "deploy-native.sh"
+    )
+    content = script_path.read_text()
+
+    # The cutover should be guarded by a conditional check on BLUEGREEN_COMMITTED
+    # Look for a pattern like: if (( BLUEGREEN_COMMITTED == 1 )); then ... cutover
+    assert "BLUEGREEN_COMMITTED" in content
+    assert "retrospective_action_cutover" in content
+    # Verify there's a conditional structure around the cutover
+    cutover_section = content[content.find("retrospective_action_cutover") - 200 :]
+    assert (
+        "BLUEGREEN_COMMITTED" in cutover_section
+        or "if "
+        in content[
+            content.find("retrospective_action_cutover") - 500 : content.find(
+                "retrospective_action_cutover"
+            )
+        ]
+    )
+
+
+# ---------------------------------------------------------------------------
+# Section 7: Shadow mode save still uses legacy JSON writer
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_shadow_mode_save_writes_parent_json(db_session: AsyncSession):
+    """In shadow mode, save_retrospective writes next_actions to parent JSONB directly."""
+    from app.services.trade_journal import trade_retrospective_service as svc
+
+    # Shadow mode is the default
+    _, retro = await svc.save_retrospective(
+        db_session,
+        symbol="005930",
+        instrument_type="equity_kr",
+        account_mode="kis_mock",
+        outcome="filled",
+        correlation_id="shadow-save-test",
+        trigger_type="fill",
+        next_actions=[{"action": "shadow mode action", "status": "open"}],
+    )
+
+    parent_na = (
+        await db_session.execute(
+            text(
+                "SELECT next_actions FROM review.trade_retrospectives WHERE id = :rid"
+            ),
+            {"rid": retro.id},
+        )
+    ).scalar_one()
+    assert parent_na is not None
+    assert len(parent_na) == 1
+    assert parent_na[0]["action"] == "shadow mode action"
+
+
+@pytest.mark.asyncio
+async def test_canonical_mode_save_uses_repository(db_session: AsyncSession):
+    """In canonical mode, save_retrospective routes through the repository."""
+    from app.services.trade_journal import trade_retrospective_service as svc
+
+    await _set_canonical_mode(db_session)
+
+    _, retro = await svc.save_retrospective(
+        db_session,
+        symbol="005930",
+        instrument_type="equity_kr",
+        account_mode="kis_mock",
+        outcome="filled",
+        correlation_id="canonical-save-test",
+        trigger_type="fill",
+        next_actions=[{"action": "canonical mode action", "status": "open"}],
+    )
+
+    # Child ledger should have the action
+    count = (
+        await db_session.execute(
+            text(
+                "SELECT count(*) FROM review.trade_retrospective_actions "
+                "WHERE retrospective_id = :rid"
+            ),
+            {"rid": retro.id},
+        )
+    ).scalar_one()
+    assert count == 1
+
+    # Parent JSONB should have the projection
+    parent_na = (
+        await db_session.execute(
+            text(
+                "SELECT next_actions FROM review.trade_retrospectives WHERE id = :rid"
+            ),
+            {"rid": retro.id},
+        )
+    ).scalar_one()
+    assert parent_na is not None
+    assert len(parent_na) == 1
+    assert parent_na[0]["action"] == "canonical mode action"
+    assert "action_id" in parent_na[0]
+
+
+# ---------------------------------------------------------------------------
+# Section 8: Runbook / operational contract tests
+# ---------------------------------------------------------------------------
+
+
+def test_runbook_exists_for_canonical_cutover():
+    """A runbook documenting mixed-version deploy/cutover/rollback exists."""
+    # Check for runbook content in the test itself — this is a self-documenting
+    # contract test. The runbook is embedded in the test file as docstrings
+    # and in the cutover script's --help output.
+    script_path = (
+        Path(__file__).resolve().parent.parent
+        / "scripts"
+        / "retrospective_action_cutover.py"
+    )
+    if not script_path.exists():
+        pytest.skip("Cutover script not yet created")
+    content = script_path.read_text()
+    # The script must document the rollback/roll-forward procedure
+    assert "roll-forward" in content.lower() or "rollback" in content.lower(), (
+        "Cutover script must document rollback/roll-forward procedure"
+    )
+
+
+@pytest.mark.asyncio
+async def test_canonical_fail_closed_on_direct_json_write(db_session: AsyncSession):
+    """After cutover, direct parent JSON writes without GUC marker fail closed."""
+    await _insert_retrospective(
+        db_session,
+        retro_id=7001,
+        next_actions=[{"action": "before cutover"}],
+    )
+    await _set_canonical_mode(db_session)
+
+    # Direct write without GUC marker should fail
+    with pytest.raises(Exception, match="canonical mode.*rejected"):
+        async with engine.begin() as conn:
+            await conn.execute(
+                text(
+                    "UPDATE review.trade_retrospectives SET next_actions = "
+                    '\'[{"action": "blocked"}]\'::jsonb WHERE id = 7001'
+                )
+            )
+
+
+@pytest.mark.asyncio
+async def test_canonical_mode_projection_writer_with_guc_succeeds(
+    db_session: AsyncSession,
+):
+    """Projection writer with GUC marker can write parent JSONB in canonical mode."""
+    from app.services.trade_journal.retrospective_action_repository import (
+        RetrospectiveActionRepository,
+    )
+
+    await _set_canonical_mode(db_session)
+    await _insert_retrospective(db_session, retro_id=7002, next_actions=None)
+
+    repo = RetrospectiveActionRepository(db_session)
+    await repo.reconcile_actions(
+        7002,
+        [{"action": "guc test", "status": "open"}],
+        actor="user:1",
+    )
+
+    # Projection should have been written (with GUC marker)
+    parent_na = (
+        await db_session.execute(
+            text("SELECT next_actions FROM review.trade_retrospectives WHERE id = 7002")
+        )
+    ).scalar_one()
+    assert parent_na is not None
+    assert len(parent_na) == 1
+    assert parent_na[0]["action"] == "guc test"

--- a/tests/test_rob878_canonical_cutover.py
+++ b/tests/test_rob878_canonical_cutover.py
@@ -32,6 +32,7 @@ from app.models.review import (
 pytestmark = [
     pytest.mark.integration,
     pytest.mark.usefixtures("investment_reports_cleanup_lock"),
+    pytest.mark.usefixtures("retrospective_action_control_lock"),
 ]
 
 
@@ -160,7 +161,11 @@ async def _clear_actions(db: AsyncSession) -> None:
 
 
 @pytest_asyncio.fixture(autouse=True)
-async def _cleanup(db_session: AsyncSession):
+async def _cleanup(
+    db_session: AsyncSession,
+    investment_reports_cleanup_lock: AsyncSession,
+    retrospective_action_control_lock,
+):
     """Clean up retrospectives, actions, and reset control mode before each test."""
     await db_session.execute(delete(TradeRetrospectiveAction))
     await db_session.execute(delete(TradeRetrospective))

--- a/tests/test_rob878_canonical_cutover.py
+++ b/tests/test_rob878_canonical_cutover.py
@@ -647,7 +647,7 @@ async def test_shadow_save_rejects_canonical_only_action_state(
     [
         ("force_new", True),
         ("terminal_status", "obsolete"),
-        ("action_id", str(uuid.uuid4())),
+        ("action_id", "00000000-0000-0000-0000-000000000880"),
         ("version", 1),
     ],
 )

--- a/tests/test_rob878_canonical_cutover.py
+++ b/tests/test_rob878_canonical_cutover.py
@@ -11,14 +11,16 @@ Tests cover:
 
 from __future__ import annotations
 
+import json
 import uuid
 from datetime import UTC, datetime
 from decimal import Decimal
 from pathlib import Path
+from typing import Any
 
 import pytest
 import pytest_asyncio
-from sqlalchemy import delete, text
+from sqlalchemy import delete, event, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.db import engine
@@ -77,7 +79,10 @@ async def _set_canonical_mode(db: AsyncSession) -> None:
     await db.execute(
         text(
             "UPDATE review.trade_retrospective_action_control "
-            "SET mode = 'canonical' WHERE id = 1"
+            "SET mode = 'canonical', cutover_at = now(), "
+            "cutover_action_count = ("
+            "    SELECT count(*) FROM review.trade_retrospective_actions"
+            "), updated_at = now() WHERE id = 1"
         )
     )
     await db.commit()
@@ -87,7 +92,7 @@ async def _insert_retrospective(
     db: AsyncSession,
     *,
     retro_id: int,
-    next_actions: list | None,
+    next_actions: Any,
     correlation_id: str | None = None,
     symbol: str = "005930",
     market: str = "kr",
@@ -119,6 +124,7 @@ async def _insert_canonical_action(
     retrospective_id: int,
     position: int,
     action: str,
+    action_id: uuid.UUID | None = None,
     owner: str | None = None,
     issue_id: str | None = None,
     status: str = "open",
@@ -130,6 +136,7 @@ async def _insert_canonical_action(
 ) -> TradeRetrospectiveAction:
     """Insert a canonical action row directly."""
     row = TradeRetrospectiveAction(
+        id=action_id,
         retrospective_id=retrospective_id,
         position=position,
         action=action,
@@ -223,6 +230,59 @@ async def test_repository_canonical_mode_reads_child_ledger(db_session: AsyncSes
 
 
 @pytest.mark.asyncio
+async def test_repository_canonical_read_preserves_unknown_payload_and_is_json_safe(
+    db_session: AsyncSession,
+):
+    """Canonical hydration keeps legacy extensions while normalizing UUIDs."""
+    from app.services.trade_journal.retrospective_action_repository import (
+        RetrospectiveActionRepository,
+    )
+
+    await _insert_retrospective(db_session, retro_id=1008, next_actions=None)
+    await _insert_canonical_action(
+        db_session,
+        retrospective_id=1008,
+        position=0,
+        action="extended action",
+        legacy_payload={
+            "action": "stale action",
+            "custom_context": {"source": "legacy"},
+            "force_new": True,
+        },
+    )
+    await _set_canonical_mode(db_session)
+
+    actions = await RetrospectiveActionRepository(db_session).read_actions(1008)
+
+    assert actions[0]["action"] == "extended action"
+    assert actions[0]["custom_context"] == {"source": "legacy"}
+    assert "force_new" not in actions[0]
+    assert isinstance(actions[0]["action_id"], str)
+    json.dumps(actions)
+
+
+@pytest.mark.asyncio
+async def test_shadow_batch_hydration_preserves_null_next_actions(
+    db_session: AsyncSession,
+):
+    from app.services.trade_journal.retrospective_action_repository import (
+        RetrospectiveActionRepository,
+    )
+
+    parent = await _insert_retrospective(
+        db_session,
+        retro_id=1009,
+        next_actions=None,
+    )
+
+    hydrated = await RetrospectiveActionRepository(db_session).read_actions_many(
+        [parent]
+    )
+
+    assert hydrated[parent.id] is None
+
+
+@pytest.mark.asyncio
 async def test_repository_missing_control_row_fails_closed(db_session: AsyncSession):
     """Absent control row must fail closed, not default to shadow."""
     from app.services.trade_journal.retrospective_action_repository import (
@@ -265,6 +325,31 @@ async def test_repository_unknown_mode_fails_closed(db_session: AsyncSession):
     repo = RetrospectiveActionRepository(db_session)
     with pytest.raises(ActionControlError, match="mode.*invalid"):
         await repo.get_control_mode()
+
+
+@pytest.mark.asyncio
+async def test_save_service_missing_control_row_fails_closed(db_session: AsyncSession):
+    """The service must not reinterpret missing DB authority as shadow mode."""
+    from app.services.trade_journal import trade_retrospective_service as svc
+    from app.services.trade_journal.retrospective_action_repository import (
+        ActionControlError,
+    )
+
+    await db_session.execute(
+        text("DELETE FROM review.trade_retrospective_action_control WHERE id = 1")
+    )
+    await db_session.commit()
+
+    with pytest.raises(ActionControlError, match="control row is missing"):
+        await svc.save_retrospective(
+            db_session,
+            symbol="005930",
+            instrument_type="equity_kr",
+            account_mode="kis_mock",
+            outcome="filled",
+            correlation_id="missing-control-service",
+            next_actions=[{"action": "must not write"}],
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -355,6 +440,270 @@ async def test_cutover_idempotent_if_shadow(db_session: AsyncSession):
         except Exception:
             await trans.rollback()
             raise
+
+
+@pytest.mark.asyncio
+async def test_cutover_requires_if_shadow_for_canonical_noop(db_session: AsyncSession):
+    """Already-canonical mode is only a no-op when the caller opted into it."""
+    from app.services.trade_journal.retrospective_action_repository import (
+        ActionControlError,
+        run_cutover,
+    )
+
+    await _set_canonical_mode(db_session)
+
+    async with engine.connect() as conn:
+        trans = await conn.begin()
+        with pytest.raises(ActionControlError, match="already canonical"):
+            await run_cutover(conn, if_shadow=False)
+        await trans.rollback()
+
+
+@pytest.mark.asyncio
+async def test_cutover_rejects_canonical_noop_without_audit_metadata(
+    db_session: AsyncSession,
+):
+    from app.services.trade_journal.retrospective_action_repository import (
+        ActionControlError,
+        run_cutover,
+    )
+
+    await db_session.execute(
+        text(
+            "UPDATE review.trade_retrospective_action_control "
+            "SET mode = 'canonical', cutover_at = NULL, "
+            "cutover_action_count = NULL WHERE id = 1"
+        )
+    )
+    await db_session.commit()
+
+    async with engine.connect() as conn:
+        trans = await conn.begin()
+        with pytest.raises(ActionControlError, match="cutover metadata"):
+            await run_cutover(conn, if_shadow=True)
+        await trans.rollback()
+
+
+@pytest.mark.asyncio
+async def test_cutover_canonical_noop_skips_heavy_table_locks(
+    db_session: AsyncSession,
+):
+    """Idempotent deploys must not block normal writes after canonical cutover."""
+    from app.services.trade_journal.retrospective_action_repository import run_cutover
+
+    await _set_canonical_mode(db_session)
+
+    async with engine.connect() as blocker:
+        blocker_tx = await blocker.begin()
+        try:
+            await blocker.execute(
+                text("LOCK TABLE review.trade_retrospectives IN ACCESS EXCLUSIVE MODE")
+            )
+            async with engine.connect() as contender:
+                contender_tx = await contender.begin()
+                try:
+                    await contender.execute(text("SET LOCAL lock_timeout = '100ms'"))
+                    result = await run_cutover(contender, if_shadow=True)
+                    assert result["idempotent"] is True
+                finally:
+                    await contender_tx.rollback()
+        finally:
+            await blocker_tx.rollback()
+
+
+@pytest.mark.asyncio
+async def test_cutover_without_if_shadow_still_switches_shadow_mode(
+    db_session: AsyncSession,
+):
+    from app.services.trade_journal.retrospective_action_repository import run_cutover
+
+    await _insert_retrospective(
+        db_session,
+        retro_id=2010,
+        next_actions=[{"action": "cut over"}],
+    )
+    async with engine.begin() as conn:
+        result = await run_cutover(conn, if_shadow=False)
+
+    assert result["mode"] == "canonical"
+    assert result["idempotent"] is False
+
+
+@pytest.mark.asyncio
+async def test_cutover_treats_space_only_due_date_as_omitted(
+    db_session: AsyncSession,
+):
+    from app.services.trade_journal.retrospective_action_repository import run_cutover
+
+    await _insert_retrospective(
+        db_session,
+        retro_id=2011,
+        next_actions=[{"action": "no due date", "due_kst_date": "   "}],
+    )
+    async with engine.begin() as conn:
+        await run_cutover(conn, if_shadow=True)
+
+    due_date = (
+        await db_session.execute(
+            text(
+                "SELECT due_kst_date FROM review.trade_retrospective_actions "
+                "WHERE retrospective_id = 2011"
+            )
+        )
+    ).scalar_one()
+    assert due_date is None
+
+
+@pytest.mark.asyncio
+async def test_shadow_force_new_key_survives_cutover_and_retry(
+    db_session: AsyncSession,
+):
+    from app.services.trade_journal import trade_retrospective_service as svc
+    from app.services.trade_journal.retrospective_action_repository import (
+        RetrospectiveActionRepository,
+        run_cutover,
+    )
+
+    creation_key = uuid.uuid4()
+    original = {
+        "action": "intentional occurrence",
+        "status": "open",
+        "force_new": True,
+        "creation_key": str(creation_key),
+    }
+    _, retro = await svc.save_retrospective(
+        db_session,
+        symbol="005930",
+        instrument_type="equity_kr",
+        account_mode="kis_mock",
+        outcome="filled",
+        correlation_id="shadow-key-cutover",
+        next_actions=[original],
+    )
+    await db_session.commit()
+    stored = (
+        await db_session.execute(
+            text("SELECT next_actions FROM review.trade_retrospectives WHERE id = :id"),
+            {"id": retro.id},
+        )
+    ).scalar_one()
+    assert stored[0]["creation_key"] == str(creation_key)
+    assert "force_new" not in stored[0]
+
+    # Shadow read payload is itself a valid idempotent re-save.
+    await svc.save_retrospective(
+        db_session,
+        symbol="005930",
+        instrument_type="equity_kr",
+        account_mode="kis_mock",
+        outcome="filled",
+        correlation_id="shadow-key-cutover",
+        next_actions=stored,
+    )
+    await db_session.commit()
+
+    async with engine.begin() as conn:
+        await run_cutover(conn, if_shadow=True)
+
+    repo = RetrospectiveActionRepository(db_session)
+    await repo.reconcile_actions(retro.id, [original], actor="user:1")
+    actions = await repo.read_actions(retro.id)
+    assert len(actions) == 1
+    assert actions[0]["creation_key"] == str(creation_key)
+    assert "force_new" not in actions[0]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "next_action",
+    [
+        {"action": "canonical terminal", "status": "obsolete"},
+        {"action": "canonical terminal", "status": "expired"},
+        {"action": "provisional id", "action_id": str(uuid.uuid4())},
+        {"action": "provisional version", "version": 2},
+    ],
+)
+async def test_shadow_save_rejects_canonical_only_action_state(
+    db_session: AsyncSession,
+    next_action: dict[str, Any],
+):
+    from app.services.trade_journal import trade_retrospective_service as svc
+
+    with pytest.raises(svc.RetrospectiveValidationError, match="shadow mode"):
+        await svc.save_retrospective(
+            db_session,
+            symbol="005930",
+            instrument_type="equity_kr",
+            account_mode="kis_mock",
+            outcome="filled",
+            correlation_id=f"shadow-reject-{next_action['action']}",
+            next_actions=[next_action],
+        )
+
+
+@pytest.mark.asyncio
+async def test_cutover_rejects_persisted_transport_only_force_new(
+    db_session: AsyncSession,
+):
+    from app.services.trade_journal.retrospective_action_repository import (
+        CutoverParityError,
+        run_cutover,
+    )
+
+    await _insert_retrospective(
+        db_session,
+        retro_id=2012,
+        next_actions=[
+            {
+                "action": "poisoned transport intent",
+                "force_new": True,
+                "creation_key": str(uuid.uuid4()),
+            }
+        ],
+    )
+
+    async with engine.connect() as conn:
+        transaction = await conn.begin()
+        with pytest.raises(CutoverParityError, match="force_new"):
+            await run_cutover(conn, if_shadow=True)
+        await transaction.rollback()
+
+
+@pytest.mark.asyncio
+async def test_cutover_lock_timeout_is_bounded_and_leaves_shadow(
+    db_session: AsyncSession,
+):
+    from app.services.trade_journal.retrospective_action_repository import (
+        CutoverLockError,
+        run_cutover,
+    )
+
+    async with engine.connect() as blocker:
+        blocker_tx = await blocker.begin()
+        try:
+            await blocker.execute(
+                text("LOCK TABLE review.trade_retrospectives IN ACCESS EXCLUSIVE MODE")
+            )
+            async with engine.connect() as contender:
+                contender_tx = await contender.begin()
+                with pytest.raises(CutoverLockError, match="lock"):
+                    await run_cutover(
+                        contender,
+                        if_shadow=True,
+                        lock_timeout_ms=50,
+                    )
+                await contender_tx.rollback()
+        finally:
+            await blocker_tx.rollback()
+
+    mode = (
+        await db_session.execute(
+            text(
+                "SELECT mode FROM review.trade_retrospective_action_control WHERE id = 1"
+            )
+        )
+    ).scalar_one()
+    assert mode == "shadow"
 
 
 @pytest.mark.asyncio
@@ -520,9 +869,273 @@ async def test_cutover_full_field_parity(db_session: AsyncSession):
     assert rows[1].resolved_at is not None
 
 
+@pytest.mark.asyncio
+async def test_cutover_rejects_non_array_shadow_drift(db_session: AsyncSession):
+    """Locked cutover preflight must not normalize malformed JSON to an empty list."""
+    from app.services.trade_journal.retrospective_action_repository import (
+        CutoverParityError,
+        run_cutover,
+    )
+
+    await _insert_retrospective(
+        db_session,
+        retro_id=2006,
+        next_actions={"action": "would be silently discarded"},
+    )
+
+    async with engine.connect() as conn:
+        trans = await conn.begin()
+        with pytest.raises(CutoverParityError, match="not an array"):
+            await run_cutover(conn, if_shadow=True)
+        await trans.rollback()
+
+    row = (
+        await db_session.execute(
+            text("SELECT next_actions FROM review.trade_retrospectives WHERE id = 2006")
+        )
+    ).scalar_one()
+    assert row == {"action": "would be silently discarded"}
+    mode = (
+        await db_session.execute(
+            text(
+                "SELECT mode FROM review.trade_retrospective_action_control WHERE id = 1"
+            )
+        )
+    ).scalar_one()
+    assert mode == "shadow"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("next_actions", "message"),
+    [
+        ([42], "element is not an object"),
+        ([{"action": 42}], "action must be a string"),
+        ([{"action": "  "}], "blank action"),
+        ([{"action": "x", "status": "bogus"}], "unknown status"),
+        ([{"action": "x", "due_kst_date": "2026-02-30"}], "invalid due_kst_date"),
+    ],
+)
+async def test_cutover_revalidates_each_shadow_action(
+    db_session: AsyncSession,
+    next_actions: list[Any],
+    message: str,
+):
+    """Cutover re-runs migration-grade validation on the frozen shadow snapshot."""
+    from app.services.trade_journal.retrospective_action_repository import (
+        CutoverParityError,
+        run_cutover,
+    )
+
+    await _insert_retrospective(
+        db_session,
+        retro_id=2007,
+        next_actions=next_actions,
+    )
+
+    async with engine.connect() as conn:
+        trans = await conn.begin()
+        with pytest.raises(CutoverParityError, match=message):
+            await run_cutover(conn, if_shadow=True)
+        await trans.rollback()
+
+
+@pytest.mark.asyncio
+async def test_cutover_parity_checks_audit_timestamps(db_session: AsyncSession):
+    """Parity detects audit-field corruption, not only display fields."""
+    from app.services.trade_journal.retrospective_action_repository import (
+        CutoverParityError,
+        _verify_parity,
+        run_cutover,
+    )
+
+    await _insert_retrospective(
+        db_session,
+        retro_id=2008,
+        next_actions=[{"action": "audit parity", "status": "open"}],
+    )
+    await _clear_actions(db_session)
+
+    async with engine.begin() as conn:
+        await run_cutover(conn, if_shadow=True)
+
+    await db_session.execute(
+        text(
+            "UPDATE review.trade_retrospective_actions "
+            "SET status_changed_at = status_changed_at + interval '1 second' "
+            "WHERE retrospective_id = 2008"
+        )
+    )
+    await db_session.commit()
+
+    async with engine.connect() as conn:
+        with pytest.raises(CutoverParityError, match="parity"):
+            await _verify_parity(conn)
+
+
+@pytest.mark.asyncio
+async def test_post_cutover_health_detects_equal_count_field_drift(
+    db_session: AsyncSession,
+):
+    from app.services.trade_journal.retrospective_action_repository import run_cutover
+    from scripts.retrospective_action_cutover import _health_check
+
+    await _insert_retrospective(
+        db_session,
+        retro_id=2009,
+        next_actions=[{"action": "health parity", "status": "open"}],
+    )
+    async with engine.begin() as conn:
+        await run_cutover(conn, if_shadow=True)
+
+    await db_session.execute(
+        text(
+            "UPDATE review.trade_retrospective_actions SET action = 'drifted' "
+            "WHERE retrospective_id = 2009"
+        )
+    )
+    await db_session.commit()
+
+    async with engine.connect() as conn:
+        health = await _health_check(conn)
+
+    assert health["healthy"] is False
+    assert "field/ordinal" in health["reason"]
+
+
+@pytest.mark.asyncio
+async def test_post_cutover_health_allows_later_canonical_actions(
+    db_session: AsyncSession,
+):
+    from app.services.trade_journal.retrospective_action_repository import (
+        RetrospectiveActionRepository,
+        run_cutover,
+    )
+    from scripts.retrospective_action_cutover import _health_check
+
+    await _insert_retrospective(
+        db_session,
+        retro_id=2013,
+        next_actions=[{"action": "at cutover", "status": "open"}],
+    )
+    async with engine.begin() as conn:
+        await run_cutover(conn, if_shadow=True)
+
+    await RetrospectiveActionRepository(db_session).reconcile_actions(
+        2013,
+        [{"action": "at cutover"}, {"action": "created later"}],
+        actor="user:1",
+    )
+    await db_session.commit()
+
+    async with engine.connect() as conn:
+        health = await _health_check(conn)
+
+    assert health["healthy"] is True
+
+
 # ---------------------------------------------------------------------------
 # Section 3: Save reconciliation
 # ---------------------------------------------------------------------------
+
+
+def test_next_action_transport_accepts_canonical_identity_fields():
+    """Service validation preserves canonical identity and idempotency controls."""
+    from app.services.trade_journal.trade_retrospective_service import (
+        _coerce_next_actions,
+    )
+
+    action_id = uuid.uuid4()
+    creation_key = uuid.uuid4()
+    result = _coerce_next_actions(
+        [
+            {
+                "action": "round trip",
+                "action_id": str(action_id),
+                "version": 3,
+                "status": "in_progress",
+                "due_kst_date": "2026-08-01",
+            },
+            {
+                "action": "intentional duplicate",
+                "force_new": True,
+                "creation_key": str(creation_key),
+            },
+        ]
+    )
+
+    assert result == [
+        {
+            "action": "round trip",
+            "action_id": str(action_id),
+            "version": 3,
+            "status": "in_progress",
+            "due_kst_date": "2026-08-01",
+        },
+        {
+            "action": "intentional duplicate",
+            "force_new": True,
+            "creation_key": str(creation_key),
+        },
+    ]
+
+
+@pytest.mark.parametrize(
+    "item",
+    [
+        {"action": "missing key", "force_new": True},
+        {
+            "action": "conflicting identity",
+            "action_id": str(uuid.uuid4()),
+            "force_new": True,
+            "creation_key": str(uuid.uuid4()),
+        },
+    ],
+)
+def test_next_action_transport_rejects_invalid_creation_controls(item: dict[str, Any]):
+    from app.services.trade_journal.trade_retrospective_service import (
+        RetrospectiveValidationError,
+        _coerce_next_actions,
+    )
+
+    with pytest.raises(RetrospectiveValidationError):
+        _coerce_next_actions([item])
+
+
+def test_next_action_transport_accepts_projected_creation_key_echo():
+    from app.services.trade_journal.trade_retrospective_service import (
+        _coerce_next_actions,
+    )
+
+    action_id = uuid.uuid4()
+    creation_key = uuid.uuid4()
+    result = _coerce_next_actions(
+        [
+            {
+                "action": "projected duplicate",
+                "action_id": str(action_id),
+                "creation_key": str(creation_key),
+            }
+        ]
+    )
+
+    assert result[0]["action_id"] == str(action_id)
+    assert result[0]["creation_key"] == str(creation_key)
+
+
+def test_next_action_transport_accepts_shadow_creation_key_echo():
+    from app.services.trade_journal.trade_retrospective_service import (
+        _coerce_next_actions,
+    )
+
+    creation_key = uuid.uuid4()
+    result = _coerce_next_actions(
+        [{"action": "shadow occurrence", "creation_key": str(creation_key)}]
+    )
+
+    assert result == [
+        {"action": "shadow occurrence", "creation_key": str(creation_key)}
+    ]
 
 
 @pytest.mark.asyncio
@@ -579,12 +1192,18 @@ async def test_canonical_save_occurrence_aware_matching(db_session: AsyncSession
     )
 
     repo = RetrospectiveActionRepository(db_session)
-    # Create two actions with identical text
+    creation_key = uuid.uuid4()
+    # Create the second identical occurrence explicitly.
     await repo.reconcile_actions(
         3002,
         [
             {"action": "same text", "status": "open"},
-            {"action": "same text", "status": "open"},
+            {
+                "action": "same text",
+                "status": "open",
+                "force_new": True,
+                "creation_key": str(creation_key),
+            },
         ],
         actor="user:1",
     )
@@ -603,6 +1222,28 @@ async def test_canonical_save_occurrence_aware_matching(db_session: AsyncSession
     )
     actions = await repo.read_actions(3002)
     assert len(actions) == 2  # no new rows
+
+
+@pytest.mark.asyncio
+async def test_canonical_save_requires_force_new_after_occurrences_exhausted(
+    db_session: AsyncSession,
+):
+    from app.services.trade_journal.retrospective_action_repository import (
+        ActionReconcileError,
+        RetrospectiveActionRepository,
+    )
+
+    await _set_canonical_mode(db_session)
+    await _insert_retrospective(db_session, retro_id=3015, next_actions=None)
+    repo = RetrospectiveActionRepository(db_session)
+    await repo.reconcile_actions(3015, [{"action": "same tuple"}], actor="user:1")
+
+    with pytest.raises(ActionReconcileError, match="force_new.*creation_key"):
+        await repo.reconcile_actions(
+            3015,
+            [{"action": "same tuple"}, {"action": "same tuple"}],
+            actor="user:1",
+        )
 
 
 @pytest.mark.asyncio
@@ -696,6 +1337,207 @@ async def test_canonical_save_force_new_creation_key_idempotency(
     )
     actions = await repo.read_actions(3005)
     assert len(actions) == 2  # idempotent
+
+
+@pytest.mark.asyncio
+async def test_canonical_save_creation_key_retry_rejects_changed_payload(
+    db_session: AsyncSession,
+):
+    from app.services.trade_journal.retrospective_action_repository import (
+        ActionReconcileError,
+        RetrospectiveActionRepository,
+    )
+
+    await _set_canonical_mode(db_session)
+    await _insert_retrospective(db_session, retro_id=3016, next_actions=None)
+    repo = RetrospectiveActionRepository(db_session)
+    creation_key = uuid.uuid4()
+    await repo.reconcile_actions(
+        3016,
+        [
+            {
+                "action": "stable payload",
+                "owner": "alice",
+                "status": "open",
+                "force_new": True,
+                "creation_key": str(creation_key),
+            }
+        ],
+        actor="user:1",
+    )
+
+    with pytest.raises(ActionReconcileError, match="creation_key.*immutable"):
+        await repo.reconcile_actions(
+            3016,
+            [
+                {
+                    "action": "changed payload",
+                    "owner": "alice",
+                    "status": "open",
+                    "force_new": True,
+                    "creation_key": str(creation_key),
+                }
+            ],
+            actor="user:1",
+        )
+
+
+@pytest.mark.asyncio
+async def test_canonical_save_rejects_duplicate_action_id(db_session: AsyncSession):
+    from app.services.trade_journal.retrospective_action_repository import (
+        ActionReconcileError,
+        RetrospectiveActionRepository,
+    )
+
+    await _set_canonical_mode(db_session)
+    await _insert_retrospective(db_session, retro_id=3004, next_actions=None)
+    repo = RetrospectiveActionRepository(db_session)
+    await repo.reconcile_actions(
+        3004,
+        [{"action": "one", "status": "open"}],
+        actor="user:1",
+    )
+    action_id = (await repo.read_actions(3004))[0]["action_id"]
+
+    with pytest.raises(ActionReconcileError, match="duplicate action_id"):
+        await repo.reconcile_actions(
+            3004,
+            [
+                {"action_id": action_id, "action": "one"},
+                {"action_id": action_id, "action": "one"},
+            ],
+            actor="user:1",
+        )
+
+
+@pytest.mark.asyncio
+async def test_canonical_save_force_new_requires_creation_key(
+    db_session: AsyncSession,
+):
+    from app.services.trade_journal.retrospective_action_repository import (
+        ActionReconcileError,
+        RetrospectiveActionRepository,
+    )
+
+    await _set_canonical_mode(db_session)
+    await _insert_retrospective(db_session, retro_id=3011, next_actions=None)
+
+    with pytest.raises(ActionReconcileError, match="creation_key.*required"):
+        await RetrospectiveActionRepository(db_session).reconcile_actions(
+            3011,
+            [{"action": "intentional duplicate", "force_new": True}],
+            actor="user:1",
+        )
+
+
+@pytest.mark.asyncio
+async def test_canonical_save_rejects_duplicate_creation_key_in_one_request(
+    db_session: AsyncSession,
+):
+    from app.services.trade_journal.retrospective_action_repository import (
+        ActionReconcileError,
+        RetrospectiveActionRepository,
+    )
+
+    await _set_canonical_mode(db_session)
+    await _insert_retrospective(db_session, retro_id=3012, next_actions=None)
+    creation_key = uuid.uuid4()
+
+    with pytest.raises(ActionReconcileError, match="duplicate creation_key"):
+        await RetrospectiveActionRepository(db_session).reconcile_actions(
+            3012,
+            [
+                {
+                    "action": "intentional duplicate",
+                    "force_new": True,
+                    "creation_key": str(creation_key),
+                },
+                {
+                    "action": "intentional duplicate",
+                    "force_new": True,
+                    "creation_key": str(creation_key),
+                },
+            ],
+            actor="user:1",
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("changed_field", "changed_value"),
+    [
+        ("action", "amended action"),
+        ("owner", "bob"),
+        ("issue_id", "ROB-999"),
+        ("due_kst_date", "2026-07-31"),
+    ],
+)
+async def test_canonical_save_action_id_tuple_is_immutable(
+    db_session: AsyncSession,
+    changed_field: str,
+    changed_value: str,
+):
+    from app.services.trade_journal.retrospective_action_repository import (
+        ActionReconcileError,
+        RetrospectiveActionRepository,
+    )
+
+    await _set_canonical_mode(db_session)
+    await _insert_retrospective(db_session, retro_id=3013, next_actions=None)
+    repo = RetrospectiveActionRepository(db_session)
+    original = {
+        "action": "original action",
+        "owner": "alice",
+        "issue_id": "ROB-878",
+        "due_kst_date": "2026-07-20",
+    }
+    await repo.reconcile_actions(3013, [original], actor="user:1")
+    action_id = (await repo.read_actions(3013))[0]["action_id"]
+    amended = {**original, "action_id": action_id, changed_field: changed_value}
+
+    with pytest.raises(ActionReconcileError, match="immutable.*transition API"):
+        await repo.reconcile_actions(3013, [amended], actor="user:1")
+
+
+@pytest.mark.asyncio
+async def test_canonical_save_occurrence_matching_uses_display_order(
+    db_session: AsyncSession,
+):
+    from app.services.trade_journal.retrospective_action_repository import (
+        RetrospectiveActionRepository,
+    )
+
+    await _set_canonical_mode(db_session)
+    await _insert_retrospective(db_session, retro_id=3014, next_actions=None)
+    first_display_id = uuid.UUID("00000000-0000-0000-0000-000000000002")
+    second_display_id = uuid.UUID("00000000-0000-0000-0000-000000000001")
+    await _insert_canonical_action(
+        db_session,
+        retrospective_id=3014,
+        position=0,
+        action="same tuple",
+        action_id=first_display_id,
+    )
+    await _insert_canonical_action(
+        db_session,
+        retrospective_id=3014,
+        position=1,
+        action="same tuple",
+        action_id=second_display_id,
+    )
+
+    repo = RetrospectiveActionRepository(db_session)
+    await repo.reconcile_actions(
+        3014,
+        [{"action": "same tuple"}],
+        actor="user:1",
+    )
+
+    actions = await repo.read_actions(3014)
+    assert [item["action_id"] for item in actions] == [
+        str(first_display_id),
+        str(second_display_id),
+    ]
 
 
 @pytest.mark.asyncio
@@ -938,9 +1780,65 @@ async def test_canonical_save_actor_from_identity(db_session: AsyncSession):
     assert row.status_source == "retrospective_save"
 
 
+@pytest.mark.asyncio
+async def test_mcp_save_derives_actor_from_server_profile(
+    db_session: AsyncSession,
+    monkeypatch,
+):
+    """MCP action provenance comes from server configuration, not payload labels."""
+    from app.mcp_server.tooling.trade_retrospective_tools import (
+        save_trade_retrospective,
+    )
+
+    await _set_canonical_mode(db_session)
+    monkeypatch.setenv("MCP_PROFILE", "tradingcodex_execution")
+
+    result = await save_trade_retrospective(
+        symbol="005930",
+        instrument_type="equity_kr",
+        account_mode="kis_mock",
+        outcome="filled",
+        correlation_id="mcp-actor-profile",
+        created_by_profile="caller-controlled-label",
+        trigger_type="fill",
+        next_actions=[{"action": "actor profile action"}],
+    )
+    assert result["success"] is True
+
+    actor = (
+        await db_session.execute(
+            text(
+                "SELECT a.status_actor "
+                "FROM review.trade_retrospective_actions a "
+                "JOIN review.trade_retrospectives r ON r.id = a.retrospective_id "
+                "WHERE r.correlation_id = 'mcp-actor-profile'"
+            )
+        )
+    ).scalar_one()
+    assert actor == "mcp:tradingcodex_execution"
+
+
 # ---------------------------------------------------------------------------
 # Section 4: Canonical GET
 # ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_canonical_get_is_unavailable_in_shadow_mode(db_session: AsyncSession):
+    """The canonical endpoint never publishes provisional shadow child IDs."""
+    from app.services.trade_journal import trade_retrospective_service as svc
+    from app.services.trade_journal.retrospective_action_repository import (
+        ActionControlError,
+    )
+
+    await _insert_retrospective(
+        db_session,
+        retro_id=4000,
+        next_actions=[{"action": "provisional"}],
+    )
+
+    with pytest.raises(ActionControlError, match="canonical.*shadow"):
+        await svc.get_canonical_actions(db_session)
 
 
 @pytest.mark.asyncio
@@ -1082,6 +1980,203 @@ async def test_canonical_get_pagination_consistency(db_session: AsyncSession):
     assert page3["count"] == 1  # last page has 1 item
 
 
+@pytest.mark.asyncio
+async def test_canonical_get_applies_outcome_and_kst_parent_filters(
+    db_session: AsyncSession,
+):
+    from app.services.trade_journal.retrospective_action_repository import (
+        RetrospectiveActionRepository,
+    )
+
+    await _set_canonical_mode(db_session)
+    parents = [
+        (4010, Decimal("100"), datetime(2026, 7, 14, 3, tzinfo=UTC), "match"),
+        (4011, Decimal("-10"), datetime(2026, 7, 14, 4, tzinfo=UTC), "loss"),
+        (4012, Decimal("50"), datetime(2026, 7, 13, 3, tzinfo=UTC), "old"),
+    ]
+    repo = RetrospectiveActionRepository(db_session)
+    for retro_id, pnl, created_at, label in parents:
+        await _insert_retrospective(
+            db_session,
+            retro_id=retro_id,
+            next_actions=None,
+            realized_pnl=pnl,
+        )
+        await db_session.execute(
+            text(
+                "UPDATE review.trade_retrospectives SET created_at = :created_at "
+                "WHERE id = :retro_id"
+            ),
+            {"created_at": created_at, "retro_id": retro_id},
+        )
+        await db_session.commit()
+        await repo.reconcile_actions(
+            retro_id,
+            [{"action": label}],
+            actor="user:1",
+        )
+
+    result = await repo.query_actions(
+        outcome_filter="win",
+        kst_date_from="2026-07-14",
+        kst_date_to="2026-07-14",
+    )
+
+    assert [item["action"] for item in result["items"]] == ["match"]
+
+
+@pytest.mark.asyncio
+async def test_canonical_get_due_before_is_strict(db_session: AsyncSession):
+    from app.services.trade_journal.retrospective_action_repository import (
+        RetrospectiveActionRepository,
+    )
+
+    await _set_canonical_mode(db_session)
+    await _insert_retrospective(db_session, retro_id=4013, next_actions=None)
+    repo = RetrospectiveActionRepository(db_session)
+    await repo.reconcile_actions(
+        4013,
+        [
+            {"action": "before", "due_kst_date": "2026-07-20"},
+            {"action": "boundary", "due_kst_date": "2026-07-21"},
+        ],
+        actor="user:1",
+    )
+
+    result = await repo.query_actions(due_before="2026-07-21")
+
+    assert [item["action"] for item in result["items"]] == ["before"]
+
+
+@pytest.mark.asyncio
+async def test_canonical_get_empty_page_keeps_total_with_one_statement(
+    db_session: AsyncSession,
+):
+    from app.services.trade_journal.retrospective_action_repository import (
+        RetrospectiveActionRepository,
+    )
+
+    await _set_canonical_mode(db_session)
+    await _insert_retrospective(db_session, retro_id=4014, next_actions=None)
+    repo = RetrospectiveActionRepository(db_session)
+    await repo.reconcile_actions(4014, [{"action": "only"}], actor="user:1")
+
+    statements: list[str] = []
+
+    def _capture(_conn, _cursor, statement, _params, _context, _many):
+        if "trade_retrospective_actions" in statement:
+            statements.append(statement)
+
+    event.listen(engine.sync_engine, "before_cursor_execute", _capture)
+    try:
+        result = await repo.query_actions(limit=10, offset=99)
+    finally:
+        event.remove(engine.sync_engine, "before_cursor_execute", _capture)
+
+    assert result["total"] == 1
+    assert result["count"] == 0
+    assert result["items"] == []
+    assert len(statements) == 1
+
+
+@pytest.mark.asyncio
+async def test_canonical_get_exposes_status_reason(db_session: AsyncSession):
+    from app.services.trade_journal.retrospective_action_repository import (
+        RetrospectiveActionRepository,
+    )
+
+    await _set_canonical_mode(db_session)
+    await _insert_retrospective(db_session, retro_id=4015, next_actions=None)
+    repo = RetrospectiveActionRepository(db_session)
+    await repo.reconcile_actions(4015, [{"action": "reasoned"}], actor="user:1")
+    await db_session.execute(
+        text(
+            "UPDATE review.trade_retrospective_actions "
+            "SET status_reason = 'operator note' WHERE retrospective_id = 4015"
+        )
+    )
+    await db_session.commit()
+
+    result = await repo.query_actions()
+
+    assert result["items"][0]["status_reason"] == "operator note"
+
+
+def test_actions_route_rejects_unknown_and_empty_status():
+    from fastapi import HTTPException
+
+    from app.routers.invest_retrospectives import _parse_action_statuses
+
+    assert _parse_action_statuses(None) is None
+    assert _parse_action_statuses("open,in_progress") == frozenset(
+        {"open", "in_progress"}
+    )
+    for value in ("", ",", "open,unknown"):
+        with pytest.raises(HTTPException) as exc_info:
+            _parse_action_statuses(value)
+        assert exc_info.value.status_code == 422
+
+
+def test_route_rejects_non_canonical_kst_date_padding():
+    from fastapi import HTTPException
+
+    from app.routers.invest_retrospectives import _parse_kst_date
+
+    assert _parse_kst_date("due_before", "2026-07-01") == "2026-07-01"
+    with pytest.raises(HTTPException) as exc_info:
+        _parse_kst_date("due_before", "2026-7-1")
+    assert exc_info.value.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_actions_route_forwards_due_before(monkeypatch):
+    from app.routers.invest_retrospectives import list_canonical_actions
+    from app.services.trade_journal import trade_retrospective_service as svc
+
+    captured: dict[str, Any] = {}
+
+    async def _fake_get(_db, **kwargs):
+        captured.update(kwargs)
+        return {
+            "total": 0,
+            "count": 0,
+            "limit": kwargs["limit"],
+            "offset": kwargs["offset"],
+            "as_of": datetime.now(UTC),
+            "items": [],
+        }
+
+    monkeypatch.setattr(svc, "get_canonical_actions", _fake_get)
+
+    await list_canonical_actions(
+        object(),
+        object(),
+        due_before="2026-07-21",
+    )
+
+    assert captured["due_before"] == "2026-07-21"
+
+
+@pytest.mark.asyncio
+async def test_actions_route_maps_control_failure_to_503(monkeypatch):
+    from fastapi import HTTPException
+
+    from app.routers.invest_retrospectives import list_canonical_actions
+    from app.services.trade_journal import trade_retrospective_service as svc
+    from app.services.trade_journal.retrospective_action_repository import (
+        ActionControlError,
+    )
+
+    async def _fail(_db, **_kwargs):
+        raise ActionControlError("control unavailable")
+
+    monkeypatch.setattr(svc, "get_canonical_actions", _fail)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await list_canonical_actions(object(), object())
+    assert exc_info.value.status_code == 503
+
+
 # ---------------------------------------------------------------------------
 # Section 5: Legacy /next-actions alias compatibility
 # ---------------------------------------------------------------------------
@@ -1134,6 +2229,131 @@ async def test_next_actions_alias_additive_action_id_version(db_session: AsyncSe
     assert item["version"] == 1
 
 
+def test_next_actions_alias_translates_legacy_status_vocabulary():
+    from fastapi import HTTPException
+
+    from app.routers.invest_retrospectives import _parse_legacy_action_statuses
+
+    assert _parse_legacy_action_statuses(None) is None
+    assert _parse_legacy_action_statuses("open,in_progress") == frozenset(
+        {"open", "in_progress"}
+    )
+    assert _parse_legacy_action_statuses("done") == frozenset(
+        {"done", "obsolete", "expired"}
+    )
+    for value in ("", ",", "obsolete", "unknown"):
+        with pytest.raises(HTTPException) as exc_info:
+            _parse_legacy_action_statuses(value)
+        assert exc_info.value.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_next_actions_alias_projects_canonical_terminal_statuses(
+    db_session: AsyncSession,
+):
+    from app.services.trade_journal import trade_retrospective_service as svc
+    from app.services.trade_journal.retrospective_action_repository import (
+        RetrospectiveActionRepository,
+    )
+
+    await _set_canonical_mode(db_session)
+    await _insert_retrospective(db_session, retro_id=5005, next_actions=None)
+    repo = RetrospectiveActionRepository(db_session)
+    await repo.reconcile_actions(
+        5005,
+        [{"action": "historical done"}, {"action": "superseded"}],
+        actor="user:1",
+    )
+    await db_session.execute(
+        text(
+            "UPDATE review.trade_retrospective_actions "
+            "SET status = CASE action WHEN 'historical done' THEN 'done' "
+            "ELSE 'obsolete' END, resolved_at = now(), "
+            "status_reason = CASE action WHEN 'superseded' THEN 'replaced' "
+            "ELSE NULL END WHERE retrospective_id = 5005"
+        )
+    )
+    await db_session.commit()
+
+    result = await svc.get_open_next_actions(db_session, statuses=frozenset({"done"}))
+
+    assert {item["action"] for item in result["items"]} == {
+        "historical done",
+        "superseded",
+    }
+    projected = next(item for item in result["items"] if item["action"] == "superseded")
+    assert projected["status"] == "done"
+    assert projected["terminal_status"] == "obsolete"
+
+
+@pytest.mark.asyncio
+async def test_next_actions_alias_returns_all_canonical_matches(
+    db_session: AsyncSession,
+):
+    from app.services.trade_journal import trade_retrospective_service as svc
+    from app.services.trade_journal.retrospective_action_repository import (
+        RetrospectiveActionRepository,
+    )
+
+    await _set_canonical_mode(db_session)
+    await _insert_retrospective(db_session, retro_id=5003, next_actions=None)
+    await RetrospectiveActionRepository(db_session).reconcile_actions(
+        5003,
+        [{"action": f"action {i}"} for i in range(205)],
+        actor="user:1",
+    )
+
+    result = await svc.get_open_next_actions(db_session)
+
+    assert result["count"] == 205
+    assert result["scan_limit"] == 0
+
+
+@pytest.mark.asyncio
+async def test_full_retrospective_hydrates_canonical_child_status(
+    db_session: AsyncSession,
+):
+    from app.services.trade_journal import trade_retrospective_service as svc
+    from app.services.trade_journal.retrospective_action_repository import (
+        RetrospectiveActionRepository,
+    )
+
+    await _set_canonical_mode(db_session)
+    await _insert_retrospective(db_session, retro_id=5004, next_actions=None)
+    repo = RetrospectiveActionRepository(db_session)
+    await repo.reconcile_actions(
+        5004,
+        [{"action": "obsolete me", "custom_context": {"ticket": "ROB-880"}}],
+        actor="user:1",
+    )
+    await db_session.execute(
+        text(
+            "UPDATE review.trade_retrospective_actions "
+            "SET status = 'obsolete', resolved_at = now(), version = 2, "
+            "status_reason = 'superseded', status_actor = 'user:1', "
+            "status_source = 'web' WHERE retrospective_id = 5004"
+        )
+    )
+    await db_session.commit()
+    await repo.reconcile_actions(5004, [{"action": "obsolete me"}], actor="user:1")
+
+    result = await svc.get_retrospectives(db_session)
+    item = next(entry for entry in result["entries"] if entry["id"] == 5004)
+
+    assert item["next_actions"][0]["status"] == "obsolete"
+    assert item["next_actions"][0]["status_reason"] == "superseded"
+    assert item["next_actions"][0]["custom_context"] == {"ticket": "ROB-880"}
+    assert isinstance(item["next_actions"][0]["action_id"], str)
+
+    # A caller can submit the fetched payload unchanged: audit fields are accepted
+    # as read-only transport data, then stripped before repository reconciliation.
+    coerced = svc._coerce_next_actions(item["next_actions"])
+    assert coerced[0]["custom_context"] == {"ticket": "ROB-880"}
+    assert "status_changed_at" not in coerced[0]
+    await repo.reconcile_actions(5004, coerced, actor="user:1")
+    assert len(await repo.read_actions(5004)) == 1
+
+
 # ---------------------------------------------------------------------------
 # Section 6: Deploy script post-switch cutover step
 # ---------------------------------------------------------------------------
@@ -1150,9 +2370,9 @@ def test_deploy_native_script_has_cutover_after_bluegreen_committed():
     bg_idx = content.find("BLUEGREEN_COMMITTED=1")
     assert bg_idx != -1, "BLUEGREEN_COMMITTED=1 not found in deploy-native.sh"
 
-    cutover_idx = content.find("retrospective_action_cutover")
+    cutover_idx = content.rfind("run_retrospective_action_cutover")
     assert cutover_idx != -1, (
-        "retrospective_action_cutover not found in deploy-native.sh"
+        "run_retrospective_action_cutover not found in deploy-native.sh"
     )
 
     assert bg_idx < cutover_idx, (
@@ -1170,6 +2390,75 @@ def test_deploy_native_script_cutover_uses_if_shadow():
     assert "--if-shadow" in content, (
         "deploy-native.sh must use --if-shadow for idempotent cutover"
     )
+
+
+def test_deploy_native_script_cutover_uses_shared_env_file():
+    """The standalone cutover command loads the same production env as migrations."""
+    script_path = (
+        Path(__file__).resolve().parent.parent / "scripts" / "deploy-native.sh"
+    )
+    content = script_path.read_text()
+
+    assert (
+        'ENV_FILE="$SHARED_ENV" uv run python '
+        "scripts/retrospective_action_cutover.py --if-shadow"
+    ) in content
+
+
+def test_deploy_native_rollback_warns_after_cutover_attempt():
+    script_path = (
+        Path(__file__).resolve().parent.parent / "scripts" / "deploy-native.sh"
+    )
+    content = script_path.read_text()
+
+    assert "RETROSPECTIVE_ACTION_CUTOVER_ATTEMPTED=0" in content
+    assert "RETROSPECTIVE_ACTION_CUTOVER_ATTEMPTED=1" in content
+    assert "database may already be canonical" in content.lower()
+    assert "do not schema-downgrade" in content.lower()
+    assert "RETROSPECTIVE_ACTION_SAFE_PRECOMMIT_EXIT=10" in content
+    assert "RETROSPECTIVE_ACTION_CUTOVER_ATTEMPTED=0" in content
+
+
+@pytest.mark.asyncio
+async def test_cutover_cli_health_exception_is_fatal(monkeypatch):
+    """A committed cutover is not reported successful when health cannot run."""
+    from scripts import retrospective_action_cutover as cli
+
+    async def _fake_run(_if_shadow: bool):
+        return {
+            "mode": "canonical",
+            "action_count": 1,
+            "cutover_at": datetime.now(UTC),
+            "idempotent": False,
+        }
+
+    class _ConnectionContext:
+        async def __aenter__(self):
+            raise RuntimeError("health connection failed")
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    class _Engine:
+        def connect(self):
+            return _ConnectionContext()
+
+    monkeypatch.setattr(cli, "_run", _fake_run)
+    monkeypatch.setattr(cli, "engine", _Engine())
+
+    assert await cli._async_main(if_shadow=True) == cli.EXIT_COMMITTED_OR_UNKNOWN
+
+
+@pytest.mark.asyncio
+async def test_cutover_cli_safe_precommit_failure_has_distinct_exit(monkeypatch):
+    from scripts import retrospective_action_cutover as cli
+
+    async def _fail(_if_shadow: bool):
+        raise cli.CutoverParityError("field mismatch")
+
+    monkeypatch.setattr(cli, "_run", _fail)
+
+    assert await cli._async_main(if_shadow=True) == cli.EXIT_SAFE_PRECOMMIT
 
 
 def test_deploy_native_script_cutover_conditional_on_committed():
@@ -1276,6 +2565,65 @@ async def test_canonical_mode_save_uses_repository(db_session: AsyncSession):
     assert "action_id" in parent_na[0]
 
 
+@pytest.mark.asyncio
+async def test_canonical_action_retry_preserves_omitted_parent_fields(
+    db_session: AsyncSession,
+):
+    """An action retry updates only fields that were present in the request."""
+    from app.services.trade_journal import trade_retrospective_service as svc
+
+    await _set_canonical_mode(db_session)
+    _, retro = await svc.save_retrospective(
+        db_session,
+        symbol="005930",
+        instrument_type="equity_kr",
+        account_mode="kis_mock",
+        outcome="filled",
+        correlation_id="canonical-presence-test",
+        market="kr",
+        strategy_key="presence-strategy",
+        rationale="keep rationale",
+        lesson="keep lesson",
+        trigger_type="fill",
+        next_actions=[{"action": "presence action", "status": "open"}],
+    )
+    await db_session.refresh(retro)
+    action_id = retro.next_actions[0]["action_id"]
+
+    _, updated = await svc.save_retrospective(
+        db_session,
+        symbol="005930",
+        instrument_type="equity_kr",
+        account_mode="kis_mock",
+        outcome="filled",
+        correlation_id="canonical-presence-test",
+        next_actions=[
+            {
+                "action_id": action_id,
+                "version": 1,
+                "action": "presence action",
+            }
+        ],
+    )
+
+    assert updated.id == retro.id
+    assert updated.market == "kr"
+    assert updated.strategy_key == "presence-strategy"
+    assert updated.rationale == "keep rationale"
+    assert updated.lesson == "keep lesson"
+
+    _, cleared = await svc.save_retrospective(
+        db_session,
+        symbol="005930",
+        instrument_type="equity_kr",
+        account_mode="kis_mock",
+        outcome="filled",
+        correlation_id="canonical-presence-test",
+        lesson=None,
+    )
+    assert cleared.lesson is None
+
+
 # ---------------------------------------------------------------------------
 # Section 8: Runbook / operational contract tests
 # ---------------------------------------------------------------------------
@@ -1293,11 +2641,13 @@ def test_runbook_exists_for_canonical_cutover():
     )
     if not script_path.exists():
         pytest.skip("Cutover script not yet created")
-    content = script_path.read_text()
-    # The script must document the rollback/roll-forward procedure
-    assert "roll-forward" in content.lower() or "rollback" in content.lower(), (
-        "Cutover script must document rollback/roll-forward procedure"
-    )
+    from scripts import retrospective_action_cutover as cli
+
+    help_text = cli._build_parser().format_help().lower()
+    assert "exit 10" in help_text
+    assert "safe rollback" in help_text
+    assert "exit 20" in help_text
+    assert "roll-forward" in help_text
 
 
 @pytest.mark.asyncio

--- a/tests/test_rob878_shadow_ledger_migration.py
+++ b/tests/test_rob878_shadow_ledger_migration.py
@@ -23,6 +23,8 @@ from sqlalchemy.exc import IntegrityError
 from app.core.db import engine
 from app.models.base import Base
 
+pytestmark = pytest.mark.usefixtures("retrospective_action_control_lock")
+
 _MIGRATION_PATH = (
     Path(__file__).resolve().parent.parent
     / "alembic"

--- a/tests/test_rob878_shadow_ledger_model.py
+++ b/tests/test_rob878_shadow_ledger_model.py
@@ -7,6 +7,8 @@ test DB with the correct columns, constraints, indexes, and control row.
 import pytest
 from sqlalchemy import text
 
+pytestmark = pytest.mark.usefixtures("retrospective_action_control_lock")
+
 
 def test_trade_retrospective_action_table_registered_on_metadata():
     """Both new tables must be registered on Base.metadata for create_all."""

--- a/tests/test_trade_retrospective_schema.py
+++ b/tests/test_trade_retrospective_schema.py
@@ -87,6 +87,9 @@ def test_next_action_status_constrained():
     assert m.issue_id == "ROB-999"
 
 
-def test_next_action_rejects_unknown_key():
-    with pytest.raises(ValidationError):
-        NextAction.model_validate({"action": "do", "bogus": True})
+def test_next_action_preserves_legacy_extension_key():
+    model = NextAction.model_validate(
+        {"action": "do", "legacy_context": {"source": "pre-cutover"}}
+    )
+
+    assert model.model_dump()["legacy_context"] == {"source": "pre-cutover"}

--- a/tests/test_trade_retrospective_service.py
+++ b/tests/test_trade_retrospective_service.py
@@ -3,14 +3,17 @@
 
 from __future__ import annotations
 
+import asyncio
+import uuid
 from datetime import UTC, datetime
 from decimal import Decimal
 
 import pytest
 import pytest_asyncio
-from sqlalchemy import delete, select
+from sqlalchemy import delete, func, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.db import AsyncSessionLocal, engine
 from app.models.review import TradeRetrospective
 from app.models.trade_journal import TradeJournal
 from app.services.trade_journal import trade_retrospective_service as svc
@@ -50,6 +53,70 @@ async def _mock_journal(db, *, cid="j1"):
     await db.commit()
     await db.refresh(j)
     return j
+
+
+@pytest.mark.asyncio
+async def test_concurrent_first_upsert_recovers_inside_savepoint():
+    cid = f"race-{uuid.uuid4()}"
+    base_payload = {
+        "symbol": "005930",
+        "instrument_type": "equity_kr",
+        "account_mode": "kis_mock",
+        "market": "kr",
+        "outcome": "filled",
+        "correlation_id": cid,
+    }
+
+    async with AsyncSessionLocal() as first, AsyncSessionLocal() as second:
+        first_pid = (await first.execute(text("SELECT pg_backend_pid()"))).scalar_one()
+        second_pid = (
+            await second.execute(text("SELECT pg_backend_pid()"))
+        ).scalar_one()
+
+        first_result, _ = await svc.TradeRetrospectiveRepository(first).upsert(
+            {**base_payload, "lesson": "first writer"}
+        )
+        assert first_result == "created"
+
+        second_task = asyncio.create_task(
+            svc.TradeRetrospectiveRepository(second).upsert(
+                {**base_payload, "lesson": "second writer"}
+            )
+        )
+        try:
+            async with engine.connect() as observer:
+                for _ in range(200):
+                    blockers = (
+                        await observer.execute(
+                            text("SELECT pg_blocking_pids(:pid)"),
+                            {"pid": second_pid},
+                        )
+                    ).scalar_one()
+                    if first_pid in blockers:
+                        break
+                    await asyncio.sleep(0.01)
+                else:
+                    pytest.fail("second upsert never blocked on the first insert")
+
+            await first.commit()
+            second_result, row = await asyncio.wait_for(second_task, timeout=5)
+            assert second_result == "updated"
+            assert row.lesson == "second writer"
+
+            # Prove the outer transaction remains usable after race recovery.
+            count = (
+                await second.execute(
+                    select(func.count())
+                    .select_from(TradeRetrospective)
+                    .where(TradeRetrospective.correlation_id == cid)
+                )
+            ).scalar_one()
+            assert count == 1
+            await second.commit()
+        finally:
+            if not second_task.done():
+                second_task.cancel()
+                await asyncio.gather(second_task, return_exceptions=True)
 
 
 @pytest.mark.asyncio
@@ -391,6 +458,48 @@ async def test_retrospective_derives_fx_fields_from_journal(
     assert row.total_pnl_krw == Decimal("112963.4000")
     assert row.fx_rate_source == "reconcile_spot"
     assert row.fx_pnl_accuracy == "approximate"
+
+
+@pytest.mark.asyncio
+async def test_update_with_journal_id_does_not_overwrite_omitted_manual_values(
+    db_session: AsyncSession,
+):
+    j = await _mock_journal(db_session, cid="journal-update-presence")
+    j.buy_fx_rate = Decimal("1389.3300")
+    j.fx_rate_source = "reconcile_spot"
+    await db_session.commit()
+
+    _, first = await svc.save_retrospective(
+        db_session,
+        symbol="005930",
+        instrument_type="equity_kr",
+        account_mode="kis_mock",
+        outcome="filled",
+        correlation_id="journal-update-presence",
+        journal_id=j.id,
+        realized_pnl=Decimal("777.0000"),
+        realized_pnl_currency="KRW",
+        buy_fx_rate=Decimal("999.0000"),
+        fx_rate_source="manual",
+    )
+    await db_session.commit()
+    assert first.realized_pnl == Decimal("777.0000")
+
+    _, updated = await svc.save_retrospective(
+        db_session,
+        symbol="005930",
+        instrument_type="equity_kr",
+        account_mode="kis_mock",
+        outcome="filled",
+        correlation_id="journal-update-presence",
+        journal_id=j.id,
+    )
+    await db_session.commit()
+
+    assert updated.realized_pnl == Decimal("777.0000")
+    assert updated.realized_pnl_source == "caller_supplied"
+    assert updated.buy_fx_rate == Decimal("999.0000")
+    assert updated.fx_rate_source == "manual"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_trade_retrospective_tools.py
+++ b/tests/test_trade_retrospective_tools.py
@@ -50,6 +50,74 @@ async def test_save_success_envelope():
 
 
 @pytest.mark.asyncio
+async def test_mcp_retry_omits_unsupplied_optional_fields():
+    first = await save_trade_retrospective(
+        symbol="005930",
+        instrument_type="equity_kr",
+        account_mode="kis_mock",
+        outcome="filled",
+        correlation_id="mcp-presence-retry",
+        market="kr",
+        lesson="preserve through MCP",
+    )
+    assert first["success"] is True
+
+    second = await save_trade_retrospective(
+        symbol="005930",
+        instrument_type="equity_kr",
+        account_mode="kis_mock",
+        outcome="filled",
+        correlation_id="mcp-presence-retry",
+    )
+
+    assert second["success"] is True
+    assert second["data"]["market"] == "kr"
+    assert second["data"]["lesson"] == "preserve through MCP"
+
+
+@pytest.mark.asyncio
+async def test_mcp_retry_preserves_explicit_null_for_nullable_clear():
+    from app.mcp_server.caller_identity import caller_argument_names_var
+
+    first = await save_trade_retrospective(
+        symbol="005930",
+        instrument_type="equity_kr",
+        account_mode="kis_mock",
+        outcome="filled",
+        correlation_id="mcp-explicit-null",
+        lesson="clear through MCP",
+    )
+    assert first["success"] is True
+
+    token = caller_argument_names_var.set(
+        frozenset(
+            {
+                "symbol",
+                "instrument_type",
+                "account_mode",
+                "outcome",
+                "correlation_id",
+                "lesson",
+            }
+        )
+    )
+    try:
+        second = await save_trade_retrospective(
+            symbol="005930",
+            instrument_type="equity_kr",
+            account_mode="kis_mock",
+            outcome="filled",
+            correlation_id="mcp-explicit-null",
+            lesson=None,
+        )
+    finally:
+        caller_argument_names_var.reset(token)
+
+    assert second["success"] is True
+    assert second["data"]["lesson"] is None
+
+
+@pytest.mark.asyncio
 async def test_save_validation_error_enumerates_outcomes():
     res = await save_trade_retrospective(
         symbol="005930",

--- a/tests/test_trade_retrospective_tools.py
+++ b/tests/test_trade_retrospective_tools.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import pytest
 import pytest_asyncio
-from sqlalchemy import delete
+from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.timezone import now_kst
@@ -47,6 +47,47 @@ async def test_save_success_envelope():
     assert res["success"] is True
     assert res["action"] == "created"
     assert res["data"]["strategy_key"] == "A"
+
+
+@pytest.mark.asyncio
+async def test_save_hydration_failure_rolls_back(
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """A failed response hydration must not leave a committed save behind."""
+    from app.services.trade_journal.retrospective_action_repository import (
+        RetrospectiveActionRepository,
+    )
+
+    correlation_id = "mcp-hydration-rollback"
+
+    async def _fail_hydration(*_args, **_kwargs):
+        raise RuntimeError("hydrate failed")
+
+    monkeypatch.setattr(
+        RetrospectiveActionRepository,
+        "read_actions",
+        _fail_hydration,
+    )
+
+    res = await save_trade_retrospective(
+        symbol="005930",
+        instrument_type="equity_kr",
+        account_mode="kis_mock",
+        outcome="filled",
+        correlation_id=correlation_id,
+    )
+
+    assert res["success"] is False
+    assert "hydrate failed" in res["error"]
+    persisted = (
+        await db_session.execute(
+            select(TradeRetrospective.id).where(
+                TradeRetrospective.correlation_id == correlation_id
+            )
+        )
+    ).scalar_one_or_none()
+    assert persisted is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## ROB-880: Canonical Cutover — Repository / Save Projection / Read API

Linear: [ROB-880](https://linear.app/mgh3326/issue/ROB-880)

### Summary

Shadow ledger를 안전하게 canonical store로 전환하고, 저장·조회·호환 projection을 DB control-mode repository 뒤로 통합한다.

### 주요 변경

- shadow/canonical repository, canonical projection writer, occurrence-aware reconciliation
- force_new + creation_key 멱등성 및 lost-response cutover 보존
- parent → control → actions lock 순서, bounded lock timeout, full parity 검증
- safe pre-commit exit 10과 committed/unknown exit 20 분리
- canonical GET pagination/filter/overdue ordering 및 legacy alias 호환
- full retrospective/MCP canonical hydration, legacy unknown-key 보존, JSON-safe identity
- MCP omitted vs explicit-null field-presence 보존
- post-cutover field/ordinal/terminal_status/creation_key health parity
- deploy-native post-switch cutover 및 상태별 rollback/roll-forward 안내

### 핵심 안전 계약

1. DB control row가 유일한 mode authority이며 missing/unknown 상태는 fail closed.
2. Cutover는 pg_try_advisory_xact_lock과 bounded table locks를 사용하고 parity 실패 시 shadow transaction 전체를 rollback.
3. canonical commit 이후 실패는 mutation-disable + roll-forward이며 schema downgrade를 금지.
4. 신규 action은 open/in_progress만 허용하고 lifecycle 변경은 save reconciliation에서 금지.
5. legacy parent projection은 unknown key와 display order를 보존하며 obsolete/expired를 done + terminal_status로 투영.

### 검증

| 검증 | 결과 |
|---|---|
| ROB-880 관련 9개 suite | 220 passed |
| Full suite, xdist | 16,110 passed, 9 skipped, 10 shared-DB contention failures |
| 위 10개 실패 순차 재실행 | 10 passed |
| make lint: Ruff + format + ty | passed |
| deploy-native bash syntax | passed |
| Alembic heads | single head: 20260714_rob878_shadow |
| 독립 post-fix review 3회 | actionable P0/P1/P2 없음 |

### 범위 제외

- transition API/MCP: ROB-881
- auto reconciler 및 decision_history 소비
- UI 변경
- legacy retirement 및 rollback window 종료

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added canonical next-action management with migration support and reliable synchronization.
  * Added a paginated actions endpoint with status, market, symbol, owner, outcome, date, and overdue filters.
  * Enhanced action results with identifiers, versions, terminal status, and overdue indicators.
  * Added idempotent action creation and retry guidance using stable action identity.
* **Bug Fixes**
  * Partial retrospective updates now preserve omitted fields while allowing explicit nulls to clear values.
  * Improved validation for dates, statuses, outcomes, and action creation rules.
* **Deployment**
  * Added guarded, parity-checked migration from legacy action storage to canonical storage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->