### PR TITLE
docs(ROB-909): kiwoom US smoke evidence — ust20000/ust20003 verified, 9-digit ord_no

### DIFF
--- a/docs/runbooks/kiwoom-mock-us-smoke.md
+++ b/docs/runbooks/kiwoom-mock-us-smoke.md
@@ -9,8 +9,15 @@ ROB-867. Operator-safe smoke for the Kiwoom **mock-investment** (모의투자)
 
 ROB-872 hardened this workflow entirely with fake transports. It did not run a
 confirmed smoke or verify any mutation capability; all mutation/order-type
-evidence below remains pending or unverified until ROB-873 records a dated
-market-hours exercise.
+evidence below remained pending or unverified until a dated market-hours
+exercise recorded broker evidence.
+
+ROB-909 recorded that exercise: a 2026-07-16 22:30 KST full smoke run via MCP
+(`kiwoom_mock_us_*`, deploy `ac0264cf`) proved the `trde_tp=00` (limit)
+buy → order-history → cancel → reconcile lifecycle (`ust20000` buy,
+`ust20003` cancel). Sell (`ust20001`), modify (`ust20002`), and every
+`trde_tp` other than `00` remain pending/unverified — this run did not
+exercise them. See ROB-867 comment (2026-07-16) for the raw evidence.
 
 The US namespace is completely independent from the KR `kiwoom_mock` smoke
 ([`kiwoom-mock-smoke.md`](kiwoom-mock-smoke.md)). It uses a separate app key,
@@ -247,10 +254,10 @@ If `full` mode exits with code 2 (`cleanup_required`), cancel the stranded order
 
 | TR | Path | Purpose | Mock status | Evidence |
 |---|---|---|---|---|
-| `ust20000` | `/api/us/ordr` | Buy order | Implemented; smoke pending | no acceptance claim yet |
-| `ust20001` | `/api/us/ordr` | Sell order | Implemented; smoke pending | no acceptance claim yet |
-| `ust20002` | `/api/us/ordr` | Modify order | Implemented; smoke pending | no acceptance claim yet |
-| `ust20003` | `/api/us/ordr` | Cancel order | Implemented; smoke pending | no acceptance claim yet |
+| `ust20000` | `/api/us/ordr` | Buy order | **Proven** (2026-07-16 full smoke via MCP `kiwoom_mock_us_*`, deploy `ac0264cf`) | return_code=0 "모의투자 매수주문완료"; `ord_no="000000063"` (9자리, leading-zero) |
+| `ust20001` | `/api/us/ordr` | Sell order | Implemented; smoke pending (still pending as of 2026-07-16) | no acceptance claim yet |
+| `ust20002` | `/api/us/ordr` | Modify order | Implemented; smoke pending (still pending as of 2026-07-16) | no acceptance claim yet |
+| `ust20003` | `/api/us/ordr` | Cancel order | **Proven** (2026-07-16 full smoke via MCP `kiwoom_mock_us_*`, deploy `ac0264cf`) | return_code=0 "모의투자 취소주문완료"; `ord_no="000000200"` (9자리), `cncl_ord_qty=000000000001`, `orig_ord_no="000000063"` |
 | `ust21050` | — | Open orders | Proven (2026-07-13 read-only smoke) | return_code=0 |
 | `ust21070` | — | Positions | Proven (2026-07-13 read-only smoke) | return_code=0 |
 | `ust21510` | — | Today's orders/fills | Proven (2026-07-13 read-only smoke) | return_code=0 |
@@ -261,11 +268,22 @@ If `full` mode exits with code 2 (`cleanup_required`), cancel the stranded order
 > "smoke pending" = the TR path is implemented; the first live mock exercise is
 > this smoke. Record the actual `return_code` / `return_msg` here after running.
 
+### Order-id format (confirmed 2026-07-16)
+
+The 2026-07-16 full smoke confirmed order IDs are **9-digit, leading-zero
+integers**: buy `ord_no="000000063"`, cancel `ord_no="000000200"` (with
+`orig_ord_no="000000063"`), and the open-order sentinel for "no original
+order" is `orig_ord_no="000000000"`. This is consistent with, and narrower
+than, the code's existing 1-18 digit acceptance range documented in the smoke
+sequence below — that range is not reduced by this evidence, since it exists
+to tolerate the full documented Kiwoom ID width, not to assert a specific
+width.
+
 ## Per-order-type evidence table
 
 | `trde_tp` | Type | MCP-exposed | Probe status | Evidence |
 |---:|---|---|---|---|
-| `00` | Limit | Yes | Unverified | full smoke required |
+| `00` | Limit | Yes | **Verified** (2026-07-16 full smoke via MCP `kiwoom_mock_us_*`, deploy `ac0264cf`) | buy `000000063` return_code=0; cancel `000000200` return_code=0; clean final reconcile |
 | `03` | Market | Yes | Unverified | not used in full mode |
 | `26` | Documented advanced buy type | No | Unverified | explicit buy probe required |
 | `27` | Documented advanced buy type | No | Unverified | explicit buy probe required |
@@ -285,6 +303,24 @@ Omit all secret values. If a probe returns a non-zero `return_code`, record the
 
 Class-share symbols are marked unverified until the smoke workflow records
 broker evidence.
+
+## Observed broker quirks (2026-07-16 full smoke)
+
+- **`fc_entra` scale mismatch — do not use as a cash source.** The buy
+  response (`ust20000`) returned `fc_entra="10.0000"` while the account's USD
+  deposit (`ust21160.d0_usd_fx_entr`) showed `$100,000.000`. This looks like a
+  10,000x ("만 단위") scale difference, but that is an **estimate, not a
+  confirmed conversion** — do not assume the factor without further evidence.
+  Current code does not consume `fc_entra`, which is why this is harmless
+  today; it must **not** be wired up as a cash/balance source until the scale
+  is confirmed.
+- **Cancelled order's original row stays `ord_stat="접수"` in today-history.**
+  After cancel, the `ust21510` (today) row for the *original* order
+  (`000000063`) still reports `ord_stat="접수"` (remnq 0, `cnfm_qty=1`) rather
+  than flipping to a cancelled state itself. **Terminal judgement must use the
+  cancel row** (`ord_no="000000200"`, `ord_stat="취소완료"`) **plus
+  `ord_remnq=0`** on the original — not the original row's own `ord_stat`
+  field in isolation.
 
 ## PR evidence table template
 


### PR DESCRIPTION
## Summary
- `docs/runbooks/kiwoom-mock-us-smoke.md` only — no code/test changes.
- Per-TR evidence table: `ust20000` (buy) and `ust20003` (cancel) upgraded to **Proven**, dated 2026-07-16, via MCP `kiwoom_mock_us_*` (deploy `ac0264cf`). `ust20001`/`ust20002` explicitly kept pending.
- Per-order-type evidence table: `trde_tp=00` (limit) upgraded to **Verified** for the same run. All other order types remain unverified.
- Added a confirmed 9-digit, leading-zero order-id note (`000000063` buy, `000000200` cancel, `orig_ord_no` sentinel `000000000`) — clarifies this doesn't shrink the code's existing 1-18 digit acceptance range.
- New "Observed broker quirks" section: `fc_entra` scale mismatch (do not use as cash evidence) and cancelled order's original row retaining `ord_stat="접수"` in today-history (terminal judgement must use the cancel row + `ord_remnq=0`).

증거: ROB-867 2026-07-16 코멘트 (실측 원문이 유일한 사실 근거; 그 외 주장 없음).

## Test plan
- [x] `git diff --stat` confirms single-file change (`docs/runbooks/kiwoom-mock-us-smoke.md`)
- [x] `git diff --check` clean (no whitespace errors)
- [x] Manual review of rendered markdown tables (cell counts match)
- n/a pytest (docs-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)