### PR TITLE
fix(ROB-912): relax sell price guard to use a marketable band

### DIFF
--- a/app/mcp_server/tooling/order_validation.py
+++ b/app/mcp_server/tooling/order_validation.py
@@ -53,6 +53,9 @@ async def _call_kis(method: Any, *args: Any, is_mock: bool, **kwargs: Any) -> An
 
 _TRADER_AGENT_ID_DEFAULT = "6b2192cc-14fa-4335-b572-2fe1e0cb54a7"
 
+# ROB-912 — marketable sell(지정가<현재가)은 유리 체결이므로 허용, fat-finger 딥디스카운트만 차단. 2%는 trim_preplace ultra_near 티어(≤2%)와 대칭.
+SELL_MARKETABLE_MAX_DISCOUNT = 0.02
+
 
 @dataclass(frozen=True)
 class DefensiveTrimContext:
@@ -144,8 +147,14 @@ def evaluate_sell_price_guards(
             f"Sell price {price} below minimum "
             f"(avg_buy_price * 1.01 = {min_sell_price:.0f})"
         )
-    if price < current_price:
-        return f"Sell price {price} below current price {current_price}"
+    if current_price > 0:
+        band_floor = current_price * (1.0 - SELL_MARKETABLE_MAX_DISCOUNT)
+        if price < band_floor:
+            return (
+                f"Sell price {price} below marketable band floor "
+                f"{band_floor:.4f} (current {current_price} * "
+                f"(1 - {SELL_MARKETABLE_MAX_DISCOUNT}))"
+            )
     return None
 
 

--- a/tests/mcp_server/tooling/test_loss_cut_preconditions.py
+++ b/tests/mcp_server/tooling/test_loss_cut_preconditions.py
@@ -60,14 +60,14 @@ def test_defensive_trim_unchanged_still_enforces_current_price():
         approval_verified_at=datetime.datetime.now(datetime.UTC),
     )
     err = evaluate_sell_price_guards(
-        price=1244.0,
+        price=1200.0,
         current_price=1245.0,
         avg_price=2000.0,
         defensive_trim_ctx=dt,
         scalping_exit_ctx=None,
         loss_cut_ctx=None,
     )
-    assert err is not None and "below current price" in err
+    assert err is not None and "below marketable band floor" in err
 
 
 @pytest.mark.unit

--- a/tests/test_kis_mock_loss_sell_guard.py
+++ b/tests/test_kis_mock_loss_sell_guard.py
@@ -8,12 +8,15 @@ equities"); live (is_mock=False) and crypto (real Upbit funds) stay fully guarde
 
 from __future__ import annotations
 
+import datetime
 from unittest.mock import AsyncMock, Mock
 
 import pytest
 
 from app.mcp_server.tooling import order_validation
 from app.mcp_server.tooling.order_validation import (
+    DefensiveTrimContext,
+    LossCutContext,
     ScalpingExitContext,
     evaluate_sell_price_guards,
 )
@@ -309,3 +312,115 @@ def test_scalping_exit_takes_precedence_over_allow_loss_sell() -> None:
         allow_loss_sell=True,
     )
     assert err is None
+
+
+# ---------------------------------------------------------------------------
+# ROB-912: Sell Price Guard Marketable Band Tests
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+def test_rob_912_sell_marketable_band_guards() -> None:
+    # a. [XOM 재현] price=145.51, current=145.71, avg=100.0(floor 무관), ctx 전부 None -> None(허용)
+    err_a = evaluate_sell_price_guards(
+        price=145.51,
+        current_price=145.71,
+        avg_price=100.0,
+        defensive_trim_ctx=None,
+        scalping_exit_ctx=None,
+        allow_loss_sell=False,
+    )
+    assert err_a is None
+
+    # b. [밴드 경계] price == current*(1-0.02) 정확히 -> None(허용, >= 시맨틱스)
+    # 145.71 * 0.98 = 142.7958
+    err_b = evaluate_sell_price_guards(
+        price=142.7958,
+        current_price=145.71,
+        avg_price=100.0,
+        defensive_trim_ctx=None,
+        scalping_exit_ctx=None,
+        allow_loss_sell=False,
+    )
+    assert err_b is None
+
+    # c. [fat-finger 차단] price = current*0.97 (밴드 밖) -> "below marketable band floor" 메시지 반환
+    # 145.71 * 0.97 = 141.3387
+    err_c = evaluate_sell_price_guards(
+        price=141.3387,
+        current_price=145.71,
+        avg_price=100.0,
+        defensive_trim_ctx=None,
+        scalping_exit_ctx=None,
+        allow_loss_sell=False,
+    )
+    assert err_c is not None and "below marketable band floor" in err_c
+
+    # d. [손실매도 여전히 차단] avg=150, current=145.71, price=145.51 (밴드 안이지만 avg*1.01=151.5 미달) -> floor 메시지 반환
+    err_d = evaluate_sell_price_guards(
+        price=145.51,
+        current_price=145.71,
+        avg_price=150.0,
+        defensive_trim_ctx=None,
+        scalping_exit_ctx=None,
+        allow_loss_sell=False,
+    )
+    assert err_d is not None and "below minimum" in err_d
+
+    trim_ctx = DefensiveTrimContext(
+        approval_issue_id="issue",
+        requester_agent_id="agent",
+        approval_verified_at=datetime.datetime.now(datetime.UTC),
+    )
+
+    # 밴드 안(<current) -> None
+    err_e1 = evaluate_sell_price_guards(
+        price=145.51,
+        current_price=145.71,
+        avg_price=150.0,
+        defensive_trim_ctx=trim_ctx,
+        scalping_exit_ctx=None,
+        allow_loss_sell=False,
+    )
+    assert err_e1 is None
+
+    # 밴드 밖(<current*0.98) -> band 메시지
+    err_e2 = evaluate_sell_price_guards(
+        price=141.3387,
+        current_price=145.71,
+        avg_price=150.0,
+        defensive_trim_ctx=trim_ctx,
+        scalping_exit_ctx=None,
+        allow_loss_sell=False,
+    )
+    assert err_e2 is not None and "below marketable band floor" in err_e2
+
+    loss_ctx = LossCutContext(
+        retrospective_id=1,
+        exit_reason="loss_cut",
+        approval_issue_id=None,
+        requester_agent_id="test",
+        max_slip=0.05,
+        approval_verified_at=datetime.datetime.now(datetime.UTC),
+    )
+    # price가 current*(1-0.05) = 145.71 * 0.95 = 138.4245 보다 작으면 차단되어야 함.
+    # price=140.0 은 2% 밴드 밖(142.7958 미만)이지만 loss_cut 5% 밴드 안이므로 None(허용)이어야 함.
+    err_f1 = evaluate_sell_price_guards(
+        price=140.0,
+        current_price=145.71,
+        avg_price=150.0,
+        defensive_trim_ctx=None,
+        scalping_exit_ctx=None,
+        allow_loss_sell=False,
+        loss_cut_ctx=loss_ctx,
+    )
+    assert err_f1 is None
+
+    # g. [시세 불가] current_price=0 -> 현재가 가드 미발동(기존 시맨틱스) 유지.
+    err_g = evaluate_sell_price_guards(
+        price=105.0,
+        current_price=0.0,
+        avg_price=100.0,
+        defensive_trim_ctx=None,
+        scalping_exit_ctx=None,
+        allow_loss_sell=False,
+    )
+    assert err_g is None

--- a/tests/test_kis_mock_scalping_exit_wiring.py
+++ b/tests/test_kis_mock_scalping_exit_wiring.py
@@ -83,6 +83,7 @@ async def test_mock_scalping_exit_bypasses_sell_floor(monkeypatch) -> None:
     err = result.get("error", "")
     assert "below minimum" not in err
     assert "below current price" not in err
+    assert "below marketable band floor" not in err
 
 
 @pytest.mark.unit
@@ -93,5 +94,6 @@ async def test_live_sell_below_floor_still_blocked(monkeypatch) -> None:
     result = await _place(is_mock=False)
     assert result["success"] is False
     assert (
-        "below minimum" in result["error"] or "below current price" in result["error"]
+        "below minimum" in result["error"]
+        or "below marketable band floor" in result["error"]
     )

--- a/tests/test_kis_mock_scalping_sell_guard.py
+++ b/tests/test_kis_mock_scalping_sell_guard.py
@@ -57,7 +57,7 @@ def test_guard_blocks_below_current_price_when_no_context() -> None:
         defensive_trim_ctx=None,
         scalping_exit_ctx=None,
     )
-    assert err is not None and "below current price" in err
+    assert err is not None and "below marketable band floor" in err
 
 
 @pytest.mark.unit
@@ -70,7 +70,7 @@ def test_defensive_trim_bypasses_floor_but_not_current_price() -> None:
         defensive_trim_ctx=_trim_ctx(),
         scalping_exit_ctx=None,
     )
-    assert err is not None and "below current price" in err
+    assert err is not None and "below marketable band floor" in err
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## 1. 근본 원인 (Root Cause)
기존의 order_proposals 승인 경로의 click-time 재검사 시, 지정가 sell 주문의 가격이 현재가보다 낮으면 (`price < current_price`) 무조건 `guard_blocked`로 차단되었습니다. 
하지만 지정가 매도 주문 시 지정가가 현재가보다 낮은 상태(Marketable Limit Order)는 실제 시장에서 더 유리하거나 즉시 체결되는 정상적인 거래 패턴입니다. 특히 트림-선배치 전략(trim-preplace)의 경우 목표가를 관통하여 현재가가 상승했을 때 이 가드에 의해 주문이 차단되는 구조적인 문제가 발생하여 정상 거래가 막히게 되었습니다.

## 2. 해결 방안 및 수정 계약 (Fix Contract)
- `SELL_MARKETABLE_MAX_DISCOUNT = 0.02` 상수를 `order_validation.py` 모듈 상수로 도입하였습니다.
- `evaluate_sell_price_guards`의 마지막 분기인 `price < current_price` 가드를 비대칭 밴드 가드로 완화시켰습니다.
- 현재가 기준 2% 디스카운트 밴드 바닥값(`band_floor = current_price * 0.98`)보다 지정가가 더 낮을 때(fat-finger 딥디스카운트)만 차단하도록 수정했습니다.
- **계약 준수 사항**:
  - `allow_loss_sell` 바이패스, `scalping_exit` 바이패스, `loss_cut_ctx` 밴드(자체 max_slip 유지), `min_sell_price = avg_price * 1.01` floor 및 defensive_trim floor 면제는 **절대 변경하지 않고 기존 비즈니스 로직을 유지**하였습니다.
  - `current_price <= 0` (시세 불가) 시 현재 동작(현재가 가드 미발동)이 유지됩니다.
  - 매수측 가드 및 `evaluate_market_sell_loss_guard`(시장가 경로)는 전혀 수정하지 않았습니다.
  - 이 함수 외 다른 프로덕션 코드는 수정하지 않았습니다.
  - migration 0.

## 3. XOM 재현 케이스 검증
- **상황**: XOM 1주 @145.51 제안 당시 현재가 144.82(정상). 승인 시점 현재가 145.71로 상승.
- **수정 전**: `145.51 < 145.71` 에 의하여 "Sell price 145.51 below current price 145.71" 에러로 guard_blocked.
- **수정 후**: 밴드 바닥인 `145.71 * 0.98 = 142.7958` 보다 `145.51`이 크므로 통과하여 승인 정상 처리됨.

## 4. 테스트 및 검증 증거 (Test Evidence)
- `tests/test_kis_mock_loss_sell_guard.py`에 XOM 재현 시나리오, 밴드 경계(2%), fat-finger 차단(>2% 디스카운트), floor 불변성, defensive_trim 연계, loss_cut 무영향, 시세 불가 케이스 등을 검증하는 `test_rob_912_sell_marketable_band_guards` RED->GREEN 테스트를 추가 및 통과하였습니다.
- 기존의 "below current price" 에러 메시지를 검증하던 테스트 스위트(`tests/mcp_server/tooling/test_loss_cut_preconditions.py`, `tests/test_kis_mock_scalping_sell_guard.py`, `tests/test_kis_mock_scalping_exit_wiring.py`)를 새 시맨틱스 및 메시지에 맞게 갱신하여 100% 통과 완료했습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
