### PR TITLE
feat(ROB-917): add get_theme_events read-only MCP tool

### DIFF
--- a/app/mcp_server/tooling/analysis_registration.py
+++ b/app/mcp_server/tooling/analysis_registration.py
@@ -24,6 +24,7 @@ from app.mcp_server.tooling.research_pipeline_read import (
     stage_analysis_get_impl,
 )
 from app.mcp_server.tooling.screener_snapshot_tool import screen_stocks_snapshot_impl
+from app.mcp_server.tooling.theme_events import get_theme_events_impl
 
 if TYPE_CHECKING:
     from fastmcp import FastMCP
@@ -47,6 +48,7 @@ ANALYSIS_TOOL_NAMES: set[str] = {
     "get_dividends",
     "get_crypto_fear_greed",
     "get_momentum_candidates",
+    "get_theme_events",
     "research_session_get",
     "research_session_list_recent",
     "stage_analysis_get",
@@ -77,6 +79,33 @@ def register_analysis_tools(
             market=market,
             date=date,
             limit=limit,
+        )
+
+    @mcp.tool(
+        name="get_theme_events",
+        description=(
+            "Read-only 테마/업종 클러스터 snapshots from persisted Naver Stock theme "
+            "events (10-minute intraday collector). Returns rank/name/change_rate/"
+            "trade_value/stock_count/leader_symbols per item, with an intraday "
+            "data_state=stale tag when the latest snapshot is >20min old during a "
+            "live KRX session. Does not fetch Naver or mutate broker/order state."
+        ),
+    )
+    async def get_theme_events(
+        market: str = "kr",
+        event_kind: str = "all",
+        top_n: int = 20,
+        trading_date: str | None = None,
+        at: str | None = None,
+        include_stocks: bool = False,
+    ) -> dict[str, Any]:
+        return await get_theme_events_impl(
+            market=market,
+            event_kind=event_kind,
+            top_n=top_n,
+            trading_date=trading_date,
+            at=at,
+            include_stocks=include_stocks,
         )
 
     @mcp.tool(

--- a/app/mcp_server/tooling/route_request_lanes.py
+++ b/app/mcp_server/tooling/route_request_lanes.py
@@ -355,6 +355,7 @@ READ_ONLY_ADVISORY_TOOLS: frozenset[str] = frozenset(
         "get_sector_peers",
         "get_short_interest",
         "get_support_resistance",
+        "get_theme_events",
         "get_top_stocks",
         "get_toss_ai_signal",
         "get_toss_buy_balance",

--- a/app/mcp_server/tooling/theme_events.py
+++ b/app/mcp_server/tooling/theme_events.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+import datetime as dt
+from typing import Any
+
+from app.core.db import AsyncSessionLocal
+from app.mcp_server.tooling.market_session import (
+    DATA_STATE_FRESH,
+    kr_market_data_state,
+)
+from app.services.invest_momentum_events.repository import (
+    InvestMomentumEventSnapshotsRepository,
+)
+
+_STALE_AFTER_MINUTES = 20
+
+
+def _now_utc() -> dt.datetime:
+    return dt.datetime.now(dt.UTC)
+
+
+def _decimal_to_float(value: Any) -> float | None:
+    return float(value) if value is not None else None
+
+
+def _stock_to_dict(stock) -> dict[str, Any]:
+    return {
+        "symbol": stock.symbol,
+        "name": stock.name,
+        "rank": stock.rank,
+        "order_type": stock.order_type,
+        "price": _decimal_to_float(stock.price),
+        "change_amount": _decimal_to_float(stock.change_amount),
+        "change_rate": _decimal_to_float(stock.change_rate),
+        "volume": stock.volume,
+        "trade_value": _decimal_to_float(stock.trade_value),
+    }
+
+
+def _theme_event_to_dict(row, stocks: list | None = None) -> dict[str, Any]:
+    item: dict[str, Any] = {
+        "event_kind": row.event_kind,
+        "source_event_key": row.source_event_key,
+        "naver_theme_no": row.naver_theme_no,
+        "naver_upjong_code": row.naver_upjong_code,
+        "name": row.name,
+        "sort_type": row.sort_type,
+        "rank": row.rank,
+        "market_type": row.market_type,
+        "change_rate": _decimal_to_float(row.change_rate),
+        "trade_value": _decimal_to_float(row.trade_value),
+        "market_cap": _decimal_to_float(row.market_cap),
+        "stock_count": row.stock_count,
+        "leader_symbols": row.leader_symbols or [],
+    }
+    if stocks is not None:
+        item["stocks"] = [_stock_to_dict(stock) for stock in stocks]
+    return item
+
+
+def _classify_theme_freshness(
+    *, latest_snapshot_at: dt.datetime, now: dt.datetime
+) -> str:
+    """Intraday staleness: >20min since the last snapshot during a live KRX session.
+
+    The collector cron runs every 10 minutes during KRX regular hours, so a gap
+    over 20 minutes means at least one cycle was missed. Outside the regular
+    session (pre-market/after-hours/weekend/holiday) the newest persisted
+    snapshot is the best available data and is reported as fresh.
+    """
+    if kr_market_data_state(now) != DATA_STATE_FRESH:
+        return "fresh"
+    age_minutes = (now - latest_snapshot_at).total_seconds() / 60.0
+    if age_minutes > _STALE_AFTER_MINUTES:
+        return "stale"
+    return "fresh"
+
+
+async def get_theme_events_impl(
+    market: str = "kr",
+    event_kind: str = "all",
+    top_n: int = 20,
+    trading_date: str | None = None,
+    at: str | None = None,
+    include_stocks: bool = False,
+) -> dict[str, Any]:
+    """Return read-only 테마/업종 클러스터 snapshots from persisted Naver theme events.
+
+    Wraps InvestMomentumEventSnapshotsRepository.list_theme_events. Never fetches
+    Naver or mutates broker/order/watch state.
+    """
+    top_n = max(1, min(int(top_n or 20), 100))
+    if market != "kr":
+        return {
+            "market": market,
+            "event_kind": event_kind,
+            "data_state": "unsupported",
+            "empty_reason": "naver_stock_supports_kr_only",
+            "snapshot_at": None,
+            "trading_date": None,
+            "items": [],
+        }
+
+    snapshot_date = dt.date.fromisoformat(trading_date) if trading_date else None
+    at_cutoff = dt.datetime.fromisoformat(at) if at else None
+    repo_event_kind = None if event_kind == "all" else event_kind
+
+    async with AsyncSessionLocal() as session:
+        repo = InvestMomentumEventSnapshotsRepository(session)
+        rows = await repo.list_theme_events(
+            trading_date=snapshot_date,
+            event_kind=repo_event_kind,
+            at=at_cutoff,
+            limit=top_n,
+        )
+        stocks_by_theme_id: dict[int, list] = {}
+        if include_stocks and rows:
+            stocks_by_theme_id = await repo.list_theme_event_stocks(
+                [row.id for row in rows]
+            )
+
+    if not rows:
+        return {
+            "market": "kr",
+            "event_kind": event_kind,
+            "data_state": "missing",
+            "empty_reason": "no_naver_theme_snapshots",
+            "snapshot_at": None,
+            "trading_date": snapshot_date.isoformat() if snapshot_date else None,
+            "items": [],
+        }
+
+    latest_snapshot_at = max(row.snapshot_at for row in rows)
+    if snapshot_date is None and at_cutoff is None:
+        data_state = _classify_theme_freshness(
+            latest_snapshot_at=latest_snapshot_at, now=_now_utc()
+        )
+    else:
+        data_state = "fresh"
+
+    return {
+        "market": "kr",
+        "event_kind": event_kind,
+        "data_state": data_state,
+        "empty_reason": None,
+        "snapshot_at": latest_snapshot_at.isoformat(),
+        "trading_date": rows[0].trading_date.isoformat(),
+        "items": [
+            _theme_event_to_dict(
+                row, stocks_by_theme_id.get(row.id) if include_stocks else None
+            )
+            for row in rows
+        ],
+    }

--- a/app/services/invest_momentum_events/repository.py
+++ b/app/services/invest_momentum_events/repository.py
@@ -349,6 +349,7 @@ class InvestMomentumEventSnapshotsRepository:
         trading_date: dt.date | None = None,
         event_kind: str | None = None,
         sort_type: str | None = None,
+        at: dt.datetime | None = None,
         limit: int = 50,
     ) -> list[InvestThemeEventSnapshot]:
         conditions = [InvestThemeEventSnapshot.market == "kr"]
@@ -358,6 +359,8 @@ class InvestMomentumEventSnapshotsRepository:
             conditions.append(InvestThemeEventSnapshot.event_kind == event_kind)
         if sort_type:
             conditions.append(InvestThemeEventSnapshot.sort_type == sort_type)
+        if at is not None:
+            conditions.append(InvestThemeEventSnapshot.snapshot_at <= at)
 
         latest_result = await self._session.execute(
             select(func.max(InvestThemeEventSnapshot.snapshot_at)).where(*conditions)
@@ -379,6 +382,27 @@ class InvestMomentumEventSnapshotsRepository:
         )
         result = await self._session.execute(stmt)
         return list(result.scalars().all())
+
+    async def list_theme_event_stocks(
+        self, theme_snapshot_ids: list[int]
+    ) -> dict[int, list[InvestThemeEventSnapshotStock]]:
+        """Fetch child leader-stock rows for the given theme snapshot ids, grouped by parent."""
+        if not theme_snapshot_ids:
+            return {}
+        result = await self._session.execute(
+            select(InvestThemeEventSnapshotStock)
+            .where(
+                InvestThemeEventSnapshotStock.theme_snapshot_id.in_(theme_snapshot_ids)
+            )
+            .order_by(
+                InvestThemeEventSnapshotStock.theme_snapshot_id.asc(),
+                InvestThemeEventSnapshotStock.rank.asc().nulls_last(),
+            )
+        )
+        grouped: dict[int, list[InvestThemeEventSnapshotStock]] = {}
+        for row in result.scalars().all():
+            grouped.setdefault(row.theme_snapshot_id, []).append(row)
+        return grouped
 
     async def coverage(self, *, as_of: dt.date) -> SnapshotCoverage:
         momentum_result = await self._session.execute(

--- a/tests/test_invest_momentum_events.py
+++ b/tests/test_invest_momentum_events.py
@@ -383,6 +383,94 @@ async def test_repository_scores_momentum_candidates_with_cross_surface_rank_del
     assert "theme_leader" in top.reason_codes
 
 
+@pytest.mark.asyncio
+async def test_repository_list_theme_events_at_cutoff_picks_prior_snapshot(db_session):
+    """ROB-917: an ``at`` cutoff must select the latest snapshot at-or-before it."""
+    theme_date = dt.date(2026, 5, 19)
+    earlier_at = dt.datetime(2026, 5, 19, 9, 10, tzinfo=dt.UTC)
+    later_at = dt.datetime(2026, 5, 19, 9, 30, tzinfo=dt.UTC)
+
+    repo = InvestMomentumEventSnapshotsRepository(db_session)
+    earlier = ThemeEventUpsert(
+        snapshot_at=earlier_at,
+        trading_date=theme_date,
+        surface="market_theme_list",
+        event_kind="theme",
+        source_event_key="theme:rob917:changeRate:ALL",
+        naver_theme_no="rob917",
+        name="ROB917테마",
+        sort_type="changeRate",
+        rank=1,
+        market_type="ALL",
+        change_rate=Decimal("1.0"),
+    )
+    await repo.upsert_theme(earlier)
+    await repo.upsert_theme(
+        earlier.model_copy(
+            update={"snapshot_at": later_at, "change_rate": Decimal("5.0")}
+        )
+    )
+    await db_session.commit()
+
+    cutoff_rows = await repo.list_theme_events(
+        trading_date=theme_date,
+        at=dt.datetime(2026, 5, 19, 9, 20, tzinfo=dt.UTC),
+    )
+    assert [row.source_event_key for row in cutoff_rows] == [
+        "theme:rob917:changeRate:ALL"
+    ]
+    assert cutoff_rows[0].snapshot_at == earlier_at
+    assert cutoff_rows[0].change_rate == Decimal("1.0000")
+
+    latest_rows = await repo.list_theme_events(trading_date=theme_date)
+    assert latest_rows[0].snapshot_at == later_at
+    assert latest_rows[0].change_rate == Decimal("5.0000")
+
+
+@pytest.mark.asyncio
+async def test_repository_list_theme_event_stocks_groups_children_by_parent(db_session):
+    theme_date = dt.date(2026, 5, 20)
+    snapshot_at = dt.datetime(2026, 5, 20, 9, 10, tzinfo=dt.UTC)
+
+    repo = InvestMomentumEventSnapshotsRepository(db_session)
+    theme_id = await repo.upsert_theme(
+        ThemeEventUpsert(
+            snapshot_at=snapshot_at,
+            trading_date=theme_date,
+            surface="market_theme_list",
+            event_kind="theme",
+            source_event_key="theme:rob917stocks:changeRate:ALL",
+            naver_theme_no="rob917stocks",
+            name="ROB917자식테마",
+            sort_type="changeRate",
+            rank=1,
+            market_type="ALL",
+            stocks=[
+                {
+                    "symbol": "111111",
+                    "name": "가나",
+                    "rank": 1,
+                    "order_type": "changeRate",
+                },
+                {
+                    "symbol": "222222",
+                    "name": "다라",
+                    "rank": 2,
+                    "order_type": "changeRate",
+                },
+            ],
+        )
+    )
+    await db_session.commit()
+    assert theme_id is not None
+
+    grouped = await repo.list_theme_event_stocks([theme_id])
+    assert [stock.symbol for stock in grouped[theme_id]] == ["111111", "222222"]
+
+    empty = await repo.list_theme_event_stocks([])
+    assert empty == {}
+
+
 def test_mcp_momentum_candidate_tool_is_registered():
     from app.mcp_server.tooling.analysis_registration import ANALYSIS_TOOL_NAMES
 

--- a/tests/test_theme_events_mcp_tool.py
+++ b/tests/test_theme_events_mcp_tool.py
@@ -1,0 +1,388 @@
+"""ROB-917: get_theme_events read-only MCP tool tests.
+
+The tool wraps InvestMomentumEventSnapshotsRepository.list_theme_events (and, when
+include_stocks=True, list_theme_event_stocks) with market-scoping, intraday
+staleness tagging, and graceful empty-data handling. These tests fake the
+repository/session so they run without a DB, mirroring
+TestMomentumDataStateHonesty in tests/test_invest_momentum_events.py.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from dataclasses import dataclass, field
+from decimal import Decimal
+
+import pytest
+
+
+@dataclass
+class _FakeThemeRow:
+    id: int
+    snapshot_at: dt.datetime
+    trading_date: dt.date
+    event_kind: str
+    source_event_key: str
+    name: str
+    sort_type: str
+    rank: int | None
+    market_type: str | None = None
+    naver_theme_no: str | None = None
+    naver_upjong_code: str | None = None
+    change_rate: Decimal | None = None
+    trade_value: Decimal | None = None
+    market_cap: Decimal | None = None
+    stock_count: int | None = None
+    leader_symbols: list = field(default_factory=list)
+
+
+@dataclass
+class _FakeThemeStockRow:
+    theme_snapshot_id: int
+    symbol: str
+    name: str | None
+    rank: int | None
+    order_type: str | None
+    price: Decimal | None = None
+    change_amount: Decimal | None = None
+    change_rate: Decimal | None = None
+    volume: int | None = None
+    trade_value: Decimal | None = None
+
+
+class _FakeSession:
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+class _FakeRepo:
+    last_call: dict | None = None
+    rows: list = []
+    stocks_by_theme_id: dict = {}
+
+    def __init__(self, session):
+        pass
+
+    async def list_theme_events(
+        self,
+        *,
+        trading_date=None,
+        event_kind=None,
+        sort_type=None,
+        at=None,
+        limit=50,
+    ):
+        type(self).last_call = {
+            "trading_date": trading_date,
+            "event_kind": event_kind,
+            "sort_type": sort_type,
+            "at": at,
+            "limit": limit,
+        }
+        return type(self).rows
+
+    async def list_theme_event_stocks(self, theme_snapshot_ids):
+        return {
+            tid: type(self).stocks_by_theme_id.get(tid, [])
+            for tid in theme_snapshot_ids
+        }
+
+
+def _install_fake_repo(monkeypatch, mod, *, rows, stocks_by_theme_id=None):
+    _FakeRepo.last_call = None
+    _FakeRepo.rows = rows
+    _FakeRepo.stocks_by_theme_id = stocks_by_theme_id or {}
+    monkeypatch.setattr(mod, "InvestMomentumEventSnapshotsRepository", _FakeRepo)
+    monkeypatch.setattr(mod, "AsyncSessionLocal", lambda: _FakeSession())
+
+
+@pytest.mark.asyncio
+async def test_get_theme_events_impl_returns_latest_snapshot_items(monkeypatch):
+    from app.mcp_server.tooling import theme_events as mod
+
+    snapshot_at = dt.datetime(2026, 5, 19, 9, 20, tzinfo=dt.UTC)
+    row = _FakeThemeRow(
+        id=1,
+        snapshot_at=snapshot_at,
+        trading_date=dt.date(2026, 5, 19),
+        event_kind="theme",
+        source_event_key="theme:591:changeRate:ALL",
+        naver_theme_no="591",
+        name="반도체",
+        sort_type="changeRate",
+        rank=1,
+        market_type="ALL",
+        change_rate=Decimal("5.12"),
+        trade_value=Decimal("1000000000"),
+        stock_count=12,
+        leader_symbols=[{"symbol": "000660", "name": "SK하이닉스"}],
+    )
+    _install_fake_repo(monkeypatch, mod, rows=[row])
+    monkeypatch.setattr(mod, "kr_market_data_state", lambda now=None: "market_closed")
+
+    result = await mod.get_theme_events_impl(market="kr", top_n=20)
+
+    assert result["market"] == "kr"
+    assert result["data_state"] == "fresh"
+    assert result["snapshot_at"] == snapshot_at.isoformat()
+    assert len(result["items"]) == 1
+    item = result["items"][0]
+    assert item["rank"] == 1
+    assert item["name"] == "반도체"
+    assert item["change_rate"] == 5.12
+    assert item["trade_value"] == 1000000000.0
+    assert item["stock_count"] == 12
+    assert item["leader_symbols"] == [{"symbol": "000660", "name": "SK하이닉스"}]
+    assert "stocks" not in item
+
+
+@pytest.mark.asyncio
+async def test_get_theme_events_impl_passes_filters_to_repository(monkeypatch):
+    from app.mcp_server.tooling import theme_events as mod
+
+    _install_fake_repo(monkeypatch, mod, rows=[])
+    monkeypatch.setattr(mod, "kr_market_data_state", lambda now=None: "market_closed")
+
+    await mod.get_theme_events_impl(
+        market="kr",
+        event_kind="upjong",
+        top_n=5,
+        trading_date="2026-05-19",
+        at="2026-05-19T09:25:00+00:00",
+    )
+
+    call = mod.InvestMomentumEventSnapshotsRepository.last_call
+    assert call["event_kind"] == "upjong"
+    assert call["limit"] == 5
+    assert call["trading_date"] == dt.date(2026, 5, 19)
+    assert call["at"] == dt.datetime(2026, 5, 19, 9, 25, tzinfo=dt.UTC)
+
+
+@pytest.mark.asyncio
+async def test_get_theme_events_impl_event_kind_all_maps_to_no_filter(monkeypatch):
+    from app.mcp_server.tooling import theme_events as mod
+
+    _install_fake_repo(monkeypatch, mod, rows=[])
+    monkeypatch.setattr(mod, "kr_market_data_state", lambda now=None: "market_closed")
+
+    await mod.get_theme_events_impl(market="kr", event_kind="all")
+
+    call = mod.InvestMomentumEventSnapshotsRepository.last_call
+    assert call["event_kind"] is None
+
+
+@pytest.mark.asyncio
+async def test_get_theme_events_impl_stale_when_intraday_gap_exceeds_20_minutes(
+    monkeypatch,
+):
+    from app.mcp_server.tooling import theme_events as mod
+
+    now = dt.datetime(2026, 5, 19, 9, 40, tzinfo=dt.UTC)
+    stale_snapshot_at = now - dt.timedelta(minutes=25)
+    row = _FakeThemeRow(
+        id=1,
+        snapshot_at=stale_snapshot_at,
+        trading_date=dt.date(2026, 5, 19),
+        event_kind="theme",
+        source_event_key="theme:591:changeRate:ALL",
+        name="반도체",
+        sort_type="changeRate",
+        rank=1,
+    )
+    _install_fake_repo(monkeypatch, mod, rows=[row])
+    monkeypatch.setattr(
+        mod, "kr_market_data_state", lambda now=None: mod.DATA_STATE_FRESH
+    )
+    monkeypatch.setattr(mod, "_now_utc", lambda: now)
+
+    result = await mod.get_theme_events_impl(market="kr")
+
+    assert result["data_state"] == "stale"
+
+
+@pytest.mark.asyncio
+async def test_get_theme_events_impl_fresh_when_within_20_minutes(monkeypatch):
+    from app.mcp_server.tooling import theme_events as mod
+
+    now = dt.datetime(2026, 5, 19, 9, 40, tzinfo=dt.UTC)
+    fresh_snapshot_at = now - dt.timedelta(minutes=10)
+    row = _FakeThemeRow(
+        id=1,
+        snapshot_at=fresh_snapshot_at,
+        trading_date=dt.date(2026, 5, 19),
+        event_kind="theme",
+        source_event_key="theme:591:changeRate:ALL",
+        name="반도체",
+        sort_type="changeRate",
+        rank=1,
+    )
+    _install_fake_repo(monkeypatch, mod, rows=[row])
+    monkeypatch.setattr(
+        mod, "kr_market_data_state", lambda now=None: mod.DATA_STATE_FRESH
+    )
+    monkeypatch.setattr(mod, "_now_utc", lambda: now)
+
+    result = await mod.get_theme_events_impl(market="kr")
+
+    assert result["data_state"] == "fresh"
+
+
+@pytest.mark.asyncio
+async def test_get_theme_events_impl_explicit_trading_date_skips_staleness_check(
+    monkeypatch,
+):
+    """A caller pinning a historical trading_date asked for that snapshot on purpose."""
+    from app.mcp_server.tooling import theme_events as mod
+
+    now = dt.datetime(2026, 5, 19, 9, 40, tzinfo=dt.UTC)
+    old_snapshot_at = now - dt.timedelta(hours=5)
+    row = _FakeThemeRow(
+        id=1,
+        snapshot_at=old_snapshot_at,
+        trading_date=dt.date(2026, 5, 18),
+        event_kind="theme",
+        source_event_key="theme:591:changeRate:ALL",
+        name="반도체",
+        sort_type="changeRate",
+        rank=1,
+    )
+    _install_fake_repo(monkeypatch, mod, rows=[row])
+    monkeypatch.setattr(
+        mod, "kr_market_data_state", lambda now=None: mod.DATA_STATE_FRESH
+    )
+    monkeypatch.setattr(mod, "_now_utc", lambda: now)
+
+    result = await mod.get_theme_events_impl(market="kr", trading_date="2026-05-18")
+
+    assert result["data_state"] == "fresh"
+
+
+@pytest.mark.asyncio
+async def test_get_theme_events_impl_missing_when_no_rows(monkeypatch):
+    from app.mcp_server.tooling import theme_events as mod
+
+    _install_fake_repo(monkeypatch, mod, rows=[])
+    monkeypatch.setattr(mod, "kr_market_data_state", lambda now=None: "market_closed")
+
+    result = await mod.get_theme_events_impl(market="kr")
+
+    assert result["data_state"] == "missing"
+    assert result["items"] == []
+    assert result["empty_reason"] == "no_naver_theme_snapshots"
+    assert result["snapshot_at"] is None
+
+
+@pytest.mark.asyncio
+async def test_get_theme_events_impl_unsupported_market_short_circuits(monkeypatch):
+    from app.mcp_server.tooling import theme_events as mod
+
+    result = await mod.get_theme_events_impl(market="us")
+
+    assert result["market"] == "us"
+    assert result["data_state"] == "unsupported"
+    assert result["empty_reason"] == "naver_stock_supports_kr_only"
+    assert result["items"] == []
+
+
+@pytest.mark.asyncio
+async def test_get_theme_events_impl_include_stocks_attaches_children(monkeypatch):
+    from app.mcp_server.tooling import theme_events as mod
+
+    snapshot_at = dt.datetime(2026, 5, 19, 9, 20, tzinfo=dt.UTC)
+    row = _FakeThemeRow(
+        id=42,
+        snapshot_at=snapshot_at,
+        trading_date=dt.date(2026, 5, 19),
+        event_kind="theme",
+        source_event_key="theme:591:changeRate:ALL",
+        name="반도체",
+        sort_type="changeRate",
+        rank=1,
+    )
+    stock = _FakeThemeStockRow(
+        theme_snapshot_id=42,
+        symbol="000660",
+        name="SK하이닉스",
+        rank=1,
+        order_type="changeRate",
+        price=Decimal("200000"),
+        change_rate=Decimal("3.5"),
+    )
+    _install_fake_repo(monkeypatch, mod, rows=[row], stocks_by_theme_id={42: [stock]})
+    monkeypatch.setattr(mod, "kr_market_data_state", lambda now=None: "market_closed")
+
+    result = await mod.get_theme_events_impl(market="kr", include_stocks=True)
+
+    item = result["items"][0]
+    assert item["stocks"] == [
+        {
+            "symbol": "000660",
+            "name": "SK하이닉스",
+            "rank": 1,
+            "order_type": "changeRate",
+            "price": 200000.0,
+            "change_amount": None,
+            "change_rate": 3.5,
+            "volume": None,
+            "trade_value": None,
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_get_theme_events_impl_without_include_stocks_skips_stocks_query(
+    monkeypatch,
+):
+    from app.mcp_server.tooling import theme_events as mod
+
+    snapshot_at = dt.datetime(2026, 5, 19, 9, 20, tzinfo=dt.UTC)
+    row = _FakeThemeRow(
+        id=42,
+        snapshot_at=snapshot_at,
+        trading_date=dt.date(2026, 5, 19),
+        event_kind="theme",
+        source_event_key="theme:591:changeRate:ALL",
+        name="반도체",
+        sort_type="changeRate",
+        rank=1,
+    )
+
+    calls: list = []
+
+    class _TrackingRepo(_FakeRepo):
+        async def list_theme_event_stocks(self, theme_snapshot_ids):
+            calls.append(theme_snapshot_ids)
+            return await super().list_theme_event_stocks(theme_snapshot_ids)
+
+    _FakeRepo.last_call = None
+    _FakeRepo.rows = [row]
+    _FakeRepo.stocks_by_theme_id = {}
+    monkeypatch.setattr(mod, "InvestMomentumEventSnapshotsRepository", _TrackingRepo)
+    monkeypatch.setattr(mod, "AsyncSessionLocal", lambda: _FakeSession())
+    monkeypatch.setattr(mod, "kr_market_data_state", lambda now=None: "market_closed")
+
+    result = await mod.get_theme_events_impl(market="kr", include_stocks=False)
+
+    assert calls == []
+    assert "stocks" not in result["items"][0]
+
+
+def test_mcp_theme_events_tool_is_registered():
+    from app.mcp_server.tooling.analysis_registration import ANALYSIS_TOOL_NAMES
+
+    assert "get_theme_events" in ANALYSIS_TOOL_NAMES
+
+
+def test_theme_events_tool_is_read_only_advisory_bucket_member():
+    from app.mcp_server.tooling.route_request_lanes import (
+        ALL_KNOWN_TOOLS,
+        MUTATION_TOOLS,
+        READ_ONLY_ADVISORY_TOOLS,
+    )
+
+    assert "get_theme_events" in READ_ONLY_ADVISORY_TOOLS
+    assert "get_theme_events" not in MUTATION_TOOLS
+    assert "get_theme_events" in ALL_KNOWN_TOOLS


### PR DESCRIPTION
## Summary

Adds a dedicated read-only MCP tool `get_theme_events` for consuming the persisted `invest_theme_event_snapshots` table (Naver 테마/업종 랭킹, collected every 10 min during KRX regular hours by the existing `app/tasks/invest_momentum_event_tasks.py` cron — untouched by this PR). Previously the only read paths were the internal HTTP API (`app/routers/invest_api.py` `/momentum/themes`) and `get_momentum_candidates`' theme-leader bonus scoring, so an MCP/Hermes session had no direct way to pull theme/upjong cluster data.

## Tool schema

```
get_theme_events(
    market: str = "kr",
    event_kind: str = "all",       # "theme" | "upjong" | "all"
    top_n: int = 20,
    trading_date: str | None = None,   # ISO date; default = latest
    at: str | None = None,             # ISO datetime cutoff; latest snapshot at-or-before
    include_stocks: bool = False,      # attach child invest_theme_event_snapshot_stocks rows
) -> {
    market, event_kind, data_state, empty_reason,
    snapshot_at, trading_date,
    items: [{ event_kind, source_event_key, naver_theme_no, naver_upjong_code,
              name, sort_type, rank, market_type, change_rate, trade_value,
              market_cap, stock_count, leader_symbols, stocks? }]
}
```

- `data_state ∈ {fresh, stale, missing, unsupported}`. `stale` fires when the latest snapshot is >20min old **during a live KRX regular session** (the collector cron runs every 10min, so a >20min gap means at least one cycle was missed) — reuses `app/mcp_server/tooling/market_session.py::kr_market_data_state`. Outside regular hours the newest persisted snapshot is the best available data and is reported `fresh`. Explicit `trading_date`/`at` queries skip the staleness check since the caller intentionally asked for that historical snapshot.
- `market != "kr"` short-circuits with `data_state="unsupported"` (Naver Stock is KR-only), matching `get_momentum_candidates`' pattern.
- No rows → `data_state="missing"`, `items=[]`, graceful (no exception).

## Repository changes (minimal, additive)

`app/services/invest_momentum_events/repository.py::list_theme_events` reused as-is, plus:
- New optional `at: dt.datetime | None` param — restricts the latest-snapshot selection to `snapshot_at <= at`. Backward-compatible (`at=None` is a no-op).
- New `list_theme_event_stocks(theme_snapshot_ids)` — single `IN (...)` query for `include_stocks=True`, grouped by parent id.

## Registration evidence (ROB-866 lesson applied)

- `app/mcp_server/tooling/analysis_registration.py`: `get_theme_events` added to `ANALYSIS_TOOL_NAMES` and registered via `@mcp.tool(...)` in `register_analysis_tools`, which is called unconditionally in the DEFAULT-profile "Always" block (`registry.py:262`) — same path as `get_momentum_candidates`.
- `app/mcp_server/tooling/route_request_lanes.py`: `get_theme_events` added to `READ_ONLY_ADVISORY_TOOLS` (alphabetical, next to `get_theme_events`/`get_top_stocks`) so `test_every_default_tool_is_classified` / `test_partition_is_total_at_default_settings` stay green — the exact gap ROB-866 flagged.

## Safety boundaries

- Pure read-only; no mutation path added.
- No new scheduler/cron registration (existing collector job untouched).
- No broker/order/watch code touched.
- Migration 0 (no schema change — reuses existing tables).

## Test plan

- [x] `uv run pytest tests/test_theme_events_mcp_tool.py -v` — 12 passed (fake-repo unit tests: latest-snapshot selection, `top_n`/`event_kind` filter passthrough, `event_kind="all"` → no filter, stale/fresh 20-min boundary, historical `trading_date` skips staleness, missing-data graceful, unsupported market, `include_stocks` attaches/skips children, DEFAULT-profile + `READ_ONLY_ADVISORY_TOOLS` registration assertions)
- [x] `uv run pytest tests/test_invest_momentum_events.py -v` — 12 passed (adds real-DB repository tests for the new `at` cutoff and `list_theme_event_stocks`, plus pre-existing coverage)
- [x] `uv run pytest tests/test_route_request_registry_diff.py tests/test_route_request_lanes.py -v` — 20 passed (bucket-classification + playbook-lane guards unaffected)
- [x] `uv run pytest tests/ -q -m "not live" --no-cov -n auto` — 16,870 passed, 10 skipped, 1 unrelated pre-existing xdist DDL-contention flake (`tests/infra/test_schema_barrier.py::test_apply_test_schema_is_idempotent`, verified to pass in isolation — a Postgres deadlock between two xdist workers issuing raw `ALTER TABLE` DDL concurrently, unrelated to this change)
- [x] `make lint` — ruff check, ruff format, `ty check` all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)