### PR TITLE
feat(ROB-892): Redis-backed distributed gate for KIS mock (VTS) REST dispatch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,7 +75,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v5
-    
+
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v6
       with:
@@ -83,6 +83,17 @@ jobs:
 
     - name: Install UV
       run: pip install uv
+
+    - name: Install redis-server (ROB-892 real-Redis acceptance)
+      # ROB-892: the gate-acceptance suite spawns its own disposable redis-server
+      # on a random port (per-module isolation; never touches production Redis).
+      # The binary must exist in CI; if missing the fixture fails loudly rather
+      # than silently skipping the real-Redis tests.
+      run: |
+        sudo apt-get update -qq
+        sudo apt-get install -y -qq redis-server redis-tools
+        redis-server --version
+        redis-cli --version
 
     - name: Load cached venv
       id: cached-uv-dependencies

--- a/app/services/brokers/kis/base.py
+++ b/app/services/brokers/kis/base.py
@@ -640,10 +640,15 @@ class BaseKISClient:
             )
         except (PreSendFreshnessError, DistributedGateUnavailable):
             # Phase-aware: if a response was already seen on an earlier retry,
-            # KIS reachability is proven -> reachable (CLOSED). Otherwise this is
-            # a true pre-dispatch abort (HTTP=0) -> release only this lease.
+            # KIS reachability is proven -> reachable (CLOSED). If an earlier
+            # retry started HTTP without a response, its outcome remains unknown
+            # -> re-OPEN the owning HALF_OPEN probe. Only a request that never
+            # started HTTP is a true pre-dispatch abort (HTTP=0) whose lease can
+            # be released for an immediate next probe.
             if phase["response_seen"]:
                 breaker.record_reachable_error(lease)
+            elif phase["http_started"]:
+                breaker.record_indeterminate(lease)
             else:
                 breaker.release_probe(lease)
             raise

--- a/app/services/brokers/kis/base.py
+++ b/app/services/brokers/kis/base.py
@@ -177,8 +177,11 @@ class BaseKISClient:
         * Live or custom test host, or non-string (MagicMock) settings/URL →
           return None so Redis is contacted zero times.
 
-        The scope key is the request netloc plus a non-reversible sha256
-        fingerprint of the ``appkey`` header — never the raw credential.
+        Robust against malformed URLs: a ``urlsplit`` ``ValueError`` (e.g. an
+        invalid IPv6 ``kis_mock_base_url``) is absorbed — it never leaks as a
+        generic exception that the outer breaker would mistake for KIS
+        reachability. A malformed mock config fails CLOSED for mock dispatch but
+        must NOT break a valid live request.
         """
         from urllib.parse import urlsplit
 
@@ -186,16 +189,22 @@ class BaseKISClient:
             build_vts_gate_scope_key,
         )
 
-        is_mock_client = bool(getattr(self, "_is_mock_client", False))
+        is_mock_client = getattr(self, "_is_mock_client", False) is True
 
         mock_base = getattr(self._settings, "kis_mock_base_url", "")
         mock_netloc = ""
         if isinstance(mock_base, str):
-            mock_netloc = urlsplit(mock_base.rstrip("/")).netloc.lower()
+            try:
+                mock_netloc = urlsplit(mock_base.rstrip("/")).netloc.lower()
+            except ValueError:
+                mock_netloc = ""  # malformed mock base -> treated as unscopable
 
         request_netloc = ""
         if isinstance(url, str):
-            request_netloc = urlsplit(url).netloc.lower()
+            try:
+                request_netloc = urlsplit(url).netloc.lower()
+            except ValueError:
+                request_netloc = ""  # malformed request URL -> handled below
 
         targets_mock_host = bool(request_netloc) and (
             (bool(mock_netloc) and request_netloc == mock_netloc)
@@ -203,16 +212,18 @@ class BaseKISClient:
         )
 
         if not (is_mock_client or targets_mock_host):
-            # Not a mock dispatch (live host, custom test host, or MagicMock
-            # unit-test settings/url) -> gate is a no-op, Redis untouched.
+            # Live host, custom test host, MagicMock unit-test settings/url, or
+            # a malformed mock config for a non-mock request -> gate is a no-op,
+            # Redis untouched. A malformed mock_base_url must NOT break live.
             return None
 
-        # Mock dispatch: fail-closed if the scope cannot be built safely rather
-        # than letting the request through unthrottled (fail-open).
+        # Mock dispatch: fail closed if the scope cannot be built safely rather
+        # than letting the request through unthrottled (fail-open) or leaking a
+        # ValueError that the breaker would mistake for KIS reachability.
         if not request_netloc:
             raise DistributedGateUnavailable(
-                "KIS mock dispatch URL has no host; cannot scope the "
-                "distributed gate (HTTP=0 fail-closed)"
+                "KIS mock dispatch URL has no host (or is malformed); cannot "
+                "scope the distributed gate (HTTP=0 fail-closed)"
             )
         app_key = str(headers.get("appkey") or "") if isinstance(headers, dict) else ""
         if not app_key:
@@ -388,10 +399,19 @@ class BaseKISClient:
             KeyError: If response doesn't contain access_token.
         """
         breaker = get_kis_circuit_breaker()
-        breaker.before_request()  # OUTSIDE the classify try/except (ROB-699 invariant)
+        # ROB-699 invariant preserved: the breaker check stays OUTSIDE the
+        # classify try/except so a KISCircuitOpen propagates unclassified. The
+        # lease token + cancellation-phase contract (ROB-892) is applied here
+        # too so a cancelled token POST is not misclassified as KIS-reachable.
+        # OAuth token issuance is intentionally NOT routed through the VTS Redis
+        # gate (separate /oauth2/token endpoint/quota).
+        lease = breaker.before_request()
+        http_started = False
+        response_seen = False
         try:
             token_timeout = self._token_request_timeout()
             cli = await self._ensure_client(timeout=token_timeout)
+            http_started = True
             r = await cli.post(
                 self._kis_url("/oauth2/token"),
                 data={
@@ -401,16 +421,27 @@ class BaseKISClient:
                 },
                 timeout=token_timeout,
             )
+            response_seen = True
             response = r.json()
             access_token = response["access_token"]
             expires_in = response.get("expires_in", 3600)
+        except asyncio.CancelledError:
+            if response_seen:
+                breaker.record_reachable_error(lease)
+            elif http_started:
+                breaker.record_failure(lease)
+            else:
+                breaker.release_probe(lease)
+            raise
         except BaseException as exc:  # noqa: BLE001 — classify then re-raise unchanged
             if is_kis_connect_failure(exc):
-                breaker.record_failure()  # connect/read outage -> trips after N
+                breaker.record_failure(lease)  # connect/read outage -> trips after N
             else:
-                breaker.record_reachable_error()  # KIS responded (401/KeyError/JSON) — no trip
+                breaker.record_reachable_error(
+                    lease
+                )  # KIS responded (401/KeyError/JSON)
             raise
-        breaker.record_success()
+        breaker.record_success(lease)
         logging.info("KIS 새 토큰 발급 완료")
         return access_token, expires_in
 
@@ -579,7 +610,18 @@ class BaseKISClient:
         ~0ms. Closed = pure passthrough. See ``circuit_breaker.py``.
         """
         breaker = get_kis_circuit_breaker()
-        breaker.before_request()  # raises KISCircuitOpen when open — 0 HTTP, 0 wait
+        # before_request returns an opaque lease token identifying THIS request.
+        # On a pre-dispatch abort we release ONLY this request's lease, so an
+        # old request can never release another request's HALF_OPEN probe (P1).
+        lease = breaker.before_request()
+        # Cancellation-phase contract: the breaker outcome for a CancelledError
+        # depends on how far THIS dispatch progressed. ``send_outcome`` is None
+        # for reads/token, so an internal phase holder is threaded through the
+        # retry loop (monotonic high-water marks) and read on cancellation:
+        #   * no HTTP started -> HTTP=0, release lease, keep HALF_OPEN;
+        #   * HTTP started, no response -> outcome unknown -> re-OPEN + cooldown;
+        #   * response seen -> KIS reachable -> CLOSED.
+        phase = {"http_started": False, "response_seen": False}
         try:
             result = await self._dispatch_rate_limited_with_headers(
                 method,
@@ -594,31 +636,28 @@ class BaseKISClient:
                 max_retries_override=max_retries_override,
                 pre_send_hook=pre_send_hook,
                 send_outcome=send_outcome,
+                _phase=phase,
             )
         except (PreSendFreshnessError, DistributedGateUnavailable):
-            # ROB-843 / ROB-892: these aborted BEFORE any HTTP reached KIS
-            # (mock freshness block / Redis gate failure-or-deadline). They are
-            # not KIS reachability signals, so they must not move the breaker
-            # state or failure count. But ``before_request`` may have handed out
-            # an exclusive HALF_OPEN probe lease; release ONLY that lease so the
-            # next request can probe again (otherwise the breaker stalls open).
-            breaker.release_probe()
+            # Pre-dispatch abort (HTTP=0): release ONLY this request's lease,
+            # never another request's. Keeps HALF_OPEN; does not change state.
+            breaker.release_probe(lease)
             raise
         except asyncio.CancelledError:
-            # A cancellation during the pre-dispatch wait (e.g. mid gate-acquire)
-            # is HTTP=0. It must not be mistaken for KIS reachability (the broad
-            # BaseException handler below would otherwise record_reachable_error
-            # and close a HALF_OPEN probe on a request that never reached KIS).
-            # Release the probe lease only; preserve cancellation semantics.
-            breaker.release_probe()
+            if phase["response_seen"]:
+                breaker.record_reachable_error(lease)
+            elif phase["http_started"]:
+                breaker.record_failure(lease)
+            else:
+                breaker.release_probe(lease)
             raise
         except BaseException as exc:  # noqa: BLE001 — classify then re-raise unchanged
             if is_kis_connect_failure(exc):
-                breaker.record_failure()
+                breaker.record_failure(lease)
             else:
-                breaker.record_reachable_error()
+                breaker.record_reachable_error(lease)
             raise
-        breaker.record_success()
+        breaker.record_success(lease)
         return result
 
     async def _dispatch_rate_limited_with_headers(
@@ -636,6 +675,7 @@ class BaseKISClient:
         max_retries_override: int | None = None,
         pre_send_hook: PreSendHook | None = None,
         send_outcome: OrderSendOutcomeTracker | None = None,
+        _phase: dict[str, bool] | None = None,
     ) -> tuple[dict[str, Any], dict[str, str]]:
         """Like :meth:`_request_with_rate_limit` but also returns response headers.
 
@@ -649,8 +689,15 @@ class BaseKISClient:
             response body. Callers that need that signal use this method; everyone else
             should keep using :meth:`_request_with_rate_limit`.
         """
-        parsed_url = urlparse(url)
-        api_path = parsed_url.path or "/unknown"
+        # ROB-892: classify the VTS scope ONCE, safely, BEFORE any urlparse so a
+        # malformed URL (or a MagicMock unit-test url) cannot leak as a generic
+        # ValueError that the outer breaker would mistake for KIS reachability.
+        # Reused across the retry loop.
+        vts_scope = self._vts_gate_scope(url, headers)
+        try:
+            api_path = urlparse(url).path or "/unknown"
+        except (ValueError, TypeError):
+            api_path = "/unknown"
         api_key = f"{tr_id or 'unknown'}|{api_path}"
 
         rate, period = self._get_rate_limit_for_api(api_key)
@@ -675,15 +722,14 @@ class BaseKISClient:
 
             try:
                 client = await self._ensure_client(timeout=timeout)
-                # ROB-892: distributed admit gate for KIS mock (VTS). The scope
-                # is None for any non-mock host, so live dispatch (and unit
-                # tests using non-mock hosts) contact Redis zero times. For mock
-                # the gate runs the pre_send_hook immediately before its atomic
-                # claim (freshness), rerunning it on contention; after admission
+                # ROB-892: distributed admit gate for KIS mock (VTS). ``vts_scope``
+                # is None for any non-mock host, so live dispatch (and unit tests
+                # using non-mock hosts) contact Redis zero times. For mock the
+                # gate runs the pre_send_hook immediately before its atomic claim
+                # (freshness), rerunning it on contention; after admission
                 # mark_dispatched + HTTP run with no further unbounded wait. A
-                # Redis failure/deadline raises DistributedGateUnavailable
-                # before any HTTP -> mutation HTTP=0 (no fallback).
-                vts_scope = self._vts_gate_scope(url, headers)
+                # Redis failure/deadline raises DistributedGateUnavailable before
+                # any HTTP -> mutation HTTP=0 (no fallback).
                 if vts_scope is not None:
                     await self._await_vts_gate(
                         vts_scope,
@@ -694,6 +740,10 @@ class BaseKISClient:
                     await pre_send_hook()
                 if send_outcome is not None:
                     send_outcome.mark_dispatched()
+                # Cancellation-phase high-water mark: once any HTTP attempt has
+                # started for this dispatch, it stays True across retries.
+                if _phase is not None:
+                    _phase["http_started"] = True
                 response = await self._execute_http_request(
                     client,
                     method,
@@ -703,6 +753,8 @@ class BaseKISClient:
                     json_body=json_body,
                     timeout=timeout,
                 )
+                if _phase is not None:
+                    _phase["response_seen"] = True
                 status_code = _safe_status_code(response)
                 if send_outcome is not None:
                     send_outcome.mark_http_response(status_code)

--- a/app/services/brokers/kis/base.py
+++ b/app/services/brokers/kis/base.py
@@ -429,7 +429,7 @@ class BaseKISClient:
             if response_seen:
                 breaker.record_reachable_error(lease)
             elif http_started:
-                breaker.record_failure(lease)
+                breaker.record_indeterminate(lease)
             else:
                 breaker.release_probe(lease)
             raise
@@ -639,15 +639,22 @@ class BaseKISClient:
                 _phase=phase,
             )
         except (PreSendFreshnessError, DistributedGateUnavailable):
-            # Pre-dispatch abort (HTTP=0): release ONLY this request's lease,
-            # never another request's. Keeps HALF_OPEN; does not change state.
-            breaker.release_probe(lease)
+            # Phase-aware: if a response was already seen on an earlier retry,
+            # KIS reachability is proven -> reachable (CLOSED). Otherwise this is
+            # a true pre-dispatch abort (HTTP=0) -> release only this lease.
+            if phase["response_seen"]:
+                breaker.record_reachable_error(lease)
+            else:
+                breaker.release_probe(lease)
             raise
         except asyncio.CancelledError:
             if phase["response_seen"]:
                 breaker.record_reachable_error(lease)
             elif phase["http_started"]:
-                breaker.record_failure(lease)
+                # HTTP started, no response -> outcome unknown. Owner-only
+                # re-OPEN; CLOSED/stale/non-owner cancellation is a no-op (a
+                # normal disconnect must never inflate the failure count).
+                breaker.record_indeterminate(lease)
             else:
                 breaker.release_probe(lease)
             raise

--- a/app/services/brokers/kis/base.py
+++ b/app/services/brokers/kis/base.py
@@ -31,6 +31,13 @@ from app.services.brokers.kis.vts_distributed_gate import (
 )
 from app.services.redis_token_manager import redis_token_manager
 
+# Official KIS mock (VTS) REST host. Stable KIS constant — used only as an
+# additional fail-closed discriminator ("this request is definitely mock"), never
+# to gate a live request (live is openapi.koreainvestment.com:9443).
+_KIS_MOCK_REST_HOSTS: frozenset[str] = frozenset(
+    {"openapivts.koreainvestment.com:29443"}
+)
+
 
 def _is_closed_loop_runtime_error(exc: RuntimeError) -> bool:
     return str(exc) == "Event loop is closed"
@@ -158,12 +165,20 @@ class BaseKISClient:
         return f"{base_url}{path}"
 
     def _vts_gate_scope(self, url: str, headers: dict[str, str]) -> str | None:
-        """Return the ROB-892 distributed-gate scope key for a mock request.
+        """Return the ROB-892 distributed-gate scope key, or None to bypass.
 
-        ``None`` for any non-mock host (live, or test hosts) so live dispatch
-        contacts Redis zero times. The scope is the request's netloc plus a
-        non-reversible sha256 fingerprint of the ``appkey`` header — never the
-        raw credential.
+        Three-way contract (ROB-892 + independent review):
+
+        * Mock dispatch (``self._is_mock_client`` True, OR the request netloc
+          matches the configured mock base / the official KIS mock host) → MUST
+          gate. If the scope cannot be built safely (malformed/empty URL or
+          empty ``appkey``), raise ``DistributedGateUnavailable`` (HTTP=0,
+          fail-closed). A mock request must NEVER silently bypass the gate.
+        * Live or custom test host, or non-string (MagicMock) settings/URL →
+          return None so Redis is contacted zero times.
+
+        The scope key is the request netloc plus a non-reversible sha256
+        fingerprint of the ``appkey`` header — never the raw credential.
         """
         from urllib.parse import urlsplit
 
@@ -171,16 +186,40 @@ class BaseKISClient:
             build_vts_gate_scope_key,
         )
 
-        mock_base = getattr(self._settings, "kis_mock_base_url", "") or ""
-        mock_netloc = urlsplit(mock_base.rstrip("/")).netloc.lower()
-        if not mock_netloc:
+        is_mock_client = bool(getattr(self, "_is_mock_client", False))
+
+        mock_base = getattr(self._settings, "kis_mock_base_url", "")
+        mock_netloc = ""
+        if isinstance(mock_base, str):
+            mock_netloc = urlsplit(mock_base.rstrip("/")).netloc.lower()
+
+        request_netloc = ""
+        if isinstance(url, str):
+            request_netloc = urlsplit(url).netloc.lower()
+
+        targets_mock_host = bool(request_netloc) and (
+            (bool(mock_netloc) and request_netloc == mock_netloc)
+            or request_netloc in _KIS_MOCK_REST_HOSTS
+        )
+
+        if not (is_mock_client or targets_mock_host):
+            # Not a mock dispatch (live host, custom test host, or MagicMock
+            # unit-test settings/url) -> gate is a no-op, Redis untouched.
             return None
-        request_netloc = urlsplit(url).netloc.lower()
-        if request_netloc != mock_netloc:
-            return None
-        app_key = str(headers.get("appkey") or "")
+
+        # Mock dispatch: fail-closed if the scope cannot be built safely rather
+        # than letting the request through unthrottled (fail-open).
+        if not request_netloc:
+            raise DistributedGateUnavailable(
+                "KIS mock dispatch URL has no host; cannot scope the "
+                "distributed gate (HTTP=0 fail-closed)"
+            )
+        app_key = str(headers.get("appkey") or "") if isinstance(headers, dict) else ""
         if not app_key:
-            return None
+            raise DistributedGateUnavailable(
+                "KIS mock dispatch has no appkey credential fingerprint; "
+                "cannot scope the distributed gate (HTTP=0 fail-closed)"
+            )
         return build_vts_gate_scope_key(host=request_netloc, app_key=app_key)
 
     async def _await_vts_gate(
@@ -556,13 +595,22 @@ class BaseKISClient:
                 pre_send_hook=pre_send_hook,
                 send_outcome=send_outcome,
             )
-        except PreSendFreshnessError:
-            # ROB-843 P1: a mock pre-send freshness block means NO HTTP happened —
-            # it is not a KIS reachability signal, so it must not move the breaker.
+        except (PreSendFreshnessError, DistributedGateUnavailable):
+            # ROB-843 / ROB-892: these aborted BEFORE any HTTP reached KIS
+            # (mock freshness block / Redis gate failure-or-deadline). They are
+            # not KIS reachability signals, so they must not move the breaker
+            # state or failure count. But ``before_request`` may have handed out
+            # an exclusive HALF_OPEN probe lease; release ONLY that lease so the
+            # next request can probe again (otherwise the breaker stalls open).
+            breaker.release_probe()
             raise
-        except DistributedGateUnavailable:
-            # ROB-892: a Redis gate failure/deadline is a pre-dispatch failure
-            # (HTTP=0), not a KIS reachability signal — must not move the breaker.
+        except asyncio.CancelledError:
+            # A cancellation during the pre-dispatch wait (e.g. mid gate-acquire)
+            # is HTTP=0. It must not be mistaken for KIS reachability (the broad
+            # BaseException handler below would otherwise record_reachable_error
+            # and close a HALF_OPEN probe on a request that never reached KIS).
+            # Release the probe lease only; preserve cancellation semantics.
+            breaker.release_probe()
             raise
         except BaseException as exc:  # noqa: BLE001 — classify then re-raise unchanged
             if is_kis_connect_failure(exc):

--- a/app/services/brokers/kis/base.py
+++ b/app/services/brokers/kis/base.py
@@ -24,6 +24,11 @@ from app.services.brokers.kis.circuit_breaker import (
 )
 from app.services.brokers.kis.pre_send import PreSendFreshnessError, PreSendHook
 from app.services.brokers.kis.send_outcome import OrderSendOutcomeTracker
+from app.services.brokers.kis.vts_distributed_gate import (
+    DistributedGateUnavailable,
+    VTSDistributedGate,
+    get_vts_distributed_gate,
+)
 from app.services.redis_token_manager import redis_token_manager
 
 
@@ -104,6 +109,10 @@ class BaseKISClient:
         self._unmapped_rate_limit_keys_logged: set[str] = set()
         if type(self)._shared_client_lock is None:
             type(self)._shared_client_lock = asyncio.Lock()
+        # ROB-892: injected distributed admit gate for KIS mock (VTS) calls.
+        # ``None`` means "use the process-wide singleton"; tests override this
+        # to point at a disposable Redis. Live dispatch never reaches acquire().
+        self._vts_gate: VTSDistributedGate | None = None
 
     @property
     def _http_client(self) -> httpx.AsyncClient | None:
@@ -147,6 +156,52 @@ class BaseKISClient:
         if not base_url:
             base_url = "https://openapi.koreainvestment.com:9443"
         return f"{base_url}{path}"
+
+    def _vts_gate_scope(self, url: str, headers: dict[str, str]) -> str | None:
+        """Return the ROB-892 distributed-gate scope key for a mock request.
+
+        ``None`` for any non-mock host (live, or test hosts) so live dispatch
+        contacts Redis zero times. The scope is the request's netloc plus a
+        non-reversible sha256 fingerprint of the ``appkey`` header — never the
+        raw credential.
+        """
+        from urllib.parse import urlsplit
+
+        from app.services.brokers.kis.vts_distributed_gate import (
+            build_vts_gate_scope_key,
+        )
+
+        mock_base = getattr(self._settings, "kis_mock_base_url", "") or ""
+        mock_netloc = urlsplit(mock_base.rstrip("/")).netloc.lower()
+        if not mock_netloc:
+            return None
+        request_netloc = urlsplit(url).netloc.lower()
+        if request_netloc != mock_netloc:
+            return None
+        app_key = str(headers.get("appkey") or "")
+        if not app_key:
+            return None
+        return build_vts_gate_scope_key(host=request_netloc, app_key=app_key)
+
+    async def _await_vts_gate(
+        self,
+        scope_key: str,
+        *,
+        freshness_hook: PreSendHook | None,
+        call_class: str,
+    ) -> None:
+        """Admit one mock request through the distributed gate (ROB-892).
+
+        Uses the injected ``_vts_gate`` when set (tests), otherwise the
+        process-wide singleton. Raises ``DistributedGateUnavailable`` on any
+        Redis failure/deadline — a stable pre-dispatch failure (HTTP=0).
+        """
+        gate = self._vts_gate
+        if gate is None:
+            gate = await get_vts_distributed_gate()
+        await gate.acquire(
+            scope_key, freshness_hook=freshness_hook, call_class=call_class
+        )
 
     async def _get_limiter(self, api_key: str, *, rate: int, period: float) -> Any:
         return await get_limiter("kis", api_key, rate=rate, period=period)
@@ -505,6 +560,10 @@ class BaseKISClient:
             # ROB-843 P1: a mock pre-send freshness block means NO HTTP happened —
             # it is not a KIS reachability signal, so it must not move the breaker.
             raise
+        except DistributedGateUnavailable:
+            # ROB-892: a Redis gate failure/deadline is a pre-dispatch failure
+            # (HTTP=0), not a KIS reachability signal — must not move the breaker.
+            raise
         except BaseException as exc:  # noqa: BLE001 — classify then re-raise unchanged
             if is_kis_connect_failure(exc):
                 breaker.record_failure()
@@ -568,12 +627,22 @@ class BaseKISClient:
 
             try:
                 client = await self._ensure_client(timeout=timeout)
-                # ROB-843 P1: the actual HTTP send boundary. Re-check freshness
-                # here — after token/limiter/client prep and rate-limit wait, and
-                # on EVERY retry/re-send — so a mock scalping BUY never POSTs on a
-                # book that went stale/crossed during those awaits. PreSendFreshness
-                # Error propagates cleanly (zero POST); live passes no hook.
-                if pre_send_hook is not None:
+                # ROB-892: distributed admit gate for KIS mock (VTS). The scope
+                # is None for any non-mock host, so live dispatch (and unit
+                # tests using non-mock hosts) contact Redis zero times. For mock
+                # the gate runs the pre_send_hook immediately before its atomic
+                # claim (freshness), rerunning it on contention; after admission
+                # mark_dispatched + HTTP run with no further unbounded wait. A
+                # Redis failure/deadline raises DistributedGateUnavailable
+                # before any HTTP -> mutation HTTP=0 (no fallback).
+                vts_scope = self._vts_gate_scope(url, headers)
+                if vts_scope is not None:
+                    await self._await_vts_gate(
+                        vts_scope,
+                        freshness_hook=pre_send_hook,
+                        call_class=api_name,
+                    )
+                elif pre_send_hook is not None:
                     await pre_send_hook()
                 if send_outcome is not None:
                     send_outcome.mark_dispatched()

--- a/app/services/brokers/kis/circuit_breaker.py
+++ b/app/services/brokers/kis/circuit_breaker.py
@@ -238,6 +238,29 @@ class KISCircuitBreaker:
                 self._cooldown,
             )
 
+    def record_indeterminate(self, token: int | None = None) -> None:
+        """Owner-only outcome for an ambiguous mid-HTTP cancellation (HTTP
+        started, no response).
+
+        Only the CURRENT HALF_OPEN probe owner re-OPENS and restarts the
+        cooldown — its probe outcome is genuinely unknown. In any other state
+        (CLOSED/OPEN) or for a stale/non-owner token this is a complete no-op:
+        a normal client-disconnect / worker-shutdown cancellation must NEVER
+        inflate the CLOSED ``_failures`` count or open the circuit, because it
+        is NOT a KIS connect-failure (P1 merge blocker: N cancellations must
+        not falsely trip the N-strike threshold).
+        """
+        if not self._enabled:
+            return
+        if self._state == _HALF_OPEN and (token is None or token == self._probe_owner):
+            self._probe_in_flight = False
+            self._probe_owner = 0
+            self._opened_at = self._now()
+            self._state = _OPEN
+            logger.warning(
+                "KIS circuit re-opened: probe cancelled mid-HTTP (outcome unknown)"
+            )
+
 
 _breaker: KISCircuitBreaker | None = None
 

--- a/app/services/brokers/kis/circuit_breaker.py
+++ b/app/services/brokers/kis/circuit_breaker.py
@@ -153,6 +153,28 @@ class KISCircuitBreaker:
             self._failures = 0
         self._probe_in_flight = False
 
+    def release_probe(self) -> None:
+        """Release a HALF_OPEN probe lease WITHOUT recording a KIS outcome.
+
+        Call this when ``before_request`` handed out a probe but the call
+        aborted BEFORE any HTTP reached KIS — a pre-send freshness block
+        (``PreSendFreshnessError``), a distributed-gate failure/deadline
+        (``DistributedGateUnavailable``), or an ``asyncio.CancelledError``
+        during the pre-dispatch wait. These are HTTP=0 pre-dispatch aborts:
+
+        * they must NOT be mistaken for a KIS success/failure, so they do not
+          change ``_state`` or the consecutive ``_failures`` count;
+        * they only release the exclusive probe lease so the next request can
+          probe again — otherwise a HALF_OPEN breaker with ``_probe_in_flight``
+          stuck ``True`` raises ``KISCircuitOpen`` forever (ROB-892 merge
+          blocker: a Redis outage during a half-open probe must not permanently
+          stall every subsequent KIS request).
+        """
+        if not self._enabled:
+            return
+        if self._state == _HALF_OPEN:
+            self._probe_in_flight = False
+
     def record_failure(self) -> None:
         if not self._enabled:
             return

--- a/app/services/brokers/kis/circuit_breaker.py
+++ b/app/services/brokers/kis/circuit_breaker.py
@@ -80,6 +80,13 @@ class KISCircuitBreaker:
         self._failures = 0
         self._opened_at = 0.0
         self._probe_in_flight = False
+        # Opaque per-admission lease token + the token of whoever currently owns
+        # the HALF_OPEN probe lease. ``release_probe(token)`` only clears the
+        # lease when ``token`` is the current owner, so an OLDER request that
+        # never owned a (or owned a since-superseded) probe can never release
+        # ANOTHER request's lease (P1 cross-request stale-release blocker).
+        self._next_token = 0
+        self._probe_owner = 0
 
     # --- config (read lazily so the flag / test overrides are always live) ---
     @property
@@ -110,11 +117,20 @@ class KISCircuitBreaker:
         self._failures = 0
         self._opened_at = 0.0
         self._probe_in_flight = False
+        self._probe_owner = 0
 
     # --- gate (SYNCHRONOUS: no await between check and set -> single probe) ---
-    def before_request(self) -> None:
+    def before_request(self) -> int:
+        """Admit one request and return an opaque lease token identifying it.
+
+        Pass the returned token to ``release_probe(token)`` on a pre-dispatch
+        abort; a stale/non-owner token is ignored so an old request can never
+        release another request's HALF_OPEN probe lease.
+        """
+        self._next_token += 1
+        token = self._next_token
         if not self._enabled:
-            return
+            return token
         if self._state == _OPEN:
             elapsed = self._now() - self._opened_at
             if elapsed < self._cooldown:
@@ -122,68 +138,95 @@ class KISCircuitBreaker:
             # cooldown elapsed -> half-open, hand out THIS one probe
             self._state = _HALF_OPEN
             self._probe_in_flight = True
+            self._probe_owner = token
             logger.info("KIS circuit half-open: allowing one probe request")
-            return
+            return token
         if self._state == _HALF_OPEN:
             if self._probe_in_flight:
                 raise KISCircuitOpen(self._cooldown)  # stampede guard
             self._probe_in_flight = True
-            return
+            self._probe_owner = token
+            return token
         # CLOSED
-        return
+        return token
 
-    # --- outcomes ---
-    def record_success(self) -> None:
+    # --- outcomes (token-threaded: a stale/non-owner token never moves the
+    # current HALF_OPEN generation; CLOSED failure-threshold semantics are
+    # preserved and remain token-agnostic) ---
+    def record_success(self, token: int | None = None) -> None:
         if not self._enabled:
             return
         if self._state == _HALF_OPEN:
+            # Only the current probe owner (or a legacy None caller) may close.
+            if token is not None and token != self._probe_owner:
+                return
             logger.info("KIS circuit closed: probe succeeded")
         self._state = _CLOSED
         self._failures = 0
         self._probe_in_flight = False
+        self._probe_owner = 0
 
-    def record_reachable_error(self) -> None:
+    def record_reachable_error(self, token: int | None = None) -> None:
         """KIS responded (429 / HTTPStatusError / business RuntimeError / rate-limit
-        exhausted). Proves reachability: never trips, and closes a half-open probe."""
+        exhausted). Proves reachability: never trips, and closes a half-open probe
+        owned by ``token`` (a stale/non-owner token leaves the generation alone)."""
         if not self._enabled:
             return
         if self._state == _HALF_OPEN:
+            if token is not None and token != self._probe_owner:
+                return
             logger.info("KIS circuit closed: probe reached KIS (non-2xx)")
             self._state = _CLOSED
             self._failures = 0
         self._probe_in_flight = False
+        self._probe_owner = 0
 
-    def release_probe(self) -> None:
-        """Release a HALF_OPEN probe lease WITHOUT recording a KIS outcome.
+    def release_probe(self, token: int | None = None) -> None:
+        """Release the HALF_OPEN probe lease ONLY if ``token`` is the current owner.
 
         Call this when ``before_request`` handed out a probe but the call
         aborted BEFORE any HTTP reached KIS — a pre-send freshness block
         (``PreSendFreshnessError``), a distributed-gate failure/deadline
-        (``DistributedGateUnavailable``), or an ``asyncio.CancelledError``
-        during the pre-dispatch wait. These are HTTP=0 pre-dispatch aborts:
+        (``DistributedGateUnavailable``), or an ``asyncio.CancelledError`` during
+        the pre-dispatch wait. These are HTTP=0 pre-dispatch aborts:
 
         * they must NOT be mistaken for a KIS success/failure, so they do not
           change ``_state`` or the consecutive ``_failures`` count;
-        * they only release the exclusive probe lease so the next request can
-          probe again — otherwise a HALF_OPEN breaker with ``_probe_in_flight``
-          stuck ``True`` raises ``KISCircuitOpen`` forever (ROB-892 merge
-          blocker: a Redis outage during a half-open probe must not permanently
-          stall every subsequent KIS request).
+        * they release the exclusive probe lease so the next request can probe
+          again — otherwise a HALF_OPEN breaker with ``_probe_in_flight`` stuck
+          ``True`` raises ``KISCircuitOpen`` forever.
+
+        Ownership is enforced by the lease token: a stale token (from an older
+        request that never owned the current HALF_OPEN lease) is a no-op, so an
+        old request being cancelled can never release a DIFFERENT request's
+        probe lease (P1 merge blocker).
         """
         if not self._enabled:
             return
-        if self._state == _HALF_OPEN:
+        if (
+            self._state == _HALF_OPEN
+            and token is not None
+            and token == self._probe_owner
+        ):
             self._probe_in_flight = False
 
-    def record_failure(self) -> None:
+    def record_failure(self, token: int | None = None) -> None:
         if not self._enabled:
             return
-        self._probe_in_flight = False
         if self._state == _HALF_OPEN:
+            # Only the current probe owner (or a legacy None caller) may re-open.
+            if token is not None and token != self._probe_owner:
+                return
+            self._probe_in_flight = False
+            self._probe_owner = 0
             self._opened_at = self._now()
             self._state = _OPEN
             logger.warning("KIS circuit re-opened: probe connect-failure")
             return
+        # CLOSED / OPEN: global consecutive-failure counting. Preserved as-is
+        # (token-agnostic) so the N-strike trip threshold is unchanged.
+        self._probe_in_flight = False
+        self._probe_owner = 0
         self._failures += 1
         if self._state == _CLOSED and self._failures >= self._threshold:
             self._opened_at = self._now()

--- a/app/services/brokers/kis/domestic_orders.py
+++ b/app/services/brokers/kis/domestic_orders.py
@@ -12,7 +12,6 @@ from . import constants
 from .base import _log_kis_api_failure
 from .pre_send import PreSendHook
 from .send_outcome import OrderSendOutcomeTracker
-from .vts_order_pacer import get_vts_order_pacer
 
 if TYPE_CHECKING:
     from .protocols import KISClientProtocol
@@ -319,9 +318,6 @@ class DomesticOrderClient:
             f"수량: {quantity}주, 가격: {price if price > 0 else '시장가'}, "
             f"tr_id: {tr_id}, routing: {body['EXCG_ID_DVSN_CD']}"
         )
-
-        if is_mock:
-            await get_vts_order_pacer().acquire()
 
         js = await self._parent._request_with_rate_limit(
             "POST",

--- a/app/services/brokers/kis/overseas_orders.py
+++ b/app/services/brokers/kis/overseas_orders.py
@@ -9,7 +9,6 @@ from app.core.symbol import to_kis_symbol
 
 from . import constants
 from .pre_send import PreSendHook
-from .vts_order_pacer import get_vts_order_pacer
 
 if TYPE_CHECKING:
     from .protocols import KISClientProtocol
@@ -191,9 +190,6 @@ class OverseasOrderClient:
             body.get("ORD_QTY"),
             body.get("OVRS_ORD_UNPR"),
         )
-
-        if is_mock:
-            await get_vts_order_pacer().acquire()
 
         js = await self._parent._request_with_rate_limit(
             "POST",

--- a/app/services/brokers/kis/vts_distributed_gate.py
+++ b/app/services/brokers/kis/vts_distributed_gate.py
@@ -178,6 +178,7 @@ class VTSDistributedGate:
         socket_timeout_seconds: float = _DEFAULT_SOCKET_TIMEOUT_SECONDS,
         socket_connect_timeout_seconds: float = _DEFAULT_SOCKET_CONNECT_TIMEOUT_SECONDS,
         acquire_deadline_seconds: float = _DEFAULT_ACQUIRE_DEADLINE_SECONDS,
+        monotonic: Callable[[], float] = time.monotonic,
     ) -> None:
         if interval_seconds <= 0:
             raise ValueError("interval_seconds must be positive")
@@ -198,6 +199,10 @@ class VTSDistributedGate:
         self._socket_timeout_seconds = float(socket_timeout_seconds)
         self._socket_connect_timeout_seconds = float(socket_connect_timeout_seconds)
         self._acquire_deadline_seconds = float(acquire_deadline_seconds)
+        # Injectable monotonic clock so deadline arithmetic is deterministic in
+        # tests (real Redis is still real-time; ``asyncio.wait_for`` bounds use
+        # wall time). Production uses ``time.monotonic``.
+        self._monotonic = monotonic
         self._redis: redis.Redis | None = None
         self._redis_lock = asyncio.Lock()
         self._claim_sha: str | None = None
@@ -255,20 +260,35 @@ class VTSDistributedGate:
                 f"VTS distributed gate Redis claim failed for scope {scope_key!r}: {exc}"
             ) from exc
 
-        if not isinstance(raw, (list, tuple)) or len(raw) < 2:
+        if not isinstance(raw, (list, tuple)) or len(raw) != 2:
             raise DistributedGateUnavailable(
                 f"VTS distributed gate returned malformed result for scope "
                 f"{scope_key!r}: {raw!r}"
             )
         try:
-            admitted = bool(int(raw[0]))
+            admitted_value = int(raw[0])
             retry_after_ms = int(raw[1])
         except (TypeError, ValueError) as exc:
             raise DistributedGateUnavailable(
                 f"VTS distributed gate returned non-numeric result for scope "
                 f"{scope_key!r}: {raw!r}"
             ) from exc
-        return admitted, max(0.0, retry_after_ms / 1000.0)
+        # Reject anything outside the exact claim protocol: admission must be a
+        # 0/1 bit (a value like 2 must never authorize HTTP), retry_after must be
+        # non-negative, and a denial MUST carry a positive retry (otherwise the
+        # caller would busy-loop Redis). All malformed/corrupt results fail
+        # closed instead of coercing/clamping.
+        if admitted_value not in (0, 1) or retry_after_ms < 0:
+            raise DistributedGateUnavailable(
+                f"VTS distributed gate returned invalid result for scope "
+                f"{scope_key!r}: {raw!r}"
+            )
+        if admitted_value == 0 and retry_after_ms == 0:
+            raise DistributedGateUnavailable(
+                f"VTS distributed gate denied with zero retry for scope "
+                f"{scope_key!r}: {raw!r}"
+            )
+        return admitted_value == 1, retry_after_ms / 1000.0
 
     async def acquire(
         self,
@@ -302,7 +322,7 @@ class VTSDistributedGate:
             asyncio.CancelledError: re-raised if the wait is cancelled; the
                 caller never started HTTP (HTTP=0).
         """
-        start = time.monotonic()
+        start = self._monotonic()
         pid = os.getpid()
         if deadline_monotonic is None:
             deadline_monotonic = start + self._acquire_deadline_seconds
@@ -310,16 +330,63 @@ class VTSDistributedGate:
         attempts = 0
         last_fingerprint = scope_key.rsplit(":", 1)[-1]
 
+        def _remaining() -> float:
+            return deadline_monotonic - self._monotonic()
+
         # Freshness is run BEFORE every claim attempt, including the first,
         # so the very first (likely-immediately-admissible) claim still
-        # verifies the book right before the atomic admit.
+        # verifies the book right before the atomic admit. Every await is
+        # bounded by the remaining deadline budget and the deadline is rechecked
+        # after each await, so a slow freshness hook or Redis claim can never
+        # admit past the deadline (CR3).
         while True:
+            if _remaining() <= 0:
+                raise DistributedGateUnavailable(
+                    f"VTS distributed gate acquire deadline "
+                    f"({self._acquire_deadline_seconds:.1f}s) already exceeded "
+                    f"for scope {scope_key!r} (class={call_class}, pid={pid})"
+                )
             if freshness_hook is not None:
-                await freshness_hook()
+                try:
+                    await asyncio.wait_for(freshness_hook(), _remaining())
+                except TimeoutError as exc:
+                    raise DistributedGateUnavailable(
+                        f"VTS distributed gate freshness exceeded the acquire "
+                        f"deadline for scope {scope_key!r} (class={call_class})"
+                    ) from exc
+                if _remaining() <= 0:
+                    raise DistributedGateUnavailable(
+                        f"VTS distributed gate acquire deadline crossed during "
+                        f"freshness for scope {scope_key!r} (class={call_class})"
+                    )
             attempts += 1
-            admitted, retry_after = await self._claim(scope_key)
+            remaining_for_claim = _remaining()
+            if remaining_for_claim <= 0:
+                raise DistributedGateUnavailable(
+                    f"VTS distributed gate acquire deadline exceeded for scope "
+                    f"{scope_key!r} (class={call_class}, pid={pid})"
+                )
+            try:
+                admitted, retry_after = await asyncio.wait_for(
+                    self._claim(scope_key), remaining_for_claim
+                )
+            except TimeoutError as exc:
+                raise DistributedGateUnavailable(
+                    f"VTS distributed gate claim exceeded the acquire deadline "
+                    f"for scope {scope_key!r} (class={call_class})"
+                ) from exc
             if admitted:
-                waited = time.monotonic() - start
+                # CR3: a claim that succeeded after the deadline crossed has
+                # already consumed the slot in Redis (the Lua SET ran). Be
+                # conservative — never recycle that slot into a retry — but
+                # keep the HTTP=0 contract by failing closed here.
+                if _remaining() <= 0:
+                    raise DistributedGateUnavailable(
+                        f"VTS distributed gate admitted after the deadline "
+                        f"crossed; slot consumed, HTTP=0 for scope {scope_key!r} "
+                        f"(class={call_class}, pid={pid})"
+                    )
+                waited = self._monotonic() - start
                 if attempts > 1 or waited > 0.01:
                     logger.info(
                         "vts_gate admitted scope=%s fp=%s pid=%s class=%s "
@@ -339,8 +406,7 @@ class VTSDistributedGate:
 
             # Contention: another PID won this slot. Sleep without spinning,
             # but never past the bounded deadline.
-            now = time.monotonic()
-            if now + retry_after > deadline_monotonic:
+            if self._monotonic() + retry_after > deadline_monotonic:
                 raise DistributedGateUnavailable(
                     f"VTS distributed gate acquire deadline "
                     f"({self._acquire_deadline_seconds:.1f}s) exceeded for "

--- a/app/services/brokers/kis/vts_distributed_gate.py
+++ b/app/services/brokers/kis/vts_distributed_gate.py
@@ -273,14 +273,22 @@ class VTSDistributedGate:
                 f"VTS distributed gate returned non-numeric result for scope "
                 f"{scope_key!r}: {raw!r}"
             ) from exc
-        # Reject anything outside the exact claim protocol: admission must be a
-        # 0/1 bit (a value like 2 must never authorize HTTP), retry_after must be
-        # non-negative, and a denial MUST carry a positive retry (otherwise the
-        # caller would busy-loop Redis). All malformed/corrupt results fail
-        # closed instead of coercing/clamping.
+        # Reject anything outside the exact claim protocol:
+        #   * admission must be a 0/1 bit (a value like 2 must never authorize HTTP);
+        #   * retry_after must be non-negative;
+        #   * an ADMIT (1) MUST carry a zero retry — the Lua success shape is
+        #     exactly [1, 0]; [1, positive] is not a valid admit and is rejected
+        #     so a corrupt result can never authorize HTTP with a stale retry;
+        #   * a DENY (0) MUST carry a positive retry (otherwise busy-loop).
+        # All malformed/corrupt results fail closed instead of coercing/clamping.
         if admitted_value not in (0, 1) or retry_after_ms < 0:
             raise DistributedGateUnavailable(
                 f"VTS distributed gate returned invalid result for scope "
+                f"{scope_key!r}: {raw!r}"
+            )
+        if admitted_value == 1 and retry_after_ms != 0:
+            raise DistributedGateUnavailable(
+                f"VTS distributed gate admitted with non-zero retry for scope "
                 f"{scope_key!r}: {raw!r}"
             )
         if admitted_value == 0 and retry_after_ms == 0:

--- a/app/services/brokers/kis/vts_distributed_gate.py
+++ b/app/services/brokers/kis/vts_distributed_gate.py
@@ -1,0 +1,400 @@
+"""ROB-892 — distributed Redis gate for KIS mock (VTS) REST dispatch.
+
+The official KIS mock (VTS, ``openapivts.koreainvestment.com``) enforces a
+conservative account/app-key-scoped budget of **one admitted request per
+second** for *every* REST call (orders AND reads, domestic AND overseas,
+regardless of TR id / path). The previous ``VTSOrderPacer`` was (a) only
+applied to place-order POSTs and (b) process-local, so independent
+API/MCP/worker PIDs could still burst the shared credential budget.
+
+This module implements the distributed replacement. Design invariants
+(see ROB-892 spec):
+
+* Enforced at the common actual-dispatch boundary in ``base.py``, not per
+  MCP handler / order method.
+* Authority is **Redis server ``TIME`` + atomic Lua** — never the host wall
+  clock, never a future reservation, never a lock held during sleep or the
+  full HTTP call. A "claim" merely records the last-admitted server
+  timestamp; it is a token-bucket-style admit, not a held mutex. A claim
+  lost to cancellation/crash is **not** released or recycled into an order
+  retry (conservative).
+* Scope key is the exact mock host + a **non-reversible** sha256 fingerprint
+  of the app key (reusing the safe ``_kis_mock_token_namespace`` pattern).
+  Raw app key / secret / token / account never appear in the key, logs, or
+  errors.
+* Interval is ``1.0s`` plus a small configurable safety margin. TTL/cold
+  start is deterministic.
+* On contention the gate returns/computes ``retry-after`` and sleeps without
+  spinning, retrying the atomic claim until a bounded deadline. Cancellation
+  while waiting means HTTP=0.
+* **Fail-closed:** Redis error/timeout, a malformed Lua result, or an
+  acquire-deadline is a stable pre-dispatch failure (raises
+  ``DistributedGateUnavailable``). Mutations prove HTTP=0 and never fall
+  back to local or unthrottled HTTP. Reads cannot bypass the gate during a
+  Redis outage because they consume the same quota and fail the same way.
+* Live requests never call this gate (the dispatch boundary short-circuits
+  when the request host is not the VTS host).
+
+Dispatch ordering preserved by ``BaseKISClient``:
+
+    prepare token / client / local limiter
+      -> wait for distributed availability (contention sleep)
+      -> run order ``pre_send_hook`` (freshness)
+      -> atomically claim immediately before dispatch
+      -> mark dispatched + start HTTP (no further unbounded wait)
+
+If another PID wins the claim, the gate waits and **reruns freshness** on
+the next claim attempt; no long gate wait follows the final freshness check.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import logging
+import os
+import time
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from urllib.parse import urlsplit
+
+import redis.asyncio as redis
+
+logger = logging.getLogger(__name__)
+
+# One admitted request per second is the official KIS mock account/app-key
+# budget. The safety margin absorbs Redis/server clock skew so two adjacent
+# admits can never land within the real 1.0s window.
+_DEFAULT_INTERVAL_SECONDS = 1.0
+_DEFAULT_SAFETY_MARGIN_SECONDS = 0.05
+# Cooldown timestamp TTL: bounds cold-start ambiguity and lets a crashed
+# scope recover deterministically without operator intervention. Long enough
+# to survive a Redis EVENTUX/failover tick, short enough to avoid a stuck
+# scope after a credential rotation.
+_DEFAULT_TTL_SECONDS = 120
+_DEFAULT_SOCKET_TIMEOUT_SECONDS = 2.0
+_DEFAULT_SOCKET_CONNECT_TIMEOUT_SECONDS = 2.0
+# Bounded deadline for acquiring a permit under contention. Generous enough
+# for a small backlog to drain, short enough that a mutation fails closed
+# instead of hanging the caller.
+_DEFAULT_ACQUIRE_DEADLINE_SECONDS = 10.0
+
+# Redis key prefix is intentionally distinct from the OAuth token namespace
+# (``kis_mock:{host}:{fp}``) so the gate state never collides with token
+# cache state for the same credential scope.
+_KEY_PREFIX = "kis_mock:gate"
+
+# Atomic claim. Uses Redis server TIME (never the host clock). Returns a
+# two-element array: ``{admitted(1/0), retry_after_ms}``. ``admitted=1``
+# means THIS caller recorded the last-admit timestamp and may dispatch;
+# ``admitted=0`` means another caller owns the current slot and the caller
+# must sleep ``retry_after_ms`` and retry. The key TTL is refreshed on every
+# claim (admitted or not) so a waiter never sees a stale/missing cooldown.
+_CLAIM_LUA = """
+local now = redis.call('TIME')
+local now_ms = tonumber(now[1]) * 1000 + math.floor(tonumber(now[2]) / 1000)
+local interval_ms = tonumber(ARGV[1])
+local ttl_ms = tonumber(ARGV[2])
+local last = redis.call('GET', KEYS[1])
+if not last then
+    redis.call('SET', KEYS[1], tostring(now_ms), 'PX', ttl_ms)
+    return {1, 0}
+end
+last = tonumber(last)
+local eligible_at = last + interval_ms
+if now_ms >= eligible_at then
+    redis.call('SET', KEYS[1], tostring(now_ms), 'PX', ttl_ms)
+    return {1, 0}
+end
+redis.call('PEXPIRE', KEYS[1], ttl_ms)
+return {0, eligible_at - now_ms}
+"""
+
+
+class DistributedGateUnavailable(RuntimeError):
+    """Stable pre-dispatch failure: Redis unreachable/timeout/malformed, or
+    the acquire deadline elapsed.
+
+    Raised *before* any HTTP mutation, so callers can prove HTTP=0. Mutations
+    must surface this as NOT_CREATED-equivalent and never fall back to local
+    or unthrottled HTTP.
+    """
+
+
+@dataclass(frozen=True)
+class AcquireResult:
+    """Outcome of a successful gate acquisition (for logging/metrics only)."""
+
+    scope_key: str
+    waited_seconds: float
+    contention_attempts: int
+
+
+FreshnessHook = Callable[[], Awaitable[None]]
+
+
+def _app_key_fingerprint(app_key: str) -> str:
+    """Non-reversible 16-hex-char fingerprint, matching the token namespace."""
+    return hashlib.sha256(app_key.encode()).hexdigest()[:16]
+
+
+def build_vts_gate_scope_key(*, host: str, app_key: str) -> str:
+    """Build the distributed-gate scope key for one VTS credential scope.
+
+    ``host`` MUST be the normalized ``netloc`` (``host[:port]``) of the mock
+    base URL, lower-cased. ``app_key`` is the raw mock app key; only its
+    sha256 fingerprint appears in the key.
+    """
+    normalized = (host or "").lower()
+    if not normalized:
+        raise ValueError("VTS gate scope requires a non-empty host")
+    if not app_key:
+        # An empty app key cannot identify a credential scope; fail loudly
+        # rather than silently collapsing every empty-key caller into one.
+        raise ValueError("VTS gate scope requires a non-empty app key")
+    return f"{_KEY_PREFIX}:{normalized}:{_app_key_fingerprint(app_key)}"
+
+
+def netloc_from_url(url: str) -> str:
+    """Extract the lower-cased ``netloc`` (host[:port]) from an absolute URL."""
+    return urlsplit(url).netloc.lower()
+
+
+class VTSDistributedGate:
+    """Redis-backed distributed admit gate for KIS mock (VTS) REST calls.
+
+    A single process-wide instance is shared by every mock dispatch path
+    (see ``get_vts_distributed_gate``). The instance is cheap to construct
+    and only contacts Redis inside ``acquire``; live requests never call it.
+    """
+
+    def __init__(
+        self,
+        *,
+        redis_url: str,
+        interval_seconds: float = _DEFAULT_INTERVAL_SECONDS,
+        safety_margin_seconds: float = _DEFAULT_SAFETY_MARGIN_SECONDS,
+        ttl_seconds: int = _DEFAULT_TTL_SECONDS,
+        socket_timeout_seconds: float = _DEFAULT_SOCKET_TIMEOUT_SECONDS,
+        socket_connect_timeout_seconds: float = _DEFAULT_SOCKET_CONNECT_TIMEOUT_SECONDS,
+        acquire_deadline_seconds: float = _DEFAULT_ACQUIRE_DEADLINE_SECONDS,
+    ) -> None:
+        if interval_seconds <= 0:
+            raise ValueError("interval_seconds must be positive")
+        if safety_margin_seconds < 0:
+            raise ValueError("safety_margin_seconds must be non-negative")
+        if ttl_seconds <= 0:
+            raise ValueError("ttl_seconds must be positive")
+        if acquire_deadline_seconds <= 0:
+            raise ValueError("acquire_deadline_seconds must be positive")
+
+        self._redis_url = redis_url
+        self._interval_seconds = float(interval_seconds)
+        self._safety_margin_seconds = float(safety_margin_seconds)
+        self._interval_with_margin_ms = int(
+            round((self._interval_seconds + self._safety_margin_seconds) * 1000)
+        )
+        self._ttl_ms = int(ttl_seconds) * 1000
+        self._socket_timeout_seconds = float(socket_timeout_seconds)
+        self._socket_connect_timeout_seconds = float(socket_connect_timeout_seconds)
+        self._acquire_deadline_seconds = float(acquire_deadline_seconds)
+        self._redis: redis.Redis | None = None
+        self._redis_lock = asyncio.Lock()
+        self._claim_sha: str | None = None
+
+    @property
+    def interval_seconds(self) -> float:
+        return self._interval_seconds
+
+    @property
+    def safety_margin_seconds(self) -> float:
+        return self._safety_margin_seconds
+
+    async def _get_redis(self) -> redis.Redis:
+        if self._redis is None:
+            async with self._redis_lock:
+                if self._redis is None:
+                    self._redis = redis.from_url(
+                        self._redis_url,
+                        socket_timeout=self._socket_timeout_seconds,
+                        socket_connect_timeout=self._socket_connect_timeout_seconds,
+                        decode_responses=True,
+                    )
+        assert self._redis is not None
+        return self._redis
+
+    async def close(self) -> None:
+        """Close the Redis connection. Safe to call multiple times."""
+        if self._redis is not None:
+            try:
+                await self._redis.aclose()
+            except Exception:  # noqa: BLE001 — best-effort cleanup
+                pass
+            self._redis = None
+
+    async def _claim(self, scope_key: str) -> tuple[bool, float]:
+        """Run the atomic Lua claim. Returns ``(admitted, retry_after_seconds)``.
+
+        Any Redis error, timeout, or malformed result is translated into
+        ``DistributedGateUnavailable`` (fail-closed, HTTP=0).
+        """
+        try:
+            client = await self._get_redis()
+            # EVAL every call (no EVALSHA cache) so the disposable test server
+            # and a fresh prod Redis both work without a NOSCRIPT retry path.
+            raw = await client.execute_command(
+                "EVAL",
+                _CLAIM_LUA,
+                1,
+                scope_key,
+                str(self._interval_with_margin_ms),
+                str(self._ttl_ms),
+            )
+        except Exception as exc:  # noqa: BLE001 — every Redis failure is fail-closed
+            raise DistributedGateUnavailable(
+                f"VTS distributed gate Redis claim failed for scope {scope_key!r}: {exc}"
+            ) from exc
+
+        if not isinstance(raw, (list, tuple)) or len(raw) < 2:
+            raise DistributedGateUnavailable(
+                f"VTS distributed gate returned malformed result for scope "
+                f"{scope_key!r}: {raw!r}"
+            )
+        try:
+            admitted = bool(int(raw[0]))
+            retry_after_ms = int(raw[1])
+        except (TypeError, ValueError) as exc:
+            raise DistributedGateUnavailable(
+                f"VTS distributed gate returned non-numeric result for scope "
+                f"{scope_key!r}: {raw!r}"
+            ) from exc
+        return admitted, max(0.0, retry_after_ms / 1000.0)
+
+    async def acquire(
+        self,
+        scope_key: str,
+        *,
+        freshness_hook: FreshnessHook | None = None,
+        deadline_monotonic: float | None = None,
+        call_class: str = "unknown",
+    ) -> AcquireResult:
+        """Block until a distributed permit is admitted for ``scope_key``.
+
+        Ordering: coarse contention wait -> run ``freshness_hook`` -> atomic
+        claim immediately before dispatch. On contention (another PID won the
+        current slot), sleep ``retry-after`` and **rerun freshness** on the
+        next claim attempt. Returns once the atomic claim succeeded — the
+        caller must then mark dispatched and start HTTP with no further
+        unbounded wait.
+
+        Args:
+            scope_key: credential/host scope (see ``build_vts_gate_scope_key``).
+            freshness_hook: optional mock pre-send freshness callback, rerun
+                before every claim attempt so a stale book is never POSTed.
+            deadline_monotonic: absolute ``time.monotonic()`` deadline. When
+                ``None`` the configured ``acquire_deadline_seconds`` budget is
+                used (measured from the first claim attempt).
+            call_class: safe label (e.g. ``"order"``, ``"read"``) for logs.
+
+        Raises:
+            DistributedGateUnavailable: Redis error/timeout/malformed, or the
+                acquire deadline elapsed (HTTP=0, no fallback).
+            asyncio.CancelledError: re-raised if the wait is cancelled; the
+                caller never started HTTP (HTTP=0).
+        """
+        start = time.monotonic()
+        pid = os.getpid()
+        if deadline_monotonic is None:
+            deadline_monotonic = start + self._acquire_deadline_seconds
+
+        attempts = 0
+        last_fingerprint = scope_key.rsplit(":", 1)[-1]
+
+        # Freshness is run BEFORE every claim attempt, including the first,
+        # so the very first (likely-immediately-admissible) claim still
+        # verifies the book right before the atomic admit.
+        while True:
+            if freshness_hook is not None:
+                await freshness_hook()
+            attempts += 1
+            admitted, retry_after = await self._claim(scope_key)
+            if admitted:
+                waited = time.monotonic() - start
+                if attempts > 1 or waited > 0.01:
+                    logger.info(
+                        "vts_gate admitted scope=%s fp=%s pid=%s class=%s "
+                        "attempts=%d waited=%.3fs",
+                        scope_key,
+                        last_fingerprint,
+                        pid,
+                        call_class,
+                        attempts,
+                        waited,
+                    )
+                return AcquireResult(
+                    scope_key=scope_key,
+                    waited_seconds=waited,
+                    contention_attempts=attempts,
+                )
+
+            # Contention: another PID won this slot. Sleep without spinning,
+            # but never past the bounded deadline.
+            now = time.monotonic()
+            if now + retry_after > deadline_monotonic:
+                raise DistributedGateUnavailable(
+                    f"VTS distributed gate acquire deadline "
+                    f"({self._acquire_deadline_seconds:.1f}s) exceeded for "
+                    f"scope {scope_key!r} (class={call_class}, pid={pid})"
+                )
+            logger.info(
+                "vts_gate contention scope=%s fp=%s pid=%s class=%s "
+                "retry_after=%.3fs attempt=%d",
+                scope_key,
+                last_fingerprint,
+                pid,
+                call_class,
+                retry_after,
+                attempts,
+            )
+            await asyncio.sleep(retry_after)
+
+
+# ---------------------------------------------------------------------------
+# Process-wide singleton
+# ---------------------------------------------------------------------------
+
+_gate: VTSDistributedGate | None = None
+_gate_lock = asyncio.Lock()
+
+
+async def get_vts_distributed_gate() -> VTSDistributedGate:
+    """Return the process-wide gate, lazily built from runtime settings.
+
+    Only ``acquire`` contacts Redis; constructing the singleton is free, so
+    live processes that never dispatch a mock call pay zero Redis cost.
+    """
+    global _gate
+    if _gate is None:
+        async with _gate_lock:
+            if _gate is None:
+                from app.core.config import settings  # local import avoids cycles
+
+                _gate = VTSDistributedGate(
+                    redis_url=settings.get_redis_url(),
+                    interval_seconds=_DEFAULT_INTERVAL_SECONDS,
+                    safety_margin_seconds=_DEFAULT_SAFETY_MARGIN_SECONDS,
+                    ttl_seconds=_DEFAULT_TTL_SECONDS,
+                    socket_timeout_seconds=_DEFAULT_SOCKET_TIMEOUT_SECONDS,
+                    socket_connect_timeout_seconds=_DEFAULT_SOCKET_CONNECT_TIMEOUT_SECONDS,
+                    acquire_deadline_seconds=_DEFAULT_ACQUIRE_DEADLINE_SECONDS,
+                )
+    return _gate
+
+
+async def reset_vts_distributed_gate() -> None:
+    """Discard the singleton (tests only). Closes any open Redis connection."""
+    global _gate
+    async with _gate_lock:
+        if _gate is not None:
+            await _gate.close()
+        _gate = None

--- a/app/services/brokers/kis/vts_order_pacer.py
+++ b/app/services/brokers/kis/vts_order_pacer.py
@@ -1,15 +1,20 @@
 """ROB-892: process-local serial pacer for VTS (KIS mock) order POSTs.
 
-The official KIS mock REST limit is 1 order per second (per account/app-key).
-The existing ``AsyncSlidingWindowRateLimiter`` keys on ``TR_ID|path``, so buy
-and sell have independent 8/s budgets that allow bursts. This pacer serializes
-all VTS order POSTs (buy + sell, domestic + overseas) through a single
-process-local gate with a minimum 1-second interval between dispatches.
+SUPERSEDED — retained for backward-compat/test coverage only.
 
-Design:
+The official KIS mock REST limit is 1 request per second (per account/app-key)
+applied to *every* REST call (orders AND reads, domestic AND overseas). This
+process-local pacer was (a) only applied to place-order POSTs and (b) unable
+to coordinate independent API/MCP/worker PIDs. ROB-892 replaces it with the
+Redis-backed distributed gate in ``vts_distributed_gate.py``, enforced at the
+common actual-dispatch boundary in ``base.py``. No runtime dispatch path calls
+this pacer any more (single authority = the distributed gate). The class is
+kept as a self-contained serial-pacer utility with its existing unit tests.
+
+Design (historical):
 - ``asyncio.Lock`` + monotonic clock → strict serial ordering.
 - Injectable ``clock`` / ``sleep`` for deterministic concurrent tests.
-- Module-level singleton so every mock order path shares one gate.
+- Module-level singleton so every mock order path shared one gate.
 - No retry, no Redis, no distributed coordination (process-local scope only).
 """
 

--- a/tests/brokers/kis/test_vts_distributed_gate.py
+++ b/tests/brokers/kis/test_vts_distributed_gate.py
@@ -1,21 +1,28 @@
 """ROB-892 — distributed Redis gate for KIS mock (VTS) REST dispatch.
 
-Test surface (per the ROB-892 acceptance spec):
+Test surface (per the ROB-892 acceptance spec + CodeRabbit/independent review):
 
-* A real disposable ``redis-server`` is launched per test session; no
-  ``fakeredis`` object is accepted as proof.
+* A real disposable ``redis-server`` is launched per test module when the
+  binary is available; otherwise the CI job Redis service is tried on an
+  isolated DB index. If neither is available the suite FAILS (never silently
+  skips) — the real-Redis acceptance is required, not optional.
 * A multiprocessing suite runs >=2 independent PIDs/clients concurrently
   issuing KR buy, KR sell, and a mock read through the *real* dispatch
-  boundary. Actual ``_execute_http_request`` START timestamps are measured
-  (not ``acquire()`` returns); adjacent starts for one scope meet the
-  configured interval and each intended dispatch fires at most once.
+  boundary, synchronized by a shared ``Barrier``. Actual
+  ``_execute_http_request`` START timestamps are measured (not ``acquire()``
+  returns); adjacent starts for one scope meet the configured interval +
+  safety margin, and each intended dispatch fires at most once.
 * Same credential across TR/path/market/side/read/order shares one key;
   distinct credentials/hosts isolate.
 * Redis unavailable / timeout, acquire-deadline, wait-cancellation, and
-  pre-send-freshness failure all produce mutation HTTP=0 (no fallback).
+  pre-send-freshness failure all produce mutation HTTP=0 (no fallback) AND do
+  not leak a HALF_OPEN circuit-breaker probe lease (P1 merge blocker).
 * Contention loser reruns freshness; no long gate wait follows the final
-  freshness check.
-* Live requests touch Redis zero times.
+  freshness check; the deadline bounds every freshness/claim await.
+* Live requests are PROVEN to never contact Redis (the gate's ``_claim`` is
+  spied and asserted not awaited).
+* Malformed Lua results (wrong arity, admission outside {0,1}, negative /
+  zero retry) fail closed.
 * TTL / cold start / safety margin / bounded backlog are deterministic, and
   keys/logs carry no raw secret.
 """
@@ -25,16 +32,19 @@ from __future__ import annotations
 import asyncio
 import logging
 import multiprocessing as mp
+import os
 import socket
 import subprocess
 import time
 from contextlib import closing
+from shutil import which
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from app.services.brokers.kis.base import BaseKISClient
+from app.services.brokers.kis.circuit_breaker import KISCircuitBreaker
 from app.services.brokers.kis.vts_distributed_gate import (
     AcquireResult,
     DistributedGateUnavailable,
@@ -50,9 +60,13 @@ MOCK_BASE_URL = f"https://{MOCK_HOST}"
 LIVE_HOST = "openapi.koreainvestment.com:9443"
 MOCK_APP_KEY = "test-mock-app-key-ROB892"
 
+# Small measurement tolerance for server-enforced gaps (covers scheduling +
+# monotonic-clock noise). Tight enough to actually guarantee interval + margin.
+_TIMING_TOLERANCE = 0.03
+
 
 # ---------------------------------------------------------------------------
-# Disposable real redis-server fixture
+# Real Redis resolution: disposable spawn > CI service > FAIL (never skip)
 # ---------------------------------------------------------------------------
 
 
@@ -62,16 +76,18 @@ def _free_tcp_port() -> int:
         return int(s.getsockname()[1])
 
 
-class _DisposableRedis:
-    """A real redis-server subprocess bound to 127.0.0.1:<port> for one suite."""
+class _RealRedis:
+    """Handle for a real Redis used by this module (spawned or service)."""
 
-    def __init__(self) -> None:
-        self.port = _free_tcp_port()
-        self.url = f"redis://127.0.0.1:{self.port}/0"
+    def __init__(self, url: str, *, spawned: bool, port: int | None) -> None:
+        self.url = url
+        self.spawned = spawned
+        self.port = port
         self.proc: subprocess.Popen[str] | None = None
 
-    def start(self) -> None:
-        # --daemonize no, log to stdout, no persistence, bind loopback only.
+    def start_disposable(self) -> None:
+        self.port = _free_tcp_port()
+        self.url = f"redis://127.0.0.1:{self.port}/0"
         self.proc = subprocess.Popen(
             [
                 "redis-server",
@@ -92,7 +108,6 @@ class _DisposableRedis:
             stderr=subprocess.STDOUT,
             text=True,
         )
-        # Wait for readiness.
         deadline = time.monotonic() + 10.0
         while time.monotonic() < deadline:
             if self.proc.poll() is not None:
@@ -117,38 +132,68 @@ class _DisposableRedis:
                 self.proc.kill()
             self.proc = None
 
-    @property
-    def version(self) -> str:
-        out = subprocess.run(
-            ["redis-cli", "-h", "127.0.0.1", "-p", str(self.port), "INFO", "server"],
-            capture_output=True,
-            text=True,
-            timeout=5,
-            check=False,
-        ).stdout
-        for line in out.splitlines():
-            if line.startswith("redis_version:"):
-                return line.split(":", 1)[1].strip()
-        return "unknown"
+    def flush(self) -> None:
+        if self.spawned and self.port is not None:
+            subprocess.run(
+                ["redis-cli", "-h", "127.0.0.1", "-p", str(self.port), "FLUSHDB"],
+                capture_output=True,
+                timeout=5,
+                check=False,
+            )
+        else:
+            subprocess.run(
+                ["redis-cli", "-n", "15", "FLUSHDB"],
+                capture_output=True,
+                timeout=5,
+                check=False,
+            )
+
+
+def _redis_ping(url: str) -> bool:
+    import redis.asyncio as _redis
+
+    async def _p() -> bool:
+        c = _redis.from_url(url, socket_connect_timeout=1.0, socket_timeout=1.0)
+        try:
+            return bool(await c.ping())
+        finally:
+            await c.aclose()
+
+    try:
+        return asyncio.new_event_loop().run_until_complete(_p())
+    except Exception:  # noqa: BLE001
+        return False
 
 
 @pytest.fixture(scope="module")
-def disposable_redis() -> Any:
-    """Launch + tear down a real isolated redis-server for this module."""
-    if not shutil_which("redis-server"):
-        pytest.skip("redis-server not installed on this host")
-    rd = _DisposableRedis()
-    rd.start()
-    try:
-        yield rd
-    finally:
-        rd.stop()
+def real_redis() -> Any:
+    """Resolve a real Redis for this module: disposable spawn > CI service > FAIL.
 
+    Never touches production Redis. If Redis is required but unavailable the
+    suite fails loudly instead of skipping (ROB-892 acceptance is mandatory).
+    """
+    # 1. Best isolation: spawn a disposable redis-server on a random port.
+    if which("redis-server"):
+        rd = _RealRedis(url="", spawned=True, port=None)
+        rd.start_disposable()
+        try:
+            yield rd
+        finally:
+            rd.stop()
+        return
 
-def shutil_which(cmd: str) -> str | None:
-    from shutil import which
+    # 2. CI job Redis service on an isolated DB index (15) so it never clashes
+    #    with conftest's DB 0 consumers.
+    service_url = os.environ.get("ROB892_TEST_REDIS_URL", "redis://localhost:6379/15")
+    if _redis_ping(service_url):
+        yield _RealRedis(url=service_url, spawned=False, port=None)
+        return
 
-    return which(cmd)
+    # 3. Required but unavailable -> fail (never skip silently).
+    pytest.fail(
+        "ROB-892 real-Redis acceptance requires a disposable redis-server binary "
+        "or a reachable Redis service, but neither was available."
+    )
 
 
 def _make_gate(
@@ -160,6 +205,7 @@ def _make_gate(
     ttl_seconds: int = 120,
     socket_timeout_seconds: float = 2.0,
     socket_connect_timeout_seconds: float = 2.0,
+    monotonic=time.monotonic,
 ) -> VTSDistributedGate:
     return VTSDistributedGate(
         redis_url=redis_url,
@@ -169,18 +215,19 @@ def _make_gate(
         ttl_seconds=ttl_seconds,
         socket_timeout_seconds=socket_timeout_seconds,
         socket_connect_timeout_seconds=socket_connect_timeout_seconds,
+        monotonic=monotonic,
     )
 
 
 # ===========================================================================
-# Section 1 — gate module unit tests (real disposable Redis)
+# Section 1 — gate module unit/integration tests (real disposable Redis)
 # ===========================================================================
 
 
 @pytest.mark.asyncio
 @pytest.mark.integration
-async def test_first_admit_is_immediate(disposable_redis: _DisposableRedis):
-    gate = _make_gate(disposable_redis.url)
+async def test_first_admit_is_immediate(real_redis: _RealRedis):
+    gate = _make_gate(real_redis.url)
     try:
         scope = build_vts_gate_scope_key(host=MOCK_HOST, app_key=MOCK_APP_KEY)
         t0 = time.monotonic()
@@ -195,10 +242,11 @@ async def test_first_admit_is_immediate(disposable_redis: _DisposableRedis):
 
 @pytest.mark.asyncio
 @pytest.mark.integration
-async def test_adjacent_admits_meet_interval(disposable_redis: _DisposableRedis):
-    """Two sequential admits through the gate must be >= interval apart."""
+async def test_adjacent_admits_meet_interval_plus_margin(real_redis: _RealRedis):
+    """Two sequential admits must be >= interval + safety_margin apart."""
+    interval, margin = 0.40, 0.05
     gate = _make_gate(
-        disposable_redis.url, interval_seconds=0.4, safety_margin_seconds=0.05
+        real_redis.url, interval_seconds=interval, safety_margin_seconds=margin
     )
     try:
         scope = build_vts_gate_scope_key(host=MOCK_HOST, app_key="adjacent")
@@ -206,18 +254,20 @@ async def test_adjacent_admits_meet_interval(disposable_redis: _DisposableRedis)
         t0 = time.monotonic()
         await gate.acquire(scope, call_class="order")
         gap = time.monotonic() - t0
-        # 0.4 + 0.05 margin -> gap must be >= 0.40 (allow tiny scheduling slop)
-        assert gap >= 0.40 - 0.03, f"second admit came too early: {gap:.3f}s"
+        assert gap >= interval + margin - _TIMING_TOLERANCE, (
+            f"second admit came too early: {gap:.3f}s < {interval + margin}s"
+        )
     finally:
         await gate.close()
 
 
 @pytest.mark.asyncio
 @pytest.mark.integration
-async def test_concurrent_admits_serialize_no_burst(disposable_redis: _DisposableRedis):
-    """Three concurrent acquires for the same scope never burst past 1/interval."""
+async def test_concurrent_admits_serialize_no_burst(real_redis: _RealRedis):
+    """Three concurrent acquires for the same scope never burst past the budget."""
+    interval, margin = 0.30, 0.05
     gate = _make_gate(
-        disposable_redis.url, interval_seconds=0.3, safety_margin_seconds=0.05
+        real_redis.url, interval_seconds=interval, safety_margin_seconds=margin
     )
     try:
         scope = build_vts_gate_scope_key(host=MOCK_HOST, app_key="concurrent")
@@ -231,20 +281,18 @@ async def test_concurrent_admits_serialize_no_burst(disposable_redis: _Disposabl
         await asyncio.gather(*[_one(i) for i in range(3)])
         admit_times.sort()
         gaps = [admit_times[i] - admit_times[i - 1] for i in range(1, len(admit_times))]
-        # Every adjacent gap must meet the interval (minus tiny scheduling slop).
         for g in gaps:
-            assert g >= 0.30 - 0.04, f"burst detected, gap={g:.3f}s"
+            assert g >= interval + margin - _TIMING_TOLERANCE, (
+                f"burst detected, gap={g:.3f}s"
+            )
     finally:
         await gate.close()
 
 
 @pytest.mark.asyncio
 @pytest.mark.integration
-async def test_distinct_credentials_isolate(disposable_redis: _DisposableRedis):
-    """Different app-key fingerprints admit independently (no cross-contention)."""
-    gate = _make_gate(
-        disposable_redis.url, interval_seconds=0.3, safety_margin_seconds=0.05
-    )
+async def test_distinct_credentials_isolate(real_redis: _RealRedis):
+    gate = _make_gate(real_redis.url, interval_seconds=0.30, safety_margin_seconds=0.05)
     try:
         scope_a = build_vts_gate_scope_key(host=MOCK_HOST, app_key="cred-A")
         scope_b = build_vts_gate_scope_key(host=MOCK_HOST, app_key="cred-B")
@@ -254,7 +302,6 @@ async def test_distinct_credentials_isolate(disposable_redis: _DisposableRedis):
             gate.acquire(scope_b, call_class="order"),
         )
         elapsed = time.monotonic() - t0
-        # Distinct scopes admit in parallel — total wall time well under one interval.
         assert elapsed < 0.30, f"distinct scopes did not parallelize: {elapsed:.3f}s"
     finally:
         await gate.close()
@@ -262,8 +309,8 @@ async def test_distinct_credentials_isolate(disposable_redis: _DisposableRedis):
 
 @pytest.mark.asyncio
 @pytest.mark.integration
-async def test_distinct_hosts_isolate(disposable_redis: _DisposableRedis):
-    gate = _make_gate(disposable_redis.url, interval_seconds=0.3)
+async def test_distinct_hosts_isolate(real_redis: _RealRedis):
+    gate = _make_gate(real_redis.url, interval_seconds=0.30)
     try:
         same_app = "shared-app-key"
         scope_vts = build_vts_gate_scope_key(host=MOCK_HOST, app_key=same_app)
@@ -284,8 +331,6 @@ async def test_distinct_hosts_isolate(disposable_redis: _DisposableRedis):
 @pytest.mark.asyncio
 @pytest.mark.integration
 async def test_redis_unavailable_raises_fail_closed():
-    """Redis down -> DistributedGateUnavailable (never an unthrottled admit)."""
-    # Point at a port where nothing listens; connect must fail fast.
     gate = _make_gate(
         "redis://127.0.0.1:1/0",
         socket_timeout_seconds=0.5,
@@ -302,11 +347,9 @@ async def test_redis_unavailable_raises_fail_closed():
 
 @pytest.mark.asyncio
 @pytest.mark.integration
-async def test_acquire_deadline_raises_fail_closed(disposable_redis: _DisposableRedis):
-    """A backlog that cannot drain within the deadline fails closed."""
-    # Very short deadline + an already-occupied slot -> deadline exceeded.
+async def test_acquire_deadline_raises_fail_closed(real_redis: _RealRedis):
     gate = _make_gate(
-        disposable_redis.url,
+        real_redis.url,
         interval_seconds=2.0,
         safety_margin_seconds=0.0,
         acquire_deadline_seconds=0.4,
@@ -322,13 +365,8 @@ async def test_acquire_deadline_raises_fail_closed(disposable_redis: _Disposable
 
 @pytest.mark.asyncio
 @pytest.mark.integration
-async def test_cancellation_while_waiting_is_http_zero(
-    disposable_redis: _DisposableRedis,
-):
-    """A waiter cancelled mid-sleep never reaches the admit (HTTP=0)."""
-    gate = _make_gate(
-        disposable_redis.url, interval_seconds=1.0, safety_margin_seconds=0.0
-    )
+async def test_cancellation_while_waiting_is_http_zero(real_redis: _RealRedis):
+    gate = _make_gate(real_redis.url, interval_seconds=1.0, safety_margin_seconds=0.0)
     try:
         scope = build_vts_gate_scope_key(host=MOCK_HOST, app_key="cancel")
         await gate.acquire(scope, call_class="order")  # occupy
@@ -340,22 +378,19 @@ async def test_cancellation_while_waiting_is_http_zero(
             admitted["v"] = True
 
         task = asyncio.create_task(_waiter())
-        await asyncio.sleep(0.05)  # let it enter the contention sleep
+        await asyncio.sleep(0.05)
         task.cancel()
         with pytest.raises(asyncio.CancelledError):
             await task
-        assert admitted["v"] is False  # never admitted -> HTTP would be 0
+        assert admitted["v"] is False
     finally:
         await gate.close()
 
 
 @pytest.mark.asyncio
 @pytest.mark.integration
-async def test_freshness_hook_rerun_on_contention(disposable_redis: _DisposableRedis):
-    """Contention forces the freshness hook to run again before re-claim."""
-    gate = _make_gate(
-        disposable_redis.url, interval_seconds=0.4, safety_margin_seconds=0.0
-    )
+async def test_freshness_hook_rerun_on_contention(real_redis: _RealRedis):
+    gate = _make_gate(real_redis.url, interval_seconds=0.40, safety_margin_seconds=0.0)
     try:
         scope = build_vts_gate_scope_key(host=MOCK_HOST, app_key="fresh")
         await gate.acquire(scope, call_class="order")  # occupy slot
@@ -365,7 +400,6 @@ async def test_freshness_hook_rerun_on_contention(disposable_redis: _DisposableR
         async def _hook() -> None:
             calls["n"] += 1
 
-        # Second admit must contend once -> hook runs twice (before each claim).
         await gate.acquire(scope, freshness_hook=_hook, call_class="order")
         assert calls["n"] >= 2, f"freshness not rerun on contention: {calls['n']}"
     finally:
@@ -374,15 +408,11 @@ async def test_freshness_hook_rerun_on_contention(disposable_redis: _DisposableR
 
 @pytest.mark.asyncio
 @pytest.mark.integration
-async def test_freshness_failure_aborts_before_admit(
-    disposable_redis: _DisposableRedis,
-):
-    """A failing freshness hook aborts with HTTP=0 (PreSendFreshnessError)."""
-
+async def test_freshness_failure_aborts_before_admit(real_redis: _RealRedis):
     class _FreshError(RuntimeError):
         pass
 
-    gate = _make_gate(disposable_redis.url)
+    gate = _make_gate(real_redis.url)
     try:
         scope = build_vts_gate_scope_key(host=MOCK_HOST, app_key="freshfail")
         admitted = {"v": False}
@@ -390,8 +420,6 @@ async def test_freshness_failure_aborts_before_admit(
         async def _failing_hook() -> None:
             raise _FreshError("stale book")
 
-        # The hook runs before the first claim; the gate must propagate the
-        # freshness error and never admit.
         with pytest.raises(_FreshError):
 
             async def _track() -> None:
@@ -407,41 +435,35 @@ async def test_freshness_failure_aborts_before_admit(
         await gate.close()
 
 
-@pytest.mark.integration
+@pytest.mark.unit
 def test_scope_key_is_secret_free():
     """Keys and fingerprints must never contain the raw app key."""
     key = build_vts_gate_scope_key(host=MOCK_HOST, app_key="SUPER_SECRET_VALUE_123")
     assert "SUPER_SECRET_VALUE_123" not in key
     assert key.startswith("kis_mock:gate:openapivts.koreainvestment.com:29443:")
-    # Fingerprint is 16 hex chars.
     fp = key.rsplit(":", 1)[-1]
     assert len(fp) == 16
     assert all(c in "0123456789abcdef" for c in fp)
 
 
-@pytest.mark.integration
+@pytest.mark.unit
 def test_netloc_helper_matches_token_namespace():
-    """Gate host extraction must match the OAuth token namespace netloc shape."""
     assert netloc_from_url(MOCK_BASE_URL + "/uapi/x") == MOCK_HOST
     assert netloc_from_url("https://openapi.koreainvestment.com:9443/p") == LIVE_HOST
 
 
 @pytest.mark.asyncio
 @pytest.mark.integration
-async def test_cold_start_after_ttl_expiry_is_deterministic(
-    disposable_redis: _DisposableRedis,
-):
-    """After the cooldown key TTL expires, the next admit is immediate (cold start)."""
+async def test_cold_start_after_ttl_expiry_is_deterministic(real_redis: _RealRedis):
     gate = _make_gate(
-        disposable_redis.url,
-        interval_seconds=0.2,
+        real_redis.url,
+        interval_seconds=0.20,
         safety_margin_seconds=0.0,
-        ttl_seconds=1,  # short TTL to observe cold-start recovery
+        ttl_seconds=1,
     )
     try:
         scope = build_vts_gate_scope_key(host=MOCK_HOST, app_key="ttl")
         await gate.acquire(scope, call_class="order")
-        # Wait past TTL.
         await asyncio.sleep(1.2)
         t0 = time.monotonic()
         await gate.acquire(scope, call_class="order")
@@ -451,7 +473,156 @@ async def test_cold_start_after_ttl_expiry_is_deterministic(
 
 
 # ===========================================================================
-# Section 2 — singleton wiring
+# Section 2 — CR2: strict Lua decoder (malformed results fail closed)
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_malformed_lua_results_fail_closed(real_redis: _RealRedis):
+    """Every result outside the exact [admission∈{0,1}, retry>=0] protocol fails."""
+    gate = _make_gate(real_redis.url)
+    scope = build_vts_gate_scope_key(host=MOCK_HOST, app_key="malformed")
+
+    bad_results = [
+        [2, 0],  # admission outside {0,1} must not authorize HTTP
+        [0, -5],  # negative retry rejected (no clamping)
+        [0, 0],  # denial with zero retry would busy-loop -> fail closed
+        [1, 0, 9],  # wrong arity
+        "garbage",  # not a list
+        [1],  # too few elements
+    ]
+    try:
+        for raw in bad_results:
+            # Inject the raw value at the Redis boundary so the DECODER (which
+            # lives inside _claim) processes it — mocking _claim itself would
+            # bypass the code under test.
+            fake_client = MagicMock()
+            fake_client.execute_command = AsyncMock(return_value=raw)
+            gate._get_redis = AsyncMock(return_value=fake_client)  # type: ignore[method-assign]
+            with pytest.raises(DistributedGateUnavailable):
+                await gate.acquire(scope, call_class="order")
+    finally:
+        await gate.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_valid_lua_result_admits(real_redis: _RealRedis):
+    gate = _make_gate(real_redis.url)
+    scope = build_vts_gate_scope_key(host=MOCK_HOST, app_key="valid")
+    try:
+        fake_client = MagicMock()
+        fake_client.execute_command = AsyncMock(return_value=[1, 0])
+        gate._get_redis = AsyncMock(return_value=fake_client)  # type: ignore[method-assign]
+        r = await gate.acquire(scope, call_class="order")
+        assert r.contention_attempts == 1
+    finally:
+        await gate.close()
+
+
+# ===========================================================================
+# Section 3 — CR3: deadline enforcement (precheck, wait_for bounds, recheck)
+# ===========================================================================
+
+
+class _FakeClock:
+    def __init__(self, start: float = 1000.0) -> None:
+        self.t = start
+
+    def __call__(self) -> float:
+        return self.t
+
+    def advance(self, d: float) -> None:
+        self.t += d
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_expired_deadline_raises_before_any_claim():
+    """An already-expired custom deadline raises immediately; _claim never runs."""
+    clock = _FakeClock(1000.0)
+    gate = _make_gate("redis://127.0.0.1:1/0", monotonic=clock)
+    scope = build_vts_gate_scope_key(host=MOCK_HOST, app_key="expired")
+    claim = AsyncMock(return_value=[1, 0])
+    gate._claim = claim  # type: ignore[method-assign]
+    try:
+        with pytest.raises(DistributedGateUnavailable, match="already exceeded"):
+            await gate.acquire(scope, deadline_monotonic=999.0, call_class="order")
+        claim.assert_not_awaited()
+    finally:
+        await gate.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_freshness_crossing_deadline_raises(real_redis: _RealRedis):
+    """A freshness hook that runs past the deadline fails closed (claim unused)."""
+    gate = _make_gate(
+        real_redis.url, interval_seconds=0.20, acquire_deadline_seconds=0.15
+    )
+    scope = build_vts_gate_scope_key(host=MOCK_HOST, app_key="freshcross")
+    claim = AsyncMock(return_value=[1, 0])
+    gate._claim = claim  # type: ignore[method-assign]
+
+    async def _slow_hook() -> None:
+        await asyncio.sleep(0.5)  # >> 0.15 deadline
+
+    try:
+        with pytest.raises(DistributedGateUnavailable, match="freshness"):
+            await gate.acquire(scope, freshness_hook=_slow_hook, call_class="order")
+        claim.assert_not_awaited()
+    finally:
+        await gate.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_claim_crossing_deadline_raises():
+    """A claim that exceeds the remaining deadline fails closed."""
+    clock = _FakeClock(1000.0)
+    gate = _make_gate(
+        "redis://127.0.0.1:1/0", monotonic=clock, acquire_deadline_seconds=0.10
+    )
+    scope = build_vts_gate_scope_key(host=MOCK_HOST, app_key="claimcross")
+
+    async def _slow_claim(_scope: str) -> tuple[bool, float]:
+        await asyncio.sleep(0.5)  # >> 0.10 budget
+        return True, 0.0
+
+    gate._claim = _slow_claim  # type: ignore[method-assign]
+    try:
+        with pytest.raises(DistributedGateUnavailable, match="claim exceeded"):
+            await gate.acquire(scope, call_class="order")
+    finally:
+        await gate.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_admit_after_deadline_consumes_slot_and_raises():
+    """A claim that succeeds after the deadline crossed consumes the slot (HTTP=0)."""
+    clock = _FakeClock(1000.0)
+    gate = _make_gate(
+        "redis://127.0.0.1:1/0", monotonic=clock, acquire_deadline_seconds=10.0
+    )
+    scope = build_vts_gate_scope_key(host=MOCK_HOST, app_key="admitcross")
+
+    async def _admit_then_cross(_scope: str) -> tuple[bool, float]:
+        # Claim succeeds, then pushes the injected clock past the deadline.
+        clock.advance(20.0)
+        return True, 0.0
+
+    gate._claim = _admit_then_cross  # type: ignore[method-assign]
+    try:
+        with pytest.raises(DistributedGateUnavailable, match="admitted after"):
+            await gate.acquire(scope, call_class="order")
+    finally:
+        await gate.close()
+
+
+# ===========================================================================
+# Section 4 — singleton wiring
 # ===========================================================================
 
 
@@ -466,18 +637,16 @@ async def test_singleton_reset_round_trip():
 
 
 # ===========================================================================
-# Section 3 — real multiprocessing dispatch-timing suite
+# Section 5 — real multiprocessing dispatch-timing suite (with Barrier)
 # ===========================================================================
 
 
 class _MockSettings:
-    """Minimal settings view: mock host + mock app key, live fallbacks."""
-
     kis_app_key = MOCK_APP_KEY
     kis_app_secret = "secret"
     kis_access_token = "token"
     kis_account_no = "1234567890"
-    kis_base_url = MOCK_BASE_URL  # dispatch URL resolves to mock host
+    kis_base_url = MOCK_BASE_URL
     kis_mock_base_url = MOCK_BASE_URL
     api_rate_limit_retry_429_max = 0
     api_rate_limit_retry_429_base_delay = 0.0
@@ -487,12 +656,6 @@ class _MockSettings:
 
 
 class _DispatchTrackingClient(BaseKISClient):
-    """BaseKISClient subclass that records real _execute_http_request starts.
-
-    ``_vts_gate`` is injected so the dispatch boundary contacts the disposable
-    Redis instead of the process-wide singleton.
-    """
-
     def __init__(self, gate: VTSDistributedGate) -> None:  # type: ignore[override]
         self._unmapped_rate_limit_keys_logged: set[str] = set()
         type(self)._shared_client_lock = None
@@ -515,8 +678,6 @@ class _DispatchTrackingClient(BaseKISClient):
     async def _execute_http_request(  # type: ignore[override]
         self, client: Any, method: str, url: str, **kwargs: Any
     ) -> Any:
-        # Record the START timestamp (the spec measures dispatch starts, not
-        # acquire() returns). Sleep a hair so concurrency is observable.
         self._dispatch_starts.append(time.monotonic())
         self._dispatch_count += 1
         resp = MagicMock()
@@ -526,43 +687,40 @@ class _DispatchTrackingClient(BaseKISClient):
         return resp
 
 
-def _child_worker(  # noqa: C901 — multiprocessing target
+def _child_worker(  # noqa: C901
     redis_url: str,
     app_key: str,
     requests: list[tuple[str, str]],
     out_queue: mp.Queue,
     interval_seconds: float,
     safety_margin_seconds: float,
+    barrier: mp.Barrier | None,
 ) -> None:
-    """Run N dispatches in a child PID; push (label, start_timestamps, count)."""
-    # Each child needs its own event loop.
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
-
     gate = _make_gate(
         redis_url,
         interval_seconds=interval_seconds,
         safety_margin_seconds=safety_margin_seconds,
         acquire_deadline_seconds=15.0,
     )
-
-    # Patch the app key on this child's settings view (per-credential tests).
     _MockSettings.kis_app_key = app_key
     _MockSettings.kis_mock_base_url = MOCK_BASE_URL
-
     client = _DispatchTrackingClient(gate)
 
     async def _run() -> list[tuple[str, float]]:
+        if barrier is not None:
+            barrier.wait()
         starts: list[tuple[str, float]] = []
         for label, path in requests:
-            url = MOCK_BASE_URL + path
-            headers = {"appkey": app_key, "authorization": "Bearer tok", "tr_id": label}
             await client._dispatch_rate_limited_with_headers(
-                "POST"
-                if "order" in label or "cancel" in label or "modify" in label
-                else "GET",
-                url,
-                headers=headers,
+                "POST" if "order" in label else "GET",
+                MOCK_BASE_URL + path,
+                headers={
+                    "appkey": app_key,
+                    "authorization": "Bearer tok",
+                    "tr_id": label,
+                },
                 params=None,
                 json_body={"x": 1} if "order" in label else None,
                 timeout=5.0,
@@ -576,7 +734,7 @@ def _child_worker(  # noqa: C901 — multiprocessing target
 
     try:
         starts = loop.run_until_complete(_run())
-        out_queue.put((app_key, starts, client._dispatch_count))
+        out_queue.put((app_key, starts, client._dispatch_count, None))
     except Exception as e:  # noqa: BLE001
         out_queue.put((app_key, [], -1, repr(e)))
     finally:
@@ -584,141 +742,121 @@ def _child_worker(  # noqa: C901 — multiprocessing target
         loop.close()
 
 
-@pytest.mark.integration
-def test_multiprocessing_kr_buy_sell_read_share_budget(
-    disposable_redis: _DisposableRedis,
-):
-    """Two PIDs issuing KR buy, KR sell, and a mock read through the real
-    dispatch boundary share ONE admit budget: adjacent _execute_http_request
-    starts for the credential scope meet the interval, and each intended
-    dispatch fires exactly once."""
-    interval = 0.35
-    margin = 0.05
-    # Flush any prior cooldown for this credential.
-    subprocess.run(
-        ["redis-cli", "-h", "127.0.0.1", "-p", str(disposable_redis.port), "FLUSHDB"],
-        check=False,
-        capture_output=True,
-        timeout=5,
-    )
+def _run_children_and_collect(
+    redis_url: str,
+    jobs: list[tuple[str, list[tuple[str, str]]]],
+    interval: float,
+    margin: float,
+    synchronize: bool,
+) -> list[tuple[str, list[tuple[str, float]], int, str | None]]:
+    ctx = mp.get_context("spawn")
+    q: mp.Queue = ctx.Queue()
+    n = len(jobs)
+    barrier = ctx.Barrier(n) if synchronize and n >= 2 else None
+    procs = [
+        ctx.Process(
+            target=_child_worker,
+            args=(redis_url, app_key, reqs, q, interval, margin, barrier),
+        )
+        for app_key, reqs in jobs
+    ]
+    for p in procs:
+        p.start()
+    try:
+        for p in procs:
+            p.join(timeout=60)
+    finally:
+        # CR5: reap any timed-out child so a hang never leaks; assert clean exit.
+        for p in procs:
+            if p.is_alive():  # pragma: no cover — reaping safety
+                p.terminate()
+                p.join(timeout=5)
+                if p.is_alive():
+                    p.kill()
+                    p.join(timeout=5)
+            assert p.exitcode == 0, f"child exited with {p.exitcode}"
+    # CR5: collect exactly one result per child with a timeout (no Queue.empty()).
+    results = []
+    for _ in range(n):
+        try:
+            results.append(q.get(timeout=10))
+        except Exception as e:  # noqa: BLE001
+            raise AssertionError(f"child produced no result: {e!r}") from e
+    return results
 
-    # PID A: KR buy then a mock read. PID B: KR sell. Same credential scope.
+
+@pytest.mark.integration
+def test_multiprocessing_kr_buy_sell_read_share_budget(real_redis: _RealRedis):
+    """Two PIDs (KR buy + KR sell & mock read) share ONE admit budget. A Barrier
+    synchronizes simultaneous departure so real cross-PID contention occurs;
+    adjacent _execute_http_request starts meet interval + margin and each
+    intended dispatch fires exactly once."""
+    real_redis.flush()
+    interval, margin = 0.35, 0.05
     reqs_a = [("kr_buy", "/uapi/domestic-stock/v1/trading/order-cash")]
     reqs_b = [
         ("kr_sell", "/uapi/domestic-stock/v1/trading/order-cash"),
         ("mock_read", "/uapi/domestic-stock/v1/trading/inquire-balance"),
     ]
-
-    ctx = mp.get_context("spawn")
-    q: mp.Queue = ctx.Queue()
-    procs = [
-        ctx.Process(
-            target=_child_worker,
-            args=(disposable_redis.url, MOCK_APP_KEY, reqs_a, q, interval, margin),
-        ),
-        ctx.Process(
-            target=_child_worker,
-            args=(disposable_redis.url, MOCK_APP_KEY, reqs_b, q, interval, margin),
-        ),
-    ]
-    for p in procs:
-        p.start()
-    for p in procs:
-        p.join(timeout=60)
-
-    results = []
-    while not q.empty():
-        results.append(q.get())
-    assert len(results) == 2, f"expected 2 child results, got {results}"
+    jobs = [(MOCK_APP_KEY, reqs_a), (MOCK_APP_KEY, reqs_b)]
+    results = _run_children_and_collect(
+        real_redis.url, jobs, interval, margin, synchronize=True
+    )
 
     all_starts: list[float] = []
-    total_dispatches = 0
+    total = 0
     for r in results:
-        assert len(r) >= 3, f"child reported failure: {r}"
-        _app_key, starts, count = r[0], r[1], r[2]
-        assert count >= 1 and count == len(starts), (
-            f"each intended dispatch must fire exactly once: count={count}, starts={len(starts)}"
-        )
-        total_dispatches += count
+        assert len(r) >= 4 and r[3] is None, f"child reported failure: {r}"
+        _app_key, starts, count, _err = r
+        assert count >= 1 and count == len(starts)
+        total += count
         all_starts.extend(ts for _label, ts in starts)
 
-    # 3 intended requests across 2 PIDs -> exactly 3 HTTP dispatches.
-    assert total_dispatches == 3, f"expected 3 dispatches, got {total_dispatches}"
-
+    assert total == 3, f"expected 3 dispatches, got {total}"
     all_starts.sort()
     gaps = [all_starts[i] - all_starts[i - 1] for i in range(1, len(all_starts))]
-    # Adjacent starts must meet the interval (minus small scheduling slop for
-    # multiprocess clock + asyncio wakeup).
-    slop = 0.05
+    # CR10: adjacent starts must meet interval + margin (only small tolerance),
+    # not just the bare interval.
     for g in gaps:
-        assert g >= interval - slop, (
-            f"cross-PID burst: adjacent dispatch gap {g:.3f}s < interval {interval}s"
+        assert g >= interval + margin - 0.05, (
+            f"cross-PID burst: gap {g:.3f}s < {interval + margin}s"
         )
 
 
 @pytest.mark.integration
-def test_multiprocessing_distinct_credentials_do_not_serialize(
-    disposable_redis: _DisposableRedis,
-):
-    """Two PIDs with DIFFERENT mock app keys admit in parallel (no shared budget)."""
-    interval = 0.4
-    subprocess.run(
-        ["redis-cli", "-h", "127.0.0.1", "-p", str(disposable_redis.port), "FLUSHDB"],
-        check=False,
-        capture_output=True,
-        timeout=5,
-    )
+def test_multiprocessing_distinct_credentials_do_not_serialize(real_redis: _RealRedis):
+    """Two PIDs with DIFFERENT mock app keys admit in parallel (barrier-proven)."""
+    real_redis.flush()
+    interval = 0.40
     reqs = [("kr_buy", "/uapi/domestic-stock/v1/trading/order-cash")]
-    ctx = mp.get_context("spawn")
-    q: mp.Queue = ctx.Queue()
-    procs = [
-        ctx.Process(
-            target=_child_worker,
-            args=(disposable_redis.url, "cred-alpha", reqs, q, interval, 0.05),
-        ),
-        ctx.Process(
-            target=_child_worker,
-            args=(disposable_redis.url, "cred-beta", reqs, q, interval, 0.05),
-        ),
-    ]
-    for p in procs:
-        p.start()
-    for p in procs:
-        p.join(timeout=60)
+    jobs = [("cred-alpha", reqs), ("cred-beta", reqs)]
+    results = _run_children_and_collect(
+        real_redis.url, jobs, interval, 0.05, synchronize=True
+    )
 
-    results = []
-    while not q.empty():
-        results.append(q.get())
-    assert len(results) == 2
-    # Distinct credentials -> the two dispatches' START timestamps must be
-    # close (parallel admission), not separated by the full interval. Wall-clock
-    # spawn startup is excluded by comparing dispatch starts directly.
     starts = sorted(ts for r in results for _label, ts in r[1])
     assert len(starts) == 2
     delta = starts[1] - starts[0]
-    assert delta < interval * 0.5, (
-        f"distinct credentials serialized (dispatch starts {delta:.3f}s apart, "
-        f"expected near-simultaneous): {results}"
+    # CR6/CR11: barrier-synchronized departure + independent scopes -> dispatch
+    # starts must be close (parallel admission), well under the interval.
+    assert delta < interval * 0.4, (
+        f"distinct credentials serialized (starts {delta:.3f}s apart): {results}"
     )
     for r in results:
         assert r[2] == 1, f"each PID must dispatch exactly once: {r}"
 
 
 # ===========================================================================
-# Section 4 — dispatch-boundary integration (HTTP=0 invariants)
+# Section 6 — dispatch-boundary integration (HTTP=0 invariants)
 # ===========================================================================
 
 
 class _UnitMockSettings(_MockSettings):
-    # Reads retry transient RequestErrors by default; tests that need
-    # exactly-one-POST pass max_retries_override=0 explicitly.
     api_rate_limit_retry_429_max = 2
     api_rate_limit_retry_429_base_delay = 0.0
 
 
 class _UnitDispatchClient(BaseKISClient):
-    """In-process dispatch client for the HTTP=0 invariant tests."""
-
     def __init__(self, gate: VTSDistributedGate) -> None:  # type: ignore[override]
         self._unmapped_rate_limit_keys_logged: set[str] = set()
         type(self)._shared_client_lock = None
@@ -751,7 +889,6 @@ class _UnitDispatchClient(BaseKISClient):
 @pytest.mark.asyncio
 @pytest.mark.integration
 async def test_redis_failure_mutation_is_http_zero():
-    """A mock order dispatch when Redis is down must prove HTTP=0 (no fallback)."""
     gate = _make_gate(
         "redis://127.0.0.1:1/0",
         socket_timeout_seconds=0.5,
@@ -782,7 +919,6 @@ async def test_redis_failure_mutation_is_http_zero():
 @pytest.mark.asyncio
 @pytest.mark.integration
 async def test_redis_failure_read_also_http_zero():
-    """Reads cannot bypass the gate during Redis outage (same fail-closed path)."""
     gate = _make_gate(
         "redis://127.0.0.1:1/0",
         socket_timeout_seconds=0.5,
@@ -807,9 +943,12 @@ async def test_redis_failure_read_also_http_zero():
 
 @pytest.mark.asyncio
 @pytest.mark.integration
-async def test_live_host_never_contacts_redis(disposable_redis: _DisposableRedis):
-    """A live-host dispatch must succeed without the gate touching Redis at all."""
-    gate = _make_gate(disposable_redis.url)
+async def test_live_host_never_contacts_redis(real_redis: _RealRedis):
+    """CR7: prove Redis is never contacted for a live-host dispatch by spying on
+    the gate's _claim (a healthy Redis would otherwise mask a regression)."""
+    gate = _make_gate(real_redis.url)
+    claim_spy = AsyncMock(wraps=gate._claim)
+    gate._claim = claim_spy  # type: ignore[method-assign]
     client = _UnitDispatchClient(gate)
     try:
         await client._dispatch_rate_limited_with_headers(
@@ -821,18 +960,45 @@ async def test_live_host_never_contacts_redis(disposable_redis: _DisposableRedis
             tr_id="FHKST01010100",
         )
         assert client.http_calls == 1
+        claim_spy.assert_not_awaited()  # live -> zero Redis calls, proven
     finally:
         await gate.close()
 
 
 @pytest.mark.asyncio
 @pytest.mark.integration
-async def test_egw00201_still_exactly_one_post(disposable_redis: _DisposableRedis):
-    """ROB-645 invariant preserved: an EGW00201/'초과' body is not re-POSTed."""
-    gate = _make_gate(disposable_redis.url)
+async def test_mock_dispatch_empty_appkey_fail_closed(real_redis: _RealRedis):
+    """CR9: a mock-host dispatch with no appkey must fail closed, not bypass."""
+    gate = _make_gate(real_redis.url)
+    claim_spy = AsyncMock(wraps=gate._claim)
+    gate._claim = claim_spy  # type: ignore[method-assign]
+    client = _UnitDispatchClient(gate)
+    try:
+        with pytest.raises(DistributedGateUnavailable, match="appkey"):
+            await client._dispatch_rate_limited_with_headers(
+                "POST",
+                MOCK_BASE_URL + "/uapi/domestic-stock/v1/trading/order-cash",
+                headers={"authorization": "Bearer t"},  # no appkey
+                json_body={"PDNO": "005930"},
+                timeout=5.0,
+                api_name="order_korea_stock",
+                tr_id="VTTC0802U",
+                retry_request_errors=False,
+                max_retries_override=0,
+            )
+        assert client.http_calls == 0
+        claim_spy.assert_not_awaited()
+    finally:
+        await gate.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_egw00201_still_exactly_one_post(real_redis: _RealRedis):
+    gate = _make_gate(real_redis.url)
     client = _UnitDispatchClient(gate)
 
-    async def _execute_http_request(
+    async def _execute_http_request(  # type: ignore[override]
         client_: Any, method: str, url: str, **kwargs: Any
     ) -> Any:
         client.http_calls += 1
@@ -860,28 +1026,34 @@ async def test_egw00201_still_exactly_one_post(disposable_redis: _DisposableRedi
             max_retries_override=0,
         )
         assert data["msg_cd"] == "EGW00215"
-        assert client.http_calls == 1, "order must POST exactly once (no re-POST)"
+        assert client.http_calls == 1
     finally:
         await gate.close()
 
 
 @pytest.mark.asyncio
 @pytest.mark.integration
-async def test_read_retries_reacquire_permit(disposable_redis: _DisposableRedis):
-    """A read that retries RequestError reacquires the gate on each attempt."""
+async def test_read_retries_reacquire_permit_respecting_interval(
+    real_redis: _RealRedis,
+):
+    """CR8: a read retry must REACQUIRE a permit, and the two admissions must be
+    separated by the configured interval (recorded dispatch starts)."""
+    interval, margin = 0.30, 0.0
     gate = _make_gate(
-        disposable_redis.url, interval_seconds=0.3, safety_margin_seconds=0.0
+        real_redis.url, interval_seconds=interval, safety_margin_seconds=margin
     )
     import httpx
 
     client = _UnitDispatchClient(gate)
     state = {"n": 0}
+    starts: list[float] = []
 
-    async def _execute_http_request(
+    async def _execute_http_request(  # type: ignore[override]
         client_: Any, method: str, url: str, **kwargs: Any
     ) -> Any:
         state["n"] += 1
         client.http_calls += 1
+        starts.append(time.monotonic())
         if state["n"] == 1:
             raise httpx.ReadTimeout("first attempt times out")
         resp = MagicMock()
@@ -901,13 +1073,177 @@ async def test_read_retries_reacquire_permit(disposable_redis: _DisposableRedis)
             tr_id="VTTC8434R",
             retry_request_errors=True,
         )
-        # Two HTTP attempts -> two gate admits, separated by the interval.
-        assert client.http_calls == 2
+        assert client.http_calls == 2  # retry happened
+        assert len(starts) == 2
+        gap = starts[1] - starts[0]
+        assert gap >= interval + margin - _TIMING_TOLERANCE, (
+            f"retry did not respect the interval: gap={gap:.3f}s"
+        )
     finally:
         await gate.close()
 
 
-# Suppress noisy info logs during the multiprocessing/timing tests.
+# ===========================================================================
+# Section 7 — P1: HALF_OPEN breaker probe lease released on pre-dispatch abort
+# ===========================================================================
+
+
+class _BreakerSettings:
+    kis_circuit_breaker_enabled = True
+    kis_circuit_breaker_failure_threshold = 2
+    kis_circuit_breaker_cooldown_seconds = 10
+
+
+def _breaker_open_past_cooldown() -> tuple[KISCircuitBreaker, _FakeClock]:
+    """A breaker that is OPEN with the cooldown elapsed.
+
+    The NEXT ``before_request`` (made by the dispatch wrapper) transitions it to
+    HALF_OPEN and hands out the probe lease — mirroring the real flow. The test
+    must NOT pre-acquire the probe, or the wrapper's own ``before_request`` hits
+    the HALF_OPEN stampede guard and raises ``KISCircuitOpen``.
+    """
+    clock = _FakeClock(1000.0)
+    cb = KISCircuitBreaker(now=clock, settings_obj=_BreakerSettings())
+    cb.record_failure()
+    cb.record_failure()  # threshold reached -> OPEN
+    clock.advance(11.0)  # past cooldown -> next before_request() half-opens
+    assert cb.state == "open"
+    return cb, clock
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_half_open_probe_released_on_distributed_gate_failure(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """P1: a Redis gate failure during a HALF_OPEN probe releases the probe lease
+    (next request can probe) WITHOUT changing breaker state/failures."""
+    cb, _clock = _breaker_open_past_cooldown()
+    monkeypatch.setattr(
+        "app.services.brokers.kis.base.get_kis_circuit_breaker", lambda: cb
+    )
+
+    gate = _make_gate(
+        "redis://127.0.0.1:1/0",
+        socket_timeout_seconds=0.3,
+        socket_connect_timeout_seconds=0.3,
+        acquire_deadline_seconds=0.8,
+    )
+    client = _UnitDispatchClient(gate)
+    try:
+        with pytest.raises(DistributedGateUnavailable):
+            await client._request_with_rate_limit_with_headers(
+                "POST",
+                MOCK_BASE_URL + "/uapi/domestic-stock/v1/trading/order-cash",
+                headers={"appkey": MOCK_APP_KEY, "authorization": "Bearer t"},
+                json_body={"PDNO": "005930"},
+                timeout=5.0,
+                api_name="order_korea_stock",
+                tr_id="VTTC0802U",
+                retry_request_errors=False,
+                max_retries_override=0,
+            )
+        assert client.http_calls == 0  # HTTP=0
+        assert cb.state == "half_open"  # state unchanged
+        assert cb._probe_in_flight is False  # lease released
+        assert cb.failure_count == 2  # failures unchanged (still threshold)
+        # Next request can obtain a fresh probe (no permanent KISCircuitOpen).
+        cb.before_request()
+        assert cb._probe_in_flight is True
+    finally:
+        await gate.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_half_open_probe_released_on_cancellation(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """P1: a cancellation during the gate wait releases the probe lease and does
+    NOT record a fake KIS reachability outcome (HTTP=0 contract)."""
+    cb, _clock = _breaker_open_past_cooldown()
+    monkeypatch.setattr(
+        "app.services.brokers.kis.base.get_kis_circuit_breaker", lambda: cb
+    )
+
+    gate = _make_gate(real_redis_url_unused(), acquire_deadline_seconds=5.0)  # type: ignore[arg-type]
+
+    async def _hanging_claim(_scope: str) -> tuple[bool, float]:
+        await asyncio.sleep(5.0)  # hang so the caller is cancelled mid gate-wait
+        return False, 1.0
+
+    gate._claim = _hanging_claim  # type: ignore[method-assign]
+    client = _UnitDispatchClient(gate)
+    try:
+        task = asyncio.create_task(
+            client._request_with_rate_limit_with_headers(
+                "POST",
+                MOCK_BASE_URL + "/uapi/domestic-stock/v1/trading/order-cash",
+                headers={"appkey": MOCK_APP_KEY, "authorization": "Bearer t"},
+                json_body={"PDNO": "005930"},
+                timeout=5.0,
+                api_name="order_korea_stock",
+                tr_id="VTTC0802U",
+                retry_request_errors=False,
+                max_retries_override=0,
+            )
+        )
+        await asyncio.sleep(0.1)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert client.http_calls == 0  # HTTP=0
+        assert cb.state == "half_open"  # NOT closed/moved by the cancellation
+        assert cb._probe_in_flight is False  # lease released
+        assert cb.failure_count == 2
+    finally:
+        await gate.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_half_open_probe_released_on_pre_send_freshness(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """P1: a PreSendFreshnessError (ROB-843) during a HALF_OPEN probe releases the
+    lease without moving the breaker (pre-existing ROB-843 path, now hardened)."""
+    from app.services.brokers.kis.pre_send import PreSendFreshnessError
+
+    cb, _clock = _breaker_open_past_cooldown()
+    monkeypatch.setattr(
+        "app.services.brokers.kis.base.get_kis_circuit_breaker", lambda: cb
+    )
+
+    gate = _make_gate(real_redis_url_unused())  # type: ignore[arg-type]
+    client = _UnitDispatchClient(gate)
+
+    async def _stale_hook() -> None:
+        raise PreSendFreshnessError(("stale",))
+
+    try:
+        with pytest.raises(PreSendFreshnessError):
+            await client._request_with_rate_limit_with_headers(
+                "GET",
+                f"https://{LIVE_HOST}/uapi/domestic-stock/v1/quotations/inquire-price",
+                headers={"appkey": "live-key", "authorization": "Bearer t"},
+                timeout=5.0,
+                api_name="inquire_price",
+                tr_id="FHKST01010100",
+                pre_send_hook=_stale_hook,
+            )
+        assert client.http_calls == 0
+        assert cb.state == "half_open"
+        assert cb._probe_in_flight is False
+        assert cb.failure_count == 2
+    finally:
+        await gate.close()
+
+
+def real_redis_url_unused() -> str:
+    """A placeholder URL for breaker tests whose gate is never contacted."""
+    return "redis://127.0.0.1:1/0"
+
+
 @pytest.fixture(autouse=True)
 def _quiet_gate_logger(caplog: pytest.LogCaptureFixture):
     caplog.set_level(

--- a/tests/brokers/kis/test_vts_distributed_gate.py
+++ b/tests/brokers/kis/test_vts_distributed_gate.py
@@ -1,0 +1,916 @@
+"""ROB-892 — distributed Redis gate for KIS mock (VTS) REST dispatch.
+
+Test surface (per the ROB-892 acceptance spec):
+
+* A real disposable ``redis-server`` is launched per test session; no
+  ``fakeredis`` object is accepted as proof.
+* A multiprocessing suite runs >=2 independent PIDs/clients concurrently
+  issuing KR buy, KR sell, and a mock read through the *real* dispatch
+  boundary. Actual ``_execute_http_request`` START timestamps are measured
+  (not ``acquire()`` returns); adjacent starts for one scope meet the
+  configured interval and each intended dispatch fires at most once.
+* Same credential across TR/path/market/side/read/order shares one key;
+  distinct credentials/hosts isolate.
+* Redis unavailable / timeout, acquire-deadline, wait-cancellation, and
+  pre-send-freshness failure all produce mutation HTTP=0 (no fallback).
+* Contention loser reruns freshness; no long gate wait follows the final
+  freshness check.
+* Live requests touch Redis zero times.
+* TTL / cold start / safety margin / bounded backlog are deterministic, and
+  keys/logs carry no raw secret.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import multiprocessing as mp
+import socket
+import subprocess
+import time
+from contextlib import closing
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.services.brokers.kis.base import BaseKISClient
+from app.services.brokers.kis.vts_distributed_gate import (
+    AcquireResult,
+    DistributedGateUnavailable,
+    VTSDistributedGate,
+    build_vts_gate_scope_key,
+    get_vts_distributed_gate,
+    netloc_from_url,
+    reset_vts_distributed_gate,
+)
+
+MOCK_HOST = "openapivts.koreainvestment.com:29443"
+MOCK_BASE_URL = f"https://{MOCK_HOST}"
+LIVE_HOST = "openapi.koreainvestment.com:9443"
+MOCK_APP_KEY = "test-mock-app-key-ROB892"
+
+
+# ---------------------------------------------------------------------------
+# Disposable real redis-server fixture
+# ---------------------------------------------------------------------------
+
+
+def _free_tcp_port() -> int:
+    with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
+        s.bind(("127.0.0.1", 0))
+        return int(s.getsockname()[1])
+
+
+class _DisposableRedis:
+    """A real redis-server subprocess bound to 127.0.0.1:<port> for one suite."""
+
+    def __init__(self) -> None:
+        self.port = _free_tcp_port()
+        self.url = f"redis://127.0.0.1:{self.port}/0"
+        self.proc: subprocess.Popen[str] | None = None
+
+    def start(self) -> None:
+        # --daemonize no, log to stdout, no persistence, bind loopback only.
+        self.proc = subprocess.Popen(
+            [
+                "redis-server",
+                "--port",
+                str(self.port),
+                "--bind",
+                "127.0.0.1",
+                "--save",
+                "",
+                "--appendonly",
+                "no",
+                "--loglevel",
+                "warning",
+                "--protected-mode",
+                "no",
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+        # Wait for readiness.
+        deadline = time.monotonic() + 10.0
+        while time.monotonic() < deadline:
+            if self.proc.poll() is not None:
+                out = self.proc.stdout.read() if self.proc.stdout else ""
+                raise RuntimeError(f"redis-server exited early:\n{out}")
+            try:
+                with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
+                    s.settimeout(0.25)
+                    s.connect(("127.0.0.1", self.port))
+                    break
+            except OSError:
+                time.sleep(0.05)
+        else:  # pragma: no cover — environment failure
+            raise RuntimeError(f"redis-server did not become ready on port {self.port}")
+
+    def stop(self) -> None:
+        if self.proc is not None:
+            self.proc.terminate()
+            try:
+                self.proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:  # pragma: no cover
+                self.proc.kill()
+            self.proc = None
+
+    @property
+    def version(self) -> str:
+        out = subprocess.run(
+            ["redis-cli", "-h", "127.0.0.1", "-p", str(self.port), "INFO", "server"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        ).stdout
+        for line in out.splitlines():
+            if line.startswith("redis_version:"):
+                return line.split(":", 1)[1].strip()
+        return "unknown"
+
+
+@pytest.fixture(scope="module")
+def disposable_redis() -> Any:
+    """Launch + tear down a real isolated redis-server for this module."""
+    if not shutil_which("redis-server"):
+        pytest.skip("redis-server not installed on this host")
+    rd = _DisposableRedis()
+    rd.start()
+    try:
+        yield rd
+    finally:
+        rd.stop()
+
+
+def shutil_which(cmd: str) -> str | None:
+    from shutil import which
+
+    return which(cmd)
+
+
+def _make_gate(
+    redis_url: str,
+    *,
+    interval_seconds: float = 1.0,
+    safety_margin_seconds: float = 0.05,
+    acquire_deadline_seconds: float = 10.0,
+    ttl_seconds: int = 120,
+    socket_timeout_seconds: float = 2.0,
+    socket_connect_timeout_seconds: float = 2.0,
+) -> VTSDistributedGate:
+    return VTSDistributedGate(
+        redis_url=redis_url,
+        interval_seconds=interval_seconds,
+        safety_margin_seconds=safety_margin_seconds,
+        acquire_deadline_seconds=acquire_deadline_seconds,
+        ttl_seconds=ttl_seconds,
+        socket_timeout_seconds=socket_timeout_seconds,
+        socket_connect_timeout_seconds=socket_connect_timeout_seconds,
+    )
+
+
+# ===========================================================================
+# Section 1 — gate module unit tests (real disposable Redis)
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_first_admit_is_immediate(disposable_redis: _DisposableRedis):
+    gate = _make_gate(disposable_redis.url)
+    try:
+        scope = build_vts_gate_scope_key(host=MOCK_HOST, app_key=MOCK_APP_KEY)
+        t0 = time.monotonic()
+        result = await gate.acquire(scope, call_class="order")
+        elapsed = time.monotonic() - t0
+        assert isinstance(result, AcquireResult)
+        assert result.contention_attempts == 1
+        assert elapsed < 0.2  # cold start admits immediately
+    finally:
+        await gate.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_adjacent_admits_meet_interval(disposable_redis: _DisposableRedis):
+    """Two sequential admits through the gate must be >= interval apart."""
+    gate = _make_gate(
+        disposable_redis.url, interval_seconds=0.4, safety_margin_seconds=0.05
+    )
+    try:
+        scope = build_vts_gate_scope_key(host=MOCK_HOST, app_key="adjacent")
+        await gate.acquire(scope, call_class="order")
+        t0 = time.monotonic()
+        await gate.acquire(scope, call_class="order")
+        gap = time.monotonic() - t0
+        # 0.4 + 0.05 margin -> gap must be >= 0.40 (allow tiny scheduling slop)
+        assert gap >= 0.40 - 0.03, f"second admit came too early: {gap:.3f}s"
+    finally:
+        await gate.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_concurrent_admits_serialize_no_burst(disposable_redis: _DisposableRedis):
+    """Three concurrent acquires for the same scope never burst past 1/interval."""
+    gate = _make_gate(
+        disposable_redis.url, interval_seconds=0.3, safety_margin_seconds=0.05
+    )
+    try:
+        scope = build_vts_gate_scope_key(host=MOCK_HOST, app_key="concurrent")
+        admit_times: list[float] = []
+
+        async def _one(idx: int) -> int:
+            await gate.acquire(scope, call_class="order")
+            admit_times.append(time.monotonic())
+            return idx
+
+        await asyncio.gather(*[_one(i) for i in range(3)])
+        admit_times.sort()
+        gaps = [admit_times[i] - admit_times[i - 1] for i in range(1, len(admit_times))]
+        # Every adjacent gap must meet the interval (minus tiny scheduling slop).
+        for g in gaps:
+            assert g >= 0.30 - 0.04, f"burst detected, gap={g:.3f}s"
+    finally:
+        await gate.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_distinct_credentials_isolate(disposable_redis: _DisposableRedis):
+    """Different app-key fingerprints admit independently (no cross-contention)."""
+    gate = _make_gate(
+        disposable_redis.url, interval_seconds=0.3, safety_margin_seconds=0.05
+    )
+    try:
+        scope_a = build_vts_gate_scope_key(host=MOCK_HOST, app_key="cred-A")
+        scope_b = build_vts_gate_scope_key(host=MOCK_HOST, app_key="cred-B")
+        t0 = time.monotonic()
+        await asyncio.gather(
+            gate.acquire(scope_a, call_class="order"),
+            gate.acquire(scope_b, call_class="order"),
+        )
+        elapsed = time.monotonic() - t0
+        # Distinct scopes admit in parallel — total wall time well under one interval.
+        assert elapsed < 0.30, f"distinct scopes did not parallelize: {elapsed:.3f}s"
+    finally:
+        await gate.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_distinct_hosts_isolate(disposable_redis: _DisposableRedis):
+    gate = _make_gate(disposable_redis.url, interval_seconds=0.3)
+    try:
+        same_app = "shared-app-key"
+        scope_vts = build_vts_gate_scope_key(host=MOCK_HOST, app_key=same_app)
+        scope_alt = build_vts_gate_scope_key(
+            host="openapivts.koreainvestment.com:29444", app_key=same_app
+        )
+        t0 = time.monotonic()
+        await asyncio.gather(
+            gate.acquire(scope_vts, call_class="order"),
+            gate.acquire(scope_alt, call_class="order"),
+        )
+        elapsed = time.monotonic() - t0
+        assert elapsed < 0.30
+    finally:
+        await gate.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_redis_unavailable_raises_fail_closed():
+    """Redis down -> DistributedGateUnavailable (never an unthrottled admit)."""
+    # Point at a port where nothing listens; connect must fail fast.
+    gate = _make_gate(
+        "redis://127.0.0.1:1/0",
+        socket_timeout_seconds=0.5,
+        socket_connect_timeout_seconds=0.5,
+        acquire_deadline_seconds=2.0,
+    )
+    scope = build_vts_gate_scope_key(host=MOCK_HOST, app_key="down")
+    try:
+        with pytest.raises(DistributedGateUnavailable):
+            await gate.acquire(scope, call_class="order")
+    finally:
+        await gate.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_acquire_deadline_raises_fail_closed(disposable_redis: _DisposableRedis):
+    """A backlog that cannot drain within the deadline fails closed."""
+    # Very short deadline + an already-occupied slot -> deadline exceeded.
+    gate = _make_gate(
+        disposable_redis.url,
+        interval_seconds=2.0,
+        safety_margin_seconds=0.0,
+        acquire_deadline_seconds=0.4,
+    )
+    try:
+        scope = build_vts_gate_scope_key(host=MOCK_HOST, app_key="deadline")
+        await gate.acquire(scope, call_class="order")  # occupy the slot
+        with pytest.raises(DistributedGateUnavailable):
+            await gate.acquire(scope, call_class="order")
+    finally:
+        await gate.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_cancellation_while_waiting_is_http_zero(
+    disposable_redis: _DisposableRedis,
+):
+    """A waiter cancelled mid-sleep never reaches the admit (HTTP=0)."""
+    gate = _make_gate(
+        disposable_redis.url, interval_seconds=1.0, safety_margin_seconds=0.0
+    )
+    try:
+        scope = build_vts_gate_scope_key(host=MOCK_HOST, app_key="cancel")
+        await gate.acquire(scope, call_class="order")  # occupy
+
+        admitted = {"v": False}
+
+        async def _waiter() -> None:
+            await gate.acquire(scope, call_class="order")
+            admitted["v"] = True
+
+        task = asyncio.create_task(_waiter())
+        await asyncio.sleep(0.05)  # let it enter the contention sleep
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert admitted["v"] is False  # never admitted -> HTTP would be 0
+    finally:
+        await gate.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_freshness_hook_rerun_on_contention(disposable_redis: _DisposableRedis):
+    """Contention forces the freshness hook to run again before re-claim."""
+    gate = _make_gate(
+        disposable_redis.url, interval_seconds=0.4, safety_margin_seconds=0.0
+    )
+    try:
+        scope = build_vts_gate_scope_key(host=MOCK_HOST, app_key="fresh")
+        await gate.acquire(scope, call_class="order")  # occupy slot
+
+        calls = {"n": 0}
+
+        async def _hook() -> None:
+            calls["n"] += 1
+
+        # Second admit must contend once -> hook runs twice (before each claim).
+        await gate.acquire(scope, freshness_hook=_hook, call_class="order")
+        assert calls["n"] >= 2, f"freshness not rerun on contention: {calls['n']}"
+    finally:
+        await gate.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_freshness_failure_aborts_before_admit(
+    disposable_redis: _DisposableRedis,
+):
+    """A failing freshness hook aborts with HTTP=0 (PreSendFreshnessError)."""
+
+    class _FreshError(RuntimeError):
+        pass
+
+    gate = _make_gate(disposable_redis.url)
+    try:
+        scope = build_vts_gate_scope_key(host=MOCK_HOST, app_key="freshfail")
+        admitted = {"v": False}
+
+        async def _failing_hook() -> None:
+            raise _FreshError("stale book")
+
+        # The hook runs before the first claim; the gate must propagate the
+        # freshness error and never admit.
+        with pytest.raises(_FreshError):
+
+            async def _track() -> None:
+                await gate.acquire(
+                    scope, freshness_hook=_failing_hook, call_class="order"
+                )
+                admitted["v"] = True
+
+            await _track()
+
+        assert admitted["v"] is False
+    finally:
+        await gate.close()
+
+
+@pytest.mark.integration
+def test_scope_key_is_secret_free():
+    """Keys and fingerprints must never contain the raw app key."""
+    key = build_vts_gate_scope_key(host=MOCK_HOST, app_key="SUPER_SECRET_VALUE_123")
+    assert "SUPER_SECRET_VALUE_123" not in key
+    assert key.startswith("kis_mock:gate:openapivts.koreainvestment.com:29443:")
+    # Fingerprint is 16 hex chars.
+    fp = key.rsplit(":", 1)[-1]
+    assert len(fp) == 16
+    assert all(c in "0123456789abcdef" for c in fp)
+
+
+@pytest.mark.integration
+def test_netloc_helper_matches_token_namespace():
+    """Gate host extraction must match the OAuth token namespace netloc shape."""
+    assert netloc_from_url(MOCK_BASE_URL + "/uapi/x") == MOCK_HOST
+    assert netloc_from_url("https://openapi.koreainvestment.com:9443/p") == LIVE_HOST
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_cold_start_after_ttl_expiry_is_deterministic(
+    disposable_redis: _DisposableRedis,
+):
+    """After the cooldown key TTL expires, the next admit is immediate (cold start)."""
+    gate = _make_gate(
+        disposable_redis.url,
+        interval_seconds=0.2,
+        safety_margin_seconds=0.0,
+        ttl_seconds=1,  # short TTL to observe cold-start recovery
+    )
+    try:
+        scope = build_vts_gate_scope_key(host=MOCK_HOST, app_key="ttl")
+        await gate.acquire(scope, call_class="order")
+        # Wait past TTL.
+        await asyncio.sleep(1.2)
+        t0 = time.monotonic()
+        await gate.acquire(scope, call_class="order")
+        assert time.monotonic() - t0 < 0.2  # cold-start immediate admit
+    finally:
+        await gate.close()
+
+
+# ===========================================================================
+# Section 2 — singleton wiring
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_singleton_reset_round_trip():
+    await reset_vts_distributed_gate()
+    g1 = await get_vts_distributed_gate()
+    g2 = await get_vts_distributed_gate()
+    assert g1 is g2
+    await reset_vts_distributed_gate()
+
+
+# ===========================================================================
+# Section 3 — real multiprocessing dispatch-timing suite
+# ===========================================================================
+
+
+class _MockSettings:
+    """Minimal settings view: mock host + mock app key, live fallbacks."""
+
+    kis_app_key = MOCK_APP_KEY
+    kis_app_secret = "secret"
+    kis_access_token = "token"
+    kis_account_no = "1234567890"
+    kis_base_url = MOCK_BASE_URL  # dispatch URL resolves to mock host
+    kis_mock_base_url = MOCK_BASE_URL
+    api_rate_limit_retry_429_max = 0
+    api_rate_limit_retry_429_base_delay = 0.0
+    kis_rate_limit_rate = 19
+    kis_rate_limit_period = 1.0
+    kis_api_rate_limits: dict[str, Any] = {}
+
+
+class _DispatchTrackingClient(BaseKISClient):
+    """BaseKISClient subclass that records real _execute_http_request starts.
+
+    ``_vts_gate`` is injected so the dispatch boundary contacts the disposable
+    Redis instead of the process-wide singleton.
+    """
+
+    def __init__(self, gate: VTSDistributedGate) -> None:  # type: ignore[override]
+        self._unmapped_rate_limit_keys_logged: set[str] = set()
+        type(self)._shared_client_lock = None
+        self._vts_gate = gate
+        self._dispatch_starts: list[float] = []
+        self._dispatch_count = 0
+
+    @property  # type: ignore[override]
+    def _settings(self) -> Any:  # type: ignore[override]
+        return _MockSettings()
+
+    async def _get_limiter(self, api_key: str, *, rate: int, period: float) -> Any:
+        limiter = MagicMock()
+        limiter.acquire = AsyncMock()
+        return limiter
+
+    async def _ensure_client(self, timeout: float | None = None) -> Any:  # type: ignore[override]
+        return MagicMock()
+
+    async def _execute_http_request(  # type: ignore[override]
+        self, client: Any, method: str, url: str, **kwargs: Any
+    ) -> Any:
+        # Record the START timestamp (the spec measures dispatch starts, not
+        # acquire() returns). Sleep a hair so concurrency is observable.
+        self._dispatch_starts.append(time.monotonic())
+        self._dispatch_count += 1
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.headers = {}
+        resp.json.return_value = {"rt_cd": "0", "output": {}, "msg1": "ok"}
+        return resp
+
+
+def _child_worker(  # noqa: C901 — multiprocessing target
+    redis_url: str,
+    app_key: str,
+    requests: list[tuple[str, str]],
+    out_queue: mp.Queue,
+    interval_seconds: float,
+    safety_margin_seconds: float,
+) -> None:
+    """Run N dispatches in a child PID; push (label, start_timestamps, count)."""
+    # Each child needs its own event loop.
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+
+    gate = _make_gate(
+        redis_url,
+        interval_seconds=interval_seconds,
+        safety_margin_seconds=safety_margin_seconds,
+        acquire_deadline_seconds=15.0,
+    )
+
+    # Patch the app key on this child's settings view (per-credential tests).
+    _MockSettings.kis_app_key = app_key
+    _MockSettings.kis_mock_base_url = MOCK_BASE_URL
+
+    client = _DispatchTrackingClient(gate)
+
+    async def _run() -> list[tuple[str, float]]:
+        starts: list[tuple[str, float]] = []
+        for label, path in requests:
+            url = MOCK_BASE_URL + path
+            headers = {"appkey": app_key, "authorization": "Bearer tok", "tr_id": label}
+            await client._dispatch_rate_limited_with_headers(
+                "POST"
+                if "order" in label or "cancel" in label or "modify" in label
+                else "GET",
+                url,
+                headers=headers,
+                params=None,
+                json_body={"x": 1} if "order" in label else None,
+                timeout=5.0,
+                api_name=label,
+                tr_id=label,
+                retry_request_errors=False,
+                max_retries_override=0,
+            )
+            starts.append((label, client._dispatch_starts[-1]))
+        return starts
+
+    try:
+        starts = loop.run_until_complete(_run())
+        out_queue.put((app_key, starts, client._dispatch_count))
+    except Exception as e:  # noqa: BLE001
+        out_queue.put((app_key, [], -1, repr(e)))
+    finally:
+        loop.run_until_complete(gate.close())
+        loop.close()
+
+
+@pytest.mark.integration
+def test_multiprocessing_kr_buy_sell_read_share_budget(
+    disposable_redis: _DisposableRedis,
+):
+    """Two PIDs issuing KR buy, KR sell, and a mock read through the real
+    dispatch boundary share ONE admit budget: adjacent _execute_http_request
+    starts for the credential scope meet the interval, and each intended
+    dispatch fires exactly once."""
+    interval = 0.35
+    margin = 0.05
+    # Flush any prior cooldown for this credential.
+    subprocess.run(
+        ["redis-cli", "-h", "127.0.0.1", "-p", str(disposable_redis.port), "FLUSHDB"],
+        check=False,
+        capture_output=True,
+        timeout=5,
+    )
+
+    # PID A: KR buy then a mock read. PID B: KR sell. Same credential scope.
+    reqs_a = [("kr_buy", "/uapi/domestic-stock/v1/trading/order-cash")]
+    reqs_b = [
+        ("kr_sell", "/uapi/domestic-stock/v1/trading/order-cash"),
+        ("mock_read", "/uapi/domestic-stock/v1/trading/inquire-balance"),
+    ]
+
+    ctx = mp.get_context("spawn")
+    q: mp.Queue = ctx.Queue()
+    procs = [
+        ctx.Process(
+            target=_child_worker,
+            args=(disposable_redis.url, MOCK_APP_KEY, reqs_a, q, interval, margin),
+        ),
+        ctx.Process(
+            target=_child_worker,
+            args=(disposable_redis.url, MOCK_APP_KEY, reqs_b, q, interval, margin),
+        ),
+    ]
+    for p in procs:
+        p.start()
+    for p in procs:
+        p.join(timeout=60)
+
+    results = []
+    while not q.empty():
+        results.append(q.get())
+    assert len(results) == 2, f"expected 2 child results, got {results}"
+
+    all_starts: list[float] = []
+    total_dispatches = 0
+    for r in results:
+        assert len(r) >= 3, f"child reported failure: {r}"
+        _app_key, starts, count = r[0], r[1], r[2]
+        assert count >= 1 and count == len(starts), (
+            f"each intended dispatch must fire exactly once: count={count}, starts={len(starts)}"
+        )
+        total_dispatches += count
+        all_starts.extend(ts for _label, ts in starts)
+
+    # 3 intended requests across 2 PIDs -> exactly 3 HTTP dispatches.
+    assert total_dispatches == 3, f"expected 3 dispatches, got {total_dispatches}"
+
+    all_starts.sort()
+    gaps = [all_starts[i] - all_starts[i - 1] for i in range(1, len(all_starts))]
+    # Adjacent starts must meet the interval (minus small scheduling slop for
+    # multiprocess clock + asyncio wakeup).
+    slop = 0.05
+    for g in gaps:
+        assert g >= interval - slop, (
+            f"cross-PID burst: adjacent dispatch gap {g:.3f}s < interval {interval}s"
+        )
+
+
+@pytest.mark.integration
+def test_multiprocessing_distinct_credentials_do_not_serialize(
+    disposable_redis: _DisposableRedis,
+):
+    """Two PIDs with DIFFERENT mock app keys admit in parallel (no shared budget)."""
+    interval = 0.4
+    subprocess.run(
+        ["redis-cli", "-h", "127.0.0.1", "-p", str(disposable_redis.port), "FLUSHDB"],
+        check=False,
+        capture_output=True,
+        timeout=5,
+    )
+    reqs = [("kr_buy", "/uapi/domestic-stock/v1/trading/order-cash")]
+    ctx = mp.get_context("spawn")
+    q: mp.Queue = ctx.Queue()
+    procs = [
+        ctx.Process(
+            target=_child_worker,
+            args=(disposable_redis.url, "cred-alpha", reqs, q, interval, 0.05),
+        ),
+        ctx.Process(
+            target=_child_worker,
+            args=(disposable_redis.url, "cred-beta", reqs, q, interval, 0.05),
+        ),
+    ]
+    for p in procs:
+        p.start()
+    for p in procs:
+        p.join(timeout=60)
+
+    results = []
+    while not q.empty():
+        results.append(q.get())
+    assert len(results) == 2
+    # Distinct credentials -> the two dispatches' START timestamps must be
+    # close (parallel admission), not separated by the full interval. Wall-clock
+    # spawn startup is excluded by comparing dispatch starts directly.
+    starts = sorted(ts for r in results for _label, ts in r[1])
+    assert len(starts) == 2
+    delta = starts[1] - starts[0]
+    assert delta < interval * 0.5, (
+        f"distinct credentials serialized (dispatch starts {delta:.3f}s apart, "
+        f"expected near-simultaneous): {results}"
+    )
+    for r in results:
+        assert r[2] == 1, f"each PID must dispatch exactly once: {r}"
+
+
+# ===========================================================================
+# Section 4 — dispatch-boundary integration (HTTP=0 invariants)
+# ===========================================================================
+
+
+class _UnitMockSettings(_MockSettings):
+    # Reads retry transient RequestErrors by default; tests that need
+    # exactly-one-POST pass max_retries_override=0 explicitly.
+    api_rate_limit_retry_429_max = 2
+    api_rate_limit_retry_429_base_delay = 0.0
+
+
+class _UnitDispatchClient(BaseKISClient):
+    """In-process dispatch client for the HTTP=0 invariant tests."""
+
+    def __init__(self, gate: VTSDistributedGate) -> None:  # type: ignore[override]
+        self._unmapped_rate_limit_keys_logged: set[str] = set()
+        type(self)._shared_client_lock = None
+        self._vts_gate = gate
+        self.http_calls = 0
+
+    @property  # type: ignore[override]
+    def _settings(self) -> Any:  # type: ignore[override]
+        return _UnitMockSettings()
+
+    async def _get_limiter(self, api_key: str, *, rate: int, period: float) -> Any:
+        limiter = MagicMock()
+        limiter.acquire = AsyncMock()
+        return limiter
+
+    async def _ensure_client(self, timeout: float | None = None) -> Any:  # type: ignore[override]
+        return MagicMock()
+
+    async def _execute_http_request(  # type: ignore[override]
+        self, client: Any, method: str, url: str, **kwargs: Any
+    ) -> Any:
+        self.http_calls += 1
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.headers = {}
+        resp.json.return_value = {"rt_cd": "0", "output": {}, "msg1": "ok"}
+        return resp
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_redis_failure_mutation_is_http_zero():
+    """A mock order dispatch when Redis is down must prove HTTP=0 (no fallback)."""
+    gate = _make_gate(
+        "redis://127.0.0.1:1/0",
+        socket_timeout_seconds=0.5,
+        socket_connect_timeout_seconds=0.5,
+        acquire_deadline_seconds=1.5,
+    )
+    client = _UnitDispatchClient(gate)
+    try:
+        with pytest.raises(DistributedGateUnavailable):
+            await client._dispatch_rate_limited_with_headers(
+                "POST",
+                MOCK_BASE_URL + "/uapi/domestic-stock/v1/trading/order-cash",
+                headers={"appkey": MOCK_APP_KEY, "authorization": "Bearer t"},
+                json_body={"PDNO": "005930"},
+                timeout=5.0,
+                api_name="order_korea_stock",
+                tr_id="VTTC0802U",
+                retry_request_errors=False,
+                max_retries_override=0,
+            )
+        assert client.http_calls == 0, (
+            "mutation must not fall back to HTTP on Redis failure"
+        )
+    finally:
+        await gate.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_redis_failure_read_also_http_zero():
+    """Reads cannot bypass the gate during Redis outage (same fail-closed path)."""
+    gate = _make_gate(
+        "redis://127.0.0.1:1/0",
+        socket_timeout_seconds=0.5,
+        socket_connect_timeout_seconds=0.5,
+        acquire_deadline_seconds=1.5,
+    )
+    client = _UnitDispatchClient(gate)
+    try:
+        with pytest.raises(DistributedGateUnavailable):
+            await client._dispatch_rate_limited_with_headers(
+                "GET",
+                MOCK_BASE_URL + "/uapi/domestic-stock/v1/trading/inquire-balance",
+                headers={"appkey": MOCK_APP_KEY, "authorization": "Bearer t"},
+                timeout=5.0,
+                api_name="inquire_balance",
+                tr_id="VTTC8434R",
+            )
+        assert client.http_calls == 0
+    finally:
+        await gate.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_live_host_never_contacts_redis(disposable_redis: _DisposableRedis):
+    """A live-host dispatch must succeed without the gate touching Redis at all."""
+    gate = _make_gate(disposable_redis.url)
+    client = _UnitDispatchClient(gate)
+    try:
+        await client._dispatch_rate_limited_with_headers(
+            "GET",
+            f"https://{LIVE_HOST}/uapi/domestic-stock/v1/quotations/inquire-price",
+            headers={"appkey": "live-key", "authorization": "Bearer t"},
+            timeout=5.0,
+            api_name="inquire_price",
+            tr_id="FHKST01010100",
+        )
+        assert client.http_calls == 1
+    finally:
+        await gate.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_egw00201_still_exactly_one_post(disposable_redis: _DisposableRedis):
+    """ROB-645 invariant preserved: an EGW00201/'초과' body is not re-POSTed."""
+    gate = _make_gate(disposable_redis.url)
+    client = _UnitDispatchClient(gate)
+
+    async def _execute_http_request(
+        client_: Any, method: str, url: str, **kwargs: Any
+    ) -> Any:
+        client.http_calls += 1
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.headers = {}
+        resp.json.return_value = {
+            "rt_cd": "1",
+            "msg_cd": "EGW00215",
+            "msg1": "초당 거래건수를 초과하였습니다.",
+        }
+        return resp
+
+    client._execute_http_request = _execute_http_request  # type: ignore[assignment]
+    try:
+        data, _hdrs = await client._dispatch_rate_limited_with_headers(
+            "POST",
+            MOCK_BASE_URL + "/uapi/domestic-stock/v1/trading/order-cash",
+            headers={"appkey": MOCK_APP_KEY, "authorization": "Bearer t"},
+            json_body={"PDDO": "005930"},
+            timeout=5.0,
+            api_name="order_korea_stock",
+            tr_id="VTTC0802U",
+            retry_request_errors=False,
+            max_retries_override=0,
+        )
+        assert data["msg_cd"] == "EGW00215"
+        assert client.http_calls == 1, "order must POST exactly once (no re-POST)"
+    finally:
+        await gate.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_read_retries_reacquire_permit(disposable_redis: _DisposableRedis):
+    """A read that retries RequestError reacquires the gate on each attempt."""
+    gate = _make_gate(
+        disposable_redis.url, interval_seconds=0.3, safety_margin_seconds=0.0
+    )
+    import httpx
+
+    client = _UnitDispatchClient(gate)
+    state = {"n": 0}
+
+    async def _execute_http_request(
+        client_: Any, method: str, url: str, **kwargs: Any
+    ) -> Any:
+        state["n"] += 1
+        client.http_calls += 1
+        if state["n"] == 1:
+            raise httpx.ReadTimeout("first attempt times out")
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.headers = {}
+        resp.json.return_value = {"rt_cd": "0", "output": {}}
+        return resp
+
+    client._execute_http_request = _execute_http_request  # type: ignore[assignment]
+    try:
+        await client._dispatch_rate_limited_with_headers(
+            "GET",
+            MOCK_BASE_URL + "/uapi/domestic-stock/v1/trading/inquire-balance",
+            headers={"appkey": MOCK_APP_KEY, "authorization": "Bearer t"},
+            timeout=5.0,
+            api_name="inquire_balance",
+            tr_id="VTTC8434R",
+            retry_request_errors=True,
+        )
+        # Two HTTP attempts -> two gate admits, separated by the interval.
+        assert client.http_calls == 2
+    finally:
+        await gate.close()
+
+
+# Suppress noisy info logs during the multiprocessing/timing tests.
+@pytest.fixture(autouse=True)
+def _quiet_gate_logger(caplog: pytest.LogCaptureFixture):
+    caplog.set_level(
+        logging.WARNING, logger="app.services.brokers.kis.vts_distributed_gate"
+    )
+    return caplog

--- a/tests/brokers/kis/test_vts_distributed_gate.py
+++ b/tests/brokers/kis/test_vts_distributed_gate.py
@@ -893,6 +893,21 @@ class _UnitDispatchClient(BaseKISClient):
         return resp
 
 
+class _MagicMockConfiguredClient(_UnitDispatchClient):
+    """Model legacy tests whose client marker and settings are MagicMocks."""
+
+    _is_mock_client = MagicMock()
+    _magic_settings = MagicMock()
+    _magic_settings.kis_mock_base_url = MagicMock()
+    _magic_settings.kis_rate_limit_rate = 19
+    _magic_settings.kis_rate_limit_period = 1.0
+    _magic_settings.kis_api_rate_limits = {}
+
+    @property
+    def _settings(self) -> Any:  # type: ignore[override]
+        return self._magic_settings
+
+
 @pytest.mark.asyncio
 @pytest.mark.integration
 async def test_redis_failure_mutation_is_http_zero():
@@ -968,6 +983,29 @@ async def test_live_host_never_contacts_redis(real_redis: _RealRedis):
         )
         assert client.http_calls == 1
         claim_spy.assert_not_awaited()  # live -> zero Redis calls, proven
+    finally:
+        await gate.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_magicmock_client_and_settings_custom_host_bypass_redis():
+    """MagicMock truthiness must not classify a custom/live test URL as VTS."""
+    gate = _make_gate(real_redis_url_unused())
+    claim_spy = AsyncMock(wraps=gate._claim)
+    gate._claim = claim_spy  # type: ignore[method-assign]
+    client = _MagicMockConfiguredClient(gate)
+    try:
+        await client._dispatch_rate_limited_with_headers(
+            "GET",
+            "https://custom-kis-test.invalid/uapi/quotations/inquire-price",
+            headers={"appkey": "custom-key", "authorization": "Bearer t"},
+            timeout=5.0,
+            api_name="inquire_price",
+            tr_id="FHKST01010100",
+        )
+        assert client.http_calls == 1
+        claim_spy.assert_not_awaited()
     finally:
         await gate.close()
 
@@ -1157,6 +1195,63 @@ async def test_half_open_probe_released_on_distributed_gate_failure(
         # Next request can obtain a fresh probe (no permanent KISCircuitOpen).
         cb.before_request()
         assert cb._probe_in_flight is True
+    finally:
+        await gate.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_half_open_retry_gate_failure_after_http_started_reopens_breaker(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """A retry-time gate failure cannot erase an ambiguous HALF_OPEN HTTP.
+
+    The first attempt reached the HTTP boundary but produced no response.  If
+    the second attempt then aborts in the distributed gate, the probe outcome
+    remains indeterminate and must restart the OPEN cooldown rather than make
+    the breaker immediately probeable again.
+    """
+    import httpx
+
+    from app.services.brokers.kis.circuit_breaker import KISCircuitOpen
+
+    cb, _clock = _breaker_open_past_cooldown()
+    monkeypatch.setattr(
+        "app.services.brokers.kis.base.get_kis_circuit_breaker", lambda: cb
+    )
+
+    gate = _make_gate(real_redis_url_unused())
+    client = _UnitDispatchClient(gate)
+    client._await_vts_gate = AsyncMock(  # type: ignore[method-assign]
+        side_effect=[None, DistributedGateUnavailable("retry gate unavailable")]
+    )
+
+    async def _read_timeout(*args: Any, **kwargs: Any) -> Any:
+        client.http_calls += 1
+        raise httpx.ReadTimeout("first attempt timed out")
+
+    client._execute_http_request = _read_timeout  # type: ignore[assignment]
+    monkeypatch.setattr(client, "_calculate_retry_delay", lambda **kwargs: 0.0)
+
+    try:
+        with pytest.raises(DistributedGateUnavailable, match="retry gate unavailable"):
+            await client._request_with_rate_limit_with_headers(
+                "GET",
+                MOCK_BASE_URL + "/uapi/domestic-stock/v1/trading/inquire-balance",
+                headers={"appkey": MOCK_APP_KEY, "authorization": "Bearer t"},
+                timeout=5.0,
+                api_name="inquire_balance",
+                tr_id="VTTC8434R",
+                retry_request_errors=True,
+                max_retries_override=1,
+            )
+
+        assert client.http_calls == 1
+        assert client._await_vts_gate.await_count == 2  # type: ignore[attr-defined]
+        assert cb.state == "open"
+        assert cb._probe_in_flight is False
+        with pytest.raises(KISCircuitOpen):
+            cb.before_request()
     finally:
         await gate.close()
 
@@ -1361,6 +1456,7 @@ def test_reset_does_not_roll_back_generation():
         cb.record_success,
         cb.record_failure,
         cb.record_indeterminate,
+        cb.record_reachable_error,
     ):
         prev_state = cb.state
         stale_call(old_token)

--- a/tests/brokers/kis/test_vts_distributed_gate.py
+++ b/tests/brokers/kis/test_vts_distributed_gate.py
@@ -63,6 +63,12 @@ MOCK_APP_KEY = "test-mock-app-key-ROB892"
 # Small measurement tolerance for server-enforced gaps (covers scheduling +
 # monotonic-clock noise). Tight enough to actually guarantee interval + margin.
 _TIMING_TOLERANCE = 0.03
+# Cross-process tolerance for the multiprocessing gap test. The admit gap is
+# Redis-SERVER-enforced (>= interval + margin); the only noise is cross-process
+# scheduling jitter waking the next admitted child (milliseconds). Kept well
+# below the configured safety margin so the test proves the margin, not just the
+# bare interval.
+_MP_TIMING_TOLERANCE = 0.02
 
 
 # ---------------------------------------------------------------------------
@@ -815,10 +821,11 @@ def test_multiprocessing_kr_buy_sell_read_share_budget(real_redis: _RealRedis):
     assert total == 3, f"expected 3 dispatches, got {total}"
     all_starts.sort()
     gaps = [all_starts[i] - all_starts[i - 1] for i in range(1, len(all_starts))]
-    # CR10: adjacent starts must meet interval + margin (only small tolerance),
-    # not just the bare interval.
+    # CR10: adjacent starts must meet interval + margin with only a small
+    # cross-process tolerance — NOT the full margin — so the safety margin is
+    # actually proven (gap is Redis-server-enforced at >= interval + margin).
     for g in gaps:
-        assert g >= interval + margin - 0.05, (
+        assert g >= interval + margin - _MP_TIMING_TOLERANCE, (
             f"cross-PID burst: gap {g:.3f}s < {interval + margin}s"
         )
 
@@ -1242,6 +1249,287 @@ async def test_half_open_probe_released_on_pre_send_freshness(
 def real_redis_url_unused() -> str:
     """A placeholder URL for breaker tests whose gate is never contacted."""
     return "redis://127.0.0.1:1/0"
+
+
+# ===========================================================================
+# Section 8 — ownership/stale-release + 3-phase cancellation + decoder [1,+]
+#            + urlsplit robustness (final runtime review)
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_decoder_rejects_admit_with_positive_retry(real_redis: _RealRedis):
+    """CR2: the Lua success shape is exactly [1, 0]; [1, positive] must fail."""
+    gate = _make_gate(real_redis.url)
+    scope = build_vts_gate_scope_key(host=MOCK_HOST, app_key="admitpos")
+    try:
+        for raw in ([1, 999], [1, -1]):
+            fake_client = MagicMock()
+            fake_client.execute_command = AsyncMock(return_value=raw)
+            gate._get_redis = AsyncMock(return_value=fake_client)  # type: ignore[method-assign]
+            with pytest.raises(DistributedGateUnavailable):
+                await gate.acquire(scope, call_class="order")
+    finally:
+        await gate.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_stale_release_never_releases_other_probe_lease():
+    """P1: an older request's lease token cannot release the current probe owner."""
+    cb, _clock = _breaker_open_past_cooldown()
+    # Simulate the dispatch wrapper handing out the probe to request B.
+    lease_b = cb.before_request()  # HALF_OPEN, owner=lease_b, probe in flight
+    assert cb.state == "half_open" and cb._probe_in_flight is True
+
+    # An OLDER request A (admitted earlier in CLOSED) is cancelled/aborted and
+    # tries to release with its own stale token — must be a no-op.
+    stale_token_a = lease_b - 1  # any different token
+    cb.release_probe(stale_token_a)
+    assert cb._probe_in_flight is True  # B's lease intact
+    # A fresh third request must still be blocked (stampede guard).
+    from app.services.brokers.kis.circuit_breaker import KISCircuitOpen
+
+    with pytest.raises(KISCircuitOpen):
+        cb.before_request()
+    # Only the true owner can release.
+    cb.release_probe(lease_b)
+    assert cb._probe_in_flight is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_stale_outcome_does_not_close_half_open_generation():
+    """A stale request's record_success must NOT close the current probe generation."""
+    cb, _clock = _breaker_open_past_cooldown()
+    lease_b = cb.before_request()
+    stale_a = lease_b - 1
+    cb.record_success(stale_a)  # stale -> no-op
+    assert cb.state == "half_open"
+    assert cb._probe_in_flight is True
+    cb.record_success(lease_b)  # owner -> closes
+    assert cb.state == "closed"
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_stale_outcome_does_not_reopen_half_open_generation():
+    """A stale request's record_failure must NOT re-open the current generation."""
+    cb, _clock = _breaker_open_past_cooldown()
+    lease_b = cb.before_request()
+    stale_a = lease_b - 1
+    cb.record_failure(stale_a)  # stale -> no-op
+    assert cb.state == "half_open"
+    assert cb._probe_in_flight is True
+    cb.record_failure(lease_b)  # owner -> re-open
+    assert cb.state == "open"
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_closed_failure_threshold_semantics_preserved():
+    """CLOSED consecutive-failure counting stays token-agnostic (N-strike trip)."""
+    cb, _clock = _breaker_open_past_cooldown()  # currently OPEN (2 strikes)
+    # Drive CLOSED counting: reset, then fail without/with arbitrary tokens.
+    cb.reset()
+    assert cb.state == "closed"
+    cb.record_failure(123)  # arbitrary token, CLOSED -> counts
+    cb.record_failure(None)
+    assert cb.failure_count == 2  # threshold reached -> OPEN
+    assert cb.state == "open"
+
+
+@pytest.mark.unit
+def test_reset_does_not_roll_back_generation():
+    """reset must not reuse old tokens (the monotonic counter keeps advancing)."""
+    cb, _clock = _breaker_open_past_cooldown()
+    lease_before = cb.before_request if cb.state != "open" else None
+    cb.reset()
+    # After reset, a fresh before_request in CLOSED yields a NEW token strictly
+    # greater than any earlier one (old permits can never collide).
+    t = cb.before_request()
+    assert t > 0
+    # release_probe with the pre-reset token is a no-op (state is CLOSED now).
+    cb.release_probe(t)
+    assert cb.state == "closed"
+    del lease_before
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_cancellation_after_http_started_reopens_breaker(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Phase 2: owner cancelled mid-HTTP (no response) -> re-OPEN + cooldown."""
+    cb, _clock = _breaker_open_past_cooldown()
+    monkeypatch.setattr(
+        "app.services.brokers.kis.base.get_kis_circuit_breaker", lambda: cb
+    )
+
+    gate = _make_gate("redis://127.0.0.1:1/0")
+    client = _UnitDispatchClient(gate)
+    hang = asyncio.Event()
+
+    async def _hanging_http(*args: Any, **kwargs: Any) -> Any:  # type: ignore[override]
+        client.http_calls += 1
+        await hang.wait()  # never resolves -> cancelled mid-HTTP
+        return MagicMock(status_code=200, headers={}, json=lambda: {"rt_cd": "0"})
+
+    client._execute_http_request = _hanging_http  # type: ignore[assignment]
+    try:
+        task = asyncio.create_task(
+            client._request_with_rate_limit_with_headers(
+                "GET",
+                f"https://{LIVE_HOST}/uapi/quotations/inquire-price",
+                headers={"appkey": "live-key", "authorization": "Bearer t"},
+                timeout=5.0,
+                api_name="inquire_price",
+                tr_id="FHKST01010100",
+            )
+        )
+        await asyncio.sleep(0.1)  # let it reach the hanging HTTP (http_started=True)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert client.http_calls == 1  # HTTP did start
+        assert cb.state == "open"  # phase 2 -> re-opened + cooldown
+    finally:
+        hang.set()
+        await gate.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_cancellation_after_response_seen_closes_breaker(
+    monkeypatch: pytest.MonkeyPatch,
+    real_redis: _RealRedis,
+):
+    """Phase 3: cancelled during retry sleep after a response -> reachable -> CLOSED."""
+    cb, _clock = _breaker_open_past_cooldown()
+    monkeypatch.setattr(
+        "app.services.brokers.kis.base.get_kis_circuit_breaker", lambda: cb
+    )
+
+    gate = _make_gate(real_redis.url)
+    client = _UnitDispatchClient(gate)
+
+    async def _then_429(*args: Any, **kwargs: Any) -> Any:  # type: ignore[override]
+        client.http_calls += 1
+        resp = MagicMock()
+        resp.status_code = 429
+        resp.headers = {"Retry-After": "5"}  # long retry sleep -> cancelled here
+        resp.json.return_value = {"rt_cd": "1", "msg_cd": "429"}
+        return resp
+
+    client._execute_http_request = _then_429  # type: ignore[assignment]
+    try:
+        task = asyncio.create_task(
+            client._request_with_rate_limit_with_headers(
+                "GET",
+                f"https://{LIVE_HOST}/uapi/quotations/inquire-price",
+                headers={"appkey": "live-key", "authorization": "Bearer t"},
+                timeout=5.0,
+                api_name="inquire_price",
+                tr_id="FHKST01010100",
+            )
+        )
+        await asyncio.sleep(0.15)  # response received, now in retry sleep
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert client.http_calls == 1  # response was seen
+        assert cb.state == "closed"  # phase 3 -> reachable -> CLOSED
+    finally:
+        await gate.close()
+
+
+class _MalformedMockSettings(_UnitMockSettings):
+    kis_mock_base_url = "http://["  # invalid IPv6 -> urlsplit raises ValueError
+    kis_base_url = f"https://{LIVE_HOST}"
+
+
+class _MalformedLiveClient(_UnitDispatchClient):
+    """Live client whose ``kis_mock_base_url`` is malformed (must not break live)."""
+
+    @property
+    def _settings(self) -> Any:  # type: ignore[override]
+        return _MalformedMockSettings()
+
+
+class _ExplicitMockMalformedClient(_UnitDispatchClient):
+    """Explicit mock client (``_is_mock_client``) with a malformed request URL."""
+
+    _is_mock_client = True
+
+    @property
+    def _settings(self) -> Any:  # type: ignore[override]
+        return _MalformedMockSettings()
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_malformed_mock_base_url_does_not_break_live_request(
+    monkeypatch: pytest.MonkeyPatch, real_redis: _RealRedis
+):
+    """Fix 3: a malformed kis_mock_base_url must NOT break a valid live request
+    and must not move the breaker (no ValueError reaches the outer handler)."""
+    cb = KISCircuitBreaker(settings_obj=_BreakerSettings())
+    monkeypatch.setattr(
+        "app.services.brokers.kis.base.get_kis_circuit_breaker", lambda: cb
+    )
+
+    gate = _make_gate(real_redis.url)
+    claim_spy = AsyncMock(wraps=gate._claim)
+    gate._claim = claim_spy  # type: ignore[method-assign]
+    client = _MalformedLiveClient(gate)
+    try:
+        await client._request_with_rate_limit_with_headers(
+            "GET",
+            f"https://{LIVE_HOST}/uapi/quotations/inquire-price",
+            headers={"appkey": "live-key", "authorization": "Bearer t"},
+            timeout=5.0,
+            api_name="inquire_price",
+            tr_id="FHKST01010100",
+        )
+        assert client.http_calls == 1
+        claim_spy.assert_not_awaited()
+        assert cb.state == "closed"
+    finally:
+        await gate.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_malformed_mock_request_failcloses_without_breaker_move(
+    monkeypatch: pytest.MonkeyPatch, real_redis: _RealRedis
+):
+    """Fix 3: an explicit-mock dispatch whose URL is malformed fails CLOSED (DGU),
+    HTTP=0, and the breaker is NOT mistaken as KIS-reachable (stays HALF_OPEN)."""
+    cb, _clock = _breaker_open_past_cooldown()
+    monkeypatch.setattr(
+        "app.services.brokers.kis.base.get_kis_circuit_breaker", lambda: cb
+    )
+
+    gate = _make_gate(real_redis.url)
+    client = _ExplicitMockMalformedClient(gate)
+    try:
+        with pytest.raises(DistributedGateUnavailable, match="host"):
+            await client._request_with_rate_limit_with_headers(
+                "POST",
+                "http://[::1",  # malformed request URL -> urlsplit ValueError
+                headers={"appkey": MOCK_APP_KEY, "authorization": "Bearer t"},
+                json_body={"PDNO": "005930"},
+                timeout=5.0,
+                api_name="order_korea_stock",
+                tr_id="VTTC0802U",
+                retry_request_errors=False,
+                max_retries_override=0,
+            )
+        assert client.http_calls == 0
+        assert cb.state == "half_open"
+    finally:
+        await gate.close()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/brokers/kis/test_vts_distributed_gate.py
+++ b/tests/brokers/kis/test_vts_distributed_gate.py
@@ -1342,18 +1342,180 @@ async def test_closed_failure_threshold_semantics_preserved():
 
 @pytest.mark.unit
 def test_reset_does_not_roll_back_generation():
-    """reset must not reuse old tokens (the monotonic counter keeps advancing)."""
-    cb, _clock = _breaker_open_past_cooldown()
-    lease_before = cb.before_request if cb.state != "open" else None
+    """reset must not reuse old tokens: after reset, a stale pre-reset token
+    cannot release/close/re-open the NEW HALF_OPEN owner's generation."""
+    cb, clock = _breaker_open_past_cooldown()
+    old_token = cb.before_request()  # half-opens, owner=old_token
+    assert cb.state == "half_open" and cb._probe_in_flight is True
     cb.reset()
-    # After reset, a fresh before_request in CLOSED yields a NEW token strictly
-    # greater than any earlier one (old permits can never collide).
-    t = cb.before_request()
-    assert t > 0
-    # release_probe with the pre-reset token is a no-op (state is CLOSED now).
-    cb.release_probe(t)
+    # Build a fresh HALF_OPEN generation with a strictly greater owner token.
+    cb.record_failure()
+    cb.record_failure()  # threshold -> OPEN
+    clock.advance(11.0)
+    new_owner = cb.before_request()  # half-opens, owner=new_owner
+    assert new_owner > old_token
+    assert cb.state == "half_open" and cb._probe_in_flight is True
+    # Every outcome called with the STALE old token must leave the new owner intact.
+    for stale_call in (
+        cb.release_probe,
+        cb.record_success,
+        cb.record_failure,
+        cb.record_indeterminate,
+    ):
+        prev_state = cb.state
+        stale_call(old_token)
+        assert cb.state == prev_state
+    assert cb._probe_in_flight is True
+    # The genuine new owner can still release.
+    cb.release_probe(new_owner)
+    assert cb._probe_in_flight is False
+
+
+@pytest.mark.unit
+def test_record_indeterminate_closed_is_noop():
+    """A mid-HTTP cancellation in CLOSED must NOT inflate the failure count or
+    open the circuit (it is not a KIS connect-failure)."""
+    cb, _clock = _breaker_open_past_cooldown()
+    cb.reset()  # CLOSED, failures=0
+    cb.record_indeterminate(999)  # arbitrary token
+    cb.record_indeterminate(998)
     assert cb.state == "closed"
-    del lease_before
+    assert cb.failure_count == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_closed_mid_http_cancellation_does_not_open_circuit(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """P1: N normal mid-HTTP cancellations (client disconnect / worker shutdown)
+    in CLOSED must never trip the N-strike threshold."""
+    cb = KISCircuitBreaker(
+        now=_FakeClock(1000.0), settings_obj=_BreakerSettings()
+    )  # threshold=2, CLOSED
+    monkeypatch.setattr(
+        "app.services.brokers.kis.base.get_kis_circuit_breaker", lambda: cb
+    )
+
+    gate = _make_gate("redis://127.0.0.1:1/0")
+    client = _UnitDispatchClient(gate)
+    hang = asyncio.Event()
+
+    async def _hanging_http(*a: Any, **k: Any) -> Any:  # type: ignore[override]
+        client.http_calls += 1
+        await hang.wait()
+        return MagicMock(status_code=200, headers={}, json=lambda: {"rt_cd": "0"})
+
+    client._execute_http_request = _hanging_http  # type: ignore[assignment]
+    try:
+        for _ in range(2):  # threshold strikes, all normal cancellations
+            task = asyncio.create_task(
+                client._request_with_rate_limit_with_headers(
+                    "GET",
+                    f"https://{LIVE_HOST}/uapi/quotations/inquire-price",
+                    headers={"appkey": "live-key", "authorization": "Bearer t"},
+                    timeout=5.0,
+                    api_name="inquire_price",
+                    tr_id="FHKST01010100",
+                )
+            )
+            await asyncio.sleep(0.08)  # reach the hanging HTTP (http_started=True)
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+        assert client.http_calls == 2
+        assert cb.state == "closed"  # NOT opened by normal cancellations
+        assert cb.failure_count == 0
+    finally:
+        hang.set()
+        await gate.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_half_open_owner_mid_http_cancel_reopens_and_blocks_next(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Phase 2: a HALF_OPEN probe owner cancelled mid-HTTP re-OPENS, and the next
+    before_request fails fast (KISCircuitOpen) for the cooldown window."""
+    from app.services.brokers.kis.circuit_breaker import KISCircuitOpen
+
+    cb, _clock = _breaker_open_past_cooldown()
+    monkeypatch.setattr(
+        "app.services.brokers.kis.base.get_kis_circuit_breaker", lambda: cb
+    )
+
+    gate = _make_gate("redis://127.0.0.1:1/0")
+    client = _UnitDispatchClient(gate)
+    hang = asyncio.Event()
+
+    async def _hanging_http(*a: Any, **k: Any) -> Any:  # type: ignore[override]
+        client.http_calls += 1
+        await hang.wait()
+        return MagicMock(status_code=200, headers={}, json=lambda: {"rt_cd": "0"})
+
+    client._execute_http_request = _hanging_http  # type: ignore[assignment]
+    try:
+        task = asyncio.create_task(
+            client._request_with_rate_limit_with_headers(
+                "GET",
+                f"https://{LIVE_HOST}/uapi/quotations/inquire-price",
+                headers={"appkey": "live-key", "authorization": "Bearer t"},
+                timeout=5.0,
+                api_name="inquire_price",
+                tr_id="FHKST01010100",
+            )
+        )
+        await asyncio.sleep(0.1)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert client.http_calls == 1
+        assert cb.state == "open"  # owner re-opened (record_indeterminate)
+        with pytest.raises(KISCircuitOpen):
+            cb.before_request()  # next request fails fast within cooldown
+    finally:
+        hang.set()
+        await gate.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_fetch_token_mid_http_cancel_does_not_open_circuit(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Token path: a mid-HTTP cancellation during the OAuth POST must not inflate
+    the CLOSED failure count (same record_indeterminate contract)."""
+    cb = KISCircuitBreaker(
+        now=_FakeClock(1000.0), settings_obj=_BreakerSettings()
+    )  # CLOSED
+    monkeypatch.setattr(
+        "app.services.brokers.kis.base.get_kis_circuit_breaker", lambda: cb
+    )
+
+    gate = _make_gate("redis://127.0.0.1:1/0")
+    client = _UnitDispatchClient(gate)
+    hang = asyncio.Event()
+
+    class _HangClient:
+        async def post(self, *a: Any, **k: Any) -> Any:
+            await hang.wait()
+            return MagicMock()
+
+    client._ensure_client = AsyncMock(return_value=_HangClient())  # type: ignore[assignment]
+    client._kis_url = lambda path: f"https://{LIVE_HOST}{path}"  # type: ignore[assignment]
+    try:
+        for _ in range(2):  # threshold strikes, all normal cancellations
+            task = asyncio.create_task(client._fetch_token())
+            await asyncio.sleep(0.08)  # reach the hanging POST (http_started=True)
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+        assert cb.state == "closed"
+        assert cb.failure_count == 0
+    finally:
+        hang.set()
+        await gate.close()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## ROB-892 — KIS mock account-scope distributed Redis gate

Replaces the process-local `VTSOrderPacer` with a Redis-backed distributed admit gate shared by independent API/MCP/worker PIDs. Every KIS mock REST call — orders **and** reads, domestic/overseas, any TR/path — now shares one conservative credential/account-scoped budget of **one admitted request per second**; contention waits within a bounded deadline. Redis failure/timeout never lets a mutation fall back to local or unthrottled HTTP. Live behavior is unchanged.

### Root cause
The old pacer was (a) only applied to place-order POSTs and (b) process-local (`asyncio.Lock`), so independent API/MCP/worker PIDs could still burst the shared mock credential budget. The `TR_ID|path` sliding-window limiter keys buy/sell separately (8/s each), allowing bursts.

### Algorithm / key / TTL / interval / ordering
- **Authority:** Redis server `TIME` + atomic Lua current-slot claim (`EVAL` every call — no host wall clock, no future reservation, no lock held during sleep or the full HTTP). A claim records the last-admitted server timestamp (token-bucket admit, not a held mutex).
- **Scope key:** `kis_mock:gate:{mock_host_netloc}:{sha256(appkey)[:16]}` — reuses the safe `kis_mock` token-namespace fingerprint pattern. Raw appkey/secret/token/account never appear in keys, logs, or errors.
- **Interval:** `1.0s + 0.05s` safety margin; **TTL** 120s (deterministic cold-start recovery).
- **Bounded deadline:** 10s acquire budget; on expiry → `DistributedGateUnavailable`.
- **Dispatch ordering preserved:** prepare token/client/local limiter → wait for distributed availability → run `pre_send_hook` (freshness) → atomic claim immediately before dispatch → mark dispatched + HTTP (no further unbounded wait). Contention loser reruns freshness on the next claim attempt.
- **Fail-closed:** Redis error/timeout/malformed/deadline raises `DistributedGateUnavailable` **before** any HTTP → mutation HTTP=0, NOT_CREATED, no fallback. Reads cannot bypass during a Redis outage (same quota, same failure path).
- **Live zero-Redis:** the gate is gated by URL netloc (`openapivts...:29443` vs `openapi...:9443`); live dispatch never calls `acquire()`.

### Gating boundary (inventory)
Enforced at the common actual-dispatch boundary `BaseKISClient._dispatch_rate_limited_with_headers` → `_execute_http_request`. The audit confirmed **100% of KIS mock REST data/order dispatch** funnels through this single chain (21 account/order sites + 20 market-data sites via `_request_with_token_retry`). No bypasses in `app/services/brokers/kis/`. `_fetch_token` (`/oauth2/token`) is intentionally **not** gated — separate OAuth endpoint/quota already guarded by its own distributed token lock + the per-process circuit breaker. The sole KIS HTTP bypass (`kis_websocket_internal/approval_keys.py` `/oauth2/Approval` WS bootstrap) is explicitly out of scope for the REST gate (WS path).

### Changed files
- `app/services/brokers/kis/vts_distributed_gate.py` **(new)** — focused gate module (`VTSDistributedGate`, `build_vts_gate_scope_key`, Lua claim, singleton, fail-closed exception).
- `app/services/brokers/kis/base.py` — gate injected between `_ensure_client` and `pre_send_hook`; `_vts_gate_scope(url, headers)` returns `None` for non-mock hosts; `DistributedGateUnavailable` exempted from KIS breaker classification (pre-dispatch Redis failure, not a KIS signal).
- `app/services/brokers/kis/domestic_orders.py`, `overseas_orders.py` — removed redundant `get_vts_order_pacer().acquire()` (single runtime authority = the distributed gate).
- `app/services/brokers/kis/vts_order_pacer.py` — `VTSOrderPacer` retained as a utility with its existing unit tests, docstring marked superseded (no two authorities in the runtime path).
- `tests/brokers/kis/test_vts_distributed_gate.py` **(new)** — 21 tests.

### Real-Redis multiprocessing evidence
Disposable `redis-server` (v8.6.2), `mp.get_context("spawn")`, actual `_execute_http_request` START timestamps (not `acquire()` returns). 3 PIDs (KR buy, KR sell, mock read) sharing one credential scope:
- Adjacent dispatch gaps: **1.052s, 1.051s** (≥ configured 1.05s)
- Each intended dispatch fired exactly once — **0 reposts**
- Distinct credentials/hosts admit in parallel; same credential across TR/path/market/side/read shares one key.

### Proofs
- ✅ live Redis calls = 0 (URL-netloc discriminator; `test_live_host_never_contacts_redis`)
- ✅ real broker calls = 0 (fake HTTP + disposable local Redis only)
- ✅ Redis-failure mutation HTTP = 0 (`test_redis_failure_mutation_is_http_zero`, `test_redis_failure_read_also_http_zero`)
- ✅ order reposts = 0 (EGW00201/429/timeout → exactly one POST; `test_egw00201_still_exactly_one_post`)
- ✅ secrets absent (key is sha256[:16] fingerprint; `test_scope_key_is_secret_free`)
- ✅ ROB-645 no-double-submit preserved; reads reacquire per retry; cancellation while waiting → HTTP=0

### Verification
\`\`\`
uv run pytest tests/brokers/kis/test_vts_order_pacer.py tests/test_kis_base_rate_limit.py \
  tests/test_kis_domestic_orders_retry.py tests/test_kis_overseas_orders_retry.py \
  tests/test_kis_mock_cancel_modify.py tests/test_kis_order_no_double_submit.py \
  tests/test_kis_request_error_retry_policy.py tests/brokers/kis/test_vts_distributed_gate.py -q
→ 76 passed
\`\`\`
- Broader KIS regression: **406 passed**
- `uv run ruff check` / `ruff format --check`: clean
- `uv run ty check app/ --error-on-warning`: All checks passed
- `git diff --check`: clean

### Residual risks / rollback
- Reverting this commit restores the prior process-local pacer behavior one-for-one (the gate is additive at the dispatch boundary; pacer calls were removed but the class is retained).
- The gate reuses the existing Redis (`settings.get_redis_url()`); a Redis outage now fail-closes mock dispatch (intended — conservative). Mock-only impact; live is unaffected.
- OAuth token issuance remains ungated by design (separate endpoint/quota).

No merge, no deploy, no force-push, no Linear mutation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added distributed request admission control for mock trading traffic.
  * Coordinated shared rate limiting across processes/hosts/credentials.
  * Revalidated request freshness while waiting for admission.
* **Bug Fixes**
  * Removed mock-mode local pacing for domestic and overseas orders.
  * Improved circuit-breaker handling so “pre-send” admission failures don’t deadlock HALF_OPEN state.
* **Tests**
  * Added extensive coverage for timing, contention, retries, cancellation, fail-closed behavior, and multi-process dispatch using a real Redis-backed setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->