### PR TITLE
feat(ROB-941): historical data corpus + immutable manifest (4-symbol Binance USD-M)

### DIFF
--- a/research/nautilus_scalping/build_rob941_corpus.py
+++ b/research/nautilus_scalping/build_rob941_corpus.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""ROB-941 — build the frozen 4-symbol historical corpus + immutable manifest.
+
+Read-only PUBLIC data only (``data.binance.vision/data/futures/um``). No keys,
+no auth, no order endpoints, no broker/scheduler wiring, no production DB
+writes. The network RUN is operator-gated behind ``--run``; CI/tests exercise
+only the pure helpers (``rob941_*``) with a fake in-memory opener.
+
+Raw archives and the normalized row shards are NEVER written to disk by this
+script — everything is streamed through memory (fetch -> checksum -> extract ->
+normalize -> hash -> discard). Only the manifest (metadata: upstream URLs,
+verified checksums, normalized-shard SHA-256, row counts, min/max timestamps,
+gap ranges — no OHLCV values) is persisted, and it goes to the COMMITTED
+``data_manifests/`` path (same convention as ``pit_universe.v1.json``), never
+``crypto_candles_1m``, never a production table.
+
+Usage (operator):
+    cd research/nautilus_scalping
+    uv run --no-project python build_rob941_corpus.py --run
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import canonical_hash
+import rob941_corpus_builder as cb
+import rob941_frozen_scope as frozen
+from rob941_manifest import (
+    CorpusManifest,
+    SymbolEligibility,
+    SymbolFundingManifest,
+    SymbolKlineManifest,
+)
+
+
+def _kline_manifest_for(symbol: str) -> tuple[SymbolKlineManifest, list]:
+    rows, provenance, gap_ranges = cb.build_symbol_kline_shard(symbol)
+    shard_hash = canonical_hash.canonical_sha256([r.__dict__ for r in rows])
+    manifest = SymbolKlineManifest(
+        symbol=symbol,
+        interval="1m",
+        archives=tuple(provenance),
+        normalized_shard_sha256=shard_hash,
+        row_count=len(rows),
+        min_open_time_ms=rows[0].open_time_ms if rows else frozen.WINDOW_START_MS,
+        max_open_time_ms=rows[-1].open_time_ms if rows else frozen.WINDOW_START_MS,
+        gap_ranges=tuple(gap_ranges),
+    )
+    return manifest, rows
+
+
+def _funding_manifest_for(symbol: str) -> SymbolFundingManifest:
+    rows, provenance = cb.build_symbol_funding_shard(symbol)
+    shard_hash = canonical_hash.canonical_sha256([r.__dict__ for r in rows])
+    return SymbolFundingManifest(
+        symbol=symbol,
+        archives=tuple(provenance),
+        normalized_shard_sha256=shard_hash,
+        row_count=len(rows),
+        min_calc_time_ms=rows[0].calc_time if rows else None,
+        max_calc_time_ms=rows[-1].calc_time if rows else None,
+    )
+
+
+def build_corpus() -> CorpusManifest:
+    """Build the full 4-symbol corpus manifest. Fail-closed: any symbol's
+    checksum/OHLCV/duplicate violation aborts the whole build (no partial
+    corpus is ever persisted as if it were complete)."""
+    eligibility = tuple(
+        SymbolEligibility(symbol=s, **frozen.eligibility(s)) for s in frozen.UNIVERSE
+    )
+    klines = []
+    funding = []
+    for symbol in frozen.UNIVERSE:
+        k_manifest, _rows = _kline_manifest_for(symbol)
+        klines.append(k_manifest)
+        funding.append(_funding_manifest_for(symbol))
+
+    manifest = CorpusManifest(
+        window_start_iso=frozen.WINDOW_START_ISO,
+        window_end_iso=frozen.WINDOW_END_ISO,
+        universe=frozen.UNIVERSE,
+        eligibility=eligibility,
+        klines=tuple(klines),
+        funding=tuple(funding),
+    )
+    manifest.validate_frozen_scope()
+    return manifest
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(
+        description="Build the ROB-941 frozen 4-symbol historical corpus manifest"
+    )
+    ap.add_argument(
+        "--run",
+        action="store_true",
+        help="Actually perform the network fetch (default: no-op, prints usage)",
+    )
+    ap.add_argument(
+        "--out",
+        default=None,
+        help=(
+            "Manifest output path (default: "
+            "data_manifests/rob941_corpus_manifest.v1.json, committed like "
+            "pit_universe.v1.json — metadata only, no raw OHLCV)"
+        ),
+    )
+    args = ap.parse_args(argv)
+
+    if not args.run:
+        print("no-op: pass --run to perform the network build (operator-gated)")
+        return 0
+
+    manifest = build_corpus()
+    default_out = (
+        Path(__file__).resolve().parent
+        / "data_manifests"
+        / "rob941_corpus_manifest.v1.json"
+    )
+    out_path = Path(args.out) if args.out else default_out
+    manifest.save(out_path)
+    print(
+        json.dumps(
+            {
+                "manifest_path": str(out_path),
+                "content_hash": manifest.content_hash(),
+                "symbols": list(manifest.universe),
+                "kline_row_counts": {k.symbol: k.row_count for k in manifest.klines},
+                "funding_row_counts": {f.symbol: f.row_count for f in manifest.funding},
+                "gap_range_counts": {
+                    k.symbol: len(k.gap_ranges) for k in manifest.klines
+                },
+            },
+            indent=2,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/research/nautilus_scalping/build_rob941_corpus.py
+++ b/research/nautilus_scalping/build_rob941_corpus.py
@@ -6,13 +6,38 @@ no auth, no order endpoints, no broker/scheduler wiring, no production DB
 writes. The network RUN is operator-gated behind ``--run``; CI/tests exercise
 only the pure helpers (``rob941_*``) with a fake in-memory opener.
 
-Raw archives and the normalized row shards are NEVER written to disk by this
-script — everything is streamed through memory (fetch -> checksum -> extract ->
-normalize -> hash -> discard). Only the manifest (metadata: upstream URLs,
-verified checksums, normalized-shard SHA-256, row counts, min/max timestamps,
-gap ranges — no OHLCV values) is persisted, and it goes to the COMMITTED
-``data_manifests/`` path (same convention as ``pit_universe.v1.json``), never
-``crypto_candles_1m``, never a production table.
+ROB-941 R1 I1 remediation: raw archives and the normalized kline/funding rows
+ARE now persisted (``rob941_persistence``), as checksum-pinned ``.zip`` files
+and schema-pinned Parquet shards, under ``artifact_paths.pit_data_root()``
+(gitignored — never committed, never containing OHLCV values in the COMMITTED
+manifest itself). Only the manifest (metadata: upstream URLs, verified
+checksums, normalized-shard SHA-256, physical shard-file SHA-256,
+artifact-root-relative shard paths, row counts, min/max timestamps, gap ranges
+— still no raw OHLCV values) goes to the COMMITTED ``data_manifests/`` path
+(same convention as ``pit_universe.v1.json``), never ``crypto_candles_1m``,
+never a production table.
+
+``ultrathink`` (captain review, atomicity correction + determinism follow-up):
+every raw archive and Parquet shard is written by ``rob941_persistence`` to a
+CONTENT-ADDRESSED path — the archive's own verified checksum, or the shard's
+semantic ``normalized_shard_sha256``, is embedded in the path itself. Two
+builds only ever write to the SAME path when their content is byte-identical
+(a safe, skipped no-op re-write); genuinely different content always lands at
+a genuinely different path. This makes a rebuild that fails partway (checksum
+mismatch on symbol 3 of 4, say) structurally incapable of corrupting or
+partially overwriting the bytes a still-published prior manifest references —
+no generation directory, temp-write, or rename is needed for the per-shard
+artifacts, and (unlike a random/time-based generation id) an identical rerun
+against identical upstream/fixture bytes reproduces the exact same relative
+paths and therefore the exact same manifest ``content_hash()`` — there is no
+circular "hash depends on its own path" dependency, since every path is
+derived from a checksum/content-hash computed BEFORE that path is ever built.
+The only remaining atomic-publish step is the single COMMITTED MANIFEST FILE
+(a same-directory temp-write + rename, publishing "which shard hashes are
+current" last, only after every symbol's shard has round-tripped through the
+same offline verification chain H4/H6 will use) — a mid-build failure leaves
+any prior committed manifest, and everything it references, byte-for-byte
+untouched.
 
 Usage (operator):
     cd research/nautilus_scalping
@@ -26,9 +51,13 @@ import json
 import sys
 from pathlib import Path
 
+import artifact_paths
 import canonical_hash
+import rob941_archive_fetch as af
 import rob941_corpus_builder as cb
 import rob941_frozen_scope as frozen
+import rob941_offline_loader as loader
+import rob941_persistence as persist
 from rob941_manifest import (
     CorpusManifest,
     SymbolEligibility,
@@ -37,10 +66,22 @@ from rob941_manifest import (
 )
 
 
-def _kline_manifest_for(symbol: str) -> tuple[SymbolKlineManifest, list]:
-    rows, provenance, gap_ranges = cb.build_symbol_kline_shard(symbol)
+def _kline_manifest_for(
+    symbol: str, artifact_root: Path, opener: af.Opener = af.urllib_opener
+) -> SymbolKlineManifest:
+    def raw_sink(sym: str, kind: str, year: int, month: int, zip_bytes: bytes) -> str:
+        return persist.write_raw_archive(
+            artifact_root, sym, kind, year, month, zip_bytes
+        )
+
+    rows, provenance, gap_ranges = cb.build_symbol_kline_shard(
+        symbol, opener=opener, raw_archive_sink=raw_sink
+    )
     shard_hash = canonical_hash.canonical_sha256([r.__dict__ for r in rows])
-    manifest = SymbolKlineManifest(
+    shard_path, shard_file_sha256 = persist.write_kline_shard(
+        artifact_root, symbol, rows
+    )
+    return SymbolKlineManifest(
         symbol=symbol,
         interval="1m",
         archives=tuple(provenance),
@@ -49,13 +90,26 @@ def _kline_manifest_for(symbol: str) -> tuple[SymbolKlineManifest, list]:
         min_open_time_ms=rows[0].open_time_ms if rows else frozen.WINDOW_START_MS,
         max_open_time_ms=rows[-1].open_time_ms if rows else frozen.WINDOW_START_MS,
         gap_ranges=tuple(gap_ranges),
+        shard_path=shard_path,
+        shard_file_sha256=shard_file_sha256,
     )
-    return manifest, rows
 
 
-def _funding_manifest_for(symbol: str) -> SymbolFundingManifest:
-    rows, provenance = cb.build_symbol_funding_shard(symbol)
+def _funding_manifest_for(
+    symbol: str, artifact_root: Path, opener: af.Opener = af.urllib_opener
+) -> SymbolFundingManifest:
+    def raw_sink(sym: str, kind: str, year: int, month: int, zip_bytes: bytes) -> str:
+        return persist.write_raw_archive(
+            artifact_root, sym, kind, year, month, zip_bytes
+        )
+
+    rows, provenance = cb.build_symbol_funding_shard(
+        symbol, opener=opener, raw_archive_sink=raw_sink
+    )
     shard_hash = canonical_hash.canonical_sha256([r.__dict__ for r in rows])
+    shard_path, shard_file_sha256 = persist.write_funding_shard(
+        artifact_root, symbol, rows
+    )
     return SymbolFundingManifest(
         symbol=symbol,
         archives=tuple(provenance),
@@ -63,22 +117,31 @@ def _funding_manifest_for(symbol: str) -> SymbolFundingManifest:
         row_count=len(rows),
         min_calc_time_ms=rows[0].calc_time if rows else None,
         max_calc_time_ms=rows[-1].calc_time if rows else None,
+        shard_path=shard_path,
+        shard_file_sha256=shard_file_sha256,
     )
 
 
-def build_corpus() -> CorpusManifest:
-    """Build the full 4-symbol corpus manifest. Fail-closed: any symbol's
+def build_corpus(
+    artifact_root: Path, opener: af.Opener = af.urllib_opener
+) -> CorpusManifest:
+    """Build the full 4-symbol corpus manifest, materializing raw archives +
+    Parquet shards at their content-addressed paths under ``artifact_root``
+    (see the module docstring's ``ultrathink`` note). Fail-closed: any symbol's
     checksum/OHLCV/duplicate violation aborts the whole build (no partial
-    corpus is ever persisted as if it were complete)."""
+    corpus is ever persisted as if it were complete), and because every path is
+    content-addressed, a failed build never overwrites/corrupts the bytes a
+    prior, still-published manifest points at. The returned manifest is ALWAYS
+    re-verified via a full offline ``load_corpus`` pass (network-0, the exact
+    chain H4/H6 will use) against ``artifact_root`` before this function
+    returns, so a materialization bug here can never silently produce an
+    unusable "complete" manifest.
+    """
     eligibility = tuple(
         SymbolEligibility(symbol=s, **frozen.eligibility(s)) for s in frozen.UNIVERSE
     )
-    klines = []
-    funding = []
-    for symbol in frozen.UNIVERSE:
-        k_manifest, _rows = _kline_manifest_for(symbol)
-        klines.append(k_manifest)
-        funding.append(_funding_manifest_for(symbol))
+    klines = [_kline_manifest_for(s, artifact_root, opener) for s in frozen.UNIVERSE]
+    funding = [_funding_manifest_for(s, artifact_root, opener) for s in frozen.UNIVERSE]
 
     manifest = CorpusManifest(
         window_start_iso=frozen.WINDOW_START_ISO,
@@ -89,7 +152,17 @@ def build_corpus() -> CorpusManifest:
         funding=tuple(funding),
     )
     manifest.validate_frozen_scope()
+    loader.load_corpus(manifest, artifact_root)  # atomic-publish gate (ROB-941 R1 I1)
     return manifest
+
+
+def _atomic_save(manifest: CorpusManifest, out_path: Path) -> None:
+    """Write ``manifest`` then atomically replace ``out_path`` -- readers never
+    observe a partially-written committed manifest file."""
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = out_path.with_suffix(out_path.suffix + ".tmp")
+    manifest.save(tmp_path)
+    tmp_path.replace(out_path)
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -116,18 +189,20 @@ def main(argv: list[str] | None = None) -> int:
         print("no-op: pass --run to perform the network build (operator-gated)")
         return 0
 
-    manifest = build_corpus()
+    artifact_root = artifact_paths.pit_data_root()
+    manifest = build_corpus(artifact_root=artifact_root)
     default_out = (
         Path(__file__).resolve().parent
         / "data_manifests"
         / "rob941_corpus_manifest.v1.json"
     )
     out_path = Path(args.out) if args.out else default_out
-    manifest.save(out_path)
+    _atomic_save(manifest, out_path)
     print(
         json.dumps(
             {
                 "manifest_path": str(out_path),
+                "artifact_root": str(artifact_root),
                 "content_hash": manifest.content_hash(),
                 "symbols": list(manifest.universe),
                 "kline_row_counts": {k.symbol: k.row_count for k in manifest.klines},

--- a/research/nautilus_scalping/data_manifests/rob941_corpus_manifest.v1.json
+++ b/research/nautilus_scalping/data_manifests/rob941_corpus_manifest.v1.json
@@ -1,0 +1,608 @@
+{
+  "eligibility": [
+    {
+      "demo_execution_eligible": false,
+      "historical_only": true,
+      "reason": "min_notional_50_exceeds_demo_cap_10",
+      "symbol": "BTCUSDT"
+    },
+    {
+      "demo_execution_eligible": true,
+      "historical_only": false,
+      "reason": null,
+      "symbol": "XRPUSDT"
+    },
+    {
+      "demo_execution_eligible": true,
+      "historical_only": false,
+      "reason": null,
+      "symbol": "DOGEUSDT"
+    },
+    {
+      "demo_execution_eligible": true,
+      "historical_only": false,
+      "reason": null,
+      "symbol": "SOLUSDT"
+    }
+  ],
+  "funding": [
+    {
+      "archives": [
+        {
+          "checksum_sha256": "b097dff828f6e43fece23db0d3cb98042a9d7bc19693b8cbfd051d88eb973b7b",
+          "checksum_url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/BTCUSDT/BTCUSDT-fundingRate-2025-07.zip.CHECKSUM",
+          "url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/BTCUSDT/BTCUSDT-fundingRate-2025-07.zip"
+        },
+        {
+          "checksum_sha256": "1180129860b6e196e8d70bb9719e81573aa6b4acb423ba5ee7f82f10c836f7ab",
+          "checksum_url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/BTCUSDT/BTCUSDT-fundingRate-2025-08.zip.CHECKSUM",
+          "url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/BTCUSDT/BTCUSDT-fundingRate-2025-08.zip"
+        },
+        {
+          "checksum_sha256": "21dc6570fc6bffad0e7b5f9e99211b82ad07c95ab4f18c3a2daa3b95ec98344c",
+          "checksum_url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/BTCUSDT/BTCUSDT-fundingRate-2025-09.zip.CHECKSUM",
+          "url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/BTCUSDT/BTCUSDT-fundingRate-2025-09.zip"
+        },
+        {
+          "checksum_sha256": "9ecdedab6344fc4cdb154763266b8e09627a71c3cc5574cf868158b541c259c2",
+          "checksum_url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/BTCUSDT/BTCUSDT-fundingRate-2025-10.zip.CHECKSUM",
+          "url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/BTCUSDT/BTCUSDT-fundingRate-2025-10.zip"
+        },
+        {
+          "checksum_sha256": "23735400405627d610123e3a43db3e98ae7addb93459cd670e65a7659a5f081b",
+          "checksum_url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/BTCUSDT/BTCUSDT-fundingRate-2025-11.zip.CHECKSUM",
+          "url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/BTCUSDT/BTCUSDT-fundingRate-2025-11.zip"
+        },
+        {
+          "checksum_sha256": "35318b789f020b0e04c9043112480743855554e52e1d188437cbdaa67246d51d",
+          "checksum_url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/BTCUSDT/BTCUSDT-fundingRate-2025-12.zip.CHECKSUM",
+          "url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/BTCUSDT/BTCUSDT-fundingRate-2025-12.zip"
+        },
+        {
+          "checksum_sha256": "fcdc796484f395830d418588a34a26baed8849dbef0ff2b56173247e493ff51f",
+          "checksum_url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/BTCUSDT/BTCUSDT-fundingRate-2026-01.zip.CHECKSUM",
+          "url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/BTCUSDT/BTCUSDT-fundingRate-2026-01.zip"
+        },
+        {
+          "checksum_sha256": "80df1dd669dc1e3afc360c9da8b9a949a127fce088eedbf5bf708bd37b0a1f58",
+          "checksum_url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/BTCUSDT/BTCUSDT-fundingRate-2026-02.zip.CHECKSUM",
+          "url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/BTCUSDT/BTCUSDT-fundingRate-2026-02.zip"
+        },
+        {
+          "checksum_sha256": "5c069d5e9597a44fd0e213395082e59ff223fb99c9eab3a2a5a2a5622ba7867c",
+          "checksum_url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/BTCUSDT/BTCUSDT-fundingRate-2026-03.zip.CHECKSUM",
+          "url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/BTCUSDT/BTCUSDT-fundingRate-2026-03.zip"
+        },
+        {
+          "checksum_sha256": "51cdeb4de7d5ef1d4eece80b6115e391bdf7a2d0803bf9ad8371ab23340b22d3",
+          "checksum_url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/BTCUSDT/BTCUSDT-fundingRate-2026-04.zip.CHECKSUM",
+          "url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/BTCUSDT/BTCUSDT-fundingRate-2026-04.zip"
+        },
+        {
+          "checksum_sha256": "445b65fd6b17bfcfb5e4d035db29fad34f729fa078f0449024db42621be84e6e",
+          "checksum_url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/BTCUSDT/BTCUSDT-fundingRate-2026-05.zip.CHECKSUM",
+          "url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/BTCUSDT/BTCUSDT-fundingRate-2026-05.zip"
+        },
+        {
+          "checksum_sha256": "cff97ce688329592bccbbf5873b5c7021649e093f5f5806e332c5b4fb7fd6a00",
+          "checksum_url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/BTCUSDT/BTCUSDT-fundingRate-2026-06.zip.CHECKSUM",
+          "url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/BTCUSDT/BTCUSDT-fundingRate-2026-06.zip"
+        }
+      ],
+      "max_calc_time_ms": 1782835200005,
+      "min_calc_time_ms": 1751328000007,
+      "normalized_shard_sha256": "28ae74450e27e893f892bb956d31abe9327ec9f76870b2f41babdaaf8dbdf2b7",
+      "row_count": 1095,
+      "symbol": "BTCUSDT",
+      "transform_version": "rob941_corpus.v1"
+    },
+    {
+      "archives": [
+        {
+          "checksum_sha256": "039ff5c8dab9d9f2633f1bd4d191e6a727d6d169d897b6cbcd7fc162ff374723",
+          "checksum_url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/XRPUSDT/XRPUSDT-fundingRate-2025-07.zip.CHECKSUM",
+          "url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/XRPUSDT/XRPUSDT-fundingRate-2025-07.zip"
+        },
+        {
+          "checksum_sha256": "07a8182394836928094bb6b476fef9e8858e234d0ff05ef41114ff25bab923ba",
+          "checksum_url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/XRPUSDT/XRPUSDT-fundingRate-2025-08.zip.CHECKSUM",
+          "url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/XRPUSDT/XRPUSDT-fundingRate-2025-08.zip"
+        },
+        {
+          "checksum_sha256": "1f09cb45eadb64731acaaae997167c54b76c3a08b367cd5acbd89f8562593ee3",
+          "checksum_url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/XRPUSDT/XRPUSDT-fundingRate-2025-09.zip.CHECKSUM",
+          "url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/XRPUSDT/XRPUSDT-fundingRate-2025-09.zip"
+        },
+        {
+          "checksum_sha256": "3fc5b1bcac5579e6cc49e17457282c6bfb970932d2aefcbc0c896d660b81a939",
+          "checksum_url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/XRPUSDT/XRPUSDT-fundingRate-2025-10.zip.CHECKSUM",
+          "url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/XRPUSDT/XRPUSDT-fundingRate-2025-10.zip"
+        },
+        {
+          "checksum_sha256": "22040d49b1cdce5337571f5641008a81f1374680226b7c7a5ae63d37dcc449fd",
+          "checksum_url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/XRPUSDT/XRPUSDT-fundingRate-2025-11.zip.CHECKSUM",
+          "url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/XRPUSDT/XRPUSDT-fundingRate-2025-11.zip"
+        },
+        {
+          "checksum_sha256": "21c4a5933de28ec693fbe3a43d9ae4504b762e70e7cc0e0de4afd46104abe7f0",
+          "checksum_url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/XRPUSDT/XRPUSDT-fundingRate-2025-12.zip.CHECKSUM",
+          "url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/XRPUSDT/XRPUSDT-fundingRate-2025-12.zip"
+        },
+        {
+          "checksum_sha256": "618977f8e0c4d048292fae038094ea9624c96debfbb1d2bd6463ffcdce2fcd2a",
+          "checksum_url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/XRPUSDT/XRPUSDT-fundingRate-2026-01.zip.CHECKSUM",
+          "url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/XRPUSDT/XRPUSDT-fundingRate-2026-01.zip"
+        },
+        {
+          "checksum_sha256": "8d8be995b48b2085a8384d9e417bfeef2d213b35478baa88cbe5001d0497535d",
+          "checksum_url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/XRPUSDT/XRPUSDT-fundingRate-2026-02.zip.CHECKSUM",
+          "url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/XRPUSDT/XRPUSDT-fundingRate-2026-02.zip"
+        },
+        {
+          "checksum_sha256": "e3399c2e5fd5c18a2716b26530bcedc7fb9ce8adb2641c0882c8ba6e0a336567",
+          "checksum_url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/XRPUSDT/XRPUSDT-fundingRate-2026-03.zip.CHECKSUM",
+          "url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/XRPUSDT/XRPUSDT-fundingRate-2026-03.zip"
+        },
+        {
+          "checksum_sha256": "0e586915d578a977ad69482ddc52c11d9c2c1a767d3865078553b3e91fb7716a",
+          "checksum_url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/XRPUSDT/XRPUSDT-fundingRate-2026-04.zip.CHECKSUM",
+          "url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/XRPUSDT/XRPUSDT-fundingRate-2026-04.zip"
+        },
+        {
+          "checksum_sha256": "f8c0c09953b112a7f5ac203a826811ead1ac43db8c075b17b2ca69e837828255",
+          "checksum_url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/XRPUSDT/XRPUSDT-fundingRate-2026-05.zip.CHECKSUM",
+          "url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/XRPUSDT/XRPUSDT-fundingRate-2026-05.zip"
+        },
+        {
+          "checksum_sha256": "f5d1b51767ddc812c4608080adf54cfca0db7cba592d3e62d7416cd358a3ebde",
+          "checksum_url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/XRPUSDT/XRPUSDT-fundingRate-2026-06.zip.CHECKSUM",
+          "url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/XRPUSDT/XRPUSDT-fundingRate-2026-06.zip"
+        }
+      ],
+      "max_calc_time_ms": 1782835200005,
+      "min_calc_time_ms": 1751328000007,
+      "normalized_shard_sha256": "3fff8b16dd5ca113804b1daf45b2405bfbf490fdec199757184b7eff923c5d3e",
+      "row_count": 1095,
+      "symbol": "XRPUSDT",
+      "transform_version": "rob941_corpus.v1"
+    },
+    {
+      "archives": [
+        {
+          "checksum_sha256": "e56f1173899b2be5b35e14cdd61d6549dfed04bd2eacc1673285fbc067affe11",
+          "checksum_url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/DOGEUSDT/DOGEUSDT-fundingRate-2025-07.zip.CHECKSUM",
+          "url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/DOGEUSDT/DOGEUSDT-fundingRate-2025-07.zip"
+        },
+        {
+          "checksum_sha256": "c73e14c91a6e44f2a7a4795c845f54f0c82fac1529dd0852c66c52175d76ff53",
+          "checksum_url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/DOGEUSDT/DOGEUSDT-fundingRate-2025-08.zip.CHECKSUM",
+          "url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/DOGEUSDT/DOGEUSDT-fundingRate-2025-08.zip"
+        },
+        {
+          "checksum_sha256": "1105b391de748f50048b5590f6a5265fcb2a6354ec8a6ac3ba79b5ca734aa9cc",
+          "checksum_url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/DOGEUSDT/DOGEUSDT-fundingRate-2025-09.zip.CHECKSUM",
+          "url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/DOGEUSDT/DOGEUSDT-fundingRate-2025-09.zip"
+        },
+        {
+          "checksum_sha256": "6217d0bc8ab8abe35dd0c56d18cc008e8a8e36adef2be37ed9ccbf3c91c71d0a",
+          "checksum_url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/DOGEUSDT/DOGEUSDT-fundingRate-2025-10.zip.CHECKSUM",
+          "url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/DOGEUSDT/DOGEUSDT-fundingRate-2025-10.zip"
+        },
+        {
+          "checksum_sha256": "ea4b56653bb13210c5fbdeceb668f632b15a8fe6e7676d1afcbbcb5a019d92f4",
+          "checksum_url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/DOGEUSDT/DOGEUSDT-fundingRate-2025-11.zip.CHECKSUM",
+          "url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/DOGEUSDT/DOGEUSDT-fundingRate-2025-11.zip"
+        },
+        {
+          "checksum_sha256": "8e84dea86eb7fe0cb7b2f9278f0df0479b68ae10ac9b6ade872372888769f874",
+          "checksum_url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/DOGEUSDT/DOGEUSDT-fundingRate-2025-12.zip.CHECKSUM",
+          "url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/DOGEUSDT/DOGEUSDT-fundingRate-2025-12.zip"
+        },
+        {
+          "checksum_sha256": "73c2760e0bf4a5dd8af31d1f03ba1e6d213aa1ed42da17a8c537f28c7f033f44",
+          "checksum_url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/DOGEUSDT/DOGEUSDT-fundingRate-2026-01.zip.CHECKSUM",
+          "url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/DOGEUSDT/DOGEUSDT-fundingRate-2026-01.zip"
+        },
+        {
+          "checksum_sha256": "5a82031b9e3009265751cf02853ded1e1649bd3c2c3c764d5e50e64edc944a6e",
+          "checksum_url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/DOGEUSDT/DOGEUSDT-fundingRate-2026-02.zip.CHECKSUM",
+          "url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/DOGEUSDT/DOGEUSDT-fundingRate-2026-02.zip"
+        },
+        {
+          "checksum_sha256": "f4b2222b88d3cf518939c38a20fdd224629c3844a8d2f710c8c14e4fe9409d85",
+          "checksum_url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/DOGEUSDT/DOGEUSDT-fundingRate-2026-03.zip.CHECKSUM",
+          "url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/DOGEUSDT/DOGEUSDT-fundingRate-2026-03.zip"
+        },
+        {
+          "checksum_sha256": "1a041267001c6417220e595f9c723919eec3b2e317012a8cfd22f95ac8105ceb",
+          "checksum_url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/DOGEUSDT/DOGEUSDT-fundingRate-2026-04.zip.CHECKSUM",
+          "url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/DOGEUSDT/DOGEUSDT-fundingRate-2026-04.zip"
+        },
+        {
+          "checksum_sha256": "99411bbfdc7508a498204faf9ce3f02958f484828a5ffd309b6c267b89c89ba6",
+          "checksum_url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/DOGEUSDT/DOGEUSDT-fundingRate-2026-05.zip.CHECKSUM",
+          "url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/DOGEUSDT/DOGEUSDT-fundingRate-2026-05.zip"
+        },
+        {
+          "checksum_sha256": "b701956a49aa6e9daf692eccbe0c79be94dd3e0dbacde8996852f551a5fbfdba",
+          "checksum_url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/DOGEUSDT/DOGEUSDT-fundingRate-2026-06.zip.CHECKSUM",
+          "url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/DOGEUSDT/DOGEUSDT-fundingRate-2026-06.zip"
+        }
+      ],
+      "max_calc_time_ms": 1782835200005,
+      "min_calc_time_ms": 1751328000007,
+      "normalized_shard_sha256": "b1c2ae3cdecd84a87e0f7a428d2562f7f0837ed996dc1ac9a673c61b2e7f5d5c",
+      "row_count": 1095,
+      "symbol": "DOGEUSDT",
+      "transform_version": "rob941_corpus.v1"
+    },
+    {
+      "archives": [
+        {
+          "checksum_sha256": "66ce38d1a8bc4bdd53af29d8ea5c72493ed48fe9894ee5e9ff4600ccec864c4f",
+          "checksum_url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/SOLUSDT/SOLUSDT-fundingRate-2025-07.zip.CHECKSUM",
+          "url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/SOLUSDT/SOLUSDT-fundingRate-2025-07.zip"
+        },
+        {
+          "checksum_sha256": "fe9efc3abe1e4be2a2fa9a4008e6957856387f6783a06b97cac3ee271746915f",
+          "checksum_url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/SOLUSDT/SOLUSDT-fundingRate-2025-08.zip.CHECKSUM",
+          "url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/SOLUSDT/SOLUSDT-fundingRate-2025-08.zip"
+        },
+        {
+          "checksum_sha256": "f953315124d20dab98ba710d108103fb4cf054d1535787fd76d35d6b9c18e534",
+          "checksum_url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/SOLUSDT/SOLUSDT-fundingRate-2025-09.zip.CHECKSUM",
+          "url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/SOLUSDT/SOLUSDT-fundingRate-2025-09.zip"
+        },
+        {
+          "checksum_sha256": "d80c5be7660a950ad673a0e82488877c6ca0eb81f084d4c844320f892ad2c020",
+          "checksum_url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/SOLUSDT/SOLUSDT-fundingRate-2025-10.zip.CHECKSUM",
+          "url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/SOLUSDT/SOLUSDT-fundingRate-2025-10.zip"
+        },
+        {
+          "checksum_sha256": "5134fdf4319d629473f8cff1e66dc74180844ae2846ab41a8128466ab3682c2f",
+          "checksum_url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/SOLUSDT/SOLUSDT-fundingRate-2025-11.zip.CHECKSUM",
+          "url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/SOLUSDT/SOLUSDT-fundingRate-2025-11.zip"
+        },
+        {
+          "checksum_sha256": "01db13c460b0190736e1da019c7fcd7ea0abbf3b047e16d3aa8a9e9acec3101f",
+          "checksum_url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/SOLUSDT/SOLUSDT-fundingRate-2025-12.zip.CHECKSUM",
+          "url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/SOLUSDT/SOLUSDT-fundingRate-2025-12.zip"
+        },
+        {
+          "checksum_sha256": "c53be79aae38a1f35e94880f106df4eceab57bfa74a0b5fc5852fdfabf57ab8e",
+          "checksum_url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/SOLUSDT/SOLUSDT-fundingRate-2026-01.zip.CHECKSUM",
+          "url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/SOLUSDT/SOLUSDT-fundingRate-2026-01.zip"
+        },
+        {
+          "checksum_sha256": "84cb9bcf44ba1364b37db876e7c852aa1b831371556b610e2387115addec9d5f",
+          "checksum_url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/SOLUSDT/SOLUSDT-fundingRate-2026-02.zip.CHECKSUM",
+          "url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/SOLUSDT/SOLUSDT-fundingRate-2026-02.zip"
+        },
+        {
+          "checksum_sha256": "75cfaea075d97779a577c3744ea63e3d83704f281806fb5f76f2d3e0f089fd2c",
+          "checksum_url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/SOLUSDT/SOLUSDT-fundingRate-2026-03.zip.CHECKSUM",
+          "url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/SOLUSDT/SOLUSDT-fundingRate-2026-03.zip"
+        },
+        {
+          "checksum_sha256": "951a280e98b6d20fe4be25bf2b71f3cda1c07c7583a88cb874151e2b1fe941f1",
+          "checksum_url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/SOLUSDT/SOLUSDT-fundingRate-2026-04.zip.CHECKSUM",
+          "url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/SOLUSDT/SOLUSDT-fundingRate-2026-04.zip"
+        },
+        {
+          "checksum_sha256": "c13066e5f7c5d161dbebd488cbeaab1205688c6dc7f9fafcc8f94296f2c1e47b",
+          "checksum_url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/SOLUSDT/SOLUSDT-fundingRate-2026-05.zip.CHECKSUM",
+          "url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/SOLUSDT/SOLUSDT-fundingRate-2026-05.zip"
+        },
+        {
+          "checksum_sha256": "8d32fa3153d54c58667650e8b2c65e489b3a433b775052a93208bf60541a40d3",
+          "checksum_url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/SOLUSDT/SOLUSDT-fundingRate-2026-06.zip.CHECKSUM",
+          "url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/SOLUSDT/SOLUSDT-fundingRate-2026-06.zip"
+        }
+      ],
+      "max_calc_time_ms": 1782835200005,
+      "min_calc_time_ms": 1751328000007,
+      "normalized_shard_sha256": "c4fc7778955cdc7274722c85a11a214277936592dd1e14b3ca1cabaa1b1e4c1c",
+      "row_count": 1095,
+      "symbol": "SOLUSDT",
+      "transform_version": "rob941_corpus.v1"
+    }
+  ],
+  "klines": [
+    {
+      "archives": [
+        {
+          "checksum_sha256": "cf5fe0891c80e68d2d613eb5457100b7d886eee8cc913ccdd96ef45e757a5aaf",
+          "checksum_url": "https://data.binance.vision/data/futures/um/monthly/klines/BTCUSDT/1m/BTCUSDT-1m-2025-07.zip.CHECKSUM",
+          "url": "https://data.binance.vision/data/futures/um/monthly/klines/BTCUSDT/1m/BTCUSDT-1m-2025-07.zip"
+        },
+        {
+          "checksum_sha256": "eaf41354fc1aa96eac94ee50b3fda603cd595f95030ebf30b2ab5bea7a4462c3",
+          "checksum_url": "https://data.binance.vision/data/futures/um/monthly/klines/BTCUSDT/1m/BTCUSDT-1m-2025-08.zip.CHECKSUM",
+          "url": "https://data.binance.vision/data/futures/um/monthly/klines/BTCUSDT/1m/BTCUSDT-1m-2025-08.zip"
+        },
+        {
+          "checksum_sha256": "c296ba45c215934e9750ca82846c7b5d14be661649d8e4423eac834cf57330dc",
+          "checksum_url": "https://data.binance.vision/data/futures/um/monthly/klines/BTCUSDT/1m/BTCUSDT-1m-2025-09.zip.CHECKSUM",
+          "url": "https://data.binance.vision/data/futures/um/monthly/klines/BTCUSDT/1m/BTCUSDT-1m-2025-09.zip"
+        },
+        {
+          "checksum_sha256": "bb7f53350fe27b6d8e38b5856ffc43f9ecda9d568d5bf31d0db0cd011da7100f",
+          "checksum_url": "https://data.binance.vision/data/futures/um/monthly/klines/BTCUSDT/1m/BTCUSDT-1m-2025-10.zip.CHECKSUM",
+          "url": "https://data.binance.vision/data/futures/um/monthly/klines/BTCUSDT/1m/BTCUSDT-1m-2025-10.zip"
+        },
+        {
+          "checksum_sha256": "981da0b054f99b959fe6245fb363336b46908d358f37251d59bad308f375bc54",
+          "checksum_url": "https://data.binance.vision/data/futures/um/monthly/klines/BTCUSDT/1m/BTCUSDT-1m-2025-11.zip.CHECKSUM",
+          "url": "https://data.binance.vision/data/futures/um/monthly/klines/BTCUSDT/1m/BTCUSDT-1m-2025-11.zip"
+        },
+        {
+          "checksum_sha256": "2d5b2e1887dac1dfe450010877de7203a72e19df7a771067b980bbb07ad3069c",
+          "checksum_url": "https://data.binance.vision/data/futures/um/monthly/klines/BTCUSDT/1m/BTCUSDT-1m-2025-12.zip.CHECKSUM",
+          "url": "https://data.binance.vision/data/futures/um/monthly/klines/BTCUSDT/1m/BTCUSDT-1m-2025-12.zip"
+        },
+        {
+          "checksum_sha256": "58e9c620a6acda209d25766b3cf4262f3104649f5c26f247d933e0da8bb7946f",
+          "checksum_url": "https://data.binance.vision/data/futures/um/monthly/klines/BTCUSDT/1m/BTCUSDT-1m-2026-01.zip.CHECKSUM",
+          "url": "https://data.binance.vision/data/futures/um/monthly/klines/BTCUSDT/1m/BTCUSDT-1m-2026-01.zip"
+        },
+        {
+          "checksum_sha256": "805626ad2dc5b704d52c211996d12e9e4b1be234998f3dba4b3d34ff79be0337",
+          "checksum_url": "https://data.binance.vision/data/futures/um/monthly/klines/BTCUSDT/1m/BTCUSDT-1m-2026-02.zip.CHECKSUM",
+          "url": "https://data.binance.vision/data/futures/um/monthly/klines/BTCUSDT/1m/BTCUSDT-1m-2026-02.zip"
+        },
+        {
+          "checksum_sha256": "c472a865f230bf1b5b17e124770a83c083144e3e11a115733288fb8f3e3b8baa",
+          "checksum_url": "https://data.binance.vision/data/futures/um/monthly/klines/BTCUSDT/1m/BTCUSDT-1m-2026-03.zip.CHECKSUM",
+          "url": "https://data.binance.vision/data/futures/um/monthly/klines/BTCUSDT/1m/BTCUSDT-1m-2026-03.zip"
+        },
+        {
+          "checksum_sha256": "515b86570f0c6924f6dc2cf90589d3db90f3de9c6bfd9a22dde0429995dc5405",
+          "checksum_url": "https://data.binance.vision/data/futures/um/monthly/klines/BTCUSDT/1m/BTCUSDT-1m-2026-04.zip.CHECKSUM",
+          "url": "https://data.binance.vision/data/futures/um/monthly/klines/BTCUSDT/1m/BTCUSDT-1m-2026-04.zip"
+        },
+        {
+          "checksum_sha256": "d91548e94220d5211bb32447cc4b604ee266d145f2092edc5ec613328cbbc20a",
+          "checksum_url": "https://data.binance.vision/data/futures/um/monthly/klines/BTCUSDT/1m/BTCUSDT-1m-2026-05.zip.CHECKSUM",
+          "url": "https://data.binance.vision/data/futures/um/monthly/klines/BTCUSDT/1m/BTCUSDT-1m-2026-05.zip"
+        },
+        {
+          "checksum_sha256": "9b214199eb5063585c7ed0f59ba19323326d68ac024b85106713989399204490",
+          "checksum_url": "https://data.binance.vision/data/futures/um/monthly/klines/BTCUSDT/1m/BTCUSDT-1m-2026-06.zip.CHECKSUM",
+          "url": "https://data.binance.vision/data/futures/um/monthly/klines/BTCUSDT/1m/BTCUSDT-1m-2026-06.zip"
+        }
+      ],
+      "gap_ranges": [],
+      "interval": "1m",
+      "max_open_time_ms": 1782863940000,
+      "min_open_time_ms": 1751328000000,
+      "normalized_shard_sha256": "8f43af68dbf401b0c3a2a800c3dd0d0675a78458d179bcd93964d634c2d90939",
+      "row_count": 525600,
+      "symbol": "BTCUSDT",
+      "transform_version": "rob941_corpus.v1"
+    },
+    {
+      "archives": [
+        {
+          "checksum_sha256": "6f5f7faa96370dacb4792b18ce628d3ff8b0a5fa4cd10063e55065e03ff9f53d",
+          "checksum_url": "https://data.binance.vision/data/futures/um/monthly/klines/XRPUSDT/1m/XRPUSDT-1m-2025-07.zip.CHECKSUM",
+          "url": "https://data.binance.vision/data/futures/um/monthly/klines/XRPUSDT/1m/XRPUSDT-1m-2025-07.zip"
+        },
+        {
+          "checksum_sha256": "823e87bba1c53bebffd8074ee190adfae55c489936ff5d539fcdf54e1ea68633",
+          "checksum_url": "https://data.binance.vision/data/futures/um/monthly/klines/XRPUSDT/1m/XRPUSDT-1m-2025-08.zip.CHECKSUM",
+          "url": "https://data.binance.vision/data/futures/um/monthly/klines/XRPUSDT/1m/XRPUSDT-1m-2025-08.zip"
+        },
+        {
+          "checksum_sha256": "0f47e24c9e133c09d0df6756e224c2547d5e1ca3c9ba7af77232d1e9368330fb",
+          "checksum_url": "https://data.binance.vision/data/futures/um/monthly/klines/XRPUSDT/1m/XRPUSDT-1m-2025-09.zip.CHECKSUM",
+          "url": "https://data.binance.vision/data/futures/um/monthly/klines/XRPUSDT/1m/XRPUSDT-1m-2025-09.zip"
+        },
+        {
+          "checksum_sha256": "9ba37c1fb1bded7e554dbfc9221c126cdb8bf4c569b4b5c639e83bcda38b6b3e",
+          "checksum_url": "https://data.binance.vision/data/futures/um/monthly/klines/XRPUSDT/1m/XRPUSDT-1m-2025-10.zip.CHECKSUM",
+          "url": "https://data.binance.vision/data/futures/um/monthly/klines/XRPUSDT/1m/XRPUSDT-1m-2025-10.zip"
+        },
+        {
+          "checksum_sha256": "dd62352ab1fc3b2e8f5f235c7c775044432a493c8a5ab732f709acfe1c8f62bc",
+          "checksum_url": "https://data.binance.vision/data/futures/um/monthly/klines/XRPUSDT/1m/XRPUSDT-1m-2025-11.zip.CHECKSUM",
+          "url": "https://data.binance.vision/data/futures/um/monthly/klines/XRPUSDT/1m/XRPUSDT-1m-2025-11.zip"
+        },
+        {
+          "checksum_sha256": "821efe300f5a66a68fe468e45fe9094431fac70b62a909c4aa7cc97239c4ce4c",
+          "checksum_url": "https://data.binance.vision/data/futures/um/monthly/klines/XRPUSDT/1m/XRPUSDT-1m-2025-12.zip.CHECKSUM",
+          "url": "https://data.binance.vision/data/futures/um/monthly/klines/XRPUSDT/1m/XRPUSDT-1m-2025-12.zip"
+        },
+        {
+          "checksum_sha256": "8612f9c3796982d55feb1696d4a08407e4910d40cfce25e71b0172dea32b9847",
+          "checksum_url": "https://data.binance.vision/data/futures/um/monthly/klines/XRPUSDT/1m/XRPUSDT-1m-2026-01.zip.CHECKSUM",
+          "url": "https://data.binance.vision/data/futures/um/monthly/klines/XRPUSDT/1m/XRPUSDT-1m-2026-01.zip"
+        },
+        {
+          "checksum_sha256": "58bff9b0136a1584414b6d24133279c02a56030da7625942c286e9d11f3d37a3",
+          "checksum_url": "https://data.binance.vision/data/futures/um/monthly/klines/XRPUSDT/1m/XRPUSDT-1m-2026-02.zip.CHECKSUM",
+          "url": "https://data.binance.vision/data/futures/um/monthly/klines/XRPUSDT/1m/XRPUSDT-1m-2026-02.zip"
+        },
+        {
+          "checksum_sha256": "38b4f4f23cd92c23b37c2fea4e827540af06c8a0e2330bff8491acaf3d14e794",
+          "checksum_url": "https://data.binance.vision/data/futures/um/monthly/klines/XRPUSDT/1m/XRPUSDT-1m-2026-03.zip.CHECKSUM",
+          "url": "https://data.binance.vision/data/futures/um/monthly/klines/XRPUSDT/1m/XRPUSDT-1m-2026-03.zip"
+        },
+        {
+          "checksum_sha256": "e887d411a37786bfd83d3fcbe7561801529d3c9e012d90b420c628226253d63a",
+          "checksum_url": "https://data.binance.vision/data/futures/um/monthly/klines/XRPUSDT/1m/XRPUSDT-1m-2026-04.zip.CHECKSUM",
+          "url": "https://data.binance.vision/data/futures/um/monthly/klines/XRPUSDT/1m/XRPUSDT-1m-2026-04.zip"
+        },
+        {
+          "checksum_sha256": "6733b41f25b4a278a67ae6002e5f20c089a61ae864d99c9d1b002e375c932f9b",
+          "checksum_url": "https://data.binance.vision/data/futures/um/monthly/klines/XRPUSDT/1m/XRPUSDT-1m-2026-05.zip.CHECKSUM",
+          "url": "https://data.binance.vision/data/futures/um/monthly/klines/XRPUSDT/1m/XRPUSDT-1m-2026-05.zip"
+        },
+        {
+          "checksum_sha256": "b49faed75492e1136f2dc3f8cad1328e55c3179368ba80b85e1f961d536a8a47",
+          "checksum_url": "https://data.binance.vision/data/futures/um/monthly/klines/XRPUSDT/1m/XRPUSDT-1m-2026-06.zip.CHECKSUM",
+          "url": "https://data.binance.vision/data/futures/um/monthly/klines/XRPUSDT/1m/XRPUSDT-1m-2026-06.zip"
+        }
+      ],
+      "gap_ranges": [],
+      "interval": "1m",
+      "max_open_time_ms": 1782863940000,
+      "min_open_time_ms": 1751328000000,
+      "normalized_shard_sha256": "72139b566eaf9ca97bba792a3458b05c1cfe028e1309a0d8517b2fac88fdc630",
+      "row_count": 525600,
+      "symbol": "XRPUSDT",
+      "transform_version": "rob941_corpus.v1"
+    },
+    {
+      "archives": [
+        {
+          "checksum_sha256": "6c6858a61ec39254b54a40fd864bef0cacd99a3a244bb9b0e5cec0acbe6eb631",
+          "checksum_url": "https://data.binance.vision/data/futures/um/monthly/klines/DOGEUSDT/1m/DOGEUSDT-1m-2025-07.zip.CHECKSUM",
+          "url": "https://data.binance.vision/data/futures/um/monthly/klines/DOGEUSDT/1m/DOGEUSDT-1m-2025-07.zip"
+        },
+        {
+          "checksum_sha256": "1a69ffc39419bb27c12e019de4809e086e40bf620e40e8a044762ba62095026e",
+          "checksum_url": "https://data.binance.vision/data/futures/um/monthly/klines/DOGEUSDT/1m/DOGEUSDT-1m-2025-08.zip.CHECKSUM",
+          "url": "https://data.binance.vision/data/futures/um/monthly/klines/DOGEUSDT/1m/DOGEUSDT-1m-2025-08.zip"
+        },
+        {
+          "checksum_sha256": "34dac0a3873c158dd3e6126719e0e931ee305f6a1ce56e1a68c5c05b00284b3d",
+          "checksum_url": "https://data.binance.vision/data/futures/um/monthly/klines/DOGEUSDT/1m/DOGEUSDT-1m-2025-09.zip.CHECKSUM",
+          "url": "https://data.binance.vision/data/futures/um/monthly/klines/DOGEUSDT/1m/DOGEUSDT-1m-2025-09.zip"
+        },
+        {
+          "checksum_sha256": "c2e2ef77ee80bd0d0fef438a5f24dc2f4765de6e3ef0ab36797d1bfb20731bd5",
+          "checksum_url": "https://data.binance.vision/data/futures/um/monthly/klines/DOGEUSDT/1m/DOGEUSDT-1m-2025-10.zip.CHECKSUM",
+          "url": "https://data.binance.vision/data/futures/um/monthly/klines/DOGEUSDT/1m/DOGEUSDT-1m-2025-10.zip"
+        },
+        {
+          "checksum_sha256": "613eba1df328da3b171bd0fe975e2dd1047e0ac535c49a71aad0649ba3da4d6c",
+          "checksum_url": "https://data.binance.vision/data/futures/um/monthly/klines/DOGEUSDT/1m/DOGEUSDT-1m-2025-11.zip.CHECKSUM",
+          "url": "https://data.binance.vision/data/futures/um/monthly/klines/DOGEUSDT/1m/DOGEUSDT-1m-2025-11.zip"
+        },
+        {
+          "checksum_sha256": "c7d230dcded82fe00f47546094318bb67b7477fe202aac48075237f30cda8840",
+          "checksum_url": "https://data.binance.vision/data/futures/um/monthly/klines/DOGEUSDT/1m/DOGEUSDT-1m-2025-12.zip.CHECKSUM",
+          "url": "https://data.binance.vision/data/futures/um/monthly/klines/DOGEUSDT/1m/DOGEUSDT-1m-2025-12.zip"
+        },
+        {
+          "checksum_sha256": "b1461ec0ea96fe535e72780b698471907136df72c97a360628c6b65ae6dd5cae",
+          "checksum_url": "https://data.binance.vision/data/futures/um/monthly/klines/DOGEUSDT/1m/DOGEUSDT-1m-2026-01.zip.CHECKSUM",
+          "url": "https://data.binance.vision/data/futures/um/monthly/klines/DOGEUSDT/1m/DOGEUSDT-1m-2026-01.zip"
+        },
+        {
+          "checksum_sha256": "2fa5c67037194c73e823abb111331334e07e5d4f0eaa6704fd879983971e8755",
+          "checksum_url": "https://data.binance.vision/data/futures/um/monthly/klines/DOGEUSDT/1m/DOGEUSDT-1m-2026-02.zip.CHECKSUM",
+          "url": "https://data.binance.vision/data/futures/um/monthly/klines/DOGEUSDT/1m/DOGEUSDT-1m-2026-02.zip"
+        },
+        {
+          "checksum_sha256": "ba4758aaa2fb1bd5be4f120d21cf5c94d7e315d38918080ee880b36dc60b7841",
+          "checksum_url": "https://data.binance.vision/data/futures/um/monthly/klines/DOGEUSDT/1m/DOGEUSDT-1m-2026-03.zip.CHECKSUM",
+          "url": "https://data.binance.vision/data/futures/um/monthly/klines/DOGEUSDT/1m/DOGEUSDT-1m-2026-03.zip"
+        },
+        {
+          "checksum_sha256": "31a8edfd1f029e3ee08d7824b6352e898828cc8d3e2c71b7cd02b3c9b2637bf5",
+          "checksum_url": "https://data.binance.vision/data/futures/um/monthly/klines/DOGEUSDT/1m/DOGEUSDT-1m-2026-04.zip.CHECKSUM",
+          "url": "https://data.binance.vision/data/futures/um/monthly/klines/DOGEUSDT/1m/DOGEUSDT-1m-2026-04.zip"
+        },
+        {
+          "checksum_sha256": "109a1d0020c4710c1aa86b8773795b21326d038d795b224e1758bf9091c4e110",
+          "checksum_url": "https://data.binance.vision/data/futures/um/monthly/klines/DOGEUSDT/1m/DOGEUSDT-1m-2026-05.zip.CHECKSUM",
+          "url": "https://data.binance.vision/data/futures/um/monthly/klines/DOGEUSDT/1m/DOGEUSDT-1m-2026-05.zip"
+        },
+        {
+          "checksum_sha256": "90b1a9a55146505876a5b0469b69e8606194b018beec06094be8b4babd37c8b4",
+          "checksum_url": "https://data.binance.vision/data/futures/um/monthly/klines/DOGEUSDT/1m/DOGEUSDT-1m-2026-06.zip.CHECKSUM",
+          "url": "https://data.binance.vision/data/futures/um/monthly/klines/DOGEUSDT/1m/DOGEUSDT-1m-2026-06.zip"
+        }
+      ],
+      "gap_ranges": [],
+      "interval": "1m",
+      "max_open_time_ms": 1782863940000,
+      "min_open_time_ms": 1751328000000,
+      "normalized_shard_sha256": "26bed8cc351e40c35eda1636eef518fae613cc16713a0d3a206f08e95288c5c4",
+      "row_count": 525600,
+      "symbol": "DOGEUSDT",
+      "transform_version": "rob941_corpus.v1"
+    },
+    {
+      "archives": [
+        {
+          "checksum_sha256": "6a11ec2b081657fd4850b61cb1f28e2217913ac1a309c484169f080733320ee7",
+          "checksum_url": "https://data.binance.vision/data/futures/um/monthly/klines/SOLUSDT/1m/SOLUSDT-1m-2025-07.zip.CHECKSUM",
+          "url": "https://data.binance.vision/data/futures/um/monthly/klines/SOLUSDT/1m/SOLUSDT-1m-2025-07.zip"
+        },
+        {
+          "checksum_sha256": "9916be68e1e354b1d2ad30e09ca2f0552ddbf9a3ad64d2854bd54016463b56a6",
+          "checksum_url": "https://data.binance.vision/data/futures/um/monthly/klines/SOLUSDT/1m/SOLUSDT-1m-2025-08.zip.CHECKSUM",
+          "url": "https://data.binance.vision/data/futures/um/monthly/klines/SOLUSDT/1m/SOLUSDT-1m-2025-08.zip"
+        },
+        {
+          "checksum_sha256": "389290c0c468d168ea3b327d926e273aa9de639249e5101f443360eda4456b4e",
+          "checksum_url": "https://data.binance.vision/data/futures/um/monthly/klines/SOLUSDT/1m/SOLUSDT-1m-2025-09.zip.CHECKSUM",
+          "url": "https://data.binance.vision/data/futures/um/monthly/klines/SOLUSDT/1m/SOLUSDT-1m-2025-09.zip"
+        },
+        {
+          "checksum_sha256": "66542f68d37e6b8b071997ea07fa495abc01d3762acbf6476398c63f79128016",
+          "checksum_url": "https://data.binance.vision/data/futures/um/monthly/klines/SOLUSDT/1m/SOLUSDT-1m-2025-10.zip.CHECKSUM",
+          "url": "https://data.binance.vision/data/futures/um/monthly/klines/SOLUSDT/1m/SOLUSDT-1m-2025-10.zip"
+        },
+        {
+          "checksum_sha256": "dbadf06d740261c21299abc82f3adeae1b41e4dbbcee8a5adca3e761f1896ce7",
+          "checksum_url": "https://data.binance.vision/data/futures/um/monthly/klines/SOLUSDT/1m/SOLUSDT-1m-2025-11.zip.CHECKSUM",
+          "url": "https://data.binance.vision/data/futures/um/monthly/klines/SOLUSDT/1m/SOLUSDT-1m-2025-11.zip"
+        },
+        {
+          "checksum_sha256": "c9375b066069aaa4dbf33fbf7c79ca9db4a534b99d4ebd9f558ba2381e610636",
+          "checksum_url": "https://data.binance.vision/data/futures/um/monthly/klines/SOLUSDT/1m/SOLUSDT-1m-2025-12.zip.CHECKSUM",
+          "url": "https://data.binance.vision/data/futures/um/monthly/klines/SOLUSDT/1m/SOLUSDT-1m-2025-12.zip"
+        },
+        {
+          "checksum_sha256": "ac9cc536ec056e7c4fc4f391da5edbe778f59fb2a059670875d05285ebca3fcf",
+          "checksum_url": "https://data.binance.vision/data/futures/um/monthly/klines/SOLUSDT/1m/SOLUSDT-1m-2026-01.zip.CHECKSUM",
+          "url": "https://data.binance.vision/data/futures/um/monthly/klines/SOLUSDT/1m/SOLUSDT-1m-2026-01.zip"
+        },
+        {
+          "checksum_sha256": "ad93c921265eb4a473ba91d21f8d02346d77330475740977cc7541a0ac1ec05a",
+          "checksum_url": "https://data.binance.vision/data/futures/um/monthly/klines/SOLUSDT/1m/SOLUSDT-1m-2026-02.zip.CHECKSUM",
+          "url": "https://data.binance.vision/data/futures/um/monthly/klines/SOLUSDT/1m/SOLUSDT-1m-2026-02.zip"
+        },
+        {
+          "checksum_sha256": "d705ca5ec2de775733be12c6e3f29bcf3204be15d7b0b273ec87a013fcaa612f",
+          "checksum_url": "https://data.binance.vision/data/futures/um/monthly/klines/SOLUSDT/1m/SOLUSDT-1m-2026-03.zip.CHECKSUM",
+          "url": "https://data.binance.vision/data/futures/um/monthly/klines/SOLUSDT/1m/SOLUSDT-1m-2026-03.zip"
+        },
+        {
+          "checksum_sha256": "8ce6bb0ea598eecdfa2078cc1429c7fc4fc39a32d306d74184f137fa6ae8d3cb",
+          "checksum_url": "https://data.binance.vision/data/futures/um/monthly/klines/SOLUSDT/1m/SOLUSDT-1m-2026-04.zip.CHECKSUM",
+          "url": "https://data.binance.vision/data/futures/um/monthly/klines/SOLUSDT/1m/SOLUSDT-1m-2026-04.zip"
+        },
+        {
+          "checksum_sha256": "588bdc611885c6de2bd55df7f8fbc597147ca0eef33f6824e340d2bff1a04066",
+          "checksum_url": "https://data.binance.vision/data/futures/um/monthly/klines/SOLUSDT/1m/SOLUSDT-1m-2026-05.zip.CHECKSUM",
+          "url": "https://data.binance.vision/data/futures/um/monthly/klines/SOLUSDT/1m/SOLUSDT-1m-2026-05.zip"
+        },
+        {
+          "checksum_sha256": "dcd12574ab820047a10c3e6977b69251b7285fe7998fa7aff6d73470c6637ecd",
+          "checksum_url": "https://data.binance.vision/data/futures/um/monthly/klines/SOLUSDT/1m/SOLUSDT-1m-2026-06.zip.CHECKSUM",
+          "url": "https://data.binance.vision/data/futures/um/monthly/klines/SOLUSDT/1m/SOLUSDT-1m-2026-06.zip"
+        }
+      ],
+      "gap_ranges": [],
+      "interval": "1m",
+      "max_open_time_ms": 1782863940000,
+      "min_open_time_ms": 1751328000000,
+      "normalized_shard_sha256": "0dbad131fcfbf7aa3b02f685d2099a9ccd060b38b8c69edd271520eec6b0c2f9",
+      "row_count": 525600,
+      "symbol": "SOLUSDT",
+      "transform_version": "rob941_corpus.v1"
+    }
+  ],
+  "universe": [
+    "BTCUSDT",
+    "XRPUSDT",
+    "DOGEUSDT",
+    "SOLUSDT"
+  ],
+  "window_end_iso": "2026-07-01T00:00:00Z",
+  "window_start_iso": "2025-07-01T00:00:00Z"
+}

--- a/research/nautilus_scalping/data_manifests/rob941_corpus_manifest.v1.json
+++ b/research/nautilus_scalping/data_manifests/rob941_corpus_manifest.v1.json
@@ -31,61 +31,73 @@
         {
           "checksum_sha256": "b097dff828f6e43fece23db0d3cb98042a9d7bc19693b8cbfd051d88eb973b7b",
           "checksum_url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/BTCUSDT/BTCUSDT-fundingRate-2025-07.zip.CHECKSUM",
+          "local_path": "raw/fundingRate/BTCUSDT/BTCUSDT-fundingRate-2025-07.b097dff828f6e43fece23db0d3cb98042a9d7bc19693b8cbfd051d88eb973b7b.zip",
           "url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/BTCUSDT/BTCUSDT-fundingRate-2025-07.zip"
         },
         {
           "checksum_sha256": "1180129860b6e196e8d70bb9719e81573aa6b4acb423ba5ee7f82f10c836f7ab",
           "checksum_url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/BTCUSDT/BTCUSDT-fundingRate-2025-08.zip.CHECKSUM",
+          "local_path": "raw/fundingRate/BTCUSDT/BTCUSDT-fundingRate-2025-08.1180129860b6e196e8d70bb9719e81573aa6b4acb423ba5ee7f82f10c836f7ab.zip",
           "url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/BTCUSDT/BTCUSDT-fundingRate-2025-08.zip"
         },
         {
           "checksum_sha256": "21dc6570fc6bffad0e7b5f9e99211b82ad07c95ab4f18c3a2daa3b95ec98344c",
           "checksum_url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/BTCUSDT/BTCUSDT-fundingRate-2025-09.zip.CHECKSUM",
+          "local_path": "raw/fundingRate/BTCUSDT/BTCUSDT-fundingRate-2025-09.21dc6570fc6bffad0e7b5f9e99211b82ad07c95ab4f18c3a2daa3b95ec98344c.zip",
           "url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/BTCUSDT/BTCUSDT-fundingRate-2025-09.zip"
         },
         {
           "checksum_sha256": "9ecdedab6344fc4cdb154763266b8e09627a71c3cc5574cf868158b541c259c2",
           "checksum_url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/BTCUSDT/BTCUSDT-fundingRate-2025-10.zip.CHECKSUM",
+          "local_path": "raw/fundingRate/BTCUSDT/BTCUSDT-fundingRate-2025-10.9ecdedab6344fc4cdb154763266b8e09627a71c3cc5574cf868158b541c259c2.zip",
           "url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/BTCUSDT/BTCUSDT-fundingRate-2025-10.zip"
         },
         {
           "checksum_sha256": "23735400405627d610123e3a43db3e98ae7addb93459cd670e65a7659a5f081b",
           "checksum_url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/BTCUSDT/BTCUSDT-fundingRate-2025-11.zip.CHECKSUM",
+          "local_path": "raw/fundingRate/BTCUSDT/BTCUSDT-fundingRate-2025-11.23735400405627d610123e3a43db3e98ae7addb93459cd670e65a7659a5f081b.zip",
           "url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/BTCUSDT/BTCUSDT-fundingRate-2025-11.zip"
         },
         {
           "checksum_sha256": "35318b789f020b0e04c9043112480743855554e52e1d188437cbdaa67246d51d",
           "checksum_url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/BTCUSDT/BTCUSDT-fundingRate-2025-12.zip.CHECKSUM",
+          "local_path": "raw/fundingRate/BTCUSDT/BTCUSDT-fundingRate-2025-12.35318b789f020b0e04c9043112480743855554e52e1d188437cbdaa67246d51d.zip",
           "url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/BTCUSDT/BTCUSDT-fundingRate-2025-12.zip"
         },
         {
           "checksum_sha256": "fcdc796484f395830d418588a34a26baed8849dbef0ff2b56173247e493ff51f",
           "checksum_url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/BTCUSDT/BTCUSDT-fundingRate-2026-01.zip.CHECKSUM",
+          "local_path": "raw/fundingRate/BTCUSDT/BTCUSDT-fundingRate-2026-01.fcdc796484f395830d418588a34a26baed8849dbef0ff2b56173247e493ff51f.zip",
           "url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/BTCUSDT/BTCUSDT-fundingRate-2026-01.zip"
         },
         {
           "checksum_sha256": "80df1dd669dc1e3afc360c9da8b9a949a127fce088eedbf5bf708bd37b0a1f58",
           "checksum_url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/BTCUSDT/BTCUSDT-fundingRate-2026-02.zip.CHECKSUM",
+          "local_path": "raw/fundingRate/BTCUSDT/BTCUSDT-fundingRate-2026-02.80df1dd669dc1e3afc360c9da8b9a949a127fce088eedbf5bf708bd37b0a1f58.zip",
           "url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/BTCUSDT/BTCUSDT-fundingRate-2026-02.zip"
         },
         {
           "checksum_sha256": "5c069d5e9597a44fd0e213395082e59ff223fb99c9eab3a2a5a2a5622ba7867c",
           "checksum_url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/BTCUSDT/BTCUSDT-fundingRate-2026-03.zip.CHECKSUM",
+          "local_path": "raw/fundingRate/BTCUSDT/BTCUSDT-fundingRate-2026-03.5c069d5e9597a44fd0e213395082e59ff223fb99c9eab3a2a5a2a5622ba7867c.zip",
           "url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/BTCUSDT/BTCUSDT-fundingRate-2026-03.zip"
         },
         {
           "checksum_sha256": "51cdeb4de7d5ef1d4eece80b6115e391bdf7a2d0803bf9ad8371ab23340b22d3",
           "checksum_url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/BTCUSDT/BTCUSDT-fundingRate-2026-04.zip.CHECKSUM",
+          "local_path": "raw/fundingRate/BTCUSDT/BTCUSDT-fundingRate-2026-04.51cdeb4de7d5ef1d4eece80b6115e391bdf7a2d0803bf9ad8371ab23340b22d3.zip",
           "url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/BTCUSDT/BTCUSDT-fundingRate-2026-04.zip"
         },
         {
           "checksum_sha256": "445b65fd6b17bfcfb5e4d035db29fad34f729fa078f0449024db42621be84e6e",
           "checksum_url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/BTCUSDT/BTCUSDT-fundingRate-2026-05.zip.CHECKSUM",
+          "local_path": "raw/fundingRate/BTCUSDT/BTCUSDT-fundingRate-2026-05.445b65fd6b17bfcfb5e4d035db29fad34f729fa078f0449024db42621be84e6e.zip",
           "url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/BTCUSDT/BTCUSDT-fundingRate-2026-05.zip"
         },
         {
           "checksum_sha256": "cff97ce688329592bccbbf5873b5c7021649e093f5f5806e332c5b4fb7fd6a00",
           "checksum_url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/BTCUSDT/BTCUSDT-fundingRate-2026-06.zip.CHECKSUM",
+          "local_path": "raw/fundingRate/BTCUSDT/BTCUSDT-fundingRate-2026-06.cff97ce688329592bccbbf5873b5c7021649e093f5f5806e332c5b4fb7fd6a00.zip",
           "url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/BTCUSDT/BTCUSDT-fundingRate-2026-06.zip"
         }
       ],
@@ -93,69 +105,83 @@
       "min_calc_time_ms": 1751328000007,
       "normalized_shard_sha256": "28ae74450e27e893f892bb956d31abe9327ec9f76870b2f41babdaaf8dbdf2b7",
       "row_count": 1095,
+      "shard_file_sha256": "2b87d97e34e817ded5be602857f5cd2e937c90f308151d218fb5a898e9c2ccc4",
+      "shard_path": "shards/funding/BTCUSDT-fundingRate.28ae74450e27e893f892bb956d31abe9327ec9f76870b2f41babdaaf8dbdf2b7.parquet",
       "symbol": "BTCUSDT",
-      "transform_version": "rob941_corpus.v1"
+      "transform_version": "rob941_corpus.v2"
     },
     {
       "archives": [
         {
           "checksum_sha256": "039ff5c8dab9d9f2633f1bd4d191e6a727d6d169d897b6cbcd7fc162ff374723",
           "checksum_url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/XRPUSDT/XRPUSDT-fundingRate-2025-07.zip.CHECKSUM",
+          "local_path": "raw/fundingRate/XRPUSDT/XRPUSDT-fundingRate-2025-07.039ff5c8dab9d9f2633f1bd4d191e6a727d6d169d897b6cbcd7fc162ff374723.zip",
           "url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/XRPUSDT/XRPUSDT-fundingRate-2025-07.zip"
         },
         {
           "checksum_sha256": "07a8182394836928094bb6b476fef9e8858e234d0ff05ef41114ff25bab923ba",
           "checksum_url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/XRPUSDT/XRPUSDT-fundingRate-2025-08.zip.CHECKSUM",
+          "local_path": "raw/fundingRate/XRPUSDT/XRPUSDT-fundingRate-2025-08.07a8182394836928094bb6b476fef9e8858e234d0ff05ef41114ff25bab923ba.zip",
           "url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/XRPUSDT/XRPUSDT-fundingRate-2025-08.zip"
         },
         {
           "checksum_sha256": "1f09cb45eadb64731acaaae997167c54b76c3a08b367cd5acbd89f8562593ee3",
           "checksum_url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/XRPUSDT/XRPUSDT-fundingRate-2025-09.zip.CHECKSUM",
+          "local_path": "raw/fundingRate/XRPUSDT/XRPUSDT-fundingRate-2025-09.1f09cb45eadb64731acaaae997167c54b76c3a08b367cd5acbd89f8562593ee3.zip",
           "url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/XRPUSDT/XRPUSDT-fundingRate-2025-09.zip"
         },
         {
           "checksum_sha256": "3fc5b1bcac5579e6cc49e17457282c6bfb970932d2aefcbc0c896d660b81a939",
           "checksum_url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/XRPUSDT/XRPUSDT-fundingRate-2025-10.zip.CHECKSUM",
+          "local_path": "raw/fundingRate/XRPUSDT/XRPUSDT-fundingRate-2025-10.3fc5b1bcac5579e6cc49e17457282c6bfb970932d2aefcbc0c896d660b81a939.zip",
           "url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/XRPUSDT/XRPUSDT-fundingRate-2025-10.zip"
         },
         {
           "checksum_sha256": "22040d49b1cdce5337571f5641008a81f1374680226b7c7a5ae63d37dcc449fd",
           "checksum_url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/XRPUSDT/XRPUSDT-fundingRate-2025-11.zip.CHECKSUM",
+          "local_path": "raw/fundingRate/XRPUSDT/XRPUSDT-fundingRate-2025-11.22040d49b1cdce5337571f5641008a81f1374680226b7c7a5ae63d37dcc449fd.zip",
           "url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/XRPUSDT/XRPUSDT-fundingRate-2025-11.zip"
         },
         {
           "checksum_sha256": "21c4a5933de28ec693fbe3a43d9ae4504b762e70e7cc0e0de4afd46104abe7f0",
           "checksum_url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/XRPUSDT/XRPUSDT-fundingRate-2025-12.zip.CHECKSUM",
+          "local_path": "raw/fundingRate/XRPUSDT/XRPUSDT-fundingRate-2025-12.21c4a5933de28ec693fbe3a43d9ae4504b762e70e7cc0e0de4afd46104abe7f0.zip",
           "url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/XRPUSDT/XRPUSDT-fundingRate-2025-12.zip"
         },
         {
           "checksum_sha256": "618977f8e0c4d048292fae038094ea9624c96debfbb1d2bd6463ffcdce2fcd2a",
           "checksum_url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/XRPUSDT/XRPUSDT-fundingRate-2026-01.zip.CHECKSUM",
+          "local_path": "raw/fundingRate/XRPUSDT/XRPUSDT-fundingRate-2026-01.618977f8e0c4d048292fae038094ea9624c96debfbb1d2bd6463ffcdce2fcd2a.zip",
           "url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/XRPUSDT/XRPUSDT-fundingRate-2026-01.zip"
         },
         {
           "checksum_sha256": "8d8be995b48b2085a8384d9e417bfeef2d213b35478baa88cbe5001d0497535d",
           "checksum_url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/XRPUSDT/XRPUSDT-fundingRate-2026-02.zip.CHECKSUM",
+          "local_path": "raw/fundingRate/XRPUSDT/XRPUSDT-fundingRate-2026-02.8d8be995b48b2085a8384d9e417bfeef2d213b35478baa88cbe5001d0497535d.zip",
           "url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/XRPUSDT/XRPUSDT-fundingRate-2026-02.zip"
         },
         {
           "checksum_sha256": "e3399c2e5fd5c18a2716b26530bcedc7fb9ce8adb2641c0882c8ba6e0a336567",
           "checksum_url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/XRPUSDT/XRPUSDT-fundingRate-2026-03.zip.CHECKSUM",
+          "local_path": "raw/fundingRate/XRPUSDT/XRPUSDT-fundingRate-2026-03.e3399c2e5fd5c18a2716b26530bcedc7fb9ce8adb2641c0882c8ba6e0a336567.zip",
           "url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/XRPUSDT/XRPUSDT-fundingRate-2026-03.zip"
         },
         {
           "checksum_sha256": "0e586915d578a977ad69482ddc52c11d9c2c1a767d3865078553b3e91fb7716a",
           "checksum_url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/XRPUSDT/XRPUSDT-fundingRate-2026-04.zip.CHECKSUM",
+          "local_path": "raw/fundingRate/XRPUSDT/XRPUSDT-fundingRate-2026-04.0e586915d578a977ad69482ddc52c11d9c2c1a767d3865078553b3e91fb7716a.zip",
           "url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/XRPUSDT/XRPUSDT-fundingRate-2026-04.zip"
         },
         {
           "checksum_sha256": "f8c0c09953b112a7f5ac203a826811ead1ac43db8c075b17b2ca69e837828255",
           "checksum_url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/XRPUSDT/XRPUSDT-fundingRate-2026-05.zip.CHECKSUM",
+          "local_path": "raw/fundingRate/XRPUSDT/XRPUSDT-fundingRate-2026-05.f8c0c09953b112a7f5ac203a826811ead1ac43db8c075b17b2ca69e837828255.zip",
           "url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/XRPUSDT/XRPUSDT-fundingRate-2026-05.zip"
         },
         {
           "checksum_sha256": "f5d1b51767ddc812c4608080adf54cfca0db7cba592d3e62d7416cd358a3ebde",
           "checksum_url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/XRPUSDT/XRPUSDT-fundingRate-2026-06.zip.CHECKSUM",
+          "local_path": "raw/fundingRate/XRPUSDT/XRPUSDT-fundingRate-2026-06.f5d1b51767ddc812c4608080adf54cfca0db7cba592d3e62d7416cd358a3ebde.zip",
           "url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/XRPUSDT/XRPUSDT-fundingRate-2026-06.zip"
         }
       ],
@@ -163,69 +189,83 @@
       "min_calc_time_ms": 1751328000007,
       "normalized_shard_sha256": "3fff8b16dd5ca113804b1daf45b2405bfbf490fdec199757184b7eff923c5d3e",
       "row_count": 1095,
+      "shard_file_sha256": "96956e9f26e496a76c743accb760ac784c365552546341329e6d30dbc3c7c4b8",
+      "shard_path": "shards/funding/XRPUSDT-fundingRate.3fff8b16dd5ca113804b1daf45b2405bfbf490fdec199757184b7eff923c5d3e.parquet",
       "symbol": "XRPUSDT",
-      "transform_version": "rob941_corpus.v1"
+      "transform_version": "rob941_corpus.v2"
     },
     {
       "archives": [
         {
           "checksum_sha256": "e56f1173899b2be5b35e14cdd61d6549dfed04bd2eacc1673285fbc067affe11",
           "checksum_url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/DOGEUSDT/DOGEUSDT-fundingRate-2025-07.zip.CHECKSUM",
+          "local_path": "raw/fundingRate/DOGEUSDT/DOGEUSDT-fundingRate-2025-07.e56f1173899b2be5b35e14cdd61d6549dfed04bd2eacc1673285fbc067affe11.zip",
           "url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/DOGEUSDT/DOGEUSDT-fundingRate-2025-07.zip"
         },
         {
           "checksum_sha256": "c73e14c91a6e44f2a7a4795c845f54f0c82fac1529dd0852c66c52175d76ff53",
           "checksum_url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/DOGEUSDT/DOGEUSDT-fundingRate-2025-08.zip.CHECKSUM",
+          "local_path": "raw/fundingRate/DOGEUSDT/DOGEUSDT-fundingRate-2025-08.c73e14c91a6e44f2a7a4795c845f54f0c82fac1529dd0852c66c52175d76ff53.zip",
           "url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/DOGEUSDT/DOGEUSDT-fundingRate-2025-08.zip"
         },
         {
           "checksum_sha256": "1105b391de748f50048b5590f6a5265fcb2a6354ec8a6ac3ba79b5ca734aa9cc",
           "checksum_url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/DOGEUSDT/DOGEUSDT-fundingRate-2025-09.zip.CHECKSUM",
+          "local_path": "raw/fundingRate/DOGEUSDT/DOGEUSDT-fundingRate-2025-09.1105b391de748f50048b5590f6a5265fcb2a6354ec8a6ac3ba79b5ca734aa9cc.zip",
           "url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/DOGEUSDT/DOGEUSDT-fundingRate-2025-09.zip"
         },
         {
           "checksum_sha256": "6217d0bc8ab8abe35dd0c56d18cc008e8a8e36adef2be37ed9ccbf3c91c71d0a",
           "checksum_url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/DOGEUSDT/DOGEUSDT-fundingRate-2025-10.zip.CHECKSUM",
+          "local_path": "raw/fundingRate/DOGEUSDT/DOGEUSDT-fundingRate-2025-10.6217d0bc8ab8abe35dd0c56d18cc008e8a8e36adef2be37ed9ccbf3c91c71d0a.zip",
           "url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/DOGEUSDT/DOGEUSDT-fundingRate-2025-10.zip"
         },
         {
           "checksum_sha256": "ea4b56653bb13210c5fbdeceb668f632b15a8fe6e7676d1afcbbcb5a019d92f4",
           "checksum_url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/DOGEUSDT/DOGEUSDT-fundingRate-2025-11.zip.CHECKSUM",
+          "local_path": "raw/fundingRate/DOGEUSDT/DOGEUSDT-fundingRate-2025-11.ea4b56653bb13210c5fbdeceb668f632b15a8fe6e7676d1afcbbcb5a019d92f4.zip",
           "url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/DOGEUSDT/DOGEUSDT-fundingRate-2025-11.zip"
         },
         {
           "checksum_sha256": "8e84dea86eb7fe0cb7b2f9278f0df0479b68ae10ac9b6ade872372888769f874",
           "checksum_url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/DOGEUSDT/DOGEUSDT-fundingRate-2025-12.zip.CHECKSUM",
+          "local_path": "raw/fundingRate/DOGEUSDT/DOGEUSDT-fundingRate-2025-12.8e84dea86eb7fe0cb7b2f9278f0df0479b68ae10ac9b6ade872372888769f874.zip",
           "url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/DOGEUSDT/DOGEUSDT-fundingRate-2025-12.zip"
         },
         {
           "checksum_sha256": "73c2760e0bf4a5dd8af31d1f03ba1e6d213aa1ed42da17a8c537f28c7f033f44",
           "checksum_url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/DOGEUSDT/DOGEUSDT-fundingRate-2026-01.zip.CHECKSUM",
+          "local_path": "raw/fundingRate/DOGEUSDT/DOGEUSDT-fundingRate-2026-01.73c2760e0bf4a5dd8af31d1f03ba1e6d213aa1ed42da17a8c537f28c7f033f44.zip",
           "url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/DOGEUSDT/DOGEUSDT-fundingRate-2026-01.zip"
         },
         {
           "checksum_sha256": "5a82031b9e3009265751cf02853ded1e1649bd3c2c3c764d5e50e64edc944a6e",
           "checksum_url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/DOGEUSDT/DOGEUSDT-fundingRate-2026-02.zip.CHECKSUM",
+          "local_path": "raw/fundingRate/DOGEUSDT/DOGEUSDT-fundingRate-2026-02.5a82031b9e3009265751cf02853ded1e1649bd3c2c3c764d5e50e64edc944a6e.zip",
           "url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/DOGEUSDT/DOGEUSDT-fundingRate-2026-02.zip"
         },
         {
           "checksum_sha256": "f4b2222b88d3cf518939c38a20fdd224629c3844a8d2f710c8c14e4fe9409d85",
           "checksum_url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/DOGEUSDT/DOGEUSDT-fundingRate-2026-03.zip.CHECKSUM",
+          "local_path": "raw/fundingRate/DOGEUSDT/DOGEUSDT-fundingRate-2026-03.f4b2222b88d3cf518939c38a20fdd224629c3844a8d2f710c8c14e4fe9409d85.zip",
           "url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/DOGEUSDT/DOGEUSDT-fundingRate-2026-03.zip"
         },
         {
           "checksum_sha256": "1a041267001c6417220e595f9c723919eec3b2e317012a8cfd22f95ac8105ceb",
           "checksum_url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/DOGEUSDT/DOGEUSDT-fundingRate-2026-04.zip.CHECKSUM",
+          "local_path": "raw/fundingRate/DOGEUSDT/DOGEUSDT-fundingRate-2026-04.1a041267001c6417220e595f9c723919eec3b2e317012a8cfd22f95ac8105ceb.zip",
           "url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/DOGEUSDT/DOGEUSDT-fundingRate-2026-04.zip"
         },
         {
           "checksum_sha256": "99411bbfdc7508a498204faf9ce3f02958f484828a5ffd309b6c267b89c89ba6",
           "checksum_url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/DOGEUSDT/DOGEUSDT-fundingRate-2026-05.zip.CHECKSUM",
+          "local_path": "raw/fundingRate/DOGEUSDT/DOGEUSDT-fundingRate-2026-05.99411bbfdc7508a498204faf9ce3f02958f484828a5ffd309b6c267b89c89ba6.zip",
           "url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/DOGEUSDT/DOGEUSDT-fundingRate-2026-05.zip"
         },
         {
           "checksum_sha256": "b701956a49aa6e9daf692eccbe0c79be94dd3e0dbacde8996852f551a5fbfdba",
           "checksum_url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/DOGEUSDT/DOGEUSDT-fundingRate-2026-06.zip.CHECKSUM",
+          "local_path": "raw/fundingRate/DOGEUSDT/DOGEUSDT-fundingRate-2026-06.b701956a49aa6e9daf692eccbe0c79be94dd3e0dbacde8996852f551a5fbfdba.zip",
           "url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/DOGEUSDT/DOGEUSDT-fundingRate-2026-06.zip"
         }
       ],
@@ -233,69 +273,83 @@
       "min_calc_time_ms": 1751328000007,
       "normalized_shard_sha256": "b1c2ae3cdecd84a87e0f7a428d2562f7f0837ed996dc1ac9a673c61b2e7f5d5c",
       "row_count": 1095,
+      "shard_file_sha256": "27aa460cfb088e0fac71eca2d181fa7814d024fe9190b791deb5426e6c176919",
+      "shard_path": "shards/funding/DOGEUSDT-fundingRate.b1c2ae3cdecd84a87e0f7a428d2562f7f0837ed996dc1ac9a673c61b2e7f5d5c.parquet",
       "symbol": "DOGEUSDT",
-      "transform_version": "rob941_corpus.v1"
+      "transform_version": "rob941_corpus.v2"
     },
     {
       "archives": [
         {
           "checksum_sha256": "66ce38d1a8bc4bdd53af29d8ea5c72493ed48fe9894ee5e9ff4600ccec864c4f",
           "checksum_url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/SOLUSDT/SOLUSDT-fundingRate-2025-07.zip.CHECKSUM",
+          "local_path": "raw/fundingRate/SOLUSDT/SOLUSDT-fundingRate-2025-07.66ce38d1a8bc4bdd53af29d8ea5c72493ed48fe9894ee5e9ff4600ccec864c4f.zip",
           "url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/SOLUSDT/SOLUSDT-fundingRate-2025-07.zip"
         },
         {
           "checksum_sha256": "fe9efc3abe1e4be2a2fa9a4008e6957856387f6783a06b97cac3ee271746915f",
           "checksum_url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/SOLUSDT/SOLUSDT-fundingRate-2025-08.zip.CHECKSUM",
+          "local_path": "raw/fundingRate/SOLUSDT/SOLUSDT-fundingRate-2025-08.fe9efc3abe1e4be2a2fa9a4008e6957856387f6783a06b97cac3ee271746915f.zip",
           "url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/SOLUSDT/SOLUSDT-fundingRate-2025-08.zip"
         },
         {
           "checksum_sha256": "f953315124d20dab98ba710d108103fb4cf054d1535787fd76d35d6b9c18e534",
           "checksum_url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/SOLUSDT/SOLUSDT-fundingRate-2025-09.zip.CHECKSUM",
+          "local_path": "raw/fundingRate/SOLUSDT/SOLUSDT-fundingRate-2025-09.f953315124d20dab98ba710d108103fb4cf054d1535787fd76d35d6b9c18e534.zip",
           "url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/SOLUSDT/SOLUSDT-fundingRate-2025-09.zip"
         },
         {
           "checksum_sha256": "d80c5be7660a950ad673a0e82488877c6ca0eb81f084d4c844320f892ad2c020",
           "checksum_url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/SOLUSDT/SOLUSDT-fundingRate-2025-10.zip.CHECKSUM",
+          "local_path": "raw/fundingRate/SOLUSDT/SOLUSDT-fundingRate-2025-10.d80c5be7660a950ad673a0e82488877c6ca0eb81f084d4c844320f892ad2c020.zip",
           "url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/SOLUSDT/SOLUSDT-fundingRate-2025-10.zip"
         },
         {
           "checksum_sha256": "5134fdf4319d629473f8cff1e66dc74180844ae2846ab41a8128466ab3682c2f",
           "checksum_url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/SOLUSDT/SOLUSDT-fundingRate-2025-11.zip.CHECKSUM",
+          "local_path": "raw/fundingRate/SOLUSDT/SOLUSDT-fundingRate-2025-11.5134fdf4319d629473f8cff1e66dc74180844ae2846ab41a8128466ab3682c2f.zip",
           "url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/SOLUSDT/SOLUSDT-fundingRate-2025-11.zip"
         },
         {
           "checksum_sha256": "01db13c460b0190736e1da019c7fcd7ea0abbf3b047e16d3aa8a9e9acec3101f",
           "checksum_url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/SOLUSDT/SOLUSDT-fundingRate-2025-12.zip.CHECKSUM",
+          "local_path": "raw/fundingRate/SOLUSDT/SOLUSDT-fundingRate-2025-12.01db13c460b0190736e1da019c7fcd7ea0abbf3b047e16d3aa8a9e9acec3101f.zip",
           "url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/SOLUSDT/SOLUSDT-fundingRate-2025-12.zip"
         },
         {
           "checksum_sha256": "c53be79aae38a1f35e94880f106df4eceab57bfa74a0b5fc5852fdfabf57ab8e",
           "checksum_url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/SOLUSDT/SOLUSDT-fundingRate-2026-01.zip.CHECKSUM",
+          "local_path": "raw/fundingRate/SOLUSDT/SOLUSDT-fundingRate-2026-01.c53be79aae38a1f35e94880f106df4eceab57bfa74a0b5fc5852fdfabf57ab8e.zip",
           "url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/SOLUSDT/SOLUSDT-fundingRate-2026-01.zip"
         },
         {
           "checksum_sha256": "84cb9bcf44ba1364b37db876e7c852aa1b831371556b610e2387115addec9d5f",
           "checksum_url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/SOLUSDT/SOLUSDT-fundingRate-2026-02.zip.CHECKSUM",
+          "local_path": "raw/fundingRate/SOLUSDT/SOLUSDT-fundingRate-2026-02.84cb9bcf44ba1364b37db876e7c852aa1b831371556b610e2387115addec9d5f.zip",
           "url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/SOLUSDT/SOLUSDT-fundingRate-2026-02.zip"
         },
         {
           "checksum_sha256": "75cfaea075d97779a577c3744ea63e3d83704f281806fb5f76f2d3e0f089fd2c",
           "checksum_url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/SOLUSDT/SOLUSDT-fundingRate-2026-03.zip.CHECKSUM",
+          "local_path": "raw/fundingRate/SOLUSDT/SOLUSDT-fundingRate-2026-03.75cfaea075d97779a577c3744ea63e3d83704f281806fb5f76f2d3e0f089fd2c.zip",
           "url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/SOLUSDT/SOLUSDT-fundingRate-2026-03.zip"
         },
         {
           "checksum_sha256": "951a280e98b6d20fe4be25bf2b71f3cda1c07c7583a88cb874151e2b1fe941f1",
           "checksum_url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/SOLUSDT/SOLUSDT-fundingRate-2026-04.zip.CHECKSUM",
+          "local_path": "raw/fundingRate/SOLUSDT/SOLUSDT-fundingRate-2026-04.951a280e98b6d20fe4be25bf2b71f3cda1c07c7583a88cb874151e2b1fe941f1.zip",
           "url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/SOLUSDT/SOLUSDT-fundingRate-2026-04.zip"
         },
         {
           "checksum_sha256": "c13066e5f7c5d161dbebd488cbeaab1205688c6dc7f9fafcc8f94296f2c1e47b",
           "checksum_url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/SOLUSDT/SOLUSDT-fundingRate-2026-05.zip.CHECKSUM",
+          "local_path": "raw/fundingRate/SOLUSDT/SOLUSDT-fundingRate-2026-05.c13066e5f7c5d161dbebd488cbeaab1205688c6dc7f9fafcc8f94296f2c1e47b.zip",
           "url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/SOLUSDT/SOLUSDT-fundingRate-2026-05.zip"
         },
         {
           "checksum_sha256": "8d32fa3153d54c58667650e8b2c65e489b3a433b775052a93208bf60541a40d3",
           "checksum_url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/SOLUSDT/SOLUSDT-fundingRate-2026-06.zip.CHECKSUM",
+          "local_path": "raw/fundingRate/SOLUSDT/SOLUSDT-fundingRate-2026-06.8d32fa3153d54c58667650e8b2c65e489b3a433b775052a93208bf60541a40d3.zip",
           "url": "https://data.binance.vision/data/futures/um/monthly/fundingRate/SOLUSDT/SOLUSDT-fundingRate-2026-06.zip"
         }
       ],
@@ -303,8 +357,10 @@
       "min_calc_time_ms": 1751328000007,
       "normalized_shard_sha256": "c4fc7778955cdc7274722c85a11a214277936592dd1e14b3ca1cabaa1b1e4c1c",
       "row_count": 1095,
+      "shard_file_sha256": "46466ddcd8593fb99356ed402a11d1d11280182caf67c9d2f132fb2e379ef273",
+      "shard_path": "shards/funding/SOLUSDT-fundingRate.c4fc7778955cdc7274722c85a11a214277936592dd1e14b3ca1cabaa1b1e4c1c.parquet",
       "symbol": "SOLUSDT",
-      "transform_version": "rob941_corpus.v1"
+      "transform_version": "rob941_corpus.v2"
     }
   ],
   "klines": [
@@ -313,61 +369,73 @@
         {
           "checksum_sha256": "cf5fe0891c80e68d2d613eb5457100b7d886eee8cc913ccdd96ef45e757a5aaf",
           "checksum_url": "https://data.binance.vision/data/futures/um/monthly/klines/BTCUSDT/1m/BTCUSDT-1m-2025-07.zip.CHECKSUM",
+          "local_path": "raw/klines/BTCUSDT/BTCUSDT-klines-2025-07.cf5fe0891c80e68d2d613eb5457100b7d886eee8cc913ccdd96ef45e757a5aaf.zip",
           "url": "https://data.binance.vision/data/futures/um/monthly/klines/BTCUSDT/1m/BTCUSDT-1m-2025-07.zip"
         },
         {
           "checksum_sha256": "eaf41354fc1aa96eac94ee50b3fda603cd595f95030ebf30b2ab5bea7a4462c3",
           "checksum_url": "https://data.binance.vision/data/futures/um/monthly/klines/BTCUSDT/1m/BTCUSDT-1m-2025-08.zip.CHECKSUM",
+          "local_path": "raw/klines/BTCUSDT/BTCUSDT-klines-2025-08.eaf41354fc1aa96eac94ee50b3fda603cd595f95030ebf30b2ab5bea7a4462c3.zip",
           "url": "https://data.binance.vision/data/futures/um/monthly/klines/BTCUSDT/1m/BTCUSDT-1m-2025-08.zip"
         },
         {
           "checksum_sha256": "c296ba45c215934e9750ca82846c7b5d14be661649d8e4423eac834cf57330dc",
           "checksum_url": "https://data.binance.vision/data/futures/um/monthly/klines/BTCUSDT/1m/BTCUSDT-1m-2025-09.zip.CHECKSUM",
+          "local_path": "raw/klines/BTCUSDT/BTCUSDT-klines-2025-09.c296ba45c215934e9750ca82846c7b5d14be661649d8e4423eac834cf57330dc.zip",
           "url": "https://data.binance.vision/data/futures/um/monthly/klines/BTCUSDT/1m/BTCUSDT-1m-2025-09.zip"
         },
         {
           "checksum_sha256": "bb7f53350fe27b6d8e38b5856ffc43f9ecda9d568d5bf31d0db0cd011da7100f",
           "checksum_url": "https://data.binance.vision/data/futures/um/monthly/klines/BTCUSDT/1m/BTCUSDT-1m-2025-10.zip.CHECKSUM",
+          "local_path": "raw/klines/BTCUSDT/BTCUSDT-klines-2025-10.bb7f53350fe27b6d8e38b5856ffc43f9ecda9d568d5bf31d0db0cd011da7100f.zip",
           "url": "https://data.binance.vision/data/futures/um/monthly/klines/BTCUSDT/1m/BTCUSDT-1m-2025-10.zip"
         },
         {
           "checksum_sha256": "981da0b054f99b959fe6245fb363336b46908d358f37251d59bad308f375bc54",
           "checksum_url": "https://data.binance.vision/data/futures/um/monthly/klines/BTCUSDT/1m/BTCUSDT-1m-2025-11.zip.CHECKSUM",
+          "local_path": "raw/klines/BTCUSDT/BTCUSDT-klines-2025-11.981da0b054f99b959fe6245fb363336b46908d358f37251d59bad308f375bc54.zip",
           "url": "https://data.binance.vision/data/futures/um/monthly/klines/BTCUSDT/1m/BTCUSDT-1m-2025-11.zip"
         },
         {
           "checksum_sha256": "2d5b2e1887dac1dfe450010877de7203a72e19df7a771067b980bbb07ad3069c",
           "checksum_url": "https://data.binance.vision/data/futures/um/monthly/klines/BTCUSDT/1m/BTCUSDT-1m-2025-12.zip.CHECKSUM",
+          "local_path": "raw/klines/BTCUSDT/BTCUSDT-klines-2025-12.2d5b2e1887dac1dfe450010877de7203a72e19df7a771067b980bbb07ad3069c.zip",
           "url": "https://data.binance.vision/data/futures/um/monthly/klines/BTCUSDT/1m/BTCUSDT-1m-2025-12.zip"
         },
         {
           "checksum_sha256": "58e9c620a6acda209d25766b3cf4262f3104649f5c26f247d933e0da8bb7946f",
           "checksum_url": "https://data.binance.vision/data/futures/um/monthly/klines/BTCUSDT/1m/BTCUSDT-1m-2026-01.zip.CHECKSUM",
+          "local_path": "raw/klines/BTCUSDT/BTCUSDT-klines-2026-01.58e9c620a6acda209d25766b3cf4262f3104649f5c26f247d933e0da8bb7946f.zip",
           "url": "https://data.binance.vision/data/futures/um/monthly/klines/BTCUSDT/1m/BTCUSDT-1m-2026-01.zip"
         },
         {
           "checksum_sha256": "805626ad2dc5b704d52c211996d12e9e4b1be234998f3dba4b3d34ff79be0337",
           "checksum_url": "https://data.binance.vision/data/futures/um/monthly/klines/BTCUSDT/1m/BTCUSDT-1m-2026-02.zip.CHECKSUM",
+          "local_path": "raw/klines/BTCUSDT/BTCUSDT-klines-2026-02.805626ad2dc5b704d52c211996d12e9e4b1be234998f3dba4b3d34ff79be0337.zip",
           "url": "https://data.binance.vision/data/futures/um/monthly/klines/BTCUSDT/1m/BTCUSDT-1m-2026-02.zip"
         },
         {
           "checksum_sha256": "c472a865f230bf1b5b17e124770a83c083144e3e11a115733288fb8f3e3b8baa",
           "checksum_url": "https://data.binance.vision/data/futures/um/monthly/klines/BTCUSDT/1m/BTCUSDT-1m-2026-03.zip.CHECKSUM",
+          "local_path": "raw/klines/BTCUSDT/BTCUSDT-klines-2026-03.c472a865f230bf1b5b17e124770a83c083144e3e11a115733288fb8f3e3b8baa.zip",
           "url": "https://data.binance.vision/data/futures/um/monthly/klines/BTCUSDT/1m/BTCUSDT-1m-2026-03.zip"
         },
         {
           "checksum_sha256": "515b86570f0c6924f6dc2cf90589d3db90f3de9c6bfd9a22dde0429995dc5405",
           "checksum_url": "https://data.binance.vision/data/futures/um/monthly/klines/BTCUSDT/1m/BTCUSDT-1m-2026-04.zip.CHECKSUM",
+          "local_path": "raw/klines/BTCUSDT/BTCUSDT-klines-2026-04.515b86570f0c6924f6dc2cf90589d3db90f3de9c6bfd9a22dde0429995dc5405.zip",
           "url": "https://data.binance.vision/data/futures/um/monthly/klines/BTCUSDT/1m/BTCUSDT-1m-2026-04.zip"
         },
         {
           "checksum_sha256": "d91548e94220d5211bb32447cc4b604ee266d145f2092edc5ec613328cbbc20a",
           "checksum_url": "https://data.binance.vision/data/futures/um/monthly/klines/BTCUSDT/1m/BTCUSDT-1m-2026-05.zip.CHECKSUM",
+          "local_path": "raw/klines/BTCUSDT/BTCUSDT-klines-2026-05.d91548e94220d5211bb32447cc4b604ee266d145f2092edc5ec613328cbbc20a.zip",
           "url": "https://data.binance.vision/data/futures/um/monthly/klines/BTCUSDT/1m/BTCUSDT-1m-2026-05.zip"
         },
         {
           "checksum_sha256": "9b214199eb5063585c7ed0f59ba19323326d68ac024b85106713989399204490",
           "checksum_url": "https://data.binance.vision/data/futures/um/monthly/klines/BTCUSDT/1m/BTCUSDT-1m-2026-06.zip.CHECKSUM",
+          "local_path": "raw/klines/BTCUSDT/BTCUSDT-klines-2026-06.9b214199eb5063585c7ed0f59ba19323326d68ac024b85106713989399204490.zip",
           "url": "https://data.binance.vision/data/futures/um/monthly/klines/BTCUSDT/1m/BTCUSDT-1m-2026-06.zip"
         }
       ],
@@ -377,69 +445,83 @@
       "min_open_time_ms": 1751328000000,
       "normalized_shard_sha256": "8f43af68dbf401b0c3a2a800c3dd0d0675a78458d179bcd93964d634c2d90939",
       "row_count": 525600,
+      "shard_file_sha256": "5646bb252f0e5d0733f6ebfa13eaec39238e84aa5cc5a5f5f4c82bcd92952d54",
+      "shard_path": "shards/klines/BTCUSDT-1m.8f43af68dbf401b0c3a2a800c3dd0d0675a78458d179bcd93964d634c2d90939.parquet",
       "symbol": "BTCUSDT",
-      "transform_version": "rob941_corpus.v1"
+      "transform_version": "rob941_corpus.v2"
     },
     {
       "archives": [
         {
           "checksum_sha256": "6f5f7faa96370dacb4792b18ce628d3ff8b0a5fa4cd10063e55065e03ff9f53d",
           "checksum_url": "https://data.binance.vision/data/futures/um/monthly/klines/XRPUSDT/1m/XRPUSDT-1m-2025-07.zip.CHECKSUM",
+          "local_path": "raw/klines/XRPUSDT/XRPUSDT-klines-2025-07.6f5f7faa96370dacb4792b18ce628d3ff8b0a5fa4cd10063e55065e03ff9f53d.zip",
           "url": "https://data.binance.vision/data/futures/um/monthly/klines/XRPUSDT/1m/XRPUSDT-1m-2025-07.zip"
         },
         {
           "checksum_sha256": "823e87bba1c53bebffd8074ee190adfae55c489936ff5d539fcdf54e1ea68633",
           "checksum_url": "https://data.binance.vision/data/futures/um/monthly/klines/XRPUSDT/1m/XRPUSDT-1m-2025-08.zip.CHECKSUM",
+          "local_path": "raw/klines/XRPUSDT/XRPUSDT-klines-2025-08.823e87bba1c53bebffd8074ee190adfae55c489936ff5d539fcdf54e1ea68633.zip",
           "url": "https://data.binance.vision/data/futures/um/monthly/klines/XRPUSDT/1m/XRPUSDT-1m-2025-08.zip"
         },
         {
           "checksum_sha256": "0f47e24c9e133c09d0df6756e224c2547d5e1ca3c9ba7af77232d1e9368330fb",
           "checksum_url": "https://data.binance.vision/data/futures/um/monthly/klines/XRPUSDT/1m/XRPUSDT-1m-2025-09.zip.CHECKSUM",
+          "local_path": "raw/klines/XRPUSDT/XRPUSDT-klines-2025-09.0f47e24c9e133c09d0df6756e224c2547d5e1ca3c9ba7af77232d1e9368330fb.zip",
           "url": "https://data.binance.vision/data/futures/um/monthly/klines/XRPUSDT/1m/XRPUSDT-1m-2025-09.zip"
         },
         {
           "checksum_sha256": "9ba37c1fb1bded7e554dbfc9221c126cdb8bf4c569b4b5c639e83bcda38b6b3e",
           "checksum_url": "https://data.binance.vision/data/futures/um/monthly/klines/XRPUSDT/1m/XRPUSDT-1m-2025-10.zip.CHECKSUM",
+          "local_path": "raw/klines/XRPUSDT/XRPUSDT-klines-2025-10.9ba37c1fb1bded7e554dbfc9221c126cdb8bf4c569b4b5c639e83bcda38b6b3e.zip",
           "url": "https://data.binance.vision/data/futures/um/monthly/klines/XRPUSDT/1m/XRPUSDT-1m-2025-10.zip"
         },
         {
           "checksum_sha256": "dd62352ab1fc3b2e8f5f235c7c775044432a493c8a5ab732f709acfe1c8f62bc",
           "checksum_url": "https://data.binance.vision/data/futures/um/monthly/klines/XRPUSDT/1m/XRPUSDT-1m-2025-11.zip.CHECKSUM",
+          "local_path": "raw/klines/XRPUSDT/XRPUSDT-klines-2025-11.dd62352ab1fc3b2e8f5f235c7c775044432a493c8a5ab732f709acfe1c8f62bc.zip",
           "url": "https://data.binance.vision/data/futures/um/monthly/klines/XRPUSDT/1m/XRPUSDT-1m-2025-11.zip"
         },
         {
           "checksum_sha256": "821efe300f5a66a68fe468e45fe9094431fac70b62a909c4aa7cc97239c4ce4c",
           "checksum_url": "https://data.binance.vision/data/futures/um/monthly/klines/XRPUSDT/1m/XRPUSDT-1m-2025-12.zip.CHECKSUM",
+          "local_path": "raw/klines/XRPUSDT/XRPUSDT-klines-2025-12.821efe300f5a66a68fe468e45fe9094431fac70b62a909c4aa7cc97239c4ce4c.zip",
           "url": "https://data.binance.vision/data/futures/um/monthly/klines/XRPUSDT/1m/XRPUSDT-1m-2025-12.zip"
         },
         {
           "checksum_sha256": "8612f9c3796982d55feb1696d4a08407e4910d40cfce25e71b0172dea32b9847",
           "checksum_url": "https://data.binance.vision/data/futures/um/monthly/klines/XRPUSDT/1m/XRPUSDT-1m-2026-01.zip.CHECKSUM",
+          "local_path": "raw/klines/XRPUSDT/XRPUSDT-klines-2026-01.8612f9c3796982d55feb1696d4a08407e4910d40cfce25e71b0172dea32b9847.zip",
           "url": "https://data.binance.vision/data/futures/um/monthly/klines/XRPUSDT/1m/XRPUSDT-1m-2026-01.zip"
         },
         {
           "checksum_sha256": "58bff9b0136a1584414b6d24133279c02a56030da7625942c286e9d11f3d37a3",
           "checksum_url": "https://data.binance.vision/data/futures/um/monthly/klines/XRPUSDT/1m/XRPUSDT-1m-2026-02.zip.CHECKSUM",
+          "local_path": "raw/klines/XRPUSDT/XRPUSDT-klines-2026-02.58bff9b0136a1584414b6d24133279c02a56030da7625942c286e9d11f3d37a3.zip",
           "url": "https://data.binance.vision/data/futures/um/monthly/klines/XRPUSDT/1m/XRPUSDT-1m-2026-02.zip"
         },
         {
           "checksum_sha256": "38b4f4f23cd92c23b37c2fea4e827540af06c8a0e2330bff8491acaf3d14e794",
           "checksum_url": "https://data.binance.vision/data/futures/um/monthly/klines/XRPUSDT/1m/XRPUSDT-1m-2026-03.zip.CHECKSUM",
+          "local_path": "raw/klines/XRPUSDT/XRPUSDT-klines-2026-03.38b4f4f23cd92c23b37c2fea4e827540af06c8a0e2330bff8491acaf3d14e794.zip",
           "url": "https://data.binance.vision/data/futures/um/monthly/klines/XRPUSDT/1m/XRPUSDT-1m-2026-03.zip"
         },
         {
           "checksum_sha256": "e887d411a37786bfd83d3fcbe7561801529d3c9e012d90b420c628226253d63a",
           "checksum_url": "https://data.binance.vision/data/futures/um/monthly/klines/XRPUSDT/1m/XRPUSDT-1m-2026-04.zip.CHECKSUM",
+          "local_path": "raw/klines/XRPUSDT/XRPUSDT-klines-2026-04.e887d411a37786bfd83d3fcbe7561801529d3c9e012d90b420c628226253d63a.zip",
           "url": "https://data.binance.vision/data/futures/um/monthly/klines/XRPUSDT/1m/XRPUSDT-1m-2026-04.zip"
         },
         {
           "checksum_sha256": "6733b41f25b4a278a67ae6002e5f20c089a61ae864d99c9d1b002e375c932f9b",
           "checksum_url": "https://data.binance.vision/data/futures/um/monthly/klines/XRPUSDT/1m/XRPUSDT-1m-2026-05.zip.CHECKSUM",
+          "local_path": "raw/klines/XRPUSDT/XRPUSDT-klines-2026-05.6733b41f25b4a278a67ae6002e5f20c089a61ae864d99c9d1b002e375c932f9b.zip",
           "url": "https://data.binance.vision/data/futures/um/monthly/klines/XRPUSDT/1m/XRPUSDT-1m-2026-05.zip"
         },
         {
           "checksum_sha256": "b49faed75492e1136f2dc3f8cad1328e55c3179368ba80b85e1f961d536a8a47",
           "checksum_url": "https://data.binance.vision/data/futures/um/monthly/klines/XRPUSDT/1m/XRPUSDT-1m-2026-06.zip.CHECKSUM",
+          "local_path": "raw/klines/XRPUSDT/XRPUSDT-klines-2026-06.b49faed75492e1136f2dc3f8cad1328e55c3179368ba80b85e1f961d536a8a47.zip",
           "url": "https://data.binance.vision/data/futures/um/monthly/klines/XRPUSDT/1m/XRPUSDT-1m-2026-06.zip"
         }
       ],
@@ -449,69 +531,83 @@
       "min_open_time_ms": 1751328000000,
       "normalized_shard_sha256": "72139b566eaf9ca97bba792a3458b05c1cfe028e1309a0d8517b2fac88fdc630",
       "row_count": 525600,
+      "shard_file_sha256": "8f58bde502bdef60d7b4a29bc7f27b97d20fb7b0f7076452ad92a56743448db4",
+      "shard_path": "shards/klines/XRPUSDT-1m.72139b566eaf9ca97bba792a3458b05c1cfe028e1309a0d8517b2fac88fdc630.parquet",
       "symbol": "XRPUSDT",
-      "transform_version": "rob941_corpus.v1"
+      "transform_version": "rob941_corpus.v2"
     },
     {
       "archives": [
         {
           "checksum_sha256": "6c6858a61ec39254b54a40fd864bef0cacd99a3a244bb9b0e5cec0acbe6eb631",
           "checksum_url": "https://data.binance.vision/data/futures/um/monthly/klines/DOGEUSDT/1m/DOGEUSDT-1m-2025-07.zip.CHECKSUM",
+          "local_path": "raw/klines/DOGEUSDT/DOGEUSDT-klines-2025-07.6c6858a61ec39254b54a40fd864bef0cacd99a3a244bb9b0e5cec0acbe6eb631.zip",
           "url": "https://data.binance.vision/data/futures/um/monthly/klines/DOGEUSDT/1m/DOGEUSDT-1m-2025-07.zip"
         },
         {
           "checksum_sha256": "1a69ffc39419bb27c12e019de4809e086e40bf620e40e8a044762ba62095026e",
           "checksum_url": "https://data.binance.vision/data/futures/um/monthly/klines/DOGEUSDT/1m/DOGEUSDT-1m-2025-08.zip.CHECKSUM",
+          "local_path": "raw/klines/DOGEUSDT/DOGEUSDT-klines-2025-08.1a69ffc39419bb27c12e019de4809e086e40bf620e40e8a044762ba62095026e.zip",
           "url": "https://data.binance.vision/data/futures/um/monthly/klines/DOGEUSDT/1m/DOGEUSDT-1m-2025-08.zip"
         },
         {
           "checksum_sha256": "34dac0a3873c158dd3e6126719e0e931ee305f6a1ce56e1a68c5c05b00284b3d",
           "checksum_url": "https://data.binance.vision/data/futures/um/monthly/klines/DOGEUSDT/1m/DOGEUSDT-1m-2025-09.zip.CHECKSUM",
+          "local_path": "raw/klines/DOGEUSDT/DOGEUSDT-klines-2025-09.34dac0a3873c158dd3e6126719e0e931ee305f6a1ce56e1a68c5c05b00284b3d.zip",
           "url": "https://data.binance.vision/data/futures/um/monthly/klines/DOGEUSDT/1m/DOGEUSDT-1m-2025-09.zip"
         },
         {
           "checksum_sha256": "c2e2ef77ee80bd0d0fef438a5f24dc2f4765de6e3ef0ab36797d1bfb20731bd5",
           "checksum_url": "https://data.binance.vision/data/futures/um/monthly/klines/DOGEUSDT/1m/DOGEUSDT-1m-2025-10.zip.CHECKSUM",
+          "local_path": "raw/klines/DOGEUSDT/DOGEUSDT-klines-2025-10.c2e2ef77ee80bd0d0fef438a5f24dc2f4765de6e3ef0ab36797d1bfb20731bd5.zip",
           "url": "https://data.binance.vision/data/futures/um/monthly/klines/DOGEUSDT/1m/DOGEUSDT-1m-2025-10.zip"
         },
         {
           "checksum_sha256": "613eba1df328da3b171bd0fe975e2dd1047e0ac535c49a71aad0649ba3da4d6c",
           "checksum_url": "https://data.binance.vision/data/futures/um/monthly/klines/DOGEUSDT/1m/DOGEUSDT-1m-2025-11.zip.CHECKSUM",
+          "local_path": "raw/klines/DOGEUSDT/DOGEUSDT-klines-2025-11.613eba1df328da3b171bd0fe975e2dd1047e0ac535c49a71aad0649ba3da4d6c.zip",
           "url": "https://data.binance.vision/data/futures/um/monthly/klines/DOGEUSDT/1m/DOGEUSDT-1m-2025-11.zip"
         },
         {
           "checksum_sha256": "c7d230dcded82fe00f47546094318bb67b7477fe202aac48075237f30cda8840",
           "checksum_url": "https://data.binance.vision/data/futures/um/monthly/klines/DOGEUSDT/1m/DOGEUSDT-1m-2025-12.zip.CHECKSUM",
+          "local_path": "raw/klines/DOGEUSDT/DOGEUSDT-klines-2025-12.c7d230dcded82fe00f47546094318bb67b7477fe202aac48075237f30cda8840.zip",
           "url": "https://data.binance.vision/data/futures/um/monthly/klines/DOGEUSDT/1m/DOGEUSDT-1m-2025-12.zip"
         },
         {
           "checksum_sha256": "b1461ec0ea96fe535e72780b698471907136df72c97a360628c6b65ae6dd5cae",
           "checksum_url": "https://data.binance.vision/data/futures/um/monthly/klines/DOGEUSDT/1m/DOGEUSDT-1m-2026-01.zip.CHECKSUM",
+          "local_path": "raw/klines/DOGEUSDT/DOGEUSDT-klines-2026-01.b1461ec0ea96fe535e72780b698471907136df72c97a360628c6b65ae6dd5cae.zip",
           "url": "https://data.binance.vision/data/futures/um/monthly/klines/DOGEUSDT/1m/DOGEUSDT-1m-2026-01.zip"
         },
         {
           "checksum_sha256": "2fa5c67037194c73e823abb111331334e07e5d4f0eaa6704fd879983971e8755",
           "checksum_url": "https://data.binance.vision/data/futures/um/monthly/klines/DOGEUSDT/1m/DOGEUSDT-1m-2026-02.zip.CHECKSUM",
+          "local_path": "raw/klines/DOGEUSDT/DOGEUSDT-klines-2026-02.2fa5c67037194c73e823abb111331334e07e5d4f0eaa6704fd879983971e8755.zip",
           "url": "https://data.binance.vision/data/futures/um/monthly/klines/DOGEUSDT/1m/DOGEUSDT-1m-2026-02.zip"
         },
         {
           "checksum_sha256": "ba4758aaa2fb1bd5be4f120d21cf5c94d7e315d38918080ee880b36dc60b7841",
           "checksum_url": "https://data.binance.vision/data/futures/um/monthly/klines/DOGEUSDT/1m/DOGEUSDT-1m-2026-03.zip.CHECKSUM",
+          "local_path": "raw/klines/DOGEUSDT/DOGEUSDT-klines-2026-03.ba4758aaa2fb1bd5be4f120d21cf5c94d7e315d38918080ee880b36dc60b7841.zip",
           "url": "https://data.binance.vision/data/futures/um/monthly/klines/DOGEUSDT/1m/DOGEUSDT-1m-2026-03.zip"
         },
         {
           "checksum_sha256": "31a8edfd1f029e3ee08d7824b6352e898828cc8d3e2c71b7cd02b3c9b2637bf5",
           "checksum_url": "https://data.binance.vision/data/futures/um/monthly/klines/DOGEUSDT/1m/DOGEUSDT-1m-2026-04.zip.CHECKSUM",
+          "local_path": "raw/klines/DOGEUSDT/DOGEUSDT-klines-2026-04.31a8edfd1f029e3ee08d7824b6352e898828cc8d3e2c71b7cd02b3c9b2637bf5.zip",
           "url": "https://data.binance.vision/data/futures/um/monthly/klines/DOGEUSDT/1m/DOGEUSDT-1m-2026-04.zip"
         },
         {
           "checksum_sha256": "109a1d0020c4710c1aa86b8773795b21326d038d795b224e1758bf9091c4e110",
           "checksum_url": "https://data.binance.vision/data/futures/um/monthly/klines/DOGEUSDT/1m/DOGEUSDT-1m-2026-05.zip.CHECKSUM",
+          "local_path": "raw/klines/DOGEUSDT/DOGEUSDT-klines-2026-05.109a1d0020c4710c1aa86b8773795b21326d038d795b224e1758bf9091c4e110.zip",
           "url": "https://data.binance.vision/data/futures/um/monthly/klines/DOGEUSDT/1m/DOGEUSDT-1m-2026-05.zip"
         },
         {
           "checksum_sha256": "90b1a9a55146505876a5b0469b69e8606194b018beec06094be8b4babd37c8b4",
           "checksum_url": "https://data.binance.vision/data/futures/um/monthly/klines/DOGEUSDT/1m/DOGEUSDT-1m-2026-06.zip.CHECKSUM",
+          "local_path": "raw/klines/DOGEUSDT/DOGEUSDT-klines-2026-06.90b1a9a55146505876a5b0469b69e8606194b018beec06094be8b4babd37c8b4.zip",
           "url": "https://data.binance.vision/data/futures/um/monthly/klines/DOGEUSDT/1m/DOGEUSDT-1m-2026-06.zip"
         }
       ],
@@ -521,69 +617,83 @@
       "min_open_time_ms": 1751328000000,
       "normalized_shard_sha256": "26bed8cc351e40c35eda1636eef518fae613cc16713a0d3a206f08e95288c5c4",
       "row_count": 525600,
+      "shard_file_sha256": "f6405ee6c99c7ece8e005067753b2b5772482d1f307aa41f5e94124ec3819a03",
+      "shard_path": "shards/klines/DOGEUSDT-1m.26bed8cc351e40c35eda1636eef518fae613cc16713a0d3a206f08e95288c5c4.parquet",
       "symbol": "DOGEUSDT",
-      "transform_version": "rob941_corpus.v1"
+      "transform_version": "rob941_corpus.v2"
     },
     {
       "archives": [
         {
           "checksum_sha256": "6a11ec2b081657fd4850b61cb1f28e2217913ac1a309c484169f080733320ee7",
           "checksum_url": "https://data.binance.vision/data/futures/um/monthly/klines/SOLUSDT/1m/SOLUSDT-1m-2025-07.zip.CHECKSUM",
+          "local_path": "raw/klines/SOLUSDT/SOLUSDT-klines-2025-07.6a11ec2b081657fd4850b61cb1f28e2217913ac1a309c484169f080733320ee7.zip",
           "url": "https://data.binance.vision/data/futures/um/monthly/klines/SOLUSDT/1m/SOLUSDT-1m-2025-07.zip"
         },
         {
           "checksum_sha256": "9916be68e1e354b1d2ad30e09ca2f0552ddbf9a3ad64d2854bd54016463b56a6",
           "checksum_url": "https://data.binance.vision/data/futures/um/monthly/klines/SOLUSDT/1m/SOLUSDT-1m-2025-08.zip.CHECKSUM",
+          "local_path": "raw/klines/SOLUSDT/SOLUSDT-klines-2025-08.9916be68e1e354b1d2ad30e09ca2f0552ddbf9a3ad64d2854bd54016463b56a6.zip",
           "url": "https://data.binance.vision/data/futures/um/monthly/klines/SOLUSDT/1m/SOLUSDT-1m-2025-08.zip"
         },
         {
           "checksum_sha256": "389290c0c468d168ea3b327d926e273aa9de639249e5101f443360eda4456b4e",
           "checksum_url": "https://data.binance.vision/data/futures/um/monthly/klines/SOLUSDT/1m/SOLUSDT-1m-2025-09.zip.CHECKSUM",
+          "local_path": "raw/klines/SOLUSDT/SOLUSDT-klines-2025-09.389290c0c468d168ea3b327d926e273aa9de639249e5101f443360eda4456b4e.zip",
           "url": "https://data.binance.vision/data/futures/um/monthly/klines/SOLUSDT/1m/SOLUSDT-1m-2025-09.zip"
         },
         {
           "checksum_sha256": "66542f68d37e6b8b071997ea07fa495abc01d3762acbf6476398c63f79128016",
           "checksum_url": "https://data.binance.vision/data/futures/um/monthly/klines/SOLUSDT/1m/SOLUSDT-1m-2025-10.zip.CHECKSUM",
+          "local_path": "raw/klines/SOLUSDT/SOLUSDT-klines-2025-10.66542f68d37e6b8b071997ea07fa495abc01d3762acbf6476398c63f79128016.zip",
           "url": "https://data.binance.vision/data/futures/um/monthly/klines/SOLUSDT/1m/SOLUSDT-1m-2025-10.zip"
         },
         {
           "checksum_sha256": "dbadf06d740261c21299abc82f3adeae1b41e4dbbcee8a5adca3e761f1896ce7",
           "checksum_url": "https://data.binance.vision/data/futures/um/monthly/klines/SOLUSDT/1m/SOLUSDT-1m-2025-11.zip.CHECKSUM",
+          "local_path": "raw/klines/SOLUSDT/SOLUSDT-klines-2025-11.dbadf06d740261c21299abc82f3adeae1b41e4dbbcee8a5adca3e761f1896ce7.zip",
           "url": "https://data.binance.vision/data/futures/um/monthly/klines/SOLUSDT/1m/SOLUSDT-1m-2025-11.zip"
         },
         {
           "checksum_sha256": "c9375b066069aaa4dbf33fbf7c79ca9db4a534b99d4ebd9f558ba2381e610636",
           "checksum_url": "https://data.binance.vision/data/futures/um/monthly/klines/SOLUSDT/1m/SOLUSDT-1m-2025-12.zip.CHECKSUM",
+          "local_path": "raw/klines/SOLUSDT/SOLUSDT-klines-2025-12.c9375b066069aaa4dbf33fbf7c79ca9db4a534b99d4ebd9f558ba2381e610636.zip",
           "url": "https://data.binance.vision/data/futures/um/monthly/klines/SOLUSDT/1m/SOLUSDT-1m-2025-12.zip"
         },
         {
           "checksum_sha256": "ac9cc536ec056e7c4fc4f391da5edbe778f59fb2a059670875d05285ebca3fcf",
           "checksum_url": "https://data.binance.vision/data/futures/um/monthly/klines/SOLUSDT/1m/SOLUSDT-1m-2026-01.zip.CHECKSUM",
+          "local_path": "raw/klines/SOLUSDT/SOLUSDT-klines-2026-01.ac9cc536ec056e7c4fc4f391da5edbe778f59fb2a059670875d05285ebca3fcf.zip",
           "url": "https://data.binance.vision/data/futures/um/monthly/klines/SOLUSDT/1m/SOLUSDT-1m-2026-01.zip"
         },
         {
           "checksum_sha256": "ad93c921265eb4a473ba91d21f8d02346d77330475740977cc7541a0ac1ec05a",
           "checksum_url": "https://data.binance.vision/data/futures/um/monthly/klines/SOLUSDT/1m/SOLUSDT-1m-2026-02.zip.CHECKSUM",
+          "local_path": "raw/klines/SOLUSDT/SOLUSDT-klines-2026-02.ad93c921265eb4a473ba91d21f8d02346d77330475740977cc7541a0ac1ec05a.zip",
           "url": "https://data.binance.vision/data/futures/um/monthly/klines/SOLUSDT/1m/SOLUSDT-1m-2026-02.zip"
         },
         {
           "checksum_sha256": "d705ca5ec2de775733be12c6e3f29bcf3204be15d7b0b273ec87a013fcaa612f",
           "checksum_url": "https://data.binance.vision/data/futures/um/monthly/klines/SOLUSDT/1m/SOLUSDT-1m-2026-03.zip.CHECKSUM",
+          "local_path": "raw/klines/SOLUSDT/SOLUSDT-klines-2026-03.d705ca5ec2de775733be12c6e3f29bcf3204be15d7b0b273ec87a013fcaa612f.zip",
           "url": "https://data.binance.vision/data/futures/um/monthly/klines/SOLUSDT/1m/SOLUSDT-1m-2026-03.zip"
         },
         {
           "checksum_sha256": "8ce6bb0ea598eecdfa2078cc1429c7fc4fc39a32d306d74184f137fa6ae8d3cb",
           "checksum_url": "https://data.binance.vision/data/futures/um/monthly/klines/SOLUSDT/1m/SOLUSDT-1m-2026-04.zip.CHECKSUM",
+          "local_path": "raw/klines/SOLUSDT/SOLUSDT-klines-2026-04.8ce6bb0ea598eecdfa2078cc1429c7fc4fc39a32d306d74184f137fa6ae8d3cb.zip",
           "url": "https://data.binance.vision/data/futures/um/monthly/klines/SOLUSDT/1m/SOLUSDT-1m-2026-04.zip"
         },
         {
           "checksum_sha256": "588bdc611885c6de2bd55df7f8fbc597147ca0eef33f6824e340d2bff1a04066",
           "checksum_url": "https://data.binance.vision/data/futures/um/monthly/klines/SOLUSDT/1m/SOLUSDT-1m-2026-05.zip.CHECKSUM",
+          "local_path": "raw/klines/SOLUSDT/SOLUSDT-klines-2026-05.588bdc611885c6de2bd55df7f8fbc597147ca0eef33f6824e340d2bff1a04066.zip",
           "url": "https://data.binance.vision/data/futures/um/monthly/klines/SOLUSDT/1m/SOLUSDT-1m-2026-05.zip"
         },
         {
           "checksum_sha256": "dcd12574ab820047a10c3e6977b69251b7285fe7998fa7aff6d73470c6637ecd",
           "checksum_url": "https://data.binance.vision/data/futures/um/monthly/klines/SOLUSDT/1m/SOLUSDT-1m-2026-06.zip.CHECKSUM",
+          "local_path": "raw/klines/SOLUSDT/SOLUSDT-klines-2026-06.dcd12574ab820047a10c3e6977b69251b7285fe7998fa7aff6d73470c6637ecd.zip",
           "url": "https://data.binance.vision/data/futures/um/monthly/klines/SOLUSDT/1m/SOLUSDT-1m-2026-06.zip"
         }
       ],
@@ -593,8 +703,10 @@
       "min_open_time_ms": 1751328000000,
       "normalized_shard_sha256": "0dbad131fcfbf7aa3b02f685d2099a9ccd060b38b8c69edd271520eec6b0c2f9",
       "row_count": 525600,
+      "shard_file_sha256": "1385c41fb3c4baaa9c81f363771f735b43b6dbda3167cde861b2def410d902ab",
+      "shard_path": "shards/klines/SOLUSDT-1m.0dbad131fcfbf7aa3b02f685d2099a9ccd060b38b8c69edd271520eec6b0c2f9.parquet",
       "symbol": "SOLUSDT",
-      "transform_version": "rob941_corpus.v1"
+      "transform_version": "rob941_corpus.v2"
     }
   ],
   "universe": [

--- a/research/nautilus_scalping/rob941_archive_fetch.py
+++ b/research/nautilus_scalping/rob941_archive_fetch.py
@@ -74,17 +74,26 @@ class ArchiveProvenance:
     The single canonical definition (``rob941_manifest`` re-exports this, it does
     not redefine it) so a value produced by the fetch layer is always the same
     type the manifest layer serializes.
+
+    ``local_path`` (ROB-941 R1 I1 remediation) is the artifact-root-relative
+    POSIX path where the checksum-verified raw ``.zip`` was persisted by
+    ``rob941_persistence.write_raw_archive`` — ``None`` when the archive was
+    only fetched in-memory (the default for every fixture/unit test and for
+    ``build_symbol_kline_shard``/``build_symbol_funding_shard`` called without
+    a ``raw_archive_sink``).
     """
 
     url: str
     checksum_url: str
     checksum_sha256: str
+    local_path: str | None = None
 
     def to_dict(self) -> dict:
         return {
             "url": self.url,
             "checksum_url": self.checksum_url,
             "checksum_sha256": self.checksum_sha256,
+            "local_path": self.local_path,
         }
 
     @classmethod
@@ -93,6 +102,7 @@ class ArchiveProvenance:
             url=d["url"],
             checksum_url=d["checksum_url"],
             checksum_sha256=d["checksum_sha256"],
+            local_path=d.get("local_path"),
         )
 
 
@@ -103,11 +113,12 @@ class FetchedArchive:
     checksum_url: str
     checksum_sha256: str  # verified to match the downloaded zip_bytes
 
-    def provenance(self) -> ArchiveProvenance:
+    def provenance(self, local_path: str | None = None) -> ArchiveProvenance:
         return ArchiveProvenance(
             url=self.url,
             checksum_url=self.checksum_url,
             checksum_sha256=self.checksum_sha256,
+            local_path=local_path,
         )
 
 

--- a/research/nautilus_scalping/rob941_archive_fetch.py
+++ b/research/nautilus_scalping/rob941_archive_fetch.py
@@ -1,0 +1,170 @@
+"""ROB-941 (AC1/AC4) — checksum-MANDATORY Binance public archive fetch.
+
+Unlike ``pit_klines_fetcher`` (best-effort checksum: an archive is accepted
+un-verified when its ``.CHECKSUM`` sidecar happens to be absent), the ROB-941
+historical corpus is fail-closed end to end: a missing archive, a missing
+checksum, a checksum mismatch, a corrupt ZIP, or a corrupt/non-UTF8 CSV member
+all abort the build for that shard. Only ``data.binance.vision`` public URLs are
+built here — no keys, no auth, no order endpoints.
+
+The network I/O is a single injectable ``opener`` (``url -> bytes | None``,
+``None`` meaning a confirmed-missing/404 URL) so every fail-closed path is unit-
+testable with an in-memory fixture table; the default ``urllib_opener`` is only
+exercised by the opt-in live test.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import urllib.error
+import urllib.request
+import zipfile
+from collections.abc import Callable
+from dataclasses import dataclass
+
+BASE = "https://data.binance.vision/data"
+
+Opener = Callable[[str], "bytes | None"]
+
+
+class ArchiveMissingError(RuntimeError):
+    """The archive ZIP itself does not exist upstream (404)."""
+
+
+class ChecksumMissingError(RuntimeError):
+    """The mandatory ``.CHECKSUM`` sidecar is absent — fail-closed, never skip verification."""
+
+
+class ChecksumMismatchError(RuntimeError):
+    """The downloaded ZIP's SHA-256 does not match its published ``.CHECKSUM``."""
+
+
+class CorruptArchiveError(RuntimeError):
+    """The ZIP is unreadable, does not contain exactly one member, or the member is not valid UTF-8."""
+
+
+def urllib_opener(url: str, timeout: int = 60) -> bytes | None:
+    """Real network opener: returns bytes, ``None`` for a 404, raises otherwise."""
+    try:
+        with urllib.request.urlopen(url, timeout=timeout) as resp:  # noqa: S310 (public data.binance.vision only)
+            return resp.read()
+    except urllib.error.HTTPError as exc:
+        if exc.code == 404:
+            return None
+        raise
+
+
+def kline_archive_url(
+    symbol: str, interval: str, year: int, month: int, market: str = "um"
+) -> str:
+    stem = f"{symbol}-{interval}-{year:04d}-{month:02d}"
+    return f"{BASE}/futures/{market}/monthly/klines/{symbol}/{interval}/{stem}.zip"
+
+
+def funding_archive_url(symbol: str, year: int, month: int, market: str = "um") -> str:
+    stem = f"{symbol}-fundingRate-{year:04d}-{month:02d}"
+    return f"{BASE}/futures/{market}/monthly/fundingRate/{symbol}/{stem}.zip"
+
+
+@dataclass(frozen=True)
+class ArchiveProvenance:
+    """Upstream URL + verified checksum for one archive — persisted in the manifest.
+
+    The single canonical definition (``rob941_manifest`` re-exports this, it does
+    not redefine it) so a value produced by the fetch layer is always the same
+    type the manifest layer serializes.
+    """
+
+    url: str
+    checksum_url: str
+    checksum_sha256: str
+
+    def to_dict(self) -> dict:
+        return {
+            "url": self.url,
+            "checksum_url": self.checksum_url,
+            "checksum_sha256": self.checksum_sha256,
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict) -> ArchiveProvenance:
+        return cls(
+            url=d["url"],
+            checksum_url=d["checksum_url"],
+            checksum_sha256=d["checksum_sha256"],
+        )
+
+
+@dataclass(frozen=True)
+class FetchedArchive:
+    url: str
+    zip_bytes: bytes
+    checksum_url: str
+    checksum_sha256: str  # verified to match the downloaded zip_bytes
+
+    def provenance(self) -> ArchiveProvenance:
+        return ArchiveProvenance(
+            url=self.url,
+            checksum_url=self.checksum_url,
+            checksum_sha256=self.checksum_sha256,
+        )
+
+
+def _sha256(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def fetch_verified_archive(url: str, opener: Opener = urllib_opener) -> FetchedArchive:
+    """Download ``url`` and its mandatory ``.CHECKSUM`` sidecar; verify SHA-256.
+
+    Fail-closed: missing archive -> ``ArchiveMissingError``; missing checksum
+    sidecar -> ``ChecksumMissingError`` (never silently skip verification);
+    mismatch -> ``ChecksumMismatchError``.
+    """
+    zip_bytes = opener(url)
+    if zip_bytes is None:
+        raise ArchiveMissingError(f"archive not found: {url}")
+    checksum_url = f"{url}.CHECKSUM"
+    checksum_bytes = opener(checksum_url)
+    if checksum_bytes is None:
+        raise ChecksumMissingError(
+            f"missing mandatory .CHECKSUM sidecar: {checksum_url}"
+        )
+    expected = checksum_bytes.decode().split()[0].strip().lower()
+    actual = _sha256(zip_bytes)
+    if actual != expected:
+        raise ChecksumMismatchError(
+            f"checksum mismatch for {url}: expected {expected}, got {actual}"
+        )
+    return FetchedArchive(
+        url=url,
+        zip_bytes=zip_bytes,
+        checksum_url=checksum_url,
+        checksum_sha256=expected,
+    )
+
+
+def extract_single_csv(zip_bytes: bytes) -> str:
+    """Extract the single CSV member of a Binance archive ZIP as UTF-8 text.
+
+    Fail-closed on a corrupt ZIP, an unexpected member count, or non-UTF8 content
+    — never silently pick a member or replace undecodable bytes.
+    """
+    try:
+        with zipfile.ZipFile(io.BytesIO(zip_bytes)) as zf:
+            names = zf.namelist()
+            if len(names) != 1:
+                raise CorruptArchiveError(
+                    f"expected exactly 1 member in archive, found {len(names)}: {names}"
+                )
+            with zf.open(names[0]) as fh:
+                raw = fh.read()
+    except zipfile.BadZipFile as exc:
+        raise CorruptArchiveError(f"corrupt ZIP: {exc}") from exc
+    try:
+        return raw.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise CorruptArchiveError(
+            f"corrupt CSV member (not valid UTF-8): {exc}"
+        ) from exc

--- a/research/nautilus_scalping/rob941_corpus_builder.py
+++ b/research/nautilus_scalping/rob941_corpus_builder.py
@@ -1,0 +1,83 @@
+"""ROB-941 — corpus builder orchestration: fetch -> checksum -> extract -> normalize
+-> gap-detect, per symbol, across the frozen 12-month window.
+
+Pure orchestration over the fetch/schema/gaps layers; the ``opener`` is
+injectable so the default test suite never touches the network (see
+``tests/test_rob941_corpus_builder.py``). The live path (``build_rob941_corpus.py``,
+operator-gated behind ``--run``) passes the real ``rob941_archive_fetch.urllib_opener``.
+
+Zero broker/order/fill/scheduler wiring and zero DB access by construction — this
+module imports only the ``rob941_*`` data layer plus the existing pure
+``funding_oi_archive`` parser (enforced structurally by
+``tests/test_rob941_corpus_builder.py::test_corpus_builder_module_has_no_broker_order_or_db_imports``
+and by the shared ``test_pit_data_layer_guard.py`` no-``app``-import guard).
+"""
+
+from __future__ import annotations
+
+import rob941_archive_fetch as af
+import rob941_frozen_scope as frozen
+import rob941_gaps as gaps
+import rob941_kline_schema as ks
+from funding_oi_archive import FundingRow, parse_funding_csv
+
+
+def build_symbol_kline_shard(
+    symbol: str, interval: str = "1m", opener: af.Opener = af.urllib_opener
+) -> tuple[list[ks.NormalizedKline], list[af.ArchiveProvenance], list[tuple[int, int]]]:
+    """Fetch+verify+normalize every frozen-window monthly kline archive for
+    ``symbol``, merging months into one sorted, deduped, gap-accounted shard.
+
+    A checksum mismatch/missing archive/corrupt ZIP/invalid OHLCV/conflicting
+    duplicate anywhere in the window aborts the WHOLE symbol build (fail-closed;
+    no partial silent corpus).
+    """
+    merged: dict[int, ks.NormalizedKline] = {}
+    provenance: list[af.ArchiveProvenance] = []
+    for year, month in frozen.months_in_window():
+        url = af.kline_archive_url(symbol, interval, year, month)
+        fetched = af.fetch_verified_archive(url, opener=opener)
+        csv_text = af.extract_single_csv(fetched.zip_bytes)
+        month_rows = ks.parse_kline_csv(
+            symbol, csv_text, frozen.WINDOW_START_MS, frozen.WINDOW_END_MS
+        )
+        for row in month_rows:
+            existing = merged.get(row.open_time_ms)
+            if existing is not None and existing != row:
+                raise ks.ConflictingDuplicateError(
+                    f"{symbol}@{row.open_time_ms}: conflicting duplicate rows across monthly archives"
+                )
+            merged[row.open_time_ms] = row
+        provenance.append(fetched.provenance())
+
+    ordered = [merged[t] for t in sorted(merged)]
+    gap_ranges = gaps.detect_gap_ranges(
+        [r.open_time_ms for r in ordered], frozen.WINDOW_START_MS, frozen.WINDOW_END_MS
+    )
+    return ordered, provenance, gap_ranges
+
+
+def build_symbol_funding_shard(
+    symbol: str, opener: af.Opener = af.urllib_opener
+) -> tuple[list[FundingRow], list[af.ArchiveProvenance]]:
+    """Fetch+verify+normalize every frozen-window monthly fundingRate archive
+    for ``symbol``, merging months into one sorted, deduped, window-clipped shard."""
+    merged: dict[int, FundingRow] = {}
+    provenance: list[af.ArchiveProvenance] = []
+    for year, month in frozen.months_in_window():
+        url = af.funding_archive_url(symbol, year, month)
+        fetched = af.fetch_verified_archive(url, opener=opener)
+        csv_text = af.extract_single_csv(fetched.zip_bytes)
+        for row in parse_funding_csv(csv_text):
+            if not (frozen.WINDOW_START_MS <= row.calc_time < frozen.WINDOW_END_MS):
+                continue
+            existing = merged.get(row.calc_time)
+            if existing is not None and existing != row:
+                raise ks.ConflictingDuplicateError(
+                    f"{symbol}@{row.calc_time}: conflicting duplicate funding rows across monthly archives"
+                )
+            merged[row.calc_time] = row
+        provenance.append(fetched.provenance())
+
+    ordered = [merged[t] for t in sorted(merged)]
+    return ordered, provenance

--- a/research/nautilus_scalping/rob941_corpus_builder.py
+++ b/research/nautilus_scalping/rob941_corpus_builder.py
@@ -15,15 +15,29 @@ and by the shared ``test_pit_data_layer_guard.py`` no-``app``-import guard).
 
 from __future__ import annotations
 
+from collections.abc import Callable
+
 import rob941_archive_fetch as af
 import rob941_frozen_scope as frozen
 import rob941_gaps as gaps
 import rob941_kline_schema as ks
 from funding_oi_archive import FundingRow, parse_funding_csv
 
+# ROB-941 R1 I1 remediation: an injectable sink so the live materialize path
+# (build_rob941_corpus.py) can persist each checksum-verified raw archive as it
+# is fetched, without making this pure fetch/normalize orchestration layer
+# itself do disk I/O (and without breaking its existing network-0 fixture
+# tests, which never pass a sink -- default ``None`` keeps prior memory-only
+# behavior byte-for-byte). ``(symbol, kind, year, month, zip_bytes) ->
+# artifact-root-relative POSIX path``.
+RawArchiveSink = Callable[[str, str, int, int, bytes], str]
+
 
 def build_symbol_kline_shard(
-    symbol: str, interval: str = "1m", opener: af.Opener = af.urllib_opener
+    symbol: str,
+    interval: str = "1m",
+    opener: af.Opener = af.urllib_opener,
+    raw_archive_sink: RawArchiveSink | None = None,
 ) -> tuple[list[ks.NormalizedKline], list[af.ArchiveProvenance], list[tuple[int, int]]]:
     """Fetch+verify+normalize every frozen-window monthly kline archive for
     ``symbol``, merging months into one sorted, deduped, gap-accounted shard.
@@ -48,7 +62,12 @@ def build_symbol_kline_shard(
                     f"{symbol}@{row.open_time_ms}: conflicting duplicate rows across monthly archives"
                 )
             merged[row.open_time_ms] = row
-        provenance.append(fetched.provenance())
+        local_path = (
+            raw_archive_sink(symbol, "klines", year, month, fetched.zip_bytes)
+            if raw_archive_sink is not None
+            else None
+        )
+        provenance.append(fetched.provenance(local_path=local_path))
 
     ordered = [merged[t] for t in sorted(merged)]
     gap_ranges = gaps.detect_gap_ranges(
@@ -58,7 +77,9 @@ def build_symbol_kline_shard(
 
 
 def build_symbol_funding_shard(
-    symbol: str, opener: af.Opener = af.urllib_opener
+    symbol: str,
+    opener: af.Opener = af.urllib_opener,
+    raw_archive_sink: RawArchiveSink | None = None,
 ) -> tuple[list[FundingRow], list[af.ArchiveProvenance]]:
     """Fetch+verify+normalize every frozen-window monthly fundingRate archive
     for ``symbol``, merging months into one sorted, deduped, window-clipped shard."""
@@ -77,7 +98,12 @@ def build_symbol_funding_shard(
                     f"{symbol}@{row.calc_time}: conflicting duplicate funding rows across monthly archives"
                 )
             merged[row.calc_time] = row
-        provenance.append(fetched.provenance())
+        local_path = (
+            raw_archive_sink(symbol, "fundingRate", year, month, fetched.zip_bytes)
+            if raw_archive_sink is not None
+            else None
+        )
+        provenance.append(fetched.provenance(local_path=local_path))
 
     ordered = [merged[t] for t in sorted(merged)]
     return ordered, provenance

--- a/research/nautilus_scalping/rob941_frozen_scope.py
+++ b/research/nautilus_scalping/rob941_frozen_scope.py
@@ -1,0 +1,69 @@
+"""ROB-941 (AC2/AC3) — frozen universe + UTC half-open window (D1 approved 2026-07-17).
+
+Single source of truth other rob941_* modules and the manifest consult. These
+constants are literal, not derived from the current wall-clock time — the
+window never tracks "latest". Editing them after a manifest/campaign has been
+built starts a new lineage (the manifest's ``content_hash`` changes); this
+module is not meant to be tuned per-run.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+WINDOW_START_ISO = "2025-07-01T00:00:00Z"
+WINDOW_END_ISO = "2026-07-01T00:00:00Z"  # exclusive
+
+
+def _iso_to_epoch_ms(iso: str) -> int:
+    dt = datetime.strptime(iso, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=UTC)
+    return int(dt.timestamp() * 1000)
+
+
+WINDOW_START_MS = _iso_to_epoch_ms(WINDOW_START_ISO)
+WINDOW_END_MS = _iso_to_epoch_ms(WINDOW_END_ISO)  # exclusive
+
+# BTCUSDT/XRPUSDT/DOGEUSDT/SOLUSDT, frozen order (ROB-941 AC2).
+UNIVERSE: tuple[str, ...] = ("BTCUSDT", "XRPUSDT", "DOGEUSDT", "SOLUSDT")
+
+BTC_INELIGIBLE_REASON = "min_notional_50_exceeds_demo_cap_10"
+
+
+def eligibility(symbol: str) -> dict:
+    """Demo-execution eligibility record for ``symbol`` (ROB-941 AC2).
+
+    BTC is ``historical_only``/demo-ineligible with a fixed reason (MIN_NOTIONAL
+    50 exceeds the $6-10 demo notional cap); the other 3 frozen symbols are
+    demo-eligible. Any symbol outside the frozen universe is a caller error.
+    """
+    if symbol not in UNIVERSE:
+        raise ValueError(f"{symbol!r} is not in the frozen universe {UNIVERSE}")
+    if symbol == "BTCUSDT":
+        return {
+            "historical_only": True,
+            "demo_execution_eligible": False,
+            "reason": BTC_INELIGIBLE_REASON,
+        }
+    return {
+        "historical_only": False,
+        "demo_execution_eligible": True,
+        "reason": None,
+    }
+
+
+def months_in_window() -> list[tuple[int, int]]:
+    """The 12 calendar (year, month) pairs the half-open window spans exactly.
+
+    ``WINDOW_START_ISO``/``WINDOW_END_ISO`` are both month boundaries, so this
+    is a closed set of full calendar months (no partial-month archive needed).
+    """
+    start = datetime.strptime(WINDOW_START_ISO, "%Y-%m-%dT%H:%M:%SZ").replace(
+        tzinfo=UTC
+    )
+    end = datetime.strptime(WINDOW_END_ISO, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=UTC)
+    months: list[tuple[int, int]] = []
+    y, m = start.year, start.month
+    while (y, m) < (end.year, end.month):
+        months.append((y, m))
+        y, m = (y + 1, 1) if m == 12 else (y, m + 1)
+    return months

--- a/research/nautilus_scalping/rob941_funding_sidecar.py
+++ b/research/nautilus_scalping/rob941_funding_sidecar.py
@@ -1,0 +1,56 @@
+"""ROB-941 (AC8) — PIT-safe funding-rate sidecar query API.
+
+Wraps parsed ``funding_oi_archive.FundingRow`` sequences with point-in-time
+query semantics only — no PnL/dollar computation happens here (that belongs to
+the execution engine consuming this data):
+
+- ``last_known_rate(ts_ms)``: the entry-gate contract. Never returns a row whose
+  ``calc_time`` is in the caller's future; a row becomes visible AT (not before)
+  its own ``calc_time``, matching ``funding_oi_archive``'s "known only at/after
+  calc_time" invariant.
+- ``realized_crossings(entry_ms, exit_ms)``: the PnL contract. Returns only the
+  funding events that actually occur strictly inside a held position's window
+  (``entry_ms <= calc_time < exit_ms``) — realized crossings only, never a
+  future event the position hasn't reached yet.
+"""
+
+from __future__ import annotations
+
+import bisect
+from collections.abc import Iterable
+from dataclasses import dataclass
+
+from funding_oi_archive import FundingRow
+
+
+@dataclass(frozen=True)
+class FundingSidecar:
+    symbol: str
+    rows: tuple[FundingRow, ...]  # sorted ascending by calc_time, conflict-free
+
+    @classmethod
+    def from_rows(cls, symbol: str, rows: Iterable[FundingRow]) -> FundingSidecar:
+        ordered = tuple(sorted(rows, key=lambda r: r.calc_time))
+        for a, b in zip(ordered, ordered[1:], strict=False):
+            if a.calc_time == b.calc_time and a != b:
+                raise ValueError(
+                    f"{symbol}: conflicting duplicate funding rows at calc_time={a.calc_time}"
+                )
+        return cls(symbol=symbol, rows=ordered)
+
+    def last_known_rate(self, ts_ms: int) -> FundingRow | None:
+        """Most recent row with ``calc_time <= ts_ms``; ``None`` before any data."""
+        times = [r.calc_time for r in self.rows]
+        idx = bisect.bisect_right(times, ts_ms) - 1
+        return self.rows[idx] if idx >= 0 else None
+
+    def realized_crossings(
+        self, entry_ts_ms: int, exit_ts_ms: int
+    ) -> tuple[FundingRow, ...]:
+        """Funding events realized while held: ``entry_ts_ms <= calc_time < exit_ts_ms``."""
+        if exit_ts_ms <= entry_ts_ms:
+            return ()
+        times = [r.calc_time for r in self.rows]
+        lo = bisect.bisect_left(times, entry_ts_ms)
+        hi = bisect.bisect_left(times, exit_ts_ms)
+        return self.rows[lo:hi]

--- a/research/nautilus_scalping/rob941_gaps.py
+++ b/research/nautilus_scalping/rob941_gaps.py
@@ -1,0 +1,69 @@
+"""ROB-941 (AC7) — gap tracking: never delete/forward-fill/synthesize, only record.
+
+``detect_gap_ranges`` finds every missing 60s bucket in a symbol's window and
+returns it as an explicit ``(start_ms, end_ms)`` range — the caller must treat
+the range as absent data, never fabricate a value for it. ``incomplete_buckets``
+marks any 5m/15m aggregate a gap touches as incomplete (never synthesized from
+partial 1m coverage). ``position_touches_gap`` is the pure predicate a trial-
+rejection rule (``rejected:data_gap_in_position``) consumes; this module does
+not itself reject trials.
+"""
+
+from __future__ import annotations
+
+GRID_MS = 60_000
+
+
+def detect_gap_ranges(
+    open_time_ms_observed: list[int], window_start_ms: int, window_end_ms: int
+) -> list[tuple[int, int]]:
+    """Sorted, merged ``[start_ms, end_ms)`` ranges of missing 60s buckets in
+    ``[window_start_ms, window_end_ms)``. Never fills/interpolates — the only
+    output is the hole's boundaries."""
+    observed = set(open_time_ms_observed)
+    ranges: list[tuple[int, int]] = []
+    t = window_start_ms
+    while t < window_end_ms:
+        if t not in observed:
+            if ranges and ranges[-1][1] == t:
+                ranges[-1] = (ranges[-1][0], t + GRID_MS)
+            else:
+                ranges.append((t, t + GRID_MS))
+        t += GRID_MS
+    return ranges
+
+
+def incomplete_buckets(
+    open_time_ms_observed: list[int],
+    window_start_ms: int,
+    window_end_ms: int,
+    bucket_seconds: int,
+) -> list[int]:
+    """``bucket_start_ms`` values (5m: 300, 15m: 900) NOT fully covered by 1m
+    bars — every such bucket is incomplete and must never be synthesized from
+    partial coverage."""
+    bucket_ms = bucket_seconds * 1000
+    if bucket_ms % GRID_MS != 0:
+        raise ValueError(
+            f"bucket_seconds={bucket_seconds} must be a whole multiple of 60s"
+        )
+    slots_per_bucket = bucket_ms // GRID_MS
+    observed = set(open_time_ms_observed)
+    out: list[int] = []
+    bucket_start = window_start_ms
+    while bucket_start < window_end_ms:
+        complete = all(
+            (bucket_start + i * GRID_MS) in observed for i in range(slots_per_bucket)
+        )
+        if not complete:
+            out.append(bucket_start)
+        bucket_start += bucket_ms
+    return out
+
+
+def position_touches_gap(
+    entry_ms: int, exit_ms: int, gap_ranges: list[tuple[int, int]]
+) -> bool:
+    """True iff ``[entry_ms, exit_ms)`` overlaps ANY gap range — the pure
+    predicate behind ``rejected:data_gap_in_position``."""
+    return any(entry_ms < g1 and g0 < exit_ms for g0, g1 in gap_ranges)

--- a/research/nautilus_scalping/rob941_kline_schema.py
+++ b/research/nautilus_scalping/rob941_kline_schema.py
@@ -15,6 +15,16 @@ rows (same timestamp, different content) also fail closed; byte-identical
 duplicates are deduped. Rows outside the caller's ``[window_start_ms,
 window_end_ms)`` are silently clipped (not a gap — just out of scope), never
 deleted/forward-filled/synthesized for rows INSIDE the window.
+
+AC5 footnote (R1 M1, not changed by design): "unterminated bars are excluded"
+is implemented here as a fail-closed ``raise`` (``InvalidOHLCVError`` on a
+duration != 59999ms), not a silent skip. This is strictly MORE conservative
+than exclude, and never actually fires on real data in this corpus: Binance's
+monthly historical archives only ever contain fully-closed bars, and the
+frozen half-open window (``rob941_frozen_scope``) already excludes the
+in-progress "current" bar by construction. The raise exists as a fail-closed
+guard against a corrupt/truncated archive, not as the exclude mechanism AC5
+describes for a live/streaming context.
 """
 
 from __future__ import annotations

--- a/research/nautilus_scalping/rob941_kline_schema.py
+++ b/research/nautilus_scalping/rob941_kline_schema.py
@@ -1,0 +1,150 @@
+"""ROB-941 (AC4/AC5) — normalized 1m kline schema + fail-closed validation.
+
+Real Binance USD-M kline CSV columns (confirmed via a live probe of
+``BTCUSDT-1m-2025-07.csv``, header present in current archives):
+
+    open_time,open,high,low,close,volume,close_time,quote_volume,count,
+    taker_buy_volume,taker_buy_quote_volume,ignore
+
+Every real row observed has ``close_time - open_time == 59999`` and
+``open_time`` aligned to the 60000ms UTC grid. This module fails closed (raises)
+on: malformed columns, non-positive/inconsistent OHLC, negative volume/trade
+count, a taker-buy volume exceeding total volume, off-grid ``open_time``, and a
+bar duration other than exactly 59999ms. Conflicting duplicate ``open_time``
+rows (same timestamp, different content) also fail closed; byte-identical
+duplicates are deduped. Rows outside the caller's ``[window_start_ms,
+window_end_ms)`` are silently clipped (not a gap — just out of scope), never
+deleted/forward-filled/synthesized for rows INSIDE the window.
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+from dataclasses import dataclass
+
+GRID_MS = 60_000
+_EXPECTED_DURATION_MS = (
+    GRID_MS - 1
+)  # 59999ms, Binance convention (close_time is inclusive-end - 1ms)
+_HEADER_TOKEN = "open_time"
+_EPS = 1e-6
+
+
+class InvalidOHLCVError(ValueError):
+    """A row's fields are structurally/economically impossible, or its bar duration
+    or grid alignment is wrong — fail-closed, never coerced or dropped silently."""
+
+
+class ConflictingDuplicateError(ValueError):
+    """Two rows share ``open_time_ms`` but disagree on content — fail-closed."""
+
+
+@dataclass(frozen=True)
+class NormalizedKline:
+    symbol: str
+    open_time_ms: int
+    open: float
+    high: float
+    low: float
+    close: float
+    base_volume: float
+    close_time_ms: int
+    quote_volume: float
+    trade_count: int
+    taker_buy_volume: float
+    taker_buy_quote_volume: float
+
+
+def parse_kline_row(symbol: str, fields: list[str]) -> NormalizedKline:
+    if len(fields) < 11:
+        raise InvalidOHLCVError(
+            f"{symbol}: expected >=11 kline columns, got {len(fields)}: {fields!r}"
+        )
+
+    open_time_ms = int(fields[0])
+    open_ = float(fields[1])
+    high = float(fields[2])
+    low = float(fields[3])
+    close = float(fields[4])
+    base_volume = float(fields[5])
+    close_time_ms = int(fields[6])
+    quote_volume = float(fields[7])
+    trade_count = int(float(fields[8]))
+    taker_buy_volume = float(fields[9])
+    taker_buy_quote_volume = float(fields[10])
+
+    if open_time_ms % GRID_MS != 0:
+        raise InvalidOHLCVError(
+            f"{symbol}@{open_time_ms}: open_time_ms is not 60s-grid aligned"
+        )
+    duration_ms = close_time_ms - open_time_ms
+    if duration_ms != _EXPECTED_DURATION_MS:
+        raise InvalidOHLCVError(
+            f"{symbol}@{open_time_ms}: bar duration {duration_ms}ms != expected "
+            f"{_EXPECTED_DURATION_MS}ms — corrupt or unterminated bar"
+        )
+    if not (open_ > 0 and high > 0 and low > 0 and close > 0):
+        raise InvalidOHLCVError(f"{symbol}@{open_time_ms}: non-positive OHLC price")
+    if high < low:
+        raise InvalidOHLCVError(f"{symbol}@{open_time_ms}: high < low")
+    if high < open_ or high < close:
+        raise InvalidOHLCVError(f"{symbol}@{open_time_ms}: high below open/close")
+    if low > open_ or low > close:
+        raise InvalidOHLCVError(f"{symbol}@{open_time_ms}: low above open/close")
+    if base_volume < 0 or quote_volume < 0 or trade_count < 0:
+        raise InvalidOHLCVError(f"{symbol}@{open_time_ms}: negative volume/trade_count")
+    if taker_buy_volume < -_EPS or taker_buy_volume > base_volume + _EPS:
+        raise InvalidOHLCVError(
+            f"{symbol}@{open_time_ms}: taker_buy_volume out of [0, base_volume]"
+        )
+    if taker_buy_quote_volume < -_EPS or taker_buy_quote_volume > quote_volume + _EPS:
+        raise InvalidOHLCVError(
+            f"{symbol}@{open_time_ms}: taker_buy_quote_volume out of [0, quote_volume]"
+        )
+
+    return NormalizedKline(
+        symbol=symbol,
+        open_time_ms=open_time_ms,
+        open=open_,
+        high=high,
+        low=low,
+        close=close,
+        base_volume=base_volume,
+        close_time_ms=close_time_ms,
+        quote_volume=quote_volume,
+        trade_count=trade_count,
+        taker_buy_volume=taker_buy_volume,
+        taker_buy_quote_volume=taker_buy_quote_volume,
+    )
+
+
+def parse_kline_csv(
+    symbol: str, text: str, window_start_ms: int, window_end_ms: int
+) -> list[NormalizedKline]:
+    """Parse a decompressed monthly kline CSV into sorted, deduped, window-clipped rows.
+
+    Rows outside ``[window_start_ms, window_end_ms)`` are clipped silently (out of
+    the frozen corpus scope). Conflicting duplicate ``open_time_ms`` rows raise;
+    byte-identical duplicates are deduped.
+    """
+    seen: dict[int, NormalizedKline] = {}
+    order: list[int] = []
+    for row_fields in csv.reader(io.StringIO(text)):
+        if not row_fields:
+            continue
+        if row_fields[0].strip().lower() == _HEADER_TOKEN:
+            continue
+        row = parse_kline_row(symbol, row_fields)
+        if row.open_time_ms < window_start_ms or row.open_time_ms >= window_end_ms:
+            continue
+        existing = seen.get(row.open_time_ms)
+        if existing is not None:
+            if existing != row:
+                raise ConflictingDuplicateError(
+                    f"{symbol}@{row.open_time_ms}: conflicting duplicate rows"
+                )
+            continue  # identical duplicate -> dedupe
+        seen[row.open_time_ms] = row
+        order.append(row.open_time_ms)
+    return [seen[t] for t in sorted(order)]

--- a/research/nautilus_scalping/rob941_manifest.py
+++ b/research/nautilus_scalping/rob941_manifest.py
@@ -207,10 +207,19 @@ class CorpusManifest:
                 f"manifest window [{self.window_start_iso}, {self.window_end_iso}) deviates from "
                 f"frozen scope [{frozen.WINDOW_START_ISO}, {frozen.WINDOW_END_ISO})"
             )
-        if set(self.universe) != set(frozen.UNIVERSE):
+        # Captain review (pre-R2 narrow integrity correction): exact tuple
+        # equality, not set() equality. set(self.universe) == set(frozen.UNIVERSE)
+        # is true even when self.universe has a duplicate entry (as long as the
+        # DISTINCT symbols present still equal the frozen 4) or is reordered --
+        # every manifest-producing call site in this codebase constructs
+        # universe=frozen.UNIVERSE verbatim, so canonical order+count IS the
+        # deterministic contract, not merely "the right symbols appear
+        # somewhere". This single comparison catches duplicate/missing/extra/
+        # reordered in one shot.
+        if self.universe != frozen.UNIVERSE:
             raise ValueError(
-                f"manifest universe {sorted(self.universe)} deviates from frozen universe "
-                f"{sorted(frozen.UNIVERSE)}"
+                f"manifest universe {list(self.universe)} deviates from frozen "
+                f"universe {list(frozen.UNIVERSE)} (exactly once each, canonical order)"
             )
         # R1 I1 loader-hardening follow-up: exactly one kline + one funding
         # entry per frozen symbol -- no duplicate/missing/extra. A duplicate
@@ -227,6 +236,20 @@ class CorpusManifest:
             raise ValueError(
                 f"manifest funding covers {funding_symbols}, expected exactly "
                 f"{sorted(frozen.UNIVERSE)} (no duplicate/missing/extra)"
+            )
+        # Captain review: coverage BEFORE per-entry value checks. The old code
+        # only ever looped over whatever entries WERE present and checked their
+        # VALUES -- a missing symbol was invisible (nothing to iterate), and a
+        # duplicate entry for one symbol substituted in place of a missing one
+        # was invisible too (every present entry individually value-matches its
+        # own claimed symbol). Exact-tuple coverage, checked first, catches
+        # both before any per-entry value comparison runs.
+        eligibility_symbols = tuple(e.symbol for e in self.eligibility)
+        if eligibility_symbols != frozen.UNIVERSE:
+            raise ValueError(
+                f"manifest eligibility symbols {list(eligibility_symbols)} deviate "
+                f"from frozen universe {list(frozen.UNIVERSE)} (exactly once each, "
+                f"canonical order)"
             )
         for e in self.eligibility:
             expected = frozen.eligibility(e.symbol)

--- a/research/nautilus_scalping/rob941_manifest.py
+++ b/research/nautilus_scalping/rob941_manifest.py
@@ -1,0 +1,204 @@
+"""ROB-941 (AC2/AC3/AC6) — the immutable historical-data corpus manifest.
+
+The single citable artifact H4/H6 consume: per symbol, exactly which upstream
+archives were checksum-verified (URL + sha256), what the normalized shard
+hashes to, its row/gap accounting, and the frozen universe/window/eligibility
+scope. ``content_hash`` uses the same canonical, collision-free identity
+authority as ``research_contracts`` (via the local ``canonical_hash`` shim) so
+the manifest's identity is reproducible and any field change is detectable —
+that is the immutability enforcement mechanism, not a promise.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+import canonical_hash
+import rob941_frozen_scope as frozen
+from rob941_archive_fetch import (
+    ArchiveProvenance,  # re-exported: single canonical definition
+)
+
+__all__ = [
+    "ArchiveProvenance",
+    "CorpusManifest",
+    "SymbolEligibility",
+    "SymbolFundingManifest",
+    "SymbolKlineManifest",
+]
+
+TRANSFORM_VERSION = "rob941_corpus.v1"
+
+
+@dataclass(frozen=True)
+class SymbolKlineManifest:
+    symbol: str
+    interval: str
+    archives: tuple[ArchiveProvenance, ...]
+    normalized_shard_sha256: str
+    row_count: int
+    min_open_time_ms: int
+    max_open_time_ms: int
+    gap_ranges: tuple[tuple[int, int], ...]
+    transform_version: str = TRANSFORM_VERSION
+
+    def to_dict(self) -> dict:
+        return {
+            "symbol": self.symbol,
+            "interval": self.interval,
+            "archives": [a.to_dict() for a in self.archives],
+            "normalized_shard_sha256": self.normalized_shard_sha256,
+            "row_count": self.row_count,
+            "min_open_time_ms": self.min_open_time_ms,
+            "max_open_time_ms": self.max_open_time_ms,
+            "gap_ranges": [list(g) for g in self.gap_ranges],
+            "transform_version": self.transform_version,
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict) -> SymbolKlineManifest:
+        return cls(
+            symbol=d["symbol"],
+            interval=d["interval"],
+            archives=tuple(ArchiveProvenance.from_dict(a) for a in d["archives"]),
+            normalized_shard_sha256=d["normalized_shard_sha256"],
+            row_count=d["row_count"],
+            min_open_time_ms=d["min_open_time_ms"],
+            max_open_time_ms=d["max_open_time_ms"],
+            gap_ranges=tuple(tuple(g) for g in d["gap_ranges"]),
+            transform_version=d.get("transform_version", TRANSFORM_VERSION),
+        )
+
+
+@dataclass(frozen=True)
+class SymbolFundingManifest:
+    symbol: str
+    archives: tuple[ArchiveProvenance, ...]
+    normalized_shard_sha256: str
+    row_count: int
+    min_calc_time_ms: int | None
+    max_calc_time_ms: int | None
+    transform_version: str = TRANSFORM_VERSION
+
+    def to_dict(self) -> dict:
+        return {
+            "symbol": self.symbol,
+            "archives": [a.to_dict() for a in self.archives],
+            "normalized_shard_sha256": self.normalized_shard_sha256,
+            "row_count": self.row_count,
+            "min_calc_time_ms": self.min_calc_time_ms,
+            "max_calc_time_ms": self.max_calc_time_ms,
+            "transform_version": self.transform_version,
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict) -> SymbolFundingManifest:
+        return cls(
+            symbol=d["symbol"],
+            archives=tuple(ArchiveProvenance.from_dict(a) for a in d["archives"]),
+            normalized_shard_sha256=d["normalized_shard_sha256"],
+            row_count=d["row_count"],
+            min_calc_time_ms=d["min_calc_time_ms"],
+            max_calc_time_ms=d["max_calc_time_ms"],
+            transform_version=d.get("transform_version", TRANSFORM_VERSION),
+        )
+
+
+@dataclass(frozen=True)
+class SymbolEligibility:
+    symbol: str
+    historical_only: bool
+    demo_execution_eligible: bool
+    reason: str | None
+
+    def to_dict(self) -> dict:
+        return {
+            "symbol": self.symbol,
+            "historical_only": self.historical_only,
+            "demo_execution_eligible": self.demo_execution_eligible,
+            "reason": self.reason,
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict) -> SymbolEligibility:
+        return cls(
+            symbol=d["symbol"],
+            historical_only=d["historical_only"],
+            demo_execution_eligible=d["demo_execution_eligible"],
+            reason=d.get("reason"),
+        )
+
+
+@dataclass(frozen=True)
+class CorpusManifest:
+    window_start_iso: str
+    window_end_iso: str
+    universe: tuple[str, ...]
+    eligibility: tuple[SymbolEligibility, ...]
+    klines: tuple[SymbolKlineManifest, ...]
+    funding: tuple[SymbolFundingManifest, ...]
+
+    def to_dict(self) -> dict:
+        return {
+            "window_start_iso": self.window_start_iso,
+            "window_end_iso": self.window_end_iso,
+            "universe": list(self.universe),
+            "eligibility": [e.to_dict() for e in self.eligibility],
+            "klines": [k.to_dict() for k in self.klines],
+            "funding": [f.to_dict() for f in self.funding],
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict) -> CorpusManifest:
+        return cls(
+            window_start_iso=d["window_start_iso"],
+            window_end_iso=d["window_end_iso"],
+            universe=tuple(d["universe"]),
+            eligibility=tuple(SymbolEligibility.from_dict(e) for e in d["eligibility"]),
+            klines=tuple(SymbolKlineManifest.from_dict(k) for k in d["klines"]),
+            funding=tuple(SymbolFundingManifest.from_dict(f) for f in d["funding"]),
+        )
+
+    def content_hash(self) -> str:
+        """Immutable identity: canonical SHA-256 over the full manifest content."""
+        return canonical_hash.canonical_sha256(self.to_dict())
+
+    def save(self, path: str | Path) -> None:
+        path = Path(path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(self.to_dict(), indent=2, sort_keys=True))
+
+    @classmethod
+    def load(cls, path: str | Path) -> CorpusManifest:
+        return cls.from_dict(json.loads(Path(path).read_text()))
+
+    def validate_frozen_scope(self) -> None:
+        """Raise if window/universe/eligibility deviate from ``rob941_frozen_scope``
+        — the manifest must describe exactly the D1-D9 approved scope."""
+        if (
+            self.window_start_iso != frozen.WINDOW_START_ISO
+            or self.window_end_iso != frozen.WINDOW_END_ISO
+        ):
+            raise ValueError(
+                f"manifest window [{self.window_start_iso}, {self.window_end_iso}) deviates from "
+                f"frozen scope [{frozen.WINDOW_START_ISO}, {frozen.WINDOW_END_ISO})"
+            )
+        if set(self.universe) != set(frozen.UNIVERSE):
+            raise ValueError(
+                f"manifest universe {sorted(self.universe)} deviates from frozen universe "
+                f"{sorted(frozen.UNIVERSE)}"
+            )
+        for e in self.eligibility:
+            expected = frozen.eligibility(e.symbol)
+            actual = (e.historical_only, e.demo_execution_eligible, e.reason)
+            expected_tuple = (
+                expected["historical_only"],
+                expected["demo_execution_eligible"],
+                expected["reason"],
+            )
+            if actual != expected_tuple:
+                raise ValueError(
+                    f"{e.symbol}: manifest eligibility {actual} deviates from frozen scope {expected_tuple}"
+                )

--- a/research/nautilus_scalping/rob941_manifest.py
+++ b/research/nautilus_scalping/rob941_manifest.py
@@ -7,6 +7,13 @@ scope. ``content_hash`` uses the same canonical, collision-free identity
 authority as ``research_contracts`` (via the local ``canonical_hash`` shim) so
 the manifest's identity is reproducible and any field change is detectable —
 that is the immutability enforcement mechanism, not a promise.
+
+ROB-941 R1 I1 remediation: ``shard_path``/``shard_file_sha256`` point at the
+actual persisted Parquet shard (``rob941_persistence.write_kline_shard``/
+``write_funding_shard``, under ``artifact_paths.pit_data_root()``) so H4/H6 can
+``rob941_offline_loader.load_corpus`` this manifest with zero network — the
+manifest alone is a fingerprint, but manifest + artifact root is the whole
+reproducible corpus.
 """
 
 from __future__ import annotations
@@ -29,7 +36,7 @@ __all__ = [
     "SymbolKlineManifest",
 ]
 
-TRANSFORM_VERSION = "rob941_corpus.v1"
+TRANSFORM_VERSION = "rob941_corpus.v2"  # v2 (R1 I1 remediation): shard_path/shard_file_sha256 persist the derived corpus, not just its fingerprint
 
 
 @dataclass(frozen=True)
@@ -43,6 +50,11 @@ class SymbolKlineManifest:
     max_open_time_ms: int
     gap_ranges: tuple[tuple[int, int], ...]
     transform_version: str = TRANSFORM_VERSION
+    # ROB-941 R1 I1: artifact-root-relative POSIX path to the persisted Parquet
+    # shard + its physical file SHA-256 (distinct from normalized_shard_sha256,
+    # the SEMANTIC canonical row-content hash) -- both required for offline load.
+    shard_path: str | None = None
+    shard_file_sha256: str | None = None
 
     def to_dict(self) -> dict:
         return {
@@ -55,6 +67,8 @@ class SymbolKlineManifest:
             "max_open_time_ms": self.max_open_time_ms,
             "gap_ranges": [list(g) for g in self.gap_ranges],
             "transform_version": self.transform_version,
+            "shard_path": self.shard_path,
+            "shard_file_sha256": self.shard_file_sha256,
         }
 
     @classmethod
@@ -69,6 +83,8 @@ class SymbolKlineManifest:
             max_open_time_ms=d["max_open_time_ms"],
             gap_ranges=tuple(tuple(g) for g in d["gap_ranges"]),
             transform_version=d.get("transform_version", TRANSFORM_VERSION),
+            shard_path=d.get("shard_path"),
+            shard_file_sha256=d.get("shard_file_sha256"),
         )
 
 
@@ -81,6 +97,8 @@ class SymbolFundingManifest:
     min_calc_time_ms: int | None
     max_calc_time_ms: int | None
     transform_version: str = TRANSFORM_VERSION
+    shard_path: str | None = None
+    shard_file_sha256: str | None = None
 
     def to_dict(self) -> dict:
         return {
@@ -91,6 +109,8 @@ class SymbolFundingManifest:
             "min_calc_time_ms": self.min_calc_time_ms,
             "max_calc_time_ms": self.max_calc_time_ms,
             "transform_version": self.transform_version,
+            "shard_path": self.shard_path,
+            "shard_file_sha256": self.shard_file_sha256,
         }
 
     @classmethod
@@ -103,6 +123,8 @@ class SymbolFundingManifest:
             min_calc_time_ms=d["min_calc_time_ms"],
             max_calc_time_ms=d["max_calc_time_ms"],
             transform_version=d.get("transform_version", TRANSFORM_VERSION),
+            shard_path=d.get("shard_path"),
+            shard_file_sha256=d.get("shard_file_sha256"),
         )
 
 
@@ -189,6 +211,22 @@ class CorpusManifest:
             raise ValueError(
                 f"manifest universe {sorted(self.universe)} deviates from frozen universe "
                 f"{sorted(frozen.UNIVERSE)}"
+            )
+        # R1 I1 loader-hardening follow-up: exactly one kline + one funding
+        # entry per frozen symbol -- no duplicate/missing/extra. A duplicate
+        # symbol would otherwise silently collapse in load_corpus's
+        # symbol-keyed dict without ever raising.
+        kline_symbols = sorted(k.symbol for k in self.klines)
+        if kline_symbols != sorted(frozen.UNIVERSE):
+            raise ValueError(
+                f"manifest klines cover {kline_symbols}, expected exactly "
+                f"{sorted(frozen.UNIVERSE)} (no duplicate/missing/extra)"
+            )
+        funding_symbols = sorted(f.symbol for f in self.funding)
+        if funding_symbols != sorted(frozen.UNIVERSE):
+            raise ValueError(
+                f"manifest funding covers {funding_symbols}, expected exactly "
+                f"{sorted(frozen.UNIVERSE)} (no duplicate/missing/extra)"
             )
         for e in self.eligibility:
             expected = frozen.eligibility(e.symbol)

--- a/research/nautilus_scalping/rob941_offline_loader.py
+++ b/research/nautilus_scalping/rob941_offline_loader.py
@@ -1,0 +1,304 @@
+"""ROB-941 (AC6, R1 I1 remediation) — offline, network-0 loader for the
+persisted corpus.
+
+Given only a ``CorpusManifest`` and the ``artifact_root`` it was materialized
+under (``artifact_paths.pit_data_root()``), H4/H6 can load every symbol's 1m
+kline + funding rows with ZERO network access. This module imports no network
+opener (enforced structurally by
+``tests/test_rob941_offline_loader.py::test_offline_loader_module_never_imports_urllib_or_network_openers``)
+and never touches ``rob941_archive_fetch.urllib_opener``.
+
+Fail-closed verification chain, per symbol shard (``load_kline_shard``/
+``load_funding_shard``): every raw archive's local path/existence/physical
+SHA-256 -> derived-shard path traversal -> file existence -> physical file
+SHA-256 -> EXACT Parquet schema (field names, types, nullability, and order —
+not names alone) -> canonical row-content hash -> row count/min/max. At the
+corpus level (``load_corpus``, ``ultrathink`` captain review): exactly one
+kline + one funding entry per frozen symbol and window/universe/eligibility
+(``CorpusManifest.validate_frozen_scope``), every loaded row's timestamp
+inside the frozen half-open window, and a from-scratch recomputation of each
+symbol's ``gap_ranges`` that must equal the manifest's declared value. Every
+failure mode raises a distinct, stable ``ShardLoadError`` subclass — tamper,
+missing data, and a wrong artifact root are never confused with a generic
+exception.
+
+Per-symbol vs. corpus-level split is deliberate: ``load_kline_shard``/
+``load_funding_shard`` only have that ONE symbol's manifest in hand, so they
+verify everything self-contained to it (including its own raw archives).
+Window-membership and gap-range recomputation need the shared corpus window
+and reuse ``rob941_gaps`` (the same algorithm ``rob941_corpus_builder`` used to
+produce the manifest in the first place), so they live in ``load_corpus``,
+the entry point H4/H6 actually call.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import canonical_hash
+import pyarrow.parquet as pq
+import rob941_frozen_scope as frozen
+import rob941_gaps as gaps
+import rob941_kline_schema as ks
+import rob941_persistence as persist
+from funding_oi_archive import FundingRow
+from rob941_manifest import (
+    ArchiveProvenance,
+    CorpusManifest,
+    SymbolFundingManifest,
+    SymbolKlineManifest,
+)
+
+
+class ShardLoadError(RuntimeError):
+    """Base class for every offline-load fail-closed rejection."""
+
+
+class ShardPathEscapesArtifactRootError(ShardLoadError):
+    """A ``shard_path``/archive ``local_path`` is absolute or resolves outside
+    ``artifact_root`` — refused before any file I/O, never followed."""
+
+
+class ShardFileMissingError(ShardLoadError):
+    """The manifest has no ``shard_path`` (never materialized), or the file it
+    names is absent on disk."""
+
+
+class ShardFileTamperedError(ShardLoadError):
+    """The on-disk shard file's SHA-256 does not match ``shard_file_sha256``."""
+
+
+class ShardSchemaMismatchError(ShardLoadError):
+    """The Parquet file's schema (field names, types, nullability, or order)
+    does not exactly match the pinned schema — a names-only match is not
+    sufficient (a tampered file could keep names but change types)."""
+
+
+class ShardContentTamperedError(ShardLoadError):
+    """The file's bytes are intact, but the decoded rows' canonical content hash
+    does not match ``normalized_shard_sha256`` — the manifest's semantic-content
+    pin and the file's actual content have diverged."""
+
+
+class ShardRowCountMismatchError(ShardLoadError):
+    """Decoded row count does not match the manifest's declared ``row_count``."""
+
+
+class ShardTimeRangeMismatchError(ShardLoadError):
+    """Decoded min/max timestamp does not match the manifest's declared bound."""
+
+
+class ArchiveFileMissingError(ShardLoadError):
+    """A raw archive's manifest ``local_path`` is ``None`` (never materialized),
+    or the file it names is absent on disk."""
+
+
+class ArchiveFileTamperedError(ShardLoadError):
+    """A raw archive's on-disk SHA-256 does not match its manifest-recorded,
+    already-verified ``checksum_sha256``."""
+
+
+class ShardWindowViolationError(ShardLoadError):
+    """A loaded row's timestamp lies outside the corpus's frozen half-open
+    window — the manifest's own declared min/max can be internally consistent
+    and still violate the corpus-level window contract."""
+
+
+class ShardGapRangesMismatchError(ShardLoadError):
+    """Recomputing gap ranges from the loaded rows (the same algorithm that
+    produced the manifest at build time) does not reproduce the manifest's
+    declared ``gap_ranges`` — the declared gaps and the actual data disagree."""
+
+
+def _resolve_within_root(artifact_root: Path, relative_path: str) -> Path:
+    root = artifact_root.resolve()
+    candidate = (root / relative_path).resolve()
+    if candidate != root and root not in candidate.parents:
+        raise ShardPathEscapesArtifactRootError(
+            f"path {relative_path!r} escapes artifact root {root}"
+        )
+    return candidate
+
+
+def verify_archives(
+    archives: tuple[ArchiveProvenance, ...], artifact_root: Path, *, symbol: str
+) -> None:
+    """Fail-closed offline verification of every raw archive a shard cites:
+    path traversal -> file existence -> physical SHA-256 == the archive's own
+    already-verified ``checksum_sha256``. Network-0; never re-fetches."""
+    for a in archives:
+        if a.local_path is None:
+            raise ArchiveFileMissingError(
+                f"{symbol}: archive {a.url!r} has no local_path (never materialized)"
+            )
+        path = _resolve_within_root(artifact_root, a.local_path)
+        if not path.is_file():
+            raise ArchiveFileMissingError(
+                f"{symbol}: archive file missing at {path} (url={a.url!r})"
+            )
+        actual = persist.sha256_file(path)
+        if actual != a.checksum_sha256:
+            raise ArchiveFileTamperedError(
+                f"{symbol}: archive {a.local_path!r} SHA-256 mismatch "
+                f"(expected {a.checksum_sha256}, got {actual})"
+            )
+
+
+def load_kline_shard(
+    manifest: SymbolKlineManifest, artifact_root: Path
+) -> list[ks.NormalizedKline]:
+    """Load+verify one symbol's kline shard fully offline. Raises a
+    ``ShardLoadError`` subclass on any tamper/missing/mismatch condition."""
+    verify_archives(manifest.archives, artifact_root, symbol=manifest.symbol)
+
+    if manifest.shard_path is None:
+        raise ShardFileMissingError(
+            f"{manifest.symbol}: manifest has no shard_path (never materialized)"
+        )
+    path = _resolve_within_root(artifact_root, manifest.shard_path)
+    if not path.is_file():
+        raise ShardFileMissingError(f"{manifest.symbol}: shard file missing at {path}")
+
+    actual_file_sha256 = persist.sha256_file(path)
+    if actual_file_sha256 != manifest.shard_file_sha256:
+        raise ShardFileTamperedError(
+            f"{manifest.symbol}: shard file SHA-256 mismatch "
+            f"(expected {manifest.shard_file_sha256}, got {actual_file_sha256})"
+        )
+
+    table = pq.read_table(path)
+    if not table.schema.equals(persist.KLINE_SCHEMA, check_metadata=False):
+        raise ShardSchemaMismatchError(
+            f"{manifest.symbol}: shard schema {table.schema} != expected "
+            f"{persist.KLINE_SCHEMA}"
+        )
+    rows = [ks.NormalizedKline(**d) for d in table.to_pylist()]
+
+    actual_row_hash = canonical_hash.canonical_sha256([r.__dict__ for r in rows])
+    if actual_row_hash != manifest.normalized_shard_sha256:
+        raise ShardContentTamperedError(
+            f"{manifest.symbol}: normalized row-content hash mismatch "
+            f"(expected {manifest.normalized_shard_sha256}, got {actual_row_hash})"
+        )
+
+    if len(rows) != manifest.row_count:
+        raise ShardRowCountMismatchError(
+            f"{manifest.symbol}: row_count mismatch (manifest={manifest.row_count}, "
+            f"loaded={len(rows)})"
+        )
+    if rows and (
+        rows[0].open_time_ms != manifest.min_open_time_ms
+        or rows[-1].open_time_ms != manifest.max_open_time_ms
+    ):
+        raise ShardTimeRangeMismatchError(
+            f"{manifest.symbol}: min/max open_time_ms mismatch "
+            f"(manifest=[{manifest.min_open_time_ms}, {manifest.max_open_time_ms}], "
+            f"loaded=[{rows[0].open_time_ms}, {rows[-1].open_time_ms}])"
+        )
+    return rows
+
+
+def load_funding_shard(
+    manifest: SymbolFundingManifest, artifact_root: Path
+) -> list[FundingRow]:
+    """Load+verify one symbol's PIT funding shard fully offline. Same fail-closed
+    chain as :func:`load_kline_shard`."""
+    verify_archives(manifest.archives, artifact_root, symbol=manifest.symbol)
+
+    if manifest.shard_path is None:
+        raise ShardFileMissingError(
+            f"{manifest.symbol}: manifest has no shard_path (never materialized)"
+        )
+    path = _resolve_within_root(artifact_root, manifest.shard_path)
+    if not path.is_file():
+        raise ShardFileMissingError(f"{manifest.symbol}: shard file missing at {path}")
+
+    actual_file_sha256 = persist.sha256_file(path)
+    if actual_file_sha256 != manifest.shard_file_sha256:
+        raise ShardFileTamperedError(
+            f"{manifest.symbol}: shard file SHA-256 mismatch "
+            f"(expected {manifest.shard_file_sha256}, got {actual_file_sha256})"
+        )
+
+    table = pq.read_table(path)
+    if not table.schema.equals(persist.FUNDING_SCHEMA, check_metadata=False):
+        raise ShardSchemaMismatchError(
+            f"{manifest.symbol}: funding shard schema {table.schema} != expected "
+            f"{persist.FUNDING_SCHEMA}"
+        )
+    rows = [FundingRow(**d) for d in table.to_pylist()]
+
+    actual_row_hash = canonical_hash.canonical_sha256([r.__dict__ for r in rows])
+    if actual_row_hash != manifest.normalized_shard_sha256:
+        raise ShardContentTamperedError(
+            f"{manifest.symbol}: funding normalized row-content hash mismatch"
+        )
+
+    if len(rows) != manifest.row_count:
+        raise ShardRowCountMismatchError(
+            f"{manifest.symbol}: funding row_count mismatch "
+            f"(manifest={manifest.row_count}, loaded={len(rows)})"
+        )
+    if rows and (
+        rows[0].calc_time != manifest.min_calc_time_ms
+        or rows[-1].calc_time != manifest.max_calc_time_ms
+    ):
+        raise ShardTimeRangeMismatchError(
+            f"{manifest.symbol}: funding min/max calc_time mismatch"
+        )
+    return rows
+
+
+def load_corpus(manifest: CorpusManifest, artifact_root: Path) -> dict:
+    """Load+verify all symbols' kline+funding shards fully offline.
+
+    ``validate_frozen_scope()`` runs first (cheap, structural window/universe/
+    eligibility/exact-symbol-coverage check) so a tampered corpus-level
+    manifest fails fast before any shard I/O; every per-shard load still runs
+    its own full fail-closed chain (including its raw archives). On top of
+    that, every loaded row's timestamp is checked against the frozen window,
+    and each symbol's kline gap_ranges is independently recomputed from the
+    loaded rows (``rob941_gaps.detect_gap_ranges``, the same algorithm used at
+    build time) and compared against the manifest's declared value.
+    """
+    manifest.validate_frozen_scope()
+
+    klines: dict[str, list[ks.NormalizedKline]] = {}
+    for k in manifest.klines:
+        rows = load_kline_shard(k, artifact_root)
+        if not all(
+            frozen.WINDOW_START_MS <= r.open_time_ms < frozen.WINDOW_END_MS
+            for r in rows
+        ):
+            raise ShardWindowViolationError(
+                f"{k.symbol}: a loaded kline row's open_time_ms lies outside the "
+                f"frozen window [{frozen.WINDOW_START_MS}, {frozen.WINDOW_END_MS})"
+            )
+        recomputed_gaps = tuple(
+            gaps.detect_gap_ranges(
+                [r.open_time_ms for r in rows],
+                frozen.WINDOW_START_MS,
+                frozen.WINDOW_END_MS,
+            )
+        )
+        if recomputed_gaps != k.gap_ranges:
+            raise ShardGapRangesMismatchError(
+                f"{k.symbol}: recomputed gap_ranges != manifest.gap_ranges "
+                f"(recomputed {len(recomputed_gaps)} ranges, manifest declared "
+                f"{len(k.gap_ranges)})"
+            )
+        klines[k.symbol] = rows
+
+    funding: dict[str, list[FundingRow]] = {}
+    for f in manifest.funding:
+        frows = load_funding_shard(f, artifact_root)
+        if not all(
+            frozen.WINDOW_START_MS <= r.calc_time < frozen.WINDOW_END_MS for r in frows
+        ):
+            raise ShardWindowViolationError(
+                f"{f.symbol}: a loaded funding row's calc_time lies outside the "
+                f"frozen window [{frozen.WINDOW_START_MS}, {frozen.WINDOW_END_MS})"
+            )
+        funding[f.symbol] = frows
+
+    return {"klines": klines, "funding": funding}

--- a/research/nautilus_scalping/rob941_persistence.py
+++ b/research/nautilus_scalping/rob941_persistence.py
@@ -1,0 +1,206 @@
+"""ROB-941 (AC6, R1 I1 remediation) — persist raw archives + normalized Parquet
+shards under a gitignored artifact root.
+
+The verify-round finding (Important I1) was that the committed manifest only
+held a checksum + a normalized-shard SHA-256 *fingerprint*, never the actual
+derived bytes — H4/H6 could not load the corpus offline; they would have had
+to re-fetch and re-normalize 96 archives from the network to reproduce it.
+This module writes the checksum-verified raw ``.zip`` archives and the
+normalized kline/funding rows (as Parquet, ``pyarrow`` — already a pinned repo
+dependency) under ``artifact_paths.pit_data_root()`` (or
+``AUTO_TRADER_RESEARCH_ARTIFACT_ROOT`` when set), so the manifest + artifact
+root together are the whole reproducible corpus.
+
+Two distinct hashes are pinned per shard, deliberately not conflated:
+
+- ``normalized_shard_sha256`` (``rob941_manifest``): the SEMANTIC canonical
+  hash of the row *content* (``canonical_hash.canonical_sha256``) — stable
+  across re-writes, re-compression, or a different pyarrow version.
+- ``shard_file_sha256`` (this module): the PHYSICAL SHA-256 of the Parquet
+  file's bytes on disk — catches any tamper/corruption of the artifact itself,
+  independent of whether the logical content also happens to still decode.
+
+Schema/column order/compression are pinned explicitly here so the write is a
+deterministic *transform* (same rows -> same logical table); byte-identical
+files across machines/pyarrow versions are NOT claimed or required — each
+build computes and pins its own fresh ``shard_file_sha256``.
+
+``ultrathink`` (captain review, atomicity follow-up): every path this module
+hands out is CONTENT-ADDRESSED — the raw archive's own verified checksum, and
+the shard's semantic ``normalized_shard_sha256`` (a *row-content* hash, NOT a
+promise about the physical Parquet bytes a given pyarrow/compression version
+would produce), are embedded directly in the relative path (alongside a
+human-readable symbol/kind/year-month prefix for operator browsability). The
+safety guarantee this buys is NOT "same semantic content always serializes to
+byte-identical Parquet" (it may not, across pyarrow versions) — it is
+IMMUTABLE NO-OVERWRITE: ``write_kline_shard``/``write_funding_shard``/
+``write_raw_archive`` never touch a path that already has a file at it (an
+existence check short-circuits before any write), and whatever bytes actually
+end up on disk at that path are pinned by their own freshly-computed
+``shard_file_sha256``/verified archive checksum every time they're read back
+(``rob941_offline_loader``). So a rebuild can only ever (a) skip a path that
+already holds *some* file (never inspecting or overwriting it) or (b) write to
+a brand-new path for genuinely different content — either way, a prior, still-
+published manifest's referenced bytes are structurally never mutated. No
+separate generation/staging directory, temp-write, or rename is needed for the
+per-shard artifacts — only the single COMMITTED MANIFEST FILE needs an atomic
+publish step (``build_rob941_corpus._atomic_save``), since it is the only
+mutable pointer ("which shard hashes does the current corpus reference"). This
+also makes an identical rerun (same fixture/upstream bytes, same content
+hashes) reproduce the exact same relative paths and therefore the exact same
+manifest ``content_hash()`` — there is no time/random component anywhere in
+this path scheme, and no circularity (every hash a path is keyed on is
+computed from in-memory content BEFORE that path is ever built or written to).
+"""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+import canonical_hash
+import pyarrow as pa
+import pyarrow.parquet as pq
+import rob941_kline_schema as ks
+from funding_oi_archive import FundingRow
+
+_CHUNK = 1 << 20
+PARQUET_COMPRESSION = "zstd"
+
+KLINE_COLUMN_ORDER: tuple[str, ...] = (
+    "symbol",
+    "open_time_ms",
+    "open",
+    "high",
+    "low",
+    "close",
+    "base_volume",
+    "close_time_ms",
+    "quote_volume",
+    "trade_count",
+    "taker_buy_volume",
+    "taker_buy_quote_volume",
+)
+# nullable=False on every field: a NormalizedKline/FundingRow never carries a
+# None value, so a NULL appearing anywhere is itself a tamper/corruption signal
+# the loader's exact-schema check (types + nullability + order) must catch.
+KLINE_SCHEMA = pa.schema(
+    [
+        pa.field("symbol", pa.string(), nullable=False),
+        pa.field("open_time_ms", pa.int64(), nullable=False),
+        pa.field("open", pa.float64(), nullable=False),
+        pa.field("high", pa.float64(), nullable=False),
+        pa.field("low", pa.float64(), nullable=False),
+        pa.field("close", pa.float64(), nullable=False),
+        pa.field("base_volume", pa.float64(), nullable=False),
+        pa.field("close_time_ms", pa.int64(), nullable=False),
+        pa.field("quote_volume", pa.float64(), nullable=False),
+        pa.field("trade_count", pa.int64(), nullable=False),
+        pa.field("taker_buy_volume", pa.float64(), nullable=False),
+        pa.field("taker_buy_quote_volume", pa.float64(), nullable=False),
+    ]
+)
+
+FUNDING_COLUMN_ORDER: tuple[str, ...] = (
+    "calc_time",
+    "funding_interval_hours",
+    "last_funding_rate",
+)
+FUNDING_SCHEMA = pa.schema(
+    [
+        pa.field("calc_time", pa.int64(), nullable=False),
+        pa.field("funding_interval_hours", pa.int64(), nullable=False),
+        pa.field("last_funding_rate", pa.float64(), nullable=False),
+    ]
+)
+
+
+def sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(_CHUNK), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def raw_archive_relative_path(
+    symbol: str, kind: str, year: int, month: int, checksum_sha256: str
+) -> str:
+    """Content-addressed path for a persisted raw archive ``.zip``: the
+    archive's OWN verified checksum is embedded in the filename, so
+    byte-identical archives always resolve to the same path and any different
+    content lands at a different one. ``kind`` mirrors the upstream Binance
+    path segment (``klines``/``fundingRate``); ``year``/``month`` are kept as a
+    human-readable prefix only (not part of the address)."""
+    return (
+        f"raw/{kind}/{symbol}/"
+        f"{symbol}-{kind}-{year:04d}-{month:02d}.{checksum_sha256}.zip"
+    )
+
+
+def kline_shard_relative_path(
+    symbol: str, normalized_shard_sha256: str, interval: str = "1m"
+) -> str:
+    """Content-addressed: ``normalized_shard_sha256`` (the semantic canonical
+    row-content hash) is embedded in the filename."""
+    return f"shards/klines/{symbol}-{interval}.{normalized_shard_sha256}.parquet"
+
+
+def funding_shard_relative_path(symbol: str, normalized_shard_sha256: str) -> str:
+    return f"shards/funding/{symbol}-fundingRate.{normalized_shard_sha256}.parquet"
+
+
+def write_raw_archive(
+    artifact_root: Path, symbol: str, kind: str, year: int, month: int, zip_bytes: bytes
+) -> str:
+    """Persist the exact, already checksum-verified ``zip_bytes`` unmodified at
+    its content-addressed path. A pre-existing file at that path is BY
+    DEFINITION byte-identical (same checksum -> same path) and is left alone
+    (no redundant re-write). Returns the artifact-root-relative POSIX path."""
+    checksum = hashlib.sha256(zip_bytes).hexdigest()
+    rel = raw_archive_relative_path(symbol, kind, year, month, checksum)
+    dest = artifact_root / rel
+    if not dest.is_file():
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_bytes(zip_bytes)
+    return rel
+
+
+def write_kline_shard(
+    artifact_root: Path,
+    symbol: str,
+    rows: list[ks.NormalizedKline],
+    interval: str = "1m",
+) -> tuple[str, str]:
+    """Write normalized kline rows as Parquet at their content-addressed path
+    (skipped if already present -- same content, same path, by construction).
+    Returns ``(relative_path, file_sha256)``."""
+    content_hash = canonical_hash.canonical_sha256([r.__dict__ for r in rows])
+    rel = kline_shard_relative_path(symbol, content_hash, interval)
+    dest = artifact_root / rel
+    if not dest.is_file():
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        columns = {
+            name: [getattr(r, name) for r in rows] for name in KLINE_COLUMN_ORDER
+        }
+        table = pa.table(columns, schema=KLINE_SCHEMA)
+        pq.write_table(table, dest, compression=PARQUET_COMPRESSION)
+    return rel, sha256_file(dest)
+
+
+def write_funding_shard(
+    artifact_root: Path, symbol: str, rows: list[FundingRow]
+) -> tuple[str, str]:
+    """Write PIT funding rows as Parquet at their content-addressed path.
+    Returns ``(relative_path, file_sha256)``."""
+    content_hash = canonical_hash.canonical_sha256([r.__dict__ for r in rows])
+    rel = funding_shard_relative_path(symbol, content_hash)
+    dest = artifact_root / rel
+    if not dest.is_file():
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        columns = {
+            name: [getattr(r, name) for r in rows] for name in FUNDING_COLUMN_ORDER
+        }
+        table = pa.table(columns, schema=FUNDING_SCHEMA)
+        pq.write_table(table, dest, compression=PARQUET_COMPRESSION)
+    return rel, sha256_file(dest)

--- a/research/nautilus_scalping/tests/test_build_rob941_corpus.py
+++ b/research/nautilus_scalping/tests/test_build_rob941_corpus.py
@@ -1,0 +1,366 @@
+"""ROB-941 R1 I1 remediation — build_rob941_corpus.py CLI orchestration.
+
+Previously ``build_corpus()``/``main()`` had ZERO fixture coverage (only the
+opt-in live test touched them, always through the real ``af.urllib_opener``).
+This file closes that gap with a fully fixture-driven, network-0 exercise of:
+
+- materialize (raw archive + Parquet shard) writes under an injected
+  ``artifact_root``, threaded through every one of the 4 frozen symbols;
+- the atomic/fail-closed publish gate: ``build_corpus()`` re-verifies its own
+  output via ``rob941_offline_loader.load_corpus`` BEFORE returning, and
+  ``main()`` never writes/replaces the committed manifest path unless
+  ``build_corpus()`` returns successfully (a mid-build failure leaves any
+  prior committed manifest untouched -- no partial corpus is ever exposed as
+  complete).
+"""
+
+import hashlib
+import io
+import json
+import zipfile
+
+import build_rob941_corpus as cli
+import canonical_hash
+import pytest
+import rob941_archive_fetch as af
+import rob941_frozen_scope as scope
+import rob941_offline_loader as loader
+import rob941_persistence as persist
+from funding_oi_archive import FundingRow
+from rob941_kline_schema import NormalizedKline
+from rob941_manifest import (
+    CorpusManifest,
+    SymbolEligibility,
+    SymbolFundingManifest,
+    SymbolKlineManifest,
+)
+
+HEADER = "open_time,open,high,low,close,volume,close_time,quote_volume,count,taker_buy_volume,taker_buy_quote_volume,ignore\n"
+FUNDING_HEADER = "calc_time,funding_interval_hours,last_funding_rate\n"
+
+
+def _kline_row(open_time_ms: int) -> str:
+    close_time = open_time_ms + 59_999
+    return (
+        f"{open_time_ms},100.0,101.0,99.0,100.5,10.0,{close_time},1000.0,5,4.0,400.0,0"
+    )
+
+
+def _zip_and_checksum(name: str, content: str):
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr(name, content)
+    zb = buf.getvalue()
+    checksum = f"{hashlib.sha256(zb).hexdigest()}  {name}\n".encode()
+    return zb, checksum
+
+
+class _FakeFourSymbolUniverse:
+    """Tiny fixture opener covering all 4 frozen symbols x 12 months (5 bars
+    each) -- enough to exercise build_corpus() end to end without a real
+    network call or a slow full-size fixture."""
+
+    def __init__(self, symbols):
+        self.table: dict[str, bytes] = {}
+        for symbol in symbols:
+            self._populate_symbol(symbol)
+
+    def _populate_symbol(self, symbol):
+        months = scope.months_in_window()
+        for idx, (year, month) in enumerate(months):
+            month_start = scope.WINDOW_START_MS + idx * 10 * 60_000
+            url = af.kline_archive_url(symbol, "1m", year, month)
+            csv_name = f"{symbol}-1m-{year:04d}-{month:02d}.csv"
+            lines = [HEADER] + [
+                _kline_row(month_start + m * 60_000) + "\n" for m in range(5)
+            ]
+            zb, chk = _zip_and_checksum(csv_name, "".join(lines))
+            self.table[url] = zb
+            self.table[url + ".CHECKSUM"] = chk
+
+            fund_url = af.funding_archive_url(symbol, year, month)
+            fund_name = f"{symbol}-fundingRate-{year:04d}-{month:02d}.csv"
+            fund_text = FUNDING_HEADER + f"{month_start},8,0.0001\n"
+            fzb, fchk = _zip_and_checksum(fund_name, fund_text)
+            self.table[fund_url] = fzb
+            self.table[fund_url + ".CHECKSUM"] = fchk
+
+    def opener(self, url):
+        return self.table.get(url)
+
+
+def test_build_corpus_materializes_and_offline_reverifies_all_four_symbols(tmp_path):
+    fake = _FakeFourSymbolUniverse(scope.UNIVERSE)
+    manifest = cli.build_corpus(artifact_root=tmp_path, opener=fake.opener)
+
+    assert set(manifest.universe) == set(scope.UNIVERSE)
+    for k in manifest.klines:
+        assert k.shard_path is not None
+        assert (tmp_path / k.shard_path).is_file()
+        assert k.shard_file_sha256 is not None
+    for f in manifest.funding:
+        assert f.shard_path is not None
+        assert (tmp_path / f.shard_path).is_file()
+    for k in manifest.klines:
+        for a in k.archives:
+            assert a.local_path is not None, "raw archive must be materialized"
+            assert (tmp_path / a.local_path).is_file()
+
+    # build_corpus() must return a manifest that is ALSO independently, offline
+    # loadable (the exact gate it ran on itself before returning).
+    reloaded = loader.load_corpus(manifest, tmp_path)
+    assert set(reloaded["klines"]) == set(scope.UNIVERSE)
+    for symbol in scope.UNIVERSE:
+        assert len(reloaded["klines"][symbol]) == 60  # 12 months x 5 bars, no gaps
+
+
+def test_build_corpus_fails_closed_on_checksum_mismatch_without_publishing(tmp_path):
+    fake = _FakeFourSymbolUniverse(scope.UNIVERSE)
+    any_checksum_key = next(
+        k for k in fake.table if k.endswith(".CHECKSUM") and "klines" in k
+    )
+    fake.table[any_checksum_key] = b"0" * 64 + b"  corrupt.csv\n"
+    with pytest.raises(af.ChecksumMismatchError):
+        cli.build_corpus(artifact_root=tmp_path, opener=fake.opener)
+
+
+def _tiny_manifest(artifact_root) -> CorpusManifest:
+    """A minimal-but-real, independently-materialized+verifiable manifest, used
+    to test main()'s atomic-publish orchestration in isolation from
+    build_corpus()'s own fetch/materialize machinery (covered above)."""
+    klines = []
+    funding = []
+    for idx, symbol in enumerate(scope.UNIVERSE):
+        rows = [
+            NormalizedKline(
+                symbol=symbol,
+                open_time_ms=scope.WINDOW_START_MS + (idx * 5 + i) * 60_000,
+                open=100.0,
+                high=101.0,
+                low=99.0,
+                close=100.5,
+                base_volume=10.0,
+                close_time_ms=scope.WINDOW_START_MS + (idx * 5 + i) * 60_000 + 59_999,
+                quote_volume=1000.0,
+                trade_count=5,
+                taker_buy_volume=4.0,
+                taker_buy_quote_volume=400.0,
+            )
+            for i in range(3)
+        ]
+        rel_path, file_sha = persist.write_kline_shard(artifact_root, symbol, rows)
+        klines.append(
+            SymbolKlineManifest(
+                symbol=symbol,
+                interval="1m",
+                archives=(),
+                normalized_shard_sha256=canonical_hash.canonical_sha256(
+                    [r.__dict__ for r in rows]
+                ),
+                shard_path=rel_path,
+                shard_file_sha256=file_sha,
+                row_count=len(rows),
+                min_open_time_ms=rows[0].open_time_ms,
+                max_open_time_ms=rows[-1].open_time_ms,
+                gap_ranges=(),
+            )
+        )
+        frows = [
+            FundingRow(
+                calc_time=scope.WINDOW_START_MS + idx * 3_600_000,
+                funding_interval_hours=8,
+                last_funding_rate=0.0001,
+            )
+        ]
+        frel, ffile_sha = persist.write_funding_shard(artifact_root, symbol, frows)
+        funding.append(
+            SymbolFundingManifest(
+                symbol=symbol,
+                archives=(),
+                normalized_shard_sha256=canonical_hash.canonical_sha256(
+                    [r.__dict__ for r in frows]
+                ),
+                shard_path=frel,
+                shard_file_sha256=ffile_sha,
+                row_count=1,
+                min_calc_time_ms=frows[0].calc_time,
+                max_calc_time_ms=frows[0].calc_time,
+            )
+        )
+    eligibility = tuple(
+        SymbolEligibility(symbol=s, **scope.eligibility(s)) for s in scope.UNIVERSE
+    )
+    return CorpusManifest(
+        window_start_iso=scope.WINDOW_START_ISO,
+        window_end_iso=scope.WINDOW_END_ISO,
+        universe=scope.UNIVERSE,
+        eligibility=eligibility,
+        klines=tuple(klines),
+        funding=tuple(funding),
+    )
+
+
+def test_main_atomic_publish_writes_committed_manifest_only_on_success(
+    tmp_path, monkeypatch
+):
+    artifact_root = tmp_path / "artifact_root"
+    artifact_root.mkdir()
+    fixed_manifest = _tiny_manifest(artifact_root)
+    out_path = tmp_path / "data_manifests" / "rob941_corpus_manifest.v1.json"
+
+    monkeypatch.setattr(cli, "build_corpus", lambda artifact_root: fixed_manifest)
+    monkeypatch.setattr("artifact_paths.pit_data_root", lambda: artifact_root)
+
+    rc = cli.main(["--run", "--out", str(out_path)])
+    assert rc == 0
+    assert out_path.is_file()
+    saved = CorpusManifest.load(out_path)
+    assert saved.content_hash() == fixed_manifest.content_hash()
+    assert not out_path.with_suffix(out_path.suffix + ".tmp").exists()
+
+
+def test_main_never_publishes_when_build_corpus_raises(tmp_path, monkeypatch):
+    out_path = tmp_path / "data_manifests" / "rob941_corpus_manifest.v1.json"
+
+    def _boom(artifact_root):
+        raise af.ChecksumMismatchError("simulated mid-build failure")
+
+    monkeypatch.setattr(cli, "build_corpus", _boom)
+    monkeypatch.setattr(
+        "artifact_paths.pit_data_root", lambda: tmp_path / "artifact_root"
+    )
+
+    with pytest.raises(af.ChecksumMismatchError):
+        cli.main(["--run", "--out", str(out_path)])
+    assert not out_path.exists()
+
+
+def test_main_atomic_publish_never_overwrites_prior_committed_manifest_on_failure(
+    tmp_path, monkeypatch
+):
+    out_path = tmp_path / "data_manifests" / "rob941_corpus_manifest.v1.json"
+    out_path.parent.mkdir(parents=True)
+    out_path.write_text('{"prior": "committed manifest"}')
+
+    def _boom(artifact_root):
+        raise af.ChecksumMismatchError("simulated mid-build failure")
+
+    monkeypatch.setattr(cli, "build_corpus", _boom)
+    monkeypatch.setattr(
+        "artifact_paths.pit_data_root", lambda: tmp_path / "artifact_root"
+    )
+
+    with pytest.raises(af.ChecksumMismatchError):
+        cli.main(["--run", "--out", str(out_path)])
+    assert json.loads(out_path.read_text()) == {"prior": "committed manifest"}
+
+
+def test_main_no_run_flag_is_still_a_no_op(capsys):
+    rc = cli.main([])
+    assert rc == 0
+    assert "no-op" in capsys.readouterr().out
+
+
+# --------------------------------------------------------------------------- #
+# captain review (ultrathink atomicity correction): a later build that fails
+# partway must NEVER mutate the bytes a prior, still-published manifest
+# references. Content-addressed paths (rob941_persistence: checksum/row-hash
+# embedded in every path) are the mechanism -- a rebuild only ever "rewrites"
+# an existing path when the content is byte-identical (a no-op skip), and
+# genuinely different content always lands at a genuinely different path. This
+# asserts the guarantee end to end, not just that the mechanism exists.
+# --------------------------------------------------------------------------- #
+def _snapshot_referenced_bytes(manifest: CorpusManifest, artifact_root):
+    paths = set()
+    for k in manifest.klines:
+        paths.add(k.shard_path)
+        paths.update(a.local_path for a in k.archives)
+    for f in manifest.funding:
+        paths.add(f.shard_path)
+        paths.update(a.local_path for a in f.archives)
+    assert all(p is not None for p in paths), (
+        "every referenced path must be materialized"
+    )
+    return {p: (artifact_root / p).read_bytes() for p in paths}
+
+
+def test_prior_published_corpus_survives_a_failed_rebuild_byte_for_byte(tmp_path):
+    artifact_root = tmp_path / "artifact_root"
+    out_path = tmp_path / "data_manifests" / "rob941_corpus_manifest.v1.json"
+
+    # ONE shared fixture object for both attempts: BTCUSDT (processed first in
+    # frozen.UNIVERSE order) is untouched, so re-running against the SAME bytes
+    # forces a genuine same-content-addressed-path "rewrite" attempt for its 12
+    # archives + shard during the second (failing) build -- not merely two
+    # unrelated builds that happen to never collide on any path.
+    fake = _FakeFourSymbolUniverse(scope.UNIVERSE)
+    manifest_v1 = cli.build_corpus(artifact_root=artifact_root, opener=fake.opener)
+    cli._atomic_save(manifest_v1, out_path)
+    before = _snapshot_referenced_bytes(manifest_v1, artifact_root)
+
+    # corrupt XRPUSDT's checksum (2nd symbol in frozen.UNIVERSE) so BTCUSDT
+    # fully re-completes (real same-path collision) before the build fails.
+    xrp_checksum_key = next(
+        k
+        for k in fake.table
+        if k.endswith(".CHECKSUM") and "klines" in k and "XRPUSDT" in k
+    )
+    original = fake.table[xrp_checksum_key]
+    fake.table[xrp_checksum_key] = b"0" * 64 + b"  corrupt.csv\n"
+    try:
+        with pytest.raises(af.ChecksumMismatchError):
+            cli.build_corpus(artifact_root=artifact_root, opener=fake.opener)
+    finally:
+        fake.table[xrp_checksum_key] = original
+
+    # every byte the v1 manifest references is untouched, including BTCUSDT's
+    # content-addressed shard/archives that the failed rebuild re-wrote to the
+    # exact same paths (a safe, verified-identical no-op, not a corruption)
+    after = _snapshot_referenced_bytes(manifest_v1, artifact_root)
+    assert after == before
+
+    # the committed manifest file was never touched by the failed rebuild,
+    # and it is still fully, independently offline-loadable
+    committed = CorpusManifest.load(out_path)
+    assert committed.content_hash() == manifest_v1.content_hash()
+    reloaded = loader.load_corpus(committed, artifact_root)
+    assert set(reloaded["klines"]) == set(scope.UNIVERSE)
+
+
+# --------------------------------------------------------------------------- #
+# captain review (ultrathink determinism follow-up): an identical rerun (same
+# upstream/fixture bytes) must reproduce the exact same manifest content_hash
+# and the exact same shard_path/local_path values -- no random/time-based
+# generation id anywhere in the path scheme.
+# --------------------------------------------------------------------------- #
+def test_identical_rerun_reproduces_identical_manifest_hash_and_paths(tmp_path):
+    fake = _FakeFourSymbolUniverse(scope.UNIVERSE)  # ONE fixture object, reused as-is
+    root1 = tmp_path / "root1"
+    root2 = tmp_path / "root2"
+
+    manifest1 = cli.build_corpus(artifact_root=root1, opener=fake.opener)
+    manifest2 = cli.build_corpus(artifact_root=root2, opener=fake.opener)
+
+    assert manifest1.content_hash() == manifest2.content_hash()
+    for k1, k2 in zip(manifest1.klines, manifest2.klines, strict=True):
+        assert k1.shard_path == k2.shard_path
+        assert k1.shard_file_sha256 == k2.shard_file_sha256
+        for a1, a2 in zip(k1.archives, k2.archives, strict=True):
+            assert a1.local_path == a2.local_path
+            assert a1.checksum_sha256 == a2.checksum_sha256
+    for f1, f2 in zip(manifest1.funding, manifest2.funding, strict=True):
+        assert f1.shard_path == f2.shard_path
+        assert f1.shard_file_sha256 == f2.shard_file_sha256
+
+
+def test_rerunning_build_corpus_against_the_same_artifact_root_is_idempotent(tmp_path):
+    fake = _FakeFourSymbolUniverse(scope.UNIVERSE)
+    artifact_root = tmp_path / "artifact_root"
+
+    manifest1 = cli.build_corpus(artifact_root=artifact_root, opener=fake.opener)
+    before = _snapshot_referenced_bytes(manifest1, artifact_root)
+    manifest2 = cli.build_corpus(artifact_root=artifact_root, opener=fake.opener)
+    after = _snapshot_referenced_bytes(manifest2, artifact_root)
+
+    assert manifest1.content_hash() == manifest2.content_hash()
+    assert before == after

--- a/research/nautilus_scalping/tests/test_pit_data_layer_guard.py
+++ b/research/nautilus_scalping/tests/test_pit_data_layer_guard.py
@@ -20,6 +20,8 @@ _MODULES = [
     "rob941_funding_sidecar.py",
     "rob941_manifest.py",
     "rob941_corpus_builder.py",
+    "rob941_persistence.py",
+    "rob941_offline_loader.py",
     "build_rob941_corpus.py",
 ]
 

--- a/research/nautilus_scalping/tests/test_pit_data_layer_guard.py
+++ b/research/nautilus_scalping/tests/test_pit_data_layer_guard.py
@@ -5,8 +5,23 @@ from pathlib import Path
 import artifact_paths
 
 _ROOT = Path(__file__).resolve().parents[1]
-_MODULES = ["pit_klines_fetcher.py", "pit_bars.py", "build_pit_universe.py", "pit_universe.py",
-            "campaign_specs.py", "campaign_controls.py", "run_rob353_campaign.py"]
+_MODULES = [
+    "pit_klines_fetcher.py",
+    "pit_bars.py",
+    "build_pit_universe.py",
+    "pit_universe.py",
+    "campaign_specs.py",
+    "campaign_controls.py",
+    "run_rob353_campaign.py",
+    "rob941_frozen_scope.py",
+    "rob941_archive_fetch.py",
+    "rob941_kline_schema.py",
+    "rob941_gaps.py",
+    "rob941_funding_sidecar.py",
+    "rob941_manifest.py",
+    "rob941_corpus_builder.py",
+    "build_rob941_corpus.py",
+]
 
 
 def _imports(path: Path):
@@ -22,7 +37,9 @@ def _imports(path: Path):
 def test_no_app_imports_in_data_layer():
     for mod in _MODULES:
         for name in _imports(_ROOT / mod):
-            assert not name.startswith("app"), f"{mod} imports forbidden app module {name!r}"
+            assert not name.startswith("app"), (
+                f"{mod} imports forbidden app module {name!r}"
+            )
 
 
 def test_pit_data_root_is_gitignored(monkeypatch):

--- a/research/nautilus_scalping/tests/test_rob941_archive_fetch.py
+++ b/research/nautilus_scalping/tests/test_rob941_archive_fetch.py
@@ -1,0 +1,112 @@
+"""ROB-941 (AC1/AC4) — checksum-MANDATORY Binance public archive fetch.
+
+Unlike ``pit_klines_fetcher`` (best-effort checksum: silently accepts an archive
+when the ``.CHECKSUM`` sidecar is absent), the ROB-941 corpus is fail-closed: a
+missing archive, a missing checksum, a checksum mismatch, a corrupt ZIP, or a
+corrupt/non-UTF8 CSV member must all raise rather than admit unverified data.
+
+All tests here use a fake in-memory ``opener`` (url -> bytes | None) — no real
+network calls. The real ``urllib_opener`` is exercised only by the opt-in live
+test (``test_rob941_corpus_builder_live.py``).
+"""
+
+import hashlib
+import io
+import zipfile
+
+import pytest
+import rob941_archive_fetch as af
+
+
+def _zip_bytes(member_name: str, content: bytes) -> bytes:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr(member_name, content)
+    return buf.getvalue()
+
+
+def _checksum_line(zip_bytes: bytes, filename: str) -> bytes:
+    digest = hashlib.sha256(zip_bytes).hexdigest()
+    return f"{digest}  {filename}\n".encode()
+
+
+# --------------------------------------------------------------------------- #
+# URL builders (pure)
+# --------------------------------------------------------------------------- #
+def test_kline_archive_url_um_monthly():
+    url = af.kline_archive_url("XRPUSDT", "1m", 2025, 7)
+    assert url == (
+        "https://data.binance.vision/data/futures/um/monthly/klines/"
+        "XRPUSDT/1m/XRPUSDT-1m-2025-07.zip"
+    )
+
+
+def test_funding_archive_url_um_monthly():
+    url = af.funding_archive_url("XRPUSDT", 2025, 7)
+    assert url == (
+        "https://data.binance.vision/data/futures/um/monthly/fundingRate/"
+        "XRPUSDT/XRPUSDT-fundingRate-2025-07.zip"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# fail-closed fetch behavior
+# --------------------------------------------------------------------------- #
+def test_fetch_verified_archive_happy_path():
+    zb = _zip_bytes("X-1m-2025-07.csv", b"open_time,open\n1,2\n")
+    chk = _checksum_line(zb, "X-1m-2025-07.csv")
+    table = {
+        "https://example/x.zip": zb,
+        "https://example/x.zip.CHECKSUM": chk,
+    }
+    fetched = af.fetch_verified_archive("https://example/x.zip", opener=table.get)
+    assert fetched.zip_bytes == zb
+    assert fetched.checksum_sha256 == hashlib.sha256(zb).hexdigest()
+
+
+def test_fetch_verified_archive_missing_archive_is_fail_closed():
+    table = {}  # 404 on the archive itself
+    with pytest.raises(af.ArchiveMissingError):
+        af.fetch_verified_archive("https://example/missing.zip", opener=table.get)
+
+
+def test_fetch_verified_archive_missing_checksum_is_fail_closed():
+    zb = _zip_bytes("X.csv", b"data")
+    table = {"https://example/x.zip": zb}  # no .CHECKSUM entry -> opener returns None
+    with pytest.raises(af.ChecksumMissingError):
+        af.fetch_verified_archive("https://example/x.zip", opener=table.get)
+
+
+def test_fetch_verified_archive_checksum_mismatch_is_fail_closed():
+    zb = _zip_bytes("X.csv", b"data")
+    table = {
+        "https://example/x.zip": zb,
+        "https://example/x.zip.CHECKSUM": b"0" * 64 + b"  X.csv\n",
+    }
+    with pytest.raises(af.ChecksumMismatchError):
+        af.fetch_verified_archive("https://example/x.zip", opener=table.get)
+
+
+def test_extract_single_csv_happy_path():
+    zb = _zip_bytes("X.csv", b"a,b\n1,2\n")
+    assert af.extract_single_csv(zb) == "a,b\n1,2\n"
+
+
+def test_extract_single_csv_corrupt_zip_is_fail_closed():
+    with pytest.raises(af.CorruptArchiveError):
+        af.extract_single_csv(b"this is not a zip file at all")
+
+
+def test_extract_single_csv_multi_member_zip_is_fail_closed():
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("a.csv", "1")
+        zf.writestr("b.csv", "2")
+    with pytest.raises(af.CorruptArchiveError):
+        af.extract_single_csv(buf.getvalue())
+
+
+def test_extract_single_csv_non_utf8_member_is_fail_closed():
+    zb = _zip_bytes("X.csv", b"\xff\xfe\x00\x01broken")
+    with pytest.raises(af.CorruptArchiveError):
+        af.extract_single_csv(zb)

--- a/research/nautilus_scalping/tests/test_rob941_corpus_builder.py
+++ b/research/nautilus_scalping/tests/test_rob941_corpus_builder.py
@@ -125,6 +125,51 @@ def test_build_symbol_funding_shard_normalizes_from_fixture():
     assert len(provenance) == 12
 
 
+def test_build_symbol_kline_shard_invokes_raw_archive_sink_once_per_month_with_verified_bytes():
+    fake = _FakeCorpusUniverse("XRPUSDT")
+    calls = []
+
+    def sink(symbol, kind, year, month, zip_bytes):
+        calls.append((symbol, kind, year, month, zip_bytes))
+        return f"rob941/raw/{kind}/{symbol}/{symbol}-{kind}-{year:04d}-{month:02d}.zip"
+
+    rows, provenance, gap_ranges = cb.build_symbol_kline_shard(
+        "XRPUSDT", opener=fake.opener, raw_archive_sink=sink
+    )
+    assert len(calls) == 12  # one per frozen-window month, never skipped
+    assert all(c[0] == "XRPUSDT" and c[1] == "klines" for c in calls)
+    assert all(isinstance(c[4], bytes) and len(c[4]) > 0 for c in calls)
+    # the sink's returned relative path must land on the archive's provenance
+    assert all(p.local_path is not None for p in provenance)
+    assert all(
+        p.local_path.startswith("rob941/raw/klines/XRPUSDT/") for p in provenance
+    )
+
+
+def test_build_symbol_kline_shard_without_sink_leaves_local_path_none():
+    fake = _FakeCorpusUniverse("XRPUSDT")
+    rows, provenance, gap_ranges = cb.build_symbol_kline_shard(
+        "XRPUSDT", opener=fake.opener
+    )
+    assert all(p.local_path is None for p in provenance)
+
+
+def test_build_symbol_funding_shard_invokes_raw_archive_sink_with_funding_rate_kind():
+    fake = _FakeCorpusUniverse("DOGEUSDT")
+    calls = []
+
+    def sink(symbol, kind, year, month, zip_bytes):
+        calls.append((symbol, kind, year, month))
+        return f"rob941/raw/{kind}/{symbol}/{symbol}-{kind}-{year:04d}-{month:02d}.zip"
+
+    rows, provenance = cb.build_symbol_funding_shard(
+        "DOGEUSDT", opener=fake.opener, raw_archive_sink=sink
+    )
+    assert len(calls) == 12
+    assert all(c[1] == "fundingRate" for c in calls)
+    assert all(p.local_path is not None for p in provenance)
+
+
 def test_corpus_builder_module_has_no_broker_order_or_db_imports():
     # zero broker/order/fill/scheduler wiring — enforced structurally, not by convention
     import ast

--- a/research/nautilus_scalping/tests/test_rob941_corpus_builder.py
+++ b/research/nautilus_scalping/tests/test_rob941_corpus_builder.py
@@ -1,0 +1,145 @@
+"""ROB-941 — corpus builder orchestration (fetch -> extract -> normalize -> gap-detect).
+
+Fully fixture-driven via a fake in-memory opener: no network in the default suite.
+Exercises the fail-closed chain end-to-end (a bad checksum anywhere in the window
+aborts the whole symbol build) and confirms zero DB/broker/scheduler code paths
+exist by construction (this module imports only rob941_* + funding_oi_archive).
+"""
+
+import hashlib
+import io
+import zipfile
+
+import pytest
+import rob941_archive_fetch as af
+import rob941_corpus_builder as cb
+import rob941_frozen_scope as scope
+
+HEADER = "open_time,open,high,low,close,volume,close_time,quote_volume,count,taker_buy_volume,taker_buy_quote_volume,ignore\n"
+FUNDING_HEADER = "calc_time,funding_interval_hours,last_funding_rate\n"
+
+
+def _kline_row(open_time_ms: int) -> str:
+    close_time = open_time_ms + 59_999
+    return (
+        f"{open_time_ms},100.0,101.0,99.0,100.5,10.0,{close_time},1000.0,5,4.0,400.0,0"
+    )
+
+
+def _month_csv(
+    symbol: str, start_ms: int, n_minutes: int, skip_offsets=frozenset()
+) -> str:
+    lines = [HEADER]
+    for m in range(n_minutes):
+        if m in skip_offsets:
+            continue
+        lines.append(_kline_row(start_ms + m * 60_000) + "\n")
+    return "".join(lines)
+
+
+def _zip_and_checksum(name: str, content: str):
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr(name, content)
+    zb = buf.getvalue()
+    checksum = f"{hashlib.sha256(zb).hexdigest()}  {name}\n".encode()
+    return zb, checksum
+
+
+class _FakeCorpusUniverse:
+    """Populates all 12 frozen-window months with a tiny 5-bar fixture each (a
+    real fetch would be a full month of 1m bars; the builder doesn't care about
+    volume, only about the fetch/checksum/parse/gap-detect chain). Every fake
+    month's 5 bars sit at a distinct minute offset from ``WINDOW_START_MS`` so
+    cross-month timestamps never collide; the second month drops one bar to
+    prove ``build_symbol_kline_shard`` surfaces a real, LOCATABLE gap (not just
+    "some gap exists somewhere in the year")."""
+
+    def __init__(self, symbol: str):
+        self.symbol = symbol
+        self.table: dict[str, bytes] = {}
+        self.second_month_gap_start_ms: int | None = None
+        self._populate()
+
+    def _populate(self):
+        months = scope.months_in_window()
+        for idx, (year, month) in enumerate(months):
+            month_start = (
+                scope.WINDOW_START_MS + idx * 10 * 60_000
+            )  # 10-min spacing, no overlap
+            url = af.kline_archive_url(self.symbol, "1m", year, month)
+            csv_name = f"{self.symbol}-1m-{year:04d}-{month:02d}.csv"
+            # each fake "month" is tiny: 5 one-minute bars, second month skips 1 bar (a gap)
+            skip = {2} if idx == 1 else frozenset()
+            if idx == 1:
+                self.second_month_gap_start_ms = month_start + 2 * 60_000
+            text = _month_csv(self.symbol, month_start, 5, skip_offsets=skip)
+            zb, chk = _zip_and_checksum(csv_name, text)
+            self.table[url] = zb
+            self.table[url + ".CHECKSUM"] = chk
+
+            fund_url = af.funding_archive_url(self.symbol, year, month)
+            fund_name = f"{self.symbol}-fundingRate-{year:04d}-{month:02d}.csv"
+            fund_text = FUNDING_HEADER + f"{month_start},8,0.0001{idx}\n"
+            fzb, fchk = _zip_and_checksum(fund_name, fund_text)
+            self.table[fund_url] = fzb
+            self.table[fund_url + ".CHECKSUM"] = fchk
+
+    def opener(self, url: str):
+        return self.table.get(url)
+
+
+def test_build_symbol_kline_shard_normalizes_and_detects_gap_from_fixture():
+    fake = _FakeCorpusUniverse("XRPUSDT")
+    rows, provenance, gap_ranges = cb.build_symbol_kline_shard(
+        "XRPUSDT", opener=fake.opener
+    )
+    assert all(r.symbol == "XRPUSDT" for r in rows)
+    assert (
+        len(provenance) == 12
+    )  # one entry per frozen-window month, all checksum-verified
+    # 11 months x 5 bars + 1 month x 4 bars (one skipped) = 59 real bars
+    assert len(rows) == 59
+    gap_start = fake.second_month_gap_start_ms
+    assert any(g0 == gap_start and g1 == gap_start + 60_000 for g0, g1 in gap_ranges), (
+        f"expected an exact 1-minute gap range at {gap_start}, got {gap_ranges[:5]}... "
+        f"({len(gap_ranges)} total ranges)"
+    )
+
+
+def test_build_symbol_kline_shard_fails_closed_on_checksum_mismatch():
+    fake = _FakeCorpusUniverse("XRPUSDT")
+    # corrupt exactly one month's checksum
+    any_checksum_key = next(
+        k for k in fake.table if k.endswith(".CHECKSUM") and "klines" in k
+    )
+    fake.table[any_checksum_key] = b"0" * 64 + b"  corrupt.csv\n"
+    with pytest.raises(af.ChecksumMismatchError):
+        cb.build_symbol_kline_shard("XRPUSDT", opener=fake.opener)
+
+
+def test_build_symbol_funding_shard_normalizes_from_fixture():
+    fake = _FakeCorpusUniverse("DOGEUSDT")
+    rows, provenance = cb.build_symbol_funding_shard("DOGEUSDT", opener=fake.opener)
+    assert len(rows) == 12  # one funding row per fake month
+    assert len(provenance) == 12
+
+
+def test_corpus_builder_module_has_no_broker_order_or_db_imports():
+    # zero broker/order/fill/scheduler wiring — enforced structurally, not by convention
+    import ast
+    from pathlib import Path
+
+    src = Path(cb.__file__).read_text()
+    tree = ast.parse(src)
+    forbidden = {"app", "sqlalchemy", "asyncpg", "taskiq"}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            names = [n.name.split(".")[0] for n in node.names]
+        elif isinstance(node, ast.ImportFrom):
+            names = [(node.module or "").split(".")[0]]
+        else:
+            continue
+        assert not (set(names) & forbidden), (
+            f"forbidden import in corpus builder: {names}"
+        )

--- a/research/nautilus_scalping/tests/test_rob941_corpus_builder_live.py
+++ b/research/nautilus_scalping/tests/test_rob941_corpus_builder_live.py
@@ -1,0 +1,62 @@
+"""ROB-941 (AC9) — opt-in LIVE network test against data.binance.vision.
+
+Skipped by default (no ``ROB941_RUN_LIVE=1`` env var): the default suite is
+fixture-only and network-free, per the AC9 requirement. This test does not use
+the repo-root ``tests/conftest.py`` ``--run-live`` flag because
+``research/nautilus_scalping`` is a separate pytest subtree (its own
+``conftest.py``, not collected under the root ``tests/`` path) — adding a second
+``--run-live`` ``addoption`` here would collide if both trees were ever
+collected together, so this uses a scoped env-var gate instead of touching the
+shared ``research/nautilus_scalping/conftest.py``.
+
+Run explicitly:
+    ROB941_RUN_LIVE=1 uv run python -m pytest \\
+        research/nautilus_scalping/tests/test_rob941_corpus_builder_live.py -v
+"""
+
+import os
+
+import pytest
+import rob941_archive_fetch as af
+import rob941_corpus_builder as cb
+import rob941_kline_schema as ks
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.live,
+    pytest.mark.skipif(
+        os.environ.get("ROB941_RUN_LIVE") != "1",
+        reason="live network test: set ROB941_RUN_LIVE=1 to run",
+    ),
+]
+
+
+def test_fetch_and_verify_one_real_month_of_xrpusdt_klines():
+    url = af.kline_archive_url("XRPUSDT", "1m", 2025, 7)
+    fetched = af.fetch_verified_archive(url)  # real urllib_opener, real checksum
+    csv_text = af.extract_single_csv(fetched.zip_bytes)
+    rows = ks.parse_kline_csv(
+        "XRPUSDT", csv_text, 1751328000000, 1751328000000 + 31 * 86_400_000
+    )
+    assert len(rows) > 40_000  # a full month of 1m bars, minus any real exchange gaps
+    assert rows[0].open_time_ms == 1751328000000
+
+
+def test_fetch_and_verify_one_real_month_of_funding_rate():
+    url = af.funding_archive_url("XRPUSDT", 2025, 7)
+    fetched = af.fetch_verified_archive(url)
+    csv_text = af.extract_single_csv(fetched.zip_bytes)
+    from funding_oi_archive import parse_funding_csv
+
+    rows = parse_funding_csv(csv_text)
+    assert len(rows) >= 60  # ~90 events/month at 8h cadence, allow for interval changes
+
+
+def test_build_symbol_kline_shard_against_real_binance_first_month_only(monkeypatch):
+    # bound the live RUN to a single month so this smoke test stays fast; the full
+    # 12-month x 4-symbol corpus is built by the operator-gated build_rob941_corpus.py
+    monkeypatch.setattr("rob941_frozen_scope.months_in_window", lambda: [(2025, 7)])
+    rows, provenance, gap_ranges = cb.build_symbol_kline_shard("XRPUSDT")
+    assert len(provenance) == 1
+    assert provenance[0].checksum_sha256
+    assert len(rows) > 40_000

--- a/research/nautilus_scalping/tests/test_rob941_frozen_scope.py
+++ b/research/nautilus_scalping/tests/test_rob941_frozen_scope.py
@@ -1,0 +1,76 @@
+"""ROB-941 (AC2/AC3) — frozen universe + UTC half-open window, single source of truth.
+
+Editing these constants after a manifest/campaign exists starts a new lineage; this
+module IS the frozen scope other rob941_* modules and the manifest consult.
+"""
+
+import pytest
+import rob941_frozen_scope as scope
+
+
+def test_universe_is_exactly_four_symbols_in_frozen_order():
+    assert scope.UNIVERSE == ("BTCUSDT", "XRPUSDT", "DOGEUSDT", "SOLUSDT")
+
+
+def test_window_iso_strings_are_frozen():
+    assert scope.WINDOW_START_ISO == "2025-07-01T00:00:00Z"
+    assert scope.WINDOW_END_ISO == "2026-07-01T00:00:00Z"
+
+
+def test_window_is_half_open_utc_epoch_ms():
+    # 2025-07-01T00:00:00Z and 2026-07-01T00:00:00Z, epoch ms
+    assert scope.WINDOW_START_MS == 1751328000000
+    assert scope.WINDOW_END_MS == 1782864000000
+    assert scope.WINDOW_START_MS < scope.WINDOW_END_MS
+
+
+def test_btc_is_historical_only_and_demo_ineligible_with_fixed_reason():
+    e = scope.eligibility("BTCUSDT")
+    assert e == {
+        "historical_only": True,
+        "demo_execution_eligible": False,
+        "reason": "min_notional_50_exceeds_demo_cap_10",
+    }
+
+
+@pytest.mark.parametrize("symbol", ["XRPUSDT", "DOGEUSDT", "SOLUSDT"])
+def test_non_btc_symbols_are_demo_eligible_with_no_reason(symbol):
+    e = scope.eligibility(symbol)
+    assert e == {
+        "historical_only": False,
+        "demo_execution_eligible": True,
+        "reason": None,
+    }
+
+
+def test_eligibility_rejects_symbol_outside_frozen_universe():
+    with pytest.raises(ValueError, match="ETHUSDT"):
+        scope.eligibility("ETHUSDT")
+
+
+def test_months_in_window_is_twelve_full_calendar_months():
+    months = scope.months_in_window()
+    assert months == [
+        (2025, 7),
+        (2025, 8),
+        (2025, 9),
+        (2025, 10),
+        (2025, 11),
+        (2025, 12),
+        (2026, 1),
+        (2026, 2),
+        (2026, 3),
+        (2026, 4),
+        (2026, 5),
+        (2026, 6),
+    ]
+
+
+def test_months_in_window_does_not_track_latest():
+    # regression guard: the frozen window must never be computed from "now" —
+    # it is a literal constant, not derived from datetime.now()/utcnow().
+    import inspect
+
+    src = inspect.getsource(scope)
+    assert "datetime.now(" not in src
+    assert "utcnow(" not in src

--- a/research/nautilus_scalping/tests/test_rob941_funding_sidecar.py
+++ b/research/nautilus_scalping/tests/test_rob941_funding_sidecar.py
@@ -1,0 +1,78 @@
+"""ROB-941 (AC8) — PIT-safe funding-rate sidecar: no lookahead, realized-crossing only.
+
+Built on ``funding_oi_archive.parse_funding_csv`` (already unit-tested for CSV
+parsing itself). This module tests only the PIT query semantics: entry-gate uses
+last-KNOWN rate (never a future row), and PnL uses realized crossings strictly
+inside the holding window.
+"""
+
+from funding_oi_archive import parse_funding_csv
+from rob941_funding_sidecar import FundingSidecar
+
+CSV = (
+    "calc_time,funding_interval_hours,last_funding_rate\n"
+    "1751328000007,8,0.00010000\n"
+    "1751356800002,8,0.00010000\n"
+    "1751385600000,8,0.00001379\n"
+    "1751414400001,8,-0.00005510\n"
+)
+
+
+def _sidecar() -> FundingSidecar:
+    return FundingSidecar.from_rows("XRPUSDT", parse_funding_csv(CSV))
+
+
+def test_last_known_rate_returns_most_recent_row_at_or_before_ts():
+    sc = _sidecar()
+    r = sc.last_known_rate(1751356800002)
+    assert r.calc_time == 1751356800002  # known exactly AT calc_time
+
+
+def test_last_known_rate_never_leaks_the_next_future_row():
+    sc = _sidecar()
+    r = sc.last_known_rate(1751356800002 - 1)  # 1ms before the 2nd row becomes known
+    assert (
+        r.calc_time == 1751328000007
+    )  # must fall back to the prior row, not leak forward
+
+
+def test_last_known_rate_before_any_data_is_none():
+    sc = _sidecar()
+    assert sc.last_known_rate(1751328000007 - 1) is None
+
+
+def test_last_known_rate_after_all_data_returns_the_last_row():
+    sc = _sidecar()
+    r = sc.last_known_rate(1751414400001 + 999_999)
+    assert r.calc_time == 1751414400001
+
+
+def test_realized_crossings_includes_only_events_strictly_inside_the_hold_window():
+    sc = _sidecar()
+    # holding window spans exactly the 2nd and 3rd funding events, not the 1st or 4th
+    crossings = sc.realized_crossings(1751356800002, 1751414400001)
+    assert [r.calc_time for r in crossings] == [1751356800002, 1751385600000]
+
+
+def test_realized_crossings_empty_when_no_event_falls_inside():
+    sc = _sidecar()
+    crossings = sc.realized_crossings(1751328000007 + 1, 1751356800002)
+    assert crossings == ()
+
+
+def test_realized_crossings_empty_for_degenerate_or_inverted_window():
+    sc = _sidecar()
+    assert sc.realized_crossings(1751356800002, 1751356800002) == ()
+    assert sc.realized_crossings(1751414400001, 1751328000007) == ()
+
+
+def test_from_rows_rejects_conflicting_duplicate_calc_time():
+    import pytest
+
+    csv = (
+        "calc_time,funding_interval_hours,last_funding_rate\n"
+        "1700000000000,8,0.0001\n"
+        "1700000000000,8,0.0002\n"  # same calc_time, different rate -> conflict
+    )
+    with pytest.raises(ValueError, match="conflicting"):
+        FundingSidecar.from_rows("XRPUSDT", parse_funding_csv(csv))

--- a/research/nautilus_scalping/tests/test_rob941_gaps.py
+++ b/research/nautilus_scalping/tests/test_rob941_gaps.py
@@ -1,0 +1,101 @@
+"""ROB-941 (AC7) — gap tracking: never delete/forward-fill/synthesize, just record.
+
+``detect_gap_ranges`` returns the missing 60s buckets as explicit ranges (never
+silently dropped). ``incomplete_buckets`` marks any 5m/15m aggregate that a gap
+touches as incomplete (never synthesized from partial coverage). ``position_touches_gap``
+is the pure predicate a trial-rejection rule (``rejected:data_gap_in_position``)
+consumes — this module does not itself reject trials, only exposes the predicate.
+"""
+
+import rob941_gaps as gaps
+
+GRID_MS = 60_000
+T0 = 1751328000000  # 2025-07-01T00:00:00Z
+
+
+def _times(*minute_offsets):
+    return [T0 + m * GRID_MS for m in minute_offsets]
+
+
+def test_detect_gap_ranges_no_gap_when_fully_contiguous():
+    observed = _times(0, 1, 2, 3, 4)
+    out = gaps.detect_gap_ranges(observed, T0, T0 + 5 * GRID_MS)
+    assert out == []
+
+
+def test_detect_gap_ranges_single_missing_minute():
+    observed = _times(0, 1, 3, 4)  # minute 2 missing
+    out = gaps.detect_gap_ranges(observed, T0, T0 + 5 * GRID_MS)
+    assert out == [(T0 + 2 * GRID_MS, T0 + 3 * GRID_MS)]
+
+
+def test_detect_gap_ranges_merges_contiguous_missing_minutes():
+    observed = _times(0, 4)  # minutes 1,2,3 missing -> one merged range
+    out = gaps.detect_gap_ranges(observed, T0, T0 + 5 * GRID_MS)
+    assert out == [(T0 + 1 * GRID_MS, T0 + 4 * GRID_MS)]
+
+
+def test_detect_gap_ranges_covers_entire_window_when_no_data():
+    out = gaps.detect_gap_ranges([], T0, T0 + 3 * GRID_MS)
+    assert out == [(T0, T0 + 3 * GRID_MS)]
+
+
+def test_detect_gap_ranges_never_synthesizes_a_row_just_reports_the_hole():
+    # regression: the function must not attempt to interpolate/ffill anything —
+    # its only output is the (start, end) range, never a fabricated bar value.
+    observed = _times(0, 2)
+    out = gaps.detect_gap_ranges(observed, T0, T0 + 3 * GRID_MS)
+    assert out == [(T0 + GRID_MS, T0 + 2 * GRID_MS)]
+    assert all(isinstance(r, tuple) and len(r) == 2 for r in out)
+
+
+# --------------------------------------------------------------------------- #
+# 5m / 15m bucket completeness (a gap anywhere in the bucket -> incomplete)
+# --------------------------------------------------------------------------- #
+def test_incomplete_buckets_5m_all_present_is_complete():
+    observed = _times(0, 1, 2, 3, 4)
+    out = gaps.incomplete_buckets(observed, T0, T0 + 5 * GRID_MS, bucket_seconds=300)
+    assert out == []
+
+
+def test_incomplete_buckets_5m_missing_one_minute_marks_whole_bucket_incomplete():
+    observed = _times(0, 1, 2, 3)  # minute 4 missing
+    out = gaps.incomplete_buckets(observed, T0, T0 + 5 * GRID_MS, bucket_seconds=300)
+    assert out == [T0]
+
+
+def test_incomplete_buckets_15m_boundary_crossing_gap():
+    # 15 one-minute bars expected; minute 7 missing -> the whole 15m bucket incomplete
+    offsets = [m for m in range(15) if m != 7]
+    observed = _times(*offsets)
+    out = gaps.incomplete_buckets(observed, T0, T0 + 15 * GRID_MS, bucket_seconds=900)
+    assert out == [T0]
+
+
+def test_incomplete_buckets_only_flags_the_bucket_touching_the_gap():
+    # two 5m buckets; first complete, second missing one minute
+    offsets = [0, 1, 2, 3, 4, 5, 6, 7, 8]  # minute 9 (bucket 2) missing
+    observed = _times(*offsets)
+    out = gaps.incomplete_buckets(observed, T0, T0 + 10 * GRID_MS, bucket_seconds=300)
+    assert out == [T0 + 5 * GRID_MS]
+
+
+# --------------------------------------------------------------------------- #
+# position-vs-gap predicate (AC7: trial touching a gap is rejected upstream)
+# --------------------------------------------------------------------------- #
+def test_position_touches_gap_true_when_overlapping():
+    gap_ranges = [(T0 + 2 * GRID_MS, T0 + 4 * GRID_MS)]
+    assert gaps.position_touches_gap(T0, T0 + 3 * GRID_MS, gap_ranges) is True
+
+
+def test_position_touches_gap_false_when_disjoint():
+    gap_ranges = [(T0 + 2 * GRID_MS, T0 + 4 * GRID_MS)]
+    assert gaps.position_touches_gap(T0, T0 + 2 * GRID_MS, gap_ranges) is False
+    assert (
+        gaps.position_touches_gap(T0 + 4 * GRID_MS, T0 + 5 * GRID_MS, gap_ranges)
+        is False
+    )
+
+
+def test_position_touches_gap_false_when_no_gaps():
+    assert gaps.position_touches_gap(T0, T0 + GRID_MS, []) is False

--- a/research/nautilus_scalping/tests/test_rob941_kline_schema.py
+++ b/research/nautilus_scalping/tests/test_rob941_kline_schema.py
@@ -1,0 +1,147 @@
+"""ROB-941 (AC4/AC5) — normalized 1m kline schema + fail-closed validation.
+
+Real Binance USD-M kline CSV columns (confirmed via a live probe of
+``BTCUSDT-1m-2025-07.csv``, header present):
+
+    open_time,open,high,low,close,volume,close_time,quote_volume,count,
+    taker_buy_volume,taker_buy_quote_volume,ignore
+
+``close_time - open_time == 59999`` and ``open_time`` is 60000ms-grid-aligned for
+every real row observed. Malformed duration (59000/61000ms) and grid misalignment
+must both raise, not be silently coerced.
+"""
+
+import pytest
+import rob941_kline_schema as ks
+
+HEADER = "open_time,open,high,low,close,volume,close_time,quote_volume,count,taker_buy_volume,taker_buy_quote_volume,ignore\n"
+
+
+def _row(
+    open_time=1751328000000,
+    open_=100.0,
+    high=101.0,
+    low=99.0,
+    close=100.5,
+    volume=10.0,
+    close_time=1751328059999,
+    quote_volume=1000.0,
+    count=5,
+    taker_buy_volume=4.0,
+    taker_buy_quote_volume=400.0,
+):
+    return (
+        f"{open_time},{open_},{high},{low},{close},{volume},{close_time},"
+        f"{quote_volume},{count},{taker_buy_volume},{taker_buy_quote_volume},0"
+    )
+
+
+def test_parse_kline_csv_happy_path_preserves_all_fields():
+    text = HEADER + _row() + "\n"
+    rows = ks.parse_kline_csv(
+        "BTCUSDT", text, 1751328000000, 1751328000000 + 3 * 60_000
+    )
+    assert len(rows) == 1
+    r = rows[0]
+    assert r.symbol == "BTCUSDT"
+    assert r.open_time_ms == 1751328000000
+    assert (r.open, r.high, r.low, r.close) == (100.0, 101.0, 99.0, 100.5)
+    assert r.base_volume == 10.0
+    assert r.close_time_ms == 1751328059999
+    assert r.quote_volume == 1000.0
+    assert r.trade_count == 5
+    assert r.taker_buy_volume == 4.0
+    assert r.taker_buy_quote_volume == 400.0
+
+
+def test_parse_kline_csv_skips_header_row():
+    text = HEADER + _row() + "\n"
+    rows = ks.parse_kline_csv(
+        "BTCUSDT", text, 1751328000000, 1751328000000 + 3 * 60_000
+    )
+    assert all(r.open_time_ms != "open_time" for r in rows)
+    assert len(rows) == 1
+
+
+def test_parse_kline_csv_clips_rows_outside_frozen_window():
+    inside = _row(open_time=1751328060000, close_time=1751328119999)
+    before_window = _row(
+        open_time=1751327940000, close_time=1751327999999
+    )  # 1 min before start
+    text = HEADER + before_window + "\n" + inside + "\n"
+    rows = ks.parse_kline_csv(
+        "BTCUSDT", text, 1751328000000, 1751328000000 + 3 * 60_000
+    )
+    assert [r.open_time_ms for r in rows] == [1751328060000]
+
+
+# --------------------------------------------------------------------------- #
+# fail-closed: invalid OHLCV (AC4)
+# --------------------------------------------------------------------------- #
+def test_high_below_low_is_invalid_ohlcv():
+    text = HEADER + _row(high=90.0, low=99.0) + "\n"
+    with pytest.raises(ks.InvalidOHLCVError):
+        ks.parse_kline_csv("BTCUSDT", text, 1751328000000, 1751328000000 + 60_000)
+
+
+def test_high_below_close_is_invalid_ohlcv():
+    text = HEADER + _row(high=100.0, close=100.5) + "\n"
+    with pytest.raises(ks.InvalidOHLCVError):
+        ks.parse_kline_csv("BTCUSDT", text, 1751328000000, 1751328000000 + 60_000)
+
+
+def test_negative_volume_is_invalid_ohlcv():
+    text = HEADER + _row(volume=-1.0) + "\n"
+    with pytest.raises(ks.InvalidOHLCVError):
+        ks.parse_kline_csv("BTCUSDT", text, 1751328000000, 1751328000000 + 60_000)
+
+
+def test_taker_buy_volume_exceeding_total_volume_is_invalid_ohlcv():
+    text = HEADER + _row(volume=10.0, taker_buy_volume=99.0) + "\n"
+    with pytest.raises(ks.InvalidOHLCVError):
+        ks.parse_kline_csv("BTCUSDT", text, 1751328000000, 1751328000000 + 60_000)
+
+
+def test_non_positive_price_is_invalid_ohlcv():
+    text = HEADER + _row(open_=0.0) + "\n"
+    with pytest.raises(ks.InvalidOHLCVError):
+        ks.parse_kline_csv("BTCUSDT", text, 1751328000000, 1751328000000 + 60_000)
+
+
+# --------------------------------------------------------------------------- #
+# fail-closed: 59s / 61s bar duration (AC4/AC5 grid validation)
+# --------------------------------------------------------------------------- #
+def test_59_second_bar_duration_is_rejected():
+    # close_time - open_time == 59000ms instead of the required 59999ms
+    text = HEADER + _row(close_time=1751328000000 + 59_000) + "\n"
+    with pytest.raises(ks.InvalidOHLCVError, match="duration"):
+        ks.parse_kline_csv("BTCUSDT", text, 1751328000000, 1751328000000 + 60_000)
+
+
+def test_61_second_bar_duration_is_rejected():
+    # close_time - open_time == 61000ms instead of the required 59999ms
+    text = HEADER + _row(close_time=1751328000000 + 61_000) + "\n"
+    with pytest.raises(ks.InvalidOHLCVError, match="duration"):
+        ks.parse_kline_csv("BTCUSDT", text, 1751328000000, 1751328000000 + 60_000)
+
+
+def test_open_time_not_grid_aligned_is_rejected():
+    text = HEADER + _row(open_time=1751328000001, close_time=1751328060000) + "\n"
+    with pytest.raises(ks.InvalidOHLCVError, match="grid"):
+        ks.parse_kline_csv("BTCUSDT", text, 1751328000000, 1751328000000 + 2 * 60_000)
+
+
+# --------------------------------------------------------------------------- #
+# fail-closed: conflicting duplicate timestamps (AC4); identical dup dedupes
+# --------------------------------------------------------------------------- #
+def test_conflicting_duplicate_open_time_is_fail_closed():
+    # both rows individually valid OHLCV, but disagree on close -> conflict, not corruption
+    text = HEADER + _row(close=100.5) + "\n" + _row(close=100.6) + "\n"
+    with pytest.raises(ks.ConflictingDuplicateError):
+        ks.parse_kline_csv("BTCUSDT", text, 1751328000000, 1751328000000 + 60_000)
+
+
+def test_identical_duplicate_open_time_is_deduped_not_rejected():
+    text = HEADER + _row() + "\n" + _row() + "\n"
+    rows = ks.parse_kline_csv("BTCUSDT", text, 1751328000000, 1751328000000 + 60_000)
+    assert len(rows) == 1

--- a/research/nautilus_scalping/tests/test_rob941_manifest.py
+++ b/research/nautilus_scalping/tests/test_rob941_manifest.py
@@ -131,6 +131,48 @@ def test_validate_frozen_scope_rejects_tampered_window():
         tampered.validate_frozen_scope()
 
 
+def test_validate_frozen_scope_rejects_duplicate_kline_symbol():
+    m = _manifest()
+    tampered = CorpusManifest(
+        window_start_iso=m.window_start_iso,
+        window_end_iso=m.window_end_iso,
+        universe=m.universe,
+        eligibility=m.eligibility,
+        klines=m.klines + (m.klines[0],),  # duplicate first symbol
+        funding=m.funding,
+    )
+    with pytest.raises(ValueError, match="klines"):
+        tampered.validate_frozen_scope()
+
+
+def test_validate_frozen_scope_rejects_missing_kline_symbol():
+    m = _manifest()
+    tampered = CorpusManifest(
+        window_start_iso=m.window_start_iso,
+        window_end_iso=m.window_end_iso,
+        universe=m.universe,
+        eligibility=m.eligibility,
+        klines=m.klines[:-1],  # drop the last symbol's kline manifest
+        funding=m.funding,
+    )
+    with pytest.raises(ValueError, match="klines"):
+        tampered.validate_frozen_scope()
+
+
+def test_validate_frozen_scope_rejects_missing_funding_symbol():
+    m = _manifest()
+    tampered = CorpusManifest(
+        window_start_iso=m.window_start_iso,
+        window_end_iso=m.window_end_iso,
+        universe=m.universe,
+        eligibility=m.eligibility,
+        klines=m.klines,
+        funding=m.funding[:-1],
+    )
+    with pytest.raises(ValueError, match="funding"):
+        tampered.validate_frozen_scope()
+
+
 def test_validate_frozen_scope_rejects_tampered_btc_eligibility():
     m = _manifest()
     bad_eligibility = tuple(
@@ -198,3 +240,110 @@ def test_manifest_save_load_round_trip_preserves_content_hash(tmp_path):
     loaded = CorpusManifest.load(path)
     assert loaded.content_hash() == m.content_hash()
     loaded.validate_frozen_scope()
+
+
+# --------------------------------------------------------------------------- #
+# R1 I1 remediation: persisted-shard fields (offline load requires these)
+# --------------------------------------------------------------------------- #
+def test_archive_provenance_local_path_defaults_to_none_and_round_trips():
+    p = ArchiveProvenance(
+        url="https://data.binance.vision/x.zip",
+        checksum_url="https://data.binance.vision/x.zip.CHECKSUM",
+        checksum_sha256="a" * 64,
+    )
+    assert p.local_path is None
+    assert ArchiveProvenance.from_dict(p.to_dict()).local_path is None
+
+    p2 = ArchiveProvenance(
+        url="https://data.binance.vision/x.zip",
+        checksum_url="https://data.binance.vision/x.zip.CHECKSUM",
+        checksum_sha256="a" * 64,
+        local_path="rob941/raw/klines/X/x.zip",
+    )
+    assert (
+        ArchiveProvenance.from_dict(p2.to_dict()).local_path
+        == "rob941/raw/klines/X/x.zip"
+    )
+
+
+def test_archive_provenance_from_dict_defaults_missing_local_path_to_none():
+    # backward compat: an older persisted manifest without local_path must load
+    d = {
+        "url": "https://data.binance.vision/x.zip",
+        "checksum_url": "https://data.binance.vision/x.zip.CHECKSUM",
+        "checksum_sha256": "a" * 64,
+    }
+    assert ArchiveProvenance.from_dict(d).local_path is None
+
+
+def test_symbol_kline_manifest_shard_fields_default_to_none_and_round_trip():
+    k = _kline_manifest("XRPUSDT")
+    assert k.shard_path is None
+    assert k.shard_file_sha256 is None
+    assert SymbolKlineManifest.from_dict(k.to_dict()).shard_path is None
+
+    k2 = SymbolKlineManifest(
+        symbol="XRPUSDT",
+        interval="1m",
+        archives=_prov(),
+        normalized_shard_sha256="b" * 64,
+        shard_path="rob941/shards/klines/XRPUSDT-1m.parquet",
+        shard_file_sha256="d" * 64,
+        row_count=44640,
+        min_open_time_ms=scope.WINDOW_START_MS,
+        max_open_time_ms=scope.WINDOW_END_MS - 60_000,
+        gap_ranges=(),
+    )
+    reloaded = SymbolKlineManifest.from_dict(k2.to_dict())
+    assert reloaded.shard_path == "rob941/shards/klines/XRPUSDT-1m.parquet"
+    assert reloaded.shard_file_sha256 == "d" * 64
+
+
+def test_symbol_funding_manifest_shard_fields_default_to_none_and_round_trip():
+    f = _funding_manifest("XRPUSDT")
+    assert f.shard_path is None
+    assert f.shard_file_sha256 is None
+
+    f2 = SymbolFundingManifest(
+        symbol="XRPUSDT",
+        archives=_prov(),
+        normalized_shard_sha256="c" * 64,
+        shard_path="rob941/shards/funding/XRPUSDT-fundingRate.parquet",
+        shard_file_sha256="e" * 64,
+        row_count=90,
+        min_calc_time_ms=scope.WINDOW_START_MS,
+        max_calc_time_ms=scope.WINDOW_END_MS - 1000,
+    )
+    reloaded = SymbolFundingManifest.from_dict(f2.to_dict())
+    assert reloaded.shard_path == "rob941/shards/funding/XRPUSDT-fundingRate.parquet"
+    assert reloaded.shard_file_sha256 == "e" * 64
+
+
+def test_content_hash_changes_when_shard_path_is_added():
+    m1 = _manifest()
+    m2_klines = tuple(
+        SymbolKlineManifest(
+            symbol=k.symbol,
+            interval=k.interval,
+            archives=k.archives,
+            normalized_shard_sha256=k.normalized_shard_sha256,
+            shard_path="rob941/shards/klines/foo.parquet"
+            if k.symbol == "BTCUSDT"
+            else k.shard_path,
+            shard_file_sha256=k.shard_file_sha256,
+            row_count=k.row_count,
+            min_open_time_ms=k.min_open_time_ms,
+            max_open_time_ms=k.max_open_time_ms,
+            gap_ranges=k.gap_ranges,
+        )
+        for k in m1.klines
+    )
+    m2 = CorpusManifest(
+        window_start_iso=m1.window_start_iso,
+        window_end_iso=m1.window_end_iso,
+        universe=m1.universe,
+        eligibility=m1.eligibility,
+        klines=m2_klines,
+        funding=m1.funding,
+    )
+    assert m1.content_hash() != m2.content_hash()

--- a/research/nautilus_scalping/tests/test_rob941_manifest.py
+++ b/research/nautilus_scalping/tests/test_rob941_manifest.py
@@ -173,6 +173,96 @@ def test_validate_frozen_scope_rejects_missing_funding_symbol():
         tampered.validate_frozen_scope()
 
 
+# --------------------------------------------------------------------------- #
+# captain review (pre-R2 narrow integrity correction): universe/eligibility
+# duplicate-safe coverage. set()-based comparison and a value-only per-entry
+# eligibility loop both silently accept a duplicate/missing/reordered entry
+# whenever the resulting SET of symbols still happens to equal the frozen
+# universe -- these prove the exact-count, exact-order, exact-coverage
+# contract, not just "the right symbols appear somewhere".
+# --------------------------------------------------------------------------- #
+def test_validate_frozen_scope_rejects_duplicate_universe_entry_with_correct_multiset():
+    m = _manifest()
+    # 5 entries: BTCUSDT appears twice, but set(universe) is still exactly the
+    # frozen 4-symbol set -- a set()-based check cannot see this duplicate.
+    tampered = CorpusManifest(
+        window_start_iso=m.window_start_iso,
+        window_end_iso=m.window_end_iso,
+        universe=(*m.universe, "BTCUSDT"),
+        eligibility=m.eligibility,
+        klines=m.klines,
+        funding=m.funding,
+    )
+    with pytest.raises(ValueError, match="universe"):
+        tampered.validate_frozen_scope()
+
+
+def test_validate_frozen_scope_rejects_universe_out_of_canonical_order():
+    m = _manifest()
+    # same 4 symbols, same set -- but every manifest-producing call site in
+    # this codebase constructs universe=frozen.UNIVERSE verbatim, so canonical
+    # order IS the deterministic contract, not merely "same set".
+    reordered = tuple(reversed(m.universe))
+    assert set(reordered) == set(scope.UNIVERSE)  # sanity: same set, different order
+    assert reordered != scope.UNIVERSE
+    tampered = CorpusManifest(
+        window_start_iso=m.window_start_iso,
+        window_end_iso=m.window_end_iso,
+        universe=reordered,
+        eligibility=m.eligibility,
+        klines=m.klines,
+        funding=m.funding,
+    )
+    with pytest.raises(ValueError, match="universe"):
+        tampered.validate_frozen_scope()
+
+
+def test_validate_frozen_scope_rejects_missing_eligibility_entry():
+    m = _manifest()
+    # drop SOLUSDT's eligibility record entirely -- the remaining 3 entries are
+    # each individually correct, so a value-only per-entry loop never raises.
+    dropped = tuple(e for e in m.eligibility if e.symbol != "SOLUSDT")
+    assert len(dropped) == 3
+    tampered = CorpusManifest(
+        window_start_iso=m.window_start_iso,
+        window_end_iso=m.window_end_iso,
+        universe=m.universe,
+        eligibility=dropped,
+        klines=m.klines,
+        funding=m.funding,
+    )
+    with pytest.raises(ValueError, match="eligibility"):
+        tampered.validate_frozen_scope()
+
+
+def test_validate_frozen_scope_rejects_duplicate_eligibility_entry_with_valid_values():
+    m = _manifest()
+    # BTCUSDT's (individually correct) eligibility record duplicated in place
+    # of SOLUSDT's -- every entry present has a value-correct match against
+    # frozen.eligibility(), so the old per-entry-only loop never raises, even
+    # though SOLUSDT eligibility is now completely absent.
+    btc_record = next(e for e in m.eligibility if e.symbol == "BTCUSDT")
+    substituted = tuple(
+        btc_record if e.symbol == "SOLUSDT" else e for e in m.eligibility
+    )
+    assert sorted(e.symbol for e in substituted) == [
+        "BTCUSDT",
+        "BTCUSDT",
+        "DOGEUSDT",
+        "XRPUSDT",
+    ]
+    tampered = CorpusManifest(
+        window_start_iso=m.window_start_iso,
+        window_end_iso=m.window_end_iso,
+        universe=m.universe,
+        eligibility=substituted,
+        klines=m.klines,
+        funding=m.funding,
+    )
+    with pytest.raises(ValueError, match="eligibility"):
+        tampered.validate_frozen_scope()
+
+
 def test_validate_frozen_scope_rejects_tampered_btc_eligibility():
     m = _manifest()
     bad_eligibility = tuple(

--- a/research/nautilus_scalping/tests/test_rob941_manifest.py
+++ b/research/nautilus_scalping/tests/test_rob941_manifest.py
@@ -1,0 +1,200 @@
+"""ROB-941 (AC2/AC3/AC6) — the immutable corpus manifest.
+
+Covers: all 4 symbols share one frozen window, BTC's fixed eligibility record,
+tamper detection (``validate_frozen_scope``), content-hash determinism (same
+inputs -> same hash; any field change -> different hash), and a save/load
+round-trip that reproduces an identical hash (JSONB-style round-trip safety,
+same discipline as ``research_contracts.canonical_hash``).
+"""
+
+import pytest
+import rob941_archive_fetch as af
+import rob941_frozen_scope as scope
+from rob941_manifest import (
+    ArchiveProvenance,
+    CorpusManifest,
+    SymbolEligibility,
+    SymbolFundingManifest,
+    SymbolKlineManifest,
+)
+
+
+def test_archive_provenance_is_the_single_canonical_class_not_a_duplicate():
+    # regression guard: a live full-corpus run once broke here because
+    # rob941_manifest defined its OWN ArchiveProvenance (no .to_dict()) while
+    # rob941_corpus_builder actually produces rob941_archive_fetch.ArchiveProvenance
+    # instances -> SymbolKlineManifest.to_dict() blew up on real (non-fixture)
+    # objects even though every isolated unit test passed. Re-export, don't
+    # redefine, so this class of bug is structurally impossible.
+    assert ArchiveProvenance is af.ArchiveProvenance
+
+
+def _prov(n=1):
+    return tuple(
+        ArchiveProvenance(
+            url=f"https://data.binance.vision/data/futures/um/monthly/klines/X/1m/X-1m-2025-0{i}.zip",
+            checksum_url=f"https://data.binance.vision/data/futures/um/monthly/klines/X/1m/X-1m-2025-0{i}.zip.CHECKSUM",
+            checksum_sha256="a" * 64,
+        )
+        for i in range(1, n + 1)
+    )
+
+
+def _kline_manifest(symbol: str) -> SymbolKlineManifest:
+    return SymbolKlineManifest(
+        symbol=symbol,
+        interval="1m",
+        archives=_prov(),
+        normalized_shard_sha256="b" * 64,
+        row_count=44640,
+        min_open_time_ms=scope.WINDOW_START_MS,
+        max_open_time_ms=scope.WINDOW_END_MS - 60_000,
+        gap_ranges=(),
+    )
+
+
+def _funding_manifest(symbol: str) -> SymbolFundingManifest:
+    return SymbolFundingManifest(
+        symbol=symbol,
+        archives=_prov(),
+        normalized_shard_sha256="c" * 64,
+        row_count=90,
+        min_calc_time_ms=scope.WINDOW_START_MS,
+        max_calc_time_ms=scope.WINDOW_END_MS - 1000,
+    )
+
+
+def _eligibility_records():
+    return tuple(
+        SymbolEligibility(symbol=s, **scope.eligibility(s)) for s in scope.UNIVERSE
+    )
+
+
+def _manifest() -> CorpusManifest:
+    return CorpusManifest(
+        window_start_iso=scope.WINDOW_START_ISO,
+        window_end_iso=scope.WINDOW_END_ISO,
+        universe=scope.UNIVERSE,
+        eligibility=_eligibility_records(),
+        klines=tuple(_kline_manifest(s) for s in scope.UNIVERSE),
+        funding=tuple(_funding_manifest(s) for s in scope.UNIVERSE),
+    )
+
+
+def test_manifest_covers_exactly_the_frozen_four_symbol_universe():
+    m = _manifest()
+    assert m.universe == ("BTCUSDT", "XRPUSDT", "DOGEUSDT", "SOLUSDT")
+    assert {k.symbol for k in m.klines} == set(m.universe)
+    assert {f.symbol for f in m.funding} == set(m.universe)
+
+
+def test_manifest_all_symbols_share_one_frozen_window():
+    m = _manifest()
+    # window is a single top-level field (not per-symbol) -> structurally one window
+    assert m.window_start_iso == "2025-07-01T00:00:00Z"
+    assert m.window_end_iso == "2026-07-01T00:00:00Z"
+
+
+def test_manifest_btc_eligibility_is_exactly_the_frozen_record():
+    m = _manifest()
+    btc = next(e for e in m.eligibility if e.symbol == "BTCUSDT")
+    assert btc.historical_only is True
+    assert btc.demo_execution_eligible is False
+    assert btc.reason == "min_notional_50_exceeds_demo_cap_10"
+
+
+def test_manifest_non_btc_eligibility_is_demo_ready():
+    m = _manifest()
+    for e in m.eligibility:
+        if e.symbol == "BTCUSDT":
+            continue
+        assert e.historical_only is False
+        assert e.demo_execution_eligible is True
+        assert e.reason is None
+
+
+def test_validate_frozen_scope_accepts_conforming_manifest():
+    _manifest().validate_frozen_scope()  # must not raise
+
+
+def test_validate_frozen_scope_rejects_tampered_window():
+    m = _manifest()
+    tampered = CorpusManifest(
+        window_start_iso="2020-01-01T00:00:00Z",
+        window_end_iso=m.window_end_iso,
+        universe=m.universe,
+        eligibility=m.eligibility,
+        klines=m.klines,
+        funding=m.funding,
+    )
+    with pytest.raises(ValueError, match="window"):
+        tampered.validate_frozen_scope()
+
+
+def test_validate_frozen_scope_rejects_tampered_btc_eligibility():
+    m = _manifest()
+    bad_eligibility = tuple(
+        SymbolEligibility(
+            symbol="BTCUSDT",
+            historical_only=False,
+            demo_execution_eligible=True,
+            reason=None,
+        )
+        if e.symbol == "BTCUSDT"
+        else e
+        for e in m.eligibility
+    )
+    tampered = CorpusManifest(
+        window_start_iso=m.window_start_iso,
+        window_end_iso=m.window_end_iso,
+        universe=m.universe,
+        eligibility=bad_eligibility,
+        klines=m.klines,
+        funding=m.funding,
+    )
+    with pytest.raises(ValueError, match="BTCUSDT"):
+        tampered.validate_frozen_scope()
+
+
+# --------------------------------------------------------------------------- #
+# content hash: deterministic identity, changes on any field mutation
+# --------------------------------------------------------------------------- #
+def test_content_hash_is_deterministic_across_rebuilds():
+    assert _manifest().content_hash() == _manifest().content_hash()
+
+
+def test_content_hash_changes_when_a_gap_range_is_added():
+    m1 = _manifest()
+    m2_klines = tuple(
+        SymbolKlineManifest(
+            symbol=k.symbol,
+            interval=k.interval,
+            archives=k.archives,
+            normalized_shard_sha256=k.normalized_shard_sha256,
+            row_count=k.row_count,
+            min_open_time_ms=k.min_open_time_ms,
+            max_open_time_ms=k.max_open_time_ms,
+            gap_ranges=((scope.WINDOW_START_MS, scope.WINDOW_START_MS + 60_000),)
+            if k.symbol == "BTCUSDT"
+            else k.gap_ranges,
+        )
+        for k in m1.klines
+    )
+    m2 = CorpusManifest(
+        window_start_iso=m1.window_start_iso,
+        window_end_iso=m1.window_end_iso,
+        universe=m1.universe,
+        eligibility=m1.eligibility,
+        klines=m2_klines,
+        funding=m1.funding,
+    )
+    assert m1.content_hash() != m2.content_hash()
+
+
+def test_manifest_save_load_round_trip_preserves_content_hash(tmp_path):
+    m = _manifest()
+    path = tmp_path / "manifest.json"
+    m.save(path)
+    loaded = CorpusManifest.load(path)
+    assert loaded.content_hash() == m.content_hash()
+    loaded.validate_frozen_scope()

--- a/research/nautilus_scalping/tests/test_rob941_offline_loader.py
+++ b/research/nautilus_scalping/tests/test_rob941_offline_loader.py
@@ -1,0 +1,554 @@
+"""ROB-941 R1 I1 remediation — offline, network-0 loader for the persisted
+corpus. The fail-closed verification chain (per-shard: raw archive
+path/existence/SHA-256 -> shard path traversal -> file existence -> file
+SHA-256 -> EXACT Parquet schema [names+types+nullability+order] -> row
+canonical hash -> row count/min/max; corpus-level: exact symbol coverage,
+window/universe, per-row window membership, gap_ranges recomputation) is
+exercised end to end with ZERO network access: every test here uses only
+``rob941_persistence`` writes to a ``tmp_path`` artifact root and
+``rob941_offline_loader`` reads back from it. No ``opener``/urllib import is
+ever touched by this module or these tests.
+"""
+
+import dataclasses
+import hashlib
+
+import canonical_hash
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+import rob941_frozen_scope as scope
+import rob941_gaps as gaps
+import rob941_kline_schema as ks
+import rob941_offline_loader as loader
+import rob941_persistence as persist
+from funding_oi_archive import FundingRow
+from rob941_manifest import (
+    ArchiveProvenance,
+    CorpusManifest,
+    SymbolEligibility,
+    SymbolFundingManifest,
+    SymbolKlineManifest,
+)
+
+
+def _kline(open_time_ms: int, symbol: str = "XRPUSDT") -> ks.NormalizedKline:
+    return ks.NormalizedKline(
+        symbol=symbol,
+        open_time_ms=open_time_ms,
+        open=100.0,
+        high=101.0,
+        low=99.0,
+        close=100.5,
+        base_volume=10.0,
+        close_time_ms=open_time_ms + 59_999,
+        quote_volume=1000.0,
+        trade_count=5,
+        taker_buy_volume=4.0,
+        taker_buy_quote_volume=400.0,
+    )
+
+
+def _funding(calc_time: int) -> FundingRow:
+    return FundingRow(
+        calc_time=calc_time, funding_interval_hours=8, last_funding_rate=0.0001
+    )
+
+
+def _write_archive(
+    tmp_path,
+    symbol: str,
+    kind: str = "klines",
+    year: int = 2025,
+    month: int = 7,
+    content: bytes = b"fake-verified-archive-bytes",
+) -> ArchiveProvenance:
+    """A REAL persisted raw archive (arbitrary bytes -- verify_archives only
+    checks the physical SHA-256, it never parses the ZIP), with a matching
+    verified checksum -- exercises the exact same content-addressed write path
+    ``build_rob941_corpus.py`` uses."""
+    rel = persist.write_raw_archive(tmp_path, symbol, kind, year, month, content)
+    checksum = hashlib.sha256(content).hexdigest()
+    return ArchiveProvenance(
+        url=f"https://data.binance.vision/data/futures/um/monthly/{kind}/{symbol}/{symbol}-{kind}-{year:04d}-{month:02d}.zip",
+        checksum_url=f"https://data.binance.vision/data/futures/um/monthly/{kind}/{symbol}/{symbol}-{kind}-{year:04d}-{month:02d}.zip.CHECKSUM",
+        checksum_sha256=checksum,
+        local_path=rel,
+    )
+
+
+def _kline_manifest_from_written_shard(
+    tmp_path, symbol: str, rows: list[ks.NormalizedKline], archives=None, gap_ranges=()
+) -> SymbolKlineManifest:
+    if archives is None:
+        archives = (_write_archive(tmp_path, symbol, "klines"),)
+    rel_path, file_sha256 = persist.write_kline_shard(tmp_path, symbol, rows)
+    return SymbolKlineManifest(
+        symbol=symbol,
+        interval="1m",
+        archives=tuple(archives),
+        normalized_shard_sha256=canonical_hash.canonical_sha256(
+            [r.__dict__ for r in rows]
+        ),
+        shard_path=rel_path,
+        shard_file_sha256=file_sha256,
+        row_count=len(rows),
+        min_open_time_ms=rows[0].open_time_ms,
+        max_open_time_ms=rows[-1].open_time_ms,
+        gap_ranges=tuple(gap_ranges),
+    )
+
+
+def _funding_manifest_from_written_shard(
+    tmp_path, symbol: str, rows: list[FundingRow], archives=None
+) -> SymbolFundingManifest:
+    if archives is None:
+        archives = (_write_archive(tmp_path, symbol, "fundingRate"),)
+    rel_path, file_sha256 = persist.write_funding_shard(tmp_path, symbol, rows)
+    return SymbolFundingManifest(
+        symbol=symbol,
+        archives=tuple(archives),
+        normalized_shard_sha256=canonical_hash.canonical_sha256(
+            [r.__dict__ for r in rows]
+        ),
+        shard_path=rel_path,
+        shard_file_sha256=file_sha256,
+        row_count=len(rows),
+        min_calc_time_ms=rows[0].calc_time,
+        max_calc_time_ms=rows[-1].calc_time,
+    )
+
+
+def _kline_gap_ranges(rows: list[ks.NormalizedKline]) -> tuple:
+    return tuple(
+        gaps.detect_gap_ranges(
+            [r.open_time_ms for r in rows], scope.WINDOW_START_MS, scope.WINDOW_END_MS
+        )
+    )
+
+
+# --------------------------------------------------------------------------- #
+# happy path: fully offline round trip
+# --------------------------------------------------------------------------- #
+def test_load_kline_shard_offline_reproduces_written_rows(tmp_path):
+    rows = [_kline(1751328000000 + i * 60_000) for i in range(5)]
+    manifest = _kline_manifest_from_written_shard(tmp_path, "XRPUSDT", rows)
+    loaded = loader.load_kline_shard(manifest, tmp_path)
+    assert loaded == rows
+
+
+def test_load_funding_shard_offline_reproduces_written_rows(tmp_path):
+    rows = [_funding(1751328000000), _funding(1751356800000)]
+    manifest = _funding_manifest_from_written_shard(tmp_path, "DOGEUSDT", rows)
+    loaded = loader.load_funding_shard(manifest, tmp_path)
+    assert loaded == rows
+
+
+# --------------------------------------------------------------------------- #
+# fail-closed chain: raw archive verification (captain review follow-up)
+# --------------------------------------------------------------------------- #
+def test_load_kline_shard_raises_when_archive_local_path_is_none(tmp_path):
+    rows = [_kline(1751328000000)]
+    unmaterialized_archive = ArchiveProvenance(
+        url="https://data.binance.vision/x.zip",
+        checksum_url="https://data.binance.vision/x.zip.CHECKSUM",
+        checksum_sha256="a" * 64,
+        local_path=None,
+    )
+    manifest = _kline_manifest_from_written_shard(
+        tmp_path, "XRPUSDT", rows, archives=(unmaterialized_archive,)
+    )
+    with pytest.raises(loader.ArchiveFileMissingError):
+        loader.load_kline_shard(manifest, tmp_path)
+
+
+def test_load_kline_shard_raises_when_archive_file_missing_on_disk(tmp_path):
+    rows = [_kline(1751328000000)]
+    archive = _write_archive(tmp_path, "XRPUSDT")
+    (tmp_path / archive.local_path).unlink()
+    manifest = _kline_manifest_from_written_shard(
+        tmp_path, "XRPUSDT", rows, archives=(archive,)
+    )
+    with pytest.raises(loader.ArchiveFileMissingError):
+        loader.load_kline_shard(manifest, tmp_path)
+
+
+def test_load_kline_shard_raises_when_archive_bytes_tampered(tmp_path):
+    rows = [_kline(1751328000000)]
+    archive = _write_archive(tmp_path, "XRPUSDT")
+    path = tmp_path / archive.local_path
+    path.write_bytes(path.read_bytes() + b"\x00")
+    manifest = _kline_manifest_from_written_shard(
+        tmp_path, "XRPUSDT", rows, archives=(archive,)
+    )
+    with pytest.raises(loader.ArchiveFileTamperedError):
+        loader.load_kline_shard(manifest, tmp_path)
+
+
+def test_load_kline_shard_raises_when_archive_local_path_escapes_artifact_root(
+    tmp_path,
+):
+    rows = [_kline(1751328000000)]
+    archive = _write_archive(tmp_path, "XRPUSDT")
+    escaped = dataclasses.replace(archive, local_path="../../outside.zip")
+    manifest = _kline_manifest_from_written_shard(
+        tmp_path, "XRPUSDT", rows, archives=(escaped,)
+    )
+    with pytest.raises(loader.ShardPathEscapesArtifactRootError):
+        loader.load_kline_shard(manifest, tmp_path)
+
+
+def test_load_funding_shard_raises_when_archive_bytes_tampered(tmp_path):
+    rows = [_funding(1751328000000)]
+    archive = _write_archive(tmp_path, "DOGEUSDT", "fundingRate")
+    path = tmp_path / archive.local_path
+    path.write_bytes(b"totally different bytes")
+    manifest = _funding_manifest_from_written_shard(
+        tmp_path, "DOGEUSDT", rows, archives=(archive,)
+    )
+    with pytest.raises(loader.ArchiveFileTamperedError):
+        loader.load_funding_shard(manifest, tmp_path)
+
+
+# --------------------------------------------------------------------------- #
+# fail-closed chain: path traversal (shard)
+# --------------------------------------------------------------------------- #
+def test_load_kline_shard_rejects_shard_path_escaping_artifact_root(tmp_path):
+    rows = [_kline(1751328000000)]
+    manifest = _kline_manifest_from_written_shard(tmp_path, "XRPUSDT", rows)
+    escaped = dataclasses.replace(manifest, shard_path="../outside.parquet")
+    with pytest.raises(loader.ShardPathEscapesArtifactRootError):
+        loader.load_kline_shard(escaped, tmp_path)
+
+
+def test_load_kline_shard_rejects_absolute_shard_path(tmp_path):
+    rows = [_kline(1751328000000)]
+    manifest = _kline_manifest_from_written_shard(tmp_path, "XRPUSDT", rows)
+    escaped = dataclasses.replace(manifest, shard_path="/etc/passwd")
+    with pytest.raises(loader.ShardPathEscapesArtifactRootError):
+        loader.load_kline_shard(escaped, tmp_path)
+
+
+# --------------------------------------------------------------------------- #
+# fail-closed chain: file existence
+# --------------------------------------------------------------------------- #
+def test_load_kline_shard_raises_when_shard_path_is_none(tmp_path):
+    rows = [_kline(1751328000000)]
+    manifest = _kline_manifest_from_written_shard(tmp_path, "XRPUSDT", rows)
+    unmaterialized = dataclasses.replace(manifest, shard_path=None)
+    with pytest.raises(loader.ShardFileMissingError):
+        loader.load_kline_shard(unmaterialized, tmp_path)
+
+
+def test_load_kline_shard_raises_when_file_absent_on_disk(tmp_path):
+    rows = [_kline(1751328000000)]
+    manifest = _kline_manifest_from_written_shard(tmp_path, "XRPUSDT", rows)
+    (tmp_path / manifest.shard_path).unlink()
+    with pytest.raises(loader.ShardFileMissingError):
+        loader.load_kline_shard(manifest, tmp_path)
+
+
+# --------------------------------------------------------------------------- #
+# fail-closed chain: physical file SHA-256 (tamper detection)
+# --------------------------------------------------------------------------- #
+def test_load_kline_shard_raises_when_file_bytes_tampered(tmp_path):
+    rows = [_kline(1751328000000 + i * 60_000) for i in range(3)]
+    manifest = _kline_manifest_from_written_shard(tmp_path, "XRPUSDT", rows)
+    path = tmp_path / manifest.shard_path
+    path.write_bytes(path.read_bytes() + b"\x00")
+    with pytest.raises(loader.ShardFileTamperedError):
+        loader.load_kline_shard(manifest, tmp_path)
+
+
+# --------------------------------------------------------------------------- #
+# fail-closed chain: EXACT schema (names + types + nullability + order)
+# --------------------------------------------------------------------------- #
+def test_load_kline_shard_raises_on_schema_mismatch(tmp_path):
+    rows = [_kline(1751328000000)]
+    manifest = _kline_manifest_from_written_shard(tmp_path, "XRPUSDT", rows)
+    path = tmp_path / manifest.shard_path
+    # overwrite with a structurally different (but validly-formed) parquet file
+    bad_table = pa.table({"only_one_column": [1, 2, 3]})
+    pq.write_table(bad_table, path)
+    bad_manifest = dataclasses.replace(
+        manifest, shard_file_sha256=hashlib.sha256(path.read_bytes()).hexdigest()
+    )
+    with pytest.raises(loader.ShardSchemaMismatchError):
+        loader.load_kline_shard(bad_manifest, tmp_path)
+
+
+def test_load_kline_shard_raises_on_schema_type_mismatch_even_with_matching_column_names(
+    tmp_path,
+):
+    rows = [_kline(1751328000000)]
+    manifest = _kline_manifest_from_written_shard(tmp_path, "XRPUSDT", rows)
+    path = tmp_path / manifest.shard_path
+    # SAME column names/order as the pinned schema, but open_time_ms is int32
+    # instead of int64 -- a names-only check would miss this.
+    wrong_type_schema = pa.schema(
+        [
+            pa.field(name, pa.int32() if name == "open_time_ms" else field.type)
+            for name, field in zip(
+                persist.KLINE_COLUMN_ORDER, persist.KLINE_SCHEMA, strict=True
+            )
+        ]
+    )
+    columns = {
+        "symbol": ["XRPUSDT"],
+        "open_time_ms": [1751328000000 % (2**31)],
+        "open": [100.0],
+        "high": [101.0],
+        "low": [99.0],
+        "close": [100.5],
+        "base_volume": [10.0],
+        "close_time_ms": [1751328059999],
+        "quote_volume": [1000.0],
+        "trade_count": [5],
+        "taker_buy_volume": [4.0],
+        "taker_buy_quote_volume": [400.0],
+    }
+    pq.write_table(pa.table(columns, schema=wrong_type_schema), path)
+    bad_manifest = dataclasses.replace(
+        manifest, shard_file_sha256=hashlib.sha256(path.read_bytes()).hexdigest()
+    )
+    with pytest.raises(loader.ShardSchemaMismatchError):
+        loader.load_kline_shard(bad_manifest, tmp_path)
+
+
+# --------------------------------------------------------------------------- #
+# fail-closed chain: canonical row content hash
+# --------------------------------------------------------------------------- #
+def test_load_kline_shard_raises_when_declared_row_hash_does_not_match_file_content(
+    tmp_path,
+):
+    rows = [_kline(1751328000000 + i * 60_000) for i in range(3)]
+    manifest = _kline_manifest_from_written_shard(tmp_path, "XRPUSDT", rows)
+    # file bytes are intact (file_sha256 still correct) but the manifest's
+    # declared logical-content hash has drifted from what's actually on disk
+    corrupted = dataclasses.replace(manifest, normalized_shard_sha256="f" * 64)
+    with pytest.raises(loader.ShardContentTamperedError):
+        loader.load_kline_shard(corrupted, tmp_path)
+
+
+# --------------------------------------------------------------------------- #
+# fail-closed chain: row count / min / max (independent metadata fields)
+# --------------------------------------------------------------------------- #
+def test_load_kline_shard_raises_on_row_count_mismatch(tmp_path):
+    rows = [_kline(1751328000000 + i * 60_000) for i in range(5)]
+    manifest = _kline_manifest_from_written_shard(tmp_path, "XRPUSDT", rows)
+    corrupted = dataclasses.replace(manifest, row_count=999)
+    with pytest.raises(loader.ShardRowCountMismatchError):
+        loader.load_kline_shard(corrupted, tmp_path)
+
+
+def test_load_kline_shard_raises_on_min_open_time_mismatch(tmp_path):
+    rows = [_kline(1751328000000 + i * 60_000) for i in range(5)]
+    manifest = _kline_manifest_from_written_shard(tmp_path, "XRPUSDT", rows)
+    corrupted = dataclasses.replace(manifest, min_open_time_ms=1)
+    with pytest.raises(loader.ShardTimeRangeMismatchError):
+        loader.load_kline_shard(corrupted, tmp_path)
+
+
+def test_load_kline_shard_raises_on_max_open_time_mismatch(tmp_path):
+    rows = [_kline(1751328000000 + i * 60_000) for i in range(5)]
+    manifest = _kline_manifest_from_written_shard(tmp_path, "XRPUSDT", rows)
+    corrupted = dataclasses.replace(manifest, max_open_time_ms=99_999_999_999)
+    with pytest.raises(loader.ShardTimeRangeMismatchError):
+        loader.load_kline_shard(corrupted, tmp_path)
+
+
+def test_load_funding_shard_raises_on_row_count_mismatch(tmp_path):
+    rows = [_funding(1751328000000), _funding(1751356800000)]
+    manifest = _funding_manifest_from_written_shard(tmp_path, "DOGEUSDT", rows)
+    corrupted = dataclasses.replace(manifest, row_count=999)
+    with pytest.raises(loader.ShardRowCountMismatchError):
+        loader.load_funding_shard(corrupted, tmp_path)
+
+
+# --------------------------------------------------------------------------- #
+# corpus-level: window/universe (validate_frozen_scope) + all-4-symbol offline load
+# --------------------------------------------------------------------------- #
+def _full_corpus_manifest(tmp_path) -> CorpusManifest:
+    klines = []
+    funding = []
+    for idx, symbol in enumerate(scope.UNIVERSE):
+        krows = [
+            _kline(scope.WINDOW_START_MS + (idx * 10 + i) * 60_000, symbol=symbol)
+            for i in range(5)
+        ]
+        klines.append(
+            _kline_manifest_from_written_shard(
+                tmp_path, symbol, krows, gap_ranges=_kline_gap_ranges(krows)
+            )
+        )
+        frows = [_funding(scope.WINDOW_START_MS + idx * 8 * 3_600_000)]
+        funding.append(_funding_manifest_from_written_shard(tmp_path, symbol, frows))
+    eligibility = tuple(
+        SymbolEligibility(symbol=s, **scope.eligibility(s)) for s in scope.UNIVERSE
+    )
+    return CorpusManifest(
+        window_start_iso=scope.WINDOW_START_ISO,
+        window_end_iso=scope.WINDOW_END_ISO,
+        universe=scope.UNIVERSE,
+        eligibility=eligibility,
+        klines=tuple(klines),
+        funding=tuple(funding),
+    )
+
+
+def test_load_corpus_offline_loads_all_four_symbols_with_zero_network(tmp_path):
+    manifest = _full_corpus_manifest(tmp_path)
+    result = loader.load_corpus(manifest, tmp_path)
+    assert set(result["klines"]) == set(scope.UNIVERSE)
+    assert set(result["funding"]) == set(scope.UNIVERSE)
+    for symbol in scope.UNIVERSE:
+        assert len(result["klines"][symbol]) == 5
+        assert len(result["funding"][symbol]) == 1
+
+
+def test_load_corpus_rejects_tampered_window(tmp_path):
+    manifest = _full_corpus_manifest(tmp_path)
+    tampered = dataclasses.replace(manifest, window_start_iso="2020-01-01T00:00:00Z")
+    with pytest.raises(ValueError, match="window"):
+        loader.load_corpus(tampered, tmp_path)
+
+
+def test_load_corpus_round_trip_from_saved_manifest_json_is_fully_offline(tmp_path):
+    manifest = _full_corpus_manifest(tmp_path)
+    manifest_path = tmp_path / "manifest.json"
+    manifest.save(manifest_path)
+    reloaded_manifest = CorpusManifest.load(manifest_path)
+    result = loader.load_corpus(reloaded_manifest, tmp_path)
+    assert set(result["klines"]) == set(scope.UNIVERSE)
+
+
+# --------------------------------------------------------------------------- #
+# corpus-level (captain review follow-up): exact symbol coverage
+# --------------------------------------------------------------------------- #
+def test_load_corpus_raises_on_duplicate_kline_symbol(tmp_path):
+    manifest = _full_corpus_manifest(tmp_path)
+    tampered = dataclasses.replace(
+        manifest, klines=manifest.klines + (manifest.klines[0],)
+    )
+    with pytest.raises(ValueError, match="klines"):
+        loader.load_corpus(tampered, tmp_path)
+
+
+def test_load_corpus_raises_on_missing_funding_symbol(tmp_path):
+    manifest = _full_corpus_manifest(tmp_path)
+    tampered = dataclasses.replace(manifest, funding=manifest.funding[:-1])
+    with pytest.raises(ValueError, match="funding"):
+        loader.load_corpus(tampered, tmp_path)
+
+
+# --------------------------------------------------------------------------- #
+# corpus-level (captain review follow-up): every row inside the frozen window
+# --------------------------------------------------------------------------- #
+def test_load_corpus_raises_when_a_kline_row_lies_outside_the_frozen_window(tmp_path):
+    manifest = _full_corpus_manifest(tmp_path)
+    symbol = scope.UNIVERSE[0]
+    out_of_window_ms = scope.WINDOW_START_MS - 60_000  # one minute BEFORE the window
+    bad_rows = [_kline(out_of_window_ms, symbol=symbol)]
+    bad_kline_manifest = _kline_manifest_from_written_shard(
+        tmp_path, symbol, bad_rows, gap_ranges=()
+    )
+    tampered_klines = tuple(
+        bad_kline_manifest if k.symbol == symbol else k for k in manifest.klines
+    )
+    tampered = dataclasses.replace(manifest, klines=tampered_klines)
+    with pytest.raises(loader.ShardWindowViolationError):
+        loader.load_corpus(tampered, tmp_path)
+
+
+def test_load_corpus_raises_when_a_funding_row_lies_outside_the_frozen_window(tmp_path):
+    manifest = _full_corpus_manifest(tmp_path)
+    symbol = scope.UNIVERSE[0]
+    out_of_window_ms = scope.WINDOW_END_MS + 3_600_000  # one hour AFTER the window
+    bad_rows = [_funding(out_of_window_ms)]
+    bad_funding_manifest = _funding_manifest_from_written_shard(
+        tmp_path, symbol, bad_rows
+    )
+    tampered_funding = tuple(
+        bad_funding_manifest if f.symbol == symbol else f for f in manifest.funding
+    )
+    tampered = dataclasses.replace(manifest, funding=tampered_funding)
+    with pytest.raises(loader.ShardWindowViolationError):
+        loader.load_corpus(tampered, tmp_path)
+
+
+# --------------------------------------------------------------------------- #
+# corpus-level (captain review follow-up): gap_ranges recomputation
+# --------------------------------------------------------------------------- #
+def test_load_corpus_raises_when_declared_gap_ranges_do_not_match_recomputed(tmp_path):
+    manifest = _full_corpus_manifest(tmp_path)
+    symbol = scope.UNIVERSE[0]
+    wrong_gap_kline = dataclasses.replace(
+        next(k for k in manifest.klines if k.symbol == symbol), gap_ranges=()
+    )
+    tampered_klines = tuple(
+        wrong_gap_kline if k.symbol == symbol else k for k in manifest.klines
+    )
+    tampered = dataclasses.replace(manifest, klines=tampered_klines)
+    with pytest.raises(loader.ShardGapRangesMismatchError):
+        loader.load_corpus(tampered, tmp_path)
+
+
+def test_load_corpus_accepts_correctly_recomputed_gap_ranges_with_a_real_gap(tmp_path):
+    # 5 bars with the 3rd minute skipped -> one genuine 1-minute gap
+    symbol = "XRPUSDT"
+    rows = [
+        _kline(scope.WINDOW_START_MS + i * 60_000, symbol=symbol) for i in (0, 1, 3, 4)
+    ]
+    kline_manifest = _kline_manifest_from_written_shard(
+        tmp_path, symbol, rows, gap_ranges=_kline_gap_ranges(rows)
+    )
+    assert kline_manifest.gap_ranges  # sanity: a real gap was recorded
+    frows = [_funding(scope.WINDOW_START_MS)]
+    funding_manifest = _funding_manifest_from_written_shard(tmp_path, symbol, frows)
+    eligibility = tuple(
+        SymbolEligibility(symbol=s, **scope.eligibility(s)) for s in scope.UNIVERSE
+    )
+    other_klines = []
+    other_funding = []
+    for other_symbol in scope.UNIVERSE:
+        if other_symbol == symbol:
+            continue
+        orows = [_kline(scope.WINDOW_START_MS, symbol=other_symbol)]
+        other_klines.append(
+            _kline_manifest_from_written_shard(
+                tmp_path, other_symbol, orows, gap_ranges=_kline_gap_ranges(orows)
+            )
+        )
+        ofrows = [_funding(scope.WINDOW_START_MS)]
+        other_funding.append(
+            _funding_manifest_from_written_shard(tmp_path, other_symbol, ofrows)
+        )
+    manifest = CorpusManifest(
+        window_start_iso=scope.WINDOW_START_ISO,
+        window_end_iso=scope.WINDOW_END_ISO,
+        universe=scope.UNIVERSE,
+        eligibility=eligibility,
+        klines=(kline_manifest, *other_klines),
+        funding=(funding_manifest, *other_funding),
+    )
+    result = loader.load_corpus(manifest, tmp_path)
+    assert len(result["klines"][symbol]) == 4
+
+
+def test_offline_loader_module_never_imports_urllib_or_network_openers():
+    import ast
+    from pathlib import Path
+
+    src = Path(loader.__file__).read_text()
+    tree = ast.parse(src)
+    forbidden = {"urllib", "requests", "httpx", "socket"}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            names = [n.name.split(".")[0] for n in node.names]
+        elif isinstance(node, ast.ImportFrom):
+            names = [(node.module or "").split(".")[0]]
+        else:
+            continue
+        assert not (set(names) & forbidden), (
+            f"offline loader must never import network modules: {names}"
+        )

--- a/research/nautilus_scalping/tests/test_rob941_persistence.py
+++ b/research/nautilus_scalping/tests/test_rob941_persistence.py
@@ -1,0 +1,157 @@
+"""ROB-941 R1 I1 remediation — persist raw archives + normalized Parquet shards
+under a gitignored artifact root (``artifact_paths.pit_data_root()`` convention).
+
+Covers: deterministic relative-path layout, physical file SHA-256 pinning, and
+that a written Parquet shard round-trips to byte-identical row content (so the
+canonical row hash computed at build time reproduces at load time).
+"""
+
+import hashlib
+
+import pyarrow.parquet as pq
+import rob941_kline_schema as ks
+import rob941_persistence as persist
+from funding_oi_archive import FundingRow
+
+
+def _kline(open_time_ms: int, symbol: str = "XRPUSDT") -> ks.NormalizedKline:
+    return ks.NormalizedKline(
+        symbol=symbol,
+        open_time_ms=open_time_ms,
+        open=100.0,
+        high=101.0,
+        low=99.0,
+        close=100.5,
+        base_volume=10.0,
+        close_time_ms=open_time_ms + 59_999,
+        quote_volume=1000.0,
+        trade_count=5,
+        taker_buy_volume=4.0,
+        taker_buy_quote_volume=400.0,
+    )
+
+
+def _funding(calc_time: int) -> FundingRow:
+    return FundingRow(
+        calc_time=calc_time, funding_interval_hours=8, last_funding_rate=0.0001
+    )
+
+
+def test_raw_archive_relative_path_is_artifact_root_relative_posix():
+    rel = persist.raw_archive_relative_path("XRPUSDT", "klines", 2025, 7, "a" * 64)
+    assert not rel.startswith("/")
+    assert "\\" not in rel
+    assert rel.endswith(f"XRPUSDT-klines-2025-07.{'a' * 64}.zip")
+
+
+def test_raw_archive_relative_path_is_content_addressed_by_checksum():
+    a = persist.raw_archive_relative_path("XRPUSDT", "klines", 2025, 7, "a" * 64)
+    b = persist.raw_archive_relative_path("XRPUSDT", "klines", 2025, 7, "b" * 64)
+    assert (
+        a != b
+    )  # different checksum -> different path, even for the same symbol/month
+
+
+def test_write_raw_archive_is_idempotent_for_identical_bytes(tmp_path):
+    zip_bytes = b"identical content"
+    rel1 = persist.write_raw_archive(tmp_path, "XRPUSDT", "klines", 2025, 7, zip_bytes)
+    rel2 = persist.write_raw_archive(tmp_path, "XRPUSDT", "klines", 2025, 7, zip_bytes)
+    assert rel1 == rel2
+    assert (tmp_path / rel1).read_bytes() == zip_bytes
+
+
+def test_write_raw_archive_different_bytes_land_at_different_paths(tmp_path):
+    rel1 = persist.write_raw_archive(
+        tmp_path, "XRPUSDT", "klines", 2025, 7, b"content A"
+    )
+    rel2 = persist.write_raw_archive(
+        tmp_path, "XRPUSDT", "klines", 2025, 7, b"content B"
+    )
+    assert rel1 != rel2
+    assert (tmp_path / rel1).read_bytes() == b"content A"
+    assert (tmp_path / rel2).read_bytes() == b"content B"
+
+
+def test_write_raw_archive_persists_exact_bytes_under_artifact_root(tmp_path):
+    zip_bytes = b"not a real zip but exact bytes must round-trip"
+    rel = persist.write_raw_archive(tmp_path, "XRPUSDT", "klines", 2025, 7, zip_bytes)
+    written = tmp_path / rel
+    assert written.is_file()
+    assert written.read_bytes() == zip_bytes
+
+
+def test_write_kline_shard_produces_parquet_with_pinned_schema_and_column_order(
+    tmp_path,
+):
+    rows = [_kline(1751328000000 + i * 60_000) for i in range(5)]
+    rel_path, file_sha256 = persist.write_kline_shard(tmp_path, "XRPUSDT", rows)
+    dest = tmp_path / rel_path
+    assert dest.is_file()
+    table = pq.read_table(dest)
+    assert table.column_names == list(persist.KLINE_COLUMN_ORDER)
+    assert table.num_rows == 5
+
+
+def test_write_kline_shard_file_sha256_matches_actual_file_bytes(tmp_path):
+    rows = [_kline(1751328000000)]
+    rel_path, file_sha256 = persist.write_kline_shard(tmp_path, "XRPUSDT", rows)
+    actual = hashlib.sha256((tmp_path / rel_path).read_bytes()).hexdigest()
+    assert file_sha256 == actual
+
+
+def test_write_kline_shard_round_trips_row_values_exactly(tmp_path):
+    rows = [_kline(1751328000000 + i * 60_000) for i in range(3)]
+    rel_path, _ = persist.write_kline_shard(tmp_path, "XRPUSDT", rows)
+    table = pq.read_table(tmp_path / rel_path)
+    reloaded = [ks.NormalizedKline(**d) for d in table.to_pylist()]
+    assert reloaded == rows
+
+
+def test_write_funding_shard_produces_parquet_with_pinned_schema(tmp_path):
+    rows = [_funding(1751328000000), _funding(1751356800000)]
+    rel_path, file_sha256 = persist.write_funding_shard(tmp_path, "DOGEUSDT", rows)
+    dest = tmp_path / rel_path
+    assert dest.is_file()
+    table = pq.read_table(dest)
+    assert table.column_names == list(persist.FUNDING_COLUMN_ORDER)
+    actual = hashlib.sha256(dest.read_bytes()).hexdigest()
+    assert file_sha256 == actual
+
+
+def test_write_funding_shard_round_trips_row_values_exactly(tmp_path):
+    rows = [_funding(1751328000000), _funding(1751356800000)]
+    rel_path, _ = persist.write_funding_shard(tmp_path, "DOGEUSDT", rows)
+    table = pq.read_table(tmp_path / rel_path)
+    reloaded = [FundingRow(**d) for d in table.to_pylist()]
+    assert reloaded == rows
+
+
+def test_write_kline_shard_is_content_addressed_and_idempotent(tmp_path):
+    rows = [_kline(1751328000000 + i * 60_000) for i in range(5)]
+    rel1, sha1 = persist.write_kline_shard(tmp_path, "XRPUSDT", rows)
+    rel2, sha2 = persist.write_kline_shard(tmp_path, "XRPUSDT", rows)
+    assert rel1 == rel2
+    assert sha1 == sha2
+
+    different_rows = [_kline(1751328000000 + i * 60_000) for i in range(3)]
+    rel3, _ = persist.write_kline_shard(tmp_path, "XRPUSDT", different_rows)
+    assert rel3 != rel1  # different content -> different content-addressed path
+
+
+def test_write_funding_shard_is_content_addressed_and_idempotent(tmp_path):
+    rows = [_funding(1751328000000)]
+    rel1, sha1 = persist.write_funding_shard(tmp_path, "DOGEUSDT", rows)
+    rel2, sha2 = persist.write_funding_shard(tmp_path, "DOGEUSDT", rows)
+    assert rel1 == rel2
+    assert sha1 == sha2
+
+
+def test_kline_and_funding_shard_paths_do_not_collide_across_symbols():
+    same_hash = "c" * 64
+    a = persist.kline_shard_relative_path("XRPUSDT", same_hash)
+    b = persist.kline_shard_relative_path("DOGEUSDT", same_hash)
+    assert a != b
+    fa = persist.funding_shard_relative_path("XRPUSDT", same_hash)
+    fb = persist.funding_shard_relative_path("DOGEUSDT", same_hash)
+    assert fa != fb
+    assert a != fa  # kline vs funding shard paths are namespaced apart


### PR DESCRIPTION
## Summary
- Checksum-**mandatory** Binance USD-M public archive fetch (`data.binance.vision/data/futures/um` only) — missing archive/missing `.CHECKSUM`/mismatch/corrupt ZIP/corrupt CSV all fail closed (unlike `pit_klines_fetcher.py`'s best-effort checksum).
- Normalized 1m kline schema preserving symbol/open_time_ms/OHLC/base_volume/close_time_ms/quote_volume/trade_count/taker_buy fields, with fail-closed validation: invalid OHLCV, 59/61s bar duration, off-grid `open_time`, conflicting duplicate timestamps (identical duplicates dedupe).
- Gap tracking that never deletes/forward-fills/synthesizes: `detect_gap_ranges`, `incomplete_buckets` (5m/15m), and the `position_touches_gap` predicate for the `rejected:data_gap_in_position` rule.
- PIT-safe funding-rate sidecar (`last_known_rate` for the entry gate, `realized_crossings` for PnL) — no lookahead, no execution/PnL math (that stays with the execution engine).
- The immutable corpus manifest (`rob941_manifest.py`) tying frozen universe/window/eligibility + per-symbol archive provenance + gap accounting into one canonical, hash-stable, tamper-detecting artifact (`validate_frozen_scope`, `content_hash`).
- **Full live corpus build executed and committed**: `data_manifests/rob941_corpus_manifest.v1.json` — BTCUSDT/XRPUSDT/DOGEUSDT/SOLUSDT, 2025-07-01T00:00:00Z–2026-07-01T00:00:00Z, 525,600 1m bars + 1,095 funding events per symbol, **zero gaps**, `content_hash=90b0e81e7564c7c0e4870120bcf36d9e3e95a9a2b87611c5462aac311b3245f6`.
- BTC is `historical_only=true`/`demo_execution_eligible=false`/`reason=min_notional_50_exceeds_demo_cap_10`; XRP/DOGE/SOL are demo-eligible.

## Scope discipline
- No broker/order/fill/scheduler wiring, no ROB-905 gate calls, no production DB writes, no `crypto_candles_1m` writes.
- No secrets printed; only public `data.binance.vision` URLs and public checksums.
- Only one shared file touched: `tests/test_pit_data_layer_guard.py`, additive-only (registered the new `rob941_*` modules in the existing no-`app`-import guard list).
- No H2 (execution engine / bar-ordering / trade ledger) files touched.

## Notable finding
The full live build initially crashed with `AttributeError: 'ArchiveProvenance' object has no attribute 'to_dict'` — two independent `ArchiveProvenance` dataclasses existed (one in `rob941_archive_fetch.py`, a duplicate in `rob941_manifest.py`), and every fixture-only unit test happened to construct manifest objects via the local (non-canonical) class, so the mismatch never surfaced until the real corpus_builder→manifest pipeline ran end-to-end. Fixed by making `rob941_archive_fetch.ArchiveProvenance` the single canonical definition (re-exported, not redefined, from `rob941_manifest`) and adding a permanent identity regression test (`test_archive_provenance_is_the_single_canonical_class_not_a_duplicate`).

## Test plan
- [x] TDD RED: all 7 new modules imported by name before existing — captured `ModuleNotFoundError` collection failures for all test files.
- [x] GREEN: `uv run python -m pytest research/nautilus_scalping/tests/test_rob941_*.py research/nautilus_scalping/tests/test_pit_data_layer_guard.py -q` → 69 passed (net of the manifest regression test added post-live-bug: 70).
- [x] Full suite regression check: `uv run python -m pytest research/nautilus_scalping/tests/ -q --ignore=.../test_signal_parity.py` → 428 passed, 4 skipped (live tests, correctly gated), same 7 pre-existing unrelated failures as baseline (missing local OHLCV fixtures on disk + one stale interval-set assertion, both predate this change).
- [x] Opt-in live network test (`ROB941_RUN_LIVE=1 pytest .../test_rob941_corpus_builder_live.py`) — 3/3 passed against real `data.binance.vision`.
- [x] Full 4-symbol × 12-month live corpus build executed and verified (content_hash reproduces exactly on save/load round-trip; `validate_frozen_scope()` passes).
- [x] `ruff check` / `ruff format --check` / `ty check` clean on every new/changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a frozen, four-symbol historical data corpus covering klines and funding rates for a 12-month window.
  * Added checksum-verified archive retrieval, normalized Parquet persistence, and deterministic manifest generation.
  * Added offline loading with strict integrity, schema, time-window, and gap validation.
  * Added PIT-safe funding-rate lookups and explicit missing-data gap tracking.
* **Bug Fixes**
  * Invalid, incomplete, tampered, or conflicting data now fails closed without publishing partial results.
* **Tests**
  * Added comprehensive offline, determinism, integrity, and opt-in live-data coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->