### PR TITLE
[strategy] ROB-943 H3 — exact deterministic signals + frozen 24-row manifest

### DIFF
--- a/research/nautilus_scalping/rob940_signal_manifest.py
+++ b/research/nautilus_scalping/rob940_signal_manifest.py
@@ -1,0 +1,270 @@
+"""ROB-943 (H3, ROB-940) — exact frozen 24-row signal manifest (pure, stdlib).
+
+Fable Q1=A (``orch-fable-answer-strategy-20260717.md``): the 12-config/strategy
+shortlist below (24 rows total) is byte-stable and frozen exactly as approved
+— row order, param values, and the ex-ante hypothesis phrases from the
+consult doc (``strategy-fable-consult-20260717-123049.md``). Any change to
+this manifest is a NEW campaign lineage, not an edit.
+
+S1-07 (payoff ratio 1.50, SL floor 45bp -> TP 67.5bp) sits below the
+execution-layer 68bp gate and can be a structural no-trade config in
+low-volatility regimes. It is retained deliberately (orch: "저변동 체제에서
+거래 불가한 payoff 설정"이라는 해석 가능한 가설) — do not delete it.
+
+This module owns identity/registration only: NO signal math, NO 81-grid
+generator API, NO parameter search. ``signal_manifest_hash`` identifies the
+24-row manifest itself; it is NOT the H4 full-campaign hash (walk-forward
+window/cost model/selection rule are separate identity components there) —
+do not conflate the two.
+
+No DB/network/app/broker/random/current-time imports — pure stdlib plus the
+existing research_contracts canonical-hash authority, deterministic given no
+input (the manifest is a fixed literal).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import NamedTuple
+
+from research_contracts.canonical_hash import canonical_sha256
+
+# AC8/ROB-943 spec: four symbols share IDENTICAL code/config. No per-symbol
+# override exists anywhere in this module (no BTC-only threshold path).
+SYMBOLS: tuple[str, ...] = ("BTCUSDT", "XRPUSDT", "DOGEUSDT", "SOLUSDT")
+
+# Exact 3-value exploration domains per free parameter (ROB-940 research
+# draft table). Explored ex-ante shortlist rows (below) must draw every
+# param value from these sets — no 81-grid generator, this is validation
+# only for the pre-registered 12 rows/strategy.
+S1_DOMAINS: dict[str, tuple[float, ...]] = {
+    "L": (12, 16, 24),
+    "q_min": (1.00, 1.25, 1.50),
+    "k_SL": (1.00, 1.25, 1.50),
+    "R_TP": (1.50, 1.80, 2.00),
+}
+S2_DOMAINS: dict[str, tuple[float, ...]] = {
+    "z_min": (2.75, 3.00, 3.25),
+    "v_min": (1.50, 2.00, 2.50),
+    "ER_max": (0.25, 0.35, 0.45),
+    "R_min": (1.20, 1.25, 1.35),
+}
+
+
+@dataclass(frozen=True)
+class S1Config:
+    L: int
+    q_min: float
+    k_SL: float
+    R_TP: float
+    config_id: str
+    hypothesis: str
+
+
+@dataclass(frozen=True)
+class S2Config:
+    z_min: float
+    v_min: float
+    ER_max: float
+    R_min: float
+    config_id: str
+    hypothesis: str
+
+
+# ultrathink: fixed (non-tunable) constants shared by every config row of a
+# strategy. Kept OUT of signal_manifest_hash (that hash identifies the
+# 24-row config shortlist specifically) but validated by dedicated tests so
+# a silent edit to e.g. the ATR period or the S2 288-bar window fails a test
+# rather than drifting unnoticed.
+class FrozenSignalConstants(NamedTuple):
+    ATR_PERIOD: int
+    VOLUME_MEDIAN_WINDOW: int
+    A_T_MIN: float
+    A_T_MAX: float
+    CHASE_MAX_ATR_MULT: float
+    S1_SL_CLIP_MIN_BPS: float
+    S1_SL_CLIP_MAX_BPS: float
+    S1_TIMEOUT_1M_BARS: int
+    S1_COOLDOWN_1M_BARS: int
+    S2_MAD_WINDOW: int
+    S2_ER_WINDOW: int
+    S2_SHOCK_ABS_RETURN_MIN: float
+    S2_SL_CLIP_MIN_BPS: float
+    S2_SL_CLIP_MAX_BPS: float
+    S2_TP_MAX_BPS: float
+    S2_TP_ABS_FLOOR_BPS: float
+    S2_TIMEOUT_1M_BARS: int
+    S2_COOLDOWN_1M_BARS: int
+
+
+FrozenSignalConstants = FrozenSignalConstants(
+    ATR_PERIOD=20,
+    VOLUME_MEDIAN_WINDOW=20,
+    A_T_MIN=0.002,
+    A_T_MAX=0.012,
+    CHASE_MAX_ATR_MULT=0.50,
+    S1_SL_CLIP_MIN_BPS=45.0,
+    S1_SL_CLIP_MAX_BPS=110.0,
+    S1_TIMEOUT_1M_BARS=12 * 15,  # 180
+    S1_COOLDOWN_1M_BARS=4 * 15,  # 60
+    S2_MAD_WINDOW=288,
+    S2_ER_WINDOW=48,
+    S2_SHOCK_ABS_RETURN_MIN=0.006,
+    S2_SL_CLIP_MIN_BPS=45.0,
+    S2_SL_CLIP_MAX_BPS=90.0,
+    S2_TP_MAX_BPS=120.0,
+    S2_TP_ABS_FLOOR_BPS=68.0,
+    S2_TIMEOUT_1M_BARS=6 * 5,  # 30
+    S2_COOLDOWN_1M_BARS=60,  # 1h == 60 * 1m bars
+)
+
+
+FROZEN_S1_CONFIGS: tuple[S1Config, ...] = (
+    S1Config(16, 1.25, 1.25, 1.80, "S1-00", "연구 default"),
+    S1Config(12, 1.25, 1.25, 1.80, "S1-01", "shorter breakout lookback"),
+    S1Config(24, 1.25, 1.25, 1.80, "S1-02", "longer breakout lookback"),
+    S1Config(16, 1.00, 1.25, 1.80, "S1-03", "looser volume confirmation"),
+    S1Config(16, 1.50, 1.25, 1.80, "S1-04", "stricter volume confirmation"),
+    S1Config(16, 1.25, 1.00, 1.80, "S1-05", "tighter ATR stop"),
+    S1Config(16, 1.25, 1.50, 1.80, "S1-06", "wider ATR stop"),
+    S1Config(16, 1.25, 1.25, 1.50, "S1-07", "lower payoff ratio"),
+    S1Config(16, 1.25, 1.25, 2.00, "S1-08", "higher payoff ratio"),
+    S1Config(12, 1.50, 1.25, 1.80, "S1-09", "fast breakout requires stronger volume"),
+    S1Config(24, 1.00, 1.25, 1.80, "S1-10", "slow breakout tolerates weaker volume"),
+    S1Config(16, 1.25, 1.00, 2.00, "S1-11", "tight-stop/high-payoff cost resilience"),
+)
+
+FROZEN_S2_CONFIGS: tuple[S2Config, ...] = (
+    S2Config(3.00, 2.00, 0.35, 1.25, "S2-00", "연구 default"),
+    S2Config(2.75, 2.00, 0.35, 1.25, "S2-01", "lower shock threshold"),
+    S2Config(3.25, 2.00, 0.35, 1.25, "S2-02", "higher shock threshold"),
+    S2Config(3.00, 1.50, 0.35, 1.25, "S2-03", "looser volume spike"),
+    S2Config(3.00, 2.50, 0.35, 1.25, "S2-04", "stricter volume spike"),
+    S2Config(3.00, 2.00, 0.25, 1.25, "S2-05", "stricter mean-reversion regime"),
+    S2Config(3.00, 2.00, 0.45, 1.25, "S2-06", "looser regime filter"),
+    S2Config(3.00, 2.00, 0.35, 1.20, "S2-07", "lower reward floor"),
+    S2Config(3.00, 2.00, 0.35, 1.35, "S2-08", "higher reward floor"),
+    S2Config(2.75, 1.50, 0.45, 1.20, "S2-09", "permissive/frequency frontier"),
+    S2Config(3.25, 2.50, 0.25, 1.35, "S2-10", "selective/quality frontier"),
+    S2Config(
+        2.75, 2.50, 0.25, 1.25, "S2-11", "lower z only when volume/regime are strict"
+    ),
+)
+
+
+def validate_s1_configs(rows: tuple[S1Config, ...]) -> None:
+    """Fail-closed structural + domain validation for an S1 config tuple."""
+    if len(rows) != 12:
+        raise ValueError(f"S1 manifest must have exactly 12 rows, got {len(rows)}")
+    seen_ids: set[str] = set()
+    for row in rows:
+        if row.config_id in seen_ids:
+            raise ValueError(f"duplicate S1 config_id {row.config_id!r}")
+        seen_ids.add(row.config_id)
+        if row.L not in S1_DOMAINS["L"]:
+            raise ValueError(f"S1 {row.config_id}: L={row.L!r} outside domain")
+        if row.q_min not in S1_DOMAINS["q_min"]:
+            raise ValueError(f"S1 {row.config_id}: q_min={row.q_min!r} outside domain")
+        if row.k_SL not in S1_DOMAINS["k_SL"]:
+            raise ValueError(f"S1 {row.config_id}: k_SL={row.k_SL!r} outside domain")
+        if row.R_TP not in S1_DOMAINS["R_TP"]:
+            raise ValueError(f"S1 {row.config_id}: R_TP={row.R_TP!r} outside domain")
+
+
+def validate_s2_configs(rows: tuple[S2Config, ...]) -> None:
+    """Fail-closed structural + domain validation for an S2 config tuple."""
+    if len(rows) != 12:
+        raise ValueError(f"S2 manifest must have exactly 12 rows, got {len(rows)}")
+    seen_ids: set[str] = set()
+    for row in rows:
+        if row.config_id in seen_ids:
+            raise ValueError(f"duplicate S2 config_id {row.config_id!r}")
+        seen_ids.add(row.config_id)
+        if row.z_min not in S2_DOMAINS["z_min"]:
+            raise ValueError(f"S2 {row.config_id}: z_min={row.z_min!r} outside domain")
+        if row.v_min not in S2_DOMAINS["v_min"]:
+            raise ValueError(f"S2 {row.config_id}: v_min={row.v_min!r} outside domain")
+        if row.ER_max not in S2_DOMAINS["ER_max"]:
+            raise ValueError(
+                f"S2 {row.config_id}: ER_max={row.ER_max!r} outside domain"
+            )
+        if row.R_min not in S2_DOMAINS["R_min"]:
+            raise ValueError(f"S2 {row.config_id}: R_min={row.R_min!r} outside domain")
+
+
+validate_s1_configs(FROZEN_S1_CONFIGS)
+validate_s2_configs(FROZEN_S2_CONFIGS)
+
+_S1_BY_ID: dict[str, S1Config] = {c.config_id: c for c in FROZEN_S1_CONFIGS}
+_S2_BY_ID: dict[str, S2Config] = {c.config_id: c for c in FROZEN_S2_CONFIGS}
+
+
+def get_s1_config(config_id: str) -> S1Config:
+    """Look up a frozen S1 config by id; unregistered ids fail closed (KeyError)."""
+    return _S1_BY_ID[config_id]
+
+
+def get_s2_config(config_id: str) -> S2Config:
+    """Look up a frozen S2 config by id; unregistered ids fail closed (KeyError)."""
+    return _S2_BY_ID[config_id]
+
+
+def _validate_symbol(symbol: str) -> None:
+    if symbol not in SYMBOLS:
+        raise ValueError(
+            f"unknown symbol {symbol!r}; must be one of {SYMBOLS} "
+            "(no per-symbol config override exists)"
+        )
+
+
+def resolve_s1_config_for_symbol(config_id: str, symbol: str) -> S1Config:
+    """Same config for every symbol — this function exists ONLY to make the
+    "no symbol override" invariant an explicit, testable call site rather
+    than an implicit assumption callers must remember on their own.
+    """
+    _validate_symbol(symbol)
+    return get_s1_config(config_id)
+
+
+def resolve_s2_config_for_symbol(config_id: str, symbol: str) -> S2Config:
+    _validate_symbol(symbol)
+    return get_s2_config(config_id)
+
+
+def _manifest_payload(
+    s1_rows: tuple[S1Config, ...], s2_rows: tuple[S2Config, ...]
+) -> dict:
+    return {
+        "symbols": list(SYMBOLS),
+        "s1": [
+            {
+                "config_id": c.config_id,
+                "L": c.L,
+                "q_min": c.q_min,
+                "k_SL": c.k_SL,
+                "R_TP": c.R_TP,
+                "hypothesis": c.hypothesis,
+            }
+            for c in s1_rows
+        ],
+        "s2": [
+            {
+                "config_id": c.config_id,
+                "z_min": c.z_min,
+                "v_min": c.v_min,
+                "ER_max": c.ER_max,
+                "R_min": c.R_min,
+                "hypothesis": c.hypothesis,
+            }
+            for c in s2_rows
+        ],
+    }
+
+
+# AC6/§4: identity hash of the 24-row manifest, named ``signal_manifest_hash``
+# specifically so it is never confused with an H4 full-campaign hash (which
+# will additionally cover the walk-forward window, cost scenarios, and
+# selection rule as separate identity components).
+signal_manifest_hash: str = canonical_sha256(
+    _manifest_payload(FROZEN_S1_CONFIGS, FROZEN_S2_CONFIGS)
+)

--- a/research/nautilus_scalping/rob940_signal_manifest.py
+++ b/research/nautilus_scalping/rob940_signal_manifest.py
@@ -76,7 +76,14 @@ class S2Config:
 # 24-row config shortlist specifically) but validated by dedicated tests so
 # a silent edit to e.g. the ATR period or the S2 288-bar window fails a test
 # rather than drifting unnoticed.
-class FrozenSignalConstants(NamedTuple):
+#
+# M2 (ROB-943 R1 remediation): the TYPE is named ``_FrozenSignalConstantsT``
+# (private) so the public name ``FrozenSignalConstants`` can be rebound below
+# to the single frozen INSTANCE without shadowing/destroying the class --
+# a future `x: _FrozenSignalConstantsT` annotation stays meaningful, whereas
+# annotating with the instance-shadowed public name would silently mean "a
+# variable of this instance's runtime type", not the intended NamedTuple type.
+class _FrozenSignalConstantsT(NamedTuple):
     ATR_PERIOD: int
     VOLUME_MEDIAN_WINDOW: int
     A_T_MIN: float
@@ -97,7 +104,7 @@ class FrozenSignalConstants(NamedTuple):
     S2_COOLDOWN_1M_BARS: int
 
 
-FrozenSignalConstants = FrozenSignalConstants(
+FrozenSignalConstants: _FrozenSignalConstantsT = _FrozenSignalConstantsT(
     ATR_PERIOD=20,
     VOLUME_MEDIAN_WINDOW=20,
     A_T_MIN=0.002,
@@ -207,6 +214,35 @@ def get_s1_config(config_id: str) -> S1Config:
 def get_s2_config(config_id: str) -> S2Config:
     """Look up a frozen S2 config by id; unregistered ids fail closed (KeyError)."""
     return _S2_BY_ID[config_id]
+
+
+# I4 (ROB-943 R1 remediation, strategy-verify-rob943-r1-20260717-170045.md):
+# `get_*_config` only fails closed for CALLERS who go through it. A caller
+# that constructs its own S1Config/S2Config (in-domain param swap, tampered
+# hypothesis text, or a wholly forged/unregistered row) and hands it
+# straight to a generator was silently accepted. These are the single-row
+# membership authority the generators must call BEFORE any math -- exact
+# VALUE equality (dataclass `==`, not `is`) against the frozen row, so a
+# freshly-deserialized-but-identical config is still accepted while any
+# field mismatch (including a same-domain swap) is rejected.
+def assert_matches_frozen_s1_config(config: S1Config) -> None:
+    canonical = _S1_BY_ID.get(config.config_id)
+    if canonical is None or config != canonical:
+        raise ValueError(
+            f"S1Config {config!r} does not exactly match the frozen manifest "
+            f"row for config_id {config.config_id!r} (forged/unregistered/"
+            "tampered config rejected fail-closed)"
+        )
+
+
+def assert_matches_frozen_s2_config(config: S2Config) -> None:
+    canonical = _S2_BY_ID.get(config.config_id)
+    if canonical is None or config != canonical:
+        raise ValueError(
+            f"S2Config {config!r} does not exactly match the frozen manifest "
+            f"row for config_id {config.config_id!r} (forged/unregistered/"
+            "tampered config rejected fail-closed)"
+        )
 
 
 def _validate_symbol(symbol: str) -> None:

--- a/research/nautilus_scalping/rob940_signal_s1.py
+++ b/research/nautilus_scalping/rob940_signal_s1.py
@@ -24,6 +24,13 @@ module's contract, so indicator state (ATR/Donchian/volume-median buffers)
 resets to a fresh, zero-indexed accumulation exactly when that flag is True.
 No prior-segment bar (including its close) is ever referenced across a gap.
 
+ultrathink (I4, ROB-943 R1 remediation): ``get_s1_config`` only fails closed
+for callers that go THROUGH it. ``generate_s1_signals`` now asserts exact
+frozen-manifest membership (symbol + config, by VALUE not identity) as its
+very first act, before touching ``bars_15m`` at all — a caller handing in a
+forged/tampered/unregistered ``S1Config`` or an out-of-universe symbol must
+never reach the math loop, even with zero bars.
+
 No DB/network/app/broker/order/fill/scheduler/random/current-time imports —
 pure stdlib, deterministic given its input.
 """
@@ -36,7 +43,12 @@ from collections.abc import Sequence
 
 from rob940_bars_agg import AggregatedBar
 from rob940_engine import SignalEvent
-from rob940_signal_manifest import FrozenSignalConstants, S1Config
+from rob940_signal_manifest import (
+    FrozenSignalConstants,
+    S1Config,
+    _validate_symbol,
+    assert_matches_frozen_s1_config,
+)
 
 _C = FrozenSignalConstants
 
@@ -137,6 +149,9 @@ def generate_s1_signals(
     frozen ``S1Config`` row. Returns signals in input (chronological) order,
     already unique by ``signal_ts``.
     """
+    _validate_symbol(symbol)
+    assert_matches_frozen_s1_config(config)
+
     out: list[SignalEvent] = []
     min_idx = max(config.L, _C.ATR_PERIOD)
 

--- a/research/nautilus_scalping/rob940_signal_s1.py
+++ b/research/nautilus_scalping/rob940_signal_s1.py
@@ -1,0 +1,212 @@
+"""ROB-943 (H3, ROB-940) — S1 Donchian-15m signal generator (pure, stdlib).
+
+Implements the ROB-940 research draft's Strategy 1 exactly (current-bar-
+excluded Donchian breakout, volume confirmation, ATR volatility/chase
+gates), scoped per the frozen 12-config manifest (``rob940_signal_manifest``)
+and emitting ``rob940_engine.SignalEvent`` instances ready for
+``run_symbol_stream`` — no execution/cost/arbitration logic lives here.
+
+ultrathink (ATR seed): Wilder's ATR is a CONTEMPORANEOUS indicator — the
+signal at bar t's close is allowed to use bar t's own True Range (the bar has
+already fully closed by signal time). "current-bar leakage" in the ROB-943
+prompt refers to Donchian U/D (which DO exclude the current bar) and to
+never using bar t+1 data, not to lagging ATR by one bar. Seed = simple
+average of TR_1..TR_N (both endpoints inclusive, 1-indexed within a
+contiguous segment so TR_1 uses bar[0] as the previous close); this matches
+the standard Wilder definition and is available starting at bar index
+``period`` (0-indexed) within a segment. Recurrence:
+``ATR_t = (ATR_{t-1}*(period-1) + TR_t) / period`` for t > period.
+
+ultrathink (segment/gap reset): ``AggregatedBar.is_segment_start`` (set by
+``rob940_bars_agg.aggregate_complete``) is the ONLY gap signal this module
+needs — consecutive bars within a segment are guaranteed contiguous by that
+module's contract, so indicator state (ATR/Donchian/volume-median buffers)
+resets to a fresh, zero-indexed accumulation exactly when that flag is True.
+No prior-segment bar (including its close) is ever referenced across a gap.
+
+No DB/network/app/broker/order/fill/scheduler/random/current-time imports —
+pure stdlib, deterministic given its input.
+"""
+
+from __future__ import annotations
+
+import math
+import statistics
+from collections.abc import Sequence
+
+from rob940_bars_agg import AggregatedBar
+from rob940_engine import SignalEvent
+from rob940_signal_manifest import FrozenSignalConstants, S1Config
+
+_C = FrozenSignalConstants
+
+
+def _segment_slices(bars: Sequence[AggregatedBar]) -> list[tuple[int, int]]:
+    """Return (start, stop) index pairs for each contiguous segment."""
+    if not bars:
+        return []
+    bounds: list[tuple[int, int]] = []
+    start = 0
+    for i in range(1, len(bars)):
+        if bars[i].is_segment_start:
+            bounds.append((start, i))
+            start = i
+    bounds.append((start, len(bars)))
+    return bounds
+
+
+def _wilder_atr_series(
+    bars: Sequence[AggregatedBar], period: int
+) -> list[float | None]:
+    """Wilder ATR for ONE contiguous segment; index i is ``None`` until warm.
+
+    ``bars`` must already be a single gap-free segment (callers slice per
+    segment via ``_segment_slices``). TR at index 0 is undefined (no prior
+    close within the segment) and is never computed or used.
+    """
+    n = len(bars)
+    atr: list[float | None] = [None] * n
+    if n <= period:
+        return atr
+    trs: list[float | None] = [None] * n
+    for i in range(1, n):
+        prev_close = bars[i - 1].close
+        h, low = bars[i].high, bars[i].low
+        trs[i] = max(h - low, abs(h - prev_close), abs(low - prev_close))
+    seed_values = trs[1 : period + 1]
+    running = sum(seed_values) / period  # type: ignore[arg-type]
+    atr[period] = running
+    for i in range(period + 1, n):
+        running = (running * (period - 1) + trs[i]) / period  # type: ignore[operator]
+        atr[i] = running
+    return atr
+
+
+def _rolling_median(values: Sequence[float], window: int, idx: int) -> float | None:
+    """Median of ``values[idx-window:idx]`` (current index excluded), or
+    ``None`` if fewer than ``window`` prior values exist.
+    """
+    if idx < window:
+        return None
+    return statistics.median(values[idx - window : idx])
+
+
+def _rolling_max(values: Sequence[float], window: int, idx: int) -> float | None:
+    if idx < window:
+        return None
+    return max(values[idx - window : idx])
+
+
+def _rolling_min(values: Sequence[float], window: int, idx: int) -> float | None:
+    if idx < window:
+        return None
+    return min(values[idx - window : idx])
+
+
+def _clip(x: float, lo: float, hi: float) -> float:
+    return min(max(x, lo), hi)
+
+
+def _assert_unique_signal_ts(signals: Sequence[SignalEvent]) -> None:
+    """Fail-closed guard: a (strategy,config,symbol) stream must never carry
+    two signals with the same ``signal_ts`` (H2 caller precondition, AC/§6).
+    """
+    seen: set[int] = set()
+    for sig in signals:
+        if sig.signal_ts in seen:
+            raise ValueError(
+                f"duplicate signal_ts {sig.signal_ts} for {sig.symbol}/"
+                f"{sig.config_id} — signal generation must be one-per-bar"
+            )
+        seen.add(sig.signal_ts)
+
+
+def generate_s1_signals(
+    bars_15m: Sequence[AggregatedBar],
+    config: S1Config,
+    *,
+    symbol: str,
+    fold_id: str | None = None,
+) -> tuple[SignalEvent, ...]:
+    """Generate the S1 (Donchian-15m) signal stream for ONE symbol/config.
+
+    ``bars_15m`` is the complete-only 15m aggregation of one symbol's 1m
+    bars (``rob940_bars_agg.aggregate_complete(..., bucket_minutes=15)``).
+    Fixed constants (ATR period, a_t band, chase cap, timeout/cooldown) come
+    from ``FrozenSignalConstants``; the four free parameters come from the
+    frozen ``S1Config`` row. Returns signals in input (chronological) order,
+    already unique by ``signal_ts``.
+    """
+    out: list[SignalEvent] = []
+    min_idx = max(config.L, _C.ATR_PERIOD)
+
+    for seg_start, seg_stop in _segment_slices(bars_15m):
+        seg = bars_15m[seg_start:seg_stop]
+        atr_series = _wilder_atr_series(seg, _C.ATR_PERIOD)
+        highs = [b.high for b in seg]
+        lows = [b.low for b in seg]
+        volumes = [b.volume for b in seg]
+
+        for i in range(min_idx, len(seg)):
+            atr = atr_series[i]
+            if atr is None or not math.isfinite(atr) or atr <= 0:
+                continue
+            bar = seg[i]
+            c = bar.close
+            if not math.isfinite(c) or c <= 0:
+                continue
+
+            vol_median = _rolling_median(volumes, _C.VOLUME_MEDIAN_WINDOW, i)
+            if vol_median is None or not math.isfinite(vol_median) or vol_median <= 0:
+                continue
+            q = bar.volume / vol_median
+
+            a_t = atr / c
+            if not (_C.A_T_MIN <= a_t <= _C.A_T_MAX):
+                continue
+            if q < config.q_min:
+                continue
+
+            u = _rolling_max(highs, config.L, i)
+            d = _rolling_min(lows, config.L, i)
+            if u is None or d is None:
+                continue
+
+            side: str | None = None
+            if c > u:
+                chase = (c - u) / atr
+                if 0 < chase <= _C.CHASE_MAX_ATR_MULT:
+                    side = "long"
+            elif c < d:
+                chase = (d - c) / atr
+                if 0 < chase <= _C.CHASE_MAX_ATR_MULT:
+                    side = "short"
+
+            if side is None:
+                continue
+
+            d_sl = _clip(
+                config.k_SL * a_t,
+                _C.S1_SL_CLIP_MIN_BPS / 1e4,
+                _C.S1_SL_CLIP_MAX_BPS / 1e4,
+            )
+            d_tp = config.R_TP * d_sl
+
+            out.append(
+                SignalEvent(
+                    strategy="S1",
+                    config_id=config.config_id,
+                    symbol=symbol,
+                    signal_ts=bar.close_ts,
+                    side=side,
+                    sl_distance_bps=d_sl * 1e4,
+                    tp_distance_bps=d_tp * 1e4,
+                    timeout_bars=_C.S1_TIMEOUT_1M_BARS,
+                    cooldown_bars=_C.S1_COOLDOWN_1M_BARS,
+                    fold_id=fold_id,
+                )
+            )
+
+    result = tuple(out)
+    _assert_unique_signal_ts(result)
+    return result

--- a/research/nautilus_scalping/rob940_signal_s2.py
+++ b/research/nautilus_scalping/rob940_signal_s2.py
@@ -1,0 +1,296 @@
+"""ROB-943 (H3, ROB-940) — S2 confirmed-shock-reversal-5m signal generator
+(pure, stdlib).
+
+Implements the ROB-940 research draft's Strategy 2: a large-shock detector
+(prior-288 return median/MAD z-score, volume spike, efficiency-ratio regime
+filter) that never enters on the shock bar itself, only on an EXACT next-bar
+confirmation, with a target-validity gate evaluated against the ACTUAL next
+contiguous 1m open ``E`` (per the ROB-943 prompt's H2-consumption contract —
+H2 does not enforce Strategy-2-specific TP bounds, so this module must
+evaluate them itself before emitting any ``SignalEvent``).
+
+ultrathink (ER denominator=0): a zero denominator means the 48-bar window
+had ZERO net movement across every consecutive pair — a degenerate/flat
+input, not a malformed one. Raising would kill the whole run on ordinary
+low-liquidity data; per the ROB-943 prompt's "명시적 deterministic no-signal"
+allowance, ``_efficiency_ratio`` returns ``None`` and the caller treats that
+as "ER gate fails" (no shock), never as NaN/silent-pass.
+
+ultrathink (S2 target-direction ambiguity — FINAL, Fable Q1=A):
+``orch-fable-answer-rob943-s2-20260717.md`` confirms the direction guard in
+``_evaluate_target_gates`` (T must be on the profit side of E for the given
+side) as the permanent behavior, not a placeholder. Economic rationale: the
+S2 thesis is literally "price reverts to the pre-shock close T"; if
+confirmation-bar overshoot already carried E past T, the reversion thesis is
+already exhausted and passing the trade to H2 unguarded produces a
+mislabeled entry-bar "take_profit" exit that is actually a realized loss
+(see ``tests/test_rob940_signal_s2.py::
+test_ambiguity_gate_direction_mismatch_is_held_pending_consult``, kept
+permanently per the ruling's condition 3). Spec-deviation register entry
+(Fable condition 2, do not re-word): see ``SPEC_DEVIATIONS`` below.
+
+No DB/network/app/broker/order/fill/scheduler/random/current-time imports —
+pure stdlib, deterministic given its input.
+"""
+
+from __future__ import annotations
+
+import math
+import statistics
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+from rob940_bars_agg import AggregatedBar, Bar1m
+from rob940_engine import SignalEvent
+from rob940_signal_manifest import FrozenSignalConstants, S2Config
+from rob940_signal_s1 import _assert_unique_signal_ts, _segment_slices
+
+_C = FrozenSignalConstants
+
+# Fable condition 2 (orch-fable-answer-rob943-s2-20260717.md): the exact
+# spec-deviation text for the future H5 scorecard register. Do not implement
+# H5 here -- this is the citation payload only.
+SPEC_DEVIATIONS: tuple[str, ...] = (
+    "원문 3게이트에 방향 유효성 게이트 추가(Fable 판정, 사유: 라벨 오염 차단)",
+)
+
+
+@dataclass(frozen=True)
+class RejectedCandidate:
+    strategy: str
+    config_id: str
+    symbol: str
+    signal_ts: int
+    side: str
+    reason: str
+    fold_id: str | None = None
+
+
+@dataclass(frozen=True)
+class S2GenerationResult:
+    signals: tuple[SignalEvent, ...]
+    rejections: tuple[RejectedCandidate, ...]
+
+
+def count_rejection_reasons(rejections: Sequence[RejectedCandidate]) -> dict[str, int]:
+    """Fable condition 1: aggregate rejection reasons (incl.
+    ``target_direction_invalid``) so H5 can surface frequency. Counting
+    only -- no H5 reporting pipeline is implemented here.
+    """
+    counts: dict[str, int] = {}
+    for r in rejections:
+        counts[r.reason] = counts.get(r.reason, 0) + 1
+    return counts
+
+
+def _log_returns(closes: Sequence[float]) -> list[float | None]:
+    out: list[float | None] = [None] * len(closes)
+    for i in range(1, len(closes)):
+        out[i] = math.log(closes[i] / closes[i - 1])
+    return out
+
+
+def _median_mad_sigma(window: Sequence[float]) -> tuple[float, float]:
+    med = statistics.median(window)
+    mad = statistics.median(abs(x - med) for x in window)
+    sigma = max(1.4826 * mad, 0.0001)
+    return med, sigma
+
+
+def _efficiency_ratio(closes: Sequence[float], t: int, window: int) -> float | None:
+    """ER48 over ``closes[t-window .. t]`` (window+1 points, window diffs).
+
+    Returns ``None`` (fail-closed no-shock sentinel) if the path-length
+    denominator is exactly zero.
+    """
+    numerator = abs(closes[t] - closes[t - window])
+    denom = sum(abs(closes[j] - closes[j - 1]) for j in range(t - window + 1, t + 1))
+    if denom == 0:
+        return None
+    return numerator / denom
+
+
+def _evaluate_target_gates(
+    side: str, entry_price: float, target_price: float, sl_distance: float, r_min: float
+) -> tuple[bool, str | None, float]:
+    """The three magnitude gates PLUS the direction-validity guard (final,
+    see module docstring). Returns ``(passed, rejection_reason, d_tp_bps)``.
+    """
+    # Rounded to 1e-8 bps to strip binary-float representation noise (e.g.
+    # 101.20/100.00-1 lands a few ULPs past 0.012) without masking any real
+    # boundary distinction -- inclusive gates below are exact-decimal spec
+    # boundaries (68/120bp, R_min*d_SL), not float-noise-sensitive ones.
+    d_tp_bps = round(abs(target_price / entry_price - 1.0) * 1e4, 8)
+    if side == "long" and not (target_price > entry_price):
+        return False, "target_direction_invalid", d_tp_bps
+    if side == "short" and not (target_price < entry_price):
+        return False, "target_direction_invalid", d_tp_bps
+    if d_tp_bps > _C.S2_TP_MAX_BPS:
+        return False, "tp_above_max", d_tp_bps
+    if d_tp_bps < r_min * sl_distance * 1e4:
+        return False, "tp_below_r_min_sl", d_tp_bps
+    if d_tp_bps < _C.S2_TP_ABS_FLOOR_BPS:
+        return False, "tp_below_abs_floor", d_tp_bps
+    return True, None, d_tp_bps
+
+
+def _clip(x: float, lo: float, hi: float) -> float:
+    return min(max(x, lo), hi)
+
+
+def generate_s2_signals(
+    bars_5m: Sequence[AggregatedBar],
+    bars_1m: Sequence[Bar1m],
+    config: S2Config,
+    *,
+    symbol: str,
+    fold_id: str | None = None,
+) -> S2GenerationResult:
+    """Generate the S2 (confirmed-shock-reversal-5m) stream for ONE symbol/
+    config. ``bars_1m`` is the raw 1m stream used ONLY to resolve the actual
+    next contiguous 1m open ``E`` for the pre-signal TP-validity gates —
+    this module never touches execution/cost/arbitration logic.
+    """
+    signals: list[SignalEvent] = []
+    rejections: list[RejectedCandidate] = []
+    bars_1m_by_ts = {b.ts: b for b in bars_1m}
+    window = _C.S2_MAD_WINDOW  # 288
+    er_window = _C.S2_ER_WINDOW  # 48
+    min_idx = window + 1  # need window PRIOR returns => t >= window+1 (289)
+
+    for seg_start, seg_stop in _segment_slices(bars_5m):
+        seg = bars_5m[seg_start:seg_stop]
+        closes = [b.close for b in seg]
+        volumes = [b.volume for b in seg]
+        returns = _log_returns(closes)
+
+        pending_t: int | None = None  # index of a shock awaiting t+1 confirmation
+        pending_direction: str | None = None  # "long" | "short"
+
+        for t in range(1, len(seg)):
+            if pending_t is not None and t == pending_t + 1:
+                shock_bar = seg[pending_t]
+                confirm_bar = seg[t]
+                if pending_direction == "long":
+                    confirmed = (
+                        confirm_bar.close > shock_bar.close
+                        and confirm_bar.low >= shock_bar.low
+                    )
+                else:
+                    confirmed = (
+                        confirm_bar.close < shock_bar.close
+                        and confirm_bar.high <= shock_bar.high
+                    )
+                signal_ts = confirm_bar.close_ts
+                if not confirmed:
+                    rejections.append(
+                        RejectedCandidate(
+                            strategy="S2",
+                            config_id=config.config_id,
+                            symbol=symbol,
+                            signal_ts=shock_bar.close_ts,
+                            side=pending_direction,
+                            reason="confirmation_failed",
+                            fold_id=fold_id,
+                        )
+                    )
+                else:
+                    entry_bar = bars_1m_by_ts.get(signal_ts)
+                    if entry_bar is None:
+                        rejections.append(
+                            RejectedCandidate(
+                                strategy="S2",
+                                config_id=config.config_id,
+                                symbol=symbol,
+                                signal_ts=signal_ts,
+                                side=pending_direction,
+                                reason="next_bar_unavailable",
+                                fold_id=fold_id,
+                            )
+                        )
+                    else:
+                        r_shock = returns[pending_t]
+                        shock_bar_prev_close = seg[pending_t - 1].close
+                        entry_price = entry_bar.open
+                        d_sl = _clip(
+                            0.60 * abs(r_shock),
+                            _C.S2_SL_CLIP_MIN_BPS / 1e4,
+                            _C.S2_SL_CLIP_MAX_BPS / 1e4,
+                        )
+                        passed, reason, _d_tp_bps = _evaluate_target_gates(
+                            pending_direction,
+                            entry_price,
+                            shock_bar_prev_close,
+                            d_sl,
+                            config.R_min,
+                        )
+                        if not passed:
+                            rejections.append(
+                                RejectedCandidate(
+                                    strategy="S2",
+                                    config_id=config.config_id,
+                                    symbol=symbol,
+                                    signal_ts=signal_ts,
+                                    side=pending_direction,
+                                    reason=reason,
+                                    fold_id=fold_id,
+                                )
+                            )
+                        else:
+                            signals.append(
+                                SignalEvent(
+                                    strategy="S2",
+                                    config_id=config.config_id,
+                                    symbol=symbol,
+                                    signal_ts=signal_ts,
+                                    side=pending_direction,
+                                    sl_distance_bps=d_sl * 1e4,
+                                    tp_target_price=shock_bar_prev_close,
+                                    timeout_bars=_C.S2_TIMEOUT_1M_BARS,
+                                    cooldown_bars=_C.S2_COOLDOWN_1M_BARS,
+                                    fold_id=fold_id,
+                                )
+                            )
+                pending_t = None
+                pending_direction = None
+                # A shock is evaluated at most once (per-shock rule); the
+                # confirmation bar itself is still independently checked
+                # below for whether IT is a new shock.
+
+            if t < min_idx or t < er_window:
+                continue
+            r_t = returns[t]
+            if r_t is None or not math.isfinite(r_t):
+                continue
+            if abs(r_t) < _C.S2_SHOCK_ABS_RETURN_MIN:
+                continue
+
+            ret_window = returns[t - window : t]
+            if any(x is None for x in ret_window):
+                continue
+            median_r, sigma = _median_mad_sigma(ret_window)  # type: ignore[arg-type]
+            z_t = (r_t - median_r) / sigma
+            if abs(z_t) < config.z_min:
+                continue
+
+            vol_window = volumes[t - window : t]
+            vol_median = statistics.median(vol_window)
+            if not math.isfinite(vol_median) or vol_median <= 0:
+                continue
+            v_t = seg[t].volume / vol_median
+            if v_t < config.v_min:
+                continue
+
+            er = _efficiency_ratio(closes, t, er_window)
+            if er is None or er > config.ER_max:
+                continue
+
+            # All shock conditions satisfied; sign of r_t determines
+            # direction (never 0 here since |r_t|>=0.006 already excludes
+            # it). Negative shock -> long confirmation; positive -> short.
+            pending_t = t
+            pending_direction = "long" if r_t < 0 else "short"
+
+    result_signals = tuple(signals)
+    _assert_unique_signal_ts(result_signals)
+    return S2GenerationResult(signals=result_signals, rejections=tuple(rejections))

--- a/research/nautilus_scalping/rob940_signal_s2.py
+++ b/research/nautilus_scalping/rob940_signal_s2.py
@@ -25,9 +25,14 @@ confirmation-bar overshoot already carried E past T, the reversion thesis is
 already exhausted and passing the trade to H2 unguarded produces a
 mislabeled entry-bar "take_profit" exit that is actually a realized loss
 (see ``tests/test_rob940_signal_s2.py::
-test_ambiguity_gate_direction_mismatch_is_held_pending_consult``, kept
+test_ambiguity_gate_direction_mismatch_final_fable_ruling``, kept
 permanently per the ruling's condition 3). Spec-deviation register entry
 (Fable condition 2, do not re-word): see ``SPEC_DEVIATIONS`` below.
+
+ultrathink (I4, ROB-943 R1 remediation): ``get_s2_config`` only fails closed
+for callers that go THROUGH it. ``generate_s2_signals`` now asserts exact
+frozen-manifest membership (symbol + config, by VALUE not identity) as its
+very first act, before touching ``bars_5m``/``bars_1m`` at all.
 
 No DB/network/app/broker/order/fill/scheduler/random/current-time imports —
 pure stdlib, deterministic given its input.
@@ -42,7 +47,12 @@ from dataclasses import dataclass
 
 from rob940_bars_agg import AggregatedBar, Bar1m
 from rob940_engine import SignalEvent
-from rob940_signal_manifest import FrozenSignalConstants, S2Config
+from rob940_signal_manifest import (
+    FrozenSignalConstants,
+    S2Config,
+    _validate_symbol,
+    assert_matches_frozen_s2_config,
+)
 from rob940_signal_s1 import _assert_unique_signal_ts, _segment_slices
 
 _C = FrozenSignalConstants
@@ -120,14 +130,21 @@ def _evaluate_target_gates(
     # 101.20/100.00-1 lands a few ULPs past 0.012) without masking any real
     # boundary distinction -- inclusive gates below are exact-decimal spec
     # boundaries (68/120bp, R_min*d_SL), not float-noise-sensitive ones.
+    # M3 (ROB-943 R1 remediation): the R_min*d_SL threshold gets the SAME
+    # rounding treatment as d_tp_bps -- rounding only the LHS left an
+    # asymmetric ~1e-14bp ULP gap (e.g. R_min=1.20/d_SL=90bp -> raw RHS
+    # 107.99999999999999 vs exact 108.0); harmless in practice (always
+    # permissive, dwarfed by the 1e-8bp LHS rounding) but a needless
+    # inconsistency once one side was already being cleaned up.
     d_tp_bps = round(abs(target_price / entry_price - 1.0) * 1e4, 8)
+    r_min_sl_bps = round(r_min * sl_distance * 1e4, 8)
     if side == "long" and not (target_price > entry_price):
         return False, "target_direction_invalid", d_tp_bps
     if side == "short" and not (target_price < entry_price):
         return False, "target_direction_invalid", d_tp_bps
     if d_tp_bps > _C.S2_TP_MAX_BPS:
         return False, "tp_above_max", d_tp_bps
-    if d_tp_bps < r_min * sl_distance * 1e4:
+    if d_tp_bps < r_min_sl_bps:
         return False, "tp_below_r_min_sl", d_tp_bps
     if d_tp_bps < _C.S2_TP_ABS_FLOOR_BPS:
         return False, "tp_below_abs_floor", d_tp_bps
@@ -151,6 +168,9 @@ def generate_s2_signals(
     next contiguous 1m open ``E`` for the pre-signal TP-validity gates —
     this module never touches execution/cost/arbitration logic.
     """
+    _validate_symbol(symbol)
+    assert_matches_frozen_s2_config(config)
+
     signals: list[SignalEvent] = []
     rejections: list[RejectedCandidate] = []
     bars_1m_by_ts = {b.ts: b for b in bars_1m}

--- a/research/nautilus_scalping/tests/test_rob940_signal_manifest.py
+++ b/research/nautilus_scalping/tests/test_rob940_signal_manifest.py
@@ -1,0 +1,235 @@
+"""ROB-943 (H3, ROB-940) — exact frozen 24-row signal manifest tests.
+
+Fable Q1=A: the 24 rows below (12 S1 + 12 S2), their order, values, and the
+consult doc's ex-ante hypothesis phrases are byte-stable and frozen. Any
+mismatch here means the manifest drifted from the approved shortlist and must
+fail closed, not silently adapt.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+from rob940_signal_manifest import (
+    S1_DOMAINS,
+    S2_DOMAINS,
+    SYMBOLS,
+    FrozenSignalConstants,
+    S1Config,
+    S2Config,
+    get_s1_config,
+    get_s2_config,
+    resolve_s1_config_for_symbol,
+    resolve_s2_config_for_symbol,
+    signal_manifest_hash,
+    validate_s1_configs,
+    validate_s2_configs,
+)
+
+EXPECTED_S1 = (
+    ("S1-00", 16, 1.25, 1.25, 1.80, "연구 default"),
+    ("S1-01", 12, 1.25, 1.25, 1.80, "shorter breakout lookback"),
+    ("S1-02", 24, 1.25, 1.25, 1.80, "longer breakout lookback"),
+    ("S1-03", 16, 1.00, 1.25, 1.80, "looser volume confirmation"),
+    ("S1-04", 16, 1.50, 1.25, 1.80, "stricter volume confirmation"),
+    ("S1-05", 16, 1.25, 1.00, 1.80, "tighter ATR stop"),
+    ("S1-06", 16, 1.25, 1.50, 1.80, "wider ATR stop"),
+    ("S1-07", 16, 1.25, 1.25, 1.50, "lower payoff ratio"),
+    ("S1-08", 16, 1.25, 1.25, 2.00, "higher payoff ratio"),
+    ("S1-09", 12, 1.50, 1.25, 1.80, "fast breakout requires stronger volume"),
+    ("S1-10", 24, 1.00, 1.25, 1.80, "slow breakout tolerates weaker volume"),
+    ("S1-11", 16, 1.25, 1.00, 2.00, "tight-stop/high-payoff cost resilience"),
+)
+
+EXPECTED_S2 = (
+    ("S2-00", 3.00, 2.00, 0.35, 1.25, "연구 default"),
+    ("S2-01", 2.75, 2.00, 0.35, 1.25, "lower shock threshold"),
+    ("S2-02", 3.25, 2.00, 0.35, 1.25, "higher shock threshold"),
+    ("S2-03", 3.00, 1.50, 0.35, 1.25, "looser volume spike"),
+    ("S2-04", 3.00, 2.50, 0.35, 1.25, "stricter volume spike"),
+    ("S2-05", 3.00, 2.00, 0.25, 1.25, "stricter mean-reversion regime"),
+    ("S2-06", 3.00, 2.00, 0.45, 1.25, "looser regime filter"),
+    ("S2-07", 3.00, 2.00, 0.35, 1.20, "lower reward floor"),
+    ("S2-08", 3.00, 2.00, 0.35, 1.35, "higher reward floor"),
+    ("S2-09", 2.75, 1.50, 0.45, 1.20, "permissive/frequency frontier"),
+    ("S2-10", 3.25, 2.50, 0.25, 1.35, "selective/quality frontier"),
+    ("S2-11", 2.75, 2.50, 0.25, 1.25, "lower z only when volume/regime are strict"),
+)
+
+
+def test_exactly_12_rows_per_strategy_24_total():
+    from rob940_signal_manifest import FROZEN_S1_CONFIGS, FROZEN_S2_CONFIGS
+
+    assert len(FROZEN_S1_CONFIGS) == 12
+    assert len(FROZEN_S2_CONFIGS) == 12
+    assert len(FROZEN_S1_CONFIGS) + len(FROZEN_S2_CONFIGS) == 24
+
+
+def test_s1_rows_exact_values_and_order():
+    from rob940_signal_manifest import FROZEN_S1_CONFIGS
+
+    actual = tuple(
+        (c.config_id, c.L, c.q_min, c.k_SL, c.R_TP, c.hypothesis)
+        for c in FROZEN_S1_CONFIGS
+    )
+    assert actual == EXPECTED_S1
+
+
+def test_s2_rows_exact_values_and_order():
+    from rob940_signal_manifest import FROZEN_S2_CONFIGS
+
+    actual = tuple(
+        (c.config_id, c.z_min, c.v_min, c.ER_max, c.R_min, c.hypothesis)
+        for c in FROZEN_S2_CONFIGS
+    )
+    assert actual == EXPECTED_S2
+
+
+def test_get_s1_config_returns_frozen_row():
+    cfg = get_s1_config("S1-07")
+    assert cfg == S1Config(16, 1.25, 1.25, 1.50, "S1-07", "lower payoff ratio")
+
+
+def test_get_s2_config_returns_frozen_row():
+    cfg = get_s2_config("S2-11")
+    assert cfg.z_min == 2.75
+    assert cfg.hypothesis == "lower z only when volume/regime are strict"
+
+
+def test_unregistered_s1_config_id_fails_closed():
+    with pytest.raises(KeyError):
+        get_s1_config("S1-99")
+
+
+def test_unregistered_s2_config_id_fails_closed():
+    with pytest.raises(KeyError):
+        get_s2_config("S2-99")
+
+
+def test_symbols_are_exactly_four_and_no_btc_only_threshold_path():
+    assert SYMBOLS == ("BTCUSDT", "XRPUSDT", "DOGEUSDT", "SOLUSDT")
+
+
+@pytest.mark.parametrize("symbol", ["BTCUSDT", "XRPUSDT", "DOGEUSDT", "SOLUSDT"])
+def test_resolve_s1_config_for_symbol_is_identical_across_symbols(symbol):
+    # No symbol-specific override exists: every symbol resolves the SAME
+    # config object/values for a given config_id (no BTC-only threshold).
+    resolved = resolve_s1_config_for_symbol("S1-00", symbol)
+    assert resolved == get_s1_config("S1-00")
+
+
+def test_resolve_s1_config_for_symbol_rejects_unknown_symbol():
+    with pytest.raises(ValueError):
+        resolve_s1_config_for_symbol("S1-00", "ETHUSDT")
+
+
+def test_resolve_s2_config_for_symbol_rejects_unknown_symbol():
+    with pytest.raises(ValueError):
+        resolve_s2_config_for_symbol("S2-00", "ETHUSDT")
+
+
+def test_s1_domains_exact():
+    assert S1_DOMAINS == {
+        "L": (12, 16, 24),
+        "q_min": (1.00, 1.25, 1.50),
+        "k_SL": (1.00, 1.25, 1.50),
+        "R_TP": (1.50, 1.80, 2.00),
+    }
+
+
+def test_s2_domains_exact():
+    assert S2_DOMAINS == {
+        "z_min": (2.75, 3.00, 3.25),
+        "v_min": (1.50, 2.00, 2.50),
+        "ER_max": (0.25, 0.35, 0.45),
+        "R_min": (1.20, 1.25, 1.35),
+    }
+
+
+def test_validate_s1_configs_rejects_13th_row():
+    from rob940_signal_manifest import FROZEN_S1_CONFIGS
+
+    extra = S1Config(16, 1.25, 1.25, 1.80, "S1-12", "unregistered 13th row")
+    with pytest.raises(ValueError, match="exactly 12"):
+        validate_s1_configs((*FROZEN_S1_CONFIGS, extra))
+
+
+def test_validate_s2_configs_rejects_13th_row():
+    from rob940_signal_manifest import FROZEN_S2_CONFIGS
+
+    extra = S2Config(3.00, 2.00, 0.35, 1.25, "S2-12", "unregistered 13th row")
+    with pytest.raises(ValueError, match="exactly 12"):
+        validate_s2_configs((*FROZEN_S2_CONFIGS, extra))
+
+
+def test_validate_s1_configs_rejects_out_of_domain_param():
+    from rob940_signal_manifest import FROZEN_S1_CONFIGS
+
+    tampered = dataclasses.replace(FROZEN_S1_CONFIGS[0], L=18)  # not in {12,16,24}
+    rows = (tampered, *FROZEN_S1_CONFIGS[1:])
+    with pytest.raises(ValueError, match="domain"):
+        validate_s1_configs(rows)
+
+
+def test_validate_s1_configs_rejects_duplicate_config_id():
+    from rob940_signal_manifest import FROZEN_S1_CONFIGS
+
+    dup = dataclasses.replace(FROZEN_S1_CONFIGS[1], config_id="S1-00")
+    rows = (FROZEN_S1_CONFIGS[0], dup, *FROZEN_S1_CONFIGS[2:])
+    with pytest.raises(ValueError, match="duplicate"):
+        validate_s1_configs(rows)
+
+
+def test_frozen_constants_exact():
+    c = FrozenSignalConstants
+    assert c.ATR_PERIOD == 20
+    assert c.VOLUME_MEDIAN_WINDOW == 20
+    assert c.A_T_MIN == pytest.approx(0.002)
+    assert c.A_T_MAX == pytest.approx(0.012)
+    assert c.CHASE_MAX_ATR_MULT == pytest.approx(0.50)
+    assert c.S1_SL_CLIP_MIN_BPS == pytest.approx(45.0)
+    assert c.S1_SL_CLIP_MAX_BPS == pytest.approx(110.0)
+    assert c.S1_TIMEOUT_1M_BARS == 180  # 12 * 15m
+    assert c.S1_COOLDOWN_1M_BARS == 60  # 4 * 15m
+    assert c.S2_MAD_WINDOW == 288
+    assert c.S2_ER_WINDOW == 48
+    assert c.S2_SHOCK_ABS_RETURN_MIN == pytest.approx(0.006)
+    assert c.S2_SL_CLIP_MIN_BPS == pytest.approx(45.0)
+    assert c.S2_SL_CLIP_MAX_BPS == pytest.approx(90.0)
+    assert c.S2_TP_MAX_BPS == pytest.approx(120.0)
+    assert c.S2_TP_ABS_FLOOR_BPS == pytest.approx(68.0)
+    assert c.S2_TIMEOUT_1M_BARS == 30  # 6 * 5m
+    assert c.S2_COOLDOWN_1M_BARS == 60  # 1h
+
+
+def test_signal_manifest_hash_is_deterministic_and_pinned():
+    # Pin the exact hash so any future accidental edit to the 24-row
+    # manifest (order/values/hypothesis text/symbols) fails closed here
+    # instead of silently drifting. Computed once at GREEN time; report as
+    # ``signal_manifest_hash`` (NOT an H4 full-campaign hash) if this ever
+    # needs to change -- a change here is a new campaign lineage.
+    assert (
+        signal_manifest_hash
+        == "199816d45e79ed52218848dc53c54464754c5befce38dbad6615cf123b628fba"
+    )
+    assert isinstance(signal_manifest_hash, str)
+    assert len(signal_manifest_hash) == 64
+
+
+def test_signal_manifest_hash_changes_if_any_row_tampered():
+    from rob940_signal_manifest import (
+        FROZEN_S1_CONFIGS,
+        FROZEN_S2_CONFIGS,
+        _manifest_payload,
+    )
+
+    from research_contracts.canonical_hash import canonical_sha256
+
+    tampered_rows = (
+        dataclasses.replace(FROZEN_S1_CONFIGS[0], q_min=1.50),
+        *FROZEN_S1_CONFIGS[1:],
+    )
+    payload = _manifest_payload(tampered_rows, FROZEN_S2_CONFIGS)
+    tampered_hash = canonical_sha256(payload)
+    assert tampered_hash != signal_manifest_hash

--- a/research/nautilus_scalping/tests/test_rob940_signal_s1.py
+++ b/research/nautilus_scalping/tests/test_rob940_signal_s1.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import dataclasses
+
 import pytest
 from rob940_bars_agg import AggregatedBar
-from rob940_signal_manifest import get_s1_config
+from rob940_signal_manifest import S1Config, get_s1_config
 from rob940_signal_s1 import _rolling_median, _wilder_atr_series, generate_s1_signals
 
 _BUCKET_MS = 15 * 60_000
@@ -273,21 +275,58 @@ def test_s1_07_sl_floor_clip_yields_exactly_67_5bp_tp_no_trade_downstream():
 
 
 def test_a_t_below_min_produces_no_signal():
+    # I2 (R1 remediation, strategy-verify-rob943-r1-20260717-170045.md): the
+    # prior fixture (price ~100, tiny absolute range) was rejected by the
+    # CHASE gate, not a_t (chase=0.741>0.50) -- deleting A_T_MIN entirely
+    # still yielded no signal, so the lower bound had zero effective
+    # coverage. Fixed by holding the ATR-relative shape (and therefore
+    # chase/q) IDENTICAL to the passing boundary fixture below while
+    # shifting the absolute price level up by a large additive offset
+    # (baseline ~1000 instead of ~100): a_t=ATR/C shrinks well under 0.20%
+    # while chase=(C-U)/ATR is UNCHANGED (it only depends on price
+    # DIFFERENCES, which are untouched by the offset) and q is
+    # volume-based, also untouched. a_t is now the ONLY binding gate.
     cfg = get_s1_config("S1-00")
-    # Extremely tight flat range -> a_t well under 0.20%.
-    bars = _flat_warmup(20, h=100.02, low=99.98, c=100.0, v=100.0)
+    baseline = 1000.0
+    bars = _flat_warmup(20, h=baseline + 0.15, low=baseline - 0.15, c=baseline, v=100.0)
     breakout = AggregatedBar(
         ts=20 * _BUCKET_MS,
-        open=100.01,
-        high=100.05,
-        low=100.0,
-        close=100.05,
+        open=baseline + 0.10,
+        high=baseline + 0.30,  # =close, no upper wick
+        low=baseline + 0.0,
+        close=baseline + 0.30,
+        volume=125.0,  # q = 1.25 exactly, same as the passing sibling below
+        close_ts=21 * _BUCKET_MS,
+        is_segment_start=False,
+    )
+    signals = generate_s1_signals([*bars, breakout], cfg, symbol="XRPUSDT")
+    assert signals == ()  # a_t ~= 0.0003 (0.03%), well under the 0.20% floor
+
+
+def test_a_t_lower_boundary_exactly_0_002_emits():
+    # Positive control/sibling for the test above: SAME relative shape
+    # (chase=0.5, q=1.25 boundaries), but the baseline is chosen so
+    # a_t=ATR/C lands EXACTLY on the 0.002 inclusive lower bound -- proving
+    # the gate is `>=`, not `>`, and that a regression loosening/removing
+    # A_T_MIN would be caught (this fixture would still emit if the lower
+    # gate were removed, but the sibling above would ALSO start emitting,
+    # which is exactly the mutation this pair is designed to detect).
+    cfg = get_s1_config("S1-00")
+    baseline = 149.70  # ATR=0.3 (clean), C=150.00 -> a_t=0.3/150.0=0.002 exactly
+    bars = _flat_warmup(20, h=baseline + 0.15, low=baseline - 0.15, c=baseline, v=100.0)
+    breakout = AggregatedBar(
+        ts=20 * _BUCKET_MS,
+        open=baseline + 0.10,
+        high=baseline + 0.30,
+        low=baseline + 0.0,
+        close=baseline + 0.30,
         volume=125.0,
         close_ts=21 * _BUCKET_MS,
         is_segment_start=False,
     )
     signals = generate_s1_signals([*bars, breakout], cfg, symbol="XRPUSDT")
-    assert signals == ()
+    assert len(signals) == 1
+    assert signals[0].side == "long"
 
 
 def test_a_t_above_max_produces_no_signal():
@@ -334,3 +373,55 @@ def test_unique_signal_ts_per_symbol_fails_closed_on_duplicate():
     )
     with pytest.raises(ValueError, match="duplicate"):
         _assert_unique_signal_ts(dup)
+
+
+# ---------------------------------------------------------------------------
+# I4 (R1 remediation): exact frozen-membership fail-closed at the generator
+# boundary -- must reject BEFORE any math, even with zero bars.
+# ---------------------------------------------------------------------------
+
+
+def test_generate_s1_signals_rejects_unknown_symbol():
+    cfg = get_s1_config("S1-00")
+    with pytest.raises(ValueError):
+        generate_s1_signals([], cfg, symbol="ETHUSDT")
+
+
+def test_generate_s1_signals_rejects_forged_unregistered_config():
+    forged = S1Config(999, 9.9, 9.9, 9.9, "S1-FORGED", "forged")
+    with pytest.raises(ValueError):
+        generate_s1_signals([], forged, symbol="XRPUSDT")
+
+
+def test_generate_s1_signals_rejects_in_domain_param_swapped_config():
+    # L swapped 12->24 (both in-domain), config_id left as "S1-01": a caller
+    # could otherwise construct this and get silently-computed signals under
+    # a registered id that doesn't match its own row.
+    swapped = dataclasses.replace(get_s1_config("S1-01"), L=24)
+    with pytest.raises(ValueError):
+        generate_s1_signals([], swapped, symbol="XRPUSDT")
+
+
+def test_generate_s1_signals_rejects_hypothesis_tampered_config():
+    tampered = dataclasses.replace(get_s1_config("S1-00"), hypothesis="tampered")
+    with pytest.raises(ValueError):
+        generate_s1_signals([], tampered, symbol="XRPUSDT")
+
+
+def test_generate_s1_signals_accepts_value_equal_deserialized_config():
+    # A freshly-constructed (not `is`-identical) S1Config with EXACTLY the
+    # frozen row's values must be accepted -- this is a value-equality
+    # check, not an identity check.
+    canonical = get_s1_config("S1-00")
+    deserialized = S1Config(
+        canonical.L,
+        canonical.q_min,
+        canonical.k_SL,
+        canonical.R_TP,
+        canonical.config_id,
+        canonical.hypothesis,
+    )
+    assert deserialized is not canonical
+    assert deserialized == canonical
+    signals = generate_s1_signals([], deserialized, symbol="XRPUSDT")
+    assert signals == ()

--- a/research/nautilus_scalping/tests/test_rob940_signal_s1.py
+++ b/research/nautilus_scalping/tests/test_rob940_signal_s1.py
@@ -1,0 +1,336 @@
+"""ROB-943 (H3, ROB-940) — S1 Donchian-15m signal generator RED/GREEN tests."""
+
+from __future__ import annotations
+
+import pytest
+from rob940_bars_agg import AggregatedBar
+from rob940_signal_manifest import get_s1_config
+from rob940_signal_s1 import _rolling_median, _wilder_atr_series, generate_s1_signals
+
+_BUCKET_MS = 15 * 60_000
+
+
+def _bar(idx: int, o, h, low, c, v, *, segment_start: bool = False) -> AggregatedBar:
+    ts = idx * _BUCKET_MS
+    return AggregatedBar(
+        ts=ts,
+        open=o,
+        high=h,
+        low=low,
+        close=c,
+        volume=v,
+        close_ts=ts + _BUCKET_MS,
+        is_segment_start=segment_start,
+    )
+
+
+def _flat_warmup(
+    n: int, *, h=100.15, low=99.85, c=100.0, v=100.0
+) -> list[AggregatedBar]:
+    bars = []
+    for i in range(n):
+        bars.append(_bar(i, c, h, low, c, v, segment_start=(i == 0)))
+    return bars
+
+
+# ---------------------------------------------------------------------------
+# Pure helper unit tests (hand-verified tiny fixtures)
+# ---------------------------------------------------------------------------
+
+
+def test_wilder_atr_seed_is_simple_average_of_first_period_trs():
+    # period=3: TR_1..TR_3 constant at 2.0 (flat H/L/C=100+-1), seed=2.0.
+    bars = [
+        _bar(0, 100, 101, 99, 100, 10, segment_start=True),
+        _bar(1, 100, 101, 99, 100, 10),
+        _bar(2, 100, 101, 99, 100, 10),
+        _bar(3, 100, 101, 99, 100, 10),
+    ]
+    atr = _wilder_atr_series(bars, period=3)
+    assert atr[0] is None
+    assert atr[1] is None
+    assert atr[2] is None
+    assert atr[3] == 2.0  # seed = avg(TR_1,TR_2,TR_3) = avg(2,2,2)
+
+
+def test_wilder_atr_recurrence_after_seed():
+    # period=2: TR_1=TR_2=2.0 -> seed ATR_2=2.0. TR_3: H=104,L=100,Cprev=100
+    # -> TR=max(4,4,0)=4.0 -> ATR_3=(2.0*1+4.0)/2=3.0.
+    bars = [
+        _bar(0, 100, 101, 99, 100, 10, segment_start=True),
+        _bar(1, 100, 101, 99, 100, 10),
+        _bar(2, 100, 101, 99, 100, 10),
+        _bar(3, 100, 104, 100, 104, 10),
+    ]
+    atr = _wilder_atr_series(bars, period=2)
+    assert atr[2] == 2.0
+    assert atr[3] == 3.0
+
+
+def test_segment_slices_splits_on_gap():
+    from rob940_signal_s1 import _segment_slices
+
+    bars = [
+        _bar(0, 100, 101, 99, 100, 10, segment_start=True),
+        _bar(1, 100, 101, 99, 100, 10),
+        _bar(2, 100, 999, 1, 500, 10, segment_start=True),  # new segment
+        _bar(3, 500, 501, 499, 500, 10),
+    ]
+    assert _segment_slices(bars) == [(0, 2), (2, 4)]
+
+
+def test_generator_resets_warmup_after_gap_no_cross_segment_leakage():
+    cfg = get_s1_config("S1-00")  # L=16, needs 20 bars warm-up (dominant)
+    warm = _flat_warmup(20)  # a full, otherwise-valid warm-up segment
+    # A brand-new segment starts right at what would be the breakout bar:
+    # only 1 bar exists in THIS segment, so warm-up must NOT be considered
+    # satisfied even though 20 bars preceded it in the (gapped-off) old one.
+    post_gap_breakout = AggregatedBar(
+        ts=20 * _BUCKET_MS,
+        open=100.1,
+        high=100.30,
+        low=100.0,
+        close=100.30,
+        volume=125.0,
+        close_ts=21 * _BUCKET_MS,
+        is_segment_start=True,  # <-- gap boundary
+    )
+    signals = generate_s1_signals([*warm, post_gap_breakout], cfg, symbol="XRPUSDT")
+    assert signals == ()
+
+
+def test_rolling_median_excludes_current_bar():
+    values = [10.0, 10.0, 10.0, 999.0]  # current bar's own huge volume excluded
+    med = _rolling_median(values, window=3, idx=3)
+    assert med == 10.0
+
+
+def test_rolling_median_none_before_window_full():
+    values = [10.0, 10.0]
+    assert _rolling_median(values, window=3, idx=1) is None
+
+
+# ---------------------------------------------------------------------------
+# Generator-level tests
+# ---------------------------------------------------------------------------
+
+
+def test_no_signal_before_warmup_complete():
+    cfg = get_s1_config("S1-00")  # L=16
+    bars = _flat_warmup(20)  # index 0..19, ATR/volume need index>=20
+    signals = generate_s1_signals(bars, cfg, symbol="XRPUSDT")
+    assert signals == ()
+
+
+def test_long_breakout_chase_boundary_exactly_half_atr_passes():
+    cfg = get_s1_config("S1-00")  # L=16, q_min=1.25, k_SL=1.25, R_TP=1.80
+    bars = _flat_warmup(20)  # indices 0..19, flat H=100.15/L=99.85/C=100 -> TR=0.3
+    # U (window [4:20)) = 100.15. TR_20 chosen = 0.3 too (H=C=100.30, L=100.0)
+    # so ATR stays clean at 0.3: seed=(19*0.3+0.3)/20=0.3.
+    # chase=(C-U)/ATR=(100.30-100.15)/0.3=0.5 exactly (upper boundary, inclusive).
+    breakout = AggregatedBar(
+        ts=20 * _BUCKET_MS,
+        open=100.1,
+        high=100.30,  # =close, no upper wick
+        low=100.0,
+        close=100.30,
+        volume=125.0,  # q = 125/100 = 1.25 exactly (boundary pass)
+        close_ts=21 * _BUCKET_MS,
+        is_segment_start=False,
+    )
+    bars = [*bars, breakout]
+    signals = generate_s1_signals(bars, cfg, symbol="XRPUSDT")
+    assert len(signals) == 1
+    sig = signals[0]
+    assert sig.side == "long"
+    assert sig.signal_ts == breakout.close_ts
+    assert sig.strategy == "S1"
+    assert sig.config_id == "S1-00"
+    assert sig.symbol == "XRPUSDT"
+    assert sig.timeout_bars == 180
+    assert sig.cooldown_bars == 60
+    # k_SL*a_t = 1.25*0.3/100.30 = 0.3738% < 0.45% floor -> clipped.
+    assert round(sig.sl_distance_bps, 6) == 45.0
+    assert round(sig.tp_distance_bps, 6) == 81.0  # R_TP=1.80 * 45bp
+
+
+def test_strict_breakout_equal_to_upper_band_does_not_trigger():
+    cfg = get_s1_config("S1-00")
+    bars = _flat_warmup(20)
+    at_band = AggregatedBar(
+        ts=20 * _BUCKET_MS,
+        open=100.15,
+        high=100.15,
+        low=99.85,
+        close=100.15,  # exactly == U, not strictly above
+        volume=200.0,
+        close_ts=21 * _BUCKET_MS,
+        is_segment_start=False,
+    )
+    signals = generate_s1_signals([*bars, at_band], cfg, symbol="XRPUSDT")
+    assert signals == ()
+
+
+def test_short_breakout_symmetric_to_long():
+    cfg = get_s1_config("S1-00")  # D (window [4:20)) = 99.85
+    bars = _flat_warmup(20)
+    # Mirror of the long chase=0.5-boundary fixture: TR_20 kept at 0.3 (clean
+    # ATR=0.3) via H=100.0(=Cprev)/L=C=99.70, so chase=(D-C)/ATR=0.5 exactly.
+    breakout = AggregatedBar(
+        ts=20 * _BUCKET_MS,
+        open=99.9,
+        high=100.0,
+        low=99.70,  # =close, no lower wick
+        close=99.70,
+        volume=125.0,  # q = 1.25 exactly
+        close_ts=21 * _BUCKET_MS,
+        is_segment_start=False,
+    )
+    signals = generate_s1_signals([*bars, breakout], cfg, symbol="XRPUSDT")
+    assert len(signals) == 1
+    sig = signals[0]
+    assert sig.side == "short"
+    assert round(sig.sl_distance_bps, 6) == 45.0
+    assert round(sig.tp_distance_bps, 6) == 81.0
+
+
+def test_volume_gate_below_q_min_produces_no_signal():
+    cfg = get_s1_config("S1-00")  # q_min=1.25
+    bars = _flat_warmup(20)
+    # Same shape as the chase=0.5-boundary fixture (breakout/chase/a_t all
+    # otherwise pass) except volume is 1 unit short of the q_min threshold.
+    breakout = AggregatedBar(
+        ts=20 * _BUCKET_MS,
+        open=100.1,
+        high=100.30,
+        low=100.0,
+        close=100.30,
+        volume=124.0,  # q = 1.24 < 1.25
+        close_ts=21 * _BUCKET_MS,
+        is_segment_start=False,
+    )
+    signals = generate_s1_signals([*bars, breakout], cfg, symbol="XRPUSDT")
+    assert signals == ()
+
+
+def test_chase_beyond_half_atr_produces_no_signal():
+    cfg = get_s1_config("S1-00")
+    bars = _flat_warmup(20)
+    far_breakout = AggregatedBar(
+        ts=20 * _BUCKET_MS,
+        open=100.1,
+        high=101.6,
+        low=100.6,
+        close=101.6,  # far above U, chase ratio > 0.5
+        volume=125.0,
+        close_ts=21 * _BUCKET_MS,
+        is_segment_start=False,
+    )
+    signals = generate_s1_signals([*bars, far_breakout], cfg, symbol="XRPUSDT")
+    assert signals == ()
+
+
+def test_s1_07_sl_floor_clip_yields_exactly_67_5bp_tp_no_trade_downstream():
+    from rob940_bars_agg import Bar1m
+    from rob940_cost_model import COST_SCENARIO_PRIMARY_STRESS
+    from rob940_engine import run_symbol_stream
+
+    cfg = get_s1_config("S1-07")  # L=16, q_min=1.25, k_SL=1.25, R_TP=1.50
+    bars = _flat_warmup(20, h=100.15, low=99.85, c=100.0, v=100.0)
+    breakout = AggregatedBar(
+        ts=20 * _BUCKET_MS,
+        open=100.2,
+        high=100.25,
+        low=99.95,
+        close=100.25,
+        volume=125.0,
+        close_ts=21 * _BUCKET_MS,
+        is_segment_start=False,
+    )
+    signals = generate_s1_signals([*bars, breakout], cfg, symbol="XRPUSDT")
+    assert len(signals) == 1
+    sig = signals[0]
+    assert sig.tp_distance_bps is not None
+    assert round(sig.tp_distance_bps, 6) == 67.5
+    assert round(sig.sl_distance_bps, 6) == 45.0
+
+    # Feed straight into H2: below the 68bp gate -> no-trade, not silently
+    # dropped by the generator itself (S1-07 is retained per Fable Q1=A).
+    bars_1m = [
+        Bar1m(
+            ts=21 * _BUCKET_MS,
+            open=100.25,
+            high=100.3,
+            low=100.2,
+            close=100.28,
+            volume=1.0,
+        )
+    ]
+    result = run_symbol_stream(bars_1m, signals, COST_SCENARIO_PRIMARY_STRESS)
+    assert result.trades == ()
+    assert len(result.no_trades) == 1
+    assert result.no_trades[0].reason == "tp_below_min_distance"
+
+
+def test_a_t_below_min_produces_no_signal():
+    cfg = get_s1_config("S1-00")
+    # Extremely tight flat range -> a_t well under 0.20%.
+    bars = _flat_warmup(20, h=100.02, low=99.98, c=100.0, v=100.0)
+    breakout = AggregatedBar(
+        ts=20 * _BUCKET_MS,
+        open=100.01,
+        high=100.05,
+        low=100.0,
+        close=100.05,
+        volume=125.0,
+        close_ts=21 * _BUCKET_MS,
+        is_segment_start=False,
+    )
+    signals = generate_s1_signals([*bars, breakout], cfg, symbol="XRPUSDT")
+    assert signals == ()
+
+
+def test_a_t_above_max_produces_no_signal():
+    cfg = get_s1_config("S1-00")
+    # Very wide flat range -> a_t well over 1.20%.
+    bars = _flat_warmup(20, h=104.0, low=96.0, c=100.0, v=100.0)
+    breakout = AggregatedBar(
+        ts=20 * _BUCKET_MS,
+        open=101.0,
+        high=105.0,
+        low=97.0,
+        close=105.0,
+        volume=125.0,
+        close_ts=21 * _BUCKET_MS,
+        is_segment_start=False,
+    )
+    signals = generate_s1_signals([*bars, breakout], cfg, symbol="XRPUSDT")
+    assert signals == ()
+
+
+def test_unique_signal_ts_per_symbol_fails_closed_on_duplicate():
+    from rob940_engine import SignalEvent
+    from rob940_signal_s1 import _assert_unique_signal_ts
+
+    dup = (
+        SignalEvent(
+            strategy="S1",
+            config_id="S1-00",
+            symbol="XRPUSDT",
+            signal_ts=1000,
+            side="long",
+            sl_distance_bps=50.0,
+            tp_distance_bps=90.0,
+        ),
+        SignalEvent(
+            strategy="S1",
+            config_id="S1-00",
+            symbol="XRPUSDT",
+            signal_ts=1000,
+            side="short",
+            sl_distance_bps=50.0,
+            tp_distance_bps=90.0,
+        ),
+    )
+    with pytest.raises(ValueError, match="duplicate"):
+        _assert_unique_signal_ts(dup)

--- a/research/nautilus_scalping/tests/test_rob940_signal_s2.py
+++ b/research/nautilus_scalping/tests/test_rob940_signal_s2.py
@@ -1,19 +1,22 @@
 """ROB-943 (H3, ROB-940) — S2 confirmed-shock-reversal-5m signal RED/GREEN tests.
 
 Includes the PERMANENT ambiguity-gate reproduction
-(``test_ambiguity_gate_direction_mismatch_is_held_pending_consult`` and its
+(``test_ambiguity_gate_direction_mismatch_final_fable_ruling`` and its
 companion GREEN test) per the Fable-approved final ruling in
 ``orch-fable-answer-rob943-s2-20260717.md`` (Q1=A, direction guard kept,
-RED fixture retained permanently — do not delete this test).
+RED fixture retained permanently — do not delete this test; only its name
+changed in the R1 remediation round to drop the stale "pending_consult"
+wording -- the ruling itself has been final since 2026-07-17).
 """
 
 from __future__ import annotations
 
+import dataclasses
 import math
 
 import pytest
 from rob940_bars_agg import AggregatedBar, Bar1m
-from rob940_signal_manifest import FrozenSignalConstants, get_s2_config
+from rob940_signal_manifest import FrozenSignalConstants, S2Config, get_s2_config
 from rob940_signal_s2 import (
     RejectedCandidate,
     _efficiency_ratio,
@@ -89,7 +92,7 @@ def test_efficiency_ratio_pure_trend_is_one():
 # ---------------------------------------------------------------------------
 
 
-def test_ambiguity_gate_direction_mismatch_is_held_pending_consult():
+def test_ambiguity_gate_direction_mismatch_final_fable_ruling():
     """PERMANENT regression (Fable Q1=A final, orch-fable-answer-rob943-s2-
     20260717.md). Reproduces the exact risk described in the consult doc:
     confirmation overshoot puts target T below entry E for a long (or above
@@ -172,24 +175,30 @@ def _flat_segment(n: int, *, c=100.0, v=100.0) -> list[AggregatedBar]:
 
 
 def _zigzag_then_shock(
-    *, shock_close: float, confirm_close=None, confirm_high=None, confirm_low=None
+    *,
+    shock_close: float,
+    confirm_close=None,
+    confirm_high=None,
+    confirm_low=None,
+    flat_n: int = _FLAT_N,
 ) -> list[AggregatedBar]:
-    """288 flat bars (index 0..287) + 47 alternating +/-0.6 "noise" bars
-    (index 288..334, 47 bars) + shock bar (index 335) [+ optional confirm
-    bar index 336]. Index 335 is bar t=335 >= 289 warm-up floor -- ample
-    margin above the min eligible index so window slicing has headroom.
+    """``flat_n`` flat bars + 47 alternating +/-0.6 "noise" bars + shock bar
+    [+ optional confirm bar]. With the default ``flat_n=288`` the shock lands
+    at bar t=335, well above the 289 min-eligible-index floor (ample margin
+    for window slicing). Passing ``flat_n=241``/``242`` places the shock
+    exactly at the t=288 (excluded) / t=289 (first eligible) boundary.
     """
-    bars = _flat_segment(_FLAT_N)
+    bars = _flat_segment(flat_n)
     noise: list[AggregatedBar] = []
     prev_close = 100.0
     for k in range(47):
-        idx = _FLAT_N + k
+        idx = flat_n + k
         c = 100.6 if k % 2 == 0 else 100.0
         noise.append(
             _bar(idx, prev_close, max(prev_close, c), min(prev_close, c), c, 100.0)
         )
         prev_close = c
-    shock_idx = _FLAT_N + 47
+    shock_idx = flat_n + 47
     shock_bar = _bar(
         shock_idx,
         prev_close,
@@ -282,18 +291,6 @@ def test_next_bar_unavailable_is_rejected_not_silently_dropped():
     assert reasons.get("next_bar_unavailable", 0) == 1
 
 
-def test_gap_reset_discards_pending_shock_and_warmup():
-    cfg = get_s2_config("S2-00")
-    bars = _zigzag_then_shock(shock_close=99.9)  # ends right at the shock bar
-    shock_idx = _FLAT_N + 47
-    # A gap: new segment starts immediately, discarding the pending shock
-    # and resetting warm-up (this lone bar can't possibly be a confirmation).
-    gap_bar = _bar(shock_idx + 1, 99.9, 100.5, 99.9, 100.4, 100.0, segment_start=True)
-    bars = [*bars, gap_bar]
-    result = generate_s2_signals(bars, [], cfg, symbol="XRPUSDT")
-    assert result.signals == ()
-
-
 def test_rejection_dataclass_has_reason_field_for_aggregation():
     rc = RejectedCandidate(
         strategy="S2",
@@ -304,3 +301,235 @@ def test_rejection_dataclass_has_reason_field_for_aggregation():
         reason="target_direction_invalid",
     )
     assert count_rejection_reasons((rc, rc)) == {"target_direction_invalid": 2}
+
+
+# ---------------------------------------------------------------------------
+# I4 (R1 remediation): exact frozen-membership fail-closed at the generator
+# boundary -- must reject BEFORE any math, even with zero bars.
+# ---------------------------------------------------------------------------
+
+
+def test_generate_s2_signals_rejects_unknown_symbol():
+    cfg = get_s2_config("S2-00")
+    with pytest.raises(ValueError):
+        generate_s2_signals([], [], cfg, symbol="ETHUSDT")
+
+
+def test_generate_s2_signals_rejects_forged_unregistered_config():
+    forged = S2Config(9.9, 9.9, 9.9, 9.9, "S2-FORGED", "forged")
+    with pytest.raises(ValueError):
+        generate_s2_signals([], [], forged, symbol="XRPUSDT")
+
+
+def test_generate_s2_signals_rejects_in_domain_param_swapped_config():
+    swapped = dataclasses.replace(get_s2_config("S2-01"), z_min=3.25)
+    with pytest.raises(ValueError):
+        generate_s2_signals([], [], swapped, symbol="XRPUSDT")
+
+
+def test_generate_s2_signals_rejects_hypothesis_tampered_config():
+    tampered = dataclasses.replace(get_s2_config("S2-00"), hypothesis="tampered")
+    with pytest.raises(ValueError):
+        generate_s2_signals([], [], tampered, symbol="XRPUSDT")
+
+
+def test_generate_s2_signals_accepts_value_equal_deserialized_config():
+    canonical = get_s2_config("S2-00")
+    deserialized = S2Config(
+        canonical.z_min,
+        canonical.v_min,
+        canonical.ER_max,
+        canonical.R_min,
+        canonical.config_id,
+        canonical.hypothesis,
+    )
+    assert deserialized is not canonical
+    assert deserialized == canonical
+    result = generate_s2_signals([], [], deserialized, symbol="XRPUSDT")
+    assert result.signals == ()
+    assert result.rejections == ()
+
+
+# ---------------------------------------------------------------------------
+# I3 (R1 remediation): non-vacuous gap-reset -- a REAL 1m bar is present at
+# the confirmation close_ts so the is_segment_start=False control genuinely
+# emits, proving the True (gap) branch's 0-signal/0-rejection result is due
+# to the reset discarding a stale pending shock, not an unrelated no-op.
+# ---------------------------------------------------------------------------
+
+
+def _gap_reset_fixture(*, gap: bool) -> tuple[list[AggregatedBar], list[Bar1m]]:
+    bars = _zigzag_then_shock(
+        shock_close=99.9, confirm_close=100.2, confirm_high=100.25, confirm_low=99.95
+    )
+    # Flip only the confirmation bar's is_segment_start flag: `gap=True`
+    # means a real time discontinuity occurred right before the would-be
+    # confirmation bar, so it starts a NEW segment and the shock (last bar
+    # of the OLD segment) can never be confirmed against it.
+    confirm = bars[-1]
+    bars[-1] = dataclasses.replace(confirm, is_segment_start=gap)
+    bars_1m = [
+        Bar1m(
+            ts=confirm.close_ts,
+            open=99.70,
+            high=99.9,
+            low=99.6,
+            close=99.8,
+            volume=10.0,
+        )
+    ]
+    return bars, bars_1m
+
+
+def test_gap_reset_control_no_gap_emits_real_signal():
+    bars, bars_1m = _gap_reset_fixture(gap=False)
+    result = generate_s2_signals(
+        bars, bars_1m, get_s2_config("S2-00"), symbol="XRPUSDT"
+    )
+    assert len(result.signals) == 1
+    assert result.signals[0].side == "long"
+
+
+def test_gap_reset_discards_pending_shock_stale_candidate_never_evaluated():
+    bars, bars_1m = _gap_reset_fixture(gap=True)
+    result = generate_s2_signals(
+        bars, bars_1m, get_s2_config("S2-00"), symbol="XRPUSDT"
+    )
+    assert result.signals == ()
+    # Not merely "no signal" -- the pending shock must never have been
+    # EVALUATED at all (no confirmation_failed/next_bar_unavailable/etc.
+    # rejection row either), proving it was discarded by the reset rather
+    # than considered and rejected for some unrelated reason.
+    assert result.rejections == ()
+
+
+# ---------------------------------------------------------------------------
+# Recommended regressions (R1's independently-verified one-offs, committed)
+# ---------------------------------------------------------------------------
+
+
+def test_shock_at_t_288_excluded_t_289_first_eligible():
+    cfg = get_s2_config("S2-00")
+    # t=288: flat_n=241 -> shock_idx=241+47=288 (one BELOW the 289 floor).
+    excluded = _zigzag_then_shock(shock_close=99.9, flat_n=241)
+    result_excluded = generate_s2_signals(excluded, [], cfg, symbol="XRPUSDT")
+    assert result_excluded.signals == ()
+    assert result_excluded.rejections == ()  # never evaluated, not rejected
+
+    # t=289: flat_n=242 -> shock_idx=242+47=289 (first eligible), with a
+    # real confirmation + 1m bar so a genuine signal proves it WAS evaluated.
+    included = _zigzag_then_shock(
+        shock_close=99.9,
+        flat_n=242,
+        confirm_close=100.2,
+        confirm_high=100.25,
+        confirm_low=99.95,
+    )
+    bars_1m = [
+        Bar1m(
+            ts=included[-1].close_ts,
+            open=99.70,
+            high=99.9,
+            low=99.6,
+            close=99.8,
+            volume=10.0,
+        )
+    ]
+    result_included = generate_s2_signals(included, bars_1m, cfg, symbol="XRPUSDT")
+    assert len(result_included.signals) == 1
+
+
+def test_positive_shock_short_confirmation_full_signal_round_trips_through_h2():
+    from rob940_cost_model import COST_SCENARIO_PRIMARY_STRESS
+    from rob940_engine import run_symbol_stream
+
+    cfg = get_s2_config("S2-00")
+    shock_close = 101.3  # prev_close=100.6 -> r_t=+0.693% (positive shock)
+    bars = _zigzag_then_shock(
+        shock_close=shock_close,
+        confirm_close=101.0,
+        confirm_high=101.2,  # <= shock high (101.3)
+        confirm_low=100.9,
+    )
+    # T=C_{t-1}=100.6 (shock's own prior close); E=101.50 puts T<E, valid
+    # for short. d_TP=|100.6/101.50-1|=88.67bp, within [68,120]bp.
+    bars_1m = [
+        Bar1m(
+            ts=bars[-1].close_ts,
+            open=101.50,
+            high=101.6,
+            low=101.4,
+            close=101.55,
+            volume=10.0,
+        )
+    ]
+    result = generate_s2_signals(bars, bars_1m, cfg, symbol="XRPUSDT")
+    assert len(result.signals) == 1
+    sig = result.signals[0]
+    assert sig.side == "short"
+    assert sig.tp_target_price == pytest.approx(100.6)
+
+    engine_bars_1m = [
+        Bar1m(
+            ts=bars_1m[0].ts,
+            open=101.50,
+            high=101.55,
+            low=101.30,
+            close=101.35,
+            volume=1.0,
+        )
+    ]
+    engine_result = run_symbol_stream(
+        engine_bars_1m, result.signals, COST_SCENARIO_PRIMARY_STRESS
+    )
+    assert len(engine_result.trades) == 1
+    assert engine_result.trades[0].side == "short"
+
+
+def test_next_bar_unavailable_does_not_scan_forward_to_a_later_1m_bar():
+    cfg = get_s2_config("S2-00")
+    bars = _zigzag_then_shock(
+        shock_close=99.9, confirm_close=100.2, confirm_high=100.25, confirm_low=99.95
+    )
+    confirm_close_ts = bars[-1].close_ts
+    # A 1m bar exists, but one minute LATER than the exact required ts --
+    # the engine-consumption contract (AC3) forbids searching further ahead.
+    later_only = [
+        Bar1m(
+            ts=confirm_close_ts + 60_000,
+            open=99.70,
+            high=99.9,
+            low=99.6,
+            close=99.8,
+            volume=10.0,
+        )
+    ]
+    result = generate_s2_signals(bars, later_only, cfg, symbol="XRPUSDT")
+    assert result.signals == ()
+    reasons = count_rejection_reasons(result.rejections)
+    assert reasons.get("next_bar_unavailable", 0) == 1
+
+
+def test_real_pipeline_target_direction_invalid_reason_count():
+    """FABLE-A1 gap closed: aggregate a rejection produced by an actual
+    ``generate_s2_signals`` run (not a hand-built ``RejectedCandidate``).
+    """
+    cfg = get_s2_config("S2-00")
+    bars = _zigzag_then_shock(
+        shock_close=99.9, confirm_close=100.2, confirm_high=100.25, confirm_low=99.95
+    )
+    # E=101.0 puts E ABOVE T=100.6 for a long -> direction-invalid, even
+    # though the shock/confirmation themselves are perfectly valid.
+    bars_1m = [
+        Bar1m(
+            ts=bars[-1].close_ts,
+            open=101.0,
+            high=101.1,
+            low=100.9,
+            close=101.05,
+            volume=10.0,
+        )
+    ]
+    result = generate_s2_signals(bars, bars_1m, cfg, symbol="XRPUSDT")
+    assert result.signals == ()
+    assert count_rejection_reasons(result.rejections) == {"target_direction_invalid": 1}

--- a/research/nautilus_scalping/tests/test_rob940_signal_s2.py
+++ b/research/nautilus_scalping/tests/test_rob940_signal_s2.py
@@ -1,0 +1,306 @@
+"""ROB-943 (H3, ROB-940) — S2 confirmed-shock-reversal-5m signal RED/GREEN tests.
+
+Includes the PERMANENT ambiguity-gate reproduction
+(``test_ambiguity_gate_direction_mismatch_is_held_pending_consult`` and its
+companion GREEN test) per the Fable-approved final ruling in
+``orch-fable-answer-rob943-s2-20260717.md`` (Q1=A, direction guard kept,
+RED fixture retained permanently — do not delete this test).
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+from rob940_bars_agg import AggregatedBar, Bar1m
+from rob940_signal_manifest import FrozenSignalConstants, get_s2_config
+from rob940_signal_s2 import (
+    RejectedCandidate,
+    _efficiency_ratio,
+    _evaluate_target_gates,
+    _log_returns,
+    _median_mad_sigma,
+    count_rejection_reasons,
+    generate_s2_signals,
+)
+
+_C = FrozenSignalConstants
+_BUCKET_MS = 5 * 60_000
+
+
+def _bar(idx, o, h, low, c, v, *, segment_start=False) -> AggregatedBar:
+    ts = idx * _BUCKET_MS
+    return AggregatedBar(
+        ts=ts,
+        open=o,
+        high=h,
+        low=low,
+        close=c,
+        volume=v,
+        close_ts=ts + _BUCKET_MS,
+        is_segment_start=segment_start,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Pure helper unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_log_returns_first_is_none_rest_computed():
+    closes = [100.0, 110.0, 99.0]
+    r = _log_returns(closes)
+    assert r[0] is None
+    assert r[1] == pytest.approx(math.log(1.1))
+    assert r[2] == pytest.approx(math.log(99.0 / 110.0))
+
+
+def test_median_mad_sigma_floor_applies_on_zero_mad():
+    med, sigma = _median_mad_sigma([0.0, 0.0, 0.0, 0.0, 0.0])
+    assert med == 0.0
+    assert sigma == 0.0001  # floor, since 1.4826*MAD=0 < floor
+
+
+def test_median_mad_sigma_hand_verified():
+    med, sigma = _median_mad_sigma([-2.0, -1.0, 0.0, 1.0, 2.0])
+    assert med == 0.0
+    assert sigma == pytest.approx(1.4826 * 1.0)  # MAD = median(|x|) = 1.0
+
+
+def test_efficiency_ratio_denominator_zero_is_none_fail_closed():
+    closes = [5.0, 5.0, 5.0, 5.0, 5.0]
+    assert _efficiency_ratio(closes, t=4, window=4) is None
+
+
+def test_efficiency_ratio_hand_verified():
+    closes = [0.0, 1.0, 2.0, 1.0, 0.0]
+    # numerator=|closes[4]-closes[0]|=0; denom=1+1+1+1=4
+    assert _efficiency_ratio(closes, t=4, window=4) == 0.0
+
+
+def test_efficiency_ratio_pure_trend_is_one():
+    closes = [0.0, 1.0, 2.0, 3.0, 4.0]
+    # numerator=4, denom=1+1+1+1=4 -> ER=1.0 (maximally trending)
+    assert _efficiency_ratio(closes, t=4, window=4) == 1.0
+
+
+# ---------------------------------------------------------------------------
+# _evaluate_target_gates: direction + magnitude boundary tests
+# ---------------------------------------------------------------------------
+
+
+def test_ambiguity_gate_direction_mismatch_is_held_pending_consult():
+    """PERMANENT regression (Fable Q1=A final, orch-fable-answer-rob943-s2-
+    20260717.md). Reproduces the exact risk described in the consult doc:
+    confirmation overshoot puts target T below entry E for a long (or above
+    E for a short) even though all THREE magnitude gates independently pass.
+    Literal (guard-less) execution would hand H2 a ``tp_target_price`` on
+    the wrong side of entry, and H2's ``_gapped_through_tp`` would fire an
+    immediate entry-bar "take_profit" exit that is actually a realized
+    LOSS (gross_bps negative) mislabeled as a win — corrupting every
+    downstream win-rate/PF/timeout metric. The direction guard rejects this
+    input with reason ``target_direction_invalid`` instead.
+    """
+    entry_price = 100.00
+    target_price = 99.20  # BELOW entry despite side="long"
+    sl_distance = 0.0045  # 45bp
+    r_min = 1.25
+    passed, reason, d_tp_bps = _evaluate_target_gates(
+        "long", entry_price, target_price, sl_distance, r_min
+    )
+    # Magnitude alone would pass: d_tp=80bp, 68<=80<=120, 80>=1.25*45=56.25.
+    assert d_tp_bps == pytest.approx(80.0)
+    assert passed is False
+    assert reason == "target_direction_invalid"
+
+
+def test_direction_guard_short_symmetric():
+    passed, reason, _ = _evaluate_target_gates("short", 100.00, 100.80, 0.0045, 1.25)
+    assert passed is False
+    assert reason == "target_direction_invalid"
+
+
+def test_direction_valid_long_passes_when_magnitude_ok():
+    passed, reason, d_tp_bps = _evaluate_target_gates(
+        "long", 100.00, 100.80, 0.0045, 1.25
+    )
+    assert passed is True
+    assert reason is None
+    assert d_tp_bps == pytest.approx(80.0)
+
+
+def test_tp_above_120bp_cap_boundary():
+    # 120bp exactly passes, 120.01bp fails.
+    ok, reason, _ = _evaluate_target_gates("long", 100.00, 101.20, 0.0045, 1.0)
+    assert ok is True and reason is None
+    bad, reason, _ = _evaluate_target_gates("long", 100.00, 101.2001, 0.0045, 1.0)
+    assert bad is False and reason == "tp_above_max"
+
+
+def test_tp_below_r_min_sl_boundary():
+    # d_SL=60bp, R_min=1.25 -> threshold=75bp (above the 68bp abs floor).
+    sl = 0.0060
+    ok, reason, d_tp = _evaluate_target_gates("long", 100.00, 100.75, sl, 1.25)
+    assert ok is True and reason is None
+    assert d_tp == pytest.approx(75.0)
+    bad, reason, _ = _evaluate_target_gates("long", 100.00, 100.7499, sl, 1.25)
+    assert bad is False and reason == "tp_below_r_min_sl"
+
+
+def test_tp_below_68bp_abs_floor_boundary():
+    # d_SL=45bp, R_min=1.20 -> R_min*d_SL=54bp, so 68bp abs floor is binding.
+    sl = 0.0045
+    ok, reason, d_tp = _evaluate_target_gates("long", 100.00, 100.68, sl, 1.20)
+    assert ok is True and reason is None
+    assert d_tp == pytest.approx(68.0)
+    bad, reason, _ = _evaluate_target_gates("long", 100.00, 100.6799, sl, 1.20)
+    assert bad is False and reason == "tp_below_abs_floor"
+
+
+# ---------------------------------------------------------------------------
+# End-to-end generator tests
+# ---------------------------------------------------------------------------
+
+_FLAT_N = 288  # prior-288 window; shock evaluated starting bar index 289
+
+
+def _flat_segment(n: int, *, c=100.0, v=100.0) -> list[AggregatedBar]:
+    return [
+        _bar(i, c, c, c, c, v, segment_start=(i == 0))  # O=H=L=C, zero TR/return
+        for i in range(n)
+    ]
+
+
+def _zigzag_then_shock(
+    *, shock_close: float, confirm_close=None, confirm_high=None, confirm_low=None
+) -> list[AggregatedBar]:
+    """288 flat bars (index 0..287) + 47 alternating +/-0.6 "noise" bars
+    (index 288..334, 47 bars) + shock bar (index 335) [+ optional confirm
+    bar index 336]. Index 335 is bar t=335 >= 289 warm-up floor -- ample
+    margin above the min eligible index so window slicing has headroom.
+    """
+    bars = _flat_segment(_FLAT_N)
+    noise: list[AggregatedBar] = []
+    prev_close = 100.0
+    for k in range(47):
+        idx = _FLAT_N + k
+        c = 100.6 if k % 2 == 0 else 100.0
+        noise.append(
+            _bar(idx, prev_close, max(prev_close, c), min(prev_close, c), c, 100.0)
+        )
+        prev_close = c
+    shock_idx = _FLAT_N + 47
+    shock_bar = _bar(
+        shock_idx,
+        prev_close,
+        max(prev_close, shock_close),
+        min(prev_close, shock_close),
+        shock_close,
+        250.0,  # v_t/median(100)=2.5, comfortably >= any v_min domain value
+    )
+    out = [*bars, *noise, shock_bar]
+    if confirm_close is not None:
+        confirm_bar = _bar(
+            shock_idx + 1,
+            shock_close,
+            confirm_high,
+            confirm_low,
+            confirm_close,
+            100.0,
+        )
+        out.append(confirm_bar)
+    return out
+
+
+def test_shock_negative_confirmed_emits_long_signal_next_bar_only():
+    cfg = get_s2_config("S2-00")  # z_min=3.00, v_min=2.00, ER_max=0.35, R_min=1.25
+    shock_close = 99.9  # prev_close(=100.6) -> r_t ~ -0.696%
+    bars = _zigzag_then_shock(
+        shock_close=shock_close,
+        confirm_close=100.2,
+        confirm_high=100.25,
+        confirm_low=99.95,  # >= shock bar's low (99.9)
+    )
+    # E chosen so d_TP=|T/E-1| lands comfortably inside [68,120]bp with
+    # T=100.6 (=C_{t-1}, the shock bar's own prior close) and T>E (long-
+    # valid direction): 100.6/99.70-1 = 90.27bp.
+    bars_1m = [
+        Bar1m(
+            ts=bars[-1].close_ts,
+            open=99.70,
+            high=99.9,
+            low=99.6,
+            close=99.8,
+            volume=10.0,
+        )
+    ]
+    result = generate_s2_signals(bars, bars_1m, cfg, symbol="XRPUSDT")
+    assert len(result.signals) == 1
+    sig = result.signals[0]
+    assert sig.side == "long"
+    assert sig.strategy == "S2"
+    assert sig.config_id == "S2-00"
+    # signal_ts is the CONFIRMATION bar's close, never the shock bar's own close.
+    assert sig.signal_ts == bars[-1].close_ts
+    assert sig.signal_ts != bars[-2].close_ts  # shock bar itself never fires
+    assert sig.timeout_bars == 30
+    assert sig.cooldown_bars == 60
+    assert sig.tp_target_price == pytest.approx(
+        100.6
+    )  # T = C_{t-1} (shock's prior close)
+    assert sig.tp_distance_bps is None
+    assert sig.sl_distance_bps == pytest.approx(45.0)  # 0.60*|r_t|=41.9bp < floor
+
+
+def test_exact_t_plus_1_only_no_retry_at_t_plus_2():
+    cfg = get_s2_config("S2-00")
+    shock_close = 99.9
+    bars = _zigzag_then_shock(shock_close=shock_close)  # no confirmation bar appended
+    shock_idx = _FLAT_N + 47
+    # t+1 FAILS confirmation (price keeps falling, doesn't recover).
+    fail_confirm = _bar(shock_idx + 1, 99.9, 99.9, 99.5, 99.6, 100.0)
+    # t+2 WOULD satisfy the (would-be) confirmation shape vs the shock bar
+    # (C=100.4>99.9=shock close, L=99.95>=99.9=shock low), but must never
+    # be considered -- only t+1 is eligible.
+    would_confirm = _bar(shock_idx + 2, 99.95, 100.5, 99.95, 100.4, 100.0)
+    bars = [*bars, fail_confirm, would_confirm]
+    result = generate_s2_signals(bars, [], cfg, symbol="XRPUSDT")
+    assert result.signals == ()
+    reasons = count_rejection_reasons(result.rejections)
+    assert reasons.get("confirmation_failed", 0) == 1
+
+
+def test_next_bar_unavailable_is_rejected_not_silently_dropped():
+    cfg = get_s2_config("S2-00")
+    bars = _zigzag_then_shock(
+        shock_close=99.9, confirm_close=100.2, confirm_high=100.25, confirm_low=99.95
+    )
+    # No 1m bars at all -> E cannot be resolved.
+    result = generate_s2_signals(bars, [], cfg, symbol="XRPUSDT")
+    assert result.signals == ()
+    reasons = count_rejection_reasons(result.rejections)
+    assert reasons.get("next_bar_unavailable", 0) == 1
+
+
+def test_gap_reset_discards_pending_shock_and_warmup():
+    cfg = get_s2_config("S2-00")
+    bars = _zigzag_then_shock(shock_close=99.9)  # ends right at the shock bar
+    shock_idx = _FLAT_N + 47
+    # A gap: new segment starts immediately, discarding the pending shock
+    # and resetting warm-up (this lone bar can't possibly be a confirmation).
+    gap_bar = _bar(shock_idx + 1, 99.9, 100.5, 99.9, 100.4, 100.0, segment_start=True)
+    bars = [*bars, gap_bar]
+    result = generate_s2_signals(bars, [], cfg, symbol="XRPUSDT")
+    assert result.signals == ()
+
+
+def test_rejection_dataclass_has_reason_field_for_aggregation():
+    rc = RejectedCandidate(
+        strategy="S2",
+        config_id="S2-00",
+        symbol="XRPUSDT",
+        signal_ts=1000,
+        side="long",
+        reason="target_direction_invalid",
+    )
+    assert count_rejection_reasons((rc, rc)) == {"target_direction_invalid": 2}

--- a/research/nautilus_scalping/tests/test_rob943_signal_import_guard.py
+++ b/research/nautilus_scalping/tests/test_rob943_signal_import_guard.py
@@ -1,0 +1,82 @@
+"""ROB-943 (H3, ROB-940) — AST import-boundary guard for the signal modules.
+
+Mirrors ``test_rob940_import_guard.py``'s pattern, scoped to the new H3
+signal-generation/manifest modules. These modules have NO legitimate need
+for wall-clock time or randomness (unlike ``rob940_engine``, which uses
+``datetime`` for UTC-day bucketing) -- H3 signal math is purely a function
+of its bar/config inputs, so ``datetime``/``time``/``random`` are forbidden
+here too, stricter than the H2 guard.
+"""
+
+import ast
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parents[1]
+_MODULES = ["rob940_signal_manifest.py", "rob940_signal_s1.py", "rob940_signal_s2.py"]
+
+_FORBIDDEN_PREFIXES = (
+    "app",
+    "sqlalchemy",
+    "asyncpg",
+    "psycopg",
+    "psycopg2",
+    "alembic",
+    "redis",
+    "taskiq",
+    "celery",
+    "httpx",
+    "requests",
+    "aiohttp",
+    "urllib3",
+    "urllib",
+    "socket",
+    "websockets",
+    "boto3",
+    "fastapi",
+    "uvicorn",
+    "random",
+    "time",
+    "datetime",
+)
+
+_ALLOWED = {
+    "__future__",
+    "collections.abc",
+    "dataclasses",
+    "math",
+    "statistics",
+    "typing",
+    "research_contracts.canonical_hash",
+    "rob940_bars_agg",
+    "rob940_cost_model",
+    "rob940_engine",
+    "rob940_signal_manifest",
+    "rob940_signal_s1",
+}
+
+
+def _imports(path: Path):
+    tree = ast.parse(path.read_text())
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for n in node.names:
+                yield n.name
+        elif isinstance(node, ast.ImportFrom):
+            yield node.module or ""
+
+
+def test_no_forbidden_db_network_app_broker_time_random_imports():
+    for mod in _MODULES:
+        for name in _imports(_ROOT / mod):
+            top = name.split(".")[0]
+            assert top not in _FORBIDDEN_PREFIXES, (
+                f"{mod} imports forbidden module {name!r} (H3: no DB/network/"
+                "app-settings/broker/order/fill/scheduler/random/current-time "
+                "imports)"
+            )
+
+
+def test_only_allowlisted_modules_are_imported():
+    for mod in _MODULES:
+        for name in _imports(_ROOT / mod):
+            assert name in _ALLOWED, f"{mod} imports non-allowlisted module {name!r}"


### PR DESCRIPTION
## Summary
- H3 (ROB-943, sub-issue of ROB-940 Wave 2) implements exact, deterministic signal generators for the two ROB-940 strategy candidates, on top of the merged H2 engine (PR #1585): **S1 Donchian-15m breakout** and **S2 confirmed-shock-reversal-5m**, plus the Fable-approved frozen 24-row config manifest.
- `rob940_signal_manifest.py`: byte-stable 12-config/strategy manifest (S1-00..11, S2-00..11) with exact param values, ex-ante hypothesis text, exploration domains, fixed constants, and fail-closed validation (13th row / unregistered param / duplicate id / symbol override all rejected). `signal_manifest_hash` identifies this 24-row manifest specifically — **not** an H4 full-campaign hash.
- `rob940_signal_s1.py`: current-bar-excluded Donchian U/D, prior-20 volume median, Wilder ATR20 (seed + recurrence), `a_t`/chase gates, SL clip/TP, long/short symmetry, `timeout_bars=180`/`cooldown_bars=60` (1m-bar units per the H2 consumption contract).
- `rob940_signal_s2.py`: prior-288 return median/MAD (`1.4826×MAD`, `0.0001` floor), ER48 (fail-closed on zero denominator), shock gate, exact-next-bar-only confirmation (shock bar itself never enters), actual-next-1m-open `E` TP-validity gates (`<=120bp`, `>=R_min·d_SL`, `>=68bp`) evaluated *before* any `SignalEvent` is emitted, `timeout_bars=30`/`cooldown_bars=60`.
- S2 target-direction ambiguity (confirmation overshoot can put target `T` on the wrong side of entry `E`) was raised via the prompt's mandatory `ultrathink` consult gate, answered by Fable/orch mid-session (`orch-fable-answer-rob943-s2-20260717.md`, Q1=A): a direction guard is kept **permanently**, with a `target_direction_invalid` reason code exposed via `count_rejection_reasons` for future H5 aggregation, and the RED reproduction test retained as a permanent regression.
- New AST import guard (`test_rob943_signal_import_guard.py`) enforces no DB/network/app/broker/order/fill/scheduler/random/current-time imports on the three new modules — stricter than H2's guard (H3 has no legitimate need for wall-clock time).

## Scope discipline
- No demo/paper/broker/order/fill/scheduler/ROB-905 wiring, artifacts, or activation.
- No network/DB/app-settings/current-time/random dependence; no production DB writes; no secrets.
- Existing `research_contracts.frozen_config.FROZEN_CONFIG` and prior campaign configs untouched.
- No 81-grid/parameter-search/generator API — only the pre-registered 24 rows.
- H4/H5/H6 runner/scorecard/DB bridge not built here.

## Test plan
- [x] TDD RED confirmed before each new module (`ModuleNotFoundError` on first test run for manifest/S1/S2).
- [x] `pytest research/nautilus_scalping/tests/test_rob940_*.py research/nautilus_scalping/tests/test_rob943_*.py` → **156 passed**.
- [x] Full `research/nautilus_scalping` suite (excluding the pre-existing `test_signal_parity.py` local-data skip) → **650 passed, 7 pre-existing unrelated failures** (missing local BTCUSDT fixture data — same 7 documented in the ROB-942 R2 verification report, untouched by this diff; `git status --short` confirms this PR's diff is exactly the 7 new files listed above).
- [x] `ruff format --check` / `ruff check` / `ty check` clean on all 7 new files.
- [x] Exact pinned `signal_manifest_hash = 199816d45e79ed52218848dc53c54464754c5befce38dbad6615cf123b628fba`.
- [x] Self-review pass for lookahead, off-by-one warm-up boundaries, long/short symmetry, manifest drift, and import scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a frozen 24-configuration signal manifest with validation and deterministic integrity tracking.
  * Added Strategy 1 Donchian breakout signal generation for 15-minute data.
  * Added Strategy 2 confirmed shock-reversal signal generation for 5-minute data, including rejection details and target validation.

* **Bug Fixes**
  * Added safeguards for invalid, incomplete, duplicate, or cross-segment signal conditions.

* **Tests**
  * Added comprehensive coverage for manifest integrity, signal boundaries, rejection handling, segment gaps, and import safety.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->