### PR TITLE
feat(ROB-907): tick blocked reason_codes + binance_demo_ledger_status read-only MCP tool

### DIFF
--- a/app/mcp_server/tooling/binance_demo_ledger_status_read.py
+++ b/app/mcp_server/tooling/binance_demo_ledger_status_read.py
@@ -1,0 +1,145 @@
+"""ROB-907 — Read-only MCP tool for the Binance Demo order ledger.
+
+Operational point-in-time status of ``binance_demo_order_ledger`` (state
+distribution, stuck-open roots, anomaly count, freshness) without a direct
+production DB SELECT fallback. No broker call, no DB write, no secrets.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from typing import TYPE_CHECKING, Any, cast
+
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from app.core.db import AsyncSessionLocal
+from app.models.binance_demo_order_ledger import BLOCKING_ROOT_LIFECYCLE_STATES
+from app.services.brokers.binance.demo.ledger import BinanceDemoLedgerService
+
+if TYPE_CHECKING:
+    from fastmcp import FastMCP
+
+_MAX_RECENT_LIMIT = 200
+_MAX_STALE_ROOTS = 50
+
+
+def _session_factory() -> async_sessionmaker[AsyncSession]:
+    return cast(async_sessionmaker[AsyncSession], cast(object, AsyncSessionLocal))
+
+
+def _isoformat(value: Any) -> Any:
+    if hasattr(value, "isoformat"):
+        return value.isoformat()
+    return value
+
+
+def _row_to_dict(row: Any) -> dict[str, Any]:
+    d: dict[str, Any] = {}
+    for col in row.__table__.columns:
+        val = getattr(row, col.name)
+        if hasattr(val, "isoformat"):
+            val = val.isoformat()
+        elif hasattr(val, "__str__") and not isinstance(
+            val, (str, int, float, bool, type(None), dict, list)
+        ):
+            val = str(val)
+        d[col.name] = val
+    return d
+
+
+def _stale_root_summary(row: Any, *, as_of: dt.datetime) -> dict[str, Any]:
+    planned_at = row.planned_at
+    age_seconds = (
+        (as_of - planned_at).total_seconds() if planned_at is not None else None
+    )
+    return {
+        "client_order_id": row.client_order_id,
+        "product": row.product,
+        "instrument_id": row.instrument_id,
+        "lifecycle_state": row.lifecycle_state,
+        "planned_at": _isoformat(planned_at),
+        "age_seconds": age_seconds,
+    }
+
+
+async def binance_demo_ledger_status(
+    stale_age_seconds: int = 3600,
+    recent_limit: int = 20,
+) -> dict[str, Any]:
+    """Read-only status summary of the Binance Demo order ledger.
+
+    Args:
+        stale_age_seconds: An open root lifecycle (planned/previewed/validated/
+            submitted/filled/anomaly, ``parent_client_order_id IS NULL``) older
+            than this many seconds is surfaced in ``stale_open_roots``.
+        recent_limit: Number of most-recently-updated rows to include in
+            ``recent`` (default 20, max 200).
+
+    Returns a dict with ``status_distribution`` (lifecycle_state -> count,
+    table-wide across products), ``open_root_count`` (blocking root
+    lifecycles — the same definition the executor's capacity gate uses),
+    ``anomaly_count``, ``stale_open_roots`` (bounded, oldest first),
+    ``latest_activity_at``, ``recent`` (bounded), and ``as_of``.
+
+    No broker call. No database write.
+    """
+    if stale_age_seconds < 0:
+        raise ValueError("stale_age_seconds must be >= 0")
+    if recent_limit < 1:
+        raise ValueError("recent_limit must be >= 1")
+    recent_limit = min(recent_limit, _MAX_RECENT_LIMIT)
+
+    as_of = dt.datetime.now(dt.UTC)
+    older_than = as_of - dt.timedelta(seconds=stale_age_seconds)
+
+    async with _session_factory()() as db:
+        svc = BinanceDemoLedgerService(db)
+        status_distribution = await svc.status_distribution()
+        open_root_count = await svc.count_open_lifecycles()
+        stale_roots = await svc.stale_open_roots(
+            older_than=older_than, limit=_MAX_STALE_ROOTS
+        )
+        latest_activity_at = await svc.latest_activity_at()
+        recent = await svc.list_recent(limit=recent_limit)
+
+    anomaly_count = sum(
+        count for state, count in status_distribution.items() if state == "anomaly"
+    )
+
+    return {
+        "success": True,
+        "source": "binance_demo_order_ledger",
+        "read_only": True,
+        "status_distribution": status_distribution,
+        "open_root_states": list(BLOCKING_ROOT_LIFECYCLE_STATES),
+        "open_root_count": open_root_count,
+        "anomaly_count": anomaly_count,
+        "stale_age_seconds": stale_age_seconds,
+        "stale_open_roots": [
+            _stale_root_summary(row, as_of=as_of) for row in stale_roots
+        ],
+        "latest_activity_at": _isoformat(latest_activity_at),
+        "recent_limit": recent_limit,
+        "recent": [_row_to_dict(row) for row in recent],
+        "as_of": as_of.isoformat(),
+    }
+
+
+def register_binance_demo_ledger_status_tool(mcp: FastMCP) -> None:
+    """Register the read-only Binance Demo ledger status MCP tool."""
+    _ = mcp.tool(
+        name="binance_demo_ledger_status",
+        description=(
+            "Read-only Binance Demo order ledger status: lifecycle_state "
+            "distribution (table-wide), open root lifecycle count, anomaly "
+            "count, stale (stuck-open) root lifecycles older than "
+            "stale_age_seconds, latest activity timestamp, and a bounded "
+            "recent-activity list. No broker call, no database write."
+        ),
+    )(binance_demo_ledger_status)
+
+
+__all__ = [
+    "binance_demo_ledger_status",
+    "register_binance_demo_ledger_status_tool",
+]

--- a/app/mcp_server/tooling/registry.py
+++ b/app/mcp_server/tooling/registry.py
@@ -346,11 +346,17 @@ def register_all_tools(mcp: FastMCP, profile: McpProfile = McpProfile.DEFAULT) -
 
             register_kiwoom_us(mcp)
         if settings.binance_demo_scalping_enabled:
+            from app.mcp_server.tooling.binance_demo_ledger_status_read import (
+                register_binance_demo_ledger_status_tool,
+            )
             from app.mcp_server.tooling.binance_demo_scalping_handler import (
                 register_binance_demo_scalping_tools,
             )
 
             register_binance_demo_scalping_tools(mcp)
+            # ROB-907: read-only ledger status alongside the scalping submit
+            # tool — same gate, since both are Demo-scalping observability.
+            register_binance_demo_ledger_status_tool(mcp)
     elif profile is McpProfile.HERMES_PAPER_KIS:
         # Paper-only: only mock-pinned order surface. Live surface is physically absent.
         register_kis_mock_order_tools(mcp)

--- a/app/mcp_server/tooling/route_request_lanes.py
+++ b/app/mcp_server/tooling/route_request_lanes.py
@@ -271,6 +271,11 @@ READ_ONLY_ADVISORY_TOOLS: frozenset[str] = frozenset(
         "analyze_portfolio",
         "analyze_stock",
         "analyze_stock_batch",
+        # ROB-907: read-only Demo ledger status (flag-gated —
+        # settings.binance_demo_scalping_enabled — like binance_demo_scalping_
+        # submit_decision itself, which is a mutation tool and lives outside
+        # this bucket).
+        "binance_demo_ledger_status",
         "execution_ledger_fill_events_list_recent",
         "forecast_resolve",
         "forecast_save",

--- a/app/services/brokers/binance/demo/ledger/repository.py
+++ b/app/services/brokers/binance/demo/ledger/repository.py
@@ -412,6 +412,60 @@ class BinanceDemoLedgerRepository:
         )
         return list(result.scalars().all())
 
+    # ------------------------------------------------------------------
+    # Read-only observability surface (ROB-907 — binance_demo_ledger_status).
+    # ------------------------------------------------------------------
+
+    async def status_distribution(self) -> dict[str, int]:
+        """Table-wide row count per ``lifecycle_state`` (all products)."""
+        result = await self._session.execute(
+            select(
+                BinanceDemoOrderLedger.lifecycle_state,
+                func.count(),
+            ).group_by(BinanceDemoOrderLedger.lifecycle_state)
+        )
+        return dict(result.all())
+
+    async def list_recent(
+        self, *, limit: int, lifecycle_state: str | None = None
+    ) -> list[BinanceDemoOrderLedger]:
+        """Most recently updated rows, newest first, optionally state-filtered."""
+        stmt = select(BinanceDemoOrderLedger).order_by(
+            BinanceDemoOrderLedger.updated_at.desc()
+        )
+        if lifecycle_state is not None:
+            stmt = stmt.where(BinanceDemoOrderLedger.lifecycle_state == lifecycle_state)
+        stmt = stmt.limit(limit)
+        result = await self._session.execute(stmt)
+        return list(result.scalars().all())
+
+    async def stale_open_roots(
+        self, *, older_than: dt.datetime, limit: int
+    ) -> list[BinanceDemoOrderLedger]:
+        """Open *root* lifecycles planned at/before ``older_than``, oldest first.
+
+        Root-only (``parent_client_order_id IS NULL``) — a close/reduce-only
+        child leg is never a stuck exposure by itself.
+        """
+        stmt = (
+            select(BinanceDemoOrderLedger)
+            .where(
+                BinanceDemoOrderLedger.parent_client_order_id.is_(None),
+                BinanceDemoOrderLedger.lifecycle_state.in_(OPEN_LIFECYCLE_STATES),
+                BinanceDemoOrderLedger.planned_at <= older_than,
+            )
+            .order_by(BinanceDemoOrderLedger.planned_at.asc())
+            .limit(limit)
+        )
+        result = await self._session.execute(stmt)
+        return list(result.scalars().all())
+
+    async def latest_activity_at(self) -> dt.datetime | None:
+        """Table-wide ``max(updated_at)`` — freshness signal for the ledger."""
+        return await self._session.scalar(
+            select(func.max(BinanceDemoOrderLedger.updated_at))
+        )
+
     async def update_state(
         self,
         row: BinanceDemoOrderLedger,

--- a/app/services/brokers/binance/demo/ledger/service.py
+++ b/app/services/brokers/binance/demo/ledger/service.py
@@ -213,6 +213,28 @@ class BinanceDemoLedgerService:
     ) -> list[BinanceDemoOrderLedger]:
         return await self._repo.closed_rows_since(since=since)
 
+    # ------------------------------------------------------------------
+    # Read-only observability surface (ROB-907 — binance_demo_ledger_status).
+    # ------------------------------------------------------------------
+
+    async def status_distribution(self) -> dict[str, int]:
+        return await self._repo.status_distribution()
+
+    async def list_recent(
+        self, *, limit: int, lifecycle_state: str | None = None
+    ) -> list[BinanceDemoOrderLedger]:
+        return await self._repo.list_recent(
+            limit=limit, lifecycle_state=lifecycle_state
+        )
+
+    async def stale_open_roots(
+        self, *, older_than: dt.datetime, limit: int
+    ) -> list[BinanceDemoOrderLedger]:
+        return await self._repo.stale_open_roots(older_than=older_than, limit=limit)
+
+    async def latest_activity_at(self) -> dt.datetime | None:
+        return await self._repo.latest_activity_at()
+
     async def record_planned(
         self,
         *,

--- a/app/services/brokers/binance/demo_scalping_exec/scheduler.py
+++ b/app/services/brokers/binance/demo_scalping_exec/scheduler.py
@@ -44,7 +44,11 @@ logger = logging.getLogger(__name__)
 @dataclass(frozen=True)
 class TickSummary:
     status: str  # "disabled" | "ran"
-    entered: list[tuple[str, str, str]] = field(default_factory=list)
+    # (product, symbol, status, reason_codes) — reason_codes surfaces the
+    # executor's blocked/dry_run/reconciled/anomaly reason vocabulary
+    # (ROB-907) so Prefect logs carry enough signal to diagnose all-blocked
+    # runs without a DB read.
+    entered: list[tuple[str, str, str, list[str]]] = field(default_factory=list)
     errors: list[str] = field(default_factory=list)
 
     def to_evidence_dict(self) -> dict[str, Any]:
@@ -84,7 +88,7 @@ async def run_scalping_tick(
         return TickSummary(status="disabled")
 
     limits = limits or ScalpingRiskLimits()
-    entered: list[tuple[str, str, str]] = []
+    entered: list[tuple[str, str, str, list[str]]] = []
     errors: list[str] = []
     monitor_kwargs = monitor_kwargs or {}
 
@@ -131,7 +135,9 @@ async def run_scalping_tick(
                 result = await executor.execute_monitored(
                     intent, confirm=confirm, market=market, **monitor_kwargs
                 )
-                entered.append((product, symbol, result.status))
+                entered.append(
+                    (product, symbol, result.status, sorted(result.reason_codes))
+                )
             except Exception as exc:  # noqa: BLE001
                 errors.append(f"enter {product}/{symbol}: {exc}")
 

--- a/docs/runbooks/binance-demo-scalping.md
+++ b/docs/runbooks/binance-demo-scalping.md
@@ -369,3 +369,37 @@ approval. Failure-only alerting wires onto the tick's error log
 (`logger.error` / the `TickSummary.errors` list) and the CLI's non-zero exit; a
 clean tick is quiet. Rollback = unset `BINANCE_DEMO_SCALPING_SCHEDULER_ENABLED`
 (kill switch) and pause the deployment in the ops repo.
+
+## Observability (ROB-907)
+
+Each tick's `entered` evidence tuple is `[product, symbol, status, reason_codes]`
+— `reason_codes` (e.g. `spread_too_wide`, `stale_data`, `global_lifecycle_cap_
+reached`, `daily_order_cap_reached`) is the executor's own preflight vocabulary
+(`app/services/brokers/binance/demo_scalping/contract.py::ReasonCode`), so a
+Prefect log line for an all-`blocked` tick is enough to diagnose the cause
+without a DB read.
+
+### `binance_demo_ledger_status` MCP tool (read-only)
+
+Use this tool instead of a direct production-DB `SELECT` to check
+`binance_demo_order_ledger` health during an operational review — state
+distribution (`anomaly` / unresolved `planned`·`submitted` / `reconciled`
+ratio), stuck-open root lifecycles, and freshness. Gated the same as
+`binance_demo_scalping_submit_decision` (`settings.binance_demo_scalping_
+enabled`, default off) and registered in the DEFAULT MCP profile.
+
+```
+binance_demo_ledger_status(stale_age_seconds=3600, recent_limit=20)
+→ {
+    "status_distribution": {"planned": 1, "reconciled": 12, "anomaly": 0, ...},
+    "open_root_count": 1,          # blocking root lifecycles — same definition
+                                    # the executor's capacity gate uses
+    "anomaly_count": 0,
+    "stale_open_roots": [...],     # open roots planned_at <= now - stale_age_seconds
+    "latest_activity_at": "2026-07-16T12:00:00+00:00",
+    "recent": [...],               # bounded by recent_limit (<= 200)
+    "as_of": "2026-07-16T12:05:00+00:00",
+  }
+```
+
+No broker call, no ledger write.

--- a/tests/mcp_server/test_binance_demo_ledger_status_tool.py
+++ b/tests/mcp_server/test_binance_demo_ledger_status_tool.py
@@ -1,0 +1,228 @@
+"""ROB-907 — tests for the read-only binance_demo_ledger_status MCP tool.
+
+No broker call, no DB write. The ledger service is mocked; these tests
+exercise response shape, limit/validation guards, and the same DEFAULT-
+profile flag gate (settings.binance_demo_scalping_enabled) as the existing
+binance_demo_scalping_submit_decision tool.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.mcp_server.profiles import McpProfile
+from app.mcp_server.tooling import registry as registry_mod
+from app.mcp_server.tooling.registry import register_all_tools
+from tests._mcp_tooling_support import DummyMCP
+
+_TOOL = "binance_demo_ledger_status"
+
+
+def _fake_recent_row(**kwargs: Any) -> SimpleNamespace:
+    defaults: dict[str, Any] = {
+        "id": 1,
+        "client_order_id": "demo-recent-1",
+        "product": "spot",
+        "lifecycle_state": "reconciled",
+        "planned_at": dt.datetime(2026, 5, 22, 12, 0, 0, tzinfo=dt.UTC),
+        "__table__": SimpleNamespace(
+            columns=[
+                SimpleNamespace(name="id"),
+                SimpleNamespace(name="client_order_id"),
+                SimpleNamespace(name="product"),
+                SimpleNamespace(name="lifecycle_state"),
+                SimpleNamespace(name="planned_at"),
+            ]
+        ),
+    }
+    defaults.update(kwargs)
+    return SimpleNamespace(**defaults)
+
+
+def _fake_stale_row(**kwargs: Any) -> SimpleNamespace:
+    defaults: dict[str, Any] = {
+        "client_order_id": "demo-stale-1",
+        "product": "usdm_futures",
+        "instrument_id": 42,
+        "lifecycle_state": "planned",
+        "planned_at": dt.datetime(2026, 5, 1, 0, 0, 0, tzinfo=dt.UTC),
+    }
+    defaults.update(kwargs)
+    return SimpleNamespace(**defaults)
+
+
+def _mock_svc(
+    *,
+    status_distribution: dict[str, int] | None = None,
+    open_root_count: int = 0,
+    stale_roots: list[Any] | None = None,
+    latest_activity_at: dt.datetime | None = None,
+    recent: list[Any] | None = None,
+) -> AsyncMock:
+    svc = AsyncMock()
+    svc.status_distribution = AsyncMock(
+        return_value=status_distribution
+        if status_distribution is not None
+        else {"planned": 1, "reconciled": 3, "anomaly": 1}
+    )
+    svc.count_open_lifecycles = AsyncMock(return_value=open_root_count)
+    svc.stale_open_roots = AsyncMock(
+        return_value=stale_roots if stale_roots is not None else []
+    )
+    svc.latest_activity_at = AsyncMock(return_value=latest_activity_at)
+    svc.list_recent = AsyncMock(return_value=recent if recent is not None else [])
+    return svc
+
+
+class _FakeDB:
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *a):
+        pass
+
+
+def _patch_ledger_service(monkeypatch, mod, mock_svc) -> None:
+    monkeypatch.setattr(mod, "_session_factory", lambda: lambda: _FakeDB())
+    monkeypatch.setattr(
+        "app.mcp_server.tooling.binance_demo_ledger_status_read.BinanceDemoLedgerService",
+        lambda db: mock_svc,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Response shape
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_status_returns_expected_shape(monkeypatch):
+    import app.mcp_server.tooling.binance_demo_ledger_status_read as mod
+
+    mock_svc = _mock_svc(
+        status_distribution={"planned": 2, "reconciled": 5, "anomaly": 1},
+        open_root_count=2,
+        stale_roots=[_fake_stale_row()],
+        latest_activity_at=dt.datetime(2026, 7, 16, 12, 0, 0, tzinfo=dt.UTC),
+        recent=[_fake_recent_row()],
+    )
+    _patch_ledger_service(monkeypatch, mod, mock_svc)
+
+    result = await mod.binance_demo_ledger_status(
+        stale_age_seconds=3600, recent_limit=10
+    )
+
+    assert result["success"] is True
+    assert result["read_only"] is True
+    assert result["status_distribution"] == {
+        "planned": 2,
+        "reconciled": 5,
+        "anomaly": 1,
+    }
+    assert result["open_root_count"] == 2
+    assert result["anomaly_count"] == 1
+    assert result["stale_age_seconds"] == 3600
+    assert len(result["stale_open_roots"]) == 1
+    assert result["stale_open_roots"][0]["client_order_id"] == "demo-stale-1"
+    assert result["stale_open_roots"][0]["age_seconds"] > 0
+    assert result["latest_activity_at"] == "2026-07-16T12:00:00+00:00"
+    assert result["recent_limit"] == 10
+    assert len(result["recent"]) == 1
+    assert result["recent"][0]["client_order_id"] == "demo-recent-1"
+    assert "as_of" in result
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_status_anomaly_count_zero_when_absent(monkeypatch):
+    import app.mcp_server.tooling.binance_demo_ledger_status_read as mod
+
+    mock_svc = _mock_svc(status_distribution={"planned": 1})
+    _patch_ledger_service(monkeypatch, mod, mock_svc)
+
+    result = await mod.binance_demo_ledger_status()
+    assert result["anomaly_count"] == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_status_latest_activity_at_none_when_ledger_empty(monkeypatch):
+    import app.mcp_server.tooling.binance_demo_ledger_status_read as mod
+
+    mock_svc = _mock_svc(status_distribution={}, latest_activity_at=None)
+    _patch_ledger_service(monkeypatch, mod, mock_svc)
+
+    result = await mod.binance_demo_ledger_status()
+    assert result["latest_activity_at"] is None
+    assert result["status_distribution"] == {}
+
+
+# ---------------------------------------------------------------------------
+# Validation / caps
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_recent_limit_capped_at_200(monkeypatch):
+    import app.mcp_server.tooling.binance_demo_ledger_status_read as mod
+
+    mock_svc = _mock_svc()
+    _patch_ledger_service(monkeypatch, mod, mock_svc)
+
+    result = await mod.binance_demo_ledger_status(recent_limit=999)
+    assert result["recent_limit"] == 200
+    mock_svc.list_recent.assert_awaited_once_with(limit=200)
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_recent_limit_below_one_raises():
+    from app.mcp_server.tooling.binance_demo_ledger_status_read import (
+        binance_demo_ledger_status,
+    )
+
+    with pytest.raises(ValueError, match="recent_limit must be >= 1"):
+        await binance_demo_ledger_status(recent_limit=0)
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_negative_stale_age_seconds_raises():
+    from app.mcp_server.tooling.binance_demo_ledger_status_read import (
+        binance_demo_ledger_status,
+    )
+
+    with pytest.raises(ValueError, match="stale_age_seconds must be >= 0"):
+        await binance_demo_ledger_status(stale_age_seconds=-1)
+
+
+# ---------------------------------------------------------------------------
+# Registry gate — same DEFAULT-profile flag as binance_demo_scalping_submit_decision
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_tool_absent_when_gate_off(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        registry_mod.settings, "binance_demo_scalping_enabled", False, raising=False
+    )
+    mcp = DummyMCP()
+    register_all_tools(cast(Any, mcp), profile=McpProfile.DEFAULT)
+    assert _TOOL not in set(mcp.tools.keys())
+
+
+@pytest.mark.unit
+def test_tool_present_when_gate_on(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        registry_mod.settings, "binance_demo_scalping_enabled", True, raising=False
+    )
+    mcp = DummyMCP()
+    register_all_tools(cast(Any, mcp), profile=McpProfile.DEFAULT)
+    assert _TOOL in set(mcp.tools.keys())

--- a/tests/scripts/test_binance_demo_scalping_tick.py
+++ b/tests/scripts/test_binance_demo_scalping_tick.py
@@ -61,6 +61,31 @@ def test_main_returns_one_when_tick_has_errors(
     assert out["error_count"] == 1
 
 
+def test_main_prints_entered_reason_codes_when_present(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """ROB-907: the CLI is a thin JSON passthrough — a blocked entry's
+    reason_codes (produced upstream by run_scalping_tick's TickSummary) must
+    reach stdout unmodified so Prefect logs carry the diagnosis."""
+
+    async def _fake_tick() -> dict:
+        return {
+            "status": "ran",
+            "error_count": 0,
+            "entered_count": 1,
+            "entered": [["usdm_futures", "XRPUSDT", "blocked", ["spread_too_wide"]]],
+            "errors": [],
+        }
+
+    monkeypatch.setattr(cli, "run_demo_scalping_tick", _fake_tick)
+    rc = cli.main([])
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out.strip())
+    assert out["entered"] == [
+        ["usdm_futures", "XRPUSDT", "blocked", ["spread_too_wide"]]
+    ]
+
+
 def test_main_returns_one_and_emits_error_json_on_exception(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:

--- a/tests/services/brokers/binance/demo/test_ledger_service.py
+++ b/tests/services/brokers/binance/demo/test_ledger_service.py
@@ -266,6 +266,117 @@ async def test_native_fill_actuals_are_write_once_across_lifecycle(
 
 
 # ---------------------------------------------------------------------------
+# ROB-907 — read-only observability surface (binance_demo_ledger_status)
+#
+# The ledger table is shared across the whole test session, so these tests
+# assert membership/delta against rows this test itself creates rather than
+# exact table-wide counts (loadfile-parallel test isolation — see
+# test_ledger_service module docstring history / ROB-844 lessons).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_status_distribution_counts_own_rows(
+    demo_ledger_service: BinanceDemoLedgerService,
+    crypto_instrument_btc_id: int,
+) -> None:
+    before = await demo_ledger_service.status_distribution()
+    cid = await _make_row(
+        demo_ledger_service,
+        instrument_id=crypto_instrument_btc_id,
+        client_order_id="demo-test-status-distribution-planned",
+    )
+    after = await demo_ledger_service.status_distribution()
+    assert after.get("planned", 0) == before.get("planned", 0) + 1
+    row = await demo_ledger_service.get_by_client_order_id(cid)
+    assert row is not None and row.lifecycle_state == "planned"
+
+
+@pytest.mark.asyncio
+async def test_list_recent_includes_own_row_and_respects_limit(
+    demo_ledger_service: BinanceDemoLedgerService,
+    crypto_instrument_btc_id: int,
+) -> None:
+    cid = await _make_row(
+        demo_ledger_service,
+        instrument_id=crypto_instrument_btc_id,
+        client_order_id="demo-test-list-recent-membership",
+    )
+    rows = await demo_ledger_service.list_recent(limit=500)
+    assert cid in {r.client_order_id for r in rows}
+
+    filtered = await demo_ledger_service.list_recent(
+        limit=500, lifecycle_state="planned"
+    )
+    assert cid in {r.client_order_id for r in filtered}
+    assert all(r.lifecycle_state == "planned" for r in filtered)
+
+    capped = await demo_ledger_service.list_recent(limit=1)
+    assert len(capped) == 1
+
+
+@pytest.mark.asyncio
+async def test_stale_open_roots_includes_old_open_root_excludes_recent(
+    demo_ledger_service: BinanceDemoLedgerService,
+    crypto_instrument_btc_id: int,
+) -> None:
+    # Each open root consumes the single-open-root-per-instrument slot
+    # (uq_binance_demo_ledger_open_root), so the "old" and "not-stale" rows
+    # need distinct instruments to coexist as open roots simultaneously.
+    other_instrument_id = await demo_ledger_service.resolve_or_create_instrument(
+        venue="binance",
+        product="spot",
+        venue_symbol="ROB907STALEUSDT",
+        base_asset="ROB907STALE",
+        quote_asset="USDT",
+    )
+    # _make_row hardcodes planned_at=2026-05-22, which postdates the 2021-01-01
+    # cutoff below — useful as the "recent, must be excluded" row.
+    not_stale_cid = await _make_row(
+        demo_ledger_service,
+        instrument_id=crypto_instrument_btc_id,
+        client_order_id="demo-test-stale-open-root-not-stale",
+    )
+    old_now = dt.datetime(2020, 1, 1, tzinfo=dt.UTC)
+    await demo_ledger_service.record_planned(
+        instrument_id=other_instrument_id,
+        product="spot",
+        venue_host="demo-api.binance.com",
+        client_order_id="demo-test-stale-open-root-old-2",
+        side="BUY",
+        order_type="MARKET",
+        qty=Decimal("0.001"),
+        price=None,
+        now=old_now,
+    )
+    cutoff = dt.datetime(2021, 1, 1, tzinfo=dt.UTC)
+    stale = await demo_ledger_service.stale_open_roots(older_than=cutoff, limit=500)
+    stale_ids = {r.client_order_id for r in stale}
+    assert "demo-test-stale-open-root-old-2" in stale_ids
+    assert not_stale_cid not in stale_ids  # planned at 2026-05-22, after the cutoff
+
+
+@pytest.mark.asyncio
+async def test_latest_activity_at_reflects_own_far_future_row(
+    demo_ledger_service: BinanceDemoLedgerService,
+    crypto_instrument_btc_id: int,
+) -> None:
+    # A far-future timestamp is guaranteed to be the table-wide max, so an
+    # exact assertion is safe here despite the shared test DB. ``updated_at``
+    # is only explicitly stamped on a state transition (insert uses the DB
+    # server default), so drive one via record_previewed.
+    far_future = dt.datetime(2099, 1, 1, tzinfo=dt.UTC)
+    cid = await _make_row(
+        demo_ledger_service,
+        instrument_id=crypto_instrument_btc_id,
+        client_order_id="demo-test-latest-activity-far-future",
+    )
+    await demo_ledger_service.record_previewed(client_order_id=cid, now=far_future)
+    latest = await demo_ledger_service.latest_activity_at()
+    assert latest == far_future
+
+
+# ---------------------------------------------------------------------------
 # AST import-boundary guard
 # ---------------------------------------------------------------------------
 

--- a/tests/services/brokers/binance/demo_scalping_exec/test_scheduler.py
+++ b/tests/services/brokers/binance/demo_scalping_exec/test_scheduler.py
@@ -54,23 +54,27 @@ def _flat() -> list[Candle]:
 
 
 class _Result:
-    def __init__(self, status):
+    def __init__(self, status, *, reason_codes=()):
         self.status = status
+        self.reason_codes = tuple(reason_codes)
 
 
 class _FakeExecutor:
-    def __init__(self, *, entry_status="reconciled", raise_on_entry=False):
+    def __init__(
+        self, *, entry_status="reconciled", raise_on_entry=False, reason_codes=()
+    ):
         self.entered: list[str] = []
         self.markets: list = []  # ROB-315 0c: captured market conditions
         self._entry_status = entry_status
         self._raise_on_entry = raise_on_entry
+        self._reason_codes = reason_codes
 
     async def execute_monitored(self, intent, *, confirm, **kwargs):
         self.markets.append(kwargs.get("market"))
         if self._raise_on_entry:
             raise RuntimeError("boom")
         self.entered.append(intent.symbol)
-        return _Result(self._entry_status)
+        return _Result(self._entry_status, reason_codes=self._reason_codes)
 
 
 class _FakeMarketData:
@@ -125,6 +129,35 @@ async def test_enters_monitored_on_signal() -> None:
     assert spot.entered == ["XRPUSDT"]  # uptrend -> long entry placed (monitored)
     assert fut.entered == ["XRPUSDT"]
     assert summary.errors == []
+    # ROB-907: entered tuples are (product, symbol, status, reason_codes).
+    assert ("spot", "XRPUSDT", "reconciled", []) in summary.entered
+    assert ("usdm_futures", "XRPUSDT", "reconciled", []) in summary.entered
+
+
+@pytest.mark.asyncio
+async def test_entered_tuple_surfaces_blocked_reason_codes() -> None:
+    """ROB-907: blocked entries carry their reason_codes into the summary so
+    Prefect logs can diagnose all-blocked ticks without a DB read."""
+    spot = _FakeExecutor(
+        entry_status="blocked", reason_codes=("spread_too_wide", "stale_data")
+    )
+    summary = await run_scalping_tick(
+        executors=_executors(spot, _FakeExecutor()),
+        market_data=_FakeMarketData(_uptrend()),
+        symbols=["XRPUSDT"],
+        products=["spot"],
+        now=_NOW,
+        confirm=True,
+        enabled=True,
+    )
+    assert summary.status == "ran"
+    assert summary.entered == [
+        ("spot", "XRPUSDT", "blocked", ["spread_too_wide", "stale_data"])
+    ]
+    evidence = summary.to_evidence_dict()
+    assert evidence["entered"] == [
+        ["spot", "XRPUSDT", "blocked", ["spread_too_wide", "stale_data"]]
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/services/brokers/binance/test_audit_no_signed_endpoints.py
+++ b/tests/services/brokers/binance/test_audit_no_signed_endpoints.py
@@ -165,6 +165,18 @@ ALLOWED_LEGACY_FILES: frozenset[str] = frozenset(
         # precedent it mirrors (strict-equality, no wildcard). String reference
         # only — same class as the other entries here.
         "app/services/action_report/remote_debug_audit/host_allowlist.py",
+        # ROB-907 — read-only binance_demo_ledger_status MCP tool. Reads the
+        # already-persisted demo ledger exclusively through
+        # BinanceDemoLedgerService (no repository import, no HTTP/WS client,
+        # no signing, no credentials). References "Binance" only via the
+        # module/tool name and the service import path. (registry.py's new
+        # conditional import of this module needs no separate entry — it is
+        # already allow-listed above for the Phase 3 handler import.)
+        "app/mcp_server/tooling/binance_demo_ledger_status_read.py",
+        # ROB-907 — route_request_lanes.py adds "binance_demo_ledger_status"
+        # to READ_ONLY_ADVISORY_TOOLS: a bare tool-name string in a Python
+        # set literal, not a Binance HTTP/WS/signed reference.
+        "app/mcp_server/tooling/route_request_lanes.py",
     }
 )
 

--- a/tests/test_route_request_registry_diff.py
+++ b/tests/test_route_request_registry_diff.py
@@ -94,6 +94,8 @@ def test_read_only_bucket_has_no_phantom_tools():
     _FLAG_GATED_OR_OPTIONAL: set[str] = {
         "analysis_bundle_create",
         "analysis_bundle_get",
+        # ROB-907: gated by settings.binance_demo_scalping_enabled (default off).
+        "binance_demo_ledger_status",
         *KIWOOM_MOCK_US_READ_TOOL_NAMES,
     }
     phantom = READ_ONLY_ADVISORY_TOOLS - default - _FLAG_GATED_OR_OPTIONAL


### PR DESCRIPTION
## Summary

Linear: ROB-907 — `[mock_binance]` observability gap: tick summary doesn't expose blocked `reason_codes` + no read-only ledger MCP tool.

- **Tick reason_codes**: `run_scalping_tick`'s `entered` evidence tuples were `(product, symbol, status)` only. When status is `blocked`, the executor's `reason_codes` (spread_too_wide / stale_data / lifecycle caps / daily budget / …) were dropped, so a month of all-blocked ticks (ROB-906) left no way to diagnose the cause from Prefect logs. `entered` is now `(product, symbol, status, reason_codes)`; `TickSummary.to_evidence_dict()` carries the 4-tuple through unchanged into the CLI's JSON summary.
- **`binance_demo_ledger_status` MCP tool**: read-only summary of `binance_demo_order_ledger` — lifecycle-state distribution, open-root count (same definition as the executor's capacity gate), anomaly count, stale (stuck-open) root lifecycles, latest activity timestamp, and a bounded recent-activity list. Registered in the DEFAULT MCP profile behind the same `settings.binance_demo_scalping_enabled` gate as `binance_demo_scalping_submit_decision`, so operational checks no longer need a direct production-DB `SELECT` fallback.

## Contract

- `app/services/brokers/binance/demo_scalping_exec/scheduler.py`: `entered.append((product, symbol, result.status, sorted(result.reason_codes)))`.
- `BinanceDemoLedgerRepository` (service-internal) + `BinanceDemoLedgerService` gain four read-only methods: `status_distribution`, `list_recent`, `stale_open_roots`, `latest_activity_at`. No writes; repository stays behind the existing AST import-boundary guard.
- New `app/mcp_server/tooling/binance_demo_ledger_status_read.py` — `binance_demo_ledger_status(stale_age_seconds=3600, recent_limit=20)`. `recent_limit` capped at 200. No broker call, no DB write, no secrets.
- Registered alongside `binance_demo_scalping_submit_decision` in `registry.py` under the existing `settings.binance_demo_scalping_enabled` DEFAULT-profile gate.
- `route_request_lanes.py`: `binance_demo_ledger_status` added to `READ_ONLY_ADVISORY_TOOLS`; `tests/test_route_request_registry_diff.py`'s `_FLAG_GATED_OR_OPTIONAL` updated (tool is absent at default settings since the feature flag defaults off).
- `docs/runbooks/binance-demo-scalping.md`: new "Observability (ROB-907)" section documenting the `entered` tuple shape and the new tool's usage for operational ledger checks.
- Migration 0 — no schema change.

## Not touched (per worker scope)

`app/jobs/binance_demo_scalping_runner.py` (owned by the concurrent ROB-905 worker) — its `to_evidence_dict()` spread already carries the new `entered` shape through unchanged, no edit needed there.

## ROB-285 Binance-location audit allow-list (CI fix)

CI's `test_only_one_binance_package_path_exists` (the ROB-285 invariant that new Binance HTTP/WS code lives only under `app/services/brokers/binance/`) flagged this PR's two new/changed files as unexpected Binance locations. Both are extended into `ALLOWED_LEGACY_FILES` with justification, following the test's own extension contract — neither adds an HTTP/WS client, signing, or credentials:

- **`app/mcp_server/tooling/binance_demo_ledger_status_read.py`** — reads the already-persisted demo ledger exclusively through `BinanceDemoLedgerService` (the public service-layer surface; it never imports `BinanceDemoLedgerRepository` directly, so it stays behind the existing AST import-boundary guard too). No broker HTTP/WS call, no signing, no credentials — it references "Binance" only via the module/tool name and the service import path.
- **`app/mcp_server/tooling/route_request_lanes.py`** — adds the bare string `"binance_demo_ledger_status"` to the `READ_ONLY_ADVISORY_TOOLS` set literal. It is a tool-name reference for the route-request lane classifier, not Binance code.

(`registry.py`'s new conditional import of the tool needed no separate allow-list entry — it was already listed there for the Phase 3 `binance_demo_scalping_handler` import.)

## Test plan

- [x] `uv run pytest tests/services/brokers/binance/demo_scalping_exec/ tests/scripts/test_binance_demo_scalping_tick.py -q` — 73 passed
- [x] `uv run pytest tests/services/brokers/binance/demo/ -q` — 138 passed
- [x] `uv run pytest tests/test_route_request_registry_diff.py tests/test_route_request_lanes.py -q` — 24 passed
- [x] `uv run pytest tests/mcp_server/ -q -k binance` — 23 passed
- [x] `uv run pytest tests/services/brokers/binance/test_audit_no_signed_endpoints.py -q` — 3 passed
- [x] `make lint` — ruff check/format + ty all pass
- [x] `git diff --check` — clean
- [x] `uv run alembic heads` — single head, unchanged (`20260714_rob850_paper_evaluation`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
