### PR TITLE
feat(ROB-956): US per-symbol USD sizing policy key + one-share exception

### DIFF
--- a/app/schemas/trading_policy.py
+++ b/app/schemas/trading_policy.py
@@ -21,6 +21,20 @@ RuleConditionValue = int | float | str | bool | list[int | float | str | bool]
 PolicyComparison = Literal["gt", "gte", "lt", "lte", "eq"]
 
 
+class OneShareExceptionPolicy(BaseModel):
+    """ROB-956 — US shares can't be bought fractionally; if a single share's
+    price exceeds a USD notional band's ceiling, allow exactly one share
+    instead of blocking the entry outright. absolute_ceiling_usd still hard-
+    blocks ultra-high-priced symbols (BRK.A/NVR-class); max_deep_rungs caps
+    additional averaging-down exposure on exception entries."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    enabled: bool
+    absolute_ceiling_usd: float
+    max_deep_rungs: int
+
+
 class PolicyThreshold(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -29,6 +43,7 @@ class PolicyThreshold(BaseModel):
     unit: str
     semantics: str
     of: int | None = None
+    one_share_exception: OneShareExceptionPolicy | None = None
 
 
 class PolicyDecisionRuleTier(BaseModel):

--- a/app/services/trading_policy_service.py
+++ b/app/services/trading_policy_service.py
@@ -80,6 +80,11 @@ def get_policy_for(market: str, lane: str) -> dict[str, Any]:
             "unit": spec.unit,
             "semantics": spec.semantics,
             "of": spec.of,
+            "one_share_exception": (
+                spec.one_share_exception.model_dump()
+                if spec.one_share_exception is not None
+                else None
+            ),
             "source": source,
         }
     decision_rules = {

--- a/config/trading_policy.yaml
+++ b/config/trading_policy.yaml
@@ -2,9 +2,9 @@
 # Seeded verbatim from docs/playbooks/trading-decision-playbook.md policy_keys
 # (captured 2026-07-02). Edited by operator PR ONLY — there is no write tool.
 # Repo is public; exposing these values is an accepted decision.
-version: "2026-07-17.2"
+version: "2026-07-17.3"
 captured_as_of: "2026-07-17"
-source: "ROB-643/751 baseline; ROB-839 crypto-recheck reports 2026-07-11/12; ROB-871 resting auto-approve seed; ROB-932 crash-day advisory keys; ROB-948 user-stance advisory keys"
+source: "ROB-643/751 baseline; ROB-839 crypto-recheck reports 2026-07-11/12; ROB-871 resting auto-approve seed; ROB-932 crash-day advisory keys; ROB-948 user-stance advisory keys; ROB-956 US per-symbol USD sizing key"
 
 authority:
   scope: judgment_policy_only
@@ -74,7 +74,19 @@ thresholds:
     lanes: [buy, discovery]
     value: [200000, 400000]
     unit: krw
-    semantics: per-symbol order sizing for new entries (policy threshold, not account balance)
+    semantics: per-symbol order sizing for new entries (policy threshold, not account balance; KR lane only)
+  # ROB-956 — US-lane sizing decoupled from KRW/FX (KR range in FX terms
+  # priced new US entries out above ~$268/share at FX~1491). USD-denominated;
+  # not derived from the KR range.
+  buy.per_symbol_notional_usd_range:
+    lanes: [buy, discovery]
+    value: [150, 450]  # 신규 진입 1차 트란치 밴드
+    unit: usd
+    one_share_exception:
+      enabled: true
+      absolute_ceiling_usd: 700
+      max_deep_rungs: 1
+    semantics: per-symbol first-tranche sizing for US new entries; advisory (ROB-646 원칙 — 코드 강제 아님)
   sell.loss_guard_min_multiple:
     lanes: [buy, sell]
     value: 1.01

--- a/tests/mcp_server/test_trading_policy_tool.py
+++ b/tests/mcp_server/test_trading_policy_tool.py
@@ -12,7 +12,7 @@ from tests._mcp_tooling_support import DummyMCP
 async def test_get_trading_policy_returns_thresholds_and_version():
     out = await get_trading_policy(market="kr", lane="buy")
     assert out["success"] is True
-    assert out["version"] == "2026-07-17.2"
+    assert out["version"] == "2026-07-17.3"
     assert out["content_hash"]
     assert out["thresholds"]["portfolio.sector_cluster_cap_pct"]["value"] == 10
     assert out["decision_rules"] == {}
@@ -23,7 +23,7 @@ async def test_get_trading_policy_returns_crypto_market_rules_and_stamp():
     out = await get_trading_policy(market="crypto", lane="buy")
 
     assert out["success"] is True
-    assert out["version"] == "2026-07-17.2"
+    assert out["version"] == "2026-07-17.3"
     assert len(out["content_hash"]) == 12
     assert out["market_rules"]["recovery_gate"]["min_conditions_met"] == 2
     assert out["market_rules"]["no_chasing"]["daily_change_pct_threshold"] is None
@@ -63,6 +63,16 @@ async def test_get_trading_policy_returns_user_stances_advisory_with_version_ech
     # every other section of the response (ROB-948, matching ROB-932).
     assert out["version"]
     assert out["content_hash"]
+
+
+@pytest.mark.asyncio
+async def test_get_trading_policy_returns_us_notional_usd_range_with_one_share_exception():
+    out = await get_trading_policy(market="us", lane="buy")
+    assert out["success"] is True
+    us_range = out["thresholds"]["buy.per_symbol_notional_usd_range"]
+    assert us_range["value"] == [150, 450]
+    assert us_range["one_share_exception"]["absolute_ceiling_usd"] == 700
+    assert us_range["one_share_exception"]["max_deep_rungs"] == 1
 
 
 @pytest.mark.asyncio

--- a/tests/schemas/test_trading_policy_schema.py
+++ b/tests/schemas/test_trading_policy_schema.py
@@ -15,7 +15,7 @@ def _raw() -> dict:
 
 def test_shipped_config_validates():
     doc = TradingPolicyDocument.model_validate(_raw())
-    assert doc.version == "2026-07-17.2"
+    assert doc.version == "2026-07-17.3"
     # verbatim seed values from the playbook policy_keys
     assert doc.thresholds["portfolio.sector_cluster_cap_pct"].value == 10
     assert doc.thresholds["sell.loss_guard_min_multiple"].value == 1.01
@@ -205,5 +205,50 @@ def test_user_stance_invalid_review_date_rejected():
 def test_user_stances_missing_block_rejected():
     raw = _raw()
     del raw["user_stances"]
+    with pytest.raises(ValidationError):
+        TradingPolicyDocument.model_validate(raw)
+
+
+def test_kr_notional_range_semantics_scoped_to_kr_lane():
+    doc = TradingPolicyDocument.model_validate(_raw())
+    kr_range = doc.thresholds["buy.per_symbol_notional_krw_range"]
+
+    assert kr_range.value == [200000, 400000]
+    assert "KR lane only" in kr_range.semantics
+
+
+def test_us_notional_usd_range_parses_with_one_share_exception():
+    doc = TradingPolicyDocument.model_validate(_raw())
+    us_range = doc.thresholds["buy.per_symbol_notional_usd_range"]
+
+    assert us_range.lanes == ["buy", "discovery"]
+    assert us_range.value == [150, 450]
+    assert us_range.unit == "usd"
+    exception = us_range.one_share_exception
+    assert exception is not None
+    assert exception.enabled is True
+    assert exception.absolute_ceiling_usd == 700
+    assert exception.max_deep_rungs == 1
+
+
+def test_other_thresholds_default_one_share_exception_to_none():
+    doc = TradingPolicyDocument.model_validate(_raw())
+    assert doc.thresholds["screen.rsi_max"].one_share_exception is None
+
+
+def test_us_notional_usd_range_one_share_exception_extra_key_rejected():
+    raw = _raw()
+    raw["thresholds"]["buy.per_symbol_notional_usd_range"]["one_share_exception"][
+        "bogus"
+    ] = 1
+    with pytest.raises(ValidationError):
+        TradingPolicyDocument.model_validate(raw)
+
+
+def test_us_notional_usd_range_one_share_exception_missing_required_field_rejected():
+    raw = _raw()
+    del raw["thresholds"]["buy.per_symbol_notional_usd_range"]["one_share_exception"][
+        "max_deep_rungs"
+    ]
     with pytest.raises(ValidationError):
         TradingPolicyDocument.model_validate(raw)

--- a/tests/services/order_proposals/test_dispatch.py
+++ b/tests/services/order_proposals/test_dispatch.py
@@ -437,10 +437,10 @@ async def test_dispatch_auto_eligible_buy_or_sell_rests_without_approval(
     refreshed, rungs = await service.get_proposal(group.proposal_id)
     assert rungs[0].state == "resting"
     assert refreshed.approved_by_telegram_user_id is None
-    assert refreshed.source_asof["auto_approved"]["policy_version"] == "2026-07-17.2"
+    assert refreshed.source_asof["auto_approved"]["policy_version"] == "2026-07-17.3"
     text, keyboard, _chat_id = notifier.sent_messages[0]
     assert "자동 접수됨" in text
-    assert "auto:policy@2026-07-17.2" in text
+    assert "auto:policy@2026-07-17.3" in text
     assert keyboard["inline_keyboard"][0][0]["text"] == "취소"
     assert keyboard["inline_keyboard"][0][0]["callback_data"].startswith("vc:")
 

--- a/tests/services/test_trading_policy_service.py
+++ b/tests/services/test_trading_policy_service.py
@@ -5,7 +5,7 @@ from app.services import trading_policy_service as svc
 
 def test_version_stamp_has_version_and_hash():
     stamp = svc.policy_version_stamp()
-    assert stamp["version"] == "2026-07-17.2"
+    assert stamp["version"] == "2026-07-17.3"
     assert len(stamp["content_hash"]) == 12
 
 
@@ -15,7 +15,7 @@ def test_content_hash_stable_across_calls():
 
 def test_get_policy_for_buy_kr_includes_cap_and_version():
     view = svc.get_policy_for("kr", "buy")
-    assert view["version"] == "2026-07-17.2"
+    assert view["version"] == "2026-07-17.3"
     assert view["content_hash"]
     t = view["thresholds"]
     # buy lane references these (playbook lane tags)
@@ -31,7 +31,7 @@ def test_get_policy_for_buy_kr_includes_cap_and_version():
 def test_get_policy_for_crypto_buy_exposes_report_derived_market_rules():
     view = svc.get_policy_for("crypto", "buy")
 
-    assert view["version"] == "2026-07-17.2"
+    assert view["version"] == "2026-07-17.3"
     assert set(view["market_rules"]) == {
         "recovery_gate",
         "support_resistance",
@@ -128,6 +128,28 @@ def test_get_policy_for_user_stances_present_regardless_of_market_lane():
     us_sell = svc.get_policy_for("us", "sell")["user_stances"]
     crypto_discovery = svc.get_policy_for("crypto", "discovery")["user_stances"]
     assert us_sell == crypto_discovery
+
+
+def test_get_policy_for_includes_us_notional_usd_range_with_one_share_exception():
+    view = svc.get_policy_for("us", "buy")
+    t = view["thresholds"]
+    us_range = t["buy.per_symbol_notional_usd_range"]
+
+    assert us_range["value"] == [150, 450]
+    assert us_range["unit"] == "usd"
+    assert us_range["one_share_exception"] == {
+        "enabled": True,
+        "absolute_ceiling_usd": 700,
+        "max_deep_rungs": 1,
+    }
+
+
+def test_get_policy_for_kr_notional_krw_range_has_no_one_share_exception():
+    view = svc.get_policy_for("kr", "buy")
+    kr_range = view["thresholds"]["buy.per_symbol_notional_krw_range"]
+
+    assert kr_range["value"] == [200000, 400000]
+    assert kr_range["one_share_exception"] is None
 
 
 def test_sector_cluster_for():


### PR DESCRIPTION
## What
Adds `buy.per_symbol_notional_usd_range` (US lane, USD-denominated so it decouples from FX) to `config/trading_policy.yaml`, and scopes the existing KRW key to KR-only. Fixes: at FX ~1491 the fixed-KRW band [₩200k,₩400k] blocks any US new entry >$268/share (CI $271 real case); US has no fractional shares, so a 1-share floor is needed.

Frozen spec (verbatim): `lanes: [buy, discovery]`, `value: [150, 450]`, `unit: usd`, `one_share_exception{enabled, absolute_ceiling_usd: 700, max_deep_rungs: 1}`, `semantics`. Advisory (ROB-646 — sessions cite, code does not enforce).

## Change
- `app/schemas/trading_policy.py`: new strict `OneShareExceptionPolicy` nested as an optional `one_share_exception` field on the generic `PolicyThreshold` (defaults None for all other thresholds).
- `config/trading_policy.yaml`: new key verbatim; KRW key semantics += "; KR lane only" (value [200000,400000] unchanged).
- version `2026-07-17.2 → 2026-07-17.3`; 4 hardcoded-literal test files bumped.

## TDD
14 RED (KeyError on missing key / AttributeError on `.one_share_exception` / version mismatch) → all pass. Touched suite 49; broad ripple sweep 1208 passed, 0 regressions. migration 0.

## Adversarial verify — PASS
Frozen spec **byte-exact incl. `lanes`**; nested design harmless (strict preserved, `extra=forbid` intact, only order_validation's `sector_cluster_cap_pct` indexing consumer — unaffected by the new subkey); real RED; strict + type checks (value list[int] like KR sibling); version bump complete (independent grep, 0 `…2` stragglers); **advisory boundary independently verified** — `per_symbol_notional_usd_range`/`one_share_exception`/`OneShareException` have 0 refs in order_proposals / order_validation exec-branch / orders_*_variants / order_execution (only schema-def + service-echo); content_hash no-regression; KR key value unchanged.
Sole cosmetic note (non-blocking): echo promotes `absolute_ceiling_usd` to `700.0` (int→float) — value-equal, advisory echo, optional int-ification.

🔒 Merge gated — orch/operator review. (ROB-948 landed first; this rebases cleanly on top.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)