### PR TITLE
fix(ROB-892): add process-local serial VTS order pacer (1/s)

### DIFF
--- a/app/services/brokers/kis/domestic_orders.py
+++ b/app/services/brokers/kis/domestic_orders.py
@@ -12,6 +12,7 @@ from . import constants
 from .base import _log_kis_api_failure
 from .pre_send import PreSendHook
 from .send_outcome import OrderSendOutcomeTracker
+from .vts_order_pacer import get_vts_order_pacer
 
 if TYPE_CHECKING:
     from .protocols import KISClientProtocol
@@ -318,6 +319,9 @@ class DomesticOrderClient:
             f"수량: {quantity}주, 가격: {price if price > 0 else '시장가'}, "
             f"tr_id: {tr_id}, routing: {body['EXCG_ID_DVSN_CD']}"
         )
+
+        if is_mock:
+            await get_vts_order_pacer().acquire()
 
         js = await self._parent._request_with_rate_limit(
             "POST",

--- a/app/services/brokers/kis/overseas_orders.py
+++ b/app/services/brokers/kis/overseas_orders.py
@@ -9,6 +9,7 @@ from app.core.symbol import to_kis_symbol
 
 from . import constants
 from .pre_send import PreSendHook
+from .vts_order_pacer import get_vts_order_pacer
 
 if TYPE_CHECKING:
     from .protocols import KISClientProtocol
@@ -190,6 +191,9 @@ class OverseasOrderClient:
             body.get("ORD_QTY"),
             body.get("OVRS_ORD_UNPR"),
         )
+
+        if is_mock:
+            await get_vts_order_pacer().acquire()
 
         js = await self._parent._request_with_rate_limit(
             "POST",

--- a/app/services/brokers/kis/vts_order_pacer.py
+++ b/app/services/brokers/kis/vts_order_pacer.py
@@ -1,0 +1,74 @@
+"""ROB-892: process-local serial pacer for VTS (KIS mock) order POSTs.
+
+The official KIS mock REST limit is 1 order per second (per account/app-key).
+The existing ``AsyncSlidingWindowRateLimiter`` keys on ``TR_ID|path``, so buy
+and sell have independent 8/s budgets that allow bursts. This pacer serializes
+all VTS order POSTs (buy + sell, domestic + overseas) through a single
+process-local gate with a minimum 1-second interval between dispatches.
+
+Design:
+- ``asyncio.Lock`` + monotonic clock → strict serial ordering.
+- Injectable ``clock`` / ``sleep`` for deterministic concurrent tests.
+- Module-level singleton so every mock order path shares one gate.
+- No retry, no Redis, no distributed coordination (process-local scope only).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from collections.abc import Awaitable, Callable
+
+_VTS_ORDER_MIN_INTERVAL_SECONDS = 1.0
+
+_pacer: VTSOrderPacer | None = None
+
+
+class VTSOrderPacer:
+    """Process-local serial pacer enforcing a minimum interval between dispatches."""
+
+    __slots__ = ("_min_interval", "_clock", "_sleep", "_last_dispatch", "_lock")
+
+    def __init__(
+        self,
+        *,
+        min_interval: float = _VTS_ORDER_MIN_INTERVAL_SECONDS,
+        clock: Callable[[], float] | None = None,
+        sleep: Callable[[float], Awaitable[None]] | None = None,
+    ) -> None:
+        self._min_interval = min_interval
+        self._clock = clock or time.monotonic
+        self._sleep = sleep or asyncio.sleep
+        self._last_dispatch: float = 0.0
+        self._lock = asyncio.Lock()
+
+    async def acquire(self) -> float:
+        """Block until at least ``min_interval`` has passed since the last dispatch.
+
+        Returns the actual wait time in seconds (0.0 if no wait was needed).
+        """
+        async with self._lock:
+            now = self._clock()
+            elapsed = now - self._last_dispatch
+            wait = max(0.0, self._min_interval - elapsed)
+            if wait > 0:
+                await self._sleep(wait)
+            self._last_dispatch = self._clock()
+            return wait
+
+    def reset(self) -> None:
+        self._last_dispatch = 0.0
+
+
+def get_vts_order_pacer() -> VTSOrderPacer:
+    """Return the process-local singleton pacer."""
+    global _pacer
+    if _pacer is None:
+        _pacer = VTSOrderPacer()
+    return _pacer
+
+
+def reset_vts_order_pacer() -> None:
+    """Discard the singleton so the next ``get_vts_order_pacer`` creates a fresh one."""
+    global _pacer
+    _pacer = None

--- a/tests/brokers/kis/test_vts_order_pacer.py
+++ b/tests/brokers/kis/test_vts_order_pacer.py
@@ -1,0 +1,128 @@
+"""ROB-892: VTS order pacer — process-local serial gate for mock order POSTs."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable
+
+import pytest
+
+from app.services.brokers.kis.vts_order_pacer import VTSOrderPacer
+
+
+class FakeClock:
+    def __init__(self, start: float = 1000.0) -> None:
+        self._now = start
+
+    def __call__(self) -> float:
+        return self._now
+
+    def advance(self, seconds: float) -> None:
+        self._now += seconds
+
+
+def _make_instant_sleep(clock: FakeClock) -> Callable[[float], Awaitable[None]]:
+    """Return a sleep that advances the fake clock instead of blocking."""
+
+    async def _sleep(seconds: float) -> None:
+        clock.advance(seconds)
+
+    return _sleep
+
+
+@pytest.mark.asyncio
+async def test_first_dispatch_no_wait():
+    clock = FakeClock()
+    pacer = VTSOrderPacer(clock=clock, sleep=_make_instant_sleep(clock))
+    wait = await pacer.acquire()
+    assert wait == 0.0
+
+
+@pytest.mark.asyncio
+async def test_second_dispatch_within_interval_waits():
+    clock = FakeClock()
+    pacer = VTSOrderPacer(clock=clock, sleep=_make_instant_sleep(clock))
+    await pacer.acquire()
+    clock.advance(0.3)
+    wait = await pacer.acquire()
+    assert wait == pytest.approx(0.7, abs=0.01)
+
+
+@pytest.mark.asyncio
+async def test_dispatch_after_interval_no_wait():
+    clock = FakeClock()
+    pacer = VTSOrderPacer(clock=clock, sleep=_make_instant_sleep(clock))
+    await pacer.acquire()
+    clock.advance(1.5)
+    wait = await pacer.acquire()
+    assert wait == 0.0
+
+
+@pytest.mark.asyncio
+async def test_concurrent_buy_sell_share_gate():
+    clock = FakeClock()
+    pacer = VTSOrderPacer(clock=clock, sleep=_make_instant_sleep(clock))
+
+    dispatch_times: list[float] = []
+
+    async def _dispatch(side: str) -> str:
+        await pacer.acquire()
+        dispatch_times.append(clock())
+        return side
+
+    results = await asyncio.gather(_dispatch("buy"), _dispatch("sell"))
+
+    assert set(results) == {"buy", "sell"}
+    assert len(dispatch_times) == 2
+    gap = dispatch_times[1] - dispatch_times[0]
+    assert gap >= 1.0
+
+
+@pytest.mark.asyncio
+async def test_three_parallel_calls_serialize_without_burst():
+    clock = FakeClock()
+    pacer = VTSOrderPacer(clock=clock, sleep=_make_instant_sleep(clock))
+
+    dispatch_times: list[float] = []
+
+    async def _dispatch(idx: int) -> int:
+        await pacer.acquire()
+        dispatch_times.append(clock())
+        return idx
+
+    await asyncio.gather(*[_dispatch(i) for i in range(3)])
+
+    assert len(dispatch_times) == 3
+    for i in range(1, len(dispatch_times)):
+        gap = dispatch_times[i] - dispatch_times[i - 1]
+        assert gap >= 1.0
+
+
+@pytest.mark.asyncio
+async def test_reset_clears_last_dispatch():
+    clock = FakeClock()
+    pacer = VTSOrderPacer(clock=clock, sleep=_make_instant_sleep(clock))
+    await pacer.acquire()
+    clock.advance(0.1)
+    pacer.reset()
+    wait = await pacer.acquire()
+    assert wait == 0.0
+
+
+@pytest.mark.asyncio
+async def test_real_sleep_does_not_block_other_tasks():
+    """With real asyncio.sleep, a waiting pacer yields control to the event loop."""
+
+    pacer = VTSOrderPacer(min_interval=0.05)
+    flag = False
+
+    async def _background():
+        nonlocal flag
+        await asyncio.sleep(0.01)
+        flag = True
+
+    await pacer.acquire()
+    bg = asyncio.create_task(_background())
+    await pacer.acquire()
+    await bg
+    assert flag


### PR DESCRIPTION
## Summary

KIS mock VTS orders used the same 8/s per-TR_ID rate limiter as live, with buy/sell on independent limiter keys. Concurrent `kis_mock_place_order` calls burst and hit `EGW00201` (초당 거래건수 초과), causing 1 of 3 parallel orders to fail.

## Root Cause

- `DEFAULT_KIS_API_RATE_LIMITS` applies live 8/s to mock order TRs
- Limiter key is `TR_ID|path`, so buy (`VTTC0012U`) and sell (`VTTC0011U`) have independent budgets
- Sliding-window allows boundary bursts
- Official KIS mock REST limit is **1 order/second** per account/app-key

## Fix

Add a process-local serial pacer (`VTSOrderPacer`) at the VTS order POST boundary:

- **Buy/sell share a single gate** (domestic + overseas mock orders)
- **Minimum 1-second interval** between actual dispatches
- **Injectable clock/sleep** for deterministic concurrent tests (no real sleeping)
- Runs **BEFORE** the rate limiter wait; `pre_send_hook` fires right before POST
- **Only active for `is_mock=True`** — live order paths are completely unchanged
- **No retry on EGW00201** — ROB-645's `retry_request_errors=False` + `max_retries_override=0` contract is preserved
- **Process-local only** — Redis/distributed limiter deferred to ROB-851 scope

## Files Changed

- `app/services/brokers/kis/vts_order_pacer.py` (new) — pacer class + singleton
- `app/services/brokers/kis/domestic_orders.py` — `if is_mock: await pacer.acquire()` before dispatch
- `app/services/brokers/kis/overseas_orders.py` — same integration for overseas mock orders
- `tests/brokers/kis/test_vts_order_pacer.py` (new) — 7 tests

## Test Coverage

- First dispatch: no wait
- Second dispatch within interval: waits remaining time
- Dispatch after interval: no wait
- Concurrent buy/sell share same gate (gap ≥1s)
- 3 parallel calls serialize without burst (each gap ≥1s)
- Reset clears last dispatch
- Real asyncio.sleep yields control to event loop

## What This Does NOT Change

- Live order rate limits or dispatch path
- Non-order read API rate limits
- ROB-645 retry=0 / no-re-POST contract
- Cross-process coordination (deferred to ROB-851)

Official limit reference: [KIS API Portal](https://apiportal.koreainvestment.com/community/10000000-0000-0011-0000-000000000001/post/d0d1a83f-6f8d-4437-9700-6d26702fd989)

Closes ROB-892

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of mock domestic and overseas stock orders by pacing requests.
  * Prevented rapid successive mock orders from exceeding supported request intervals.
  * Ensured concurrent mock orders are dispatched in a controlled, serialized manner.

* **Tests**
  * Added coverage for pacing intervals, concurrent orders, reset behavior, and asynchronous waiting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->