### PR TITLE
fix(ROB-910): book sell-to-zero fills instead of holdings_snapshot_missing anomaly

### DIFF
--- a/app/jobs/kis_mock_reconciliation_job.py
+++ b/app/jobs/kis_mock_reconciliation_job.py
@@ -12,6 +12,8 @@ baseline is captured at order-insert time by the order execution path.
 
 from __future__ import annotations
 
+import logging
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from decimal import Decimal, InvalidOperation
 from typing import Any
@@ -39,15 +41,43 @@ def _to_decimal(val: Any) -> Decimal:
         return Decimal(0)
 
 
+@dataclass(frozen=True, slots=True)
+class _HoldingsCollection:
+    """Snapshot dict plus per-market fetch-success flags.
+
+    ``kr_ok`` / ``us_ok`` are True only when the corresponding
+    ``fetch_my_stocks`` call returned a real list (an empty ``[]`` is a valid
+    "truly empty account" and counts as success). A raised exception or a
+    ``None`` return leaves the flag False so the reconciler can tell a genuine
+    qty-0 position apart from a failed/unverifiable inquiry (ROB-910).
+    """
+
+    snapshots: dict[str, HoldingsSnapshot]
+    kr_ok: bool
+    us_ok: bool
+
+
 async def _collect_kis_mock_holdings(
     kis_client: KISClient,
     *,
     taken_at: datetime,
-) -> dict[str, HoldingsSnapshot]:
-    """Read-only snapshot of KIS mock holdings (KR + US)."""
+) -> _HoldingsCollection:
+    """Read-only snapshot of KIS mock holdings (KR + US).
+
+    KIS balance inquiries return only nonzero holdings, so a fully-sold symbol
+    is simply absent from the response. We therefore track KR and US fetch
+    success independently: a verified-successful market lets the caller treat an
+    absent open-order symbol as qty 0, while a failed fetch keeps it unresolved
+    (fail-closed) rather than fabricating a zero (ROB-910).
+    """
     snapshots: dict[str, HoldingsSnapshot] = {}
 
-    kr = await kis_client.fetch_my_stocks(is_mock=True, is_overseas=False)
+    try:
+        kr = await kis_client.fetch_my_stocks(is_mock=True, is_overseas=False)
+    except Exception:
+        logging.exception("KIS mock KR holdings fetch failed")
+        kr = None
+    kr_ok = kr is not None
     for stock in kr or []:
         symbol = to_db_symbol(str(stock.get("pdno") or ""))
         if not symbol:
@@ -58,7 +88,12 @@ async def _collect_kis_mock_holdings(
             taken_at=taken_at,
         )
 
-    us = await kis_client.fetch_my_stocks(is_mock=True, is_overseas=True)
+    try:
+        us = await kis_client.fetch_my_stocks(is_mock=True, is_overseas=True)
+    except Exception:
+        logging.exception("KIS mock US holdings fetch failed")
+        us = None
+    us_ok = us is not None
     for stock in us or []:
         symbol = to_db_symbol(str(stock.get("ovrs_pdno") or ""))
         if not symbol:
@@ -69,7 +104,45 @@ async def _collect_kis_mock_holdings(
             taken_at=taken_at,
         )
 
-    return snapshots
+    return _HoldingsCollection(snapshots=snapshots, kr_ok=kr_ok, us_ok=us_ok)
+
+
+def _synthesize_zero_for_absent_symbols(
+    *,
+    open_rows: list[Any],
+    collection: _HoldingsCollection,
+    taken_at: datetime,
+) -> None:
+    """Fill in qty-0 snapshots for open-order symbols absent from a verified
+    market fetch (ROB-910).
+
+    "Broker inquiry succeeded + symbol absent" == "held qty is 0" (KIS lists
+    only nonzero holdings). Synthesizing a zero snapshot lets the existing delta
+    logic book a sell-to-zero as a full fill. A symbol whose market fetch did
+    NOT verifiably succeed is left absent so the reconciler still emits
+    ``holdings_snapshot_missing`` (fetch failure != qty 0). When the market
+    cannot be determined from ``instrument_type`` we require BOTH markets to have
+    succeeded before treating the symbol as zero (conservative).
+    """
+    snapshots = collection.snapshots
+    for row in open_rows:
+        symbol = row.symbol
+        if not symbol or symbol in snapshots:
+            continue
+        instrument = str(getattr(row, "instrument_type", "") or "")
+        if instrument == "equity_kr":
+            verified = collection.kr_ok
+        elif instrument == "equity_us":
+            verified = collection.us_ok
+        else:
+            verified = collection.kr_ok and collection.us_ok
+        if not verified:
+            continue
+        snapshots[symbol] = HoldingsSnapshot(
+            symbol=symbol,
+            quantity=Decimal(0),
+            taken_at=taken_at,
+        )
 
 
 async def run_kis_mock_reconciliation(
@@ -105,7 +178,15 @@ async def run_kis_mock_reconciliation(
 
     now = datetime.now(UTC)
     client = kis_client if kis_client is not None else KISClient(is_mock=True)
-    holdings_map = await _collect_kis_mock_holdings(client, taken_at=now)
+    collection = await _collect_kis_mock_holdings(client, taken_at=now)
+    # ROB-910: an open-order symbol absent from a verified-successful market
+    # fetch means the position is now zero (KIS lists only nonzero holdings).
+    # Synthesize a zero snapshot so sell-to-zero books a fill; a failed fetch
+    # leaves the symbol unresolved → holdings_snapshot_missing (fail-closed).
+    _synthesize_zero_for_absent_symbols(
+        open_rows=open_rows, collection=collection, taken_at=now
+    )
+    holdings_map = collection.snapshots
 
     order_inputs: list[LedgerOrderInput] = [
         LedgerOrderInput(

--- a/tests/jobs/test_kis_mock_reconciliation_job.py
+++ b/tests/jobs/test_kis_mock_reconciliation_job.py
@@ -22,6 +22,8 @@ def _ledger_row(
     state: str = "accepted",
     baseline: Decimal | None = Decimal("5"),
     accepted_age_sec: int = 5,
+    instrument_type: str = "equity_kr",
+    price: Decimal = Decimal("0"),
 ):
     row = MagicMock(spec=KISMockOrderLedger)
     row.id = ledger_id
@@ -31,12 +33,23 @@ def _ledger_row(
     row.lifecycle_state = state
     row.holdings_baseline_qty = baseline
     row.trade_date = datetime.now(UTC) - timedelta(seconds=accepted_age_sec)
+    row.instrument_type = instrument_type
+    row.price = price
     return row
 
 
 def _fake_kis_client(*, kr=None, us=None):
     client = MagicMock()
     client.fetch_my_stocks = AsyncMock(side_effect=[kr or [], us or []])
+    return client
+
+
+def _fake_kis_client_seq(*, side_effect):
+    """KIS client whose fetch_my_stocks resolves KR then US via an explicit
+    side_effect list (entries may be lists or Exception instances to fail a
+    market fetch)."""
+    client = MagicMock()
+    client.fetch_my_stocks = AsyncMock(side_effect=side_effect)
     return client
 
 
@@ -280,6 +293,185 @@ async def test_run_passes_symbol_to_list_open_orders(db_session, monkeypatch):
     )
     assert captured["symbol"] == "005930"
     assert result["orders_processed"] == 0
+
+
+@pytest.mark.asyncio
+async def test_sell_to_zero_books_fill_when_symbol_absent_but_fetch_ok(monkeypatch):
+    """ROB-910 core reproduction: full sell to zero.
+
+    Baseline 1, sell 1. KIS holdings inquiry succeeds (US market) but returns NO
+    row for the symbol because the position is now zero (KIS only returns
+    nonzero holdings). Expected: next_state=fill, observed_holdings_qty=0,
+    observed_delta=-1, attributed_fill_qty=1 — NOT anomaly.
+    """
+    mock_db = AsyncMock()
+    mock_lifecycle_svc = AsyncMock()
+    mock_lifecycle_svc.list_open_orders.return_value = [
+        _ledger_row(
+            ledger_id=54,
+            symbol="F",
+            side="sell",
+            qty=Decimal("1"),
+            state="accepted",
+            baseline=Decimal("1"),
+            instrument_type="equity_us",
+        )
+    ]
+    mock_lifecycle_svc.apply_lifecycle_transition.return_value = {"applied": True}
+    monkeypatch.setattr(
+        "app.jobs.kis_mock_reconciliation_job.KISMockLifecycleService",
+        lambda _: mock_lifecycle_svc,
+    )
+
+    # Both fetches succeed; US returns empty (F is now zero → not listed).
+    fake_kis = _fake_kis_client(kr=[], us=[])
+
+    await run_kis_mock_reconciliation(mock_db, dry_run=True, kis_client=fake_kis)
+
+    args = mock_lifecycle_svc.apply_lifecycle_transition.call_args.kwargs
+    assert args["ledger_id"] == 54
+    assert args["next_state"] == "fill"
+    assert args["reason_code"] == "fill_detected"
+    assert args["detail"]["observed_holdings_qty"] == "0"
+    assert args["detail"]["observed_delta"] == "-1"
+    assert args["detail"]["attributed_fill_qty"] == "1"
+
+
+@pytest.mark.asyncio
+async def test_sell_to_zero_stays_anomaly_when_market_fetch_fails(monkeypatch):
+    """ROB-910 fail-closed boundary: if the symbol's market fetch RAISED, we must
+    NOT synthesize a zero snapshot. The order stays anomaly /
+    holdings_snapshot_missing (fetch failure != qty 0)."""
+    mock_db = AsyncMock()
+    mock_lifecycle_svc = AsyncMock()
+    mock_lifecycle_svc.list_open_orders.return_value = [
+        _ledger_row(
+            ledger_id=54,
+            symbol="F",
+            side="sell",
+            qty=Decimal("1"),
+            state="accepted",
+            baseline=Decimal("1"),
+            instrument_type="equity_us",
+        )
+    ]
+    mock_lifecycle_svc.apply_lifecycle_transition.return_value = {"applied": True}
+    monkeypatch.setattr(
+        "app.jobs.kis_mock_reconciliation_job.KISMockLifecycleService",
+        lambda _: mock_lifecycle_svc,
+    )
+
+    # KR succeeds ([]), US fetch RAISES → US market unverified.
+    fake_kis = _fake_kis_client_seq(
+        side_effect=[[], RuntimeError("EGW00201 mock inquiry failed")]
+    )
+
+    await run_kis_mock_reconciliation(mock_db, dry_run=True, kis_client=fake_kis)
+
+    args = mock_lifecycle_svc.apply_lifecycle_transition.call_args.kwargs
+    assert args["ledger_id"] == 54
+    assert args["next_state"] == "anomaly"
+    assert args["reason_code"] == "holdings_snapshot_missing"
+
+
+@pytest.mark.asyncio
+async def test_sell_to_zero_stays_anomaly_when_fetch_returns_none(monkeypatch):
+    """ROB-910 fail-closed: a None return (not a real empty list) is treated as an
+    unverified fetch — no zero synthesis, anomaly preserved."""
+    mock_db = AsyncMock()
+    mock_lifecycle_svc = AsyncMock()
+    mock_lifecycle_svc.list_open_orders.return_value = [
+        _ledger_row(
+            ledger_id=55,
+            symbol="F",
+            side="sell",
+            qty=Decimal("1"),
+            state="accepted",
+            baseline=Decimal("1"),
+            instrument_type="equity_us",
+        )
+    ]
+    mock_lifecycle_svc.apply_lifecycle_transition.return_value = {"applied": True}
+    monkeypatch.setattr(
+        "app.jobs.kis_mock_reconciliation_job.KISMockLifecycleService",
+        lambda _: mock_lifecycle_svc,
+    )
+
+    fake_kis = _fake_kis_client_seq(side_effect=[[], None])
+
+    await run_kis_mock_reconciliation(mock_db, dry_run=True, kis_client=fake_kis)
+
+    args = mock_lifecycle_svc.apply_lifecycle_transition.call_args.kwargs
+    assert args["next_state"] == "anomaly"
+    assert args["reason_code"] == "holdings_snapshot_missing"
+
+
+@pytest.mark.asyncio
+async def test_empty_account_books_sell_to_zero_fill(monkeypatch):
+    """ROB-910: genuinely empty account (fetch succeeds, returns []) is a verified
+    zero for a KR sell-to-zero — books the fill, distinct from a fetch failure."""
+    mock_db = AsyncMock()
+    mock_lifecycle_svc = AsyncMock()
+    mock_lifecycle_svc.list_open_orders.return_value = [
+        _ledger_row(
+            ledger_id=60,
+            symbol="005930",
+            side="sell",
+            qty=Decimal("2"),
+            state="accepted",
+            baseline=Decimal("2"),
+            instrument_type="equity_kr",
+        )
+    ]
+    mock_lifecycle_svc.apply_lifecycle_transition.return_value = {"applied": True}
+    monkeypatch.setattr(
+        "app.jobs.kis_mock_reconciliation_job.KISMockLifecycleService",
+        lambda _: mock_lifecycle_svc,
+    )
+
+    fake_kis = _fake_kis_client(kr=[], us=[])
+
+    await run_kis_mock_reconciliation(mock_db, dry_run=True, kis_client=fake_kis)
+
+    args = mock_lifecycle_svc.apply_lifecycle_transition.call_args.kwargs
+    assert args["next_state"] == "fill"
+    assert args["reason_code"] == "fill_detected"
+    assert args["detail"]["attributed_fill_qty"] == "2"
+
+
+@pytest.mark.asyncio
+async def test_buy_absent_symbol_not_misbooked_as_fill(monkeypatch):
+    """ROB-910 buy guard: a BUY whose symbol is absent from a verified fetch
+    reflects observed qty 0 (delta 0 vs baseline 0) → still pending, never a
+    fabricated fill."""
+    mock_db = AsyncMock()
+    mock_lifecycle_svc = AsyncMock()
+    mock_lifecycle_svc.list_open_orders.return_value = [
+        _ledger_row(
+            ledger_id=70,
+            symbol="0148J0",
+            side="buy",
+            qty=Decimal("10"),
+            state="accepted",
+            baseline=Decimal("0"),
+            instrument_type="equity_kr",
+            accepted_age_sec=5,
+        )
+    ]
+    mock_lifecycle_svc.apply_lifecycle_transition.return_value = {"applied": True}
+    monkeypatch.setattr(
+        "app.jobs.kis_mock_reconciliation_job.KISMockLifecycleService",
+        lambda _: mock_lifecycle_svc,
+    )
+
+    fake_kis = _fake_kis_client(kr=[], us=[])
+
+    await run_kis_mock_reconciliation(mock_db, dry_run=True, kis_client=fake_kis)
+
+    args = mock_lifecycle_svc.apply_lifecycle_transition.call_args.kwargs
+    assert args["next_state"] == "pending"
+    assert args["reason_code"] == "pending_unconfirmed"
+    assert args["detail"]["attributed_fill_qty"] == "0"
 
 
 def test_reconcile_gate_flags_default_false():


### PR DESCRIPTION
## 근본 원인

`kis_mock_reconciliation_run`이 전량매도(sell-to-zero) 체결을 `fill`이 아니라 `anomaly / holdings_snapshot_missing`으로 오분류한다.

KIS 보유조회(`fetch_my_stocks`)는 **nonzero 행만** 반환한다 (`_filter_nonzero_holdings`가 qty 0 행을 제거). 따라서 포지션을 전량 매도해 qty=0이 되면 해당 심볼은 응답에서 그냥 사라진다. 그런데 `classify_orders`는 `holdings.get(order.symbol) is None`이면 무조건 `_anomaly(order, "holdings_snapshot_missing")`을 낸다 — 즉 **"전량매도의 정상 종결(qty 0)"과 "조회 실패(데이터 결손)"를 구분하지 못한다.** 결과적으로 전량매도 주문이 영구 shadow-pending으로 잔존해 fill을 부킹할 수 없다.

재현 (2026-07-16 22:36 KST, w7 mock_kis US 실측): baseline 1주 F(포드) sell 1주 접수(ledger 54) → 브로커 당일 체결이력 filled(1@14.095), get_holdings F 1→0 → `reconciliation_run(dry_run=True)`이 `next_state=anomaly, reason_code=holdings_snapshot_missing` 반환. 기대는 `fill`.

## 수정 (job 레이어 전용 — 순수 reconciler 무변경)

`app/jobs/kis_mock_reconciliation_job.py`:

- `_collect_kis_mock_holdings`가 **KR/US fetch 성공 여부를 각각 추적**한다 (`_HoldingsCollection.kr_ok/us_ok`). 예외 raise 또는 `None` 반환 → 해당 market 플래그 False. 빈 `[]`(진짜 빈 계좌)는 검증된 성공으로 취급. 기존 `for stock in kr or []`의 **None↔[] conflation을 해소**한다.
- open 주문 심볼이 **검증 성공한 market**의 fetch 응답에 없으면 qty 0 `HoldingsSnapshot`을 합성한다 (market은 `instrument_type`으로 판별: `equity_kr`/`equity_us`; 판별 불가 시 보수적으로 **KR·US 둘 다 성공했을 때만**). 이후 기존 delta 로직이 sell-to-zero를 full delta fill로 산출한다.
- **fail-closed 경계 (핵심 안전 경계)**: fetch가 실패(예외/None)한 market의 심볼은 스냅샷에 **합성하지 않는다** → 현행대로 `holdings_snapshot_missing` anomaly 유지. **조회 실패 ≠ qty 0.**
- **BUY 가드**: 부재 buy 심볼은 관측 qty 0(baseline 대비 delta 0) → 여전히 pending, fill로 오분류되지 않음.

`_apportion_group`/thresholds/`baseline_missing` 등 분류 로직은 변경하지 않았다.

## 테스트 증거

`tests/jobs/test_kis_mock_reconciliation_job.py` (TDD, RED→GREEN):

- `test_sell_to_zero_books_fill_when_symbol_absent_but_fetch_ok` — 핵심 재현: `next_state=fill`, `observed_holdings_qty=0`, `observed_delta=-1`, `attributed_fill_qty=1`.
- `test_sell_to_zero_stays_anomaly_when_market_fetch_fails` — fail-closed: US fetch 예외 → anomaly 유지.
- `test_sell_to_zero_stays_anomaly_when_fetch_returns_none` — None 반환은 미검증 → anomaly 유지.
- `test_empty_account_books_sell_to_zero_fill` — 빈 계좌(성공+[]) → fill 부킹.
- `test_buy_absent_symbol_not_misbooked_as_fill` — buy 가드: pending 유지.

검증 명령:
- `pytest tests/ -k "reconcil or holdings_reconciler"` → **376 passed**
- `pytest tests/jobs/test_kis_mock_reconciliation_job.py` → **13 passed**
- `pytest tests/mcp_server -k kis_mock` → **8 passed**
- `make lint` → ruff + ty **all passed**
- `git diff --check` → clean, `alembic heads` → 단일 head (migration 변경 없음)

## 운영 주의

KR 레거시 anomaly 4건(ledger 44/48/50/53)은 이미 `anomaly` 상태라 이 수정의 재분류 대상이 **아니다** — 별도 운영 조치 필요. 재현 대상 ledger 54 재처리(프로덕션)는 배포 후 운영 탭 몫.

🤖 Generated with [Claude Code](https://claude.com/claude-code)