### PR TITLE
fix(ROB-888): surface self-describing premarket fields on NXT quote

### DIFF
--- a/app/mcp_server/tooling/analysis_tool_handlers.py
+++ b/app/mcp_server/tooling/analysis_tool_handlers.py
@@ -793,9 +793,15 @@ def _summarize_analysis_result(
 
     # ROB-725: surface NXT price provenance so the agent knows current_price is
     # an NXT-derived quote (not the stale KRX regular-session close).
+    # ROB-888: also carry the self-describing premarket fields (session_state /
+    # krx_prev_close / change_pct) so consumers judge the real gap from the MCP
+    # summary alone instead of scraping CDP naver's two-block premarket dump.
     for _px_key in (
         "price_source",
         "session",
+        "session_state",
+        "krx_prev_close",
+        "change_pct",
         "data_state",
         "data_state_reason",
         "venue",

--- a/app/mcp_server/tooling/market_data_quotes.py
+++ b/app/mcp_server/tooling/market_data_quotes.py
@@ -359,6 +359,42 @@ def _positive_price(value: float | int | None) -> float | None:
     return price if price > 0 else None
 
 
+# ROB-888: map the internal NXT session label to a consumer-facing session_state.
+_NXT_SESSION_STATE = {
+    "nxt_premarket": "premarket",
+    "nxt_after": "nxt_after",
+}
+
+
+def _annotate_nxt_session_change(
+    quote: dict[str, Any], *, session: str, krx_prev_close: float | None
+) -> None:
+    """ROB-888: stamp self-describing fields onto an NXT-overlaid quote.
+
+    Consumers (e.g. the operator premarket cross-check) can then judge the real
+    gap from the MCP quote alone instead of scraping CDP naver, whose premarket
+    dump conflates the KRX prior close with the NXT realtime block.
+
+    - ``session_state``: ``premarket`` | ``nxt_after`` (normalized from the NXT
+      session label).
+    - ``krx_prev_close``: the most recent completed KRX regular close — captured
+      as the quote's pre-overlay price (prior-day close in premarket, today's
+      regular close during nxt_after). ``None`` when unavailable.
+    - ``change_pct``: ``(nxt_price - krx_prev_close) / krx_prev_close * 100``,
+      rounded to 2dp. ``None`` (never a fake 0, never raise) when either side is
+      missing/non-positive — mirrors the ROB-448 previous_close convention.
+    """
+    quote["session_state"] = _NXT_SESSION_STATE.get(session, session)
+    quote["krx_prev_close"] = krx_prev_close
+    nxt_price = _positive_price(quote.get("price"))
+    if krx_prev_close is not None and nxt_price is not None:
+        quote["change_pct"] = round(
+            (nxt_price - krx_prev_close) / krx_prev_close * 100.0, 2
+        )
+    else:
+        quote["change_pct"] = None
+
+
 def _nxt_price_from_orderbook(
     snapshot: market_data_service.OrderbookSnapshot,
 ) -> tuple[float | None, str | None]:
@@ -426,12 +462,16 @@ async def _apply_nxt_quote_overlay(
     session = await _nxt_quote_session(data_state)
     if session is None:
         return False
+    # ROB-888: capture the pre-overlay price (the most recent completed KRX
+    # regular close) before ``quote.update`` overwrites it with the NXT price.
+    krx_prev_close = _positive_price(quote.get("price"))
     overlay = await _fetch_nxt_quote_overlay(symbol, session=session)
     if overlay is None:
         return False
     quote.update(overlay)
     quote["regular_session_data_state"] = data_state
     quote["data_state"] = DATA_STATE_FRESH
+    _annotate_nxt_session_change(quote, session=session, krx_prev_close=krx_prev_close)
     _annotate_kr_price_freshness(quote, now_kst())
     return True
 

--- a/tests/test_analyze_nxt_exposure.py
+++ b/tests/test_analyze_nxt_exposure.py
@@ -25,6 +25,31 @@ def test_summary_copies_nxt_fields_from_quote():
 
 
 @pytest.mark.unit
+def test_summary_copies_self_describing_premarket_fields_from_quote():
+    """ROB-888: the compact analyze_stock_batch summary must carry
+    krx_prev_close / change_pct / session_state so the operator can cross-check
+    the premarket gap from the MCP response alone (no CDP naver)."""
+    analysis = {
+        "market_type": "equity_kr",
+        "source": "kis",
+        "quote": {
+            "price": 2082500.0,
+            "price_source": "nxt_mid",
+            "session": "nxt_premarket",
+            "session_state": "premarket",
+            "krx_prev_close": 1913000.0,
+            "change_pct": 8.86,
+        },
+    }
+    summary = _summarize_analysis_result("000660", analysis)
+    assert summary["current_price"] == 2082500.0
+    assert summary["price_source"] == "nxt_mid"
+    assert summary["session_state"] == "premarket"
+    assert summary["krx_prev_close"] == 1913000.0
+    assert summary["change_pct"] == 8.86
+
+
+@pytest.mark.unit
 def test_summary_us_has_no_nxt_fields():
     analysis = {
         "market_type": "equity_us",

--- a/tests/test_analyze_stock_kr_live_price.py
+++ b/tests/test_analyze_stock_kr_live_price.py
@@ -140,6 +140,59 @@ async def test_kr_quote_overlays_nxt_price_in_premarket(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_kr_quote_surfaces_self_describing_fields_end_to_end(monkeypatch):
+    """ROB-888: through the analyze path with the REAL overlay, the SK하이닉스
+    premarket case surfaces krx_prev_close / change_pct / session_state so the
+    operator can cross-check the gap from the MCP quote without CDP naver."""
+    from app.mcp_server.tooling import market_data_quotes
+
+    async def fake_live(symbol):
+        return {
+            "symbol": symbol,
+            "instrument_type": "equity_kr",
+            "price": 1913000.0,  # KRX prior close (premarket "개장전" block)
+            "source": "kis",
+            "price_as_of": (datetime.now(KST) - timedelta(days=1)).isoformat(),
+        }
+
+    async def fake_session(data_state, *, now=None):
+        return "nxt_premarket"
+
+    async def fake_inner_overlay(symbol, *, session):
+        return {
+            "price": 2082500.0,  # NXT premarket realtime (nxt_mid)
+            "session": session,
+            "venue": "nxt",
+            "price_source": "nxt_mid",
+        }
+
+    monkeypatch.setattr(analysis_analyze, "_fetch_kr_live_quote", fake_live)
+    # Restore the REAL overlay (autouse fixture noop'd it) and mock its internals.
+    monkeypatch.setattr(
+        analysis_analyze,
+        "_apply_nxt_quote_overlay",
+        market_data_quotes._apply_nxt_quote_overlay,
+    )
+    monkeypatch.setattr(market_data_quotes, "_nxt_quote_session", fake_session)
+    monkeypatch.setattr(
+        market_data_quotes, "_fetch_nxt_quote_overlay", fake_inner_overlay
+    )
+    monkeypatch.setattr(
+        analysis_analyze,
+        "kr_market_data_state",
+        lambda *a, **k: "premarket_unavailable",
+    )
+
+    quote = await analysis_analyze._resolve_kr_quote("000660", _ohlcv())
+
+    assert quote["price"] == 2082500.0
+    assert quote["price_source"] == "nxt_mid"
+    assert quote["session_state"] == "premarket"
+    assert quote["krx_prev_close"] == 1913000.0
+    assert quote["change_pct"] == pytest.approx(8.86, abs=0.01)
+
+
+@pytest.mark.asyncio
 async def test_kr_quote_keeps_kis_price_when_no_overlay(monkeypatch):
     today = datetime.now(KST)
 

--- a/tests/test_mcp_quotes_tools.py
+++ b/tests/test_mcp_quotes_tools.py
@@ -451,6 +451,103 @@ async def test_apply_nxt_quote_overlay_applies_in_premarket(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_apply_nxt_quote_overlay_surfaces_self_describing_fields(monkeypatch):
+    """ROB-888: premarket overlay exposes krx_prev_close / change_pct /
+    session_state so consumers judge the real gap without scraping CDP naver."""
+    from app.mcp_server.tooling import market_data_quotes
+
+    async def fake_session(data_state, *, now=None):
+        return "nxt_premarket"
+
+    async def fake_overlay(symbol, *, session):
+        return {
+            "price": 2082500.0,  # NXT premarket realtime
+            "session": session,
+            "venue": "nxt",
+            "price_source": "nxt_mid",
+        }
+
+    monkeypatch.setattr(market_data_quotes, "_nxt_quote_session", fake_session)
+    monkeypatch.setattr(market_data_quotes, "_fetch_nxt_quote_overlay", fake_overlay)
+
+    # Pre-overlay price is the most recent completed KRX regular close (prev day).
+    quote = {"symbol": "000660", "price": 1913000.0, "source": "kis"}
+    applied = await market_data_quotes._apply_nxt_quote_overlay(
+        "000660", quote, data_state="premarket_unavailable"
+    )
+
+    assert applied is True
+    assert quote["price"] == 2082500.0
+    assert quote["price_source"] == "nxt_mid"
+    assert quote["session_state"] == "premarket"
+    assert quote["krx_prev_close"] == 1913000.0
+    # (2082500 - 1913000) / 1913000 * 100 = 8.86%
+    assert quote["change_pct"] == pytest.approx(8.86, abs=0.01)
+
+
+@pytest.mark.asyncio
+async def test_apply_nxt_quote_overlay_after_hours_session_state(monkeypatch):
+    """ROB-888: nxt_after overlay tags session_state=nxt_after; krx_prev_close is
+    the just-closed KRX regular close."""
+    from app.mcp_server.tooling import market_data_quotes
+
+    async def fake_session(data_state, *, now=None):
+        return "nxt_after"
+
+    async def fake_overlay(symbol, *, session):
+        return {
+            "price": 68500.0,
+            "session": session,
+            "venue": "nxt",
+            "price_source": "nxt_mid",
+        }
+
+    monkeypatch.setattr(market_data_quotes, "_nxt_quote_session", fake_session)
+    monkeypatch.setattr(market_data_quotes, "_fetch_nxt_quote_overlay", fake_overlay)
+
+    quote = {"symbol": "005930", "price": 70000.0, "source": "kis"}
+    applied = await market_data_quotes._apply_nxt_quote_overlay(
+        "005930", quote, data_state="fresh"
+    )
+
+    assert applied is True
+    assert quote["session_state"] == "nxt_after"
+    assert quote["krx_prev_close"] == 70000.0
+    assert quote["change_pct"] == pytest.approx(-2.14, abs=0.01)
+
+
+@pytest.mark.asyncio
+async def test_apply_nxt_quote_overlay_change_pct_null_when_no_prev_close(monkeypatch):
+    """ROB-888: no fake 0 / no raise when the pre-overlay KRX price is missing or
+    non-positive — krx_prev_close and change_pct honestly report null."""
+    from app.mcp_server.tooling import market_data_quotes
+
+    async def fake_session(data_state, *, now=None):
+        return "nxt_premarket"
+
+    async def fake_overlay(symbol, *, session):
+        return {
+            "price": 2082500.0,
+            "session": session,
+            "venue": "nxt",
+            "price_source": "nxt_mid",
+        }
+
+    monkeypatch.setattr(market_data_quotes, "_nxt_quote_session", fake_session)
+    monkeypatch.setattr(market_data_quotes, "_fetch_nxt_quote_overlay", fake_overlay)
+
+    quote = {"symbol": "000660", "price": None, "source": "kis"}
+    applied = await market_data_quotes._apply_nxt_quote_overlay(
+        "000660", quote, data_state="premarket_unavailable"
+    )
+
+    assert applied is True
+    assert quote["session_state"] == "premarket"
+    assert quote["krx_prev_close"] is None
+    assert quote["change_pct"] is None
+
+
+@pytest.mark.asyncio
 async def test_apply_nxt_quote_overlay_noop_outside_session(monkeypatch):
     from app.mcp_server.tooling import market_data_quotes
 


### PR DESCRIPTION
## 배경 (ROB-888)

프리마켓(08:00~09:00 KST)에 operator의 `scripts/cdp_read.py naver`가 Naver m.stock의 **두 가격 블록**(KRX 전일종가 "개장전" vs NXT 프리마켓 실시간)을 구조화하지 않고 raw 덤프만 해서, 파싱측이 첫 블록(전일종가 1,913,000)을 실시간으로 오독 → SK하이닉스 매도 판단이 완전히 뒤집힌 사고(수익 +2.9% → 손실 -5.4%로 오판).

**근본 원인은 operator repo의 `cdp_read.py`이고 auto_trader가 아니다.** 같은 시각 auto_trader MCP `analyze_stock_batch`는 `price_source: nxt_mid`로 **2,082,500**을 정확히 반영했다(ROB-725 오버레이). operator CLAUDE.md §7 "실시간은 CDP 우선" 규칙 때문에 정확한 MCP 값을 버리고 틀린 CDP 값을 채택한 것.

## 이 PR의 스코프 (auto_trader)

operator가 프리마켓에 CDP 스크래핑 대신 **MCP를 신뢰**하도록, NXT 오버레이 quote를 자기설명적으로 만든다. 근본 수정(cdp_read.py 구조화·operator CLAUDE.md §6/§7)은 **operator repo 별도 작업**으로 이 PR 밖.

### 노출 필드 (`_apply_nxt_quote_overlay`)
- `session_state`: `premarket` | `nxt_after` (NXT 세션 라벨 정규화)
- `krx_prev_close`: 오버레이 직전 price = 가장 최근 완료된 KRX 정규장 종가 (프리마켓=전일종가, nxt_after=당일 종가 — 세션 무관하게 시장의 change% 기준)
- `change_pct`: `(nxt_price - krx_prev_close)/krx_prev_close*100`, 2dp. prev_close 없으면 `null` (0 위장/raise 금지, ROB-448 관례)

### 관통 경로
`analyze_stock_batch` 요약(`_summarize_analysis_result`)이 quote를 화이트리스트하므로, 3개 필드를 요약 루프에도 등록해 operator 응답까지 관통시킴.

## 수용 기준
- 프리마켓 SK하이닉스(000660): `price≈2,082,500`, `price_source=nxt_mid`, `krx_prev_close≈1,913,000`, `change_pct≈+8.86%`, `session_state=premarket` 동반 반환 ✅ (e2e 테스트)
- prev_close None → `change_pct=null` ✅
- 정규장/장마감 경로 무변경, migration 0 ✅

## 테스트
- 신규 5 (unit 3 overlay + e2e 1 resolve + summary 1)
- 회귀 스윕 571 passed, ruff/ty clean
- 실 premarket 라이브 검증은 08:00~09:00 KST 창에서만 가능 — 테스트가 실 오버레이 로직으로 런타임 경로 관통 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Market quotes now identify trading session states, including premarket and after-hours.
  * NXT-overlaid quotes display the preserved KRX previous close and calculated percentage change.
  * Analysis summaries now include these price context fields for clearer interpretation.
  * Percentage changes remain blank when a valid previous close is unavailable, preventing misleading values.

* **Tests**
  * Added coverage for session labeling, price calculations, summary fields, and missing-data scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->