### PR TITLE
fix(ROB-889): prioritize get_holdings_news basket by holding size before 30-cap

### DIFF
--- a/app/mcp_server/tooling/fundamentals/_news.py
+++ b/app/mcp_server/tooling/fundamentals/_news.py
@@ -111,6 +111,30 @@ def _infer_holdings_news_market(symbol: str) -> str:
     return "us"
 
 
+def _safe_float(value: Any) -> float:
+    """Best-effort float; unknown/None/garbage -> 0.0 (sorts last, never raises)."""
+    try:
+        if value is None:
+            return 0.0
+        return float(value)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _holding_priority_key(entry: dict[str, Any]) -> tuple[float, int, str]:
+    """ROB-889: sort key for holdings-mode candidates before the 30-cap.
+
+    Orders by cost-basis weight (``quantity * avg_buy_price``) descending so the
+    biggest exposures' catalysts survive, with ``order_routable`` breaking ties
+    (actionable holdings first) and ``symbol`` as a final deterministic tiebreak.
+    Replaces the old arbitrary alphabetical (account, market, symbol) order that
+    let front-of-alphabet ETFs crowd out watched names. Cost-basis is used (not
+    live market value) so the sweep stays a cheap no-price read."""
+    weight = _safe_float(entry.get("_weight"))
+    routable_rank = 0 if entry.get("_order_routable") else 1
+    return (-weight, routable_rank, str(entry.get("symbol") or ""))
+
+
 async def _resolve_holdings_news_candidates(
     symbols: list[str] | None,
 ) -> tuple[list[dict[str, Any]], str | None]:
@@ -142,7 +166,10 @@ async def _resolve_holdings_news_candidates(
     # Holdings mode. Lazy import keeps the portfolio_holdings dependency (and its
     # broker clients) out of the plain fundamentals import path and avoids any
     # import cycle — mirrors _collect_portfolio_positions' own lazy imports.
-    from app.mcp_server.tooling.portfolio_holdings import _collect_portfolio_positions
+    from app.mcp_server.tooling.portfolio_holdings import (
+        _account_order_routable,
+        _collect_portfolio_positions,
+    )
 
     try:
         positions, errors, _, _ = await _collect_portfolio_positions(
@@ -168,10 +195,25 @@ async def _resolve_holdings_news_candidates(
         if key in seen:
             continue
         seen.add(key)
+        # ROB-889: carry cost-basis weight + routability so the cap keeps the
+        # biggest/actionable positions (not the alphabetical front). include_
+        # current_price=False nulls live value, but quantity/avg_buy_price
+        # survive — a free cost-basis proxy needing no extra price fetch.
         candidates.append(
-            {"symbol": symbol, "market": market, "name": position.get("name")}
+            {
+                "symbol": symbol,
+                "market": market,
+                "name": position.get("name"),
+                "_weight": _safe_float(position.get("quantity"))
+                * _safe_float(position.get("avg_buy_price")),
+                "_order_routable": _account_order_routable(
+                    source=position.get("source"),
+                    broker=position.get("broker"),
+                ),
+            }
         )
 
+    candidates.sort(key=_holding_priority_key)
     return candidates, degraded_reason
 
 
@@ -197,8 +239,9 @@ async def _get_holdings_news_impl(
 
     if len(candidates) > HOLDINGS_NEWS_MAX_SYMBOLS:
         degraded_reasons.append(
-            f"resolved {len(candidates)} symbols; capped to "
-            f"{HOLDINGS_NEWS_MAX_SYMBOLS} — pass a narrower symbols list to widen"
+            f"resolved {len(candidates)} symbols; swept the top "
+            f"{HOLDINGS_NEWS_MAX_SYMBOLS} by holding size (routable first) — "
+            f"pass a narrower symbols list to sweep specific names"
         )
         candidates = candidates[:HOLDINGS_NEWS_MAX_SYMBOLS]
 

--- a/tests/mcp_server/tooling/test_get_holdings_news.py
+++ b/tests/mcp_server/tooling/test_get_holdings_news.py
@@ -190,6 +190,143 @@ async def test_caps_symbols_at_max_with_degraded(monkeypatch) -> None:
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_holdings_mode_sorts_by_priority_before_cap(monkeypatch) -> None:
+    """ROB-889: holdings-mode candidates are ordered by cost-basis weight (desc)
+    with order_routable as the tiebreaker — not the arbitrary alphabetical
+    (account, market, symbol) order that let ETFs crowd out big positions."""
+
+    async def fake_collect(**kwargs):
+        return (
+            [
+                # alphabetically first, tiny position -> must NOT lead anymore
+                {
+                    "symbol": "000010",
+                    "market": "kr",
+                    "name": "Tiny ETF",
+                    "source": "kis",
+                    "broker": "kis",
+                    "quantity": 1,
+                    "avg_buy_price": 1000,  # weight 1_000
+                },
+                # alphabetically last, biggest conviction -> must lead
+                {
+                    "symbol": "999990",
+                    "market": "kr",
+                    "name": "Big conviction",
+                    "source": "kis",
+                    "broker": "kis",
+                    "quantity": 100,
+                    "avg_buy_price": 1000,  # weight 100_000
+                },
+                # mid weight, routable
+                {
+                    "symbol": "500000",
+                    "market": "kr",
+                    "name": "Mid",
+                    "source": "kis",
+                    "broker": "kis",
+                    "quantity": 10,
+                    "avg_buy_price": 1000,  # weight 10_000
+                },
+            ],
+            [],
+            None,
+            None,
+        )
+
+    monkeypatch.setattr(
+        portfolio_holdings, "_collect_portfolio_positions", fake_collect
+    )
+
+    async def fake_fetch(
+        symbol, market, instrument_type=None, *, limit=20, timeout_s=5.0
+    ):
+        return _ok_result(symbol, market)
+
+    _patch_fetch(monkeypatch, fake_fetch)
+
+    out = await _news._get_holdings_news_impl(symbols=None, limit_per_symbol=5)
+
+    # weight desc: 999990 (100k) > 500000 (10k) > 000010 (1k)
+    assert out["symbols_resolved"] == ["999990", "500000", "000010"]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_holdings_cap_keeps_high_priority_over_front_etfs(monkeypatch) -> None:
+    """ROB-889: a big watched name placed LAST in the raw holdings order must
+    survive the 30-cap; a tiny front ETF is the one dropped. (Pre-fix the head
+    slice kept the front and dropped the watched name.)"""
+    etfs = [
+        {
+            "symbol": f"{i:06d}",
+            "market": "kr",
+            "name": f"ETF {i}",
+            "source": "kis",
+            "broker": "kis",
+            "quantity": 1,
+            "avg_buy_price": 1000,  # weight 1_000 each
+        }
+        for i in range(1, 31)  # 000001..000030 — 30 tiny ETFs, front of the list
+    ]
+    watched = {
+        "symbol": "999999",
+        "market": "kr",
+        "name": "Watched big",
+        "source": "kis",
+        "broker": "kis",
+        "quantity": 1000,
+        "avg_buy_price": 1000,  # weight 1_000_000 — last in list
+    }
+
+    async def fake_collect(**kwargs):
+        return (etfs + [watched], [], None, None)
+
+    monkeypatch.setattr(
+        portfolio_holdings, "_collect_portfolio_positions", fake_collect
+    )
+
+    async def fake_fetch(
+        symbol, market, instrument_type=None, *, limit=20, timeout_s=5.0
+    ):
+        return _ok_result(symbol, market)
+
+    _patch_fetch(monkeypatch, fake_fetch)
+
+    out = await _news._get_holdings_news_impl(symbols=None, limit_per_symbol=5)
+
+    resolved = out["symbols_resolved"]
+    assert len(resolved) == _news.HOLDINGS_NEWS_MAX_SYMBOLS
+    # the big watched name survived and now leads
+    assert resolved[0] == "999999"
+    assert "999999" in resolved
+    # exactly one tiny ETF got dropped (the lowest-priority by symbol tiebreak)
+    assert "000030" not in resolved
+    assert "degraded_reason" in out
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_explicit_symbols_mode_preserves_request_order(monkeypatch) -> None:
+    """ROB-889: priority sort applies ONLY to holdings mode. An explicit symbols
+    list is the caller's own priority order and must be preserved verbatim."""
+
+    async def fake_fetch(
+        symbol, market, instrument_type=None, *, limit=20, timeout_s=5.0
+    ):
+        return _ok_result(symbol, market)
+
+    _patch_fetch(monkeypatch, fake_fetch)
+
+    out = await _news._get_holdings_news_impl(
+        symbols=["999990", "000010", "500000"], limit_per_symbol=5
+    )
+
+    assert out["symbols_resolved"] == ["999990", "000010", "500000"]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_per_symbol_failure_is_fail_soft(monkeypatch) -> None:
     async def fake_fetch(
         symbol, market, instrument_type=None, *, limit=20, timeout_s=5.0


### PR DESCRIPTION
## 배경 (ROB-889 병행개선 ③)

102종 보유에서 `get_holdings_news`(symbols 생략=보유 전체 스윕)가 `HOLDINGS_NEWS_MAX_SYMBOLS=30`으로 자를 때, 후보 순서가 `_collect_portfolio_positions`의 `(account, market, symbol)` **알파벳순**이라 앞쪽 ETF가 30자리를 채우고 고확신·관심 종목이 탈락했음. 컷은 단순 head-slice(`candidates[:30]`)라 우선순위 개념이 없었음.

## 수정

holdings 모드 후보를 cap **직전** 우선순위 정렬(`_holding_priority_key`):
1. **원가기준 비중** `quantity * avg_buy_price` 내림차순 — 최대 노출부터
2. **order_routable** 우선 (tiebreak) — 주문 가능한 보유 먼저 (`_account_order_routable` 재사용)
3. **symbol** — 결정적 tiebreak

- 원가기준은 `include_current_price=False`(무가격 read)에서도 살아있는 `quantity`/`avg_buy_price`로 계산 → **추가 시세 fetch 없음**(cheap sweep 유지). live 시가총액은 안 씀.
- **명시 `symbols=[...]` 모드는 정렬 미적용** — 호출자의 의도 순서이므로 그대로 보존.
- 출력 계약 무변경(내부 `_weight`/`_order_routable` 키는 row에 안 샘). cap 경고 문구만 `"top N by holding size (routable first)"`로 갱신.

## 테스트
- 신규 3: 우선순위 정렬 순서 / cap이 알파벳 앞 ETF 대신 뒤쪽 고비중 관심종목 보존 / 명시 symbols 순서 보존
- 회귀 307 passed, ruff/ty clean. migration 0.

## ROB-889 나머지 2건은 이 PR 밖 (operator/운영 몫)
병렬 코드조사로 판정:
- **relevance 자동채점 pending(judged_by null)**: auto_trader 코드 버그 아님. 설계상 자가판정 안 하고 외부 Job이 `ingest/bulk`/webhook으로 write-back. 게이트 3종 전부 default off(`NEWS_RELEVANCE_ASYNC_JUDGMENT_ENABLED`/`..._WEBHOOK_URL`/`..._INGEST_TOKEN`) → **운영 배선 갭**.
- **NAVER↔티빙 오태깅**: 우리는 종목코드로만 네이버 per-code 페이지를 긁음 → 티빙 기사는 네이버 편집(업스트림). ROB-491이 결정적 자동제외 금지. 완화책 = 위 외부 판정 활성화.

둘 다 operator 핸드오프 프롬프트에서 다룸.

🤖 Generated with [Claude Code](https://claude.com/claude-code)