### PR TITLE
feat(ROB-889): news-relevance judgment plumbing helper (no LLM)

### DIFF
--- a/docs/runbooks/news-relevance-judgment.md
+++ b/docs/runbooks/news-relevance-judgment.md
@@ -67,6 +67,37 @@ get_news(KR)가 수집·저장한 기사의 종목 관련성 판정을 **외부 
    - 판정 후 `get_news(symbol)` 호출 → `excluded_count` 증가 + 해당 기사 미노출
      + confirmed 기사의 `relevance` 블록에 판정 필드 채워짐 확인.
 
+## 판정 plumbing 헬퍼 (ROB-889)
+
+수동 판정 루프(§Job 절차)를 반복·안전하게 만드는 default-disabled CLI.
+**LLM 미포함** — pending fetch / 페이로드 검증 / ingest POST의 HTTP glue만 담당한다.
+판정 자체는 세션(Claude/Hermes)이 수행(ROB-501 LLM boundary 준수).
+
+```bash
+# 1. pending 조회 (read-only, 토큰 필요)
+uv run python -m scripts.news_relevance_judge_smoke --mode fetch \
+    --market kr --limit 50 --host https://<host> > pending.json
+
+# 2. <세션이 pending.json을 판정해 judgments.json 작성>
+
+# 3. 로컬 검증 (네트워크/토큰 불필요 — 서버 422를 미리 잡음)
+uv run python -m scripts.news_relevance_judge_smoke --mode validate \
+    --file judgments.json
+#    → {"status":"valid","judgments":N,"would_exclude":X,"would_confirm":Y}
+#    would_exclude 은 서버 파생 규칙(unrelated|low)의 로컬 미리보기다.
+
+# 4. 제출 (DB mutation → --confirm 필수; 없으면 dry_run 미리보기)
+uv run python -m scripts.news_relevance_judge_smoke --mode submit \
+    --file judgments.json --host https://<host> --confirm
+```
+
+- 토큰은 `NEWS_RELEVANCE_INGEST_TOKEN` env 에서 읽고 **절대 출력하지 않는다**(키 유무만 보고).
+  헤더 이름은 `NEWS_RELEVANCE_INGEST_TOKEN_HEADER`(기본 `X-News-Relevance-Ingest-Token`).
+- host 기본값은 `NEWS_RELEVANCE_SMOKE_HOST` 또는 `http://localhost:8000`.
+- `submit`은 `--confirm` 없으면 검증+미리보기만 하고 아무것도 보내지 않는다(fail-safe).
+- 판정 JSON은 서버와 동일한 pydantic 계약(`NewsRelevanceIngestRequest`)으로 검증한다 —
+  enum/shape 위반은 POST 전에 걸린다. `status`는 서버가 파생하므로 절대 보내지 않는다.
+
 ## TaskIQ 비동기 판정 worker (ROB-506)
 
 `get_news`(KR)가 새 pending link를 만들면 `news_relevance.judge_pending`

--- a/scripts/news_relevance_judge_smoke.py
+++ b/scripts/news_relevance_judge_smoke.py
@@ -1,0 +1,279 @@
+# scripts/news_relevance_judge_smoke.py
+"""Operator/session plumbing for the news-relevance judgment loop (ROB-889).
+
+This is **plumbing only — it contains no LLM and makes no relevance decision**.
+The judgment itself (relationship / relevance / price_relevance / reason) is made
+out-of-process by a Claude/Hermes session, honoring the ROB-501 LLM-ownership
+boundary. This helper just does the safe HTTP glue around that session:
+
+    fetch    GET  /trading/api/news-relevance/pending   (read-only)
+    validate local pydantic check of a judgments JSON     (no network, no token)
+    submit   POST /trading/api/news-relevance/ingest/bulk (mutation; --confirm)
+
+Typical loop:
+    1. uv run python -m scripts.news_relevance_judge_smoke --mode fetch \
+           --market kr --limit 50 > pending.json
+    2. <the session reads pending.json, judges, writes judgments.json>
+    3. uv run python -m scripts.news_relevance_judge_smoke --mode validate \
+           --file judgments.json
+    4. uv run python -m scripts.news_relevance_judge_smoke --mode submit \
+           --file judgments.json --confirm
+    5. re-fetch / call get_news to confirm excluded_count rose and pending fell.
+
+Safety:
+    * The ingest token is read from ``NEWS_RELEVANCE_INGEST_TOKEN`` and is NEVER
+      printed — only the presence/absence of the env key is reported.
+    * ``submit`` mutates DB state (status transitions) and therefore requires an
+      explicit ``--confirm``; without it the payload is validated and previewed
+      but nothing is sent.
+    * Server status is derived server-side (unrelated/low -> excluded); this
+      script never sends ``status``.
+
+See docs/runbooks/news-relevance-judgment.md for the judgment criteria.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+from typing import Any
+
+import httpx
+from pydantic import ValidationError
+
+from app.schemas.news_relevance import NewsRelevanceIngestRequest
+
+_TOKEN_ENV = "NEWS_RELEVANCE_INGEST_TOKEN"
+_TOKEN_HEADER_ENV = "NEWS_RELEVANCE_INGEST_TOKEN_HEADER"
+_DEFAULT_TOKEN_HEADER = "X-News-Relevance-Ingest-Token"
+_HOST_ENV = "NEWS_RELEVANCE_SMOKE_HOST"
+_DEFAULT_HOST = "http://localhost:8000"
+
+_PENDING_PATH = "/trading/api/news-relevance/pending"
+_INGEST_PATH = "/trading/api/news-relevance/ingest/bulk"
+
+
+class SmokeRejected(RuntimeError):
+    """Raised when operator inputs violate a smoke safety boundary."""
+
+
+def resolve_host(host: str | None, env: dict[str, str] | None = None) -> str:
+    env = os.environ if env is None else env
+    return (host or env.get(_HOST_ENV) or _DEFAULT_HOST).rstrip("/")
+
+
+def resolve_token_header(env: dict[str, str] | None = None) -> str:
+    env = os.environ if env is None else env
+    return (env.get(_TOKEN_HEADER_ENV) or _DEFAULT_TOKEN_HEADER).strip()
+
+
+def require_ingest_token(env: dict[str, str] | None = None) -> str:
+    """Return the ingest token, or raise reporting the KEY NAME only.
+
+    The token value is never included in the error message or any output.
+    """
+    env = os.environ if env is None else env
+    token = (env.get(_TOKEN_ENV) or "").strip()
+    if not token:
+        raise SmokeRejected(
+            f"missing env {_TOKEN_ENV} (value never printed) — set it to the "
+            "server's news-relevance ingest token"
+        )
+    return token
+
+
+def build_auth_headers(
+    token: str, *, env: dict[str, str] | None = None
+) -> dict[str, str]:
+    return {resolve_token_header(env): token}
+
+
+def validate_judgments_payload(raw: Any) -> NewsRelevanceIngestRequest:
+    """Validate a judgments payload against the server contract (offline).
+
+    Accepts either the wrapped ``{"judgments": [...]}`` shape or a bare list of
+    judgment objects. Raises ``SmokeRejected`` with a readable, index-tagged
+    message on any enum/shape violation — mirrors the server's 422 so bad
+    payloads are caught before they ever hit the network.
+    """
+    if isinstance(raw, list):
+        payload: dict[str, Any] = {"judgments": raw}
+    elif isinstance(raw, dict):
+        payload = raw
+    else:
+        raise SmokeRejected(
+            "judgments payload must be a JSON object with a 'judgments' list "
+            "or a bare list of judgment objects"
+        )
+    try:
+        return NewsRelevanceIngestRequest.model_validate(payload)
+    except ValidationError as exc:
+        raise SmokeRejected(f"invalid judgments payload:\n{exc}") from exc
+
+
+def load_judgments_file(path: str) -> NewsRelevanceIngestRequest:
+    try:
+        with open(path, encoding="utf-8") as fh:
+            raw = json.load(fh)
+    except FileNotFoundError as exc:
+        raise SmokeRejected(f"judgments file not found: {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise SmokeRejected(f"judgments file is not valid JSON: {path}\n{exc}") from exc
+    return validate_judgments_payload(raw)
+
+
+async def fetch_pending(
+    *,
+    host: str,
+    token: str,
+    market: str,
+    limit: int,
+    symbol: str | None = None,
+    client: httpx.AsyncClient | None = None,
+    env: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    """GET the pending judgment batch. Read-only; token-authed."""
+    params: dict[str, Any] = {"market": market, "limit": limit}
+    if symbol:
+        params["symbol"] = symbol
+    headers = build_auth_headers(token, env=env)
+    owns_client = client is None
+    client = client or httpx.AsyncClient(timeout=30.0)
+    try:
+        response = await client.get(
+            f"{host}{_PENDING_PATH}", params=params, headers=headers
+        )
+    finally:
+        if owns_client:
+            await client.aclose()
+    return _envelope(response)
+
+
+async def submit_judgments(
+    *,
+    host: str,
+    token: str,
+    request: NewsRelevanceIngestRequest,
+    client: httpx.AsyncClient | None = None,
+    env: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    """POST validated judgments to the ingest endpoint. Mutation; token-authed."""
+    headers = build_auth_headers(token, env=env)
+    body = request.model_dump(mode="json")
+    owns_client = client is None
+    client = client or httpx.AsyncClient(timeout=60.0)
+    try:
+        response = await client.post(
+            f"{host}{_INGEST_PATH}", json=body, headers=headers
+        )
+    finally:
+        if owns_client:
+            await client.aclose()
+    return _envelope(response)
+
+
+def _envelope(response: httpx.Response) -> dict[str, Any]:
+    try:
+        body: Any = response.json()
+    except (json.JSONDecodeError, ValueError):
+        body = response.text
+    return {"http_status": response.status_code, "body": body}
+
+
+def summarize_judgments(request: NewsRelevanceIngestRequest) -> dict[str, Any]:
+    """Local, no-network preview: how many will confirm vs exclude (server rule)."""
+    would_exclude = sum(
+        1
+        for j in request.judgments
+        if j.relationship == "unrelated" or j.relevance == "low"
+    )
+    return {
+        "judgments": len(request.judgments),
+        "would_exclude": would_exclude,
+        "would_confirm": len(request.judgments) - would_exclude,
+    }
+
+
+def _print(obj: Any) -> None:
+    print(json.dumps(obj, ensure_ascii=False, indent=2))
+
+
+async def _run(args: argparse.Namespace) -> int:
+    host = resolve_host(args.host)
+
+    if args.mode == "validate":
+        request = load_judgments_file(args.file)
+        _print({"status": "valid", **summarize_judgments(request)})
+        return 0
+
+    if args.mode == "fetch":
+        token = require_ingest_token()
+        result = await fetch_pending(
+            host=host,
+            token=token,
+            market=args.market,
+            limit=args.limit,
+            symbol=args.symbol,
+        )
+        _print(result)
+        return 0 if result["http_status"] < 400 else 2
+
+    if args.mode == "submit":
+        request = load_judgments_file(args.file)
+        preview = summarize_judgments(request)
+        if not args.confirm:
+            _print(
+                {
+                    "status": "dry_run",
+                    "note": "pass --confirm to POST; nothing was sent",
+                    "host": host,
+                    **preview,
+                }
+            )
+            return 0
+        token = require_ingest_token()
+        result = await submit_judgments(host=host, token=token, request=request)
+        _print({"submitted": preview, **result})
+        return 0 if result["http_status"] < 400 else 2
+
+    raise SmokeRejected(f"unknown mode: {args.mode}")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="news_relevance_judge_smoke",
+        description="Plumbing for the news-relevance judgment loop (no LLM).",
+    )
+    parser.add_argument(
+        "--mode", required=True, choices=("fetch", "validate", "submit")
+    )
+    parser.add_argument(
+        "--host", default=None, help=f"default: ${_HOST_ENV} or {_DEFAULT_HOST}"
+    )
+    parser.add_argument("--market", default="kr", choices=("kr", "us", "crypto"))
+    parser.add_argument("--limit", type=int, default=50)
+    parser.add_argument("--symbol", default=None)
+    parser.add_argument("--file", default=None, help="judgments JSON (validate/submit)")
+    parser.add_argument(
+        "--confirm",
+        action="store_true",
+        help="required to actually POST judgments (submit mode mutates DB state)",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    if args.mode in ("validate", "submit") and not args.file:
+        raise SmokeRejected(f"--file is required for --mode {args.mode}")
+    try:
+        return asyncio.run(_run(args))
+    except SmokeRejected as exc:
+        _print({"status": "rejected", "error": str(exc)})
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_news_relevance_judge_smoke.py
+++ b/tests/scripts/test_news_relevance_judge_smoke.py
@@ -1,0 +1,258 @@
+# tests/scripts/test_news_relevance_judge_smoke.py
+"""ROB-889: news-relevance judgment plumbing helper — no LLM, safe HTTP glue."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from scripts import news_relevance_judge_smoke as smoke
+
+
+def _valid_judgment(**over: Any) -> dict[str, Any]:
+    base = {
+        "article_id": 123,
+        "market": "kr",
+        "symbol": "035420",
+        "relationship": "direct",
+        "relevance": "high",
+        "price_relevance": "catalyst",
+        "score": 0.9,
+        "reason": "급락 원인 직접 보도",
+        "judged_by": "session",
+    }
+    base.update(over)
+    return base
+
+
+# --- token / secret safety -------------------------------------------------
+
+
+def test_require_ingest_token_returns_when_set() -> None:
+    assert smoke.require_ingest_token({"NEWS_RELEVANCE_INGEST_TOKEN": "s3cret"}) == (
+        "s3cret"
+    )
+
+
+def test_require_ingest_token_raises_without_leaking_value() -> None:
+    with pytest.raises(smoke.SmokeRejected) as exc:
+        smoke.require_ingest_token({"NEWS_RELEVANCE_INGEST_TOKEN": ""})
+    msg = str(exc.value)
+    assert "NEWS_RELEVANCE_INGEST_TOKEN" in msg  # names the key
+    assert "value never printed" in msg
+
+
+def test_require_ingest_token_missing_key() -> None:
+    with pytest.raises(smoke.SmokeRejected):
+        smoke.require_ingest_token({})
+
+
+def test_build_auth_headers_uses_default_header_name() -> None:
+    headers = smoke.build_auth_headers("tok", env={})
+    assert headers == {"X-News-Relevance-Ingest-Token": "tok"}
+
+
+def test_build_auth_headers_respects_header_override() -> None:
+    headers = smoke.build_auth_headers(
+        "tok", env={"NEWS_RELEVANCE_INGEST_TOKEN_HEADER": "X-Custom"}
+    )
+    assert headers == {"X-Custom": "tok"}
+
+
+# --- host resolution -------------------------------------------------------
+
+
+def test_resolve_host_prefers_arg_then_env_then_default() -> None:
+    assert smoke.resolve_host("https://h/", env={}) == "https://h"
+    assert smoke.resolve_host(None, env={"NEWS_RELEVANCE_SMOKE_HOST": "https://e"}) == (
+        "https://e"
+    )
+    assert smoke.resolve_host(None, env={}) == "http://localhost:8000"
+
+
+# --- payload validation (offline, mirrors server 422) ----------------------
+
+
+def test_validate_accepts_wrapped_and_bare() -> None:
+    wrapped = smoke.validate_judgments_payload({"judgments": [_valid_judgment()]})
+    bare = smoke.validate_judgments_payload([_valid_judgment()])
+    assert len(wrapped.judgments) == 1
+    assert len(bare.judgments) == 1
+
+
+def test_validate_rejects_bad_enum() -> None:
+    with pytest.raises(smoke.SmokeRejected) as exc:
+        smoke.validate_judgments_payload(
+            [_valid_judgment(relationship="totally-made-up")]
+        )
+    assert "invalid judgments payload" in str(exc.value)
+
+
+def test_validate_rejects_empty_batch() -> None:
+    with pytest.raises(smoke.SmokeRejected):
+        smoke.validate_judgments_payload([])
+
+
+def test_validate_rejects_non_container() -> None:
+    with pytest.raises(smoke.SmokeRejected):
+        smoke.validate_judgments_payload("nope")
+
+
+def test_summarize_applies_server_exclusion_rule() -> None:
+    request = smoke.validate_judgments_payload(
+        [
+            _valid_judgment(article_id=1),  # confirm
+            _valid_judgment(article_id=2, relationship="unrelated"),  # exclude
+            _valid_judgment(article_id=3, relevance="low"),  # exclude
+        ]
+    )
+    assert smoke.summarize_judgments(request) == {
+        "judgments": 3,
+        "would_exclude": 2,
+        "would_confirm": 1,
+    }
+
+
+# --- file loading ----------------------------------------------------------
+
+
+def test_load_judgments_file_missing(tmp_path) -> None:
+    with pytest.raises(smoke.SmokeRejected):
+        smoke.load_judgments_file(str(tmp_path / "nope.json"))
+
+
+def test_load_judgments_file_bad_json(tmp_path) -> None:
+    p = tmp_path / "bad.json"
+    p.write_text("{not json", encoding="utf-8")
+    with pytest.raises(smoke.SmokeRejected):
+        smoke.load_judgments_file(str(p))
+
+
+def test_load_judgments_file_valid(tmp_path) -> None:
+    p = tmp_path / "j.json"
+    p.write_text(json.dumps({"judgments": [_valid_judgment()]}), encoding="utf-8")
+    request = smoke.load_judgments_file(str(p))
+    assert request.judgments[0].symbol == "035420"
+
+
+# --- HTTP glue (fake client, no network) -----------------------------------
+
+
+class _FakeResponse:
+    def __init__(self, status_code: int, payload: Any) -> None:
+        self.status_code = status_code
+        self._payload = payload
+
+    def json(self) -> Any:
+        return self._payload
+
+    @property
+    def text(self) -> str:
+        return json.dumps(self._payload)
+
+
+class _FakeClient:
+    def __init__(self, response: _FakeResponse) -> None:
+        self._response = response
+        self.get_calls: list[dict[str, Any]] = []
+        self.post_calls: list[dict[str, Any]] = []
+
+    async def get(self, url, params=None, headers=None) -> _FakeResponse:
+        self.get_calls.append({"url": url, "params": params, "headers": headers})
+        return self._response
+
+    async def post(self, url, json=None, headers=None) -> _FakeResponse:
+        self.post_calls.append({"url": url, "json": json, "headers": headers})
+        return self._response
+
+
+@pytest.mark.asyncio
+async def test_fetch_pending_sends_token_and_params() -> None:
+    client = _FakeClient(
+        _FakeResponse(200, {"market": "kr", "count": 0, "pending": []})
+    )
+    out = await smoke.fetch_pending(
+        host="https://h",
+        token="tok",
+        market="kr",
+        limit=25,
+        symbol="035420",
+        client=client,
+        env={},
+    )
+    assert out == {
+        "http_status": 200,
+        "body": {"market": "kr", "count": 0, "pending": []},
+    }
+    call = client.get_calls[0]
+    assert call["url"] == "https://h/trading/api/news-relevance/pending"
+    assert call["params"] == {"market": "kr", "limit": 25, "symbol": "035420"}
+    assert call["headers"] == {"X-News-Relevance-Ingest-Token": "tok"}
+
+
+@pytest.mark.asyncio
+async def test_fetch_pending_omits_symbol_when_absent() -> None:
+    client = _FakeClient(_FakeResponse(200, {"pending": []}))
+    await smoke.fetch_pending(
+        host="https://h", token="tok", market="kr", limit=50, client=client, env={}
+    )
+    assert client.get_calls[0]["params"] == {"market": "kr", "limit": 50}
+
+
+@pytest.mark.asyncio
+async def test_submit_judgments_posts_body_and_token() -> None:
+    request = smoke.validate_judgments_payload([_valid_judgment()])
+    client = _FakeClient(
+        _FakeResponse(200, {"applied": [{"status": "confirmed"}], "errors": []})
+    )
+    out = await smoke.submit_judgments(
+        host="https://h", token="tok", request=request, client=client, env={}
+    )
+    assert out["http_status"] == 200
+    call = client.post_calls[0]
+    assert call["url"] == "https://h/trading/api/news-relevance/ingest/bulk"
+    assert call["headers"] == {"X-News-Relevance-Ingest-Token": "tok"}
+    assert call["json"]["judgments"][0]["symbol"] == "035420"
+    # no server-derived 'status' is ever sent
+    assert "status" not in call["json"]["judgments"][0]
+
+
+@pytest.mark.asyncio
+async def test_submit_surfaces_non_2xx_status() -> None:
+    request = smoke.validate_judgments_payload([_valid_judgment()])
+    client = _FakeClient(_FakeResponse(403, {"detail": "token not configured"}))
+    out = await smoke.submit_judgments(
+        host="https://h", token="tok", request=request, client=client, env={}
+    )
+    assert out["http_status"] == 403
+
+
+# --- CLI gating ------------------------------------------------------------
+
+
+def test_main_submit_dry_run_without_confirm_does_not_require_token(
+    tmp_path, capsys
+) -> None:
+    p = tmp_path / "j.json"
+    p.write_text(json.dumps([_valid_judgment()]), encoding="utf-8")
+    # No token in env, but dry-run submit must not need it and must not POST.
+    rc = smoke.main(["--mode", "submit", "--file", str(p)])
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["status"] == "dry_run"
+    assert out["would_confirm"] == 1
+
+
+def test_main_validate_requires_file() -> None:
+    with pytest.raises(smoke.SmokeRejected):
+        smoke.main(["--mode", "validate"])
+
+
+def test_main_validate_ok(tmp_path, capsys) -> None:
+    p = tmp_path / "j.json"
+    p.write_text(json.dumps([_valid_judgment()]), encoding="utf-8")
+    rc = smoke.main(["--mode", "validate", "--file", str(p)])
+    assert rc == 0
+    assert json.loads(capsys.readouterr().out)["status"] == "valid"


### PR DESCRIPTION
## 배경 (ROB-889 병행 ①의 활성화 도구)

세션에서 스윕한 뉴스가 전건 `relevance.status=pending`인 근본 원인은 **auto_trader 코드 버그가 아니라 외부 판정 Job 미배선**이다 (설계상 auto_trader는 자가판정 금지 — ROB-501 LLM boundary / ROB-491). 활성화의 첫 단계는 런북 §Job 절차의 **수동 판정 루프**인데, GET pending → 판정 → POST ingest/bulk를 매번 curl로 돌리는 건 오류·토큰 노출 위험이 있다.

이 PR은 그 루프를 **반복·안전하게** 만드는 default-disabled 플러밍 CLI를 추가한다.

## `scripts/news_relevance_judge_smoke.py` — plumbing만, LLM 미포함

| mode | 동작 |
|---|---|
| `fetch` | `GET /news-relevance/pending` (read-only, 토큰) → pending 배치 출력 |
| `validate` | judgments JSON을 **서버와 동일한 pydantic 계약**(`NewsRelevanceIngestRequest`)으로 오프라인 검증 → enum/shape 위반을 POST 전에 차단. `would_exclude` 미리보기 |
| `submit` | `POST /ingest/bulk` (DB mutation → **`--confirm` 필수**; 없으면 dry_run 미리보기) |

판정 자체(relationship/relevance/price_relevance/reason)는 세션(Claude/Hermes)이 수행 — 스크립트엔 LLM 없음.

## 안전 경계
- 토큰은 `NEWS_RELEVANCE_INGEST_TOKEN`에서 읽고 **절대 출력 안 함** — 키 유무만 보고.
- `submit`은 `--confirm` 없으면 검증+미리보기만, 아무것도 전송 안 함 (fail-safe).
- `status`는 서버 파생(unrelated|low→excluded)이라 스크립트가 절대 전송 안 함.
- 서버 코드 무변경, migration 0.

## 테스트 (21)
토큰 비노출·enum 검증·헤더 override·host 해석·fake-client HTTP glue(토큰헤더/쿼리/바디)·CLI dry_run 게이트. 실 CLI validate/dry-run로 SK하이닉스·티빙(unrelated/low → would_exclude=1) 시나리오 확인.

## 이후 (이 PR 밖)
- Phase 0: 서버 env에 `NEWS_RELEVANCE_INGEST_TOKEN` 배치 (ops).
- Phase 1: 세션이 이 헬퍼로 수동 판정 루프 1회 실행 → 검증.
- Phase 3: 헤드리스 `claude -p` cron 또는 ROB-506 webhook 자동화 (수동 reps 후).

런북 `docs/runbooks/news-relevance-judgment.md`에 사용 절차 추가.

🤖 Generated with [Claude Code](https://claude.com/claude-code)