### PR TITLE
fix(ROB-994): terminalize zero-fill expired/canceled/rejected alpaca paper orders

### DIFF
--- a/app/services/alpaca_paper_reconcile_service.py
+++ b/app/services/alpaca_paper_reconcile_service.py
@@ -7,6 +7,7 @@ from decimal import Decimal, InvalidOperation
 from typing import Any
 
 from app.services.alpaca_paper_ledger_service import (
+    KNOWN_TERMINAL_BROKER_STATUSES,
     LIFECYCLE_ANOMALY,
     LIFECYCLE_CANCELED,
     LIFECYCLE_FILLED,
@@ -44,6 +45,16 @@ _LIFECYCLE_ACTION_LABELS: dict[str, str] = {
     LIFECYCLE_SUBMITTED: "partial",
     LIFECYCLE_ANOMALY: "anomaly",
     LIFECYCLE_CANCELED: "canceled",
+}
+
+# ROB-994 — known broker-terminal statuses that still carry zero fill evidence
+# (``FillVerdict.PENDING`` from the classifier, since filled_qty<=0). "filled"
+# is excluded: that combination is a broker/evidence contradiction handled
+# separately as ``filled_status_without_fill_evidence``, never a silent
+# terminalization. Any status outside this explicit known set stays
+# ``noop_pending`` (fail-closed) rather than being guessed at as terminal.
+_ZERO_FILL_TERMINAL_STATUSES: frozenset[str] = KNOWN_TERMINAL_BROKER_STATUSES - {
+    "filled"
 }
 
 
@@ -336,6 +347,32 @@ class AlpacaPaperReconcileService:
                 # The broker calls the order filled but produced no quantity to
                 # book. That contradiction is escalated, never a silent no-op.
                 return manual_review("filled_status_without_fill_evidence")
+            if broker_status in _ZERO_FILL_TERMINAL_STATUSES:
+                # ROB-994: a known broker-terminal, zero-fill order (expired /
+                # canceled / rejected) must not sit in noop_pending forever —
+                # terminalize it to anomaly (or canceled, with cancel evidence)
+                # via the same resolve/persist path as every other transition.
+                zero_qty = Decimal("0")
+                result.update(filled_qty=str(zero_qty), delta_qty="0")
+                transition = resolve_transition(
+                    verdict=evidence.verdict,
+                    broker_status=broker_status,
+                    filled_qty=zero_qty,
+                    has_cancel_evidence=(
+                        getattr(row, "cancel_status", None) is not None
+                        or getattr(row, "canceled_at", None) is not None
+                    ),
+                )
+                return await self._book_transition(
+                    row,
+                    order,
+                    fills,
+                    transition,
+                    broker_qty=zero_qty,
+                    avg_price=None,
+                    dry_run=dry_run,
+                    result=result,
+                )
             result.update(action="noop_pending")
             return result
 
@@ -362,6 +399,35 @@ class AlpacaPaperReconcileService:
                 or getattr(row, "canceled_at", None) is not None
             ),
         )
+        return await self._book_transition(
+            row,
+            order,
+            fills,
+            transition,
+            broker_qty=broker_qty,
+            avg_price=evidence.avg_price,
+            dry_run=dry_run,
+            result=result,
+        )
+
+    async def _book_transition(
+        self,
+        row: Any,
+        order: Any,
+        fills: list[Any],
+        transition: ReconcileTransition,
+        *,
+        broker_qty: Decimal,
+        avg_price: Decimal | None,
+        dry_run: bool,
+        result: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Persist ``transition`` (or plan it, for dry-run) and report the outcome.
+
+        Shared by every transition shape — fills and zero-fill terminalization
+        alike — so the reported ``action`` can never diverge from what
+        ``record_status`` actually persists (ROB-953 R4 invariant).
+        """
         result["transition_depth"] = transition.label
         if dry_run:
             result["lifecycle_state"] = transition.lifecycle_state
@@ -373,7 +439,7 @@ class AlpacaPaperReconcileService:
             {
                 "status": transition.broker_status,
                 "filled_qty": str(broker_qty),
-                "filled_avg_price": str(evidence.avg_price),
+                "filled_avg_price": str(avg_price) if avg_price is not None else None,
                 "id": order.id,
             },
             # raw_response is persisted to a JSONB column: Decimal is not JSON

--- a/tests/services/test_alpaca_paper_reconcile_service.py
+++ b/tests/services/test_alpaca_paper_reconcile_service.py
@@ -658,6 +658,169 @@ async def test_fill_pages_are_walked_until_the_set_is_complete() -> None:
 # ---------------------------------------------------------------------------
 
 
+# ---------------------------------------------------------------------------
+# ROB-994 — zero-fill terminal (expired/canceled/rejected) orders must not
+# sit in noop_pending forever. Reproduces the REGN sell (ledger id=18,
+# client_order_id=rob73-856b151e164fc98f) stuck 3 days as noop_pending.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_zero_fill_expired_order_books_anomaly_not_noop_pending() -> None:
+    from app.services.alpaca_paper_reconcile_service import AlpacaPaperReconcileService
+
+    ledger = Ledger([Row()])
+    order = filled_order(status="expired", qty="0")
+    result = await AlpacaPaperReconcileService(ledger, Broker(order)).reconcile(
+        dry_run=False
+    )
+    outcome = result["reconciled"][0]
+
+    assert outcome["action"] == "booked_anomaly"
+    assert outcome["lifecycle_state"] == "anomaly"
+    assert outcome["persisted_lifecycle_state"] == "anomaly"
+    assert ledger.rows[0].lifecycle_state == "anomaly"
+    assert ledger.status_calls[0]["status"] == "expired"
+    assert ledger.status_calls[0]["filled_qty"] == "0"
+
+
+@pytest.mark.asyncio
+async def test_zero_fill_rejected_order_books_anomaly() -> None:
+    from app.services.alpaca_paper_reconcile_service import AlpacaPaperReconcileService
+
+    ledger = Ledger([Row()])
+    order = filled_order(status="rejected", qty="0")
+    result = await AlpacaPaperReconcileService(ledger, Broker(order)).reconcile(
+        dry_run=False
+    )
+    outcome = result["reconciled"][0]
+
+    assert outcome["action"] == "booked_anomaly"
+    assert ledger.rows[0].lifecycle_state == "anomaly"
+
+
+@pytest.mark.asyncio
+async def test_zero_fill_canceled_order_without_cancel_evidence_books_anomaly() -> None:
+    from app.services.alpaca_paper_reconcile_service import AlpacaPaperReconcileService
+
+    ledger = Ledger([Row(cancel_status=None, canceled_at=None)])
+    order = filled_order(status="canceled", qty="0")
+    result = await AlpacaPaperReconcileService(ledger, Broker(order)).reconcile(
+        dry_run=False
+    )
+    outcome = result["reconciled"][0]
+
+    assert outcome["action"] == "booked_anomaly"
+    assert ledger.rows[0].lifecycle_state == "anomaly"
+
+
+@pytest.mark.asyncio
+async def test_zero_fill_canceled_order_with_cancel_evidence_books_canceled() -> None:
+    from app.services.alpaca_paper_reconcile_service import AlpacaPaperReconcileService
+
+    ledger = Ledger([Row(cancel_status="canceled")])
+    order = filled_order(status="canceled", qty="0")
+    result = await AlpacaPaperReconcileService(ledger, Broker(order)).reconcile(
+        dry_run=False
+    )
+    outcome = result["reconciled"][0]
+
+    assert outcome["action"] == "booked_canceled"
+    assert ledger.rows[0].lifecycle_state == "canceled"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("open_status", ["new", "accepted", "pending_new"])
+async def test_zero_fill_open_broker_status_stays_noop_pending(
+    open_status: str,
+) -> None:
+    """Regression: a zero-fill order still open at the broker must not be
+    terminalized — only the explicit known-terminal set may transition."""
+    from app.services.alpaca_paper_reconcile_service import AlpacaPaperReconcileService
+
+    ledger = Ledger([Row()])
+    order = filled_order(status=open_status, qty="0")
+    result = await AlpacaPaperReconcileService(ledger, Broker(order)).reconcile(
+        dry_run=False
+    )
+    outcome = result["reconciled"][0]
+
+    assert outcome["action"] == "noop_pending"
+    assert ledger.rows[0].lifecycle_state == "submitted"
+    assert ledger.status_calls == []
+
+
+@pytest.mark.asyncio
+async def test_zero_fill_unknown_broker_status_stays_noop_pending() -> None:
+    """An unrecognized/blank status must never be guessed at as terminal."""
+    from app.services.alpaca_paper_reconcile_service import AlpacaPaperReconcileService
+
+    ledger = Ledger([Row()])
+    order = filled_order(status="some_future_broker_status", qty="0")
+    result = await AlpacaPaperReconcileService(ledger, Broker(order)).reconcile(
+        dry_run=False
+    )
+    outcome = result["reconciled"][0]
+
+    assert outcome["action"] == "noop_pending"
+    assert ledger.rows[0].lifecycle_state == "submitted"
+    assert ledger.status_calls == []
+
+
+@pytest.mark.asyncio
+async def test_filled_status_without_fill_evidence_still_manual_review() -> None:
+    """Regression: the broker/evidence contradiction for status=filled with no
+    fill evidence must remain manual_review, never silently terminalized."""
+    from app.services.alpaca_paper_reconcile_service import AlpacaPaperReconcileService
+
+    ledger = Ledger([Row()])
+    order = filled_order(status="filled", qty="0")
+    result = await AlpacaPaperReconcileService(ledger, Broker(order)).reconcile(
+        dry_run=False
+    )
+    outcome = result["reconciled"][0]
+
+    assert outcome["action"] == "noop_requires_manual_review"
+    assert outcome["reason"] == "filled_status_without_fill_evidence"
+    assert ledger.rows[0].lifecycle_state == "submitted"
+    assert ledger.status_calls == []
+
+
+@pytest.mark.asyncio
+async def test_zero_fill_expired_dry_run_plans_without_a_ledger_write() -> None:
+    from app.services.alpaca_paper_reconcile_service import AlpacaPaperReconcileService
+
+    ledger = Ledger([Row()])
+    order = filled_order(status="expired", qty="0")
+    result = await AlpacaPaperReconcileService(ledger, Broker(order)).reconcile(
+        dry_run=True
+    )
+    outcome = result["reconciled"][0]
+
+    assert outcome["action"] == "would_book_anomaly"
+    assert outcome["lifecycle_state"] == "anomaly"
+    assert ledger.status_calls == []
+    assert ledger.rows[0].lifecycle_state == "submitted"
+
+
+@pytest.mark.asyncio
+async def test_zero_fill_terminal_booking_is_delta_idempotent_on_rerun() -> None:
+    """Once booked to anomaly, the row leaves the reconcile candidate set —
+    a rerun must not re-derive or re-write it."""
+    from app.services.alpaca_paper_reconcile_service import AlpacaPaperReconcileService
+
+    ledger = Ledger([Row()])
+    order = filled_order(status="expired", qty="0")
+    service = AlpacaPaperReconcileService(ledger, Broker(order))
+
+    first = await service.reconcile(dry_run=False)
+    second = await service.reconcile(dry_run=False)
+
+    assert first["reconciled"][0]["action"] == "booked_anomaly"
+    assert len(ledger.status_calls) == 1
+    assert second == {"success": True, "dry_run": False, "reconciled": [], "count": 0}
+
+
 @pytest.mark.asyncio
 async def test_bulk_limit_applies_after_eligibility_filters() -> None:
     """200 newer preview/terminal rows must not hide the 201st open execution."""


### PR DESCRIPTION
## Summary
- `alpaca_paper_reconcile_orders` left broker-terminal, zero-fill orders (expired/canceled/rejected) in `noop_pending` forever — the shared classifier returns `FillVerdict.PENDING` whenever `filled_qty<=0`, regardless of broker status, so the PENDING branch had no path off that state.
- Reproduced with the operational stuck row: REGN sell (ledger id=18, `client_order_id=rob73-856b151e164fc98f`), broker `status="expired"`, `filled_qty="0"` — stuck 3 days.
- Adds a known-terminal branch inside the existing `FillVerdict.PENDING` handling in `_reconcile_one` (`app/services/alpaca_paper_reconcile_service.py`): when `broker_status` is in `{rejected, expired, suspended, canceled}` (`KNOWN_TERMINAL_BROKER_STATUSES - {"filled"}`), it resolves a transition via the existing `resolve_transition()` and books it through a newly-extracted `_book_transition()` helper — **the exact same persistence path** (`record_status` → rowcount-applied + fresh-refresh confirmation → `booked_*`/`noop_stale_write_rejected`) that the non-PENDING fill-booking branch already used. No bespoke writes, no bypass of the ROB-953 R4 response↔DB invariant.
- `"filled"` is explicitly excluded from the known-terminal set — that combination stays `manual_review("filled_status_without_fill_evidence")`, unchanged.
- Any status outside the explicit known-terminal set (open/new/accepted/pending_new/unknown/blank) still falls through to `noop_pending` — fail-closed, no guessing at unknown broker statuses.

## Test plan
- [x] `uv run pytest tests/ -q -k "alpaca_paper"` — 554 passed
- [x] `uv run pytest tests/services/test_alpaca_paper_reconcile_service.py tests/services/test_alpaca_paper_ledger_service.py -q` — 118 passed
- [x] `uv run pytest tests/test_watch_triage_readonly_settings.py tests/test_route_request_lanes.py -q` — 27 passed
- [x] RED→GREEN: stashed the service change, confirmed the 6 new terminalization-behavior tests failed (`noop_pending` where `booked_anomaly`/`booked_canceled`/`would_book_anomaly` expected), restored the fix, confirmed all pass
- [x] `make lint` — ruff check/format + ty check all pass
- [x] `git diff --check` — clean
- [x] `uv run alembic heads` — single head, unchanged (no migration added)
- [ ] `gh pr checks` — pending CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)