### PR TITLE
feat(ROB-925): manual Toss fill-reconcile poller CLI (detection-gap manual reps)

### DIFF
--- a/docs/runbooks/toss-fill-reconcile-poller.md
+++ b/docs/runbooks/toss-fill-reconcile-poller.md
@@ -1,0 +1,182 @@
+# Toss Fill Reconcile Poller — Manual Runner (ROB-925)
+
+## Problem
+
+Toss has no broker websocket. The only path that books a confirmed fill into
+`review.execution_ledger` / `review.trades` / trade journals is
+`toss_reconcile_orders` (MCP) or the equivalent service kernel
+(`toss_reconcile_orders_impl`). Absent a live session calling that manually,
+a fill sits unbooked indefinitely — a 6월 fill was only discovered and
+backfilled in 7월 (~24 days later).
+
+`app/tasks/toss_live_reconcile_tasks.py::toss_live_poll_fills_periodic` (ROB-757)
+already implements the discover+reconcile kernels with a market-session gate
+and a kill switch, but it is a TaskIQ task: its in-repo `schedule=` is only
+non-empty when `TOSS_FILL_POLL_ENABLED=true`, and turning that cadence on
+requires the TaskIQ worker + scheduler infra to be live. Per this repo's
+"manual verification before automation" convention, ROB-925 ships a
+standalone CLI **before** that promotion so an operator can run reps by hand
+first.
+
+`scripts/toss_fill_reconcile_poller.py` wraps the exact same kernels
+(`TossFillPollerService.discover_external_orders` +
+`toss_reconcile_orders_impl`) as a single-shot process. It introduces **no
+new booking logic and no new broker mutation path** — order place / modify /
+cancel code is untouched, and every write goes through the same
+already-idempotent reconcile kernel used by `toss_reconcile_orders` today.
+
+## Modes
+
+| Mode | Flag | Broker calls | DB writes | What it does |
+|---|---|---|---|---|
+| Preview (default) | *(none)* / `--dry-run` | 0 | 0 | Lists the current open `toss_live_order_ledger` rows a real run would scan (`TossLiveOrderLedgerService.list_open`). |
+| Commit | `--commit` | yes (read + write) | yes | Runs `discover_external_orders(dry_run=False)` then `toss_reconcile_orders_impl(dry_run=False)` — identical to what the TaskIQ poller does per cycle. |
+
+Both modes short-circuit to **zero broker calls** before touching Toss if
+either gate below is closed — this holds for `--commit` too, not just
+preview.
+
+## Gates (checked in this order, before any broker call)
+
+1. **Kill switch** — `TOSS_FILL_POLL_ENABLED` (default `false`). This is the
+   same flag that gates the TaskIQ poller's schedule (ROB-757) — intentionally
+   reused rather than adding a second flag, so there is one on/off decision
+   for "should the fill poller run at all" regardless of which process runs
+   it. `false` → `{"status": "disabled", ...}`, exits 0, no I/O.
+2. **Market-session gate** — `_toss_fill_poll_market_gate()`
+   (`app/tasks/toss_live_reconcile_tasks.py`, reused as-is): active when the
+   KRX regular session (09:00–20:00 KST) is open **or** the US session
+   (pre-market/regular/after-hours, `us_market_session`) is open. Gated by
+   `TOSS_FILL_POLL_MARKET_GATE_ENABLED` (default `true`). Inactive →
+   `{"status": "skipped", "gate": {...}}`, exits 0, no broker call.
+
+## Env / config knobs
+
+| Env var | Default | Purpose |
+|---|---|---|
+| `TOSS_FILL_POLL_ENABLED` | `false` | Kill switch — must be `true` for `--commit` (or preview's gate check) to proceed past the first gate. |
+| `TOSS_FILL_POLL_MARKET_GATE_ENABLED` | `true` | Set `false` only to force a run outside session hours for testing; do not disable in production. |
+| `TOSS_FILL_POLL_LOOKBACK_DAYS` | `7` | How far back `discover_external_orders` scans closed orders when no prior watermark exists. |
+| `TOSS_FILL_POLL_CLOSED_PAGE_CAP` | `20` | Bounded pagination cap on the closed-order scan (no unbounded loop). |
+| `TOSS_FILL_POLL_RECONCILE_LIMIT` | `100` | Per-run cap on the number of open ledger rows reconciled (order/symbol cap for AC5). |
+| `TOSS_API_ENABLED` + Toss credentials | — | Required by `TossReadClient.from_settings()`; unrelated to this poller's own gates. |
+
+Per-request rate limiting (TPS, including the 09:00–09:10 KST order-window
+throttle) is enforced by `TossReadClient`'s shared process-global rate
+limiter (`app/services/brokers/toss/rate_limiter.py`) — this script does not
+add its own sleep/backoff, it just reuses the same client every other Toss
+caller uses, so it inherits the same limits without a second, potentially
+divergent implementation.
+
+## Manual reps procedure
+
+Run from the repo root with `TOSS_FILL_POLL_ENABLED=true` exported (or
+inline per-command as below). All commands are safe to re-run.
+
+**1. DRY_RUN — confirm the scan target list, zero broker calls:**
+
+```bash
+TOSS_FILL_POLL_ENABLED=true uv run python -m scripts.toss_fill_reconcile_poller
+```
+
+Expect `{"status": "preview", "target_count": N, "targets": [...]}` (or
+`{"status": "skipped", ...}` outside market hours — this is correct, not a
+failure). Inspect `targets` against what you expect to be open right now.
+
+**2. Single real run:**
+
+```bash
+TOSS_FILL_POLL_ENABLED=true uv run python -m scripts.toss_fill_reconcile_poller --commit
+```
+
+Expect `{"status": "ran", "success": true, "discover": {...}, "reconcile": {...}, "booked_symbols": [...]}`.
+Re-running this immediately is safe — the second pass should report
+`booked_symbols: []` and `reconcile.counts` dominated by
+`noop_already_booked` for rows the first pass already booked (idempotent by
+construction: `_reconcile_one_toss_row` in
+`app/mcp_server/tooling/toss_live_ledger.py` compares `delta = broker_cum -
+already_filled_qty` and no-ops when `delta <= 0`).
+
+**3. Verification query** (run against the DB the process pointed at):
+
+```sql
+SELECT id, market, symbol, broker_order_id, status, filled_qty,
+       avg_fill_price, trade_id, journal_id, updated_at
+FROM review.toss_live_order_ledger
+WHERE updated_at >= now() - interval '15 minutes'
+ORDER BY updated_at DESC;
+```
+
+Confirm newly `filled`/`partial` rows carry a non-null `trade_id` /
+`journal_id` (buy) and that no row was booked twice (compare `filled_qty`
+against the known broker quantity — it should match, not double).
+
+Optional scope narrowing: `--market kr` / `--market us` limits both the
+preview list and the commit-mode reconcile pass to one market (the discover
+scan itself is always both-market, matching the existing TaskIQ poller).
+
+## Exit codes / output contract
+
+- Always prints one JSON line to stdout, `status` ∈
+  `{disabled, skipped, preview, ran, error}`.
+- Exit `0` for `disabled` / `skipped` / `preview` / `ran` (all are expected
+  no-op-or-success outcomes — a closed market window is not a failure).
+- Exit `1` only when an unhandled exception occurs (`status: "error"` with
+  `error.type` / `error.message`); nothing is swallowed.
+
+## Future: launchd promotion (not applied by this issue)
+
+This issue ships the runner + docs only. Registering a recurring schedule is
+a separate operator decision, mirroring the existing
+`~/ops/fill-event-triage/poller.sh` + launchd pattern
+(`docs/runbooks/fill-event-claude-triage.md` §4). A draft plist for when that
+decision is made:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>
+  <key>Label</key><string>com.operator.toss-fill-reconcile-poller</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/usr/bin/env</string>
+    <string>uv</string>
+    <string>run</string>
+    <string>python</string>
+    <string>-m</string>
+    <string>scripts.toss_fill_reconcile_poller</string>
+    <string>--commit</string>
+  </array>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>TOSS_FILL_POLL_ENABLED</key><string>true</string>
+  </dict>
+  <key>WorkingDirectory</key><string>/Users/USERNAME/work/auto_trader</string>
+  <key>StartInterval</key><integer>120</integer>
+  <key>StandardOutPath</key><string>/Users/USERNAME/.local/state/toss-fill-reconcile-poller/stdout.log</string>
+  <key>StandardErrorPath</key><string>/Users/USERNAME/.local/state/toss-fill-reconcile-poller/stderr.log</string>
+</dict></plist>
+```
+
+`StartInterval=120` (2 minutes) matches the existing
+`TOSS_FILL_POLL_CRON` default (`*/2 * * * *`, see `app/core/config.py`) so
+both vehicles imply the same target cadence. Do not register this plist
+until: (a) several manual reps above have been observed clean, (b) the
+production `.env` has `TOSS_FILL_POLL_ENABLED=true` and valid Toss
+credentials, and (c) an operator has reviewed log rotation for the state
+dir. Registration itself (`launchctl bootstrap gui/$UID ...`) is out of
+scope for this issue — see `docs/runbooks/fill-event-claude-triage.md` §4
+for the exact bootstrap/bootout commands, which apply unchanged to this
+plist.
+
+## Relationship to other Toss reconcile docs
+
+- `docs/runbooks/toss-live-order-reconcile.md` — the underlying
+  `toss_reconcile_orders` contract, status semantics, and the ROB-757 fill
+  poller's TaskIQ-task framing. Read this first for what "reconcile" means.
+- `docs/runbooks/fill-event-claude-triage.md` — the downstream consumer:
+  once a fill lands in `review.execution_ledger` (source=`reconciler`,
+  broker=`toss`), a separately-scheduled poller triages it (ROB-755/ROB-926).
+  This runner's job ends at booking; it does not triage or notify beyond the
+  existing `TOSS_FILL_NOTIFY_ENABLED` fill-notification path inside
+  `toss_reconcile_orders_impl`.

--- a/docs/runbooks/toss-fill-reconcile-poller.md
+++ b/docs/runbooks/toss-fill-reconcile-poller.md
@@ -89,6 +89,12 @@ failure). Inspect `targets` against what you expect to be open right now.
 TOSS_FILL_POLL_ENABLED=true uv run python -m scripts.toss_fill_reconcile_poller --commit
 ```
 
+> ⚠️ **동시 실행 금지**: ROB-757 TaskIQ 폴러 스케줄이 armed(워커+스케줄러 가동
+> 중)일 때 `--commit`을 돌리지 말 것. dedupe는 delta 기반이라 **직렬** 재실행만
+> 보호한다 — 두 reconcile 패스가 겹치면(둘 다 `already=0`을 읽은 뒤 커밋)
+> 이중 부기 가능성이 있다(`update_reconcile_outcome`에 row lock 없음). 수동
+> reps 기간엔 TaskIQ 폴러가 off인 것을 먼저 확인하라.
+
 Expect `{"status": "ran", "success": true, "discover": {...}, "reconcile": {...}, "booked_symbols": [...]}`.
 Re-running this immediately is safe — the second pass should report
 `booked_symbols: []` and `reconcile.counts` dominated by

--- a/docs/runbooks/toss-live-order-reconcile.md
+++ b/docs/runbooks/toss-live-order-reconcile.md
@@ -234,3 +234,8 @@ Activation gates:
 The task never places, modifies, or cancels broker orders. Confirmed fill deltas
 are written to `review.execution_ledger` with `broker="toss"` and
 `source="reconciler"`; ROB-755 triage should query `--source reconciler --broker toss`.
+
+For manual reps / single-shot runs of this exact poll before promoting it to
+a recurring schedule, see `docs/runbooks/toss-fill-reconcile-poller.md`
+(ROB-925) — a standalone CLI wrapping the same kernels, usable without the
+TaskIQ worker/scheduler.

--- a/scripts/toss_fill_reconcile_poller.py
+++ b/scripts/toss_fill_reconcile_poller.py
@@ -1,0 +1,206 @@
+"""Manual/single-shot CLI runner for the Toss fill-to-ledger reconcile poller.
+
+ROB-925: Toss has no broker websocket, so a filled order only lands in
+``execution_ledger`` when something calls ``toss_reconcile_orders`` (MCP) or
+the equivalent service kernel. The only in-repo automated path today is the
+TaskIQ task ``toss_live.poll_fills_periodic``
+(``app/tasks/toss_live_reconcile_tasks.py``), which requires the TaskIQ
+worker + scheduler to be running. This script wraps the *same* kernels
+(``TossFillPollerService.discover_external_orders`` +
+``toss_reconcile_orders_impl``) as a standalone process so an operator can
+run manual reps now, and promote it to launchd later (see
+``docs/runbooks/toss-fill-reconcile-poller.md``) without touching TaskIQ.
+
+No new broker mutation path is introduced: this only ever calls the existing
+read/reconcile kernels. Order place/modify/cancel code is not touched.
+
+Two modes:
+
+* Preview (default, no ``--commit``) — DB-only, zero broker calls. Lists the
+  current open ``toss_live`` ledger rows that a real run would scan.
+* ``--commit`` — runs the real discover + reconcile pass (broker calls,
+  ledger writes), gated by ``TOSS_FILL_POLL_ENABLED`` and the KR/US market
+  session window.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+from typing import Any
+
+from app.core.config import settings
+from app.mcp_server.tooling.kis_live_ledger import _order_session_factory
+from app.mcp_server.tooling.toss_live_ledger import toss_reconcile_orders_impl
+from app.services.brokers.toss import TossReadClient
+from app.services.toss_fill_poller_service import TossFillPollerService
+from app.services.toss_live_order_ledger_service import TossLiveOrderLedgerService
+from app.tasks.toss_live_reconcile_tasks import _toss_fill_poll_market_gate
+
+logger = logging.getLogger(__name__)
+
+
+async def _preview_targets(*, market: str | None) -> dict[str, Any]:
+    """DB-only scan-target listing. Makes no broker calls."""
+    async with _order_session_factory()() as db:
+        rows = await TossLiveOrderLedgerService(db).list_open(
+            market=market, limit=settings.TOSS_FILL_POLL_RECONCILE_LIMIT
+        )
+    targets = [
+        {
+            "ledger_id": row.id,
+            "broker_order_id": row.broker_order_id,
+            "client_order_id": row.client_order_id,
+            "market": row.market,
+            "symbol": row.symbol,
+            "operation_kind": row.operation_kind,
+            "status": row.status,
+        }
+        for row in rows
+    ]
+    return {"target_count": len(targets), "targets": targets}
+
+
+async def _invalidate_sellable_cache(booked_symbols: list[str]) -> None:
+    if not booked_symbols:
+        return
+    try:
+        from app.services.toss_sellable_cache import get_shared_sellable_cache
+
+        await get_shared_sellable_cache().invalidate_many(booked_symbols)
+    except Exception as exc:  # noqa: BLE001 — reconcile result remains authoritative
+        logger.warning(
+            "Toss fill poller: sellable-cache invalidation failed symbols=%s: %s",
+            booked_symbols,
+            exc,
+        )
+
+
+async def _run_commit(*, market: str | None) -> dict[str, Any]:
+    client = TossReadClient.from_settings()
+    try:
+        async with _order_session_factory()() as db:
+            discover = await TossFillPollerService(
+                db, client=client
+            ).discover_external_orders(
+                dry_run=False,
+                lookback_days=settings.TOSS_FILL_POLL_LOOKBACK_DAYS,
+                closed_page_cap=settings.TOSS_FILL_POLL_CLOSED_PAGE_CAP,
+            )
+        reconcile = await toss_reconcile_orders_impl(
+            dry_run=False,
+            market=market,
+            limit=settings.TOSS_FILL_POLL_RECONCILE_LIMIT,
+        )
+        booked_symbols = sorted(
+            {
+                str(outcome["symbol"])
+                for outcome in reconcile.get("reconciled", [])
+                if outcome.get("action") == "booked" and outcome.get("symbol")
+            }
+        )
+        await _invalidate_sellable_cache(booked_symbols)
+        return {
+            "discover": discover,
+            "reconcile": reconcile,
+            "booked_symbols": booked_symbols,
+        }
+    finally:
+        await client.aclose()
+
+
+async def run_poll(*, dry_run: bool, market: str | None = None) -> dict[str, Any]:
+    """Single pass of the Toss fill-reconcile poller.
+
+    Kill-switch (``TOSS_FILL_POLL_ENABLED``) and the market-session gate are
+    both checked before any broker call — a disabled flag or an outside-hours
+    gate makes this a zero-broker-call no-op regardless of ``dry_run``.
+    """
+    if not settings.TOSS_FILL_POLL_ENABLED:
+        return {
+            "status": "disabled",
+            "message": "TOSS_FILL_POLL_ENABLED is False",
+            "dry_run": dry_run,
+        }
+
+    gate = _toss_fill_poll_market_gate()
+    if not gate["active"]:
+        return {
+            "status": "skipped",
+            "message": "outside Toss fill poll market window",
+            "gate": gate,
+            "dry_run": dry_run,
+        }
+
+    if dry_run:
+        preview = await _preview_targets(market=market)
+        return {
+            "status": "preview",
+            "success": True,
+            "dry_run": True,
+            "gate": gate,
+            **preview,
+        }
+
+    result = await _run_commit(market=market)
+    return {
+        "status": "ran",
+        "success": True,
+        "dry_run": False,
+        "gate": gate,
+        **result,
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Manual/single-shot runner for the Toss fill-to-ledger reconcile "
+            "poller (ROB-925). Default is a DB-only preview; pass --commit to "
+            "run the real discover+reconcile pass."
+        )
+    )
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument("--dry-run", action="store_true", default=True)
+    mode.add_argument("--commit", action="store_true")
+    parser.add_argument(
+        "--market",
+        choices=["kr", "us"],
+        default=None,
+        help="Optional market filter for the preview/reconcile scope.",
+    )
+    return parser.parse_args()
+
+
+async def _main() -> int:
+    args = parse_args()
+    dry_run = not bool(args.commit)
+    try:
+        result = await run_poll(dry_run=dry_run, market=args.market)
+    except Exception as exc:  # noqa: BLE001 — surfaced as a structured CLI failure
+        logger.exception("Toss fill poller run failed")
+        print(
+            json.dumps(
+                {
+                    "status": "error",
+                    "success": False,
+                    "dry_run": dry_run,
+                    "error": {"type": type(exc).__name__, "message": str(exc)},
+                },
+                ensure_ascii=False,
+                sort_keys=True,
+            )
+        )
+        return 1
+    print(json.dumps(result, ensure_ascii=False, sort_keys=True, default=str))
+    return 0
+
+
+def main() -> int:
+    return asyncio.run(_main())
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_toss_fill_reconcile_poller.py
+++ b/tests/scripts/test_toss_fill_reconcile_poller.py
@@ -1,0 +1,183 @@
+# tests/scripts/test_toss_fill_reconcile_poller.py
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+import scripts.toss_fill_reconcile_poller as cli
+
+
+@pytest.mark.asyncio
+async def test_disabled_kill_switch_makes_zero_calls():
+    with (
+        patch.object(cli.settings, "TOSS_FILL_POLL_ENABLED", False),
+        patch.object(cli, "TossReadClient") as client_cls,
+        patch.object(cli, "TossFillPollerService") as poller_cls,
+        patch.object(cli, "TossLiveOrderLedgerService") as ledger_cls,
+        patch.object(cli, "toss_reconcile_orders_impl", AsyncMock()) as reconcile,
+    ):
+        result = await cli.run_poll(dry_run=True)
+
+    assert result["status"] == "disabled"
+    client_cls.from_settings.assert_not_called()
+    poller_cls.assert_not_called()
+    ledger_cls.assert_not_called()
+    reconcile.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_market_gate_inactive_skips_with_zero_broker_calls():
+    with (
+        patch.object(cli.settings, "TOSS_FILL_POLL_ENABLED", True),
+        patch.object(
+            cli,
+            "_toss_fill_poll_market_gate",
+            return_value={"active": False, "reason": "closed"},
+        ),
+        patch.object(cli, "TossReadClient") as client_cls,
+        patch.object(cli, "TossFillPollerService") as poller_cls,
+        patch.object(cli, "TossLiveOrderLedgerService") as ledger_cls,
+        patch.object(cli, "toss_reconcile_orders_impl", AsyncMock()) as reconcile,
+    ):
+        result = await cli.run_poll(dry_run=False)
+
+    assert result["status"] == "skipped"
+    assert result["gate"]["active"] is False
+    client_cls.from_settings.assert_not_called()
+    poller_cls.assert_not_called()
+    ledger_cls.assert_not_called()
+    reconcile.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_preview_lists_open_rows_without_broker_call():
+    fake_row = type(
+        "Row",
+        (),
+        {
+            "id": 1,
+            "broker_order_id": "toss-order-1",
+            "client_order_id": "client-1",
+            "market": "kr",
+            "symbol": "005930",
+            "operation_kind": "place",
+            "status": "accepted",
+        },
+    )()
+
+    fake_service = AsyncMock()
+    fake_service.list_open = AsyncMock(return_value=[fake_row])
+
+    with (
+        patch.object(cli.settings, "TOSS_FILL_POLL_ENABLED", True),
+        patch.object(cli, "_toss_fill_poll_market_gate", return_value={"active": True}),
+        patch.object(cli, "TossLiveOrderLedgerService", return_value=fake_service),
+        patch.object(cli, "TossReadClient") as client_cls,
+        patch.object(cli, "TossFillPollerService") as poller_cls,
+        patch.object(cli, "toss_reconcile_orders_impl", AsyncMock()) as reconcile,
+    ):
+        result = await cli.run_poll(dry_run=True, market="kr")
+
+    assert result["status"] == "preview"
+    assert result["target_count"] == 1
+    assert result["targets"][0]["broker_order_id"] == "toss-order-1"
+    fake_service.list_open.assert_awaited_once_with(market="kr", limit=100)
+    client_cls.from_settings.assert_not_called()
+    poller_cls.assert_not_called()
+    reconcile.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_commit_rerun_does_not_double_book_already_reconciled_row():
+    """Two consecutive --commit passes over the same broker-confirmed fill must
+    only invoke the write path once; the second pass sees the kernel's own
+    dedupe outcome (``noop_already_booked``) and reports zero booked symbols.
+    """
+    fake_client = AsyncMock()
+    fake_client.aclose = AsyncMock()
+
+    fake_discover_service = AsyncMock()
+    fake_discover_service.discover_external_orders = AsyncMock(
+        return_value={"success": True, "seeded": 0, "candidates": 1}
+    )
+
+    first_reconcile = {
+        "success": True,
+        "counts": {"filled": 1},
+        "reconciled": [{"action": "booked", "symbol": "005930"}],
+    }
+    second_reconcile = {
+        "success": True,
+        "counts": {"filled": 1},
+        "reconciled": [{"action": "noop_already_booked", "symbol": "005930"}],
+    }
+
+    with (
+        patch.object(cli.settings, "TOSS_FILL_POLL_ENABLED", True),
+        patch.object(cli.settings, "TOSS_FILL_POLL_LOOKBACK_DAYS", 7),
+        patch.object(cli.settings, "TOSS_FILL_POLL_CLOSED_PAGE_CAP", 20),
+        patch.object(cli.settings, "TOSS_FILL_POLL_RECONCILE_LIMIT", 100),
+        patch.object(cli, "_toss_fill_poll_market_gate", return_value={"active": True}),
+        patch.object(cli.TossReadClient, "from_settings", return_value=fake_client),
+        patch.object(cli, "TossFillPollerService", return_value=fake_discover_service),
+        patch.object(
+            cli,
+            "toss_reconcile_orders_impl",
+            AsyncMock(side_effect=[first_reconcile, second_reconcile]),
+        ) as reconcile,
+        patch.object(cli, "_invalidate_sellable_cache", AsyncMock()) as invalidate,
+    ):
+        first = await cli.run_poll(dry_run=False)
+        second = await cli.run_poll(dry_run=False)
+
+    assert first["status"] == "ran"
+    assert first["booked_symbols"] == ["005930"]
+    assert second["status"] == "ran"
+    assert second["booked_symbols"] == []
+    assert reconcile.await_count == 2
+    for call in reconcile.await_args_list:
+        assert call.kwargs["dry_run"] is False
+        assert call.kwargs["limit"] == 100
+    invalidate.assert_any_await(["005930"])
+    invalidate.assert_any_await([])
+    assert fake_client.aclose.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_run_poll_error_is_not_swallowed():
+    with (
+        patch.object(cli.settings, "TOSS_FILL_POLL_ENABLED", True),
+        patch.object(cli, "_toss_fill_poll_market_gate", return_value={"active": True}),
+        patch.object(
+            cli.TossReadClient,
+            "from_settings",
+            side_effect=RuntimeError("toss disabled"),
+        ),
+    ):
+        with pytest.raises(RuntimeError, match="toss disabled"):
+            await cli.run_poll(dry_run=False)
+
+
+@pytest.mark.asyncio
+async def test_main_reports_structured_error_and_exit_code(monkeypatch, capsys):
+    monkeypatch.setattr("sys.argv", ["toss_fill_reconcile_poller.py", "--commit"])
+    with patch.object(cli, "run_poll", AsyncMock(side_effect=RuntimeError("boom"))):
+        rc = await cli._main()
+
+    assert rc == 1
+    out = capsys.readouterr().out
+    assert '"status": "error"' in out
+    assert "boom" in out
+
+
+@pytest.mark.asyncio
+async def test_main_dry_run_by_default(monkeypatch):
+    monkeypatch.setattr("sys.argv", ["toss_fill_reconcile_poller.py"])
+    with patch.object(
+        cli, "run_poll", AsyncMock(return_value={"status": "preview"})
+    ) as run_poll:
+        rc = await cli._main()
+
+    assert rc == 0
+    run_poll.assert_awaited_once_with(dry_run=True, market=None)


### PR DESCRIPTION
## Summary
- New `scripts/toss_fill_reconcile_poller.py` — thin CLI vehicle for manual reps of the Toss fill-reconcile cycle; reuses the existing ROB-757 kernels (`TossFillPollerService.discover_external_orders`, `toss_reconcile_orders_impl`), market gate (`_toss_fill_poll_market_gate`), shared TPS limiter, and the existing `TOSS_FILL_POLL_ENABLED` kill switch (default **false**) — zero duplicated booking/dedupe/rate-limit logic
- Preview mode (default) is DB-only (zero broker calls); `--commit` runs discover+reconcile identical to one TaskIQ poller cycle
- Runbook `docs/runbooks/toss-fill-reconcile-poller.md`: preview→commit→verification-SQL reps procedure, launchd promotion explicitly deferred as a separate operator decision ('자동화 전 수동 검증'), concurrency warning (no `--commit` while the ROB-757 TaskIQ schedule is armed)

## Verification
- Adversarial verify (opus): **no blocking issues.** Evidence-backed: preview zero-broker-call path, kill switch default false, gate bypass default off, shared rate limiter wired on both client paths, per-run caps (`TOSS_FILL_POLL_RECONCILE_LIMIT=100`, `CLOSED_PAGE_CAP=20`), idempotency delta-guard covered by existing `test_toss_live_ledger.py`
- 7 new mocked unit tests + 14 pre-existing related tests pass; ruff/ty clean
- AC-1 (≤15 min) is owned by the schedule (`TOSS_FILL_POLL_CRON="*/2 * * * *"` / launchd draft 120s), documented in the runbook

## Follow-up notes (owner decisions, out of scope here)
- Reused ROB-757 gate opens KR at 09:00 (AC said 08:00) — premarket fills delayed ≤1h, never lost; tightening the kernel gate affects ROB-757 too
- `update_reconcile_outcome` has no row-lock; overlapping reconcile passes could double-book (pre-existing kernel exposure; mitigated by runbook warning + manual-before-automation ordering)

Closes ROB-925

🤖 Generated with [Claude Code](https://claude.com/claude-code)