### PR TITLE
feat(ROB-918): kr-preopen new-candidate shadow section (advisory-only)

### DIFF
--- a/app/services/research_run_decision_session_service.py
+++ b/app/services/research_run_decision_session_service.py
@@ -27,6 +27,7 @@ from app.schemas.research_run_decision_session import (
 from app.services import (
     nxt_classifier_service,
     pending_reconciliation_service,
+    research_run_new_candidates,
     research_run_service,
     trading_decision_service,
 )
@@ -571,10 +572,19 @@ async def create_decision_session_from_research_run(
         proposals=proposals,
     )
 
+    # ROB-918: advisory-only shadow section (new-candidate observations, no
+    # proposal rows). Reads via its own DB session, so a failure here can
+    # never poison this function's write transaction.
+    new_candidates = await research_run_new_candidates.build_new_candidate_section(
+        market_scope=research_run.market_scope,
+        stage=research_run.stage,
+    )
+
     session.market_brief = _json_safe(
         {
             "advisory_only": True,
             "execution_allowed": False,
+            "new_candidates": new_candidates,
             "research_run_uuid": str(research_run.run_uuid),
             "refreshed_at": snapshot.refreshed_at,
             "counts": {

--- a/app/services/research_run_new_candidates.py
+++ b/app/services/research_run_new_candidates.py
@@ -1,0 +1,421 @@
+"""ROB-918: kr-preopen new-candidate shadow section (advisory-only, 2-week shadow).
+
+Builds a read-only "new candidates" observation block — 전일 consecutive_gainers
+상위 + 전일 마감 테마 상위 + 수급 double_buy 요약 — for injection into
+``TradingDecisionSession.market_brief``. This module NEVER creates
+``trading_decision_proposals`` rows and NEVER touches broker/order/watch state;
+it only reads from existing snapshot tables.
+
+Safety-by-construction: the public entrypoint opens its own DB session (never
+the caller's) so any read failure here can never poison a caller's write
+transaction, and this module structurally has no access to write a proposal
+row even by mistake.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import logging
+from decimal import Decimal
+from typing import Any
+
+import sqlalchemy as sa
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.invest_screener_snapshot import InvestScreenerSnapshot
+from app.models.kr_symbol_universe import KRSymbolUniverse
+from app.models.market_valuation_snapshot import MarketValuationSnapshot
+from app.services.daily_candles.repository import (
+    DailyCandleRow,
+    DailyCandlesRepository,
+    MarketKey,
+)
+from app.services.invest_momentum_events.repository import (
+    InvestMomentumEventSnapshotsRepository,
+)
+from app.services.invest_screener_snapshots.partition_health import (
+    resolve_healthy_partition,
+)
+from app.services.invest_view_model.double_buy_screener import (
+    load_double_buy_from_snapshots,
+)
+from app.services.market_valuation_snapshots.repository import metric_rich_filter
+
+logger = logging.getLogger(__name__)
+
+# 필터: 시총≥2,000억·거래대금≥200억 (ROB-918 spec)
+_MIN_MARKET_CAP_KRW = Decimal("200000000000")
+_MIN_TRADE_VALUE_KRW = Decimal("20000000000")
+
+_CRASH_INDEX_SYMBOL = "069500"  # KODEX200
+_CRASH_INDEX_VENUE = "KRX"
+_CRASH_GAP_THRESHOLD_PCT = Decimal("-3.0")
+
+_DEFAULT_TOP_N = 10
+_THEME_LEADERS_PER_THEME = 3
+
+
+def _decimal_to_float(value: Any) -> float | None:
+    return float(value) if value is not None else None
+
+
+# ---------------------------------------------------------------------------
+# Crash guard (AC #5): label only, never blocks candidate generation.
+# ---------------------------------------------------------------------------
+
+
+async def _fetch_index_recent_closes(session: AsyncSession) -> list[DailyCandleRow]:
+    repo = DailyCandlesRepository(session=session)
+    return await repo.fetch_recent(
+        market=MarketKey.KR,
+        symbol=_CRASH_INDEX_SYMBOL,
+        partition=_CRASH_INDEX_VENUE,
+        count=2,
+    )
+
+
+async def _resolve_market_state(session: AsyncSession) -> tuple[str, dict[str, Any]]:
+    """전일比 지수 갭으로 crash_warning 라벨만 부여한다 (차단 아님)."""
+    try:
+        rows = await _fetch_index_recent_closes(session)
+    except Exception as exc:  # noqa: BLE001 -- must never break session creation
+        logger.warning(
+            "new_candidates: index candle fetch failed: %s", exc, exc_info=True
+        )
+        return "unknown", {
+            "reason": "index_candles_fetch_failed",
+            "symbol": _CRASH_INDEX_SYMBOL,
+        }
+
+    if len(rows) < 2:
+        return "unknown", {
+            "reason": "index_candles_insufficient",
+            "symbol": _CRASH_INDEX_SYMBOL,
+        }
+
+    latest, prior = rows[0], rows[1]
+    if not prior.close:
+        return "unknown", {
+            "reason": "index_prior_close_zero",
+            "symbol": _CRASH_INDEX_SYMBOL,
+        }
+
+    gap_pct = (
+        (Decimal(str(latest.close)) - Decimal(str(prior.close)))
+        / Decimal(str(prior.close))
+        * 100
+    )
+    detail = {
+        "symbol": _CRASH_INDEX_SYMBOL,
+        "venue": _CRASH_INDEX_VENUE,
+        "gap_pct": float(gap_pct),
+        "latest_close": latest.close,
+        "latest_time": latest.time_utc.isoformat(),
+        "prior_close": prior.close,
+        "prior_time": prior.time_utc.isoformat(),
+    }
+    if gap_pct <= _CRASH_GAP_THRESHOLD_PCT:
+        return "crash_warning", detail
+    return "normal", detail
+
+
+# ---------------------------------------------------------------------------
+# 전일 consecutive_gainers 상위 (시총/거래대금 필터, change_rate 상위 N)
+# ---------------------------------------------------------------------------
+
+
+async def _build_consecutive_gainers_candidates(
+    session: AsyncSession, *, top_n: int, omitted: list[dict[str, str]]
+) -> list[dict[str, Any]]:
+    try:
+        hp = await resolve_healthy_partition(
+            session,
+            model=InvestScreenerSnapshot,
+            date_col=InvestScreenerSnapshot.snapshot_date,
+            market_col=InvestScreenerSnapshot.market,
+            market="kr",
+        )
+        if hp is None:
+            omitted.append(
+                {"section": "consecutive_gainers", "reason": "snapshot_missing"}
+            )
+            return []
+        snapshot_date = hp.partition_date
+
+        stmt = (
+            sa.select(InvestScreenerSnapshot)
+            .where(
+                InvestScreenerSnapshot.market == "kr",
+                InvestScreenerSnapshot.snapshot_date == snapshot_date,
+            )
+            .order_by(
+                InvestScreenerSnapshot.change_rate.desc().nullslast(),
+                InvestScreenerSnapshot.symbol.asc(),
+            )
+            .limit(max(top_n * 10, top_n + 100))
+        )
+        snaps = (await session.execute(stmt)).scalars().all()
+        if not snaps:
+            omitted.append(
+                {
+                    "section": "consecutive_gainers",
+                    "reason": "healthy_partition_no_rows",
+                }
+            )
+            return []
+
+        symbols = [s.symbol for s in snaps]
+
+        val_hp = await resolve_healthy_partition(
+            session,
+            model=MarketValuationSnapshot,
+            date_col=MarketValuationSnapshot.snapshot_date,
+            market_col=MarketValuationSnapshot.market,
+            market="kr",
+            row_filter=metric_rich_filter(),
+        )
+        market_cap_map: dict[str, Decimal] = {}
+        if val_hp is not None:
+            rows = (
+                await session.execute(
+                    sa.select(
+                        MarketValuationSnapshot.symbol,
+                        MarketValuationSnapshot.market_cap,
+                    ).where(
+                        MarketValuationSnapshot.market == "kr",
+                        MarketValuationSnapshot.snapshot_date == val_hp.partition_date,
+                        MarketValuationSnapshot.symbol.in_(symbols),
+                    )
+                )
+            ).all()
+            market_cap_map = {
+                r.symbol: r.market_cap for r in rows if r.market_cap is not None
+            }
+        else:
+            omitted.append(
+                {
+                    "section": "consecutive_gainers_market_cap",
+                    "reason": "valuation_snapshot_missing",
+                }
+            )
+
+        name_map: dict[str, str] = {}
+        if symbols:
+            name_rows = (
+                await session.execute(
+                    sa.select(KRSymbolUniverse.symbol, KRSymbolUniverse.name).where(
+                        KRSymbolUniverse.symbol.in_(symbols)
+                    )
+                )
+            ).all()
+            name_map = {r.symbol: r.name for r in name_rows}
+
+        candidates: list[dict[str, Any]] = []
+        for snap in snaps:
+            market_cap = market_cap_map.get(snap.symbol)
+            if market_cap is None or market_cap < _MIN_MARKET_CAP_KRW:
+                continue
+            trade_value_est: Decimal | None = None
+            if snap.daily_volume is not None and snap.latest_close is not None:
+                trade_value_est = Decimal(snap.daily_volume) * snap.latest_close
+            if trade_value_est is None or trade_value_est < _MIN_TRADE_VALUE_KRW:
+                continue
+
+            candidates.append(
+                {
+                    "symbol": snap.symbol,
+                    "name": name_map.get(snap.symbol),
+                    "reason": "consecutive_gainers",
+                    "advisory_only": True,
+                    "selection_rationale": (
+                        f"전일({snap.snapshot_date.isoformat()}) "
+                        f"{_decimal_to_float(snap.change_rate)}% 상승, "
+                        f"연속상승 {snap.consecutive_up_days}일, "
+                        "시총≥2,000억·거래대금≥200억 필터 통과"
+                    ),
+                    "metrics": {
+                        "change_rate": _decimal_to_float(snap.change_rate),
+                        "consecutive_up_days": snap.consecutive_up_days,
+                        "week_change_rate": _decimal_to_float(snap.week_change_rate),
+                        "market_cap": _decimal_to_float(market_cap),
+                        "trade_value_est": _decimal_to_float(trade_value_est),
+                    },
+                    "baseline_date": snap.snapshot_date.isoformat(),
+                    "baseline_close": _decimal_to_float(snap.latest_close),
+                    "outcome": {"d1_close_pct": None},
+                }
+            )
+            if len(candidates) >= top_n:
+                break
+        return candidates
+    except Exception as exc:  # noqa: BLE001 -- must never break session creation
+        logger.warning(
+            "new_candidates: consecutive_gainers build failed: %s", exc, exc_info=True
+        )
+        omitted.append({"section": "consecutive_gainers", "reason": "query_failed"})
+        return []
+
+
+# ---------------------------------------------------------------------------
+# 전일 마감 테마 상위 (leader_symbols 플랫튼)
+# ---------------------------------------------------------------------------
+
+
+async def _build_theme_leader_candidates(
+    session: AsyncSession, *, top_n: int, omitted: list[dict[str, str]]
+) -> list[dict[str, Any]]:
+    try:
+        repo = InvestMomentumEventSnapshotsRepository(session)
+        rows = await repo.list_theme_events(event_kind="theme", limit=top_n)
+        if not rows:
+            omitted.append(
+                {"section": "theme_leaders", "reason": "no_naver_theme_snapshots"}
+            )
+            return []
+
+        stocks_by_theme = await repo.list_theme_event_stocks([row.id for row in rows])
+
+        candidates: list[dict[str, Any]] = []
+        for row in rows:
+            leaders = (row.leader_symbols or [])[:_THEME_LEADERS_PER_THEME]
+            stock_price_map = {
+                s.symbol: s.price for s in stocks_by_theme.get(row.id, [])
+            }
+            for leader in leaders:
+                symbol = leader.get("symbol") if isinstance(leader, dict) else None
+                if not symbol:
+                    continue
+                baseline_close = stock_price_map.get(symbol)
+                candidates.append(
+                    {
+                        "symbol": symbol,
+                        "name": (
+                            leader.get("name") if isinstance(leader, dict) else None
+                        ),
+                        "reason": "theme_leader",
+                        "advisory_only": True,
+                        "selection_rationale": (
+                            f"전일 마감 테마 '{row.name}' 상위(rank={row.rank}) 주도주"
+                        ),
+                        "metrics": {
+                            "theme_name": row.name,
+                            "theme_rank": row.rank,
+                            "theme_change_rate": _decimal_to_float(row.change_rate),
+                            "theme_trade_value": _decimal_to_float(row.trade_value),
+                            "theme_market_cap": _decimal_to_float(row.market_cap),
+                            "theme_stock_count": row.stock_count,
+                        },
+                        "baseline_date": row.trading_date.isoformat(),
+                        "baseline_close": _decimal_to_float(baseline_close),
+                        "outcome": {"d1_close_pct": None},
+                    }
+                )
+        return candidates
+    except Exception as exc:  # noqa: BLE001 -- must never break session creation
+        logger.warning(
+            "new_candidates: theme_leaders build failed: %s", exc, exc_info=True
+        )
+        omitted.append({"section": "theme_leaders", "reason": "query_failed"})
+        return []
+
+
+# ---------------------------------------------------------------------------
+# 수급 double_buy 요약
+# ---------------------------------------------------------------------------
+
+
+async def _build_double_buy_candidates(
+    session: AsyncSession, *, top_n: int, omitted: list[dict[str, str]]
+) -> list[dict[str, Any]]:
+    try:
+        result = await load_double_buy_from_snapshots(session, market="kr", limit=top_n)
+        if result is None:
+            omitted.append(
+                {"section": "double_buy", "reason": "investor_flow_snapshot_missing"}
+            )
+            return []
+
+        candidates: list[dict[str, Any]] = []
+        for row in result.rows[:top_n]:
+            snapshot_date = row.get("snapshot_date")
+            candidates.append(
+                {
+                    "symbol": row["symbol"],
+                    "name": row.get("name"),
+                    "reason": "double_buy",
+                    "advisory_only": True,
+                    "selection_rationale": "외국인·기관 순매수 전일比 동시 증가(쌍끌이)",
+                    "metrics": {
+                        "change_rate": row.get("change_rate"),
+                        "foreign_net": row.get("foreign_net"),
+                        "institution_net": row.get("institution_net"),
+                        "market_cap": row.get("market_cap"),
+                    },
+                    "baseline_date": (
+                        snapshot_date.isoformat()
+                        if isinstance(snapshot_date, dt.date)
+                        else None
+                    ),
+                    "baseline_close": row.get("close"),
+                    "outcome": {"d1_close_pct": None},
+                }
+            )
+        return candidates
+    except Exception as exc:  # noqa: BLE001 -- must never break session creation
+        logger.warning(
+            "new_candidates: double_buy build failed: %s", exc, exc_info=True
+        )
+        omitted.append({"section": "double_buy", "reason": "query_failed"})
+        return []
+
+
+# ---------------------------------------------------------------------------
+# Public entrypoint
+# ---------------------------------------------------------------------------
+
+
+async def build_new_candidate_section(
+    *,
+    market_scope: str,
+    stage: str,
+    top_n: int = _DEFAULT_TOP_N,
+) -> dict[str, Any] | None:
+    """Advisory-only new-candidate observation block for kr-preopen sessions.
+
+    Returns None for any market/stage other than kr-preopen (the shadow
+    rollout is scoped there only, per ROB-918). Opens its own DB session so a
+    read failure here can never poison a caller's write transaction, and
+    never creates ``trading_decision_proposals`` rows.
+    """
+    if market_scope != "kr" or stage != "preopen":
+        return None
+
+    from app.core.db import AsyncSessionLocal
+
+    async with AsyncSessionLocal() as session:
+        omitted: list[dict[str, str]] = []
+        market_state, market_state_detail = await _resolve_market_state(session)
+        consecutive_gainers = await _build_consecutive_gainers_candidates(
+            session, top_n=top_n, omitted=omitted
+        )
+        theme_leaders = await _build_theme_leader_candidates(
+            session, top_n=top_n, omitted=omitted
+        )
+        double_buy = await _build_double_buy_candidates(
+            session, top_n=top_n, omitted=omitted
+        )
+
+    return {
+        "advisory_only": True,
+        "market_state": market_state,
+        "market_state_detail": market_state_detail,
+        "consecutive_gainers": consecutive_gainers,
+        "theme_leaders": theme_leaders,
+        "double_buy": double_buy,
+        "omitted_sections": omitted,
+    }
+
+
+__all__ = [
+    "build_new_candidate_section",
+]

--- a/docs/runbooks/kr-preopen-new-candidates-shadow.md
+++ b/docs/runbooks/kr-preopen-new-candidates-shadow.md
@@ -1,0 +1,108 @@
+# kr-preopen New-Candidate Shadow Section (ROB-918)
+
+## What this is
+
+`research_run_decision_session_service.create_decision_session_from_research_run`
+now injects an **advisory-only** `market_brief["new_candidates"]` block into
+every `trading_decision_sessions` row created for `market_scope="kr"` +
+`stage="preopen"` research runs. It never creates
+`trading_decision_proposals` rows and never touches broker/order/watch state
+— it is a pure observation record for a 2-week shadow review (see ROB-918).
+
+For any other market/stage combination, `market_brief["new_candidates"]` is
+`None`.
+
+## What it contains
+
+```jsonc
+{
+  "advisory_only": true,
+  "market_state": "normal" | "crash_warning" | "unknown",
+  "market_state_detail": {"symbol": "069500", "venue": "KRX", "gap_pct": -4.1, ...},
+  "consecutive_gainers": [ {...candidate...}, ... ],
+  "theme_leaders": [ {...candidate...}, ... ],
+  "double_buy": [ {...candidate...}, ... ],
+  "omitted_sections": [ {"section": "theme_leaders", "reason": "no_naver_theme_snapshots"}, ... ]
+}
+```
+
+Each candidate:
+
+```jsonc
+{
+  "symbol": "042660",
+  "name": "한화오션",
+  "reason": "consecutive_gainers" | "theme_leader" | "double_buy",
+  "advisory_only": true,
+  "selection_rationale": "전일(...) 8.7% 상승, 연속상승 1일, 시총≥2,000억·거래대금≥200억 필터 통과",
+  "metrics": { ... reason-specific fields ... },
+  "baseline_date": "2026-07-16",
+  "baseline_close": 50000.0,
+  "outcome": {"d1_close_pct": null}
+}
+```
+
+`outcome.d1_close_pct` starts `null` and is filled in retrospectively by the
+shadow aggregation script below — it is never written back into the session
+row (this repo's DB-write path stays out of scope; the script only reads).
+
+## Sources and filters
+
+- **consecutive_gainers** — `invest_screener_snapshots` latest healthy `kr`
+  partition, filtered to `market_cap >= 2,000억` (joined from
+  `market_valuation_snapshots`) and an estimated `trade_value_est =
+  daily_volume * latest_close >= 200억` (no direct 거래대금 column exists on
+  `invest_screener_snapshots`), sorted by `change_rate` desc, top N.
+- **theme_leaders** — `get_theme_events`'s underlying repository
+  (`InvestMomentumEventSnapshotsRepository.list_theme_events(event_kind="theme")`
+  over `invest_theme_event_snapshots`), flattened to one candidate per leader
+  symbol (up to 3 per theme) using `invest_theme_event_snapshot_stocks.price`
+  as the baseline close.
+- **double_buy** — delegates to the existing
+  `load_double_buy_from_snapshots(market="kr")` loader (Toss-parity 쌍끌이
+  매수, day-over-day 외국인/기관 순매수 증가) unmodified.
+
+## Crash guard (label only, never blocks)
+
+Compares the latest two `kr_candles_1d` closes for KODEX200 (`069500`,
+venue `KRX`). If the gap is `<= -3.0%`, `market_state` is tagged
+`"crash_warning"`. This never suppresses candidate generation — it is
+advisory context only, per ROB-918 AC #5.
+
+## Graceful degradation
+
+If any source snapshot is missing or a query fails, that section returns an
+empty list and an entry is appended to `omitted_sections` with a `reason`
+(e.g. `"snapshot_missing"`, `"no_naver_theme_snapshots"`,
+`"investor_flow_snapshot_missing"`, `"query_failed"`). The section builder
+never raises — a read failure here can never break kr-preopen session
+creation.
+
+Structural safety note: `build_new_candidate_section` opens its **own** DB
+session (`AsyncSessionLocal()`), never the caller's — so even an unexpected
+exception here cannot poison the write transaction that creates the session
+and its `research_run` proposals.
+
+## Running the 2-week shadow aggregation report
+
+Read-only — SELECT only, never writes:
+
+```bash
+uv run python -m scripts.shadow_new_candidates_report --since-days 14
+```
+
+It scans recent `kr` `research_run` sessions' `market_brief.new_candidates`,
+joins each candidate's `baseline_date`/`baseline_close` against the next
+`kr_candles_1d` close for that symbol (`venue='KRX'`), and prints a
+recovered-rate / false-positive-rate / average-D+1-% table per selection
+reason (`consecutive_gainers` / `theme_leader` / `double_buy`).
+
+## Safety boundaries
+
+- No `trading_decision_proposals` rows are ever created for these
+  candidates — proven by
+  `tests/test_research_run_decision_session_service_new_candidates.py::test_kr_preopen_session_gets_new_candidates_section_without_proposals`.
+- No migration (JSONB reuse on the existing `market_brief` column).
+- No TaskIQ/cron schedule added or changed — the section is computed inline
+  whenever `create_decision_session_from_research_run` already runs.
+- `scripts/shadow_new_candidates_report.py` never writes to the database.

--- a/docs/superpowers/plans/2026-07-17-rob-918-kr-preopen-new-candidates-shadow.md
+++ b/docs/superpowers/plans/2026-07-17-rob-918-kr-preopen-new-candidates-shadow.md
@@ -1,0 +1,128 @@
+# ROB-918: kr-preopen New-Candidate Shadow Section Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Inject a read-only, advisory-only "new candidate" observation section (consecutive-gainers + theme leaders + double-buy) into kr-preopen `trading_decision_sessions.market_brief`, plus a read-only shadow-aggregation script — with a hard guarantee that no `trading_decision_proposals` rows are ever created for these candidates.
+
+**Architecture:** A new pure-read service module (`app/services/research_run_new_candidates.py`) queries three existing snapshot tables (`invest_screener_snapshots`, `invest_theme_event_snapshots`, `investor_flow_snapshots`) plus `kr_candles_1d` (crash-guard index proxy), and returns a plain dict. `research_run_decision_session_service.create_decision_session_from_research_run` calls it once and merges the result into the `market_brief` JSONB it already assembles (no new proposal path, no migration). A separate read-only CLI script later joins recorded candidates against `kr_candles_1d` to compute D+1 % moves for the 2-week shadow review.
+
+**Tech Stack:** Python 3.13, SQLAlchemy async, existing `resolve_healthy_partition` / `InvestMomentumEventSnapshotsRepository` / `load_double_buy_from_snapshots` helpers.
+
+## Global Constraints
+
+- MUST NOT insert any `trading_decision_proposals` row for these candidates (hard requirement, proven by test).
+- MUST NOT change any TaskIQ/cron schedule.
+- MUST NOT write to the DB from the shadow script (SELECT only).
+- Migration must be 0 (JSONB reuse on `trading_decision_sessions.market_brief`).
+- Only activates for `research_run.market_scope == "kr"` and `research_run.stage == "preopen"`; all other market/stage combos are a no-op (return `None`, key omitted from `market_brief`).
+- `research_run_decision_session_service.py` is guarded by `tests/test_research_run_decision_session_service_safety.py::test_orchestrator_service_forbidden_imports` — the new module must not import anything under `app.services.brokers`, `app.services.kis*`, `app.services.upbit*`, `app.services.market_data`, `app.tasks`, etc. (see forbidden-prefix list in that test).
+- Filters for consecutive_gainers candidates: market_cap >= 200_000_000_000 KRW AND trade_value_est >= 20_000_000_000 KRW (trade_value has no direct column on `invest_screener_snapshots`; approximate as `daily_volume * latest_close`, documented inline).
+- Crash guard: KODEX200 (symbol `069500`, venue `KRX`) latest two `kr_candles_1d` closes; gap_pct = (latest.close - prior.close) / prior.close * 100. `<= -3.0` → `market_state = "crash_warning"`, else `"normal"`. Insufficient data → `"unknown"`. Label only — never blocks candidate generation.
+- Every candidate record carries `advisory_only: true`, `baseline_date`, `baseline_close`, and `outcome: {"d1_close_pct": null}` for later shadow-script fill-in.
+
+---
+
+## Task 1: `research_run_new_candidates` service module
+
+**Files:**
+- Create: `app/services/research_run_new_candidates.py`
+- Test: `tests/services/test_research_run_new_candidates.py`
+
+**Interfaces:**
+- Consumes: `AsyncSession`; `app.services.invest_screener_snapshots.partition_health.resolve_healthy_partition`; `app.services.invest_momentum_events.repository.InvestMomentumEventSnapshotsRepository`; `app.services.invest_view_model.double_buy_screener.load_double_buy_from_snapshots`; `app.services.daily_candles.repository.DailyCandlesRepository`, `MarketKey`; `app.models.invest_screener_snapshot.InvestScreenerSnapshot`; `app.models.market_valuation_snapshot.MarketValuationSnapshot`; `app.models.kr_symbol_universe.KRSymbolUniverse`.
+- Produces: `async def build_new_candidate_section(db: AsyncSession, *, market_scope: str, stage: str, top_n: int = 10) -> dict[str, Any] | None`. Returns `None` when `(market_scope, stage) != ("kr", "preopen")`. Otherwise returns:
+  ```python
+  {
+      "advisory_only": True,
+      "market_state": "normal" | "crash_warning" | "unknown",
+      "market_state_detail": {...},
+      "consecutive_gainers": [ {...candidate...}, ... ],
+      "theme_leaders": [ {...candidate...}, ... ],
+      "double_buy": [ {...candidate...}, ... ],
+      "omitted_sections": [ {"section": str, "reason": str}, ... ],
+  }
+  ```
+  Each candidate dict: `symbol`, `name`, `reason` (`"consecutive_gainers" | "theme_leader" | "double_buy"`), `advisory_only: True`, `selection_rationale` (Korean string), `metrics` (dict, keys vary by reason), `baseline_date` (ISO date str | None), `baseline_close` (float | None), `outcome: {"d1_close_pct": None}`.
+
+- [ ] Write failing tests in `tests/services/test_research_run_new_candidates.py`:
+  - `test_returns_none_for_non_kr_preopen` — market_scope="us" or stage="intraday" → `None`.
+  - `test_crash_warning_label_when_index_gap_below_threshold` — seed two `kr_candles_1d` rows for `069500`/`KRX` with a -4% gap → `market_state == "crash_warning"`.
+  - `test_normal_market_state_when_index_gap_small` — seed a +0.5% gap → `market_state == "normal"`.
+  - `test_unknown_market_state_when_index_candles_missing` — no `069500` rows → `market_state == "unknown"`, no exception.
+  - `test_consecutive_gainers_filters_by_market_cap_and_trade_value` — seed `InvestScreenerSnapshot` rows (one above both thresholds, one below market_cap, one below trade_value-via-volume) + matching `MarketValuationSnapshot` rows; assert only the qualifying symbol appears, with `metrics.market_cap`/`metrics.trade_value_est`/`metrics.change_rate`/`metrics.consecutive_up_days` populated and `baseline_close == latest_close`.
+  - `test_consecutive_gainers_omitted_when_snapshot_missing` — no `InvestScreenerSnapshot` rows for market='kr' → `consecutive_gainers == []` and an `omitted_sections` entry with `section="consecutive_gainers"`.
+  - `test_theme_leaders_flattened_from_leader_symbols` — seed `InvestThemeEventSnapshot` (event_kind='theme') + `InvestThemeEventSnapshotStock` rows; assert flattened per-symbol candidates with `reason="theme_leader"`, `metrics.theme_name`, `baseline_close` from the stock row's `price`.
+  - `test_theme_leaders_omitted_when_no_snapshots` — empty table → `theme_leaders == []` + omitted entry.
+  - `test_double_buy_delegates_to_existing_loader` — monkeypatch `load_double_buy_from_snapshots` to return a canned `_SnapshotLoadResult`; assert mapping into `reason="double_buy"` candidates.
+  - `test_double_buy_omitted_when_loader_returns_none` — monkeypatch loader to return `None` → `double_buy == []` + omitted entry.
+  - Run: `uv run pytest tests/services/test_research_run_new_candidates.py -v` — expect all FAIL (`ModuleNotFoundError`).
+
+- [ ] Implement `app/services/research_run_new_candidates.py` per the interface above. Reuse `resolve_healthy_partition` for the screener/valuation partitions (mirrors `screener_service.py`/`double_buy_screener.py` patterns already in the codebase). Reuse `InvestMomentumEventSnapshotsRepository.list_theme_events(event_kind="theme", limit=top_n)` + `list_theme_event_stocks(...)`. Reuse `load_double_buy_from_snapshots(db, market="kr", limit=top_n)` unmodified. Use `DailyCandlesRepository(session=db).fetch_recent(market=MarketKey.KR, symbol="069500", partition="KRX", count=2)` for the crash guard (rows come back newest-first per the existing KR/US branch of `fetch_recent`).
+
+- [ ] Run: `uv run pytest tests/services/test_research_run_new_candidates.py -v` — expect PASS.
+
+- [ ] Commit: `feat(ROB-918): add kr-preopen new-candidate shadow service module`
+
+## Task 2: Wire into `create_decision_session_from_research_run`
+
+**Files:**
+- Modify: `app/services/research_run_decision_session_service.py:574-600` (the `session.market_brief = _json_safe({...})` block)
+- Test: `tests/test_research_run_decision_session_service.py` (extend), new `tests/test_research_run_decision_session_service_new_candidates.py`
+
+**Interfaces:**
+- Consumes: `research_run_new_candidates.build_new_candidate_section` (Task 1).
+- Produces: `market_brief["new_candidates"]` key populated for kr/preopen sessions; absent (or explicitly omitted) for other market/stage combos.
+
+- [ ] Write failing test in new file `tests/test_research_run_decision_session_service_new_candidates.py`:
+  ```python
+  @pytest.mark.unit
+  async def test_kr_preopen_session_gets_new_candidates_section_without_proposals(
+      db_session, user, research_run_factory, research_run_candidate_factory,
+  ):
+      run = await research_run_factory(db_session, user_id=user.id, market_scope="kr", stage="preopen")
+      await research_run_candidate_factory(db_session, research_run_id=run.id, symbol="005930")
+      snapshot = LiveRefreshSnapshot(refreshed_at=datetime.now(UTC), quote_by_symbol={}, warnings=[])
+      request = ResearchRunDecisionSessionRequest(selector=ResearchRunSelector(run_uuid=run.run_uuid))
+
+      before_count = (await db_session.execute(select(func.count(TradingDecisionProposal.id)))).scalar_one()
+      result = await create_decision_session_from_research_run(
+          db_session, user_id=user.id, research_run=run, snapshot=snapshot, request=request,
+      )
+      after_count = (await db_session.execute(select(func.count(TradingDecisionProposal.id)))).scalar_one()
+
+      assert "new_candidates" in result.session.market_brief
+      assert result.session.market_brief["new_candidates"]["advisory_only"] is True
+      # Hard safety requirement: the new-candidate section must add zero proposal rows.
+      assert after_count - before_count == 1  # only the one seeded research-run candidate
+  ```
+  Run: `uv run pytest tests/test_research_run_decision_session_service_new_candidates.py -v` — expect FAIL (`KeyError: 'new_candidates'`).
+
+- [ ] Implement: in `research_run_decision_session_service.py`, import `research_run_new_candidates`, call `new_candidates = await research_run_new_candidates.build_new_candidate_section(db, market_scope=research_run.market_scope, stage=research_run.stage)` before building the `market_brief` dict, and add `"new_candidates": new_candidates` as a key (may be `None` for non-kr-preopen — keep the key present but `None` so the shape is predictable, or omit if `None`; prefer always-present key for a stable Hermes-side contract).
+
+- [ ] Run: `uv run pytest tests/test_research_run_decision_session_service_new_candidates.py tests/test_research_run_decision_session_service.py tests/test_research_run_decision_session_service_safety.py -v` — expect PASS (including the forbidden-imports guard).
+
+- [ ] Commit: `feat(ROB-918): inject new-candidate section into kr-preopen market_brief`
+
+## Task 3: Read-only shadow aggregation script
+
+**Files:**
+- Create: `scripts/shadow_new_candidates_report.py`
+- Test: `tests/test_shadow_new_candidates_report.py`
+
+**Interfaces:**
+- Consumes: `trading_decision_sessions.market_brief->'new_candidates'` (Task 2 shape); `kr_candles_1d` via `DailyCandlesRepository`.
+- Produces: `async def build_shadow_report(session: AsyncSession, *, since: date, market_scope: str = "kr") -> ShadowReportRow list` (testable core, no argparse/DB-write), plus a thin CLI `main()` mirroring `scripts/diagnose_invest_screener_snapshots.py`'s shape.
+
+- [ ] Write failing test `tests/test_shadow_new_candidates_report.py`: seed one `TradingDecisionSession` (source_profile='research_run', market_scope='kr') with a `market_brief["new_candidates"]["consecutive_gainers"]` entry carrying `baseline_date`/`baseline_close`, seed two `kr_candles_1d` rows (baseline day + D+1) for that symbol, call `build_shadow_report`, assert the returned row's `d1_close_pct` matches the expected computed percentage and that no writes occurred (assert `db_session` has no pending changes / re-query row counts unchanged for `kr_candles_1d`).
+
+- [ ] Implement `scripts/shadow_new_candidates_report.py`: query recent `TradingDecisionSession` rows with `market_brief['new_candidates']` present, flatten all three candidate lists, for each `(symbol, baseline_date)` find the next `kr_candles_1d` row strictly after `baseline_date` (`ORDER BY time ASC LIMIT 1`), compute `pct = (close - baseline_close) / baseline_close * 100`, print a table (recovered-rate / false-positive-rate style summary) — no DB writes anywhere in the file.
+
+- [ ] Run: `uv run pytest tests/test_shadow_new_candidates_report.py -v` — expect PASS.
+
+- [ ] Commit: `feat(ROB-918): add read-only 2-week shadow aggregation script`
+
+## Task 4: Runbook + PR
+
+- [ ] Create `docs/runbooks/kr-preopen-new-candidates-shadow.md` documenting the shadow rollout, filters, crash-guard, and how to run the aggregation script.
+- [ ] Run full suite: `uv run pytest tests/services/test_research_run_new_candidates.py tests/test_research_run_decision_session_service*.py tests/test_shadow_new_candidates_report.py -v` and `make lint`.
+- [ ] `gh pr create --base main` with proposal-count-unchanged evidence in the PR body.

--- a/scripts/shadow_new_candidates_report.py
+++ b/scripts/shadow_new_candidates_report.py
@@ -1,0 +1,267 @@
+#!/usr/bin/env python3
+"""ROB-918: read-only 2-week shadow report for kr-preopen new candidates.
+
+Scans ``trading_decision_sessions.market_brief -> 'new_candidates'`` for
+recent kr-preopen research_run sessions, joins each candidate's baseline
+close against the next available ``kr_candles_1d`` close to compute a D+1
+% move, and prints a recovered-rate / false-positive-rate summary per
+selection reason (consecutive_gainers / theme_leader / double_buy).
+
+NEVER writes to the database. SELECT only, everywhere in this file.
+
+Examples:
+    uv run python -m scripts.shadow_new_candidates_report
+    uv run python -m scripts.shadow_new_candidates_report --since-days 14
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import datetime as dt
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+from sqlalchemy import select, text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.cli import setup_logging_and_sentry
+from app.core.db import AsyncSessionLocal
+from app.models.trading_decision import TradingDecisionSession
+
+logger = logging.getLogger(__name__)
+
+_CANDIDATE_SECTIONS = ("consecutive_gainers", "theme_leaders", "double_buy")
+
+
+@dataclass(frozen=True)
+class ShadowCandidateRow:
+    session_id: int
+    session_uuid: str
+    generated_at: dt.datetime
+    reason: str
+    symbol: str
+    name: str | None
+    baseline_date: dt.date | None
+    baseline_close: float | None
+    d1_close: float | None
+    d1_time: dt.datetime | None
+    d1_close_pct: float | None
+    evaluable: bool
+
+
+async def _fetch_next_close(
+    session: AsyncSession, *, symbol: str, venue: str, after_date: dt.date
+) -> tuple[float, dt.datetime] | None:
+    """Return (close, time) of the first kr_candles_1d row strictly after after_date.
+
+    Read-only. Returns None when the table is unavailable or no such row
+    exists (never raises — the caller marks the candidate unevaluable).
+    """
+    try:
+        result = await session.execute(
+            text(
+                """
+                SELECT close, time
+                FROM public.kr_candles_1d
+                WHERE symbol = :symbol AND venue = :venue AND time > :after_date
+                ORDER BY time ASC
+                LIMIT 1
+                """
+            ),
+            {"symbol": symbol, "venue": venue, "after_date": after_date},
+        )
+        row = result.first()
+    except Exception as exc:  # noqa: BLE001 -- read-only diagnostic, never raise
+        logger.warning(
+            "shadow_new_candidates_report: kr_candles_1d read failed for %s: %s",
+            symbol,
+            exc,
+            exc_info=True,
+        )
+        return None
+    if row is None:
+        return None
+    return float(row.close), row.time
+
+
+def _iter_candidates(market_brief: dict[str, Any]) -> list[dict[str, Any]]:
+    new_candidates = (market_brief or {}).get("new_candidates") or {}
+    out: list[dict[str, Any]] = []
+    for section in _CANDIDATE_SECTIONS:
+        out.extend(new_candidates.get(section) or [])
+    return out
+
+
+def _parse_date(value: Any) -> dt.date | None:
+    if not value:
+        return None
+    try:
+        return dt.date.fromisoformat(str(value)[:10])
+    except ValueError:
+        return None
+
+
+async def build_shadow_report(
+    session: AsyncSession, *, since: dt.date, market_scope: str = "kr"
+) -> list[ShadowCandidateRow]:
+    """Read-only: flatten new_candidates from recent sessions and join D+1 closes.
+
+    NEVER writes. `since` filters on trading_decision_sessions.generated_at.
+    """
+    stmt = select(TradingDecisionSession).where(
+        TradingDecisionSession.source_profile == "research_run",
+        TradingDecisionSession.market_scope == market_scope,
+        TradingDecisionSession.generated_at
+        >= dt.datetime.combine(since, dt.time.min, tzinfo=dt.UTC),
+    )
+    sessions = (await session.execute(stmt)).scalars().all()
+
+    rows: list[ShadowCandidateRow] = []
+    for sess in sessions:
+        for candidate in _iter_candidates(sess.market_brief or {}):
+            symbol = candidate.get("symbol")
+            if not symbol:
+                continue
+            baseline_date = _parse_date(candidate.get("baseline_date"))
+            baseline_close = candidate.get("baseline_close")
+
+            d1_close: float | None = None
+            d1_time: dt.datetime | None = None
+            if baseline_date is not None:
+                next_close = await _fetch_next_close(
+                    session, symbol=symbol, venue="KRX", after_date=baseline_date
+                )
+                if next_close is not None:
+                    d1_close, d1_time = next_close
+
+            d1_close_pct: float | None = None
+            evaluable = False
+            if (
+                baseline_close is not None
+                and d1_close is not None
+                and float(baseline_close) != 0.0
+            ):
+                d1_close_pct = (
+                    (d1_close - float(baseline_close)) / float(baseline_close) * 100
+                )
+                evaluable = True
+
+            rows.append(
+                ShadowCandidateRow(
+                    session_id=sess.id,
+                    session_uuid=str(sess.session_uuid),
+                    generated_at=sess.generated_at,
+                    reason=candidate.get("reason", "unknown"),
+                    symbol=symbol,
+                    name=candidate.get("name"),
+                    baseline_date=baseline_date,
+                    baseline_close=(
+                        float(baseline_close) if baseline_close is not None else None
+                    ),
+                    d1_close=d1_close,
+                    d1_time=d1_time,
+                    d1_close_pct=d1_close_pct,
+                    evaluable=evaluable,
+                )
+            )
+    return rows
+
+
+def summarize_rows(rows: list[ShadowCandidateRow]) -> dict[str, dict[str, Any]]:
+    """Group rows by selection reason and compute recovered/false-positive rates.
+
+    "recovered" = d1_close_pct > 0 (the candidate was up the next session).
+    """
+    by_reason: dict[str, list[ShadowCandidateRow]] = {}
+    for row in rows:
+        by_reason.setdefault(row.reason, []).append(row)
+
+    summary: dict[str, dict[str, Any]] = {}
+    for reason, reason_rows in by_reason.items():
+        evaluated = [
+            r for r in reason_rows if r.evaluable and r.d1_close_pct is not None
+        ]
+        recovered = [r for r in evaluated if r.d1_close_pct > 0]
+        summary[reason] = {
+            "total": len(reason_rows),
+            "evaluated": len(evaluated),
+            "recovered_count": len(recovered),
+            "recovered_rate": (len(recovered) / len(evaluated) if evaluated else None),
+            "false_positive_rate": (
+                (len(evaluated) - len(recovered)) / len(evaluated)
+                if evaluated
+                else None
+            ),
+            "avg_d1_close_pct": (
+                sum(r.d1_close_pct for r in evaluated) / len(evaluated)
+                if evaluated
+                else None
+            ),
+        }
+    return summary
+
+
+def _print_report(
+    rows: list[ShadowCandidateRow], summary: dict[str, dict[str, Any]]
+) -> None:
+    print(f"\ncandidates={len(rows)}\n")
+    for reason, stats in summary.items():
+        recovered_rate = stats["recovered_rate"]
+        false_positive_rate = stats["false_positive_rate"]
+        avg_pct = stats["avg_d1_close_pct"]
+        print(
+            f"  {reason:20s} total={stats['total']:4d} evaluated={stats['evaluated']:4d} "
+            f"recovered_rate={recovered_rate if recovered_rate is None else f'{recovered_rate:.1%}':>7} "
+            f"false_positive_rate={false_positive_rate if false_positive_rate is None else f'{false_positive_rate:.1%}':>7} "
+            f"avg_d1_close_pct={avg_pct if avg_pct is None else f'{avg_pct:+.2f}%':>8}"
+        )
+    print()
+    for row in rows:
+        pct_label = (
+            f"{row.d1_close_pct:+.2f}%" if row.d1_close_pct is not None else "n/a"
+        )
+        print(
+            f"  [{row.generated_at.date().isoformat()}] {row.reason:20s} "
+            f"{row.symbol:8s} {row.name or '':10s} "
+            f"baseline={row.baseline_close!r} d1={row.d1_close!r} pct={pct_label}"
+        )
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Read-only ROB-918 kr-preopen new-candidate shadow report "
+            "(never writes to the database)."
+        )
+    )
+    parser.add_argument("--market", choices=["kr"], default="kr")
+    parser.add_argument(
+        "--since-days",
+        type=int,
+        default=14,
+        help="Look back this many days from today (default: 14, the shadow window).",
+    )
+    return parser.parse_args(argv)
+
+
+async def main(argv: list[str] | None = None) -> int:
+    setup_logging_and_sentry(service_name="shadow-new-candidates-report")
+    args = parse_args(argv)
+    since = dt.datetime.now(dt.UTC).date() - dt.timedelta(days=args.since_days)
+    try:
+        async with AsyncSessionLocal() as session:
+            rows = await build_shadow_report(
+                session, since=since, market_scope=args.market
+            )
+        summary = summarize_rows(rows)
+        _print_report(rows, summary)
+        return 0
+    except Exception:
+        logger.exception("shadow_new_candidates_report crashed")
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/tests/services/test_research_run_new_candidates.py
+++ b/tests/services/test_research_run_new_candidates.py
@@ -1,0 +1,485 @@
+"""ROB-918: kr-preopen new-candidate shadow section tests.
+
+The service module is read-only/advisory-only: it never touches
+trading_decision_proposals, and it opens its own DB session (never the
+caller's) so a read failure here can never poison a caller's write
+transaction. These tests exercise the internal per-source builders directly
+against the shared test_db (far-future snapshot dates keep rows isolated as
+the "latest" partition, per the existing double_buy_screener test
+convention) plus the top-level gating/crash-guard behavior.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import decimal
+
+import pytest
+import pytest_asyncio
+import sqlalchemy as sa
+
+from app.models.invest_momentum_event_snapshot import (
+    InvestThemeEventSnapshot,
+    InvestThemeEventSnapshotStock,
+)
+from app.models.invest_screener_snapshot import InvestScreenerSnapshot
+from app.models.kr_symbol_universe import KRSymbolUniverse
+from app.models.market_valuation_snapshot import MarketValuationSnapshot
+from app.services import research_run_new_candidates as svc
+from app.services.daily_candles.repository import DailyCandleRow
+
+pytestmark = pytest.mark.asyncio
+
+# ROB-918 owns the 918xxx symbol range to stay isolated from other suites'
+# synthetic symbols in the shared persistent test_db.
+_SYM_QUALIFIES = "918001"
+_SYM_LOW_MARKET_CAP = "918002"
+_SYM_LOW_TRADE_VALUE = "918003"
+_SNAPSHOT_DATE = dt.date(2099, 12, 31)
+
+
+def _candle_row(*, symbol: str, close: float, time_utc: dt.datetime) -> DailyCandleRow:
+    return DailyCandleRow(
+        time_utc=time_utc,
+        symbol=symbol,
+        partition="KRX",
+        open=close,
+        high=close,
+        low=close,
+        close=close,
+        adj_close=None,
+        volume=1000.0,
+        value=1000.0 * close,
+        source="kis",
+    )
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def _cleanup(db_session):
+    async def _purge() -> None:
+        await db_session.execute(
+            sa.delete(InvestScreenerSnapshot).where(
+                InvestScreenerSnapshot.symbol.in_(
+                    [_SYM_QUALIFIES, _SYM_LOW_MARKET_CAP, _SYM_LOW_TRADE_VALUE]
+                )
+            )
+        )
+        await db_session.execute(
+            sa.delete(MarketValuationSnapshot).where(
+                MarketValuationSnapshot.symbol.in_(
+                    [_SYM_QUALIFIES, _SYM_LOW_MARKET_CAP, _SYM_LOW_TRADE_VALUE]
+                )
+            )
+        )
+        await db_session.execute(
+            sa.delete(KRSymbolUniverse).where(
+                KRSymbolUniverse.symbol.in_(
+                    [_SYM_QUALIFIES, _SYM_LOW_MARKET_CAP, _SYM_LOW_TRADE_VALUE]
+                )
+            )
+        )
+        await db_session.execute(
+            sa.delete(InvestThemeEventSnapshotStock).where(
+                InvestThemeEventSnapshotStock.symbol == _SYM_QUALIFIES
+            )
+        )
+        await db_session.execute(
+            sa.delete(InvestThemeEventSnapshot).where(
+                InvestThemeEventSnapshot.source_event_key == "rob918-test-theme"
+            )
+        )
+        await db_session.commit()
+
+    await _purge()
+    yield
+    await _purge()
+
+
+# ---------------------------------------------------------------------------
+# Top-level gating
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+async def test_returns_none_for_non_kr_market():
+    result = await svc.build_new_candidate_section(market_scope="us", stage="preopen")
+    assert result is None
+
+
+@pytest.mark.unit
+async def test_returns_none_for_non_preopen_stage():
+    result = await svc.build_new_candidate_section(market_scope="kr", stage="intraday")
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Crash guard
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+async def test_crash_warning_when_index_gap_below_threshold(monkeypatch):
+    async def _fake_fetch(_session):
+        return [
+            _candle_row(
+                symbol="069500",
+                close=96.0,
+                time_utc=dt.datetime(2026, 7, 16, tzinfo=dt.UTC),
+            ),
+            _candle_row(
+                symbol="069500",
+                close=100.0,
+                time_utc=dt.datetime(2026, 7, 15, tzinfo=dt.UTC),
+            ),
+        ]
+
+    monkeypatch.setattr(svc, "_fetch_index_recent_closes", _fake_fetch)
+
+    state, detail = await svc._resolve_market_state(object())
+
+    assert state == "crash_warning"
+    assert detail["gap_pct"] == pytest.approx(-4.0)
+
+
+@pytest.mark.unit
+async def test_normal_market_state_when_index_gap_small(monkeypatch):
+    async def _fake_fetch(_session):
+        return [
+            _candle_row(
+                symbol="069500",
+                close=100.5,
+                time_utc=dt.datetime(2026, 7, 16, tzinfo=dt.UTC),
+            ),
+            _candle_row(
+                symbol="069500",
+                close=100.0,
+                time_utc=dt.datetime(2026, 7, 15, tzinfo=dt.UTC),
+            ),
+        ]
+
+    monkeypatch.setattr(svc, "_fetch_index_recent_closes", _fake_fetch)
+
+    state, detail = await svc._resolve_market_state(object())
+
+    assert state == "normal"
+    assert detail["gap_pct"] == pytest.approx(0.5)
+
+
+@pytest.mark.unit
+async def test_unknown_market_state_when_index_candles_missing(monkeypatch):
+    async def _fake_fetch(_session):
+        raise RuntimeError("relation kr_candles_1d does not exist")
+
+    monkeypatch.setattr(svc, "_fetch_index_recent_closes", _fake_fetch)
+
+    state, detail = await svc._resolve_market_state(object())
+
+    assert state == "unknown"
+    assert detail["reason"]
+
+
+@pytest.mark.unit
+async def test_unknown_market_state_when_only_one_candle(monkeypatch):
+    async def _fake_fetch(_session):
+        return [
+            _candle_row(
+                symbol="069500",
+                close=100.0,
+                time_utc=dt.datetime(2026, 7, 16, tzinfo=dt.UTC),
+            )
+        ]
+
+    monkeypatch.setattr(svc, "_fetch_index_recent_closes", _fake_fetch)
+
+    state, detail = await svc._resolve_market_state(object())
+
+    assert state == "unknown"
+
+
+# ---------------------------------------------------------------------------
+# consecutive_gainers
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+async def test_consecutive_gainers_filters_by_market_cap_and_trade_value(db_session):
+    db_session.add_all(
+        [
+            KRSymbolUniverse(
+                symbol=_SYM_QUALIFIES, name="합격종목", exchange="KOSPI", is_active=True
+            ),
+            KRSymbolUniverse(
+                symbol=_SYM_LOW_MARKET_CAP,
+                name="시총미달",
+                exchange="KOSPI",
+                is_active=True,
+            ),
+            KRSymbolUniverse(
+                symbol=_SYM_LOW_TRADE_VALUE,
+                name="거래대금미달",
+                exchange="KOSPI",
+                is_active=True,
+            ),
+        ]
+    )
+    db_session.add_all(
+        [
+            InvestScreenerSnapshot(
+                market="kr",
+                symbol=_SYM_QUALIFIES,
+                snapshot_date=_SNAPSHOT_DATE,
+                latest_close=decimal.Decimal("50000"),
+                prev_close=decimal.Decimal("46000"),
+                change_amount=decimal.Decimal("4000"),
+                change_rate=decimal.Decimal("8.7"),
+                consecutive_up_days=1,
+                week_change_rate=decimal.Decimal("12.0"),
+                daily_volume=1_000_000,  # 1M * 50000 = 50B >= 20B floor
+                closes_window=[46000, 50000],
+                source="kis",
+            ),
+            InvestScreenerSnapshot(
+                market="kr",
+                symbol=_SYM_LOW_MARKET_CAP,
+                snapshot_date=_SNAPSHOT_DATE,
+                latest_close=decimal.Decimal("50000"),
+                prev_close=decimal.Decimal("46000"),
+                change_rate=decimal.Decimal("8.7"),
+                consecutive_up_days=1,
+                daily_volume=1_000_000,
+                closes_window=[46000, 50000],
+                source="kis",
+            ),
+            InvestScreenerSnapshot(
+                market="kr",
+                symbol=_SYM_LOW_TRADE_VALUE,
+                snapshot_date=_SNAPSHOT_DATE,
+                latest_close=decimal.Decimal("50000"),
+                prev_close=decimal.Decimal("46000"),
+                change_rate=decimal.Decimal("8.7"),
+                consecutive_up_days=1,
+                daily_volume=100,  # 100 * 50000 = 5M << 20B floor
+                closes_window=[46000, 50000],
+                source="kis",
+            ),
+        ]
+    )
+    db_session.add_all(
+        [
+            MarketValuationSnapshot(
+                market="kr",
+                symbol=_SYM_QUALIFIES,
+                snapshot_date=_SNAPSHOT_DATE,
+                source="naver_finance",
+                market_cap=decimal.Decimal("300000000000"),  # 3000억 >= floor
+            ),
+            MarketValuationSnapshot(
+                market="kr",
+                symbol=_SYM_LOW_MARKET_CAP,
+                snapshot_date=_SNAPSHOT_DATE,
+                source="naver_finance",
+                market_cap=decimal.Decimal("50000000000"),  # 500억 < floor
+            ),
+            MarketValuationSnapshot(
+                market="kr",
+                symbol=_SYM_LOW_TRADE_VALUE,
+                snapshot_date=_SNAPSHOT_DATE,
+                source="naver_finance",
+                market_cap=decimal.Decimal("300000000000"),
+            ),
+        ]
+    )
+    await db_session.commit()
+
+    omitted: list[dict[str, str]] = []
+    candidates = await svc._build_consecutive_gainers_candidates(
+        db_session, top_n=10, omitted=omitted
+    )
+
+    symbols = [c["symbol"] for c in candidates]
+    assert _SYM_QUALIFIES in symbols
+    assert _SYM_LOW_MARKET_CAP not in symbols
+    assert _SYM_LOW_TRADE_VALUE not in symbols
+
+    winner = next(c for c in candidates if c["symbol"] == _SYM_QUALIFIES)
+    assert winner["reason"] == "consecutive_gainers"
+    assert winner["advisory_only"] is True
+    assert winner["metrics"]["change_rate"] == pytest.approx(8.7)
+    assert winner["metrics"]["consecutive_up_days"] == 1
+    assert winner["metrics"]["market_cap"] == pytest.approx(300000000000)
+    assert winner["metrics"]["trade_value_est"] == pytest.approx(50_000_000_000)
+    assert winner["baseline_date"] == _SNAPSHOT_DATE.isoformat()
+    assert winner["baseline_close"] == pytest.approx(50000.0)
+    assert winner["outcome"] == {"d1_close_pct": None}
+
+
+@pytest.mark.unit
+async def test_consecutive_gainers_omitted_when_snapshot_missing(
+    db_session, monkeypatch
+):
+    # Force resolve_healthy_partition to report "no partitions" regardless of
+    # any real data another xdist worker may have seeded for market='kr'.
+    async def _no_partition(*_a, **_k):
+        return None
+
+    monkeypatch.setattr(svc, "resolve_healthy_partition", _no_partition)
+
+    omitted: list[dict[str, str]] = []
+    candidates = await svc._build_consecutive_gainers_candidates(
+        db_session, top_n=10, omitted=omitted
+    )
+
+    assert candidates == []
+    assert any(o["section"] == "consecutive_gainers" for o in omitted)
+
+
+# ---------------------------------------------------------------------------
+# theme_leaders
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+async def test_theme_leaders_flattened_from_leader_symbols(db_session):
+    theme = InvestThemeEventSnapshot(
+        snapshot_at=dt.datetime(2099, 12, 31, 15, 30, tzinfo=dt.UTC),
+        trading_date=_SNAPSHOT_DATE,
+        surface="theme_upjong_list",
+        market="kr",
+        event_kind="theme",
+        source_event_key="rob918-test-theme",
+        name="ROB918테스트테마",
+        sort_type="change_rate",
+        rank=1,
+        change_rate=decimal.Decimal("15.0"),
+        trade_value=decimal.Decimal("999000000"),
+        market_cap=decimal.Decimal("5000000000"),
+        stock_count=3,
+        leader_symbols=[
+            {"symbol": _SYM_QUALIFIES, "name": "합격종목"},
+        ],
+    )
+    db_session.add(theme)
+    await db_session.flush()
+    db_session.add(
+        InvestThemeEventSnapshotStock(
+            theme_snapshot_id=theme.id,
+            symbol=_SYM_QUALIFIES,
+            name="합격종목",
+            rank=1,
+            order_type="rise",
+            price=decimal.Decimal("50000"),
+            change_rate=decimal.Decimal("8.7"),
+        )
+    )
+    await db_session.commit()
+
+    omitted: list[dict[str, str]] = []
+    candidates = await svc._build_theme_leader_candidates(
+        db_session, top_n=10, omitted=omitted
+    )
+
+    matches = [c for c in candidates if c["symbol"] == _SYM_QUALIFIES]
+    assert matches, f"expected {_SYM_QUALIFIES} among theme leaders, got {candidates}"
+    winner = matches[0]
+    assert winner["reason"] == "theme_leader"
+    assert winner["advisory_only"] is True
+    assert winner["metrics"]["theme_name"] == "ROB918테스트테마"
+    assert winner["baseline_close"] == pytest.approx(50000.0)
+    assert winner["outcome"] == {"d1_close_pct": None}
+
+
+@pytest.mark.unit
+async def test_theme_leaders_omitted_when_no_snapshots(monkeypatch):
+    class _EmptyRepo:
+        def __init__(self, _session):
+            pass
+
+        async def list_theme_events(self, **_kwargs):
+            return []
+
+    monkeypatch.setattr(svc, "InvestMomentumEventSnapshotsRepository", _EmptyRepo)
+
+    omitted: list[dict[str, str]] = []
+    candidates = await svc._build_theme_leader_candidates(
+        object(), top_n=10, omitted=omitted
+    )
+
+    assert candidates == []
+    assert any(o["section"] == "theme_leaders" for o in omitted)
+
+
+# ---------------------------------------------------------------------------
+# double_buy
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+async def test_double_buy_maps_loader_rows(monkeypatch):
+    class _FakeResult:
+        rows = [
+            {
+                "symbol": "918777",
+                "name": "쌍끌이종목",
+                "change_rate": 3.2,
+                "foreign_net": 1000,
+                "institution_net": 2000,
+                "market_cap": 400000000000.0,
+                "close": 12345.0,
+                "snapshot_date": _SNAPSHOT_DATE,
+            }
+        ]
+
+    async def _fake_loader(_session, *, market, limit):
+        assert market == "kr"
+        return _FakeResult()
+
+    monkeypatch.setattr(svc, "load_double_buy_from_snapshots", _fake_loader)
+
+    omitted: list[dict[str, str]] = []
+    candidates = await svc._build_double_buy_candidates(
+        object(), top_n=10, omitted=omitted
+    )
+
+    assert len(candidates) == 1
+    winner = candidates[0]
+    assert winner["symbol"] == "918777"
+    assert winner["reason"] == "double_buy"
+    assert winner["advisory_only"] is True
+    assert winner["metrics"]["foreign_net"] == 1000
+    assert winner["baseline_date"] == _SNAPSHOT_DATE.isoformat()
+    assert winner["baseline_close"] == pytest.approx(12345.0)
+    assert winner["outcome"] == {"d1_close_pct": None}
+
+
+@pytest.mark.unit
+async def test_double_buy_omitted_when_loader_returns_none(monkeypatch):
+    async def _fake_loader(_session, *, market, limit):
+        return None
+
+    monkeypatch.setattr(svc, "load_double_buy_from_snapshots", _fake_loader)
+
+    omitted: list[dict[str, str]] = []
+    candidates = await svc._build_double_buy_candidates(
+        object(), top_n=10, omitted=omitted
+    )
+
+    assert candidates == []
+    assert any(o["section"] == "double_buy" for o in omitted)
+
+
+# ---------------------------------------------------------------------------
+# End-to-end (own session, graceful on a totally empty DB)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+async def test_build_new_candidate_section_graceful_with_no_seeded_data():
+    result = await svc.build_new_candidate_section(market_scope="kr", stage="preopen")
+
+    assert result is not None
+    assert result["advisory_only"] is True
+    assert result["market_state"] in {"normal", "crash_warning", "unknown"}
+    assert isinstance(result["consecutive_gainers"], list)
+    assert isinstance(result["theme_leaders"], list)
+    assert isinstance(result["double_buy"], list)
+    assert isinstance(result["omitted_sections"], list)

--- a/tests/test_research_run_decision_session_service_new_candidates.py
+++ b/tests/test_research_run_decision_session_service_new_candidates.py
@@ -1,0 +1,113 @@
+"""ROB-918: kr-preopen sessions get an advisory-only new_candidates section.
+
+Hard safety requirement under test: injecting the new-candidate section must
+never add a trading_decision_proposals row — the section is observation-only
+and lives entirely inside market_brief (JSONB).
+"""
+
+from __future__ import annotations
+
+import importlib
+from datetime import UTC, datetime
+
+import pytest
+from sqlalchemy import func, select
+
+from app.models.trading_decision import TradingDecisionProposal
+from app.schemas.research_run_decision_session import (
+    LiveRefreshSnapshot,
+    ResearchRunDecisionSessionRequest,
+    ResearchRunSelector,
+)
+from app.services.research_run_decision_session_service import (
+    create_decision_session_from_research_run,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.fixture(autouse=True)
+def restore_trading_decision_service_module():
+    """Keep this persistence-backed service isolated from router mock tests."""
+    from app.services import trading_decision_service
+
+    importlib.reload(trading_decision_service)
+    yield
+    importlib.reload(trading_decision_service)
+
+
+async def _proposal_count(db_session) -> int:
+    return (
+        await db_session.execute(select(func.count(TradingDecisionProposal.id)))
+    ).scalar_one()
+
+
+@pytest.mark.unit
+async def test_kr_preopen_session_gets_new_candidates_section_without_proposals(
+    db_session, user, research_run_factory, research_run_candidate_factory
+):
+    run = await research_run_factory(
+        db_session, user_id=user.id, market_scope="kr", stage="preopen"
+    )
+    await research_run_candidate_factory(
+        db_session, research_run_id=run.id, symbol="005930"
+    )
+
+    snapshot = LiveRefreshSnapshot(
+        refreshed_at=datetime.now(UTC), quote_by_symbol={}, warnings=[]
+    )
+    request = ResearchRunDecisionSessionRequest(
+        selector=ResearchRunSelector(run_uuid=run.run_uuid)
+    )
+
+    before = await _proposal_count(db_session)
+    result = await create_decision_session_from_research_run(
+        db_session,
+        user_id=user.id,
+        research_run=run,
+        snapshot=snapshot,
+        request=request,
+    )
+    after = await _proposal_count(db_session)
+
+    market_brief = result.session.market_brief
+    assert market_brief is not None
+    assert "new_candidates" in market_brief
+    new_candidates = market_brief["new_candidates"]
+    assert new_candidates["advisory_only"] is True
+    assert new_candidates["market_state"] in {"normal", "crash_warning", "unknown"}
+    for section in ("consecutive_gainers", "theme_leaders", "double_buy"):
+        assert isinstance(new_candidates[section], list)
+
+    # Hard safety requirement: the new-candidate section adds zero proposal
+    # rows. Only the one seeded research-run candidate becomes a proposal.
+    assert after - before == 1
+
+
+@pytest.mark.unit
+async def test_non_kr_or_non_preopen_session_omits_new_candidates(
+    db_session, user, research_run_factory, research_run_candidate_factory
+):
+    run = await research_run_factory(
+        db_session, user_id=user.id, market_scope="us", stage="preopen"
+    )
+    await research_run_candidate_factory(
+        db_session, research_run_id=run.id, symbol="AAPL"
+    )
+
+    snapshot = LiveRefreshSnapshot(
+        refreshed_at=datetime.now(UTC), quote_by_symbol={}, warnings=[]
+    )
+    request = ResearchRunDecisionSessionRequest(
+        selector=ResearchRunSelector(run_uuid=run.run_uuid)
+    )
+
+    result = await create_decision_session_from_research_run(
+        db_session,
+        user_id=user.id,
+        research_run=run,
+        snapshot=snapshot,
+        request=request,
+    )
+
+    assert result.session.market_brief["new_candidates"] is None

--- a/tests/test_shadow_new_candidates_report.py
+++ b/tests/test_shadow_new_candidates_report.py
@@ -1,0 +1,255 @@
+"""ROB-918: read-only 2-week shadow aggregation for kr-preopen new candidates.
+
+The script never writes to the DB — it only reads trading_decision_sessions
+and joins kr_candles_1d (via a mockable helper, since kr_candles_1d is a raw
+Timescale hypertable absent from the unit test_db) to compute D+1 % moves.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+
+import pytest
+import pytest_asyncio
+import sqlalchemy as sa
+
+from app.models.trading_decision import TradingDecisionSession
+from app.services import trading_decision_service
+from scripts.shadow_new_candidates_report import build_shadow_report, summarize_rows
+
+# ROB-918 owns this strategy_name marker so cleanup can scope to just these
+# tests' rows in the shared persistent test_db (no exact-count assertions).
+_STRATEGY_NAME = "kr-preopen-shadow-test"
+_BASELINE_DATE = dt.date(2026, 7, 15)
+_SYMBOL = "918555"
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def _cleanup(db_session):
+    async def _purge() -> None:
+        await db_session.execute(
+            sa.delete(TradingDecisionSession).where(
+                TradingDecisionSession.strategy_name == _STRATEGY_NAME
+            )
+        )
+        await db_session.commit()
+
+    await _purge()
+    yield
+    await _purge()
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_build_shadow_report_computes_d1_close_pct(db_session, user, monkeypatch):
+    async def _fake_next_close(_session, *, symbol, venue, after_date):
+        if symbol != _SYMBOL:
+            return None
+        assert venue == "KRX"
+        assert after_date == _BASELINE_DATE
+        return 106.0, dt.datetime(2026, 7, 16, 6, 0, tzinfo=dt.UTC)
+
+    import scripts.shadow_new_candidates_report as mod
+
+    monkeypatch.setattr(mod, "_fetch_next_close", _fake_next_close)
+
+    market_brief = {
+        "advisory_only": True,
+        "new_candidates": {
+            "advisory_only": True,
+            "market_state": "normal",
+            "consecutive_gainers": [
+                {
+                    "symbol": _SYMBOL,
+                    "name": "테스트종목",
+                    "reason": "consecutive_gainers",
+                    "advisory_only": True,
+                    "baseline_date": _BASELINE_DATE.isoformat(),
+                    "baseline_close": 100.0,
+                    "outcome": {"d1_close_pct": None},
+                }
+            ],
+            "theme_leaders": [],
+            "double_buy": [],
+        },
+    }
+    await trading_decision_service.create_decision_session(
+        db_session,
+        user_id=user.id,
+        source_profile="research_run",
+        strategy_name="kr-preopen-shadow-test",
+        market_scope="kr",
+        market_brief=market_brief,
+        generated_at=dt.datetime(2026, 7, 16, 0, 0, tzinfo=dt.UTC),
+    )
+    await db_session.commit()
+
+    rows = await build_shadow_report(
+        db_session, since=dt.date(2026, 7, 1), market_scope="kr"
+    )
+
+    matches = [r for r in rows if r.symbol == _SYMBOL]
+    assert matches, f"expected a row for {_SYMBOL}, got {[r.symbol for r in rows]}"
+    row = matches[0]
+    assert row.reason == "consecutive_gainers"
+    assert row.baseline_close == pytest.approx(100.0)
+    assert row.d1_close == pytest.approx(106.0)
+    assert row.d1_close_pct == pytest.approx(6.0)
+    assert row.evaluable is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_build_shadow_report_marks_unevaluable_when_no_next_candle(
+    db_session, user, monkeypatch
+):
+    async def _fake_next_close(_session, *, symbol, venue, after_date):
+        return None
+
+    import scripts.shadow_new_candidates_report as mod
+
+    monkeypatch.setattr(mod, "_fetch_next_close", _fake_next_close)
+
+    symbol = "918556"
+    market_brief = {
+        "new_candidates": {
+            "advisory_only": True,
+            "market_state": "normal",
+            "consecutive_gainers": [
+                {
+                    "symbol": symbol,
+                    "name": "노데이터",
+                    "reason": "consecutive_gainers",
+                    "baseline_date": _BASELINE_DATE.isoformat(),
+                    "baseline_close": 100.0,
+                    "outcome": {"d1_close_pct": None},
+                }
+            ],
+            "theme_leaders": [],
+            "double_buy": [],
+        },
+    }
+    await trading_decision_service.create_decision_session(
+        db_session,
+        user_id=user.id,
+        source_profile="research_run",
+        strategy_name="kr-preopen-shadow-test",
+        market_scope="kr",
+        market_brief=market_brief,
+        generated_at=dt.datetime(2026, 7, 16, 0, 0, tzinfo=dt.UTC),
+    )
+    await db_session.commit()
+
+    rows = await build_shadow_report(
+        db_session, since=dt.date(2026, 7, 1), market_scope="kr"
+    )
+
+    matches = [r for r in rows if r.symbol == symbol]
+    assert matches
+    assert matches[0].evaluable is False
+    assert matches[0].d1_close_pct is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_build_shadow_report_ignores_sessions_before_since(
+    db_session, user, monkeypatch
+):
+    async def _fake_next_close(_session, **_kwargs):
+        return 999.0, dt.datetime(2026, 6, 2, tzinfo=dt.UTC)
+
+    import scripts.shadow_new_candidates_report as mod
+
+    monkeypatch.setattr(mod, "_fetch_next_close", _fake_next_close)
+
+    symbol = "918557"
+    market_brief = {
+        "new_candidates": {
+            "consecutive_gainers": [
+                {
+                    "symbol": symbol,
+                    "baseline_date": "2026-06-01",
+                    "baseline_close": 50.0,
+                    "reason": "consecutive_gainers",
+                }
+            ],
+            "theme_leaders": [],
+            "double_buy": [],
+        }
+    }
+    await trading_decision_service.create_decision_session(
+        db_session,
+        user_id=user.id,
+        source_profile="research_run",
+        strategy_name="kr-preopen-shadow-test",
+        market_scope="kr",
+        market_brief=market_brief,
+        generated_at=dt.datetime(2026, 6, 1, 0, 0, tzinfo=dt.UTC),
+    )
+    await db_session.commit()
+
+    rows = await build_shadow_report(
+        db_session, since=dt.date(2026, 7, 1), market_scope="kr"
+    )
+
+    assert all(r.symbol != symbol for r in rows)
+
+
+@pytest.mark.unit
+def test_summarize_rows_computes_recovered_and_false_positive_rate():
+    from scripts.shadow_new_candidates_report import ShadowCandidateRow
+
+    rows = [
+        ShadowCandidateRow(
+            session_id=1,
+            session_uuid="a",
+            generated_at=dt.datetime(2026, 7, 16, tzinfo=dt.UTC),
+            reason="consecutive_gainers",
+            symbol="A",
+            name=None,
+            baseline_date=_BASELINE_DATE,
+            baseline_close=100.0,
+            d1_close=110.0,
+            d1_time=None,
+            d1_close_pct=10.0,
+            evaluable=True,
+        ),
+        ShadowCandidateRow(
+            session_id=1,
+            session_uuid="a",
+            generated_at=dt.datetime(2026, 7, 16, tzinfo=dt.UTC),
+            reason="consecutive_gainers",
+            symbol="B",
+            name=None,
+            baseline_date=_BASELINE_DATE,
+            baseline_close=100.0,
+            d1_close=95.0,
+            d1_time=None,
+            d1_close_pct=-5.0,
+            evaluable=True,
+        ),
+        ShadowCandidateRow(
+            session_id=1,
+            session_uuid="a",
+            generated_at=dt.datetime(2026, 7, 16, tzinfo=dt.UTC),
+            reason="consecutive_gainers",
+            symbol="C",
+            name=None,
+            baseline_date=_BASELINE_DATE,
+            baseline_close=None,
+            d1_close=None,
+            d1_time=None,
+            d1_close_pct=None,
+            evaluable=False,
+        ),
+    ]
+
+    summary = summarize_rows(rows)
+
+    cg = summary["consecutive_gainers"]
+    assert cg["total"] == 3
+    assert cg["evaluated"] == 2
+    assert cg["recovered_count"] == 1
+    assert cg["recovered_rate"] == pytest.approx(0.5)
+    assert cg["false_positive_rate"] == pytest.approx(0.5)
+    assert cg["avg_d1_close_pct"] == pytest.approx(2.5)


### PR DESCRIPTION
## Summary

ROB-918: injects an **advisory-only** "new candidates" observation block into `market_brief["new_candidates"]` for kr-preopen `trading_decision_sessions`, plus a read-only 2-week shadow-aggregation script.

- **Sources**: 전일 `consecutive_gainers` 상위 (`invest_screener_snapshots`, filtered to 시총≥2,000억 & 거래대금(추정)≥200억, sorted by change_rate), 전일 마감 테마 상위 (reuses `InvestMomentumEventSnapshotsRepository.list_theme_events`/`list_theme_event_stocks` from ROB-917's `get_theme_events`, flattened by `leader_symbols`), 수급 `double_buy` 요약 (delegates unmodified to the existing `load_double_buy_from_snapshots`).
- **Crash guard** (AC #5): compares the latest two `kr_candles_1d` closes for KODEX200 (`069500`/`KRX`); gap `<= -3%` sets `market_state: "crash_warning"` — **label only, never blocks**.
- **Every candidate** carries `advisory_only: true`, `baseline_date`/`baseline_close`, and `outcome: {"d1_close_pct": null}` for later shadow fill-in.
- **Graceful degradation**: any missing/failed source yields an empty section + an `omitted_sections` entry with a `reason` — never raises.
- **No migration**: reuses the existing `trading_decision_sessions.market_brief` JSONB column.
- **No proposal rows**: the section lives entirely in `market_brief`; `trading_decision_proposals` is never touched for these candidates.

### Structural safety guarantee

`build_new_candidate_section()` opens its **own** `AsyncSessionLocal()` — never the caller's session — so a read failure inside it can never poison `create_decision_session_from_research_run`'s write transaction, and the module has no access to write a proposal row even by mistake.

### Shadow aggregation script

`scripts/shadow_new_candidates_report.py` (SELECT-only, never writes) scans recent kr `research_run` sessions' `market_brief.new_candidates`, joins each candidate's baseline close against the next `kr_candles_1d` close, and prints a recovered-rate / false-positive-rate / avg-D+1-% table per selection reason:

```
uv run python -m scripts.shadow_new_candidates_report --since-days 14
```

## Proof: no proposal rows created

`tests/test_research_run_decision_session_service_new_candidates.py::test_kr_preopen_session_gets_new_candidates_section_without_proposals` seeds one research-run candidate, asserts `trading_decision_proposals` count increases by exactly 1 (the seeded candidate only) while `market_brief["new_candidates"]` is populated and `advisory_only: true`.

Also re-ran the existing forbidden-imports safety guard (`test_research_run_decision_session_service_safety.py::test_orchestrator_service_forbidden_imports`) — still green, confirming the new module doesn't pull in any broker/order/task import.

## Test plan

- [x] `uv run pytest tests/services/test_research_run_new_candidates.py -v` (13 tests: filters, crash guard states, graceful omission, non-kr/non-preopen gating)
- [x] `uv run pytest tests/test_research_run_decision_session_service_new_candidates.py tests/test_research_run_decision_session_service.py tests/test_research_run_decision_session_service_safety.py -v` (14 tests, incl. proposal-count-unchanged proof + forbidden-imports guard)
- [x] `uv run pytest tests/test_shadow_new_candidates_report.py -v` (4 tests: D+1 pct calc, unevaluable-when-no-candle, since-date filtering, summary rates)
- [x] `uv run pytest tests/ -q -m "not integration and not live and not slow" -k "research_run or trading_decision or shadow_new_candidates or new_candidates"` → 117 passed, no regressions
- [x] `make lint` (ruff check + format + ty) → all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)