### PR TITLE
perf(ROB-903): bound KIS order-history display pagination (dedupe-stop + drop redundant inter-page sleep)

### DIFF
--- a/app/mcp_server/tooling/orders_history.py
+++ b/app/mcp_server/tooling/orders_history.py
@@ -225,6 +225,12 @@ async def _fetch_kr_orders(
             stock_code=normalized_symbol,
             side="00",
             is_mock=is_mock,
+            # ROB-903: display-only fast pagination. rate limiter paces requests
+            # (drop the redundant inter-page sleep) and halt on the KIS
+            # duplicate-cursor runaway. Reconcile/fill-evidence paths keep the
+            # broker defaults (exhaustive, 0.1s spacing) — untouched.
+            inter_page_delay=0.0,
+            stop_when_no_new_rows=True,
         )
         fetched.extend([_normalize_kis_domestic_order(o) for o in hist_ops])
 
@@ -295,6 +301,10 @@ async def _fetch_us_orders(
             exchange_code=ex,
             side="00",
             is_mock=is_mock,
+            # ROB-903: display-only fast pagination (see _fetch_kr_orders).
+            # Reconcile/fill-evidence paths keep the broker defaults.
+            inter_page_delay=0.0,
+            stop_when_no_new_rows=True,
         )
         fetched.extend([_normalize_kis_overseas_order(o) for o in hist_ops])
 

--- a/app/services/brokers/kis/client.py
+++ b/app/services/brokers/kis/client.py
@@ -430,9 +430,19 @@ class KISClient(BaseKISClient):
         order_number: str = "",
         is_mock: bool = False,
         max_pages: int = 100,
+        inter_page_delay: float = 0.1,
+        stop_when_no_new_rows: bool = False,
     ) -> list[dict[str, Any]]:
         return await self._domestic_orders.inquire_daily_order_domestic(
-            start_date, end_date, stock_code, side, order_number, is_mock, max_pages
+            start_date,
+            end_date,
+            stock_code,
+            side,
+            order_number,
+            is_mock,
+            max_pages,
+            inter_page_delay=inter_page_delay,
+            stop_when_no_new_rows=stop_when_no_new_rows,
         )
 
     async def modify_korea_order(
@@ -533,6 +543,8 @@ class KISClient(BaseKISClient):
         order_number: str = "",
         is_mock: bool = False,
         max_pages: int = 100,
+        inter_page_delay: float = 0.1,
+        stop_when_no_new_rows: bool = False,
     ) -> list[dict[str, Any]]:
         return await self._overseas_orders.inquire_daily_order_overseas(
             start_date,
@@ -543,6 +555,8 @@ class KISClient(BaseKISClient):
             order_number,
             is_mock,
             max_pages,
+            inter_page_delay=inter_page_delay,
+            stop_when_no_new_rows=stop_when_no_new_rows,
         )
 
     async def modify_overseas_order(

--- a/app/services/brokers/kis/domestic_orders.py
+++ b/app/services/brokers/kis/domestic_orders.py
@@ -24,6 +24,18 @@ if TYPE_CHECKING:
 _MAX_TOKEN_REFRESH_RESUBMITS = 1
 
 
+def _domestic_order_key(order: dict[str, Any]) -> str | None:
+    """Identity key for a daily-order row (ROB-903 dedupe-aware early stop).
+
+    KIS re-emits the same execution row across continuation pages; the order
+    number (odno) uniquely identifies a row. Returns ``None`` when absent so
+    callers fall back to exhaustive pagination.
+    """
+    odno = order.get("odno") or order.get("ODNO")
+    key = str(odno).strip() if odno is not None else ""
+    return key or None
+
+
 class DomesticOrderClient:
     """Client for KIS domestic (Korean) stock order operations.
 
@@ -615,6 +627,8 @@ class DomesticOrderClient:
         order_number: str = "",
         is_mock: bool = False,
         max_pages: int = 100,
+        inter_page_delay: float = 0.1,
+        stop_when_no_new_rows: bool = False,
     ) -> list[dict]:
         """
         국내주식 일별 체결조회 (주문 히스토리)
@@ -627,6 +641,13 @@ class DomesticOrderClient:
             order_number: 주문번호 (특정 주문만 조회 시)
             is_mock: True면 모의투자, False면 실전투자
             max_pages: 최대 조회 페이지 수
+            inter_page_delay: 연속조회 페이지 사이 sleep(초). KIS 19 req/s rate
+                limiter가 이미 페이싱하므로 이중 스로틀 — 표시 경로는 0.0을 넘긴다
+                (ROB-903). reconcile/fill-evidence 경로는 기본 0.1 유지.
+            stop_when_no_new_rows: True면 non-empty 페이지가 새 주문행(odno)을 더하지
+                못하는 순간 중단(KIS 중복행 연속조회 runaway 방지). 이미 모든 고유 행을
+                수집한 시점이라 증거 손실 없음. 기본 False(현행 exhaustive) — reconcile
+                경로는 기본값 유지.
 
         Returns:
             체결 주문 목록 (list of dict)
@@ -676,6 +697,7 @@ class DomesticOrderClient:
         )
 
         all_orders = []
+        seen_order_keys: set[str] = set()
         ctx_area_fk100 = ""
         ctx_area_nk100 = ""
         tr_cont = ""
@@ -763,6 +785,18 @@ class DomesticOrderClient:
                 logging.info(f"페이지 {page}에서 더 이상 주문이 없음")
                 break
 
+            # ROB-903: display path halts once a page adds no new order rows
+            # (KIS duplicate-cursor runaway). All unique rows already collected →
+            # no fill evidence lost. Reconcile keeps the default (exhaustive).
+            if stop_when_no_new_rows:
+                page_keys = {
+                    key for o in orders if (key := _domestic_order_key(o)) is not None
+                }
+                if page_keys and page_keys <= seen_order_keys:
+                    logging.info("연속조회 새 주문행 없음 — 조기 종료(display)")
+                    break
+                seen_order_keys |= page_keys
+
             all_orders.extend(orders)
             logging.info(
                 f"페이지 {page}: {len(orders)}건 조회 (누적: {len(all_orders)}건)"
@@ -783,7 +817,8 @@ class DomesticOrderClient:
             if page > page_limit:
                 truncated = True
                 break
-            await asyncio.sleep(0.1)
+            if inter_page_delay > 0:
+                await asyncio.sleep(inter_page_delay)
 
         if truncated:
             raise RuntimeError(

--- a/app/services/brokers/kis/overseas_orders.py
+++ b/app/services/brokers/kis/overseas_orders.py
@@ -45,6 +45,18 @@ def _is_token_expiry(js: dict[str, Any]) -> bool:
     return js.get("msg_cd") in ["EGW00123", "EGW00121"]
 
 
+def _overseas_order_key(order: dict[str, Any]) -> str | None:
+    """Identity key for a daily-order row (ROB-903 dedupe-aware early stop).
+
+    KIS may re-emit the same execution row across continuation pages; the order
+    number (odno) uniquely identifies a row. Returns ``None`` when no order
+    number is present so callers fall back to exhaustive pagination.
+    """
+    odno = order.get("odno") or order.get("ODNO")
+    key = str(odno).strip() if odno is not None else ""
+    return key or None
+
+
 def _normalize_kis_exchange_code(code: str) -> str:
     """Normalize exchange code to KIS format.
 
@@ -619,6 +631,8 @@ class OverseasOrderClient:
         order_number: str = "",
         is_mock: bool = False,
         max_pages: int = 100,
+        inter_page_delay: float = 0.1,
+        stop_when_no_new_rows: bool = False,
     ) -> list[dict]:
         """
         해외주식 일별 체결조회 (주문 히스토리)
@@ -632,6 +646,15 @@ class OverseasOrderClient:
             order_number: 주문번호 (해외주식은 미지원으로 무시됨)
             is_mock: True면 모의투자, False면 실전투자
             max_pages: 최대 조회 페이지 수
+            inter_page_delay: 연속조회 페이지 사이 sleep(초). KIS는 이미 19 req/s
+                sliding-window rate limiter로 페이싱되므로 이 sleep은 이중 스로틀.
+                기본 0.1(현행 유지) — 표시(display) 경로는 0.0으로 넘겨 rate limiter에만
+                의존한다(ROB-903). reconcile/fill-evidence 경로는 기본값 유지.
+            stop_when_no_new_rows: True면 non-empty 페이지가 새 주문행(odno 기준)을 하나도
+                더하지 못하는 순간 중단한다. KIS는 연속조회 커서(nk200)가 계속 전진해도
+                동일 행을 중복 반환하는 경우가 있어(runaway 100페이지) 표시 경로 비용을
+                증폭시킨다. 이 시점에는 이미 모든 고유 행을 수집했으므로 증거 손실이 없다.
+                기본 False(현행 exhaustive pagination 유지) — reconcile 경로는 기본값 유지.
 
         Returns:
             체결 주문 목록 (list of dict)
@@ -657,6 +680,7 @@ class OverseasOrderClient:
         )
 
         all_orders = []
+        seen_order_keys: set[str] = set()
         ctx_area_fk200 = ""
         ctx_area_nk200 = ""
         tr_cont = ""
@@ -754,6 +778,20 @@ class OverseasOrderClient:
                 logging.info(f"페이지 {page}에서 더 이상 주문이 없음")
                 break
 
+            # ROB-903: on the display path, halt once a page contributes no new
+            # order rows (KIS re-emits duplicate rows across continuation pages
+            # with an ever-advancing cursor). Every unique row is already
+            # collected, so this loses no fill evidence. Reconcile keeps the
+            # default (stop_when_no_new_rows=False) → exhaustive pagination.
+            if stop_when_no_new_rows:
+                page_keys = {
+                    key for o in orders if (key := _overseas_order_key(o)) is not None
+                }
+                if page_keys and page_keys <= seen_order_keys:
+                    logging.info("연속조회 새 주문행 없음 — 조기 종료(display)")
+                    break
+                seen_order_keys |= page_keys
+
             all_orders.extend(orders)
             logging.info(
                 f"페이지 {page}: {len(orders)}건 조회 (누적: {len(all_orders)}건)"
@@ -774,7 +812,8 @@ class OverseasOrderClient:
             if page > page_limit:
                 truncated = True
                 break
-            await asyncio.sleep(0.1)
+            if inter_page_delay > 0:
+                await asyncio.sleep(inter_page_delay)
 
         if truncated:
             raise RuntimeError(

--- a/tests/test_kis_order_history_pagination_rob903.py
+++ b/tests/test_kis_order_history_pagination_rob903.py
@@ -1,0 +1,274 @@
+"""ROB-903: display-path pagination cost reduction for KIS order-history.
+
+Root cause (Sentry 24h): ``inquire_daily_order_overseas`` /
+``inquire_daily_order_domestic`` paginate until KIS's continuation cursor
+(``ctx_area_nk*``) stops advancing or a page is empty. For some symbols KIS
+re-emits duplicate rows across continuation pages with an ever-changing cursor,
+so pagination runs all the way to ``max_pages`` (100). Each page also pays a
+redundant ``asyncio.sleep(0.1)`` on top of the already-enforced 19 req/s KIS
+sliding-window rate limiter. Worst case ≈ 100 × (~34ms HTTP + 100ms sleep) ≈
+13.4s (~10s of which is pure sleep) — matching the observed p95 = 13.9s.
+
+Two display-scoped, default-preserving knobs are added to the shared broker
+pagination methods:
+
+* ``inter_page_delay`` (default 0.1) — the display path passes 0.0 and relies
+  on the KIS rate limiter for continuation pacing.
+* ``stop_when_no_new_rows`` (default False) — the display path passes True so
+  pagination halts once a non-empty page contributes zero *new* order rows
+  (the KIS duplicate-cursor signature). Every unique row is already collected,
+  so no fill evidence is lost.
+
+Reconcile / fill-evidence callers keep the defaults, so their behavior is
+byte-for-byte unchanged (locked by the *invariant* tests below).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+def _make_overseas_client():
+    from app.services.brokers.kis.overseas_orders import OverseasOrderClient
+
+    parent = MagicMock()
+    parent._hdr_base = {"content-type": "application/json"}
+    parent._ensure_token = AsyncMock()
+    token_manager = MagicMock()
+    token_manager.clear_token = AsyncMock()
+    parent._token_manager = token_manager
+    parent._kis_url = lambda path: f"https://host{path}"
+    settings = MagicMock()
+    settings.kis_account_no = "1234567890"
+    settings.kis_access_token = "test-token"
+    parent._settings = settings
+    return OverseasOrderClient(parent), parent
+
+
+def _make_domestic_client():
+    from app.services.brokers.kis.domestic_orders import DomesticOrderClient
+
+    parent = MagicMock()
+    parent._hdr_base = {"content-type": "application/json"}
+    parent._ensure_token = AsyncMock()
+    token_manager = MagicMock()
+    token_manager.clear_token = AsyncMock()
+    parent._token_manager = token_manager
+    parent._kis_url = lambda path: f"https://host{path}"
+    settings = MagicMock()
+    settings.kis_account_no = "1234567890"
+    settings.kis_access_token = "test-token"
+    parent._settings = settings
+    return DomesticOrderClient(parent), parent
+
+
+def _dup_cursor_page(nk: str) -> dict:
+    """A page whose rows are all duplicates of page 1 but whose cursor keeps
+    advancing — the KIS runaway-pagination signature."""
+    return {
+        "rt_cd": "0",
+        "output1": [{"odno": "001", "pdno": "AAPL"}],
+        "ctx_area_fk200": nk,
+        "ctx_area_nk200": nk,
+    }
+
+
+@pytest.mark.unit
+class TestOverseasDisplayPaginationRob903:
+    @pytest.mark.asyncio
+    async def test_stop_when_no_new_rows_halts_on_duplicate_cursor(self):
+        """Display path: pagination stops as soon as a page adds no new rows."""
+        instance, parent = _make_overseas_client()
+        # Cursor advances forever, rows never change → without the guard this
+        # would run to max_pages and raise "truncated".
+        pages = [_dup_cursor_page(f"NK{i}") for i in range(200)]
+        parent._request_with_rate_limit = AsyncMock(side_effect=pages)
+
+        result = await instance.inquire_daily_order_overseas(
+            start_date="20260317",
+            end_date="20260317",
+            stop_when_no_new_rows=True,
+            inter_page_delay=0.0,
+        )
+
+        # Page 1 has a new row; page 2 is all duplicates → stop after 2 calls.
+        assert parent._request_with_rate_limit.call_count == 2
+        assert result == [{"odno": "001", "pdno": "AAPL"}]
+
+    @pytest.mark.asyncio
+    async def test_inter_page_delay_zero_skips_sleep(self, monkeypatch):
+        instance, parent = _make_overseas_client()
+        pages = [
+            {
+                "rt_cd": "0",
+                "output1": [{"odno": "001", "pdno": "AAPL"}],
+                "ctx_area_fk200": "NK1",
+                "ctx_area_nk200": "NK1",
+            },
+            {
+                "rt_cd": "0",
+                "output1": [{"odno": "002", "pdno": "MSFT"}],
+                "ctx_area_fk200": "",
+                "ctx_area_nk200": "",
+            },
+        ]
+        parent._request_with_rate_limit = AsyncMock(side_effect=pages)
+        sleep_mock = AsyncMock()
+        monkeypatch.setattr(
+            "app.services.brokers.kis.overseas_orders.asyncio.sleep", sleep_mock
+        )
+
+        await instance.inquire_daily_order_overseas(
+            start_date="20260317", end_date="20260317", inter_page_delay=0.0
+        )
+
+        sleep_mock.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_default_paginates_exhaustively_reconcile_invariant(self):
+        """RECONCILE LOCK: defaults must keep exhaustive pagination — a duplicate
+        cursor still runs to max_pages and raises, exactly as today."""
+        instance, parent = _make_overseas_client()
+        parent._request_with_rate_limit = AsyncMock(
+            side_effect=[_dup_cursor_page(f"NK{i}") for i in range(500)]
+        )
+
+        with pytest.raises(RuntimeError, match="truncated"):
+            await instance.inquire_daily_order_overseas(
+                start_date="20260317", end_date="20260317", max_pages=100
+            )
+        assert parent._request_with_rate_limit.call_count == 100
+
+    @pytest.mark.asyncio
+    async def test_default_delay_still_sleeps_between_pages(self, monkeypatch):
+        """RECONCILE LOCK: default inter_page_delay keeps the 0.1s spacing."""
+        instance, parent = _make_overseas_client()
+        pages = [
+            {
+                "rt_cd": "0",
+                "output1": [{"odno": "001", "pdno": "AAPL"}],
+                "ctx_area_fk200": "NK1",
+                "ctx_area_nk200": "NK1",
+            },
+            {
+                "rt_cd": "0",
+                "output1": [{"odno": "002", "pdno": "MSFT"}],
+                "ctx_area_fk200": "",
+                "ctx_area_nk200": "",
+            },
+        ]
+        parent._request_with_rate_limit = AsyncMock(side_effect=pages)
+        sleep_mock = AsyncMock()
+        monkeypatch.setattr(
+            "app.services.brokers.kis.overseas_orders.asyncio.sleep", sleep_mock
+        )
+
+        await instance.inquire_daily_order_overseas(
+            start_date="20260317", end_date="20260317"
+        )
+
+        sleep_mock.assert_awaited_once_with(0.1)
+
+
+@pytest.mark.unit
+class TestDomesticDisplayPaginationRob903:
+    @pytest.mark.asyncio
+    async def test_stop_when_no_new_rows_halts_on_duplicate_cursor(self):
+        instance, parent = _make_domestic_client()
+        pages = [
+            {
+                "rt_cd": "0",
+                "output1": [{"odno": "001", "pdno": "005930"}],
+                "ctx_area_fk100": f"NK{i}",
+                "ctx_area_nk100": f"NK{i}",
+            }
+            for i in range(200)
+        ]
+        parent._request_with_rate_limit = AsyncMock(side_effect=pages)
+
+        result = await instance.inquire_daily_order_domestic(
+            start_date="20260317",
+            end_date="20260317",
+            stop_when_no_new_rows=True,
+            inter_page_delay=0.0,
+        )
+
+        assert parent._request_with_rate_limit.call_count == 2
+        assert result == [{"odno": "001", "pdno": "005930"}]
+
+    @pytest.mark.asyncio
+    async def test_default_paginates_exhaustively_reconcile_invariant(self):
+        instance, parent = _make_domestic_client()
+        parent._request_with_rate_limit = AsyncMock(
+            side_effect=[
+                {
+                    "rt_cd": "0",
+                    "output1": [{"odno": "001", "pdno": "005930"}],
+                    "ctx_area_fk100": f"NK{i}",
+                    "ctx_area_nk100": f"NK{i}",
+                }
+                for i in range(500)
+            ]
+        )
+
+        with pytest.raises(RuntimeError, match="truncated"):
+            await instance.inquire_daily_order_domestic(
+                start_date="20260317", end_date="20260317", max_pages=100
+            )
+        assert parent._request_with_rate_limit.call_count == 100
+
+
+@pytest.mark.unit
+class TestDisplayFetchersWireFastPagination:
+    """The ROB-903 display tool wires the fast-pagination knobs; reconcile does not."""
+
+    @pytest.mark.asyncio
+    async def test_fetch_us_orders_passes_fast_pagination_kwargs(self, monkeypatch):
+        import app.mcp_server.tooling.orders_history as oh
+
+        captured: dict = {}
+
+        async def fake_overseas(*args, **kwargs):
+            captured.update(kwargs)
+            return []
+
+        async def fake_pending(*args, **kwargs):
+            return []
+
+        fake_client = MagicMock()
+        fake_client.inquire_daily_order_overseas = fake_overseas
+        fake_client.inquire_overseas_orders = fake_pending
+        monkeypatch.setattr(oh, "_create_kis_client", lambda *, is_mock: fake_client)
+        monkeypatch.setattr(
+            oh, "get_us_exchange_by_symbol", AsyncMock(return_value="NASD")
+        )
+
+        await oh._fetch_us_orders("AAPL", "filled", effective_days=30, is_mock=False)
+
+        assert captured.get("inter_page_delay") == 0.0
+        assert captured.get("stop_when_no_new_rows") is True
+
+    @pytest.mark.asyncio
+    async def test_fetch_kr_orders_passes_fast_pagination_kwargs(self, monkeypatch):
+        import app.mcp_server.tooling.orders_history as oh
+
+        captured: dict = {}
+
+        async def fake_domestic(*args, **kwargs):
+            captured.update(kwargs)
+            return []
+
+        async def fake_pending(*args, **kwargs):
+            return []
+
+        fake_client = MagicMock()
+        fake_client.inquire_daily_order_domestic = fake_domestic
+        fake_client.inquire_korea_orders = fake_pending
+        monkeypatch.setattr(oh, "_create_kis_client", lambda *, is_mock: fake_client)
+
+        await oh._fetch_kr_orders("005930", "filled", effective_days=30, is_mock=False)
+
+        assert captured.get("inter_page_delay") == 0.0
+        assert captured.get("stop_when_no_new_rows") is True


### PR DESCRIPTION
## ROB-903 — kis_live_get_order_history avg 5.8s / p95 13.9s × 20콜/24h (sum ~116s)

Linear: https://linear.app/mgh3326/issue/ROB-903

### (a) 5.8s 근본원인 분해 — 어디서 시간이 나는가

Sentry 24h span 분해(`transaction:"tools/call kis_live_get_order_history"`):

| span | count | avg | sum |
|---|---|---|---|
| `tools/call kis_live_get_order_history` (txn) | 17 | 6.74s | 114.6s |
| `GET …/overseas-stock/v1/trading/inquire-ccnl` (US 일별체결) | **812** | 34ms | 27.8s |
| `GET …/overseas-stock/v1/trading/inquire-nccs` (US 미체결) | 17 | 80ms | 1.35s |
| `GET …/domestic-stock/v1/trading/inquire-psbl-rvsecncl` (KR 미체결) | 3 | 55ms | 0.17s |
| `GET api.upbit.com/v1/orders` | 1 | 214ms | 0.21s |
| DB (us_symbol_universe SELECT 등) | — | ~1ms | <0.2s |

**결정적 사실**: 812 ccnl 콜 중 **800개가 단일 trace**(`a4d4d1dd…`)에서 나왔고, 그 trace는 이 도구를 **8회** 호출 → **호출당 정확히 100 페이지**(= `max_pages` 상한). 즉 특정 US 심볼 조회가 **연속조회(pagination) runaway** 로 100 페이지까지 감.

호출당 비용 ≈ 100 페이지 × (HTTP ~34ms + **`asyncio.sleep(0.1)`**) ≈ **13.4s** (관측 max/p95 13.9s와 일치). 이 중 **~10s가 페이지 사이 sleep** — HTTP는 ~1.6s. `avg 5.8s`는 이 outlier 세션이 평균을 끌어올린 값이고, 나머지 ~16콜은 sub-second.

**어디서**: HTTP 자체(1.6s)보다 **페이지네이션 루프의 이중 스로틀 sleep(~10s)** 이 지배. 토큰/DB/expiry 분류(ROB-671, offline)는 무시할 수준(<0.2s). expiry 분류는 이 도구 경로에서 호출되지 않음.

**왜 runaway인가**: KIS 연속조회 커서(`ctx_area_nk*`)가 계속 전진하면서 **동일 행을 중복 반환**(도메스틱 docstring에 "모든 행 2회" 실측 명시). 종료 조건은 빈 페이지 or 커서 정지뿐이라, 중복만 도는데도 `max_pages=100`까지 감. 그리고 페이지 사이 `sleep(0.1)`은 이미 **19 req/s KIS sliding-window rate limiter**가 페이싱하므로 **이중 스로틀**(순수 낭비).

### (b) 수정 내용

공유 브로커 메서드 `inquire_daily_order_domestic` / `inquire_daily_order_overseas`(+ `KISClient` facade)에 **기본값이 현행을 그대로 보존하는** 파라미터 2개 추가:

- `inter_page_delay: float = 0.1` — 표시 경로는 `0.0`으로 넘겨 rate limiter에만 의존(중복 sleep 제거).
- `stop_when_no_new_rows: bool = False` — 표시 경로는 `True` → non-empty 페이지가 **새 주문행(odno 기준)** 을 하나도 못 더하는 순간 중단. 이미 모든 고유 행 수집 완료 시점이라 **증거 손실 0**.

표시 도구 **fetcher만** opt-in:
- `app/mcp_server/tooling/orders_history.py:_fetch_kr_orders` (`inquire_daily_order_domestic` 호출) — +`inter_page_delay=0.0, stop_when_no_new_rows=True`
- `app/mcp_server/tooling/orders_history.py:_fetch_us_orders` (`inquire_daily_order_overseas` 호출) — 동일

변경 파일:
- `app/services/brokers/kis/overseas_orders.py` — `_overseas_order_key()` 헬퍼 + 루프에 dedupe-stop / 조건부 sleep
- `app/services/brokers/kis/domestic_orders.py` — `_domestic_order_key()` 헬퍼 + 동일
- `app/services/brokers/kis/client.py` — facade 두 메서드에 파라미터 pass-through
- `app/mcp_server/tooling/orders_history.py` — 표시 fetcher 2곳 opt-in

효과: runaway 100-페이지 표시 조회가 ~13.4s → **고유 데이터 크기 + 무sleep**로 축소(중복 커서면 2페이지에서 정지).

### (c) reconcile evidence 경로 fresh 유지

**reconcile/fill-evidence 경로는 전부 브로커 기본값 사용 → byte-for-byte 무변경**:
- KR: `app/mcp_server/tooling/kis_live_ledger.py` (`inquire_daily_order_domestic`, 기본값)
- US: `live_order_evidence.UsOverseasEvidenceAdapter` → `orders_modify_cancel._find_us_order_in_recent_history` (`inquire_daily_order_overseas`, 기본값, 7d, `symbol="%"`)
- `mock_scalping_exec/adapters.py`, `filled_orders_service.py` — 기본값

즉 exhaustive pagination · 0.1s 간격 · **fresh & complete** evidence 유지. 캐시/스테일 **미도입**. 날짜범위·`max_pages`·raise-on-truncate 시맨틱 **무변경**. expiry 분류(ROB-671) **무변경**. `dedupe-stop`은 "새 행 없음" 이후에만 정지하므로 특정 order_id의 체결 라인을 누락시키지 않음. reconcile 불변성은 아래 회귀락 테스트로 고정.

### (d) 테스트 증거

신규 `tests/test_kis_order_history_pagination_rob903.py` (TDD: 5 red → green, 3 invariant green):

```
tests/test_kis_order_history_pagination_rob903.py ........  [8 passed]
```

- `test_stop_when_no_new_rows_halts_on_duplicate_cursor` (overseas/domestic) — 중복 커서에서 2페이지 정지
- `test_inter_page_delay_zero_skips_sleep` — 표시 경로 sleep 미발생
- `test_default_paginates_exhaustively_reconcile_invariant` (overseas/domestic) — **RECONCILE LOCK**: 기본값은 여전히 max_pages까지 돌고 `truncated` raise (call_count==100)
- `test_default_delay_still_sleeps_between_pages` — **RECONCILE LOCK**: 기본 0.1s sleep 유지
- `test_fetch_{us,kr}_orders_passes_fast_pagination_kwargs` — 표시 fetcher만 fast kwargs 배선

회귀 스위트 (`-p no:xdist`):
```
tests/test_kis_overseas_orders_retry.py tests/test_kis_domestic_orders_retry.py
tests/test_orders_history_summary_rob657.py tests/test_orders_history_kis_mock.py
tests/test_filled_orders_service.py tests/test_mcp_kis_order_variants.py
tests/test_kis_mock_routing.py → 79 passed
tests/tasks/test_kis_live_reconcile_tasks.py tests/mcp_server/test_kis_live_reconcile_expiry.py
tests/scripts/test_kis_live_auto_reconcile_cli.py tests/test_order_outcome_unknown.py → 25 passed
tests/test_mcp_order_tools.py tests/test_rob653_ledger_passthrough.py
tests/test_mcp_place_order.py tests/test_kis_mock_routing.py → 148 passed
```

`make lint`: `ruff check` ✅ / `ruff format --check` ✅ (2721 files) / `ty check` ✅ All checks passed.

### (e) migration 카운트

**0** (스키마/모델 변경 없음).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)