### PR TITLE
feat(ROB-885): add read-only retrospective action triage UX

### DIFF
--- a/frontend/invest/src/__tests__/DesktopInsightsPage.test.tsx
+++ b/frontend/invest/src/__tests__/DesktopInsightsPage.test.tsx
@@ -125,6 +125,7 @@ test("renders the dedicated read-only insights scaffold", () => {
   // ROB-678: retrospectives panel mounted under a 학습·회고 section
   expect(screen.getByRole("heading", { name: "학습·회고" })).toBeInTheDocument();
   expect(screen.getByTestId("retrospectives-panel")).toBeInTheDocument();
+  expect(screen.getByTestId("retro-actions")).toBeInTheDocument();
 });
 
 test("shows the accumulating banner when all three data panels are empty (ROB-677)", async () => {
@@ -147,8 +148,8 @@ test("shows the accumulating banner when all three data panels are empty (ROB-67
       body = { success: true, count: 0, filters: {}, artifacts: [] };
     } else if (u.includes("/session-context")) {
       body = { success: true, count: 0, filters: {}, entries: [] };
-    } else if (u.includes("next-actions")) {
-      body = { market: "all", symbol: null, count: 0, scan_limit: 200, items: [] };
+    } else if (u.includes("/actions")) {
+      body = { total: 0, count: 0, limit: 10, offset: 0, as_of: "2026-07-03T00:00:00Z", items: [] };
     } else if (u.includes("retrospectives")) {
       body = { market: "all", trigger_type: null, root_cause_class: null, symbol: null, count: 0, total: 0, items: [], as_of: "2026-07-03T00:00:00Z" };
     }
@@ -226,8 +227,8 @@ function buildCrosslinkFetchMock(retroSymbol: string) {
       body = { success: true, count: 0, filters: {}, artifacts: [] };
     } else if (u.includes("/session-context")) {
       body = { success: true, count: 0, filters: {}, entries: [] };
-    } else if (u.includes("next-actions")) {
-      body = { market: "all", symbol: null, count: 0, scan_limit: 200, items: [] };
+    } else if (u.includes("/actions")) {
+      body = { total: 0, count: 0, limit: 10, offset: 0, as_of: "2026-07-03T00:00:00Z", items: [] };
     } else if (u.includes("retrospectives")) {
       body = {
         market: "all", trigger_type: null, root_cause_class: null, symbol: null, count: 1, total: 1, as_of: "2026-07-03T00:00:00Z",

--- a/frontend/invest/src/__tests__/RetrospectiveActionHosts.test.tsx
+++ b/frontend/invest/src/__tests__/RetrospectiveActionHosts.test.tsx
@@ -1,0 +1,117 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
+
+import { MobileInsightsPage } from "../pages/mobile/MobileInsightsPage";
+import { DesktopPortfolioPage } from "../pages/desktop/DesktopPortfolioPage";
+import { MobilePortfolioPage } from "../pages/mobile/MobilePortfolioPage";
+import { useCommonPreferredDisparity } from "../hooks/useCommonPreferredDisparity";
+import { useMarketParity } from "../hooks/useMarketParity";
+import { useInvestHome } from "../hooks/useInvestHome";
+import { AccountPanelProvider } from "../desktop/AccountPanelProvider";
+import { mockRightRail } from "../test/mockRightRail";
+import type { InvestHomeResponse } from "../types/invest";
+
+vi.mock("../hooks/useMarketParity", () => ({ useMarketParity: vi.fn() }));
+vi.mock("../hooks/useCommonPreferredDisparity", () => ({
+  useCommonPreferredDisparity: vi.fn(),
+}));
+vi.mock("../hooks/useInvestHome", () => ({ useInvestHome: vi.fn() }));
+
+const emptyActionsBody = {
+  total: 0, count: 0, limit: 10, offset: 0,
+  as_of: "2026-07-15T00:00:00Z", items: [],
+};
+const emptyRetroBody = {
+  market: "all", trigger_type: null, root_cause_class: null, symbol: null,
+  outcome_filter: null, q: null, kst_date_from: null, kst_date_to: null,
+  count: 0, total: 0, items: [], as_of: "2026-07-15T00:00:00Z",
+};
+
+function stubFetchForPanels() {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (url: string) => {
+      const u = String(url);
+      let body: unknown = {};
+      if (u.includes("/scoreboard")) {
+        body = { group_by: "strategy", market: "all", kst_date_from: null, kst_date_to: null, count: 0, groups: [], as_of: "2026-07-15T00:00:00Z", totals: { sample_size: 0, wins: 0, misses: 0, decided: 0, win_rate_pct: null, realized_pnl_sum: {}, fx_pnl_krw_sum: 0, total_pnl_krw_sum: 0, excluded_no_fill_evidence: 0 } };
+      } else if (u.includes("/calibration")) {
+        body = { group_by: "created_by", created_by: null, symbol: null, instrument_type: null, days: null, count: 0, groups: [], as_of: "2026-07-15T00:00:00Z" };
+      } else if (u.includes("/forecasts/open") || u.includes("/forecasts/closed")) {
+        body = { kind: "open", symbol: null, created_by: null, instrument_type: null, count: 0, items: [], as_of: "2026-07-15T00:00:00Z" };
+      } else if (u.includes("/artifacts")) {
+        body = { success: true, count: 0, filters: {}, artifacts: [] };
+      } else if (u.includes("/session-context")) {
+        body = { success: true, count: 0, filters: {}, entries: [] };
+      } else if (u.includes("/actions")) {
+        body = emptyActionsBody;
+      } else if (u.includes("retrospectives")) {
+        body = emptyRetroBody;
+      }
+      return { ok: true, status: 200, json: async () => body };
+    }) as unknown as typeof fetch,
+  );
+}
+
+const minimalHome: InvestHomeResponse = {
+  homeSummary: {
+    includedSources: [], excludedSources: [], totalValueKrw: 0,
+    costBasisKrw: null, pnlKrw: null, pnlRate: null,
+  },
+  accounts: [],
+  holdings: [],
+  groupedHoldings: [],
+  meta: { warnings: [], hiddenCounts: { upbitInactive: 0, upbitDust: 0 }, hiddenHoldings: [] },
+};
+
+beforeEach(() => {
+  localStorage.clear();
+  mockRightRail();
+  stubFetchForPanels();
+  vi.mocked(useMarketParity).mockReturnValue({
+    state: { status: "ready", data: { asOf: "x", market: "kr", state: "fresh", emptyReason: null, warnings: [], notes: [], cards: [] } },
+    reload: vi.fn(),
+  });
+  vi.mocked(useCommonPreferredDisparity).mockReturnValue({ status: "ready", data: { asOf: "x", market: "kr", state: "fresh", emptyReason: null, warnings: [], notes: [], cards: [] } });
+  vi.mocked(useInvestHome).mockReturnValue({ state: { status: "ready", data: minimalHome }, reload: vi.fn() });
+});
+
+afterEach(() => vi.unstubAllGlobals());
+
+test("ROB-885: MobileInsightsPage (compact) mounts the canonical action section", async () => {
+  render(
+    <AccountPanelProvider>
+      <MemoryRouter basename="/invest" initialEntries={["/invest/insights"]}>
+        <MobileInsightsPage />
+      </MemoryRouter>
+    </AccountPanelProvider>,
+  );
+
+  await waitFor(() => expect(screen.getByTestId("retrospectives-panel")).toBeInTheDocument());
+  expect(screen.getByTestId("retro-actions")).toBeInTheDocument();
+});
+
+test("ROB-885: DesktopPortfolioPage 회고 tab (normal) mounts the canonical action section", async () => {
+  render(
+    <AccountPanelProvider>
+      <MemoryRouter basename="/invest" initialEntries={["/invest/my?tab=retrospectives"]}>
+        <DesktopPortfolioPage />
+      </MemoryRouter>
+    </AccountPanelProvider>,
+  );
+
+  await waitFor(() => expect(screen.getByTestId("retrospectives-panel")).toBeInTheDocument());
+  expect(screen.getByTestId("retro-actions")).toBeInTheDocument();
+});
+
+test("ROB-885: MobilePortfolioPage 회고 tab (compact) mounts the canonical action section", async () => {
+  render(
+    <MemoryRouter basename="/invest" initialEntries={["/invest/my?tab=retrospectives"]}>
+      <MobilePortfolioPage />
+    </MemoryRouter>,
+  );
+
+  await waitFor(() => expect(screen.getByTestId("retrospectives-panel")).toBeInTheDocument());
+  expect(screen.getByTestId("retro-actions")).toBeInTheDocument();
+});

--- a/frontend/invest/src/__tests__/RetrospectiveCard.test.tsx
+++ b/frontend/invest/src/__tests__/RetrospectiveCard.test.tsx
@@ -44,4 +44,44 @@ describe("RetrospectiveCard", () => {
     );
     expect(screen.queryByText("끝난 액션")).not.toBeInTheDocument();
   });
+
+  test("ROB-885: shows open and in_progress actions (explicit allowlist)", () => {
+    render(
+      <RetrospectiveCard
+        retrospectives={[
+          retro({
+            next_actions: [
+              { action: "열린 액션", status: "open" },
+              { action: "진행 액션", status: "in_progress" },
+            ],
+          }),
+        ]}
+      />,
+    );
+    expect(screen.getByText("열린 액션")).toBeInTheDocument();
+    expect(screen.getByText("진행 액션")).toBeInTheDocument();
+  });
+
+  test("ROB-885: hides obsolete, expired, missing-status, and unknown-status actions", () => {
+    render(
+      <RetrospectiveCard
+        retrospectives={[
+          retro({
+            next_actions: [
+              { action: "폐기 액션", status: "obsolete" },
+              { action: "만료 액션", status: "expired" },
+              { action: "상태누락 액션" },
+              { action: "알수없음 액션", status: "bogus" },
+              { action: "보여줘", status: "open" },
+            ],
+          }),
+        ]}
+      />,
+    );
+    expect(screen.queryByText("폐기 액션")).not.toBeInTheDocument();
+    expect(screen.queryByText("만료 액션")).not.toBeInTheDocument();
+    expect(screen.queryByText("상태누락 액션")).not.toBeInTheDocument();
+    expect(screen.queryByText("알수없음 액션")).not.toBeInTheDocument();
+    expect(screen.getByText("보여줘")).toBeInTheDocument();
+  });
 });

--- a/frontend/invest/src/__tests__/RetrospectivesPanel.test.tsx
+++ b/frontend/invest/src/__tests__/RetrospectivesPanel.test.tsx
@@ -2,7 +2,10 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { afterEach, expect, test, vi } from "vitest";
 import { RetrospectivesPanel } from "../components/my/RetrospectivesPanel";
-import type { NextActionsResponse, RetrospectivesResponse } from "../types/retrospectives";
+import type {
+  RetrospectiveActionsResponse,
+  RetrospectivesResponse,
+} from "../types/retrospectives";
 
 const list: RetrospectivesResponse = {
   market: "all", trigger_type: null, root_cause_class: null, symbol: null,
@@ -18,25 +21,40 @@ const list: RetrospectivesResponse = {
     policy_version: null, created_at: "2026-07-01T00:00:00Z",
   }],
 };
-const na: NextActionsResponse = {
-  market: "all", symbol: null, count: 1, scan_limit: 200,
-  items: [{
-    action: "재진입 룰 재검토", owner: null, issue_id: null, status: "open",
-    due_kst_date: "2026-07-10", symbol: "005930", market: "kr", retro_id: 1,
-    correlation_id: "c", trigger_type: "fill", realized_pnl: 1000,
-    created_at: "2026-07-01T00:00:00Z",
-  }],
-};
+
+function actionsFixture(overrides: Partial<RetrospectiveActionsResponse> = {}): RetrospectiveActionsResponse {
+  return {
+    total: 1, count: 1, limit: 10, offset: 0, as_of: "2026-07-01T00:00:00Z",
+    items: [{
+      action_id: "a1", version: 1, action: "재진입 룰 재검토",
+      owner: null, issue_id: null, status: "open", due_kst_date: "2026-07-10",
+      overdue: false, status_changed_at: null, resolved_at: null,
+      status_actor: null, status_source: null, status_reason: null,
+      retrospective_id: 1, correlation_id: "c", symbol: "005930", market: "kr",
+      trigger_type: "fill", outcome: "win", realized_pnl: 1000,
+      created_at: "2026-07-01T00:00:00Z",
+    }],
+    ...overrides,
+  };
+}
+
+function mockFetch(opts: { actions?: RetrospectiveActionsResponse } = {}) {
+  const actions = opts.actions ?? actionsFixture();
+  const calls: string[] = [];
+  const fetchMock = vi.fn((url: string) => {
+    calls.push(String(url));
+    return Promise.resolve({
+      ok: true,
+      json: async () => (String(url).includes("/actions") ? actions : list),
+    });
+  });
+  return { fetchMock, calls };
+}
 
 afterEach(() => vi.unstubAllGlobals());
 
-test("renders pinned next-action checklist and retrospective row", async () => {
-  const fetchMock = vi.fn((url: string) =>
-    Promise.resolve({
-      ok: true,
-      json: async () => (String(url).includes("next-actions") ? na : list),
-    }),
-  );
+test("renders canonical action queue and retrospective row", async () => {
+  const { fetchMock } = mockFetch();
   vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
 
   render(
@@ -49,10 +67,229 @@ test("renders pinned next-action checklist and retrospective row", async () => {
   expect(screen.getByText(/분할 매수가 유효했다/)).toBeInTheDocument();
 });
 
+test("ROB-885: action request always sends status=open,in_progress explicitly", async () => {
+  const { fetchMock, calls } = mockFetch();
+  vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+  render(
+    <MemoryRouter>
+      <RetrospectivesPanel />
+    </MemoryRouter>,
+  );
+  await waitFor(() => expect(screen.getByText("재진입 룰 재검토")).toBeInTheDocument());
+
+  const actionCall = calls.find((u) => u.includes("/actions"))!;
+  const params = new URLSearchParams(actionCall.split("?")[1]);
+  expect(params.get("status")).toBe("open,in_progress");
+});
+
+test("ROB-885: no legacy /next-actions network call", async () => {
+  const { calls } = mockFetch();
+  vi.stubGlobal("fetch", calls.length ? vi.fn() : vi.fn());
+
+  const fresh = mockFetch();
+  vi.stubGlobal("fetch", fresh.fetchMock as unknown as typeof fetch);
+
+  render(
+    <MemoryRouter>
+      <RetrospectivesPanel />
+    </MemoryRouter>,
+  );
+  await waitFor(() => expect(screen.getByText("재진입 룰 재검토")).toBeInTheDocument());
+
+  expect(fresh.calls.some((u) => u.includes("/next-actions"))).toBe(false);
+  expect(fresh.calls.some((u) => u.includes("/actions"))).toBe(true);
+});
+
+test("ROB-885: distinguishes open and in_progress with distinct labels", async () => {
+  const { fetchMock } = mockFetch({
+    actions: actionsFixture({
+      items: [
+        { ...actionsFixture().items[0]!, action_id: "a1", status: "open", action: "열린 작업" },
+        { ...actionsFixture().items[0]!, action_id: "a2", status: "in_progress", action: "진행 작업" },
+      ],
+      count: 2, total: 2,
+    }),
+  });
+  vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+  render(
+    <MemoryRouter>
+      <RetrospectivesPanel />
+    </MemoryRouter>,
+  );
+
+  await waitFor(() => expect(screen.getByText("열린 작업")).toBeInTheDocument());
+  expect(screen.getByText("진행 작업")).toBeInTheDocument();
+  expect(screen.getByText("예정")).toBeInTheDocument();
+  expect(screen.getByText("진행중")).toBeInTheDocument();
+});
+
+test("ROB-885: shows owner, issue id, due date, and overdue badge", async () => {
+  const { fetchMock } = mockFetch({
+    actions: actionsFixture({
+      items: [{
+        ...actionsFixture().items[0]!, action_id: "a1", action: "소유자 액션",
+        owner: "김개발", issue_id: "ROB-885", due_kst_date: "2026-07-10", overdue: true,
+      }],
+    }),
+  });
+  vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+  render(
+    <MemoryRouter>
+      <RetrospectivesPanel />
+    </MemoryRouter>,
+  );
+
+  await waitFor(() => expect(screen.getByText("소유자 액션")).toBeInTheDocument());
+  expect(screen.getByText(/김개발/)).toBeInTheDocument();
+  expect(screen.getByText(/ROB-885/)).toBeInTheDocument();
+  expect(screen.getByText(/2026-07-10/)).toBeInTheDocument();
+  expect(screen.getByText("지연")).toBeInTheDocument();
+});
+
+test("ROB-885: shows exact server total", async () => {
+  const { fetchMock } = mockFetch({
+    actions: actionsFixture({ total: 42, items: actionsFixture().items, count: 1 }),
+  });
+  vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+  render(
+    <MemoryRouter>
+      <RetrospectivesPanel />
+    </MemoryRouter>,
+  );
+
+  await waitFor(() => expect(screen.getByText(/미완료 액션 \(42\)/)).toBeInTheDocument());
+});
+
+test("ROB-885: shows dedicated action loading and error states", async () => {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn((url: string) => {
+      if (String(url).includes("/actions")) {
+        return Promise.resolve({ ok: false, status: 500 });
+      }
+      return Promise.resolve({ ok: true, json: async () => list });
+    }) as unknown as typeof fetch,
+  );
+
+  render(
+    <MemoryRouter>
+      <RetrospectivesPanel />
+    </MemoryRouter>,
+  );
+
+  await waitFor(() =>
+    expect(screen.getByText(/액션을 불러오지 못했습니다/)).toBeInTheDocument(),
+  );
+});
+
+test("ROB-885: shows action empty state when no active actions", async () => {
+  const { fetchMock } = mockFetch({
+    actions: actionsFixture({ total: 0, count: 0, items: [] }),
+  });
+  vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+  render(
+    <MemoryRouter>
+      <RetrospectivesPanel />
+    </MemoryRouter>,
+  );
+
+  await waitFor(() => expect(screen.getByText(/진행 중인 액션이 없습니다/)).toBeInTheDocument());
+});
+
+test("ROB-885: progressive expansion loads more actions via offset", async () => {
+  const { fetchMock, calls } = mockFetch({
+    actions: actionsFixture({
+      total: 25, count: 10, limit: 10, offset: 0,
+      items: Array.from({ length: 10 }, (_, i) => ({
+        ...actionsFixture().items[0]!, action_id: `a${i}`, action: `액션${i}`,
+      })),
+    }),
+  });
+  vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+  render(
+    <MemoryRouter>
+      <RetrospectivesPanel compact={false} />
+    </MemoryRouter>,
+  );
+
+  await waitFor(() => expect(screen.getByText("액션0")).toBeInTheDocument());
+
+  const moreBtn = await screen.findByRole("button", { name: /더 많은 액션 보기/ });
+  fireEvent.click(moreBtn);
+
+  await waitFor(() =>
+    expect(calls.some((u) => u.includes("offset=10"))).toBe(true),
+  );
+});
+
+test("ROB-885: filter change resets action offset to 0", async () => {
+  const { calls } = mockFetch({
+    actions: actionsFixture({ total: 25, count: 10, items: Array.from({ length: 10 }, (_, i) => ({ ...actionsFixture().items[0]!, action_id: `a${i}`, action: `액션${i}` })) }),
+  });
+  vi.stubGlobal("fetch", calls.length ? vi.fn() : vi.fn());
+
+  const fresh = mockFetch({
+    actions: actionsFixture({ total: 25, count: 10, items: Array.from({ length: 10 }, (_, i) => ({ ...actionsFixture().items[0]!, action_id: `a${i}`, action: `액션${i}` })) }),
+  });
+  vi.stubGlobal("fetch", fresh.fetchMock as unknown as typeof fetch);
+
+  render(
+    <MemoryRouter>
+      <RetrospectivesPanel compact={false} />
+    </MemoryRouter>,
+  );
+  await waitFor(() => expect(screen.getByText("액션0")).toBeInTheDocument());
+
+  fireEvent.click(screen.getByRole("button", { name: "국내" }));
+
+  await waitFor(() => {
+    const actionCalls = fresh.calls.filter((u) => u.includes("/actions"));
+    const last = actionCalls[actionCalls.length - 1]!;
+    expect(new URLSearchParams(last.split("?")[1]).get("offset")).toBe("0");
+    expect(new URLSearchParams(last.split("?")[1]).get("market")).toBe("kr");
+  });
+});
+
+test("ROB-885: shared filters — outcome/symbol/date forwarded to action request", async () => {
+  const { calls } = mockFetch();
+  vi.stubGlobal("fetch", vi.fn());
+  const fresh = mockFetch();
+  vi.stubGlobal("fetch", fresh.fetchMock as unknown as typeof fetch);
+
+  render(
+    <MemoryRouter>
+      <RetrospectivesPanel />
+    </MemoryRouter>,
+  );
+  await waitFor(() => expect(screen.getByText(/분할 매수가 유효했다/)).toBeInTheDocument());
+
+  fireEvent.click(screen.getByRole("button", { name: "승" }));
+  await waitFor(() =>
+    expect(fresh.calls.some((u) => u.includes("/actions") && u.includes("outcome_filter=win"))).toBe(true),
+  );
+});
+
+test("ROB-885: no mutation/PATCH request is issued", async () => {
+  const { fetchMock, calls } = mockFetch();
+  vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+  render(
+    <MemoryRouter>
+      <RetrospectivesPanel />
+    </MemoryRouter>,
+  );
+  await waitFor(() => expect(screen.getByText("재진입 룰 재검토")).toBeInTheDocument());
+
+  expect(calls.every((u) => !String(u).includes("PATCH") && !u.includes("/actions/"))).toBe(true);
+});
+
 test("retrospective crosslinks to its forecast by symbol key (ROB-682)", async () => {
-  // correlation_id is deliberately exec-style text ("toss_live:x") — the
-  // crosslink no longer keys on it (ROB-678's exact-id scheme was
-  // structurally dead since forecast/retro correlation_ids never overlap).
   const listExec: RetrospectivesResponse = {
     ...list,
     items: [{ ...list.items[0]!, correlation_id: "toss_live:x" }],
@@ -60,7 +297,7 @@ test("retrospective crosslinks to its forecast by symbol key (ROB-682)", async (
   const fetchMock = vi.fn((url: string) =>
     Promise.resolve({
       ok: true,
-      json: async () => (String(url).includes("next-actions") ? na : listExec),
+      json: async () => (String(url).includes("/actions") ? actionsFixture() : listExec),
     }),
   );
   vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
@@ -77,14 +314,7 @@ test("retrospective crosslinks to its forecast by symbol key (ROB-682)", async (
 });
 
 test("outcome chip refetches with outcome_filter (ROB-691)", async () => {
-  const calls: string[] = [];
-  const fetchMock = vi.fn((url: string) => {
-    calls.push(String(url));
-    return Promise.resolve({
-      ok: true,
-      json: async () => (String(url).includes("next-actions") ? na : list),
-    });
-  });
+  const { fetchMock, calls } = mockFetch();
   vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
 
   render(
@@ -101,14 +331,7 @@ test("outcome chip refetches with outcome_filter (ROB-691)", async () => {
 });
 
 test("symbol search input refetches with q (debounced, ROB-691)", async () => {
-  const calls: string[] = [];
-  const fetchMock = vi.fn((url: string) => {
-    calls.push(String(url));
-    return Promise.resolve({
-      ok: true,
-      json: async () => (String(url).includes("next-actions") ? na : list),
-    });
-  });
+  const { fetchMock, calls } = mockFetch();
   vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
 
   render(
@@ -127,14 +350,7 @@ test("symbol search input refetches with q (debounced, ROB-691)", async () => {
 });
 
 test("date range inputs refetch with kst_date_from/to (ROB-691)", async () => {
-  const calls: string[] = [];
-  const fetchMock = vi.fn((url: string) => {
-    calls.push(String(url));
-    return Promise.resolve({
-      ok: true,
-      json: async () => (String(url).includes("next-actions") ? na : list),
-    });
-  });
+  const { fetchMock, calls } = mockFetch();
   vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
 
   render(
@@ -160,12 +376,7 @@ test("date range inputs refetch with kst_date_from/to (ROB-691)", async () => {
 });
 
 test("compact mode hides symbol search and date range controls", async () => {
-  const fetchMock = vi.fn((url: string) =>
-    Promise.resolve({
-      ok: true,
-      json: async () => (String(url).includes("next-actions") ? na : list),
-    }),
-  );
+  const { fetchMock } = mockFetch();
   vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
 
   render(
@@ -178,6 +389,5 @@ test("compact mode hides symbol search and date range controls", async () => {
   expect(screen.queryByPlaceholderText("종목 검색")).not.toBeInTheDocument();
   expect(screen.queryByLabelText("시작일")).not.toBeInTheDocument();
   expect(screen.queryByLabelText("종료일")).not.toBeInTheDocument();
-  // outcome chips remain visible even in compact mode (small footprint, like market chips)
   expect(screen.getByRole("button", { name: "승" })).toBeInTheDocument();
 });

--- a/frontend/invest/src/__tests__/linearLink.test.ts
+++ b/frontend/invest/src/__tests__/linearLink.test.ts
@@ -1,0 +1,74 @@
+// ROB-885 — safe Linear issue URL builder. Pure helper, no React, no network.
+// Returns a validated HTTPS URL string or `null` (caller renders plain text).
+import { describe, expect, test } from "vitest";
+import { buildLinearIssueUrl } from "../linearLink";
+
+describe("buildLinearIssueUrl", () => {
+  test("returns HTTPS issue URL for valid ROB-<number> + configured workspace", () => {
+    expect(buildLinearIssueUrl("ROB-885", "https://linear.app/team")).toBe(
+      "https://linear.app/team/issue/ROB-885",
+    );
+  });
+
+  test("preserves existing workspace path segments and normalizes trailing slash", () => {
+    expect(buildLinearIssueUrl("ROB-1", "https://linear.app/my-team/")).toBe(
+      "https://linear.app/my-team/issue/ROB-1",
+    );
+    expect(buildLinearIssueUrl("ROB-1", "https://linear.app/a/b/c")).toBe(
+      "https://linear.app/a/b/c/issue/ROB-1",
+    );
+  });
+
+  test("returns null when workspace URL is missing/empty", () => {
+    expect(buildLinearIssueUrl("ROB-885", undefined)).toBeNull();
+    expect(buildLinearIssueUrl("ROB-885", "")).toBeNull();
+    expect(buildLinearIssueUrl("ROB-885", "   ")).toBeNull();
+  });
+
+  test("returns null for malformed URL", () => {
+    expect(buildLinearIssueUrl("ROB-885", "not-a-url")).toBeNull();
+    expect(buildLinearIssueUrl("ROB-885", "://no-host")).toBeNull();
+  });
+
+  test("returns null for non-HTTPS protocol", () => {
+    expect(buildLinearIssueUrl("ROB-885", "http://linear.app/team")).toBeNull();
+    expect(buildLinearIssueUrl("ROB-885", "ftp://linear.app/team")).toBeNull();
+    expect(buildLinearIssueUrl("ROB-885", "javascript:void(0)")).toBeNull();
+  });
+
+  test("returns null when URL carries credentials", () => {
+    expect(
+      buildLinearIssueUrl("ROB-885", "https://user:pass@linear.app/team"),
+    ).toBeNull();
+    expect(buildLinearIssueUrl("ROB-885", "https://user@linear.app/team")).toBeNull();
+  });
+
+  test("returns null when base URL includes a query string or hash", () => {
+    expect(
+      buildLinearIssueUrl("ROB-885", "https://linear.app/team?x=1"),
+    ).toBeNull();
+    expect(buildLinearIssueUrl("ROB-885", "https://linear.app/team#frag")).toBeNull();
+  });
+
+  test("returns null for invalid issue IDs", () => {
+    expect(buildLinearIssueUrl("rob-885", "https://linear.app/team")).toBeNull();
+    expect(buildLinearIssueUrl("ROB-", "https://linear.app/team")).toBeNull();
+    expect(buildLinearIssueUrl("ROB-abc", "https://linear.app/team")).toBeNull();
+    expect(buildLinearIssueUrl("ROB885", "https://linear.app/team")).toBeNull();
+    expect(buildLinearIssueUrl("", "https://linear.app/team")).toBeNull();
+    expect(buildLinearIssueUrl("https://evil.com/", "https://linear.app/team")).toBeNull();
+  });
+
+  test("issue ID cannot change host or escape the path (no path traversal)", () => {
+    // encodeURIComponent keeps these inert, but verify the result stays under
+    // the configured origin and path.
+    expect(buildLinearIssueUrl("ROB-1", "https://linear.app/team")).toBe(
+      "https://linear.app/team/issue/ROB-1",
+    );
+    // A URL-shaped issue id is rejected by the ROB-<number> guard, not turned
+    // into a link.
+    expect(
+      buildLinearIssueUrl("ROB-1/../../other", "https://linear.app/team"),
+    ).toBeNull();
+  });
+});

--- a/frontend/invest/src/__tests__/retrospectives.api.test.ts
+++ b/frontend/invest/src/__tests__/retrospectives.api.test.ts
@@ -1,6 +1,14 @@
 import { afterEach, expect, test, vi } from "vitest";
-import { fetchOpenNextActions, fetchRetrospectives } from "../api/retrospectives";
-import type { NextActionsResponse, RetrospectivesResponse } from "../types/retrospectives";
+import {
+  fetchOpenNextActions,
+  fetchRetrospectiveActions,
+  fetchRetrospectives,
+} from "../api/retrospectives";
+import type {
+  NextActionsResponse,
+  RetrospectiveActionsResponse,
+  RetrospectivesResponse,
+} from "../types/retrospectives";
 
 const listResponse: RetrospectivesResponse = {
   market: "kr", trigger_type: null, root_cause_class: null, symbol: null,
@@ -67,4 +75,83 @@ test("fetchOpenNextActions hits next-actions with scope", async () => {
 test("rejects non-OK responses", async () => {
   vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, status: 401 }));
   await expect(fetchRetrospectives({})).rejects.toThrow("retrospectives 401");
+});
+
+const actionsResponse: RetrospectiveActionsResponse = {
+  total: 0,
+  count: 0,
+  limit: 50,
+  offset: 0,
+  as_of: "2026-07-15T00:00:00Z",
+  items: [],
+};
+
+test("fetchRetrospectiveActions hits canonical /actions endpoint with explicit active status (ROB-885)", async () => {
+  const fetchMock = vi.fn().mockResolvedValue({
+    ok: true,
+    json: async () => actionsResponse,
+  });
+  vi.stubGlobal("fetch", fetchMock);
+
+  await expect(fetchRetrospectiveActions({})).resolves.toEqual(actionsResponse);
+
+  const [url, init] = fetchMock.mock.calls[0]!;
+  expect(init).toEqual({ credentials: "include" });
+  expect(String(url)).toMatch(/^\/trading\/api\/invest\/retrospectives\/actions\?/);
+  const params = new URLSearchParams(String(url).split("?")[1]);
+  // ROB-885 — always send explicit active status, never rely on server default.
+  expect(params.get("status")).toBe("open,in_progress");
+  expect(params.get("market")).toBe("all");
+});
+
+test("fetchRetrospectiveActions always sends status=open,in_progress even when other filters vary", async () => {
+  const fetchMock = vi.fn().mockResolvedValue({
+    ok: true,
+    json: async () => actionsResponse,
+  });
+  vi.stubGlobal("fetch", fetchMock);
+
+  await fetchRetrospectiveActions({
+    market: "us",
+    triggerType: "fill",
+    outcomeFilter: "win",
+    q: "AAPL",
+    dateFrom: "2026-07-01",
+    dateTo: "2026-07-04",
+    limit: 10,
+    offset: 20,
+  });
+
+  const [url] = fetchMock.mock.calls[0]!;
+  const params = new URLSearchParams(String(url).split("?")[1]);
+  expect(params.get("status")).toBe("open,in_progress");
+  expect(params.get("market")).toBe("us");
+  expect(params.get("trigger_type")).toBe("fill");
+  expect(params.get("outcome_filter")).toBe("win");
+  expect(params.get("q")).toBe("AAPL");
+  expect(params.get("kst_date_from")).toBe("2026-07-01");
+  expect(params.get("kst_date_to")).toBe("2026-07-04");
+  expect(params.get("limit")).toBe("10");
+  expect(params.get("offset")).toBe("20");
+});
+
+test("fetchRetrospectiveActions forwards pagination offset for progressive expansion (ROB-885)", async () => {
+  const fetchMock = vi.fn().mockResolvedValue({
+    ok: true,
+    json: async () => actionsResponse,
+  });
+  vi.stubGlobal("fetch", fetchMock);
+
+  await fetchRetrospectiveActions({ offset: 40 });
+
+  const [url] = fetchMock.mock.calls[0]!;
+  const params = new URLSearchParams(String(url).split("?")[1]);
+  expect(params.get("offset")).toBe("40");
+});
+
+test("fetchRetrospectiveActions rejects non-OK responses", async () => {
+  vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, status: 500 }));
+  await expect(fetchRetrospectiveActions({})).rejects.toThrow(
+    "retrospectives actions 500",
+  );
 });

--- a/frontend/invest/src/api/retrospectives.ts
+++ b/frontend/invest/src/api/retrospectives.ts
@@ -2,6 +2,7 @@ import type {
   NextActionsResponse,
   RetroMarket,
   RetroOutcomeFilter,
+  RetrospectiveActionsResponse,
   RetrospectivesResponse,
 } from "../types/retrospectives";
 
@@ -50,5 +51,35 @@ export async function fetchOpenNextActions(
   if (status) params.set("status", status);
   const res = await fetch(`${BASE}/next-actions?${params}`, { credentials: "include" });
   if (!res.ok) throw new Error(`retrospectives next-actions ${res.status}`);
+  return res.json();
+}
+
+export interface RetrospectiveActionsQuery {
+  market?: RetroMarket;
+  triggerType?: string;
+  outcomeFilter?: RetroOutcomeFilter;
+  q?: string;
+  dateFrom?: string;
+  dateTo?: string;
+  limit?: number;
+  offset?: number;
+}
+
+export async function fetchRetrospectiveActions(
+  q: RetrospectiveActionsQuery,
+): Promise<RetrospectiveActionsResponse> {
+  const params = new URLSearchParams({
+    market: q.market ?? "all",
+    status: "open,in_progress",
+  });
+  if (q.triggerType) params.set("trigger_type", q.triggerType);
+  if (q.outcomeFilter) params.set("outcome_filter", q.outcomeFilter);
+  if (q.q) params.set("q", q.q);
+  if (q.dateFrom) params.set("kst_date_from", q.dateFrom);
+  if (q.dateTo) params.set("kst_date_to", q.dateTo);
+  if (q.limit != null) params.set("limit", String(q.limit));
+  if (q.offset != null) params.set("offset", String(q.offset));
+  const res = await fetch(`${BASE}/actions?${params}`, { credentials: "include" });
+  if (!res.ok) throw new Error(`retrospectives actions ${res.status}`);
   return res.json();
 }

--- a/frontend/invest/src/components/my/RetrospectivesPanel.tsx
+++ b/frontend/invest/src/components/my/RetrospectivesPanel.tsx
@@ -1,16 +1,19 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { Link } from "react-router-dom";
 
-import { fetchOpenNextActions, fetchRetrospectives } from "../../api/retrospectives";
+import { fetchRetrospectiveActions, fetchRetrospectives } from "../../api/retrospectives";
 import { Pill } from "../../ds";
+import { buildLinearIssueUrl } from "../../linearLink";
 import { crosslinkAnchorSlug, crosslinkKey, retroMarket } from "../../insightsCrosslink";
 import { stockDetailPath } from "../../stockDetailPath";
 import type {
-  NextActionRow,
   RetroMarket,
   RetroOutcomeFilter,
+  RetrospectiveAction,
   RetrospectiveRow,
 } from "../../types/retrospectives";
+
+const LINEAR_WORKSPACE_URL = import.meta.env.VITE_LINEAR_WORKSPACE_URL;
 
 const MARKET_OPTIONS: { key: RetroMarket; label: string }[] = [
   { key: "all", label: "전체" },
@@ -32,8 +35,6 @@ const TRIGGER_OPTIONS: { key: string; label: string }[] = [
   { key: "guardrail_block", label: "가드레일" },
 ];
 
-// ROB-691 — win/loss/decided trade-history filter, forwarded as
-// outcome_filter. "" = no filter (all outcomes, decided or not).
 const OUTCOME_OPTIONS: { key: RetroOutcomeFilter | ""; label: string }[] = [
   { key: "", label: "전체" },
   { key: "win", label: "승" },
@@ -41,9 +42,14 @@ const OUTCOME_OPTIONS: { key: RetroOutcomeFilter | ""; label: string }[] = [
   { key: "decided", label: "결정" },
 ];
 
-// Debounce the free-text symbol search so every keystroke doesn't fire a
-// request; 300ms mirrors common UI debounce defaults elsewhere in the app.
 const SEARCH_DEBOUNCE_MS = 300;
+
+// ROB-885 — read-only triage UX. No mutation controls; the action network
+// call is GET-only and always requests status=open,in_progress explicitly.
+const ACTION_STATUS_LABEL: Record<string, { label: string; tone: "paper" | "accent" }> = {
+  open: { label: "예정", tone: "paper" },
+  in_progress: { label: "진행중", tone: "accent" },
+};
 
 function pnlText(row: { realized_pnl: number | null; realized_pnl_currency: string | null }): string {
   if (row.realized_pnl == null) return "—";
@@ -51,36 +57,105 @@ function pnlText(row: { realized_pnl: number | null; realized_pnl_currency: stri
   return `${sign}${row.realized_pnl.toLocaleString("ko-KR")} ${row.realized_pnl_currency ?? ""}`.trim();
 }
 
-function NextActionChecklist({ items }: { items: NextActionRow[] }) {
-  if (items.length === 0) return null;
+function ActionIssueLink({ issueId }: { issueId: string | null }) {
+  if (!issueId) return null;
+  const href = buildLinearIssueUrl(issueId, LINEAR_WORKSPACE_URL);
+  if (!href) {
+    return <span style={{ color: "var(--fg-3)", fontSize: 11 }}>· {issueId}</span>;
+  }
   return (
-    <div
-      data-testid="retro-next-actions"
-      style={{ margin: "0 14px 12px", padding: "10px 12px", borderRadius: 12, background: "var(--surface-2)" }}
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      style={{ color: "var(--link, #4a9)", textDecoration: "none", fontSize: 11, whiteSpace: "nowrap" }}
     >
-      <div style={{ fontSize: 12, fontWeight: 800, marginBottom: 6 }}>
-        미완료 액션 ({items.length})
+      · {issueId}
+    </a>
+  );
+}
+
+function ActionQueue({
+  state,
+  compact,
+  loadingMore,
+  onLoadMore,
+}: {
+  state:
+    | { status: "loading" }
+    | { status: "ready"; items: RetrospectiveAction[]; total: number; hasMore: boolean }
+    | { status: "error"; message: string };
+  compact: boolean;
+  loadingMore: boolean;
+  onLoadMore: () => void;
+}) {
+  if (state.status === "loading") {
+    return (
+      <div data-testid="retro-actions" style={{ margin: "0 14px 12px", padding: "10px 12px", borderRadius: 12, background: "var(--surface-2)" }}>
+        <div style={{ fontSize: 12, fontWeight: 800, marginBottom: 6 }}>미완료 액션</div>
+        <div style={{ fontSize: 13, color: "var(--fg-3)" }}>액션을 불러오는 중…</div>
       </div>
+    );
+  }
+  if (state.status === "error") {
+    return (
+      <div data-testid="retro-actions" role="alert" style={{ margin: "0 14px 12px", padding: "10px 12px", borderRadius: 12, background: "var(--surface-2)" }}>
+        <div style={{ fontSize: 12, fontWeight: 800, marginBottom: 6 }}>미완료 액션</div>
+        <div style={{ fontSize: 13, color: "var(--danger)" }}>액션을 불러오지 못했습니다. {state.message}</div>
+      </div>
+    );
+  }
+  const { items, total, hasMore } = state;
+  if (items.length === 0) {
+    return (
+      <div data-testid="retro-actions" style={{ margin: "0 14px 12px", padding: "10px 12px", borderRadius: 12, background: "var(--surface-2)" }}>
+        <div style={{ fontSize: 12, fontWeight: 800, marginBottom: 6 }}>미완료 액션 ({total})</div>
+        <div style={{ fontSize: 13, color: "var(--fg-3)" }}>진행 중인 액션이 없습니다.</div>
+      </div>
+    );
+  }
+  return (
+    <div data-testid="retro-actions" style={{ margin: "0 14px 12px", padding: "10px 12px", borderRadius: 12, background: "var(--surface-2)" }}>
+      <div style={{ fontSize: 12, fontWeight: 800, marginBottom: 6 }}>미완료 액션 ({total})</div>
       <div style={{ display: "grid", gap: 6 }}>
-        {items.map((a, idx) => {
-          const href = a.market ? stockDetailPath(a.market as "kr" | "us" | "crypto", a.symbol) : null;
-          const sym = (
-            <span style={{ fontWeight: 700 }}>
-              {href ? <Link to={href} style={{ color: "inherit", textDecoration: "none" }}>{a.symbol}</Link> : a.symbol}
-            </span>
-          );
+        {items.map((a) => {
+          const statusMeta = ACTION_STATUS_LABEL[a.status] ?? { label: a.status, tone: "paper" as const };
+          const href = a.market ? stockDetailPath(a.market as "kr" | "us" | "crypto", a.symbol ?? "") : null;
           return (
-            <div key={`${a.retro_id}-${idx}`} style={{ display: "flex", gap: 8, alignItems: "center", fontSize: 13 }}>
-              <Pill tone={a.status === "in_progress" ? "accent" : "paper"} size="sm">
-                {a.status === "in_progress" ? "진행중" : "예정"}
-              </Pill>
-              <span>{a.action}</span>
-              <span style={{ color: "var(--fg-3)", fontSize: 11 }}>· {sym}</span>
-              {a.due_kst_date && <span style={{ color: "var(--fg-3)", fontSize: 11 }}>· {a.due_kst_date}</span>}
+            <div key={a.action_id} style={{ display: "grid", gap: 3, fontSize: 13, padding: "4px 0", borderBottom: "1px solid var(--divider)" }}>
+              <div style={{ display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap" }}>
+                <Pill tone={statusMeta.tone} size="sm">{statusMeta.label}</Pill>
+                {a.overdue && <Pill tone="warn" size="sm">지연</Pill>}
+                <span>{a.action}</span>
+              </div>
+              <div style={{ display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap", color: "var(--fg-3)", fontSize: 11 }}>
+                {href && a.symbol ? (
+                  <Link to={href} style={{ color: "inherit", textDecoration: "none", fontWeight: 700 }}>{a.symbol}</Link>
+                ) : a.symbol ? (
+                  <span style={{ fontWeight: 700 }}>{a.symbol}</span>
+                ) : null}
+                {a.owner && <span>· 담당 {a.owner}</span>}
+                <ActionIssueLink issueId={a.issue_id} />
+                {a.due_kst_date && <span>· 마감 {a.due_kst_date}</span>}
+              </div>
             </div>
           );
         })}
       </div>
+      {hasMore && (
+        <button
+          type="button"
+          onClick={onLoadMore}
+          disabled={loadingMore}
+          style={{
+            marginTop: 8, border: "1px solid var(--border)", borderRadius: 8, padding: "4px 10px",
+            fontSize: 11, fontWeight: 700, cursor: loadingMore ? "default" : "pointer", fontFamily: "inherit",
+            background: "var(--surface)", color: "var(--fg-2)",
+          }}
+        >
+          {loadingMore ? "불러오는 중…" : compact ? "더 보기" : "더 많은 액션 보기"}
+        </button>
+      )}
     </div>
   );
 }
@@ -97,18 +172,25 @@ export function RetrospectivesPanel({
   const [market, setMarket] = useState<RetroMarket>("all");
   const [triggerType, setTriggerType] = useState<string>("");
   const [outcomeFilter, setOutcomeFilter] = useState<RetroOutcomeFilter | "">("");
-  // Raw input vs. debounced value: the raw value drives the <input>, the
-  // debounced value drives the fetch (ROB-691 — avoid firing a request per keystroke).
   const [symbolSearchInput, setSymbolSearchInput] = useState("");
   const [symbolSearch, setSymbolSearch] = useState("");
   const [dateFrom, setDateFrom] = useState("");
   const [dateTo, setDateTo] = useState("");
-  const [nextActions, setNextActions] = useState<NextActionRow[]>([]);
   const [state, setState] = useState<
     | { status: "loading" }
     | { status: "ready"; items: RetrospectiveRow[]; total: number }
     | { status: "error"; message: string }
   >({ status: "loading" });
+
+  const actionPageSize = compact ? 5 : 10;
+  const [actionOffset, setActionOffset] = useState(0);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [actionState, setActionState] = useState<
+    | { status: "loading" }
+    | { status: "ready"; items: RetrospectiveAction[]; total: number; hasMore: boolean }
+    | { status: "error"; message: string }
+  >({ status: "loading" });
+  const actionReqIdRef = useRef(0);
 
   useEffect(() => {
     const timer = setTimeout(() => setSymbolSearch(symbolSearchInput.trim()), SEARCH_DEBOUNCE_MS);
@@ -136,18 +218,76 @@ export function RetrospectivesPanel({
     return () => { cancelled = true; };
   }, [market, triggerType, outcomeFilter, symbolSearch, dateFrom, dateTo, compact]);
 
+  // ROB-885 — canonical action queue. Shares the same filter semantics as the
+  // retrospective list. Filter changes reset offset to 0. A request-id guard
+  // discards stale responses so a slow older fetch can't overwrite a newer one.
   useEffect(() => {
-    let cancelled = false;
-    fetchOpenNextActions(market)
-      .then((data) => { if (!cancelled) setNextActions(data.items); })
-      .catch(() => { if (!cancelled) setNextActions([]); });
-    return () => { cancelled = true; };
-  }, [market]);
+    const reqId = ++actionReqIdRef.current;
+    setActionOffset(0);
+    setLoadingMore(false);
+    setActionState({ status: "loading" });
+    fetchRetrospectiveActions({
+      market,
+      triggerType: triggerType || undefined,
+      outcomeFilter: outcomeFilter || undefined,
+      q: symbolSearch || undefined,
+      dateFrom: dateFrom || undefined,
+      dateTo: dateTo || undefined,
+      limit: actionPageSize,
+      offset: 0,
+    })
+      .then((data) => {
+        if (actionReqIdRef.current !== reqId) return;
+        setActionState({
+          status: "ready",
+          items: data.items,
+          total: data.total,
+          hasMore: data.offset + data.count < data.total,
+        });
+      })
+      .catch((err: unknown) => {
+        if (actionReqIdRef.current !== reqId) return;
+        setActionState({ status: "error", message: err instanceof Error ? err.message : String(err) });
+      });
+  }, [market, triggerType, outcomeFilter, symbolSearch, dateFrom, dateTo, actionPageSize]);
 
-  // Report retrospective symbol keys so a host page can crosslink them to
-  // matching closed forecasts (ROB-682 — re-keyed from correlation_id, which
-  // was structurally dead: forecast/retro id namespaces never overlap).
-  // No-op off /insights (prop undefined) — /my never passes this prop.
+  function handleLoadMoreActions() {
+    if (actionState.status !== "ready" || !actionState.hasMore || loadingMore) return;
+    const nextOffset = actionOffset + actionPageSize;
+    const reqId = ++actionReqIdRef.current;
+    setActionOffset(nextOffset);
+    setLoadingMore(true);
+    fetchRetrospectiveActions({
+      market,
+      triggerType: triggerType || undefined,
+      outcomeFilter: outcomeFilter || undefined,
+      q: symbolSearch || undefined,
+      dateFrom: dateFrom || undefined,
+      dateTo: dateTo || undefined,
+      limit: actionPageSize,
+      offset: nextOffset,
+    })
+      .then((data) => {
+        if (actionReqIdRef.current !== reqId) return;
+        setActionState((prev) => {
+          if (prev.status !== "ready") return prev;
+          return {
+            status: "ready",
+            items: [...prev.items, ...data.items],
+            total: data.total,
+            hasMore: data.offset + data.count < data.total,
+          };
+        });
+      })
+      .catch((err: unknown) => {
+        if (actionReqIdRef.current !== reqId) return;
+        setActionState({ status: "error", message: err instanceof Error ? err.message : String(err) });
+      })
+      .finally(() => {
+        if (actionReqIdRef.current === reqId) setLoadingMore(false);
+      });
+  }
+
   useEffect(() => {
     if (!onSymbolKeys) return;
     if (state.status !== "ready") return;
@@ -180,9 +320,6 @@ export function RetrospectivesPanel({
               </button>
             ))}
           </div>
-          {/* ROB-691 — win/loss/decided filter: small footprint like the
-              market chips above, so it stays visible in compact mode too
-              (unlike the wider trigger/search/date-range controls below). */}
           <div style={{ display: "flex", gap: 6, flexWrap: "wrap", alignSelf: "flex-end" }}>
             {OUTCOME_OPTIONS.map((option) => (
               <button key={option.key || "all"} type="button" onClick={() => setOutcomeFilter(option.key)}
@@ -235,7 +372,7 @@ export function RetrospectivesPanel({
         </div>
       </div>
 
-      <NextActionChecklist items={nextActions} />
+      <ActionQueue state={actionState} compact={compact} loadingMore={loadingMore} onLoadMore={handleLoadMoreActions} />
 
       {state.status === "loading" && (
         <div style={{ padding: 24, color: "var(--fg-3)", fontSize: 13, textAlign: "center" }}>회고를 불러오는 중…</div>
@@ -261,10 +398,6 @@ export function RetrospectivesPanel({
             </thead>
             <tbody>
               {(() => {
-                // Anchor ids are keyed by symbol, so a symbol with multiple
-                // retrospectives would otherwise emit duplicate DOM ids. Only
-                // the first matching row per key gets the anchor; the
-                // crosslink `<a>` still renders on every match.
                 const anchored = new Set<string>();
                 return rows.map((row) => {
                   const href = row.market ? stockDetailPath(row.market as "kr" | "us" | "crypto", row.symbol) : null;

--- a/frontend/invest/src/desktop/stock-detail/RetrospectiveCard.tsx
+++ b/frontend/invest/src/desktop/stock-detail/RetrospectiveCard.tsx
@@ -12,9 +12,13 @@ function pnlText(row: RetrospectiveRow): string {
   return `${sign}${row.realized_pnl.toLocaleString("ko-KR")} ${row.realized_pnl_currency ?? ""}`.trim();
 }
 
-function incompleteActions(row: RetrospectiveRow): string[] {
+// ROB-885 — explicit active allowlist. Only open|in_progress render; missing,
+// unknown, and terminal (done/obsolete/expired) statuses are inactive.
+const ACTIVE_ACTION_STATUSES = new Set(["open", "in_progress"]);
+
+function activeActions(row: RetrospectiveRow): string[] {
   return (row.next_actions ?? [])
-    .filter((a) => (a as { status?: string }).status !== "done")
+    .filter((a) => ACTIVE_ACTION_STATUSES.has(String((a as { status?: string }).status ?? "")))
     .map((a) => String((a as { action?: unknown }).action ?? ""))
     .filter(Boolean);
 }
@@ -35,7 +39,7 @@ export function RetrospectiveCard({ retrospectives }: { retrospectives: Retrospe
       {retrospectives && retrospectives.length > 0 ? (
         <div style={{ display: "grid", gap: 8 }}>
           {retrospectives.map((row) => {
-            const actions = incompleteActions(row);
+            const actions = activeActions(row);
             return (
               <div key={row.id} style={{ border: "1px solid var(--divider)", borderRadius: 12, padding: "10px 12px", display: "grid", gap: 6 }}>
                 <div style={{ display: "flex", justifyContent: "space-between", gap: 8, alignItems: "center" }}>

--- a/frontend/invest/src/linearLink.ts
+++ b/frontend/invest/src/linearLink.ts
@@ -1,0 +1,30 @@
+const ISSUE_ID_RE = /^ROB-\d+$/;
+
+// ROB-885 — build a safe HTTPS Linear issue URL, or return null so the caller
+// renders the issue id as plain text. Never hardcodes a workspace. The issue
+// id is appended via the URL API so it cannot mutate the host or base path.
+export function buildLinearIssueUrl(
+  issueId: string,
+  workspaceUrl: string | undefined,
+): string | null {
+  if (!issueId || !ISSUE_ID_RE.test(issueId)) return null;
+  const raw = workspaceUrl?.trim();
+  if (!raw) return null;
+
+  let base: URL;
+  try {
+    base = new URL(raw);
+  } catch {
+    return null;
+  }
+
+  if (base.protocol !== "https:") return null;
+  if (!base.hostname) return null;
+  if (base.username || base.password) return null;
+  if (base.search) return null;
+  if (base.hash) return null;
+
+  const path = base.pathname.replace(/\/+$/, "");
+  base.pathname = `${path}/issue/${encodeURIComponent(issueId)}`;
+  return base.href;
+}

--- a/frontend/invest/src/types/retrospectives.ts
+++ b/frontend/invest/src/types/retrospectives.ts
@@ -62,3 +62,37 @@ export interface NextActionsResponse {
   scan_limit: number;
   items: NextActionRow[];
 }
+
+// ROB-885 — must field-for-field match backend CanonicalActionRow.
+export interface RetrospectiveAction {
+  action_id: string;
+  version: number;
+  action: string;
+  owner: string | null;
+  issue_id: string | null;
+  status: string;
+  due_kst_date: string | null;
+  overdue: boolean;
+  status_changed_at: string | null;
+  resolved_at: string | null;
+  status_actor: string | null;
+  status_source: string | null;
+  status_reason: string | null;
+  retrospective_id: number;
+  correlation_id: string | null;
+  symbol: string | null;
+  market: string | null;
+  trigger_type: string | null;
+  outcome: string | null;
+  realized_pnl: number | null;
+  created_at: string | null;
+}
+
+export interface RetrospectiveActionsResponse {
+  total: number;
+  count: number;
+  limit: number;
+  offset: number;
+  as_of: string;
+  items: RetrospectiveAction[];
+}

--- a/frontend/invest/src/vite-env.d.ts
+++ b/frontend/invest/src/vite-env.d.ts
@@ -1,1 +1,9 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_LINEAR_WORKSPACE_URL?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}


### PR DESCRIPTION
## ROB-885 — `/invest` 회고 액션 read-only triage UX

Provides the canonical paginated action queue from ROB-880 as a read-only triage UX across all four `/invest` hosts.

### What changed

**Canonical endpoint + explicit active status**
- New `fetchRetrospectiveActions` hits `GET /trading/api/invest/retrospectives/actions`
- Always sends `status=open,in_progress` explicitly — never relies on the server default
- Action network calls are GET-only; no PATCH/mutation endpoint is called

**Shared filter / pagination**
- `RetrospectivesPanel` market/trigger/outcome/symbol/date filter state is shared between retrospective and action requests with the same semantics
- Filter changes reset the action offset to 0
- Progressive expansion (load-more) with a request-id guard that discards stale responses so a slow older fetch cannot overwrite a newer filter result

**Four-host coverage**
- DesktopInsightsPage (normal), MobileInsightsPage (compact)
- DesktopPortfolioPage 회고 tab (normal), MobilePortfolioPage 회고 tab (compact)
- All four verified to mount the canonical action section; a shared-component test alone does not replace host verification

**Safe Linear URL fallback**
- `buildLinearIssueUrl` reads `VITE_LINEAR_WORKSPACE_URL` at build time — never hardcodes a workspace
- HTTPS-only, rejects credentials/query/hash, `ROB-<number>` issue-id guard, URL-API path append (issue value cannot mutate host/base path)
- Missing/malformed/non-HTTPS/credential/query/hash config or invalid issue ID → plain-text fallback (no arbitrary URL navigation)
- New tabs use `rel="noopener noreferrer"`

**Stock-detail allowlist**
- `RetrospectiveCard` switches from `status !== "done"` to an explicit `open | in_progress` allowlist
- Missing, unknown, and terminal (`done`/`obsolete`/`expired`) statuses are inactive

**Read-only / mutation-free**
- No checkbox, status button, inline editor, or PATCH control was added
- Lifecycle transition, MCP, and projection retirement remain out of scope

### Backend contract

No backend changes — the canonical GET endpoint and `CanonicalActionRow` schema were delivered by ROB-880. This PR consumes the existing contract as-is.

### Test results

**Targeted (RED → GREEN):**
```
frontend/invest: 49 passed (retrospectives.api, RetrospectivesPanel, RetrospectiveCard,
                            DesktopInsightsPage, linearLink, RetrospectiveActionHosts)
backend router:  21 passed (tests/routers/test_invest_retrospectives_router.py)
```

**Full frontend:**
```
607 passed | 5 failed (pre-existing, unrelated — calendar/coverage/events)
npm run typecheck: clean
npm run build: success
make lint (ruff + ty): all checks passed
git diff --check: clean
```

The 5 pre-existing failures (ActionReadiness, DaySection, DesktopCalendarPage ×2, MonthlyEventsTimeline) were verified to fail on the clean base commit before these changes.

### Linear

ROB-885 — https://linear.app/mgh3326/issue/ROB-885