### PR TITLE
fix(ROB-901): dedup KIS domestic open orders by order_no

### DIFF
--- a/app/services/current_orders_service.py
+++ b/app/services/current_orders_service.py
@@ -492,11 +492,23 @@ class CurrentOrdersService:
                 count=0,
                 message=type(exc).__name__,
             )
-        rows = [
-            normalize_kis_order(row, market="kr", exchange="KRX")
-            for row in raw or []
-            if isinstance(row, dict)
-        ]
+        # KIS domestic pending-order inquiry (TTTC8036R) can surface the same
+        # order_no more than once — pagination is known to repeat rows and a
+        # NXT/SOR-routed order shows up under both KRX and NXT venues. Dedup by
+        # order_no the way the US path (_collect_kis_us) already does so the row
+        # list and header count reflect distinct orders. order_no is unique per
+        # order in this TR, so this never collapses legitimate partial-fill rows.
+        rows: list[OpenOrderRow] = []
+        seen: set[str] = set()
+        for row in raw or []:
+            if not isinstance(row, dict):
+                continue
+            order_no = _first_str(row, ("ord_no", "odno", "order_id"))
+            if order_no and order_no in seen:
+                continue
+            if order_no:
+                seen.add(order_no)
+            rows.append(normalize_kis_order(row, market="kr", exchange="KRX"))
         return rows, _source(
             broker="kis", market="kr", status="ok", fetched_at=now, count=len(rows)
         )

--- a/tests/test_current_orders_service.py
+++ b/tests/test_current_orders_service.py
@@ -956,7 +956,5 @@ async def test_current_orders_kis_kr_dedupes_same_order_no() -> None:
 
     assert response.count == 1
     assert [item.order_no for item in response.items] == ["00156551"]
-    kis_kr = next(
-        s for s in response.sources if s.broker == "kis" and s.market == "kr"
-    )
+    kis_kr = next(s for s in response.sources if s.broker == "kis" and s.market == "kr")
     assert kis_kr.count == 1

--- a/tests/test_current_orders_service.py
+++ b/tests/test_current_orders_service.py
@@ -916,3 +916,47 @@ async def test_current_orders_name_lookup_failure_fails_open(monkeypatch) -> Non
     assert response.count == 1
     assert response.items[0].symbol == "005930"
     assert response.items[0].symbol_name is None
+
+
+@pytest.mark.asyncio
+async def test_current_orders_kis_kr_dedupes_same_order_no() -> None:
+    """ROB-901: KIS domestic pending inquiry surfaces the same order_no twice
+    (KRX + NXT/SOR venue rows, or repeated pagination). It must collapse to one
+    row and the source count must reflect distinct orders, not the raw rows."""
+    from app.services.current_orders_service import CurrentOrdersService
+
+    class _FakeKIS:
+        async def inquire_korea_orders(self, is_mock: bool = False):
+            # 하나금융지주 sell 1 @137,000 returned twice under the same order_no.
+            row = {
+                "ord_no": "00156551",
+                "pdno": "086790",
+                "prdt_name": "하나금융지주",
+                "sll_buy_dvsn_cd": "01",
+                "ord_qty": "1",
+                "ord_unpr": "137000",
+                "rmn_qty": "1",
+            }
+            return [dict(row), dict(row)]
+
+        async def inquire_overseas_orders(
+            self, exchange_code: str = "NASD", is_mock: bool = False
+        ):
+            return []
+
+    service = CurrentOrdersService(
+        kis_client_factory=lambda: _FakeKIS(),
+        upbit_client=None,
+        toss_client_factory=None,
+        db="db-session",  # type: ignore[arg-type]
+        clock=lambda: dt.datetime(2026, 7, 16, 0, 0, tzinfo=dt.UTC),
+    )
+
+    response = await service.list_open_orders(market="kr")
+
+    assert response.count == 1
+    assert [item.order_no for item in response.items] == ["00156551"]
+    kis_kr = next(
+        s for s in response.sources if s.broker == "kis" and s.market == "kr"
+    )
+    assert kis_kr.count == 1


### PR DESCRIPTION
## 증상 (2026-07-16 관찰)

`/invest/my?tab=currentOrders`에서 하나금융지주(086790) 매도 1주 @137,000이 동일 order_id(`00156551`)로 **두 줄 중복 표시**. 헤더 집계도 "KIS/국내 2"로 중복 카운트.

## 근본 원인

KIS 국내 정정취소가능주문 조회(TTTC8036R)는 같은 `order_no`를 여러 행으로 반환할 수 있음:
- NXT/SOR 라우팅 주문이 KRX·NXT 두 venue 행으로 표면화 (조회에 거래소 필터 없음)
- 페이지네이션이 동일 행을 재반환 (`inquire_daily_order_domestic` docstring에 "실측: 모든 행 2회"로 명시)

US 경로(`_collect_kis_us`)와 fill-evidence 경로(`_dedupe_rows`)에는 order_no dedup이 있으나 **KR 수집 경로(`_collect_kis_kr`)에만 누락**되어 있었음. 중복 행이 그대로 UI·헤더 카운트로 통과.

## 수정

- `_collect_kis_kr`에 US 경로와 동일한 `seen`-set `order_no` dedup 적용
- 이 TR에서 `order_no`는 주문당 유일 → 부분체결 등 정당한 다중 행에는 영향 없음 (주석에 근거 명시)
- source `count`(헤더 "KIS/국내 N")도 distinct 기준으로 집계
- 프론트(`CurrentOrdersPanel.tsx`)는 백엔드 dedup만으로 자동 해결 (duplicate React key 경고도 해소), 별도 변경 없음

## 테스트

- 회귀 테스트 추가: 하나금융지주 086790 매도 1주 @137,000, `order_no 00156551` 2회 반환 → 1행 + `count==1` + source count 1 검증
- `tests/test_current_orders_service.py` + `tests/routers/test_invest_open_orders_router.py` 25개 통과, `ruff check` 통과

## 남은 검증

테스트는 fake KIS 기반 — 배포 전 실 KIS 계좌로 이 탭을 한 번 열어 "KIS/국내 1"로 정상 표시되는지 수동 확인 권장. (이슈 메모대로 넥스트증권 미팅 후 배포)

🤖 Generated with [Claude Code](https://claude.com/claude-code)