### PR TITLE
feat(ROB-944): H4 deterministic walk-forward campaign runner — frozen 24-experiment CLI + normalized persistence boundary

### DIFF
--- a/app/services/rob944_campaign_controller.py
+++ b/app/services/rob944_campaign_controller.py
@@ -1,0 +1,667 @@
+"""ROB-944 (H4, ROB-940) — thin --run preflight/registration controller.
+
+Wires the frozen H4 campaign envelope (research/nautilus_scalping.
+rob944_frozen_campaign — never imported here, kept research-side pure) to
+the already-merged ROB-846/946 registry bridge
+(app.services.research_campaign_bridge) and DB write guard
+(app.services.research_db_write_guard). This module owns NO independent
+authorization decision: opt-in/policy checks are entirely
+``research_campaign_bridge``'s own (``assert_research_write_authorized`` is
+evaluated FIRST, inside ``register_campaign_experiments``/``record_attempt``,
+before any spec/shape inspection — see that module).
+
+``run_full_campaign`` is the full gated orchestration (captain blocking
+correction, 2026-07-17). It NEVER leaves a partial "registered but no
+attempts" write:
+
+  1. identity/hash-drift check BEFORE any DB call;
+  2. register all 24 experiments (H6 bridge's own opt-in/policy checks fire
+     first, inside that call);
+  3. PREDECLARE the resulting 24 ``(strategy_key, config_id) -> experiment_id``
+     mapping and its expected ``experiment_id`` SET -- this is the trusted
+     ground truth every later step is validated against;
+  4. ONLY THEN invoke the caller-injected ``build_attempt_evidence`` (child
+     execution) with that predeclared mapping;
+  5. validate the FULL returned batch against the predeclared expected set
+     BEFORE recording a single attempt: exact count/set match (no missing/
+     extra/duplicate experiment_id), every attempt's
+     ``campaign_run_id``/``retry_index=0`` matches, and every attempt carries
+     exactly 3 non-null scenario artifact hashes/counts;
+  6. record each attempt keyed by the TRUSTED expected ``experiment_id``
+     (never the evidence's own self-reported ``attempt_key.experiment_id`` --
+     using the evidence's own value there would make
+     ``record_primary_attempt``'s cross-check tautological, since it would
+     be comparing a value against itself);
+  7. call the SAME ``campaign_completeness_report`` H6 already provides; if
+     its verdict is anything other than ``"complete"``, raise BEFORE the
+     caller can commit -- an accounting-incomplete campaign must never be
+     persisted as if it were.
+
+Accounting completeness is NOT the same as empirical success: a campaign
+where H6 accounting is fully ``"complete"`` but every primary attempt's
+``status`` is ``crashed``/``rejected``/``timeout`` is legitimate, COMMITTABLE
+terminal evidence (a real, complete record of a failed run) — this module
+returns normally for that case. Distinguishing "did the campaign actually
+pass" from "is the record of it complete" is the CALLER's (CLI's)
+responsibility, by inspecting ``report.status_counts``.
+
+Boundary: no broker/order/fill/execution-ledger/scheduler/MCP import (see
+tests/services/research/test_no_broker_import_guard.py-style AST coverage,
+extended to this module in ROB-944's guard test).
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Callable
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.research_backtest import ResearchBacktestRun, ResearchStrategyExperiment
+from app.schemas.research_backtest import StrategyExperimentIdentity
+from app.schemas.research_campaign_bridge import (
+    AttemptEvidence,
+    CampaignCompletenessReport,
+)
+from app.services.research_campaign_bridge import (
+    campaign_completeness_report,
+    record_attempt,
+    register_campaign_experiments,
+)
+from app.services.research_db_write_guard import ResearchDbPolicy
+
+__all__ = [
+    "AttemptKeyExperimentMismatchError",
+    "CampaignAccountingIncompleteError",
+    "CampaignBatchValidationError",
+    "CampaignHashDriftError",
+    "CampaignRunIdDerivationError",
+    "RunIdentityMismatchError",
+    "run_full_campaign",
+]
+# Captain trust-boundary hole #1 (2026-07-17): the OLD public
+# ``run_preflight_and_register``/``record_primary_attempt`` let a caller
+# persist directly WITHOUT going through ``run_full_campaign``'s full
+# validated-batch path (malformed hashes, forged run_identity, cross-status
+# reason pairs, non-canonical scenario order/hashes all bypassed). They are
+# now module-PRIVATE (``_run_preflight_and_register``/
+# ``_record_primary_attempt``) -- ``run_full_campaign`` is the SOLE
+# supported/exported DB-write entry point. They also each independently
+# enforce the same format/contract checks now, as defense in depth for the
+# (test-only) direct-call path that remains.
+
+_EXPECTED_SCENARIO_COUNT = 3
+# Captain BLOCKING controller audit (item 5): the exact canonical
+# scenario ORDER, mirroring rob940_cost_model.COST_SCENARIOS -- this
+# module never imports the research-side module (see module docstring),
+# so this stable, frozen ROB-942 contract is a literal here, exactly like
+# ``_EXPECTED_SCENARIO_COUNT`` already is.
+_EXPECTED_SCENARIO_ORDER: tuple[str, ...] = ("base", "primary_stress", "upward_stress")
+_HEX64_RE = re.compile(
+    r"\A[0-9a-f]{64}\Z"
+)  # \Z (not $) -- $ tolerates one trailing "\n" in non-MULTILINE mode
+
+# Captain persistence-boundary correction (2026-07-17): a caller-injected
+# ``allowed_reason_codes`` set would let ANY caller pass e.g.
+# ``frozenset({"SECRET"})`` and have it persisted -- this controller must
+# own its OWN closed allowlist, exactly like ``_EXPECTED_SCENARIO_ORDER``
+# above, with no expansion hook. Literal duplication of
+# ``rob944_walkforward``'s fixed reason codes (this module never imports
+# that research-side module -- see module docstring boundary); scoped by
+# ``status`` since a reason_code legal for "crashed" is never legal for
+# "rejected" and vice versa.
+_REASON_CHILD_EXECUTION_CRASHED = "child_execution_crashed"
+_REASON_CHILD_EXECUTION_TIMEOUT = "child_execution_timeout"
+_REASON_GLOBAL_CORPUS_LOAD_FAILED = "global_corpus_load_failed"
+_REASON_DATA_GAP_IN_POSITION = "rejected:data_gap_in_position"
+_REASON_INSUFFICIENT_TRAIN_EVIDENCE_ALL_FOLDS = "insufficient_train_evidence_all_folds"
+
+_ALLOWED_REASON_CODES_BY_STATUS: dict[str, frozenset[str]] = {
+    "completed": frozenset(),  # must be None -- checked separately, never a code
+    "crashed": frozenset(
+        {_REASON_CHILD_EXECUTION_CRASHED, _REASON_GLOBAL_CORPUS_LOAD_FAILED}
+    ),
+    "timeout": frozenset({_REASON_CHILD_EXECUTION_TIMEOUT}),
+    "rejected": frozenset(
+        {_REASON_DATA_GAP_IN_POSITION, _REASON_INSUFFICIENT_TRAIN_EVIDENCE_ALL_FOLDS}
+    ),
+}
+
+
+class CampaignHashDriftError(ValueError):
+    """The caller's campaign specs do not derive the pinned expected
+    full-campaign hash -- refused BEFORE any registration/DB call."""
+
+
+class AttemptKeyExperimentMismatchError(ValueError):
+    """``AttemptEvidence.attempt_key.experiment_id``/``campaign_run_id``
+    does not match the identity this call is explicitly recording under --
+    refused BEFORE delegating to the registry (captain audit item 4)."""
+
+
+class CampaignBatchValidationError(ValueError):
+    """The returned attempt-evidence batch does not exactly match the
+    PREDECLARED expected experiment_id set (missing/extra/duplicate), does
+    not name the expected ``campaign_run_id``, is not ``retry_index=0``, or
+    is missing a required scenario artifact hash -- refused BEFORE any
+    attempt is recorded."""
+
+
+class CampaignRunIdDerivationError(ValueError):
+    """``campaign_run_id`` is not the value canonically DERIVED from
+    ``actual_full_campaign_hash`` (an arbitrary UUID/timestamp/operator typo),
+    or either hash is not a well-formed lowercase 64-hex digest -- refused
+    BEFORE any registration/child-execution/DB call (captain direct-controller
+    identity gate, 2026-07-17): this app-side controller is the actual DB
+    persistence boundary and must not rely solely on the CLI's own (separate)
+    copy of this same check."""
+
+
+class RunIdentityMismatchError(ValueError):
+    """``AttemptEvidence.run_identity`` does not equal the value canonically
+    RE-DERIVED at this DB persistence boundary from trusted lineage facts
+    (full_campaign_hash, campaign_run_id, predeclared strategy_key/config_id,
+    experiment_id, retry_index, this evidence's own status, and its
+    format-checked fold_evidence_hash) -- refused BEFORE any
+    ``record_attempt`` call (independent controller audit correction,
+    2026-07-17). A forged/tampered/arbitrary 64-hex ``run_identity`` was
+    previously accepted as long as its FORMAT looked like a hash; this
+    closes that gap for every field this module can independently
+    reconstruct. ``fold_evidence_hash``/scenario ``artifact_hash`` remain
+    format-checked only -- this module has no access to the raw scenario
+    evidence they were derived from, so it cannot re-derive THEM, only
+    verify ``run_identity`` was built correctly ON TOP of whichever
+    fold_evidence_hash this evidence carries."""
+
+
+class CampaignAccountingIncompleteError(ValueError):
+    """``campaign_completeness_report``'s verdict is not ``"complete"``
+    after recording every predeclared attempt -- something is structurally
+    wrong (missing/extra/mismatch/duplicate-or-gap). Raised so the caller
+    never commits an accounting-incomplete campaign."""
+
+
+async def _run_preflight_and_register(
+    session: AsyncSession,
+    *,
+    specs: list[StrategyExperimentIdentity],
+    actual_full_campaign_hash: str,
+    expected_full_campaign_hash: str,
+    guard_opt_in_enabled: bool,
+    guard_policy: ResearchDbPolicy,
+) -> list[ResearchStrategyExperiment]:
+    """Fail closed BEFORE any DB call if the identity hash has drifted, then
+    delegate registration to the existing, already-merged bridge (which
+    itself checks write-authorization FIRST, then exactly-24/unique specs).
+
+    Module-private (captain trust-boundary hole #1, 2026-07-17): this used
+    to be a PUBLIC export a caller could use to bypass ``run_full_campaign``'s
+    full validated-batch path entirely. ``run_full_campaign`` is the sole
+    supported/exported entry point; this remains only as an internal
+    building block (and a direct-call target for narrowly-scoped tests).
+    """
+    if not _HEX64_RE.match(actual_full_campaign_hash) or not _HEX64_RE.match(
+        expected_full_campaign_hash
+    ):
+        raise CampaignHashDriftError(
+            "actual_full_campaign_hash/expected_full_campaign_hash must both be well-formed "
+            "lowercase 64-hex digests -- refusing registration/write"
+        )
+    if actual_full_campaign_hash != expected_full_campaign_hash:
+        # Sanitization addendum (2026-07-17): never echo either hash value
+        # -- both are caller-controlled at this trust boundary.
+        raise CampaignHashDriftError(
+            "full_campaign_hash mismatch -- refusing registration/write"
+        )
+    return await register_campaign_experiments(
+        session,
+        specs=specs,
+        guard_opt_in_enabled=guard_opt_in_enabled,
+        guard_policy=guard_policy,
+    )
+
+
+async def _record_primary_attempt(
+    session: AsyncSession,
+    *,
+    experiment_id: str,
+    campaign_run_id: str,
+    evidence: AttemptEvidence,
+    strategy_name: str,
+    timeframe: str,
+    runner: str,
+    guard_opt_in_enabled: bool,
+    guard_policy: ResearchDbPolicy,
+) -> ResearchBacktestRun:
+    """Record one attempt (typically the primary, ``retry_index=0``) after
+    asserting ``evidence.attempt_key`` genuinely names the identity this call
+    is recording under -- checked BEFORE any delegation to ``record_attempt``.
+
+    ``experiment_id`` MUST come from a source the caller trusts independently
+    of ``evidence`` (e.g. a registration result or a predeclared expected
+    set) -- passing ``evidence.attempt_key.experiment_id`` back as
+    ``experiment_id`` makes this check compare a value against itself and
+    catches nothing; ``run_full_campaign`` never does that.
+
+    Module-private (captain trust-boundary hole #1, 2026-07-17) -- also now
+    independently re-checks the closed status/reason contract and hash
+    formats as defense in depth for the direct-call path, since it is no
+    longer guaranteed every caller went through ``_validate_attempt_batch``
+    first.
+    """
+    # Captain persistence-boundary correction + delta sanitization pass
+    # (2026-07-17): never echo EITHER side's ID/hash value -- not
+    # evidence.attempt_key's own (untrusted, evidence-self-reported) value,
+    # and not the "expected" experiment_id/campaign_run_id this call itself
+    # received, for consistency with every other validation message in this
+    # module (field/count-only, never interpolated raw identifiers).
+    if evidence.attempt_key.experiment_id != experiment_id:
+        raise AttemptKeyExperimentMismatchError(
+            "AttemptKey.experiment_id does not match the expected experiment_id this call "
+            "is recording under"
+        )
+    if evidence.attempt_key.campaign_run_id != campaign_run_id:
+        raise AttemptKeyExperimentMismatchError(
+            "AttemptKey.campaign_run_id does not match the expected campaign_run_id this "
+            "call is recording under"
+        )
+    _assert_single_attempt_format_and_contract(evidence, experiment_id=experiment_id)
+    # TOCTOU correction (2026-07-17): persist a DEEP, decoupled snapshot --
+    # never the caller's own (potentially still-mutable, still-referenced)
+    # object -- so a caller cannot mutate ``evidence`` after this point and
+    # have the mutation reach ``record_attempt``.
+    snapshot = evidence.model_copy(deep=True)
+    return await record_attempt(
+        session,
+        experiment_id=experiment_id,
+        evidence=snapshot,
+        strategy_name=strategy_name,
+        timeframe=timeframe,
+        runner=runner,
+        guard_opt_in_enabled=guard_opt_in_enabled,
+        guard_policy=guard_policy,
+    )
+
+
+def _assert_hex64(value: str | None, *, field: str) -> None:
+    """Captain BLOCKING controller audit (item 5): every persisted hash
+    field must be a lowercase 64-hex SHA-256 digest before ``record_attempt``
+    is ever called -- catches a malformed/truncated/uppercase/non-hash value
+    (e.g. a caller accidentally passing a raw label or a 32-char digest)
+    fail-closed at this trust boundary.
+
+    Captain P1-C sanitization precision (2026-07-17): never interpolate
+    ``experiment_id`` (or any other caller-controlled identifier) into this
+    message -- field name only, even though ``experiment_id`` at most call
+    sites here is itself a TRUSTED value; the recovered contract at this
+    persistence trust boundary is field/count-only, uniformly, regardless
+    of per-call trust reasoning."""
+    if value is None or not _HEX64_RE.match(value):
+        raise CampaignBatchValidationError(
+            f"{field} must be a lowercase 64-hex SHA-256 digest"
+        )
+
+
+def _assert_single_attempt_format_and_contract(
+    evidence: AttemptEvidence, *, experiment_id: str
+) -> None:
+    """The per-entry checks that do NOT require extra caller context
+    (scenario count/order, hex64 hash formats, exact status/reason
+    contract, nonnegative trade counts) -- factored out so BOTH
+    ``_validate_attempt_batch`` (the batch path) and ``_record_primary_attempt``
+    (the direct-call path, now private but still independently defended)
+    apply the IDENTICAL rules. Does NOT include ``run_identity``
+    re-derivation, which needs ``full_campaign_hash``/``strategy_key``/
+    ``config_id`` this function does not have."""
+    # Captain P1-C sanitization precision (2026-07-17): none of these
+    # messages interpolate ``experiment_id`` (dropped from every branch
+    # below) -- field/count-only at this persistence trust boundary,
+    # uniformly, even for the calls where ``experiment_id`` happens to be a
+    # trusted value. ``evidence.status``/``scenario.scenario_name`` remain
+    # safe to report: both are Literal-typed (closed enum) at the pydantic
+    # layer, not raw free-form caller text.
+    if len(evidence.scenario_evidence) != _EXPECTED_SCENARIO_COUNT:
+        raise CampaignBatchValidationError(
+            f"attempt does not have exactly {_EXPECTED_SCENARIO_COUNT} scenario_evidence rows"
+        )
+    scenario_names = tuple(s.scenario_name for s in evidence.scenario_evidence)
+    if scenario_names != _EXPECTED_SCENARIO_ORDER:
+        raise CampaignBatchValidationError(
+            "attempt scenario_evidence must be in the exact canonical order"
+        )
+    if evidence.status == "completed":
+        if evidence.reason_code is not None:
+            raise CampaignBatchValidationError(
+                "attempt has status='completed' but a non-null reason_code -- refusing to persist"
+            )
+    elif evidence.reason_code not in _ALLOWED_REASON_CODES_BY_STATUS[evidence.status]:
+        raise CampaignBatchValidationError(
+            f"attempt has a reason_code not permitted for status={evidence.status!r} under "
+            "the closed allowlist -- refusing to persist"
+        )
+    _assert_hex64(evidence.fold_evidence_hash, field="fold_evidence_hash")
+    _assert_hex64(evidence.run_identity, field="run_identity")
+    for scenario in evidence.scenario_evidence:
+        if scenario.trade_count < 0:
+            raise CampaignBatchValidationError(
+                f"attempt scenario {scenario.scenario_name!r} has a negative trade_count"
+            )
+        _assert_hex64(
+            scenario.artifact_hash,
+            field=f"scenario[{scenario.scenario_name}].artifact_hash",
+        )
+
+
+def _validate_attempt_batch(
+    attempts: list[AttemptEvidence],
+    *,
+    expected_experiment_ids: frozenset[str],
+    campaign_run_id: str,
+    full_campaign_hash: str,
+    key_by_experiment_id: dict[str, tuple[str, str]],
+) -> dict[str, AttemptEvidence]:
+    """Validate the FULL returned batch against the PREDECLARED expected
+    experiment_id set, BEFORE any attempt is recorded. Returns an
+    ``experiment_id -> AttemptEvidence`` map built from the validated batch,
+    keyed by the id the evidence itself claims -- which, having just been
+    proven to exactly match ``expected_experiment_ids``, is safe for the
+    caller to iterate by the TRUSTED expected id instead.
+
+    Captain BLOCKING controller audit (item 5) + persistence-boundary
+    correction: this is the PERSISTENCE TRUST BOUNDARY -- ``status``/
+    ``scenario_name`` are already Literal-typed at the pydantic layer
+    (closed by construction), but ``reason_code`` is a free string, scenario
+    ORDER is not pydantic-enforced (only membership is), and hash fields
+    carry no format constraint. All four are checked here, fail-closed,
+    before any ``record_attempt`` call, against this module's OWN closed
+    ``_ALLOWED_REASON_CODES_BY_STATUS`` -- never a caller-injected allowlist
+    (a direct caller could otherwise pass ``frozenset({"SECRET"})`` and have
+    it persisted).
+
+    Every raised message reports counts/field names/TRUSTED expected
+    identifiers only -- never a raw value taken from the untrusted
+    ``attempts`` batch itself (that batch comes from a caller-injected
+    ``build_attempt_evidence`` callback and must never be treated as safe
+    to echo back into an exception message, which could be logged/printed/
+    surfaced to an operator terminal).
+    """
+    seen_ids = [a.attempt_key.experiment_id for a in attempts]
+    if len(seen_ids) != len(expected_experiment_ids):
+        raise CampaignBatchValidationError(
+            f"expected exactly {len(expected_experiment_ids)} attempt evidence entries, "
+            f"got {len(seen_ids)}"
+        )
+    if len(set(seen_ids)) != len(seen_ids):
+        duplicate_count = len(seen_ids) - len(set(seen_ids))
+        raise CampaignBatchValidationError(
+            f"the returned attempt batch contains {duplicate_count} duplicate experiment_id "
+            "entry/entries"
+        )
+    actual_set = set(seen_ids)
+    if actual_set != set(expected_experiment_ids):
+        # Captain P1-C sanitization precision (2026-07-17): count-only, even
+        # for the "missing" side (a subset of OUR OWN predeclared set) --
+        # never echo the actual id list in either direction.
+        missing_count = len(set(expected_experiment_ids) - actual_set)
+        extra_count = len(actual_set - set(expected_experiment_ids))
+        raise CampaignBatchValidationError(
+            "returned attempt batch does not match the predeclared expected experiment_id "
+            f"set ({missing_count} missing, {extra_count} unexpected id(s) present)"
+        )
+
+    by_id: dict[str, AttemptEvidence] = {}
+    for evidence in attempts:
+        # Safe to report from here on: actual_set == expected_experiment_ids
+        # was just proven above, so every evidence.attempt_key.experiment_id
+        # in this loop is confirmed to be one of OUR OWN predeclared ids.
+        experiment_id = evidence.attempt_key.experiment_id
+        # Captain P1-C sanitization precision (2026-07-17): field/count-only
+        # here too -- never echo experiment_id/campaign_run_id, even though
+        # both are trusted-derived at this point in the batch loop.
+        if evidence.attempt_key.campaign_run_id != campaign_run_id:
+            raise CampaignBatchValidationError(
+                "attempt does not have the expected campaign_run_id"
+            )
+        if evidence.attempt_key.retry_index != 0:
+            raise CampaignBatchValidationError(
+                "attempt does not have retry_index=0 (only primary attempts here)"
+            )
+        if len(evidence.scenario_evidence) != _EXPECTED_SCENARIO_COUNT:
+            raise CampaignBatchValidationError(
+                f"attempt does not have exactly {_EXPECTED_SCENARIO_COUNT} scenario_evidence rows"
+            )
+        # scenario_name is Literal-typed (closed enum) -- safe to report as-is.
+        _assert_single_attempt_format_and_contract(
+            evidence, experiment_id=experiment_id
+        )
+        strategy_key, config_id = key_by_experiment_id[experiment_id]
+        expected_run_identity = _derive_expected_run_identity(
+            full_campaign_hash=full_campaign_hash,
+            campaign_run_id=campaign_run_id,
+            strategy_key=strategy_key,
+            experiment_id=experiment_id,
+            retry_index=evidence.attempt_key.retry_index,
+            config_id=config_id,
+            status=evidence.status,
+            fold_evidence_hash=evidence.fold_evidence_hash,
+        )
+        if evidence.run_identity != expected_run_identity:
+            # Captain P1-C sanitization precision (2026-07-17): the last
+            # missed raw-ID seam -- never interpolate experiment_id here
+            # either, even though it is trusted-derived at this point in the
+            # loop (actual_set == expected_experiment_ids already proven).
+            raise RunIdentityMismatchError(
+                "attempt has a run_identity that does not match the value canonically "
+                "re-derived from trusted lineage facts -- refusing to persist"
+            )
+        # TOCTOU correction (2026-07-17): store a DEEP, decoupled snapshot,
+        # taken immediately after this entry passed every check -- never
+        # the caller's own (still-mutable, still-referenced) object. A
+        # caller mutating its original ``evidence`` after this call returns
+        # can never affect what actually gets recorded downstream.
+        by_id[experiment_id] = evidence.model_copy(deep=True)
+    return by_id
+
+
+def _derive_expected_campaign_run_id(full_campaign_hash: str) -> str:
+    """The SAME deterministic derivation the CLI uses (``research_contracts.
+    canonical_hash`` directly -- the pure, generic authority; never the
+    ``app.services.research_canonical_hash`` wrapper, and never
+    ``rob944_walkforward``/``rob944_frozen_campaign``, both of which stay
+    research-side-only). Duplicated here deliberately: this controller is
+    the actual DB persistence boundary and must not rely solely on the
+    CLI's own (separate) copy of this same check.
+
+    Fable Q1 FINAL (orch-fable-answer-rob944b-20260717.md, 2026-07-17) --
+    exact recipe (precision correction, 2026-07-17: this does NOT base64-
+    encode ``full_campaign_hash``'s own bytes directly): canonical SHA-256
+    of the payload ``{full_campaign_hash, kind: "primary_run"}`` produces a
+    NEW 32-byte digest; THAT digest's full 32 raw bytes (not the input
+    hash's bytes, and not that digest's 64-hex string form) are re-encoded
+    as UNPADDED URL-safe base64 (43 chars) -- NOT hex, and NOT a truncation
+    of anything (full 256-bit entropy of the new digest is preserved).
+    Required so that
+    ``AttemptKey.idempotency_key()`` (``campaign_run_id:experiment_id:retry_index``)
+    fits ``research.backtest_runs.trial_idempotency_key VARCHAR(128)``
+    WITHOUT any H6 schema/source mutation: ``"rob944-primary-"`` (15) + 43 =
+    58-char campaign_run_id; 58 + 1 + 64 (experiment_id, H6's own unchanged
+    full-hex format) + 1 + 1 ("0") = 125 <= 128. This EXACT derivation
+    (identical stdlib base64 recipe) must match
+    ``run_rob944_campaign._derive_primary_campaign_run_id`` bit-for-bit.
+    """
+    import base64
+
+    from research_contracts.canonical_hash import canonical_sha256
+
+    digest_hex = canonical_sha256(
+        {"full_campaign_hash": full_campaign_hash, "kind": "primary_run"}
+    )
+    digest_bytes = bytes.fromhex(digest_hex)
+    suffix = base64.urlsafe_b64encode(digest_bytes).rstrip(b"=").decode("ascii")
+    return f"rob944-primary-{suffix}"
+
+
+def _derive_expected_run_identity(
+    *,
+    full_campaign_hash: str,
+    campaign_run_id: str,
+    strategy_key: str,
+    experiment_id: str,
+    retry_index: int,
+    config_id: str,
+    status: str,
+    fold_evidence_hash: str,
+) -> str:
+    """Independent controller audit correction (2026-07-17): re-derive
+    ``run_identity`` at the DB boundary from ONLY trusted values -- must
+    match ``run_rob944_campaign._summary_to_attempt_evidence``'s payload
+    shape EXACTLY (the redundant short-slug ``"strategy"`` field was
+    dropped from that payload specifically so it is fully reconstructible
+    here from ``strategy_key``/``config_id`` alone, both already known via
+    the predeclared ``experiment_id_by_key`` mapping)."""
+    from research_contracts.canonical_hash import canonical_sha256
+
+    return canonical_sha256(
+        {
+            "full_campaign_hash": full_campaign_hash,
+            "campaign_run_id": campaign_run_id,
+            "strategy_key": strategy_key,
+            "experiment_id": experiment_id,
+            "retry_index": retry_index,
+            "config_id": config_id,
+            "status": status,
+            "fold_evidence_hash": fold_evidence_hash,
+        }
+    )
+
+
+async def run_full_campaign(
+    session: AsyncSession,
+    *,
+    specs: list[StrategyExperimentIdentity],
+    actual_full_campaign_hash: str,
+    expected_full_campaign_hash: str,
+    campaign_run_id: str,
+    guard_opt_in_enabled: bool,
+    guard_policy: ResearchDbPolicy,
+    build_attempt_evidence: Callable[
+        [dict[tuple[str, str], str]], list[AttemptEvidence]
+    ],
+    strategy_name: str,
+    timeframe: str,
+    runner: str,
+) -> CampaignCompletenessReport:
+    """The full gated orchestration -- see module docstring for the exact
+    7-step order. Raises (never commits) on hash drift, campaign_run_id
+    derivation mismatch, batch-validation failure, or accounting
+    incompleteness; the caller (CLI) is responsible for calling
+    ``session.commit()`` only after this returns successfully, and for
+    rolling back on any exception.
+
+    Captain direct-controller identity gate (2026-07-17): both hashes must
+    be well-formed lowercase 64-hex digests, and ``campaign_run_id`` must be
+    the value canonically DERIVED from ``actual_full_campaign_hash`` -- all
+    checked here, BEFORE ``register_campaign_experiments``/any child
+    execution/any DB write, independent of whatever the CLI already checked
+    (defense in depth at the actual persistence boundary).
+    """
+    if not _HEX64_RE.match(actual_full_campaign_hash) or not _HEX64_RE.match(
+        expected_full_campaign_hash
+    ):
+        raise CampaignHashDriftError(
+            "actual_full_campaign_hash/expected_full_campaign_hash must both be well-formed "
+            "lowercase 64-hex digests -- refusing registration/write"
+        )
+    if actual_full_campaign_hash != expected_full_campaign_hash:
+        # Sanitization addendum (2026-07-17): never echo either hash value
+        # -- both are caller-controlled at this trust boundary.
+        raise CampaignHashDriftError(
+            "full_campaign_hash mismatch -- refusing registration/write"
+        )
+    expected_campaign_run_id = _derive_expected_campaign_run_id(
+        actual_full_campaign_hash
+    )
+    if campaign_run_id != expected_campaign_run_id:
+        # Captain P1-C sanitization precision (2026-07-17): never echo
+        # either campaign_run_id value in this message, even the OUR-OWN
+        # derived "expected" one -- field/count-only uniformly at this
+        # persistence trust boundary.
+        raise CampaignRunIdDerivationError(
+            "campaign_run_id must be the value canonically derived from the frozen "
+            "full-campaign hash -- an arbitrary UUID/timestamp/operator typo is refused"
+        )
+
+    registered = await register_campaign_experiments(
+        session,
+        specs=specs,
+        guard_opt_in_enabled=guard_opt_in_enabled,
+        guard_policy=guard_policy,
+    )
+    await session.flush()
+
+    # Step 3: PREDECLARE the expected (strategy_key, config_id) ->
+    # experiment_id mapping and its id SET -- the trusted ground truth for
+    # everything that follows. Child execution (step 4) happens AFTER this.
+    experiment_id_by_key: dict[tuple[str, str], str] = {}
+    for spec, row in zip(specs, registered, strict=True):
+        config_id = (
+            spec.params.get("config_id") if isinstance(spec.params, dict) else None
+        )
+        experiment_id_by_key[(spec.strategy_key, config_id)] = row.experiment_id
+    expected_experiment_ids = frozenset(experiment_id_by_key.values())
+    if len(expected_experiment_ids) != len(registered):
+        raise CampaignBatchValidationError(
+            "registered experiment_ids are not unique -- cannot predeclare attempt keys"
+        )
+    # Reverse mapping -- lets _validate_attempt_batch re-derive/verify each
+    # attempt's run_identity from ONLY trusted (strategy_key, config_id)
+    # facts, never the evidence's own self-reported values.
+    key_by_experiment_id = {v: k for k, v in experiment_id_by_key.items()}
+
+    # Step 4: child execution -- ONLY NOW, against the predeclared mapping.
+    attempts = build_attempt_evidence(experiment_id_by_key)
+
+    # Step 5: validate the FULL batch against the predeclared expected set
+    # BEFORE recording a single attempt.
+    evidence_by_id = _validate_attempt_batch(
+        attempts,
+        expected_experiment_ids=expected_experiment_ids,
+        campaign_run_id=campaign_run_id,
+        full_campaign_hash=actual_full_campaign_hash,
+        key_by_experiment_id=key_by_experiment_id,
+    )
+
+    # Step 6: record each attempt keyed by the TRUSTED expected id, in a
+    # deterministic (sorted) order -- never by the evidence's own
+    # self-reported id, which would make the cross-check tautological.
+    for experiment_id in sorted(expected_experiment_ids):
+        evidence = evidence_by_id[experiment_id]
+        await _record_primary_attempt(
+            session,
+            experiment_id=experiment_id,
+            campaign_run_id=campaign_run_id,
+            evidence=evidence,
+            strategy_name=strategy_name,
+            timeframe=timeframe,
+            runner=runner,
+            guard_opt_in_enabled=guard_opt_in_enabled,
+            guard_policy=guard_policy,
+        )
+    await session.flush()
+
+    # Step 7: accounting completeness is the final gate before the caller
+    # may commit. It is NOT the same as empirical success -- see docstring.
+    report = await campaign_completeness_report(
+        session, campaign_run_id=campaign_run_id, expected_specs=specs
+    )
+    if report.verdict != "complete":
+        # Captain P1-C sanitization precision (2026-07-17): never interpolate
+        # the actual (non-"complete") verdict text into this message -- H6's
+        # own injected/derived verdict category is still not safe to echo
+        # verbatim at this trust boundary.
+        raise CampaignAccountingIncompleteError(
+            "campaign_completeness_report verdict is not 'complete' after recording every "
+            "predeclared attempt -- refusing to let the caller commit an accounting-incomplete "
+            "campaign"
+        )
+    return report

--- a/research/nautilus_scalping/rob940_cost_model.py
+++ b/research/nautilus_scalping/rob940_cost_model.py
@@ -82,7 +82,17 @@ MIN_TP_DISTANCE_BPS = 4.0 * COST_SCENARIO_PRIMARY_STRESS.all_in_bps  # 68.0
 
 @dataclass(frozen=True)
 class FundingCrossing:
-    ts: int  # crossing timestamp, epoch ms UTC, entry_ts < ts <= exit_ts
+    # ROB-944 Q2 (orch-fable-answer-rob944-20260717.md, 2026-07-17): corrected
+    # stale boundary doc (was "entry_ts < ts <= exit_ts"). H1's
+    # FundingSidecar.realized_crossings is the frozen, tested authority: the
+    # half-open position window [entry_ts, exit_ts) is what "held" means -- a
+    # crossing exactly at entry_ts is included (funding is charged if the
+    # position exists at the snapshot instant) and one exactly at exit_ts is
+    # excluded. This module still does not enforce the boundary itself (it
+    # accepts whatever crossings its caller supplies); H4 is the one caller
+    # that builds crossings, and it does so directly from H1's sidecar
+    # without reinterpreting the endpoint.
+    ts: int  # crossing timestamp, epoch ms UTC, entry_ts <= ts < exit_ts
     rate_bps: float  # signed realized funding rate; positive => longs pay shorts
 
     def __post_init__(self) -> None:

--- a/research/nautilus_scalping/rob944_folds.py
+++ b/research/nautilus_scalping/rob944_folds.py
@@ -1,0 +1,175 @@
+"""ROB-944 (H4, ROB-940) — rolling walk-forward fold schedule (pure, stdlib).
+
+Generates ROLLING (never expanding) UTC half-open folds per the orch-approved
+D3 ruling (``orch-strategy-approval-20260717.md``): train 120d / embargo
+exactly 3h as ``[train_end, oos_start)`` / OOS 28d / roll 28d, minimum 6
+complete folds.
+
+Every boundary is derived purely from millisecond arithmetic on the caller's
+``window_start_ms``/``window_end_ms`` -- no calendar/timezone/DST handling is
+needed because all inputs/outputs are already UTC epoch ms and every span
+(day/hour) is a fixed millisecond constant. A fold whose OOS end would exceed
+``window_end_ms`` is dropped WHOLE (never truncated) -- see
+``generate_fold_schedule``.
+
+``generate_fold_schedule`` accepts injectable train/embargo/oos/roll/min-fold
+parameters so tests can exercise the walk-forward MECHANICS (leakage,
+concatenation, no-reselection) against small synthetic windows without
+requiring 120+ real days of fixture bars; the REAL ROB-940 campaign always
+calls ``generate_frozen_fold_schedule``, which hardcodes the approved
+120d/3h/28d/28d/min-6 contract and takes no schedule parameters of its own.
+
+No DB/network/app/broker/random/current-time imports -- pure stdlib,
+deterministic given its input.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+_MS_PER_HOUR = 3_600_000
+_MS_PER_DAY = 86_400_000
+
+TRAIN_DAYS = 120
+EMBARGO_HOURS = 3
+OOS_DAYS = 28
+ROLL_DAYS = 28
+MIN_COMPLETE_FOLDS = 6
+
+TRAIN_MS = TRAIN_DAYS * _MS_PER_DAY
+EMBARGO_MS = EMBARGO_HOURS * _MS_PER_HOUR
+OOS_MS = OOS_DAYS * _MS_PER_DAY
+ROLL_MS = ROLL_DAYS * _MS_PER_DAY
+
+
+class InsufficientFoldsError(ValueError):
+    """Fewer than the required minimum complete folds fit the window."""
+
+
+@dataclass(frozen=True)
+class Fold:
+    """One rolling walk-forward fold; every boundary is UTC epoch ms,
+    half-open (``*_end_ms`` is exclusive). ``embargo_start_ms`` MUST equal
+    ``train_end_ms`` and ``oos_start_ms`` MUST equal ``embargo_end_ms`` --
+    the embargo is defined as exactly ``[train_end, oos_start)``, not a
+    free-floating span, so any caller building a ``Fold`` by hand (not via
+    ``generate_fold_schedule``) still gets that contract enforced.
+    """
+
+    fold_id: str
+    fold_index: int
+    train_start_ms: int
+    train_end_ms: int
+    embargo_start_ms: int
+    embargo_end_ms: int
+    oos_start_ms: int
+    oos_end_ms: int
+
+    def __post_init__(self) -> None:
+        if self.embargo_start_ms != self.train_end_ms:
+            raise ValueError(
+                f"{self.fold_id}: embargo_start_ms ({self.embargo_start_ms}) must "
+                f"equal train_end_ms ({self.train_end_ms}) -- embargo is exactly "
+                "[train_end, oos_start)"
+            )
+        if self.oos_start_ms != self.embargo_end_ms:
+            raise ValueError(
+                f"{self.fold_id}: oos_start_ms ({self.oos_start_ms}) must equal "
+                f"embargo_end_ms ({self.embargo_end_ms}) -- embargo is exactly "
+                "[train_end, oos_start)"
+            )
+        if not (
+            self.train_start_ms
+            < self.train_end_ms
+            < self.embargo_end_ms
+            < self.oos_end_ms
+        ):
+            raise ValueError(
+                f"{self.fold_id}: fold boundaries must be strictly increasing "
+                f"(train_start={self.train_start_ms}, train_end={self.train_end_ms}, "
+                f"embargo_end={self.embargo_end_ms}, oos_end={self.oos_end_ms})"
+            )
+
+
+def generate_fold_schedule(
+    window_start_ms: int,
+    window_end_ms: int,
+    *,
+    train_ms: int = TRAIN_MS,
+    embargo_ms: int = EMBARGO_MS,
+    oos_ms: int = OOS_MS,
+    roll_ms: int = ROLL_MS,
+    min_complete_folds: int = MIN_COMPLETE_FOLDS,
+) -> tuple[Fold, ...]:
+    """Generate rolling half-open folds covering ``[window_start_ms, window_end_ms)``.
+
+    Fold ``i``'s train window starts at ``window_start_ms + i * roll_ms``; a
+    fold is emitted only if its full ``[train_start, oos_end)`` span fits
+    inside the window -- the last, partially-covered fold is dropped WHOLE,
+    never truncated to fit. Raises :class:`InsufficientFoldsError` if fewer
+    than ``min_complete_folds`` complete folds result, and ``ValueError`` if
+    any span parameter is non-positive, the window is empty/inverted, or
+    ``roll_ms < oos_ms`` would make consecutive OOS windows overlap.
+    """
+    if window_end_ms <= window_start_ms:
+        raise ValueError(
+            f"window_end_ms ({window_end_ms}) must be after window_start_ms "
+            f"({window_start_ms})"
+        )
+    for name, value in (
+        ("train_ms", train_ms),
+        ("embargo_ms", embargo_ms),
+        ("oos_ms", oos_ms),
+        ("roll_ms", roll_ms),
+    ):
+        if value <= 0:
+            raise ValueError(f"{name} must be positive, got {value!r}")
+    if roll_ms < oos_ms:
+        raise ValueError(
+            f"roll_ms ({roll_ms}) < oos_ms ({oos_ms}) would make consecutive "
+            "OOS windows overlap -- rejected fail-closed"
+        )
+
+    folds: list[Fold] = []
+    i = 0
+    while True:
+        train_start = window_start_ms + i * roll_ms
+        train_end = train_start + train_ms
+        embargo_end = train_end + embargo_ms
+        oos_start = embargo_end
+        oos_end = oos_start + oos_ms
+        if oos_end > window_end_ms:
+            break
+        folds.append(
+            Fold(
+                fold_id=f"fold-{i:02d}",
+                fold_index=i,
+                train_start_ms=train_start,
+                train_end_ms=train_end,
+                embargo_start_ms=train_end,
+                embargo_end_ms=embargo_end,
+                oos_start_ms=oos_start,
+                oos_end_ms=oos_end,
+            )
+        )
+        i += 1
+
+    if len(folds) < min_complete_folds:
+        raise InsufficientFoldsError(
+            f"only {len(folds)} complete fold(s) fit in [{window_start_ms}, "
+            f"{window_end_ms}); minimum {min_complete_folds} required"
+        )
+    return tuple(folds)
+
+
+def generate_frozen_fold_schedule(
+    window_start_ms: int, window_end_ms: int
+) -> tuple[Fold, ...]:
+    """The exact frozen 120d/3h/28d/28d/min-6 walk-forward schedule (ROB-944).
+
+    Takes no schedule parameters of its own -- the ROB-940 campaign contract
+    is fixed; only the (also-frozen) data window is a caller input, so a
+    change to the window is visible as a full-campaign hash change rather
+    than a silent schedule tweak.
+    """
+    return generate_fold_schedule(window_start_ms, window_end_ms)

--- a/research/nautilus_scalping/rob944_frozen_campaign.py
+++ b/research/nautilus_scalping/rob944_frozen_campaign.py
@@ -1,0 +1,755 @@
+"""ROB-944 (H4, ROB-940) — acyclic full-campaign identity envelope (pure,
+stdlib).
+
+Q4 (``orch-fable-answer-rob944-20260717.md``, final): the envelope is built
+ACYCLICALLY:
+
+  1. freeze material components and actual source/code/dataset-manifest
+     hashes (this module's ``build_production_*``/``load_production_*``
+     helpers, all verifying against a pinned expected hash);
+  2. build the 24 H6 identity specs FROM those components
+     (``rob946_campaign_identity.build_campaign_experiment_specs`` — that
+     module stays untouched, generic, manifest-injected);
+  3. build ONE top-level envelope containing the 24 specs' full components
+     (ordered) plus H4-owned provenance not already in a H6 identity
+     component: the exact fold schedule, the Q2/Q3 funding PIT policy, the
+     ``scenario_execution`` independent-run declaration, the data-gap
+     rejection policy, and the historical-only posture disclosure;
+  4. hash that envelope ONCE (``full_campaign_hash``).
+
+The final hash is NEVER fed back into any of its own inputs or embedded in
+identity-bearing source — an inbox echo (if/when written) is external
+evidence only, never a second identity input.
+
+Production strategy identifiers (Q1, final, Fable-promoted 2026-07-17):
+``S1 = ROB940-S1-DONCHIAN-15M / s1-v1``, ``S2 = ROB940-S2-SHOCK-REVERSAL-5M /
+s2-v1`` — human-readable, strategy-distinct; code provenance is captured by
+the separate ``code`` identity component (source SHA-256), so the name does
+not need to encode it.
+
+Captain audit supplement (2026-07-17), item 3 + frozen-lineage follow-up:
+``@dataclass(frozen=True)`` only blocks attribute REBINDING
+(``envelope.rows = ...``) — it does nothing to the MUTABLE dicts/lists
+living inside those attributes, so
+``envelope.funding_pit_policy["entry_gate"]["max_expected_cost_bps"] = 999``
+would otherwise succeed and change a later ``full_campaign_hash()`` call on
+the very same object. ``__post_init__`` closes this by recursively
+converting every nested dict/list field into an immutable structure
+(``types.MappingProxyType`` + ``tuple``, see ``_freeze``) — the SAME pass
+also performs a full deep, non-aliasing copy (a `_freeze`'d structure shares
+no mutable node with its input), so a caller's own pre-construction dict
+(e.g. the injected ``dataset_manifest``) can never leak in either. Any
+attempt to mutate a nested field post-construction raises ``TypeError``
+(``mappingproxy`` objects and ``tuple``s do not support item assignment).
+``to_dict()`` rebuilds a plain (mutable) dict via ``_unfreeze`` on the way
+OUT, so a caller mutating the RETURNED dict can never affect the sealed
+internal state either.
+
+No DB/network/app/broker/random/current-time imports — pure stdlib plus the
+sibling rob940_*/rob941_*/rob944_* modules and ``rob946_campaign_identity``
+(all already pure themselves), deterministic given its input.
+"""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import types
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import rob941_frozen_scope as frozen
+import rob944_folds as foldmod
+import rob946_campaign_identity as identity
+from rob940_signal_manifest import (
+    FROZEN_S1_CONFIGS,
+    FROZEN_S2_CONFIGS,
+    FrozenSignalConstants,
+    S1Config,
+    S2Config,
+    assert_matches_frozen_s1_config,
+    assert_matches_frozen_s2_config,
+)
+from rob940_signal_manifest import (
+    signal_manifest_hash as _ACTUAL_H3_SIGNAL_MANIFEST_HASH,
+)
+from rob940_signal_s2 import SPEC_DEVIATIONS as _S2_SPEC_DEVIATIONS
+from rob941_manifest import CorpusManifest
+from rob944_gap_funding import (
+    FUNDING_ENTRY_GATE_MAX_EXPECTED_COST_BPS,
+    REASON_DATA_GAP_IN_POSITION,
+    REASON_EXPECTED_FUNDING_COST_ABOVE_3BPS,
+    REASON_FUNDING_EVIDENCE_UNAVAILABLE,
+)
+from rob944_selection import (
+    INSUFFICIENT_ELIGIBLE_SYMBOLS_REASON,
+    INSUFFICIENT_SYMBOL_EVIDENCE_REASON,
+    MIN_ELIGIBLE_SYMBOLS,
+    MIN_SYMBOL_TRAIN_TRADES,
+)
+from rob944_walkforward import (
+    REASON_CHILD_EXECUTION_CRASHED,
+    REASON_CHILD_EXECUTION_TIMEOUT,
+    REASON_GLOBAL_CORPUS_LOAD_FAILED,
+    REASON_INSUFFICIENT_TRAIN_EVIDENCE_ALL_FOLDS,
+    REASON_NEVER_SELECTED_IN_ANY_FOLD,
+)
+
+SCHEMA_VERSION = "rob944_full_campaign.v1"
+
+# Q1 (final, Fable-promoted 2026-07-17): frozen production strategy identifiers.
+PRODUCTION_S1_STRATEGY_KEY = "ROB940-S1-DONCHIAN-15M"
+PRODUCTION_S1_STRATEGY_VERSION = "s1-v1"
+PRODUCTION_S2_STRATEGY_KEY = "ROB940-S2-SHOCK-REVERSAL-5M"
+PRODUCTION_S2_STRATEGY_VERSION = "s2-v1"
+
+# The committed corpus manifest fixture -- verified byte-for-byte against
+# this pinned content_hash before use (ROB-941 discipline, re-applied here).
+_HERE = Path(__file__).resolve().parent
+H1_MANIFEST_PATH = _HERE / "data_manifests" / "rob941_corpus_manifest.v1.json"
+H1_MANIFEST_EXPECTED_CONTENT_HASH = (
+    "4bcc2da979b47caa45b5f90a09c326aefff91fa605e110d55ef316d53c9a9351"
+)
+
+_S1_SOURCE_PATH = _HERE / "rob940_signal_s1.py"
+_S2_SOURCE_PATH = _HERE / "rob940_signal_s2.py"
+
+H3_MANIFEST_EXPECTED_HASH = (
+    "199816d45e79ed52218848dc53c54464754c5befce38dbad6615cf123b628fba"
+)
+
+# ROB-942 R1 correction (rob940_cost_model/rob940_engine docstrings): each
+# cost scenario is simulated via its OWN independent
+# rob940_engine.run_symbol_stream invocation/ledger -- never a net-only
+# revaluation of one shared path.
+SCENARIO_EXECUTION_SEMANTICS = "independent_run_with_fresh_state"
+
+
+class FrozenCampaignError(ValueError):
+    """The envelope's own frozen-pin verification failed (stale/tampered
+    caller-asserted hash) -- distinct from ``rob946_campaign_identity``'s own
+    errors, which this module lets propagate unchanged for its own concerns
+    (dataset-manifest hash, campaign row shape, strategy-source mismatch)."""
+
+
+class RowOrderError(FrozenCampaignError):
+    """``config_rows`` did not arrive in the exact frozen H3 canonical order.
+
+    Captain contract correction (2026-07-17): ``rob946_campaign_identity``'s
+    own ``validate_campaign_rows`` deliberately only checks
+    count/uniqueness/slug-membership (SORTED comparison) -- it is a generic,
+    order-agnostic mechanism by design and must not be mutated here without a
+    fresh consult. Exact row ORDER (aligned 1:1 with the frozen H3 24-row
+    manifest: S1-00..S1-11 then S2-00..S2-11, literal input order, not
+    sorted) is an H4-owned contract enforced here, before any H6 spec is
+    built -- a reorder/13th-row/missing/duplicate/tampered config_id must
+    fail closed rather than silently produce a differently-ordered (but
+    otherwise "valid") envelope.
+    """
+
+
+CANONICAL_ROW_ORDER: tuple[str, ...] = tuple(f"S1-{i:02d}" for i in range(12)) + tuple(
+    f"S2-{i:02d}" for i in range(12)
+)
+
+
+class RowContentTamperError(FrozenCampaignError):
+    """A ``CampaignConfigRow``'s ``params``/``hypothesis`` do not exactly
+    match the frozen H3 manifest row for the same ``config_id``."""
+
+
+def _assert_row_matches_frozen_h3_manifest(row: identity.CampaignConfigRow) -> None:
+    """Captain exact-membership addendum (2026-07-17): row ORDER alone is
+    not enough -- a same-domain param swap or an altered hypothesis string
+    riding under an otherwise-correct/correctly-ordered ``config_id`` (e.g.
+    ``S1-00``) must also fail closed. Reconstructs the native H3
+    ``S1Config``/``S2Config`` from this row's ``params``/``config_id``/
+    ``hypothesis`` and reuses H3's OWN membership authority
+    (``assert_matches_frozen_s1_config``/``assert_matches_frozen_s2_config``,
+    ROB-943 R1 remediation) for exact dataclass-``==`` verification against
+    the frozen manifest row -- no new/duplicate tamper-detection logic here.
+    This is production-content verification, scoped to
+    ``build_production_campaign_config_rows()``'s own output; it is
+    deliberately NOT applied inside the generic ``build_frozen_campaign_envelope``
+    (which legitimately accepts caller-injected non-production rows for
+    isolated hash-sensitivity tests -- test-only fake-row convenience must
+    not weaken this production contract, but it also must not be broken by
+    it).
+    """
+    slug = row.strategy_slug()
+    try:
+        if slug == "S1":
+            assert_matches_frozen_s1_config(
+                S1Config(
+                    L=row.params["L"],
+                    q_min=row.params["q_min"],
+                    k_SL=row.params["k_SL"],
+                    R_TP=row.params["R_TP"],
+                    config_id=row.config_id,
+                    hypothesis=row.hypothesis,
+                )
+            )
+        else:
+            assert_matches_frozen_s2_config(
+                S2Config(
+                    z_min=row.params["z_min"],
+                    v_min=row.params["v_min"],
+                    ER_max=row.params["ER_max"],
+                    R_min=row.params["R_min"],
+                    config_id=row.config_id,
+                    hypothesis=row.hypothesis,
+                )
+            )
+    except (KeyError, ValueError) as exc:
+        raise RowContentTamperError(
+            f"row {row.config_id!r} does not exactly match the frozen H3 manifest "
+            "(param swap, altered hypothesis, or malformed params rejected fail-closed)"
+        ) from exc
+
+
+def _assert_canonical_row_order(config_rows: list[identity.CampaignConfigRow]) -> None:
+    actual = tuple(row.config_id for row in config_rows)
+    if actual != CANONICAL_ROW_ORDER:
+        raise RowOrderError(
+            "config_rows must arrive in the exact frozen H3 canonical order "
+            f"{CANONICAL_ROW_ORDER!r}, got {actual!r} -- reorder, missing, "
+            "duplicate, extra, and tampered config_id are all rejected here"
+        )
+
+
+def build_funding_pit_policy_component() -> dict:
+    """Q2/Q3 (orch-fable-answer-rob944-20260717.md, final): the frozen
+    funding PIT gate/PnL contract, as an explicit identity component."""
+    return {
+        "position_window": "half_open_entry_inclusive_exit_exclusive",  # Q2=A
+        "entry_gate": {
+            "rule": ("last_known_rate_and_interval_project_first_crossing_after_entry"),
+            "max_expected_cost_bps": FUNDING_ENTRY_GATE_MAX_EXPECTED_COST_BPS,
+            "reject_only_if_signed_cost_strictly_greater_than_max": True,
+            "exactly_at_max_remains_eligible": True,
+            "no_lookahead": True,
+            "reason_codes": {
+                "evidence_unavailable": REASON_FUNDING_EVIDENCE_UNAVAILABLE,
+                "expected_cost_above_max": REASON_EXPECTED_FUNDING_COST_ABOVE_3BPS,
+            },
+        },
+        "pnl": "realized_crossings_only_no_future_rate",
+    }
+
+
+def build_data_gap_policy_component() -> dict:
+    return {
+        "reject_reason": REASON_DATA_GAP_IN_POSITION,
+        "predicate": "rob941_gaps.position_touches_gap",
+    }
+
+
+def build_posture_component() -> dict:
+    return {
+        "historical_screen_only": True,
+        "no_broker_execution": True,
+        "no_runtime_gate_activation": True,
+        "spread_age_lot_gates": "absent_from_historical_deferred_to_demo",
+        "optimistic_bias_disclosure": (
+            "four symbols simulated as independent single-position streams; "
+            "does not model account-global one-position arbitration/skip "
+            "(demo-stage arbitration design is out of this historical scope)"
+        ),
+    }
+
+
+# Captain audit supplement (2026-07-17): build_campaign_experiment_specs' own
+# per-row "code" component only hashes S1/S2 STRATEGY signal source -- it
+# never touches the shared H2 execution engine or H4's own runner/CLI/
+# controller files. These logical names are STABLE (bare filenames, never an
+# absolute path) so the resulting hash is identical across checkout
+# locations; each entry's byte-hash is (re)computed at plan/build time
+# directly from the current file, so an edit to any of them changes the
+# full-campaign hash. Extend this tuple as new H4 execution-affecting files
+# are added (H6 preflight gate, CLI) -- do not freeze/echo the campaign
+# until this list is final.
+_APP_SERVICES_DIR = _HERE.parent.parent / "app" / "services"
+
+EXECUTION_CODE_LOGICAL_FILES: tuple[tuple[str, Path], ...] = (
+    ("rob940_bars_agg.py", _HERE / "rob940_bars_agg.py"),
+    ("rob940_engine.py", _HERE / "rob940_engine.py"),
+    ("rob940_cost_model.py", _HERE / "rob940_cost_model.py"),
+    ("rob944_folds.py", _HERE / "rob944_folds.py"),
+    ("rob944_selection.py", _HERE / "rob944_selection.py"),
+    ("rob944_signal_ordering.py", _HERE / "rob944_signal_ordering.py"),
+    ("rob944_gap_funding.py", _HERE / "rob944_gap_funding.py"),
+    ("rob944_scenario_evidence.py", _HERE / "rob944_scenario_evidence.py"),
+    ("rob944_walkforward.py", _HERE / "rob944_walkforward.py"),
+    ("rob944_frozen_campaign.py", _HERE / "rob944_frozen_campaign.py"),
+    ("run_rob944_campaign.py", _HERE / "run_rob944_campaign.py"),
+    (
+        "app/services/rob944_campaign_controller.py",
+        _APP_SERVICES_DIR / "rob944_campaign_controller.py",
+    ),
+    # Captain freeze-provenance blocker (2026-07-17): actually invoked by
+    # --run and material to results, but previously omitted -- their byte
+    # changes would NOT have altered full_campaign_hash. rob941_funding_sidecar.py
+    # and rob941_gaps.py are the delegated authorities for Fable Q2/PIT
+    # (position window) and gap-in-position semantics respectively;
+    # rob941_manifest.py's parsing/validation is execution-affecting since
+    # rob941_offline_loader.py imports and relies on it at real corpus-load
+    # time (not just at freeze/plan time).
+    ("rob941_offline_loader.py", _HERE / "rob941_offline_loader.py"),
+    ("rob941_funding_sidecar.py", _HERE / "rob941_funding_sidecar.py"),
+    ("rob941_gaps.py", _HERE / "rob941_gaps.py"),
+    ("rob941_manifest.py", _HERE / "rob941_manifest.py"),
+)
+
+
+def build_execution_code_provenance_component(
+    files: tuple[tuple[str, Path], ...] | None = None,
+) -> dict[str, str]:
+    """Actual, byte-derived SHA-256 per logical execution-code filename.
+
+    ``files`` defaults to :data:`EXECUTION_CODE_LOGICAL_FILES` (the real
+    production set); tests may inject an alternate ``files`` tuple (e.g.
+    pointing at a temp directory) to prove sensitivity to byte content
+    without touching real repository files. It is safe for this module to
+    hash its OWN file bytes (self-reference) -- the file's source text never
+    contains the resulting ``full_campaign_hash`` value, so there is no
+    circularity, only ordinary "this campaign's identity changed because its
+    own definition changed" sensitivity.
+    """
+    resolved = files if files is not None else EXECUTION_CODE_LOGICAL_FILES
+    return {
+        name: hashlib.sha256(path.read_bytes()).hexdigest() for name, path in resolved
+    }
+
+
+def build_h3_fixed_constants_component() -> dict:
+    """H3's fixed (non-tunable) constants and spec-deviation register --
+    material to execution but NOT covered by ``signal_manifest_hash`` (which
+    identifies only the 24-row tunable-config table)."""
+    return {
+        "frozen_signal_constants": dict(FrozenSignalConstants._asdict()),
+        "s2_spec_deviations": list(_S2_SPEC_DEVIATIONS),
+        "s2_target_direction_invalid_reason_code": "target_direction_invalid",
+    }
+
+
+def build_h4_reason_contract_component() -> dict:
+    """H4-owned selection/funding-gate/data-gap reason codes and thresholds
+    -- an execution-affecting contract that lives in H4's own modules, not
+    in any H1/H2/H3/H6 identity component."""
+    return {
+        "selection": {
+            "min_symbol_train_trades": MIN_SYMBOL_TRAIN_TRADES,
+            "min_eligible_symbols": MIN_ELIGIBLE_SYMBOLS,
+            "insufficient_symbol_evidence_reason": INSUFFICIENT_SYMBOL_EVIDENCE_REASON,
+            "insufficient_eligible_symbols_reason": INSUFFICIENT_ELIGIBLE_SYMBOLS_REASON,
+        },
+        "funding_gate": {
+            "max_expected_cost_bps": FUNDING_ENTRY_GATE_MAX_EXPECTED_COST_BPS,
+            "evidence_unavailable_reason": REASON_FUNDING_EVIDENCE_UNAVAILABLE,
+            "expected_cost_above_max_reason": REASON_EXPECTED_FUNDING_COST_ABOVE_3BPS,
+        },
+        "data_gap_reason": REASON_DATA_GAP_IN_POSITION,
+        "insufficient_train_evidence_all_folds_reason": (
+            REASON_INSUFFICIENT_TRAIN_EVIDENCE_ALL_FOLDS
+        ),
+        "attempt_statuses": ["completed", "rejected", "crashed", "timeout"],
+        # Captain freeze-audit addendum (2026-07-17, item C): the frozen
+        # declared scenario_statuses must exactly cover the runtime terminal
+        # AggregateScenarioStatus contract (rob944_walkforward), including
+        # "rejected" (a gap-touching trade forces the whole scenario trial
+        # rejected) and "never_selected" (a config that never won a single
+        # fold across the whole campaign) -- not only the 3 raw per-run
+        # ScenarioRunOutcome statuses.
+        "scenario_statuses": [
+            "completed",
+            "rejected",
+            "crashed",
+            "timeout",
+            "never_selected",
+        ],
+        "child_execution_failure_reasons": {
+            # Captain security correction (2026-07-17): raw exception/log
+            # text never becomes a persisted reason_code -- these FIXED
+            # codes are the only non-selection/non-funding/non-gap reasons a
+            # crashed/timeout/global-failure attempt can carry.
+            "crashed": REASON_CHILD_EXECUTION_CRASHED,
+            "timeout": REASON_CHILD_EXECUTION_TIMEOUT,
+            "global_corpus_load_failed": REASON_GLOBAL_CORPUS_LOAD_FAILED,
+        },
+        "never_selected_in_any_fold_reason": REASON_NEVER_SELECTED_IN_ANY_FOLD,
+    }
+
+
+class ExperimentIdDerivationError(FrozenCampaignError):
+    """The 24 rows did not derive exactly 24 unique canonical experiment IDs."""
+
+
+def _derive_experiment_ids_from_rows(rows: tuple[dict, ...]) -> tuple[str, ...]:
+    """Q4 addendum (captain, 2026-07-17): the acyclic envelope must contain
+    the exact ORDERED 24 experiment IDs as an explicit, hashed component --
+    not merely a value re-derivable off-envelope by the CLI after the fact.
+    This is step 3 of the acyclic chain (component hashes -> IDs -> top
+    payload/hash): each row's ``components`` dict (already built in step 2,
+    from frozen step-1 components) is hashed per-component and combined into
+    one canonical experiment_id via the SAME
+    ``research_contracts.canonical_hash`` authority the CLI and H6 registry
+    both use (reached here via the ``identity`` module's own ``canonical_hash``
+    import -- no new/duplicate hashing authority). The result is then embedded
+    in the envelope BEFORE the top-level ``full_campaign_hash()`` call, so
+    that hash now explicitly commits to the ordered 24 IDs themselves, not
+    only to the raw components they were derived from. Order is exactly
+    ``rows``' own order (one experiment_id per row, same index) -- there is
+    no separate sort/reorder step, so index-for-index correspondence with
+    ``rows`` is structural, not asserted after the fact.
+    """
+    ids = tuple(
+        identity.canonical_hash.derive_experiment_id(
+            row["strategy_key"],
+            row["strategy_version"],
+            identity.canonical_hash.compute_identity_hashes(row["components"]),
+        )
+        for row in rows
+    )
+    if len(ids) != 24 or len(set(ids)) != 24:
+        raise ExperimentIdDerivationError(
+            f"expected exactly 24 unique experiment IDs derived from 24 rows, got "
+            f"{len(ids)} total ({len(set(ids))} unique)"
+        )
+    return ids
+
+
+def _fold_to_dict(fold: foldmod.Fold) -> dict:
+    return {
+        "fold_id": fold.fold_id,
+        "fold_index": fold.fold_index,
+        "train_start_ms": fold.train_start_ms,
+        "train_end_ms": fold.train_end_ms,
+        "embargo_start_ms": fold.embargo_start_ms,
+        "embargo_end_ms": fold.embargo_end_ms,
+        "oos_start_ms": fold.oos_start_ms,
+        "oos_end_ms": fold.oos_end_ms,
+    }
+
+
+def _freeze(obj: Any) -> Any:
+    """Recursively convert dict/list/tuple into an immutable structure
+    (``types.MappingProxyType`` + ``tuple``). This is simultaneously a full,
+    non-aliasing deep copy (every nested dict/list is rebuilt into a BRAND
+    NEW node) and a mutation guard (any attempted item assignment on the
+    result raises ``TypeError``) -- the two properties the frozen-lineage
+    correction requires together."""
+    if isinstance(obj, types.MappingProxyType):
+        return types.MappingProxyType({k: _freeze(v) for k, v in obj.items()})
+    if isinstance(obj, dict):
+        return types.MappingProxyType({k: _freeze(v) for k, v in obj.items()})
+    if isinstance(obj, (list, tuple)):
+        return tuple(_freeze(v) for v in obj)
+    return obj
+
+
+def _unfreeze(obj: Any) -> Any:
+    """The inverse of :func:`_freeze` -- rebuilds an ordinary, fully mutable
+    dict/list structure. Used ONLY inside ``to_dict()``/hashing so a caller
+    mutating the RETURNED structure can never reach the sealed internal
+    state, and so ``canonical_sha256`` (which expects plain dict/list)
+    receives ordinary types rather than ``MappingProxyType``/``tuple``
+    (``copy.deepcopy`` cannot even traverse a bare ``mappingproxy``)."""
+    if isinstance(obj, types.MappingProxyType):
+        return {k: _unfreeze(v) for k, v in obj.items()}
+    if isinstance(obj, tuple):
+        return [_unfreeze(v) for v in obj]
+    return obj
+
+
+@dataclass(frozen=True)
+class FrozenCampaignEnvelope:
+    """The full ROB-940/H4 campaign identity envelope. ``__post_init__``
+    recursively FREEZES every nested dict/list field (see ``_freeze``) --
+    this is both the sealing/deep-copy boundary (captain audit item 3) AND
+    a hard mutation guard (captain frozen-lineage correction): unlike a bare
+    ``@dataclass(frozen=True)``, which only blocks attribute REBINDING,
+    nested field mutation (e.g.
+    ``envelope.funding_pit_policy["entry_gate"]["x"] = 999``) now raises
+    ``TypeError`` instead of silently corrupting a later
+    ``full_campaign_hash()`` call -- regardless of whether the envelope was
+    built via ``build_frozen_campaign_envelope`` or constructed directly.
+    """
+
+    schema_version: str
+    window_start_iso: str
+    window_end_iso: str
+    universe: tuple[str, ...]
+    dataset_manifest_hash: str
+    signal_manifest_hash: str
+    rows: tuple[dict, ...]
+    experiment_ids: tuple[str, ...]
+    fold_schedule: tuple[dict, ...]
+    scenario_execution: str
+    funding_pit_policy: dict
+    data_gap_policy: dict
+    posture: dict
+    execution_code_provenance: dict[str, str]
+    h3_fixed_constants: dict
+    h4_reason_contract: dict
+
+    def __post_init__(self) -> None:
+        for name in (
+            "universe",
+            "rows",
+            "experiment_ids",
+            "fold_schedule",
+            "funding_pit_policy",
+            "data_gap_policy",
+            "posture",
+            "execution_code_provenance",
+            "h3_fixed_constants",
+            "h4_reason_contract",
+        ):
+            object.__setattr__(self, name, _freeze(getattr(self, name)))
+
+    def to_dict(self) -> dict:
+        """A freshly-rebuilt plain-dict view -- mutating the RETURNED
+        structure must never leak back into this sealed envelope."""
+        return {
+            "schema_version": self.schema_version,
+            "window_start_iso": self.window_start_iso,
+            "window_end_iso": self.window_end_iso,
+            "universe": _unfreeze(self.universe),
+            "dataset_manifest_hash": self.dataset_manifest_hash,
+            "signal_manifest_hash": self.signal_manifest_hash,
+            "rows": _unfreeze(self.rows),
+            "experiment_ids": _unfreeze(self.experiment_ids),
+            "fold_schedule": _unfreeze(self.fold_schedule),
+            "scenario_execution": self.scenario_execution,
+            "funding_pit_policy": _unfreeze(self.funding_pit_policy),
+            "data_gap_policy": _unfreeze(self.data_gap_policy),
+            "posture": _unfreeze(self.posture),
+            "execution_code_provenance": _unfreeze(self.execution_code_provenance),
+            "h3_fixed_constants": _unfreeze(self.h3_fixed_constants),
+            "h4_reason_contract": _unfreeze(self.h4_reason_contract),
+        }
+
+    def full_campaign_hash(self) -> str:
+        """The ONE top-level hash (Q4 step 4) -- never fed back into any of
+        this envelope's own inputs."""
+        return identity.canonical_hash.canonical_sha256(self.to_dict())
+
+
+def build_frozen_campaign_envelope(
+    *,
+    config_rows: list[identity.CampaignConfigRow],
+    sources: dict[str, identity.StrategySourceProvenance],
+    dataset_manifest: dict,
+    dataset_manifest_expected_hash: str,
+    fold_schedule: tuple[foldmod.Fold, ...],
+    signal_manifest_hash_value: str,
+    expected_signal_manifest_hash: str,
+    schema_version: str = SCHEMA_VERSION,
+    execution_code_files: tuple[tuple[str, Path], ...] | None = None,
+) -> FrozenCampaignEnvelope:
+    """Build the acyclic envelope from already-frozen components (Q4 steps
+    1-3). Fail-closed BEFORE building the 24 H6 specs if the caller's
+    asserted H3 ``signal_manifest_hash`` pin is stale; the dataset-manifest
+    hash and campaign-row-shape checks are ``rob946_campaign_identity``'s own
+    (its errors propagate unchanged, never re-wrapped or swallowed).
+    ``FrozenCampaignEnvelope.__post_init__`` performs the actual sealing/
+    freezing -- this function just assembles plain dicts.
+    """
+    if signal_manifest_hash_value != expected_signal_manifest_hash:
+        raise FrozenCampaignError(
+            "H3 signal_manifest_hash mismatch (expected "
+            f"{expected_signal_manifest_hash}, actual {signal_manifest_hash_value}) "
+            "-- stale or tampered H3 signal manifest"
+        )
+    _assert_canonical_row_order(config_rows)
+    # Captain boundary correction (2026-07-17): H4 owns exactly ONE frozen
+    # production envelope -- unlike H6's rob946_campaign_identity (a
+    # deliberately generic, manifest-injected mechanism), this builder must
+    # not silently accept a same-domain param swap or altered hypothesis
+    # riding under an otherwise-correct/correctly-ordered config_id. Every
+    # row is verified against the frozen H3 manifest BEFORE any spec/ID is
+    # built.
+    for row in config_rows:
+        _assert_row_matches_frozen_h3_manifest(row)
+
+    specs = identity.build_campaign_experiment_specs(
+        config_rows,
+        sources=sources,
+        dataset_manifest=dataset_manifest,
+        dataset_manifest_expected_hash=dataset_manifest_expected_hash,
+    )
+
+    rows = tuple(
+        {
+            "strategy_key": spec.strategy_key,
+            "strategy_version": spec.strategy_version,
+            "hypothesis": spec.hypothesis,
+            "components": spec.components,
+        }
+        for spec in specs
+    )
+    fold_dicts = tuple(_fold_to_dict(f) for f in fold_schedule)
+    # Q4 addendum (step 3): derive the ordered 24 experiment IDs from the
+    # already-built rows/components BEFORE constructing the envelope, so the
+    # top-level full_campaign_hash (step 4) explicitly commits to them --
+    # acyclic (IDs never feed back into the components they were derived
+    # from; the final hash is never fed back into anything).
+    experiment_ids = _derive_experiment_ids_from_rows(rows)
+
+    return FrozenCampaignEnvelope(
+        schema_version=schema_version,
+        window_start_iso=frozen.WINDOW_START_ISO,
+        window_end_iso=frozen.WINDOW_END_ISO,
+        universe=frozen.UNIVERSE,
+        dataset_manifest_hash=dataset_manifest_expected_hash,
+        signal_manifest_hash=expected_signal_manifest_hash,
+        rows=rows,
+        experiment_ids=experiment_ids,
+        fold_schedule=fold_dicts,
+        scenario_execution=SCENARIO_EXECUTION_SEMANTICS,
+        funding_pit_policy=build_funding_pit_policy_component(),
+        data_gap_policy=build_data_gap_policy_component(),
+        posture=build_posture_component(),
+        execution_code_provenance=build_execution_code_provenance_component(
+            execution_code_files
+        ),
+        h3_fixed_constants=build_h3_fixed_constants_component(),
+        h4_reason_contract=build_h4_reason_contract_component(),
+    )
+
+
+def build_production_campaign_config_rows() -> list[identity.CampaignConfigRow]:
+    """The exact frozen 24 rows, read directly FROM ``rob940_signal_manifest``'s
+    own frozen tuples -- never a second hand-copied 24-row table. Each
+    constructed row is immediately self-verified via
+    ``_assert_row_matches_frozen_h3_manifest`` (reconstruct + H3's own
+    dataclass-``==`` membership check) -- a regression guard against a future
+    field-mapping bug in this translation (e.g. an accidental ``k_SL``/``R_TP``
+    swap) rather than a tautology, since ``params``/``hypothesis`` here are a
+    hand-written transcription of the S1Config/S2Config fields, not the same
+    object.
+    """
+    rows: list[identity.CampaignConfigRow] = []
+    for c in FROZEN_S1_CONFIGS:
+        rows.append(
+            identity.CampaignConfigRow(
+                config_id=c.config_id,
+                params={"L": c.L, "q_min": c.q_min, "k_SL": c.k_SL, "R_TP": c.R_TP},
+                hypothesis=c.hypothesis,
+            )
+        )
+    for c in FROZEN_S2_CONFIGS:
+        rows.append(
+            identity.CampaignConfigRow(
+                config_id=c.config_id,
+                params={
+                    "z_min": c.z_min,
+                    "v_min": c.v_min,
+                    "ER_max": c.ER_max,
+                    "R_min": c.R_min,
+                },
+                hypothesis=c.hypothesis,
+            )
+        )
+    for row in rows:
+        _assert_row_matches_frozen_h3_manifest(row)
+    return rows
+
+
+def load_production_dataset_manifest() -> dict:
+    """Load + verify the committed H1 corpus manifest fixture against the
+    pinned ``H1_MANIFEST_EXPECTED_CONTENT_HASH``. Returns a fresh deep copy
+    (no aliasing with any cached/module-level object)."""
+    manifest = CorpusManifest.load(H1_MANIFEST_PATH)
+    actual_hash = manifest.content_hash()
+    if actual_hash != H1_MANIFEST_EXPECTED_CONTENT_HASH:
+        raise FrozenCampaignError(
+            f"H1 corpus manifest content_hash mismatch (expected "
+            f"{H1_MANIFEST_EXPECTED_CONTENT_HASH}, actual {actual_hash}) -- the "
+            "committed fixture has drifted from the frozen pin"
+        )
+    return copy.deepcopy(manifest.to_dict())
+
+
+def build_production_strategy_sources(
+    *,
+    expected_s1_source_sha256: str | None = None,
+    expected_s2_source_sha256: str | None = None,
+) -> dict[str, identity.StrategySourceProvenance]:
+    """Real, byte-derived S1/S2 strategy source provenance, read from the
+    actual committed source files. A stale ``expected_*_source_sha256`` pin
+    fails closed on ``.verified_source_sha256()`` (H6's own discipline).
+
+    Captain config/plan audit (2026-07-18, item B): reads raw bytes and
+    decodes them via a STRICT UTF-8 decode -- never ``Path.read_text()``,
+    which opens the file in universal-newline TEXT mode and silently
+    translates any ``\\r\\n``/``\\r`` sequence to ``\\n`` before this
+    function ever sees the string. ``StrategySourceProvenance`` (merged
+    H6, ``rob946_campaign_identity.py`` -- not modified here) computes
+    ``hashlib.sha256(self.source_text.encode("utf-8")).hexdigest()``; a
+    plain ``bytes.decode("utf-8")`` (no I/O layer, no newline translation)
+    is a LOSSLESS round-trip for valid UTF-8 bytes, so
+    ``source_text.encode("utf-8")`` reproduces the ORIGINAL file bytes
+    exactly -- ``hashlib.sha256(path.read_bytes()).hexdigest()`` --
+    regardless of the file's actual line-ending convention.
+    """
+    return {
+        "S1": identity.StrategySourceProvenance(
+            strategy_key=PRODUCTION_S1_STRATEGY_KEY,
+            strategy_version=PRODUCTION_S1_STRATEGY_VERSION,
+            source_text=_S1_SOURCE_PATH.read_bytes().decode("utf-8"),
+            expected_source_sha256=expected_s1_source_sha256,
+        ),
+        "S2": identity.StrategySourceProvenance(
+            strategy_key=PRODUCTION_S2_STRATEGY_KEY,
+            strategy_version=PRODUCTION_S2_STRATEGY_VERSION,
+            source_text=_S2_SOURCE_PATH.read_bytes().decode("utf-8"),
+            expected_source_sha256=expected_s2_source_sha256,
+        ),
+    }
+
+
+def build_production_frozen_campaign_envelope(
+    *,
+    expected_signal_manifest_hash: str = H3_MANIFEST_EXPECTED_HASH,
+    expected_dataset_manifest_hash: str = H1_MANIFEST_EXPECTED_CONTENT_HASH,
+    execution_code_base_dir: Path | None = None,
+) -> FrozenCampaignEnvelope:
+    """The real, production ROB-940 campaign envelope -- pure, no network/DB/
+    child execution. Every hash pin is independently re-verified against the
+    actual committed source/fixture, never trusted as a bare literal.
+
+    ``execution_code_base_dir`` is a TEST-ONLY escape hatch: when given, the
+    execution-code provenance component is computed from files of the same
+    logical names under that directory instead of the real repo files --
+    used to prove the envelope's hash is genuinely sensitive to execution
+    code bytes without mutating real source. Production callers never pass
+    this.
+    """
+    dataset_manifest = load_production_dataset_manifest()
+    actual_dm_hash = identity.canonical_hash.canonical_sha256(dataset_manifest)
+    if actual_dm_hash != expected_dataset_manifest_hash:
+        raise FrozenCampaignError(
+            "H1 dataset manifest hash mismatch (expected "
+            f"{expected_dataset_manifest_hash}, actual {actual_dm_hash})"
+        )
+    fold_schedule = foldmod.generate_frozen_fold_schedule(
+        frozen.WINDOW_START_MS, frozen.WINDOW_END_MS
+    )
+    execution_code_files = None
+    if execution_code_base_dir is not None:
+        execution_code_files = tuple(
+            (name, execution_code_base_dir / name)
+            for name, _real_path in EXECUTION_CODE_LOGICAL_FILES
+        )
+    return build_frozen_campaign_envelope(
+        config_rows=build_production_campaign_config_rows(),
+        sources=build_production_strategy_sources(),
+        dataset_manifest=dataset_manifest,
+        dataset_manifest_expected_hash=actual_dm_hash,
+        fold_schedule=fold_schedule,
+        signal_manifest_hash_value=_ACTUAL_H3_SIGNAL_MANIFEST_HASH,
+        expected_signal_manifest_hash=expected_signal_manifest_hash,
+        execution_code_files=execution_code_files,
+    )

--- a/research/nautilus_scalping/rob944_gap_funding.py
+++ b/research/nautilus_scalping/rob944_gap_funding.py
@@ -1,0 +1,149 @@
+"""ROB-944 (H4, ROB-940) — data-gap-in-position rejection + funding PIT entry
+gate (pure, stdlib).
+
+Frozen by ``orch-fable-answer-rob944-20260717.md`` (Q2/Q3, final):
+
+* Q2 -- H1's ``rob941_funding_sidecar.FundingSidecar.realized_crossings``
+  half-open ``[entry_ts, exit_ts)`` position window is authoritative.
+  ``build_funding_lookup`` delegates to it directly and never reinterprets
+  the endpoint convention (the stale ``rob940_cost_model.FundingCrossing``
+  field comment was corrected in this PR to match).
+* Q3 -- the entry funding gate, evaluated once at the resolved entry time
+  ``E`` (never re-evaluated with a later-known rate):
+  1. fetch ``last_known_rate(E)``; missing (or an invalid non-positive
+     interval) fails closed with ``funding_evidence_unavailable``;
+  2. compute the first expected crossing strictly after ``E`` by repeatedly
+     adding that row's own ``funding_interval_hours`` (in ms) to its
+     ``calc_time``;
+  3. a crossing is relevant only if it falls in ``(E, E + max_hold_ms]``
+     (the position's maximum holding deadline for THIS signal's
+     ``timeout_bars``); otherwise the expected cost is exactly ``0.0``;
+  4. the SIGNED expected cost is ``last_known_rate * 1e4`` for longs, negated
+     for shorts (positive => longs pay shorts, matching
+     ``rob940_cost_model.realized_funding_bps``'s sign convention);
+  5. reject ONLY when that signed value is strictly greater than
+     ``FUNDING_ENTRY_GATE_MAX_EXPECTED_COST_BPS`` (3.0bp) -- exactly 3.0bp
+     remains eligible, and a negative signed value (an expected CREDIT, e.g.
+     a short receiving positive-rate funding) never rejects regardless of its
+     magnitude, since the gate exists to block expected PAYMENTS, not credits;
+  6. the two rejection reasons are stable and reported/aggregated separately.
+
+``is_trade_gap_in_position`` reuses H1's own ``rob941_gaps.position_touches_gap``
+predicate verbatim (no reimplementation) to flag ``rejected:data_gap_in_position``.
+
+No DB/network/app/broker/random/current-time imports -- pure stdlib plus the
+sibling rob941_* modules, deterministic given its input.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+import rob941_gaps as gaps
+from rob940_cost_model import FundingCrossing, Side
+from rob940_engine import TradeRecord
+from rob941_funding_sidecar import FundingSidecar
+
+_MS_PER_HOUR = 3_600_000
+
+FUNDING_ENTRY_GATE_MAX_EXPECTED_COST_BPS = 3.0
+REASON_FUNDING_EVIDENCE_UNAVAILABLE = "funding_evidence_unavailable"
+REASON_EXPECTED_FUNDING_COST_ABOVE_3BPS = "expected_funding_cost_above_3bps"
+REASON_DATA_GAP_IN_POSITION = "rejected:data_gap_in_position"
+
+
+def is_trade_gap_in_position(
+    trade: TradeRecord, gap_ranges: Sequence[tuple[int, int]]
+) -> bool:
+    """True iff ``trade``'s ``[entry_ts, exit_ts)`` window overlaps ANY gap
+    range -- delegates verbatim to H1's ``position_touches_gap``."""
+    return gaps.position_touches_gap(trade.entry_ts, trade.exit_ts, list(gap_ranges))
+
+
+@dataclass(frozen=True)
+class FundingEntryGateResult:
+    passed: bool
+    rejection_reason: str | None
+    expected_cost_bps: float | None  # None iff funding_evidence_unavailable
+
+
+def evaluate_funding_entry_gate(
+    sidecar: FundingSidecar,
+    *,
+    side: Side,
+    entry_ts_ms: int,
+    max_hold_ms: int,
+) -> FundingEntryGateResult:
+    """PIT-safe entry funding gate (Q3, final). Uses ONLY the rate known
+    at/before ``entry_ts_ms`` -- a later-known rate change can never affect
+    this decision, by construction of ``FundingSidecar.last_known_rate``.
+    """
+    last_row = sidecar.last_known_rate(entry_ts_ms)
+    if (
+        last_row is None
+        or last_row.funding_interval_hours <= 0
+        or not math.isfinite(last_row.last_funding_rate)
+    ):
+        # Captain correction (2026-07-17): a NaN last_funding_rate previously
+        # fell through to `round(nan, 8) > 3.0` -- always False in Python,
+        # which silently PASSED the gate (fail-OPEN) instead of treating a
+        # malformed/non-finite known rate as unusable evidence.
+        return FundingEntryGateResult(
+            passed=False,
+            rejection_reason=REASON_FUNDING_EVIDENCE_UNAVAILABLE,
+            expected_cost_bps=None,
+        )
+
+    interval_ms = last_row.funding_interval_hours * _MS_PER_HOUR
+    deadline_ms = entry_ts_ms + max_hold_ms
+    next_crossing_ms = last_row.calc_time
+    while next_crossing_ms <= entry_ts_ms:
+        next_crossing_ms += interval_ms
+
+    if not (entry_ts_ms < next_crossing_ms <= deadline_ms):
+        return FundingEntryGateResult(
+            passed=True, rejection_reason=None, expected_cost_bps=0.0
+        )
+
+    signed_rate_bps = last_row.last_funding_rate * 1e4
+    expected_cost_bps = signed_rate_bps if side == "long" else -signed_rate_bps
+    # Rounded to 1e-8 bp to strip binary-float representation noise (e.g.
+    # 0.0003*1e4 lands a few ULPs below 3.0) without masking any real
+    # boundary distinction -- same treatment as
+    # rob940_signal_s2._evaluate_target_gates's d_tp_bps/r_min_sl_bps.
+    expected_cost_bps = round(expected_cost_bps, 8)
+
+    if expected_cost_bps > FUNDING_ENTRY_GATE_MAX_EXPECTED_COST_BPS:
+        return FundingEntryGateResult(
+            passed=False,
+            rejection_reason=REASON_EXPECTED_FUNDING_COST_ABOVE_3BPS,
+            expected_cost_bps=expected_cost_bps,
+        )
+    return FundingEntryGateResult(
+        passed=True, rejection_reason=None, expected_cost_bps=expected_cost_bps
+    )
+
+
+def build_funding_lookup(sidecars: dict[str, FundingSidecar]):
+    """Build the ``funding_lookup`` callable ``rob940_engine.run_symbol_stream``
+    expects: ``(symbol, side, entry_ts, exit_ts) -> Sequence[FundingCrossing]``.
+
+    Delegates straight to H1's ``FundingSidecar.realized_crossings`` (Q2's
+    frozen ``[entry, exit)`` window) -- no second crossing implementation.
+    """
+
+    def _lookup(
+        symbol: str, side: Side, entry_ts: int, exit_ts: int
+    ) -> tuple[FundingCrossing, ...]:
+        sidecar = sidecars.get(symbol)
+        if sidecar is None:
+            return ()
+        rows = sidecar.realized_crossings(entry_ts, exit_ts)
+        return tuple(
+            FundingCrossing(ts=r.calc_time, rate_bps=r.last_funding_rate * 1e4)
+            for r in rows
+        )
+
+    return _lookup

--- a/research/nautilus_scalping/rob944_scenario_evidence.py
+++ b/research/nautilus_scalping/rob944_scenario_evidence.py
@@ -1,0 +1,179 @@
+"""ROB-944 (H4, ROB-940) — H4-owned scenario terminal-evidence contract (pure,
+stdlib).
+
+Captain audit supplement (2026-07-17): ``rob940_engine.ledger_hash`` hashes
+ONLY the trade ledger (that is its AC1 determinism contract, and correct for
+that narrow purpose) -- it must NEVER be used as the full scenario artifact
+hash, because two runs whose trade ledgers are both empty (e.g. every signal
+was rejected ``daily_stop_active`` vs every signal was rejected
+``tp_below_min_distance``) would otherwise hash identically, silently losing
+the no-trade/reason distribution. ``scenario_artifact_hash`` binds identity
+(strategy/config/symbol/fold/scenario) + status + the ordered trade ledger +
+the no-trade reason histogram, so any of those differing changes the hash.
+
+Captain Q3-enforcement correction (2026-07-17): a hash that merely COMMITS
+to the no-trade reason histogram is not REPORT EXPOSURE -- Fable Q3 requires
+``funding_evidence_unavailable``/``expected_funding_cost_above_3bps`` (and
+every other no-trade reason, including ``rejected:data_gap_in_position``) to
+remain separately countable downstream, not hidden behind a SHA-256 digest.
+``ScenarioRunOutcome.no_trade_reason_counts`` exposes the SAME histogram
+``scenario_artifact_hash`` hashes, as a real, readable field.
+
+``ScenarioRunOutcome`` is the H4-owned, REQUIRED (never-optional) per-scenario
+terminal contract -- unlike ``app.schemas.research_campaign_bridge.
+ScenarioEvidence`` (H6's generic DTO), whose ``artifact_hash`` is
+``str | None`` because H6 must serve any campaign, not just this one. H4
+always supplies ``status``, ``artifact_hash``, and
+``no_trade_reason_counts`` for every one of a fold's 3 scenario runs.
+``status`` has FOUR values: ``completed`` (evidence generation succeeded --
+NOT a strategy PASS verdict), ``rejected`` (the trial itself is invalid --
+e.g. a position touched a data gap, so ANY trade ledger from that run is
+untrustworthy and must not be salvaged), ``crashed``/``timeout`` (the child
+invocation itself failed). ``rob944_walkforward`` is the caller that decides
+when each applies; this module only defines the per-scenario shape.
+
+No DB/network/app/broker/random/current-time imports -- pure stdlib plus the
+existing research_contracts canonical-hash authority and ``rob940_engine``'s
+result types, deterministic given its input.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Literal
+
+from rob940_engine import EngineResult
+
+from research_contracts.canonical_hash import canonical_sha256
+
+ScenarioRunStatus = Literal["completed", "rejected", "crashed", "timeout"]
+
+_EXPECTED_SCENARIO_NAMES = ("base", "primary_stress", "upward_stress")
+
+
+@dataclass(frozen=True)
+class ScenarioRunOutcome:
+    """One (strategy, config, symbol, fold)'s single cost-scenario run
+    outcome. ``status="completed"`` means the engine invocation produced
+    evidence successfully -- NOT a strategy PASS verdict (same "completed
+    != PASS" discipline as ROB-846/ROB-946). ``no_trade_reason_counts`` is
+    the SAME reason -> count histogram ``scenario_artifact_hash`` commits
+    to, exposed here as real, readable, countable data (never just implicit
+    in a hash) -- this is what makes ``funding_evidence_unavailable``/
+    ``expected_funding_cost_above_3bps``/etc. Fable-Q3-report-visible rather
+    than merely hash-committed.
+    """
+
+    scenario_name: str
+    status: ScenarioRunStatus
+    trade_count: int
+    artifact_hash: str
+    error_reason: str | None = None
+    no_trade_reason_counts: dict[str, int] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if self.scenario_name not in _EXPECTED_SCENARIO_NAMES:
+            raise ValueError(
+                f"unknown scenario_name {self.scenario_name!r}, expected one of "
+                f"{_EXPECTED_SCENARIO_NAMES}"
+            )
+        if self.trade_count < 0:
+            raise ValueError(f"trade_count must be >= 0, got {self.trade_count!r}")
+        if self.status != "completed" and self.error_reason is None:
+            raise ValueError(
+                f"{self.scenario_name}: error_reason is required for non-completed "
+                f"status {self.status!r}"
+            )
+
+
+def no_trade_reason_counts(result: EngineResult) -> dict[str, int]:
+    """The reason -> count histogram over ``result.no_trades`` -- the SAME
+    computation ``scenario_artifact_hash`` folds into its digest, exposed as
+    a standalone, reusable, readable function (Fable Q3 report exposure)."""
+    counts: dict[str, int] = {}
+    for nt in result.no_trades:
+        counts[nt.reason] = counts.get(nt.reason, 0) + 1
+    return counts
+
+
+def scenario_artifact_hash(
+    result: EngineResult,
+    *,
+    strategy: str,
+    config_id: str,
+    symbol: str,
+    fold_id: str,
+    scenario_name: str,
+) -> str:
+    """Full terminal-evidence hash for one scenario run.
+
+    Binds identity + the ordered trade ledger + a no-trade REASON HISTOGRAM
+    (reason -> count, plus the total). Two runs with equally-empty trade
+    ledgers but different no-trade reason distributions hash differently;
+    two runs with the same reason histogram (even over different
+    ``signal_ts`` values) hash the same -- this is a deliberate, documented
+    identity-level summary, not a full no-trade-record dump.
+    """
+    reason_counts = no_trade_reason_counts(result)
+
+    payload = {
+        "strategy": strategy,
+        "config_id": config_id,
+        "symbol": symbol,
+        "fold_id": fold_id,
+        "scenario_name": scenario_name,
+        "trades": [
+            {
+                "side": t.side,
+                "signal_ts": t.signal_ts,
+                "entry_ts": t.entry_ts,
+                "entry_price": t.entry_price,
+                "exit_ts": t.exit_ts,
+                "exit_price": t.exit_price,
+                "exit_reason": t.exit_reason,
+                "gross_bps": t.gross_bps,
+                "fee_bps": t.fee_bps,
+                "all_in_bps": t.all_in_bps,
+                "funding_bps": t.funding_bps,
+                "net_bps": t.net_bps,
+                "gap_fill": t.gap_fill,
+            }
+            for t in result.trades
+        ],
+        "no_trade_reason_counts": reason_counts,
+        "no_trade_total": len(result.no_trades),
+    }
+    return canonical_sha256(payload)
+
+
+def scenario_run_outcome_from_engine_result(
+    result: EngineResult,
+    *,
+    strategy: str,
+    config_id: str,
+    symbol: str,
+    fold_id: str,
+    scenario_name: str,
+) -> ScenarioRunOutcome:
+    """Build a ``completed`` outcome from a successful engine invocation.
+
+    Non-``completed`` outcomes (``rejected``/``crashed``/``timeout``) are
+    constructed directly by the caller (the walk-forward runner) at the
+    point a trial is invalidated or a child invocation actually fails --
+    this factory only covers the success path.
+    """
+    artifact_hash = scenario_artifact_hash(
+        result,
+        strategy=strategy,
+        config_id=config_id,
+        symbol=symbol,
+        fold_id=fold_id,
+        scenario_name=scenario_name,
+    )
+    return ScenarioRunOutcome(
+        scenario_name=scenario_name,
+        status="completed",
+        trade_count=len(result.trades),
+        artifact_hash=artifact_hash,
+        no_trade_reason_counts=no_trade_reason_counts(result),
+    )

--- a/research/nautilus_scalping/rob944_selection.py
+++ b/research/nautilus_scalping/rob944_selection.py
@@ -1,0 +1,283 @@
+"""ROB-944 (H4, ROB-940) — per-fold TRAIN selection authority (pure, stdlib).
+
+Selection authority (orch-fable-answer-strategy-20260717.md, confirmed final
+by ``orch-fable-answer-rob944-20260717.md``): the ONE AND ONLY selection/pass
+authority is the eligible-symbol EQUAL-WEIGHT MEAN of per-symbol TRAIN net
+expectancy (bps/trade) under the independent 17bp primary-stress run.
+
+Trade-level POOLED expectancy (this module still computes and reports it,
+per the H5 report contract) is REPORT-ONLY -- ``select_fold_config`` never
+reads ``pooled_expectancy_bps`` when ranking. A symbol with fewer than
+``MIN_SYMBOL_TRAIN_TRADES`` completed train trades is excluded from a
+config's equal-weight mean (``insufficient_symbol_evidence``); if fewer than
+``MIN_ELIGIBLE_SYMBOLS`` symbols remain eligible, the config itself is
+rejected (``rejected:insufficient_train_evidence``) for that fold but stays
+visible in the trace for H6 trial accounting -- never silently dropped.
+
+Ranking of the (exactly 12) candidates: descending equal-weight expectancy,
+then descending profit factor, then ascending canonical ``config_id``. NaN/
+Inf inputs, a wrong candidate count, and duplicate config_id/symbol are all
+rejected fail-closed before any ranking math runs.
+
+No DB/network/app/broker/random/current-time imports -- pure stdlib plus the
+existing research_contracts canonical-hash authority, deterministic given
+its input.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+
+from research_contracts.canonical_hash import canonical_sha256
+
+MIN_SYMBOL_TRAIN_TRADES = 5
+MIN_ELIGIBLE_SYMBOLS = 2
+INSUFFICIENT_SYMBOL_EVIDENCE_REASON = "insufficient_symbol_evidence"
+INSUFFICIENT_ELIGIBLE_SYMBOLS_REASON = "rejected:insufficient_train_evidence"
+
+_EXPECTED_CONFIGS_PER_STRATEGY = 12
+
+
+@dataclass(frozen=True)
+class SymbolTrainEvidence:
+    """One symbol's TRAIN-window evidence for one (strategy, config) row, at
+    the primary-stress (17bp) cost scenario. ``gross_profit_bps``/
+    ``gross_loss_bps`` are the sums of positive/|negative| ``net_bps`` across
+    that symbol's completed train trades -- used ONLY for the report-only
+    pooled expectancy and the profit-factor tie-break, never for eligibility.
+
+    ``train_artifact_hash`` (captain correction, 2026-07-17) is the H4-owned
+    scenario artifact hash (``rob944_scenario_evidence.scenario_artifact_hash``)
+    of the ACTUAL train scenario run this evidence was derived from -- i.e.
+    it is bound to the exact train bar slice + generated signals' resulting
+    trade/no-trade evidence, not merely a re-hash of the four aggregate
+    metrics above. Two genuinely different underlying inputs that happen to
+    average to the same aggregate metrics MUST still produce different
+    ``train_artifact_hash`` values (and therefore a different
+    ``ConfigSelectionOutcome.train_input_hash``) -- this is what makes the
+    selection trace's "preserve train input hashes" contract actually true
+    rather than a re-hash of already-lossy aggregates.
+
+    ``no_trade_reason_counts`` (captain Q3-enforcement follow-up,
+    2026-07-17) exposes the SAME no-trade reason histogram
+    ``rob944_scenario_evidence.ScenarioRunOutcome`` carries for this train
+    run -- so ``funding_evidence_unavailable``/
+    ``expected_funding_cost_above_3bps`` (and every other no-trade reason)
+    remain separately countable for TRAIN evidence too, not collapsed into
+    the generic ``insufficient_symbol_evidence`` eligibility reason.
+    """
+
+    symbol: str
+    completed_trades: int
+    net_expectancy_bps: float  # mean net_bps/trade, TRAIN window, @17bp
+    gross_profit_bps: float
+    gross_loss_bps: float
+    train_artifact_hash: str
+    no_trade_reason_counts: dict[str, int] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if self.completed_trades < 0:
+            raise ValueError(
+                f"{self.symbol}: completed_trades must be >= 0, got "
+                f"{self.completed_trades!r}"
+            )
+        for name in ("net_expectancy_bps", "gross_profit_bps", "gross_loss_bps"):
+            value = getattr(self, name)
+            if not math.isfinite(value):
+                raise ValueError(
+                    f"{self.symbol}: SymbolTrainEvidence.{name} must be finite, "
+                    f"got {value!r}"
+                )
+        if self.gross_profit_bps < 0 or self.gross_loss_bps < 0:
+            raise ValueError(
+                f"{self.symbol}: gross_profit_bps/gross_loss_bps must be >= 0"
+            )
+        if not self.train_artifact_hash:
+            raise ValueError(f"{self.symbol}: train_artifact_hash must be non-empty")
+
+
+@dataclass(frozen=True)
+class ConfigTrainCandidate:
+    """One (strategy) config's per-symbol train evidence, as actually
+    computed -- callers omit a symbol entirely only if it produced zero
+    evidence rows; this dataclass rejects duplicate symbol entries."""
+
+    config_id: str
+    symbol_evidence: tuple[SymbolTrainEvidence, ...]
+
+    def __post_init__(self) -> None:
+        symbols = [e.symbol for e in self.symbol_evidence]
+        if len(set(symbols)) != len(symbols):
+            raise ValueError(
+                f"{self.config_id}: duplicate symbol evidence in "
+                f"symbol_evidence {symbols}"
+            )
+
+
+@dataclass(frozen=True)
+class ConfigSelectionOutcome:
+    """One config's evaluated selection outcome -- present in the trace for
+    EVERY candidate, rejected or not (H6 trial accounting must see rejected
+    configs, not just the eventual winner). ``no_trade_reason_counts`` is the
+    SUM of every symbol's (eligible AND excluded) train no-trade reason
+    histogram -- campaign-report-visible funding/gap/other reason exposure
+    for this config's fold-level train evaluation."""
+
+    config_id: str
+    eligible_symbols: tuple[str, ...]
+    excluded_symbols: tuple[tuple[str, str], ...]  # (symbol, reason)
+    equal_weight_expectancy_bps: float | None  # None iff rejected
+    pooled_expectancy_bps: float | None  # report-only; None iff rejected
+    profit_factor: float  # tie-break value only; meaningless when rejected
+    rejected: bool
+    rejection_reason: str | None
+    train_input_hash: str
+    no_trade_reason_counts: dict[str, int] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class FoldSelectionTrace:
+    """The full per-fold, per-strategy selection trace: every candidate in
+    ORIGINAL input order (not sorted by score), plus the winner (or ``None``
+    if every candidate was rejected for that fold)."""
+
+    strategy: str
+    candidates: tuple[ConfigSelectionOutcome, ...]
+    selected_config_id: str | None
+
+
+def _train_input_hash(candidate: ConfigTrainCandidate) -> str:
+    """Bound to each symbol's ACTUAL train scenario evidence
+    (``train_artifact_hash``, itself derived from the exact train bar slice
+    + generated signals' resulting trades/no-trades) as well as the
+    aggregate metrics -- two inputs that differ only underneath (different
+    bars/signals producing the same aggregate bps) still change this hash,
+    because ``train_artifact_hash`` differs."""
+    payload = {
+        "config_id": candidate.config_id,
+        "symbol_evidence": [
+            {
+                "symbol": e.symbol,
+                "completed_trades": e.completed_trades,
+                "net_expectancy_bps": e.net_expectancy_bps,
+                "gross_profit_bps": e.gross_profit_bps,
+                "gross_loss_bps": e.gross_loss_bps,
+                "train_artifact_hash": e.train_artifact_hash,
+            }
+            for e in candidate.symbol_evidence
+        ],
+    }
+    return canonical_sha256(payload)
+
+
+def _aggregate_no_trade_reason_counts(
+    symbol_evidence: Sequence[SymbolTrainEvidence],
+) -> dict[str, int]:
+    combined: dict[str, int] = {}
+    for e in symbol_evidence:
+        for reason, count in e.no_trade_reason_counts.items():
+            combined[reason] = combined.get(reason, 0) + count
+    return combined
+
+
+def evaluate_config_candidate(
+    candidate: ConfigTrainCandidate,
+) -> ConfigSelectionOutcome:
+    """Evaluate ONE config's eligibility/score in isolation (no ranking)."""
+    eligible: list[SymbolTrainEvidence] = []
+    excluded: list[tuple[str, str]] = []
+    for e in candidate.symbol_evidence:
+        if e.completed_trades < MIN_SYMBOL_TRAIN_TRADES:
+            excluded.append((e.symbol, INSUFFICIENT_SYMBOL_EVIDENCE_REASON))
+        else:
+            eligible.append(e)
+
+    train_input_hash = _train_input_hash(candidate)
+    no_trade_reason_counts = _aggregate_no_trade_reason_counts(
+        candidate.symbol_evidence
+    )
+
+    if len(eligible) < MIN_ELIGIBLE_SYMBOLS:
+        return ConfigSelectionOutcome(
+            config_id=candidate.config_id,
+            eligible_symbols=tuple(e.symbol for e in eligible),
+            excluded_symbols=tuple(excluded),
+            equal_weight_expectancy_bps=None,
+            pooled_expectancy_bps=None,
+            profit_factor=math.nan,
+            rejected=True,
+            rejection_reason=INSUFFICIENT_ELIGIBLE_SYMBOLS_REASON,
+            train_input_hash=train_input_hash,
+            no_trade_reason_counts=no_trade_reason_counts,
+        )
+
+    equal_weight = sum(e.net_expectancy_bps for e in eligible) / len(eligible)
+    total_trades = sum(e.completed_trades for e in eligible)
+    pooled = (
+        sum(e.net_expectancy_bps * e.completed_trades for e in eligible) / total_trades
+        if total_trades > 0
+        else None
+    )
+    gross_profit = sum(e.gross_profit_bps for e in eligible)
+    gross_loss = sum(e.gross_loss_bps for e in eligible)
+    if gross_loss > 0:
+        profit_factor = gross_profit / gross_loss
+    elif gross_profit > 0:
+        profit_factor = math.inf
+    else:
+        profit_factor = 1.0  # degenerate breakeven (no profit, no loss)
+
+    return ConfigSelectionOutcome(
+        config_id=candidate.config_id,
+        eligible_symbols=tuple(e.symbol for e in eligible),
+        excluded_symbols=tuple(excluded),
+        equal_weight_expectancy_bps=equal_weight,
+        pooled_expectancy_bps=pooled,
+        profit_factor=profit_factor,
+        rejected=False,
+        rejection_reason=None,
+        train_input_hash=train_input_hash,
+        no_trade_reason_counts=no_trade_reason_counts,
+    )
+
+
+def select_fold_config(
+    strategy: str, candidates: Sequence[ConfigTrainCandidate]
+) -> FoldSelectionTrace:
+    """Evaluate all (exactly 12) candidates and select the fold's winner.
+
+    Fail-closed BEFORE any ranking math: exactly
+    ``_EXPECTED_CONFIGS_PER_STRATEGY`` candidates, all with unique
+    ``config_id``. Ranking key (descending): equal-weight expectancy, profit
+    factor, then ascending ``config_id`` -- NEVER pooled expectancy.
+    """
+    if len(candidates) != _EXPECTED_CONFIGS_PER_STRATEGY:
+        raise ValueError(
+            f"{strategy}: expected exactly {_EXPECTED_CONFIGS_PER_STRATEGY} "
+            f"config candidates, got {len(candidates)}"
+        )
+    ids = [c.config_id for c in candidates]
+    if len(set(ids)) != len(ids):
+        duplicates = sorted({cid for cid in ids if ids.count(cid) > 1})
+        raise ValueError(f"{strategy}: duplicate config_id(s) {duplicates}")
+
+    outcomes = tuple(evaluate_config_candidate(c) for c in candidates)
+    eligible_outcomes = [o for o in outcomes if not o.rejected]
+
+    selected_config_id: str | None = None
+    if eligible_outcomes:
+        winner = min(
+            eligible_outcomes,
+            key=lambda o: (
+                -o.equal_weight_expectancy_bps,
+                -o.profit_factor,
+                o.config_id,
+            ),
+        )
+        selected_config_id = winner.config_id
+
+    return FoldSelectionTrace(
+        strategy=strategy, candidates=outcomes, selected_config_id=selected_config_id
+    )

--- a/research/nautilus_scalping/rob944_signal_ordering.py
+++ b/research/nautilus_scalping/rob944_signal_ordering.py
@@ -1,0 +1,67 @@
+"""ROB-944 (H4, ROB-940) — canonical signal ordering + duplicate-signal_ts
+guard (pure, stdlib).
+
+``rob940_engine.run_symbol_stream``'s ONLY tie-break for same-``signal_ts``
+signals is Python's stable sort on input order (see its module docstring's
+caller-precondition note) -- H4 owns presenting signals in a REPRODUCIBLE
+canonical order so AC1's "same bars/config -> same bytes" determinism claim
+actually holds regardless of dict/set/filesystem iteration order upstream.
+
+``assert_unique_signal_ts_per_symbol_config`` is defense-in-depth on top of
+H3's own per-generator-call uniqueness guard
+(``rob940_signal_s1._assert_unique_signal_ts`` / the S2 equivalent): it
+re-validates uniqueness scoped to (strategy, config_id, symbol) at the point
+H4 actually hands a combined signal list to the engine, so a caller that
+merges signal lists from multiple sources (or replays a stale one) cannot
+silently reintroduce a same-bar double entry.
+
+No DB/network/app/broker/random/current-time imports -- pure stdlib,
+deterministic given its input.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from rob940_engine import SignalEvent
+
+
+class DuplicateSignalTimestampError(ValueError):
+    """Two signals share ``signal_ts`` within the same (strategy, config_id,
+    symbol) stream -- a single-position stream must never see two candidate
+    entries for the same bar."""
+
+
+def canonical_signal_sort_key(signal: SignalEvent) -> tuple[int, str, str, str]:
+    """``(signal_ts, symbol, config_id, strategy)`` -- the canonical,
+    reproducible tie-break order H4 guarantees before calling H2."""
+    return (signal.signal_ts, signal.symbol, signal.config_id, signal.strategy)
+
+
+def assert_unique_signal_ts_per_symbol_config(
+    signals: Sequence[SignalEvent],
+) -> None:
+    """Fail closed if any (strategy, config_id, symbol) stream carries two
+    signals with the same ``signal_ts``. Same ``signal_ts`` across DIFFERENT
+    symbols/configs/strategies is expected and allowed (that's the normal
+    case of several independent streams firing near the same instant)."""
+    seen: dict[tuple[str, str, str], set[int]] = {}
+    for sig in signals:
+        key = (sig.strategy, sig.config_id, sig.symbol)
+        bucket = seen.setdefault(key, set())
+        if sig.signal_ts in bucket:
+            raise DuplicateSignalTimestampError(
+                f"duplicate signal_ts {sig.signal_ts} for strategy={sig.strategy!r} "
+                f"config_id={sig.config_id!r} symbol={sig.symbol!r} -- a "
+                "single-position stream must have at most one signal per bar"
+            )
+        bucket.add(sig.signal_ts)
+
+
+def sort_signals_canonically(
+    signals: Sequence[SignalEvent],
+) -> tuple[SignalEvent, ...]:
+    """Validate uniqueness, then return signals in the canonical stable
+    order -- byte-identical regardless of the caller's input order."""
+    assert_unique_signal_ts_per_symbol_config(signals)
+    return tuple(sorted(signals, key=canonical_signal_sort_key))

--- a/research/nautilus_scalping/rob944_walkforward.py
+++ b/research/nautilus_scalping/rob944_walkforward.py
@@ -1,0 +1,1634 @@
+"""ROB-944 (H4, ROB-940) — walk-forward runner (pure, stdlib).
+
+Orchestrates, per strategy, the frozen 120d/3h/28d/28d rolling walk-forward
+across the 12 frozen configs and 4 symbols:
+
+  * prevalidates that ``bars_1m``/``funding_sidecars``/``gap_ranges`` cover
+    EXACTLY the frozen 4-symbol universe -- a missing symbol's row is a
+    terminal invalid-data condition (``MissingSymbolDataError``), never a
+    silent <4-symbol partial campaign;
+  * per fold: generate signals against that fold's TRAIN-only bar slice for
+    each (config, symbol); apply the funding PIT entry gate (Q3, final)
+    BEFORE H2 (H2 has no funding gate itself, only a ``funding_lookup`` PnL
+    hook); run the primary-stress (17bp) scenario ONLY for TRAIN evidence
+    (the frozen selection authority); if ANY resulting trade's
+    ``[entry_ts, exit_ts)`` window overlaps a data gap, the WHOLE scenario
+    trial is terminal-``rejected`` (``rejected:data_gap_in_position``) --
+    the entire ledger is discarded, never partially salvaged, because the
+    engine's own daily-stop/cooldown state accounting already treated the
+    now-invalidated trade as real before this check runs;
+  * hand exactly 12 ``ConfigTrainCandidate``s to ``rob944_selection.
+    select_fold_config`` -- the ONLY selection authority, TRAIN evidence
+    only, never re-consulted after OOS is known;
+  * if a fold selects a winner, run that config's OOS (all 4 symbols) through
+    all THREE independent cost-scenario runs (``rob940_engine.
+    run_symbol_stream`` — each its own fresh invocation, never a shared-path
+    revaluation), same funding-gate/gap-rejection treatment;
+  * concatenate each scenario's OOS ledger across ALL folds, in canonical
+    ``(entry_ts, symbol, config_id, exit_ts, side)`` order;
+  * aggregate per-config ATTEMPT evidence (H6's "one logical attempt = one
+    config's full walk-forward invocation" unit): a config's attempt is
+    ``crashed``/``timeout`` if ANY child (signal generation or engine)
+    invocation actually raised anywhere across any fold/symbol/scenario (a
+    crash NEVER silently vanishes -- the config still appears, with its
+    crash log), ``rejected`` if it was never train-eligible in ANY fold
+    (never had a chance to be selected), else ``completed`` (evidence
+    generation succeeded -- NOT a strategy PASS verdict, ROB-846/946's
+    "completed != PASS" discipline). Data-gap rejections are tracked
+    SEPARATELY from code crashes (they are a data-quality fact, not a bug)
+    and never by themselves flip a config's attempt to ``crashed``.
+
+This module takes bars/signals/fold-schedule as PLAIN INPUT (dicts/tuples of
+already-pure H1/H2/H3 types) -- it has no opinion on how those were loaded;
+the CLI/H6-adapter layer is responsible for actually loading the real corpus
+via ``rob941_offline_loader`` (network-0) before calling this.
+
+No DB/network/app/broker/random/current-time imports -- pure stdlib plus the
+sibling rob940_*/rob941_*/rob944_* modules, deterministic given its input.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from typing import Literal
+
+import rob941_frozen_scope as frozen
+from rob940_bars_agg import Bar1m
+from rob940_cost_model import COST_SCENARIO_PRIMARY_STRESS, COST_SCENARIOS, CostScenario
+from rob940_engine import (
+    EngineResult,
+    NoTradeRecord,
+    SignalEvent,
+    TradeRecord,
+    run_symbol_stream,
+)
+from rob941_funding_sidecar import FundingSidecar
+from rob944_folds import Fold
+from rob944_gap_funding import (
+    REASON_DATA_GAP_IN_POSITION,
+    build_funding_lookup,
+    evaluate_funding_entry_gate,
+    is_trade_gap_in_position,
+)
+from rob944_scenario_evidence import ScenarioRunOutcome
+from rob944_scenario_evidence import (
+    no_trade_reason_counts as _no_trade_reason_counts,
+)
+from rob944_scenario_evidence import (
+    scenario_run_outcome_from_engine_result as _outcome_from_result,
+)
+from rob944_selection import (
+    ConfigTrainCandidate,
+    FoldSelectionTrace,
+    SymbolTrainEvidence,
+    select_fold_config,
+)
+from rob944_signal_ordering import sort_signals_canonically
+
+from research_contracts.canonical_hash import canonical_sha256
+
+_MS_PER_MINUTE = 60_000
+_EXPECTED_CONFIGS_PER_STRATEGY = 12
+
+AttemptStatus = Literal["completed", "rejected", "crashed", "timeout"]
+AggregateScenarioStatus = Literal[
+    "completed", "rejected", "crashed", "timeout", "never_selected"
+]
+
+# Captain security/determinism correction (2026-07-17): raw exception/log
+# text must NEVER flow into a persisted reason_code OR into any persisted
+# artifact hash's INPUT (a hash bound to `str(exc)` would make identical
+# fixed-failure-classes vary with secrets/paths/runtime wording, and the
+# input itself -- even hashed -- should never have depended on it). Every
+# non-completed/non-rejected attempt or scenario gets one of these FIXED,
+# stable codes instead -- the raw message stays only in
+# `ConfigAttemptResult.crash_log`/`ScenarioRunOutcome.error_reason`,
+# in-memory, in-process research diagnostics that are never persisted to a
+# DB row, never hashed, and never included in `ConfigAttemptEvidenceSummary`.
+REASON_CHILD_EXECUTION_CRASHED = "child_execution_crashed"
+REASON_CHILD_EXECUTION_TIMEOUT = "child_execution_timeout"
+REASON_INSUFFICIENT_TRAIN_EVIDENCE_ALL_FOLDS = "insufficient_train_evidence_all_folds"
+REASON_NEVER_SELECTED_IN_ANY_FOLD = "never_selected_in_any_fold"
+# A GLOBAL (not per-config) failure -- corpus loading, manifest validation,
+# or any other precondition that must succeed before ANY per-strategy
+# walk-forward can run at all. Captain correction (2026-07-17): once the 24
+# experiment keys are predeclared (post-registration), such a failure must
+# still yield a full 24-entry terminal batch (all "crashed" with this fixed
+# reason), never zero attempts -- see the CLI's fallback-batch builder.
+REASON_GLOBAL_CORPUS_LOAD_FAILED = "global_corpus_load_failed"
+
+# The complete, closed allowlist of reason codes this module (and its H6
+# evidence-conversion callers) may ever persist. Any other value -- in
+# particular raw exception/log text -- must be rejected, never passed
+# through, by any caller building persisted evidence from a
+# ConfigAttemptEvidenceSummary/ScenarioEvidenceSummary.
+KNOWN_REASON_CODES = frozenset(
+    {
+        REASON_CHILD_EXECUTION_CRASHED,
+        REASON_CHILD_EXECUTION_TIMEOUT,
+        REASON_INSUFFICIENT_TRAIN_EVIDENCE_ALL_FOLDS,
+        REASON_DATA_GAP_IN_POSITION,
+        REASON_NEVER_SELECTED_IN_ANY_FOLD,
+        REASON_GLOBAL_CORPUS_LOAD_FAILED,
+    }
+)
+
+
+@dataclass(frozen=True)
+class GeneratedSignalBatch:
+    """Captain Fable condition 1 correction (2026-07-17): a generator's full
+    output -- the accepted ``signals`` PLUS its own pre-execution rejection
+    evidence (``rejections``, e.g. H3 S2's ``target_direction_invalid``/
+    ``tp_above_max``/etc, or H1's ``next_bar_unavailable``/``confirmation_failed``)
+    as canonical ``NoTradeRecord``s. Discarding ``rejections`` (the real
+    S2 adapter previously did exactly this) means H3's own rejection reason
+    counts never reach any independent scenario result, the TRAIN input
+    hash, or the operator-visible CLI summary -- Fable condition 1 requires
+    they survive end-to-end."""
+
+    signals: tuple[SignalEvent, ...]
+    rejections: tuple[NoTradeRecord, ...] = ()
+
+
+# A generator may legitimately return either the older bare-tuple shape
+# (every existing S1/test-fixture generator) or the richer
+# GeneratedSignalBatch (real H3 adapters with rejection evidence) --
+# _normalize_generated_batch below accepts either, so this stays backward
+# compatible with every existing generator/test fixture.
+SignalGenerator = Callable[
+    [str, tuple[Bar1m, ...], str | None],
+    "GeneratedSignalBatch | tuple[SignalEvent, ...]",
+]
+
+
+def _normalize_generated_batch(result) -> GeneratedSignalBatch:
+    """Accept either the older bare ``tuple[SignalEvent, ...]`` (every
+    existing generator/test fixture) or a ``GeneratedSignalBatch`` (real H3
+    adapters carrying rejection evidence) -- never a breaking change to the
+    generator contract."""
+    if isinstance(result, GeneratedSignalBatch):
+        return result
+    return GeneratedSignalBatch(signals=tuple(result), rejections=())
+
+
+# Captain GeneratedSignalBatch checklist (2026-07-17): the CLOSED set of
+# reasons a generator's OWN pre-execution rejection evidence may carry --
+# H3 S2's exact 6-code set (rob940_signal_s2.py:142-150,213,227; H3 source
+# stays untouched -- this is a literal, hand-verified duplicate, same
+# pattern as run_rob944_campaign._known_no_trade_reasons). Distinct from
+# KNOWN_REASON_CODES (ATTEMPT-level terminal reasons) -- a different
+# concern at a different layer.
+H3_GENERATOR_REJECTION_REASONS: frozenset[str] = frozenset(
+    {
+        "confirmation_failed",
+        "next_bar_unavailable",
+        "target_direction_invalid",
+        "tp_above_max",
+        "tp_below_r_min_sl",
+        "tp_below_abs_floor",
+    }
+)
+
+
+def _rejection_sort_key(rec: NoTradeRecord) -> tuple[int, str, str, str]:
+    """Mirrors ``rob944_signal_ordering.canonical_signal_sort_key`` for
+    ``NoTradeRecord`` -- a generator's own (implementation-detail) rejection
+    ORDER must never change any hash it feeds into."""
+    return (rec.signal_ts, rec.symbol, rec.config_id, rec.strategy)
+
+
+def _validate_generated_rejections(
+    rejections: Sequence[NoTradeRecord],
+    *,
+    strategy: str,
+    config_id: str,
+    symbol: str,
+    fold_id: str | None,
+    window_start_ms: int,
+    window_end_ms: int,
+) -> tuple[NoTradeRecord, ...]:
+    """Captain GeneratedSignalBatch checklist (2026-07-17): fail closed on
+    a non-``NoTradeRecord``, an invalid ``side``, a reason outside H3's
+    exact closed 6-code set, forged identity/out-of-window ``signal_ts``, a
+    non-int/bool ``signal_ts``, or a duplicate/colliding record (same
+    ``signal_ts`` -- mirrors the accepted-signals uniqueness rule) -- the
+    SAME identity/window forgery discipline ``_validate_generated_signals``
+    applies to accepted signals, applied here to a generator's own
+    pre-execution rejection evidence, which is just as untrusted. Returns
+    the rejections in CANONICAL (sorted) order -- callers must use the
+    returned tuple, never the raw input order, for any downstream
+    hashing/merging.
+    """
+    seen_ts: set[int] = set()
+    for rec in rejections:
+        if not isinstance(rec, NoTradeRecord):
+            raise ForgedSignalError(
+                f"rejection for {strategy}/{config_id}/{symbol}/{fold_id} is not a "
+                "NoTradeRecord -- refusing to trust an arbitrary object"
+            )
+        if rec.side not in ("long", "short"):
+            raise ForgedSignalError(
+                f"rejection for {strategy}/{config_id}/{symbol}/{fold_id} has an invalid side "
+                "-- refusing to trust"
+            )
+        if rec.reason not in H3_GENERATOR_REJECTION_REASONS:
+            raise ForgedSignalError(
+                f"rejection for {strategy}/{config_id}/{symbol}/{fold_id} has a reason outside "
+                "the closed H3 generator-rejection allowlist -- refusing to trust"
+            )
+        if isinstance(rec.signal_ts, bool) or not isinstance(rec.signal_ts, int):
+            raise ForgedSignalError(
+                f"rejection for {strategy}/{config_id}/{symbol}/{fold_id} has a non-int "
+                "signal_ts -- refusing to trust"
+            )
+        if (
+            rec.strategy != strategy
+            or rec.config_id != config_id
+            or rec.symbol != symbol
+            or rec.fold_id != fold_id
+        ):
+            raise ForgedSignalError(
+                f"forged rejection identity: requested (strategy={strategy!r}, "
+                f"config_id={config_id!r}, symbol={symbol!r}, fold_id={fold_id!r}) but "
+                f"rejection claims (strategy={rec.strategy!r}, config_id={rec.config_id!r}, "
+                f"symbol={rec.symbol!r}, fold_id={rec.fold_id!r})"
+            )
+        if not (window_start_ms <= rec.signal_ts <= window_end_ms):
+            raise ForgedSignalError(
+                f"rejection signal_ts {rec.signal_ts} outside requested window "
+                f"[{window_start_ms}, {window_end_ms}] for {strategy}/{config_id}/{symbol}/{fold_id}"
+            )
+        if rec.signal_ts in seen_ts:
+            raise ForgedSignalError(
+                f"duplicate/colliding rejection signal_ts for {strategy}/{config_id}/{symbol}/"
+                f"{fold_id} -- refusing to trust"
+            )
+        seen_ts.add(rec.signal_ts)
+    return tuple(sorted(rejections, key=_rejection_sort_key))
+
+
+def _assert_no_signal_rejection_ts_collision(
+    signals: Sequence[SignalEvent],
+    rejections: Sequence[NoTradeRecord],
+    *,
+    strategy: str,
+    config_id: str,
+    symbol: str,
+    fold_id: str | None,
+) -> None:
+    """Captain GeneratedSignalBatch fail-closed seam (2026-07-17):
+    ``_validate_generated_signals``/``_validate_generated_rejections`` each
+    maintain their OWN ``seen_ts`` set -- neither ever checks the OTHER
+    list, so a forged/buggy generator callback could emit BOTH an accepted
+    signal AND a rejection at the SAME ``signal_ts``. A single timestamp
+    can never be both emitted and rejected; called AFTER both individual
+    validators succeed, on their already-validated (canonical) outputs."""
+    signal_ts_values = {s.signal_ts for s in signals}
+    rejection_ts_values = {r.signal_ts for r in rejections}
+    overlap = signal_ts_values & rejection_ts_values
+    if overlap:
+        raise ForgedSignalError(
+            f"signal_ts collision between accepted signals and rejections for "
+            f"{strategy}/{config_id}/{symbol}/{fold_id} -- a timestamp cannot be both "
+            "emitted and rejected"
+        )
+
+
+# Severity order for combining multiple fold-level ScenarioRunOutcome
+# statuses into ONE aggregate per (config, scenario): the most severe wins.
+_STATUS_SEVERITY: dict[str, int] = {
+    "completed": 0,
+    "rejected": 1,
+    "timeout": 2,
+    "crashed": 3,
+}
+
+
+class MissingSymbolDataError(ValueError):
+    """``bars_1m``/``funding_sidecars``/``gap_ranges`` does not cover
+    EXACTLY the frozen 4-symbol universe -- ROB-944 requires four exact
+    independent streams; a missing symbol's row must never silently
+    collapse into a <4-symbol partial campaign."""
+
+
+class ForgedSignalError(ValueError):
+    """A generator returned a ``SignalEvent`` whose identity fields do not
+    match what was REQUESTED (strategy/config_id/symbol/fold_id), or whose
+    ``signal_ts`` falls outside the exact half-open window it was given --
+    stable terminal invalid-data evidence, never silently trusted or
+    relabeled under the caller's requested identity."""
+
+
+def _validate_generated_signals(
+    signals: Sequence[SignalEvent],
+    *,
+    strategy: str,
+    config_id: str,
+    symbol: str,
+    fold_id: str | None,
+    window_start_ms: int,
+    window_end_ms: int,
+) -> None:
+    """Fail closed BEFORE H2 unless every signal's identity matches what was
+    REQUESTED and its ``signal_ts`` is temporally derivable from the exact
+    window it was generated against.
+
+    The upper bound is INCLUSIVE (``signal_ts <= window_end_ms``): an
+    aggregated bar's ``close_ts`` can legitimately equal ``window_end_ms``
+    (train_end/oos_end) -- a real close-boundary H3 signal, not a forgery.
+    The 1m execution slice passed to H2 is ``[window_start_ms,
+    window_end_ms)`` (half-open, exclusive of the end), so a bar AT
+    ``signal_ts == window_end_ms`` is never present in it; H2's own
+    ``resolve_entry`` naturally reports ``next_bar_unavailable`` for that
+    signal rather than crossing into the embargo/next fold -- this function
+    must NOT reject that case as forged. Only ``signal_ts < window_start_ms``
+    or ``signal_ts > window_end_ms`` is a genuine temporal violation.
+    """
+    for sig in signals:
+        if (
+            sig.strategy != strategy
+            or sig.config_id != config_id
+            or sig.symbol != symbol
+            or sig.fold_id != fold_id
+        ):
+            raise ForgedSignalError(
+                f"forged signal identity: requested (strategy={strategy!r}, "
+                f"config_id={config_id!r}, symbol={symbol!r}, fold_id={fold_id!r}) but "
+                f"signal claims (strategy={sig.strategy!r}, config_id={sig.config_id!r}, "
+                f"symbol={sig.symbol!r}, fold_id={sig.fold_id!r})"
+            )
+        if not (window_start_ms <= sig.signal_ts <= window_end_ms):
+            raise ForgedSignalError(
+                f"signal_ts {sig.signal_ts} outside requested window "
+                f"[{window_start_ms}, {window_end_ms}] for {strategy}/{config_id}/{symbol}/{fold_id}"
+            )
+
+
+@dataclass(frozen=True)
+class ConfigSpec:
+    """One config's signal-generation entry point, already bound to its
+    frozen params (and, for S2, its target-validity gates) -- the runner
+    never inspects strategy-specific math, only calls this callable."""
+
+    config_id: str
+    generate_signals: SignalGenerator
+
+
+@dataclass(frozen=True)
+class ConfigAttemptResult:
+    """H6's "one logical attempt" unit: one config's full walk-forward
+    invocation, across every fold. ``status="completed"`` means evidence
+    generation succeeded, NOT a strategy PASS verdict. ``gap_rejection_log``
+    is tracked SEPARATELY from ``crash_log`` -- a data-quality gap rejection
+    is never itself a code crash, but must still be exposed/counted, never
+    silently dropped."""
+
+    strategy: str
+    config_id: str
+    status: AttemptStatus
+    reason_code: str | None
+    selected_in_folds: tuple[str, ...]
+    crash_log: tuple[str, ...]
+    gap_rejection_log: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class FoldWalkForwardResult:
+    fold: Fold
+    selection_trace: FoldSelectionTrace
+    oos_outcomes: tuple[
+        ScenarioRunOutcome, ...
+    ]  # per (symbol, scenario) of the winner; () if none selected
+
+
+@dataclass(frozen=True)
+class WalkForwardResult:
+    strategy: str
+    folds: tuple[FoldWalkForwardResult, ...]
+    config_attempts: tuple[ConfigAttemptResult, ...]  # exactly 12, input order
+    concatenated_oos_ledgers: dict[
+        str, tuple[TradeRecord, ...]
+    ]  # scenario_name -> ledger
+
+
+def _validate_exact_universe_coverage(
+    bars_1m: dict[str, tuple[Bar1m, ...]],
+    funding_sidecars: dict[str, FundingSidecar],
+    gap_ranges: dict[str, tuple[tuple[int, int], ...]],
+) -> None:
+    """Fail closed BEFORE any fold work unless all three inputs cover
+    EXACTLY the frozen 4-symbol universe -- no missing, no silently-defaulted
+    symbol. A partial (<4-symbol) run is never a valid ROB-940 campaign."""
+    expected = set(frozen.UNIVERSE)
+    for name, mapping in (
+        ("bars_1m", bars_1m),
+        ("funding_sidecars", funding_sidecars),
+        ("gap_ranges", gap_ranges),
+    ):
+        actual = set(mapping.keys())
+        if actual != expected:
+            missing = sorted(expected - actual)
+            extra = sorted(actual - expected)
+            raise MissingSymbolDataError(
+                f"{name} must cover EXACTLY the frozen universe {sorted(expected)} "
+                f"(missing={missing}, extra={extra})"
+            )
+
+
+def _slice_bars(bars: Sequence[Bar1m], start_ms: int, end_ms: int) -> tuple[Bar1m, ...]:
+    """Half-open ``[start_ms, end_ms)`` slice -- the ONLY boundary between
+    train/embargo/OOS phases; embargo bars are simply never sliced into
+    either phase, so they can never leak into scoring or execution."""
+    return tuple(b for b in bars if start_ms <= b.ts < end_ms)
+
+
+def _canonical_trade_key(t: TradeRecord) -> tuple:
+    return (t.entry_ts, t.symbol, t.config_id, t.exit_ts, t.side)
+
+
+def _apply_funding_gate(
+    bars_slice: tuple[Bar1m, ...],
+    signals: Sequence[SignalEvent],
+    sidecar: FundingSidecar,
+) -> tuple[tuple[SignalEvent, ...], tuple[NoTradeRecord, ...]]:
+    """Filter signals through the Q3 PIT funding entry gate BEFORE H2 (H2 has
+    no funding-cost gate of its own). A signal whose entry can't resolve at
+    all is passed through unfiltered -- H2 will reject it as
+    ``next_bar_unavailable``, the existing/expected reason for that case."""
+    index = {b.ts: i for i, b in enumerate(bars_slice)}
+    eligible: list[SignalEvent] = []
+    rejections: list[NoTradeRecord] = []
+    for sig in signals:
+        entry_idx = index.get(sig.signal_ts)
+        if entry_idx is None:
+            eligible.append(sig)
+            continue
+        entry_ts = bars_slice[entry_idx].ts
+        max_hold_ms = sig.timeout_bars * _MS_PER_MINUTE
+        gate = evaluate_funding_entry_gate(
+            sidecar, side=sig.side, entry_ts_ms=entry_ts, max_hold_ms=max_hold_ms
+        )
+        if gate.passed:
+            eligible.append(sig)
+        else:
+            rejections.append(
+                NoTradeRecord(
+                    strategy=sig.strategy,
+                    config_id=sig.config_id,
+                    symbol=sig.symbol,
+                    side=sig.side,
+                    signal_ts=sig.signal_ts,
+                    reason=gate.rejection_reason,
+                    fold_id=sig.fold_id,
+                )
+            )
+    return tuple(eligible), tuple(rejections)
+
+
+def _stable_terminal_hash(
+    *,
+    strategy: str,
+    config_id: str,
+    symbol: str,
+    fold_id: str,
+    scope: str,
+    status: str,
+    reason_code: str,
+) -> str:
+    """A deterministic hash built ONLY from stable identity + a FIXED status/
+    reason_code -- never from raw exception/log text. Two different
+    secret-bearing exception messages for the "same" failure class (same
+    identity + same status + same reason_code) hash IDENTICALLY."""
+    return canonical_sha256(
+        {
+            "strategy": strategy,
+            "config_id": config_id,
+            "symbol": symbol,
+            "fold_id": fold_id,
+            "scope": scope,
+            "status": status,
+            "reason_code": reason_code,
+        }
+    )
+
+
+def _crash_outcome(
+    exc: Exception,
+    *,
+    strategy: str,
+    config_id: str,
+    symbol: str,
+    fold_id: str,
+    scenario_name: str,
+    no_trade_reason_counts: dict[str, int] | None = None,
+) -> ScenarioRunOutcome:
+    """Any child (signal-generation or engine) exception becomes terminal
+    evidence -- never a silent skip. A ``TimeoutError`` (or subclass) is
+    reported as ``status="timeout"``; every other exception is
+    ``status="crashed"``. The persisted ``artifact_hash`` is bound ONLY to
+    stable identity + status + reason_code (PLUS any already-preserved
+    no_trade_reason_counts, captain P1 correction 2026-07-17) -- NEVER to
+    ``str(exc)`` -- so two different secret-bearing exception messages for
+    the same failure class hash identically; the raw message survives only
+    in ``error_reason`` (in-memory only, never re-hashed/persisted)."""
+    status: Literal["crashed", "timeout"] = (
+        "timeout" if isinstance(exc, TimeoutError) else "crashed"
+    )
+    reason_code = (
+        REASON_CHILD_EXECUTION_TIMEOUT
+        if status == "timeout"
+        else REASON_CHILD_EXECUTION_CRASHED
+    )
+    base_hash = _stable_terminal_hash(
+        strategy=strategy,
+        config_id=config_id,
+        symbol=symbol,
+        fold_id=fold_id,
+        scope=scenario_name,
+        status=status,
+        reason_code=reason_code,
+    )
+    counts = no_trade_reason_counts or {}
+    artifact_hash = canonical_sha256(
+        {"base_hash": base_hash, "no_trade_reason_counts": counts}
+    )
+    return ScenarioRunOutcome(
+        scenario_name=scenario_name,
+        status=status,
+        trade_count=0,
+        artifact_hash=artifact_hash,
+        error_reason=str(exc)[:500],
+        no_trade_reason_counts=counts,
+    )
+
+
+def _rejected_gap_outcome(
+    *,
+    strategy: str,
+    config_id: str,
+    symbol: str,
+    fold_id: str,
+    scenario_name: str,
+    no_trade_reason_counts: dict[str, int] | None = None,
+) -> ScenarioRunOutcome:
+    """The WHOLE scenario trial is invalidated: at least one trade in this
+    run touched a data gap, so the engine's own daily-stop/cooldown state
+    accounting downstream of that (now-invalid) trade is untrustworthy --
+    the entire ledger is discarded, never partially salvaged.
+
+    Captain independent Fable e2e audit correction (2026-07-17): the
+    funding entry gate runs BEFORE the gap check within one scenario
+    invocation (see ``_run_scenario``) -- its own no-trade rejections
+    (``funding_evidence_unavailable``/``expected_funding_cost_above_3bps``)
+    are REAL, already-observed evidence for this run and must not be
+    silently dropped just because the run is ALSO gap-rejected. They are
+    preserved on ``no_trade_reason_counts`` AND folded into the artifact
+    hash (combined with the stable identity+status+reason base hash) --
+    Fable Q3 requires these stay separately countable in every terminal
+    scenario evidence path, not only the completed one.
+    """
+    base_hash = _stable_terminal_hash(
+        strategy=strategy,
+        config_id=config_id,
+        symbol=symbol,
+        fold_id=fold_id,
+        scope=scenario_name,
+        status="rejected",
+        reason_code=REASON_DATA_GAP_IN_POSITION,
+    )
+    counts = no_trade_reason_counts or {}
+    artifact_hash = canonical_sha256(
+        {"base_hash": base_hash, "no_trade_reason_counts": counts}
+    )
+    return ScenarioRunOutcome(
+        scenario_name=scenario_name,
+        status="rejected",
+        trade_count=0,
+        artifact_hash=artifact_hash,
+        error_reason=REASON_DATA_GAP_IN_POSITION,
+        no_trade_reason_counts=counts,
+    )
+
+
+def _run_scenario(
+    bars_slice: tuple[Bar1m, ...],
+    signals: Sequence[SignalEvent],
+    cost_scenario: CostScenario,
+    sidecar: FundingSidecar,
+    gap_ranges: Sequence[tuple[int, int]],
+    *,
+    strategy: str,
+    config_id: str,
+    symbol: str,
+    fold_id: str,
+    pre_execution_rejections: Sequence[NoTradeRecord] = (),
+) -> tuple[ScenarioRunOutcome, EngineResult | None]:
+    """Run ONE independent scenario invocation (fresh engine state, ROB-942
+    R1 discipline).
+
+    Any exception becomes a ``crashed``/``timeout`` terminal outcome, never
+    a silent skip. If ANY resulting trade touches a data gap, the WHOLE
+    trial is terminal-``rejected`` and its entire ledger discarded -- the
+    engine's daily-stop/cooldown/entry-cap state was already computed AS IF
+    the now-invalidated trade were real, so no partial ledger from this run
+    can be trusted, even trades that don't themselves touch the gap.
+
+    ``pre_execution_rejections`` (Fable condition 1): the generator's OWN
+    pre-execution rejection evidence (e.g. H3 S2's
+    ``target_direction_invalid``/``tp_above_max``/etc) -- real, already-
+    observed evidence for this run, merged into ``no_trades`` alongside the
+    funding gate's own rejections, in EVERY terminal path (completed AND
+    gap-rejected), never silently dropped.
+    """
+    # Captain P1 correction (2026-07-17): split into two stages so a crash
+    # can preserve whatever no-trade evidence was ALREADY known at the
+    # point of failure -- pre_execution_rejections (the generator's own,
+    # known from the very start) survive EITHER crash point; funding_rejections
+    # (only known once the funding gate itself has actually run) additionally
+    # survive an engine-stage crash.
+    try:
+        eligible_signals, funding_rejections = _apply_funding_gate(
+            bars_slice, signals, sidecar
+        )
+    except Exception as exc:  # noqa: BLE001 -- deliberate: any child failure becomes terminal crashed/timeout evidence, never a silent skip
+        preserved = _no_trade_reason_counts(
+            EngineResult(trades=(), no_trades=tuple(pre_execution_rejections))
+        )
+        return (
+            _crash_outcome(
+                exc,
+                strategy=strategy,
+                config_id=config_id,
+                symbol=symbol,
+                fold_id=fold_id,
+                scenario_name=cost_scenario.name,
+                no_trade_reason_counts=preserved,
+            ),
+            None,
+        )
+
+    try:
+        ordered_signals = sort_signals_canonically(eligible_signals)
+        funding_lookup = build_funding_lookup({symbol: sidecar})
+        engine_result = run_symbol_stream(
+            bars_slice, ordered_signals, cost_scenario, funding_lookup=funding_lookup
+        )
+    except Exception as exc:  # noqa: BLE001 -- deliberate: any child failure becomes terminal crashed/timeout evidence, never a silent skip
+        preserved = _no_trade_reason_counts(
+            EngineResult(
+                trades=(),
+                no_trades=funding_rejections + tuple(pre_execution_rejections),
+            )
+        )
+        return (
+            _crash_outcome(
+                exc,
+                strategy=strategy,
+                config_id=config_id,
+                symbol=symbol,
+                fold_id=fold_id,
+                scenario_name=cost_scenario.name,
+                no_trade_reason_counts=preserved,
+            ),
+            None,
+        )
+
+    combined_no_trades = (
+        engine_result.no_trades + funding_rejections + tuple(pre_execution_rejections)
+    )
+
+    if any(is_trade_gap_in_position(t, gap_ranges) for t in engine_result.trades):
+        # The funding gate AND the generator's own pre-execution rejections
+        # already ran/were produced (and are real, observed evidence)
+        # BEFORE this gap check -- preserve them rather than silently
+        # dropping them just because the run is ALSO gap-rejected (Fable
+        # Q3: separately countable in every path).
+        preserved_no_trade_counts = _no_trade_reason_counts(
+            EngineResult(
+                trades=(),
+                no_trades=funding_rejections + tuple(pre_execution_rejections),
+            )
+        )
+        return (
+            _rejected_gap_outcome(
+                strategy=strategy,
+                config_id=config_id,
+                symbol=symbol,
+                fold_id=fold_id,
+                scenario_name=cost_scenario.name,
+                no_trade_reason_counts=preserved_no_trade_counts,
+            ),
+            None,
+        )
+
+    merged = EngineResult(trades=engine_result.trades, no_trades=combined_no_trades)
+    outcome = _outcome_from_result(
+        merged,
+        strategy=strategy,
+        config_id=config_id,
+        symbol=symbol,
+        fold_id=fold_id,
+        scenario_name=cost_scenario.name,
+    )
+    return outcome, merged
+
+
+def _record_crash_note(
+    crash_notes: dict[str, list[tuple[str, bool]]],
+    config_id: str,
+    message: str,
+    *,
+    is_timeout: bool,
+) -> None:
+    crash_notes.setdefault(config_id, []).append((message, is_timeout))
+
+
+def _record_gap_note(
+    gap_notes: dict[str, list[str]], config_id: str, message: str
+) -> None:
+    gap_notes.setdefault(config_id, []).append(message)
+
+
+def _json_safe_funding_rate(rate: float) -> float | str:
+    """``canonical_sha256``/``encode_canonical`` fail-closed (raise
+    ``TypeError``) on a non-finite float -- JSONB cannot represent NaN/±Inf.
+    A malformed/non-finite ``last_funding_rate`` is a real state
+    ``evaluate_funding_entry_gate`` already handles (fails closed as
+    ``funding_evidence_unavailable``), so it must not instead escape as an
+    UNACCOUNTED ``TypeError`` from this fingerprint computation -- map it to
+    a stable string sentinel distinct from any finite numeric value, so the
+    fingerprint (and therefore ``train_artifact_hash``) still deterministically
+    reflects it without ever calling ``canonical_sha256`` on the raw
+    non-finite float itself."""
+    if math.isfinite(rate):
+        return rate
+    if math.isnan(rate):
+        return "nonfinite:nan"
+    return "nonfinite:inf" if rate > 0 else "nonfinite:-inf"
+
+
+def _train_relevant_funding_rows(
+    sidecar: FundingSidecar, *, train_start_ms: int, train_end_ms: int
+) -> list:
+    """Captain PIT-scope correction (2026-07-17): only the funding evidence
+    the TRAIN-window entry gate could ever actually consult -- the single
+    last-known row visible AT ``train_start_ms`` (covers every entry from
+    the very start of the window until a newer row appears), plus any row
+    strictly inside ``(train_start_ms, train_end_ms)``. A row at/after
+    ``train_end_ms`` (OOS-only) is NEVER included -- hashing the WHOLE
+    sidecar would make a future OOS-only funding change spuriously alter a
+    TRAIN input hash/selection trace, which never actually saw it."""
+    last_at_start = sidecar.last_known_rate(train_start_ms)
+    window_rows = [
+        r for r in sidecar.rows if train_start_ms < r.calc_time < train_end_ms
+    ]
+    return ([last_at_start] if last_at_start is not None else []) + window_rows
+
+
+def _train_relevant_gap_ranges(
+    gap_ranges_for_symbol: Sequence[tuple[int, int]],
+    *,
+    train_start_ms: int,
+    train_end_ms: int,
+) -> list[tuple[int, int]]:
+    """Only gap ranges that actually INTERSECT ``[train_start_ms, train_end_ms)``
+    -- an OOS-only gap must never alter a TRAIN input hash. Independent
+    audit correction (2026-07-17): hash the CLIPPED intersection
+    (``[max(start, train_start_ms), min(end, train_end_ms)]``), never the
+    gap's own original (possibly partly-OOS) endpoints -- otherwise
+    changing ONLY the OOS-side tail of a gap that merely touches the train
+    window would still alter the TRAIN hash, even though the train-visible
+    portion is unchanged."""
+    return sorted(
+        (max(start, train_start_ms), min(end, train_end_ms))
+        for start, end in gap_ranges_for_symbol
+        if start < train_end_ms and end > train_start_ms
+    )
+
+
+def _train_static_fingerprint(
+    bars: Sequence[Bar1m],
+    sidecar: FundingSidecar,
+    gap_ranges_for_symbol: Sequence[tuple[int, int]],
+    *,
+    train_start_ms: int,
+    train_end_ms: int,
+) -> str:
+    """Captain freeze-audit addendum (2026-07-17, item A) + train-input
+    completeness/PIT-scope/performance follow-ups: ``train_artifact_hash``
+    was previously derived ONLY from the scenario OUTPUT (trades +
+    no_trade_reason_counts) -- two materially DIFFERENT raw inputs (e.g. two
+    distinct ``signal_ts`` values, or identical bars/signals under two
+    different funding-sidecar/gap-range states) that both happen to produce
+    zero trades with the identical no-trade-reason histogram hashed
+    IDENTICALLY, so ``train_input_hash``/the selection trace never actually
+    bound the real INPUT.
+
+    This is the CONFIG-INDEPENDENT half of that fix: the bar slice, the
+    PIT-visible/train-relevant funding evidence (never OOS-only future rows,
+    see ``_train_relevant_funding_rows``), the train-intersecting gap ranges
+    (never OOS-only gaps, see ``_train_relevant_gap_ranges``), and the FIXED
+    primary scenario identity/cost -- ALL of which are IDENTICAL across
+    every config for a given (fold, symbol), so this is computed ONCE per
+    (fold, symbol) by the caller (``_evaluate_fold_train``, 4 calls per
+    fold, never 12x4=48) and reused for every config via
+    ``_combine_static_and_signals`` (cheap: just the small per-config signal
+    list). No production-global mutable call-counter lives here -- a test
+    that needs to prove the exact call count wraps THIS function with its
+    own local ``monkeypatch`` spy instead, so runtime behavior carries no
+    extra mutable instrumentation state.
+    """
+    relevant_funding_rows = _train_relevant_funding_rows(
+        sidecar, train_start_ms=train_start_ms, train_end_ms=train_end_ms
+    )
+    relevant_gap_ranges = _train_relevant_gap_ranges(
+        gap_ranges_for_symbol, train_start_ms=train_start_ms, train_end_ms=train_end_ms
+    )
+    return canonical_sha256(
+        {
+            "bars": [(b.ts, b.open, b.high, b.low, b.close, b.volume) for b in bars],
+            "funding_symbol": sidecar.symbol,
+            "funding_rows": [
+                (
+                    r.calc_time,
+                    r.funding_interval_hours,
+                    _json_safe_funding_rate(r.last_funding_rate),
+                )
+                for r in relevant_funding_rows
+            ],
+            "gap_ranges": relevant_gap_ranges,
+            "scenario_name": COST_SCENARIO_PRIMARY_STRESS.name,
+            "scenario_all_in_bps": COST_SCENARIO_PRIMARY_STRESS.all_in_bps,
+        }
+    )
+
+
+def _combine_static_and_signals(
+    static_hash: str,
+    signals: Sequence[SignalEvent],
+    rejections: Sequence[NoTradeRecord] = (),
+) -> str:
+    """The CONFIG-SPECIFIC half: cheaply combines the precomputed
+    config-independent ``static_hash`` (see ``_train_static_fingerprint``)
+    with this config's own (small) generated-signal list AND its own
+    generator-produced rejection evidence (Fable condition 1 -- canonical,
+    already-validated/sorted by the caller) -- never re-hashes the shared
+    bars/funding/gaps per config."""
+    return canonical_sha256(
+        {
+            "static_hash": static_hash,
+            "signals": [
+                (
+                    s.strategy,
+                    s.config_id,
+                    s.symbol,
+                    s.signal_ts,
+                    s.side,
+                    s.sl_distance_bps,
+                    s.tp_distance_bps,
+                    s.tp_target_price,
+                    s.timeout_bars,
+                    s.cooldown_bars,
+                    s.fold_id,
+                )
+                for s in signals
+            ],
+            "rejections": [
+                (
+                    r.strategy,
+                    r.config_id,
+                    r.symbol,
+                    r.side,
+                    r.signal_ts,
+                    r.reason,
+                    r.fold_id,
+                )
+                for r in rejections
+            ],
+        }
+    )
+
+
+def _bind_train_input(output_hash: str, input_fingerprint: str) -> str:
+    """Combine the (already-computed) output-side hash with the raw-input
+    fingerprint into the FINAL ``train_artifact_hash`` -- deliberately
+    combines rather than replaces, so this stays sensitive to BOTH what was
+    fed in and what came out."""
+    return canonical_sha256(
+        {"input_fingerprint": input_fingerprint, "output_hash": output_hash}
+    )
+
+
+def _zero_evidence(
+    symbol: str,
+    *,
+    train_artifact_hash: str,
+    no_trade_reason_counts: dict[str, int] | None = None,
+) -> SymbolTrainEvidence:
+    """Captain P1 correction (2026-07-17): rejected/crashed/timeout TRAIN
+    outcomes previously always defaulted to an EMPTY no_trade_reason_counts
+    here, silently dropping known no-trade evidence (e.g.
+    target_direction_invalid) that ``outcome`` had already preserved."""
+    return SymbolTrainEvidence(
+        symbol=symbol,
+        completed_trades=0,
+        net_expectancy_bps=0.0,
+        gross_profit_bps=0.0,
+        gross_loss_bps=0.0,
+        train_artifact_hash=train_artifact_hash,
+        no_trade_reason_counts=no_trade_reason_counts or {},
+    )
+
+
+def _train_evidence_for_symbol(
+    strategy: str,
+    config_spec: ConfigSpec,
+    symbol: str,
+    fold: Fold,
+    train_bars: tuple[Bar1m, ...],
+    static_input_hash: str,
+    sidecar: FundingSidecar,
+    gap_ranges: dict[str, tuple[tuple[int, int], ...]],
+    crash_notes: dict[str, list[tuple[str, bool]]],
+    gap_notes: dict[str, list[str]],
+) -> SymbolTrainEvidence:
+    """``train_bars`` (already sliced) and ``static_input_hash`` (the
+    config-independent half of the train-input fingerprint) are precomputed
+    ONCE per (fold, symbol) by the caller -- see ``_train_static_fingerprint``
+    for why (performance: identical across every config for this symbol)."""
+    try:
+        raw_result = config_spec.generate_signals(symbol, train_bars, fold.fold_id)
+        batch = _normalize_generated_batch(raw_result)
+        signals = batch.signals
+        _validate_generated_signals(
+            signals,
+            strategy=strategy,
+            config_id=config_spec.config_id,
+            symbol=symbol,
+            fold_id=fold.fold_id,
+            window_start_ms=fold.train_start_ms,
+            window_end_ms=fold.train_end_ms,
+        )
+        rejections = _validate_generated_rejections(
+            batch.rejections,
+            strategy=strategy,
+            config_id=config_spec.config_id,
+            symbol=symbol,
+            fold_id=fold.fold_id,
+            window_start_ms=fold.train_start_ms,
+            window_end_ms=fold.train_end_ms,
+        )
+        _assert_no_signal_rejection_ts_collision(
+            signals,
+            rejections,
+            strategy=strategy,
+            config_id=config_spec.config_id,
+            symbol=symbol,
+            fold_id=fold.fold_id,
+        )
+        # Independent audit correction (2026-07-17): canonicalize BEFORE
+        # hashing/execution -- a generator's own (implementation-detail)
+        # return order must never change train_artifact_hash, and a
+        # duplicate signal_ts is a terminal failure here too (consistent
+        # with the OOS path's own sort_signals_canonically call), never a
+        # silent pass-through.
+        signals = sort_signals_canonically(signals)
+    except Exception as exc:  # noqa: BLE001 -- child signal-generation failure (incl. forged/out-of-window identity/duplicate signal_ts) is terminal crash evidence
+        _record_crash_note(
+            crash_notes,
+            config_spec.config_id,
+            f"{fold.fold_id}/{symbol}/train/generate_signals: {exc}",
+            is_timeout=isinstance(exc, TimeoutError),
+        )
+        status = "timeout" if isinstance(exc, TimeoutError) else "crashed"
+        reason_code = (
+            REASON_CHILD_EXECUTION_TIMEOUT
+            if status == "timeout"
+            else REASON_CHILD_EXECUTION_CRASHED
+        )
+        sentinel_hash = _stable_terminal_hash(
+            strategy=strategy,
+            config_id=config_spec.config_id,
+            symbol=symbol,
+            fold_id=fold.fold_id,
+            scope="train",
+            status=status,
+            reason_code=reason_code,
+        )
+        # Captain follow-up (2026-07-17): a bare identity+status+reason
+        # sentinel means two DIFFERENT train bars/funding/gaps that happen
+        # to hit the SAME generator failure class would still collide --
+        # bind the already-computed (config-independent) static_input_hash
+        # too, so distinct train-relevant inputs still diverge, while raw
+        # exception/log text (``exc``) still never enters any hash input.
+        return _zero_evidence(
+            symbol,
+            train_artifact_hash=_bind_train_input(sentinel_hash, static_input_hash),
+        )
+
+    # Cheap: combines the precomputed (per-symbol, config-independent)
+    # static_input_hash with THIS config's own small signal list AND its
+    # own canonical (sorted) rejection evidence -- never re-hashes the
+    # shared bars/funding/gaps.
+    input_fingerprint = _combine_static_and_signals(
+        static_input_hash, signals, rejections
+    )
+
+    outcome, filtered = _run_scenario(
+        train_bars,
+        signals,
+        COST_SCENARIO_PRIMARY_STRESS,
+        sidecar,
+        gap_ranges[symbol],
+        strategy=strategy,
+        config_id=config_spec.config_id,
+        symbol=symbol,
+        fold_id=fold.fold_id,
+        pre_execution_rejections=rejections,
+    )
+    if outcome.status == "rejected":
+        _record_gap_note(
+            gap_notes,
+            config_spec.config_id,
+            f"{fold.fold_id}/{symbol}/train/{outcome.scenario_name}: {outcome.error_reason}",
+        )
+        return _zero_evidence(
+            symbol,
+            train_artifact_hash=_bind_train_input(
+                outcome.artifact_hash, input_fingerprint
+            ),
+            no_trade_reason_counts=outcome.no_trade_reason_counts,
+        )
+    if outcome.status != "completed" or filtered is None:
+        _record_crash_note(
+            crash_notes,
+            config_spec.config_id,
+            f"{fold.fold_id}/{symbol}/train/{outcome.scenario_name}: {outcome.error_reason}",
+            is_timeout=(outcome.status == "timeout"),
+        )
+        return _zero_evidence(
+            symbol,
+            train_artifact_hash=_bind_train_input(
+                outcome.artifact_hash, input_fingerprint
+            ),
+            no_trade_reason_counts=outcome.no_trade_reason_counts,
+        )
+
+    trades = filtered.trades
+    completed = len(trades)
+    net_expectancy = (sum(t.net_bps for t in trades) / completed) if completed else 0.0
+    gross_profit = sum(t.net_bps for t in trades if t.net_bps > 0)
+    gross_loss = sum(-t.net_bps for t in trades if t.net_bps < 0)
+    return SymbolTrainEvidence(
+        symbol=symbol,
+        completed_trades=completed,
+        net_expectancy_bps=net_expectancy,
+        gross_profit_bps=gross_profit,
+        gross_loss_bps=gross_loss,
+        train_artifact_hash=_bind_train_input(outcome.artifact_hash, input_fingerprint),
+        no_trade_reason_counts=outcome.no_trade_reason_counts,
+    )
+
+
+def _evaluate_fold_train(
+    strategy: str,
+    configs: Sequence[ConfigSpec],
+    bars_1m: dict[str, tuple[Bar1m, ...]],
+    funding_sidecars: dict[str, FundingSidecar],
+    gap_ranges: dict[str, tuple[tuple[int, int], ...]],
+    fold: Fold,
+    crash_notes: dict[str, list[tuple[str, bool]]],
+    gap_notes: dict[str, list[str]],
+) -> list[ConfigTrainCandidate]:
+    # Captain performance correction (2026-07-17): bar-slicing and the
+    # config-independent static train-input fingerprint are IDENTICAL across
+    # every config for a given (fold, symbol) -- computed ONCE per symbol
+    # here (4 times per fold), never once per (config, symbol) (48 times
+    # per fold), which is what made a naive per-config recomputation
+    # prohibitive for real 120-day 1m slices.
+    evidence_by_config: dict[str, list[SymbolTrainEvidence]] = {
+        spec.config_id: [] for spec in configs
+    }
+    for symbol in frozen.UNIVERSE:
+        train_bars = _slice_bars(
+            bars_1m[symbol], fold.train_start_ms, fold.train_end_ms
+        )
+        sidecar = funding_sidecars[symbol]
+        static_input_hash = _train_static_fingerprint(
+            train_bars,
+            sidecar,
+            gap_ranges[symbol],
+            train_start_ms=fold.train_start_ms,
+            train_end_ms=fold.train_end_ms,
+        )
+        for spec in configs:
+            evidence_by_config[spec.config_id].append(
+                _train_evidence_for_symbol(
+                    strategy,
+                    spec,
+                    symbol,
+                    fold,
+                    train_bars,
+                    static_input_hash,
+                    sidecar,
+                    gap_ranges,
+                    crash_notes,
+                    gap_notes,
+                )
+            )
+    return [
+        ConfigTrainCandidate(
+            config_id=spec.config_id,
+            symbol_evidence=tuple(evidence_by_config[spec.config_id]),
+        )
+        for spec in configs
+    ]
+
+
+def _evaluate_fold_oos(
+    strategy: str,
+    config_spec: ConfigSpec,
+    bars_1m: dict[str, tuple[Bar1m, ...]],
+    funding_sidecars: dict[str, FundingSidecar],
+    gap_ranges: dict[str, tuple[tuple[int, int], ...]],
+    fold: Fold,
+    crash_notes: dict[str, list[tuple[str, bool]]],
+    gap_notes: dict[str, list[str]],
+) -> tuple[tuple[ScenarioRunOutcome, ...], dict[str, list[TradeRecord]]]:
+    outcomes: list[ScenarioRunOutcome] = []
+    ledgers: dict[str, list[TradeRecord]] = {s.name: [] for s in COST_SCENARIOS}
+
+    for symbol in frozen.UNIVERSE:
+        oos_bars = _slice_bars(bars_1m[symbol], fold.oos_start_ms, fold.oos_end_ms)
+        sidecar = funding_sidecars[symbol]
+        try:
+            raw_result = config_spec.generate_signals(symbol, oos_bars, fold.fold_id)
+            batch = _normalize_generated_batch(raw_result)
+            signals = batch.signals
+            _validate_generated_signals(
+                signals,
+                strategy=strategy,
+                config_id=config_spec.config_id,
+                symbol=symbol,
+                fold_id=fold.fold_id,
+                window_start_ms=fold.oos_start_ms,
+                window_end_ms=fold.oos_end_ms,
+            )
+            rejections = _validate_generated_rejections(
+                batch.rejections,
+                strategy=strategy,
+                config_id=config_spec.config_id,
+                symbol=symbol,
+                fold_id=fold.fold_id,
+                window_start_ms=fold.oos_start_ms,
+                window_end_ms=fold.oos_end_ms,
+            )
+            _assert_no_signal_rejection_ts_collision(
+                signals,
+                rejections,
+                strategy=strategy,
+                config_id=config_spec.config_id,
+                symbol=symbol,
+                fold_id=fold.fold_id,
+            )
+        except Exception as exc:  # noqa: BLE001 -- child signal-generation failure (incl. forged/out-of-window identity) is terminal crash evidence
+            _record_crash_note(
+                crash_notes,
+                config_spec.config_id,
+                f"{fold.fold_id}/{symbol}/oos/generate_signals: {exc}",
+                is_timeout=isinstance(exc, TimeoutError),
+            )
+            for scenario in COST_SCENARIOS:
+                outcomes.append(
+                    _crash_outcome(
+                        exc,
+                        strategy=strategy,
+                        config_id=config_spec.config_id,
+                        symbol=symbol,
+                        fold_id=fold.fold_id,
+                        scenario_name=scenario.name,
+                    )
+                )
+            continue
+
+        for scenario in COST_SCENARIOS:
+            # Fable condition 1: this generator's own pre-execution
+            # rejection evidence (e.g. H3 S2's target_direction_invalid) is
+            # merged into EACH independent fresh scenario run alongside the
+            # funding gate's/engine's own no-trades -- never a shared-path
+            # revaluation, matching the 3-independent-runs discipline.
+            outcome, filtered = _run_scenario(
+                oos_bars,
+                signals,
+                scenario,
+                sidecar,
+                gap_ranges[symbol],
+                strategy=strategy,
+                config_id=config_spec.config_id,
+                symbol=symbol,
+                fold_id=fold.fold_id,
+                pre_execution_rejections=rejections,
+            )
+            outcomes.append(outcome)
+            if outcome.status == "rejected":
+                _record_gap_note(
+                    gap_notes,
+                    config_spec.config_id,
+                    f"{fold.fold_id}/{symbol}/oos/{scenario.name}: {outcome.error_reason}",
+                )
+                continue
+            if outcome.status != "completed" or filtered is None:
+                _record_crash_note(
+                    crash_notes,
+                    config_spec.config_id,
+                    f"{fold.fold_id}/{symbol}/oos/{scenario.name}: {outcome.error_reason}",
+                    is_timeout=(outcome.status == "timeout"),
+                )
+                continue
+            ledgers[scenario.name].extend(filtered.trades)
+
+    return tuple(outcomes), ledgers
+
+
+def run_walkforward(
+    *,
+    strategy: str,
+    configs: tuple[ConfigSpec, ...],
+    bars_1m: dict[str, tuple[Bar1m, ...]],
+    funding_sidecars: dict[str, FundingSidecar],
+    gap_ranges: dict[str, tuple[tuple[int, int], ...]],
+    fold_schedule: tuple[Fold, ...],
+) -> WalkForwardResult:
+    """Run the full walk-forward for ONE strategy's 12 frozen configs.
+
+    Fails closed immediately (``MissingSymbolDataError``) unless
+    ``bars_1m``/``funding_sidecars``/``gap_ranges`` cover EXACTLY the frozen
+    4-symbol universe -- no fold work happens otherwise. Selection uses
+    TRAIN evidence only and is immutable once made for a fold; OOS
+    execution/ledgers are NEVER fed back into selection. Every one of the
+    (exactly 12) configs gets exactly one ``ConfigAttemptResult``,
+    regardless of whether it ever won a fold.
+    """
+    _validate_exact_universe_coverage(bars_1m, funding_sidecars, gap_ranges)
+
+    if len(configs) != _EXPECTED_CONFIGS_PER_STRATEGY:
+        raise ValueError(
+            f"{strategy}: expected exactly {_EXPECTED_CONFIGS_PER_STRATEGY} configs, "
+            f"got {len(configs)}"
+        )
+    config_ids = [c.config_id for c in configs]
+    if len(set(config_ids)) != len(config_ids):
+        raise ValueError(f"{strategy}: duplicate config_id in configs")
+
+    fold_results: list[FoldWalkForwardResult] = []
+    selected_in_folds: dict[str, list[str]] = {cid: [] for cid in config_ids}
+    crash_notes: dict[str, list[tuple[str, bool]]] = {cid: [] for cid in config_ids}
+    gap_notes: dict[str, list[str]] = {cid: [] for cid in config_ids}
+    ever_eligible: dict[str, bool] = dict.fromkeys(config_ids, False)
+    concatenated_by_scenario: dict[str, list[TradeRecord]] = {
+        s.name: [] for s in COST_SCENARIOS
+    }
+
+    for fold in fold_schedule:
+        candidates = _evaluate_fold_train(
+            strategy,
+            configs,
+            bars_1m,
+            funding_sidecars,
+            gap_ranges,
+            fold,
+            crash_notes,
+            gap_notes,
+        )
+        trace = select_fold_config(strategy, candidates)
+        for outcome in trace.candidates:
+            if not outcome.rejected:
+                ever_eligible[outcome.config_id] = True
+
+        oos_outcomes: tuple[ScenarioRunOutcome, ...] = ()
+        if trace.selected_config_id is not None:
+            winner_spec = next(
+                c for c in configs if c.config_id == trace.selected_config_id
+            )
+            oos_outcomes, ledgers = _evaluate_fold_oos(
+                strategy,
+                winner_spec,
+                bars_1m,
+                funding_sidecars,
+                gap_ranges,
+                fold,
+                crash_notes,
+                gap_notes,
+            )
+            selected_in_folds[trace.selected_config_id].append(fold.fold_id)
+            for scenario_name, trades in ledgers.items():
+                concatenated_by_scenario[scenario_name].extend(trades)
+
+        fold_results.append(
+            FoldWalkForwardResult(
+                fold=fold, selection_trace=trace, oos_outcomes=oos_outcomes
+            )
+        )
+
+    config_attempts = []
+    for cid in config_ids:
+        entries = crash_notes[cid]
+        crash_log = tuple(message for message, _is_timeout in entries)
+        gap_rejection_log = tuple(gap_notes[cid])
+        # Priority (most severe first): a genuine code crash/timeout always
+        # wins; else ANY data-gap rejection anywhere (train or OOS) makes
+        # the WHOLE attempt "rejected:data_gap_in_position" -- never
+        # "completed" merely because the config was otherwise eligible
+        # elsewhere (captain correction: a gap-contaminated trial must not
+        # be silently absorbed into an otherwise-clean attempt); else
+        # "rejected" if never train-eligible in any fold; else "completed".
+        if entries:
+            # "timeout" only if EVERY failure for this config was a timeout;
+            # any non-timeout crash makes the whole attempt "crashed" (the
+            # more generic, non-recoverable-by-waiting-longer classification).
+            status: AttemptStatus = (
+                "timeout" if all(is_to for _m, is_to in entries) else "crashed"
+            )
+            reason_code = None
+        elif gap_rejection_log:
+            status = "rejected"
+            reason_code = REASON_DATA_GAP_IN_POSITION
+        elif not ever_eligible[cid]:
+            status = "rejected"
+            reason_code = REASON_INSUFFICIENT_TRAIN_EVIDENCE_ALL_FOLDS
+        else:
+            status = "completed"
+            reason_code = None
+        config_attempts.append(
+            ConfigAttemptResult(
+                strategy=strategy,
+                config_id=cid,
+                status=status,
+                reason_code=reason_code,
+                selected_in_folds=tuple(selected_in_folds[cid]),
+                crash_log=crash_log,
+                gap_rejection_log=gap_rejection_log,
+            )
+        )
+
+    concatenated_oos_ledgers = {
+        scenario_name: tuple(sorted(trades, key=_canonical_trade_key))
+        for scenario_name, trades in concatenated_by_scenario.items()
+    }
+
+    return WalkForwardResult(
+        strategy=strategy,
+        folds=tuple(fold_results),
+        config_attempts=tuple(config_attempts),
+        concatenated_oos_ledgers=concatenated_oos_ledgers,
+    )
+
+
+def _json_safe_float_or_sentinel(value: float | None) -> float | str | None:
+    """Captain P1 correction (2026-07-17): a rejected candidate's
+    ``profit_factor`` is ``math.nan`` and a legitimate zero-loss winner's
+    can be ``math.inf`` -- both are real, meaningful values that must still
+    be BOUND into the hash (never silently dropped), but ``canonical_sha256``
+    fails closed on non-finite floats (JSONB cannot represent them). Maps
+    non-finite values to a stable, JSON/canonical-safe string sentinel;
+    ``None`` (e.g. a rejected candidate's ``equal_weight_expectancy_bps``)
+    and finite floats pass through unchanged."""
+    if value is None:
+        return None
+    if math.isfinite(value):
+        return value
+    if math.isnan(value):
+        return "nonfinite:nan"
+    return "nonfinite:inf" if value > 0 else "nonfinite:-inf"
+
+
+@dataclass(frozen=True)
+class FoldSelectionEvidenceSummary:
+    """Captain P1 end-to-end provenance correction (2026-07-17): a compact,
+    canonical per-config/per-fold TRAIN selection trace --
+    ``summarize_config_attempts_for_h6`` previously only consulted
+    ``FoldSelectionTrace.selected_config_id`` (who won), never each config's
+    own ``ConfigSelectionOutcome`` (eligible/excluded symbols, expectancy,
+    profit factor, rejection reason, ``train_input_hash``, no-trade counts)
+    -- so a TRAIN-only mutation (e.g. a price change that alters
+    ``train_input_hash`` but does not change which config eventually won
+    OOS in every fold) was silently INVISIBLE to the final
+    ``fold_evidence_hash``/``run_identity``. One entry per fold (fold order),
+    for every config, whether or not that config won that fold."""
+
+    fold_id: str
+    fold_selected_config_id: str | None
+    eligible_symbols: tuple[str, ...]
+    excluded_symbols: tuple[tuple[str, str], ...]
+    equal_weight_expectancy_bps: float | None
+    pooled_expectancy_bps: float | None
+    profit_factor: float
+    rejected: bool
+    rejection_reason: str | None
+    train_input_hash: str
+    no_trade_reason_counts: dict[str, int]
+
+
+@dataclass(frozen=True)
+class ScenarioEvidenceSummary:
+    """One config's ONE scenario's aggregate evidence across every fold it
+    was selected in. Captain correction (2026-07-17): H6's ``ScenarioEvidence``
+    DTO has no status field, so a hash alone is not REPORT EXPOSURE of which
+    of base/17/22 failed -- this H4-owned summary preserves ``status``,
+    a FIXED ``reason_code`` (never raw text), ``trade_count``, the combined
+    ``artifact_hash``, AND the combined ``no_trade_reason_counts`` histogram
+    (Fable Q3: funding_evidence_unavailable/expected_funding_cost_above_3bps
+    must stay separately countable, not just hash-committed) -- readable
+    through the whole H4->H6/CLI conversion boundary, independent of H6's
+    own (unmodified) schema.
+    """
+
+    scenario_name: str
+    status: AggregateScenarioStatus
+    reason_code: str | None
+    trade_count: int
+    artifact_hash: str
+    no_trade_reason_counts: dict[str, int]
+
+
+@dataclass(frozen=True)
+class ConfigAttemptEvidenceSummary:
+    """One config's H6-ready terminal evidence, aggregated ACROSS every fold
+    it was selected in (never selected -> a deterministic sentinel per
+    scenario, not a missing/None value -- H6's ``ScenarioEvidence`` schema
+    requires exactly 3 rows regardless). ``reason_code`` is always a FIXED,
+    stable code (never raw exception/log text). This summary deliberately
+    has NO ``run_identity`` field: that requires lineage facts (full-campaign
+    hash, campaign_run_id, canonical experiment_id, retry_index) this pure
+    module has no way to know -- the caller (app-side controller/CLI, which
+    DOES know them) computes the final ``run_identity`` when building
+    ``AttemptEvidence``.
+    """
+
+    strategy: str
+    config_id: str
+    status: AttemptStatus
+    reason_code: str | None
+    scenario_summaries: tuple[ScenarioEvidenceSummary, ...]
+    fold_selection_trace: tuple[FoldSelectionEvidenceSummary, ...] = ()
+
+
+def _combine_scenario_outcomes(
+    strategy: str,
+    config_id: str,
+    scenario_name: str,
+    outcomes: list[ScenarioRunOutcome],
+) -> ScenarioEvidenceSummary:
+    if not outcomes:
+        artifact_hash = canonical_sha256(
+            {
+                "strategy": strategy,
+                "config_id": config_id,
+                "scenario_name": scenario_name,
+                "note": REASON_NEVER_SELECTED_IN_ANY_FOLD,
+            }
+        )
+        return ScenarioEvidenceSummary(
+            scenario_name=scenario_name,
+            status="never_selected",
+            reason_code=REASON_NEVER_SELECTED_IN_ANY_FOLD,
+            trade_count=0,
+            artifact_hash=artifact_hash,
+            no_trade_reason_counts={},
+        )
+
+    worst = max(outcomes, key=lambda o: _STATUS_SEVERITY[o.status])
+    status: AggregateScenarioStatus = worst.status
+    if status == "crashed":
+        reason_code = REASON_CHILD_EXECUTION_CRASHED
+    elif status == "timeout":
+        reason_code = REASON_CHILD_EXECUTION_TIMEOUT
+    elif status == "rejected":
+        reason_code = REASON_DATA_GAP_IN_POSITION
+    else:
+        reason_code = None
+
+    total_trades = sum(o.trade_count for o in outcomes)
+    combined_reason_counts: dict[str, int] = {}
+    for o in outcomes:
+        for reason, count in o.no_trade_reason_counts.items():
+            combined_reason_counts[reason] = (
+                combined_reason_counts.get(reason, 0) + count
+            )
+    combined_hash = canonical_sha256(
+        {
+            "strategy": strategy,
+            "config_id": config_id,
+            "scenario_name": scenario_name,
+            "status": status,
+            "fold_artifact_hashes": [o.artifact_hash for o in outcomes],
+        }
+    )
+    return ScenarioEvidenceSummary(
+        scenario_name=scenario_name,
+        status=status,
+        reason_code=reason_code,
+        trade_count=total_trades,
+        artifact_hash=combined_hash,
+        no_trade_reason_counts=combined_reason_counts,
+    )
+
+
+def summarize_config_attempts_for_h6(
+    result: WalkForwardResult,
+) -> tuple[ConfigAttemptEvidenceSummary, ...]:
+    """Pure aggregation from a completed ``run_walkforward`` result into the
+    exactly-3-scenario-rows-per-config shape H6's ``AttemptEvidence`` needs,
+    while preserving PER-SCENARIO status/reason/count/artifact/no-trade-
+    reason-histogram evidence (see ``ScenarioEvidenceSummary``).
+
+    For each config, every fold it WON contributes that fold's 4-symbols x
+    per-scenario ``ScenarioRunOutcome``s; these are combined per scenario
+    (most-severe-status-wins) into one aggregate row. A config never
+    selected in any fold gets a deterministic ``never_selected`` sentinel
+    per scenario, with ``trade_count=0`` -- never a missing/None row.
+
+    Security: only ``ScenarioRunOutcome.artifact_hash`` (a SHA-256 digest,
+    preimage-resistant, itself bound only to stable identity/status/reason,
+    never raw exception text) and fixed reason codes cross into the returned
+    summary -- raw exception/log text (``ConfigAttemptResult.crash_log``,
+    ``ScenarioRunOutcome.error_reason``) never does.
+    """
+    by_config_scenario: dict[str, dict[str, list[ScenarioRunOutcome]]] = {
+        a.config_id: {s.name: [] for s in COST_SCENARIOS}
+        for a in result.config_attempts
+    }
+    for fold_result in result.folds:
+        winner = fold_result.selection_trace.selected_config_id
+        if winner is None:
+            continue
+        for outcome in fold_result.oos_outcomes:
+            by_config_scenario[winner][outcome.scenario_name].append(outcome)
+
+    summaries: list[ConfigAttemptEvidenceSummary] = []
+    for attempt in result.config_attempts:
+        scenario_rows = tuple(
+            _combine_scenario_outcomes(
+                result.strategy,
+                attempt.config_id,
+                scenario.name,
+                by_config_scenario[attempt.config_id][scenario.name],
+            )
+            for scenario in COST_SCENARIOS
+        )
+
+        if attempt.status == "crashed":
+            reason_code = REASON_CHILD_EXECUTION_CRASHED
+        elif attempt.status == "timeout":
+            reason_code = REASON_CHILD_EXECUTION_TIMEOUT
+        else:
+            reason_code = (
+                attempt.reason_code
+            )  # "rejected" reason, or None for "completed"
+
+        # Captain P1 correction: this config's OWN ConfigSelectionOutcome,
+        # per fold (fold order) -- makes TRAIN-only evidence (eligible/
+        # excluded, expectancy, profit factor, rejection reason,
+        # train_input_hash, no-trade counts) part of this config's
+        # returned evidence, not silently dropped after selection.
+        fold_selection_trace = []
+        for fold_result in result.folds:
+            candidate = next(
+                (
+                    c
+                    for c in fold_result.selection_trace.candidates
+                    if c.config_id == attempt.config_id
+                ),
+                None,
+            )
+            if candidate is None:
+                continue
+            fold_selection_trace.append(
+                FoldSelectionEvidenceSummary(
+                    fold_id=fold_result.fold.fold_id,
+                    fold_selected_config_id=fold_result.selection_trace.selected_config_id,
+                    eligible_symbols=candidate.eligible_symbols,
+                    excluded_symbols=candidate.excluded_symbols,
+                    equal_weight_expectancy_bps=candidate.equal_weight_expectancy_bps,
+                    pooled_expectancy_bps=candidate.pooled_expectancy_bps,
+                    profit_factor=candidate.profit_factor,
+                    rejected=candidate.rejected,
+                    rejection_reason=candidate.rejection_reason,
+                    train_input_hash=candidate.train_input_hash,
+                    no_trade_reason_counts=candidate.no_trade_reason_counts,
+                )
+            )
+
+        summaries.append(
+            ConfigAttemptEvidenceSummary(
+                strategy=result.strategy,
+                config_id=attempt.config_id,
+                status=attempt.status,
+                reason_code=reason_code,
+                scenario_summaries=scenario_rows,
+                fold_selection_trace=tuple(fold_selection_trace),
+            )
+        )
+    return tuple(summaries)

--- a/research/nautilus_scalping/run_rob944_campaign.py
+++ b/research/nautilus_scalping/run_rob944_campaign.py
@@ -1,0 +1,2195 @@
+#!/usr/bin/env python3
+"""ROB-944 (H4, ROB-940) — walk-forward campaign CLI: --plan / --run boundary.
+
+``--plan`` is PURE: no network, DB connection/query/write, file-artifact
+write, environment mutation, or child run. It validates the full frozen
+ROB-940 campaign envelope and emits stable, machine-readable JSON --
+byte-identical across repeated invocations and across ``PYTHONHASHSEED``.
+The 24 canonical experiment IDs are derived via the PURE
+``research_contracts.canonical_hash`` authority (the same algorithm H6's
+registry uses) -- ``--plan`` never imports ``app.*``. The plan also emits
+``expected_campaign_run_id``: the ONE deterministic ``campaign_run_id`` a
+``--run`` invocation for this exact frozen campaign must supply (see
+``_derive_primary_campaign_run_id`` -- never a UUID/wall-clock value).
+
+``--run`` is the empirical execution path, gated IN THIS ORDER, fail-closed
+on the first unmet condition, before any later step:
+
+  1. a FRESH recomputation of the full-campaign hash + 24 identities,
+     compared against an operator-pinned ``--expected-full-campaign-hash``
+     (never two values both freshly derived from the same call -- that
+     would be vacuous), AND a check that ``--campaign-run-id`` exactly
+     equals the value canonically DERIVED from that hash -- an arbitrary
+     caller-supplied UUID/timestamp is rejected, not merely accepted as-is;
+  2. the H6 registration bridge (``app.services.rob944_campaign_controller``)
+     is importable;
+  3. an explicit, default-off write opt-in
+     (``ROB944_RESEARCH_WRITE_OPT_IN=true``);
+  4. an authorized non-production research DB target
+     (``app.services.research_db_write_guard``'s policy, positively matched
+     against the actual resolved session bind);
+  5. all 24 experiment registrations, with the resulting mapping PREDECLARED
+     before any child execution;
+  6. ONLY THEN: corpus loading (network-0 offline loader) + per-strategy
+     walk-forward execution + recording all 24 deterministic
+     ``retry_index=0`` attempts (each ``completed``/``rejected``/``crashed``/
+     ``timeout``, with 3 required scenario artifact hashes/counts) +
+     ``campaign_completeness_report``.
+
+Accounting completeness (H6's verdict) is NOT the same as empirical success:
+a campaign can be fully, correctly RECORDED (every attempt accounted for)
+while every attempt's own status is ``crashed``/``rejected``/``timeout``.
+``main`` distinguishes the two -- exit 0 requires BOTH accounting-complete
+AND every primary attempt ``status="completed"``; anything else exits
+nonzero, even though the (legitimate, accurate) evidence was still
+committed.
+
+This worker (ROB-944 H4) NEVER invokes ``--run`` -- every empirical run is a
+deliberate, later, operator action. This file is nonetheless the COMPLETE,
+correct implementation (not a stub) so that a later operator invocation
+needs no further wiring; it is unit-tested throughout with fixtures/local
+disposable-DB only (see the ``tests/`` alongside this file and
+``tests/services/research/test_rob944_campaign_controller.py``).
+
+Security (captain corrections, 2026-07-17): no raw exception/log text ever
+reaches a persisted ``reason_code`` OR any persisted artifact hash's INPUT
+-- ``rob944_walkforward`` maps every crash/timeout/gap-rejection to a FIXED
+code and hashes only stable identity + that code, never ``str(exc)``; this
+module additionally re-validates every ``reason_code`` against the SAME
+closed allowlist before building any ``AttemptEvidence`` (defense in depth
+against a caller who bypasses ``summarize_config_attempts_for_h6``).
+``campaign_run_id``/``run_identity`` are always deterministic canonical
+hashes of lineage facts -- never a wall-clock timestamp or UUID.
+
+``--help``/``--version`` are handled entirely by argparse before any of this
+module's own gate logic runs -- they never touch DB/network/runtime
+surfaces.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+# Captain config/plan audit (2026-07-18, item C): this module previously
+# mutated process-global ``sys.path`` at IMPORT TIME (inserting its own
+# directory + the repo root) so that a bare ``import rob944_frozen_campaign``
+# and ``from app.services...`` would resolve. That mutation is redundant in
+# BOTH real invocation modes and has been removed rather than restructured:
+# (1) direct script execution (``python .../run_rob944_campaign.py``) --
+# CPython itself already prepends the executed script's own directory to
+# ``sys.path[0]`` before running it, so ``rob944_frozen_campaign`` (a
+# sibling module) resolves with no help from this file; (2) test/module
+# import (``import run_rob944_campaign``) -- this package's ``conftest.py``
+# already inserts both paths before any test module is collected. ``app.*``
+# resolves in both modes purely from the project's own editable install
+# (verified: ``uv run python3 -c "import app"`` succeeds regardless of cwd,
+# with no path manipulation anywhere). Removing this satisfies the pure
+# ``--plan`` command contract (no process-global state mutation as a
+# side effect of merely importing this module) without weakening direct
+# CLI usability -- both invocation paths were empirically re-verified
+# after removal (this file's own test suite, and a bare
+# ``uv run python3 research/nautilus_scalping/run_rob944_campaign.py --plan``).
+from rob944_frozen_campaign import (
+    H1_MANIFEST_PATH,
+    PRODUCTION_S1_STRATEGY_KEY,
+    PRODUCTION_S2_STRATEGY_KEY,
+    build_production_frozen_campaign_envelope,
+)
+
+__version__ = "rob944-campaign-cli.v1"
+
+_ENV_WRITE_OPT_IN = "ROB944_RESEARCH_WRITE_OPT_IN"
+_ENV_ARTIFACT_ROOT = "AUTO_TRADER_RESEARCH_ARTIFACT_ROOT"
+
+
+class RunPreflightError(RuntimeError):
+    """A ``--run`` fail-closed gate was not satisfied."""
+
+
+def _derive_experiment_ids(rows: list[dict]) -> list[str]:
+    """The 24 canonical experiment IDs, derived via the PURE
+    ``research_contracts.canonical_hash`` authority (identical algorithm to
+    H6's registry) -- no ``app.*`` import, no DB, no network. ``rows`` MUST
+    be plain dicts (e.g. from ``FrozenCampaignEnvelope.to_dict()["rows"]``,
+    never the envelope's own sealed ``MappingProxyType`` fields directly --
+    ``encode_canonical`` does not accept ``mappingproxy``).
+    """
+    from research_contracts.canonical_hash import (
+        compute_identity_hashes,
+        derive_experiment_id,
+    )
+
+    ids = []
+    for row in rows:
+        components = row["components"]
+        hashes = compute_identity_hashes(components)
+        ids.append(
+            derive_experiment_id(row["strategy_key"], row["strategy_version"], hashes)
+        )
+    return ids
+
+
+def _derive_primary_campaign_run_id(full_campaign_hash: str) -> str:
+    """The ONE deterministic ``campaign_run_id`` for the primary run of a
+    given frozen campaign -- a canonical hash of the campaign's own identity
+    and a fixed run-kind label, never a UUID/wall-clock value. A ``--run``
+    invocation MUST supply exactly this value; any other string (a UUID, a
+    timestamp, an operator typo) is rejected.
+
+    Fable Q1 FINAL (orch-fable-answer-rob944b-20260717.md, 2026-07-17):
+    derivation payload is the canonical ``{full_campaign_hash, kind:
+    "primary_run"}`` dict -> SHA-256 -> the full 32-byte digest re-encoded
+    as UNPADDED URL-safe base64 (43 chars) -- NOT the 64-hex string, and NOT
+    a truncation of it. Full 256-bit entropy is preserved (a re-encoding,
+    not a shortening) while fitting H6's existing
+    ``trial_idempotency_key VARCHAR(128)`` composite
+    (``campaign_run_id:experiment_id:retry_index``) without any H6
+    schema/source mutation: ``"rob944-primary-"`` (15) + 43 = 58-char
+    campaign_run_id; 58 + 1 + 64 (experiment_id, unchanged full-hex) + 1 +
+    1 ("0") = 125 <= 128. ``app.services.rob944_campaign_controller``
+    duplicates this EXACT derivation (see its own
+    ``_derive_expected_campaign_run_id``) as an independent defense-in-depth
+    check at the actual DB persistence boundary -- both must always agree
+    bit-for-bit.
+    """
+    import base64
+
+    from research_contracts.canonical_hash import canonical_sha256
+
+    digest_hex = canonical_sha256(
+        {"full_campaign_hash": full_campaign_hash, "kind": "primary_run"}
+    )
+    digest_bytes = bytes.fromhex(digest_hex)
+    suffix = base64.urlsafe_b64encode(digest_bytes).rstrip(b"=").decode("ascii")
+    return f"rob944-primary-{suffix}"
+
+
+def build_plan() -> dict:
+    """Build the pure, stable --plan payload. Raises on any frozen-pin
+    mismatch or malformed campaign shape -- never silently degrades.
+
+    Uses ``envelope.to_dict()`` (a plain, JSON-serializable structure)
+    throughout, never the envelope's own sealed ``MappingProxyType``
+    fields directly -- those exist to make the envelope immutable, not to
+    be handed to ``json.dumps``/``encode_canonical`` (neither accepts
+    ``mappingproxy``).
+    """
+    envelope = build_production_frozen_campaign_envelope()
+    plain = envelope.to_dict()
+    # Q4 addendum (captain, 2026-07-17): the envelope itself now carries the
+    # ordered 24 experiment IDs as an explicit, hashed component (step 3 of
+    # the acyclic chain) -- ``plain["experiment_ids"]`` IS the authoritative
+    # value the just-computed full_campaign_hash below commits to. A fresh,
+    # independent recomputation off the same rows must agree exactly; any
+    # divergence would mean the envelope's own internal derivation and this
+    # CLI's derivation authority have drifted apart.
+    experiment_ids = plain["experiment_ids"]
+    if len(experiment_ids) != 24 or len(set(experiment_ids)) != 24:
+        raise RuntimeError(
+            f"expected exactly 24 unique experiment IDs, got {len(experiment_ids)} "
+            f"total ({len(set(experiment_ids))} unique)"
+        )
+    if list(experiment_ids) != _derive_experiment_ids(plain["rows"]):
+        raise RuntimeError(
+            "envelope-embedded experiment_ids diverged from an independent "
+            "recomputation off the same rows -- refusing to proceed"
+        )
+    full_campaign_hash = envelope.full_campaign_hash()
+    # Captain config/plan audit (2026-07-18, item A): --plan must emit a
+    # LOSSLESS, machine-resolvable payload an external auditor can feed
+    # straight back into canonical_sha256 to independently reproduce
+    # full_campaign_hash -- never merely assert an opaque digest. ``plain``
+    # (envelope.to_dict()) IS the exact structure full_campaign_hash() was
+    # computed from; self-verify that here (cheap, and catches any future
+    # drift between to_dict()'s shape and full_campaign_hash()'s own
+    # internal computation) before ever emitting it as authoritative.
+    from research_contracts.canonical_hash import canonical_sha256
+
+    if canonical_sha256(plain) != full_campaign_hash:
+        raise RuntimeError(
+            "full_campaign_payload does not independently reproduce "
+            "full_campaign_hash -- refusing to emit an unauditable plan"
+        )
+    # Captain config/plan audit (item A): explicit, top-level, actual
+    # byte-derived S1/S2 source SHA-256s -- extracted from the SAME rows
+    # already bound into full_campaign_hash (components["code"] carries
+    # each row's StrategySourceProvenance.verified_source_sha256()), never
+    # re-read/re-derived independently (which could silently diverge from
+    # what was actually hashed).
+    s1_source_sha256 = next(
+        row["components"]["code"]["source_sha256"]
+        for row in plain["rows"]
+        if row["strategy_key"] == PRODUCTION_S1_STRATEGY_KEY
+    )
+    s2_source_sha256 = next(
+        row["components"]["code"]["source_sha256"]
+        for row in plain["rows"]
+        if row["strategy_key"] == PRODUCTION_S2_STRATEGY_KEY
+    )
+    cost = plain["rows"][0]["components"]["cost"]
+    return {
+        "schema_version": plain["schema_version"],
+        "full_campaign_hash": full_campaign_hash,
+        # Captain config/plan audit (item A): the exact, complete payload
+        # full_campaign_hash was computed from -- canonical_sha256(this
+        # field) MUST equal full_campaign_hash above; any external auditor
+        # can verify this without trusting the CLI's own self-check.
+        "full_campaign_payload": plain,
+        "s1_source_sha256": s1_source_sha256,
+        "s2_source_sha256": s2_source_sha256,
+        "expected_campaign_run_id": _derive_primary_campaign_run_id(full_campaign_hash),
+        "window_start_iso": plain["window_start_iso"],
+        "window_end_iso": plain["window_end_iso"],
+        "universe": plain["universe"],
+        "dataset_manifest_hash": plain["dataset_manifest_hash"],
+        "signal_manifest_hash": plain["signal_manifest_hash"],
+        "fold_schedule": plain["fold_schedule"],
+        "fold_count": len(plain["fold_schedule"]),
+        "scenario_execution": plain["scenario_execution"],
+        "cost_scenarios": cost["scenarios"],
+        "primary_scenario": cost["primary_scenario"],
+        "min_tp_distance_bps": cost["min_tp_distance_bps"],
+        "funding_pit_policy": plain["funding_pit_policy"],
+        "data_gap_policy": plain["data_gap_policy"],
+        "posture": plain["posture"],
+        "execution_code_provenance": plain["execution_code_provenance"],
+        "h3_fixed_constants": plain["h3_fixed_constants"],
+        "h4_reason_contract": plain["h4_reason_contract"],
+        "experiment_ids": experiment_ids,
+        "expected_logical_attempts": len(experiment_ids),
+        # Fable report/register closure (2026-07-17): H5 is out of scope --
+        # H4 only hands off a READABLE contract. Top-level (not nested
+        # inside h3_fixed_constants) for operator discoverability; the
+        # verbatim Korean S2 spec-deviation sentence (Fable condition 2,
+        # do not re-word) must survive unchanged into the eventual freeze
+        # echo/completion report/H5 handoff.
+        "spec_deviations": plain["h3_fixed_constants"]["s2_spec_deviations"],
+        "campaign_run_id_derivation": {
+            "payload": {
+                "full_campaign_hash": "<the full_campaign_hash above>",
+                "kind": "primary_run",
+            },
+            "recipe": "SHA-256 -> full 32 raw bytes -> unpadded URL-safe base64 (43 chars)",
+            "note": "NOT the 64-hex digest string, and NOT a truncation of it -- full 256-bit entropy preserved",
+            "prefix": "rob944-primary-",
+            "campaign_run_id_length": 58,
+            "primary_idempotency_key_length": 125,
+            "idempotency_key_max": 128,
+        },
+    }
+
+
+def _import_campaign_controller():
+    """Isolated so tests can force an ImportError without faking sys.modules."""
+    import app.services.rob944_campaign_controller as controller
+
+    return controller
+
+
+# ---------------------------------------------------------------------------
+# --run: lineage-bound evidence construction (pure conversion logic, unit-
+# testable with fake summaries -- no corpus loading required for THIS part).
+# ---------------------------------------------------------------------------
+
+
+def _attempt_allowed_reasons_by_status() -> dict[str, frozenset]:
+    """Captain trust-boundary addendum (2026-07-17): a bare membership
+    check against the GLOBAL ``KNOWN_REASON_CODES`` allowlist lets a
+    cross-status pair through (e.g. ``status="completed"`` with
+    ``reason_code="child_execution_crashed"``) -- H6's own DTO has no
+    status/reason-pair validation of its own and would silently accept it,
+    so this exact closed status-scoped mapping is the only place this gets
+    caught. ATTEMPT-level statuses are exactly ``completed``/``rejected``/
+    ``crashed``/``timeout`` (``AttemptStatus`` -- never ``never_selected``,
+    which is scenario-only)."""
+    from rob944_walkforward import (
+        REASON_CHILD_EXECUTION_CRASHED,
+        REASON_CHILD_EXECUTION_TIMEOUT,
+        REASON_DATA_GAP_IN_POSITION,
+        REASON_GLOBAL_CORPUS_LOAD_FAILED,
+        REASON_INSUFFICIENT_TRAIN_EVIDENCE_ALL_FOLDS,
+    )
+
+    return {
+        "completed": frozenset(),  # must be None -- checked separately
+        "rejected": frozenset(
+            {REASON_DATA_GAP_IN_POSITION, REASON_INSUFFICIENT_TRAIN_EVIDENCE_ALL_FOLDS}
+        ),
+        "crashed": frozenset(
+            {REASON_CHILD_EXECUTION_CRASHED, REASON_GLOBAL_CORPUS_LOAD_FAILED}
+        ),
+        "timeout": frozenset({REASON_CHILD_EXECUTION_TIMEOUT}),
+    }
+
+
+def _scenario_allowed_reasons_by_status() -> dict[str, frozenset]:
+    """SCENARIO-level statuses differ from ATTEMPT-level in two ways
+    (captain precision correction, 2026-07-17): (1) they additionally
+    include ``never_selected`` (a config that never won a single fold),
+    whose reason is always the fixed ``REASON_NEVER_SELECTED_IN_ANY_FOLD``
+    sentinel; (2) ``rejected`` is narrower -- a SCENARIO can only ever be
+    gap-rejected (``REASON_DATA_GAP_IN_POSITION``); ``insufficient_train_evidence_all_folds``
+    is an ATTEMPT-only reason (the whole config was never train-eligible in
+    any fold) and must never appear on a per-scenario row. ``crashed`` stays
+    the SAME two-code set as attempt-level -- the deterministic 24-row
+    global-corpus-load-failure fallback intentionally emits 3 crashed
+    scenario sentinels with ``REASON_GLOBAL_CORPUS_LOAD_FAILED`` per config,
+    and that must remain valid."""
+    from rob944_walkforward import (
+        REASON_DATA_GAP_IN_POSITION,
+        REASON_NEVER_SELECTED_IN_ANY_FOLD,
+    )
+
+    allowed = dict(_attempt_allowed_reasons_by_status())
+    allowed["rejected"] = frozenset({REASON_DATA_GAP_IN_POSITION})
+    allowed["never_selected"] = frozenset({REASON_NEVER_SELECTED_IN_ANY_FOLD})
+    return allowed
+
+
+def _assert_status_reason_contract(
+    status: str, reason_code: str | None, *, allowed_by_status, context: str
+) -> None:
+    """Fail closed unless ``reason_code`` is EXACTLY the set permitted for
+    ``status`` under the closed mapping -- ``completed`` requires ``None``;
+    every other status requires ``reason_code`` to be one of its own
+    specific allowed codes, never merely "some known code from anywhere".
+    Never echoes the offending status/reason_code (could be a forged/
+    secret-bearing value)."""
+    allowed = allowed_by_status.get(status)
+    if allowed is None:
+        raise ValueError(f"refusing to persist an unknown status for {context}")
+    if status == "completed":
+        if reason_code is not None:
+            raise ValueError(
+                f"attempt/scenario for {context} has status='completed' but a non-null "
+                "reason_code -- refusing to persist"
+            )
+        return
+    if reason_code not in allowed:
+        raise ValueError(
+            f"attempt/scenario for {context} has a reason_code not permitted for its status "
+            "under the closed status-scoped allowlist -- refusing to persist"
+        )
+
+
+_KNOWN_SCENARIO_NAMES = frozenset({"base", "primary_stress", "upward_stress"})
+_HEX64_RE = re.compile(r"\A[0-9a-f]{64}\Z")
+
+
+def _assert_hex64(value, *, context: str) -> None:
+    # type(...) is not str (never isinstance) -- captain normalization
+    # correction (2026-07-17): consistent exact-type discipline with every
+    # other persisted/hashed identifier field, even though a regex match
+    # here already operates on the real underlying character buffer.
+    if type(value) is not str or not _HEX64_RE.match(value):
+        raise ValueError(
+            f"{context} has a malformed hash -- must be a lowercase 64-hex digest"
+        )
+
+
+_CANONICAL_FOLD_IDS = frozenset(f"fold-{i:02d}" for i in range(8))
+_CANONICAL_CONFIG_IDS_BY_STRATEGY = {
+    "S1": frozenset(f"S1-{i:02d}" for i in range(12)),
+    "S2": frozenset(f"S2-{i:02d}" for i in range(12)),
+}
+
+
+def _assert_valid_attempt_identity(
+    strategy: str, config_id: str, *, context: str
+) -> None:
+    """Captain live-validation correction (2026-07-17): ``summary.strategy``
+    must be exactly ``"S1"``/``"S2"``, and ``summary.config_id`` must be an
+    EXACT member of that strategy's own frozen 12-config set (``S{1,2}-00``
+    through ``-11``) -- not merely regex-shaped (which would let ``S1-99``
+    or ``S3-00`` through)."""
+    if strategy not in _CANONICAL_CONFIG_IDS_BY_STRATEGY:
+        raise ValueError(
+            f"{context} has a strategy outside the closed {{S1, S2}} set -- refusing to persist"
+        )
+    if config_id not in _CANONICAL_CONFIG_IDS_BY_STRATEGY[strategy]:
+        raise ValueError(
+            f"{context} has a config_id outside its strategy's exact frozen 12-config set -- "
+            "refusing to persist"
+        )
+
+
+def _assert_valid_fold_selection_row(row, *, strategy: str, context: str) -> None:
+    """Captain final-audit item A (2026-07-17) + follow-up: ``fold_selection_trace``
+    rows were previously hashed with NO validation of ``train_input_hash``
+    (format), ``rejection_reason``/``excluded_symbols`` reasons (closed
+    set), their consistency with ``rejected``, ``fold_id``/``fold_selected_config_id``
+    (closed/canonical formats), or ``eligible_symbols``/``excluded_symbols``
+    (must be unique, subsets of the frozen 4-symbol universe, disjoint from
+    each other, and together cover it EXACTLY) -- all untrusted input from a
+    caller-injected callback. Never echoes any offending value itself."""
+    from rob941_frozen_scope import UNIVERSE
+    from rob944_selection import (
+        INSUFFICIENT_ELIGIBLE_SYMBOLS_REASON,
+        INSUFFICIENT_SYMBOL_EVIDENCE_REASON,
+    )
+
+    if row.fold_id not in _CANONICAL_FOLD_IDS:
+        raise ValueError(
+            f"{context} has a fold_id outside the closed canonical set -- refusing to persist"
+        )
+    if row.fold_selected_config_id is not None:
+        # Exact membership in the SAME strategy's frozen 12-config set --
+        # not merely regex-shaped (would let S1-99/S3-00 through).
+        if row.fold_selected_config_id not in _CANONICAL_CONFIG_IDS_BY_STRATEGY.get(
+            strategy, frozenset()
+        ):
+            raise ValueError(
+                f"{context} has a fold_selected_config_id outside this attempt's exact "
+                "frozen 12-config set -- refusing to persist"
+            )
+    _assert_hex64(row.train_input_hash, context=f"{context} train_input_hash")
+    # Captain final-audit semantic correction (2026-07-17): a pure auditor
+    # probe fed rejected="SECRET-CONTROL\n" (a truthy non-bool) straight
+    # into the branch below -- FoldSelectionEvidenceSummary's type hint
+    # (bool) is NOT runtime-enforced (a plain dataclass, no validator), so
+    # this is a genuine runtime trust boundary. Require EXACT bool
+    # (``type(...) is bool``) BEFORE any branch/hash/output touches this
+    # field -- expressing the declared bool-only contract directly, the
+    # same exact-type discipline this validator already applies elsewhere
+    # (e.g. trade_count). Never interpolate the offending value itself.
+    if type(row.rejected) is not bool:
+        raise ValueError(f"{context} has a non-bool rejected -- refusing to persist")
+    if row.rejected:
+        if row.rejection_reason != INSUFFICIENT_ELIGIBLE_SYMBOLS_REASON:
+            raise ValueError(
+                f"{context} is rejected but its rejection_reason is not the expected "
+                "closed sentinel -- refusing to persist"
+            )
+    elif row.rejection_reason is not None:
+        raise ValueError(
+            f"{context} is not rejected but carries a non-null rejection_reason -- "
+            "refusing to persist"
+        )
+    # Captain adjacent trust-boundary correction (2026-07-17, item B): type
+    # hints are not runtime validators -- pure probes fed
+    # equal_weight_expectancy_bps=True, pooled_expectancy_bps=Decimal(...),
+    # profit_factor=None straight through. Decimal in particular can
+    # survive canonical_sha256 but then fail json.dumps AFTER a DB commit
+    # already happened -- must be caught here, before hashing. Exact
+    # ``type(...) is float`` (never isinstance, which would accept the
+    # bool subtype) rejects bool/int/Decimal/None uniformly; NaN/+Inf/-Inf
+    # remain valid float values here (accepted) since
+    # _json_safe_float_or_sentinel's sentinel normalization is the
+    # contractual way those are represented downstream, not a reason to
+    # reject them at this layer.
+    if row.rejected:
+        if row.equal_weight_expectancy_bps is not None:
+            raise ValueError(
+                f"{context} is rejected but equal_weight_expectancy_bps is not None -- "
+                "refusing to persist"
+            )
+        if row.pooled_expectancy_bps is not None:
+            raise ValueError(
+                f"{context} is rejected but pooled_expectancy_bps is not None -- "
+                "refusing to persist"
+            )
+    else:
+        if type(row.equal_weight_expectancy_bps) is not float:
+            raise ValueError(
+                f"{context} equal_weight_expectancy_bps must be an exact float for a "
+                "non-rejected row -- refusing to persist"
+            )
+        if type(row.pooled_expectancy_bps) is not float:
+            raise ValueError(
+                f"{context} pooled_expectancy_bps must be an exact float for a "
+                "non-rejected row -- refusing to persist"
+            )
+    if type(row.profit_factor) is not float:
+        raise ValueError(
+            f"{context} profit_factor must be an exact float (finite/nan/+inf/-inf all "
+            "permitted; sentinel normalization is contractual) -- refusing to persist"
+        )
+    # Captain adjacent trust-boundary correction (2026-07-17, item A):
+    # eligible_symbols/excluded_symbols must be the EXACT container types
+    # the dataclass/generator contract declares (tuple, and tuple-of-
+    # 2-tuples) -- a set/list-valued probe would otherwise pass every
+    # membership/uniqueness/coverage check below while its ORDER varies
+    # across PYTHONHASHSEED once list(...)/iteration silently accepted it,
+    # corrupting canonical_sha256/operator JSON determinism. Checked BEFORE
+    # any list(...)/set(...) conversion or tuple-unpacking (a malformed
+    # excluded_symbols entry would otherwise raise a raw, unsanitized
+    # unpacking error here instead of this fixed message).
+    if type(row.eligible_symbols) is not tuple:
+        raise ValueError(
+            f"{context} eligible_symbols must be an exact tuple -- refusing to persist"
+        )
+    if type(row.excluded_symbols) is not tuple:
+        raise ValueError(
+            f"{context} excluded_symbols must be an exact tuple -- refusing to persist"
+        )
+    for entry in row.excluded_symbols:
+        if type(entry) is not tuple or len(entry) != 2:
+            raise ValueError(
+                f"{context} has an excluded_symbols entry that is not an exact 2-tuple -- "
+                "refusing to persist"
+            )
+    eligible_list = list(row.eligible_symbols)
+    eligible_set = set(eligible_list)
+    if len(eligible_set) != len(eligible_list):
+        raise ValueError(
+            f"{context} has a duplicate eligible_symbols entry -- refusing to persist"
+        )
+    excluded_list = [symbol for symbol, _reason in row.excluded_symbols]
+    excluded_set = set(excluded_list)
+    if len(excluded_set) != len(excluded_list):
+        raise ValueError(
+            f"{context} has a duplicate excluded_symbols entry -- refusing to persist"
+        )
+    for _symbol, reason in row.excluded_symbols:
+        if reason != INSUFFICIENT_SYMBOL_EVIDENCE_REASON:
+            raise ValueError(
+                f"{context} has an excluded_symbols entry with a reason outside the "
+                "closed allowlist -- refusing to persist"
+            )
+    universe_set = set(UNIVERSE)
+    if not eligible_set.issubset(universe_set) or not excluded_set.issubset(
+        universe_set
+    ):
+        raise ValueError(
+            f"{context} has a symbol outside the frozen 4-symbol universe -- refusing to persist"
+        )
+    if eligible_set & excluded_set:
+        raise ValueError(
+            f"{context} has a symbol in BOTH eligible_symbols and excluded_symbols -- "
+            "refusing to persist"
+        )
+    if eligible_set | excluded_set != universe_set:
+        raise ValueError(
+            f"{context} eligible_symbols/excluded_symbols do not exactly cover the frozen "
+            "4-symbol universe -- refusing to persist"
+        )
+    # Item A (continued): membership/uniqueness/coverage alone do not prove
+    # ORDER -- both partitions must preserve the FROZEN UNIVERSE's own
+    # order (expected = UNIVERSE filtered by membership), checked only
+    # AFTER exact-cover is already proven above. Never silently sort/
+    # reorder attacker input to "fix" it -- a wrong order is refused, not
+    # normalized.
+    expected_eligible_order = tuple(
+        symbol for symbol in UNIVERSE if symbol in eligible_set
+    )
+    if row.eligible_symbols != expected_eligible_order:
+        raise ValueError(
+            f"{context} eligible_symbols does not preserve the frozen universe order -- "
+            "refusing to persist"
+        )
+    expected_excluded_symbol_order = tuple(
+        symbol for symbol in UNIVERSE if symbol in excluded_set
+    )
+    actual_excluded_symbol_order = tuple(
+        symbol for symbol, _reason in row.excluded_symbols
+    )
+    if actual_excluded_symbol_order != expected_excluded_symbol_order:
+        raise ValueError(
+            f"{context} excluded_symbols does not preserve the frozen universe order -- "
+            "refusing to persist"
+        )
+
+
+def _assert_valid_fold_selection_trace(
+    trace, *, strategy: str, status: str, reason_code: str | None, context: str
+) -> None:
+    """Captain precision addendum + live-validation correction (2026-07-17):
+    every NON-global attempt must have EXACTLY the 8 canonical unique fold
+    IDs. An EMPTY trace is exempted ONLY for the exact deterministic
+    global-corpus-load-failure signature (``status="crashed"`` AND
+    ``reason_code=REASON_GLOBAL_CORPUS_LOAD_FAILED``) -- any OTHER
+    status/reason with an empty trace is refused fail-closed, never
+    silently accepted just because the trace happens to be empty."""
+    if not trace:
+        from rob944_walkforward import REASON_GLOBAL_CORPUS_LOAD_FAILED
+
+        if status == "crashed" and reason_code == REASON_GLOBAL_CORPUS_LOAD_FAILED:
+            return
+        raise ValueError(
+            f"{context} has an empty fold_selection_trace but is not the exact "
+            "global-corpus-load-failure fallback signature -- refusing to persist"
+        )
+    fold_ids = [row.fold_id for row in trace]
+    if len(set(fold_ids)) != len(fold_ids) or set(fold_ids) != _CANONICAL_FOLD_IDS:
+        raise ValueError(
+            f"{context} fold_selection_trace does not have exactly the 8 canonical unique "
+            "fold IDs -- refusing to persist"
+        )
+    for idx, row in enumerate(trace):
+        _assert_valid_fold_selection_row(
+            row, strategy=strategy, context=f"{context}/fold#{idx}"
+        )
+
+
+def _s2_rejections_to_no_trade_records(rejections):
+    """Fable condition 1 (2026-07-17): convert H3 S2's own
+    ``RejectedCandidate``s (target_direction_invalid/tp_above_max/
+    tp_below_r_min_sl/tp_below_abs_floor/confirmation_failed/
+    next_bar_unavailable) into canonical ``NoTradeRecord``s -- a pure,
+    directly testable field-mapping, extracted from ``_s2_gen_factory`` so
+    the conversion itself (not just the wiring) has an isolated test."""
+    from rob940_engine import NoTradeRecord
+
+    return tuple(
+        NoTradeRecord(
+            strategy=r.strategy,
+            config_id=r.config_id,
+            symbol=r.symbol,
+            side=r.side,
+            signal_ts=r.signal_ts,
+            reason=r.reason,
+            fold_id=r.fold_id,
+        )
+        for r in rejections
+    )
+
+
+def _known_no_trade_reasons() -> frozenset[str]:
+    """Captain trust-boundary addendum (2026-07-17) + allowlist correction:
+    the CLOSED set of no_trade_reason_counts KEYS this system can ever
+    legitimately produce -- H2's own engine-level no-fill reasons
+    (rob940_engine.py, bare string literals -- that module exports no named
+    constants for them, so these are duplicated here deliberately, same
+    pattern as ``app.services.rob944_campaign_controller._EXPECTED_SCENARIO_ORDER``),
+    H4's funding-gate reasons (importable from ``rob944_gap_funding``), and
+    H3 S2's own FULL six-code rejection set (rob940_signal_s2.py:142-150,
+    213, 227 -- likewise bare literals, no exported named authority to
+    import instead; this list must stay in sync with that source if it ever
+    changes). A ``no_trade_reason_counts`` dict is untrusted input flowing
+    from a caller-injected ``build_attempt_evidence``/generator callback --
+    an arbitrary caller-injected key must never be hashed or printed.
+    """
+    from rob944_gap_funding import (
+        REASON_EXPECTED_FUNDING_COST_ABOVE_3BPS,
+        REASON_FUNDING_EVIDENCE_UNAVAILABLE,
+    )
+
+    return frozenset(
+        {
+            # rob940_engine.py (H2)
+            "next_bar_unavailable",
+            "daily_stop_active",
+            "daily_entry_cap",
+            "cooldown_active",
+            "tp_below_min_distance",
+            # rob944_gap_funding.py (H4 funding PIT gate)
+            REASON_FUNDING_EVIDENCE_UNAVAILABLE,
+            REASON_EXPECTED_FUNDING_COST_ABOVE_3BPS,
+            # rob940_signal_s2.py (H3 S2's full 6-code rejection set --
+            # next_bar_unavailable already listed above, shared with H2)
+            "confirmation_failed",
+            "target_direction_invalid",
+            "tp_above_max",
+            "tp_below_r_min_sl",
+            "tp_below_abs_floor",
+        }
+    )
+
+
+def _assert_known_no_trade_reason_counts(counts, *, context: str) -> None:
+    """Fail closed on an unknown key, a non-int count, a bool masquerading
+    as an int (``bool`` is an ``int`` subclass in Python), or a negative
+    count -- BEFORE any such dict is hashed or printed. Never echoes the
+    offending key/value itself (could be an arbitrary/secret string)."""
+    known = _known_no_trade_reasons()
+    for key, value in counts.items():
+        if key not in known:
+            raise ValueError(
+                f"refusing to persist an unknown no_trade_reason_counts key for {context} -- "
+                "only the closed known-reasons allowlist may be persisted"
+            )
+        if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+            raise ValueError(
+                f"no_trade_reason_counts for {context} has a non-nonnegative-int count -- "
+                "refusing to persist"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Captain normalization-boundary correction (2026-07-17): a pure auditor
+# probe demonstrated a caller-owned mapping (no_trade_reason_counts) can be
+# a dict SUBCLASS returning benign content on a first .items() pass (during
+# validation) and secret-bearing content on a LATER pass (during hashing/
+# operator-JSON output) -- validating one object and then re-reading it a
+# second time for hashing/output is a TOCTOU hole. The bounded audit then
+# widened this to the WHOLE summary boundary (scenario_summaries/
+# fold_selection_trace themselves, nested eligible/excluded containers,
+# and every persisted/hashed identifier string) -- a stateful iterable/
+# proxy/subclass can misbehave anywhere a caller-owned object is read more
+# than once. And a str SUBCLASS ("AliasStr") can override __eq__/__hash__
+# to pass an allowlist/membership check while its actual buffer content
+# (what canonical_sha256/output actually uses) is something else entirely.
+#
+# The fix is ONE architectural boundary: require EXACT canonical runtime
+# types everywhere (``type(x) is T``, never ``isinstance`` -- isinstance
+# accepts subclasses, which is exactly what enables every attack above),
+# reading every field/container/dict EXACTLY ONCE to build a BRAND-NEW
+# snapshot (fresh tuples, fresh plain dicts, values copied out of
+# caller-owned rows into freshly-constructed dataclass instances) --
+# thereafter, hashing/evidence-building/operator-capture consume ONLY the
+# normalized snapshot, never touching the caller's original objects again.
+# A real (non-subclassed) tuple/dict/dataclass instance cannot lie between
+# reads -- only a subclass overriding dunder methods can, and exact-type
+# checks reject every subclass outright, closing this for good.
+# ---------------------------------------------------------------------------
+
+
+def _assert_exact_str(value, *, context: str) -> str:
+    """``type(value) is str`` -- never ``isinstance`` -- rejects an
+    AliasStr-style subclass whose overridden ``__eq__``/``__hash__`` could
+    otherwise pass an allowlist/membership check while its actual buffer
+    content (what canonical_sha256/output actually reads) differs. Checked
+    BEFORE any membership/equality comparison, never after."""
+    if type(value) is not str:
+        raise ValueError(f"{context} must be an exact str -- refusing to persist")
+    return value
+
+
+def _assert_exact_str_or_none(value, *, context: str):
+    if value is None:
+        return None
+    return _assert_exact_str(value, context=context)
+
+
+def _assert_exact_bool(value, *, context: str) -> bool:
+    if type(value) is not bool:
+        raise ValueError(f"{context} must be an exact bool -- refusing to persist")
+    return value
+
+
+def _assert_exact_int(value, *, context: str) -> int:
+    """``type(value) is int`` rejects bool (``type(True) is bool``, never
+    ``int``) AND any int subclass uniformly -- ``isinstance`` would accept
+    both."""
+    if type(value) is not int:
+        raise ValueError(f"{context} must be an exact int -- refusing to persist")
+    return value
+
+
+def _assert_exact_float(value, *, context: str) -> float:
+    """``type(value) is float`` rejects bool/int/``Decimal``/``None``
+    uniformly. NaN/+Inf/-Inf remain valid float VALUES here (accepted) --
+    ``_json_safe_float_or_sentinel``'s sentinel normalization is the
+    contractual way those are represented downstream, not a reason to
+    reject them at this type-only layer."""
+    if type(value) is not float:
+        raise ValueError(f"{context} must be an exact float -- refusing to persist")
+    return value
+
+
+def _normalize_no_trade_reason_counts(value, *, context: str) -> dict[str, int]:
+    """A dict SUBCLASS can override ``.items()``/``__iter__`` to return
+    DIFFERENT content on each call -- a pure deterministic probe returning
+    ``{}`` on a first (validation) pass and ``{"SECRET-...": 1}`` on a
+    later (hash/output) pass. A genuine builtin ``dict`` cannot do this
+    (its methods are fixed C-level implementations that always reflect
+    current storage) -- requiring ``type(value) is dict`` (never
+    ``isinstance``) BEFORE the single ``.items()`` pass below closes this
+    fully: every key/value is read HERE, ONCE, into a brand-new plain
+    dict; every caller downstream operates ONLY on that copy, never the
+    original mapping again."""
+    if type(value) is not dict:
+        raise ValueError(
+            f"{context} no_trade_reason_counts must be an exact dict -- refusing to persist"
+        )
+    normalized: dict[str, int] = {}
+    for idx, (key, val) in enumerate(value.items()):
+        key = _assert_exact_str(
+            key, context=f"{context} no_trade_reason_counts key#{idx}"
+        )
+        val = _assert_exact_int(
+            val, context=f"{context} no_trade_reason_counts value#{idx}"
+        )
+        normalized[key] = val
+    return normalized
+
+
+def _normalize_scenario_evidence_summary(row, *, context: str):
+    """One caller-owned ``ScenarioEvidenceSummary`` -> a brand-new one
+    built from freshly type-checked/copied fields. Rejects any subclass/
+    proxy of ``ScenarioEvidenceSummary`` itself (``type(row) is ...``,
+    never ``isinstance``) -- a frozen dataclass only blocks external
+    ``__setattr__``, not a subclass overriding ``__getattribute__`` to
+    return different values on repeated reads. ``trade_count`` is snapshot
+    via ``_assert_exact_int`` HERE (captain live-review correction,
+    2026-07-17: the prior version passed it through unchecked, so an int
+    SUBCLASS would survive into the normalized DTO and only be caught by
+    the downstream nonnegative check's ``isinstance`` -- which accepts
+    subclasses) -- the nonnegative semantic check remains downstream,
+    applied to this now-guaranteed-exact int."""
+    from rob944_walkforward import ScenarioEvidenceSummary
+
+    if type(row) is not ScenarioEvidenceSummary:
+        raise ValueError(
+            f"{context} must be an exact ScenarioEvidenceSummary -- refusing to persist"
+        )
+    scenario_name = _assert_exact_str(
+        row.scenario_name, context=f"{context} scenario_name"
+    )
+    status = _assert_exact_str(row.status, context=f"{context} status")
+    reason_code = _assert_exact_str_or_none(
+        row.reason_code, context=f"{context} reason_code"
+    )
+    trade_count = _assert_exact_int(row.trade_count, context=f"{context} trade_count")
+    artifact_hash = _assert_exact_str(
+        row.artifact_hash, context=f"{context} artifact_hash"
+    )
+    no_trade_reason_counts = _normalize_no_trade_reason_counts(
+        row.no_trade_reason_counts, context=context
+    )
+    return ScenarioEvidenceSummary(
+        scenario_name=scenario_name,
+        status=status,
+        reason_code=reason_code,
+        trade_count=trade_count,
+        artifact_hash=artifact_hash,
+        no_trade_reason_counts=no_trade_reason_counts,
+    )
+
+
+def _normalize_fold_selection_evidence_summary(row, *, context: str):
+    """One caller-owned ``FoldSelectionEvidenceSummary`` -> a brand-new
+    one. Exact-type container/entry checks here mirror (and precede, in
+    the normal path) ``_assert_valid_fold_selection_row``'s own item-A/B
+    checks -- kept in BOTH places deliberately: this is the primary
+    boundary in the normal (normalize-first) path, while
+    ``_assert_valid_fold_selection_row`` remains a defense-in-depth net
+    for any caller that reaches it without going through normalization
+    first."""
+    from rob944_walkforward import FoldSelectionEvidenceSummary
+
+    if type(row) is not FoldSelectionEvidenceSummary:
+        raise ValueError(
+            f"{context} must be an exact FoldSelectionEvidenceSummary -- refusing to persist"
+        )
+    fold_id = _assert_exact_str(row.fold_id, context=f"{context} fold_id")
+    fold_selected_config_id = _assert_exact_str_or_none(
+        row.fold_selected_config_id, context=f"{context} fold_selected_config_id"
+    )
+    # Captain design precision (2026-07-17): bind every raw field to a
+    # local exactly once, BEFORE type-checking/iterating it -- type-
+    # checking ``row.eligible_symbols`` and then separately re-reading
+    # ``row.eligible_symbols`` for iteration is exactly the double-read
+    # TOCTOU seam this whole boundary exists to close (applies uniformly
+    # here to excluded_symbols/expectancy/profit_factor too).
+    raw_eligible_symbols = row.eligible_symbols
+    if type(raw_eligible_symbols) is not tuple:
+        raise ValueError(
+            f"{context} eligible_symbols must be an exact tuple -- refusing to persist"
+        )
+    eligible_symbols = tuple(
+        _assert_exact_str(s, context=f"{context} eligible_symbols#{idx}")
+        for idx, s in enumerate(raw_eligible_symbols)
+    )
+    raw_excluded_symbols = row.excluded_symbols
+    if type(raw_excluded_symbols) is not tuple:
+        raise ValueError(
+            f"{context} excluded_symbols must be an exact tuple -- refusing to persist"
+        )
+    excluded_symbols = []
+    for idx, entry in enumerate(raw_excluded_symbols):
+        if type(entry) is not tuple or len(entry) != 2:
+            raise ValueError(
+                f"{context} excluded_symbols#{idx} must be an exact 2-tuple -- "
+                "refusing to persist"
+            )
+        raw_symbol, raw_reason = entry
+        symbol = _assert_exact_str(
+            raw_symbol, context=f"{context} excluded_symbols#{idx} symbol"
+        )
+        reason = _assert_exact_str(
+            raw_reason, context=f"{context} excluded_symbols#{idx} reason"
+        )
+        excluded_symbols.append((symbol, reason))
+    rejected = _assert_exact_bool(row.rejected, context=f"{context} rejected")
+    rejection_reason = _assert_exact_str_or_none(
+        row.rejection_reason, context=f"{context} rejection_reason"
+    )
+    train_input_hash = _assert_exact_str(
+        row.train_input_hash, context=f"{context} train_input_hash"
+    )
+    no_trade_reason_counts = _normalize_no_trade_reason_counts(
+        row.no_trade_reason_counts, context=context
+    )
+    raw_equal_weight_expectancy_bps = row.equal_weight_expectancy_bps
+    raw_pooled_expectancy_bps = row.pooled_expectancy_bps
+    if rejected:
+        if raw_equal_weight_expectancy_bps is not None:
+            raise ValueError(
+                f"{context} is rejected but equal_weight_expectancy_bps is not None -- "
+                "refusing to persist"
+            )
+        if raw_pooled_expectancy_bps is not None:
+            raise ValueError(
+                f"{context} is rejected but pooled_expectancy_bps is not None -- "
+                "refusing to persist"
+            )
+        equal_weight_expectancy_bps = None
+        pooled_expectancy_bps = None
+    else:
+        equal_weight_expectancy_bps = _assert_exact_float(
+            raw_equal_weight_expectancy_bps,
+            context=f"{context} equal_weight_expectancy_bps",
+        )
+        pooled_expectancy_bps = _assert_exact_float(
+            raw_pooled_expectancy_bps, context=f"{context} pooled_expectancy_bps"
+        )
+    profit_factor = _assert_exact_float(
+        row.profit_factor, context=f"{context} profit_factor"
+    )
+    return FoldSelectionEvidenceSummary(
+        fold_id=fold_id,
+        fold_selected_config_id=fold_selected_config_id,
+        eligible_symbols=eligible_symbols,
+        excluded_symbols=tuple(excluded_symbols),
+        equal_weight_expectancy_bps=equal_weight_expectancy_bps,
+        pooled_expectancy_bps=pooled_expectancy_bps,
+        profit_factor=profit_factor,
+        rejected=rejected,
+        rejection_reason=rejection_reason,
+        train_input_hash=train_input_hash,
+        no_trade_reason_counts=no_trade_reason_counts,
+    )
+
+
+def _normalize_config_attempt_evidence_summary(summary, *, context: str):
+    """THE single normalization entry point (captain normalization-scope
+    clarification, 2026-07-17): every container is required to be its
+    exact canonical runtime type, every nested row its exact canonical
+    dataclass type, every persisted/hashed string its exact ``str``, every
+    count its exact ``int``, every no_trade_reason_counts mapping its
+    exact ``dict`` -- rejecting subclasses/proxies BEFORE any allowlist
+    membership/equality check runs on them anywhere downstream. Returns a
+    BRAND-NEW ``ConfigAttemptEvidenceSummary`` built entirely from this one
+    pass; nothing downstream (validation, hashing, operator capture)
+    touches the caller's original object again."""
+    from rob944_walkforward import ConfigAttemptEvidenceSummary
+
+    if type(summary) is not ConfigAttemptEvidenceSummary:
+        raise ValueError(
+            f"{context} must be an exact ConfigAttemptEvidenceSummary -- refusing to persist"
+        )
+    strategy = _assert_exact_str(summary.strategy, context=f"{context} strategy")
+    config_id = _assert_exact_str(summary.config_id, context=f"{context} config_id")
+    status = _assert_exact_str(summary.status, context=f"{context} status")
+    reason_code = _assert_exact_str_or_none(
+        summary.reason_code, context=f"{context} reason_code"
+    )
+    # Captain design precision (2026-07-17): bind every raw field to a
+    # local exactly once, BEFORE type-checking/iterating it -- never
+    # type-check an attribute then re-read the attribute a second time
+    # for iteration (that second read is exactly the TOCTOU seam this
+    # whole boundary exists to close). ``summary`` is already confirmed
+    # ``type(...) is ConfigAttemptEvidenceSummary`` above, so
+    # ``fold_selection_trace`` is read directly (the exact DTO always
+    # carries this field) -- never ``getattr`` with a fallback default.
+    raw_scenario_summaries = summary.scenario_summaries
+    if type(raw_scenario_summaries) is not tuple:
+        raise ValueError(
+            f"{context} scenario_summaries must be an exact tuple -- refusing to persist"
+        )
+    normalized_scenario_rows = tuple(
+        _normalize_scenario_evidence_summary(row, context=f"{context}/scenario#{idx}")
+        for idx, row in enumerate(raw_scenario_summaries)
+    )
+    raw_fold_trace = summary.fold_selection_trace
+    if type(raw_fold_trace) is not tuple:
+        raise ValueError(
+            f"{context} fold_selection_trace must be an exact tuple -- refusing to persist"
+        )
+    normalized_fold_rows = tuple(
+        _normalize_fold_selection_evidence_summary(row, context=f"{context}/fold#{idx}")
+        for idx, row in enumerate(raw_fold_trace)
+    )
+    # Captain design review (2026-07-17, item 3): canonically order BOTH
+    # traces HERE, in the snapshot itself, right after exact-primitive
+    # normalization -- so operator capture/output and H6/hash-building
+    # consume the IDENTICAL order from a single source, rather than each
+    # independently re-sorting (or worse, one of them forgetting to).
+    # Safe to sort now: every row's scenario_name/fold_id is already
+    # proven an exact str by the per-row normalizer above.
+    scenario_summaries = tuple(
+        sorted(normalized_scenario_rows, key=lambda row: row.scenario_name)
+    )
+    fold_selection_trace = tuple(
+        sorted(normalized_fold_rows, key=lambda row: row.fold_id)
+    )
+    return ConfigAttemptEvidenceSummary(
+        strategy=strategy,
+        config_id=config_id,
+        status=status,
+        reason_code=reason_code,
+        scenario_summaries=scenario_summaries,
+        fold_selection_trace=fold_selection_trace,
+    )
+
+
+def _summary_to_attempt_evidence(
+    summary,
+    *,
+    strategy_key: str,
+    experiment_id: str,
+    full_campaign_hash: str,
+    campaign_run_id: str,
+):
+    """Thin direct-call wrapper (captain design cross-check correction,
+    2026-07-17): normalizes the RAW ``summary`` exactly ONCE, then
+    delegates every remaining validation/hash-building step to
+    ``_normalized_summary_to_attempt_evidence``, which assumes an
+    already-normalized snapshot and never re-normalizes. This is the
+    entry point for any caller handing over a raw (not yet normalized)
+    ``ConfigAttemptEvidenceSummary`` -- including every direct test call --
+    while the batch/capture path (``_normalize_and_capture_summaries``)
+    normalizes once itself and calls the CORE directly, never this
+    wrapper, so a summary is never normalized twice."""
+    # Captain design review (2026-07-17, item 2): the lineage args
+    # themselves need exact-str gating BEFORE they are used to build a
+    # context string or enter any hash payload -- static, non-
+    # interpolating contexts here, since the values are not yet proven
+    # safe to reference in a message.
+    strategy_key = _assert_exact_str(
+        strategy_key, context="lineage argument strategy_key"
+    )
+    experiment_id = _assert_exact_str(
+        experiment_id, context="lineage argument experiment_id"
+    )
+    full_campaign_hash = _assert_exact_str(
+        full_campaign_hash, context="lineage argument full_campaign_hash"
+    )
+    campaign_run_id = _assert_exact_str(
+        campaign_run_id, context="lineage argument campaign_run_id"
+    )
+    context = f"experiment {experiment_id}"
+    normalized = _normalize_config_attempt_evidence_summary(summary, context=context)
+    return _normalized_summary_to_attempt_evidence(
+        normalized,
+        strategy_key=strategy_key,
+        experiment_id=experiment_id,
+        full_campaign_hash=full_campaign_hash,
+        campaign_run_id=campaign_run_id,
+    )
+
+
+def _normalized_summary_to_attempt_evidence(
+    summary,
+    *,
+    strategy_key: str,
+    experiment_id: str,
+    full_campaign_hash: str,
+    campaign_run_id: str,
+):
+    """The normalized CORE (captain design cross-check correction,
+    2026-07-17): ASSUMES ``summary`` already came from
+    ``_normalize_config_attempt_evidence_summary`` (exact types
+    throughout, scenario/fold rows already canonically ordered) -- does
+    NOT re-normalize or re-sort. Callers that hold a raw summary must go
+    through ``_summary_to_attempt_evidence`` (the thin wrapper) instead;
+    calling this directly on an unnormalized object is the caller's own
+    contract violation, not something this function re-defends against
+    (that would be exactly the double-normalization/double-copy this
+    split exists to avoid).
+
+    One ``rob944_walkforward.ConfigAttemptEvidenceSummary`` -> one
+    ``AttemptEvidence``.
+
+    ``fold_evidence_hash`` is a hash of JUST the per-scenario fold-derived
+    evidence (status/reason/count/artifact/no-trade-reason-counts per
+    scenario) -- semantically distinct from ``run_identity``, which NESTS
+    ``fold_evidence_hash`` inside a payload that additionally binds the full
+    lineage: full-campaign hash, campaign_run_id, canonical experiment_id,
+    retry_index, strategy/config_id/status. Both are deterministic, no
+    wall-clock/UUID. Every reason_code (attempt-level and per-scenario) is
+    re-validated against the closed allowlist before anything is built.
+    """
+    from rob944_walkforward import _json_safe_float_or_sentinel
+
+    from app.schemas.research_campaign_bridge import (
+        AttemptEvidence,
+        AttemptKey,
+        ScenarioEvidence,
+    )
+    from research_contracts.canonical_hash import canonical_sha256
+
+    # Captain final-audit item A (2026-07-17): context strings must NEVER
+    # be built from unvalidated summary.strategy/config_id/scenario_name/
+    # fold_id (an injected secret/control string would otherwise be
+    # echoed) -- only the CALLER-TRUSTED experiment_id (already validated/
+    # looked-up by the caller before this function is ever invoked) is
+    # safe to interpolate. Untrusted per-row identifiers are replaced with
+    # a bare index.
+    context = f"experiment {experiment_id}"
+    # Captain live-validation correction (2026-07-17): summary.strategy must
+    # be exactly S1/S2, and summary.config_id must be an EXACT member of
+    # that strategy's own frozen 12-config set -- checked BEFORE anything
+    # else touches either value.
+    _assert_valid_attempt_identity(summary.strategy, summary.config_id, context=context)
+    # Captain trust-boundary addendum (2026-07-17): a bare KNOWN_REASON_CODES
+    # membership check lets a cross-status pair through (e.g.
+    # status="completed" + reason_code="child_execution_crashed") -- H6's
+    # own DTO has no status/reason-pair validation, so this exact
+    # status-scoped contract is the only place that gets caught, BEFORE
+    # anything is hashed/persisted.
+    _assert_status_reason_contract(
+        summary.status,
+        summary.reason_code,
+        allowed_by_status=_attempt_allowed_reasons_by_status(),
+        context=context,
+    )
+    scenario_allowed = _scenario_allowed_reasons_by_status()
+    # Captain pre-hash trust check (2026-07-17): exact 3 UNIQUE canonical
+    # scenarios -- checked BEFORE anything below is hashed, not merely
+    # relied on downstream (the controller rejects a malformed batch LATER,
+    # but by then an unsafe artifact_hash/trade_count may already have
+    # entered fold_evidence_hash).
+    if (
+        len(summary.scenario_summaries) != 3
+        or {row.scenario_name for row in summary.scenario_summaries}
+        != _KNOWN_SCENARIO_NAMES
+    ):
+        raise ValueError(
+            f"{context} does not have exactly the 3 unique canonical scenarios -- refusing to persist"
+        )
+    for idx, row in enumerate(summary.scenario_summaries):
+        scenario_context = f"{context}/scenario#{idx}"
+        _assert_status_reason_contract(
+            row.status,
+            row.reason_code,
+            allowed_by_status=scenario_allowed,
+            context=scenario_context,
+        )
+        # Captain trust-boundary addendum (2026-07-17): validate
+        # no_trade_reason_counts KEYS/VALUES too -- untrusted input from a
+        # caller-injected callback must never be hashed/printed as-is.
+        _assert_known_no_trade_reason_counts(
+            row.no_trade_reason_counts, context=scenario_context
+        )
+        # Captain pre-hash trust check: artifact_hash must be lowercase
+        # hex64, and trade_count a strict (non-bool) nonnegative int --
+        # BEFORE either is hashed.
+        _assert_hex64(row.artifact_hash, context=f"{scenario_context} artifact_hash")
+        # type(...) is not int (never isinstance) also rejects an int
+        # SUBCLASS uniformly, not merely bool -- captain normalization
+        # correction (2026-07-17). Message text unchanged.
+        if type(row.trade_count) is not int or row.trade_count < 0:
+            raise ValueError(
+                f"{scenario_context} has a non-nonnegative-int trade_count -- refusing to persist"
+            )
+    # ``summary`` is the NORMALIZED core's input -- an exact
+    # ConfigAttemptEvidenceSummary always carries this field; read it
+    # directly, never via getattr with a fallback default.
+    fold_trace = summary.fold_selection_trace
+    for idx, fold_row in enumerate(fold_trace):
+        _assert_known_no_trade_reason_counts(
+            fold_row.no_trade_reason_counts, context=f"{context}/fold#{idx}"
+        )
+    _assert_valid_fold_selection_trace(
+        fold_trace,
+        strategy=summary.strategy,
+        status=summary.status,
+        reason_code=summary.reason_code,
+        context=context,
+    )
+
+    # Captain design review (2026-07-17, item 3): canonical ordering (by
+    # scenario_name / fold_id) now happens ONCE, inside
+    # ``_normalize_config_attempt_evidence_summary`` itself -- ``summary``
+    # here is ALREADY sorted; re-sorting a second time would be a harmless
+    # no-op, but the whole point of the split is that this core trusts its
+    # normalized input rather than re-deriving guarantees the normalizer
+    # already established. Named identically to the old locals (now a
+    # direct alias) so the hash-payload/evidence-building code below is
+    # unchanged.
+    ordered_summaries = summary.scenario_summaries
+    ordered_fold_trace = summary.fold_selection_trace
+
+    retry_index = 0
+    fold_evidence_hash = canonical_sha256(
+        {
+            "strategy": summary.strategy,
+            "config_id": summary.config_id,
+            # Captain P1 (independent audit): the ATTEMPT's own terminal
+            # status/reason_code must be bound here too -- two rejected
+            # summaries with identical scenario rows but DIFFERENT
+            # rejection reasons (e.g. data_gap vs insufficient_train_evidence)
+            # previously collided in this hash.
+            "status": summary.status,
+            "reason_code": summary.reason_code,
+            "scenario_summaries": [
+                {
+                    "scenario_name": row.scenario_name,
+                    "status": row.status,
+                    "reason_code": row.reason_code,
+                    "trade_count": row.trade_count,
+                    "artifact_hash": row.artifact_hash,
+                    "no_trade_reason_counts": row.no_trade_reason_counts,
+                }
+                for row in ordered_summaries
+            ],
+            # Captain P1 (end-to-end provenance gap): the per-fold TRAIN
+            # selection trace -- previously entirely absent, so a TRAIN-only
+            # mutation (e.g. a price change altering train_input_hash
+            # without changing which config won OOS) was invisible here.
+            "fold_selection_trace": [
+                {
+                    "fold_id": row.fold_id,
+                    "fold_selected_config_id": row.fold_selected_config_id,
+                    "eligible_symbols": list(row.eligible_symbols),
+                    "excluded_symbols": [list(pair) for pair in row.excluded_symbols],
+                    "equal_weight_expectancy_bps": _json_safe_float_or_sentinel(
+                        row.equal_weight_expectancy_bps
+                    ),
+                    "pooled_expectancy_bps": _json_safe_float_or_sentinel(
+                        row.pooled_expectancy_bps
+                    ),
+                    "profit_factor": _json_safe_float_or_sentinel(row.profit_factor),
+                    "rejected": row.rejected,
+                    "rejection_reason": row.rejection_reason,
+                    "train_input_hash": row.train_input_hash,
+                    "no_trade_reason_counts": row.no_trade_reason_counts,
+                }
+                for row in ordered_fold_trace
+            ],
+        }
+    )
+    # Independent controller audit correction (2026-07-17): drop the
+    # redundant short-slug "strategy" ("S1"/"S2") field -- strategy_key (the
+    # full production key) already identifies the strategy, and dropping it
+    # makes this payload fully reconstructible by
+    # app.services.rob944_campaign_controller from ONLY values it already
+    # trusts (predeclared strategy_key/config_id per experiment_id, the
+    # validated campaign_run_id/full_campaign_hash, and this evidence's own
+    # status/fold_evidence_hash) -- see that module's
+    # ``_derive_expected_run_identity``, which MUST match this shape exactly.
+    run_identity = canonical_sha256(
+        {
+            "full_campaign_hash": full_campaign_hash,
+            "campaign_run_id": campaign_run_id,
+            "strategy_key": strategy_key,
+            "experiment_id": experiment_id,
+            "retry_index": retry_index,
+            "config_id": summary.config_id,
+            "status": summary.status,  # explicit for direct queryability; reason_code already nested via fold_evidence_hash
+            "fold_evidence_hash": fold_evidence_hash,
+        }
+    )
+    return AttemptEvidence(
+        attempt_key=AttemptKey(
+            campaign_run_id=campaign_run_id,
+            experiment_id=experiment_id,
+            retry_index=retry_index,
+        ),
+        status=summary.status,
+        reason_code=summary.reason_code,
+        fold_evidence_hash=fold_evidence_hash,
+        run_identity=run_identity,
+        scenario_evidence=tuple(
+            ScenarioEvidence(
+                scenario_name=row.scenario_name,
+                trade_count=row.trade_count,
+                artifact_hash=row.artifact_hash,
+            )
+            for row in ordered_summaries
+        ),
+    )
+
+
+def _summaries_to_attempt_evidence(
+    summaries,
+    *,
+    strategy_key: str,
+    experiment_id_by_key: dict,
+    full_campaign_hash: str,
+    campaign_run_id: str,
+):
+    """Legacy convenience wrapper -- routed through the SAME normalized-
+    batch boundary as ``_normalize_and_capture_summaries`` (captain
+    precision follow-up, 2026-07-17, item 2), so it can never silently
+    regress to the old per-item raw-wrapper pattern (which re-normalized
+    each item independently and had no exact-tuple discipline on the
+    outer batch). No capture wiring -- this helper never touches
+    operator-visible output. ``summaries`` must now be an exact tuple,
+    matching the boundary's own requirement."""
+    return _normalize_and_capture_summaries(
+        summaries,
+        strategy_key=strategy_key,
+        experiment_id_by_key=experiment_id_by_key,
+        full_campaign_hash=full_campaign_hash,
+        campaign_run_id=campaign_run_id,
+        capture_summaries_into=None,
+    )
+
+
+def _normalize_experiment_id_by_key(value, *, context: str) -> dict:
+    """``experiment_id_by_key``: ``{(strategy_key, config_id):
+    experiment_id}`` -- captain design precision (2026-07-17, item 2):
+    snapshot and exact-validate this mapping too, exactly once, BEFORE any
+    fallback artifact/evidence construction reads it. Exact plain ``dict``
+    (never a subclass), every key an exact 2-tuple of exact ``str``
+    (strategy_key, config_id), every value an exact ``str`` experiment_id.
+    Every downstream consumer must use ONLY this normalized snapshot,
+    never the caller's original mapping."""
+    if type(value) is not dict:
+        raise ValueError(f"{context} must be an exact dict -- refusing to persist")
+    normalized: dict[tuple[str, str], str] = {}
+    for idx, (key, val) in enumerate(value.items()):
+        if type(key) is not tuple or len(key) != 2:
+            raise ValueError(
+                f"{context} key#{idx} must be an exact 2-tuple -- refusing to persist"
+            )
+        raw_strategy_key, raw_config_id = key
+        strategy_key = _assert_exact_str(
+            raw_strategy_key, context=f"{context} key#{idx} strategy_key"
+        )
+        config_id = _assert_exact_str(
+            raw_config_id, context=f"{context} key#{idx} config_id"
+        )
+        experiment_id = _assert_exact_str(
+            val, context=f"{context} key#{idx} experiment_id"
+        )
+        normalized[(strategy_key, config_id)] = experiment_id
+    return normalized
+
+
+def _normalize_and_capture_summaries(
+    summaries,
+    *,
+    strategy_key: str,
+    experiment_id_by_key: dict,
+    full_campaign_hash: str,
+    campaign_run_id: str,
+    capture_summaries_into: list | None = None,
+) -> list:
+    """Captain design cross-check + design-review corrections (2026-07-17):
+    normalize EVERY summary exactly once, HERE, into an exact TUPLE batch
+    -- before ``experiment_id_by_key``'s lookup (which uses ``config_id``
+    as part of its dict key) and before operator-visible capture. Builds
+    ALL H6 evidence by calling the NORMALIZED CORE
+    (``_normalized_summary_to_attempt_evidence``) directly on those exact
+    snapshot objects -- never the raw wrapper (``_summary_to_attempt_evidence``
+    would re-normalize, contradicting exactly-once/same-snapshot and
+    copying every nested dict twice). Only AFTER every evidence entry has
+    been successfully built does operator capture receive the SAME
+    normalized objects -- never before, and never a second independent
+    traversal/copy of the caller's original summaries.
+
+    Captain precision follow-up (2026-07-17, item 1): every lineage arg
+    AND ``experiment_id_by_key`` itself are gated/normalized FIRST, before
+    any f-string context, dict lookup, or normalized-core call -- calling
+    the core directly (as this function does) bypasses the thin wrapper's
+    OWN lineage gating, so this is the only place left that can do it for
+    this call path."""
+    strategy_key = _assert_exact_str(
+        strategy_key, context="lineage argument strategy_key"
+    )
+    full_campaign_hash = _assert_exact_str(
+        full_campaign_hash, context="lineage argument full_campaign_hash"
+    )
+    campaign_run_id = _assert_exact_str(
+        campaign_run_id, context="lineage argument campaign_run_id"
+    )
+    experiment_id_by_key = _normalize_experiment_id_by_key(
+        experiment_id_by_key, context="experiment_id_by_key"
+    )
+    if type(summaries) is not tuple:
+        raise ValueError(
+            "summaries batch must be an exact tuple -- refusing to persist"
+        )
+    normalized = tuple(
+        _normalize_config_attempt_evidence_summary(
+            s, context=f"{strategy_key}/summary#{idx}"
+        )
+        for idx, s in enumerate(summaries)
+    )
+    evidence = [
+        _normalized_summary_to_attempt_evidence(
+            s,
+            strategy_key=strategy_key,
+            experiment_id=experiment_id_by_key[(strategy_key, s.config_id)],
+            full_campaign_hash=full_campaign_hash,
+            campaign_run_id=campaign_run_id,
+        )
+        for s in normalized
+    ]
+    if capture_summaries_into is not None:
+        capture_summaries_into.extend(normalized)
+    return evidence
+
+
+def _global_failure_summaries(experiment_id_by_key: dict) -> tuple:
+    """The 24 deterministic ``ConfigAttemptEvidenceSummary`` sentinel rows
+    for a GLOBAL (pre-per-config) failure -- corpus loading, manifest
+    validation, or any other precondition needed before ANY per-strategy
+    walk-forward can run. Every entry is ``status="crashed"`` with the FIXED
+    ``REASON_GLOBAL_CORPUS_LOAD_FAILED`` code and a deterministic 3-scenario
+    sentinel (no raw exception text anywhere; every hash is stable identity
+    + status + reason only). Kept separate from evidence conversion so the
+    SAME summaries can back both the persisted DB evidence
+    (``_global_failure_evidence_batch``) and the operator-visible CLI
+    ``capture_summaries_into`` view, through one single source.
+    """
+    from rob940_cost_model import COST_SCENARIOS
+    from rob944_walkforward import (
+        REASON_GLOBAL_CORPUS_LOAD_FAILED,
+        ConfigAttemptEvidenceSummary,
+        ScenarioEvidenceSummary,
+    )
+
+    from research_contracts.canonical_hash import canonical_sha256
+
+    summaries = []
+    for (strategy_key, config_id), _experiment_id in experiment_id_by_key.items():
+        # Captain global-fallback identity-consistency correction
+        # (2026-07-17): the OPERATOR-VISIBLE summary.strategy must be
+        # consistently the short "S1"/"S2" slug (matching every real,
+        # non-fallback summary) -- the FULL production strategy_key is
+        # still bound into the artifact hash (identity provenance) and
+        # passed explicitly to _summary_to_attempt_evidence's own
+        # strategy_key param by the caller, never conflated with this field.
+        slug = config_id.split("-", 1)[0]
+        scenario_summaries = tuple(
+            ScenarioEvidenceSummary(
+                scenario_name=scenario.name,
+                status="crashed",
+                reason_code=REASON_GLOBAL_CORPUS_LOAD_FAILED,
+                trade_count=0,
+                artifact_hash=canonical_sha256(
+                    {
+                        "strategy_key": strategy_key,
+                        "config_id": config_id,
+                        "scenario_name": scenario.name,
+                        "status": "crashed",
+                        "reason_code": REASON_GLOBAL_CORPUS_LOAD_FAILED,
+                    }
+                ),
+                no_trade_reason_counts={},
+            )
+            for scenario in COST_SCENARIOS
+        )
+        summaries.append(
+            ConfigAttemptEvidenceSummary(
+                strategy=slug,
+                config_id=config_id,
+                status="crashed",
+                reason_code=REASON_GLOBAL_CORPUS_LOAD_FAILED,
+                scenario_summaries=scenario_summaries,
+            )
+        )
+    return tuple(summaries)
+
+
+def _global_failure_evidence_batch(
+    experiment_id_by_key: dict, *, full_campaign_hash: str, campaign_run_id: str
+) -> list:
+    """A GLOBAL (pre-per-config) failure must still yield a full 24-entry
+    terminal batch, never zero attempts, once the 24 experiment keys are
+    already predeclared (post-registration).
+
+    Captain consistency correction (2026-07-17): builds the SAME
+    ``rob944_walkforward.ConfigAttemptEvidenceSummary``/``ScenarioEvidenceSummary``
+    shape the real (non-failure) path produces (via ``_global_failure_summaries``),
+    then converts via the IDENTICAL normalized-core boundary used for real
+    evidence -- so ``fold_evidence_hash``/``run_identity`` bind the actual
+    3 canonical scenario names/status/count/artifact-hashes here too, not
+    merely the bare reason code, and the operator-visible CLI view and
+    persisted DB evidence are built through one single conversion path,
+    never two independently hand-rolled ones that could silently drift
+    apart.
+
+    Captain precision follow-up (2026-07-17, item 2): routed through
+    ``_build_fallback_evidence_and_capture`` (``capture_summaries_into=None``
+    -- this legacy helper never touched operator-visible output) so it
+    cannot silently regress to the old per-item raw-wrapper pattern this
+    module has moved away from everywhere else.
+    """
+    return _build_fallback_evidence_and_capture(
+        experiment_id_by_key,
+        full_campaign_hash=full_campaign_hash,
+        campaign_run_id=campaign_run_id,
+        capture_summaries_into=None,
+    )
+
+
+def _build_fallback_evidence_and_capture(
+    experiment_id_by_key: dict,
+    *,
+    full_campaign_hash: str,
+    campaign_run_id: str,
+    capture_summaries_into: list | None = None,
+) -> list:
+    """Captain design precision (2026-07-17, items 2-3): the ONE fallback
+    helper. Snapshots/exact-validates ``experiment_id_by_key`` first (never
+    the caller's original mapping again after this point), generates the
+    deterministic 24-entry global-fallback summaries as an exact tuple,
+    normalizes each entry exactly once, builds/validates ALL 24 via the
+    normalized core, and ONLY THEN -- after every entry has succeeded --
+    replaces operator capture atomically with those same normalized
+    objects. Never a partial or raw (pre-normalization) capture.
+
+    Captain precision follow-up (2026-07-17, item 1): ``full_campaign_hash``/
+    ``campaign_run_id`` are ALSO gated here, first -- this function calls
+    the normalized core directly (bypassing the thin wrapper's own
+    lineage gating), so it must do that gating itself."""
+    full_campaign_hash = _assert_exact_str(
+        full_campaign_hash, context="lineage argument full_campaign_hash"
+    )
+    campaign_run_id = _assert_exact_str(
+        campaign_run_id, context="lineage argument campaign_run_id"
+    )
+    normalized_ids = _normalize_experiment_id_by_key(
+        experiment_id_by_key, context="global-fallback experiment_id_by_key"
+    )
+    fallback_summaries = _global_failure_summaries(normalized_ids)
+    # summaries only carry the short "S1"/"S2" slug in .strategy --
+    # recover the FULL production strategy_key/experiment_id per
+    # config_id (unique across the whole campaign), from the SAME
+    # normalized snapshot.
+    strategy_key_by_config_id = {
+        config_id: strategy_key for (strategy_key, config_id) in normalized_ids
+    }
+    experiment_id_by_config_id = {
+        config_id: exp_id
+        for (_strategy_key, config_id), exp_id in normalized_ids.items()
+    }
+    normalized_fallback = tuple(
+        _normalize_config_attempt_evidence_summary(
+            s, context=f"global-fallback/summary#{idx}"
+        )
+        for idx, s in enumerate(fallback_summaries)
+    )
+    fallback_evidence = [
+        _normalized_summary_to_attempt_evidence(
+            s,
+            strategy_key=strategy_key_by_config_id[s.config_id],
+            experiment_id=experiment_id_by_config_id[s.config_id],
+            full_campaign_hash=full_campaign_hash,
+            campaign_run_id=campaign_run_id,
+        )
+        for s in normalized_fallback
+    ]
+    if capture_summaries_into is not None:
+        capture_summaries_into.clear()
+        capture_summaries_into.extend(normalized_fallback)
+    return fallback_evidence
+
+
+def _build_real_attempt_evidence(
+    experiment_id_by_key: dict,
+    *,
+    full_campaign_hash: str,
+    campaign_run_id: str,
+    capture_summaries_into: list | None = None,
+) -> list:
+    """The REAL corpus-loading + walk-forward + H6-evidence pipeline.
+
+    Fully implemented and correct, but ROB-944 (H4) NEVER invokes this --
+    empirical --run remains a deliberate, later, operator action. ANY
+    exception here (missing/tampered corpus, manifest validation failure,
+    etc.) is caught and converted into a full 24-entry crashed terminal
+    batch (see ``_build_fallback_evidence_and_capture``) -- never zero
+    attempts, since the 24 keys are already predeclared by the time this
+    runs.
+
+    Captain global-fallback consistency correction (2026-07-17): if S1
+    already succeeded and populated ``capture_summaries_into`` with 12 real
+    summaries before S2 (or any later step) fails, the operator-visible CLI
+    view MUST match the persisted DB evidence exactly -- so on this path the
+    partial capture is CLEARED and refilled with the full 24-entry global
+    failure sentinel, never left showing 12 real + nothing.
+
+    Captain precision follow-up (2026-07-17, "one remaining boundary"):
+    ``experiment_id_by_key``/``full_campaign_hash``/``campaign_run_id`` are
+    snapshotted/exact-gated HERE, at the very entry point, BEFORE any
+    corpus loading or walk-forward work -- previously the first gate on
+    this mapping fired only AFTER a full per-strategy walk-forward run had
+    already completed (inside ``_normalize_and_capture_summaries``), and
+    the fallback branch re-read the caller's ORIGINAL mapping again after
+    an exception. The SAME normalized snapshot is now passed to BOTH the
+    inner (real pipeline) and fallback branches -- no downstream path
+    sees the caller's original mapping/strings again. Leaf helpers still
+    re-gate their own inputs too (harmless/idempotent on an already-
+    normalized snapshot, and keeps them safe for any other direct caller).
+    """
+    full_campaign_hash = _assert_exact_str(
+        full_campaign_hash, context="lineage argument full_campaign_hash"
+    )
+    campaign_run_id = _assert_exact_str(
+        campaign_run_id, context="lineage argument campaign_run_id"
+    )
+    experiment_id_by_key = _normalize_experiment_id_by_key(
+        experiment_id_by_key, context="experiment_id_by_key"
+    )
+    try:
+        return _build_real_attempt_evidence_inner(
+            experiment_id_by_key,
+            full_campaign_hash=full_campaign_hash,
+            campaign_run_id=campaign_run_id,
+            capture_summaries_into=capture_summaries_into,
+        )
+    except Exception:  # noqa: BLE001 -- deliberate: any global pre-execution failure still yields a full terminal batch, never zero attempts, and never re-raises raw exception text
+        return _build_fallback_evidence_and_capture(
+            experiment_id_by_key,
+            full_campaign_hash=full_campaign_hash,
+            campaign_run_id=campaign_run_id,
+            capture_summaries_into=capture_summaries_into,
+        )
+
+
+def _build_real_attempt_evidence_inner(
+    experiment_id_by_key: dict,
+    *,
+    full_campaign_hash: str,
+    campaign_run_id: str,
+    capture_summaries_into: list | None = None,
+) -> list:
+    """Requires ``AUTO_TRADER_RESEARCH_ARTIFACT_ROOT`` to locate the
+    offline-persisted H1 corpus shards (network-0 load, see
+    ``rob941_offline_loader``). ``capture_summaries_into``, if given, is
+    appended with every ``ConfigAttemptEvidenceSummary`` produced -- the
+    full per-scenario status/reason/count/artifact/no-trade-reason detail,
+    for OPERATOR-VISIBLE output alongside the (necessarily coarser)
+    H6-shaped DB write.
+    """
+    import rob941_offline_loader as offline_loader
+    from rob940_bars_agg import Bar1m, aggregate_complete
+    from rob940_signal_manifest import FROZEN_S1_CONFIGS, FROZEN_S2_CONFIGS
+    from rob940_signal_s1 import generate_s1_signals
+    from rob940_signal_s2 import generate_s2_signals
+    from rob941_frozen_scope import WINDOW_END_MS, WINDOW_START_MS
+    from rob941_funding_sidecar import FundingSidecar
+    from rob941_manifest import CorpusManifest
+    from rob944_folds import generate_frozen_fold_schedule
+    from rob944_walkforward import (
+        ConfigSpec,
+        GeneratedSignalBatch,
+        run_walkforward,
+        summarize_config_attempts_for_h6,
+    )
+
+    artifact_root = os.environ.get(_ENV_ARTIFACT_ROOT)
+    if not artifact_root:
+        raise RunPreflightError(
+            f"{_ENV_ARTIFACT_ROOT} is required for --run corpus loading"
+        )
+
+    manifest = CorpusManifest.load(H1_MANIFEST_PATH)
+    corpus = offline_loader.load_corpus(manifest, Path(artifact_root))
+
+    bars_1m = {
+        symbol: tuple(
+            Bar1m(
+                ts=r.open_time_ms,
+                open=r.open,
+                high=r.high,
+                low=r.low,
+                close=r.close,
+                volume=r.base_volume,
+            )
+            for r in rows
+        )
+        for symbol, rows in corpus["klines"].items()
+    }
+    funding_sidecars = {
+        symbol: FundingSidecar.from_rows(symbol, rows)
+        for symbol, rows in corpus["funding"].items()
+    }
+    gap_ranges = {k.symbol: k.gap_ranges for k in manifest.klines}
+    fold_schedule = generate_frozen_fold_schedule(WINDOW_START_MS, WINDOW_END_MS)
+
+    def _s1_gen_factory(config):
+        def _gen(symbol, bars_slice, fold_id):
+            bars_15m = aggregate_complete(bars_slice, bucket_minutes=15)
+            return generate_s1_signals(bars_15m, config, symbol=symbol, fold_id=fold_id)
+
+        return _gen
+
+    def _s2_gen_factory(config):
+        def _gen(symbol, bars_slice, fold_id):
+            bars_5m = aggregate_complete(bars_slice, bucket_minutes=5)
+            gen_result = generate_s2_signals(
+                bars_5m, bars_slice, config, symbol=symbol, fold_id=fold_id
+            )
+            return GeneratedSignalBatch(
+                signals=gen_result.signals,
+                rejections=_s2_rejections_to_no_trade_records(gen_result.rejections),
+            )
+
+        return _gen
+
+    evidence: list = []
+    for strategy, configs, gen_factory, strategy_key in (
+        ("S1", FROZEN_S1_CONFIGS, _s1_gen_factory, PRODUCTION_S1_STRATEGY_KEY),
+        ("S2", FROZEN_S2_CONFIGS, _s2_gen_factory, PRODUCTION_S2_STRATEGY_KEY),
+    ):
+        specs = tuple(
+            ConfigSpec(config_id=c.config_id, generate_signals=gen_factory(c))
+            for c in configs
+        )
+        result = run_walkforward(
+            strategy=strategy,
+            configs=specs,
+            bars_1m=bars_1m,
+            funding_sidecars=funding_sidecars,
+            gap_ranges=gap_ranges,
+            fold_schedule=fold_schedule,
+        )
+        summaries = summarize_config_attempts_for_h6(result)
+        # Captain normalization-scope clarification (2026-07-17): capture
+        # and evidence-building must consume the SAME normalized snapshot
+        # -- never capture the raw ``summaries`` here while a separate,
+        # later traversal (inside evidence-building) normalizes its own
+        # copy independently.
+        evidence.extend(
+            _normalize_and_capture_summaries(
+                summaries,
+                strategy_key=strategy_key,
+                experiment_id_by_key=experiment_id_by_key,
+                full_campaign_hash=full_campaign_hash,
+                campaign_run_id=campaign_run_id,
+                capture_summaries_into=capture_summaries_into,
+            )
+        )
+    return evidence
+
+
+def _run_precheck_bridge_and_opt_in() -> None:
+    """The pre-DB ``run`` gates, IN ORDER: H6 bridge importability FIRST,
+    then explicit write opt-in. (Captain correction: the prior revision
+    checked opt-in before the bridge; the required order is hash+24 IDs ->
+    bridge importability -> opt-in -> DB policy -> registrations -> loader.)
+    """
+    try:
+        _import_campaign_controller()
+    except ImportError as exc:
+        # The import error's own message is never echoed -- it can contain
+        # local filesystem paths or other environment details.
+        raise RunPreflightError("H6 registration bridge unavailable") from exc
+
+    from app.services.research_db_write_guard import research_write_opt_in_enabled
+
+    if not research_write_opt_in_enabled(os.environ.get(_ENV_WRITE_OPT_IN)):
+        raise RunPreflightError(
+            f"{_ENV_WRITE_OPT_IN} is not explicitly true -- refusing to run "
+            "(default-off research-write opt-in)"
+        )
+
+
+async def _safe_rollback(session) -> None:
+    """Independent controller audit correction (2026-07-17): a rollback
+    attempted in response to an ALREADY-failed orchestration/commit must
+    never itself raw-trace (which would mask the original failure's
+    sanitized message with a second, unsanitized one, and could leak
+    connection/query details). Any rollback failure is reported via a
+    FIXED, sanitized message only."""
+    try:
+        await session.rollback()
+    except Exception:  # noqa: BLE001 -- deliberate: never let a rollback failure raw-trace or mask the original error
+        print(
+            "rollback failed after an orchestration/commit error -- see server-side logs "
+            "for diagnostics",
+            file=sys.stderr,
+        )
+
+
+def _is_empirical_success(report) -> bool:
+    """H6 "accounting complete" is a DIFFERENT claim from "empirical
+    success": a campaign can be fully recorded with every attempt
+    crashed/rejected/timeout. Empirical success additionally requires every
+    PRIMARY attempt to be ``status="completed"`` -- and must be retry-safe:
+    ``report.status_counts`` aggregates ALL attempts including any future
+    retries, so counting ``status_counts["completed"] == expected_total``
+    alone is not enough (e.g. 23 completed primaries + 1 crashed primary + 1
+    completed RETRY of that same experiment would satisfy that count without
+    every primary having succeeded). Requiring ``total_attempts ==
+    expected_total`` (no extra retry rows at all) AND ``retry_attempts == 0``
+    closes that gap; only then does the completed-count check mean what it
+    claims to mean.
+    """
+    return (
+        report.verdict == "complete"
+        and report.total_attempts == report.expected_total
+        and report.retry_attempts == 0
+        and report.status_counts.get("completed", 0) == report.expected_total
+    )
+
+
+def _run_empirical(*, expected_full_campaign_hash: str, campaign_run_id: str) -> int:
+    """Thin sanitized wrapper around ``_run_empirical_impl`` (P1-C outer-
+    boundary hardening, 2026-07-17): EVERY documented exit code (2/4/5/6/7/0)
+    is produced by the impl's own explicit control flow -- this wrapper only
+    exists to catch whatever the impl's own internal (narrower) sanitized
+    try/excepts do NOT already cover: envelope construction/hash/derive/
+    to_dict/experiment-id recomputation, and any non-``RunPreflightError``
+    escaping ``_run_precheck_bridge_and_opt_in`` -- none of which sit inside
+    any try today. A raw traceback anywhere in that surface could leak
+    secrets/paths; this is the final backstop, never the primary mechanism
+    (the impl's own narrower catches still produce more specific sanitized
+    messages first).
+    """
+    try:
+        return _run_empirical_impl(
+            expected_full_campaign_hash=expected_full_campaign_hash,
+            campaign_run_id=campaign_run_id,
+        )
+    except Exception:  # noqa: BLE001 -- deliberate: final sanitized backstop for the whole --run boundary, never re-raise
+        print(
+            "run failed with an unexpected error before a documented exit code could be "
+            "produced -- see server-side logs for diagnostics",
+            file=sys.stderr,
+        )
+        return 6
+
+
+def _run_empirical_impl(
+    *, expected_full_campaign_hash: str, campaign_run_id: str
+) -> int:
+    """Gate 1 (fresh hash + 24 IDs + campaign_run_id derivation check), then
+    gates 2-3 (bridge, opt-in), then delegate gates 4-6 (policy,
+    registration, attempt recording) to
+    ``app.services.rob944_campaign_controller.run_full_campaign``. Exit 0
+    requires BOTH H6 accounting-complete AND every primary attempt
+    ``status="completed"`` -- accounting completeness alone is not
+    empirical success.
+    """
+    envelope = build_production_frozen_campaign_envelope()
+    actual_hash = envelope.full_campaign_hash()
+    if actual_hash != expected_full_campaign_hash:
+        # Sanitization pass (2026-07-17): never echo either hash value --
+        # --expected-full-campaign-hash is caller-controlled at this trust
+        # boundary; a fixed, field-only message only.
+        print(
+            "run preflight failed: full_campaign_hash mismatch -- refusing to run",
+            file=sys.stderr,
+        )
+        return 4
+    expected_campaign_run_id = _derive_primary_campaign_run_id(actual_hash)
+    if campaign_run_id != expected_campaign_run_id:
+        # Sanitization pass: never echo --campaign-run-id (caller-controlled)
+        # or the derived expected value in the same message.
+        print(
+            "run preflight failed: --campaign-run-id does not match the value canonically "
+            "derived from the frozen full-campaign hash -- an arbitrary UUID/timestamp is "
+            "refused",
+            file=sys.stderr,
+        )
+        return 4
+    plain = envelope.to_dict()
+    # Q4 addendum: the envelope-embedded experiment_ids (already part of what
+    # actual_hash above committed to) are authoritative; cross-check against
+    # an independent recomputation off the same rows before trusting them.
+    experiment_ids = plain["experiment_ids"]
+    if len(experiment_ids) != 24 or len(set(experiment_ids)) != 24:
+        print(
+            "run preflight failed: expected exactly 24 unique experiment IDs",
+            file=sys.stderr,
+        )
+        return 4
+    if list(experiment_ids) != _derive_experiment_ids(plain["rows"]):
+        print(
+            "run preflight failed: envelope-embedded experiment_ids diverged from an "
+            "independent recomputation off the same rows -- refusing to run",
+            file=sys.stderr,
+        )
+        return 4
+
+    try:
+        _run_precheck_bridge_and_opt_in()
+    except RunPreflightError as exc:
+        print(f"run preflight failed: {exc}", file=sys.stderr)
+        return 2
+
+    import asyncio
+
+    # P1-C outer-boundary hardening (2026-07-17): setup (imports, controller/
+    # policy resolution, spec construction) happens BEFORE any session
+    # exists -- a failure here (e.g. a broken app.* import, a malformed
+    # frozen row failing StrategyExperimentIdentity validation) must not
+    # raw-trace either, even though nothing has touched the DB yet.
+    try:
+        from app.core.db import AsyncSessionLocal
+        from app.schemas.research_backtest import StrategyExperimentIdentity
+        from app.services.research_db_write_guard import default_research_db_policy
+        from app.services.rob944_campaign_controller import (
+            CampaignAccountingIncompleteError,
+            CampaignBatchValidationError,
+            CampaignHashDriftError,
+            CampaignRunIdDerivationError,
+            RunIdentityMismatchError,
+        )
+
+        controller = _import_campaign_controller()
+        guard_policy = default_research_db_policy()
+        specs = [
+            StrategyExperimentIdentity(
+                strategy_key=row["strategy_key"],
+                strategy_version=row["strategy_version"],
+                hypothesis=row["hypothesis"],
+                **row["components"],
+            )
+            for row in plain["rows"]
+        ]
+    except Exception:  # noqa: BLE001 -- deliberate: pre-session setup failure must exit sanitized, never re-raise
+        print(
+            "run setup failed before any database session was opened -- see server-side logs "
+            "for diagnostics",
+            file=sys.stderr,
+        )
+        return 6
+
+    captured_summaries: list = []
+
+    def _build_attempt_evidence(experiment_id_by_key: dict) -> list:
+        return _build_real_attempt_evidence(
+            experiment_id_by_key,
+            full_campaign_hash=actual_hash,
+            campaign_run_id=campaign_run_id,
+            capture_summaries_into=captured_summaries,
+        )
+
+    async def _do_run() -> int:
+        # P1-C outer-boundary hardening: this outer try wraps the
+        # ``async with`` statement ITSELF, not only the code inside it --
+        # AsyncSessionLocal() construction and __aenter__/__aexit__ failures
+        # are NOT covered by the inner try (which only starts once ``session``
+        # is already bound) and must not raw-trace either. No rollback is
+        # attempted here: if construction/__aenter__ failed there is no valid
+        # session to roll back, and if __aexit__ failed the session is
+        # already mid-close.
+        try:
+            return await _do_run_with_session()
+        except Exception:  # noqa: BLE001 -- deliberate: session-boundary failure must exit sanitized, never re-raise
+            print(
+                "run orchestration failed to establish/close the database session -- see "
+                "server-side logs for diagnostics",
+                file=sys.stderr,
+            )
+            return 6
+
+    async def _do_run_with_session() -> int:
+        async with AsyncSessionLocal() as session:
+            try:
+                report = await controller.run_full_campaign(
+                    session,
+                    specs=specs,
+                    actual_full_campaign_hash=actual_hash,
+                    expected_full_campaign_hash=expected_full_campaign_hash,
+                    campaign_run_id=campaign_run_id,
+                    guard_opt_in_enabled=True,
+                    guard_policy=guard_policy,
+                    build_attempt_evidence=_build_attempt_evidence,
+                    strategy_name="rob940_walkforward",
+                    timeframe="mixed_5m_15m",
+                    runner="rob944-cli",
+                )
+            except (
+                CampaignHashDriftError,
+                CampaignBatchValidationError,
+                CampaignAccountingIncompleteError,
+                CampaignRunIdDerivationError,
+                RunIdentityMismatchError,
+            ) as exc:
+                # These are OUR OWN typed exceptions with fixed, safe-to-print
+                # templates (hashes/experiment IDs only, never raw external
+                # text) -- printing them is intentional. Captain controller
+                # catch-classification correction (2026-07-17):
+                # CampaignRunIdDerivationError/RunIdentityMismatchError are
+                # controller validation failures too -- they must roll back
+                # and return the documented code 4, not fall through to the
+                # generic "unknown failure" code 6.
+                # P1-C sanitization precision (2026-07-17): never print
+                # str(exc) -- even though these 5 are OUR OWN typed
+                # exceptions whose messages were just sanitized at the
+                # controller layer, this boundary must not rely on that
+                # invariant holding forever. type(exc).__name__ is a TRUSTED
+                # value (one of exactly these 5 literal class names in this
+                # except clause), safe to report; the exception's own
+                # message text is not.
+                await _safe_rollback(session)
+                print(
+                    f"run preflight/orchestration failed (rolled back): {type(exc).__name__}",
+                    file=sys.stderr,
+                )
+                return 4
+            except Exception:  # noqa: BLE001 -- deliberate: an UNKNOWN failure must roll back and exit with a FIXED sanitized message, never re-raise (a raw traceback could contain secrets/paths)
+                await _safe_rollback(session)
+                print(
+                    "run orchestration failed with an unexpected error (rolled back) -- "
+                    "see server-side logs for diagnostics",
+                    file=sys.stderr,
+                )
+                return 6
+
+            # Independent controller audit correction (2026-07-17): commit
+            # itself can fail (constraint violation, connection drop) -- it
+            # must be inside a sanitized try too, never a bare call whose
+            # exception (and any subsequent rollback failure) could raw-trace.
+            try:
+                await session.commit()
+            except Exception:  # noqa: BLE001 -- deliberate: a commit failure must roll back and exit with a FIXED sanitized message, never re-raise
+                await _safe_rollback(session)
+                print(
+                    "run commit failed after orchestration succeeded (rolled back) -- "
+                    "see server-side logs for diagnostics",
+                    file=sys.stderr,
+                )
+                return 7
+
+            accounting_complete = report.verdict == "complete"
+            empirical_success = _is_empirical_success(report)
+            # Captain item D (2026-07-17): the operator-visible
+            # train_selection_trace was missing the expectancy/profit-factor/
+            # train_input_hash fields already bound into fold_evidence_hash
+            # (see _summary_to_attempt_evidence) -- same NaN/Inf-safe sentinel
+            # encoding for the float fields.
+            from rob944_walkforward import _json_safe_float_or_sentinel
+
+            print(
+                json.dumps(
+                    {
+                        "verdict": report.verdict,
+                        "accounting_complete": accounting_complete,
+                        "empirical_success": empirical_success,
+                        "actual_registrations": report.actual_registrations,
+                        "primary_attempts": report.primary_attempts,
+                        "status_counts": report.status_counts,
+                        "full_campaign_hash": actual_hash,
+                        "campaign_run_id": campaign_run_id,
+                        # Fable report/register closure (2026-07-17): H5 is
+                        # out of scope -- H4 hands off a readable contract
+                        # here too (same top-level field as --plan).
+                        "spec_deviations": plain["h3_fixed_constants"][
+                            "s2_spec_deviations"
+                        ],
+                        "per_config_scenario_evidence": [
+                            {
+                                "strategy": s.strategy,
+                                "config_id": s.config_id,
+                                "status": s.status,
+                                "reason_code": s.reason_code,
+                                "scenarios": [
+                                    {
+                                        "scenario_name": row.scenario_name,
+                                        "status": row.status,
+                                        "reason_code": row.reason_code,
+                                        "trade_count": row.trade_count,
+                                        "artifact_hash": row.artifact_hash,
+                                        "no_trade_reason_counts": row.no_trade_reason_counts,
+                                    }
+                                    for row in s.scenario_summaries
+                                ],
+                                # Captain item E: TRAIN selection rejection
+                                # traces/counts are operator-visible too,
+                                # not only OOS scenario counts.
+                                "train_selection_trace": [
+                                    {
+                                        "fold_id": row.fold_id,
+                                        "fold_selected_config_id": row.fold_selected_config_id,
+                                        "eligible_symbols": list(row.eligible_symbols),
+                                        "excluded_symbols": [
+                                            list(pair) for pair in row.excluded_symbols
+                                        ],
+                                        "equal_weight_expectancy_bps": _json_safe_float_or_sentinel(
+                                            row.equal_weight_expectancy_bps
+                                        ),
+                                        "pooled_expectancy_bps": _json_safe_float_or_sentinel(
+                                            row.pooled_expectancy_bps
+                                        ),
+                                        "profit_factor": _json_safe_float_or_sentinel(
+                                            row.profit_factor
+                                        ),
+                                        "train_input_hash": row.train_input_hash,
+                                        "rejected": row.rejected,
+                                        "rejection_reason": row.rejection_reason,
+                                        "no_trade_reason_counts": row.no_trade_reason_counts,
+                                    }
+                                    for row in getattr(s, "fold_selection_trace", ())
+                                ],
+                            }
+                            for s in captured_summaries
+                        ],
+                    },
+                    indent=2,
+                    sort_keys=True,
+                )
+            )
+            return 0 if empirical_success else 5
+
+    # P1-C outer-boundary hardening: asyncio.run itself (event loop
+    # setup/teardown) is outside every try above -- must not raw-trace.
+    try:
+        return asyncio.run(_do_run())
+    except Exception:  # noqa: BLE001 -- deliberate: event-loop failure must exit sanitized, never re-raise
+        print(
+            "run orchestration failed before any result could be produced -- see server-side "
+            "logs for diagnostics",
+            file=sys.stderr,
+        )
+        return 6
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="run_rob944_campaign",
+        description="ROB-944 (H4, ROB-940) walk-forward campaign runner",
+    )
+    parser.add_argument(
+        "--version", action="version", version=f"%(prog)s {__version__}"
+    )
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument(
+        "--plan",
+        action="store_true",
+        help="pure, no I/O -- prints the frozen campaign plan",
+    )
+    mode.add_argument(
+        "--run", action="store_true", help="empirical, fail-closed gated execution"
+    )
+    parser.add_argument(
+        "--expected-full-campaign-hash",
+        default=None,
+        help="[--run, required] operator-pinned expected full_campaign_hash",
+    )
+    parser.add_argument(
+        "--campaign-run-id",
+        default=None,
+        help=(
+            "[--run, required] MUST equal the value --plan reports as "
+            "expected_campaign_run_id -- never an arbitrary UUID/timestamp"
+        ),
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_arg_parser()
+    args = parser.parse_args(
+        argv
+    )  # --help/--version exit via SystemExit here, before any gate logic
+    if args.plan:
+        print(json.dumps(build_plan(), indent=2, sort_keys=True))
+        return 0
+    # args.run
+    if not args.expected_full_campaign_hash:
+        print(
+            "run preflight failed: --expected-full-campaign-hash is required for --run",
+            file=sys.stderr,
+        )
+        return 2
+    if not args.campaign_run_id:
+        print(
+            "run preflight failed: --campaign-run-id is required for --run",
+            file=sys.stderr,
+        )
+        return 2
+    return _run_empirical(
+        expected_full_campaign_hash=args.expected_full_campaign_hash,
+        campaign_run_id=args.campaign_run_id,
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/research/nautilus_scalping/tests/test_rob944_cli.py
+++ b/research/nautilus_scalping/tests/test_rob944_cli.py
@@ -1,0 +1,3682 @@
+"""ROB-944 (H4, ROB-940) — CLI --plan / --run boundary tests.
+
+``--plan`` must be pure (no network/DB/write/env-mutation/child-run), byte-
+identical across repeated invocations and PYTHONHASHSEED, and must emit the
+full-campaign hash, fold schedule, 24 experiment IDs, expected logical
+attempts=24, cost scenarios, and source/data/signal hashes -- derived via the
+PURE ``research_contracts`` authority (no ``app.*`` import on this path).
+``--run``'s PRE-DB gate ordering (fresh-hash-vs-operator-pin, then write
+opt-in, then H6 bridge availability) must fail closed before any DB/network/
+child-execution touches occur; ``--plan``/``--run`` are mutually exclusive
+flags, and ``--version`` never touches any gate logic.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import run_rob944_campaign as cli
+
+_SCRIPT = Path(__file__).resolve().parents[1] / "run_rob944_campaign.py"
+
+
+def test_build_plan_is_deterministic_across_repeated_calls():
+    plan1 = cli.build_plan()
+    plan2 = cli.build_plan()
+    assert plan1 == plan2
+
+
+def test_build_plan_contains_required_fields():
+    plan = cli.build_plan()
+    assert len(plan["full_campaign_hash"]) == 64
+    assert plan["fold_count"] == 8
+    assert len(plan["fold_schedule"]) == 8
+    assert len(plan["experiment_ids"]) == 24
+    assert len(set(plan["experiment_ids"])) == 24
+    assert plan["expected_logical_attempts"] == 24
+    assert set(plan["cost_scenarios"]) == {"base", "primary_stress", "upward_stress"}
+    assert plan["primary_scenario"] == "primary_stress"
+    assert plan["dataset_manifest_hash"]
+    assert plan["signal_manifest_hash"]
+    assert plan["scenario_execution"] == "independent_run_with_fresh_state"
+
+
+# ---------------------------------------------------------------------------
+# Captain config/plan audit (2026-07-18): four pre-freeze blockers --
+# (A) explicit S1/S2 source SHA-256s + an independently-auditable lossless
+# canonical payload; (B) byte-exact (not text-mode) strategy source
+# provenance (covered in test_rob944_frozen_campaign.py); (C) pure --plan
+# sentinel/snapshot proof (zero DB/network/file-write/os.environ/child
+# execution, no process-global sys.path mutation); (D) these are the plan
+# output-contract tests catching the above omissions.
+# ---------------------------------------------------------------------------
+
+
+def test_plan_full_campaign_payload_independently_reproduces_full_campaign_hash():
+    """Item A: full_campaign_payload must be the EXACT structure
+    full_campaign_hash was computed from -- canonical_sha256(payload) ==
+    full_campaign_hash, independently verifiable by any external auditor
+    without trusting the CLI's own self-check."""
+    from research_contracts.canonical_hash import canonical_sha256
+
+    plan = cli.build_plan()
+    assert canonical_sha256(plan["full_campaign_payload"]) == plan["full_campaign_hash"]
+
+
+def test_plan_emits_s1_and_s2_source_sha256_matching_actual_committed_files():
+    """Item A: s1_source_sha256/s2_source_sha256 must be the ACTUAL
+    byte-derived SHA-256 of the real committed S1/S2 source files -- not
+    merely present, but independently reproducible from the raw file
+    bytes."""
+    import hashlib
+
+    from rob944_frozen_campaign import _S1_SOURCE_PATH, _S2_SOURCE_PATH
+
+    plan = cli.build_plan()
+    assert (
+        plan["s1_source_sha256"]
+        == hashlib.sha256(_S1_SOURCE_PATH.read_bytes()).hexdigest()
+    )
+    assert (
+        plan["s2_source_sha256"]
+        == hashlib.sha256(_S2_SOURCE_PATH.read_bytes()).hexdigest()
+    )
+    assert plan["s1_source_sha256"] != plan["s2_source_sha256"]
+
+
+def test_plan_full_campaign_payload_contains_h1_h3_hashes_24_rows_and_policy_components():
+    """Item A: the emitted payload must actually carry H1's
+    dataset_manifest_hash, H3's signal_manifest_hash, all 24 rows/
+    experiment_ids, and the material policy components (funding_pit_policy/
+    data_gap_policy/posture) -- not a curated subset that omits exactly
+    what would be needed to audit the hash."""
+    plan = cli.build_plan()
+    payload = plan["full_campaign_payload"]
+    assert payload["dataset_manifest_hash"] == plan["dataset_manifest_hash"]
+    assert payload["signal_manifest_hash"] == plan["signal_manifest_hash"]
+    assert len(payload["rows"]) == 24
+    assert len(payload["experiment_ids"]) == 24
+    assert len(set(payload["experiment_ids"])) == 24
+    assert payload["funding_pit_policy"] == plan["funding_pit_policy"]
+    assert payload["data_gap_policy"] == plan["data_gap_policy"]
+    assert payload["posture"] == plan["posture"]
+
+
+def test_plan_never_touches_the_network(monkeypatch):
+    """Item C: --plan must never open a network socket.
+
+    Every purity test in this section explicitly ``monkeypatch.undo()``s
+    BEFORE returning (not merely relying on the fixture's own end-of-test
+    teardown) -- pytest's own internal bookkeeping (e.g. writing
+    ``PYTEST_CURRENT_TEST`` into ``os.environ`` at teardown) runs AFTER
+    the test function body but can still observe an un-reverted patch,
+    which would misattribute pytest's own activity to ``build_plan``."""
+    import socket
+
+    def _boom(*args, **kwargs):
+        raise AssertionError("build_plan must never touch the network")
+
+    monkeypatch.setattr(socket.socket, "connect", _boom)
+    monkeypatch.setattr(socket, "create_connection", _boom)
+    try:
+        cli.build_plan()  # must not raise
+    finally:
+        monkeypatch.undo()
+
+
+def test_plan_never_mutates_os_environ(monkeypatch):
+    """Item C: --plan must never mutate os.environ.
+
+    Captain test precision (2026-07-18): a bare ``__setitem__`` sentinel
+    alone would stay green if build_plan regressed to
+    ``os.environ.pop``/``.update``/``.setdefault``/``.clear``/``del
+    os.environ[...]`` instead -- a full ``dict(os.environ)`` before/after
+    SNAPSHOT comparison catches any mutation regardless of which method
+    performed it, non-vacuously."""
+    import os
+
+    def _boom(self, key, value):
+        raise AssertionError(
+            f"build_plan must never mutate os.environ (attempted key={key!r})"
+        )
+
+    monkeypatch.setattr(type(os.environ), "__setitem__", _boom)
+    before = dict(os.environ)
+    try:
+        cli.build_plan()
+    finally:
+        monkeypatch.undo()
+    after = dict(os.environ)
+    assert before == after
+
+
+def test_plan_never_spawns_a_child_process(monkeypatch):
+    """Item C: --plan must never spawn a child process."""
+    import os
+    import subprocess
+
+    def _boom(*args, **kwargs):
+        raise AssertionError("build_plan must never spawn a child process")
+
+    monkeypatch.setattr(subprocess.Popen, "__init__", _boom)
+    monkeypatch.setattr(os, "fork", _boom, raising=False)
+    monkeypatch.setattr(os, "posix_spawn", _boom, raising=False)
+    try:
+        cli.build_plan()
+    finally:
+        monkeypatch.undo()
+
+
+def test_plan_never_opens_a_file_for_writing(monkeypatch, tmp_path):
+    """Item C: --plan legitimately READS pinned fixture/source files, but
+    must never open anything in a write/append/create/update mode.
+
+    Captain test precision (2026-07-18): ``io.open`` and ``builtins.open``
+    are the SAME object initially (``io.open is builtins.open`` at
+    interpreter startup), but they are two INDEPENDENT attribute bindings
+    (on the ``io`` module and the ``builtins`` module respectively) --
+    patching only ``builtins.open`` does NOT affect ``io.open``, and
+    ``pathlib.Path.open()``/``write_text()``/``write_bytes()`` all call
+    ``io.open(...)`` directly (an attribute lookup on the ``io`` module),
+    never ``builtins.open``. A build_plan regression to
+    ``Path.write_text(...)`` would have stayed GREEN under a
+    ``builtins.open``-only guard -- verified empirically before this fix.
+    Both are patched here; read-only modes remain allowed."""
+    import builtins
+    import io
+
+    original_open = builtins.open
+
+    def _guarded_open(file, mode="r", *args, **kwargs):
+        if any(ch in mode for ch in ("w", "a", "x", "+")):
+            raise AssertionError(
+                f"build_plan must never open a file for writing (mode={mode!r})"
+            )
+        return original_open(file, mode, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "open", _guarded_open)
+    monkeypatch.setattr(io, "open", _guarded_open)
+    try:
+        # Non-vacuous proof (2026-07-18): the guard itself must actually
+        # fire for a real Path.write_text() call, under the SAME patch
+        # build_plan() runs under -- proving this is a real guard, not a
+        # vacuously-passing no-op.
+        with pytest.raises(AssertionError, match="must never open a file for writing"):
+            (tmp_path / "probe.txt").write_text("should never reach disk")
+        cli.build_plan()
+    finally:
+        monkeypatch.undo()
+
+
+def test_plan_never_mutates_process_global_sys_path():
+    """Item C: --plan (and merely importing/using this module) must never
+    mutate process-global sys.path -- the module-level bootstrap mutation
+    this file used to have at import time has been removed entirely."""
+    before = list(sys.path)
+    cli.build_plan()
+    after = list(sys.path)
+    assert before == after
+
+
+def test_plan_never_imports_db_module_in_a_clean_subprocess():
+    """Item C: --plan must cause zero DB touch -- proven in a CLEAN
+    subprocess (avoids cross-test sys.modules pollution from other tests
+    in this same file that legitimately exercise the --run path and DO
+    import app.core.db)."""
+    code = (
+        "import sys\n"
+        f"sys.path.insert(0, {str(_SCRIPT.parent)!r})\n"
+        "import run_rob944_campaign as cli\n"
+        "cli.build_plan()\n"
+        "assert 'app.core.db' not in sys.modules, "
+        "'app.core.db was imported during --plan'\n"
+        "print('OK')\n"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        cwd=str(_SCRIPT.parent),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "OK"
+
+
+def test_main_plan_flag_prints_valid_stable_json_to_stdout(capsys):
+    exit_code = cli.main(["--plan"])
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    parsed = json.loads(captured.out)
+    assert len(parsed["experiment_ids"]) == 24
+
+
+def test_plan_and_run_are_mutually_exclusive():
+    with pytest.raises(SystemExit):
+        cli.main(["--plan", "--run"])
+
+
+def test_neither_plan_nor_run_fails_closed():
+    with pytest.raises(SystemExit):
+        cli.main([])
+
+
+def test_plan_flag_is_byte_identical_across_pythonhashseed_subprocess():
+    outputs = []
+    for seed in ("0", "12345", "999999"):
+        result = subprocess.run(
+            [sys.executable, str(_SCRIPT), "--plan"],
+            env={"PYTHONHASHSEED": seed, "PATH": "/usr/bin:/bin"},
+            cwd=str(_SCRIPT.parent),
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        outputs.append(result.stdout)
+    assert outputs[0] == outputs[1] == outputs[2]
+
+
+def test_version_flag_never_touches_run_gates(monkeypatch):
+    called = {"gate": False}
+
+    def _boom(*a, **k):
+        called["gate"] = True
+        raise AssertionError("--version must never reach run-gate logic")
+
+    monkeypatch.setattr(cli, "_run_precheck_bridge_and_opt_in", _boom)
+    with pytest.raises(SystemExit) as exc_info:
+        cli.main(["--version"])
+    assert exc_info.value.code == 0
+    assert called["gate"] is False
+
+
+def test_help_never_touches_run_gates(monkeypatch):
+    called = {"gate": False}
+
+    def _boom(*a, **k):
+        called["gate"] = True
+        raise AssertionError("--help must never reach run-gate logic")
+
+    monkeypatch.setattr(cli, "_run_precheck_bridge_and_opt_in", _boom)
+    with pytest.raises(SystemExit) as exc_info:
+        cli.main(["--help"])
+    assert exc_info.value.code == 0
+    assert called["gate"] is False
+
+
+def test_run_without_expected_hash_fails_closed_before_any_gate(monkeypatch):
+    called = {"gate": False}
+    monkeypatch.setattr(
+        cli, "_run_precheck_bridge_and_opt_in", lambda: called.__setitem__("gate", True)
+    )
+    exit_code = cli.main(["--run", "--campaign-run-id", "run-fixed-001"])
+    assert exit_code != 0
+    assert called["gate"] is False
+
+
+def test_run_without_campaign_run_id_fails_closed_before_any_gate(monkeypatch):
+    called = {"gate": False}
+    monkeypatch.setattr(
+        cli, "_run_precheck_bridge_and_opt_in", lambda: called.__setitem__("gate", True)
+    )
+    exit_code = cli.main(["--run", "--expected-full-campaign-hash", "a" * 64])
+    assert exit_code != 0
+    assert called["gate"] is False
+
+
+def test_run_fails_closed_on_hash_mismatch_before_opt_in_or_bridge_check(monkeypatch):
+    """A fresh recomputation vs an operator-pinned MISMATCHED value must fail
+    BEFORE the opt-in/bridge gates are ever consulted -- proving the two
+    hash values are genuinely independent, not both freshly recomputed from
+    the same call (which would be vacuous)."""
+    called = {"gate": False}
+    monkeypatch.setattr(
+        cli, "_run_precheck_bridge_and_opt_in", lambda: called.__setitem__("gate", True)
+    )
+    exit_code = cli.main(
+        [
+            "--run",
+            "--expected-full-campaign-hash",
+            "0" * 64,
+            "--campaign-run-id",
+            "run-fixed-001",
+        ]
+    )
+    assert exit_code != 0
+    assert called["gate"] is False
+
+
+def test_run_hash_mismatch_message_never_echoes_either_hash_value(monkeypatch, capsys):
+    """P1-B: on full_campaign_hash mismatch, _run_empirical must print a
+    fixed, field-only message -- never the operator-supplied
+    --expected-full-campaign-hash (caller-controlled, could be a secret-
+    looking sentinel) nor the freshly recomputed actual hash."""
+    monkeypatch.setattr(cli, "_run_precheck_bridge_and_opt_in", lambda: None)
+    sentinel = "sk-live-SUPERSECRETTOKEN-should-never-appear-in-stderr-0000000"
+    exit_code = cli.main(
+        [
+            "--run",
+            "--expected-full-campaign-hash",
+            sentinel,
+            "--campaign-run-id",
+            "run-fixed-001",
+        ]
+    )
+    assert exit_code == 4
+    stderr = capsys.readouterr().err
+    assert sentinel not in stderr
+    actual_hash = cli.build_production_frozen_campaign_envelope().full_campaign_hash()
+    assert actual_hash not in stderr
+    assert "full_campaign_hash mismatch" in stderr
+
+
+def test_run_campaign_run_id_mismatch_message_never_echoes_either_id(
+    monkeypatch, capsys
+):
+    """P1-B: on campaign_run_id mismatch (hash already matches), the printed
+    message must never echo the operator-supplied --campaign-run-id
+    (caller-controlled) nor the canonically-derived expected value."""
+    monkeypatch.setattr(cli, "_run_precheck_bridge_and_opt_in", lambda: None)
+    plan = cli.build_plan()
+    sentinel = "sk-live-SUPERSECRETTOKEN-should-never-appear-in-stderr"
+    exit_code = cli.main(
+        [
+            "--run",
+            "--expected-full-campaign-hash",
+            plan["full_campaign_hash"],
+            "--campaign-run-id",
+            sentinel,
+        ]
+    )
+    assert exit_code == 4
+    stderr = capsys.readouterr().err
+    assert sentinel not in stderr
+    assert plan["expected_campaign_run_id"] not in stderr
+    assert "--campaign-run-id" in stderr
+
+
+def test_run_mode_fails_closed_when_write_opt_in_is_absent(monkeypatch):
+    monkeypatch.delenv("ROB944_RESEARCH_WRITE_OPT_IN", raising=False)
+    with pytest.raises(cli.RunPreflightError):
+        cli._run_precheck_bridge_and_opt_in()
+
+
+def test_run_mode_fails_closed_when_write_opt_in_is_false(monkeypatch):
+    monkeypatch.setenv("ROB944_RESEARCH_WRITE_OPT_IN", "false")
+    with pytest.raises(cli.RunPreflightError):
+        cli._run_precheck_bridge_and_opt_in()
+
+
+def test_run_mode_passes_precheck_when_opt_in_true_and_bridge_importable(monkeypatch):
+    monkeypatch.setenv("ROB944_RESEARCH_WRITE_OPT_IN", "true")
+    cli._run_precheck_bridge_and_opt_in()  # must not raise
+
+
+def test_run_mode_fails_closed_when_bridge_unimportable(monkeypatch):
+    monkeypatch.setenv("ROB944_RESEARCH_WRITE_OPT_IN", "true")
+
+    def _raise_import_error():
+        raise ImportError(
+            "simulated: app.services.rob944_campaign_controller unavailable"
+        )
+
+    monkeypatch.setattr(cli, "_import_campaign_controller", _raise_import_error)
+    with pytest.raises(cli.RunPreflightError):
+        cli._run_precheck_bridge_and_opt_in()
+
+
+def test_main_run_mode_exits_nonzero_when_hash_matches_but_opt_in_absent(
+    monkeypatch, capsys
+):
+    """Once the (matching) hash AND correctly-derived campaign_run_id gates
+    pass, the NEXT gate (opt-in) must still fail closed. Independent
+    controller audit correction (2026-07-17): the prior version of this test
+    passed an ARBITRARY campaign_run_id ("run-fixed-001"), so it never
+    actually reached the opt-in gate at all (it failed earlier, at the
+    campaign_run_id-derivation gate) -- the assertion (bare ``!= 0``) never
+    noticed. Passes the REAL derived ``expected_campaign_run_id`` so this
+    test genuinely exercises the opt-in gate, and checks the printed
+    message names opt-in specifically."""
+    monkeypatch.delenv("ROB944_RESEARCH_WRITE_OPT_IN", raising=False)
+    plan = cli.build_plan()
+    exit_code = cli.main(
+        [
+            "--run",
+            "--expected-full-campaign-hash",
+            plan["full_campaign_hash"],
+            "--campaign-run-id",
+            plan["expected_campaign_run_id"],
+        ]
+    )
+    assert exit_code != 0
+    assert "opt-in" in capsys.readouterr().err
+
+
+def test_bridge_gate_is_checked_before_opt_in_gate(monkeypatch, capsys):
+    """Independent controller audit correction: with a matching hash AND
+    correctly-derived campaign_run_id, if BOTH the bridge import AND the
+    opt-in check would independently fail, the reported failure must be the
+    BRIDGE one -- proving bridge-importability is checked strictly before
+    opt-in (per _run_precheck_bridge_and_opt_in's own documented order),
+    not merely that "some" RunPreflightError was raised."""
+    monkeypatch.delenv(
+        "ROB944_RESEARCH_WRITE_OPT_IN", raising=False
+    )  # opt-in would ALSO fail
+
+    def _raise_import_error():
+        raise ImportError("simulated: bridge unavailable")
+
+    monkeypatch.setattr(cli, "_import_campaign_controller", _raise_import_error)
+    plan = cli.build_plan()
+    exit_code = cli.main(
+        [
+            "--run",
+            "--expected-full-campaign-hash",
+            plan["full_campaign_hash"],
+            "--campaign-run-id",
+            plan["expected_campaign_run_id"],
+        ]
+    )
+    assert exit_code != 0
+    stderr = capsys.readouterr().err
+    assert "bridge" in stderr
+    assert "opt-in" not in stderr
+
+
+# ---------------------------------------------------------------------------
+# Independent controller audit correction (2026-07-17): a rollback attempted
+# in response to an ALREADY-failed orchestration/commit must never itself
+# raw-trace (masking the original sanitized message with an unsanitized
+# one, potentially leaking connection/query details).
+# ---------------------------------------------------------------------------
+
+
+def test_safe_rollback_succeeds_silently_when_rollback_succeeds():
+    import asyncio
+
+    class _FakeSession:
+        async def rollback(self):
+            pass
+
+    asyncio.run(cli._safe_rollback(_FakeSession()))  # must not raise
+
+
+def test_safe_rollback_swallows_rollback_failure_and_prints_only_a_sanitized_message(
+    capsys,
+):
+    import asyncio
+
+    class _FakeSession:
+        async def rollback(self):
+            raise RuntimeError(
+                "boom: raw connection string postgres://user:secret@host/db"
+            )
+
+    asyncio.run(cli._safe_rollback(_FakeSession()))  # must not raise
+    stderr = capsys.readouterr().err
+    assert "boom" not in stderr
+    assert "secret" not in stderr
+    assert "rollback failed" in stderr
+
+
+class _FakeDbSession:
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_exc_info):
+        return False
+
+    async def commit(self):
+        pass
+
+    async def rollback(self):
+        pass
+
+
+class _FakeSessionLocal:
+    def __call__(self):
+        return _FakeDbSession()
+
+
+def _run_main_with_fake_controller(monkeypatch, run_full_campaign_side_effect):
+    """Exercises the real --run path (main -> _run_empirical -> _do_run) with
+    a fake DB session (no real DB touched) and a fake controller module
+    whose ``run_full_campaign`` raises/returns ``run_full_campaign_side_effect``
+    -- used to prove the CLI's exit-code classification for each controller
+    exception type without needing a live database."""
+    monkeypatch.setenv("ROB944_RESEARCH_WRITE_OPT_IN", "true")
+    monkeypatch.setattr("app.core.db.AsyncSessionLocal", _FakeSessionLocal())
+
+    class _FakeController:
+        @staticmethod
+        async def run_full_campaign(*args, **kwargs):
+            result = run_full_campaign_side_effect()
+            if isinstance(result, Exception):
+                raise result
+            return result
+
+    monkeypatch.setattr(cli, "_import_campaign_controller", lambda: _FakeController)
+
+    plan = cli.build_plan()
+    return cli.main(
+        [
+            "--run",
+            "--expected-full-campaign-hash",
+            plan["full_campaign_hash"],
+            "--campaign-run-id",
+            plan["expected_campaign_run_id"],
+        ]
+    )
+
+
+def test_campaign_run_id_derivation_error_exits_with_documented_code_4_not_generic_6(
+    monkeypatch,
+):
+    from app.services.rob944_campaign_controller import CampaignRunIdDerivationError
+
+    exit_code = _run_main_with_fake_controller(
+        monkeypatch, lambda: CampaignRunIdDerivationError("forged campaign_run_id")
+    )
+    assert exit_code == 4
+
+
+def test_run_identity_mismatch_error_exits_with_documented_code_4_not_generic_6(
+    monkeypatch,
+):
+    from app.services.rob944_campaign_controller import RunIdentityMismatchError
+
+    exit_code = _run_main_with_fake_controller(
+        monkeypatch, lambda: RunIdentityMismatchError("forged run_identity")
+    )
+    assert exit_code == 4
+
+
+def test_typed_controller_exception_message_never_echoed_only_exception_type_name(
+    monkeypatch, capsys
+):
+    """P1-C sanitization precision (2026-07-17): the code-4 catch for the 5
+    typed controller exceptions must never print ``str(exc)`` -- only the
+    trusted ``type(exc).__name__`` -- even though these are OUR OWN
+    (already-sanitized-at-the-controller-layer) exceptions, this boundary
+    must not depend on that invariant holding forever."""
+    from app.services.rob944_campaign_controller import CampaignRunIdDerivationError
+
+    sentinel = "RAW-TRACE-SECRET-typed-exception-message-should-never-leak"
+    exit_code = _run_main_with_fake_controller(
+        monkeypatch, lambda: CampaignRunIdDerivationError(sentinel)
+    )
+    assert exit_code == 4
+    stderr = capsys.readouterr().err
+    assert sentinel not in stderr
+    assert "CampaignRunIdDerivationError" in stderr
+
+
+def test_unknown_controller_failure_still_exits_with_sanitized_code_6(monkeypatch):
+    exit_code = _run_main_with_fake_controller(
+        monkeypatch, lambda: RuntimeError("unexpected")
+    )
+    assert exit_code == 6
+
+
+def test_envelope_construction_failure_exits_sanitized_code_6_never_raw_traces(
+    monkeypatch, capsys
+):
+    """P1-C outer-boundary hardening: build_production_frozen_campaign_hash/
+    envelope construction, hash/derive/to_dict/experiment-id recomputation
+    all sit BEFORE any try in the impl -- a failure there must still exit
+    sanitized code 6 via the ``_run_empirical`` thin-wrapper backstop, never
+    raw-trace a secret-looking message."""
+    sentinel = "RAW-TRACE-SECRET-envelope-construction-boom"
+
+    def _boom():
+        raise RuntimeError(sentinel)
+
+    monkeypatch.setattr(cli, "build_production_frozen_campaign_envelope", _boom)
+    exit_code = cli.main(
+        [
+            "--run",
+            "--expected-full-campaign-hash",
+            "a" * 64,
+            "--campaign-run-id",
+            "run-x",
+        ]
+    )
+    assert exit_code == 6
+    stderr = capsys.readouterr().err
+    assert sentinel not in stderr
+
+
+def test_unexpected_precheck_failure_exits_sanitized_code_6_never_raw_traces(
+    monkeypatch, capsys
+):
+    """P1-C outer-boundary hardening: ``_run_empirical_impl`` only catches
+    ``RunPreflightError`` around ``_run_precheck_bridge_and_opt_in`` -- any
+    OTHER exception type escaping it (a bug, not a documented preflight
+    failure) must still exit sanitized code 6 via the outer backstop, never
+    raw-trace."""
+    sentinel = "RAW-TRACE-SECRET-unexpected-precheck-boom"
+
+    def _boom():
+        raise RuntimeError(sentinel)
+
+    monkeypatch.setattr(cli, "_run_precheck_bridge_and_opt_in", _boom)
+    plan = cli.build_plan()
+    exit_code = cli.main(
+        [
+            "--run",
+            "--expected-full-campaign-hash",
+            plan["full_campaign_hash"],
+            "--campaign-run-id",
+            plan["expected_campaign_run_id"],
+        ]
+    )
+    assert exit_code == 6
+    stderr = capsys.readouterr().err
+    assert sentinel not in stderr
+
+
+def test_session_factory_construction_failure_exits_sanitized_code_6(
+    monkeypatch, capsys
+):
+    """P1-C outer-boundary hardening: ``AsyncSessionLocal()`` itself
+    (session-factory construction, before ``__aenter__`` even runs) raising
+    must exit sanitized code 6, never raw-trace -- no rollback is attempted
+    since no valid session was ever constructed."""
+    monkeypatch.setenv("ROB944_RESEARCH_WRITE_OPT_IN", "true")
+    sentinel = "RAW-TRACE-SECRET-session-factory-boom"
+
+    def _boom():
+        raise RuntimeError(sentinel)
+
+    monkeypatch.setattr("app.core.db.AsyncSessionLocal", _boom)
+    plan = cli.build_plan()
+    exit_code = cli.main(
+        [
+            "--run",
+            "--expected-full-campaign-hash",
+            plan["full_campaign_hash"],
+            "--campaign-run-id",
+            plan["expected_campaign_run_id"],
+        ]
+    )
+    assert exit_code == 6
+    stderr = capsys.readouterr().err
+    assert sentinel not in stderr
+
+
+def test_session_aenter_failure_exits_sanitized_code_6(monkeypatch, capsys):
+    """P1-C outer-boundary hardening: ``__aenter__`` raising (session
+    constructed but connection/setup failed) must exit sanitized code 6,
+    never raw-trace -- this failure is NOT inside the inner try (which only
+    starts once ``session`` is already bound), so only the outer boundary
+    catches it."""
+    monkeypatch.setenv("ROB944_RESEARCH_WRITE_OPT_IN", "true")
+    sentinel = "RAW-TRACE-SECRET-aenter-boom"
+
+    class _AenterFailingSession:
+        async def __aenter__(self):
+            raise RuntimeError(sentinel)
+
+        async def __aexit__(self, *_exc_info):
+            return False
+
+    monkeypatch.setattr(
+        "app.core.db.AsyncSessionLocal", lambda: _AenterFailingSession()
+    )
+    plan = cli.build_plan()
+    exit_code = cli.main(
+        [
+            "--run",
+            "--expected-full-campaign-hash",
+            plan["full_campaign_hash"],
+            "--campaign-run-id",
+            plan["expected_campaign_run_id"],
+        ]
+    )
+    assert exit_code == 6
+    stderr = capsys.readouterr().err
+    assert sentinel not in stderr
+
+
+def test_session_aexit_failure_after_successful_commit_exits_sanitized_code_6(
+    monkeypatch, capsys
+):
+    """P1-C outer-boundary hardening: ``__aexit__`` raising during close --
+    even AFTER a successful controller run + commit -- must exit sanitized
+    code 6 (not raw-trace, and not silently report the would-be success
+    exit code, since the session's own close genuinely failed)."""
+    monkeypatch.setenv("ROB944_RESEARCH_WRITE_OPT_IN", "true")
+    sentinel = "RAW-TRACE-SECRET-aexit-boom"
+
+    class _AexitFailingSession(_FakeDbSession):
+        async def __aexit__(self, *_exc_info):
+            raise RuntimeError(sentinel)
+
+    monkeypatch.setattr("app.core.db.AsyncSessionLocal", lambda: _AexitFailingSession())
+
+    class _FakeReport:
+        verdict = "complete"
+        total_attempts = 24
+        expected_total = 24
+        retry_attempts = 0
+        status_counts = {"completed": 24}
+        actual_registrations = 24
+        primary_attempts = 24
+
+    class _FakeController:
+        @staticmethod
+        async def run_full_campaign(*args, **kwargs):
+            return _FakeReport()
+
+    monkeypatch.setattr(cli, "_import_campaign_controller", lambda: _FakeController)
+    plan = cli.build_plan()
+    exit_code = cli.main(
+        [
+            "--run",
+            "--expected-full-campaign-hash",
+            plan["full_campaign_hash"],
+            "--campaign-run-id",
+            plan["expected_campaign_run_id"],
+        ]
+    )
+    assert exit_code == 6
+    stderr = capsys.readouterr().err
+    assert sentinel not in stderr
+
+
+def test_asyncio_run_failure_exits_sanitized_code_6(monkeypatch, capsys):
+    """P1-C outer-boundary hardening: ``asyncio.run`` itself (event loop
+    setup/teardown) failing must exit sanitized code 6, never raw-trace."""
+    monkeypatch.setenv("ROB944_RESEARCH_WRITE_OPT_IN", "true")
+    sentinel = "RAW-TRACE-SECRET-asyncio-run-boom"
+
+    def _boom(coro):
+        coro.close()  # avoid a "coroutine was never awaited" warning from this fake
+        raise RuntimeError(sentinel)
+
+    monkeypatch.setattr("asyncio.run", _boom)
+    plan = cli.build_plan()
+    exit_code = cli.main(
+        [
+            "--run",
+            "--expected-full-campaign-hash",
+            plan["full_campaign_hash"],
+            "--campaign-run-id",
+            plan["expected_campaign_run_id"],
+        ]
+    )
+    assert exit_code == 6
+    stderr = capsys.readouterr().err
+    assert sentinel not in stderr
+
+
+def test_commit_failure_exits_with_documented_code_7(monkeypatch):
+    monkeypatch.setenv("ROB944_RESEARCH_WRITE_OPT_IN", "true")
+
+    class _CommitFailingSession(_FakeDbSession):
+        async def commit(self):
+            raise RuntimeError("commit failed: constraint violation")
+
+    monkeypatch.setattr(
+        "app.core.db.AsyncSessionLocal", lambda: _CommitFailingSession()
+    )
+
+    class _FakeReport:
+        verdict = "complete"
+        total_attempts = 24
+        expected_total = 24
+        retry_attempts = 0
+        status_counts = {"completed": 24}
+        actual_registrations = 24
+        primary_attempts = 24
+
+    class _FakeController:
+        @staticmethod
+        async def run_full_campaign(*args, **kwargs):
+            return _FakeReport()
+
+    monkeypatch.setattr(cli, "_import_campaign_controller", lambda: _FakeController)
+
+    plan = cli.build_plan()
+    exit_code = cli.main(
+        [
+            "--run",
+            "--expected-full-campaign-hash",
+            plan["full_campaign_hash"],
+            "--campaign-run-id",
+            plan["expected_campaign_run_id"],
+        ]
+    )
+    assert exit_code == 7
+
+
+# ---------------------------------------------------------------------------
+# Captain P1-C transaction-coverage correction (2026-07-17): the exit-code
+# tests above only assert the returned int -- they do NOT prove the actual
+# commit()/rollback() CALL COUNTS match the documented lifecycle contract.
+# This shared instrumented fake session + factory, run through the REAL
+# main -> _run_empirical -> _do_run path, gives an independent, exact
+# commit/rollback count assertion per documented exit code, plus
+# factory/__aenter__/__aexit__ call counts and rollback-failure-through-main
+# sanitization -- none inferred from the exit code alone.
+# ---------------------------------------------------------------------------
+
+
+class _CountingSession:
+    def __init__(self, *, commit_exc=None, rollback_exc=None):
+        self.commit_calls = 0
+        self.rollback_calls = 0
+        self.aenter_calls = 0
+        self.aexit_calls = 0
+        self._commit_exc = commit_exc
+        self._rollback_exc = rollback_exc
+
+    async def __aenter__(self):
+        self.aenter_calls += 1
+        return self
+
+    async def __aexit__(self, *_exc_info):
+        self.aexit_calls += 1
+        return False
+
+    async def commit(self):
+        self.commit_calls += 1
+        if self._commit_exc is not None:
+            raise self._commit_exc
+
+    async def rollback(self):
+        self.rollback_calls += 1
+        if self._rollback_exc is not None:
+            raise self._rollback_exc
+
+
+class _CountingSessionFactory:
+    def __init__(self, session):
+        self.session = session
+        self.construct_calls = 0
+
+    def __call__(self):
+        self.construct_calls += 1
+        return self.session
+
+
+def _lifecycle_fake_report(
+    *,
+    verdict="complete",
+    total_attempts=24,
+    expected_total=24,
+    retry_attempts=0,
+    completed=24,
+):
+    return SimpleNamespace(
+        verdict=verdict,
+        total_attempts=total_attempts,
+        expected_total=expected_total,
+        retry_attempts=retry_attempts,
+        status_counts={"completed": completed},
+        actual_registrations=expected_total,
+        primary_attempts=total_attempts,
+    )
+
+
+def _run_main_with_counting_session(
+    monkeypatch, *, run_full_campaign_side_effect, commit_exc=None, rollback_exc=None
+):
+    """Runs the REAL --run path (main -> _run_empirical -> _do_run) against
+    a session whose commit()/rollback()/__aenter__/__aexit__ calls are all
+    counted, and a fake controller whose run_full_campaign either raises or
+    returns ``run_full_campaign_side_effect()``. Returns
+    ``(exit_code, session, factory)`` so the caller can assert exact call
+    counts independent of the returned exit code."""
+    monkeypatch.setenv("ROB944_RESEARCH_WRITE_OPT_IN", "true")
+    session = _CountingSession(commit_exc=commit_exc, rollback_exc=rollback_exc)
+    factory = _CountingSessionFactory(session)
+    monkeypatch.setattr("app.core.db.AsyncSessionLocal", factory)
+
+    class _FakeController:
+        @staticmethod
+        async def run_full_campaign(*args, **kwargs):
+            result = run_full_campaign_side_effect()
+            if isinstance(result, Exception):
+                raise result
+            return result
+
+    monkeypatch.setattr(cli, "_import_campaign_controller", lambda: _FakeController)
+
+    plan = cli.build_plan()
+    exit_code = cli.main(
+        [
+            "--run",
+            "--expected-full-campaign-hash",
+            plan["full_campaign_hash"],
+            "--campaign-run-id",
+            plan["expected_campaign_run_id"],
+        ]
+    )
+    return exit_code, session, factory
+
+
+def test_lifecycle_success_code_0_commits_once_never_rolls_back(monkeypatch):
+    exit_code, session, factory = _run_main_with_counting_session(
+        monkeypatch, run_full_campaign_side_effect=lambda: _lifecycle_fake_report()
+    )
+    assert exit_code == 0
+    assert session.commit_calls == 1
+    assert session.rollback_calls == 0
+    assert factory.construct_calls == 1
+    assert session.aenter_calls == 1
+    assert session.aexit_calls == 1
+
+
+def test_lifecycle_accounting_complete_empirical_failure_code_5_commits_once_never_rolls_back(
+    monkeypatch,
+):
+    """Accounting-complete (verdict="complete") but not every primary
+    completed (completed=0) -- exit 5, and the commit still happens exactly
+    once (a legitimate, COMMITTABLE record of a failed run) with no
+    rollback attempted."""
+    exit_code, session, factory = _run_main_with_counting_session(
+        monkeypatch,
+        run_full_campaign_side_effect=lambda: _lifecycle_fake_report(completed=0),
+    )
+    assert exit_code == 5
+    assert session.commit_calls == 1
+    assert session.rollback_calls == 0
+    assert factory.construct_calls == 1
+
+
+def test_lifecycle_typed_validation_failure_code_4_never_commits_rolls_back_once(
+    monkeypatch,
+):
+    from app.services.rob944_campaign_controller import CampaignRunIdDerivationError
+
+    exit_code, session, factory = _run_main_with_counting_session(
+        monkeypatch,
+        run_full_campaign_side_effect=lambda: CampaignRunIdDerivationError("forged"),
+    )
+    assert exit_code == 4
+    assert session.commit_calls == 0
+    assert session.rollback_calls == 1
+    assert factory.construct_calls == 1
+
+
+def test_lifecycle_unknown_failure_code_6_never_commits_rolls_back_once(monkeypatch):
+    exit_code, session, factory = _run_main_with_counting_session(
+        monkeypatch, run_full_campaign_side_effect=lambda: RuntimeError("unexpected")
+    )
+    assert exit_code == 6
+    assert session.commit_calls == 0
+    assert session.rollback_calls == 1
+    assert factory.construct_calls == 1
+
+
+def test_lifecycle_commit_failure_code_7_attempts_commit_once_then_rolls_back_once(
+    monkeypatch,
+):
+    exit_code, session, factory = _run_main_with_counting_session(
+        monkeypatch,
+        run_full_campaign_side_effect=lambda: _lifecycle_fake_report(),
+        commit_exc=RuntimeError("commit failed: constraint violation"),
+    )
+    assert exit_code == 7
+    assert session.commit_calls == 1  # the attempt itself, which then raised
+    assert session.rollback_calls == 1
+    assert factory.construct_calls == 1
+
+
+def test_lifecycle_rollback_failure_through_main_stays_sanitized_and_still_counted(
+    monkeypatch, capsys
+):
+    """A typed validation failure (code 4) whose OWN rollback attempt then
+    ALSO fails: rollback is still attempted exactly once (counted, even
+    though it raised internally), the exit code is unaffected (still 4, not
+    masked into something else), and neither the rollback failure's raw
+    text nor the original exception's message leaks into stderr -- only
+    _safe_rollback's own fixed sanitized text."""
+    from app.services.rob944_campaign_controller import CampaignRunIdDerivationError
+
+    rollback_sentinel = "RAW-TRACE-SECRET-rollback-failure-boom"
+    exit_code, session, factory = _run_main_with_counting_session(
+        monkeypatch,
+        run_full_campaign_side_effect=lambda: CampaignRunIdDerivationError("forged"),
+        rollback_exc=RuntimeError(rollback_sentinel),
+    )
+    assert exit_code == 4
+    assert session.commit_calls == 0
+    assert session.rollback_calls == 1
+    stderr = capsys.readouterr().err
+    assert rollback_sentinel not in stderr
+    assert "rollback failed" in stderr
+
+
+# ---------------------------------------------------------------------------
+# Captain global-fallback consistency (2026-07-17, item D): a GLOBAL
+# (pre-per-config) failure -- whether it happens BEFORE any per-strategy
+# work starts, or AFTER S1 already succeeded and populated captured
+# summaries -- must always yield a full 24-entry deterministic crashed
+# batch, never zero/partial attempts, with the operator-visible
+# capture_summaries_into view IDENTICAL to what's returned for persistence.
+# ---------------------------------------------------------------------------
+
+
+def _fake_experiment_id_by_key():
+    return {
+        (f"ROB940-S{slug}-KEY", f"S{slug}-{i:02d}"): f"exp-{slug}-{i:02d}"
+        for slug in (1, 2)
+        for i in range(12)
+    }
+
+
+def test_global_failure_evidence_batch_produces_exactly_24_crashed_entries():
+    from rob944_walkforward import REASON_GLOBAL_CORPUS_LOAD_FAILED
+
+    experiment_id_by_key = _fake_experiment_id_by_key()
+    evidence = cli._global_failure_evidence_batch(
+        experiment_id_by_key, full_campaign_hash="a" * 64, campaign_run_id="run-x"
+    )
+    assert len(evidence) == 24
+    assert {e.attempt_key.experiment_id for e in evidence} == set(
+        experiment_id_by_key.values()
+    )
+    assert all(e.status == "crashed" for e in evidence)
+    assert all(e.reason_code == REASON_GLOBAL_CORPUS_LOAD_FAILED for e in evidence)
+    assert all(len(e.scenario_evidence) == 3 for e in evidence)
+
+
+def test_build_real_attempt_evidence_rejects_malformed_mapping_before_inner_is_called(
+    monkeypatch,
+):
+    """Captain precision follow-up ("one remaining boundary", 2026-07-17):
+    a dict-SUBCLASS experiment_id_by_key must be rejected BEFORE
+    _build_real_attempt_evidence_inner is ever called -- proving the gate
+    fires at the very entry point, before any corpus-loading/walk-forward
+    work, not merely somewhere downstream after expensive work already
+    ran."""
+
+    def _boom(*args, **kwargs):
+        raise AssertionError(
+            "_build_real_attempt_evidence_inner must never be called for a malformed mapping"
+        )
+
+    monkeypatch.setattr(cli, "_build_real_attempt_evidence_inner", _boom)
+
+    class _DictSubclass(dict):
+        pass
+
+    bad_mapping = _DictSubclass({("K", "S1-00"): "exp-00"})
+    with pytest.raises(ValueError, match="experiment_id_by_key"):
+        cli._build_real_attempt_evidence(
+            bad_mapping,
+            full_campaign_hash="h" * 64,
+            campaign_run_id="run-001",
+        )
+
+
+def test_build_real_attempt_evidence_rejects_lineage_str_subclass_before_inner_is_called(
+    monkeypatch,
+):
+    """Same boundary, for an AliasStr-style full_campaign_hash/
+    campaign_run_id -- also rejected before _build_real_attempt_evidence_inner
+    is ever called."""
+
+    def _boom(*args, **kwargs):
+        raise AssertionError(
+            "_build_real_attempt_evidence_inner must never be called for a malformed lineage arg"
+        )
+
+    monkeypatch.setattr(cli, "_build_real_attempt_evidence_inner", _boom)
+
+    class _AliasStr(str):
+        pass
+
+    with pytest.raises(ValueError, match="full_campaign_hash"):
+        cli._build_real_attempt_evidence(
+            {("K", "S1-00"): "exp-00"},
+            full_campaign_hash=_AliasStr("h" * 64),
+            campaign_run_id="run-001",
+        )
+
+
+def test_failure_before_any_strategy_work_yields_24_crashed_captured_and_24_crashed_evidence(
+    monkeypatch,
+):
+    """A GLOBAL failure that happens BEFORE S1 even starts (e.g. corpus
+    loading itself fails) -- capture_summaries_into must end up with
+    exactly 24 crashed summaries, matching the 24 crashed AttemptEvidence
+    actually returned for persistence."""
+
+    def _boom(
+        _experiment_id_by_key,
+        *,
+        full_campaign_hash,
+        campaign_run_id,
+        capture_summaries_into=None,
+    ):
+        raise RuntimeError("simulated: corpus load failed before any strategy ran")
+
+    monkeypatch.setattr(cli, "_build_real_attempt_evidence_inner", _boom)
+
+    experiment_id_by_key = _fake_experiment_id_by_key()
+    captured: list = []
+    evidence = cli._build_real_attempt_evidence(
+        experiment_id_by_key,
+        full_campaign_hash="b" * 64,
+        campaign_run_id="run-y",
+        capture_summaries_into=captured,
+    )
+    assert len(evidence) == 24
+    assert all(e.status == "crashed" for e in evidence)
+    assert len(captured) == 24
+    assert all(s.status == "crashed" for s in captured)
+    # Captain global-fallback identity-consistency correction: operator
+    # summary.strategy is consistently the short S1/S2 slug (exactly 12
+    # each), and every experiment_id in the returned evidence matches the
+    # predeclared 24-entry mapping unchanged.
+    assert sorted(s.strategy for s in captured) == ["S1"] * 12 + ["S2"] * 12
+    assert {e.attempt_key.experiment_id for e in evidence} == set(
+        experiment_id_by_key.values()
+    )
+
+
+def test_partial_s1_success_then_global_bomb_clears_stale_capture_to_24_crashed(
+    monkeypatch,
+):
+    """S1 already succeeded and populated capture_summaries_into with 12
+    REAL summaries before S2 (or any later global precondition) fails --
+    the partial capture must be CLEARED and refilled with the full 24-entry
+    crashed sentinel, never left showing 12 real + nothing (which would
+    make the operator-visible CLI view inconsistent with the 24 crashed
+    rows actually persisted)."""
+    from rob944_walkforward import ConfigAttemptEvidenceSummary, ScenarioEvidenceSummary
+
+    def _fake_real_summary(config_id):
+        return ConfigAttemptEvidenceSummary(
+            strategy="S1",
+            config_id=config_id,
+            status="completed",
+            reason_code=None,
+            scenario_summaries=(
+                ScenarioEvidenceSummary(
+                    scenario_name="base",
+                    status="completed",
+                    reason_code=None,
+                    trade_count=1,
+                    artifact_hash="a" * 64,
+                    no_trade_reason_counts={},
+                ),
+                ScenarioEvidenceSummary(
+                    scenario_name="primary_stress",
+                    status="completed",
+                    reason_code=None,
+                    trade_count=1,
+                    artifact_hash="b" * 64,
+                    no_trade_reason_counts={},
+                ),
+                ScenarioEvidenceSummary(
+                    scenario_name="upward_stress",
+                    status="completed",
+                    reason_code=None,
+                    trade_count=1,
+                    artifact_hash="c" * 64,
+                    no_trade_reason_counts={},
+                ),
+            ),
+        )
+
+    def _partial_then_boom(
+        _experiment_id_by_key,
+        *,
+        full_campaign_hash,
+        campaign_run_id,
+        capture_summaries_into=None,
+    ):
+        if capture_summaries_into is not None:
+            capture_summaries_into.extend(
+                _fake_real_summary(f"S1-{i:02d}") for i in range(12)
+            )
+        raise RuntimeError(
+            "simulated: S2/global precondition failed after S1 succeeded"
+        )
+
+    monkeypatch.setattr(cli, "_build_real_attempt_evidence_inner", _partial_then_boom)
+
+    experiment_id_by_key = _fake_experiment_id_by_key()
+    captured: list = []
+    evidence = cli._build_real_attempt_evidence(
+        experiment_id_by_key,
+        full_campaign_hash="c" * 64,
+        campaign_run_id="run-z",
+        capture_summaries_into=captured,
+    )
+    assert len(evidence) == 24
+    assert all(e.status == "crashed" for e in evidence)
+    # The stale partial (12 real "completed") capture must be gone entirely.
+    assert len(captured) == 24
+    assert all(s.status == "crashed" for s in captured)
+    assert not any(s.status == "completed" for s in captured)
+    # Captain global-fallback identity-consistency correction: exact 12
+    # S1 + 12 S2 operator labels, and the 24 experiment_ids are unchanged
+    # from the predeclared mapping (never dropped/duplicated/renamed).
+    assert sorted(s.strategy for s in captured) == ["S1"] * 12 + ["S2"] * 12
+    assert {e.attempt_key.experiment_id for e in evidence} == set(
+        experiment_id_by_key.values()
+    )
+    # Captain precision follow-up (2026-07-17, item 3): every captured
+    # object must be the exact normalized DTO type, and correspond
+    # ONE-TO-ONE (via config_id -> experiment_id) with the 24 returned
+    # attempts -- never a dropped/duplicated/mismatched entry between
+    # operator capture and persisted evidence. (ConfigAttemptEvidenceSummary
+    # already imported above, in this same function.)
+    assert all(type(s) is ConfigAttemptEvidenceSummary for s in captured)
+    experiment_id_by_config_id = {
+        config_id: exp_id for (_sk, config_id), exp_id in experiment_id_by_key.items()
+    }
+    captured_config_ids = {s.config_id for s in captured}
+    assert len(captured_config_ids) == 24  # no duplicates
+    captured_experiment_ids = {
+        experiment_id_by_config_id[cid] for cid in captured_config_ids
+    }
+    evidence_experiment_ids = {e.attempt_key.experiment_id for e in evidence}
+    assert (
+        captured_experiment_ids
+        == evidence_experiment_ids
+        == set(experiment_id_by_key.values())
+    )
+
+
+# ---------------------------------------------------------------------------
+# lineage-bound evidence construction (pure, no corpus loading required)
+# ---------------------------------------------------------------------------
+
+
+def _fake_summary(
+    config_id="S1-00", status="completed", reason_code=None, fold_selection_trace=None
+):
+    from rob944_walkforward import ConfigAttemptEvidenceSummary, ScenarioEvidenceSummary
+
+    # Captain live-validation correction (2026-07-17): an EMPTY
+    # fold_selection_trace is only valid for the exact global-corpus-load-
+    # failure signature (status="crashed" + REASON_GLOBAL_CORPUS_LOAD_FAILED)
+    # -- default to a full valid 8-fold trace so existing fixtures that
+    # don't care about fold-trace specifics still pass; callers testing
+    # that signature explicitly pass fold_selection_trace=().
+    if fold_selection_trace is None:
+        fold_selection_trace = _fake_full_fold_trace()
+    return ConfigAttemptEvidenceSummary(
+        strategy="S1",
+        config_id=config_id,
+        status=status,
+        reason_code=reason_code,
+        fold_selection_trace=fold_selection_trace,
+        scenario_summaries=(
+            ScenarioEvidenceSummary(
+                scenario_name="base",
+                status="completed",
+                reason_code=None,
+                trade_count=3,
+                artifact_hash="a" * 64,
+                no_trade_reason_counts={},
+            ),
+            ScenarioEvidenceSummary(
+                scenario_name="primary_stress",
+                status="completed",
+                reason_code=None,
+                trade_count=3,
+                artifact_hash="b" * 64,
+                no_trade_reason_counts={},
+            ),
+            ScenarioEvidenceSummary(
+                scenario_name="upward_stress",
+                status="completed",
+                reason_code=None,
+                trade_count=2,
+                artifact_hash="c" * 64,
+                no_trade_reason_counts={},
+            ),
+        ),
+    )
+
+
+def test_summary_to_attempt_evidence_binds_full_lineage_deterministically():
+    summary = _fake_summary()
+    evidence1 = cli._summary_to_attempt_evidence(
+        summary,
+        strategy_key="ROB940-S1-DONCHIAN-15M",
+        experiment_id="exp-abc",
+        full_campaign_hash="h" * 64,
+        campaign_run_id="run-001",
+    )
+    evidence2 = cli._summary_to_attempt_evidence(
+        summary,
+        strategy_key="ROB940-S1-DONCHIAN-15M",
+        experiment_id="exp-abc",
+        full_campaign_hash="h" * 64,
+        campaign_run_id="run-001",
+    )
+    assert evidence1.run_identity == evidence2.run_identity  # deterministic
+    assert evidence1.attempt_key.experiment_id == "exp-abc"
+    assert evidence1.attempt_key.campaign_run_id == "run-001"
+    assert evidence1.attempt_key.retry_index == 0
+    assert len(evidence1.scenario_evidence) == 3
+
+
+def test_summary_to_attempt_evidence_run_identity_changes_with_lineage_facts():
+    summary = _fake_summary()
+    base = cli._summary_to_attempt_evidence(
+        summary,
+        strategy_key="K",
+        experiment_id="exp-abc",
+        full_campaign_hash="h" * 64,
+        campaign_run_id="run-001",
+    )
+    diff_hash = cli._summary_to_attempt_evidence(
+        summary,
+        strategy_key="K",
+        experiment_id="exp-abc",
+        full_campaign_hash="i" * 64,
+        campaign_run_id="run-001",
+    )
+    diff_run = cli._summary_to_attempt_evidence(
+        summary,
+        strategy_key="K",
+        experiment_id="exp-abc",
+        full_campaign_hash="h" * 64,
+        campaign_run_id="run-002",
+    )
+    diff_exp = cli._summary_to_attempt_evidence(
+        summary,
+        strategy_key="K",
+        experiment_id="exp-xyz",
+        full_campaign_hash="h" * 64,
+        campaign_run_id="run-001",
+    )
+    assert base.run_identity != diff_hash.run_identity
+    assert base.run_identity != diff_run.run_identity
+    assert base.run_identity != diff_exp.run_identity
+
+
+def test_summaries_to_attempt_evidence_maps_via_strategy_key_and_config_id():
+    # Captain precision follow-up (2026-07-17, item 2): _summaries_to_attempt_evidence
+    # now routes through the normalized-batch boundary, which requires an
+    # exact tuple -- a list is no longer accepted.
+    summaries = (_fake_summary(config_id="S1-00"), _fake_summary(config_id="S1-01"))
+    experiment_id_by_key = {
+        ("ROB940-S1-DONCHIAN-15M", "S1-00"): "exp-00",
+        ("ROB940-S1-DONCHIAN-15M", "S1-01"): "exp-01",
+    }
+    evidence_list = cli._summaries_to_attempt_evidence(
+        summaries,
+        strategy_key="ROB940-S1-DONCHIAN-15M",
+        experiment_id_by_key=experiment_id_by_key,
+        full_campaign_hash="h" * 64,
+        campaign_run_id="run-001",
+    )
+    assert {e.attempt_key.experiment_id for e in evidence_list} == {"exp-00", "exp-01"}
+
+
+def test_normalize_and_capture_summaries_rejects_non_tuple_batch():
+    """Captain design review (2026-07-17, item 1): the OUTER summaries
+    container itself must be an exact tuple -- a list (or any other
+    iterable) is refused before anything inside it is even normalized."""
+    with pytest.raises(ValueError, match="exact tuple"):
+        cli._normalize_and_capture_summaries(
+            [_fake_summary()],  # a list, not a tuple
+            strategy_key="K",
+            experiment_id_by_key={("K", "S1-00"): "exp-abc"},
+            full_campaign_hash="h" * 64,
+            campaign_run_id="run-001",
+        )
+
+
+def test_normalize_and_capture_summaries_capture_uses_same_normalized_snapshot_as_evidence():
+    """Captain design cross-check correction (2026-07-17): capture must
+    consume the IDENTICAL normalized snapshot objects that evidence-
+    building consumed -- never a second, independent normalization pass
+    (which would copy every nested dict twice and could, in principle,
+    diverge). Proven by re-deriving evidence from the CAPTURED object
+    directly (via the normalized core) and checking it matches the
+    evidence _normalize_and_capture_summaries itself returned."""
+    from rob944_walkforward import ConfigAttemptEvidenceSummary
+
+    summary = _fake_summary()
+    captured: list = []
+    experiment_id_by_key = {("K", summary.config_id): "exp-abc"}
+    evidence = cli._normalize_and_capture_summaries(
+        (summary,),
+        strategy_key="K",
+        experiment_id_by_key=experiment_id_by_key,
+        full_campaign_hash="h" * 64,
+        campaign_run_id="run-001",
+        capture_summaries_into=captured,
+    )
+    assert len(evidence) == 1
+    assert len(captured) == 1
+    assert type(captured[0]) is ConfigAttemptEvidenceSummary
+    rederived = cli._normalized_summary_to_attempt_evidence(
+        captured[0],
+        strategy_key="K",
+        experiment_id="exp-abc",
+        full_campaign_hash="h" * 64,
+        campaign_run_id="run-001",
+    )
+    assert rederived.run_identity == evidence[0].run_identity
+    assert rederived.fold_evidence_hash == evidence[0].fold_evidence_hash
+
+
+def test_normalize_and_capture_summaries_captured_object_is_the_same_identity_consumed_by_core(
+    monkeypatch,
+):
+    """Captain design precision (2026-07-17, item 4): literal object-
+    IDENTITY proof (``is``, not merely hash-equivalence) that the object
+    the normalized core actually consumed to build evidence is the SAME
+    Python object later appended to operator capture -- never two
+    independently-normalized copies."""
+    summary = _fake_summary()
+    captured: list = []
+    experiment_id_by_key = {("K", summary.config_id): "exp-abc"}
+
+    consumed_objects: list = []
+    original_core = cli._normalized_summary_to_attempt_evidence
+
+    def _spy_core(s, **kwargs):
+        consumed_objects.append(s)
+        return original_core(s, **kwargs)
+
+    monkeypatch.setattr(cli, "_normalized_summary_to_attempt_evidence", _spy_core)
+
+    cli._normalize_and_capture_summaries(
+        (summary,),
+        strategy_key="K",
+        experiment_id_by_key=experiment_id_by_key,
+        full_campaign_hash="h" * 64,
+        campaign_run_id="run-001",
+        capture_summaries_into=captured,
+    )
+    assert len(consumed_objects) == 1
+    assert len(captured) == 1
+    assert consumed_objects[0] is captured[0]
+
+
+def test_normalize_and_capture_summaries_no_capture_when_evidence_build_fails():
+    """Captain design precision (2026-07-17, item 4): if evidence-building
+    fails for ANY entry in the batch, capture must receive NOTHING --
+    never a partial capture from entries that happened to succeed before
+    the failing one."""
+    good_summary = _fake_summary(config_id="S1-00")
+    bad_summary = _fake_summary(
+        config_id="S1-99"
+    )  # outside the canonical 12-config set
+    captured: list = []
+    experiment_id_by_key = {("K", "S1-00"): "exp-00", ("K", "S1-99"): "exp-99"}
+    with pytest.raises(ValueError):
+        cli._normalize_and_capture_summaries(
+            (good_summary, bad_summary),
+            strategy_key="K",
+            experiment_id_by_key=experiment_id_by_key,
+            full_campaign_hash="h" * 64,
+            campaign_run_id="run-001",
+            capture_summaries_into=captured,
+        )
+    assert captured == []
+
+
+def test_build_fallback_evidence_and_capture_yields_exact_24_normalized_entries():
+    """Captain design precision (2026-07-17, item 4): the fallback helper
+    must produce EXACTLY 24 normalized ``ConfigAttemptEvidenceSummary``
+    entries (never a partial/raw capture), each an exact instance (not a
+    subclass/proxy) of the canonical type."""
+    from rob944_walkforward import ConfigAttemptEvidenceSummary
+
+    experiment_id_by_key = {
+        (f"ROB940-S{slug}-KEY", f"S{slug}-{i:02d}"): f"exp-{slug}-{i:02d}"
+        for slug in (1, 2)
+        for i in range(12)
+    }
+    captured: list = []
+    evidence = cli._build_fallback_evidence_and_capture(
+        experiment_id_by_key,
+        full_campaign_hash="h" * 64,
+        campaign_run_id="run-001",
+        capture_summaries_into=captured,
+    )
+    assert len(evidence) == 24
+    assert len(captured) == 24
+    assert all(type(s) is ConfigAttemptEvidenceSummary for s in captured)
+    assert all(s.status == "crashed" for s in captured)
+
+
+def test_build_fallback_evidence_and_capture_captured_objects_are_the_same_identity_consumed_by_core(
+    monkeypatch,
+):
+    """Captain normalization reaudit (2026-07-18): analogous to
+    ``test_normalize_and_capture_summaries_captured_object_is_the_same_identity_consumed_by_core``
+    (the real-batch path) -- every object the normalized core actually
+    consumed to build FALLBACK evidence must be the SAME Python object
+    (``is``, not merely equal) later published in operator capture, for
+    all 24 entries, in order. Never two independently-normalized copies."""
+    consumed_objects: list = []
+    original_core = cli._normalized_summary_to_attempt_evidence
+
+    def _spy_core(s, **kwargs):
+        consumed_objects.append(s)
+        return original_core(s, **kwargs)
+
+    monkeypatch.setattr(cli, "_normalized_summary_to_attempt_evidence", _spy_core)
+
+    experiment_id_by_key = {
+        (f"ROB940-S{slug}-KEY", f"S{slug}-{i:02d}"): f"exp-{slug}-{i:02d}"
+        for slug in (1, 2)
+        for i in range(12)
+    }
+    captured: list = []
+    evidence = cli._build_fallback_evidence_and_capture(
+        experiment_id_by_key,
+        full_campaign_hash="h" * 64,
+        campaign_run_id="run-001",
+        capture_summaries_into=captured,
+    )
+    assert len(evidence) == 24
+    assert len(consumed_objects) == 24
+    assert len(captured) == 24
+    for consumed, cap in zip(consumed_objects, captured, strict=True):
+        assert consumed is cap
+
+
+def test_build_fallback_evidence_and_capture_leaves_capture_unchanged_when_a_later_entry_fails(
+    monkeypatch,
+):
+    """Captain precision follow-up (2026-07-17, item 3): seed capture with
+    STALE objects, force the normalized core to fail partway through the
+    24-entry fallback batch, and prove capture remains ENTIRELY unchanged
+    -- never partially cleared/overwritten before the whole batch
+    succeeds."""
+    stale_sentinel = object()
+    captured = [stale_sentinel]
+
+    call_count = {"n": 0}
+    original_core = cli._normalized_summary_to_attempt_evidence
+
+    def _flaky_core(s, **kwargs):
+        call_count["n"] += 1
+        if call_count["n"] == 5:
+            raise RuntimeError("simulated failure partway through the fallback batch")
+        return original_core(s, **kwargs)
+
+    monkeypatch.setattr(cli, "_normalized_summary_to_attempt_evidence", _flaky_core)
+
+    experiment_id_by_key = {
+        (f"ROB940-S{slug}-KEY", f"S{slug}-{i:02d}"): f"exp-{slug}-{i:02d}"
+        for slug in (1, 2)
+        for i in range(12)
+    }
+    with pytest.raises(RuntimeError):
+        cli._build_fallback_evidence_and_capture(
+            experiment_id_by_key,
+            full_campaign_hash="h" * 64,
+            campaign_run_id="run-001",
+            capture_summaries_into=captured,
+        )
+    assert captured == [stale_sentinel]
+    assert call_count["n"] == 5  # confirms the failure actually fired partway through
+
+
+def test_lineage_arg_str_subclass_rejected_before_canonical_sha256(monkeypatch):
+    """Captain precision follow-up (2026-07-17, item 4): an AliasStr-style
+    str SUBCLASS strategy_key must be rejected -- exact-str gated BEFORE
+    any f-string context, dict lookup, or canonical_sha256 call -- proven
+    via the spy pattern (zero hash calls)."""
+    import research_contracts.canonical_hash as canonical_hash_module
+
+    class _AliasStr(str):
+        pass
+
+    def _boom(*args, **kwargs):
+        raise AssertionError("canonical_sha256 must never be called for this input")
+
+    monkeypatch.setattr(canonical_hash_module, "canonical_sha256", _boom)
+
+    summary = _fake_summary()
+    experiment_id_by_key = {("K", summary.config_id): "exp-abc"}
+    with pytest.raises(ValueError, match="strategy_key"):
+        cli._normalize_and_capture_summaries(
+            (summary,),
+            strategy_key=_AliasStr("K"),
+            experiment_id_by_key=experiment_id_by_key,
+            full_campaign_hash="h" * 64,
+            campaign_run_id="run-001",
+        )
+
+
+def test_lineage_arg_full_campaign_hash_subclass_rejected_before_canonical_sha256(
+    monkeypatch,
+):
+    import research_contracts.canonical_hash as canonical_hash_module
+
+    class _AliasStr(str):
+        pass
+
+    def _boom(*args, **kwargs):
+        raise AssertionError("canonical_sha256 must never be called for this input")
+
+    monkeypatch.setattr(canonical_hash_module, "canonical_sha256", _boom)
+
+    summary = _fake_summary()
+    experiment_id_by_key = {("K", summary.config_id): "exp-abc"}
+    with pytest.raises(ValueError, match="full_campaign_hash"):
+        cli._normalize_and_capture_summaries(
+            (summary,),
+            strategy_key="K",
+            experiment_id_by_key=experiment_id_by_key,
+            full_campaign_hash=_AliasStr("h" * 64),
+            campaign_run_id="run-001",
+        )
+
+
+def test_lineage_arg_campaign_run_id_subclass_rejected_before_canonical_sha256(
+    monkeypatch,
+):
+    import research_contracts.canonical_hash as canonical_hash_module
+
+    class _AliasStr(str):
+        pass
+
+    def _boom(*args, **kwargs):
+        raise AssertionError("canonical_sha256 must never be called for this input")
+
+    monkeypatch.setattr(canonical_hash_module, "canonical_sha256", _boom)
+
+    summary = _fake_summary()
+    experiment_id_by_key = {("K", summary.config_id): "exp-abc"}
+    with pytest.raises(ValueError, match="campaign_run_id"):
+        cli._normalize_and_capture_summaries(
+            (summary,),
+            strategy_key="K",
+            experiment_id_by_key=experiment_id_by_key,
+            full_campaign_hash="h" * 64,
+            campaign_run_id=_AliasStr("run-001"),
+        )
+
+
+def test_experiment_id_by_key_dict_subclass_rejected_before_canonical_sha256(
+    monkeypatch,
+):
+    """A dict-SUBCLASS experiment_id_by_key mapping must be rejected --
+    exact type(x) is dict, never isinstance -- BEFORE any canonical_sha256
+    call."""
+    import research_contracts.canonical_hash as canonical_hash_module
+
+    class _DictSubclass(dict):
+        pass
+
+    def _boom(*args, **kwargs):
+        raise AssertionError("canonical_sha256 must never be called for this input")
+
+    monkeypatch.setattr(canonical_hash_module, "canonical_sha256", _boom)
+
+    summary = _fake_summary()
+    bad_mapping = _DictSubclass({("K", summary.config_id): "exp-abc"})
+    with pytest.raises(ValueError, match="experiment_id_by_key"):
+        cli._normalize_and_capture_summaries(
+            (summary,),
+            strategy_key="K",
+            experiment_id_by_key=bad_mapping,
+            full_campaign_hash="h" * 64,
+            campaign_run_id="run-001",
+        )
+
+
+class _TupleSubclass(tuple):
+    pass
+
+
+class _AliasStrForMappingComponents(str):
+    pass
+
+
+def _mutate_experiment_id_by_key_tuple_key_subclass(mapping):
+    ((strategy_key, config_id), exp_id) = next(iter(mapping.items()))
+    return {_TupleSubclass((strategy_key, config_id)): exp_id}
+
+
+def _mutate_experiment_id_by_key_strategy_key_component_str_subclass(mapping):
+    ((strategy_key, config_id), exp_id) = next(iter(mapping.items()))
+    return {(_AliasStrForMappingComponents(strategy_key), config_id): exp_id}
+
+
+def _mutate_experiment_id_by_key_config_id_component_str_subclass(mapping):
+    ((strategy_key, config_id), exp_id) = next(iter(mapping.items()))
+    return {(strategy_key, _AliasStrForMappingComponents(config_id)): exp_id}
+
+
+def _mutate_experiment_id_by_key_experiment_id_value_str_subclass(mapping):
+    ((strategy_key, config_id), exp_id) = next(iter(mapping.items()))
+    return {(strategy_key, config_id): _AliasStrForMappingComponents(exp_id)}
+
+
+@pytest.mark.parametrize(
+    "mutate",
+    [
+        _mutate_experiment_id_by_key_tuple_key_subclass,
+        _mutate_experiment_id_by_key_strategy_key_component_str_subclass,
+        _mutate_experiment_id_by_key_config_id_component_str_subclass,
+        _mutate_experiment_id_by_key_experiment_id_value_str_subclass,
+    ],
+    ids=[
+        "tuple_key_subclass",
+        "strategy_key_component_str_subclass",
+        "config_id_component_str_subclass",
+        "experiment_id_value_str_subclass",
+    ],
+)
+def test_experiment_id_by_key_component_subclass_rejected_before_canonical_sha256(
+    monkeypatch, mutate
+):
+    """Captain normalization reaudit (2026-07-18): not just the outer dict
+    or the 2-tuple key's own container type -- each COMPONENT (the
+    strategy_key/config_id inside the tuple key, and the experiment_id
+    value) must ALSO be exact-str/exact-tuple gated individually. A str
+    subclass in any of these three positions, or a tuple-subclass key
+    itself, must be rejected BEFORE any canonical_sha256 call -- proven
+    via the same zero-hash-calls spy pattern used throughout this
+    module's pre-hash regressions."""
+    import research_contracts.canonical_hash as canonical_hash_module
+
+    def _boom(*args, **kwargs):
+        raise AssertionError("canonical_sha256 must never be called for this input")
+
+    monkeypatch.setattr(canonical_hash_module, "canonical_sha256", _boom)
+
+    summary = _fake_summary()
+    base_mapping = {("K", summary.config_id): "exp-abc"}
+    bad_mapping = mutate(base_mapping)
+    with pytest.raises(ValueError, match="experiment_id_by_key"):
+        cli._normalize_and_capture_summaries(
+            (summary,),
+            strategy_key="K",
+            experiment_id_by_key=bad_mapping,
+            full_campaign_hash="h" * 64,
+            campaign_run_id="run-001",
+        )
+
+
+def test_canonical_scenario_and_fold_order_preserved_in_both_capture_and_evidence():
+    """Captain design precision (2026-07-17, item 4): a deliberately
+    reverse-ordered scenario_summaries/fold_selection_trace must come out
+    canonically ordered (by scenario_name / fold_id) in BOTH the captured
+    operator-visible object and the returned AttemptEvidence -- from a
+    single normalization source, never independently re-derived (or
+    forgotten) in one place but not the other."""
+    from rob944_walkforward import ScenarioEvidenceSummary
+
+    reversed_scenarios = (
+        ScenarioEvidenceSummary(
+            scenario_name="upward_stress",
+            status="completed",
+            reason_code=None,
+            trade_count=2,
+            artifact_hash="c" * 64,
+            no_trade_reason_counts={},
+        ),
+        ScenarioEvidenceSummary(
+            scenario_name="primary_stress",
+            status="completed",
+            reason_code=None,
+            trade_count=3,
+            artifact_hash="b" * 64,
+            no_trade_reason_counts={},
+        ),
+        ScenarioEvidenceSummary(
+            scenario_name="base",
+            status="completed",
+            reason_code=None,
+            trade_count=3,
+            artifact_hash="a" * 64,
+            no_trade_reason_counts={},
+        ),
+    )
+    summary = _fake_summary()
+    object.__setattr__(summary, "scenario_summaries", reversed_scenarios)
+    object.__setattr__(summary, "fold_selection_trace", _fake_full_fold_trace()[::-1])
+
+    captured: list = []
+    experiment_id_by_key = {("K", summary.config_id): "exp-abc"}
+    evidence = cli._normalize_and_capture_summaries(
+        (summary,),
+        strategy_key="K",
+        experiment_id_by_key=experiment_id_by_key,
+        full_campaign_hash="h" * 64,
+        campaign_run_id="run-001",
+        capture_summaries_into=captured,
+    )
+    expected_scenario_order = ("base", "primary_stress", "upward_stress")
+    expected_fold_order = tuple(f"fold-{i:02d}" for i in range(8))
+
+    assert (
+        tuple(row.scenario_name for row in captured[0].scenario_summaries)
+        == expected_scenario_order
+    )
+    assert (
+        tuple(row.fold_id for row in captured[0].fold_selection_trace)
+        == expected_fold_order
+    )
+    assert (
+        tuple(se.scenario_name for se in evidence[0].scenario_evidence)
+        == expected_scenario_order
+    )
+
+
+def test_sentinel_secret_reason_code_is_rejected_not_silently_persisted():
+    """A caller that bypasses ``summarize_config_attempts_for_h6`` and hands
+    ``_summary_to_attempt_evidence`` a raw-text/secret-looking reason_code
+    directly must be REJECTED (fail closed), not silently persisted --
+    ``_summary_to_attempt_evidence`` re-validates against the closed
+    KNOWN_REASON_CODES allowlist."""
+    sentinel = "sk-live-SUPERSECRETTOKEN-should-never-appear-in-hashes"
+    summary = _fake_summary(status="crashed", reason_code=sentinel)
+    with pytest.raises(ValueError):
+        cli._summary_to_attempt_evidence(
+            summary,
+            strategy_key="K",
+            experiment_id="exp-abc",
+            full_campaign_hash="h" * 64,
+            campaign_run_id="run-001",
+        )
+
+
+def test_allowlisted_reason_code_is_accepted_and_never_leaks_into_hashes():
+    from rob944_walkforward import REASON_CHILD_EXECUTION_CRASHED
+
+    summary = _fake_summary(
+        status="crashed", reason_code=REASON_CHILD_EXECUTION_CRASHED
+    )
+    evidence = cli._summary_to_attempt_evidence(
+        summary,
+        strategy_key="K",
+        experiment_id="exp-abc",
+        full_campaign_hash="h" * 64,
+        campaign_run_id="run-001",
+    )
+    assert evidence.reason_code == REASON_CHILD_EXECUTION_CRASHED
+
+
+def test_cross_status_pair_completed_status_with_crashed_reason_is_rejected():
+    """Captain trust-boundary hole #2: a bare KNOWN_REASON_CODES membership
+    check would WRONGLY accept status="completed" paired with
+    reason_code="child_execution_crashed" (a known code, just not valid for
+    "completed") -- the exact status-scoped contract must catch this
+    cross-status pair before anything is hashed/persisted, since H6's own
+    DTO has no status/reason-pair validation and the controller cannot
+    catch it either (status/reason are folded into an opaque hash by then)."""
+    from rob944_walkforward import REASON_CHILD_EXECUTION_CRASHED
+
+    summary = _fake_summary(
+        status="completed", reason_code=REASON_CHILD_EXECUTION_CRASHED
+    )
+    with pytest.raises(ValueError):
+        cli._summary_to_attempt_evidence(
+            summary,
+            strategy_key="K",
+            experiment_id="exp-abc",
+            full_campaign_hash="h" * 64,
+            campaign_run_id="run-001",
+        )
+
+
+def test_cross_status_pair_rejected_status_with_timeout_reason_is_rejected():
+    from rob944_walkforward import REASON_CHILD_EXECUTION_TIMEOUT
+
+    summary = _fake_summary(
+        status="rejected", reason_code=REASON_CHILD_EXECUTION_TIMEOUT
+    )
+    with pytest.raises(ValueError):
+        cli._summary_to_attempt_evidence(
+            summary,
+            strategy_key="K",
+            experiment_id="exp-abc",
+            full_campaign_hash="h" * 64,
+            campaign_run_id="run-001",
+        )
+
+
+def test_scenario_level_cross_status_pair_is_rejected():
+    """Same contract, applied to a per-scenario row (never_selected's
+    reason is the fixed sentinel, never a crashed/timeout reason)."""
+    from rob944_walkforward import REASON_CHILD_EXECUTION_CRASHED
+
+    summary = _fake_summary()
+    object.__setattr__(summary.scenario_summaries[0], "status", "never_selected")
+    object.__setattr__(
+        summary.scenario_summaries[0], "reason_code", REASON_CHILD_EXECUTION_CRASHED
+    )
+    with pytest.raises(ValueError):
+        cli._summary_to_attempt_evidence(
+            summary,
+            strategy_key="K",
+            experiment_id="exp-abc",
+            full_campaign_hash="h" * 64,
+            campaign_run_id="run-001",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Captain item E (2026-07-17): the pre-hash validation added to
+# _summary_to_attempt_evidence (exact 3 unique canonical scenarios,
+# per-scenario hex64 artifact_hash, non-bool/non-negative-int trade_count)
+# had ZERO negative-path test coverage -- these prove rejection happens
+# BEFORE anything is hashed/persisted, for each distinct malformed input.
+# ---------------------------------------------------------------------------
+
+
+def test_duplicate_scenario_name_is_rejected_before_hashing():
+    """3 scenario_summaries rows, but two share the same scenario_name (a
+    duplicate "base" instead of the canonical base/primary_stress/
+    upward_stress trio) -- the set of unique names no longer equals the
+    closed 3-name canonical set, even though the row COUNT is still 3."""
+    from rob944_walkforward import ScenarioEvidenceSummary
+
+    summary = _fake_summary()
+    duplicated = (
+        ScenarioEvidenceSummary(
+            scenario_name="base",
+            status="completed",
+            reason_code=None,
+            trade_count=1,
+            artifact_hash="a" * 64,
+            no_trade_reason_counts={},
+        ),
+        ScenarioEvidenceSummary(
+            scenario_name="base",
+            status="completed",
+            reason_code=None,
+            trade_count=1,
+            artifact_hash="b" * 64,
+            no_trade_reason_counts={},
+        ),
+        ScenarioEvidenceSummary(
+            scenario_name="upward_stress",
+            status="completed",
+            reason_code=None,
+            trade_count=1,
+            artifact_hash="c" * 64,
+            no_trade_reason_counts={},
+        ),
+    )
+    object.__setattr__(summary, "scenario_summaries", duplicated)
+    with pytest.raises(ValueError, match="exactly the 3 unique canonical scenarios"):
+        cli._summary_to_attempt_evidence(
+            summary,
+            strategy_key="K",
+            experiment_id="exp-abc",
+            full_campaign_hash="h" * 64,
+            campaign_run_id="run-001",
+        )
+
+
+def test_missing_scenario_name_is_rejected_before_hashing():
+    """Only 2 scenario_summaries rows (upward_stress entirely absent) --
+    row count alone (!= 3) must fail closed before hashing."""
+    from rob944_walkforward import ScenarioEvidenceSummary
+
+    summary = _fake_summary()
+    only_two = (
+        ScenarioEvidenceSummary(
+            scenario_name="base",
+            status="completed",
+            reason_code=None,
+            trade_count=1,
+            artifact_hash="a" * 64,
+            no_trade_reason_counts={},
+        ),
+        ScenarioEvidenceSummary(
+            scenario_name="primary_stress",
+            status="completed",
+            reason_code=None,
+            trade_count=1,
+            artifact_hash="b" * 64,
+            no_trade_reason_counts={},
+        ),
+    )
+    object.__setattr__(summary, "scenario_summaries", only_two)
+    with pytest.raises(ValueError, match="exactly the 3 unique canonical scenarios"):
+        cli._summary_to_attempt_evidence(
+            summary,
+            strategy_key="K",
+            experiment_id="exp-abc",
+            full_campaign_hash="h" * 64,
+            campaign_run_id="run-001",
+        )
+
+
+def test_wrong_scenario_name_is_rejected_before_hashing():
+    """Exactly 3 unique names, but one is outside the closed canonical set
+    (a caller-injected/typo'd scenario name) -- row count alone would pass,
+    so this proves the SET-equality check (not just len==3) is what catches
+    it."""
+    from rob944_walkforward import ScenarioEvidenceSummary
+
+    summary = _fake_summary()
+    wrong_name = (
+        ScenarioEvidenceSummary(
+            scenario_name="base",
+            status="completed",
+            reason_code=None,
+            trade_count=1,
+            artifact_hash="a" * 64,
+            no_trade_reason_counts={},
+        ),
+        ScenarioEvidenceSummary(
+            scenario_name="primary_stress",
+            status="completed",
+            reason_code=None,
+            trade_count=1,
+            artifact_hash="b" * 64,
+            no_trade_reason_counts={},
+        ),
+        ScenarioEvidenceSummary(
+            scenario_name="SECRET-INJECTED-SCENARIO",
+            status="completed",
+            reason_code=None,
+            trade_count=1,
+            artifact_hash="c" * 64,
+            no_trade_reason_counts={},
+        ),
+    )
+    object.__setattr__(summary, "scenario_summaries", wrong_name)
+    with pytest.raises(ValueError) as exc_info:
+        cli._summary_to_attempt_evidence(
+            summary,
+            strategy_key="K",
+            experiment_id="exp-abc",
+            full_campaign_hash="h" * 64,
+            campaign_run_id="run-001",
+        )
+    assert "SECRET-INJECTED-SCENARIO" not in str(exc_info.value)
+
+
+def test_non_hex_artifact_hash_is_rejected_before_hashing():
+    """A scenario's artifact_hash is not a well-formed lowercase 64-hex
+    digest (e.g. a raw label accidentally passed through) -- rejected
+    fail-closed, the offending value itself never echoed."""
+    summary = _fake_summary()
+    sentinel = "not-a-valid-hex64-hash-SECRET"
+    object.__setattr__(summary.scenario_summaries[0], "artifact_hash", sentinel)
+    with pytest.raises(ValueError) as exc_info:
+        cli._summary_to_attempt_evidence(
+            summary,
+            strategy_key="K",
+            experiment_id="exp-abc",
+            full_campaign_hash="h" * 64,
+            campaign_run_id="run-001",
+        )
+    assert sentinel not in str(exc_info.value)
+
+
+def test_bool_trade_count_is_rejected_before_hashing():
+    """trade_count=True must be rejected -- bool is a subclass of int in
+    Python, so a bare ``isinstance(x, int)`` check alone would silently
+    accept it as trade_count=1. Captain live-review correction
+    (2026-07-17): now caught at NORMALIZATION time (``_assert_exact_int``,
+    "must be an exact int"), earlier than the downstream nonnegative
+    check's own message."""
+    summary = _fake_summary()
+    object.__setattr__(summary.scenario_summaries[0], "trade_count", True)
+    with pytest.raises(ValueError, match="trade_count must be an exact int"):
+        cli._summary_to_attempt_evidence(
+            summary,
+            strategy_key="K",
+            experiment_id="exp-abc",
+            full_campaign_hash="h" * 64,
+            campaign_run_id="run-001",
+        )
+
+
+def test_non_int_trade_count_is_rejected_before_hashing():
+    """A float trade_count (e.g. 3.0) must be rejected -- only a strict
+    int is accepted, never anything merely numerically equal to one.
+    Caught at NORMALIZATION time (``_assert_exact_int``)."""
+    summary = _fake_summary()
+    object.__setattr__(summary.scenario_summaries[0], "trade_count", 3.0)
+    with pytest.raises(ValueError, match="trade_count must be an exact int"):
+        cli._summary_to_attempt_evidence(
+            summary,
+            strategy_key="K",
+            experiment_id="exp-abc",
+            full_campaign_hash="h" * 64,
+            campaign_run_id="run-001",
+        )
+
+
+def test_int_subclass_trade_count_is_rejected_before_hashing():
+    """Captain live-review correction (2026-07-17): an int SUBCLASS (not
+    merely bool) must also be rejected -- a downstream ``isinstance(x,
+    int)`` check would have wrongly accepted it (isinstance follows the
+    subclass MRO); ``_assert_exact_int``'s ``type(x) is int`` catches it
+    at NORMALIZATION time instead, before it ever reaches the normalized
+    DTO."""
+
+    class _IntSubclass(int):
+        pass
+
+    summary = _fake_summary()
+    object.__setattr__(summary.scenario_summaries[0], "trade_count", _IntSubclass(3))
+    with pytest.raises(ValueError, match="trade_count must be an exact int"):
+        cli._summary_to_attempt_evidence(
+            summary,
+            strategy_key="K",
+            experiment_id="exp-abc",
+            full_campaign_hash="h" * 64,
+            campaign_run_id="run-001",
+        )
+
+
+def test_negative_trade_count_is_rejected_before_hashing():
+    summary = _fake_summary()
+    object.__setattr__(summary.scenario_summaries[0], "trade_count", -1)
+    with pytest.raises(ValueError, match="non-nonnegative-int trade_count"):
+        cli._summary_to_attempt_evidence(
+            summary,
+            strategy_key="K",
+            experiment_id="exp-abc",
+            full_campaign_hash="h" * 64,
+            campaign_run_id="run-001",
+        )
+
+
+def _mutate_duplicate_scenario_name(summary):
+    from rob944_walkforward import ScenarioEvidenceSummary
+
+    object.__setattr__(
+        summary,
+        "scenario_summaries",
+        (
+            ScenarioEvidenceSummary(
+                scenario_name="base",
+                status="completed",
+                reason_code=None,
+                trade_count=1,
+                artifact_hash="a" * 64,
+                no_trade_reason_counts={},
+            ),
+            ScenarioEvidenceSummary(
+                scenario_name="base",
+                status="completed",
+                reason_code=None,
+                trade_count=1,
+                artifact_hash="b" * 64,
+                no_trade_reason_counts={},
+            ),
+            ScenarioEvidenceSummary(
+                scenario_name="upward_stress",
+                status="completed",
+                reason_code=None,
+                trade_count=1,
+                artifact_hash="c" * 64,
+                no_trade_reason_counts={},
+            ),
+        ),
+    )
+
+
+def _mutate_missing_scenario(summary):
+    from rob944_walkforward import ScenarioEvidenceSummary
+
+    object.__setattr__(
+        summary,
+        "scenario_summaries",
+        (
+            ScenarioEvidenceSummary(
+                scenario_name="base",
+                status="completed",
+                reason_code=None,
+                trade_count=1,
+                artifact_hash="a" * 64,
+                no_trade_reason_counts={},
+            ),
+            ScenarioEvidenceSummary(
+                scenario_name="primary_stress",
+                status="completed",
+                reason_code=None,
+                trade_count=1,
+                artifact_hash="b" * 64,
+                no_trade_reason_counts={},
+            ),
+        ),
+    )
+
+
+def _mutate_wrong_scenario_name(summary):
+    from rob944_walkforward import ScenarioEvidenceSummary
+
+    object.__setattr__(
+        summary,
+        "scenario_summaries",
+        (
+            ScenarioEvidenceSummary(
+                scenario_name="base",
+                status="completed",
+                reason_code=None,
+                trade_count=1,
+                artifact_hash="a" * 64,
+                no_trade_reason_counts={},
+            ),
+            ScenarioEvidenceSummary(
+                scenario_name="primary_stress",
+                status="completed",
+                reason_code=None,
+                trade_count=1,
+                artifact_hash="b" * 64,
+                no_trade_reason_counts={},
+            ),
+            ScenarioEvidenceSummary(
+                scenario_name="SECRET-INJECTED-SCENARIO",
+                status="completed",
+                reason_code=None,
+                trade_count=1,
+                artifact_hash="c" * 64,
+                no_trade_reason_counts={},
+            ),
+        ),
+    )
+
+
+def _mutate_non_hex_artifact_hash(summary):
+    object.__setattr__(
+        summary.scenario_summaries[0], "artifact_hash", "not-a-valid-hex64-hash"
+    )
+
+
+def _mutate_bool_trade_count(summary):
+    object.__setattr__(summary.scenario_summaries[0], "trade_count", True)
+
+
+def _mutate_non_int_trade_count(summary):
+    object.__setattr__(summary.scenario_summaries[0], "trade_count", 3.0)
+
+
+def _mutate_negative_trade_count(summary):
+    object.__setattr__(summary.scenario_summaries[0], "trade_count", -1)
+
+
+def _mutate_fold_rejected_secret_control_string(summary):
+    """Captain final-audit semantic correction (2026-07-17): a pure auditor
+    probe fed ``rejected="SECRET-CONTROL\\n"`` (a truthy non-bool) straight
+    into the ``if row.rejected:`` branch -- FoldSelectionEvidenceSummary's
+    ``bool`` type hint is not runtime-enforced (a plain frozen dataclass,
+    no validator)."""
+    object.__setattr__(summary.fold_selection_trace[0], "rejected", "SECRET-CONTROL\n")
+
+
+def _mutate_fold_rejected_int_one(summary):
+    """int 1 is truthy and would pass silently through a naive
+    ``if row.rejected:`` check as if it were ``True`` -- must still be
+    rejected as not a bool (``type(x) is bool``), not merely accepted
+    because it is truthy or numerically equal to ``True``."""
+    object.__setattr__(summary.fold_selection_trace[0], "rejected", 1)
+
+
+def _mutate_fold_eligible_symbols_as_set(summary):
+    """Captain adjacent trust-boundary correction (2026-07-17, item A): a
+    set-valued eligible_symbols would still pass every membership/
+    uniqueness/coverage check (same content), but its iteration order
+    varies with PYTHONHASHSEED once accepted -- corrupting
+    canonical_sha256/operator JSON determinism. Rejected purely for being
+    the wrong container TYPE, before any of that."""
+    object.__setattr__(
+        summary.fold_selection_trace[0],
+        "eligible_symbols",
+        frozenset({"BTCUSDT", "XRPUSDT"}),
+    )
+
+
+def _mutate_fold_excluded_symbols_as_set(summary):
+    object.__setattr__(
+        summary.fold_selection_trace[0],
+        "excluded_symbols",
+        frozenset(
+            {
+                ("DOGEUSDT", "insufficient_symbol_evidence"),
+                ("SOLUSDT", "insufficient_symbol_evidence"),
+            }
+        ),
+    )
+
+
+def _mutate_fold_excluded_entry_not_2_tuple(summary):
+    object.__setattr__(
+        summary.fold_selection_trace[0],
+        "excluded_symbols",
+        (
+            ["DOGEUSDT", "insufficient_symbol_evidence"],  # list, not a tuple
+            ("SOLUSDT", "insufficient_symbol_evidence"),
+        ),
+    )
+
+
+def _mutate_fold_eligible_symbols_reversed_order(summary):
+    """Same 2 symbols, same set, a genuinely valid tuple container -- but
+    in the REVERSE of the frozen UNIVERSE's own order. Valid content is
+    not enough; canonical order is required too."""
+    object.__setattr__(
+        summary.fold_selection_trace[0], "eligible_symbols", ("XRPUSDT", "BTCUSDT")
+    )
+
+
+def _mutate_fold_excluded_symbols_reversed_order(summary):
+    object.__setattr__(
+        summary.fold_selection_trace[0],
+        "excluded_symbols",
+        (
+            ("SOLUSDT", "insufficient_symbol_evidence"),
+            ("DOGEUSDT", "insufficient_symbol_evidence"),
+        ),
+    )
+
+
+def _mutate_fold_equal_weight_expectancy_bool(summary):
+    object.__setattr__(
+        summary.fold_selection_trace[0], "equal_weight_expectancy_bps", True
+    )
+
+
+def _mutate_fold_pooled_expectancy_decimal(summary):
+    from decimal import Decimal
+
+    object.__setattr__(
+        summary.fold_selection_trace[0], "pooled_expectancy_bps", Decimal("1.25")
+    )
+
+
+def _mutate_fold_profit_factor_none(summary):
+    object.__setattr__(summary.fold_selection_trace[0], "profit_factor", None)
+
+
+def _mutate_fold_rejected_true_but_expectancy_non_null(summary):
+    """A rejected/non-rejected consistency violation: rejected=True with a
+    VALID matching rejection_reason (so the earlier rejected/reason-code
+    check does not mask this one), but equal_weight_expectancy_bps is
+    still a real (non-None) float -- must be rejected as None-required-
+    when-rejected."""
+    from rob944_selection import INSUFFICIENT_ELIGIBLE_SYMBOLS_REASON
+
+    row = summary.fold_selection_trace[0]
+    object.__setattr__(row, "rejected", True)
+    object.__setattr__(row, "rejection_reason", INSUFFICIENT_ELIGIBLE_SYMBOLS_REASON)
+    # equal_weight_expectancy_bps stays a real float (5.0) -- the violation.
+
+
+@pytest.mark.parametrize(
+    "mutate",
+    [
+        _mutate_duplicate_scenario_name,
+        _mutate_missing_scenario,
+        _mutate_wrong_scenario_name,
+        _mutate_non_hex_artifact_hash,
+        _mutate_bool_trade_count,
+        _mutate_non_int_trade_count,
+        _mutate_negative_trade_count,
+        _mutate_fold_rejected_secret_control_string,
+        _mutate_fold_rejected_int_one,
+        _mutate_fold_eligible_symbols_as_set,
+        _mutate_fold_excluded_symbols_as_set,
+        _mutate_fold_excluded_entry_not_2_tuple,
+        _mutate_fold_eligible_symbols_reversed_order,
+        _mutate_fold_excluded_symbols_reversed_order,
+        _mutate_fold_equal_weight_expectancy_bool,
+        _mutate_fold_pooled_expectancy_decimal,
+        _mutate_fold_profit_factor_none,
+        _mutate_fold_rejected_true_but_expectancy_non_null,
+    ],
+    ids=[
+        "duplicate_scenario_name",
+        "missing_scenario",
+        "wrong_scenario_name",
+        "non_hex_artifact_hash",
+        "bool_trade_count",
+        "non_int_trade_count",
+        "negative_trade_count",
+        "fold_rejected_secret_control_string",
+        "fold_rejected_int_one",
+        "fold_eligible_symbols_as_set",
+        "fold_excluded_symbols_as_set",
+        "fold_excluded_entry_not_2_tuple",
+        "fold_eligible_symbols_reversed_order",
+        "fold_excluded_symbols_reversed_order",
+        "fold_equal_weight_expectancy_bool",
+        "fold_pooled_expectancy_decimal",
+        "fold_profit_factor_none",
+        "fold_rejected_true_but_expectancy_non_null",
+    ],
+)
+def test_pre_hash_validation_rejects_before_any_canonical_sha256_call(
+    monkeypatch, mutate
+):
+    """P1-E ordering proof: naming a test "before_hashing" is not itself
+    evidence of ordering -- this spies on canonical_sha256 directly (the
+    function _summary_to_attempt_evidence locally imports and calls to
+    build fold_evidence_hash/run_identity) and monkeypatches it to raise
+    AssertionError if ever called. For each representative invalid mutation,
+    only a ValueError (never the AssertionError) may propagate -- proving
+    genuine pre-hash rejection, not merely an eventual ValueError from
+    somewhere downstream. _summary_to_attempt_evidence has no persistence
+    call of its own (that's the controller's job), so zero hash calls is
+    the correct pre-persistence proof at this layer."""
+    import research_contracts.canonical_hash as canonical_hash_module
+
+    def _boom(*args, **kwargs):
+        raise AssertionError(
+            "canonical_sha256 must never be called -- pre-hash validation should have "
+            "rejected this input first"
+        )
+
+    monkeypatch.setattr(canonical_hash_module, "canonical_sha256", _boom)
+
+    summary = _fake_summary()
+    mutate(summary)
+    with pytest.raises(ValueError):
+        cli._summary_to_attempt_evidence(
+            summary,
+            strategy_key="K",
+            experiment_id="exp-abc",
+            full_campaign_hash="h" * 64,
+            campaign_run_id="run-001",
+        )
+
+
+def test_fold_rejected_non_bool_secret_control_string_never_leaks_and_is_type_exact(
+    monkeypatch, capsys
+):
+    """Captain final-audit semantic correction (2026-07-17), dedicated
+    sentinel-leak proof: the exact offending value
+    ``"SECRET-CONTROL\\n"`` must never appear in the raised exception's own
+    message, and (since --run's stdout print only ever happens AFTER a
+    successful, fully-validated _summary_to_attempt_evidence call, which
+    this input never reaches) there is no JSON/persistence side effect to
+    check either -- captured stdout must remain empty."""
+    import research_contracts.canonical_hash as canonical_hash_module
+
+    def _boom(*args, **kwargs):
+        raise AssertionError(
+            "canonical_sha256 must never be called for this rejected input"
+        )
+
+    monkeypatch.setattr(canonical_hash_module, "canonical_sha256", _boom)
+
+    sentinel = "SECRET-CONTROL\n"
+    summary = _fake_summary()
+    object.__setattr__(summary.fold_selection_trace[0], "rejected", sentinel)
+    with pytest.raises(ValueError) as exc_info:
+        cli._summary_to_attempt_evidence(
+            summary,
+            strategy_key="K",
+            experiment_id="exp-abc",
+            full_campaign_hash="h" * 64,
+            campaign_run_id="run-001",
+        )
+    message = str(exc_info.value)
+    assert sentinel not in message
+    assert "SECRET-CONTROL" not in message
+    captured = capsys.readouterr()
+    assert sentinel not in captured.out
+    assert sentinel not in captured.err
+    assert captured.out == ""
+
+
+# ---------------------------------------------------------------------------
+# Captain normalization-boundary correction (2026-07-17): a caller-owned
+# mapping/tuple/dataclass can be a SUBCLASS/PROXY that returns benign
+# content on a first read and secret-bearing content on a LATER read
+# (validate-then-hash/output is a TOCTOU hole if the same object is read
+# twice). The fix (_normalize_config_attempt_evidence_summary et al.)
+# requires EXACT canonical runtime types everywhere and snapshots every
+# field/container/dict in ONE pass -- these regressions prove: (a) the
+# stateful hook is never even invoked (exact-type rejection happens BEFORE
+# any .items()/__iter__ call), and (b) the secret never appears in any
+# exception message, captured stdout, or (transitively) any hash payload,
+# since canonical_sha256 is never reached at all.
+# ---------------------------------------------------------------------------
+
+
+class _StatefulDict(dict):
+    """A dict SUBCLASS whose .items() returns a benign empty view on its
+    first call and a SECRET-bearing view on any later call -- pure/
+    deterministic (call-count based, no wall-clock/randomness)."""
+
+    def __init__(self, secret_items):
+        super().__init__()
+        self.secret_items = secret_items
+        self.items_call_count = 0
+
+    def items(self):
+        self.items_call_count += 1
+        if self.items_call_count == 1:
+            return {}.items()
+        return dict(self.secret_items).items()
+
+
+class _StatefulSecretTuple(tuple):
+    """A tuple SUBCLASS whose __iter__ returns a benign empty view on its
+    first call and a SECRET-bearing view on any later call. Used for every
+    tuple-typed container field (scenario_summaries/fold_selection_trace/
+    eligible_symbols/excluded_symbols) to prove exact-type rejection
+    happens BEFORE any iteration at all -- ``iter_call_count`` stays 0."""
+
+    def __new__(cls, secret_items):
+        obj = super().__new__(cls, ())
+        obj.secret_items = tuple(secret_items)
+        obj.iter_call_count = 0
+        return obj
+
+    def __iter__(self):
+        self.iter_call_count += 1
+        if self.iter_call_count == 1:
+            return iter(())
+        return iter(self.secret_items)
+
+
+def _assert_secret_absent_everywhere(monkeypatch, secret, run_fn):
+    """Shared assertion shape for every normalization-boundary regression:
+    canonical_sha256 must never be called (spy raises AssertionError if
+    it is), a ValueError (never the spy's AssertionError) must propagate,
+    and the secret must never appear in the exception message or captured
+    stdout/stderr."""
+    import research_contracts.canonical_hash as canonical_hash_module
+
+    def _boom(*args, **kwargs):
+        raise AssertionError("canonical_sha256 must never be called for this input")
+
+    monkeypatch.setattr(canonical_hash_module, "canonical_sha256", _boom)
+    with pytest.raises(ValueError) as exc_info:
+        run_fn()
+    message = str(exc_info.value)
+    assert secret not in message
+    return exc_info
+
+
+def test_stateful_dict_subclass_scenario_no_trade_reason_counts_rejected_before_any_items_call(
+    monkeypatch, capsys
+):
+    secret = "SECRET-CONTROL-scenario-counts\n"
+    stateful = _StatefulDict({secret: 1})
+    summary = _fake_summary()
+    object.__setattr__(
+        summary.scenario_summaries[0], "no_trade_reason_counts", stateful
+    )
+    _assert_secret_absent_everywhere(
+        monkeypatch,
+        secret,
+        lambda: cli._summary_to_attempt_evidence(
+            summary,
+            strategy_key="K",
+            experiment_id="exp-abc",
+            full_campaign_hash="h" * 64,
+            campaign_run_id="run-001",
+        ),
+    )
+    # Exact-type rejection (type(value) is not dict) fires BEFORE any
+    # .items() call -- the stateful hook is never even invoked.
+    assert stateful.items_call_count == 0
+    captured = capsys.readouterr()
+    assert secret not in captured.out
+    assert secret not in captured.err
+
+
+def test_stateful_dict_subclass_fold_no_trade_reason_counts_rejected_before_any_items_call(
+    monkeypatch, capsys
+):
+    secret = "SECRET-CONTROL-fold-counts\n"
+    stateful = _StatefulDict({secret: 1})
+    summary = _fake_summary()
+    object.__setattr__(
+        summary.fold_selection_trace[0], "no_trade_reason_counts", stateful
+    )
+    _assert_secret_absent_everywhere(
+        monkeypatch,
+        secret,
+        lambda: cli._summary_to_attempt_evidence(
+            summary,
+            strategy_key="K",
+            experiment_id="exp-abc",
+            full_campaign_hash="h" * 64,
+            campaign_run_id="run-001",
+        ),
+    )
+    assert stateful.items_call_count == 0
+    captured = capsys.readouterr()
+    assert secret not in captured.out
+    assert secret not in captured.err
+
+
+def test_stateful_tuple_subclass_scenario_summaries_rejected_before_any_iteration(
+    monkeypatch, capsys
+):
+    from rob944_walkforward import ScenarioEvidenceSummary
+
+    secret = "SECRET-CONTROL-scenario-name\n"
+    secret_row = ScenarioEvidenceSummary(
+        scenario_name=secret,
+        status="completed",
+        reason_code=None,
+        trade_count=1,
+        artifact_hash="a" * 64,
+        no_trade_reason_counts={},
+    )
+    stateful = _StatefulSecretTuple((secret_row,))
+    summary = _fake_summary()
+    object.__setattr__(summary, "scenario_summaries", stateful)
+    _assert_secret_absent_everywhere(
+        monkeypatch,
+        secret,
+        lambda: cli._summary_to_attempt_evidence(
+            summary,
+            strategy_key="K",
+            experiment_id="exp-abc",
+            full_campaign_hash="h" * 64,
+            campaign_run_id="run-001",
+        ),
+    )
+    assert stateful.iter_call_count == 0
+    captured = capsys.readouterr()
+    assert secret not in captured.out
+    assert secret not in captured.err
+
+
+def test_stateful_tuple_subclass_fold_selection_trace_rejected_before_any_iteration(
+    monkeypatch, capsys
+):
+    secret = "SECRET-CONTROL-fold-trace\n"
+    secret_row = _fake_fold_trace_row(fold_id=secret)
+    stateful = _StatefulSecretTuple((secret_row,))
+    summary = _fake_summary()
+    object.__setattr__(summary, "fold_selection_trace", stateful)
+    _assert_secret_absent_everywhere(
+        monkeypatch,
+        secret,
+        lambda: cli._summary_to_attempt_evidence(
+            summary,
+            strategy_key="K",
+            experiment_id="exp-abc",
+            full_campaign_hash="h" * 64,
+            campaign_run_id="run-001",
+        ),
+    )
+    assert stateful.iter_call_count == 0
+    captured = capsys.readouterr()
+    assert secret not in captured.out
+    assert secret not in captured.err
+
+
+def test_stateful_tuple_subclass_eligible_symbols_rejected_before_any_iteration(
+    monkeypatch, capsys
+):
+    secret = "SECRET-CONTROL-eligible-symbol\n"
+    stateful = _StatefulSecretTuple((secret,))
+    summary = _fake_summary()
+    object.__setattr__(summary.fold_selection_trace[0], "eligible_symbols", stateful)
+    _assert_secret_absent_everywhere(
+        monkeypatch,
+        secret,
+        lambda: cli._summary_to_attempt_evidence(
+            summary,
+            strategy_key="K",
+            experiment_id="exp-abc",
+            full_campaign_hash="h" * 64,
+            campaign_run_id="run-001",
+        ),
+    )
+    assert stateful.iter_call_count == 0
+    captured = capsys.readouterr()
+    assert secret not in captured.out
+    assert secret not in captured.err
+
+
+def test_stateful_tuple_subclass_excluded_symbols_rejected_before_any_iteration(
+    monkeypatch, capsys
+):
+    secret = "SECRET-CONTROL-excluded-symbol\n"
+    stateful = _StatefulSecretTuple(((secret, "insufficient_symbol_evidence"),))
+    summary = _fake_summary()
+    object.__setattr__(summary.fold_selection_trace[0], "excluded_symbols", stateful)
+    _assert_secret_absent_everywhere(
+        monkeypatch,
+        secret,
+        lambda: cli._summary_to_attempt_evidence(
+            summary,
+            strategy_key="K",
+            experiment_id="exp-abc",
+            full_campaign_hash="h" * 64,
+            campaign_run_id="run-001",
+        ),
+    )
+    assert stateful.iter_call_count == 0
+    captured = capsys.readouterr()
+    assert secret not in captured.out
+    assert secret not in captured.err
+
+
+def test_config_attempt_evidence_summary_subclass_proxy_is_rejected():
+    """The OUTER summary object itself being a subclass/proxy of
+    ConfigAttemptEvidenceSummary (not merely a nested field) must also be
+    rejected -- type(summary) is not ConfigAttemptEvidenceSummary."""
+    from rob944_walkforward import ConfigAttemptEvidenceSummary
+
+    class _ProxySummary(ConfigAttemptEvidenceSummary):
+        pass
+
+    base = _fake_summary()
+    proxy = _ProxySummary(
+        strategy=base.strategy,
+        config_id=base.config_id,
+        status=base.status,
+        reason_code=base.reason_code,
+        scenario_summaries=base.scenario_summaries,
+        fold_selection_trace=base.fold_selection_trace,
+    )
+    with pytest.raises(ValueError, match="exact ConfigAttemptEvidenceSummary"):
+        cli._summary_to_attempt_evidence(
+            proxy,
+            strategy_key="K",
+            experiment_id="exp-abc",
+            full_campaign_hash="h" * 64,
+            campaign_run_id="run-001",
+        )
+
+
+def test_alias_str_subclass_scenario_name_never_bypasses_membership_check(monkeypatch):
+    """Captain normalization detail: an AliasStr-style str SUBCLASS whose
+    __eq__/__hash__ are overridden to equal an allowed literal (so a bare
+    membership check would wrongly accept it) must still be rejected --
+    exact type(x) is str is checked BEFORE any allowlist/membership
+    comparison, so the override can never even reach that comparison."""
+
+    class _AliasStr(str):
+        def __new__(cls, real_value, alias_target):
+            obj = super().__new__(cls, real_value)
+            obj._alias_target = alias_target
+            return obj
+
+        def __eq__(self, other):
+            return other == self._alias_target
+
+        def __hash__(self):
+            return hash(self._alias_target)
+
+    secret = "SECRET-CONTROL-alias-scenario-name"
+    alias = _AliasStr(secret, "base")  # claims to equal "base" via __eq__/__hash__
+    assert alias == "base"  # the override genuinely fools bare equality/membership
+    assert str(alias) == secret  # but its ACTUAL buffer content is the secret
+
+    summary = _fake_summary()
+    rows = list(summary.scenario_summaries)
+    from rob944_walkforward import ScenarioEvidenceSummary
+
+    rows[0] = ScenarioEvidenceSummary(
+        scenario_name=alias,
+        status="completed",
+        reason_code=None,
+        trade_count=rows[0].trade_count,
+        artifact_hash=rows[0].artifact_hash,
+        no_trade_reason_counts={},
+    )
+    object.__setattr__(summary, "scenario_summaries", tuple(rows))
+
+    exc_info = _assert_secret_absent_everywhere(
+        monkeypatch,
+        secret,
+        lambda: cli._summary_to_attempt_evidence(
+            summary,
+            strategy_key="K",
+            experiment_id="exp-abc",
+            full_campaign_hash="h" * 64,
+            campaign_run_id="run-001",
+        ),
+    )
+    assert "scenario_name" in str(exc_info.value)
+
+
+def test_known_reason_histogram_content_preserved_through_normalization():
+    """Preserve existing known-reason-histogram behavior: a genuine (non-
+    adversarial) no_trade_reason_counts dict with real known-reason keys
+    and correct int counts must survive normalization UNCHANGED and still
+    be reachable in the fold_evidence_hash payload -- proven indirectly
+    via a content-sensitivity check (changing a real count changes
+    run_identity)."""
+    # Captain live test review (2026-07-17): a FIXED, documented allowed
+    # key -- not next(iter(frozenset)) (seed-dependent iteration order) --
+    # confirmed to be an actual member of the closed no-trade allowlist.
+    known_reason = "next_bar_unavailable"
+    assert known_reason in cli._known_no_trade_reasons()
+
+    summary_a = _fake_summary()
+    summary_b = _fake_summary()
+    object.__setattr__(
+        summary_a.scenario_summaries[0],
+        "no_trade_reason_counts",
+        {known_reason: 3},
+    )
+    object.__setattr__(
+        summary_b.scenario_summaries[0],
+        "no_trade_reason_counts",
+        {known_reason: 7},
+    )
+    evidence_a = cli._summary_to_attempt_evidence(
+        summary_a,
+        strategy_key="K",
+        experiment_id="exp-abc",
+        full_campaign_hash="h" * 64,
+        campaign_run_id="run-001",
+    )
+    evidence_b = cli._summary_to_attempt_evidence(
+        summary_b,
+        strategy_key="K",
+        experiment_id="exp-abc",
+        full_campaign_hash="h" * 64,
+        campaign_run_id="run-001",
+    )
+    assert evidence_a.run_identity != evidence_b.run_identity
+    assert evidence_a.fold_evidence_hash != evidence_b.fold_evidence_hash
+
+
+# ---------------------------------------------------------------------------
+# Captain trust-boundary addendum (2026-07-17): no_trade_reason_counts is
+# untrusted input from a caller-injected callback -- keys must be checked
+# against the closed known-reasons allowlist and values must be
+# nonnegative ints (never bool-as-int), BEFORE anything is hashed/printed.
+# ---------------------------------------------------------------------------
+
+
+def test_sentinel_secret_no_trade_reason_key_is_rejected_not_silently_persisted():
+    sentinel_key = "SECRET-INJECTED-KEY-should-never-appear"
+    summary = _fake_summary()
+    object.__setattr__(
+        summary.scenario_summaries[0], "no_trade_reason_counts", {sentinel_key: 1}
+    )
+    with pytest.raises(ValueError) as exc_info:
+        cli._summary_to_attempt_evidence(
+            summary,
+            strategy_key="K",
+            experiment_id="exp-abc",
+            full_campaign_hash="h" * 64,
+            campaign_run_id="run-001",
+        )
+    assert sentinel_key not in str(exc_info.value)
+
+
+def test_negative_no_trade_reason_count_is_rejected():
+    summary = _fake_summary()
+    object.__setattr__(
+        summary.scenario_summaries[0],
+        "no_trade_reason_counts",
+        {"next_bar_unavailable": -1},
+    )
+    with pytest.raises(ValueError):
+        cli._summary_to_attempt_evidence(
+            summary,
+            strategy_key="K",
+            experiment_id="exp-abc",
+            full_campaign_hash="h" * 64,
+            campaign_run_id="run-001",
+        )
+
+
+def test_bool_masquerading_as_no_trade_reason_count_is_rejected():
+    summary = _fake_summary()
+    object.__setattr__(
+        summary.scenario_summaries[0],
+        "no_trade_reason_counts",
+        {"next_bar_unavailable": True},
+    )
+    with pytest.raises(ValueError):
+        cli._summary_to_attempt_evidence(
+            summary,
+            strategy_key="K",
+            experiment_id="exp-abc",
+            full_campaign_hash="h" * 64,
+            campaign_run_id="run-001",
+        )
+
+
+def test_known_no_trade_reasons_is_the_exact_12_code_closed_set():
+    """Captain allowlist correction (2026-07-17): H3 S2's fixed rejection
+    set is SIX codes (rob940_signal_s2.py:142-150,213,227), not two --
+    confirmation_failed, next_bar_unavailable, target_direction_invalid,
+    tp_above_max, tp_below_r_min_sl, tp_below_abs_floor (next_bar_unavailable
+    shared with H2). Combined with H2's other 4 and H4's 2 funding-gate
+    reasons: exactly 12 unique codes total (5 + 2 + 5, since S2's
+    next_bar_unavailable dedupes against H2's)."""
+    known = cli._known_no_trade_reasons()
+    assert known == frozenset(
+        {
+            "next_bar_unavailable",
+            "daily_stop_active",
+            "daily_entry_cap",
+            "cooldown_active",
+            "tp_below_min_distance",
+            "funding_evidence_unavailable",
+            "expected_funding_cost_above_3bps",
+            "confirmation_failed",
+            "target_direction_invalid",
+            "tp_above_max",
+            "tp_below_r_min_sl",
+            "tp_below_abs_floor",
+        }
+    )
+    assert len(known) == 12
+
+
+def test_known_no_trade_reasons_matches_real_h3_s2_gate_rejections_no_drift():
+    """Captain correction (2026-07-17): H3's merged rob940_signal_s2.py
+    source (pinned SHA 762e850e46a0e5f9529e019a1daa34aab0f6f3e4601678aef6db55b95db6f830)
+    must NEVER be edited just to export this allowlist -- it stays a
+    literal, hand-verified copy. This test is the drift guard: it calls
+    the REAL H3 ``_evaluate_target_gates`` function with synthetic inputs
+    engineered to trigger each of its 4 magnitude/direction rejection
+    reasons, and asserts each one it ACTUALLY returns is present in this
+    module's known-reasons set -- if H3 ever renames/adds/removes a reason,
+    this test (not just a hand-maintained literal) fails."""
+    from rob940_signal_s2 import _evaluate_target_gates
+
+    known = cli._known_no_trade_reasons()
+
+    _passed, reason_direction, _d = _evaluate_target_gates(
+        side="long", entry_price=100.0, target_price=99.0, sl_distance=100.0, r_min=1.2
+    )
+    assert reason_direction == "target_direction_invalid"
+    assert reason_direction in known
+
+    _passed, reason_above_max, _d = _evaluate_target_gates(
+        side="long", entry_price=100.0, target_price=101.5, sl_distance=100.0, r_min=1.2
+    )
+    assert reason_above_max == "tp_above_max"
+    assert reason_above_max in known
+
+    # sl_distance is a FRACTIONAL price distance (e.g. 0.0075 == 75bp), the
+    # same unit as (target_price/entry_price - 1) -- not a bare bps number.
+    _passed, reason_below_r_min, _d = _evaluate_target_gates(
+        side="long",
+        entry_price=100.0,
+        target_price=100.80,
+        sl_distance=0.0075,
+        r_min=1.2,
+    )
+    assert (
+        reason_below_r_min == "tp_below_r_min_sl"
+    )  # r_min_sl_bps=90 > d_tp_bps=80 > floor=68
+    assert reason_below_r_min in known
+
+    _passed, reason_below_floor, _d = _evaluate_target_gates(
+        side="long",
+        entry_price=100.0,
+        target_price=100.50,
+        sl_distance=0.0010,
+        r_min=1.0,
+    )
+    assert (
+        reason_below_floor == "tp_below_abs_floor"
+    )  # r_min_sl_bps=10 < d_tp_bps=50 < floor=68
+    assert reason_below_floor in known
+
+    # confirmation_failed/next_bar_unavailable require full bar-level
+    # generate_s2_signals integration to trigger directly; verified via a
+    # textual presence check against the real (pinned) H3 source instead.
+    import inspect
+
+    import rob940_signal_s2
+
+    source = inspect.getsource(rob940_signal_s2)
+    assert '"confirmation_failed"' in source
+    assert '"next_bar_unavailable"' in source
+
+
+@pytest.mark.parametrize(
+    "reason",
+    [
+        "next_bar_unavailable",
+        "daily_stop_active",
+        "daily_entry_cap",
+        "cooldown_active",
+        "tp_below_min_distance",
+        "funding_evidence_unavailable",
+        "expected_funding_cost_above_3bps",
+        "confirmation_failed",
+        "target_direction_invalid",
+        "tp_above_max",
+        "tp_below_r_min_sl",
+        "tp_below_abs_floor",
+    ],
+)
+def test_each_known_no_trade_reason_is_individually_accepted(reason):
+    summary = _fake_summary()
+    object.__setattr__(
+        summary.scenario_summaries[0], "no_trade_reason_counts", {reason: 1}
+    )
+    evidence = cli._summary_to_attempt_evidence(  # must not raise
+        summary,
+        strategy_key="K",
+        experiment_id="exp-abc",
+        full_campaign_hash="h" * 64,
+        campaign_run_id="run-001",
+    )
+    assert evidence is not None
+
+
+def test_known_no_trade_reason_counts_are_accepted_and_bound_into_the_hash():
+    summary_a = _fake_summary()
+    summary_b = _fake_summary()
+    object.__setattr__(
+        summary_a.scenario_summaries[0],
+        "no_trade_reason_counts",
+        {"next_bar_unavailable": 3, "cooldown_active": 1},
+    )
+    object.__setattr__(
+        summary_b.scenario_summaries[0],
+        "no_trade_reason_counts",
+        {"next_bar_unavailable": 5},
+    )
+    ev_a = cli._summary_to_attempt_evidence(  # must not raise
+        summary_a,
+        strategy_key="K",
+        experiment_id="exp-abc",
+        full_campaign_hash="h" * 64,
+        campaign_run_id="run-001",
+    )
+    ev_b = cli._summary_to_attempt_evidence(  # must not raise
+        summary_b,
+        strategy_key="K",
+        experiment_id="exp-abc",
+        full_campaign_hash="h" * 64,
+        campaign_run_id="run-001",
+    )
+    assert (
+        ev_a.fold_evidence_hash != ev_b.fold_evidence_hash
+    )  # genuinely bound into the hash
+
+
+def test_sentinel_secret_no_trade_reason_key_in_fold_selection_trace_is_rejected():
+    summary = _fake_summary()
+    sentinel_key = "SECRET-INJECTED-FOLD-KEY"
+    bad_row = _fake_fold_trace_row()
+    object.__setattr__(bad_row, "no_trade_reason_counts", {sentinel_key: 1})
+    object.__setattr__(summary, "fold_selection_trace", (bad_row,))
+    with pytest.raises(ValueError) as exc_info:
+        cli._summary_to_attempt_evidence(
+            summary,
+            strategy_key="K",
+            experiment_id="exp-abc",
+            full_campaign_hash="h" * 64,
+            campaign_run_id="run-001",
+        )
+    assert sentinel_key not in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# captain BLOCKING controller audit (item 7): empirical_success must be
+# PRIMARY-only and retry-safe -- report.status_counts aggregates ALL
+# attempts including retries, so a naive completed-count check alone is
+# fooled by a completed retry masking a crashed primary.
+# ---------------------------------------------------------------------------
+
+
+def _fake_report(
+    *,
+    verdict="complete",
+    expected_total=24,
+    total_attempts=24,
+    retry_attempts=0,
+    completed=24,
+):
+    return SimpleNamespace(
+        verdict=verdict,
+        expected_total=expected_total,
+        total_attempts=total_attempts,
+        retry_attempts=retry_attempts,
+        status_counts={"completed": completed},
+    )
+
+
+def test_all_24_primaries_completed_no_retries_is_empirical_success():
+    assert cli._is_empirical_success(_fake_report()) is True
+
+
+def test_accounting_incomplete_is_never_empirical_success():
+    assert cli._is_empirical_success(_fake_report(verdict="incomplete")) is False
+
+
+def test_all_24_accounted_but_not_all_completed_is_not_empirical_success():
+    """Accounting-complete (every attempt recorded) but every attempt
+    crashed/rejected/timeout -- accounting completeness is NOT empirical
+    success."""
+    assert cli._is_empirical_success(_fake_report(completed=0)) is False
+
+
+def test_23_completed_plus_1_crashed_primary_plus_1_completed_retry_is_not_empirical_success():
+    """The exact captain-specified regression fixture: a completed RETRY
+    of a crashed primary experiment inflates status_counts["completed"] to
+    24 without every PRIMARY having actually succeeded. total_attempts=25
+    (24 primaries + 1 retry) and retry_attempts=1 must both independently
+    catch this -- a naive ``status_counts["completed"] == expected_total``
+    check alone would have wrongly returned True here."""
+    report = _fake_report(total_attempts=25, retry_attempts=1, completed=24)
+    assert (
+        report.status_counts["completed"] == report.expected_total
+    )  # the naive check would pass
+    assert cli._is_empirical_success(report) is False
+
+
+def test_only_total_attempts_mismatch_alone_is_caught_retry_attempts_otherwise_correct():
+    """Isolate the ``total_attempts == expected_total`` conjunct: mutate
+    ONLY total_attempts (an extra row exists) while retry_attempts=0 and the
+    completed-count naive check would still pass -- proving this conjunct
+    alone (not merely in combination with a simultaneously-wrong
+    retry_attempts) is sufficient to fail closed."""
+    report = _fake_report(total_attempts=25, retry_attempts=0, completed=24)
+    assert (
+        report.status_counts["completed"] == report.expected_total
+    )  # naive check would pass
+    assert report.retry_attempts == 0  # this conjunct alone is NOT what catches it
+    assert cli._is_empirical_success(report) is False
+
+
+def test_only_retry_attempts_mismatch_alone_is_caught_total_attempts_otherwise_correct():
+    """Isolate the ``retry_attempts == 0`` conjunct: mutate ONLY
+    retry_attempts (a retry was recorded) while total_attempts still equals
+    expected_total and the completed-count naive check would still pass --
+    proving this conjunct alone (not merely in combination with a
+    simultaneously-wrong total_attempts) is sufficient to fail closed."""
+    report = _fake_report(total_attempts=24, retry_attempts=1, completed=24)
+    assert (
+        report.status_counts["completed"] == report.expected_total
+    )  # naive check would pass
+    assert (
+        report.total_attempts == report.expected_total
+    )  # this conjunct alone is NOT what catches it
+    assert cli._is_empirical_success(report) is False
+
+
+# ---------------------------------------------------------------------------
+# Captain P1 findings (2026-07-17): fold_evidence_hash/run_identity must
+# bind the attempt's own status/reason_code (two rejected summaries with
+# identical scenario rows but DIFFERENT rejection reasons previously
+# collided) AND the per-fold TRAIN selection trace (previously entirely
+# absent -- a TRAIN-only mutation that never changed which config won OOS
+# was invisible to the final hash).
+# ---------------------------------------------------------------------------
+
+
+def _fake_fold_trace_row(
+    fold_id="fold-00",
+    train_input_hash="1" * 64,
+    profit_factor=1.5,
+    equal_weight_expectancy_bps=5.0,
+    pooled_expectancy_bps=5.0,
+):
+    from rob944_walkforward import FoldSelectionEvidenceSummary
+
+    return FoldSelectionEvidenceSummary(
+        fold_id=fold_id,
+        fold_selected_config_id="S1-00",
+        eligible_symbols=("BTCUSDT", "XRPUSDT"),
+        excluded_symbols=(
+            ("DOGEUSDT", "insufficient_symbol_evidence"),
+            ("SOLUSDT", "insufficient_symbol_evidence"),
+        ),
+        equal_weight_expectancy_bps=equal_weight_expectancy_bps,
+        pooled_expectancy_bps=pooled_expectancy_bps,
+        profit_factor=profit_factor,
+        rejected=False,
+        rejection_reason=None,
+        train_input_hash=train_input_hash,
+        no_trade_reason_counts={},
+    )
+
+
+def _fake_full_fold_trace(*, override_fold_id="fold-00", **row_kwargs):
+    """8 canonical fold rows (fold-00..fold-07) -- the closed
+    fold_selection_trace contract requires exactly these 8 unique fold IDs
+    for every NON-global attempt. ``row_kwargs`` overrides apply ONLY to
+    the row at ``override_fold_id``; every other row uses plain defaults."""
+    rows = []
+    for i in range(8):
+        fid = f"fold-{i:02d}"
+        if fid == override_fold_id:
+            rows.append(_fake_fold_trace_row(fold_id=fid, **row_kwargs))
+        else:
+            rows.append(_fake_fold_trace_row(fold_id=fid))
+    return tuple(rows)
+
+
+def test_train_only_mutation_changes_fold_evidence_hash_and_run_identity():
+    """A TRAIN-only mutation (train_input_hash differs; attempt status/
+    scenario_summaries/which-config-won are UNCHANGED) must still change
+    the final fold_evidence_hash/run_identity -- previously invisible since
+    fold_selection_trace was never bound into either hash."""
+    summary_a = _fake_summary()
+    summary_b = _fake_summary()
+    object.__setattr__(
+        summary_a,
+        "fold_selection_trace",
+        _fake_full_fold_trace(train_input_hash="a" * 64),
+    )
+    object.__setattr__(
+        summary_b,
+        "fold_selection_trace",
+        _fake_full_fold_trace(train_input_hash="b" * 64),
+    )
+
+    ev_a = cli._summary_to_attempt_evidence(
+        summary_a,
+        strategy_key="K",
+        experiment_id="exp-abc",
+        full_campaign_hash="h" * 64,
+        campaign_run_id="run-001",
+    )
+    ev_b = cli._summary_to_attempt_evidence(
+        summary_b,
+        strategy_key="K",
+        experiment_id="exp-abc",
+        full_campaign_hash="h" * 64,
+        campaign_run_id="run-001",
+    )
+    assert ev_a.fold_evidence_hash != ev_b.fold_evidence_hash
+    assert ev_a.run_identity != ev_b.run_identity
+
+
+def test_fold_selection_trace_reorder_does_not_change_the_hash():
+    summary_a = _fake_summary()
+    summary_b = _fake_summary()
+    forward = _fake_full_fold_trace()
+    reversed_trace = tuple(reversed(forward))
+    object.__setattr__(summary_a, "fold_selection_trace", forward)
+    object.__setattr__(summary_b, "fold_selection_trace", reversed_trace)
+
+    ev_a = cli._summary_to_attempt_evidence(
+        summary_a,
+        strategy_key="K",
+        experiment_id="exp-abc",
+        full_campaign_hash="h" * 64,
+        campaign_run_id="run-001",
+    )
+    ev_b = cli._summary_to_attempt_evidence(
+        summary_b,
+        strategy_key="K",
+        experiment_id="exp-abc",
+        full_campaign_hash="h" * 64,
+        campaign_run_id="run-001",
+    )
+    assert ev_a.fold_evidence_hash == ev_b.fold_evidence_hash
+    assert ev_a.run_identity == ev_b.run_identity
+
+
+def test_nonfinite_profit_factor_does_not_raise_and_still_changes_the_hash():
+    """A rejected candidate's profit_factor is math.nan; a legitimate
+    zero-loss winner's can be math.inf -- both must be bound into the hash
+    (never dropped) without ever raising (canonical_sha256 itself rejects
+    raw non-finite floats)."""
+    summary_nan = _fake_summary()
+    summary_inf = _fake_summary()
+    object.__setattr__(
+        summary_nan,
+        "fold_selection_trace",
+        _fake_full_fold_trace(profit_factor=float("nan")),
+    )
+    object.__setattr__(
+        summary_inf,
+        "fold_selection_trace",
+        _fake_full_fold_trace(profit_factor=float("inf")),
+    )
+
+    ev_nan = cli._summary_to_attempt_evidence(  # must not raise
+        summary_nan,
+        strategy_key="K",
+        experiment_id="exp-abc",
+        full_campaign_hash="h" * 64,
+        campaign_run_id="run-001",
+    )
+    ev_inf = cli._summary_to_attempt_evidence(  # must not raise
+        summary_inf,
+        strategy_key="K",
+        experiment_id="exp-abc",
+        full_campaign_hash="h" * 64,
+        campaign_run_id="run-001",
+    )
+    assert ev_nan.fold_evidence_hash != ev_inf.fold_evidence_hash
+
+
+def test_identical_scenarios_but_different_rejection_reason_changes_fold_evidence_hash():
+    """Captain P1 (independent audit): two rejected attempt summaries with
+    IDENTICAL scenario_summaries but DIFFERENT rejection reasons
+    (data_gap vs insufficient_train_evidence) must no longer collide --
+    the attempt's own status/reason_code is now bound into fold_evidence_hash."""
+    from rob944_walkforward import (
+        REASON_DATA_GAP_IN_POSITION,
+        REASON_INSUFFICIENT_TRAIN_EVIDENCE_ALL_FOLDS,
+    )
+
+    summary_gap = _fake_summary(
+        status="rejected", reason_code=REASON_DATA_GAP_IN_POSITION
+    )
+    summary_insufficient = _fake_summary(
+        status="rejected", reason_code=REASON_INSUFFICIENT_TRAIN_EVIDENCE_ALL_FOLDS
+    )
+
+    ev_gap = cli._summary_to_attempt_evidence(
+        summary_gap,
+        strategy_key="K",
+        experiment_id="exp-abc",
+        full_campaign_hash="h" * 64,
+        campaign_run_id="run-001",
+    )
+    ev_insufficient = cli._summary_to_attempt_evidence(
+        summary_insufficient,
+        strategy_key="K",
+        experiment_id="exp-abc",
+        full_campaign_hash="h" * 64,
+        campaign_run_id="run-001",
+    )
+    assert ev_gap.fold_evidence_hash != ev_insufficient.fold_evidence_hash
+    assert ev_gap.run_identity != ev_insufficient.run_identity
+
+
+# ---------------------------------------------------------------------------
+# Fable Q1 FINAL (orch-fable-answer-rob944b-20260717.md): campaign_run_id
+# suffix is 43-char unpadded URL-safe base64 (full 256-bit entropy), NOT
+# hex, NOT a truncation. CLI and controller derivations must agree
+# bit-for-bit, and the resulting AttemptKey.idempotency_key() must fit
+# H6's existing trial_idempotency_key VARCHAR(128) (exact length 125).
+# ---------------------------------------------------------------------------
+
+_B64URL_NO_PAD_RE = re.compile(r"^[A-Za-z0-9_-]{43}$")
+_HEX_RE = re.compile(r"^[0-9a-f]+$")
+
+
+def test_campaign_run_id_suffix_is_43_char_unpadded_base64url_not_hex():
+    full_campaign_hash = "3" * 64
+    run_id = cli._derive_primary_campaign_run_id(full_campaign_hash)
+    assert run_id.startswith("rob944-primary-")
+    suffix = run_id[len("rob944-primary-") :]
+    assert len(suffix) == 43
+    assert _B64URL_NO_PAD_RE.match(suffix)
+    assert "=" not in suffix
+    # Not a (truncated-or-not) hex digest -- a 43-char base64url string will
+    # essentially always contain at least one non-hex-alphabet character
+    # (A-Z, or one of "-_"); assert this explicitly rather than just by length.
+    assert not _HEX_RE.match(suffix)
+
+
+def test_campaign_run_id_suffix_round_trips_the_full_32_byte_digest():
+    from research_contracts.canonical_hash import canonical_sha256
+
+    full_campaign_hash = "4" * 64
+    run_id = cli._derive_primary_campaign_run_id(full_campaign_hash)
+    suffix = run_id[len("rob944-primary-") :]
+
+    expected_digest_hex = canonical_sha256(
+        {"full_campaign_hash": full_campaign_hash, "kind": "primary_run"}
+    )
+    expected_bytes = bytes.fromhex(expected_digest_hex)
+
+    # Un-pad -> re-pad -> decode: must recover the exact same 32 raw bytes.
+    padded = suffix + "=" * (-len(suffix) % 4)
+    decoded_bytes = base64.urlsafe_b64decode(padded)
+    assert decoded_bytes == expected_bytes
+    assert len(decoded_bytes) == 32
+
+
+def test_cli_and_controller_campaign_run_id_derivation_agree_bit_for_bit():
+    from app.services.rob944_campaign_controller import _derive_expected_campaign_run_id
+
+    full_campaign_hash = "5" * 64
+    assert cli._derive_primary_campaign_run_id(
+        full_campaign_hash
+    ) == _derive_expected_campaign_run_id(full_campaign_hash)
+
+
+def test_attempt_key_idempotency_key_exact_length_125_for_real_production_format():
+    from app.schemas.research_campaign_bridge import AttemptKey
+
+    full_campaign_hash = "6" * 64
+    campaign_run_id = cli._derive_primary_campaign_run_id(
+        full_campaign_hash
+    )  # 58 chars
+    experiment_id = "e" * 64  # H6's own unchanged full-hex experiment_id format
+    key = AttemptKey(
+        campaign_run_id=campaign_run_id, experiment_id=experiment_id, retry_index=0
+    )
+    assert len(campaign_run_id) == 58
+    assert len(key.idempotency_key()) == 125
+    assert len(key.idempotency_key()) <= 128
+
+
+def test_campaign_run_id_matches_the_independent_golden_vector():
+    """Captain Fable-b test completeness: an independent, hand-verified
+    golden vector (not derived FROM the implementation under test, so the
+    implementation cannot be its own oracle) for
+    full_campaign_hash="0"*64. If this ever changes, the derivation
+    recipe itself changed -- a fact that must be deliberate, documented,
+    and Fable-consulted, never an accidental byproduct of an unrelated
+    refactor."""
+    full_campaign_hash = "0" * 64
+    run_id = cli._derive_primary_campaign_run_id(full_campaign_hash)
+    assert run_id == "rob944-primary-4BXyzKXLdP4yxjb_7E5k6IhukhDhOlOwJEya22gc5-o"
+    suffix = run_id[len("rob944-primary-") :]
+    assert len(suffix) == 43
+    assert len(run_id) == 58
+    assert _B64URL_NO_PAD_RE.match(suffix)
+
+    from app.schemas.research_campaign_bridge import AttemptKey
+    from app.services.rob944_campaign_controller import _derive_expected_campaign_run_id
+
+    assert _derive_expected_campaign_run_id(full_campaign_hash) == run_id
+    key = AttemptKey(campaign_run_id=run_id, experiment_id="e" * 64, retry_index=0)
+    assert len(key.idempotency_key()) == 125
+
+
+# ---------------------------------------------------------------------------
+# Captain item D (2026-07-17): direct --plan/--run output-contract
+# regressions for spec_deviations/campaign_run_id_derivation -- these two
+# top-level fields were added earlier this session with NO test asserting
+# their exact shape/content.
+# ---------------------------------------------------------------------------
+
+
+def test_plan_spec_deviations_matches_real_h3_s2_source_verbatim():
+    """The verbatim Korean S2 spec-deviation sentence(s) (Fable condition 2)
+    must survive unchanged from H3's own pinned SPEC_DEVIATIONS constant --
+    never re-worded/paraphrased by this CLI's own plan-building code."""
+    from rob940_signal_s2 import SPEC_DEVIATIONS
+
+    plan = cli.build_plan()
+    assert plan["spec_deviations"] == list(SPEC_DEVIATIONS)
+    assert plan["spec_deviations"] == plan["h3_fixed_constants"]["s2_spec_deviations"]
+
+
+def test_plan_campaign_run_id_derivation_contract_exact_shape():
+    """The campaign_run_id_derivation dict must document the EXACT recipe
+    actually implemented by _derive_primary_campaign_run_id -- prefix/
+    lengths in particular must match the real derived value, not just be
+    plausible-looking documentation text."""
+    plan = cli.build_plan()
+    derivation = plan["campaign_run_id_derivation"]
+    assert derivation == {
+        "payload": {
+            "full_campaign_hash": "<the full_campaign_hash above>",
+            "kind": "primary_run",
+        },
+        "recipe": "SHA-256 -> full 32 raw bytes -> unpadded URL-safe base64 (43 chars)",
+        "note": "NOT the 64-hex digest string, and NOT a truncation of it -- full 256-bit entropy preserved",
+        "prefix": "rob944-primary-",
+        "campaign_run_id_length": 58,
+        "primary_idempotency_key_length": 125,
+        "idempotency_key_max": 128,
+    }
+    # Cross-check the documented lengths/prefix against the REAL derivation
+    # for THIS plan's own full_campaign_hash -- not just a hardcoded example.
+    real_run_id = cli._derive_primary_campaign_run_id(plan["full_campaign_hash"])
+    assert real_run_id == plan["expected_campaign_run_id"]
+    assert real_run_id.startswith(derivation["prefix"])
+    assert len(real_run_id) == derivation["campaign_run_id_length"]
+
+
+def test_run_output_spec_deviations_matches_plan(monkeypatch, capsys):
+    """--run's JSON output must echo the SAME spec_deviations value --plan
+    reports (both sourced from the identical plain["h3_fixed_constants"]
+    field), never a divergent/independently-maintained copy."""
+    plan = cli.build_plan()
+    exit_code = _run_main_with_fake_controller(
+        monkeypatch, lambda: _lifecycle_fake_report()
+    )
+    assert exit_code == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["spec_deviations"] == plan["spec_deviations"]
+
+
+def test_run_output_train_selection_trace_includes_expectancy_and_train_input_hash_fields(
+    monkeypatch, capsys
+):
+    """Captain item D: the operator-visible --run train_selection_trace was
+    missing equal_weight_expectancy_bps/pooled_expectancy_bps/profit_factor/
+    train_input_hash (already bound into fold_evidence_hash upstream) --
+    must now be present with the exact values the summary carries."""
+    monkeypatch.setenv("ROB944_RESEARCH_WRITE_OPT_IN", "true")
+    monkeypatch.setattr("app.core.db.AsyncSessionLocal", _FakeSessionLocal())
+
+    fake_summary = _fake_summary(
+        fold_selection_trace=_fake_full_fold_trace(
+            train_input_hash="7" * 64, profit_factor=2.25
+        )
+    )
+
+    def _fake_build_real_attempt_evidence(
+        experiment_id_by_key,
+        *,
+        full_campaign_hash,
+        campaign_run_id,
+        capture_summaries_into=None,
+    ):
+        if capture_summaries_into is not None:
+            capture_summaries_into.append(fake_summary)
+        return []
+
+    monkeypatch.setattr(
+        cli, "_build_real_attempt_evidence", _fake_build_real_attempt_evidence
+    )
+
+    class _FakeReport:
+        verdict = "complete"
+        total_attempts = 24
+        expected_total = 24
+        retry_attempts = 0
+        status_counts = {"completed": 24}
+        actual_registrations = 24
+        primary_attempts = 24
+
+    class _FakeController:
+        @staticmethod
+        async def run_full_campaign(*args, **kwargs):
+            kwargs["build_attempt_evidence"]({})
+            return _FakeReport()
+
+    monkeypatch.setattr(cli, "_import_campaign_controller", lambda: _FakeController)
+
+    plan = cli.build_plan()
+    exit_code = cli.main(
+        [
+            "--run",
+            "--expected-full-campaign-hash",
+            plan["full_campaign_hash"],
+            "--campaign-run-id",
+            plan["expected_campaign_run_id"],
+        ]
+    )
+    assert exit_code == 0
+    out = json.loads(capsys.readouterr().out)
+    trace = out["per_config_scenario_evidence"][0]["train_selection_trace"]
+    assert len(trace) == 8
+    fold_00 = next(row for row in trace if row["fold_id"] == "fold-00")
+    assert fold_00["equal_weight_expectancy_bps"] == 5.0
+    assert fold_00["pooled_expectancy_bps"] == 5.0
+    assert fold_00["profit_factor"] == 2.25
+    assert fold_00["train_input_hash"] == "7" * 64
+
+
+def test_run_output_train_selection_trace_encodes_nonfinite_metrics_as_stable_sentinels(
+    monkeypatch, capsys
+):
+    """P1-D last test gap: NaN/+Inf/-Inf across the three float metrics
+    (equal_weight_expectancy_bps/pooled_expectancy_bps/profit_factor) must
+    survive into --run stdout as the EXACT _json_safe_float_or_sentinel
+    string tokens -- never a bare (non-strict-JSON) NaN/Infinity token, and
+    never silently dropped/coerced to null."""
+    import math
+
+    monkeypatch.setenv("ROB944_RESEARCH_WRITE_OPT_IN", "true")
+    monkeypatch.setattr("app.core.db.AsyncSessionLocal", _FakeSessionLocal())
+
+    fake_summary = _fake_summary(
+        fold_selection_trace=_fake_full_fold_trace(
+            equal_weight_expectancy_bps=math.nan,
+            pooled_expectancy_bps=math.inf,
+            profit_factor=-math.inf,
+        )
+    )
+
+    def _fake_build_real_attempt_evidence(
+        experiment_id_by_key,
+        *,
+        full_campaign_hash,
+        campaign_run_id,
+        capture_summaries_into=None,
+    ):
+        if capture_summaries_into is not None:
+            capture_summaries_into.append(fake_summary)
+        return []
+
+    monkeypatch.setattr(
+        cli, "_build_real_attempt_evidence", _fake_build_real_attempt_evidence
+    )
+
+    class _FakeReport:
+        verdict = "complete"
+        total_attempts = 24
+        expected_total = 24
+        retry_attempts = 0
+        status_counts = {"completed": 24}
+        actual_registrations = 24
+        primary_attempts = 24
+
+    class _FakeController:
+        @staticmethod
+        async def run_full_campaign(*args, **kwargs):
+            kwargs["build_attempt_evidence"]({})
+            return _FakeReport()
+
+    monkeypatch.setattr(cli, "_import_campaign_controller", lambda: _FakeController)
+
+    plan = cli.build_plan()
+    exit_code = cli.main(
+        [
+            "--run",
+            "--expected-full-campaign-hash",
+            plan["full_campaign_hash"],
+            "--campaign-run-id",
+            plan["expected_campaign_run_id"],
+        ]
+    )
+    assert exit_code == 0
+    raw = capsys.readouterr().out
+    assert "NaN" not in raw
+    assert "Infinity" not in raw
+    out = json.loads(
+        raw
+    )  # would still parse even with a leaked bare NaN token -- the substring checks above are the real assertion
+    trace = out["per_config_scenario_evidence"][0]["train_selection_trace"]
+    fold_00 = next(row for row in trace if row["fold_id"] == "fold-00")
+    assert fold_00["equal_weight_expectancy_bps"] == "nonfinite:nan"
+    assert fold_00["pooled_expectancy_bps"] == "nonfinite:inf"
+    assert fold_00["profit_factor"] == "nonfinite:-inf"

--- a/research/nautilus_scalping/tests/test_rob944_cli_import_guard.py
+++ b/research/nautilus_scalping/tests/test_rob944_cli_import_guard.py
@@ -1,0 +1,74 @@
+"""ROB-944 (H4, ROB-940) — CLI module-scope import guard.
+
+``run_rob944_campaign.py`` is a CLI, not a pure module -- its ``run`` mode
+legitimately needs ``app.*`` (DB session, registry bridge) to do real work.
+But ``--help``/``--version``/``plan`` must NEVER touch DB/network/broker
+surfaces, so every ``app.*``/DB/network import must be DEFERRED inside a
+function body, never at module scope. This guard inspects ONLY the
+top-level (module-scope) import statements -- deferred imports inside
+``def``/``async def`` bodies are expected and allowed.
+"""
+
+import ast
+from pathlib import Path
+
+_SCRIPT = Path(__file__).resolve().parents[1] / "run_rob944_campaign.py"
+
+_FORBIDDEN_PREFIXES = (
+    "app",
+    "sqlalchemy",
+    "asyncpg",
+    "psycopg",
+    "psycopg2",
+    "alembic",
+    "redis",
+    "taskiq",
+    "celery",
+    "httpx",
+    "requests",
+    "aiohttp",
+    "urllib3",
+    "socket",
+    "websockets",
+    "boto3",
+    "fastapi",
+    "uvicorn",
+)
+
+
+def _module_scope_import_names(tree: ast.Module):
+    for node in tree.body:  # top-level only -- do NOT recurse into functions
+        if isinstance(node, ast.Import):
+            for n in node.names:
+                yield n.name
+        elif isinstance(node, ast.ImportFrom):
+            yield node.module or ""
+
+
+def test_module_scope_imports_never_touch_db_network_broker():
+    tree = ast.parse(_SCRIPT.read_text())
+    for name in _module_scope_import_names(tree):
+        top = name.split(".")[0]
+        assert top not in _FORBIDDEN_PREFIXES, (
+            f"run_rob944_campaign.py imports {name!r} at MODULE SCOPE -- "
+            "--help/--version/plan must never touch DB/network/broker; move "
+            "this import inside the function that actually needs it"
+        )
+
+
+def test_app_imports_exist_but_only_inside_function_bodies():
+    """Sanity check the guard above isn't vacuous -- the script DOES use
+    app.* somewhere (deferred), proving the guard is exercising a real
+    boundary, not an absent one."""
+    tree = ast.parse(_SCRIPT.read_text())
+    found_deferred_app_import = False
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            for inner in ast.walk(node):
+                if (
+                    isinstance(inner, ast.ImportFrom)
+                    and inner.module
+                    and inner.module.startswith("app.")
+                ):
+                    found_deferred_app_import = True
+    assert found_deferred_app_import, "expected at least one deferred app.* import"

--- a/research/nautilus_scalping/tests/test_rob944_folds.py
+++ b/research/nautilus_scalping/tests/test_rob944_folds.py
@@ -1,0 +1,187 @@
+"""ROB-944 (H4, ROB-940) — rolling walk-forward fold schedule tests.
+
+Covers the RED/regression matrix item 1: exact one-year fold boundaries/count,
+120d/3h/28d/28d half-open schedule, last-incomplete-fold exclusion (never
+truncated), and minimum-six refusal.
+"""
+
+from __future__ import annotations
+
+import pytest
+import rob941_frozen_scope as frozen
+from rob944_folds import (
+    EMBARGO_MS,
+    MIN_COMPLETE_FOLDS,
+    OOS_MS,
+    ROLL_MS,
+    TRAIN_MS,
+    Fold,
+    InsufficientFoldsError,
+    generate_fold_schedule,
+    generate_frozen_fold_schedule,
+)
+
+_DAY_MS = 86_400_000
+_HOUR_MS = 3_600_000
+
+
+def test_frozen_constants_match_the_approved_contract():
+    assert TRAIN_MS == 120 * _DAY_MS
+    assert EMBARGO_MS == 3 * _HOUR_MS
+    assert OOS_MS == 28 * _DAY_MS
+    assert ROLL_MS == 28 * _DAY_MS
+    assert MIN_COMPLETE_FOLDS == 6
+
+
+def test_frozen_one_year_window_yields_exactly_eight_complete_folds():
+    folds = generate_frozen_fold_schedule(frozen.WINDOW_START_MS, frozen.WINDOW_END_MS)
+    assert len(folds) == 8
+
+
+def test_frozen_window_fold_boundaries_pinned_exactly():
+    folds = generate_frozen_fold_schedule(frozen.WINDOW_START_MS, frozen.WINDOW_END_MS)
+    expected = [
+        (0, 1751328000000, 1761696000000, 1761706800000, 1764126000000),
+        (1, 1753747200000, 1764115200000, 1764126000000, 1766545200000),
+        (2, 1756166400000, 1766534400000, 1766545200000, 1768964400000),
+        (3, 1758585600000, 1768953600000, 1768964400000, 1771383600000),
+        (4, 1761004800000, 1771372800000, 1771383600000, 1773802800000),
+        (5, 1763424000000, 1773792000000, 1773802800000, 1776222000000),
+        (6, 1765843200000, 1776211200000, 1776222000000, 1778641200000),
+        (7, 1768262400000, 1778630400000, 1778641200000, 1781060400000),
+    ]
+    for fold, (idx, train_start, train_end, oos_start, oos_end) in zip(
+        folds, expected, strict=True
+    ):
+        assert fold.fold_index == idx
+        assert fold.train_start_ms == train_start
+        assert fold.train_end_ms == train_end
+        assert fold.embargo_start_ms == train_end
+        assert fold.embargo_end_ms == oos_start
+        assert fold.oos_start_ms == oos_start
+        assert fold.oos_end_ms == oos_end
+
+
+def test_embargo_is_exactly_three_hours_half_open_train_end_to_oos_start():
+    folds = generate_frozen_fold_schedule(frozen.WINDOW_START_MS, frozen.WINDOW_END_MS)
+    for fold in folds:
+        assert fold.embargo_end_ms - fold.embargo_start_ms == 3 * _HOUR_MS
+        assert fold.embargo_start_ms == fold.train_end_ms
+        assert fold.embargo_end_ms == fold.oos_start_ms
+
+
+def test_last_incomplete_fold_is_excluded_never_truncated():
+    # The would-be 9th fold's own oos_end (train_start rolled by 8*ROLL_MS,
+    # then a full train+embargo+oos span) sits a fixed distance past the
+    # frozen window's end -- independently derived here, not assumed to be
+    # exactly one ROLL_MS. Extending the window by one ms LESS than that
+    # distance must still exclude the 9th fold WHOLE (never truncated);
+    # extending by exactly that distance must admit it fully.
+    ninth_fold_train_start = frozen.WINDOW_START_MS + 8 * ROLL_MS
+    ninth_fold_oos_end = ninth_fold_train_start + TRAIN_MS + EMBARGO_MS + OOS_MS
+    margin_needed = ninth_fold_oos_end - frozen.WINDOW_END_MS
+    assert margin_needed > 0
+
+    folds = generate_fold_schedule(
+        frozen.WINDOW_START_MS,
+        frozen.WINDOW_END_MS + margin_needed - 1,
+    )
+    assert len(folds) == 8  # NOT a 9th fold with a truncated oos_end
+    for fold in folds:
+        assert fold.oos_end_ms <= frozen.WINDOW_END_MS + margin_needed - 1
+
+    folds_with_ninth = generate_fold_schedule(
+        frozen.WINDOW_START_MS, frozen.WINDOW_END_MS + margin_needed
+    )
+    assert len(folds_with_ninth) == 9
+    assert folds_with_ninth[8].oos_end_ms == ninth_fold_oos_end
+
+
+def test_fewer_than_six_complete_folds_is_rejected():
+    # A window barely wide enough for exactly 6 folds minus one roll period.
+    six_fold_span = TRAIN_MS + EMBARGO_MS + OOS_MS + 5 * ROLL_MS
+    with pytest.raises(InsufficientFoldsError):
+        generate_fold_schedule(0, six_fold_span - 1)
+
+
+def test_exactly_six_complete_folds_is_accepted():
+    six_fold_span = TRAIN_MS + EMBARGO_MS + OOS_MS + 5 * ROLL_MS
+    folds = generate_fold_schedule(0, six_fold_span)
+    assert len(folds) == 6
+
+
+def test_no_two_folds_oos_windows_overlap():
+    folds = generate_frozen_fold_schedule(frozen.WINDOW_START_MS, frozen.WINDOW_END_MS)
+    for prev, cur in zip(folds, folds[1:], strict=False):
+        assert prev.oos_end_ms <= cur.oos_start_ms
+
+
+def test_overlapping_oos_windows_from_a_too_short_roll_are_rejected():
+    # roll_ms < oos_ms would make consecutive OOS windows overlap -- must
+    # fail closed rather than silently emit overlapping folds.
+    with pytest.raises(ValueError):
+        generate_fold_schedule(
+            0,
+            TRAIN_MS + EMBARGO_MS + OOS_MS + 6 * (OOS_MS // 2),
+            roll_ms=OOS_MS // 2,
+        )
+
+
+def test_fold_construction_rejects_non_monotonic_boundaries():
+    with pytest.raises(ValueError):
+        Fold(
+            fold_id="bad",
+            fold_index=0,
+            train_start_ms=100,
+            train_end_ms=50,  # train_end before train_start
+            embargo_start_ms=50,
+            embargo_end_ms=60,
+            oos_start_ms=60,
+            oos_end_ms=70,
+        )
+
+
+def test_fold_construction_rejects_embargo_start_not_matching_train_end():
+    with pytest.raises(ValueError):
+        Fold(
+            fold_id="bad",
+            fold_index=0,
+            train_start_ms=0,
+            train_end_ms=100,
+            embargo_start_ms=101,  # must equal train_end_ms
+            embargo_end_ms=200,
+            oos_start_ms=200,
+            oos_end_ms=300,
+        )
+
+
+def test_fold_construction_rejects_oos_start_not_matching_embargo_end():
+    with pytest.raises(ValueError):
+        Fold(
+            fold_id="bad",
+            fold_index=0,
+            train_start_ms=0,
+            train_end_ms=100,
+            embargo_start_ms=100,
+            embargo_end_ms=200,
+            oos_start_ms=201,  # must equal embargo_end_ms
+            oos_end_ms=300,
+        )
+
+
+def test_non_positive_span_parameters_are_rejected():
+    with pytest.raises(ValueError):
+        generate_fold_schedule(0, 10**12, train_ms=0)
+    with pytest.raises(ValueError):
+        generate_fold_schedule(0, 10**12, embargo_ms=-1)
+    with pytest.raises(ValueError):
+        generate_fold_schedule(0, 10**12, oos_ms=0)
+    with pytest.raises(ValueError):
+        generate_fold_schedule(0, 10**12, roll_ms=0)
+
+
+def test_window_end_not_after_window_start_is_rejected():
+    with pytest.raises(ValueError):
+        generate_fold_schedule(100, 100)
+    with pytest.raises(ValueError):
+        generate_fold_schedule(100, 50)

--- a/research/nautilus_scalping/tests/test_rob944_frozen_campaign.py
+++ b/research/nautilus_scalping/tests/test_rob944_frozen_campaign.py
@@ -1,0 +1,793 @@
+"""ROB-944 (H4, ROB-940) — acyclic full-campaign identity envelope tests.
+
+Q4 (orch-fable-answer-rob944-20260717.md, final): acyclic envelope -- freeze
+components/hashes first, build the 24 H6 specs from them, build ONE top-level
+envelope, hash it ONCE; the final hash is never fed back into its own inputs.
+Covers RED/regression matrix item 10: pure --plan determinism + every frozen
+subtree changing the hash when mutated, plus captain-audit item 3 (deep-copy
+sealing against post-build mutation of shared/injected dicts).
+"""
+
+from __future__ import annotations
+
+import pytest
+import rob941_frozen_scope as frozen
+import rob944_folds as foldmod
+import rob946_campaign_identity as identity
+from rob944_frozen_campaign import (
+    CANONICAL_ROW_ORDER,
+    H1_MANIFEST_EXPECTED_CONTENT_HASH,
+    H3_MANIFEST_EXPECTED_HASH,
+    PRODUCTION_S1_STRATEGY_KEY,
+    PRODUCTION_S1_STRATEGY_VERSION,
+    PRODUCTION_S2_STRATEGY_KEY,
+    PRODUCTION_S2_STRATEGY_VERSION,
+    SCENARIO_EXECUTION_SEMANTICS,
+    FrozenCampaignEnvelope,
+    FrozenCampaignError,
+    RowContentTamperError,
+    RowOrderError,
+    _assert_row_matches_frozen_h3_manifest,
+    build_frozen_campaign_envelope,
+    build_production_campaign_config_rows,
+    build_production_frozen_campaign_envelope,
+    build_production_strategy_sources,
+    load_production_dataset_manifest,
+)
+
+_FAKE_HASH = "ab" * 32
+
+
+def _fake_source(key, version, text):
+    return identity.StrategySourceProvenance(
+        strategy_key=key, strategy_version=version, source_text=text
+    )
+
+
+def _fake_rows():
+    """Captain boundary correction (2026-07-17): H4 owns exactly ONE frozen
+    production envelope, not a generic fake-row generator (that already
+    exists as H6's ``rob946_campaign_identity``) -- ``build_frozen_campaign_envelope``
+    now verifies EVERY row's params/hypothesis against the frozen H3 manifest
+    before building specs/IDs, so these "fake" fixtures use the REAL frozen
+    24 rows. Only genuinely swappable, non-row components (sources, dataset
+    manifest, execution-code files) remain injectable fakes below."""
+    return build_production_campaign_config_rows()
+
+
+def _synthetic_rows_bypassing_content_check():
+    """The OLD synthetic-param row generator -- kept only for the row-ORDER/
+    membership tests (missing/duplicate/13th/tampered-id), which must fail
+    on config_id shape/order alone, before content verification even runs."""
+    rows = []
+    for i in range(12):
+        rows.append(
+            identity.CampaignConfigRow(
+                config_id=f"S1-{i:02d}", params={"L": 16 + i}, hypothesis=f"s1-{i}"
+            )
+        )
+    for i in range(12):
+        rows.append(
+            identity.CampaignConfigRow(
+                config_id=f"S2-{i:02d}", params={"z_min": 3.0 + i}, hypothesis=f"s2-{i}"
+            )
+        )
+    return rows
+
+
+def _fake_dataset_manifest():
+    return {"symbols": ["BTCUSDT"], "rows": 100}
+
+
+def _fake_sources():
+    return {
+        "S1": _fake_source("FAKE-S1", "v1", "def s1(): ..."),
+        "S2": _fake_source("FAKE-S2", "v2", "def s2(): ..."),
+    }
+
+
+def _fake_fold_schedule():
+    return foldmod.generate_fold_schedule(
+        0,
+        foldmod.TRAIN_MS + foldmod.EMBARGO_MS + foldmod.OOS_MS + 5 * foldmod.ROLL_MS,
+    )
+
+
+def _build_fake_envelope(dataset_manifest=None, signal_hash=_FAKE_HASH):
+    dataset_manifest = dataset_manifest or _fake_dataset_manifest()
+    dm_hash = identity.canonical_hash.canonical_sha256(dataset_manifest)
+    return build_frozen_campaign_envelope(
+        config_rows=_fake_rows(),
+        sources=_fake_sources(),
+        dataset_manifest=dataset_manifest,
+        dataset_manifest_expected_hash=dm_hash,
+        fold_schedule=_fake_fold_schedule(),
+        signal_manifest_hash_value=signal_hash,
+        expected_signal_manifest_hash=signal_hash,
+    )
+
+
+# ---------------------------------------------------------------------------
+# builder mechanics
+# ---------------------------------------------------------------------------
+
+
+def test_build_frozen_campaign_envelope_produces_stable_deterministic_hash():
+    env1 = _build_fake_envelope()
+    env2 = _build_fake_envelope()
+    assert env1.full_campaign_hash() == env2.full_campaign_hash()
+    assert len(env1.full_campaign_hash()) == 64
+
+
+def test_builder_rejects_stale_signal_manifest_hash_pin():
+    with pytest.raises(FrozenCampaignError):
+        build_frozen_campaign_envelope(
+            config_rows=_fake_rows(),
+            sources=_fake_sources(),
+            dataset_manifest=_fake_dataset_manifest(),
+            dataset_manifest_expected_hash=identity.canonical_hash.canonical_sha256(
+                _fake_dataset_manifest()
+            ),
+            fold_schedule=_fake_fold_schedule(),
+            signal_manifest_hash_value="stale-actual-value",
+            expected_signal_manifest_hash="pinned-expected-value",
+        )
+
+
+def test_builder_rejects_stale_dataset_manifest_hash_pin():
+    with pytest.raises(identity.DatasetManifestHashMismatchError):
+        build_frozen_campaign_envelope(
+            config_rows=_fake_rows(),
+            sources=_fake_sources(),
+            dataset_manifest=_fake_dataset_manifest(),
+            dataset_manifest_expected_hash="0" * 64,  # wrong on purpose
+            fold_schedule=_fake_fold_schedule(),
+            signal_manifest_hash_value=_FAKE_HASH,
+            expected_signal_manifest_hash=_FAKE_HASH,
+        )
+
+
+def test_builder_seals_dataset_manifest_against_post_build_mutation():
+    """Captain audit item 3: mutating the CALLER's own dataset_manifest dict
+    after the envelope was built must NOT change subsequent hash calls --
+    the envelope must have deep-copied at construction, not aliased."""
+    dataset_manifest = _fake_dataset_manifest()
+    env = _build_fake_envelope(dataset_manifest=dataset_manifest)
+    hash_before = env.full_campaign_hash()
+
+    dataset_manifest["rows"] = 999999  # mutate the ORIGINAL caller-owned dict
+    dataset_manifest["symbols"].append("MUTATED")
+
+    hash_after = env.full_campaign_hash()
+    assert hash_before == hash_after  # the envelope's own copy is unaffected
+
+    # A genuinely NEW envelope built from the mutated dict DOES differ --
+    # proving the sealing test above isn't accidentally insensitive.
+    new_dm_hash = identity.canonical_hash.canonical_sha256(dataset_manifest)
+    new_env = build_frozen_campaign_envelope(
+        config_rows=_fake_rows(),
+        sources=_fake_sources(),
+        dataset_manifest=dataset_manifest,
+        dataset_manifest_expected_hash=new_dm_hash,
+        fold_schedule=_fake_fold_schedule(),
+        signal_manifest_hash_value=_FAKE_HASH,
+        expected_signal_manifest_hash=_FAKE_HASH,
+    )
+    assert new_env.full_campaign_hash() != hash_before
+
+
+# ---------------------------------------------------------------------------
+# Q4 addendum (captain, 2026-07-17): the acyclic envelope must contain the
+# exact ordered 24 experiment IDs as an explicit, hashed component --
+# component hashes -> IDs -> top payload/hash, never a cyclic dependency.
+# ---------------------------------------------------------------------------
+
+
+def test_envelope_carries_exactly_24_unique_experiment_ids_in_row_order():
+    env = _build_fake_envelope()
+    plain = env.to_dict()
+    ids = plain["experiment_ids"]
+    assert len(ids) == 24
+    assert len(set(ids)) == 24
+    # Order/membership contract: index-for-index correspondence with rows,
+    # independently re-derived here via the SAME research_contracts authority
+    # (not merely trusting the envelope's own internal computation).
+    for row, exp_id in zip(plain["rows"], ids, strict=True):
+        hashes = identity.canonical_hash.compute_identity_hashes(row["components"])
+        expected = identity.canonical_hash.derive_experiment_id(
+            row["strategy_key"], row["strategy_version"], hashes
+        )
+        assert exp_id == expected
+
+
+def test_experiment_ids_are_derived_before_the_top_level_hash_not_fed_back_into_it():
+    """The IDs are a pure function of already-frozen components (never of
+    full_campaign_hash itself) -- two envelopes built from identical inputs
+    must derive byte-identical experiment_ids AND byte-identical
+    full_campaign_hash, with no circularity between the two."""
+    env_a = _build_fake_envelope()
+    env_b = _build_fake_envelope()
+    assert env_a.to_dict()["experiment_ids"] == env_b.to_dict()["experiment_ids"]
+    assert env_a.full_campaign_hash() == env_b.full_campaign_hash()
+
+
+def _envelope_kwargs_for(rows):
+    dataset_manifest = _fake_dataset_manifest()
+    dm_hash = identity.canonical_hash.canonical_sha256(dataset_manifest)
+    return {
+        "config_rows": rows,
+        "sources": _fake_sources(),
+        "dataset_manifest": dataset_manifest,
+        "dataset_manifest_expected_hash": dm_hash,
+        "fold_schedule": _fake_fold_schedule(),
+        "signal_manifest_hash_value": _FAKE_HASH,
+        "expected_signal_manifest_hash": _FAKE_HASH,
+    }
+
+
+def test_canonical_row_order_constant_is_s1_00_to_11_then_s2_00_to_11():
+    assert CANONICAL_ROW_ORDER == (
+        *(f"S1-{i:02d}" for i in range(12)),
+        *(f"S2-{i:02d}" for i in range(12)),
+    )
+
+
+def test_reordered_rows_fail_closed_instead_of_silently_reordering_ids():
+    """Prompt RED #4: exact ordered H3 membership -- reorder (a swap here)
+    must be REJECTED, not silently accepted with a merely-different
+    experiment_ids order/top hash."""
+    rows = _synthetic_rows_bypassing_content_check()
+    reordered = [rows[1], rows[0], *rows[2:]]
+    with pytest.raises(RowOrderError):
+        build_frozen_campaign_envelope(**_envelope_kwargs_for(reordered))
+
+
+def test_missing_row_fails_closed():
+    rows = _synthetic_rows_bypassing_content_check()[
+        :-1
+    ]  # 23 rows -- last S2 config missing
+    with pytest.raises((RowOrderError, identity.CampaignIdentityError)):
+        build_frozen_campaign_envelope(**_envelope_kwargs_for(rows))
+
+
+def test_duplicate_row_fails_closed():
+    rows = _synthetic_rows_bypassing_content_check()[:-1]
+    rows.append(rows[0])  # duplicate S1-00 instead of the missing S2-11
+    with pytest.raises((RowOrderError, identity.CampaignIdentityError)):
+        build_frozen_campaign_envelope(**_envelope_kwargs_for(rows))
+
+
+def test_a_13th_extra_row_fails_closed():
+    rows = _synthetic_rows_bypassing_content_check()
+    rows.append(
+        identity.CampaignConfigRow(
+            config_id="S1-12", params={"L": 99}, hypothesis="extra"
+        )
+    )
+    with pytest.raises((RowOrderError, identity.CampaignIdentityError)):
+        build_frozen_campaign_envelope(**_envelope_kwargs_for(rows))
+
+
+def test_tampered_config_id_fails_closed():
+    rows = _synthetic_rows_bypassing_content_check()
+    rows[0] = identity.CampaignConfigRow(
+        config_id="S1-TAMPERED", params=rows[0].params, hypothesis=rows[0].hypothesis
+    )
+    with pytest.raises((RowOrderError, identity.CampaignIdentityError)):
+        build_frozen_campaign_envelope(**_envelope_kwargs_for(rows))
+
+
+# ---------------------------------------------------------------------------
+# captain exact-membership addendum (2026-07-17): row ORDER alone is not
+# enough -- a same-domain param swap or altered hypothesis under an
+# otherwise-correct config_id must fail closed too. These exercise the
+# production-scoped content-verification helper directly (never the generic
+# build_frozen_campaign_envelope, which legitimately accepts fake test rows).
+# ---------------------------------------------------------------------------
+
+
+def test_production_rows_pass_their_own_content_self_check():
+    for row in build_production_campaign_config_rows():
+        _assert_row_matches_frozen_h3_manifest(row)  # must not raise
+
+
+def test_s1_param_swap_with_correct_config_id_fails_closed():
+    rows = build_production_campaign_config_rows()
+    real = rows[0]
+    assert real.config_id == "S1-00"
+    tampered = identity.CampaignConfigRow(
+        config_id=real.config_id,
+        params={**real.params, "k_SL": real.params["k_SL"] + 0.5},  # in-domain swap
+        hypothesis=real.hypothesis,
+    )
+    with pytest.raises(RowContentTamperError):
+        _assert_row_matches_frozen_h3_manifest(tampered)
+
+
+def test_s1_hypothesis_tamper_with_correct_config_id_and_params_fails_closed():
+    rows = build_production_campaign_config_rows()
+    real = rows[0]
+    tampered = identity.CampaignConfigRow(
+        config_id=real.config_id,
+        params=real.params,
+        hypothesis="a tampered hypothesis",
+    )
+    with pytest.raises(RowContentTamperError):
+        _assert_row_matches_frozen_h3_manifest(tampered)
+
+
+def test_s2_param_swap_with_correct_config_id_fails_closed():
+    rows = build_production_campaign_config_rows()
+    real = next(r for r in rows if r.config_id == "S2-00")
+    tampered = identity.CampaignConfigRow(
+        config_id=real.config_id,
+        params={**real.params, "z_min": real.params["z_min"] + 1.0},
+        hypothesis=real.hypothesis,
+    )
+    with pytest.raises(RowContentTamperError):
+        _assert_row_matches_frozen_h3_manifest(tampered)
+
+
+def test_s2_hypothesis_tamper_with_correct_config_id_and_params_fails_closed():
+    rows = build_production_campaign_config_rows()
+    real = next(r for r in rows if r.config_id == "S2-00")
+    tampered = identity.CampaignConfigRow(
+        config_id=real.config_id,
+        params=real.params,
+        hypothesis="a tampered hypothesis",
+    )
+    with pytest.raises(RowContentTamperError):
+        _assert_row_matches_frozen_h3_manifest(tampered)
+
+
+def test_build_frozen_campaign_envelope_rejects_param_tamper_at_the_boundary():
+    """Captain BLOCKER (2026-07-17): directly unit-testing the content-check
+    helper is insufficient/vacuous on its own -- build_frozen_campaign_envelope
+    ITSELF must call it, over every config_rows entry, before any
+    spec/experiment_id is built. This exercises the real boundary: a
+    same-domain param swap riding under a correct, correctly-ordered S1-00
+    must be rejected by the builder, not merely by a helper nobody calls."""
+    rows = list(build_production_campaign_config_rows())
+    real = rows[0]
+    assert real.config_id == "S1-00"
+    rows[0] = identity.CampaignConfigRow(
+        config_id=real.config_id,
+        params={**real.params, "k_SL": real.params["k_SL"] + 0.5},
+        hypothesis=real.hypothesis,
+    )
+    with pytest.raises(RowContentTamperError):
+        build_frozen_campaign_envelope(**_envelope_kwargs_for(rows))
+
+
+def test_build_frozen_campaign_envelope_rejects_hypothesis_tamper_at_the_boundary():
+    rows = list(build_production_campaign_config_rows())
+    real = rows[0]
+    rows[0] = identity.CampaignConfigRow(
+        config_id=real.config_id,
+        params=real.params,
+        hypothesis="a tampered hypothesis",
+    )
+    with pytest.raises(RowContentTamperError):
+        build_frozen_campaign_envelope(**_envelope_kwargs_for(rows))
+
+
+def test_build_frozen_campaign_envelope_accepts_the_real_untampered_24_rows():
+    """The positive control for the two tests above -- the boundary check
+    must not be a false-positive trap that rejects legitimate production
+    rows too."""
+    env = build_frozen_campaign_envelope(
+        **_envelope_kwargs_for(build_production_campaign_config_rows())
+    )
+    assert len(env.to_dict()["rows"]) == 24
+
+
+def test_production_config_rows_are_in_the_exact_canonical_order():
+    """Production plan assertion: the real frozen 24 rows must already
+    satisfy the canonical order contract -- build_production_frozen_campaign_envelope
+    must never itself trip the RowOrderError guard."""
+    rows = build_production_campaign_config_rows()
+    assert tuple(r.config_id for r in rows) == CANONICAL_ROW_ORDER
+    env = build_production_frozen_campaign_envelope()
+    assert tuple(r["strategy_key"] for r in env.to_dict()["rows"][:12]) == (
+        (PRODUCTION_S1_STRATEGY_KEY,) * 12
+    )
+    assert tuple(r["strategy_key"] for r in env.to_dict()["rows"][12:]) == (
+        (PRODUCTION_S2_STRATEGY_KEY,) * 12
+    )
+
+
+def test_builder_seals_mutable_row_components_against_post_build_mutation():
+    rows = _fake_rows()
+    env = _build_fake_envelope()
+    hash_before = env.full_campaign_hash()
+    rows[0].params["L"] = -99999  # mutate a CampaignConfigRow's params dict
+    assert env.full_campaign_hash() == hash_before  # envelope already deep-copied
+
+
+def test_to_dict_returned_structure_mutation_does_not_leak_back():
+    env = _build_fake_envelope()
+    hash_before = env.full_campaign_hash()
+    payload = env.to_dict()
+    payload["rows"][0]["components"]["params"]["L"] = -1
+    payload["universe"].append("MUTATED")
+    assert env.full_campaign_hash() == hash_before
+
+
+# ---------------------------------------------------------------------------
+# frozen-lineage correction: @dataclass(frozen=True) only blocks attribute
+# REBINDING -- it does nothing to mutable dicts/lists living INSIDE those
+# attributes. Direct nested-field mutation on the envelope itself must
+# RAISE (never silently succeed and change a later full_campaign_hash()).
+# ---------------------------------------------------------------------------
+
+
+def test_direct_nested_dict_mutation_on_funding_pit_policy_raises():
+    env = _build_fake_envelope()
+    with pytest.raises(TypeError):
+        env.funding_pit_policy["entry_gate"] = {}
+    with pytest.raises(TypeError):
+        env.funding_pit_policy["max_expected_cost_bps"] = 999
+
+
+def test_direct_nested_dict_mutation_on_rows_components_raises():
+    env = _build_fake_envelope()
+    with pytest.raises(TypeError):
+        env.rows[0]["components"]["params"]["L"] = -1
+    with pytest.raises(TypeError):
+        env.rows[0]["components"]["params"] = {}
+
+
+def test_direct_nested_dict_mutation_on_h4_reason_contract_raises():
+    env = _build_fake_envelope()
+    with pytest.raises(TypeError):
+        env.h4_reason_contract["selection"]["min_symbol_train_trades"] = 999
+
+
+def test_direct_nested_mutation_attempts_never_change_the_hash():
+    """Even setting aside whether mutation raises, the hash itself must be
+    provably unaffected -- attempt every mutation inside a try/except and
+    confirm the hash is identical before and after each attempt."""
+    env = _build_fake_envelope()
+    hash_before = env.full_campaign_hash()
+
+    def _try(fn):
+        try:
+            fn()
+        except (TypeError, AttributeError):
+            pass
+
+    def _set(mapping, key, value):
+        mapping[key] = value
+
+    _try(lambda: _set(env.funding_pit_policy, "max_expected_cost_bps", 999))
+    _try(lambda: _set(env.rows[0]["components"]["params"], "L", -1))
+    _try(lambda: _set(env.h3_fixed_constants, "ATR_PERIOD", -1))
+    _try(lambda: _set(env.posture, "historical_screen_only", False))
+    _try(lambda: _set(env.data_gap_policy, "reject_reason", "tampered"))
+    _try(lambda: _set(env.execution_code_provenance, "x", "y"))
+    _try(lambda: _set(env.fold_schedule[0], "fold_id", "tampered"))
+
+    assert env.full_campaign_hash() == hash_before
+
+
+def test_direct_construction_with_a_mutable_universe_list_is_sealed_too():
+    """Captain freeze-audit addendum (2026-07-17, item B): __post_init__
+    previously omitted ``universe`` from its freeze loop, so a caller passing
+    ``universe=[...]`` (a plain, mutable list) directly could ``.append()``
+    a fifth symbol post-construction and silently change a later
+    full_campaign_hash() call on the SAME object. universe must now be
+    normalized/sealed into an immutable tuple exactly like every other
+    nested field, regardless of whether the caller passed a list or tuple."""
+    kwargs = _base_kwargs()
+    kwargs["universe"] = list(frozen.UNIVERSE)  # deliberately a mutable list
+    env = FrozenCampaignEnvelope(**kwargs)
+    hash_before = env.full_campaign_hash()
+
+    with pytest.raises((TypeError, AttributeError)):
+        env.universe.append("MUTATED")
+    assert env.full_campaign_hash() == hash_before
+    assert env.universe == tuple(frozen.UNIVERSE)
+
+
+def test_frozen_envelope_constructed_directly_is_also_sealed():
+    """The seal is enforced by __post_init__, universally -- regardless of
+    whether the envelope was built via build_frozen_campaign_envelope or
+    constructed directly with plain (caller-owned, mutable) dicts."""
+    kwargs = _base_kwargs()
+    original_policy = kwargs["funding_pit_policy"]
+    env = FrozenCampaignEnvelope(**kwargs)
+    hash_before = env.full_campaign_hash()
+
+    # The CALLER's original dict is untouched by freezing (freeze copies).
+    original_policy["max_expected_cost_bps"] = 999
+    assert env.full_campaign_hash() == hash_before
+
+    # And the envelope's OWN field is immutable too.
+    with pytest.raises(TypeError):
+        env.funding_pit_policy["max_expected_cost_bps"] = 999
+
+
+# ---------------------------------------------------------------------------
+# every frozen subtree changes the hash (constructed directly, not via
+# the builder, to isolate the hash function itself)
+# ---------------------------------------------------------------------------
+
+
+def _base_kwargs():
+    return {
+        "schema_version": "v1",
+        "window_start_iso": frozen.WINDOW_START_ISO,
+        "window_end_iso": frozen.WINDOW_END_ISO,
+        "universe": frozen.UNIVERSE,
+        "dataset_manifest_hash": "a" * 64,
+        "signal_manifest_hash": "b" * 64,
+        "rows": ({"config_id": "S1-00"},),
+        "experiment_ids": (
+            "exp-0000000000000000000000000000000000000000000000000000000000000000",
+        ),
+        "fold_schedule": ({"fold_id": "fold-00"},),
+        "scenario_execution": "independent_run_with_fresh_state",
+        "funding_pit_policy": {"max_expected_cost_bps": 3.0},
+        "data_gap_policy": {"reject_reason": "rejected:data_gap_in_position"},
+        "posture": {"historical_screen_only": True},
+        "execution_code_provenance": {"rob940_engine.py": "e" * 64},
+        "h3_fixed_constants": {"ATR_PERIOD": 20},
+        "h4_reason_contract": {"min_symbol_train_trades": 5},
+    }
+
+
+@pytest.mark.parametrize(
+    "field,new_value",
+    [
+        ("schema_version", "v2"),
+        ("window_start_iso", "2020-01-01T00:00:00Z"),
+        ("window_end_iso", "2020-02-01T00:00:00Z"),
+        ("universe", ("BTCUSDT",)),
+        ("dataset_manifest_hash", "c" * 64),
+        ("signal_manifest_hash", "d" * 64),
+        ("rows", ({"config_id": "S1-99"},)),
+        (
+            "experiment_ids",
+            ("exp-9999999999999999999999999999999999999999999999999999999999999999",),
+        ),
+        ("fold_schedule", ({"fold_id": "fold-99"},)),
+        ("scenario_execution", "shared_path_net_only_revaluation"),
+        ("funding_pit_policy", {"max_expected_cost_bps": 999.0}),
+        ("data_gap_policy", {"reject_reason": "something_else"}),
+        ("posture", {"historical_screen_only": False}),
+        ("execution_code_provenance", {"rob940_engine.py": "f" * 64}),
+        ("h3_fixed_constants", {"ATR_PERIOD": 21}),
+        ("h4_reason_contract", {"min_symbol_train_trades": 6}),
+    ],
+)
+def test_mutating_every_subtree_changes_the_full_campaign_hash(field, new_value):
+    base = FrozenCampaignEnvelope(**_base_kwargs())
+    mutated_kwargs = _base_kwargs()
+    mutated_kwargs[field] = new_value
+    mutated = FrozenCampaignEnvelope(**mutated_kwargs)
+    assert base.full_campaign_hash() != mutated.full_campaign_hash()
+
+
+def test_identical_envelopes_hash_identically():
+    a = FrozenCampaignEnvelope(**_base_kwargs())
+    b = FrozenCampaignEnvelope(**_base_kwargs())
+    assert a.full_campaign_hash() == b.full_campaign_hash()
+
+
+# ---------------------------------------------------------------------------
+# production wiring (real S1/S2 source, real committed H1 manifest fixture,
+# real frozen H3 24-row manifest, real frozen fold schedule)
+# ---------------------------------------------------------------------------
+
+
+def test_production_strategy_identifiers_are_frozen_fable_promoted_values():
+    assert PRODUCTION_S1_STRATEGY_KEY == "ROB940-S1-DONCHIAN-15M"
+    assert PRODUCTION_S1_STRATEGY_VERSION == "s1-v1"
+    assert PRODUCTION_S2_STRATEGY_KEY == "ROB940-S2-SHOCK-REVERSAL-5M"
+    assert PRODUCTION_S2_STRATEGY_VERSION == "s2-v1"
+
+
+def test_production_config_rows_are_exactly_the_frozen_24():
+    rows = build_production_campaign_config_rows()
+    ids = [r.config_id for r in rows]
+    assert len(ids) == 24
+    assert len(set(ids)) == 24
+
+
+def test_load_production_dataset_manifest_matches_pinned_h1_hash():
+    manifest = load_production_dataset_manifest()
+    actual = identity.canonical_hash.canonical_sha256(manifest)
+    assert actual == H1_MANIFEST_EXPECTED_CONTENT_HASH
+
+
+def test_production_strategy_sources_hash_from_actual_files_and_reject_stale_pin():
+    sources = build_production_strategy_sources()
+    s1_actual = sources["S1"].verified_source_sha256()
+    s2_actual = sources["S2"].verified_source_sha256()
+    assert s1_actual != s2_actual  # distinct sources (H6 §1 contract)
+    assert len(s1_actual) == 64
+
+    with pytest.raises(identity.StrategySourceMismatchError):
+        build_production_strategy_sources(expected_s1_source_sha256="0" * 64)[
+            "S1"
+        ].verified_source_sha256()
+
+
+def test_build_production_frozen_campaign_envelope_is_deterministic_and_complete():
+    env1 = build_production_frozen_campaign_envelope()
+    env2 = build_production_frozen_campaign_envelope()
+    assert env1.full_campaign_hash() == env2.full_campaign_hash()
+    assert len(env1.rows) == 24
+    assert env1.signal_manifest_hash == H3_MANIFEST_EXPECTED_HASH
+    assert env1.dataset_manifest_hash == H1_MANIFEST_EXPECTED_CONTENT_HASH
+    assert env1.scenario_execution == SCENARIO_EXECUTION_SEMANTICS
+    assert len(env1.fold_schedule) == 8  # the pinned frozen-window fold count
+
+
+def test_build_production_frozen_campaign_envelope_rejects_tampered_signal_hash_pin():
+    with pytest.raises(FrozenCampaignError):
+        build_production_frozen_campaign_envelope(
+            expected_signal_manifest_hash="tampered" + H3_MANIFEST_EXPECTED_HASH[8:]
+        )
+
+
+# ---------------------------------------------------------------------------
+# captain audit supplement (2026-07-17): execution code provenance, H3 fixed
+# constants, H4 reason contract -- build_campaign_experiment_specs' per-row
+# "code" component only binds S1/S2 STRATEGY source, not the shared H2
+# execution engine or H4's own runner/controller/CLI, nor H3's fixed
+# (non-tunable) constants/spec-deviation text, nor H4's own reason/threshold
+# contract. These three components close that gap.
+# ---------------------------------------------------------------------------
+
+
+def test_execution_code_provenance_hashes_actual_current_file_bytes():
+    import hashlib
+
+    from rob944_frozen_campaign import (
+        EXECUTION_CODE_LOGICAL_FILES,
+        build_execution_code_provenance_component,
+    )
+
+    provenance = build_execution_code_provenance_component()
+    assert set(provenance) == {name for name, _path in EXECUTION_CODE_LOGICAL_FILES}
+    for name, path in EXECUTION_CODE_LOGICAL_FILES:
+        expected = hashlib.sha256(path.read_bytes()).hexdigest()
+        assert provenance[name] == expected, name
+
+
+def test_execution_code_provenance_is_injectable_and_sensitive_to_byte_content(
+    tmp_path,
+):
+    from rob944_frozen_campaign import build_execution_code_provenance_component
+
+    file_a = tmp_path / "some_module.py"
+    file_a.write_text("x = 1\n")
+    files = (("some_module.py", file_a),)
+    hash_a = build_execution_code_provenance_component(files=files)["some_module.py"]
+
+    file_a.write_text("x = 2\n")  # different byte content
+    hash_b = build_execution_code_provenance_component(files=files)["some_module.py"]
+    assert hash_a != hash_b
+
+
+def test_execution_code_provenance_uses_stable_logical_names_not_absolute_paths():
+    """Logical names may include a relative subdirectory prefix (e.g.
+    ``app/services/...``) to disambiguate across directories, but must never
+    be an ABSOLUTE filesystem path -- the resulting hash must not depend on
+    where the repo happens to be checked out."""
+    from rob944_frozen_campaign import build_execution_code_provenance_component
+
+    provenance = build_execution_code_provenance_component()
+    for name in provenance:
+        assert not name.startswith("/")
+        assert ":" not in name  # no Windows drive letters either
+
+
+def test_h3_fixed_constants_component_matches_actual_frozen_signal_constants():
+    from rob940_signal_manifest import FrozenSignalConstants
+    from rob940_signal_s2 import SPEC_DEVIATIONS
+    from rob944_frozen_campaign import build_h3_fixed_constants_component
+
+    component = build_h3_fixed_constants_component()
+    assert component["frozen_signal_constants"] == dict(FrozenSignalConstants._asdict())
+    assert tuple(component["s2_spec_deviations"]) == SPEC_DEVIATIONS
+    assert (
+        component["s2_target_direction_invalid_reason_code"]
+        == "target_direction_invalid"
+    )
+
+
+def test_h4_reason_contract_component_matches_actual_constants():
+    from rob944_frozen_campaign import build_h4_reason_contract_component
+    from rob944_gap_funding import (
+        FUNDING_ENTRY_GATE_MAX_EXPECTED_COST_BPS,
+        REASON_DATA_GAP_IN_POSITION,
+        REASON_EXPECTED_FUNDING_COST_ABOVE_3BPS,
+        REASON_FUNDING_EVIDENCE_UNAVAILABLE,
+    )
+    from rob944_selection import (
+        INSUFFICIENT_ELIGIBLE_SYMBOLS_REASON,
+        INSUFFICIENT_SYMBOL_EVIDENCE_REASON,
+        MIN_ELIGIBLE_SYMBOLS,
+        MIN_SYMBOL_TRAIN_TRADES,
+    )
+
+    component = build_h4_reason_contract_component()
+    assert component["selection"]["min_symbol_train_trades"] == MIN_SYMBOL_TRAIN_TRADES
+    assert component["selection"]["min_eligible_symbols"] == MIN_ELIGIBLE_SYMBOLS
+    assert (
+        component["selection"]["insufficient_symbol_evidence_reason"]
+        == INSUFFICIENT_SYMBOL_EVIDENCE_REASON
+    )
+    assert (
+        component["selection"]["insufficient_eligible_symbols_reason"]
+        == INSUFFICIENT_ELIGIBLE_SYMBOLS_REASON
+    )
+    assert (
+        component["funding_gate"]["max_expected_cost_bps"]
+        == FUNDING_ENTRY_GATE_MAX_EXPECTED_COST_BPS
+    )
+    assert (
+        component["funding_gate"]["evidence_unavailable_reason"]
+        == REASON_FUNDING_EVIDENCE_UNAVAILABLE
+    )
+    assert (
+        component["funding_gate"]["expected_cost_above_max_reason"]
+        == REASON_EXPECTED_FUNDING_COST_ABOVE_3BPS
+    )
+    assert component["data_gap_reason"] == REASON_DATA_GAP_IN_POSITION
+
+
+def test_production_envelope_includes_all_three_new_components_populated():
+    env = build_production_frozen_campaign_envelope()
+    assert len(env.execution_code_provenance) > 0
+    assert all(len(v) == 64 for v in env.execution_code_provenance.values())
+    assert env.h3_fixed_constants["frozen_signal_constants"]["ATR_PERIOD"] == 20
+    assert env.h4_reason_contract["selection"]["min_symbol_train_trades"] == 5
+
+
+def test_production_envelope_hash_changes_if_execution_code_base_dir_differs(tmp_path):
+    """Proves the envelope's hash is genuinely sensitive to the execution
+    code's actual bytes -- swap in a base_dir with DIFFERENT file content
+    for the same logical names and confirm the hash moves."""
+    from rob944_frozen_campaign import EXECUTION_CODE_LOGICAL_FILES
+
+    alt_dir = tmp_path
+    for name, _real_path in EXECUTION_CODE_LOGICAL_FILES:
+        target = alt_dir / name
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(f"# stand-in content for {name}\n")
+
+    env_real = build_production_frozen_campaign_envelope()
+    env_alt = build_production_frozen_campaign_envelope(execution_code_base_dir=alt_dir)
+    assert env_real.full_campaign_hash() != env_alt.full_campaign_hash()
+
+
+def test_build_production_strategy_sources_verified_sha_equals_raw_bytes_sha():
+    """Captain config/plan audit (2026-07-18, item B): each H6-verified
+    source SHA-256 must equal ``hashlib.sha256(path.read_bytes()).hexdigest()``
+    exactly -- proving ``read_bytes().decode("utf-8")`` is a lossless
+    round-trip for these committed source files (no universal-newline
+    translation silently altering what actually gets hashed, unlike
+    ``Path.read_text()``)."""
+    import hashlib
+
+    from rob944_frozen_campaign import (
+        _S1_SOURCE_PATH,
+        _S2_SOURCE_PATH,
+        build_production_strategy_sources,
+    )
+
+    sources = build_production_strategy_sources()
+    assert (
+        sources["S1"].verified_source_sha256()
+        == hashlib.sha256(_S1_SOURCE_PATH.read_bytes()).hexdigest()
+    )
+    assert (
+        sources["S2"].verified_source_sha256()
+        == hashlib.sha256(_S2_SOURCE_PATH.read_bytes()).hexdigest()
+    )
+    assert (
+        sources["S1"].verified_source_sha256() != sources["S2"].verified_source_sha256()
+    )

--- a/research/nautilus_scalping/tests/test_rob944_gap_funding.py
+++ b/research/nautilus_scalping/tests/test_rob944_gap_funding.py
@@ -1,0 +1,285 @@
+"""ROB-944 (H4, ROB-940) — data-gap-in-position rejection + funding PIT entry
+gate tests.
+
+Q2/Q3 (orch-fable-answer-rob944-20260717.md, final): H1's half-open
+``[entry, exit)`` position window is authoritative; the entry funding gate
+uses ONLY the last-known rate/interval before entry (no lookahead), rejects
+only when the SIGNED expected cost is strictly greater than 3.0bp (exactly
+3.0bp remains eligible), and reports ``funding_evidence_unavailable`` /
+``expected_funding_cost_above_3bps`` as separate, stable reason codes.
+"""
+
+from __future__ import annotations
+
+from funding_oi_archive import FundingRow
+from rob940_engine import TradeRecord
+from rob941_funding_sidecar import FundingSidecar
+from rob944_gap_funding import (
+    FUNDING_ENTRY_GATE_MAX_EXPECTED_COST_BPS,
+    REASON_DATA_GAP_IN_POSITION,
+    REASON_EXPECTED_FUNDING_COST_ABOVE_3BPS,
+    REASON_FUNDING_EVIDENCE_UNAVAILABLE,
+    build_funding_lookup,
+    evaluate_funding_entry_gate,
+    is_trade_gap_in_position,
+)
+
+_HOUR_MS = 3_600_000
+
+
+def _trade(entry_ts=10_000, exit_ts=20_000):
+    return TradeRecord(
+        strategy="S1",
+        config_id="S1-00",
+        symbol="BTCUSDT",
+        side="long",
+        signal_ts=entry_ts,
+        entry_ts=entry_ts,
+        entry_price=100.0,
+        exit_ts=exit_ts,
+        exit_price=101.0,
+        exit_reason="take_profit",
+        gross_bps=100.0,
+        fee_bps=10.0,
+        all_in_bps=17.0,
+        funding_bps=0.0,
+        net_bps=90.0,
+        fold_id="fold-00",
+    )
+
+
+# ---------------------------------------------------------------------------
+# data-gap-in-position
+# ---------------------------------------------------------------------------
+
+
+def test_trade_with_no_gap_overlap_is_not_flagged():
+    trade = _trade(entry_ts=10_000, exit_ts=20_000)
+    assert is_trade_gap_in_position(trade, [(30_000, 40_000)]) is False
+
+
+def test_trade_whose_window_overlaps_a_gap_is_flagged():
+    trade = _trade(entry_ts=10_000, exit_ts=20_000)
+    assert is_trade_gap_in_position(trade, [(15_000, 16_000)]) is True
+
+
+def test_trade_gap_reason_constant_is_stable():
+    assert REASON_DATA_GAP_IN_POSITION == "rejected:data_gap_in_position"
+
+
+# ---------------------------------------------------------------------------
+# funding PIT entry gate
+# ---------------------------------------------------------------------------
+
+
+def test_funding_gate_constant_is_frozen_at_3_bps():
+    assert FUNDING_ENTRY_GATE_MAX_EXPECTED_COST_BPS == 3.0
+
+
+def test_no_known_rate_before_entry_fails_closed_as_evidence_unavailable():
+    sidecar = FundingSidecar.from_rows(
+        "BTCUSDT",
+        [
+            FundingRow(
+                calc_time=50_000, funding_interval_hours=8, last_funding_rate=0.0001
+            )
+        ],
+    )
+    result = evaluate_funding_entry_gate(
+        sidecar, side="long", entry_ts_ms=10_000, max_hold_ms=8 * _HOUR_MS
+    )
+    assert result.passed is False
+    assert result.rejection_reason == REASON_FUNDING_EVIDENCE_UNAVAILABLE
+    assert result.expected_cost_bps is None
+
+
+def test_nan_last_funding_rate_fails_closed_not_fail_open():
+    """Captain correction: round(nan, 8) > 3.0 is False in Python, so a bare
+    arithmetic check would silently PASS a NaN rate (fail-open). The gate
+    must explicitly reject non-finite rates as funding_evidence_unavailable."""
+    entry_ts = 0
+    sidecar = FundingSidecar.from_rows(
+        "BTCUSDT",
+        [
+            FundingRow(
+                calc_time=entry_ts,
+                funding_interval_hours=8,
+                last_funding_rate=float("nan"),
+            )
+        ],
+    )
+    result = evaluate_funding_entry_gate(
+        sidecar, side="long", entry_ts_ms=entry_ts, max_hold_ms=8 * _HOUR_MS
+    )
+    assert result.passed is False
+    assert result.rejection_reason == REASON_FUNDING_EVIDENCE_UNAVAILABLE
+    assert result.expected_cost_bps is None
+
+
+def test_positive_infinity_last_funding_rate_fails_closed():
+    entry_ts = 0
+    sidecar = FundingSidecar.from_rows(
+        "BTCUSDT",
+        [
+            FundingRow(
+                calc_time=entry_ts,
+                funding_interval_hours=8,
+                last_funding_rate=float("inf"),
+            )
+        ],
+    )
+    result = evaluate_funding_entry_gate(
+        sidecar, side="long", entry_ts_ms=entry_ts, max_hold_ms=8 * _HOUR_MS
+    )
+    assert result.passed is False
+    assert result.rejection_reason == REASON_FUNDING_EVIDENCE_UNAVAILABLE
+
+
+def test_negative_infinity_last_funding_rate_fails_closed():
+    entry_ts = 0
+    sidecar = FundingSidecar.from_rows(
+        "BTCUSDT",
+        [
+            FundingRow(
+                calc_time=entry_ts,
+                funding_interval_hours=8,
+                last_funding_rate=float("-inf"),
+            )
+        ],
+    )
+    result = evaluate_funding_entry_gate(
+        sidecar, side="long", entry_ts_ms=entry_ts, max_hold_ms=8 * _HOUR_MS
+    )
+    assert result.passed is False
+    assert result.rejection_reason == REASON_FUNDING_EVIDENCE_UNAVAILABLE
+
+
+def test_no_relevant_crossing_before_deadline_passes_with_zero_expected_cost():
+    entry_ts = 0
+    sidecar = FundingSidecar.from_rows(
+        "BTCUSDT",
+        [
+            FundingRow(
+                calc_time=entry_ts - 1000,
+                funding_interval_hours=8,
+                last_funding_rate=0.01,
+            )
+        ],
+    )
+    # max_hold shorter than time to next crossing (8h away) -> not relevant.
+    result = evaluate_funding_entry_gate(
+        sidecar, side="long", entry_ts_ms=entry_ts, max_hold_ms=1 * _HOUR_MS
+    )
+    assert result.passed is True
+    assert result.rejection_reason is None
+    assert result.expected_cost_bps == 0.0
+
+
+def test_expected_cost_exactly_3bps_remains_eligible_inclusive_boundary():
+    entry_ts = 0
+    # rate 0.0003 -> 0.0003*1e4 = 3.0bp signed cost for longs (positive rate).
+    sidecar = FundingSidecar.from_rows(
+        "BTCUSDT",
+        [
+            FundingRow(
+                calc_time=entry_ts, funding_interval_hours=8, last_funding_rate=0.0003
+            )
+        ],
+    )
+    result = evaluate_funding_entry_gate(
+        sidecar, side="long", entry_ts_ms=entry_ts, max_hold_ms=8 * _HOUR_MS
+    )
+    assert result.passed is True
+    assert result.rejection_reason is None
+    assert result.expected_cost_bps == 3.0
+
+
+def test_expected_cost_above_3bps_for_long_is_rejected():
+    entry_ts = 0
+    sidecar = FundingSidecar.from_rows(
+        "BTCUSDT",
+        [
+            FundingRow(
+                calc_time=entry_ts, funding_interval_hours=8, last_funding_rate=0.0004
+            )
+        ],
+    )
+    result = evaluate_funding_entry_gate(
+        sidecar, side="long", entry_ts_ms=entry_ts, max_hold_ms=8 * _HOUR_MS
+    )
+    assert result.passed is False
+    assert result.rejection_reason == REASON_EXPECTED_FUNDING_COST_ABOVE_3BPS
+    assert result.expected_cost_bps == 4.0
+
+
+def test_negative_signed_cost_ie_a_credit_never_rejects_regardless_of_magnitude():
+    """The gate compares the SIGNED expected cost, not its magnitude -- a
+    position expected to RECEIVE funding (a credit) must never be rejected,
+    however large the credit is."""
+    entry_ts = 0
+    sidecar = FundingSidecar.from_rows(
+        "BTCUSDT",
+        [
+            FundingRow(
+                calc_time=entry_ts, funding_interval_hours=8, last_funding_rate=0.01
+            )
+        ],
+    )
+    # short side flips sign: positive rate -> shorts RECEIVE -> negative signed cost.
+    result = evaluate_funding_entry_gate(
+        sidecar, side="short", entry_ts_ms=entry_ts, max_hold_ms=8 * _HOUR_MS
+    )
+    assert result.passed is True
+    assert result.expected_cost_bps == -100.0
+
+
+def test_gate_uses_only_last_known_rate_no_lookahead():
+    """A LATER rate change already present in the sidecar (after entry_ts)
+    must NOT influence the entry gate's decision -- only the rate known
+    at/before entry_ts is consulted."""
+    entry_ts = 100_000
+    sidecar = FundingSidecar.from_rows(
+        "BTCUSDT",
+        [
+            FundingRow(
+                calc_time=90_000, funding_interval_hours=8, last_funding_rate=0.0001
+            ),
+            # A future, much larger rate becomes known AFTER entry_ts.
+            FundingRow(
+                calc_time=200_000, funding_interval_hours=8, last_funding_rate=0.05
+            ),
+        ],
+    )
+    result = evaluate_funding_entry_gate(
+        sidecar, side="long", entry_ts_ms=entry_ts, max_hold_ms=1 * _HOUR_MS
+    )
+    # Only the 0.0001 row (known at/before entry_ts) may be consulted; the
+    # 0.05 future row must never leak into this decision.
+    assert result.expected_cost_bps != 0.05 * 1e4
+    assert result.passed is True  # next crossing (8h away) is beyond the 1h max hold
+
+
+def test_build_funding_lookup_delegates_to_h1_half_open_window_without_reinterpretation():
+    sidecar = FundingSidecar.from_rows(
+        "BTCUSDT",
+        [
+            FundingRow(
+                calc_time=10_000, funding_interval_hours=8, last_funding_rate=0.0001
+            ),  # at entry: included
+            FundingRow(
+                calc_time=20_000, funding_interval_hours=8, last_funding_rate=0.0002
+            ),  # at exit: excluded
+            FundingRow(
+                calc_time=15_000, funding_interval_hours=8, last_funding_rate=0.0003
+            ),  # strictly inside: included
+        ],
+    )
+    lookup = build_funding_lookup({"BTCUSDT": sidecar})
+    crossings = lookup("BTCUSDT", "long", 10_000, 20_000)
+    assert {c.ts for c in crossings} == {10_000, 15_000}
+    assert 20_000 not in {c.ts for c in crossings}
+
+
+def test_build_funding_lookup_returns_empty_for_unknown_symbol():
+    lookup = build_funding_lookup({})
+    assert lookup("BTCUSDT", "long", 10_000, 20_000) == ()

--- a/research/nautilus_scalping/tests/test_rob944_import_guard.py
+++ b/research/nautilus_scalping/tests/test_rob944_import_guard.py
@@ -1,0 +1,123 @@
+"""ROB-944 (H4, ROB-940) — AC import-boundary guard for the pure H4 modules.
+
+Mirrors ``test_rob940_import_guard.py``/``test_rob943_signal_import_guard.py``'s
+pattern: a pure H4 module either imports only stdlib + the allowed
+research-local names, or this test fails. ``run_rob944_campaign.py`` (the
+CLI) is intentionally NOT covered here -- its ``app.*`` imports are all
+deferred inside function bodies (see ``test_rob944_cli_import_guard.py``,
+which checks its module-scope imports only).
+"""
+
+import ast
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parents[1]
+_MODULES = [
+    "rob944_folds.py",
+    "rob944_selection.py",
+    "rob944_signal_ordering.py",
+    "rob944_gap_funding.py",
+    "rob944_scenario_evidence.py",
+    "rob944_walkforward.py",
+    "rob944_frozen_campaign.py",
+]
+
+_FORBIDDEN_PREFIXES = (
+    "app",
+    "sqlalchemy",
+    "asyncpg",
+    "psycopg",
+    "psycopg2",
+    "alembic",
+    "redis",
+    "taskiq",
+    "celery",
+    "httpx",
+    "requests",
+    "aiohttp",
+    "urllib3",
+    "urllib",
+    "socket",
+    "websockets",
+    "boto3",
+    "fastapi",
+    "uvicorn",
+)
+
+_ALLOWED = {
+    "__future__",
+    "collections.abc",
+    "copy",
+    "dataclasses",
+    "datetime",
+    "hashlib",
+    "math",
+    "pathlib",
+    "statistics",
+    "types",
+    "typing",
+    "research_contracts.canonical_hash",
+    "canonical_hash",
+    "funding_oi_archive",
+    "rob940_bars_agg",
+    "rob940_cost_model",
+    "rob940_engine",
+    "rob940_signal_manifest",
+    "rob940_signal_s1",
+    "rob940_signal_s2",
+    "rob941_frozen_scope",
+    "rob941_funding_sidecar",
+    "rob941_gaps",
+    "rob941_manifest",
+    "rob944_folds",
+    "rob944_gap_funding",
+    "rob944_scenario_evidence",
+    "rob944_selection",
+    "rob944_signal_ordering",
+    "rob944_walkforward",
+    "rob946_campaign_identity",
+}
+
+
+def _imports(path: Path):
+    tree = ast.parse(path.read_text())
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for n in node.names:
+                yield n.name
+        elif isinstance(node, ast.ImportFrom):
+            yield node.module or ""
+
+
+def test_no_forbidden_db_network_app_broker_order_fill_scheduler_imports():
+    for mod in _MODULES:
+        for name in _imports(_ROOT / mod):
+            top = name.split(".")[0]
+            assert top not in _FORBIDDEN_PREFIXES, (
+                f"{mod} imports forbidden module {name!r} (no DB/network/"
+                "app-settings/broker/order/fill/scheduler imports)"
+            )
+
+
+def test_only_allowlisted_modules_are_imported():
+    for mod in _MODULES:
+        for name in _imports(_ROOT / mod):
+            assert name in _ALLOWED, f"{mod} imports non-allowlisted module {name!r}"
+
+
+def test_no_random_or_dynamic_import_bypass():
+    forbidden_names = {"random", "time", "importlib", "__import__", "eval", "exec"}
+    for mod in _MODULES:
+        tree = ast.parse((_ROOT / mod).read_text())
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Name) and node.id in forbidden_names:
+                raise AssertionError(f"{mod} references forbidden name {node.id!r}")
+            if isinstance(node, (ast.Import, ast.ImportFrom)):
+                names = (
+                    [node.module]
+                    if isinstance(node, ast.ImportFrom)
+                    else [n.name for n in node.names]
+                )
+                for name in names:
+                    if name and name.split(".")[0] in ("random", "time", "importlib"):
+                        raise AssertionError(f"{mod} imports forbidden module {name!r}")

--- a/research/nautilus_scalping/tests/test_rob944_scenario_evidence.py
+++ b/research/nautilus_scalping/tests/test_rob944_scenario_evidence.py
@@ -1,0 +1,215 @@
+"""ROB-944 (H4, ROB-940) — H4-owned scenario terminal-evidence contract tests.
+
+Captain audit supplement (2026-07-17): ``rob940_engine.ledger_hash`` hashes
+ONLY the trade ledger -- it must never stand in as the full scenario
+artifact hash, because two runs with equally-empty trade ledgers but
+DIFFERENT no-trade reasons must still hash differently. This module's
+``scenario_artifact_hash`` binds identity + status + trades + the full
+no-trade reason histogram.
+"""
+
+from __future__ import annotations
+
+import pytest
+from rob940_engine import EngineResult, NoTradeRecord, TradeRecord
+from rob944_scenario_evidence import (
+    ScenarioRunOutcome,
+    no_trade_reason_counts,
+    scenario_artifact_hash,
+    scenario_run_outcome_from_engine_result,
+)
+
+_IDENTITY = {
+    "strategy": "S1",
+    "config_id": "S1-00",
+    "symbol": "BTCUSDT",
+    "fold_id": "fold-00",
+    "scenario_name": "primary_stress",
+}
+
+
+def _no_trade(reason, signal_ts=1):
+    return NoTradeRecord(
+        strategy="S1",
+        config_id="S1-00",
+        symbol="BTCUSDT",
+        side="long",
+        signal_ts=signal_ts,
+        reason=reason,
+    )
+
+
+def _trade(net_bps=10.0, entry_ts=1000, exit_ts=2000):
+    return TradeRecord(
+        strategy="S1",
+        config_id="S1-00",
+        symbol="BTCUSDT",
+        side="long",
+        signal_ts=entry_ts,
+        entry_ts=entry_ts,
+        entry_price=100.0,
+        exit_ts=exit_ts,
+        exit_price=101.0,
+        exit_reason="take_profit",
+        gross_bps=100.0,
+        fee_bps=10.0,
+        all_in_bps=17.0,
+        funding_bps=0.0,
+        net_bps=net_bps,
+        fold_id="fold-00",
+    )
+
+
+def test_two_empty_ledgers_with_different_no_trade_reasons_hash_differently():
+    result_a = EngineResult(trades=(), no_trades=(_no_trade("daily_stop_active"),))
+    result_b = EngineResult(trades=(), no_trades=(_no_trade("tp_below_min_distance"),))
+    hash_a = scenario_artifact_hash(result_a, **_IDENTITY)
+    hash_b = scenario_artifact_hash(result_b, **_IDENTITY)
+    assert hash_a != hash_b
+
+
+def test_two_empty_ledgers_with_identical_no_trade_reasons_hash_identically():
+    result_a = EngineResult(trades=(), no_trades=(_no_trade("daily_stop_active", 1),))
+    result_b = EngineResult(trades=(), no_trades=(_no_trade("daily_stop_active", 2),))
+    # Different signal_ts but same reason histogram shape is intentionally
+    # NOT distinguished by this identity-level hash (it summarizes reason
+    # counts, not full no-trade record contents) -- documented behavior.
+    hash_a = scenario_artifact_hash(result_a, **_IDENTITY)
+    hash_b = scenario_artifact_hash(result_b, **_IDENTITY)
+    assert hash_a == hash_b
+
+
+def test_hash_changes_when_trade_ledger_differs():
+    result_a = EngineResult(trades=(_trade(net_bps=10.0),), no_trades=())
+    result_b = EngineResult(trades=(_trade(net_bps=20.0),), no_trades=())
+    assert scenario_artifact_hash(result_a, **_IDENTITY) != scenario_artifact_hash(
+        result_b, **_IDENTITY
+    )
+
+
+def test_hash_changes_when_scenario_identity_differs():
+    result = EngineResult(trades=(), no_trades=())
+    base_hash = scenario_artifact_hash(result, **_IDENTITY)
+    other = dict(_IDENTITY, scenario_name="base")
+    assert scenario_artifact_hash(result, **other) != base_hash
+
+
+def test_hash_is_not_h2s_bare_ledger_hash():
+    from rob940_engine import ledger_hash
+
+    result = EngineResult(trades=(), no_trades=(_no_trade("daily_stop_active"),))
+    assert scenario_artifact_hash(result, **_IDENTITY) != ledger_hash(result.trades)
+
+
+def test_scenario_run_outcome_from_engine_result_is_completed_with_required_fields():
+    result = EngineResult(trades=(_trade(),), no_trades=())
+    outcome = scenario_run_outcome_from_engine_result(result, **_IDENTITY)
+    assert outcome.status == "completed"
+    assert outcome.trade_count == 1
+    assert isinstance(outcome.artifact_hash, str) and len(outcome.artifact_hash) == 64
+    assert outcome.error_reason is None
+
+
+def test_scenario_run_outcome_rejects_unknown_scenario_name():
+    with pytest.raises(ValueError):
+        ScenarioRunOutcome(
+            scenario_name="not_a_real_scenario",
+            status="completed",
+            trade_count=0,
+            artifact_hash="a" * 64,
+        )
+
+
+def test_scenario_run_outcome_rejects_negative_trade_count():
+    with pytest.raises(ValueError):
+        ScenarioRunOutcome(
+            scenario_name="base",
+            status="completed",
+            trade_count=-1,
+            artifact_hash="a" * 64,
+        )
+
+
+def test_scenario_run_outcome_requires_error_reason_for_non_completed_status():
+    with pytest.raises(ValueError):
+        ScenarioRunOutcome(
+            scenario_name="base",
+            status="crashed",
+            trade_count=0,
+            artifact_hash="a" * 64,
+            error_reason=None,
+        )
+    # With a reason, it is accepted.
+    outcome = ScenarioRunOutcome(
+        scenario_name="base",
+        status="crashed",
+        trade_count=0,
+        artifact_hash="a" * 64,
+        error_reason="engine raised ValueError",
+    )
+    assert outcome.status == "crashed"
+
+
+def test_scenario_run_outcome_accepts_rejected_status_with_reason():
+    outcome = ScenarioRunOutcome(
+        scenario_name="base",
+        status="rejected",
+        trade_count=0,
+        artifact_hash="a" * 64,
+        error_reason="rejected:data_gap_in_position",
+    )
+    assert outcome.status == "rejected"
+
+
+# ---------------------------------------------------------------------------
+# Captain Q3-enforcement correction: no_trade_reason_counts is REPORT
+# EXPOSURE, not merely hash-committed -- funding_evidence_unavailable and
+# expected_funding_cost_above_3bps (and every other no-trade reason) must
+# remain separately countable, not hidden behind a SHA-256 digest.
+# ---------------------------------------------------------------------------
+
+
+def test_no_trade_reason_counts_exposes_the_same_histogram_the_hash_commits_to():
+    result = EngineResult(
+        trades=(),
+        no_trades=(
+            _no_trade("funding_evidence_unavailable", 1),
+            _no_trade("funding_evidence_unavailable", 2),
+            _no_trade("expected_funding_cost_above_3bps", 3),
+        ),
+    )
+    counts = no_trade_reason_counts(result)
+    assert counts == {
+        "funding_evidence_unavailable": 2,
+        "expected_funding_cost_above_3bps": 1,
+    }
+
+
+def test_scenario_run_outcome_from_engine_result_exposes_no_trade_reason_counts():
+    result = EngineResult(
+        trades=(_trade(),),
+        no_trades=(
+            _no_trade("funding_evidence_unavailable", 1),
+            _no_trade("expected_funding_cost_above_3bps", 2),
+        ),
+    )
+    outcome = scenario_run_outcome_from_engine_result(result, **_IDENTITY)
+    assert outcome.no_trade_reason_counts == {
+        "funding_evidence_unavailable": 1,
+        "expected_funding_cost_above_3bps": 1,
+    }
+    # Both distinct funding reasons remain separately countable -- neither
+    # collapses into the other nor disappears behind the artifact hash.
+    assert outcome.no_trade_reason_counts["funding_evidence_unavailable"] == 1
+    assert outcome.no_trade_reason_counts["expected_funding_cost_above_3bps"] == 1
+
+
+def test_scenario_run_outcome_default_no_trade_reason_counts_is_empty_dict():
+    outcome = ScenarioRunOutcome(
+        scenario_name="base",
+        status="crashed",
+        trade_count=0,
+        artifact_hash="a" * 64,
+        error_reason="child_execution_crashed",
+    )
+    assert outcome.no_trade_reason_counts == {}

--- a/research/nautilus_scalping/tests/test_rob944_selection.py
+++ b/research/nautilus_scalping/tests/test_rob944_selection.py
@@ -1,0 +1,288 @@
+"""ROB-944 (H4, ROB-940) — fold train-selection authority tests.
+
+Selection authority (orch-fable-answer-strategy-20260717.md, final): eligible-
+symbol EQUAL-WEIGHT MEAN of per-symbol TRAIN net expectancy (bps/trade) at
+the independent 17bp primary-stress run is the ONLY selection/pass authority.
+Trade-level POOLED expectancy is report-only and must never rank candidates.
+Symbols with <5 completed train trades are excluded
+(``insufficient_symbol_evidence``); a config with <2 eligible symbols is
+``rejected:insufficient_train_evidence``. Tie-break: profit factor, then
+canonical config_id ascending.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+from rob944_selection import (
+    INSUFFICIENT_ELIGIBLE_SYMBOLS_REASON,
+    INSUFFICIENT_SYMBOL_EVIDENCE_REASON,
+    MIN_ELIGIBLE_SYMBOLS,
+    MIN_SYMBOL_TRAIN_TRADES,
+    ConfigTrainCandidate,
+    SymbolTrainEvidence,
+    evaluate_config_candidate,
+    select_fold_config,
+)
+
+
+def _ev(symbol, trades, expectancy, profit=None, loss=None, train_artifact_hash=None):
+    if profit is None and loss is None:
+        profit = max(expectancy, 0.0) * trades
+        loss = max(-expectancy, 0.0) * trades
+    if train_artifact_hash is None:
+        train_artifact_hash = f"artifact-{symbol}-{trades}-{expectancy}"
+    return SymbolTrainEvidence(
+        symbol=symbol,
+        completed_trades=trades,
+        net_expectancy_bps=expectancy,
+        gross_profit_bps=profit,
+        gross_loss_bps=loss,
+        train_artifact_hash=train_artifact_hash,
+    )
+
+
+def _twelve_candidates(winner_id="S1-00", **overrides):
+    """12 uniquely-ided, trivially-eligible candidates; ``overrides`` maps
+    config_id -> tuple[SymbolTrainEvidence, ...] to replace the default."""
+    candidates = []
+    for i in range(12):
+        config_id = f"S1-{i:02d}"
+        if config_id in overrides:
+            evidence = overrides[config_id]
+        else:
+            evidence = (_ev("BTCUSDT", 10, 1.0), _ev("XRPUSDT", 10, 1.0))
+        candidates.append(
+            ConfigTrainCandidate(config_id=config_id, symbol_evidence=evidence)
+        )
+    return candidates
+
+
+def test_min_symbol_train_trades_and_min_eligible_symbols_constants():
+    assert MIN_SYMBOL_TRAIN_TRADES == 5
+    assert MIN_ELIGIBLE_SYMBOLS == 2
+
+
+def test_symbol_below_five_trades_is_excluded_as_insufficient_evidence():
+    candidate = ConfigTrainCandidate(
+        config_id="S1-00",
+        symbol_evidence=(
+            _ev("BTCUSDT", 4, 10.0),
+            _ev("XRPUSDT", 10, 5.0),
+            _ev("DOGEUSDT", 10, 5.0),
+        ),
+    )
+    outcome = evaluate_config_candidate(candidate)
+    assert outcome.rejected is False
+    assert "BTCUSDT" not in outcome.eligible_symbols
+    assert ("BTCUSDT", INSUFFICIENT_SYMBOL_EVIDENCE_REASON) in outcome.excluded_symbols
+    assert outcome.eligible_symbols == ("XRPUSDT", "DOGEUSDT")
+
+
+def test_exactly_five_trades_is_eligible_not_excluded():
+    candidate = ConfigTrainCandidate(
+        config_id="S1-00",
+        symbol_evidence=(_ev("BTCUSDT", 5, 10.0), _ev("XRPUSDT", 10, 5.0)),
+    )
+    outcome = evaluate_config_candidate(candidate)
+    assert outcome.excluded_symbols == ()
+    assert outcome.eligible_symbols == ("BTCUSDT", "XRPUSDT")
+
+
+def test_fewer_than_two_eligible_symbols_rejects_the_config():
+    candidate = ConfigTrainCandidate(
+        config_id="S1-00",
+        symbol_evidence=(
+            _ev("BTCUSDT", 4, 10.0),  # excluded
+            _ev("XRPUSDT", 10, 5.0),  # only 1 eligible symbol remains
+        ),
+    )
+    outcome = evaluate_config_candidate(candidate)
+    assert outcome.rejected is True
+    assert outcome.rejection_reason == INSUFFICIENT_ELIGIBLE_SYMBOLS_REASON
+    assert outcome.equal_weight_expectancy_bps is None
+
+
+def test_equal_weight_mean_is_unweighted_average_across_eligible_symbols():
+    candidate = ConfigTrainCandidate(
+        config_id="S1-00",
+        symbol_evidence=(
+            _ev("BTCUSDT", 1000, 10.0),
+            _ev("XRPUSDT", 5, -6.0),
+        ),
+    )
+    outcome = evaluate_config_candidate(candidate)
+    assert outcome.equal_weight_expectancy_bps == pytest.approx(2.0)  # (10 + -6) / 2
+
+
+def test_pooled_expectancy_is_report_only_never_the_selection_authority_RED_fixture():
+    """The decisive RED fixture (H4 prompt item 6): pooled and equal-weight
+    expectancy must rank two configs OPPOSITELY, and the equal-weight winner
+    must be the one selected -- pooled expectancy must never be consulted by
+    ``select_fold_config``.
+    """
+    # Config A: a high-volume symbol dominates pooled expectancy upward.
+    config_a = ConfigTrainCandidate(
+        config_id="S1-00",
+        symbol_evidence=(_ev("BTCUSDT", 100, 10.0), _ev("XRPUSDT", 5, -5.0)),
+    )
+    # Config B: both symbols equal, lower pooled number but higher equal-weight.
+    config_b = ConfigTrainCandidate(
+        config_id="S1-01",
+        symbol_evidence=(_ev("BTCUSDT", 100, 5.0), _ev("XRPUSDT", 5, 5.0)),
+    )
+    outcome_a = evaluate_config_candidate(config_a)
+    outcome_b = evaluate_config_candidate(config_b)
+
+    # Equal-weight: A = (10-5)/2 = 2.5 ; B = (5+5)/2 = 5.0 -> B wins.
+    assert outcome_a.equal_weight_expectancy_bps == pytest.approx(2.5)
+    assert outcome_b.equal_weight_expectancy_bps == pytest.approx(5.0)
+    assert outcome_b.equal_weight_expectancy_bps > outcome_a.equal_weight_expectancy_bps
+
+    # Pooled (trade-count-weighted, report-only): A = (100*10 + 5*-5)/105 ~= 9.29
+    # ; B = (100*5 + 5*5)/105 = 5.0 -> pooled would rank A ABOVE B (opposite order).
+    assert outcome_a.pooled_expectancy_bps == pytest.approx((1000 - 25) / 105)
+    assert outcome_b.pooled_expectancy_bps == pytest.approx(5.0)
+    assert outcome_a.pooled_expectancy_bps > outcome_b.pooled_expectancy_bps
+
+    candidates = _twelve_candidates(
+        **{"S1-00": config_a.symbol_evidence, "S1-01": config_b.symbol_evidence}
+    )
+    trace = select_fold_config("S1", candidates)
+    assert trace.selected_config_id == "S1-01"  # the EQUAL-WEIGHT winner, not pooled
+
+
+def test_tie_break_by_profit_factor_when_equal_weight_expectancy_ties():
+    evidence_high_pf = (
+        _ev("BTCUSDT", 10, 5.0, profit=100.0, loss=10.0),
+        _ev("XRPUSDT", 10, 5.0, profit=100.0, loss=10.0),
+    )
+    evidence_low_pf = (
+        _ev("BTCUSDT", 10, 5.0, profit=60.0, loss=50.0),
+        _ev("XRPUSDT", 10, 5.0, profit=60.0, loss=50.0),
+    )
+    candidates = _twelve_candidates(
+        **{"S1-00": evidence_low_pf, "S1-01": evidence_high_pf}
+    )
+    trace = select_fold_config("S1", candidates)
+    outcome_00 = next(o for o in trace.candidates if o.config_id == "S1-00")
+    outcome_01 = next(o for o in trace.candidates if o.config_id == "S1-01")
+    assert (
+        outcome_00.equal_weight_expectancy_bps == outcome_01.equal_weight_expectancy_bps
+    )
+    assert outcome_01.profit_factor > outcome_00.profit_factor
+    assert trace.selected_config_id == "S1-01"
+
+
+def test_tie_break_by_canonical_config_id_ascending_when_expectancy_and_pf_tie():
+    evidence = (_ev("BTCUSDT", 10, 5.0), _ev("XRPUSDT", 10, 5.0))
+    candidates = _twelve_candidates(**{"S1-07": evidence, "S1-03": evidence})
+    # Force every OTHER candidate to be worse so 03/07 are the true top-2 tie.
+    trace = select_fold_config("S1", candidates)
+    assert trace.selected_config_id == "S1-03"  # ascending config_id wins the tie
+
+
+def test_select_fold_config_rejects_wrong_candidate_count():
+    candidates = _twelve_candidates()[:11]
+    with pytest.raises(ValueError):
+        select_fold_config("S1", candidates)
+
+
+def test_select_fold_config_rejects_duplicate_config_id():
+    candidates = _twelve_candidates()
+    mutated = list(candidates[:-1]) + [
+        ConfigTrainCandidate(
+            config_id=candidates[0].config_id,  # duplicate of candidates[0]
+            symbol_evidence=candidates[0].symbol_evidence,
+        )
+    ]
+    with pytest.raises(ValueError):
+        select_fold_config("S1", mutated)
+
+
+def test_select_fold_config_rejects_a_13th_config():
+    candidates = _twelve_candidates() + [
+        ConfigTrainCandidate(
+            config_id="S1-12",
+            symbol_evidence=(_ev("BTCUSDT", 10, 1.0), _ev("XRPUSDT", 10, 1.0)),
+        )
+    ]
+    with pytest.raises(ValueError):
+        select_fold_config("S1", candidates)
+
+
+def test_symbol_evidence_rejects_non_finite_expectancy():
+    with pytest.raises(ValueError):
+        SymbolTrainEvidence(
+            symbol="BTCUSDT",
+            completed_trades=10,
+            net_expectancy_bps=math.nan,
+            gross_profit_bps=0.0,
+            gross_loss_bps=0.0,
+            train_artifact_hash="a" * 64,
+        )
+    with pytest.raises(ValueError):
+        SymbolTrainEvidence(
+            symbol="BTCUSDT",
+            completed_trades=10,
+            net_expectancy_bps=math.inf,
+            gross_profit_bps=0.0,
+            gross_loss_bps=0.0,
+            train_artifact_hash="a" * 64,
+        )
+
+
+def test_symbol_evidence_rejects_empty_train_artifact_hash():
+    with pytest.raises(ValueError):
+        SymbolTrainEvidence(
+            symbol="BTCUSDT",
+            completed_trades=10,
+            net_expectancy_bps=1.0,
+            gross_profit_bps=1.0,
+            gross_loss_bps=0.0,
+            train_artifact_hash="",
+        )
+
+
+def test_config_train_candidate_rejects_duplicate_symbol_evidence():
+    with pytest.raises(ValueError):
+        ConfigTrainCandidate(
+            config_id="S1-00",
+            symbol_evidence=(_ev("BTCUSDT", 10, 1.0), _ev("BTCUSDT", 10, 1.0)),
+        )
+
+
+def test_all_configs_rejected_yields_no_selection():
+    candidates = _twelve_candidates(
+        **{
+            f"S1-{i:02d}": (_ev("BTCUSDT", 1, 1.0),)  # only 1 eligible symbol
+            for i in range(12)
+        }
+    )
+    trace = select_fold_config("S1", candidates)
+    assert trace.selected_config_id is None
+    assert all(o.rejected for o in trace.candidates)
+
+
+def test_selection_trace_preserves_per_config_train_input_hash():
+    candidates = _twelve_candidates()
+    trace = select_fold_config("S1", candidates)
+    hashes = [o.train_input_hash for o in trace.candidates]
+    assert len(hashes) == 12
+    assert all(isinstance(h, str) and len(h) == 64 for h in hashes)
+    # Distinguishable inputs must NOT collide.
+    distinct_candidates = _twelve_candidates(
+        **{"S1-00": (_ev("BTCUSDT", 999, 42.0), _ev("XRPUSDT", 999, 42.0))}
+    )
+    distinct_trace = select_fold_config("S1", distinct_candidates)
+    assert (
+        distinct_trace.candidates[0].train_input_hash
+        != trace.candidates[0].train_input_hash
+    )
+
+
+def test_selection_trace_orders_candidates_by_input_order_not_by_score():
+    candidates = _twelve_candidates()
+    trace = select_fold_config("S1", candidates)
+    assert [o.config_id for o in trace.candidates] == [c.config_id for c in candidates]

--- a/research/nautilus_scalping/tests/test_rob944_signal_ordering.py
+++ b/research/nautilus_scalping/tests/test_rob944_signal_ordering.py
@@ -1,0 +1,93 @@
+"""ROB-944 (H4, ROB-940) — canonical signal ordering + duplicate-signal_ts guard.
+
+RED/regression matrix item 8: per-symbol/config duplicate signal_ts
+rejection, canonical signal ordering, stable ledger tie-break independent of
+input/dict/hash-set iteration order.
+"""
+
+from __future__ import annotations
+
+import pytest
+from rob940_engine import SignalEvent
+from rob944_signal_ordering import (
+    DuplicateSignalTimestampError,
+    assert_unique_signal_ts_per_symbol_config,
+    canonical_signal_sort_key,
+    sort_signals_canonically,
+)
+
+
+def _sig(
+    strategy="S1", config_id="S1-00", symbol="BTCUSDT", signal_ts=1000, side="long"
+):
+    return SignalEvent(
+        strategy=strategy,
+        config_id=config_id,
+        symbol=symbol,
+        signal_ts=signal_ts,
+        side=side,
+        sl_distance_bps=50.0,
+        tp_distance_bps=100.0,
+    )
+
+
+def test_duplicate_signal_ts_same_strategy_config_symbol_is_rejected():
+    signals = [_sig(signal_ts=1000), _sig(signal_ts=1000)]
+    with pytest.raises(DuplicateSignalTimestampError):
+        assert_unique_signal_ts_per_symbol_config(signals)
+
+
+def test_same_signal_ts_different_symbol_is_allowed():
+    signals = [
+        _sig(symbol="BTCUSDT", signal_ts=1000),
+        _sig(symbol="XRPUSDT", signal_ts=1000),
+    ]
+    assert_unique_signal_ts_per_symbol_config(signals)  # must not raise
+
+
+def test_same_signal_ts_different_config_is_allowed():
+    signals = [
+        _sig(config_id="S1-00", signal_ts=1000),
+        _sig(config_id="S1-01", signal_ts=1000),
+    ]
+    assert_unique_signal_ts_per_symbol_config(signals)  # must not raise
+
+
+def test_same_signal_ts_different_strategy_is_allowed():
+    signals = [_sig(strategy="S1", signal_ts=1000), _sig(strategy="S2", signal_ts=1000)]
+    assert_unique_signal_ts_per_symbol_config(signals)  # must not raise
+
+
+def test_canonical_sort_key_shape():
+    sig = _sig(strategy="S2", config_id="S2-03", symbol="XRPUSDT", signal_ts=42)
+    assert canonical_signal_sort_key(sig) == (42, "XRPUSDT", "S2-03", "S2")
+
+
+def test_sort_signals_canonically_is_independent_of_input_permutation():
+    a = _sig(symbol="BTCUSDT", signal_ts=3000)
+    b = _sig(symbol="XRPUSDT", signal_ts=1000)
+    c = _sig(symbol="DOGEUSDT", signal_ts=2000)
+    order1 = sort_signals_canonically([a, b, c])
+    order2 = sort_signals_canonically([c, a, b])
+    order3 = sort_signals_canonically([b, c, a])
+    assert order1 == order2 == order3
+    assert [s.signal_ts for s in order1] == [1000, 2000, 3000]
+
+
+def test_sort_signals_canonically_rejects_duplicates_before_sorting():
+    with pytest.raises(DuplicateSignalTimestampError):
+        sort_signals_canonically([_sig(signal_ts=1000), _sig(signal_ts=1000)])
+
+
+def test_sort_signals_canonically_breaks_same_ts_ties_by_symbol_then_config_then_strategy():
+    same_ts = [
+        _sig(strategy="S2", config_id="S2-00", symbol="XRPUSDT", signal_ts=500),
+        _sig(strategy="S1", config_id="S1-01", symbol="BTCUSDT", signal_ts=500),
+        _sig(strategy="S1", config_id="S1-00", symbol="BTCUSDT", signal_ts=500),
+    ]
+    ordered = sort_signals_canonically(same_ts)
+    assert [(s.symbol, s.config_id, s.strategy) for s in ordered] == [
+        ("BTCUSDT", "S1-00", "S1"),
+        ("BTCUSDT", "S1-01", "S1"),
+        ("XRPUSDT", "S2-00", "S2"),
+    ]

--- a/research/nautilus_scalping/tests/test_rob944_walkforward.py
+++ b/research/nautilus_scalping/tests/test_rob944_walkforward.py
@@ -1,0 +1,2353 @@
+"""ROB-944 (H4, ROB-940) — walk-forward runner mechanics tests.
+
+Uses small, fully-controlled synthetic bars/signals (not the real H3 signal
+math, which is already covered by test_rob940_signal_s1/s2.py) to exercise
+the walk-forward CONTRACT in isolation: train/OOS slicing (no leak), train-
+only selection (no reselection from OOS), canonical concatenation, child
+crash/timeout terminal evidence, gap-in-position reclassification, the
+funding entry gate wired in before H2, and per-config attempt accounting.
+
+Synthetic folds span several CALENDAR DAYS (not just minutes) so that each
+fold's TRAIN window can produce >= MIN_SYMBOL_TRAIN_TRADES (5) completed
+trades per symbol without hitting ``rob940_engine.DAILY_MAX_ENTRIES`` (3) --
+trades are placed 2-per-calendar-day across the zone's span.
+"""
+
+from __future__ import annotations
+
+import pytest
+import rob944_walkforward
+from rob940_cost_model import COST_SCENARIO_PRIMARY_STRESS, COST_SCENARIOS
+from rob940_engine import Bar1m, NoTradeRecord, SignalEvent
+from rob941_funding_sidecar import FundingSidecar
+from rob944_folds import Fold
+from rob944_walkforward import (
+    REASON_CHILD_EXECUTION_CRASHED,
+    REASON_CHILD_EXECUTION_TIMEOUT,
+    REASON_DATA_GAP_IN_POSITION,
+    ConfigSpec,
+    ForgedSignalError,
+    GeneratedSignalBatch,
+    MissingSymbolDataError,
+    _combine_static_and_signals,
+    _evaluate_fold_oos,
+    _evaluate_fold_train,
+    _json_safe_funding_rate,
+    _run_scenario,
+    _validate_generated_rejections,
+    run_walkforward,
+    summarize_config_attempts_for_h6,
+)
+
+_SYMBOLS = ("BTCUSDT", "XRPUSDT", "DOGEUSDT", "SOLUSDT")
+_DAY_MS = 86_400_000
+_HOUR_MS = 3_600_000
+
+
+def _bar(ts, price=100.0):
+    return Bar1m(ts=ts, open=price, high=price, low=price, close=price, volume=1.0)
+
+
+def _flat_bars(start_ms, end_ms, overrides: dict[int, float] | None = None):
+    overrides = overrides or {}
+    out = []
+    ts = start_ms
+    while ts < end_ms:
+        out.append(_bar(ts, overrides.get(ts, 100.0)))
+        ts += 60_000
+    return tuple(out)
+
+
+def _permissive_funding_sidecars():
+    from funding_oi_archive import FundingRow
+
+    return {
+        s: FundingSidecar.from_rows(
+            s,
+            [
+                FundingRow(
+                    calc_time=-10_000_000,
+                    funding_interval_hours=8,
+                    last_funding_rate=0.0,
+                )
+            ],
+        )
+        for s in _SYMBOLS
+    }
+
+
+def _no_gaps():
+    return dict.fromkeys(_SYMBOLS, ())
+
+
+# Two contiguous, non-overlapping folds spanning several calendar days: train
+# 3 days / embargo 3h / OOS 2 days / roll 2 days (test-only spans -- NOT the
+# frozen 120d/3h/28d/28d production contract, which is covered separately by
+# test_rob944_folds.py; only the mechanics under test here need these spans).
+_FOLD_0 = Fold(
+    fold_id="fold-00",
+    fold_index=0,
+    train_start_ms=0,
+    train_end_ms=3 * _DAY_MS,
+    embargo_start_ms=3 * _DAY_MS,
+    embargo_end_ms=3 * _DAY_MS + 3 * _HOUR_MS,
+    oos_start_ms=3 * _DAY_MS + 3 * _HOUR_MS,
+    oos_end_ms=3 * _DAY_MS + 3 * _HOUR_MS + 2 * _DAY_MS,
+)
+_ROLL_MS = 2 * _DAY_MS
+_FOLD_1 = Fold(
+    fold_id="fold-01",
+    fold_index=1,
+    train_start_ms=_ROLL_MS,
+    train_end_ms=_ROLL_MS + 3 * _DAY_MS,
+    embargo_start_ms=_ROLL_MS + 3 * _DAY_MS,
+    embargo_end_ms=_ROLL_MS + 3 * _DAY_MS + 3 * _HOUR_MS,
+    oos_start_ms=_ROLL_MS + 3 * _DAY_MS + 3 * _HOUR_MS,
+    oos_end_ms=_ROLL_MS + 3 * _DAY_MS + 3 * _HOUR_MS + 2 * _DAY_MS,
+)
+_WINDOW_END = _FOLD_1.oos_end_ms
+
+assert _FOLD_0.oos_end_ms == _FOLD_1.oos_start_ms  # contiguous, non-overlapping
+
+
+def _make_signal(
+    symbol,
+    signal_ts,
+    side="long",
+    config_id="S1-00",
+    fold_id=None,
+    sl=200.0,
+    tp=300.0,
+    timeout_bars=1,
+):
+    return SignalEvent(
+        strategy="S1",
+        config_id=config_id,
+        symbol=symbol,
+        signal_ts=signal_ts,
+        side=side,
+        sl_distance_bps=sl,
+        tp_distance_bps=tp,
+        timeout_bars=timeout_bars,
+        cooldown_bars=0,
+        fold_id=fold_id,
+    )
+
+
+def _entries_in_zone(zone_start_ms, zone_end_ms):
+    """Two entry timestamps per calendar day within ``[zone_start, zone_end)``
+    -- each entry needs its own bar plus a deadline bar one minute later, both
+    within the SAME calendar day (rob940_engine's daily-entry-cap/halt
+    accounting keys off the entry bar's own UTC date) and within the zone.
+    """
+    entries = []
+    day_start = (zone_start_ms // _DAY_MS) * _DAY_MS
+    while day_start < zone_end_ms:
+        day_end = day_start + _DAY_MS
+        iter_start = max(day_start, zone_start_ms)
+        window_end = min(day_end, zone_end_ms)
+        for offset in (0, 120_000):
+            entry_ts = iter_start + offset
+            deadline_ts = entry_ts + 60_000
+            if entry_ts < window_end and deadline_ts <= window_end:
+                entries.append(entry_ts)
+        day_start += _DAY_MS
+    return entries
+
+
+def _controlled_bars_and_generator(config_id, *, train_price, oos_price):
+    """Build a full flat bars_1m array (shared across all configs, since
+    market data isn't per-config) with 2 controlled entry/deadline trade
+    pairs per calendar day in EACH fold's train/oos zones (``train_price``
+    used for both folds' train zones, ``oos_price`` for both folds' oos
+    zones), and a matching generator that emits signals at those same
+    entries whenever they fall inside whatever bars_slice it's given.
+    """
+    zones = [
+        (_FOLD_0.train_start_ms, _FOLD_0.train_end_ms, train_price),
+        (_FOLD_0.oos_start_ms, _FOLD_0.oos_end_ms, oos_price),
+        (_FOLD_1.train_start_ms, _FOLD_1.train_end_ms, train_price),
+        (_FOLD_1.oos_start_ms, _FOLD_1.oos_end_ms, oos_price),
+    ]
+    overrides: dict[int, float] = {}
+    entry_set: set[int] = set()
+    for zone_start, zone_end, price in zones:
+        for entry_ts in _entries_in_zone(zone_start, zone_end):
+            overrides[entry_ts + 60_000] = price
+            entry_set.add(entry_ts)
+
+    bars_1m = {symbol: _flat_bars(0, _WINDOW_END, overrides) for symbol in _SYMBOLS}
+
+    def _gen(symbol, bars_slice, fold_id):
+        present = {b.ts for b in bars_slice}
+        return tuple(
+            _make_signal(symbol, ts, config_id=config_id, fold_id=fold_id)
+            for ts in sorted(entry_set)
+            if ts in present
+        )
+
+    return bars_1m, _gen
+
+
+def _twelve_configs(
+    winner_id,
+    *,
+    winner_train_price,
+    winner_oos_price,
+    loser_train_price=100.0,
+    loser_oos_price=100.0,
+):
+    """12 uniquely-ided ConfigSpecs; ``winner_id`` gets the caller-controlled
+    prices, every other config is flat (deadline price == entry price ==
+    100 -> every trade times out with zero gross move, net_bps is
+    cost-drag-negative but IDENTICAL and small for every flat config)."""
+    bars_by_config: dict[str, dict[str, tuple[Bar1m, ...]]] = {}
+    specs = []
+    for i in range(12):
+        cid = f"S1-{i:02d}"
+        if cid == winner_id:
+            bars, gen = _controlled_bars_and_generator(
+                cid, train_price=winner_train_price, oos_price=winner_oos_price
+            )
+        else:
+            bars, gen = _controlled_bars_and_generator(
+                cid, train_price=loser_train_price, oos_price=loser_oos_price
+            )
+        bars_by_config[cid] = bars
+        specs.append(ConfigSpec(config_id=cid, generate_signals=gen))
+    return specs, bars_by_config
+
+
+def test_train_and_oos_signal_generators_only_see_their_own_window_bars():
+    seen_windows: list[tuple[str, int, int]] = []
+
+    def _recording_gen(symbol, bars_slice, fold_id):
+        seen_windows.append((fold_id, bars_slice[0].ts, bars_slice[-1].ts))
+        return ()
+
+    specs = [
+        ConfigSpec(config_id=f"S1-{i:02d}", generate_signals=_recording_gen)
+        for i in range(12)
+    ]
+    bars_1m = {s: _flat_bars(0, _WINDOW_END) for s in _SYMBOLS}
+    run_walkforward(
+        strategy="S1",
+        configs=tuple(specs),
+        bars_1m=bars_1m,
+        funding_sidecars=_permissive_funding_sidecars(),
+        gap_ranges=_no_gaps(),
+        fold_schedule=(_FOLD_0, _FOLD_1),
+    )
+    for fold_id, first_ts, last_ts in seen_windows:
+        if fold_id == "fold-00":
+            in_train = (
+                first_ts >= _FOLD_0.train_start_ms and last_ts < _FOLD_0.train_end_ms
+            )
+            in_oos = first_ts >= _FOLD_0.oos_start_ms and last_ts < _FOLD_0.oos_end_ms
+            assert in_train or in_oos, (fold_id, first_ts, last_ts)
+        if fold_id == "fold-01":
+            in_train = (
+                first_ts >= _FOLD_1.train_start_ms and last_ts < _FOLD_1.train_end_ms
+            )
+            in_oos = first_ts >= _FOLD_1.oos_start_ms and last_ts < _FOLD_1.oos_end_ms
+            assert in_train or in_oos, (fold_id, first_ts, last_ts)
+        # never straddling the embargo of either fold.
+        assert not (_FOLD_0.embargo_start_ms <= first_ts < _FOLD_0.embargo_end_ms)
+        assert not (_FOLD_1.embargo_start_ms <= first_ts < _FOLD_1.embargo_end_ms)
+
+
+def test_selection_is_train_only_oos_reversal_does_not_change_the_winner():
+    """Config WINNER looks great on TRAIN and bad on OOS; config LOSER looks
+    bad on TRAIN and great on OOS. The fold must still select WINNER (train
+    evidence only) and then RUN winner's own (bad) OOS -- never reselect
+    based on the OOS numbers."""
+    specs = []
+    bars_by_config = {}
+    for i in range(12):
+        cid = f"S1-{i:02d}"
+        if cid == "S1-00":
+            bars, gen = _controlled_bars_and_generator(
+                cid, train_price=110.0, oos_price=90.0
+            )
+        elif cid == "S1-01":
+            bars, gen = _controlled_bars_and_generator(
+                cid, train_price=90.0, oos_price=110.0
+            )
+        else:
+            bars, gen = _controlled_bars_and_generator(
+                cid, train_price=100.0, oos_price=100.0
+            )
+        bars_by_config[cid] = bars
+        specs.append(ConfigSpec(config_id=cid, generate_signals=gen))
+
+    # Fake generators derive prices from their OWN closures (not from
+    # `bars_1m`'s content); the runner's `bars_1m` argument just needs to be
+    # long/minute-aligned enough for the loop -- use the winner's own bars.
+    result = run_walkforward(
+        strategy="S1",
+        configs=tuple(specs),
+        bars_1m=bars_by_config["S1-00"],
+        funding_sidecars=_permissive_funding_sidecars(),
+        gap_ranges=_no_gaps(),
+        fold_schedule=(_FOLD_0, _FOLD_1),
+    )
+    for fold_result in result.folds:
+        assert fold_result.selection_trace.selected_config_id == "S1-00"
+    primary_ledger = result.concatenated_oos_ledgers["primary_stress"]
+    assert primary_ledger  # WINNER's (bad) OOS still produced trades
+    assert all(t.config_id == "S1-00" for t in primary_ledger)
+
+
+def test_concatenated_oos_ledger_is_canonically_ordered_and_folds_never_overlap():
+    specs, bars_by_config = _twelve_configs(
+        "S1-00", winner_train_price=110.0, winner_oos_price=105.0
+    )
+    result = run_walkforward(
+        strategy="S1",
+        configs=tuple(specs),
+        bars_1m=bars_by_config["S1-00"],
+        funding_sidecars=_permissive_funding_sidecars(),
+        gap_ranges=_no_gaps(),
+        fold_schedule=(_FOLD_0, _FOLD_1),
+    )
+    ledger = result.concatenated_oos_ledgers["primary_stress"]
+    entry_ts_values = [t.entry_ts for t in ledger]
+    assert entry_ts_values == sorted(entry_ts_values)
+    fold00_entries = [t for t in ledger if t.entry_ts < _FOLD_1.oos_start_ms]
+    fold01_entries = [t for t in ledger if t.entry_ts >= _FOLD_1.oos_start_ms]
+    assert fold00_entries and fold01_entries
+    assert max(t.entry_ts for t in fold00_entries) < min(
+        t.entry_ts for t in fold01_entries
+    )
+
+
+def test_a_config_that_never_wins_any_fold_still_has_a_completed_attempt():
+    specs, bars_by_config = _twelve_configs(
+        "S1-00", winner_train_price=110.0, winner_oos_price=105.0
+    )
+    result = run_walkforward(
+        strategy="S1",
+        configs=tuple(specs),
+        bars_1m=bars_by_config["S1-00"],
+        funding_sidecars=_permissive_funding_sidecars(),
+        gap_ranges=_no_gaps(),
+        fold_schedule=(_FOLD_0, _FOLD_1),
+    )
+    loser_attempt = next(a for a in result.config_attempts if a.config_id == "S1-01")
+    assert loser_attempt.status == "completed"
+    assert loser_attempt.selected_in_folds == ()
+
+    winner_attempt = next(a for a in result.config_attempts if a.config_id == "S1-00")
+    assert winner_attempt.status == "completed"
+    assert winner_attempt.selected_in_folds == ("fold-00", "fold-01")
+
+
+def test_exactly_twelve_config_attempts_in_original_input_order():
+    specs, bars_by_config = _twelve_configs(
+        "S1-05", winner_train_price=110.0, winner_oos_price=105.0
+    )
+    result = run_walkforward(
+        strategy="S1",
+        configs=tuple(specs),
+        bars_1m=bars_by_config["S1-05"],
+        funding_sidecars=_permissive_funding_sidecars(),
+        gap_ranges=_no_gaps(),
+        fold_schedule=(_FOLD_0, _FOLD_1),
+    )
+    assert [a.config_id for a in result.config_attempts] == [
+        f"S1-{i:02d}" for i in range(12)
+    ]
+
+
+def test_child_generator_exception_produces_crashed_attempt_not_silent_skip():
+    def _raising_gen(symbol, bars_slice, fold_id):
+        raise RuntimeError("boom: synthetic signal-generation failure")
+
+    specs = [
+        ConfigSpec(config_id=f"S1-{i:02d}", generate_signals=_raising_gen)
+        for i in range(12)
+    ]
+    bars_1m = {s: _flat_bars(0, _WINDOW_END) for s in _SYMBOLS}
+    result = run_walkforward(
+        strategy="S1",
+        configs=tuple(specs),
+        bars_1m=bars_1m,
+        funding_sidecars=_permissive_funding_sidecars(),
+        gap_ranges=_no_gaps(),
+        fold_schedule=(_FOLD_0, _FOLD_1),
+    )
+    assert all(a.status == "crashed" for a in result.config_attempts)
+    assert all(a.crash_log for a in result.config_attempts)
+    assert len(result.config_attempts) == 12
+
+
+def test_data_gap_in_position_excludes_the_trade_from_the_oos_ledger():
+    specs, bars_by_config = _twelve_configs(
+        "S1-00", winner_train_price=110.0, winner_oos_price=105.0
+    )
+    fold0_oos_entries = sorted(
+        _entries_in_zone(_FOLD_0.oos_start_ms, _FOLD_0.oos_end_ms)
+    )
+    fold1_oos_entries = sorted(
+        _entries_in_zone(_FOLD_1.oos_start_ms, _FOLD_1.oos_end_ms)
+    )
+    # Pick a fold-00 OOS entry that does NOT also fall inside fold-01's TRAIN
+    # zone (fold-00's OOS span [oos_start, oos_end) partially overlaps
+    # fold-01's train span, since folds roll) -- otherwise the "same" gap
+    # would ALSO invalidate fold-01's train evidence and change (or remove)
+    # its own winner, contaminating this test's assumption that fold-01 is
+    # unaffected.
+    gapped_entry = next(ts for ts in fold0_oos_entries if ts >= _FOLD_1.train_end_ms)
+    # A gap squarely inside that ONE trade's [entry, exit) window.
+    gap_ranges = dict.fromkeys(_SYMBOLS, ((gapped_entry, gapped_entry + 30000),))
+
+    result = run_walkforward(
+        strategy="S1",
+        configs=tuple(specs),
+        bars_1m=bars_by_config["S1-00"],
+        funding_sidecars=_permissive_funding_sidecars(),
+        gap_ranges=gap_ranges,
+        fold_schedule=(_FOLD_0, _FOLD_1),
+    )
+    ledger = result.concatenated_oos_ledgers["primary_stress"]
+    assert all(t.entry_ts != gapped_entry for t in ledger)
+    # An OOS trade from fold-01 (unaffected window) must still be present.
+    assert any(t.entry_ts == fold1_oos_entries[0] for t in ledger)
+
+
+def test_funding_gate_rejection_prevents_a_trade_without_silently_vanishing_it():
+    from funding_oi_archive import FundingRow
+
+    # A 2-hour hold window (timeout_bars=120) against an HOURLY funding
+    # interval guarantees at least one relevant crossing after every entry --
+    # a reliably "hostile" sidecar regardless of exact entry alignment.
+    def _long_hold_gen(symbol, bars_slice, fold_id):
+        if not bars_slice:
+            return ()
+        return (
+            SignalEvent(
+                strategy="S1",
+                config_id="S1-00",
+                symbol=symbol,
+                signal_ts=bars_slice[0].ts,
+                side="long",
+                sl_distance_bps=200.0,
+                tp_distance_bps=300.0,
+                timeout_bars=120,
+                cooldown_bars=0,
+                fold_id=fold_id,
+            ),
+        )
+
+    specs = [
+        ConfigSpec(config_id=f"S1-{i:02d}", generate_signals=_long_hold_gen)
+        for i in range(12)
+    ]
+    bars_1m = {s: _flat_bars(0, _WINDOW_END) for s in _SYMBOLS}
+    # A funding sidecar whose known rate implies a large expected LONG cost
+    # at every relevant entry (0.01 -> 100bp signed cost, far above 3bp).
+    hostile_sidecars = {
+        s: FundingSidecar.from_rows(
+            s,
+            [
+                FundingRow(
+                    calc_time=-10, funding_interval_hours=1, last_funding_rate=0.01
+                )
+            ],
+        )
+        for s in _SYMBOLS
+    }
+    result = run_walkforward(
+        strategy="S1",
+        configs=tuple(specs),
+        bars_1m=bars_1m,
+        funding_sidecars=hostile_sidecars,
+        gap_ranges=_no_gaps(),
+        fold_schedule=(_FOLD_0, _FOLD_1),
+    )
+    ledger = result.concatenated_oos_ledgers["primary_stress"]
+    assert ledger == ()  # every signal was funding-gated out, not silently traded
+    winner_attempt = next(a for a in result.config_attempts if a.config_id == "S1-00")
+    # The gate rejection isn't a crash -- but with EVERY train trade also
+    # funding-gated out, no symbol ever reaches MIN_SYMBOL_TRAIN_TRADES, so
+    # every config is rejected in every fold (never eligible anywhere).
+    assert winner_attempt.status == "rejected"
+    assert winner_attempt.reason_code == "insufficient_train_evidence_all_folds"
+    assert not winner_attempt.crash_log
+
+
+def test_three_cost_scenarios_are_each_present_in_oos_results():
+    specs, bars_by_config = _twelve_configs(
+        "S1-00", winner_train_price=110.0, winner_oos_price=105.0
+    )
+    result = run_walkforward(
+        strategy="S1",
+        configs=tuple(specs),
+        bars_1m=bars_by_config["S1-00"],
+        funding_sidecars=_permissive_funding_sidecars(),
+        gap_ranges=_no_gaps(),
+        fold_schedule=(_FOLD_0, _FOLD_1),
+    )
+    assert set(result.concatenated_oos_ledgers.keys()) == {
+        s.name for s in COST_SCENARIOS
+    }
+
+
+# ---------------------------------------------------------------------------
+# summarize_config_attempts_for_h6 -- captain security/determinism correction
+# (2026-07-17): fixed reason codes only (never raw exception/log text).
+# ---------------------------------------------------------------------------
+
+
+def test_summarize_never_selected_config_gets_sentinel_hash_zero_trades():
+    specs, bars_by_config = _twelve_configs(
+        "S1-00", winner_train_price=110.0, winner_oos_price=105.0
+    )
+    result = run_walkforward(
+        strategy="S1",
+        configs=tuple(specs),
+        bars_1m=bars_by_config["S1-00"],
+        funding_sidecars=_permissive_funding_sidecars(),
+        gap_ranges=_no_gaps(),
+        fold_schedule=(_FOLD_0, _FOLD_1),
+    )
+    summaries = summarize_config_attempts_for_h6(result)
+    loser = next(s for s in summaries if s.config_id == "S1-01")
+    assert loser.status == "completed"
+    assert loser.reason_code is None
+    for row in loser.scenario_summaries:
+        assert row.status == "never_selected"
+        assert row.trade_count == 0
+        assert len(row.artifact_hash) == 64
+
+
+def test_summarize_selected_config_combines_all_won_folds_trade_counts():
+    specs, bars_by_config = _twelve_configs(
+        "S1-00", winner_train_price=110.0, winner_oos_price=105.0
+    )
+    result = run_walkforward(
+        strategy="S1",
+        configs=tuple(specs),
+        bars_1m=bars_by_config["S1-00"],
+        funding_sidecars=_permissive_funding_sidecars(),
+        gap_ranges=_no_gaps(),
+        fold_schedule=(_FOLD_0, _FOLD_1),
+    )
+    summaries = summarize_config_attempts_for_h6(result)
+    winner = next(s for s in summaries if s.config_id == "S1-00")
+    assert winner.status == "completed"
+    primary = next(
+        row
+        for row in winner.scenario_summaries
+        if row.scenario_name == "primary_stress"
+    )
+    # Won BOTH folds, 4 symbols each -> trades summed across both folds/symbols.
+    total_primary_trades = sum(
+        1
+        for t in result.concatenated_oos_ledgers["primary_stress"]
+        if t.config_id == "S1-00"
+    )
+    assert primary.trade_count == total_primary_trades
+    assert primary.trade_count > 0
+    assert primary.status == "completed"
+
+
+def test_summarize_exactly_three_scenario_rows_covering_all_scenario_names():
+    specs, bars_by_config = _twelve_configs(
+        "S1-00", winner_train_price=110.0, winner_oos_price=105.0
+    )
+    result = run_walkforward(
+        strategy="S1",
+        configs=tuple(specs),
+        bars_1m=bars_by_config["S1-00"],
+        funding_sidecars=_permissive_funding_sidecars(),
+        gap_ranges=_no_gaps(),
+        fold_schedule=(_FOLD_0, _FOLD_1),
+    )
+    summaries = summarize_config_attempts_for_h6(result)
+    assert len(summaries) == 12
+    for summary in summaries:
+        assert len(summary.scenario_summaries) == 3
+        assert {row.scenario_name for row in summary.scenario_summaries} == {
+            s.name for s in COST_SCENARIOS
+        }
+
+
+def test_summarize_crashed_attempt_gets_fixed_reason_code_not_raw_text():
+    def _raising_gen(symbol, bars_slice, fold_id):
+        raise RuntimeError("simulated child failure")
+
+    specs = [
+        ConfigSpec(config_id=f"S1-{i:02d}", generate_signals=_raising_gen)
+        for i in range(12)
+    ]
+    bars_1m = {s: _flat_bars(0, _WINDOW_END) for s in _SYMBOLS}
+    result = run_walkforward(
+        strategy="S1",
+        configs=tuple(specs),
+        bars_1m=bars_1m,
+        funding_sidecars=_permissive_funding_sidecars(),
+        gap_ranges=_no_gaps(),
+        fold_schedule=(_FOLD_0, _FOLD_1),
+    )
+    summaries = summarize_config_attempts_for_h6(result)
+    assert all(s.status == "crashed" for s in summaries)
+    assert all(s.reason_code == REASON_CHILD_EXECUTION_CRASHED for s in summaries)
+    assert all(
+        "simulated child failure" not in (s.reason_code or "") for s in summaries
+    )
+
+
+def test_summarize_timeout_only_attempt_gets_fixed_timeout_reason_code():
+    def _timing_out_gen(symbol, bars_slice, fold_id):
+        raise TimeoutError("simulated child timeout")
+
+    specs = [
+        ConfigSpec(config_id=f"S1-{i:02d}", generate_signals=_timing_out_gen)
+        for i in range(12)
+    ]
+    bars_1m = {s: _flat_bars(0, _WINDOW_END) for s in _SYMBOLS}
+    result = run_walkforward(
+        strategy="S1",
+        configs=tuple(specs),
+        bars_1m=bars_1m,
+        funding_sidecars=_permissive_funding_sidecars(),
+        gap_ranges=_no_gaps(),
+        fold_schedule=(_FOLD_0, _FOLD_1),
+    )
+    summaries = summarize_config_attempts_for_h6(result)
+    assert all(s.status == "timeout" for s in summaries)
+    assert all(s.reason_code == REASON_CHILD_EXECUTION_TIMEOUT for s in summaries)
+
+
+def test_summarize_sentinel_secret_never_leaks_into_evidence_or_hashes():
+    """A crash/timeout exception message that LOOKS like a leaked credential
+    must never surface anywhere in the returned evidence -- not in
+    reason_code, not (in readable form) in any scenario artifact hash."""
+    sentinel = "sk-live-SUPERSECRETTOKEN-should-never-appear-in-evidence"
+
+    def _raising_gen(symbol, bars_slice, fold_id):
+        raise RuntimeError(f"DB connect failed: password={sentinel}")
+
+    specs = [
+        ConfigSpec(config_id=f"S1-{i:02d}", generate_signals=_raising_gen)
+        for i in range(12)
+    ]
+    bars_1m = {s: _flat_bars(0, _WINDOW_END) for s in _SYMBOLS}
+    result = run_walkforward(
+        strategy="S1",
+        configs=tuple(specs),
+        bars_1m=bars_1m,
+        funding_sidecars=_permissive_funding_sidecars(),
+        gap_ranges=_no_gaps(),
+        fold_schedule=(_FOLD_0, _FOLD_1),
+    )
+    summaries = summarize_config_attempts_for_h6(result)
+    for summary in summaries:
+        assert sentinel not in (summary.reason_code or "")
+        for row in summary.scenario_summaries:
+            assert sentinel not in row.artifact_hash
+            assert row.artifact_hash != sentinel
+
+
+def test_summarize_is_deterministic_across_repeated_calls():
+    specs, bars_by_config = _twelve_configs(
+        "S1-00", winner_train_price=110.0, winner_oos_price=105.0
+    )
+    result = run_walkforward(
+        strategy="S1",
+        configs=tuple(specs),
+        bars_1m=bars_by_config["S1-00"],
+        funding_sidecars=_permissive_funding_sidecars(),
+        gap_ranges=_no_gaps(),
+        fold_schedule=(_FOLD_0, _FOLD_1),
+    )
+    summary1 = summarize_config_attempts_for_h6(result)
+    summary2 = summarize_config_attempts_for_h6(result)
+    assert summary1 == summary2
+
+
+# ---------------------------------------------------------------------------
+# captain core-semantic corrections: exact 4-symbol universe coverage
+# fail-closed; forged/out-of-window signal identity fail-closed; gap
+# rejection propagates to the WHOLE logical attempt.
+# ---------------------------------------------------------------------------
+
+
+def _valid_full_kwargs():
+    specs, bars_by_config = _twelve_configs(
+        "S1-00", winner_train_price=110.0, winner_oos_price=105.0
+    )
+    return {
+        "strategy": "S1",
+        "configs": tuple(specs),
+        "bars_1m": bars_by_config["S1-00"],
+        "funding_sidecars": _permissive_funding_sidecars(),
+        "gap_ranges": _no_gaps(),
+        "fold_schedule": (_FOLD_0, _FOLD_1),
+    }
+
+
+def test_missing_symbol_in_bars_1m_fails_closed_before_any_fold_work():
+    kwargs = _valid_full_kwargs()
+    bars_1m = dict(kwargs["bars_1m"])
+    del bars_1m["SOLUSDT"]
+    kwargs["bars_1m"] = bars_1m
+    with pytest.raises(MissingSymbolDataError):
+        run_walkforward(**kwargs)
+
+
+def test_missing_symbol_in_funding_sidecars_fails_closed():
+    kwargs = _valid_full_kwargs()
+    sidecars = dict(kwargs["funding_sidecars"])
+    del sidecars["SOLUSDT"]
+    kwargs["funding_sidecars"] = sidecars
+    with pytest.raises(MissingSymbolDataError):
+        run_walkforward(**kwargs)
+
+
+def test_missing_symbol_in_gap_ranges_fails_closed():
+    kwargs = _valid_full_kwargs()
+    gaps = dict(kwargs["gap_ranges"])
+    del gaps["SOLUSDT"]
+    kwargs["gap_ranges"] = gaps
+    with pytest.raises(MissingSymbolDataError):
+        run_walkforward(**kwargs)
+
+
+def test_extra_symbol_beyond_frozen_universe_fails_closed():
+    kwargs = _valid_full_kwargs()
+    bars_1m = dict(kwargs["bars_1m"])
+    bars_1m["ETHUSDT"] = bars_1m["BTCUSDT"]
+    kwargs["bars_1m"] = bars_1m
+    with pytest.raises(MissingSymbolDataError):
+        run_walkforward(**kwargs)
+
+
+def test_forged_signal_identity_symbol_is_terminal_crash_evidence():
+    """A generator requested for symbol=BTCUSDT that returns a SignalEvent
+    forged under a DIFFERENT symbol must never be silently trusted/relabeled
+    -- it is terminal (crashed) invalid-data evidence."""
+
+    def _forging_gen(symbol, bars_slice, fold_id):
+        if not bars_slice:
+            return ()
+        real_bar = bars_slice[0]
+        forged_symbol = "XRPUSDT" if symbol == "BTCUSDT" else symbol
+        return (
+            SignalEvent(
+                strategy="S1",
+                config_id="S1-00",
+                symbol=forged_symbol,
+                signal_ts=real_bar.ts,
+                side="long",
+                sl_distance_bps=200.0,
+                tp_distance_bps=300.0,
+                timeout_bars=1,
+                cooldown_bars=0,
+                fold_id=fold_id,
+            ),
+        )
+
+    specs = [
+        ConfigSpec(config_id=f"S1-{i:02d}", generate_signals=_forging_gen)
+        for i in range(12)
+    ]
+    bars_1m = {s: _flat_bars(0, _WINDOW_END) for s in _SYMBOLS}
+    result = run_walkforward(
+        strategy="S1",
+        configs=tuple(specs),
+        bars_1m=bars_1m,
+        funding_sidecars=_permissive_funding_sidecars(),
+        gap_ranges=_no_gaps(),
+        fold_schedule=(_FOLD_0, _FOLD_1),
+    )
+    assert all(a.status == "crashed" for a in result.config_attempts)
+    assert all(a.crash_log for a in result.config_attempts)
+    # The forgery must never leak a mislabeled trade into any ledger.
+    for ledger in result.concatenated_oos_ledgers.values():
+        assert ledger == ()
+
+
+def test_forged_signal_identity_config_id_is_terminal_crash_evidence():
+    def _forging_gen(symbol, bars_slice, fold_id):
+        if not bars_slice:
+            return ()
+        return (
+            SignalEvent(
+                strategy="S1",
+                config_id="S1-99-FORGED",
+                symbol=symbol,
+                signal_ts=bars_slice[0].ts,
+                side="long",
+                sl_distance_bps=200.0,
+                tp_distance_bps=300.0,
+                timeout_bars=1,
+                cooldown_bars=0,
+                fold_id=fold_id,
+            ),
+        )
+
+    specs = [
+        ConfigSpec(config_id=f"S1-{i:02d}", generate_signals=_forging_gen)
+        for i in range(12)
+    ]
+    bars_1m = {s: _flat_bars(0, _WINDOW_END) for s in _SYMBOLS}
+    result = run_walkforward(
+        strategy="S1",
+        configs=tuple(specs),
+        bars_1m=bars_1m,
+        funding_sidecars=_permissive_funding_sidecars(),
+        gap_ranges=_no_gaps(),
+        fold_schedule=(_FOLD_0, _FOLD_1),
+    )
+    assert all(a.status == "crashed" for a in result.config_attempts)
+
+
+def test_signal_ts_before_window_start_is_rejected_as_forged():
+    def _early_gen(symbol, bars_slice, fold_id):
+        return (
+            SignalEvent(
+                strategy="S1",
+                config_id="S1-00",
+                symbol=symbol,
+                signal_ts=-1,
+                side="long",
+                sl_distance_bps=200.0,
+                tp_distance_bps=300.0,
+                timeout_bars=1,
+                cooldown_bars=0,
+                fold_id=fold_id,
+            ),
+        )
+
+    specs = [
+        ConfigSpec(config_id=f"S1-{i:02d}", generate_signals=_early_gen)
+        for i in range(12)
+    ]
+    bars_1m = {s: _flat_bars(0, _WINDOW_END) for s in _SYMBOLS}
+    result = run_walkforward(
+        strategy="S1",
+        configs=tuple(specs),
+        bars_1m=bars_1m,
+        funding_sidecars=_permissive_funding_sidecars(),
+        gap_ranges=_no_gaps(),
+        fold_schedule=(_FOLD_0, _FOLD_1),
+    )
+    assert all(a.status == "crashed" for a in result.config_attempts)
+
+
+def test_signal_ts_after_window_end_is_rejected_as_forged():
+    def _late_gen(symbol, bars_slice, fold_id):
+        return (
+            SignalEvent(
+                strategy="S1",
+                config_id="S1-00",
+                symbol=symbol,
+                signal_ts=_FOLD_1.oos_end_ms + 60_000,
+                side="long",
+                sl_distance_bps=200.0,
+                tp_distance_bps=300.0,
+                timeout_bars=1,
+                cooldown_bars=0,
+                fold_id=fold_id,
+            ),
+        )
+
+    specs = [
+        ConfigSpec(config_id=f"S1-{i:02d}", generate_signals=_late_gen)
+        for i in range(12)
+    ]
+    bars_1m = {s: _flat_bars(0, _WINDOW_END) for s in _SYMBOLS}
+    result = run_walkforward(
+        strategy="S1",
+        configs=tuple(specs),
+        bars_1m=bars_1m,
+        funding_sidecars=_permissive_funding_sidecars(),
+        gap_ranges=_no_gaps(),
+        fold_schedule=(_FOLD_0, _FOLD_1),
+    )
+    assert all(a.status == "crashed" for a in result.config_attempts)
+
+
+def test_signal_ts_exactly_at_window_end_is_a_legitimate_close_boundary_not_forged():
+    """A legitimate H3 close-boundary signal (aggregated bar close_ts ==
+    train_end/oos_end exactly) must NOT be rejected as forged -- it simply
+    finds no entry bar in the half-open [start, end) slice and H2 reports
+    next_bar_unavailable, never crossing into the embargo/next fold."""
+
+    def _boundary_gen_factory(config_id):
+        def _gen(symbol, bars_slice, fold_id):
+            if not bars_slice:
+                return ()
+            # signal_ts == the slice's own end boundary (one bar-width past
+            # the last bar actually in bars_slice, since the slice is
+            # [start, end)).
+            boundary_ts = bars_slice[-1].ts + 60_000
+            return (
+                SignalEvent(
+                    strategy="S1",
+                    config_id=config_id,
+                    symbol=symbol,
+                    signal_ts=boundary_ts,
+                    side="long",
+                    sl_distance_bps=200.0,
+                    tp_distance_bps=300.0,
+                    timeout_bars=1,
+                    cooldown_bars=0,
+                    fold_id=fold_id,
+                ),
+            )
+
+        return _gen
+
+    specs = [
+        ConfigSpec(
+            config_id=f"S1-{i:02d}",
+            generate_signals=_boundary_gen_factory(f"S1-{i:02d}"),
+        )
+        for i in range(12)
+    ]
+    bars_1m = {s: _flat_bars(0, _WINDOW_END) for s in _SYMBOLS}
+    result = run_walkforward(
+        strategy="S1",
+        configs=tuple(specs),
+        bars_1m=bars_1m,
+        funding_sidecars=_permissive_funding_sidecars(),
+        gap_ranges=_no_gaps(),
+        fold_schedule=(_FOLD_0, _FOLD_1),
+    )
+    # Never treated as forged (no crash) -- just structurally ineligible
+    # (0 completed trades everywhere -> insufficient train evidence).
+    assert all(a.status != "crashed" for a in result.config_attempts)
+    assert all(not a.crash_log for a in result.config_attempts)
+
+
+def test_gap_rejection_makes_the_whole_attempt_rejected_not_completed():
+    """A scenario-level gap rejection (train or OOS) must make the WHOLE
+    logical config attempt status="rejected" with
+    rejected:data_gap_in_position -- never remain "completed" merely because
+    the config was train-eligible somewhere."""
+    specs, bars_by_config = _twelve_configs(
+        "S1-00", winner_train_price=110.0, winner_oos_price=105.0
+    )
+    fold0_oos_entries = sorted(
+        _entries_in_zone(_FOLD_0.oos_start_ms, _FOLD_0.oos_end_ms)
+    )
+    gapped_entry = next(ts for ts in fold0_oos_entries if ts >= _FOLD_1.train_end_ms)
+    gap_ranges = dict.fromkeys(_SYMBOLS, ((gapped_entry, gapped_entry + 30_000),))
+
+    result = run_walkforward(
+        strategy="S1",
+        configs=tuple(specs),
+        bars_1m=bars_by_config["S1-00"],
+        funding_sidecars=_permissive_funding_sidecars(),
+        gap_ranges=gap_ranges,
+        fold_schedule=(_FOLD_0, _FOLD_1),
+    )
+    winner_attempt = next(a for a in result.config_attempts if a.config_id == "S1-00")
+    assert winner_attempt.status == "rejected"
+    assert winner_attempt.reason_code == REASON_DATA_GAP_IN_POSITION
+    assert winner_attempt.gap_rejection_log
+    assert not winner_attempt.crash_log
+
+
+# ---------------------------------------------------------------------------
+# Q4 addendum (captain, 2026-07-17): "merely having 3 output keys does not
+# kill a one-path revaluer mutation" -- an H4-level spy on
+# rob944_walkforward.run_symbol_stream must prove EXACTLY 3 FRESH
+# invocations per (symbol, fold) OOS evaluation (one per COST_SCENARIOS
+# entry), each receiving the IDENTICAL raw (bars, signals) input -- not one
+# real run whose ledger is then rescaled/derived for the other two. Reuses
+# H2's own known 3/3/2 trade-count divergence + scenario-independent 68bp
+# gate fixture (test_rob940_engine.test_cost_scenario_dependent_daily_stop_diverges_trade_count)
+# verbatim, so this is provably the SAME divergence H2 already owns, not a
+# new/different H4 reimplementation of it.
+# ---------------------------------------------------------------------------
+
+
+def _h2_repro_bars_and_signals(base_ts):
+    """Verbatim reproduction of H2's 3/3/2 divergence fixture (trade1 SL
+    touch, trade2 timeout, trade3 clean gap-through TP), re-anchored at
+    ``base_ts`` instead of ts=0 so it can be placed inside an OOS window."""
+    specs = [
+        (100, 100, 100, 100),
+        (91, 91.5, 90, 90.5),
+        (100, 100, 100, 100),
+        (99.97, 99.97, 99.97, 99.97),
+        (100, 100, 100, 100),
+        (102, 102, 102, 102),
+    ]
+    bars = tuple(
+        Bar1m(ts=base_ts + i * 60_000, open=o, high=h, low=lo, close=c, volume=1.0)
+        for i, (o, h, lo, c) in enumerate(specs)
+    )
+    sig1 = SignalEvent(
+        strategy="S1",
+        config_id="S1-00",
+        symbol="BTCUSDT",
+        signal_ts=base_ts,
+        side="long",
+        sl_distance_bps=1000.0,
+        tp_distance_bps=100000.0,
+        timeout_bars=5,
+        cooldown_bars=0,
+        fold_id="fold-00",
+    )
+    sig2 = SignalEvent(
+        strategy="S1",
+        config_id="S1-00",
+        symbol="BTCUSDT",
+        signal_ts=base_ts + 2 * 60_000,
+        side="long",
+        sl_distance_bps=25.0,
+        tp_distance_bps=100000.0,
+        timeout_bars=1,
+        cooldown_bars=0,
+        fold_id="fold-00",
+    )
+    sig3 = SignalEvent(
+        strategy="S1",
+        config_id="S1-00",
+        symbol="BTCUSDT",
+        signal_ts=base_ts + 4 * 60_000,
+        side="long",
+        sl_distance_bps=1000.0,
+        tp_distance_bps=100.0,
+        timeout_bars=1,
+        cooldown_bars=0,
+        fold_id="fold-00",
+    )
+    return bars, (sig1, sig2, sig3)
+
+
+def test_h4_wires_three_fresh_independent_scenario_runs_reproducing_h2_3_3_2_divergence(
+    monkeypatch,
+):
+    target_bars, target_signals = _h2_repro_bars_and_signals(_FOLD_0.oos_start_ms)
+
+    bars_1m = {
+        s: (
+            target_bars
+            if s == "BTCUSDT"
+            else _flat_bars(_FOLD_0.oos_start_ms, _FOLD_0.oos_start_ms + 6 * 60_000)
+        )
+        for s in _SYMBOLS
+    }
+
+    def gen(symbol, bars_slice, fold_id):
+        return target_signals if symbol == "BTCUSDT" else ()
+
+    calls: list[tuple] = []
+    real_run_symbol_stream = rob944_walkforward.run_symbol_stream
+
+    def spy(bars, signals, scenario, *args, **kwargs):
+        calls.append((bars, signals, scenario.name))
+        return real_run_symbol_stream(bars, signals, scenario, *args, **kwargs)
+
+    monkeypatch.setattr(rob944_walkforward, "run_symbol_stream", spy)
+
+    outcomes, ledgers = _evaluate_fold_oos(
+        "S1",
+        ConfigSpec(config_id="S1-00", generate_signals=gen),
+        bars_1m,
+        _permissive_funding_sidecars(),
+        _no_gaps(),
+        _FOLD_0,
+        {},
+        {},
+    )
+
+    # Exactly one FRESH run_symbol_stream invocation per COST_SCENARIOS entry
+    # for the target symbol -- never fewer (a shared-path revaluer collapsing
+    # 3 calls into 1) and never more (a duplicate/retry leak).
+    btc_calls = [c for c in calls if c[1] == target_signals]
+    assert len(btc_calls) == len(COST_SCENARIOS) == 3
+    assert {c[2] for c in btc_calls} == {s.name for s in COST_SCENARIOS}
+
+    # "Fresh state" proof: every call received the IDENTICAL raw (bars,
+    # signals) input -- a one-path revaluer would instead feed call N+1 some
+    # DERIVED/mutated state from call N's own result (e.g. a filtered ledger,
+    # a running R-multiple) rather than the same untouched inputs each time.
+    for bars, signals, _name in btc_calls:
+        assert bars == target_bars
+        assert signals == target_signals
+
+    # H2's own known divergence, reproduced verbatim through the H4 wiring:
+    # base/primary=3 trades, upward=2 trades (AC8 cost-included daily stop).
+    trade_counts = {
+        name: len(ledgers[name]) for name in ("base", "primary_stress", "upward_stress")
+    }
+    assert trade_counts == {"base": 3, "primary_stress": 3, "upward_stress": 2}
+
+    # The 68bp entry-eligibility gate itself is scenario-independent: all 3
+    # scenarios agree on trade1/trade2 (only trade3's inclusion diverges).
+    for name in ("base", "primary_stress", "upward_stress"):
+        first_two_entry_ts = sorted(t.entry_ts for t in ledgers[name])[:2]
+        assert first_two_entry_ts == [
+            _FOLD_0.oos_start_ms,
+            _FOLD_0.oos_start_ms + 2 * 60_000,
+        ]
+
+
+# ---------------------------------------------------------------------------
+# Captain mutation-test correction (2026-07-17): the trade1/trade2 entry_ts
+# equality above is VACUOUS for the 68bp-gate claim -- both signals used
+# tp_distance_bps of 100bp/100000bp, far above ANY plausible scenario-scaled
+# threshold (52/68/88bp), so a mutant that computes MIN_TP_DISTANCE_BPS
+# per-scenario (e.g. base=52, primary=68, upward=88) would still pass both
+# and this suite would never notice. This fixture uses tp_distance_bps
+# EXACTLY 68.0 (eligible) and 67.99 (just below) -- verbatim H2 values from
+# test_68bp_gate_is_identical_across_all_cost_scenarios -- through the SAME
+# H4 _evaluate_fold_oos + run_symbol_stream-spy boundary, across all 3 REAL
+# cost scenarios, to kill exactly that mutation class.
+# ---------------------------------------------------------------------------
+
+
+def _h2_68bp_gate_bars(base_ts):
+    specs = [(100, 100, 100, 100), (100, 100.1, 99.9, 100)]
+    return tuple(
+        Bar1m(ts=base_ts + i * 60_000, open=o, high=h, low=lo, close=c, volume=1.0)
+        for i, (o, h, lo, c) in enumerate(specs)
+    )
+
+
+def _h2_68bp_signal(base_ts, tp_distance_bps):
+    return SignalEvent(
+        strategy="S1",
+        config_id="S1-00",
+        symbol="BTCUSDT",
+        signal_ts=base_ts,
+        side="long",
+        sl_distance_bps=100.0,
+        tp_distance_bps=tp_distance_bps,
+        timeout_bars=1,
+        cooldown_bars=0,
+        fold_id="fold-00",
+    )
+
+
+def _run_68bp_case(monkeypatch, tp_distance_bps):
+    bars = _h2_68bp_gate_bars(_FOLD_0.oos_start_ms)
+    signal = _h2_68bp_signal(_FOLD_0.oos_start_ms, tp_distance_bps)
+    bars_1m = {
+        s: (
+            bars
+            if s == "BTCUSDT"
+            else _flat_bars(_FOLD_0.oos_start_ms, _FOLD_0.oos_start_ms + 2 * 60_000)
+        )
+        for s in _SYMBOLS
+    }
+
+    def gen(symbol, bars_slice, fold_id):
+        return (signal,) if symbol == "BTCUSDT" else ()
+
+    calls: list[tuple] = []
+    real_run_symbol_stream = rob944_walkforward.run_symbol_stream
+
+    def spy(bars_arg, signals_arg, scenario, *args, **kwargs):
+        result = real_run_symbol_stream(
+            bars_arg, signals_arg, scenario, *args, **kwargs
+        )
+        if signals_arg == (signal,):
+            calls.append((scenario.name, result))
+        return result
+
+    monkeypatch.setattr(rob944_walkforward, "run_symbol_stream", spy)
+
+    _evaluate_fold_oos(
+        "S1",
+        ConfigSpec(config_id="S1-00", generate_signals=gen),
+        bars_1m,
+        _permissive_funding_sidecars(),
+        _no_gaps(),
+        _FOLD_0,
+        {},
+        {},
+    )
+    assert {name for name, _r in calls} == {s.name for s in COST_SCENARIOS}
+    return dict(calls)
+
+
+def test_tp_distance_exactly_68bp_is_eligible_in_all_three_independent_scenario_runs(
+    monkeypatch,
+):
+    results = _run_68bp_case(monkeypatch, 68.0)
+    for name, result in results.items():
+        assert len(result.trades) == 1, name  # entry gate passed -- not rejected
+        assert not result.no_trades, name
+
+
+def test_tp_distance_just_below_68bp_is_rejected_in_all_three_independent_scenario_runs(
+    monkeypatch,
+):
+    results = _run_68bp_case(monkeypatch, 67.99)
+    for name, result in results.items():
+        assert result.trades == (), name
+        assert result.no_trades[0].reason == "tp_below_min_distance", name
+
+
+# ---------------------------------------------------------------------------
+# Captain freeze-audit addendum (item A) + train-input completeness/PIT-
+# scope/performance follow-ups: train_artifact_hash must bind the ACTUAL
+# raw TRAIN-relevant funding rows/gap ranges (never OOS-only future ones),
+# fail closed (never an unaccounted exception) on non-finite funding rates,
+# and do so WITHOUT re-hashing the shared bars/funding/gaps once per config
+# (static fingerprint computed once per (fold, symbol), not once per
+# (config, symbol)).
+# ---------------------------------------------------------------------------
+
+
+def _no_signal_configs(n=12):
+    def _gen(symbol, bars_slice, fold_id):
+        return ()
+
+    return [
+        ConfigSpec(config_id=f"S1-{i:02d}", generate_signals=_gen) for i in range(n)
+    ]
+
+
+def _flat_bars_all_symbols(start_ms, end_ms):
+    return {s: _flat_bars(start_ms, end_ms) for s in _SYMBOLS}
+
+
+def _sidecars_with_rate(fold, rate, *, extra_rows=()):
+    from funding_oi_archive import FundingRow
+
+    rows = [
+        FundingRow(
+            calc_time=fold.train_start_ms + 1000,
+            funding_interval_hours=8,
+            last_funding_rate=rate,
+        )
+    ]
+    rows.extend(extra_rows)
+    return {s: FundingSidecar.from_rows(s, rows) for s in _SYMBOLS}
+
+
+def _btc_train_hash(candidates):
+    return candidates[0].symbol_evidence[0].train_artifact_hash
+
+
+def _btc_train_evidence(candidates):
+    return candidates[0].symbol_evidence[0]
+
+
+def _configs_with_target_gen(gen, *, target_id="S1-00", n=12):
+    def _empty_gen(symbol, bars_slice, fold_id):
+        return ()
+
+    return [
+        ConfigSpec(
+            config_id=f"S1-{i:02d}",
+            generate_signals=(gen if f"S1-{i:02d}" == target_id else _empty_gen),
+        )
+        for i in range(n)
+    ]
+
+
+def test_train_relevant_funding_row_change_alters_train_artifact_hash():
+    fold = _FOLD_0
+    bars_1m = _flat_bars_all_symbols(fold.train_start_ms, fold.oos_end_ms)
+    configs = _no_signal_configs()
+
+    candidates_a = _evaluate_fold_train(
+        "S1",
+        configs,
+        bars_1m,
+        _sidecars_with_rate(fold, 0.0001),
+        _no_gaps(),
+        fold,
+        {},
+        {},
+    )
+    candidates_b = _evaluate_fold_train(
+        "S1",
+        configs,
+        bars_1m,
+        _sidecars_with_rate(fold, 0.0005),
+        _no_gaps(),
+        fold,
+        {},
+        {},
+    )
+    assert _btc_train_hash(candidates_a) != _btc_train_hash(candidates_b)
+
+
+def test_oos_only_future_funding_row_does_not_alter_train_artifact_hash():
+    fold = _FOLD_0
+    bars_1m = _flat_bars_all_symbols(fold.train_start_ms, fold.oos_end_ms)
+    configs = _no_signal_configs()
+    from funding_oi_archive import FundingRow
+
+    oos_only_row = FundingRow(
+        calc_time=fold.oos_start_ms + 1000,
+        funding_interval_hours=8,
+        last_funding_rate=0.0009,
+    )
+
+    baseline = _evaluate_fold_train(
+        "S1",
+        configs,
+        bars_1m,
+        _sidecars_with_rate(fold, 0.0001),
+        _no_gaps(),
+        fold,
+        {},
+        {},
+    )
+    with_future_row = _evaluate_fold_train(
+        "S1",
+        configs,
+        bars_1m,
+        _sidecars_with_rate(fold, 0.0001, extra_rows=(oos_only_row,)),
+        _no_gaps(),
+        fold,
+        {},
+        {},
+    )
+    assert _btc_train_hash(baseline) == _btc_train_hash(with_future_row)
+
+
+def test_train_relevant_gap_range_change_alters_train_artifact_hash():
+    fold = _FOLD_0
+    bars_1m = _flat_bars_all_symbols(fold.train_start_ms, fold.oos_end_ms)
+    configs = _no_signal_configs()
+    sidecars = _sidecars_with_rate(fold, 0.0001)
+    train_gap = dict.fromkeys(
+        _SYMBOLS, ((fold.train_start_ms + 500, fold.train_start_ms + 600),)
+    )
+
+    without_gap = _evaluate_fold_train(
+        "S1", configs, bars_1m, sidecars, _no_gaps(), fold, {}, {}
+    )
+    with_gap = _evaluate_fold_train(
+        "S1", configs, bars_1m, sidecars, train_gap, fold, {}, {}
+    )
+    assert _btc_train_hash(without_gap) != _btc_train_hash(with_gap)
+
+
+def test_oos_only_gap_range_does_not_alter_train_artifact_hash():
+    fold = _FOLD_0
+    bars_1m = _flat_bars_all_symbols(fold.train_start_ms, fold.oos_end_ms)
+    configs = _no_signal_configs()
+    sidecars = _sidecars_with_rate(fold, 0.0001)
+    oos_gap = dict.fromkeys(
+        _SYMBOLS, ((fold.oos_start_ms + 500, fold.oos_start_ms + 600),)
+    )
+
+    baseline = _evaluate_fold_train(
+        "S1", configs, bars_1m, sidecars, _no_gaps(), fold, {}, {}
+    )
+    with_oos_gap = _evaluate_fold_train(
+        "S1", configs, bars_1m, sidecars, oos_gap, fold, {}, {}
+    )
+    assert _btc_train_hash(baseline) == _btc_train_hash(with_oos_gap)
+
+
+def test_nan_funding_rate_fails_closed_not_an_unaccounted_exception():
+    fold = _FOLD_0
+    bars_1m = _flat_bars_all_symbols(fold.train_start_ms, fold.oos_end_ms)
+    configs = _no_signal_configs()
+
+    baseline = _evaluate_fold_train(
+        "S1",
+        configs,
+        bars_1m,
+        _sidecars_with_rate(fold, 0.0001),
+        _no_gaps(),
+        fold,
+        {},
+        {},
+    )
+    nan_candidates = _evaluate_fold_train(  # must not raise
+        "S1",
+        configs,
+        bars_1m,
+        _sidecars_with_rate(fold, float("nan")),
+        _no_gaps(),
+        fold,
+        {},
+        {},
+    )
+    # The NaN is folded into the hash via a stable sentinel -- distinct from
+    # the finite baseline, never silently collapsed/ignored.
+    assert _btc_train_hash(baseline) != _btc_train_hash(nan_candidates)
+
+
+def test_generate_signals_failure_hash_binds_train_relevant_input_never_raw_secret_text():
+    """Captain follow-up (2026-07-17): a bare identity+status+reason
+    sentinel for a generate_signals failure means two DIFFERENT train
+    bars/funding/gaps that happen to hit the SAME generator failure class
+    would still collide -- the static_input_hash must now be bound in too,
+    so train-relevant input changes still diverge the failure artifact hash,
+    while the raw (potentially secret-bearing) exception text itself must
+    NEVER leak into -- or even influence -- that hash."""
+    fold = _FOLD_0
+    bars_1m_a = _flat_bars_all_symbols(fold.train_start_ms, fold.oos_end_ms)
+    bars_1m_b = {
+        **bars_1m_a,
+        "BTCUSDT": _flat_bars(
+            fold.train_start_ms, fold.oos_end_ms, overrides={fold.train_start_ms: 999.0}
+        ),
+    }
+    sidecars = _sidecars_with_rate(fold, 0.0001)
+
+    def _boom_a(symbol, bars_slice, fold_id):
+        raise ValueError("SECRET-A-token")
+
+    def _boom_b(symbol, bars_slice, fold_id):
+        raise ValueError("SECRET-B-completely-different-token")
+
+    configs_a = [
+        ConfigSpec(config_id=f"S1-{i:02d}", generate_signals=_boom_a) for i in range(12)
+    ]
+    configs_b = [
+        ConfigSpec(config_id=f"S1-{i:02d}", generate_signals=_boom_b) for i in range(12)
+    ]
+
+    # Same train-relevant input, DIFFERENT raw secret exception text -> the
+    # failure artifact hash must be IDENTICAL (raw text never leaks in).
+    same_input_1 = _evaluate_fold_train(
+        "S1", configs_a, bars_1m_a, sidecars, _no_gaps(), fold, {}, {}
+    )
+    same_input_2 = _evaluate_fold_train(
+        "S1", configs_b, bars_1m_a, sidecars, _no_gaps(), fold, {}, {}
+    )
+    assert _btc_train_hash(same_input_1) == _btc_train_hash(same_input_2)
+
+    # DIFFERENT train-relevant input, SAME generator failure class -> the
+    # failure artifact hash must now DIFFER (previously collided).
+    diff_input = _evaluate_fold_train(
+        "S1", configs_a, bars_1m_b, sidecars, _no_gaps(), fold, {}, {}
+    )
+    assert _btc_train_hash(same_input_1) != _btc_train_hash(diff_input)
+
+
+@pytest.mark.parametrize("rate", [float("nan"), float("inf"), float("-inf")])
+def test_json_safe_funding_rate_maps_nonfinite_to_stable_string_sentinels(rate):
+    assert isinstance(_json_safe_funding_rate(rate), str)
+
+
+def test_json_safe_funding_rate_passes_finite_values_through_unchanged():
+    assert _json_safe_funding_rate(0.0001) == 0.0001
+
+
+def test_static_train_fingerprint_computed_once_per_symbol_not_once_per_config(
+    monkeypatch,
+):
+    """Captain performance correction: bar/funding/gap hashing must be
+    computed ONCE per (fold, symbol) -- 4 times per fold for the frozen
+    4-symbol universe -- never once per (config, symbol) (48 times per fold
+    for 12 configs), which made a naive per-config recomputation
+    prohibitive for real 120-day 1m slices.
+
+    Captain follow-up (2026-07-17): no production-global mutable call
+    counter -- this test wraps ``rob944_walkforward._train_static_fingerprint``
+    with a local monkeypatch spy that counts calls while delegating to the
+    real function, so runtime code carries no extra instrumentation state.
+    """
+    fold = _FOLD_0
+    bars_1m = _flat_bars_all_symbols(fold.train_start_ms, fold.oos_end_ms)
+    configs = _no_signal_configs(n=12)
+
+    calls = {"count": 0}
+    real_fn = rob944_walkforward._train_static_fingerprint
+
+    def spy(*args, **kwargs):
+        calls["count"] += 1
+        return real_fn(*args, **kwargs)
+
+    monkeypatch.setattr(rob944_walkforward, "_train_static_fingerprint", spy)
+
+    _evaluate_fold_train(
+        "S1",
+        configs,
+        bars_1m,
+        _sidecars_with_rate(fold, 0.0001),
+        _no_gaps(),
+        fold,
+        {},
+        {},
+    )
+    assert calls["count"] == len(_SYMBOLS) == 4
+
+
+# ---------------------------------------------------------------------------
+# Independent walk-forward audit (2026-07-17): canonicalize generator signal
+# order before hashing/execution; direct TRAIN bar/signal mutation coverage
+# (previously only funding/gap were exercised); gap ranges must hash the
+# CLIPPED train-intersection, never the gap's own possibly-partly-OOS
+# endpoints.
+# ---------------------------------------------------------------------------
+
+
+def test_reversed_generator_signal_order_yields_identical_train_hash_and_trades():
+    fold = _FOLD_0
+    bars_1m = _flat_bars_all_symbols(fold.train_start_ms, fold.oos_end_ms)
+    sidecars = _sidecars_with_rate(fold, 0.0001)
+    # Both timestamps strictly AFTER the funding sidecar's own calc_time
+    # (train_start_ms + 1000, see _sidecars_with_rate) so neither is
+    # rejected as funding_evidence_unavailable.
+    ts1, ts2 = fold.train_start_ms + 60_000, fold.train_start_ms + 3 * 60_000
+    sig1 = _make_signal("BTCUSDT", ts1, config_id="S1-00", fold_id=fold.fold_id)
+    sig2 = _make_signal("BTCUSDT", ts2, config_id="S1-00", fold_id=fold.fold_id)
+
+    def gen_forward(symbol, bars_slice, fold_id):
+        return (sig1, sig2) if symbol == "BTCUSDT" else ()
+
+    def gen_backward(symbol, bars_slice, fold_id):
+        return (sig2, sig1) if symbol == "BTCUSDT" else ()
+
+    candidates_forward = _evaluate_fold_train(
+        "S1",
+        _configs_with_target_gen(gen_forward),
+        bars_1m,
+        sidecars,
+        _no_gaps(),
+        fold,
+        {},
+        {},
+    )
+    candidates_backward = _evaluate_fold_train(
+        "S1",
+        _configs_with_target_gen(gen_backward),
+        bars_1m,
+        sidecars,
+        _no_gaps(),
+        fold,
+        {},
+        {},
+    )
+
+    assert _btc_train_hash(candidates_forward) == _btc_train_hash(candidates_backward)
+    ev_f = _btc_train_evidence(candidates_forward)
+    ev_b = _btc_train_evidence(candidates_backward)
+    assert ev_f.completed_trades == ev_b.completed_trades == 2
+    assert ev_f.net_expectancy_bps == ev_b.net_expectancy_bps
+
+
+def test_direct_train_bar_mutation_changes_train_artifact_hash():
+    """Only funding/gap mutation was previously exercised -- this proves the
+    bar slice ITSELF (bars/prices, not funding or gaps) is bound too."""
+    fold = _FOLD_0
+    bars_a = _flat_bars_all_symbols(fold.train_start_ms, fold.oos_end_ms)
+    bars_b = {
+        **bars_a,
+        "BTCUSDT": _flat_bars(
+            fold.train_start_ms, fold.oos_end_ms, overrides={fold.train_start_ms: 123.0}
+        ),
+    }
+    sidecars = _sidecars_with_rate(fold, 0.0001)
+    configs = _no_signal_configs()
+
+    candidates_a = _evaluate_fold_train(
+        "S1", configs, bars_a, sidecars, _no_gaps(), fold, {}, {}
+    )
+    candidates_b = _evaluate_fold_train(
+        "S1", configs, bars_b, sidecars, _no_gaps(), fold, {}, {}
+    )
+    assert _btc_train_hash(candidates_a) != _btc_train_hash(candidates_b)
+
+
+def test_direct_generated_signal_mutation_changes_train_artifact_hash():
+    """Only funding/gap mutation was previously exercised -- this proves the
+    generated SIGNAL's own params are bound too (bars/funding/gaps held
+    fixed, only sl_distance_bps differs)."""
+    fold = _FOLD_0
+    bars_1m = _flat_bars_all_symbols(fold.train_start_ms, fold.oos_end_ms)
+    sidecars = _sidecars_with_rate(fold, 0.0001)
+    ts = fold.train_start_ms
+
+    def gen_a(symbol, bars_slice, fold_id):
+        if symbol != "BTCUSDT":
+            return ()
+        return (_make_signal(symbol, ts, config_id="S1-00", fold_id=fold_id, sl=200.0),)
+
+    def gen_b(symbol, bars_slice, fold_id):
+        if symbol != "BTCUSDT":
+            return ()
+        return (_make_signal(symbol, ts, config_id="S1-00", fold_id=fold_id, sl=250.0),)
+
+    candidates_a = _evaluate_fold_train(
+        "S1",
+        _configs_with_target_gen(gen_a),
+        bars_1m,
+        sidecars,
+        _no_gaps(),
+        fold,
+        {},
+        {},
+    )
+    candidates_b = _evaluate_fold_train(
+        "S1",
+        _configs_with_target_gen(gen_b),
+        bars_1m,
+        sidecars,
+        _no_gaps(),
+        fold,
+        {},
+        {},
+    )
+    assert _btc_train_hash(candidates_a) != _btc_train_hash(candidates_b)
+
+
+def test_gap_hash_clips_to_train_intersection_oos_tail_change_does_not_alter_train_hash():
+    """A gap that touches the train window but extends into OOS must be
+    hashed as the CLIPPED train-visible portion only -- changing ONLY the
+    OOS-side tail of such a gap must never alter the TRAIN hash."""
+    fold = _FOLD_0
+    bars_1m = _flat_bars_all_symbols(fold.train_start_ms, fold.oos_end_ms)
+    sidecars = _sidecars_with_rate(fold, 0.0001)
+    configs = _no_signal_configs()
+
+    gap_end_a = fold.train_end_ms + 1000  # extends slightly into embargo/OOS-side
+    gap_end_b = fold.train_end_ms + 50_000  # a materially different OOS-side tail
+    gap_start = (
+        fold.train_end_ms - 500
+    )  # starts strictly inside train, straddles the boundary
+
+    gap_ranges_a = dict.fromkeys(_SYMBOLS, ((gap_start, gap_end_a),))
+    gap_ranges_b = dict.fromkeys(_SYMBOLS, ((gap_start, gap_end_b),))
+
+    candidates_a = _evaluate_fold_train(
+        "S1", configs, bars_1m, sidecars, gap_ranges_a, fold, {}, {}
+    )
+    candidates_b = _evaluate_fold_train(
+        "S1", configs, bars_1m, sidecars, gap_ranges_b, fold, {}, {}
+    )
+    assert _btc_train_hash(candidates_a) == _btc_train_hash(candidates_b)
+
+
+# ---------------------------------------------------------------------------
+# Captain independent Fable e2e audit (2026-07-17): the funding entry gate
+# runs BEFORE the gap check within one scenario invocation -- its own
+# no-trade rejections (funding_evidence_unavailable/
+# expected_funding_cost_above_3bps) are real, already-observed evidence and
+# must survive into the gap-rejected terminal outcome, not be silently
+# dropped just because the run is ALSO gap-rejected.
+# ---------------------------------------------------------------------------
+
+
+def test_gap_rejected_scenario_preserves_already_observed_funding_rejection_counts():
+    from funding_oi_archive import FundingRow
+
+    bars = _flat_bars(0, 4 * 60_000)  # ts 0, 60_000, 120_000, 180_000
+    sidecar = FundingSidecar.from_rows(
+        "BTCUSDT",
+        [
+            FundingRow(
+                calc_time=90_000, funding_interval_hours=8, last_funding_rate=0.0001
+            )
+        ],
+    )
+    sig_funding_rejected = (
+        _make_signal(  # entry at ts=0, BEFORE the only known funding row -> rejected
+            "BTCUSDT",
+            0,
+            config_id="S1-00",
+            fold_id="fold-00",
+            timeout_bars=1,
+        )
+    )
+    sig_gap_touching = (
+        _make_signal(  # entry at ts=120_000, funding-eligible -> produces a trade
+            "BTCUSDT",
+            120_000,
+            config_id="S1-00",
+            fold_id="fold-00",
+            timeout_bars=1,
+        )
+    )
+    gap_ranges = (
+        (150_000, 151_000),
+    )  # inside the second signal's [120_000, 180_000) trade window
+
+    outcome, filtered = _run_scenario(
+        bars,
+        (sig_funding_rejected, sig_gap_touching),
+        COST_SCENARIO_PRIMARY_STRESS,
+        sidecar,
+        gap_ranges,
+        strategy="S1",
+        config_id="S1-00",
+        symbol="BTCUSDT",
+        fold_id="fold-00",
+    )
+
+    assert outcome.status == "rejected"
+    assert outcome.error_reason == REASON_DATA_GAP_IN_POSITION
+    assert filtered is None
+    assert outcome.no_trade_reason_counts.get("funding_evidence_unavailable") == 1
+
+
+# ---------------------------------------------------------------------------
+# Fable condition 1 (2026-07-17): a generator's OWN pre-execution rejection
+# evidence (H3 S2's target_direction_invalid/tp_above_max/tp_below_r_min_sl/
+# tp_below_abs_floor/confirmation_failed/next_bar_unavailable) must be
+# validated fail-closed, canonicalized before hashing/merging, bound into
+# the train input hash, and merged into EVERY independent scenario result
+# (completed AND gap/crash terminal evidence) -- never silently dropped.
+# ---------------------------------------------------------------------------
+
+
+def _rejection(
+    reason="target_direction_invalid",
+    signal_ts=0,
+    symbol="BTCUSDT",
+    config_id="S1-00",
+    strategy="S1",
+    side="long",
+    fold_id="fold-00",
+):
+    return NoTradeRecord(
+        strategy=strategy,
+        config_id=config_id,
+        symbol=symbol,
+        side=side,
+        signal_ts=signal_ts,
+        reason=reason,
+        fold_id=fold_id,
+    )
+
+
+def _valid_window_kwargs():
+    return {
+        "strategy": "S1",
+        "config_id": "S1-00",
+        "symbol": "BTCUSDT",
+        "fold_id": "fold-00",
+        "window_start_ms": 0,
+        "window_end_ms": 10 * 60_000,
+    }
+
+
+def test_validate_generated_rejections_accepts_empty():
+    assert _validate_generated_rejections((), **_valid_window_kwargs()) == ()
+
+
+def test_validate_generated_rejections_rejects_non_no_trade_record():
+    with pytest.raises(ForgedSignalError):
+        _validate_generated_rejections(("not-a-record",), **_valid_window_kwargs())
+
+
+def test_validate_generated_rejections_rejects_invalid_side():
+    bad = _rejection(side="sideways")
+    with pytest.raises(ForgedSignalError):
+        _validate_generated_rejections((bad,), **_valid_window_kwargs())
+
+
+def test_validate_generated_rejections_rejects_unknown_reason():
+    bad = _rejection(reason="SECRET-UNKNOWN-REASON")
+    with pytest.raises(ForgedSignalError) as exc_info:
+        _validate_generated_rejections((bad,), **_valid_window_kwargs())
+    assert "SECRET-UNKNOWN-REASON" not in str(exc_info.value)
+
+
+def test_validate_generated_rejections_rejects_forged_identity():
+    bad = _rejection(config_id="S1-99")  # requested config_id is "S1-00"
+    with pytest.raises(ForgedSignalError):
+        _validate_generated_rejections((bad,), **_valid_window_kwargs())
+
+
+def test_validate_generated_rejections_rejects_out_of_window_signal_ts():
+    bad = _rejection(signal_ts=999_999_999)
+    with pytest.raises(ForgedSignalError):
+        _validate_generated_rejections((bad,), **_valid_window_kwargs())
+
+
+def test_validate_generated_rejections_rejects_bool_signal_ts():
+    bad = _rejection(
+        signal_ts=True
+    )  # bool is an int subclass -- must still be rejected
+    with pytest.raises(ForgedSignalError):
+        _validate_generated_rejections((bad,), **_valid_window_kwargs())
+
+
+def test_validate_generated_rejections_rejects_duplicate_signal_ts():
+    dup_a = _rejection(signal_ts=60_000, reason="target_direction_invalid")
+    dup_b = _rejection(signal_ts=60_000, reason="tp_above_max")
+    with pytest.raises(ForgedSignalError):
+        _validate_generated_rejections((dup_a, dup_b), **_valid_window_kwargs())
+
+
+def test_validate_generated_rejections_returns_canonical_sorted_order():
+    later = _rejection(signal_ts=120_000, reason="tp_above_max")
+    earlier = _rejection(signal_ts=60_000, reason="target_direction_invalid")
+    ordered = _validate_generated_rejections((later, earlier), **_valid_window_kwargs())
+    assert [r.signal_ts for r in ordered] == [60_000, 120_000]
+
+
+def test_rejections_reorder_does_not_change_the_combined_hash():
+    rej_a = _rejection(signal_ts=60_000, reason="target_direction_invalid")
+    rej_b = _rejection(signal_ts=120_000, reason="tp_above_max")
+    kwargs = _valid_window_kwargs()
+    ordered_1 = _validate_generated_rejections((rej_a, rej_b), **kwargs)
+    ordered_2 = _validate_generated_rejections((rej_b, rej_a), **kwargs)
+    hash_1 = _combine_static_and_signals("static", (), ordered_1)
+    hash_2 = _combine_static_and_signals("static", (), ordered_2)
+    assert hash_1 == hash_2
+
+
+def test_rejections_content_change_alters_the_combined_hash():
+    rej_a = _rejection(signal_ts=60_000, reason="target_direction_invalid")
+    rej_b = _rejection(signal_ts=60_000, reason="tp_above_max")
+    hash_a = _combine_static_and_signals("static", (), (rej_a,))
+    hash_b = _combine_static_and_signals("static", (), (rej_b,))
+    assert hash_a != hash_b
+
+
+def test_direct_signal_rejection_ts_collision_is_rejected():
+    """Captain GeneratedSignalBatch fail-closed seam (2026-07-17): an
+    accepted signal and a rejection sharing the SAME signal_ts must fail
+    closed -- a forged/buggy callback could otherwise create a trade AND
+    contribute a no-trade-reason count at the same timestamp."""
+    sig = _make_signal("BTCUSDT", 60_000, config_id="S1-00", fold_id="fold-00")
+    rejection = _rejection(
+        signal_ts=60_000, reason="target_direction_invalid", fold_id="fold-00"
+    )
+    with pytest.raises(ForgedSignalError):
+        rob944_walkforward._assert_no_signal_rejection_ts_collision(
+            (sig,),
+            (rejection,),
+            strategy="S1",
+            config_id="S1-00",
+            symbol="BTCUSDT",
+            fold_id="fold-00",
+        )
+
+
+def test_direct_signal_rejection_no_collision_when_ts_differ():
+    sig = _make_signal("BTCUSDT", 60_000, config_id="S1-00", fold_id="fold-00")
+    rejection = _rejection(
+        signal_ts=120_000, reason="target_direction_invalid", fold_id="fold-00"
+    )
+    rob944_walkforward._assert_no_signal_rejection_ts_collision(  # must not raise
+        (sig,),
+        (rejection,),
+        strategy="S1",
+        config_id="S1-00",
+        symbol="BTCUSDT",
+        fold_id="fold-00",
+    )
+
+
+def test_train_signal_rejection_ts_collision_yields_zero_partial_evidence_whole_attempt_crashed():
+    """A colliding generator output must crash the WHOLE symbol's TRAIN
+    evidence for that config -- never partially accept the signal while
+    silently dropping/keeping the colliding rejection (or vice versa)."""
+    fold = _FOLD_0
+    bars_1m = _flat_bars_all_symbols(fold.train_start_ms, fold.oos_end_ms)
+    sidecar = _sidecars_with_rate(fold, 0.0001)
+    ts = fold.train_start_ms + 60_000
+    colliding_sig = _make_signal("BTCUSDT", ts, config_id="S1-00", fold_id=fold.fold_id)
+    colliding_rejection = _rejection(
+        signal_ts=ts, reason="target_direction_invalid", fold_id=fold.fold_id
+    )
+
+    def gen(symbol, bars_slice, fold_id):
+        if symbol != "BTCUSDT":
+            return ()
+        return GeneratedSignalBatch(
+            signals=(colliding_sig,), rejections=(colliding_rejection,)
+        )
+
+    crash_notes: dict = {}
+    candidates = _evaluate_fold_train(
+        "S1",
+        _configs_with_target_gen(gen),
+        bars_1m,
+        sidecar,
+        _no_gaps(),
+        fold,
+        crash_notes,
+        {},
+    )
+    btc_evidence = _btc_train_evidence(candidates)
+    # Crashed -- zero partial evidence (no completed_trades, no leaked counts
+    # from either the accepted-but-forbidden signal or the rejection).
+    assert btc_evidence.completed_trades == 0
+    assert "S1-00" in crash_notes
+
+
+def test_oos_signal_rejection_ts_collision_yields_crashed_terminal_evidence_not_partial():
+    fold = _FOLD_0
+    bars_1m = _flat_bars_all_symbols(fold.oos_start_ms, fold.oos_end_ms)
+    sidecar = _permissive_funding_sidecars()
+    ts = fold.oos_start_ms
+    colliding_sig = _make_signal("BTCUSDT", ts, config_id="S1-00", fold_id=fold.fold_id)
+    colliding_rejection = _rejection(
+        signal_ts=ts, reason="target_direction_invalid", fold_id=fold.fold_id
+    )
+
+    def gen(symbol, bars_slice, fold_id):
+        if symbol != "BTCUSDT":
+            return ()
+        return GeneratedSignalBatch(
+            signals=(colliding_sig,), rejections=(colliding_rejection,)
+        )
+
+    outcomes, ledgers = _evaluate_fold_oos(
+        "S1",
+        ConfigSpec(config_id="S1-00", generate_signals=gen),
+        bars_1m,
+        sidecar,
+        _no_gaps(),
+        fold,
+        {},
+        {},
+    )
+    btc_crashed = [o for o in outcomes if o.status == "crashed"]
+    assert (
+        len(btc_crashed) == 3
+    )  # all 3 independent scenarios crash, none partially succeed
+    assert all(len(v) == 0 for v in ledgers.values())
+
+
+def test_pre_execution_rejections_are_merged_into_a_completed_scenario_outcome():
+    bars = _flat_bars(0, 2 * 60_000)
+    sidecar = _permissive_funding_sidecars()["BTCUSDT"]
+    rejection = _rejection(signal_ts=0, reason="target_direction_invalid")
+
+    outcome, filtered = _run_scenario(
+        bars,
+        (),
+        COST_SCENARIOS[0],
+        sidecar,
+        (),
+        strategy="S1",
+        config_id="S1-00",
+        symbol="BTCUSDT",
+        fold_id="fold-00",
+        pre_execution_rejections=(rejection,),
+    )
+    assert outcome.status == "completed"
+    assert outcome.no_trade_reason_counts.get("target_direction_invalid") == 1
+    assert filtered is not None
+    assert any(nt.reason == "target_direction_invalid" for nt in filtered.no_trades)
+
+
+def test_pre_execution_rejections_survive_a_gap_rejected_scenario_outcome():
+    """Mirrors the funding-rejection-preserved-through-gap-rejection fix --
+    the generator's OWN pre-execution rejections must ALSO survive when the
+    run is separately gap-rejected."""
+    bars = _flat_bars(0, 4 * 60_000)
+    sidecar = _permissive_funding_sidecars()["BTCUSDT"]
+    sig_gap_touching = _make_signal(
+        "BTCUSDT", 120_000, config_id="S1-00", fold_id="fold-00", timeout_bars=1
+    )
+    rejection = _rejection(signal_ts=0, reason="target_direction_invalid")
+    gap_ranges = ((150_000, 151_000),)
+
+    outcome, filtered = _run_scenario(
+        bars,
+        (sig_gap_touching,),
+        COST_SCENARIO_PRIMARY_STRESS,
+        sidecar,
+        gap_ranges,
+        strategy="S1",
+        config_id="S1-00",
+        symbol="BTCUSDT",
+        fold_id="fold-00",
+        pre_execution_rejections=(rejection,),
+    )
+    assert outcome.status == "rejected"
+    assert filtered is None
+    assert outcome.no_trade_reason_counts.get("target_direction_invalid") == 1
+
+
+def test_normalized_batch_backward_compat_bare_tuple_generator_has_no_rejections():
+    """Every existing S1/test-fixture generator returns a bare
+    tuple[SignalEvent, ...] -- GeneratedSignalBatch normalization must keep
+    that working unchanged, with an empty rejections tuple."""
+    from rob944_walkforward import _normalize_generated_batch
+
+    sig = _make_signal("BTCUSDT", 0, config_id="S1-00", fold_id="fold-00")
+    batch = _normalize_generated_batch((sig,))
+    assert batch.signals == (sig,)
+    assert batch.rejections == ()
+
+
+def test_normalized_batch_passes_through_a_real_generated_signal_batch_unchanged():
+    """A real H3 adapter (e.g. the S2 factory) returns a GeneratedSignalBatch
+    directly -- normalization must pass it through as-is, never re-wrap or
+    drop its rejections."""
+    from rob944_walkforward import _normalize_generated_batch
+
+    sig = _make_signal("BTCUSDT", 0, config_id="S1-00", fold_id="fold-00")
+    rejection = _rejection(signal_ts=60_000)
+    batch_in = GeneratedSignalBatch(signals=(sig,), rejections=(rejection,))
+    batch_out = _normalize_generated_batch(batch_in)
+    assert batch_out is batch_in
+    assert batch_out.rejections == (rejection,)
+
+
+def test_real_generate_s2_signals_target_direction_invalid_survives_adapter_to_h4_scenario_evidence():
+    """Fable condition 1 end-to-end, using the ACTUAL real generator (not a
+    manually-constructed RejectedCandidate): reuses
+    test_rob940_signal_s2.py's own real-pipeline fixture
+    (``test_real_pipeline_target_direction_invalid_reason_count``) -- a
+    genuine confirmed shock whose target lands on the WRONG side of entry
+    for a long, so H3's real ``_evaluate_target_gates`` gate itself
+    produces the rejection, not a hand-built stand-in. Drives it through
+    the REAL run_rob944_campaign adapter conversion, REAL H4
+    _validate_generated_rejections, and a REAL _run_scenario call."""
+    import run_rob944_campaign as cli
+    from rob940_signal_manifest import get_s2_config
+    from rob940_signal_s2 import count_rejection_reasons, generate_s2_signals
+    from test_rob940_signal_s2 import _zigzag_then_shock
+
+    cfg = get_s2_config("S2-00")
+    bars_5m = _zigzag_then_shock(
+        shock_close=99.9, confirm_close=100.2, confirm_high=100.25, confirm_low=99.95
+    )
+    # E=101.0 puts E ABOVE T=100.6 for a long -> direction-invalid, even
+    # though the shock/confirmation themselves are perfectly valid.
+    bars_1m_fixture = [
+        Bar1m(
+            ts=bars_5m[-1].close_ts,
+            open=101.0,
+            high=101.1,
+            low=100.9,
+            close=101.05,
+            volume=10.0,
+        )
+    ]
+    result = generate_s2_signals(
+        bars_5m, bars_1m_fixture, cfg, symbol="XRPUSDT", fold_id="fold-00"
+    )
+    assert result.signals == ()
+    assert count_rejection_reasons(result.rejections) == {"target_direction_invalid": 1}
+
+    # REAL adapter conversion (the exact function _s2_gen_factory calls).
+    converted = cli._s2_rejections_to_no_trade_records(result.rejections)
+    assert len(converted) == 1
+    assert converted[0].reason == "target_direction_invalid"
+    assert converted[0].strategy == "S2"
+    assert converted[0].config_id == "S2-00"
+    assert converted[0].symbol == "XRPUSDT"
+
+    # REAL H4 identity/window validation, canonical order.
+    window_ms = bars_1m_fixture[0].ts
+    validated = _validate_generated_rejections(
+        converted,
+        strategy="S2",
+        config_id="S2-00",
+        symbol="XRPUSDT",
+        fold_id="fold-00",
+        window_start_ms=window_ms,
+        window_end_ms=window_ms,
+    )
+    assert validated[0].reason == "target_direction_invalid"
+
+    # REAL _run_scenario call: the rejection must survive into the
+    # completed scenario's own no_trade_reason_counts.
+    outcome, filtered = _run_scenario(
+        tuple(bars_1m_fixture),
+        (),
+        COST_SCENARIOS[0],
+        _permissive_funding_sidecars()["XRPUSDT"],
+        (),
+        strategy="S2",
+        config_id="S2-00",
+        symbol="XRPUSDT",
+        fold_id="fold-00",
+        pre_execution_rejections=validated,
+    )
+    assert outcome.status == "completed"
+    assert outcome.no_trade_reason_counts.get("target_direction_invalid") == 1
+
+
+# ---------------------------------------------------------------------------
+# Captain P1 (2026-07-17): a crash/timeout at EITHER stage of _run_scenario
+# must still preserve whatever no-trade evidence was already known at the
+# point of failure -- pre_execution_rejections survive either crash point;
+# funding_rejections additionally survive an engine-stage crash (since the
+# funding gate had already run by then).
+# ---------------------------------------------------------------------------
+
+
+def test_funding_gate_stage_crash_preserves_pre_execution_rejection_counts(monkeypatch):
+    bars = _flat_bars(0, 2 * 60_000)
+    sidecar = _permissive_funding_sidecars()["BTCUSDT"]
+    rejection = _rejection(signal_ts=0, reason="target_direction_invalid")
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError("simulated funding-gate crash")
+
+    monkeypatch.setattr(rob944_walkforward, "_apply_funding_gate", _boom)
+
+    outcome, filtered = _run_scenario(
+        bars,
+        (),
+        COST_SCENARIOS[0],
+        sidecar,
+        (),
+        strategy="S1",
+        config_id="S1-00",
+        symbol="BTCUSDT",
+        fold_id="fold-00",
+        pre_execution_rejections=(rejection,),
+    )
+    assert outcome.status == "crashed"
+    assert filtered is None
+    assert outcome.no_trade_reason_counts.get("target_direction_invalid") == 1
+
+
+def test_engine_stage_crash_preserves_both_funding_and_pre_execution_rejection_counts(
+    monkeypatch,
+):
+    bars = _flat_bars(0, 2 * 60_000)
+    rejection = _rejection(signal_ts=0, reason="target_direction_invalid")
+    # A signal that the funding gate itself REJECTS (entry before any known
+    # funding row) -- funding_rejections is non-empty by the time the
+    # (mocked) engine stage crashes.
+    sidecar_no_rate = FundingSidecar.from_rows("BTCUSDT", [])
+    sig_funding_rejected = _make_signal(
+        "BTCUSDT", 0, config_id="S1-00", fold_id="fold-00"
+    )
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError("simulated engine crash")
+
+    monkeypatch.setattr(rob944_walkforward, "run_symbol_stream", _boom)
+
+    outcome, filtered = _run_scenario(
+        bars,
+        (sig_funding_rejected,),
+        COST_SCENARIOS[0],
+        sidecar_no_rate,
+        (),
+        strategy="S1",
+        config_id="S1-00",
+        symbol="BTCUSDT",
+        fold_id="fold-00",
+        pre_execution_rejections=(rejection,),
+    )
+    assert outcome.status == "crashed"
+    assert filtered is None
+    assert outcome.no_trade_reason_counts.get("target_direction_invalid") == 1
+    assert outcome.no_trade_reason_counts.get("funding_evidence_unavailable") == 1
+
+
+def test_train_evidence_preserves_no_trade_reason_counts_on_gap_rejected_zero_evidence():
+    """The TRAIN-level _zero_evidence call site for a gap-rejected outcome
+    must carry outcome.no_trade_reason_counts through -- previously always
+    silently defaulted to empty, dropping a generator's own
+    pre_execution_rejections (e.g. target_direction_invalid) whenever the
+    TRAIN window's winning candidate was ALSO gap-rejected."""
+    fold = _FOLD_0
+    bars_1m = _flat_bars_all_symbols(fold.train_start_ms, fold.oos_end_ms)
+    sidecar = _sidecars_with_rate(fold, 0.0001)
+
+    ts = fold.train_start_ms + 60_000
+    rejection_ts = (
+        fold.train_start_ms
+    )  # DIFFERENT ts than the accepted signal -- no cross-list collision
+    rejection = _rejection(
+        signal_ts=rejection_ts, reason="target_direction_invalid", fold_id=fold.fold_id
+    )
+    sig_gap_touching = _make_signal(
+        "BTCUSDT", ts, config_id="S1-00", fold_id=fold.fold_id, timeout_bars=1
+    )
+    gap_ranges = dict.fromkeys(_SYMBOLS, ())
+    gap_ranges["BTCUSDT"] = ((ts + 30_000, ts + 31_000),)
+
+    def gen(symbol, bars_slice, fold_id):
+        if symbol != "BTCUSDT":
+            return ()
+        return GeneratedSignalBatch(
+            signals=(sig_gap_touching,), rejections=(rejection,)
+        )
+
+    candidates = _evaluate_fold_train(
+        "S1", _configs_with_target_gen(gen), bars_1m, sidecar, gap_ranges, fold, {}, {}
+    )
+    btc_evidence = _btc_train_evidence(candidates)
+    assert btc_evidence.no_trade_reason_counts.get("target_direction_invalid") == 1
+
+
+def test_funding_gate_stage_timeout_preserves_pre_execution_rejection_counts(
+    monkeypatch,
+):
+    """TimeoutError coverage (captain follow-up) -- same preservation
+    guarantee as a generic crash, but classified status="timeout"."""
+    bars = _flat_bars(0, 2 * 60_000)
+    sidecar = _permissive_funding_sidecars()["BTCUSDT"]
+    rejection = _rejection(signal_ts=0, reason="target_direction_invalid")
+
+    def _timeout(*args, **kwargs):
+        raise TimeoutError("simulated funding-gate timeout")
+
+    monkeypatch.setattr(rob944_walkforward, "_apply_funding_gate", _timeout)
+
+    outcome, filtered = _run_scenario(
+        bars,
+        (),
+        COST_SCENARIOS[0],
+        sidecar,
+        (),
+        strategy="S1",
+        config_id="S1-00",
+        symbol="BTCUSDT",
+        fold_id="fold-00",
+        pre_execution_rejections=(rejection,),
+    )
+    assert outcome.status == "timeout"
+    assert filtered is None
+    assert outcome.no_trade_reason_counts.get("target_direction_invalid") == 1
+
+
+def test_engine_stage_timeout_preserves_both_funding_and_pre_execution_rejection_counts(
+    monkeypatch,
+):
+    bars = _flat_bars(0, 2 * 60_000)
+    rejection = _rejection(signal_ts=0, reason="target_direction_invalid")
+    sidecar_no_rate = FundingSidecar.from_rows("BTCUSDT", [])
+    sig_funding_rejected = _make_signal(
+        "BTCUSDT", 0, config_id="S1-00", fold_id="fold-00"
+    )
+
+    def _timeout(*args, **kwargs):
+        raise TimeoutError("simulated engine timeout")
+
+    monkeypatch.setattr(rob944_walkforward, "run_symbol_stream", _timeout)
+
+    outcome, filtered = _run_scenario(
+        bars,
+        (sig_funding_rejected,),
+        COST_SCENARIOS[0],
+        sidecar_no_rate,
+        (),
+        strategy="S1",
+        config_id="S1-00",
+        symbol="BTCUSDT",
+        fold_id="fold-00",
+        pre_execution_rejections=(rejection,),
+    )
+    assert outcome.status == "timeout"
+    assert filtered is None
+    assert outcome.no_trade_reason_counts.get("target_direction_invalid") == 1
+    assert outcome.no_trade_reason_counts.get("funding_evidence_unavailable") == 1
+
+
+def test_crashed_scenario_artifact_hash_changes_when_preserved_histogram_changes():
+    """The preserved no_trade_reason_counts must be genuinely BOUND into
+    the crashed/timeout artifact_hash, not merely attached cosmetically."""
+    bars = _flat_bars(0, 2 * 60_000)
+    sidecar = _permissive_funding_sidecars()["BTCUSDT"]
+
+    def _make_outcome(reason):
+        rejection = _rejection(signal_ts=0, reason=reason)
+
+        def _boom(*args, **kwargs):
+            raise RuntimeError("simulated crash")
+
+        import pytest as _pytest
+
+        with _pytest.MonkeyPatch.context() as mp:
+            mp.setattr(rob944_walkforward, "_apply_funding_gate", _boom)
+            outcome, _filtered = _run_scenario(
+                bars,
+                (),
+                COST_SCENARIOS[0],
+                sidecar,
+                (),
+                strategy="S1",
+                config_id="S1-00",
+                symbol="BTCUSDT",
+                fold_id="fold-00",
+                pre_execution_rejections=(rejection,),
+            )
+        return outcome
+
+    outcome_a = _make_outcome("target_direction_invalid")
+    outcome_b = _make_outcome("tp_above_max")
+    assert outcome_a.status == outcome_b.status == "crashed"
+    assert outcome_a.artifact_hash != outcome_b.artifact_hash
+
+
+def test_train_evidence_preserves_no_trade_reason_counts_on_engine_crash_zero_evidence():
+    """The TRAIN-level _zero_evidence call site for a CRASHED (not just
+    gap-rejected) outcome must also carry outcome.no_trade_reason_counts
+    through."""
+    fold = _FOLD_0
+    bars_1m = _flat_bars_all_symbols(fold.train_start_ms, fold.oos_end_ms)
+    sidecar = _sidecars_with_rate(fold, 0.0001)
+
+    ts = fold.train_start_ms + 60_000
+    rejection_ts = (
+        fold.train_start_ms
+    )  # DIFFERENT ts than the accepted signal -- no cross-list collision
+    rejection = _rejection(
+        signal_ts=rejection_ts, reason="target_direction_invalid", fold_id=fold.fold_id
+    )
+    sig = _make_signal(
+        "BTCUSDT", ts, config_id="S1-00", fold_id=fold.fold_id, timeout_bars=1
+    )
+
+    def gen(symbol, bars_slice, fold_id):
+        if symbol != "BTCUSDT":
+            return ()
+        return GeneratedSignalBatch(signals=(sig,), rejections=(rejection,))
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError("simulated engine crash")
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(rob944_walkforward, "run_symbol_stream", _boom)
+        candidates = _evaluate_fold_train(
+            "S1",
+            _configs_with_target_gen(gen),
+            bars_1m,
+            sidecar,
+            _no_gaps(),
+            fold,
+            {},
+            {},
+        )
+    btc_evidence = _btc_train_evidence(candidates)
+    assert btc_evidence.no_trade_reason_counts.get("target_direction_invalid") == 1
+
+
+def test_oos_preserves_target_direction_invalid_in_each_of_all_3_crashed_scenarios():
+    """_evaluate_fold_oos runs 3 INDEPENDENT scenario invocations -- a
+    generator's own pre_execution_rejections must survive into EACH of the
+    3, not just one, when the engine crashes in every one of them."""
+    fold = _FOLD_0
+    bars_1m = _flat_bars_all_symbols(fold.oos_start_ms, fold.oos_end_ms)
+    sidecar = _permissive_funding_sidecars()
+    ts = fold.oos_start_ms
+    rejection = _rejection(
+        signal_ts=ts, reason="target_direction_invalid", fold_id=fold.fold_id
+    )
+
+    def gen(symbol, bars_slice, fold_id):
+        if symbol != "BTCUSDT":
+            return ()
+        return GeneratedSignalBatch(signals=(), rejections=(rejection,))
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError("simulated engine crash")
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(rob944_walkforward, "run_symbol_stream", _boom)
+        outcomes, _ledgers = _evaluate_fold_oos(
+            "S1",
+            ConfigSpec(config_id="S1-00", generate_signals=gen),
+            bars_1m,
+            sidecar,
+            _no_gaps(),
+            fold,
+            {},
+            {},
+        )
+    btc_outcomes = [o for o in outcomes if o.status == "crashed"]
+    # 4 symbols x 3 scenarios = 12 outcomes; only BTCUSDT's 3 carry the
+    # rejection (other symbols produced no signals/rejections at all).
+    btc_scenario_outcomes = [o for o in btc_outcomes if o.no_trade_reason_counts]
+    assert len(btc_scenario_outcomes) == 3
+    assert all(
+        o.no_trade_reason_counts.get("target_direction_invalid") == 1
+        for o in btc_scenario_outcomes
+    )

--- a/research/nautilus_scalping/tests/test_rob946_campaign_identity.py
+++ b/research/nautilus_scalping/tests/test_rob946_campaign_identity.py
@@ -172,9 +172,16 @@ def _rows(s1=_S1_ROWS, s2=_S2_ROWS) -> list[CampaignConfigRow]:
 
 
 def _sources() -> dict[str, StrategySourceProvenance]:
-    s1_text = "def donchian_15m_signal(): ...  # S1 placeholder pending H3"
+    # ROB-944 Q1 (orch-fable-answer-rob944-20260717.md, 2026-07-17): these
+    # strategy_key/strategy_version pairs are FROZEN PRODUCTION IDENTIFIERS
+    # (Fable-promoted), not a placeholder pending H3 -- H3 merged with its own
+    # actual signal source; the source TEXT below is still a stand-in for
+    # this identity-mechanism test only (the pure identity builder never reads
+    # real strategy source itself, it only hashes whatever text it is given).
+    s1_text = "def donchian_15m_signal(): ...  # S1 frozen production identifier (Fable-promoted 2026-07-17)"
     s2_text = (
-        "def confirmed_shock_reversal_5m_signal(): ...  # S2 placeholder pending H3"
+        "def confirmed_shock_reversal_5m_signal(): ...  "
+        "# S2 frozen production identifier (Fable-promoted 2026-07-17)"
     )
     return {
         "S1": StrategySourceProvenance(

--- a/tests/services/research/test_no_broker_import_guard.py
+++ b/tests/services/research/test_no_broker_import_guard.py
@@ -31,6 +31,8 @@ GUARDED_FILES: tuple[pathlib.Path, ...] = (
     REPO_ROOT / "app" / "services" / "research_campaign_bridge.py",
     REPO_ROOT / "app" / "services" / "research_db_write_guard.py",
     REPO_ROOT / "app" / "schemas" / "research_campaign_bridge.py",
+    # ROB-944 (H4) — thin --run preflight/registration controller.
+    REPO_ROOT / "app" / "services" / "rob944_campaign_controller.py",
     *sorted((REPO_ROOT / "research_contracts").glob("*.py")),
 )
 

--- a/tests/services/research/test_rob944_campaign_controller.py
+++ b/tests/services/research/test_rob944_campaign_controller.py
@@ -1,0 +1,1023 @@
+"""ROB-944 (H4, ROB-940) — thin --run preflight/registration controller.
+
+Covers the H4 empirical --run fail-closed gate (RED/regression matrix item
+11/12): identity/hash drift rejected BEFORE any DB call, deterministic
+primary attempt-key recording with an explicit AttemptKey<->experiment_id
+cross-check (captain audit item 4), and the full 24-registration + 24
+primary-attempt + completeness pipeline -- all against the local disposable
+test_db only, per the dispatch's "injected fakes/local disposable DB tests
+only" instruction. No empirical --run, network, or broker/order/fill access
+occurs anywhere in this file.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import uuid
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import text
+
+from app.schemas.research_backtest import StrategyExperimentIdentity
+from app.schemas.research_campaign_bridge import (
+    AttemptEvidence,
+    AttemptKey,
+    ScenarioEvidence,
+)
+from app.services import strategy_experiment_registry as reg
+from app.services.research_campaign_bridge import (
+    CampaignSpecCountError,
+    campaign_completeness_report,
+)
+from app.services.research_db_write_guard import ResearchDbPolicy, ResearchDbTarget
+from app.services.rob944_campaign_controller import (
+    AttemptKeyExperimentMismatchError,
+    CampaignBatchValidationError,
+    CampaignHashDriftError,
+    CampaignRunIdDerivationError,
+    RunIdentityMismatchError,
+    _derive_expected_campaign_run_id,
+    _derive_expected_run_identity,
+    _record_primary_attempt,
+    _run_preflight_and_register,
+    run_full_campaign,
+)
+
+_POLICY = ResearchDbPolicy.of(
+    ResearchDbTarget(host="localhost", database_name="test_db")
+)
+
+
+def _hex64(label: str) -> str:
+    return hashlib.sha256(label.encode()).hexdigest()
+
+
+def _identity(config_id: str, strategy_key: str) -> StrategyExperimentIdentity:
+    return StrategyExperimentIdentity(
+        strategy_key=strategy_key,
+        strategy_version="v1",
+        hypothesis="rob944 controller test",
+        strategy={"slug": "S1"},
+        code={"source_sha256": "0" * 64},
+        params={"config_id": config_id},
+        dataset_manifest={"corpus": "fixture"},
+        universe={"symbols": ["XRPUSDT"]},
+        pit={"window": "fixture"},
+        frozen_config={"timeframe": "15m"},
+        policy={"selection": "fixture"},
+        benchmark={},
+        cost={"primary_stress": 17.0},
+        mdd={"role": "report_only"},
+    )
+
+
+def _campaign_specs(strategy_key: str) -> list[StrategyExperimentIdentity]:
+    return [_identity(f"S1-{i:02d}", strategy_key) for i in range(24)]
+
+
+def _scenario_evidence() -> tuple:
+    return (
+        ScenarioEvidence(
+            scenario_name="base", trade_count=3, artifact_hash=_hex64("h-base")
+        ),
+        ScenarioEvidence(
+            scenario_name="primary_stress",
+            trade_count=3,
+            artifact_hash=_hex64("h-primary"),
+        ),
+        ScenarioEvidence(
+            scenario_name="upward_stress",
+            trade_count=2,
+            artifact_hash=_hex64("h-upward"),
+        ),
+    )
+
+
+def _evidence(
+    campaign_run_id: str, experiment_id: str, *, retry_index: int = 0
+) -> AttemptEvidence:
+    return AttemptEvidence(
+        attempt_key=AttemptKey(
+            campaign_run_id=campaign_run_id,
+            experiment_id=experiment_id,
+            retry_index=retry_index,
+        ),
+        status="completed",
+        reason_code=None,
+        fold_evidence_hash=_hex64("fold-hash-1"),
+        run_identity=_hex64(f"run-{uuid.uuid4().hex[:8]}"),
+        scenario_evidence=_scenario_evidence(),
+    )
+
+
+@pytest_asyncio.fixture
+async def registry_tables(db_session):
+    exists = await db_session.scalar(
+        text("SELECT to_regclass('research.strategy_experiments')")
+    )
+    if exists is None:
+        pytest.skip("ROB-846 registry tables are not migrated in this DB")
+    return db_session
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_hash_drift_is_rejected_before_any_db_call(registry_tables):
+    session = registry_tables
+    strategy_key = "ROB944-CTRL-DRIFT-" + uuid.uuid4().hex[:8]
+    specs = _campaign_specs(strategy_key)
+
+    with pytest.raises(CampaignHashDriftError):
+        await _run_preflight_and_register(
+            session,
+            specs=specs,
+            actual_full_campaign_hash="a" * 64,
+            expected_full_campaign_hash="b" * 64,
+            guard_opt_in_enabled=True,
+            guard_policy=_POLICY,
+        )
+
+    count = await session.scalar(
+        reg.select(reg.ResearchStrategyExperiment).where(
+            reg.ResearchStrategyExperiment.strategy_key == strategy_key
+        )
+    )
+    assert count is None  # nothing was registered
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_matching_hash_registers_all_24(registry_tables):
+    session = registry_tables
+    strategy_key = "ROB944-CTRL-MATCH-" + uuid.uuid4().hex[:8]
+    specs = _campaign_specs(strategy_key)
+
+    registered = await _run_preflight_and_register(
+        session,
+        specs=specs,
+        actual_full_campaign_hash="c" * 64,
+        expected_full_campaign_hash="c" * 64,
+        guard_opt_in_enabled=True,
+        guard_policy=_POLICY,
+    )
+    await session.flush()
+    assert len(registered) == 24
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test__record_primary_attempt_rejects_experiment_id_mismatch(registry_tables):
+    session = registry_tables
+    strategy_key = "ROB944-CTRL-EIDMISMATCH-" + uuid.uuid4().hex[:8]
+    specs = _campaign_specs(strategy_key)
+    registered = await _run_preflight_and_register(
+        session,
+        specs=specs,
+        actual_full_campaign_hash="d" * 64,
+        expected_full_campaign_hash="d" * 64,
+        guard_opt_in_enabled=True,
+        guard_policy=_POLICY,
+    )
+    await session.flush()
+    campaign_run_id = "run-" + uuid.uuid4().hex[:8]
+    real_id = registered[0].experiment_id
+    wrong_id = registered[1].experiment_id
+    evidence = _evidence(
+        campaign_run_id, wrong_id
+    )  # attempt_key names a DIFFERENT experiment
+
+    with pytest.raises(AttemptKeyExperimentMismatchError):
+        await _record_primary_attempt(
+            session,
+            experiment_id=real_id,
+            campaign_run_id=campaign_run_id,
+            evidence=evidence,
+            strategy_name="S1",
+            timeframe="15m",
+            runner="rob944-test",
+            guard_opt_in_enabled=True,
+            guard_policy=_POLICY,
+        )
+
+    trials = await reg.list_trials(session, real_id)
+    assert trials == []  # nothing was recorded under the mismatched call
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test__record_primary_attempt_rejects_campaign_run_id_mismatch(
+    registry_tables,
+):
+    session = registry_tables
+    strategy_key = "ROB944-CTRL-RUNIDMISMATCH-" + uuid.uuid4().hex[:8]
+    specs = _campaign_specs(strategy_key)
+    registered = await _run_preflight_and_register(
+        session,
+        specs=specs,
+        actual_full_campaign_hash="e" * 64,
+        expected_full_campaign_hash="e" * 64,
+        guard_opt_in_enabled=True,
+        guard_policy=_POLICY,
+    )
+    await session.flush()
+    exp_id = registered[0].experiment_id
+    evidence = _evidence("run-A", exp_id)
+
+    with pytest.raises(AttemptKeyExperimentMismatchError):
+        await _record_primary_attempt(
+            session,
+            experiment_id=exp_id,
+            campaign_run_id="run-B",
+            evidence=evidence,
+            strategy_name="S1",
+            timeframe="15m",
+            runner="rob944-test",
+            guard_opt_in_enabled=True,
+            guard_policy=_POLICY,
+        )
+    trials = await reg.list_trials(session, exp_id)
+    assert trials == []
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test__record_primary_attempt_mismatch_errors_never_echo_raw_ids(
+    registry_tables,
+):
+    """Captain delta sanitization pass (2026-07-17): neither the expected
+    (this call's own params) NOR the evidence's own self-reported
+    experiment_id/campaign_run_id may appear in the raised message -- field/
+    count-only text throughout, matching every other validation error in
+    this module."""
+    session = registry_tables
+    strategy_key = "ROB944-CTRL-SENTINELECHO-" + uuid.uuid4().hex[:8]
+    specs = _campaign_specs(strategy_key)
+    registered = await _run_preflight_and_register(
+        session,
+        specs=specs,
+        actual_full_campaign_hash="2" * 64,
+        expected_full_campaign_hash="2" * 64,
+        guard_opt_in_enabled=True,
+        guard_policy=_POLICY,
+    )
+    await session.flush()
+    real_id = registered[0].experiment_id
+    wrong_id = registered[1].experiment_id
+    campaign_run_id = "run-sentinel-" + uuid.uuid4().hex[:8]
+    evidence = _evidence(campaign_run_id, wrong_id)
+
+    with pytest.raises(AttemptKeyExperimentMismatchError) as exc_info:
+        await _record_primary_attempt(
+            session,
+            experiment_id=real_id,
+            campaign_run_id=campaign_run_id,
+            evidence=evidence,
+            strategy_name="S1",
+            timeframe="15m",
+            runner="rob944-test",
+            guard_opt_in_enabled=True,
+            guard_policy=_POLICY,
+        )
+    message = str(exc_info.value)
+    assert real_id not in message
+    assert wrong_id not in message
+    assert campaign_run_id not in message
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_full_pipeline_24_registrations_24_primary_attempts_reports_complete(
+    registry_tables,
+):
+    session = registry_tables
+    strategy_key = "ROB944-CTRL-FULL-" + uuid.uuid4().hex[:8]
+    specs = _campaign_specs(strategy_key)
+
+    registered = await _run_preflight_and_register(
+        session,
+        specs=specs,
+        actual_full_campaign_hash="f" * 64,
+        expected_full_campaign_hash="f" * 64,
+        guard_opt_in_enabled=True,
+        guard_policy=_POLICY,
+    )
+    await session.flush()
+    campaign_run_id = "run-" + uuid.uuid4().hex[:8]
+
+    for exp in registered:
+        evidence = _evidence(campaign_run_id, exp.experiment_id)
+        recorded = await _record_primary_attempt(
+            session,
+            experiment_id=exp.experiment_id,
+            campaign_run_id=campaign_run_id,
+            evidence=evidence,
+            strategy_name="S1",
+            timeframe="15m",
+            runner="rob944-test",
+            guard_opt_in_enabled=True,
+            guard_policy=_POLICY,
+        )
+        assert recorded is not None
+    await session.flush()
+
+    report = await campaign_completeness_report(
+        session, campaign_run_id=campaign_run_id, expected_specs=specs
+    )
+    assert report.verdict == "complete"
+    assert report.actual_registrations == 24
+    assert report.primary_attempts == 24
+    assert report.missing_experiment_ids == []
+    assert report.extra_experiment_ids == []
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test__record_primary_attempt_is_idempotent_on_identical_replay(
+    registry_tables,
+):
+    session = registry_tables
+    strategy_key = "ROB944-CTRL-IDEMPOTENT-" + uuid.uuid4().hex[:8]
+    specs = _campaign_specs(strategy_key)
+    registered = await _run_preflight_and_register(
+        session,
+        specs=specs,
+        actual_full_campaign_hash="1" * 64,
+        expected_full_campaign_hash="1" * 64,
+        guard_opt_in_enabled=True,
+        guard_policy=_POLICY,
+    )
+    await session.flush()
+    exp_id = registered[0].experiment_id
+    campaign_run_id = "run-" + uuid.uuid4().hex[:8]
+    evidence = _evidence(campaign_run_id, exp_id)
+
+    first = await _record_primary_attempt(
+        session,
+        experiment_id=exp_id,
+        campaign_run_id=campaign_run_id,
+        evidence=evidence,
+        strategy_name="S1",
+        timeframe="15m",
+        runner="rob944-test",
+        guard_opt_in_enabled=True,
+        guard_policy=_POLICY,
+    )
+    await session.flush()
+    second = await _record_primary_attempt(
+        session,
+        experiment_id=exp_id,
+        campaign_run_id=campaign_run_id,
+        evidence=evidence,
+        strategy_name="S1",
+        timeframe="15m",
+        runner="rob944-test",
+        guard_opt_in_enabled=True,
+        guard_policy=_POLICY,
+    )
+    assert first.id == second.id  # same row, not a duplicate trial
+
+
+# ---------------------------------------------------------------------------
+# run_full_campaign -- captain blocking correction (2026-07-17): the full
+# dependency-injected orchestration. Never a partial "24 registrations, no
+# attempts" write path -- every registered identity gets exactly one
+# deterministic retry_index=0 attempt recorded, and campaign_completeness_report
+# is the final word. ``build_attempt_evidence`` is the sole injection point
+# for the (research-side, never imported here) loader/walkforward/summarize
+# pipeline -- this test file only ever supplies FAKE evidence.
+# ---------------------------------------------------------------------------
+
+
+def _full_campaign_evidence_factory(
+    campaign_run_id, full_campaign_hash, *, status="completed", reason_code=None
+):
+    def _build(experiment_id_by_key):
+        out = []
+        fold_evidence_hash = _hex64("fold-hash-1")
+        for (skey, config_id), exp_id in experiment_id_by_key.items():
+            run_identity = _derive_expected_run_identity(
+                full_campaign_hash=full_campaign_hash,
+                campaign_run_id=campaign_run_id,
+                strategy_key=skey,
+                experiment_id=exp_id,
+                retry_index=0,
+                config_id=config_id,
+                status=status,
+                fold_evidence_hash=fold_evidence_hash,
+            )
+            out.append(
+                AttemptEvidence(
+                    attempt_key=AttemptKey(
+                        campaign_run_id=campaign_run_id,
+                        experiment_id=exp_id,
+                        retry_index=0,
+                    ),
+                    status=status,
+                    reason_code=reason_code,
+                    fold_evidence_hash=fold_evidence_hash,
+                    run_identity=run_identity,
+                    scenario_evidence=_scenario_evidence(),
+                )
+            )
+        return out
+
+    return _build
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_run_full_campaign_hash_drift_prevents_any_registration_or_attempt(
+    registry_tables,
+):
+    session = registry_tables
+    strategy_key = "ROB944-FULLCAMP-DRIFT-" + uuid.uuid4().hex[:8]
+    specs = _campaign_specs(strategy_key)
+    campaign_run_id = "run-" + uuid.uuid4().hex[:8]
+    called = {"n": 0}
+
+    def _boom(_experiment_id_by_key):
+        called["n"] += 1
+        raise AssertionError(
+            "build_attempt_evidence must never be called on hash drift"
+        )
+
+    with pytest.raises(CampaignHashDriftError):
+        await run_full_campaign(
+            session,
+            specs=specs,
+            actual_full_campaign_hash="a" * 64,
+            expected_full_campaign_hash="b" * 64,
+            campaign_run_id=campaign_run_id,
+            guard_opt_in_enabled=True,
+            guard_policy=_POLICY,
+            build_attempt_evidence=_boom,
+            strategy_name="S1",
+            timeframe="15m",
+            runner="rob944-test",
+        )
+    assert called["n"] == 0
+    row = await session.scalar(
+        reg.select(reg.ResearchStrategyExperiment).where(
+            reg.ResearchStrategyExperiment.strategy_key == strategy_key
+        )
+    )
+    assert row is None
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_run_full_campaign_rejects_malformed_hash_format_before_any_registration(
+    registry_tables,
+):
+    """Captain direct-controller identity gate: a malformed (non-hex64)
+    hash must be rejected fail-closed BEFORE registration/child execution,
+    independent of whatever the CLI already checked."""
+    session = registry_tables
+    strategy_key = "ROB944-FULLCAMP-MALFORMEDHASH-" + uuid.uuid4().hex[:8]
+    specs = _campaign_specs(strategy_key)
+    called = {"n": 0}
+
+    def _boom(_experiment_id_by_key):
+        called["n"] += 1
+        raise AssertionError(
+            "build_attempt_evidence must never be called on a malformed hash"
+        )
+
+    with pytest.raises(CampaignHashDriftError):
+        await run_full_campaign(
+            session,
+            specs=specs,
+            actual_full_campaign_hash="NOT-A-VALID-HEX64-HASH",
+            expected_full_campaign_hash="NOT-A-VALID-HEX64-HASH",
+            campaign_run_id="run-" + uuid.uuid4().hex[:8],
+            guard_opt_in_enabled=True,
+            guard_policy=_POLICY,
+            build_attempt_evidence=_boom,
+            strategy_name="S1",
+            timeframe="15m",
+            runner="rob944-test",
+        )
+    assert called["n"] == 0
+    row = await session.scalar(
+        reg.select(reg.ResearchStrategyExperiment).where(
+            reg.ResearchStrategyExperiment.strategy_key == strategy_key
+        )
+    )
+    assert row is None
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_run_full_campaign_rejects_arbitrary_campaign_run_id_before_any_registration(
+    registry_tables,
+):
+    """Captain direct-controller identity gate: even with a genuinely
+    matching, well-formed hash pair, an arbitrary UUID/timestamp
+    campaign_run_id (not the value canonically derived from the hash) must
+    be rejected fail-closed BEFORE any registration/child execution."""
+    session = registry_tables
+    strategy_key = "ROB944-FULLCAMP-ARBITRARYRUNID-" + uuid.uuid4().hex[:8]
+    specs = _campaign_specs(strategy_key)
+    matching_hash = "9" * 64
+    arbitrary_campaign_run_id = (
+        "run-" + uuid.uuid4().hex[:8]
+    )  # NOT derived from matching_hash
+    assert arbitrary_campaign_run_id != _derive_expected_campaign_run_id(matching_hash)
+    called = {"n": 0}
+
+    def _boom(_experiment_id_by_key):
+        called["n"] += 1
+        raise AssertionError(
+            "build_attempt_evidence must never be called on a bad campaign_run_id"
+        )
+
+    with pytest.raises(CampaignRunIdDerivationError):
+        await run_full_campaign(
+            session,
+            specs=specs,
+            actual_full_campaign_hash=matching_hash,
+            expected_full_campaign_hash=matching_hash,
+            campaign_run_id=arbitrary_campaign_run_id,
+            guard_opt_in_enabled=True,
+            guard_policy=_POLICY,
+            build_attempt_evidence=_boom,
+            strategy_name="S1",
+            timeframe="15m",
+            runner="rob944-test",
+        )
+    assert called["n"] == 0
+    row = await session.scalar(
+        reg.select(reg.ResearchStrategyExperiment).where(
+            reg.ResearchStrategyExperiment.strategy_key == strategy_key
+        )
+    )
+    assert row is None
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_run_full_campaign_run_id_derivation_error_never_echoes_either_campaign_run_id(
+    registry_tables,
+):
+    """Captain P1-C sanitization precision (2026-07-17): neither the
+    operator-supplied (arbitrary) campaign_run_id NOR the controller's own
+    canonically-derived "expected" one may appear in
+    CampaignRunIdDerivationError's message -- field/count-only, uniformly,
+    even for the OUR-OWN trusted-derived value."""
+    session = registry_tables
+    strategy_key = "ROB944-FULLCAMP-RUNIDSENTINEL-" + uuid.uuid4().hex[:8]
+    specs = _campaign_specs(strategy_key)
+    matching_hash = "4" * 64
+    arbitrary_campaign_run_id = "run-sentinel-" + uuid.uuid4().hex[:8]
+    expected_campaign_run_id = _derive_expected_campaign_run_id(matching_hash)
+    assert arbitrary_campaign_run_id != expected_campaign_run_id
+
+    def _boom(_experiment_id_by_key):
+        raise AssertionError(
+            "build_attempt_evidence must never be called on a bad campaign_run_id"
+        )
+
+    with pytest.raises(CampaignRunIdDerivationError) as exc_info:
+        await run_full_campaign(
+            session,
+            specs=specs,
+            actual_full_campaign_hash=matching_hash,
+            expected_full_campaign_hash=matching_hash,
+            campaign_run_id=arbitrary_campaign_run_id,
+            guard_opt_in_enabled=True,
+            guard_policy=_POLICY,
+            build_attempt_evidence=_boom,
+            strategy_name="S1",
+            timeframe="15m",
+            runner="rob944-test",
+        )
+    message = str(exc_info.value)
+    assert arbitrary_campaign_run_id not in message
+    assert expected_campaign_run_id not in message
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_run_full_campaign_batch_campaign_run_id_mismatch_never_echoes_ids(
+    registry_tables,
+):
+    """Captain P1-C sanitization precision: ``_validate_attempt_batch``'s
+    per-entry campaign_run_id check must never echo either the mismatched
+    attempt's experiment_id or its (wrong) campaign_run_id."""
+    session = registry_tables
+    strategy_key = "ROB944-FULLCAMP-BATCHRUNIDSENTINEL-" + uuid.uuid4().hex[:8]
+    specs = _campaign_specs(strategy_key)
+    campaign_run_id = _derive_expected_campaign_run_id("5" * 64)
+    wrong_campaign_run_id = "run-sentinel-wrong-" + uuid.uuid4().hex[:8]
+
+    def _build(experiment_id_by_key):
+        out = []
+        fold_evidence_hash = _hex64("fold-hash-1")
+        for i, ((skey, cfg), exp_id) in enumerate(experiment_id_by_key.items()):
+            # Every attempt names the CORRECT campaign_run_id except one,
+            # which claims a different (wrong) one.
+            this_run_id = wrong_campaign_run_id if i == 0 else campaign_run_id
+            run_identity = _derive_expected_run_identity(
+                full_campaign_hash="5" * 64,
+                campaign_run_id=campaign_run_id,
+                strategy_key=skey,
+                experiment_id=exp_id,
+                retry_index=0,
+                config_id=cfg,
+                status="completed",
+                fold_evidence_hash=fold_evidence_hash,
+            )
+            out.append(
+                AttemptEvidence(
+                    attempt_key=AttemptKey(
+                        campaign_run_id=this_run_id, experiment_id=exp_id, retry_index=0
+                    ),
+                    status="completed",
+                    reason_code=None,
+                    fold_evidence_hash=fold_evidence_hash,
+                    run_identity=run_identity,
+                    scenario_evidence=_scenario_evidence(),
+                )
+            )
+        return out
+
+    with pytest.raises(CampaignBatchValidationError) as exc_info:
+        await run_full_campaign(
+            session,
+            specs=specs,
+            actual_full_campaign_hash="5" * 64,
+            expected_full_campaign_hash="5" * 64,
+            campaign_run_id=campaign_run_id,
+            guard_opt_in_enabled=True,
+            guard_policy=_POLICY,
+            build_attempt_evidence=_build,
+            strategy_name="S1",
+            timeframe="15m",
+            runner="rob944-test",
+        )
+    message = str(exc_info.value)
+    assert wrong_campaign_run_id not in message
+    assert campaign_run_id not in message
+    report = await campaign_completeness_report(
+        session, campaign_run_id=campaign_run_id, expected_specs=specs
+    )
+    assert report.primary_attempts == 0
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_run_full_campaign_incomplete_verdict_message_never_echoes_injected_verdict_text(
+    registry_tables, monkeypatch
+):
+    """Captain P1-C sanitization precision (2026-07-17): ``report.verdict``
+    is ``Literal["complete", "incomplete"]`` at the schema layer, but this
+    module's own message must never interpolate it verbatim regardless --
+    uniform field-only text at this trust boundary even for values that
+    happen to be closed-enum-safe. Proven by monkeypatching
+    ``campaign_completeness_report`` (as bound into this controller module)
+    to return an obviously sentinel-injected verdict string and asserting
+    it never surfaces in the raised message."""
+    import app.services.rob944_campaign_controller as controller_module
+
+    session = registry_tables
+    strategy_key = "ROB944-FULLCAMP-VERDICTSENTINEL-" + uuid.uuid4().hex[:8]
+    specs = _campaign_specs(strategy_key)
+    campaign_run_id = _derive_expected_campaign_run_id("6" * 64)
+    build_evidence = _full_campaign_evidence_factory(campaign_run_id, "6" * 64)
+    sentinel_verdict = "SECRET-INJECTED-VERDICT-should-never-leak"
+
+    class _FakeReport:
+        verdict = sentinel_verdict
+
+    async def _fake_completeness_report(*args, **kwargs):
+        return _FakeReport()
+
+    monkeypatch.setattr(
+        controller_module, "campaign_completeness_report", _fake_completeness_report
+    )
+
+    with pytest.raises(controller_module.CampaignAccountingIncompleteError) as exc_info:
+        await run_full_campaign(
+            session,
+            specs=specs,
+            actual_full_campaign_hash="6" * 64,
+            expected_full_campaign_hash="6" * 64,
+            campaign_run_id=campaign_run_id,
+            guard_opt_in_enabled=True,
+            guard_policy=_POLICY,
+            build_attempt_evidence=build_evidence,
+            strategy_name="S1",
+            timeframe="15m",
+            runner="rob944-test",
+        )
+    assert sentinel_verdict not in str(exc_info.value)
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_run_full_campaign_registration_failure_never_calls_build_attempt_evidence(
+    registry_tables,
+):
+    session = registry_tables
+    strategy_key = "ROB944-FULLCAMP-REGFAIL-" + uuid.uuid4().hex[:8]
+    specs = _campaign_specs(strategy_key)[:23]  # wrong count -> CampaignSpecCountError
+    campaign_run_id = _derive_expected_campaign_run_id("c" * 64)
+    called = {"n": 0}
+
+    def _boom(_experiment_id_by_key):
+        called["n"] += 1
+        raise AssertionError(
+            "build_attempt_evidence must never be called after registration failure"
+        )
+
+    with pytest.raises(CampaignSpecCountError):
+        await run_full_campaign(
+            session,
+            specs=specs,
+            actual_full_campaign_hash="c" * 64,
+            expected_full_campaign_hash="c" * 64,
+            campaign_run_id=campaign_run_id,
+            guard_opt_in_enabled=True,
+            guard_policy=_POLICY,
+            build_attempt_evidence=_boom,
+            strategy_name="S1",
+            timeframe="15m",
+            runner="rob944-test",
+        )
+    assert called["n"] == 0
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_run_full_campaign_rejects_sentinel_reason_code_never_records_and_never_leaks_into_str_exc(
+    registry_tables,
+):
+    """Captain persistence-boundary correction: a reason_code outside the
+    controller's OWN closed, status-scoped allowlist (e.g. a sentinel
+    "SECRET" value a compromised/buggy build_attempt_evidence callback might
+    smuggle in) must be rejected fail-closed by ``_validate_attempt_batch``
+    -- BEFORE any ``record_attempt`` call for ANY of the 24 -- and the
+    sentinel value itself must never appear in the raised exception's own
+    message (which could be logged/printed/surfaced to an operator
+    terminal)."""
+    session = registry_tables
+    strategy_key = "ROB944-FULLCAMP-SENTINEL-" + uuid.uuid4().hex[:8]
+    specs = _campaign_specs(strategy_key)
+    campaign_run_id = _derive_expected_campaign_run_id("7" * 64)
+    sentinel = "SECRET-TOKEN-abc123"
+
+    def _build(experiment_id_by_key):
+        out = []
+        for i, ((_skey, _cfg), exp_id) in enumerate(experiment_id_by_key.items()):
+            # Every attempt is "completed" (reason_code=None) EXCEPT one,
+            # which claims "crashed" with a sentinel reason_code outside the
+            # closed allowlist for that status.
+            if i == 0:
+                status, reason = "crashed", sentinel
+            else:
+                status, reason = "completed", None
+            out.append(
+                AttemptEvidence(
+                    attempt_key=AttemptKey(
+                        campaign_run_id=campaign_run_id,
+                        experiment_id=exp_id,
+                        retry_index=0,
+                    ),
+                    status=status,
+                    reason_code=reason,
+                    fold_evidence_hash=_hex64("fold-hash-1"),
+                    run_identity=_hex64(f"run-identity-{exp_id}"),
+                    scenario_evidence=_scenario_evidence(),
+                )
+            )
+        return out
+
+    with pytest.raises(CampaignBatchValidationError) as exc_info:
+        await run_full_campaign(
+            session,
+            specs=specs,
+            actual_full_campaign_hash="7" * 64,
+            expected_full_campaign_hash="7" * 64,
+            campaign_run_id=campaign_run_id,
+            guard_opt_in_enabled=True,
+            guard_policy=_POLICY,
+            build_attempt_evidence=_build,
+            strategy_name="S1",
+            timeframe="15m",
+            runner="rob944-test",
+        )
+    assert sentinel not in str(exc_info.value)
+
+    report = await campaign_completeness_report(
+        session, campaign_run_id=campaign_run_id, expected_specs=specs
+    )
+    assert report.primary_attempts == 0  # no record_attempt call for ANY of the 24
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_run_full_campaign_rejects_forged_but_well_formed_run_identity(
+    registry_tables,
+):
+    """Independent controller audit correction (2026-07-17): a run_identity
+    that is a well-FORMED 64-hex string (passes _assert_hex64) but was not
+    actually derived from the trusted lineage facts (a forged/tampered/
+    arbitrary value) must still be rejected -- format alone is not enough.
+
+    Captain P1-C sanitization precision: the raised RunIdentityMismatchError
+    message must never interpolate experiment_id either, even though it is
+    trusted-derived at this point in the batch loop -- field-only text."""
+    session = registry_tables
+    strategy_key = "ROB944-FULLCAMP-FORGEDRUNID-" + uuid.uuid4().hex[:8]
+    specs = _campaign_specs(strategy_key)
+    campaign_run_id = _derive_expected_campaign_run_id("8" * 64)
+    forged_exp_ids: list[str] = []
+
+    def _build(experiment_id_by_key):
+        out = []
+        fold_evidence_hash = _hex64("fold-hash-1")
+        for (_skey, _config_id), exp_id in experiment_id_by_key.items():
+            forged_exp_ids.append(exp_id)
+            out.append(
+                AttemptEvidence(
+                    attempt_key=AttemptKey(
+                        campaign_run_id=campaign_run_id,
+                        experiment_id=exp_id,
+                        retry_index=0,
+                    ),
+                    status="completed",
+                    reason_code=None,
+                    fold_evidence_hash=fold_evidence_hash,
+                    run_identity=_hex64(
+                        f"forged-{exp_id}"
+                    ),  # well-formed hex64, but NOT re-derivable
+                    scenario_evidence=_scenario_evidence(),
+                )
+            )
+        return out
+
+    with pytest.raises(RunIdentityMismatchError) as exc_info:
+        await run_full_campaign(
+            session,
+            specs=specs,
+            actual_full_campaign_hash="8" * 64,
+            expected_full_campaign_hash="8" * 64,
+            campaign_run_id=campaign_run_id,
+            guard_opt_in_enabled=True,
+            guard_policy=_POLICY,
+            build_attempt_evidence=_build,
+            strategy_name="S1",
+            timeframe="15m",
+            runner="rob944-test",
+        )
+    message = str(exc_info.value)
+    assert all(exp_id not in message for exp_id in forged_exp_ids)
+    report = await campaign_completeness_report(
+        session, campaign_run_id=campaign_run_id, expected_specs=specs
+    )
+    assert report.primary_attempts == 0  # rejected before any record_attempt call
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_run_full_campaign_records_all_24_attempts_and_reports_complete(
+    registry_tables,
+):
+    session = registry_tables
+    strategy_key = "ROB944-FULLCAMP-FULL-" + uuid.uuid4().hex[:8]
+    specs = _campaign_specs(strategy_key)
+    campaign_run_id = _derive_expected_campaign_run_id("d" * 64)
+
+    report = await run_full_campaign(
+        session,
+        specs=specs,
+        actual_full_campaign_hash="d" * 64,
+        expected_full_campaign_hash="d" * 64,
+        campaign_run_id=campaign_run_id,
+        guard_opt_in_enabled=True,
+        guard_policy=_POLICY,
+        build_attempt_evidence=_full_campaign_evidence_factory(
+            campaign_run_id, "d" * 64
+        ),
+        strategy_name="S1",
+        timeframe="15m",
+        runner="rob944-test",
+    )
+    assert report.verdict == "complete"
+    assert report.actual_registrations == 24
+    assert report.primary_attempts == 24
+    assert report.status_counts["completed"] == 24
+    assert report.missing_experiment_ids == []
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_run_full_campaign_records_mixed_terminal_statuses_never_skipping_a_config(
+    registry_tables,
+):
+    session = registry_tables
+    strategy_key = "ROB944-FULLCAMP-MIXED-" + uuid.uuid4().hex[:8]
+    specs = _campaign_specs(strategy_key)
+    campaign_run_id = _derive_expected_campaign_run_id("e" * 64)
+    # Reason codes drawn from the controller's own closed, status-scoped
+    # allowlist (_ALLOWED_REASON_CODES_BY_STATUS) -- an arbitrary free-text
+    # reason (the old f"reason_{status}") is no longer accepted.
+    reasons_by_status = {
+        "completed": None,
+        "rejected": "rejected:data_gap_in_position",
+        "crashed": "child_execution_crashed",
+        "timeout": "child_execution_timeout",
+    }
+
+    def _build(experiment_id_by_key):
+        out = []
+        statuses = ["completed", "rejected", "crashed", "timeout"]
+        fold_evidence_hash = _hex64("fold-hash-1")
+        for i, ((skey, cfg), exp_id) in enumerate(experiment_id_by_key.items()):
+            status = statuses[i % 4]
+            run_identity = _derive_expected_run_identity(
+                full_campaign_hash="e" * 64,
+                campaign_run_id=campaign_run_id,
+                strategy_key=skey,
+                experiment_id=exp_id,
+                retry_index=0,
+                config_id=cfg,
+                status=status,
+                fold_evidence_hash=fold_evidence_hash,
+            )
+            out.append(
+                AttemptEvidence(
+                    attempt_key=AttemptKey(
+                        campaign_run_id=campaign_run_id,
+                        experiment_id=exp_id,
+                        retry_index=0,
+                    ),
+                    status=status,
+                    reason_code=reasons_by_status[status],
+                    fold_evidence_hash=fold_evidence_hash,
+                    run_identity=run_identity,
+                    scenario_evidence=_scenario_evidence(),
+                )
+            )
+        return out
+
+    report = await run_full_campaign(
+        session,
+        specs=specs,
+        actual_full_campaign_hash="e" * 64,
+        expected_full_campaign_hash="e" * 64,
+        campaign_run_id=campaign_run_id,
+        guard_opt_in_enabled=True,
+        guard_policy=_POLICY,
+        build_attempt_evidence=_build,
+        strategy_name="S1",
+        timeframe="15m",
+        runner="rob944-test",
+    )
+    assert report.verdict == "complete"
+    assert report.primary_attempts == 24
+    assert report.status_counts["completed"] == 6
+    assert report.status_counts["rejected"] == 6
+    assert report.status_counts["crashed"] == 6
+    assert report.status_counts["timeout"] == 6
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_run_full_campaign_is_idempotent_no_auto_retry_on_replay(registry_tables):
+    session = registry_tables
+    strategy_key = "ROB944-FULLCAMP-IDEMPOTENT-" + uuid.uuid4().hex[:8]
+    specs = _campaign_specs(strategy_key)
+    campaign_run_id = _derive_expected_campaign_run_id("f" * 64)
+    build_evidence = _full_campaign_evidence_factory(campaign_run_id, "f" * 64)
+
+    report1 = await run_full_campaign(
+        session,
+        specs=specs,
+        actual_full_campaign_hash="f" * 64,
+        expected_full_campaign_hash="f" * 64,
+        campaign_run_id=campaign_run_id,
+        guard_opt_in_enabled=True,
+        guard_policy=_POLICY,
+        build_attempt_evidence=build_evidence,
+        strategy_name="S1",
+        timeframe="15m",
+        runner="rob944-test",
+    )
+    report2 = await run_full_campaign(
+        session,
+        specs=specs,
+        actual_full_campaign_hash="f" * 64,
+        expected_full_campaign_hash="f" * 64,
+        campaign_run_id=campaign_run_id,
+        guard_opt_in_enabled=True,
+        guard_policy=_POLICY,
+        build_attempt_evidence=build_evidence,
+        strategy_name="S1",
+        timeframe="15m",
+        runner="rob944-test",
+    )
+    assert report1.primary_attempts == 24
+    assert report2.primary_attempts == 24  # replay, NOT 48 -- no duplicate/auto-retry
+    assert report2.retry_attempts == 0


### PR DESCRIPTION
## Summary

- Adds the H4 (ROB-940) walk-forward campaign layer: fold schedule, selection authority, signal ordering/gap-funding gates, scenario-evidence contract, the walk-forward runner, and the frozen acyclic campaign envelope (H1/H3 hash-pinned, byte-derived S1/S2 source provenance, execution-code provenance).
- `run_rob944_campaign.py` exposes a **pure `--plan`** (deterministic JSON, zero DB/network/file-write/env-mutation/child-execution, no process-global `sys.path` mutation) and a fully gated, dependency-injected `--run` path (**never invoked by this worker**) delegating to `app/services/rob944_campaign_controller.py` for H6 registration/persistence.
- Persistence-boundary hardening: a single normalization entry point (exact-type gating of every container/row/dict/string/lineage-arg, never `isinstance`) snapshots caller-owned summaries exactly once before any hashing, with operator-visible capture and H6 evidence-building always consuming the identical normalized objects.
- Extensive adversarial test coverage (stateful dict/tuple subclasses, AliasStr-style equality overrides, TOCTOU probes) proves rejection happens before any `canonical_sha256` call.

## Frozen configuration (this PR's HEAD)

- `full_campaign_hash`: `d48fc8442f2caab209c5880f91cb8d18b9b8456f88e64316acea17b4722525f2`
- `expected_campaign_run_id`: `rob944-primary-tqaxgJ1GBmpoVBCQk2shlHUJV4yJIxkAjY9vEZmsIJ4`
- `--plan` stdout SHA-256 (deterministic across `PYTHONHASHSEED` 0/1/999): `18c7350350e5fbd055ed9e9284817a2eec271f53963aff5c9b74a7df279c9690`
- Full frozen-config detail: `herdr-inbox/strategy-frozen-config-20260718-003750.md`

## Test plan

- [x] `research/nautilus_scalping/tests/` full H4/H3/H2 suite (rob944_folds, rob944_frozen_campaign, rob944_selection, rob944_signal_ordering, rob944_gap_funding, rob944_scenario_evidence, rob944_walkforward, rob944_cli, rob944_cli_import_guard, rob944_import_guard, rob940_signal_s1, rob940_signal_s2, rob940_engine) + `tests/services/research/test_rob944_campaign_controller.py` + `tests/services/research/test_no_broker_import_guard.py` — 474 passed
- [x] `ruff check` / `ruff format --check` clean on all touched files
- [x] `ty check` clean on `app/services/rob944_campaign_controller.py`
- [x] `git diff --check` clean
- [x] Pure `--plan` re-verified byte-deterministic post-commit (3× `PYTHONHASHSEED`, subprocess stdout captured to file)
- [x] Lossless `full_campaign_payload` self-hash independently reproduces `full_campaign_hash`
- [ ] Empirical `--run` — **deliberately NOT invoked**; a separate, later, explicit operator action

No empirical `--run`, database write, network access, or broker/order/fill/child-execution occurred anywhere in this branch's implementation or verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a complete ROB-944 campaign planning and execution workflow with deterministic campaign identities and accounting checks.
  * Added rolling walk-forward analysis with frozen folds, train-based configuration selection, scenario evidence, and canonical signal ordering.
  * Added data-gap detection and point-in-time funding cost safeguards.
  * Added fail-closed validation for campaign inputs, evidence, hashes, and execution outcomes.
  * Added command-line plan/run modes with sanitized reporting and lifecycle safeguards.

* **Documentation**
  * Corrected funding-crossing window documentation to use half-open interval semantics.

* **Tests**
  * Added extensive coverage for campaign integrity, walk-forward behavior, funding gates, evidence hashing, and CLI safety.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->