### PR TITLE
perf(ROB-964): defer asyncpg (lazy DB engine) + pandas off mock-test hot path

### DIFF
--- a/app/core/db.py
+++ b/app/core/db.py
@@ -1,5 +1,6 @@
 import os
 from collections.abc import AsyncGenerator
+from typing import Any
 
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
@@ -46,8 +47,72 @@ def build_engine(database_url: str | None = None) -> AsyncEngine:
     )
 
 
-engine = build_engine()
-AsyncSessionLocal = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+# ROB-964: defer engine + sessionmaker construction to first use.
+#
+# ``create_async_engine('postgresql+asyncpg://...')`` eagerly imports the
+# ``asyncpg`` DBAPI (~0.8s cold, amplified by coverage's sys.monitoring under
+# xdist). This module is imported by ~130 call sites, so building the engine at
+# import time charged that asyncpg import to every worker's first test — even
+# pure-mock tests that never touch the DB. Constructing the engine lazily keeps
+# the singleton semantics (one engine per process) while moving the asyncpg
+# import to the first real ``AsyncSessionLocal()`` / ``get_db()`` / ``engine``
+# access.
+_engine: AsyncEngine | None = None
+# ``sessionmaker`` is left unparameterized: its stub TypeVar is bound to the sync
+# ``Session`` and rejects ``AsyncSession`` as a type argument, mirroring the
+# original untyped ``AsyncSessionLocal = sessionmaker(...)`` binding.
+_session_local: Any = None
+
+
+def _get_engine() -> AsyncEngine:
+    global _engine
+    if _engine is None:
+        _engine = build_engine()
+    return _engine
+
+
+def _get_session_local() -> Any:
+    global _session_local
+    if _session_local is None:
+        _session_local = sessionmaker(
+            _get_engine(), class_=AsyncSession, expire_on_commit=False
+        )
+    return _session_local
+
+
+class _LazyAsyncSessionLocal:
+    """Stable-singleton proxy for the async ``sessionmaker``.
+
+    Callers do ``AsyncSessionLocal()`` (and pass the object around as a session
+    factory / compare it by identity), so a single proxy instance preserves
+    every existing usage while deferring engine creation — and the ``asyncpg``
+    import — until the first session is opened. ROB-964.
+    """
+
+    def __call__(self, *args: Any, **kwargs: Any) -> AsyncSession:
+        return _get_session_local()(*args, **kwargs)
+
+    def __getattr__(self, name: str) -> Any:
+        # Guard against dunder probes (copy/pickle/etc.) forcing eager engine
+        # creation; only real ``sessionmaker`` attributes are delegated.
+        if name.startswith("__") and name.endswith("__"):
+            raise AttributeError(name)
+        return getattr(_get_session_local(), name)
+
+
+AsyncSessionLocal = _LazyAsyncSessionLocal()
+
+
+def __getattr__(name: str) -> Any:
+    """Module-level lazy attribute access for the shared engine.
+
+    ``from app.core.db import engine`` (or ``app.core.db.engine``) resolves here
+    only when ``engine`` is not a real module attribute, so it builds the engine
+    on first access instead of at import. ROB-964.
+    """
+    if name == "engine":
+        return _get_engine()
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 async def get_db() -> AsyncGenerator[AsyncSession]:

--- a/app/mcp_server/tooling/shared.py
+++ b/app/mcp_server/tooling/shared.py
@@ -6,9 +6,7 @@ import datetime
 import logging
 import math
 import re
-from typing import Any
-
-import pandas as pd
+from typing import TYPE_CHECKING, Any
 
 from app.core.symbol import to_db_symbol
 from app.mcp_server.env_utils import _env_int
@@ -16,7 +14,28 @@ from app.mcp_server.tick_size import adjust_tick_size_kr
 from app.models.manual_holdings import MarketType
 from app.services.domain_errors import DomainServiceError
 
+if TYPE_CHECKING:
+    import pandas as pd
+
 logger = logging.getLogger(__name__)
+
+# ROB-964: ``shared`` is imported by nearly every MCP tool module, but pandas is
+# only needed by the value normalizers below. Importing pandas eagerly pulled
+# the pyarrow/numpy chain (~seconds cold) into every tool's import — charged to
+# each xdist worker's first test even when it never touches a DataFrame. Defer
+# it to first normalizer use; production screener paths already hold pandas
+# loaded, so this is just a cached ``sys.modules`` lookup there.
+_pd: Any = None
+
+
+def _pandas() -> Any:
+    global _pd
+    if _pd is None:
+        import pandas as pd
+
+        _pd = pd
+    return _pd
+
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -195,13 +214,13 @@ def normalize_value(value: Any) -> Any:
     if value is None:
         return None
     try:
-        if pd.isna(value):
+        if _pandas().isna(value):
             return None
     except Exception:
         pass
     if isinstance(value, (datetime.date, datetime.datetime, datetime.time)):
         return value.isoformat()
-    if isinstance(value, pd.Timedelta):
+    if isinstance(value, _pandas().Timedelta):
         return value.total_seconds()
     if hasattr(value, "item"):
         try:
@@ -457,7 +476,7 @@ def _to_optional_consensus_count(value: Any) -> int | None:
     if normalized in (None, ""):
         return None
     try:
-        if pd.isna(normalized):
+        if _pandas().isna(normalized):
             return None
     except Exception:
         pass
@@ -479,7 +498,7 @@ def _to_optional_consensus_upside(value: Any) -> float | None:
         return None
     if isinstance(value, (int, float)):
         try:
-            if pd.isna(value):
+            if _pandas().isna(value):
                 return None
         except Exception:
             pass


### PR DESCRIPTION
## 배경 (ROB-964)

CI shard의 순수 mock 테스트가 29~32s (로컬 `.test_durations`는 <1s). 원인은 **xdist 워커별 첫 테스트에 청구되는 무거운 콜드 import**이고 coverage(sys.monitoring)가 증폭. `python -X importtime` 프로파일링으로 두 개의 지배적 third-party 비용을 확정:

| third-party | cold self-time | 유입 경로 |
| -- | -- | -- |
| `asyncpg` | ~0.8s | `create_async_engine('postgresql+asyncpg://...')` — `app/core/db.py`가 **import 시점**에 엔진 생성. `app.core.db`를 import하는 모듈 ~130개 → 모든 워커가 지불 (DB 안 쓰는 mock 테스트 포함) |
| `pandas` → `pyarrow.lib` (+numpy) | pyarrow ~3.8s(!) | `import pandas` (app 모듈 49개). MCP 툴 공용 베이스 `shared.py` 경유 |

## 변경

### 1. `app/core/db.py` — 엔진/세션메이커 지연 생성
- `engine = build_engine()`을 import 시점에서 **최초 사용 시점**으로 이동.
- `AsyncSessionLocal`을 **안정적 싱글턴 프록시**(`_LazyAsyncSessionLocal`)로 교체. 모든 호출부가 `AsyncSessionLocal()` 호출 / 팩토리로 전달 / identity 비교(`kr_hourly_candles_read_service`)만 하므로 프록시로 100% 호환.
- `engine`은 모듈 `__getattr__`로 지연 노출 (`from app.core.db import engine`은 여전히 동일 싱글턴).
- **의미 변화 없음**: 프로세스당 엔진 1개, 동일 URL/pool(`DB_POOL_CLASS`). 생성 *시점*만 첫 DB 사용으로 이동.

### 2. `app/mcp_server/tooling/shared.py` — pandas 지연
- `import pandas as pd`를 캐시된 `_pandas()` 접근자로 이동 (5개 사용처). `pd.DataFrame` 어노테이션은 `TYPE_CHECKING` + `from __future__ import annotations`로 유지.
- 프로덕션 스크리너 경로는 이미 pandas 로딩 상태라 런타임엔 `sys.modules` 캐시 조회뿐.

## 결과 (import 시 heavy 모듈 미로딩)

```
app.mcp_server.tooling.screener_snapshot_tool   1.16s → 0.22s   (asyncpg no longer loaded)
app.core.db                                     heavy_loaded=[]  (asyncpg deferred)
app.mcp_server.tooling.shared                   heavy_loaded=[]  (pandas deferred)
```

## Task 3 — 10초+ setup fixture 원인 확인

`test_watch_follow_up_service`(12.3s)·`test_mock_loop_retrospective_service`(10.6s)의 "setup"은 **세션 스코프 `_bootstrap_test_schema` 배리어(ROB-723)** — 워커당 1회 전체 스키마 DDL을 advisory lock 하에 적용하고, pytest가 그 워커의 첫 테스트에 청구. 이미 세션 공유(once/worker)이며 by-design. 이 PR은 그 first-test 세금의 콜드 import(asyncpg) 부분을 줄임. (격리 실행 시 0.92s — 스키마 sentinel 존재 시 DDL skip.)

## 검증

- 전체 스위트 `pytest -n auto -m "not live"` → **17155 passed, 16 skipped**. 매 실행 2건이 `asyncpg DeadlockDetectedError`로 실패하나 **실패 집합이 실행마다 바뀜** (run1: `{schema_barrier, kis_mock_cancel}`, run2: `{schema_barrier, live_order_ledger}`) — 전형적 xdist Postgres 데드락 플레이크. 모두 격리 실행 시 통과. 로컬 10워커가 CI 4-vCPU shard보다 경합 심함. DB 레이어 의미 변화 없어 회귀 아님.
- `ruff check app/ tests/` + `ty check` clean.
- ROB-501 in-process LLM import guard 등 기존 static guard 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)