### PR TITLE
feat(ROB-881): add versioned retrospective action transition core

### DIFF
--- a/app/services/trade_journal/retrospective_action_repository.py
+++ b/app/services/trade_journal/retrospective_action_repository.py
@@ -591,6 +591,18 @@ class RetrospectiveActionRepository:
 
     # -- Projection ---------------------------------------------------------
 
+    async def rebuild_projection(self, retrospective_id: int) -> None:
+        """Public projection-rebuild entry point for sibling action writers.
+
+        ROB-881's transition service reuses this so projection logic is not
+        duplicated across action-writing boundaries. The caller MUST already
+        hold the parent row lock and all of that parent's child row locks
+        (parent ``FOR UPDATE`` then children ``ORDER BY id FOR UPDATE``),
+        exactly like :meth:`reconcile_actions`. The rebuild happens in the
+        caller's transaction; commit/rollback ownership stays with the caller.
+        """
+        await self._rebuild_projection(retrospective_id)
+
     async def _rebuild_projection(self, retrospective_id: int) -> None:
         """Rebuild parent JSONB projection from canonical children.
 

--- a/app/services/trade_journal/retrospective_action_transition.py
+++ b/app/services/trade_journal/retrospective_action_transition.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
-from datetime import UTC, datetime
+from datetime import datetime
 from typing import Any
 from uuid import UUID
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.timezone import now_kst
 from app.models.review import TradeRetrospective, TradeRetrospectiveAction
 from app.services.trade_journal.retrospective_action_repository import (
     ActionControlError,
@@ -213,6 +214,12 @@ async def transition_retrospective_action(
         raise _conflict(action, "expected_version does not match current version")
 
     if target_status == action.status:
+        _validate_transition_payload(
+            target_status=target_status,
+            actor=actor,
+            reason=reason,
+            evidence=evidence,
+        )
         return ActionTransitionResult(
             changed=False,
             idempotent=True,
@@ -226,7 +233,7 @@ async def transition_retrospective_action(
         reason=reason,
         evidence=evidence,
     )
-    changed_at = datetime.now(UTC)
+    changed_at = now_kst()
     resolved_at = changed_at if target_status in TERMINAL_STATUSES else None
     next_version = action.version + 1
 

--- a/app/services/trade_journal/retrospective_action_transition.py
+++ b/app/services/trade_journal/retrospective_action_transition.py
@@ -1,0 +1,265 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.review import TradeRetrospective, TradeRetrospectiveAction
+from app.services.trade_journal.retrospective_action_repository import (
+    ActionControlError,
+    RetrospectiveActionRepository,
+)
+from app.services.trade_journal.retrospective_action_types import (
+    ACTIVE_STATUSES,
+    ALL_STATUSES,
+    REASON_MAX_LENGTH,
+    TERMINAL_STATUSES,
+    ActionControlModeError,
+    ActionNotFoundError,
+    ActionStatus,
+    ActionTransitionConflict,
+    ActionTransitionInvalid,
+    ActionTransitionResult,
+    TransitionActor,
+    validate_operator_attestation,
+)
+
+
+def _normalize_reason(reason: str | None, *, required: bool) -> str | None:
+    if reason is None:
+        if required:
+            raise ActionTransitionInvalid("a non-blank reason is required")
+        return None
+    if not isinstance(reason, str):
+        raise ActionTransitionInvalid("reason must be a string")
+    normalized = reason.strip()
+    if not normalized:
+        if required:
+            raise ActionTransitionInvalid("a non-blank reason is required")
+        return None
+    if len(normalized) > REASON_MAX_LENGTH:
+        raise ActionTransitionInvalid(f"reason exceeds {REASON_MAX_LENGTH} characters")
+    return normalized
+
+
+def _validate_transition_payload(
+    *,
+    target_status: str,
+    actor: TransitionActor,
+    reason: str | None,
+    evidence: dict[str, object] | None,
+) -> tuple[str | None, dict[str, Any] | None]:
+    normalized_reason = _normalize_reason(
+        reason, required=target_status in {"obsolete", "expired"}
+    )
+
+    if target_status in ACTIVE_STATUSES:
+        if evidence is not None:
+            raise ActionTransitionInvalid(
+                "evidence is only permitted for terminal transitions"
+            )
+        return normalized_reason, None
+
+    if target_status == "expired" or (
+        target_status == "done" and actor.source == "reconciler"
+    ):
+        if evidence is None:
+            raise ActionTransitionInvalid(
+                f"{target_status} by {actor.source} requires authoritative evidence"
+            )
+        return normalized_reason, validate_operator_attestation(evidence)
+
+    if evidence is None:
+        return normalized_reason, None
+    return normalized_reason, validate_operator_attestation(evidence)
+
+
+def _snapshot(
+    action: TradeRetrospectiveAction,
+    *,
+    status: str | None = None,
+    version: int | None = None,
+    changed_at: datetime | None = None,
+    resolved_at: datetime | None = None,
+    actor: TransitionActor | None = None,
+    reason: str | None = None,
+) -> dict[str, Any]:
+    effective_status = status if status is not None else action.status
+    return {
+        "action_id": str(action.id),
+        "status": effective_status,
+        "version": version if version is not None else action.version,
+        "status_changed_at": (
+            changed_at if changed_at is not None else action.status_changed_at
+        ).isoformat(),
+        "resolved_at": (
+            resolved_at if resolved_at is not None else action.resolved_at
+        ).isoformat()
+        if (resolved_at is not None or action.resolved_at is not None)
+        else None,
+        "status_actor": actor.value if actor is not None else action.status_actor,
+        "status_source": actor.source if actor is not None else action.status_source,
+        "status_reason": reason if status is not None else action.status_reason,
+    }
+
+
+def _conflict(
+    action: TradeRetrospectiveAction, reason: str
+) -> ActionTransitionConflict:
+    return ActionTransitionConflict(
+        action_id=action.id,
+        status=action.status,
+        version=action.version,
+        reason=reason,
+    )
+
+
+def _terminal_retry_matches(
+    action: TradeRetrospectiveAction,
+    *,
+    reason: str | None,
+    evidence: dict[str, object] | None,
+) -> bool:
+    try:
+        normalized_reason = _normalize_reason(
+            reason, required=action.status in {"obsolete", "expired"}
+        )
+        normalized_evidence = (
+            validate_operator_attestation(evidence) if evidence is not None else None
+        )
+    except ActionTransitionInvalid:
+        return False
+    return (
+        normalized_reason == action.status_reason
+        and normalized_evidence == action.status_evidence
+    )
+
+
+async def transition_retrospective_action(
+    db: AsyncSession,
+    *,
+    action_id: UUID,
+    target_status: ActionStatus,
+    expected_version: int,
+    actor: TransitionActor,
+    reason: str | None,
+    evidence: dict[str, object] | None,
+    dry_run: bool = False,
+) -> ActionTransitionResult:
+    """Evaluate and optionally persist one canonical action transition."""
+    if target_status not in ALL_STATUSES:
+        raise ActionTransitionInvalid(f"unknown target status: {target_status!r}")
+    if not isinstance(expected_version, int) or isinstance(expected_version, bool):
+        raise ActionTransitionInvalid("expected_version must be an integer")
+    if expected_version < 1:
+        raise ActionTransitionInvalid("expected_version must be at least 1")
+    if len(actor.value) > 128:
+        raise ActionTransitionInvalid("transition actor exceeds 128 characters")
+
+    parent_id = await db.scalar(
+        select(TradeRetrospectiveAction.retrospective_id).where(
+            TradeRetrospectiveAction.id == action_id
+        )
+    )
+    if parent_id is None:
+        raise ActionNotFoundError(action_id)
+
+    repository = RetrospectiveActionRepository(db)
+    try:
+        mode = await repository.get_control_mode()
+    except ActionControlError as exc:
+        raise ActionControlModeError(None) from exc
+    if mode != "canonical":
+        raise ActionControlModeError(mode)
+
+    parent = await db.scalar(
+        select(TradeRetrospective)
+        .where(TradeRetrospective.id == parent_id)
+        .with_for_update()
+    )
+    if parent is None:
+        raise ActionNotFoundError(action_id)
+
+    locked_children = list(
+        (
+            await db.scalars(
+                select(TradeRetrospectiveAction)
+                .where(TradeRetrospectiveAction.retrospective_id == parent_id)
+                .order_by(TradeRetrospectiveAction.id)
+                .with_for_update()
+            )
+        ).all()
+    )
+    action = next((child for child in locked_children if child.id == action_id), None)
+    if action is None:
+        raise ActionNotFoundError(action_id)
+
+    if action.status in TERMINAL_STATUSES:
+        if target_status != action.status:
+            raise _conflict(action, "terminal actions cannot transition or reopen")
+        if not _terminal_retry_matches(action, reason=reason, evidence=evidence):
+            raise _conflict(action, "terminal audit payload does not match")
+        return ActionTransitionResult(
+            changed=False,
+            idempotent=True,
+            dry_run=dry_run,
+            action=_snapshot(action),
+        )
+
+    if expected_version != action.version:
+        raise _conflict(action, "expected_version does not match current version")
+
+    if target_status == action.status:
+        return ActionTransitionResult(
+            changed=False,
+            idempotent=True,
+            dry_run=dry_run,
+            action=_snapshot(action),
+        )
+
+    normalized_reason, normalized_evidence = _validate_transition_payload(
+        target_status=target_status,
+        actor=actor,
+        reason=reason,
+        evidence=evidence,
+    )
+    changed_at = datetime.now(UTC)
+    resolved_at = changed_at if target_status in TERMINAL_STATUSES else None
+    next_version = action.version + 1
+
+    if dry_run:
+        return ActionTransitionResult(
+            changed=True,
+            idempotent=False,
+            dry_run=True,
+            action=_snapshot(
+                action,
+                status=target_status,
+                version=next_version,
+                changed_at=changed_at,
+                resolved_at=resolved_at,
+                actor=actor,
+                reason=normalized_reason,
+            ),
+        )
+
+    action.status = target_status
+    action.version = next_version
+    action.status_changed_at = changed_at
+    action.status_actor = actor.value
+    action.status_source = actor.source
+    action.status_reason = normalized_reason
+    action.status_evidence = normalized_evidence
+    action.resolved_at = resolved_at
+    await db.flush()
+    await repository.rebuild_projection(parent_id)
+
+    return ActionTransitionResult(
+        changed=True,
+        idempotent=False,
+        dry_run=False,
+        action=_snapshot(action),
+    )

--- a/app/services/trade_journal/retrospective_action_types.py
+++ b/app/services/trade_journal/retrospective_action_types.py
@@ -1,0 +1,387 @@
+"""ROB-881 — typed domain core for retrospective action transitions.
+
+This module holds the pure domain vocabulary used by
+:mod:`app.services.trade_journal.retrospective_action_transition`. It defines
+no I/O and imports nothing from the ORM or HTTP layers, so the transition
+service stays a single boundary that HTTP/MCP/triage callers can reuse.
+
+Contracts enforced here (see ROB-878 design ``State Machine`` /
+``Evidence envelope``):
+
+* state graph — ``open``/``in_progress`` are active; ``done``/``obsolete``/
+  ``expired`` are terminal and immutable.
+* optimistic version — active transitions require the current version;
+  same-terminal retry is idempotent even with a stale version.
+* typed evidence — the manual ``operator_attestation`` envelope is an exact
+  six-key schema that rejects extras, secrets, raw payloads, and oversized or
+  deeply nested content.
+* caller-owned transactions — the service only flushes; commit/rollback
+  ownership stays with the caller. Exceptions are typed so ROB-882 can map
+  them to 404/409/422 without touching this layer.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, Literal
+
+# ---------------------------------------------------------------------------
+# Status vocabulary
+# ---------------------------------------------------------------------------
+
+#: All valid canonical action statuses.
+ActionStatus = Literal["open", "in_progress", "done", "obsolete", "expired"]
+
+ACTIVE_STATUSES: frozenset[str] = frozenset({"open", "in_progress"})
+TERMINAL_STATUSES: frozenset[str] = frozenset({"done", "obsolete", "expired"})
+ALL_STATUSES: frozenset[str] = ACTIVE_STATUSES | TERMINAL_STATUSES
+
+#: Transition ``status_source`` values permitted at this layer.
+ALLOWED_TRANSITION_SOURCES: frozenset[str] = frozenset(
+    {"web", "mcp", "triage", "reconciler"}
+)
+
+#: Reason text upper bound (mirrors the DB CHECK constraint).
+REASON_MAX_LENGTH = 2000
+
+#: Evidence envelope canonical UTF-8 JSON size bound.
+EVIDENCE_MAX_BYTES = 16 * 1024
+
+#: Maximum nesting depth of any evidence envelope.
+EVIDENCE_MAX_DEPTH = 5
+
+#: Maximum object key length in any evidence envelope.
+EVIDENCE_KEY_MAX_LENGTH = 64
+
+#: Maximum string value length in any evidence envelope.
+EVIDENCE_STRING_MAX_LENGTH = 2000
+
+#: Key fragments (case-insensitive) that may never appear in evidence keys.
+SECRET_KEY_FRAGMENTS: tuple[str, ...] = (
+    "secret",
+    "token",
+    "password",
+    "api_key",
+    "apikey",
+    "authorization",
+    "cookie",
+)
+
+#: The manual operator-attestation envelope — exactly these keys, in order.
+_OPERATOR_ATTESTATION_KEYS: tuple[str, ...] = (
+    "schema_version",
+    "kind",
+    "source",
+    "reference",
+    "observed_at",
+    "summary",
+)
+
+
+# ---------------------------------------------------------------------------
+# Transition actor (caller-attested identity, never caller-controlled string)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class TransitionActor:
+    """A typed transition actor.
+
+    The HTTP/MCP/triage boundaries build this from authenticated identity so a
+    caller can never inject an arbitrary ``status_actor`` string. ``source``
+    is one of :data:`ALLOWED_TRANSITION_SOURCES`; ``value`` is the derived
+    persisted actor string (e.g. ``user:42`` or ``mcp:tradingcodex_execution``).
+    """
+
+    source: str
+    value: str
+
+    def __post_init__(self) -> None:
+        if self.source not in ALLOWED_TRANSITION_SOURCES:
+            raise ActionTransitionInvalid(
+                f"invalid transition actor source: {self.source!r}"
+            )
+        if not self.value or not self.value.strip():
+            raise ActionTransitionInvalid("transition actor value must be non-empty")
+
+    # -- Factory constructors (preferred over hand-built values) ------------
+
+    @classmethod
+    def web(cls, user_id: int | str) -> TransitionActor:
+        """Web operator actor — ``user:<stable database user id>``."""
+        return cls(source="web", value=f"user:{user_id}")
+
+    @classmethod
+    def mcp(cls, profile: str) -> TransitionActor:
+        """MCP server actor — ``mcp:<server profile>``."""
+        if not profile or not profile.strip():
+            raise ActionTransitionInvalid("mcp actor profile must be non-empty")
+        return cls(source="mcp", value=f"mcp:{profile.strip()}")
+
+    @classmethod
+    def triage(cls, user_id: int | str) -> TransitionActor:
+        """Triage CLI actor — the approving stable user id."""
+        return cls(source="triage", value=f"user:{user_id}")
+
+    @classmethod
+    def reconciler(cls, binding: str) -> TransitionActor:
+        """Automated reconciler actor — ``reconciler:<binding>``."""
+        if not binding or not binding.strip():
+            raise ActionTransitionInvalid("reconciler binding must be non-empty")
+        return cls(source="reconciler", value=f"reconciler:{binding.strip()}")
+
+
+# ---------------------------------------------------------------------------
+# Typed domain exceptions (ROB-882 maps these to HTTP status codes)
+# ---------------------------------------------------------------------------
+
+
+class ActionTransitionError(Exception):
+    """Base class for all transition-core domain errors."""
+
+
+class ActionNotFoundError(ActionTransitionError):
+    """The target action id does not exist (ROB-882 → 404)."""
+
+    def __init__(self, action_id: Any) -> None:
+        self.action_id = action_id
+        super().__init__(f"retrospective action {action_id} not found")
+
+
+class ActionControlModeError(ActionTransitionError):
+    """Control mode is not canonical — writes fail closed (ROB-882 → 409)."""
+
+    def __init__(self, mode: str | None) -> None:
+        self.mode = mode
+        super().__init__(
+            "retrospective action control mode is not canonical; "
+            f"transitions are disabled (mode={mode!r})"
+        )
+
+
+class ActionTransitionConflict(ActionTransitionError):
+    """Optimistic-version or terminal-state conflict (ROB-882 → 409).
+
+    Carries the current ``action_id``/``status``/``version`` so the operator
+    surface can echo them in a 409 body without re-reading the row.
+    """
+
+    def __init__(
+        self,
+        *,
+        action_id: Any,
+        status: str,
+        version: int,
+        reason: str,
+    ) -> None:
+        self.action_id = action_id
+        self.status = status
+        self.version = version
+        self.reason = reason
+        super().__init__(
+            f"transition conflict for action {action_id} "
+            f"(status={status}, version={version}): {reason}"
+        )
+
+
+class ActionTransitionInvalid(ActionTransitionError):
+    """Invalid transition input — bad graph step, reason, or evidence (→ 422)."""
+
+
+# ---------------------------------------------------------------------------
+# Transition result
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ActionTransitionResult:
+    """Evaluated outcome of a transition request.
+
+    ``action`` is a snapshot of the evaluated action row after the transition
+    (or the stored row for an idempotent result). It never includes
+    ``legacy_payload`` or raw ``status_evidence``; callers that need those read
+    them through the repository.
+    """
+
+    changed: bool
+    idempotent: bool
+    dry_run: bool
+    action: dict[str, Any] = field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# Evidence envelope validation
+# ---------------------------------------------------------------------------
+
+
+def _is_blank(value: Any) -> bool:
+    return not isinstance(value, str) or value.strip() == ""
+
+
+def _max_depth(value: Any, depth: int = 0) -> int:
+    if isinstance(value, Mapping):
+        if not value:
+            return depth + 1
+        return max(_max_depth(v, depth + 1) for v in value.values())
+    if isinstance(value, (list, tuple)):
+        if not value:
+            return depth + 1
+        return max(_max_depth(v, depth + 1) for v in value)
+    return depth
+
+
+def _scan_for_secrets(value: Any) -> str | None:
+    """Return the first forbidden key fragment found, else ``None``.
+
+    Keys are matched case-insensitively at every nesting level so a buried
+    ``config.apiKey`` cannot smuggle a credential into the audit record.
+    """
+    if isinstance(value, Mapping):
+        for key, child in value.items():
+            if isinstance(key, str):
+                lowered = key.lower()
+                for fragment in SECRET_KEY_FRAGMENTS:
+                    if fragment in lowered:
+                        return fragment
+            found = _scan_for_secrets(child)
+            if found is not None:
+                return found
+    elif isinstance(value, (list, tuple)):
+        for child in value:
+            found = _scan_for_secrets(child)
+            if found is not None:
+                return found
+    return None
+
+
+def validate_operator_attestation(evidence: Any) -> dict[str, Any]:
+    """Validate and canonicalize a manual ``operator_attestation`` envelope.
+
+    Returns the canonical envelope (exactly the six keys, ordered). Raises
+    :class:`ActionTransitionInvalid` on any contract violation. Raw provider
+    payloads and credentials are never accepted: the envelope holds references
+    and a bounded summary only.
+    """
+    if evidence is None:
+        raise ActionTransitionInvalid("operator_attestation evidence is required")
+    if not isinstance(evidence, Mapping):
+        raise ActionTransitionInvalid(
+            "operator_attestation evidence must be a JSON object"
+        )
+
+    keys = set(evidence.keys())
+    expected = set(_OPERATOR_ATTESTATION_KEYS)
+    extra = keys - expected
+    if extra:
+        # Report the shape, never a value — extras may be a credential.
+        raise ActionTransitionInvalid(
+            f"operator_attestation evidence rejects unknown keys: {sorted(extra)}"
+        )
+    missing = expected - keys
+    if missing:
+        raise ActionTransitionInvalid(
+            f"operator_attestation evidence is missing required keys: {sorted(missing)}"
+        )
+
+    schema_version = evidence["schema_version"]
+    if schema_version != 1:
+        raise ActionTransitionInvalid(
+            f"unsupported operator_attestation schema_version: {schema_version!r}"
+        )
+
+    kind = evidence["kind"]
+    if kind != "operator_attestation":
+        raise ActionTransitionInvalid(
+            f"operator_attestation evidence kind must be 'operator_attestation', "
+            f"got {kind!r}"
+        )
+
+    source = evidence["source"]
+    reference = evidence["reference"]
+    summary = evidence["summary"]
+    if _is_blank(source):
+        raise ActionTransitionInvalid("operator_attestation source must be non-blank")
+    if _is_blank(reference):
+        raise ActionTransitionInvalid(
+            "operator_attestation reference must be non-blank"
+        )
+    if _is_blank(summary):
+        raise ActionTransitionInvalid("operator_attestation summary must be non-blank")
+
+    observed_at_raw = evidence["observed_at"]
+    if not isinstance(observed_at_raw, str):
+        raise ActionTransitionInvalid(
+            "operator_attestation observed_at must be an RFC3339 string"
+        )
+    observed_at_str = observed_at_raw.strip()
+    if not observed_at_str:
+        raise ActionTransitionInvalid(
+            "operator_attestation observed_at must be non-blank"
+        )
+    try:
+        observed_at = datetime.fromisoformat(observed_at_str)
+    except ValueError as exc:
+        raise ActionTransitionInvalid(
+            "operator_attestation observed_at must be RFC3339"
+        ) from exc
+    # Reject naive timestamps — an offset (or ``Z``) is mandatory.
+    if observed_at.tzinfo is None or observed_at.utcoffset() is None:
+        raise ActionTransitionInvalid(
+            "operator_attestation observed_at must include a timezone offset"
+        )
+
+    canonical: dict[str, Any] = {
+        "schema_version": 1,
+        "kind": "operator_attestation",
+        "source": source.strip(),
+        "reference": reference.strip(),
+        "observed_at": observed_at_str,
+        "summary": summary.strip(),
+    }
+
+    # Structural bounds (depth, key length, string length, secret scan).
+    depth = _max_depth(canonical)
+    if depth > EVIDENCE_MAX_DEPTH:
+        raise ActionTransitionInvalid(
+            f"operator_attestation evidence nesting depth {depth} exceeds limit "
+            f"{EVIDENCE_MAX_DEPTH}"
+        )
+    _enforce_string_bounds(canonical)
+    secret = _scan_for_secrets(canonical)
+    if secret is not None:
+        raise ActionTransitionInvalid(
+            "operator_attestation evidence rejects secret-like key "
+            f"(fragment={secret!r})"
+        )
+
+    encoded = json.dumps(canonical, ensure_ascii=False).encode("utf-8")
+    if len(encoded) > EVIDENCE_MAX_BYTES:
+        raise ActionTransitionInvalid(
+            f"operator_attestation evidence exceeds {EVIDENCE_MAX_BYTES} bytes"
+        )
+
+    return canonical
+
+
+def _enforce_string_bounds(value: Any) -> None:
+    """Recursively enforce key/string length limits, raising on violation."""
+    if isinstance(value, Mapping):
+        for key, child in value.items():
+            if isinstance(key, str) and len(key) > EVIDENCE_KEY_MAX_LENGTH:
+                raise ActionTransitionInvalid(
+                    f"operator_attestation evidence key exceeds "
+                    f"{EVIDENCE_KEY_MAX_LENGTH} characters"
+                )
+            _enforce_string_bounds(child)
+    elif isinstance(value, str):
+        if len(value) > EVIDENCE_STRING_MAX_LENGTH:
+            raise ActionTransitionInvalid(
+                f"operator_attestation evidence string exceeds "
+                f"{EVIDENCE_STRING_MAX_LENGTH} characters"
+            )
+    elif isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+        for child in value:
+            _enforce_string_bounds(child)

--- a/app/services/trade_journal/retrospective_action_types.py
+++ b/app/services/trade_journal/retrospective_action_types.py
@@ -23,6 +23,7 @@ Contracts enforced here (see ROB-878 design ``State Machine`` /
 from __future__ import annotations
 
 import json
+import re
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from datetime import datetime
@@ -80,6 +81,17 @@ _OPERATOR_ATTESTATION_KEYS: tuple[str, ...] = (
     "summary",
 )
 
+_ACTOR_PREFIXES = {
+    "web": "user:",
+    "triage": "user:",
+    "mcp": "mcp:",
+    "reconciler": "reconciler:",
+}
+
+_RFC3339_PATTERN = re.compile(
+    r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$"
+)
+
 
 # ---------------------------------------------------------------------------
 # Transition actor (caller-attested identity, never caller-controlled string)
@@ -106,6 +118,13 @@ class TransitionActor:
             )
         if not self.value or not self.value.strip():
             raise ActionTransitionInvalid("transition actor value must be non-empty")
+        normalized = self.value.strip()
+        prefix = _ACTOR_PREFIXES[self.source]
+        if not normalized.startswith(prefix) or not normalized[len(prefix) :].strip():
+            raise ActionTransitionInvalid(
+                "transition actor value does not match its source"
+            )
+        object.__setattr__(self, "value", normalized)
 
     # -- Factory constructors (preferred over hand-built values) ------------
 
@@ -272,32 +291,38 @@ def validate_operator_attestation(evidence: Any) -> dict[str, Any]:
             "operator_attestation evidence must be a JSON object"
         )
 
+    depth = _max_depth(evidence)
+    if depth > EVIDENCE_MAX_DEPTH:
+        raise ActionTransitionInvalid(
+            f"operator_attestation evidence nesting depth {depth} exceeds limit "
+            f"{EVIDENCE_MAX_DEPTH}"
+        )
+    _enforce_string_bounds(evidence)
+    if _scan_for_secrets(evidence) is not None:
+        raise ActionTransitionInvalid(
+            "operator_attestation evidence rejects a secret-like key"
+        )
+
     keys = set(evidence.keys())
     expected = set(_OPERATOR_ATTESTATION_KEYS)
     extra = keys - expected
     if extra:
-        # Report the shape, never a value — extras may be a credential.
         raise ActionTransitionInvalid(
-            f"operator_attestation evidence rejects unknown keys: {sorted(extra)}"
+            "operator_attestation evidence rejects unknown keys"
         )
     missing = expected - keys
     if missing:
         raise ActionTransitionInvalid(
-            f"operator_attestation evidence is missing required keys: {sorted(missing)}"
+            "operator_attestation evidence is missing required keys"
         )
 
     schema_version = evidence["schema_version"]
     if schema_version != 1:
-        raise ActionTransitionInvalid(
-            f"unsupported operator_attestation schema_version: {schema_version!r}"
-        )
+        raise ActionTransitionInvalid("operator_attestation schema_version must be 1")
 
     kind = evidence["kind"]
     if kind != "operator_attestation":
-        raise ActionTransitionInvalid(
-            f"operator_attestation evidence kind must be 'operator_attestation', "
-            f"got {kind!r}"
-        )
+        raise ActionTransitionInvalid("operator_attestation evidence kind is invalid")
 
     source = evidence["source"]
     reference = evidence["reference"]
@@ -321,13 +346,20 @@ def validate_operator_attestation(evidence: Any) -> dict[str, Any]:
         raise ActionTransitionInvalid(
             "operator_attestation observed_at must be non-blank"
         )
+    if _RFC3339_PATTERN.fullmatch(observed_at_str) is None:
+        raise ActionTransitionInvalid(
+            "operator_attestation observed_at must be RFC3339"
+        )
     try:
-        observed_at = datetime.fromisoformat(observed_at_str)
+        observed_at = datetime.fromisoformat(
+            observed_at_str[:-1] + "+00:00"
+            if observed_at_str.endswith("Z")
+            else observed_at_str
+        )
     except ValueError as exc:
         raise ActionTransitionInvalid(
             "operator_attestation observed_at must be RFC3339"
         ) from exc
-    # Reject naive timestamps — an offset (or ``Z``) is mandatory.
     if observed_at.tzinfo is None or observed_at.utcoffset() is None:
         raise ActionTransitionInvalid(
             "operator_attestation observed_at must include a timezone offset"
@@ -342,22 +374,9 @@ def validate_operator_attestation(evidence: Any) -> dict[str, Any]:
         "summary": summary.strip(),
     }
 
-    # Structural bounds (depth, key length, string length, secret scan).
-    depth = _max_depth(canonical)
-    if depth > EVIDENCE_MAX_DEPTH:
-        raise ActionTransitionInvalid(
-            f"operator_attestation evidence nesting depth {depth} exceeds limit "
-            f"{EVIDENCE_MAX_DEPTH}"
-        )
-    _enforce_string_bounds(canonical)
-    secret = _scan_for_secrets(canonical)
-    if secret is not None:
-        raise ActionTransitionInvalid(
-            "operator_attestation evidence rejects secret-like key "
-            f"(fragment={secret!r})"
-        )
-
-    encoded = json.dumps(canonical, ensure_ascii=False).encode("utf-8")
+    encoded = json.dumps(
+        canonical, ensure_ascii=False, sort_keys=True, separators=(",", ":")
+    ).encode("utf-8")
     if len(encoded) > EVIDENCE_MAX_BYTES:
         raise ActionTransitionInvalid(
             f"operator_attestation evidence exceeds {EVIDENCE_MAX_BYTES} bytes"
@@ -370,7 +389,11 @@ def _enforce_string_bounds(value: Any) -> None:
     """Recursively enforce key/string length limits, raising on violation."""
     if isinstance(value, Mapping):
         for key, child in value.items():
-            if isinstance(key, str) and len(key) > EVIDENCE_KEY_MAX_LENGTH:
+            if not isinstance(key, str):
+                raise ActionTransitionInvalid(
+                    "operator_attestation evidence keys must be strings"
+                )
+            if len(key) > EVIDENCE_KEY_MAX_LENGTH:
                 raise ActionTransitionInvalid(
                     f"operator_attestation evidence key exceeds "
                     f"{EVIDENCE_KEY_MAX_LENGTH} characters"

--- a/tests/test_rob878_transition_core.py
+++ b/tests/test_rob878_transition_core.py
@@ -1,0 +1,1009 @@
+from __future__ import annotations
+
+import asyncio
+import uuid
+from collections.abc import AsyncIterator
+from datetime import UTC, date, datetime, timedelta
+from unittest.mock import AsyncMock
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import delete, event, text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.db import AsyncSessionLocal, engine
+from app.models.review import TradeRetrospective, TradeRetrospectiveAction
+from app.services.trade_journal.retrospective_action_types import (
+    EVIDENCE_MAX_BYTES,
+    EVIDENCE_MAX_DEPTH,
+    EVIDENCE_STRING_MAX_LENGTH,
+    ActionControlModeError,
+    ActionNotFoundError,
+    ActionTransitionConflict,
+    ActionTransitionInvalid,
+    TransitionActor,
+    _max_depth,
+    validate_operator_attestation,
+)
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.usefixtures("investment_reports_cleanup_lock"),
+    pytest.mark.usefixtures("retrospective_action_control_lock"),
+]
+
+
+def _evidence(**overrides: object) -> dict[str, object]:
+    value: dict[str, object] = {
+        "schema_version": 1,
+        "kind": "operator_attestation",
+        "source": "postmortem review",
+        "reference": "ROB-881:test",
+        "observed_at": "2026-07-15T12:00:00+09:00",
+        "summary": "authoritative operator observation",
+    }
+    value.update(overrides)
+    return value
+
+
+def _terminal_payload(status: str) -> tuple[str | None, dict[str, object] | None]:
+    if status == "done":
+        return "completed", None
+    if status == "obsolete":
+        return "superseded", None
+    if status == "expired":
+        return "validity condition ended", _evidence()
+    return None, None
+
+
+async def _set_mode(db: AsyncSession, mode: str) -> None:
+    await db.execute(
+        text(
+            "INSERT INTO review.trade_retrospective_action_control (id, mode) "
+            "VALUES (1, :mode) ON CONFLICT (id) DO UPDATE SET mode = :mode, "
+            "cutover_at = CASE WHEN :mode = 'canonical' THEN now() ELSE NULL END, "
+            "cutover_action_count = CASE WHEN :mode = 'canonical' THEN "
+            "(SELECT count(*) FROM review.trade_retrospective_actions) ELSE NULL END"
+        ),
+        {"mode": mode},
+    )
+    await db.commit()
+
+
+async def _seed_action(
+    db: AsyncSession,
+    *,
+    status: str = "open",
+    version: int = 1,
+    position: int = 0,
+    parent_id: int | None = None,
+    due_kst_date: date | None = None,
+    reason: str | None = None,
+    evidence: dict[str, object] | None = None,
+    legacy_payload: dict[str, object] | None = None,
+) -> tuple[int, uuid.UUID]:
+    retrospective_id = parent_id or (2_000_000_000 + uuid.uuid4().int % 1_000_000_000)
+    parent = await db.get(TradeRetrospective, retrospective_id)
+    if parent is None:
+        parent = TradeRetrospective(
+            id=retrospective_id,
+            correlation_id=f"rob881-{uuid.uuid4()}",
+            symbol="005930",
+            instrument_type="equity_kr",
+            account_mode="kis_mock",
+            market="kr",
+            outcome="filled",
+        )
+        db.add(parent)
+        await db.flush()
+
+    is_terminal = status in {"done", "obsolete", "expired"}
+    status_reason, status_evidence = _terminal_payload(status)
+    row = TradeRetrospectiveAction(
+        id=uuid.uuid4(),
+        retrospective_id=retrospective_id,
+        position=position,
+        action=f"action-{position}",
+        status=status,
+        due_kst_date=due_kst_date,
+        version=version,
+        status_changed_at=datetime.now(UTC) - timedelta(days=1),
+        resolved_at=datetime.now(UTC) - timedelta(hours=1) if is_terminal else None,
+        status_actor="user:original" if is_terminal else "migration:rob-878",
+        status_source="web" if is_terminal else "migration",
+        status_reason=reason if reason is not None else status_reason,
+        status_evidence=evidence if evidence is not None else status_evidence,
+        legacy_payload=legacy_payload
+        or {"action": f"action-{position}", "custom": f"preserve-{position}"},
+    )
+    db.add(row)
+    await db.commit()
+    return retrospective_id, row.id
+
+
+async def _load_action(
+    db: AsyncSession, action_id: uuid.UUID
+) -> TradeRetrospectiveAction:
+    db.expire_all()
+    row = await db.get(TradeRetrospectiveAction, action_id)
+    assert row is not None
+    return row
+
+
+async def _projection(db: AsyncSession, parent_id: int) -> list[dict[str, object]]:
+    db.expire_all()
+    parent = await db.get(TradeRetrospective, parent_id)
+    assert parent is not None
+    return list(parent.next_actions or [])
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def _isolate_tables(
+    db_session: AsyncSession,
+    investment_reports_cleanup_lock: AsyncSession,
+    retrospective_action_control_lock: None,
+) -> AsyncIterator[None]:
+    await db_session.rollback()
+    await db_session.execute(delete(TradeRetrospectiveAction))
+    await db_session.execute(delete(TradeRetrospective))
+    await db_session.commit()
+    await _set_mode(db_session, "canonical")
+    yield
+    await db_session.rollback()
+    await db_session.execute(delete(TradeRetrospectiveAction))
+    await db_session.execute(delete(TradeRetrospective))
+    await db_session.commit()
+    await _set_mode(db_session, "shadow")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "source", ["open", "in_progress", "done", "obsolete", "expired"]
+)
+@pytest.mark.parametrize(
+    "target", ["open", "in_progress", "done", "obsolete", "expired"]
+)
+async def test_complete_transition_matrix(
+    db_session: AsyncSession, source: str, target: str
+) -> None:
+    from app.services.trade_journal.retrospective_action_transition import (
+        transition_retrospective_action,
+    )
+
+    reason, evidence = _terminal_payload(source if source == target else target)
+    _, action_id = await _seed_action(db_session, status=source, version=4)
+
+    if source in {"done", "obsolete", "expired"} and source != target:
+        with pytest.raises(ActionTransitionConflict):
+            await transition_retrospective_action(
+                db_session,
+                action_id=action_id,
+                target_status=target,
+                expected_version=4,
+                actor=TransitionActor.web(7),
+                reason=reason,
+                evidence=evidence,
+            )
+        return
+
+    result = await transition_retrospective_action(
+        db_session,
+        action_id=action_id,
+        target_status=target,
+        expected_version=1
+        if source == target and source not in {"open", "in_progress"}
+        else 4,
+        actor=TransitionActor.web(7),
+        reason=reason,
+        evidence=evidence,
+    )
+    assert result.changed is (source != target)
+    assert result.idempotent is (source == target)
+    assert result.action["status"] == target
+    assert result.action["version"] == (5 if source != target else 4)
+
+
+@pytest.mark.asyncio
+async def test_active_same_state_requires_current_version(
+    db_session: AsyncSession,
+) -> None:
+    from app.services.trade_journal.retrospective_action_transition import (
+        transition_retrospective_action,
+    )
+
+    _, action_id = await _seed_action(db_session, status="open", version=3)
+    current = await transition_retrospective_action(
+        db_session,
+        action_id=action_id,
+        target_status="open",
+        expected_version=3,
+        actor=TransitionActor.web(1),
+        reason=None,
+        evidence=None,
+    )
+    assert current.idempotent and not current.changed
+    with pytest.raises(ActionTransitionConflict) as exc_info:
+        await transition_retrospective_action(
+            db_session,
+            action_id=action_id,
+            target_status="open",
+            expected_version=2,
+            actor=TransitionActor.web(1),
+            reason=None,
+            evidence=None,
+        )
+    assert (
+        exc_info.value.action_id,
+        exc_info.value.status,
+        exc_info.value.version,
+    ) == (
+        action_id,
+        "open",
+        3,
+    )
+
+
+@pytest.mark.asyncio
+async def test_real_transition_increments_version_exactly_once(
+    db_session: AsyncSession,
+) -> None:
+    from app.services.trade_journal.retrospective_action_transition import (
+        transition_retrospective_action,
+    )
+
+    _, action_id = await _seed_action(db_session, version=8)
+    result = await transition_retrospective_action(
+        db_session,
+        action_id=action_id,
+        target_status="done",
+        expected_version=8,
+        actor=TransitionActor.web(9),
+        reason=" completed ",
+        evidence=None,
+    )
+    assert result.action["version"] == 9
+    row = await _load_action(db_session, action_id)
+    assert row.version == 9
+    assert row.status_reason == "completed"
+
+
+@pytest.mark.asyncio
+async def test_same_terminal_stale_retry_returns_stored_audit(
+    db_session: AsyncSession,
+) -> None:
+    from app.services.trade_journal.retrospective_action_transition import (
+        transition_retrospective_action,
+    )
+
+    _, action_id = await _seed_action(
+        db_session,
+        status="expired",
+        version=6,
+        reason="window ended",
+        evidence=_evidence(),
+    )
+    before = await _load_action(db_session, action_id)
+    immutable = (
+        before.status_actor,
+        before.status_source,
+        before.status_reason,
+        before.status_evidence,
+        before.resolved_at,
+        before.status_changed_at,
+    )
+    result = await transition_retrospective_action(
+        db_session,
+        action_id=action_id,
+        target_status="expired",
+        expected_version=1,
+        actor=TransitionActor.web(999),
+        reason=" window ended ",
+        evidence=_evidence(source=" postmortem review "),
+    )
+    assert result.idempotent and not result.changed
+    after = await _load_action(db_session, action_id)
+    assert after.version == 6
+    assert (
+        after.status_actor,
+        after.status_source,
+        after.status_reason,
+        after.status_evidence,
+        after.resolved_at,
+        after.status_changed_at,
+    ) == immutable
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("target", "reason", "evidence"),
+    [
+        ("done", "window ended", _evidence()),
+        ("expired", "different", _evidence()),
+        ("expired", "window ended", _evidence(summary="different")),
+        ("open", None, None),
+    ],
+)
+async def test_terminal_reopen_or_audit_edit_conflicts_without_mutation(
+    db_session: AsyncSession,
+    target: str,
+    reason: str | None,
+    evidence: dict[str, object] | None,
+) -> None:
+    from app.services.trade_journal.retrospective_action_transition import (
+        transition_retrospective_action,
+    )
+
+    _, action_id = await _seed_action(
+        db_session,
+        status="expired",
+        version=2,
+        reason="window ended",
+        evidence=_evidence(),
+    )
+    before = await _load_action(db_session, action_id)
+    immutable = (
+        before.version,
+        before.status_actor,
+        before.status_reason,
+        before.status_evidence,
+        before.resolved_at,
+    )
+    with pytest.raises(ActionTransitionConflict):
+        await transition_retrospective_action(
+            db_session,
+            action_id=action_id,
+            target_status=target,
+            expected_version=2,
+            actor=TransitionActor.web(2),
+            reason=reason,
+            evidence=evidence,
+        )
+    after = await _load_action(db_session, action_id)
+    assert (
+        after.version,
+        after.status_actor,
+        after.status_reason,
+        after.status_evidence,
+        after.resolved_at,
+    ) == immutable
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("reason", [None, "", "   "])
+async def test_obsolete_requires_nonblank_reason(
+    db_session: AsyncSession, reason: str | None
+) -> None:
+    from app.services.trade_journal.retrospective_action_transition import (
+        transition_retrospective_action,
+    )
+
+    _, action_id = await _seed_action(db_session)
+    with pytest.raises(ActionTransitionInvalid):
+        await transition_retrospective_action(
+            db_session,
+            action_id=action_id,
+            target_status="obsolete",
+            expected_version=1,
+            actor=TransitionActor.web(1),
+            reason=reason,
+            evidence=None,
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("reason", "evidence"),
+    [(None, _evidence()), ("", _evidence()), ("ended", None), ("ended", {})],
+)
+async def test_expired_requires_reason_and_complete_evidence(
+    db_session: AsyncSession,
+    reason: str | None,
+    evidence: dict[str, object] | None,
+) -> None:
+    from app.services.trade_journal.retrospective_action_transition import (
+        transition_retrospective_action,
+    )
+
+    _, action_id = await _seed_action(db_session)
+    with pytest.raises(ActionTransitionInvalid):
+        await transition_retrospective_action(
+            db_session,
+            action_id=action_id,
+            target_status="expired",
+            expected_version=1,
+            actor=TransitionActor.web(1),
+            reason=reason,
+            evidence=evidence,
+        )
+
+
+@pytest.mark.asyncio
+async def test_past_due_date_alone_never_expires_action(
+    db_session: AsyncSession,
+) -> None:
+    from app.services.trade_journal.retrospective_action_transition import (
+        transition_retrospective_action,
+    )
+
+    _, action_id = await _seed_action(
+        db_session, status="open", due_kst_date=date.today() - timedelta(days=30)
+    )
+    with pytest.raises(ActionTransitionInvalid):
+        await transition_retrospective_action(
+            db_session,
+            action_id=action_id,
+            target_status="expired",
+            expected_version=1,
+            actor=TransitionActor.web(1),
+            reason="past due",
+            evidence=None,
+        )
+    row = await _load_action(db_session, action_id)
+    assert row.status == "open" and row.version == 1
+
+
+@pytest.mark.parametrize(
+    "bad_evidence",
+    [
+        _evidence(extra="forbidden"),
+        _evidence(observed_at="2026-07-15T12:00:00"),
+        _evidence(source=" "),
+        _evidence(reference=""),
+        _evidence(summary="x" * (EVIDENCE_STRING_MAX_LENGTH + 1)),
+        _evidence(source="한" * 2000, reference="한" * 2000, summary="한" * 2000),
+        _evidence(**{"Api_Token": "do-not-log-this-secret"}),
+        _evidence(summary={"nested": {"PASSWORD": "do-not-log-this-secret"}}),
+    ],
+)
+def test_operator_attestation_rejects_schema_time_bounds_and_secret_keys(
+    bad_evidence: dict[str, object],
+) -> None:
+    with pytest.raises(ActionTransitionInvalid) as exc_info:
+        validate_operator_attestation(bad_evidence)
+    assert "do-not-log-this-secret" not in str(exc_info.value)
+
+
+def test_operator_attestation_accepts_exact_boundary_and_offset() -> None:
+    valid = validate_operator_attestation(
+        _evidence(
+            summary="x" * EVIDENCE_STRING_MAX_LENGTH, observed_at="2026-07-15T03:00:00Z"
+        )
+    )
+    assert len(valid["summary"]) == EVIDENCE_STRING_MAX_LENGTH
+    assert EVIDENCE_MAX_BYTES == 16 * 1024
+
+
+def test_operator_attestation_rejects_key_over_64_characters() -> None:
+    with pytest.raises(ActionTransitionInvalid):
+        validate_operator_attestation(_evidence(**{"k" * 65: "value"}))
+
+
+def test_evidence_depth_boundary_is_five() -> None:
+    at_limit: object = {"a": {"b": {"c": {"d": {"e": "value"}}}}}
+    too_deep: object = {"a": {"b": {"c": {"d": {"e": {"f": "value"}}}}}}
+    assert _max_depth(at_limit) == EVIDENCE_MAX_DEPTH
+    assert _max_depth(too_deep) == EVIDENCE_MAX_DEPTH + 1
+
+
+@pytest.mark.asyncio
+async def test_manual_done_may_omit_evidence_but_reconciler_done_may_not(
+    db_session: AsyncSession,
+) -> None:
+    from app.services.trade_journal.retrospective_action_transition import (
+        transition_retrospective_action,
+    )
+
+    parent_id, manual_id = await _seed_action(db_session, position=0)
+    _, reconciler_id = await _seed_action(db_session, parent_id=parent_id, position=1)
+    manual = await transition_retrospective_action(
+        db_session,
+        action_id=manual_id,
+        target_status="done",
+        expected_version=1,
+        actor=TransitionActor.web(1),
+        reason=None,
+        evidence=None,
+    )
+    assert manual.changed
+    with pytest.raises(ActionTransitionInvalid):
+        await transition_retrospective_action(
+            db_session,
+            action_id=reconciler_id,
+            target_status="done",
+            expected_version=1,
+            actor=TransitionActor.reconciler("position-flat"),
+            reason=None,
+            evidence=None,
+        )
+
+
+@pytest.mark.asyncio
+async def test_reason_length_boundary(db_session: AsyncSession) -> None:
+    from app.services.trade_journal.retrospective_action_transition import (
+        transition_retrospective_action,
+    )
+
+    parent_id, accepted_id = await _seed_action(db_session, position=0)
+    _, rejected_id = await _seed_action(db_session, parent_id=parent_id, position=1)
+    accepted = await transition_retrospective_action(
+        db_session,
+        action_id=accepted_id,
+        target_status="obsolete",
+        expected_version=1,
+        actor=TransitionActor.web(1),
+        reason="x" * 2000,
+        evidence=None,
+    )
+    assert accepted.changed
+    with pytest.raises(ActionTransitionInvalid):
+        await transition_retrospective_action(
+            db_session,
+            action_id=rejected_id,
+            target_status="obsolete",
+            expected_version=1,
+            actor=TransitionActor.web(1),
+            reason="x" * 2001,
+            evidence=None,
+        )
+
+
+@pytest.mark.asyncio
+async def test_dry_run_returns_would_be_snapshot_without_db_or_projection_write(
+    db_session: AsyncSession,
+) -> None:
+    from app.services.trade_journal.retrospective_action_transition import (
+        transition_retrospective_action,
+    )
+
+    parent_id, action_id = await _seed_action(db_session)
+    projection_before = await _projection(db_session, parent_id)
+    result = await transition_retrospective_action(
+        db_session,
+        action_id=action_id,
+        target_status="done",
+        expected_version=1,
+        actor=TransitionActor.web(1),
+        reason="complete",
+        evidence=None,
+        dry_run=True,
+    )
+    assert result.dry_run and result.changed and not result.idempotent
+    assert result.action["status"] == "done" and result.action["version"] == 2
+    row = await _load_action(db_session, action_id)
+    assert row.status == "open" and row.version == 1 and row.resolved_at is None
+    assert await _projection(db_session, parent_id) == projection_before
+    marker = await db_session.scalar(
+        text(
+            "SELECT current_setting('app.retrospective_action_projection_writer', true)"
+        )
+    )
+    assert marker != "v1"
+
+
+@pytest.mark.asyncio
+async def test_noop_and_conflict_do_not_write_projection_or_guc(
+    db_session: AsyncSession,
+) -> None:
+    from app.services.trade_journal.retrospective_action_transition import (
+        transition_retrospective_action,
+    )
+
+    parent_id, action_id = await _seed_action(db_session, version=3)
+    projection_before = await _projection(db_session, parent_id)
+    result = await transition_retrospective_action(
+        db_session,
+        action_id=action_id,
+        target_status="open",
+        expected_version=3,
+        actor=TransitionActor.web(1),
+        reason=None,
+        evidence=None,
+    )
+    assert result.idempotent
+    with pytest.raises(ActionTransitionConflict):
+        await transition_retrospective_action(
+            db_session,
+            action_id=action_id,
+            target_status="done",
+            expected_version=2,
+            actor=TransitionActor.web(1),
+            reason=None,
+            evidence=None,
+        )
+    assert await _projection(db_session, parent_id) == projection_before
+    marker = await db_session.scalar(
+        text(
+            "SELECT current_setting('app.retrospective_action_projection_writer', true)"
+        )
+    )
+    assert marker != "v1"
+
+
+@pytest.mark.asyncio
+async def test_not_found_and_noncanonical_fail_closed(db_session: AsyncSession) -> None:
+    from app.services.trade_journal.retrospective_action_transition import (
+        transition_retrospective_action,
+    )
+
+    missing_id = uuid.uuid4()
+    with pytest.raises(ActionNotFoundError):
+        await transition_retrospective_action(
+            db_session,
+            action_id=missing_id,
+            target_status="done",
+            expected_version=1,
+            actor=TransitionActor.web(1),
+            reason=None,
+            evidence=None,
+        )
+    _, action_id = await _seed_action(db_session)
+    await _set_mode(db_session, "shadow")
+    with pytest.raises(ActionControlModeError):
+        await transition_retrospective_action(
+            db_session,
+            action_id=action_id,
+            target_status="done",
+            expected_version=1,
+            actor=TransitionActor.web(1),
+            reason=None,
+            evidence=None,
+        )
+
+
+@pytest.mark.asyncio
+async def test_missing_and_unknown_control_modes_fail_closed(
+    db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from app.services.trade_journal.retrospective_action_repository import (
+        RetrospectiveActionRepository,
+    )
+    from app.services.trade_journal.retrospective_action_transition import (
+        transition_retrospective_action,
+    )
+
+    _, action_id = await _seed_action(db_session)
+    await db_session.execute(
+        text("DELETE FROM review.trade_retrospective_action_control WHERE id = 1")
+    )
+    await db_session.commit()
+    with pytest.raises(ActionControlModeError):
+        await transition_retrospective_action(
+            db_session,
+            action_id=action_id,
+            target_status="done",
+            expected_version=1,
+            actor=TransitionActor.web(1),
+            reason=None,
+            evidence=None,
+        )
+
+    monkeypatch.setattr(
+        RetrospectiveActionRepository,
+        "get_control_mode",
+        AsyncMock(return_value="unknown"),
+    )
+    with pytest.raises(ActionControlModeError) as exc_info:
+        await transition_retrospective_action(
+            db_session,
+            action_id=action_id,
+            target_status="done",
+            expected_version=1,
+            actor=TransitionActor.web(1),
+            reason=None,
+            evidence=None,
+        )
+    assert exc_info.value.mode == "unknown"
+
+
+@pytest.mark.asyncio
+async def test_parent_is_locked_before_all_children_in_id_order(
+    db_session: AsyncSession,
+) -> None:
+    from app.services.trade_journal.retrospective_action_transition import (
+        transition_retrospective_action,
+    )
+
+    parent_id, first_id = await _seed_action(db_session, position=0)
+    await _seed_action(db_session, parent_id=parent_id, position=1)
+    statements: list[str] = []
+
+    def record_sql(_conn, _cursor, statement, _parameters, _context, _executemany):
+        normalized = " ".join(statement.lower().split())
+        if "for update" in normalized:
+            statements.append(normalized)
+
+    event.listen(engine.sync_engine, "before_cursor_execute", record_sql)
+    try:
+        await transition_retrospective_action(
+            db_session,
+            action_id=first_id,
+            target_status="in_progress",
+            expected_version=1,
+            actor=TransitionActor.web(1),
+            reason=None,
+            evidence=None,
+        )
+    finally:
+        event.remove(engine.sync_engine, "before_cursor_execute", record_sql)
+
+    parent_lock = next(
+        i
+        for i, sql in enumerate(statements)
+        if "trade_retrospectives" in sql and "trade_retrospective_actions" not in sql
+    )
+    child_lock = next(
+        i for i, sql in enumerate(statements) if "trade_retrospective_actions" in sql
+    )
+    assert parent_lock < child_lock
+    assert "order by" in statements[child_lock] and ".id" in statements[child_lock]
+
+
+@pytest.mark.asyncio
+async def test_caller_owned_commit_and_rollback(db_session: AsyncSession) -> None:
+    from app.services.trade_journal.retrospective_action_transition import (
+        transition_retrospective_action,
+    )
+
+    _, committed_id = await _seed_action(db_session, position=0)
+    await transition_retrospective_action(
+        db_session,
+        action_id=committed_id,
+        target_status="done",
+        expected_version=1,
+        actor=TransitionActor.web(1),
+        reason=None,
+        evidence=None,
+    )
+    await db_session.commit()
+    assert (await _load_action(db_session, committed_id)).status == "done"
+
+    parent_id = (await _load_action(db_session, committed_id)).retrospective_id
+    _, rolled_back_id = await _seed_action(db_session, parent_id=parent_id, position=1)
+    await transition_retrospective_action(
+        db_session,
+        action_id=rolled_back_id,
+        target_status="done",
+        expected_version=1,
+        actor=TransitionActor.web(1),
+        reason=None,
+        evidence=None,
+    )
+    await db_session.rollback()
+    rolled_back = await _load_action(db_session, rolled_back_id)
+    assert rolled_back.status == "open" and rolled_back.version == 1
+
+
+@pytest.mark.asyncio
+async def test_explicit_caller_transaction_commits_atomically(
+    db_session: AsyncSession,
+) -> None:
+    from app.services.trade_journal.retrospective_action_transition import (
+        transition_retrospective_action,
+    )
+
+    _, action_id = await _seed_action(db_session)
+    async with AsyncSessionLocal() as session:
+        async with session.begin():
+            result = await transition_retrospective_action(
+                session,
+                action_id=action_id,
+                target_status="done",
+                expected_version=1,
+                actor=TransitionActor.web(1),
+                reason=None,
+                evidence=None,
+            )
+            assert result.changed
+    row = await _load_action(db_session, action_id)
+    assert row.status == "done" and row.version == 2
+
+
+@pytest.mark.asyncio
+async def test_projection_failure_rolls_back_child_and_parent(
+    db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from app.services.trade_journal.retrospective_action_repository import (
+        RetrospectiveActionRepository,
+    )
+    from app.services.trade_journal.retrospective_action_transition import (
+        transition_retrospective_action,
+    )
+
+    parent_id, action_id = await _seed_action(db_session)
+    before_projection = await _projection(db_session, parent_id)
+    monkeypatch.setattr(
+        RetrospectiveActionRepository,
+        "rebuild_projection",
+        AsyncMock(side_effect=RuntimeError("projection failed")),
+    )
+    with pytest.raises(RuntimeError, match="projection failed"):
+        await transition_retrospective_action(
+            db_session,
+            action_id=action_id,
+            target_status="done",
+            expected_version=1,
+            actor=TransitionActor.web(1),
+            reason=None,
+            evidence=None,
+        )
+    await db_session.rollback()
+    row = await _load_action(db_session, action_id)
+    assert row.status == "open" and row.version == 1
+    assert await _projection(db_session, parent_id) == before_projection
+
+
+async def _set_timeout(session: AsyncSession) -> None:
+    await session.execute(text("SET LOCAL statement_timeout = '8s'"))
+    await session.execute(text("SET LOCAL lock_timeout = '7s'"))
+
+
+@pytest.mark.asyncio
+async def test_same_row_stale_race_serializes_without_deadlock(
+    db_session: AsyncSession,
+) -> None:
+    from app.services.trade_journal.retrospective_action_transition import (
+        transition_retrospective_action,
+    )
+
+    _, action_id = await _seed_action(db_session)
+    first_holds_lock = asyncio.Event()
+    release_first = asyncio.Event()
+
+    async def first() -> None:
+        async with AsyncSessionLocal() as session:
+            await _set_timeout(session)
+            await transition_retrospective_action(
+                session,
+                action_id=action_id,
+                target_status="in_progress",
+                expected_version=1,
+                actor=TransitionActor.web(1),
+                reason=None,
+                evidence=None,
+            )
+            first_holds_lock.set()
+            await release_first.wait()
+            await session.commit()
+
+    async def stale_second() -> None:
+        await first_holds_lock.wait()
+        async with AsyncSessionLocal() as session:
+            await _set_timeout(session)
+            with pytest.raises(ActionTransitionConflict):
+                await transition_retrospective_action(
+                    session,
+                    action_id=action_id,
+                    target_status="done",
+                    expected_version=1,
+                    actor=TransitionActor.web(2),
+                    reason=None,
+                    evidence=None,
+                )
+
+    first_task = asyncio.create_task(first())
+    second_task = asyncio.create_task(stale_second())
+    await asyncio.wait_for(first_holds_lock.wait(), timeout=3)
+    await asyncio.sleep(0.1)
+    release_first.set()
+    await asyncio.wait_for(asyncio.gather(first_task, second_task), timeout=8)
+    row = await _load_action(db_session, action_id)
+    assert row.status == "in_progress" and row.version == 2
+
+
+@pytest.mark.asyncio
+async def test_sibling_transitions_preserve_both_projection_updates(
+    db_session: AsyncSession,
+) -> None:
+    from app.services.trade_journal.retrospective_action_transition import (
+        transition_retrospective_action,
+    )
+
+    parent_id, first_id = await _seed_action(db_session, position=0)
+    _, second_id = await _seed_action(db_session, parent_id=parent_id, position=1)
+
+    async def transition(action_id: uuid.UUID, actor_id: int) -> None:
+        async with AsyncSessionLocal() as session:
+            await _set_timeout(session)
+            await transition_retrospective_action(
+                session,
+                action_id=action_id,
+                target_status="done",
+                expected_version=1,
+                actor=TransitionActor.web(actor_id),
+                reason=None,
+                evidence=None,
+            )
+            await session.commit()
+
+    await asyncio.wait_for(
+        asyncio.gather(transition(first_id, 1), transition(second_id, 2)), timeout=8
+    )
+    projection = await _projection(db_session, parent_id)
+    assert [item["status"] for item in projection] == ["done", "done"]
+    assert [item["version"] for item in projection] == [2, 2]
+    assert [item["custom"] for item in projection] == ["preserve-0", "preserve-1"]
+
+
+@pytest.mark.asyncio
+async def test_save_and_transition_share_lock_order_and_keep_projection(
+    db_session: AsyncSession,
+) -> None:
+    from app.services.trade_journal.retrospective_action_repository import (
+        RetrospectiveActionRepository,
+    )
+    from app.services.trade_journal.retrospective_action_transition import (
+        transition_retrospective_action,
+    )
+
+    parent_id, action_id = await _seed_action(db_session, position=0)
+
+    async def save() -> None:
+        async with AsyncSessionLocal() as session:
+            await _set_timeout(session)
+            await RetrospectiveActionRepository(session).reconcile_actions(
+                parent_id,
+                [
+                    {
+                        "action_id": str(action_id),
+                        "action": "action-0",
+                        "owner": None,
+                        "issue_id": None,
+                        "status": "open",
+                        "due_kst_date": None,
+                        "custom": "preserve-0",
+                    }
+                ],
+                "user:save",
+                control_mode="canonical",
+            )
+            await session.commit()
+
+    async def transition() -> None:
+        async with AsyncSessionLocal() as session:
+            await _set_timeout(session)
+            await transition_retrospective_action(
+                session,
+                action_id=action_id,
+                target_status="in_progress",
+                expected_version=1,
+                actor=TransitionActor.web(2),
+                reason=None,
+                evidence=None,
+            )
+            await session.commit()
+
+    outcomes = await asyncio.wait_for(
+        asyncio.gather(save(), transition(), return_exceptions=True), timeout=8
+    )
+    assert not any(isinstance(outcome, BaseException) for outcome in outcomes)
+    row = await _load_action(db_session, action_id)
+    assert row.status == "in_progress" and row.version == 2
+    projection = await _projection(db_session, parent_id)
+    assert projection[0]["status"] == "in_progress"
+    assert projection[0]["version"] == 2
+
+
+@pytest.mark.asyncio
+async def test_transition_has_no_external_side_effects(
+    db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from app.services.trade_journal.retrospective_action_transition import (
+        transition_retrospective_action,
+    )
+
+    notifier = AsyncMock()
+    monkeypatch.setattr(
+        "app.monitoring.trade_notifier.get_trade_notifier",
+        AsyncMock(return_value=notifier),
+    )
+    _, action_id = await _seed_action(db_session)
+    await transition_retrospective_action(
+        db_session,
+        action_id=action_id,
+        target_status="done",
+        expected_version=1,
+        actor=TransitionActor.web(1),
+        reason=None,
+        evidence=None,
+    )
+    notifier.assert_not_called()

--- a/tests/test_rob878_transition_core.py
+++ b/tests/test_rob878_transition_core.py
@@ -244,6 +244,33 @@ async def test_active_same_state_requires_current_version(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("reason", "evidence"),
+    [("x" * 2001, None), (None, _evidence())],
+)
+async def test_active_same_state_still_validates_audit_payload(
+    db_session: AsyncSession,
+    reason: str | None,
+    evidence: dict[str, object] | None,
+) -> None:
+    from app.services.trade_journal.retrospective_action_transition import (
+        transition_retrospective_action,
+    )
+
+    _, action_id = await _seed_action(db_session, status="open", version=3)
+    with pytest.raises(ActionTransitionInvalid):
+        await transition_retrospective_action(
+            db_session,
+            action_id=action_id,
+            target_status="open",
+            expected_version=3,
+            actor=TransitionActor.web(1),
+            reason=reason,
+            evidence=evidence,
+        )
+
+
+@pytest.mark.asyncio
 async def test_real_transition_increments_version_exactly_once(
     db_session: AsyncSession,
 ) -> None:
@@ -301,6 +328,16 @@ async def test_same_terminal_stale_retry_returns_stored_audit(
         evidence=_evidence(source=" postmortem review "),
     )
     assert result.idempotent and not result.changed
+    assert result.action == {
+        "action_id": str(action_id),
+        "status": "expired",
+        "version": 6,
+        "status_changed_at": immutable[5].isoformat(),
+        "resolved_at": immutable[4].isoformat(),
+        "status_actor": immutable[0],
+        "status_source": immutable[1],
+        "status_reason": immutable[2],
+    }
     after = await _load_action(db_session, action_id)
     assert after.version == 6
     assert (
@@ -447,6 +484,9 @@ async def test_past_due_date_alone_never_expires_action(
     [
         _evidence(extra="forbidden"),
         _evidence(observed_at="2026-07-15T12:00:00"),
+        _evidence(observed_at="20260715T120000+09:00"),
+        _evidence(observed_at="2026-07-15 12:00:00+09:00"),
+        _evidence(observed_at="2026-W29-3T12:00:00+09:00"),
         _evidence(source=" "),
         _evidence(reference=""),
         _evidence(summary="x" * (EVIDENCE_STRING_MAX_LENGTH + 1)),
@@ -474,8 +514,38 @@ def test_operator_attestation_accepts_exact_boundary_and_offset() -> None:
 
 
 def test_operator_attestation_rejects_key_over_64_characters() -> None:
-    with pytest.raises(ActionTransitionInvalid):
+    with pytest.raises(ActionTransitionInvalid, match="key exceeds"):
         validate_operator_attestation(_evidence(**{"k" * 65: "value"}))
+
+
+def test_operator_attestation_errors_do_not_echo_untrusted_keys_or_values() -> None:
+    secret_key = "password_supersecret_material"
+    secret_value = "credential-value-must-not-appear"
+    evidence: dict[object, object] = _evidence()
+    evidence[secret_key] = secret_value
+    evidence[1] = "mixed-key"
+    with pytest.raises(ActionTransitionInvalid) as exc_info:
+        validate_operator_attestation(evidence)
+    message = str(exc_info.value)
+    assert secret_key not in message
+    assert secret_value not in message
+
+
+@pytest.mark.parametrize(
+    ("source", "value"),
+    [
+        ("web", "reconciler:job"),
+        ("triage", "mcp:profile"),
+        ("mcp", "user:1"),
+        ("reconciler", "user:1"),
+        ("web", "user:"),
+    ],
+)
+def test_transition_actor_rejects_source_value_mismatch(
+    source: str, value: str
+) -> None:
+    with pytest.raises(ActionTransitionInvalid):
+        TransitionActor(source=source, value=value)
 
 
 def test_evidence_depth_boundary_is_five() -> None:
@@ -992,9 +1062,10 @@ async def test_transition_has_no_external_side_effects(
     )
 
     notifier = AsyncMock()
+    getter = AsyncMock(return_value=notifier)
     monkeypatch.setattr(
         "app.monitoring.trade_notifier.get_trade_notifier",
-        AsyncMock(return_value=notifier),
+        getter,
     )
     _, action_id = await _seed_action(db_session)
     await transition_retrospective_action(
@@ -1006,4 +1077,5 @@ async def test_transition_has_no_external_side_effects(
         reason=None,
         evidence=None,
     )
-    notifier.assert_not_called()
+    getter.assert_not_called()
+    assert notifier.mock_calls == []


### PR DESCRIPTION
## Summary

- add a single async domain transition operation for canonical retrospective actions
- enforce the active/terminal state graph, optimistic versions, terminal audit immutability, and typed 404/409/422-equivalent domain errors
- validate bounded operator-attestation evidence without HTTP/MCP or external side effects
- reuse the ROB-880 compatibility projection writer in the caller transaction

## State / version / evidence contract

- `open <-> in_progress`; active actions may enter `done`, `obsolete`, or `expired`
- same active target is idempotent only at the current version; stale active requests conflict
- a real transition increments `version` exactly once
- same-terminal stale retries return the stored result only when reason/evidence match
- terminal reopen, target changes, and terminal audit edits conflict while preserving the original actor/source/reason/evidence/timestamps
- `obsolete` requires a trimmed nonblank reason; `expired` requires reason plus exact six-key evidence
- manual `done` may omit evidence; reconciler `done` requires authoritative evidence
- evidence enforces offset-aware RFC3339, 16 KiB UTF-8 JSON, depth/key/string limits, and secret-like key rejection

## Lock / transaction / projection design

1. identify immutable parent ID without a mutation lock
2. lock parent `FOR UPDATE`
3. lock all siblings `ORDER BY id FOR UPDATE`
4. reselect the target from the locked collection
5. validate state/version/audit payload
6. mutate and flush only
7. rebuild the ROB-880 compatibility projection in the same transaction

The service never commits or rolls back. No-op, conflict, and dry-run paths do not call the projection writer or set its GUC marker. Projection failures remain atomic with the child mutation under caller rollback.

## Verification

- `uv run pytest tests/test_rob878_transition_core.py -v` -> 76 passed
- `uv run pytest tests/test_rob878_transition_core.py -n 2 -v` -> 76 passed
- requested related suite -> 212 passed; final core suite re-passed 76/76
- `make lint` -> Ruff check/format + ty passed
- `git diff --check` -> passed
- `uv run alembic heads` -> `20260714_rob850_paper_evaluation (head)`
- full non-live/non-slow xdist suite -> 16,444 passed, 9 skipped, 9 shared-DB/DDL race failures; all 9 failed node IDs passed in a serial isolated rerun

## Out of scope

- HTTP/PATCH and MCP operator surfaces
- auth/CSRF, migrations/schema changes, triage CLI, frontend
- broker, Linear, Telegram, TaskIQ side effects
- merge, deploy, cutover, or production DB mutation

Linear: ROB-881 (kept In Progress until merge)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added controlled retrospective action transitions across open, in-progress, done, obsolete, and expired states.
  * Added dry-run previews without saving changes.
  * Added optimistic concurrency and idempotent handling for repeated requests.
  * Added strict validation for reasons, actors, and operator evidence.
  * Automatically refreshes related retrospective projections after successful changes.

* **Bug Fixes**
  * Prevented terminal actions from being reopened or having their audit details altered.
  * Ensured invalid control modes, conflicts, and projection failures fail safely without partial updates.

* **Tests**
  * Added comprehensive coverage for transitions, validation, concurrency, rollback, locking, and projection consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->