### PR TITLE
fix(ROB-916): 뉴스→심볼 매핑 수리 + KR 커버리지 (kr_symbol_universe 매처)

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -694,6 +694,12 @@ class Settings(BaseSettings):
     NEWS_RELEVANCE_JUDGMENT_TOKEN: str = ""
     NEWS_RELEVANCE_JUDGMENT_TIMEOUT_S: float = 120.0
     NEWS_RELEVANCE_JUDGMENT_BATCH_LIMIT: int = 50
+    # ROB-916 — default-disabled gate for scripts/backfill_news_related_symbols.py.
+    # Read-only DB access + additive news_article_related_symbols inserts only
+    # (never touches symbol_news_relevance excluded/pending state); the gate
+    # exists so the script can't run against a target DB unattended even in
+    # --dry-run.
+    NEWS_RELATED_SYMBOLS_BACKFILL_ENABLED: bool = False
 
     # ROB-510 — Finnhub news fetch reliability (per-attempt timeout + bounded retry)
     FINNHUB_NEWS_TIMEOUT_S: float = 8.0

--- a/app/services/kr_symbol_universe_service.py
+++ b/app/services/kr_symbol_universe_service.py
@@ -554,6 +554,32 @@ async def get_kr_names_by_symbols(
         await session.close()
 
 
+async def _list_active_symbol_names_impl(db: AsyncSession) -> list[tuple[str, str]]:
+    stmt = select(KRSymbolUniverse.symbol, KRSymbolUniverse.name).where(
+        KRSymbolUniverse.is_active.is_(True)
+    )
+    rows = (await db.execute(stmt)).all()
+    return [(row.symbol, row.name) for row in rows]
+
+
+async def list_active_kr_symbol_names(
+    db: AsyncSession | None = None,
+) -> list[tuple[str, str]]:
+    """Return ``[(symbol, name)]`` for every active KR symbol.
+
+    ROB-916: feeds `news_entity_matcher.match_kr_universe_symbols` — the
+    DB-backed long-tail name dictionary the curated `KR_ALIASES` list defers
+    to. Read-only; no ordering guarantee beyond what the DB returns.
+    """
+    if db is not None:
+        return await _list_active_symbol_names_impl(db)
+    session = cast(AsyncSession, cast(object, AsyncSessionLocal()))
+    try:
+        return await _list_active_symbol_names_impl(session)
+    finally:
+        await session.close()
+
+
 __all__ = [
     "KRSymbolUniverseLookupError",
     "KRSymbolUniverseEmptyError",
@@ -565,6 +591,7 @@ __all__ = [
     "get_kr_nxt_tradability",
     "get_kr_symbol_by_name",
     "is_nxt_eligible",
+    "list_active_kr_symbol_names",
     "search_kr_symbols",
     "sync_kr_symbol_universe",
 ]

--- a/app/services/llm_news_service.py
+++ b/app/services/llm_news_service.py
@@ -23,13 +23,16 @@ from app.schemas.news import (
     NewsReadinessResponse,
     NewsSourceCoverage,
 )
+from app.services import kr_symbol_universe_service, symbol_news_store
 from app.services.news_entity_matcher import (
     SymbolMatch,
+    match_kr_universe_symbols,
     match_symbols_for_article,
 )
 from app.services.news_payload_normalizer import (
     _RELATED_SYMBOL_MARKETS,
     _article_values_from_ingestor_payload,
+    _kr_universe_related_symbol_row,
     _normalize_related_symbol_market,
     _normalize_related_symbol_symbol,
     _related_symbol_values_from_ingestor_payload,
@@ -330,29 +333,65 @@ async def ingest_news_ingestor_bulk(
         inserted_count = len(inserted_urls)
 
         related_symbol_values: list[dict[str, Any]] = []
+        related_symbols_by_article: dict[int, set[str]] = {}
         for article_data in request.articles:
             article_id = inserted_url_to_id.get(article_data.url.strip())
             if article_id is None:
                 continue
-            related_symbol_values.extend(
-                _related_symbol_values_from_ingestor_payload(
-                    article_id=article_id, article_data=article_data
-                )
+            rows = _related_symbol_values_from_ingestor_payload(
+                article_id=article_id, article_data=article_data
             )
+            related_symbol_values.extend(rows)
+            for row in rows:
+                if row["market"] == "kr":
+                    related_symbols_by_article.setdefault(article_id, set()).add(
+                        row["symbol"]
+                    )
+
+        # ROB-916: supplementary deterministic KR name-dictionary match — the
+        # news-ingestor's own candidate extraction (source=candidate_metadata/
+        # tv_related_symbol above) is external and sometimes misses an
+        # explicit company-name mention in the title (e.g. 한화오션). This
+        # fills the gap without touching/overriding what the ingestor sent.
+        kr_article_present = any(
+            _normalize_related_symbol_market(a.market, a.market) == "kr"
+            for a in request.articles
+        )
+        if kr_article_present:
+            kr_universe = await kr_symbol_universe_service.list_active_kr_symbol_names(
+                db
+            )
+            if kr_universe:
+                for article_data in request.articles:
+                    if (
+                        _normalize_related_symbol_market(
+                            article_data.market, article_data.market
+                        )
+                        != "kr"
+                    ):
+                        continue
+                    article_id = inserted_url_to_id.get(article_data.url.strip())
+                    if article_id is None:
+                        continue
+                    already = related_symbols_by_article.setdefault(article_id, set())
+                    text = f"{article_data.title}\n{article_data.summary or ''}"
+                    for match in match_kr_universe_symbols(text, kr_universe):
+                        if match.symbol in already:
+                            continue
+                        related_symbol_values.append(
+                            _kr_universe_related_symbol_row(
+                                article_id=article_id,
+                                symbol=match.symbol,
+                                matched_term=match.matched_term,
+                                canonical_name=match.canonical_name,
+                            )
+                        )
+                        already.add(match.symbol)
+
         if related_symbol_values:
-            related_stmt = (
-                pg_insert(NewsArticleRelatedSymbol)
-                .values(related_symbol_values)
-                .on_conflict_do_nothing(
-                    index_elements=[
-                        NewsArticleRelatedSymbol.article_id,
-                        NewsArticleRelatedSymbol.market,
-                        NewsArticleRelatedSymbol.symbol,
-                        NewsArticleRelatedSymbol.source,
-                    ]
-                )
+            await symbol_news_store.upsert_related_symbols(
+                db, related_symbol_values, commit=False
             )
-            await db.execute(related_stmt)
 
         run = request.ingestion_run
         run_values = {

--- a/app/services/news_entity_matcher.py
+++ b/app/services/news_entity_matcher.py
@@ -88,6 +88,67 @@ def match_symbols(
     return sorted(seen.values(), key=lambda m: (m.market, m.symbol))
 
 
+def match_kr_universe_symbols(
+    text: str,
+    universe: Iterable[tuple[str, str]],
+) -> list[SymbolMatch]:
+    """Longest-match-wins full-name matcher over a DB-backed KR symbol universe.
+
+    ROB-916: supplementary mapping source for `news_article_related_symbols`
+    when the upstream news-ingestor's own candidate extraction misses an
+    explicit company-name mention (the curated `KR_ALIASES` dict is
+    intentionally small — this covers the long-tail via `kr_symbol_universe`).
+
+    ``universe`` is a caller-supplied ``(symbol, name)`` sequence (e.g. all
+    active `kr_symbol_universe` rows) so this function stays DB-free/pure.
+    Matching is done against the *full* registered company name only (never a
+    truncated alias), and overlapping matches are resolved by trying longest
+    names first and skipping any shorter match whose span is already claimed —
+    this is what prevents a short name that is a literal substring of a
+    longer one (e.g. "한화" inside a "한화오션" mention) from also firing as a
+    spurious extra symbol tag alongside the correct longer match.
+    """
+    if not text:
+        return []
+    haystack = text.lower()
+    entries = sorted(
+        (
+            (symbol, name.strip())
+            for symbol, name in universe
+            if symbol and name and name.strip()
+        ),
+        key=lambda pair: len(pair[1]),
+        reverse=True,
+    )
+    claimed: list[tuple[int, int]] = []
+    matches: dict[str, SymbolMatch] = {}
+    for symbol, name in entries:
+        if symbol in matches:
+            continue
+        needle = name.lower()
+        if needle not in haystack:
+            continue
+        if _is_ascii_term(name):
+            pattern = r"(?<![A-Za-z0-9])" + re.escape(needle) + r"(?![A-Za-z0-9])"
+            occurrences = re.finditer(pattern, haystack)
+        else:
+            occurrences = re.finditer(re.escape(needle), haystack)
+        for occurrence in occurrences:
+            start, end = occurrence.span()
+            if any(start < c_end and end > c_start for c_start, c_end in claimed):
+                continue
+            claimed.append((start, end))
+            matches[symbol] = SymbolMatch(
+                symbol=symbol,
+                market="kr",
+                canonical_name=name,
+                matched_term=name,
+                reason="kr_symbol_universe_name",
+            )
+            break
+    return sorted(matches.values(), key=lambda m: m.symbol)
+
+
 _URL_METADATA_PREFIXES = (
     "canonical_url:",
     "source_url:",

--- a/app/services/news_payload_normalizer.py
+++ b/app/services/news_payload_normalizer.py
@@ -279,6 +279,34 @@ def _related_symbol_row_from_candidate(
     }
 
 
+def _kr_universe_related_symbol_row(
+    *,
+    article_id: int,
+    symbol: str,
+    matched_term: str,
+    canonical_name: str,
+) -> dict[str, Any]:
+    """Row for the ROB-916 supplementary `kr_symbol_universe_name` source.
+
+    Distinct ``source`` value from the ingestor-provided candidates
+    (``candidate_metadata``/``tv_related_symbol``) so both can coexist per
+    article under the ``(article_id, market, symbol, source)`` unique
+    constraint — this is additive, never a replacement for ingestor tags.
+    """
+    return {
+        "article_id": article_id,
+        "market": "kr",
+        "symbol": symbol,
+        "display_name": canonical_name.strip()[:120] or None,
+        "source": "kr_symbol_universe_name",
+        "matched_term": matched_term.strip()[:120] or None,
+        "score": None,
+        "rank": None,
+        "raw": {"matcher": "kr_symbol_universe_name"},
+        "created_at": now_kst_naive(),
+    }
+
+
 def _related_symbol_values_from_ingestor_payload(
     *, article_id: int, article_data: Any
 ) -> list[dict[str, Any]]:

--- a/app/services/symbol_news_store.py
+++ b/app/services/symbol_news_store.py
@@ -17,7 +17,7 @@ from sqlalchemy import func, select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models.news import NewsArticle
+from app.models.news import NewsArticle, NewsArticleRelatedSymbol
 from app.models.symbol_news_relevance import SymbolNewsRelevance
 from app.services.symbol_news_relevance import build_relevance_hints
 
@@ -168,6 +168,41 @@ async def upsert_kr_feed_articles(
 ) -> int:
     """KR 호환 래퍼 — 기존 호출부 보존용 (ROB-491)."""
     return await upsert_feed_articles(db, "kr", symbol, items, feed_source=feed_source)
+
+
+async def upsert_related_symbols(
+    db: AsyncSession,
+    rows: list[dict[str, Any]],
+    *,
+    commit: bool = True,
+) -> int:
+    """Single write seam for `news_article_related_symbols` (ROB-916).
+
+    ``rows`` are pre-built dicts matching the ORM column set (see
+    ``app.services.news_payload_normalizer`` row builders). Idempotent by the
+    ``(article_id, market, symbol, source)`` unique constraint — re-running
+    over the same articles/matcher is always a no-op for existing rows.
+    Callers that batch multiple writes in one transaction (e.g. the
+    news-ingestor bulk endpoint) should pass ``commit=False`` and commit once
+    at the end themselves.
+    """
+    if not rows:
+        return 0
+    result = await db.execute(
+        pg_insert(NewsArticleRelatedSymbol)
+        .values(rows)
+        .on_conflict_do_nothing(
+            index_elements=[
+                NewsArticleRelatedSymbol.article_id,
+                NewsArticleRelatedSymbol.market,
+                NewsArticleRelatedSymbol.symbol,
+                NewsArticleRelatedSymbol.source,
+            ]
+        )
+    )
+    if commit:
+        await db.commit()
+    return int(result.rowcount or 0)
 
 
 async def list_pending(

--- a/scripts/backfill_news_related_symbols.py
+++ b/scripts/backfill_news_related_symbols.py
@@ -1,0 +1,306 @@
+"""Backfill CLI for `news_article_related_symbols` (ROB-916).
+
+Reprocesses already-ingested KR `news_articles` rows with the ROB-916
+supplementary KR name-dictionary matcher (`news_entity_matcher.
+match_kr_universe_symbols` over `kr_symbol_universe`), so articles the
+upstream news-ingestor's own candidate extraction missed an explicit
+company-name mention in (e.g. 한화오션 in http_naver_stock_aggregate feed
+items) get a `news_article_related_symbols` row after the fact.
+
+Read-mostly: selects from `news_articles` + `kr_symbol_universe`, writes only
+through `symbol_news_store.upsert_related_symbols` (additive, idempotent by
+the `(article_id, market, symbol, source)` unique constraint). Never touches
+`symbol_news_relevance` status (ROB-491 boundary — no auto-exclusion here).
+
+Default-disabled: requires `NEWS_RELATED_SYMBOLS_BACKFILL_ENABLED=true` even
+for --dry-run, and --dry-run is the default even when enabled — --apply must
+be passed explicitly to write.
+
+Examples:
+    NEWS_RELATED_SYMBOLS_BACKFILL_ENABLED=true \
+        uv run python scripts/backfill_news_related_symbols.py \
+        --from-date 2026-07-14 --to-date 2026-07-17
+
+    NEWS_RELATED_SYMBOLS_BACKFILL_ENABLED=true \
+        uv run python scripts/backfill_news_related_symbols.py \
+        --from-date 2026-07-14 --to-date 2026-07-17 --apply
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+from dataclasses import dataclass, field
+from datetime import date, datetime
+
+from sqlalchemy import select
+
+from app.core.config import settings
+from app.core.db import AsyncSessionLocal
+from app.models.news import NewsArticle, NewsArticleRelatedSymbol
+from app.services import kr_symbol_universe_service, symbol_news_store
+from app.services.news_entity_matcher import match_kr_universe_symbols
+from app.services.news_payload_normalizer import _kr_universe_related_symbol_row
+
+DEFAULT_FROM_DATE = "2026-07-14"
+DEFAULT_TO_DATE = "2026-07-17"  # exclusive — covers 07-14, 07-15, 07-16
+DEFAULT_FOCUS_SYMBOLS = (
+    "042660",  # 한화오션
+    "009540",  # HD한국조선해양
+    "017670",  # SK텔레콤
+    "000810",  # 삼성화재
+    "279570",  # 케이뱅크
+    "004310",  # 현대약품
+    "483650",  # 달바글로벌
+    "476060",  # 온코닉테라퓨틱스
+)
+
+
+@dataclass(frozen=True)
+class SymbolRecall:
+    symbol: str
+    name: str | None
+    articles_in_window: int
+    already_mapped: int
+    newly_mapped: int
+
+    @property
+    def after_mapped(self) -> int:
+        return self.already_mapped + self.newly_mapped
+
+
+@dataclass
+class BackfillResult:
+    articles_scanned: int
+    articles_with_new_mapping: int
+    new_rows: int
+    applied: bool
+    recall: list[SymbolRecall] = field(default_factory=list)
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Reprocess KR news_articles for missed news_article_related_symbols "
+            "mappings using the kr_symbol_universe name matcher (dry-run by default)."
+        )
+    )
+    parser.add_argument(
+        "--from-date",
+        default=DEFAULT_FROM_DATE,
+        help="KST date, inclusive (YYYY-MM-DD).",
+    )
+    parser.add_argument(
+        "--to-date", default=DEFAULT_TO_DATE, help="KST date, exclusive (YYYY-MM-DD)."
+    )
+    parser.add_argument(
+        "--feed-source",
+        default=None,
+        help=(
+            "Restrict to one feed_source (e.g. http_naver_stock_aggregate). "
+            "Default: all KR feed sources in the date window."
+        ),
+    )
+    parser.add_argument(
+        "--focus-symbols",
+        default=",".join(DEFAULT_FOCUS_SYMBOLS),
+        help="Comma-separated KR symbols for the recall report.",
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Write new news_article_related_symbols rows. Default is --dry-run.",
+    )
+    args = parser.parse_args(argv)
+    args.dry_run = not args.apply
+    return args
+
+
+def _parse_date(value: str) -> datetime:
+    return datetime.combine(date.fromisoformat(value), datetime.min.time())
+
+
+async def _load_candidate_articles(
+    *,
+    from_dt: datetime,
+    to_dt: datetime,
+    feed_source: str | None,
+) -> list[NewsArticle]:
+    async with AsyncSessionLocal() as db:
+        conditions = [
+            NewsArticle.market == "kr",
+            NewsArticle.article_published_at >= from_dt,
+            NewsArticle.article_published_at < to_dt,
+        ]
+        if feed_source:
+            conditions.append(NewsArticle.feed_source == feed_source)
+        stmt = select(NewsArticle).where(*conditions).order_by(NewsArticle.id.asc())
+        return list((await db.execute(stmt)).scalars().all())
+
+
+async def _load_existing_symbols_by_article(
+    article_ids: list[int],
+) -> dict[int, set[str]]:
+    if not article_ids:
+        return {}
+    async with AsyncSessionLocal() as db:
+        stmt = select(
+            NewsArticleRelatedSymbol.article_id, NewsArticleRelatedSymbol.symbol
+        ).where(
+            NewsArticleRelatedSymbol.market == "kr",
+            NewsArticleRelatedSymbol.article_id.in_(article_ids),
+        )
+        rows = (await db.execute(stmt)).all()
+    out: dict[int, set[str]] = {}
+    for article_id, symbol in rows:
+        out.setdefault(article_id, set()).add(symbol)
+    return out
+
+
+def _build_recall_report(
+    *,
+    focus_symbols: list[str],
+    focus_names: dict[str, str],
+    articles: list[NewsArticle],
+    existing_by_article: dict[int, set[str]],
+    new_rows_by_article: dict[int, list[dict]],
+) -> list[SymbolRecall]:
+    focus_set = set(focus_symbols)
+    articles_in_window: dict[str, int] = dict.fromkeys(focus_set, 0)
+    already_mapped: dict[str, int] = dict.fromkeys(focus_set, 0)
+    newly_mapped: dict[str, int] = dict.fromkeys(focus_set, 0)
+
+    for article in articles:
+        existing = existing_by_article.get(article.id, set())
+        new_rows = new_rows_by_article.get(article.id, [])
+        new_symbols = {row["symbol"] for row in new_rows}
+        text = f"{article.title}\n{article.summary or ''}"
+        for symbol in focus_set:
+            name = focus_names.get(symbol)
+            if name and name.lower() in text.lower():
+                articles_in_window[symbol] += 1
+            if symbol in existing:
+                already_mapped[symbol] += 1
+            elif symbol in new_symbols:
+                newly_mapped[symbol] += 1
+
+    return [
+        SymbolRecall(
+            symbol=symbol,
+            name=focus_names.get(symbol),
+            articles_in_window=articles_in_window[symbol],
+            already_mapped=already_mapped[symbol],
+            newly_mapped=newly_mapped[symbol],
+        )
+        for symbol in focus_symbols
+    ]
+
+
+async def run_backfill(
+    *,
+    from_date: str,
+    to_date: str,
+    feed_source: str | None,
+    focus_symbols: list[str],
+    apply: bool,
+) -> BackfillResult:
+    from_dt = _parse_date(from_date)
+    to_dt = _parse_date(to_date)
+
+    articles = await _load_candidate_articles(
+        from_dt=from_dt, to_dt=to_dt, feed_source=feed_source
+    )
+    article_ids = [a.id for a in articles]
+    existing_by_article = await _load_existing_symbols_by_article(article_ids)
+
+    universe = await kr_symbol_universe_service.list_active_kr_symbol_names()
+    universe_names = dict(universe)
+    focus_names = {
+        sym: universe_names[sym] for sym in focus_symbols if sym in universe_names
+    }
+
+    new_rows: list[dict] = []
+    new_rows_by_article: dict[int, list[dict]] = {}
+    for article in articles:
+        already = existing_by_article.get(article.id, set())
+        text = f"{article.title}\n{article.summary or ''}"
+        for match in match_kr_universe_symbols(text, universe):
+            if match.symbol in already:
+                continue
+            row = _kr_universe_related_symbol_row(
+                article_id=article.id,
+                symbol=match.symbol,
+                matched_term=match.matched_term,
+                canonical_name=match.canonical_name,
+            )
+            new_rows.append(row)
+            new_rows_by_article.setdefault(article.id, []).append(row)
+
+    recall = _build_recall_report(
+        focus_symbols=focus_symbols,
+        focus_names=focus_names,
+        articles=articles,
+        existing_by_article=existing_by_article,
+        new_rows_by_article=new_rows_by_article,
+    )
+
+    applied = False
+    if apply and new_rows:
+        async with AsyncSessionLocal() as db:
+            await symbol_news_store.upsert_related_symbols(db, new_rows, commit=True)
+        applied = True
+
+    return BackfillResult(
+        articles_scanned=len(articles),
+        articles_with_new_mapping=len(new_rows_by_article),
+        new_rows=len(new_rows),
+        applied=applied,
+        recall=recall,
+    )
+
+
+def _print_result(result: BackfillResult) -> None:
+    mode = "APPLIED" if result.applied else "DRY-RUN (no rows written)"
+    print(f"\nnews_article_related_symbols backfill — {mode}")
+    print(f"  articles scanned:            {result.articles_scanned}")
+    print(f"  articles with new mapping:   {result.articles_with_new_mapping}")
+    print(f"  new related-symbol rows:     {result.new_rows}")
+    if result.recall:
+        print("\n  Recall by focus symbol:")
+        print(
+            f"  {'symbol':<8}{'name':<16}{'in_window':>10}{'already':>10}"
+            f"{'newly':>10}{'after':>10}"
+        )
+        for row in result.recall:
+            print(
+                f"  {row.symbol:<8}{(row.name or '-')[:14]:<16}"
+                f"{row.articles_in_window:>10}{row.already_mapped:>10}"
+                f"{row.newly_mapped:>10}{row.after_mapped:>10}"
+            )
+    print()
+
+
+async def main() -> int:
+    args = parse_args()
+    if not settings.NEWS_RELATED_SYMBOLS_BACKFILL_ENABLED:
+        print(
+            "NEWS_RELATED_SYMBOLS_BACKFILL_ENABLED is not set — refusing to run "
+            "(default-disabled gate, ROB-916). Set it to 'true' to proceed, "
+            "still --dry-run by default."
+        )
+        return 1
+
+    focus_symbols = [s.strip() for s in args.focus_symbols.split(",") if s.strip()]
+    result = await run_backfill(
+        from_date=args.from_date,
+        to_date=args.to_date,
+        feed_source=args.feed_source,
+        focus_symbols=focus_symbols,
+        apply=args.apply,
+    )
+    _print_result(result)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/tests/test_news_entity_matcher.py
+++ b/tests/test_news_entity_matcher.py
@@ -6,6 +6,7 @@ import pytest
 
 from app.services.news_entity_matcher import (
     SymbolMatch,
+    match_kr_universe_symbols,
     match_symbols,
     match_symbols_for_article,
 )
@@ -205,3 +206,82 @@ def test_match_for_article_with_market_none_finds_us_alias_in_korean_text():
     assert by_symbol["NVDA"].market == "us"
     assert by_symbol["NVDA"].reason == "alias_dict"
     assert by_symbol["NVDA"].matched_term == "엔비디아"
+
+
+# ---------------------------------------------------------------------------
+# match_kr_universe_symbols (ROB-916)
+# ---------------------------------------------------------------------------
+
+_UNIVERSE = [
+    ("042660", "한화오션"),
+    ("000880", "한화"),
+    ("005930", "삼성전자"),
+    ("000810", "삼성화재"),
+    ("017670", "SK텔레콤"),
+    ("034730", "SK"),
+]
+
+
+@pytest.mark.unit
+def test_kr_universe_matches_hanwha_ocean_by_full_name():
+    """ROB-916 evidence case: 042660 title mentions must resolve to 한화오션."""
+    matches = match_kr_universe_symbols(
+        "한화오션, 3943억 규모 VLCC 2척 수주", _UNIVERSE
+    )
+    symbols = {m.symbol for m in matches}
+    assert "042660" in symbols
+
+
+@pytest.mark.unit
+def test_kr_universe_overlap_guard_suppresses_shorter_substring_match():
+    """부분 문자열 오탐 가드: "한화오션" 안의 "한화"(000880)는 별도 매치되면 안 됨."""
+    matches = match_kr_universe_symbols(
+        "한화오션, 3943억 규모 VLCC 2척 수주", _UNIVERSE
+    )
+    symbols = {m.symbol for m in matches}
+    assert "000880" not in symbols
+    assert symbols == {"042660"}
+
+
+@pytest.mark.unit
+def test_kr_universe_samsung_electronics_and_fire_insurance_resolve_independently():
+    """삼성전자/삼성화재 혼동 가드 — 둘 다 온전한 회사명으로 독립 매치돼야 함."""
+    matches = match_kr_universe_symbols(
+        "삼성전자 실적 호조, 삼성화재는 배당 확대 검토", _UNIVERSE
+    )
+    symbols = {m.symbol for m in matches}
+    assert symbols == {"005930", "000810"}
+
+
+@pytest.mark.unit
+def test_kr_universe_bare_short_name_still_matches_without_overlap():
+    matches = match_kr_universe_symbols("한화 그룹 지배구조 개편 검토", _UNIVERSE)
+    symbols = {m.symbol for m in matches}
+    assert "000880" in symbols
+
+
+@pytest.mark.unit
+def test_kr_universe_sk_telecom_mention_does_not_also_tag_bare_sk_holding():
+    matches = match_kr_universe_symbols(
+        "SK텔레콤, 실적 안정·배당 정상화 기대", _UNIVERSE
+    )
+    symbols = {m.symbol for m in matches}
+    assert symbols == {"017670"}
+
+
+@pytest.mark.unit
+def test_kr_universe_no_match_returns_empty_list():
+    assert match_kr_universe_symbols("오늘 날씨는 맑음", _UNIVERSE) == []
+
+
+@pytest.mark.unit
+def test_kr_universe_empty_text_returns_empty_list():
+    assert match_kr_universe_symbols("", _UNIVERSE) == []
+
+
+@pytest.mark.unit
+def test_kr_universe_match_reason_is_kr_symbol_universe_name():
+    matches = match_kr_universe_symbols("한화오션 수주 소식", _UNIVERSE)
+    assert matches
+    assert all(m.reason == "kr_symbol_universe_name" for m in matches)
+    assert all(m.market == "kr" for m in matches)

--- a/tests/test_rob916_kr_symbol_universe_mapping.py
+++ b/tests/test_rob916_kr_symbol_universe_mapping.py
@@ -1,0 +1,410 @@
+"""ROB-916: KR symbol-universe name matcher wiring + backfill script tests.
+
+Covers the news→symbol mapping repair: the news-ingestor bulk endpoint gets a
+supplementary deterministic match against `kr_symbol_universe` when the
+upstream ingestor's own candidate metadata misses an explicit company-name
+mention (the 한화오션/http_naver_stock_aggregate evidence case), and the
+`scripts/backfill_news_related_symbols.py` reprocessing CLI defaults to
+dry-run behind a default-disabled env gate.
+"""
+
+from __future__ import annotations
+
+import random
+from datetime import datetime
+from uuid import uuid4
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import delete, select
+
+from app.models.kr_symbol_universe import KRSymbolUniverse
+from app.models.news import NewsArticle, NewsArticleRelatedSymbol
+from app.schemas.news import NewsBulkIngestRequest
+from app.services.llm_news_service import ingest_news_ingestor_bulk
+
+
+def _unique_symbol() -> str:
+    return f"9{random.randint(10000, 99999)}"
+
+
+def _kr_article_payload(*, run_uuid: str, title: str, raw: dict | None = None) -> dict:
+    suffix = uuid4().hex[:12]
+    return {
+        "ingestion_run": {
+            "run_uuid": run_uuid,
+            "market": "kr",
+            "feed_set": "kr-core",
+            "started_at": "2026-07-15T00:00:00+00:00",
+            "finished_at": "2026-07-15T00:05:00+00:00",
+            "source_counts": {"http_naver_stock_aggregate": 1},
+        },
+        "articles": [
+            {
+                "fingerprint": f"rob916-{suffix}",
+                "market": "kr",
+                "source": "http_naver_stock_aggregate",
+                "title": title,
+                "url": f"https://n.news.naver.com/mnews/article/rob916/{suffix}",
+                "canonical_url": f"https://n.news.naver.com/mnews/article/rob916/{suffix}",
+                "publisher": "연합뉴스",
+                "published_at": "2026-07-15T10:00:00+09:00",
+                "summary": None,
+                "raw": raw or {},
+            }
+        ],
+    }
+
+
+@pytest_asyncio.fixture
+async def synthetic_kr_universe_row(db_session):
+    """Insert+commit a synthetic (symbol, name) row so a second session sees it."""
+    symbol = _unique_symbol()
+    name = f"테스트한화오션{symbol[-3:]}"
+    db_session.add(
+        KRSymbolUniverse(symbol=symbol, name=name, exchange="KOSPI", is_active=True)
+    )
+    await db_session.commit()
+    try:
+        yield symbol, name
+    finally:
+        await db_session.execute(
+            delete(KRSymbolUniverse).where(KRSymbolUniverse.symbol == symbol)
+        )
+        await db_session.commit()
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_ingest_bulk_maps_missed_symbol_via_kr_universe_name(
+    db_session, synthetic_kr_universe_row
+):
+    """Reproduces the 한화오션 evidence case: ingestor sends NO stock_candidates
+    for a KR article whose title explicitly names the company — the
+    kr_symbol_universe_name supplementary match must still create the
+    news_article_related_symbols row."""
+    symbol, name = synthetic_kr_universe_row
+    run_uuid = f"test-rob916-{uuid4().hex}"
+    payload = _kr_article_payload(
+        run_uuid=run_uuid,
+        title=f"{name}, 3943억 규모 VLCC 2척 수주",
+        raw={},  # no stock_candidates / related_symbols / tv_related_symbols
+    )
+
+    request = NewsBulkIngestRequest.model_validate(payload)
+    response = await ingest_news_ingestor_bulk(request)
+    assert response.success
+    assert response.inserted_count == 1
+
+    target_url = payload["articles"][0]["canonical_url"]
+    article_id = (
+        await db_session.execute(
+            select(NewsArticle.id).where(NewsArticle.url == target_url)
+        )
+    ).scalar_one()
+
+    rows = (
+        (
+            await db_session.execute(
+                select(NewsArticleRelatedSymbol).where(
+                    NewsArticleRelatedSymbol.article_id == article_id
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+    assert any(
+        row.symbol == symbol and row.source == "kr_symbol_universe_name" for row in rows
+    ), f"expected a kr_symbol_universe_name row for {symbol}, got {rows}"
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_ingest_bulk_does_not_duplicate_when_ingestor_already_tagged_symbol(
+    db_session, synthetic_kr_universe_row
+):
+    """When the ingestor's own candidate metadata already covers the symbol,
+    the kr_symbol_universe_name matcher must not add a redundant duplicate
+    row for the same (article, symbol) — additive, not double-booking."""
+    symbol, name = synthetic_kr_universe_row
+    run_uuid = f"test-rob916-{uuid4().hex}"
+    payload = _kr_article_payload(
+        run_uuid=run_uuid,
+        title=f"{name}, 3943억 규모 VLCC 2척 수주",
+        raw={
+            "stock_candidates": [
+                {"symbol": symbol, "market": "kr", "name": name, "score": 0.9}
+            ]
+        },
+    )
+
+    request = NewsBulkIngestRequest.model_validate(payload)
+    response = await ingest_news_ingestor_bulk(request)
+    assert response.success
+
+    target_url = payload["articles"][0]["canonical_url"]
+    article_id = (
+        await db_session.execute(
+            select(NewsArticle.id).where(NewsArticle.url == target_url)
+        )
+    ).scalar_one()
+
+    rows = (
+        (
+            await db_session.execute(
+                select(NewsArticleRelatedSymbol).where(
+                    NewsArticleRelatedSymbol.article_id == article_id,
+                    NewsArticleRelatedSymbol.symbol == symbol,
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+    assert len(rows) == 1
+    assert rows[0].source == "candidate_metadata"
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_ingest_bulk_us_article_does_not_query_kr_universe(db_session):
+    """Non-KR articles must not trigger the KR-only universe matcher path
+    (no crash, no spurious symbol rows)."""
+    run_uuid = f"test-rob916-us-{uuid4().hex}"
+    suffix = uuid4().hex[:12]
+    payload = {
+        "ingestion_run": {
+            "run_uuid": run_uuid,
+            "market": "us",
+            "feed_set": "us-core",
+            "started_at": "2026-07-15T00:00:00+00:00",
+            "finished_at": "2026-07-15T00:05:00+00:00",
+            "source_counts": {"rss_cnbc_us_markets": 1},
+        },
+        "articles": [
+            {
+                "fingerprint": f"rob916-us-{suffix}",
+                "market": "us",
+                "source": "rss_cnbc_us_markets",
+                "title": "Fed holds rates steady",
+                "url": f"https://example.com/us/{suffix}",
+                "canonical_url": f"https://example.com/us/{suffix}",
+                "publisher": "CNBC",
+                "published_at": "2026-07-15T10:00:00+09:00",
+                "summary": None,
+                "raw": {},
+            }
+        ],
+    }
+
+    request = NewsBulkIngestRequest.model_validate(payload)
+    response = await ingest_news_ingestor_bulk(request)
+    assert response.success
+    assert response.inserted_count == 1
+
+
+class TestBackfillScriptCLI:
+    def test_default_is_dry_run(self):
+        from scripts.backfill_news_related_symbols import parse_args
+
+        args = parse_args([])
+        assert args.apply is False
+        assert args.dry_run is True
+
+    def test_apply_flag(self):
+        from scripts.backfill_news_related_symbols import parse_args
+
+        args = parse_args(["--apply"])
+        assert args.apply is True
+        assert args.dry_run is False
+
+    def test_default_focus_symbols_include_tier_b_evidence_symbols(self):
+        from scripts.backfill_news_related_symbols import parse_args
+
+        args = parse_args([])
+        symbols = args.focus_symbols.split(",")
+        assert "042660" in symbols  # 한화오션
+        assert "279570" in symbols  # 케이뱅크
+        assert "476060" in symbols  # 온코닉테라퓨틱스
+
+
+@pytest.mark.asyncio
+async def test_backfill_main_refuses_when_env_gate_disabled(monkeypatch):
+    from app.core.config import settings
+    from scripts import backfill_news_related_symbols as script
+
+    monkeypatch.setattr(
+        settings, "NEWS_RELATED_SYMBOLS_BACKFILL_ENABLED", False, raising=False
+    )
+    monkeypatch.setattr("sys.argv", ["backfill_news_related_symbols.py"])
+
+    exit_code = await script.main()
+
+    assert exit_code == 1
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_backfill_dry_run_does_not_write_and_reports_recall(
+    db_session, synthetic_kr_universe_row
+):
+    """Dry-run must compute the recall report (would-be-mapped rows) without
+    persisting anything — this is the mode ROB-916 requires against prod."""
+    from scripts.backfill_news_related_symbols import run_backfill
+
+    symbol, name = synthetic_kr_universe_row
+    now = datetime(2026, 7, 15, 10, 0, 0)
+    article = NewsArticle(
+        url=f"https://n.news.naver.com/mnews/article/rob916-backfill/{uuid4().hex[:12]}",
+        title=f"{name} 캐나다 수주실패 선반영",
+        market="kr",
+        feed_source="http_naver_stock_aggregate",
+        article_published_at=now,
+        scraped_at=now,
+        created_at=now,
+    )
+    db_session.add(article)
+    await db_session.commit()
+    await db_session.refresh(article)
+
+    try:
+        result = await run_backfill(
+            from_date="2026-07-14",
+            to_date="2026-07-17",
+            feed_source="http_naver_stock_aggregate",
+            focus_symbols=[symbol],
+            apply=False,
+        )
+
+        assert result.applied is False
+        matching_rows = [r for r in result.recall if r.symbol == symbol]
+        assert matching_rows
+        assert matching_rows[0].newly_mapped >= 1
+
+        # Dry-run: nothing written.
+        existing = (
+            (
+                await db_session.execute(
+                    select(NewsArticleRelatedSymbol).where(
+                        NewsArticleRelatedSymbol.article_id == article.id
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert existing == []
+
+        # Now apply=True and confirm it writes exactly once, idempotently.
+        result_apply = await run_backfill(
+            from_date="2026-07-14",
+            to_date="2026-07-17",
+            feed_source="http_naver_stock_aggregate",
+            focus_symbols=[symbol],
+            apply=True,
+        )
+        assert result_apply.applied is True
+        assert result_apply.new_rows >= 1
+
+        written = (
+            (
+                await db_session.execute(
+                    select(NewsArticleRelatedSymbol).where(
+                        NewsArticleRelatedSymbol.article_id == article.id,
+                        NewsArticleRelatedSymbol.symbol == symbol,
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert len(written) == 1
+        assert written[0].source == "kr_symbol_universe_name"
+
+        # Re-running apply must be idempotent (on_conflict_do_nothing).
+        result_rerun = await run_backfill(
+            from_date="2026-07-14",
+            to_date="2026-07-17",
+            feed_source="http_naver_stock_aggregate",
+            focus_symbols=[symbol],
+            apply=True,
+        )
+        rerun_matching = [r for r in result_rerun.recall if r.symbol == symbol]
+        assert rerun_matching[0].newly_mapped == 0
+        assert rerun_matching[0].already_mapped >= 1
+    finally:
+        await db_session.execute(
+            delete(NewsArticleRelatedSymbol).where(
+                NewsArticleRelatedSymbol.article_id == article.id
+            )
+        )
+        await db_session.execute(
+            delete(NewsArticle).where(NewsArticle.id == article.id)
+        )
+        await db_session.commit()
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_upsert_related_symbols_is_idempotent(db_session):
+    from app.services import symbol_news_store
+
+    now = datetime(2026, 7, 15, 10, 0, 0)
+    article = NewsArticle(
+        url=f"https://example.com/rob916-upsert/{uuid4().hex[:12]}",
+        title="테스트 기사",
+        market="kr",
+        feed_source="http_naver_stock_aggregate",
+        article_published_at=now,
+        scraped_at=now,
+        created_at=now,
+    )
+    db_session.add(article)
+    await db_session.commit()
+    await db_session.refresh(article)
+
+    row = {
+        "article_id": article.id,
+        "market": "kr",
+        "symbol": _unique_symbol(),
+        "display_name": "테스트종목",
+        "source": "kr_symbol_universe_name",
+        "matched_term": "테스트종목",
+        "score": None,
+        "rank": None,
+        "raw": {"matcher": "kr_symbol_universe_name"},
+        "created_at": now,
+    }
+
+    try:
+        first = await symbol_news_store.upsert_related_symbols(db_session, [row])
+        second = await symbol_news_store.upsert_related_symbols(db_session, [row])
+
+        assert first == 1
+        assert second == 0
+
+        rows = (
+            (
+                await db_session.execute(
+                    select(NewsArticleRelatedSymbol).where(
+                        NewsArticleRelatedSymbol.article_id == article.id
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert len(rows) == 1
+    finally:
+        await db_session.execute(
+            delete(NewsArticleRelatedSymbol).where(
+                NewsArticleRelatedSymbol.article_id == article.id
+            )
+        )
+        await db_session.execute(
+            delete(NewsArticle).where(NewsArticle.id == article.id)
+        )
+        await db_session.commit()


### PR DESCRIPTION
## 원인 진단

`get_news`(MCP)는 KR 심볼에 대해 매번 Naver 개별종목 뉴스 페이지를 실시간
조회하므로 이번 결함과 무관하다. 실제 결함은 **`news_article_related_symbols`
매핑 테이블**(뉴스↔종목 역-조회, 브리핑/스크리너 등이 소비)에 있다.

- 이 테이블은 외부 news-ingestor가 `POST /api/v1/news/ingest/bulk`로 보내는
  자체 `raw.stock_candidates`/`related_symbols`/`tv_related_symbols` 메타데이터
  로만 채워진다 (`app/services/llm_news_service.py::ingest_news_ingestor_bulk`
  → `app/services/news_payload_normalizer.py::_related_symbol_values_from_ingestor_payload`).
  **auto_trader 코드는 ingest 시점에 독립적인 엔티티 매칭을 전혀 수행하지
  않는다** — 업스트림 추출이 제목의 명시적 종목명 언급을 놓치면 그 기사는
  영구히 매핑되지 않는다.
- auto_trader에 결정적 매처(`app/services/news_entity_matcher.py::match_symbols_for_article`)가
  있긴 하지만, alias 사전(`KR_ALIASES`, `news_entity_alias_data.py`)이 **14개
  종목**으로 의도적으로 좁게 curated되어 있고, 주석에 "long-tail mapping is
  delegated to the DB symbol universe + `stock_aliases`"라고 적혀 있음에도
  그 DB 연동은 실제로 구현된 적이 없었다. 한화오션/케이뱅크/온코닉테라퓨틱스는
  이 14개 목록에 없다.
- **실측 증거**: `http_naver_stock_aggregate` 피드의 07-14~16 기사 974건 중
  단 179건(18.4%)만 매핑 보유 — 전부 업스트림 자체 태깅(`candidate_metadata`/
  `tv_related_symbol`) 기원. SK텔레콤이 같은 기간 일부 매핑을 가진 것도
  auto_trader 로직 덕이 아니라 업스트림 추출이 우연히 "SK텔레콤"/"SKT" 문자열을
  잡아냈기 때문 — "매핑 경로가 부분적으로만 동작"한다는 관찰과 정확히 일치.
- 참고로 3단계 폴백 조회 유틸(`llm_news_service.get_news_articles_with_fallback`,
  exact→related_symbol→alias_scan)이 이미 존재하지만 **어떤 라우터/MCP 도구도
  호출하지 않는 미배선 코드**이며, 사용하는 alias 사전도 동일하게 14개뿐이라
  이 결함을 막지 못한다.
- 케이뱅크(279570)/온코닉테라퓨틱스(476060)는 07-14~16 기간 **모든 feed_source를
  통틀어** 제목에 해당 종목명을 포함한 기사가 0건 — 매핑 버그가 아니라
  업스트림 뉴스 피드 커버리지 자체의 갭 (아래 "커버리지 개선안" 참고).

## 수리

1. `app/services/news_entity_matcher.py::match_kr_universe_symbols(text, universe)`
   — DB(`kr_symbol_universe`) 전체 활성 종목명(3,918개)에 대한 순수 함수
   longest-match-wins 매처. **정확 매칭 우선**(축약 별칭이 아닌 등록된 전체
   회사명만 매칭) + **부분 문자열 오탐 가드**(가장 긴 이름부터 시도해 span을
   선점하므로, "한화오션" 언급이 "한화"(000880)를 동시에 오매칭하지 않고,
   "삼성전자"/"삼성화재"도 독립적으로 정확히 매칭됨 — 스펙의 "삼성" 혼동 예시
   케이스를 정확히 가드).
2. `app/services/kr_symbol_universe_service.py::list_active_kr_symbol_names` —
   매처에 넣을 (symbol, name) 사전 read 헬퍼.
3. `app/services/symbol_news_store.py::upsert_related_symbols` — `news_article_
   related_symbols`의 단일 쓰기 seam(신규, idempotent by unique constraint).
4. `ingest_news_ingestor_bulk`에 위 매처를 **보조 소스**(source=
   `kr_symbol_universe_name`)로 배선 — 업스트림이 이미 보낸 candidate를
   대체/덮어쓰지 않고 놓친 것만 채움. KR 기사가 없으면 쿼리 자체를 스킵.

## 백필 스크립트

`scripts/backfill_news_related_symbols.py` — 이미 적재된 KR 기사를 재처리.
- 기본 `--dry-run`, `--apply` 명시해야 씀. 게이트: `NEWS_RELATED_SYMBOLS_
  BACKFILL_ENABLED=true` 없으면 dry-run조차 거부(default-disabled).
- 쓰기는 전부 `symbol_news_store.upsert_related_symbols` 경유.
- Tier B 8종목 recall 리포트 내장(`--focus-symbols`).

## 회수율 검증 (dry-run, 프로덕션 DB, `.env.prod`, **--apply 미실행**)

`http_naver_stock_aggregate` 단독 (974건 스캔, 372건 신규매핑, 542행 신규):

```
symbol  name             in_window   already   newly   after
042660  한화오션                 3         0       3       3   ← 증거 기사 3건 전부 회수
009540  HD한국조선해양             0         0       0       0   (피드 갭)
017670  SK텔레콤                1         1       0       1
000810  삼성화재                 2         0       2       2
279570  케이뱅크                 0         0       0       0   (피드 갭)
004310  현대약품                 4         0       4       4
483650  달바글로벌                1         0       1       1
476060  온코닉테라퓨틱스           0         0       0       0   (피드 갭)
```

전체 KR 피드 포함(1,430건 스캔, 462건 신규매핑, 645행 신규)도 동일 패턴.
`in_window`은 제목/요약 내 정확 회사명 문자열 존재 여부(단순 근사치)이며,
`already`는 다른 신호(리서치 리포트 바이라인 등)로 이미 매핑된 경우를 포함할
수 있어 `in_window`보다 클 수 있음(SK텔레콤 행 참고) — 매처 정확도 문제가
아니라 두 컬럼이 서로 다른 것을 측정하기 때문.

검증 후 실측 재확인: `news_article_related_symbols` 대상 3개 article_id
(75173/75280/75668)는 여전히 0건 — dry-run이 실제로 아무것도 쓰지 않았음을
프로덕션 DB에서 직접 확인.

## 커버리지 개선안 (후속 제안)

케이뱅크/온코닉테라퓨틱스는 **모든 feed_source**를 통틀어 07-14~16 기간에
제목에 종목명이 있는 기사가 0건 — 업스트림 뉴스 수집(news-ingestor) 자체가
이 저볼륨 종목들을 놓치고 있다는 뜻이며, auto_trader 쪽 매핑 로직으로는
고칠 수 없는 **피드 커버리지 갭**이다. 제안: (a) news-ingestor에 보유/워치
종목 목록 기반 능동 조회(query) 소스를 추가하거나, (b) auto_trader의 기존
on-demand 경로(`get_news`가 이미 쓰는 `naver_finance.fetch_news(symbol)`
개별종목 조회)를 저볼륨 워치 종목에 대해 주기적으로 트리거하는 배치를
별도 이슈로 검토.

## 안전 경계 준수

- `symbol_news_relevance`(excluded/pending) 상태 미변경 — 이번 변경은
  `news_article_related_symbols`만 다룸.
- `KR_INVEST_KEYWORDS` 미수정.
- 브로커/주문/감시 mutation 없음. 프로덕션 DB에는 SELECT + dry-run만 실행,
  `--apply`는 실행하지 않음 (머지/배포 후 operator 단계).
- migration 0건 (기존 `news_article_related_symbols` 테이블 재사용, 신규
  `source` 값만 추가).

## 테스트

```
uv run pytest tests/test_news_entity_matcher.py tests/test_rob916_kr_symbol_universe_mapping.py \
  tests/test_news_ingestor_bulk.py tests/test_news_ingestor_bulk_tvscreener_content.py \
  tests/test_news_ingestor_bulk_tvscreener.py tests/services/test_symbol_news_store.py \
  tests/test_kr_symbol_universe_service.py tests/services/test_news_payload_normalizer.py -q
# 121 passed
```

- `match_kr_universe_symbols` 유닛: 한화오션 매핑 재현 + "한화" 오매칭 가드 +
  삼성전자/삼성화재 독립 매칭 + SK텔레콤/SK 오매칭 가드
- `ingest_news_ingestor_bulk` 통합(실 test_db, 합성 kr_symbol_universe row):
  업스트림이 안 보낸 심볼이 매핑됨 / 이미 태깅된 심볼은 중복 안 됨 / US 기사는
  KR 매처를 안 탐
- 백필 스크립트: 기본 dry-run(`--apply` 없으면 안 씀), env 게이트 거부,
  dry-run→apply→재실행 idempotency
- `uv run pytest -m unit` 4569 passed / `make lint` all green (ruff+ty)
