### PR TITLE
feat(ROB-928): downside watch auto-register + stop_loss→watch mirror

### DIFF
--- a/app/mcp_server/tooling/downside_watch_registration.py
+++ b/app/mcp_server/tooling/downside_watch_registration.py
@@ -1,0 +1,61 @@
+# app/mcp_server/tooling/downside_watch_registration.py
+"""MCP registration for the ROB-928 downside-watch auto-register sweep."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from app.core.db import AsyncSessionLocal
+from app.services.downside_watch_service import DownsideWatchService
+
+if TYPE_CHECKING:
+    from fastmcp import FastMCP
+
+DOWNSIDE_WATCH_TOOL_NAMES: set[str] = {"watch_downside_register_sweep"}
+
+_SUPPORTED_MARKETS = frozenset({"kr"})
+
+
+async def watch_downside_register_sweep_impl(
+    market: str = "kr", dry_run: bool = True
+) -> dict[str, Any]:
+    """List (dry_run=True, default) or register (dry_run=False) support-break
+    downside watches for currently held equity, mirroring
+    ``review.trade_journals.stop_loss`` into ``review.investment_watch_alerts``.
+    """
+    if market not in _SUPPORTED_MARKETS:
+        return {
+            "success": False,
+            "error": f"unsupported market: {market!r} (only 'kr' is implemented)",
+        }
+    async with AsyncSessionLocal() as db:
+        result = await DownsideWatchService(db).register_sweep(dry_run=dry_run)
+    return {"success": True, "market": market, **result}
+
+
+def register_downside_watch_tools(mcp: FastMCP) -> None:
+    mcp.tool(
+        name="watch_downside_register_sweep",
+        description=(
+            "ROB-928 — sweep active KR equity holdings (review.trade_journals, "
+            "status=active/account_type=live/side=buy) and register (or, with "
+            "dry_run=True default, just list) support-break downside watch "
+            "alerts: operator=below, intent=sell_review. Threshold = the "
+            "journal stop_loss (max across lots for a symbol) when present, "
+            "else the trailing 20-session KRX low. Skips a symbol that "
+            "already has an active below+sell_review/risk_review watch "
+            "(idempotent — safe to rerun). Notify-only registration "
+            "(action_mode=notify_only): never submits, previews, or touches "
+            "any order/broker path — the only mutation is inserting a "
+            "review.investment_watch_alerts row via DirectWatchCreateService. "
+            "Levels are NOT trailing stops; they are fixed at registration "
+            "time, so rerun this sweep periodically to refresh them."
+        ),
+    )(watch_downside_register_sweep_impl)
+
+
+__all__ = [
+    "DOWNSIDE_WATCH_TOOL_NAMES",
+    "register_downside_watch_tools",
+    "watch_downside_register_sweep_impl",
+]

--- a/app/mcp_server/tooling/registry.py
+++ b/app/mcp_server/tooling/registry.py
@@ -108,6 +108,9 @@ from app.mcp_server.tooling.analysis_readonly_registration import (
     register_analysis_readonly_tools,
 )
 from app.mcp_server.tooling.analysis_registration import register_analysis_tools
+from app.mcp_server.tooling.downside_watch_registration import (
+    register_downside_watch_tools,
+)
 from app.mcp_server.tooling.execution_ledger_events import (
     register_execution_ledger_event_tools,
 )
@@ -298,6 +301,9 @@ def register_all_tools(mcp: FastMCP, profile: McpProfile = McpProfile.DEFAULT) -
     register_portfolio_tools(mcp)
     register_account_routing_tools(mcp)
     register_trade_journal_tools(mcp)
+    # ROB-928 — downside watch auto-register sweep; read-only advisory
+    # (notify-only watch registration only, no broker/order mutation).
+    register_downside_watch_tools(mcp)
     # ROB-755 — execution ledger fill event read tool; read-only, always registered.
     register_execution_ledger_event_tools(mcp)
     register_mock_loop_retro_tools(mcp)

--- a/app/mcp_server/tooling/route_request_lanes.py
+++ b/app/mcp_server/tooling/route_request_lanes.py
@@ -403,6 +403,9 @@ READ_ONLY_ADVISORY_TOOLS: frozenset[str] = frozenset(
         "trade_retrospective_pending",
         "update_manual_holdings",
         "update_trade_journal",
+        # ROB-928: notify-only downside watch sweep (dry_run default; only
+        # mutation is an investment_watch_alerts INSERT, no broker/order path).
+        "watch_downside_register_sweep",
     }
 )
 

--- a/app/services/downside_watch_service.py
+++ b/app/services/downside_watch_service.py
@@ -1,0 +1,241 @@
+"""ROB-928 — downside watch auto-register + stop_loss->watch mirror.
+
+Mirrors ``review.trade_journals.stop_loss`` for currently-held KR equity
+positions into a support-break (``operator=below``) watch alert so a
+stop-loss breach produces a notify-only Hermes trigger instead of the
+silent -14.6% drift observed on 005930 (stop 286,000 breached 2026-07-02,
+unactioned for two weeks — the incident that motivated this ticket).
+Symbols with no journal ``stop_loss`` fall back to the trailing 20-session
+low as a support-break proxy.
+
+Safety boundary: the only mutation this module performs is inserting a
+``review.investment_watch_alerts`` row via ``DirectWatchCreateService``
+(action_mode=notify_only). It never imports an order/broker surface —
+see tests/services/test_downside_watch_service_no_broker_imports.py.
+Registration is fixed-level, not trailing: rerun periodically to refresh.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from datetime import timedelta
+from decimal import Decimal
+from typing import Any, Literal
+
+import sqlalchemy as sa
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.timezone import now_kst
+from app.models.trade_journal import JournalStatus, TradeJournal
+from app.models.trading import InstrumentType
+from app.schemas.investment_reports import CreateInvestmentWatchRequest
+from app.services.investment_reports.repository import InvestmentReportsRepository
+from app.services.investment_reports.watch_create import DirectWatchCreateService
+
+logger = logging.getLogger(__name__)
+
+# Level-selection rule (ROB-928 AC): journal stop_loss wins when present
+# (max across lots for the same symbol); otherwise fall back to the
+# trailing N-session low. Kept as module constants so the rule is a
+# single tunable, not scattered magic numbers.
+RECENT_LOW_LOOKBACK_SESSIONS = 20
+DEFAULT_VALID_FOR = timedelta(days=14)
+CREATED_BY = "downside_watch_service"
+DEFENSIVE_INTENT: Literal["sell_review"] = "sell_review"
+_DEFENSIVE_INTENTS = frozenset({"sell_review", "risk_review"})
+
+LevelSource = Literal["stop_loss_mirror", "recent_low_20d"]
+RecentLowFetcher = Callable[[str], Awaitable[Decimal | None]]
+
+
+@dataclass(frozen=True)
+class DownsideWatchLevel:
+    symbol: str
+    threshold: Decimal
+    source: LevelSource
+    quantity: Decimal
+
+
+async def _fetch_recent_low_from_db(
+    session: AsyncSession, symbol: str
+) -> Decimal | None:
+    """Trailing 20-session KRX low, read directly (bypassing the
+    freshness-gated cache_first_kr helper so callers control staleness
+    policy explicitly for this advisory-only fallback)."""
+    from app.services.daily_candles.repository import DailyCandlesRepository, MarketKey
+
+    repo = DailyCandlesRepository(session=session)
+    rows = await repo.fetch_recent(
+        market=MarketKey.KR,
+        symbol=symbol,
+        partition="KRX",
+        count=RECENT_LOW_LOOKBACK_SESSIONS,
+    )
+    if not rows:
+        return None
+    return Decimal(str(min(row.low for row in rows)))
+
+
+class DownsideWatchService:
+    """Session-invoked sweep: hydrate KR holdings -> support-break watch."""
+
+    def __init__(
+        self,
+        session: AsyncSession,
+        *,
+        watch_repo: InvestmentReportsRepository | None = None,
+        recent_low_fetcher: RecentLowFetcher | None = None,
+    ) -> None:
+        self._session = session
+        self._watch_repo = watch_repo or InvestmentReportsRepository(session)
+        self._recent_low_fetcher = recent_low_fetcher or (
+            lambda symbol: _fetch_recent_low_from_db(session, symbol)
+        )
+
+    async def _active_kr_holdings(self) -> dict[str, list[TradeJournal]]:
+        stmt = sa.select(TradeJournal).where(
+            TradeJournal.status == JournalStatus.active,
+            TradeJournal.account_type == "live",
+            TradeJournal.side == "buy",
+            TradeJournal.instrument_type == InstrumentType.equity_kr,
+        )
+        rows = (await self._session.execute(stmt)).scalars().all()
+        grouped: dict[str, list[TradeJournal]] = {}
+        for row in rows:
+            grouped.setdefault(row.symbol, []).append(row)
+        return grouped
+
+    async def compute_levels(self) -> list[DownsideWatchLevel]:
+        levels: list[DownsideWatchLevel] = []
+        for symbol, lots in (await self._active_kr_holdings()).items():
+            quantity = sum((lot.quantity or Decimal("0")) for lot in lots)
+            stop_losses = [lot.stop_loss for lot in lots if lot.stop_loss is not None]
+            if stop_losses:
+                levels.append(
+                    DownsideWatchLevel(
+                        symbol=symbol,
+                        threshold=max(stop_losses),
+                        source="stop_loss_mirror",
+                        quantity=quantity,
+                    )
+                )
+                continue
+
+            recent_low = await self._recent_low_fetcher(symbol)
+            if recent_low is None:
+                logger.info(
+                    "downside_watch: no stop_loss and no recent-low data for "
+                    "%s; skipping this sweep",
+                    symbol,
+                )
+                continue
+            levels.append(
+                DownsideWatchLevel(
+                    symbol=symbol,
+                    threshold=recent_low,
+                    source="recent_low_20d",
+                    quantity=quantity,
+                )
+            )
+        return levels
+
+    async def _has_active_downside_watch(self, symbol: str) -> bool:
+        existing = await self._watch_repo.list_alerts(
+            market="kr", symbol=symbol, status="active", limit=250
+        )
+        return any(
+            alert.operator == "below" and alert.intent in _DEFENSIVE_INTENTS
+            for alert in existing
+        )
+
+    def _build_request(
+        self, level: DownsideWatchLevel, *, valid_until
+    ) -> CreateInvestmentWatchRequest:
+        rationale = (
+            f"ROB-928 하방 워치 자동등록 (source={level.source}): "
+            f"근거 레벨={level.threshold}. 트레일링 미지원 — 레벨 고정, "
+            "주기 재등록 필요 (stale 경고)."
+        )
+        return CreateInvestmentWatchRequest.model_validate(
+            {
+                "created_by": CREATED_BY,
+                "market": "kr",
+                "symbol": level.symbol,
+                "intent": DEFENSIVE_INTENT,
+                "rationale": rationale,
+                "watch_condition": {
+                    "metric": "price",
+                    "operator": "below",
+                    "threshold": level.threshold,
+                    "action_mode": "notify_only",
+                },
+                "valid_until": valid_until,
+                "metadata": {
+                    "rob928_level_source": level.source,
+                    "rob928_quantity": str(level.quantity),
+                    "trailing_supported": False,
+                },
+            }
+        )
+
+    async def register_sweep(self, *, dry_run: bool = True) -> dict[str, Any]:
+        levels = await self.compute_levels()
+        valid_until = now_kst() + DEFAULT_VALID_FOR
+
+        registered: list[dict[str, Any]] = []
+        skipped_existing: list[dict[str, Any]] = []
+        level_summaries: list[dict[str, Any]] = []
+
+        for level in levels:
+            level_summaries.append(
+                {
+                    "symbol": level.symbol,
+                    "threshold": str(level.threshold),
+                    "source": level.source,
+                    "quantity": str(level.quantity),
+                }
+            )
+
+            if await self._has_active_downside_watch(level.symbol):
+                skipped_existing.append(
+                    {
+                        "symbol": level.symbol,
+                        "reason": "active_downside_watch_exists",
+                    }
+                )
+                continue
+
+            if dry_run:
+                registered.append(
+                    {
+                        "symbol": level.symbol,
+                        "threshold": str(level.threshold),
+                        "source": level.source,
+                        "would_register": True,
+                    }
+                )
+                continue
+
+            request = self._build_request(level, valid_until=valid_until)
+            alert, idempotent = await DirectWatchCreateService(
+                self._session, self._watch_repo
+            ).create(request)
+            await self._session.commit()
+            registered.append(
+                {
+                    "symbol": level.symbol,
+                    "alert_uuid": str(alert.alert_uuid),
+                    "threshold": str(level.threshold),
+                    "source": level.source,
+                    "idempotent": idempotent,
+                }
+            )
+
+        return {
+            "dry_run": dry_run,
+            "registered": registered,
+            "skipped_existing": skipped_existing,
+            "levels": level_summaries,
+        }

--- a/tests/services/test_downside_watch_service.py
+++ b/tests/services/test_downside_watch_service.py
@@ -1,0 +1,237 @@
+"""ROB-928 — downside watch auto-register + stop_loss->watch mirror.
+
+Covers: stop_loss mirror level selection (max across lots), 20d-low
+fallback when no journal has a stop_loss, idempotent skip of an
+already-active below+defensive watch, and dry_run defaulting to zero DB
+mutation. Alert-table cleanup is handled by the shared ``session``
+fixture (tests/_investment_reports_helpers.py truncates
+review.investment_watch_alerts between tests); trade_journals rows are
+seeded with unique per-test symbols and cleaned up explicitly since that
+table is outside that fixture's truncation list.
+"""
+
+from __future__ import annotations
+
+import uuid
+from decimal import Decimal
+
+import pytest
+import pytest_asyncio
+import sqlalchemy as sa
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.investment_reports import InvestmentWatchAlert
+from app.models.trade_journal import TradeJournal
+from app.services.downside_watch_service import DownsideWatchService
+
+
+def _symbol() -> str:
+    return f"R928{uuid.uuid4().hex[:6].upper()}"
+
+
+async def _seed_journal(
+    session: AsyncSession,
+    *,
+    symbol: str,
+    quantity: str = "10",
+    entry_price: str = "50000",
+    stop_loss: str | None = None,
+    status: str = "active",
+    account_type: str = "live",
+    side: str = "buy",
+) -> TradeJournal:
+    journal = TradeJournal(
+        symbol=symbol,
+        instrument_type="equity_kr",
+        side=side,
+        entry_price=Decimal(entry_price),
+        quantity=Decimal(quantity),
+        thesis="ROB-928 test fixture",
+        stop_loss=Decimal(stop_loss) if stop_loss is not None else None,
+        status=status,
+        account_type=account_type,
+    )
+    session.add(journal)
+    await session.flush()
+    return journal
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def _cleanup_trade_journals(session: AsyncSession):
+    yield
+    await session.execute(
+        sa.delete(TradeJournal).where(TradeJournal.symbol.like("R928%"))
+    )
+    await session.commit()
+
+
+@pytest.mark.asyncio
+async def test_compute_levels_prefers_stop_loss_mirror_max_across_lots(
+    session: AsyncSession,
+) -> None:
+    symbol = _symbol()
+    await _seed_journal(session, symbol=symbol, quantity="5", stop_loss="48000")
+    await _seed_journal(session, symbol=symbol, quantity="5", stop_loss="49500")
+    await session.commit()
+
+    async def _fail_recent_low(_symbol: str) -> Decimal | None:
+        raise AssertionError(
+            "recent-low fallback must not be called when stop_loss exists"
+        )
+
+    service = DownsideWatchService(session, recent_low_fetcher=_fail_recent_low)
+    levels = await service.compute_levels()
+
+    matching = [lvl for lvl in levels if lvl.symbol == symbol]
+    assert len(matching) == 1
+    level = matching[0]
+    assert level.source == "stop_loss_mirror"
+    assert level.threshold == Decimal("49500")
+    assert level.quantity == Decimal("10")
+
+
+@pytest.mark.asyncio
+async def test_compute_levels_falls_back_to_recent_low_when_no_stop_loss(
+    session: AsyncSession,
+) -> None:
+    symbol = _symbol()
+    await _seed_journal(session, symbol=symbol, quantity="3", stop_loss=None)
+    await session.commit()
+
+    async def _fake_recent_low(sym: str) -> Decimal | None:
+        assert sym == symbol
+        return Decimal("46250")
+
+    service = DownsideWatchService(session, recent_low_fetcher=_fake_recent_low)
+    levels = await service.compute_levels()
+
+    matching = [lvl for lvl in levels if lvl.symbol == symbol]
+    assert len(matching) == 1
+    level = matching[0]
+    assert level.source == "recent_low_20d"
+    assert level.threshold == Decimal("46250")
+
+
+@pytest.mark.asyncio
+async def test_compute_levels_skips_symbol_when_no_stop_loss_and_no_recent_low_data(
+    session: AsyncSession,
+) -> None:
+    symbol = _symbol()
+    await _seed_journal(session, symbol=symbol, stop_loss=None)
+    await session.commit()
+
+    async def _no_data(_symbol: str) -> Decimal | None:
+        return None
+
+    service = DownsideWatchService(session, recent_low_fetcher=_no_data)
+    levels = await service.compute_levels()
+
+    assert all(lvl.symbol != symbol for lvl in levels)
+
+
+@pytest.mark.asyncio
+async def test_compute_levels_ignores_non_kr_equity_and_non_active_holdings(
+    session: AsyncSession,
+) -> None:
+    symbol_draft = _symbol()
+    symbol_us = _symbol()
+    await _seed_journal(session, symbol=symbol_draft, stop_loss="1000", status="draft")
+    journal_us = TradeJournal(
+        symbol=symbol_us,
+        instrument_type="equity_us",
+        side="buy",
+        entry_price=Decimal("100"),
+        quantity=Decimal("1"),
+        thesis="ROB-928 test fixture (US, excluded)",
+        stop_loss=Decimal("90"),
+        status="active",
+        account_type="live",
+    )
+    session.add(journal_us)
+    await session.commit()
+
+    async def _no_recent_low(_symbol: str) -> Decimal | None:
+        return None
+
+    service = DownsideWatchService(session, recent_low_fetcher=_no_recent_low)
+    levels = await service.compute_levels()
+
+    symbols = {lvl.symbol for lvl in levels}
+    assert symbol_draft not in symbols
+    assert symbol_us not in symbols
+
+
+@pytest.mark.asyncio
+async def test_register_sweep_skips_symbol_with_existing_active_downside_watch(
+    session: AsyncSession,
+) -> None:
+    symbol = _symbol()
+    await _seed_journal(session, symbol=symbol, stop_loss="48000")
+    await session.commit()
+
+    async def _fail_recent_low(_symbol: str) -> Decimal | None:
+        raise AssertionError("must not be called; stop_loss present")
+
+    service = DownsideWatchService(session, recent_low_fetcher=_fail_recent_low)
+
+    first = await service.register_sweep(dry_run=False)
+    assert len(first["registered"]) == 1
+    assert first["registered"][0]["symbol"] == symbol
+
+    second = await service.register_sweep(dry_run=False)
+    assert all(entry["symbol"] != symbol for entry in second["registered"])
+    assert any(
+        entry["symbol"] == symbol and entry["reason"] == "active_downside_watch_exists"
+        for entry in second["skipped_existing"]
+    )
+
+    count = await session.scalar(
+        sa.select(sa.func.count())
+        .select_from(InvestmentWatchAlert)
+        .where(InvestmentWatchAlert.symbol == symbol)
+    )
+    assert count == 1
+
+
+@pytest.mark.asyncio
+async def test_register_sweep_dry_run_default_makes_no_db_changes(
+    session: AsyncSession,
+) -> None:
+    symbol = _symbol()
+    await _seed_journal(session, symbol=symbol, stop_loss="48000")
+    await session.commit()
+
+    service = DownsideWatchService(session)
+    result = await service.register_sweep()
+
+    assert result["dry_run"] is True
+    assert len(result["registered"]) == 1
+    assert result["registered"][0]["would_register"] is True
+
+    count = await session.scalar(
+        sa.select(sa.func.count()).select_from(InvestmentWatchAlert)
+    )
+    assert count == 0
+
+
+@pytest.mark.asyncio
+async def test_register_sweep_registered_alert_shape(session: AsyncSession) -> None:
+    symbol = _symbol()
+    await _seed_journal(session, symbol=symbol, stop_loss="48000")
+    await session.commit()
+
+    service = DownsideWatchService(session)
+    await service.register_sweep(dry_run=False)
+
+    alert = await session.scalar(
+        sa.select(InvestmentWatchAlert).where(InvestmentWatchAlert.symbol == symbol)
+    )
+    assert alert is not None
+    assert alert.market == "kr"
+    assert alert.metric == "price"
+    assert alert.operator == "below"
+    assert alert.intent in {"sell_review", "risk_review"}
+    assert alert.threshold == Decimal("48000")
+    assert alert.action_mode == "notify_only"
+    assert alert.status == "active"
+    assert "stop_loss_mirror" in alert.rationale

--- a/tests/services/test_downside_watch_service_no_broker_imports.py
+++ b/tests/services/test_downside_watch_service_no_broker_imports.py
@@ -1,0 +1,68 @@
+"""ROB-928 safety-boundary guard.
+
+The downside-watch mirror feature must only ever INSERT into
+review.investment_watch_alerts (via DirectWatchCreateService) — it must
+never import an order/broker mutation surface. This is a static AST
+import scan, mirroring the style of
+tests/services/action_report/snapshot_backed/test_no_internal_llm_imports.py,
+scoped to the two ROB-928 modules.
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+
+import pytest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+
+GUARDED_FILES: tuple[pathlib.Path, ...] = (
+    REPO_ROOT / "app" / "services" / "downside_watch_service.py",
+    REPO_ROOT / "app" / "mcp_server" / "tooling" / "downside_watch_registration.py",
+)
+
+FORBIDDEN_MODULE_PREFIXES: tuple[str, ...] = (
+    "app.services.brokers",
+    "app.mcp_server.tooling.orders_",
+    "app.mcp_server.tooling.order_proposal_tools",
+    "app.mcp_server.tooling.alpaca_paper_orders",
+    "app.mcp_server.tooling.live_order_ledger",
+    "app.mcp_server.tooling.kis_live_ledger",
+)
+
+FORBIDDEN_NAME_SUBSTRINGS: tuple[str, ...] = (
+    "place_order",
+    "submit_order",
+    "cancel_order",
+    "modify_order",
+    "preview_order",
+)
+
+
+def _imported_module_names(tree: ast.Module) -> set[str]:
+    modules: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            modules.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            modules.add(node.module)
+            modules.update(f"{node.module}.{alias.name}" for alias in node.names)
+    return modules
+
+
+@pytest.mark.parametrize("path", GUARDED_FILES, ids=lambda p: p.name)
+def test_no_broker_mutation_imports(path: pathlib.Path) -> None:
+    assert path.exists(), f"expected ROB-928 module missing: {path}"
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    modules = _imported_module_names(tree)
+
+    for module in modules:
+        for prefix in FORBIDDEN_MODULE_PREFIXES:
+            assert not module.startswith(prefix), (
+                f"{path.name} imports forbidden broker-mutation module {module!r}"
+            )
+        for needle in FORBIDDEN_NAME_SUBSTRINGS:
+            assert needle not in module.lower(), (
+                f"{path.name} imports a name suggesting order mutation: {module!r}"
+            )


### PR DESCRIPTION
## Summary

- Adds `DownsideWatchService` (`app/services/downside_watch_service.py`) — a session-invoked sweep that hydrates currently-held KR equity (`review.trade_journals`, `status=active`/`account_type=live`/`side=buy`/`instrument_type=equity_kr`) and registers a support-break (`operator=below`) watch per symbol into the existing `review.investment_watch_alerts` table via the existing `DirectWatchCreateService` — no new table, no raw INSERT.
- Adds MCP tool `watch_downside_register_sweep(market="kr", dry_run=True)` (`app/mcp_server/tooling/downside_watch_registration.py`), wired into the DEFAULT profile in `registry.py` and classified in `READ_ONLY_ADVISORY_TOOLS` in `route_request_lanes.py` (ROB-866 lesson — a new DEFAULT tool must be bucketed or `test_route_request_registry_diff.py` fails CI).

## Why this matters

72 production watches today are 100% upside (above+sell_review take-profit, below+buy_review dip-buy) — **zero** downside/defensive watches exist. 005930's stop (286,000) broke on 2026-07-02 and sat unactioned for two weeks (-14.6%, ~10pp of avoidable drawdown) because nothing mirrored `trade_journals.stop_loss` into the watch/alert pipeline that already fires Hermes notifications every 5 minutes.

## Level-selection rule

Per symbol, in order:
1. **`stop_loss_mirror`** — if any active lot for the symbol has a non-null `stop_loss`, use the **max** across lots (the most conservative/highest stop wins when a position has multiple entries).
2. **`recent_low_20d`** — else, the trailing 20-session KRX low (`kr_candles_1d`, venue=`KRX`), read via an injectable fetcher (production wiring uses `DailyCandlesRepository.fetch_recent`; kept injectable because `kr_candles_1d` is a Timescale hypertable with no ORM model and is absent from the `create_all` test DB — the existing `test_forecast_service.py`/`test_forecast_read_window_candles.py` tests hit the same constraint and solve it the same way).
3. If neither is available, the symbol is skipped for this sweep (logged), not force-registered against no evidence.

## Intent choice: `sell_review` over `risk_review`

Both are legal `ItemIntentLiteral` values and the DB has no CHECK constraint on `investment_watch_alerts.intent`. Chose **`sell_review`** because the watch signals "support broken on a *held* position, review for exit" — directly analogous to (but the inverse direction of) the existing `above`+`sell_review` take-profit watches already in production, keeping the `below`↔`above` / `sell_review` naming symmetric. The idempotency/skip check treats `sell_review` and `risk_review` as an equivalent "defensive" bucket (`_DEFENSIVE_INTENTS`), so a future watch registered with either intent is still recognized and won't be duplicated.

## Idempotency strategy

`DirectWatchCreateService`'s own idempotency key includes `valid_until`, which is freshly computed (`now + 14d`) on every sweep run — so its internal same-key dedupe would NOT prevent re-registration across daily reruns. Instead, `DownsideWatchService._has_active_downside_watch(symbol)` does its own pre-insert check: skip if any **active** alert for `(market="kr", symbol, operator="below", intent in {sell_review, risk_review})` already exists, regardless of threshold/valid_until. Verified by `test_register_sweep_skips_symbol_with_existing_active_downside_watch`.

## Safety boundary

- `dry_run=True` is the tool default; it only computes+lists levels, calling zero mutation code (verified by `test_register_sweep_dry_run_default_makes_no_db_changes`).
- The only mutation this feature performs, ever, is one row insert into `review.investment_watch_alerts` (`action_mode="notify_only"`) via the existing `DirectWatchCreateService` — no new table, no order/broker call.
- A static AST import-guard test (`tests/services/test_downside_watch_service_no_broker_imports.py`) asserts neither new module imports any `app.services.brokers.*` module or anything named `place_order`/`submit_order`/`cancel_order`/`modify_order`/`preview_order`.
- No scheduler/cron wiring — the tool is scheduleless, session/operator-invoked only, per the ticket's explicit instruction.
- `valid_until` defaults to +14 days; rationale/metadata explicitly note "트레일링 미지원 — 레벨 고정, 주기 재등록 필요" (not a trailing stop; rerun periodically to refresh), per AC (4).

## Not done in this PR (per ticket scope)

- The 1-week shadow run against the current 43 KR holdings (AC 3) is an operational step for after merge/deploy — this PR only ships the registration capability.
- US market holdings: `DownsideWatchService` filters to `instrument_type=equity_kr` only per the ticket's "1차 스코프"; the data shapes (dataclass, request builder) are market-agnostic enough to extend later, but no US wiring is included here.

## Test plan

- [x] `uv run pytest tests/ -k "downside or watch" -v` — 241 passed
- [x] `uv run pytest tests/ -k "investment_watch" -v` — 20 passed
- [x] `uv run pytest tests/test_mcp_tool_registration_boot.py tests/test_mcp_profiles.py tests/test_playbook_tool_names.py tests/test_route_request_registry_diff.py -q` — 109 + 6 passed (registry wiring sanity)
- [x] `make lint` — ruff check/format + ty all clean
- [x] `git diff --check` — no whitespace issues
- [x] `uv run alembic heads` — single head, unchanged (no migration; reuses existing `investment_watch_alerts` table as the ticket expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)