### PR TITLE
[strategy] ROB-946 H6 — immutable 24-experiment bridge + complete trial accounting

### DIFF
--- a/app/schemas/research_campaign_bridge.py
+++ b/app/schemas/research_campaign_bridge.py
@@ -1,0 +1,115 @@
+"""ROB-946 (H6) — campaign trial-attempt evidence contracts.
+
+New schemas alongside (not modifying) ``app.schemas.research_backtest``. An
+``AttemptEvidence`` is the COMPLETE terminal evidence for one logical attempt
+— a config's full walk-forward invocation. ``completed`` records evidence
+generation success, NOT a strategy PASS verdict (ROB-946 §5): pass/fail
+judgement belongs to a separate downstream consumer (H5), never this schema.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from app.schemas.research_backtest import TrialStatus
+
+ScenarioName = Literal["base", "primary_stress", "upward_stress"]
+_EXPECTED_SCENARIO_NAMES = frozenset({"base", "primary_stress", "upward_stress"})
+
+__all__ = [
+    "AttemptEvidence",
+    "AttemptKey",
+    "CampaignCompletenessReport",
+    "ScenarioEvidence",
+    "ScenarioName",
+]
+
+
+class ScenarioEvidence(BaseModel):
+    """One independent 13/17/22bp cost-scenario simulation ledger's evidence.
+
+    ROB-942 R1: each cost scenario is its OWN independent ``run_symbol_stream``
+    invocation, never a net-only revaluation of a shared path — this schema
+    stores each scenario's own trade_count/artifact_hash so that divergence
+    (e.g. a higher-cost scenario halting sooner) is preserved, never collapsed
+    into a single reference count.
+    """
+
+    scenario_name: ScenarioName
+    trade_count: int = Field(ge=0)
+    artifact_hash: str | None = None
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class AttemptKey(BaseModel):
+    """Deterministic invocation identity for one logical attempt.
+
+    A logical attempt is one config's full walk-forward invocation. An
+    explicit retry uses the SAME ``campaign_run_id``/``experiment_id`` but a
+    higher ``retry_index`` — a genuinely new invocation key, never a mutation
+    of the original.
+    """
+
+    campaign_run_id: str = Field(min_length=1)
+    experiment_id: str = Field(min_length=1)
+    retry_index: int = Field(default=0, ge=0)
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    def idempotency_key(self) -> str:
+        return f"{self.campaign_run_id}:{self.experiment_id}:{self.retry_index}"
+
+
+class AttemptEvidence(BaseModel):
+    """Complete terminal evidence for one logical attempt (ROB-946 §5/§6).
+
+    ``status`` is one of the 4 ROB-846 terminal outcomes. A non-``completed``
+    status requires a stable ``reason_code`` (e.g. ``insufficient_symbol_evidence``,
+    ``rejected:insufficient_train_evidence``, ``rejected:data_gap_in_position``,
+    or a crash/timeout description) so the reason is never silently dropped.
+    """
+
+    attempt_key: AttemptKey
+    status: TrialStatus
+    reason_code: str | None = None
+    fold_evidence_hash: str | None = None
+    run_identity: str = Field(min_length=1)
+    scenario_evidence: tuple[ScenarioEvidence, ScenarioEvidence, ScenarioEvidence]
+
+    model_config = ConfigDict(extra="forbid")
+
+    @model_validator(mode="after")
+    def _validate(self) -> AttemptEvidence:
+        names = {s.scenario_name for s in self.scenario_evidence}
+        if names != _EXPECTED_SCENARIO_NAMES:
+            raise ValueError(
+                "scenario_evidence must cover exactly "
+                f"{sorted(_EXPECTED_SCENARIO_NAMES)}, got {sorted(names)}"
+            )
+        if self.status != "completed" and self.reason_code is None:
+            raise ValueError("reason_code is required for non-completed statuses")
+        return self
+
+
+class CampaignCompletenessReport(BaseModel):
+    """ROB-946 §9 completeness DTO — no winner-only filter.
+
+    ``verdict`` is ``"complete"`` iff every one of ``expected_total`` (always
+    24) experiment_ids has at least one terminal (any of the 4 statuses)
+    attempt AND no duplicate logical attempt was detected. A campaign where
+    every attempt is ``rejected``/``crashed``/``timeout`` is still "complete"
+    evidence — ``completed`` is not a pass filter here.
+    """
+
+    campaign_run_id: str
+    expected_total: int
+    experiments_with_attempts: int
+    status_counts: dict[str, int]
+    missing_experiment_ids: list[str]
+    duplicate_logical_attempts: list[str]
+    verdict: Literal["complete", "incomplete"]
+
+    model_config = ConfigDict(extra="forbid")

--- a/app/schemas/research_campaign_bridge.py
+++ b/app/schemas/research_campaign_bridge.py
@@ -97,19 +97,50 @@ class AttemptEvidence(BaseModel):
 class CampaignCompletenessReport(BaseModel):
     """ROB-946 §9 completeness DTO — no winner-only filter.
 
-    ``verdict`` is ``"complete"`` iff every one of ``expected_total`` (always
-    24) experiment_ids has at least one terminal (any of the 4 statuses)
-    attempt AND no duplicate logical attempt was detected. A campaign where
-    every attempt is ``rejected``/``crashed``/``timeout`` is still "complete"
+    R1 Important-3/4 remediation: completeness is now derived from a
+    bidirectional diff between the 24 EXPECTED identities (re-derived from
+    caller-supplied ``StrategyExperimentIdentity`` specs via the SAME
+    canonical-hash authority used at registration, never trusted as a bare
+    caller-supplied id string) and the ACTUAL registered rows found for those
+    strategies:
+
+    * ``missing_experiment_ids`` — an expected identity with no registration
+      at all, OR one that is registered but has no ``retry_index=0`` (primary)
+      terminal attempt recorded — a campaign with only a ``retry_index=1``
+      attempt and no primary is "missing", not "complete" (R1 Important-3).
+    * ``extra_experiment_ids`` — a registered row (within the expected
+      strategy_key scope) that does not correspond to ANY expected identity.
+    * ``mismatch_experiment_ids`` — an expected identity's ``params`` slot
+      (matched by ``params_hash``) IS registered, but under a DIFFERENT overall
+      ``experiment_id`` — i.e. some OTHER component drifted from what was
+      expected (R1 Important-4).
+    * ``duplicate_or_gap_experiment_ids`` — the recorded retry-index sequence
+      for an otherwise-correctly-registered experiment is non-contiguous from
+      0 (a gap) or contains a raw-row duplicate. A duplicate retry INDEX for
+      one experiment cannot occur while ROB-846's own
+      ``uq_research_backtest_runs_experiment_idempotency`` constraint holds
+      (the idempotency key embeds the retry index) — this branch is kept as
+      defense-in-depth against that invariant ever being weakened, while the
+      gap check is independently reachable today.
+
+    ``verdict`` is ``"complete"`` iff ALL four of the above lists are empty —
+    every expected identity has a primary attempt, nothing extra or drifted
+    was found, and no gap/duplicate was observed. A campaign where every
+    attempt is ``rejected``/``crashed``/``timeout`` is still "complete"
     evidence — ``completed`` is not a pass filter here.
     """
 
     campaign_run_id: str
     expected_total: int
-    experiments_with_attempts: int
+    actual_registrations: int
+    primary_attempts: int
+    total_attempts: int
+    retry_attempts: int
     status_counts: dict[str, int]
     missing_experiment_ids: list[str]
-    duplicate_logical_attempts: list[str]
+    extra_experiment_ids: list[str]
+    mismatch_experiment_ids: list[str]
+    duplicate_or_gap_experiment_ids: list[str]
     verdict: Literal["complete", "incomplete"]
 
     model_config = ConfigDict(extra="forbid")

--- a/app/services/research_campaign_bridge.py
+++ b/app/services/research_campaign_bridge.py
@@ -10,20 +10,27 @@ surfaces:
   * ``record_attempt`` — hardened, idempotent recording of one logical
     attempt's complete terminal evidence.
 
-Both require the ROB-946 two-gate write guard
+Plus one read surface:
+
+  * ``campaign_completeness_report`` — expected-vs-actual campaign coverage.
+
+All writes require the ROB-946 two-gate write guard
 (``app.services.research_db_write_guard``) to pass FIRST, before any registry
 call or spec/shape inspection.
 
-Idempotency hardening (ROB-946 §6): the raw ROB-846 ``record_trial`` returns
-the ORIGINAL row on ANY replay of a matching idempotency key, even if the
-incoming payload differs — it does not itself detect divergence. This module
-computes a canonical fingerprint of ALL terminal evidence (status/reason/fold
-hash/artifact hashes per scenario/run identity) and compares it against the
-stored fingerprint before ever calling the raw registry function: identical
-evidence replays the original row; any mismatch fails closed
-(``TerminalEvidenceMismatch``) and the raw ``record_trial`` (whose own
-idempotency would otherwise silently mask the divergence) is never invoked in
-that case.
+Idempotency hardening (ROB-946 §6, R1 Critical-2 remediation): the raw
+ROB-846 ``record_trial`` returns the ORIGINAL row on ANY replay of a matching
+idempotency key — on BOTH of its own internal paths (the pre-insert lookup
+AND the post-IntegrityError re-read after losing a concurrent insert race) —
+without ever comparing payloads. This module's own PRE-check (before calling
+``record_trial``) closes the sequential-replay case, but a genuine race (this
+caller's pre-check misses because a concurrent writer's row is not yet
+visible to it, then ``record_trial`` itself resolves the DB-level conflict
+and hands back the WINNER's row) is only closed by re-checking AFTER
+delegating: the returned row's stored fingerprint is compared against this
+call's computed fingerprint, and a mismatch raises ``TerminalEvidenceMismatch``
+even when the raw registry call itself returned successfully with someone
+else's row.
 
 Boundary (ROB-946 §7): no broker/order/fill/execution-ledger/scheduler/
 ROB-905 import — see the extended
@@ -49,8 +56,13 @@ from app.schemas.research_campaign_bridge import (
     CampaignCompletenessReport,
 )
 from app.services import strategy_experiment_registry as registry
-from app.services.research_canonical_hash import canonical_sha256
+from app.services.research_canonical_hash import (
+    canonical_sha256,
+    compute_identity_hashes,
+    derive_experiment_id,
+)
 from app.services.research_db_write_guard import (
+    ResearchDbPolicy,
     ResearchDbTarget,
     assert_research_write_authorized,
     resolve_research_db_target,
@@ -58,6 +70,7 @@ from app.services.research_db_write_guard import (
 
 __all__ = [
     "CampaignBridgeError",
+    "CampaignDuplicateSpecError",
     "CampaignSpecCountError",
     "RunnerNameTooLongError",
     "TerminalEvidenceMismatch",
@@ -80,6 +93,13 @@ class CampaignSpecCountError(CampaignBridgeError):
     """A registration or completeness call was made with != 24 items."""
 
 
+class CampaignDuplicateSpecError(CampaignBridgeError):
+    """Two or more of the (expected) 24 specs derive the SAME experiment_id —
+    a duplicate identity masquerading as a distinct config slot. Raised
+    BEFORE any write/query (R1 Minor-5): a caller must never be able to
+    register/expect 24 specs where one silently replaces a missing one."""
+
+
 class RunnerNameTooLongError(CampaignBridgeError):
     """``runner`` exceeds the DB column's 16-character limit."""
 
@@ -87,7 +107,8 @@ class RunnerNameTooLongError(CampaignBridgeError):
 class TerminalEvidenceMismatch(CampaignBridgeError):
     """A replay under the same attempt key carries DIFFERENT terminal
     evidence than the stored trial — fail closed, never silently replayed or
-    duplicated."""
+    duplicated. Raised on EITHER the pre-check path (sequential replay) or
+    the post-delegate path (a concurrent race whose winner row diverges)."""
 
 
 def terminal_evidence_fingerprint(evidence: AttemptEvidence) -> str:
@@ -118,6 +139,32 @@ def terminal_evidence_fingerprint(evidence: AttemptEvidence) -> str:
     return canonical_sha256(payload)
 
 
+def _derive_experiment_id(spec: StrategyExperimentIdentity) -> str:
+    """Re-derive the canonical experiment_id from a spec's OWN components,
+    using the exact same authority ``register_experiment`` does — never
+    trust a caller-supplied experiment_id string directly."""
+    hashes = compute_identity_hashes(spec.components())
+    return derive_experiment_id(spec.strategy_key, spec.strategy_version, hashes)
+
+
+def _assert_specs_derive_unique_experiment_ids(
+    specs: list[StrategyExperimentIdentity],
+) -> list[str]:
+    """Fail closed if two+ specs derive the SAME experiment_id (R1 Minor-5:
+    a duplicate identity silently replacing a missing 24th slot). Returns the
+    derived ids in input order for reuse by the caller."""
+    experiment_ids = [_derive_experiment_id(spec) for spec in specs]
+    if len(set(experiment_ids)) != len(experiment_ids):
+        duplicates = sorted(
+            {eid for eid in experiment_ids if experiment_ids.count(eid) > 1}
+        )
+        raise CampaignDuplicateSpecError(
+            f"expected {_EXPECTED_CAMPAIGN_SIZE} UNIQUE identities but found "
+            f"duplicate derived experiment_id(s): {duplicates}"
+        )
+    return experiment_ids
+
+
 async def _get_experiment_by_id(
     session: AsyncSession, experiment_id: str
 ) -> ResearchStrategyExperiment | None:
@@ -133,24 +180,27 @@ async def register_campaign_experiments(
     *,
     specs: list[StrategyExperimentIdentity],
     guard_opt_in_enabled: bool,
-    guard_allowlist: frozenset[str],
+    guard_policy: ResearchDbPolicy,
 ) -> list[ResearchStrategyExperiment]:
     """Register all 24 campaign experiments via the ROB-846 registry.
 
-    The write guard is evaluated FIRST — before the spec count is even
-    inspected — so a disabled/unauthorized guard always wins over a malformed
-    spec list. Registering anything other than exactly 24 specs is refused
-    (ROB-946 §1: register all 24 before the empirical runner may start).
+    The write guard is evaluated FIRST — before the spec count or uniqueness
+    is even inspected — so a disabled/unauthorized guard always wins over a
+    malformed spec list. Registering anything other than exactly 24 UNIQUE
+    specs is refused before any write (ROB-946 §1 + R1 Minor-5: a duplicate
+    identity must never silently stand in for a missing 24th slot).
     """
     target: ResearchDbTarget = resolve_research_db_target(session)
     assert_research_write_authorized(
-        opt_in_enabled=guard_opt_in_enabled, target=target, allowlist=guard_allowlist
+        opt_in_enabled=guard_opt_in_enabled, target=target, policy=guard_policy
     )
     if len(specs) != _EXPECTED_CAMPAIGN_SIZE:
         raise CampaignSpecCountError(
             f"expected exactly {_EXPECTED_CAMPAIGN_SIZE} campaign experiment "
             f"specs, got {len(specs)}"
         )
+    _assert_specs_derive_unique_experiment_ids(specs)
+
     registered = []
     for identity in specs:
         registered.append(await registry.register_experiment(session, identity))
@@ -179,6 +229,10 @@ def _scenario_evidence_payload(evidence: AttemptEvidence) -> list[dict]:
     ]
 
 
+def _stored_fingerprint(row: ResearchBacktestRun) -> object:
+    return (row.raw_payload or {}).get("h6_evidence_fingerprint")
+
+
 async def record_attempt(
     session: AsyncSession,
     *,
@@ -188,21 +242,24 @@ async def record_attempt(
     timeframe: str,
     runner: str,
     guard_opt_in_enabled: bool,
-    guard_allowlist: frozenset[str],
+    guard_policy: ResearchDbPolicy,
 ) -> ResearchBacktestRun:
     """Record one hardened, idempotent logical-attempt trial.
 
     * Same attempt key + IDENTICAL terminal evidence -> returns the original
       row (idempotent replay), never a second trial.
     * Same attempt key + ANY terminal evidence mismatch -> raises
-      ``TerminalEvidenceMismatch`` fail-closed; the raw ``record_trial`` is
-      never called in that branch.
+      ``TerminalEvidenceMismatch`` fail-closed, checked on BOTH the pre-check
+      path (sequential replay, this row already visible to us) AND the
+      post-delegate path (R1 Critical-2: a concurrent race where our
+      pre-check missed and the raw ``record_trial`` handed back someone
+      else's already-committed winner row).
     * A new attempt key (an explicit retry -> higher ``retry_index``) always
       records a new trial, consuming the next monotonic ``trial_index``.
     """
     target = resolve_research_db_target(session)
     assert_research_write_authorized(
-        opt_in_enabled=guard_opt_in_enabled, target=target, allowlist=guard_allowlist
+        opt_in_enabled=guard_opt_in_enabled, target=target, policy=guard_policy
     )
     if len(runner) > _MAX_RUNNER_LENGTH:
         raise RunnerNameTooLongError(
@@ -223,13 +280,12 @@ async def record_attempt(
         session, experiment_pk=experiment.id, idempotency_key=idempotency_key
     )
     if existing is not None:
-        stored_fingerprint = (existing.raw_payload or {}).get("h6_evidence_fingerprint")
-        if stored_fingerprint == fingerprint:
+        if _stored_fingerprint(existing) == fingerprint:
             return existing
         raise TerminalEvidenceMismatch(
             f"attempt {idempotency_key!r} was already recorded with different "
-            "terminal evidence; refusing to overwrite, duplicate, or silently "
-            "replay a stale row"
+            "terminal evidence (pre-check); refusing to overwrite, duplicate, "
+            "or silently replay a stale row"
         )
 
     # A SHA-256 over the full (campaign_run_id, experiment_id, retry_index)
@@ -262,47 +318,133 @@ async def record_attempt(
             "scenario_evidence": _scenario_evidence_payload(evidence),
         },
     )
-    return await registry.record_trial(
+    returned = await registry.record_trial(
         session, experiment_id=experiment_id, request=request
     )
+    # R1 Critical-2: `record_trial` returns a WINNER row (not necessarily the
+    # one we just built) on both of its own internal replay paths. Re-verify
+    # after delegating: if the returned row's evidence differs from what we
+    # asked to record, someone else's concurrently-committed attempt won the
+    # race under our very own attempt key — fail closed rather than let the
+    # caller believe its own evidence was recorded.
+    if _stored_fingerprint(returned) != fingerprint:
+        raise TerminalEvidenceMismatch(
+            f"attempt {idempotency_key!r} was recorded concurrently by another "
+            "writer with different terminal evidence (post-delegate); this "
+            "call's evidence was NOT recorded — the existing row is unchanged"
+        )
+    return returned
 
 
 async def campaign_completeness_report(
     session: AsyncSession,
     *,
     campaign_run_id: str,
-    expected_experiment_ids: list[str],
+    expected_specs: list[StrategyExperimentIdentity],
 ) -> CampaignCompletenessReport:
-    """ROB-946 §9 — expected=24 vs actual terminal-attempt coverage.
+    """ROB-946 §9 — expected=24 vs actual registration + terminal-attempt
+    coverage (R1 Important-3/4 remediation).
 
-    Refuses (fail-closed, before any query) an ``expected_experiment_ids``
-    list that is not exactly 24 unique ids — a wrong denominator must never
-    be silently reported as "incomplete". A retry (same experiment_id, higher
-    ``retry_index``) is never confused with a duplicate: both attempts count
-    toward ``status_counts``, but the experiment is counted once in
-    ``experiments_with_attempts``.
+    ``expected_specs`` are the 24 caller-asserted identities; this function
+    NEVER trusts a bare experiment_id string — it re-derives each spec's
+    canonical experiment_id via the SAME ``compute_identity_hashes`` /
+    ``derive_experiment_id`` authority ``register_experiment`` uses, then
+    diffs BOTH directions against what is actually registered under the
+    expected specs' ``strategy_key``s:
+
+    * an expected identity with no matching registered row, OR a registered
+      row with no ``retry_index=0`` primary terminal attempt -> ``missing``;
+    * a registered row (in scope) matching no expected identity -> ``extra``;
+    * a registered row sharing an expected identity's ``params_hash`` (the
+      SAME logical config slot) but under a DIFFERENT overall experiment_id
+      (some other component drifted) -> ``mismatch``;
+    * a non-contiguous (gapped) or raw-row-duplicated retry sequence for an
+      otherwise-correctly-registered experiment -> ``duplicate_or_gap``.
+
+    Refuses (fail-closed, before any query) anything other than exactly 24
+    UNIQUE expected specs — a wrong denominator, or a duplicate expected
+    identity, must never be silently reported as "incomplete" with a wrong
+    basis.
     """
-    if len(expected_experiment_ids) != _EXPECTED_CAMPAIGN_SIZE:
+    if len(expected_specs) != _EXPECTED_CAMPAIGN_SIZE:
         raise CampaignSpecCountError(
-            f"expected exactly {_EXPECTED_CAMPAIGN_SIZE} experiment_ids for a "
-            f"campaign completeness report, got {len(expected_experiment_ids)}"
+            f"expected exactly {_EXPECTED_CAMPAIGN_SIZE} specs for a campaign "
+            f"completeness report, got {len(expected_specs)}"
         )
-    if len(set(expected_experiment_ids)) != len(expected_experiment_ids):
-        raise CampaignBridgeError("expected_experiment_ids contains duplicates")
+    expected_experiment_ids = _assert_specs_derive_unique_experiment_ids(expected_specs)
+    expected = list(
+        zip(
+            expected_specs,
+            expected_experiment_ids,
+            (
+                compute_identity_hashes(spec.components())["params_hash"]
+                for spec in expected_specs
+            ),
+            strict=True,
+        )
+    )
+
+    strategy_keys = {spec.strategy_key for spec in expected_specs}
+    actual_rows = list(
+        (
+            await session.execute(
+                select(ResearchStrategyExperiment).where(
+                    ResearchStrategyExperiment.strategy_key.in_(strategy_keys)
+                )
+            )
+        ).scalars()
+    )
+    actual_by_id = {row.experiment_id: row for row in actual_rows}
+    actual_by_params_hash: dict[str, list[ResearchStrategyExperiment]] = {}
+    for row in actual_rows:
+        actual_by_params_hash.setdefault(row.params_hash, []).append(row)
+
+    claimed_actual_ids: set[str] = set()
+    missing: set[str] = set()
+    mismatch: set[str] = set()
+    matched_registered: list[tuple[str, ResearchStrategyExperiment]] = []
+
+    for _spec, expected_experiment_id, expected_params_hash in expected:
+        row = actual_by_id.get(expected_experiment_id)
+        if row is not None:
+            claimed_actual_ids.add(row.experiment_id)
+            matched_registered.append((expected_experiment_id, row))
+            continue
+        drifted_candidates = [
+            candidate
+            for candidate in actual_by_params_hash.get(expected_params_hash, [])
+            if candidate.experiment_id != expected_experiment_id
+        ]
+        if drifted_candidates:
+            mismatch.add(expected_experiment_id)
+            claimed_actual_ids.update(
+                candidate.experiment_id for candidate in drifted_candidates
+            )
+            continue
+        missing.add(expected_experiment_id)
+
+    extra = sorted(
+        row.experiment_id
+        for row in actual_rows
+        if row.experiment_id not in claimed_actual_ids
+    )
 
     status_counts: dict[str, int] = dict.fromkeys(TRIAL_STATUSES, 0)
-    missing: list[str] = []
-    duplicates: list[str] = []
-    experiments_with_attempts = 0
+    primary_attempts = 0
+    total_attempts = 0
+    duplicate_or_gap: set[str] = set()
 
-    for experiment_id in expected_experiment_ids:
-        experiment = await _get_experiment_by_id(session, experiment_id)
-        if experiment is None:
-            missing.append(experiment_id)
-            continue
-
-        trials = await registry.list_trials(session, experiment_id)
-        prefix = f"{campaign_run_id}:{experiment_id}:"
+    for expected_experiment_id, _row in matched_registered:
+        trials = await registry.list_trials(session, expected_experiment_id)
+        prefix = f"{campaign_run_id}:{expected_experiment_id}:"
+        # Scan the RAW row list for a genuine duplicate BEFORE any dict/set
+        # collapse (R1 Minor-6): under ROB-846's own
+        # uq_research_backtest_runs_experiment_idempotency constraint (the
+        # idempotency key embeds the retry index), two rows for the SAME
+        # retry index cannot coexist for one experiment today — this check is
+        # kept as defense-in-depth against that invariant weakening, not
+        # decorative: it inspects `campaign_trials` directly, not a
+        # pre-deduplicated view of it.
         campaign_trials = [
             t
             for t in trials
@@ -310,25 +452,54 @@ async def campaign_completeness_report(
             and t.trial_idempotency_key.startswith(prefix)
         ]
         if not campaign_trials:
-            missing.append(experiment_id)
+            missing.add(expected_experiment_id)
             continue
 
-        experiments_with_attempts += 1
-        retry_indices = [
-            t.trial_idempotency_key[len(prefix) :] for t in campaign_trials
-        ]
-        if len(set(retry_indices)) != len(retry_indices):
-            duplicates.append(experiment_id)
+        raw_suffixes = [t.trial_idempotency_key[len(prefix) :] for t in campaign_trials]
+        if len(set(raw_suffixes)) != len(raw_suffixes):
+            duplicate_or_gap.add(expected_experiment_id)
+            continue
+        try:
+            retry_indices = sorted(int(suffix) for suffix in raw_suffixes)
+        except ValueError:
+            duplicate_or_gap.add(expected_experiment_id)
+            continue
+
+        if retry_indices[0] != 0:
+            # A retry_index=1+ attempt exists but there is no primary
+            # (retry_index=0) attempt — R1 Important-3: this is NOT complete
+            # evidence, regardless of how many later retries exist.
+            missing.add(expected_experiment_id)
+            continue
+        if retry_indices != list(range(len(retry_indices))):
+            # Non-contiguous from 0 (e.g. 0 and 2 present, 1 missing) — a
+            # genuinely reachable gap, distinct from the unreachable
+            # same-index duplicate case above.
+            duplicate_or_gap.add(expected_experiment_id)
+            continue
+
+        primary_attempts += 1
+        total_attempts += len(campaign_trials)
         for t in campaign_trials:
             status_counts[t.trial_status] += 1
 
-    verdict = "complete" if not missing and not duplicates else "incomplete"
+    retry_attempts = total_attempts - primary_attempts
+    verdict = (
+        "complete"
+        if not (missing or extra or mismatch or duplicate_or_gap)
+        else "incomplete"
+    )
     return CampaignCompletenessReport(
         campaign_run_id=campaign_run_id,
         expected_total=_EXPECTED_CAMPAIGN_SIZE,
-        experiments_with_attempts=experiments_with_attempts,
+        actual_registrations=len(actual_rows),
+        primary_attempts=primary_attempts,
+        total_attempts=total_attempts,
+        retry_attempts=retry_attempts,
         status_counts=status_counts,
-        missing_experiment_ids=missing,
-        duplicate_logical_attempts=duplicates,
+        missing_experiment_ids=sorted(missing),
+        extra_experiment_ids=extra,
+        mismatch_experiment_ids=sorted(mismatch),
+        duplicate_or_gap_experiment_ids=sorted(duplicate_or_gap),
         verdict=verdict,
     )

--- a/app/services/research_campaign_bridge.py
+++ b/app/services/research_campaign_bridge.py
@@ -1,0 +1,334 @@
+"""ROB-946 (H6) — app-side campaign registration + hardened trial bridge.
+
+The generic bridge between an injected 24-experiment campaign identity (built
+by the pure ``research/nautilus_scalping/rob946_campaign_identity.py`` module
+or any other caller) and the ROB-846 immutable registry
+(``app.services.strategy_experiment_registry``). Owns exactly two write
+surfaces:
+
+  * ``register_campaign_experiments`` — registers all 24 experiments.
+  * ``record_attempt`` — hardened, idempotent recording of one logical
+    attempt's complete terminal evidence.
+
+Both require the ROB-946 two-gate write guard
+(``app.services.research_db_write_guard``) to pass FIRST, before any registry
+call or spec/shape inspection.
+
+Idempotency hardening (ROB-946 §6): the raw ROB-846 ``record_trial`` returns
+the ORIGINAL row on ANY replay of a matching idempotency key, even if the
+incoming payload differs — it does not itself detect divergence. This module
+computes a canonical fingerprint of ALL terminal evidence (status/reason/fold
+hash/artifact hashes per scenario/run identity) and compares it against the
+stored fingerprint before ever calling the raw registry function: identical
+evidence replays the original row; any mismatch fails closed
+(``TerminalEvidenceMismatch``) and the raw ``record_trial`` (whose own
+idempotency would otherwise silently mask the divergence) is never invoked in
+that case.
+
+Boundary (ROB-946 §7): no broker/order/fill/execution-ledger/scheduler/
+ROB-905 import — see the extended
+``tests/services/research/test_no_broker_import_guard.py``.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.research_backtest import (
+    TRIAL_STATUSES,
+    ResearchBacktestRun,
+    ResearchStrategyExperiment,
+)
+from app.schemas.research_backtest import (
+    BacktestTrialRequest,
+    StrategyExperimentIdentity,
+)
+from app.schemas.research_campaign_bridge import (
+    AttemptEvidence,
+    CampaignCompletenessReport,
+)
+from app.services import strategy_experiment_registry as registry
+from app.services.research_canonical_hash import canonical_sha256
+from app.services.research_db_write_guard import (
+    ResearchDbTarget,
+    assert_research_write_authorized,
+    resolve_research_db_target,
+)
+
+__all__ = [
+    "CampaignBridgeError",
+    "CampaignSpecCountError",
+    "RunnerNameTooLongError",
+    "TerminalEvidenceMismatch",
+    "campaign_completeness_report",
+    "record_attempt",
+    "register_campaign_experiments",
+    "terminal_evidence_fingerprint",
+]
+
+_EXPECTED_CAMPAIGN_SIZE = 24
+# research.backtest_runs.runner is VARCHAR(16) — reject before the DB does.
+_MAX_RUNNER_LENGTH = 16
+
+
+class CampaignBridgeError(Exception):
+    """Base error for the ROB-946 campaign bridge."""
+
+
+class CampaignSpecCountError(CampaignBridgeError):
+    """A registration or completeness call was made with != 24 items."""
+
+
+class RunnerNameTooLongError(CampaignBridgeError):
+    """``runner`` exceeds the DB column's 16-character limit."""
+
+
+class TerminalEvidenceMismatch(CampaignBridgeError):
+    """A replay under the same attempt key carries DIFFERENT terminal
+    evidence than the stored trial — fail closed, never silently replayed or
+    duplicated."""
+
+
+def terminal_evidence_fingerprint(evidence: AttemptEvidence) -> str:
+    """Canonical fingerprint of ALL terminal evidence for one attempt.
+
+    Two calls with the SAME semantic evidence (status/reason/fold hash/run
+    identity/per-scenario trade_count+artifact_hash) always fingerprint
+    identically regardless of scenario list order; any divergence in any of
+    those fields changes the fingerprint.
+    """
+    payload = {
+        "status": evidence.status,
+        "reason_code": evidence.reason_code,
+        "fold_evidence_hash": evidence.fold_evidence_hash,
+        "run_identity": evidence.run_identity,
+        "scenario_evidence": sorted(
+            (
+                {
+                    "scenario_name": s.scenario_name,
+                    "trade_count": s.trade_count,
+                    "artifact_hash": s.artifact_hash,
+                }
+                for s in evidence.scenario_evidence
+            ),
+            key=lambda d: d["scenario_name"],
+        ),
+    }
+    return canonical_sha256(payload)
+
+
+async def _get_experiment_by_id(
+    session: AsyncSession, experiment_id: str
+) -> ResearchStrategyExperiment | None:
+    return await session.scalar(
+        select(ResearchStrategyExperiment).where(
+            ResearchStrategyExperiment.experiment_id == experiment_id
+        )
+    )
+
+
+async def register_campaign_experiments(
+    session: AsyncSession,
+    *,
+    specs: list[StrategyExperimentIdentity],
+    guard_opt_in_enabled: bool,
+    guard_allowlist: frozenset[str],
+) -> list[ResearchStrategyExperiment]:
+    """Register all 24 campaign experiments via the ROB-846 registry.
+
+    The write guard is evaluated FIRST — before the spec count is even
+    inspected — so a disabled/unauthorized guard always wins over a malformed
+    spec list. Registering anything other than exactly 24 specs is refused
+    (ROB-946 §1: register all 24 before the empirical runner may start).
+    """
+    target: ResearchDbTarget = resolve_research_db_target(session)
+    assert_research_write_authorized(
+        opt_in_enabled=guard_opt_in_enabled, target=target, allowlist=guard_allowlist
+    )
+    if len(specs) != _EXPECTED_CAMPAIGN_SIZE:
+        raise CampaignSpecCountError(
+            f"expected exactly {_EXPECTED_CAMPAIGN_SIZE} campaign experiment "
+            f"specs, got {len(specs)}"
+        )
+    registered = []
+    for identity in specs:
+        registered.append(await registry.register_experiment(session, identity))
+    return registered
+
+
+async def _find_trial_by_attempt_key(
+    session: AsyncSession, *, experiment_pk: int, idempotency_key: str
+) -> ResearchBacktestRun | None:
+    return await session.scalar(
+        select(ResearchBacktestRun).where(
+            ResearchBacktestRun.strategy_experiment_id == experiment_pk,
+            ResearchBacktestRun.trial_idempotency_key == idempotency_key,
+        )
+    )
+
+
+def _scenario_evidence_payload(evidence: AttemptEvidence) -> list[dict]:
+    return [
+        {
+            "scenario_name": s.scenario_name,
+            "trade_count": s.trade_count,
+            "artifact_hash": s.artifact_hash,
+        }
+        for s in evidence.scenario_evidence
+    ]
+
+
+async def record_attempt(
+    session: AsyncSession,
+    *,
+    experiment_id: str,
+    evidence: AttemptEvidence,
+    strategy_name: str,
+    timeframe: str,
+    runner: str,
+    guard_opt_in_enabled: bool,
+    guard_allowlist: frozenset[str],
+) -> ResearchBacktestRun:
+    """Record one hardened, idempotent logical-attempt trial.
+
+    * Same attempt key + IDENTICAL terminal evidence -> returns the original
+      row (idempotent replay), never a second trial.
+    * Same attempt key + ANY terminal evidence mismatch -> raises
+      ``TerminalEvidenceMismatch`` fail-closed; the raw ``record_trial`` is
+      never called in that branch.
+    * A new attempt key (an explicit retry -> higher ``retry_index``) always
+      records a new trial, consuming the next monotonic ``trial_index``.
+    """
+    target = resolve_research_db_target(session)
+    assert_research_write_authorized(
+        opt_in_enabled=guard_opt_in_enabled, target=target, allowlist=guard_allowlist
+    )
+    if len(runner) > _MAX_RUNNER_LENGTH:
+        raise RunnerNameTooLongError(
+            f"runner {runner!r} ({len(runner)} chars) exceeds the "
+            f"{_MAX_RUNNER_LENGTH}-char DB column limit"
+        )
+
+    experiment = await _get_experiment_by_id(session, experiment_id)
+    if experiment is None:
+        raise registry.ExperimentNotFound(
+            f"experiment_id {experiment_id!r} is not registered"
+        )
+
+    idempotency_key = evidence.attempt_key.idempotency_key()
+    fingerprint = terminal_evidence_fingerprint(evidence)
+
+    existing = await _find_trial_by_attempt_key(
+        session, experiment_pk=experiment.id, idempotency_key=idempotency_key
+    )
+    if existing is not None:
+        stored_fingerprint = (existing.raw_payload or {}).get("h6_evidence_fingerprint")
+        if stored_fingerprint == fingerprint:
+            return existing
+        raise TerminalEvidenceMismatch(
+            f"attempt {idempotency_key!r} was already recorded with different "
+            "terminal evidence; refusing to overwrite, duplicate, or silently "
+            "replay a stale row"
+        )
+
+    # A SHA-256 over the full (campaign_run_id, experiment_id, retry_index)
+    # triple, not a truncated concatenation: the triple is already globally
+    # unique by construction, and hashing it keeps run_id both a fixed,
+    # comfortably-under-128-char length (independent of campaign_run_id's
+    # length) and free of any truncation-collision risk (a 12-char slice of
+    # experiment_id would only be *practically*, not *provably*, unique).
+    run_id = "rob946-" + canonical_sha256(
+        {
+            "campaign_run_id": evidence.attempt_key.campaign_run_id,
+            "experiment_id": experiment_id,
+            "retry_index": evidence.attempt_key.retry_index,
+        }
+    )
+    request = BacktestTrialRequest(
+        status=evidence.status,
+        strategy_name=strategy_name,
+        timeframe=timeframe,
+        runner=runner,
+        run_id=run_id,
+        idempotency_key=idempotency_key,
+        raw_payload={
+            "h6_evidence_fingerprint": fingerprint,
+            "campaign_run_id": evidence.attempt_key.campaign_run_id,
+            "retry_index": evidence.attempt_key.retry_index,
+            "reason_code": evidence.reason_code,
+            "fold_evidence_hash": evidence.fold_evidence_hash,
+            "run_identity": evidence.run_identity,
+            "scenario_evidence": _scenario_evidence_payload(evidence),
+        },
+    )
+    return await registry.record_trial(
+        session, experiment_id=experiment_id, request=request
+    )
+
+
+async def campaign_completeness_report(
+    session: AsyncSession,
+    *,
+    campaign_run_id: str,
+    expected_experiment_ids: list[str],
+) -> CampaignCompletenessReport:
+    """ROB-946 §9 — expected=24 vs actual terminal-attempt coverage.
+
+    Refuses (fail-closed, before any query) an ``expected_experiment_ids``
+    list that is not exactly 24 unique ids — a wrong denominator must never
+    be silently reported as "incomplete". A retry (same experiment_id, higher
+    ``retry_index``) is never confused with a duplicate: both attempts count
+    toward ``status_counts``, but the experiment is counted once in
+    ``experiments_with_attempts``.
+    """
+    if len(expected_experiment_ids) != _EXPECTED_CAMPAIGN_SIZE:
+        raise CampaignSpecCountError(
+            f"expected exactly {_EXPECTED_CAMPAIGN_SIZE} experiment_ids for a "
+            f"campaign completeness report, got {len(expected_experiment_ids)}"
+        )
+    if len(set(expected_experiment_ids)) != len(expected_experiment_ids):
+        raise CampaignBridgeError("expected_experiment_ids contains duplicates")
+
+    status_counts: dict[str, int] = dict.fromkeys(TRIAL_STATUSES, 0)
+    missing: list[str] = []
+    duplicates: list[str] = []
+    experiments_with_attempts = 0
+
+    for experiment_id in expected_experiment_ids:
+        experiment = await _get_experiment_by_id(session, experiment_id)
+        if experiment is None:
+            missing.append(experiment_id)
+            continue
+
+        trials = await registry.list_trials(session, experiment_id)
+        prefix = f"{campaign_run_id}:{experiment_id}:"
+        campaign_trials = [
+            t
+            for t in trials
+            if t.trial_idempotency_key is not None
+            and t.trial_idempotency_key.startswith(prefix)
+        ]
+        if not campaign_trials:
+            missing.append(experiment_id)
+            continue
+
+        experiments_with_attempts += 1
+        retry_indices = [
+            t.trial_idempotency_key[len(prefix) :] for t in campaign_trials
+        ]
+        if len(set(retry_indices)) != len(retry_indices):
+            duplicates.append(experiment_id)
+        for t in campaign_trials:
+            status_counts[t.trial_status] += 1
+
+    verdict = "complete" if not missing and not duplicates else "incomplete"
+    return CampaignCompletenessReport(
+        campaign_run_id=campaign_run_id,
+        expected_total=_EXPECTED_CAMPAIGN_SIZE,
+        experiments_with_attempts=experiments_with_attempts,
+        status_counts=status_counts,
+        missing_experiment_ids=missing,
+        duplicate_logical_attempts=duplicates,
+        verdict=verdict,
+    )

--- a/app/services/research_db_write_guard.py
+++ b/app/services/research_db_write_guard.py
@@ -1,0 +1,104 @@
+"""ROB-946 (H6) — research DB write guard.
+
+ROB-946 §7 requires TWO independent conditions before any ROB-846 registry
+write primitive (``register_experiment``/``record_trial``) fires:
+
+  1. an explicit, default-off ROB-940 research-write opt-in;
+  2. a typed/allowlisted non-production research DB target.
+
+Neither may be satisfied by ``ENVIRONMENT != "production"``, a URL substring
+check, or an empty/unknown/malformed/deceptive target — all of those are
+explicitly banned justifications. This module is therefore pure and
+dependency-injected: it never reads ``os.environ`` or opens a DB connection
+itself. Callers resolve the opt-in flag and DB target from real ambient state
+(env var, live session bind) and pass the resolved, typed values in; the guard
+only judges those already-resolved facts against an explicit allowlist.
+
+Boundary: this module must never import a broker/order/fill ledger — see
+``tests/services/research/test_no_broker_import_guard.py``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+__all__ = [
+    "ResearchDbTarget",
+    "ResearchDbTargetRejected",
+    "ResearchWriteDisabled",
+    "ResearchWriteGuardError",
+    "assert_research_write_authorized",
+    "research_write_opt_in_enabled",
+    "resolve_research_db_target",
+]
+
+_TRUTHY_VALUES = frozenset({"1", "true", "yes", "on"})
+
+
+class ResearchWriteGuardError(Exception):
+    """Base error for the ROB-946 research-DB write guard."""
+
+
+class ResearchWriteDisabled(ResearchWriteGuardError):
+    """The explicit ROB-940 research-write opt-in is false or absent."""
+
+
+class ResearchDbTargetRejected(ResearchWriteGuardError):
+    """The resolved DB target is empty, unknown, or not on the explicit
+    allowlist — never derived from '!= production' or a substring check."""
+
+
+@dataclass(frozen=True)
+class ResearchDbTarget:
+    """A resolved (not caller-asserted) database identity.
+
+    Deliberately holds only the bare database name — never a full DSN, host,
+    or credentials — so no error message built from it can leak a secret.
+    """
+
+    database_name: str
+
+
+def research_write_opt_in_enabled(raw_value: str | None) -> bool:
+    """Pure truthy check for the ROB-940 research-write opt-in env var.
+
+    Takes the raw string value directly (e.g. ``os.environ.get(...)``) rather
+    than reading the environment itself, so this stays a pure function.
+    """
+    if raw_value is None:
+        return False
+    return raw_value.strip().lower() in _TRUTHY_VALUES
+
+
+def resolve_research_db_target(session: object) -> ResearchDbTarget:
+    """Resolve the ACTUAL bound database identity from a live session.
+
+    Pure metadata inspection (``session.get_bind().url.database``) — no query,
+    no I/O. This is a real fact taken from the engine's own bind, not a label
+    a caller could assert falsely.
+    """
+    bind = session.get_bind()  # type: ignore[attr-defined]
+    return ResearchDbTarget(database_name=bind.url.database or "")
+
+
+def assert_research_write_authorized(
+    *,
+    opt_in_enabled: bool,
+    target: ResearchDbTarget,
+    allowlist: frozenset[str],
+) -> None:
+    """Fail closed unless BOTH conditions hold; raises before any DB write.
+
+    * ``opt_in_enabled`` must be explicitly True.
+    * ``target.database_name`` must be a non-empty EXACT match against
+      ``allowlist`` — never a substring/prefix match, never "not production".
+    """
+    if not opt_in_enabled:
+        raise ResearchWriteDisabled(
+            "ROB-940 research-write opt-in is disabled; refusing to write"
+        )
+    name = target.database_name
+    if not name or name not in allowlist:
+        raise ResearchDbTargetRejected(
+            "research DB target is not on the explicit non-production allowlist"
+        )

--- a/app/services/research_db_write_guard.py
+++ b/app/services/research_db_write_guard.py
@@ -11,8 +11,24 @@ check, or an empty/unknown/malformed/deceptive target — all of those are
 explicitly banned justifications. This module is therefore pure and
 dependency-injected: it never reads ``os.environ`` or opens a DB connection
 itself. Callers resolve the opt-in flag and DB target from real ambient state
-(env var, live session bind) and pass the resolved, typed values in; the guard
-only judges those already-resolved facts against an explicit allowlist.
+(env var, live session bind) and pass the resolved, typed values in.
+
+R1 remediation (Critical 1, ``strategy-verify-rob946-r1-20260717-170647.md``):
+a bare database NAME cannot distinguish a disposable local fixture from a
+production cluster that happens to share the same database name (``test_db``
+is an extremely common name on staging/prod replicas). ``ResearchDbTarget`` now
+binds ``host`` AND ``database_name`` together — both resolved from the real
+session bind, never a caller-asserted label — and authorization is a positive
+EXACT match of that (host, database) pair against a ``ResearchDbPolicy``: a
+closed, validated, immutable set of KNOWN disposable research targets, not a
+bag of raw strings a caller can self-issue at the call site. A single string
+(a database name, an ``ENVIRONMENT`` value, a URL substring) can never satisfy
+this by itself — the caller must additionally supply the correct real host,
+which is not something a careless or malicious caller controls (it comes from
+the actual bound engine, not their assertion). This is not a cryptographic
+capability boundary (Python cannot enforce that), but it removes the specific
+reproduced failure: a production host is rejected even when its database
+happens to be named identically to the disposable local one.
 
 Boundary: this module must never import a broker/order/fill ledger — see
 ``tests/services/research/test_no_broker_import_guard.py``.
@@ -23,16 +39,28 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 __all__ = [
+    "ResearchDbPolicy",
     "ResearchDbTarget",
     "ResearchDbTargetRejected",
     "ResearchWriteDisabled",
     "ResearchWriteGuardError",
     "assert_research_write_authorized",
+    "default_research_db_policy",
     "research_write_opt_in_enabled",
     "resolve_research_db_target",
 ]
 
 _TRUTHY_VALUES = frozenset({"1", "true", "yes", "on"})
+
+# The one known-disposable local research target this repo's test suite runs
+# against (see tests/conftest.py `_ensure_test_env` — DATABASE_URL is
+# force-overwritten to this exact host+database for every test run). This is
+# NOT consulted automatically by the guard; it exists only as an explicit,
+# reviewed convenience for real (non-test) call sites via
+# `default_research_db_policy()`. Every caller — test or real — must still
+# pass a policy object explicitly; nothing here is read from ambient state.
+_LOCAL_TEST_DB_HOST = "localhost"
+_LOCAL_TEST_DB_NAME = "test_db"
 
 
 class ResearchWriteGuardError(Exception):
@@ -44,19 +72,79 @@ class ResearchWriteDisabled(ResearchWriteGuardError):
 
 
 class ResearchDbTargetRejected(ResearchWriteGuardError):
-    """The resolved DB target is empty, unknown, or not on the explicit
-    allowlist — never derived from '!= production' or a substring check."""
+    """The resolved (host, database) target is malformed or not a positive
+    match against the authority-owned policy — never derived from
+    '!= production', a substring check, or a bare database name alone."""
 
 
 @dataclass(frozen=True)
 class ResearchDbTarget:
-    """A resolved (not caller-asserted) database identity.
+    """A resolved (not caller-asserted) (host, database) identity.
 
-    Deliberately holds only the bare database name — never a full DSN, host,
-    or credentials — so no error message built from it can leak a secret.
+    Both fields are required and normalized (stripped, lowercased) so that
+    casing/whitespace cannot create a false mismatch OR a false match. Holds
+    no port/driver/credentials — never a full DSN — so no error message built
+    from it can leak a secret. A target with either field empty is malformed
+    and can never authorize (see ``__post_init__``).
     """
 
+    host: str
     database_name: str
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "host", self.host.strip().lower())
+        object.__setattr__(self, "database_name", self.database_name.strip())
+
+
+@dataclass(frozen=True)
+class ResearchDbPolicy:
+    """An authority-owned, closed set of positively-identified disposable
+    research DB targets.
+
+    Deliberately NOT a bag of raw strings (e.g. ``frozenset({"test_db"})``):
+    every entry is a full ``ResearchDbTarget`` (host AND database bound
+    together), and the ONLY way to build one is :meth:`of`, which rejects an
+    empty policy and any malformed (empty-field) target. A caller who only
+    knows a database name cannot construct an authorizing policy without also
+    naming a specific host — and the guard compares that policy against the
+    REAL resolved bind, which the caller does not control.
+    """
+
+    allowed_targets: frozenset[ResearchDbTarget]
+
+    @classmethod
+    def of(cls, *targets: ResearchDbTarget) -> ResearchDbPolicy:
+        if not targets:
+            raise ValueError(
+                "a ResearchDbPolicy must name at least one disposable research target"
+            )
+        for target in targets:
+            if not target.host or not target.database_name:
+                raise ValueError(
+                    f"malformed policy target (host={target.host!r}, "
+                    f"database_name={target.database_name!r}) — both fields "
+                    "are required"
+                )
+        return cls(allowed_targets=frozenset(targets))
+
+    def authorizes(self, target: ResearchDbTarget) -> bool:
+        return (
+            bool(target.host)
+            and bool(target.database_name)
+            and target in self.allowed_targets
+        )
+
+
+def default_research_db_policy() -> ResearchDbPolicy:
+    """The one reviewed, known-disposable local research target.
+
+    A convenience for real (non-test) call sites — NOT read automatically by
+    the guard and NOT a fallback; every caller still passes a policy
+    explicitly.
+    """
+    return ResearchDbPolicy.of(
+        ResearchDbTarget(host=_LOCAL_TEST_DB_HOST, database_name=_LOCAL_TEST_DB_NAME)
+    )
 
 
 def research_write_opt_in_enabled(raw_value: str | None) -> bool:
@@ -71,34 +159,36 @@ def research_write_opt_in_enabled(raw_value: str | None) -> bool:
 
 
 def resolve_research_db_target(session: object) -> ResearchDbTarget:
-    """Resolve the ACTUAL bound database identity from a live session.
+    """Resolve the ACTUAL bound (host, database) identity from a live session.
 
-    Pure metadata inspection (``session.get_bind().url.database``) — no query,
-    no I/O. This is a real fact taken from the engine's own bind, not a label
-    a caller could assert falsely.
+    Pure metadata inspection (``session.get_bind().url``) — no query, no I/O.
+    These are real facts taken from the engine's own bind, not a label a
+    caller could assert falsely.
     """
     bind = session.get_bind()  # type: ignore[attr-defined]
-    return ResearchDbTarget(database_name=bind.url.database or "")
+    url = bind.url
+    return ResearchDbTarget(host=url.host or "", database_name=url.database or "")
 
 
 def assert_research_write_authorized(
     *,
     opt_in_enabled: bool,
     target: ResearchDbTarget,
-    allowlist: frozenset[str],
+    policy: ResearchDbPolicy,
 ) -> None:
     """Fail closed unless BOTH conditions hold; raises before any DB write.
 
     * ``opt_in_enabled`` must be explicitly True.
-    * ``target.database_name`` must be a non-empty EXACT match against
-      ``allowlist`` — never a substring/prefix match, never "not production".
+    * ``target`` (host AND database, both non-empty) must be a positive EXACT
+      match against ``policy`` — never a substring/prefix match, never a bare
+      database-name check, never "not production".
     """
     if not opt_in_enabled:
         raise ResearchWriteDisabled(
             "ROB-940 research-write opt-in is disabled; refusing to write"
         )
-    name = target.database_name
-    if not name or name not in allowlist:
+    if not policy.authorizes(target):
         raise ResearchDbTargetRejected(
-            "research DB target is not on the explicit non-production allowlist"
+            "research DB target (host, database) is not a positive match "
+            "against the authority-owned disposable-target policy"
         )

--- a/research/nautilus_scalping/rob946_campaign_identity.py
+++ b/research/nautilus_scalping/rob946_campaign_identity.py
@@ -1,0 +1,455 @@
+"""ROB-946 (H6, ROB-940) — pure, generic campaign-identity builder.
+
+This module is deliberately a GENERIC, manifest-injected mechanism, not the
+production 24-row campaign itself. ROB-946 §9 (H3 parallel-dependency
+handling): H3 owns the actual production 24-row manifest and the real
+strategy source once it merges; this module must not fabricate a competing
+"production" copy of that data or a temporary hash authority. Callers (tests
+today, the future captain pipeline once H3 lands) supply:
+
+  * the 24 ``CampaignConfigRow``s (config_id/params/hypothesis) — literal data
+    that is already frozen/approved (Fable Q1=A, 2026-07-17) independent of
+    any strategy source code;
+  * a ``StrategySourceProvenance`` per strategy (S1/S2) carrying the ACTUAL
+    strategy source text, whose SHA-256 is recomputed here and compared
+    against any caller-asserted ``expected_source_sha256`` — a stale/tampered
+    assertion fails closed before any identity is built (same discipline as
+    ROB-941's archive checksum re-verification);
+  * the full committed ROB-941 corpus manifest dict, verified byte-for-byte
+    against its expected ``content_hash`` before use as the ``dataset_manifest``
+    identity component.
+
+Every other identity component (universe/pit/cost/policy/benchmark/mdd, and
+per-strategy frozen_config) is built from already-frozen ROB-940/941 constants
+(``rob941_frozen_scope``, ``rob940_cost_model``) — literal, not tunable, and
+identical for both strategies except the two documented per-strategy
+constants sets (frozen_config) and the two strategy-specific components
+(strategy, code). ``params`` is the ONLY component that legitimately varies
+row-to-row within one strategy's 12 configs.
+
+No DB/network/app import — pure stdlib plus the existing
+``research_contracts.canonical_hash`` authority (via the local ``canonical_hash``
+shim) and sibling rob941_*/rob940_* modules, all already pure themselves.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from dataclasses import dataclass
+from typing import Any
+
+import canonical_hash
+import rob941_frozen_scope as frozen
+from rob940_cost_model import (
+    COST_SCENARIOS,
+    FEE_ENTRY_BPS,
+    FEE_EXIT_BPS,
+    FEE_ROUND_TRIP_BPS,
+    MIN_TP_DISTANCE_BPS,
+)
+
+__all__ = [
+    "CampaignConfigRow",
+    "CampaignExperimentSpec",
+    "CampaignIdentityError",
+    "CampaignRowCountError",
+    "CampaignRowIdError",
+    "DatasetManifestHashMismatchError",
+    "StrategySourceMismatchError",
+    "StrategySourceProvenance",
+    "build_benchmark_component",
+    "build_campaign_experiment_specs",
+    "build_code_component",
+    "build_cost_component",
+    "build_dataset_manifest_component",
+    "build_frozen_config_component",
+    "build_mdd_component",
+    "build_params_component",
+    "build_pit_component",
+    "build_policy_component",
+    "build_strategy_component",
+    "build_universe_component",
+    "validate_campaign_rows",
+    "validate_same_strategy_components_are_identical",
+]
+
+_CONFIG_ID_PATTERN = re.compile(r"^S(?P<slug>[12])-(?P<idx>\d{2})$")
+_CONFIGS_PER_STRATEGY = 12
+_EXPECTED_TOTAL = 24
+_EXPECTED_SLUGS = ("S1", "S2")
+_NON_PARAMS_COMPONENT_NAMES = (
+    "strategy",
+    "code",
+    "dataset_manifest",
+    "universe",
+    "pit",
+    "frozen_config",
+    "policy",
+    "benchmark",
+    "cost",
+    "mdd",
+)
+
+
+class CampaignIdentityError(ValueError):
+    """Base error for campaign-identity construction/validation failures."""
+
+
+class CampaignRowCountError(CampaignIdentityError):
+    """The campaign does not have exactly 24 rows (12 per strategy)."""
+
+
+class CampaignRowIdError(CampaignIdentityError):
+    """A config_id is malformed, duplicated, or the per-strategy set is wrong."""
+
+
+class StrategySourceMismatchError(CampaignIdentityError):
+    """A strategy source's asserted hash is stale, or S1/S2 sources collide."""
+
+
+class DatasetManifestHashMismatchError(CampaignIdentityError):
+    """The injected dataset manifest does not hash to the expected value."""
+
+
+@dataclass(frozen=True)
+class CampaignConfigRow:
+    """One of the 24 approved (strategy, parameter-set) rows.
+
+    Deliberately carries no symbol field — there is no per-row universe
+    override hook; ``build_universe_component`` always returns the single
+    frozen 4-symbol universe regardless of which row is being built.
+    """
+
+    config_id: str
+    params: dict[str, Any]
+    hypothesis: str
+
+    def strategy_slug(self) -> str:
+        match = _CONFIG_ID_PATTERN.match(self.config_id)
+        if not match:
+            raise CampaignRowIdError(
+                f"config_id {self.config_id!r} does not match the required "
+                "S<1|2>-NN pattern"
+            )
+        return f"S{match.group('slug')}"
+
+
+@dataclass(frozen=True)
+class StrategySourceProvenance:
+    """Actual strategy source text + its verified (not merely asserted) SHA-256.
+
+    ``expected_source_sha256`` is an optional caller-supplied pin (e.g. from a
+    prior registration); if given, it is compared against the SHA-256 actually
+    computed from ``source_text`` and a mismatch fails closed rather than
+    silently trusting the assertion — the same "trust but verify" discipline
+    ROB-941 uses for archive checksums.
+    """
+
+    strategy_key: str
+    strategy_version: str
+    source_text: str
+    expected_source_sha256: str | None = None
+
+    def verified_source_sha256(self) -> str:
+        actual = hashlib.sha256(self.source_text.encode("utf-8")).hexdigest()
+        if (
+            self.expected_source_sha256 is not None
+            and actual != self.expected_source_sha256
+        ):
+            raise StrategySourceMismatchError(
+                f"{self.strategy_key}: source SHA-256 mismatch (expected "
+                f"{self.expected_source_sha256}, actual {actual}) — stale or "
+                "tampered strategy source"
+            )
+        return actual
+
+
+@dataclass(frozen=True)
+class CampaignExperimentSpec:
+    """One row's full identity, ready to feed an app-side
+    ``StrategyExperimentIdentity`` (this module never imports that schema —
+    pure research side stays app-free)."""
+
+    strategy_key: str
+    strategy_version: str
+    hypothesis: str
+    components: dict[str, Any]  # the 11 ROB-846 IDENTITY_COMPONENTS
+
+
+def validate_campaign_rows(rows: list[CampaignConfigRow]) -> None:
+    """Fail closed unless ``rows`` is exactly 12 S1 + 12 S2 rows, no dup/missing."""
+    if len(rows) != _EXPECTED_TOTAL:
+        raise CampaignRowCountError(
+            f"expected exactly {_EXPECTED_TOTAL} campaign rows, got {len(rows)}"
+        )
+    ids = [row.config_id for row in rows]
+    if len(set(ids)) != len(ids):
+        duplicates = sorted(
+            {config_id for config_id in ids if ids.count(config_id) > 1}
+        )
+        raise CampaignRowIdError(f"duplicate config_id(s): {duplicates}")
+
+    by_slug: dict[str, list[str]] = {}
+    for row in rows:
+        by_slug.setdefault(row.strategy_slug(), []).append(row.config_id)
+
+    if sorted(by_slug) != sorted(_EXPECTED_SLUGS):
+        raise CampaignRowIdError(
+            f"expected exactly strategy slugs {sorted(_EXPECTED_SLUGS)}, got "
+            f"{sorted(by_slug)}"
+        )
+    for slug in _EXPECTED_SLUGS:
+        expected_ids = [f"{slug}-{i:02d}" for i in range(_CONFIGS_PER_STRATEGY)]
+        if sorted(by_slug[slug]) != expected_ids:
+            raise CampaignRowIdError(
+                f"{slug}: expected exactly {expected_ids}, got {sorted(by_slug[slug])}"
+            )
+
+
+def build_dataset_manifest_component(
+    dataset_manifest: dict[str, Any], *, expected_content_hash: str
+) -> dict[str, Any]:
+    """Verify the injected ROB-941 manifest hashes to the expected value.
+
+    Uses the SAME canonical-hash authority ``CorpusManifest.content_hash()``
+    uses, over the SAME dict shape, so this reproduces the identical digest —
+    no wrapper/locator, the full manifest content is the identity component.
+    """
+    actual = canonical_hash.canonical_sha256(dataset_manifest)
+    if actual != expected_content_hash:
+        raise DatasetManifestHashMismatchError(
+            f"dataset manifest content_hash mismatch (expected "
+            f"{expected_content_hash}, actual {actual}) — missing/tampered corpus"
+        )
+    return dataset_manifest
+
+
+def build_universe_component() -> dict[str, Any]:
+    """The single frozen 4-symbol universe + eligibility — no override hook."""
+    return {
+        "symbols": list(frozen.UNIVERSE),
+        "eligibility": [
+            {"symbol": symbol, **frozen.eligibility(symbol)}
+            for symbol in frozen.UNIVERSE
+        ],
+    }
+
+
+def build_pit_component() -> dict[str, Any]:
+    return {
+        "window_start_iso": frozen.WINDOW_START_ISO,
+        "window_end_iso": frozen.WINDOW_END_ISO,
+        "funding_pit_policy": (
+            "entry_gate_last_known_rate_interval;pnl_realized_crossing;no_lookahead"
+        ),
+    }
+
+
+def build_cost_component() -> dict[str, Any]:
+    return {
+        "fee_entry_bps": FEE_ENTRY_BPS,
+        "fee_exit_bps": FEE_EXIT_BPS,
+        "fee_round_trip_bps": FEE_ROUND_TRIP_BPS,
+        "scenarios": {
+            scenario.name: scenario.all_in_bps for scenario in COST_SCENARIOS
+        },
+        "primary_scenario": "primary_stress",
+        "min_tp_distance_bps": MIN_TP_DISTANCE_BPS,
+    }
+
+
+def build_policy_component() -> dict[str, Any]:
+    return {
+        "walk_forward": {
+            "train_days": 120,
+            "embargo_hours": 3,
+            "oos_days": 28,
+            "roll_days": 28,
+            "min_folds": 6,
+        },
+        "selection": {
+            "authority": (
+                "equal_weight_mean_eligible_symbol_train_net_expectancy_bps_at_"
+                "primary_stress"
+            ),
+            "min_symbol_train_trades": 5,
+            "min_eligible_symbols": 2,
+            "insufficient_symbol_evidence_reason": "insufficient_symbol_evidence",
+            "insufficient_eligible_symbols_reason": "rejected:insufficient_train_evidence",
+            "tie_break": ["profit_factor", "config_id_ascending"],
+            "pooled_expectancy_role": "report_only_not_selection_authority",
+        },
+        "pass_thresholds_primary_stress": {
+            "expectancy_bps_min": 5,
+            "profit_factor_min": 1.15,
+            "positive_folds_min": 4,
+            "month_concentration_max": 0.50,
+        },
+        "pass_thresholds_upward_stress": {"expectancy_bps_min": 0},
+        "pbo": {"slices": 4, "role": "auxiliary_report_only_not_pass_gate"},
+        "no_broker_execution": True,
+        "data_gap_reject_reason": "rejected:data_gap_in_position",
+    }
+
+
+def build_benchmark_component() -> dict[str, Any]:
+    """Explicit canonical sentinel — NOT a historical pass authority (ROB-946 §4)."""
+    return {"kind": "none_explicit_sentinel", "role": "not_a_historical_pass_authority"}
+
+
+def build_mdd_component() -> dict[str, Any]:
+    """Historical MDD is report-only — never a hard gate (ROB-946 §4)."""
+    return {
+        "definition": "peak_to_trough_R_multiples",
+        "historical_role": "report_only",
+        "hard_gate": False,
+    }
+
+
+def build_frozen_config_component(strategy_slug: str) -> dict[str, Any]:
+    """Per-strategy FIXED (non-tunable) constants — identical for all 12 configs
+    of that strategy, different between S1 and S2."""
+    if strategy_slug == "S1":
+        return {
+            "timeframe": "15m",
+            "atr_period": 20,
+            "a_t_range_pct": [0.20, 1.20],
+            "chase_guard_atr_mult": 0.50,
+            "timeout_bars": 12,
+            "cooldown_bars": 4,
+            "daily_max_entries": 3,
+            "daily_max_consecutive_stop_outs": 2,
+            "daily_max_loss_r": -2.0,
+        }
+    if strategy_slug == "S2":
+        return {
+            "timeframe": "5m",
+            "mad_window": 288,
+            "er_window": 48,
+            "shock_return_floor_pct": 0.60,
+            "target_cap_pct": 1.20,
+            "cost_multiple_floor": 4,
+            "timeout_bars": 6,
+            "cooldown_bars": 12,
+            "daily_max_entries": 3,
+            "daily_max_consecutive_stop_outs": 2,
+            "daily_max_loss_r": -2.0,
+        }
+    raise CampaignIdentityError(f"unknown strategy slug {strategy_slug!r}")
+
+
+def build_strategy_component(
+    slug: str, source: StrategySourceProvenance
+) -> dict[str, Any]:
+    return {
+        "slug": slug,
+        "strategy_key": source.strategy_key,
+        "strategy_version": source.strategy_version,
+    }
+
+
+def build_code_component(source: StrategySourceProvenance) -> dict[str, Any]:
+    return {"source_sha256": source.verified_source_sha256()}
+
+
+def build_params_component(row: CampaignConfigRow) -> dict[str, Any]:
+    """The ONLY component allowed to vary within a strategy's 12 rows."""
+    return {"config_id": row.config_id, "hypothesis": row.hypothesis, **row.params}
+
+
+def validate_same_strategy_components_are_identical(
+    specs: list[CampaignExperimentSpec],
+) -> None:
+    """Fail closed unless every non-``params`` component is identical across
+    all rows sharing a ``strategy_key`` — the ROB-946 §3 params-only-variation
+    contract."""
+    by_strategy: dict[str, list[CampaignExperimentSpec]] = {}
+    for spec in specs:
+        by_strategy.setdefault(spec.strategy_key, []).append(spec)
+    for strategy_key, group in by_strategy.items():
+        first = group[0]
+        for other in group[1:]:
+            for name in _NON_PARAMS_COMPONENT_NAMES:
+                if first.components[name] != other.components[name]:
+                    raise CampaignIdentityError(
+                        f"strategy_key {strategy_key!r}: component {name!r} "
+                        f"differs between {first.components['params']['config_id']!r} "
+                        f"and {other.components['params']['config_id']!r} — only "
+                        "'params' may vary within one strategy's rows"
+                    )
+
+
+def build_campaign_experiment_specs(
+    rows: list[CampaignConfigRow],
+    *,
+    sources: dict[str, StrategySourceProvenance],
+    dataset_manifest: dict[str, Any],
+    dataset_manifest_expected_hash: str,
+) -> tuple[CampaignExperimentSpec, ...]:
+    """Build all 24 identity specs from injected rows/sources/manifest.
+
+    Fail-closed order: row-shape (count/id pattern) -> strategy-source
+    presence/distinctness -> dataset-manifest hash -> per-row component
+    assembly. Nothing is written or hashed into an experiment_id here — that
+    is the app-side bridge's job, using this module's output as pure data.
+    """
+    validate_campaign_rows(rows)
+
+    if set(sources) != set(_EXPECTED_SLUGS):
+        raise CampaignIdentityError(
+            f"expected strategy sources for exactly {sorted(_EXPECTED_SLUGS)}, "
+            f"got {sorted(sources)}"
+        )
+    s1_source, s2_source = sources["S1"], sources["S2"]
+    if s1_source.strategy_key == s2_source.strategy_key:
+        raise StrategySourceMismatchError("S1 and S2 must have different strategy_key")
+    if s1_source.strategy_version == s2_source.strategy_version:
+        raise StrategySourceMismatchError(
+            "S1 and S2 must have different strategy_version"
+        )
+    if s1_source.verified_source_sha256() == s2_source.verified_source_sha256():
+        raise StrategySourceMismatchError(
+            "S1 and S2 must have different source SHA-256 (source collision)"
+        )
+
+    dataset_component = build_dataset_manifest_component(
+        dataset_manifest, expected_content_hash=dataset_manifest_expected_hash
+    )
+    universe_component = build_universe_component()
+    pit_component = build_pit_component()
+    cost_component = build_cost_component()
+    policy_component = build_policy_component()
+    benchmark_component = build_benchmark_component()
+    mdd_component = build_mdd_component()
+    frozen_config_by_slug = {
+        slug: build_frozen_config_component(slug) for slug in _EXPECTED_SLUGS
+    }
+
+    specs = []
+    for row in rows:
+        slug = row.strategy_slug()
+        source = sources[slug]
+        specs.append(
+            CampaignExperimentSpec(
+                strategy_key=source.strategy_key,
+                strategy_version=source.strategy_version,
+                hypothesis=row.hypothesis,
+                components={
+                    "strategy": build_strategy_component(slug, source),
+                    "code": build_code_component(source),
+                    "params": build_params_component(row),
+                    "dataset_manifest": dataset_component,
+                    "universe": universe_component,
+                    "pit": pit_component,
+                    "frozen_config": frozen_config_by_slug[slug],
+                    "policy": policy_component,
+                    "benchmark": benchmark_component,
+                    "cost": cost_component,
+                    "mdd": mdd_component,
+                },
+            )
+        )
+
+    validate_same_strategy_components_are_identical(specs)
+    return tuple(specs)

--- a/research/nautilus_scalping/tests/test_pit_data_layer_guard.py
+++ b/research/nautilus_scalping/tests/test_pit_data_layer_guard.py
@@ -23,6 +23,7 @@ _MODULES = [
     "rob941_persistence.py",
     "rob941_offline_loader.py",
     "build_rob941_corpus.py",
+    "rob946_campaign_identity.py",
 ]
 
 

--- a/research/nautilus_scalping/tests/test_rob946_campaign_identity.py
+++ b/research/nautilus_scalping/tests/test_rob946_campaign_identity.py
@@ -1,0 +1,466 @@
+"""ROB-946 (H6, ROB-940) — pure campaign-identity builder: RED-first coverage.
+
+This module is deliberately GENERIC and manifest-injected (ROB-946 §9): it does
+not hardcode the production 24-row campaign (that is H3's authority once
+merged). The exact Fable-approved 24 rows below are a TEST FIXTURE only, used
+to prove the generic builder (a) reproduces the exact frozen values/order when
+fed them, and (b) fails closed on every malformed campaign shape a real caller
+could accidentally supply (13th row, missing, duplicate, wrong count, stale
+source hash, tampered dataset manifest).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import canonical_hash
+import pytest
+import rob941_frozen_scope as frozen
+from rob940_cost_model import COST_SCENARIOS, MIN_TP_DISTANCE_BPS
+from rob946_campaign_identity import (
+    CampaignConfigRow,
+    CampaignExperimentSpec,
+    CampaignIdentityError,
+    CampaignRowCountError,
+    CampaignRowIdError,
+    DatasetManifestHashMismatchError,
+    StrategySourceMismatchError,
+    StrategySourceProvenance,
+    build_campaign_experiment_specs,
+    build_universe_component,
+    validate_campaign_rows,
+    validate_same_strategy_components_are_identical,
+)
+
+_MANIFEST_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "data_manifests"
+    / "rob941_corpus_manifest.v1.json"
+)
+_EXPECTED_MANIFEST_HASH = (
+    "4bcc2da979b47caa45b5f90a09c326aefff91fa605e110d55ef316d53c9a9351"
+)
+
+# Fable Q1=A, frozen 2026-07-17 (strategy-fable-consult-20260717-123049.md +
+# orch-fable-answer-strategy-20260717.md) — exact, no modifications.
+_S1_ROWS: tuple[tuple[str, dict, str], ...] = (
+    ("S1-00", {"L": 16, "q_min": 1.25, "k_SL": 1.25, "R_TP": 1.80}, "연구 default"),
+    (
+        "S1-01",
+        {"L": 12, "q_min": 1.25, "k_SL": 1.25, "R_TP": 1.80},
+        "shorter breakout lookback",
+    ),
+    (
+        "S1-02",
+        {"L": 24, "q_min": 1.25, "k_SL": 1.25, "R_TP": 1.80},
+        "longer breakout lookback",
+    ),
+    (
+        "S1-03",
+        {"L": 16, "q_min": 1.00, "k_SL": 1.25, "R_TP": 1.80},
+        "looser volume confirmation",
+    ),
+    (
+        "S1-04",
+        {"L": 16, "q_min": 1.50, "k_SL": 1.25, "R_TP": 1.80},
+        "stricter volume confirmation",
+    ),
+    ("S1-05", {"L": 16, "q_min": 1.25, "k_SL": 1.00, "R_TP": 1.80}, "tighter ATR stop"),
+    ("S1-06", {"L": 16, "q_min": 1.25, "k_SL": 1.50, "R_TP": 1.80}, "wider ATR stop"),
+    (
+        "S1-07",
+        {"L": 16, "q_min": 1.25, "k_SL": 1.25, "R_TP": 1.50},
+        "lower payoff ratio",
+    ),
+    (
+        "S1-08",
+        {"L": 16, "q_min": 1.25, "k_SL": 1.25, "R_TP": 2.00},
+        "higher payoff ratio",
+    ),
+    (
+        "S1-09",
+        {"L": 12, "q_min": 1.50, "k_SL": 1.25, "R_TP": 1.80},
+        "fast breakout requires stronger volume",
+    ),
+    (
+        "S1-10",
+        {"L": 24, "q_min": 1.00, "k_SL": 1.25, "R_TP": 1.80},
+        "slow breakout tolerates weaker volume",
+    ),
+    (
+        "S1-11",
+        {"L": 16, "q_min": 1.25, "k_SL": 1.00, "R_TP": 2.00},
+        "tight-stop/high-payoff cost resilience",
+    ),
+)
+_S2_ROWS: tuple[tuple[str, dict, str], ...] = (
+    (
+        "S2-00",
+        {"z_min": 3.00, "v_min": 2.00, "ER_max": 0.35, "R_min": 1.25},
+        "연구 default",
+    ),
+    (
+        "S2-01",
+        {"z_min": 2.75, "v_min": 2.00, "ER_max": 0.35, "R_min": 1.25},
+        "lower shock threshold",
+    ),
+    (
+        "S2-02",
+        {"z_min": 3.25, "v_min": 2.00, "ER_max": 0.35, "R_min": 1.25},
+        "higher shock threshold",
+    ),
+    (
+        "S2-03",
+        {"z_min": 3.00, "v_min": 1.50, "ER_max": 0.35, "R_min": 1.25},
+        "looser volume spike",
+    ),
+    (
+        "S2-04",
+        {"z_min": 3.00, "v_min": 2.50, "ER_max": 0.35, "R_min": 1.25},
+        "stricter volume spike",
+    ),
+    (
+        "S2-05",
+        {"z_min": 3.00, "v_min": 2.00, "ER_max": 0.25, "R_min": 1.25},
+        "stricter mean-reversion regime",
+    ),
+    (
+        "S2-06",
+        {"z_min": 3.00, "v_min": 2.00, "ER_max": 0.45, "R_min": 1.25},
+        "looser regime filter",
+    ),
+    (
+        "S2-07",
+        {"z_min": 3.00, "v_min": 2.00, "ER_max": 0.35, "R_min": 1.20},
+        "lower reward floor",
+    ),
+    (
+        "S2-08",
+        {"z_min": 3.00, "v_min": 2.00, "ER_max": 0.35, "R_min": 1.35},
+        "higher reward floor",
+    ),
+    (
+        "S2-09",
+        {"z_min": 2.75, "v_min": 1.50, "ER_max": 0.45, "R_min": 1.20},
+        "permissive/frequency frontier",
+    ),
+    (
+        "S2-10",
+        {"z_min": 3.25, "v_min": 2.50, "ER_max": 0.25, "R_min": 1.35},
+        "selective/quality frontier",
+    ),
+    (
+        "S2-11",
+        {"z_min": 2.75, "v_min": 2.50, "ER_max": 0.25, "R_min": 1.25},
+        "lower z only when volume/regime are strict",
+    ),
+)
+
+
+def _rows(s1=_S1_ROWS, s2=_S2_ROWS) -> list[CampaignConfigRow]:
+    out = []
+    for config_id, params, hyp in s1:
+        out.append(
+            CampaignConfigRow(config_id=config_id, params=dict(params), hypothesis=hyp)
+        )
+    for config_id, params, hyp in s2:
+        out.append(
+            CampaignConfigRow(config_id=config_id, params=dict(params), hypothesis=hyp)
+        )
+    return out
+
+
+def _sources() -> dict[str, StrategySourceProvenance]:
+    s1_text = "def donchian_15m_signal(): ...  # S1 placeholder pending H3"
+    s2_text = (
+        "def confirmed_shock_reversal_5m_signal(): ...  # S2 placeholder pending H3"
+    )
+    return {
+        "S1": StrategySourceProvenance(
+            strategy_key="ROB940-S1-DONCHIAN-15M",
+            strategy_version="s1-v1",
+            source_text=s1_text,
+        ),
+        "S2": StrategySourceProvenance(
+            strategy_key="ROB940-S2-SHOCK-REVERSAL-5M",
+            strategy_version="s2-v1",
+            source_text=s2_text,
+        ),
+    }
+
+
+def _dataset_manifest() -> dict:
+    return json.loads(_MANIFEST_PATH.read_text())
+
+
+def _build(
+    rows=None,
+    sources=None,
+    dataset_manifest=None,
+    expected_hash=_EXPECTED_MANIFEST_HASH,
+):
+    return build_campaign_experiment_specs(
+        rows if rows is not None else _rows(),
+        sources=sources if sources is not None else _sources(),
+        dataset_manifest=dataset_manifest
+        if dataset_manifest is not None
+        else _dataset_manifest(),
+        dataset_manifest_expected_hash=expected_hash,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Exact 24 rows: IDs, order, values                                            #
+# --------------------------------------------------------------------------- #
+
+
+def test_exact_24_config_ids_in_canonical_order():
+    specs = _build()
+    ids = [s.components["params"]["config_id"] for s in specs]
+    expected = [c for c, _, _ in _S1_ROWS] + [c for c, _, _ in _S2_ROWS]
+    assert ids == expected
+    assert len(ids) == 24
+
+
+def test_exact_params_and_hypothesis_per_row():
+    specs = _build()
+    by_id = {s.components["params"]["config_id"]: s for s in specs}
+    for config_id, params, hyp in (*_S1_ROWS, *_S2_ROWS):
+        got = by_id[config_id].components["params"]
+        assert got["hypothesis"] == hyp
+        for key, value in params.items():
+            assert got[key] == value
+
+
+def test_all_24_derived_experiment_ids_are_unique():
+    specs = _build()
+    ids = {
+        canonical_hash.derive_experiment_id(
+            s.strategy_key,
+            s.strategy_version,
+            canonical_hash.compute_identity_hashes(s.components),
+        )
+        for s in specs
+    }
+    assert len(ids) == 24
+
+
+# --------------------------------------------------------------------------- #
+# Same-strategy: params-only variation                                        #
+# --------------------------------------------------------------------------- #
+
+
+def test_same_strategy_12_configs_share_every_component_except_params():
+    specs = _build()
+    validate_same_strategy_components_are_identical(specs)  # must not raise
+
+
+def test_validator_actually_detects_injected_component_drift():
+    # A real regression guard, not a vacuous positive: build_campaign_experiment_specs
+    # reuses the SAME object for every common component, so equality holds by
+    # construction there. This proves validate_same_strategy_components_are_identical
+    # is independently load-bearing — it must reject a list an EXTERNAL builder
+    # (e.g. a future H3 manifest) assembled with per-row component drift.
+    specs = list(_build())
+    drifted = specs[1]
+    corrupted = CampaignExperimentSpec(
+        strategy_key=drifted.strategy_key,
+        strategy_version=drifted.strategy_version,
+        hypothesis=drifted.hypothesis,
+        components={
+            **drifted.components,
+            "frozen_config": {
+                **drifted.components["frozen_config"],
+                "timeout_bars": 999,
+            },
+        },
+    )
+    specs[1] = corrupted
+    with pytest.raises(CampaignIdentityError):
+        validate_same_strategy_components_are_identical(specs)
+
+
+def test_s1_and_s2_differ_in_strategy_key_version_and_code_hash():
+    specs = _build()
+    s1 = next(s for s in specs if s.components["params"]["config_id"] == "S1-00")
+    s2 = next(s for s in specs if s.components["params"]["config_id"] == "S2-00")
+    assert s1.strategy_key != s2.strategy_key
+    assert s1.strategy_version != s2.strategy_version
+    assert s1.components["code"] != s2.components["code"]
+    # non-params components besides code/strategy/frozen_config are common
+    # across BOTH strategies (shared corpus/cost/policy) — only these three
+    # (plus params) are allowed to differ between S1 and S2.
+    for name in (
+        "dataset_manifest",
+        "universe",
+        "pit",
+        "policy",
+        "benchmark",
+        "cost",
+        "mdd",
+    ):
+        assert s1.components[name] == s2.components[name], name
+
+
+# --------------------------------------------------------------------------- #
+# Fail-closed: row-shape violations                                           #
+# --------------------------------------------------------------------------- #
+
+
+def test_23_rows_rejected():
+    with pytest.raises(CampaignRowCountError):
+        _build(rows=_rows()[:-1])
+
+
+def test_25_rows_rejected():
+    rows = _rows()
+    extra = CampaignConfigRow(
+        config_id="S1-12", params={"L": 99}, hypothesis="13th row"
+    )
+    with pytest.raises(CampaignRowCountError):
+        _build(rows=[*rows, extra])
+
+
+def test_duplicate_config_id_rejected():
+    rows = _rows()
+    rows[1] = CampaignConfigRow(
+        config_id=rows[0].config_id,
+        params=rows[1].params,
+        hypothesis=rows[1].hypothesis,
+    )
+    with pytest.raises(CampaignRowIdError):
+        validate_campaign_rows(rows)
+
+
+def test_missing_config_id_in_sequence_rejected():
+    rows = _rows()
+    rows[0] = CampaignConfigRow(
+        config_id="S1-00b", params=rows[0].params, hypothesis=rows[0].hypothesis
+    )
+    with pytest.raises(CampaignRowIdError):
+        validate_campaign_rows(rows)
+
+
+def test_81_grid_style_count_rejected():
+    # A full 3^4 per-strategy grid (81) is explicitly banned by the research
+    # brief; feeding it in must fail on row-count alone.
+    grid_rows = [
+        CampaignConfigRow(config_id=f"S1-{i:02d}", params={"L": i}, hypothesis="grid")
+        for i in range(81)
+    ]
+    with pytest.raises(CampaignRowCountError):
+        validate_campaign_rows(grid_rows)
+
+
+def test_universe_component_has_no_symbol_override_hook():
+    import inspect
+
+    assert dict(inspect.signature(build_universe_component).parameters) == {}
+    assert build_universe_component() == build_universe_component()
+    assert build_universe_component()["symbols"] == list(frozen.UNIVERSE)
+
+
+# --------------------------------------------------------------------------- #
+# Fail-closed: dataset manifest / strategy source integrity                   #
+# --------------------------------------------------------------------------- #
+
+
+def test_dataset_manifest_hash_must_match_committed_rob941_manifest():
+    specs = _build()
+    assert specs[0].components["dataset_manifest"] == _dataset_manifest()
+
+
+def test_tampered_dataset_manifest_rejected():
+    tampered = _dataset_manifest()
+    tampered["window_start_iso"] = "2020-01-01T00:00:00Z"
+    with pytest.raises(DatasetManifestHashMismatchError):
+        _build(dataset_manifest=tampered)
+
+
+def test_wrong_expected_hash_rejected_even_if_manifest_itself_is_untampered():
+    with pytest.raises(DatasetManifestHashMismatchError):
+        _build(expected_hash="0" * 64)
+
+
+def test_stale_asserted_source_hash_rejected():
+    sources = _sources()
+    sources["S1"] = StrategySourceProvenance(
+        strategy_key=sources["S1"].strategy_key,
+        strategy_version=sources["S1"].strategy_version,
+        source_text=sources["S1"].source_text,
+        expected_source_sha256="0" * 64,
+    )
+    with pytest.raises(StrategySourceMismatchError):
+        _build(sources=sources)
+
+
+def test_matching_asserted_source_hash_is_accepted():
+    sources = _sources()
+    actual = sources["S1"].verified_source_sha256()
+    sources["S1"] = StrategySourceProvenance(
+        strategy_key=sources["S1"].strategy_key,
+        strategy_version=sources["S1"].strategy_version,
+        source_text=sources["S1"].source_text,
+        expected_source_sha256=actual,
+    )
+    _build(sources=sources)  # must not raise
+
+
+def test_s1_and_s2_source_provenance_must_not_collide():
+    sources = _sources()
+    sources["S2"] = StrategySourceProvenance(
+        strategy_key=sources["S2"].strategy_key,
+        strategy_version=sources["S2"].strategy_version,
+        source_text=sources["S1"].source_text,  # identical bytes to S1
+    )
+    with pytest.raises(StrategySourceMismatchError):
+        _build(sources=sources)
+
+
+def test_missing_strategy_source_rejected():
+    sources = _sources()
+    del sources["S2"]
+    with pytest.raises(CampaignIdentityError):
+        _build(sources=sources)
+
+
+# --------------------------------------------------------------------------- #
+# Cost/policy components pin the frozen ROB-940 numeric contract              #
+# --------------------------------------------------------------------------- #
+
+
+def test_cost_component_pins_5_10_13_17_22_68():
+    specs = _build()
+    cost = specs[0].components["cost"]
+    assert cost["fee_entry_bps"] == 5.0
+    assert cost["fee_exit_bps"] == 5.0
+    assert cost["fee_round_trip_bps"] == 10.0
+    assert cost["scenarios"] == {s.name: s.all_in_bps for s in COST_SCENARIOS}
+    assert cost["scenarios"] == {
+        "base": 13.0,
+        "primary_stress": 17.0,
+        "upward_stress": 22.0,
+    }
+    assert cost["min_tp_distance_bps"] == 68.0 == MIN_TP_DISTANCE_BPS
+
+
+def test_policy_component_pins_folds_selection_and_min_evidence_guards():
+    specs = _build()
+    policy = specs[0].components["policy"]
+    assert policy["walk_forward"] == {
+        "train_days": 120,
+        "embargo_hours": 3,
+        "oos_days": 28,
+        "roll_days": 28,
+        "min_folds": 6,
+    }
+    assert policy["selection"]["min_symbol_train_trades"] == 5
+    assert policy["selection"]["min_eligible_symbols"] == 2
+    assert policy["no_broker_execution"] is True
+
+
+def test_build_is_pure_and_repeatable():
+    specs_a = _build()
+    specs_b = _build()
+    assert specs_a == specs_b

--- a/tests/services/research/test_no_broker_import_guard.py
+++ b/tests/services/research/test_no_broker_import_guard.py
@@ -1,10 +1,12 @@
-"""ROB-846 AC#6 — the experiment registry must not import broker/order/fill surfaces.
+"""ROB-846 AC#6 / ROB-946 §7 — the experiment registry and the ROB-946
+campaign bridge must not import broker/order/fill/scheduler surfaces.
 
-The immutable strategy experiment registry is deterministic research
+The immutable strategy experiment registry (and the ROB-946 app-side campaign
+bridge + DB write guard built on top of it) is deterministic research
 bookkeeping in the ``research`` schema only. It must never reach a broker,
-order, or fill ledger — neither to import one nor (transitively) to write one.
-This static guard scans the registry's own modules and fails if a forbidden
-surface is imported.
+order, fill ledger, or scheduler — neither to import one nor (transitively)
+to write/schedule one. This static guard scans those modules and fails if a
+forbidden surface is imported.
 """
 
 from __future__ import annotations
@@ -25,6 +27,10 @@ GUARDED_FILES: tuple[pathlib.Path, ...] = (
     REPO_ROOT / "app" / "services" / "research_offline_gate_service.py",
     REPO_ROOT / "app" / "models" / "research_backtest.py",
     REPO_ROOT / "app" / "schemas" / "research_backtest.py",
+    # ROB-946 (H6) — app-side campaign bridge + DB write guard + schemas.
+    REPO_ROOT / "app" / "services" / "research_campaign_bridge.py",
+    REPO_ROOT / "app" / "services" / "research_db_write_guard.py",
+    REPO_ROOT / "app" / "schemas" / "research_campaign_bridge.py",
     *sorted((REPO_ROOT / "research_contracts").glob("*.py")),
 )
 
@@ -45,13 +51,19 @@ FORBIDDEN_MODULE_PREFIXES: tuple[str, ...] = (
     "app.monitoring.trade_notifier",
 )
 
-# Substrings that indicate an order/fill ledger regardless of package path.
+# Substrings that indicate an order/fill ledger or scheduler regardless of
+# package path.
 FORBIDDEN_MODULE_SUBSTRINGS: tuple[str, ...] = (
     "order_ledger",
     "_ledger",
     "broker",
     "order_intent",
     "trade_notifier",
+    # ROB-946 §7 — no scheduler wiring from research bookkeeping.
+    "taskiq",
+    "celery",
+    "prefect",
+    "apscheduler",
 )
 
 

--- a/tests/services/research/test_research_campaign_bridge_registration.py
+++ b/tests/services/research/test_research_campaign_bridge_registration.py
@@ -1,0 +1,195 @@
+"""ROB-946 (H6) — campaign registration bridge: RED-first coverage.
+
+Registering the 24 campaign experiments must go through the SAME two-gate
+write guard as trial recording (ROB-946 §7/§8), and must refuse anything
+other than exactly 24 specs — the empirical runner (H4) is not allowed to
+start against a partially-registered campaign.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import func, select, text
+
+from app.models.research_backtest import ResearchStrategyExperiment
+from app.schemas.research_backtest import StrategyExperimentIdentity
+from app.services.research_campaign_bridge import (
+    CampaignSpecCountError,
+    register_campaign_experiments,
+)
+from app.services.research_db_write_guard import (
+    ResearchDbTargetRejected,
+    ResearchWriteDisabled,
+)
+
+_ALLOWLIST = frozenset({"test_db"})
+
+
+def _identity(config_id: str, **overrides) -> StrategyExperimentIdentity:
+    base = {
+        "strategy_key": "ROB946-CAMPAIGN-TEST-" + uuid.uuid4().hex[:8],
+        "strategy_version": "v1",
+        "hypothesis": "campaign registration bridge test",
+        "strategy": {"slug": "S1"},
+        "code": {"source_sha256": "0" * 64},
+        "params": {"config_id": config_id},
+        "dataset_manifest": {"corpus": "fixture"},
+        "universe": {"symbols": ["XRPUSDT"]},
+        "pit": {"window": "fixture"},
+        "frozen_config": {"timeframe": "15m"},
+        "policy": {"selection": "fixture"},
+        "benchmark": {},
+        "cost": {"primary_stress": 17.0},
+        "mdd": {"role": "report_only"},
+    }
+    base.update(overrides)
+    return StrategyExperimentIdentity(**base)
+
+
+def _campaign_specs() -> list[StrategyExperimentIdentity]:
+    return [
+        _identity(f"S1-{i:02d}", params={"config_id": f"S1-{i:02d}"}) for i in range(24)
+    ]
+
+
+@pytest_asyncio.fixture
+async def registry_tables(db_session):
+    exists = await db_session.scalar(
+        text("SELECT to_regclass('research.strategy_experiments')")
+    )
+    if exists is None:
+        pytest.skip("ROB-846 registry tables are not migrated in this DB")
+    return db_session
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_registers_all_24_unique_specs(registry_tables) -> None:
+    session = registry_tables
+    specs = _campaign_specs()
+
+    registered = await register_campaign_experiments(
+        session,
+        specs=specs,
+        guard_opt_in_enabled=True,
+        guard_allowlist=_ALLOWLIST,
+    )
+    await session.flush()
+
+    assert len(registered) == 24
+    assert len({r.experiment_id for r in registered}) == 24
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_guard_disabled_rejects_before_any_registration_row_is_written(
+    registry_tables,
+) -> None:
+    session = registry_tables
+    specs = _campaign_specs()
+    before = await session.scalar(
+        select(func.count()).select_from(ResearchStrategyExperiment)
+    )
+
+    with pytest.raises(ResearchWriteDisabled):
+        await register_campaign_experiments(
+            session,
+            specs=specs,
+            guard_opt_in_enabled=False,
+            guard_allowlist=_ALLOWLIST,
+        )
+
+    after = await session.scalar(
+        select(func.count()).select_from(ResearchStrategyExperiment)
+    )
+    assert after == before
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_guard_unlisted_target_rejects_before_any_registration_row_is_written(
+    registry_tables,
+) -> None:
+    session = registry_tables
+    specs = _campaign_specs()
+    before = await session.scalar(
+        select(func.count()).select_from(ResearchStrategyExperiment)
+    )
+
+    with pytest.raises(ResearchDbTargetRejected):
+        await register_campaign_experiments(
+            session,
+            specs=specs,
+            guard_opt_in_enabled=True,
+            guard_allowlist=frozenset(),
+        )
+
+    after = await session.scalar(
+        select(func.count()).select_from(ResearchStrategyExperiment)
+    )
+    assert after == before
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_wrong_spec_count_rejected_23(registry_tables) -> None:
+    session = registry_tables
+    with pytest.raises(CampaignSpecCountError):
+        await register_campaign_experiments(
+            session,
+            specs=_campaign_specs()[:-1],
+            guard_opt_in_enabled=True,
+            guard_allowlist=_ALLOWLIST,
+        )
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_wrong_spec_count_rejected_25(registry_tables) -> None:
+    session = registry_tables
+    specs = _campaign_specs()
+    extra = _identity("S1-24", params={"config_id": "S1-24"})
+    with pytest.raises(CampaignSpecCountError):
+        await register_campaign_experiments(
+            session,
+            specs=[*specs, extra],
+            guard_opt_in_enabled=True,
+            guard_allowlist=_ALLOWLIST,
+        )
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_guard_runs_before_spec_count_check(registry_tables) -> None:
+    session = registry_tables
+    # Disabled guard + a malformed (23-item) spec list: the guard's rejection
+    # must win — authorization is checked before any spec-shape inspection.
+    with pytest.raises(ResearchWriteDisabled):
+        await register_campaign_experiments(
+            session,
+            specs=_campaign_specs()[:-1],
+            guard_opt_in_enabled=False,
+            guard_allowlist=_ALLOWLIST,
+        )
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_registering_same_24_twice_is_idempotent_by_identity(
+    registry_tables,
+) -> None:
+    session = registry_tables
+    specs = _campaign_specs()
+
+    first = await register_campaign_experiments(
+        session, specs=specs, guard_opt_in_enabled=True, guard_allowlist=_ALLOWLIST
+    )
+    await session.flush()
+    second = await register_campaign_experiments(
+        session, specs=specs, guard_opt_in_enabled=True, guard_allowlist=_ALLOWLIST
+    )
+
+    assert [r.experiment_id for r in first] == [r.experiment_id for r in second]

--- a/tests/services/research/test_research_campaign_bridge_registration.py
+++ b/tests/services/research/test_research_campaign_bridge_registration.py
@@ -2,8 +2,9 @@
 
 Registering the 24 campaign experiments must go through the SAME two-gate
 write guard as trial recording (ROB-946 §7/§8), and must refuse anything
-other than exactly 24 specs — the empirical runner (H4) is not allowed to
-start against a partially-registered campaign.
+other than exactly 24 UNIQUE specs — the empirical runner (H4) is not allowed
+to start against a partially-registered or duplicate-masking campaign (R1
+Minor-5: a 24th duplicate spec must never silently replace a missing one).
 """
 
 from __future__ import annotations
@@ -17,15 +18,23 @@ from sqlalchemy import func, select, text
 from app.models.research_backtest import ResearchStrategyExperiment
 from app.schemas.research_backtest import StrategyExperimentIdentity
 from app.services.research_campaign_bridge import (
+    CampaignDuplicateSpecError,
     CampaignSpecCountError,
     register_campaign_experiments,
 )
 from app.services.research_db_write_guard import (
+    ResearchDbPolicy,
+    ResearchDbTarget,
     ResearchDbTargetRejected,
     ResearchWriteDisabled,
 )
 
-_ALLOWLIST = frozenset({"test_db"})
+_POLICY = ResearchDbPolicy.of(
+    ResearchDbTarget(host="localhost", database_name="test_db")
+)
+_DENYING_POLICY = ResearchDbPolicy.of(
+    ResearchDbTarget(host="some-other-host", database_name="some_other_db")
+)
 
 
 def _identity(config_id: str, **overrides) -> StrategyExperimentIdentity:
@@ -75,7 +84,7 @@ async def test_registers_all_24_unique_specs(registry_tables) -> None:
         session,
         specs=specs,
         guard_opt_in_enabled=True,
-        guard_allowlist=_ALLOWLIST,
+        guard_policy=_POLICY,
     )
     await session.flush()
 
@@ -99,7 +108,7 @@ async def test_guard_disabled_rejects_before_any_registration_row_is_written(
             session,
             specs=specs,
             guard_opt_in_enabled=False,
-            guard_allowlist=_ALLOWLIST,
+            guard_policy=_POLICY,
         )
 
     after = await session.scalar(
@@ -110,7 +119,7 @@ async def test_guard_disabled_rejects_before_any_registration_row_is_written(
 
 @pytest.mark.integration
 @pytest.mark.asyncio
-async def test_guard_unlisted_target_rejects_before_any_registration_row_is_written(
+async def test_guard_unauthorized_target_rejects_before_any_registration_row_is_written(
     registry_tables,
 ) -> None:
     session = registry_tables
@@ -124,7 +133,7 @@ async def test_guard_unlisted_target_rejects_before_any_registration_row_is_writ
             session,
             specs=specs,
             guard_opt_in_enabled=True,
-            guard_allowlist=frozenset(),
+            guard_policy=_DENYING_POLICY,
         )
 
     after = await session.scalar(
@@ -142,7 +151,7 @@ async def test_wrong_spec_count_rejected_23(registry_tables) -> None:
             session,
             specs=_campaign_specs()[:-1],
             guard_opt_in_enabled=True,
-            guard_allowlist=_ALLOWLIST,
+            guard_policy=_POLICY,
         )
 
 
@@ -157,7 +166,7 @@ async def test_wrong_spec_count_rejected_25(registry_tables) -> None:
             session,
             specs=[*specs, extra],
             guard_opt_in_enabled=True,
-            guard_allowlist=_ALLOWLIST,
+            guard_policy=_POLICY,
         )
 
 
@@ -172,8 +181,40 @@ async def test_guard_runs_before_spec_count_check(registry_tables) -> None:
             session,
             specs=_campaign_specs()[:-1],
             guard_opt_in_enabled=False,
-            guard_allowlist=_ALLOWLIST,
+            guard_policy=_POLICY,
         )
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_duplicate_spec_replacing_a_missing_one_is_rejected_before_any_write(
+    registry_tables,
+) -> None:
+    # R1 Minor-5 reproduction: 23 distinct specs + 1 EXACT duplicate of the
+    # first, instead of a 24th distinct config — must be rejected, never
+    # silently accepted as "24 registered".
+    session = registry_tables
+    base_specs = [
+        _identity(f"S1-{i:02d}", params={"config_id": f"S1-{i:02d}"}) for i in range(23)
+    ]
+    duplicate_of_first = base_specs[0]
+    specs = [*base_specs, duplicate_of_first]
+    assert len(specs) == 24
+
+    before = await session.scalar(
+        select(func.count()).select_from(ResearchStrategyExperiment)
+    )
+    with pytest.raises(CampaignDuplicateSpecError):
+        await register_campaign_experiments(
+            session,
+            specs=specs,
+            guard_opt_in_enabled=True,
+            guard_policy=_POLICY,
+        )
+    after = await session.scalar(
+        select(func.count()).select_from(ResearchStrategyExperiment)
+    )
+    assert after == before
 
 
 @pytest.mark.integration
@@ -185,11 +226,11 @@ async def test_registering_same_24_twice_is_idempotent_by_identity(
     specs = _campaign_specs()
 
     first = await register_campaign_experiments(
-        session, specs=specs, guard_opt_in_enabled=True, guard_allowlist=_ALLOWLIST
+        session, specs=specs, guard_opt_in_enabled=True, guard_policy=_POLICY
     )
     await session.flush()
     second = await register_campaign_experiments(
-        session, specs=specs, guard_opt_in_enabled=True, guard_allowlist=_ALLOWLIST
+        session, specs=specs, guard_opt_in_enabled=True, guard_policy=_POLICY
     )
 
     assert [r.experiment_id for r in first] == [r.experiment_id for r in second]

--- a/tests/services/research/test_research_campaign_bridge_trials.py
+++ b/tests/services/research/test_research_campaign_bridge_trials.py
@@ -1,0 +1,699 @@
+"""ROB-946 (H6) — hardened trial idempotency + scenario evidence + campaign
+completeness: RED-first coverage.
+
+Covers ROB-946 §5/§6/§8: independent 13/17/22bp scenario evidence, replay
+idempotency hardening (exact-evidence replay vs fail-closed mismatch), all 4
+terminal statuses, explicit-retry next index, and the campaign completeness
+report (24/23/25/missing/duplicate/retry, no winner-only filter).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+
+import pytest
+import pytest_asyncio
+from pydantic import ValidationError
+from sqlalchemy import func, select, text
+from sqlalchemy.ext.asyncio import async_sessionmaker
+
+from app.models.research_backtest import ResearchBacktestRun
+from app.schemas.research_backtest import StrategyExperimentIdentity
+from app.schemas.research_campaign_bridge import (
+    AttemptEvidence,
+    AttemptKey,
+    ScenarioEvidence,
+)
+from app.services import strategy_experiment_registry as reg
+from app.services.research_campaign_bridge import (
+    CampaignSpecCountError,
+    RunnerNameTooLongError,
+    TerminalEvidenceMismatch,
+    campaign_completeness_report,
+    record_attempt,
+)
+from app.services.research_db_write_guard import ResearchWriteDisabled
+
+_ALLOWLIST = frozenset({"test_db"})
+
+
+def _identity(**overrides) -> StrategyExperimentIdentity:
+    base = {
+        "strategy_key": "ROB946-TRIALS-TEST-" + uuid.uuid4().hex[:8],
+        "strategy_version": "v1",
+        "hypothesis": "trial bridge test",
+        "strategy": {"slug": "S1"},
+        "code": {"source_sha256": "0" * 64},
+        "params": {"config_id": "S1-00"},
+        "dataset_manifest": {"corpus": "fixture"},
+        "universe": {"symbols": ["XRPUSDT"]},
+        "pit": {"window": "fixture"},
+        "frozen_config": {"timeframe": "15m"},
+        "policy": {"selection": "fixture"},
+        "benchmark": {},
+        "cost": {"primary_stress": 17.0},
+        "mdd": {"role": "report_only"},
+    }
+    base.update(overrides)
+    return StrategyExperimentIdentity(**base)
+
+
+def _scenario_evidence(base=3, primary=3, upward=2) -> tuple:
+    return (
+        ScenarioEvidence(
+            scenario_name="base", trade_count=base, artifact_hash="h-base"
+        ),
+        ScenarioEvidence(
+            scenario_name="primary_stress",
+            trade_count=primary,
+            artifact_hash="h-primary",
+        ),
+        ScenarioEvidence(
+            scenario_name="upward_stress", trade_count=upward, artifact_hash="h-upward"
+        ),
+    )
+
+
+def _evidence(
+    campaign_run_id: str,
+    experiment_id: str,
+    retry_index: int = 0,
+    status: str = "completed",
+    reason_code: str | None = None,
+    scenario_evidence=None,
+    run_identity: str | None = None,
+    fold_evidence_hash: str | None = "fold-hash-1",
+) -> AttemptEvidence:
+    return AttemptEvidence(
+        attempt_key=AttemptKey(
+            campaign_run_id=campaign_run_id,
+            experiment_id=experiment_id,
+            retry_index=retry_index,
+        ),
+        status=status,
+        reason_code=reason_code if status != "completed" else reason_code,
+        fold_evidence_hash=fold_evidence_hash,
+        run_identity=run_identity or f"run-{uuid.uuid4().hex[:8]}",
+        scenario_evidence=scenario_evidence or _scenario_evidence(),
+    )
+
+
+@pytest_asyncio.fixture
+async def registry_tables(db_session):
+    exists = await db_session.scalar(
+        text("SELECT to_regclass('research.strategy_experiments')")
+    )
+    if exists is None:
+        pytest.skip("ROB-846 registry tables are not migrated in this DB")
+    return db_session
+
+
+async def _register(session) -> str:
+    exp = await reg.register_experiment(session, _identity())
+    await session.flush()
+    return exp.experiment_id
+
+
+# --------------------------------------------------------------------------- #
+# AttemptEvidence schema validation (pure, no DB)                             #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.unit
+def test_reason_code_required_for_non_completed_status() -> None:
+    with pytest.raises(ValidationError):
+        _evidence("camp1", "e" * 64, status="rejected", reason_code=None)
+
+
+@pytest.mark.unit
+def test_scenario_evidence_must_cover_exactly_three_named_scenarios() -> None:
+    only_two = (
+        ScenarioEvidence(scenario_name="base", trade_count=1),
+        ScenarioEvidence(scenario_name="primary_stress", trade_count=1),
+    )
+    with pytest.raises(ValidationError):
+        AttemptEvidence(
+            attempt_key=AttemptKey(
+                campaign_run_id="c", experiment_id="e" * 64, retry_index=0
+            ),
+            status="completed",
+            run_identity="run-1",
+            scenario_evidence=only_two,
+        )
+
+
+@pytest.mark.unit
+def test_duplicate_scenario_name_rejected() -> None:
+    duped = (
+        ScenarioEvidence(scenario_name="base", trade_count=1),
+        ScenarioEvidence(scenario_name="base", trade_count=2),
+        ScenarioEvidence(scenario_name="upward_stress", trade_count=1),
+    )
+    with pytest.raises(ValidationError):
+        AttemptEvidence(
+            attempt_key=AttemptKey(
+                campaign_run_id="c", experiment_id="e" * 64, retry_index=0
+            ),
+            status="completed",
+            run_identity="run-1",
+            scenario_evidence=duped,
+        )
+
+
+# --------------------------------------------------------------------------- #
+# Independent 13/17/22bp scenario evidence preservation                       #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_divergent_scenario_trade_counts_are_preserved_not_collapsed(
+    registry_tables,
+) -> None:
+    session = registry_tables
+    experiment_id = await _register(session)
+    evidence = _evidence(
+        "camp1",
+        experiment_id,
+        scenario_evidence=_scenario_evidence(base=3, primary=3, upward=2),
+    )
+
+    row = await record_attempt(
+        session,
+        experiment_id=experiment_id,
+        evidence=evidence,
+        strategy_name="S1",
+        timeframe="15m",
+        runner="pytest",
+        guard_opt_in_enabled=True,
+        guard_allowlist=_ALLOWLIST,
+    )
+
+    stored = row.raw_payload["scenario_evidence"]
+    by_name = {s["scenario_name"]: s for s in stored}
+    assert by_name["base"]["trade_count"] == 3
+    assert by_name["primary_stress"]["trade_count"] == 3
+    assert by_name["upward_stress"]["trade_count"] == 2
+    assert len(by_name) == 3  # no collapse into a single reference count
+
+
+# --------------------------------------------------------------------------- #
+# Idempotency hardening: exact replay vs fail-closed mismatch                 #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_same_key_identical_evidence_replays_the_original_row(
+    registry_tables,
+) -> None:
+    session = registry_tables
+    experiment_id = await _register(session)
+    evidence = _evidence("camp1", experiment_id, run_identity="run-fixed")
+
+    first = await record_attempt(
+        session,
+        experiment_id=experiment_id,
+        evidence=evidence,
+        strategy_name="S1",
+        timeframe="15m",
+        runner="pytest",
+        guard_opt_in_enabled=True,
+        guard_allowlist=_ALLOWLIST,
+    )
+    second = await record_attempt(
+        session,
+        experiment_id=experiment_id,
+        evidence=evidence,
+        strategy_name="S1",
+        timeframe="15m",
+        runner="pytest",
+        guard_opt_in_enabled=True,
+        guard_allowlist=_ALLOWLIST,
+    )
+
+    assert first.id == second.id
+    assert second.trial_status == "completed"
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_same_key_mismatched_status_fails_closed(registry_tables) -> None:
+    session = registry_tables
+    experiment_id = await _register(session)
+    key = AttemptKey(
+        campaign_run_id="camp1", experiment_id=experiment_id, retry_index=0
+    )
+    original = _evidence("camp1", experiment_id, run_identity="run-fixed")
+    original = original.model_copy(update={"attempt_key": key})
+
+    await record_attempt(
+        session,
+        experiment_id=experiment_id,
+        evidence=original,
+        strategy_name="S1",
+        timeframe="15m",
+        runner="pytest",
+        guard_opt_in_enabled=True,
+        guard_allowlist=_ALLOWLIST,
+    )
+
+    mismatched = _evidence(
+        "camp1",
+        experiment_id,
+        status="crashed",
+        reason_code="boom",
+        run_identity="run-fixed",
+    ).model_copy(update={"attempt_key": key})
+
+    with pytest.raises(TerminalEvidenceMismatch):
+        await record_attempt(
+            session,
+            experiment_id=experiment_id,
+            evidence=mismatched,
+            strategy_name="S1",
+            timeframe="15m",
+            runner="pytest",
+            guard_opt_in_enabled=True,
+            guard_allowlist=_ALLOWLIST,
+        )
+
+    trials = await reg.list_trials(session, experiment_id)
+    matching = [t for t in trials if t.trial_idempotency_key == key.idempotency_key()]
+    assert len(matching) == 1
+    assert matching[0].trial_status == "completed"  # original untouched
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_same_key_mismatched_scenario_trade_count_fails_closed(
+    registry_tables,
+) -> None:
+    session = registry_tables
+    experiment_id = await _register(session)
+    key = AttemptKey(
+        campaign_run_id="camp1", experiment_id=experiment_id, retry_index=0
+    )
+    original = _evidence("camp1", experiment_id, run_identity="run-fixed").model_copy(
+        update={"attempt_key": key}
+    )
+    await record_attempt(
+        session,
+        experiment_id=experiment_id,
+        evidence=original,
+        strategy_name="S1",
+        timeframe="15m",
+        runner="pytest",
+        guard_opt_in_enabled=True,
+        guard_allowlist=_ALLOWLIST,
+    )
+
+    diverged = _evidence(
+        "camp1",
+        experiment_id,
+        run_identity="run-fixed",
+        scenario_evidence=_scenario_evidence(base=3, primary=3, upward=99),
+    ).model_copy(update={"attempt_key": key})
+
+    with pytest.raises(TerminalEvidenceMismatch):
+        await record_attempt(
+            session,
+            experiment_id=experiment_id,
+            evidence=diverged,
+            strategy_name="S1",
+            timeframe="15m",
+            runner="pytest",
+            guard_opt_in_enabled=True,
+            guard_allowlist=_ALLOWLIST,
+        )
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_explicit_retry_uses_new_key_and_next_monotonic_trial_index(
+    registry_tables,
+) -> None:
+    session = registry_tables
+    experiment_id = await _register(session)
+
+    first = await record_attempt(
+        session,
+        experiment_id=experiment_id,
+        evidence=_evidence(
+            "camp1", experiment_id, retry_index=0, status="crashed", reason_code="oom"
+        ),
+        strategy_name="S1",
+        timeframe="15m",
+        runner="pytest",
+        guard_opt_in_enabled=True,
+        guard_allowlist=_ALLOWLIST,
+    )
+    retry = await record_attempt(
+        session,
+        experiment_id=experiment_id,
+        evidence=_evidence("camp1", experiment_id, retry_index=1, status="completed"),
+        strategy_name="S1",
+        timeframe="15m",
+        runner="pytest",
+        guard_opt_in_enabled=True,
+        guard_allowlist=_ALLOWLIST,
+    )
+
+    assert retry.trial_index == first.trial_index + 1
+    assert retry.trial_idempotency_key != first.trial_idempotency_key
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_all_four_terminal_statuses_recorded(registry_tables) -> None:
+    session = registry_tables
+    experiment_id = await _register(session)
+
+    statuses = [
+        ("completed", None),
+        ("rejected", "insufficient_symbol_evidence"),
+        ("crashed", "boom"),
+        ("timeout", "budget_exceeded"),
+    ]
+    for retry_index, (status, reason) in enumerate(statuses):
+        await record_attempt(
+            session,
+            experiment_id=experiment_id,
+            evidence=_evidence(
+                "camp1",
+                experiment_id,
+                retry_index=retry_index,
+                status=status,
+                reason_code=reason,
+            ),
+            strategy_name="S1",
+            timeframe="15m",
+            runner="pytest",
+            guard_opt_in_enabled=True,
+            guard_allowlist=_ALLOWLIST,
+        )
+
+    accounting = await reg.get_trial_accounting(session, experiment_id)
+    assert accounting.outcome_counts == {
+        "completed": 1,
+        "rejected": 1,
+        "crashed": 1,
+        "timeout": 1,
+    }
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_stable_reason_codes_survive_round_trip_unmutated(
+    registry_tables,
+) -> None:
+    # ROB-946 §5/§8: these exact strings must never be paraphrased/altered.
+    session = registry_tables
+    experiment_id = await _register(session)
+    reason_codes = [
+        "insufficient_symbol_evidence",
+        "rejected:insufficient_train_evidence",
+        "rejected:data_gap_in_position",
+    ]
+    for retry_index, reason_code in enumerate(reason_codes):
+        await record_attempt(
+            session,
+            experiment_id=experiment_id,
+            evidence=_evidence(
+                "camp-reason",
+                experiment_id,
+                retry_index=retry_index,
+                status="rejected",
+                reason_code=reason_code,
+            ),
+            strategy_name="S1",
+            timeframe="15m",
+            runner="pytest",
+            guard_opt_in_enabled=True,
+            guard_allowlist=_ALLOWLIST,
+        )
+
+    trials = await reg.list_trials(session, experiment_id)
+    stored_reasons = {
+        t.raw_payload["reason_code"]
+        for t in trials
+        if t.trial_idempotency_key
+        and t.trial_idempotency_key.startswith("camp-reason:")
+    }
+    assert stored_reasons == set(reason_codes)
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_runner_name_over_16_chars_rejected_before_any_write(
+    registry_tables,
+) -> None:
+    session = registry_tables
+    experiment_id = await _register(session)
+    before = await session.scalar(select(func.count()).select_from(ResearchBacktestRun))
+
+    with pytest.raises(RunnerNameTooLongError):
+        await record_attempt(
+            session,
+            experiment_id=experiment_id,
+            evidence=_evidence("camp1", experiment_id),
+            strategy_name="S1",
+            timeframe="15m",
+            runner="this-runner-name-is-way-too-long",
+            guard_opt_in_enabled=True,
+            guard_allowlist=_ALLOWLIST,
+        )
+
+    after = await session.scalar(select(func.count()).select_from(ResearchBacktestRun))
+    assert after == before
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_guard_disabled_rejects_attempt_recording_before_any_write(
+    registry_tables,
+) -> None:
+    session = registry_tables
+    experiment_id = await _register(session)
+    before = await session.scalar(select(func.count()).select_from(ResearchBacktestRun))
+
+    with pytest.raises(ResearchWriteDisabled):
+        await record_attempt(
+            session,
+            experiment_id=experiment_id,
+            evidence=_evidence("camp1", experiment_id),
+            strategy_name="S1",
+            timeframe="15m",
+            runner="pytest",
+            guard_opt_in_enabled=False,
+            guard_allowlist=_ALLOWLIST,
+        )
+
+    after = await session.scalar(select(func.count()).select_from(ResearchBacktestRun))
+    assert after == before
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_concurrent_identical_replay_never_creates_a_duplicate_row(
+    registry_tables,
+) -> None:
+    from app.core.db import engine
+
+    session_maker = async_sessionmaker(bind=engine, expire_on_commit=False)
+
+    async with session_maker() as setup:
+        experiment_id = await _register(setup)
+        await setup.commit()
+
+    evidence = _evidence("camp1", experiment_id, run_identity="run-fixed")
+
+    async def worker() -> int:
+        async with session_maker() as s:
+            row = await record_attempt(
+                s,
+                experiment_id=experiment_id,
+                evidence=evidence,
+                strategy_name="S1",
+                timeframe="15m",
+                runner="pytest",
+                guard_opt_in_enabled=True,
+                guard_allowlist=_ALLOWLIST,
+            )
+            index = row.trial_index
+            await s.commit()
+            return index
+
+    left, right = await asyncio.gather(worker(), worker())
+    assert left == right
+
+    async with session_maker() as check:
+        count = await check.scalar(
+            select(func.count())
+            .select_from(ResearchBacktestRun)
+            .where(
+                ResearchBacktestRun.trial_idempotency_key
+                == evidence.attempt_key.idempotency_key()
+            )
+        )
+    assert count == 1
+
+
+# --------------------------------------------------------------------------- #
+# Campaign completeness report                                                #
+# --------------------------------------------------------------------------- #
+
+
+async def _register_n(session, n: int) -> list[str]:
+    ids = []
+    for _ in range(n):
+        exp = await reg.register_experiment(session, _identity())
+        await session.flush()
+        ids.append(exp.experiment_id)
+    return ids
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_completeness_reports_complete_when_all_24_have_any_terminal_status(
+    registry_tables,
+) -> None:
+    session = registry_tables
+    experiment_ids = await _register_n(session, 24)
+    statuses = ["completed", "rejected", "crashed", "timeout"]
+    for i, experiment_id in enumerate(experiment_ids):
+        status = statuses[i % 4]
+        await record_attempt(
+            session,
+            experiment_id=experiment_id,
+            evidence=_evidence(
+                "camp-complete",
+                experiment_id,
+                status=status,
+                reason_code=None if status == "completed" else "reason",
+            ),
+            strategy_name="S1",
+            timeframe="15m",
+            runner="pytest",
+            guard_opt_in_enabled=True,
+            guard_allowlist=_ALLOWLIST,
+        )
+
+    report = await campaign_completeness_report(
+        session, campaign_run_id="camp-complete", expected_experiment_ids=experiment_ids
+    )
+
+    assert report.verdict == "complete"
+    assert report.expected_total == 24
+    assert report.experiments_with_attempts == 24
+    assert sum(report.status_counts.values()) == 24
+    assert report.missing_experiment_ids == []
+    assert report.duplicate_logical_attempts == []
+    # No winner-only filter: an all-crashed/rejected/timeout campaign is still
+    # "complete" evidence — completed != PASS.
+    assert report.status_counts["crashed"] >= 1
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_completeness_reports_incomplete_when_one_experiment_has_no_attempt(
+    registry_tables,
+) -> None:
+    session = registry_tables
+    experiment_ids = await _register_n(session, 24)
+    for experiment_id in experiment_ids[:-1]:
+        await record_attempt(
+            session,
+            experiment_id=experiment_id,
+            evidence=_evidence("camp-missing", experiment_id),
+            strategy_name="S1",
+            timeframe="15m",
+            runner="pytest",
+            guard_opt_in_enabled=True,
+            guard_allowlist=_ALLOWLIST,
+        )
+
+    report = await campaign_completeness_report(
+        session, campaign_run_id="camp-missing", expected_experiment_ids=experiment_ids
+    )
+
+    assert report.verdict == "incomplete"
+    assert report.missing_experiment_ids == [experiment_ids[-1]]
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_completeness_rejects_wrong_expected_count_23(registry_tables) -> None:
+    session = registry_tables
+    experiment_ids = await _register_n(session, 23)
+    with pytest.raises(CampaignSpecCountError):
+        await campaign_completeness_report(
+            session, campaign_run_id="camp-23", expected_experiment_ids=experiment_ids
+        )
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_completeness_rejects_wrong_expected_count_25(registry_tables) -> None:
+    session = registry_tables
+    experiment_ids = await _register_n(session, 24)
+    with pytest.raises(CampaignSpecCountError):
+        await campaign_completeness_report(
+            session,
+            campaign_run_id="camp-25",
+            expected_experiment_ids=[*experiment_ids, experiment_ids[0]],
+        )
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_completeness_distinguishes_retry_from_duplicate(registry_tables) -> None:
+    session = registry_tables
+    experiment_ids = await _register_n(session, 24)
+    retried_id = experiment_ids[0]
+
+    await record_attempt(
+        session,
+        experiment_id=retried_id,
+        evidence=_evidence(
+            "camp-retry", retried_id, retry_index=0, status="crashed", reason_code="oom"
+        ),
+        strategy_name="S1",
+        timeframe="15m",
+        runner="pytest",
+        guard_opt_in_enabled=True,
+        guard_allowlist=_ALLOWLIST,
+    )
+    await record_attempt(
+        session,
+        experiment_id=retried_id,
+        evidence=_evidence("camp-retry", retried_id, retry_index=1, status="completed"),
+        strategy_name="S1",
+        timeframe="15m",
+        runner="pytest",
+        guard_opt_in_enabled=True,
+        guard_allowlist=_ALLOWLIST,
+    )
+    for experiment_id in experiment_ids[1:]:
+        await record_attempt(
+            session,
+            experiment_id=experiment_id,
+            evidence=_evidence("camp-retry", experiment_id),
+            strategy_name="S1",
+            timeframe="15m",
+            runner="pytest",
+            guard_opt_in_enabled=True,
+            guard_allowlist=_ALLOWLIST,
+        )
+
+    report = await campaign_completeness_report(
+        session, campaign_run_id="camp-retry", expected_experiment_ids=experiment_ids
+    )
+
+    assert report.verdict == "complete"
+    assert report.duplicate_logical_attempts == []
+    assert report.experiments_with_attempts == 24
+    # both the retried crash AND the eventual completion are counted — 25 rows
+    # total across 24 experiments, not treated as a duplicate.
+    assert sum(report.status_counts.values()) == 25

--- a/tests/services/research/test_research_campaign_bridge_trials.py
+++ b/tests/services/research/test_research_campaign_bridge_trials.py
@@ -1,10 +1,12 @@
 """ROB-946 (H6) — hardened trial idempotency + scenario evidence + campaign
 completeness: RED-first coverage.
 
-Covers ROB-946 §5/§6/§8: independent 13/17/22bp scenario evidence, replay
-idempotency hardening (exact-evidence replay vs fail-closed mismatch), all 4
-terminal statuses, explicit-retry next index, and the campaign completeness
-report (24/23/25/missing/duplicate/retry, no winner-only filter).
+Covers ROB-946 §5/§6/§8/§9: independent 13/17/22bp scenario evidence, replay
+idempotency hardening (exact-evidence replay vs fail-closed mismatch on BOTH
+the sequential pre-check path AND the concurrent post-delegate path — R1
+Critical-2), all 4 terminal statuses, explicit-retry next index, and the
+campaign completeness report (24/23/25/missing/extra/mismatch/retry-gap, no
+winner-only filter — R1 Important-3/4).
 """
 
 from __future__ import annotations
@@ -25,6 +27,7 @@ from app.schemas.research_campaign_bridge import (
     AttemptKey,
     ScenarioEvidence,
 )
+from app.services import research_campaign_bridge as bridge
 from app.services import strategy_experiment_registry as reg
 from app.services.research_campaign_bridge import (
     CampaignSpecCountError,
@@ -33,19 +36,27 @@ from app.services.research_campaign_bridge import (
     campaign_completeness_report,
     record_attempt,
 )
-from app.services.research_db_write_guard import ResearchWriteDisabled
+from app.services.research_db_write_guard import (
+    ResearchDbPolicy,
+    ResearchDbTarget,
+    ResearchWriteDisabled,
+)
 
-_ALLOWLIST = frozenset({"test_db"})
+_POLICY = ResearchDbPolicy.of(
+    ResearchDbTarget(host="localhost", database_name="test_db")
+)
 
 
-def _identity(**overrides) -> StrategyExperimentIdentity:
+def _identity(
+    config_id: str = "S1-00", strategy_key: str | None = None, **overrides
+) -> StrategyExperimentIdentity:
     base = {
-        "strategy_key": "ROB946-TRIALS-TEST-" + uuid.uuid4().hex[:8],
+        "strategy_key": strategy_key or ("ROB946-TRIALS-TEST-" + uuid.uuid4().hex[:8]),
         "strategy_version": "v1",
         "hypothesis": "trial bridge test",
         "strategy": {"slug": "S1"},
         "code": {"source_sha256": "0" * 64},
-        "params": {"config_id": "S1-00"},
+        "params": {"config_id": config_id},
         "dataset_manifest": {"corpus": "fixture"},
         "universe": {"symbols": ["XRPUSDT"]},
         "pit": {"window": "fixture"},
@@ -109,10 +120,21 @@ async def registry_tables(db_session):
     return db_session
 
 
-async def _register(session) -> str:
-    exp = await reg.register_experiment(session, _identity())
+async def _register(
+    session, spec: StrategyExperimentIdentity | None = None
+) -> tuple[StrategyExperimentIdentity, str]:
+    spec = spec or _identity()
+    exp = await reg.register_experiment(session, spec)
     await session.flush()
-    return exp.experiment_id
+    return spec, exp.experiment_id
+
+
+async def _register_n(session, n: int) -> list[tuple[StrategyExperimentIdentity, str]]:
+    out = []
+    for i in range(n):
+        spec = _identity(config_id=f"S1-{i:02d}")
+        out.append(await _register(session, spec))
+    return out
 
 
 # --------------------------------------------------------------------------- #
@@ -172,7 +194,7 @@ async def test_divergent_scenario_trade_counts_are_preserved_not_collapsed(
     registry_tables,
 ) -> None:
     session = registry_tables
-    experiment_id = await _register(session)
+    _spec, experiment_id = await _register(session)
     evidence = _evidence(
         "camp1",
         experiment_id,
@@ -187,7 +209,7 @@ async def test_divergent_scenario_trade_counts_are_preserved_not_collapsed(
         timeframe="15m",
         runner="pytest",
         guard_opt_in_enabled=True,
-        guard_allowlist=_ALLOWLIST,
+        guard_policy=_POLICY,
     )
 
     stored = row.raw_payload["scenario_evidence"]
@@ -209,7 +231,7 @@ async def test_same_key_identical_evidence_replays_the_original_row(
     registry_tables,
 ) -> None:
     session = registry_tables
-    experiment_id = await _register(session)
+    _spec, experiment_id = await _register(session)
     evidence = _evidence("camp1", experiment_id, run_identity="run-fixed")
 
     first = await record_attempt(
@@ -220,7 +242,7 @@ async def test_same_key_identical_evidence_replays_the_original_row(
         timeframe="15m",
         runner="pytest",
         guard_opt_in_enabled=True,
-        guard_allowlist=_ALLOWLIST,
+        guard_policy=_POLICY,
     )
     second = await record_attempt(
         session,
@@ -230,7 +252,7 @@ async def test_same_key_identical_evidence_replays_the_original_row(
         timeframe="15m",
         runner="pytest",
         guard_opt_in_enabled=True,
-        guard_allowlist=_ALLOWLIST,
+        guard_policy=_POLICY,
     )
 
     assert first.id == second.id
@@ -239,9 +261,11 @@ async def test_same_key_identical_evidence_replays_the_original_row(
 
 @pytest.mark.integration
 @pytest.mark.asyncio
-async def test_same_key_mismatched_status_fails_closed(registry_tables) -> None:
+async def test_same_key_mismatched_status_fails_closed_on_precheck_path(
+    registry_tables,
+) -> None:
     session = registry_tables
-    experiment_id = await _register(session)
+    _spec, experiment_id = await _register(session)
     key = AttemptKey(
         campaign_run_id="camp1", experiment_id=experiment_id, retry_index=0
     )
@@ -256,7 +280,7 @@ async def test_same_key_mismatched_status_fails_closed(registry_tables) -> None:
         timeframe="15m",
         runner="pytest",
         guard_opt_in_enabled=True,
-        guard_allowlist=_ALLOWLIST,
+        guard_policy=_POLICY,
     )
 
     mismatched = _evidence(
@@ -276,7 +300,7 @@ async def test_same_key_mismatched_status_fails_closed(registry_tables) -> None:
             timeframe="15m",
             runner="pytest",
             guard_opt_in_enabled=True,
-            guard_allowlist=_ALLOWLIST,
+            guard_policy=_POLICY,
         )
 
     trials = await reg.list_trials(session, experiment_id)
@@ -291,7 +315,7 @@ async def test_same_key_mismatched_scenario_trade_count_fails_closed(
     registry_tables,
 ) -> None:
     session = registry_tables
-    experiment_id = await _register(session)
+    _spec, experiment_id = await _register(session)
     key = AttemptKey(
         campaign_run_id="camp1", experiment_id=experiment_id, retry_index=0
     )
@@ -306,7 +330,7 @@ async def test_same_key_mismatched_scenario_trade_count_fails_closed(
         timeframe="15m",
         runner="pytest",
         guard_opt_in_enabled=True,
-        guard_allowlist=_ALLOWLIST,
+        guard_policy=_POLICY,
     )
 
     diverged = _evidence(
@@ -325,8 +349,120 @@ async def test_same_key_mismatched_scenario_trade_count_fails_closed(
             timeframe="15m",
             runner="pytest",
             guard_opt_in_enabled=True,
-            guard_allowlist=_ALLOWLIST,
+            guard_policy=_POLICY,
         )
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_concurrent_same_key_different_evidence_fails_closed_on_postdelegate_path(
+    registry_tables, monkeypatch
+) -> None:
+    """R1 Critical-2 reproduction/regression.
+
+    Forces the EXACT race window: this caller's pre-check misses (simulating
+    a concurrent writer's commit not yet visible), so it proceeds to delegate
+    to the raw ``record_trial`` — which, for the SAME attempt key, resolves
+    to the ALREADY-COMMITTED winner row. The post-delegate fingerprint check
+    must catch the divergence even though the pre-check never did.
+    """
+    session = registry_tables
+    _spec, experiment_id = await _register(session)
+    key = AttemptKey(
+        campaign_run_id="camp-race", experiment_id=experiment_id, retry_index=0
+    )
+
+    winner_evidence = _evidence(
+        "camp-race", experiment_id, run_identity="run-winner"
+    ).model_copy(update={"attempt_key": key})
+    await record_attempt(
+        session,
+        experiment_id=experiment_id,
+        evidence=winner_evidence,
+        strategy_name="S1",
+        timeframe="15m",
+        runner="pytest",
+        guard_opt_in_enabled=True,
+        guard_policy=_POLICY,
+    )
+
+    async def _always_miss(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(bridge, "_find_trial_by_attempt_key", _always_miss)
+
+    loser_evidence = _evidence(
+        "camp-race",
+        experiment_id,
+        status="crashed",
+        reason_code="oom",
+        run_identity="run-loser",
+        scenario_evidence=_scenario_evidence(base=0, primary=0, upward=0),
+    ).model_copy(update={"attempt_key": key})
+
+    with pytest.raises(TerminalEvidenceMismatch):
+        await record_attempt(
+            session,
+            experiment_id=experiment_id,
+            evidence=loser_evidence,
+            strategy_name="S1",
+            timeframe="15m",
+            runner="pytest",
+            guard_opt_in_enabled=True,
+            guard_policy=_POLICY,
+        )
+
+    # The winner's row must remain exactly as recorded — no overwrite.
+    trials = await reg.list_trials(session, experiment_id)
+    matching = [t for t in trials if t.trial_idempotency_key == key.idempotency_key()]
+    assert len(matching) == 1
+    assert matching[0].trial_status == "completed"
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_concurrent_same_key_identical_evidence_still_replays_on_postdelegate_path(
+    registry_tables, monkeypatch
+) -> None:
+    """The post-delegate check must NOT false-positive when the race winner's
+    evidence is actually identical to this caller's own (a true duplicate
+    concurrent submission of the SAME result)."""
+    session = registry_tables
+    _spec, experiment_id = await _register(session)
+    key = AttemptKey(
+        campaign_run_id="camp-race2", experiment_id=experiment_id, retry_index=0
+    )
+    evidence = _evidence(
+        "camp-race2", experiment_id, run_identity="run-same"
+    ).model_copy(update={"attempt_key": key})
+
+    first = await record_attempt(
+        session,
+        experiment_id=experiment_id,
+        evidence=evidence,
+        strategy_name="S1",
+        timeframe="15m",
+        runner="pytest",
+        guard_opt_in_enabled=True,
+        guard_policy=_POLICY,
+    )
+
+    async def _always_miss(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(bridge, "_find_trial_by_attempt_key", _always_miss)
+
+    second = await record_attempt(
+        session,
+        experiment_id=experiment_id,
+        evidence=evidence,
+        strategy_name="S1",
+        timeframe="15m",
+        runner="pytest",
+        guard_opt_in_enabled=True,
+        guard_policy=_POLICY,
+    )
+    assert second.id == first.id
 
 
 @pytest.mark.integration
@@ -335,7 +471,7 @@ async def test_explicit_retry_uses_new_key_and_next_monotonic_trial_index(
     registry_tables,
 ) -> None:
     session = registry_tables
-    experiment_id = await _register(session)
+    _spec, experiment_id = await _register(session)
 
     first = await record_attempt(
         session,
@@ -347,7 +483,7 @@ async def test_explicit_retry_uses_new_key_and_next_monotonic_trial_index(
         timeframe="15m",
         runner="pytest",
         guard_opt_in_enabled=True,
-        guard_allowlist=_ALLOWLIST,
+        guard_policy=_POLICY,
     )
     retry = await record_attempt(
         session,
@@ -357,7 +493,7 @@ async def test_explicit_retry_uses_new_key_and_next_monotonic_trial_index(
         timeframe="15m",
         runner="pytest",
         guard_opt_in_enabled=True,
-        guard_allowlist=_ALLOWLIST,
+        guard_policy=_POLICY,
     )
 
     assert retry.trial_index == first.trial_index + 1
@@ -368,7 +504,7 @@ async def test_explicit_retry_uses_new_key_and_next_monotonic_trial_index(
 @pytest.mark.asyncio
 async def test_all_four_terminal_statuses_recorded(registry_tables) -> None:
     session = registry_tables
-    experiment_id = await _register(session)
+    _spec, experiment_id = await _register(session)
 
     statuses = [
         ("completed", None),
@@ -391,7 +527,7 @@ async def test_all_four_terminal_statuses_recorded(registry_tables) -> None:
             timeframe="15m",
             runner="pytest",
             guard_opt_in_enabled=True,
-            guard_allowlist=_ALLOWLIST,
+            guard_policy=_POLICY,
         )
 
     accounting = await reg.get_trial_accounting(session, experiment_id)
@@ -410,7 +546,7 @@ async def test_stable_reason_codes_survive_round_trip_unmutated(
 ) -> None:
     # ROB-946 §5/§8: these exact strings must never be paraphrased/altered.
     session = registry_tables
-    experiment_id = await _register(session)
+    _spec, experiment_id = await _register(session)
     reason_codes = [
         "insufficient_symbol_evidence",
         "rejected:insufficient_train_evidence",
@@ -431,7 +567,7 @@ async def test_stable_reason_codes_survive_round_trip_unmutated(
             timeframe="15m",
             runner="pytest",
             guard_opt_in_enabled=True,
-            guard_allowlist=_ALLOWLIST,
+            guard_policy=_POLICY,
         )
 
     trials = await reg.list_trials(session, experiment_id)
@@ -450,7 +586,7 @@ async def test_runner_name_over_16_chars_rejected_before_any_write(
     registry_tables,
 ) -> None:
     session = registry_tables
-    experiment_id = await _register(session)
+    _spec, experiment_id = await _register(session)
     before = await session.scalar(select(func.count()).select_from(ResearchBacktestRun))
 
     with pytest.raises(RunnerNameTooLongError):
@@ -462,7 +598,7 @@ async def test_runner_name_over_16_chars_rejected_before_any_write(
             timeframe="15m",
             runner="this-runner-name-is-way-too-long",
             guard_opt_in_enabled=True,
-            guard_allowlist=_ALLOWLIST,
+            guard_policy=_POLICY,
         )
 
     after = await session.scalar(select(func.count()).select_from(ResearchBacktestRun))
@@ -475,7 +611,7 @@ async def test_guard_disabled_rejects_attempt_recording_before_any_write(
     registry_tables,
 ) -> None:
     session = registry_tables
-    experiment_id = await _register(session)
+    _spec, experiment_id = await _register(session)
     before = await session.scalar(select(func.count()).select_from(ResearchBacktestRun))
 
     with pytest.raises(ResearchWriteDisabled):
@@ -487,7 +623,7 @@ async def test_guard_disabled_rejects_attempt_recording_before_any_write(
             timeframe="15m",
             runner="pytest",
             guard_opt_in_enabled=False,
-            guard_allowlist=_ALLOWLIST,
+            guard_policy=_POLICY,
         )
 
     after = await session.scalar(select(func.count()).select_from(ResearchBacktestRun))
@@ -504,7 +640,7 @@ async def test_concurrent_identical_replay_never_creates_a_duplicate_row(
     session_maker = async_sessionmaker(bind=engine, expire_on_commit=False)
 
     async with session_maker() as setup:
-        experiment_id = await _register(setup)
+        _spec, experiment_id = await _register(setup)
         await setup.commit()
 
     evidence = _evidence("camp1", experiment_id, run_identity="run-fixed")
@@ -519,7 +655,7 @@ async def test_concurrent_identical_replay_never_creates_a_duplicate_row(
                 timeframe="15m",
                 runner="pytest",
                 guard_opt_in_enabled=True,
-                guard_allowlist=_ALLOWLIST,
+                guard_policy=_POLICY,
             )
             index = row.trial_index
             await s.commit()
@@ -545,24 +681,16 @@ async def test_concurrent_identical_replay_never_creates_a_duplicate_row(
 # --------------------------------------------------------------------------- #
 
 
-async def _register_n(session, n: int) -> list[str]:
-    ids = []
-    for _ in range(n):
-        exp = await reg.register_experiment(session, _identity())
-        await session.flush()
-        ids.append(exp.experiment_id)
-    return ids
-
-
 @pytest.mark.integration
 @pytest.mark.asyncio
-async def test_completeness_reports_complete_when_all_24_have_any_terminal_status(
+async def test_completeness_reports_complete_when_all_24_have_a_primary_terminal_status(
     registry_tables,
 ) -> None:
     session = registry_tables
-    experiment_ids = await _register_n(session, 24)
+    registrations = await _register_n(session, 24)
+    specs = [spec for spec, _eid in registrations]
     statuses = ["completed", "rejected", "crashed", "timeout"]
-    for i, experiment_id in enumerate(experiment_ids):
+    for i, (_spec, experiment_id) in enumerate(registrations):
         status = statuses[i % 4]
         await record_attempt(
             session,
@@ -577,19 +705,24 @@ async def test_completeness_reports_complete_when_all_24_have_any_terminal_statu
             timeframe="15m",
             runner="pytest",
             guard_opt_in_enabled=True,
-            guard_allowlist=_ALLOWLIST,
+            guard_policy=_POLICY,
         )
 
     report = await campaign_completeness_report(
-        session, campaign_run_id="camp-complete", expected_experiment_ids=experiment_ids
+        session, campaign_run_id="camp-complete", expected_specs=specs
     )
 
     assert report.verdict == "complete"
     assert report.expected_total == 24
-    assert report.experiments_with_attempts == 24
+    assert report.actual_registrations == 24
+    assert report.primary_attempts == 24
+    assert report.total_attempts == 24
+    assert report.retry_attempts == 0
     assert sum(report.status_counts.values()) == 24
     assert report.missing_experiment_ids == []
-    assert report.duplicate_logical_attempts == []
+    assert report.extra_experiment_ids == []
+    assert report.mismatch_experiment_ids == []
+    assert report.duplicate_or_gap_experiment_ids == []
     # No winner-only filter: an all-crashed/rejected/timeout campaign is still
     # "complete" evidence — completed != PASS.
     assert report.status_counts["crashed"] >= 1
@@ -601,8 +734,9 @@ async def test_completeness_reports_incomplete_when_one_experiment_has_no_attemp
     registry_tables,
 ) -> None:
     session = registry_tables
-    experiment_ids = await _register_n(session, 24)
-    for experiment_id in experiment_ids[:-1]:
+    registrations = await _register_n(session, 24)
+    specs = [spec for spec, _eid in registrations]
+    for _spec, experiment_id in registrations[:-1]:
         await record_attempt(
             session,
             experiment_id=experiment_id,
@@ -611,25 +745,26 @@ async def test_completeness_reports_incomplete_when_one_experiment_has_no_attemp
             timeframe="15m",
             runner="pytest",
             guard_opt_in_enabled=True,
-            guard_allowlist=_ALLOWLIST,
+            guard_policy=_POLICY,
         )
 
     report = await campaign_completeness_report(
-        session, campaign_run_id="camp-missing", expected_experiment_ids=experiment_ids
+        session, campaign_run_id="camp-missing", expected_specs=specs
     )
 
     assert report.verdict == "incomplete"
-    assert report.missing_experiment_ids == [experiment_ids[-1]]
+    assert report.missing_experiment_ids == [registrations[-1][1]]
 
 
 @pytest.mark.integration
 @pytest.mark.asyncio
 async def test_completeness_rejects_wrong_expected_count_23(registry_tables) -> None:
     session = registry_tables
-    experiment_ids = await _register_n(session, 23)
+    registrations = await _register_n(session, 23)
+    specs = [spec for spec, _eid in registrations]
     with pytest.raises(CampaignSpecCountError):
         await campaign_completeness_report(
-            session, campaign_run_id="camp-23", expected_experiment_ids=experiment_ids
+            session, campaign_run_id="camp-23", expected_specs=specs
         )
 
 
@@ -637,12 +772,26 @@ async def test_completeness_rejects_wrong_expected_count_23(registry_tables) -> 
 @pytest.mark.asyncio
 async def test_completeness_rejects_wrong_expected_count_25(registry_tables) -> None:
     session = registry_tables
-    experiment_ids = await _register_n(session, 24)
+    registrations = await _register_n(session, 24)
+    specs = [spec for spec, _eid in registrations]
     with pytest.raises(CampaignSpecCountError):
         await campaign_completeness_report(
-            session,
-            campaign_run_id="camp-25",
-            expected_experiment_ids=[*experiment_ids, experiment_ids[0]],
+            session, campaign_run_id="camp-25", expected_specs=[*specs, specs[0]]
+        )
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_completeness_rejects_duplicate_expected_specs(registry_tables) -> None:
+    # 23 distinct + 1 EXACT duplicate of the first -- still 24 items in length
+    # but only 23 unique identities; must fail closed (never silently treat
+    # the duplicate as covering a 24th slot).
+    session = registry_tables
+    registrations = await _register_n(session, 23)
+    specs = [spec for spec, _eid in registrations]
+    with pytest.raises(bridge.CampaignDuplicateSpecError):
+        await campaign_completeness_report(
+            session, campaign_run_id="camp-dup", expected_specs=[*specs, specs[0]]
         )
 
 
@@ -650,8 +799,9 @@ async def test_completeness_rejects_wrong_expected_count_25(registry_tables) -> 
 @pytest.mark.asyncio
 async def test_completeness_distinguishes_retry_from_duplicate(registry_tables) -> None:
     session = registry_tables
-    experiment_ids = await _register_n(session, 24)
-    retried_id = experiment_ids[0]
+    registrations = await _register_n(session, 24)
+    specs = [spec for spec, _eid in registrations]
+    _retried_spec, retried_id = registrations[0]
 
     await record_attempt(
         session,
@@ -663,7 +813,7 @@ async def test_completeness_distinguishes_retry_from_duplicate(registry_tables) 
         timeframe="15m",
         runner="pytest",
         guard_opt_in_enabled=True,
-        guard_allowlist=_ALLOWLIST,
+        guard_policy=_POLICY,
     )
     await record_attempt(
         session,
@@ -673,9 +823,9 @@ async def test_completeness_distinguishes_retry_from_duplicate(registry_tables) 
         timeframe="15m",
         runner="pytest",
         guard_opt_in_enabled=True,
-        guard_allowlist=_ALLOWLIST,
+        guard_policy=_POLICY,
     )
-    for experiment_id in experiment_ids[1:]:
+    for _spec, experiment_id in registrations[1:]:
         await record_attempt(
             session,
             experiment_id=experiment_id,
@@ -684,16 +834,190 @@ async def test_completeness_distinguishes_retry_from_duplicate(registry_tables) 
             timeframe="15m",
             runner="pytest",
             guard_opt_in_enabled=True,
-            guard_allowlist=_ALLOWLIST,
+            guard_policy=_POLICY,
         )
 
     report = await campaign_completeness_report(
-        session, campaign_run_id="camp-retry", expected_experiment_ids=experiment_ids
+        session, campaign_run_id="camp-retry", expected_specs=specs
     )
 
     assert report.verdict == "complete"
-    assert report.duplicate_logical_attempts == []
-    assert report.experiments_with_attempts == 24
+    assert report.duplicate_or_gap_experiment_ids == []
+    assert report.primary_attempts == 24
     # both the retried crash AND the eventual completion are counted — 25 rows
     # total across 24 experiments, not treated as a duplicate.
+    assert report.total_attempts == 25
+    assert report.retry_attempts == 1
     assert sum(report.status_counts.values()) == 25
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_completeness_reports_incomplete_when_only_retry_1_exists_no_primary(
+    registry_tables,
+) -> None:
+    """R1 Important-3 reproduction/regression: an experiment with ONLY a
+    retry_index=1 attempt (no retry_index=0 primary) must be treated as
+    missing, never as satisfying completeness."""
+    session = registry_tables
+    registrations = await _register_n(session, 24)
+    specs = [spec for spec, _eid in registrations]
+    gapped_spec, gapped_id = registrations[0]
+
+    for _spec, experiment_id in registrations[1:]:
+        await record_attempt(
+            session,
+            experiment_id=experiment_id,
+            evidence=_evidence("camp-noprimary", experiment_id),
+            strategy_name="S1",
+            timeframe="15m",
+            runner="pytest",
+            guard_opt_in_enabled=True,
+            guard_policy=_POLICY,
+        )
+    await record_attempt(
+        session,
+        experiment_id=gapped_id,
+        evidence=_evidence(
+            "camp-noprimary", gapped_id, retry_index=1, status="completed"
+        ),
+        strategy_name="S1",
+        timeframe="15m",
+        runner="pytest",
+        guard_opt_in_enabled=True,
+        guard_policy=_POLICY,
+    )
+
+    report = await campaign_completeness_report(
+        session, campaign_run_id="camp-noprimary", expected_specs=specs
+    )
+    assert report.verdict == "incomplete"
+    assert gapped_id in report.missing_experiment_ids
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_completeness_reports_retry_gap_as_incomplete(registry_tables) -> None:
+    """retry_index 0 and 2 exist, 1 is missing -- a genuinely reachable gap
+    (distinct from the unreachable same-index-duplicate case)."""
+    session = registry_tables
+    registrations = await _register_n(session, 24)
+    specs = [spec for spec, _eid in registrations]
+    gapped_spec, gapped_id = registrations[0]
+
+    for _spec, experiment_id in registrations[1:]:
+        await record_attempt(
+            session,
+            experiment_id=experiment_id,
+            evidence=_evidence("camp-gap", experiment_id),
+            strategy_name="S1",
+            timeframe="15m",
+            runner="pytest",
+            guard_opt_in_enabled=True,
+            guard_policy=_POLICY,
+        )
+    await record_attempt(
+        session,
+        experiment_id=gapped_id,
+        evidence=_evidence(
+            "camp-gap", gapped_id, retry_index=0, status="crashed", reason_code="oom"
+        ),
+        strategy_name="S1",
+        timeframe="15m",
+        runner="pytest",
+        guard_opt_in_enabled=True,
+        guard_policy=_POLICY,
+    )
+    await record_attempt(
+        session,
+        experiment_id=gapped_id,
+        evidence=_evidence("camp-gap", gapped_id, retry_index=2, status="completed"),
+        strategy_name="S1",
+        timeframe="15m",
+        runner="pytest",
+        guard_opt_in_enabled=True,
+        guard_policy=_POLICY,
+    )
+
+    report = await campaign_completeness_report(
+        session, campaign_run_id="camp-gap", expected_specs=specs
+    )
+    assert report.verdict == "incomplete"
+    assert gapped_id in report.duplicate_or_gap_experiment_ids
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_completeness_surfaces_extra_registration(registry_tables) -> None:
+    """R1 Important-4 reproduction/regression: an unexpected 25th registered
+    experiment (same strategy_key scope) must surface as `extra`, not be
+    silently invisible."""
+    session = registry_tables
+    common_key = "ROB946-I4-SHARED-" + uuid.uuid4().hex[:8]
+    registrations = []
+    for i in range(24):
+        spec = _identity(config_id=f"S1-{i:02d}", strategy_key=common_key)
+        registrations.append(await _register(session, spec))
+    specs = [spec for spec, _eid in registrations]
+
+    stray_spec = _identity(config_id="S1-99", strategy_key=common_key)
+    stray_spec, stray_id = await _register(session, stray_spec)
+
+    report = await campaign_completeness_report(
+        session, campaign_run_id="camp-extra", expected_specs=specs
+    )
+    assert stray_id in report.extra_experiment_ids
+    assert report.verdict == "incomplete"
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_completeness_surfaces_identity_component_drift_as_mismatch(
+    registry_tables,
+) -> None:
+    """R1 Important-4 reproduction/regression: the SAME config_id slot (same
+    params_hash) is registered, but under a DIFFERENT overall identity (some
+    other component drifted) — must surface as `mismatch`, not `missing`."""
+    session = registry_tables
+    common_key = "ROB946-I4-DRIFT-" + uuid.uuid4().hex[:8]
+    expected_spec = _identity(config_id="S1-00", strategy_key=common_key)
+
+    # What actually got registered has the SAME params (same params_hash,
+    # same logical slot) but a DIFFERENT frozen_config -- a drifted identity.
+    drifted_spec = _identity(
+        config_id="S1-00",
+        strategy_key=common_key,
+        frozen_config={"timeframe": "5m"},  # differs from expected_spec's "15m"
+    )
+    _spec, drifted_id = await _register(session, drifted_spec)
+
+    other_specs = [
+        _identity(config_id=f"S1-{i:02d}", strategy_key=common_key)
+        for i in range(1, 24)
+    ]
+    for spec in other_specs:
+        await _register(session, spec)
+
+    from app.services.research_canonical_hash import (
+        compute_identity_hashes,
+        derive_experiment_id,
+    )
+
+    expected_id = derive_experiment_id(
+        expected_spec.strategy_key,
+        expected_spec.strategy_version,
+        compute_identity_hashes(expected_spec.components()),
+    )
+    assert expected_id != drifted_id  # the drift IS the point
+
+    report = await campaign_completeness_report(
+        session,
+        campaign_run_id="camp-drift",
+        expected_specs=[expected_spec, *other_specs],
+    )
+    # mismatch_experiment_ids names the EXPECTED slot whose registration
+    # drifted (symmetric with missing_experiment_ids), not the actual
+    # drifted row's own id.
+    assert expected_id in report.mismatch_experiment_ids
+    assert expected_id not in report.missing_experiment_ids
+    assert report.verdict == "incomplete"

--- a/tests/services/research/test_research_db_write_guard.py
+++ b/tests/services/research/test_research_db_write_guard.py
@@ -2,12 +2,17 @@
 
 The guard is the FIRST of two independent conditions ROB-946 §7 requires
 before any registry write primitive fires: (1) explicit default-off opt-in,
-(2) a typed/allowlisted non-production research DB target. Neither condition
-is derived from ``ENVIRONMENT != "production"``, a URL substring, or an
-unknown/empty/malformed/deceptive target — every one of those must fail
-closed. The guard is pure/dependency-injected: it never reads ``os.environ``
-or a live DB connection itself, so it is trivially testable and cannot be
-fooled by ambient process state.
+(2) a typed/authority-owned non-production research DB target. Neither
+condition is satisfied by ``ENVIRONMENT != "production"``, a URL substring, a
+bare database-name allowlist, or an empty/unknown/malformed/deceptive target
+— every one of those must fail closed.
+
+R1 Critical-1 remediation: a bare database name (e.g. ``test_db``) cannot
+distinguish a disposable local fixture from a production cluster sharing the
+same name. ``ResearchDbTarget`` now binds host+database together, and
+authorization requires a positive EXACT match against a ``ResearchDbPolicy``
+— a closed, validated set of real (host, database) pairs, not a caller-
+supplied ``frozenset[str]`` a bridge caller could self-issue.
 """
 
 from __future__ import annotations
@@ -15,72 +20,121 @@ from __future__ import annotations
 import pytest
 
 from app.services.research_db_write_guard import (
+    ResearchDbPolicy,
     ResearchDbTarget,
     ResearchDbTargetRejected,
     ResearchWriteDisabled,
     assert_research_write_authorized,
+    default_research_db_policy,
     research_write_opt_in_enabled,
     resolve_research_db_target,
 )
 
-_ALLOWLIST = frozenset({"test_db"})
+_DISPOSABLE_TARGET = ResearchDbTarget(host="localhost", database_name="test_db")
+_POLICY = ResearchDbPolicy.of(_DISPOSABLE_TARGET)
 
 
-def test_opt_in_disabled_rejects_even_with_allowlisted_target():
+def test_opt_in_disabled_rejects_even_with_authorized_target():
     with pytest.raises(ResearchWriteDisabled):
         assert_research_write_authorized(
-            opt_in_enabled=False,
-            target=ResearchDbTarget(database_name="test_db"),
-            allowlist=_ALLOWLIST,
+            opt_in_enabled=False, target=_DISPOSABLE_TARGET, policy=_POLICY
         )
 
 
-def test_opt_in_enabled_and_allowlisted_target_is_authorized():
+def test_opt_in_enabled_and_positively_matched_target_is_authorized():
     assert_research_write_authorized(
-        opt_in_enabled=True,
-        target=ResearchDbTarget(database_name="test_db"),
-        allowlist=_ALLOWLIST,
+        opt_in_enabled=True, target=_DISPOSABLE_TARGET, policy=_POLICY
     )  # must not raise
 
 
-def test_opt_in_enabled_but_unlisted_target_rejected():
+def test_production_host_with_allowlisted_bare_database_name_is_rejected():
+    # R1 Critical-1 reproduction: the database is named identically to the
+    # disposable target, but the HOST is a production cluster — must reject.
+    production_target = ResearchDbTarget(
+        host="prod-primary.internal.example", database_name="test_db"
+    )
     with pytest.raises(ResearchDbTargetRejected):
         assert_research_write_authorized(
-            opt_in_enabled=True,
-            target=ResearchDbTarget(database_name="auto_trader_production"),
-            allowlist=_ALLOWLIST,
+            opt_in_enabled=True, target=production_target, policy=_POLICY
         )
 
 
-def test_empty_database_name_rejected_even_when_opted_in():
+def test_staging_host_with_allowlisted_database_name_is_rejected():
+    staging_target = ResearchDbTarget(
+        host="staging-db.internal.example", database_name="test_db"
+    )
     with pytest.raises(ResearchDbTargetRejected):
         assert_research_write_authorized(
-            opt_in_enabled=True,
-            target=ResearchDbTarget(database_name=""),
-            allowlist=_ALLOWLIST,
+            opt_in_enabled=True, target=staging_target, policy=_POLICY
         )
 
 
-def test_deceptive_substring_target_is_not_accepted_by_substring_match():
-    # "nottest_db" and "test_db_2" both CONTAIN the allowlisted name as a
-    # substring; only an EXACT match may pass — proves the guard is not doing
-    # substring/prefix matching that a deceptive name could slip through.
-    for deceptive in ("nottest_db", "test_db_2", "TEST_DB"):
+def test_unknown_host_and_database_never_defaults_to_authorized():
+    with pytest.raises(ResearchDbTargetRejected):
+        assert_research_write_authorized(
+            opt_in_enabled=True,
+            target=ResearchDbTarget(host="some-unknown-host", database_name="some_db"),
+            policy=_POLICY,
+        )
+
+
+def test_correct_host_but_wrong_database_is_rejected():
+    with pytest.raises(ResearchDbTargetRejected):
+        assert_research_write_authorized(
+            opt_in_enabled=True,
+            target=ResearchDbTarget(host="localhost", database_name="production"),
+            policy=_POLICY,
+        )
+
+
+def test_correct_database_but_missing_host_is_rejected():
+    with pytest.raises(ResearchDbTargetRejected):
+        assert_research_write_authorized(
+            opt_in_enabled=True,
+            target=ResearchDbTarget(host="", database_name="test_db"),
+            policy=_POLICY,
+        )
+
+
+def test_deceptive_lookalike_host_is_not_accepted_by_substring_match():
+    # "localhost.evil.example" and "notlocalhost" both relate textually to
+    # "localhost"; only an EXACT match may pass.
+    for deceptive_host in ("localhost.evil.example", "notlocalhost", "LOCALHOST."):
         with pytest.raises(ResearchDbTargetRejected):
             assert_research_write_authorized(
                 opt_in_enabled=True,
-                target=ResearchDbTarget(database_name=deceptive),
-                allowlist=_ALLOWLIST,
+                target=ResearchDbTarget(host=deceptive_host, database_name="test_db"),
+                policy=_POLICY,
             )
 
 
-def test_unknown_target_never_defaults_to_authorized():
-    with pytest.raises(ResearchDbTargetRejected):
-        assert_research_write_authorized(
-            opt_in_enabled=True,
-            target=ResearchDbTarget(database_name="some_unknown_db"),
-            allowlist=_ALLOWLIST,
-        )
+def test_host_case_and_whitespace_are_normalized_for_a_true_match():
+    messy_target = ResearchDbTarget(host="  LOCALHOST  ", database_name="test_db")
+    assert_research_write_authorized(
+        opt_in_enabled=True, target=messy_target, policy=_POLICY
+    )  # must not raise -- normalization, not a security hole
+
+
+def test_policy_cannot_be_constructed_empty():
+    with pytest.raises(ValueError):
+        ResearchDbPolicy.of()
+
+
+def test_policy_rejects_malformed_targets_at_construction():
+    with pytest.raises(ValueError):
+        ResearchDbPolicy.of(ResearchDbTarget(host="localhost", database_name=""))
+    with pytest.raises(ValueError):
+        ResearchDbPolicy.of(ResearchDbTarget(host="", database_name="test_db"))
+
+
+def test_default_research_db_policy_only_authorizes_the_one_known_local_target():
+    policy = default_research_db_policy()
+    assert policy.authorizes(
+        ResearchDbTarget(host="localhost", database_name="test_db")
+    )
+    assert not policy.authorizes(
+        ResearchDbTarget(host="prod-primary.internal.example", database_name="test_db")
+    )
 
 
 @pytest.mark.parametrize("raw", ["1", "true", "True", "TRUE", "yes", "on"])
@@ -96,6 +150,7 @@ def test_opt_in_falsy_values(raw):
 def test_resolve_research_db_target_reads_actual_session_bind_not_a_caller_label():
     class _FakeURL:
         database = "test_db"
+        host = "localhost"
 
     class _FakeBind:
         url = _FakeURL()
@@ -105,15 +160,35 @@ def test_resolve_research_db_target_reads_actual_session_bind_not_a_caller_label
             return _FakeBind()
 
     target = resolve_research_db_target(_FakeSession())
-    assert target == ResearchDbTarget(database_name="test_db")
+    assert target == ResearchDbTarget(host="localhost", database_name="test_db")
+
+
+def test_resolve_research_db_target_on_a_production_looking_bind_carries_that_host_through():
+    class _FakeURL:
+        database = "test_db"
+        host = "prod-primary.internal.example"
+
+    class _FakeBind:
+        url = _FakeURL()
+
+    class _FakeSession:
+        def get_bind(self):
+            return _FakeBind()
+
+    target = resolve_research_db_target(_FakeSession())
+    assert target.host == "prod-primary.internal.example"
+    with pytest.raises(ResearchDbTargetRejected):
+        assert_research_write_authorized(
+            opt_in_enabled=True, target=target, policy=_POLICY
+        )
 
 
 def test_error_messages_never_contain_dsn_or_password_shaped_text():
     try:
         assert_research_write_authorized(
             opt_in_enabled=True,
-            target=ResearchDbTarget(database_name="production"),
-            allowlist=_ALLOWLIST,
+            target=ResearchDbTarget(host="prod.example", database_name="production"),
+            policy=_POLICY,
         )
     except ResearchDbTargetRejected as exc:
         message = str(exc)

--- a/tests/services/research/test_research_db_write_guard.py
+++ b/tests/services/research/test_research_db_write_guard.py
@@ -1,0 +1,121 @@
+"""ROB-946 (H6) — research DB write guard: RED-first coverage.
+
+The guard is the FIRST of two independent conditions ROB-946 §7 requires
+before any registry write primitive fires: (1) explicit default-off opt-in,
+(2) a typed/allowlisted non-production research DB target. Neither condition
+is derived from ``ENVIRONMENT != "production"``, a URL substring, or an
+unknown/empty/malformed/deceptive target — every one of those must fail
+closed. The guard is pure/dependency-injected: it never reads ``os.environ``
+or a live DB connection itself, so it is trivially testable and cannot be
+fooled by ambient process state.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.services.research_db_write_guard import (
+    ResearchDbTarget,
+    ResearchDbTargetRejected,
+    ResearchWriteDisabled,
+    assert_research_write_authorized,
+    research_write_opt_in_enabled,
+    resolve_research_db_target,
+)
+
+_ALLOWLIST = frozenset({"test_db"})
+
+
+def test_opt_in_disabled_rejects_even_with_allowlisted_target():
+    with pytest.raises(ResearchWriteDisabled):
+        assert_research_write_authorized(
+            opt_in_enabled=False,
+            target=ResearchDbTarget(database_name="test_db"),
+            allowlist=_ALLOWLIST,
+        )
+
+
+def test_opt_in_enabled_and_allowlisted_target_is_authorized():
+    assert_research_write_authorized(
+        opt_in_enabled=True,
+        target=ResearchDbTarget(database_name="test_db"),
+        allowlist=_ALLOWLIST,
+    )  # must not raise
+
+
+def test_opt_in_enabled_but_unlisted_target_rejected():
+    with pytest.raises(ResearchDbTargetRejected):
+        assert_research_write_authorized(
+            opt_in_enabled=True,
+            target=ResearchDbTarget(database_name="auto_trader_production"),
+            allowlist=_ALLOWLIST,
+        )
+
+
+def test_empty_database_name_rejected_even_when_opted_in():
+    with pytest.raises(ResearchDbTargetRejected):
+        assert_research_write_authorized(
+            opt_in_enabled=True,
+            target=ResearchDbTarget(database_name=""),
+            allowlist=_ALLOWLIST,
+        )
+
+
+def test_deceptive_substring_target_is_not_accepted_by_substring_match():
+    # "nottest_db" and "test_db_2" both CONTAIN the allowlisted name as a
+    # substring; only an EXACT match may pass — proves the guard is not doing
+    # substring/prefix matching that a deceptive name could slip through.
+    for deceptive in ("nottest_db", "test_db_2", "TEST_DB"):
+        with pytest.raises(ResearchDbTargetRejected):
+            assert_research_write_authorized(
+                opt_in_enabled=True,
+                target=ResearchDbTarget(database_name=deceptive),
+                allowlist=_ALLOWLIST,
+            )
+
+
+def test_unknown_target_never_defaults_to_authorized():
+    with pytest.raises(ResearchDbTargetRejected):
+        assert_research_write_authorized(
+            opt_in_enabled=True,
+            target=ResearchDbTarget(database_name="some_unknown_db"),
+            allowlist=_ALLOWLIST,
+        )
+
+
+@pytest.mark.parametrize("raw", ["1", "true", "True", "TRUE", "yes", "on"])
+def test_opt_in_truthy_values(raw):
+    assert research_write_opt_in_enabled(raw) is True
+
+
+@pytest.mark.parametrize("raw", [None, "", "0", "false", "False", "no", "off", "nope"])
+def test_opt_in_falsy_values(raw):
+    assert research_write_opt_in_enabled(raw) is False
+
+
+def test_resolve_research_db_target_reads_actual_session_bind_not_a_caller_label():
+    class _FakeURL:
+        database = "test_db"
+
+    class _FakeBind:
+        url = _FakeURL()
+
+    class _FakeSession:
+        def get_bind(self):
+            return _FakeBind()
+
+    target = resolve_research_db_target(_FakeSession())
+    assert target == ResearchDbTarget(database_name="test_db")
+
+
+def test_error_messages_never_contain_dsn_or_password_shaped_text():
+    try:
+        assert_research_write_authorized(
+            opt_in_enabled=True,
+            target=ResearchDbTarget(database_name="production"),
+            allowlist=_ALLOWLIST,
+        )
+    except ResearchDbTargetRejected as exc:
+        message = str(exc)
+        assert "://" not in message
+        assert "password" not in message.lower()


### PR DESCRIPTION
## Summary

Implements H6 of the ROB-940 coin auto-trade strategy epic: the app-side bridge between an injected ROB-940 24-experiment campaign identity and the ROB-846 immutable strategy-experiment registry, plus a pure/generic campaign-identity builder on the research side.

- **DB write guard** (`app/services/research_db_write_guard.py`): pure, dependency-injected. Requires (1) an explicit opt-in flag resolved by the caller from a real env var and (2) an exact-allowlist match on the actual resolved DB target (`session.get_bind().url.database`) — never `ENVIRONMENT != production`, a URL substring, or an unknown/empty/deceptive target.
- **Campaign bridge** (`app/services/research_campaign_bridge.py`): registers exactly 24 `StrategyExperimentIdentity` specs (guard-first, before spec-count inspection); hardens ROB-846's raw `record_trial` idempotency by fingerprinting *all* terminal evidence (status/reason/fold hash/run identity/per-scenario trade counts+hashes) and failing closed on any mismatch instead of silently replaying a stale row; preserves the 13/17/22bp cost-scenario ledgers as three independent, non-collapsed entries per attempt; and reports campaign completeness (24 expected vs missing/duplicate/status counts) with no winner-only filter.
- **Pure campaign-identity builder** (`research/nautilus_scalping/rob946_campaign_identity.py`): generic and manifest-injected — does not hardcode the production 24-row manifest (that remains H3's authority once merged). Enforces params-only variation within a strategy's 12 rows, S1/S2 strategy_key/version/source-hash separation (with stale-source-hash fail-closed re-verification), and exact ROB-941 corpus-manifest content-hash verification (`4bcc2da9...9351`, confirmed against the committed manifest).
- AST import guards extended: the new app-side bridge/guard/schema files must not import broker/order/fill/ledger/scheduler (taskiq/celery/prefect/apscheduler added to the forbidden-substring list); the new research-side module must not import `app.*`.

## Test plan
- [x] RED confirmed for every new module before implementation (ImportError/ModuleNotFoundError, not typos)
- [x] `pytest tests/services/research/` — 245 passed (includes full ROB-846 regression + all new H6 tests)
- [x] `pytest research/nautilus_scalping/tests/` — 614 passed, 4 skipped, 7 failed (pre-existing, unrelated: `test_rob382_*`/`test_pit_klines_fetcher` missing local 5m fixture data)
- [x] `ruff check` / `ruff format --check` / `ty check` all clean on touched files
- [x] Manual verification: independently recomputed the committed ROB-941 manifest's `content_hash()` and confirmed it equals `4bcc2da979b47caa45b5f90a09c326aefff91fa605e110d55ef316d53c9a9351`
- [x] Zero production/external DB writes; zero broker/order/fill/execution-ledger/scheduler/ROB-905 imports or wiring; zero existing ROB-846 rows/model/migration/`FROZEN_CONFIG` touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)