### PR TITLE
feat(ROB-922): opt-in US premarket/afterhours quote path (Yahoo prepost)

### DIFF
--- a/app/mcp_server/tooling/market_data_quotes.py
+++ b/app/mcp_server/tooling/market_data_quotes.py
@@ -31,7 +31,9 @@ from app.mcp_server.tooling.market_session import (
     DATA_STATE_FRESH,
     DATA_STATE_PREMARKET_UNAVAILABLE,
     DATA_STATE_STALE,
+    US_SESSION_AFTERHOURS,
     US_SESSION_CLOSED,
+    US_SESSION_PREMARKET,
     is_kr_session_day,
     kr_market_data_state,
     us_market_session,
@@ -843,13 +845,59 @@ def _tag_us_quote_session(
     return quote
 
 
-async def _fetch_quote_equity_us(symbol: str) -> dict[str, Any]:
+async def _apply_extended_hours_overlay(
+    quote: dict[str, Any], symbol: str, include_extended_hours: bool
+) -> dict[str, Any]:
+    """ROB-922: opt-in Yahoo prepost overlay for US premarket/afterhours quotes.
+
+    Only attempted when the caller opts in AND the tagged session is an
+    extended session (premarket/afterhours) — regular-session and closed
+    quotes are untouched (no-op), and KR/crypto callers never reach this
+    helper at all. On any failure or empty prepost data the existing quote
+    and its labels are kept as-is — never lie about price_source.
+    """
+    if not include_extended_hours:
+        return quote
+    if quote.get("session") not in (US_SESSION_PREMARKET, US_SESSION_AFTERHOURS):
+        return quote
+    try:
+        prepost = await yahoo_service.fetch_prepost_quote(symbol)
+    except Exception as exc:  # noqa: BLE001 — best-effort overlay, never breaks the base quote
+        logger.warning(
+            "Yahoo prepost overlay failed for '%s'; keeping existing quote: %s",
+            symbol,
+            exc,
+        )
+        return quote
+    if prepost is None:
+        return quote
+    price = _to_float_or_none(prepost.get("price"))
+    if price is None:
+        return quote
+    quote["price"] = price
+    quote["price_source"] = "yahoo_prepost_last"
+    quote_asof = _optional_text(prepost.get("quote_asof"))
+    if quote_asof is not None:
+        quote["quote_asof"] = quote_asof
+    quote["data_state"] = DATA_STATE_FRESH
+    quote.pop("data_state_reason", None)
+    return quote
+
+
+async def _fetch_quote_equity_us(
+    symbol: str, *, include_extended_hours: bool = False
+) -> dict[str, Any]:
     """Fetch US equity quote.
 
     ROB-471: KIS 해외 현재가 primary(settings.us_quote_kis_primary), Yahoo
     fast_info fallback. 정직 에러 분리:
       - provider 명시적 not-found → symbol_not_found (ValueError)
       - fast_info 정상응답·무가격 → quote_unavailable (RuntimeError)
+
+    ROB-922: include_extended_hours=True opportunistically overlays the
+    latest Yahoo prepost (extended-hours) price during premarket/afterhours
+    sessions via ``_apply_extended_hours_overlay``. Default False leaves the
+    result byte-identical to the pre-ROB-922 payload.
     """
     normalized_symbol = str(symbol or "").strip().upper()
     not_found_message = f"Symbol '{normalized_symbol}' not found"
@@ -868,7 +916,11 @@ async def _fetch_quote_equity_us(symbol: str) -> dict[str, Any]:
             )
         else:
             if kis_quote is not None:
-                return _tag_us_quote_session(kis_quote)
+                return await _apply_extended_hours_overlay(
+                    _tag_us_quote_session(kis_quote),
+                    normalized_symbol,
+                    include_extended_hours,
+                )
 
     # FALLBACK: Yahoo fast_info
     try:
@@ -888,20 +940,24 @@ async def _fetch_quote_equity_us(symbol: str) -> dict[str, Any]:
             )
         raise RuntimeError(f"{unavailable_message} (yahoo returned no price)")
 
-    return _tag_us_quote_session(
-        {
-            "symbol": normalized_symbol,
-            "instrument_type": "equity_us",
-            "price": price,
-            "previous_close": _to_float_or_none(fast_info.get("previous_close")),
-            "open": _to_float_or_none(fast_info.get("open")),
-            "high": _to_float_or_none(fast_info.get("high")),
-            "low": _to_float_or_none(fast_info.get("low")),
-            "volume": _to_int_or_none(fast_info.get("volume")),
-            "source": "yahoo",
-            "delayed": True,
-            "price_source": "yahoo_fast_info_close",
-        }
+    return await _apply_extended_hours_overlay(
+        _tag_us_quote_session(
+            {
+                "symbol": normalized_symbol,
+                "instrument_type": "equity_us",
+                "price": price,
+                "previous_close": _to_float_or_none(fast_info.get("previous_close")),
+                "open": _to_float_or_none(fast_info.get("open")),
+                "high": _to_float_or_none(fast_info.get("high")),
+                "low": _to_float_or_none(fast_info.get("low")),
+                "volume": _to_int_or_none(fast_info.get("volume")),
+                "source": "yahoo",
+                "delayed": True,
+                "price_source": "yahoo_fast_info_close",
+            }
+        ),
+        normalized_symbol,
+        include_extended_hours,
     )
 
 
@@ -1370,8 +1426,14 @@ async def _search_symbol_impl(
 async def _get_quote_impl(
     symbol: str | int,
     market: str | None = None,
+    include_extended_hours: bool = False,
 ) -> dict[str, Any]:
-    """Implementation for get_quote tool."""
+    """Implementation for get_quote tool.
+
+    ROB-922: include_extended_hours is US-equity-only opt-in (see
+    _fetch_quote_equity_us / _apply_extended_hours_overlay); KR and crypto
+    ignore the parameter entirely (no-op).
+    """
     symbol = _normalize_symbol_input(symbol, market)
     if not symbol:
         raise ValueError("symbol is required")
@@ -1379,7 +1441,9 @@ async def _get_quote_impl(
     market_type, symbol = _resolve_market_type(symbol, market)
 
     if market_type == "equity_us":
-        return await _fetch_quote_equity_us(symbol)
+        return await _fetch_quote_equity_us(
+            symbol, include_extended_hours=include_extended_hours
+        )
 
     source_map = {"crypto": "upbit", "equity_kr": "kis"}
     source = source_map[market_type]
@@ -1624,11 +1688,19 @@ def _register_market_data_tools_impl(mcp: FastMCP) -> None:
             "Get latest quote/last price for a symbol (KR equity / US equity / crypto). "
             "For KR equities during NXT pre-market/after-hours sessions, price falls "
             "back to the NXT orderbook expected price or best bid/ask mid while "
-            "preserving KRX previous_close for gap calculations."
+            "preserving KRX previous_close for gap calculations. "
+            "include_extended_hours=True (US equity only, default False) opportunistically "
+            "overlays the latest Yahoo pre/post-market 1-minute price during premarket/"
+            "afterhours sessions (price_source='yahoo_prepost_last'); no-op for KR/crypto "
+            "and for regular/closed US sessions."
         ),
     )
-    async def get_quote(symbol: str | int, market: str | None = None) -> dict[str, Any]:
-        return await _get_quote_impl(symbol, market)
+    async def get_quote(
+        symbol: str | int,
+        market: str | None = None,
+        include_extended_hours: bool = False,
+    ) -> dict[str, Any]:
+        return await _get_quote_impl(symbol, market, include_extended_hours)
 
     @mcp.tool(
         name="get_orderbook",

--- a/app/services/brokers/yahoo/client.py
+++ b/app/services/brokers/yahoo/client.py
@@ -109,11 +109,17 @@ async def fetch_ohlcv(
     days: int = 100,
     period: str = "day",
     end_date: datetime | None = None,
+    *,
+    prepost: bool = False,
 ) -> pd.DataFrame:
     normalized_period = str(period or "").strip().lower()
 
+    # ROB-922: prepost=True must never read/write the closed-candle cache — the
+    # cache is built from regular-session-only data (_filter_closed_buckets_nyse),
+    # so mixing in extended-hours candles would silently corrupt it.
     if (
-        normalized_period in {"day", "week", "month"}
+        not prepost
+        and normalized_period in {"day", "week", "month"}
         and settings.yahoo_ohlcv_cache_enabled
     ):
         from app.services import yahoo_ohlcv_cache as yahoo_ohlcv_cache_service
@@ -132,6 +138,7 @@ async def fetch_ohlcv(
         days=days,
         period=normalized_period,
         end_date=end_date,
+        prepost=prepost,
     )
     if normalized_period in {"day", "week", "month"}:
         return _filter_closed_buckets_nyse(raw, normalized_period)
@@ -161,6 +168,8 @@ async def _fetch_ohlcv_raw(
     days: int = 100,
     period: str = "day",
     end_date: datetime | None = None,
+    *,
+    prepost: bool = False,
 ) -> pd.DataFrame:
     period_map = {"day": "1d", "week": "1wk", "month": "1mo", "1h": "60m"}
     if period not in period_map:
@@ -172,6 +181,10 @@ async def _fetch_ohlcv_raw(
     )
     multiplier = {"day": 2, "week": 10, "month": 40, "1h": 2}.get(period, 2)
     start = end - timedelta(days=days * multiplier)
+
+    # ROB-922: prepost=False (default) omits the kwarg entirely so the
+    # yf.download call stays byte-identical to the pre-ROB-922 signature.
+    extra_kwargs: dict[str, Any] = {"prepost": True} if prepost else {}
 
     last_exc: BaseException | None = None
     for attempt in range(_CRUMB_RETRY_MAX + 1):
@@ -185,6 +198,7 @@ async def _fetch_ohlcv_raw(
                     progress=False,
                     auto_adjust=False,
                     session=session,
+                    **extra_kwargs,
                 )
             df = _flatten_cols(df).reset_index(names="date")
             df = (
@@ -323,6 +337,63 @@ async def fetch_price(ticker: str) -> pd.DataFrame:
 
 async def fetch_fast_info(ticker: str) -> dict[str, Any]:
     return await asyncio.to_thread(_fetch_fast_info_sync, ticker)
+
+
+def _fetch_prepost_quote_sync(ticker: str) -> dict[str, Any] | None:
+    """ROB-922: last extended-session (pre/post-market) 1-minute bar for
+    ``ticker``, or ``None`` when today's prepost data is empty (fail-closed —
+    never fabricate a quote)."""
+    yahoo_ticker = to_yahoo_symbol(ticker)
+    last_exc: BaseException | None = None
+
+    for attempt in range(_CRUMB_RETRY_MAX + 1):
+        try:
+            with yfinance_tracing_session() as session:
+                df = yf.Ticker(yahoo_ticker, session=session).history(
+                    period="1d", interval="1m", prepost=True
+                )
+            if df is None or df.empty:
+                return None
+            df = _flatten_cols(df.reset_index())
+            last_row = df.iloc[-1].to_dict()
+            price = _to_float_or_none(last_row.get("close"))
+            if price is None:
+                return None
+            ts_col = "datetime" if "datetime" in df.columns else "date"
+            quote_asof: str | None = None
+            ts_raw = last_row.get(ts_col)
+            if ts_raw is not None:
+                ts = pd.Timestamp(ts_raw)
+                ts = ts.tz_localize(UTC) if ts.tzinfo is None else ts.tz_convert(UTC)
+                quote_asof = ts.isoformat()
+            return {
+                "symbol": ticker,
+                "price": price,
+                "quote_asof": quote_asof,
+                "volume": _to_int_or_none(last_row.get("volume")),
+            }
+        except Exception as exc:
+            last_exc = exc
+            if _is_crumb_auth_error(exc) and attempt < _CRUMB_RETRY_MAX:
+                logger.warning(
+                    "Yahoo crumb/auth error for %s prepost quote (attempt %d/%d), retrying: %s",
+                    safe_log_value(yahoo_ticker),
+                    attempt + 1,
+                    _CRUMB_RETRY_MAX + 1,
+                    exc,
+                )
+                continue
+            raise
+
+    raise last_exc  # type: ignore[misc]
+
+
+async def fetch_prepost_quote(ticker: str) -> dict[str, Any] | None:
+    """ROB-922: opt-in extended-hours (pre/post-market) last quote from Yahoo's
+    1-minute prepost bars. Returns ``None`` when no extended-session data is
+    available (never fabricated) — callers fall back to their existing quote
+    source."""
+    return await asyncio.to_thread(_fetch_prepost_quote_sync, ticker)
 
 
 def _roe_to_percent(raw_roe: Any) -> float | None:

--- a/docs/runbooks/kis-overseas-premarket-probe.md
+++ b/docs/runbooks/kis-overseas-premarket-probe.md
@@ -1,0 +1,91 @@
+# KIS 해외 프리마켓 실측 프로브 (ROB-922)
+
+`HHDFS00000300`(KIS 해외 현재가)이 US 프리마켓 창(21:00~22:25 KST, 서머타임 기준
+08:00~09:25 ET)에 **실제 프리마켓 가격**을 주는지, 아니면 **전일종가를 그대로**
+돌려주는지 실측하는 read-only 진단 스크립트. ROB-922 AC(3) 게이트.
+
+- **CLI**: `scripts/kis_overseas_premarket_probe.py`
+- **관련**: ROB-922 (Linear, 에픽 ROB-921), `docs/runbooks/kis-overseas-price-smoke.md`(ROB-471, 인접 스모크)
+
+## 무엇을/왜
+
+07-16 실측(us_research 리서치)에서 MAN이 08:00 ET 프리마켓에 +11.7% 움직였지만,
+운영 표면(`get_quote(market="us")`) 어디서도 그 가격이 보이지 않았다. 원인은
+4경로 전부에 프리마켓 파라미터가 없었기 때문(`app/mcp_server/tooling/market_data_quotes.py`,
+`app/services/brokers/yahoo/client.py`, `app/services/brokers/kis/constants.py`).
+
+ROB-922는 두 opt-in 경로를 추가했다:
+
+1. Yahoo `fetch_prepost_quote` (yfinance `Ticker.history(prepost=True)` 기반, 검증됨)
+2. KIS `HHDFS00000300`이 프리마켓 시간대에 실제로 무엇을 반환하는지는 **레포에서
+   검증 불가**(라이브 creds 필요) — 이 프로브가 그 사실을 라이브로 확인한다.
+
+같은 심볼에 대해 Yahoo prepost 결과를 대조군으로 나란히 출력해서, KIS 가격이
+프리마켓 실가격에 가까운지(신뢰 가능) 전일종가에 고정돼 있는지(신뢰 불가) 사람이
+판단할 근거를 만든다.
+
+## 안전 경계
+
+- **READ-ONLY 조회 TR만 호출**: `KISClient().inquire_overseas_price`
+  (`HHDFS00000300`). 주문/계좌 TR 절대 호출하지 않음.
+- 브로커/주문/워치/order-intent mutation 없음. 스케줄러/TaskIQ 연결 없음
+  (명시 실행에서만 동작).
+- 라이브 KIS creds 미설정 시 누락 **env 키 NAME만** 보고하고 exit 3 (값 출력 없음).
+- 호스트는 `KIS_BASE_URL` 라이브 그대로 사용.
+
+## 사전 조건
+
+라이브 KIS creds (`.env` 또는 환경변수):
+
+```
+KIS_APP_KEY=...
+KIS_APP_SECRET=...
+```
+
+## 실행 절차
+
+**창: 21:00~22:25 KST** (US 프리마켓, `us_market_session()`이 `premarket`을
+반환하는 구간 — 서머타임 여부에 따라 ±1시간 이동 가능하니 스크립트 출력의
+`us_market_session` 필드로 실제 세션을 확인할 것).
+
+```bash
+# 기본 심볼(AAPL, NVDA)
+uv run python -m scripts.kis_overseas_premarket_probe
+
+# 특정 심볼
+uv run python -m scripts.kis_overseas_premarket_probe --symbols AAPL,NVDA,MAN
+
+# JSON 출력(기록/비교용)
+uv run python -m scripts.kis_overseas_premarket_probe --symbols AAPL --json
+```
+
+## 출력 해석
+
+각 심볼에 대해:
+
+- `us_market_session` — 로컬 시각이 실제로 프리마켓 창에 있는지 확인.
+- `kis.price` vs `kis.previous_close` — **동일하면** KIS가 전일종가를 그대로
+  돌려주고 있다는 강한 의심 신호. **다르면** 실제 프리마켓 가격을 반영하고
+  있다는 신호.
+- `yahoo_prepost.price` — 대조군. `kis.price`와 근접하면 KIS 프리마켓 가격이
+  신뢰 가능하다는 근거가 강해진다.
+- `kis.quote_asof` — KIS가 준 타임스탬프가 당일 프리마켓 시각을 가리키는지
+  (전일 날짜/시각이면 stale 신호).
+
+## 실측 결과
+
+> **pending — operator 실행 후 기입.** (자동으로 "실측했다"고 기입하지 않는다 —
+> 21:00~22:25 KST 창에서 실제로 실행한 사람이 아래 표를 채운다.)
+
+| 날짜(KST) | 심볼 | us_market_session | kis.price | kis.previous_close | yahoo_prepost.price | 판정(실가격 / 전일종가 고정) |
+|-----------|------|--------------------|-----------|---------------------|----------------------|-------------------------------|
+| pending   | pending | pending | pending | pending | pending | pending |
+
+## 후속 조치
+
+- KIS가 전일종가 고정으로 판정되면: `get_quote(market="us", include_extended_hours=True)`의
+  Yahoo prepost 오버레이(ROB-922)가 이미 정직한 라벨(`price_source="yahoo_prepost_last"`)로
+  실가격을 채워주므로 별도 코드 변경 불필요 — 이 문서에 실측 결과만 남기면 충분.
+- KIS가 실제 프리마켓 가격을 준다고 판정되면: follow-up 이슈로 KIS를
+  premarket/afterhours opt-in 경로의 primary 소스로 승격하는 안을 검토
+  (현재는 Yahoo prepost만 opt-in 오버레이로 배선돼 있음).

--- a/scripts/kis_overseas_premarket_probe.py
+++ b/scripts/kis_overseas_premarket_probe.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""KIS 해외 프리마켓(HHDFS00000300) 실측 프로브 (ROB-922).
+
+미국 프리마켓 창(21:00~22:25 KST, 즉 08:00~09:25 ET 서머타임 기준)에 KIS
+HHDFS00000300이 실제로 어떤 가격을 반환하는지 — **프리마켓 실가격**인지
+**전일종가 그대로**인지 — 실측하기 위한 read-only 진단 스크립트다.
+
+같은 심볼에 대해 Yahoo prepost(``fetch_prepost_quote``, ROB-922)를 대조군으로
+나란히 출력한다 — 두 소스가 얼마나 다른지 비교해서 KIS 프리마켓 가격의
+신뢰도를 판단하는 근거로 쓴다.
+
+READ-ONLY: ``KISClient().inquire_overseas_price`` (조회 TR)만 호출한다.
+주문/계좌 TR은 절대 호출하지 않는다. 브로커/주문/워치 mutation 없음.
+
+Usage
+-----
+    uv run python -m scripts.kis_overseas_premarket_probe --symbols AAPL,NVDA
+    uv run python -m scripts.kis_overseas_premarket_probe --symbols AAPL --json
+
+Exit codes
+----------
+    0  - 모든 심볼 조회 완료(가격 유무와 무관 — 이 스크립트는 진단용이며
+         "프리마켓가 vs 전일종가" 판정은 사람이 출력을 보고 내린다)
+    3  - 라이브 KIS creds 미설정
+    1  - 예기치 못한 예외
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+from typing import Any
+
+_REQUIRED_KIS_ENV: tuple[str, ...] = ("KIS_APP_KEY", "KIS_APP_SECRET")
+_DEFAULT_SYMBOLS: tuple[str, ...] = ("AAPL", "NVDA")
+
+
+def missing_kis_cred_names() -> list[str]:
+    """Return the env-var NAMES (never values) of unset live KIS creds."""
+    return [name for name in _REQUIRED_KIS_ENV if not os.environ.get(name)]
+
+
+def _to_float(value: Any) -> float | None:
+    try:
+        return float(value) if value not in (None, "") else None
+    except (TypeError, ValueError):
+        return None
+
+
+async def probe_symbol(symbol: str) -> dict[str, Any]:
+    """Fetch the KIS overseas price + Yahoo prepost quote for one symbol.
+
+    Read-only: ``inquire_overseas_price`` (HHDFS00000300) and
+    ``fetch_prepost_quote`` (Yahoo prepost 1m bar) only — no order/account TR.
+    """
+    import datetime as dt
+    from zoneinfo import ZoneInfo
+
+    from app.core.symbol import to_db_symbol
+    from app.mcp_server.tooling.market_session import us_market_session
+    from app.services.brokers.kis.client import KISClient
+    from app.services.brokers.yahoo.client import fetch_prepost_quote
+    from app.services.us_symbol_universe_service import (
+        USSymbolInactiveError,
+        USSymbolNotRegisteredError,
+        USSymbolUniverseEmptyError,
+        get_us_exchange_by_symbol,
+    )
+
+    normalized = str(symbol or "").strip().upper()
+    now_utc = dt.datetime.now(dt.UTC)
+    now_kst = now_utc.astimezone(ZoneInfo("Asia/Seoul"))
+    now_et = now_utc.astimezone(ZoneInfo("America/New_York"))
+    session_label = us_market_session(now_utc)
+
+    result: dict[str, Any] = {
+        "symbol": normalized,
+        "now_kst": now_kst.isoformat(),
+        "now_et": now_et.isoformat(),
+        "us_market_session": session_label,
+    }
+
+    try:
+        exchange_code = await get_us_exchange_by_symbol(to_db_symbol(normalized))
+    except (
+        USSymbolNotRegisteredError,
+        USSymbolInactiveError,
+        USSymbolUniverseEmptyError,
+    ) as exc:
+        result["kis"] = {"error": f"{type(exc).__name__}: {exc}"}
+        exchange_code = None
+    else:
+        result["venue"] = exchange_code
+
+    if exchange_code is not None:
+        try:
+            df = await KISClient().inquire_overseas_price(normalized, exchange_code)
+        except Exception as exc:  # noqa: BLE001 — 진단 출력, 다음 심볼로 계속
+            result["kis"] = {"error": f"{type(exc).__name__}: {exc}"}
+        else:
+            if df.empty:
+                result["kis"] = {"price": None, "note": "empty frame (no price)"}
+            else:
+                row = df.iloc[0].to_dict()
+                result["kis"] = {
+                    "price": _to_float(row.get("close")),
+                    "previous_close": _to_float(row.get("previous_close")),
+                    "volume": row.get("volume"),
+                    "quote_asof": row.get("quote_asof"),
+                }
+
+    try:
+        prepost = await fetch_prepost_quote(normalized)
+    except Exception as exc:  # noqa: BLE001 — 진단 출력
+        result["yahoo_prepost"] = {"error": f"{type(exc).__name__}: {exc}"}
+    else:
+        result["yahoo_prepost"] = prepost if prepost is not None else {"price": None}
+
+    return result
+
+
+def _print_human(rows: list[dict[str, Any]]) -> None:
+    for row in rows:
+        print(f"[probe] symbol={row['symbol']}")
+        print(
+            f"        now_kst={row['now_kst']} now_et={row['now_et']} "
+            f"us_market_session={row['us_market_session']}"
+        )
+        if "venue" in row:
+            print(f"        venue={row['venue']}")
+        kis = row.get("kis") or {}
+        print(f"        kis(HHDFS00000300)      = {kis}")
+        yahoo = row.get("yahoo_prepost") or {}
+        print(f"        yahoo_prepost(대조군)     = {yahoo}")
+        print()
+
+
+async def run_probe(*, symbols: list[str], as_json: bool) -> int:
+    if missing_kis_cred_names():
+        missing = ", ".join(missing_kis_cred_names())
+        print(
+            f"[probe] 라이브 KIS creds 미설정: {missing} "
+            "(.env 또는 환경변수에 설정 후 재실행). 값은 출력하지 않음."
+        )
+        return 3
+
+    rows = [await probe_symbol(symbol) for symbol in symbols]
+
+    if as_json:
+        print(json.dumps(rows, ensure_ascii=False, indent=2, default=str))
+    else:
+        _print_human(rows)
+        print(
+            "[probe] 판정은 사람 몫: kis.price 가 전일종가(previous_close)와 "
+            "동일하면 '전일종가 그대로' 의심, yahoo_prepost.price 와 근접하면 "
+            "'프리마켓 실가격' 근거."
+        )
+
+    return 0
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="kis_overseas_premarket_probe",
+        description=(
+            "KIS 해외 프리마켓(HHDFS00000300) 실측 프로브 — 21:00~22:25 KST 창에서 "
+            "실행해 프리마켓 실가격 여부를 확인한다 (ROB-922, read-only)"
+        ),
+    )
+    parser.add_argument(
+        "--symbols",
+        default=",".join(_DEFAULT_SYMBOLS),
+        help=f"콤마 구분 심볼 목록 (기본: {','.join(_DEFAULT_SYMBOLS)})",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="사람이 읽는 출력 대신 JSON 배열 출력",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_arg_parser().parse_args(argv)
+    symbols = [s.strip().upper() for s in args.symbols.split(",") if s.strip()]
+    try:
+        return asyncio.run(run_probe(symbols=symbols, as_json=args.json))
+    except KeyboardInterrupt:
+        print("[probe] interrupted")
+        return 1
+    except Exception as exc:  # noqa: BLE001 — 최상위 진단
+        print(f"[probe] 예기치 못한 예외({type(exc).__name__}): {exc}")
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_kis_overseas_premarket_probe.py
+++ b/tests/test_kis_overseas_premarket_probe.py
@@ -1,0 +1,46 @@
+"""Unit tests for the ROB-922 KIS overseas-premarket probe pure helpers.
+
+The live KIS/Yahoo calls are operator-run (creds-gated, network); here we pin
+the pure decision/formatting helpers the probe uses to build its report.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from scripts.kis_overseas_premarket_probe import (
+    _to_float,
+    missing_kis_cred_names,
+)
+
+
+def test_missing_kis_cred_names_reports_only_unset(monkeypatch):
+    monkeypatch.delenv("KIS_APP_KEY", raising=False)
+    monkeypatch.setenv("KIS_APP_SECRET", "present")
+    assert missing_kis_cred_names() == ["KIS_APP_KEY"]
+
+
+def test_missing_kis_cred_names_empty_when_all_present(monkeypatch):
+    monkeypatch.setenv("KIS_APP_KEY", "x")
+    monkeypatch.setenv("KIS_APP_SECRET", "y")
+    assert missing_kis_cred_names() == []
+
+
+def test_missing_kis_cred_names_reports_both_when_unset(monkeypatch):
+    monkeypatch.delenv("KIS_APP_KEY", raising=False)
+    monkeypatch.delenv("KIS_APP_SECRET", raising=False)
+    assert missing_kis_cred_names() == ["KIS_APP_KEY", "KIS_APP_SECRET"]
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        ("205.12", 205.12),
+        (205.12, 205.12),
+        (None, None),
+        ("", None),
+        ("not-a-number", None),
+    ],
+)
+def test_to_float(value, expected):
+    assert _to_float(value) == expected

--- a/tests/test_mcp_quotes_tools.py
+++ b/tests/test_mcp_quotes_tools.py
@@ -1264,6 +1264,229 @@ async def test_get_quote_us_yahoo_fallback_tags_session_and_price_source(monkeyp
 
 
 # ---------------------------------------------------------------------------
+# get_quote Tests - US Equity include_extended_hours (ROB-922)
+# ---------------------------------------------------------------------------
+
+
+def _setup_us_kis_premarket_quote(monkeypatch, session: str) -> None:
+    """Shared fixture: KIS overseas quote in the given (non-regular) session."""
+    _patch_runtime_attr(
+        monkeypatch, "get_us_exchange_by_symbol", AsyncMock(return_value="NASD")
+    )
+    _patch_runtime_attr(monkeypatch, "us_market_session", lambda *a, **k: session)
+
+    price_df = pd.DataFrame(
+        [
+            {
+                "close": 195.29,
+                "previous_close": 194.83,
+                "volume": 123456,
+                "quote_asof": "2026-07-06T08:45:12-04:00",
+            }
+        ]
+    )
+
+    class DummyKISClient:
+        async def inquire_overseas_price(self, symbol, exchange_code="NASD"):
+            return price_df
+
+    _patch_runtime_attr(monkeypatch, "KISClient", DummyKISClient)
+
+
+@pytest.mark.asyncio
+async def test_get_quote_us_include_extended_hours_default_false_is_noop(monkeypatch):
+    """Unspecified include_extended_hours must never call the Yahoo prepost
+    path — default result stays byte-identical to the pre-ROB-922 payload."""
+    tools = build_tools()
+    _setup_us_kis_premarket_quote(monkeypatch, "premarket")
+    monkeypatch.setattr(
+        yahoo_service,
+        "fetch_prepost_quote",
+        AsyncMock(side_effect=AssertionError("prepost must not be called")),
+    )
+
+    result = await tools["get_quote"]("NVDA", market="us")
+
+    assert result["price"] == pytest.approx(195.29)
+    assert result["price_source"] == "kis_overseas_last"
+    assert result["session"] == "premarket"
+
+
+@pytest.mark.asyncio
+async def test_get_quote_us_include_extended_hours_premarket_overlays_yahoo_prepost(
+    monkeypatch,
+):
+    tools = build_tools()
+    _setup_us_kis_premarket_quote(monkeypatch, "premarket")
+    monkeypatch.setattr(
+        yahoo_service,
+        "fetch_prepost_quote",
+        AsyncMock(
+            return_value={
+                "symbol": "NVDA",
+                "price": 210.5,
+                "quote_asof": "2026-07-16T12:01:00+00:00",
+                "volume": 5000,
+            }
+        ),
+    )
+
+    result = await tools["get_quote"]("NVDA", market="us", include_extended_hours=True)
+
+    assert result["price"] == pytest.approx(210.5)
+    assert result["price_source"] == "yahoo_prepost_last"
+    assert result["quote_asof"] == "2026-07-16T12:01:00+00:00"
+    assert result["session"] == "premarket"
+    assert result["data_state"] == "fresh"
+    # previous_close must be preserved from the base source for gap math.
+    assert result["previous_close"] == pytest.approx(194.83)
+
+
+@pytest.mark.asyncio
+async def test_get_quote_us_include_extended_hours_afterhours_overlays_yahoo_prepost(
+    monkeypatch,
+):
+    tools = build_tools()
+    _setup_us_kis_premarket_quote(monkeypatch, "afterhours")
+    monkeypatch.setattr(
+        yahoo_service,
+        "fetch_prepost_quote",
+        AsyncMock(
+            return_value={
+                "symbol": "NVDA",
+                "price": 208.1,
+                "quote_asof": "2026-07-16T21:15:00+00:00",
+                "volume": 900,
+            }
+        ),
+    )
+
+    result = await tools["get_quote"]("NVDA", market="us", include_extended_hours=True)
+
+    assert result["price"] == pytest.approx(208.1)
+    assert result["price_source"] == "yahoo_prepost_last"
+    assert result["session"] == "afterhours"
+
+
+@pytest.mark.asyncio
+async def test_get_quote_us_include_extended_hours_prepost_none_keeps_honest_label(
+    monkeypatch,
+):
+    """When Yahoo has no prepost data, the existing (honest) quote/labels are
+    kept — never lie about the price_source."""
+    tools = build_tools()
+    _setup_us_kis_premarket_quote(monkeypatch, "premarket")
+    monkeypatch.setattr(
+        yahoo_service, "fetch_prepost_quote", AsyncMock(return_value=None)
+    )
+
+    result = await tools["get_quote"]("NVDA", market="us", include_extended_hours=True)
+
+    assert result["price"] == pytest.approx(195.29)
+    assert result["price_source"] == "kis_overseas_last"
+    assert result["session"] == "premarket"
+
+
+@pytest.mark.asyncio
+async def test_get_quote_us_include_extended_hours_prepost_exception_keeps_honest_label(
+    monkeypatch,
+):
+    """A Yahoo transport failure during the opt-in overlay must not break the
+    base quote — degrade gracefully to the existing result."""
+    tools = build_tools()
+    _setup_us_kis_premarket_quote(monkeypatch, "premarket")
+    monkeypatch.setattr(
+        yahoo_service,
+        "fetch_prepost_quote",
+        AsyncMock(side_effect=RuntimeError("yahoo down")),
+    )
+
+    result = await tools["get_quote"]("NVDA", market="us", include_extended_hours=True)
+
+    assert result["price"] == pytest.approx(195.29)
+    assert result["price_source"] == "kis_overseas_last"
+
+
+@pytest.mark.asyncio
+async def test_get_quote_us_include_extended_hours_regular_session_is_noop(
+    monkeypatch,
+):
+    tools = build_tools()
+    _setup_us_kis_premarket_quote(monkeypatch, "regular")
+    monkeypatch.setattr(
+        yahoo_service,
+        "fetch_prepost_quote",
+        AsyncMock(side_effect=AssertionError("prepost must not be called")),
+    )
+
+    result = await tools["get_quote"]("NVDA", market="us", include_extended_hours=True)
+
+    assert result["price"] == pytest.approx(195.29)
+    assert result["price_source"] == "kis_overseas_last"
+    assert result["session"] == "regular"
+
+
+@pytest.mark.asyncio
+async def test_get_quote_us_include_extended_hours_closed_session_is_noop(
+    monkeypatch,
+):
+    tools = build_tools()
+    _setup_us_kis_premarket_quote(monkeypatch, "closed")
+    monkeypatch.setattr(
+        yahoo_service,
+        "fetch_prepost_quote",
+        AsyncMock(side_effect=AssertionError("prepost must not be called")),
+    )
+
+    result = await tools["get_quote"]("NVDA", market="us", include_extended_hours=True)
+
+    assert result["session"] == "closed"
+    assert result["data_state"] == "stale"
+    assert result["price_source"] == "kis_overseas_last"
+
+
+@pytest.mark.asyncio
+async def test_get_quote_kr_include_extended_hours_is_noop(monkeypatch):
+    """KR market ignores include_extended_hours entirely — no-op."""
+    tools = build_tools()
+
+    df = _single_row_df()
+
+    class DummyKISClient:
+        async def inquire_daily_itemchartprice(self, code, market, n):
+            return df
+
+    _patch_runtime_attr(monkeypatch, "KISClient", DummyKISClient)
+    monkeypatch.setattr(
+        yahoo_service,
+        "fetch_prepost_quote",
+        AsyncMock(side_effect=AssertionError("prepost must not be called for KR")),
+    )
+
+    result = await tools["get_quote"]("005930", include_extended_hours=True)
+
+    assert result["instrument_type"] == "equity_kr"
+
+
+@pytest.mark.asyncio
+async def test_get_quote_crypto_include_extended_hours_is_noop(monkeypatch):
+    """Crypto market ignores include_extended_hours entirely — no-op."""
+    tools = build_tools()
+
+    mock_fetch = AsyncMock(return_value={"KRW-BTC": 123.4})
+    monkeypatch.setattr(upbit_service, "fetch_multiple_current_prices", mock_fetch)
+    monkeypatch.setattr(
+        yahoo_service,
+        "fetch_prepost_quote",
+        AsyncMock(side_effect=AssertionError("prepost must not be called for crypto")),
+    )
+
+    result = await tools["get_quote"]("krw-btc", include_extended_hours=True)
+
+    assert result["instrument_type"] == "crypto"
+
+
+# ---------------------------------------------------------------------------
 # get_quote Tests - Error Handling
 # ---------------------------------------------------------------------------
 

--- a/tests/test_services_yahoo.py
+++ b/tests/test_services_yahoo.py
@@ -292,3 +292,173 @@ class TestYahooService:
             "marketCap": None,
         }
         assert mock_ticker_class.call_args.kwargs["session"] is tracing_session
+
+
+class TestYahooPrepostQuote:
+    """ROB-922: opt-in Yahoo prepost (extended-hours) quote path."""
+
+    @pytest.mark.asyncio
+    @patch("app.services.brokers.yahoo.client.yf.download")
+    async def test_fetch_ohlcv_prepost_default_omits_kwarg(
+        self, mock_download, monkeypatch
+    ):
+        """prepost unspecified (default False) must be byte-identical to the
+        existing call — no new kwarg reaches yf.download."""
+        monkeypatch.setattr(
+            "app.services.brokers.yahoo.client.build_yfinance_tracing_session",
+            lambda: object(),
+        )
+        monkeypatch.setattr(
+            "app.services.brokers.yahoo.client.settings.yahoo_ohlcv_cache_enabled",
+            False,
+            raising=False,
+        )
+        mock_download.return_value = pd.DataFrame(
+            {
+                "open": [100],
+                "high": [105],
+                "low": [95],
+                "close": [103],
+                "volume": [1000],
+            }
+        )
+
+        from app.services.brokers.yahoo.client import fetch_ohlcv
+
+        await fetch_ohlcv("AAPL", days=1)
+
+        assert "prepost" not in mock_download.call_args.kwargs
+
+    @pytest.mark.asyncio
+    @patch("app.services.brokers.yahoo.client.yf.download")
+    async def test_fetch_ohlcv_prepost_true_passes_flag_to_yf_download(
+        self, mock_download, monkeypatch
+    ):
+        monkeypatch.setattr(
+            "app.services.brokers.yahoo.client.build_yfinance_tracing_session",
+            lambda: object(),
+        )
+        mock_download.return_value = pd.DataFrame(
+            {
+                "open": [100],
+                "high": [105],
+                "low": [95],
+                "close": [103],
+                "volume": [1000],
+            }
+        )
+
+        from app.services.brokers.yahoo.client import fetch_ohlcv
+
+        await fetch_ohlcv("AAPL", days=1, period="1h", prepost=True)
+
+        assert mock_download.call_args.kwargs["prepost"] is True
+
+    @pytest.mark.asyncio
+    @patch("app.services.brokers.yahoo.client.yf.download")
+    async def test_fetch_ohlcv_prepost_true_bypasses_closed_candle_cache(
+        self, mock_download, monkeypatch
+    ):
+        """ROB-922: prepost=True must never read/write the closed-candle cache
+        (cache is built from regular-session data only — mixing in prepost
+        would silently corrupt it)."""
+        monkeypatch.setattr(
+            "app.services.brokers.yahoo.client.build_yfinance_tracing_session",
+            lambda: object(),
+        )
+        monkeypatch.setattr(
+            "app.services.brokers.yahoo.client.settings.yahoo_ohlcv_cache_enabled",
+            True,
+            raising=False,
+        )
+        mock_download.return_value = pd.DataFrame(
+            {
+                "open": [100],
+                "high": [105],
+                "low": [95],
+                "close": [103],
+                "volume": [1000],
+            }
+        )
+
+        import app.services.yahoo_ohlcv_cache as yahoo_ohlcv_cache_service
+
+        async def _fail_if_called(*args, **kwargs):
+            raise AssertionError("cache must be bypassed when prepost=True")
+
+        monkeypatch.setattr(
+            yahoo_ohlcv_cache_service, "get_closed_candles", _fail_if_called
+        )
+
+        from app.services.brokers.yahoo.client import fetch_ohlcv
+
+        result = await fetch_ohlcv("AAPL", days=1, period="day", prepost=True)
+
+        assert mock_download.call_args.kwargs["prepost"] is True
+        assert not result.empty
+
+    @pytest.mark.asyncio
+    @patch("app.services.brokers.yahoo.client.yf.Ticker")
+    async def test_fetch_prepost_quote_returns_last_row(
+        self, mock_ticker_class, monkeypatch
+    ):
+        tracing_session = object()
+        monkeypatch.setattr(
+            "app.services.brokers.yahoo.client.build_yfinance_tracing_session",
+            lambda: tracing_session,
+        )
+
+        index = pd.DatetimeIndex(
+            [
+                "2026-07-16 08:00:00-04:00",
+                "2026-07-16 08:01:00-04:00",
+            ],
+            name="Datetime",
+        )
+        history_df = pd.DataFrame(
+            {
+                "Open": [10.0, 11.0],
+                "High": [10.5, 11.5],
+                "Low": [9.5, 10.5],
+                "Close": [10.2, 11.7],
+                "Volume": [1000, 2000],
+            },
+            index=index,
+        )
+
+        mock_ticker = MagicMock()
+        mock_ticker.history.return_value = history_df
+        mock_ticker_class.return_value = mock_ticker
+
+        from app.services.brokers.yahoo.client import fetch_prepost_quote
+
+        result = await fetch_prepost_quote("AAPL")
+
+        assert result is not None
+        assert result["price"] == pytest.approx(11.7)
+        assert result["volume"] == 2000
+        assert result["quote_asof"] == "2026-07-16T12:01:00+00:00"
+        mock_ticker.history.assert_called_once_with(
+            period="1d", interval="1m", prepost=True
+        )
+        assert mock_ticker_class.call_args.kwargs["session"] is tracing_session
+
+    @pytest.mark.asyncio
+    @patch("app.services.brokers.yahoo.client.yf.Ticker")
+    async def test_fetch_prepost_quote_returns_none_for_empty_frame(
+        self, mock_ticker_class, monkeypatch
+    ):
+        monkeypatch.setattr(
+            "app.services.brokers.yahoo.client.build_yfinance_tracing_session",
+            lambda: object(),
+        )
+
+        mock_ticker = MagicMock()
+        mock_ticker.history.return_value = pd.DataFrame()
+        mock_ticker_class.return_value = mock_ticker
+
+        from app.services.brokers.yahoo.client import fetch_prepost_quote
+
+        result = await fetch_prepost_quote("AAPL")
+
+        assert result is None


### PR DESCRIPTION
## Summary

- Adds an **opt-in** `include_extended_hours` parameter to `get_quote` (US equity only). During premarket/afterhours sessions it opportunistically overlays the latest Yahoo pre/post-market 1-minute price (`price_source="yahoo_prepost_last"`, honest `quote_asof`). Default `False` is unchanged.
- Adds `fetch_prepost_quote()` to the Yahoo client using `yfinance Ticker.history(period="1d", interval="1m", prepost=True)`. Returns `None` on empty extended-session data — never fabricated.
- Adds a keyword-only `prepost` param to `fetch_ohlcv`/`_fetch_ohlcv_raw` (default `False`). `prepost=True` always bypasses the closed-candle cache (the cache is built from regular-session-only data and must not be mixed with extended-hours candles).
- Adds `scripts/kis_overseas_premarket_probe.py` + `docs/runbooks/kis-overseas-premarket-probe.md`: a **read-only** live probe (`inquire_overseas_price` only, no order/account TR) to measure whether KIS `HHDFS00000300` returns real premarket prices or a stale previous close during the 21:00–22:25 KST window, with Yahoo prepost as a side-by-side comparison. The results table is left `pending — operator 실행 후 기입` (not fabricated).

Context: on 07-16, MAN moved +11.7% at 08:00 ET premarket / +17.4% by 09:25 ET, but none of the 4 existing US quote paths (`get_quote`, Yahoo client, KIS constants) exposed premarket data — this closes that gap behind an explicit opt-in.

## Safety boundaries

- **Default calls are byte-identical**: `fetch_ohlcv`/`_fetch_ohlcv_raw` omit the `prepost` kwarg entirely to `yf.download` when unspecified; `get_quote` without `include_extended_hours` returns the exact pre-existing payload.
- **Cache never mixed**: `prepost=True` always skips the `yahoo_ohlcv_cache` closed-candle branch.
- **watch scanner / XNYS gate untouched**: no `app/services/watch*` or scanner files changed; `_tag_us_quote_session`'s existing semantics are preserved (the overlay runs strictly after it).
- **No mutation**: quotes are read-only; no broker/proposal/watch mutation reached; no new schedule/TaskIQ wiring.
- **migration 0**: no alembic changes; `alembic heads` still shows a single head.
- **Honest degrade**: any Yahoo prepost failure/empty result keeps the existing (pre-overlay) quote and labels — never mislabels `price_source`.

## Test plan

- [x] `uv run pytest tests/ -q -k "quote or yahoo or prepost or extended"` → 407 passed
- [x] `uv run pytest tests/mcp_server -q -k "quote"` → 17 passed
- [x] Broader sweep of all test files importing the Yahoo client / `market_data_quotes` (20 files) → 414 passed
- [x] `make lint` (ruff check + format + `ty check`) → clean
- [x] `git diff --check` → clean
- [x] `uv run alembic heads` → single head, unchanged

TDD: RED confirmed before implementation for both the Yahoo client changes (`TypeError`/`ImportError` on the new `prepost` kwarg / `fetch_prepost_quote`) and the `get_quote` changes (`TypeError` on the new `include_extended_hours` kwarg), then implemented to GREEN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an opt-in extended-hours overlay for US equity quotes.
  * Quotes can now show Yahoo premarket or after-hours prices with source and timestamp details.
  * Added a diagnostic tool and runbook for comparing overseas premarket pricing.

* **Bug Fixes**
  * Extended-hours data no longer alters regular-session cached market data.
  * Quotes remain unchanged when extended-hours data is unavailable or fails.

* **Tests**
  * Added coverage for extended-hours behavior, fallback handling, and diagnostic helpers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->