### PR TITLE
fix(ROB-891): kiwoom_mock get_orderable_cash no-symbol path uses kt00001 deposit endpoint

### DIFF
--- a/app/mcp_server/tooling/orders_kiwoom_variants.py
+++ b/app/mcp_server/tooling/orders_kiwoom_variants.py
@@ -32,6 +32,8 @@ from app.services.brokers.kiwoom.domestic_orders import KiwoomDomesticOrderClien
 from app.services.brokers.kiwoom.normalization import (
     KiwoomMockEvidenceError,
     build_mock_provenance,
+    normalize_deposit,
+    normalize_orderable_cash,
     normalize_orders,
     normalize_positions,
     redact_broker_response,
@@ -222,32 +224,6 @@ def _finalize_normalized_read_response(
         response["error"] = exc.code
         response["error_detail"] = str(exc)
     return response
-
-
-# Candidate Kiwoom cash fields, most specific first. Unknown shapes stay
-# unparsed (cash=None) rather than being faked (ROB-319 operator default).
-_ORDERABLE_CASH_KEYS = (
-    "ord_psbl_cash",
-    "ord_alowa",
-    "100stk_ord_alow_amt",
-    "ord_psbl_amt",
-    "entr",
-)
-
-
-def _extract_orderable_cash(broker_response: dict[str, Any]) -> int:
-    for key in _ORDERABLE_CASH_KEYS:
-        if key in broker_response and broker_response[key] not in (None, ""):
-            try:
-                cash = int(str(broker_response[key]).replace(",", "").strip())
-            except (TypeError, ValueError) as exc:
-                raise KiwoomMockEvidenceError(
-                    f"Kiwoom cash field {key} is not an integer"
-                ) from exc
-            if cash < 0:
-                raise KiwoomMockEvidenceError(f"Kiwoom cash field {key} is negative")
-            return cash
-    raise KiwoomMockEvidenceError("Kiwoom response has no recognized cash field")
 
 
 # ---------------------------------------------------------------------------
@@ -466,27 +442,39 @@ async def _kiwoom_mock_positions_impl(**kwargs: Any) -> dict[str, Any]:
 async def _kiwoom_mock_orderable_cash_impl(**kwargs: Any) -> dict[str, Any]:
     symbol_raw = kwargs.get("symbol")
     symbol = None if symbol_raw is None else normalize_krx_symbol(symbol_raw)
+    side = kwargs.get("side")
+    price = kwargs.get("price")
     cont_yn = kwargs.get("cont_yn")
     next_key = kwargs.get("next_key")
-    base_source = "orderable_amount" if symbol is not None else "balance"
-    api_id = (
-        constants.ACCOUNT_ORDERABLE_AMOUNT_API_ID
-        if symbol is not None
-        else constants.ACCOUNT_BALANCE_API_ID
-    )
-    extra = {
+
+    if symbol is not None:
+        base_source = "orderable_amount"
+        api_id = constants.ACCOUNT_ORDERABLE_AMOUNT_API_ID
+        normalizer = normalize_orderable_cash
+    else:
+        base_source = "deposit"
+        api_id = constants.ACCOUNT_DEPOSIT_API_ID
+        normalizer = normalize_deposit
+
+    extra: dict[str, Any] = {
         "cash_source": f"{base_source}_unavailable",
-        **({"symbol": symbol} if symbol is not None else {}),
     }
+    if symbol is not None:
+        extra["symbol"] = symbol
+
     try:
         client = KiwoomMockClient.from_app_settings()
         account_client = KiwoomDomesticAccountClient(cast(Any, client))
         if symbol is not None:
             broker_response = await account_client.get_orderable_amount(
-                symbol=symbol, cont_yn=cont_yn, next_key=next_key
+                symbol=symbol,
+                side=side,
+                price=price,
+                cont_yn=cont_yn,
+                next_key=next_key,
             )
         else:
-            broker_response = await account_client.get_balance(
+            broker_response = await account_client.get_deposit(
                 cont_yn=cont_yn, next_key=next_key
             )
     except Exception as exc:  # noqa: BLE001 - MCP tools fail closed with JSON
@@ -525,7 +513,7 @@ async def _kiwoom_mock_orderable_cash_impl(**kwargs: Any) -> dict[str, Any]:
         return response
 
     try:
-        cash = _extract_orderable_cash(broker_response)
+        cash = normalizer(broker_response)
     except KiwoomMockEvidenceError as exc:
         return _stable_read_failure(
             result_key="cash",
@@ -765,13 +753,16 @@ def register(mcp: FastMCP) -> None:
     )
     async def kiwoom_mock_get_orderable_cash(
         symbol: str | None = None,
+        side: Literal["buy", "sell"] | None = None,
+        price: int | None = None,
     ) -> dict[str, Any]:
         if (guard := _mock_config_error()) is not None:
-            api_id = (
-                constants.ACCOUNT_ORDERABLE_AMOUNT_API_ID
-                if symbol is not None
-                else constants.ACCOUNT_BALANCE_API_ID
-            )
+            if symbol is not None:
+                api_id = constants.ACCOUNT_ORDERABLE_AMOUNT_API_ID
+                cash_source = "orderable_amount_unavailable"
+            else:
+                api_id = constants.ACCOUNT_DEPOSIT_API_ID
+                cash_source = "deposit_unavailable"
             return _stable_read_failure(
                 result_key="cash",
                 result_value=None,
@@ -779,11 +770,7 @@ def register(mcp: FastMCP) -> None:
                 error="kiwoom_mock_config_invalid",
                 error_detail=str(guard["error"]),
                 extra={
-                    "cash_source": (
-                        "orderable_amount_unavailable"
-                        if symbol is not None
-                        else "balance_unavailable"
-                    ),
+                    "cash_source": cash_source,
                     **({"symbol": symbol} if symbol is not None else {}),
                 },
             )
@@ -802,4 +789,6 @@ def register(mcp: FastMCP) -> None:
                         "symbol": symbol,
                     },
                 )
-        return await _kiwoom_mock_orderable_cash_impl(symbol=symbol)
+        return await _kiwoom_mock_orderable_cash_impl(
+            symbol=symbol, side=side, price=price
+        )

--- a/app/services/brokers/kiwoom/constants.py
+++ b/app/services/brokers/kiwoom/constants.py
@@ -33,7 +33,13 @@ ORDER_CANCEL_API_ID = "kt10003"
 ACCOUNT_ORDER_DETAIL_API_ID = "kt00007"
 ACCOUNT_ORDER_STATUS_API_ID = "kt00009"
 ACCOUNT_ORDERABLE_AMOUNT_API_ID = "kt00010"
+ACCOUNT_DEPOSIT_API_ID = "kt00001"  # ROB-891 — 예수금상세현황 (account-level cash)
 ACCOUNT_BALANCE_API_ID = "kt00018"
+
+# ROB-891 — kt00010 (주문가능금액) trde_tp (주문구분) values for order-specific
+# orderable-cash queries. Maps side → Kiwoom trade-type code.
+TRADE_TYPE_BUY = "1"  # 매수
+TRADE_TYPE_SELL = "2"  # 매도
 
 # Chart API IDs (scaffolded, deferred — NOT routed from get_ohlcv)
 CHART_MINUTE_API_ID = "ka10080"

--- a/app/services/brokers/kiwoom/domestic_account.py
+++ b/app/services/brokers/kiwoom/domestic_account.py
@@ -38,18 +38,39 @@ class KiwoomDomesticAccountClient:
         self,
         *,
         symbol: str,
+        side: str | None = None,
+        price: int | None = None,
+        cont_yn: str | None = None,
+        next_key: str | None = None,
+    ) -> dict[str, Any]:
+        body: dict[str, Any] = {
+            "dmst_stex_tp": constants.ACCOUNT_DMST_STEX_TP_DEFAULT,
+            "stk_cd": normalize_krx_symbol(symbol),
+        }
+        if side is not None and price is not None:
+            body["trde_tp"] = (
+                constants.TRADE_TYPE_BUY if side == "buy" else constants.TRADE_TYPE_SELL
+            )
+            body["uv"] = str(price)
+        return await self._client.post_api(
+            api_id=constants.ACCOUNT_ORDERABLE_AMOUNT_API_ID,
+            path=ACCOUNT_PATH,
+            body=body,
+            cont_yn=cont_yn,
+            next_key=next_key,
+        )
+
+    async def get_deposit(
+        self,
+        *,
         cont_yn: str | None = None,
         next_key: str | None = None,
     ) -> dict[str, Any]:
         return await self._client.post_api(
-            api_id=constants.ACCOUNT_ORDERABLE_AMOUNT_API_ID,
+            api_id=constants.ACCOUNT_DEPOSIT_API_ID,
             path=ACCOUNT_PATH,
-            # ROB-460 — kt00010 (get_orderable_cash symbol path) requires
-            # dmst_stex_tp (국내거래소구분), like its sibling kt00018; value "KRX" is
-            # proven by the order endpoints. Mock is KRX-only.
             body={
                 "dmst_stex_tp": constants.ACCOUNT_DMST_STEX_TP_DEFAULT,
-                "stk_cd": normalize_krx_symbol(symbol),
             },
             cont_yn=cont_yn,
             next_key=next_key,

--- a/app/services/brokers/kiwoom/normalization.py
+++ b/app/services/brokers/kiwoom/normalization.py
@@ -137,6 +137,38 @@ def _normalize_kr_symbol(row: Mapping[str, Any]) -> str:
         raise KiwoomMockEvidenceError("Kiwoom row has invalid KRX symbol") from exc
 
 
+def _required_non_negative_cash(payload: Mapping[str, Any], key: str) -> int:
+    raw = payload.get(key)
+    if raw is None:
+        raise KiwoomMockEvidenceError(
+            f"Kiwoom response missing required cash field {key}"
+        )
+    text = str(raw).strip()
+    if not text:
+        raise KiwoomMockEvidenceError(
+            f"Kiwoom response missing required cash field {key}"
+        )
+    try:
+        value = int(text.replace(",", ""))
+    except ValueError as exc:
+        raise KiwoomMockEvidenceError(
+            f"Kiwoom cash field {key} is not an integer"
+        ) from exc
+    if value < 0:
+        raise KiwoomMockEvidenceError(f"Kiwoom cash field {key} is negative")
+    return value
+
+
+def normalize_deposit(payload: dict[str, Any]) -> int:
+    """Parse kt00001 deposit detail — ord_alow_amt only (ROB-891)."""
+    return _required_non_negative_cash(payload, "ord_alow_amt")
+
+
+def normalize_orderable_cash(payload: dict[str, Any]) -> int:
+    """Parse kt00010 orderable amount — ord_alowa only (ROB-891)."""
+    return _required_non_negative_cash(payload, "ord_alowa")
+
+
 def normalize_positions(payload: dict[str, Any]) -> list[dict[str, Any]]:
     positions: list[dict[str, Any]] = []
     for row in _required_rows(payload, "acnt_evlt_remn_indv_tot"):
@@ -301,6 +333,8 @@ __all__ = [
     "REDACTED_VALUE",
     "KiwoomMockEvidenceError",
     "build_mock_provenance",
+    "normalize_deposit",
+    "normalize_orderable_cash",
     "normalize_orders",
     "normalize_positions",
     "redact_broker_response",

--- a/tests/test_kiwoom_constants.py
+++ b/tests/test_kiwoom_constants.py
@@ -30,6 +30,7 @@ def test_account_api_ids():
     assert k.ACCOUNT_ORDER_DETAIL_API_ID == "kt00007"
     assert k.ACCOUNT_ORDER_STATUS_API_ID == "kt00009"
     assert k.ACCOUNT_ORDERABLE_AMOUNT_API_ID == "kt00010"
+    assert k.ACCOUNT_DEPOSIT_API_ID == "kt00001"
     assert k.ACCOUNT_BALANCE_API_ID == "kt00018"
 
 

--- a/tests/test_kiwoom_domestic_account.py
+++ b/tests/test_kiwoom_domestic_account.py
@@ -55,6 +55,44 @@ async def test_get_orderable_amount_includes_dmst_stex_tp():
 
 
 @pytest.mark.asyncio
+async def test_get_orderable_amount_with_side_price_sends_trde_tp_and_uv():
+    fake = FakeClient()
+    acct = KiwoomDomesticAccountClient(fake)
+    await acct.get_orderable_amount(symbol="005930", side="buy", price=70000)
+    call = fake.calls[-1]
+    assert call["body"]["trde_tp"] == constants.TRADE_TYPE_BUY
+    assert call["body"]["uv"] == "70000"
+
+
+@pytest.mark.asyncio
+async def test_get_orderable_amount_with_sell_side_sends_correct_trde_tp():
+    fake = FakeClient()
+    acct = KiwoomDomesticAccountClient(fake)
+    await acct.get_orderable_amount(symbol="005930", side="sell", price=70000)
+    assert fake.calls[-1]["body"]["trde_tp"] == constants.TRADE_TYPE_SELL
+
+
+@pytest.mark.asyncio
+async def test_get_orderable_amount_without_side_price_omits_trde_tp_and_uv():
+    fake = FakeClient()
+    acct = KiwoomDomesticAccountClient(fake)
+    await acct.get_orderable_amount(symbol="005930")
+    body = fake.calls[-1]["body"]
+    assert "trde_tp" not in body
+    assert "uv" not in body
+
+
+@pytest.mark.asyncio
+async def test_get_deposit_uses_kt00001_with_dmst_stex_tp():
+    fake = FakeClient()
+    acct = KiwoomDomesticAccountClient(fake)
+    await acct.get_deposit()
+    call = fake.calls[-1]
+    assert call["api_id"] == constants.ACCOUNT_DEPOSIT_API_ID
+    assert call["body"]["dmst_stex_tp"] == constants.ACCOUNT_DMST_STEX_TP_DEFAULT
+
+
+@pytest.mark.asyncio
 async def test_get_balance_uses_kt00018_with_qry_tp_and_dmst_stex_tp():
     fake = FakeClient()
     acct = KiwoomDomesticAccountClient(fake)

--- a/tests/test_kiwoom_mock_normalization.py
+++ b/tests/test_kiwoom_mock_normalization.py
@@ -93,9 +93,7 @@ def test_normalize_deposit_rejects_prsm_dpst_aset_amt_only() -> None:
     ],
 )
 def test_normalize_orderable_cash_parses_ord_alowa(raw: str, expected: int) -> None:
-    assert (
-        normalize_orderable_cash({"return_code": 0, "ord_alowa": raw}) == expected
-    )
+    assert normalize_orderable_cash({"return_code": 0, "ord_alowa": raw}) == expected
 
 
 @pytest.mark.parametrize(

--- a/tests/test_kiwoom_mock_normalization.py
+++ b/tests/test_kiwoom_mock_normalization.py
@@ -8,6 +8,8 @@ from app.services.brokers.kiwoom.normalization import (
     REDACTED_VALUE,
     KiwoomMockEvidenceError,
     build_mock_provenance,
+    normalize_deposit,
+    normalize_orderable_cash,
     normalize_orders,
     normalize_positions,
     redact_broker_response,
@@ -39,6 +41,88 @@ def test_normalize_kt00018_positions_uses_official_fields() -> None:
 
 def test_normalize_kt00018_empty_positions_is_stable_empty_list() -> None:
     assert normalize_positions({"return_code": 0, "acnt_evlt_remn_indv_tot": []}) == []
+
+
+# ---------------------------------------------------------------------------
+# ROB-891 — kt00001 deposit (ord_alow_amt) and kt00010 orderable (ord_alowa)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("50000000", 50_000_000),
+        ("0", 0),
+        ("+000000050000000", 50_000_000),
+        ("50,000,000", 50_000_000),
+        ("+000,000,050,000,000", 50_000_000),
+    ],
+)
+def test_normalize_deposit_parses_ord_alow_amt(raw: str, expected: int) -> None:
+    assert normalize_deposit({"return_code": 0, "ord_alow_amt": raw}) == expected
+
+
+@pytest.mark.parametrize(
+    ("payload", "match"),
+    [
+        ({"return_code": 0}, "missing required cash field"),
+        ({"return_code": 0, "ord_alow_amt": None}, "missing required cash field"),
+        ({"return_code": 0, "ord_alow_amt": ""}, "missing required cash field"),
+        ({"return_code": 0, "ord_alow_amt": "not-a-number"}, "not an integer"),
+        ({"return_code": 0, "ord_alow_amt": "-1"}, "negative"),
+    ],
+)
+def test_normalize_deposit_rejects_invalid_evidence(payload: dict, match: str) -> None:
+    with pytest.raises(KiwoomMockEvidenceError, match=match):
+        normalize_deposit(payload)
+
+
+def test_normalize_deposit_rejects_prsm_dpst_aset_amt_only() -> None:
+    payload = {"return_code": 0, "prsm_dpst_aset_amt": "999999999"}
+    with pytest.raises(KiwoomMockEvidenceError, match="missing required cash field"):
+        normalize_deposit(payload)
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("1500000", 1_500_000),
+        ("0", 0),
+        ("+000000001500000", 1_500_000),
+        ("1,500,000", 1_500_000),
+    ],
+)
+def test_normalize_orderable_cash_parses_ord_alowa(raw: str, expected: int) -> None:
+    assert (
+        normalize_orderable_cash({"return_code": 0, "ord_alowa": raw}) == expected
+    )
+
+
+@pytest.mark.parametrize(
+    ("payload", "match"),
+    [
+        ({"return_code": 0}, "missing required cash field"),
+        ({"return_code": 0, "ord_alowa": None}, "missing required cash field"),
+        ({"return_code": 0, "ord_alowa": ""}, "missing required cash field"),
+        ({"return_code": 0, "ord_alowa": "abc"}, "not an integer"),
+        ({"return_code": 0, "ord_alowa": "-5"}, "negative"),
+    ],
+)
+def test_normalize_orderable_cash_rejects_invalid_evidence(
+    payload: dict, match: str
+) -> None:
+    with pytest.raises(KiwoomMockEvidenceError, match=match):
+        normalize_orderable_cash(payload)
+
+
+def test_normalize_orderable_cash_rejects_cross_endpoint_fields() -> None:
+    payload = {
+        "return_code": 0,
+        "ord_psbl_cash": "1500000",
+        "entr": "987654",
+    }
+    with pytest.raises(KiwoomMockEvidenceError, match="missing required cash field"):
+        normalize_orderable_cash(payload)
 
 
 def test_normalize_kt00009_orders_derives_stable_status_and_quantities() -> None:

--- a/tests/test_mcp_kiwoom_order_variants.py
+++ b/tests/test_mcp_kiwoom_order_variants.py
@@ -923,7 +923,7 @@ async def test_registered_symbol_tools_forward_trimmed_canonical_symbol(monkeypa
 
 
 def _patch_fake_kiwoom_account_client(monkeypatch, mod, payloads):
-    """payloads keyed by method name: 'orderable_amount' | 'balance' | 'order_status'."""
+    """payloads keyed by method name: 'orderable_amount' | 'balance' | 'deposit' | 'order_status'."""
 
     calls: list[dict[str, Any]] = []
 
@@ -939,15 +939,19 @@ def _patch_fake_kiwoom_account_client(monkeypatch, mod, payloads):
 
         async def get_orderable_amount(self, **kwargs):
             calls.append({"method": "orderable_amount", **kwargs})
-            return payloads["orderable_amount"]
+            return payloads.get("orderable_amount", {"return_code": 0})
+
+        async def get_deposit(self, **kwargs):
+            calls.append({"method": "deposit", **kwargs})
+            return payloads.get("deposit", {"return_code": 0})
 
         async def get_balance(self, **kwargs):
             calls.append({"method": "balance", **kwargs})
-            return payloads["balance"]
+            return payloads.get("balance", {"return_code": 0})
 
         async def get_order_status(self, **kwargs):
             calls.append({"method": "order_status", **kwargs})
-            return payloads["order_status"]
+            return payloads.get("order_status", {"return_code": 0})
 
     monkeypatch.setattr(mod, "_mock_config_error", lambda: None)
     monkeypatch.setattr(mod, "KiwoomMockClient", FakeKiwoomMockClient, raising=False)
@@ -968,7 +972,7 @@ async def test_orderable_cash_with_symbol_calls_orderable_amount(monkeypatch):
             "orderable_amount": {
                 "return_code": 0,
                 "return_msg": "정상",
-                "ord_psbl_cash": "1500000",
+                "ord_alowa": "1500000",
             },
             "balance": {"return_code": 0},
             "order_status": {"return_code": 0},
@@ -982,18 +986,45 @@ async def test_orderable_cash_with_symbol_calls_orderable_amount(monkeypatch):
     assert response["success"] is True
     assert response["source"] == "kiwoom"
     assert response["account_mode"] == "kiwoom_mock"
-    assert response["broker_response"]["ord_psbl_cash"] == "1500000"
+    assert response["broker_response"]["ord_alowa"] == "1500000"
     assert response["cash"] == 1500000
     assert response["cash_source"] == "orderable_amount"
     assert response["symbol"] == "005930"
     assert response["provenance"]["api_id"] == "kt00010"
     assert response["provenance"]["host"] == "mockapi.kiwoom.com"
-    # balance must NOT have been called
-    assert all(c.get("method") != "balance" for c in calls)
+    # balance/deposit must NOT have been called
+    assert all(c.get("method") not in ("balance", "deposit") for c in calls)
 
 
 @pytest.mark.asyncio
-async def test_orderable_cash_without_symbol_calls_balance(monkeypatch):
+async def test_orderable_cash_with_symbol_side_price_sends_trde_tp_and_uv(monkeypatch):
+    from app.mcp_server.tooling import orders_kiwoom_variants as mod
+
+    calls = _patch_fake_kiwoom_account_client(
+        monkeypatch,
+        mod,
+        payloads={
+            "orderable_amount": {
+                "return_code": 0,
+                "ord_alowa": "1500000",
+            },
+        },
+    )
+    mcp = DummyMCP()
+    _register(mcp)
+
+    await mcp.tools["kiwoom_mock_get_orderable_cash"](
+        symbol="005930", side="buy", price=70000
+    )
+
+    orderable_calls = [c for c in calls if c.get("method") == "orderable_amount"]
+    assert len(orderable_calls) == 1
+    assert orderable_calls[0]["side"] == "buy"
+    assert orderable_calls[0]["price"] == 70000
+
+
+@pytest.mark.asyncio
+async def test_orderable_cash_without_symbol_calls_deposit(monkeypatch):
     from app.mcp_server.tooling import orders_kiwoom_variants as mod
 
     calls = _patch_fake_kiwoom_account_client(
@@ -1001,7 +1032,8 @@ async def test_orderable_cash_without_symbol_calls_balance(monkeypatch):
         mod,
         payloads={
             "orderable_amount": {"return_code": 0},
-            "balance": {"return_code": 0, "return_msg": "정상", "entr": "987654"},
+            "deposit": {"return_code": 0, "return_msg": "정상", "ord_alow_amt": "987654"},
+            "balance": {"return_code": 0},
             "order_status": {"return_code": 0},
         },
     )
@@ -1011,13 +1043,13 @@ async def test_orderable_cash_without_symbol_calls_balance(monkeypatch):
     response = await mcp.tools["kiwoom_mock_get_orderable_cash"]()
 
     assert response["success"] is True
-    assert response["broker_response"]["entr"] == "987654"
+    assert response["broker_response"]["ord_alow_amt"] == "987654"
     assert response["cash"] == 987654
-    assert response["cash_source"] == "balance"
-    assert response["provenance"]["api_id"] == "kt00018"
+    assert response["cash_source"] == "deposit"
+    assert response["provenance"]["api_id"] == "kt00001"
     assert response["provenance"]["host"] == "mockapi.kiwoom.com"
-    assert any(c.get("method") == "balance" for c in calls)
-    assert all(c.get("method") != "orderable_amount" for c in calls)
+    assert any(c.get("method") == "deposit" for c in calls)
+    assert all(c.get("method") not in ("orderable_amount", "balance") for c in calls)
 
 
 @pytest.mark.asyncio
@@ -1034,37 +1066,37 @@ async def test_orderable_cash_without_symbol_calls_balance(monkeypatch):
         (
             "005930",
             "orderable_amount",
-            {"return_code": 0, "ord_psbl_cash": "not-a-number"},
+            {"return_code": 0, "ord_alowa": "not-a-number"},
             "kt00010",
             "orderable_amount_unavailable",
         ),
         (
             "005930",
             "orderable_amount",
-            {"return_code": 0, "ord_psbl_cash": "-1"},
+            {"return_code": 0, "ord_alowa": "-1"},
             "kt00010",
             "orderable_amount_unavailable",
         ),
         (
             None,
-            "balance",
+            "deposit",
             {"return_code": 0, "some_unknown_field": "x"},
-            "kt00018",
-            "balance_unavailable",
+            "kt00001",
+            "deposit_unavailable",
         ),
         (
             None,
-            "balance",
-            {"return_code": 0, "entr": "not-a-number"},
-            "kt00018",
-            "balance_unavailable",
+            "deposit",
+            {"return_code": 0, "ord_alow_amt": "not-a-number"},
+            "kt00001",
+            "deposit_unavailable",
         ),
         (
             None,
-            "balance",
-            {"return_code": 0, "entr": "-1"},
-            "kt00018",
-            "balance_unavailable",
+            "deposit",
+            {"return_code": 0, "ord_alow_amt": "-1"},
+            "kt00001",
+            "deposit_unavailable",
         ),
     ],
 )
@@ -1074,8 +1106,9 @@ async def test_orderable_cash_unavailable_evidence_fails_closed(
     from app.mcp_server.tooling import orders_kiwoom_variants as mod
 
     payloads = {
-        "orderable_amount": {"return_code": 0, "ord_psbl_cash": "1500000"},
-        "balance": {"return_code": 0, "entr": "987654"},
+        "orderable_amount": {"return_code": 0, "ord_alowa": "1500000"},
+        "deposit": {"return_code": 0, "ord_alow_amt": "987654"},
+        "balance": {"return_code": 0},
         "order_status": {"return_code": 0},
     }
     payloads[payload_key] = payload
@@ -1110,9 +1143,9 @@ async def test_orderable_cash_unavailable_evidence_fails_closed(
             False,
         ),
         ("005930", "orderable_amount", "kt00010", "orderable_amount_unavailable", 0.5),
-        (None, "balance", "kt00018", "balance_unavailable", 40),
-        (None, "balance", "kt00018", "balance_unavailable", False),
-        (None, "balance", "kt00018", "balance_unavailable", 0.5),
+        (None, "deposit", "kt00001", "deposit_unavailable", 40),
+        (None, "deposit", "kt00001", "deposit_unavailable", False),
+        (None, "deposit", "kt00001", "deposit_unavailable", 0.5),
     ],
 )
 async def test_orderable_cash_broker_rejection_has_stable_failure_source(
@@ -1121,8 +1154,9 @@ async def test_orderable_cash_broker_rejection_has_stable_failure_source(
     from app.mcp_server.tooling import orders_kiwoom_variants as mod
 
     payloads = {
-        "orderable_amount": {"return_code": 0, "ord_psbl_cash": "1500000"},
-        "balance": {"return_code": 0, "entr": "987654"},
+        "orderable_amount": {"return_code": 0, "ord_alowa": "1500000"},
+        "deposit": {"return_code": 0, "ord_alow_amt": "987654"},
+        "balance": {"return_code": 0},
         "order_status": {"return_code": 0},
     }
     payloads[payload_key] = {
@@ -1143,7 +1177,14 @@ async def test_orderable_cash_broker_rejection_has_stable_failure_source(
 
 
 @pytest.mark.asyncio
-async def test_orderable_cash_broker_error_is_fail_closed(monkeypatch):
+@pytest.mark.parametrize(
+    ("symbol", "api_id"),
+    [
+        ("005930", "kt00010"),
+        (None, "kt00001"),
+    ],
+)
+async def test_orderable_cash_broker_error_is_fail_closed(monkeypatch, symbol, api_id):
     from app.mcp_server.tooling import orders_kiwoom_variants as mod
 
     class FakeKiwoomMockClient:
@@ -1158,6 +1199,9 @@ async def test_orderable_cash_broker_error_is_fail_closed(monkeypatch):
         async def get_orderable_amount(self, **kwargs):  # noqa: ARG002
             raise RuntimeError("boom")
 
+        async def get_deposit(self, **kwargs):  # noqa: ARG002
+            raise RuntimeError("boom")
+
         async def get_balance(self, **kwargs):  # noqa: ARG002
             raise RuntimeError("boom")
 
@@ -1169,14 +1213,14 @@ async def test_orderable_cash_broker_error_is_fail_closed(monkeypatch):
     mcp = DummyMCP()
     _register(mcp)
 
-    response = await mcp.tools["kiwoom_mock_get_orderable_cash"](symbol="005930")
+    response = await mcp.tools["kiwoom_mock_get_orderable_cash"](symbol=symbol)
 
     assert response["success"] is False
     assert response["error"] == "kiwoom_mock_transport_error"
     assert "RuntimeError" in response["error_detail"]
     assert response["account_mode"] == "kiwoom_mock"
     assert response["cash"] is None
-    assert response["provenance"]["api_id"] == "kt00010"
+    assert response["provenance"]["api_id"] == api_id
 
 
 @pytest.mark.asyncio
@@ -1399,7 +1443,7 @@ def _assert_stable_read_failure(
     ("symbol", "payload_key", "api_id"),
     [
         ("005930", "orderable_amount", "kt00010"),
-        (None, "balance", "kt00018"),
+        (None, "deposit", "kt00001"),
     ],
 )
 async def test_orderable_cash_both_branches_fail_closed_on_live_provenance(
@@ -1408,8 +1452,9 @@ async def test_orderable_cash_both_branches_fail_closed_on_live_provenance(
     from app.mcp_server.tooling import orders_kiwoom_variants as mod
 
     payloads = {
-        "orderable_amount": {"return_code": 0, "ord_psbl_cash": "1500000"},
-        "balance": {"return_code": 0, "entr": "987654"},
+        "orderable_amount": {"return_code": 0, "ord_alowa": "1500000"},
+        "deposit": {"return_code": 0, "ord_alow_amt": "987654"},
+        "balance": {"return_code": 0},
         "order_status": {"return_code": 0},
     }
     payloads[payload_key]["provenance"] = {"environment": "live"}
@@ -1584,7 +1629,7 @@ async def test_registered_reads_config_failure_has_stable_envelope(
     ("symbol", "api_id", "cash_source"),
     [
         ("005930", "kt00010", "orderable_amount_unavailable"),
-        (None, "kt00018", "balance_unavailable"),
+        (None, "kt00001", "deposit_unavailable"),
     ],
 )
 async def test_registered_cash_config_failure_has_stable_source(

--- a/tests/test_mcp_kiwoom_order_variants.py
+++ b/tests/test_mcp_kiwoom_order_variants.py
@@ -1032,7 +1032,11 @@ async def test_orderable_cash_without_symbol_calls_deposit(monkeypatch):
         mod,
         payloads={
             "orderable_amount": {"return_code": 0},
-            "deposit": {"return_code": 0, "return_msg": "정상", "ord_alow_amt": "987654"},
+            "deposit": {
+                "return_code": 0,
+                "return_msg": "정상",
+                "ord_alow_amt": "987654",
+            },
             "balance": {"return_code": 0},
             "order_status": {"return_code": 0},
         },


### PR DESCRIPTION
## Summary

Fixes the no-symbol `get_orderable_cash` path that incorrectly called `kt00018` (잔고/balance) instead of `kt00001` (예수금상세현황/deposit detail).

## Changes

### Service layer
- **constants.py**: Add `ACCOUNT_DEPOSIT_API_ID = "kt00001"` and `TRADE_TYPE_BUY/SELL` constants
- **domestic_account.py**: Add `get_deposit()` method (kt00001); update `get_orderable_amount()` to accept optional `side`/`price` for kt00010 `trde_tp`/`uv` fields
- **normalization.py**: Add `normalize_deposit()` (kt00001 → `ord_alow_amt` only) and `normalize_orderable_cash()` (kt00010 → `ord_alowa` only) with strict signed/zero-padded/comma-grouped parsing

### MCP tooling
- **orders_kiwoom_variants.py**: Route no-symbol path to `get_deposit()`/`kt00001`; replace permissive `_extract_orderable_cash` multi-field fallback with per-endpoint normalizers; update `cash_source` strings (`balance` → `deposit`); add `side`/`price` params to `kiwoom_mock_get_orderable_cash` tool

### What was wrong
- No-symbol path called `kt00018` (잔고) which returns positions/balance, not orderable cash
- `_ORDERABLE_CASH_KEYS` used permissive cross-endpoint field guessing (`entr`, `ord_psbl_cash`, etc.)
- `prsm_dpst_aset_amt` from kt00018 could overestimate buying power if used as cash

### What is fixed
- No-symbol → `kt00001` / `ord_alow_amt` (authoritative)
- Symbol+side+price → `kt00010` / `ord_alowa` (authoritative) with `trde_tp`/`uv`
- `prsm_dpst_aset_amt` is never a cash candidate
- 0 is valid; missing/malformed/negative → fail-closed
- Provenance/redaction/evidence contract preserved

## Test plan
- [x] `test_kiwoom_constants.py` — `ACCOUNT_DEPOSIT_API_ID == "kt00001"`
- [x] `test_kiwoom_domestic_account.py` — `get_deposit()` uses kt00001 + dmst_stex_tp; `get_orderable_amount()` sends trde_tp/uv when side/price provided
- [x] `test_kiwoom_mock_normalization.py` — deposit/orderable_cash normalizer tests (zero-padded, signed, comma-grouped, missing, malformed, negative, prsm_dpst_aset_amt rejection, cross-endpoint rejection)
- [x] `test_mcp_kiwoom_order_variants.py` — all no-symbol tests updated (kt00018→kt00001, balance→deposit, entr→ord_alow_amt); symbol path tests updated (ord_psbl_cash→ord_alowa); parametrized failure/provenance/config tables updated
- [x] All 215 focused tests pass
- [x] Ruff + ty clean

Closes ROB-891