### PR TITLE
fix(ROB-952): classify expired KIS US day orders

### DIFF
--- a/app/mcp_server/tooling/live_order_evidence.py
+++ b/app/mcp_server/tooling/live_order_evidence.py
@@ -15,6 +15,7 @@ from app.mcp_server.tooling.kis_live_ledger import _create_live_kis_client
 from app.mcp_server.tooling.orders_modify_cancel import (
     _build_us_exchange_candidates,
     _find_us_order_in_recent_history,
+    _normalize_kis_overseas_order,
 )
 from app.services.brokers.kis.mock_scalping_exec.fill_evidence import (
     FillEvidence,
@@ -70,6 +71,42 @@ class UsOverseasEvidenceAdapter:
                 "not_found",
                 f"order {row.order_no} not in recent overseas history",
             )
+
+        # Reuse the same normalizer as order-history / proposal target
+        # preflight.  It consumes KIS ``nccs_qty`` and direct cancellation
+        # evidence, unlike the fill-only canonical row below.  Without this,
+        # a DAY order with zero remaining and zero fills was always reduced to
+        # ``PENDING`` by ``classify_fill_evidence``.
+        normalized_order = _normalize_kis_overseas_order(order)
+        filled_qty = _to_decimal(normalized_order["filled_qty"]) or Decimal("0")
+        remaining_qty = _to_decimal(normalized_order["remaining_qty"]) or Decimal("0")
+        normalized_status = str(normalized_order["status"])
+        if filled_qty == 0 and remaining_qty == 0:
+            if normalized_status == "expired":
+                return FillEvidence(
+                    FillVerdict.EXPIRED,
+                    Decimal("0"),
+                    None,
+                    None,
+                    "expired",
+                    f"KIS overseas order {row.order_no} expired with no fills",
+                )
+            if normalized_status == "cancelled":
+                return FillEvidence(
+                    FillVerdict.NONE,
+                    Decimal("0"),
+                    None,
+                    None,
+                    "cancelled",
+                    f"KIS overseas order {row.order_no} cancelled with no fills",
+                )
+            if normalized_status != "pending":
+                # This invariant must never silently regress into pending: an
+                # unfilled order with zero remaining is terminal broker evidence.
+                raise RuntimeError(
+                    "unexpected terminal KIS overseas order state "
+                    f"status={normalized_status!r} order_no={row.order_no}"
+                )
         normalized = _normalize_overseas_for_classify(order)
         return classify_fill_evidence(order_no=str(row.order_no), rows=[normalized])
 

--- a/app/mcp_server/tooling/live_order_ledger.py
+++ b/app/mcp_server/tooling/live_order_ledger.py
@@ -298,6 +298,20 @@ async def _reconcile_one_live_row(
         base["action"] = "noop_pending"
         return base
 
+    if evidence.verdict == FillVerdict.EXPIRED:
+        base["action"] = "would_mark_expired" if dry_run else "marked_expired"
+        if not dry_run:
+            await _update_live_ledger_outcome(ledger_id=row.id, status="expired")
+            # Proposal rungs have no separate expired state; expiry is a
+            # terminal cancel-family outcome there, while the ledger preserves
+            # the more precise broker-facing ``expired`` vocabulary.
+            converged = await _converge_proposal_rung(
+                row, terminal_state="cancelled", filled_qty=None
+            )
+            if converged is not None:
+                base["proposal_rung"] = converged
+        return base
+
     if evidence.verdict == FillVerdict.NONE:
         base["action"] = "marked_cancelled"
         if not dry_run:

--- a/app/services/brokers/kis/mock_scalping_exec/fill_evidence.py
+++ b/app/services/brokers/kis/mock_scalping_exec/fill_evidence.py
@@ -23,6 +23,7 @@ class FillVerdict(StrEnum):
     FILLED = "filled"
     PARTIAL = "partial"
     PENDING = "pending"
+    EXPIRED = "expired"
     NONE = "none"
     UNSUPPORTED = "unsupported"
 

--- a/tests/mcp_server/tooling/test_live_order_evidence_us.py
+++ b/tests/mcp_server/tooling/test_live_order_evidence_us.py
@@ -86,3 +86,136 @@ async def test_us_adapter_not_found_is_pending():
     ):
         evidence = await ev.UsOverseasEvidenceAdapter().fetch_evidence(_Row())
     assert evidence.verdict == FillVerdict.PENDING  # fail-closed, no booking
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("order_no", "symbol", "ordered_price"),
+    [
+        ("0031116724", "GOOGL", "380.1"),
+        ("0031117219", "AMZN", "262"),
+    ],
+)
+async def test_us_adapter_classifies_expired_day_order_from_broker_terminal_shape(
+    order_no: str, symbol: str, ordered_price: str
+) -> None:
+    """ROB-952: KIS overseas DAY expiry must not become a phantom pending order."""
+    from app.mcp_server.tooling import live_order_evidence as ev
+    from app.services.brokers.kis.mock_scalping_exec.fill_evidence import FillVerdict
+
+    class _Row:
+        exchange = "NASD"
+
+        def __init__(self, order_no: str, symbol: str) -> None:
+            self.order_no = order_no
+            self.symbol = symbol
+
+    broker_order = _row(
+        odno=order_no,
+        pdno=symbol,
+        ft_ord_qty="1",
+        ft_ccld_qty="0",
+        nccs_qty="0",
+        ft_ord_unpr3=ordered_price,
+        ord_dt="20260716",
+        ord_tmd="224201",
+    )
+    with (
+        patch.object(ev, "_create_live_kis_client", return_value=object()),
+        patch.object(
+            ev, "_build_us_exchange_candidates", new=AsyncMock(return_value=["NASD"])
+        ),
+        patch.object(
+            ev,
+            "_find_us_order_in_recent_history",
+            new=AsyncMock(return_value=(broker_order, "NASD")),
+        ),
+    ):
+        evidence = await ev.UsOverseasEvidenceAdapter().fetch_evidence(
+            _Row(order_no, symbol)
+        )
+
+    assert evidence.verdict == FillVerdict.EXPIRED
+    assert evidence.filled_qty == Decimal("0")
+    assert evidence.reason_code == "expired"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_us_adapter_keeps_actual_open_order_pending() -> None:
+    from app.mcp_server.tooling import live_order_evidence as ev
+    from app.services.brokers.kis.mock_scalping_exec.fill_evidence import FillVerdict
+
+    class _Row:
+        symbol = "GOOGL"
+        exchange = "NASD"
+        order_no = "US-OPEN-1"
+
+    with (
+        patch.object(ev, "_create_live_kis_client", return_value=object()),
+        patch.object(
+            ev, "_build_us_exchange_candidates", new=AsyncMock(return_value=["NASD"])
+        ),
+        patch.object(
+            ev,
+            "_find_us_order_in_recent_history",
+            new=AsyncMock(
+                return_value=(
+                    _row(
+                        odno="US-OPEN-1",
+                        pdno="GOOGL",
+                        ft_ord_qty="1",
+                        ft_ccld_qty="0",
+                        nccs_qty="1",
+                    ),
+                    "NASD",
+                )
+            ),
+        ),
+    ):
+        evidence = await ev.UsOverseasEvidenceAdapter().fetch_evidence(_Row())
+
+    assert evidence.verdict == FillVerdict.PENDING
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_us_adapter_preserves_partial_fill_when_expired_row_has_fill_evidence() -> (
+    None
+):
+    from app.mcp_server.tooling import live_order_evidence as ev
+    from app.services.brokers.kis.mock_scalping_exec.fill_evidence import FillVerdict
+
+    class _Row:
+        symbol = "GOOGL"
+        exchange = "NASD"
+        order_no = "US-PARTIAL-EXPIRED"
+
+    with (
+        patch.object(ev, "_create_live_kis_client", return_value=object()),
+        patch.object(
+            ev, "_build_us_exchange_candidates", new=AsyncMock(return_value=["NASD"])
+        ),
+        patch.object(
+            ev,
+            "_find_us_order_in_recent_history",
+            new=AsyncMock(
+                return_value=(
+                    _row(
+                        odno="US-PARTIAL-EXPIRED",
+                        pdno="GOOGL",
+                        ft_ord_qty="2",
+                        ft_ccld_qty="1",
+                        nccs_qty="0",
+                        ft_ccld_unpr3="380.1",
+                    ),
+                    "NASD",
+                )
+            ),
+        ),
+    ):
+        evidence = await ev.UsOverseasEvidenceAdapter().fetch_evidence(_Row())
+
+    assert evidence.verdict == FillVerdict.PARTIAL
+    assert evidence.filled_qty == Decimal("1")

--- a/tests/mcp_server/tooling/test_live_order_ledger.py
+++ b/tests/mcp_server/tooling/test_live_order_ledger.py
@@ -237,6 +237,134 @@ async def test_reconcile_cancelled_no_journal():
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_reconcile_expired_marks_terminal_without_booking_fill_or_journal():
+    """ROB-952: terminal US DAY expiry closes the ledger, never a trade."""
+    from decimal import Decimal
+    from unittest.mock import AsyncMock, patch
+
+    from app.mcp_server.tooling import live_order_ledger as ll
+    from app.services.brokers.kis.mock_scalping_exec.fill_evidence import (
+        FillEvidence,
+        FillVerdict,
+    )
+
+    lid = await ll._save_live_order_ledger(
+        broker="kis",
+        account_scope="kis_live",
+        market="us",
+        symbol="GOOGL",
+        exchange="NASD",
+        market_symbol=None,
+        side="buy",
+        order_kind="limit",
+        quantity=1.0,
+        price=380.1,
+        amount=380.1,
+        currency="USD",
+        order_no="0031116724",
+        order_time="224201",
+        status="accepted",
+        response_code="0",
+        response_message=None,
+        raw_response=None,
+        reason=None,
+        thesis=None,
+        strategy=None,
+        target_price=None,
+        stop_loss=None,
+        min_hold_days=None,
+        notes=None,
+        exit_reason=None,
+        indicators_snapshot=None,
+    )
+    row = await ll._load_live_ledger_row(lid)
+    expired = FillEvidence(
+        FillVerdict.EXPIRED, Decimal("0"), None, None, "expired", "us_day_order"
+    )
+
+    class _Adapter:
+        broker = "kis"
+        fetch_evidence = AsyncMock(return_value=expired)
+
+    with (
+        patch.object(ll, "get_evidence_adapter", return_value=_Adapter()),
+        patch.object(ll, "_save_order_fill", new=AsyncMock()) as save_fill,
+        patch.object(
+            ll, "_create_trade_journal_for_buy", new=AsyncMock()
+        ) as create_journal,
+        patch.object(ll, "_close_journals_on_sell", new=AsyncMock()) as close_journals,
+    ):
+        preview = await ll._reconcile_one_live_row(row, dry_run=True)
+        out = await ll._reconcile_one_live_row(row, dry_run=False)
+
+    assert preview["verdict"] == "expired"
+    assert preview["action"] == "would_mark_expired"
+    assert out["verdict"] == "expired"
+    assert out["action"] == "marked_expired"
+    save_fill.assert_not_awaited()
+    create_journal.assert_not_awaited()
+    close_journals.assert_not_awaited()
+    after = await ll._load_live_ledger_row(lid)
+    assert after.status == "expired"
+    assert after.filled_qty is None
+    assert after.trade_id is None
+    assert after.journal_id is None
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_reconcile_evidence_fetch_failure_keeps_us_ledger_open() -> None:
+    """ROB-952: unavailable broker evidence remains fail-closed, never expiry."""
+    from unittest.mock import AsyncMock, patch
+
+    from app.mcp_server.tooling import live_order_ledger as ll
+
+    lid = await ll._save_live_order_ledger(
+        broker="kis",
+        account_scope="kis_live",
+        market="us",
+        symbol="GOOGL",
+        exchange="NASD",
+        market_symbol=None,
+        side="buy",
+        order_kind="limit",
+        quantity=1.0,
+        price=380.1,
+        amount=380.1,
+        currency="USD",
+        order_no="US-EVIDENCE-FAILURE",
+        order_time="224201",
+        status="accepted",
+        response_code="0",
+        response_message=None,
+        raw_response=None,
+        reason=None,
+        thesis=None,
+        strategy=None,
+        target_price=None,
+        stop_loss=None,
+        min_hold_days=None,
+        notes=None,
+        exit_reason=None,
+        indicators_snapshot=None,
+    )
+    row = await ll._load_live_ledger_row(lid)
+
+    class _Adapter:
+        broker = "kis"
+        fetch_evidence = AsyncMock(side_effect=RuntimeError("history unavailable"))
+
+    with patch.object(ll, "get_evidence_adapter", return_value=_Adapter()):
+        with pytest.raises(RuntimeError, match="history unavailable"):
+            await ll._reconcile_one_live_row(row, dry_run=False)
+
+    after = await ll._load_live_ledger_row(lid)
+    assert after.status == "accepted"
+    assert after.filled_qty is None
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_live_reconcile_impl_dry_run_empty():
     from app.mcp_server.tooling import live_order_ledger as ll
 


### PR DESCRIPTION
## Summary
- Reuse the KIS overseas order-history normalizer for US reconcile terminal evidence.
- Mark unfilled KIS DAY expiries as `expired` without booking fills, realized P&L, or journals.
- Preserve pending, partial-fill, and fail-closed evidence behavior with regression fixtures for GOOGL `0031116724` and AMZN `0031117219`.

## Validation
- `uv run pytest tests/mcp_server/tooling/test_live_order_evidence_us.py tests/mcp_server/tooling/test_live_order_ledger.py tests/test_kis_domestic_order_normalization.py tests/mcp_server/test_kis_live_reconcile_expiry.py tests/mcp_server/tooling/test_live_order_evidence_upbit.py -q`
- `uv run pytest tests/ -q -k "live_reconcile or live_order_evidence or reconcile"`
- `uv run pytest tests/ -q -k "kis_live or toss_reconcile"`
- `make lint`
- `git diff --check`
- `uv run alembic heads`

## Notes
- `review.live_order_ledger` has no status CHECK constraint in its ORM table definition or creation migration (`307953861e78`), so `expired` needs no migration.
- Follow up separately on the US sell lot-to-buy-journal linkage gap that leaves `journals_closed=0` / unavailable FX P&L.

🤖 Generated with [Claude Code](https://claude.com/claude-code)