### PR TITLE
test(ROB-955): US live sell journal-matching regression guards (verdict A — data gap, no code fix)

### DIFF
--- a/tests/mcp_server/tooling/test_live_order_ledger.py
+++ b/tests/mcp_server/tooling/test_live_order_ledger.py
@@ -1128,9 +1128,7 @@ async def test_reconcile_us_sell_real_db_account_type_mismatch_leaves_pnl_null()
 
     with (
         patch.object(ll, "get_evidence_adapter", return_value=_Adapter()),
-        patch.object(
-            ll, "capture_reconcile_spot_fx", new=AsyncMock(return_value=None)
-        ),
+        patch.object(ll, "capture_reconcile_spot_fx", new=AsyncMock(return_value=None)),
         patch.object(ll, "_save_order_fill", new=AsyncMock(return_value=502)),
     ):
         out = await ll._reconcile_one_live_row(row, dry_run=False)

--- a/tests/mcp_server/tooling/test_live_order_ledger.py
+++ b/tests/mcp_server/tooling/test_live_order_ledger.py
@@ -705,6 +705,222 @@ async def test_kis_us_buy_reconcile_captures_buy_fx_rate():
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_reconcile_us_sell_with_no_prior_journal_leaves_pnl_null():
+    """ROB-955 regression guard — no false matching when no buy journal exists.
+
+    Reproduces the exact prod incident (trades 274/275, XOM/AMZN 2026-07-17/18):
+    the position was a pre-existing broker holding with no ``TradeJournal`` buy
+    row ever recorded (data gap, not a matching-key bug — see ROB-955
+    investigation). ``_close_journals_on_sell`` runs for real here (not mocked)
+    against an empty journal set; it must book the fill/trade but leave
+    ``journals_closed=0`` and ``security_pnl_usd``/``journal_id`` null rather
+    than guessing a lot to attribute PnL against.
+    """
+    from decimal import Decimal
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    from app.mcp_server.tooling import live_order_ledger as ll
+    from app.services.brokers.kis.mock_scalping_exec.fill_evidence import (
+        FillEvidence,
+        FillVerdict,
+    )
+
+    lid = await ll._save_live_order_ledger(
+        broker="kis",
+        account_scope="kis_live",
+        market="us",
+        symbol="ROB955XOM",
+        exchange="NYSE",
+        market_symbol=None,
+        side="sell",
+        order_kind="limit",
+        quantity=1.0,
+        price=145.51,
+        amount=145.51,
+        currency="USD",
+        order_no="ROB955-SELL-NOMATCH",
+        order_time="2210",
+        status="accepted",
+        response_code="0",
+        response_message=None,
+        raw_response=None,
+        reason=None,
+        thesis=None,
+        strategy=None,
+        target_price=None,
+        stop_loss=None,
+        min_hold_days=None,
+        notes=None,
+        exit_reason="defensive_trim",
+        indicators_snapshot=None,
+    )
+    row = await ll._load_live_ledger_row(lid)
+    filled = FillEvidence(
+        FillVerdict.FILLED, Decimal("1"), Decimal("146.515"), None, "filled", ""
+    )
+
+    class _Adapter:
+        broker = "kis"
+        fetch_evidence = AsyncMock(return_value=filled)
+
+    # Real _close_journals_on_sell queries this session factory; return an
+    # empty active-journal set to mirror the prod data gap exactly.
+    mock_session = AsyncMock()
+    mock_scalars = MagicMock()
+    mock_scalars.all.return_value = []
+    mock_result = MagicMock()
+    mock_result.scalars.return_value = mock_scalars
+    mock_session.execute.return_value = mock_result
+    session_cm = AsyncMock()
+    session_cm.__aenter__.return_value = mock_session
+    session_cm.__aexit__.return_value = None
+    journal_factory = MagicMock(return_value=session_cm)
+
+    with (
+        patch.object(ll, "get_evidence_adapter", return_value=_Adapter()),
+        patch.object(ll, "capture_reconcile_spot_fx", new=AsyncMock(return_value=None)),
+        patch.object(ll, "_save_order_fill", new=AsyncMock(return_value=274)),
+        patch(
+            "app.mcp_server.tooling.order_journal._order_session_factory",
+            return_value=journal_factory,
+        ),
+    ):
+        out = await ll._reconcile_one_live_row(row, dry_run=False)
+
+    assert out["verdict"] == "filled"
+    assert out["action"] == "booked"
+    assert out["journals_closed"] == 0
+    assert out["closed_journal_ids"] == []
+    assert out.get("security_pnl_usd") is None
+
+    after = await ll._load_live_ledger_row(lid)
+    assert after.status == "filled"
+    assert after.trade_id == 274
+    assert after.journal_id is None
+    assert after.security_pnl_usd is None
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_reconcile_us_sell_with_matching_active_journal_computes_pnl():
+    """ROB-955 regression guard — normal matching still computes realized PnL.
+
+    Mirrors the same XOM lot basis from the prod incident's manual retro
+    correction (KIS avg cost 136.28 -> sell 146.515 = +$10.235) to prove the
+    FIFO lot matcher books it automatically when a buy journal genuinely
+    exists, instead of leaving it null.
+    """
+    from decimal import Decimal
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    from app.mcp_server.tooling import live_order_ledger as ll
+    from app.mcp_server.tooling.fx_pnl import FxRateCapture
+    from app.models.trade_journal import TradeJournal
+    from app.models.trading import InstrumentType
+    from app.services.brokers.kis.mock_scalping_exec.fill_evidence import (
+        FillEvidence,
+        FillVerdict,
+    )
+
+    active_journal = TradeJournal(
+        id=9001,
+        symbol="ROB955XOM2",
+        instrument_type=InstrumentType.equity_us,
+        side="buy",
+        entry_price=Decimal("136.28"),
+        quantity=Decimal("1"),
+        status="active",
+        account="kis",
+        account_type="live",
+        thesis="t",
+        buy_fx_rate=Decimal("1300.00"),
+    )
+
+    lid = await ll._save_live_order_ledger(
+        broker="kis",
+        account_scope="kis_live",
+        market="us",
+        symbol="ROB955XOM2",
+        exchange="NYSE",
+        market_symbol=None,
+        side="sell",
+        order_kind="limit",
+        quantity=1.0,
+        price=145.51,
+        amount=145.51,
+        currency="USD",
+        order_no="ROB955-SELL-MATCH",
+        order_time="2210",
+        status="accepted",
+        response_code="0",
+        response_message=None,
+        raw_response=None,
+        reason=None,
+        thesis=None,
+        strategy=None,
+        target_price=None,
+        stop_loss=None,
+        min_hold_days=None,
+        notes=None,
+        exit_reason="defensive_trim",
+        indicators_snapshot=None,
+    )
+    row = await ll._load_live_ledger_row(lid)
+    filled = FillEvidence(
+        FillVerdict.FILLED, Decimal("1"), Decimal("146.515"), None, "filled", ""
+    )
+
+    class _Adapter:
+        broker = "kis"
+        fetch_evidence = AsyncMock(return_value=filled)
+
+    mock_session = AsyncMock()
+    mock_scalars = MagicMock()
+    mock_scalars.all.return_value = [active_journal]
+    mock_result = MagicMock()
+    mock_result.scalars.return_value = mock_scalars
+    mock_session.execute.return_value = mock_result
+    session_cm = AsyncMock()
+    session_cm.__aenter__.return_value = mock_session
+    session_cm.__aexit__.return_value = None
+    journal_factory = MagicMock(return_value=session_cm)
+
+    with (
+        patch.object(ll, "get_evidence_adapter", return_value=_Adapter()),
+        patch.object(
+            ll,
+            "capture_reconcile_spot_fx",
+            new=AsyncMock(
+                return_value=FxRateCapture(
+                    rate=Decimal("1389.33"),
+                    fx_rate_source="reconcile_spot",
+                    fx_pnl_accuracy="approximate",
+                )
+            ),
+        ),
+        patch.object(ll, "_save_order_fill", new=AsyncMock(return_value=275)),
+        patch(
+            "app.mcp_server.tooling.order_journal._order_session_factory",
+            return_value=journal_factory,
+        ),
+    ):
+        out = await ll._reconcile_one_live_row(row, dry_run=False)
+
+    assert out["verdict"] == "filled"
+    assert out["action"] == "booked"
+    assert out["journals_closed"] == 1
+    assert out["closed_journal_ids"] == [9001]
+    assert out["security_pnl_usd"] == pytest.approx(10.235)
+    assert active_journal.status == "closed"
+
+    after = await ll._load_live_ledger_row(lid)
+    assert after.status == "filled"
+    assert after.trade_id == 275
+    assert after.security_pnl_usd == Decimal("10.2350")
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_reconcile_buy_journal_backfills_correlation_id():
     """ROB-714: reconcile-time buy journal must carry the ledger row's
     correlation_id. Drives the REAL _reconcile_one_live_row (US path)."""

--- a/tests/mcp_server/tooling/test_live_order_ledger.py
+++ b/tests/mcp_server/tooling/test_live_order_ledger.py
@@ -711,10 +711,17 @@ async def test_reconcile_us_sell_with_no_prior_journal_leaves_pnl_null():
     Reproduces the exact prod incident (trades 274/275, XOM/AMZN 2026-07-17/18):
     the position was a pre-existing broker holding with no ``TradeJournal`` buy
     row ever recorded (data gap, not a matching-key bug — see ROB-955
-    investigation). ``_close_journals_on_sell`` runs for real here (not mocked)
-    against an empty journal set; it must book the fill/trade but leave
-    ``journals_closed=0`` and ``security_pnl_usd``/``journal_id`` null rather
-    than guessing a lot to attribute PnL against.
+    investigation).
+
+    NOTE: the DB session/query here is mocked to unconditionally return an
+    empty ``scalars().all()`` regardless of the WHERE predicate — this test
+    exercises ``_reconcile_one_live_row``'s handling of an empty journal
+    result (booking the fill/trade while leaving ``journals_closed=0`` and
+    ``security_pnl_usd``/``journal_id`` null), NOT the SQL matching predicate
+    itself (symbol/status/account_type/account). The matching predicate is
+    covered by the real-DB tests below
+    (``test_reconcile_us_sell_real_db_*``), which run against an actual
+    ``TradeJournal`` row with no session-factory mock.
     """
     from decimal import Decimal
     from unittest.mock import AsyncMock, MagicMock, patch
@@ -806,9 +813,15 @@ async def test_reconcile_us_sell_with_matching_active_journal_computes_pnl():
     """ROB-955 regression guard — normal matching still computes realized PnL.
 
     Mirrors the same XOM lot basis from the prod incident's manual retro
-    correction (KIS avg cost 136.28 -> sell 146.515 = +$10.235) to prove the
-    FIFO lot matcher books it automatically when a buy journal genuinely
-    exists, instead of leaving it null.
+    correction (KIS avg cost 136.28 -> sell 146.515 = +$10.235).
+
+    NOTE: like the sibling test above, the DB session/query is mocked to
+    unconditionally return a fixed single-journal list regardless of the
+    WHERE predicate — this test exercises the FIFO lot consumption / PnL
+    computation logic inside ``_close_journals_on_sell`` once a journal is
+    in hand, NOT the SQL matching predicate that selects which journal(s)
+    come back. The matching predicate is covered by the real-DB tests below
+    (``test_reconcile_us_sell_real_db_*``).
     """
     from decimal import Decimal
     from unittest.mock import AsyncMock, MagicMock, patch
@@ -917,6 +930,223 @@ async def test_reconcile_us_sell_with_matching_active_journal_computes_pnl():
     assert after.status == "filled"
     assert after.trade_id == 275
     assert after.security_pnl_usd == Decimal("10.2350")
+
+
+async def _seed_active_journal(
+    *, symbol: str, account: str = "kis", account_type: str = "live"
+):
+    """Insert a real, committed active ``TradeJournal`` row via the shared
+    ``AsyncSessionLocal`` sessionmaker (the same factory ``order_journal``'s
+    ``_order_session_factory()`` returns), so a subsequent unmocked
+    ``_close_journals_on_sell`` query can find (or, deliberately, fail to
+    find) it through the real WHERE predicate."""
+    from decimal import Decimal
+
+    from app.mcp_server.tooling.live_order_ledger import _order_session_factory
+    from app.models.trade_journal import JournalStatus, TradeJournal
+    from app.models.trading import InstrumentType
+
+    journal = TradeJournal(
+        symbol=symbol,
+        instrument_type=InstrumentType.equity_us,
+        side="buy",
+        entry_price=Decimal("136.28"),
+        quantity=Decimal("1"),
+        status=JournalStatus.active,
+        account=account,
+        account_type=account_type,
+        thesis="t",
+        buy_fx_rate=Decimal("1300.00"),
+    )
+    async with _order_session_factory()() as db:
+        db.add(journal)
+        await db.commit()
+        await db.refresh(journal)
+        return journal.id
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_reconcile_us_sell_real_db_match_computes_pnl():
+    """ROB-955 F1 remediation — exercises the REAL ``TradeJournal`` matching
+    query (symbol/status/account_type/account WHERE predicate) end-to-end,
+    with NO ``order_journal._order_session_factory`` mock anywhere in this
+    test. A real active journal is inserted via a separate session, then
+    ``_reconcile_one_live_row`` runs the genuine SQL query to find it.
+
+    Paired with ``test_reconcile_us_sell_real_db_account_type_mismatch_*``
+    below: together they prove the predicate is actually evaluated — if any
+    matching key regresses (e.g. account_type default drifts, or the account
+    filter is dropped), this test or its sibling goes red.
+    """
+    import uuid
+    from decimal import Decimal
+    from unittest.mock import AsyncMock, patch
+
+    from app.mcp_server.tooling import live_order_ledger as ll
+    from app.mcp_server.tooling.fx_pnl import FxRateCapture
+    from app.models.trade_journal import JournalStatus, TradeJournal
+    from app.services.brokers.kis.mock_scalping_exec.fill_evidence import (
+        FillEvidence,
+        FillVerdict,
+    )
+
+    symbol = f"ROB955REALDB{uuid.uuid4().hex[:8].upper()}"
+    journal_id = await _seed_active_journal(symbol=symbol)
+
+    lid = await ll._save_live_order_ledger(
+        broker="kis",
+        account_scope="kis_live",
+        market="us",
+        symbol=symbol,
+        exchange="NYSE",
+        market_symbol=None,
+        side="sell",
+        order_kind="limit",
+        quantity=1.0,
+        price=145.51,
+        amount=145.51,
+        currency="USD",
+        order_no=f"ROB955-REALDB-MATCH-{symbol}",
+        order_time="2210",
+        status="accepted",
+        response_code="0",
+        response_message=None,
+        raw_response=None,
+        reason=None,
+        thesis=None,
+        strategy=None,
+        target_price=None,
+        stop_loss=None,
+        min_hold_days=None,
+        notes=None,
+        exit_reason="defensive_trim",
+        indicators_snapshot=None,
+    )
+    row = await ll._load_live_ledger_row(lid)
+    filled = FillEvidence(
+        FillVerdict.FILLED, Decimal("1"), Decimal("146.515"), None, "filled", ""
+    )
+
+    class _Adapter:
+        broker = "kis"
+        fetch_evidence = AsyncMock(return_value=filled)
+
+    with (
+        patch.object(ll, "get_evidence_adapter", return_value=_Adapter()),
+        patch.object(
+            ll,
+            "capture_reconcile_spot_fx",
+            new=AsyncMock(
+                return_value=FxRateCapture(
+                    rate=Decimal("1389.33"),
+                    fx_rate_source="reconcile_spot",
+                    fx_pnl_accuracy="approximate",
+                )
+            ),
+        ),
+        patch.object(ll, "_save_order_fill", new=AsyncMock(return_value=501)),
+    ):
+        out = await ll._reconcile_one_live_row(row, dry_run=False)
+
+    assert out["verdict"] == "filled"
+    assert out["journals_closed"] == 1
+    assert out["closed_journal_ids"] == [journal_id]
+    assert out["security_pnl_usd"] == pytest.approx(10.235)
+
+    from app.mcp_server.tooling.live_order_ledger import _order_session_factory
+
+    async with _order_session_factory()() as db:
+        refreshed = await db.get(TradeJournal, journal_id)
+        assert refreshed.status == JournalStatus.closed
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_reconcile_us_sell_real_db_account_type_mismatch_leaves_pnl_null():
+    """ROB-955 F1 remediation — sibling of the match test above, proving the
+    real query's ``account_type`` predicate is actually load-bearing.
+
+    Seeds a real, otherwise-identical active journal but with
+    ``account_type="paper"`` (the sell reconcile always queries
+    ``account_type="live"``). If the matching predicate ever regressed to
+    ignore ``account_type`` (or any other key), this journal would wrongly
+    match and this test would go red — unlike the over-mocked guards this
+    replaces, which returned a fixed result regardless of the WHERE clause.
+    """
+    import uuid
+    from decimal import Decimal
+    from unittest.mock import AsyncMock, patch
+
+    from app.mcp_server.tooling import live_order_ledger as ll
+    from app.models.trade_journal import JournalStatus, TradeJournal
+    from app.services.brokers.kis.mock_scalping_exec.fill_evidence import (
+        FillEvidence,
+        FillVerdict,
+    )
+
+    symbol = f"ROB955REALDB{uuid.uuid4().hex[:8].upper()}"
+    journal_id = await _seed_active_journal(symbol=symbol, account_type="paper")
+
+    lid = await ll._save_live_order_ledger(
+        broker="kis",
+        account_scope="kis_live",
+        market="us",
+        symbol=symbol,
+        exchange="NYSE",
+        market_symbol=None,
+        side="sell",
+        order_kind="limit",
+        quantity=1.0,
+        price=145.51,
+        amount=145.51,
+        currency="USD",
+        order_no=f"ROB955-REALDB-MISMATCH-{symbol}",
+        order_time="2210",
+        status="accepted",
+        response_code="0",
+        response_message=None,
+        raw_response=None,
+        reason=None,
+        thesis=None,
+        strategy=None,
+        target_price=None,
+        stop_loss=None,
+        min_hold_days=None,
+        notes=None,
+        exit_reason="defensive_trim",
+        indicators_snapshot=None,
+    )
+    row = await ll._load_live_ledger_row(lid)
+    filled = FillEvidence(
+        FillVerdict.FILLED, Decimal("1"), Decimal("146.515"), None, "filled", ""
+    )
+
+    class _Adapter:
+        broker = "kis"
+        fetch_evidence = AsyncMock(return_value=filled)
+
+    with (
+        patch.object(ll, "get_evidence_adapter", return_value=_Adapter()),
+        patch.object(
+            ll, "capture_reconcile_spot_fx", new=AsyncMock(return_value=None)
+        ),
+        patch.object(ll, "_save_order_fill", new=AsyncMock(return_value=502)),
+    ):
+        out = await ll._reconcile_one_live_row(row, dry_run=False)
+
+    assert out["verdict"] == "filled"
+    assert out["journals_closed"] == 0
+    assert out["closed_journal_ids"] == []
+    assert out.get("security_pnl_usd") is None
+
+    from app.mcp_server.tooling.live_order_ledger import _order_session_factory
+
+    async with _order_session_factory()() as db:
+        refreshed = await db.get(TradeJournal, journal_id)
+        # untouched: the mismatched-account_type journal must never be
+        # consumed by a "live" sell reconcile.
+        assert refreshed.status == JournalStatus.active
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Verdict: A (data gap), no production code change
Investigation + adversarial verify confirmed the reported symptom (`journals_closed=0`/`security_pnl_usd=null` on XOM·AMZN sells) is a **data gap**, not a matching-logic bug: XOM/AMZN have zero buy rows in `review.trades` and 0 rows in `review.trade_journals` — legacy pre-journal-system real positions. `_close_journals_on_sell`'s matching key (symbol/account/account_type/status) is sound; there was simply nothing to match. Per orch decision: **no journal backfill** (synthesizing buy events that never occurred = audit-trail contamination); retro 190/191 manual corrections are the record of truth.

## Deliverable: regression guards only (`app/` untouched)
`git diff origin/main -- app/` is empty.

**Remediation of verify finding F1** — the first two guards patched `_order_session_factory`, so the WHERE-clause predicates were never evaluated (flipping account to a wrong broker still passed GREEN). Added two guards that insert a **real committed `TradeJournal`** via the shared `AsyncSessionLocal` (no session-factory mock) and run the genuine reconcile SQL:
- **match** (account_type=live/account=kis) → `journals_closed==1`, PnL≈$10.235, journal→closed
- **mismatch** (account_type=paper) → `journals_closed==0`, PnL null, journal stays active

**Predicate self-check (reproduced independently):** deleting the `account_type` predicate in `_close_journals_on_sell` (line 257) makes the mismatch guard red (`assert 1 == 0`); reverted → production byte-identical. The two prior over-mocked docstrings were softened to state they mock the query result and point to these for predicate coverage (neither deleted — they still guard FIFO/PnL/return-shape).

19 passed; ruff/ty clean; migration 0.

## Follow-ups (separate)
- **ROB-959** (created, Medium): FIFO partial-sell (<lot) also yields `journals_closed=0` — doc the two null causes (data-gap vs FIFO) to prevent operator misread (verify F3).
- **F2** (verify): KIS-US matching has 0 prod success precedent (all filled KIS-US sells journal_id=null; only US match success is the toss path). Now test-covered here; live first-KIS-US-match to be watched — orch folding into next US-session handoff.

🔒 Merge gated — orch/operator review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)