### PR TITLE
perf(ROB-902): exempt KIS-account KR holdings from get_holdings itemchartprice N+1

### DIFF
--- a/app/mcp_server/tooling/portfolio_holdings.py
+++ b/app/mcp_server/tooling/portfolio_holdings.py
@@ -620,11 +620,25 @@ async def _collect_toss_api_positions(
     return positions, snapshot.errors, True
 
 
-def _has_valid_kis_equity_us_snapshot(position: dict[str, Any]) -> bool:
+def _has_valid_kis_equity_snapshot(position: dict[str, Any]) -> bool:
+    """KIS-account equity (KR or US) whose broker balance snapshot is complete.
+
+    When True, get_holdings keeps the KIS-provided snapshot values
+    (``current_price`` / ``evaluation_amount`` / ``profit_loss`` /
+    ``profit_rate``) and skips the per-symbol live current-price refresh.
+
+    PR #288 (ROB-365) established this for ``equity_us`` — the Yahoo/KIS live
+    refresh is a *fallback*, not the default for a valid KIS US snapshot.
+    ROB-902 extends the identical rule to ``equity_kr``: the KIS domestic
+    balance (``fetch_my_stocks``) already returns 현재가(``prpr``) / 평가금액 /
+    평가손익 for every holding in ONE bulk call, so the per-symbol
+    ``inquire-daily-itemchartprice`` refresh was a redundant N+1 (~41 KR HTTP
+    calls per get_holdings invocation).
+    """
     if position.get("source") != "kis_api":
         return False
 
-    if str(position.get("instrument_type") or "") != "equity_us":
+    if str(position.get("instrument_type") or "") not in {"equity_kr", "equity_us"}:
         return False
 
     current_price = _to_optional_float(position.get("current_price"))
@@ -644,7 +658,7 @@ def _has_valid_kis_equity_us_snapshot(position: dict[str, Any]) -> bool:
 
 def _position_needs_current_price_refresh(position: dict[str, Any]) -> bool:
     instrument_type = str(position.get("instrument_type") or "")
-    if _has_valid_kis_equity_us_snapshot(position):
+    if _has_valid_kis_equity_snapshot(position):
         return False
 
     return instrument_type in {"equity_kr", "equity_us", "crypto"}

--- a/docs/plans/ROB-902-get-holdings-kr-itemchartprice-n1.md
+++ b/docs/plans/ROB-902-get-holdings-kr-itemchartprice-n1.md
@@ -1,0 +1,90 @@
+# ROB-902 — get_holdings KR itemchartprice N+1 (ROB-830 잔여)
+
+## 요약 (근본원인 한 줄)
+
+get_holdings 안 KR 현재가 refresh 가 **KIS 국내 잔고 API(`fetch_my_stocks`)가 이미
+벌크로 내려주는 스냅샷(prpr/평가금액/평가손익)을 무시하고 보유 종목마다 개별
+`inquire-daily-itemchartprice` 를 다시 부른다.** US 는 PR #288(ROB-365)에서
+"KIS 스냅샷이 유효하면 live refresh 를 건너뛴다"는 규칙을 얻었지만 **KR 은 그 규칙
+대상에서 빠져 있어(#288 이 US-scoped)** 매 호출마다 ~41 KR 종목 × 1 HTTP = N+1 이
+남았다. → 가설 **3 (경로 미적용/콜사이트 배선)** 확정. 가설 1(캐시)·2(조건)는 반증.
+
+## 판별 근거 (조사 우선)
+
+### 콜사이트 특정
+- get_holdings 의 KR 현재가는 `_fetch_price_map_for_positions.fetch_equity_price`
+  (`app/mcp_server/tooling/portfolio_holdings.py:747`) 에서 결정된다.
+- ROB-830 이 배선한 DB-first 는 `cache_first_kr(symbol, 2)`
+  (`portfolio_holdings.py:749`). **miss 시 fallback** 이 `_fetch_quote_equity_kr`
+  (`market_data_quotes.py:688`) → `kis.inquire_daily_itemchartprice(n=2)`
+  (`market_data_quotes.py:691`). 이게 Sentry 가 잡은 132/24h 콜의 실제 발원지.
+
+### 가설 1 (DB miss 상시 → 짧은 TTL 캐시가 답) — **기각**
+- Sentry 24h 실측: `transaction:"tools/call get_holdings"` itemchartprice **123 spans**,
+  그러나 `count_unique(trace) = 3`. 즉 **get_holdings 는 24h 에 3번 호출**되었고
+  호출당 **~41 KR 종목**을 개별 fetch. (issue 의 "4 tool-call × ~33" 과 동일 패턴.)
+- 콜 시각(모두 KST 장중, 15:35 cutoff 이전):
+  - `2026-07-16T02:46 UTC = 11:46 KST` (~50 spans, 단일 호출)
+  - `2026-07-16T00:44 UTC = 09:44 KST` (~10 spans)
+- 장중이라 `cache_first_kr` 의 `kr_daily_bar_may_be_forming` 게이트
+  (`read_service.py:272`) 가 **설계상 None 을 반환** → DB-first 우회. 맞다.
+- **그러나** 병목은 "호출당 41개 고유 종목 fan-out" 이다. 3번의 호출은 2h+ 간격
+  으로 흩어져 있고 각 호출 내부는 **고유 종목(중복 없음, `equity_pairs` 는 set
+  dedup, `portfolio_holdings.py:817`)**. → **짧은 TTL 캐시는 이 접근 패턴을 못
+  줄인다** (cold-miss on unique symbols within one call; 호출 간 간격 > any 짧은 TTL).
+  캐시는 무효.
+
+### 가설 2 (조건 불일치) — **기각**
+- `cache_first_kr` 는 심볼/venue/count 조건 불일치가 아니라 **의도된 장중 게이트**로
+  None 을 낸다. 조건 교정으로 장중 오늘 현재가를 DB 에서 낼 수는 없다(오늘 봉 미적재).
+
+### 가설 3 (경로 미적용) — **확정**
+- KIS 국내 잔고 수집(`_collect_kis_positions`, `portfolio_holdings.py:352`)는 보유
+  종목마다 이미 완전한 스냅샷을 벌크로 담는다:
+  `current_price=prpr`(367), `evaluation_amount=evlu_amt`(369),
+  `profit_loss=evlu_pfls_amt`(370), `profit_rate=evlu_pfls_rt`(371).
+- US 는 동일한 4필드 스냅샷(`now_pric2`/`ovrs_stck_evlu_amt`/...)을 담고,
+  `_has_valid_kis_equity_us_snapshot`(623) 로 **유효하면 refresh 를 건너뛴다**
+  (`_position_needs_current_price_refresh`, 647). PR #288 README:
+  *"KIS US holdings keep KIS-provided snapshot values ... Yahoo is a fallback
+  refresh path, not the default for valid KIS US holdings."*
+- **KR 은 동일 스냅샷을 갖고도 이 예외에서 빠져 있다** → 매번 itemchartprice N+1.
+
+## 수정 (최소·원칙적)
+
+US 전용 스냅샷 예외를 **KR 로 확장**한다 (PR #288 이 세운 규칙을 KR 에도 적용):
+
+- `_has_valid_kis_equity_us_snapshot` → `_has_valid_kis_equity_snapshot` 로 일반화,
+  `equity_kr` **또는** `equity_us` 의 KIS-account(`source == "kis_api"`) 포지션에서
+  스냅샷 4필드가 수치상 유효(`current_price>0`, `evaluation_amount>0`,
+  `profit_loss`/`profit_rate` 파싱가능)하면 True.
+- `_position_needs_current_price_refresh` 가 이를 호출 → 유효 KR KIS 스냅샷은
+  `equity_pairs` 에서 제외 → **cache_first_kr / itemchartprice 를 아예 안 부른다.**
+
+효과: KIS-account KR 보유의 itemchartprice 123/24h → **0** (Toss/manual/screenshot
+등 스냅샷 없는 KR 만 기존 DB-first→KIS fallback 유지). issue 목표 "132 → 수 콜" 달성.
+
+## 정확성 불변식 (값 동일) — 편차 명시
+
+- **스냅샷 없는 KR(Toss/manual/source≠kis_api)**: 경로 **완전 불변**. 여전히
+  `cache_first_kr`(DB-first, ROB-830) → miss 시 `_fetch_quote_equity_kr`. 값 동일.
+- **KIS-account KR (스냅샷 유효)**: 표시 `current_price` 소스가
+  itemchartprice-close → **잔고 API prpr** 로 바뀐다. 둘 다 KIS 실시간 현재가(같은
+  브로커, 같은 순간 ±틱). 이는 **US 가 이미 #288 이후 채택한 동작과 동일한 정렬**
+  이며, 잔고 스냅샷(평가금액/평가손익 포함)이 더 authoritative. 엄밀 byte-동일은
+  아니나(issue "같은 데이터, 소스만" 의 초과), 장중 오늘 현재가는 본질적으로 live
+  per-symbol 소스라 캐시/DB 로는 값 보존+콜감축을 동시 달성 불가 → **#288 설계
+  의도에 부합하는 정렬을 선택**. profit_loss/profit_rate/evaluation_amount 도 잔고
+  스냅샷 값을 그대로 유지(현재는 itemchartprice-close 로 재계산). 반환 스키마 불변.
+
+## 회귀/테스트 (TDD)
+
+- RED→GREEN: KIS-account KR 유효 스냅샷 → `_fetch_price_map_for_positions` 가
+  cache_first_kr/`_fetch_quote_equity_kr` 를 **0회** 호출(카운터 증명).
+- 스냅샷 미유효/manual KR → 기존대로 refresh(기존 테스트 green 유지).
+- US 스냅샷 skip 계속 유효(기존 테스트 green 유지).
+- `_has_valid_kis_equity_snapshot` 단위 표(KR true/false, US true).
+
+## 안전 경계
+
+read/enrichment 전용. 주문/mutation 무변경. migration 0.

--- a/tests/mcp_server/tooling/test_get_holdings_n1_residuals.py
+++ b/tests/mcp_server/tooling/test_get_holdings_n1_residuals.py
@@ -234,3 +234,73 @@ async def test_kr_price_enrichment_db_miss_falls_back_to_legacy_kis_result(
 
     assert actual == ({("equity_kr", "005930"): 62_000.0}, [], {})
     kis_quote.assert_awaited_once_with("005930")
+
+
+def _kr_kis_snapshot_position(symbol: str = "005930") -> dict[str, object]:
+    """A KIS-account KR holding whose balance snapshot is numerically complete.
+
+    ``_collect_kis_positions`` fills these four fields in one bulk balance call
+    (``prpr`` / ``evlu_amt`` / ``evlu_pfls_amt`` / ``evlu_pfls_rt``). ROB-902:
+    such a holding must NOT trigger the per-symbol itemchartprice refresh —
+    mirroring the pre-existing US snapshot exemption (PR #288 / ROB-365).
+    """
+    return {
+        "instrument_type": "equity_kr",
+        "symbol": symbol,
+        "source": "kis_api",
+        "current_price": 62_000.0,
+        "evaluation_amount": 620_000.0,
+        "profit_loss": 20_000.0,
+        "profit_rate": 3.33,
+    }
+
+
+@pytest.mark.asyncio
+async def test_kr_kis_snapshot_skips_price_refresh_and_makes_zero_kis_http(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """ROB-902: valid KIS-account KR snapshot fans out 0 DB reads and 0 KIS HTTP."""
+    db_read = AsyncMock(return_value=None)
+    kis_quote = AsyncMock(return_value={"price": 61_000.0})
+    monkeypatch.setattr(portfolio_holdings, "cache_first_kr", db_read)
+    monkeypatch.setattr(portfolio_holdings, "_fetch_quote_equity_kr", kis_quote)
+
+    actual = await portfolio_holdings._fetch_price_map_for_positions(
+        [_kr_kis_snapshot_position()]
+    )
+
+    # No equity pair enqueued -> empty price map, no errors.
+    assert actual == ({}, [], {})
+    db_read.assert_not_awaited()
+    kis_quote.assert_not_awaited()
+
+
+def test_kr_kis_snapshot_is_exempt_from_refresh() -> None:
+    """ROB-902: the refresh predicate exempts a complete KIS-account KR snapshot."""
+    assert (
+        portfolio_holdings._position_needs_current_price_refresh(
+            _kr_kis_snapshot_position()
+        )
+        is False
+    )
+
+
+def test_kr_kis_incomplete_snapshot_still_refreshes() -> None:
+    """A KIS-account KR holding with a zero/absent price still needs a refresh."""
+    incomplete = _kr_kis_snapshot_position()
+    incomplete["current_price"] = None
+    assert portfolio_holdings._position_needs_current_price_refresh(incomplete) is True
+
+
+def test_kr_non_kis_snapshot_still_refreshes() -> None:
+    """A manual/Toss KR holding (source != kis_api) is never exempt."""
+    manual = _kr_kis_snapshot_position()
+    manual["source"] = "manual"
+    assert portfolio_holdings._position_needs_current_price_refresh(manual) is True
+
+
+def test_us_kis_snapshot_remains_exempt() -> None:
+    """Regression: the pre-existing US snapshot exemption is preserved."""
+    us = _kr_kis_snapshot_position("AAPL")
+    us["instrument_type"] = "equity_us"
+    assert portfolio_holdings._position_needs_current_price_refresh(us) is False

--- a/tests/test_mcp_portfolio_tools.py
+++ b/tests/test_mcp_portfolio_tools.py
@@ -952,10 +952,15 @@ async def test_get_holdings_groups_by_account_and_calculates_pnl(monkeypatch):
     kis_kr = next(
         item for item in kis_account["positions"] if item["symbol"] == "005930"
     )
-    assert kis_kr["current_price"] == pytest.approx(71000.0)
-    assert kis_kr["evaluation_amount"] == pytest.approx(142000.0)
-    assert kis_kr["profit_loss"] == pytest.approx(2000.0)
-    assert kis_kr["profit_rate"] == pytest.approx(1.43)
+    # ROB-902: a KIS-account KR holding keeps its bulk balance snapshot
+    # (prpr / evlu_amt / evlu_pfls_amt / evlu_pfls_rt) instead of firing the
+    # per-symbol itemchartprice refresh — mirroring the US snapshot exemption
+    # asserted below. The 71000 KR refresh mock only serves the manual/Toss
+    # 005930 holding (source != kis_api), not this KIS-account one.
+    assert kis_kr["current_price"] == pytest.approx(70500.0)
+    assert kis_kr["evaluation_amount"] == pytest.approx(141000.0)
+    assert kis_kr["profit_loss"] == pytest.approx(1000.0)
+    assert kis_kr["profit_rate"] == pytest.approx(0.71)
 
     kis_us = next(item for item in kis_account["positions"] if item["symbol"] == "AAPL")
     assert kis_us["current_price"] == pytest.approx(210.0)
@@ -3314,7 +3319,7 @@ async def test_get_available_capital_paper(monkeypatch):
 def _us_refresh_position(symbol: str = "AAPL") -> dict:
     """A US position whose KIS snapshot is incomplete, so the refresh path fires.
 
-    source != "kis_api" makes _has_valid_kis_equity_us_snapshot() return False.
+    source != "kis_api" makes _has_valid_kis_equity_snapshot() return False.
     """
     return {
         "instrument_type": "equity_us",


### PR DESCRIPTION
## 근본원인 (issue 가설 3 확정)

get_holdings 는 KR 보유 종목마다 개별 `inquire-daily-itemchartprice`(KIS HTTP)로
현재가를 refresh 한다. 그러나 **KIS 국내 잔고 API(`fetch_my_stocks`)가 이미 벌크로
현재가(`prpr`)/평가금액(`evlu_amt`)/평가손익(`evlu_pfls_amt`,`evlu_pfls_rt`)을
내려준다** (`portfolio_holdings.py:352-372`).

PR #288(ROB-365)이 "KIS 잔고 스냅샷이 유효하면 live refresh 를 건너뛴다"는 규칙을
세웠지만 **`equity_us` 에만** 적용(`_has_valid_kis_equity_us_snapshot`, line 623).
KR 은 동일한 4필드 스냅샷을 갖고도 예외에서 빠져 있어 매 호출 N+1 이 남았다.

### 코드/trace 근거
- 콜사이트: `_fetch_price_map_for_positions.fetch_equity_price`
  (`portfolio_holdings.py:747`) → miss fallback `_fetch_quote_equity_kr`
  (`market_data_quotes.py:688,691`).
- Sentry 24h: `transaction:"tools/call get_holdings"` itemchartprice **123 spans**,
  `count_unique(trace) = 3` → **호출 3회 × ~41 종목 = 호출 내부 fan-out** 이 병목.
- 관측 콜 시각: `00:44 UTC = 09:44 KST`, `02:46 UTC = 11:46 KST` — 둘 다 KRX 장중
  (15:35 cutoff 이전) → `cache_first_kr` 의 `kr_daily_bar_may_be_forming` 게이트가
  **설계상 None** 반환(DB-first 우회). 그리고 호출 간 2h+ 간격 + 호출 내부 고유
  종목이라 **짧은 TTL 캐시로도 못 줄인다** → 가설 1(캐시)·2(조건) 기각.

## 수정

`_has_valid_kis_equity_us_snapshot` → `_has_valid_kis_equity_snapshot` 로 일반화하여
`equity_kr` **또는** `equity_us` KIS-account 포지션의 완전한 스냅샷을 refresh 에서
제외. KIS-account KR 보유는 이제 itemchartprice 를 **0회** 호출.

- 변경 파일:
  - `app/mcp_server/tooling/portfolio_holdings.py:623` — 헬퍼 일반화(KR+US)
  - `app/mcp_server/tooling/portfolio_holdings.py:661` — 호출부 이름 갱신
  - `docs/plans/ROB-902-...md` — 조사·근거 기록
  - 테스트 2건

**효과**: KIS-account KR itemchartprice **123/24h → 0**. (Toss/manual/screenshot KR
스냅샷 없는 보유만 기존 ROB-830 DB-first→KIS fallback 유지.)

## 정확성 불변식

- **스냅샷 없는 KR(source≠kis_api / 불완전)**: 경로·값 **완전 불변**
  (`cache_first_kr` DB-first → miss 시 `_fetch_quote_equity_kr`).
- **KIS-account KR(스냅샷 유효)**: 표시 `current_price` 소스가 itemchartprice-close
  → 잔고 `prpr` 로 변경(둘 다 KIS 실시간 현재가). 평가금액/평가손익도 잔고 스냅샷
  값 유지. **US 가 #288 이후 이미 채택한 동작과 동일한 정렬** — 잔고 스냅샷이 더
  authoritative. 장중 오늘 현재가는 본질적으로 live per-symbol 소스라 값보존+콜감축
  동시 달성 불가 → #288 설계의도에 맞춘 정렬. 반환 스키마 불변.

## 테스트 증거

```
tests/mcp_server/tooling/test_get_holdings_n1_residuals.py: 12 passed
tests/test_mcp_portfolio_tools.py + n1_residuals + daily_candles: 124 passed
tests/test_portfolio_overview_service.py + test_kis_holdings_service.py + test_mcp_quotes_tools.py: 88 passed
```

TDD: RED (KR 스냅샷 exemption 2건 실패: refresh 예측자 + zero-KIS-HTTP) → GREEN.
Regression: 불완전/manual KR 은 여전히 refresh, US 은 여전히 exempt.

`make lint`: ruff check ✅ · ruff format --check ✅ · ty ✅

## migration 카운트

**0** (스키마 변경 없음).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
