### PR TITLE
feat(ROB-951): add KIS mock US cash probe

### DIFF
--- a/docs/runbooks/kis-mock-us-cash-probe.md
+++ b/docs/runbooks/kis-mock-us-cash-probe.md
@@ -1,0 +1,88 @@
+# KIS mock US 현금 조회 TR probe (ROB-951)
+
+`scripts/kis_mock_us_cash_probe.py`는 KIS 모의 서버가 다음 **조회 전용** TR을
+실제로 지원하는지 측정하는 default-disabled 진단 도구다.
+
+- `VTTS3007R` — 해외주식 매수가능금액조회
+- `VTTC0869R` — 통합증거금조회
+
+이는 배선이나 주문 도구가 아니다. **이 스크립트는 주문·정정·취소 API를 절대
+호출하지 않는다.** 두 대상은 모두 고정된 `GET` 조회 endpoint이고, 스크립트에는
+주문 endpoint/TR 또는 broker mutation 경로가 없다.
+
+이 위치를 새 런북으로 선택했다. 인접 `kis-mock-*.md` 런북들은 보유·주문 smoke의
+운영 절차이고, 이 문서는 아직 확정되지 않은 두 cash TR의 독립 증거를 기록한다.
+
+## 안전 게이트와 사전 조건
+
+기본값은 비활성이다. 아래 전용 게이트가 정확히 `true`가 아니면 스크립트는 즉시
+exit 0으로 끝나며 KIS client, 토큰, HTTP 요청을 만들지 않는다.
+
+```bash
+KIS_MOCK_US_CASH_PROBE_ENABLED=true
+```
+
+명시 실행 시에는 다음 기존 KIS mock credential이 필요하다. 누락 시 값이 아니라
+**키 이름만** 출력하고 exit 3으로 끝난다.
+
+```bash
+KIS_MOCK_APP_KEY=...
+KIS_MOCK_APP_SECRET=...
+KIS_MOCK_ACCOUNT_NO=12345678-01
+```
+
+실행은 캡틴/운영자 지시가 있을 때만 한다. 이 PR에서는 실행하지 않는다.
+
+## 실행
+
+```bash
+# 기본 preflight: HTTP 요청 없음
+uv run python -m scripts.kis_mock_us_cash_probe
+
+# 최우선 후보: mock 해외 매수가능금액조회
+KIS_MOCK_US_CASH_PROBE_ENABLED=true uv run python -m \
+  scripts.kis_mock_us_cash_probe --tr vtts3007
+
+# mock 통합증거금조회
+KIS_MOCK_US_CASH_PROBE_ENABLED=true uv run python -m \
+  scripts.kis_mock_us_cash_probe --tr vttc0869
+
+# 둘 다: 순차 실행하며 호출 사이 0.25초 간격을 둠
+KIS_MOCK_US_CASH_PROBE_ENABLED=true uv run python -m \
+  scripts.kis_mock_us_cash_probe --tr both
+```
+
+각 호출은 JSON evidence 한 줄로 `http_status`, 원문 `rt_cd` / `msg_cd` /
+`msg1`, 파싱한 `stck_cash_ord_psbl_amt`, `usd_ord_psbl_amt`, `usd_balance`,
+해외 주문가능금액 후보를 출력한다. 필드가 없으면 `null`로 남긴다. 성공으로
+추정하거나 0으로 보정하지 않는다.
+
+`raw_response_redacted`는 기존 `redact_broker_response`를 재사용하고, KIS
+계좌 필드(`CANO`, `ACNT_PRDT_CD`)와 현재 설정된 계좌/앱키/앱시크릿/토큰의 echo를
+추가 마스킹한다. 따라서 운영 로그에는 비밀값이나 계좌번호를 남기지 않는다.
+
+## 판정과 exit code
+
+| 관측 | 결론 | exit |
+|---|---|---:|
+| HTTP 응답 + `rt_cd="0"` | 해당 mock TR은 서버가 수락했다. cash 필드는 출력값으로 별도 확인한다. | 0 |
+| HTTP 응답 + `rt_cd!="0"` 또는 KIS `msg_cd`/`msg1` 거부 | broker가 요청을 거부했다. `msg_cd`/`msg1` 원문을 ROB-951 증거로 기록한다. 이는 crash가 아닌 정상 판정 종결이다. | 2 |
+| credential 누락 | 실행 전 구성 불충분; 서버 지원 여부는 미판정 | 3 |
+| 연결/토큰/비JSON 등 응답 전송 실패 | 서버 지원 여부 미판정; `http_status=null`과 오류를 기록 | 1 |
+| gate 비활성 또는 `--tr` 미선택 preflight | HTTP 요청 없음 | 0 |
+
+`VTTS3007R`가 `rt_cd="0"`이더라도 KRW 자동환전 주문 경로가 가능하다는 뜻은
+아니다. `VTTC0869R`가 성공하더라도 `stck_cash_ord_psbl_amt` 계열 및
+`usd_ord_psbl_amt` / `usd_balance`의 실제 값이 비어 있지 않은지를 별도로 보며,
+환율·capability 배선은 후속 결정이다.
+
+## 구현 경계
+
+`KISClient(is_mock=True)`의 `_ensure_token()`과 `_request_with_rate_limit()`을
+직접 사용한다. 이는 기존 rate limit, mock credential view, token cache를 보존한다.
+`AccountClient.inquire_integrated_margin(is_mock=True)`는 의도적으로 호출하지
+않는다. 해당 상위 래퍼는 mock에서 전송 전 fail-close 하며, 이 probe의 목적은 바로
+`VTTC0869R`의 서버 측 지원을 별도로 측정하는 것이기 때문이다.
+
+이 도구의 결과가 나오기 전에는 `app/services/brokers/kis/account.py`의 mock
+integrated-margin fail-close 게이트와 그 회귀 테스트를 변경하지 않는다.

--- a/scripts/kis_mock_us_cash_probe.py
+++ b/scripts/kis_mock_us_cash_probe.py
@@ -1,0 +1,366 @@
+#!/usr/bin/env python3
+"""Read-only KIS mock US cash-TR probe for ROB-951.
+
+This script is default-disabled and has no order, modify, or cancel code path.
+When an operator explicitly enables it, it sends only the two GET inquiry TRs
+needed to measure KIS mock support: VTTS3007R and VTTC0869R.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import re
+import sys
+from collections.abc import Awaitable, Callable, Mapping
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+PROBE_ENABLE_ENV = "KIS_MOCK_US_CASH_PROBE_ENABLED"
+REQUIRED_MOCK_ENV: tuple[str, ...] = (
+    "KIS_MOCK_APP_KEY",
+    "KIS_MOCK_APP_SECRET",
+    "KIS_MOCK_ACCOUNT_NO",
+)
+_READ_ONLY_PACING_SECONDS = 0.25
+_REDACTED = "[REDACTED]"
+_SENSITIVE_TEXT = re.compile(
+    r"(?i)(authorization|bearer|access[_ -]?token|app[_ -]?(?:key|secret)|"
+    r"account(?:[_ -]?(?:no|number))?|cano)\\s*[:=]\\s*[^,\\s}]+"
+)
+
+
+@dataclass(frozen=True)
+class ProbeTarget:
+    key: str
+    label: str
+    tr_id: str
+    path: str
+
+    def params(self, *, cano: str, product_code: str) -> dict[str, str]:
+        if self.key == "vtts3007":
+            # A non-ordering reference quote only; this endpoint calculates
+            # buying power and does not submit an order.
+            return {
+                "CANO": cano,
+                "ACNT_PRDT_CD": product_code,
+                "OVRS_EXCG_CD": "NASD",
+                "OVRS_ORD_UNPR": "1",
+                "ITEM_CD": "AAPL",
+            }
+        return {
+            "CANO": cano,
+            "ACNT_PRDT_CD": product_code,
+            "CMA_EVLU_AMT_ICLD_YN": "N",
+            "WCRC_FRCR_DVSN_CD": "01",
+            "FWEX_CTRT_FRCR_DVSN_CD": "01",
+        }
+
+
+TARGETS: dict[str, ProbeTarget] = {
+    "vtts3007": ProbeTarget(
+        key="vtts3007",
+        label="overseas buyable amount",
+        tr_id="VTTS3007R",
+        path="/uapi/overseas-stock/v1/trading/inquire-psamount",
+    ),
+    "vttc0869": ProbeTarget(
+        key="vttc0869",
+        label="integrated margin",
+        tr_id="VTTC0869R",
+        path="/uapi/domestic-stock/v1/trading/intgr-margin",
+    ),
+}
+
+
+class ProbeTransport(Protocol):
+    secret_values: tuple[str, ...]
+
+    async def request(self, target: ProbeTarget) -> tuple[int | None, dict[str, Any]]:
+        """Dispatch exactly one read-only request and return status plus JSON."""
+
+
+def probe_enabled(environ: Mapping[str, str] | None = None) -> bool:
+    value = (environ or os.environ).get(PROBE_ENABLE_ENV, "")
+    return value.strip().lower() == "true"
+
+
+def missing_mock_credential_names(
+    environ: Mapping[str, str] | None = None,
+) -> list[str]:
+    values = environ or os.environ
+    return [name for name in REQUIRED_MOCK_ENV if not values.get(name, "").strip()]
+
+
+def _account_parts(account_no: str) -> tuple[str, str]:
+    compact = account_no.strip().replace("-", "")
+    if len(compact) < 3 or not compact.isdigit():
+        raise ValueError(
+            "KIS_MOCK_ACCOUNT_NO must be digits with an account product code"
+        )
+    return compact[:-2], compact[-2:]
+
+
+class KISReadOnlyTransport:
+    """Adapter that preserves KISClient token and rate-limit machinery."""
+
+    def __init__(self) -> None:
+        from app.services.brokers.kis import constants
+        from app.services.brokers.kis.client import KISClient
+
+        self._client = KISClient(is_mock=True)
+        self._constants = constants
+        self._account_no = str(self._client._settings.kis_account_no or "")
+        self.secret_values = tuple(
+            value
+            for value in (
+                self._account_no,
+                str(self._client._settings.kis_app_key or ""),
+                str(self._client._settings.kis_app_secret or ""),
+                str(self._client._settings.kis_access_token or ""),
+            )
+            if value
+        )
+
+    async def request(self, target: ProbeTarget) -> tuple[int | None, dict[str, Any]]:
+        import httpx
+
+        expected_tr = (
+            self._constants.OVERSEAS_BUYABLE_AMOUNT_TR_MOCK
+            if target.key == "vtts3007"
+            else self._constants.INTEGRATED_MARGIN_TR_MOCK
+        )
+        expected_path = (
+            self._constants.OVERSEAS_BUYABLE_AMOUNT_URL
+            if target.key == "vtts3007"
+            else self._constants.INTEGRATED_MARGIN_URL
+        )
+        if target.tr_id != expected_tr or target.path != expected_path:
+            raise RuntimeError(
+                "probe target does not match the KIS read-only constants"
+            )
+
+        # Deliberately bypasses AccountClient.inquire_integrated_margin(): that
+        # production wrapper fail-closes mock mode before token/TR selection.
+        await self._client._ensure_token()
+        cano, product_code = _account_parts(self._account_no)
+        headers = self._client._hdr_base | {
+            "authorization": f"Bearer {self._client._settings.kis_access_token}",
+            "tr_id": target.tr_id,
+        }
+        status_code: int | None = None
+        original_execute = self._client._execute_http_request
+
+        async def capture_status(*args: Any, **kwargs: Any) -> Any:
+            nonlocal status_code
+            response = await original_execute(*args, **kwargs)
+            status_code = response.status_code
+            return response
+
+        self._client._execute_http_request = capture_status
+        try:
+            try:
+                payload = await self._client._request_with_rate_limit(
+                    "GET",
+                    self._client._kis_url(target.path),
+                    headers=headers,
+                    params=target.params(cano=cano, product_code=product_code),
+                    timeout=10,
+                    api_name=f"rob_951_{target.key}_probe",
+                    tr_id=target.tr_id,
+                )
+            except httpx.HTTPStatusError as exc:
+                status_code = exc.response.status_code
+                try:
+                    body = exc.response.json()
+                except ValueError:
+                    body = {"msg1": "non-JSON HTTP error response"}
+                payload = body if isinstance(body, dict) else {"msg1": str(body)}
+        finally:
+            self._client._execute_http_request = original_execute
+        return status_code, payload
+
+
+def redact_payload(payload: Any, *, secret_values: tuple[str, ...]) -> Any:
+    """Use existing broker-key redaction, then mask known credential echoes."""
+    from app.services.brokers.kiwoom.normalization import redact_broker_response
+
+    def scrub(value: Any) -> Any:
+        if isinstance(value, Mapping):
+            result: dict[str, Any] = {}
+            for key, item in value.items():
+                normalized_key = re.sub(r"[^a-z0-9]", "", str(key).lower())
+                if normalized_key in {"cano", "acntprdtcd"}:
+                    result[str(key)] = _REDACTED
+                else:
+                    result[str(key)] = scrub(item)
+            return result
+        if isinstance(value, list | tuple):
+            return [scrub(item) for item in value]
+        if not isinstance(value, str):
+            return value
+        redacted = value
+        for secret in secret_values:
+            if secret:
+                redacted = redacted.replace(secret, _REDACTED)
+                redacted = redacted.replace(secret.replace("-", ""), _REDACTED)
+        return _SENSITIVE_TEXT.sub(_REDACTED, redacted)
+
+    if isinstance(payload, Mapping):
+        return scrub(redact_broker_response(dict(payload)))
+    return scrub(payload)
+
+
+def _first_field(payload: Mapping[str, Any], names: tuple[str, ...]) -> Any:
+    containers = [payload]
+    for key in ("output", "output1", "output2"):
+        value = payload.get(key)
+        if isinstance(value, Mapping):
+            containers.append(value)
+    for name in names:
+        for container in containers:
+            value = container.get(name)
+            if value not in (None, ""):
+                return value
+    return None
+
+
+def parse_cash_fields(payload: Mapping[str, Any]) -> dict[str, Any]:
+    """Expose parsed field values or null; absence is evidence, not success."""
+    fields = {
+        "stck_cash_ord_psbl_amt": ("stck_cash_ord_psbl_amt",),
+        "usd_ord_psbl_amt": ("usd_ord_psbl_amt",),
+        "usd_balance": ("usd_balance",),
+        "overseas_orderable_amount": (
+            "ovrs_ord_psbl_amt",
+            "frcr_ord_psbl_amt",
+            "frcr_ord_psbl_amt1",
+        ),
+    }
+    return {
+        name: _first_field(payload, candidates) for name, candidates in fields.items()
+    }
+
+
+def evaluate_response(
+    http_status: int | None, payload: Mapping[str, Any]
+) -> tuple[int, str]:
+    if str(payload.get("rt_cd", "")) == "0":
+        return 0, "supported"
+    if http_status is not None or any(
+        key in payload for key in ("rt_cd", "msg_cd", "msg1")
+    ):
+        return 2, "broker_rejected_or_not_supported"
+    return 1, "unclassified_transport_result"
+
+
+def _emit_result(
+    *,
+    target: ProbeTarget,
+    http_status: int | None,
+    payload: dict[str, Any],
+    secrets: tuple[str, ...],
+) -> tuple[int, str]:
+    code, verdict = evaluate_response(http_status, payload)
+    evidence = {
+        "target": target.key,
+        "tr_id": target.tr_id,
+        "http_status": http_status,
+        "rt_cd": payload.get("rt_cd"),
+        "msg_cd": payload.get("msg_cd"),
+        "msg1": payload.get("msg1"),
+        "parsed_cash_fields": parse_cash_fields(payload),
+        "verdict": verdict,
+        "raw_response_redacted": redact_payload(payload, secret_values=secrets),
+    }
+    print(json.dumps(evidence, ensure_ascii=False, default=str))
+    return code, verdict
+
+
+async def run_probe(
+    *,
+    selected: str,
+    transport_factory: Callable[[], ProbeTransport] = KISReadOnlyTransport,
+    sleep: Callable[[float], Awaitable[Any]] = asyncio.sleep,
+) -> int:
+    if not probe_enabled():
+        print(
+            f"[probe] disabled: set {PROBE_ENABLE_ENV}=true to permit read-only TR calls"
+        )
+        return 0
+
+    missing = missing_mock_credential_names()
+    if missing:
+        print(
+            f"[probe] missing KIS mock credentials: {', '.join(missing)} (names only)"
+        )
+        return 3
+
+    if selected == "preflight":
+        print("[probe] preflight only: no --tr selected; no broker request sent")
+        return 0
+
+    keys = tuple(TARGETS) if selected == "both" else (selected,)
+    transport = transport_factory()
+    exit_code = 0
+    for index, key in enumerate(keys):
+        if index:
+            await sleep(_READ_ONLY_PACING_SECONDS)
+        target = TARGETS[key]
+        try:
+            status, payload = await transport.request(target)
+        except Exception as exc:  # noqa: BLE001 - diagnostic script must not pretend success
+            print(
+                json.dumps(
+                    {
+                        "target": target.key,
+                        "tr_id": target.tr_id,
+                        "http_status": None,
+                        "error_type": type(exc).__name__,
+                        "error": redact_payload(
+                            str(exc), secret_values=transport.secret_values
+                        ),
+                        "verdict": "transport_or_setup_error",
+                    },
+                    ensure_ascii=False,
+                )
+            )
+            exit_code = max(exit_code, 1)
+            continue
+        code, _ = _emit_result(
+            target=target,
+            http_status=status,
+            payload=payload,
+            secrets=transport.secret_values,
+        )
+        exit_code = max(exit_code, code)
+    return exit_code
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="kis_mock_us_cash_probe",
+        description="ROB-951 KIS mock US cash read-only TR probe (default-disabled)",
+    )
+    parser.add_argument(
+        "--tr",
+        choices=("preflight", "vtts3007", "vttc0869", "both"),
+        default="preflight",
+        help="TR to probe; default preflight makes no broker request",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_arg_parser().parse_args(argv)
+    try:
+        return asyncio.run(run_probe(selected=args.tr))
+    except KeyboardInterrupt:
+        print("[probe] interrupted")
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_kis_mock_us_cash_probe.py
+++ b/tests/test_kis_mock_us_cash_probe.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+import importlib
+from typing import Any
+
+import pytest
+
+
+@pytest.fixture
+def probe_module():
+    return importlib.import_module("scripts.kis_mock_us_cash_probe")
+
+
+class FakeTransport:
+    def __init__(self, replies: dict[str, tuple[int | None, dict[str, Any]]]) -> None:
+        self.replies = replies
+        self.secret_values: tuple[str, ...] = ()
+        self.calls: list[str] = []
+
+    async def request(self, target):  # noqa: ANN001
+        self.calls.append(target.key)
+        status, payload = self.replies[target.key]
+        return status, payload
+
+
+@pytest.mark.asyncio
+async def test_disabled_gate_exits_without_constructing_transport(
+    monkeypatch, capsys, probe_module
+):
+    monkeypatch.delenv("KIS_MOCK_US_CASH_PROBE_ENABLED", raising=False)
+
+    def unexpected_transport():
+        raise AssertionError("disabled probe must not construct transport")
+
+    exit_code = await probe_module.run_probe(
+        selected="vtts3007",
+        transport_factory=unexpected_transport,
+    )
+
+    assert exit_code == 0
+    assert "disabled" in capsys.readouterr().out
+
+
+@pytest.mark.asyncio
+async def test_missing_mock_credentials_reports_names_not_values(
+    monkeypatch, capsys, probe_module
+):
+    monkeypatch.setenv("KIS_MOCK_US_CASH_PROBE_ENABLED", "true")
+    monkeypatch.setenv("KIS_MOCK_APP_KEY", "secret-app-key")
+    monkeypatch.delenv("KIS_MOCK_APP_SECRET", raising=False)
+    monkeypatch.delenv("KIS_MOCK_ACCOUNT_NO", raising=False)
+
+    exit_code = await probe_module.run_probe(selected="vtts3007")
+
+    output = capsys.readouterr().out
+    assert exit_code == 3
+    assert "KIS_MOCK_APP_SECRET" in output
+    assert "KIS_MOCK_ACCOUNT_NO" in output
+    assert "secret-app-key" not in output
+
+
+@pytest.mark.asyncio
+async def test_success_reports_codes_and_parsed_usd_and_krw_fields(
+    monkeypatch, capsys, probe_module
+):
+    monkeypatch.setenv("KIS_MOCK_US_CASH_PROBE_ENABLED", "true")
+    monkeypatch.setenv("KIS_MOCK_APP_KEY", "key")
+    monkeypatch.setenv("KIS_MOCK_APP_SECRET", "secret")
+    monkeypatch.setenv("KIS_MOCK_ACCOUNT_NO", "12345678-01")
+    transport = FakeTransport(
+        {
+            "vttc0869": (
+                200,
+                {
+                    "rt_cd": "0",
+                    "msg_cd": "0",
+                    "msg1": "OK",
+                    "output": {
+                        "stck_cash_ord_psbl_amt": "2950965",
+                        "usd_ord_psbl_amt": "101.25",
+                        "usd_balance": "99.50",
+                    },
+                },
+            )
+        }
+    )
+
+    exit_code = await probe_module.run_probe(
+        selected="vttc0869", transport_factory=lambda: transport
+    )
+
+    output = capsys.readouterr().out
+    assert exit_code == 0
+    assert "http_status" in output
+    assert "rt_cd" in output
+    assert "2950965" in output
+    assert "101.25" in output
+    assert transport.calls == ["vttc0869"]
+
+
+@pytest.mark.asyncio
+async def test_explicit_broker_rejection_is_normal_nonzero_verdict(
+    monkeypatch, probe_module
+):
+    monkeypatch.setenv("KIS_MOCK_US_CASH_PROBE_ENABLED", "true")
+    monkeypatch.setenv("KIS_MOCK_APP_KEY", "key")
+    monkeypatch.setenv("KIS_MOCK_APP_SECRET", "secret")
+    monkeypatch.setenv("KIS_MOCK_ACCOUNT_NO", "12345678-01")
+    transport = FakeTransport(
+        {
+            "vtts3007": (
+                200,
+                {"rt_cd": "1", "msg_cd": "OPSQ0002", "msg1": "not supported"},
+            )
+        }
+    )
+
+    exit_code = await probe_module.run_probe(
+        selected="vtts3007", transport_factory=lambda: transport
+    )
+
+    assert exit_code == 2
+
+
+def test_redaction_masks_account_and_secret_values(probe_module):
+    payload = {
+        "CANO": "12345678",
+        "authorization": "Bearer secret-token",
+        "nested": {"appsecret": "secret-app-secret", "echo": "secret-token"},
+    }
+
+    redacted = probe_module.redact_payload(
+        payload,
+        secret_values=("12345678-01", "secret-token", "secret-app-secret"),
+    )
+
+    rendered = str(redacted)
+    assert "12345678" not in rendered
+    assert "secret-token" not in rendered
+    assert "secret-app-secret" not in rendered
+    assert "[REDACTED]" in rendered


### PR DESCRIPTION
## Summary

- Add a default-disabled, read-only probe for mock VTTS3007R and VTTC0869R.
- Preserve KIS token/rate-limit transport while bypassing only the intentional mock fail-close wrapper for measurement.
- Add fake-transport TDD coverage and an operator runbook with response/exit-code verdict rules.

## Verification

- `uv run pytest tests/ -q -k "kis_mock or integrated_margin or cash_probe"`
- `make lint`
- `git diff --check`
- `uv run alembic heads`
- Confirmed staged diff has 0 `app/` files.

No live or mock broker call was made while preparing this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)