### PR TITLE
feat(ROB-942): deterministic 1m execution engine — next-bar fill, SL-first, corrected costs

### DIFF
--- a/research/nautilus_scalping/rob940_bars_agg.py
+++ b/research/nautilus_scalping/rob940_bars_agg.py
@@ -17,6 +17,7 @@ No DB/network/app/broker imports — pure stdlib, deterministic given its input.
 
 from __future__ import annotations
 
+import math
 from collections.abc import Sequence
 from dataclasses import dataclass
 
@@ -31,6 +32,14 @@ class Bar1m:
     low: float
     close: float
     volume: float
+
+    def __post_init__(self) -> None:
+        # ROB-942 R1 M1: reject NaN/+-Inf at the input boundary (fail-closed)
+        # before any downstream aggregation/engine/ledger code can see it.
+        for field_name in ("open", "high", "low", "close", "volume"):
+            value = getattr(self, field_name)
+            if not math.isfinite(value):
+                raise ValueError(f"Bar1m.{field_name} must be finite, got {value!r}")
 
 
 @dataclass(frozen=True)

--- a/research/nautilus_scalping/rob940_bars_agg.py
+++ b/research/nautilus_scalping/rob940_bars_agg.py
@@ -1,0 +1,110 @@
+"""ROB-942 (H2, ROB-940) — complete-only 1m -> 5m/15m OHLCV aggregation (pure, stdlib).
+
+AC2: 5m/15m OHLCV buckets are emitted ONLY when every one of their constituent
+1m bars is present, contiguous (exactly 60s apart), and aligned to the UTC
+bucket grid (``bucket_start = floor(ts / bucket_ms) * bucket_ms``). A single
+missing/gapped 1m bar anywhere in a bucket's span means that bucket is never
+emitted (no partial/bridged buckets, no leading/trailing partials).
+
+A gap in the underlying 1m stream also resets "warm-up": the FIRST bucket that
+completes after a gap is marked ``is_segment_start=True`` so any downstream
+indicator state (H3) knows it must restart rather than treat history across
+the gap as continuous. This module has no opinion on what "warm-up" means for
+any particular indicator — it only exposes the discontinuity boundary.
+
+No DB/network/app/broker imports — pure stdlib, deterministic given its input.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+_MS_PER_MINUTE = 60_000
+
+
+@dataclass(frozen=True)
+class Bar1m:
+    ts: int  # open_time, epoch ms UTC, minute-aligned
+    open: float
+    high: float
+    low: float
+    close: float
+    volume: float
+
+
+@dataclass(frozen=True)
+class AggregatedBar:
+    ts: int  # bucket open_time (start), epoch ms UTC
+    open: float
+    high: float
+    low: float
+    close: float
+    volume: float
+    close_ts: int  # bucket close boundary == ts of the immediately-following 1m bar
+    is_segment_start: bool  # True iff this is the first complete bucket after a gap
+
+
+def _validate_sorted_1m(bars_1m: Sequence[Bar1m]) -> None:
+    for i in range(1, len(bars_1m)):
+        if bars_1m[i].ts <= bars_1m[i - 1].ts:
+            raise ValueError(
+                "bars_1m must be strictly increasing by ts; got "
+                f"{bars_1m[i - 1].ts} then {bars_1m[i].ts}"
+            )
+
+
+def _split_contiguous_segments(bars_1m: Sequence[Bar1m]) -> list[list[Bar1m]]:
+    """Split into maximal runs of exactly-60s-spaced 1m bars."""
+    if not bars_1m:
+        return []
+    segments: list[list[Bar1m]] = [[bars_1m[0]]]
+    for prev, cur in zip(bars_1m, bars_1m[1:], strict=False):
+        if cur.ts == prev.ts + _MS_PER_MINUTE:
+            segments[-1].append(cur)
+        else:
+            segments.append([cur])
+    return segments
+
+
+def aggregate_complete(
+    bars_1m: Sequence[Bar1m], bucket_minutes: int
+) -> list[AggregatedBar]:
+    """Aggregate 1m bars into complete, UTC-grid-aligned ``bucket_minutes`` buckets.
+
+    Only fully-covered buckets are emitted. Raises ``ValueError`` if
+    ``bars_1m`` is not strictly increasing by ``ts`` or ``bucket_minutes`` is
+    not positive.
+    """
+    if bucket_minutes <= 0:
+        raise ValueError("bucket_minutes must be positive")
+    _validate_sorted_1m(bars_1m)
+    bucket_ms = bucket_minutes * _MS_PER_MINUTE
+    out: list[AggregatedBar] = []
+    for segment in _split_contiguous_segments(bars_1m):
+        by_ts = {b.ts: b for b in segment}
+        seen_starts: set[int] = set()
+        first_in_segment = True
+        for b in segment:
+            start = (b.ts // bucket_ms) * bucket_ms
+            if start in seen_starts:
+                continue
+            seen_starts.add(start)
+            offsets = [start + k * _MS_PER_MINUTE for k in range(bucket_minutes)]
+            if not all(o in by_ts for o in offsets):
+                continue
+            source = [by_ts[o] for o in offsets]
+            out.append(
+                AggregatedBar(
+                    ts=start,
+                    open=source[0].open,
+                    high=max(x.high for x in source),
+                    low=min(x.low for x in source),
+                    close=source[-1].close,
+                    volume=sum(x.volume for x in source),
+                    close_ts=start + bucket_ms,
+                    is_segment_start=first_in_segment,
+                )
+            )
+            first_in_segment = False
+    return out

--- a/research/nautilus_scalping/rob940_cost_model.py
+++ b/research/nautilus_scalping/rob940_cost_model.py
@@ -6,10 +6,26 @@ superseding the GPT Pro research draft's 4bp/8bp/11bp/15bp/60bp figures):
   * taker fee: 5bp per leg -> 10bp round trip (``FEE_ROUND_TRIP_BPS``).
   * round-trip all-in scenarios: base=13bp, primary stress=17bp,
     upward stress=22bp. ``COST_SCENARIO_PRIMARY_STRESS`` (17bp) is the
-    selection/scoring cost; 13/22bp are pre-registered sensitivity scenarios
-    over the SAME trade path (see ``rob940_engine.run_symbol_stream``, which
-    takes one ``CostScenario`` per invocation and reproduces the identical
-    entries/exits across scenarios).
+    selection/scoring cost; 13/22bp are pre-registered sensitivity scenarios.
+  * ROB-942 R1 correction (2026-07-17, supersedes an earlier "identical
+    entries/exits across scenarios" claim in this docstring that a verifier
+    proved false by repro): each ``CostScenario`` is simulated via its OWN
+    independent ``rob940_engine.run_symbol_stream`` invocation/ledger, not a
+    net-only revaluation of one shared path. The signal ELIGIBILITY gate
+    (``MIN_TP_DISTANCE_BPS``, 68bp) is a fixed value derived once from the
+    primary-stress scenario — it does NOT vary per scenario, so which signals
+    are even considered for entry is identical across the three runs. But
+    AC8's cost-included ``<=-2.0R`` daily stop uses each scenario's own
+    ``net_bps`` (which subtracts that scenario's ``all_in_bps``), so the point
+    at which a day HALTS can differ by scenario: a higher-cost scenario can
+    reach ``-2.0R`` sooner than a lower-cost one on the exact same bars/
+    signals, producing fewer trades (a shorter path) for that scenario alone.
+    This is intentional (AC8 is deliberately cost-included, not cost-blind)
+    and each run's ledger is self-consistent; it is simply NOT a same-path
+    sensitivity revaluation. See ``rob940_engine.run_symbol_stream`` for the
+    mechanism and the pinning regression tests in
+    ``tests/test_rob940_engine.py`` (68bp-gate-identical-across-scenarios /
+    cost-scenario-dependent-daily-stop-diverges-trade-count).
   * ``MIN_TP_DISTANCE_BPS`` (68bp) is DERIVED as 4x the primary stress
     all-in, not a bare literal, so the two numbers cannot silently drift apart
     (AC7 pins the derived value, not the multiplier).
@@ -25,6 +41,7 @@ No DB/network/app/broker imports — pure stdlib, deterministic given its input.
 
 from __future__ import annotations
 
+import math
 from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Literal
@@ -40,6 +57,13 @@ FEE_ROUND_TRIP_BPS = FEE_ENTRY_BPS + FEE_EXIT_BPS  # 10.0
 class CostScenario:
     name: str
     all_in_bps: float  # round-trip all-in bps; already embeds FEE_ROUND_TRIP_BPS
+
+    def __post_init__(self) -> None:
+        # ROB-942 R1 M1: reject NaN/+-Inf fail-closed at construction.
+        if not math.isfinite(self.all_in_bps):
+            raise ValueError(
+                f"CostScenario.all_in_bps must be finite, got {self.all_in_bps!r}"
+            )
 
 
 COST_SCENARIO_BASE = CostScenario("base", 13.0)
@@ -61,6 +85,13 @@ class FundingCrossing:
     ts: int  # crossing timestamp, epoch ms UTC, entry_ts < ts <= exit_ts
     rate_bps: float  # signed realized funding rate; positive => longs pay shorts
 
+    def __post_init__(self) -> None:
+        # ROB-942 R1 M1: reject NaN/+-Inf fail-closed at construction.
+        if not math.isfinite(self.rate_bps):
+            raise ValueError(
+                f"FundingCrossing.rate_bps must be finite, got {self.rate_bps!r}"
+            )
+
 
 def gross_bps(side: Side, entry_price: float, exit_price: float) -> float:
     """Signed gross price-return in bps, entry-based (linear) and long/short symmetric.
@@ -71,6 +102,10 @@ def gross_bps(side: Side, entry_price: float, exit_price: float) -> float:
     the R-multiple accounting (``R = net_bps / sl_distance_bps``, AC8) to mean
     the same thing for longs and shorts.
     """
+    if not math.isfinite(entry_price):
+        raise ValueError(f"entry_price must be finite, got {entry_price!r}")
+    if not math.isfinite(exit_price):
+        raise ValueError(f"exit_price must be finite, got {exit_price!r}")
     if entry_price <= 0:
         raise ValueError("entry_price must be positive")
     if side == "long":
@@ -100,4 +135,8 @@ def net_bps(gross: float, cost_scenario: CostScenario, funding: float) -> float:
     ``cost_scenario.all_in_bps`` already embeds the round-trip fee — do not
     additionally subtract ``FEE_ROUND_TRIP_BPS`` here (that would double-count).
     """
+    if not math.isfinite(gross):
+        raise ValueError(f"gross must be finite, got {gross!r}")
+    if not math.isfinite(funding):
+        raise ValueError(f"funding must be finite, got {funding!r}")
     return gross - cost_scenario.all_in_bps - funding

--- a/research/nautilus_scalping/rob940_cost_model.py
+++ b/research/nautilus_scalping/rob940_cost_model.py
@@ -1,0 +1,103 @@
+"""ROB-942 (H2, ROB-940) — corrected cost model (pure, stdlib).
+
+Frozen ROB-940 cost contract (orch 2026-07-17 fee-recalibration comment,
+superseding the GPT Pro research draft's 4bp/8bp/11bp/15bp/60bp figures):
+
+  * taker fee: 5bp per leg -> 10bp round trip (``FEE_ROUND_TRIP_BPS``).
+  * round-trip all-in scenarios: base=13bp, primary stress=17bp,
+    upward stress=22bp. ``COST_SCENARIO_PRIMARY_STRESS`` (17bp) is the
+    selection/scoring cost; 13/22bp are pre-registered sensitivity scenarios
+    over the SAME trade path (see ``rob940_engine.run_symbol_stream``, which
+    takes one ``CostScenario`` per invocation and reproduces the identical
+    entries/exits across scenarios).
+  * ``MIN_TP_DISTANCE_BPS`` (68bp) is DERIVED as 4x the primary stress
+    all-in, not a bare literal, so the two numbers cannot silently drift apart
+    (AC7 pins the derived value, not the multiplier).
+
+Funding is a PIT-safe sidecar concern (H1 supplies realized crossings via an
+explicit pure input); this module only defines the crossing shape and the
+sign convention for turning crossings into a signed cost, plus the single
+"subtract everything exactly once" net formula (AC6: no fee+all_in+funding
+double count).
+
+No DB/network/app/broker imports — pure stdlib, deterministic given its input.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Literal
+
+Side = Literal["long", "short"]
+
+FEE_ENTRY_BPS = 5.0
+FEE_EXIT_BPS = 5.0
+FEE_ROUND_TRIP_BPS = FEE_ENTRY_BPS + FEE_EXIT_BPS  # 10.0
+
+
+@dataclass(frozen=True)
+class CostScenario:
+    name: str
+    all_in_bps: float  # round-trip all-in bps; already embeds FEE_ROUND_TRIP_BPS
+
+
+COST_SCENARIO_BASE = CostScenario("base", 13.0)
+COST_SCENARIO_PRIMARY_STRESS = CostScenario("primary_stress", 17.0)
+COST_SCENARIO_UPWARD_STRESS = CostScenario("upward_stress", 22.0)
+COST_SCENARIOS: tuple[CostScenario, ...] = (
+    COST_SCENARIO_BASE,
+    COST_SCENARIO_PRIMARY_STRESS,
+    COST_SCENARIO_UPWARD_STRESS,
+)
+
+# AC7: computed TP distance <68bp is no-trade; ==68bp is allowed. Derived, not
+# hardcoded, from 4x the primary stress scenario (frozen relationship).
+MIN_TP_DISTANCE_BPS = 4.0 * COST_SCENARIO_PRIMARY_STRESS.all_in_bps  # 68.0
+
+
+@dataclass(frozen=True)
+class FundingCrossing:
+    ts: int  # crossing timestamp, epoch ms UTC, entry_ts < ts <= exit_ts
+    rate_bps: float  # signed realized funding rate; positive => longs pay shorts
+
+
+def gross_bps(side: Side, entry_price: float, exit_price: float) -> float:
+    """Signed gross price-return in bps, entry-based (linear) and long/short symmetric.
+
+    Entry-based (not exit-based) so a fill that lands EXACTLY on a barrier
+    computed as ``entry * (1 +/- d_bps/1e4)`` (see ``rob940_engine``) realizes
+    gross_bps with magnitude exactly ``d_bps`` on both sides — required for
+    the R-multiple accounting (``R = net_bps / sl_distance_bps``, AC8) to mean
+    the same thing for longs and shorts.
+    """
+    if entry_price <= 0:
+        raise ValueError("entry_price must be positive")
+    if side == "long":
+        return (exit_price - entry_price) / entry_price * 1e4
+    if side == "short":
+        return (entry_price - exit_price) / entry_price * 1e4
+    raise ValueError(f"unknown side {side!r}")
+
+
+def realized_funding_bps(side: Side, crossings: Sequence[FundingCrossing]) -> float:
+    """Signed realized funding cost for the hold (positive = cost, negative = credit).
+
+    Longs pay when the realized rate is positive (shorts receive); the
+    convention flips sign for shorts.
+    """
+    total_rate = sum(c.rate_bps for c in crossings)
+    if side == "long":
+        return total_rate
+    if side == "short":
+        return -total_rate
+    raise ValueError(f"unknown side {side!r}")
+
+
+def net_bps(gross: float, cost_scenario: CostScenario, funding: float) -> float:
+    """AC6: net = gross - all_in(scenario) - funding, each subtracted exactly once.
+
+    ``cost_scenario.all_in_bps`` already embeds the round-trip fee — do not
+    additionally subtract ``FEE_ROUND_TRIP_BPS`` here (that would double-count).
+    """
+    return gross - cost_scenario.all_in_bps - funding

--- a/research/nautilus_scalping/rob940_engine.py
+++ b/research/nautilus_scalping/rob940_engine.py
@@ -1,0 +1,426 @@
+"""ROB-942 (H2, ROB-940) — deterministic 1m execution engine (pure, stdlib).
+
+Signal MATH (Donchian-15m / confirmed-shock-reversal-5m, ROB-943/H3) and
+account-global multi-symbol arbitration are OUT of scope here — this module
+owns only: next-bar-open fill, bar-ordering (gap-exit-first then intrabar,
+same-bar SL-first), single-position-per-symbol sequencing (cooldown/timeout),
+UTC-day entry cap and stop-out/loss halts, and cost/funding accounting. See
+``rob940_bars_agg`` for 5m/15m aggregation and ``rob940_cost_model`` for the
+fee/all-in/funding primitives this module composes. ``run_symbol_stream``
+processes ONE symbol's bars/signals per call — H4 (walk-forward runner, not
+built here) is expected to call it once per symbol; no cross-symbol state
+exists anywhere in this module (AC4).
+
+ultrathink decisions (frozen; see the ROB-942 completion report for the full
+write-up):
+
+  * ``SignalEvent.signal_ts`` is defined as the CLOSE boundary of the signal
+    bar. For a contiguous 1m grid that is numerically identical to the ``ts``
+    (open time) of the very next 1m bar — one candle's close is the next
+    candle's open. The engine's "next contiguous 1m bar" (AC3) is therefore
+    the bar found AT ``ts == signal_ts``; if it's missing, there is no entry.
+    This keeps the engine fully decoupled from signal-timeframe (5m vs 15m)
+    bucket size: it never needs to know which timeframe produced a signal.
+  * TP may be given either as a distance in bps from entry (Strategy 1, known
+    at signal time) or as an absolute target price (Strategy 2, whose
+    distance is only knowable once E is resolved: ``d_TP=|T/E-1|``). Exactly
+    one of ``tp_distance_bps``/``tp_target_price`` must be set; this engine
+    resolves the actual distance against E and applies the shared >=68bp gate
+    (AC7). Strategy-specific EXTRA TP bounds (e.g. Strategy 2's <=1.20%/
+    >=R_min*d_SL) are NOT enforced here — those belong to the signal layer
+    (H3/H4), which owns the strategy-specific formulas, not the shared
+    execution-layer cost gate.
+  * A gap-through gets the unfavorable "fill at open" price ONLY for a stop
+    loss; a favorable gap through TP fills at the TP barrier (no windfall) —
+    symmetric with "normal touch = barrier price" for every other case. This
+    generalizes the repo's existing conservative SL-first convention
+    (rob382_backtest.py) to the gap-open case.
+  * ``exit_reason`` has exactly 3 values (take_profit/stop_loss/timeout) so
+    consecutive-stop-out accounting (AC8) has one unambiguous check; a
+    separate ``gap_fill`` bool preserves the gap-vs-touch fill-mechanism
+    distinction for audit without forking that logic into a 4th reason.
+  * UTC-day bucketing for the entry cap / stop-out halt / -2.0R halt (AC8)
+    keys off the RESOLVED ``entry_ts``, not ``signal_ts``, so a signal firing
+    near a UTC midnight boundary is attributed to the day its capital is
+    actually at risk.
+  * Cooldown and "position still open" are the SAME check: the candidate
+    entry's bar index must be >= ``last_exit_idx + cooldown_bars``. Since
+    ``last_exit_idx`` is only known once a position closes, a signal whose
+    candidate entry falls inside the PRIOR trade's still-open hold also fails
+    this check (entry_idx <= exit_idx < exit_idx + cooldown_bars) — no
+    separate "position already open" reason is needed (AC4 single-position
+    stream + AC8 cooldown collapse into one gate).
+  * Consecutive-stop-out counting resets on ANY non-stop_loss exit (take
+    profit OR timeout) — only back-to-back SL exits count as a "stop-out
+    streak"; a timeout is not a stop-out.
+  * ``fold_id`` is a pass-through field for H4 (walk-forward runner); this
+    engine does not compute or validate fold boundaries.
+
+No DB/network/app/broker/order/fill/scheduler imports — pure stdlib plus the
+existing research_contracts canonical-hash authority (itself stdlib-only),
+deterministic given its input.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from datetime import UTC, date, datetime
+
+from rob940_bars_agg import Bar1m
+from rob940_cost_model import FEE_ROUND_TRIP_BPS as _FEE_ROUND_TRIP_BPS
+from rob940_cost_model import (
+    MIN_TP_DISTANCE_BPS,
+    CostScenario,
+    FundingCrossing,
+    Side,
+    gross_bps,
+    net_bps,
+    realized_funding_bps,
+)
+
+from research_contracts.canonical_hash import canonical_sha256
+
+_MS_PER_MINUTE = 60_000
+
+# AC8: UTC-day 3-entry cap; consecutive 2 stop-outs OR cost-included daily
+# <=-2.0R halts further entries for the rest of that UTC day.
+DAILY_MAX_ENTRIES = 3
+DAILY_MAX_CONSECUTIVE_STOP_OUTS = 2
+DAILY_MAX_LOSS_R = -2.0
+
+ExitReason = str  # "take_profit" | "stop_loss" | "timeout"
+NoTradeReason = str
+
+
+@dataclass(frozen=True)
+class SignalEvent:
+    strategy: str
+    config_id: str
+    symbol: str
+    signal_ts: int  # close boundary of the signal bar == required next 1m bar's ts
+    side: Side
+    sl_distance_bps: float  # > 0, resolved at signal time, relative to E
+    tp_distance_bps: float | None = None  # relative to E; mutually excl. w/ target
+    tp_target_price: float | None = None  # absolute; distance resolved vs E
+    timeout_bars: int = 1  # count of 1m bars from entry (inclusive deadline index)
+    cooldown_bars: int = 0  # 1m bars after exit before the next entry is allowed
+    fold_id: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.side not in ("long", "short"):
+            raise ValueError(f"unknown side {self.side!r}")
+        if self.sl_distance_bps <= 0:
+            raise ValueError("sl_distance_bps must be positive")
+        has_bps = self.tp_distance_bps is not None
+        has_target = self.tp_target_price is not None
+        if has_bps == has_target:  # both set or neither set
+            raise ValueError(
+                "exactly one of tp_distance_bps/tp_target_price must be set"
+            )
+        if has_bps and self.tp_distance_bps <= 0:
+            raise ValueError("tp_distance_bps must be positive")
+        if has_target and self.tp_target_price <= 0:
+            raise ValueError("tp_target_price must be positive")
+        if self.timeout_bars < 1:
+            raise ValueError("timeout_bars must be >= 1")
+        if self.cooldown_bars < 0:
+            raise ValueError("cooldown_bars must be >= 0")
+
+
+@dataclass(frozen=True)
+class TradeRecord:
+    strategy: str
+    config_id: str
+    symbol: str
+    side: Side
+    signal_ts: int
+    entry_ts: int
+    entry_price: float
+    exit_ts: int
+    exit_price: float
+    exit_reason: ExitReason
+    gross_bps: float
+    fee_bps: float
+    all_in_bps: float
+    funding_bps: float
+    net_bps: float
+    fold_id: str | None
+    gap_fill: bool = False
+
+
+@dataclass(frozen=True)
+class NoTradeRecord:
+    strategy: str
+    config_id: str
+    symbol: str
+    side: Side
+    signal_ts: int
+    reason: NoTradeReason
+    fold_id: str | None = None
+
+
+@dataclass(frozen=True)
+class EngineResult:
+    trades: tuple[TradeRecord, ...]
+    no_trades: tuple[NoTradeRecord, ...]
+
+
+def _validate_sorted_1m(bars_1m: Sequence[Bar1m]) -> None:
+    for i in range(1, len(bars_1m)):
+        if bars_1m[i].ts <= bars_1m[i - 1].ts:
+            raise ValueError(
+                "bars_1m must be strictly increasing by ts; got "
+                f"{bars_1m[i - 1].ts} then {bars_1m[i].ts}"
+            )
+
+
+def _bar_index_by_ts(bars_1m: Sequence[Bar1m]) -> dict[int, int]:
+    return {b.ts: i for i, b in enumerate(bars_1m)}
+
+
+def _utc_date(ts_ms: int) -> date:
+    return datetime.fromtimestamp(ts_ms / 1000.0, tz=UTC).date()
+
+
+def resolve_entry(
+    bars_1m: Sequence[Bar1m], signal_ts: int, index: dict[int, int] | None = None
+) -> int | None:
+    """Index of the 1m bar at ``ts == signal_ts``, or ``None`` if absent (AC3/AC10).
+
+    ``signal_ts`` is the CLOSE boundary of the signal bar, which for a
+    contiguous 1m grid equals the open time of the very next 1m bar — see the
+    module docstring's ultrathink note. A missing bar there (a gap right at
+    the execution boundary) is a hard no-entry; the engine never searches
+    further ahead (that would be a different, unspecified "delayed entry"
+    policy, not next-bar-open).
+    """
+    idx = index if index is not None else _bar_index_by_ts(bars_1m)
+    return idx.get(signal_ts)
+
+
+def _gapped_through_sl(side: Side, open_price: float, sl_price: float) -> bool:
+    return open_price <= sl_price if side == "long" else open_price >= sl_price
+
+
+def _gapped_through_tp(side: Side, open_price: float, tp_price: float) -> bool:
+    return open_price >= tp_price if side == "long" else open_price <= tp_price
+
+
+def _touched_sl(side: Side, bar: Bar1m, sl_price: float) -> bool:
+    return bar.low <= sl_price if side == "long" else bar.high >= sl_price
+
+
+def _touched_tp(side: Side, bar: Bar1m, tp_price: float) -> bool:
+    return bar.high >= tp_price if side == "long" else bar.low <= tp_price
+
+
+def _walk_exit(
+    bars_1m: Sequence[Bar1m],
+    entry_idx: int,
+    side: Side,
+    sl_price: float,
+    tp_price: float,
+    timeout_bars: int,
+) -> tuple[int, float, ExitReason, bool]:
+    """Return ``(exit_idx, exit_price, exit_reason, gap_fill)``.
+
+    Lookahead-free by construction: walks bars strictly in chronological order
+    starting at ``entry_idx`` and returns on the FIRST bar satisfying any exit
+    condition (AC5). Every bar (including the entry bar itself, whose ``open``
+    trivially never gaps past a barrier defined relative to that same open)
+    checks gap-open exit before intrabar touch; same-bar SL+TP is SL-first,
+    side-agnostic. The deadline bar (first bar at ``entry_idx + timeout_bars``)
+    still checks gap-open exit first, then falls back to a timeout fill at its
+    own open — it never inspects its own intrabar range (AC5: timeout is a
+    market order sent at that bar's open, before its range develops).
+    """
+    deadline_idx = entry_idx + timeout_bars
+    n = len(bars_1m)
+    last_idx = min(deadline_idx, n - 1)
+    for j in range(entry_idx, last_idx + 1):
+        bar = bars_1m[j]
+        gap_sl = _gapped_through_sl(side, bar.open, sl_price)
+        gap_tp = _gapped_through_tp(side, bar.open, tp_price)
+        if gap_sl:
+            return j, bar.open, "stop_loss", True
+        if j == deadline_idx:
+            if gap_tp:
+                return j, tp_price, "take_profit", False
+            return j, bar.open, "timeout", False
+        if gap_tp:
+            return j, tp_price, "take_profit", False
+        if _touched_sl(side, bar, sl_price):
+            return j, sl_price, "stop_loss", False
+        if _touched_tp(side, bar, tp_price):
+            return j, tp_price, "take_profit", False
+    # ran off the end of available data before reaching SL/TP/the deadline bar
+    j = n - 1
+    return j, bars_1m[j].close, "timeout", False
+
+
+@dataclass
+class _DayState:
+    entries: int = 0
+    consecutive_stop_outs: int = 0
+    daily_r: float = 0.0
+    halted: bool = False
+
+
+def _no_trade(sig: SignalEvent, reason: NoTradeReason) -> NoTradeRecord:
+    return NoTradeRecord(
+        strategy=sig.strategy,
+        config_id=sig.config_id,
+        symbol=sig.symbol,
+        side=sig.side,
+        signal_ts=sig.signal_ts,
+        reason=reason,
+        fold_id=sig.fold_id,
+    )
+
+
+def run_symbol_stream(
+    bars_1m: Sequence[Bar1m],
+    signals: Sequence[SignalEvent],
+    cost_scenario: CostScenario,
+    *,
+    funding_lookup=None,
+) -> EngineResult:
+    """Walk ``signals`` (sorted by ``signal_ts``) against ONE symbol's 1m bars.
+
+    ``funding_lookup``, if given, is ``(symbol, side, entry_ts, exit_ts) ->
+    Sequence[FundingCrossing]`` — the explicit pure input interface for H1's
+    PIT-safe funding sidecar (AC6). Realized crossings are summed and
+    subtracted from ``net_bps`` exactly once; omitting it is equivalent to
+    zero funding crossings.
+    """
+    _validate_sorted_1m(bars_1m)
+    index = _bar_index_by_ts(bars_1m)
+    trades: list[TradeRecord] = []
+    no_trades: list[NoTradeRecord] = []
+    day_states: dict[date, _DayState] = {}
+    earliest_allowed_entry_idx = 0
+
+    for sig in sorted(signals, key=lambda s: s.signal_ts):
+        entry_idx = resolve_entry(bars_1m, sig.signal_ts, index)
+        if entry_idx is None:
+            no_trades.append(_no_trade(sig, "next_bar_unavailable"))
+            continue
+
+        entry_bar = bars_1m[entry_idx]
+        entry_price = entry_bar.open
+        day = _utc_date(entry_bar.ts)
+        state = day_states.setdefault(day, _DayState())
+
+        if state.halted:
+            no_trades.append(_no_trade(sig, "daily_stop_active"))
+            continue
+        if state.entries >= DAILY_MAX_ENTRIES:
+            no_trades.append(_no_trade(sig, "daily_entry_cap"))
+            continue
+        if entry_idx < earliest_allowed_entry_idx:
+            no_trades.append(_no_trade(sig, "cooldown_active"))
+            continue
+
+        sl_price = (
+            entry_price * (1.0 - sig.sl_distance_bps / 1e4)
+            if sig.side == "long"
+            else entry_price * (1.0 + sig.sl_distance_bps / 1e4)
+        )
+        if sig.tp_distance_bps is not None:
+            tp_distance_bps = sig.tp_distance_bps
+            tp_price = (
+                entry_price * (1.0 + tp_distance_bps / 1e4)
+                if sig.side == "long"
+                else entry_price * (1.0 - tp_distance_bps / 1e4)
+            )
+        else:
+            tp_price = sig.tp_target_price
+            tp_distance_bps = abs(tp_price / entry_price - 1.0) * 1e4
+
+        if tp_distance_bps < MIN_TP_DISTANCE_BPS:
+            no_trades.append(_no_trade(sig, "tp_below_min_distance"))
+            continue
+
+        exit_idx, exit_price, exit_reason, gap_fill = _walk_exit(
+            bars_1m, entry_idx, sig.side, sl_price, tp_price, sig.timeout_bars
+        )
+        exit_bar = bars_1m[exit_idx]
+        gross = gross_bps(sig.side, entry_price, exit_price)
+        crossings: Sequence[FundingCrossing] = (
+            funding_lookup(sig.symbol, sig.side, entry_bar.ts, exit_bar.ts)
+            if funding_lookup is not None
+            else ()
+        )
+        funding = realized_funding_bps(sig.side, crossings)
+        net = net_bps(gross, cost_scenario, funding)
+
+        trades.append(
+            TradeRecord(
+                strategy=sig.strategy,
+                config_id=sig.config_id,
+                symbol=sig.symbol,
+                side=sig.side,
+                signal_ts=sig.signal_ts,
+                entry_ts=entry_bar.ts,
+                entry_price=entry_price,
+                exit_ts=exit_bar.ts,
+                exit_price=exit_price,
+                exit_reason=exit_reason,
+                gross_bps=gross,
+                fee_bps=_FEE_ROUND_TRIP_BPS,
+                all_in_bps=cost_scenario.all_in_bps,
+                funding_bps=funding,
+                net_bps=net,
+                fold_id=sig.fold_id,
+                gap_fill=gap_fill,
+            )
+        )
+
+        state.entries += 1
+        state.consecutive_stop_outs = (
+            state.consecutive_stop_outs + 1 if exit_reason == "stop_loss" else 0
+        )
+        state.daily_r += net / sig.sl_distance_bps
+        if (
+            state.consecutive_stop_outs >= DAILY_MAX_CONSECUTIVE_STOP_OUTS
+            or state.daily_r <= DAILY_MAX_LOSS_R
+        ):
+            state.halted = True
+
+        earliest_allowed_entry_idx = exit_idx + sig.cooldown_bars
+
+    return EngineResult(trades=tuple(trades), no_trades=tuple(no_trades))
+
+
+def ledger_hash(trades: Sequence[TradeRecord]) -> str:
+    """AC1: byte-identical hash of an ORDERED trade ledger for the same input.
+
+    Delegates to the repo's existing typed-canonical SHA-256 authority
+    (``research_contracts.canonical_hash``), so float fields hash via their
+    exact hex representation (no JSON-numeric round-trip drift) and list order
+    is preserved (the ledger's ordering is part of its identity).
+    """
+    payload = [
+        {
+            "strategy": t.strategy,
+            "config_id": t.config_id,
+            "symbol": t.symbol,
+            "side": t.side,
+            "signal_ts": t.signal_ts,
+            "entry_ts": t.entry_ts,
+            "entry_price": t.entry_price,
+            "exit_ts": t.exit_ts,
+            "exit_price": t.exit_price,
+            "exit_reason": t.exit_reason,
+            "gross_bps": t.gross_bps,
+            "fee_bps": t.fee_bps,
+            "all_in_bps": t.all_in_bps,
+            "funding_bps": t.funding_bps,
+            "net_bps": t.net_bps,
+            "fold_id": t.fold_id,
+            "gap_fill": t.gap_fill,
+        }
+        for t in trades
+    ]
+    return canonical_sha256(payload)

--- a/research/nautilus_scalping/rob940_engine.py
+++ b/research/nautilus_scalping/rob940_engine.py
@@ -56,6 +56,38 @@ write-up):
   * ``fold_id`` is a pass-through field for H4 (walk-forward runner); this
     engine does not compute or validate fold boundaries.
 
+ROB-942 R1 correction (cost-scenario path divergence, 2026-07-17): each call
+to ``run_symbol_stream`` is an INDEPENDENT simulation over its own fresh
+``_DayState`` — there is no shared/cached path across scenarios. Passing a
+different ``cost_scenario`` does not just change ``net_bps`` after the fact;
+``state.daily_r`` (fed by that scenario's own ``net_bps``) is part of the
+loop's own control flow (AC8's ``<=-2.0R`` halt), so a higher-cost scenario
+CAN cross the halt threshold sooner than a lower-cost one on the exact same
+``bars_1m``/``signals`` input, producing a different trade COUNT (a shorter
+path) for that invocation only. Signal eligibility itself does not diverge:
+``MIN_TP_DISTANCE_BPS`` (68bp) is one fixed value independent of
+``cost_scenario``, so every scenario sees the same set of candidate entries
+before any cost-driven halt can prune them. Callers (H4/H5) MUST treat the
+three cost-scenario ledgers as three separate runs to compare, never as a
+single reference path with net-only revaluation. See
+``rob940_cost_model`` module docstring and the
+``test_68bp_gate_is_identical_across_all_cost_scenarios`` /
+``test_cost_scenario_dependent_daily_stop_diverges_trade_count`` regressions
+in ``tests/test_rob940_engine.py``.
+
+Caller preconditions (H4, not enforced here — documented per R1 M2/M3):
+  * ``signals`` for a given symbol SHOULD NOT contain duplicate
+    ``signal_ts`` values. The cooldown/position gate
+    (``entry_idx < earliest_allowed_entry_idx``) assumes at most one signal
+    per bar per symbol; two same-``signal_ts`` signals combined with an
+    immediate same-bar exit and ``cooldown_bars=0`` could otherwise slip a
+    second entry into what should be a single-position stream.
+  * ``sorted(signals, key=lambda s: s.signal_ts)`` (Python's stable sort) is
+    the engine's ONLY tie-break for same-``signal_ts`` signals — it resolves
+    ties by INPUT ORDER, not by any semantic priority. AC1's "same
+    bars/config -> same bytes" determinism claim holds only if H4 presents
+    ``signals`` in a canonical, reproducible order.
+
 No DB/network/app/broker/order/fill/scheduler imports — pure stdlib plus the
 existing research_contracts canonical-hash authority (itself stdlib-only),
 deterministic given its input.
@@ -63,6 +95,7 @@ deterministic given its input.
 
 from __future__ import annotations
 
+import math
 from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import UTC, date, datetime
@@ -110,6 +143,12 @@ class SignalEvent:
     def __post_init__(self) -> None:
         if self.side not in ("long", "short"):
             raise ValueError(f"unknown side {self.side!r}")
+        # ROB-942 R1 M1: `nan <= 0` is False, so a bare `<= 0` check silently
+        # let NaN/+-Inf through; check finiteness explicitly and first.
+        if not math.isfinite(self.sl_distance_bps):
+            raise ValueError(
+                f"sl_distance_bps must be finite, got {self.sl_distance_bps!r}"
+            )
         if self.sl_distance_bps <= 0:
             raise ValueError("sl_distance_bps must be positive")
         has_bps = self.tp_distance_bps is not None
@@ -118,8 +157,16 @@ class SignalEvent:
             raise ValueError(
                 "exactly one of tp_distance_bps/tp_target_price must be set"
             )
+        if has_bps and not math.isfinite(self.tp_distance_bps):
+            raise ValueError(
+                f"tp_distance_bps must be finite, got {self.tp_distance_bps!r}"
+            )
         if has_bps and self.tp_distance_bps <= 0:
             raise ValueError("tp_distance_bps must be positive")
+        if has_target and not math.isfinite(self.tp_target_price):
+            raise ValueError(
+                f"tp_target_price must be finite, got {self.tp_target_price!r}"
+            )
         if has_target and self.tp_target_price <= 0:
             raise ValueError("tp_target_price must be positive")
         if self.timeout_bars < 1:

--- a/research/nautilus_scalping/tests/test_rob940_bars_agg.py
+++ b/research/nautilus_scalping/tests/test_rob940_bars_agg.py
@@ -1,0 +1,129 @@
+"""ROB-942 (H2, ROB-940) — complete-only 1m -> 5m/15m aggregation RED fixtures.
+
+Pins AC2: only fully-covered UTC buckets are emitted (open=first open,
+high/low=max/min, close=last close, volume=sum); any gap in the source 1m grid
+must NOT bridge a bucket, and must reset warm-up (``is_segment_start``) on the
+next bucket that completes after the gap.
+"""
+
+from rob940_bars_agg import Bar1m, aggregate_complete
+
+MIN = 60_000
+
+
+def _bars(start_ts, closes, *, opens=None, highs=None, lows=None, volumes=None):
+    n = len(closes)
+    opens = opens or closes
+    highs = highs or [c + 1 for c in closes]
+    lows = lows or [c - 1 for c in closes]
+    volumes = volumes or [10.0] * n
+    return [
+        Bar1m(
+            ts=start_ts + i * MIN,
+            open=opens[i],
+            high=highs[i],
+            low=lows[i],
+            close=closes[i],
+            volume=volumes[i],
+        )
+        for i in range(n)
+    ]
+
+
+def test_aggregate_5m_complete_bucket_ohlcv():
+    bars = _bars(
+        0,
+        [10, 11, 12, 9, 13],
+        opens=[10, 11, 12, 9, 13],
+        highs=[10.5, 11.5, 12.5, 9.5, 13.5],
+        lows=[9.9, 10.9, 8.0, 8.9, 12.9],
+        volumes=[1.0, 2.0, 3.0, 4.0, 5.0],
+    )
+    out = aggregate_complete(bars, bucket_minutes=5)
+    assert len(out) == 1
+    b = out[0]
+    assert b.ts == 0
+    assert b.close_ts == 5 * MIN
+    assert b.open == 10  # first 1m open
+    assert b.high == 13.5  # max of highs
+    assert b.low == 8.0  # min of lows
+    assert b.close == 13  # last 1m close
+    assert b.volume == 15.0  # sum of volumes
+    assert b.is_segment_start is True
+
+
+def test_aggregate_15m_complete_bucket_ohlcv():
+    bars = _bars(0, list(range(15)))
+    out = aggregate_complete(bars, bucket_minutes=15)
+    assert len(out) == 1
+    b = out[0]
+    assert b.ts == 0
+    assert b.close_ts == 15 * MIN
+    assert b.open == bars[0].open
+    assert b.close == bars[-1].close
+    assert b.volume == sum(x.volume for x in bars)
+
+
+def test_incomplete_bucket_not_emitted_missing_middle_bar():
+    bars = _bars(0, [1, 2, 3, 4, 5])
+    del bars[2]  # drop the middle 1m bar -> bucket can never complete
+    out = aggregate_complete(bars, bucket_minutes=5)
+    assert out == []
+
+
+def test_leading_partial_bucket_at_series_start_not_emitted():
+    # data starts at minute offset 2 of a 5m bucket [0,5) -> that bucket can
+    # never see offsets 0/1 and must never be emitted.
+    bars = _bars(2 * MIN, [1, 2, 3])
+    out = aggregate_complete(bars, bucket_minutes=5)
+    assert out == []
+
+
+def test_trailing_partial_bucket_at_series_end_not_emitted():
+    bars = _bars(0, [1, 2, 3, 4, 5, 6, 7])  # 7 bars: one full 5m bucket + 2 leftover
+    out = aggregate_complete(bars, bucket_minutes=5)
+    assert len(out) == 1
+    assert out[0].ts == 0
+
+
+def test_gap_between_two_5m_buckets_does_not_bridge_and_resets_segment():
+    first = _bars(0, [1, 2, 3, 4, 5])  # bucket [0, 5*MIN)
+    # gap: skip minutes 5..9, resume at minute 10 with a complete bucket [10*MIN,15*MIN)
+    second = _bars(10 * MIN, [10, 11, 12, 13, 14])
+    out = aggregate_complete(first + second, bucket_minutes=5)
+    assert [b.ts for b in out] == [0, 10 * MIN]
+    assert out[0].is_segment_start is True
+    assert out[1].is_segment_start is True  # first bucket after the gap resets warm-up
+
+
+def test_contiguous_second_bucket_in_same_segment_is_not_a_segment_start():
+    bars = _bars(0, list(range(10)))  # two back-to-back complete 5m buckets, no gap
+    out = aggregate_complete(bars, bucket_minutes=5)
+    assert [b.ts for b in out] == [0, 5 * MIN]
+    assert out[0].is_segment_start is True
+    assert out[1].is_segment_start is False
+
+
+def test_unsorted_or_duplicate_timestamps_raise():
+    bars = _bars(0, [1, 2, 3])
+    bad = [bars[0], bars[0], bars[2]]
+    try:
+        aggregate_complete(bad, bucket_minutes=5)
+        raised = False
+    except ValueError:
+        raised = True
+    assert raised
+
+
+def test_empty_input_returns_empty():
+    assert aggregate_complete([], bucket_minutes=5) == []
+
+
+def test_non_positive_bucket_minutes_raises():
+    bars = _bars(0, [1, 2, 3])
+    try:
+        aggregate_complete(bars, bucket_minutes=0)
+        raised = False
+    except ValueError:
+        raised = True
+    assert raised

--- a/research/nautilus_scalping/tests/test_rob940_cost_model.py
+++ b/research/nautilus_scalping/tests/test_rob940_cost_model.py
@@ -1,0 +1,76 @@
+"""ROB-942 (H2, ROB-940) — corrected cost model RED fixtures.
+
+Pins the frozen ROB-940 cost contract (orch 2026-07-17 fee-recalibration
+comment): taker 5bp/leg, round-trip fee 10bp, all-in scenarios 13/17/22bp
+(primary=17bp), and the derived 68bp minimum-TP-distance gate (4x17bp). Also
+pins the realized-funding-crossing sign convention and the "subtract exactly
+once" net formula (no fee+all_in double count).
+"""
+
+import rob940_cost_model as cm
+
+
+def test_fee_constants_are_5bp_legs_10bp_round_trip():
+    assert cm.FEE_ENTRY_BPS == 5.0
+    assert cm.FEE_EXIT_BPS == 5.0
+    assert cm.FEE_ROUND_TRIP_BPS == 10.0
+
+
+def test_cost_scenarios_are_13_17_22_with_17_primary():
+    assert cm.COST_SCENARIO_BASE.all_in_bps == 13.0
+    assert cm.COST_SCENARIO_PRIMARY_STRESS.all_in_bps == 17.0
+    assert cm.COST_SCENARIO_UPWARD_STRESS.all_in_bps == 22.0
+    assert [s.all_in_bps for s in cm.COST_SCENARIOS] == [13.0, 17.0, 22.0]
+
+
+def test_min_tp_distance_is_4x_primary_stress_68bp():
+    assert cm.MIN_TP_DISTANCE_BPS == 68.0
+    assert cm.MIN_TP_DISTANCE_BPS == 4.0 * cm.COST_SCENARIO_PRIMARY_STRESS.all_in_bps
+
+
+def test_gross_bps_long_and_short_symmetry():
+    assert abs(cm.gross_bps("long", 100.0, 101.0) - 100.0) < 1e-9
+    assert abs(cm.gross_bps("short", 100.0, 99.0) - 100.0) < 1e-9
+    # entry-based: exact barrier distance realizes exact bps magnitude, both sides
+    assert cm.gross_bps("long", 100.0, 101.0) == -cm.gross_bps("short", 100.0, 101.0)
+    # mirrored move, mirrored side -> same-sign gain
+    long_gain = cm.gross_bps("long", 100.0, 105.0)
+    short_gain = cm.gross_bps("short", 100.0, 95.0)
+    assert long_gain > 0 and short_gain > 0
+
+
+def test_gross_bps_rejects_nonpositive_entry():
+    try:
+        cm.gross_bps("long", 0.0, 10.0)
+        raised = False
+    except ValueError:
+        raised = True
+    assert raised
+
+
+def test_realized_funding_bps_sign_convention_long_pays_short_receives():
+    crossings = [
+        cm.FundingCrossing(ts=1, rate_bps=2.0),
+        cm.FundingCrossing(ts=2, rate_bps=1.0),
+    ]
+    assert cm.realized_funding_bps("long", crossings) == 3.0
+    assert cm.realized_funding_bps("short", crossings) == -3.0
+
+
+def test_realized_funding_bps_no_crossings_is_zero():
+    assert cm.realized_funding_bps("long", []) == 0.0
+
+
+def test_net_bps_subtracts_all_in_and_funding_exactly_once_no_fee_double_count():
+    # gross=100, scenario all_in=17 (already embeds the 10bp fee), funding=3
+    net = cm.net_bps(100.0, cm.COST_SCENARIO_PRIMARY_STRESS, 3.0)
+    assert net == 100.0 - 17.0 - 3.0
+    # fee_bps (10.0) must NOT appear as an additional subtraction anywhere
+    assert net != 100.0 - cm.FEE_ROUND_TRIP_BPS - 17.0 - 3.0
+
+
+def test_net_bps_scenario_sensitivity_same_gross_and_funding():
+    gross, funding = 50.0, 0.0
+    nets = [cm.net_bps(gross, s, funding) for s in cm.COST_SCENARIOS]
+    assert nets == [50.0 - 13.0, 50.0 - 17.0, 50.0 - 22.0]
+    assert nets[0] > nets[1] > nets[2]

--- a/research/nautilus_scalping/tests/test_rob940_engine.py
+++ b/research/nautilus_scalping/tests/test_rob940_engine.py
@@ -1,0 +1,563 @@
+"""ROB-942 (H2, ROB-940) — deterministic 1m execution engine RED fixtures.
+
+``SignalEvent.signal_ts`` is defined as the CLOSE boundary of the signal bar,
+which (for a contiguous 1m grid) is numerically identical to the ``ts`` (open
+time) of the very next 1m bar. The engine's "next contiguous 1m bar" is
+therefore the 1m bar found AT ``ts == signal_ts``; if it's missing (a gap in
+the 1m grid right at the execution boundary), there is no entry. This keeps
+the engine decoupled from signal-timeframe (5m vs 15m) bucket size — see
+``rob940_engine`` module docstring for the full ultrathink rationale.
+"""
+
+import rob940_cost_model as cm
+from rob940_bars_agg import Bar1m
+from rob940_engine import SignalEvent, resolve_entry, run_symbol_stream
+
+MIN = 60_000
+
+
+def _mk(ts0, specs):
+    """specs: list of (open, high, low, close) tuples, one per 1m bar."""
+    return [
+        Bar1m(ts=ts0 + i * MIN, open=o, high=h, low=lo, close=c, volume=1.0)
+        for i, (o, h, lo, c) in enumerate(specs)
+    ]
+
+
+def _sig(
+    signal_ts,
+    side="long",
+    sl=100.0,
+    tp=None,
+    tp_target=None,
+    timeout=10,
+    cooldown=0,
+    strategy="s1",
+    config_id="c1",
+    symbol="XRPUSDT",
+    fold_id=None,
+):
+    kwargs = {
+        "strategy": strategy,
+        "config_id": config_id,
+        "symbol": symbol,
+        "signal_ts": signal_ts,
+        "side": side,
+        "sl_distance_bps": sl,
+        "timeout_bars": timeout,
+        "cooldown_bars": cooldown,
+        "fold_id": fold_id,
+    }
+    if tp_target is not None:
+        kwargs["tp_target_price"] = tp_target
+    else:
+        kwargs["tp_distance_bps"] = tp if tp is not None else 200.0
+    return SignalEvent(**kwargs)
+
+
+# --------------------------------------------------------------------------- #
+# SignalEvent validation
+# --------------------------------------------------------------------------- #
+def test_signal_event_requires_exactly_one_tp_spec():
+    for kw in (
+        {"tp_distance_bps": 100.0, "tp_target_price": 101.0},
+        {},
+    ):
+        try:
+            SignalEvent(
+                strategy="s",
+                config_id="c",
+                symbol="X",
+                signal_ts=0,
+                side="long",
+                sl_distance_bps=50.0,
+                **kw,
+            )
+            raised = False
+        except ValueError:
+            raised = True
+        assert raised, kw
+
+
+def test_signal_event_validates_positive_fields():
+    base = {
+        "strategy": "s",
+        "config_id": "c",
+        "symbol": "X",
+        "signal_ts": 0,
+        "side": "long",
+        "tp_distance_bps": 100.0,
+    }
+    for bad in (
+        {"sl_distance_bps": 0.0},
+        {"sl_distance_bps": -1.0},
+    ):
+        try:
+            SignalEvent(**{**base, "sl_distance_bps": 50.0, **bad})
+            raised = False
+        except ValueError:
+            raised = True
+        assert raised
+    try:
+        SignalEvent(**base, sl_distance_bps=50.0, timeout_bars=0)
+        raised = False
+    except ValueError:
+        raised = True
+    assert raised
+    try:
+        SignalEvent(**base, sl_distance_bps=50.0, cooldown_bars=-1)
+        raised = False
+    except ValueError:
+        raised = True
+    assert raised
+    try:
+        SignalEvent(**{**base, "sl_distance_bps": 50.0, "side": "sideways"})
+        raised = False
+    except ValueError:
+        raised = True
+    assert raised
+
+
+# --------------------------------------------------------------------------- #
+# next-1m-open entry + non-contiguous no-entry (AC3, AC10)
+# --------------------------------------------------------------------------- #
+def test_resolve_entry_returns_bar_index_at_signal_ts():
+    bars = _mk(0, [(10, 10, 10, 10), (105, 110, 100, 108), (108, 108, 108, 108)])
+    assert resolve_entry(bars, signal_ts=MIN) == 1
+
+
+def test_resolve_entry_none_when_bar_missing_at_signal_ts():
+    bars = _mk(0, [(10, 10, 10, 10)]) + _mk(2 * MIN, [(20, 20, 20, 20)])  # gap at MIN
+    assert resolve_entry(bars, signal_ts=MIN) is None
+
+
+def test_next_1m_open_used_as_entry_price_not_signal_bar_close():
+    # bar at signal_ts has open=105 but a DIFFERENT close=108 -- entry must be 105.
+    bars = _mk(
+        0, [(10, 10, 10, 10), (105, 110, 100, 108)] + [(108, 109, 107, 108)] * 20
+    )
+    sig = _sig(signal_ts=MIN, tp=300.0, timeout=15)
+    result = run_symbol_stream(bars, [sig], cm.COST_SCENARIO_PRIMARY_STRESS)
+    assert len(result.trades) == 1
+    assert result.trades[0].entry_price == 105.0
+    assert result.trades[0].entry_ts == MIN
+
+
+def test_non_contiguous_no_entry_produces_no_trade_record():
+    bars = _mk(0, [(10, 10, 10, 10)]) + _mk(
+        2 * MIN, [(20, 20, 20, 20)] * 5
+    )  # gap at 1*MIN
+    sig = _sig(signal_ts=MIN)
+    result = run_symbol_stream(bars, [sig], cm.COST_SCENARIO_PRIMARY_STRESS)
+    assert result.trades == ()
+    assert len(result.no_trades) == 1
+    assert result.no_trades[0].reason == "next_bar_unavailable"
+
+
+# --------------------------------------------------------------------------- #
+# lookahead sentinel
+# --------------------------------------------------------------------------- #
+def test_walk_exits_on_first_qualifying_bar_not_a_later_more_favorable_one():
+    # entry E=100, SL=99 (100bps), TP=110 (1000bps, i.e. deliberately far).
+    # bar[entry+1] touches SL; bar[entry+5] would touch TP if peeked -- must not.
+    specs = [(100, 100, 100, 100)]  # entry bar itself, flat
+    specs += [(99.5, 99.6, 98.5, 99.0)]  # entry+1: touches SL (low<=99)
+    specs += [(99.0, 99.2, 98.8, 99.0)] * 3  # entry+2..4: irrelevant
+    specs += [(99.0, 120.0, 98.5, 110.0)]  # entry+5: would touch TP if peeked
+    bars = _mk(0, specs)
+    sig = _sig(signal_ts=0, sl=100.0, tp=1000.0, timeout=10)
+    result = run_symbol_stream(bars, [sig], cm.COST_SCENARIO_PRIMARY_STRESS)
+    t = result.trades[0]
+    assert t.exit_reason == "stop_loss"
+    assert t.exit_ts == 1 * MIN
+    assert t.exit_price == 99.0
+
+
+def test_truncating_data_after_the_actual_exit_bar_does_not_change_the_trade():
+    specs = [(100, 100, 100, 100), (99.5, 99.6, 98.5, 99.0)]
+    specs_extra = (
+        specs + [(200, 300, 190, 250)] * 5
+    )  # wild future data, must not matter
+    bars_full = _mk(0, specs_extra)
+    bars_trunc = _mk(0, specs)
+    sig = _sig(signal_ts=0, sl=100.0, tp=1000.0, timeout=10)
+    r_full = run_symbol_stream(bars_full, [sig], cm.COST_SCENARIO_PRIMARY_STRESS)
+    r_trunc = run_symbol_stream(bars_trunc, [sig], cm.COST_SCENARIO_PRIMARY_STRESS)
+    assert r_full.trades[0] == r_trunc.trades[0]
+
+
+# --------------------------------------------------------------------------- #
+# long/short symmetry
+# --------------------------------------------------------------------------- #
+def test_long_short_symmetry_mirrored_stop_loss():
+    long_specs = [(100, 100, 100, 100), (99.5, 99.6, 98.5, 99.0)]
+    short_specs = [(100, 100, 100, 100), (100.5, 101.5, 100.4, 101.0)]
+    bars_long = _mk(0, long_specs)
+    bars_short = _mk(0, short_specs)
+    sig_long = _sig(signal_ts=0, side="long", sl=100.0, tp=1000.0)
+    sig_short = _sig(signal_ts=0, side="short", sl=100.0, tp=1000.0)
+    r_long = run_symbol_stream(bars_long, [sig_long], cm.COST_SCENARIO_PRIMARY_STRESS)
+    r_short = run_symbol_stream(
+        bars_short, [sig_short], cm.COST_SCENARIO_PRIMARY_STRESS
+    )
+    tl, ts = r_long.trades[0], r_short.trades[0]
+    assert tl.exit_reason == ts.exit_reason == "stop_loss"
+    assert abs(tl.gross_bps - ts.gross_bps) < 1e-6
+    assert abs(tl.net_bps - ts.net_bps) < 1e-6
+
+
+# --------------------------------------------------------------------------- #
+# gap-through vs normal touch, same-bar SL-first (AC5)
+# --------------------------------------------------------------------------- #
+def test_gap_through_sl_fills_at_unfavorable_open_long():
+    specs = [(100, 100, 100, 100), (98.0, 98.5, 97.0, 98.2)]  # gaps below SL=99
+    bars = _mk(0, specs)
+    sig = _sig(signal_ts=0, side="long", sl=100.0, tp=1000.0)
+    result = run_symbol_stream(bars, [sig], cm.COST_SCENARIO_PRIMARY_STRESS)
+    t = result.trades[0]
+    assert t.exit_reason == "stop_loss"
+    assert t.exit_price == 98.0  # bar's open, NOT sl_price=99.0
+    assert t.gap_fill is True
+
+
+def test_gap_through_tp_fills_at_barrier_not_open_long():
+    specs = [(100, 100, 100, 100), (103.0, 104.0, 102.5, 103.5)]  # gaps above TP=102
+    bars = _mk(0, specs)
+    sig = _sig(signal_ts=0, side="long", sl=1000.0, tp=200.0)  # TP = 102
+    result = run_symbol_stream(bars, [sig], cm.COST_SCENARIO_PRIMARY_STRESS)
+    t = result.trades[0]
+    assert t.exit_reason == "take_profit"
+    assert t.exit_price == 102.0  # TP barrier, NOT the more favorable open=103
+    assert t.gap_fill is False
+
+
+def test_normal_intrabar_touch_fills_at_exact_barrier_not_extreme():
+    specs = [
+        (100, 100, 100, 100),
+        (100.5, 102.5, 99.8, 101.0),
+    ]  # touches TP=102 intrabar
+    bars = _mk(0, specs)
+    sig = _sig(signal_ts=0, side="long", sl=1000.0, tp=200.0)  # TP=102
+    result = run_symbol_stream(bars, [sig], cm.COST_SCENARIO_PRIMARY_STRESS)
+    t = result.trades[0]
+    assert t.exit_reason == "take_profit"
+    assert t.exit_price == 102.0  # barrier, not intrabar high=102.5
+    assert t.gap_fill is False
+
+
+def test_same_bar_both_touched_sl_wins_long():
+    specs = [
+        (100, 100, 100, 100),
+        (100.2, 103.0, 98.0, 101.0),
+    ]  # touches both SL=99,TP=102
+    bars = _mk(0, specs)
+    sig = _sig(signal_ts=0, side="long", sl=100.0, tp=200.0)
+    result = run_symbol_stream(bars, [sig], cm.COST_SCENARIO_PRIMARY_STRESS)
+    t = result.trades[0]
+    assert t.exit_reason == "stop_loss"
+    assert t.exit_price == 99.0
+
+
+def test_same_bar_both_touched_sl_wins_short():
+    specs = [
+        (100, 100, 100, 100),
+        (99.8, 102.0, 97.0, 99.0),
+    ]  # SL=101(short), TP=98(short)
+    bars = _mk(0, specs)
+    sig = _sig(signal_ts=0, side="short", sl=100.0, tp=200.0)
+    result = run_symbol_stream(bars, [sig], cm.COST_SCENARIO_PRIMARY_STRESS)
+    t = result.trades[0]
+    assert t.exit_reason == "stop_loss"
+    assert t.exit_price == 101.0
+
+
+# --------------------------------------------------------------------------- #
+# timeout (AC5, AC8)
+# --------------------------------------------------------------------------- #
+def test_timeout_exits_at_first_deadline_bar_open():
+    # SL/TP deliberately unreachable; timeout_bars=3 -> deadline at entry_idx+3
+    specs = [(100, 100, 100, 100)]
+    specs += [(100, 100.2, 99.8, 100)] * 2  # entry+1, entry+2: flat, no touch
+    specs += [(101.5, 101.6, 101.4, 101.5)]  # entry+3: deadline bar
+    specs += [(999, 999, 999, 999)]  # must never be reached
+    bars = _mk(0, specs)
+    sig = _sig(signal_ts=0, side="long", sl=1000.0, tp=1000.0, timeout=3)
+    result = run_symbol_stream(bars, [sig], cm.COST_SCENARIO_PRIMARY_STRESS)
+    t = result.trades[0]
+    assert t.exit_reason == "timeout"
+    assert t.exit_ts == 3 * MIN
+    assert t.exit_price == 101.5
+
+
+def test_deadline_bar_gap_through_sl_still_classified_stop_loss_not_timeout():
+    specs = [(100, 100, 100, 100)]
+    specs += [(100, 100.2, 99.8, 100)] * 1  # entry+1
+    specs += [(97.0, 97.2, 96.5, 97.0)]  # entry+2: deadline bar, gaps through SL=99
+    bars = _mk(0, specs)
+    sig = _sig(signal_ts=0, side="long", sl=100.0, tp=1000.0, timeout=2)
+    result = run_symbol_stream(bars, [sig], cm.COST_SCENARIO_PRIMARY_STRESS)
+    t = result.trades[0]
+    assert t.exit_reason == "stop_loss"
+    assert t.exit_price == 97.0
+    assert t.gap_fill is True
+
+
+def test_run_off_end_of_data_before_timeout_closes_at_last_close():
+    specs = [(100, 100, 100, 100), (100, 100.2, 99.8, 100.1)]
+    bars = _mk(0, specs)
+    sig = _sig(signal_ts=0, side="long", sl=1000.0, tp=1000.0, timeout=50)
+    result = run_symbol_stream(bars, [sig], cm.COST_SCENARIO_PRIMARY_STRESS)
+    t = result.trades[0]
+    assert t.exit_reason == "timeout"
+    assert t.exit_ts == 1 * MIN
+    assert t.exit_price == 100.1
+
+
+# --------------------------------------------------------------------------- #
+# cooldown / single-position-per-symbol (AC4)
+# --------------------------------------------------------------------------- #
+def test_cooldown_blocks_entry_before_threshold_and_allows_at_threshold():
+    # trade 1: entry at idx0, TP hit at idx1 (exit_idx=1). cooldown=3 -> earliest allowed=4.
+    specs = [
+        (100, 100, 100, 100),
+        (100.5, 102.0, 100.4, 101.9),
+    ]  # idx0 entry, idx1 TP exit
+    specs += [(101, 101, 101, 101)] * 6  # idx2..7 filler, flat (never touches anything)
+    bars = _mk(0, specs)
+    sig1 = _sig(signal_ts=0, side="long", sl=1000.0, tp=200.0, timeout=1, cooldown=3)
+    sig_too_early = _sig(
+        signal_ts=3 * MIN, side="long", sl=1000.0, tp=1000.0, timeout=1
+    )  # idx3 < 4
+    sig_ok = _sig(
+        signal_ts=4 * MIN, side="long", sl=1000.0, tp=1000.0, timeout=1
+    )  # idx4 == 4
+    result = run_symbol_stream(
+        bars, [sig1, sig_too_early, sig_ok], cm.COST_SCENARIO_PRIMARY_STRESS
+    )
+    assert len(result.trades) == 2
+    reasons = [nt.reason for nt in result.no_trades]
+    assert "cooldown_active" in reasons
+
+
+def test_overlapping_signal_during_open_hold_is_rejected_via_cooldown_check():
+    specs = [(100, 100, 100, 100)]
+    specs += [
+        (100, 100.2, 99.8, 100)
+    ] * 5  # flat, no touch; timeout=5 keeps position open
+    bars = _mk(0, specs)
+    sig1 = _sig(signal_ts=0, side="long", sl=1000.0, tp=1000.0, timeout=5, cooldown=0)
+    sig_overlap = _sig(signal_ts=2 * MIN, side="long", sl=1000.0, tp=1000.0, timeout=1)
+    result = run_symbol_stream(
+        bars, [sig1, sig_overlap], cm.COST_SCENARIO_PRIMARY_STRESS
+    )
+    assert len(result.trades) == 1
+    assert result.no_trades[0].reason == "cooldown_active"
+
+
+# --------------------------------------------------------------------------- #
+# daily caps / stops (AC8)
+# --------------------------------------------------------------------------- #
+def _quick_tp_trade_specs():
+    # 1-bar hold, TP always hit on bar 1 (open=100.5, high=102 >= TP 102)
+    return [(100, 100, 100, 100), (100.5, 102.0, 100.4, 101.9)]
+
+
+def test_daily_entry_cap_blocks_fourth_entry_same_utc_day():
+    block = _quick_tp_trade_specs()
+    specs = block * 5  # each pair: entry bar + TP-exit bar, back to back, no gap
+    bars = _mk(0, specs)
+    sigs = [
+        _sig(signal_ts=2 * i * MIN, side="long", sl=1000.0, tp=200.0, timeout=1)
+        for i in range(5)
+    ]
+    result = run_symbol_stream(bars, sigs, cm.COST_SCENARIO_PRIMARY_STRESS)
+    assert len(result.trades) == 3
+    cap_reasons = [nt.reason for nt in result.no_trades]
+    assert cap_reasons.count("daily_entry_cap") == 2
+
+
+def test_consecutive_two_stop_outs_halts_day():
+    sl_specs = [(100, 100, 100, 100), (99.0, 99.1, 98.0, 98.5)]  # SL=99 touched
+    specs = sl_specs + sl_specs  # two consecutive SL trades, back to back
+    specs += [
+        (100, 100, 100, 100),
+        (100.5, 102.0, 100.4, 101.9),
+    ]  # a 3rd (would-be TP) trade
+    bars = _mk(0, specs)
+    sigs = [
+        _sig(signal_ts=0, side="long", sl=100.0, tp=200.0, timeout=1),
+        _sig(signal_ts=2 * MIN, side="long", sl=100.0, tp=200.0, timeout=1),
+        _sig(signal_ts=4 * MIN, side="long", sl=1000.0, tp=200.0, timeout=1),
+    ]
+    result = run_symbol_stream(bars, sigs, cm.COST_SCENARIO_PRIMARY_STRESS)
+    assert len(result.trades) == 2
+    assert all(t.exit_reason == "stop_loss" for t in result.trades)
+    assert result.no_trades[0].reason == "daily_stop_active"
+
+
+def test_single_trade_minus_2r_halts_day():
+    # tight SL (10bps) so a single stop-out's cost-included R <= -2.0 alone.
+    specs = [
+        (100, 100, 100, 100),
+        (99.9, 99.91, 99.89, 99.9),
+    ]  # SL=99.9 (10bps) touched
+    specs += [(100, 100, 100, 100), (100.5, 102.0, 100.4, 101.9)]  # would-be TP trade
+    bars = _mk(0, specs)
+    sigs = [
+        _sig(signal_ts=0, side="long", sl=10.0, tp=200.0, timeout=1),
+        _sig(signal_ts=2 * MIN, side="long", sl=1000.0, tp=200.0, timeout=1),
+    ]
+    result = run_symbol_stream(bars, sigs, cm.COST_SCENARIO_PRIMARY_STRESS)
+    assert len(result.trades) == 1
+    t = result.trades[0]
+    r = t.net_bps / 10.0
+    assert r <= -2.0
+    assert result.no_trades[0].reason == "daily_stop_active"
+
+
+def test_daily_state_resets_on_a_new_utc_day():
+    day1 = [(100, 100, 100, 100), (100.5, 102.0, 100.4, 101.9)]
+    bars_day1 = _mk(0, day1 * 3)  # 3 entries on day 0, exhausts cap
+    day2_start = 24 * 60 * MIN  # +1 day in ms, aligned to a 1m boundary
+    bars_day2 = _mk(day2_start, day1)
+    bars = bars_day1 + bars_day2
+    sigs = [
+        _sig(signal_ts=2 * i * MIN, side="long", sl=1000.0, tp=200.0, timeout=1)
+        for i in range(3)
+    ]
+    sigs.append(_sig(signal_ts=day2_start, side="long", sl=1000.0, tp=200.0, timeout=1))
+    result = run_symbol_stream(bars, sigs, cm.COST_SCENARIO_PRIMARY_STRESS)
+    assert len(result.trades) == 4  # day-2 entry not blocked by day-1's exhausted cap
+    assert result.no_trades == ()
+
+
+# --------------------------------------------------------------------------- #
+# 68bp boundary (AC7)
+# --------------------------------------------------------------------------- #
+def test_68bp_exact_passes_and_67_99_fails():
+    specs = [(100, 100, 100, 100), (100, 100.1, 99.9, 100)]
+    bars = _mk(0, specs)
+    sig_pass = _sig(signal_ts=0, tp=68.0, sl=100.0, timeout=1)
+    result_pass = run_symbol_stream(bars, [sig_pass], cm.COST_SCENARIO_PRIMARY_STRESS)
+    assert len(result_pass.trades) == 1
+
+    sig_fail = _sig(signal_ts=0, tp=67.99, sl=100.0, timeout=1)
+    result_fail = run_symbol_stream(bars, [sig_fail], cm.COST_SCENARIO_PRIMARY_STRESS)
+    assert result_fail.trades == ()
+    assert result_fail.no_trades[0].reason == "tp_below_min_distance"
+
+
+def test_68bp_gate_applies_to_absolute_target_price_too():
+    bars = _mk(0, [(100, 100, 100, 100), (100, 100.1, 99.9, 100)])
+    # entry=100 -> target=100.68 is exactly 68bps
+    sig_pass = _sig(signal_ts=0, sl=100.0, tp_target=100.68, timeout=1)
+    result_pass = run_symbol_stream(bars, [sig_pass], cm.COST_SCENARIO_PRIMARY_STRESS)
+    assert len(result_pass.trades) == 1
+
+    sig_fail = _sig(signal_ts=0, sl=100.0, tp_target=100.6799, timeout=1)
+    result_fail = run_symbol_stream(bars, [sig_fail], cm.COST_SCENARIO_PRIMARY_STRESS)
+    assert result_fail.trades == ()
+    assert result_fail.no_trades[0].reason == "tp_below_min_distance"
+
+
+# --------------------------------------------------------------------------- #
+# 13/17/22bp cost scenarios + fee/funding no-double-count (AC6)
+# --------------------------------------------------------------------------- #
+def test_13_17_22_cost_scenarios_share_trade_path_differ_only_in_net():
+    specs = [(100, 100, 100, 100), (100.5, 102.0, 100.4, 101.9)]
+    bars = _mk(0, specs)
+    sig = _sig(signal_ts=0, sl=1000.0, tp=200.0, timeout=1)
+    results = {
+        s.name: run_symbol_stream(bars, [sig], s).trades[0] for s in cm.COST_SCENARIOS
+    }
+    base, primary, upward = (
+        results["base"],
+        results["primary_stress"],
+        results["upward_stress"],
+    )
+    assert base.entry_ts == primary.entry_ts == upward.entry_ts
+    assert base.exit_ts == primary.exit_ts == upward.exit_ts
+    assert base.exit_price == primary.exit_price == upward.exit_price
+    assert base.gross_bps == primary.gross_bps == upward.gross_bps
+    assert (
+        base.all_in_bps == 13.0
+        and primary.all_in_bps == 17.0
+        and upward.all_in_bps == 22.0
+    )
+    assert base.net_bps == base.gross_bps - 13.0
+    assert primary.net_bps == primary.gross_bps - 17.0
+    assert upward.net_bps == upward.gross_bps - 22.0
+    assert base.net_bps > primary.net_bps > upward.net_bps
+
+
+def test_fee_bps_recorded_but_not_subtracted_twice_in_net():
+    specs = [(100, 100, 100, 100), (100.5, 102.0, 100.4, 101.9)]
+    bars = _mk(0, specs)
+    sig = _sig(signal_ts=0, sl=1000.0, tp=200.0, timeout=1)
+    t = run_symbol_stream(bars, [sig], cm.COST_SCENARIO_PRIMARY_STRESS).trades[0]
+    assert t.fee_bps == 10.0
+    assert t.net_bps == t.gross_bps - t.all_in_bps - t.funding_bps
+    assert t.net_bps != t.gross_bps - t.fee_bps - t.all_in_bps - t.funding_bps
+
+
+def test_funding_applied_exactly_once_via_lookup():
+    specs = [(100, 100, 100, 100), (100.5, 102.0, 100.4, 101.9)]
+    bars = _mk(0, specs)
+    sig = _sig(signal_ts=0, sl=1000.0, tp=200.0, timeout=1)
+    calls = []
+
+    def lookup(symbol, side, entry_ts, exit_ts):
+        calls.append((symbol, side, entry_ts, exit_ts))
+        return [
+            cm.FundingCrossing(ts=entry_ts + 1, rate_bps=2.0),
+            cm.FundingCrossing(ts=entry_ts + 2, rate_bps=1.0),
+        ]
+
+    result = run_symbol_stream(
+        bars, [sig], cm.COST_SCENARIO_PRIMARY_STRESS, funding_lookup=lookup
+    )
+    t = result.trades[0]
+    assert calls == [("XRPUSDT", "long", 0, MIN)]
+    assert t.funding_bps == 3.0  # long pays: sum(rate_bps)
+    assert t.net_bps == t.gross_bps - t.all_in_bps - 3.0
+
+
+# --------------------------------------------------------------------------- #
+# ordering / determinism / hash
+# --------------------------------------------------------------------------- #
+def test_signals_processed_in_signal_ts_order_regardless_of_input_order():
+    block = _quick_tp_trade_specs()
+    bars = _mk(0, block * 2)
+    sig_a = _sig(signal_ts=0, sl=1000.0, tp=200.0, timeout=1)
+    sig_b = _sig(signal_ts=2 * MIN, sl=1000.0, tp=200.0, timeout=1)
+    forward = run_symbol_stream(bars, [sig_a, sig_b], cm.COST_SCENARIO_PRIMARY_STRESS)
+    backward = run_symbol_stream(bars, [sig_b, sig_a], cm.COST_SCENARIO_PRIMARY_STRESS)
+    assert forward.trades == backward.trades
+
+
+def test_ledger_hash_is_deterministic_and_content_sensitive():
+    from rob940_engine import ledger_hash
+
+    specs = [(100, 100, 100, 100), (100.5, 102.0, 100.4, 101.9)]
+    bars = _mk(0, specs)
+    sig = _sig(signal_ts=0, sl=1000.0, tp=200.0, timeout=1)
+    r1 = run_symbol_stream(bars, [sig], cm.COST_SCENARIO_PRIMARY_STRESS)
+    r2 = run_symbol_stream(bars, [sig], cm.COST_SCENARIO_PRIMARY_STRESS)
+    assert ledger_hash(r1.trades) == ledger_hash(r2.trades)
+
+    r3 = run_symbol_stream(bars, [sig], cm.COST_SCENARIO_BASE)  # different scenario
+    assert ledger_hash(r1.trades) != ledger_hash(r3.trades)
+
+    assert isinstance(ledger_hash(()), str) and len(ledger_hash(())) == 64
+
+
+def test_rejects_non_increasing_bar_timestamps():
+    bars = _mk(0, [(1, 1, 1, 1), (2, 2, 2, 2)])
+    bars = [bars[0], bars[0]]
+    sig = _sig(signal_ts=0)
+    try:
+        run_symbol_stream(bars, [sig], cm.COST_SCENARIO_PRIMARY_STRESS)
+        raised = False
+    except ValueError:
+        raised = True
+    assert raised

--- a/research/nautilus_scalping/tests/test_rob940_engine.py
+++ b/research/nautilus_scalping/tests/test_rob940_engine.py
@@ -464,6 +464,12 @@ def test_68bp_gate_applies_to_absolute_target_price_too():
 # 13/17/22bp cost scenarios + fee/funding no-double-count (AC6)
 # --------------------------------------------------------------------------- #
 def test_13_17_22_cost_scenarios_share_trade_path_differ_only_in_net():
+    # NOTE (ROB-942 R1 correction): this pins the narrow case where the
+    # single trade never triggers AC8's cost-included daily stop, so all
+    # three scenarios' independent runs happen to walk the same path. It is
+    # NOT a general "scenarios always share a path" guarantee -- see
+    # test_cost_scenario_dependent_daily_stop_diverges_trade_count below for
+    # the case where they provably do not.
     specs = [(100, 100, 100, 100), (100.5, 102.0, 100.4, 101.9)]
     bars = _mk(0, specs)
     sig = _sig(signal_ts=0, sl=1000.0, tp=200.0, timeout=1)
@@ -520,6 +526,86 @@ def test_funding_applied_exactly_once_via_lookup():
     assert calls == [("XRPUSDT", "long", 0, MIN)]
     assert t.funding_bps == 3.0  # long pays: sum(rate_bps)
     assert t.net_bps == t.gross_bps - t.all_in_bps - 3.0
+
+
+# --------------------------------------------------------------------------- #
+# ROB-942 R1 correction: cost-scenario path divergence is an intended
+# consequence of AC8's cost-included daily stop, not a bug -- and the 68bp
+# entry-eligibility gate itself does NOT vary by scenario. See the
+# rob940_cost_model / rob940_engine module docstrings for the full writeup.
+# --------------------------------------------------------------------------- #
+def test_68bp_gate_is_identical_across_all_cost_scenarios():
+    specs = [(100, 100, 100, 100), (100, 100.1, 99.9, 100)]
+    bars = _mk(0, specs)
+    for scenario in cm.COST_SCENARIOS:
+        sig_pass = _sig(signal_ts=0, tp=68.0, sl=100.0, timeout=1)
+        result_pass = run_symbol_stream(bars, [sig_pass], scenario)
+        assert len(result_pass.trades) == 1, scenario.name
+
+        sig_fail = _sig(signal_ts=0, tp=67.99, sl=100.0, timeout=1)
+        result_fail = run_symbol_stream(bars, [sig_fail], scenario)
+        assert result_fail.trades == (), scenario.name
+        assert result_fail.no_trades[0].reason == "tp_below_min_distance"
+
+
+def test_cost_scenario_dependent_daily_stop_diverges_trade_count():
+    # trade1: SL touch at sl_distance=1000bps -> gross=-1000bps exactly.
+    # trade2: timeout exit at sl_distance=25bps with gross=-3bps (no SL touch).
+    # trade3: clean TP hit (gap-through), scenario-independent outcome.
+    #
+    # cumulative R after trade1+trade2 = -1.12 - 0.041*all_in_bps:
+    #   base(13)    -> -1.653  (> -2.0, NOT halted -> trade3 fires)
+    #   primary(17) -> -1.817  (> -2.0, NOT halted -> trade3 fires)
+    #   upward(22)  -> -2.022  (<= -2.0, HALTED -> trade3 blocked)
+    # This is the reproduction from the R1 verify report (base/primary=3
+    # trades, upward=2 trades) with hand-derived, exactly-reproducible bars.
+    specs = [
+        (100, 100, 100, 100),  # idx0: trade1 entry (flat)
+        (91, 91.5, 90, 90.5),  # idx1: trade1 SL touch, low<=90
+        (100, 100, 100, 100),  # idx2: trade2 entry (flat)
+        (99.97, 99.97, 99.97, 99.97),  # idx3: trade2 timeout deadline (open=99.97)
+        (100, 100, 100, 100),  # idx4: trade3 entry (flat)
+        (102, 102, 102, 102),  # idx5: trade3 deadline, gaps through TP=101
+    ]
+    bars = _mk(0, specs)
+    sig1 = _sig(signal_ts=0, side="long", sl=1000.0, tp=100000.0, timeout=5, cooldown=0)
+    sig2 = _sig(
+        signal_ts=2 * MIN, side="long", sl=25.0, tp=100000.0, timeout=1, cooldown=0
+    )
+    sig3 = _sig(
+        signal_ts=4 * MIN, side="long", sl=1000.0, tp=100.0, timeout=1, cooldown=0
+    )
+    signals = [sig1, sig2, sig3]
+
+    results = {s.name: run_symbol_stream(bars, signals, s) for s in cm.COST_SCENARIOS}
+    base, primary, upward = (
+        results["base"],
+        results["primary_stress"],
+        results["upward_stress"],
+    )
+
+    # trade1/trade2 are eligibility-identical (same 68bp gate, no halt yet
+    # reached) across all three scenarios -- only the count diverges via AC8.
+    for r in (base, primary, upward):
+        assert len(r.trades) >= 2
+        assert r.trades[0].exit_reason == "stop_loss"
+        assert r.trades[0].exit_ts == base.trades[0].exit_ts == 1 * MIN
+        assert r.trades[1].exit_reason == "timeout"
+        assert r.trades[1].exit_ts == base.trades[1].exit_ts == 3 * MIN
+
+    assert len(base.trades) == 3
+    assert len(primary.trades) == 3
+    assert len(upward.trades) == 2
+    assert upward.no_trades[-1].reason == "daily_stop_active"
+    assert base.no_trades == ()
+    assert primary.no_trades == ()
+
+    r1 = base.trades[0].net_bps / 1000.0
+    r2 = base.trades[1].net_bps / 25.0
+    assert r1 + r2 > -2.0  # base: not halted after trade1+trade2
+    r1u = upward.trades[0].net_bps / 1000.0
+    r2u = upward.trades[1].net_bps / 25.0
+    assert r1u + r2u <= -2.0  # upward: halted after trade1+trade2
 
 
 # --------------------------------------------------------------------------- #

--- a/research/nautilus_scalping/tests/test_rob940_import_guard.py
+++ b/research/nautilus_scalping/tests/test_rob940_import_guard.py
@@ -43,6 +43,7 @@ _ALLOWED = {
     "collections.abc",
     "dataclasses",
     "datetime",
+    "math",
     "typing",
     "research_contracts.canonical_hash",
     "rob940_bars_agg",

--- a/research/nautilus_scalping/tests/test_rob940_import_guard.py
+++ b/research/nautilus_scalping/tests/test_rob940_import_guard.py
@@ -1,0 +1,76 @@
+"""ROB-942 (H2, ROB-940) — AC1 import-boundary guard.
+
+Mirrors the existing ``test_pit_data_layer_guard.py`` AST-check pattern, but
+covers the full AC1 forbidden surface for the engine modules specifically:
+DB/network/app-settings/broker/order/fill/scheduler. A module either imports
+only stdlib + the allowed research-local names, or this test fails.
+"""
+
+import ast
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parents[1]
+_MODULES = ["rob940_bars_agg.py", "rob940_cost_model.py", "rob940_engine.py"]
+
+# Forbidden top-level import prefixes: app settings/broker/order/fill/scheduler
+# surfaces, plus common DB/network client libraries. Anything matching one of
+# these (as an exact name or dotted-prefix) fails the guard.
+_FORBIDDEN_PREFIXES = (
+    "app",  # app.* settings/broker/order/fill/scheduler/db surfaces
+    "sqlalchemy",
+    "asyncpg",
+    "psycopg",
+    "psycopg2",
+    "alembic",
+    "redis",
+    "taskiq",
+    "celery",
+    "httpx",
+    "requests",
+    "aiohttp",
+    "urllib3",
+    "urllib",
+    "socket",
+    "websockets",
+    "boto3",
+    "fastapi",
+    "uvicorn",
+)
+
+# Explicit allowlist for what these pure engine modules MAY import.
+_ALLOWED = {
+    "__future__",
+    "collections.abc",
+    "dataclasses",
+    "datetime",
+    "typing",
+    "research_contracts.canonical_hash",
+    "rob940_bars_agg",
+    "rob940_cost_model",
+}
+
+
+def _imports(path: Path):
+    tree = ast.parse(path.read_text())
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for n in node.names:
+                yield n.name
+        elif isinstance(node, ast.ImportFrom):
+            yield node.module or ""
+
+
+def test_no_forbidden_db_network_app_broker_order_fill_scheduler_imports():
+    for mod in _MODULES:
+        for name in _imports(_ROOT / mod):
+            top = name.split(".")[0]
+            assert top not in _FORBIDDEN_PREFIXES, (
+                f"{mod} imports forbidden module {name!r} (AC1: no DB/network/"
+                "app-settings/broker/order/fill/scheduler imports)"
+            )
+
+
+def test_only_allowlisted_modules_are_imported():
+    for mod in _MODULES:
+        for name in _imports(_ROOT / mod):
+            assert name in _ALLOWED, f"{mod} imports non-allowlisted module {name!r}"

--- a/research/nautilus_scalping/tests/test_rob940_nonfinite_guard.py
+++ b/research/nautilus_scalping/tests/test_rob940_nonfinite_guard.py
@@ -1,0 +1,149 @@
+"""ROB-942 R1 M1 fix — non-finite (NaN/+Inf/-Inf) input fail-closed RED fixtures.
+
+R1 verifier finding M1: ``SignalEvent.__post_init__``'s ``<= 0`` checks let NaN
+through (``nan <= 0`` is ``False``), and ``Bar1m``/``CostScenario``/
+``FundingCrossing`` had no validation at all, so a non-finite value could ride
+all the way to ``TradeRecord``/``ledger_hash`` before failing (if it failed at
+all). This module pins that every non-finite entry point raises ``ValueError``
+at construction/call time, BEFORE any ledger (TradeRecord) is built — not
+deferred to hashing. Existing "price must be positive" / "distance must be
+positive" contracts are preserved unchanged; this only closes the NaN/Inf gap.
+"""
+
+import math
+
+import pytest
+import rob940_cost_model as cm
+from rob940_bars_agg import Bar1m
+from rob940_engine import SignalEvent
+
+_NONFINITE = (math.nan, math.inf, -math.inf)
+
+
+# --------------------------------------------------------------------------- #
+# SignalEvent: sl_distance_bps / tp_distance_bps / tp_target_price
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("bad", _NONFINITE)
+def test_signal_event_rejects_nonfinite_sl_distance_bps(bad):
+    with pytest.raises(ValueError):
+        SignalEvent(
+            strategy="s",
+            config_id="c",
+            symbol="X",
+            signal_ts=0,
+            side="long",
+            sl_distance_bps=bad,
+            tp_distance_bps=100.0,
+        )
+
+
+@pytest.mark.parametrize("bad", _NONFINITE)
+def test_signal_event_rejects_nonfinite_tp_distance_bps(bad):
+    with pytest.raises(ValueError):
+        SignalEvent(
+            strategy="s",
+            config_id="c",
+            symbol="X",
+            signal_ts=0,
+            side="long",
+            sl_distance_bps=50.0,
+            tp_distance_bps=bad,
+        )
+
+
+@pytest.mark.parametrize("bad", _NONFINITE)
+def test_signal_event_rejects_nonfinite_tp_target_price(bad):
+    with pytest.raises(ValueError):
+        SignalEvent(
+            strategy="s",
+            config_id="c",
+            symbol="X",
+            signal_ts=0,
+            side="long",
+            sl_distance_bps=50.0,
+            tp_target_price=bad,
+        )
+
+
+# --------------------------------------------------------------------------- #
+# Bar1m OHLCV
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("bad", _NONFINITE)
+@pytest.mark.parametrize("field", ["open", "high", "low", "close", "volume"])
+def test_bar1m_rejects_nonfinite_ohlcv_field(field, bad):
+    kwargs = {
+        "ts": 0,
+        "open": 100.0,
+        "high": 100.0,
+        "low": 100.0,
+        "close": 100.0,
+        "volume": 1.0,
+    }
+    kwargs[field] = bad
+    with pytest.raises(ValueError):
+        Bar1m(**kwargs)
+
+
+# --------------------------------------------------------------------------- #
+# CostScenario / FundingCrossing
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("bad", _NONFINITE)
+def test_cost_scenario_rejects_nonfinite_all_in_bps(bad):
+    with pytest.raises(ValueError):
+        cm.CostScenario("bad", bad)
+
+
+@pytest.mark.parametrize("bad", _NONFINITE)
+def test_funding_crossing_rejects_nonfinite_rate_bps(bad):
+    with pytest.raises(ValueError):
+        cm.FundingCrossing(ts=0, rate_bps=bad)
+
+
+# --------------------------------------------------------------------------- #
+# gross_bps / net_bps boundary
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("bad", _NONFINITE)
+def test_gross_bps_rejects_nonfinite_entry_price(bad):
+    with pytest.raises(ValueError):
+        cm.gross_bps("long", bad, 100.0)
+
+
+@pytest.mark.parametrize("bad", _NONFINITE)
+def test_gross_bps_rejects_nonfinite_exit_price(bad):
+    with pytest.raises(ValueError):
+        cm.gross_bps("long", 100.0, bad)
+
+
+@pytest.mark.parametrize("bad", _NONFINITE)
+def test_net_bps_rejects_nonfinite_gross(bad):
+    with pytest.raises(ValueError):
+        cm.net_bps(bad, cm.COST_SCENARIO_PRIMARY_STRESS, 0.0)
+
+
+@pytest.mark.parametrize("bad", _NONFINITE)
+def test_net_bps_rejects_nonfinite_funding(bad):
+    with pytest.raises(ValueError):
+        cm.net_bps(50.0, cm.COST_SCENARIO_PRIMARY_STRESS, bad)
+
+
+# --------------------------------------------------------------------------- #
+# existing positive-price / positive-distance contracts must still hold
+# --------------------------------------------------------------------------- #
+def test_gross_bps_still_rejects_nonpositive_finite_entry():
+    with pytest.raises(ValueError):
+        cm.gross_bps("long", 0.0, 10.0)
+    with pytest.raises(ValueError):
+        cm.gross_bps("long", -5.0, 10.0)
+
+
+def test_signal_event_still_rejects_nonpositive_finite_sl_distance():
+    with pytest.raises(ValueError):
+        SignalEvent(
+            strategy="s",
+            config_id="c",
+            symbol="X",
+            signal_ts=0,
+            side="long",
+            sl_distance_bps=0.0,
+            tp_distance_bps=100.0,
+        )


### PR DESCRIPTION
## Summary

- Pure, stdlib-only ROB-940 (H2) historical-screen execution engine under `research/nautilus_scalping/`: `rob940_bars_agg.py` (complete-only 1m→5m/15m aggregation with gap warm-up reset), `rob940_cost_model.py` (5bp/leg fee, 13/17/22bp all-in scenarios, derived 68bp min-TP gate, PIT funding crossing math), `rob940_engine.py` (next-1m-open fill, gap-exit-first + intrabar SL-first bar ordering, single-position-per-symbol cooldown/timeout, UTC-day entry cap + stop-out/loss halts, deterministic canonical-hash ledger).
- 52 TDD tests, RED-first (module-not-found failures captured before implementation), covering every AC10 fixture plus an AST-based import guard proving zero DB/network/app/broker/order/fill/scheduler imports.
- Runs in parallel with ROB-941 (H1/data pipeline) under separate file ownership; no signal math (ROB-943), no multi-symbol arbitration, no broker/demo/paper mutation, no ROB-905 gate artifacts, no production DB access.

## Test plan

- [x] RED: `ModuleNotFoundError` for all three new modules before implementation (see PR description / worker report for captured output)
- [x] GREEN: `uv run --project . python -m pytest tests/test_rob940_bars_agg.py tests/test_rob940_cost_model.py tests/test_rob940_engine.py tests/test_rob940_import_guard.py -v` → 52 passed
- [x] Regression: full `research/nautilus_scalping/tests/` suite (excluding pre-existing, unrelated `nautilus_trader`-optional-dep and locally-downloaded-market-data failures) → 410 passed, no new failures
- [x] `ruff check` / `ruff format --check` clean on all new files
- [x] `uv run ty check` clean on all new files
- [x] Ledger hash verified byte-identical across 4 separate process invocations with different `PYTHONHASHSEED` values (0, 999999, 42, default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added complete higher-timeframe OHLCV aggregation from 1-minute bars, excluding incomplete buckets and handling data gaps.
  * Added deterministic cost calculations for fees, funding, gross returns, and scenario-based net performance.
  * Added a 1-minute execution engine supporting entries, exits, stop-loss/take-profit handling, timeouts, cooldowns, daily limits, and trade ledgers.
  * Added deterministic ledger hashing for reproducible results.

* **Tests**
  * Added comprehensive coverage for aggregation, cost calculations, execution behavior, validation, determinism, and import boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->