### PR TITLE
fix(ROB-900): converge proposal rung projection on reconcile (R1 intersection ownership, fail-closed)

### DIFF
--- a/app/mcp_server/tooling/kis_live_ledger.py
+++ b/app/mcp_server/tooling/kis_live_ledger.py
@@ -642,7 +642,17 @@ async def _converge_kis_proposal_rung(
     try:
         async with _order_session_factory()() as db:
             service = OrderProposalsService(db)
-            rung = await service.record_fill_evidence(
+            rung_id = await service.find_unambiguous_evidence_rung_id(
+                correlation_id=row.correlation_id,
+                broker_order_id=row.order_no,
+                account_mode="kis_live",
+                symbol=row.symbol,
+                market=row.instrument_type,
+            )
+            if rung_id is None:
+                return None
+            rung = await service.record_fill_evidence_for_rung(
+                rung_id=rung_id,
                 correlation_id=row.correlation_id,
                 broker_order_id=row.order_no,
                 filled_qty=(
@@ -651,6 +661,8 @@ async def _converge_kis_proposal_rung(
                 terminal_state=terminal_state,
                 now=datetime.datetime.now(datetime.UTC),
                 account_mode="kis_live",
+                symbol=row.symbol,
+                market=row.instrument_type,
             )
             await db.commit()
     except Exception as exc:  # noqa: BLE001 - ledger booking remains authoritative

--- a/app/mcp_server/tooling/kis_live_ledger.py
+++ b/app/mcp_server/tooling/kis_live_ledger.py
@@ -865,6 +865,15 @@ async def _reconcile_one_ledger_row(
         trade_id=trade_id,
         journal_id=journal_id,
     )
+    # Historical terminal rows are handled by the repair pre-pass. A fill
+    # booked during this scan must project immediately in the same reconcile.
+    converged = await _converge_kis_proposal_rung(
+        row,
+        ledger_status=new_status,
+        filled_qty=broker_cum,
+    )
+    if converged is not None:
+        base["proposal_rung"] = converged
     base["action"] = f"booked_{new_status}"
     base["trade_id"] = trade_id
     base["journal_id"] = journal_id

--- a/app/mcp_server/tooling/kis_live_ledger.py
+++ b/app/mcp_server/tooling/kis_live_ledger.py
@@ -40,6 +40,7 @@ from app.services.brokers.kis.mock_scalping_exec.fill_evidence import (
     FillVerdict,
     classify_fill_evidence,
 )
+from app.services.kis_live_order_ledger_service import KISLiveOrderLedgerService
 from app.services.live_correlation import live_correlation_id
 from app.services.live_place_provenance import publish_place_time_forecast
 
@@ -619,6 +620,74 @@ async def _list_open_ledger_rows(
         return rows
 
 
+async def _converge_kis_proposal_rung(
+    row: KISLiveOrderLedger,
+    *,
+    ledger_status: str,
+    filled_qty: Decimal | None,
+) -> dict[str, Any] | None:
+    """Project committed KIS terminal evidence in an independent session."""
+    from app.services.order_proposals import OrderProposalsService
+
+    terminal_state = {
+        "filled": "filled",
+        "cancelled": "cancelled",
+        "expired": "expired",
+        # A broker rejection observed after submission is expiry evidence for a
+        # resting DAY rung; do not force the submit-time `rejected` transition.
+        "rejected": "expired",
+    }.get(ledger_status)
+    if terminal_state is None:
+        return None
+    try:
+        async with _order_session_factory()() as db:
+            service = OrderProposalsService(db)
+            rung = await service.record_fill_evidence(
+                correlation_id=row.correlation_id,
+                broker_order_id=row.order_no,
+                filled_qty=(
+                    None if terminal_state in {"cancelled", "expired"} else filled_qty
+                ),
+                terminal_state=terminal_state,
+                now=datetime.datetime.now(datetime.UTC),
+                account_mode="kis_live",
+            )
+            await db.commit()
+    except Exception as exc:  # noqa: BLE001 - ledger booking remains authoritative
+        logger.error(
+            "KIS proposal rung convergence failed ledger_id=%s order_no=%s "
+            "ledger_status=%s: %s",
+            row.id,
+            row.order_no,
+            ledger_status,
+            exc,
+        )
+        return {"converged": False, "error": str(exc) or exc.__class__.__name__}
+    if rung is None:
+        return None
+    return {"converged": True, "proposal_rung_state": rung.state}
+
+
+async def _repair_terminal_kis_proposal_projections(
+    *, symbol: str | None, order_id: str | None, limit: int
+) -> dict[str, int]:
+    """Idempotently repair KIS terminal ledger rows skipped by the open scan."""
+    async with _order_session_factory()() as db:
+        rows = await KISLiveOrderLedgerService(db).list_terminal_projection_candidates(
+            symbol=symbol, order_id=order_id, limit=limit
+        )
+    report = {"candidates": len(rows), "converged": 0, "failed": 0}
+    for row in rows:
+        result = await _converge_kis_proposal_rung(
+            row, ledger_status=row.status, filled_qty=row.filled_qty
+        )
+        if result is not None and result.get("converged") is False:
+            report["failed"] += 1
+        else:
+            report["converged"] += 1
+    return report
+
+
 async def _reconcile_one_ledger_row(
     row: KISLiveOrderLedger, *, dry_run: bool
 ) -> dict[str, Any]:
@@ -798,6 +867,11 @@ async def kis_live_reconcile_orders_impl(
     limit: int = 100,
 ) -> dict[str, Any]:
     """Reconcile accepted/pending live KR orders against broker fill evidence."""
+    projection_repair = {"candidates": 0, "converged": 0, "failed": 0}
+    if not dry_run:
+        projection_repair = await _repair_terminal_kis_proposal_projections(
+            symbol=symbol, order_id=order_id, limit=limit
+        )
     try:
         rows = await _list_open_ledger_rows(
             symbol=symbol, order_no=order_id, limit=limit
@@ -843,6 +917,7 @@ async def kis_live_reconcile_orders_impl(
         "dry_run": dry_run,
         "counts": counts,
         "reconciled": reconciled,
+        "proposal_projection_repair": projection_repair,
         "message": message,
     }
 

--- a/app/mcp_server/tooling/kis_live_ledger.py
+++ b/app/mcp_server/tooling/kis_live_ledger.py
@@ -687,10 +687,17 @@ async def _repair_terminal_kis_proposal_projections(
 ) -> dict[str, int]:
     """Idempotently repair KIS terminal ledger rows skipped by the open scan."""
     async with _order_session_factory()() as db:
-        rows = await KISLiveOrderLedgerService(db).list_terminal_projection_candidates(
+        rows, anomalies = await KISLiveOrderLedgerService(
+            db
+        ).list_terminal_projection_candidates(
             symbol=symbol, order_id=order_id, limit=limit
         )
-    report = {"candidates": len(rows), "converged": 0, "failed": 0}
+    report = {
+        "candidates": len(rows),
+        "converged": 0,
+        "failed": 0,
+        "anomalies": anomalies,
+    }
     for row in rows:
         result = await _converge_kis_proposal_rung(
             row, ledger_status=row.status, filled_qty=row.filled_qty
@@ -890,7 +897,7 @@ async def kis_live_reconcile_orders_impl(
     limit: int = 100,
 ) -> dict[str, Any]:
     """Reconcile accepted/pending live KR orders against broker fill evidence."""
-    projection_repair = {"candidates": 0, "converged": 0, "failed": 0}
+    projection_repair = {"candidates": 0, "converged": 0, "failed": 0, "anomalies": {}}
     if not dry_run:
         projection_repair = await _repair_terminal_kis_proposal_projections(
             symbol=symbol, order_id=order_id, limit=limit

--- a/app/mcp_server/tooling/kis_live_ledger.py
+++ b/app/mcp_server/tooling/kis_live_ledger.py
@@ -645,6 +645,7 @@ async def _converge_kis_proposal_rung(
             rung_id = await service.find_unambiguous_evidence_rung_id(
                 correlation_id=row.correlation_id,
                 broker_order_id=row.order_no,
+                idempotency_key=row.idempotency_key,
                 account_mode="kis_live",
                 symbol=row.symbol,
                 market=row.instrument_type,
@@ -655,6 +656,7 @@ async def _converge_kis_proposal_rung(
                 rung_id=rung_id,
                 correlation_id=row.correlation_id,
                 broker_order_id=row.order_no,
+                idempotency_key=row.idempotency_key,
                 filled_qty=(
                     None if terminal_state in {"cancelled", "expired"} else filled_qty
                 ),

--- a/app/mcp_server/tooling/toss_live_ledger.py
+++ b/app/mcp_server/tooling/toss_live_ledger.py
@@ -288,6 +288,7 @@ async def _converge_toss_proposal_rung(
             rung_id = await service.find_unambiguous_evidence_rung_id(
                 correlation_id=getattr(row, "correlation_id", None),
                 broker_order_id=row.broker_order_id,
+                idempotency_key=row.client_order_id,
                 account_mode="toss_live",
                 symbol=row.symbol,
                 market=market,
@@ -320,6 +321,7 @@ async def _converge_toss_proposal_rung(
                 rung_id=rung_id,
                 correlation_id=getattr(row, "correlation_id", None),
                 broker_order_id=row.broker_order_id,
+                idempotency_key=row.client_order_id,
                 filled_qty=(
                     None if terminal_state in {"cancelled", "expired"} else filled_qty
                 ),

--- a/app/mcp_server/tooling/toss_live_ledger.py
+++ b/app/mcp_server/tooling/toss_live_ledger.py
@@ -356,14 +356,21 @@ async def _repair_terminal_toss_proposal_projections(
 ) -> dict[str, int]:
     """Idempotently repair terminal ledger rows skipped by the open-row scan."""
     async with _order_session_factory()() as db:
-        rows = await TossLiveOrderLedgerService(db).list_terminal_projection_candidates(
+        rows, anomalies = await TossLiveOrderLedgerService(
+            db
+        ).list_terminal_projection_candidates(
             symbol=symbol,
             order_id=order_id,
             market=market,
             limit=limit,
         )
 
-    report = {"candidates": len(rows), "converged": 0, "failed": 0}
+    report = {
+        "candidates": len(rows),
+        "converged": 0,
+        "failed": 0,
+        "anomalies": anomalies,
+    }
     for row in rows:
         result = await _converge_toss_proposal_rung(
             row,
@@ -751,7 +758,7 @@ async def toss_reconcile_orders_impl(
     dry_run: bool = True,
     limit: int = 100,
 ) -> dict[str, Any]:
-    projection_repair = {"candidates": 0, "converged": 0, "failed": 0}
+    projection_repair = {"candidates": 0, "converged": 0, "failed": 0, "anomalies": {}}
     if not dry_run:
         projection_repair = await _repair_terminal_toss_proposal_projections(
             symbol=symbol,

--- a/app/mcp_server/tooling/toss_live_ledger.py
+++ b/app/mcp_server/tooling/toss_live_ledger.py
@@ -264,7 +264,7 @@ async def _converge_toss_proposal_rung(
     """Project committed Toss evidence in an independent committed session."""
     from app.services.order_proposals import OrderProposalsService
 
-    if ledger_status not in {"partial", "filled", "cancelled"}:
+    if ledger_status not in {"partial", "filled", "cancelled", "rejected"}:
         return None
 
     try:
@@ -287,11 +287,17 @@ async def _converge_toss_proposal_rung(
                 "partial": "partially_filled",
                 "filled": "filled",
                 "cancelled": "cancelled",
+                # Toss reports DAY expiry as REJECTED after an order was already
+                # submitted.  `expired` is the legal evidence-grounded rung
+                # terminal state from resting/partially_filled.
+                "rejected": "expired",
             }[ledger_status]
             rung = await service.record_fill_evidence(
                 correlation_id=getattr(row, "correlation_id", None),
                 broker_order_id=row.broker_order_id,
-                filled_qty=None if terminal_state == "cancelled" else filled_qty,
+                filled_qty=(
+                    None if terminal_state in {"cancelled", "expired"} else filled_qty
+                ),
                 terminal_state=terminal_state,
                 now=datetime.now(UTC),
                 account_mode="toss_live",

--- a/app/mcp_server/tooling/toss_live_ledger.py
+++ b/app/mcp_server/tooling/toss_live_ledger.py
@@ -270,6 +270,30 @@ async def _converge_toss_proposal_rung(
     try:
         async with _order_session_factory()() as db:
             service = OrderProposalsService(db)
+            market = _TOSS_MARKET_TO_INSTRUMENT.get(row.market, row.market)
+            if ledger_status == "partial":
+                rung = await service.record_fill_evidence(
+                    correlation_id=getattr(row, "correlation_id", None),
+                    broker_order_id=row.broker_order_id,
+                    idempotency_key=row.client_order_id,
+                    filled_qty=filled_qty,
+                    terminal_state="partially_filled",
+                    now=datetime.now(UTC),
+                    account_mode="toss_live",
+                )
+                await db.commit()
+                if rung is None:
+                    return None
+                return {"converged": True, "proposal_rung_state": rung.state}
+            rung_id = await service.find_unambiguous_evidence_rung_id(
+                correlation_id=getattr(row, "correlation_id", None),
+                broker_order_id=row.broker_order_id,
+                account_mode="toss_live",
+                symbol=row.symbol,
+                market=market,
+            )
+            if rung_id is None:
+                return None
             # A broker-confirmed cancel may carry a final cumulative partial fill.
             # Project that quantity first, then cancel with filled_qty=None so the
             # service preserves the partial audit value on the terminal rung.
@@ -292,7 +316,8 @@ async def _converge_toss_proposal_rung(
                 # terminal state from resting/partially_filled.
                 "rejected": "expired",
             }[ledger_status]
-            rung = await service.record_fill_evidence(
+            rung = await service.record_fill_evidence_for_rung(
+                rung_id=rung_id,
                 correlation_id=getattr(row, "correlation_id", None),
                 broker_order_id=row.broker_order_id,
                 filled_qty=(
@@ -301,6 +326,8 @@ async def _converge_toss_proposal_rung(
                 terminal_state=terminal_state,
                 now=datetime.now(UTC),
                 account_mode="toss_live",
+                symbol=row.symbol,
+                market=market,
             )
             await db.commit()
     except Exception as exc:  # noqa: BLE001 - ledger booking remains authoritative

--- a/app/services/kis_live_order_ledger_service.py
+++ b/app/services/kis_live_order_ledger_service.py
@@ -80,7 +80,16 @@ class KISLiveOrderLedgerService:
             if row.correlation_id is not None
             else literal(False)
         )
-        if row.order_no is None and row.correlation_id is None:
+        idempotency_match = (
+            OrderProposalRung.idempotency_key == row.idempotency_key
+            if row.idempotency_key is not None
+            else literal(False)
+        )
+        if (
+            row.order_no is None
+            and row.correlation_id is None
+            and row.idempotency_key is None
+        ):
             return False
         stmt = (
             select(
@@ -88,10 +97,11 @@ class KISLiveOrderLedgerService:
                 OrderProposalRung.state,
                 broker_match.label("broker_match"),
                 correlation_match.label("correlation_match"),
+                idempotency_match.label("idempotency_match"),
             )
             .join(OrderProposal, OrderProposalRung.proposal_pk == OrderProposal.id)
             .where(
-                or_(broker_match, correlation_match),
+                or_(broker_match, correlation_match, idempotency_match),
                 OrderProposal.account_mode == "kis_live",
                 OrderProposal.symbol == row.symbol,
                 OrderProposal.market == row.instrument_type,
@@ -100,14 +110,16 @@ class KISLiveOrderLedgerService:
         matches = list((await self._db.execute(stmt)).all())
         broker_ids = {match.id for match in matches if match.broker_match}
         correlation_ids = {match.id for match in matches if match.correlation_match}
-        evidence_sets = [ids for ids in (broker_ids, correlation_ids) if ids]
-        if not (
-            bool(evidence_sets)
-            and all(ids == evidence_sets[0] for ids in evidence_sets)
-            and len(evidence_sets[0]) == 1
-        ):
+        idempotency_ids = {match.id for match in matches if match.idempotency_match}
+        evidence_sets = [
+            ids for ids in (broker_ids, correlation_ids, idempotency_ids) if ids
+        ]
+        if not evidence_sets:
             return False
-        rung_id = next(iter(evidence_sets[0]))
+        intersection = set.intersection(*evidence_sets)
+        if len(intersection) != 1:
+            return False
+        rung_id = next(iter(intersection))
         return next(match.state for match in matches if match.id == rung_id) in (
             _PROPOSAL_EVIDENCE_ACCEPTING_STATES
         )

--- a/app/services/kis_live_order_ledger_service.py
+++ b/app/services/kis_live_order_ledger_service.py
@@ -47,7 +47,6 @@ class KISLiveOrderLedgerService:
                 KISLiveOrderLedger.status.in_(
                     ("filled", "cancelled", "expired", "rejected")
                 ),
-                OrderProposalRung.state.in_(_PROPOSAL_EVIDENCE_ACCEPTING_STATES),
                 OrderProposal.account_mode == "kis_live",
                 OrderProposal.symbol == KISLiveOrderLedger.symbol,
                 OrderProposal.market == KISLiveOrderLedger.instrument_type,
@@ -86,13 +85,13 @@ class KISLiveOrderLedgerService:
         stmt = (
             select(
                 OrderProposalRung.id,
+                OrderProposalRung.state,
                 broker_match.label("broker_match"),
                 correlation_match.label("correlation_match"),
             )
             .join(OrderProposal, OrderProposalRung.proposal_pk == OrderProposal.id)
             .where(
                 or_(broker_match, correlation_match),
-                OrderProposalRung.state.in_(_PROPOSAL_EVIDENCE_ACCEPTING_STATES),
                 OrderProposal.account_mode == "kis_live",
                 OrderProposal.symbol == row.symbol,
                 OrderProposal.market == row.instrument_type,
@@ -102,8 +101,13 @@ class KISLiveOrderLedgerService:
         broker_ids = {match.id for match in matches if match.broker_match}
         correlation_ids = {match.id for match in matches if match.correlation_match}
         evidence_sets = [ids for ids in (broker_ids, correlation_ids) if ids]
-        return (
+        if not (
             bool(evidence_sets)
             and all(ids == evidence_sets[0] for ids in evidence_sets)
             and len(evidence_sets[0]) == 1
+        ):
+            return False
+        rung_id = next(iter(evidence_sets[0]))
+        return next(match.state for match in matches if match.id == rung_id) in (
+            _PROPOSAL_EVIDENCE_ACCEPTING_STATES
         )

--- a/app/services/kis_live_order_ledger_service.py
+++ b/app/services/kis_live_order_ledger_service.py
@@ -1,0 +1,109 @@
+"""Terminal KIS ledger candidates for proposal projection repair."""
+
+from __future__ import annotations
+
+from sqlalchemy import and_, literal, or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.order_proposals import OrderProposal, OrderProposalRung
+from app.models.review import KISLiveOrderLedger
+
+_PROPOSAL_EVIDENCE_ACCEPTING_STATES = (
+    "acked",
+    "resting",
+    "partially_filled",
+    "unverified",
+)
+
+
+class KISLiveOrderLedgerService:
+    """Read-only KIS terminal candidate lookup, symmetric with Toss repair."""
+
+    def __init__(self, db: AsyncSession) -> None:
+        self._db = db
+
+    async def list_terminal_projection_candidates(
+        self,
+        *,
+        symbol: str | None = None,
+        order_id: str | None = None,
+        limit: int = 100,
+    ) -> list[KISLiveOrderLedger]:
+        evidence_match = or_(
+            and_(
+                KISLiveOrderLedger.correlation_id.is_not(None),
+                KISLiveOrderLedger.correlation_id == OrderProposalRung.correlation_id,
+            ),
+            and_(
+                KISLiveOrderLedger.order_no.is_not(None),
+                KISLiveOrderLedger.order_no == OrderProposalRung.broker_order_id,
+            ),
+        )
+        stmt = (
+            select(KISLiveOrderLedger)
+            .join(OrderProposalRung, evidence_match)
+            .join(OrderProposal, OrderProposalRung.proposal_pk == OrderProposal.id)
+            .where(
+                KISLiveOrderLedger.status.in_(
+                    ("filled", "cancelled", "expired", "rejected")
+                ),
+                OrderProposalRung.state.in_(_PROPOSAL_EVIDENCE_ACCEPTING_STATES),
+                OrderProposal.account_mode == "kis_live",
+                OrderProposal.symbol == KISLiveOrderLedger.symbol,
+                OrderProposal.market == KISLiveOrderLedger.instrument_type,
+            )
+        )
+        if symbol:
+            stmt = stmt.where(KISLiveOrderLedger.symbol == symbol)
+        if order_id:
+            stmt = stmt.where(KISLiveOrderLedger.order_no == order_id)
+        stmt = stmt.order_by(KISLiveOrderLedger.id.asc()).limit(limit)
+        rows = list((await self._db.execute(stmt)).unique().scalars().all())
+        rows = [
+            row
+            for row in rows
+            if await self._has_unambiguous_terminal_projection_match(row)
+        ]
+        for row in rows:
+            self._db.expunge(row)
+        return rows
+
+    async def _has_unambiguous_terminal_projection_match(
+        self, row: KISLiveOrderLedger
+    ) -> bool:
+        broker_match = (
+            OrderProposalRung.broker_order_id == row.order_no
+            if row.order_no is not None
+            else literal(False)
+        )
+        correlation_match = (
+            OrderProposalRung.correlation_id == row.correlation_id
+            if row.correlation_id is not None
+            else literal(False)
+        )
+        if row.order_no is None and row.correlation_id is None:
+            return False
+        stmt = (
+            select(
+                OrderProposalRung.id,
+                broker_match.label("broker_match"),
+                correlation_match.label("correlation_match"),
+            )
+            .join(OrderProposal, OrderProposalRung.proposal_pk == OrderProposal.id)
+            .where(
+                or_(broker_match, correlation_match),
+                OrderProposalRung.state.in_(_PROPOSAL_EVIDENCE_ACCEPTING_STATES),
+                OrderProposal.account_mode == "kis_live",
+                OrderProposal.symbol == row.symbol,
+                OrderProposal.market == row.instrument_type,
+            )
+        )
+        matches = list((await self._db.execute(stmt)).all())
+        broker_ids = {match.id for match in matches if match.broker_match}
+        correlation_ids = {match.id for match in matches if match.correlation_match}
+        evidence_sets = [ids for ids in (broker_ids, correlation_ids) if ids]
+        return (
+            bool(evidence_sets)
+            and all(ids == evidence_sets[0] for ids in evidence_sets)
+            and len(evidence_sets[0]) == 1
+        )

--- a/app/services/kis_live_order_ledger_service.py
+++ b/app/services/kis_live_order_ledger_service.py
@@ -28,7 +28,7 @@ class KISLiveOrderLedgerService:
         symbol: str | None = None,
         order_id: str | None = None,
         limit: int = 100,
-    ) -> list[KISLiveOrderLedger]:
+    ) -> tuple[list[KISLiveOrderLedger], dict[str, int]]:
         evidence_match = or_(
             and_(
                 KISLiveOrderLedger.correlation_id.is_not(None),
@@ -58,18 +58,21 @@ class KISLiveOrderLedgerService:
             stmt = stmt.where(KISLiveOrderLedger.order_no == order_id)
         stmt = stmt.order_by(KISLiveOrderLedger.id.asc()).limit(limit)
         rows = list((await self._db.execute(stmt)).unique().scalars().all())
-        rows = [
-            row
-            for row in rows
-            if await self._has_unambiguous_terminal_projection_match(row)
-        ]
+        candidates: list[KISLiveOrderLedger] = []
+        anomalies: dict[str, int] = {}
         for row in rows:
+            accepted, reason = await self._terminal_projection_match(row)
+            if accepted:
+                candidates.append(row)
+            elif reason is not None:
+                anomalies[reason] = anomalies.get(reason, 0) + 1
+        for row in candidates:
             self._db.expunge(row)
-        return rows
+        return candidates, anomalies
 
-    async def _has_unambiguous_terminal_projection_match(
+    async def _terminal_projection_match(
         self, row: KISLiveOrderLedger
-    ) -> bool:
+    ) -> tuple[bool, str | None]:
         broker_match = (
             OrderProposalRung.broker_order_id == row.order_no
             if row.order_no is not None
@@ -90,7 +93,7 @@ class KISLiveOrderLedgerService:
             and row.correlation_id is None
             and row.idempotency_key is None
         ):
-            return False
+            return False, None
         stmt = (
             select(
                 OrderProposalRung.id,
@@ -115,11 +118,17 @@ class KISLiveOrderLedgerService:
             ids for ids in (broker_ids, correlation_ids, idempotency_ids) if ids
         ]
         if not evidence_sets:
-            return False
+            return False, None
         intersection = set.intersection(*evidence_sets)
-        if len(intersection) != 1:
-            return False
+        if not intersection:
+            return False, "proposal_evidence_conflict"
+        if len(broker_ids) > 1:
+            return False, "broker_id_duplicate"
+        if not broker_ids and not idempotency_ids and len(correlation_ids) > 1:
+            return False, "content_hash_only_ambiguous"
+        if len(intersection) > 1:
+            return False, "proposal_evidence_ambiguous"
         rung_id = next(iter(intersection))
         return next(match.state for match in matches if match.id == rung_id) in (
             _PROPOSAL_EVIDENCE_ACCEPTING_STATES
-        )
+        ), None

--- a/app/services/order_proposals/service.py
+++ b/app/services/order_proposals/service.py
@@ -16,7 +16,7 @@ from datetime import UTC, datetime, timedelta
 from decimal import Decimal
 from typing import Any, Literal
 
-from sqlalchemy import or_, select, text
+from sqlalchemy import literal, or_, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.timezone import KST
@@ -1606,6 +1606,135 @@ class OrderProposalsService:
             ):
                 return None
             return await self._repo.update_rung(locked, **audit)
+        return await self._transition_locked_rung(
+            group, locked, new_state=terminal_state, **audit
+        )
+
+    async def find_unambiguous_evidence_rung_id(
+        self,
+        *,
+        correlation_id: str | None,
+        broker_order_id: str | None,
+        idempotency_key: str | None = None,
+        account_mode: str,
+        symbol: str,
+        market: str,
+    ) -> int | None:
+        """Resolve one rung only when all nonempty evidence-key sets intersect.
+
+        Terminal rungs intentionally participate in this comparison: their
+        presence must block an otherwise matching resting rung rather than be
+        hidden by an evidence-accepting state filter.
+        """
+        if correlation_id is None and broker_order_id is None and idempotency_key is None:
+            return None
+        broker_match = (
+            OrderProposalRung.broker_order_id == broker_order_id
+            if broker_order_id is not None
+            else literal(False)
+        )
+        correlation_match = (
+            OrderProposalRung.correlation_id == correlation_id
+            if correlation_id is not None
+            else literal(False)
+        )
+        idempotency_match = (
+            OrderProposalRung.idempotency_key == idempotency_key
+            if idempotency_key is not None
+            else literal(False)
+        )
+        rows = list(
+            (
+                await self._session.execute(
+                    select(
+                        OrderProposalRung.id,
+                        OrderProposalRung.state,
+                        broker_match.label("broker_match"),
+                        correlation_match.label("correlation_match"),
+                        idempotency_match.label("idempotency_match"),
+                    )
+                    .join(
+                        OrderProposal,
+                        OrderProposalRung.proposal_pk == OrderProposal.id,
+                    )
+                    .where(
+                        or_(broker_match, correlation_match, idempotency_match),
+                        OrderProposal.account_mode == account_mode,
+                        OrderProposal.symbol == symbol,
+                        OrderProposal.market == market,
+                    )
+                )
+            ).all()
+        )
+        broker_ids = {row.id for row in rows if row.broker_match}
+        correlation_ids = {row.id for row in rows if row.correlation_match}
+        idempotency_ids = {row.id for row in rows if row.idempotency_match}
+        evidence_sets = [ids for ids in (broker_ids, correlation_ids, idempotency_ids) if ids]
+        if not evidence_sets:
+            return None
+        # R1 resolving-keys intersection: absence is neutral, while every
+        # present key constrains ownership.  This preserves broker attribution
+        # when a content-hash correlation has legitimate sibling rungs.
+        if len(broker_ids) > 1:
+            raise OrderProposalError("broker_id_duplicate")
+        if not broker_ids and not idempotency_ids and len(correlation_ids) > 1:
+            raise OrderProposalError("content_hash_only_ambiguous")
+        intersection = set.intersection(*evidence_sets)
+        if not intersection:
+            raise OrderProposalError("proposal_evidence_conflict")
+        if len(intersection) > 1:
+            raise OrderProposalError("proposal_evidence_ambiguous")
+        return next(iter(intersection))
+
+    async def record_fill_evidence_for_rung(
+        self,
+        *,
+        rung_id: int,
+        correlation_id: str | None,
+        broker_order_id: str | None,
+        idempotency_key: str | None = None,
+        filled_qty: Decimal | None,
+        terminal_state: Literal["filled", "partially_filled", "cancelled", "expired"],
+        now: datetime,
+        account_mode: str,
+        symbol: str,
+        market: str,
+    ) -> OrderProposalRung | None:
+        """Lock and transition the already validated exact rung, never re-pick."""
+        target = (
+            await self._session.execute(
+                select(OrderProposal.proposal_id, OrderProposalRung.rung_index)
+                .join(
+                    OrderProposalRung, OrderProposalRung.proposal_pk == OrderProposal.id
+                )
+                .where(OrderProposalRung.id == rung_id)
+            )
+        ).one_or_none()
+        if target is None:
+            return None
+        group, locked = await self._get_locked_rung(
+            target.proposal_id, target.rung_index
+        )
+        verified_id = await self.find_unambiguous_evidence_rung_id(
+            correlation_id=correlation_id,
+            broker_order_id=broker_order_id,
+            idempotency_key=idempotency_key,
+            account_mode=account_mode,
+            symbol=symbol,
+            market=market,
+        )
+        if verified_id != rung_id:
+            return None
+        if sm.is_terminal(locked.state):
+            if (
+                locked.state == terminal_state
+                and locked.broker_order_id == broker_order_id
+            ):
+                return locked
+            raise OrderProposalError("proposal_terminal_evidence_conflict")
+        audit: dict[str, Any] = {"updated_at": now}
+        if filled_qty is not None:
+            audit["filled_qty"] = filled_qty
         return await self._transition_locked_rung(
             group, locked, new_state=terminal_state, **audit
         )

--- a/app/services/order_proposals/service.py
+++ b/app/services/order_proposals/service.py
@@ -1626,7 +1626,11 @@ class OrderProposalsService:
         presence must block an otherwise matching resting rung rather than be
         hidden by an evidence-accepting state filter.
         """
-        if correlation_id is None and broker_order_id is None and idempotency_key is None:
+        if (
+            correlation_id is None
+            and broker_order_id is None
+            and idempotency_key is None
+        ):
             return None
         broker_match = (
             OrderProposalRung.broker_order_id == broker_order_id
@@ -1669,7 +1673,9 @@ class OrderProposalsService:
         broker_ids = {row.id for row in rows if row.broker_match}
         correlation_ids = {row.id for row in rows if row.correlation_match}
         idempotency_ids = {row.id for row in rows if row.idempotency_match}
-        evidence_sets = [ids for ids in (broker_ids, correlation_ids, idempotency_ids) if ids]
+        evidence_sets = [
+            ids for ids in (broker_ids, correlation_ids, idempotency_ids) if ids
+        ]
         if not evidence_sets:
             return None
         # R1 resolving-keys intersection: absence is neutral, while every

--- a/app/services/order_proposals/service.py
+++ b/app/services/order_proposals/service.py
@@ -1548,11 +1548,13 @@ class OrderProposalsService:
         broker_order_id: str | None = None,
         idempotency_key: str | None = None,
         filled_qty: Decimal | None = None,
-        terminal_state: Literal["filled", "partially_filled", "cancelled"] = "filled",
+        terminal_state: Literal[
+            "filled", "partially_filled", "cancelled", "expired"
+        ] = "filled",
         now: datetime,
         account_mode: str | None = None,
     ) -> OrderProposalRung | None:
-        """Converge a rung from broker fill/cancel evidence (ROB-816 PR-3c).
+        """Converge a rung from broker terminal evidence (ROB-816 PR-3c).
 
         Called by the live reconcile kernel. Fail-safe by construction:
 
@@ -1562,8 +1564,9 @@ class OrderProposalsService:
           (which reconcile would otherwise mislabel as an anomaly).
         - The matched rung is re-read under a row lock and re-checked for
           terminality, closing the find→transition race with a concurrent pass.
-        - ``cancelled`` carries no fill quantity (``filled_qty=None``) so a
-          partial fill booked before a cancel is preserved, not zeroed.
+        - ``cancelled`` and ``expired`` carry no fill quantity
+          (``filled_qty=None``) so a partial fill booked before terminal broker
+          evidence is preserved, not zeroed.
         - No terminal state is ever inferred without matching broker evidence.
         - Upbit client identifiers match the rung ``idempotency_key`` while
           broker UUIDs continue to match ``broker_order_id``.

--- a/app/services/toss_live_order_ledger_service.py
+++ b/app/services/toss_live_order_ledger_service.py
@@ -5,7 +5,7 @@ from datetime import UTC, date, datetime
 from decimal import Decimal
 from typing import Any
 
-from sqlalchemy import and_, or_, select
+from sqlalchemy import and_, literal, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.order_proposals import OrderProposal, OrderProposalRung
@@ -289,7 +289,7 @@ class TossLiveOrderLedgerService:
             )
             .where(
                 TossLiveOrderLedger.operation_kind == "place",
-                TossLiveOrderLedger.status.in_(("filled", "cancelled")),
+                TossLiveOrderLedger.status.in_(("filled", "cancelled", "rejected")),
                 OrderProposalRung.state.in_(_PROPOSAL_EVIDENCE_ACCEPTING_STATES),
                 OrderProposal.account_mode == "toss_live",
                 OrderProposal.symbol == TossLiveOrderLedger.symbol,
@@ -313,9 +313,64 @@ class TossLiveOrderLedgerService:
             stmt = stmt.where(TossLiveOrderLedger.market == market)
         stmt = stmt.order_by(TossLiveOrderLedger.id.asc()).limit(limit)
         rows = list((await self._db.execute(stmt)).unique().scalars().all())
+        rows = [
+            row
+            for row in rows
+            if await self._has_unambiguous_terminal_projection_match(row)
+        ]
         for row in rows:
             self._db.expunge(row)
         return rows
+
+    async def _has_unambiguous_terminal_projection_match(
+        self, row: TossLiveOrderLedger
+    ) -> bool:
+        """Accept only one broker/correlation-consistent rung for repair.
+
+        A terminal ledger row may be linked to legacy duplicated correlations.
+        Projection repair must never pick an arbitrary rung: a present evidence
+        key must identify exactly one eligible rung, and when both keys resolve
+        they must resolve to the same rung.
+        """
+        broker_match = (
+            OrderProposalRung.broker_order_id == row.broker_order_id
+            if row.broker_order_id is not None
+            else literal(False)
+        )
+        correlation_match = (
+            OrderProposalRung.correlation_id == row.correlation_id
+            if row.correlation_id is not None
+            else literal(False)
+        )
+        if row.broker_order_id is None and row.correlation_id is None:
+            return False
+        stmt = (
+            select(
+                OrderProposalRung.id,
+                broker_match.label("broker_match"),
+                correlation_match.label("correlation_match"),
+            )
+            .join(OrderProposal, OrderProposalRung.proposal_pk == OrderProposal.id)
+            .where(
+                or_(broker_match, correlation_match),
+                OrderProposalRung.state.in_(_PROPOSAL_EVIDENCE_ACCEPTING_STATES),
+                OrderProposal.account_mode == "toss_live",
+                OrderProposal.symbol == row.symbol,
+                or_(
+                    and_(row.market == "kr", OrderProposal.market == "equity_kr"),
+                    and_(row.market == "us", OrderProposal.market == "equity_us"),
+                ),
+            )
+        )
+        matches = list((await self._db.execute(stmt)).all())
+        broker_ids = {match.id for match in matches if match.broker_match}
+        correlation_ids = {match.id for match in matches if match.correlation_match}
+        evidence_sets = [ids for ids in (broker_ids, correlation_ids) if ids]
+        return (
+            bool(evidence_sets)
+            and all(ids == evidence_sets[0] for ids in evidence_sets)
+            and len(evidence_sets[0]) == 1
+        )
 
     async def update_reconcile_outcome(
         self,

--- a/app/services/toss_live_order_ledger_service.py
+++ b/app/services/toss_live_order_ledger_service.py
@@ -341,7 +341,16 @@ class TossLiveOrderLedgerService:
             if row.correlation_id is not None
             else literal(False)
         )
-        if row.broker_order_id is None and row.correlation_id is None:
+        idempotency_match = (
+            OrderProposalRung.idempotency_key == row.client_order_id
+            if row.client_order_id is not None
+            else literal(False)
+        )
+        if (
+            row.broker_order_id is None
+            and row.correlation_id is None
+            and row.client_order_id is None
+        ):
             return False
         stmt = (
             select(
@@ -349,10 +358,11 @@ class TossLiveOrderLedgerService:
                 OrderProposalRung.state,
                 broker_match.label("broker_match"),
                 correlation_match.label("correlation_match"),
+                idempotency_match.label("idempotency_match"),
             )
             .join(OrderProposal, OrderProposalRung.proposal_pk == OrderProposal.id)
             .where(
-                or_(broker_match, correlation_match),
+                or_(broker_match, correlation_match, idempotency_match),
                 OrderProposal.account_mode == "toss_live",
                 OrderProposal.symbol == row.symbol,
                 or_(
@@ -364,14 +374,16 @@ class TossLiveOrderLedgerService:
         matches = list((await self._db.execute(stmt)).all())
         broker_ids = {match.id for match in matches if match.broker_match}
         correlation_ids = {match.id for match in matches if match.correlation_match}
-        evidence_sets = [ids for ids in (broker_ids, correlation_ids) if ids]
-        if not (
-            bool(evidence_sets)
-            and all(ids == evidence_sets[0] for ids in evidence_sets)
-            and len(evidence_sets[0]) == 1
-        ):
+        idempotency_ids = {match.id for match in matches if match.idempotency_match}
+        evidence_sets = [
+            ids for ids in (broker_ids, correlation_ids, idempotency_ids) if ids
+        ]
+        if not evidence_sets:
             return False
-        rung_id = next(iter(evidence_sets[0]))
+        intersection = set.intersection(*evidence_sets)
+        if len(intersection) != 1:
+            return False
+        rung_id = next(iter(intersection))
         return next(match.state for match in matches if match.id == rung_id) in (
             _PROPOSAL_EVIDENCE_ACCEPTING_STATES
         )

--- a/app/services/toss_live_order_ledger_service.py
+++ b/app/services/toss_live_order_ledger_service.py
@@ -290,7 +290,6 @@ class TossLiveOrderLedgerService:
             .where(
                 TossLiveOrderLedger.operation_kind == "place",
                 TossLiveOrderLedger.status.in_(("filled", "cancelled", "rejected")),
-                OrderProposalRung.state.in_(_PROPOSAL_EVIDENCE_ACCEPTING_STATES),
                 OrderProposal.account_mode == "toss_live",
                 OrderProposal.symbol == TossLiveOrderLedger.symbol,
                 or_(
@@ -347,13 +346,13 @@ class TossLiveOrderLedgerService:
         stmt = (
             select(
                 OrderProposalRung.id,
+                OrderProposalRung.state,
                 broker_match.label("broker_match"),
                 correlation_match.label("correlation_match"),
             )
             .join(OrderProposal, OrderProposalRung.proposal_pk == OrderProposal.id)
             .where(
                 or_(broker_match, correlation_match),
-                OrderProposalRung.state.in_(_PROPOSAL_EVIDENCE_ACCEPTING_STATES),
                 OrderProposal.account_mode == "toss_live",
                 OrderProposal.symbol == row.symbol,
                 or_(
@@ -366,10 +365,15 @@ class TossLiveOrderLedgerService:
         broker_ids = {match.id for match in matches if match.broker_match}
         correlation_ids = {match.id for match in matches if match.correlation_match}
         evidence_sets = [ids for ids in (broker_ids, correlation_ids) if ids]
-        return (
+        if not (
             bool(evidence_sets)
             and all(ids == evidence_sets[0] for ids in evidence_sets)
             and len(evidence_sets[0]) == 1
+        ):
+            return False
+        rung_id = next(iter(evidence_sets[0]))
+        return next(match.state for match in matches if match.id == rung_id) in (
+            _PROPOSAL_EVIDENCE_ACCEPTING_STATES
         )
 
     async def update_reconcile_outcome(

--- a/app/services/toss_live_order_ledger_service.py
+++ b/app/services/toss_live_order_ledger_service.py
@@ -239,7 +239,7 @@ class TossLiveOrderLedgerService:
         order_id: str | None = None,
         market: str | None = None,
         limit: int = 100,
-    ) -> list[TossLiveOrderLedger]:
+    ) -> tuple[list[TossLiveOrderLedger], dict[str, int]]:
         stmt = select(TossLiveOrderLedger).where(
             TossLiveOrderLedger.status.in_(("accepted", "pending", "partial"))
         )
@@ -312,18 +312,21 @@ class TossLiveOrderLedgerService:
             stmt = stmt.where(TossLiveOrderLedger.market == market)
         stmt = stmt.order_by(TossLiveOrderLedger.id.asc()).limit(limit)
         rows = list((await self._db.execute(stmt)).unique().scalars().all())
-        rows = [
-            row
-            for row in rows
-            if await self._has_unambiguous_terminal_projection_match(row)
-        ]
+        candidates: list[TossLiveOrderLedger] = []
+        anomalies: dict[str, int] = {}
         for row in rows:
+            accepted, reason = await self._terminal_projection_match(row)
+            if accepted:
+                candidates.append(row)
+            elif reason is not None:
+                anomalies[reason] = anomalies.get(reason, 0) + 1
+        for row in candidates:
             self._db.expunge(row)
-        return rows
+        return candidates, anomalies
 
-    async def _has_unambiguous_terminal_projection_match(
+    async def _terminal_projection_match(
         self, row: TossLiveOrderLedger
-    ) -> bool:
+    ) -> tuple[bool, str | None]:
         """Accept only one broker/correlation-consistent rung for repair.
 
         A terminal ledger row may be linked to legacy duplicated correlations.
@@ -351,7 +354,7 @@ class TossLiveOrderLedgerService:
             and row.correlation_id is None
             and row.client_order_id is None
         ):
-            return False
+            return False, None
         stmt = (
             select(
                 OrderProposalRung.id,
@@ -379,14 +382,20 @@ class TossLiveOrderLedgerService:
             ids for ids in (broker_ids, correlation_ids, idempotency_ids) if ids
         ]
         if not evidence_sets:
-            return False
+            return False, None
         intersection = set.intersection(*evidence_sets)
-        if len(intersection) != 1:
-            return False
+        if not intersection:
+            return False, "proposal_evidence_conflict"
+        if len(broker_ids) > 1:
+            return False, "broker_id_duplicate"
+        if not broker_ids and not idempotency_ids and len(correlation_ids) > 1:
+            return False, "content_hash_only_ambiguous"
+        if len(intersection) > 1:
+            return False, "proposal_evidence_ambiguous"
         rung_id = next(iter(intersection))
         return next(match.state for match in matches if match.id == rung_id) in (
             _PROPOSAL_EVIDENCE_ACCEPTING_STATES
-        )
+        ), None
 
     async def update_reconcile_outcome(
         self,

--- a/docs/runbooks/rob-900-proposal-link-backfill-dry-run.md
+++ b/docs/runbooks/rob-900-proposal-link-backfill-dry-run.md
@@ -1,0 +1,51 @@
+# ROB-900 Proposal-Link Backfill Dry Run
+
+## Purpose
+
+List conservative, operator-reviewable suggestions for terminal Toss ledger rows
+that have no exact `correlation_id` or `broker_order_id` link to an order
+proposal rung. This is an evidence-gathering tool only; it cannot backfill,
+reconcile, submit, cancel, or call a broker.
+
+## Preconditions
+
+- Use a production environment only after loading its normal application
+  configuration. Do not paste credentials into shell history or output.
+- Confirm the requested scope is proposal-link evidence review, not a database
+  mutation. There is deliberately no `--apply`, `--commit`, or write mode.
+- Do not run this as a substitute for `toss_reconcile_orders`; linked rows are
+  repaired by the existing reconcile path.
+
+## Run
+
+```bash
+uv run python scripts/list_rob900_toss_projection_backfill_candidates.py \
+  --limit 500 --window-seconds 300
+```
+
+The command starts its database transaction with `SET TRANSACTION READ ONLY`
+and emits one JSON document. Save its output as review evidence rather than
+editing it into a migration.
+
+## Matching and guards
+
+A suggestion is emitted only when exactly one live Toss proposal rung matches:
+
+- the same symbol, normalized market, and side;
+- the exact requested/filled quantity; and
+- a rung `updated_at` within the requested window of ledger `created_at`
+  (default: 300 seconds).
+
+`broker_order_id` is displayed so an operator can independently inspect the
+broker evidence, but missing proposal links are never inferred from a partial
+identifier. Zero candidates, more than one candidate, quantity mismatches,
+market/side mismatches, and timestamps outside the window are excluded. Every
+emitted row has `auto_backfill_eligible: false`.
+
+## Review and next step
+
+For each suggestion, an operator must independently verify broker order detail,
+proposal approval/submission evidence, symbol/side/quantity, and timestamps.
+This PR intentionally provides no execution mechanism. Any approved database
+backfill must be designed, reviewed, and run as a separate authorized change
+with its own audit trail and rollback plan.

--- a/scripts/list_rob900_toss_projection_backfill_candidates.py
+++ b/scripts/list_rob900_toss_projection_backfill_candidates.py
@@ -1,0 +1,190 @@
+"""ROB-900 evidence-first, read-only Toss proposal-link backfill list.
+
+This tool never updates either ledger or proposal tables.  It prints only
+unlinked terminal Toss rows with exactly one conservative, reviewable proposal
+rung suggestion; ambiguous and weak matches are counted but not emitted.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+from datetime import datetime
+from decimal import Decimal
+from typing import Any
+
+from sqlalchemy import text
+
+from app.core.db import AsyncSessionLocal
+
+
+def _market_for_toss(market: str) -> str | None:
+    return {"kr": "equity_kr", "us": "equity_us"}.get(market)
+
+
+def _as_decimal(value: Any) -> Decimal | None:
+    if value is None:
+        return None
+    try:
+        return Decimal(str(value))
+    except Exception:
+        return None
+
+
+def _within_seconds(left: datetime, right: datetime, seconds: int) -> int | None:
+    if left.tzinfo is None or right.tzinfo is None:
+        return None
+    delta = abs(int((left - right).total_seconds()))
+    return delta if delta <= seconds else None
+
+
+def _unique_suggestion(
+    ledger: dict[str, Any], rungs: list[dict[str, Any]], *, window_seconds: int
+) -> dict[str, Any] | None:
+    """Return one exact-intent/time-near rung, otherwise fail closed."""
+    proposal_market = _market_for_toss(str(ledger["market"]))
+    ledger_quantity = _as_decimal(ledger["filled_qty"] or ledger["quantity"])
+    created_at = ledger["created_at"]
+    if (
+        proposal_market is None
+        or ledger_quantity is None
+        or not isinstance(created_at, datetime)
+    ):
+        return None
+
+    matches: list[tuple[dict[str, Any], int]] = []
+    for rung in rungs:
+        if (
+            rung["symbol"] != ledger["symbol"]
+            or rung["market"] != proposal_market
+            or rung["side"] != ledger["side"]
+            or _as_decimal(rung["quantity"]) != ledger_quantity
+        ):
+            continue
+        seconds_apart = _within_seconds(
+            created_at, rung["rung_updated_at"], window_seconds
+        )
+        if seconds_apart is not None:
+            matches.append((rung, seconds_apart))
+
+    if len(matches) != 1:
+        return None
+    rung, seconds_apart = matches[0]
+    return {
+        "ledger_id": ledger["id"],
+        "broker_order_id": ledger["broker_order_id"],
+        "ledger_status": ledger["status"],
+        "symbol": ledger["symbol"],
+        "market": ledger["market"],
+        "side": ledger["side"],
+        "ledger_quantity": str(ledger_quantity),
+        "ledger_created_at": created_at.isoformat(),
+        "proposal_id": str(rung["proposal_id"]),
+        "proposal_rung_id": rung["rung_id"],
+        "proposal_rung_index": rung["rung_index"],
+        "proposal_state": rung["state"],
+        "rung_updated_at": rung["rung_updated_at"].isoformat(),
+        "seconds_apart": seconds_apart,
+        "match_basis": [
+            "same_symbol",
+            "same_market",
+            "same_side",
+            "exact_quantity",
+            "near_resting_timestamp",
+        ],
+        "auto_backfill_eligible": False,
+        "operator_action": "review evidence; no mutation is performed by this tool",
+    }
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="ROB-900 read-only Toss proposal-link backfill candidate list"
+    )
+    parser.add_argument("--limit", type=int, default=500)
+    parser.add_argument("--window-seconds", type=int, default=300)
+    return parser.parse_args(argv)
+
+
+async def run(args: argparse.Namespace) -> int:
+    if args.limit <= 0 or args.window_seconds <= 0:
+        raise ValueError("--limit and --window-seconds must be positive")
+    async with AsyncSessionLocal() as session:
+        await session.execute(text("SET TRANSACTION READ ONLY"))
+        ledger_rows = list(
+            (
+                await session.execute(
+                    text(
+                        """
+                        SELECT l.id, l.broker_order_id, l.status, l.market, l.symbol,
+                               l.side, l.quantity, l.filled_qty, l.created_at
+                        FROM review.toss_live_order_ledger l
+                        WHERE l.status IN ('filled', 'cancelled', 'rejected')
+                          AND NOT EXISTS (
+                              SELECT 1
+                              FROM review.order_proposal_rungs r
+                              WHERE (l.correlation_id IS NOT NULL
+                                     AND r.correlation_id = l.correlation_id)
+                                 OR (l.broker_order_id IS NOT NULL
+                                     AND r.broker_order_id = l.broker_order_id)
+                          )
+                        ORDER BY l.id ASC
+                        LIMIT :limit
+                        """
+                    ),
+                    {"limit": args.limit},
+                )
+            ).mappings()
+        )
+        rung_rows = list(
+            (
+                await session.execute(
+                    text(
+                        """
+                        SELECT p.proposal_id, p.symbol, p.market, r.id AS rung_id,
+                               r.rung_index, r.side, r.quantity, r.state,
+                               r.updated_at AS rung_updated_at
+                        FROM review.order_proposals p
+                        JOIN review.order_proposal_rungs r ON r.proposal_pk = p.id
+                        WHERE p.account_mode = 'toss_live'
+                          AND r.state IN ('acked', 'resting', 'partially_filled', 'unverified')
+                        """
+                    )
+                )
+            ).mappings()
+        )
+        suggestions = [
+            suggestion
+            for row in ledger_rows
+            if (
+                suggestion := _unique_suggestion(
+                    dict(row),
+                    [dict(rung) for rung in rung_rows],
+                    window_seconds=args.window_seconds,
+                )
+            )
+            is not None
+        ]
+        await session.rollback()
+
+    print(
+        json.dumps(
+            {
+                "dry_run": True,
+                "read_only": True,
+                "terminal_unlinked_rows_scanned": len(ledger_rows),
+                "unique_review_suggestions": len(suggestions),
+                "excluded_no_or_ambiguous_match": len(ledger_rows) - len(suggestions),
+                "suggestions": suggestions,
+            },
+            default=str,
+            ensure_ascii=False,
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(run(parse_args())))

--- a/tests/mcp_server/tooling/test_kis_live_ledger.py
+++ b/tests/mcp_server/tooling/test_kis_live_ledger.py
@@ -230,6 +230,7 @@ async def test_reconcile_repairs_terminal_filled_proposal_projection(db_session)
         "candidates": 1,
         "converged": 1,
         "failed": 0,
+        "anomalies": {},
     }
     assert rungs[0].state == "filled"
 
@@ -313,6 +314,7 @@ async def test_terminal_repair_skips_terminal_and_resting_key_conflict(db_sessio
         "candidates": 0,
         "converged": 0,
         "failed": 0,
+        "anomalies": {},
     }
     assert terminal[0].state == "filled"
     assert resting[0].state == "resting"

--- a/tests/mcp_server/tooling/test_kis_live_ledger.py
+++ b/tests/mcp_server/tooling/test_kis_live_ledger.py
@@ -153,6 +153,89 @@ async def test_record_kis_live_order_does_not_book_fill(db_session):
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_reconcile_repairs_terminal_filled_proposal_projection(db_session):
+    """ROB-900: a booked KIS fill must repair its linked resting rung.
+
+    This intentionally seeds a terminal ledger row before reconcile.  The open
+    row scan cannot see it, so only the terminal projection-repair path may
+    converge the proposal.
+    """
+    from datetime import UTC, datetime
+    from decimal import Decimal
+    from uuid import uuid4
+
+    from app.mcp_server.tooling import kis_live_ledger as kl
+    from app.services.order_proposals import OrderProposalsService
+    from app.services.order_proposals.service import RungInput
+
+    suffix = uuid4().hex
+    order_no = f"KIS-ROB900-{suffix}"
+    correlation_id = f"live:kis_live:rob900-{suffix}"
+    service = OrderProposalsService(db_session)
+    group = await service.create_proposal(
+        symbol="214150",
+        market="equity_kr",
+        account_mode="kis_live",
+        side="buy",
+        order_type="limit",
+        proposer="rob900-test",
+        rungs=[RungInput(0, "buy", Decimal("1"), Decimal("50000"), None)],
+    )
+    for state in ("revalidating", "approved", "submitting"):
+        await service.transition_rung(group.proposal_id, 0, new_state=state)
+    await service.record_resting(
+        group.proposal_id,
+        0,
+        broker_order_id=order_no,
+        correlation_id=correlation_id,
+        idempotency_key=f"idem-{suffix}",
+        approval_hash_digest=f"digest-{suffix}",
+        now=datetime.now(UTC),
+    )
+    await db_session.commit()
+
+    ledger_id = await kl._save_kis_live_order_ledger(
+        symbol="214150",
+        instrument_type="equity_kr",
+        side="buy",
+        order_type="limit",
+        quantity=1.0,
+        price=50000.0,
+        amount=50000.0,
+        currency="KRW",
+        order_no=order_no,
+        order_time="090000",
+        krx_fwdg_ord_orgno=None,
+        status="filled",
+        response_code="0",
+        response_message=None,
+        raw_response={},
+        reason=None,
+        thesis="test",
+        strategy="test",
+        target_price=None,
+        stop_loss=None,
+        min_hold_days=None,
+        notes=None,
+        exit_reason=None,
+        indicators_snapshot=None,
+        correlation_id=correlation_id,
+    )
+    assert ledger_id is not None
+
+    result = await kl.kis_live_reconcile_orders_impl(dry_run=False)
+    _, rungs = await OrderProposalsService(db_session).get_proposal(group.proposal_id)
+
+    assert result["proposal_projection_repair"] == {
+        "candidates": 1,
+        "converged": 1,
+        "failed": 0,
+    }
+    assert rungs[0].state == "filled"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_fetch_live_daily_rows_for_order():
     from unittest.mock import AsyncMock, patch
 

--- a/tests/mcp_server/tooling/test_kis_live_ledger.py
+++ b/tests/mcp_server/tooling/test_kis_live_ledger.py
@@ -249,10 +249,11 @@ async def test_terminal_repair_skips_terminal_and_resting_key_conflict(db_sessio
 
     suffix = uuid4().hex
     order_no = f"KIS-ROB900-CONFLICT-{suffix}"
-    correlation_id = f"live:kis_live:conflict-{suffix}"
+    resting_correlation = f"live:kis_live:resting-{suffix}"
+    terminal_correlation = f"live:kis_live:terminal-{suffix}"
     service = OrderProposalsService(db_session)
 
-    async def create_rung(*, broker_order_id: str):
+    async def create_rung(*, broker_order_id: str, correlation_id: str):
         group = await service.create_proposal(
             symbol="214150",
             market="equity_kr",
@@ -275,8 +276,12 @@ async def test_terminal_repair_skips_terminal_and_resting_key_conflict(db_sessio
         )
         return group.proposal_id
 
-    resting_id = await create_rung(broker_order_id=order_no)
-    terminal_id = await create_rung(broker_order_id=f"terminal-{order_no}")
+    resting_id = await create_rung(
+        broker_order_id=order_no, correlation_id=resting_correlation
+    )
+    terminal_id = await create_rung(
+        broker_order_id=f"terminal-{order_no}", correlation_id=terminal_correlation
+    )
     await service.transition_rung(terminal_id, 0, new_state="filled")
     await db_session.commit()
     await kl._save_kis_live_order_ledger(
@@ -304,7 +309,7 @@ async def test_terminal_repair_skips_terminal_and_resting_key_conflict(db_sessio
         notes=None,
         exit_reason=None,
         indicators_snapshot=None,
-        correlation_id=correlation_id,
+        correlation_id=terminal_correlation,
     )
 
     result = await kl.kis_live_reconcile_orders_impl(dry_run=False)
@@ -314,7 +319,7 @@ async def test_terminal_repair_skips_terminal_and_resting_key_conflict(db_sessio
         "candidates": 0,
         "converged": 0,
         "failed": 0,
-        "anomalies": {},
+        "anomalies": {"proposal_evidence_conflict": 1},
     }
     assert terminal[0].state == "filled"
     assert resting[0].state == "resting"

--- a/tests/mcp_server/tooling/test_kis_live_ledger.py
+++ b/tests/mcp_server/tooling/test_kis_live_ledger.py
@@ -236,6 +236,179 @@ async def test_reconcile_repairs_terminal_filled_proposal_projection(db_session)
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_terminal_repair_skips_terminal_and_resting_key_conflict(db_session):
+    """ROB-900 P0: terminal correlation evidence blocks a conflicting KIS fill."""
+    from datetime import UTC, datetime
+    from decimal import Decimal
+    from uuid import uuid4
+
+    from app.mcp_server.tooling import kis_live_ledger as kl
+    from app.services.order_proposals import OrderProposalsService
+    from app.services.order_proposals.service import RungInput
+
+    suffix = uuid4().hex
+    order_no = f"KIS-ROB900-CONFLICT-{suffix}"
+    correlation_id = f"live:kis_live:conflict-{suffix}"
+    service = OrderProposalsService(db_session)
+
+    async def create_rung(*, broker_order_id: str):
+        group = await service.create_proposal(
+            symbol="214150",
+            market="equity_kr",
+            account_mode="kis_live",
+            side="buy",
+            order_type="limit",
+            proposer="rob900-conflict-test",
+            rungs=[RungInput(0, "buy", Decimal("1"), Decimal("50000"), None)],
+        )
+        for state in ("revalidating", "approved", "submitting"):
+            await service.transition_rung(group.proposal_id, 0, new_state=state)
+        await service.record_resting(
+            group.proposal_id,
+            0,
+            broker_order_id=broker_order_id,
+            correlation_id=correlation_id,
+            idempotency_key=f"idem-{broker_order_id}",
+            approval_hash_digest=f"digest-{broker_order_id}",
+            now=datetime.now(UTC),
+        )
+        return group.proposal_id
+
+    resting_id = await create_rung(broker_order_id=order_no)
+    terminal_id = await create_rung(broker_order_id=f"terminal-{order_no}")
+    await service.transition_rung(terminal_id, 0, new_state="filled")
+    await db_session.commit()
+    await kl._save_kis_live_order_ledger(
+        symbol="214150",
+        instrument_type="equity_kr",
+        side="buy",
+        order_type="limit",
+        quantity=1.0,
+        price=50000.0,
+        amount=50000.0,
+        currency="KRW",
+        order_no=order_no,
+        order_time="090000",
+        krx_fwdg_ord_orgno=None,
+        status="filled",
+        response_code="0",
+        response_message=None,
+        raw_response={},
+        reason=None,
+        thesis="test",
+        strategy="test",
+        target_price=None,
+        stop_loss=None,
+        min_hold_days=None,
+        notes=None,
+        exit_reason=None,
+        indicators_snapshot=None,
+        correlation_id=correlation_id,
+    )
+
+    result = await kl.kis_live_reconcile_orders_impl(dry_run=False)
+    _, resting = await OrderProposalsService(db_session).get_proposal(resting_id)
+    _, terminal = await OrderProposalsService(db_session).get_proposal(terminal_id)
+    assert result["proposal_projection_repair"] == {
+        "candidates": 0,
+        "converged": 0,
+        "failed": 0,
+    }
+    assert terminal[0].state == "filled"
+    assert resting[0].state == "resting"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_reconcile_new_filled_row_converges_proposal_in_same_pass(db_session):
+    """ROB-900 P1: KIS fill booking immediately projects its resting rung."""
+    from datetime import UTC, datetime
+    from decimal import Decimal
+    from unittest.mock import AsyncMock, patch
+    from uuid import uuid4
+
+    from app.mcp_server.tooling import kis_live_ledger as kl
+    from app.services.brokers.kis.mock_scalping_exec.fill_evidence import (
+        FillEvidence,
+        FillVerdict,
+    )
+    from app.services.order_proposals import OrderProposalsService
+    from app.services.order_proposals.service import RungInput
+
+    suffix = uuid4().hex
+    order_no = f"KIS-ROB900-IMMEDIATE-{suffix}"
+    correlation_id = f"live:kis_live:immediate-{suffix}"
+    service = OrderProposalsService(db_session)
+    group = await service.create_proposal(
+        symbol="214150",
+        market="equity_kr",
+        account_mode="kis_live",
+        side="buy",
+        order_type="limit",
+        proposer="rob900-immediate-test",
+        rungs=[RungInput(0, "buy", Decimal("1"), Decimal("50000"), None)],
+    )
+    for state in ("revalidating", "approved", "submitting"):
+        await service.transition_rung(group.proposal_id, 0, new_state=state)
+    await service.record_resting(
+        group.proposal_id,
+        0,
+        broker_order_id=order_no,
+        correlation_id=correlation_id,
+        idempotency_key=f"idem-{suffix}",
+        approval_hash_digest=f"digest-{suffix}",
+        now=datetime.now(UTC),
+    )
+    await db_session.commit()
+    await kl._save_kis_live_order_ledger(
+        symbol="214150",
+        instrument_type="equity_kr",
+        side="buy",
+        order_type="limit",
+        quantity=1.0,
+        price=50000.0,
+        amount=50000.0,
+        currency="KRW",
+        order_no=order_no,
+        order_time="090000",
+        krx_fwdg_ord_orgno=None,
+        status="accepted",
+        response_code="0",
+        response_message=None,
+        raw_response={},
+        reason=None,
+        thesis="test",
+        strategy="test",
+        target_price=None,
+        stop_loss=None,
+        min_hold_days=None,
+        notes=None,
+        exit_reason=None,
+        indicators_snapshot=None,
+        correlation_id=correlation_id,
+    )
+    filled = FillEvidence(
+        FillVerdict.FILLED, Decimal("1"), Decimal("50000"), None, "filled", ""
+    )
+    with (
+        patch.object(kl, "_fetch_live_daily_rows", new=AsyncMock(return_value=[])),
+        patch.object(kl, "classify_fill_evidence", return_value=filled),
+        patch.object(kl, "_save_order_fill", new=AsyncMock(return_value=1)),
+        patch.object(
+            kl,
+            "_create_trade_journal_for_buy",
+            new=AsyncMock(return_value={"journal_id": 2}),
+        ),
+        patch.object(kl, "_link_journal_to_fill", new=AsyncMock(return_value=None)),
+    ):
+        result = await kl.kis_live_reconcile_orders_impl(dry_run=False)
+    _, rungs = await OrderProposalsService(db_session).get_proposal(group.proposal_id)
+    assert result["reconciled"][0]["action"] == "booked_filled"
+    assert rungs[0].state == "filled"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_fetch_live_daily_rows_for_order():
     from unittest.mock import AsyncMock, patch
 

--- a/tests/mcp_server/tooling/test_toss_live_ledger.py
+++ b/tests/mcp_server/tooling/test_toss_live_ledger.py
@@ -243,7 +243,10 @@ async def test_proposal_projection_partial_fill_and_duplicate_evidence_are_idemp
     )
     rung = await _proposal_rung(db_session, proposal_id)
     assert duplicate["action"] == "noop_already_booked"
-    assert "proposal_rung" not in duplicate
+    assert duplicate["proposal_rung"] == {
+        "converged": True,
+        "proposal_rung_state": "filled",
+    }
     assert rung.state == "filled"
     assert rung.filled_qty == Decimal("2")
 
@@ -398,7 +401,7 @@ async def test_terminal_ledger_projection_failure_is_retried_by_sweep(db_session
 
     with patch.object(
         OrderProposalsService,
-        "record_fill_evidence",
+        "record_fill_evidence_for_rung",
         new=AsyncMock(side_effect=RuntimeError("projection unavailable")),
     ):
         failed = await _reconcile_with_evidence(mod, row, evidence)
@@ -454,8 +457,6 @@ async def test_projection_repair_converges_after_timestamptz_kst_round_trip(
     the sweep must converge even though the execution-ledger fill is stored on
     the preceding UTC date.
     """
-    from app.mcp_server.tooling import toss_live_ledger as mod
-
     proposal_id, toss_row = await _proposal_accepted_row(db_session, suffix="rob933")
     filled_at_utc = datetime(2026, 7, 15, 15, 17, 28, tzinfo=UTC)
     db_session.add(
@@ -599,6 +600,74 @@ async def test_terminal_repair_skips_ambiguous_correlation_link(db_session):
     assert first.state == second.state == "resting"
 
 
+async def test_terminal_repair_skips_terminal_and_resting_key_conflict(db_session):
+    """ROB-900 P0: a terminal correlation conflict must block broker-id repair."""
+    from datetime import UTC, datetime
+
+    from app.mcp_server.tooling import toss_live_ledger as mod
+    from app.services.order_proposals import OrderProposalsService
+    from app.services.order_proposals.service import RungInput
+
+    resting_id, row = await _proposal_accepted_row(
+        db_session, suffix="terminal-conflict"
+    )
+    service = OrderProposalsService(db_session)
+    terminal = await service.create_proposal(
+        symbol="AAPL",
+        market="equity_us",
+        account_mode="toss_live",
+        side="buy",
+        order_type="limit",
+        proposer="terminal-conflict-test",
+        rungs=[RungInput(0, "buy", Decimal("2"), Decimal("190"), None)],
+    )
+    for state in ("revalidating", "approved", "submitting"):
+        await service.transition_rung(terminal.proposal_id, 0, new_state=state)
+    await service.record_resting(
+        terminal.proposal_id,
+        0,
+        broker_order_id=f"terminal-{row.broker_order_id}",
+        correlation_id=row.correlation_id,
+        idempotency_key="terminal-conflict-idempotency",
+        approval_hash_digest="terminal-conflict-digest",
+        now=datetime.now(UTC),
+    )
+    await service.transition_rung(terminal.proposal_id, 0, new_state="filled")
+    row.status = "filled"
+    await db_session.commit()
+
+    with (
+        patch.object(
+            mod.TossLiveOrderLedgerService,
+            "reopen_anomalies_for_reconcile",
+            new=AsyncMock(
+                return_value={
+                    "rows": [],
+                    "dry_run": False,
+                    "reopened": 0,
+                    "candidates": 0,
+                }
+            ),
+        ),
+        patch.object(
+            mod.TossLiveOrderLedgerService,
+            "list_open",
+            new=AsyncMock(return_value=[]),
+        ),
+    ):
+        repaired = await mod.toss_reconcile_orders_impl(dry_run=False)
+
+    resting = await _proposal_rung(db_session, resting_id)
+    terminal_rung = await _proposal_rung(db_session, terminal.proposal_id)
+    assert repaired["proposal_projection_repair"] == {
+        "candidates": 0,
+        "converged": 0,
+        "failed": 0,
+    }
+    assert terminal_rung.state == "filled"
+    assert resting.state == "resting"
+
+
 @pytest.mark.parametrize("terminal_status", ["filled", "cancelled"])
 async def test_toss_loss_cut_proposal_approval_submit_and_reconcile_e2e(
     db_session,
@@ -619,6 +688,8 @@ async def test_toss_loss_cut_proposal_approval_submit_and_reconcile_e2e(
 
     unique = uuid4().hex
     broker_order_id = f"toss-loss-cut-{terminal_status}-{unique}"
+    proposal_quantity = Decimal("2") if terminal_status == "filled" else Decimal("3")
+    proposal_price = Decimal("99") if terminal_status == "filled" else Decimal("98")
     now = datetime.now(UTC)
     submit_agent_id = f"proposal-submit-{unique}"
 
@@ -647,7 +718,7 @@ async def test_toss_loss_cut_proposal_approval_submit_and_reconcile_e2e(
         side="sell",
         order_type="limit",
         proposer="e2e-test",
-        rungs=[RungInput(0, "sell", Decimal("2"), Decimal("99"), None)],
+        rungs=[RungInput(0, "sell", proposal_quantity, proposal_price, None)],
         exit_intent="loss_cut",
         exit_reason="stop_loss",
         retrospective_id=42,
@@ -837,7 +908,7 @@ async def test_toss_loss_cut_proposal_approval_submit_and_reconcile_e2e(
     await db_session.refresh(row)
     if terminal_status == "filled":
         terminal = _toss_evidence(
-            verdict="filled", local_status="filled", filled_qty="2"
+            verdict="filled", local_status="filled", filled_qty=str(proposal_quantity)
         )
     else:
         terminal = _toss_evidence(

--- a/tests/mcp_server/tooling/test_toss_live_ledger.py
+++ b/tests/mcp_server/tooling/test_toss_live_ledger.py
@@ -494,6 +494,15 @@ async def test_projection_repair_converges_after_timestamptz_kst_round_trip(
     ).scalar_one()
     assert persisted_kst_day == "20260716"
 
+
+async def test_terminal_rejected_ledger_projection_repairs_resting_rung(db_session):
+    """ROB-900: broker REJECTED/DAY expiry is terminal proposal evidence."""
+    from app.mcp_server.tooling import toss_live_ledger as mod
+
+    proposal_id, row = await _proposal_accepted_row(db_session, suffix="rejected")
+    row.status = "rejected"
+    await db_session.commit()
+
     with (
         patch.object(
             mod.TossLiveOrderLedgerService,
@@ -508,7 +517,9 @@ async def test_projection_repair_converges_after_timestamptz_kst_round_trip(
             ),
         ),
         patch.object(
-            mod.TossLiveOrderLedgerService, "list_open", new=AsyncMock(return_value=[])
+            mod.TossLiveOrderLedgerService,
+            "list_open",
+            new=AsyncMock(return_value=[]),
         ),
     ):
         repaired = await mod.toss_reconcile_orders_impl(dry_run=False)
@@ -519,7 +530,73 @@ async def test_projection_repair_converges_after_timestamptz_kst_round_trip(
         "converged": 1,
         "failed": 0,
     }
-    assert rung.state == "filled"
+    # A broker REJECTED after a submitted DAY order is an expired order, not an
+    # ungrounded transition to the state-machine's submit-time `rejected`.
+    assert rung.state == "expired"
+
+
+async def test_terminal_repair_skips_ambiguous_correlation_link(db_session):
+    """ROB-900: repair must not choose a rung when evidence keys disagree."""
+    from datetime import UTC, datetime
+
+    from app.mcp_server.tooling import toss_live_ledger as mod
+    from app.services.order_proposals import OrderProposalsService
+    from app.services.order_proposals.service import RungInput
+
+    proposal_id, row = await _proposal_accepted_row(db_session, suffix="ambiguous")
+    service = OrderProposalsService(db_session)
+    group = await service.create_proposal(
+        symbol="AAPL",
+        market="equity_us",
+        account_mode="toss_live",
+        side="buy",
+        order_type="limit",
+        proposer="ambiguous-projection-test",
+        rungs=[RungInput(0, "buy", Decimal("2"), Decimal("190"), None)],
+    )
+    for state in ("revalidating", "approved", "submitting"):
+        await service.transition_rung(group.proposal_id, 0, new_state=state)
+    await service.record_resting(
+        group.proposal_id,
+        0,
+        broker_order_id=f"other-{row.broker_order_id}",
+        correlation_id=row.correlation_id,
+        idempotency_key="ambiguous-idempotency",
+        approval_hash_digest="ambiguous-digest",
+        now=datetime.now(UTC),
+    )
+    row.status = "filled"
+    await db_session.commit()
+
+    with (
+        patch.object(
+            mod.TossLiveOrderLedgerService,
+            "reopen_anomalies_for_reconcile",
+            new=AsyncMock(
+                return_value={
+                    "rows": [],
+                    "dry_run": False,
+                    "reopened": 0,
+                    "candidates": 0,
+                }
+            ),
+        ),
+        patch.object(
+            mod.TossLiveOrderLedgerService,
+            "list_open",
+            new=AsyncMock(return_value=[]),
+        ),
+    ):
+        repaired = await mod.toss_reconcile_orders_impl(dry_run=False)
+
+    first = await _proposal_rung(db_session, proposal_id)
+    second = await _proposal_rung(db_session, group.proposal_id)
+    assert repaired["proposal_projection_repair"] == {
+        "candidates": 0,
+        "converged": 0,
+        "failed": 0,
+    }
+    assert first.state == second.state == "resting"
 
 
 @pytest.mark.parametrize("terminal_status", ["filled", "cancelled"])

--- a/tests/mcp_server/tooling/test_toss_live_ledger.py
+++ b/tests/mcp_server/tooling/test_toss_live_ledger.py
@@ -495,6 +495,34 @@ async def test_projection_repair_converges_after_timestamptz_kst_round_trip(
     ).scalar_one()
     assert persisted_kst_day == "20260716"
 
+    from app.mcp_server.tooling import toss_live_ledger as mod
+
+    with (
+        patch.object(
+            mod.TossLiveOrderLedgerService,
+            "reopen_anomalies_for_reconcile",
+            new=AsyncMock(
+                return_value={
+                    "rows": [],
+                    "dry_run": False,
+                    "reopened": 0,
+                    "candidates": 0,
+                }
+            ),
+        ),
+        patch.object(
+            mod.TossLiveOrderLedgerService, "list_open", new=AsyncMock(return_value=[])
+        ),
+    ):
+        repaired = await mod.toss_reconcile_orders_impl(dry_run=False)
+    rung = await _proposal_rung(db_session, proposal_id)
+    assert repaired["proposal_projection_repair"] == {
+        "candidates": 1,
+        "converged": 1,
+        "failed": 0,
+    }
+    assert rung.state == "filled"
+
 
 async def test_terminal_rejected_ledger_projection_repairs_resting_rung(db_session):
     """ROB-900: broker REJECTED/DAY expiry is terminal proposal evidence."""

--- a/tests/mcp_server/tooling/test_toss_live_ledger.py
+++ b/tests/mcp_server/tooling/test_toss_live_ledger.py
@@ -441,6 +441,7 @@ async def test_terminal_ledger_projection_failure_is_retried_by_sweep(db_session
         "candidates": 1,
         "converged": 1,
         "failed": 0,
+        "anomalies": {},
     }
     assert rung.state == "filled"
     assert rung.filled_qty == Decimal("2")
@@ -520,6 +521,7 @@ async def test_projection_repair_converges_after_timestamptz_kst_round_trip(
         "candidates": 1,
         "converged": 1,
         "failed": 0,
+        "anomalies": {},
     }
     assert rung.state == "filled"
 
@@ -558,6 +560,7 @@ async def test_terminal_rejected_ledger_projection_repairs_resting_rung(db_sessi
         "candidates": 1,
         "converged": 1,
         "failed": 0,
+        "anomalies": {},
     }
     # A broker REJECTED after a submitted DAY order is an expired order, not an
     # ungrounded transition to the state-machine's submit-time `rejected`.
@@ -624,6 +627,7 @@ async def test_terminal_repair_skips_ambiguous_correlation_link(db_session):
         "candidates": 0,
         "converged": 0,
         "failed": 0,
+        "anomalies": {},
     }
     assert first.state == second.state == "resting"
 
@@ -691,6 +695,7 @@ async def test_terminal_repair_skips_terminal_and_resting_key_conflict(db_sessio
         "candidates": 0,
         "converged": 0,
         "failed": 0,
+        "anomalies": {},
     }
     assert terminal_rung.state == "filled"
     assert resting.state == "resting"

--- a/tests/mcp_server/tooling/test_toss_live_ledger.py
+++ b/tests/mcp_server/tooling/test_toss_live_ledger.py
@@ -592,11 +592,13 @@ async def test_terminal_repair_skips_ambiguous_correlation_link(db_session):
         group.proposal_id,
         0,
         broker_order_id=f"other-{row.broker_order_id}",
-        correlation_id=row.correlation_id,
+        correlation_id=f"terminal-{row.correlation_id}",
         idempotency_key="ambiguous-idempotency",
         approval_hash_digest="ambiguous-digest",
         now=datetime.now(UTC),
     )
+    await service.transition_rung(group.proposal_id, 0, new_state="filled")
+    row.correlation_id = f"terminal-{row.correlation_id}"
     row.status = "filled"
     await db_session.commit()
 
@@ -627,9 +629,10 @@ async def test_terminal_repair_skips_ambiguous_correlation_link(db_session):
         "candidates": 0,
         "converged": 0,
         "failed": 0,
-        "anomalies": {},
+        "anomalies": {"proposal_evidence_conflict": 1},
     }
-    assert first.state == second.state == "resting"
+    assert first.state == "resting"
+    assert second.state == "filled"
 
 
 async def test_terminal_repair_skips_terminal_and_resting_key_conflict(db_session):
@@ -659,12 +662,13 @@ async def test_terminal_repair_skips_terminal_and_resting_key_conflict(db_sessio
         terminal.proposal_id,
         0,
         broker_order_id=f"terminal-{row.broker_order_id}",
-        correlation_id=row.correlation_id,
+        correlation_id=f"terminal-{row.correlation_id}",
         idempotency_key="terminal-conflict-idempotency",
         approval_hash_digest="terminal-conflict-digest",
         now=datetime.now(UTC),
     )
     await service.transition_rung(terminal.proposal_id, 0, new_state="filled")
+    row.correlation_id = f"terminal-{row.correlation_id}"
     row.status = "filled"
     await db_session.commit()
 
@@ -695,7 +699,7 @@ async def test_terminal_repair_skips_terminal_and_resting_key_conflict(db_sessio
         "candidates": 0,
         "converged": 0,
         "failed": 0,
-        "anomalies": {},
+        "anomalies": {"proposal_evidence_conflict": 1},
     }
     assert terminal_rung.state == "filled"
     assert resting.state == "resting"

--- a/tests/services/order_proposals/test_projection_evidence_resolution.py
+++ b/tests/services/order_proposals/test_projection_evidence_resolution.py
@@ -1,0 +1,227 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from decimal import Decimal
+from uuid import uuid4
+
+import pytest
+
+from app.services.order_proposals import OrderProposalsService
+from app.services.order_proposals.service import OrderProposalError, RungInput
+
+pytestmark = [pytest.mark.unit, pytest.mark.asyncio]
+
+
+@pytest.fixture(
+    params=[("toss_live", "equity_us", "AAPL"), ("kis_live", "equity_kr", "005930")]
+)
+def broker_scope(request):
+    return request.param
+
+
+async def _resting_rung(
+    db_session,
+    *,
+    account_mode: str,
+    market: str,
+    symbol: str,
+    broker_order_id: str | None,
+    correlation_id: str | None,
+    idempotency_key: str | None = None,
+):
+    service = OrderProposalsService(db_session)
+    group = await service.create_proposal(
+        symbol=symbol,
+        market=market,
+        account_mode=account_mode,
+        side="sell",
+        order_type="limit",
+        proposer="projection-evidence-test",
+        rungs=[RungInput(0, "sell", Decimal("2"), Decimal("100"), None)],
+    )
+    for state in ("revalidating", "approved", "submitting"):
+        await service.transition_rung(group.proposal_id, 0, new_state=state)
+    await service.record_resting(
+        group.proposal_id,
+        0,
+        broker_order_id=broker_order_id,
+        correlation_id=correlation_id,
+        idempotency_key=idempotency_key,
+        approval_hash_digest=f"digest-{uuid4().hex}",
+        now=datetime.now(UTC),
+    )
+    _, rungs = await service.get_proposal(group.proposal_id)
+    return group.proposal_id, rungs[0].id
+
+
+async def _rung(db_session, proposal_id):
+    _, rungs = await OrderProposalsService(db_session).get_proposal(proposal_id)
+    await db_session.refresh(rungs[0])
+    return rungs[0]
+
+
+async def test_intersection_keeps_terminal_sibling_untouched_and_transitions_owner(
+    db_session, broker_scope
+):
+    """broker={B}, corr={A,B}: R1 selects B even when A is terminal."""
+    account_mode, market, symbol = broker_scope
+    unique = uuid4().hex
+    broker_b = f"broker-b-{unique}"
+    broker_a = f"broker-a-{unique}"
+    correlation = f"corr-siblings-{unique}"
+    b_proposal, b_id = await _resting_rung(
+        db_session,
+        account_mode=account_mode,
+        market=market,
+        symbol=symbol,
+        broker_order_id=broker_b,
+        correlation_id=correlation,
+    )
+    a_proposal, _ = await _resting_rung(
+        db_session,
+        account_mode=account_mode,
+        market=market,
+        symbol=symbol,
+        broker_order_id=broker_a,
+        correlation_id=correlation,
+    )
+    service = OrderProposalsService(db_session)
+    await service.transition_rung(a_proposal, 0, new_state="filled")
+
+    owner = await service.find_unambiguous_evidence_rung_id(
+        broker_order_id=broker_b,
+        correlation_id=correlation,
+        account_mode=account_mode,
+        market=market,
+        symbol=symbol,
+    )
+    assert owner == b_id
+    transitioned = await service.record_fill_evidence_for_rung(
+        rung_id=owner,
+        broker_order_id=broker_b,
+        correlation_id=correlation,
+        filled_qty=Decimal("2"),
+        terminal_state="filled",
+        now=datetime.now(UTC),
+        account_mode=account_mode,
+        market=market,
+        symbol=symbol,
+    )
+    assert transitioned is not None and transitioned.id == b_id
+    assert (await _rung(db_session, b_proposal)).state == "filled"
+    assert (await _rung(db_session, a_proposal)).state == "filled"
+
+
+async def test_correlation_only_content_hash_siblings_are_classified_separately(
+    db_session, broker_scope
+):
+    account_mode, market, symbol = broker_scope
+    correlation = f"corr-content-{uuid4().hex}"
+    await _resting_rung(
+        db_session,
+        account_mode=account_mode,
+        market=market,
+        symbol=symbol,
+        broker_order_id=f"broker-1-{uuid4().hex}",
+        correlation_id=correlation,
+    )
+    await _resting_rung(
+        db_session,
+        account_mode=account_mode,
+        market=market,
+        symbol=symbol,
+        broker_order_id=f"broker-2-{uuid4().hex}",
+        correlation_id=correlation,
+    )
+    service = OrderProposalsService(db_session)
+    with pytest.raises(OrderProposalError, match="content_hash_only_ambiguous"):
+        await service.find_unambiguous_evidence_rung_id(
+            broker_order_id=None,
+            correlation_id=correlation,
+            account_mode=account_mode,
+            market=market,
+            symbol=symbol,
+        )
+
+
+async def test_duplicate_broker_id_is_classified_separately(db_session, broker_scope):
+    account_mode, market, symbol = broker_scope
+    broker_order_id = f"broker-duplicate-{uuid4().hex}"
+    await _resting_rung(
+        db_session,
+        account_mode=account_mode,
+        market=market,
+        symbol=symbol,
+        broker_order_id=broker_order_id,
+        correlation_id=f"corr-1-{uuid4().hex}",
+    )
+    await _resting_rung(
+        db_session,
+        account_mode=account_mode,
+        market=market,
+        symbol=symbol,
+        broker_order_id=broker_order_id,
+        correlation_id=f"corr-2-{uuid4().hex}",
+    )
+    service = OrderProposalsService(db_session)
+    with pytest.raises(OrderProposalError, match="broker_id_duplicate"):
+        await service.find_unambiguous_evidence_rung_id(
+            broker_order_id=broker_order_id,
+            correlation_id=None,
+            account_mode=account_mode,
+            market=market,
+            symbol=symbol,
+        )
+
+
+async def test_superseded_shared_client_id_uses_intersection_not_key_priority(
+    db_session, broker_scope
+):
+    """A content-derived client id may be shared; broker evidence chooses B."""
+    account_mode, market, symbol = broker_scope
+    unique = uuid4().hex
+    correlation = f"corr-supersede-{unique}"
+    idempotency_key = f"tossp6-{unique[:16]}"
+    broker_b = f"broker-b-{unique}"
+    b_proposal, b_id = await _resting_rung(
+        db_session,
+        account_mode=account_mode,
+        market=market,
+        symbol=symbol,
+        broker_order_id=broker_b,
+        correlation_id=correlation,
+        idempotency_key=idempotency_key,
+    )
+    a_proposal, _ = await _resting_rung(
+        db_session,
+        account_mode=account_mode,
+        market=market,
+        symbol=symbol,
+        broker_order_id=f"broker-a-{unique}",
+        correlation_id=correlation,
+        idempotency_key=idempotency_key,
+    )
+    service = OrderProposalsService(db_session)
+    owner = await service.find_unambiguous_evidence_rung_id(
+        broker_order_id=broker_b,
+        correlation_id=correlation,
+        idempotency_key=idempotency_key,
+        account_mode=account_mode,
+        market=market,
+        symbol=symbol,
+    )
+    assert owner == b_id
+    await service.record_fill_evidence_for_rung(
+        rung_id=owner,
+        broker_order_id=broker_b,
+        correlation_id=correlation,
+        idempotency_key=idempotency_key,
+        filled_qty=Decimal("2"),
+        terminal_state="filled",
+        now=datetime.now(UTC),
+        account_mode=account_mode,
+        market=market,
+        symbol=symbol,
+    )
+    assert (await _rung(db_session, b_proposal)).state == "filled"
+    assert (await _rung(db_session, a_proposal)).state == "resting"

--- a/tests/services/order_proposals/test_projection_evidence_resolution.py
+++ b/tests/services/order_proposals/test_projection_evidence_resolution.py
@@ -174,6 +174,103 @@ async def test_duplicate_broker_id_is_classified_separately(db_session, broker_s
         )
 
 
+async def test_disjoint_broker_and_correlation_keys_are_a_conflict(
+    db_session, broker_scope
+):
+    account_mode, market, symbol = broker_scope
+    unique = uuid4().hex
+    await _resting_rung(
+        db_session,
+        account_mode=account_mode,
+        market=market,
+        symbol=symbol,
+        broker_order_id=f"broker-b-{unique}",
+        correlation_id=f"corr-b-{unique}",
+    )
+    terminal_proposal, _ = await _resting_rung(
+        db_session,
+        account_mode=account_mode,
+        market=market,
+        symbol=symbol,
+        broker_order_id=f"broker-a-{unique}",
+        correlation_id=f"corr-a-{unique}",
+    )
+    service = OrderProposalsService(db_session)
+    await service.transition_rung(terminal_proposal, 0, new_state="filled")
+    with pytest.raises(OrderProposalError, match="proposal_evidence_conflict"):
+        await service.find_unambiguous_evidence_rung_id(
+            broker_order_id=f"broker-b-{unique}",
+            correlation_id=f"corr-a-{unique}",
+            account_mode=account_mode,
+            market=market,
+            symbol=symbol,
+        )
+
+
+async def test_disjoint_broker_and_client_id_keys_are_a_conflict(
+    db_session, broker_scope
+):
+    account_mode, market, symbol = broker_scope
+    unique = uuid4().hex
+    await _resting_rung(
+        db_session,
+        account_mode=account_mode,
+        market=market,
+        symbol=symbol,
+        broker_order_id=f"broker-b-{unique}",
+        correlation_id=None,
+    )
+    terminal_proposal, _ = await _resting_rung(
+        db_session,
+        account_mode=account_mode,
+        market=market,
+        symbol=symbol,
+        broker_order_id=f"broker-a-{unique}",
+        correlation_id=None,
+        idempotency_key=f"client-a-{unique}",
+    )
+    service = OrderProposalsService(db_session)
+    await service.transition_rung(terminal_proposal, 0, new_state="filled")
+    with pytest.raises(OrderProposalError, match="proposal_evidence_conflict"):
+        await service.find_unambiguous_evidence_rung_id(
+            broker_order_id=f"broker-b-{unique}",
+            correlation_id=None,
+            idempotency_key=f"client-a-{unique}",
+            account_mode=account_mode,
+            market=market,
+            symbol=symbol,
+        )
+
+
+async def test_overlapping_multi_rung_intersection_is_ambiguous(
+    db_session, broker_scope
+):
+    account_mode, market, symbol = broker_scope
+    unique = uuid4().hex
+    corr = f"corr-shared-{unique}"
+    idempotency_key = f"idem-shared-{unique}"
+    for index in range(2):
+        await _resting_rung(
+            db_session,
+            account_mode=account_mode,
+            market=market,
+            symbol=symbol,
+            broker_order_id=f"broker-{index}-{unique}",
+            correlation_id=corr,
+            idempotency_key=idempotency_key,
+        )
+    service = OrderProposalsService(db_session)
+    with pytest.raises(OrderProposalError, match="proposal_evidence_ambiguous"):
+        await service.find_unambiguous_evidence_rung_id(
+            broker_order_id=None,
+            correlation_id=corr,
+            idempotency_key=idempotency_key,
+            account_mode=account_mode,
+            market=market,
+            symbol=symbol,
+        )
+
+
 async def test_superseded_shared_client_id_uses_intersection_not_key_priority(
     db_session, broker_scope
 ):


### PR DESCRIPTION
## Problem
`toss_reconcile_orders`/`kis_live_reconcile_orders` booked fills to execution_ledger but left the linked order_proposal rung `resting` (`proposal_projection_repair: {candidates:0}`) → stale resting rungs, duplicate-sell risk. Root cause (per broker): KIS had **no** projection-repair path; Toss candidate filter excluded rejected/expired.

## Fix — R1 "resolving-keys intersection" ownership (Fable-reviewed)
Owner rung = the single rung in the **intersection of all non-empty resolving-key sets** (broker_order_id / correlation_id / client_order_id). Absence of a key is neutral; disagreement is fail-closed.
- Intersection = 1 rung → transition (locked, re-verified).
- Disjoint (∅) → `proposal_evidence_conflict` → skip (P0 guard).
- `content_hash_only_ambiguous` / `broker_id_duplicate` / `proposal_evidence_ambiguous` → skip, surfaced in report `anomalies` for backfill triage.
- Both the **matcher** and the **candidate pre-filter** use identical R1 logic, and callers pass **every** evidence key (incl. client_order_id/idempotency) to both.
- Transition semantics: idempotent-terminal (same state+broker) = no-op converged; terminal-invariant (never overwrite); non-terminal = FOR UPDATE lock + re-verify.
- **KIS** gains a projection-repair path + same-pass convergence of newly-booked fills (one reconcile pass, no next-scan dependency).

Why not "unique-key priority" (R2): `client_order_id` is also content-derived (`tossp6-<sha16>`), so promoting any single key reopens the cross-rung P0. R1 assumes no uniqueness — set algebra reads discriminating power from the data.

## Production link backfill — evidence-first, separate
`scripts/list_rob900_toss_projection_backfill_candidates.py`: **read-only** (`SET TRANSACTION READ ONLY`, no `--apply`), conservative single-match (same symbol/market/side + exact qty + 300s window; 0/multi excluded). Prod scan: 372 unlinked terminal rows, 0 conservative suggestions. Runbook included. No automated write.

## Verification (adversarial, multiple rounds)
Two P0-class regressions were caught and closed during review:
1. First fix force-transitioned a *different* rung on terminal/resting key conflict → fixed with intersection + exact-rung lock.
2. Callers weren't feeding client/idempotency keys → client-key P0 path → fixed by wiring every key to both layers.
Final adversarial verify (real PostgreSQL): disjoint-key P0 and client-key P0 both **fail-closed** (rung stays resting, sibling untouched, report `proposal_evidence_conflict:1`); RED authentic (guard-neuter → red); ROB-933 untouched; boundaries clean. Suite: **703 passed, 0 failed**, ruff/ty clean.

## Out of scope (separate)
- Production link backfill *execution* (dry-run list only here).
- ROB-934 (websocket timestamp), ROB-933 (filled_at — merged).

Closes ROB-900

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Live order reconciliation now projects completed, partially filled, cancelled, and rejected orders into proposal states.
  * Reconciliation results include projection-repair counts and evidence anomaly details.
  * Added conservative, read-only tooling to identify potential Toss proposal-link backfill candidates.

* **Bug Fixes**
  * Improved handling of missed terminal projections and duplicate or conflicting evidence.
  * Rejected orders now correctly appear as expired proposal outcomes.

* **Documentation**
  * Added an operator runbook for reviewing backfill candidates safely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->