### PR TITLE
fix(ROB-905): enforce validated-signal gate for Binance Demo scalping confirm=true

### DIFF
--- a/app/jobs/binance_demo_scalping_runner.py
+++ b/app/jobs/binance_demo_scalping_runner.py
@@ -58,8 +58,33 @@ async def run_demo_scalping_tick(*, now: dt.datetime | None = None) -> dict[str,
             "scheduler_enabled": scheduler,
         }
 
-    confirm = _truthy(os.environ.get(_CONFIRM_ENV))
     now = now or dt.datetime.now(dt.UTC)
+
+    # ROB-905: confirm=true is honoured only behind a validated-signal gate.
+    # ROB-316's posture (OOS gross-negative micro-breakout signal) requires the
+    # signal to stay dry-run/observe-only until a validated-signal artifact
+    # authorises live Demo orders. If confirm is requested but the gate denies,
+    # downgrade to a dry-run tick (keep telemetry, place no real order) — never
+    # crash the tick.
+    confirm_requested = _truthy(os.environ.get(_CONFIRM_ENV))
+    confirm = confirm_requested
+    validated_signal_gate: dict[str, Any] | None = None
+    if confirm_requested:
+        from app.services.brokers.binance.demo_scalping_exec.validated_signal_gate import (  # noqa: E501
+            evaluate_validated_signal_gate,
+        )
+
+        gate = evaluate_validated_signal_gate(now=now)
+        validated_signal_gate = {"allowed": gate.allowed, "reason": gate.reason}
+        if not gate.allowed:
+            confirm = False
+            logger.warning(
+                "demo scalping confirm=true requested but validated-signal gate "
+                "denied (reason=%s) — downgrading this tick to dry-run "
+                "(no real Demo orders)",
+                gate.reason,
+            )
+
     symbols = sorted(DEFAULT_ALLOWLIST)
 
     # Lazy imports so the disabled path triggers zero engine/credential setup.
@@ -133,4 +158,16 @@ async def run_demo_scalping_tick(*, now: dt.datetime | None = None) -> dict[str,
             if aclose is not None:
                 await aclose()
 
-    return {"status": "ran", "confirm": confirm, **summary.to_evidence_dict()}
+    extra: dict[str, Any] = {}
+    if confirm_requested:
+        # Only surface the request/gate keys when confirm was actually
+        # requested; the no-confirm summary shape is left unchanged.
+        extra["confirm_requested"] = confirm_requested
+        if validated_signal_gate is not None:
+            extra["validated_signal_gate"] = validated_signal_gate
+    return {
+        "status": "ran",
+        "confirm": confirm,
+        **extra,
+        **summary.to_evidence_dict(),
+    }

--- a/app/services/brokers/binance/demo_scalping_exec/validated_signal_gate.py
+++ b/app/services/brokers/binance/demo_scalping_exec/validated_signal_gate.py
@@ -1,0 +1,135 @@
+"""ROB-905 — fail-closed validated-signal gate for Demo scalping confirm=true.
+
+Per ROB-316's documented posture, ``confirm=true`` under any recurring
+activation (Prefect / scheduler / TaskIQ / launchd) requires a **separate
+validated-signal gate** — the micro-breakout signal is OOS gross-negative and
+must stay dry-run/observe-only until a validated-signal artifact says
+otherwise. This module enforces that boundary in code so the documented safety
+gate can no longer be bypassed by env flags alone.
+
+The gate reads a JSON artifact whose path is supplied by
+``BINANCE_DEMO_SCALPING_VALIDATED_GATE_PATH`` (default unset). ``confirm=true``
+is honoured only when that artifact:
+
+* exists and is a readable file,
+* parses as a JSON object,
+* declares ``schema == "validated_signal_gate.v1"``,
+* carries ``verdict == "validated"``, and
+* if it has a ``valid_until`` (ISO-8601), that instant is still in the future.
+
+Every other outcome is fail-closed (``allowed=False``) with a distinct,
+machine-readable ``reason``. No exception is ever raised out of this module —
+an unexpected failure resolves to "not allowed", never "allowed".
+
+Design constraint: **stdlib only** (no broker / DB / network / pydantic
+imports). It runs on the order hot path, so it stays dependency-free.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import json
+import os
+from dataclasses import dataclass, field
+from typing import Any
+
+#: Env var naming the gate artifact path. Unset → fail-closed (``gate_path_unset``).
+_GATE_PATH_ENV = "BINANCE_DEMO_SCALPING_VALIDATED_GATE_PATH"
+
+#: Source of truth: ``app.schemas.validated_run_card.GATE_SCHEMA``. Duplicated
+#: here as a bare literal to keep this module stdlib-only (importing the schema
+#: module would pull pydantic onto the order hot path). A unit test
+#: (``test_local_schema_literal_matches_schema_module``) asserts the two never
+#: drift apart.
+_GATE_SCHEMA = "validated_signal_gate.v1"
+
+
+@dataclass(frozen=True)
+class GateDecision:
+    """Outcome of a validated-signal gate evaluation.
+
+    ``allowed`` is the fail-closed verdict; ``reason`` is a stable slug
+    (see module docstring) for logging/telemetry; ``evidence`` is a small,
+    JSON-safe dict for audit context (never contains secrets).
+    """
+
+    allowed: bool
+    reason: str
+    evidence: dict[str, Any] = field(default_factory=dict)
+
+
+def _deny(reason: str, **evidence: Any) -> GateDecision:
+    return GateDecision(allowed=False, reason=reason, evidence=dict(evidence))
+
+
+def _parse_iso8601(value: Any) -> dt.datetime | None:
+    if not isinstance(value, str):
+        return None
+    try:
+        parsed = dt.datetime.fromisoformat(value)
+    except ValueError:
+        return None
+    # Naive timestamps are interpreted as UTC (conservative, comparable).
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=dt.UTC)
+    return parsed
+
+
+def evaluate_validated_signal_gate(*, now: dt.datetime | None = None) -> GateDecision:
+    """Evaluate the validated-signal gate. Fail-closed on every anomaly.
+
+    ``now`` is injectable for deterministic expiry checks; it defaults to the
+    current UTC time.
+    """
+    try:
+        raw_path = os.environ.get(_GATE_PATH_ENV)
+        if not raw_path or not raw_path.strip():
+            return _deny("gate_path_unset")
+        path = raw_path.strip()
+
+        try:
+            with open(path, encoding="utf-8") as fh:
+                text = fh.read()
+        except FileNotFoundError:
+            return _deny("gate_file_missing", path=path)
+        except (IsADirectoryError, PermissionError, OSError) as exc:
+            return _deny("gate_file_unreadable", path=path, error=type(exc).__name__)
+
+        try:
+            data = json.loads(text)
+        except (ValueError, TypeError):
+            return _deny("gate_invalid_json", path=path)
+        if not isinstance(data, dict):
+            return _deny("gate_invalid_json", path=path)
+
+        schema = data.get("schema")
+        if schema != _GATE_SCHEMA:
+            return _deny("gate_schema_mismatch", schema=schema, expected=_GATE_SCHEMA)
+
+        verdict = data.get("verdict")
+        if verdict != "validated":
+            return _deny("gate_verdict_not_validated", verdict=verdict)
+
+        valid_until = data.get("valid_until")
+        if valid_until is not None:
+            parsed = _parse_iso8601(valid_until)
+            if parsed is None:
+                # Unparseable expiry → cannot prove freshness → fail closed.
+                return _deny("gate_expired", valid_until=valid_until)
+            now_dt = now or dt.datetime.now(dt.UTC)
+            if now_dt.tzinfo is None:
+                now_dt = now_dt.replace(tzinfo=dt.UTC)
+            if parsed <= now_dt:
+                return _deny("gate_expired", valid_until=valid_until)
+
+        return GateDecision(
+            allowed=True,
+            reason="validated",
+            evidence={
+                "schema": schema,
+                "verdict": verdict,
+                "valid_until": valid_until,
+            },
+        )
+    except Exception as exc:  # noqa: BLE001 — absolute fail-closed backstop
+        return _deny("gate_file_unreadable", error=type(exc).__name__)

--- a/docs/runbooks/binance-demo-scalping.md
+++ b/docs/runbooks/binance-demo-scalping.md
@@ -316,11 +316,37 @@ exits flat in-run) on each signal. It is **registered with no schedule**
 | `BINANCE_DEMO_SCALPING_ENABLED` | shared feature gate |
 | `BINANCE_DEMO_SCALPING_SCHEDULER_ENABLED` | scheduler **kill switch** |
 | `BINANCE_DEMO_SCALPING_SCHEDULER_CONFIRM` | second key — without it the tick runs signals + risk re-checks but every `execute_monitored` is a **dry-run** (zero broker mutation) |
+| `BINANCE_DEMO_SCALPING_VALIDATED_GATE_PATH` | ROB-905 — path to the validated-signal gate artifact; `SCHEDULER_CONFIRM` is honoured **only** when this passes |
 
 Both `*_ENABLED` flags must be truthy or the tick builds zero clients,
 touches no DB, and returns `{"status": "disabled"}`. **The kill switch is:
 unset `BINANCE_DEMO_SCALPING_SCHEDULER_ENABLED`** (or set it false) — the
 next tick is an immediate no-op.
+
+### Validated-signal gate for `confirm=true` (ROB-905, code-enforced)
+
+Per the ROB-316 posture above, `confirm=true` alone can no longer place real
+Demo orders. `run_demo_scalping_tick` evaluates a **fail-closed validated-signal
+gate** (`app/services/brokers/binance/demo_scalping_exec/validated_signal_gate.py`)
+whenever `BINANCE_DEMO_SCALPING_SCHEDULER_CONFIRM` is truthy. The applied
+`confirm` is downgraded to `False` (the tick still runs — dry-run telemetry
+preserved, zero broker mutation) unless `BINANCE_DEMO_SCALPING_VALIDATED_GATE_PATH`
+points at a readable JSON file with:
+
+```json
+{"schema": "validated_signal_gate.v1", "verdict": "validated"}
+```
+
+An optional `"valid_until"` (ISO-8601) must be in the future or the gate is
+`gate_expired`. Any other outcome (`gate_path_unset` / `gate_file_missing` /
+`gate_file_unreadable` / `gate_invalid_json` / `gate_schema_mismatch` /
+`gate_verdict_not_validated` / `gate_expired`) downgrades to dry-run. When
+confirm was requested the tick summary carries `confirm_requested` and
+`validated_signal_gate: {allowed, reason}` alongside the applied `confirm`.
+Because the current micro-breakout signal is OOS gross-negative, **no validated
+gate artifact should exist yet** — this guard exists so an unpaused Prefect
+deployment with `confirm=true` (as observed in ROB-905) cannot place real Demo
+orders without a validated-signal artifact.
 
 ### Manual invocation (no schedule registered)
 

--- a/docs/runbooks/binance-demo-ws-scalping.md
+++ b/docs/runbooks/binance-demo-ws-scalping.md
@@ -10,6 +10,8 @@
 > - Treat this daemon (and the 5-min Prefect tick in `binance-demo-scalping.md`) as **plumbing / observe / a harness for a future validated signal** — not a strategy-alpha runner.
 > - The current micro-breakout signal must remain **disabled or observe/dry-run only**.
 > - `confirm=true` and any recurring activation (Prefect / scheduler / launchd / TaskIQ) require a **separate validated-signal gate**. Do not enable live Demo order confirmation on this signal.
+>
+> **ROB-905 — the validated-signal gate is now enforced in code** for the 5-min Prefect tick path (`run_demo_scalping_tick`). `BINANCE_DEMO_SCALPING_SCHEDULER_CONFIRM=true` is honoured only when `BINANCE_DEMO_SCALPING_VALIDATED_GATE_PATH` points at a readable `validated_signal_gate.v1` / `verdict: "validated"` (optional future `valid_until`) artifact; otherwise confirm is fail-closed **downgraded to dry-run**. Since no validated signal exists yet, that artifact should not exist and the tick stays dry-run. See `binance-demo-scalping.md` → "Validated-signal gate for `confirm=true`".
 
 ---
 

--- a/env.example
+++ b/env.example
@@ -437,6 +437,21 @@ BINANCE_FUTURES_DEMO_API_KEY=
 BINANCE_FUTURES_DEMO_API_SECRET=
 BINANCE_FUTURES_DEMO_BASE_URL=https://demo-fapi.binance.com
 
+# Demo scalping scheduler tick gates (ROB-307 PR4 / ROB-905). All default-off.
+# Both ENABLED + SCHEDULER_ENABLED must be truthy for the tick to build clients;
+# SCHEDULER_CONFIRM=true requests real Demo orders. ROB-905: SCHEDULER_CONFIRM
+# now takes effect ONLY when a validated-signal gate artifact authorises it.
+# BINANCE_DEMO_SCALPING_VALIDATED_GATE_PATH must point at a readable JSON file
+# with {"schema":"validated_signal_gate.v1","verdict":"validated"} (optional
+# future "valid_until" ISO-8601). If the path is unset / missing / stale /
+# invalid, confirm=true is fail-closed DOWNGRADED to a dry-run tick (no real
+# Demo order). The micro-breakout signal is OOS gross-negative (ROB-316) — do
+# not point this at a validated gate until a validated signal actually exists.
+BINANCE_DEMO_SCALPING_ENABLED=false
+BINANCE_DEMO_SCALPING_SCHEDULER_ENABLED=false
+BINANCE_DEMO_SCALPING_SCHEDULER_CONFIRM=false
+BINANCE_DEMO_SCALPING_VALIDATED_GATE_PATH=
+
 # -----------------------------------------------------------------------------
 # 토스증권 Open API (ROB-529 — KR/US live broker + data source)
 # -----------------------------------------------------------------------------

--- a/tests/services/brokers/binance/demo_scalping_exec/test_runner_from_env.py
+++ b/tests/services/brokers/binance/demo_scalping_exec/test_runner_from_env.py
@@ -7,9 +7,12 @@ are truthy. Verified without creds/DB/network.
 
 from __future__ import annotations
 
+import json
+
 import pytest
 
 from app.jobs.binance_demo_scalping_runner import run_demo_scalping_tick
+from app.schemas.validated_run_card import GATE_SCHEMA
 
 
 def _no_client(monkeypatch) -> None:
@@ -170,3 +173,106 @@ async def test_enabled_runner_uses_one_transaction_per_execution(monkeypatch) ->
     assert len(sessions) == 2
     assert executor_sessions == sessions
     assert [session.commits for session in sessions] == [1, 1]
+
+
+def _arm_enabled_path(monkeypatch) -> list[dict]:
+    """Fake the enabled path (creds/DB/network) and capture run_scalping_tick
+    kwargs so a test can assert the *applied* confirm value.
+    """
+    import app.core.db as dbmod
+    import app.services.brokers.binance.demo_scalping_exec.scheduler as schedmod
+    from app.services.brokers.binance.futures_demo.execution_client import (
+        BinanceFuturesDemoExecutionClient,
+    )
+    from app.services.brokers.binance.spot_demo.execution_client import (
+        BinanceSpotDemoExecutionClient,
+    )
+
+    monkeypatch.setenv("BINANCE_DEMO_SCALPING_ENABLED", "true")
+    monkeypatch.setenv("BINANCE_DEMO_SCALPING_SCHEDULER_ENABLED", "true")
+
+    class _Cli:
+        async def aclose(self):
+            return None
+
+    for cls in (BinanceSpotDemoExecutionClient, BinanceFuturesDemoExecutionClient):
+        monkeypatch.setattr(cls, "from_env", classmethod(lambda cls: _Cli()))
+
+    class _Sess:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+        async def commit(self):
+            return None
+
+    monkeypatch.setattr(dbmod, "AsyncSessionLocal", lambda: _Sess())
+
+    captured: list[dict] = []
+
+    class _Summary:
+        def to_evidence_dict(self):
+            return {"status": "ran", "entered_count": 0, "error_count": 0}
+
+    async def _fake_tick(**kwargs):
+        captured.append(kwargs)
+        return _Summary()
+
+    monkeypatch.setattr(schedmod, "run_scalping_tick", _fake_tick)
+    return captured
+
+
+@pytest.mark.asyncio
+async def test_confirm_requested_but_gate_unset_downgrades_to_dry_run(
+    monkeypatch,
+) -> None:
+    captured = _arm_enabled_path(monkeypatch)
+    monkeypatch.setenv("BINANCE_DEMO_SCALPING_SCHEDULER_CONFIRM", "true")
+    monkeypatch.delenv("BINANCE_DEMO_SCALPING_VALIDATED_GATE_PATH", raising=False)
+
+    result = await run_demo_scalping_tick()
+
+    # The confirm actually passed to the scheduler/executor is downgraded.
+    assert captured[0]["confirm"] is False
+    # Summary reflects both the request and the applied value + gate reason.
+    assert result["confirm_requested"] is True
+    assert result["confirm"] is False
+    assert result["validated_signal_gate"]["allowed"] is False
+    assert result["validated_signal_gate"]["reason"] == "gate_path_unset"
+
+
+@pytest.mark.asyncio
+async def test_confirm_requested_with_valid_gate_applies_confirm(
+    monkeypatch, tmp_path
+) -> None:
+    captured = _arm_enabled_path(monkeypatch)
+    gate = tmp_path / "gate.json"
+    gate.write_text(
+        json.dumps({"schema": GATE_SCHEMA, "verdict": "validated"}), encoding="utf-8"
+    )
+    monkeypatch.setenv("BINANCE_DEMO_SCALPING_SCHEDULER_CONFIRM", "true")
+    monkeypatch.setenv("BINANCE_DEMO_SCALPING_VALIDATED_GATE_PATH", str(gate))
+
+    result = await run_demo_scalping_tick()
+
+    assert captured[0]["confirm"] is True
+    assert result["confirm_requested"] is True
+    assert result["confirm"] is True
+    assert result["validated_signal_gate"]["allowed"] is True
+
+
+@pytest.mark.asyncio
+async def test_confirm_not_requested_leaves_summary_unchanged(monkeypatch) -> None:
+    captured = _arm_enabled_path(monkeypatch)
+    monkeypatch.delenv("BINANCE_DEMO_SCALPING_SCHEDULER_CONFIRM", raising=False)
+    monkeypatch.delenv("BINANCE_DEMO_SCALPING_VALIDATED_GATE_PATH", raising=False)
+
+    result = await run_demo_scalping_tick()
+
+    assert captured[0]["confirm"] is False
+    assert result["confirm"] is False
+    # No gate evaluation, no new keys when confirm was never requested.
+    assert "validated_signal_gate" not in result
+    assert "confirm_requested" not in result

--- a/tests/services/brokers/binance/demo_scalping_exec/test_validated_signal_gate.py
+++ b/tests/services/brokers/binance/demo_scalping_exec/test_validated_signal_gate.py
@@ -1,0 +1,170 @@
+"""ROB-905 — fail-closed validated-signal gate for Demo scalping confirm=true.
+
+The gate reads a JSON artifact whose path is given by
+``BINANCE_DEMO_SCALPING_VALIDATED_GATE_PATH``. ``confirm=true`` may only take
+effect when the artifact exists, parses, carries the
+``validated_signal_gate.v1`` schema, a ``validated`` verdict, and (if present)
+a future ``valid_until``. Every other case is fail-closed (``allowed=False``)
+with a distinct, machine-readable ``reason``; no exception ever escapes.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import json
+
+from app.schemas.validated_run_card import GATE_SCHEMA
+from app.services.brokers.binance.demo_scalping_exec.validated_signal_gate import (
+    _GATE_PATH_ENV,
+    _GATE_SCHEMA,
+    GateDecision,
+    evaluate_validated_signal_gate,
+)
+
+_ENV = _GATE_PATH_ENV
+
+
+def _write(tmp_path, payload, *, name="gate.json") -> str:
+    p = tmp_path / name
+    p.write_text(json.dumps(payload), encoding="utf-8")
+    return str(p)
+
+
+def test_local_schema_literal_matches_schema_module() -> None:
+    # The stdlib-only module duplicates the literal; it must not drift.
+    assert _GATE_SCHEMA == GATE_SCHEMA
+
+
+def test_gate_path_unset(monkeypatch) -> None:
+    monkeypatch.delenv(_ENV, raising=False)
+    decision = evaluate_validated_signal_gate()
+    assert isinstance(decision, GateDecision)
+    assert decision.allowed is False
+    assert decision.reason == "gate_path_unset"
+
+
+def test_gate_path_blank(monkeypatch) -> None:
+    monkeypatch.setenv(_ENV, "   ")
+    decision = evaluate_validated_signal_gate()
+    assert decision.allowed is False
+    assert decision.reason == "gate_path_unset"
+
+
+def test_gate_file_missing(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv(_ENV, str(tmp_path / "does_not_exist.json"))
+    decision = evaluate_validated_signal_gate()
+    assert decision.allowed is False
+    assert decision.reason == "gate_file_missing"
+
+
+def test_gate_file_unreadable(monkeypatch, tmp_path) -> None:
+    # A directory path is not a readable file → OSError, fail closed.
+    d = tmp_path / "a_dir"
+    d.mkdir()
+    monkeypatch.setenv(_ENV, str(d))
+    decision = evaluate_validated_signal_gate()
+    assert decision.allowed is False
+    assert decision.reason in {"gate_file_unreadable", "gate_file_missing"}
+    # A directory specifically must not be reported as a valid pass.
+    assert decision.reason == "gate_file_unreadable"
+
+
+def test_gate_invalid_json(monkeypatch, tmp_path) -> None:
+    p = tmp_path / "bad.json"
+    p.write_text("{not valid json", encoding="utf-8")
+    monkeypatch.setenv(_ENV, str(p))
+    decision = evaluate_validated_signal_gate()
+    assert decision.allowed is False
+    assert decision.reason == "gate_invalid_json"
+
+
+def test_gate_json_not_object(monkeypatch, tmp_path) -> None:
+    p = tmp_path / "arr.json"
+    p.write_text("[1, 2, 3]", encoding="utf-8")
+    monkeypatch.setenv(_ENV, str(p))
+    decision = evaluate_validated_signal_gate()
+    assert decision.allowed is False
+    assert decision.reason == "gate_invalid_json"
+
+
+def test_gate_schema_mismatch(monkeypatch, tmp_path) -> None:
+    path = _write(tmp_path, {"schema": "something_else.v1", "verdict": "validated"})
+    monkeypatch.setenv(_ENV, path)
+    decision = evaluate_validated_signal_gate()
+    assert decision.allowed is False
+    assert decision.reason == "gate_schema_mismatch"
+
+
+def test_gate_verdict_not_validated(monkeypatch, tmp_path) -> None:
+    path = _write(tmp_path, {"schema": GATE_SCHEMA, "verdict": "not_validated"})
+    monkeypatch.setenv(_ENV, path)
+    decision = evaluate_validated_signal_gate()
+    assert decision.allowed is False
+    assert decision.reason == "gate_verdict_not_validated"
+
+
+def test_gate_verdict_missing(monkeypatch, tmp_path) -> None:
+    path = _write(tmp_path, {"schema": GATE_SCHEMA})
+    monkeypatch.setenv(_ENV, path)
+    decision = evaluate_validated_signal_gate()
+    assert decision.allowed is False
+    assert decision.reason == "gate_verdict_not_validated"
+
+
+def test_gate_expired(monkeypatch, tmp_path) -> None:
+    past = "2020-01-01T00:00:00+00:00"
+    path = _write(
+        tmp_path,
+        {"schema": GATE_SCHEMA, "verdict": "validated", "valid_until": past},
+    )
+    monkeypatch.setenv(_ENV, path)
+    decision = evaluate_validated_signal_gate()
+    assert decision.allowed is False
+    assert decision.reason == "gate_expired"
+
+
+def test_gate_expired_unparseable_valid_until(monkeypatch, tmp_path) -> None:
+    # Unparseable expiry is fail-closed, not silently allowed.
+    path = _write(
+        tmp_path,
+        {"schema": GATE_SCHEMA, "verdict": "validated", "valid_until": "not-a-date"},
+    )
+    monkeypatch.setenv(_ENV, path)
+    decision = evaluate_validated_signal_gate()
+    assert decision.allowed is False
+    assert decision.reason == "gate_expired"
+
+
+def test_gate_valid_no_expiry(monkeypatch, tmp_path) -> None:
+    path = _write(tmp_path, {"schema": GATE_SCHEMA, "verdict": "validated"})
+    monkeypatch.setenv(_ENV, path)
+    decision = evaluate_validated_signal_gate()
+    assert decision.allowed is True
+    assert decision.reason == "validated"
+
+
+def test_gate_valid_future_expiry(monkeypatch, tmp_path) -> None:
+    future = "2999-01-01T00:00:00+00:00"
+    path = _write(
+        tmp_path,
+        {"schema": GATE_SCHEMA, "verdict": "validated", "valid_until": future},
+    )
+    monkeypatch.setenv(_ENV, path)
+    decision = evaluate_validated_signal_gate()
+    assert decision.allowed is True
+    assert decision.reason == "validated"
+
+
+def test_gate_expiry_uses_injected_now(monkeypatch, tmp_path) -> None:
+    valid_until = "2026-01-01T00:00:00+00:00"
+    path = _write(
+        tmp_path,
+        {"schema": GATE_SCHEMA, "verdict": "validated", "valid_until": valid_until},
+    )
+    monkeypatch.setenv(_ENV, path)
+
+    before = dt.datetime(2025, 12, 31, tzinfo=dt.UTC)
+    after = dt.datetime(2026, 1, 2, tzinfo=dt.UTC)
+    assert evaluate_validated_signal_gate(now=before).allowed is True
+    assert evaluate_validated_signal_gate(now=after).allowed is False
+    assert evaluate_validated_signal_gate(now=after).reason == "gate_expired"


### PR DESCRIPTION
## ROB-905 (Urgent)

[ROB-905](https://linear.app/mgh3326/issue/ROB-905) — *[mock_binance] Binance Demo 스캘핑 5분 틱이 confirm=true로 상시 가동 중 — ROB-316 문서 자세(dry-run only) 위반*

The Prefect deployment `Binance Demo Scalping Tick/every-5-min` was observed **unpaused + confirm=true** (interval 300s), directly contradicting the runbook posture that `confirm=true` under any recurring activation requires a **separate validated-signal gate** (ROB-316: the micro-breakout signal is OOS gross-negative). The gate existed only as documentation. This PR makes it a **code check** so `confirm=true` cannot take effect without a validated-signal artifact. Demo-only (no real funds), but it restores the documented safety boundary.

> Immediate mitigation (Prefect pause / env unset) remains the operator's job — this PR does not touch ops/Prefect config.

## Contract

1. **New fail-closed gate module** `app/services/brokers/binance/demo_scalping_exec/validated_signal_gate.py` (stdlib-only — no broker/DB/network/pydantic on the order hot path). `evaluate_validated_signal_gate() -> GateDecision(allowed, reason, evidence)`:
   - `allowed=True` only when `BINANCE_DEMO_SCALPING_VALIDATED_GATE_PATH` points at a readable JSON object with `schema == "validated_signal_gate.v1"` + `verdict == "validated"`, and any `valid_until` (ISO-8601) is in the future.
   - Distinct fail-closed reasons: `gate_path_unset` / `gate_file_missing` / `gate_file_unreadable` / `gate_invalid_json` / `gate_schema_mismatch` / `gate_verdict_not_validated` / `gate_expired`. No exception escapes.
   - The `validated_signal_gate.v1` literal is duplicated from `app/schemas/validated_run_card.GATE_SCHEMA` (kept stdlib-only) with a unit test asserting they never drift.
2. **Runner wiring** (`app/jobs/binance_demo_scalping_runner.py`): when `BINANCE_DEMO_SCALPING_SCHEDULER_CONFIRM` is truthy, evaluate the gate; if denied, **downgrade the applied `confirm` to `False`** — the tick still runs (dry-run telemetry preserved, zero broker mutation), never crashes. Summary gains `confirm_requested` + `validated_signal_gate: {allowed, reason}` **only when confirm was requested**; the no-confirm summary shape is unchanged, and `confirm` still means the *applied* value. Disabled path (base/scheduler off) untouched.
3. **Docs**: `docs/runbooks/binance-demo-scalping.md` + `binance-demo-ws-scalping.md` document the code-enforced gate; `env.example` adds `BINANCE_DEMO_SCALPING_VALIDATED_GATE_PATH` (+ the two existing scheduler gates) with commentary.
4. **No** Prefect/ops changes, **no** executor/scheduler semantic changes, **no** DB table/column/migration (single alembic head unchanged), **no** MCP tool changes.

## Tests (TDD — RED first)

- New `tests/services/brokers/binance/demo_scalping_exec/test_validated_signal_gate.py` — every reason case (unset/blank/missing/unreadable-dir/invalid-json/non-object/schema-mismatch/verdict-not-validated/verdict-missing/expired/unparseable-expiry/valid-no-expiry/valid-future-expiry/injected-now) + literal-sync assertion.
- Extended `test_runner_from_env.py`: (a) confirm env=true + gate unset → applied `confirm=False`, summary `confirm_requested=true`, `confirm=false`, `validated_signal_gate.reason=="gate_path_unset"`; (b) confirm env=true + valid gate file → `confirm=True`; (c) confirm env unset → summary unchanged (no new keys).

```
uv run pytest tests/services/brokers/binance/demo_scalping_exec/ tests/scripts/test_binance_demo_scalping_tick.py -q   # 89 passed
uv run pytest tests/services/brokers/binance/demo_scalping/ -q                                                          # 120 passed
make lint            # ruff check + format + ty → all pass
git diff --check     # clean
uv run alembic heads # single head, no new migration
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)