### PR TITLE
test(ROB-895): serialize decision-history report cleanup

### DIFF
--- a/tests/services/test_decision_history_realized_r.py
+++ b/tests/services/test_decision_history_realized_r.py
@@ -8,6 +8,11 @@ from app.models.investment_reports import InvestmentReport, InvestmentReportItem
 from app.services import decision_history as dh
 from app.services.trade_journal.forecast_service import _normalize_symbol_for_filter
 
+# This file writes investment-report rows through the shared ``db_session``.
+# Serialize it with the helper fixture cleanup so xdist workers cannot race an
+# INSERT against ``TRUNCATE ... investment_reports ... CASCADE``.
+pytestmark = pytest.mark.usefixtures("investment_reports_cleanup_lock")
+
 
 def _digit_symbol() -> str:
     return ("9" + uuid.uuid4().hex[:9])[:10].upper()


### PR DESCRIPTION
## Summary

- apply the existing investment_reports_cleanup_lock to the realized-R decision-history test module
- prevent xdist INSERT versus TRUNCATE deadlocks on the shared test database
- change test isolation only; production code and database schema are unchanged

## Evidence

The same deadlock hit PR #1545 and PR #1543 in tests/services/test_decision_history_realized_r.py::test_realized_r_by_tag_present_and_bounded.

## Verification

- 9 focused decision-history tests passed
- 3 repeated xdist loadfile runs passed: 29 tests each
- Ruff check and format passed
- ty passed

Linear: ROB-895