### PR TITLE
fix(ROB-906): reconcile pre-ack open roots (previewed/validated, no broker ack)

### DIFF
--- a/app/jobs/binance_demo_root_reservation_reconciliation.py
+++ b/app/jobs/binance_demo_root_reservation_reconciliation.py
@@ -1,9 +1,13 @@
 """Broker-truth reconciliation for abandoned Binance Demo root reservations.
 
-Only root rows still persisted as ``planned`` are candidates. A reservation is
-released solely when Binance explicitly reports the client order missing, or a
-terminal order with zero executed quantity. Transport errors, malformed truth,
-open orders, and any executed quantity remain blocking.
+Candidates are *pre-acknowledgement* open roots: a still-persisted ``planned``
+root, or a ``previewed``/``validated`` root whose ``broker_order_id`` is still
+NULL (ROB-906 — the broker POST never reached the venue, so no ack exists).
+``submitted``/``filled``/``anomaly`` roots carry a broker acknowledgement and
+remain owned by the fill-evidence reconcile path. A reservation is released
+solely when Binance explicitly reports the client order missing, or a terminal
+order with zero executed quantity. Transport errors, malformed truth, open
+orders, and any executed quantity remain blocking.
 """
 
 from __future__ import annotations
@@ -14,8 +18,9 @@ from collections.abc import Mapping
 from decimal import Decimal, InvalidOperation
 from typing import Any
 
-from sqlalchemy import select
+from sqlalchemy import and_, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+from sqlalchemy.sql.elements import ColumnElement
 
 from app.core.db import AsyncSessionLocal
 from app.models.binance_demo_order_ledger import BinanceDemoOrderLedger
@@ -117,6 +122,38 @@ async def _lookup_order(client: Any, *, product: str, symbol: str, cid: str) -> 
     return await client.get_order(symbol=symbol, client_order_id=cid)
 
 
+def _candidate_where_clauses(
+    stale_before: dt.datetime,
+) -> tuple[ColumnElement[bool], ...]:
+    """Shared predicate for the discovery snapshot and the FOR UPDATE re-read.
+
+    A candidate is an old *pre-acknowledgement* open root:
+
+    * a ``planned`` root (original ROB-844 semantics, unchanged), or
+    * a ``previewed``/``validated`` root whose ``broker_order_id`` is still NULL
+      (ROB-906 — a crash after ``record_validated`` but before the broker POST
+      leaves a durable open root that no ack-keyed fill-evidence path can free).
+
+    ``submitted``/``filled``/``anomaly`` roots carry a broker acknowledgement and
+    are deliberately excluded here. ``planned_at`` is set at insert and never
+    cleared across pre-ack transitions, so it remains the age gate for all three
+    states. The re-read applies the same predicate, so a row that advanced to
+    ``submitted`` (or gained a ``broker_order_id``) between snapshot and lock is
+    silently dropped, never kept.
+    """
+    return (
+        BinanceDemoOrderLedger.parent_client_order_id.is_(None),
+        BinanceDemoOrderLedger.planned_at <= stale_before,
+        or_(
+            BinanceDemoOrderLedger.lifecycle_state == "planned",
+            and_(
+                BinanceDemoOrderLedger.lifecycle_state.in_(("previewed", "validated")),
+                BinanceDemoOrderLedger.broker_order_id.is_(None),
+            ),
+        ),
+    )
+
+
 async def reconcile_binance_demo_root_reservations(
     session_factory: async_sessionmaker[AsyncSession],
     *,
@@ -140,11 +177,7 @@ async def reconcile_binance_demo_root_reservations(
             (
                 await discovery_session.scalars(
                     select(BinanceDemoOrderLedger.id)
-                    .where(
-                        BinanceDemoOrderLedger.parent_client_order_id.is_(None),
-                        BinanceDemoOrderLedger.lifecycle_state == "planned",
-                        BinanceDemoOrderLedger.planned_at <= stale_before,
-                    )
+                    .where(*_candidate_where_clauses(stale_before))
                     .order_by(
                         BinanceDemoOrderLedger.planned_at,
                         BinanceDemoOrderLedger.id,
@@ -172,9 +205,7 @@ async def reconcile_binance_demo_root_reservations(
                     )
                     .where(
                         BinanceDemoOrderLedger.id == candidate_id,
-                        BinanceDemoOrderLedger.parent_client_order_id.is_(None),
-                        BinanceDemoOrderLedger.lifecycle_state == "planned",
-                        BinanceDemoOrderLedger.planned_at <= stale_before,
+                        *_candidate_where_clauses(stale_before),
                     )
                     .with_for_update(skip_locked=True, of=BinanceDemoOrderLedger)
                     .execution_options(populate_existing=True)
@@ -184,6 +215,12 @@ async def reconcile_binance_demo_root_reservations(
                     continue
                 row, symbol = candidate
                 scanned += 1
+                # Snapshot the pre-release lifecycle state for operator-readable
+                # outcomes (ROB-906). Reported on every outcome — including
+                # released rows — so the operator sees which pre-ack state
+                # (planned/previewed/validated) was reconciled rather than the
+                # post-release ``reconciled``.
+                lifecycle_state = row.lifecycle_state
                 client = clients.get(row.product)
                 if client is None:
                     kept += 1
@@ -192,6 +229,7 @@ async def reconcile_binance_demo_root_reservations(
                             "client_order_id": row.client_order_id,
                             "action": "kept",
                             "reason": "client_unavailable",
+                            "lifecycle_state": lifecycle_state,
                         }
                     )
                     continue
@@ -202,6 +240,7 @@ async def reconcile_binance_demo_root_reservations(
                             "client_order_id": row.client_order_id,
                             "action": "kept",
                             "reason": "venue_host_mismatch",
+                            "lifecycle_state": lifecycle_state,
                         }
                     )
                     continue
@@ -220,6 +259,7 @@ async def reconcile_binance_demo_root_reservations(
                             "client_order_id": row.client_order_id,
                             "action": "kept",
                             "reason": "credential_fingerprint_missing",
+                            "lifecycle_state": lifecycle_state,
                         }
                     )
                     continue
@@ -238,6 +278,7 @@ async def reconcile_binance_demo_root_reservations(
                             "client_order_id": row.client_order_id,
                             "action": "kept",
                             "reason": "client_credential_fingerprint_unavailable",
+                            "lifecycle_state": lifecycle_state,
                         }
                     )
                     continue
@@ -248,6 +289,7 @@ async def reconcile_binance_demo_root_reservations(
                             "client_order_id": row.client_order_id,
                             "action": "kept",
                             "reason": "credential_fingerprint_mismatch",
+                            "lifecycle_state": lifecycle_state,
                         }
                     )
                     continue
@@ -272,6 +314,7 @@ async def reconcile_binance_demo_root_reservations(
                                 "client_order_id": row.client_order_id,
                                 "action": "kept",
                                 "reason": "broker_lookup_retention_exceeded",
+                                "lifecycle_state": lifecycle_state,
                             }
                         )
                         continue
@@ -283,6 +326,7 @@ async def reconcile_binance_demo_root_reservations(
                             "client_order_id": row.client_order_id,
                             "action": "kept",
                             "reason": "broker_lookup_failed",
+                            "lifecycle_state": lifecycle_state,
                         }
                     )
                     continue
@@ -299,6 +343,7 @@ async def reconcile_binance_demo_root_reservations(
                                 "client_order_id": row.client_order_id,
                                 "action": "kept",
                                 "reason": "malformed_broker_truth",
+                                "lifecycle_state": lifecycle_state,
                             }
                         )
                         continue
@@ -316,6 +361,7 @@ async def reconcile_binance_demo_root_reservations(
                                 "client_order_id": row.client_order_id,
                                 "action": "kept",
                                 "reason": "broker_identity_mismatch",
+                                "lifecycle_state": lifecycle_state,
                             }
                         )
                         continue
@@ -331,6 +377,7 @@ async def reconcile_binance_demo_root_reservations(
                                 "client_order_id": row.client_order_id,
                                 "action": "kept",
                                 "reason": "broker_exposure_not_disproven",
+                                "lifecycle_state": lifecycle_state,
                             }
                         )
                         continue
@@ -362,6 +409,7 @@ async def reconcile_binance_demo_root_reservations(
                         "client_order_id": row.client_order_id,
                         "action": action,
                         "reason": release_reason,
+                        "lifecycle_state": lifecycle_state,
                     }
                 )
 

--- a/docs/runbooks/binance-demo-scalping.md
+++ b/docs/runbooks/binance-demo-scalping.md
@@ -177,18 +177,34 @@ don't (correctly) trip the global cap. Procedure:
 5. Capture the redacted evidence line + a broker/ledger reconciliation
    check (open orders 0; futures position flat).
 
-### Abandoned root-reservation reconciliation (ROB-844)
+### Abandoned root-reservation reconciliation (ROB-844, ROB-906)
 
 `reserve_root_planned` commits its exposure claim in an independent DB
-transaction before broker order submission. A process crash can therefore leave a durable
-`planned` root. It is never released by elapsed time alone. The scheduleless
+transaction before broker order submission. A process crash can therefore leave
+a durable **pre-acknowledgement open root** — a root row still persisted as
+`planned`, `previewed`, or `validated` whose `broker_order_id` is still NULL
+(the broker POST never reached the venue, so no acknowledgement exists). All
+three occupy the global open-root cap and are candidates here.
+`submitted`/`filled`/`anomaly` roots carry a broker ack and stay owned by the
+fill-evidence reconcile path — they are never candidates for this job.
+
+> **ROB-906:** the original job only scanned `planned` rows, so a crash *after*
+> `record_validated` (but before the broker POST) stranded a `validated` root
+> that permanently occupied the cap — observed in production as every scalping
+> tick entry blocking with `global_lifecycle_cap_reached` while the broker
+> account was flat. The pre-ack candidate set above closes that blind spot.
+
+It is never released by elapsed time alone. The scheduleless
 TaskIQ entrypoint `binance.demo_root_reservation.reconcile` combines an age
-eligibility guard with exact broker truth by `client_order_id`. Before any
+eligibility guard (`planned_at`, populated at insert and preserved across pre-ack
+transitions) with exact broker truth by `client_order_id`. Before any
 broker GET, the persisted row must match the product's exact Demo host and its
 `extra_metadata.credential_fingerprint` must exactly match the running
 adapter's opaque API-key fingerprint. Raw API keys/secrets are never stored.
 Legacy rows with no fingerprint, rotated/mismatched credentials, or unavailable
-client identity stay blocking and dispatch zero broker reads.
+client identity stay blocking and dispatch zero broker reads. Each outcome
+reports its pre-release `lifecycle_state` (`planned`/`previewed`/`validated`) for
+operator readability.
 
 - explicit Binance `-2013` order-not-found is releasable only while reservation
   age is **strictly below 89 days**. At exactly 89 days or older, lookup
@@ -248,8 +264,10 @@ does not propagate gates or credentials to an existing worker.
    `BINANCE_DEMO_RESERVATION_RECONCILE_CONFIRM=true`, restart/reload the worker,
    confirm the effective setting, then issue the same plain kick exactly once.
 5. Verify each reported `released` row is now `reconciled` with matching
-   redacted reconciliation evidence; verify kept rows remain `planned`, broker
-   open orders are expected, and Futures positions are understood.
+   redacted reconciliation evidence; verify kept rows remain in their pre-ack
+   open state (`planned`/`previewed`/`validated`, per each outcome's
+   `lifecycle_state`), broker open orders are expected, and Futures positions
+   are understood.
 6. **Immediately close the apply window:** set confirm back to `false`, restart/
    reload the worker, and verify a subsequent controlled invocation reports
    `mutation_confirmed=false`. On any error or unexpected outcome, perform this

--- a/tests/services/brokers/binance/demo/test_root_reservation_reconciler.py
+++ b/tests/services/brokers/binance/demo/test_root_reservation_reconciler.py
@@ -97,6 +97,44 @@ async def _row(cid: str) -> BinanceDemoOrderLedger:
         return row
 
 
+async def _advance(cid: str, *, to: str, at: dt.datetime = _PLANNED_AT) -> None:
+    """Advance a freshly-seeded root through pre-ack lifecycle transitions.
+
+    Only ``previewed``/``validated`` are supported here: both leave
+    ``broker_order_id`` NULL (no broker acknowledgement), which is exactly the
+    pre-ack open-root class ROB-906 must reconcile.
+    """
+    async with AsyncSessionLocal() as db:
+        service = BinanceDemoLedgerService(db)
+        await service.record_previewed(client_order_id=cid, now=at)
+        if to == "validated":
+            await service.record_validated(client_order_id=cid, now=at)
+        elif to != "previewed":  # pragma: no cover - guard against typos
+            raise AssertionError(f"unsupported pre-ack target state {to!r}")
+        await db.commit()
+
+
+async def _force_broker_order_id(cid: str, broker_order_id: str) -> None:
+    """Attach a broker ack id without advancing state (artificial test state).
+
+    Used only to prove a ``previewed``/``validated`` row that already carries a
+    broker acknowledgement is excluded from the pre-ack candidate set.
+    """
+    async with AsyncSessionLocal() as db:
+        row = await db.scalar(
+            select(BinanceDemoOrderLedger).where(
+                BinanceDemoOrderLedger.client_order_id == cid
+            )
+        )
+        assert row is not None
+        row.broker_order_id = broker_order_id
+        await db.commit()
+
+
+async def _instrument_id(cid: str) -> int:
+    return (await _row(cid)).instrument_id
+
+
 @pytest.mark.parametrize(
     ("invalid_field", "invalid"),
     [
@@ -215,6 +253,7 @@ async def test_candidate_for_unconfigured_product_stays_client_unavailable() -> 
             "client_order_id": cid,
             "action": "kept",
             "reason": "client_unavailable",
+            "lifecycle_state": "planned",
         }
     ]
     assert (await _row(cid)).lifecycle_state == "planned"
@@ -660,6 +699,7 @@ async def test_not_found_release_is_bounded_by_broker_lookup_retention(
             "client_order_id": cid,
             "action": expected_action,
             "reason": expected_reason,
+            "lifecycle_state": "planned",
         }
     ]
     assert (await _row(cid)).lifecycle_state == (
@@ -1064,3 +1104,217 @@ async def test_invalid_required_truth_is_kept_malformed(
 
     assert result["outcomes"][0]["reason"] == "malformed_broker_truth"
     assert (await _row(cid)).lifecycle_state == "planned"
+
+
+# ---------------------------------------------------------------------------
+# ROB-906 — pre-ack open roots (previewed/validated with no broker ack) are
+# candidates for the same broker-truth release path. This closes the blind spot
+# where a crash after record_validated() (broker POST never reached) left a
+# durable `validated` root permanently occupying the global open-root cap.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("state", ["previewed", "validated"])
+async def test_pre_ack_open_root_not_found_would_release(state: str) -> None:
+    from app.jobs.binance_demo_root_reservation_reconciliation import (
+        reconcile_binance_demo_root_reservations,
+    )
+    from app.services.brokers.binance.demo.errors import BinanceDemoOrderNotFound
+
+    cid, _symbol = await _seed(product="spot", suffix=f"preack{state}notfound")
+    await _advance(cid, to=state)
+
+    class _Spot(_CredentialBoundClient):
+        async def get_order_status(self, **_kwargs):
+            raise BinanceDemoOrderNotFound(cid)
+
+    result = await reconcile_binance_demo_root_reservations(
+        AsyncSessionLocal,
+        clients={"spot": _Spot()},
+        now=_NOW,
+        stale_before=_STALE_BEFORE,
+        dry_run=True,
+    )
+
+    assert result["scanned"] == 1
+    assert result["outcomes"] == [
+        {
+            "client_order_id": cid,
+            "action": "would_release",
+            "reason": "broker_order_not_found",
+            "lifecycle_state": state,
+        }
+    ]
+    # dry-run mutates nothing.
+    assert (await _row(cid)).lifecycle_state == state
+
+
+@pytest.mark.asyncio
+async def test_validated_pre_ack_root_release_frees_open_cap() -> None:
+    from app.jobs.binance_demo_root_reservation_reconciliation import (
+        reconcile_binance_demo_root_reservations,
+    )
+    from app.services.brokers.binance.demo.errors import BinanceDemoOrderNotFound
+
+    cid, _symbol = await _seed(product="spot", suffix="preackapply")
+    await _advance(cid, to="validated")
+    instrument_id = await _instrument_id(cid)
+
+    async with AsyncSessionLocal() as db:
+        service = BinanceDemoLedgerService(db)
+        assert (
+            await service.has_open_lifecycle_for_instrument(
+                product="spot", instrument_id=instrument_id
+            )
+            is True
+        )
+
+    class _Spot(_CredentialBoundClient):
+        async def get_order_status(self, **_kwargs):
+            raise BinanceDemoOrderNotFound(cid)
+
+    async with AsyncSessionLocal() as db:
+        result = await reconcile_binance_demo_root_reservations(
+            AsyncSessionLocal,
+            clients={"spot": _Spot()},
+            now=_NOW,
+            stale_before=_STALE_BEFORE,
+            dry_run=False,
+        )
+        await db.commit()
+
+    assert result["released"] == 1
+    assert result["outcomes"][0]["lifecycle_state"] == "validated"
+    assert (await _row(cid)).lifecycle_state == "reconciled"
+    # Root exposure slot for this instrument is freed — the cap is released.
+    async with AsyncSessionLocal() as db:
+        service = BinanceDemoLedgerService(db)
+        assert (
+            await service.has_open_lifecycle_for_instrument(
+                product="spot", instrument_id=instrument_id
+            )
+            is False
+        )
+
+
+@pytest.mark.asyncio
+async def test_validated_pre_ack_root_kept_when_client_unavailable() -> None:
+    from app.jobs.binance_demo_root_reservation_reconciliation import (
+        reconcile_binance_demo_root_reservations,
+    )
+
+    cid, _symbol = await _seed(product="usdm_futures", suffix="preacknolane")
+    await _advance(cid, to="validated")
+
+    result = await reconcile_binance_demo_root_reservations(
+        AsyncSessionLocal,
+        clients={},
+        now=_NOW,
+        stale_before=_STALE_BEFORE,
+        dry_run=False,
+    )
+
+    assert result["outcomes"] == [
+        {
+            "client_order_id": cid,
+            "action": "kept",
+            "reason": "client_unavailable",
+            "lifecycle_state": "validated",
+        }
+    ]
+    assert (await _row(cid)).lifecycle_state == "validated"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("state", ["previewed", "validated"])
+async def test_pre_ack_root_with_broker_ack_is_not_a_candidate(state: str) -> None:
+    """A broker-acknowledged row is out of scope — fill evidence owns it."""
+    from app.jobs.binance_demo_root_reservation_reconciliation import (
+        reconcile_binance_demo_root_reservations,
+    )
+
+    cid, _symbol = await _seed(product="spot", suffix=f"preackacked{state}")
+    await _advance(cid, to=state)
+    await _force_broker_order_id(cid, "9990001")
+
+    class _Spot(_CredentialBoundClient):
+        calls = 0
+
+        async def get_order_status(self, **_kwargs):
+            self.calls += 1
+            raise AssertionError("acked pre-ack row must not be looked up")
+
+    client = _Spot()
+    result = await reconcile_binance_demo_root_reservations(
+        AsyncSessionLocal,
+        clients={"spot": client},
+        now=_NOW,
+        stale_before=_STALE_BEFORE,
+        dry_run=False,
+    )
+
+    assert result["scanned"] == 0
+    assert client.calls == 0
+    assert not any(o["client_order_id"] == cid for o in result["outcomes"])
+    assert (await _row(cid)).lifecycle_state == state
+
+
+@pytest.mark.asyncio
+async def test_submitted_root_is_not_a_pre_ack_candidate() -> None:
+    """`submitted` (broker-acked) roots stay owned by the fill-evidence path."""
+    from app.jobs.binance_demo_root_reservation_reconciliation import (
+        reconcile_binance_demo_root_reservations,
+    )
+
+    cid, _symbol = await _seed(product="spot", suffix="submittedroot")
+    async with AsyncSessionLocal() as db:
+        service = BinanceDemoLedgerService(db)
+        await service.record_previewed(client_order_id=cid, now=_PLANNED_AT)
+        await service.record_validated(client_order_id=cid, now=_PLANNED_AT)
+        await service.record_submitted(
+            client_order_id=cid,
+            broker_order_id="submitted-broker-order",
+            now=_PLANNED_AT,
+        )
+        await db.commit()
+
+    class _Spot(_CredentialBoundClient):
+        calls = 0
+
+        async def get_order_status(self, **_kwargs):
+            self.calls += 1
+            raise AssertionError("submitted root must not be looked up")
+
+    client = _Spot()
+    result = await reconcile_binance_demo_root_reservations(
+        AsyncSessionLocal,
+        clients={"spot": client},
+        now=_NOW,
+        stale_before=_STALE_BEFORE,
+        dry_run=False,
+    )
+
+    assert result["scanned"] == 0
+    assert client.calls == 0
+    assert (await _row(cid)).lifecycle_state == "submitted"
+
+
+@pytest.mark.asyncio
+async def test_record_cancelled_permitted_from_pre_ack_states() -> None:
+    """State-machine guarantee the pre-ack release path depends on."""
+    from app.services.brokers.binance.demo.ledger.service import (
+        _ALLOWED_TRANSITIONS,
+    )
+
+    assert "cancelled" in _ALLOWED_TRANSITIONS["previewed"]
+    assert "cancelled" in _ALLOWED_TRANSITIONS["validated"]
+
+    cid, _symbol = await _seed(product="spot", suffix="cancelfromvalidated")
+    await _advance(cid, to="validated")
+    async with AsyncSessionLocal() as db:
+        service = BinanceDemoLedgerService(db)
+        await service.record_cancelled(client_order_id=cid, now=_NOW)
+        await service.record_reconciled(client_order_id=cid, now=_NOW)
+        await db.commit()
+    assert (await _row(cid)).lifecycle_state == "reconciled"


### PR DESCRIPTION
## ROB-906 — [mock_binance] 스캘핑 틱 entry가 수주간 전건 blocked (브로커는 flat)

Linear: **ROB-906** (High)

### 진단 (2026-07-16 프로덕션 read-only 조회, 캡틴 확정)

- 프로덕션 `binance_demo_order_ledger` 상태분포 = `{reconciled: 424, validated: 1}`. 잔존 open root 정확히 1건: `rob307-725be4cd88264b4fad85f037` (usdm_futures, BUY MARKET, `validated_at=2026-07-05T04:37:21Z`, **`broker_order_id=null`, `submitted_at=null`** — 브로커 POST 미도달 pre-ack 예약, 브로커 계좌는 flat).
- 이 1건이 global open-root cap(기본 1)을 상시 점유 → 2026-07-05 이후 모든 entry가 `global_lifecycle_cap_reached`로 blocked.
- 런북 reconcile dry-run 실측: `{"scanned": 0, "released": 0, "kept": 0}` — 후보 필터가 `lifecycle_state == "planned"`만 잡아 `validated` 잔존 행이 **영구 사각지대**.

근본 원인: `reserve_root_planned`은 브로커 제출 전 독립 트랜잭션으로 예약을 커밋한다. `record_validated` 직후 · 브로커 POST 직전 크래시가 나면 `validated` 루트가 durable하게 남아 cap을 영구 점유하는데, 리컨실러는 `planned`만 후보로 봐서 이를 해소하지 못했다.

### 계약 (코드만 — 프로덕션 데이터 정리는 운영자가 배포 후 dry-run→apply)

- **후보 확장** (discovery 스냅샷 + FOR UPDATE 재조회 동일 술어): root & `planned_at <= stale_before` & (`planned` OR (`previewed`/`validated` AND `broker_order_id IS NULL`)). `submitted`/`filled`/`anomaly`(broker-acked)는 기존 fill-evidence 경로 관할 — 후보 아님.
- **재조회 가드**: 스냅샷과 락 사이에 broker_order_id가 생기거나 submitted로 전진하면 재조회 술어에서 자동 탈락(skip, kept 아님).
- **릴리스/kept 증거 규칙 무변경**: 브로커 truth로만 release (`broker_order_not_found` 89일 retention 경계 · `terminal_zero_fill`). 나머지 전부 fail-closed kept.
- **outcome에 `lifecycle_state`** 필드 추가(운영 가독성). 기존 키 유지.
- **상태머신**: `previewed`/`validated` → `cancelled` → `reconciled`는 이미 허용(`_ALLOWED_TRANSITIONS`) — 변경 불필요, 회귀 테스트만 추가.
- **런북**: pre-ack 후보 정의 + ROB-906 사례 갱신.
- **하지 않은 것**: min_age/env 게이트 · submitted 이후 상태 · 릴리스 조건 완화 · 신규 테이블/컬럼/migration · executor/scheduler/runner · 프로덕션 데이터.

### 테스트 증거

TDD (RED→GREEN). 신규/변경:
- `test_pre_ack_open_root_not_found_would_release[previewed|validated]` — dry-run `would_release`, `lifecycle_state` echo.
- `test_validated_pre_ack_root_release_frees_open_cap` — apply 모드에서 released → `reconciled` + `has_open_lifecycle_for_instrument` False (cap 해제).
- `test_validated_pre_ack_root_kept_when_client_unavailable` — client 부재 시 fail-closed kept.
- `test_pre_ack_root_with_broker_ack_is_not_a_candidate[previewed|validated]`, `test_submitted_root_is_not_a_pre_ack_candidate` — broker-acked/submitted 후보 제외 (broker GET 0회).
- `test_record_cancelled_permitted_from_pre_ack_states` — 상태머신 전이 검증.
- 기존 planned 케이스 전부 green (2건 exact-equality outcome 어서션에 `lifecycle_state` 추가).

```
uv run pytest tests/services/brokers/binance/demo/ tests/services/brokers/binance/demo_scalping_exec/ tests/services/brokers/binance/test_audit_no_signed_endpoints.py
  → 233 passed
make lint  → ruff check + format + ty 전부 pass
git diff --check  → clean
uv run alembic heads  → 단일 head, 신규 migration 없음
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Expanded abandoned reservation reconciliation to cover pre-acknowledgement roots in `planned`, `previewed`, and `validated` states.
  - Added lifecycle-state details to operator-visible reconciliation outcomes.
  - Added safeguards to prevent reconciliation when broker acknowledgement or verified client credentials are unavailable.

- **Bug Fixes**
  - Prevented already acknowledged or advanced reservations from being incorrectly reconciled.
  - Ensured released pre-acknowledgement reservations free their instrument capacity.

- **Documentation**
  - Clarified candidate eligibility, broker verification requirements, redacted evidence handling, and post-release checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->