### PR TITLE
fix(ROB-957): 14-digit KIS timestamp KST-aware (mirror ROB-934)

### DIFF
--- a/app/services/kis_websocket_internal/parsers.py
+++ b/app/services/kis_websocket_internal/parsers.py
@@ -615,7 +615,17 @@ class ExecutionMessageParser:
                     .isoformat()
                 )
             if len(cleaned) == 14:
-                return datetime.strptime(cleaned, "%Y%m%d%H%M%S").isoformat()
+                # KIS 14-digit YYYYMMDDHHMMSS fields are KST wall-clock
+                # time, same as the 6-digit HHMMSS fields above; return
+                # KST-aware so events.py's naive->UTC fallback doesn't
+                # misattribute. (ROB-958's prod evidence was overseas
+                # 6-digit ord_tmd, but it establishes KIS echoes KST
+                # regardless of digit width; domestic 14-digit is KST too.)
+                return (
+                    datetime.strptime(cleaned, "%Y%m%d%H%M%S")
+                    .replace(tzinfo=KST)
+                    .isoformat()
+                )
         return cleaned
 
     def _find_hhmmss_token(

--- a/tests/services/kis_websocket/test_parsers.py
+++ b/tests/services/kis_websocket/test_parsers.py
@@ -6,6 +6,7 @@ import pytest
 from app.core.timezone import KST
 from app.services.kis_websocket import KISExecutionWebSocket
 from app.services.kis_websocket_internal import parsers as parsers_module
+from app.services.kis_websocket_internal.events import build_lifecycle_event
 from tests.services.kis_websocket import (
     build_domestic_message,
     build_official_h0gscni0_message,
@@ -85,12 +86,73 @@ class TestExtractTimestampKST:
 
     def test_full_14_digit_timestamp_unaffected_by_now(self, client, monkeypatch):
         # Full YYYYMMDDHHMMSS tokens must not regress: they carry their own
-        # date and are unaffected by "now" framing.
+        # date and are unaffected by "now" framing. ROB-957: KIS 14-digit
+        # tokens are KST wall-clock (confirmed prod evidence, ROB-958) and
+        # must be tz-aware, not naive.
         self._freeze(monkeypatch, utc_now=datetime(2026, 7, 16, 15, 20, 0, tzinfo=UTC))
 
         result = client._extract_timestamp("20260716153045")
 
-        assert result == "2026-07-16T15:30:45"
+        parsed = datetime.fromisoformat(result)
+        assert parsed.tzinfo is not None
+        assert parsed.astimezone(KST).strftime("%Y-%m-%d") == "2026-07-16"
+        assert parsed.astimezone(KST).strftime("%H:%M:%S") == "15:30:45"
+
+    def test_full_14_digit_timestamp_evening_window_not_misattributed_to_next_utc_day(
+        self, client, monkeypatch
+    ):
+        # ROB-957: a 14-digit token reported inside KST 15:00-23:59 is the
+        # window where naive-then-assume-UTC downstream handling
+        # (events.py _resolve_occurred_at) would shift the fill forward by
+        # 9h, rolling it onto the wrong KST calendar date. With the fix,
+        # the KST-aware value must convert to the correct UTC instant.
+        self._freeze(monkeypatch, utc_now=datetime(2026, 7, 16, 15, 20, 0, tzinfo=UTC))
+
+        result = client._extract_timestamp("20260716223000")
+
+        parsed = datetime.fromisoformat(result)
+        assert parsed.tzinfo is not None
+        assert parsed.astimezone(UTC).isoformat() == "2026-07-16T13:30:00+00:00"
+        assert (
+            parsed.astimezone(KST).strftime("%Y-%m-%d %H:%M:%S")
+            == "2026-07-16 22:30:00"
+        )
+
+    def test_full_14_digit_timestamp_near_kst_midnight_is_kst_aware(
+        self, client, monkeypatch
+    ):
+        self._freeze(monkeypatch, utc_now=datetime(2026, 7, 16, 15, 20, 0, tzinfo=UTC))
+
+        result = client._extract_timestamp("20260717000030")
+
+        parsed = datetime.fromisoformat(result)
+        assert parsed.tzinfo is not None
+        assert (
+            parsed.astimezone(KST).strftime("%Y-%m-%d %H:%M:%S")
+            == "2026-07-17 00:00:30"
+        )
+
+    def test_full_14_digit_timestamp_via_full_message_parse_not_misattributed_forward(
+        self, client, monkeypatch
+    ):
+        # End-to-end: a domestic execution message with a 14-digit KST
+        # ord_tmd inside the 15:00-23:59 misattribution window must produce
+        # a filled_at that events.py's naive->UTC fallback does not shift
+        # onto the wrong KST calendar date.
+        self._freeze(monkeypatch, utc_now=datetime(2026, 7, 16, 15, 20, 0, tzinfo=UTC))
+
+        message = build_domestic_message(
+            symbol="005930",
+            filled_qty="10",
+            filled_price="70000",
+            ord_tmd="20260716223000",
+        )
+        result = client._parse_message(message)
+
+        assert result is not None
+        event = build_lifecycle_event(result, account_mode="kis_mock")
+        assert event.occurred_at.astimezone(KST).strftime("%Y-%m-%d") == "2026-07-16"
+        assert event.occurred_at.astimezone(KST).strftime("%H:%M:%S") == "22:30:00"
 
     def test_already_iso_timestamp_passthrough_unaffected(self, client, monkeypatch):
         self._freeze(monkeypatch, utc_now=datetime(2026, 7, 16, 15, 20, 0, tzinfo=UTC))


### PR DESCRIPTION
## What
`_extract_timestamp`'s `len==14` branch (`parsers.py`) returned a **naive** `.isoformat()`, which `events.py`'s naive→UTC fallback then misattributes forward by 9h for fills reported in the KST 15:00–23:59 window — the mirror image of the 6-digit bug ROB-934 fixed. Reachable via domestic official fill.

Fix: apply the same `.replace(tzinfo=KST)` treatment (KST constant reused), returning KST-aware. 6-digit path untouched.

## Change (2 files, isolated)
- `app/services/kis_websocket_internal/parsers.py` — 14-digit branch only.
- `tests/services/kis_websocket/test_parsers.py` — updated the naive-locking test to expect KST-aware; added midnight-window RED.

## TDD
RED: 22:30 KST 14-digit fill → `_resolve_occurred_at` naive→UTC → `assert '2026-07-17' == '2026-07-16'` (+1-day misattribution), an e2e case through `build_domestic_message(ord_tmd=14-digit)`. GREEN after `.replace(tzinfo=KST)`. Boundaries: 00:00:30 (harmless morning window) / 15:30 / 22:30 (bug window) / midnight / ISO passthrough / all 6-digit cases.

## Adversarial verify — GO
Real RED (value mismatch, not collection error); the ROB-934 naive-locking test was **updated (not deleted)** to KST-aware; 6-digit branch and its tests fully untouched (`git diff c141a0b5 HEAD` = 14-digit branch only); KST constant reused (fixed +09:00, no dup tzinfo); events.py consistency verified at runtime (aware value bypasses the naive→UTC branch, no double-convert); boundary + reach-path coverage complete; consistent with ROB-958's KIS-uses-KST finding. `tests/services/kis_websocket/` 126 passed; ruff check + `ruff format --check` + ty all clean.
Comment softened per verify note (ROB-958's direct evidence was overseas 6-digit; it establishes KIS echoes KST regardless of digit width, and domestic 14-digit KST is independently established).

🔒 Merge gated — orch/operator review. Closes the ROB-934 verify residual (14-digit path); companion to ROB-958 (overseas TZ, merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected timestamp handling for domestic execution messages with full date-and-time values.
  * Preserved Korea Standard Time (KST) information to prevent timestamps from being shifted to the wrong UTC date or time.
  * Improved lifecycle event timestamps, including values near midnight and during evening hours.

* **Tests**
  * Added coverage for full timestamp parsing and end-to-end execution event timestamps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->