### PR TITLE
fix(ROB-933): KIS filled_at KST trade-day data-quality (aware fallback + invariant + trade_day_kst)

### DIFF
--- a/app/core/timezone.py
+++ b/app/core/timezone.py
@@ -5,7 +5,7 @@ This module provides KST (Korea Standard Time) as the default timezone
 for all datetime operations throughout the application.
 """
 
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta, timezone
 
 # KST (한국 표준시, UTC+9)
 KST = timezone(timedelta(hours=9))
@@ -41,6 +41,17 @@ def to_kst_naive(dt: datetime) -> datetime:
     if dt.tzinfo is not None:
         return dt.astimezone(KST).replace(tzinfo=None)
     return dt
+
+
+def trade_day_kst(dt: datetime) -> str:
+    """Return the KST trade day for an instant persisted as TIMESTAMPTZ.
+
+    Execution-ledger timestamps are instants.  Treat legacy naive values as UTC
+    rather than letting the host/session timezone change their reported day.
+    """
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=UTC)
+    return dt.astimezone(KST).strftime("%Y%m%d")
 
 
 def format_datetime(dt: datetime | None = None, fmt: str = "%Y-%m-%d %H:%M:%S") -> str:

--- a/app/mcp_server/README.md
+++ b/app/mcp_server/README.md
@@ -569,11 +569,11 @@ allowlist.
     on success; `{"success": False, "error": str}` on failure.
   - **No broker mutation.** No order mutation. No DB write.
 
-**Sanitized fill shape (20 keys, identical to the CLI output):**
+**Sanitized fill shape (21 keys, identical to the CLI output):**
 `ledger_id`, `event_key`, `broker`, `account_mode`, `venue`, `instrument_type`,
 `market`, `symbol`, `raw_symbol`, `side`, `filled_qty`, `filled_price`,
 `filled_notional`, `currency`, `broker_order_id`, `fill_seq`, `correlation_id`,
-`source`, `filled_at`, `created_at`. **`raw_payload_json` is never emitted**
+`source`, `filled_at`, `trade_day_kst`, `created_at`. **`raw_payload_json` is never emitted**
 (security constraint — same as the CLI).
 
 **Validation errors:**

--- a/app/schemas/execution_ledger.py
+++ b/app/schemas/execution_ledger.py
@@ -7,7 +7,16 @@ from datetime import datetime
 from decimal import Decimal
 from typing import Literal
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    computed_field,
+    field_validator,
+    model_validator,
+)
+
+from app.core.timezone import trade_day_kst
 
 Broker = Literal["kis", "upbit", "toss"]
 ReconcileRunBroker = Literal["kis", "upbit"]
@@ -91,6 +100,12 @@ class ExecutionLedgerRead(BaseModel):
     cost_basis_notional: Decimal | None = None
     realized_profit: Decimal | None = None
     realized_profit_rate: Decimal | None = None
+
+    @computed_field
+    @property
+    def trade_day_kst(self) -> str:
+        """Explicit KST grouping key for API consumers of UTC TIMESTAMPTZ fills."""
+        return trade_day_kst(self.filled_at)
 
 
 class SourceBreakdown(BaseModel):

--- a/app/services/execution_ledger/fill_event_sanitizer.py
+++ b/app/services/execution_ledger/fill_event_sanitizer.py
@@ -18,6 +18,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from app.core.timezone import trade_day_kst
+
 
 def derive_market(instrument_type: str) -> str:
     """``instrument_type`` 컬럼을 poller 친화적인 market 코드로 변환.
@@ -63,6 +65,7 @@ def sanitize_fill(row: Any) -> dict[str, Any]:
         ),
         "source": row.source,
         "filled_at": row.filled_at.isoformat(),
+        "trade_day_kst": trade_day_kst(row.filled_at),
         "created_at": row.created_at.isoformat(),
     }
 

--- a/app/services/execution_ledger/fill_event_sanitizer.py
+++ b/app/services/execution_ledger/fill_event_sanitizer.py
@@ -2,7 +2,7 @@
 
 The CLI (``scripts/list_recent_fill_events.py``) and the MCP tool
 (``app/mcp_server/tooling/execution_ledger_events.py``) both need to render
-``ExecutionLedger`` rows into the same 20-key triage-friendly dict shape.
+``ExecutionLedger`` rows into the same 21-key triage-friendly dict shape.
 
 That shape lives here as the **single source of truth**: both callers import
 ``sanitize_fill`` / ``derive_market`` from this module so the JSON output stays

--- a/app/services/execution_ledger/normalizers.py
+++ b/app/services/execution_ledger/normalizers.py
@@ -8,7 +8,7 @@ from datetime import datetime
 from decimal import Decimal
 from typing import Any
 
-from app.core.timezone import KST
+from app.core.timezone import KST, trade_day_kst
 from app.schemas.execution_ledger import ExecutionLedgerUpsert
 
 SENSITIVE_KEY_MARKERS = (
@@ -48,23 +48,53 @@ def _to_decimal(value: object, default: str = "0") -> Decimal:
         return Decimal(default)
 
 
-def _parse_filled_at(value: object) -> datetime:
+def _parse_kis_order_timestamp(ord_dt: object, ord_tmd: object) -> datetime:
+    date_text = str(ord_dt or "").strip()
+    time_text = str(ord_tmd or "000000").strip()
+    if len(date_text) != 8 or not date_text.isdigit():
+        raise ValueError("filled_at is empty and ord_dt is invalid")
+    if len(time_text) < 6 or not time_text[:6].isdigit():
+        raise ValueError("filled_at is empty and ord_tmd is invalid")
+    try:
+        return datetime.strptime(
+            f"{date_text} {time_text[:6]}", "%Y%m%d %H%M%S"
+        ).replace(tzinfo=KST)
+    except ValueError as exc:
+        raise ValueError(
+            "filled_at is empty and KIS order timestamp is invalid"
+        ) from exc
+
+
+def _parse_filled_at(
+    value: object,
+    *,
+    ord_dt: object | None = None,
+    ord_tmd: object | None = None,
+) -> datetime:
     text = str(value or "").strip()
     if not text:
-        return datetime.now(tz=KST)
-    try:
-        parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
-    except ValueError:
-        if len(text) == 8:
-            try:
-                parsed = datetime.strptime(text, "%Y%m%d").replace(tzinfo=KST)
-            except ValueError:
-                parsed = datetime.now(tz=KST)
-        else:
-            parsed = datetime.now(tz=KST)
+        parsed = _parse_kis_order_timestamp(ord_dt, ord_tmd)
+    else:
+        try:
+            parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+        except ValueError:
+            if len(text) == 8 and text.isdigit():
+                try:
+                    parsed = datetime.strptime(text, "%Y%m%d").replace(tzinfo=KST)
+                except ValueError as exc:
+                    raise ValueError(f"invalid filled_at: {text!r}") from exc
+            else:
+                raise ValueError(f"invalid filled_at: {text!r}") from None
     if parsed.tzinfo is None:
-        return parsed.replace(tzinfo=KST)
-    return parsed.astimezone(KST)
+        parsed = parsed.replace(tzinfo=KST)
+    else:
+        parsed = parsed.astimezone(KST)
+    if ord_dt not in (None, "") and trade_day_kst(parsed) != str(ord_dt).strip():
+        raise ValueError(
+            "KST trade day mismatch: "
+            f"filled_at={trade_day_kst(parsed)} ord_dt={str(ord_dt).strip()}"
+        )
+    return parsed
 
 
 def _redact_sensitive_keys(payload: Any) -> Any:
@@ -281,6 +311,8 @@ def _normalize_kis_domestic_filled(order: dict[str, Any]) -> dict[str, Any] | No
         "account": "kis",
         "order_id": str(order.get("ord_no") or order.get("odno") or ""),
         "filled_at": _kis_datetime(ord_dt, ord_tmd),
+        "ord_dt": ord_dt,
+        "ord_tmd": ord_tmd,
         "fill_seq": _domestic_fill_seq(order),
         "venue": "krx",
         "raw_payload_json": _redact_sensitive_keys(order),
@@ -309,6 +341,8 @@ def _normalize_kis_overseas_filled(order: dict[str, Any]) -> dict[str, Any] | No
         "account": "kis_overseas",
         "order_id": str(order.get("odno") or order.get("ord_no") or ""),
         "filled_at": _kis_datetime(ord_dt, ord_tmd),
+        "ord_dt": ord_dt,
+        "ord_tmd": ord_tmd,
         "fill_seq": _overseas_fill_seq(order),
         "venue": str(order.get("ovrs_excg_cd") or order.get("excg_cd") or "NASD"),
         "raw_payload_json": _redact_sensitive_keys(order),
@@ -347,7 +381,11 @@ def to_execution_ledger_upsert(
         if normalized.get("fee") is not None
         else None,
         fee_currency=normalized.get("currency"),
-        filled_at=_parse_filled_at(normalized.get("filled_at")),
+        filled_at=_parse_filled_at(
+            normalized.get("filled_at"),
+            ord_dt=normalized.get("ord_dt"),
+            ord_tmd=normalized.get("ord_tmd"),
+        ),
         currency=normalized["currency"],
         correlation_id=correlation_id or normalized.get("correlation_id"),
         source=source,

--- a/app/services/execution_ledger/reconciler.py
+++ b/app/services/execution_ledger/reconciler.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import uuid
 from collections.abc import Awaitable, Callable
 from datetime import UTC, datetime, timedelta
@@ -18,6 +19,8 @@ from app.schemas.execution_ledger import (
 from app.services.execution_ledger.normalizers import to_execution_ledger_upsert
 from app.services.execution_ledger.repository import ExecutionLedgerRepository
 from app.services.filled_orders_service import fetch_filled_orders
+
+logger = logging.getLogger(__name__)
 
 Broker = Literal["kis", "upbit"]
 FilledOrdersFetcher = Callable[..., Awaitable[dict[str, Any]]]
@@ -162,9 +165,21 @@ class ExecutionLedgerReconciler:
             )
         rows = result.get("orders") or result.get("items") or []
         upserts: list[ExecutionLedgerUpsert] = []
+        malformed_filled_at_rows = 0
         for row in rows:
-            upsert = to_execution_ledger_upsert(
-                row, broker=broker, source_run_id=source_run_id
-            )
+            try:
+                upsert = to_execution_ledger_upsert(
+                    row, broker=broker, source_run_id=source_run_id
+                )
+            except ValueError as exc:
+                if "filled_at" not in str(exc):
+                    raise
+                malformed_filled_at_rows += 1
+                continue
             upserts.append(upsert)
+        if malformed_filled_at_rows:
+            logger.warning(
+                "execution ledger skipped %d malformed filled_at row(s)",
+                malformed_filled_at_rows,
+            )
         return upserts

--- a/app/services/filled_orders_service.py
+++ b/app/services/filled_orders_service.py
@@ -41,9 +41,9 @@ def _resolve_kst_window(
 def _parse_upbit_fill_datetime(value: object) -> datetime | None:
     """Strictly parse an Upbit fill timestamp for window filtering.
 
-    Execution-ledger normalizers may default malformed provider timestamps to
-    ``now`` for persistence compatibility, but the legacy n8n filled-orders
-    surface must skip rows whose provider timestamp cannot be parsed.
+    Execution-ledger normalizers fail closed on malformed provider timestamps,
+    and the legacy n8n filled-orders surface likewise skips rows whose provider
+    timestamp cannot be parsed.
     """
     text = str(value or "").strip()
     if not text:

--- a/tests/mcp_server/test_execution_ledger_fill_events_tool.py
+++ b/tests/mcp_server/test_execution_ledger_fill_events_tool.py
@@ -37,6 +37,7 @@ EXPECTED_FILL_KEYS: set[str] = {
     "correlation_id",
     "source",
     "filled_at",
+    "trade_day_kst",
     "created_at",
 }
 
@@ -169,6 +170,7 @@ async def test_tool_returns_sanitized_fills_with_expected_shape(
     assert fill["market"] == "crypto"
     assert fill["filled_qty"] == "0.01"
     assert fill["correlation_id"] == "corr-uuid-1"
+    assert fill["trade_day_kst"] == "20260707"
 
     # repo가 호출되었는지 + source 기본값 websocket이 그대로 전달되었는지
     assert len(fake_repo.calls) == 1

--- a/tests/mcp_server/tooling/test_toss_live_ledger.py
+++ b/tests/mcp_server/tooling/test_toss_live_ledger.py
@@ -9,7 +9,7 @@ from uuid import uuid4
 
 import pytest
 import pytest_asyncio
-from sqlalchemy import delete, select
+from sqlalchemy import delete, select, text
 
 from app.models.execution_ledger import ExecutionLedger
 from app.models.review import TossLiveOrderLedger
@@ -441,6 +441,85 @@ async def test_terminal_ledger_projection_failure_is_retried_by_sweep(db_session
     }
     assert rung.state == "filled"
     assert rung.filled_qty == Decimal("2")
+
+
+async def test_projection_repair_converges_after_timestamptz_kst_round_trip(
+    db_session,
+):
+    """ROB-933 diagnostic: execution-ledger trade day cannot gate Toss repair.
+
+    This uses PostgreSQL's TIMESTAMPTZ conversion with the session set to KST;
+    it deliberately does not derive the date through Python ``astimezone``.
+    The terminal Toss ledger row and resting rung have the same broker id, so
+    the sweep must converge even though the execution-ledger fill is stored on
+    the preceding UTC date.
+    """
+    from app.mcp_server.tooling import toss_live_ledger as mod
+
+    proposal_id, toss_row = await _proposal_accepted_row(db_session, suffix="rob933")
+    filled_at_utc = datetime(2026, 7, 15, 15, 17, 28, tzinfo=UTC)
+    db_session.add(
+        ExecutionLedger(
+            broker="kis",
+            account_mode="live",
+            venue="krx",
+            instrument_type="equity_kr",
+            symbol="214150",
+            raw_symbol="214150",
+            side="sell",
+            broker_order_id=toss_row.broker_order_id,
+            fill_seq=0,
+            filled_qty=Decimal("2"),
+            filled_price=Decimal("100000"),
+            filled_notional=Decimal("200000"),
+            filled_at=filled_at_utc,
+            currency="KRW",
+            source="reconciler",
+        )
+    )
+    toss_row.status = "filled"
+    toss_row.filled_qty = Decimal("2")
+    await db_session.commit()
+
+    await db_session.execute(text("SET TIME ZONE 'Asia/Seoul'"))
+    persisted_kst_day = (
+        await db_session.execute(
+            text(
+                "SELECT to_char(filled_at, 'YYYYMMDD') "
+                "FROM review.execution_ledger "
+                "WHERE broker_order_id = :order_id"
+            ),
+            {"order_id": toss_row.broker_order_id},
+        )
+    ).scalar_one()
+    assert persisted_kst_day == "20260716"
+
+    with (
+        patch.object(
+            mod.TossLiveOrderLedgerService,
+            "reopen_anomalies_for_reconcile",
+            new=AsyncMock(
+                return_value={
+                    "rows": [],
+                    "dry_run": False,
+                    "reopened": 0,
+                    "candidates": 0,
+                }
+            ),
+        ),
+        patch.object(
+            mod.TossLiveOrderLedgerService, "list_open", new=AsyncMock(return_value=[])
+        ),
+    ):
+        repaired = await mod.toss_reconcile_orders_impl(dry_run=False)
+
+    rung = await _proposal_rung(db_session, proposal_id)
+    assert repaired["proposal_projection_repair"] == {
+        "candidates": 1,
+        "converged": 1,
+        "failed": 0,
+    }
+    assert rung.state == "filled"
 
 
 @pytest.mark.parametrize("terminal_status", ["filled", "cancelled"])

--- a/tests/routers/test_invest_fills_router.py
+++ b/tests/routers/test_invest_fills_router.py
@@ -137,6 +137,7 @@ def test_recent_fills_returns_200_with_items():
     assert data["count"] == 1
     assert data["items"][0]["symbol"] == "005930"
     assert data["items"][0]["source"] == "reconciler"
+    assert data["items"][0]["trade_day_kst"] == "20260510"
     # K2: enriched fields
     assert "data_state" in data
     assert "source_breakdown" in data

--- a/tests/scripts/test_list_recent_fill_events_cli.py
+++ b/tests/scripts/test_list_recent_fill_events_cli.py
@@ -35,6 +35,7 @@ EXPECTED_FILL_KEYS: set[str] = {
     "correlation_id",
     "source",
     "filled_at",
+    "trade_day_kst",
     "created_at",
 }
 
@@ -220,6 +221,7 @@ async def test_collect_emits_exact_shape_for_crypto_row(
     assert fill["filled_notional"] == "1000000"
     assert fill["correlation_id"] == "corr-uuid-1"
     assert fill["filled_at"] == "2026-07-07T00:00:00+00:00"
+    assert fill["trade_day_kst"] == "20260707"
     assert fill["created_at"] == "2026-07-07T00:00:01+00:00"
 
     # JSON 직렬화 가능 + secret 값 누출 없음

--- a/tests/services/execution_ledger/test_fill_event_sanitizer.py
+++ b/tests/services/execution_ledger/test_fill_event_sanitizer.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from decimal import Decimal
+from types import SimpleNamespace
+
+from app.services.execution_ledger.fill_event_sanitizer import sanitize_fill
+
+
+def test_sanitize_fill_exposes_explicit_kst_trade_day() -> None:
+    row = SimpleNamespace(
+        id=933,
+        broker="kis",
+        account_mode="live",
+        venue="krx",
+        instrument_type="equity_kr",
+        symbol="214150",
+        raw_symbol="214150",
+        side="sell",
+        filled_qty=Decimal("2"),
+        filled_price=Decimal("100000"),
+        filled_notional=Decimal("200000"),
+        currency="KRW",
+        broker_order_id="rob933-sanitizer",
+        fill_seq=0,
+        correlation_id=None,
+        source="reconciler",
+        filled_at=datetime(2026, 7, 15, 15, 17, 28, tzinfo=UTC),
+        created_at=datetime(2026, 7, 15, 15, 18, tzinfo=UTC),
+    )
+
+    assert sanitize_fill(row)["trade_day_kst"] == "20260716"

--- a/tests/services/execution_ledger/test_normalizers.py
+++ b/tests/services/execution_ledger/test_normalizers.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
+from datetime import datetime
 from decimal import Decimal
 
+import pytest
+
+from app.core.timezone import KST
 from app.services.execution_ledger.normalizers import (
     MAX_SQL_INT32,
     _domestic_fill_seq,
@@ -41,6 +45,67 @@ def test_upbit_normalizer_redacts_and_maps_execution_upsert() -> None:
     assert upsert.broker_order_id == "upbit-order-1"
     assert upsert.fill_seq == 0
     assert upsert.filled_notional == Decimal("1000000.0")
+
+
+def test_kis_empty_filled_at_uses_kst_order_date_and_time() -> None:
+    upsert = to_execution_ledger_upsert(
+        {
+            "symbol": "214150",
+            "raw_symbol": "214150",
+            "instrument_type": "equity_kr",
+            "side": "sell",
+            "price": "100000",
+            "quantity": "2",
+            "total_amount": "200000",
+            "currency": "KRW",
+            "account": "kis",
+            "order_id": "rob933-empty-filled-at",
+            "filled_at": "",
+            "ord_dt": "20260716",
+            "ord_tmd": "001728",
+        }
+    )
+
+    assert upsert.filled_at == datetime(2026, 7, 16, 0, 17, 28, tzinfo=KST)
+
+
+def test_kis_filled_at_rejects_trade_day_drift_from_order_date() -> None:
+    with pytest.raises(ValueError, match="KST trade day"):
+        to_execution_ledger_upsert(
+            {
+                "symbol": "214150",
+                "raw_symbol": "214150",
+                "instrument_type": "equity_kr",
+                "side": "sell",
+                "price": "100000",
+                "quantity": "2",
+                "total_amount": "200000",
+                "currency": "KRW",
+                "account": "kis",
+                "order_id": "rob933-day-drift",
+                "filled_at": "2026-07-15T15:17:28+00:00",
+                "ord_dt": "20260715",
+            }
+        )
+
+
+def test_malformed_filled_at_fails_closed_instead_of_using_current_time() -> None:
+    with pytest.raises(ValueError, match="filled_at"):
+        to_execution_ledger_upsert(
+            {
+                "symbol": "214150",
+                "raw_symbol": "214150",
+                "instrument_type": "equity_kr",
+                "side": "sell",
+                "price": "100000",
+                "quantity": "2",
+                "total_amount": "200000",
+                "currency": "KRW",
+                "account": "kis",
+                "order_id": "rob933-malformed-filled-at",
+                "filled_at": "definitely-not-a-timestamp",
+            }
+        )
 
 
 # --- Issue 1 regression: cancel+partial fill acceptance ---

--- a/tests/services/execution_ledger/test_reconciler.py
+++ b/tests/services/execution_ledger/test_reconciler.py
@@ -172,3 +172,42 @@ async def test_reconciler_rejects_fetch_errors_and_records_failed_run(
     assert len(repo.runs) == 1
     assert "crypto" in repo.runs[0].error_summary
     assert "truncated window" in repo.runs[0].error_summary
+
+
+@pytest.mark.asyncio
+async def test_reconciler_skips_malformed_filled_at_with_one_run_warning(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    monkeypatch.setattr(
+        "app.services.execution_ledger.reconciler.settings",
+        SimpleNamespace(EXECUTION_LEDGER_COMMIT_ENABLED=False),
+    )
+
+    async def fetcher(**_kwargs):  # noqa: ANN003
+        return {
+            "orders": [
+                {
+                    "symbol": "214150",
+                    "raw_symbol": "214150",
+                    "instrument_type": "equity_kr",
+                    "side": "sell",
+                    "price": "100000",
+                    "quantity": "2",
+                    "total_amount": "200000",
+                    "currency": "KRW",
+                    "account": "kis",
+                    "order_id": f"bad-filled-at-{index}",
+                    "filled_at": "not-a-timestamp",
+                }
+                for index in range(2)
+            ]
+        }
+
+    with caplog.at_level("WARNING"):
+        diff = await ExecutionLedgerReconciler(FakeRepo(), fetcher=fetcher).run(
+            "kis", dry_run=True
+        )
+
+    assert diff.would_insert == 0
+    warnings = [r.message for r in caplog.records if "malformed filled_at" in r.message]
+    assert warnings == ["execution ledger skipped 2 malformed filled_at row(s)"]


### PR DESCRIPTION
## 진단 우선 (STEP1 = 분기 B 확정)
1차 수정이 적대검증 FAIL(약한 RED·미배선·인과 미확립) 후, 진단부터 재수립. **실 PostgreSQL TIMESTAMPTZ 왕복**으로 재현: UTC `2026-07-15T15:17:28+00:00`가 세션 Asia/Seoul에서 트레이드일 `20260716`으로 정확 복원되고, broker_order_id 매칭 terminal rung은 `proposal_projection_repair {candidates:1, converged:1}`로 resting→filled **정상 수렴**.
→ repair 후보 조인은 `correlation_id OR broker_order_id`(+상태/계정/심볼/마켓)만 보고 **filled_at을 참조하지 않음**. 따라서 34208 rung-resting(중복매도 위험의 실제 증상)의 원인은 filled_at 날짜가 **아니라** projection-repair 링크 조인 실패 = **ROB-900 소관**(prod 실측: terminal Toss 297건 중 proposal evidence 링크 17건뿐).

## ROB-933 확정 범위 (data-quality only)
- 빈 `filled_at` → KIS `ord_dt`/`ord_tmd` **KST-aware fallback**
- malformed `filled_at` → **fail-closed**(현재시각 대입 금지, ValueError), reconcile은 run당 1회 집계 경고 후 해당 행 제외
- **KST trade-day invariant**: UTC instant 복원 KST일 ≠ `ord_dt`면 거부(전일·익일 drift **양방향**)
- API DTO(`schemas/execution_ledger.py`) + fill-event sanitizer에 **`trade_day_kst` 명시 노출**(기존 UTC `filled_at` 무회귀)
- PnL FIFO(instant 순서)·websocket parser **무변경**

## 검증 (적대검증 codex high, 전 게이트 PASS)
- 분기 B 진단 PASS(실 PG fixture, SQL to_char 확인) · RED 진짜 동작 실패 PASS(app/ revert 시 6 failed, 기대값 완화 없음) · invariant/fail-closed/경계 PASS · PnL/websocket/ROB-900 무접촉 PASS
- 도메인 스위트 **215 passed, 0 failed**(execution_ledger·fill-event·toss/kis live ledger·reconcile·invest fills·filled-orders KR/US/crypto), ruff/ty 클린
- prod read-only: `ord_dt` 보유 KIS 190건 KST trade-day 불일치 **0** → 날짜 backfill **0건**
- verify가 P2 1건 수정(sanitizer 21번째 키 계약/README 동기화, ace5d38f)

## 스코프 밖 (별도)
- **ROB-900**: execution_ledger↔rung 비수렴(projection-repair 링크 조인) — 실제 중복매도 위험 원인, 미해결(코드 폴러 신설보다 기존 repair 매칭 수리가 정공법)
- **ROB-934**: websocket `parsers.py:588` 실시간 체결 timestamp UTC날짜+KST HHMMSS+naive 오프셋(동일 결함군, 별도 등록)

Closes ROB-933 · Refs ROB-900, ROB-934

🤖 Generated with [Claude Code](https://claude.com/claude-code)