### PR TITLE
feat(ROB-908): flag-gate Alpaca paper surface in DEFAULT MCP profile

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -257,6 +257,13 @@ class Settings(BaseSettings):
     kiwoom_mock_us_app_secret: str | None = None
     kiwoom_mock_us_account_no: str | None = None
 
+    # ROB-908: surface Alpaca paper read/preview/confirm-gated order/ledger tools
+    # in the DEFAULT profile (mock_alpaca operator session runs on DEFAULT, not a
+    # separate us-paper instance). Flag-gated off by default, mirroring the
+    # ROB-601/ROB-867 kiwoom-mock DEFAULT gate; the automated-submit tool stays
+    # US_PAPER-only regardless (ROB-842 governance).
+    alpaca_paper_default_tools_enabled: bool = False
+
     # Toss Securities Open API. Live-only, disabled by default. ROB-530 adds
     # read-only client support; order mutations are handled by follow-up issues.
     toss_api_enabled: bool = False

--- a/app/mcp_server/tooling/registry.py
+++ b/app/mcp_server/tooling/registry.py
@@ -8,8 +8,11 @@ Profile → tool surface mapping
   legacy ambiguous order tools (place_order / cancel_order / modify_order /
   get_order_history with account_mode switching) +
   typed kis_live_* and kis_mock_* variants (additive). Typed kiwoom_mock_* is
-  additive only when the existing ROB-601 feature gate is enabled. Alpaca,
-  us-dual paper, and DB paper tools are omitted.
+  additive only when the existing ROB-601 feature gate is enabled. Alpaca paper
+  read/preview/confirm-gated order/ledger tools are additive only when the
+  ROB-908 ``alpaca_paper_default_tools_enabled`` gate is on — and even then the
+  ROB-842 automated-submit tool is excluded (US_PAPER-only). DB paper tools are
+  omitted.
 
 "hermes-paper-kis" (McpProfile.HERMES_PAPER_KIS):
   All side-effect-free research tools + read-only portfolio tools +
@@ -357,6 +360,24 @@ def register_all_tools(mcp: FastMCP, profile: McpProfile = McpProfile.DEFAULT) -
             # ROB-907: read-only ledger status alongside the scalping submit
             # tool — same gate, since both are Demo-scalping observability.
             register_binance_demo_ledger_status_tool(mcp)
+        # ROB-908: surface the Alpaca paper surface in the operator DEFAULT
+        # session so the mock_alpaca lane (account/positions/ledger reads,
+        # confirm-gated round-trip) works without standing up a separate
+        # us-paper MCP instance — same flag-gated DEFAULT pattern as the
+        # ROB-601/867 kiwoom blocks above. Gated by
+        # ``settings.alpaca_paper_default_tools_enabled`` so the tools are
+        # physically absent unless the operator opts in; the confirm=True +
+        # server-issued quote_snapshot_id order gates are unchanged. The
+        # automated-submit surface (register_alpaca_paper_automated_orders_tools)
+        # is DELIBERATELY excluded here — ``alpaca_paper_automated_submit_order``
+        # is a ROB-842 governance deny-list tool and must never appear in
+        # DEFAULT; it stays US_PAPER-only below.
+        if settings.alpaca_paper_default_tools_enabled:
+            register_alpaca_paper_tools(mcp)
+            register_alpaca_paper_preview_tools(mcp)
+            register_us_dual_paper_tools(mcp)
+            register_alpaca_paper_orders_tools(mcp)
+            register_alpaca_paper_ledger_read_tools(mcp)
     elif profile is McpProfile.HERMES_PAPER_KIS:
         # Paper-only: only mock-pinned order surface. Live surface is physically absent.
         register_kis_mock_order_tools(mcp)

--- a/app/mcp_server/tooling/route_request_lanes.py
+++ b/app/mcp_server/tooling/route_request_lanes.py
@@ -12,6 +12,9 @@ from __future__ import annotations
 
 from typing import Any
 
+from app.mcp_server.tooling.alpaca_paper import ALPACA_PAPER_READONLY_TOOL_NAMES
+from app.mcp_server.tooling.alpaca_paper_orders import ALPACA_PAPER_MUTATING_TOOL_NAMES
+from app.mcp_server.tooling.alpaca_paper_preview import ALPACA_PAPER_PREVIEW_TOOL_NAMES
 from app.mcp_server.tooling.mirror_counterfactual_registration import (
     MIRROR_COUNTERFACTUAL_TOOL_NAMES,
 )
@@ -27,6 +30,7 @@ from app.mcp_server.tooling.orders_kiwoom_us_variants import (
 from app.mcp_server.tooling.orders_kiwoom_variants import KIWOOM_MOCK_TOOL_NAMES
 from app.mcp_server.tooling.orders_registration import ORDER_TOOL_NAMES
 from app.mcp_server.tooling.orders_toss_variants import TOSS_LIVE_ORDER_TOOL_NAMES
+from app.mcp_server.tooling.us_dual_paper import US_DUAL_PAPER_TOOL_NAMES
 
 # intent enum (the only free LLM choice) -> playbook lane
 INTENT_TO_LANE: dict[str, str] = {
@@ -183,6 +187,12 @@ MUTATION_TOOLS: frozenset[str] = frozenset(
     | KIWOOM_MOCK_TOOL_NAMES
     | KIWOOM_MOCK_US_MUTATION_TOOL_NAMES
     | MIRROR_COUNTERFACTUAL_TOOL_NAMES
+    # ROB-908: Alpaca paper confirm-gated order mutations (submit/cancel). Flag-
+    # gated in DEFAULT (settings.alpaca_paper_default_tools_enabled, default off);
+    # the read/preview/us_dual/ledger surface is read-only and lives in
+    # READ_ONLY_ADVISORY_TOOLS. The automated-submit tool is not registered in
+    # DEFAULT at all (ROB-842), so it is intentionally not classified here.
+    | frozenset(ALPACA_PAPER_MUTATING_TOOL_NAMES)
     | frozenset(
         {
             # ROB-703: paper resting-limit sim mutations (paper-table writes only,
@@ -262,6 +272,17 @@ _MARKET_EXEC_PURPOSE: dict[str, str] = {
 READ_ONLY_ADVISORY_TOOLS: frozenset[str] = frozenset(
     {
         *KIWOOM_MOCK_US_READ_TOOL_NAMES,
+        # ROB-908: Alpaca paper read surface, flag-gated in DEFAULT
+        # (settings.alpaca_paper_default_tools_enabled, default off). Covers the
+        # account/positions/orders/assets/fills + ledger reads
+        # (ALPACA_PAPER_READONLY_TOOL_NAMES), the pure-validator preview
+        # (ALPACA_PAPER_PREVIEW_TOOL_NAMES — no side effects, does not submit),
+        # and the read-only us_dual capability/state/preview trio
+        # (US_DUAL_PAPER_TOOL_NAMES, submit_enabled always False). The
+        # confirm-gated submit/cancel mutations live in MUTATION_TOOLS.
+        *ALPACA_PAPER_READONLY_TOOL_NAMES,
+        *ALPACA_PAPER_PREVIEW_TOOL_NAMES,
+        *US_DUAL_PAPER_TOOL_NAMES,
         "route_request",
         "analysis_artifact_get",
         "analysis_artifact_list",

--- a/docs/runbooks/alpaca-paper-ledger.md
+++ b/docs/runbooks/alpaca-paper-ledger.md
@@ -173,6 +173,33 @@ alpaca_paper_roundtrip_report(lifecycle_correlation_id=None, client_order_id=Non
 
 ---
 
+## Profile exposure (ROB-908 — DEFAULT-profile flag)
+
+The Alpaca paper surface historically registered only under the `us-paper`
+(`McpProfile.US_PAPER`) server. The mock_alpaca operator session runs on the
+single DEFAULT profile (8765 haproxy → 8766), so those tools were invisible to
+it. ROB-908 adds a flag-gated DEFAULT exposure, mirroring the ROB-601/ROB-867
+kiwoom-mock pattern:
+
+- Set `ALPACA_PAPER_DEFAULT_TOOLS_ENABLED=true`
+  (`settings.alpaca_paper_default_tools_enabled`, default `False`) to surface the
+  Alpaca paper surface in the DEFAULT profile: the read tools
+  (`alpaca_paper_get_account` / `_get_cash` / `_list_positions` / `_list_orders`
+  / `_get_order` / `_list_assets` / `_list_fills`), the pure-validator
+  `alpaca_paper_preview_order`, the read-only `us_dual_paper_*` trio, the
+  confirm-gated `alpaca_paper_submit_order` / `alpaca_paper_cancel_order`, and
+  the ledger reads (`alpaca_paper_ledger_list_recent` / `_ledger_get` /
+  `_ledger_get_by_correlation` / `_roundtrip_report` /
+  `_execution_preflight_check`).
+- With the flag off (default) these tools are **physically absent** from the
+  DEFAULT profile — a defense-in-depth complement to the per-call `confirm=True`
+  + server-issued `quote_snapshot_id` order gates, which are unchanged.
+- `alpaca_paper_automated_submit_order` (and its automated preview) are
+  **never** exposed in DEFAULT even with the flag on — they stay `us-paper`-only
+  (ROB-842 governance deny-list).
+
+---
+
 ## Operator FAQ
 
 **Q: How do I find all anomaly (formerly canceled/unexpected) orders?**

--- a/tests/mcp_server/test_alpaca_paper_default_profile_gate.py
+++ b/tests/mcp_server/test_alpaca_paper_default_profile_gate.py
@@ -1,0 +1,105 @@
+"""ROB-908 — registry gate for Alpaca paper tools in the DEFAULT profile.
+
+The mock_alpaca operator session runs on the DEFAULT profile (single 8765→8766
+server). Alpaca paper read + preview + confirm-gated order + ledger tools are
+*physically absent* from DEFAULT unless the operator opts in via
+``settings.alpaca_paper_default_tools_enabled`` (default False), mirroring the
+ROB-601/ROB-867 kiwoom-mock DEFAULT gate.
+
+Core safety invariant: ``alpaca_paper_automated_submit_order`` (ROB-842
+governance deny-list) is NEVER exposed in DEFAULT — even when the flag is on it
+stays US_PAPER-only. And US_PAPER remains unchanged regardless of the flag.
+"""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+import pytest
+
+from app.mcp_server.profiles import McpProfile
+from app.mcp_server.tooling import registry as registry_mod
+from app.mcp_server.tooling.alpaca_paper import ALPACA_PAPER_READONLY_TOOL_NAMES
+from app.mcp_server.tooling.alpaca_paper_automated_orders import (
+    ALPACA_PAPER_AUTOMATED_TOOL_NAMES,
+)
+from app.mcp_server.tooling.alpaca_paper_orders import ALPACA_PAPER_MUTATING_TOOL_NAMES
+from app.mcp_server.tooling.alpaca_paper_preview import ALPACA_PAPER_PREVIEW_TOOL_NAMES
+from app.mcp_server.tooling.registry import register_all_tools
+from app.mcp_server.tooling.us_dual_paper import US_DUAL_PAPER_TOOL_NAMES
+from tests._mcp_tooling_support import DummyMCP
+
+# The full flag-gated DEFAULT surface (18 tools): read + preview + us_dual +
+# confirm-gated submit/cancel + ledger reads.
+_DEFAULT_ALPACA_TOOL_NAMES = (
+    ALPACA_PAPER_READONLY_TOOL_NAMES
+    | ALPACA_PAPER_PREVIEW_TOOL_NAMES
+    | US_DUAL_PAPER_TOOL_NAMES
+    | ALPACA_PAPER_MUTATING_TOOL_NAMES
+)
+
+
+def _default_tools(monkeypatch: pytest.MonkeyPatch, *, enabled: bool) -> set[str]:
+    monkeypatch.setattr(
+        registry_mod.settings,
+        "alpaca_paper_default_tools_enabled",
+        enabled,
+        raising=False,
+    )
+    mcp = DummyMCP()
+    register_all_tools(cast(Any, mcp), profile=McpProfile.DEFAULT)
+    return set(mcp.tools.keys())
+
+
+@pytest.mark.unit
+def test_alpaca_paper_tools_absent_when_gate_off(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    tools = _default_tools(monkeypatch, enabled=False)
+    leaked = _DEFAULT_ALPACA_TOOL_NAMES & tools
+    assert not leaked, (
+        f"alpaca paper tools leaked into DEFAULT while gate off: {sorted(leaked)}"
+    )
+
+
+@pytest.mark.unit
+def test_alpaca_paper_tools_present_when_gate_on(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    tools = _default_tools(monkeypatch, enabled=True)
+    missing = _DEFAULT_ALPACA_TOOL_NAMES - tools
+    assert not missing, (
+        f"alpaca paper tools missing from DEFAULT while gate on: {sorted(missing)}"
+    )
+
+
+@pytest.mark.unit
+def test_automated_orders_never_registered_in_default_when_gate_on(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # ROB-842 governance: alpaca_paper_automated_submit_order (and its preview)
+    # must NEVER be exposed in DEFAULT — it stays US_PAPER-only even with the flag.
+    tools = _default_tools(monkeypatch, enabled=True)
+    leaked = ALPACA_PAPER_AUTOMATED_TOOL_NAMES & tools
+    assert not leaked, (
+        f"automated order tools must not surface in DEFAULT: {sorted(leaked)}"
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("enabled", [False, True])
+def test_us_paper_profile_unchanged_regardless_of_flag(
+    monkeypatch: pytest.MonkeyPatch, enabled: bool
+) -> None:
+    monkeypatch.setattr(
+        registry_mod.settings,
+        "alpaca_paper_default_tools_enabled",
+        enabled,
+        raising=False,
+    )
+    mcp = DummyMCP()
+    register_all_tools(cast(Any, mcp), profile=McpProfile.US_PAPER)
+    tools = set(mcp.tools.keys())
+    expected = _DEFAULT_ALPACA_TOOL_NAMES | ALPACA_PAPER_AUTOMATED_TOOL_NAMES
+    missing = expected - tools
+    assert not missing, f"US_PAPER surface regressed: {sorted(missing)}"

--- a/tests/test_route_request_registry_diff.py
+++ b/tests/test_route_request_registry_diff.py
@@ -17,6 +17,8 @@ from typing import Any, cast
 import yaml
 
 from app.mcp_server.profiles import McpProfile
+from app.mcp_server.tooling.alpaca_paper import ALPACA_PAPER_READONLY_TOOL_NAMES
+from app.mcp_server.tooling.alpaca_paper_preview import ALPACA_PAPER_PREVIEW_TOOL_NAMES
 from app.mcp_server.tooling.orders_kiwoom_us_variants import (
     KIWOOM_MOCK_US_MUTATION_TOOL_NAMES,
     KIWOOM_MOCK_US_READ_TOOL_NAMES,
@@ -29,6 +31,7 @@ from app.mcp_server.tooling.route_request_lanes import (
     READ_ONLY_ADVISORY_TOOLS,
     lane_tool_names,
 )
+from app.mcp_server.tooling.us_dual_paper import US_DUAL_PAPER_TOOL_NAMES
 from tests._mcp_tooling_support import DummyMCP
 
 _PLAYBOOK_PATH = (
@@ -96,6 +99,11 @@ def test_read_only_bucket_has_no_phantom_tools():
         "analysis_bundle_get",
         # ROB-907: gated by settings.binance_demo_scalping_enabled (default off).
         "binance_demo_ledger_status",
+        # ROB-908: Alpaca paper read/preview/us_dual surface, gated by
+        # settings.alpaca_paper_default_tools_enabled (default off).
+        *ALPACA_PAPER_READONLY_TOOL_NAMES,
+        *ALPACA_PAPER_PREVIEW_TOOL_NAMES,
+        *US_DUAL_PAPER_TOOL_NAMES,
         *KIWOOM_MOCK_US_READ_TOOL_NAMES,
     }
     phantom = READ_ONLY_ADVISORY_TOOLS - default - _FLAG_GATED_OR_OPTIONAL


### PR DESCRIPTION
## 요약

mock_alpaca 운영 세션(w7)은 단일 DEFAULT 프로파일(8765 haproxy → 8766)에서 동작하는데, Alpaca paper 도구는 `McpProfile.US_PAPER` 분기에서만 등록되어 세션에 하나도 노출되지 않았음(read·주문·레저 전면 차단, ROB-908).

ROB-601/ROB-867 kiwoom-mock 패턴을 따라 새 flag `alpaca_paper_default_tools_enabled`(기본 off)를 추가하고, flag on일 때 DEFAULT 분기에 Alpaca paper 표면을 등록:

- `register_alpaca_paper_tools` — read (get_account/get_cash/list_positions/list_orders/get_order/list_assets/list_fills)
- `register_alpaca_paper_preview_tools` — `alpaca_paper_preview_order` (순수 검증기, 제출 없음)
- `register_us_dual_paper_tools` — read-only 3종 (submit_enabled 항상 False)
- `register_alpaca_paper_orders_tools` — `alpaca_paper_submit_order` / `alpaca_paper_cancel_order` (confirm=True + 서버발급 quote_snapshot_id 게이트 무변경)
- `register_alpaca_paper_ledger_read_tools` — ledger 5종

## 안전 경계

- **automated 미등록**: `register_alpaca_paper_automated_orders_tools`는 DEFAULT에 등록하지 않음 — `alpaca_paper_automated_submit_order`는 ROB-842 거버넌스 deny-list 대상으로 US_PAPER 전용 유지. flag on이어도 DEFAULT에 절대 노출 안 됨(핵심 assertion으로 고정).
- **기본 off**: flag 미설정 시 18개 도구 전부 DEFAULT에서 물리적 부재 (per-call confirm + quote_snapshot_id 게이트의 defense-in-depth 보완).
- **게이트 무변경**: 브로커/주문 게이트 로직 순수 무변경. US_PAPER 분기 현행 유지.
- **migration 0**: 순수 registry 배선 + flag + lane 분류.

## 테스트 증거

TDD (RED→GREEN). 새 게이트 테스트 `tests/mcp_server/test_alpaca_paper_default_profile_gate.py`:
- flag off → 18개 도구 DEFAULT 부재
- flag on → 18개 도구 DEFAULT 등록 + `alpaca_paper_automated_submit_order` **미등록**
- US_PAPER는 flag 무관하게 automated 포함 전체 유지

route_request lane 분류: reads(preview·us_dual·ledger 포함) → `READ_ONLY_ADVISORY_TOOLS`, submit/cancel → `MUTATION_TOOLS`; flag-gated read는 registry-diff phantom allowlist에 추가(kiwoom 선례).

```
uv run pytest tests/test_route_request_registry_diff.py tests/test_route_request_lanes.py -q  → 24 passed
uv run pytest tests/mcp_server -q -k "registry or profile or alpaca"                          → 96 passed
uv run pytest tests/test_mcp_profiles.py -q                                                   → 92 passed
uv run pytest tests/.../test_no_internal_llm_imports.py -q                                     → 1233 passed
make lint (ruff check + format + ty)                                                          → All checks passed
uv run alembic heads                                                                          → 단일 head (변경 없음)
git diff --check                                                                              → clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)