### PR TITLE
ci(ROB-963): tolerate flaky test failures in durations-refresh workflow

### DIFF
--- a/.github/workflows/test-durations-refresh.yml
+++ b/.github/workflows/test-durations-refresh.yml
@@ -152,6 +152,9 @@ jobs:
         # if you want CI to run automatically on the refresh PR.
         token: ${{ secrets.DURATIONS_REFRESH_TOKEN || secrets.GITHUB_TOKEN }}
         commit-message: "chore(ci): refresh .test_durations (pytest-split shard balance)"
+        # The suite mutates tracked files as a side effect (.smoke-out/*.json);
+        # commit ONLY the durations file so the auto-PR never picks them up.
+        add-paths: .test_durations
         branch: ci/test-durations-refresh
         delete-branch: true
         base: main

--- a/.github/workflows/test-durations-refresh.yml
+++ b/.github/workflows/test-durations-refresh.yml
@@ -100,9 +100,26 @@ jobs:
       # single committed .test_durations covers the whole suite. Running with
       # --splits/--group would only record that shard's subset. No --cov here
       # (durations only). Mirrors the command documented in test.yml.
+      #
+      # Exit code 1 (test failures) is tolerated: unsharded, every test file
+      # shares ONE postgres, so files that the 4-shard split normally isolates
+      # into separate jobs collide here (advisory-lock deadlocks, cross-file
+      # row contamination — observed in runs 29641342852 / 29642419871 with a
+      # different flaky set each time). Correctness gating belongs to test.yml;
+      # this job only needs per-test durations, which pytest-split records for
+      # failed tests too. Exit codes >= 2 (interrupted / internal error /
+      # collection error) still fail the job so a partial run never ships.
       run: |
+        set +e
         uv run pytest tests/ -m "not live" --store-durations -n 4 --dist=loadfile \
           -o faulthandler_timeout=120 -ra
+        status=$?
+        if [ "$status" -eq 1 ]; then
+          echo "::warning title=durations refresh::test failures tolerated (exit 1); durations were still recorded"
+        elif [ "$status" -ne 0 ]; then
+          echo "pytest exited with $status (interrupted/internal/collection error) — aborting refresh"
+          exit "$status"
+        fi
 
     - name: Detect .test_durations changes
       id: diff
@@ -117,6 +134,12 @@ jobs:
           echo "before_entries=$before" >> "$GITHUB_OUTPUT"
           echo "after_entries=$after" >> "$GITHUB_OUTPUT"
           echo "Recorded duration entries: $before -> $after"
+          # A large entry-count drop means the run recorded only part of the
+          # suite (legit test removals shrink it far less) — never PR that.
+          if [ "$after" -lt $(( before * 9 / 10 )) ]; then
+            echo "Entry count dropped >10% ($before -> $after) — refusing to open a PR with partial durations."
+            exit 1
+          fi
         fi
 
     - name: Open auto-PR with refreshed durations


### PR DESCRIPTION
Both dispatches of the new durations-refresh workflow died on suite flakes that only occur unsharded (all test files sharing ONE postgres — the 4-shard split normally isolates the colliding files into separate jobs/DBs):

- run 29641342852: `DeadlockDetectedError` (schema-barrier advisory lock)
- run 29642419871: 5 cross-file DB contamination failures (`StaleDataError`, off-by-one counts) — a different set each time

Since this job only needs per-test **durations** (recorded for failed tests too) and correctness gating stays in `test.yml`:

- pytest exit 1 (test failures) → tolerated with a `::warning`
- exit ≥ 2 (interrupted / internal / collection error) → still fails the job
- new guard: refuse to open the auto-PR if the recorded entry count drops >10% (partial-run protection)

After merge I'll re-dispatch the workflow to produce the CI-measured durations PR (current committed durations are local-machine-measured, which is why shard 4 still runs ~340s vs ~240-300s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Test duration data can now be refreshed even when the test suite reports failures, provided duration records are generated.
  * Refreshes still fail for interrupted or invalid test runs.
  * Automatic updates are blocked when recorded test entries drop by more than 10%, preventing incomplete duration data from being published.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->