### PR TITLE
docs(ROB-958): confirm KIS overseas ord_tmd is KST, not ET-local (no code change)

### DIFF
--- a/app/services/kis_websocket_internal/parsers.py
+++ b/app/services/kis_websocket_internal/parsers.py
@@ -390,6 +390,23 @@ class ExecutionMessageParser:
         if not order_id:
             order_id = None
 
+        # ROB-958: H0GSCNI0's HHMMSS field is KIS's own back-office clock (KST),
+        # not exchange-local (ET) time, despite the US venue. This WebSocket
+        # fill field has no direct prod sample (execution_ledger has 0
+        # source=websocket US rows), so the KST determination is induction from
+        # KIS's REST surfaces — which all use KST (verified prod, 2026-07-18):
+        #  - live_order_ledger.order_time for kis US orders matches order-accept
+        #    created_at within ~2s when parsed as KST (94 samples, all EDT,
+        #    Jun–Jul 2026); the ET-tagged parse is off by ~11-13h (an impossible
+        #    ~half-day gap between accept and record).
+        #  - execution_ledger reconciler ord_dt/ord_tmd KST invariant
+        #    (_parse_kis_order_timestamp, ROB-933) passes for every overseas row
+        #    (52/52, incl. the 2026-03-08 DST boundary) — KIS books ord_dt as
+        #    the KST calendar day.
+        # So the shared KST anchor from _extract_timestamp (ROB-934) is correct
+        # here too — do not add a venue-specific ET branch. (Grouping US trade
+        # days by ET session, if ever needed, is a separate concern — KIS itself
+        # books in KST.)
         filled_at = self._extract_timestamp(fields[OVERSEAS_FILL_FIELDS["filled_at"]])
         execution_status = self._classify_overseas_execution_status(
             rfus_yn=rfus_yn,


### PR DESCRIPTION
## Verdict: KST confirmed — ROB-934's shared KST anchor is correct for the overseas (US) path too
Investigation-first issue (AC#1 = live/record confirmation of the KIS overseas `ord_tmd` timezone). **Conclusion: KST, not ET-local** → no venue-specific ET branch needed. **Docs-only: 0 logic change** (comment at the H0GSCNI0 overseas call site, `parsers.py:393`).

## Evidence (prod, read-only, reproduced by adversarial verify)
The WebSocket fill field itself has **0 direct prod samples** (`execution_ledger` has no `source=websocket` US rows), so KST is **induction from KIS's REST surfaces**, which all use KST:
1. `live_order_ledger.order_time` vs order-accept `created_at`: matches within ~2s as **KST** across **94** kis-US samples (all EDT, Jun–Jul 2026); the ET-tagged parse is ~11–13h off (an impossible ~half-day accept↔record gap).
2. `execution_ledger` reconciler `ord_dt/ord_tmd` KST invariant (`_parse_kis_order_timestamp`, ROB-933) passes for **every** overseas row (**52/52**, incl. the 2026-03-08 DST boundary) — KIS books `ord_dt` as the KST calendar day.

Adversarial verify independently re-ran both paths on prod (94/94 + 52/52, no counterexample) and confirmed the KST verdict. Comment wording was corrected per its findings: **N1** — sample provenance separated (94 all-EDT order-accept rows vs the reconciler-row coverage; the prior "89 samples spanning EDT/EST" conflated two datasets); **N3** — the WebSocket field is REST-induction, not direct measurement ("confirmed empirically" softened).

## Scope note (AC#4)
Instant-TZ (KST) is distinct from trade-day grouping. KIS books `ord_dt` in KST; if downstream US analysis ever needs ET-session grouping, that's a separate concern — not this fix, and ROB-934 stays consistent with KIS.

`tests/services/kis_websocket/` 123 passed; ruff/ty clean.

🔒 Merge gated — orch/operator review. Resolves the ROB-934 verify F2 concern (overseas KST stamp is correct, not a regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)