### PR TITLE
feat(ROB-980): H3 S3 signal engine + H2 integration (round-2 campaign)

### DIFF
--- a/research/nautilus_scalping/rob974_h3_evidence.py
+++ b/research/nautilus_scalping/rob974_h3_evidence.py
@@ -1,0 +1,483 @@
+"""ROB-974 H3 scenario-independent unique generator evidence.
+
+One evidence object consumes one whole global S3 or S4 invocation.  Per-unit
+callbacks, cost scenarios, funding gates, phase horizons, and engine state are
+outside this boundary.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from dataclasses import dataclass
+
+from rob974_h3_manifest import (
+    PAIRS,
+    S3_STRATEGY_CONTRACT,
+    S4_STRATEGY_CONTRACT,
+    SYMBOLS,
+    S3Config,
+    S4Config,
+    get_config,
+)
+from rob974_h3_manifest import (
+    S3_GENERATOR_REJECTION_TAXONOMY as _S3_GENERATOR_REJECTION_TAXONOMY,
+)
+from rob974_h3_manifest import (
+    S3_NO_SIGNAL_TAXONOMY as _S3_NO_SIGNAL_TAXONOMY,
+)
+from rob974_h3_manifest import (
+    S4_GENERATOR_REJECTION_TAXONOMY as _S4_GENERATOR_REJECTION_TAXONOMY,
+)
+from rob974_h3_manifest import (
+    S4_NO_SIGNAL_TAXONOMY as _S4_NO_SIGNAL_TAXONOMY,
+)
+from rob974_h3_s3 import S3Candidate, S3GeneratorOutput
+from rob974_h3_s4 import S4Candidate, S4GeneratorOutput
+
+from research_contracts.canonical_hash import canonical_sha256
+
+PHASES: tuple[str, ...] = (
+    "train",
+    "selected_oos",
+    "pbo_full_window",
+    "offline_smoke",
+)
+S3_NO_SIGNAL_TAXONOMY: tuple[str, ...] = _S3_NO_SIGNAL_TAXONOMY
+S4_NO_SIGNAL_TAXONOMY: tuple[str, ...] = _S4_NO_SIGNAL_TAXONOMY
+S3_GENERATOR_REJECTION_TAXONOMY: tuple[str, ...] = _S3_GENERATOR_REJECTION_TAXONOMY
+S4_GENERATOR_REJECTION_TAXONOMY: tuple[str, ...] = _S4_GENERATOR_REJECTION_TAXONOMY
+
+
+def _str(value: object, name: str) -> str:
+    if type(value) is not str:
+        raise TypeError(f"{name} must be built-in str")
+    return value
+
+
+def _int(value: object, name: str) -> int:
+    if type(value) is not int:
+        raise TypeError(f"{name} must be built-in int")
+    return value
+
+
+def _sha(value: object, name: str) -> str:
+    text = _str(value, name)
+    if len(text) != 64 or any(char not in "0123456789abcdef" for char in text):
+        raise ValueError(f"{name} must be lowercase SHA-256")
+    return text
+
+
+@dataclass(frozen=True, slots=True)
+class GeneratorIdentity:
+    strategy: str
+    config_id: str
+    fold_or_full_window: str
+    phase: str
+    decision_ts: int
+    symbol_or_pair: str
+    side: str
+
+    def __post_init__(self) -> None:
+        if _str(self.strategy, "strategy") not in ("S3", "S4"):
+            raise ValueError("strategy must be S3 or S4")
+        config = get_config(_str(self.config_id, "config_id"))
+        expected_type = S3Config if self.strategy == "S3" else S4Config
+        if (
+            not self.config_id.startswith(f"{self.strategy}-")
+            or type(config) is not expected_type
+        ):
+            raise ValueError("identity strategy/config mismatch")
+        if not _str(self.fold_or_full_window, "fold_or_full_window"):
+            raise ValueError("fold_or_full_window must not be empty")
+        if _str(self.phase, "phase") not in PHASES:
+            raise ValueError("phase outside the closed generator phase set")
+        _int(self.decision_ts, "decision_ts")
+        if self.strategy == "S3":
+            if self.symbol_or_pair not in SYMBOLS or self.side not in ("long", "short"):
+                raise ValueError("invalid S3 candidate identity")
+        elif self.symbol_or_pair not in PAIRS or self.side not in (
+            "short_a_long_b",
+            "long_a_short_b",
+        ):
+            raise ValueError("invalid S4 candidate identity")
+
+    def as_tuple(self) -> tuple[str, str, str, str, int, str, str]:
+        return (
+            self.strategy,
+            self.config_id,
+            self.fold_or_full_window,
+            self.phase,
+            self.decision_ts,
+            self.symbol_or_pair,
+            self.side,
+        )
+
+
+def _histogram_keys(strategy: str) -> tuple[tuple[str, ...], tuple[str, ...]]:
+    if strategy == "S3":
+        return S3_NO_SIGNAL_TAXONOMY, S3_GENERATOR_REJECTION_TAXONOMY
+    return S4_NO_SIGNAL_TAXONOMY, S4_GENERATOR_REJECTION_TAXONOMY
+
+
+def _side_keys(strategy: str) -> tuple[str, ...]:
+    return (
+        ("long", "short") if strategy == "S3" else ("short_a_long_b", "long_a_short_b")
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class UniqueGeneratorEvidence:
+    schema_version: str
+    strategy: str
+    config_id: str
+    strategy_contract_hash: str
+    fold_or_full_window: str
+    phase: str
+    global_invocation_count: int
+    evaluated_decision_units: int
+    no_signal: int
+    candidate: int
+    generator_rejected: int
+    generator_accepted: int
+    outcome_histogram: tuple[tuple[str, int], ...]
+    no_signal_reason_histogram: tuple[tuple[str, int], ...]
+    generator_rejection_reason_histogram: tuple[tuple[str, int], ...]
+    candidate_side_histogram: tuple[tuple[str, int], ...]
+    accepted_identities: tuple[GeneratorIdentity, ...]
+    rejected_identities: tuple[GeneratorIdentity, ...]
+    candidate_payload_hashes: tuple[tuple[GeneratorIdentity, str], ...]
+
+    def __post_init__(self) -> None:
+        if (
+            _str(self.schema_version, "schema_version")
+            != "rob974-h3-generator-evidence-v1"
+        ):
+            raise ValueError("unique evidence schema drift")
+        if _str(self.strategy, "strategy") not in ("S3", "S4"):
+            raise ValueError("unique evidence strategy must be S3 or S4")
+        _str(self.config_id, "config_id")
+        _sha(self.strategy_contract_hash, "strategy_contract_hash")
+        expected_contract = (
+            S3_STRATEGY_CONTRACT.contract_hash
+            if self.strategy == "S3"
+            else S4_STRATEGY_CONTRACT.contract_hash
+        )
+        if self.strategy_contract_hash != expected_contract:
+            raise ValueError("unique evidence strategy contract mismatch")
+        if not _str(self.fold_or_full_window, "fold_or_full_window"):
+            raise ValueError("fold_or_full_window must not be empty")
+        if _str(self.phase, "phase") not in PHASES:
+            raise ValueError("phase outside closed set")
+        for name in (
+            "global_invocation_count",
+            "evaluated_decision_units",
+            "no_signal",
+            "candidate",
+            "generator_rejected",
+            "generator_accepted",
+        ):
+            value = _int(getattr(self, name), name)
+            if value < 0:
+                raise ValueError(f"{name} must not be negative")
+        if self.global_invocation_count != 1:
+            raise ValueError("evidence must represent exactly one global invocation")
+        if self.evaluated_decision_units != self.no_signal + self.candidate:
+            raise ValueError("evaluated_decision_units equation failed")
+        if self.candidate != self.generator_rejected + self.generator_accepted:
+            raise ValueError("candidate equation failed")
+        expected_outcomes = (
+            ("no_signal", self.no_signal),
+            ("candidate", self.candidate),
+            ("generator_rejected", self.generator_rejected),
+            ("generator_accepted", self.generator_accepted),
+        )
+        if self.outcome_histogram != expected_outcomes:
+            raise ValueError("closed outcome histogram mismatch")
+        no_signal_keys, rejection_keys = _histogram_keys(self.strategy)
+        if tuple(key for key, _ in self.no_signal_reason_histogram) != no_signal_keys:
+            raise ValueError("closed no-signal histogram keys/order mismatch")
+        if tuple(key for key, _ in self.generator_rejection_reason_histogram) != (
+            rejection_keys
+        ):
+            raise ValueError("closed rejection histogram keys/order mismatch")
+        for histogram in (
+            self.outcome_histogram,
+            self.no_signal_reason_histogram,
+            self.generator_rejection_reason_histogram,
+            self.candidate_side_histogram,
+        ):
+            if type(histogram) is not tuple or any(
+                type(item) is not tuple
+                or len(item) != 2
+                or type(item[0]) is not str
+                or type(item[1]) is not int
+                or item[1] < 0
+                for item in histogram
+            ):
+                raise TypeError("histograms must use exact ordered tuple entries")
+        if sum(value for _, value in self.no_signal_reason_histogram) != self.no_signal:
+            raise ValueError("no-signal histogram subtotal mismatch")
+        if (
+            sum(value for _, value in self.generator_rejection_reason_histogram)
+            != self.generator_rejected
+        ):
+            raise ValueError("generator-rejection histogram subtotal mismatch")
+        if (
+            tuple(key for key, _ in self.candidate_side_histogram)
+            != _side_keys(self.strategy)
+            or sum(value for _, value in self.candidate_side_histogram)
+            != self.candidate
+        ):
+            raise ValueError("candidate-side histogram mismatch")
+        for values, expected_count in (
+            (self.accepted_identities, self.generator_accepted),
+            (self.rejected_identities, self.generator_rejected),
+        ):
+            if type(values) is not tuple or any(
+                type(identity) is not GeneratorIdentity for identity in values
+            ):
+                raise TypeError("identity sets must be exact tuples")
+            if len(values) != expected_count or len(values) != len(set(values)):
+                raise ValueError("identity count/uniqueness mismatch")
+        if set(self.accepted_identities) & set(self.rejected_identities):
+            raise ValueError("accepted/rejected identity collision")
+        all_identities = set(self.accepted_identities) | set(self.rejected_identities)
+        if (
+            type(self.candidate_payload_hashes) is not tuple
+            or len(self.candidate_payload_hashes) != self.candidate
+        ):
+            raise ValueError("candidate payload-hash count mismatch")
+        payload_ids: list[GeneratorIdentity] = []
+        for identity, payload_hash in self.candidate_payload_hashes:
+            if type(identity) is not GeneratorIdentity:
+                raise TypeError("payload hash identity must be exact GeneratorIdentity")
+            _sha(payload_hash, "candidate_payload_hash")
+            payload_ids.append(identity)
+        if set(payload_ids) != all_identities or len(payload_ids) != len(
+            set(payload_ids)
+        ):
+            raise ValueError("candidate payload identities mismatch")
+
+    def to_payload(self) -> dict[str, object]:
+        return {
+            "schema_version": self.schema_version,
+            "strategy": self.strategy,
+            "config_id": self.config_id,
+            "strategy_contract_hash": self.strategy_contract_hash,
+            "fold_or_full_window": self.fold_or_full_window,
+            "phase": self.phase,
+            "global_invocation_count": self.global_invocation_count,
+            "evaluated_decision_units": self.evaluated_decision_units,
+            "no_signal": self.no_signal,
+            "candidate": self.candidate,
+            "generator_rejected": self.generator_rejected,
+            "generator_accepted": self.generator_accepted,
+            "outcome_histogram": self.outcome_histogram,
+            "no_signal_reason_histogram": self.no_signal_reason_histogram,
+            "generator_rejection_reason_histogram": self.generator_rejection_reason_histogram,
+            "candidate_side_histogram": self.candidate_side_histogram,
+            "accepted_identities": tuple(
+                identity.as_tuple() for identity in self.accepted_identities
+            ),
+            "rejected_identities": tuple(
+                identity.as_tuple() for identity in self.rejected_identities
+            ),
+            "candidate_payload_hashes": tuple(
+                (identity.as_tuple(), payload_hash)
+                for identity, payload_hash in self.candidate_payload_hashes
+            ),
+        }
+
+    @property
+    def content_hash(self) -> str:
+        return canonical_sha256(self.to_payload())
+
+
+def _plain(value: object) -> object:
+    if dataclasses.is_dataclass(value) and not isinstance(value, type):
+        return {
+            field.name: _plain(getattr(value, field.name))
+            for field in dataclasses.fields(value)
+        }
+    if type(value) is tuple:
+        return tuple(_plain(item) for item in value)
+    if value is None or type(value) in (str, int, float, bool):
+        return value
+    raise TypeError(f"unsupported candidate payload type {type(value).__name__}")
+
+
+def _candidate_identity(
+    candidate: S3Candidate | S4Candidate,
+    fold_or_full_window: str,
+    phase: str,
+) -> GeneratorIdentity:
+    return GeneratorIdentity(
+        candidate.strategy,
+        candidate.config_id,
+        fold_or_full_window,
+        phase,
+        candidate.decision_ts,
+        candidate.symbol if type(candidate) is S3Candidate else candidate.pair,
+        candidate.side,
+    )
+
+
+def _validate_global_units(output: S3GeneratorOutput | S4GeneratorOutput) -> None:
+    decisions = output.decisions
+    if not decisions or len(decisions) % 3:
+        raise ValueError("one global invocation must evaluate three units per close")
+    expected_units = SYMBOLS if output.strategy == "S3" else PAIRS
+    by_close: dict[int, list[object]] = {}
+    for decision in decisions:
+        by_close.setdefault(decision.decision_ts, []).append(decision)
+    for at_close in by_close.values():
+        units = tuple(
+            decision.symbol if output.strategy == "S3" else decision.pair
+            for decision in at_close
+        )
+        if len(units) != 3 or set(units) != set(expected_units):
+            raise ValueError("global invocation unit coverage mismatch")
+
+
+def build_unique_generator_evidence(
+    output: S3GeneratorOutput | S4GeneratorOutput,
+    *,
+    fold_or_full_window: str,
+    phase: str,
+) -> UniqueGeneratorEvidence:
+    """Build one immutable evidence set from one whole global invocation."""
+    if type(output) not in (S3GeneratorOutput, S4GeneratorOutput):
+        raise TypeError("output must be one exact global S3/S4 generator output")
+    _str(fold_or_full_window, "fold_or_full_window")
+    _str(phase, "phase")
+    if phase not in PHASES:
+        raise ValueError("phase outside closed set")
+    _validate_global_units(output)
+    strategy = output.strategy
+    config = get_config(output.config_id)
+    if (strategy == "S3" and type(config) is not S3Config) or (
+        strategy == "S4" and type(config) is not S4Config
+    ):
+        raise ValueError("global output strategy/config mismatch")
+    no_signal_keys, rejection_keys = _histogram_keys(strategy)
+    no_signal_counts = dict.fromkeys(no_signal_keys, 0)
+    rejection_counts = dict.fromkeys(rejection_keys, 0)
+    side_counts = dict.fromkeys(_side_keys(strategy), 0)
+
+    no_signal = candidate_count = rejected_count = accepted_count = 0
+    decision_accepted: set[tuple[object, ...]] = set()
+    decision_rejected: set[tuple[object, ...]] = set()
+    for decision in output.decisions:
+        if decision.status == "NO_SIGNAL":
+            if decision.candidate is not None or decision.no_signal_reason is None:
+                raise ValueError("malformed NO_SIGNAL decision")
+            no_signal += 1
+            no_signal_counts[decision.no_signal_reason] += 1
+        elif decision.status in ("GENERATOR_ACCEPTED", "GENERATOR_REJECTED"):
+            if decision.candidate is None or decision.no_signal_reason is not None:
+                raise ValueError("malformed candidate decision")
+            candidate_count += 1
+            side_counts[decision.candidate.side] += 1
+            if decision.status == "GENERATOR_ACCEPTED":
+                if decision.generator_rejection_reason is not None:
+                    raise ValueError("accepted candidate has rejection reason")
+                accepted_count += 1
+                decision_accepted.add(decision.candidate.identity)
+            else:
+                if decision.generator_rejection_reason is None:
+                    raise ValueError("rejected candidate lacks first-failing reason")
+                rejected_count += 1
+                rejection_counts[decision.generator_rejection_reason] += 1
+                decision_rejected.add(decision.candidate.identity)
+        else:
+            raise ValueError("unknown generator decision status")
+
+    output_accepted = {candidate.identity for candidate in output.accepted}
+    output_rejected = {item.candidate.identity for item in output.rejected}
+    if decision_accepted != output_accepted or decision_rejected != output_rejected:
+        raise ValueError("decision/output candidate membership mismatch")
+    if output_accepted & output_rejected:
+        raise ValueError("accepted/rejected candidate collision")
+
+    accepted = tuple(
+        sorted(
+            (
+                _candidate_identity(candidate, fold_or_full_window, phase)
+                for candidate in output.accepted
+            ),
+            key=GeneratorIdentity.as_tuple,
+        )
+    )
+    rejected_candidates = tuple(item.candidate for item in output.rejected)
+    rejected = tuple(
+        sorted(
+            (
+                _candidate_identity(candidate, fold_or_full_window, phase)
+                for candidate in rejected_candidates
+            ),
+            key=GeneratorIdentity.as_tuple,
+        )
+    )
+    candidate_by_core_id = {
+        candidate.identity: candidate
+        for candidate in (*output.accepted, *rejected_candidates)
+    }
+    identity_by_core_id = {
+        candidate.identity: _candidate_identity(candidate, fold_or_full_window, phase)
+        for candidate in candidate_by_core_id.values()
+    }
+    payload_hashes = tuple(
+        sorted(
+            (
+                (
+                    identity_by_core_id[core_identity],
+                    canonical_sha256(_plain(candidate)),
+                )
+                for core_identity, candidate in candidate_by_core_id.items()
+            ),
+            key=lambda item: item[0].as_tuple(),
+        )
+    )
+    contract_hash = (
+        S3_STRATEGY_CONTRACT.contract_hash
+        if strategy == "S3"
+        else S4_STRATEGY_CONTRACT.contract_hash
+    )
+    return UniqueGeneratorEvidence(
+        "rob974-h3-generator-evidence-v1",
+        strategy,
+        output.config_id,
+        contract_hash,
+        fold_or_full_window,
+        phase,
+        1,
+        len(output.decisions),
+        no_signal,
+        candidate_count,
+        rejected_count,
+        accepted_count,
+        (
+            ("no_signal", no_signal),
+            ("candidate", candidate_count),
+            ("generator_rejected", rejected_count),
+            ("generator_accepted", accepted_count),
+        ),
+        tuple((key, no_signal_counts[key]) for key in no_signal_keys),
+        tuple((key, rejection_counts[key]) for key in rejection_keys),
+        tuple((key, side_counts[key]) for key in _side_keys(strategy)),
+        accepted,
+        rejected,
+        payload_hashes,
+    )
+
+
+__all__ = [
+    "GeneratorIdentity",
+    "PHASES",
+    "S3_GENERATOR_REJECTION_TAXONOMY",
+    "S3_NO_SIGNAL_TAXONOMY",
+    "S4_GENERATOR_REJECTION_TAXONOMY",
+    "S4_NO_SIGNAL_TAXONOMY",
+    "UniqueGeneratorEvidence",
+    "build_unique_generator_evidence",
+]

--- a/research/nautilus_scalping/rob974_h3_h2_adapter.py
+++ b/research/nautilus_scalping/rob974_h3_h2_adapter.py
@@ -1,0 +1,542 @@
+"""ROB-980 CP8 -- the sole concrete merged-H2 integration seam.
+
+H3's formula/generator modules remain independent of H2 concrete classes.
+This adapter alone verifies the merged ROB-979 schemas, converts accepted H3
+payloads without re-estimation, reuses ROB-979's actual H1 bridge, invokes the
+real account-global engines, and delegates the base13 ledger to H2's scenario
+module.  It has no behavior/funding callback and no fallback/rerank path.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import inspect
+import json
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+
+import rob974_h2_s3_engine as h2_s3_engine
+import rob974_h2_s4_engine as h2_s4_engine
+from rob974_h2_dtos import (
+    S3EngineResult,
+    S3SignalIntent,
+    S3Trade,
+    S4EngineResult,
+    S4PairSignalIntent,
+    S4PairTrade,
+)
+from rob974_h2_h1_bridge import (
+    from_h1_close_features,
+    from_h1_minute_bars,
+    from_h1_pair_leg_closes,
+)
+from rob974_h2_ingress import build_minute_index
+from rob974_h2_scenarios import (
+    PATH_SCENARIO_BASE13,
+    S3ScenarioTradeRow,
+    S4ScenarioTradeRow,
+    build_s3_scenario_ledger,
+    build_s4_scenario_ledger,
+    s3_ledger_hash,
+    s4_ledger_hash,
+)
+from rob974_h3_manifest import SYMBOLS
+from rob974_h3_s3 import FeatureContext, S3Candidate, S3GeneratorOutput
+from rob974_h3_s4 import S4Candidate, S4GeneratorOutput
+
+from research_contracts.canonical_hash import canonical_sha256
+
+H2_MERGE_SHA = "0b81057c7b450f1539c836fd6cfa5732fb5800c5"
+INTEGRATION_SCHEMA_VERSION = "rob974-h3-h2-integration-v1"
+
+
+class ContractDriftError(RuntimeError):
+    """The merged H2 surface no longer matches the reviewed CP8 mapping."""
+
+
+_EXPECTED_DATACLASS_FIELDS: tuple[tuple[str, object, tuple[str, ...]], ...] = (
+    (
+        "S3SignalIntent",
+        S3SignalIntent,
+        (
+            "symbol",
+            "side",
+            "signal_ts",
+            "entry_sl_distance",
+            "entry_tp_distance",
+            "config_id",
+            "fold_id",
+            "volatility_percentile",
+        ),
+    ),
+    (
+        "S4PairSignalIntent",
+        S4PairSignalIntent,
+        (
+            "pair",
+            "signal_ts",
+            "side_a",
+            "side_b",
+            "weight_a",
+            "weight_b",
+            "beta_a",
+            "beta_b",
+            "mu",
+            "sigma",
+            "z_entry",
+            "gross_notional",
+            "entry_sl_distance",
+            "entry_tp_distance",
+            "config_id",
+            "fold_id",
+        ),
+    ),
+    (
+        "S3Trade",
+        S3Trade,
+        (
+            "symbol",
+            "side",
+            "config_id",
+            "fold_id",
+            "signal_ts",
+            "entry_ts",
+            "entry_price",
+            "exit_ts",
+            "exit_price",
+            "exit_reason",
+            "mfe_bps",
+            "mae_bps",
+            "gross_bps",
+            "volatility_percentile",
+        ),
+    ),
+    (
+        "S4PairTrade",
+        S4PairTrade,
+        (
+            "pair",
+            "side_a",
+            "side_b",
+            "config_id",
+            "fold_id",
+            "signal_ts",
+            "entry_ts",
+            "weight_a",
+            "weight_b",
+            "beta_a",
+            "beta_b",
+            "mu",
+            "sigma",
+            "z_entry",
+            "gross_notional",
+            "entry_price_a",
+            "entry_price_b",
+            "exit_ts",
+            "exit_price_a",
+            "exit_price_b",
+            "exit_reason",
+            "mfe_bps",
+            "mae_bps",
+            "gross_bps",
+            "order_id_a",
+            "order_id_b",
+            "pair_exec_status",
+            "pair_executor_validated",
+            "demo_eligible",
+            "volatility_percentile",
+            "volatility_percentile_provenance",
+            "pair_exec_fail",
+            "promotion_status",
+        ),
+    ),
+    ("S3EngineResult", S3EngineResult, ("trades", "no_trades", "incompletes")),
+    ("S4EngineResult", S4EngineResult, ("trades", "no_trades", "incompletes")),
+    (
+        "S3ScenarioTradeRow",
+        S3ScenarioTradeRow,
+        (
+            "trade",
+            "path_scenario",
+            "funding_bps",
+            "e13_bps",
+            "e17_bps",
+            "e22_bps",
+            "thesis_exit_flag",
+            "timeout_flag",
+        ),
+    ),
+    (
+        "S4ScenarioTradeRow",
+        S4ScenarioTradeRow,
+        (
+            "trade",
+            "path_scenario",
+            "funding_bps",
+            "e13_bps",
+            "e17_bps",
+            "e22_bps",
+            "thesis_exit_flag",
+            "timeout_flag",
+        ),
+    ),
+)
+
+_EXPECTED_CALL_FIELDS = (
+    (
+        "run_s3_portfolio_stream",
+        h2_s3_engine.run_s3_portfolio_stream,
+        (
+            "candidates",
+            "minute_index",
+            "close_feature_index",
+            "corpus_end_ts",
+            "horizon_end_ts",
+        ),
+    ),
+    (
+        "run_s4_pair_basket_stream",
+        h2_s4_engine.run_s4_pair_basket_stream,
+        (
+            "candidates",
+            "minute_index",
+            "pair_close_index",
+            "corpus_end_ts",
+            "horizon_end_ts",
+        ),
+    ),
+    ("from_h1_minute_bars", from_h1_minute_bars, ("symbol", "rows")),
+    (
+        "from_h1_close_features",
+        from_h1_close_features,
+        ("symbol", "bars4h", "snapshots"),
+    ),
+    (
+        "from_h1_pair_leg_closes",
+        from_h1_pair_leg_closes,
+        ("symbol", "bars4h"),
+    ),
+)
+
+
+def _contract_drift(message: str) -> ContractDriftError:
+    return ContractDriftError(f"CONTRACT_DRIFT: {message}")
+
+
+def verify_h2_contract() -> None:
+    """Fail closed if any reviewed DTO, bridge, or engine seam has moved."""
+    # Resolve the two intent classes dynamically so a runtime replacement or
+    # future merged edit cannot be masked by the static seal table above.
+    current_types = {
+        "S3SignalIntent": S3SignalIntent,
+        "S4PairSignalIntent": S4PairSignalIntent,
+        "S3Trade": S3Trade,
+        "S4PairTrade": S4PairTrade,
+        "S3EngineResult": S3EngineResult,
+        "S4EngineResult": S4EngineResult,
+        "S3ScenarioTradeRow": S3ScenarioTradeRow,
+        "S4ScenarioTradeRow": S4ScenarioTradeRow,
+    }
+    for name, _sealed_type, expected in _EXPECTED_DATACLASS_FIELDS:
+        current = current_types[name]
+        try:
+            actual = tuple(field.name for field in dataclasses.fields(current))
+        except TypeError as exc:
+            raise _contract_drift(f"{name} is no longer a dataclass") from exc
+        if actual != expected:
+            raise _contract_drift(
+                f"{name} fields changed: expected={expected!r} actual={actual!r}"
+            )
+    for name, function, expected in _EXPECTED_CALL_FIELDS:
+        actual = tuple(inspect.signature(function).parameters)
+        if actual != expected:
+            raise _contract_drift(
+                f"{name} signature changed: expected={expected!r} actual={actual!r}"
+            )
+    if h2_s3_engine.MAX_HOLD_BARS != 12:
+        raise _contract_drift("S3 MAX_HOLD_BARS is no longer 12")
+    if h2_s4_engine.MAX_HOLD_BARS != 9:
+        raise _contract_drift("S4 MAX_HOLD_BARS is no longer 9")
+    if PATH_SCENARIO_BASE13 != "base13":
+        raise _contract_drift("H2 base scenario label changed")
+
+
+def _fold_id(value: object) -> str:
+    if type(value) is not str or not value:
+        raise TypeError("fold_id must be a non-empty built-in str")
+    return value
+
+
+def _exact_int(value: object, name: str) -> int:
+    if type(value) is not int:
+        raise TypeError(f"{name} must be exact built-in int")
+    return value
+
+
+def _adapted_or_drift(factory, *, strategy: str):
+    try:
+        return factory()
+    except (TypeError, ValueError) as exc:
+        raise _contract_drift(
+            f"merged H2 rejected an invariant-valid {strategy} candidate: {exc}"
+        ) from exc
+
+
+def adapt_s3_candidate(candidate: S3Candidate, *, fold_id: str) -> S3SignalIntent:
+    verify_h2_contract()
+    if type(candidate) is not S3Candidate:
+        raise TypeError("candidate must be exact H3 S3Candidate")
+    fold_id = _fold_id(fold_id)
+    if candidate.max_hold_4h_bars != h2_s3_engine.MAX_HOLD_BARS:
+        raise _contract_drift("S3 maximum-hold authority differs between H3 and H2")
+    return _adapted_or_drift(
+        lambda: S3SignalIntent(
+            symbol=candidate.symbol,
+            side=candidate.side,
+            signal_ts=candidate.decision_ts,
+            entry_sl_distance=candidate.d_SL,
+            entry_tp_distance=candidate.d_TP,
+            config_id=candidate.config_id,
+            fold_id=fold_id,
+            volatility_percentile=candidate.volatility_percentile,
+        ),
+        strategy="S3",
+    )
+
+
+def adapt_s4_candidate(candidate: S4Candidate, *, fold_id: str) -> S4PairSignalIntent:
+    verify_h2_contract()
+    if type(candidate) is not S4Candidate:
+        raise TypeError("candidate must be exact H3 S4Candidate")
+    fold_id = _fold_id(fold_id)
+    if candidate.max_hold_4h_bars != h2_s4_engine.MAX_HOLD_BARS:
+        raise _contract_drift("S4 maximum-hold authority differs between H3 and H2")
+    if candidate.volatility_percentile is not None or (
+        candidate.volatility_percentile_provenance != "not_defined_for_s4"
+    ):
+        raise _contract_drift("S4 volatility-null provenance differs from merged H2")
+    return _adapted_or_drift(
+        lambda: S4PairSignalIntent(
+            pair=(candidate.symbol_a, candidate.symbol_b),
+            signal_ts=candidate.decision_ts,
+            side_a=candidate.side_a,
+            side_b=candidate.side_b,
+            weight_a=candidate.weight_a,
+            weight_b=candidate.weight_b,
+            beta_a=candidate.beta_a,
+            beta_b=candidate.beta_b,
+            mu=candidate.mu,
+            # H2's historical name `sigma` means the entry-frozen effective
+            # MAD spread scale.  It must never receive sigma_pair_risk.
+            sigma=candidate.effective_mad_scale,
+            # H2's historical name `z_entry` means the signed observed z at
+            # entry.  It must never receive the unsigned config threshold.
+            z_entry=candidate.observed_z,
+            gross_notional=candidate.gross_notional_usd,
+            entry_sl_distance=candidate.d_SL,
+            entry_tp_distance=candidate.d_TP,
+            config_id=candidate.config_id,
+            fold_id=fold_id,
+        ),
+        strategy="S4",
+    )
+
+
+def _plain(value: object) -> object:
+    if dataclasses.is_dataclass(value) and not isinstance(value, type):
+        return {
+            field.name: _plain(getattr(value, field.name))
+            for field in dataclasses.fields(value)
+        }
+    if type(value) is tuple:
+        return [_plain(item) for item in value]
+    if type(value) is list:
+        return [_plain(item) for item in value]
+    if type(value) is dict:
+        return {key: _plain(item) for key, item in value.items()}
+    if value is None or type(value) in (str, int, float, bool):
+        return value
+    raise TypeError(f"unsupported integration payload type {type(value).__name__}")
+
+
+@dataclass(frozen=True, slots=True)
+class H2IntegrationResult:
+    fold_id: str
+    s3_intents: tuple[S3SignalIntent, ...]
+    s4_intents: tuple[S4PairSignalIntent, ...]
+    s3_engine_result: S3EngineResult
+    s4_engine_result: S4EngineResult
+    s3_scenario_rows: tuple[S3ScenarioTradeRow, ...]
+    s4_scenario_rows: tuple[S4ScenarioTradeRow, ...]
+    s3_ledger_hash: str
+    s4_ledger_hash: str
+
+    def __post_init__(self) -> None:
+        _fold_id(self.fold_id)
+        if type(self.s3_intents) is not tuple or any(
+            type(item) is not S3SignalIntent for item in self.s3_intents
+        ):
+            raise TypeError("s3_intents must contain exact merged-H2 DTOs")
+        if type(self.s4_intents) is not tuple or any(
+            type(item) is not S4PairSignalIntent for item in self.s4_intents
+        ):
+            raise TypeError("s4_intents must contain exact merged-H2 DTOs")
+        if type(self.s3_engine_result) is not S3EngineResult:
+            raise TypeError("s3_engine_result must be exact merged-H2 result")
+        if type(self.s4_engine_result) is not S4EngineResult:
+            raise TypeError("s4_engine_result must be exact merged-H2 result")
+        if type(self.s3_scenario_rows) is not tuple or any(
+            type(item) is not S3ScenarioTradeRow for item in self.s3_scenario_rows
+        ):
+            raise TypeError("s3_scenario_rows must be exact merged-H2 rows")
+        if type(self.s4_scenario_rows) is not tuple or any(
+            type(item) is not S4ScenarioTradeRow for item in self.s4_scenario_rows
+        ):
+            raise TypeError("s4_scenario_rows must be exact merged-H2 rows")
+        for name in ("s3_ledger_hash", "s4_ledger_hash"):
+            value = getattr(self, name)
+            if type(value) is not str or len(value) != 64:
+                raise TypeError(f"{name} must be a SHA-256 hex string")
+
+    def to_payload(self) -> dict[str, object]:
+        return {
+            "schema_version": INTEGRATION_SCHEMA_VERSION,
+            "h2_merge_sha": H2_MERGE_SHA,
+            "fold_id": self.fold_id,
+            "path_scenario": PATH_SCENARIO_BASE13,
+            "funding_authority": "h2_scenario_default_no_lookup",
+            "s3_intents": _plain(self.s3_intents),
+            "s4_intents": _plain(self.s4_intents),
+            "s3_engine_result": _plain(self.s3_engine_result),
+            "s4_engine_result": _plain(self.s4_engine_result),
+            "s3_scenario_rows": _plain(self.s3_scenario_rows),
+            "s4_scenario_rows": _plain(self.s4_scenario_rows),
+            "s3_ledger_hash": self.s3_ledger_hash,
+            "s4_ledger_hash": self.s4_ledger_hash,
+        }
+
+    @property
+    def content_hash(self) -> str:
+        return canonical_sha256(self.to_payload())
+
+    def to_json_bytes(self) -> bytes:
+        payload = {**self.to_payload(), "content_hash": self.content_hash}
+        return (
+            json.dumps(
+                payload,
+                ensure_ascii=False,
+                sort_keys=True,
+                separators=(",", ":"),
+            )
+            + "\n"
+        ).encode("utf-8")
+
+
+def _require_h1_minutes(
+    value: object,
+) -> Mapping[str, Sequence[object]]:
+    if not isinstance(value, Mapping) or set(value) != set(SYMBOLS):
+        raise ValueError("h1_minutes must cover the exact frozen H1 universe")
+    for symbol in SYMBOLS:
+        if not isinstance(value[symbol], Sequence):
+            raise TypeError("each H1 minute history must be a sequence")
+    return value
+
+
+def run_h2_integration(
+    s3_output: S3GeneratorOutput,
+    s4_output: S4GeneratorOutput,
+    h1_minutes: Mapping[str, Sequence[object]],
+    feature_context: FeatureContext,
+    *,
+    fold_id: str,
+    corpus_end_ts: int,
+    horizon_end_ts: int | None = None,
+) -> H2IntegrationResult:
+    """Run accepted global H3 candidates through real H2 engines/scenario rows."""
+    verify_h2_contract()
+    if type(s3_output) is not S3GeneratorOutput:
+        raise TypeError("s3_output must be exact H3 S3GeneratorOutput")
+    if type(s4_output) is not S4GeneratorOutput:
+        raise TypeError("s4_output must be exact H3 S4GeneratorOutput")
+    if type(feature_context) is not FeatureContext:
+        raise TypeError("feature_context must be exact H3 FeatureContext")
+    fold_id = _fold_id(fold_id)
+    corpus_end_ts = _exact_int(corpus_end_ts, "corpus_end_ts")
+    if horizon_end_ts is not None:
+        horizon_end_ts = _exact_int(horizon_end_ts, "horizon_end_ts")
+    minutes = _require_h1_minutes(h1_minutes)
+
+    s3_intents = tuple(
+        adapt_s3_candidate(candidate, fold_id=fold_id)
+        for candidate in s3_output.accepted
+    )
+    s4_intents = tuple(
+        adapt_s4_candidate(candidate, fold_id=fold_id)
+        for candidate in s4_output.accepted
+    )
+
+    normalized_minutes = tuple(
+        row
+        for symbol in SYMBOLS
+        for row in from_h1_minute_bars(symbol, minutes[symbol])
+    )
+    minute_index = build_minute_index(normalized_minutes)
+
+    close_features = tuple(
+        row
+        for symbol in SYMBOLS
+        for row in from_h1_close_features(
+            symbol, feature_context.bars_for(symbol), feature_context.snapshots
+        )
+    )
+    close_feature_index = {(row.symbol, row.close_ts): row for row in close_features}
+    pair_closes = tuple(
+        row
+        for symbol in SYMBOLS
+        for row in from_h1_pair_leg_closes(symbol, feature_context.bars_for(symbol))
+    )
+    pair_close_index = {(row.symbol, row.close_ts): row for row in pair_closes}
+
+    s3_result = h2_s3_engine.run_s3_portfolio_stream(
+        s3_intents,
+        minute_index,
+        close_feature_index,
+        corpus_end_ts=corpus_end_ts,
+        horizon_end_ts=horizon_end_ts,
+    )
+    s4_result = h2_s4_engine.run_s4_pair_basket_stream(
+        s4_intents,
+        minute_index,
+        pair_close_index,
+        corpus_end_ts=corpus_end_ts,
+        horizon_end_ts=horizon_end_ts,
+    )
+
+    # Scenario/funding math remains H2-owned.  No lookup/callback is accepted
+    # by this seam; the explicit synthetic integration has no funding rows.
+    s3_rows = build_s3_scenario_ledger(s3_result.trades, PATH_SCENARIO_BASE13)
+    s4_rows = build_s4_scenario_ledger(s4_result.trades, PATH_SCENARIO_BASE13)
+    return H2IntegrationResult(
+        fold_id,
+        s3_intents,
+        s4_intents,
+        s3_result,
+        s4_result,
+        s3_rows,
+        s4_rows,
+        s3_ledger_hash(s3_rows),
+        s4_ledger_hash(s4_rows),
+    )
+
+
+__all__ = [
+    "ContractDriftError",
+    "H2IntegrationResult",
+    "H2_MERGE_SHA",
+    "INTEGRATION_SCHEMA_VERSION",
+    "adapt_s3_candidate",
+    "adapt_s4_candidate",
+    "run_h2_integration",
+    "verify_h2_contract",
+]

--- a/research/nautilus_scalping/rob974_h3_manifest.py
+++ b/research/nautilus_scalping/rob974_h3_manifest.py
@@ -1,0 +1,715 @@
+"""ROB-974 round-2 H3 immutable S3/S4 preregistration authority.
+
+This module owns one canonical 48-row roster and two distinct structured
+strategy-contract seals.  It is pure registration code: no data access,
+runtime state, parameter search, execution, clock, or environment authority.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import math
+from dataclasses import dataclass
+
+from research_contracts.canonical_hash import canonical_sha256
+
+RESEARCH_DOCUMENT_SHA256 = (
+    "2f535196cf0f0a03292e8f4c1806794ffbf8282ba7b5c3f564a930763577a009"
+)
+SYMBOLS: tuple[str, ...] = ("XRPUSDT", "DOGEUSDT", "SOLUSDT")
+PAIRS: tuple[str, ...] = ("XRP-DOGE", "XRP-SOL", "DOGE-SOL")
+DESIGN_TYPES = ("baseline", "OFAT", "interaction")
+
+S3_HYPOTHESIS_UTF8 = (
+    "사전등록 가설: 암호자산의 정보·포지션 조정이 여러 시간에 걸쳐 반영되는 구간에서는 24~80h 방향성이 형성될 수 있다. "
+    "그러나 이미 고가를 돌파한 시점에 추격하면 역선택과 false breakout 비용을 부담한다. 따라서 ①공통시장과 개별 심볼의 장주기 방향성이 일치하고 "
+    "②가격이 4~8h 동안 12h VWAP 아래/위로 제한된 눌림을 보인 뒤 ③기존 고가·저가를 돌파하기 전에 VWAP을 재회복하며 ④최근 정상적인 일간 range가 TP를 감당할 때만 기존 방향으로 진입하면 "
+    "단기 돌파보다 높은 gross 이동폭과 낮은 timeout을 얻을 수 있다는 가설이다.\n"
+).encode()
+S4_HYPOTHESIS_UTF8 = (
+    "사전등록 가설: XRP/DOGE/SOL에는 공통 암호자산 요인과 심볼별 일시적 자금흐름이 동시에 존재할 수 있다. 공통 요인을 베타중립 long/short로 제거한 뒤에도 상대가격 spread가 정상 범위에서 반복적으로 이탈·복귀하고, "
+    "그 반감기가 8~48h 범위에서 안정적이라면 부분 수렴 108bp 이상을 거래비용 후 포착할 수 있다는 가설이다.\n"
+).encode()
+
+S3_HYPOTHESIS_SHA256 = (
+    "f8893d558067e07f6248beb66fbc3f917af558634226484c6506c489e2752e01"
+)
+S4_HYPOTHESIS_SHA256 = (
+    "c5152f9d207682a569c4df197e4e276cdf907d8eb6a2f68d3d9725b9bf229d28"
+)
+
+
+def _exact_str(value: object, name: str) -> str:
+    if type(value) is not str:
+        raise TypeError(f"{name} must be built-in str")
+    return value
+
+
+def _exact_int(value: object, name: str) -> int:
+    if type(value) is not int:
+        raise TypeError(f"{name} must be built-in int")
+    return value
+
+
+def _exact_float(value: object, name: str) -> float:
+    if type(value) is not float:
+        raise TypeError(f"{name} must be built-in float")
+    if not math.isfinite(value):
+        raise ValueError(f"{name} must be finite")
+    return value
+
+
+def _exact_bytes(value: object, name: str) -> bytes:
+    if type(value) is not bytes:
+        raise TypeError(f"{name} must be built-in bytes")
+    return value
+
+
+def _sha256(value: object, name: str) -> str:
+    text = _exact_str(value, name)
+    if len(text) != 64 or any(char not in "0123456789abcdef" for char in text):
+        raise ValueError(f"{name} must be lowercase SHA-256")
+    return text
+
+
+def _validate_common_config_fields(
+    config_id: object,
+    k_sl: object,
+    r_tp: object,
+    design_type: object,
+    authority_label: object,
+    hypothesis_utf8: object,
+) -> None:
+    _exact_str(config_id, "config_id")
+    _exact_float(k_sl, "k_SL")
+    _exact_float(r_tp, "R_TP")
+    design = _exact_str(design_type, "design_type")
+    if design not in DESIGN_TYPES:
+        raise ValueError("design_type is outside the closed set")
+    if not _exact_str(authority_label, "authority_label"):
+        raise ValueError("authority_label must not be empty")
+    _exact_bytes(hypothesis_utf8, "hypothesis_utf8")
+
+
+@dataclass(frozen=True, slots=True)
+class S3Config:
+    config_id: str
+    L: int
+    q_min: float
+    ER_min: float
+    k_SL: float
+    R_TP: float
+    design_type: str
+    authority_label: str
+    hypothesis_utf8: bytes
+
+    def __post_init__(self) -> None:
+        _validate_common_config_fields(
+            self.config_id,
+            self.k_SL,
+            self.R_TP,
+            self.design_type,
+            self.authority_label,
+            self.hypothesis_utf8,
+        )
+        _exact_int(self.L, "L")
+        _exact_float(self.q_min, "q_min")
+        _exact_float(self.ER_min, "ER_min")
+
+
+@dataclass(frozen=True, slots=True)
+class S4Config:
+    config_id: str
+    W: int
+    z_entry: float
+    d_min_bp: int
+    k_SL: float
+    R_TP: float
+    design_type: str
+    authority_label: str
+    hypothesis_utf8: bytes
+
+    def __post_init__(self) -> None:
+        _validate_common_config_fields(
+            self.config_id,
+            self.k_SL,
+            self.R_TP,
+            self.design_type,
+            self.authority_label,
+            self.hypothesis_utf8,
+        )
+        _exact_int(self.W, "W")
+        _exact_float(self.z_entry, "z_entry")
+        _exact_int(self.d_min_bp, "d_min_bp")
+
+
+S3_DOMAINS = {
+    "L": (8, 10, 12, 16, 20),
+    "q_min": (0.20, 0.30, 0.35, 0.50, 0.65),
+    "ER_min": (0.25, 0.30, 0.35, 0.40, 0.45),
+    "k_SL": (1.00, 1.10, 1.25, 1.40, 1.60),
+    "R_TP": (1.35, 1.45, 1.60, 1.80, 2.00),
+}
+S4_DOMAINS = {
+    "W": (120, 150, 180, 240, 300),
+    "z_entry": (1.40, 1.60, 1.80, 2.00, 2.20),
+    "d_min_bp": (140, 160, 180, 220, 260),
+    "k_SL": (1.00, 1.10, 1.25, 1.40, 1.60),
+    "R_TP": (1.35, 1.50, 1.65, 1.80, 2.00),
+}
+
+
+# The sole production roster source. Strategy-specific views below are slices,
+# never independently maintained copies.
+FROZEN_H3_ROSTER: tuple[S3Config | S4Config, ...] = (
+    S3Config(
+        "S3-00", 12, 0.35, 0.35, 1.25, 1.60, "baseline", "baseline", S3_HYPOTHESIS_UTF8
+    ),
+    S3Config(
+        "S3-01",
+        8,
+        0.35,
+        0.35,
+        1.25,
+        1.60,
+        "OFAT",
+        "OFAT: 짧은 trend",
+        S3_HYPOTHESIS_UTF8,
+    ),
+    S3Config("S3-02", 10, 0.35, 0.35, 1.25, 1.60, "OFAT", "OFAT", S3_HYPOTHESIS_UTF8),
+    S3Config("S3-03", 16, 0.35, 0.35, 1.25, 1.60, "OFAT", "OFAT", S3_HYPOTHESIS_UTF8),
+    S3Config(
+        "S3-04",
+        20,
+        0.35,
+        0.35,
+        1.25,
+        1.60,
+        "OFAT",
+        "OFAT: 긴 trend",
+        S3_HYPOTHESIS_UTF8,
+    ),
+    S3Config(
+        "S3-05",
+        12,
+        0.20,
+        0.35,
+        1.25,
+        1.60,
+        "OFAT",
+        "OFAT: 얕은 pullback",
+        S3_HYPOTHESIS_UTF8,
+    ),
+    S3Config("S3-06", 12, 0.30, 0.35, 1.25, 1.60, "OFAT", "OFAT", S3_HYPOTHESIS_UTF8),
+    S3Config("S3-07", 12, 0.50, 0.35, 1.25, 1.60, "OFAT", "OFAT", S3_HYPOTHESIS_UTF8),
+    S3Config(
+        "S3-08",
+        12,
+        0.65,
+        0.35,
+        1.25,
+        1.60,
+        "OFAT",
+        "OFAT: 깊은 pullback",
+        S3_HYPOTHESIS_UTF8,
+    ),
+    S3Config(
+        "S3-09",
+        12,
+        0.35,
+        0.25,
+        1.25,
+        1.60,
+        "OFAT",
+        "OFAT: 낮은 효율",
+        S3_HYPOTHESIS_UTF8,
+    ),
+    S3Config("S3-10", 12, 0.35, 0.30, 1.25, 1.60, "OFAT", "OFAT", S3_HYPOTHESIS_UTF8),
+    S3Config("S3-11", 12, 0.35, 0.40, 1.25, 1.60, "OFAT", "OFAT", S3_HYPOTHESIS_UTF8),
+    S3Config(
+        "S3-12",
+        12,
+        0.35,
+        0.45,
+        1.25,
+        1.60,
+        "OFAT",
+        "OFAT: 높은 효율",
+        S3_HYPOTHESIS_UTF8,
+    ),
+    S3Config(
+        "S3-13", 12, 0.35, 0.35, 1.00, 1.60, "OFAT", "OFAT: 좁은 SL", S3_HYPOTHESIS_UTF8
+    ),
+    S3Config("S3-14", 12, 0.35, 0.35, 1.10, 1.60, "OFAT", "OFAT", S3_HYPOTHESIS_UTF8),
+    S3Config("S3-15", 12, 0.35, 0.35, 1.40, 1.60, "OFAT", "OFAT", S3_HYPOTHESIS_UTF8),
+    S3Config(
+        "S3-16", 12, 0.35, 0.35, 1.60, 1.60, "OFAT", "OFAT: 넓은 SL", S3_HYPOTHESIS_UTF8
+    ),
+    S3Config(
+        "S3-17", 12, 0.35, 0.35, 1.25, 1.35, "OFAT", "OFAT: 낮은 RR", S3_HYPOTHESIS_UTF8
+    ),
+    S3Config("S3-18", 12, 0.35, 0.35, 1.25, 1.45, "OFAT", "OFAT", S3_HYPOTHESIS_UTF8),
+    S3Config("S3-19", 12, 0.35, 0.35, 1.25, 1.80, "OFAT", "OFAT", S3_HYPOTHESIS_UTF8),
+    S3Config(
+        "S3-20", 12, 0.35, 0.35, 1.25, 2.00, "OFAT", "OFAT: 높은 RR", S3_HYPOTHESIS_UTF8
+    ),
+    S3Config(
+        "S3-21",
+        10,
+        0.30,
+        0.30,
+        1.25,
+        1.60,
+        "interaction",
+        "interaction: 빠른 trend + 얕은 pullback",
+        S3_HYPOTHESIS_UTF8,
+    ),
+    S3Config(
+        "S3-22",
+        16,
+        0.50,
+        0.40,
+        1.25,
+        1.60,
+        "interaction",
+        "interaction: 느린 trend + 깊은 pullback",
+        S3_HYPOTHESIS_UTF8,
+    ),
+    S3Config(
+        "S3-23",
+        12,
+        0.50,
+        0.35,
+        1.40,
+        1.80,
+        "interaction",
+        "interaction: 깊은 pullback + 넓은 risk/return",
+        S3_HYPOTHESIS_UTF8,
+    ),
+    S4Config(
+        "S4-00", 180, 1.80, 180, 1.25, 1.50, "baseline", "baseline", S4_HYPOTHESIS_UTF8
+    ),
+    S4Config(
+        "S4-01",
+        120,
+        1.80,
+        180,
+        1.25,
+        1.50,
+        "OFAT",
+        "OFAT: 짧은 beta window",
+        S4_HYPOTHESIS_UTF8,
+    ),
+    S4Config("S4-02", 150, 1.80, 180, 1.25, 1.50, "OFAT", "OFAT", S4_HYPOTHESIS_UTF8),
+    S4Config("S4-03", 240, 1.80, 180, 1.25, 1.50, "OFAT", "OFAT", S4_HYPOTHESIS_UTF8),
+    S4Config(
+        "S4-04",
+        300,
+        1.80,
+        180,
+        1.25,
+        1.50,
+        "OFAT",
+        "OFAT: 긴 beta window",
+        S4_HYPOTHESIS_UTF8,
+    ),
+    S4Config(
+        "S4-05", 180, 1.40, 180, 1.25, 1.50, "OFAT", "OFAT: 낮은 z", S4_HYPOTHESIS_UTF8
+    ),
+    S4Config("S4-06", 180, 1.60, 180, 1.25, 1.50, "OFAT", "OFAT", S4_HYPOTHESIS_UTF8),
+    S4Config("S4-07", 180, 2.00, 180, 1.25, 1.50, "OFAT", "OFAT", S4_HYPOTHESIS_UTF8),
+    S4Config(
+        "S4-08", 180, 2.20, 180, 1.25, 1.50, "OFAT", "OFAT: 높은 z", S4_HYPOTHESIS_UTF8
+    ),
+    S4Config(
+        "S4-09",
+        180,
+        1.80,
+        140,
+        1.25,
+        1.50,
+        "OFAT",
+        "OFAT: 작은 절대거리",
+        S4_HYPOTHESIS_UTF8,
+    ),
+    S4Config("S4-10", 180, 1.80, 160, 1.25, 1.50, "OFAT", "OFAT", S4_HYPOTHESIS_UTF8),
+    S4Config("S4-11", 180, 1.80, 220, 1.25, 1.50, "OFAT", "OFAT", S4_HYPOTHESIS_UTF8),
+    S4Config(
+        "S4-12",
+        180,
+        1.80,
+        260,
+        1.25,
+        1.50,
+        "OFAT",
+        "OFAT: 큰 절대거리",
+        S4_HYPOTHESIS_UTF8,
+    ),
+    S4Config(
+        "S4-13", 180, 1.80, 180, 1.00, 1.50, "OFAT", "OFAT: 좁은 SL", S4_HYPOTHESIS_UTF8
+    ),
+    S4Config("S4-14", 180, 1.80, 180, 1.10, 1.50, "OFAT", "OFAT", S4_HYPOTHESIS_UTF8),
+    S4Config("S4-15", 180, 1.80, 180, 1.40, 1.50, "OFAT", "OFAT", S4_HYPOTHESIS_UTF8),
+    S4Config(
+        "S4-16", 180, 1.80, 180, 1.60, 1.50, "OFAT", "OFAT: 넓은 SL", S4_HYPOTHESIS_UTF8
+    ),
+    S4Config(
+        "S4-17", 180, 1.80, 180, 1.25, 1.35, "OFAT", "OFAT: 낮은 RR", S4_HYPOTHESIS_UTF8
+    ),
+    S4Config("S4-18", 180, 1.80, 180, 1.25, 1.65, "OFAT", "OFAT", S4_HYPOTHESIS_UTF8),
+    S4Config("S4-19", 180, 1.80, 180, 1.25, 1.80, "OFAT", "OFAT", S4_HYPOTHESIS_UTF8),
+    S4Config(
+        "S4-20", 180, 1.80, 180, 1.25, 2.00, "OFAT", "OFAT: 높은 RR", S4_HYPOTHESIS_UTF8
+    ),
+    S4Config(
+        "S4-21",
+        150,
+        1.60,
+        160,
+        1.25,
+        1.50,
+        "interaction",
+        "interaction: 빠른 적응 + 낮은 entry",
+        S4_HYPOTHESIS_UTF8,
+    ),
+    S4Config(
+        "S4-22",
+        240,
+        2.00,
+        220,
+        1.25,
+        1.50,
+        "interaction",
+        "interaction: 안정성 우선 strict",
+        S4_HYPOTHESIS_UTF8,
+    ),
+    S4Config(
+        "S4-23",
+        180,
+        2.00,
+        220,
+        1.40,
+        1.80,
+        "interaction",
+        "interaction: 큰 이탈 + tail 완충",
+        S4_HYPOTHESIS_UTF8,
+    ),
+)
+FROZEN_S3_CONFIGS: tuple[S3Config, ...] = FROZEN_H3_ROSTER[:24]  # type: ignore[assignment]
+FROZEN_S4_CONFIGS: tuple[S4Config, ...] = FROZEN_H3_ROSTER[24:]  # type: ignore[assignment]
+
+
+def _validate_hypothesis(raw: bytes, size: int, digest: str) -> None:
+    if len(raw) != size or hashlib.sha256(raw).hexdigest() != digest:
+        raise ValueError("registered hypothesis bytes/hash mismatch")
+    if not raw.endswith(b"\n") or raw.endswith(b"\n\n") or b"\r" in raw:
+        raise ValueError("registered hypothesis must carry exactly one terminal LF")
+    if any(line.endswith(b" ") for line in raw.splitlines()):
+        raise ValueError("registered hypothesis has trailing whitespace")
+
+
+def validate_manifest(rows: tuple[S3Config | S4Config, ...]) -> None:
+    if type(rows) is not tuple:
+        raise TypeError("manifest must be built-in tuple")
+    if len(rows) != 48:
+        raise ValueError("H3 manifest must contain exactly 48 rows")
+    expected_ids = tuple(
+        [f"S3-{index:02d}" for index in range(24)]
+        + [f"S4-{index:02d}" for index in range(24)]
+    )
+    if tuple(row.config_id for row in rows) != expected_ids:
+        raise ValueError("missing, duplicate, reordered, or cross-strategy config id")
+    if any(type(row) is not S3Config for row in rows[:24]) or any(
+        type(row) is not S4Config for row in rows[24:]
+    ):
+        raise TypeError("strategy rows must use their exact built-in DTO class")
+    for row in rows[:24]:
+        for name, domain in S3_DOMAINS.items():
+            if getattr(row, name) not in domain:
+                raise ValueError(f"{row.config_id} {name} outside registered domain")
+        if row.hypothesis_utf8 != S3_HYPOTHESIS_UTF8:
+            raise ValueError("S3 hypothesis mutation")
+    for row in rows[24:]:
+        for name, domain in S4_DOMAINS.items():
+            if getattr(row, name) not in domain:
+                raise ValueError(f"{row.config_id} {name} outside registered domain")
+        if row.hypothesis_utf8 != S4_HYPOTHESIS_UTF8:
+            raise ValueError("S4 hypothesis mutation")
+    if rows != FROZEN_H3_ROSTER:
+        raise ValueError("manifest row does not exactly match preregistration")
+
+
+_validate_hypothesis(S3_HYPOTHESIS_UTF8, 699, S3_HYPOTHESIS_SHA256)
+_validate_hypothesis(S4_HYPOTHESIS_UTF8, 423, S4_HYPOTHESIS_SHA256)
+validate_manifest(FROZEN_H3_ROSTER)
+_BY_ID = {row.config_id: row for row in FROZEN_H3_ROSTER}
+
+
+def get_config(config_id: str) -> S3Config | S4Config:
+    _exact_str(config_id, "config_id")
+    return _BY_ID[config_id]
+
+
+def assert_registered_config(config: S3Config | S4Config) -> None:
+    if type(config) not in (S3Config, S4Config):
+        raise TypeError("config must be an exact H3 config DTO")
+    canonical = _BY_ID.get(config.config_id)
+    if canonical is None or config != canonical:
+        raise ValueError("config does not exactly match its registered row")
+
+
+_S3_MECHANISM = (
+    "Donchian high/low is not calculated.",
+    "A bar that breaks the prior high/low is excluded from entry.",
+    "No single-5m shock z-score or shock-origin reversion is used.",
+    "The three-symbol 24h common regime and breadth determine direction first.",
+    "Expected holding time is 8-48h.",
+)
+_S4_MECHANISM = (
+    "No individual-symbol 5m shock magnitude is used.",
+    "There is no immediate contrarian entry after a shock.",
+    "Long/short legs neutralize common-market beta instead of predicting direction.",
+    "Being outside the spread threshold alone never permits entry.",
+    "Historical half-life, correlation, beta stability, and convergence onset are required.",
+    "TP and SL apply to gross basket return, never individual legs.",
+)
+
+
+def _config_payload(row: S3Config | S4Config) -> dict[str, object]:
+    common = {
+        "config_id": row.config_id,
+        "k_SL": row.k_SL,
+        "R_TP": row.R_TP,
+        "design_type": row.design_type,
+        "authority_label": row.authority_label,
+        "hypothesis_utf8": row.hypothesis_utf8.decode("utf-8"),
+    }
+    if type(row) is S3Config:
+        return {"L": row.L, "q_min": row.q_min, "ER_min": row.ER_min, **common}
+    return {
+        "W": row.W,
+        "z_entry": row.z_entry,
+        "d_min_bp": row.d_min_bp,
+        **common,
+    }
+
+
+def strategy_contract_payload(strategy: str) -> dict[str, object]:
+    """Return a fresh plain payload for the requested frozen strategy seal."""
+    _exact_str(strategy, "strategy")
+    if strategy == "S3":
+        return {
+            "contract_key": "rob974.s3.rpt-4h",
+            "contract_version": "1",
+            "source_research_sha256": RESEARCH_DOCUMENT_SHA256,
+            "strategy": "S3",
+            "name": "RPT-4H Regime-Aligned Pullback Trend",
+            "posture": "historical_champion",
+            "symbols": list(SYMBOLS),
+            "formulas": {
+                "R": "ln(C_t/C_(t-L)); L deltas and L+1 closes",
+                "ER": "abs(C_t-C_(t-L))/fsum(abs(C_j-C_(j-1)),j=t-L+1..t)",
+                "S": "R/max(A_t*sqrt(L),1e-6)",
+                "Qplus": "-min((C_j-VWAP12_j)/ATR20_j,j in {t-2,t-1})",
+                "Qminus": "max((C_j-VWAP12_j)/ATR20_j,j in {t-2,t-1})",
+                "d_SL": "clip(k_SL*A_t,0.008,0.020)",
+                "d_TP": "max(0.0068,R_TP*d_SL)",
+            },
+            "fixed_constants": {
+                "bar_hours": 4,
+                "strength_threshold": 1.25,
+                "regime_abs_fraction": 0.0075,
+                "breadth_min": 2,
+                "q_max": 1.25,
+                "volatility_percentile_min": 20.0,
+                "volatility_percentile_max": 90.0,
+                "range24_tp_fraction": 0.60,
+                "timeout_4h_bars": 12,
+                "all_config_tp_floor_fraction": 0.0108,
+                "baseline_tp_floor_fraction": 0.0128,
+            },
+            "parameter_domains": {
+                key: list(value) for key, value in S3_DOMAINS.items()
+            },
+            "diagnostic_bins": {
+                "abs_S": ["[1.25,1.75)", "[1.75,2.50)", "[2.50,inf)"],
+                "pullback_Q": ["[q_min,0.50)", "[0.50,0.85)", "[0.85,1.25]"],
+                "abs_M": ["[0.0075,0.015)", "[0.015,0.03)", "[0.03,inf)"],
+                "volatility_percentile": ["[20,40)", "[40,60)", "[60,75)", "[75,90]"],
+                "direction": ["Long", "Short"],
+                "symbol": ["XRP", "DOGE", "SOL"],
+                "exit": ["TP", "SL", "THESIS_EXIT", "TIMEOUT"],
+            },
+            "mechanism_statements": list(_S3_MECHANISM),
+            "hypothesis_utf8": S3_HYPOTHESIS_UTF8.decode("utf-8"),
+            "hypothesis_sha256": S3_HYPOTHESIS_SHA256,
+            "authority_labels": [row.authority_label for row in FROZEN_S3_CONFIGS],
+            "configs": [_config_payload(row) for row in FROZEN_S3_CONFIGS],
+        }
+    if strategy == "S4":
+        return {
+            "contract_key": "rob974.s4.brc-4h",
+            "contract_version": "1",
+            "source_research_sha256": RESEARCH_DOCUMENT_SHA256,
+            "strategy": "S4",
+            "name": "BRC-4H Beta-Neutral Residual Convergence",
+            "posture": "historical_research_only",
+            "symbols": list(SYMBOLS),
+            "pairs": list(PAIRS),
+            "formulas": {
+                "beta": "clip(Cov_W(r_i,m)/Var_W(m),0.25,3.00)",
+                "weights": "w_a=beta_b/(beta_a+beta_b);w_b=beta_a/(beta_a+beta_b)",
+                "spread": "s_j=w_a*ln(C_a,j)-w_b*ln(C_b,j); current weights over W including t",
+                "z": "(s_t-median_W(s))/max(1.4826*MAD_W(s),1e-6)",
+                "D": "abs(s_t-median_W(s))",
+                "phi": "fsum(x_(j-1)*x_j)/fsum(x_(j-1)^2), x=s-median(s)",
+                "half_life": "ln(0.5)/ln(phi)",
+                "sigma_pair": "population_stddev_W(w_a*r_a-w_b*r_b)",
+                "d_SL": "clip(k_SL*sigma_pair,0.008,0.016)",
+                "d_TP": "max(0.0068,R_TP*d_SL)",
+                "gross_notional": "G_min=max(6/w_a,6/w_b);G_max=min(10/w_a,10/w_b);G=G_min",
+            },
+            "fixed_constants": {
+                "bar_hours": 4,
+                "rho_min": 0.60,
+                "beta_clip_min": 0.25,
+                "beta_clip_max": 3.0,
+                "half_life_min_4h_bars": 2.0,
+                "half_life_max_4h_bars": 12.0,
+                "beta_stability_max": 0.20,
+                "convergence_fraction": 0.10,
+                "current_abs_z_max_prior_fraction": 0.90,
+                "distance_tp_multiple": 1.25,
+                "mean_exit_abs_z": 0.25,
+                "stall_after_4h_bars": 2,
+                "stall_min_convergence_fraction": 0.15,
+                "timeout_4h_bars": 9,
+                "all_config_tp_floor_fraction": 0.0108,
+                "baseline_tp_floor_fraction": 0.0120,
+            },
+            "parameter_domains": {
+                key: list(value) for key, value in S4_DOMAINS.items()
+            },
+            "diagnostic_bins": {
+                "abs_z": ["[z_entry,2.2)", "[2.2,2.8)", "[2.8,inf)"],
+                "D_bps": ["[140,200)", "[200,300)", "[300,inf)"],
+                "rho": ["[0.60,0.70)", "[0.70,0.80)", "[0.80,1.00]"],
+                "half_life_hours": ["[8,16)", "[16,32)", "[32,48]"],
+                "M_24h": [
+                    "[-inf,-0.03)",
+                    "[-0.03,-0.01)",
+                    "[-0.01,0.01]",
+                    "(0.01,0.03]",
+                    "(0.03,inf)",
+                ],
+                "pair": list(PAIRS),
+                "exit": [
+                    "TP",
+                    "SL",
+                    "MEAN_EXIT",
+                    "STALL_EXIT",
+                    "TIMEOUT",
+                    "PAIR_EXEC_FAIL",
+                ],
+            },
+            "mechanism_statements": list(_S4_MECHANISM),
+            "hypothesis_utf8": S4_HYPOTHESIS_UTF8.decode("utf-8"),
+            "hypothesis_sha256": S4_HYPOTHESIS_SHA256,
+            "authority_labels": [row.authority_label for row in FROZEN_S4_CONFIGS],
+            "configs": [_config_payload(row) for row in FROZEN_S4_CONFIGS],
+        }
+    raise ValueError("strategy must be S3 or S4")
+
+
+def hash_contract_payload(payload: dict[str, object]) -> str:
+    if type(payload) is not dict:
+        raise TypeError("contract payload must be built-in dict")
+    return canonical_sha256(payload)
+
+
+@dataclass(frozen=True, slots=True)
+class StrategyContract:
+    key: str
+    version: str
+    source_research_sha256: str
+    contract_hash: str
+
+    def __post_init__(self) -> None:
+        if not _exact_str(self.key, "key") or not _exact_str(self.version, "version"):
+            raise ValueError("contract key/version must not be empty")
+        _sha256(self.source_research_sha256, "source_research_sha256")
+        _sha256(self.contract_hash, "contract_hash")
+
+
+S3_STRATEGY_CONTRACT = StrategyContract(
+    "rob974.s3.rpt-4h",
+    "1",
+    RESEARCH_DOCUMENT_SHA256,
+    hash_contract_payload(strategy_contract_payload("S3")),
+)
+S4_STRATEGY_CONTRACT = StrategyContract(
+    "rob974.s4.brc-4h",
+    "1",
+    RESEARCH_DOCUMENT_SHA256,
+    hash_contract_payload(strategy_contract_payload("S4")),
+)
+
+
+def validate_contract_seals(s3: StrategyContract, s4: StrategyContract) -> None:
+    if type(s3) is not StrategyContract or type(s4) is not StrategyContract:
+        raise TypeError("contract seals must be exact StrategyContract values")
+    if (
+        s3.source_research_sha256 != RESEARCH_DOCUMENT_SHA256
+        or s4.source_research_sha256 != RESEARCH_DOCUMENT_SHA256
+    ):
+        raise ValueError("strategy contracts must cite the one research document SHA")
+    if (
+        s3.contract_hash in (RESEARCH_DOCUMENT_SHA256, s4.contract_hash)
+        or s4.contract_hash == RESEARCH_DOCUMENT_SHA256
+    ):
+        raise ValueError("source/strategy contract hash collision")
+    expected = (
+        (
+            "rob974.s3.rpt-4h",
+            "1",
+            hash_contract_payload(strategy_contract_payload("S3")),
+        ),
+        (
+            "rob974.s4.brc-4h",
+            "1",
+            hash_contract_payload(strategy_contract_payload("S4")),
+        ),
+    )
+    if (s3.key, s3.version, s3.contract_hash) != expected[0] or (
+        s4.key,
+        s4.version,
+        s4.contract_hash,
+    ) != expected[1]:
+        raise ValueError("strategy contract seal drift")
+
+
+validate_contract_seals(S3_STRATEGY_CONTRACT, S4_STRATEGY_CONTRACT)
+
+__all__ = [
+    "FROZEN_H3_ROSTER",
+    "FROZEN_S3_CONFIGS",
+    "FROZEN_S4_CONFIGS",
+    "PAIRS",
+    "RESEARCH_DOCUMENT_SHA256",
+    "S3Config",
+    "S3_HYPOTHESIS_SHA256",
+    "S3_HYPOTHESIS_UTF8",
+    "S3_STRATEGY_CONTRACT",
+    "S4Config",
+    "S4_HYPOTHESIS_SHA256",
+    "S4_HYPOTHESIS_UTF8",
+    "S4_STRATEGY_CONTRACT",
+    "SYMBOLS",
+    "StrategyContract",
+    "assert_registered_config",
+    "get_config",
+    "hash_contract_payload",
+    "strategy_contract_payload",
+    "validate_contract_seals",
+    "validate_manifest",
+]

--- a/research/nautilus_scalping/rob974_h3_manifest.py
+++ b/research/nautilus_scalping/rob974_h3_manifest.py
@@ -19,6 +19,43 @@ RESEARCH_DOCUMENT_SHA256 = (
 SYMBOLS: tuple[str, ...] = ("XRPUSDT", "DOGEUSDT", "SOLUSDT")
 PAIRS: tuple[str, ...] = ("XRP-DOGE", "XRP-SOL", "DOGE-SOL")
 DESIGN_TYPES = ("baseline", "OFAT", "interaction")
+S3_NO_SIGNAL_TAXONOMY: tuple[str, ...] = (
+    "missing_required_context",
+    "market_regime",
+    "market_breadth",
+    "trend_strength",
+    "efficiency",
+    "pullback_depth",
+    "vwap_reclaim",
+    "momentum",
+    "prior_l_non_breakout",
+    "volatility_percentile",
+    "range_tp_capacity",
+)
+S3_GENERATOR_REJECTION_TAXONOMY: tuple[str, ...] = (
+    "simultaneous_candidate_arbitration_loser",
+)
+S4_NO_SIGNAL_TAXONOMY: tuple[str, ...] = (
+    "missing_required_context",
+    "degenerate_beta_market_variance",
+    "degenerate_rho_variance",
+    "degenerate_phi_denominator",
+    "phi_not_in_open_unit_interval",
+    "nonfinite_required_input",
+    "convergence_sign",
+    "prior_z_entry",
+    "current_z_entry",
+    "convergence_fraction",
+    "rho",
+    "half_life",
+    "beta_stability",
+    "absolute_distance",
+    "distance_to_tp",
+    "historical_notional_feasibility",
+)
+S4_GENERATOR_REJECTION_TAXONOMY: tuple[str, ...] = (
+    "simultaneous_pair_arbitration_loser",
+)
 
 S3_HYPOTHESIS_UTF8 = (
     "사전등록 가설: 암호자산의 정보·포지션 조정이 여러 시간에 걸쳐 반영되는 구간에서는 24~80h 방향성이 형성될 수 있다. "
@@ -541,6 +578,8 @@ def strategy_contract_payload(strategy: str) -> dict[str, object]:
                 "exit": ["TP", "SL", "THESIS_EXIT", "TIMEOUT"],
             },
             "mechanism_statements": list(_S3_MECHANISM),
+            "no_signal_reasons": list(S3_NO_SIGNAL_TAXONOMY),
+            "generator_rejection_reasons": list(S3_GENERATOR_REJECTION_TAXONOMY),
             "hypothesis_utf8": S3_HYPOTHESIS_UTF8.decode("utf-8"),
             "hypothesis_sha256": S3_HYPOTHESIS_SHA256,
             "authority_labels": [row.authority_label for row in FROZEN_S3_CONFIGS],
@@ -613,6 +652,8 @@ def strategy_contract_payload(strategy: str) -> dict[str, object]:
                 ],
             },
             "mechanism_statements": list(_S4_MECHANISM),
+            "no_signal_reasons": list(S4_NO_SIGNAL_TAXONOMY),
+            "generator_rejection_reasons": list(S4_GENERATOR_REJECTION_TAXONOMY),
             "hypothesis_utf8": S4_HYPOTHESIS_UTF8.decode("utf-8"),
             "hypothesis_sha256": S4_HYPOTHESIS_SHA256,
             "authority_labels": [row.authority_label for row in FROZEN_S4_CONFIGS],
@@ -697,12 +738,16 @@ __all__ = [
     "PAIRS",
     "RESEARCH_DOCUMENT_SHA256",
     "S3Config",
+    "S3_GENERATOR_REJECTION_TAXONOMY",
     "S3_HYPOTHESIS_SHA256",
     "S3_HYPOTHESIS_UTF8",
+    "S3_NO_SIGNAL_TAXONOMY",
     "S3_STRATEGY_CONTRACT",
     "S4Config",
+    "S4_GENERATOR_REJECTION_TAXONOMY",
     "S4_HYPOTHESIS_SHA256",
     "S4_HYPOTHESIS_UTF8",
+    "S4_NO_SIGNAL_TAXONOMY",
     "S4_STRATEGY_CONTRACT",
     "SYMBOLS",
     "StrategyContract",

--- a/research/nautilus_scalping/rob974_h3_s3.py
+++ b/research/nautilus_scalping/rob974_h3_s3.py
@@ -20,6 +20,8 @@ from rob974_features import (
     SymbolFeature,
 )
 from rob974_h3_manifest import (
+    S3_GENERATOR_REJECTION_TAXONOMY,
+    S3_NO_SIGNAL_TAXONOMY,
     SYMBOLS,
     S3Config,
     assert_registered_config,
@@ -429,22 +431,8 @@ def s3_formula_grid(
     )
 
 
-S3_NO_SIGNAL_REASONS: tuple[str, ...] = (
-    "missing_required_context",
-    "market_regime",
-    "market_breadth",
-    "trend_strength",
-    "efficiency",
-    "pullback_depth",
-    "vwap_reclaim",
-    "momentum",
-    "prior_l_non_breakout",
-    "volatility_percentile",
-    "range_tp_capacity",
-)
-S3_GENERATOR_REJECTION_REASONS: tuple[str, ...] = (
-    "simultaneous_candidate_arbitration_loser",
-)
+S3_NO_SIGNAL_REASONS: tuple[str, ...] = S3_NO_SIGNAL_TAXONOMY
+S3_GENERATOR_REJECTION_REASONS: tuple[str, ...] = S3_GENERATOR_REJECTION_TAXONOMY
 
 
 def s3_risk_distances(config: S3Config, a_value: float) -> tuple[float, float]:
@@ -756,11 +744,20 @@ class S3UnitDecision:
 
 @dataclass(frozen=True, slots=True)
 class S3GeneratorOutput:
+    strategy: str
+    config_id: str
     decisions: tuple[S3UnitDecision, ...]
     accepted: tuple[S3Candidate, ...]
     rejected: tuple[S3RejectedCandidate, ...]
 
     def __post_init__(self) -> None:
+        if _str(self.strategy, "strategy") != "S3":
+            raise ValueError("S3 generator output strategy must be S3")
+        _str(self.config_id, "config_id")
+        if any(item.config_id != self.config_id for item in self.accepted) or any(
+            item.candidate.config_id != self.config_id for item in self.rejected
+        ):
+            raise ValueError("S3 generator output config mismatch")
         if type(self.decisions) is not tuple or type(self.accepted) is not tuple:
             raise TypeError("generator output containers must be tuples")
         if type(self.rejected) is not tuple:
@@ -850,7 +847,9 @@ def generate_s3_global(
                         loser.reason,
                     )
                 )
-    return S3GeneratorOutput(tuple(decisions), tuple(accepted), tuple(rejected))
+    return S3GeneratorOutput(
+        "S3", config.config_id, tuple(decisions), tuple(accepted), tuple(rejected)
+    )
 
 
 __all__ = [

--- a/research/nautilus_scalping/rob974_h3_s3.py
+++ b/research/nautilus_scalping/rob974_h3_s3.py
@@ -12,7 +12,13 @@ import math
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 
-from rob974_features import FOUR_HOUR_MS, Bar4h, CommonSnapshot, SymbolFeature
+from rob974_features import (
+    FOUR_HOUR_MS,
+    MINUTE_MS,
+    Bar4h,
+    CommonSnapshot,
+    SymbolFeature,
+)
 from rob974_h3_manifest import (
     SYMBOLS,
     S3Config,
@@ -423,12 +429,448 @@ def s3_formula_grid(
     )
 
 
+S3_NO_SIGNAL_REASONS: tuple[str, ...] = (
+    "missing_required_context",
+    "market_regime",
+    "market_breadth",
+    "trend_strength",
+    "efficiency",
+    "pullback_depth",
+    "vwap_reclaim",
+    "momentum",
+    "prior_l_non_breakout",
+    "volatility_percentile",
+    "range_tp_capacity",
+)
+S3_GENERATOR_REJECTION_REASONS: tuple[str, ...] = (
+    "simultaneous_candidate_arbitration_loser",
+)
+
+
+def s3_risk_distances(config: S3Config, a_value: float) -> tuple[float, float]:
+    """Registered fractional SL/TP math with no rounding or extra epsilon."""
+    if type(config) is not S3Config:
+        raise TypeError("config must be exact registered S3Config")
+    assert_registered_config(config)
+    _float(a_value, "A")
+    if a_value < 0.0:
+        raise ValueError("A must not be negative")
+    d_sl = min(max(config.k_SL * a_value, 0.008), 0.020)
+    d_tp = max(0.0068, config.R_TP * d_sl)
+    return d_sl, d_tp
+
+
+@dataclass(frozen=True, slots=True)
+class S3Candidate:
+    """H3-owned accepted-intent payload; CP8 alone adapts it to merged H2."""
+
+    strategy: str
+    config_id: str
+    decision_ts: int
+    symbol: str
+    side: str
+    R: float
+    S: float
+    ER: float
+    Q: float
+    A: float
+    atr20: float
+    close: float
+    vwap12: float
+    vwap24: float
+    market_return_24h: float
+    current_market_return_4h: float
+    volatility_percentile: float
+    volatility_percentile_provenance: str
+    range24: float
+    d_SL: float
+    d_TP: float
+    entry_tick_ts: int
+    entry_deadline_ts: int
+    max_hold_4h_bars: int
+
+    def __post_init__(self) -> None:
+        if _str(self.strategy, "strategy") != "S3":
+            raise ValueError("S3 candidate strategy must be S3")
+        _str(self.config_id, "config_id")
+        _int(self.decision_ts, "decision_ts")
+        if _str(self.symbol, "symbol") not in SYMBOLS:
+            raise ValueError("candidate symbol outside frozen universe")
+        if _str(self.side, "side") not in ("long", "short"):
+            raise ValueError("candidate side must be long or short")
+        for name in (
+            "R",
+            "S",
+            "ER",
+            "Q",
+            "A",
+            "atr20",
+            "close",
+            "vwap12",
+            "vwap24",
+            "market_return_24h",
+            "current_market_return_4h",
+            "volatility_percentile",
+            "range24",
+            "d_SL",
+            "d_TP",
+        ):
+            _float(getattr(self, name), name)
+        if (
+            _str(
+                self.volatility_percentile_provenance,
+                "volatility_percentile_provenance",
+            )
+            != "h1_percentile_30d"
+        ):
+            raise ValueError("S3 percentile provenance drift")
+        _int(self.entry_tick_ts, "entry_tick_ts")
+        _int(self.entry_deadline_ts, "entry_deadline_ts")
+        _int(self.max_hold_4h_bars, "max_hold_4h_bars")
+        if self.entry_tick_ts != self.decision_ts:
+            raise ValueError("entry tick must be the exact decision close")
+        if self.entry_deadline_ts != self.decision_ts + MINUTE_MS:
+            raise ValueError("entry deadline must bound the exact next minute")
+        if self.max_hold_4h_bars != 12:
+            raise ValueError("S3 maximum hold is frozen at twelve 4h bars")
+
+    @property
+    def signal_ts(self) -> int:
+        return self.decision_ts
+
+    @property
+    def identity(self) -> tuple[str, str, int, str, str]:
+        return (
+            self.strategy,
+            self.config_id,
+            self.decision_ts,
+            self.symbol,
+            self.side,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class S3GateOutcome:
+    side: str | None
+    candidate: S3Candidate | None
+    no_signal_reason: str | None
+
+    def __post_init__(self) -> None:
+        if self.side is not None and (
+            type(self.side) is not str or self.side not in ("long", "short")
+        ):
+            raise ValueError("side must be long, short, or None")
+        if self.candidate is not None and type(self.candidate) is not S3Candidate:
+            raise TypeError("candidate must be exact S3Candidate or None")
+        if (self.candidate is None) == (self.no_signal_reason is None):
+            raise ValueError("gate outcome must contain exactly candidate or reason")
+        if self.no_signal_reason is not None and (
+            type(self.no_signal_reason) is not str
+            or self.no_signal_reason not in S3_NO_SIGNAL_REASONS
+        ):
+            raise ValueError("unknown S3 no-signal reason")
+
+
+def _no_signal(reason: str, side: str | None = None) -> S3GateOutcome:
+    return S3GateOutcome(side, None, reason)
+
+
+def evaluate_s3_gates(metrics: S3Metrics, config: S3Config) -> S3GateOutcome:
+    """Evaluate the registered first-failing S3 gates in frozen order."""
+    if type(metrics) is not S3Metrics:
+        raise TypeError("metrics must be exact S3Metrics")
+    if type(config) is not S3Config:
+        raise TypeError("config must be exact registered S3Config")
+    assert_registered_config(config)
+    if metrics.config_id != config.config_id:
+        raise ValueError("metrics/config identity mismatch")
+
+    if metrics.market_return_24h >= 0.0075:
+        side = "long"
+    elif metrics.market_return_24h <= -0.0075:
+        side = "short"
+    else:
+        return _no_signal("market_regime")
+
+    if (metrics.bplus if side == "long" else metrics.bminus) < 2:
+        return _no_signal("market_breadth", side)
+    if (side == "long" and metrics.S < 1.25) or (side == "short" and metrics.S > -1.25):
+        return _no_signal("trend_strength", side)
+    if metrics.ER < config.ER_min:
+        return _no_signal("efficiency", side)
+    pullback = metrics.Qplus if side == "long" else metrics.Qminus
+    if not config.q_min <= pullback <= 1.25:
+        return _no_signal("pullback_depth", side)
+    if (side == "long" and metrics.close <= metrics.vwap12) or (
+        side == "short" and metrics.close >= metrics.vwap12
+    ):
+        return _no_signal("vwap_reclaim", side)
+    if (side == "long" and metrics.close <= metrics.previous_close) or (
+        side == "short" and metrics.close >= metrics.previous_close
+    ):
+        return _no_signal("momentum", side)
+    if (side == "long" and metrics.close >= metrics.prior_l_high) or (
+        side == "short" and metrics.close <= metrics.prior_l_low
+    ):
+        return _no_signal("prior_l_non_breakout", side)
+    if not 20.0 <= metrics.percentile_30d <= 90.0:
+        return _no_signal("volatility_percentile", side)
+    d_sl, d_tp = s3_risk_distances(config, metrics.A)
+    if d_tp > 0.60 * metrics.range24:
+        return _no_signal("range_tp_capacity", side)
+
+    return S3GateOutcome(
+        side,
+        S3Candidate(
+            "S3",
+            config.config_id,
+            metrics.decision_ts,
+            metrics.symbol,
+            side,
+            metrics.R,
+            metrics.S,
+            metrics.ER,
+            pullback,
+            metrics.A,
+            metrics.atr20,
+            metrics.close,
+            metrics.vwap12,
+            metrics.vwap24,
+            metrics.market_return_24h,
+            metrics.current_market_return_4h,
+            metrics.percentile_30d,
+            "h1_percentile_30d",
+            metrics.range24,
+            d_sl,
+            d_tp,
+            metrics.decision_ts,
+            metrics.decision_ts + MINUTE_MS,
+            12,
+        ),
+        None,
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class S3RejectedCandidate:
+    candidate: S3Candidate
+    reason: str
+
+    def __post_init__(self) -> None:
+        if type(self.candidate) is not S3Candidate:
+            raise TypeError("rejected candidate must be exact S3Candidate")
+        if (
+            type(self.reason) is not str
+            or self.reason not in S3_GENERATOR_REJECTION_REASONS
+        ):
+            raise ValueError("unknown S3 generator-rejection reason")
+
+
+@dataclass(frozen=True, slots=True)
+class S3ArbitrationResult:
+    winner: S3Candidate
+    rejected: tuple[S3RejectedCandidate, ...]
+
+    def __post_init__(self) -> None:
+        if type(self.winner) is not S3Candidate:
+            raise TypeError("winner must be exact S3Candidate")
+        if type(self.rejected) is not tuple or any(
+            type(item) is not S3RejectedCandidate for item in self.rejected
+        ):
+            raise TypeError("rejected must be a tuple of exact records")
+        rejected_ids = tuple(item.candidate.identity for item in self.rejected)
+        if self.winner.identity in rejected_ids or len(rejected_ids) != len(
+            set(rejected_ids)
+        ):
+            raise ValueError("accepted/rejected candidate collision")
+
+
+def _s3_rank(candidate: S3Candidate) -> tuple[float, float, float, str]:
+    return (-abs(candidate.S), -candidate.ER, -candidate.A, candidate.symbol)
+
+
+def arbitrate_s3_candidates(
+    candidates: Sequence[S3Candidate],
+) -> S3ArbitrationResult:
+    if not isinstance(candidates, Sequence):
+        raise TypeError("candidates must be a sequence")
+    exact = tuple(candidates)
+    if not exact:
+        raise ValueError("cannot arbitrate an empty candidate set")
+    if any(type(candidate) is not S3Candidate for candidate in exact):
+        raise TypeError("candidates must contain exact S3Candidate values")
+    scope = {
+        (candidate.strategy, candidate.config_id, candidate.decision_ts)
+        for candidate in exact
+    }
+    if len(scope) != 1:
+        raise ValueError("simultaneous arbitration scope mismatch")
+    identities = tuple(candidate.identity for candidate in exact)
+    if len(identities) != len(set(identities)):
+        raise ValueError("duplicate simultaneous candidate identity")
+    ordered = tuple(sorted(exact, key=_s3_rank))
+    return S3ArbitrationResult(
+        ordered[0],
+        tuple(
+            S3RejectedCandidate(candidate, "simultaneous_candidate_arbitration_loser")
+            for candidate in ordered[1:]
+        ),
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class S3UnitDecision:
+    decision_ts: int
+    symbol: str
+    status: str
+    side: str | None
+    candidate: S3Candidate | None
+    no_signal_reason: str | None
+    generator_rejection_reason: str | None
+
+    def __post_init__(self) -> None:
+        _int(self.decision_ts, "decision_ts")
+        if _str(self.symbol, "symbol") not in SYMBOLS:
+            raise ValueError("decision symbol outside frozen universe")
+        if _str(self.status, "status") not in (
+            "NO_SIGNAL",
+            "GENERATOR_REJECTED",
+            "GENERATOR_ACCEPTED",
+        ):
+            raise ValueError("unknown S3 unit status")
+        if self.side is not None and self.side not in ("long", "short"):
+            raise ValueError("invalid decision side")
+        if self.candidate is not None and type(self.candidate) is not S3Candidate:
+            raise TypeError("candidate must be exact S3Candidate or None")
+        if self.no_signal_reason is not None and (
+            type(self.no_signal_reason) is not str
+            or self.no_signal_reason not in S3_NO_SIGNAL_REASONS
+        ):
+            raise ValueError("unknown no-signal reason")
+        if self.generator_rejection_reason is not None and (
+            type(self.generator_rejection_reason) is not str
+            or self.generator_rejection_reason not in S3_GENERATOR_REJECTION_REASONS
+        ):
+            raise ValueError("unknown generator-rejection reason")
+
+
+@dataclass(frozen=True, slots=True)
+class S3GeneratorOutput:
+    decisions: tuple[S3UnitDecision, ...]
+    accepted: tuple[S3Candidate, ...]
+    rejected: tuple[S3RejectedCandidate, ...]
+
+    def __post_init__(self) -> None:
+        if type(self.decisions) is not tuple or type(self.accepted) is not tuple:
+            raise TypeError("generator output containers must be tuples")
+        if type(self.rejected) is not tuple:
+            raise TypeError("generator rejected container must be tuple")
+        if any(type(item) is not S3UnitDecision for item in self.decisions):
+            raise TypeError("decisions must contain exact S3UnitDecision")
+        if any(type(item) is not S3Candidate for item in self.accepted):
+            raise TypeError("accepted must contain exact S3Candidate")
+        if any(type(item) is not S3RejectedCandidate for item in self.rejected):
+            raise TypeError("rejected must contain exact S3RejectedCandidate")
+        accepted_ids = {item.identity for item in self.accepted}
+        rejected_ids = {item.candidate.identity for item in self.rejected}
+        if accepted_ids & rejected_ids:
+            raise ValueError("accepted/rejected candidate collision")
+
+
+def generate_s3_global(
+    feature_context: FeatureContext,
+    emit_window: EmitWindow,
+    config: S3Config,
+) -> S3GeneratorOutput:
+    """Run one account-global S3 invocation across all expected closes/symbols."""
+    units = s3_formula_grid(feature_context, emit_window, config)
+    decisions: list[S3UnitDecision] = []
+    accepted: list[S3Candidate] = []
+    rejected: list[S3RejectedCandidate] = []
+    for decision_ts in expected_decision_closes(emit_window):
+        at_close = tuple(unit for unit in units if unit.decision_ts == decision_ts)
+        gate_outcomes: dict[str, S3GateOutcome] = {}
+        candidates: list[S3Candidate] = []
+        for unit in at_close:
+            if unit.metrics is None:
+                gate_outcomes[unit.symbol] = _no_signal("missing_required_context")
+            else:
+                gate_outcomes[unit.symbol] = evaluate_s3_gates(unit.metrics, config)
+            candidate = gate_outcomes[unit.symbol].candidate
+            if candidate is not None:
+                candidates.append(candidate)
+
+        arbitration = arbitrate_s3_candidates(candidates) if candidates else None
+        winner_id = arbitration.winner.identity if arbitration is not None else None
+        loser_by_id = (
+            {item.candidate.identity: item for item in arbitration.rejected}
+            if arbitration is not None
+            else {}
+        )
+        if arbitration is not None:
+            accepted.append(arbitration.winner)
+            rejected.extend(arbitration.rejected)
+        for unit in at_close:
+            outcome = gate_outcomes[unit.symbol]
+            candidate = outcome.candidate
+            if candidate is None:
+                decisions.append(
+                    S3UnitDecision(
+                        decision_ts,
+                        unit.symbol,
+                        "NO_SIGNAL",
+                        outcome.side,
+                        None,
+                        outcome.no_signal_reason,
+                        None,
+                    )
+                )
+            elif candidate.identity == winner_id:
+                decisions.append(
+                    S3UnitDecision(
+                        decision_ts,
+                        unit.symbol,
+                        "GENERATOR_ACCEPTED",
+                        candidate.side,
+                        candidate,
+                        None,
+                        None,
+                    )
+                )
+            else:
+                loser = loser_by_id[candidate.identity]
+                decisions.append(
+                    S3UnitDecision(
+                        decision_ts,
+                        unit.symbol,
+                        "GENERATOR_REJECTED",
+                        candidate.side,
+                        candidate,
+                        None,
+                        loser.reason,
+                    )
+                )
+    return S3GeneratorOutput(tuple(decisions), tuple(accepted), tuple(rejected))
+
+
 __all__ = [
     "EmitWindow",
     "FeatureContext",
+    "S3ArbitrationResult",
+    "S3Candidate",
     "S3FormulaUnit",
+    "S3GateOutcome",
+    "S3GeneratorOutput",
     "S3Metrics",
+    "S3RejectedCandidate",
+    "S3UnitDecision",
+    "S3_GENERATOR_REJECTION_REASONS",
+    "S3_NO_SIGNAL_REASONS",
+    "arbitrate_s3_candidates",
     "compute_s3_metrics",
+    "evaluate_s3_gates",
     "expected_decision_closes",
+    "generate_s3_global",
     "s3_formula_grid",
+    "s3_risk_distances",
 ]

--- a/research/nautilus_scalping/rob974_h3_s3.py
+++ b/research/nautilus_scalping/rob974_h3_s3.py
@@ -1,0 +1,434 @@
+"""ROB-974 H3 S3 point-in-time context and exact formula core.
+
+The input boundary stores actual merged-H1 frozen DTOs.  Calculations are
+stateless, consume only complete history at or before ``decision_ts``, and use
+a separate half-open emission window.  Missing required history is represented
+as no formula result; malformed input is terminal.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+
+from rob974_features import FOUR_HOUR_MS, Bar4h, CommonSnapshot, SymbolFeature
+from rob974_h3_manifest import (
+    SYMBOLS,
+    S3Config,
+    assert_registered_config,
+)
+
+
+def _int(value: object, name: str) -> int:
+    if type(value) is not int:
+        raise TypeError(f"{name} must be built-in int")
+    return value
+
+
+def _str(value: object, name: str) -> str:
+    if type(value) is not str:
+        raise TypeError(f"{name} must be built-in str")
+    return value
+
+
+def _float(value: object, name: str) -> float:
+    if type(value) is not float:
+        raise TypeError(f"{name} must be built-in float")
+    if not math.isfinite(value):
+        raise ValueError(f"{name} must be finite")
+    return value
+
+
+def _validate_bar(bar: Bar4h) -> None:
+    if type(bar) is not Bar4h:
+        raise TypeError("FeatureContext bars must be exact merged-H1 Bar4h values")
+    _int(bar.ts, "bar.ts")
+    _int(bar.close_ts, "bar.close_ts")
+    if bar.close_ts != bar.ts + FOUR_HOUR_MS or bar.ts % FOUR_HOUR_MS:
+        raise ValueError("malformed H1 Bar4h timestamp")
+    for name in ("open", "high", "low", "close", "volume"):
+        _float(getattr(bar, name), f"bar.{name}")
+    if bar.close <= 0.0 or bar.low <= 0.0 or bar.volume < 0.0:
+        raise ValueError("malformed H1 Bar4h economic value")
+
+
+def _validate_feature(feature: SymbolFeature, decision_ts: int) -> None:
+    if type(feature) is not SymbolFeature:
+        raise TypeError("snapshot features must be exact merged-H1 SymbolFeature")
+    if feature.decision_ts != decision_ts:
+        raise ValueError("H1 feature timestamp differs from snapshot")
+    for name in (
+        "r",
+        "tr",
+        "atr20",
+        "a",
+        "vwap12",
+        "vwap24",
+        "percentile_30d",
+        "range24",
+    ):
+        value = getattr(feature, name)
+        if value is not None:
+            _float(value, f"feature.{name}")
+    for name in ("atr20", "a", "range24"):
+        value = getattr(feature, name)
+        if value is not None and value < 0.0:
+            raise ValueError(f"feature.{name} must not be negative")
+    if feature.vwap12 is not None and feature.vwap12 <= 0.0:
+        raise ValueError("feature.vwap12 must be positive")
+    if feature.vwap24 is not None and feature.vwap24 <= 0.0:
+        raise ValueError("feature.vwap24 must be positive")
+    if feature.percentile_30d is not None and not (
+        0.0 <= feature.percentile_30d <= 100.0
+    ):
+        raise ValueError("feature.percentile_30d must be in [0,100]")
+
+
+def _validate_snapshot(snapshot: CommonSnapshot) -> None:
+    if type(snapshot) is not CommonSnapshot:
+        raise TypeError("snapshots must be exact merged-H1 CommonSnapshot values")
+    _int(snapshot.decision_ts, "snapshot.decision_ts")
+    if snapshot.decision_ts % FOUR_HOUR_MS:
+        raise ValueError("snapshot decision_ts must be a UTC 4h close")
+    _float(snapshot.m, "snapshot.m")
+    _float(snapshot.M, "snapshot.M")
+    _int(snapshot.bplus, "snapshot.bplus")
+    _int(snapshot.bminus, "snapshot.bminus")
+    if not (0 <= snapshot.bplus <= 3 and 0 <= snapshot.bminus <= 3):
+        raise ValueError("snapshot breadth must be in [0,3]")
+    if (
+        type(snapshot.features) is not tuple
+        or tuple(feature.symbol for feature in snapshot.features) != SYMBOLS
+    ):
+        raise ValueError("snapshot feature order must match merged H1")
+    for feature in snapshot.features:
+        _validate_feature(feature, snapshot.decision_ts)
+
+
+@dataclass(frozen=True, slots=True)
+class FeatureContext:
+    """Immutable normalized storage of actual H1 bars and synchronized DTOs."""
+
+    bars_by_symbol: tuple[tuple[str, tuple[Bar4h, ...]], ...]
+    snapshots: tuple[CommonSnapshot, ...]
+
+    def __post_init__(self) -> None:
+        if (
+            type(self.bars_by_symbol) is not tuple
+            or tuple(symbol for symbol, _ in self.bars_by_symbol) != SYMBOLS
+        ):
+            raise ValueError("bars_by_symbol must use the fixed H1 symbol order")
+        for symbol, bars in self.bars_by_symbol:
+            if type(symbol) is not str or type(bars) is not tuple:
+                raise TypeError("FeatureContext bar storage must be built-in tuples")
+            prior: Bar4h | None = None
+            seen: set[int] = set()
+            for bar in bars:
+                _validate_bar(bar)
+                if bar.close_ts in seen or (
+                    prior is not None and bar.close_ts <= prior.close_ts
+                ):
+                    raise ValueError("H1 Bar4h history must be strictly ordered")
+                if (
+                    prior is not None
+                    and bar.ts != prior.close_ts
+                    and not bar.is_segment_start
+                ):
+                    raise ValueError("an H1 time gap must start a new segment")
+                seen.add(bar.close_ts)
+                prior = bar
+        if type(self.snapshots) is not tuple:
+            raise TypeError("snapshots must be built-in tuple")
+        prior_ts: int | None = None
+        available = {
+            symbol: {bar.close_ts for bar in bars}
+            for symbol, bars in self.bars_by_symbol
+        }
+        for snapshot in self.snapshots:
+            _validate_snapshot(snapshot)
+            if prior_ts is not None and snapshot.decision_ts <= prior_ts:
+                raise ValueError("H1 snapshots must be strictly ordered and unique")
+            if any(snapshot.decision_ts not in available[symbol] for symbol in SYMBOLS):
+                raise ValueError("H1 snapshot lacks its exact synchronized Bar4h close")
+            prior_ts = snapshot.decision_ts
+
+    @classmethod
+    def from_h1(
+        cls,
+        bars: Mapping[str, Sequence[Bar4h]],
+        snapshots: Sequence[CommonSnapshot],
+    ) -> FeatureContext:
+        if not isinstance(bars, Mapping) or set(bars) != set(SYMBOLS):
+            raise ValueError("bars must cover the exact H1 selected universe")
+        normalized: list[tuple[str, tuple[Bar4h, ...]]] = []
+        for symbol in SYMBOLS:
+            values = bars[symbol]
+            if not isinstance(values, Sequence):
+                raise TypeError("each H1 bar history must be a sequence")
+            exact = values if type(values) is tuple else tuple(values)
+            normalized.append((symbol, exact))
+        if not isinstance(snapshots, Sequence):
+            raise TypeError("H1 snapshots must be a sequence")
+        exact_snapshots = snapshots if type(snapshots) is tuple else tuple(snapshots)
+        return cls(tuple(normalized), exact_snapshots)
+
+    def bars_for(self, symbol: str) -> tuple[Bar4h, ...]:
+        _str(symbol, "symbol")
+        if symbol not in SYMBOLS:
+            raise ValueError("symbol outside the frozen H1 universe")
+        return self.bars_by_symbol[SYMBOLS.index(symbol)][1]
+
+    def snapshot_at(self, decision_ts: int) -> CommonSnapshot | None:
+        _int(decision_ts, "decision_ts")
+        return next(
+            (
+                snapshot
+                for snapshot in self.snapshots
+                if snapshot.decision_ts == decision_ts
+            ),
+            None,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class EmitWindow:
+    start: int
+    end: int
+
+    def __post_init__(self) -> None:
+        _int(self.start, "emit_window.start")
+        _int(self.end, "emit_window.end")
+        if self.start < 0 or self.end <= self.start:
+            raise ValueError("emit_window must be a non-empty half-open range")
+
+
+def expected_decision_closes(emit_window: EmitWindow) -> tuple[int, ...]:
+    if type(emit_window) is not EmitWindow:
+        raise TypeError("emit_window must be exact EmitWindow")
+    first = ((emit_window.start + FOUR_HOUR_MS - 1) // FOUR_HOUR_MS) * FOUR_HOUR_MS
+    return tuple(range(first, emit_window.end, FOUR_HOUR_MS))
+
+
+@dataclass(frozen=True, slots=True)
+class S3Metrics:
+    config_id: str
+    decision_ts: int
+    symbol: str
+    R: float
+    ER: float
+    S: float
+    Qplus: float
+    Qminus: float
+    close: float
+    previous_close: float
+    prior_l_high: float
+    prior_l_low: float
+    atr20: float
+    A: float
+    vwap12: float
+    vwap24: float
+    percentile_30d: float
+    range24: float
+    market_return_24h: float
+    current_market_return_4h: float
+    bplus: int
+    bminus: int
+
+    def __post_init__(self) -> None:
+        _str(self.config_id, "config_id")
+        _int(self.decision_ts, "decision_ts")
+        if _str(self.symbol, "symbol") not in SYMBOLS:
+            raise ValueError("unregistered symbol")
+        for name in (
+            "R",
+            "ER",
+            "S",
+            "Qplus",
+            "Qminus",
+            "close",
+            "previous_close",
+            "prior_l_high",
+            "prior_l_low",
+            "atr20",
+            "A",
+            "vwap12",
+            "vwap24",
+            "percentile_30d",
+            "range24",
+            "market_return_24h",
+            "current_market_return_4h",
+        ):
+            _float(getattr(self, name), name)
+        _int(self.bplus, "bplus")
+        _int(self.bminus, "bminus")
+
+
+@dataclass(frozen=True, slots=True)
+class S3FormulaUnit:
+    decision_ts: int
+    symbol: str
+    metrics: S3Metrics | None
+
+    def __post_init__(self) -> None:
+        _int(self.decision_ts, "decision_ts")
+        if _str(self.symbol, "symbol") not in SYMBOLS:
+            raise ValueError("unregistered symbol")
+        if self.metrics is not None and type(self.metrics) is not S3Metrics:
+            raise TypeError("metrics must be exact S3Metrics or None")
+        if self.metrics is not None and (
+            self.metrics.decision_ts != self.decision_ts
+            or self.metrics.symbol != self.symbol
+        ):
+            raise ValueError("formula-unit identity mismatch")
+
+
+def _feature_at(snapshot: CommonSnapshot, symbol: str) -> SymbolFeature:
+    return snapshot.features[SYMBOLS.index(symbol)]
+
+
+def _required_current_values(feature: SymbolFeature) -> tuple[float, ...] | None:
+    values = (
+        feature.atr20,
+        feature.a,
+        feature.vwap12,
+        feature.vwap24,
+        feature.percentile_30d,
+        feature.range24,
+    )
+    if any(value is None for value in values):
+        return None
+    return tuple(value for value in values if value is not None)
+
+
+def compute_s3_metrics(
+    feature_context: FeatureContext,
+    config: S3Config,
+    decision_ts: int,
+    symbol: str,
+) -> S3Metrics | None:
+    """Compute exact registered S3 formula values, or None for unavailable PIT data."""
+    if type(feature_context) is not FeatureContext:
+        raise TypeError("feature_context must be exact FeatureContext")
+    if type(config) is not S3Config:
+        raise TypeError("config must be exact registered S3Config")
+    assert_registered_config(config)
+    _int(decision_ts, "decision_ts")
+    if decision_ts % FOUR_HOUR_MS:
+        raise ValueError("decision_ts must be an exact UTC 4h close")
+    if _str(symbol, "symbol") not in SYMBOLS:
+        raise ValueError("symbol outside the frozen universe")
+
+    snapshot = feature_context.snapshot_at(decision_ts)
+    if snapshot is None:
+        return None
+    current_feature = _feature_at(snapshot, symbol)
+    required = _required_current_values(current_feature)
+    if required is None:
+        return None
+    atr20, a_value, vwap12, vwap24, percentile, range24 = required
+
+    bars = feature_context.bars_for(symbol)
+    current_index = next(
+        (index for index, bar in enumerate(bars) if bar.close_ts == decision_ts),
+        None,
+    )
+    if current_index is None or current_index < config.L:
+        return None
+    history = bars[current_index - config.L : current_index + 1]
+    if len(history) != config.L + 1:
+        return None
+    for left, right in zip(history, history[1:], strict=False):
+        if right.ts != left.close_ts or right.is_segment_start:
+            return None
+
+    prior_snapshots = (
+        feature_context.snapshot_at(decision_ts - 2 * FOUR_HOUR_MS),
+        feature_context.snapshot_at(decision_ts - FOUR_HOUR_MS),
+    )
+    if any(item is None for item in prior_snapshots):
+        return None
+    normalized_pullbacks: list[float] = []
+    for bar, prior_snapshot in zip(history[-3:-1], prior_snapshots, strict=True):
+        if prior_snapshot is None:  # narrowed above; keeps runtime branch explicit
+            return None
+        feature = _feature_at(prior_snapshot, symbol)
+        if feature.atr20 is None or feature.vwap12 is None or feature.atr20 <= 0.0:
+            return None
+        normalized_pullbacks.append((bar.close - feature.vwap12) / feature.atr20)
+
+    closes = tuple(bar.close for bar in history)
+    er_denominator = math.fsum(
+        abs(current - previous)
+        for previous, current in zip(closes, closes[1:], strict=False)
+    )
+    if er_denominator <= 0.0:
+        return None
+    r_value = math.log(closes[-1] / closes[0])
+    er_value = abs(closes[-1] - closes[0]) / er_denominator
+    s_denominator = max(a_value * math.sqrt(config.L), 1e-6)
+    s_value = r_value / s_denominator
+    q_plus = -min(normalized_pullbacks)
+    q_minus = max(normalized_pullbacks)
+    calculated = (r_value, er_value, s_value, q_plus, q_minus)
+    if not all(math.isfinite(value) for value in calculated):
+        raise ValueError("nonfinite S3 formula result")
+
+    prior_l = history[:-1]
+    return S3Metrics(
+        config.config_id,
+        decision_ts,
+        symbol,
+        r_value,
+        er_value,
+        s_value,
+        q_plus,
+        q_minus,
+        history[-1].close,
+        history[-2].close,
+        max(bar.high for bar in prior_l),
+        min(bar.low for bar in prior_l),
+        atr20,
+        a_value,
+        vwap12,
+        vwap24,
+        percentile,
+        range24,
+        snapshot.M,
+        snapshot.m,
+        snapshot.bplus,
+        snapshot.bminus,
+    )
+
+
+def s3_formula_grid(
+    feature_context: FeatureContext,
+    emit_window: EmitWindow,
+    config: S3Config,
+) -> tuple[S3FormulaUnit, ...]:
+    """Enumerate all three symbol units at every expected close in [start,end)."""
+    if type(feature_context) is not FeatureContext:
+        raise TypeError("feature_context must be exact FeatureContext")
+    if type(config) is not S3Config:
+        raise TypeError("config must be exact registered S3Config")
+    assert_registered_config(config)
+    return tuple(
+        S3FormulaUnit(
+            decision_ts,
+            symbol,
+            compute_s3_metrics(feature_context, config, decision_ts, symbol),
+        )
+        for decision_ts in expected_decision_closes(emit_window)
+        for symbol in SYMBOLS
+    )
+
+
+__all__ = [
+    "EmitWindow",
+    "FeatureContext",
+    "S3FormulaUnit",
+    "S3Metrics",
+    "compute_s3_metrics",
+    "expected_decision_closes",
+    "s3_formula_grid",
+]

--- a/research/nautilus_scalping/rob974_h3_s4.py
+++ b/research/nautilus_scalping/rob974_h3_s4.py
@@ -1,0 +1,601 @@
+"""ROB-974 H3 S4 exact point-in-time pair estimator.
+
+Every evaluation uses its own W-wide beta-neutral weights over its historical
+spread.  The stored prior z-score is a separate t-1 evaluation and therefore
+cannot consume t betas, weights, closes, median, MAD, or scale.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+from rob974_features import FOUR_HOUR_MS, CommonSnapshot
+from rob974_h3_manifest import PAIRS, SYMBOLS, S4Config, assert_registered_config
+from rob974_h3_s3 import FeatureContext
+
+PAIR_ORDER: tuple[str, ...] = PAIRS
+_PAIR_SYMBOLS = {
+    "XRP-DOGE": ("XRPUSDT", "DOGEUSDT"),
+    "XRP-SOL": ("XRPUSDT", "SOLUSDT"),
+    "DOGE-SOL": ("DOGEUSDT", "SOLUSDT"),
+}
+S4_ESTIMATION_REASONS: tuple[str, ...] = (
+    "missing_required_context",
+    "degenerate_beta_market_variance",
+    "degenerate_rho_variance",
+    "degenerate_phi_denominator",
+    "phi_not_in_open_unit_interval",
+    "nonfinite_required_input",
+)
+
+
+def _int(value: object, name: str) -> int:
+    if type(value) is not int:
+        raise TypeError(f"{name} must be built-in int")
+    return value
+
+
+def _str(value: object, name: str) -> str:
+    if type(value) is not str:
+        raise TypeError(f"{name} must be built-in str")
+    return value
+
+
+def _float(value: object, name: str) -> float:
+    if type(value) is not float:
+        raise TypeError(f"{name} must be built-in float")
+    if not math.isfinite(value):
+        raise ValueError(f"{name} must be finite")
+    return value
+
+
+def _numeric_tuple(values: tuple[float, ...], name: str) -> bool:
+    if type(values) is not tuple:
+        raise TypeError(f"{name} must be built-in tuple")
+    for value in values:
+        if type(value) is not float:
+            raise TypeError(f"{name} must contain built-in float")
+    return bool(values) and all(math.isfinite(value) for value in values)
+
+
+def _safe_fsum(values) -> float | None:
+    materialized = tuple(values)
+    if not all(type(value) is float and math.isfinite(value) for value in materialized):
+        return None
+    try:
+        result = math.fsum(materialized)
+    except OverflowError:
+        return None
+    return result if math.isfinite(result) else None
+
+
+def fixed_median(values: tuple[float, ...]) -> float | None:
+    """Deterministic median; even middles are combined with fixed-order fsum."""
+    if not _numeric_tuple(values, "values"):
+        return None
+    ordered = tuple(sorted(values))
+    middle = len(ordered) // 2
+    if len(ordered) % 2:
+        return ordered[middle]
+    combined = _safe_fsum((ordered[middle - 1], ordered[middle]))
+    return None if combined is None else combined / 2.0
+
+
+@dataclass(frozen=True, slots=True)
+class SpreadStatistics:
+    mu: float
+    mad: float
+    effective_scale: float
+
+    def __post_init__(self) -> None:
+        _float(self.mu, "mu")
+        _float(self.mad, "mad")
+        _float(self.effective_scale, "effective_scale")
+        if self.mad < 0.0 or self.effective_scale < 1e-6:
+            raise ValueError("invalid spread scale")
+
+
+def spread_statistics(spreads: tuple[float, ...]) -> SpreadStatistics | None:
+    if not _numeric_tuple(spreads, "spreads"):
+        return None
+    mu = fixed_median(spreads)
+    if mu is None:
+        return None
+    deviations = tuple(abs(value - mu) for value in spreads)
+    if not all(math.isfinite(value) for value in deviations):
+        return None
+    mad = fixed_median(deviations)
+    if mad is None:
+        return None
+    scaled = 1.4826 * mad
+    if not math.isfinite(scaled):
+        return None
+    return SpreadStatistics(mu, mad, max(scaled, 1e-6))
+
+
+def _mean(values: tuple[float, ...]) -> float | None:
+    total = _safe_fsum(values)
+    return None if total is None else total / len(values)
+
+
+def compute_clipped_beta(
+    returns: tuple[float, ...], market: tuple[float, ...]
+) -> float | None:
+    if not _numeric_tuple(returns, "returns") or not _numeric_tuple(market, "market"):
+        return None
+    if len(returns) != len(market) or len(returns) < 2:
+        return None
+    return_mean = _mean(returns)
+    market_mean = _mean(market)
+    if return_mean is None or market_mean is None:
+        return None
+    covariance_terms = tuple(
+        (return_value - return_mean) * (market_value - market_mean)
+        for return_value, market_value in zip(returns, market, strict=True)
+    )
+    variance_terms = tuple((value - market_mean) ** 2 for value in market)
+    numerator = _safe_fsum(covariance_terms)
+    denominator = _safe_fsum(variance_terms)
+    if numerator is None or denominator is None or denominator <= 0.0:
+        return None
+    beta = numerator / denominator
+    if not math.isfinite(beta):
+        return None
+    return min(max(beta, 0.25), 3.0)
+
+
+def correlation(left: tuple[float, ...], right: tuple[float, ...]) -> float | None:
+    if not _numeric_tuple(left, "left") or not _numeric_tuple(right, "right"):
+        return None
+    if len(left) != len(right) or len(left) < 2:
+        return None
+    left_mean = _mean(left)
+    right_mean = _mean(right)
+    if left_mean is None or right_mean is None:
+        return None
+    left_centered = tuple(value - left_mean for value in left)
+    right_centered = tuple(value - right_mean for value in right)
+    covariance = _safe_fsum(
+        tuple(
+            a_value * b_value
+            for a_value, b_value in zip(left_centered, right_centered, strict=True)
+        )
+    )
+    left_ss = _safe_fsum(tuple(value * value for value in left_centered))
+    right_ss = _safe_fsum(tuple(value * value for value in right_centered))
+    if (
+        covariance is None
+        or left_ss is None
+        or right_ss is None
+        or left_ss <= 0.0
+        or right_ss <= 0.0
+    ):
+        return None
+    denominator = math.sqrt(left_ss * right_ss)
+    if not math.isfinite(denominator) or denominator <= 0.0:
+        return None
+    result = covariance / denominator
+    return result if math.isfinite(result) else None
+
+
+def population_sigma(values: tuple[float, ...]) -> float | None:
+    if not _numeric_tuple(values, "values"):
+        return None
+    mean = _mean(values)
+    if mean is None:
+        return None
+    squared = tuple((value - mean) ** 2 for value in values)
+    total = _safe_fsum(squared)
+    if total is None:
+        return None
+    variance = total / len(values)
+    result = math.sqrt(variance)
+    return result if math.isfinite(result) else None
+
+
+def _phi_raw(spreads: tuple[float, ...], mu: float) -> tuple[float | None, bool]:
+    if not _numeric_tuple(spreads, "spreads"):
+        return None, False
+    _float(mu, "mu")
+    if len(spreads) < 2:
+        return None, True
+    centered = tuple(value - mu for value in spreads)
+    numerator = _safe_fsum(
+        tuple(
+            centered[index - 1] * centered[index] for index in range(1, len(centered))
+        )
+    )
+    denominator = _safe_fsum(tuple(value * value for value in centered[:-1]))
+    if numerator is None or denominator is None:
+        return None, False
+    if denominator <= 0.0:
+        return None, True
+    result = numerator / denominator
+    return (result if math.isfinite(result) else None), False
+
+
+def phi_and_half_life(
+    spreads: tuple[float, ...], mu: float
+) -> tuple[float, float] | None:
+    phi, _ = _phi_raw(spreads, mu)
+    if phi is None or not 0.0 < phi < 1.0:
+        return None
+    half_life = math.log(0.5) / math.log(phi)
+    if not math.isfinite(half_life):
+        return None
+    return phi, half_life
+
+
+@dataclass(frozen=True, slots=True)
+class S4Estimate:
+    config_id: str
+    decision_ts: int
+    pair: str
+    symbol_a: str
+    symbol_b: str
+    beta_a: float
+    beta_b: float
+    beta_a_first: float
+    beta_a_second: float
+    beta_b_first: float
+    beta_b_second: float
+    weight_a: float
+    weight_b: float
+    spread: float
+    mu: float
+    mad: float
+    effective_mad_scale: float
+    z: float
+    prior_beta_a: float
+    prior_beta_b: float
+    prior_weight_a: float
+    prior_weight_b: float
+    prior_mu: float
+    prior_mad: float
+    prior_effective_mad_scale: float
+    z_prior: float
+    D_fraction: float
+    D_bps: float
+    rho: float
+    phi: float
+    half_life_4h_bars: float
+    beta_stability: float
+    sigma_pair: float
+    pair_return_fraction: float
+    pair_return_bps: float
+    current_market_return_4h: float
+
+    def __post_init__(self) -> None:
+        _str(self.config_id, "config_id")
+        _int(self.decision_ts, "decision_ts")
+        if _str(self.pair, "pair") not in PAIR_ORDER:
+            raise ValueError("pair outside frozen order")
+        expected_symbols = _PAIR_SYMBOLS[self.pair]
+        if (self.symbol_a, self.symbol_b) != expected_symbols:
+            raise ValueError("pair symbol order drift")
+        for name in (
+            "beta_a",
+            "beta_b",
+            "beta_a_first",
+            "beta_a_second",
+            "beta_b_first",
+            "beta_b_second",
+            "weight_a",
+            "weight_b",
+            "spread",
+            "mu",
+            "mad",
+            "effective_mad_scale",
+            "z",
+            "prior_beta_a",
+            "prior_beta_b",
+            "prior_weight_a",
+            "prior_weight_b",
+            "prior_mu",
+            "prior_mad",
+            "prior_effective_mad_scale",
+            "z_prior",
+            "D_fraction",
+            "D_bps",
+            "rho",
+            "phi",
+            "half_life_4h_bars",
+            "beta_stability",
+            "sigma_pair",
+            "pair_return_fraction",
+            "pair_return_bps",
+            "current_market_return_4h",
+        ):
+            _float(getattr(self, name), name)
+        if not 0.0 < self.phi < 1.0:
+            raise ValueError("phi must be in the open unit interval")
+        if self.mad < 0.0 or self.prior_mad < 0.0 or self.sigma_pair < 0.0:
+            raise ValueError("scale values must not be negative")
+
+
+@dataclass(frozen=True, slots=True)
+class S4EstimationOutcome:
+    estimate: S4Estimate | None
+    rejection_reason: str | None
+
+    def __post_init__(self) -> None:
+        if self.estimate is not None and type(self.estimate) is not S4Estimate:
+            raise TypeError("estimate must be exact S4Estimate or None")
+        if (self.estimate is None) == (self.rejection_reason is None):
+            raise ValueError("outcome must contain exactly estimate or rejection")
+        if self.rejection_reason is not None and (
+            type(self.rejection_reason) is not str
+            or self.rejection_reason not in S4_ESTIMATION_REASONS
+        ):
+            raise ValueError("unknown S4 estimation reason")
+
+
+def _reject(reason: str) -> S4EstimationOutcome:
+    return S4EstimationOutcome(None, reason)
+
+
+@dataclass(frozen=True, slots=True)
+class _Window:
+    returns_a: tuple[float, ...]
+    returns_b: tuple[float, ...]
+    market: tuple[float, ...]
+    closes_a: tuple[float, ...]
+    closes_b: tuple[float, ...]
+
+
+def _feature_return(snapshot: CommonSnapshot, symbol: str) -> float | None:
+    return snapshot.features[SYMBOLS.index(symbol)].r
+
+
+def _window(
+    feature_context: FeatureContext,
+    snapshots: tuple[CommonSnapshot, ...],
+    symbols: tuple[str, str],
+) -> _Window | None:
+    returns_a = tuple(_feature_return(snapshot, symbols[0]) for snapshot in snapshots)
+    returns_b = tuple(_feature_return(snapshot, symbols[1]) for snapshot in snapshots)
+    if any(value is None for value in returns_a + returns_b):
+        return None
+    bars_a = {bar.close_ts: bar.close for bar in feature_context.bars_for(symbols[0])}
+    bars_b = {bar.close_ts: bar.close for bar in feature_context.bars_for(symbols[1])}
+    try:
+        closes_a = tuple(bars_a[snapshot.decision_ts] for snapshot in snapshots)
+        closes_b = tuple(bars_b[snapshot.decision_ts] for snapshot in snapshots)
+    except KeyError:
+        return None
+    return _Window(
+        tuple(value for value in returns_a if value is not None),
+        tuple(value for value in returns_b if value is not None),
+        tuple(snapshot.m for snapshot in snapshots),
+        closes_a,
+        closes_b,
+    )
+
+
+def _spreads(window: _Window, weight_a: float, weight_b: float) -> tuple[float, ...]:
+    return tuple(
+        weight_a * math.log(close_a) - weight_b * math.log(close_b)
+        for close_a, close_b in zip(window.closes_a, window.closes_b, strict=True)
+    )
+
+
+def _all_finite(values: tuple[float, ...]) -> bool:
+    return all(type(value) is float and math.isfinite(value) for value in values)
+
+
+def estimate_s4_pair(
+    feature_context: FeatureContext,
+    config: S4Config,
+    decision_ts: int,
+    pair: str,
+) -> S4EstimationOutcome:
+    """Evaluate one frozen-order pair at one exact complete close."""
+    if type(feature_context) is not FeatureContext:
+        raise TypeError("feature_context must be exact FeatureContext")
+    if type(config) is not S4Config:
+        raise TypeError("config must be exact registered S4Config")
+    assert_registered_config(config)
+    _int(decision_ts, "decision_ts")
+    if decision_ts % FOUR_HOUR_MS:
+        raise ValueError("decision_ts must be an exact UTC 4h close")
+    if _str(pair, "pair") not in PAIR_ORDER:
+        raise ValueError("pair outside frozen pair order")
+    symbols = _PAIR_SYMBOLS[pair]
+
+    position = next(
+        (
+            index
+            for index, snapshot in enumerate(feature_context.snapshots)
+            if snapshot.decision_ts == decision_ts
+        ),
+        None,
+    )
+    if position is None or position < config.W:
+        return _reject("missing_required_context")
+    combined = feature_context.snapshots[position - config.W : position + 1]
+    if len(combined) != config.W + 1 or any(
+        right.decision_ts != left.decision_ts + FOUR_HOUR_MS
+        for left, right in zip(combined, combined[1:], strict=False)
+    ):
+        return _reject("missing_required_context")
+    for symbol in symbols:
+        by_close = {bar.close_ts: bar for bar in feature_context.bars_for(symbol)}
+        selected = tuple(by_close.get(snapshot.decision_ts) for snapshot in combined)
+        if any(bar is None for bar in selected):
+            return _reject("missing_required_context")
+        exact_bars = tuple(bar for bar in selected if bar is not None)
+        if any(
+            right.ts != left.close_ts or right.is_segment_start
+            for left, right in zip(exact_bars, exact_bars[1:], strict=False)
+        ):
+            return _reject("missing_required_context")
+
+    prior_window = _window(feature_context, combined[:-1], symbols)
+    current_window = _window(feature_context, combined[1:], symbols)
+    if prior_window is None or current_window is None:
+        return _reject("missing_required_context")
+    required_inputs = (
+        current_window.returns_a
+        + current_window.returns_b
+        + current_window.market
+        + current_window.closes_a
+        + current_window.closes_b
+        + prior_window.returns_a
+        + prior_window.returns_b
+        + prior_window.market
+        + prior_window.closes_a
+        + prior_window.closes_b
+    )
+    if not _all_finite(required_inputs):
+        return _reject("nonfinite_required_input")
+
+    beta_a = compute_clipped_beta(current_window.returns_a, current_window.market)
+    beta_b = compute_clipped_beta(current_window.returns_b, current_window.market)
+    prior_beta_a = compute_clipped_beta(prior_window.returns_a, prior_window.market)
+    prior_beta_b = compute_clipped_beta(prior_window.returns_b, prior_window.market)
+    if None in (beta_a, beta_b, prior_beta_a, prior_beta_b):
+        return _reject("degenerate_beta_market_variance")
+    if beta_a is None or beta_b is None or prior_beta_a is None or prior_beta_b is None:
+        return _reject("degenerate_beta_market_variance")
+
+    half = config.W // 2
+    beta_a_first = compute_clipped_beta(
+        current_window.returns_a[:half], current_window.market[:half]
+    )
+    beta_a_second = compute_clipped_beta(
+        current_window.returns_a[half:], current_window.market[half:]
+    )
+    beta_b_first = compute_clipped_beta(
+        current_window.returns_b[:half], current_window.market[:half]
+    )
+    beta_b_second = compute_clipped_beta(
+        current_window.returns_b[half:], current_window.market[half:]
+    )
+    if None in (beta_a_first, beta_a_second, beta_b_first, beta_b_second):
+        return _reject("degenerate_beta_market_variance")
+    if (
+        beta_a_first is None
+        or beta_a_second is None
+        or beta_b_first is None
+        or beta_b_second is None
+    ):
+        return _reject("degenerate_beta_market_variance")
+
+    rho = correlation(current_window.returns_a, current_window.returns_b)
+    if rho is None:
+        return _reject("degenerate_rho_variance")
+    weight_a = beta_b / (beta_a + beta_b)
+    weight_b = beta_a / (beta_a + beta_b)
+    prior_weight_a = prior_beta_b / (prior_beta_a + prior_beta_b)
+    prior_weight_b = prior_beta_a / (prior_beta_a + prior_beta_b)
+    current_spreads = _spreads(current_window, weight_a, weight_b)
+    prior_spreads = _spreads(prior_window, prior_weight_a, prior_weight_b)
+    if not _all_finite(current_spreads + prior_spreads):
+        return _reject("nonfinite_required_input")
+    current_stats = spread_statistics(current_spreads)
+    prior_stats = spread_statistics(prior_spreads)
+    if current_stats is None or prior_stats is None:
+        return _reject("nonfinite_required_input")
+    z_value = (current_spreads[-1] - current_stats.mu) / current_stats.effective_scale
+    z_prior = (prior_spreads[-1] - prior_stats.mu) / prior_stats.effective_scale
+
+    phi, denominator_degenerate = _phi_raw(current_spreads, current_stats.mu)
+    if phi is None:
+        return _reject(
+            "degenerate_phi_denominator"
+            if denominator_degenerate
+            else "nonfinite_required_input"
+        )
+    if not 0.0 < phi < 1.0:
+        return _reject("phi_not_in_open_unit_interval")
+    half_life = math.log(0.5) / math.log(phi)
+    if not math.isfinite(half_life):
+        return _reject("nonfinite_required_input")
+
+    pair_returns = tuple(
+        weight_a * left - weight_b * right
+        for left, right in zip(
+            current_window.returns_a, current_window.returns_b, strict=True
+        )
+    )
+    sigma_pair = population_sigma(pair_returns)
+    if sigma_pair is None:
+        return _reject("nonfinite_required_input")
+    beta_stability = max(
+        abs(beta_a_first - beta_a_second) / beta_a,
+        abs(beta_b_first - beta_b_second) / beta_b,
+    )
+    d_fraction = abs(current_spreads[-1] - current_stats.mu)
+    pair_return = pair_returns[-1]
+    final_values = (
+        weight_a,
+        weight_b,
+        prior_weight_a,
+        prior_weight_b,
+        z_value,
+        z_prior,
+        beta_stability,
+        d_fraction,
+        pair_return,
+    )
+    if not _all_finite(final_values):
+        return _reject("nonfinite_required_input")
+
+    return S4EstimationOutcome(
+        S4Estimate(
+            config.config_id,
+            decision_ts,
+            pair,
+            symbols[0],
+            symbols[1],
+            beta_a,
+            beta_b,
+            beta_a_first,
+            beta_a_second,
+            beta_b_first,
+            beta_b_second,
+            weight_a,
+            weight_b,
+            current_spreads[-1],
+            current_stats.mu,
+            current_stats.mad,
+            current_stats.effective_scale,
+            z_value,
+            prior_beta_a,
+            prior_beta_b,
+            prior_weight_a,
+            prior_weight_b,
+            prior_stats.mu,
+            prior_stats.mad,
+            prior_stats.effective_scale,
+            z_prior,
+            d_fraction,
+            d_fraction * 10_000.0,
+            rho,
+            phi,
+            half_life,
+            beta_stability,
+            sigma_pair,
+            pair_return,
+            pair_return * 10_000.0,
+            combined[-1].m,
+        ),
+        None,
+    )
+
+
+__all__ = [
+    "PAIR_ORDER",
+    "S4Estimate",
+    "S4EstimationOutcome",
+    "S4_ESTIMATION_REASONS",
+    "SpreadStatistics",
+    "compute_clipped_beta",
+    "correlation",
+    "estimate_s4_pair",
+    "fixed_median",
+    "phi_and_half_life",
+    "population_sigma",
+    "spread_statistics",
+]

--- a/research/nautilus_scalping/rob974_h3_s4.py
+++ b/research/nautilus_scalping/rob974_h3_s4.py
@@ -12,7 +12,14 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 
 from rob974_features import FOUR_HOUR_MS, MINUTE_MS, CommonSnapshot
-from rob974_h3_manifest import PAIRS, SYMBOLS, S4Config, assert_registered_config
+from rob974_h3_manifest import (
+    PAIRS,
+    S4_GENERATOR_REJECTION_TAXONOMY,
+    S4_NO_SIGNAL_TAXONOMY,
+    SYMBOLS,
+    S4Config,
+    assert_registered_config,
+)
 from rob974_h3_s3 import EmitWindow, FeatureContext, expected_decision_closes
 
 PAIR_ORDER: tuple[str, ...] = PAIRS
@@ -21,14 +28,7 @@ _PAIR_SYMBOLS = {
     "XRP-SOL": ("XRPUSDT", "SOLUSDT"),
     "DOGE-SOL": ("DOGEUSDT", "SOLUSDT"),
 }
-S4_ESTIMATION_REASONS: tuple[str, ...] = (
-    "missing_required_context",
-    "degenerate_beta_market_variance",
-    "degenerate_rho_variance",
-    "degenerate_phi_denominator",
-    "phi_not_in_open_unit_interval",
-    "nonfinite_required_input",
-)
+S4_ESTIMATION_REASONS: tuple[str, ...] = S4_NO_SIGNAL_TAXONOMY[:6]
 
 
 def _int(value: object, name: str) -> int:
@@ -586,21 +586,8 @@ def estimate_s4_pair(
     )
 
 
-S4_NO_SIGNAL_REASONS: tuple[str, ...] = S4_ESTIMATION_REASONS + (
-    "convergence_sign",
-    "prior_z_entry",
-    "current_z_entry",
-    "convergence_fraction",
-    "rho",
-    "half_life",
-    "beta_stability",
-    "absolute_distance",
-    "distance_to_tp",
-    "historical_notional_feasibility",
-)
-S4_GENERATOR_REJECTION_REASONS: tuple[str, ...] = (
-    "simultaneous_pair_arbitration_loser",
-)
+S4_NO_SIGNAL_REASONS: tuple[str, ...] = S4_NO_SIGNAL_TAXONOMY
+S4_GENERATOR_REJECTION_REASONS: tuple[str, ...] = S4_GENERATOR_REJECTION_TAXONOMY
 HISTORICAL_NOTIONAL_ASSUMPTION = "frozen_continuous_6_to_10_usd_per_leg"
 
 
@@ -1051,11 +1038,20 @@ class S4UnitDecision:
 
 @dataclass(frozen=True, slots=True)
 class S4GeneratorOutput:
+    strategy: str
+    config_id: str
     decisions: tuple[S4UnitDecision, ...]
     accepted: tuple[S4Candidate, ...]
     rejected: tuple[S4RejectedCandidate, ...]
 
     def __post_init__(self) -> None:
+        if _str(self.strategy, "strategy") != "S4":
+            raise ValueError("S4 generator output strategy must be S4")
+        _str(self.config_id, "config_id")
+        if any(item.config_id != self.config_id for item in self.accepted) or any(
+            item.candidate.config_id != self.config_id for item in self.rejected
+        ):
+            raise ValueError("S4 generator output config mismatch")
         if type(self.decisions) is not tuple or type(self.accepted) is not tuple:
             raise TypeError("generator output containers must be tuples")
         if type(self.rejected) is not tuple:
@@ -1150,7 +1146,9 @@ def generate_s4_global(
                         loser.reason,
                     )
                 )
-    return S4GeneratorOutput(tuple(decisions), tuple(accepted), tuple(rejected))
+    return S4GeneratorOutput(
+        "S4", config.config_id, tuple(decisions), tuple(accepted), tuple(rejected)
+    )
 
 
 __all__ = [

--- a/research/nautilus_scalping/rob974_h3_s4.py
+++ b/research/nautilus_scalping/rob974_h3_s4.py
@@ -8,11 +8,12 @@ cannot consume t betas, weights, closes, median, MAD, or scale.
 from __future__ import annotations
 
 import math
+from collections.abc import Sequence
 from dataclasses import dataclass
 
-from rob974_features import FOUR_HOUR_MS, CommonSnapshot
+from rob974_features import FOUR_HOUR_MS, MINUTE_MS, CommonSnapshot
 from rob974_h3_manifest import PAIRS, SYMBOLS, S4Config, assert_registered_config
-from rob974_h3_s3 import FeatureContext
+from rob974_h3_s3 import EmitWindow, FeatureContext, expected_decision_closes
 
 PAIR_ORDER: tuple[str, ...] = PAIRS
 _PAIR_SYMBOLS = {
@@ -585,17 +586,599 @@ def estimate_s4_pair(
     )
 
 
+S4_NO_SIGNAL_REASONS: tuple[str, ...] = S4_ESTIMATION_REASONS + (
+    "convergence_sign",
+    "prior_z_entry",
+    "current_z_entry",
+    "convergence_fraction",
+    "rho",
+    "half_life",
+    "beta_stability",
+    "absolute_distance",
+    "distance_to_tp",
+    "historical_notional_feasibility",
+)
+S4_GENERATOR_REJECTION_REASONS: tuple[str, ...] = (
+    "simultaneous_pair_arbitration_loser",
+)
+HISTORICAL_NOTIONAL_ASSUMPTION = "frozen_continuous_6_to_10_usd_per_leg"
+
+
+def s4_risk_distances(config: S4Config, sigma_pair: float) -> tuple[float, float]:
+    if type(config) is not S4Config:
+        raise TypeError("config must be exact registered S4Config")
+    assert_registered_config(config)
+    _float(sigma_pair, "sigma_pair")
+    if sigma_pair < 0.0:
+        raise ValueError("sigma_pair must not be negative")
+    d_sl = min(max(config.k_SL * sigma_pair, 0.008), 0.016)
+    d_tp = max(0.0068, config.R_TP * d_sl)
+    return d_sl, d_tp
+
+
+@dataclass(frozen=True, slots=True)
+class HistoricalNotional:
+    G_min: float
+    G_max: float
+    G: float | None
+
+    def __post_init__(self) -> None:
+        _float(self.G_min, "G_min")
+        _float(self.G_max, "G_max")
+        if self.G is not None:
+            _float(self.G, "G")
+            if self.G != self.G_min or self.G_min > self.G_max:
+                raise ValueError("feasible historical G must be exact G_min")
+        elif self.G_min <= self.G_max:
+            raise ValueError("feasible historical sizing cannot omit G")
+
+
+def historical_notional(weight_a: float, weight_b: float) -> HistoricalNotional:
+    _float(weight_a, "weight_a")
+    _float(weight_b, "weight_b")
+    if weight_a <= 0.0 or weight_b <= 0.0:
+        raise ValueError("historical weights must be positive")
+    g_min = max(6.0 / weight_a, 6.0 / weight_b)
+    g_max = min(10.0 / weight_a, 10.0 / weight_b)
+    if not math.isfinite(g_min) or not math.isfinite(g_max):
+        raise ValueError("nonfinite historical notional")
+    return HistoricalNotional(g_min, g_max, g_min if g_min <= g_max else None)
+
+
+@dataclass(frozen=True, slots=True)
+class S4Candidate:
+    """Dedicated H3 historical pair intent; it is never split into two intents."""
+
+    strategy: str
+    config_id: str
+    decision_ts: int
+    pair: str
+    side: str
+    symbol_a: str
+    symbol_b: str
+    side_a: str
+    side_b: str
+    beta_a: float
+    beta_b: float
+    weight_a: float
+    weight_b: float
+    mu: float
+    mad: float
+    effective_mad_scale: float
+    observed_z: float
+    prior_observed_z: float
+    D_fraction: float
+    D_bps: float
+    rho: float
+    half_life_4h_bars: float
+    beta_stability: float
+    sigma_pair_risk: float
+    observed_pair_return_fraction: float
+    gross_notional_usd: float
+    notional_a_usd: float
+    notional_b_usd: float
+    d_SL: float
+    d_TP: float
+    historical_notional_assumption: str
+    historical_eligibility: bool
+    historical_eligibility_authority: str
+    volatility_percentile: None
+    volatility_percentile_provenance: str
+    entry_tick_ts: int
+    entry_deadline_ts: int
+    max_hold_4h_bars: int
+    leg_a_order_id: None
+    leg_b_order_id: None
+    leg_a_fill_id: None
+    leg_b_fill_id: None
+    pair_executor_provenance: str
+
+    def __post_init__(self) -> None:
+        if _str(self.strategy, "strategy") != "S4":
+            raise ValueError("S4 candidate strategy must be S4")
+        _str(self.config_id, "config_id")
+        _int(self.decision_ts, "decision_ts")
+        if _str(self.pair, "pair") not in PAIR_ORDER:
+            raise ValueError("candidate pair outside frozen order")
+        if (self.symbol_a, self.symbol_b) != _PAIR_SYMBOLS[self.pair]:
+            raise ValueError("candidate pair symbol order drift")
+        if _str(self.side, "side") not in (
+            "short_a_long_b",
+            "long_a_short_b",
+        ):
+            raise ValueError("invalid pair side")
+        if (self.side_a, self.side_b) not in (("short", "long"), ("long", "short")):
+            raise ValueError("invalid frozen leg directions")
+        if self.side == "short_a_long_b" and (self.side_a, self.side_b) != (
+            "short",
+            "long",
+        ):
+            raise ValueError("positive-z direction mismatch")
+        if self.side == "long_a_short_b" and (self.side_a, self.side_b) != (
+            "long",
+            "short",
+        ):
+            raise ValueError("negative-z direction mismatch")
+        for name in (
+            "beta_a",
+            "beta_b",
+            "weight_a",
+            "weight_b",
+            "mu",
+            "mad",
+            "effective_mad_scale",
+            "observed_z",
+            "prior_observed_z",
+            "D_fraction",
+            "D_bps",
+            "rho",
+            "half_life_4h_bars",
+            "beta_stability",
+            "sigma_pair_risk",
+            "observed_pair_return_fraction",
+            "gross_notional_usd",
+            "notional_a_usd",
+            "notional_b_usd",
+            "d_SL",
+            "d_TP",
+        ):
+            _float(getattr(self, name), name)
+        if (
+            _str(self.historical_notional_assumption, "historical_notional_assumption")
+            != HISTORICAL_NOTIONAL_ASSUMPTION
+        ):
+            raise ValueError("historical notional authority drift")
+        if (
+            type(self.historical_eligibility) is not bool
+            or not self.historical_eligibility
+        ):
+            raise ValueError("S4 requires frozen historical eligibility")
+        if (
+            _str(
+                self.historical_eligibility_authority,
+                "historical_eligibility_authority",
+            )
+            != "rob974_h1_parent_manifest_selected_universe"
+        ):
+            raise ValueError("historical eligibility authority drift")
+        if self.volatility_percentile is not None:
+            raise ValueError("S4 volatility percentile must be exactly null")
+        if (
+            _str(
+                self.volatility_percentile_provenance,
+                "volatility_percentile_provenance",
+            )
+            != "not_defined_for_s4"
+        ):
+            raise ValueError("S4 volatility provenance drift")
+        _int(self.entry_tick_ts, "entry_tick_ts")
+        _int(self.entry_deadline_ts, "entry_deadline_ts")
+        _int(self.max_hold_4h_bars, "max_hold_4h_bars")
+        if self.entry_tick_ts != self.decision_ts:
+            raise ValueError("entry tick must equal decision close")
+        if self.entry_deadline_ts != self.decision_ts + MINUTE_MS:
+            raise ValueError("entry deadline must bound the exact next minute")
+        if self.max_hold_4h_bars != 9:
+            raise ValueError("S4 maximum hold is frozen at nine 4h bars")
+        if self.notional_a_usd != self.weight_a * self.gross_notional_usd or (
+            self.notional_b_usd != self.weight_b * self.gross_notional_usd
+        ):
+            raise ValueError("leg notionals must use frozen weights and gross G")
+        if not (
+            6.0 <= self.notional_a_usd <= 10.0 and 6.0 <= self.notional_b_usd <= 10.0
+        ):
+            raise ValueError("leg notionals must remain in the frozen $6-10 range")
+        if any(
+            value is not None
+            for value in (
+                self.leg_a_order_id,
+                self.leg_b_order_id,
+                self.leg_a_fill_id,
+                self.leg_b_fill_id,
+            )
+        ):
+            raise ValueError("H3 historical order/fill identifiers must be null")
+        if (
+            _str(self.pair_executor_provenance, "pair_executor_provenance")
+            != "not_evaluated_h3_generator"
+        ):
+            raise ValueError("pair executor evidence must not be fabricated")
+
+    @property
+    def signal_ts(self) -> int:
+        return self.decision_ts
+
+    @property
+    def identity(self) -> tuple[str, str, int, str, str]:
+        return (
+            self.strategy,
+            self.config_id,
+            self.decision_ts,
+            self.pair,
+            self.side,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class S4GateOutcome:
+    side: str | None
+    candidate: S4Candidate | None
+    no_signal_reason: str | None
+
+    def __post_init__(self) -> None:
+        if self.side is not None and self.side not in (
+            "short_a_long_b",
+            "long_a_short_b",
+        ):
+            raise ValueError("invalid S4 outcome side")
+        if self.candidate is not None and type(self.candidate) is not S4Candidate:
+            raise TypeError("candidate must be exact S4Candidate or None")
+        if (self.candidate is None) == (self.no_signal_reason is None):
+            raise ValueError("gate outcome must contain exactly candidate or reason")
+        if self.no_signal_reason is not None and (
+            type(self.no_signal_reason) is not str
+            or self.no_signal_reason not in S4_NO_SIGNAL_REASONS
+        ):
+            raise ValueError("unknown S4 no-signal reason")
+
+
+def _gate_reject(reason: str, side: str | None = None) -> S4GateOutcome:
+    return S4GateOutcome(side, None, reason)
+
+
+def evaluate_s4_gates(estimate: S4Estimate, config: S4Config) -> S4GateOutcome:
+    """Evaluate convergence and registered S4 eligibility in frozen order."""
+    if type(estimate) is not S4Estimate:
+        raise TypeError("estimate must be exact S4Estimate")
+    if type(config) is not S4Config:
+        raise TypeError("config must be exact registered S4Config")
+    assert_registered_config(config)
+    if estimate.config_id != config.config_id:
+        raise ValueError("estimate/config identity mismatch")
+
+    if (
+        estimate.z == 0.0
+        or estimate.z_prior == 0.0
+        or math.copysign(1.0, estimate.z) != math.copysign(1.0, estimate.z_prior)
+    ):
+        return _gate_reject("convergence_sign")
+    side = "short_a_long_b" if estimate.z > 0.0 else "long_a_short_b"
+    if abs(estimate.z_prior) < config.z_entry:
+        return _gate_reject("prior_z_entry", side)
+    if abs(estimate.z) < config.z_entry:
+        return _gate_reject("current_z_entry", side)
+    if abs(estimate.z) > 0.90 * abs(estimate.z_prior):
+        return _gate_reject("convergence_fraction", side)
+    if estimate.rho < 0.60:
+        return _gate_reject("rho", side)
+    if not 2.0 <= estimate.half_life_4h_bars <= 12.0:
+        return _gate_reject("half_life", side)
+    if estimate.beta_stability > 0.20:
+        return _gate_reject("beta_stability", side)
+    if estimate.D_bps < float(config.d_min_bp):
+        return _gate_reject("absolute_distance", side)
+    d_sl, d_tp = s4_risk_distances(config, estimate.sigma_pair)
+    if estimate.D_fraction < 1.25 * d_tp:
+        return _gate_reject("distance_to_tp", side)
+    sizing = historical_notional(estimate.weight_a, estimate.weight_b)
+    if sizing.G is None:
+        return _gate_reject("historical_notional_feasibility", side)
+
+    side_a, side_b = (
+        ("short", "long") if side == "short_a_long_b" else ("long", "short")
+    )
+    return S4GateOutcome(
+        side,
+        S4Candidate(
+            "S4",
+            config.config_id,
+            estimate.decision_ts,
+            estimate.pair,
+            side,
+            estimate.symbol_a,
+            estimate.symbol_b,
+            side_a,
+            side_b,
+            estimate.beta_a,
+            estimate.beta_b,
+            estimate.weight_a,
+            estimate.weight_b,
+            estimate.mu,
+            estimate.mad,
+            estimate.effective_mad_scale,
+            estimate.z,
+            estimate.z_prior,
+            estimate.D_fraction,
+            estimate.D_bps,
+            estimate.rho,
+            estimate.half_life_4h_bars,
+            estimate.beta_stability,
+            estimate.sigma_pair,
+            estimate.pair_return_fraction,
+            sizing.G,
+            estimate.weight_a * sizing.G,
+            estimate.weight_b * sizing.G,
+            d_sl,
+            d_tp,
+            HISTORICAL_NOTIONAL_ASSUMPTION,
+            True,
+            "rob974_h1_parent_manifest_selected_universe",
+            None,
+            "not_defined_for_s4",
+            estimate.decision_ts,
+            estimate.decision_ts + MINUTE_MS,
+            9,
+            None,
+            None,
+            None,
+            None,
+            "not_evaluated_h3_generator",
+        ),
+        None,
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class S4RejectedCandidate:
+    candidate: S4Candidate
+    reason: str
+
+    def __post_init__(self) -> None:
+        if type(self.candidate) is not S4Candidate:
+            raise TypeError("rejected candidate must be exact S4Candidate")
+        if (
+            type(self.reason) is not str
+            or self.reason not in S4_GENERATOR_REJECTION_REASONS
+        ):
+            raise ValueError("unknown S4 generator-rejection reason")
+
+
+@dataclass(frozen=True, slots=True)
+class S4ArbitrationResult:
+    winner: S4Candidate
+    rejected: tuple[S4RejectedCandidate, ...]
+
+    def __post_init__(self) -> None:
+        if type(self.winner) is not S4Candidate:
+            raise TypeError("winner must be exact S4Candidate")
+        if type(self.rejected) is not tuple or any(
+            type(item) is not S4RejectedCandidate for item in self.rejected
+        ):
+            raise TypeError("rejected must be tuple of exact records")
+        rejected_ids = tuple(item.candidate.identity for item in self.rejected)
+        if self.winner.identity in rejected_ids or len(rejected_ids) != len(
+            set(rejected_ids)
+        ):
+            raise ValueError("accepted/rejected pair collision")
+
+
+def _s4_rank(candidate: S4Candidate) -> tuple[float, float, float, str]:
+    return (
+        -candidate.D_fraction,
+        -abs(candidate.observed_z),
+        -candidate.rho,
+        candidate.pair,
+    )
+
+
+def arbitrate_s4_candidates(
+    candidates: Sequence[S4Candidate],
+) -> S4ArbitrationResult:
+    if not isinstance(candidates, Sequence):
+        raise TypeError("candidates must be a sequence")
+    exact = tuple(candidates)
+    if not exact:
+        raise ValueError("cannot arbitrate an empty pair candidate set")
+    if any(type(candidate) is not S4Candidate for candidate in exact):
+        raise TypeError("candidates must contain exact S4Candidate values")
+    scope = {
+        (candidate.strategy, candidate.config_id, candidate.decision_ts)
+        for candidate in exact
+    }
+    if len(scope) != 1:
+        raise ValueError("simultaneous pair arbitration scope mismatch")
+    identities = tuple(candidate.identity for candidate in exact)
+    if len(identities) != len(set(identities)):
+        raise ValueError("duplicate simultaneous pair candidate identity")
+    ordered = tuple(sorted(exact, key=_s4_rank))
+    return S4ArbitrationResult(
+        ordered[0],
+        tuple(
+            S4RejectedCandidate(candidate, "simultaneous_pair_arbitration_loser")
+            for candidate in ordered[1:]
+        ),
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class S4UnitDecision:
+    decision_ts: int
+    pair: str
+    status: str
+    side: str | None
+    candidate: S4Candidate | None
+    no_signal_reason: str | None
+    generator_rejection_reason: str | None
+
+    def __post_init__(self) -> None:
+        _int(self.decision_ts, "decision_ts")
+        if _str(self.pair, "pair") not in PAIR_ORDER:
+            raise ValueError("decision pair outside frozen order")
+        if _str(self.status, "status") not in (
+            "NO_SIGNAL",
+            "GENERATOR_REJECTED",
+            "GENERATOR_ACCEPTED",
+        ):
+            raise ValueError("unknown S4 unit status")
+        if self.side is not None and self.side not in (
+            "short_a_long_b",
+            "long_a_short_b",
+        ):
+            raise ValueError("invalid decision side")
+        if self.candidate is not None and type(self.candidate) is not S4Candidate:
+            raise TypeError("candidate must be exact S4Candidate or None")
+        if self.no_signal_reason is not None and (
+            type(self.no_signal_reason) is not str
+            or self.no_signal_reason not in S4_NO_SIGNAL_REASONS
+        ):
+            raise ValueError("unknown no-signal reason")
+        if self.generator_rejection_reason is not None and (
+            type(self.generator_rejection_reason) is not str
+            or self.generator_rejection_reason not in S4_GENERATOR_REJECTION_REASONS
+        ):
+            raise ValueError("unknown generator-rejection reason")
+
+
+@dataclass(frozen=True, slots=True)
+class S4GeneratorOutput:
+    decisions: tuple[S4UnitDecision, ...]
+    accepted: tuple[S4Candidate, ...]
+    rejected: tuple[S4RejectedCandidate, ...]
+
+    def __post_init__(self) -> None:
+        if type(self.decisions) is not tuple or type(self.accepted) is not tuple:
+            raise TypeError("generator output containers must be tuples")
+        if type(self.rejected) is not tuple:
+            raise TypeError("generator rejected container must be tuple")
+        if any(type(item) is not S4UnitDecision for item in self.decisions):
+            raise TypeError("decisions must contain exact S4UnitDecision")
+        if any(type(item) is not S4Candidate for item in self.accepted):
+            raise TypeError("accepted must contain exact S4Candidate")
+        if any(type(item) is not S4RejectedCandidate for item in self.rejected):
+            raise TypeError("rejected must contain exact S4RejectedCandidate")
+        accepted_ids = {item.identity for item in self.accepted}
+        rejected_ids = {item.candidate.identity for item in self.rejected}
+        if accepted_ids & rejected_ids:
+            raise ValueError("accepted/rejected pair collision")
+
+
+def generate_s4_global(
+    feature_context: FeatureContext,
+    emit_window: EmitWindow,
+    config: S4Config,
+) -> S4GeneratorOutput:
+    """Run one historical S4 invocation across all expected closes/pairs."""
+    if type(feature_context) is not FeatureContext:
+        raise TypeError("feature_context must be exact FeatureContext")
+    if type(config) is not S4Config:
+        raise TypeError("config must be exact registered S4Config")
+    assert_registered_config(config)
+    decisions: list[S4UnitDecision] = []
+    accepted: list[S4Candidate] = []
+    rejected: list[S4RejectedCandidate] = []
+    for decision_ts in expected_decision_closes(emit_window):
+        outcomes: dict[str, S4GateOutcome] = {}
+        candidates: list[S4Candidate] = []
+        for pair in PAIR_ORDER:
+            estimation = estimate_s4_pair(feature_context, config, decision_ts, pair)
+            if estimation.estimate is None:
+                if estimation.rejection_reason is None:
+                    raise AssertionError("invalid S4 estimation outcome")
+                outcome = _gate_reject(estimation.rejection_reason)
+            else:
+                outcome = evaluate_s4_gates(estimation.estimate, config)
+            outcomes[pair] = outcome
+            if outcome.candidate is not None:
+                candidates.append(outcome.candidate)
+        arbitration = arbitrate_s4_candidates(candidates) if candidates else None
+        winner_id = arbitration.winner.identity if arbitration is not None else None
+        loser_by_id = (
+            {item.candidate.identity: item for item in arbitration.rejected}
+            if arbitration is not None
+            else {}
+        )
+        if arbitration is not None:
+            accepted.append(arbitration.winner)
+            rejected.extend(arbitration.rejected)
+        for pair in PAIR_ORDER:
+            outcome = outcomes[pair]
+            candidate = outcome.candidate
+            if candidate is None:
+                decisions.append(
+                    S4UnitDecision(
+                        decision_ts,
+                        pair,
+                        "NO_SIGNAL",
+                        outcome.side,
+                        None,
+                        outcome.no_signal_reason,
+                        None,
+                    )
+                )
+            elif candidate.identity == winner_id:
+                decisions.append(
+                    S4UnitDecision(
+                        decision_ts,
+                        pair,
+                        "GENERATOR_ACCEPTED",
+                        candidate.side,
+                        candidate,
+                        None,
+                        None,
+                    )
+                )
+            else:
+                loser = loser_by_id[candidate.identity]
+                decisions.append(
+                    S4UnitDecision(
+                        decision_ts,
+                        pair,
+                        "GENERATOR_REJECTED",
+                        candidate.side,
+                        candidate,
+                        None,
+                        loser.reason,
+                    )
+                )
+    return S4GeneratorOutput(tuple(decisions), tuple(accepted), tuple(rejected))
+
+
 __all__ = [
+    "HISTORICAL_NOTIONAL_ASSUMPTION",
+    "HistoricalNotional",
     "PAIR_ORDER",
+    "S4ArbitrationResult",
+    "S4Candidate",
     "S4Estimate",
     "S4EstimationOutcome",
+    "S4GateOutcome",
+    "S4GeneratorOutput",
+    "S4RejectedCandidate",
+    "S4UnitDecision",
     "S4_ESTIMATION_REASONS",
+    "S4_GENERATOR_REJECTION_REASONS",
+    "S4_NO_SIGNAL_REASONS",
     "SpreadStatistics",
+    "arbitrate_s4_candidates",
     "compute_clipped_beta",
     "correlation",
     "estimate_s4_pair",
+    "evaluate_s4_gates",
     "fixed_median",
+    "generate_s4_global",
+    "historical_notional",
     "phi_and_half_life",
     "population_sigma",
+    "s4_risk_distances",
     "spread_statistics",
 ]

--- a/research/nautilus_scalping/rob974_h3_smoke.py
+++ b/research/nautilus_scalping/rob974_h3_smoke.py
@@ -1,0 +1,904 @@
+"""Persisted fake-free ROB-974 H3 generator smoke and frozen-fold command.
+
+The synthetic path deliberately traverses the real ROB-941 writer, manifest,
+Parquet shards and offline loader before the merged ROB-978 H1 feature plane
+and the H3 global generators.  It stops at immutable generator evidence: no
+engine, funding gate, order/fill simulation, runtime service, or corpus write
+is reachable from the frozen-fold command.
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import hashlib
+import json
+import math
+from dataclasses import dataclass
+from pathlib import Path
+
+import canonical_hash
+import rob941_frozen_scope as frozen
+import rob941_gaps as gaps
+import rob941_kline_schema as schema
+import rob941_offline_loader as loader
+import rob941_persistence as persistence
+from funding_oi_archive import FundingRow
+from rob941_manifest import (
+    ArchiveProvenance,
+    CorpusManifest,
+    SymbolEligibility,
+    SymbolFundingManifest,
+    SymbolKlineManifest,
+)
+from rob944_folds import generate_frozen_fold_schedule
+from rob974_features import (
+    FOUR_HOUR_MS,
+    MINUTE_MS,
+    MinuteBar,
+    build_complete_4h,
+    symbol_features,
+    synchronized_features,
+)
+from rob974_h3_evidence import (
+    UniqueGeneratorEvidence,
+    build_unique_generator_evidence,
+)
+from rob974_h3_manifest import (
+    RESEARCH_DOCUMENT_SHA256,
+    S3_GENERATOR_REJECTION_TAXONOMY,
+    S3_NO_SIGNAL_TAXONOMY,
+    S3_STRATEGY_CONTRACT,
+    S4_GENERATOR_REJECTION_TAXONOMY,
+    S4_NO_SIGNAL_TAXONOMY,
+    S4_STRATEGY_CONTRACT,
+    SYMBOLS,
+    S3Config,
+    S4Config,
+    get_config,
+)
+from rob974_h3_s3 import EmitWindow, FeatureContext, S3Candidate, generate_s3_global
+from rob974_h3_s4 import S4Candidate, generate_s4_global
+from rob974_lineage import DerivedManifest
+
+_SMOKE_4H_BARS = 202
+_SMOKE_MINUTES = _SMOKE_4H_BARS * 240
+_GAP_BAR_INDEX = 10
+_GAP_MINUTE_OFFSET = 100
+_S3_SMOKE_CONFIG_ID = "S3-05"
+_S4_SMOKE_CONFIG_ID = "S4-01"
+_SMOKE_WINDOW_ID = "rob941-shaped-persisted-synthetic"
+
+_WORKTREE = Path("/Users/mgh3326/work/auto_trader.rob-980")
+_UV = Path("/Users/mgh3326/.local/bin/uv")
+_FROZEN_MANIFEST = (
+    _WORKTREE
+    / "research/nautilus_scalping/data_manifests/rob941_corpus_manifest.v1.json"
+)
+_FROZEN_DATA_ROOT = _WORKTREE / "research/nautilus_scalping/data"
+_THIS_FILE = _WORKTREE / "research/nautilus_scalping/rob974_h3_smoke.py"
+
+
+def _plain(value: object) -> object:
+    if dataclasses.is_dataclass(value) and not isinstance(value, type):
+        return {
+            field.name: _plain(getattr(value, field.name))
+            for field in dataclasses.fields(value)
+        }
+    if type(value) is tuple:
+        return [_plain(item) for item in value]
+    if type(value) is list:
+        return [_plain(item) for item in value]
+    if type(value) is dict:
+        return {key: _plain(item) for key, item in value.items()}
+    if value is None or type(value) in (str, int, float, bool):
+        return value
+    raise TypeError(f"unsupported smoke payload type {type(value).__name__}")
+
+
+@dataclass(frozen=True, slots=True)
+class StrategySmokeResult:
+    strategy: str
+    config_id: str
+    evidence: UniqueGeneratorEvidence
+    accepted_payloads: tuple[S3Candidate | S4Candidate, ...]
+
+    def __post_init__(self) -> None:
+        if self.strategy not in ("S3", "S4"):
+            raise ValueError("smoke strategy must be S3 or S4")
+        if type(self.config_id) is not str:
+            raise TypeError("smoke config_id must be built-in str")
+        if type(self.evidence) is not UniqueGeneratorEvidence:
+            raise TypeError("smoke evidence must be exact UniqueGeneratorEvidence")
+        if (
+            self.evidence.strategy != self.strategy
+            or self.evidence.config_id != self.config_id
+        ):
+            raise ValueError("smoke strategy/evidence mismatch")
+        expected = S3Candidate if self.strategy == "S3" else S4Candidate
+        if type(self.accepted_payloads) is not tuple or any(
+            type(candidate) is not expected for candidate in self.accepted_payloads
+        ):
+            raise TypeError("smoke accepted payload type mismatch")
+        if len(self.accepted_payloads) != self.evidence.generator_accepted:
+            raise ValueError("smoke accepted payload count mismatch")
+
+    def to_payload(self) -> dict[str, object]:
+        evidence = self.evidence
+        return {
+            "config_id": self.config_id,
+            "global_invocation_count": evidence.global_invocation_count,
+            "evaluated_decision_units": evidence.evaluated_decision_units,
+            "no_signal": evidence.no_signal,
+            "candidate": evidence.candidate,
+            "generator_rejected": evidence.generator_rejected,
+            "generator_accepted": evidence.generator_accepted,
+            "outcome_histogram": dict(evidence.outcome_histogram),
+            "no_signal_reason_histogram": dict(evidence.no_signal_reason_histogram),
+            "generator_rejection_reason_histogram": dict(
+                evidence.generator_rejection_reason_histogram
+            ),
+            "candidate_side_histogram": dict(evidence.candidate_side_histogram),
+            "unique_evidence_hash": evidence.content_hash,
+            "accepted_payloads": _plain(self.accepted_payloads),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class GeneratorSmokeResult:
+    generator_smoke: str
+    actual_h2_engine_integration: str
+    persisted_root: str
+    strategies: tuple[StrategySmokeResult, StrategySmokeResult]
+    gap_symbol: str
+    gap_close: int
+    recovery_close: int
+    gap_close_absent: bool
+    other_symbol_gap_close_present: bool
+    recovery_close_present: bool
+    mapping_permutation_hashes_match: bool
+    feature_hash: str
+    lineage_hash: str
+    content_hash: str
+
+    def __post_init__(self) -> None:
+        if self.generator_smoke != "PASS":
+            raise ValueError("generator smoke must be PASS")
+        if self.actual_h2_engine_integration != "NOT_EVALUATED":
+            raise ValueError("H2 integration must remain explicitly unevaluated")
+        if not Path(self.persisted_root).is_absolute():
+            raise ValueError("persisted smoke root must be absolute")
+        if tuple(item.strategy for item in self.strategies) != ("S3", "S4"):
+            raise ValueError("smoke strategies must use frozen S3/S4 order")
+        if self.gap_symbol != "SOLUSDT":
+            raise ValueError("localized smoke gap symbol drift")
+        for name in ("gap_close", "recovery_close"):
+            if type(getattr(self, name)) is not int:
+                raise TypeError(f"{name} must be built-in int")
+        for name in (
+            "gap_close_absent",
+            "other_symbol_gap_close_present",
+            "recovery_close_present",
+            "mapping_permutation_hashes_match",
+        ):
+            if type(getattr(self, name)) is not bool:
+                raise TypeError(f"{name} must be bool")
+        for name in ("feature_hash", "lineage_hash", "content_hash"):
+            value = getattr(self, name)
+            if (
+                type(value) is not str
+                or len(value) != 64
+                or any(char not in "0123456789abcdef" for char in value)
+            ):
+                raise ValueError(f"{name} must be lowercase SHA-256")
+
+    def to_payload(self, *, include_root: bool = True) -> dict[str, object]:
+        payload: dict[str, object] = {
+            "schema_version": "rob974-h3-generator-smoke-v1",
+            "generator_smoke": self.generator_smoke,
+            "actual_h2_engine_integration": self.actual_h2_engine_integration,
+            "authorities": {
+                "research_sha256": RESEARCH_DOCUMENT_SHA256,
+                "s3_contract_hash": S3_STRATEGY_CONTRACT.contract_hash,
+                "s4_contract_hash": S4_STRATEGY_CONTRACT.contract_hash,
+            },
+            "window": {
+                "fold_or_full_window": _SMOKE_WINDOW_ID,
+                "phase": "offline_smoke",
+            },
+            "universe": list(SYMBOLS),
+            "gap": {
+                "symbol": self.gap_symbol,
+                "close_ts": self.gap_close,
+                "recovery_close_ts": self.recovery_close,
+                "gap_close_absent": self.gap_close_absent,
+                "other_symbol_gap_close_present": self.other_symbol_gap_close_present,
+                "recovery_close_present": self.recovery_close_present,
+            },
+            "mapping_permutation_hashes_match": (self.mapping_permutation_hashes_match),
+            "feature_hash": self.feature_hash,
+            "lineage_hash": self.lineage_hash,
+            "content_hash": self.content_hash,
+            "strategies": {
+                item.strategy: item.to_payload() for item in self.strategies
+            },
+        }
+        if include_root:
+            payload["persisted_root"] = self.persisted_root
+        return payload
+
+    def to_json_bytes(self) -> bytes:
+        return (
+            json.dumps(
+                self.to_payload(),
+                ensure_ascii=False,
+                sort_keys=True,
+                separators=(",", ":"),
+            )
+            + "\n"
+        ).encode("utf-8")
+
+
+def _archive(root: Path, symbol: str, kind: str) -> ArchiveProvenance:
+    data = f"ROB980 persisted synthetic {symbol} {kind}".encode()
+    local = persistence.write_raw_archive(root, symbol, kind, 2025, 7, data)
+    digest = hashlib.sha256(data).hexdigest()
+    return ArchiveProvenance(
+        "https://example.invalid/" + local,
+        "https://example.invalid/checksum",
+        digest,
+        local,
+    )
+
+
+def _market_returns() -> tuple[float, ...]:
+    daily = (0.018, -0.016, 0.014, -0.012, 0.010, -0.014)
+    scales = (0.72, 0.86, 1.00, 1.14, 1.28, 1.42)
+    values = [0.0]
+    for index in range(1, _SMOKE_4H_BARS):
+        values.append(daily[index % 6] * scales[(index // 6) % len(scales)])
+    states = _residual_cycle()
+    residual_returns = tuple(states[index] - states[index - 1] for index in range(60))
+    cycle = [
+        (0.024, -0.018, 0.020, -0.016, 0.022, -0.014)[index % 6] for index in range(48)
+    ] + [
+        0.035,
+        -0.008,
+        0.034,
+        -0.007,
+        0.033,
+        -0.006,
+        0.032,
+        -0.005,
+        0.030,
+        -0.050,
+        0.020,
+        0.018,
+    ]
+    projection = math.fsum(
+        residual * market
+        for residual, market in zip(residual_returns, cycle, strict=True)
+    ) / math.fsum(residual_returns[index] ** 2 for index in range(48))
+    for index in range(48):
+        cycle[index] -= projection * residual_returns[index]
+    values[80] = cycle[58]
+    values[81] = cycle[59]
+    values[82:142] = cycle
+    values[142:202] = cycle
+    return tuple(values)
+
+
+def _residual_cycle() -> tuple[float, ...]:
+    values = [
+        0.008 * math.sin(2.0 * math.pi * float(index) / 12.0) for index in range(60)
+    ]
+    values[-6:] = [0.025, 0.035, 0.040, 0.060, 0.050, 0.040]
+    return tuple(values)
+
+
+def _residual_states() -> tuple[float, ...]:
+    innovations = (0.0024, -0.0016, 0.0011, -0.0020, 0.0018, -0.0012)
+    values = [0.0]
+    for index in range(1, _SMOKE_4H_BARS):
+        values.append(0.82 * values[-1] + innovations[index % len(innovations)])
+    cycle = _residual_cycle()
+    values[80] = cycle[58]
+    values[81] = cycle[59]
+    values[82:142] = cycle
+    values[142:202] = cycle
+    return tuple(values)
+
+
+def _target_closes(symbol: str) -> tuple[float, ...]:
+    bases = {
+        "BTCUSDT": 60_000.0,
+        "XRPUSDT": 0.50,
+        "DOGEUSDT": 0.20,
+        "SOLUSDT": 150.0,
+    }
+    residual_loadings = {
+        "BTCUSDT": 0.0,
+        "XRPUSDT": 1.0,
+        "DOGEUSDT": 0.0,
+        "SOLUSDT": -1.0,
+    }
+    market_level = 0.0
+    closes: list[float] = []
+    for market_return, residual in zip(
+        _market_returns(), _residual_states(), strict=True
+    ):
+        market_level += market_return
+        closes.append(
+            bases[symbol]
+            * math.exp(market_level + residual_loadings[symbol] * residual)
+        )
+    return tuple(closes)
+
+
+def _normalized_rows(
+    symbol: str, symbol_index: int
+) -> tuple[schema.NormalizedKline, ...]:
+    targets = _target_closes(symbol)
+    previous = targets[0] / math.exp(_market_returns()[0])
+    rows: list[schema.NormalizedKline] = []
+    for bar_index, target in enumerate(targets):
+        log_delta = math.log(target / previous)
+        wick = (
+            0.040
+            if (bar_index <= 180 and bar_index % 12 == 0) or bar_index == 190
+            else (
+                0.014
+                if bar_index == 201
+                else 0.0018 + 0.00035 * float((bar_index * 7) % 5)
+            )
+        )
+        prior_minute_close = previous
+        for minute in range(240):
+            close = previous * math.exp(log_delta * float(minute + 1) / 240.0)
+            open_value = prior_minute_close
+            high = max(open_value, close) * (1.0 + wick)
+            low = min(open_value, close) * (1.0 - wick)
+            volume = 1.0 + float(symbol_index) / 10.0
+            open_time = frozen.WINDOW_START_MS + (bar_index * 240 + minute) * MINUTE_MS
+            rows.append(
+                schema.NormalizedKline(
+                    symbol,
+                    open_time,
+                    open_value,
+                    high,
+                    low,
+                    close,
+                    volume,
+                    open_time + MINUTE_MS - 1,
+                    close * volume,
+                    1,
+                    0.0,
+                    0.0,
+                )
+            )
+            prior_minute_close = close
+        previous = target
+    if symbol == "SOLUSDT":
+        missing = _GAP_BAR_INDEX * 240 + _GAP_MINUTE_OFFSET
+        rows.pop(missing)
+    return tuple(rows)
+
+
+def _persist_synthetic_corpus(root: Path) -> CorpusManifest:
+    klines: list[SymbolKlineManifest] = []
+    funding: list[SymbolFundingManifest] = []
+    for symbol_index, symbol in enumerate(frozen.UNIVERSE):
+        source = _normalized_rows(symbol, symbol_index)
+        relative, physical = persistence.write_kline_shard(root, symbol, source)
+        klines.append(
+            SymbolKlineManifest(
+                symbol,
+                "1m",
+                (_archive(root, symbol, "klines"),),
+                canonical_hash.canonical_sha256([row.__dict__ for row in source]),
+                len(source),
+                source[0].open_time_ms,
+                source[-1].open_time_ms,
+                tuple(
+                    gaps.detect_gap_ranges(
+                        [row.open_time_ms for row in source],
+                        frozen.WINDOW_START_MS,
+                        frozen.WINDOW_END_MS,
+                    )
+                ),
+                shard_path=relative,
+                shard_file_sha256=physical,
+            )
+        )
+        funding_rows = (FundingRow(frozen.WINDOW_START_MS, 8, 0.0),)
+        funding_relative, funding_physical = persistence.write_funding_shard(
+            root, symbol, funding_rows
+        )
+        funding.append(
+            SymbolFundingManifest(
+                symbol,
+                (_archive(root, symbol, "fundingRate"),),
+                canonical_hash.canonical_sha256([row.__dict__ for row in funding_rows]),
+                len(funding_rows),
+                funding_rows[0].calc_time,
+                funding_rows[-1].calc_time,
+                shard_path=funding_relative,
+                shard_file_sha256=funding_physical,
+            )
+        )
+    manifest = CorpusManifest(
+        frozen.WINDOW_START_ISO,
+        frozen.WINDOW_END_ISO,
+        frozen.UNIVERSE,
+        tuple(
+            SymbolEligibility(symbol, **frozen.eligibility(symbol))
+            for symbol in frozen.UNIVERSE
+        ),
+        tuple(klines),
+        tuple(funding),
+    )
+    manifest.save(root / "rob980-smoke-manifest.json")
+    return manifest
+
+
+def _selected_minutes(loaded: dict[str, object]) -> dict[str, tuple[MinuteBar, ...]]:
+    klines = loaded["klines"]
+    if type(klines) is not dict:
+        raise TypeError("offline loader kline result must be a dict")
+    return {
+        symbol: tuple(
+            MinuteBar(
+                row.open_time_ms,
+                row.open,
+                row.high,
+                row.low,
+                row.close,
+                row.base_volume,
+            )
+            for row in klines[symbol]
+        )
+        for symbol in SYMBOLS
+    }
+
+
+def _feature_hash(snapshots: tuple[object, ...]) -> str:
+    return canonical_hash.canonical_sha256(
+        [
+            {
+                **snapshot.__dict__,
+                "features": [feature.__dict__ for feature in snapshot.features],
+            }
+            for snapshot in snapshots
+        ]
+    )
+
+
+def _context(rows: dict[str, tuple[MinuteBar, ...]]) -> tuple[FeatureContext, str]:
+    snapshots = synchronized_features(rows)
+    bars = {symbol: build_complete_4h(rows[symbol]) for symbol in SYMBOLS}
+    return FeatureContext.from_h1(bars, snapshots), _feature_hash(snapshots)
+
+
+def _run_generators(
+    context: FeatureContext, emit_window: EmitWindow
+) -> tuple[
+    StrategySmokeResult,
+    StrategySmokeResult,
+]:
+    s3_config = get_config(_S3_SMOKE_CONFIG_ID)
+    s4_config = get_config(_S4_SMOKE_CONFIG_ID)
+    if type(s3_config) is not S3Config or type(s4_config) is not S4Config:
+        raise AssertionError("registered smoke config strategy drift")
+    s3_output = generate_s3_global(context, emit_window, s3_config)
+    s4_output = generate_s4_global(context, emit_window, s4_config)
+    s3_evidence = build_unique_generator_evidence(
+        s3_output,
+        fold_or_full_window=_SMOKE_WINDOW_ID,
+        phase="offline_smoke",
+    )
+    s4_evidence = build_unique_generator_evidence(
+        s4_output,
+        fold_or_full_window=_SMOKE_WINDOW_ID,
+        phase="offline_smoke",
+    )
+    return (
+        StrategySmokeResult("S3", s3_config.config_id, s3_evidence, s3_output.accepted),
+        StrategySmokeResult("S4", s4_config.config_id, s4_evidence, s4_output.accepted),
+    )
+
+
+def _smoke_emit_window() -> EmitWindow:
+    return EmitWindow(
+        frozen.WINDOW_START_MS + (_GAP_BAR_INDEX + 1) * FOUR_HOUR_MS,
+        frozen.WINDOW_START_MS + 203 * FOUR_HOUR_MS,
+    )
+
+
+def _result_content_payload(
+    strategies: tuple[StrategySmokeResult, StrategySmokeResult],
+    *,
+    feature_hash: str,
+    lineage_hash: str,
+    gap_close: int,
+    recovery_close: int,
+    gap_close_absent: bool,
+    other_symbol_gap_close_present: bool,
+    recovery_close_present: bool,
+) -> dict[str, object]:
+    return {
+        "schema_version": "rob974-h3-generator-smoke-v1",
+        "research_sha256": RESEARCH_DOCUMENT_SHA256,
+        "strategy_contract_hashes": (
+            S3_STRATEGY_CONTRACT.contract_hash,
+            S4_STRATEGY_CONTRACT.contract_hash,
+        ),
+        "window": _SMOKE_WINDOW_ID,
+        "phase": "offline_smoke",
+        "universe": SYMBOLS,
+        "feature_hash": feature_hash,
+        "lineage_hash": lineage_hash,
+        "gap": (
+            "SOLUSDT",
+            gap_close,
+            recovery_close,
+            gap_close_absent,
+            other_symbol_gap_close_present,
+            recovery_close_present,
+        ),
+        "strategy_evidence_hashes": tuple(
+            (item.strategy, item.evidence.content_hash) for item in strategies
+        ),
+    }
+
+
+def run_persisted_generator_smoke(root: Path) -> GeneratorSmokeResult:
+    """Run the authorized local synthetic persistence/H1/H3 generator chain."""
+    if not isinstance(root, Path):
+        raise TypeError("smoke root must be pathlib.Path")
+    root = root.resolve()
+    root.mkdir(parents=True, exist_ok=True)
+    manifest = _persist_synthetic_corpus(root)
+    manifest_path = root / "rob980-smoke-manifest.json"
+    loaded = loader.load_corpus(CorpusManifest.load(manifest_path), root)
+    if manifest.content_hash() != CorpusManifest.load(manifest_path).content_hash():
+        raise ValueError("persisted synthetic manifest content changed on reload")
+    selected = _selected_minutes(loaded)
+    context, feature_hash = _context(selected)
+    permuted_rows = {symbol: selected[symbol] for symbol in reversed(SYMBOLS)}
+    permuted_context, permuted_feature_hash = _context(permuted_rows)
+
+    emit_window = _smoke_emit_window()
+    strategies = _run_generators(context, emit_window)
+    permuted_strategies = _run_generators(permuted_context, emit_window)
+    mapping_permutation_hashes_match = feature_hash == permuted_feature_hash and tuple(
+        item.evidence.content_hash for item in strategies
+    ) == tuple(item.evidence.content_hash for item in permuted_strategies)
+
+    funding = loaded["funding"]
+    if type(funding) is not dict:
+        raise TypeError("offline loader funding result must be a dict")
+    funding_coverage = tuple(
+        (
+            symbol,
+            len(funding[symbol]),
+            funding[symbol][0].calc_time,
+            funding[symbol][-1].calc_time,
+        )
+        for symbol in SYMBOLS
+    )
+    derived = DerivedManifest.create(
+        rows=selected,
+        context_start=frozen.WINDOW_START_MS,
+        context_end=frozen.WINDOW_START_MS + _SMOKE_MINUTES * MINUTE_MS,
+        funding_coverage=funding_coverage,
+        funding_source_sha256=canonical_hash.canonical_sha256(
+            {symbol: [row.__dict__ for row in funding[symbol]] for symbol in SYMBOLS}
+        ),
+        feature_hash=feature_hash,
+    )
+
+    gap_close = frozen.WINDOW_START_MS + (_GAP_BAR_INDEX + 1) * FOUR_HOUR_MS
+    recovery_close = gap_close + 7 * FOUR_HOUR_MS
+    synchronized_closes = {snapshot.decision_ts for snapshot in context.snapshots}
+    gap_close_absent = gap_close not in synchronized_closes
+    other_symbol_gap_close_present = any(
+        feature.decision_ts == gap_close
+        for feature in symbol_features("XRPUSDT", selected["XRPUSDT"])
+    )
+    recovery_close_present = recovery_close in synchronized_closes
+    content_hash = canonical_hash.canonical_sha256(
+        _result_content_payload(
+            strategies,
+            feature_hash=feature_hash,
+            lineage_hash=derived.hash,
+            gap_close=gap_close,
+            recovery_close=recovery_close,
+            gap_close_absent=gap_close_absent,
+            other_symbol_gap_close_present=other_symbol_gap_close_present,
+            recovery_close_present=recovery_close_present,
+        )
+    )
+    return GeneratorSmokeResult(
+        "PASS",
+        "NOT_EVALUATED",
+        str(root),
+        strategies,
+        "SOLUSDT",
+        gap_close,
+        recovery_close,
+        gap_close_absent,
+        other_symbol_gap_close_present,
+        recovery_close_present,
+        mapping_permutation_hashes_match,
+        feature_hash,
+        derived.hash,
+        content_hash,
+    )
+
+
+def deterministic_hash_probe() -> dict[str, str]:
+    """Pure synthetic H1/H3 probe used to compare interpreter hash seeds."""
+    selected = {
+        symbol: tuple(
+            MinuteBar(
+                row.open_time_ms,
+                row.open,
+                row.high,
+                row.low,
+                row.close,
+                row.base_volume,
+            )
+            for row in _normalized_rows(symbol, symbol_index)
+        )
+        for symbol_index, symbol in enumerate(SYMBOLS, start=1)
+    }
+    context, feature_hash = _context(selected)
+    permuted, permuted_feature_hash = _context(
+        {symbol: selected[symbol] for symbol in reversed(SYMBOLS)}
+    )
+    emit_window = _smoke_emit_window()
+    strategies = _run_generators(context, emit_window)
+    permuted_strategies = _run_generators(permuted, emit_window)
+    hashes = tuple(item.evidence.content_hash for item in strategies)
+    if feature_hash != permuted_feature_hash or hashes != tuple(
+        item.evidence.content_hash for item in permuted_strategies
+    ):
+        raise ValueError("synthetic H1/H3 hash probe changed under mapping order")
+    return {"feature_hash": feature_hash, "S3": hashes[0], "S4": hashes[1]}
+
+
+def _closed_histogram_schema(keys: tuple[str, ...]) -> dict[str, object]:
+    return {
+        "type": "object",
+        "additionalProperties": False,
+        "required": list(keys),
+        "properties": {key: {"type": "integer", "minimum": 0} for key in keys},
+    }
+
+
+def _fold_strategy_schema(strategy: str) -> dict[str, object]:
+    no_signal_keys = (
+        S3_NO_SIGNAL_TAXONOMY if strategy == "S3" else S4_NO_SIGNAL_TAXONOMY
+    )
+    rejection_keys = (
+        S3_GENERATOR_REJECTION_TAXONOMY
+        if strategy == "S3"
+        else S4_GENERATOR_REJECTION_TAXONOMY
+    )
+    required = [
+        "config_id",
+        "evaluated_decision_units",
+        "no_signal",
+        "candidate",
+        "generator_rejected",
+        "generator_accepted",
+        "no_signal_reason_histogram",
+        "generator_rejection_reason_histogram",
+        "unique_evidence_hash",
+    ]
+    return {
+        "type": "object",
+        "additionalProperties": False,
+        "required": required,
+        "properties": {
+            "config_id": {"const": f"{strategy}-00"},
+            **{key: {"type": "integer", "minimum": 0} for key in required[1:6]},
+            "no_signal_reason_histogram": _closed_histogram_schema(no_signal_keys),
+            "generator_rejection_reason_histogram": _closed_histogram_schema(
+                rejection_keys
+            ),
+            "unique_evidence_hash": {
+                "type": "string",
+                "pattern": "^[0-9a-f]{64}$",
+            },
+        },
+    }
+
+
+_SHA_SCHEMA = {"type": "string", "pattern": "^[0-9a-f]{64}$"}
+_FOLD00_SCHEMA = {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title": "ROB-974 H3 bounded fold-00 pure-generator evidence",
+    "type": "object",
+    "additionalProperties": False,
+    "required": [
+        "authorities",
+        "window",
+        "universe",
+        "phase",
+        "strategies",
+    ],
+    "properties": {
+        "authorities": {
+            "type": "object",
+            "additionalProperties": False,
+            "required": [
+                "research_sha256",
+                "parent_manifest_physical_sha256",
+                "parent_manifest_content_hash",
+                "feature_hash",
+                "strategy_contract_hashes",
+            ],
+            "properties": {
+                "research_sha256": _SHA_SCHEMA,
+                "parent_manifest_physical_sha256": _SHA_SCHEMA,
+                "parent_manifest_content_hash": _SHA_SCHEMA,
+                "feature_hash": _SHA_SCHEMA,
+                "strategy_contract_hashes": {
+                    "type": "object",
+                    "additionalProperties": False,
+                    "required": ["S3", "S4"],
+                    "properties": {"S3": _SHA_SCHEMA, "S4": _SHA_SCHEMA},
+                },
+            },
+        },
+        "window": {
+            "type": "object",
+            "additionalProperties": False,
+            "required": ["fold_id", "oos_start_ms", "oos_end_ms", "half_open"],
+            "properties": {
+                "fold_id": {"const": "fold-00"},
+                "oos_start_ms": {"type": "integer", "minimum": 0},
+                "oos_end_ms": {"type": "integer", "minimum": 0},
+                "half_open": {"const": True},
+            },
+        },
+        "universe": {
+            "type": "array",
+            "minItems": 3,
+            "maxItems": 3,
+            "prefixItems": [
+                {"const": "XRPUSDT"},
+                {"const": "DOGEUSDT"},
+                {"const": "SOLUSDT"},
+            ],
+            "items": False,
+        },
+        "phase": {"const": "selected_oos"},
+        "strategies": {
+            "type": "object",
+            "required": ["S3", "S4"],
+            "additionalProperties": False,
+            "properties": {
+                strategy: _fold_strategy_schema(strategy) for strategy in ("S3", "S4")
+            },
+        },
+    },
+}
+
+
+def prepared_fold00_packet() -> dict[str, str]:
+    command = (
+        "env -i PATH=/Users/mgh3326/.local/bin:/usr/bin:/bin "
+        "PYTHONPATH=/Users/mgh3326/work/auto_trader.rob-980/"
+        "research/nautilus_scalping "
+        f"{_UV} run python {_THIS_FILE} "
+        f"--manifest {_FROZEN_MANIFEST} "
+        f"--data-root {_FROZEN_DATA_ROOT} "
+        "--fold-id fold-00 --phase selected_oos"
+    )
+    return {
+        "status": "NOT_EXECUTED_AWAITING_ORCH_GO",
+        "command": command,
+        "json_schema": json.dumps(
+            _FOLD00_SCHEMA, sort_keys=True, separators=(",", ":")
+        ),
+    }
+
+
+def _frozen_fold_packet(
+    manifest_path: Path,
+    data_root: Path,
+    fold_id: str,
+    phase: str,
+) -> dict[str, object]:
+    if fold_id != "fold-00" or phase != "selected_oos":
+        raise ValueError("only the frozen fold-00 selected_oos smoke is permitted")
+    physical_manifest_hash = hashlib.sha256(manifest_path.read_bytes()).hexdigest()
+    manifest = CorpusManifest.load(manifest_path)
+    loaded = loader.load_corpus(manifest, data_root)
+    selected = _selected_minutes(loaded)
+    context, feature_hash = _context(selected)
+    fold = generate_frozen_fold_schedule(frozen.WINDOW_START_MS, frozen.WINDOW_END_MS)[
+        0
+    ]
+    emit_window = EmitWindow(fold.oos_start_ms, fold.oos_end_ms)
+    s3_config = get_config("S3-00")
+    s4_config = get_config("S4-00")
+    if type(s3_config) is not S3Config or type(s4_config) is not S4Config:
+        raise AssertionError("baseline config strategy drift")
+    outputs = (
+        generate_s3_global(context, emit_window, s3_config),
+        generate_s4_global(context, emit_window, s4_config),
+    )
+    evidence = tuple(
+        build_unique_generator_evidence(
+            output, fold_or_full_window=fold_id, phase=phase
+        )
+        for output in outputs
+    )
+    return {
+        "authorities": {
+            "research_sha256": RESEARCH_DOCUMENT_SHA256,
+            "parent_manifest_physical_sha256": physical_manifest_hash,
+            "parent_manifest_content_hash": manifest.content_hash(),
+            "feature_hash": feature_hash,
+            "strategy_contract_hashes": {
+                "S3": S3_STRATEGY_CONTRACT.contract_hash,
+                "S4": S4_STRATEGY_CONTRACT.contract_hash,
+            },
+        },
+        "window": {
+            "fold_id": fold.fold_id,
+            "oos_start_ms": fold.oos_start_ms,
+            "oos_end_ms": fold.oos_end_ms,
+            "half_open": True,
+        },
+        "universe": list(SYMBOLS),
+        "phase": phase,
+        "strategies": {
+            item.strategy: {
+                "config_id": item.config_id,
+                "evaluated_decision_units": item.evaluated_decision_units,
+                "no_signal": item.no_signal,
+                "candidate": item.candidate,
+                "generator_rejected": item.generator_rejected,
+                "generator_accepted": item.generator_accepted,
+                "no_signal_reason_histogram": dict(item.no_signal_reason_histogram),
+                "generator_rejection_reason_histogram": dict(
+                    item.generator_rejection_reason_histogram
+                ),
+                "unique_evidence_hash": item.content_hash,
+            }
+            for item in evidence
+        },
+    }
+
+
+def _main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--manifest", type=Path, required=True)
+    parser.add_argument("--data-root", type=Path, required=True)
+    parser.add_argument("--fold-id", required=True)
+    parser.add_argument("--phase", required=True)
+    arguments = parser.parse_args()
+    packet = _frozen_fold_packet(
+        arguments.manifest.resolve(),
+        arguments.data_root.resolve(),
+        arguments.fold_id,
+        arguments.phase,
+    )
+    print(json.dumps(packet, sort_keys=True, separators=(",", ":")))
+
+
+if __name__ == "__main__":
+    _main()
+
+
+__all__ = [
+    "GeneratorSmokeResult",
+    "StrategySmokeResult",
+    "deterministic_hash_probe",
+    "prepared_fold00_packet",
+    "run_persisted_generator_smoke",
+]

--- a/research/nautilus_scalping/tests/test_rob962_frozen_production_delta.py
+++ b/research/nautilus_scalping/tests/test_rob962_frozen_production_delta.py
@@ -58,6 +58,7 @@ _AUTHORIZED_PRODUCTION_CHANGES = [
     ("A", ("research/nautilus_scalping/rob974_h2_scenarios.py",)),
     # ROB-980 authorized additive modules.
     ("A", ("research/nautilus_scalping/rob974_h3_evidence.py",)),
+    ("A", ("research/nautilus_scalping/rob974_h3_h2_adapter.py",)),
     ("A", ("research/nautilus_scalping/rob974_h3_manifest.py",)),
     ("A", ("research/nautilus_scalping/rob974_h3_s3.py",)),
     ("A", ("research/nautilus_scalping/rob974_h3_s4.py",)),

--- a/research/nautilus_scalping/tests/test_rob962_frozen_production_delta.py
+++ b/research/nautilus_scalping/tests/test_rob962_frozen_production_delta.py
@@ -56,6 +56,12 @@ _AUTHORIZED_PRODUCTION_CHANGES = [
     ("A", ("research/nautilus_scalping/rob974_h2_s3_engine.py",)),
     ("A", ("research/nautilus_scalping/rob974_h2_s4_engine.py",)),
     ("A", ("research/nautilus_scalping/rob974_h2_scenarios.py",)),
+    # ROB-980 authorized additive modules.
+    ("A", ("research/nautilus_scalping/rob974_h3_evidence.py",)),
+    ("A", ("research/nautilus_scalping/rob974_h3_manifest.py",)),
+    ("A", ("research/nautilus_scalping/rob974_h3_s3.py",)),
+    ("A", ("research/nautilus_scalping/rob974_h3_s4.py",)),
+    ("A", ("research/nautilus_scalping/rob974_h3_smoke.py",)),
 ]
 _FROZEN_PATHS = (
     "research/nautilus_scalping",

--- a/research/nautilus_scalping/tests/test_rob980_cp1_manifest.py
+++ b/research/nautilus_scalping/tests/test_rob980_cp1_manifest.py
@@ -214,11 +214,11 @@ def test_structured_contract_seals_are_distinct_complete_and_source_honest(manif
     assert s3.source_research_sha256 == manifest.RESEARCH_DOCUMENT_SHA256
     assert (
         s3.contract_hash
-        == "4ca659bfbd0f6dad43a276fb77721198c00ff6038462395dd1bd1f98332601e6"
+        == "52118734b8fbbfe8c1fcec45641578e16b25a4bb22f625ff117cc40f648eb562"
     )
     assert (
         s4.contract_hash
-        == "8e0926404b91f2db762a3744b43bf7dc54fae3a302cb59ec6e518e47886dddef"
+        == "767fdeb136f7f78050890b98b6128e826ec49d0fdf2ed3ccbd0572cad4118180"
     )
     assert s3.contract_hash != s4.contract_hash
     assert s3.contract_hash != manifest.RESEARCH_DOCUMENT_SHA256

--- a/research/nautilus_scalping/tests/test_rob980_cp1_manifest.py
+++ b/research/nautilus_scalping/tests/test_rob980_cp1_manifest.py
@@ -1,0 +1,311 @@
+from __future__ import annotations
+
+import dataclasses
+import hashlib
+import importlib
+import importlib.util
+import inspect
+import math
+from decimal import Decimal
+
+import pytest
+
+S3_EXPECTED = (
+    ("S3-00", 12, 0.35, 0.35, 1.25, 1.60, "baseline"),
+    ("S3-01", 8, 0.35, 0.35, 1.25, 1.60, "OFAT"),
+    ("S3-02", 10, 0.35, 0.35, 1.25, 1.60, "OFAT"),
+    ("S3-03", 16, 0.35, 0.35, 1.25, 1.60, "OFAT"),
+    ("S3-04", 20, 0.35, 0.35, 1.25, 1.60, "OFAT"),
+    ("S3-05", 12, 0.20, 0.35, 1.25, 1.60, "OFAT"),
+    ("S3-06", 12, 0.30, 0.35, 1.25, 1.60, "OFAT"),
+    ("S3-07", 12, 0.50, 0.35, 1.25, 1.60, "OFAT"),
+    ("S3-08", 12, 0.65, 0.35, 1.25, 1.60, "OFAT"),
+    ("S3-09", 12, 0.35, 0.25, 1.25, 1.60, "OFAT"),
+    ("S3-10", 12, 0.35, 0.30, 1.25, 1.60, "OFAT"),
+    ("S3-11", 12, 0.35, 0.40, 1.25, 1.60, "OFAT"),
+    ("S3-12", 12, 0.35, 0.45, 1.25, 1.60, "OFAT"),
+    ("S3-13", 12, 0.35, 0.35, 1.00, 1.60, "OFAT"),
+    ("S3-14", 12, 0.35, 0.35, 1.10, 1.60, "OFAT"),
+    ("S3-15", 12, 0.35, 0.35, 1.40, 1.60, "OFAT"),
+    ("S3-16", 12, 0.35, 0.35, 1.60, 1.60, "OFAT"),
+    ("S3-17", 12, 0.35, 0.35, 1.25, 1.35, "OFAT"),
+    ("S3-18", 12, 0.35, 0.35, 1.25, 1.45, "OFAT"),
+    ("S3-19", 12, 0.35, 0.35, 1.25, 1.80, "OFAT"),
+    ("S3-20", 12, 0.35, 0.35, 1.25, 2.00, "OFAT"),
+    ("S3-21", 10, 0.30, 0.30, 1.25, 1.60, "interaction"),
+    ("S3-22", 16, 0.50, 0.40, 1.25, 1.60, "interaction"),
+    ("S3-23", 12, 0.50, 0.35, 1.40, 1.80, "interaction"),
+)
+
+S4_EXPECTED = (
+    ("S4-00", 180, 1.80, 180, 1.25, 1.50, "baseline"),
+    ("S4-01", 120, 1.80, 180, 1.25, 1.50, "OFAT"),
+    ("S4-02", 150, 1.80, 180, 1.25, 1.50, "OFAT"),
+    ("S4-03", 240, 1.80, 180, 1.25, 1.50, "OFAT"),
+    ("S4-04", 300, 1.80, 180, 1.25, 1.50, "OFAT"),
+    ("S4-05", 180, 1.40, 180, 1.25, 1.50, "OFAT"),
+    ("S4-06", 180, 1.60, 180, 1.25, 1.50, "OFAT"),
+    ("S4-07", 180, 2.00, 180, 1.25, 1.50, "OFAT"),
+    ("S4-08", 180, 2.20, 180, 1.25, 1.50, "OFAT"),
+    ("S4-09", 180, 1.80, 140, 1.25, 1.50, "OFAT"),
+    ("S4-10", 180, 1.80, 160, 1.25, 1.50, "OFAT"),
+    ("S4-11", 180, 1.80, 220, 1.25, 1.50, "OFAT"),
+    ("S4-12", 180, 1.80, 260, 1.25, 1.50, "OFAT"),
+    ("S4-13", 180, 1.80, 180, 1.00, 1.50, "OFAT"),
+    ("S4-14", 180, 1.80, 180, 1.10, 1.50, "OFAT"),
+    ("S4-15", 180, 1.80, 180, 1.40, 1.50, "OFAT"),
+    ("S4-16", 180, 1.80, 180, 1.60, 1.50, "OFAT"),
+    ("S4-17", 180, 1.80, 180, 1.25, 1.35, "OFAT"),
+    ("S4-18", 180, 1.80, 180, 1.25, 1.65, "OFAT"),
+    ("S4-19", 180, 1.80, 180, 1.25, 1.80, "OFAT"),
+    ("S4-20", 180, 1.80, 180, 1.25, 2.00, "OFAT"),
+    ("S4-21", 150, 1.60, 160, 1.25, 1.50, "interaction"),
+    ("S4-22", 240, 2.00, 220, 1.25, 1.50, "interaction"),
+    ("S4-23", 180, 2.00, 220, 1.40, 1.80, "interaction"),
+)
+
+S3_LABELS = (
+    "baseline",
+    "OFAT: 짧은 trend",
+    "OFAT",
+    "OFAT",
+    "OFAT: 긴 trend",
+    "OFAT: 얕은 pullback",
+    "OFAT",
+    "OFAT",
+    "OFAT: 깊은 pullback",
+    "OFAT: 낮은 효율",
+    "OFAT",
+    "OFAT",
+    "OFAT: 높은 효율",
+    "OFAT: 좁은 SL",
+    "OFAT",
+    "OFAT",
+    "OFAT: 넓은 SL",
+    "OFAT: 낮은 RR",
+    "OFAT",
+    "OFAT",
+    "OFAT: 높은 RR",
+    "interaction: 빠른 trend + 얕은 pullback",
+    "interaction: 느린 trend + 깊은 pullback",
+    "interaction: 깊은 pullback + 넓은 risk/return",
+)
+
+S4_LABELS = (
+    "baseline",
+    "OFAT: 짧은 beta window",
+    "OFAT",
+    "OFAT",
+    "OFAT: 긴 beta window",
+    "OFAT: 낮은 z",
+    "OFAT",
+    "OFAT",
+    "OFAT: 높은 z",
+    "OFAT: 작은 절대거리",
+    "OFAT",
+    "OFAT",
+    "OFAT: 큰 절대거리",
+    "OFAT: 좁은 SL",
+    "OFAT",
+    "OFAT",
+    "OFAT: 넓은 SL",
+    "OFAT: 낮은 RR",
+    "OFAT",
+    "OFAT",
+    "OFAT: 높은 RR",
+    "interaction: 빠른 적응 + 낮은 entry",
+    "interaction: 안정성 우선 strict",
+    "interaction: 큰 이탈 + tail 완충",
+)
+
+
+@pytest.fixture(scope="module")
+def manifest():
+    spec = importlib.util.find_spec("rob974_h3_manifest")
+    assert spec is not None, "ROB-980 CP1 manifest behavior is not implemented"
+    return importlib.import_module("rob974_h3_manifest")
+
+
+def test_exact_48_row_roster_order_values_designs_and_labels(manifest):
+    rows = manifest.FROZEN_H3_ROSTER
+    assert type(rows) is tuple
+    assert len(rows) == 48
+    assert tuple(row.config_id for row in rows) == tuple(
+        [f"S3-{index:02d}" for index in range(24)]
+        + [f"S4-{index:02d}" for index in range(24)]
+    )
+    assert (
+        tuple(
+            (
+                row.config_id,
+                row.L,
+                row.q_min,
+                row.ER_min,
+                row.k_SL,
+                row.R_TP,
+                row.design_type,
+            )
+            for row in rows[:24]
+        )
+        == S3_EXPECTED
+    )
+    assert (
+        tuple(
+            (
+                row.config_id,
+                row.W,
+                row.z_entry,
+                row.d_min_bp,
+                row.k_SL,
+                row.R_TP,
+                row.design_type,
+            )
+            for row in rows[24:]
+        )
+        == S4_EXPECTED
+    )
+    assert tuple(row.authority_label for row in rows[:24]) == S3_LABELS
+    assert tuple(row.authority_label for row in rows[24:]) == S4_LABELS
+    assert manifest.FROZEN_S3_CONFIGS == rows[:24]
+    assert manifest.FROZEN_S4_CONFIGS == rows[24:]
+
+
+def test_hypothesis_bytes_are_exact_unmodified_line_plus_one_lf(manifest):
+    expected = (
+        (
+            manifest.S3_HYPOTHESIS_UTF8,
+            699,
+            "f8893d558067e07f6248beb66fbc3f917af558634226484c6506c489e2752e01",
+        ),
+        (
+            manifest.S4_HYPOTHESIS_UTF8,
+            423,
+            "c5152f9d207682a569c4df197e4e276cdf907d8eb6a2f68d3d9725b9bf229d28",
+        ),
+    )
+    for raw, size, digest in expected:
+        assert type(raw) is bytes
+        assert len(raw) == size
+        assert hashlib.sha256(raw).hexdigest() == digest
+        assert raw.endswith(b"\n")
+        assert not raw.endswith(b"\n\n")
+        assert b"\r" not in raw
+        assert all(not line.endswith(b" ") for line in raw.splitlines())
+    assert all(
+        row.hypothesis_utf8 is manifest.S3_HYPOTHESIS_UTF8
+        for row in manifest.FROZEN_S3_CONFIGS
+    )
+    assert all(
+        row.hypothesis_utf8 is manifest.S4_HYPOTHESIS_UTF8
+        for row in manifest.FROZEN_S4_CONFIGS
+    )
+
+
+def test_structured_contract_seals_are_distinct_complete_and_source_honest(manifest):
+    assert (
+        manifest.RESEARCH_DOCUMENT_SHA256
+        == "2f535196cf0f0a03292e8f4c1806794ffbf8282ba7b5c3f564a930763577a009"
+    )
+    s3 = manifest.S3_STRATEGY_CONTRACT
+    s4 = manifest.S4_STRATEGY_CONTRACT
+    assert (s3.key, s3.version) == ("rob974.s3.rpt-4h", "1")
+    assert (s4.key, s4.version) == ("rob974.s4.brc-4h", "1")
+    assert s3.source_research_sha256 == s4.source_research_sha256
+    assert s3.source_research_sha256 == manifest.RESEARCH_DOCUMENT_SHA256
+    assert (
+        s3.contract_hash
+        == "4ca659bfbd0f6dad43a276fb77721198c00ff6038462395dd1bd1f98332601e6"
+    )
+    assert (
+        s4.contract_hash
+        == "8e0926404b91f2db762a3744b43bf7dc54fae3a302cb59ec6e518e47886dddef"
+    )
+    assert s3.contract_hash != s4.contract_hash
+    assert s3.contract_hash != manifest.RESEARCH_DOCUMENT_SHA256
+    assert s4.contract_hash != manifest.RESEARCH_DOCUMENT_SHA256
+    assert all(len(item.contract_hash) == 64 for item in (s3, s4))
+    manifest.validate_contract_seals(s3, s4)
+
+    s3_payload = manifest.strategy_contract_payload("S3")
+    s4_payload = manifest.strategy_contract_payload("S4")
+    assert s3_payload["symbols"] == ["XRPUSDT", "DOGEUSDT", "SOLUSDT"]
+    assert s4_payload["pairs"] == ["XRP-DOGE", "XRP-SOL", "DOGE-SOL"]
+    assert s4_payload["posture"] == "historical_research_only"
+    for payload in (s3_payload, s4_payload):
+        assert payload["formulas"]
+        assert payload["fixed_constants"]
+        assert payload["parameter_domains"]
+        assert payload["diagnostic_bins"]
+        assert payload["mechanism_statements"]
+        assert len(payload["configs"]) == 24
+
+
+def test_manifest_validation_rejects_class_wide_tampering(manifest):
+    rows = manifest.FROZEN_H3_ROSTER
+    mutants = (
+        rows[:-1],
+        rows + (rows[-1],),
+        rows[:1] + (rows[0],) + rows[2:],
+        (rows[1], rows[0], *rows[2:]),
+        (dataclasses.replace(rows[0], q_min=rows[5].q_min), *rows[1:]),
+        (dataclasses.replace(rows[0], authority_label="OFAT"), *rows[1:]),
+        (
+            dataclasses.replace(
+                rows[0], hypothesis_utf8=rows[0].hypothesis_utf8 + b"\n"
+            ),
+            *rows[1:],
+        ),
+        (*rows[:24], dataclasses.replace(rows[24], config_id="S3-00"), *rows[25:]),
+    )
+    for mutant in mutants:
+        with pytest.raises(ValueError):
+            manifest.validate_manifest(tuple(mutant))
+
+    forged_source = dataclasses.replace(
+        manifest.S3_STRATEGY_CONTRACT,
+        contract_hash=manifest.RESEARCH_DOCUMENT_SHA256,
+    )
+    with pytest.raises(ValueError):
+        manifest.validate_contract_seals(forged_source, manifest.S4_STRATEGY_CONTRACT)
+    collided = dataclasses.replace(
+        manifest.S4_STRATEGY_CONTRACT,
+        contract_hash=manifest.S3_STRATEGY_CONTRACT.contract_hash,
+    )
+    with pytest.raises(ValueError):
+        manifest.validate_contract_seals(manifest.S3_STRATEGY_CONTRACT, collided)
+
+
+def test_exact_builtin_numeric_types_and_no_unit_or_fold_override(manifest):
+    row = manifest.FROZEN_S3_CONFIGS[0]
+    for bad in (True, 1, Decimal("1.25"), type("F", (float,), {})(1.25)):
+        with pytest.raises(TypeError):
+            dataclasses.replace(row, k_SL=bad)
+    for bad in (True, 12.0, type("I", (int,), {})(12)):
+        with pytest.raises(TypeError):
+            dataclasses.replace(row, L=bad)
+    for bad in (math.nan, math.inf, -math.inf):
+        with pytest.raises(ValueError):
+            dataclasses.replace(row, q_min=bad)
+    with pytest.raises(TypeError):
+        dataclasses.replace(row, hypothesis_utf8=bytearray(row.hypothesis_utf8))
+    assert tuple(inspect.signature(manifest.get_config).parameters) == ("config_id",)
+    assert not {"symbol", "pair", "unit", "fold"} & {
+        field.name for field in dataclasses.fields(row)
+    }
+
+
+def test_registered_membership_and_typed_hash_are_tamper_sensitive(manifest):
+    canonical = manifest.FROZEN_S4_CONFIGS[0]
+    manifest.assert_registered_config(canonical)
+    with pytest.raises(ValueError):
+        manifest.assert_registered_config(
+            dataclasses.replace(canonical, z_entry=math.nextafter(1.80, math.inf))
+        )
+    payload = manifest.strategy_contract_payload("S4")
+    changed = dict(payload)
+    changed["fixed_constants"] = dict(payload["fixed_constants"])
+    changed["fixed_constants"]["rho_min"] = math.nextafter(0.60, math.inf)
+    assert (
+        manifest.hash_contract_payload(changed)
+        != manifest.S4_STRATEGY_CONTRACT.contract_hash
+    )

--- a/research/nautilus_scalping/tests/test_rob980_cp2_s3_core.py
+++ b/research/nautilus_scalping/tests/test_rob980_cp2_s3_core.py
@@ -1,0 +1,264 @@
+from __future__ import annotations
+
+import dataclasses
+import importlib
+import importlib.util
+import math
+
+import pytest
+from rob974_features import Bar4h, CommonSnapshot, SymbolFeature
+from rob974_h3_manifest import SYMBOLS, get_config
+
+H4 = 4 * 60 * 60 * 1000
+
+
+@pytest.fixture(scope="module")
+def s3():
+    spec = importlib.util.find_spec("rob974_h3_s3")
+    assert spec is not None, "ROB-980 CP2 S3 formula core is not implemented"
+    return importlib.import_module("rob974_h3_s3")
+
+
+def _bars(count: int, *, start: int = 0, offset: float = 0.0):
+    return tuple(
+        Bar4h(
+            index * H4,
+            (index + 1) * H4,
+            99.5 + index + offset,
+            101.0 + index + offset,
+            99.0 + index + offset,
+            100.0 + index + offset,
+            1.0,
+            index == start,
+        )
+        for index in range(start, count)
+    )
+
+
+def _feature(
+    symbol: str,
+    ts: int,
+    *,
+    close: float,
+    atr20: float | None = 2.0,
+    a: float | None = 0.02,
+    vwap12: float | None = None,
+    vwap24: float | None = 98.0,
+    percentile: float | None = 50.0,
+    range24: float | None = 0.10,
+):
+    return SymbolFeature(
+        symbol,
+        ts,
+        0.01,
+        2.0,
+        atr20,
+        a,
+        close if vwap12 is None else vwap12,
+        vwap24,
+        percentile,
+        range24,
+    )
+
+
+def _snapshot(
+    index: int,
+    *,
+    market_4h: float = -0.123,
+    market_24h: float = 0.008,
+    overrides: dict[str, dict[str, float | None]] | None = None,
+):
+    ts = (index + 1) * H4
+    overrides = overrides or {}
+    features = []
+    for symbol_offset, symbol in enumerate(SYMBOLS):
+        close = 100.0 + index + symbol_offset * 10.0
+        features.append(_feature(symbol, ts, close=close, **overrides.get(symbol, {})))
+    return CommonSnapshot(ts, market_4h, market_24h, 2, 1, tuple(features))
+
+
+def _context(s3, count: int = 14, snapshots=None):
+    bars = {
+        symbol: _bars(count, offset=float(position * 10))
+        for position, symbol in enumerate(SYMBOLS)
+    }
+    values = (
+        tuple(_snapshot(index) for index in range(count))
+        if snapshots is None
+        else tuple(snapshots)
+    )
+    return s3.FeatureContext.from_h1(bars, values)
+
+
+def test_feature_context_keeps_actual_h1_dtos_and_distinct_emit_window(s3):
+    bars = {symbol: _bars(10) for symbol in SYMBOLS}
+    snapshots = tuple(_snapshot(index) for index in range(10))
+    context = s3.FeatureContext.from_h1(bars, snapshots)
+    assert context.bars_for("XRPUSDT") is bars["XRPUSDT"]
+    assert context.snapshots == snapshots
+    assert all(type(bar) is Bar4h for bar in context.bars_for("XRPUSDT"))
+    assert all(type(item) is CommonSnapshot for item in context.snapshots)
+    window = s3.EmitWindow(3 * 60 * 60 * 1000, 13 * 60 * 60 * 1000)
+    assert window not in dataclasses.astuple(context)
+    assert s3.expected_decision_closes(window) == (H4, 2 * H4, 3 * H4)
+
+
+def test_exact_s3_formula_uses_l_deltas_l_plus_one_closes_and_prior_q_only(s3):
+    config = get_config("S3-01")  # L=8
+    snapshots = [_snapshot(index) for index in range(12)]
+    target_index = 8
+    target_ts = (target_index + 1) * H4
+    snapshots[target_index - 2] = _snapshot(
+        target_index - 2,
+        overrides={"XRPUSDT": {"vwap12": 107.0, "atr20": 2.0}},
+    )
+    snapshots[target_index - 1] = _snapshot(
+        target_index - 1,
+        overrides={"XRPUSDT": {"vwap12": 107.5, "atr20": 2.0}},
+    )
+    snapshots[target_index] = _snapshot(
+        target_index,
+        market_4h=-0.123,
+        market_24h=0.008,
+        overrides={
+            "XRPUSDT": {
+                "atr20": 9.0,
+                "a": 0.02,
+                "vwap12": 107.0,
+                "vwap24": 106.0,
+                "percentile": 20.0,
+                "range24": 0.05,
+            }
+        },
+    )
+    context = _context(s3, snapshots=snapshots)
+    metrics = s3.compute_s3_metrics(context, config, target_ts, "XRPUSDT")
+    assert metrics is not None
+    expected_r = math.log(108.0 / 100.0)
+    assert metrics.R == expected_r
+    assert metrics.ER == 1.0
+    assert metrics.S == expected_r / (0.02 * math.sqrt(8))
+    assert metrics.Qplus == 0.5
+    assert metrics.Qminus == -0.25
+    assert metrics.atr20 == 9.0
+    assert metrics.A == 0.02
+    assert metrics.vwap24 == 106.0
+    assert metrics.percentile_30d == 20.0
+    assert metrics.range24 == 0.05
+    assert metrics.market_return_24h == 0.008
+    assert metrics.current_market_return_4h == -0.123
+    assert metrics.decision_ts == target_ts
+
+    changed = list(snapshots)
+    changed[target_index] = _snapshot(
+        target_index,
+        overrides={"XRPUSDT": {"vwap12": 1.0, "atr20": 9.0, "a": 0.02}},
+    )
+    changed_metrics = s3.compute_s3_metrics(
+        _context(s3, snapshots=changed), config, target_ts, "XRPUSDT"
+    )
+    assert changed_metrics is not None
+    assert (changed_metrics.Qplus, changed_metrics.Qminus) == (
+        metrics.Qplus,
+        metrics.Qminus,
+    )
+
+
+def test_expected_grid_counts_missing_middle_and_recovers_without_state(s3):
+    config = get_config("S3-01")
+    snapshots = [_snapshot(index) for index in range(16)]
+    missing_ts = 10 * H4
+    snapshots = [item for item in snapshots if item.decision_ts != missing_ts]
+    context = _context(s3, count=16, snapshots=snapshots)
+    window = s3.EmitWindow(9 * H4, 14 * H4)
+    units = s3.s3_formula_grid(context, window, config)
+    assert len(units) == 5 * 3
+    assert tuple(sorted({unit.decision_ts for unit in units})) == tuple(
+        range(9 * H4, 14 * H4, H4)
+    )
+    missing = [unit for unit in units if unit.decision_ts == missing_ts]
+    assert len(missing) == 3
+    assert all(unit.metrics is None for unit in missing)
+    recovered = [
+        unit
+        for unit in units
+        if unit.decision_ts == 13 * H4 and unit.symbol == "XRPUSDT"
+    ]
+    assert len(recovered) == 1
+    assert recovered[0].metrics is not None
+
+
+def test_missing_required_h1_values_are_no_signal(s3):
+    config = get_config("S3-01")
+    snapshots = [_snapshot(index) for index in range(12)]
+    target_index = 9
+    snapshots[target_index] = _snapshot(
+        target_index,
+        overrides={"XRPUSDT": {"range24": None}},
+    )
+    context = _context(s3, snapshots=snapshots)
+    assert (
+        s3.compute_s3_metrics(context, config, (target_index + 1) * H4, "XRPUSDT")
+        is None
+    )
+
+
+def test_future_bar_mutation_cannot_change_prior_decision(s3):
+    config = get_config("S3-01")
+    snapshots = tuple(_snapshot(index) for index in range(14))
+    bars = {
+        symbol: _bars(14, offset=float(position * 10))
+        for position, symbol in enumerate(SYMBOLS)
+    }
+    decision_ts = 10 * H4
+    baseline = s3.compute_s3_metrics(
+        s3.FeatureContext.from_h1(bars, snapshots),
+        config,
+        decision_ts,
+        "XRPUSDT",
+    )
+    changed = dict(bars)
+    future = list(changed["XRPUSDT"])
+    future[11] = dataclasses.replace(
+        future[11], open=500.0, high=900.0, low=400.0, close=800.0
+    )
+    changed["XRPUSDT"] = tuple(future)
+    assert (
+        s3.compute_s3_metrics(
+            s3.FeatureContext.from_h1(changed, snapshots),
+            config,
+            decision_ts,
+            "XRPUSDT",
+        )
+        == baseline
+    )
+
+
+def test_bar_gap_cannot_bridge_and_new_segment_later_recovers(s3):
+    config = get_config("S3-01")
+    source = list(_bars(22))
+    source[10] = dataclasses.replace(source[10], is_segment_start=True)
+    bars = {
+        "XRPUSDT": tuple(source),
+        "DOGEUSDT": _bars(22, offset=10.0),
+        "SOLUSDT": _bars(22, offset=20.0),
+    }
+    snapshots = tuple(_snapshot(index) for index in range(22))
+    context = s3.FeatureContext.from_h1(bars, snapshots)
+    assert s3.compute_s3_metrics(context, config, 11 * H4, "XRPUSDT") is None
+    assert s3.compute_s3_metrics(context, config, 19 * H4, "XRPUSDT") is not None
+
+
+def test_exact_timestamp_and_malformed_nonfinite_are_terminal(s3):
+    with pytest.raises(TypeError):
+        s3.EmitWindow(True, H4)
+    context = _context(s3)
+    with pytest.raises(TypeError):
+        s3.compute_s3_metrics(context, get_config("S3-01"), True, "XRPUSDT")
+
+    corrupted = _snapshot(10)
+    object.__setattr__(corrupted, "M", math.nan)
+    with pytest.raises(ValueError):
+        s3.FeatureContext.from_h1(
+            {symbol: _bars(14) for symbol in SYMBOLS}, (corrupted,)
+        )

--- a/research/nautilus_scalping/tests/test_rob980_cp3_s3_gates.py
+++ b/research/nautilus_scalping/tests/test_rob980_cp3_s3_gates.py
@@ -1,0 +1,314 @@
+from __future__ import annotations
+
+import dataclasses
+import math
+
+import pytest
+import rob974_h3_s3 as s3
+from rob974_features import Bar4h, CommonSnapshot, SymbolFeature
+from rob974_h3_manifest import FROZEN_S3_CONFIGS, SYMBOLS, get_config
+
+H4 = 4 * 60 * 60 * 1000
+
+
+def test_cp3_gate_behavior_exists_on_the_importable_cp2_core():
+    assert hasattr(s3, "evaluate_s3_gates"), (
+        "ROB-980 CP3 S3 gate behavior is not implemented"
+    )
+
+
+def _long(**changes):
+    config = get_config("S3-00")
+    _, d_tp = s3.s3_risk_distances(config, 0.006)
+    values = {
+        "config_id": config.config_id,
+        "decision_ts": 144_000_000,
+        "symbol": "XRPUSDT",
+        "R": 0.10,
+        "ER": 0.35,
+        "S": 1.25,
+        "Qplus": 0.35,
+        "Qminus": -0.10,
+        "close": 101.0,
+        "previous_close": 100.0,
+        "prior_l_high": 102.0,
+        "prior_l_low": 90.0,
+        "atr20": 0.6,
+        "A": 0.006,
+        "vwap12": 100.0,
+        "vwap24": 99.0,
+        "percentile_30d": 20.0,
+        "range24": d_tp / 0.60,
+        "market_return_24h": 0.0075,
+        "current_market_return_4h": -0.50,
+        "bplus": 2,
+        "bminus": 1,
+    }
+    values.update(changes)
+    return s3.S3Metrics(**values)
+
+
+def _short(**changes):
+    config = get_config("S3-00")
+    _, d_tp = s3.s3_risk_distances(config, 0.006)
+    values = {
+        "config_id": config.config_id,
+        "decision_ts": 144_000_000,
+        "symbol": "XRPUSDT",
+        "R": -0.10,
+        "ER": 0.35,
+        "S": -1.25,
+        "Qplus": -0.10,
+        "Qminus": 0.35,
+        "close": 99.0,
+        "previous_close": 100.0,
+        "prior_l_high": 110.0,
+        "prior_l_low": 98.0,
+        "atr20": 0.6,
+        "A": 0.006,
+        "vwap12": 100.0,
+        "vwap24": 101.0,
+        "percentile_30d": 20.0,
+        "range24": d_tp / 0.60,
+        "market_return_24h": -0.0075,
+        "current_market_return_4h": 0.50,
+        "bplus": 1,
+        "bminus": 2,
+    }
+    values.update(changes)
+    return s3.S3Metrics(**values)
+
+
+def _reason(metrics):
+    return s3.evaluate_s3_gates(metrics, get_config("S3-00")).no_signal_reason
+
+
+def test_long_inclusive_boundaries_and_strict_one_ulp_inside_pass():
+    exact = _long(
+        Qplus=1.25,
+        percentile_30d=90.0,
+        vwap12=math.nextafter(101.0, -math.inf),
+        previous_close=math.nextafter(101.0, -math.inf),
+        prior_l_high=math.nextafter(101.0, math.inf),
+    )
+    outcome = s3.evaluate_s3_gates(exact, get_config("S3-00"))
+    assert outcome.no_signal_reason is None
+    assert outcome.candidate is not None
+    assert outcome.side == "long"
+
+
+@pytest.mark.parametrize(
+    ("changes", "reason"),
+    (
+        ({"market_return_24h": math.nextafter(0.0075, -math.inf)}, "market_regime"),
+        ({"bplus": 1}, "market_breadth"),
+        ({"S": math.nextafter(1.25, -math.inf)}, "trend_strength"),
+        ({"ER": math.nextafter(0.35, -math.inf)}, "efficiency"),
+        ({"Qplus": math.nextafter(0.35, -math.inf)}, "pullback_depth"),
+        ({"Qplus": math.nextafter(1.25, math.inf)}, "pullback_depth"),
+        ({"close": 100.0}, "vwap_reclaim"),
+        ({"previous_close": 101.0}, "momentum"),
+        ({"prior_l_high": 101.0}, "prior_l_non_breakout"),
+        ({"percentile_30d": math.nextafter(20.0, -math.inf)}, "volatility_percentile"),
+        ({"percentile_30d": math.nextafter(90.0, math.inf)}, "volatility_percentile"),
+    ),
+)
+def test_long_each_boundary_one_ulp_outside_or_strict_equality_fails(changes, reason):
+    assert _reason(_long(**changes)) == reason
+
+
+def test_long_range_capacity_equality_passes_and_one_ulp_outside_fails():
+    metrics = _long()
+    outcome = s3.evaluate_s3_gates(metrics, get_config("S3-00"))
+    assert outcome.candidate is not None
+    assert outcome.candidate.d_TP == 0.60 * metrics.range24
+    smaller = math.nextafter(metrics.range24, -math.inf)
+    assert _reason(dataclasses.replace(metrics, range24=smaller)) == "range_tp_capacity"
+
+
+def test_short_inclusive_boundaries_and_strict_one_ulp_inside_pass():
+    exact = _short(
+        Qminus=1.25,
+        percentile_30d=90.0,
+        vwap12=math.nextafter(99.0, math.inf),
+        previous_close=math.nextafter(99.0, math.inf),
+        prior_l_low=math.nextafter(99.0, -math.inf),
+    )
+    outcome = s3.evaluate_s3_gates(exact, get_config("S3-00"))
+    assert outcome.no_signal_reason is None
+    assert outcome.candidate is not None
+    assert outcome.side == "short"
+
+
+@pytest.mark.parametrize(
+    ("changes", "reason"),
+    (
+        ({"market_return_24h": math.nextafter(-0.0075, math.inf)}, "market_regime"),
+        ({"bminus": 1}, "market_breadth"),
+        ({"S": math.nextafter(-1.25, math.inf)}, "trend_strength"),
+        ({"ER": math.nextafter(0.35, -math.inf)}, "efficiency"),
+        ({"Qminus": math.nextafter(0.35, -math.inf)}, "pullback_depth"),
+        ({"Qminus": math.nextafter(1.25, math.inf)}, "pullback_depth"),
+        ({"close": 100.0}, "vwap_reclaim"),
+        ({"previous_close": 99.0}, "momentum"),
+        ({"prior_l_low": 99.0}, "prior_l_non_breakout"),
+        ({"percentile_30d": math.nextafter(20.0, -math.inf)}, "volatility_percentile"),
+        ({"percentile_30d": math.nextafter(90.0, math.inf)}, "volatility_percentile"),
+    ),
+)
+def test_short_each_boundary_one_ulp_outside_or_strict_equality_fails(changes, reason):
+    assert _reason(_short(**changes)) == reason
+
+
+def test_short_range_capacity_equality_passes_and_one_ulp_outside_fails():
+    metrics = _short()
+    outcome = s3.evaluate_s3_gates(metrics, get_config("S3-00"))
+    assert outcome.candidate is not None
+    assert outcome.candidate.d_TP == 0.60 * metrics.range24
+    smaller = math.nextafter(metrics.range24, -math.inf)
+    assert _reason(dataclasses.replace(metrics, range24=smaller)) == "range_tp_capacity"
+
+
+def test_exact_sl_tp_clips_and_registered_floors_for_every_config():
+    baseline = get_config("S3-00")
+    assert s3.s3_risk_distances(baseline, 0.0) == (0.008, 0.0128)
+    assert s3.s3_risk_distances(baseline, 0.01) == (0.0125, 0.020000000000000004)
+    assert s3.s3_risk_distances(baseline, 1.0) == (0.020, 0.032)
+    floors = tuple(s3.s3_risk_distances(config, 0.0)[1] for config in FROZEN_S3_CONFIGS)
+    assert min(floors) == 0.0108
+    assert floors[0] == 0.0128
+
+
+def _candidate(symbol: str, *, strength: float, efficiency: float, a_value: float):
+    _, d_tp = s3.s3_risk_distances(get_config("S3-00"), a_value)
+    outcome = s3.evaluate_s3_gates(
+        _long(
+            symbol=symbol,
+            S=strength,
+            ER=efficiency,
+            A=a_value,
+            range24=d_tp / 0.60,
+        ),
+        get_config("S3-00"),
+    )
+    assert outcome.candidate is not None
+    return outcome.candidate
+
+
+@pytest.mark.parametrize(
+    ("candidate_specs", "winner"),
+    (
+        (
+            (
+                ("XRPUSDT", 1.50, 0.50, 0.010),
+                ("DOGEUSDT", 1.60, 0.35, 0.006),
+            ),
+            "DOGEUSDT",
+        ),
+        (
+            (
+                ("XRPUSDT", 1.50, 0.40, 0.010),
+                ("DOGEUSDT", 1.50, 0.50, 0.006),
+            ),
+            "DOGEUSDT",
+        ),
+        (
+            (
+                ("XRPUSDT", 1.50, 0.50, 0.010),
+                ("DOGEUSDT", 1.50, 0.50, 0.011),
+            ),
+            "DOGEUSDT",
+        ),
+        (
+            tuple((symbol, 1.50, 0.50, 0.010) for symbol in reversed(SYMBOLS)),
+            "DOGEUSDT",
+        ),
+    ),
+)
+def test_global_arbitration_exact_rank_tiers(candidate_specs, winner):
+    candidates = tuple(
+        _candidate(
+            symbol,
+            strength=strength,
+            efficiency=efficiency,
+            a_value=a_value,
+        )
+        for symbol, strength, efficiency, a_value in candidate_specs
+    )
+    result = s3.arbitrate_s3_candidates(candidates)
+    assert result.winner.symbol == winner
+    assert len(result.rejected) == len(candidates) - 1
+    assert all(
+        item.reason == "simultaneous_candidate_arbitration_loser"
+        for item in result.rejected
+    )
+    assert {item.candidate.identity for item in result.rejected}.isdisjoint(
+        {result.winner.identity}
+    )
+
+
+def test_h3_owned_accepted_payload_is_frozen_complete_and_h2_independent():
+    candidate = _candidate("XRPUSDT", strength=1.50, efficiency=0.50, a_value=0.010)
+    assert candidate.strategy == "S3"
+    assert candidate.signal_ts == candidate.decision_ts
+    assert candidate.entry_tick_ts == candidate.decision_ts
+    assert candidate.entry_deadline_ts == candidate.decision_ts + 60_000
+    assert candidate.max_hold_4h_bars == 12
+    assert candidate.volatility_percentile_provenance == "h1_percentile_30d"
+    assert candidate.side == "long"
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        candidate.side = "short"
+
+
+def test_real_global_api_accepts_one_and_rejects_every_simultaneous_loser():
+    config = get_config("S3-01")
+    bars = {}
+    snapshots = []
+    for symbol_offset, symbol in enumerate(SYMBOLS):
+        offset = float(symbol_offset * 10)
+        bars[symbol] = tuple(
+            Bar4h(
+                index * H4,
+                (index + 1) * H4,
+                99.5 + index + offset,
+                102.0 + index + offset,
+                98.0 + index + offset,
+                100.0 + index + offset,
+                1.0,
+                index == 0,
+            )
+            for index in range(10)
+        )
+    for index in range(10):
+        features = []
+        for symbol_offset, symbol in enumerate(SYMBOLS):
+            close = 100.0 + index + symbol_offset * 10.0
+            vwap12 = close + 1.0 if index in (6, 7) else close - 1.0
+            features.append(
+                SymbolFeature(
+                    symbol,
+                    (index + 1) * H4,
+                    0.01,
+                    4.0,
+                    2.0,
+                    0.01,
+                    vwap12,
+                    close - 2.0,
+                    50.0,
+                    0.10,
+                )
+            )
+        snapshots.append(
+            CommonSnapshot((index + 1) * H4, -0.50, 0.0075, 2, 1, tuple(features))
+        )
+    context = s3.FeatureContext.from_h1(bars, tuple(snapshots))
+    target = 9 * H4
+    output = s3.generate_s3_global(context, s3.EmitWindow(target, target + H4), config)
+    assert len(output.decisions) == 3
+    assert len(output.accepted) == 1
+    assert len(output.rejected) == 2
+    assert [item.status for item in output.decisions].count("GENERATOR_ACCEPTED") == 1
+    assert [item.status for item in output.decisions].count("GENERATOR_REJECTED") == 2
+    assert output.accepted[0].identity not in {
+        item.candidate.identity for item in output.rejected
+    }

--- a/research/nautilus_scalping/tests/test_rob980_cp4_s4_estimator.py
+++ b/research/nautilus_scalping/tests/test_rob980_cp4_s4_estimator.py
@@ -1,0 +1,375 @@
+from __future__ import annotations
+
+import dataclasses
+import importlib
+import importlib.util
+import math
+
+import pytest
+from rob974_features import Bar4h, CommonSnapshot, SymbolFeature
+from rob974_h3_manifest import PAIRS, SYMBOLS, get_config
+from rob974_h3_s3 import FeatureContext
+
+H4 = 4 * 60 * 60 * 1000
+
+
+@pytest.fixture(scope="module")
+def s4():
+    spec = importlib.util.find_spec("rob974_h3_s4")
+    assert spec is not None, "ROB-980 CP4 S4 PIT estimator is not implemented"
+    return importlib.import_module("rob974_h3_s4")
+
+
+def _median(values):
+    ordered = sorted(values)
+    middle = len(ordered) // 2
+    if len(ordered) % 2:
+        return ordered[middle]
+    return math.fsum((ordered[middle - 1], ordered[middle])) / 2.0
+
+
+def _beta(returns, market):
+    r_mean = math.fsum(returns) / len(returns)
+    m_mean = math.fsum(market) / len(market)
+    numerator = math.fsum(
+        (r_value - r_mean) * (m_value - m_mean)
+        for r_value, m_value in zip(returns, market, strict=True)
+    )
+    denominator = math.fsum((value - m_mean) ** 2 for value in market)
+    return min(max(numerator / denominator, 0.25), 3.0)
+
+
+def _normal_context(count: int = 121):
+    states = []
+    for index in range(-1, count):
+        common = 0.001 * index + 0.012 * math.sin(index * 0.19)
+        states.append(
+            (
+                math.log(100.0) + 5.0 * common + 0.006 * math.sin(index * 0.31),
+                math.log(80.0) + 0.10 * common - 0.004 * math.sin(index * 0.23),
+                math.log(60.0) + 1.20 * common + 0.003 * math.sin(index * 0.17),
+            )
+        )
+    bars = {symbol: [] for symbol in SYMBOLS}
+    snapshots = []
+    for index in range(count):
+        current = states[index + 1]
+        prior = states[index]
+        returns = tuple(
+            current[position] - prior[position] for position in range(len(SYMBOLS))
+        )
+        features = []
+        for position, symbol in enumerate(SYMBOLS):
+            close = math.exp(current[position])
+            bars[symbol].append(
+                Bar4h(
+                    index * H4,
+                    (index + 1) * H4,
+                    close,
+                    close * 1.001,
+                    close * 0.999,
+                    close,
+                    1.0,
+                    index == 0,
+                )
+            )
+            features.append(
+                SymbolFeature(
+                    symbol,
+                    (index + 1) * H4,
+                    returns[position],
+                    1.0,
+                    1.0,
+                    0.01,
+                    close,
+                    close,
+                    50.0,
+                    0.10,
+                )
+            )
+        snapshots.append(
+            CommonSnapshot(
+                (index + 1) * H4,
+                sorted(returns)[1],
+                999.0,
+                2,
+                1,
+                tuple(features),
+            )
+        )
+    return FeatureContext.from_h1(
+        {symbol: tuple(values) for symbol, values in bars.items()}, tuple(snapshots)
+    )
+
+
+def _window_values(context, pair, end_index, length):
+    left, right = pair.split("-")
+    symbols = (f"{left}USDT", f"{right}USDT")
+    snapshots = context.snapshots[end_index - length + 1 : end_index + 1]
+    returns_a = tuple(
+        snapshot.features[SYMBOLS.index(symbols[0])].r for snapshot in snapshots
+    )
+    returns_b = tuple(
+        snapshot.features[SYMBOLS.index(symbols[1])].r for snapshot in snapshots
+    )
+    market = tuple(snapshot.m for snapshot in snapshots)
+    closes = []
+    for symbol in symbols:
+        by_ts = {bar.close_ts: bar.close for bar in context.bars_for(symbol)}
+        closes.append(tuple(by_ts[snapshot.decision_ts] for snapshot in snapshots))
+    return returns_a, returns_b, market, tuple(closes)
+
+
+def _degenerate_context(kind: str, count: int = 121):
+    bars = {symbol: [] for symbol in SYMBOLS}
+    snapshots = []
+    for index in range(count):
+        market = 0.0 if kind == "beta" else 0.001 * ((index % 7) - 3)
+        if kind == "rho":
+            returns = (2.0 * market, 0.001, market)
+        else:
+            returns = (2.0 * market, market, market)
+        features = []
+        for position, symbol in enumerate(SYMBOLS):
+            close = 100.0 + position * 10.0
+            bars[symbol].append(
+                Bar4h(
+                    index * H4,
+                    (index + 1) * H4,
+                    close,
+                    close,
+                    close,
+                    close,
+                    1.0,
+                    index == 0,
+                )
+            )
+            features.append(
+                SymbolFeature(
+                    symbol,
+                    (index + 1) * H4,
+                    returns[position],
+                    0.0,
+                    0.0,
+                    0.0,
+                    close,
+                    close,
+                    50.0,
+                    0.0,
+                )
+            )
+        snapshots.append(
+            CommonSnapshot((index + 1) * H4, market, 999.0, 2, 1, tuple(features))
+        )
+    return FeatureContext.from_h1(
+        {symbol: tuple(values) for symbol, values in bars.items()}, tuple(snapshots)
+    )
+
+
+def test_pair_order_and_exact_fixed_order_estimator_against_independent_oracle(s4):
+    assert s4.PAIR_ORDER == PAIRS == ("XRP-DOGE", "XRP-SOL", "DOGE-SOL")
+    config = get_config("S4-01")
+    context = _normal_context()
+    outcome = s4.estimate_s4_pair(context, config, 121 * H4, "XRP-DOGE")
+    assert outcome.rejection_reason is None
+    estimate = outcome.estimate
+    assert estimate is not None
+    returns_a, returns_b, market, closes = _window_values(
+        context, "XRP-DOGE", 120, config.W
+    )
+    beta_a = _beta(returns_a, market)
+    beta_b = _beta(returns_b, market)
+    weight_a = beta_b / (beta_a + beta_b)
+    weight_b = beta_a / (beta_a + beta_b)
+    spreads = tuple(
+        weight_a * math.log(a_close) - weight_b * math.log(b_close)
+        for a_close, b_close in zip(*closes, strict=True)
+    )
+    mu = _median(spreads)
+    mad = _median(tuple(abs(value - mu) for value in spreads))
+    scale = max(1.4826 * mad, 1e-6)
+    centered = tuple(value - mu for value in spreads)
+    phi = math.fsum(
+        centered[index - 1] * centered[index] for index in range(1, len(centered))
+    ) / math.fsum(value * value for value in centered[:-1])
+    assert estimate.beta_a == beta_a
+    assert estimate.beta_b == beta_b
+    assert estimate.weight_a == weight_a
+    assert estimate.weight_b == weight_b
+    assert estimate.mu == mu
+    assert estimate.mad == mad
+    assert estimate.effective_mad_scale == scale
+    assert estimate.z == (spreads[-1] - mu) / scale
+    assert estimate.phi == phi
+    assert estimate.half_life_4h_bars == math.log(0.5) / math.log(phi)
+    returns_a_centered = tuple(
+        value - math.fsum(returns_a) / len(returns_a) for value in returns_a
+    )
+    returns_b_centered = tuple(
+        value - math.fsum(returns_b) / len(returns_b) for value in returns_b
+    )
+    expected_rho = math.fsum(
+        left * right
+        for left, right in zip(returns_a_centered, returns_b_centered, strict=True)
+    ) / math.sqrt(
+        math.fsum(value * value for value in returns_a_centered)
+        * math.fsum(value * value for value in returns_b_centered)
+    )
+    assert estimate.rho == expected_rho
+    pair_returns = tuple(
+        weight_a * left - weight_b * right
+        for left, right in zip(returns_a, returns_b, strict=True)
+    )
+    pair_mean = math.fsum(pair_returns) / len(pair_returns)
+    expected_sigma = math.sqrt(
+        math.fsum((value - pair_mean) ** 2 for value in pair_returns)
+        / len(pair_returns)
+    )
+    assert estimate.sigma_pair == expected_sigma
+    assert estimate.pair_return_bps == estimate.pair_return_fraction * 10_000.0
+    assert estimate.D_bps == estimate.D_fraction * 10_000.0
+
+    prior_a, prior_b, prior_market, prior_closes = _window_values(
+        context, "XRP-DOGE", 119, config.W
+    )
+    prior_beta_a = _beta(prior_a, prior_market)
+    prior_beta_b = _beta(prior_b, prior_market)
+    prior_weight_a = prior_beta_b / (prior_beta_a + prior_beta_b)
+    prior_weight_b = prior_beta_a / (prior_beta_a + prior_beta_b)
+    prior_spreads = tuple(
+        prior_weight_a * math.log(a_close) - prior_weight_b * math.log(b_close)
+        for a_close, b_close in zip(*prior_closes, strict=True)
+    )
+    prior_mu = _median(prior_spreads)
+    prior_mad = _median(tuple(abs(value - prior_mu) for value in prior_spreads))
+    prior_scale = max(1.4826 * prior_mad, 1e-6)
+    assert (
+        estimate.prior_beta_a,
+        estimate.prior_beta_b,
+        estimate.prior_weight_a,
+        estimate.prior_weight_b,
+        estimate.prior_mu,
+        estimate.prior_mad,
+        estimate.prior_effective_mad_scale,
+        estimate.z_prior,
+    ) == (
+        prior_beta_a,
+        prior_beta_b,
+        prior_weight_a,
+        prior_weight_b,
+        prior_mu,
+        prior_mad,
+        prior_scale,
+        (prior_spreads[-1] - prior_mu) / prior_scale,
+    )
+
+
+def test_prior_z_is_recomputed_from_prior_own_window_and_ignores_t_values(s4):
+    config = get_config("S4-01")
+    context = _normal_context()
+    baseline = s4.estimate_s4_pair(context, config, 121 * H4, "XRP-DOGE").estimate
+    assert baseline is not None
+    bars = {symbol: context.bars_for(symbol) for symbol in SYMBOLS}
+    changed_xrp = list(bars["XRPUSDT"])
+    current = changed_xrp[-1]
+    changed_xrp[-1] = dataclasses.replace(
+        current,
+        open=current.open * 1.01,
+        high=current.high * 1.02,
+        low=current.low,
+        close=current.close * 1.01,
+    )
+    bars["XRPUSDT"] = tuple(changed_xrp)
+    changed = FeatureContext.from_h1(bars, context.snapshots)
+    mutated = s4.estimate_s4_pair(changed, config, 121 * H4, "XRP-DOGE").estimate
+    assert mutated is not None
+    assert mutated.z != baseline.z
+    assert (
+        mutated.z_prior,
+        mutated.prior_beta_a,
+        mutated.prior_beta_b,
+        mutated.prior_weight_a,
+        mutated.prior_weight_b,
+        mutated.prior_mu,
+        mutated.prior_effective_mad_scale,
+    ) == (
+        baseline.z_prior,
+        baseline.prior_beta_a,
+        baseline.prior_beta_b,
+        baseline.prior_weight_a,
+        baseline.prior_weight_b,
+        baseline.prior_mu,
+        baseline.prior_effective_mad_scale,
+    )
+
+
+def test_lowercase_m_is_beta_authority_and_uppercase_M_is_irrelevant(s4):
+    config = get_config("S4-01")
+    context = _normal_context()
+    first = s4.estimate_s4_pair(context, config, 121 * H4, "XRP-DOGE")
+    snapshots = tuple(
+        dataclasses.replace(snapshot, M=-999.0) for snapshot in context.snapshots
+    )
+    changed = s4.estimate_s4_pair(
+        FeatureContext.from_h1(
+            {symbol: context.bars_for(symbol) for symbol in SYMBOLS}, snapshots
+        ),
+        config,
+        121 * H4,
+        "XRP-DOGE",
+    )
+    assert changed == first
+
+
+def test_mad_zero_uses_only_effective_scale_floor_and_sigma_zero_remains_zero(s4):
+    spreads = (0.0,) * 119 + (0.01,)
+    stats = s4.spread_statistics(spreads)
+    assert stats is not None
+    assert stats.mad == 0.0
+    assert stats.effective_scale == 1e-6
+    assert s4.population_sigma((0.0,) * 120) == 0.0
+
+
+def test_degenerate_and_nonfinite_numeric_inputs_reject_deterministically(s4):
+    assert s4.compute_clipped_beta((1.0, 2.0), (0.0, 0.0)) is None
+    assert s4.correlation((1.0, 1.0), (1.0, 2.0)) is None
+    assert s4.phi_and_half_life((1.0, 1.0, 1.0), 1.0) is None
+    assert s4.spread_statistics((0.0, math.nan)) is None
+    assert s4.population_sigma((0.0, math.inf)) is None
+
+    config = get_config("S4-01")
+    beta = s4.estimate_s4_pair(
+        _degenerate_context("beta"), config, 121 * H4, "XRP-DOGE"
+    )
+    assert beta.rejection_reason == "degenerate_beta_market_variance"
+    rho = s4.estimate_s4_pair(_degenerate_context("rho"), config, 121 * H4, "XRP-DOGE")
+    assert rho.rejection_reason == "degenerate_rho_variance"
+    phi = s4.estimate_s4_pair(_degenerate_context("phi"), config, 121 * H4, "XRP-DOGE")
+    assert phi.rejection_reason == "degenerate_phi_denominator"
+
+
+def test_clipped_beta_definition_is_identical_for_full_and_halves(s4):
+    config = get_config("S4-01")
+    estimate = s4.estimate_s4_pair(
+        _normal_context(), config, 121 * H4, "XRP-DOGE"
+    ).estimate
+    assert estimate is not None
+    assert estimate.beta_a == 3.0
+    assert estimate.beta_b == 0.25
+    returns_a, returns_b, market, _ = _window_values(
+        _normal_context(), "XRP-DOGE", 120, config.W
+    )
+    half = config.W // 2
+    assert estimate.beta_a_first == _beta(returns_a[:half], market[:half])
+    assert estimate.beta_a_second == _beta(returns_a[half:], market[half:])
+    assert estimate.beta_b_first == _beta(returns_b[:half], market[:half])
+    assert estimate.beta_b_second == _beta(returns_b[half:], market[half:])
+
+
+def test_exact_types_and_invalid_pair_fail_closed(s4):
+    context = _normal_context()
+    config = get_config("S4-01")
+    with pytest.raises(TypeError):
+        s4.estimate_s4_pair(context, config, True, "XRP-DOGE")
+    with pytest.raises(ValueError):
+        s4.estimate_s4_pair(context, config, 121 * H4, "DOGE-XRP")

--- a/research/nautilus_scalping/tests/test_rob980_cp5_s4_gates.py
+++ b/research/nautilus_scalping/tests/test_rob980_cp5_s4_gates.py
@@ -1,0 +1,209 @@
+from __future__ import annotations
+
+import dataclasses
+import math
+
+import pytest
+import rob974_h3_s4 as s4
+from rob974_h3_manifest import FROZEN_S4_CONFIGS, PAIRS, get_config
+
+
+def test_cp5_gate_behavior_exists_on_the_importable_cp4_estimator():
+    assert hasattr(s4, "evaluate_s4_gates"), (
+        "ROB-980 CP5 S4 gate behavior is not implemented"
+    )
+
+
+def _estimate(config_id: str = "S4-00", **changes):
+    pair = changes.pop("pair", "XRP-DOGE")
+    symbols = {
+        "XRP-DOGE": ("XRPUSDT", "DOGEUSDT"),
+        "XRP-SOL": ("XRPUSDT", "SOLUSDT"),
+        "DOGE-SOL": ("DOGEUSDT", "SOLUSDT"),
+    }[pair]
+    values = {
+        "config_id": config_id,
+        "decision_ts": 144_000_000,
+        "pair": pair,
+        "symbol_a": symbols[0],
+        "symbol_b": symbols[1],
+        "beta_a": 1.0,
+        "beta_b": 1.0,
+        "beta_a_first": 1.0,
+        "beta_a_second": 1.0,
+        "beta_b_first": 1.0,
+        "beta_b_second": 1.0,
+        "weight_a": 0.5,
+        "weight_b": 0.5,
+        "spread": 0.018,
+        "mu": 0.0,
+        "mad": 0.01,
+        "effective_mad_scale": 0.014826,
+        "z": 1.8,
+        "prior_beta_a": 1.0,
+        "prior_beta_b": 1.0,
+        "prior_weight_a": 0.5,
+        "prior_weight_b": 0.5,
+        "prior_mu": 0.0,
+        "prior_mad": 0.01,
+        "prior_effective_mad_scale": 0.014826,
+        "z_prior": 2.0,
+        "D_fraction": 0.018,
+        "D_bps": 180.0,
+        "rho": 0.60,
+        "phi": 0.75,
+        "half_life_4h_bars": 2.0,
+        "beta_stability": 0.20,
+        "sigma_pair": 0.0,
+        "pair_return_fraction": -0.001,
+        "pair_return_bps": -10.0,
+        "current_market_return_4h": 0.50,
+    }
+    values.update(changes)
+    return s4.S4Estimate(**values)
+
+
+def _reason(estimate, config_id: str = "S4-00"):
+    return s4.evaluate_s4_gates(estimate, get_config(config_id)).no_signal_reason
+
+
+def test_convergence_exact_equality_and_both_entry_thresholds_pass():
+    outcome = s4.evaluate_s4_gates(_estimate(), get_config("S4-00"))
+    assert outcome.no_signal_reason is None
+    assert outcome.candidate is not None
+    assert outcome.candidate.side == "short_a_long_b"
+
+
+@pytest.mark.parametrize(
+    ("changes", "reason"),
+    (
+        ({"z": 0.0}, "convergence_sign"),
+        ({"z_prior": -2.0}, "convergence_sign"),
+        ({"z_prior": math.nextafter(1.8, -math.inf)}, "prior_z_entry"),
+        ({"z": math.nextafter(1.8, -math.inf)}, "current_z_entry"),
+        ({"z": math.nextafter(1.8, math.inf)}, "convergence_fraction"),
+        ({"rho": math.nextafter(0.60, -math.inf)}, "rho"),
+        ({"half_life_4h_bars": math.nextafter(2.0, -math.inf)}, "half_life"),
+        ({"half_life_4h_bars": math.nextafter(12.0, math.inf)}, "half_life"),
+        ({"beta_stability": math.nextafter(0.20, math.inf)}, "beta_stability"),
+        ({"D_bps": math.nextafter(180.0, -math.inf)}, "absolute_distance"),
+    ),
+)
+def test_each_convergence_and_quality_boundary_one_ulp_outside_fails(changes, reason):
+    assert _reason(_estimate(**changes)) == reason
+
+
+def test_inclusive_half_life_rho_beta_stability_and_d_min_upper_boundaries_pass():
+    assert _reason(_estimate(half_life_4h_bars=12.0)) is None
+    assert _reason(_estimate(rho=0.60, beta_stability=0.20, D_bps=180.0)) is None
+    prior_threshold = _estimate(z_prior=1.8, z=1.8)
+    assert _reason(prior_threshold) == "convergence_fraction"
+
+
+def test_distance_to_tp_equality_passes_and_one_ulp_outside_fails():
+    config = get_config("S4-09")
+    _, d_tp = s4.s4_risk_distances(config, 0.0)
+    exact = _estimate("S4-09", D_fraction=1.25 * d_tp, D_bps=1.25 * d_tp * 10_000.0)
+    assert _reason(exact, "S4-09") is None
+    outside = dataclasses.replace(
+        exact,
+        D_fraction=math.nextafter(exact.D_fraction, -math.inf),
+        D_bps=math.nextafter(exact.D_fraction, -math.inf) * 10_000.0,
+    )
+    assert _reason(outside, "S4-09") == "distance_to_tp"
+
+
+def test_exact_risk_clips_and_all_registered_tp_floors():
+    baseline = get_config("S4-00")
+    assert s4.s4_risk_distances(baseline, 0.0) == (0.008, 0.012)
+    assert s4.s4_risk_distances(baseline, 0.01) == (0.0125, 0.018750000000000003)
+    assert s4.s4_risk_distances(baseline, 1.0) == (0.016, 0.024)
+    floors = tuple(s4.s4_risk_distances(config, 0.0)[1] for config in FROZEN_S4_CONFIGS)
+    assert min(floors) == 0.0108
+    assert floors[0] == 0.012
+
+
+def test_gross_notional_feasibility_is_inclusive_and_uses_exact_g_min():
+    balanced = s4.historical_notional(0.5, 0.5)
+    assert (balanced.G_min, balanced.G_max, balanced.G) == (12.0, 20.0, 12.0)
+    boundary = s4.historical_notional(0.375, 0.625)
+    assert boundary.G_min == boundary.G_max == boundary.G == 16.0
+    outside = s4.historical_notional(math.nextafter(0.375, -math.inf), 0.625)
+    assert outside.G_min > outside.G_max
+    assert outside.G is None
+
+
+def test_exact_direction_frozen_weights_null_executor_and_volatility_provenance():
+    positive = s4.evaluate_s4_gates(_estimate(), get_config("S4-00")).candidate
+    negative = s4.evaluate_s4_gates(
+        _estimate(z=-1.8, z_prior=-2.0), get_config("S4-00")
+    ).candidate
+    assert positive is not None and negative is not None
+    assert (positive.side_a, positive.side_b) == ("short", "long")
+    assert (negative.side_a, negative.side_b) == ("long", "short")
+    assert positive.weight_a == positive.weight_b == 0.5
+    assert positive.gross_notional_usd == 12.0
+    assert positive.notional_a_usd == positive.notional_b_usd == 6.0
+    assert (
+        positive.historical_notional_assumption
+        == "frozen_continuous_6_to_10_usd_per_leg"
+    )
+    assert positive.historical_eligibility is True
+    assert positive.volatility_percentile is None
+    assert positive.volatility_percentile_provenance == "not_defined_for_s4"
+    assert positive.leg_a_order_id is None
+    assert positive.leg_b_order_id is None
+    assert positive.leg_a_fill_id is None
+    assert positive.leg_b_fill_id is None
+    assert positive.pair_executor_provenance == "not_evaluated_h3_generator"
+    assert positive.entry_tick_ts == positive.decision_ts
+    assert positive.entry_deadline_ts == positive.decision_ts + 60_000
+    assert positive.max_hold_4h_bars == 9
+
+
+def _candidate(pair: str, *, distance: float, z_value: float, rho: float):
+    estimate = _estimate(
+        pair=pair,
+        z=z_value,
+        z_prior=math.copysign(max(abs(z_value) / 0.90, 2.0), z_value),
+        D_fraction=distance,
+        D_bps=distance * 10_000.0,
+        rho=rho,
+    )
+    outcome = s4.evaluate_s4_gates(estimate, get_config("S4-00"))
+    assert outcome.candidate is not None
+    return outcome.candidate
+
+
+@pytest.mark.parametrize(
+    ("specs", "winner"),
+    (
+        (
+            (("XRP-DOGE", 0.020, 2.0, 0.70), ("XRP-SOL", 0.021, 1.8, 0.60)),
+            "XRP-SOL",
+        ),
+        (
+            (("XRP-DOGE", 0.020, 1.9, 0.70), ("XRP-SOL", 0.020, 2.0, 0.60)),
+            "XRP-SOL",
+        ),
+        (
+            (("XRP-DOGE", 0.020, 2.0, 0.70), ("XRP-SOL", 0.020, 2.0, 0.80)),
+            "XRP-SOL",
+        ),
+        (tuple((pair, 0.020, 2.0, 0.70) for pair in reversed(PAIRS)), "DOGE-SOL"),
+    ),
+)
+def test_global_pair_arbitration_exact_rank_tiers(specs, winner):
+    candidates = tuple(
+        _candidate(pair, distance=distance, z_value=z_value, rho=rho)
+        for pair, distance, z_value, rho in specs
+    )
+    result = s4.arbitrate_s4_candidates(candidates)
+    assert result.winner.pair == winner
+    assert len(result.rejected) == len(candidates) - 1
+    assert all(
+        item.reason == "simultaneous_pair_arbitration_loser" for item in result.rejected
+    )
+    assert result.winner.identity not in {
+        item.candidate.identity for item in result.rejected
+    }

--- a/research/nautilus_scalping/tests/test_rob980_cp6_unique_evidence.py
+++ b/research/nautilus_scalping/tests/test_rob980_cp6_unique_evidence.py
@@ -1,0 +1,371 @@
+from __future__ import annotations
+
+import dataclasses
+import importlib
+import importlib.util
+import inspect
+import math
+
+import pytest
+import rob974_h3_s3 as s3
+import rob974_h3_s4 as s4
+from rob974_h3_manifest import PAIRS, SYMBOLS, get_config, strategy_contract_payload
+
+
+@pytest.fixture(scope="module")
+def evidence():
+    spec = importlib.util.find_spec("rob974_h3_evidence")
+    assert spec is not None, "ROB-980 CP6 unique generator evidence is not implemented"
+    return importlib.import_module("rob974_h3_evidence")
+
+
+def _s3_candidate(symbol: str, strength: float):
+    config = get_config("S3-00")
+    metrics = s3.S3Metrics(
+        config.config_id,
+        144_000_000,
+        symbol,
+        0.10,
+        0.50,
+        strength,
+        0.50,
+        -0.10,
+        101.0,
+        100.0,
+        102.0,
+        90.0,
+        0.6,
+        0.006,
+        100.0,
+        99.0,
+        50.0,
+        0.10,
+        0.0075,
+        -0.50,
+        2,
+        1,
+    )
+    candidate = s3.evaluate_s3_gates(metrics, config).candidate
+    assert candidate is not None
+    return candidate
+
+
+def _s3_output():
+    candidates = tuple(
+        _s3_candidate(symbol, 2.0 - index * 0.1) for index, symbol in enumerate(SYMBOLS)
+    )
+    arbitration = s3.arbitrate_s3_candidates(candidates[:2])
+    accepted = arbitration.winner
+    rejected = arbitration.rejected[0]
+    decisions = tuple(
+        (
+            s3.S3UnitDecision(
+                candidate.decision_ts,
+                candidate.symbol,
+                "GENERATOR_ACCEPTED",
+                candidate.side,
+                candidate,
+                None,
+                None,
+            )
+            if candidate.identity == accepted.identity
+            else s3.S3UnitDecision(
+                candidate.decision_ts,
+                candidate.symbol,
+                "GENERATOR_REJECTED",
+                candidate.side,
+                candidate,
+                None,
+                "simultaneous_candidate_arbitration_loser",
+            )
+        )
+        for candidate in candidates[:2]
+    ) + (
+        s3.S3UnitDecision(
+            144_000_000,
+            SYMBOLS[2],
+            "NO_SIGNAL",
+            "long",
+            None,
+            "momentum",
+            None,
+        ),
+    )
+    return s3.S3GeneratorOutput("S3", "S3-00", decisions, (accepted,), (rejected,))
+
+
+def _s4_estimate(pair: str, distance: float, z_value: float):
+    symbols = {
+        "XRP-DOGE": ("XRPUSDT", "DOGEUSDT"),
+        "XRP-SOL": ("XRPUSDT", "SOLUSDT"),
+        "DOGE-SOL": ("DOGEUSDT", "SOLUSDT"),
+    }[pair]
+    return s4.S4Estimate(
+        "S4-00",
+        144_000_000,
+        pair,
+        symbols[0],
+        symbols[1],
+        1.0,
+        1.0,
+        1.0,
+        1.0,
+        1.0,
+        1.0,
+        0.5,
+        0.5,
+        distance,
+        0.0,
+        0.01,
+        0.014826,
+        z_value,
+        1.0,
+        1.0,
+        0.5,
+        0.5,
+        0.0,
+        0.01,
+        0.014826,
+        math.copysign(max(abs(z_value) / 0.90, 2.0), z_value),
+        distance,
+        distance * 10_000.0,
+        0.70,
+        0.75,
+        4.0,
+        0.10,
+        0.0,
+        -0.001,
+        -10.0,
+        0.50,
+    )
+
+
+def _s4_output():
+    candidates = tuple(
+        s4.evaluate_s4_gates(
+            _s4_estimate(pair, 0.020 - index * 0.001, 2.0),
+            get_config("S4-00"),
+        ).candidate
+        for index, pair in enumerate(PAIRS)
+    )
+    assert all(candidate is not None for candidate in candidates)
+    exact = tuple(candidate for candidate in candidates if candidate is not None)
+    arbitration = s4.arbitrate_s4_candidates(exact[:2])
+    accepted = arbitration.winner
+    rejected = arbitration.rejected[0]
+    decisions = tuple(
+        (
+            s4.S4UnitDecision(
+                candidate.decision_ts,
+                candidate.pair,
+                "GENERATOR_ACCEPTED",
+                candidate.side,
+                candidate,
+                None,
+                None,
+            )
+            if candidate.identity == accepted.identity
+            else s4.S4UnitDecision(
+                candidate.decision_ts,
+                candidate.pair,
+                "GENERATOR_REJECTED",
+                candidate.side,
+                candidate,
+                None,
+                "simultaneous_pair_arbitration_loser",
+            )
+        )
+        for candidate in exact[:2]
+    ) + (
+        s4.S4UnitDecision(
+            144_000_000,
+            PAIRS[2],
+            "NO_SIGNAL",
+            None,
+            None,
+            "rho",
+            None,
+        ),
+    )
+    return s4.S4GeneratorOutput("S4", "S4-00", decisions, (accepted,), (rejected,))
+
+
+def test_closed_identity_phase_and_scenario_absence(evidence):
+    identity = evidence.GeneratorIdentity(
+        "S3",
+        "S3-00",
+        "fold-00",
+        "selected_oos",
+        144_000_000,
+        "XRPUSDT",
+        "long",
+    )
+    assert identity.as_tuple() == (
+        "S3",
+        "S3-00",
+        "fold-00",
+        "selected_oos",
+        144_000_000,
+        "XRPUSDT",
+        "long",
+    )
+    assert evidence.PHASES == (
+        "train",
+        "selected_oos",
+        "pbo_full_window",
+        "offline_smoke",
+    )
+    assert "scenario" not in {field.name for field in dataclasses.fields(identity)}
+    with pytest.raises(ValueError):
+        dataclasses.replace(identity, phase="base13")
+    with pytest.raises(TypeError):
+        dataclasses.replace(identity, decision_ts=True)
+
+
+@pytest.mark.parametrize(
+    ("output_factory", "strategy", "config_id", "unit"),
+    (
+        (_s3_output, "S3", "S3-00", "XRPUSDT"),
+        (_s4_output, "S4", "S4-00", "XRP-DOGE"),
+    ),
+)
+def test_one_global_invocation_exact_equations_closed_histograms_and_hash(
+    evidence, output_factory, strategy, config_id, unit
+):
+    result = evidence.build_unique_generator_evidence(
+        output_factory(), fold_or_full_window="fold-00", phase="selected_oos"
+    )
+    assert result.strategy == strategy
+    assert result.config_id == config_id
+    assert result.global_invocation_count == 1
+    assert result.evaluated_decision_units == 3
+    assert result.no_signal == 1
+    assert result.candidate == 2
+    assert result.generator_rejected == 1
+    assert result.generator_accepted == 1
+    assert result.evaluated_decision_units == result.no_signal + result.candidate
+    assert result.candidate == result.generator_rejected + result.generator_accepted
+    assert (
+        sum(value for _, value in result.no_signal_reason_histogram) == result.no_signal
+    )
+    assert (
+        sum(value for _, value in result.generator_rejection_reason_histogram)
+        == result.generator_rejected
+    )
+    assert all(type(value) is int for _, value in result.outcome_histogram)
+    assert all(key for key, _ in result.no_signal_reason_histogram)
+    assert all(key for key, _ in result.generator_rejection_reason_histogram)
+    assert any(value == 0 for _, value in result.no_signal_reason_histogram)
+    assert (
+        result.content_hash
+        == {
+            "S3": "895fd170fed051c3ed7f18bf51dd18092c5743e4f95dbc1b59e23e339f18bfc4",
+            "S4": "e3b1baca166f911141d97adebf56a5df818dd917973c8679b428160416f57058",
+        }[strategy]
+    )
+    assert result.accepted_identities[0].symbol_or_pair == unit
+    assert set(result.accepted_identities).isdisjoint(result.rejected_identities)
+
+
+def test_container_order_invariance_and_one_ulp_candidate_sensitivity(evidence):
+    output = _s3_output()
+    baseline = evidence.build_unique_generator_evidence(
+        output, fold_or_full_window="fold-00", phase="selected_oos"
+    )
+    permuted = dataclasses.replace(output, decisions=tuple(reversed(output.decisions)))
+    assert (
+        evidence.build_unique_generator_evidence(
+            permuted, fold_or_full_window="fold-00", phase="selected_oos"
+        ).content_hash
+        == baseline.content_hash
+    )
+    changed_candidate = dataclasses.replace(
+        output.accepted[0], S=math.nextafter(output.accepted[0].S, math.inf)
+    )
+    changed_decisions = tuple(
+        dataclasses.replace(decision, candidate=changed_candidate)
+        if decision.status == "GENERATOR_ACCEPTED"
+        else decision
+        for decision in output.decisions
+    )
+    changed = dataclasses.replace(
+        output, decisions=changed_decisions, accepted=(changed_candidate,)
+    )
+    mutated = evidence.build_unique_generator_evidence(
+        changed, fold_or_full_window="fold-00", phase="selected_oos"
+    )
+    assert mutated.accepted_identities == baseline.accepted_identities
+    assert mutated.content_hash != baseline.content_hash
+
+
+def test_collision_and_per_unit_regeneration_fail_closed(evidence):
+    output = _s3_output()
+    with pytest.raises(ValueError):
+        s3.S3GeneratorOutput(
+            "S3",
+            "S3-00",
+            output.decisions,
+            output.accepted,
+            (
+                s3.S3RejectedCandidate(
+                    output.accepted[0],
+                    "simultaneous_candidate_arbitration_loser",
+                ),
+            ),
+        )
+    with pytest.raises(TypeError):
+        evidence.build_unique_generator_evidence(
+            output.accepted[0],
+            fold_or_full_window="fold-00",
+            phase="selected_oos",
+        )
+    with pytest.raises(ValueError):
+        evidence.build_unique_generator_evidence(
+            dataclasses.replace(output, decisions=output.decisions[:2]),
+            fold_or_full_window="fold-00",
+            phase="selected_oos",
+        )
+
+
+def test_taxonomies_are_ordered_closed_contract_seals_and_exclude_h4_h2_state(evidence):
+    assert evidence.S3_NO_SIGNAL_TAXONOMY == s3.S3_NO_SIGNAL_REASONS
+    assert evidence.S4_NO_SIGNAL_TAXONOMY == s4.S4_NO_SIGNAL_REASONS
+    assert evidence.S3_GENERATOR_REJECTION_TAXONOMY == s3.S3_GENERATOR_REJECTION_REASONS
+    assert evidence.S4_GENERATOR_REJECTION_TAXONOMY == s4.S4_GENERATOR_REJECTION_REASONS
+    for strategy, no_signal, rejected in (
+        (
+            "S3",
+            evidence.S3_NO_SIGNAL_TAXONOMY,
+            evidence.S3_GENERATOR_REJECTION_TAXONOMY,
+        ),
+        (
+            "S4",
+            evidence.S4_NO_SIGNAL_TAXONOMY,
+            evidence.S4_GENERATOR_REJECTION_TAXONOMY,
+        ),
+    ):
+        payload = strategy_contract_payload(strategy)
+        assert payload["no_signal_reasons"] == list(no_signal)
+        assert payload["generator_rejection_reasons"] == list(rejected)
+        assert all(
+            forbidden not in reason
+            for reason in no_signal + rejected
+            for forbidden in ("funding", "horizon", "engine_state")
+        )
+    signature = inspect.signature(evidence.build_unique_generator_evidence)
+    assert "scenario" not in signature.parameters
+    assert not hasattr(evidence, "rerank_after_funding_rejection")
+
+
+def test_winner_payload_exposes_h4_boundary_but_computes_no_funding(evidence):
+    s3_winner = _s3_output().accepted[0]
+    s4_winner = _s4_output().accepted[0]
+    assert s3_winner.side in ("long", "short")
+    assert s3_winner.entry_deadline_ts == s3_winner.decision_ts + 60_000
+    assert s3_winner.max_hold_4h_bars == 12
+    assert s4_winner.side in ("short_a_long_b", "long_a_short_b")
+    assert s4_winner.weight_a + s4_winner.weight_b == 1.0
+    assert s4_winner.entry_deadline_ts == s4_winner.decision_ts + 60_000
+    assert s4_winner.max_hold_4h_bars == 9
+    assert "funding" not in {field.name for field in dataclasses.fields(s3_winner)}
+    assert "funding" not in {field.name for field in dataclasses.fields(s4_winner)}

--- a/research/nautilus_scalping/tests/test_rob980_cp7_safety.py
+++ b/research/nautilus_scalping/tests/test_rob980_cp7_safety.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import ast
+import json
+import subprocess
+from pathlib import Path
+
+import rob974_h3_smoke as smoke
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_MODULE_ROOT = Path(__file__).resolve().parents[1]
+_H3_CORE = (
+    "rob974_h3_manifest.py",
+    "rob974_h3_s3.py",
+    "rob974_h3_s4.py",
+    "rob974_h3_evidence.py",
+)
+_H3_ALL = (*_H3_CORE, "rob974_h3_smoke.py")
+_FORBIDDEN_IMPORT_ROOTS = {
+    "app",
+    "sqlalchemy",
+    "asyncpg",
+    "psycopg",
+    "redis",
+    "taskiq",
+    "celery",
+    "httpx",
+    "requests",
+    "aiohttp",
+    "urllib",
+    "socket",
+    "websockets",
+    "boto3",
+    "fastapi",
+    "uvicorn",
+    "random",
+    "time",
+    "datetime",
+    "importlib",
+    "os",
+}
+
+
+def _tree(module: str) -> ast.Module:
+    return ast.parse((_MODULE_ROOT / module).read_text())
+
+
+def test_h3_modules_have_no_app_db_network_broker_clock_random_or_dynamic_authority():
+    for module in _H3_ALL:
+        tree = _tree(module)
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                imported = tuple(alias.name for alias in node.names)
+            elif isinstance(node, ast.ImportFrom):
+                imported = (node.module or "",)
+            else:
+                continue
+            assert all(
+                name.split(".")[0] not in _FORBIDDEN_IMPORT_ROOTS for name in imported
+            ), module
+        names = {node.id for node in ast.walk(tree) if isinstance(node, ast.Name)}
+        source = (_MODULE_ROOT / module).read_text()
+        assert not names & {"__import__", "eval", "exec", "getenv"}, module
+        assert "os.environ" not in source, module
+        assert "PYTHONPATH" not in source or module == "rob974_h3_smoke.py"
+
+
+def test_h3_core_has_no_h2_executor_funding_horizon_or_forbidden_formula_dependency():
+    for module in _H3_CORE:
+        source = (_MODULE_ROOT / module).read_text().lower()
+        tree = _tree(module)
+        imports = {
+            name
+            for node in ast.walk(tree)
+            for name in (
+                [alias.name for alias in node.names]
+                if isinstance(node, ast.Import)
+                else [node.module or ""]
+                if isinstance(node, ast.ImportFrom)
+                else []
+            )
+        }
+        assert not any("h2" in name for name in imports), module
+        assert "expm1" not in source, module
+        assert "pair_executor" not in imports, module
+        assert "funding" not in imports, module
+        assert "horizon" not in imports, module
+
+
+def test_smoke_has_no_exception_swallowing_or_empirical_execution_entrypoint():
+    tree = _tree("rob974_h3_smoke.py")
+    assert not any(isinstance(node, (ast.Try, ast.TryStar)) for node in ast.walk(tree))
+    source = (_MODULE_ROOT / "rob974_h3_smoke.py").read_text()
+    assert "--run" not in source
+    assert "materializer" not in source.lower()
+    assert "NOT_EXECUTED_AWAITING_ORCH_GO" in source
+    assert "actual_h2_engine_integration" in source
+
+
+def _probe(seed: str) -> str:
+    code = (
+        "import json; import rob974_h3_smoke as s; "
+        "print(json.dumps(s.deterministic_hash_probe(),sort_keys=True,"
+        "separators=(',',':')))"
+    )
+    completed = subprocess.run(
+        (str(_REPO_ROOT / ".venv/bin/python"), "-c", code),
+        cwd=_REPO_ROOT,
+        env={
+            "PATH": "/usr/bin:/bin",
+            "PYTHONHASHSEED": seed,
+            "PYTHONPATH": str(_MODULE_ROOT),
+        },
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert "rob-979" not in str(_MODULE_ROOT)
+    return completed.stdout.strip()
+
+
+def test_real_h1_h3_probe_is_identical_across_hash_seeds_and_pinned():
+    expected = json.dumps(
+        smoke.deterministic_hash_probe(), sort_keys=True, separators=(",", ":")
+    )
+    assert _probe("1") == expected
+    assert _probe("987654321") == expected
+    assert json.loads(expected) == {
+        "S3": "cd0367dcd1b3d0723e7f7815144d2120dba80f0f2603fe1a88eb3f7b234df7ac",
+        "S4": "778381ed58a245dce084a76a855966914afe9377264a75a82fcf70cccee0545c",
+        "feature_hash": (
+            "5abc827a3a3d28c02d4ad5313a299dcf0bbf95397c66d80d5e359d95193e19a2"
+        ),
+    }

--- a/research/nautilus_scalping/tests/test_rob980_cp7_smoke.py
+++ b/research/nautilus_scalping/tests/test_rob980_cp7_smoke.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+import importlib
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture(scope="module")
+def smoke_module():
+    spec = importlib.util.find_spec("rob974_h3_smoke")
+    assert spec is not None, (
+        "ROB-980 CP7 persisted real-H1 generator smoke is not implemented"
+    )
+    return importlib.import_module("rob974_h3_smoke")
+
+
+@pytest.fixture(scope="module")
+def smoke_result(smoke_module, tmp_path_factory: pytest.TempPathFactory):
+    return smoke_module.run_persisted_generator_smoke(
+        tmp_path_factory.mktemp("rob980-cp7")
+    )
+
+
+def test_persisted_real_h1_smoke_is_non_vacuous_for_both_strategies(smoke_result):
+    assert smoke_result.generator_smoke == "PASS"
+    assert smoke_result.actual_h2_engine_integration == "NOT_EVALUATED"
+    assert tuple(item.strategy for item in smoke_result.strategies) == ("S3", "S4")
+    expected = {
+        "S3": (
+            576,
+            574,
+            2,
+            1,
+            1,
+            "cd0367dcd1b3d0723e7f7815144d2120dba80f0f2603fe1a88eb3f7b234df7ac",
+        ),
+        "S4": (
+            576,
+            570,
+            6,
+            2,
+            4,
+            "778381ed58a245dce084a76a855966914afe9377264a75a82fcf70cccee0545c",
+        ),
+    }
+    for strategy in smoke_result.strategies:
+        evidence = strategy.evidence
+        assert evidence.global_invocation_count == 1
+        assert evidence.evaluated_decision_units > 0
+        assert evidence.no_signal > 0
+        assert evidence.candidate > 0
+        assert evidence.generator_rejected > 0
+        assert evidence.generator_accepted > 0
+        assert (
+            evidence.evaluated_decision_units == evidence.no_signal + evidence.candidate
+        )
+        assert evidence.candidate == (
+            evidence.generator_rejected + evidence.generator_accepted
+        )
+        assert sum(value for _, value in evidence.no_signal_reason_histogram) == (
+            evidence.no_signal
+        )
+        assert (
+            sum(value for _, value in evidence.generator_rejection_reason_histogram)
+            == evidence.generator_rejected
+        )
+        assert (
+            dict(evidence.no_signal_reason_histogram)["missing_required_context"] >= 3
+        )
+        assert (
+            evidence.evaluated_decision_units,
+            evidence.no_signal,
+            evidence.candidate,
+            evidence.generator_rejected,
+            evidence.generator_accepted,
+            evidence.content_hash,
+        ) == expected[strategy.strategy]
+    assert smoke_result.feature_hash == (
+        "5abc827a3a3d28c02d4ad5313a299dcf0bbf95397c66d80d5e359d95193e19a2"
+    )
+    assert smoke_result.strategies[0].accepted_payloads[0].symbol == "XRPUSDT"
+    assert smoke_result.strategies[0].accepted_payloads[0].side == "long"
+    assert smoke_result.strategies[1].accepted_payloads[0].pair == "XRP-SOL"
+    assert smoke_result.strategies[1].accepted_payloads[0].side == "short_a_long_b"
+
+
+def test_localized_gap_is_absent_only_at_its_close_and_later_recovers(smoke_result):
+    assert smoke_result.gap_symbol == "SOLUSDT"
+    assert smoke_result.gap_close_absent
+    assert smoke_result.other_symbol_gap_close_present
+    assert smoke_result.recovery_close_present
+    assert smoke_result.recovery_close > smoke_result.gap_close
+
+
+def test_smoke_hashes_are_mapping_order_invariant_and_payloads_are_historical_only(
+    smoke_result,
+):
+    assert smoke_result.mapping_permutation_hashes_match
+    assert len(smoke_result.feature_hash) == 64
+    assert len(smoke_result.lineage_hash) == 64
+    assert len(smoke_result.content_hash) == 64
+    s4_strategy = smoke_result.strategies[1]
+    for accepted in s4_strategy.accepted_payloads:
+        assert accepted.volatility_percentile is None
+        assert accepted.volatility_percentile_provenance == "not_defined_for_s4"
+        assert accepted.historical_eligibility is True
+        assert accepted.leg_a_order_id is None
+        assert accepted.leg_b_order_id is None
+        assert accepted.leg_a_fill_id is None
+        assert accepted.leg_b_fill_id is None
+        assert accepted.pair_executor_provenance == "not_evaluated_h3_generator"
+
+
+def test_prepared_fold00_packet_is_absolute_bounded_and_never_executed(smoke_module):
+    packet = smoke_module.prepared_fold00_packet()
+    assert packet["status"] == "NOT_EXECUTED_AWAITING_ORCH_GO"
+    command = packet["command"]
+    assert command.startswith("env -i PATH=/Users/mgh3326/.local/bin:/usr/bin:/bin ")
+    assert " /Users/mgh3326/.local/bin/uv run python " in command
+    assert "--fold-id fold-00" in command
+    assert "--phase selected_oos" in command
+    assert "--manifest /Users/mgh3326/work/auto_trader.rob-980/" in command
+    assert "--data-root /Users/mgh3326/work/auto_trader.rob-980/" in command
+    assert "rob-979" not in command
+    schema = json.loads(packet["json_schema"])
+    assert schema["additionalProperties"] is False
+    required = set(schema["required"])
+    assert {
+        "authorities",
+        "window",
+        "universe",
+        "phase",
+        "strategies",
+    } <= required
+    assert schema["properties"]["authorities"]["additionalProperties"] is False
+    assert schema["properties"]["window"]["additionalProperties"] is False
+    strategy_schemas = schema["properties"]["strategies"]["properties"]
+    assert tuple(strategy_schemas) == ("S3", "S4")
+    assert all(
+        item["additionalProperties"] is False for item in strategy_schemas.values()
+    )
+
+
+def test_smoke_result_json_is_stable_and_contains_closed_zero_bins(smoke_result):
+    rendered = smoke_result.to_json_bytes()
+    assert rendered.endswith(b"\n")
+    assert rendered == smoke_result.to_json_bytes()
+    payload = json.loads(rendered)
+    assert payload["generator_smoke"] == "PASS"
+    assert payload["actual_h2_engine_integration"] == "NOT_EVALUATED"
+    assert tuple(payload["strategies"]) == ("S3", "S4")
+    for name, strategy in payload["strategies"].items():
+        assert 0 in strategy["no_signal_reason_histogram"].values()
+        assert tuple(strategy["generator_rejection_reason_histogram"]) == (
+            "simultaneous_candidate_arbitration_loser"
+            if name == "S3"
+            else "simultaneous_pair_arbitration_loser",
+        )
+        assert (
+            sum(strategy["generator_rejection_reason_histogram"].values())
+            == (strategy["generator_rejected"])
+        )
+    assert Path(payload["persisted_root"]).is_absolute()

--- a/research/nautilus_scalping/tests/test_rob980_cp8_h2_integration.py
+++ b/research/nautilus_scalping/tests/test_rob980_cp8_h2_integration.py
@@ -1,0 +1,375 @@
+"""ROB-980 CP8: merged ROB-979 DTO/engine integration through one adapter."""
+
+from __future__ import annotations
+
+import ast
+import importlib
+import importlib.util
+import inspect
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+import rob941_offline_loader as loader
+import rob974_h3_smoke as h3_smoke
+from rob941_manifest import CorpusManifest
+from rob974_h3_evidence import build_unique_generator_evidence
+from rob974_h3_manifest import SYMBOLS, S3Config, S4Config, get_config
+from rob974_h3_s3 import generate_s3_global
+from rob974_h3_s4 import generate_s4_global
+
+_ADAPTER_NAME = "rob974_h3_h2_adapter"
+_ADAPTER_SPEC = importlib.util.find_spec(_ADAPTER_NAME)
+adapter = importlib.import_module(_ADAPTER_NAME) if _ADAPTER_SPEC is not None else None
+
+_FOLD_ID = "rob941-shaped-persisted-synthetic"
+_MINUTE_MS = 60_000
+
+
+def test_cp8_adapter_behavior_is_implemented():
+    assert adapter is not None, "ROB-980 CP8 merged-H2 integration is not implemented"
+
+
+@pytest.fixture(scope="module")
+def pipeline(tmp_path_factory):
+    assert adapter is not None
+    root = tmp_path_factory.mktemp("rob980-cp8-persisted")
+
+    # Preserve the CP7 fixture byte-for-byte while extending a CP8-only persisted
+    # corpus by two complete 4h bars.  At the first new bar, market=-20% and the
+    # residual rises +20%: XRP stays flat while DOGE/SOL fall, making the next
+    # synchronized uppercase M negative without stopping the accepted S3 long.
+    base_market = h3_smoke._market_returns()
+    base_residual = h3_smoke._residual_states()
+    original_count = h3_smoke._SMOKE_4H_BARS
+    original_market = h3_smoke._market_returns
+    original_residual = h3_smoke._residual_states
+    try:
+        h3_smoke._SMOKE_4H_BARS = original_count + 2
+        h3_smoke._market_returns = lambda: base_market + (-0.20, 0.0)
+        h3_smoke._residual_states = lambda: base_residual + (0.24, 0.24)
+        manifest = h3_smoke._persist_synthetic_corpus(root)
+    finally:
+        h3_smoke._SMOKE_4H_BARS = original_count
+        h3_smoke._market_returns = original_market
+        h3_smoke._residual_states = original_residual
+
+    manifest_path = root / "rob980-smoke-manifest.json"
+    reloaded = CorpusManifest.load(manifest_path)
+    assert manifest.content_hash() == reloaded.content_hash()
+    loaded = loader.load_corpus(reloaded, root)
+    minutes = h3_smoke._selected_minutes(loaded)
+    context, feature_hash = h3_smoke._context(minutes)
+
+    s3_config = get_config("S3-05")
+    s4_config = get_config("S4-01")
+    assert type(s3_config) is S3Config
+    assert type(s4_config) is S4Config
+    emit_window = h3_smoke._smoke_emit_window()
+    s3_output = generate_s3_global(context, emit_window, s3_config)
+    s4_output = generate_s4_global(context, emit_window, s4_config)
+    s3_evidence = build_unique_generator_evidence(
+        s3_output, fold_or_full_window=_FOLD_ID, phase="offline_smoke"
+    )
+    s4_evidence = build_unique_generator_evidence(
+        s4_output, fold_or_full_window=_FOLD_ID, phase="offline_smoke"
+    )
+    corpus_end_ts = max(rows[-1].ts for rows in minutes.values()) + _MINUTE_MS
+    integration = adapter.run_h2_integration(
+        s3_output,
+        s4_output,
+        minutes,
+        context,
+        fold_id=_FOLD_ID,
+        corpus_end_ts=corpus_end_ts,
+    )
+    return {
+        "root": root,
+        "minutes": minutes,
+        "context": context,
+        "feature_hash": feature_hash,
+        "s3_config": s3_config,
+        "s4_config": s4_config,
+        "s3_output": s3_output,
+        "s4_output": s4_output,
+        "s3_evidence": s3_evidence,
+        "s4_evidence": s4_evidence,
+        "corpus_end_ts": corpus_end_ts,
+        "integration": integration,
+    }
+
+
+def test_real_persisted_h1_h3_h2_path_is_non_vacuous(pipeline):
+    result = pipeline["integration"]
+    for strategy in ("s3", "s4"):
+        evidence = pipeline[f"{strategy}_evidence"]
+        assert evidence.candidate > 0
+        assert evidence.generator_rejected > 0
+        assert evidence.generator_accepted > 0
+        assert len(getattr(result, f"{strategy}_engine_result").trades) > 0
+
+    assert any(
+        trade.exit_reason == "THESIS_EXIT" for trade in result.s3_engine_result.trades
+    )
+    assert result.s4_engine_result.trades
+    assert all(len(trade.pair) == 2 for trade in result.s4_engine_result.trades)
+    assert result.s3_scenario_rows
+    assert result.s4_scenario_rows
+
+
+def test_missing_minute_remains_h3_no_signal_and_later_closes_trade(pipeline):
+    gap_close = (
+        h3_smoke.frozen.WINDOW_START_MS
+        + (h3_smoke._GAP_BAR_INDEX + 1) * h3_smoke.FOUR_HOUR_MS
+    )
+    s3_gap = [
+        item
+        for item in pipeline["s3_output"].decisions
+        if item.decision_ts == gap_close and item.symbol == "SOLUSDT"
+    ]
+    assert len(s3_gap) == 1
+    assert s3_gap[0].status == "NO_SIGNAL"
+    assert s3_gap[0].no_signal_reason == "missing_required_context"
+    assert any(
+        trade.signal_ts > gap_close
+        for trade in pipeline["integration"].s3_engine_result.trades
+    )
+    assert any(
+        trade.signal_ts > gap_close
+        for trade in pipeline["integration"].s4_engine_result.trades
+    )
+
+
+def test_s3_mapping_preserves_distances_percentile_and_timestamps(pipeline):
+    output = pipeline["s3_output"]
+    intents = pipeline["integration"].s3_intents
+    assert len(intents) == len(output.accepted)
+    for candidate, intent in zip(output.accepted, intents, strict=True):
+        assert type(intent.signal_ts) is int
+        assert intent.signal_ts == candidate.decision_ts == candidate.entry_tick_ts
+        assert intent.entry_sl_distance.hex() == candidate.d_SL.hex()
+        assert intent.entry_tp_distance.hex() == candidate.d_TP.hex()
+        assert (
+            intent.volatility_percentile.hex() == candidate.volatility_percentile.hex()
+        )
+        assert intent.fold_id == _FOLD_ID
+
+
+def test_s4_mapping_uses_effective_mad_and_signed_observed_z(pipeline):
+    output = pipeline["s4_output"]
+    intents = pipeline["integration"].s4_intents
+    assert len(intents) == len(output.accepted)
+    for candidate, intent in zip(output.accepted, intents, strict=True):
+        assert intent.pair == (candidate.symbol_a, candidate.symbol_b)
+        assert intent.side_a == candidate.side_a
+        assert intent.side_b == candidate.side_b
+        assert intent.weight_a.hex() == candidate.weight_a.hex()
+        assert intent.weight_b.hex() == candidate.weight_b.hex()
+        assert intent.beta_a.hex() == candidate.beta_a.hex()
+        assert intent.beta_b.hex() == candidate.beta_b.hex()
+        assert intent.mu.hex() == candidate.mu.hex()
+        assert intent.sigma.hex() == candidate.effective_mad_scale.hex()
+        assert intent.z_entry.hex() == candidate.observed_z.hex()
+        assert intent.gross_notional.hex() == candidate.gross_notional_usd.hex()
+        assert intent.entry_sl_distance.hex() == candidate.d_SL.hex()
+        assert intent.entry_tp_distance.hex() == candidate.d_TP.hex()
+    assert any(
+        intent.sigma.hex() != candidate.sigma_pair_risk.hex()
+        for candidate, intent in zip(output.accepted, intents, strict=True)
+    )
+    assert any(
+        intent.z_entry.hex() != pipeline["s4_config"].z_entry.hex()
+        for intent in intents
+    )
+
+
+def test_real_trade_null_type_timestamp_and_provenance_are_exact(pipeline):
+    result = pipeline["integration"]
+    thesis = next(
+        trade
+        for trade in result.s3_engine_result.trades
+        if trade.exit_reason == "THESIS_EXIT"
+    )
+    assert type(thesis.signal_ts) is int
+    assert type(thesis.entry_ts) is int
+    assert type(thesis.entry_price) is float
+    assert type(thesis.volatility_percentile) is float
+    assert thesis.entry_ts == thesis.signal_ts
+
+    for trade in result.s4_engine_result.trades:
+        assert type(trade.signal_ts) is int
+        assert type(trade.entry_ts) is int
+        assert type(trade.sigma) is float
+        assert type(trade.z_entry) is float
+        assert trade.entry_ts == trade.signal_ts
+        assert trade.order_id_a is None
+        assert trade.order_id_b is None
+        assert trade.pair_executor_validated is False
+        assert trade.demo_eligible is False
+        assert trade.pair_exec_status == "historical_atomic_assumption"
+        assert trade.pair_exec_fail == "not_evaluated"
+        assert trade.promotion_status == "promotion_blocked_pending_pair_executor"
+        assert trade.volatility_percentile is None
+        assert trade.volatility_percentile_provenance == "not_defined_for_s4"
+
+
+def test_same_inputs_and_mapping_permutation_have_identical_bytes_and_hashes(pipeline):
+    first = pipeline["integration"]
+    kwargs = {
+        "fold_id": _FOLD_ID,
+        "corpus_end_ts": pipeline["corpus_end_ts"],
+    }
+    second = adapter.run_h2_integration(
+        pipeline["s3_output"],
+        pipeline["s4_output"],
+        pipeline["minutes"],
+        pipeline["context"],
+        **kwargs,
+    )
+    permuted = adapter.run_h2_integration(
+        pipeline["s3_output"],
+        pipeline["s4_output"],
+        {symbol: pipeline["minutes"][symbol] for symbol in reversed(SYMBOLS)},
+        pipeline["context"],
+        **kwargs,
+    )
+    assert first.to_json_bytes() == second.to_json_bytes() == permuted.to_json_bytes()
+    assert first.content_hash == second.content_hash == permuted.content_hash
+    assert first.s3_ledger_hash == second.s3_ledger_hash
+    assert first.s4_ledger_hash == second.s4_ledger_hash
+
+
+def test_actual_integration_bytes_hashes_and_exits_are_pinned(pipeline):
+    result = pipeline["integration"]
+    assert pipeline["feature_hash"] == (
+        "00a382c6fd92ad8c883d5b6290fb78acd0dbf7ee7c2ecc824b91fa023100f7ad"
+    )
+    assert result.content_hash == (
+        "3a82be84136f762598e3b8d0cd2d4c1d18bbfc97d6a224f15ac5b27529670b87"
+    )
+    assert len(result.to_json_bytes()) == 10_523
+    assert result.s3_ledger_hash == (
+        "eeb95ba24b5dc9e0c534f22b886ee191810dee395fa96047315205b92094d2c2"
+    )
+    assert result.s4_ledger_hash == (
+        "5c37e9b9156e9ffbaecbc0cdba0457eba3cf10f36e7e47d3e0a55895628791c9"
+    )
+    assert tuple(
+        (trade.symbol, trade.signal_ts, trade.exit_ts, trade.exit_reason)
+        for trade in result.s3_engine_result.trades
+    ) == (("XRPUSDT", 1_754_236_800_000, 1_754_251_200_000, "THESIS_EXIT"),)
+    assert tuple(
+        (trade.pair, trade.signal_ts, trade.exit_ts, trade.exit_reason)
+        for trade in result.s4_engine_result.trades
+    ) == (
+        (
+            ("XRPUSDT", "SOLUSDT"),
+            1_753_358_400_000,
+            1_753_373_520_000,
+            "TP",
+        ),
+        (
+            ("XRPUSDT", "SOLUSDT"),
+            1_753_545_600_000,
+            1_753_574_400_000,
+            "SL",
+        ),
+        (
+            ("XRPUSDT", "SOLUSDT"),
+            1_754_236_800_000,
+            1_754_237_220_000,
+            "SL",
+        ),
+    )
+
+
+def test_contract_drift_is_named_and_fail_closed(monkeypatch):
+    assert adapter is not None
+
+    @dataclass(frozen=True)
+    class DriftedS4Intent:
+        pair: tuple[str, str]
+        signal_ts: int
+
+    monkeypatch.setattr(adapter, "S4PairSignalIntent", DriftedS4Intent)
+    with pytest.raises(adapter.ContractDriftError, match=r"^CONTRACT_DRIFT:"):
+        adapter.verify_h2_contract()
+
+
+def test_adapter_is_the_only_h3_module_with_concrete_h2_imports():
+    source_root = Path(__file__).resolve().parents[1]
+    offenders = []
+    for path in sorted(source_root.glob("rob974_h3_*.py")):
+        if path.name == "rob974_h3_h2_adapter.py":
+            continue
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                names = tuple(alias.name for alias in node.names)
+            elif isinstance(node, ast.ImportFrom):
+                names = (node.module or "",)
+            else:
+                continue
+            if any(name.startswith("rob974_h2") for name in names):
+                offenders.append((path.name, node.lineno, names))
+    assert offenders == []
+
+
+def test_adapter_import_and_authority_surface_is_pure_and_bridge_owned():
+    path = Path(__file__).resolve().parents[1] / "rob974_h3_h2_adapter.py"
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    imported = []
+    forbidden_calls = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported.extend(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom):
+            imported.append(node.module or "")
+        elif isinstance(node, ast.Call):
+            function = node.func
+            if isinstance(function, ast.Name) and function.id in {
+                "__import__",
+                "eval",
+                "exec",
+            }:
+                forbidden_calls.append((node.lineno, function.id))
+            if isinstance(function, ast.Attribute) and function.attr in {
+                "import_module",
+                "now",
+                "today",
+                "utcnow",
+                "getenv",
+            }:
+                forbidden_calls.append((node.lineno, function.attr))
+    forbidden_roots = {
+        "app",
+        "sqlalchemy",
+        "asyncpg",
+        "psycopg",
+        "redis",
+        "taskiq",
+        "celery",
+        "httpx",
+        "requests",
+        "aiohttp",
+        "urllib",
+        "socket",
+        "websockets",
+        "boto3",
+        "fastapi",
+        "uvicorn",
+        "random",
+        "time",
+        "datetime",
+        "os",
+    }
+    assert not {name.split(".")[0] for name in imported} & forbidden_roots
+    assert forbidden_calls == []
+    assert "rob974_features" not in imported
+    assert "rob974_h2_h1_bridge" in imported
+
+
+def test_integration_seam_exposes_no_behavior_or_funding_callback():
+    parameters = inspect.signature(adapter.run_h2_integration).parameters
+    assert all("callback" not in name for name in parameters)
+    assert "funding_lookup" not in parameters


### PR DESCRIPTION
2차 캠페인 H3 — S3 RPT-4H 신호엔진 (리서치 §2 수식·anti-breakout·thesis exit·24-config). 검증: opus R1 APPROVED(반증 실패 명시)→CP8 H2 통합→최종 APPROVED. re-pin 선례 3호. 모델 조합: worker=codex-max, verifier=opus, rounds=1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JnyLNhp2ocP4u5hfqHeicJ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added deterministic S3 and S4 strategy generation with point-in-time calculations, eligibility checks, and candidate selection.
  * Added a fixed strategy roster and integrity validation for configurations and research contracts.
  * Added structured evidence records with reproducible hashes and detailed outcome summaries.
  * Added integration with execution and scenario processing, including serialized results and ledger verification.
  * Added persisted-data smoke workflows for validating generator outputs and prepared analysis packets.

* **Tests**
  * Added comprehensive coverage for calculations, thresholds, arbitration, evidence integrity, determinism, safety checks, smoke workflows, and end-to-end integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->