### PR TITLE
feat(ROB-932): crash-day advisory policy keys (minimal: gap-trigger only)

### DIFF
--- a/app/schemas/trading_policy.py
+++ b/app/schemas/trading_policy.py
@@ -151,6 +151,41 @@ class OrderProposalsPolicy(BaseModel):
     auto_approve: OrderProposalAutoApprovePolicy
 
 
+class CrashDayTrigger(BaseModel):
+    """ROB-932 — gap-only trigger. Intraday crashes (e.g. 2026-07-13: gap
+    -0.8% -> intraday -9.8%) are NOT covered by this trigger; that gap is a
+    documented limitation, not an oversight."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    index_symbol: str
+    index_gap_pct_max: float
+
+
+class CrashDayActions(BaseModel):
+    """ROB-932 — advisory only, no code enforcement. new_entry_hold applies
+    to NEW entries only; averaging-down deep rungs on existing positions are
+    exempt (2026-07-16 midday dip-buys measured effective)."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    new_entry_hold: bool
+    deep_rung_reprice_to_band_floor: bool
+    profit_trim_marketable_allowed: bool
+    defensive_brief_cross_check: bool
+
+
+class CrashDayPolicy(BaseModel):
+    """ROB-932 — crash-day advisory playbook. Not enforced in code; a
+    cross-check reference for judgment only. defensive_trim execution support
+    is out of scope for this PR."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    trigger: CrashDayTrigger
+    actions: CrashDayActions
+
+
 class TradingPolicyDocument(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -164,3 +199,4 @@ class TradingPolicyDocument(BaseModel):
     decision_rules: dict[str, PolicyDecisionRule] = Field(default_factory=dict)
     market_rules: dict[Literal["crypto"], CryptoMarketRules]
     market_overrides: dict[Market, dict[str, ThresholdValue]]
+    crash_day: CrashDayPolicy

--- a/app/services/trading_policy_service.py
+++ b/app/services/trading_policy_service.py
@@ -102,6 +102,9 @@ def get_policy_for(market: str, lane: str) -> dict[str, Any]:
         "thresholds": thresholds,
         "decision_rules": decision_rules,
         "market_rules": market_rules,
+        # ROB-932 — single global advisory trigger, not market/lane-scoped;
+        # echoed unconditionally alongside the version/content_hash stamp.
+        "crash_day": doc.crash_day.model_dump(),
     }
 
 

--- a/config/trading_policy.yaml
+++ b/config/trading_policy.yaml
@@ -2,9 +2,9 @@
 # Seeded verbatim from docs/playbooks/trading-decision-playbook.md policy_keys
 # (captured 2026-07-02). Edited by operator PR ONLY — there is no write tool.
 # Repo is public; exposing these values is an accepted decision.
-version: "2026-07-14.1"
-captured_as_of: "2026-07-14"
-source: "ROB-643/751 baseline; ROB-839 crypto-recheck reports 2026-07-11/12; ROB-871 resting auto-approve seed"
+version: "2026-07-17.1"
+captured_as_of: "2026-07-17"
+source: "ROB-643/751 baseline; ROB-839 crypto-recheck reports 2026-07-11/12; ROB-871 resting auto-approve seed; ROB-932 crash-day advisory keys"
 
 authority:
   scope: judgment_policy_only
@@ -232,3 +232,20 @@ market_overrides:
   kr: {}
   us: {}
   crypto: {}
+
+# ROB-932 — crash-day advisory playbook. Trigger = index-open gap only
+# (KODEX200 open vs prev close, judged 09:00-09:05 KST). advisory-only, no
+# code enforcement; defensive_trim execution support is deferred (separate
+# issue). Cross-check against ROB-930 preopen shadow gap_risk verdict.
+crash_day:
+  trigger:
+    index_symbol: "069500"        # KODEX200
+    index_gap_pct_max: -3.0       # open vs prev close, 09:00-09:05 판정
+    # LIMITATION: intraday crashes (e.g. 2026-07-13: gap -0.8% -> intraday
+    # -9.8%) are NOT covered by this gap-only trigger. Documented gap, not
+    # an oversight — see docs/runbooks/crash-day-policy-mock-reps.md.
+  actions:
+    new_entry_hold: true          # NEW entries only; averaging-down deep rungs are EXEMPT (2026-07-16 midday dip-buys measured effective)
+    deep_rung_reprice_to_band_floor: true    # advisory: reprice deep rungs toward buy.deep_limit_pct_range floor
+    profit_trim_marketable_allowed: true     # advisory: profit-side trims may use marketable band (ROB-912 -2%)
+    defensive_brief_cross_check: true        # cross-check with ROB-930 preopen gap_risk verdict

--- a/docs/runbooks/crash-day-policy-mock-reps.md
+++ b/docs/runbooks/crash-day-policy-mock-reps.md
@@ -1,0 +1,155 @@
+# Crash-Day Advisory Policy — Manual kis_mock Reps (ROB-932)
+
+## What this is
+
+`config/trading_policy.yaml` now carries a `crash_day` advisory block
+(ROB-932, epic ROB-927). It is **judgment guidance only** — there is no code
+enforcement anywhere in the order/execution path, and this PR does not touch
+`order_execution` / `order_validation` / any `orders_*_variants` module. A
+session reads `get_trading_policy(...)`'s echoed `crash_day` section the same
+way it reads any other advisory threshold, and decides for itself whether to
+act on it.
+
+```yaml
+crash_day:
+  trigger:
+    index_symbol: "069500"        # KODEX200
+    index_gap_pct_max: -3.0       # open vs prev close, 09:00-09:05 판정
+  actions:
+    new_entry_hold: true
+    deep_rung_reprice_to_band_floor: true
+    profit_trim_marketable_allowed: true
+    defensive_brief_cross_check: true
+```
+
+## Confirmed decisions (do not re-litigate)
+
+- **Trigger = gap only.** KODEX200(069500) open vs prior close, judged in the
+  09:00–09:05 KST window. There is **no intraday trigger** in this version.
+- **LIMITATION**: intraday-only crashes are NOT covered. 2026-07-13 is the
+  reference case — gap was only -0.8% at the open (would not have fired) but
+  the index fell to -9.8% intraday. This is a known, documented gap in this
+  minimal version, not an oversight. A future version may add an intraday
+  trigger; that is out of scope here.
+- **`new_entry_hold` = NEW entries only.** Averaging-down / adding to an
+  existing position at a deeper rung is explicitly **exempt** — the
+  2026-07-16 midday dip-buys were measured effective and this policy must not
+  discourage that pattern.
+- **`defensive_trim` execution support is deferred.** This PR does not wire
+  any exit_intent / defensive_trim execution path. `profit_trim_marketable_allowed`
+  here means: an operator or session *may* choose to use the existing
+  ROB-912 marketable-sell band (-2%) for a profit-side trim during a crash
+  day, exactly as they could on any other day — the policy block does not
+  grant a new capability, it just flags that doing so is advisory-sanctioned
+  during a crash day. Whether to build dedicated defensive_trim execution
+  support is a separate, still-open design question.
+- **Cross-check, not override.** `defensive_brief_cross_check` means: when
+  `crash_day` fires, cross-reference the ROB-930 preopen shadow §0-R
+  `gap_risk` verdict (already wired into the preopen session) rather than
+  treating this trigger as a standalone signal.
+
+## Why manual reps first
+
+Per this repo's "verify manually before automating" convention, no
+scheduler, cron, or TaskIQ task is introduced by this policy addition, and
+none should be until a human has watched the trigger behave correctly across
+a real sample of trading days. **This runbook is for a session or operator
+to run by hand, once per trading day, for 4 weeks.** There is no code path
+that calls `get_trading_policy` on a timer for this purpose.
+
+## Daily procedure (repeat once per trading day, ~09:05 KST)
+
+1. **Judge the trigger.** Get KODEX200 (069500) today's open and yesterday's
+   close (any existing quote/candle MCP tool is fine — this is a read, no
+   new tool is introduced by ROB-932). Compute:
+
+   ```
+   gap_pct = (open - prev_close) / prev_close * 100
+   fired = gap_pct <= -3.0
+   ```
+
+2. **Record one line** (append to your own working log — this repo does not
+   ship a dedicated log file for this):
+
+   ```
+   [ROB-932-mock] date=YYYY-MM-DD gap=X.X% fired=yes|no | actions_taken(mock): ... | roundtrip_cost: ...
+   ```
+
+3. **If `fired=no`:** log the line with `actions_taken(mock): none` and stop.
+   This is the expected outcome most days — confirming **zero false-fires**
+   on non-crash days is itself part of what these reps are measuring.
+
+4. **If `fired=yes`:** using `account_mode="kis_mock"` (the shared
+   `place_order` / `modify_order` / `cancel_order` MCP tools' KIS mock
+   routing — `app/mcp_server/tooling/orders_registration.py`, backed by
+   `review.kis_mock_order_ledger`; never `kis_live`), perform up to three
+   mock actions and note each in the log line:
+
+   - **(a) Profit-side mock trim, marketable.** Pick one held KR position
+     that is in profit. Preview + place a marketable limit sell
+     (`account_mode="kis_mock"`) for a small trim, referencing the ROB-912
+     -2% band. Record the ledger id and round-trip cost (fees/slippage) in
+     the log line.
+   - **(b) New-entry hold, logged not executed.** For any candidate that
+     would otherwise be a NEW entry today, log
+     `actions_taken(mock): new_entry_held symbol=<X>` — do **not** place a
+     mock buy for it. (A candidate that is an averaging-down add to an
+     *existing* position is explicitly exempt from this hold — proceed with
+     that mock buy normally and log it as `deep_rung_add` instead.)
+   - **(c) One deep-rung reprice.** For one existing deep-rung resting order
+     (buy-side ladder), mock-modify (`modify_order`, `account_mode="kis_mock"`)
+     its price toward the `buy.deep_limit_pct_range` floor (-12%). Record
+     the old/new price and the ledger id.
+
+   See `docs/runbooks/kis-mock-scalping-smoke.md` / `kis-mock-reconciliation.md`
+   for the underlying `kis_mock` account-mode mechanics (gates, ledger,
+   reconcile) these reps ride on unmodified.
+
+   Cap this at one action per category per day — these are reps to observe
+   behavior, not a full defensive playbook execution (which remains
+   deferred).
+
+## 4-week scoring (after ~20 trading days)
+
+At the end of the 4-week window, an operator/session reviews the accumulated
+log lines and scores:
+
+- **`fired` day count** — how many days actually crossed the -3% gap
+  threshold, vs. how many days a session *felt* like it should have fired
+  (this is where the intraday-crash limitation, e.g. 2026-07-13-shaped days,
+  should surface as a gap in coverage, not a bug in this trigger).
+- **Defense effectiveness (%p)** — for `fired` days where a mock profit trim
+  (action a) was taken, compare the trim's realized price vs. the position's
+  price at end-of-day / next-day-open, expressed as percentage points of
+  downside avoided (or given up, if the trim turned out to be premature).
+- **Round-trip cost** — cumulative fees/slippage across all mock actions
+  taken during the window, to weigh against the defense effectiveness above.
+
+This scoring is the input to the still-open decision of whether to build
+real `defensive_trim` execution support (separate issue) and whether an
+intraday trigger is worth adding in a follow-up.
+
+## Explicitly out of scope for this policy addition
+
+- **No scheduler / automation wiring.** Nothing in `app/tasks/`,
+  `app/flows/`, or TaskIQ registers a periodic call for this trigger. All
+  reps above are manual, session/operator-initiated.
+- **No code enforcement.** `crash_day` is not read by any fail-closed guard,
+  order-validation path, or execution client. It is advisory data returned
+  by `get_trading_policy(market, lane)` alongside the existing
+  `{version, content_hash}` stamp.
+- **No `defensive_trim` exit_intent path.** See "Confirmed decisions" above.
+- **No live orders.** All reps in this runbook use `account_mode="kis_mock"`;
+  do not substitute a live order tool or `kis_live` account mode.
+
+## Related docs
+
+- `docs/runbooks/kis-mock-scalping-smoke.md`,
+  `docs/runbooks/kis-mock-reconciliation.md` — the KR `kis_mock` order
+  lifecycle/ledger/reconcile mechanics used for reps (a)/(c) above.
+- ROB-912 — marketable sell band (-2%) referenced by
+  `profit_trim_marketable_allowed`.
+- ROB-930 — preopen shadow §0-R `gap_risk` verdict referenced by
+  `defensive_brief_cross_check`.
+- `config/trading_policy.yaml` §`crash_day` — the source values this runbook
+  exercises.

--- a/tests/mcp_server/test_trading_policy_tool.py
+++ b/tests/mcp_server/test_trading_policy_tool.py
@@ -12,7 +12,7 @@ from tests._mcp_tooling_support import DummyMCP
 async def test_get_trading_policy_returns_thresholds_and_version():
     out = await get_trading_policy(market="kr", lane="buy")
     assert out["success"] is True
-    assert out["version"] == "2026-07-14.1"
+    assert out["version"] == "2026-07-17.1"
     assert out["content_hash"]
     assert out["thresholds"]["portfolio.sector_cluster_cap_pct"]["value"] == 10
     assert out["decision_rules"] == {}
@@ -23,7 +23,7 @@ async def test_get_trading_policy_returns_crypto_market_rules_and_stamp():
     out = await get_trading_policy(market="crypto", lane="buy")
 
     assert out["success"] is True
-    assert out["version"] == "2026-07-14.1"
+    assert out["version"] == "2026-07-17.1"
     assert len(out["content_hash"]) == 12
     assert out["market_rules"]["recovery_gate"]["min_conditions_met"] == 2
     assert out["market_rules"]["no_chasing"]["daily_change_pct_threshold"] is None
@@ -37,6 +37,19 @@ async def test_get_trading_policy_returns_sell_trim_preplace_rule():
     assert rule["tiers"][0]["action"] == "preplace_small_trim_ladder"
     assert rule["tiers"][1]["conditions"]["resistance_near_pct_max"] == 2
     assert rule["tiers"][2]["action"] == "register_watch"
+
+
+@pytest.mark.asyncio
+async def test_get_trading_policy_returns_crash_day_advisory_with_version_echo():
+    out = await get_trading_policy(market="kr", lane="buy")
+    assert out["success"] is True
+    assert out["crash_day"]["trigger"]["index_symbol"] == "069500"
+    assert out["crash_day"]["trigger"]["index_gap_pct_max"] == -3.0
+    assert out["crash_day"]["actions"]["new_entry_hold"] is True
+    # advisory keys are echoed with the same version/content_hash stamp as
+    # every other section of the response (ROB-932).
+    assert out["version"]
+    assert out["content_hash"]
 
 
 @pytest.mark.asyncio

--- a/tests/schemas/test_trading_policy_schema.py
+++ b/tests/schemas/test_trading_policy_schema.py
@@ -15,7 +15,7 @@ def _raw() -> dict:
 
 def test_shipped_config_validates():
     doc = TradingPolicyDocument.model_validate(_raw())
-    assert doc.version == "2026-07-14.1"
+    assert doc.version == "2026-07-17.1"
     # verbatim seed values from the playbook policy_keys
     assert doc.thresholds["portfolio.sector_cluster_cap_pct"].value == 10
     assert doc.thresholds["sell.loss_guard_min_multiple"].value == 1.01
@@ -128,5 +128,38 @@ def test_extra_threshold_key_rejected():
 def test_extra_crypto_market_rule_key_rejected():
     raw = _raw()
     raw["market_rules"]["crypto"]["no_chasing"]["bogus"] = True
+    with pytest.raises(ValidationError):
+        TradingPolicyDocument.model_validate(raw)
+
+
+def test_crash_day_trigger_and_actions_parse():
+    doc = TradingPolicyDocument.model_validate(_raw())
+    crash_day = doc.crash_day
+
+    assert crash_day.trigger.index_symbol == "069500"
+    assert crash_day.trigger.index_gap_pct_max == -3.0
+    assert crash_day.actions.new_entry_hold is True
+    assert crash_day.actions.deep_rung_reprice_to_band_floor is True
+    assert crash_day.actions.profit_trim_marketable_allowed is True
+    assert crash_day.actions.defensive_brief_cross_check is True
+
+
+def test_crash_day_extra_trigger_key_rejected():
+    raw = _raw()
+    raw["crash_day"]["trigger"]["bogus"] = 1
+    with pytest.raises(ValidationError):
+        TradingPolicyDocument.model_validate(raw)
+
+
+def test_crash_day_extra_actions_key_rejected():
+    raw = _raw()
+    raw["crash_day"]["actions"]["bogus"] = True
+    with pytest.raises(ValidationError):
+        TradingPolicyDocument.model_validate(raw)
+
+
+def test_crash_day_missing_block_rejected():
+    raw = _raw()
+    del raw["crash_day"]
     with pytest.raises(ValidationError):
         TradingPolicyDocument.model_validate(raw)

--- a/tests/services/order_proposals/test_dispatch.py
+++ b/tests/services/order_proposals/test_dispatch.py
@@ -437,10 +437,10 @@ async def test_dispatch_auto_eligible_buy_or_sell_rests_without_approval(
     refreshed, rungs = await service.get_proposal(group.proposal_id)
     assert rungs[0].state == "resting"
     assert refreshed.approved_by_telegram_user_id is None
-    assert refreshed.source_asof["auto_approved"]["policy_version"] == "2026-07-14.1"
+    assert refreshed.source_asof["auto_approved"]["policy_version"] == "2026-07-17.1"
     text, keyboard, _chat_id = notifier.sent_messages[0]
     assert "자동 접수됨" in text
-    assert "auto:policy@2026-07-14.1" in text
+    assert "auto:policy@2026-07-17.1" in text
     assert keyboard["inline_keyboard"][0][0]["text"] == "취소"
     assert keyboard["inline_keyboard"][0][0]["callback_data"].startswith("vc:")
 

--- a/tests/services/test_trading_policy_service.py
+++ b/tests/services/test_trading_policy_service.py
@@ -5,7 +5,7 @@ from app.services import trading_policy_service as svc
 
 def test_version_stamp_has_version_and_hash():
     stamp = svc.policy_version_stamp()
-    assert stamp["version"] == "2026-07-14.1"
+    assert stamp["version"] == "2026-07-17.1"
     assert len(stamp["content_hash"]) == 12
 
 
@@ -15,7 +15,7 @@ def test_content_hash_stable_across_calls():
 
 def test_get_policy_for_buy_kr_includes_cap_and_version():
     view = svc.get_policy_for("kr", "buy")
-    assert view["version"] == "2026-07-14.1"
+    assert view["version"] == "2026-07-17.1"
     assert view["content_hash"]
     t = view["thresholds"]
     # buy lane references these (playbook lane tags)
@@ -31,7 +31,7 @@ def test_get_policy_for_buy_kr_includes_cap_and_version():
 def test_get_policy_for_crypto_buy_exposes_report_derived_market_rules():
     view = svc.get_policy_for("crypto", "buy")
 
-    assert view["version"] == "2026-07-14.1"
+    assert view["version"] == "2026-07-17.1"
     assert set(view["market_rules"]) == {
         "recovery_gate",
         "support_resistance",
@@ -96,6 +96,23 @@ def test_market_override_applied(monkeypatch, tmp_path):
     t = svc.get_policy_for("us", "discovery")["thresholds"]
     assert t["screen.rsi_max"]["value"] == 55
     assert t["screen.rsi_max"]["source"] == "override"
+
+
+def test_get_policy_for_includes_crash_day_advisory_with_version_stamp():
+    view = svc.get_policy_for("kr", "buy")
+    assert view["version"] == svc.policy_version_stamp()["version"]
+    assert view["content_hash"] == svc.policy_content_hash()
+    crash_day = view["crash_day"]
+    assert crash_day["trigger"]["index_symbol"] == "069500"
+    assert crash_day["trigger"]["index_gap_pct_max"] == -3.0
+    assert crash_day["actions"]["new_entry_hold"] is True
+
+
+def test_get_policy_for_crash_day_present_regardless_of_market_lane():
+    # crash_day is a single global advisory trigger, not market/lane-scoped.
+    us_sell = svc.get_policy_for("us", "sell")["crash_day"]
+    crypto_discovery = svc.get_policy_for("crypto", "discovery")["crash_day"]
+    assert us_sell == crypto_discovery
 
 
 def test_sector_cluster_for():


### PR DESCRIPTION
## Summary

Adds a minimal, advisory-only `crash_day` playbook to
`config/trading_policy.yaml` (ROB-932, epic ROB-927) — a gap-down trigger a
session or operator can read via `get_trading_policy(...)` and cross-check
judgment against. **No code enforcement is added anywhere** — this PR does
not touch `order_execution`, `order_validation`, or any `orders_*_variants`
module, and no fail-closed guard changes.

## User-confirmed decisions (locked, not re-litigated by this PR)

- **Trigger = gap only.** KODEX200 (069500) open vs prior close, judged in
  the 09:00–09:05 KST window. There is intentionally **no intraday
  trigger** in this minimal version.
- **LIMITATION (documented, not fixed here):** 2026-07-13-shaped days are
  **not covered** — that day's open gap was only -0.8% (would not have
  fired) but the index fell to -9.8% intraday. Both `config/trading_policy.yaml`
  and the new runbook call this out explicitly as a known gap.
- **`new_entry_hold` = NEW entries only.** Averaging-down / adding to an
  existing position at a deeper rung is explicitly exempt — the 2026-07-16
  midday dip-buys were measured effective and this policy must not
  discourage that pattern.
- **`defensive_trim` execution support is deferred.** This PR does not add
  or touch any exit_intent / defensive_trim execution path.
  `profit_trim_marketable_allowed` only flags that using the existing
  ROB-912 marketable-sell band (-2%) for a profit-side trim is
  advisory-sanctioned during a crash day — it grants no new capability.

## Changes

- `config/trading_policy.yaml` — new top-level `crash_day: {trigger, actions}`
  block; `version` bumped `2026-07-14.1` → `2026-07-17.1`.
- `app/schemas/trading_policy.py` — `CrashDayTrigger` / `CrashDayActions` /
  `CrashDayPolicy` (strict, `extra="forbid"`), required `crash_day` field on
  `TradingPolicyDocument`.
- `app/services/trading_policy_service.py` — `get_policy_for(...)` now
  echoes `crash_day` unconditionally (it's a single global advisory trigger,
  not market/lane-scoped), alongside the existing `{version, content_hash}`
  stamp. Flows straight through to the `get_trading_policy` MCP tool with no
  tool-layer changes needed.
- `docs/runbooks/crash-day-policy-mock-reps.md` (new) — 4-week manual
  `account_mode="kis_mock"` reps procedure: daily trigger judgment + log
  line format, mock actions on fired days (profit-trim / new-entry-hold /
  deep-rung reprice), 4-week scoring criteria. Explicit: no scheduler/cron/
  TaskIQ wiring — session/operator-run only.
- Version-string bump propagated to existing hardcoded-version test
  assertions (`tests/schemas/test_trading_policy_schema.py`,
  `tests/services/test_trading_policy_service.py`,
  `tests/mcp_server/test_trading_policy_tool.py`,
  `tests/services/order_proposals/test_dispatch.py`).

## Test plan

- [x] New RED tests written first (schema strict-key rejection, service
      echo, MCP tool echo) — confirmed failing before implementation.
- [x] `uv run pytest tests/ -k "trading_policy" -v` — 33 passed.
- [x] Broader sweep (`tests/schemas/`, `tests/services/order_proposals/`,
      `test_operating_briefing_policy_version.py`,
      `test_shadow_replay_profile.py`, `test_loss_cut_policy_and_settings.py`,
      `test_mcp_profiles.py`) — 637 passed.
- [x] `make lint` (ruff check + format + ty) — all green.
- [x] `git diff --check` — clean.
- [x] `uv run alembic heads` — single head, unchanged (migration 0).

## Not done in this PR (by design)

- No intraday crash trigger.
- No `defensive_trim` execution / exit_intent wiring.
- No scheduler/cron/TaskIQ automation for the mock reps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)