### PR TITLE
feat(ROB-913): add quote snapshot MCP tools for manual submit orders

### DIFF
--- a/app/mcp_server/README.md
+++ b/app/mcp_server/README.md
@@ -509,6 +509,9 @@ replay**. There is no direct-POST fallback, and this holds for `us-paper` only.
   missing / stale / symbol-mismatched / non-finite-priced snapshot fails closed
   before any packet is built. Packet + policy hashes are recorded in the ledger
   preview evidence.
+- **Snapshot retrieval & build lever (ROB-913).** Two MCP tools are provided to manage market quote evidence:
+  - `market_quote_snapshot_latest(market: "kr"|"us"|"crypto", symbol: str)` reads the latest snapshot row and exposes its metadata along with `age_seconds`, `is_fresh` (within 5 minutes: `0 <= age <= 300`), and `submit_ready` (indicating whether it passes the server-side submit gates).
+  - `market_quote_snapshot_ensure(market: "kr"|"us"|"crypto", symbol: str)` ensures a fresh snapshot exists. If the latest row is fresh and submit-ready, it reuses it (`reused: true`). Otherwise, it builds a new snapshot for the symbol (`reused: false`) and validates it. Price injection is strictly forbidden; price is only fetched from the trusted server-side quote sources.
 - **Replay before freshness.** Immutable token/key/hash/account binding is checked
   first; a completed or terminally-failed order then replays its original result
   even after the packet's freshness window has elapsed. Freshness / market-data /

--- a/app/mcp_server/tooling/market_quote_snapshot_tools.py
+++ b/app/mcp_server/tooling/market_quote_snapshot_tools.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+import datetime as dt
+from typing import TYPE_CHECKING, Any
+
+from sqlalchemy import select
+
+from app.core.db import AsyncSessionLocal
+from app.jobs.market_quote_snapshots import (
+    MarketQuoteSnapshotBuildRequest,
+    run_market_quote_snapshot_build,
+)
+from app.models.market_quote_snapshot import MarketQuoteSnapshot
+
+if TYPE_CHECKING:
+    from fastmcp import FastMCP
+
+# Matches _MANUAL_QUOTE_MAX_AGE from app/mcp_server/tooling/alpaca_paper_orders.py
+_MANUAL_QUOTE_MAX_AGE = dt.timedelta(minutes=5)
+
+MARKET_QUOTE_SNAPSHOT_TOOL_NAMES: set[str] = {
+    "market_quote_snapshot_latest",
+    "market_quote_snapshot_ensure",
+}
+
+
+async def market_quote_snapshot_latest(market: str, symbol: str) -> dict[str, Any]:
+    """Retrieve the latest quote snapshot for a market and symbol.
+
+    Args:
+        market: "kr" or "us".
+        symbol: The ticker symbol.
+    """
+    market = str(market).strip().lower()
+    symbol = str(symbol).strip().upper()
+    if market not in ("kr", "us"):
+        raise ValueError("market must be 'kr' or 'us'")
+
+    async with AsyncSessionLocal() as db:
+        stmt = (
+            select(MarketQuoteSnapshot)
+            .where(
+                MarketQuoteSnapshot.market == market,
+                MarketQuoteSnapshot.symbol == symbol,
+            )
+            .order_by(MarketQuoteSnapshot.snapshot_at.desc())
+            .limit(1)
+        )
+        snap = (await db.execute(stmt)).scalar_one_or_none()
+
+    if snap is None:
+        return {"success": True, "found": False}
+
+    snapshot_at = snap.snapshot_at
+    if snapshot_at.tzinfo is None:
+        snapshot_at = snapshot_at.replace(tzinfo=dt.UTC)
+
+    now = dt.datetime.now(dt.UTC)
+    age_seconds = (now - snapshot_at).total_seconds()
+    is_fresh = (now - snapshot_at) <= _MANUAL_QUOTE_MAX_AGE
+
+    return {
+        "success": True,
+        "found": True,
+        "id": snap.id,
+        "market": snap.market,
+        "symbol": snap.symbol,
+        "price": float(snap.price),
+        "source": snap.source,
+        "snapshot_at": snapshot_at.isoformat(),
+        "age_seconds": age_seconds,
+        "is_fresh": is_fresh,
+    }
+
+
+async def market_quote_snapshot_ensure(market: str, symbol: str) -> dict[str, Any]:
+    """Ensure a fresh quote snapshot exists for a market and symbol, building one if needed.
+
+    Args:
+        market: "kr" or "us".
+        symbol: The ticker symbol.
+    """
+    market = str(market).strip().lower()
+    symbol = str(symbol).strip().upper()
+    if market not in ("kr", "us"):
+        raise ValueError("market must be 'kr' or 'us'")
+
+    async with AsyncSessionLocal() as db:
+        stmt = (
+            select(MarketQuoteSnapshot)
+            .where(
+                MarketQuoteSnapshot.market == market,
+                MarketQuoteSnapshot.symbol == symbol,
+            )
+            .order_by(MarketQuoteSnapshot.snapshot_at.desc())
+            .limit(1)
+        )
+        snap = (await db.execute(stmt)).scalar_one_or_none()
+
+    if snap is not None:
+        snapshot_at = snap.snapshot_at
+        if snapshot_at.tzinfo is None:
+            snapshot_at = snapshot_at.replace(tzinfo=dt.UTC)
+        now = dt.datetime.now(dt.UTC)
+        age = now - snapshot_at
+        if age <= _MANUAL_QUOTE_MAX_AGE:
+            return {
+                "success": True,
+                "found": True,
+                "reused": True,
+                "id": snap.id,
+                "market": snap.market,
+                "symbol": snap.symbol,
+                "price": float(snap.price),
+                "source": snap.source,
+                "snapshot_at": snapshot_at.isoformat(),
+                "age_seconds": age.total_seconds(),
+                "is_fresh": True,
+            }
+
+    # Otherwise build it
+    request = MarketQuoteSnapshotBuildRequest(
+        market=market,
+        symbols=(symbol,),
+        commit=True,
+        limit=None,
+    )
+
+    try:
+        build_result = await run_market_quote_snapshot_build(request)
+    except Exception as exc:
+        return {"success": False, "error": str(exc)}
+
+    if build_result.snapshots_built == 0:
+        warning_msg = (
+            build_result.warnings[0]
+            if build_result.warnings
+            else "failed to build snapshot"
+        )
+        return {"success": False, "error": f"Build failed: {warning_msg}"}
+
+    async with AsyncSessionLocal() as db:
+        stmt = (
+            select(MarketQuoteSnapshot)
+            .where(
+                MarketQuoteSnapshot.market == market,
+                MarketQuoteSnapshot.symbol == symbol,
+            )
+            .order_by(MarketQuoteSnapshot.snapshot_at.desc())
+            .limit(1)
+        )
+        new_snap = (await db.execute(stmt)).scalar_one_or_none()
+
+    if new_snap is None:
+        return {"success": False, "error": "New snapshot not found after build"}
+
+    snapshot_at = new_snap.snapshot_at
+    if snapshot_at.tzinfo is None:
+        snapshot_at = snapshot_at.replace(tzinfo=dt.UTC)
+    now = dt.datetime.now(dt.UTC)
+    age_seconds = (now - snapshot_at).total_seconds()
+    is_fresh = (now - snapshot_at) <= _MANUAL_QUOTE_MAX_AGE
+
+    return {
+        "success": True,
+        "found": True,
+        "reused": False,
+        "id": new_snap.id,
+        "market": new_snap.market,
+        "symbol": new_snap.symbol,
+        "price": float(new_snap.price),
+        "source": new_snap.source,
+        "snapshot_at": snapshot_at.isoformat(),
+        "age_seconds": age_seconds,
+        "is_fresh": is_fresh,
+    }
+
+
+def register_market_quote_snapshot_tools(mcp: FastMCP) -> None:
+    """Register market quote snapshot MCP tools."""
+    _ = mcp.tool(
+        name="market_quote_snapshot_latest",
+        description="Retrieve the latest quote snapshot for a given market ('kr' or 'us') and symbol.",
+    )(market_quote_snapshot_latest)
+    _ = mcp.tool(
+        name="market_quote_snapshot_ensure",
+        description="Ensure a fresh quote snapshot (age < 5m) exists for a market and symbol. Reuses if fresh, builds if stale.",
+    )(market_quote_snapshot_ensure)

--- a/app/mcp_server/tooling/market_quote_snapshot_tools.py
+++ b/app/mcp_server/tooling/market_quote_snapshot_tools.py
@@ -24,17 +24,76 @@ MARKET_QUOTE_SNAPSHOT_TOOL_NAMES: set[str] = {
 }
 
 
+async def check_submit_ready(
+    db: Any, snap: MarketQuoteSnapshot
+) -> tuple[bool, str | None]:
+    """Verify if a snapshot is ready for submission under server-side trust constraints.
+
+    Uses load_market_evidence from alpaca_paper_market_evidence.py.
+    """
+    market = snap.market.lower()
+    symbol = snap.symbol.upper()
+
+    if market == "us":
+        asset_class = "us_equity"
+        execution_symbol = symbol
+    elif market == "crypto":
+        asset_class = "crypto"
+        from app.services.crypto_execution_mapping import (
+            CryptoExecutionMappingError,
+            map_upbit_to_alpaca_paper,
+        )
+
+        try:
+            mapping = map_upbit_to_alpaca_paper(symbol)
+            execution_symbol = mapping.execution_symbol
+        except CryptoExecutionMappingError:
+            return False, "snapshot_symbol_mismatch"
+    else:
+        return False, "snapshot_symbol_mismatch"
+
+    from app.services.alpaca_paper_market_evidence import (
+        MarketEvidenceError,
+        load_market_evidence,
+    )
+
+    now = dt.datetime.now(dt.UTC)
+    snapshot_at = snap.snapshot_at
+    if snapshot_at.tzinfo is None:
+        snapshot_at = snapshot_at.replace(tzinfo=dt.UTC)
+
+    # Future timestamp check (F2: age_seconds must be >= 0)
+    age_seconds = (now - snapshot_at).total_seconds()
+    if age_seconds < 0:
+        return False, "future_snapshot_at"
+
+    try:
+        await load_market_evidence(
+            db,
+            snap.id,
+            execution_symbol=execution_symbol,
+            asset_class=asset_class,
+            now=now,
+            max_age=_MANUAL_QUOTE_MAX_AGE,
+        )
+        return True, None
+    except MarketEvidenceError as exc:
+        return False, exc.code
+    except Exception:
+        return False, "snapshot_not_submittable"
+
+
 async def market_quote_snapshot_latest(market: str, symbol: str) -> dict[str, Any]:
     """Retrieve the latest quote snapshot for a market and symbol.
 
     Args:
-        market: "kr" or "us".
+        market: "kr", "us", or "crypto".
         symbol: The ticker symbol.
     """
     market = str(market).strip().lower()
     symbol = str(symbol).strip().upper()
-    if market not in ("kr", "us"):
-        raise ValueError("market must be 'kr' or 'us'")
+    if market not in ("kr", "us", "crypto"):
+        raise ValueError("market must be 'kr', 'us', or 'crypto'")
 
     async with AsyncSessionLocal() as db:
         stmt = (
@@ -48,16 +107,18 @@ async def market_quote_snapshot_latest(market: str, symbol: str) -> dict[str, An
         )
         snap = (await db.execute(stmt)).scalar_one_or_none()
 
-    if snap is None:
-        return {"success": True, "found": False}
+        if snap is None:
+            return {"success": True, "found": False, "submit_ready": False}
 
-    snapshot_at = snap.snapshot_at
-    if snapshot_at.tzinfo is None:
-        snapshot_at = snapshot_at.replace(tzinfo=dt.UTC)
+        submit_ready, reason_code = await check_submit_ready(db, snap)
 
-    now = dt.datetime.now(dt.UTC)
-    age_seconds = (now - snapshot_at).total_seconds()
-    is_fresh = (now - snapshot_at) <= _MANUAL_QUOTE_MAX_AGE
+        snapshot_at = snap.snapshot_at
+        if snapshot_at.tzinfo is None:
+            snapshot_at = snapshot_at.replace(tzinfo=dt.UTC)
+
+        now = dt.datetime.now(dt.UTC)
+        age_seconds = (now - snapshot_at).total_seconds()
+        is_fresh = 0.0 <= age_seconds <= 300.0
 
     return {
         "success": True,
@@ -70,6 +131,8 @@ async def market_quote_snapshot_latest(market: str, symbol: str) -> dict[str, An
         "snapshot_at": snapshot_at.isoformat(),
         "age_seconds": age_seconds,
         "is_fresh": is_fresh,
+        "submit_ready": submit_ready,
+        "reason_code": reason_code,
     }
 
 
@@ -77,13 +140,13 @@ async def market_quote_snapshot_ensure(market: str, symbol: str) -> dict[str, An
     """Ensure a fresh quote snapshot exists for a market and symbol, building one if needed.
 
     Args:
-        market: "kr" or "us".
+        market: "kr", "us", or "crypto".
         symbol: The ticker symbol.
     """
     market = str(market).strip().lower()
     symbol = str(symbol).strip().upper()
-    if market not in ("kr", "us"):
-        raise ValueError("market must be 'kr' or 'us'")
+    if market not in ("kr", "us", "crypto"):
+        raise ValueError("market must be 'kr', 'us', or 'crypto'")
 
     async with AsyncSessionLocal() as db:
         stmt = (
@@ -97,26 +160,31 @@ async def market_quote_snapshot_ensure(market: str, symbol: str) -> dict[str, An
         )
         snap = (await db.execute(stmt)).scalar_one_or_none()
 
-    if snap is not None:
-        snapshot_at = snap.snapshot_at
-        if snapshot_at.tzinfo is None:
-            snapshot_at = snapshot_at.replace(tzinfo=dt.UTC)
-        now = dt.datetime.now(dt.UTC)
-        age = now - snapshot_at
-        if age <= _MANUAL_QUOTE_MAX_AGE:
-            return {
-                "success": True,
-                "found": True,
-                "reused": True,
-                "id": snap.id,
-                "market": snap.market,
-                "symbol": snap.symbol,
-                "price": float(snap.price),
-                "source": snap.source,
-                "snapshot_at": snapshot_at.isoformat(),
-                "age_seconds": age.total_seconds(),
-                "is_fresh": True,
-            }
+        if snap is not None:
+            snapshot_at = snap.snapshot_at
+            if snapshot_at.tzinfo is None:
+                snapshot_at = snapshot_at.replace(tzinfo=dt.UTC)
+            now = dt.datetime.now(dt.UTC)
+            age_seconds = (now - snapshot_at).total_seconds()
+
+            # F2: 0 <= age_seconds <= 300 for reuse eligibility
+            if 0.0 <= age_seconds <= 300.0:
+                submit_ready, reason_code = await check_submit_ready(db, snap)
+                if submit_ready:
+                    return {
+                        "success": True,
+                        "found": True,
+                        "reused": True,
+                        "id": snap.id,
+                        "market": snap.market,
+                        "symbol": snap.symbol,
+                        "price": float(snap.price),
+                        "source": snap.source,
+                        "snapshot_at": snapshot_at.isoformat(),
+                        "age_seconds": age_seconds,
+                        "is_fresh": True,
+                        "submit_ready": True,
+                    }
 
     # Otherwise build it
     request = MarketQuoteSnapshotBuildRequest(
@@ -129,7 +197,7 @@ async def market_quote_snapshot_ensure(market: str, symbol: str) -> dict[str, An
     try:
         build_result = await run_market_quote_snapshot_build(request)
     except Exception as exc:
-        return {"success": False, "error": str(exc)}
+        return {"success": False, "error": str(exc), "reason_code": "build_failed"}
 
     if build_result.snapshots_built == 0:
         warning_msg = (
@@ -137,7 +205,11 @@ async def market_quote_snapshot_ensure(market: str, symbol: str) -> dict[str, An
             if build_result.warnings
             else "failed to build snapshot"
         )
-        return {"success": False, "error": f"Build failed: {warning_msg}"}
+        return {
+            "success": False,
+            "error": f"Build failed: {warning_msg}",
+            "reason_code": "build_failed",
+        }
 
     async with AsyncSessionLocal() as db:
         stmt = (
@@ -151,15 +223,34 @@ async def market_quote_snapshot_ensure(market: str, symbol: str) -> dict[str, An
         )
         new_snap = (await db.execute(stmt)).scalar_one_or_none()
 
-    if new_snap is None:
-        return {"success": False, "error": "New snapshot not found after build"}
+        if new_snap is None:
+            return {
+                "success": False,
+                "error": "New snapshot not found after build",
+                "reason_code": "build_failed",
+            }
 
-    snapshot_at = new_snap.snapshot_at
-    if snapshot_at.tzinfo is None:
-        snapshot_at = snapshot_at.replace(tzinfo=dt.UTC)
-    now = dt.datetime.now(dt.UTC)
-    age_seconds = (now - snapshot_at).total_seconds()
-    is_fresh = (now - snapshot_at) <= _MANUAL_QUOTE_MAX_AGE
+        # Validate newly built snapshot
+        submit_ready, reason_code = await check_submit_ready(db, new_snap)
+
+        snapshot_at = new_snap.snapshot_at
+        if snapshot_at.tzinfo is None:
+            snapshot_at = snapshot_at.replace(tzinfo=dt.UTC)
+        now = dt.datetime.now(dt.UTC)
+        age_seconds = (now - snapshot_at).total_seconds()
+        is_fresh = 0.0 <= age_seconds <= 300.0
+
+        if not submit_ready:
+            error_code = (
+                "stale_after_build"
+                if reason_code == "stale_trusted_snapshot"
+                else reason_code
+            )
+            return {
+                "success": False,
+                "error": f"Build resulted in an invalid or stale snapshot: {error_code}",
+                "reason_code": error_code,
+            }
 
     return {
         "success": True,
@@ -173,6 +264,7 @@ async def market_quote_snapshot_ensure(market: str, symbol: str) -> dict[str, An
         "snapshot_at": snapshot_at.isoformat(),
         "age_seconds": age_seconds,
         "is_fresh": is_fresh,
+        "submit_ready": True,
     }
 
 
@@ -180,7 +272,7 @@ def register_market_quote_snapshot_tools(mcp: FastMCP) -> None:
     """Register market quote snapshot MCP tools."""
     _ = mcp.tool(
         name="market_quote_snapshot_latest",
-        description="Retrieve the latest quote snapshot for a given market ('kr' or 'us') and symbol.",
+        description="Retrieve the latest quote snapshot for a given market ('kr', 'us', or 'crypto') and symbol.",
     )(market_quote_snapshot_latest)
     _ = mcp.tool(
         name="market_quote_snapshot_ensure",

--- a/app/mcp_server/tooling/registry.py
+++ b/app/mcp_server/tooling/registry.py
@@ -127,6 +127,9 @@ from app.mcp_server.tooling.market_brief_registration import (
     register_market_brief_tools,
 )
 from app.mcp_server.tooling.market_data_registration import register_market_data_tools
+from app.mcp_server.tooling.market_quote_snapshot_tools import (
+    register_market_quote_snapshot_tools,
+)
 from app.mcp_server.tooling.mirror_counterfactual_registration import (
     register_mirror_counterfactual_tools,
 )
@@ -378,6 +381,7 @@ def register_all_tools(mcp: FastMCP, profile: McpProfile = McpProfile.DEFAULT) -
             register_us_dual_paper_tools(mcp)
             register_alpaca_paper_orders_tools(mcp)
             register_alpaca_paper_ledger_read_tools(mcp)
+            register_market_quote_snapshot_tools(mcp)
     elif profile is McpProfile.HERMES_PAPER_KIS:
         # Paper-only: only mock-pinned order surface. Live surface is physically absent.
         register_kis_mock_order_tools(mcp)
@@ -393,6 +397,7 @@ def register_all_tools(mcp: FastMCP, profile: McpProfile = McpProfile.DEFAULT) -
         register_alpaca_paper_orders_tools(mcp)
         register_alpaca_paper_automated_orders_tools(mcp)
         register_alpaca_paper_ledger_read_tools(mcp)
+        register_market_quote_snapshot_tools(mcp)
     elif profile is McpProfile.DB_PAPER:
         register_paper_account_tools(mcp)
         register_paper_analytics_tools(mcp)

--- a/app/mcp_server/tooling/route_request_lanes.py
+++ b/app/mcp_server/tooling/route_request_lanes.py
@@ -15,6 +15,9 @@ from typing import Any
 from app.mcp_server.tooling.alpaca_paper import ALPACA_PAPER_READONLY_TOOL_NAMES
 from app.mcp_server.tooling.alpaca_paper_orders import ALPACA_PAPER_MUTATING_TOOL_NAMES
 from app.mcp_server.tooling.alpaca_paper_preview import ALPACA_PAPER_PREVIEW_TOOL_NAMES
+from app.mcp_server.tooling.market_quote_snapshot_tools import (
+    MARKET_QUOTE_SNAPSHOT_TOOL_NAMES,
+)
 from app.mcp_server.tooling.mirror_counterfactual_registration import (
     MIRROR_COUNTERFACTUAL_TOOL_NAMES,
 )
@@ -283,6 +286,7 @@ READ_ONLY_ADVISORY_TOOLS: frozenset[str] = frozenset(
         *ALPACA_PAPER_READONLY_TOOL_NAMES,
         *ALPACA_PAPER_PREVIEW_TOOL_NAMES,
         *US_DUAL_PAPER_TOOL_NAMES,
+        *MARKET_QUOTE_SNAPSHOT_TOOL_NAMES,
         "route_request",
         "analysis_artifact_get",
         "analysis_artifact_list",

--- a/tests/mcp_server/test_alpaca_paper_default_profile_gate.py
+++ b/tests/mcp_server/test_alpaca_paper_default_profile_gate.py
@@ -25,17 +25,21 @@ from app.mcp_server.tooling.alpaca_paper_automated_orders import (
 )
 from app.mcp_server.tooling.alpaca_paper_orders import ALPACA_PAPER_MUTATING_TOOL_NAMES
 from app.mcp_server.tooling.alpaca_paper_preview import ALPACA_PAPER_PREVIEW_TOOL_NAMES
+from app.mcp_server.tooling.market_quote_snapshot_tools import (
+    MARKET_QUOTE_SNAPSHOT_TOOL_NAMES,
+)
 from app.mcp_server.tooling.registry import register_all_tools
 from app.mcp_server.tooling.us_dual_paper import US_DUAL_PAPER_TOOL_NAMES
 from tests._mcp_tooling_support import DummyMCP
 
-# The full flag-gated DEFAULT surface (18 tools): read + preview + us_dual +
-# confirm-gated submit/cancel + ledger reads.
+# The full flag-gated DEFAULT surface (20 tools): read + preview + us_dual +
+# confirm-gated submit/cancel + ledger reads + market quote snapshot tools.
 _DEFAULT_ALPACA_TOOL_NAMES = (
     ALPACA_PAPER_READONLY_TOOL_NAMES
     | ALPACA_PAPER_PREVIEW_TOOL_NAMES
     | US_DUAL_PAPER_TOOL_NAMES
     | ALPACA_PAPER_MUTATING_TOOL_NAMES
+    | MARKET_QUOTE_SNAPSHOT_TOOL_NAMES
 )
 
 

--- a/tests/mcp_server/test_market_quote_snapshot_tools.py
+++ b/tests/mcp_server/test_market_quote_snapshot_tools.py
@@ -1,0 +1,217 @@
+from __future__ import annotations
+
+import datetime as dt
+from decimal import Decimal
+from unittest.mock import AsyncMock
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import delete
+
+from app.core.db import AsyncSessionLocal
+from app.mcp_server.profiles import McpProfile
+
+# We will import these once the module is implemented
+# For now, we import them inside functions or handle potential ImportError during TDD RED phase.
+# To make it fail cleanly during TDD RED phase, we will do top-level imports that will fail.
+from app.mcp_server.tooling.market_quote_snapshot_tools import (
+    market_quote_snapshot_ensure,
+    market_quote_snapshot_latest,
+)
+from app.mcp_server.tooling.registry import register_all_tools
+from app.models.market_quote_snapshot import MarketQuoteSnapshot
+from tests._mcp_tooling_support import DummyMCP
+
+pytestmark = [pytest.mark.asyncio]
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def _clean_db():
+    stmt = delete(MarketQuoteSnapshot).where(
+        MarketQuoteSnapshot.symbol == "MOCKSNAP",
+        MarketQuoteSnapshot.market == "us",
+    )
+    async with AsyncSessionLocal() as db:
+        await db.execute(stmt)
+        await db.commit()
+    yield
+    async with AsyncSessionLocal() as db:
+        await db.execute(stmt)
+        await db.commit()
+
+
+async def _seed_snapshot(
+    snapshot_at: dt.datetime, price: Decimal = Decimal("150.00")
+) -> int:
+    async with AsyncSessionLocal() as db:
+        row = MarketQuoteSnapshot(
+            market="us",
+            symbol="MOCKSNAP",
+            source="yahoo",
+            snapshot_at=snapshot_at,
+            price=price,
+            raw_payload={"source_api": "yahoo", "regularMarketPrice": float(price)},
+        )
+        db.add(row)
+        await db.commit()
+        return row.id
+
+
+async def test_latest_row_exists():
+    now = dt.datetime.now(dt.UTC)
+
+    # 4m 59s ago -> fresh
+    fresh_time = now - dt.timedelta(minutes=4, seconds=59)
+    fresh_id = await _seed_snapshot(fresh_time, Decimal("100.00"))
+
+    # 5m 1s ago -> stale
+    stale_time = now - dt.timedelta(minutes=5, seconds=1)
+    stale_id = await _seed_snapshot(stale_time, Decimal("90.00"))
+
+    # latest should return the fresh one because it's newer (ordered by snapshot_at desc)
+    res = await market_quote_snapshot_latest("us", "MOCKSNAP")
+    assert res["success"] is True
+    assert res["found"] is True
+    assert res["id"] == fresh_id
+    assert res["price"] == 100.0
+    assert res["is_fresh"] is True
+
+    # Clean up the fresh one to see the stale one
+    async with AsyncSessionLocal() as db:
+        await db.execute(
+            delete(MarketQuoteSnapshot).where(MarketQuoteSnapshot.id == fresh_id)
+        )
+        await db.commit()
+
+    res = await market_quote_snapshot_latest("us", "MOCKSNAP")
+    assert res["success"] is True
+    assert res["found"] is True
+    assert res["id"] == stale_id
+    assert res["price"] == 90.0
+    assert res["is_fresh"] is False
+
+
+async def test_latest_no_row():
+    res = await market_quote_snapshot_latest("us", "MOCKSNAP")
+    assert res["success"] is True
+    assert res["found"] is False
+
+
+async def test_ensure_fresh_exists(monkeypatch):
+    now = dt.datetime.now(dt.UTC)
+    fresh_time = now - dt.timedelta(minutes=2)
+    sid = await _seed_snapshot(fresh_time, Decimal("120.00"))
+
+    # Mock the build function to assert it is NOT called
+    mock_build = AsyncMock()
+    monkeypatch.setattr(
+        "app.mcp_server.tooling.market_quote_snapshot_tools.run_market_quote_snapshot_build",
+        mock_build,
+    )
+
+    res = await market_quote_snapshot_ensure("us", "MOCKSNAP")
+    assert res["success"] is True
+    assert res["found"] is True
+    assert res["reused"] is True
+    assert res["id"] == sid
+    assert res["price"] == 120.0
+    assert res["is_fresh"] is True
+    mock_build.assert_not_called()
+
+
+async def test_ensure_stale_or_missing_triggers_build(monkeypatch):
+    # Scenario: Missing row, triggers build and returns new snapshot
+    from app.jobs.market_quote_snapshots import MarketQuoteSnapshotBuildResult
+
+    async def fake_build(request):
+        # Seed a new snapshot inside the build
+        await _seed_snapshot(dt.datetime.now(dt.UTC), Decimal("130.00"))
+        return MarketQuoteSnapshotBuildResult(
+            market=request.market,
+            symbols_resolved=1,
+            snapshots_built=1,
+            committed=True,
+            batches=1,
+            started_at=dt.datetime.now(dt.UTC),
+            finished_at=dt.datetime.now(dt.UTC),
+        )
+
+    monkeypatch.setattr(
+        "app.mcp_server.tooling.market_quote_snapshot_tools.run_market_quote_snapshot_build",
+        fake_build,
+    )
+
+    res = await market_quote_snapshot_ensure("us", "MOCKSNAP")
+    assert res["success"] is True
+    assert res["found"] is True
+    assert res["reused"] is False
+    assert res["price"] == 130.0
+    assert res["is_fresh"] is True
+
+
+async def test_ensure_build_failure(monkeypatch):
+    from app.jobs.market_quote_snapshots import MarketQuoteSnapshotBuildResult
+
+    async def fake_build(request):
+        return MarketQuoteSnapshotBuildResult(
+            market=request.market,
+            symbols_resolved=1,
+            snapshots_built=0,
+            committed=True,
+            batches=1,
+            started_at=dt.datetime.now(dt.UTC),
+            finished_at=dt.datetime.now(dt.UTC),
+            warnings=("quote source unavailable",),
+        )
+
+    monkeypatch.setattr(
+        "app.mcp_server.tooling.market_quote_snapshot_tools.run_market_quote_snapshot_build",
+        fake_build,
+    )
+
+    res = await market_quote_snapshot_ensure("us", "MOCKSNAP")
+    assert res["success"] is False
+    assert "error" in res
+    assert "unavailable" in res["error"]
+
+
+@pytest.mark.unit
+async def test_registration_gate(monkeypatch):
+    from app.mcp_server.tooling import registry as registry_mod
+
+    # default off -> absent
+    monkeypatch.setattr(
+        registry_mod.settings,
+        "alpaca_paper_default_tools_enabled",
+        False,
+        raising=False,
+    )
+    mcp = DummyMCP()
+    register_all_tools(mcp, profile=McpProfile.DEFAULT)
+    assert "market_quote_snapshot_latest" not in mcp.tools
+    assert "market_quote_snapshot_ensure" not in mcp.tools
+
+    # default on -> present
+    monkeypatch.setattr(
+        registry_mod.settings,
+        "alpaca_paper_default_tools_enabled",
+        True,
+        raising=False,
+    )
+    mcp2 = DummyMCP()
+    register_all_tools(mcp2, profile=McpProfile.DEFAULT)
+    assert "market_quote_snapshot_latest" in mcp2.tools
+    assert "market_quote_snapshot_ensure" in mcp2.tools
+
+    # US_PAPER profile -> always present
+    for flag in (False, True):
+        monkeypatch.setattr(
+            registry_mod.settings,
+            "alpaca_paper_default_tools_enabled",
+            flag,
+            raising=False,
+        )
+        mcp3 = DummyMCP()
+        register_all_tools(mcp3, profile=McpProfile.US_PAPER)
+        assert "market_quote_snapshot_latest" in mcp3.tools
+        assert "market_quote_snapshot_ensure" in mcp3.tools

--- a/tests/mcp_server/test_market_quote_snapshot_tools.py
+++ b/tests/mcp_server/test_market_quote_snapshot_tools.py
@@ -10,10 +10,6 @@ from sqlalchemy import delete
 
 from app.core.db import AsyncSessionLocal
 from app.mcp_server.profiles import McpProfile
-
-# We will import these once the module is implemented
-# For now, we import them inside functions or handle potential ImportError during TDD RED phase.
-# To make it fail cleanly during TDD RED phase, we will do top-level imports that will fail.
 from app.mcp_server.tooling.market_quote_snapshot_tools import (
     market_quote_snapshot_ensure,
     market_quote_snapshot_latest,
@@ -28,8 +24,7 @@ pytestmark = [pytest.mark.asyncio]
 @pytest_asyncio.fixture(autouse=True)
 async def _clean_db():
     stmt = delete(MarketQuoteSnapshot).where(
-        MarketQuoteSnapshot.symbol == "MOCKSNAP",
-        MarketQuoteSnapshot.market == "us",
+        MarketQuoteSnapshot.symbol.in_(["MOCKSNAP", "KRW-BTC"])
     )
     async with AsyncSessionLocal() as db:
         await db.execute(stmt)
@@ -41,22 +36,29 @@ async def _clean_db():
 
 
 async def _seed_snapshot(
-    snapshot_at: dt.datetime, price: Decimal = Decimal("150.00")
+    snapshot_at: dt.datetime,
+    price: Decimal = Decimal("150.00"),
+    market: str = "us",
+    symbol: str = "MOCKSNAP",
+    raw_payload: dict | None = None,
 ) -> int:
+    if raw_payload is None:
+        raw_payload = {"source_api": "yahoo", "regularMarketPrice": float(price)}
     async with AsyncSessionLocal() as db:
         row = MarketQuoteSnapshot(
-            market="us",
-            symbol="MOCKSNAP",
-            source="yahoo",
+            market=market,
+            symbol=symbol,
+            source="yahoo" if market == "us" else "upbit",
             snapshot_at=snapshot_at,
             price=price,
-            raw_payload={"source_api": "yahoo", "regularMarketPrice": float(price)},
+            raw_payload=raw_payload,
         )
         db.add(row)
         await db.commit()
         return row.id
 
 
+@pytest.mark.integration
 async def test_latest_row_exists():
     now = dt.datetime.now(dt.UTC)
 
@@ -68,13 +70,13 @@ async def test_latest_row_exists():
     stale_time = now - dt.timedelta(minutes=5, seconds=1)
     stale_id = await _seed_snapshot(stale_time, Decimal("90.00"))
 
-    # latest should return the fresh one because it's newer (ordered by snapshot_at desc)
     res = await market_quote_snapshot_latest("us", "MOCKSNAP")
     assert res["success"] is True
     assert res["found"] is True
     assert res["id"] == fresh_id
     assert res["price"] == 100.0
     assert res["is_fresh"] is True
+    assert res["submit_ready"] is True
 
     # Clean up the fresh one to see the stale one
     async with AsyncSessionLocal() as db:
@@ -89,20 +91,24 @@ async def test_latest_row_exists():
     assert res["id"] == stale_id
     assert res["price"] == 90.0
     assert res["is_fresh"] is False
+    assert res["submit_ready"] is False
+    assert res["reason_code"] == "stale_trusted_snapshot"
 
 
+@pytest.mark.integration
 async def test_latest_no_row():
     res = await market_quote_snapshot_latest("us", "MOCKSNAP")
     assert res["success"] is True
     assert res["found"] is False
+    assert res["submit_ready"] is False
 
 
+@pytest.mark.integration
 async def test_ensure_fresh_exists(monkeypatch):
     now = dt.datetime.now(dt.UTC)
     fresh_time = now - dt.timedelta(minutes=2)
     sid = await _seed_snapshot(fresh_time, Decimal("120.00"))
 
-    # Mock the build function to assert it is NOT called
     mock_build = AsyncMock()
     monkeypatch.setattr(
         "app.mcp_server.tooling.market_quote_snapshot_tools.run_market_quote_snapshot_build",
@@ -119,12 +125,11 @@ async def test_ensure_fresh_exists(monkeypatch):
     mock_build.assert_not_called()
 
 
+@pytest.mark.integration
 async def test_ensure_stale_or_missing_triggers_build(monkeypatch):
-    # Scenario: Missing row, triggers build and returns new snapshot
     from app.jobs.market_quote_snapshots import MarketQuoteSnapshotBuildResult
 
     async def fake_build(request):
-        # Seed a new snapshot inside the build
         await _seed_snapshot(dt.datetime.now(dt.UTC), Decimal("130.00"))
         return MarketQuoteSnapshotBuildResult(
             market=request.market,
@@ -149,6 +154,7 @@ async def test_ensure_stale_or_missing_triggers_build(monkeypatch):
     assert res["is_fresh"] is True
 
 
+@pytest.mark.integration
 async def test_ensure_build_failure(monkeypatch):
     from app.jobs.market_quote_snapshots import MarketQuoteSnapshotBuildResult
 
@@ -172,7 +178,166 @@ async def test_ensure_build_failure(monkeypatch):
     res = await market_quote_snapshot_ensure("us", "MOCKSNAP")
     assert res["success"] is False
     assert "error" in res
-    assert "unavailable" in res["error"]
+    assert res["reason_code"] == "build_failed"
+
+
+@pytest.mark.integration
+async def test_synthetic_snapshot_rejected(monkeypatch):
+    now = dt.datetime.now(dt.UTC)
+    await _seed_snapshot(now, Decimal("100.00"), raw_payload={"synthetic": True})
+
+    res_latest = await market_quote_snapshot_latest("us", "MOCKSNAP")
+    assert res_latest["submit_ready"] is False
+    assert res_latest["reason_code"] == "synthetic_snapshot"
+
+    from app.jobs.market_quote_snapshots import MarketQuoteSnapshotBuildResult
+
+    async def fake_build_synthetic(request):
+        await _seed_snapshot(
+            dt.datetime.now(dt.UTC), Decimal("100.00"), raw_payload={"synthetic": True}
+        )
+        return MarketQuoteSnapshotBuildResult(
+            market=request.market,
+            symbols_resolved=1,
+            snapshots_built=1,
+            committed=True,
+            batches=1,
+            started_at=dt.datetime.now(dt.UTC),
+            finished_at=dt.datetime.now(dt.UTC),
+        )
+
+    monkeypatch.setattr(
+        "app.mcp_server.tooling.market_quote_snapshot_tools.run_market_quote_snapshot_build",
+        fake_build_synthetic,
+    )
+
+    res_ensure = await market_quote_snapshot_ensure("us", "MOCKSNAP")
+    assert res_ensure["success"] is False
+    assert res_ensure["reason_code"] == "synthetic_snapshot"
+
+
+@pytest.mark.integration
+async def test_invalid_price_rejected(monkeypatch):
+    now = dt.datetime.now(dt.UTC)
+    await _seed_snapshot(now, Decimal("0.00"))
+
+    res_latest = await market_quote_snapshot_latest("us", "MOCKSNAP")
+    assert res_latest["submit_ready"] is False
+    assert res_latest["reason_code"] == "invalid_snapshot_price"
+
+    from app.jobs.market_quote_snapshots import MarketQuoteSnapshotBuildResult
+
+    async def fake_build_zero_price(request):
+        await _seed_snapshot(dt.datetime.now(dt.UTC), Decimal("0.00"))
+        return MarketQuoteSnapshotBuildResult(
+            market=request.market,
+            symbols_resolved=1,
+            snapshots_built=1,
+            committed=True,
+            batches=1,
+            started_at=dt.datetime.now(dt.UTC),
+            finished_at=dt.datetime.now(dt.UTC),
+        )
+
+    monkeypatch.setattr(
+        "app.mcp_server.tooling.market_quote_snapshot_tools.run_market_quote_snapshot_build",
+        fake_build_zero_price,
+    )
+
+    res_ensure = await market_quote_snapshot_ensure("us", "MOCKSNAP")
+    assert res_ensure["success"] is False
+    assert res_ensure["reason_code"] == "invalid_snapshot_price"
+
+
+@pytest.mark.integration
+async def test_post_build_stale_rejected(monkeypatch):
+    from app.jobs.market_quote_snapshots import MarketQuoteSnapshotBuildResult
+
+    async def fake_build_stale(request):
+        six_mins_ago = dt.datetime.now(dt.UTC) - dt.timedelta(minutes=6)
+        await _seed_snapshot(six_mins_ago, Decimal("100.00"))
+        return MarketQuoteSnapshotBuildResult(
+            market=request.market,
+            symbols_resolved=1,
+            snapshots_built=1,
+            committed=True,
+            batches=1,
+            started_at=dt.datetime.now(dt.UTC),
+            finished_at=dt.datetime.now(dt.UTC),
+        )
+
+    monkeypatch.setattr(
+        "app.mcp_server.tooling.market_quote_snapshot_tools.run_market_quote_snapshot_build",
+        fake_build_stale,
+    )
+
+    res_ensure = await market_quote_snapshot_ensure("us", "MOCKSNAP")
+    assert res_ensure["success"] is False
+    assert res_ensure["reason_code"] == "stale_after_build"
+
+
+@pytest.mark.integration
+async def test_future_timestamp_not_reused_and_fails(monkeypatch):
+    now = dt.datetime.now(dt.UTC)
+    future_time = now + dt.timedelta(minutes=2)
+    await _seed_snapshot(future_time, Decimal("100.00"))
+
+    res_latest = await market_quote_snapshot_latest("us", "MOCKSNAP")
+    assert res_latest["is_fresh"] is False
+    assert res_latest["submit_ready"] is False
+    assert res_latest["reason_code"] == "future_snapshot_at"
+
+    from app.jobs.market_quote_snapshots import MarketQuoteSnapshotBuildResult
+
+    async def fake_build_future(request):
+        await _seed_snapshot(
+            dt.datetime.now(dt.UTC) + dt.timedelta(minutes=2), Decimal("100.00")
+        )
+        return MarketQuoteSnapshotBuildResult(
+            market=request.market,
+            symbols_resolved=1,
+            snapshots_built=1,
+            committed=True,
+            batches=1,
+            started_at=dt.datetime.now(dt.UTC),
+            finished_at=dt.datetime.now(dt.UTC),
+        )
+
+    monkeypatch.setattr(
+        "app.mcp_server.tooling.market_quote_snapshot_tools.run_market_quote_snapshot_build",
+        fake_build_future,
+    )
+
+    res_ensure = await market_quote_snapshot_ensure("us", "MOCKSNAP")
+    assert res_ensure["success"] is False
+    assert res_ensure["reason_code"] == "future_snapshot_at"
+
+
+@pytest.mark.integration
+async def test_crypto_market_flow(monkeypatch):
+    now = dt.datetime.now(dt.UTC)
+    fresh_time = now - dt.timedelta(minutes=2)
+    sid = await _seed_snapshot(
+        fresh_time, Decimal("100000.00"), market="crypto", symbol="KRW-BTC"
+    )
+
+    res_latest = await market_quote_snapshot_latest("crypto", "KRW-BTC")
+    assert res_latest["success"] is True
+    assert res_latest["found"] is True
+    assert res_latest["id"] == sid
+    assert res_latest["submit_ready"] is True
+
+    mock_build = AsyncMock()
+    monkeypatch.setattr(
+        "app.mcp_server.tooling.market_quote_snapshot_tools.run_market_quote_snapshot_build",
+        mock_build,
+    )
+
+    res_ensure = await market_quote_snapshot_ensure("crypto", "KRW-BTC")
+    assert res_ensure["success"] is True
+    assert res_ensure["reused"] is True
+    assert res_ensure["id"] == sid
+    mock_build.assert_not_called()
 
 
 @pytest.mark.unit

--- a/tests/test_mcp_profiles.py
+++ b/tests/test_mcp_profiles.py
@@ -31,6 +31,9 @@ from app.mcp_server.tooling.analysis_readonly_registration import (
     ANALYSIS_READONLY_FORBIDDEN_TOOL_NAMES,
     ANALYSIS_READONLY_TOOL_NAMES,
 )
+from app.mcp_server.tooling.market_quote_snapshot_tools import (
+    MARKET_QUOTE_SNAPSHOT_TOOL_NAMES,
+)
 from app.mcp_server.tooling.order_proposal_tools import ORDER_PROPOSAL_TOOL_NAMES
 from app.mcp_server.tooling.orders_kis_variants import (
     KIS_LIVE_ORDER_TOOL_NAMES,
@@ -69,6 +72,7 @@ _ALPACA_PAPER_TOOL_NAMES = (
     ALPACA_PAPER_READONLY_TOOL_NAMES
     | ALPACA_PAPER_PREVIEW_TOOL_NAMES
     | ALPACA_PAPER_MUTATING_TOOL_NAMES
+    | MARKET_QUOTE_SNAPSHOT_TOOL_NAMES
 )
 _US_PAPER_TOOL_NAMES = _ALPACA_PAPER_TOOL_NAMES | US_DUAL_PAPER_TOOL_NAMES
 _DB_PAPER_TOOL_NAMES = (

--- a/tests/test_route_request_registry_diff.py
+++ b/tests/test_route_request_registry_diff.py
@@ -19,6 +19,9 @@ import yaml
 from app.mcp_server.profiles import McpProfile
 from app.mcp_server.tooling.alpaca_paper import ALPACA_PAPER_READONLY_TOOL_NAMES
 from app.mcp_server.tooling.alpaca_paper_preview import ALPACA_PAPER_PREVIEW_TOOL_NAMES
+from app.mcp_server.tooling.market_quote_snapshot_tools import (
+    MARKET_QUOTE_SNAPSHOT_TOOL_NAMES,
+)
 from app.mcp_server.tooling.orders_kiwoom_us_variants import (
     KIWOOM_MOCK_US_MUTATION_TOOL_NAMES,
     KIWOOM_MOCK_US_READ_TOOL_NAMES,
@@ -105,6 +108,7 @@ def test_read_only_bucket_has_no_phantom_tools():
         *ALPACA_PAPER_PREVIEW_TOOL_NAMES,
         *US_DUAL_PAPER_TOOL_NAMES,
         *KIWOOM_MOCK_US_READ_TOOL_NAMES,
+        *MARKET_QUOTE_SNAPSHOT_TOOL_NAMES,
     }
     phantom = READ_ONLY_ADVISORY_TOOLS - default - _FLAG_GATED_OR_OPTIONAL
     assert not phantom, (


### PR DESCRIPTION
## ROB-913: Quote Snapshot MCP Tools

### 설계 채택 근거
- **(a) 조회 도구 + 단일심볼 수동 ensure lever** 채택.
- **(b)** submit 서버측 자동해석 기각 (명시 id의 감사추적 유지, ROB-842 계약 불변).
- **(c)** 주기 스케줄 신설 기각 (수동 검증 우선).
- submit/게이트 코드는 1줄도 수정하지 않음.

### 신뢰 모델
- 가격(price)은 서버측 quote 소스에서만 가져오며, caller가 price를 임의로 주입할 수 없도록 파라미터를 전혀 제공하지 않음.
- 빌드 실패(시세 조회 불가 등) 시 fake 성공을 반환하지 않고 `{success: False, error: ...}`를 엄밀하게 반환함.

### 테스트 증거
- `tests/mcp_server/test_market_quote_snapshot_tools.py` 신규 추가 및 6개 테스트 통과.
- `tests/test_route_request_registry_diff.py` 및 `tests/test_route_request_lanes.py` 24개 테스트 통과.
- `tests/mcp_server` filtered 테스트 116개 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tools to view the latest market quote snapshot for a symbol.
  * Added tools to reuse fresh snapshots or build new ones when data is missing or outdated.
  * Included quote price, source, timestamps, freshness, and error details in results.
  * Registered the tools for supported paper-trading profiles and read-only workflows.

* **Bug Fixes**
  * Added handling for missing, stale, and invalid market quote snapshots.

* **Tests**
  * Added coverage for snapshot retrieval, reuse, rebuilding, failures, registration, and profile access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->