### PR TITLE
fix(ROB-904): switch kiwoom mock buy preflight cash-evidence to kt00001 fallback

### DIFF
--- a/app/mcp_server/tooling/orders_kiwoom_variants.py
+++ b/app/mcp_server/tooling/orders_kiwoom_variants.py
@@ -33,7 +33,6 @@ from app.services.brokers.kiwoom.normalization import (
     KiwoomMockEvidenceError,
     build_mock_provenance,
     normalize_deposit,
-    normalize_orderable_cash,
     normalize_orders,
     normalize_positions,
     redact_broker_response,
@@ -51,6 +50,14 @@ if TYPE_CHECKING:
 __all__ = ("_derive_broker_success",)
 
 ACCOUNT_MODE_KIWOOM_MOCK = "kiwoom_mock"
+
+# ROB-904 — kt00010 (주문인출가능금액) is unsupported by mockapi.kiwoom.com
+# (return_code=20, RC7006; ROB-891 4-variant probe confirmed this). Cash
+# evidence — with or without a symbol — always comes from kt00001
+# (예수금상세현황) ord_alow_amt now. The symbol-path cash_source is spelled out
+# explicitly so callers can tell the figure is account-level, not order-scoped.
+_CASH_SOURCE_DEPOSIT = "deposit"
+_CASH_SOURCE_DEPOSIT_FALLBACK = "deposit_fallback_kt00010_unsupported"
 
 KIWOOM_MOCK_TOOL_NAMES: set[str] = {
     "kiwoom_mock_preview_order",
@@ -626,19 +633,17 @@ async def _kiwoom_mock_positions_impl(**kwargs: Any) -> dict[str, Any]:
 async def _kiwoom_mock_orderable_cash_impl(**kwargs: Any) -> dict[str, Any]:
     symbol_raw = kwargs.get("symbol")
     symbol = None if symbol_raw is None else normalize_krx_symbol(symbol_raw)
-    side = kwargs.get("side")
-    price = kwargs.get("price")
     cont_yn = kwargs.get("cont_yn")
     next_key = kwargs.get("next_key")
 
-    if symbol is not None:
-        base_source = "orderable_amount"
-        api_id = constants.ACCOUNT_ORDERABLE_AMOUNT_API_ID
-        normalizer = normalize_orderable_cash
-    else:
-        base_source = "deposit"
-        api_id = constants.ACCOUNT_DEPOSIT_API_ID
-        normalizer = normalize_deposit
+    # ROB-904 — kt00010 is mock-unsupported (RC7006), so the symbol path no
+    # longer dispatches to it. Both branches call kt00001 (get_deposit); side
+    # and price are accepted (kwargs) for call-site backcompat only and do not
+    # affect dispatch or the cash value, which is account-level either way.
+    base_source = (
+        _CASH_SOURCE_DEPOSIT_FALLBACK if symbol is not None else _CASH_SOURCE_DEPOSIT
+    )
+    api_id = constants.ACCOUNT_DEPOSIT_API_ID
 
     extra: dict[str, Any] = {
         "cash_source": f"{base_source}_unavailable",
@@ -646,38 +651,12 @@ async def _kiwoom_mock_orderable_cash_impl(**kwargs: Any) -> dict[str, Any]:
     if symbol is not None:
         extra["symbol"] = symbol
 
-    # ROB-891 — Official kt00010 symbol path requires stk_cd, trde_tp, uv.
-    # Reject missing or invalid side/price before any dispatch.
-    if symbol is not None and (
-        side not in ("buy", "sell") or type(price) is not int or price <= 0
-    ):
-        return _stable_read_failure(
-            result_key="cash",
-            result_value=None,
-            api_id=api_id,
-            error="kiwoom_mock_symbol_path_requires_side_and_price",
-            error_detail=(
-                "kt00010 symbol path requires side='buy'|'sell' "
-                f"and a positive int price; got side={side!r}, price={price!r}"
-            ),
-            extra=extra,
-        )
-
     try:
         client = KiwoomMockClient.from_app_settings()
         account_client = KiwoomDomesticAccountClient(cast(Any, client))
-        if symbol is not None:
-            broker_response = await account_client.get_orderable_amount(
-                symbol=symbol,
-                side=side,
-                price=price,
-                cont_yn=cont_yn,
-                next_key=next_key,
-            )
-        else:
-            broker_response = await account_client.get_deposit(
-                cont_yn=cont_yn, next_key=next_key
-            )
+        broker_response = await account_client.get_deposit(
+            cont_yn=cont_yn, next_key=next_key
+        )
     except Exception as exc:  # noqa: BLE001 - MCP tools fail closed with JSON
         return _stable_read_failure(
             result_key="cash",
@@ -714,7 +693,7 @@ async def _kiwoom_mock_orderable_cash_impl(**kwargs: Any) -> dict[str, Any]:
         return response
 
     try:
-        cash = normalizer(broker_response)
+        cash = normalize_deposit(broker_response)
     except KiwoomMockEvidenceError as exc:
         return _stable_read_failure(
             result_key="cash",
@@ -957,13 +936,15 @@ def register(mcp: FastMCP) -> None:
         side: Literal["buy", "sell"] | None = None,
         price: int | None = None,
     ) -> dict[str, Any]:
+        # ROB-904 — cash evidence always resolves via kt00001 now (kt00010 is
+        # mock-unsupported); symbol path is a fallback, not a distinct API.
+        api_id = constants.ACCOUNT_DEPOSIT_API_ID
+        base_source = (
+            _CASH_SOURCE_DEPOSIT_FALLBACK
+            if symbol is not None
+            else _CASH_SOURCE_DEPOSIT
+        )
         if (guard := _mock_config_error()) is not None:
-            if symbol is not None:
-                api_id = constants.ACCOUNT_ORDERABLE_AMOUNT_API_ID
-                cash_source = "orderable_amount_unavailable"
-            else:
-                api_id = constants.ACCOUNT_DEPOSIT_API_ID
-                cash_source = "deposit_unavailable"
             return _stable_read_failure(
                 result_key="cash",
                 result_value=None,
@@ -971,7 +952,7 @@ def register(mcp: FastMCP) -> None:
                 error="kiwoom_mock_config_invalid",
                 error_detail=str(guard["error"]),
                 extra={
-                    "cash_source": cash_source,
+                    "cash_source": f"{base_source}_unavailable",
                     **({"symbol": symbol} if symbol is not None else {}),
                 },
             )
@@ -982,11 +963,11 @@ def register(mcp: FastMCP) -> None:
                 return _stable_read_failure(
                     result_key="cash",
                     result_value=None,
-                    api_id=constants.ACCOUNT_ORDERABLE_AMOUNT_API_ID,
+                    api_id=api_id,
                     error="kiwoom_mock_symbol_invalid",
                     error_detail=str(exc),
                     extra={
-                        "cash_source": "orderable_amount_unavailable",
+                        "cash_source": f"{base_source}_unavailable",
                         "symbol": symbol,
                     },
                 )

--- a/app/services/brokers/kiwoom/domestic_account.py
+++ b/app/services/brokers/kiwoom/domestic_account.py
@@ -46,6 +46,18 @@ class KiwoomDomesticAccountClient:
         # ROB-891 — Official kt00010 body fields: stk_cd, trde_tp, uv.
         # Both side and price are required (trde_tp + uv are mandatory).
         # dmst_stex_tp is NOT in the official kt00010 docs.
+        #
+        # ROB-904 — kt00010 (주문인출가능금액) is unsupported by
+        # mockapi.kiwoom.com: a 2026-07-16 wire-body smoke sent this exact
+        # official-contract body across 4 field variants and got
+        # return_code=20 ("[2000](RC7006:모의투자 조회실패)") every time (same
+        # class of gap as US ust31490). No caller in this codebase invokes
+        # this method anymore — buy preflight and the orderable-cash MCP tool
+        # both fall back to kt00001 (get_deposit/normalize_deposit) instead.
+        # This method is kept, unmodified, as the correct implementation
+        # against Kiwoom's official contract for when/if live trading (or a
+        # future mock fix) needs it. Do NOT "fix" it by tweaking body fields —
+        # the contract is already correct; the gap is server-side.
         canonical_symbol = normalize_krx_symbol(symbol)
         if side not in ("buy", "sell"):
             raise ValueError(

--- a/app/services/brokers/kiwoom/order_preflight.py
+++ b/app/services/brokers/kiwoom/order_preflight.py
@@ -7,7 +7,7 @@ from app.mcp_server.tick_size import get_tick_size_kr
 from app.services.brokers.kiwoom.client import KiwoomPreDispatchError
 from app.services.brokers.kiwoom.normalization import (
     KiwoomMockEvidenceError,
-    normalize_orderable_cash,
+    normalize_deposit,
     normalize_positions,
     validate_mock_response_provenance,
 )
@@ -273,13 +273,17 @@ async def _check_buy_cash(
     checks: list[PreflightCheck],
     estimated: dict[str, Any],
 ) -> PreflightResult | None:
+    # ROB-904 — kt00010 (주문인출가능금액) is unsupported by mockapi.kiwoom.com
+    # (return_code=20, RC7006; ROB-891 4-variant probe). Cash evidence for buy
+    # preflight comes from kt00001 (예수금상세현황) ord_alow_amt instead — mock is
+    # a cash account (margin 100%), so account-level orderable cash is a
+    # conservative valid buy-cash bound. symbol/price are unused for this call
+    # but kept in the signature for interface stability.
     try:
-        cash_response = await account_client.get_orderable_amount(
-            symbol=symbol, side="buy", price=price
-        )
+        cash_response = await account_client.get_deposit()
         validate_mock_response_provenance(cash_response)
         _validate_successful_broker_response(cash_response)
-        orderable_cash = normalize_orderable_cash(cash_response)
+        orderable_cash = normalize_deposit(cash_response)
     except KiwoomPreDispatchError:
         raise
     except KiwoomMockEvidenceError as exc:

--- a/scripts/kiwoom_mock_smoke.py
+++ b/scripts/kiwoom_mock_smoke.py
@@ -662,14 +662,19 @@ _CONTRACT_STEPS_SPEC: list[dict[str, Any]] = [
         },
     },
     {
+        # ROB-904 — kt00010 (주문인출가능금액) is unsupported by mockapi.kiwoom.com
+        # (return_code=20, RC7006; ROB-891 4-variant probe). The symbol-scoped
+        # orderable-cash query now falls back to kt00001 (예수금상세현황) — same
+        # endpoint as the "deposit" stage, surfaced via a distinct cash_source.
         "stage": "orderable_amount",
         "tool": "kiwoom_mock_get_orderable_cash",
-        "expected_api_id": kw_constants.ACCOUNT_ORDERABLE_AMOUNT_API_ID,
+        "expected_api_id": kw_constants.ACCOUNT_DEPOSIT_API_ID,
         "evidence_kind": "orderable_amount",
         "tool_args": {"symbol": "005930", "side": "buy", "price": 50000},
         "contract_fields": {
-            "request_body": {"stk_cd": "<symbol>", "trde_tp": "1|2", "uv": "<price>"},
-            "response_field": "ord_alowa",
+            "request_body": {"qry_tp": "2"},
+            "response_field": "ord_alow_amt",
+            "cash_source": "deposit_fallback_kt00010_unsupported",
         },
     },
     {

--- a/tests/scripts/test_kiwoom_mock_smoke_contract.py
+++ b/tests/scripts/test_kiwoom_mock_smoke_contract.py
@@ -2,7 +2,9 @@
 
 Verifies ``--mode contract`` in ``scripts/kiwoom_mock_smoke.py``:
 
-* Four read endpoints called (kt00018, kt00001, kt00010, kt00009).
+* Four read stages called (kt00018, kt00001, kt00001, kt00009). ROB-904 —
+  the "orderable_amount" stage now falls back to kt00001 (kt00010 is
+  mock-unsupported, RC7006), so only three distinct api_ids are dispatched.
 * Strict pass: success==True AND return_code==0 AND exact mock provenance AND
   expected api_id. Inconsistent envelopes (success=true + nonzero RC) fail.
 * Zero broker mutations. Mutation tools are guarded.
@@ -184,7 +186,9 @@ async def test_four_endpoints_with_contract_fields(
     assert len(steps) == 4
 
     api_ids = {ln["expected_api_id"] for ln in steps}
-    assert api_ids == {"kt00018", "kt00001", "kt00010", "kt00009"}
+    # ROB-904 — orderable_amount stage now falls back to kt00001 (kt00010 is
+    # mock-unsupported), so only three distinct api_ids appear across 4 stages.
+    assert api_ids == {"kt00018", "kt00001", "kt00009"}
 
     for step in steps:
         assert "contract_fields" in step
@@ -207,20 +211,19 @@ async def test_request_body_captured_via_mocktransport(
 
     assert kw_constants.ACCOUNT_BALANCE_API_ID in captured
     assert kw_constants.ACCOUNT_DEPOSIT_API_ID in captured
-    assert kw_constants.ACCOUNT_ORDERABLE_AMOUNT_API_ID in captured
+    # ROB-904 — kt00010 is mock-unsupported (RC7006) and must never be
+    # dispatched by the contract sweep's "orderable_amount" stage.
+    assert kw_constants.ACCOUNT_ORDERABLE_AMOUNT_API_ID not in captured
     assert kw_constants.ACCOUNT_ORDER_STATUS_API_ID in captured
 
     assert captured[kw_constants.ACCOUNT_BALANCE_API_ID] == {
         "qry_tp": kw_constants.ACCOUNT_BALANCE_QRY_TP_DEFAULT,
         "dmst_stex_tp": kw_constants.ACCOUNT_DMST_STEX_TP_DEFAULT,
     }
+    # Both the "deposit" and "orderable_amount" stages dispatch the identical
+    # kt00001 request body; the account-level query takes no symbol/side/price.
     assert captured[kw_constants.ACCOUNT_DEPOSIT_API_ID] == {
         "qry_tp": kw_constants.ACCOUNT_DEPOSIT_QRY_TP_DEFAULT,
-    }
-    assert captured[kw_constants.ACCOUNT_ORDERABLE_AMOUNT_API_ID] == {
-        "stk_cd": "005930",
-        "trde_tp": kw_constants.TRADE_TYPE_BUY,
-        "uv": "50000",
     }
     assert captured[kw_constants.ACCOUNT_ORDER_STATUS_API_ID] == {
         "stk_bond_tp": kw_constants.ACCOUNT_ORDER_STK_BOND_TP_DEFAULT,

--- a/tests/test_kiwoom_mock_preflight.py
+++ b/tests/test_kiwoom_mock_preflight.py
@@ -28,16 +28,20 @@ class _FakeAccountClient:
         self,
         *,
         balance_payload: dict[str, Any] | None = None,
-        cash_payload: dict[str, Any] | None = None,
+        deposit_payload: dict[str, Any] | None = None,
         balance_error: Exception | None = None,
-        cash_error: Exception | None = None,
+        deposit_error: Exception | None = None,
     ) -> None:
         self.balance_calls = 0
-        self.cash_calls = 0
+        self.deposit_calls = 0
+        # ROB-904 — kt00010 (주문인출가능금액) is unsupported by mockapi (RC7006,
+        # ROB-891). Buy preflight no longer calls get_orderable_amount; this
+        # counter stays at 0 across every buy test to prove that.
+        self.orderable_amount_calls = 0
         self._balance_payload = balance_payload
-        self._cash_payload = cash_payload
+        self._deposit_payload = deposit_payload
         self._balance_error = balance_error
-        self._cash_error = cash_error
+        self._deposit_error = deposit_error
 
     async def get_balance(self, **_kwargs):
         self.balance_calls += 1
@@ -45,11 +49,18 @@ class _FakeAccountClient:
             raise self._balance_error
         return self._balance_payload or {"return_code": 0}
 
+    async def get_deposit(self, **_kwargs):
+        self.deposit_calls += 1
+        if self._deposit_error is not None:
+            raise self._deposit_error
+        return self._deposit_payload or {"return_code": 0}
+
     async def get_orderable_amount(self, **_kwargs):
-        self.cash_calls += 1
-        if self._cash_error is not None:
-            raise self._cash_error
-        return self._cash_payload or {"return_code": 0}
+        self.orderable_amount_calls += 1
+        raise AssertionError(
+            "kt00010 get_orderable_amount must never be dispatched by buy "
+            "preflight (mockapi RC7006-unsupported, ROB-904)"
+        )
 
 
 def _positions_payload(rows: list[dict[str, Any]] | None = None) -> dict[str, Any]:
@@ -80,7 +91,7 @@ async def test_preflight_quote_missing_fails_closed():
     assert result.checks[0].name == "quote_freshness"
     assert result.checks[0].ok is False
     assert client.balance_calls == 0
-    assert client.cash_calls == 0
+    assert client.deposit_calls == 0
 
 
 @pytest.mark.asyncio
@@ -98,7 +109,7 @@ async def test_preflight_quote_stale_fails_closed():
     assert result.ok is False
     assert result.error_code == PREFLIGHT_QUOTE_STALE
     assert client.balance_calls == 0
-    assert client.cash_calls == 0
+    assert client.deposit_calls == 0
 
 
 @pytest.mark.parametrize(
@@ -156,14 +167,14 @@ async def test_preflight_tick_validation_rejects_non_krx_ticks(invalid_price):
     )
     assert result.ok is False
     assert result.error_code == PREFLIGHT_TICK_INVALID
-    assert client.cash_calls == 0
+    assert client.deposit_calls == 0
 
 
 @pytest.mark.parametrize("price", [40000, 100000])
 @pytest.mark.asyncio
 async def test_preflight_price_distance_exceeded_fails_closed(price):
     client = _FakeAccountClient(
-        cash_payload={"return_code": 0, "ord_alowa": "100000000"}
+        deposit_payload={"return_code": 0, "ord_alow_amt": "100000000"}
     )
     result = await run_order_preflight(
         account_client=client,
@@ -180,13 +191,13 @@ async def test_preflight_price_distance_exceeded_fails_closed(price):
     distance_check = next(c for c in result.checks if c.name == "price_distance")
     assert distance_check.ok is False
     assert result.estimated_evidence["price_distance_pct"] > 30.0
-    assert client.cash_calls == 0
+    assert client.deposit_calls == 0
 
 
 @pytest.mark.asyncio
 async def test_preflight_price_distance_at_limit_passes():
     client = _FakeAccountClient(
-        cash_payload={"return_code": 0, "ord_alowa": "100000000"}
+        deposit_payload={"return_code": 0, "ord_alow_amt": "100000000"}
     )
     result = await run_order_preflight(
         account_client=client,
@@ -202,7 +213,7 @@ async def test_preflight_price_distance_at_limit_passes():
     distance_check = next(c for c in result.checks if c.name == "price_distance")
     assert distance_check.ok is True
     assert result.estimated_evidence["price_distance_pct"] == 30.0
-    assert client.cash_calls == 1
+    assert client.deposit_calls == 1
 
 
 @pytest.mark.asyncio
@@ -269,9 +280,9 @@ async def test_preflight_missing_symbol_position_fails_closed():
 @pytest.mark.asyncio
 async def test_preflight_cash_insufficient_fails_closed():
     client = _FakeAccountClient(
-        cash_payload={
+        deposit_payload={
             "return_code": 0,
-            "ord_alowa": "500000",
+            "ord_alow_amt": "500000",
         }
     )
     result = await run_order_preflight(
@@ -294,9 +305,9 @@ async def test_preflight_cash_insufficient_fails_closed():
 @pytest.mark.asyncio
 async def test_preflight_cash_sufficient_passes(return_code):
     client = _FakeAccountClient(
-        cash_payload={
+        deposit_payload={
             "return_code": return_code,
-            "ord_alowa": "100000000",
+            "ord_alow_amt": "100000000",
         }
     )
     result = await run_order_preflight(
@@ -313,9 +324,53 @@ async def test_preflight_cash_sufficient_passes(return_code):
 
 
 @pytest.mark.asyncio
+async def test_preflight_buy_uses_kt00001_deposit_not_kt00010_orderable_amount():
+    """ROB-904 — buy cash-evidence source is kt00001 (deposit), never kt00010."""
+    client = _FakeAccountClient(
+        deposit_payload={"return_code": 0, "ord_alow_amt": "100000000"}
+    )
+    result = await run_order_preflight(
+        account_client=client,
+        symbol="005930",
+        side="buy",
+        quantity=10,
+        price=70000,
+        quote_price=70000,
+        quote_freshness="fresh",
+    )
+    assert result.ok is True
+    assert result.estimated_evidence.get("orderable_cash") == 100000000
+    assert client.deposit_calls == 1
+    assert client.orderable_amount_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_preflight_buy_provenance_conflict_fails_closed():
+    client = _FakeAccountClient(
+        deposit_payload={
+            "return_code": 0,
+            "provenance": {"environment": "live"},
+            "ord_alow_amt": "100000000",
+        }
+    )
+    result = await run_order_preflight(
+        account_client=client,
+        symbol="005930",
+        side="buy",
+        quantity=1,
+        price=70000,
+        quote_price=70000,
+        quote_freshness="fresh",
+    )
+    assert result.ok is False
+    assert result.error_code == PREFLIGHT_PROVENANCE_CONFLICT
+    assert client.orderable_amount_calls == 0
+
+
+@pytest.mark.asyncio
 async def test_preflight_buy_marks_fee_and_tax_estimates_unavailable():
     client = _FakeAccountClient(
-        cash_payload={"return_code": 0, "ord_alowa": "100000000"}
+        deposit_payload={"return_code": 0, "ord_alow_amt": "100000000"}
     )
 
     result = await run_order_preflight(
@@ -346,7 +401,7 @@ async def test_preflight_buy_marks_fee_and_tax_estimates_unavailable():
 @pytest.mark.asyncio
 async def test_preflight_cash_missing_field_fails_closed():
     client = _FakeAccountClient(
-        cash_payload={"return_code": 0}  # no ord_alowa
+        deposit_payload={"return_code": 0}  # no ord_alow_amt
     )
     result = await run_order_preflight(
         account_client=client,
@@ -374,10 +429,10 @@ async def test_preflight_cash_missing_field_fails_closed():
 )
 @pytest.mark.asyncio
 async def test_preflight_cash_broker_failure_fails_closed(return_code):
-    payload: dict[str, Any] = {"ord_alowa": "100000000"}
+    payload: dict[str, Any] = {"ord_alow_amt": "100000000"}
     if return_code != "missing":
         payload["return_code"] = return_code
-    client = _FakeAccountClient(cash_payload=payload)
+    client = _FakeAccountClient(deposit_payload=payload)
 
     result = await run_order_preflight(
         account_client=client,
@@ -489,12 +544,12 @@ async def test_preflight_sell_reraises_pre_dispatch_error():
     assert exc_info.value.stage == "request_build"
     assert exc_info.value.api_id == "kt00018"
     assert client.balance_calls == 1
-    assert client.cash_calls == 0
+    assert client.deposit_calls == 0
 
 
 @pytest.mark.asyncio
 async def test_preflight_cash_transport_failure_fails_closed():
-    client = _FakeAccountClient(cash_error=RuntimeError("broker timeout"))
+    client = _FakeAccountClient(deposit_error=RuntimeError("broker timeout"))
     result = await run_order_preflight(
         account_client=client,
         symbol="005930",
@@ -511,9 +566,9 @@ async def test_preflight_cash_transport_failure_fails_closed():
 @pytest.mark.asyncio
 async def test_preflight_buy_reraises_pre_dispatch_error():
     client = _FakeAccountClient(
-        cash_error=KiwoomPreDispatchError(
+        deposit_error=KiwoomPreDispatchError(
             stage="host_validation",
-            api_id="kt00010",
+            api_id="kt00001",
             cause_type="ValueError",
         )
     )
@@ -530,9 +585,9 @@ async def test_preflight_buy_reraises_pre_dispatch_error():
         )
 
     assert exc_info.value.stage == "host_validation"
-    assert exc_info.value.api_id == "kt00010"
+    assert exc_info.value.api_id == "kt00001"
     assert client.balance_calls == 0
-    assert client.cash_calls == 1
+    assert client.deposit_calls == 1
 
 
 @pytest.mark.asyncio
@@ -651,7 +706,7 @@ async def test_preflight_does_not_mutate_account_position_for_sell():
 @pytest.mark.asyncio
 async def test_preflight_buy_path_never_calls_position_read():
     client = _FakeAccountClient(
-        cash_payload={"return_code": 0, "ord_alowa": "100000000"}
+        deposit_payload={"return_code": 0, "ord_alow_amt": "100000000"}
     )
     result = await run_order_preflight(
         account_client=client,
@@ -664,7 +719,7 @@ async def test_preflight_buy_path_never_calls_position_read():
     )
     assert result.ok is True
     assert client.balance_calls == 0
-    assert client.cash_calls == 1
+    assert client.deposit_calls == 1
 
 
 @pytest.mark.asyncio
@@ -682,7 +737,7 @@ async def test_preflight_sell_path_skips_cash_read():
         quote_freshness="fresh",
     )
     assert result.ok is True
-    assert client.cash_calls == 0
+    assert client.deposit_calls == 0
 
 
 @pytest.mark.asyncio

--- a/tests/test_mcp_kiwoom_order_variants.py
+++ b/tests/test_mcp_kiwoom_order_variants.py
@@ -983,17 +983,20 @@ def _patch_preflight_success(monkeypatch, mod) -> None:
 
 
 @pytest.mark.asyncio
-async def test_orderable_cash_with_symbol_calls_orderable_amount(monkeypatch):
+async def test_orderable_cash_with_symbol_calls_deposit_fallback(monkeypatch):
+    # ROB-904 — kt00010 (주문인출가능금액) is unsupported by mockapi (RC7006,
+    # ROB-891 4-variant probe). The symbol path now falls back to kt00001
+    # (예수금상세현황) and must never dispatch kt00010.
     from app.mcp_server.tooling import orders_kiwoom_variants as mod
 
     calls = _patch_fake_kiwoom_account_client(
         monkeypatch,
         mod,
         payloads={
-            "orderable_amount": {
+            "deposit": {
                 "return_code": 0,
                 "return_msg": "정상",
-                "ord_alowa": "1500000",
+                "ord_alow_amt": "1500000",
             },
             "balance": {"return_code": 0},
             "order_status": {"return_code": 0},
@@ -1009,41 +1012,47 @@ async def test_orderable_cash_with_symbol_calls_orderable_amount(monkeypatch):
     assert response["success"] is True
     assert response["source"] == "kiwoom"
     assert response["account_mode"] == "kiwoom_mock"
-    assert response["broker_response"]["ord_alowa"] == "1500000"
+    assert response["broker_response"]["ord_alow_amt"] == "1500000"
     assert response["cash"] == 1500000
-    assert response["cash_source"] == "orderable_amount"
+    assert response["cash_source"] == "deposit_fallback_kt00010_unsupported"
     assert response["symbol"] == "005930"
-    assert response["provenance"]["api_id"] == "kt00010"
+    assert response["provenance"]["api_id"] == "kt00001"
     assert response["provenance"]["host"] == "mockapi.kiwoom.com"
-    # balance/deposit must NOT have been called
-    assert all(c.get("method") not in ("balance", "deposit") for c in calls)
+    # balance/orderable_amount (kt00010) must NOT have been called
+    assert all(c.get("method") not in ("balance", "orderable_amount") for c in calls)
+    assert any(c.get("method") == "deposit" for c in calls)
 
 
 @pytest.mark.asyncio
-async def test_orderable_cash_with_symbol_side_price_sends_trde_tp_and_uv(monkeypatch):
+async def test_orderable_cash_with_symbol_side_price_accepted_but_unused(monkeypatch):
+    # ROB-904 — symbol/side/price are accepted for call-site backcompat but no
+    # longer shape the broker dispatch: the deposit call takes no args derived
+    # from them (kt00010's trde_tp/uv are gone).
     from app.mcp_server.tooling import orders_kiwoom_variants as mod
 
     calls = _patch_fake_kiwoom_account_client(
         monkeypatch,
         mod,
         payloads={
-            "orderable_amount": {
+            "deposit": {
                 "return_code": 0,
-                "ord_alowa": "1500000",
+                "ord_alow_amt": "1500000",
             },
         },
     )
     mcp = DummyMCP()
     _register(mcp)
 
-    await mcp.tools["kiwoom_mock_get_orderable_cash"](
+    response = await mcp.tools["kiwoom_mock_get_orderable_cash"](
         symbol="005930", side="buy", price=70000
     )
 
-    orderable_calls = [c for c in calls if c.get("method") == "orderable_amount"]
-    assert len(orderable_calls) == 1
-    assert orderable_calls[0]["side"] == "buy"
-    assert orderable_calls[0]["price"] == 70000
+    assert response["success"] is True
+    deposit_calls = [c for c in calls if c.get("method") == "deposit"]
+    assert len(deposit_calls) == 1
+    assert "side" not in deposit_calls[0]
+    assert "price" not in deposit_calls[0]
+    assert all(c.get("method") != "orderable_amount" for c in calls)
 
 
 @pytest.mark.asyncio
@@ -1053,9 +1062,6 @@ async def test_orderable_cash_with_symbol_side_price_sends_trde_tp_and_uv(monkey
         (None, 70000),
         ("buy", None),
         (None, None),
-        # ROB-891 — bool is an int subclass; isinstance(price, int) wrongly
-        # accepted True and dispatched uv="True". type(price) is int rejects
-        # bools/floats/strings before any broker dispatch.
         ("buy", True),
         ("buy", False),
         ("buy", 1.5),
@@ -1063,18 +1069,18 @@ async def test_orderable_cash_with_symbol_side_price_sends_trde_tp_and_uv(monkey
         ("buy", "70000"),
     ],
 )
-async def test_orderable_cash_symbol_path_rejects_missing_side_or_price(
+async def test_orderable_cash_symbol_path_ignores_missing_or_invalid_side_price(
     monkeypatch, side, price
 ):
-    # ROB-891 — Official kt00010 symbol path requires stk_cd, trde_tp, uv.
-    # Missing side or price must be rejected before any dispatch.
+    # ROB-904 — kt00010 is no longer dispatched, so the symbol path no longer
+    # requires side/price to be well-formed; it succeeds via kt00001 regardless.
     from app.mcp_server.tooling import orders_kiwoom_variants as mod
 
     calls = _patch_fake_kiwoom_account_client(
         monkeypatch,
         mod,
         payloads={
-            "orderable_amount": {"return_code": 0, "ord_alowa": "1500000"},
+            "deposit": {"return_code": 0, "ord_alow_amt": "1500000"},
         },
     )
     mcp = DummyMCP()
@@ -1084,36 +1090,10 @@ async def test_orderable_cash_symbol_path_rejects_missing_side_or_price(
         symbol="005930", side=side, price=price
     )
 
-    assert response["success"] is False
-    assert response["cash"] is None
-    assert response["provenance"]["api_id"] == "kt00010"
+    assert response["success"] is True
+    assert response["cash"] == 1500000
+    assert response["provenance"]["api_id"] == "kt00001"
     assert all(c.get("method") != "orderable_amount" for c in calls)
-
-
-@pytest.mark.asyncio
-async def test_orderable_cash_bool_price_never_dispatched(monkeypatch):
-    # ROB-891 regression — price=True previously dispatched uv="True" because
-    # isinstance(True, int) is True. Fail-closed at the MCP boundary with zero
-    # broker dispatch.
-    from app.mcp_server.tooling import orders_kiwoom_variants as mod
-
-    calls = _patch_fake_kiwoom_account_client(
-        monkeypatch,
-        mod,
-        payloads={
-            "orderable_amount": {"return_code": 0, "ord_alowa": "1500000"},
-        },
-    )
-    mcp = DummyMCP()
-    _register(mcp)
-
-    response = await mcp.tools["kiwoom_mock_get_orderable_cash"](
-        symbol="005930", side="buy", price=True
-    )
-
-    assert response["success"] is False
-    assert response["cash"] is None
-    assert calls == []
 
 
 @pytest.mark.asyncio
@@ -1151,46 +1131,40 @@ async def test_orderable_cash_without_symbol_calls_deposit(monkeypatch):
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ("symbol", "payload_key", "payload", "api_id", "cash_source"),
+    ("symbol", "payload", "api_id", "cash_source"),
     [
         (
             "005930",
-            "orderable_amount",
             {"return_code": 0, "some_unknown_field": "x"},
-            "kt00010",
-            "orderable_amount_unavailable",
+            "kt00001",
+            "deposit_fallback_kt00010_unsupported_unavailable",
         ),
         (
             "005930",
-            "orderable_amount",
-            {"return_code": 0, "ord_alowa": "not-a-number"},
-            "kt00010",
-            "orderable_amount_unavailable",
+            {"return_code": 0, "ord_alow_amt": "not-a-number"},
+            "kt00001",
+            "deposit_fallback_kt00010_unsupported_unavailable",
         ),
         (
             "005930",
-            "orderable_amount",
-            {"return_code": 0, "ord_alowa": "-1"},
-            "kt00010",
-            "orderable_amount_unavailable",
+            {"return_code": 0, "ord_alow_amt": "-1"},
+            "kt00001",
+            "deposit_fallback_kt00010_unsupported_unavailable",
         ),
         (
             None,
-            "deposit",
             {"return_code": 0, "some_unknown_field": "x"},
             "kt00001",
             "deposit_unavailable",
         ),
         (
             None,
-            "deposit",
             {"return_code": 0, "ord_alow_amt": "not-a-number"},
             "kt00001",
             "deposit_unavailable",
         ),
         (
             None,
-            "deposit",
             {"return_code": 0, "ord_alow_amt": "-1"},
             "kt00001",
             "deposit_unavailable",
@@ -1198,18 +1172,16 @@ async def test_orderable_cash_without_symbol_calls_deposit(monkeypatch):
     ],
 )
 async def test_orderable_cash_unavailable_evidence_fails_closed(
-    monkeypatch, symbol, payload_key, payload, api_id, cash_source
+    monkeypatch, symbol, payload, api_id, cash_source
 ):
     from app.mcp_server.tooling import orders_kiwoom_variants as mod
 
     payloads = {
-        "orderable_amount": {"return_code": 0, "ord_alowa": "1500000"},
-        "deposit": {"return_code": 0, "ord_alow_amt": "987654"},
+        "deposit": payload,
         "balance": {"return_code": 0},
         "order_status": {"return_code": 0},
     }
-    payloads[payload_key] = payload
-    _patch_fake_kiwoom_account_client(
+    calls = _patch_fake_kiwoom_account_client(
         monkeypatch,
         mod,
         payloads=payloads,
@@ -1227,42 +1199,50 @@ async def test_orderable_cash_unavailable_evidence_fails_closed(
     assert response["cash_source"] == cash_source
     assert response["broker_response"] == payload
     assert response["provenance"]["api_id"] == api_id
+    assert all(c.get("method") != "orderable_amount" for c in calls)
 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ("symbol", "payload_key", "api_id", "cash_source", "return_code"),
+    ("symbol", "api_id", "cash_source", "return_code"),
     [
-        ("005930", "orderable_amount", "kt00010", "orderable_amount_unavailable", 40),
         (
             "005930",
-            "orderable_amount",
-            "kt00010",
-            "orderable_amount_unavailable",
+            "kt00001",
+            "deposit_fallback_kt00010_unsupported_unavailable",
+            40,
+        ),
+        (
+            "005930",
+            "kt00001",
+            "deposit_fallback_kt00010_unsupported_unavailable",
             False,
         ),
-        ("005930", "orderable_amount", "kt00010", "orderable_amount_unavailable", 0.5),
-        (None, "deposit", "kt00001", "deposit_unavailable", 40),
-        (None, "deposit", "kt00001", "deposit_unavailable", False),
-        (None, "deposit", "kt00001", "deposit_unavailable", 0.5),
+        (
+            "005930",
+            "kt00001",
+            "deposit_fallback_kt00010_unsupported_unavailable",
+            0.5,
+        ),
+        (None, "kt00001", "deposit_unavailable", 40),
+        (None, "kt00001", "deposit_unavailable", False),
+        (None, "kt00001", "deposit_unavailable", 0.5),
     ],
 )
 async def test_orderable_cash_broker_rejection_has_stable_failure_source(
-    monkeypatch, symbol, payload_key, api_id, cash_source, return_code
+    monkeypatch, symbol, api_id, cash_source, return_code
 ):
     from app.mcp_server.tooling import orders_kiwoom_variants as mod
 
     payloads = {
-        "orderable_amount": {"return_code": 0, "ord_alowa": "1500000"},
-        "deposit": {"return_code": 0, "ord_alow_amt": "987654"},
+        "deposit": {
+            "return_code": return_code,
+            "return_msg": "broker rejected",
+        },
         "balance": {"return_code": 0},
         "order_status": {"return_code": 0},
     }
-    payloads[payload_key] = {
-        "return_code": return_code,
-        "return_msg": "broker rejected",
-    }
-    _patch_fake_kiwoom_account_client(monkeypatch, mod, payloads=payloads)
+    calls = _patch_fake_kiwoom_account_client(monkeypatch, mod, payloads=payloads)
     mcp = DummyMCP()
     _register(mcp)
 
@@ -1275,13 +1255,14 @@ async def test_orderable_cash_broker_rejection_has_stable_failure_source(
     assert response["cash"] is None
     assert response["cash_source"] == cash_source
     assert response["provenance"]["api_id"] == api_id
+    assert all(c.get("method") != "orderable_amount" for c in calls)
 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("symbol", "api_id"),
     [
-        ("005930", "kt00010"),
+        ("005930", "kt00001"),
         (None, "kt00001"),
     ],
 )
@@ -1298,7 +1279,7 @@ async def test_orderable_cash_broker_error_is_fail_closed(monkeypatch, symbol, a
             pass
 
         async def get_orderable_amount(self, **kwargs):  # noqa: ARG002
-            raise RuntimeError("boom")
+            raise AssertionError("kt00010 must never be dispatched (ROB-904)")
 
         async def get_deposit(self, **kwargs):  # noqa: ARG002
             raise RuntimeError("boom")
@@ -1543,31 +1524,34 @@ def _assert_stable_read_failure(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ("symbol", "payload_key", "api_id"),
+    ("symbol", "api_id"),
     [
-        ("005930", "orderable_amount", "kt00010"),
-        (None, "deposit", "kt00001"),
+        ("005930", "kt00001"),
+        (None, "kt00001"),
     ],
 )
 async def test_orderable_cash_both_branches_fail_closed_on_live_provenance(
-    monkeypatch, symbol, payload_key, api_id
+    monkeypatch, symbol, api_id
 ):
     from app.mcp_server.tooling import orders_kiwoom_variants as mod
 
     payloads = {
-        "orderable_amount": {"return_code": 0, "ord_alowa": "1500000"},
-        "deposit": {"return_code": 0, "ord_alow_amt": "987654"},
+        "deposit": {
+            "return_code": 0,
+            "ord_alow_amt": "987654",
+            "provenance": {"environment": "live"},
+        },
         "balance": {"return_code": 0},
         "order_status": {"return_code": 0},
     }
-    payloads[payload_key]["provenance"] = {"environment": "live"}
-    _patch_fake_kiwoom_account_client(monkeypatch, mod, payloads=payloads)
+    calls = _patch_fake_kiwoom_account_client(monkeypatch, mod, payloads=payloads)
     mcp = DummyMCP()
     _register(mcp)
 
     response = await mcp.tools["kiwoom_mock_get_orderable_cash"](
         symbol=symbol, side="buy", price=70000
     )
+    assert all(c.get("method") != "orderable_amount" for c in calls)
 
     assert response["success"] is False
     assert response["cash"] is None
@@ -1733,7 +1717,11 @@ async def test_registered_reads_config_failure_has_stable_envelope(
 @pytest.mark.parametrize(
     ("symbol", "api_id", "cash_source"),
     [
-        ("005930", "kt00010", "orderable_amount_unavailable"),
+        (
+            "005930",
+            "kt00001",
+            "deposit_fallback_kt00010_unsupported_unavailable",
+        ),
         (None, "kt00001", "deposit_unavailable"),
     ],
 )


### PR DESCRIPTION
## Premise (re-investigation forbidden — confirmed 2026-07-16)

`kiwoom_mock` buy preflight was universally blocked with
`preflight_evidence_invalid: return_code=20`. Root cause confirmed by a
2026-07-16 wire-body smoke: the deployed code/contract was already correct —
kt00010 (주문인출가능금액) body matched the official spec
(`{stk_cd, trde_tp, uv}`) exactly. **mockapi.kiwoom.com does not support the
kt00010 TR at all** (4 read-only field-variant probes, all
`return_code=20, "[2000](RC7006:모의투자 조회실패)"` — same class of gap as
US `ust31490`). Control group in the same deploy: kt00001 (예수금상세현황,
`{"qry_tp":"2"}`) works normally — `ord_alow_amt` measured 9,110,660.

Per the issue, further "improving" kt00010's request fields is explicitly
out of scope — this is the 4th round of that dead end.

## Fix

1. **`order_preflight.py::_check_buy_cash`** — cash evidence now comes from
   `account_client.get_deposit()` (kt00001) + `normalize_deposit`
   (`ord_alow_amt`) instead of `get_orderable_amount()` (kt00010). Mock is a
   cash account (100% margin), so account-level orderable cash is a
   conservative valid buy-cash bound. provenance/fail-closed contract
   (`validate_mock_response_provenance`, non-zero `return_code` rejection)
   unchanged. This function is shared by both `kiwoom_mock_place_order` and
   `kiwoom_mock_preview_order` (ROB-893) — see below.
2. **`orders_kiwoom_variants.py::_kiwoom_mock_orderable_cash_impl`** — the
   `symbol=...` path now falls back to kt00001 instead of dispatching
   kt00010. Response is honest about the fallback: `cash_source` is
   `"deposit_fallback_kt00010_unsupported"` (vs plain `"deposit"` for the
   no-symbol path) and `provenance.api_id` reports the actually-called
   `kt00001`. `symbol`/`side`/`price` are still accepted for call-site
   backcompat but no longer shape the dispatch (kt00010's `trde_tp`/`uv`
   fields are gone).
3. **kt00010 code path preserved** — `domestic_account.py::get_orderable_amount`,
   `TRADE_TYPE_*` constants, and `normalize_orderable_cash` are untouched,
   now annotated as mock-unsupported-but-contract-correct (kept for
   live/future use, not deleted).
4. **Cash-insufficient gate unchanged** — `order_amount > orderable_cash` →
   `PREFLIGHT_CASH_INSUFFICIENT`, still fail-closed.

## ROB-893 preview path

`kiwoom_mock_preview_order` and `kiwoom_mock_place_order` both call
`_run_preflight_for_kiwoom_mock` → `run_order_preflight` → `_check_buy_cash`
— the exact same function fixed in (1). No separate preview-path change was
needed; verified by `test_preview_and_place_normalize_with_same_error_code`
and the full preflight suite passing unchanged.

## Tests (TDD: RED confirmed before implementing each fix)

- `tests/test_kiwoom_mock_preflight.py` — `_FakeAccountClient.get_orderable_amount`
  now raises `AssertionError` if ever called by buy preflight (proves 0
  kt00010 dispatch); buy-cash fixtures switched to `ord_alow_amt`/`get_deposit`.
  New: `test_preflight_buy_uses_kt00001_deposit_not_kt00010_orderable_amount`,
  `test_preflight_buy_provenance_conflict_fails_closed`. 54/54 pass.
- `tests/test_mcp_kiwoom_order_variants.py` — symbol-path orderable-cash tests
  rewritten for the kt00001 fallback contract (new cash_source/api_id,
  zero-kt00010-dispatch assertions). 164/164 pass.
- `tests/scripts/test_kiwoom_mock_smoke_contract.py` +
  `scripts/kiwoom_mock_smoke.py` — the read-only contract sweep's
  `orderable_amount` stage now expects kt00001, not kt00010. 72/72 pass.

## Verification

- `uv run pytest tests/ -k "kiwoom" -v` → **674 passed**
- `uv run pytest -m "not live and not slow" -n auto` → **16789 passed, 1 failed
  (pre-existing, unrelated), 9 skipped**. The failure,
  `tests/infra/test_schema_barrier.py::test_apply_test_schema_is_idempotent`,
  is a known ROB-723-class xdist test-DB contention flake — passes in
  isolation, reproduces identically on two full runs, and lives in
  `tests/infra/` with zero relation to this diff's files.
- `make lint` (ruff check + ruff format + ty) → **all clean**
- `git diff --check` → clean
- `uv run alembic heads` → single head (`20260714_rob850_paper_evaluation`) — migration 0, as expected

## Out of scope

Live operational verification of kt00001-fallback cash values against a real
mock account is **not** part of this PR (no network probes were run per
instructions) — that's for a follow-up deployed-verification pass.

Linear: ROB-904

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Kiwoom mock handling when orderable-cash API support is unavailable.
  * Cash checks now reliably fall back to account deposit information.
  * Buy-order preflight validation uses deposit evidence and avoids unsupported requests.
  * Updated error reporting and cash-source metadata for clearer failure handling.

* **Tests**
  * Expanded coverage for deposit fallback behavior, validation failures, and unsupported API calls.
  * Updated smoke checks to verify consistent account-deposit requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->