### PR TITLE
feat(ROB-953): reconcile Alpaca paper fills

### DIFF
--- a/.claude/settings.readonly.json
+++ b/.claude/settings.readonly.json
@@ -23,6 +23,7 @@
       "mcp__auto_trader_local__alpaca_paper_submit_order",
       "mcp__auto_trader_local__alpaca_paper_automated_submit_order",
       "mcp__auto_trader_local__alpaca_paper_cancel_order",
+      "mcp__auto_trader_local__alpaca_paper_reconcile_orders",
       "mcp__auto_trader_local__paper_execution_preview_order",
       "mcp__auto_trader_local__paper_execution_submit_order",
       "mcp__auto_trader_local__paper_execution_cancel_order",

--- a/app/mcp_server/README.md
+++ b/app/mcp_server/README.md
@@ -439,6 +439,17 @@ not part of the default or `hermes-paper-kis` surfaces.
 - `alpaca_paper_ledger_get(client_order_id)`
 - `alpaca_paper_execution_preflight_check(...)`
 
+`alpaca_paper_reconcile_orders(symbol=None, client_order_id=None, dry_run=True,
+confirm=False, limit=100)` is the confirm-gated, evidence-first fill-booking
+tool for manually submitted Alpaca paper orders. It queries the broker by the
+ledger `client_order_id`, normalizes the order/fill evidence through the shared
+fill classifier, and only books confirmed cumulative fills. `dry_run=True`
+returns transition plans without ledger writes; `dry_run=False` requires
+`confirm=True`. Missing or unreadable evidence is fail-closed: the row remains
+unchanged and is returned with `requires_manual_review=true`. This tool books
+to `filled` (or records an anomaly/partial state); it deliberately does not
+infer position or final reconciliation without independent evidence.
+
 `alpaca_paper_execution_preflight_check` is a read-only runner gate for the
 later automated paper cycle. It reads recent ledger rows and accepts optional
 caller-supplied read-only `open_orders`, `positions`, and `approval_packet`

--- a/app/mcp_server/README.md
+++ b/app/mcp_server/README.md
@@ -455,12 +455,13 @@ submitted Alpaca paper orders. It queries the broker by the ledger
 classifier, and only books confirmed cumulative fills. `dry_run=True` returns
 transition plans without ledger writes; `dry_run=False` requires `confirm=True`.
 
-Evidence handling is fail-closed. The row is left unchanged and returned with
-`requires_manual_review=true` when the broker read fails, the order is missing,
-the observed fills do not sum to the order's cumulative `filled_qty` (a
-truncated fill page would otherwise yield a wrong weighted average), or the
-broker reports `status=filled` with no bookable quantity. The reported `action`
-and the persisted `lifecycle_state` are derived from a single mapping, so they
+Evidence handling is fail-closed. For `status=filled`, the tool always walks the
+complete FILL activity feed with Alpaca `page_token` pagination, even when the
+order already includes `filled_qty` and `filled_avg_price`. The row is left
+unchanged and returned with `requires_manual_review=true` when the broker read
+fails, the order is missing, or the observed fills are empty, incomplete, or do
+not sum to the order's cumulative `filled_qty`. The reported `action` and the
+persisted `lifecycle_state` are derived from the confirmed write result, so they
 cannot disagree. The tool books to `filled` / `partial` / `anomaly` / `canceled`
 only; it deliberately does not infer position or final reconciliation without
 independent evidence.

--- a/app/mcp_server/README.md
+++ b/app/mcp_server/README.md
@@ -439,16 +439,31 @@ not part of the default or `hermes-paper-kis` surfaces.
 - `alpaca_paper_ledger_get(client_order_id)`
 - `alpaca_paper_execution_preflight_check(...)`
 
+### Alpaca paper fill reconcile (DB-writing mutation, ROB-953)
+
 `alpaca_paper_reconcile_orders(symbol=None, client_order_id=None, dry_run=True,
-confirm=False, limit=100)` is the confirm-gated, evidence-first fill-booking
-tool for manually submitted Alpaca paper orders. It queries the broker by the
-ledger `client_order_id`, normalizes the order/fill evidence through the shared
-fill classifier, and only books confirmed cumulative fills. `dry_run=True`
-returns transition plans without ledger writes; `dry_run=False` requires
-`confirm=True`. Missing or unreadable evidence is fail-closed: the row remains
-unchanged and is returned with `requires_manual_review=true`. This tool books
-to `filled` (or records an anomaly/partial state); it deliberately does not
-infer position or final reconciliation without independent evidence.
+confirm=False, limit=100)` is **not** part of the read-only surface above. It is
+a **DB-writing mutation** classified in `MUTATION_TOOLS`, denied by the
+read-only settings profile, and exposed on the **DEFAULT** profile behind
+`settings.alpaca_paper_default_tools_enabled` (default off) — not `us-paper`
+only. Broker access is read-only (it never submits, replaces, or cancels), but
+it writes lifecycle state to `review.alpaca_paper_order_ledger`.
+
+It is the confirm-gated, evidence-first fill-booking tool for manually
+submitted Alpaca paper orders. It queries the broker by the ledger
+`client_order_id`, normalizes the order/fill evidence through the shared fill
+classifier, and only books confirmed cumulative fills. `dry_run=True` returns
+transition plans without ledger writes; `dry_run=False` requires `confirm=True`.
+
+Evidence handling is fail-closed. The row is left unchanged and returned with
+`requires_manual_review=true` when the broker read fails, the order is missing,
+the observed fills do not sum to the order's cumulative `filled_qty` (a
+truncated fill page would otherwise yield a wrong weighted average), or the
+broker reports `status=filled` with no bookable quantity. The reported `action`
+and the persisted `lifecycle_state` are derived from a single mapping, so they
+cannot disagree. The tool books to `filled` / `partial` / `anomaly` / `canceled`
+only; it deliberately does not infer position or final reconciliation without
+independent evidence.
 
 `alpaca_paper_execution_preflight_check` is a read-only runner gate for the
 later automated paper cycle. It reads recent ledger rows and accepts optional

--- a/app/mcp_server/tooling/alpaca_paper_orders.py
+++ b/app/mcp_server/tooling/alpaca_paper_orders.py
@@ -36,6 +36,7 @@ from app.services.alpaca_paper_market_evidence import (
     MarketEvidenceError,
     load_market_evidence,
 )
+from app.services.alpaca_paper_reconcile_service import AlpacaPaperReconcileService
 from app.services.alpaca_paper_submit_service import (
     AlpacaPaperSubmitCoordinator,
     build_canonical_payload,
@@ -53,6 +54,7 @@ if TYPE_CHECKING:
 ALPACA_PAPER_MUTATING_TOOL_NAMES: set[str] = {
     "alpaca_paper_submit_order",
     "alpaca_paper_cancel_order",
+    "alpaca_paper_reconcile_orders",
 }
 
 SUBMIT_MAX_QTY: Decimal = Decimal("5")
@@ -427,6 +429,50 @@ async def alpaca_paper_cancel_order(
     }
 
 
+async def alpaca_paper_reconcile_orders(
+    *,
+    symbol: str | None = None,
+    client_order_id: str | None = None,
+    dry_run: bool = True,
+    confirm: bool = False,
+    limit: int = 100,
+) -> dict[str, Any]:
+    """Book broker-confirmed Alpaca paper fills into non-terminal ledger rows.
+
+    This only performs read-only broker evidence lookups plus existing ledger
+    writes. It never submits, replaces, or cancels a broker order.
+    """
+    if limit < 1:
+        raise ValueError("limit must be >= 1")
+    if not dry_run and not confirm:
+        return {
+            "success": False,
+            "dry_run": False,
+            "blocked_reason": "confirmation_required",
+        }
+    clean_symbol = symbol.strip().upper() if symbol and symbol.strip() else None
+    clean_order_id = (
+        client_order_id.strip() if client_order_id and client_order_id.strip() else None
+    )
+    async with _session_factory()() as db:
+        reconcile = AlpacaPaperReconcileService(
+            AlpacaPaperLedgerService(db), _service_factory()
+        )
+        result = await reconcile.reconcile(
+            symbol=clean_symbol,
+            client_order_id=clean_order_id,
+            dry_run=dry_run,
+            limit=min(limit, 200),
+        )
+    return {
+        "account_mode": "alpaca_paper",
+        "source": "alpaca_paper_reconcile_orders",
+        "symbol": clean_symbol,
+        "client_order_id": clean_order_id,
+        **result,
+    }
+
+
 def register_alpaca_paper_orders_tools(mcp: FastMCP) -> None:
     _ = mcp.tool(
         name="alpaca_paper_submit_order",
@@ -456,6 +502,15 @@ def register_alpaca_paper_orders_tools(mcp: FastMCP) -> None:
             "No bulk/all/by-symbol/by-status options. Paper endpoint only."
         ),
     )(alpaca_paper_cancel_order)
+    _ = mcp.tool(
+        name="alpaca_paper_reconcile_orders",
+        description=(
+            "Evidence-first reconcile for submitted Alpaca PAPER ledger rows. "
+            "Defaults to dry_run=True and returns transition plans with no DB writes. "
+            "Set dry_run=False and confirm=True to book only broker-confirmed fills. "
+            "Missing broker evidence remains unchanged and requires manual review."
+        ),
+    )(alpaca_paper_reconcile_orders)
 
 
 __all__ = [
@@ -464,6 +519,7 @@ __all__ = [
     "SUBMIT_MAX_QTY",
     "ORDER_ID_SAFE_SEGMENT_RE",
     "alpaca_paper_cancel_order",
+    "alpaca_paper_reconcile_orders",
     "alpaca_paper_submit_order",
     "register_alpaca_paper_orders_tools",
     "reset_alpaca_paper_orders_service_factory",

--- a/app/mcp_server/tooling/route_request_lanes.py
+++ b/app/mcp_server/tooling/route_request_lanes.py
@@ -190,7 +190,9 @@ MUTATION_TOOLS: frozenset[str] = frozenset(
     | KIWOOM_MOCK_TOOL_NAMES
     | KIWOOM_MOCK_US_MUTATION_TOOL_NAMES
     | MIRROR_COUNTERFACTUAL_TOOL_NAMES
-    # ROB-908: Alpaca paper confirm-gated order mutations (submit/cancel). Flag-
+    # ROB-908/ROB-953: Alpaca paper confirm-gated mutations — submit/cancel plus
+    # alpaca_paper_reconcile_orders, which reads the broker read-only but WRITES
+    # lifecycle state to review.alpaca_paper_order_ledger. Flag-
     # gated in DEFAULT (settings.alpaca_paper_default_tools_enabled, default off);
     # the read/preview/us_dual/ledger surface is read-only and lives in
     # READ_ONLY_ADVISORY_TOOLS. The automated-submit tool is not registered in
@@ -282,7 +284,8 @@ READ_ONLY_ADVISORY_TOOLS: frozenset[str] = frozenset(
         # (ALPACA_PAPER_PREVIEW_TOOL_NAMES — no side effects, does not submit),
         # and the read-only us_dual capability/state/preview trio
         # (US_DUAL_PAPER_TOOL_NAMES, submit_enabled always False). The
-        # confirm-gated submit/cancel mutations live in MUTATION_TOOLS.
+        # confirm-gated submit/cancel mutations and the DB-writing
+        # alpaca_paper_reconcile_orders live in MUTATION_TOOLS.
         *ALPACA_PAPER_READONLY_TOOL_NAMES,
         *ALPACA_PAPER_PREVIEW_TOOL_NAMES,
         *US_DUAL_PAPER_TOOL_NAMES,

--- a/app/services/alpaca_paper_ledger_service.py
+++ b/app/services/alpaca_paper_ledger_service.py
@@ -14,7 +14,7 @@ from datetime import UTC, datetime
 from decimal import Decimal
 from typing import Any
 
-from sqlalchemy import func, select, text, update
+from sqlalchemy import func, or_, select, text, update
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -82,6 +82,8 @@ RECORD_KIND_EXECUTION = "execution"
 RECORD_KIND_RECONCILE = "reconcile"
 RECORD_KIND_ANOMALY = "anomaly"
 
+# ROB-953: states a reconcile pass never re-opens as a *booking candidate*.
+# Used for candidate selection only — not as a write guard.
 RECONCILE_TERMINAL_LIFECYCLE_STATES: frozenset[str] = frozenset(
     {
         LIFECYCLE_FILLED,
@@ -90,6 +92,23 @@ RECONCILE_TERMINAL_LIFECYCLE_STATES: frozenset[str] = frozenset(
         LIFECYCLE_FINAL_RECONCILED,
         LIFECYCLE_CANCELED,
         LIFECYCLE_ANOMALY,
+    }
+)
+
+# ROB-953: states from which a status write must never resurrect a row. Only
+# *completed* downstream states qualify — position/close/final bookkeeping has
+# already consumed the row, so re-deriving a state from a late broker read would
+# corrupt it.
+#
+# Deliberately EXCLUDES anomaly/canceled/filled: those are terminal outcomes but
+# remain legitimately re-transitionable (anomaly -> canceled once cancel evidence
+# lands, filled -> anomaly on contradicting evidence). An earlier revision of
+# this PR guarded on the full terminal set and silently broke anomaly -> canceled.
+RECONCILE_IMMUTABLE_LIFECYCLE_STATES: frozenset[str] = frozenset(
+    {
+        LIFECYCLE_POSITION_RECONCILED,
+        LIFECYCLE_CLOSED,
+        LIFECYCLE_FINAL_RECONCILED,
     }
 )
 
@@ -226,6 +245,12 @@ def _derive_lifecycle_state(
     if status in _ANOMALY_STATUSES:
         return LIFECYCLE_ANOMALY
     return LIFECYCLE_ANOMALY
+
+
+# ROB-953: public handle on the canonical mapping. The reconcile service derives
+# the state it reports from this exact function, so a reported action can never
+# diverge from what ``record_status`` persists.
+derive_lifecycle_state = _derive_lifecycle_state
 
 
 # ---------------------------------------------------------------------------
@@ -405,6 +430,35 @@ class AlpacaPaperLedgerService:
         if lifecycle_state is not None:
             stmt = stmt.where(AlpacaPaperOrderLedger.lifecycle_state == lifecycle_state)
         stmt = stmt.limit(limit)
+        result = await self._db.execute(stmt)
+        return list(result.scalars().all())
+
+    async def list_reconcile_candidates(
+        self,
+        limit: int = 100,
+        symbol: str | None = None,
+    ) -> list[AlpacaPaperOrderLedger]:
+        """Execution rows still eligible for fill booking, newest first.
+
+        ROB-953: eligibility (``record_kind``, non-terminal lifecycle, optional
+        symbol) is filtered in SQL *before* ``limit``. Selecting the newest N rows
+        first and filtering afterwards made an older open execution unrecoverable
+        as soon as N newer preview/terminal rows existed.
+        """
+        conditions: list[Any] = [
+            AlpacaPaperOrderLedger.record_kind == RECORD_KIND_EXECUTION,
+            AlpacaPaperOrderLedger.lifecycle_state.not_in(
+                RECONCILE_TERMINAL_LIFECYCLE_STATES
+            ),
+        ]
+        if symbol is not None:
+            conditions.append(AlpacaPaperOrderLedger.execution_symbol == symbol)
+        stmt = (
+            select(AlpacaPaperOrderLedger)
+            .where(*conditions)
+            .order_by(AlpacaPaperOrderLedger.created_at.desc())
+            .limit(limit)
+        )
         result = await self._db.execute(stmt)
         return list(result.scalars().all())
 
@@ -1446,14 +1500,27 @@ class AlpacaPaperLedgerService:
                 f"anomaly: order_status={order_status!r} during status check"
             )
 
+        # ROB-953 optimistic write guard, evaluated in SQL against the *live* row
+        # rather than the possibly-stale row read above.
+        guard_predicates: list[Any] = [
+            AlpacaPaperOrderLedger.lifecycle_state.not_in(
+                RECONCILE_IMMUTABLE_LIFECYCLE_STATES
+            )
+        ]
+        if filled_qty is not None:
+            # Cumulative fills are monotonic at the broker. Under concurrent
+            # partial-fill reconciles, a stale lower reading must not overwrite a
+            # higher already-persisted quantity (0.8 then 0.7 -> keep 0.8).
+            guard_predicates.append(
+                or_(
+                    AlpacaPaperOrderLedger.filled_qty.is_(None),
+                    AlpacaPaperOrderLedger.filled_qty <= filled_qty,
+                )
+            )
+
         update_result = await self._db.execute(
             update(AlpacaPaperOrderLedger)
-            .where(
-                AlpacaPaperOrderLedger.id == target_row.id,
-                AlpacaPaperOrderLedger.lifecycle_state.not_in(
-                    RECONCILE_TERMINAL_LIFECYCLE_STATES
-                ),
-            )
+            .where(AlpacaPaperOrderLedger.id == target_row.id, *guard_predicates)
             .values(**update_vals)
         )
 
@@ -1766,6 +1833,9 @@ __all__ = [
     "ApprovalProvenance",
     "CANONICAL_LIFECYCLE_STATES",
     "EXECUTED_LIFECYCLE_STATES",
+    "RECONCILE_IMMUTABLE_LIFECYCLE_STATES",
+    "RECONCILE_TERMINAL_LIFECYCLE_STATES",
+    "derive_lifecycle_state",
     "LIFECYCLE_ANOMALY",
     "LIFECYCLE_CANCELED",
     "LIFECYCLE_CLOSED",

--- a/app/services/alpaca_paper_ledger_service.py
+++ b/app/services/alpaca_paper_ledger_service.py
@@ -344,6 +344,14 @@ class SellReservationClaim:
     source_available: Decimal | None = None
 
 
+@dataclass(frozen=True)
+class StatusWriteResult:
+    """Fresh execution row plus the conditional UPDATE outcome."""
+
+    applied: bool
+    row: AlpacaPaperOrderLedger
+
+
 def is_inflight_execution(row: Any) -> bool:
     """True when an execution row is a claimed-but-not-yet-recorded submit.
 
@@ -1451,7 +1459,8 @@ class AlpacaPaperLedgerService:
         *,
         commit: bool = True,
         lifecycle_state_override: str | None = None,
-    ) -> AlpacaPaperOrderLedger:
+        return_write_result: bool = False,
+    ) -> AlpacaPaperOrderLedger | StatusWriteResult:
         """Update lifecycle state from a status-check response."""
         if lifecycle_state_override not in {None, LIFECYCLE_SUBMITTED}:
             raise ValueError("status lifecycle override may only retain submitted")
@@ -1523,16 +1532,26 @@ class AlpacaPaperLedgerService:
             .where(AlpacaPaperOrderLedger.id == target_row.id, *guard_predicates)
             .values(**update_vals)
         )
+        rowcount = getattr(update_result, "rowcount", None)
+        write_applied = rowcount is None or rowcount > 0
 
-        if raw_response is not None and getattr(update_result, "rowcount", 1) != 0:
+        if raw_response is not None and write_applied:
             await self._accumulate_raw_response(
                 client_order_id, "status", raw_response, row=target_row
             )
 
         if commit:
             await self._db.commit()
+        else:
+            await self._db.flush()
+
+        if return_write_result:
+            # expire_on_commit=False keeps target_row stale after a competing
+            # session wins. Refresh the execution row before reporting the write.
+            await self._db.refresh(target_row)
+            return StatusWriteResult(applied=write_applied, row=target_row)
+        if commit:
             return await self._require_row(client_order_id)
-        await self._db.flush()
         return target_row
 
     async def record_cancel(
@@ -1858,6 +1877,7 @@ __all__ = [
     "RECORD_KIND_RECONCILE",
     "RECORD_KIND_VALIDATION_ATTEMPT",
     "SellReservationClaim",
+    "StatusWriteResult",
     "SubmitClaim",
     "_derive_lifecycle_state",
     "_redact_sensitive_keys",

--- a/app/services/alpaca_paper_ledger_service.py
+++ b/app/services/alpaca_paper_ledger_service.py
@@ -82,6 +82,17 @@ RECORD_KIND_EXECUTION = "execution"
 RECORD_KIND_RECONCILE = "reconcile"
 RECORD_KIND_ANOMALY = "anomaly"
 
+RECONCILE_TERMINAL_LIFECYCLE_STATES: frozenset[str] = frozenset(
+    {
+        LIFECYCLE_FILLED,
+        LIFECYCLE_POSITION_RECONCILED,
+        LIFECYCLE_CLOSED,
+        LIFECYCLE_FINAL_RECONCILED,
+        LIFECYCLE_CANCELED,
+        LIFECYCLE_ANOMALY,
+    }
+)
+
 # ---------------------------------------------------------------------------
 # Sensitive key patterns — redact before any JSON persistence
 # ---------------------------------------------------------------------------
@@ -989,11 +1000,13 @@ class AlpacaPaperLedgerService:
         client_order_id: str,
         event_key: str,
         raw_response: dict[str, Any] | None,
+        *,
+        row: AlpacaPaperOrderLedger | None = None,
     ) -> None:
         if raw_response is None:
             return
         sanitized = _redact_sensitive_keys(raw_response)
-        row = await self._require_row(client_order_id)
+        row = row or await self._require_row(client_order_id)
         existing: dict[str, Any] = dict(row.raw_responses or {})
         target_key = event_key
         suffix = 2
@@ -1388,7 +1401,11 @@ class AlpacaPaperLedgerService:
         """Update lifecycle state from a status-check response."""
         if lifecycle_state_override not in {None, LIFECYCLE_SUBMITTED}:
             raise ValueError("status lifecycle override may only retain submitted")
-        target_row = await self._require_row(client_order_id)
+        target_row = await self.get_execution_by_client_order_id(client_order_id)
+        if target_row is None:
+            raise LedgerNotFoundError(
+                f"No execution row found for client_order_id={client_order_id!r}"
+            )
 
         order_status = order.get("status")
         filled_qty_raw = order.get("filled_qty") or order.get("filled_quantity")
@@ -1429,14 +1446,21 @@ class AlpacaPaperLedgerService:
                 f"anomaly: order_status={order_status!r} during status check"
             )
 
-        await self._db.execute(
+        update_result = await self._db.execute(
             update(AlpacaPaperOrderLedger)
-            .where(AlpacaPaperOrderLedger.id == target_row.id)
+            .where(
+                AlpacaPaperOrderLedger.id == target_row.id,
+                AlpacaPaperOrderLedger.lifecycle_state.not_in(
+                    RECONCILE_TERMINAL_LIFECYCLE_STATES
+                ),
+            )
             .values(**update_vals)
         )
 
-        if raw_response is not None:
-            await self._accumulate_raw_response(client_order_id, "status", raw_response)
+        if raw_response is not None and getattr(update_result, "rowcount", 1) != 0:
+            await self._accumulate_raw_response(
+                client_order_id, "status", raw_response, row=target_row
+            )
 
         if commit:
             await self._db.commit()

--- a/app/services/alpaca_paper_reconcile_service.py
+++ b/app/services/alpaca_paper_reconcile_service.py
@@ -46,6 +46,14 @@ _LIFECYCLE_ACTION_LABELS: dict[str, str] = {
 }
 
 
+def _json_safe(payload: dict[str, Any]) -> dict[str, Any]:
+    """Stringify Decimals so the evidence can land in the JSONB raw_responses."""
+    return {
+        key: str(value) if isinstance(value, Decimal) else value
+        for key, value in payload.items()
+    }
+
+
 def _decimal(value: Any) -> Decimal | None:
     if value is None:
         return None
@@ -354,7 +362,7 @@ class AlpacaPaperReconcileService:
         if dry_run:
             return result
 
-        updated = await self._ledger.record_status(
+        await self._ledger.record_status(
             row.client_order_id,
             {
                 "status": transition.broker_status,
@@ -362,11 +370,21 @@ class AlpacaPaperReconcileService:
                 "filled_avg_price": str(evidence.avg_price),
                 "id": order.id,
             },
+            # raw_response is persisted to a JSONB column: Decimal is not JSON
+            # serializable, so the evidence is stringified here.
             raw_response={
-                "reconcile_order": normalize_alpaca_order_for_classify(order, fills)
+                "reconcile_order": _json_safe(
+                    normalize_alpaca_order_for_classify(order, fills)
+                )
             },
         )
-        persisted = getattr(updated, "lifecycle_state", None)
+        # Re-read the EXECUTION row explicitly. record_status returns whichever
+        # row for this client_order_id is newest regardless of record_kind, so a
+        # sibling plan/preview row would otherwise look like a rejected write.
+        confirmed = await self._ledger.get_execution_by_client_order_id(
+            row.client_order_id
+        )
+        persisted = getattr(confirmed, "lifecycle_state", None)
         result["persisted_lifecycle_state"] = persisted
         if persisted is not None and persisted != transition.lifecycle_state:
             # The write guard rejected this update (stale quantity or a completed

--- a/app/services/alpaca_paper_reconcile_service.py
+++ b/app/services/alpaca_paper_reconcile_service.py
@@ -13,6 +13,7 @@ from app.services.alpaca_paper_ledger_service import (
     LIFECYCLE_SUBMITTED,
     RECONCILE_TERMINAL_LIFECYCLE_STATES,
     RECORD_KIND_EXECUTION,
+    StatusWriteResult,
     derive_lifecycle_state,
 )
 from app.services.brokers.kis.mock_scalping_exec.fill_evidence import (
@@ -242,10 +243,15 @@ class AlpacaPaperReconcileService:
     async def _load_order_fills(self, order: Any) -> list[Any]:
         """Page every FILL activity, then keep the ones belonging to ``order``."""
         collected: dict[str, Any] = {}
-        after: Any = None
+        page_token: str | None = None
         for _ in range(_MAX_FILL_PAGES):
             page = list(
-                await self._broker.list_fills(after=after, limit=_FILL_PAGE_LIMIT) or []
+                await self._broker.list_fills(
+                    page_token=page_token,
+                    page_size=_FILL_PAGE_LIMIT,
+                    direction="desc",
+                )
+                or []
             )
             for fill in page:
                 fill_id = getattr(fill, "id", None)
@@ -254,19 +260,16 @@ class AlpacaPaperReconcileService:
                 )
             if len(page) < _FILL_PAGE_LIMIT:
                 break
-            next_after = max(
-                (
-                    stamp
-                    for stamp in (
-                        getattr(fill, "transaction_time", None) for fill in page
-                    )
-                    if stamp is not None
-                ),
-                default=None,
+            last_activity_id = getattr(page[-1], "id", None)
+            next_page_token = (
+                str(last_activity_id) if last_activity_id is not None else None
             )
-            if next_after is None or next_after == after:
-                break
-            after = next_after
+            if next_page_token is None or next_page_token == page_token:
+                raise RuntimeError("fill_pagination_token_missing")
+            page_token = next_page_token
+        else:
+            # Never treat a bounded/truncated account activity feed as complete.
+            raise RuntimeError("fill_pagination_limit_exceeded")
         return [
             fill
             for fill in collected.values()
@@ -300,10 +303,13 @@ class AlpacaPaperReconcileService:
         cumulative = _decimal(getattr(order, "filled_qty", None))
         broker_avg = _decimal(getattr(order, "filled_avg_price", None))
 
-        # Fills are only read when the order alone cannot prove the fill: either
-        # it reports no cumulative quantity at all, or it reports one without a
-        # price to value it at.
-        needs_fills = cumulative is None or (cumulative > 0 and broker_avg is None)
+        # A terminal filled status must be backed by the complete activity set,
+        # even when the order payload already carries qty/average fields.
+        needs_fills = (
+            broker_status == "filled"
+            or cumulative is None
+            or (cumulative > 0 and broker_avg is None)
+        )
         fills: list[Any] = []
         if needs_fills:
             try:
@@ -357,12 +363,12 @@ class AlpacaPaperReconcileService:
             ),
         )
         result["transition_depth"] = transition.label
-        result["lifecycle_state"] = transition.lifecycle_state
-        result["action"] = transition.action(dry_run=dry_run)
         if dry_run:
+            result["lifecycle_state"] = transition.lifecycle_state
+            result["action"] = transition.action(dry_run=True)
             return result
 
-        await self._ledger.record_status(
+        status_write = await self._ledger.record_status(
             row.client_order_id,
             {
                 "status": transition.broker_status,
@@ -377,19 +383,50 @@ class AlpacaPaperReconcileService:
                     normalize_alpaca_order_for_classify(order, fills)
                 )
             },
+            return_write_result=True,
         )
-        # Re-read the EXECUTION row explicitly. record_status returns whichever
-        # row for this client_order_id is newest regardless of record_kind, so a
-        # sibling plan/preview row would otherwise look like a rejected write.
-        confirmed = await self._ledger.get_execution_by_client_order_id(
-            row.client_order_id
-        )
+        if isinstance(status_write, StatusWriteResult):
+            write_applied = status_write.applied
+            confirmed = status_write.row
+        else:
+            # Lightweight test doubles retain the historical row return contract.
+            write_applied = True
+            confirmed = status_write
+
         persisted = getattr(confirmed, "lifecycle_state", None)
+        persisted_qty = _decimal(getattr(confirmed, "filled_qty", None))
+        persisted_avg = _decimal(getattr(confirmed, "filled_avg_price", None))
+        result["lifecycle_state"] = persisted
         result["persisted_lifecycle_state"] = persisted
-        if persisted is not None and persisted != transition.lifecycle_state:
-            # The write guard rejected this update (stale quantity or a completed
-            # row). Surface it instead of reporting a booking that did not land.
-            result.update(requires_manual_review=True, stale_write_rejected=True)
+        if persisted_qty is not None:
+            result["filled_qty"] = str(persisted_qty)
+        if persisted_avg is not None:
+            result["avg_price"] = str(persisted_avg)
+
+        write_confirmed = (
+            write_applied
+            and persisted == transition.lifecycle_state
+            and persisted_qty == broker_qty
+        )
+        if not write_confirmed:
+            # The SQL guard rejected the attempt, or a later concurrent write is
+            # already visible. Report the fresh row, never the precomputed intent.
+            result.update(
+                action="noop_stale_write_rejected",
+                transition_depth=(
+                    _LIFECYCLE_ACTION_LABELS.get(persisted, persisted or "none")
+                ),
+                delta_qty="0",
+                requires_manual_review=True,
+                stale_write_rejected=True,
+            )
+            return result
+
+        persisted_label = _LIFECYCLE_ACTION_LABELS.get(
+            persisted, persisted or transition.label
+        )
+        result["transition_depth"] = persisted_label
+        result["action"] = f"booked_{persisted_label}"
         return result
 
 

--- a/app/services/alpaca_paper_reconcile_service.py
+++ b/app/services/alpaca_paper_reconcile_service.py
@@ -2,13 +2,18 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from decimal import Decimal, InvalidOperation
 from typing import Any
 
 from app.services.alpaca_paper_ledger_service import (
-    KNOWN_OPEN_BROKER_STATUSES,
+    LIFECYCLE_ANOMALY,
+    LIFECYCLE_CANCELED,
+    LIFECYCLE_FILLED,
     LIFECYCLE_SUBMITTED,
+    RECONCILE_TERMINAL_LIFECYCLE_STATES,
     RECORD_KIND_EXECUTION,
+    derive_lifecycle_state,
 )
 from app.services.brokers.kis.mock_scalping_exec.fill_evidence import (
     FillEvidence,
@@ -16,16 +21,29 @@ from app.services.brokers.kis.mock_scalping_exec.fill_evidence import (
     classify_fill_evidence,
 )
 
-_TERMINAL_STATES = frozenset(
-    {
-        "filled",
-        "position_reconciled",
-        "closed",
-        "final_reconciled",
-        "canceled",
-        "anomaly",
-    }
-)
+# Alpaca's FILL activity feed is account-wide and page-capped, so one read can
+# omit fills belonging to an older order. Walk pages forward, bounded.
+_FILL_PAGE_LIMIT = 100
+_MAX_FILL_PAGES = 20
+
+# ---------------------------------------------------------------------------
+# ROB-953 — the single (evidence -> persisted state -> reported action) mapping
+# ---------------------------------------------------------------------------
+# Both the ``action`` returned to the caller and the ``lifecycle_state`` written
+# to the ledger are derived from ONE resolution below. Earlier revisions of this
+# PR computed them in two independent if/else ladders, which reported
+# ``booked_filled`` for a rejected order that actually persisted as ``anomaly``
+# (and ``booked_anomaly`` for rows that persisted as ``submitted``).
+#
+# The codomain of ``derive_lifecycle_state`` is exactly these four states.
+_LIFECYCLE_ACTION_LABELS: dict[str, str] = {
+    LIFECYCLE_FILLED: "filled",
+    # A booking transition that lands on ``submitted`` is by construction a
+    # partial fill: an open status carrying qty>0 derives ``anomaly`` instead.
+    LIFECYCLE_SUBMITTED: "partial",
+    LIFECYCLE_ANOMALY: "anomaly",
+    LIFECYCLE_CANCELED: "canceled",
+}
 
 
 def _decimal(value: Any) -> Decimal | None:
@@ -37,47 +55,126 @@ def _decimal(value: Any) -> Decimal | None:
         return None
 
 
+@dataclass(frozen=True)
+class ReconcileTransition:
+    """Binds the persisted lifecycle state to the reported action, one source.
+
+    ``broker_status`` is exactly the ``status`` handed to ``record_status``, and
+    ``lifecycle_state`` is what ``record_status`` will derive from it — same
+    function, same inputs — so the reported action cannot drift from the row.
+    """
+
+    broker_status: str
+    lifecycle_state: str
+
+    @property
+    def label(self) -> str:
+        return _LIFECYCLE_ACTION_LABELS.get(self.lifecycle_state, self.lifecycle_state)
+
+    def action(self, *, dry_run: bool) -> str:
+        return f"would_book_{self.label}" if dry_run else f"booked_{self.label}"
+
+
+def resolve_transition(
+    *,
+    verdict: FillVerdict,
+    broker_status: Any,
+    filled_qty: Decimal,
+    has_cancel_evidence: bool = False,
+) -> ReconcileTransition:
+    """Resolve the ledger status payload and lifecycle state from one evidence set."""
+    status = str(broker_status or "").strip().lower()
+    if verdict is FillVerdict.PARTIAL:
+        # The broker may report ``filled`` while the evidence only proves a
+        # partial cumulative quantity. Never promote past the evidence.
+        status = "partially_filled"
+    return ReconcileTransition(
+        broker_status=status,
+        lifecycle_state=derive_lifecycle_state(
+            status, filled_qty, has_cancel_evidence=has_cancel_evidence
+        ),
+    )
+
+
+@dataclass(frozen=True)
+class FillSetEvidence:
+    """Whether the observed fills fully account for the broker's cumulative qty."""
+
+    fills: list[Any]
+    summed_qty: Decimal | None
+    cumulative_qty: Decimal | None
+    complete: bool
+    reason: str | None
+
+    @property
+    def weighted_avg_price(self) -> Decimal | None:
+        """Quantity-weighted average, computed only from a complete fill set."""
+        if not self.complete:
+            return None
+        total_qty = Decimal("0")
+        total_notional = Decimal("0")
+        for fill in self.fills:
+            qty = _decimal(getattr(fill, "qty", None))
+            price = _decimal(getattr(fill, "price", None))
+            if qty is None or price is None:
+                return None
+            total_qty += qty
+            total_notional += qty * price
+        if total_qty <= 0:
+            return None
+        return total_notional / total_qty
+
+
+def summarize_fill_set(order: Any, fills: list[Any] | None) -> FillSetEvidence:
+    """Check the fills for ``order`` against the broker's own cumulative quantity.
+
+    A weighted average over a truncated fill set is simply a wrong price, so
+    completeness is proven before any average is derived. The authority is the
+    order's ``filled_qty``; when the order omits it, the highest ``cum_qty``
+    the fills themselves claim is used instead.
+    """
+    relevant = [
+        fill for fill in fills or [] if getattr(fill, "order_id", None) == order.id
+    ]
+    per_fill = [_decimal(getattr(fill, "qty", None)) for fill in relevant]
+    summed: Decimal | None = (
+        None
+        if any(qty is None for qty in per_fill)
+        else sum((qty for qty in per_fill if qty is not None), Decimal("0"))
+    )
+    cum_claims = [
+        cum
+        for cum in (_decimal(getattr(fill, "cum_qty", None)) for fill in relevant)
+        if cum is not None
+    ]
+    cumulative = _decimal(getattr(order, "filled_qty", None))
+    if cumulative is None:
+        cumulative = max(cum_claims, default=None)
+
+    if cumulative is None:
+        return FillSetEvidence(relevant, summed, None, False, "cumulative_qty_unknown")
+    if summed is None:
+        return FillSetEvidence(
+            relevant, None, cumulative, False, "unparseable_fill_quantity"
+        )
+    if summed != cumulative:
+        return FillSetEvidence(
+            relevant, summed, cumulative, False, "incomplete_fill_set"
+        )
+    return FillSetEvidence(relevant, summed, cumulative, True, None)
+
+
 def normalize_alpaca_order_for_classify(
     order: Any, fills: list[Any] | None = None
 ) -> dict[str, Any]:
     """Adapt Alpaca's cumulative order/fill values to the shared classifier shape."""
-    relevant = [
-        fill for fill in fills or [] if getattr(fill, "order_id", None) == order.id
-    ]
-    cumulative = max(
-        (_decimal(getattr(fill, "cum_qty", None)) or Decimal("0") for fill in relevant),
-        default=Decimal("0"),
-    )
-    filled_qty = _decimal(getattr(order, "filled_qty", None)) or cumulative
+    fill_set = summarize_fill_set(order, fills)
+    filled_qty = _decimal(getattr(order, "filled_qty", None))
+    if filled_qty is None:
+        filled_qty = fill_set.cumulative_qty
     avg_price = _decimal(getattr(order, "filled_avg_price", None))
     if avg_price is None:
-        priced_fills = [
-            (
-                _decimal(getattr(fill, "qty", None)),
-                _decimal(getattr(fill, "price", None)),
-            )
-            for fill in relevant
-        ]
-        total_qty = sum(
-            (
-                qty
-                for qty, price in priced_fills
-                if qty is not None and price is not None
-            ),
-            start=Decimal("0"),
-        )
-        if total_qty > 0:
-            avg_price = (
-                sum(
-                    (
-                        qty * price
-                        for qty, price in priced_fills
-                        if qty is not None and price is not None
-                    ),
-                    start=Decimal("0"),
-                )
-                / total_qty
-            )
+        avg_price = fill_set.weighted_avg_price
     return {
         "odno": order.id,
         "ord_qty": getattr(order, "qty", None),
@@ -105,12 +202,19 @@ class AlpacaPaperReconcileService:
             row = await self._ledger.get_execution_by_client_order_id(client_order_id)
             rows = [row] if row is not None else []
         else:
-            rows = await self._ledger.list_recent(limit=limit)
+            # Eligibility is filtered in SQL before ``limit`` so older open
+            # executions stay reachable behind newer preview/terminal rows.
+            rows = await self._ledger.list_reconcile_candidates(
+                limit=limit, symbol=symbol
+            )
+        # Re-assert the predicates in Python: defence in depth, and the only
+        # filter for the single-order lookup path.
         candidates = [
             row
             for row in rows
             if getattr(row, "record_kind", None) == RECORD_KIND_EXECUTION
-            and getattr(row, "lifecycle_state", None) not in _TERMINAL_STATES
+            and getattr(row, "lifecycle_state", None)
+            not in RECONCILE_TERMINAL_LIFECYCLE_STATES
             and (symbol is None or getattr(row, "execution_symbol", None) == symbol)
             and (
                 client_order_id is None
@@ -127,6 +231,40 @@ class AlpacaPaperReconcileService:
             "count": len(outcomes),
         }
 
+    async def _load_order_fills(self, order: Any) -> list[Any]:
+        """Page every FILL activity, then keep the ones belonging to ``order``."""
+        collected: dict[str, Any] = {}
+        after: Any = None
+        for _ in range(_MAX_FILL_PAGES):
+            page = list(
+                await self._broker.list_fills(after=after, limit=_FILL_PAGE_LIMIT) or []
+            )
+            for fill in page:
+                fill_id = getattr(fill, "id", None)
+                collected.setdefault(
+                    str(fill_id) if fill_id is not None else str(id(fill)), fill
+                )
+            if len(page) < _FILL_PAGE_LIMIT:
+                break
+            next_after = max(
+                (
+                    stamp
+                    for stamp in (
+                        getattr(fill, "transaction_time", None) for fill in page
+                    )
+                    if stamp is not None
+                ),
+                default=None,
+            )
+            if next_after is None or next_after == after:
+                break
+            after = next_after
+        return [
+            fill
+            for fill in collected.values()
+            if getattr(fill, "order_id", None) == order.id
+        ]
+
     async def _reconcile_one(self, row: Any, *, dry_run: bool) -> dict[str, Any]:
         result: dict[str, Any] = {
             "ledger_id": row.id,
@@ -134,50 +272,56 @@ class AlpacaPaperReconcileService:
             "symbol": row.execution_symbol,
             "transition_depth": "none",
         }
-        try:
-            order = await self._broker.get_order_by_client_order_id(row.client_order_id)
-        except Exception as exc:  # read failure is never execution evidence
+
+        def manual_review(reason: str) -> dict[str, Any]:
             result.update(
                 action="noop_requires_manual_review",
                 requires_manual_review=True,
-                reason=str(exc) or exc.__class__.__name__,
-            )
-            return result
-        if order is None:
-            result.update(
-                action="noop_requires_manual_review",
-                requires_manual_review=True,
-                reason="broker_order_not_found",
+                reason=reason,
             )
             return result
 
-        fills: list[Any] | None = None
-        if (
-            _decimal(getattr(order, "filled_qty", None)) or Decimal("0")
-        ) <= 0 or getattr(order, "filled_avg_price", None) is None:
+        try:
+            order = await self._broker.get_order_by_client_order_id(row.client_order_id)
+        except Exception as exc:  # read failure is never execution evidence
+            return manual_review(str(exc) or exc.__class__.__name__)
+        if order is None:
+            return manual_review("broker_order_not_found")
+
+        broker_status = str(getattr(order, "status", "") or "").strip().lower()
+        cumulative = _decimal(getattr(order, "filled_qty", None))
+        broker_avg = _decimal(getattr(order, "filled_avg_price", None))
+
+        # Fills are only read when the order alone cannot prove the fill: either
+        # it reports no cumulative quantity at all, or it reports one without a
+        # price to value it at.
+        needs_fills = cumulative is None or (cumulative > 0 and broker_avg is None)
+        fills: list[Any] = []
+        if needs_fills:
             try:
-                fills = await self._broker.list_fills(limit=100)
+                fills = await self._load_order_fills(order)
             except Exception as exc:
-                if str(getattr(order, "status", "")).lower() == "filled":
-                    result.update(
-                        action="noop_requires_manual_review",
-                        requires_manual_review=True,
-                        reason=str(exc) or exc.__class__.__name__,
-                    )
-                    return result
-                fills = None
+                return manual_review(str(exc) or exc.__class__.__name__)
+            fill_set = summarize_fill_set(order, fills)
+            if not fill_set.complete:
+                # A truncated / unreadable fill set yields a wrong average, so it
+                # is escalated rather than partially booked.
+                result["fill_set_complete"] = False
+                return manual_review(fill_set.reason or "incomplete_fill_set")
+            result["fill_set_complete"] = True
+
         evidence: FillEvidence = classify_fill_evidence(
             order_no=order.id, rows=[normalize_alpaca_order_for_classify(order, fills)]
         )
         result["verdict"] = evidence.verdict.value
+
         if evidence.verdict is FillVerdict.NONE:
-            result.update(
-                action="noop_requires_manual_review",
-                requires_manual_review=True,
-                reason=evidence.reason_code,
-            )
-            return result
+            return manual_review(evidence.reason_code)
         if evidence.verdict is FillVerdict.PENDING:
+            if broker_status == "filled":
+                # The broker calls the order filled but produced no quantity to
+                # book. That contradiction is escalated, never a silent no-op.
+                return manual_review("filled_status_without_fill_evidence")
             result.update(action="noop_pending")
             return result
 
@@ -195,30 +339,25 @@ class AlpacaPaperReconcileService:
             )
             return result
 
-        # An open status claiming a fill is explicitly recorded as the ledger's
-        # existing anomaly state; it must not be promoted to a terminal fill.
-        broker_status = str(getattr(order, "status", "")).lower()
-        anomaly = (
-            broker_status in KNOWN_OPEN_BROKER_STATUSES
-            and broker_status != "partially_filled"
-            and broker_qty > 0
+        transition = resolve_transition(
+            verdict=evidence.verdict,
+            broker_status=broker_status,
+            filled_qty=broker_qty,
+            has_cancel_evidence=(
+                getattr(row, "cancel_status", None) is not None
+                or getattr(row, "canceled_at", None) is not None
+            ),
         )
-        if anomaly:
-            target = "anomaly"
-        elif evidence.verdict is FillVerdict.PARTIAL:
-            target = "partial"
-        else:
-            target = "filled"
-        result["transition_depth"] = target
-        result["action"] = f"would_book_{target}" if dry_run else f"booked_{target}"
+        result["transition_depth"] = transition.label
+        result["lifecycle_state"] = transition.lifecycle_state
+        result["action"] = transition.action(dry_run=dry_run)
         if dry_run:
             return result
-        await self._ledger.record_status(
+
+        updated = await self._ledger.record_status(
             row.client_order_id,
             {
-                "status": "partially_filled"
-                if evidence.verdict is FillVerdict.PARTIAL
-                else order.status,
+                "status": transition.broker_status,
                 "filled_qty": str(broker_qty),
                 "filled_avg_price": str(evidence.avg_price),
                 "id": order.id,
@@ -226,11 +365,21 @@ class AlpacaPaperReconcileService:
             raw_response={
                 "reconcile_order": normalize_alpaca_order_for_classify(order, fills)
             },
-            lifecycle_state_override=(
-                LIFECYCLE_SUBMITTED if evidence.verdict is FillVerdict.PARTIAL else None
-            ),
         )
+        persisted = getattr(updated, "lifecycle_state", None)
+        result["persisted_lifecycle_state"] = persisted
+        if persisted is not None and persisted != transition.lifecycle_state:
+            # The write guard rejected this update (stale quantity or a completed
+            # row). Surface it instead of reporting a booking that did not land.
+            result.update(requires_manual_review=True, stale_write_rejected=True)
         return result
 
 
-__all__ = ["AlpacaPaperReconcileService", "normalize_alpaca_order_for_classify"]
+__all__ = [
+    "AlpacaPaperReconcileService",
+    "FillSetEvidence",
+    "ReconcileTransition",
+    "normalize_alpaca_order_for_classify",
+    "resolve_transition",
+    "summarize_fill_set",
+]

--- a/app/services/alpaca_paper_reconcile_service.py
+++ b/app/services/alpaca_paper_reconcile_service.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 from decimal import Decimal, InvalidOperation
 from typing import Any
 
-from app.services.alpaca_paper_ledger_service import KNOWN_OPEN_BROKER_STATUSES
+from app.services.alpaca_paper_ledger_service import (
+    KNOWN_OPEN_BROKER_STATUSES,
+    LIFECYCLE_SUBMITTED,
+    RECORD_KIND_EXECUTION,
+)
 from app.services.brokers.kis.mock_scalping_exec.fill_evidence import (
     FillEvidence,
     FillVerdict,
@@ -13,7 +17,14 @@ from app.services.brokers.kis.mock_scalping_exec.fill_evidence import (
 )
 
 _TERMINAL_STATES = frozenset(
-    {"filled", "position_reconciled", "closed", "final_reconciled", "canceled"}
+    {
+        "filled",
+        "position_reconciled",
+        "closed",
+        "final_reconciled",
+        "canceled",
+        "anomaly",
+    }
 )
 
 
@@ -39,8 +50,34 @@ def normalize_alpaca_order_for_classify(
     )
     filled_qty = _decimal(getattr(order, "filled_qty", None)) or cumulative
     avg_price = _decimal(getattr(order, "filled_avg_price", None))
-    if avg_price is None and relevant:
-        avg_price = _decimal(getattr(relevant[-1], "price", None))
+    if avg_price is None:
+        priced_fills = [
+            (
+                _decimal(getattr(fill, "qty", None)),
+                _decimal(getattr(fill, "price", None)),
+            )
+            for fill in relevant
+        ]
+        total_qty = sum(
+            (
+                qty
+                for qty, price in priced_fills
+                if qty is not None and price is not None
+            ),
+            start=Decimal("0"),
+        )
+        if total_qty > 0:
+            avg_price = (
+                sum(
+                    (
+                        qty * price
+                        for qty, price in priced_fills
+                        if qty is not None and price is not None
+                    ),
+                    start=Decimal("0"),
+                )
+                / total_qty
+            )
     return {
         "odno": order.id,
         "ord_qty": getattr(order, "qty", None),
@@ -64,11 +101,16 @@ class AlpacaPaperReconcileService:
         dry_run: bool = True,
         limit: int = 100,
     ) -> dict[str, Any]:
-        rows = await self._ledger.list_recent(limit=limit)
+        if client_order_id is not None:
+            row = await self._ledger.get_execution_by_client_order_id(client_order_id)
+            rows = [row] if row is not None else []
+        else:
+            rows = await self._ledger.list_recent(limit=limit)
         candidates = [
             row
             for row in rows
-            if getattr(row, "lifecycle_state", None) not in _TERMINAL_STATES
+            if getattr(row, "record_kind", None) == RECORD_KIND_EXECUTION
+            and getattr(row, "lifecycle_state", None) not in _TERMINAL_STATES
             and (symbol is None or getattr(row, "execution_symbol", None) == symbol)
             and (
                 client_order_id is None
@@ -115,7 +157,14 @@ class AlpacaPaperReconcileService:
         ) <= 0 or getattr(order, "filled_avg_price", None) is None:
             try:
                 fills = await self._broker.list_fills(limit=100)
-            except Exception:
+            except Exception as exc:
+                if str(getattr(order, "status", "")).lower() == "filled":
+                    result.update(
+                        action="noop_requires_manual_review",
+                        requires_manual_review=True,
+                        reason=str(exc) or exc.__class__.__name__,
+                    )
+                    return result
                 fills = None
         evidence: FillEvidence = classify_fill_evidence(
             order_no=order.id, rows=[normalize_alpaca_order_for_classify(order, fills)]
@@ -167,7 +216,9 @@ class AlpacaPaperReconcileService:
         await self._ledger.record_status(
             row.client_order_id,
             {
-                "status": order.status,
+                "status": "partially_filled"
+                if evidence.verdict is FillVerdict.PARTIAL
+                else order.status,
                 "filled_qty": str(broker_qty),
                 "filled_avg_price": str(evidence.avg_price),
                 "id": order.id,
@@ -175,6 +226,9 @@ class AlpacaPaperReconcileService:
             raw_response={
                 "reconcile_order": normalize_alpaca_order_for_classify(order, fills)
             },
+            lifecycle_state_override=(
+                LIFECYCLE_SUBMITTED if evidence.verdict is FillVerdict.PARTIAL else None
+            ),
         )
         return result
 

--- a/app/services/alpaca_paper_reconcile_service.py
+++ b/app/services/alpaca_paper_reconcile_service.py
@@ -1,0 +1,182 @@
+"""Evidence-first reconcile for manually submitted Alpaca paper orders (ROB-953)."""
+
+from __future__ import annotations
+
+from decimal import Decimal, InvalidOperation
+from typing import Any
+
+from app.services.alpaca_paper_ledger_service import KNOWN_OPEN_BROKER_STATUSES
+from app.services.brokers.kis.mock_scalping_exec.fill_evidence import (
+    FillEvidence,
+    FillVerdict,
+    classify_fill_evidence,
+)
+
+_TERMINAL_STATES = frozenset(
+    {"filled", "position_reconciled", "closed", "final_reconciled", "canceled"}
+)
+
+
+def _decimal(value: Any) -> Decimal | None:
+    if value is None:
+        return None
+    try:
+        return Decimal(str(value))
+    except (InvalidOperation, TypeError, ValueError):
+        return None
+
+
+def normalize_alpaca_order_for_classify(
+    order: Any, fills: list[Any] | None = None
+) -> dict[str, Any]:
+    """Adapt Alpaca's cumulative order/fill values to the shared classifier shape."""
+    relevant = [
+        fill for fill in fills or [] if getattr(fill, "order_id", None) == order.id
+    ]
+    cumulative = max(
+        (_decimal(getattr(fill, "cum_qty", None)) or Decimal("0") for fill in relevant),
+        default=Decimal("0"),
+    )
+    filled_qty = _decimal(getattr(order, "filled_qty", None)) or cumulative
+    avg_price = _decimal(getattr(order, "filled_avg_price", None))
+    if avg_price is None and relevant:
+        avg_price = _decimal(getattr(relevant[-1], "price", None))
+    return {
+        "odno": order.id,
+        "ord_qty": getattr(order, "qty", None),
+        "tot_ccld_qty": filled_qty,
+        "ccld_unpr": avg_price,
+    }
+
+
+class AlpacaPaperReconcileService:
+    """Reconcile existing non-terminal ledger rows using read-only broker evidence."""
+
+    def __init__(self, ledger: Any, broker: Any) -> None:
+        self._ledger = ledger
+        self._broker = broker
+
+    async def reconcile(
+        self,
+        *,
+        symbol: str | None = None,
+        client_order_id: str | None = None,
+        dry_run: bool = True,
+        limit: int = 100,
+    ) -> dict[str, Any]:
+        rows = await self._ledger.list_recent(limit=limit)
+        candidates = [
+            row
+            for row in rows
+            if getattr(row, "lifecycle_state", None) not in _TERMINAL_STATES
+            and (symbol is None or getattr(row, "execution_symbol", None) == symbol)
+            and (
+                client_order_id is None
+                or getattr(row, "client_order_id", None) == client_order_id
+            )
+        ]
+        outcomes = [
+            await self._reconcile_one(row, dry_run=dry_run) for row in candidates
+        ]
+        return {
+            "success": True,
+            "dry_run": dry_run,
+            "reconciled": outcomes,
+            "count": len(outcomes),
+        }
+
+    async def _reconcile_one(self, row: Any, *, dry_run: bool) -> dict[str, Any]:
+        result: dict[str, Any] = {
+            "ledger_id": row.id,
+            "client_order_id": row.client_order_id,
+            "symbol": row.execution_symbol,
+            "transition_depth": "none",
+        }
+        try:
+            order = await self._broker.get_order_by_client_order_id(row.client_order_id)
+        except Exception as exc:  # read failure is never execution evidence
+            result.update(
+                action="noop_requires_manual_review",
+                requires_manual_review=True,
+                reason=str(exc) or exc.__class__.__name__,
+            )
+            return result
+        if order is None:
+            result.update(
+                action="noop_requires_manual_review",
+                requires_manual_review=True,
+                reason="broker_order_not_found",
+            )
+            return result
+
+        fills: list[Any] | None = None
+        if (
+            _decimal(getattr(order, "filled_qty", None)) or Decimal("0")
+        ) <= 0 or getattr(order, "filled_avg_price", None) is None:
+            try:
+                fills = await self._broker.list_fills(limit=100)
+            except Exception:
+                fills = None
+        evidence: FillEvidence = classify_fill_evidence(
+            order_no=order.id, rows=[normalize_alpaca_order_for_classify(order, fills)]
+        )
+        result["verdict"] = evidence.verdict.value
+        if evidence.verdict is FillVerdict.NONE:
+            result.update(
+                action="noop_requires_manual_review",
+                requires_manual_review=True,
+                reason=evidence.reason_code,
+            )
+            return result
+        if evidence.verdict is FillVerdict.PENDING:
+            result.update(action="noop_pending")
+            return result
+
+        broker_qty = evidence.filled_qty or Decimal("0")
+        already = _decimal(getattr(row, "filled_qty", None)) or Decimal("0")
+        result.update(
+            filled_qty=str(broker_qty),
+            avg_price=str(evidence.avg_price),
+            delta_qty=str(broker_qty - already),
+        )
+        if broker_qty <= already:
+            result.update(
+                action="noop_already_booked",
+                transition_depth=getattr(row, "lifecycle_state", "none"),
+            )
+            return result
+
+        # An open status claiming a fill is explicitly recorded as the ledger's
+        # existing anomaly state; it must not be promoted to a terminal fill.
+        broker_status = str(getattr(order, "status", "")).lower()
+        anomaly = (
+            broker_status in KNOWN_OPEN_BROKER_STATUSES
+            and broker_status != "partially_filled"
+            and broker_qty > 0
+        )
+        if anomaly:
+            target = "anomaly"
+        elif evidence.verdict is FillVerdict.PARTIAL:
+            target = "partial"
+        else:
+            target = "filled"
+        result["transition_depth"] = target
+        result["action"] = f"would_book_{target}" if dry_run else f"booked_{target}"
+        if dry_run:
+            return result
+        await self._ledger.record_status(
+            row.client_order_id,
+            {
+                "status": order.status,
+                "filled_qty": str(broker_qty),
+                "filled_avg_price": str(evidence.avg_price),
+                "id": order.id,
+            },
+            raw_response={
+                "reconcile_order": normalize_alpaca_order_for_classify(order, fills)
+            },
+        )
+        return result
+
+
+__all__ = ["AlpacaPaperReconcileService", "normalize_alpaca_order_for_classify"]

--- a/app/services/brokers/alpaca/protocols.py
+++ b/app/services/brokers/alpaca/protocols.py
@@ -45,4 +45,7 @@ class AlpacaPaperBrokerProtocol(Protocol):
         after: datetime | None = None,
         until: datetime | None = None,
         limit: int | None = None,
+        page_token: str | None = None,
+        page_size: int | None = None,
+        direction: str | None = None,
     ) -> list[Fill]: ...

--- a/app/services/brokers/alpaca/service.py
+++ b/app/services/brokers/alpaca/service.py
@@ -186,14 +186,22 @@ class AlpacaPaperBrokerService:
         after: datetime | None = None,
         until: datetime | None = None,
         limit: int | None = None,
+        page_token: str | None = None,
+        page_size: int | None = None,
+        direction: str | None = None,
     ) -> list[Fill]:
         params: dict[str, str | int] = {}
         if after is not None:
             params["after"] = after.isoformat()
         if until is not None:
             params["until"] = until.isoformat()
-        if limit is not None:
-            params["limit"] = limit
+        if page_token is not None:
+            params["page_token"] = page_token
+        effective_page_size = page_size if page_size is not None else limit
+        if effective_page_size is not None:
+            params["page_size"] = effective_page_size
+        if direction is not None:
+            params["direction"] = direction
         data = await self._request("GET", "/v2/account/activities/FILL", params=params)
         if not data:
             return []

--- a/docs/superpowers/plans/2026-07-18-alpaca-paper-reconcile-orders.md
+++ b/docs/superpowers/plans/2026-07-18-alpaca-paper-reconcile-orders.md
@@ -1,0 +1,50 @@
+# Alpaca Paper Reconcile Orders Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Provide a confirm-gated MCP reconciliation route that books broker-confirmed Alpaca paper fills into the existing ledger.
+
+**Architecture:** A focused service lists only non-terminal Alpaca paper execution rows, normalizes the read-only Alpaca order/fill data into the shared KIS fill-evidence classifier input, and records only classifier-confirmed transitions. The MCP handler supplies scoping and the dry-run/confirm gate.
+
+**Tech Stack:** Python 3.13, FastMCP, SQLAlchemy async, Pydantic, pytest.
+
+## Global Constraints
+
+- Reuse `classify_fill_evidence`; do not duplicate verdict logic.
+- No broker mutation, production DB access, migration, or retrospective-service change.
+- Default to `dry_run=True`; `dry_run=False` requires `confirm=True`.
+- Missing/error evidence is fail-closed and reports manual review.
+
+---
+
+### Task 1: Evidence-first reconciliation service
+
+**Files:**
+- Create: `app/services/alpaca_paper_reconcile_service.py`
+- Test: `tests/services/test_alpaca_paper_reconcile_service.py`
+
+- [ ] Write RED tests for filled, partial, pending, missing evidence, anomaly, dry-run, and idempotency.
+- [ ] Run the focused tests and observe the missing-service failure.
+- [ ] Normalize Alpaca order/fill fields to `odno`, `ord_qty`, `tot_ccld_qty`, and `ccld_unpr`, then call `classify_fill_evidence`.
+- [ ] Use existing ledger `record_status` only for booked evidence and return structured no-op/manual-review plans otherwise.
+- [ ] Run focused service tests green.
+
+### Task 2: MCP exposure and contract tests
+
+**Files:**
+- Modify: `app/mcp_server/tooling/alpaca_paper_orders.py`
+- Modify: `tests/test_alpaca_paper_orders_tools.py`
+
+- [ ] Write RED tests covering the dry-run default, confirm gate, registration, scope, and ISRG evidence fixture.
+- [ ] Run the focused tests and observe the missing-tool failure.
+- [ ] Add `alpaca_paper_reconcile_orders` to the existing Alpaca paper mutating registration surface and delegate to Task 1.
+- [ ] Run focused tool tests green.
+
+### Task 3: Verification and delivery
+
+**Files:**
+- Modify: `app/mcp_server/README.md`
+
+- [ ] Document the reconcile tool and fail-closed scope.
+- [ ] Run the requested Alpaca, lane guard, lint, diff, and Alembic checks.
+- [ ] Commit, push the dedicated branch, and open a main-targeted PR.

--- a/tests/services/test_alpaca_paper_ledger_service.py
+++ b/tests/services/test_alpaca_paper_ledger_service.py
@@ -1409,6 +1409,27 @@ async def test_record_status_without_cancel_evidence_derives_anomaly():
 
 @pytest.mark.asyncio
 @pytest.mark.unit
+async def test_record_status_does_not_update_final_reconciled_row():
+    from app.models.review import AlpacaPaperOrderLedger
+    from app.services.alpaca_paper_ledger_service import AlpacaPaperLedgerService
+
+    row = _make_row(lifecycle_state="final_reconciled", record_kind="execution")
+    db = _mock_db_with_row(row)
+
+    await AlpacaPaperLedgerService(db).record_status(
+        "test-client-001",
+        order={"id": "bid1", "status": "filled", "filled_qty": "1"},
+    )
+
+    update_stmt = db.execute.call_args_list[1].args[0]
+    compiled = str(update_stmt.compile(compile_kwargs={"literal_binds": True}))
+    assert "lifecycle_state NOT IN" in compiled
+    assert "final_reconciled" in compiled
+    assert AlpacaPaperOrderLedger.__tablename__ in compiled
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
 async def test_record_cancel_transitions_to_canceled_if_order_status_is_canceled():
     from app.services.alpaca_paper_ledger_service import AlpacaPaperLedgerService
 

--- a/tests/services/test_alpaca_paper_ledger_service.py
+++ b/tests/services/test_alpaca_paper_ledger_service.py
@@ -1374,6 +1374,16 @@ def test_service_is_valid_python():
 @pytest.mark.asyncio
 @pytest.mark.unit
 async def test_record_status_with_cancel_evidence_derives_canceled():
+    """ROB-953: asserts the TRANSITION, not just the SET clause.
+
+    Do not trust a green CI here on the SET value alone — the previous version of
+    this test only compiled `update_params["lifecycle_state"]` and therefore
+    stayed green while a WHERE guard silently filtered the anomaly row out,
+    blocking the legitimate anomaly -> canceled transition entirely. A false
+    green. The WHERE clause is now asserted alongside the SET clause, and
+    `test_record_status_anomaly_to_canceled_transition_actually_lands` proves the
+    same path against a real row.
+    """
     from app.services.alpaca_paper_ledger_service import AlpacaPaperLedgerService
 
     row = _make_row(cancel_status="canceled", lifecycle_state="anomaly")
@@ -1385,8 +1395,21 @@ async def test_record_status_with_cancel_evidence_derives_canceled():
         order={"id": "bid1", "status": "canceled", "filled_qty": "0"},
     )
     update_stmt = db.execute.call_args_list[1].args[0]
-    update_params = update_stmt.compile().params
-    assert update_params["lifecycle_state"] == "canceled"
+    compiled = update_stmt.compile()
+    assert compiled.params["lifecycle_state"] == "canceled"
+
+    # The row's CURRENT state (anomaly) must not be excluded by the write guard,
+    # or the derived "canceled" would never be applied to any row.
+    guarded_states = {
+        state
+        for key, value in compiled.params.items()
+        if key.startswith("lifecycle_state_") and isinstance(value, list)
+        for state in value
+    }
+    assert guarded_states, "expected an immutable-state guard in the WHERE clause"
+    assert "anomaly" not in guarded_states
+    assert "canceled" not in guarded_states
+    assert guarded_states == {"position_reconciled", "closed", "final_reconciled"}
 
 
 @pytest.mark.asyncio

--- a/tests/services/test_alpaca_paper_reconcile_guard.py
+++ b/tests/services/test_alpaca_paper_reconcile_guard.py
@@ -1,0 +1,172 @@
+"""ROB-953 — record_status optimistic write guard, proven against real rows.
+
+These are DB-backed on purpose. The round-1 revision of this guard was covered
+only by a mock test that compiled the SET clause, so it stayed green while the
+WHERE clause silently blocked the legitimate ``anomaly -> canceled`` transition.
+Asserting the final persisted state is the only assertion that cannot go
+false-green that way.
+
+Guard contract:
+  * completed states (position_reconciled / closed / final_reconciled) are
+    immutable — a late broker read must not resurrect them;
+  * every other state, including the terminal-but-revisable anomaly / canceled /
+    filled, stays transitionable;
+  * cumulative filled_qty is monotonic — a stale lower reading never overwrites
+    a higher persisted one.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import delete, select
+
+from app.models.review import AlpacaPaperOrderLedger
+from app.models.trading import InstrumentType
+from app.services.alpaca_paper_ledger_service import AlpacaPaperLedgerService
+
+pytestmark = [pytest.mark.asyncio]
+
+_COIDS = (
+    "rob953-guard-anomaly-cancel",
+    "rob953-guard-final-reconciled",
+    "rob953-guard-monotonic",
+    "rob953-guard-filled-revisable",
+)
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def _clean_rows(db_session):
+    stmt = delete(AlpacaPaperOrderLedger).where(
+        AlpacaPaperOrderLedger.client_order_id.in_(_COIDS)
+    )
+    await db_session.execute(stmt)
+    await db_session.commit()
+    yield
+    await db_session.execute(stmt)
+    await db_session.commit()
+
+
+async def _seed(
+    db_session,
+    client_order_id: str,
+    *,
+    lifecycle_state: str,
+    filled_qty: Decimal | None = None,
+    cancel_status: str | None = None,
+) -> AlpacaPaperOrderLedger:
+    row = AlpacaPaperOrderLedger(
+        client_order_id=client_order_id,
+        lifecycle_correlation_id=client_order_id,
+        record_kind="execution",
+        broker="alpaca",
+        account_mode="alpaca_paper",
+        lifecycle_state=lifecycle_state,
+        execution_symbol="ISRG",
+        execution_venue="alpaca_paper",
+        instrument_type=InstrumentType.equity_us,
+        side="buy",
+        order_type="limit",
+        time_in_force="day",
+        filled_qty=filled_qty,
+        cancel_status=cancel_status,
+    )
+    db_session.add(row)
+    await db_session.commit()
+    return row
+
+
+async def _state(db_session, client_order_id: str) -> AlpacaPaperOrderLedger:
+    result = await db_session.execute(
+        select(AlpacaPaperOrderLedger).where(
+            AlpacaPaperOrderLedger.client_order_id == client_order_id
+        )
+    )
+    return result.scalar_one()
+
+
+async def test_anomaly_to_canceled_transition_actually_lands(db_session):
+    """The regression the round-1 guard introduced: a real anomaly row given
+    cancel evidence must end up canceled, not silently unchanged."""
+    coid = "rob953-guard-anomaly-cancel"
+    await _seed(db_session, coid, lifecycle_state="anomaly", cancel_status="canceled")
+
+    await AlpacaPaperLedgerService(db_session).record_status(
+        coid, {"id": "b1", "status": "canceled", "filled_qty": "0"}
+    )
+
+    assert (await _state(db_session, coid)).lifecycle_state == "canceled"
+
+
+async def test_filled_row_remains_transitionable_on_contradicting_evidence(db_session):
+    """``filled`` is terminal but not completed — it must stay revisable."""
+    coid = "rob953-guard-filled-revisable"
+    await _seed(db_session, coid, lifecycle_state="filled", filled_qty=Decimal("0.014"))
+
+    await AlpacaPaperLedgerService(db_session).record_status(
+        coid, {"id": "b1", "status": "rejected", "filled_qty": "0.014"}
+    )
+
+    assert (await _state(db_session, coid)).lifecycle_state == "anomaly"
+
+
+async def test_completed_row_is_never_resurrected_by_a_late_status_write(db_session):
+    """final_reconciled has already been consumed downstream — it is immutable."""
+    coid = "rob953-guard-final-reconciled"
+    await _seed(
+        db_session,
+        coid,
+        lifecycle_state="final_reconciled",
+        filled_qty=Decimal("0.014"),
+    )
+
+    await AlpacaPaperLedgerService(db_session).record_status(
+        coid, {"id": "b1", "status": "filled", "filled_qty": "0.014"}
+    )
+
+    row = await _state(db_session, coid)
+    assert row.lifecycle_state == "final_reconciled"
+    # the rejected write must not leave a raw_responses breadcrumb either
+    assert not (row.raw_responses or {})
+
+
+async def test_stale_lower_filled_qty_never_overwrites_a_higher_one(db_session):
+    """Concurrent partial reconciles: 0.8 lands, a stale 0.7 must be ignored."""
+    coid = "rob953-guard-monotonic"
+    await _seed(db_session, coid, lifecycle_state="submitted")
+    svc = AlpacaPaperLedgerService(db_session)
+
+    await svc.record_status(
+        coid, {"id": "b1", "status": "partially_filled", "filled_qty": "0.8"}
+    )
+    assert (await _state(db_session, coid)).filled_qty == Decimal("0.8")
+
+    # stale reader replays an older, lower cumulative quantity
+    await svc.record_status(
+        coid, {"id": "b1", "status": "partially_filled", "filled_qty": "0.7"}
+    )
+
+    row = await _state(db_session, coid)
+    assert row.filled_qty == Decimal("0.8"), "stale quantity regressed the row"
+
+
+async def test_equal_and_increasing_filled_qty_still_apply(db_session):
+    """Monotonicity must not block idempotent replay or genuine progress."""
+    coid = "rob953-guard-monotonic"
+    await _seed(db_session, coid, lifecycle_state="submitted")
+    svc = AlpacaPaperLedgerService(db_session)
+
+    await svc.record_status(
+        coid, {"id": "b1", "status": "partially_filled", "filled_qty": "0.7"}
+    )
+    await svc.record_status(
+        coid, {"id": "b1", "status": "partially_filled", "filled_qty": "0.7"}
+    )
+    assert (await _state(db_session, coid)).filled_qty == Decimal("0.7")
+
+    await svc.record_status(coid, {"id": "b1", "status": "filled", "filled_qty": "0.9"})
+    row = await _state(db_session, coid)
+    assert row.filled_qty == Decimal("0.9")
+    assert row.lifecycle_state == "filled"

--- a/tests/services/test_alpaca_paper_reconcile_guard.py
+++ b/tests/services/test_alpaca_paper_reconcile_guard.py
@@ -361,7 +361,7 @@ async def test_reconcile_response_reflects_competing_final_state(db_session):
     assert outcome["action"] == "noop_stale_write_rejected"
     assert outcome["lifecycle_state"] == "final_reconciled"
     assert outcome["persisted_lifecycle_state"] == "final_reconciled"
-    assert outcome["filled_qty"] == "0.8"
+    assert Decimal(outcome["filled_qty"]) == Decimal("0.8")
     assert outcome["stale_write_rejected"] is True
 
 
@@ -394,5 +394,5 @@ async def test_reconcile_response_reflects_competing_higher_quantity(db_session)
     assert outcome["action"] == "noop_stale_write_rejected"
     assert outcome["lifecycle_state"] == "submitted"
     assert outcome["persisted_lifecycle_state"] == "submitted"
-    assert outcome["filled_qty"] == "0.8"
+    assert Decimal(outcome["filled_qty"]) == Decimal("0.8")
     assert outcome["stale_write_rejected"] is True

--- a/tests/services/test_alpaca_paper_reconcile_guard.py
+++ b/tests/services/test_alpaca_paper_reconcile_guard.py
@@ -30,6 +30,8 @@ from app.services.alpaca_paper_ledger_service import AlpacaPaperLedgerService
 pytestmark = [pytest.mark.asyncio]
 
 _COIDS = (
+    "rob953-guard-e2e",
+    "rob953-guard-sibling-rows",
     "rob953-guard-anomaly-cancel",
     "rob953-guard-final-reconciled",
     "rob953-guard-monotonic",
@@ -170,3 +172,100 @@ async def test_equal_and_increasing_filled_qty_still_apply(db_session):
     row = await _state(db_session, coid)
     assert row.filled_qty == Decimal("0.9")
     assert row.lifecycle_state == "filled"
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: the real reconcile service against the real ledger service.
+# The unit suite drives a fake ledger, so this is the only place the two real
+# implementations meet — which is where record_status' return-row semantics bite.
+# ---------------------------------------------------------------------------
+
+
+class _FakeBroker:
+    def __init__(self, order):
+        self._order = order
+
+    async def get_order_by_client_order_id(self, _):
+        return self._order
+
+    async def list_fills(self, **_):
+        return []
+
+
+def _order(status: str = "filled", filled_qty: str = "1"):
+    from types import SimpleNamespace
+
+    return SimpleNamespace(
+        id="broker-order-1",
+        client_order_id="rob953-guard-sibling-rows",
+        qty=Decimal("1"),
+        filled_qty=Decimal(filled_qty),
+        filled_avg_price=Decimal("353.156"),
+        status=status,
+    )
+
+
+async def test_reconcile_books_through_the_real_ledger_service(db_session):
+    from app.services.alpaca_paper_reconcile_service import AlpacaPaperReconcileService
+
+    coid = "rob953-guard-e2e"
+    await _seed(db_session, coid, lifecycle_state="submitted")
+
+    result = await AlpacaPaperReconcileService(
+        AlpacaPaperLedgerService(db_session), _FakeBroker(_order())
+    ).reconcile(client_order_id=coid, dry_run=False)
+
+    outcome = result["reconciled"][0]
+    row = await _state(db_session, coid)
+    assert outcome["action"] == "booked_filled"
+    assert row.lifecycle_state == "filled"
+    assert row.filled_qty == Decimal("1")
+    # a successful booking must not be flagged as rejected
+    assert outcome.get("stale_write_rejected") is not True
+    assert outcome.get("requires_manual_review") is not True
+    assert outcome["persisted_lifecycle_state"] == "filled"
+
+
+async def test_sibling_preview_row_does_not_fake_a_rejected_write(db_session):
+    """A newer non-execution row sharing the client_order_id must not be mistaken
+    for the execution row when confirming what was persisted."""
+    from app.services.alpaca_paper_reconcile_service import AlpacaPaperReconcileService
+
+    coid = "rob953-guard-sibling-rows"
+    await _seed(db_session, coid, lifecycle_state="submitted")
+    # a preview row created *after* the execution row, same client_order_id
+    sibling = AlpacaPaperOrderLedger(
+        client_order_id=coid,
+        lifecycle_correlation_id=coid,
+        record_kind="preview",
+        broker="alpaca",
+        account_mode="alpaca_paper",
+        lifecycle_state="previewed",
+        execution_symbol="ISRG",
+        execution_venue="alpaca_paper",
+        instrument_type=InstrumentType.equity_us,
+        side="buy",
+        order_type="limit",
+        time_in_force="day",
+    )
+    db_session.add(sibling)
+    await db_session.commit()
+
+    result = await AlpacaPaperReconcileService(
+        AlpacaPaperLedgerService(db_session), _FakeBroker(_order())
+    ).reconcile(client_order_id=coid, dry_run=False)
+
+    outcome = result["reconciled"][0]
+    execution = (
+        await db_session.execute(
+            select(AlpacaPaperOrderLedger).where(
+                AlpacaPaperOrderLedger.client_order_id == coid,
+                AlpacaPaperOrderLedger.record_kind == "execution",
+            )
+        )
+    ).scalar_one()
+
+    assert execution.lifecycle_state == "filled"
+    assert outcome["persisted_lifecycle_state"] == "filled"
+    assert outcome.get("stale_write_rejected") is not True
+    assert outcome.get("requires_manual_review") is not True

--- a/tests/services/test_alpaca_paper_reconcile_guard.py
+++ b/tests/services/test_alpaca_paper_reconcile_guard.py
@@ -21,7 +21,7 @@ from decimal import Decimal
 
 import pytest
 import pytest_asyncio
-from sqlalchemy import delete, select
+from sqlalchemy import delete, select, update
 
 from app.models.review import AlpacaPaperOrderLedger
 from app.models.trading import InstrumentType
@@ -36,6 +36,8 @@ _COIDS = (
     "rob953-guard-final-reconciled",
     "rob953-guard-monotonic",
     "rob953-guard-filled-revisable",
+    "rob953-guard-final-race",
+    "rob953-guard-monotonic-race",
 )
 
 
@@ -189,7 +191,66 @@ class _FakeBroker:
         return self._order
 
     async def list_fills(self, **_):
-        return []
+        from types import SimpleNamespace
+
+        return [
+            SimpleNamespace(
+                id="fill-1",
+                order_id=self._order.id,
+                qty=self._order.filled_qty,
+                price=self._order.filled_avg_price,
+                cum_qty=self._order.filled_qty,
+            )
+        ]
+
+
+class _CompetingBroker(_FakeBroker):
+    """Commits a competing lifecycle write after reconcile loaded its stale row."""
+
+    def __init__(
+        self,
+        order,
+        *,
+        client_order_id: str,
+        lifecycle_state: str,
+        filled_qty: str,
+    ) -> None:
+        super().__init__(order)
+        self._client_order_id = client_order_id
+        self._lifecycle_state = lifecycle_state
+        self._filled_qty = Decimal(filled_qty)
+
+    async def get_order_by_client_order_id(self, _):
+        from app.core.db import AsyncSessionLocal
+
+        async with AsyncSessionLocal() as competing_session:
+            await competing_session.execute(
+                update(AlpacaPaperOrderLedger)
+                .where(
+                    AlpacaPaperOrderLedger.client_order_id == self._client_order_id,
+                    AlpacaPaperOrderLedger.record_kind == "execution",
+                )
+                .values(
+                    lifecycle_state=self._lifecycle_state,
+                    filled_qty=self._filled_qty,
+                    filled_avg_price=Decimal("353.156"),
+                )
+            )
+            await competing_session.commit()
+        return self._order
+
+
+async def _fresh_state(client_order_id: str) -> AlpacaPaperOrderLedger:
+    from app.core.db import AsyncSessionLocal
+
+    async with AsyncSessionLocal() as fresh_session:
+        result = await fresh_session.execute(
+            select(AlpacaPaperOrderLedger).where(
+                AlpacaPaperOrderLedger.client_order_id == client_order_id,
+                AlpacaPaperOrderLedger.record_kind == "execution",
+            )
+        )
+        return result.scalar_one()
 
 
 def _order(status: str = "filled", filled_qty: str = "1"):
@@ -269,3 +330,69 @@ async def test_sibling_preview_row_does_not_fake_a_rejected_write(db_session):
     assert outcome["persisted_lifecycle_state"] == "filled"
     assert outcome.get("stale_write_rejected") is not True
     assert outcome.get("requires_manual_review") is not True
+
+
+async def test_reconcile_response_reflects_competing_final_state(db_session):
+    """A rejected write must not report booked_filled from a stale identity map."""
+    from app.services.alpaca_paper_reconcile_service import AlpacaPaperReconcileService
+
+    coid = "rob953-guard-final-race"
+    await _seed(
+        db_session,
+        coid,
+        lifecycle_state="submitted",
+        filled_qty=Decimal("0"),
+    )
+    broker = _CompetingBroker(
+        _order(status="filled", filled_qty="1"),
+        client_order_id=coid,
+        lifecycle_state="final_reconciled",
+        filled_qty="0.8",
+    )
+
+    result = await AlpacaPaperReconcileService(
+        AlpacaPaperLedgerService(db_session), broker
+    ).reconcile(client_order_id=coid, dry_run=False)
+
+    outcome = result["reconciled"][0]
+    persisted = await _fresh_state(coid)
+    assert persisted.lifecycle_state == "final_reconciled"
+    assert persisted.filled_qty == Decimal("0.8")
+    assert outcome["action"] == "noop_stale_write_rejected"
+    assert outcome["lifecycle_state"] == "final_reconciled"
+    assert outcome["persisted_lifecycle_state"] == "final_reconciled"
+    assert outcome["filled_qty"] == "0.8"
+    assert outcome["stale_write_rejected"] is True
+
+
+async def test_reconcile_response_reflects_competing_higher_quantity(db_session):
+    """A stale 0.7 attempt must report the already-persisted 0.8, not a booking."""
+    from app.services.alpaca_paper_reconcile_service import AlpacaPaperReconcileService
+
+    coid = "rob953-guard-monotonic-race"
+    await _seed(
+        db_session,
+        coid,
+        lifecycle_state="submitted",
+        filled_qty=Decimal("0"),
+    )
+    broker = _CompetingBroker(
+        _order(status="partially_filled", filled_qty="0.7"),
+        client_order_id=coid,
+        lifecycle_state="submitted",
+        filled_qty="0.8",
+    )
+
+    result = await AlpacaPaperReconcileService(
+        AlpacaPaperLedgerService(db_session), broker
+    ).reconcile(client_order_id=coid, dry_run=False)
+
+    outcome = result["reconciled"][0]
+    persisted = await _fresh_state(coid)
+    assert persisted.lifecycle_state == "submitted"
+    assert persisted.filled_qty == Decimal("0.8")
+    assert outcome["action"] == "noop_stale_write_rejected"
+    assert outcome["lifecycle_state"] == "submitted"
+    assert outcome["persisted_lifecycle_state"] == "submitted"
+    assert outcome["filled_qty"] == "0.8"
+    assert outcome["stale_write_rejected"] is True

--- a/tests/services/test_alpaca_paper_reconcile_service.py
+++ b/tests/services/test_alpaca_paper_reconcile_service.py
@@ -93,12 +93,38 @@ class Ledger:
 class Broker:
     def __init__(self, order: Order | None) -> None:
         self.order = order
+        self.fill_calls: list[dict[str, Any]] = []
 
     async def get_order_by_client_order_id(self, _: str) -> Order | None:
         return self.order
 
-    async def list_fills(self, **_: Any) -> list[Any]:
-        return []
+    async def list_fills(
+        self,
+        *,
+        page_token: str | None = None,
+        page_size: int = 100,
+        direction: str = "desc",
+    ) -> list[Any]:
+        self.fill_calls.append(
+            {
+                "page_token": page_token,
+                "page_size": page_size,
+                "direction": direction,
+            }
+        )
+        if page_token is not None or self.order is None:
+            return []
+        qty = Decimal(str(self.order.filled_qty or 0))
+        if qty <= 0:
+            return []
+        return [
+            _fill(
+                self.order.id,
+                str(qty),
+                str(self.order.filled_avg_price or Decimal("353.156")),
+                str(qty),
+            )
+        ]
 
 
 def filled_order(*, status: str = "filled", qty: str = "0.014") -> Order:
@@ -475,15 +501,36 @@ def _fill(order_id: str, qty: str, price: str, cum: str, fill_id: str = "f1") ->
 
 
 class FillsBroker(Broker):
-    def __init__(self, order: Order | None, pages: list[list[Any]]) -> None:
+    """Alpaca-semantic activity fake: desc pages continue after page_token."""
+
+    def __init__(self, order: Order | None, activities: list[Any]) -> None:
         super().__init__(order)
-        self.pages = pages
+        self.activities = activities
         self.calls: list[dict[str, Any]] = []
 
-    async def list_fills(self, **kwargs: Any) -> list[Any]:
-        self.calls.append(kwargs)
-        index = len(self.calls) - 1
-        return self.pages[index] if index < len(self.pages) else []
+    async def list_fills(
+        self,
+        *,
+        page_token: str | None = None,
+        page_size: int = 100,
+        direction: str = "desc",
+    ) -> list[Any]:
+        assert direction == "desc"
+        self.calls.append(
+            {
+                "page_token": page_token,
+                "page_size": page_size,
+                "direction": direction,
+            }
+        )
+        start = 0
+        if page_token is not None:
+            start = next(
+                index + 1
+                for index, activity in enumerate(self.activities)
+                if str(activity.id) == page_token
+            )
+        return self.activities[start : start + page_size]
 
 
 @pytest.mark.asyncio
@@ -495,7 +542,7 @@ async def test_incomplete_fill_set_requires_manual_review_without_transition() -
     order = filled_order(qty="0.014")
     order.filled_avg_price = None
     ledger = Ledger([Row()])
-    broker = FillsBroker(order, [[_fill(order.id, "0.007", "100", "0.007")]])
+    broker = FillsBroker(order, [_fill(order.id, "0.007", "100", "0.007")])
 
     result = await AlpacaPaperReconcileService(ledger, broker).reconcile(dry_run=False)
     outcome = result["reconciled"][0]
@@ -510,22 +557,24 @@ async def test_incomplete_fill_set_requires_manual_review_without_transition() -
 
 @pytest.mark.asyncio
 async def test_filled_status_with_empty_fills_requires_manual_review() -> None:
-    """status=filled with no quantity and no fills is a contradiction, not a
-    silent noop_pending (which left real fills unbooked forever)."""
+    """A broker average cannot substitute for the required fill activity set."""
     from app.services.alpaca_paper_reconcile_service import AlpacaPaperReconcileService
 
-    order = filled_order(qty="0")
-    order.filled_qty = None
-    order.filled_avg_price = None
+    order = filled_order(qty="1")
     ledger = Ledger([Row()])
+    broker = FillsBroker(order, [])
 
-    result = await AlpacaPaperReconcileService(ledger, Broker(order)).reconcile(
+    result = await AlpacaPaperReconcileService(ledger, broker).reconcile(
         dry_run=False
     )
     outcome = result["reconciled"][0]
 
     assert outcome["action"] == "noop_requires_manual_review"
     assert outcome["requires_manual_review"] is True
+    assert outcome["reason"] == "incomplete_fill_set"
+    assert broker.calls == [
+        {"page_token": None, "page_size": 100, "direction": "desc"}
+    ]
     assert ledger.status_calls == []
 
 
@@ -560,10 +609,8 @@ async def test_complete_fill_set_books_exact_quantity_weighted_average() -> None
     broker = FillsBroker(
         order,
         [
-            [
-                _fill(order.id, "0.005", "100", "0.005", fill_id="a"),
-                _fill(order.id, "0.005", "110", "0.010", fill_id="b"),
-            ]
+            _fill(order.id, "0.005", "100", "0.005", fill_id="a"),
+            _fill(order.id, "0.005", "110", "0.010", fill_id="b"),
         ],
     )
 
@@ -594,13 +641,16 @@ async def test_fill_pages_are_walked_until_the_set_is_complete() -> None:
         page_one.append(fill)
     page_two = [_fill(order.id, "0.5", "200", "100.5", fill_id="p2-0")]
 
-    broker = FillsBroker(order, [page_one, page_two])
+    broker = FillsBroker(order, [*page_one, *page_two])
     ledger = Ledger([Row()])
 
     result = await AlpacaPaperReconcileService(ledger, broker).reconcile(dry_run=False)
     outcome = result["reconciled"][0]
 
     assert len(broker.calls) == 2
+    assert [call["page_token"] for call in broker.calls] == [None, "p1-99"]
+    assert all(call["page_size"] == 100 for call in broker.calls)
+    assert all(call["direction"] == "desc" for call in broker.calls)
     assert outcome["fill_set_complete"] is True
     assert outcome["action"] == "booked_filled"
     # (100 * 100 + 0.5 * 200) / 100.5

--- a/tests/services/test_alpaca_paper_reconcile_service.py
+++ b/tests/services/test_alpaca_paper_reconcile_service.py
@@ -564,17 +564,13 @@ async def test_filled_status_with_empty_fills_requires_manual_review() -> None:
     ledger = Ledger([Row()])
     broker = FillsBroker(order, [])
 
-    result = await AlpacaPaperReconcileService(ledger, broker).reconcile(
-        dry_run=False
-    )
+    result = await AlpacaPaperReconcileService(ledger, broker).reconcile(dry_run=False)
     outcome = result["reconciled"][0]
 
     assert outcome["action"] == "noop_requires_manual_review"
     assert outcome["requires_manual_review"] is True
     assert outcome["reason"] == "incomplete_fill_set"
-    assert broker.calls == [
-        {"page_token": None, "page_size": 100, "direction": "desc"}
-    ]
+    assert broker.calls == [{"page_token": None, "page_size": 100, "direction": "desc"}]
     assert ledger.status_calls == []
 
 

--- a/tests/services/test_alpaca_paper_reconcile_service.py
+++ b/tests/services/test_alpaca_paper_reconcile_service.py
@@ -1,0 +1,173 @@
+"""Evidence-first booking for manually submitted Alpaca paper orders (ROB-953)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import Any
+
+import pytest
+
+from app.services.brokers.alpaca.schemas import Order
+
+
+@dataclass
+class Row:
+    id: int = 20
+    client_order_id: str = "rob73-08ebbf8c64e2dd93"
+    execution_symbol: str = "ISRG"
+    lifecycle_state: str = "submitted"
+    filled_qty: Decimal = Decimal("0")
+
+
+class Ledger:
+    def __init__(self, rows: list[Row]) -> None:
+        self.rows = rows
+        self.status_calls: list[dict[str, Any]] = []
+
+    async def list_recent(self, limit: int) -> list[Row]:
+        return self.rows[:limit]
+
+    async def record_status(
+        self, client_order_id: str, order: dict[str, Any], **_: Any
+    ) -> Row:
+        self.status_calls.append(order)
+        row = next(r for r in self.rows if r.client_order_id == client_order_id)
+        row.filled_qty = Decimal(str(order["filled_qty"]))
+        row.lifecycle_state = (
+            "filled"
+            if order["status"] == "filled"
+            else "submitted"
+            if order["status"] == "partially_filled"
+            else "anomaly"
+        )
+        return row
+
+
+class Broker:
+    def __init__(self, order: Order | None) -> None:
+        self.order = order
+
+    async def get_order_by_client_order_id(self, _: str) -> Order | None:
+        return self.order
+
+    async def list_fills(self, **_: Any) -> list[Any]:
+        return []
+
+
+def filled_order(*, status: str = "filled", qty: str = "0.014") -> Order:
+    return Order(
+        id="36caf22a-e305-4b19-8fdb-3fb88d57c589",
+        client_order_id="rob73-08ebbf8c64e2dd93",
+        symbol="ISRG",
+        qty=Decimal("0.014"),
+        filled_qty=Decimal(qty),
+        filled_avg_price=Decimal("353.156"),
+        side="buy",
+        type="limit",
+        time_in_force="day",
+        status=status,
+    )
+
+
+@pytest.mark.asyncio
+async def test_reconcile_books_isrg_broker_fill_as_absolute_ledger_status() -> None:
+    from app.services.alpaca_paper_reconcile_service import AlpacaPaperReconcileService
+
+    ledger = Ledger([Row()])
+    result = await AlpacaPaperReconcileService(
+        ledger, Broker(filled_order())
+    ).reconcile(dry_run=False)
+
+    assert result["reconciled"][0]["action"] == "booked_filled"
+    assert result["reconciled"][0]["transition_depth"] == "filled"
+    assert ledger.rows[0].lifecycle_state == "filled"
+    assert ledger.status_calls[0]["filled_qty"] == "0.014"
+
+
+@pytest.mark.asyncio
+async def test_reconcile_is_delta_idempotent_for_same_cumulative_evidence() -> None:
+    from app.services.alpaca_paper_reconcile_service import AlpacaPaperReconcileService
+
+    ledger = Ledger([Row(filled_qty=Decimal("0.014"), lifecycle_state="submitted")])
+    result = await AlpacaPaperReconcileService(
+        ledger, Broker(filled_order())
+    ).reconcile(dry_run=False)
+
+    assert result["reconciled"][0]["action"] == "noop_already_booked"
+    assert ledger.status_calls == []
+
+
+@pytest.mark.asyncio
+async def test_reconcile_missing_broker_evidence_fails_closed_for_manual_review() -> (
+    None
+):
+    from app.services.alpaca_paper_reconcile_service import AlpacaPaperReconcileService
+
+    ledger = Ledger([Row()])
+    result = await AlpacaPaperReconcileService(ledger, Broker(None)).reconcile(
+        dry_run=False
+    )
+
+    assert result["reconciled"][0]["action"] == "noop_requires_manual_review"
+    assert result["reconciled"][0]["requires_manual_review"] is True
+    assert ledger.rows[0].lifecycle_state == "submitted"
+    assert ledger.status_calls == []
+
+
+@pytest.mark.asyncio
+async def test_reconcile_open_order_without_fill_keeps_submitted() -> None:
+    from app.services.alpaca_paper_reconcile_service import AlpacaPaperReconcileService
+
+    ledger = Ledger([Row()])
+    result = await AlpacaPaperReconcileService(
+        ledger, Broker(filled_order(status="accepted", qty="0"))
+    ).reconcile(dry_run=False)
+
+    assert result["reconciled"][0]["action"] == "noop_pending"
+    assert ledger.rows[0].lifecycle_state == "submitted"
+
+
+@pytest.mark.asyncio
+async def test_reconcile_partial_fill_stays_submitted_without_early_terminal_booking() -> (
+    None
+):
+    from app.services.alpaca_paper_reconcile_service import AlpacaPaperReconcileService
+
+    ledger = Ledger([Row()])
+    order = filled_order(status="partially_filled", qty="0.007")
+    order.qty = Decimal("0.014")
+    result = await AlpacaPaperReconcileService(ledger, Broker(order)).reconcile(
+        dry_run=False
+    )
+
+    assert result["reconciled"][0]["action"] == "booked_partial"
+    assert ledger.rows[0].lifecycle_state == "submitted"
+
+
+@pytest.mark.asyncio
+async def test_reconcile_open_status_with_fill_books_anomaly_not_terminal_fill() -> (
+    None
+):
+    from app.services.alpaca_paper_reconcile_service import AlpacaPaperReconcileService
+
+    ledger = Ledger([Row()])
+    result = await AlpacaPaperReconcileService(
+        ledger, Broker(filled_order(status="accepted"))
+    ).reconcile(dry_run=False)
+
+    assert result["reconciled"][0]["action"] == "booked_anomaly"
+    assert ledger.rows[0].lifecycle_state == "anomaly"
+
+
+@pytest.mark.asyncio
+async def test_reconcile_dry_run_plans_without_a_ledger_write() -> None:
+    from app.services.alpaca_paper_reconcile_service import AlpacaPaperReconcileService
+
+    ledger = Ledger([Row()])
+    result = await AlpacaPaperReconcileService(
+        ledger, Broker(filled_order())
+    ).reconcile(dry_run=True)
+
+    assert result["reconciled"][0]["action"] == "would_book_filled"
+    assert ledger.status_calls == []

--- a/tests/services/test_alpaca_paper_reconcile_service.py
+++ b/tests/services/test_alpaca_paper_reconcile_service.py
@@ -18,6 +18,7 @@ class Row:
     execution_symbol: str = "ISRG"
     lifecycle_state: str = "submitted"
     filled_qty: Decimal = Decimal("0")
+    record_kind: str = "execution"
 
 
 class Ledger:
@@ -28,11 +29,28 @@ class Ledger:
     async def list_recent(self, limit: int) -> list[Row]:
         return self.rows[:limit]
 
+    async def get_execution_by_client_order_id(
+        self, client_order_id: str
+    ) -> Row | None:
+        return next(
+            (
+                row
+                for row in self.rows
+                if row.client_order_id == client_order_id
+                and row.record_kind == "execution"
+            ),
+            None,
+        )
+
     async def record_status(
         self, client_order_id: str, order: dict[str, Any], **_: Any
     ) -> Row:
         self.status_calls.append(order)
-        row = next(r for r in self.rows if r.client_order_id == client_order_id)
+        row = next(
+            r
+            for r in self.rows
+            if r.client_order_id == client_order_id and r.record_kind == "execution"
+        )
         row.filled_qty = Decimal(str(order["filled_qty"]))
         row.lifecycle_state = (
             "filled"
@@ -171,3 +189,127 @@ async def test_reconcile_dry_run_plans_without_a_ledger_write() -> None:
 
     assert result["reconciled"][0]["action"] == "would_book_filled"
     assert ledger.status_calls == []
+
+
+@pytest.mark.asyncio
+async def test_reconcile_only_books_execution_row_and_rerun_is_noop() -> None:
+    from app.services.alpaca_paper_reconcile_service import AlpacaPaperReconcileService
+
+    rows = [
+        Row(id=1, record_kind="plan", lifecycle_state="planned"),
+        Row(id=2, record_kind="preview", lifecycle_state="previewed"),
+        Row(id=3, record_kind="validation_attempt", lifecycle_state="validated"),
+        Row(id=4, record_kind="execution"),
+    ]
+    ledger = Ledger(rows)
+    service = AlpacaPaperReconcileService(ledger, Broker(filled_order()))
+
+    first = await service.reconcile(dry_run=False)
+    second = await service.reconcile(dry_run=False)
+
+    assert first["count"] == 1
+    assert first["reconciled"][0]["ledger_id"] == 4
+    assert len(ledger.status_calls) == 1
+    assert second == {"success": True, "dry_run": False, "reconciled": [], "count": 0}
+
+
+@pytest.mark.asyncio
+async def test_reconcile_skips_final_reconciled_execution_row() -> None:
+    from app.services.alpaca_paper_reconcile_service import AlpacaPaperReconcileService
+
+    ledger = Ledger([Row(lifecycle_state="final_reconciled")])
+    result = await AlpacaPaperReconcileService(
+        ledger, Broker(filled_order())
+    ).reconcile(dry_run=False)
+
+    assert result["count"] == 0
+    assert ledger.rows[0].lifecycle_state == "final_reconciled"
+    assert ledger.status_calls == []
+
+
+@pytest.mark.asyncio
+async def test_reconcile_filled_status_with_partial_evidence_keeps_partial_state() -> (
+    None
+):
+    from app.services.alpaca_paper_reconcile_service import AlpacaPaperReconcileService
+
+    ledger = Ledger([Row()])
+    order = filled_order(status="filled", qty="0.007")
+    order.qty = Decimal("0.014")
+    result = await AlpacaPaperReconcileService(ledger, Broker(order)).reconcile(
+        dry_run=False
+    )
+
+    assert result["reconciled"][0]["action"] == "booked_partial"
+    assert ledger.status_calls[0]["status"] == "partially_filled"
+    assert ledger.rows[0].lifecycle_state == "submitted"
+
+
+def test_normalize_alpaca_order_uses_quantity_weighted_fill_average() -> None:
+    from types import SimpleNamespace
+
+    from app.services.alpaca_paper_reconcile_service import (
+        normalize_alpaca_order_for_classify,
+    )
+
+    order = filled_order(qty="0")
+    order.filled_avg_price = None
+    normalized = normalize_alpaca_order_for_classify(
+        order,
+        [
+            SimpleNamespace(
+                order_id=order.id,
+                qty=Decimal("0.005"),
+                price=Decimal("100"),
+                cum_qty=Decimal("0.005"),
+            ),
+            SimpleNamespace(
+                order_id=order.id,
+                qty=Decimal("0.005"),
+                price=Decimal("110"),
+                cum_qty=Decimal("0.010"),
+            ),
+        ],
+    )
+
+    assert normalized["ccld_unpr"] == Decimal("105")
+
+
+@pytest.mark.asyncio
+async def test_reconcile_filled_missing_evidence_and_failed_fill_read_requires_review() -> (
+    None
+):
+    from app.services.alpaca_paper_reconcile_service import AlpacaPaperReconcileService
+
+    class FailingFillsBroker(Broker):
+        async def list_fills(self, **_: Any) -> list[Any]:
+            raise RuntimeError("fill activity unavailable")
+
+    order = filled_order(qty="0")
+    order.filled_qty = None
+    order.filled_avg_price = None
+    result = await AlpacaPaperReconcileService(
+        Ledger([Row()]), FailingFillsBroker(order)
+    ).reconcile(dry_run=False)
+
+    assert result["reconciled"][0]["action"] == "noop_requires_manual_review"
+    assert result["reconciled"][0]["requires_manual_review"] is True
+
+
+@pytest.mark.asyncio
+async def test_reconcile_specific_old_client_order_uses_direct_ledger_and_broker_lookup() -> (
+    None
+):
+    from app.services.alpaca_paper_reconcile_service import AlpacaPaperReconcileService
+
+    old_execution = Row(id=201, client_order_id="old-order")
+    rows = [Row(id=index, client_order_id=f"recent-{index}") for index in range(200)]
+    ledger = Ledger(rows + [old_execution])
+    broker = Broker(filled_order())
+    result = await AlpacaPaperReconcileService(ledger, broker).reconcile(
+        client_order_id="old-order", dry_run=False, limit=200
+    )
+
+    assert result["count"] == 1
+    assert result["reconciled"][0]["ledger_id"] == 201
+    assert len(ledger.status_calls) == 1

--- a/tests/services/test_alpaca_paper_reconcile_service.py
+++ b/tests/services/test_alpaca_paper_reconcile_service.py
@@ -10,6 +10,15 @@ import pytest
 
 from app.services.brokers.alpaca.schemas import Order
 
+TERMINAL_STATES = {
+    "filled",
+    "position_reconciled",
+    "closed",
+    "final_reconciled",
+    "canceled",
+    "anomaly",
+}
+
 
 @dataclass
 class Row:
@@ -19,15 +28,33 @@ class Row:
     lifecycle_state: str = "submitted"
     filled_qty: Decimal = Decimal("0")
     record_kind: str = "execution"
+    cancel_status: str | None = None
+    canceled_at: Any = None
 
 
 class Ledger:
+    """Fake ledger that persists through the *real* lifecycle derivation.
+
+    Using the production mapping here is what makes the action-vs-persisted-state
+    assertions meaningful: a hand-rolled fake mapping would re-introduce exactly
+    the divergence these tests exist to catch.
+    """
+
     def __init__(self, rows: list[Row]) -> None:
         self.rows = rows
         self.status_calls: list[dict[str, Any]] = []
 
-    async def list_recent(self, limit: int) -> list[Row]:
-        return self.rows[:limit]
+    async def list_reconcile_candidates(
+        self, limit: int = 100, symbol: str | None = None
+    ) -> list[Row]:
+        eligible = [
+            row
+            for row in self.rows
+            if row.record_kind == "execution"
+            and row.lifecycle_state not in TERMINAL_STATES
+            and (symbol is None or row.execution_symbol == symbol)
+        ]
+        return eligible[:limit]
 
     async def get_execution_by_client_order_id(
         self, client_order_id: str
@@ -45,6 +72,8 @@ class Ledger:
     async def record_status(
         self, client_order_id: str, order: dict[str, Any], **_: Any
     ) -> Row:
+        from app.services.alpaca_paper_ledger_service import derive_lifecycle_state
+
         self.status_calls.append(order)
         row = next(
             r
@@ -52,12 +81,11 @@ class Ledger:
             if r.client_order_id == client_order_id and r.record_kind == "execution"
         )
         row.filled_qty = Decimal(str(order["filled_qty"]))
-        row.lifecycle_state = (
-            "filled"
-            if order["status"] == "filled"
-            else "submitted"
-            if order["status"] == "partially_filled"
-            else "anomaly"
+        row.lifecycle_state = derive_lifecycle_state(
+            order["status"],
+            row.filled_qty,
+            has_cancel_evidence=row.cancel_status is not None
+            or row.canceled_at is not None,
         )
         return row
 
@@ -252,7 +280,7 @@ def test_normalize_alpaca_order_uses_quantity_weighted_fill_average() -> None:
         normalize_alpaca_order_for_classify,
     )
 
-    order = filled_order(qty="0")
+    order = filled_order(qty="0.010")
     order.filled_avg_price = None
     normalized = normalize_alpaca_order_for_classify(
         order,
@@ -313,3 +341,298 @@ async def test_reconcile_specific_old_client_order_uses_direct_ledger_and_broker
     assert result["count"] == 1
     assert result["reconciled"][0]["ledger_id"] == 201
     assert len(ledger.status_calls) == 1
+
+
+# ---------------------------------------------------------------------------
+# ROB-953 R3 (1) — the reported action and the persisted lifecycle_state are
+# derived from one mapping, so they must agree for EVERY transition shape.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("broker_status", "qty", "order_qty", "cancel_status", "expected_label"),
+    [
+        # broker agrees the order is done and the quantity backs it up
+        ("filled", "0.014", "0.014", None, "filled"),
+        # broker reports filled but only a partial quantity is evidenced
+        ("filled", "0.007", "0.014", None, "partial"),
+        ("partially_filled", "0.007", "0.014", None, "partial"),
+        # an open status carrying a fill is a contradiction, never a fill
+        ("accepted", "0.014", "0.014", None, "anomaly"),
+        ("new", "0.014", "0.014", None, "anomaly"),
+        ("accepted", "0.007", "0.014", None, "partial"),
+        # terminal non-fill statuses reporting a full quantity
+        ("rejected", "0.014", "0.014", None, "anomaly"),
+        ("expired", "0.014", "0.014", None, "anomaly"),
+        ("canceled", "0.014", "0.014", None, "anomaly"),
+        # canceled *with* cancel evidence on the row is a legitimate cancel
+        ("canceled", "0.014", "0.014", "canceled", "canceled"),
+    ],
+)
+async def test_reported_action_always_matches_persisted_lifecycle_state(
+    broker_status: str,
+    qty: str,
+    order_qty: str,
+    cancel_status: str | None,
+    expected_label: str,
+) -> None:
+    """Regression for the round-1/2 defect class: response said one thing, the
+    ledger row said another (booked_filled persisted as anomaly, and inverse)."""
+    from app.services.alpaca_paper_reconcile_service import AlpacaPaperReconcileService
+
+    ledger = Ledger([Row(cancel_status=cancel_status)])
+    order = filled_order(status=broker_status, qty=qty)
+    order.qty = Decimal(order_qty)
+
+    result = await AlpacaPaperReconcileService(ledger, Broker(order)).reconcile(
+        dry_run=False
+    )
+    outcome = result["reconciled"][0]
+
+    assert outcome["action"] == f"booked_{expected_label}"
+    assert outcome["transition_depth"] == expected_label
+    # the persisted row is the ground truth the action claims to describe
+    assert outcome["lifecycle_state"] == ledger.rows[0].lifecycle_state
+    assert outcome["persisted_lifecycle_state"] == ledger.rows[0].lifecycle_state
+    assert outcome.get("requires_manual_review") is not True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("broker_status", ["filled", "rejected", "accepted"])
+async def test_dry_run_plan_matches_the_state_a_real_run_would_persist(
+    broker_status: str,
+) -> None:
+    from app.services.alpaca_paper_reconcile_service import AlpacaPaperReconcileService
+
+    def run(dry_run: bool) -> Any:
+        return AlpacaPaperReconcileService(
+            Ledger([Row()]), Broker(filled_order(status=broker_status))
+        ).reconcile(dry_run=dry_run)
+
+    planned = (await run(True))["reconciled"][0]
+    booked = (await run(False))["reconciled"][0]
+
+    assert planned["lifecycle_state"] == booked["lifecycle_state"]
+    assert planned["action"] == booked["action"].replace("booked_", "would_book_")
+
+
+def test_resolve_transition_labels_cover_every_derivable_state() -> None:
+    """No lifecycle state the resolver can produce may fall through unlabelled."""
+    from app.services.alpaca_paper_ledger_service import derive_lifecycle_state
+    from app.services.alpaca_paper_reconcile_service import (
+        _LIFECYCLE_ACTION_LABELS,
+        resolve_transition,
+    )
+    from app.services.brokers.kis.mock_scalping_exec.fill_evidence import FillVerdict
+
+    statuses = [
+        "filled",
+        "partially_filled",
+        "accepted",
+        "new",
+        "pending_new",
+        "rejected",
+        "expired",
+        "canceled",
+        "suspended",
+        "weird_unknown_status",
+    ]
+    for status in statuses:
+        for verdict in (FillVerdict.FILLED, FillVerdict.PARTIAL):
+            for cancel_evidence in (True, False):
+                transition = resolve_transition(
+                    verdict=verdict,
+                    broker_status=status,
+                    filled_qty=Decimal("1"),
+                    has_cancel_evidence=cancel_evidence,
+                )
+                assert transition.lifecycle_state in _LIFECYCLE_ACTION_LABELS
+                # the resolver's state is literally what record_status derives
+                assert transition.lifecycle_state == derive_lifecycle_state(
+                    transition.broker_status,
+                    Decimal("1"),
+                    has_cancel_evidence=cancel_evidence,
+                )
+
+
+# ---------------------------------------------------------------------------
+# ROB-953 R3 (4) — fill-set completeness gates the weighted average
+# ---------------------------------------------------------------------------
+
+
+def _fill(order_id: str, qty: str, price: str, cum: str, fill_id: str = "f1") -> Any:
+    from types import SimpleNamespace
+
+    return SimpleNamespace(
+        id=fill_id,
+        order_id=order_id,
+        qty=Decimal(qty),
+        price=Decimal(price),
+        cum_qty=Decimal(cum),
+        transaction_time=None,
+    )
+
+
+class FillsBroker(Broker):
+    def __init__(self, order: Order | None, pages: list[list[Any]]) -> None:
+        super().__init__(order)
+        self.pages = pages
+        self.calls: list[dict[str, Any]] = []
+
+    async def list_fills(self, **kwargs: Any) -> list[Any]:
+        self.calls.append(kwargs)
+        index = len(self.calls) - 1
+        return self.pages[index] if index < len(self.pages) else []
+
+
+@pytest.mark.asyncio
+async def test_incomplete_fill_set_requires_manual_review_without_transition() -> None:
+    """Σ(fill qty) < the order's cumulative filled_qty means fills were truncated;
+    averaging over them would book a wrong price."""
+    from app.services.alpaca_paper_reconcile_service import AlpacaPaperReconcileService
+
+    order = filled_order(qty="0.014")
+    order.filled_avg_price = None
+    ledger = Ledger([Row()])
+    broker = FillsBroker(order, [[_fill(order.id, "0.007", "100", "0.007")]])
+
+    result = await AlpacaPaperReconcileService(ledger, broker).reconcile(dry_run=False)
+    outcome = result["reconciled"][0]
+
+    assert outcome["action"] == "noop_requires_manual_review"
+    assert outcome["requires_manual_review"] is True
+    assert outcome["reason"] == "incomplete_fill_set"
+    assert outcome["fill_set_complete"] is False
+    assert ledger.rows[0].lifecycle_state == "submitted"
+    assert ledger.status_calls == []
+
+
+@pytest.mark.asyncio
+async def test_filled_status_with_empty_fills_requires_manual_review() -> None:
+    """status=filled with no quantity and no fills is a contradiction, not a
+    silent noop_pending (which left real fills unbooked forever)."""
+    from app.services.alpaca_paper_reconcile_service import AlpacaPaperReconcileService
+
+    order = filled_order(qty="0")
+    order.filled_qty = None
+    order.filled_avg_price = None
+    ledger = Ledger([Row()])
+
+    result = await AlpacaPaperReconcileService(ledger, Broker(order)).reconcile(
+        dry_run=False
+    )
+    outcome = result["reconciled"][0]
+
+    assert outcome["action"] == "noop_requires_manual_review"
+    assert outcome["requires_manual_review"] is True
+    assert ledger.status_calls == []
+
+
+@pytest.mark.asyncio
+async def test_filled_status_with_zero_qty_and_no_fills_requires_manual_review() -> (
+    None
+):
+    from app.services.alpaca_paper_reconcile_service import AlpacaPaperReconcileService
+
+    order = filled_order(status="filled", qty="0")
+    order.filled_avg_price = None
+    ledger = Ledger([Row()])
+
+    result = await AlpacaPaperReconcileService(ledger, Broker(order)).reconcile(
+        dry_run=False
+    )
+    outcome = result["reconciled"][0]
+
+    assert outcome["action"] == "noop_requires_manual_review"
+    assert outcome["reason"] == "filled_status_without_fill_evidence"
+    assert ledger.status_calls == []
+
+
+@pytest.mark.asyncio
+async def test_complete_fill_set_books_exact_quantity_weighted_average() -> None:
+    from app.services.alpaca_paper_reconcile_service import AlpacaPaperReconcileService
+
+    order = filled_order(qty="0.010")
+    order.qty = Decimal("0.010")
+    order.filled_avg_price = None
+    ledger = Ledger([Row()])
+    broker = FillsBroker(
+        order,
+        [
+            [
+                _fill(order.id, "0.005", "100", "0.005", fill_id="a"),
+                _fill(order.id, "0.005", "110", "0.010", fill_id="b"),
+            ]
+        ],
+    )
+
+    result = await AlpacaPaperReconcileService(ledger, broker).reconcile(dry_run=False)
+    outcome = result["reconciled"][0]
+
+    assert outcome["fill_set_complete"] is True
+    assert outcome["action"] == "booked_filled"
+    assert Decimal(outcome["avg_price"]) == Decimal("105")
+    assert ledger.rows[0].lifecycle_state == "filled"
+
+
+@pytest.mark.asyncio
+async def test_fill_pages_are_walked_until_the_set_is_complete() -> None:
+    """A single 100-row page must not cap the fill set."""
+    from datetime import UTC, datetime
+
+    from app.services.alpaca_paper_reconcile_service import AlpacaPaperReconcileService
+
+    order = filled_order(qty="100.5")
+    order.qty = Decimal("100.5")
+    order.filled_avg_price = None
+
+    page_one = []
+    for index in range(100):
+        fill = _fill(order.id, "1", "100", str(index + 1), fill_id=f"p1-{index}")
+        fill.transaction_time = datetime(2026, 7, 18, 12, index % 60, tzinfo=UTC)
+        page_one.append(fill)
+    page_two = [_fill(order.id, "0.5", "200", "100.5", fill_id="p2-0")]
+
+    broker = FillsBroker(order, [page_one, page_two])
+    ledger = Ledger([Row()])
+
+    result = await AlpacaPaperReconcileService(ledger, broker).reconcile(dry_run=False)
+    outcome = result["reconciled"][0]
+
+    assert len(broker.calls) == 2
+    assert outcome["fill_set_complete"] is True
+    assert outcome["action"] == "booked_filled"
+    # (100 * 100 + 0.5 * 200) / 100.5
+    assert Decimal(outcome["avg_price"]) == (Decimal("10100") / Decimal("100.5"))
+
+
+# ---------------------------------------------------------------------------
+# ROB-953 R3 (5) — eligibility filters run before the bulk limit
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_bulk_limit_applies_after_eligibility_filters() -> None:
+    """200 newer preview/terminal rows must not hide the 201st open execution."""
+    from app.services.alpaca_paper_reconcile_service import AlpacaPaperReconcileService
+
+    noise = [
+        Row(
+            id=index,
+            client_order_id=f"noise-{index}",
+            record_kind="preview" if index % 2 else "execution",
+            lifecycle_state="previewed" if index % 2 else "filled",
+        )
+        for index in range(200)
+    ]
+    eligible = Row(id=201, client_order_id="rob73-08ebbf8c64e2dd93")
+    ledger = Ledger([*noise, eligible])
+
+    result = await AlpacaPaperReconcileService(
+        ledger, Broker(filled_order())
+    ).reconcile(dry_run=False, limit=100)
+
+    assert result["count"] == 1
+    assert result["reconciled"][0]["ledger_id"] == 201
+    assert eligible.lifecycle_state == "filled"

--- a/tests/test_alpaca_paper_orders_tools.py
+++ b/tests/test_alpaca_paper_orders_tools.py
@@ -17,6 +17,7 @@ from app.mcp_server.tooling.alpaca_paper_orders import (
     SUBMIT_MAX_NOTIONAL_USD,
     SUBMIT_MAX_QTY,
     alpaca_paper_cancel_order,
+    alpaca_paper_reconcile_orders,
     alpaca_paper_submit_order,
     reset_alpaca_paper_orders_service_factory,
     set_alpaca_paper_orders_service_factory,
@@ -79,9 +80,11 @@ def test_module_exposes_expected_surface() -> None:
     assert _orders_mod.ALPACA_PAPER_MUTATING_TOOL_NAMES == {
         "alpaca_paper_submit_order",
         "alpaca_paper_cancel_order",
+        "alpaca_paper_reconcile_orders",
     }
     assert callable(_orders_mod.alpaca_paper_submit_order)
     assert callable(_orders_mod.alpaca_paper_cancel_order)
+    assert callable(_orders_mod.alpaca_paper_reconcile_orders)
     assert callable(_orders_mod.set_alpaca_paper_orders_service_factory)
     assert callable(_orders_mod.reset_alpaca_paper_orders_service_factory)
     assert callable(_orders_mod.register_alpaca_paper_orders_tools)
@@ -133,6 +136,18 @@ class FakeOrdersService(FakeAlpacaPaperService):
             status="canceled",
             limit_price=Decimal("1.00"),
         )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_reconcile_mutation_requires_confirm_when_not_dry_run() -> None:
+    payload = await alpaca_paper_reconcile_orders(dry_run=False, confirm=False)
+
+    assert payload == {
+        "success": False,
+        "dry_run": False,
+        "blocked_reason": "confirmation_required",
+    }
 
 
 @pytest.fixture

--- a/tests/test_alpaca_paper_service_methods.py
+++ b/tests/test_alpaca_paper_service_methods.py
@@ -272,7 +272,13 @@ async def test_list_fills_uses_activities_executions_endpoint():
 
     after = datetime(2024, 1, 1, tzinfo=UTC)
     until = datetime(2024, 1, 2, tzinfo=UTC)
-    fills = await svc.list_fills(after=after, until=until, limit=100)
+    fills = await svc.list_fills(
+        after=after,
+        until=until,
+        page_token="fill-previous-page",
+        page_size=100,
+        direction="desc",
+    )
 
     call_args = transport.request.call_args
     assert call_args[0][0] == "GET"
@@ -280,7 +286,10 @@ async def test_list_fills_uses_activities_executions_endpoint():
     params = call_args[1]["params"]
     assert "after" in params
     assert "until" in params
-    assert params["limit"] == 100
+    assert params["page_token"] == "fill-previous-page"
+    assert params["page_size"] == 100
+    assert params["direction"] == "desc"
+    assert "limit" not in params
     assert len(fills) == 1
     assert fills[0].symbol == "AAPL"
 

--- a/tests/test_watch_triage_readonly_settings.py
+++ b/tests/test_watch_triage_readonly_settings.py
@@ -39,6 +39,7 @@ KNOWN_MUTATION_TOOLS = frozenset(
         "alpaca_paper_submit_order",
         "alpaca_paper_automated_submit_order",
         "alpaca_paper_cancel_order",
+        "alpaca_paper_reconcile_orders",
         "paper_execution_preview_order",
         "paper_execution_submit_order",
         "paper_execution_cancel_order",


### PR DESCRIPTION
## Summary
- Add evidence-first `alpaca_paper_reconcile_orders` for non-terminal Alpaca paper ledger rows.
- Reuse `classify_fill_evidence` through a thin Alpaca order/fill normalization adapter; missing or unreadable evidence fails closed with `requires_manual_review`.
- Default to `dry_run=True`; writes require `dry_run=False` and `confirm=True`. Confirmed fills book via existing absolute `record_status`; partials remain submitted and open-with-fill discrepancies book as anomalies.

## Scope
- Deliberately stops at `filled`/partial/anomaly. It does not infer position or final reconciliation without independent evidence.
- AC2 is out of scope: `trade_retrospective_pending(account_mode="paper")` scans `PaperTrade`, not `AlpacaPaperOrderLedger`; a separate retrospective branch is required.
- No migration required: the ROB-920 lifecycle CHECK already permits `filled`, `position_reconciled`, `closed`, and `final_reconciled`.

## Verification
- `uv run pytest tests/ -q -k "alpaca_paper"`
- `uv run pytest tests/services/test_alpaca_paper_reconcile_service.py tests/test_alpaca_paper_orders_tools.py tests/test_route_request_registry_diff.py tests/test_route_request_lanes.py -q` (74 passed)
- `make lint`
- `git diff --check`
- `uv run alembic heads`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an Alpaca Paper fill-booking reconciliation MCP tool (evidence-first), with optional symbol/client order ID filtering and a configurable limit.
  - Writes are confirm-gated: default is dry-run/preview, and committing requires explicit confirmation (enabled only when the default profile setting is turned on).
- **Bug Fixes**
  - Improved fail-closed behavior: incomplete/missing evidence now routes to manual review instead of booking incorrect quantities/prices.
  - Prevents overwriting terminal and final reconciliation states; enforces monotonic filled quantity updates.
- **Documentation**
  - Documented the reconciliation approach, gating behavior, and fail-closed rules.
- **Tests**
  - Expanded reconciliation, guard/optimistic update, idempotency, pagination completeness, and tool confirmation-gate coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->