### PR TITLE
feat(ROB-948): user_stances advisory policy section

### DIFF
--- a/app/schemas/trading_policy.py
+++ b/app/schemas/trading_policy.py
@@ -8,6 +8,7 @@ fails loudly instead of silently dropping a key.
 
 from __future__ import annotations
 
+from datetime import date
 from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
@@ -186,6 +187,28 @@ class CrashDayPolicy(BaseModel):
     actions: CrashDayActions
 
 
+class UserStance(BaseModel):
+    """ROB-948 — user investment-stance advisory. Cited by session judgment
+    (upside/downside weighting) alongside other advisory context; does not
+    override fail-closed risk guards (loss-cut sizing, ladder guards) in
+    code. Same advisory-only pattern as ROB-932 crash_day."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: str
+    stance: str
+    implications: list[str]
+    risk_scenario: str
+    review_condition: str
+    review_date: str
+
+    @field_validator("review_date")
+    @classmethod
+    def validate_review_date_parses(cls, value: str) -> str:
+        date.fromisoformat(value)
+        return value
+
+
 class TradingPolicyDocument(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -200,3 +223,4 @@ class TradingPolicyDocument(BaseModel):
     market_rules: dict[Literal["crypto"], CryptoMarketRules]
     market_overrides: dict[Market, dict[str, ThresholdValue]]
     crash_day: CrashDayPolicy
+    user_stances: list[UserStance]

--- a/app/services/trading_policy_service.py
+++ b/app/services/trading_policy_service.py
@@ -105,6 +105,9 @@ def get_policy_for(market: str, lane: str) -> dict[str, Any]:
         # ROB-932 — single global advisory trigger, not market/lane-scoped;
         # echoed unconditionally alongside the version/content_hash stamp.
         "crash_day": doc.crash_day.model_dump(),
+        # ROB-948 — global advisory stance context, not market/lane-scoped;
+        # same echo pattern as crash_day above.
+        "user_stances": [stance.model_dump() for stance in doc.user_stances],
     }
 
 

--- a/config/trading_policy.yaml
+++ b/config/trading_policy.yaml
@@ -2,9 +2,9 @@
 # Seeded verbatim from docs/playbooks/trading-decision-playbook.md policy_keys
 # (captured 2026-07-02). Edited by operator PR ONLY — there is no write tool.
 # Repo is public; exposing these values is an accepted decision.
-version: "2026-07-17.1"
+version: "2026-07-17.2"
 captured_as_of: "2026-07-17"
-source: "ROB-643/751 baseline; ROB-839 crypto-recheck reports 2026-07-11/12; ROB-871 resting auto-approve seed; ROB-932 crash-day advisory keys"
+source: "ROB-643/751 baseline; ROB-839 crypto-recheck reports 2026-07-11/12; ROB-871 resting auto-approve seed; ROB-932 crash-day advisory keys; ROB-948 user-stance advisory keys"
 
 authority:
   scope: judgment_policy_only
@@ -249,3 +249,19 @@ crash_day:
     deep_rung_reprice_to_band_floor: true    # advisory: reprice deep rungs toward buy.deep_limit_pct_range floor
     profit_trim_marketable_allowed: true     # advisory: profit-side trims may use marketable band (ROB-912 -2%)
     defensive_brief_cross_check: true        # cross-check with ROB-930 preopen gap_risk verdict
+
+# ROB-948 — user investment-stance advisory. Session judgment cites this for
+# upside/downside weighting; it does not override fail-closed risk guards
+# (loss-cut sizing, ladder guards) in code. Frozen block (2026-07-17) — use
+# verbatim, no paraphrasing.
+user_stances:
+  - id: ai-demand-real-value-selective
+    stance: "AI 수요는 실사용 관점에서 실재. 단, (a)가치 포착은 가격결정력 보유 종목에 편중될 수 있고 (b)고베타 반도체는 테제가 맞아도 중간 낙폭이 크다"
+    implications:
+      - "AI/반도체 급락일: 패닉 동조 매도 금지 (보유분은 기존 리스크 규칙으로만 판단)"
+      - "눌림 신규 진입: 검토 후보 승격 가능하되 — 동시 신규 최대 1종목, 분할 진입, 섹터 클러스터 집중도 체크 엄격 적용"
+      - "테마 내 선택 시 가격결정력 보유 종목 우선. 커머디티형은 공급제약 증거 있을 때만"
+      - "3배 레버리지 ETF(SOXL류)는 눌림 보유 수단에서 기본 제외 (변동성 감쇠)"
+    risk_scenario: "효율 충격 — 저비용 고성능 모델 확산으로 프런티어 capex 지불의사 재평가. 판정 이벤트 = 하이퍼스케일러 capex 가이던스"
+    review_condition: "하이퍼스케일러 AI capex 감소 가이던스, 또는 HBM 공급과잉 실측 시 재검토"
+    review_date: "2026-10-17"

--- a/tests/mcp_server/test_trading_policy_tool.py
+++ b/tests/mcp_server/test_trading_policy_tool.py
@@ -12,7 +12,7 @@ from tests._mcp_tooling_support import DummyMCP
 async def test_get_trading_policy_returns_thresholds_and_version():
     out = await get_trading_policy(market="kr", lane="buy")
     assert out["success"] is True
-    assert out["version"] == "2026-07-17.1"
+    assert out["version"] == "2026-07-17.2"
     assert out["content_hash"]
     assert out["thresholds"]["portfolio.sector_cluster_cap_pct"]["value"] == 10
     assert out["decision_rules"] == {}
@@ -23,7 +23,7 @@ async def test_get_trading_policy_returns_crypto_market_rules_and_stamp():
     out = await get_trading_policy(market="crypto", lane="buy")
 
     assert out["success"] is True
-    assert out["version"] == "2026-07-17.1"
+    assert out["version"] == "2026-07-17.2"
     assert len(out["content_hash"]) == 12
     assert out["market_rules"]["recovery_gate"]["min_conditions_met"] == 2
     assert out["market_rules"]["no_chasing"]["daily_change_pct_threshold"] is None

--- a/tests/mcp_server/test_trading_policy_tool.py
+++ b/tests/mcp_server/test_trading_policy_tool.py
@@ -53,6 +53,19 @@ async def test_get_trading_policy_returns_crash_day_advisory_with_version_echo()
 
 
 @pytest.mark.asyncio
+async def test_get_trading_policy_returns_user_stances_advisory_with_version_echo():
+    out = await get_trading_policy(market="kr", lane="buy")
+    assert out["success"] is True
+    stances = {s["id"]: s for s in out["user_stances"]}
+    stance = stances["ai-demand-real-value-selective"]
+    assert stance["review_date"] == "2026-10-17"
+    # advisory keys are echoed with the same version/content_hash stamp as
+    # every other section of the response (ROB-948, matching ROB-932).
+    assert out["version"]
+    assert out["content_hash"]
+
+
+@pytest.mark.asyncio
 async def test_get_trading_policy_unknown_key_explicit_error():
     out = await get_trading_policy(market="jp", lane="buy")
     assert out["success"] is False

--- a/tests/schemas/test_trading_policy_schema.py
+++ b/tests/schemas/test_trading_policy_schema.py
@@ -15,7 +15,7 @@ def _raw() -> dict:
 
 def test_shipped_config_validates():
     doc = TradingPolicyDocument.model_validate(_raw())
-    assert doc.version == "2026-07-17.1"
+    assert doc.version == "2026-07-17.2"
     # verbatim seed values from the playbook policy_keys
     assert doc.thresholds["portfolio.sector_cluster_cap_pct"].value == 10
     assert doc.thresholds["sell.loss_guard_min_multiple"].value == 1.01

--- a/tests/schemas/test_trading_policy_schema.py
+++ b/tests/schemas/test_trading_policy_schema.py
@@ -163,3 +163,47 @@ def test_crash_day_missing_block_rejected():
     del raw["crash_day"]
     with pytest.raises(ValidationError):
         TradingPolicyDocument.model_validate(raw)
+
+
+def test_user_stance_ai_demand_selective_parses():
+    doc = TradingPolicyDocument.model_validate(_raw())
+    stances = {stance.id: stance for stance in doc.user_stances}
+    stance = stances["ai-demand-real-value-selective"]
+
+    assert stance.stance.startswith("AI 수요는 실사용 관점에서 실재")
+    assert len(stance.implications) == 4
+    assert (
+        "3배 레버리지 ETF(SOXL류)는 눌림 보유 수단에서 기본 제외 (변동성 감쇠)"
+        in stance.implications
+    )
+    assert stance.risk_scenario.startswith("효율 충격")
+    assert stance.review_condition.startswith("하이퍼스케일러 AI capex 감소 가이던스")
+    assert stance.review_date == "2026-10-17"
+
+
+def test_user_stance_extra_key_rejected():
+    raw = _raw()
+    raw["user_stances"][0]["bogus"] = 1
+    with pytest.raises(ValidationError):
+        TradingPolicyDocument.model_validate(raw)
+
+
+def test_user_stance_missing_required_field_rejected():
+    raw = _raw()
+    del raw["user_stances"][0]["risk_scenario"]
+    with pytest.raises(ValidationError):
+        TradingPolicyDocument.model_validate(raw)
+
+
+def test_user_stance_invalid_review_date_rejected():
+    raw = _raw()
+    raw["user_stances"][0]["review_date"] = "not-a-date"
+    with pytest.raises(ValidationError):
+        TradingPolicyDocument.model_validate(raw)
+
+
+def test_user_stances_missing_block_rejected():
+    raw = _raw()
+    del raw["user_stances"]
+    with pytest.raises(ValidationError):
+        TradingPolicyDocument.model_validate(raw)

--- a/tests/services/order_proposals/test_dispatch.py
+++ b/tests/services/order_proposals/test_dispatch.py
@@ -437,10 +437,10 @@ async def test_dispatch_auto_eligible_buy_or_sell_rests_without_approval(
     refreshed, rungs = await service.get_proposal(group.proposal_id)
     assert rungs[0].state == "resting"
     assert refreshed.approved_by_telegram_user_id is None
-    assert refreshed.source_asof["auto_approved"]["policy_version"] == "2026-07-17.1"
+    assert refreshed.source_asof["auto_approved"]["policy_version"] == "2026-07-17.2"
     text, keyboard, _chat_id = notifier.sent_messages[0]
     assert "자동 접수됨" in text
-    assert "auto:policy@2026-07-17.1" in text
+    assert "auto:policy@2026-07-17.2" in text
     assert keyboard["inline_keyboard"][0][0]["text"] == "취소"
     assert keyboard["inline_keyboard"][0][0]["callback_data"].startswith("vc:")
 

--- a/tests/services/test_trading_policy_service.py
+++ b/tests/services/test_trading_policy_service.py
@@ -5,7 +5,7 @@ from app.services import trading_policy_service as svc
 
 def test_version_stamp_has_version_and_hash():
     stamp = svc.policy_version_stamp()
-    assert stamp["version"] == "2026-07-17.1"
+    assert stamp["version"] == "2026-07-17.2"
     assert len(stamp["content_hash"]) == 12
 
 
@@ -15,7 +15,7 @@ def test_content_hash_stable_across_calls():
 
 def test_get_policy_for_buy_kr_includes_cap_and_version():
     view = svc.get_policy_for("kr", "buy")
-    assert view["version"] == "2026-07-17.1"
+    assert view["version"] == "2026-07-17.2"
     assert view["content_hash"]
     t = view["thresholds"]
     # buy lane references these (playbook lane tags)
@@ -31,7 +31,7 @@ def test_get_policy_for_buy_kr_includes_cap_and_version():
 def test_get_policy_for_crypto_buy_exposes_report_derived_market_rules():
     view = svc.get_policy_for("crypto", "buy")
 
-    assert view["version"] == "2026-07-17.1"
+    assert view["version"] == "2026-07-17.2"
     assert set(view["market_rules"]) == {
         "recovery_gate",
         "support_resistance",

--- a/tests/services/test_trading_policy_service.py
+++ b/tests/services/test_trading_policy_service.py
@@ -115,6 +115,21 @@ def test_get_policy_for_crash_day_present_regardless_of_market_lane():
     assert us_sell == crypto_discovery
 
 
+def test_get_policy_for_includes_user_stances_advisory():
+    view = svc.get_policy_for("kr", "buy")
+    stances = {s["id"]: s for s in view["user_stances"]}
+    stance = stances["ai-demand-real-value-selective"]
+    assert stance["review_date"] == "2026-10-17"
+    assert stance["risk_scenario"].startswith("효율 충격")
+
+
+def test_get_policy_for_user_stances_present_regardless_of_market_lane():
+    # user_stances is global advisory context, not market/lane-scoped.
+    us_sell = svc.get_policy_for("us", "sell")["user_stances"]
+    crypto_discovery = svc.get_policy_for("crypto", "discovery")["user_stances"]
+    assert us_sell == crypto_discovery
+
+
 def test_sector_cluster_for():
     assert svc.sector_cluster_for("반도체") == "semis_memory"
     assert svc.sector_cluster_for("Financial Services") == "financials"


### PR DESCRIPTION
## What
Adds a `user_stances` advisory section to `config/trading_policy.yaml` — sessions cite it (add/subtract rationale) but it never overrides fail-closed risk guards. Same pattern as ROB-932 (crash_day).

## Change
- `app/schemas/trading_policy.py`: `UserStance` (strict, `extra=forbid`; id/stance/implications/risk_scenario/review_condition/review_date) + `review_date` validator (`date.fromisoformat`). `TradingPolicyDocument.user_stances: list[UserStance]` required.
- `config/trading_policy.yaml`: frozen block verbatim + version `2026-07-17.1 → 2026-07-17.2`.
- 4 hardcoded version-literal test files bumped.

## TDD
RED (8 tests): `AttributeError`/`KeyError: 'user_stances'` (real runtime, not collection error). GREEN: schema + yaml + echo pass-through. 55/55; rebased suite 41 passed; ruff/ty clean; migration 0.

## Adversarial verify — PASS (merge approved)
Byte-exact frozen block; real RED; strict `extra=forbid` + all 6 required-field omissions + malformed `review_date` rejected; version bump complete (independent grep, 0 stragglers); **advisory boundary independently verified** — `user_stances`/`UserStance` referenced in exactly 3 places (schema def ×2 + service echo), **0 references in order_proposals / order_validation / orders_*_variants / order_execution / mcp execution branches**; existing `thresholds` consumers unaffected; content_hash stamping no-regression; echo identical across kr/us/crypto × buy/sell/discovery.
Sole note (non-blocking): `date.fromisoformat` accepts basic-ISO `20261017` — a valid ISO date, advisory-only, no code branch. Not a defect.

🔒 Merge gated — orch/operator review. ⚠️ ROB-956 lands on the same file (config/trading_policy.yaml + schemas/trading_policy.py); sequence 948 → 956.

🤖 Generated with [Claude Code](https://claude.com/claude-code)