### PR TITLE
fix(ROB-936): export BINANCE_ env prefix in mcp startup wrapper

### DIFF
--- a/docs/runbooks/binance-demo-scalping-llm-session.md
+++ b/docs/runbooks/binance-demo-scalping-llm-session.md
@@ -30,3 +30,7 @@
 - spread/data-age는 **서버 관측값만** 판정에 사용한다. caller/LLM이 spread·age를 입력할 수 없고,
   관측 실패 시 0/0으로 합성하지 않고 `market_conditions_unavailable`로 fail-close 한다(ROB-841).
 - 같은 날 결과는 `session_tag="llm"`로 분리 집계(규칙 baseline과 비교; surfacing은 D-PR2).
+
+## MCP 배포 반영 절차
+MCP 배포 반영 절차 = ops/native/scripts sync → mcp 재기동, BINANCE_*는 래퍼의 접두사 export에 의존. `BINANCE_*` 접두사(예: `BINANCE_FUTURES_DEMO_ENABLED` 등)를 통해 노출되는 환경 변수들은 MCP 기동 래퍼의 접두사 export 기능을 거쳐 `os.environ`에 공급되므로, 배포 시 스크립트 동기화와 MCP 재기동이 필수적이다.
+

--- a/docs/runbooks/binance-demo-scalping-llm-session.md
+++ b/docs/runbooks/binance-demo-scalping-llm-session.md
@@ -33,4 +33,3 @@
 
 ## MCP 배포 반영 절차
 MCP 배포 반영 절차 = ops/native/scripts sync → mcp 재기동, BINANCE_*는 래퍼의 접두사 export에 의존. `BINANCE_*` 접두사(예: `BINANCE_FUTURES_DEMO_ENABLED` 등)를 통해 노출되는 환경 변수들은 MCP 기동 래퍼의 접두사 export 기능을 거쳐 `os.environ`에 공급되므로, 배포 시 스크립트 동기화와 MCP 재기동이 필수적이다.
-

--- a/ops/native/scripts/run-mcp.sh
+++ b/ops/native/scripts/run-mcp.sh
@@ -24,7 +24,7 @@ source "${AUTO_TRADER_BASE:-$HOME/services/auto_trader}/scripts/common.sh"
 
 # _export_selected_env_prefixes may pull MCP_PORT from the env file; export after
 # the prefix call so the per-color value wins.
-_export_selected_env_prefixes MCP_
+_export_selected_env_prefixes MCP_ BINANCE_
 export MCP_PORT="$PORT"
 # ROB-469 PR3: per-color liveness heartbeat the watchdog polls.
 export MCP_HEARTBEAT_PATH="${AUTO_TRADER_BASE:-$HOME/services/auto_trader}/state/heartbeat/mcp-${COLOR}.json"

--- a/tests/scripts/test_native_run_wrappers.py
+++ b/tests/scripts/test_native_run_wrappers.py
@@ -60,6 +60,7 @@ def _uv_stub_dir(tmp_path: Path) -> Path:
         'echo "MCP_AUTH_TOKEN=${MCP_AUTH_TOKEN:-unset}"\n'
         'echo "AUTO_TRADER_CURRENT=${AUTO_TRADER_CURRENT:-unset}"\n'
         'echo "PWD=$(pwd)"\n'
+        "env\n"
     )
     stub.chmod(0o755)
     return bin_dir
@@ -148,6 +149,33 @@ def test_run_mcp_cds_into_color_current(tmp_path: Path) -> None:
     proc = _run(RUN_MCP, "green", {}, tmp_path)
     assert proc.returncode == 0
     assert "current-green" in proc.stdout
+
+
+def test_run_mcp_exports_binance_env_vars(tmp_path: Path) -> None:
+    color = "blue"
+    base = _build_base(tmp_path, color)
+    env_file = base / "shared" / ".env.prod.native"
+    env_file.write_text(
+        "MCP_SOME_VAR=mcp_val\n"
+        "BINANCE_FUTURES_DEMO_ENABLED=true\n"
+        "BINANCE_SOME_OTHER=binance_val\n"
+        "OTHER_VAR=should_not_export\n"
+    )
+    bin_dir = _uv_stub_dir(tmp_path)
+    env = {
+        "PATH": f"{bin_dir}:{os.environ['PATH']}",
+        "HOME": str(tmp_path),
+        "AUTO_TRADER_BASE": str(base),
+        "AUTO_TRADER_COLOR": color,
+    }
+    proc = subprocess.run(
+        ["bash", str(RUN_MCP)], check=False, capture_output=True, text=True, env=env
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert "MCP_SOME_VAR=mcp_val" in proc.stdout
+    assert "BINANCE_FUTURES_DEMO_ENABLED=true" in proc.stdout
+    assert "BINANCE_SOME_OTHER=binance_val" in proc.stdout
+    assert "OTHER_VAR" not in proc.stdout
 
 
 # ----- run-mcp-profile -------------------------------------------------------


### PR DESCRIPTION
MCP launcher run-mcp.sh now exports BINANCE_* environment variables, resolving the preflight fail-close issue for binance demo scalping decisions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)