### PR TITLE
fix(ROB-954): surface alpaca_paper ledger terminals in retrospective due-list

### DIFF
--- a/alembic/versions/20260721_rob954_terminalized_at.py
+++ b/alembic/versions/20260721_rob954_terminalized_at.py
@@ -10,8 +10,6 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 
-import sqlalchemy as sa
-
 from alembic import op
 
 # revision identifiers, used by Alembic.
@@ -27,17 +25,17 @@ _INDEX = "ix_alpaca_paper_ledger_terminalized_at"
 
 def upgrade() -> None:
     """Add the immutable first-terminal-transition timestamp and scan index."""
-    op.add_column(
-        _TABLE,
-        sa.Column("terminalized_at", sa.TIMESTAMP(timezone=True), nullable=True),
-        schema=_SCHEMA,
+    # IF NOT EXISTS keeps the repository's migration acceptance pattern valid:
+    # it creates current Base.metadata first, stamps an older revision, and then
+    # upgrades to head. Production upgrades still add the genuinely absent
+    # column normally.
+    op.execute(
+        f"ALTER TABLE {_SCHEMA}.{_TABLE} "
+        "ADD COLUMN IF NOT EXISTS terminalized_at TIMESTAMP WITH TIME ZONE"
     )
-    op.create_index(
-        _INDEX,
-        _TABLE,
-        ["terminalized_at"],
-        unique=False,
-        schema=_SCHEMA,
+    op.execute(
+        f"CREATE INDEX IF NOT EXISTS {_INDEX} "
+        f"ON {_SCHEMA}.{_TABLE} (terminalized_at)"
     )
 
     # Intentionally no data backfill: updated_at is mutable metadata time, so
@@ -48,5 +46,8 @@ def upgrade() -> None:
 
 def downgrade() -> None:
     """Remove the terminal transition timestamp and its index."""
-    op.drop_index(_INDEX, table_name=_TABLE, schema=_SCHEMA)
-    op.drop_column(_TABLE, "terminalized_at", schema=_SCHEMA)
+    op.execute(f"DROP INDEX IF EXISTS {_SCHEMA}.{_INDEX}")
+    op.execute(
+        f"ALTER TABLE {_SCHEMA}.{_TABLE} "
+        "DROP COLUMN IF EXISTS terminalized_at"
+    )

--- a/alembic/versions/20260721_rob954_terminalized_at.py
+++ b/alembic/versions/20260721_rob954_terminalized_at.py
@@ -1,0 +1,52 @@
+"""rob954_alpaca_terminalized_at
+
+Revision ID: 20260721_rob954_terminalized_at
+Revises: 20260717_rob920_alpaca_canceled
+Create Date: 2026-07-21 00:00:00
+
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "20260721_rob954_terminalized_at"
+down_revision: str | Sequence[str] | None = "20260717_rob920_alpaca_canceled"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_TABLE = "alpaca_paper_order_ledger"
+_SCHEMA = "review"
+_INDEX = "ix_alpaca_paper_ledger_terminalized_at"
+
+
+def upgrade() -> None:
+    """Add the immutable first-terminal-transition timestamp and scan index."""
+    op.add_column(
+        _TABLE,
+        sa.Column("terminalized_at", sa.TIMESTAMP(timezone=True), nullable=True),
+        schema=_SCHEMA,
+    )
+    op.create_index(
+        _INDEX,
+        _TABLE,
+        ["terminalized_at"],
+        unique=False,
+        schema=_SCHEMA,
+    )
+
+    # Intentionally no data backfill: updated_at is mutable metadata time, so
+    # copying it would fabricate a terminal transition and preserve the window
+    # churn bug in historical data. The scanner explicitly falls back to stable
+    # created_at for these pre-migration NULL terminal rows.
+
+
+def downgrade() -> None:
+    """Remove the terminal transition timestamp and its index."""
+    op.drop_index(_INDEX, table_name=_TABLE, schema=_SCHEMA)
+    op.drop_column(_TABLE, "terminalized_at", schema=_SCHEMA)

--- a/app/models/review.py
+++ b/app/models/review.py
@@ -742,6 +742,7 @@ class AlpacaPaperOrderLedger(Base):
         Index("ix_alpaca_paper_ledger_broker_order_id", "broker_order_id"),
         Index("ix_alpaca_paper_ledger_lifecycle_state", "lifecycle_state"),
         Index("ix_alpaca_paper_ledger_created_at", "created_at"),
+        Index("ix_alpaca_paper_ledger_terminalized_at", "terminalized_at"),
         Index("ix_alpaca_paper_ledger_candidate_uuid", "candidate_uuid"),
         Index(
             "ix_alpaca_paper_ledger_briefing_run_uuid",
@@ -773,6 +774,11 @@ class AlpacaPaperOrderLedger(Base):
 
     # Application lifecycle state (ROB-90 canonical)
     lifecycle_state: Mapped[str] = mapped_column(Text, nullable=False)
+
+    # ROB-954: first transition into a retrospective-terminal lifecycle state.
+    # Nullable for pre-migration rows and every still-open row; unlike updated_at,
+    # this has no onupdate hook and metadata-only writes must never move it.
+    terminalized_at: Mapped[datetime | None] = mapped_column(TIMESTAMP(timezone=True))
 
     # ROB-90: buy/sell leg role — separate from broker `side` (order direction).
     leg_role: Mapped[str | None] = mapped_column(Text)

--- a/app/schemas/alpaca_paper_ledger.py
+++ b/app/schemas/alpaca_paper_ledger.py
@@ -18,6 +18,7 @@ class AlpacaPaperOrderLedgerRead(BaseModel):
     broker: str
     account_mode: str
     lifecycle_state: str
+    terminalized_at: datetime | None = None
 
     # ROB-90 taxonomy fields
     lifecycle_correlation_id: str

--- a/app/services/alpaca_paper_ledger_service.py
+++ b/app/services/alpaca_paper_ledger_service.py
@@ -14,7 +14,7 @@ from datetime import UTC, datetime
 from decimal import Decimal
 from typing import Any
 
-from sqlalchemy import func, or_, select, text, update
+from sqlalchemy import and_, case, func, or_, select, text, update
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -82,9 +82,11 @@ RECORD_KIND_EXECUTION = "execution"
 RECORD_KIND_RECONCILE = "reconcile"
 RECORD_KIND_ANOMALY = "anomaly"
 
-# ROB-953: states a reconcile pass never re-opens as a *booking candidate*.
-# Used for candidate selection only — not as a write guard.
-RECONCILE_TERMINAL_LIFECYCLE_STATES: frozenset[str] = frozenset(
+# ROB-954: retrospective-terminal outcomes. ``terminalized_at`` is stamped only
+# on the first transition from outside this set into it. Downstream terminal to
+# terminal transitions (for example anomaly -> canceled or filled -> closed)
+# preserve the original timestamp.
+TERMINAL_LIFECYCLE_STATES: frozenset[str] = frozenset(
     {
         LIFECYCLE_FILLED,
         LIFECYCLE_POSITION_RECONCILED,
@@ -94,6 +96,10 @@ RECONCILE_TERMINAL_LIFECYCLE_STATES: frozenset[str] = frozenset(
         LIFECYCLE_ANOMALY,
     }
 )
+
+# ROB-953: states a reconcile pass never re-opens as a *booking candidate*.
+# The candidate terminal set and retrospective terminal set intentionally match.
+RECONCILE_TERMINAL_LIFECYCLE_STATES = TERMINAL_LIFECYCLE_STATES
 
 # ROB-953: states from which a status write must never resurrect a row. Only
 # *completed* downstream states qualify — position/close/final bookkeeping has
@@ -374,6 +380,36 @@ def _get_attr(row: Any, key: str, default: Any = None) -> Any:
     if isinstance(row, dict):
         return row.get(key, default)
     return getattr(row, key, default)
+
+
+def _initial_terminalized_at(lifecycle_state: str) -> Any | None:
+    """Database timestamp for a row inserted directly into a terminal state."""
+    return func.now() if lifecycle_state in TERMINAL_LIFECYCLE_STATES else None
+
+
+def _terminal_transition_timestamp(lifecycle_state: str) -> Any:
+    """Stamp only a live-row non-terminal -> terminal transition.
+
+    The CASE is evaluated by PostgreSQL against the row version being updated,
+    not against a possibly stale ORM read. Checking both the current lifecycle
+    and the nullable timestamp preserves the first transition under retries and
+    concurrent terminal writes. A legacy terminal row with NULL stays NULL on a
+    repeated terminal write and continues through the scanner's stable fallback.
+    """
+    if lifecycle_state not in TERMINAL_LIFECYCLE_STATES:
+        return AlpacaPaperOrderLedger.terminalized_at
+    return case(
+        (
+            and_(
+                AlpacaPaperOrderLedger.terminalized_at.is_(None),
+                AlpacaPaperOrderLedger.lifecycle_state.not_in(
+                    TERMINAL_LIFECYCLE_STATES
+                ),
+            ),
+            func.now(),
+        ),
+        else_=AlpacaPaperOrderLedger.terminalized_at,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -992,9 +1028,8 @@ class AlpacaPaperLedgerService:
 
         Marks the existing execution (claim) row ``anomaly`` and stamps
         ``submitted_at`` so it is no longer in-flight — a retry of the same key
-        replays this failure instead of re-POSTing. Reuses existing columns only
-        (no new schema). ``error_summary`` is redacted + length-bounded so no raw
-        broker body / token is persisted.
+        replays this failure instead of re-POSTing. ``error_summary`` is redacted
+        and length-bounded so no raw broker body / token is persisted.
         """
         target = await self._find_execution_row(client_order_id)
         if target is None:
@@ -1007,6 +1042,7 @@ class AlpacaPaperLedgerService:
             .where(AlpacaPaperOrderLedger.id == target.id)
             .values(
                 lifecycle_state=LIFECYCLE_ANOMALY,
+                terminalized_at=_terminal_transition_timestamp(LIFECYCLE_ANOMALY),
                 order_status=order_status,
                 submitted_at=datetime.now(UTC),
                 confirm_flag=True,
@@ -1214,6 +1250,7 @@ class AlpacaPaperLedgerService:
             "broker": "alpaca",
             "account_mode": "alpaca_paper",
             "lifecycle_state": lifecycle_state,
+            "terminalized_at": _initial_terminalized_at(lifecycle_state),
             "execution_symbol": execution_symbol,
             "execution_venue": execution_venue,
             "execution_asset_class": execution_asset_class,
@@ -1301,6 +1338,7 @@ class AlpacaPaperLedgerService:
             "broker": "alpaca",
             "account_mode": "alpaca_paper",
             "lifecycle_state": lc_state,
+            "terminalized_at": _initial_terminalized_at(lc_state),
             "execution_symbol": execution_symbol,
             "execution_venue": execution_venue,
             "instrument_type": instrument_type,
@@ -1396,6 +1434,7 @@ class AlpacaPaperLedgerService:
             "broker": "alpaca",
             "account_mode": "alpaca_paper",
             "lifecycle_state": lifecycle_state,
+            "terminalized_at": _initial_terminalized_at(lifecycle_state),
             "execution_symbol": source_row.execution_symbol,
             "execution_venue": source_row.execution_venue,
             "instrument_type": source_row.instrument_type,
@@ -1436,8 +1475,13 @@ class AlpacaPaperLedgerService:
         update_vals = {
             k: v
             for k, v in values.items()
-            if k not in {"client_order_id", "record_kind"} and v is not None
+            if k not in {"client_order_id", "record_kind", "terminalized_at"}
+            and v is not None
         }
+        if lifecycle_state in TERMINAL_LIFECYCLE_STATES:
+            update_vals["terminalized_at"] = _terminal_transition_timestamp(
+                lifecycle_state
+            )
         stmt = (
             pg_insert(AlpacaPaperOrderLedger)
             .values(**values)
@@ -1449,6 +1493,13 @@ class AlpacaPaperLedgerService:
         )
         await self._db.execute(stmt)
         await self._db.commit()
+        # ON CONFLICT updates bypass ORM identity-map synchronization. Refresh a
+        # pre-existing submit-claim row so callers observe the persisted state
+        # and first terminalized_at rather than the stale claimed object. A
+        # preview source has no execution identity to refresh, so re-query it.
+        if source_row.record_kind == RECORD_KIND_EXECUTION:
+            await self._db.refresh(source_row)
+            return source_row
         return await self._require_row(client_order_id)
 
     async def record_status(
@@ -1504,6 +1555,10 @@ class AlpacaPaperLedgerService:
             "filled_qty": filled_qty,
             "filled_avg_price": filled_avg_price,
         }
+        if lifecycle_state in TERMINAL_LIFECYCLE_STATES:
+            update_vals["terminalized_at"] = _terminal_transition_timestamp(
+                lifecycle_state
+            )
         if lifecycle_state == LIFECYCLE_ANOMALY:
             update_vals["error_summary"] = (
                 f"anomaly: order_status={order_status!r} during status check"
@@ -1582,6 +1637,9 @@ class AlpacaPaperLedgerService:
 
         if current_status and current_status.lower() == "canceled":
             update_vals["lifecycle_state"] = LIFECYCLE_CANCELED
+            update_vals["terminalized_at"] = _terminal_transition_timestamp(
+                LIFECYCLE_CANCELED
+            )
             err = getattr(target_row, "error_summary", None)
             if (
                 err
@@ -1641,6 +1699,9 @@ class AlpacaPaperLedgerService:
             .values(
                 position_snapshot=snapshot,
                 lifecycle_state=LIFECYCLE_POSITION_RECONCILED,
+                terminalized_at=_terminal_transition_timestamp(
+                    LIFECYCLE_POSITION_RECONCILED
+                ),
             )
         )
 
@@ -1750,6 +1811,7 @@ class AlpacaPaperLedgerService:
 
         update_vals: dict[str, Any] = {
             "lifecycle_state": LIFECYCLE_CLOSED,
+            "terminalized_at": _terminal_transition_timestamp(LIFECYCLE_CLOSED),
         }
         if qty_delta is not None:
             update_vals["qty_delta"] = qty_delta
@@ -1819,6 +1881,9 @@ class AlpacaPaperLedgerService:
 
         update_vals: dict[str, Any] = {
             "lifecycle_state": LIFECYCLE_FINAL_RECONCILED,
+            "terminalized_at": _terminal_transition_timestamp(
+                LIFECYCLE_FINAL_RECONCILED
+            ),
             "record_kind": RECORD_KIND_RECONCILE,
             "reconcile_status": reconcile_status,
             "reconciled_at": datetime.now(UTC),
@@ -1854,6 +1919,7 @@ __all__ = [
     "EXECUTED_LIFECYCLE_STATES",
     "RECONCILE_IMMUTABLE_LIFECYCLE_STATES",
     "RECONCILE_TERMINAL_LIFECYCLE_STATES",
+    "TERMINAL_LIFECYCLE_STATES",
     "derive_lifecycle_state",
     "LIFECYCLE_ANOMALY",
     "LIFECYCLE_CANCELED",

--- a/app/services/trade_journal/trade_retrospective_service.py
+++ b/app/services/trade_journal/trade_retrospective_service.py
@@ -38,6 +38,9 @@ from app.schemas.trade_retrospective import (
 from app.services.alpaca_paper_ledger_service import (
     RECORD_KIND_EXECUTION as _ALPACA_PAPER_RECORD_KIND_EXECUTION,
 )
+from app.services.alpaca_paper_ledger_service import (
+    RECORD_KIND_RECONCILE as _ALPACA_PAPER_RECORD_KIND_RECONCILE,
+)
 from app.services.brokers.kis.mock_scalping_exec.ledger_state import real_order_filter
 from app.services.trade_journal.retrospective_action_repository import (
     ActionControlError,
@@ -1079,6 +1082,24 @@ _ALPACA_PAPER_DEFAULT_TERMINAL = frozenset(
     {"filled", "position_reconciled", "closed", "final_reconciled", "anomaly"}
 )
 _ALPACA_PAPER_CANCEL_TERMINAL = frozenset({"canceled"})
+# ROB-954 round-2: record_kind alone is not a stable identity for "the
+# execution row". AlpacaPaperLedgerService.record_final_reconcile() flips
+# record_kind from 'execution' to 'reconcile' on the *same* row (an in-place
+# UPDATE, not a second INSERT) at the exact moment it books
+# lifecycle_state='final_reconciled' — every other terminal lifecycle_state
+# (filled/position_reconciled/closed/anomaly/canceled) is reached through
+# record_status/record_cancel/record_position_snapshot/record_close/
+# record_submit_failure, none of which ever touch record_kind, so they stay
+# 'execution'. Scanning only 'execution' therefore made every
+# final_reconciled roundtrip invisible to the due-list. 'reconcile' is safe
+# to add here: it is never produced by an INSERT (only this one UPDATE path),
+# so it cannot introduce a second row for an order already counted under
+# 'execution'. plan/preview/validation_attempt remain excluded — audited
+# against every AlpacaPaperLedgerService.record_* method, none of them ever
+# set a terminal lifecycle_state on those record_kinds.
+_ALPACA_PAPER_RECORD_KINDS = frozenset(
+    {_ALPACA_PAPER_RECORD_KIND_EXECUTION, _ALPACA_PAPER_RECORD_KIND_RECONCILE}
+)
 
 _KIS_LIVE_TERMINAL = _KIS_LIVE_DEFAULT_TERMINAL | _KIS_LIVE_CANCEL_TERMINAL
 _GENERIC_LIVE_TERMINAL = _GENERIC_LIVE_DEFAULT_TERMINAL | _GENERIC_LIVE_CANCEL_TERMINAL
@@ -1393,31 +1414,52 @@ async def build_retrospective_pending(
 
     # 6. Alpaca paper ledger (ROB-954) — US equity/crypto paper execution loop
     # (ROB-953 reconcile + ROB-994 zero-fill terminalization). Scoped to
-    # record_kind='execution': plan/preview/validation_attempt/reconcile/anomaly
-    # record_kinds are bookkeeping rows sharing the same (client_order_id,
-    # record_kind) unique-slot family, not a second order — scanning them would
-    # double-surface a single execution as multiple due-list entries.
+    # record_kind IN {execution, reconcile} — see _ALPACA_PAPER_RECORD_KINDS
+    # for why 'reconcile' belongs alongside 'execution'. plan/preview/
+    # validation_attempt record_kinds are bookkeeping rows sharing the same
+    # (client_order_id, record_kind) unique-slot family, not a second order —
+    # scanning them would double-surface a single execution as multiple
+    # due-list entries.
     if account_mode in (None, "alpaca_paper"):
-        # This ledger has no trade_date column. `submitted_at` is NULL for an
-        # execution row still claimed-but-not-yet-sent, so it cannot anchor the
-        # window without silently dropping otherwise-terminal rows; `created_at`
-        # (NOT NULL, stamped at claim time) is the one timestamp guaranteed
-        # present on every execution row and is already the ordering key used
-        # elsewhere in this ledger (list_recent/list_reconcile_candidates).
+        # ROB-954 round-2: window anchors on `updated_at`, not `created_at`.
+        # `created_at` is claim time and never changes again; a row claimed
+        # days ago that only becomes terminal today was invisible in today's
+        # window under the old anchor (the REGN long-stall repro — see
+        # test_stale_created_at_with_recent_terminal_transition_surfaces_in_narrow_window).
+        # `updated_at` (NOT NULL, onupdate=func.now()) is bumped by every
+        # ledger write, including the terminal-transition write itself, so it
+        # tracks "when this row last became actionable" the same way
+        # KISMockOrderLedger.reconciled_at is stamped in
+        # apply_lifecycle_transition when next_state is terminal — a
+        # terminal-transition timestamp, not a send-time one.
         stmt = (
             select(AlpacaPaperOrderLedger)
             .where(
-                AlpacaPaperOrderLedger.record_kind
-                == _ALPACA_PAPER_RECORD_KIND_EXECUTION,
+                AlpacaPaperOrderLedger.record_kind.in_(_ALPACA_PAPER_RECORD_KINDS),
                 AlpacaPaperOrderLedger.lifecycle_state.in_(_ALPACA_PAPER_TERMINAL),
-                AlpacaPaperOrderLedger.created_at >= window_start,
-                AlpacaPaperOrderLedger.created_at <= window_end,
+                AlpacaPaperOrderLedger.updated_at >= window_start,
+                AlpacaPaperOrderLedger.updated_at <= window_end,
             )
-            .order_by(AlpacaPaperOrderLedger.created_at.desc())
+            .order_by(AlpacaPaperOrderLedger.updated_at.desc())
             .limit(_PENDING_LEDGER_FETCH_CAP)
         )
+        # ROB-954 round-2: a buy/sell roundtrip's two execution rows can share
+        # one lifecycle_correlation_id. review.trade_retrospectives enforces
+        # UNIQUE(correlation_id, account_mode) (app/models/review.py), so two
+        # independent due entries for the same correlation_id can never both
+        # be resolved — saving one retrospective always covers both rows at
+        # once. Collapse to a single due entry per (lifecycle_correlation_id)
+        # before appending, keyed on the row with the latest updated_at (the
+        # most recently terminal-transitioned leg — typically the closing/
+        # sell leg, since it settles after the entry leg).
+        by_correlation: dict[str, AlpacaPaperOrderLedger] = {}
         for row in (await db.execute(stmt)).scalars().all():
             scanned += 1
+            key = row.lifecycle_correlation_id
+            current = by_correlation.get(key)
+            if current is None or row.updated_at > current.updated_at:
+                by_correlation[key] = row
+        for row in by_correlation.values():
             itype = row.instrument_type.value
             market = "crypto" if itype == "crypto" else itype.removeprefix("equity_")
             entry = _pending_entry(
@@ -1430,7 +1472,7 @@ async def build_retrospective_pending(
                 status=row.lifecycle_state,
                 order_ref=row.client_order_id,
                 report_item_uuid=None,
-                trade_date=row.created_at,
+                trade_date=row.updated_at,
                 row_id=row.id,
                 suggested_correlation_id=row.lifecycle_correlation_id,
             )

--- a/app/services/trade_journal/trade_retrospective_service.py
+++ b/app/services/trade_journal/trade_retrospective_service.py
@@ -21,6 +21,7 @@ from app.core.symbol import to_db_symbol
 from app.core.timezone import now_kst
 from app.models.paper_trading import PaperTrade
 from app.models.review import (
+    AlpacaPaperOrderLedger,
     KISLiveOrderLedger,
     KISMockOrderLedger,
     LiveOrderLedger,
@@ -33,6 +34,9 @@ from app.schemas.trade_retrospective import (
     VALID_TRIGGER_TYPES,
     IntendedVsHappened,
     NextAction,
+)
+from app.services.alpaca_paper_ledger_service import (
+    RECORD_KIND_EXECUTION as _ALPACA_PAPER_RECORD_KIND_EXECUTION,
 )
 from app.services.brokers.kis.mock_scalping_exec.ledger_state import real_order_filter
 from app.services.trade_journal.retrospective_action_repository import (
@@ -1061,11 +1065,26 @@ _TOSS_CANCEL_TERMINAL = frozenset({"cancelled", "cancel_rejected", "replace_reje
 # churn, hidden by default like live expiry.
 _KIS_MOCK_DEFAULT_TERMINAL = frozenset({"fill", "reconciled", "failed", "anomaly"})
 _KIS_MOCK_CANCEL_TERMINAL = frozenset({"cancelled", "stale"})
+# ROB-954: Alpaca Paper terminality is keyed on `lifecycle_state` (the ROB-90
+# canonical state machine), never the raw broker `order_status` — same
+# convention as kis_mock above. ROB-953 reconcile books proven fills into
+# filled/position_reconciled/closed/final_reconciled; ROB-994 additionally
+# terminalizes known broker-terminal zero-fill orders (expired/canceled/
+# rejected evidence) into `anomaly`, or into `canceled` when cancel evidence
+# is present — so both belong in the terminal set or those rows never surface.
+# NOTE spelling: the alpaca ledger's cancel state is `canceled` (one L) — do
+# not conflate with the `cancelled` (two L) spelling used by the KIS/generic/
+# Toss ledgers above; they are deliberately distinct strings.
+_ALPACA_PAPER_DEFAULT_TERMINAL = frozenset(
+    {"filled", "position_reconciled", "closed", "final_reconciled", "anomaly"}
+)
+_ALPACA_PAPER_CANCEL_TERMINAL = frozenset({"canceled"})
 
 _KIS_LIVE_TERMINAL = _KIS_LIVE_DEFAULT_TERMINAL | _KIS_LIVE_CANCEL_TERMINAL
 _GENERIC_LIVE_TERMINAL = _GENERIC_LIVE_DEFAULT_TERMINAL | _GENERIC_LIVE_CANCEL_TERMINAL
 _TOSS_TERMINAL = _TOSS_DEFAULT_TERMINAL | _TOSS_CANCEL_TERMINAL
 _KIS_MOCK_TERMINAL = _KIS_MOCK_DEFAULT_TERMINAL | _KIS_MOCK_CANCEL_TERMINAL
+_ALPACA_PAPER_TERMINAL = _ALPACA_PAPER_DEFAULT_TERMINAL | _ALPACA_PAPER_CANCEL_TERMINAL
 
 # Statuses hidden from `pending` unless include_cancelled=True. Disjoint from the
 # DEFAULT statuses (note: `rejected` is DEFAULT; `cancel_rejected` /
@@ -1075,6 +1094,7 @@ _CANCEL_FAMILY_STATUSES = (
     | _GENERIC_LIVE_CANCEL_TERMINAL
     | _TOSS_CANCEL_TERMINAL
     | _KIS_MOCK_CANCEL_TERMINAL
+    | _ALPACA_PAPER_CANCEL_TERMINAL
 )
 # Bound per-ledger scan so a wide window cannot load unbounded rows.
 _PENDING_LEDGER_FETCH_CAP = 1000
@@ -1172,13 +1192,13 @@ async def build_retrospective_pending(
     """List terminal ledger orders lacking a retrospective.
 
     Read-only. Scans review.{kis_live_order_ledger, live_order_ledger,
-    toss_live_order_ledger, kis_mock_order_ledger} plus paper_trades for
-    lifecycle-terminal rows in the KST trade_date window, then subtracts rows
-    already covered by a retrospective (matched on report_item_uuid or the
-    suggested correlation_id). Mirrors the ROB-120 coverage pattern
-    (terminal-without-artifact). Filter to one source with account_mode
-    (e.g. "kis_mock" for the counterfactual mock loop, "kis_live"/"toss_live"/
-    "upbit_live"/"paper" otherwise); None scans all.
+    toss_live_order_ledger, kis_mock_order_ledger, alpaca_paper_order_ledger}
+    plus paper_trades for lifecycle-terminal rows in the KST trade_date window,
+    then subtracts rows already covered by a retrospective (matched on
+    report_item_uuid or the suggested correlation_id). Mirrors the ROB-120
+    coverage pattern (terminal-without-artifact). Filter to one source with
+    account_mode (e.g. "kis_mock" for the counterfactual mock loop, "kis_live"/
+    "toss_live"/"upbit_live"/"paper"/"alpaca_paper" otherwise); None scans all.
 
     Cancel-family rows (cancelled / cancel_rejected / replace_rejected) are
     hidden unless include_cancelled=True; the hidden count is reported in
@@ -1367,6 +1387,52 @@ async def build_retrospective_pending(
                 trade_date=row.trade_date,
                 row_id=row.id,
                 suggested_correlation_id=row.correlation_id,
+            )
+            if not _is_covered(entry, covered_cids, covered_item_uuids):
+                pending.append(entry)
+
+    # 6. Alpaca paper ledger (ROB-954) — US equity/crypto paper execution loop
+    # (ROB-953 reconcile + ROB-994 zero-fill terminalization). Scoped to
+    # record_kind='execution': plan/preview/validation_attempt/reconcile/anomaly
+    # record_kinds are bookkeeping rows sharing the same (client_order_id,
+    # record_kind) unique-slot family, not a second order — scanning them would
+    # double-surface a single execution as multiple due-list entries.
+    if account_mode in (None, "alpaca_paper"):
+        # This ledger has no trade_date column. `submitted_at` is NULL for an
+        # execution row still claimed-but-not-yet-sent, so it cannot anchor the
+        # window without silently dropping otherwise-terminal rows; `created_at`
+        # (NOT NULL, stamped at claim time) is the one timestamp guaranteed
+        # present on every execution row and is already the ordering key used
+        # elsewhere in this ledger (list_recent/list_reconcile_candidates).
+        stmt = (
+            select(AlpacaPaperOrderLedger)
+            .where(
+                AlpacaPaperOrderLedger.record_kind
+                == _ALPACA_PAPER_RECORD_KIND_EXECUTION,
+                AlpacaPaperOrderLedger.lifecycle_state.in_(_ALPACA_PAPER_TERMINAL),
+                AlpacaPaperOrderLedger.created_at >= window_start,
+                AlpacaPaperOrderLedger.created_at <= window_end,
+            )
+            .order_by(AlpacaPaperOrderLedger.created_at.desc())
+            .limit(_PENDING_LEDGER_FETCH_CAP)
+        )
+        for row in (await db.execute(stmt)).scalars().all():
+            scanned += 1
+            itype = row.instrument_type.value
+            market = "crypto" if itype == "crypto" else itype.removeprefix("equity_")
+            entry = _pending_entry(
+                ledger="alpaca_paper",
+                account_mode="alpaca_paper",
+                market=market,
+                instrument_type=itype,
+                symbol=row.execution_symbol,
+                side=row.side,
+                status=row.lifecycle_state,
+                order_ref=row.client_order_id,
+                report_item_uuid=None,
+                trade_date=row.created_at,
+                row_id=row.id,
+                suggested_correlation_id=row.lifecycle_correlation_id,
             )
             if not _is_covered(entry, covered_cids, covered_item_uuids):
                 pending.append(entry)

--- a/app/services/trade_journal/trade_retrospective_service.py
+++ b/app/services/trade_journal/trade_retrospective_service.py
@@ -13,7 +13,7 @@ from typing import Any
 from zoneinfo import ZoneInfo
 
 from pydantic import ValidationError
-from sqlalchemy import func, select, text
+from sqlalchemy import and_, func, or_, select, text
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -1086,17 +1086,16 @@ _ALPACA_PAPER_CANCEL_TERMINAL = frozenset({"canceled"})
 # execution row". AlpacaPaperLedgerService.record_final_reconcile() flips
 # record_kind from 'execution' to 'reconcile' on the *same* row (an in-place
 # UPDATE, not a second INSERT) at the exact moment it books
-# lifecycle_state='final_reconciled' — every other terminal lifecycle_state
-# (filled/position_reconciled/closed/anomaly/canceled) is reached through
-# record_status/record_cancel/record_position_snapshot/record_close/
-# record_submit_failure, none of which ever touch record_kind, so they stay
-# 'execution'. Scanning only 'execution' therefore made every
+# lifecycle_state='final_reconciled' — terminal execution lifecycle states are
+# otherwise reached through record_submit/record_submit_failure/record_status/
+# record_cancel/record_position_snapshot/record_close, none of which ever touch
+# record_kind, so they stay 'execution'. Scanning only 'execution' therefore made every
 # final_reconciled roundtrip invisible to the due-list. 'reconcile' is safe
 # to add here: it is never produced by an INSERT (only this one UPDATE path),
 # so it cannot introduce a second row for an order already counted under
-# 'execution'. plan/preview/validation_attempt remain excluded — audited
-# against every AlpacaPaperLedgerService.record_* method, none of them ever
-# set a terminal lifecycle_state on those record_kinds.
+# 'execution'. plan/preview/validation_attempt remain excluded because they are
+# bookkeeping rather than confirmed execution rows; failed validation/preview
+# bookkeeping may be `anomaly` but must not create an execution retrospective.
 _ALPACA_PAPER_RECORD_KINDS = frozenset(
     {_ALPACA_PAPER_RECORD_KIND_EXECUTION, _ALPACA_PAPER_RECORD_KIND_RECONCILE}
 )
@@ -1106,6 +1105,89 @@ _GENERIC_LIVE_TERMINAL = _GENERIC_LIVE_DEFAULT_TERMINAL | _GENERIC_LIVE_CANCEL_T
 _TOSS_TERMINAL = _TOSS_DEFAULT_TERMINAL | _TOSS_CANCEL_TERMINAL
 _KIS_MOCK_TERMINAL = _KIS_MOCK_DEFAULT_TERMINAL | _KIS_MOCK_CANCEL_TERMINAL
 _ALPACA_PAPER_TERMINAL = _ALPACA_PAPER_DEFAULT_TERMINAL | _ALPACA_PAPER_CANCEL_TERMINAL
+
+# Representative selection is independent of mutable metadata timestamps.
+# A completed closing leg is the most informative roundtrip summary; then prefer
+# an explicit sell leg, lifecycle maturity, the stable terminal window instant,
+# and finally the immutable primary key as a deterministic tie-break.
+_ALPACA_PAPER_STATE_PRIORITY = {
+    "canceled": 0,
+    "anomaly": 1,
+    "filled": 2,
+    "position_reconciled": 3,
+    "closed": 4,
+    "final_reconciled": 5,
+}
+
+
+def _alpaca_paper_window_at(row: AlpacaPaperOrderLedger) -> datetime:
+    # ROB-954 R3 legacy policy: do not backfill an unknowable historical
+    # transition from mutable updated_at. Pre-migration terminal rows retain
+    # NULL and use immutable created_at, so later metadata writes cannot churn
+    # their retrospective window. New terminal transitions always stamp the
+    # dedicated column in AlpacaPaperLedgerService.
+    return row.terminalized_at or row.created_at
+
+
+def _alpaca_paper_representative_rank(
+    row: AlpacaPaperOrderLedger,
+) -> tuple[int, int, int, datetime, int]:
+    return (
+        int(row.lifecycle_state in {"closed", "final_reconciled"}),
+        int(row.side == "sell" or row.leg_role == "sell"),
+        _ALPACA_PAPER_STATE_PRIORITY.get(row.lifecycle_state, -1),
+        _alpaca_paper_window_at(row),
+        row.id,
+    )
+
+
+def _alpaca_paper_correlation_anomaly(
+    rows: list[AlpacaPaperOrderLedger],
+) -> dict[str, Any] | None:
+    """Describe malformed cross-leg identity without emitting unresolvable dupes.
+
+    One retrospective is uniquely keyed by (correlation_id, account_mode), so
+    emitting an entry per malformed member would create due rows that cannot all
+    be resolved. Keep one deterministic representative and attach every member
+    as anomaly evidence instead; no execution is silently discarded.
+    """
+
+    def instrument_type(row: AlpacaPaperOrderLedger) -> str:
+        return getattr(row.instrument_type, "value", str(row.instrument_type))
+
+    identities = {
+        (
+            row.execution_symbol,
+            row.execution_venue,
+            instrument_type(row),
+            row.account_mode,
+        )
+        for row in rows
+    }
+    if len(identities) <= 1:
+        return None
+
+    members = sorted(rows, key=lambda row: row.id)
+    return {
+        "code": "inconsistent_correlation_group",
+        "group_size": len(members),
+        "ledger_row_ids": [row.id for row in members],
+        "client_order_ids": sorted(row.client_order_id for row in members),
+        "symbols": sorted({row.execution_symbol for row in members}),
+        "execution_venues": sorted({row.execution_venue for row in members}),
+        "instrument_types": sorted({instrument_type(row) for row in members}),
+        "members": [
+            {
+                "ledger_row_id": row.id,
+                "client_order_id": row.client_order_id,
+                "symbol": row.execution_symbol,
+                "side": row.side,
+                "status": row.lifecycle_state,
+            }
+            for row in members
+        ],
+    }
+
 
 # Statuses hidden from `pending` unless include_cancelled=True. Disjoint from the
 # DEFAULT statuses (note: `rejected` is DEFAULT; `cancel_rejected` /
@@ -1421,45 +1503,51 @@ async def build_retrospective_pending(
     # scanning them would double-surface a single execution as multiple
     # due-list entries.
     if account_mode in (None, "alpaca_paper"):
-        # ROB-954 round-2: window anchors on `updated_at`, not `created_at`.
-        # `created_at` is claim time and never changes again; a row claimed
-        # days ago that only becomes terminal today was invisible in today's
-        # window under the old anchor (the REGN long-stall repro — see
-        # test_stale_created_at_with_recent_terminal_transition_surfaces_in_narrow_window).
-        # `updated_at` (NOT NULL, onupdate=func.now()) is bumped by every
-        # ledger write, including the terminal-transition write itself, so it
-        # tracks "when this row last became actionable" the same way
-        # KISMockOrderLedger.reconciled_at is stamped in
-        # apply_lifecycle_transition when next_state is terminal — a
-        # terminal-transition timestamp, not a send-time one.
+        # ROB-954 R3: terminalized_at is the first terminal transition, not the
+        # mutable updated_at. Existing terminal rows have NULL after this
+        # additive migration; created_at is the deliberate stable fallback.
+        # Express the fallback as two indexed branches (terminalized_at has the
+        # R3 index, created_at already has one) rather than COALESCE in WHERE.
+        terminal_window_at = func.coalesce(
+            AlpacaPaperOrderLedger.terminalized_at,
+            AlpacaPaperOrderLedger.created_at,
+        )
         stmt = (
             select(AlpacaPaperOrderLedger)
             .where(
                 AlpacaPaperOrderLedger.record_kind.in_(_ALPACA_PAPER_RECORD_KINDS),
                 AlpacaPaperOrderLedger.lifecycle_state.in_(_ALPACA_PAPER_TERMINAL),
-                AlpacaPaperOrderLedger.updated_at >= window_start,
-                AlpacaPaperOrderLedger.updated_at <= window_end,
+                or_(
+                    and_(
+                        AlpacaPaperOrderLedger.terminalized_at.is_not(None),
+                        AlpacaPaperOrderLedger.terminalized_at >= window_start,
+                        AlpacaPaperOrderLedger.terminalized_at <= window_end,
+                    ),
+                    and_(
+                        AlpacaPaperOrderLedger.terminalized_at.is_(None),
+                        AlpacaPaperOrderLedger.created_at >= window_start,
+                        AlpacaPaperOrderLedger.created_at <= window_end,
+                    ),
+                ),
             )
-            .order_by(AlpacaPaperOrderLedger.updated_at.desc())
+            .order_by(terminal_window_at.desc(), AlpacaPaperOrderLedger.id.desc())
             .limit(_PENDING_LEDGER_FETCH_CAP)
         )
-        # ROB-954 round-2: a buy/sell roundtrip's two execution rows can share
+        # ROB-954 R3: a buy/sell roundtrip's two execution rows can share
         # one lifecycle_correlation_id. review.trade_retrospectives enforces
         # UNIQUE(correlation_id, account_mode) (app/models/review.py), so two
         # independent due entries for the same correlation_id can never both
         # be resolved — saving one retrospective always covers both rows at
-        # once. Collapse to a single due entry per (lifecycle_correlation_id)
-        # before appending, keyed on the row with the latest updated_at (the
-        # most recently terminal-transitioned leg — typically the closing/
-        # sell leg, since it settles after the entry leg).
-        by_correlation: dict[str, AlpacaPaperOrderLedger] = {}
+        # once. Collapse to one deterministic close/sell-first representative;
+        # metadata-only updated_at changes play no role. Identity-inconsistent
+        # groups keep every member in correlation_anomaly evidence below.
+        by_correlation: dict[str, list[AlpacaPaperOrderLedger]] = {}
         for row in (await db.execute(stmt)).scalars().all():
             scanned += 1
-            key = row.lifecycle_correlation_id
-            current = by_correlation.get(key)
-            if current is None or row.updated_at > current.updated_at:
-                by_correlation[key] = row
-        for row in by_correlation.values():
+            key = row.lifecycle_correlation_id or f"ledger-row:{row.id}"
+            by_correlation.setdefault(key, []).append(row)
+        for group in by_correlation.values():
+            row = max(group, key=_alpaca_paper_representative_rank)
             itype = row.instrument_type.value
             market = "crypto" if itype == "crypto" else itype.removeprefix("equity_")
             entry = _pending_entry(
@@ -1472,10 +1560,13 @@ async def build_retrospective_pending(
                 status=row.lifecycle_state,
                 order_ref=row.client_order_id,
                 report_item_uuid=None,
-                trade_date=row.updated_at,
+                trade_date=_alpaca_paper_window_at(row),
                 row_id=row.id,
                 suggested_correlation_id=row.lifecycle_correlation_id,
             )
+            anomaly = _alpaca_paper_correlation_anomaly(group)
+            if anomaly is not None:
+                entry["correlation_anomaly"] = anomaly
             if not _is_covered(entry, covered_cids, covered_item_uuids):
                 pending.append(entry)
 

--- a/tests/_schema_bootstrap.py
+++ b/tests/_schema_bootstrap.py
@@ -54,7 +54,8 @@ from sqlalchemy import text
 # The ORM tables are built by create_all; the trigger functions are non-ORM DDL
 # mirrored here.
 # v25 (ROB-920): update alpaca_paper_order_ledger check constraint to include canceled state.
-SCHEMA_BOOTSTRAP_VERSION = 25
+# v26 (ROB-954): add the dedicated terminal transition timestamp + scan index.
+SCHEMA_BOOTSTRAP_VERSION = 26
 
 # ---- constraints + enums (moved verbatim from conftest.py) ----
 MARKET_VALUATION_SOURCE_CHECK_NAME = "ck_market_valuation_snapshots_source"
@@ -812,6 +813,11 @@ _DDL_STATEMENTS: tuple[str, ...] = (
     "ALTER TABLE paper.paper_pending_orders ADD COLUMN IF NOT EXISTS journal_id BIGINT",
     "ALTER TABLE paper.paper_pending_orders ADD COLUMN IF NOT EXISTS artifact_uuid TEXT",
     "ALTER TABLE paper.paper_pending_orders ADD COLUMN IF NOT EXISTS forecast_id TEXT",
+    # ---- ROB-954 stable Alpaca-paper retrospective window ----
+    "ALTER TABLE review.alpaca_paper_order_ledger "
+    "ADD COLUMN IF NOT EXISTS terminalized_at TIMESTAMPTZ",
+    "CREATE INDEX IF NOT EXISTS ix_alpaca_paper_ledger_terminalized_at "
+    "ON review.alpaca_paper_order_ledger (terminalized_at)",
     # ---- benchmark_return_bps on scalping_daily_reviews (B-1) ----
     "ALTER TABLE scalping_daily_reviews ADD COLUMN IF NOT EXISTS benchmark_return_bps NUMERIC(12, 4)",
     # ---- ROB-734 mirror counterfactual metadata ----

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -350,9 +350,24 @@ def _serialize_alpaca_paper_db_suites(request):
     autouse fixtures wrap module autouse fixtures), so a peer never runs while
     another suite's committed cleanup is in flight. The intra-test
     ``asyncio.gather`` concurrency the exactly-once claim tests rely on still
-    runs inside the lock (one process holds it for the whole test)."""
+    runs inside the lock (one process holds it for the whole test).
+
+    ROB-954 round-2: ``test_trade_retrospective_pending.py`` doesn't seed the
+    shared ``alpaca_paper_order_ledger`` table itself, but its
+    ``account_mode=None`` scans read it with exact ``total_pending ==`` counts
+    over a wide ``2000-01-01``..``2100-01-01`` window — a peer alpaca_paper
+    suite committing a ``rob73-``/``rob74-crypto-`` row mid-test inflates that
+    count exactly like the write/write races above, so it needs the same
+    cross-worker serialization even though it is read-mostly here. (Do not
+    also wrap this file's own cleanup in ``_alpaca_paper_db_suite_lock()`` —
+    ``fcntl.flock`` is not reentrant across separate ``open()`` calls even
+    within one process, so nesting it under this fixture would deadlock.)"""
     path = str(getattr(request.node, "fspath", "") or "")
-    if "alpaca_paper" not in path and "paper_approval_packet" not in path:
+    if (
+        "alpaca_paper" not in path
+        and "paper_approval_packet" not in path
+        and "test_trade_retrospective_pending" not in path
+    ):
         yield
         return
     with _alpaca_paper_db_suite_lock():

--- a/tests/services/paper_evaluation/test_migration.py
+++ b/tests/services/paper_evaluation/test_migration.py
@@ -56,7 +56,7 @@ def test_migration_descends_from_latest_main_head_and_is_the_single_head() -> No
     config = Config(str(REPO / "alembic.ini"))
     config.set_main_option("script_location", str(REPO / "alembic"))
     assert ScriptDirectory.from_config(config).get_heads() == [
-        "20260717_rob920_alpaca_canceled"
+        "20260721_rob954_terminalized_at"
     ]
 
 
@@ -151,7 +151,7 @@ async def test_real_postgresql_upgrade_downgrade_upgrade_single_head() -> None:
             assert completed.returncode == 0, completed.stdout + completed.stderr
         current = await asyncio.to_thread(alembic, "current")
         assert current.returncode == 0, current.stdout + current.stderr
-        assert "20260717_rob920_alpaca_canceled (head)" in current.stdout
+        assert "20260721_rob954_terminalized_at (head)" in current.stdout
 
         async with engine.connect() as connection:
             triggers = await connection.scalar(

--- a/tests/services/test_alpaca_paper_ledger_service.py
+++ b/tests/services/test_alpaca_paper_ledger_service.py
@@ -1453,6 +1453,47 @@ async def test_record_status_does_not_update_final_reconciled_row():
 
 @pytest.mark.asyncio
 @pytest.mark.unit
+async def test_record_status_rowcount_zero_skips_raw_response_accumulation():
+    """ROB-953 LOW follow-up: a guard-rejected write (rowcount=0, e.g. a
+    concurrent write already landed a higher-lifecycle state) must not
+    accumulate raw_response evidence for a transition that never persisted.
+    The shipped code already gates `_accumulate_raw_response` on
+    `write_applied` — this was unguarded by any test, so a regression that
+    dropped the gate would have shipped silently (a prior audit found
+    `write_applied=True` mutations still left the whole test suite green)."""
+    from app.services.alpaca_paper_ledger_service import AlpacaPaperLedgerService
+
+    row = _make_row(lifecycle_state="submitted", record_kind="execution")
+    db = AsyncMock()
+
+    class _SelectResult:
+        def scalar_one_or_none(self):
+            return row
+
+    class _UpdateResult:
+        rowcount = 0
+
+    db.execute = AsyncMock(side_effect=[_SelectResult(), _UpdateResult()])
+    db.commit = AsyncMock()
+    db.refresh = AsyncMock()
+
+    svc = AlpacaPaperLedgerService(db)
+    result = await svc.record_status(
+        "test-client-001",
+        order={"id": "bid1", "status": "filled", "filled_qty": "1"},
+        raw_response={"reconcile_order": {"status": "filled"}},
+        return_write_result=True,
+    )
+
+    assert result.applied is False
+    # Exactly 2 execute calls: the read (get_execution_by_client_order_id) and
+    # the guarded UPDATE. A 3rd call would be the raw_responses-accumulation
+    # UPDATE, which must never fire when the guard rejected the write.
+    assert db.execute.call_count == 2
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
 async def test_record_cancel_transitions_to_canceled_if_order_status_is_canceled():
     from app.services.alpaca_paper_ledger_service import AlpacaPaperLedgerService
 

--- a/tests/services/test_alpaca_paper_ledger_service.py
+++ b/tests/services/test_alpaca_paper_ledger_service.py
@@ -47,6 +47,7 @@ def test_alpaca_paper_ledger_model_columns():
         "broker",
         "account_mode",
         "lifecycle_state",
+        "terminalized_at",
         "signal_symbol",
         "signal_venue",
         "execution_symbol",
@@ -128,6 +129,7 @@ def test_alpaca_paper_ledger_partial_unique_indexes():
     # New correlation/record_kind lookup indexes
     assert "ix_alpaca_paper_ledger_correlation_id" in index_names
     assert "ix_alpaca_paper_ledger_record_kind" in index_names
+    assert "ix_alpaca_paper_ledger_terminalized_at" in index_names
 
 
 @pytest.mark.unit
@@ -1400,12 +1402,14 @@ async def test_record_status_with_cancel_evidence_derives_canceled():
 
     # The row's CURRENT state (anomaly) must not be excluded by the write guard,
     # or the derived "canceled" would never be applied to any row.
-    guarded_states = {
-        state
-        for key, value in compiled.params.items()
-        if key.startswith("lifecycle_state_") and isinstance(value, list)
-        for state in value
-    }
+    # Compile WHERE criteria separately: the terminalized_at SET expression also
+    # contains the full terminal-state set, but that CASE is not a write guard.
+    guarded_states = set()
+    for criterion in update_stmt._where_criteria:
+        where_params = criterion.compile().params
+        for key, value in where_params.items():
+            if key.startswith("lifecycle_state_") and isinstance(value, list):
+                guarded_states.update(value)
     assert guarded_states, "expected an immutable-state guard in the WHERE clause"
     assert "anomaly" not in guarded_states
     assert "canceled" not in guarded_states

--- a/tests/services/test_alpaca_paper_retrospective_pending.py
+++ b/tests/services/test_alpaca_paper_retrospective_pending.py
@@ -6,10 +6,17 @@ service and the ROB-994 zero-fill terminalization sat invisible to the
 retrospective due-list forever. This exercises the new branch: terminal
 lifecycle_state rows surface (filled/position_reconciled/closed/
 final_reconciled/anomaly by default, canceled only with include_cancelled),
-non-terminal states and non-execution record_kinds stay excluded, coverage
-still applies, and the scan is properly isolated from every other source
-(especially `paper` / PaperTrade, a structurally disjoint writer — see
+non-terminal states and non-{execution,reconcile} record_kinds stay excluded,
+coverage still applies, and the scan is properly isolated from every other
+source (especially `paper` / PaperTrade, a structurally disjoint writer — see
 ROB-954 PR notes for the grep evidence that no code path writes both).
+
+ROB-954 round-2 (adversarial-review fix pass) added three more behaviors
+this file covers: the window anchors on `updated_at` (terminal-transition
+time), not `created_at` (claim time); record_kind='reconcile' rows (produced
+in-place by record_final_reconcile()) surface alongside 'execution'; and
+roundtrip buy/sell legs sharing one lifecycle_correlation_id collapse to a
+single due entry.
 
 This file's name contains "alpaca_paper" so conftest's
 `_serialize_alpaca_paper_db_suites` automatically cross-worker-locks it
@@ -19,7 +26,9 @@ against every other alpaca_paper suite sharing this table.
 from __future__ import annotations
 
 import uuid
+from datetime import UTC, timedelta
 from decimal import Decimal
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
@@ -32,6 +41,8 @@ from app.models.paper_trading import PaperTrade
 from app.models.review import AlpacaPaperOrderLedger
 from app.models.trading import InstrumentType
 from app.services.alpaca_paper_ledger_service import AlpacaPaperLedgerService
+from app.services.alpaca_paper_reconcile_service import AlpacaPaperReconcileService
+from app.services.brokers.alpaca.schemas import Order
 from app.services.paper_trading_service import PaperTradingService
 from app.services.trade_journal.trade_retrospective_service import (
     build_retrospective_pending,
@@ -191,13 +202,18 @@ async def test_non_terminal_states_excluded(
 async def test_non_execution_record_kind_excluded_even_with_terminal_state(
     db_session: AsyncSession,
 ) -> None:
-    """record_kind != 'execution' rows share the (client_order_id, record_kind)
-    unique-slot family with the real execution row — scanning them too would
-    double-surface a single order as multiple due-list entries. lifecycle_state
-    is deliberately set to a terminal value here to isolate the record_kind
-    filter from the lifecycle_state filter (not a realistic broker combo)."""
+    """record_kind IN {plan, preview, validation_attempt} rows share the
+    (client_order_id, record_kind) unique-slot family with the real execution
+    row — scanning them too would double-surface a single order as multiple
+    due-list entries. lifecycle_state is deliberately set to a terminal value
+    here to isolate the record_kind filter from the lifecycle_state filter
+    (not a realistic broker combo). 'reconcile' is intentionally NOT in this
+    list — see test_reconcile_record_kind_surfaces_with_final_reconciled_state
+    below, since AlpacaPaperLedgerService.record_final_reconcile() genuinely
+    produces record_kind='reconcile' in production (an in-place UPDATE of the
+    execution row, not a second row)."""
     coid = _uniq()
-    for record_kind in ("plan", "preview", "validation_attempt", "reconcile"):
+    for record_kind in ("plan", "preview", "validation_attempt"):
         db_session.add(
             _row(
                 client_order_id=f"{coid}-{record_kind}",
@@ -215,6 +231,35 @@ async def test_non_execution_record_kind_excluded_even_with_terminal_state(
     )
     refs = {p["order_ref"] for p in result["pending"]}
     assert not any(ref.startswith(coid) for ref in refs if ref)
+
+
+async def test_reconcile_record_kind_surfaces_with_final_reconciled_state(
+    db_session: AsyncSession,
+) -> None:
+    """record_kind='reconcile' paired with lifecycle_state='final_reconciled'
+    is the realistic combination AlpacaPaperLedgerService.record_final_reconcile()
+    produces (it flips record_kind on the same row at the moment it books
+    final_reconciled) — this must surface, not be silently dropped by an
+    execution-only record_kind filter."""
+    coid = _uniq()
+    db_session.add(
+        _row(
+            client_order_id=coid,
+            lifecycle_state="final_reconciled",
+            record_kind="reconcile",
+        )
+    )
+    await db_session.commit()
+
+    result = await _pending_with_retry(
+        db_session,
+        kst_date_from="2000-01-01",
+        kst_date_to="2100-01-01",
+        account_mode="alpaca_paper",
+    )
+    entry = await _find(result, coid)
+    assert entry is not None, result["pending"]
+    assert entry["status"] == "final_reconciled"
 
 
 # ---------------------------------------------------------------------------
@@ -341,15 +386,50 @@ async def test_covered_by_correlation_id(db_session: AsyncSession) -> None:
 
 
 # ---------------------------------------------------------------------------
-# AC4 — a real ROB-953-reconciled fill (claim -> submit -> status booked
-# filled) surfaces, mirroring the ISRG rob73-... production evidence.
+# AC4 — a real ROB-953-reconciled fill, produced by the actual
+# AlpacaPaperReconcileService against a fake broker (not a hand-rolled
+# record_status() call), surfaces in a narrow today-only window — mirroring
+# the ISRG rob73-... production evidence and jointly proving the round-2
+# `updated_at` window fix (HIGH-1).
 # ---------------------------------------------------------------------------
 
 
-async def test_reconciled_fill_via_real_ledger_service_surfaces_as_pending(
+class _FakeAlpacaBroker:
+    """Minimal broker double for AlpacaPaperReconcileService.reconcile().
+
+    Returns a single deterministic filled Order plus its matching fill
+    activity, exercising the real classify_fill_evidence/resolve_transition/
+    record_status chain that production reconcile uses — no fake ledger, no
+    shortcut through record_status directly.
+    """
+
+    def __init__(self, order: Order) -> None:
+        self._order = order
+
+    async def get_order_by_client_order_id(self, _: str) -> Order:
+        return self._order
+
+    async def list_fills(self, **_: Any) -> list[Any]:
+        return [
+            SimpleNamespace(
+                id="f1",
+                order_id=self._order.id,
+                qty=self._order.filled_qty,
+                price=self._order.filled_avg_price,
+                cum_qty=self._order.filled_qty,
+                transaction_time=None,
+            )
+        ]
+
+
+async def test_reconciled_fill_via_real_reconcile_service_surfaces_as_pending(
     db_session: AsyncSession,
 ) -> None:
-    coid = _uniq()
+    # Realistic client_order_id shape (rob73-<hex16>), matching the production
+    # evidence format used in tests/services/test_alpaca_paper_reconcile_service.py
+    # (Row.client_order_id default "rob73-08ebbf8c64e2dd93"). Kept under this
+    # file's _PREFIX so the autouse cleanup fixture still reclaims it.
+    coid = f"{_PREFIX}rob73-{uuid.uuid4().hex[:16]}"
     ledger = AlpacaPaperLedgerService(db_session)
     claim = await ledger.claim_submit(
         client_order_id=coid,
@@ -366,23 +446,32 @@ async def test_reconciled_fill_via_real_ledger_service_surfaces_as_pending(
 
     await ledger.record_submit(coid, {"id": f"broker-{coid}", "status": "new"})
 
-    # Mirrors AlpacaPaperReconcileService._book_transition's write path
-    # (ROB-953): a status check whose evidence proves a complete fill books
-    # lifecycle_state=filled via the same record_status call.
-    await ledger.record_status(
-        coid,
-        {
-            "id": f"broker-{coid}",
-            "status": "filled",
-            "filled_qty": "1",
-            "filled_avg_price": "512.34",
-        },
+    order = Order(
+        id=f"broker-{coid}",
+        client_order_id=coid,
+        symbol="ISRG",
+        qty=Decimal("1"),
+        filled_qty=Decimal("1"),
+        filled_avg_price=Decimal("512.34"),
+        side="buy",
+        type="limit",
+        time_in_force="day",
+        status="filled",
     )
+    reconcile_result = await AlpacaPaperReconcileService(
+        ledger, _FakeAlpacaBroker(order)
+    ).reconcile(client_order_id=coid, dry_run=False)
+    assert reconcile_result["reconciled"][0]["action"] == "booked_filled"
 
+    # Narrow, realistic (today-only) window — NOT the 2000-2100 span used
+    # elsewhere in this file. A wide window can mask the created_at-vs-
+    # updated_at window bug (HIGH-1); a narrow today-only window only passes
+    # if the scan actually anchors on the terminal-transition timestamp.
+    today = now_kst().strftime("%Y-%m-%d")
     result = await _pending_with_retry(
         db_session,
-        kst_date_from="2000-01-01",
-        kst_date_to="2100-01-01",
+        kst_date_from=today,
+        kst_date_to=today,
         account_mode="alpaca_paper",
     )
     entry = await _find(result, coid)
@@ -394,3 +483,115 @@ async def test_reconciled_fill_via_real_ledger_service_surfaces_as_pending(
     assert entry["instrument_type"] == "equity_us"
     # lifecycle_correlation_id defaults to client_order_id (claim_submit).
     assert entry["suggested_correlation_id"] == coid
+
+
+# ---------------------------------------------------------------------------
+# HIGH-1 (round-2) — window anchors on updated_at (terminal-transition time),
+# not created_at (claim time). A row claimed days ago that only becomes
+# terminal today must surface in today's narrow window; the old created_at
+# anchor silently dropped exactly this shape (the REGN long-stall repro).
+# ---------------------------------------------------------------------------
+
+
+async def test_stale_created_at_with_recent_terminal_transition_surfaces_in_narrow_window(
+    db_session: AsyncSession,
+) -> None:
+    coid = _uniq()
+    stale = now_kst().astimezone(UTC) - timedelta(days=3)
+    row = _row(client_order_id=coid, lifecycle_state="submitted")
+    row.created_at = stale
+    row.updated_at = stale
+    db_session.add(row)
+    await db_session.commit()
+
+    # Sanity: the setup is genuinely stale before the transition below.
+    assert row.created_at.date() < now_kst().date()
+
+    # Real terminal transition today — bumps updated_at via onupdate=func.now(),
+    # created_at is untouched by the UPDATE and stays stale forever.
+    ledger = AlpacaPaperLedgerService(db_session)
+    await ledger.record_status(
+        coid,
+        {
+            "id": f"broker-{coid}",
+            "status": "filled",
+            "filled_qty": "1",
+            "filled_avg_price": "500",
+        },
+    )
+
+    today = now_kst().strftime("%Y-%m-%d")
+    narrow = await _pending_with_retry(
+        db_session,
+        kst_date_from=today,
+        kst_date_to=today,
+        account_mode="alpaca_paper",
+    )
+    entry = await _find(narrow, coid)
+    assert entry is not None, narrow["pending"]
+    assert entry["status"] == "filled"
+
+
+# ---------------------------------------------------------------------------
+# HIGH-3 (round-2) — buy/sell roundtrip legs sharing one
+# lifecycle_correlation_id collapse to a single due entry, since
+# review.trade_retrospectives enforces UNIQUE(correlation_id, account_mode)
+# and one saved retrospective covers both legs at once.
+# ---------------------------------------------------------------------------
+
+
+async def test_shared_correlation_id_roundtrip_collapses_to_one_pending_entry(
+    db_session: AsyncSession,
+) -> None:
+    correlation_id = _uniq("-roundtrip")
+    buy_coid = _uniq("-buy")
+    sell_coid = _uniq("-sell")
+    db_session.add(
+        _row(
+            client_order_id=buy_coid,
+            lifecycle_state="filled",
+            side="buy",
+            lifecycle_correlation_id=correlation_id,
+        )
+    )
+    db_session.add(
+        _row(
+            client_order_id=sell_coid,
+            lifecycle_state="closed",
+            side="sell",
+            lifecycle_correlation_id=correlation_id,
+        )
+    )
+    await db_session.commit()
+
+    result = await _pending_with_retry(
+        db_session,
+        kst_date_from="2000-01-01",
+        kst_date_to="2100-01-01",
+        account_mode="alpaca_paper",
+    )
+    matches = [
+        p for p in result["pending"] if p["suggested_correlation_id"] == correlation_id
+    ]
+    assert len(matches) == 1, result["pending"]
+
+    await save_retrospective(
+        db_session,
+        symbol="ISRG",
+        instrument_type="equity_us",
+        account_mode="alpaca_paper",
+        outcome="filled",
+        correlation_id=correlation_id,
+    )
+    await db_session.commit()
+
+    covered = await _pending_with_retry(
+        db_session,
+        kst_date_from="2000-01-01",
+        kst_date_to="2100-01-01",
+        account_mode="alpaca_paper",
+    )
+    matches_after = [
+        p for p in covered["pending"] if p["suggested_correlation_id"] == correlation_id
+    ]
+    assert matches_after == []

--- a/tests/services/test_alpaca_paper_retrospective_pending.py
+++ b/tests/services/test_alpaca_paper_retrospective_pending.py
@@ -18,6 +18,10 @@ in-place by record_final_reconcile()) surface alongside 'execution'; and
 roundtrip buy/sell legs sharing one lifecycle_correlation_id collapse to a
 single due entry.
 
+The terminal window is anchored on the dedicated ``terminalized_at`` transition
+timestamp. Legacy terminal rows created before that nullable column existed use
+the stable ``created_at`` fallback; metadata-only writes must move neither path.
+
 This file's name contains "alpaca_paper" so conftest's
 `_serialize_alpaca_paper_db_suites` automatically cross-worker-locks it
 against every other alpaca_paper suite sharing this table.
@@ -36,8 +40,8 @@ import pytest_asyncio
 from sqlalchemy import delete
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.timezone import now_kst
-from app.models.paper_trading import PaperTrade
+from app.core.timezone import KST, now_kst
+from app.models.paper_trading import PaperAccount, PaperTrade
 from app.models.review import AlpacaPaperOrderLedger
 from app.models.trading import InstrumentType
 from app.services.alpaca_paper_ledger_service import AlpacaPaperLedgerService
@@ -49,7 +53,7 @@ from app.services.trade_journal.trade_retrospective_service import (
     save_retrospective,
 )
 
-pytestmark = [pytest.mark.asyncio]
+pytestmark = [pytest.mark.asyncio, pytest.mark.integration]
 
 _PREFIX = "rob954-"
 
@@ -87,6 +91,11 @@ async def _cleanup(db_session: AsyncSession):
         )
         await db_session.execute(
             delete(PaperTrade).where(PaperTrade.correlation_id.like(f"{_PREFIX}%"))
+        )
+        # Prefix-scoped account cleanup closes the leak from the disjoint
+        # PaperTrade coverage test without touching unrelated shared-test rows.
+        await db_session.execute(
+            delete(PaperAccount).where(PaperAccount.name.like(f"{_PREFIX}%"))
         )
         await db_session.commit()
 
@@ -444,7 +453,18 @@ async def test_reconciled_fill_via_real_reconcile_service_surfaces_as_pending(
     )
     assert claim.won is True
 
-    await ledger.record_submit(coid, {"id": f"broker-{coid}", "status": "new"})
+    submitted = await ledger.record_submit(
+        coid, {"id": f"broker-{coid}", "status": "new"}
+    )
+
+    # The claim/submit really happened three days ago. Only the terminal write
+    # produced by the real reconcile below happens today; this makes reverting
+    # the scanner to created_at fail instead of yielding the round-2 false green.
+    stale = now_kst().astimezone(UTC) - timedelta(days=3)
+    submitted.created_at = stale
+    submitted.updated_at = stale
+    await db_session.commit()
+    assert submitted.terminalized_at is None
 
     order = Order(
         id=f"broker-{coid}",
@@ -465,8 +485,8 @@ async def test_reconciled_fill_via_real_reconcile_service_surfaces_as_pending(
 
     # Narrow, realistic (today-only) window — NOT the 2000-2100 span used
     # elsewhere in this file. A wide window can mask the created_at-vs-
-    # updated_at window bug (HIGH-1); a narrow today-only window only passes
-    # if the scan actually anchors on the terminal-transition timestamp.
+    # terminalized_at bug; this only passes when the actual transition is the
+    # window anchor.
     today = now_kst().strftime("%Y-%m-%d")
     result = await _pending_with_retry(
         db_session,
@@ -486,7 +506,7 @@ async def test_reconciled_fill_via_real_reconcile_service_surfaces_as_pending(
 
 
 # ---------------------------------------------------------------------------
-# HIGH-1 (round-2) — window anchors on updated_at (terminal-transition time),
+# HIGH-1 (round-3) — window anchors on terminalized_at (terminal-transition time),
 # not created_at (claim time). A row claimed days ago that only becomes
 # terminal today must surface in today's narrow window; the old created_at
 # anchor silently dropped exactly this shape (the REGN long-stall repro).
@@ -507,7 +527,7 @@ async def test_stale_created_at_with_recent_terminal_transition_surfaces_in_narr
     # Sanity: the setup is genuinely stale before the transition below.
     assert row.created_at.date() < now_kst().date()
 
-    # Real terminal transition today — bumps updated_at via onupdate=func.now(),
+    # Real terminal transition today stamps terminalized_at exactly once;
     # created_at is untouched by the UPDATE and stays stale forever.
     ledger = AlpacaPaperLedgerService(db_session)
     await ledger.record_status(
@@ -530,10 +550,102 @@ async def test_stale_created_at_with_recent_terminal_transition_surfaces_in_narr
     entry = await _find(narrow, coid)
     assert entry is not None, narrow["pending"]
     assert entry["status"] == "filled"
+    transitioned = await ledger.get_execution_by_client_order_id(coid)
+    assert transitioned is not None
+    assert transitioned.terminalized_at is not None
+
+
+async def test_terminal_window_does_not_move_after_metadata_only_writes(
+    db_session: AsyncSession,
+) -> None:
+    """Round-2 real-DB counterexample: reconcile/cancel metadata updates
+    ``updated_at`` but may never re-date an already-terminal execution."""
+    coid = _uniq()
+    terminalized = now_kst().astimezone(UTC) - timedelta(days=3)
+    row = _row(client_order_id=coid, lifecycle_state="filled")
+    row.created_at = terminalized - timedelta(days=2)
+    row.updated_at = terminalized
+    row.terminalized_at = terminalized
+    db_session.add(row)
+    await db_session.commit()
+
+    ledger = AlpacaPaperLedgerService(db_session)
+    await ledger.record_reconcile(coid, reconcile_status="metadata-only")
+    # order_status is not canceled, so this is another metadata-only write.
+    updated = await ledger.record_cancel(coid, cancel_status="not_requested")
+    assert updated.lifecycle_state == "filled"
+    assert updated.terminalized_at == terminalized
+    assert updated.updated_at > terminalized
+
+    old_day = terminalized.astimezone(KST).strftime("%Y-%m-%d")
+    old_window = await _pending_with_retry(
+        db_session,
+        kst_date_from=old_day,
+        kst_date_to=old_day,
+        account_mode="alpaca_paper",
+    )
+    assert await _find(old_window, coid) is not None
+
+    today = now_kst().strftime("%Y-%m-%d")
+    today_window = await _pending_with_retry(
+        db_session,
+        kst_date_from=today,
+        kst_date_to=today,
+        account_mode="alpaca_paper",
+    )
+    assert await _find(today_window, coid) is None
+
+
+async def test_legacy_null_terminal_timestamp_surfaces_without_window_churn(
+    db_session: AsyncSession,
+) -> None:
+    """Pre-migration terminal rows remain visible through created_at fallback.
+
+    The fallback deliberately avoids updated_at: a metadata-only reconcile must
+    not move a legacy NULL row from its original window into today's window.
+    """
+    coid = _uniq()
+    created = now_kst().astimezone(UTC) - timedelta(days=3)
+    row = _row(client_order_id=coid, lifecycle_state="filled")
+    row.created_at = created
+    row.updated_at = created
+    row.terminalized_at = None
+    db_session.add(row)
+    await db_session.commit()
+
+    legacy_day = created.astimezone(KST).strftime("%Y-%m-%d")
+    before = await _pending_with_retry(
+        db_session,
+        kst_date_from=legacy_day,
+        kst_date_to=legacy_day,
+        account_mode="alpaca_paper",
+    )
+    assert await _find(before, coid) is not None
+
+    ledger = AlpacaPaperLedgerService(db_session)
+    updated = await ledger.record_reconcile(coid, reconcile_status="legacy-metadata")
+    assert updated.terminalized_at is None
+
+    still_legacy = await _pending_with_retry(
+        db_session,
+        kst_date_from=legacy_day,
+        kst_date_to=legacy_day,
+        account_mode="alpaca_paper",
+    )
+    assert await _find(still_legacy, coid) is not None
+
+    today = now_kst().strftime("%Y-%m-%d")
+    moved = await _pending_with_retry(
+        db_session,
+        kst_date_from=today,
+        kst_date_to=today,
+        account_mode="alpaca_paper",
+    )
+    assert await _find(moved, coid) is None
 
 
 # ---------------------------------------------------------------------------
-# HIGH-3 (round-2) — buy/sell roundtrip legs sharing one
+# HIGH-3 (round-3) — buy/sell roundtrip legs sharing one
 # lifecycle_correlation_id collapse to a single due entry, since
 # review.trade_retrospectives enforces UNIQUE(correlation_id, account_mode)
 # and one saved retrospective covers both legs at once.
@@ -546,22 +658,22 @@ async def test_shared_correlation_id_roundtrip_collapses_to_one_pending_entry(
     correlation_id = _uniq("-roundtrip")
     buy_coid = _uniq("-buy")
     sell_coid = _uniq("-sell")
-    db_session.add(
-        _row(
-            client_order_id=buy_coid,
-            lifecycle_state="filled",
-            side="buy",
-            lifecycle_correlation_id=correlation_id,
-        )
+    transitioned = now_kst().astimezone(UTC) - timedelta(hours=1)
+    buy = _row(
+        client_order_id=buy_coid,
+        lifecycle_state="filled",
+        side="buy",
+        lifecycle_correlation_id=correlation_id,
     )
-    db_session.add(
-        _row(
-            client_order_id=sell_coid,
-            lifecycle_state="closed",
-            side="sell",
-            lifecycle_correlation_id=correlation_id,
-        )
+    buy.terminalized_at = transitioned
+    sell = _row(
+        client_order_id=sell_coid,
+        lifecycle_state="closed",
+        side="sell",
+        lifecycle_correlation_id=correlation_id,
     )
+    sell.terminalized_at = transitioned
+    db_session.add_all([buy, sell])
     await db_session.commit()
 
     result = await _pending_with_retry(
@@ -574,6 +686,30 @@ async def test_shared_correlation_id_roundtrip_collapses_to_one_pending_entry(
         p for p in result["pending"] if p["suggested_correlation_id"] == correlation_id
     ]
     assert len(matches) == 1, result["pending"]
+    assert matches[0]["order_ref"] == sell_coid
+    assert matches[0]["side"] == "sell"
+    assert matches[0]["status"] == "closed"
+
+    # A later metadata write on the buy leg changes updated_at only. The
+    # representative must remain the deterministic sell/close leg.
+    await AlpacaPaperLedgerService(db_session).record_reconcile(
+        buy_coid, reconcile_status="metadata-only"
+    )
+    after_metadata = await _pending_with_retry(
+        db_session,
+        kst_date_from="2000-01-01",
+        kst_date_to="2100-01-01",
+        account_mode="alpaca_paper",
+    )
+    after_matches = [
+        p
+        for p in after_metadata["pending"]
+        if p["suggested_correlation_id"] == correlation_id
+    ]
+    assert len(after_matches) == 1, after_metadata["pending"]
+    assert after_matches[0]["order_ref"] == sell_coid
+    assert after_matches[0]["side"] == "sell"
+    assert after_matches[0]["status"] == "closed"
 
     await save_retrospective(
         db_session,
@@ -595,3 +731,49 @@ async def test_shared_correlation_id_roundtrip_collapses_to_one_pending_entry(
         p for p in covered["pending"] if p["suggested_correlation_id"] == correlation_id
     ]
     assert matches_after == []
+
+
+async def test_mismatched_symbols_in_one_correlation_surface_anomaly(
+    db_session: AsyncSession,
+) -> None:
+    """A malformed correlation group is one resolvable due entry plus explicit
+    anomaly evidence accounting for every affected execution row."""
+    correlation_id = _uniq("-mismatch")
+    aapl_coid = _uniq("-aapl")
+    msft_coid = _uniq("-msft")
+    transitioned = now_kst().astimezone(UTC) - timedelta(minutes=5)
+    aapl = _row(
+        client_order_id=aapl_coid,
+        lifecycle_state="filled",
+        symbol="AAPL",
+        side="buy",
+        lifecycle_correlation_id=correlation_id,
+    )
+    msft = _row(
+        client_order_id=msft_coid,
+        lifecycle_state="closed",
+        symbol="MSFT",
+        side="sell",
+        lifecycle_correlation_id=correlation_id,
+    )
+    aapl.terminalized_at = transitioned
+    msft.terminalized_at = transitioned
+    db_session.add_all([aapl, msft])
+    await db_session.commit()
+
+    result = await _pending_with_retry(
+        db_session,
+        kst_date_from="2000-01-01",
+        kst_date_to="2100-01-01",
+        account_mode="alpaca_paper",
+    )
+    matches = [
+        p for p in result["pending"] if p["suggested_correlation_id"] == correlation_id
+    ]
+    assert len(matches) == 1, result["pending"]
+    anomaly = matches[0]["correlation_anomaly"]
+    assert anomaly["code"] == "inconsistent_correlation_group"
+    assert anomaly["group_size"] == 2
+    assert anomaly["symbols"] == ["AAPL", "MSFT"]
+    assert anomaly["client_order_ids"] == sorted([aapl_coid, msft_coid])
+    assert len(anomaly["ledger_row_ids"]) == 2

--- a/tests/services/test_alpaca_paper_retrospective_pending.py
+++ b/tests/services/test_alpaca_paper_retrospective_pending.py
@@ -1,0 +1,396 @@
+"""ROB-954 — Alpaca paper ledger source branch in build_retrospective_pending.
+
+trade_retrospective_pending never surfaced alpaca_paper_order_ledger terminal
+rows (no scan branch existed), so fills booked by the ROB-953 reconcile
+service and the ROB-994 zero-fill terminalization sat invisible to the
+retrospective due-list forever. This exercises the new branch: terminal
+lifecycle_state rows surface (filled/position_reconciled/closed/
+final_reconciled/anomaly by default, canceled only with include_cancelled),
+non-terminal states and non-execution record_kinds stay excluded, coverage
+still applies, and the scan is properly isolated from every other source
+(especially `paper` / PaperTrade, a structurally disjoint writer — see
+ROB-954 PR notes for the grep evidence that no code path writes both).
+
+This file's name contains "alpaca_paper" so conftest's
+`_serialize_alpaca_paper_db_suites` automatically cross-worker-locks it
+against every other alpaca_paper suite sharing this table.
+"""
+
+from __future__ import annotations
+
+import uuid
+from decimal import Decimal
+from typing import Any
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import delete
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.timezone import now_kst
+from app.models.paper_trading import PaperTrade
+from app.models.review import AlpacaPaperOrderLedger
+from app.models.trading import InstrumentType
+from app.services.alpaca_paper_ledger_service import AlpacaPaperLedgerService
+from app.services.paper_trading_service import PaperTradingService
+from app.services.trade_journal.trade_retrospective_service import (
+    build_retrospective_pending,
+    save_retrospective,
+)
+
+pytestmark = [pytest.mark.asyncio]
+
+_PREFIX = "rob954-"
+
+
+def _uniq(suffix: str = "") -> str:
+    return f"{_PREFIX}{uuid.uuid4().hex[:12]}{suffix}"
+
+
+async def _pending_with_retry(db: Any, **kwargs: Any) -> Any:
+    """Retry on deadlock — the scan also touches the live order ledgers, which
+    can deadlock with parallel live-ledger suites under xdist (shared test DB).
+    """
+    from sqlalchemy.exc import DBAPIError
+
+    last: Exception | None = None
+    for _ in range(6):
+        try:
+            return await build_retrospective_pending(db, **kwargs)
+        except DBAPIError as exc:
+            if "deadlock" not in str(exc).lower():
+                raise
+            last = exc
+            await db.rollback()
+    assert last is not None
+    raise last
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def _cleanup(db_session: AsyncSession):
+    async def _wipe() -> None:
+        await db_session.execute(
+            delete(AlpacaPaperOrderLedger).where(
+                AlpacaPaperOrderLedger.client_order_id.like(f"{_PREFIX}%")
+            )
+        )
+        await db_session.execute(
+            delete(PaperTrade).where(PaperTrade.correlation_id.like(f"{_PREFIX}%"))
+        )
+        await db_session.commit()
+
+    await _wipe()
+    yield
+    await _wipe()
+
+
+def _row(
+    *,
+    client_order_id: str,
+    lifecycle_state: str,
+    record_kind: str = "execution",
+    side: str = "buy",
+    symbol: str = "ISRG",
+    instrument_type: InstrumentType = InstrumentType.equity_us,
+    lifecycle_correlation_id: str | None = None,
+) -> AlpacaPaperOrderLedger:
+    return AlpacaPaperOrderLedger(
+        client_order_id=client_order_id,
+        lifecycle_correlation_id=lifecycle_correlation_id or client_order_id,
+        record_kind=record_kind,
+        broker="alpaca",
+        account_mode="alpaca_paper",
+        lifecycle_state=lifecycle_state,
+        execution_symbol=symbol,
+        execution_venue="alpaca_paper",
+        instrument_type=instrument_type,
+        side=side,
+        order_type="limit",
+        currency="USD",
+        requested_qty=Decimal("1"),
+    )
+
+
+async def _find(result: dict[str, Any], coid: str) -> dict[str, Any] | None:
+    return next((p for p in result["pending"] if p["order_ref"] == coid), None)
+
+
+# ---------------------------------------------------------------------------
+# AC1/AC2 — terminal lifecycle states surface, non-terminal stay excluded
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "lifecycle_state",
+    ["filled", "position_reconciled", "closed", "final_reconciled", "anomaly"],
+)
+async def test_default_terminal_states_surface_as_pending(
+    db_session: AsyncSession, lifecycle_state: str
+) -> None:
+    coid = _uniq()
+    db_session.add(_row(client_order_id=coid, lifecycle_state=lifecycle_state))
+    await db_session.commit()
+
+    result = await _pending_with_retry(
+        db_session,
+        kst_date_from="2000-01-01",
+        kst_date_to="2100-01-01",
+        account_mode="alpaca_paper",
+    )
+    entry = await _find(result, coid)
+    assert entry is not None, result["pending"]
+    assert entry["ledger"] == "alpaca_paper"
+    assert entry["status"] == lifecycle_state
+    assert entry["account_mode"] == "alpaca_paper"
+
+
+async def test_canceled_hidden_unless_included(db_session: AsyncSession) -> None:
+    coid = _uniq()
+    db_session.add(_row(client_order_id=coid, lifecycle_state="canceled"))
+    await db_session.commit()
+
+    default = await _pending_with_retry(
+        db_session,
+        kst_date_from="2000-01-01",
+        kst_date_to="2100-01-01",
+        account_mode="alpaca_paper",
+    )
+    assert await _find(default, coid) is None
+
+    included = await _pending_with_retry(
+        db_session,
+        kst_date_from="2000-01-01",
+        kst_date_to="2100-01-01",
+        account_mode="alpaca_paper",
+        include_cancelled=True,
+    )
+    entry = await _find(included, coid)
+    assert entry is not None
+    assert entry["status"] == "canceled"
+
+
+@pytest.mark.parametrize(
+    "lifecycle_state", ["planned", "previewed", "validated", "submitted"]
+)
+async def test_non_terminal_states_excluded(
+    db_session: AsyncSession, lifecycle_state: str
+) -> None:
+    coid = _uniq()
+    db_session.add(_row(client_order_id=coid, lifecycle_state=lifecycle_state))
+    await db_session.commit()
+
+    result = await _pending_with_retry(
+        db_session,
+        kst_date_from="2000-01-01",
+        kst_date_to="2100-01-01",
+        account_mode="alpaca_paper",
+    )
+    assert await _find(result, coid) is None
+
+
+async def test_non_execution_record_kind_excluded_even_with_terminal_state(
+    db_session: AsyncSession,
+) -> None:
+    """record_kind != 'execution' rows share the (client_order_id, record_kind)
+    unique-slot family with the real execution row — scanning them too would
+    double-surface a single order as multiple due-list entries. lifecycle_state
+    is deliberately set to a terminal value here to isolate the record_kind
+    filter from the lifecycle_state filter (not a realistic broker combo)."""
+    coid = _uniq()
+    for record_kind in ("plan", "preview", "validation_attempt", "reconcile"):
+        db_session.add(
+            _row(
+                client_order_id=f"{coid}-{record_kind}",
+                lifecycle_state="filled",
+                record_kind=record_kind,
+            )
+        )
+    await db_session.commit()
+
+    result = await _pending_with_retry(
+        db_session,
+        kst_date_from="2000-01-01",
+        kst_date_to="2100-01-01",
+        account_mode="alpaca_paper",
+    )
+    refs = {p["order_ref"] for p in result["pending"]}
+    assert not any(ref.startswith(coid) for ref in refs if ref)
+
+
+# ---------------------------------------------------------------------------
+# AC3 — isolation from other account_mode sources (especially `paper`)
+# ---------------------------------------------------------------------------
+
+
+async def test_account_mode_filter_isolates_from_paper(
+    db_session: AsyncSession,
+) -> None:
+    coid = _uniq()
+    db_session.add(_row(client_order_id=coid, lifecycle_state="filled"))
+    await db_session.commit()
+
+    only_alpaca = await _pending_with_retry(
+        db_session,
+        kst_date_from="2000-01-01",
+        kst_date_to="2100-01-01",
+        account_mode="alpaca_paper",
+    )
+    assert await _find(only_alpaca, coid) is not None
+    assert all(p["account_mode"] == "alpaca_paper" for p in only_alpaca["pending"])
+
+    only_paper = await _pending_with_retry(
+        db_session,
+        kst_date_from="2000-01-01",
+        kst_date_to="2100-01-01",
+        account_mode="paper",
+    )
+    assert await _find(only_paper, coid) is None
+    assert all(p["ledger"] == "paper_trades" for p in only_paper["pending"])
+
+
+async def test_account_mode_none_scans_alpaca_and_paper_without_duplication(
+    db_session: AsyncSession,
+) -> None:
+    """AC5 — PaperTrade and AlpacaPaperOrderLedger are structurally disjoint
+    writers (no function writes to both; see PR notes for the grep evidence),
+    so a combined account_mode=None scan must surface both as distinct
+    entries, never collapsed into one and never double-counted."""
+    coid = _uniq()
+    db_session.add(_row(client_order_id=coid, lifecycle_state="filled", symbol="MSFT"))
+    await db_session.commit()
+
+    pts = PaperTradingService(db_session)
+    acct = await pts.create_account(
+        name=_uniq("acct"), initial_capital_krw=Decimal("100000000")
+    )
+    paper_correlation_id = _uniq("paper")
+    db_session.add(
+        PaperTrade(
+            account_id=acct.id,
+            symbol="MSFT",
+            instrument_type=InstrumentType.crypto,
+            side="buy",
+            order_type="market",
+            quantity=Decimal("0.01"),
+            price=Decimal("50000000"),
+            total_amount=Decimal("500000"),
+            fee=Decimal("0"),
+            currency="KRW",
+            correlation_id=paper_correlation_id,
+            executed_at=now_kst(),
+        )
+    )
+    await db_session.commit()
+
+    result = await _pending_with_retry(
+        db_session, kst_date_from="2000-01-01", kst_date_to="2100-01-01"
+    )
+    alpaca_matches = [p for p in result["pending"] if p["order_ref"] == coid]
+    paper_matches = [
+        p
+        for p in result["pending"]
+        if p["suggested_correlation_id"] == paper_correlation_id
+    ]
+    assert len(alpaca_matches) == 1, result["pending"]
+    assert len(paper_matches) == 1, result["pending"]
+    assert alpaca_matches[0]["ledger"] == "alpaca_paper"
+    assert paper_matches[0]["ledger"] == "paper_trades"
+    # Distinct suggested_correlation_id namespaces prove neither entry
+    # collapsed onto the other via the coverage-dedup key.
+    assert (
+        alpaca_matches[0]["suggested_correlation_id"]
+        != paper_matches[0]["suggested_correlation_id"]
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC6 — coverage exclusion
+# ---------------------------------------------------------------------------
+
+
+async def test_covered_by_correlation_id(db_session: AsyncSession) -> None:
+    coid = _uniq()
+    db_session.add(_row(client_order_id=coid, lifecycle_state="filled"))
+    await db_session.commit()
+
+    result = await _pending_with_retry(
+        db_session,
+        kst_date_from="2000-01-01",
+        kst_date_to="2100-01-01",
+        account_mode="alpaca_paper",
+    )
+    assert await _find(result, coid) is not None
+
+    await save_retrospective(
+        db_session,
+        symbol="ISRG",
+        instrument_type="equity_us",
+        account_mode="alpaca_paper",
+        outcome="filled",
+        correlation_id=coid,
+    )
+    await db_session.commit()
+
+    covered = await _pending_with_retry(
+        db_session,
+        kst_date_from="2000-01-01",
+        kst_date_to="2100-01-01",
+        account_mode="alpaca_paper",
+    )
+    assert await _find(covered, coid) is None
+
+
+# ---------------------------------------------------------------------------
+# AC4 — a real ROB-953-reconciled fill (claim -> submit -> status booked
+# filled) surfaces, mirroring the ISRG rob73-... production evidence.
+# ---------------------------------------------------------------------------
+
+
+async def test_reconciled_fill_via_real_ledger_service_surfaces_as_pending(
+    db_session: AsyncSession,
+) -> None:
+    coid = _uniq()
+    ledger = AlpacaPaperLedgerService(db_session)
+    claim = await ledger.claim_submit(
+        client_order_id=coid,
+        execution_symbol="ISRG",
+        execution_venue="alpaca_paper",
+        instrument_type=InstrumentType.equity_us,
+        side="buy",
+        order_type="limit",
+        time_in_force="day",
+        requested_qty=Decimal("1"),
+        requested_price=Decimal("500"),
+    )
+    assert claim.won is True
+
+    await ledger.record_submit(coid, {"id": f"broker-{coid}", "status": "new"})
+
+    # Mirrors AlpacaPaperReconcileService._book_transition's write path
+    # (ROB-953): a status check whose evidence proves a complete fill books
+    # lifecycle_state=filled via the same record_status call.
+    await ledger.record_status(
+        coid,
+        {
+            "id": f"broker-{coid}",
+            "status": "filled",
+            "filled_qty": "1",
+            "filled_avg_price": "512.34",
+        },
+    )
+
+    result = await _pending_with_retry(
+        db_session,
+        kst_date_from="2000-01-01",
+        kst_date_to="2100-01-01",
+        account_mode="alpaca_paper",
+    )
+    entry = await _find(result, coid)
+    assert entry is not None, result["pending"]
+    assert entry["ledger"] == "alpaca_paper"
+    assert entry["status"] == "filled"
+    assert entry["symbol"] == "ISRG"
+    assert entry["market"] == "us"
+    assert entry["instrument_type"] == "equity_us"
+    # lifecycle_correlation_id defaults to client_order_id (claim_submit).
+    assert entry["suggested_correlation_id"] == coid

--- a/tests/services/test_alpaca_paper_retrospective_pending.py
+++ b/tests/services/test_alpaca_paper_retrospective_pending.py
@@ -644,6 +644,140 @@ async def test_legacy_null_terminal_timestamp_surfaces_without_window_churn(
     assert await _find(moved, coid) is None
 
 
+@pytest.mark.parametrize(
+    "writer",
+    [
+        "record_submit",
+        "record_submit_failure",
+        "record_status",
+        "record_cancel",
+        "record_position_snapshot",
+        "record_close",
+        "record_final_reconcile",
+    ],
+)
+async def test_every_execution_terminal_write_stamps_once(
+    db_session: AsyncSession, writer: str
+) -> None:
+    """Every execution terminal writer stamps the first transition and retries
+    preserve that exact instant, including terminal-to-terminal paths."""
+    coid = _uniq(f"-{writer}")
+    row = _row(client_order_id=coid, lifecycle_state="submitted")
+    if writer == "record_cancel":
+        row.order_status = "canceled"
+    db_session.add(row)
+    await db_session.commit()
+    ledger = AlpacaPaperLedgerService(db_session)
+
+    async def invoke() -> AlpacaPaperOrderLedger:
+        if writer == "record_submit":
+            return await ledger.record_submit(
+                coid,
+                {
+                    "id": f"broker-{coid}",
+                    "status": "filled",
+                    "filled_qty": "1",
+                    "filled_avg_price": "500",
+                },
+            )
+        if writer == "record_submit_failure":
+            return await ledger.record_submit_failure(
+                coid, error_summary="deterministic rejection"
+            )
+        if writer == "record_status":
+            result = await ledger.record_status(
+                coid,
+                {
+                    "id": f"broker-{coid}",
+                    "status": "filled",
+                    "filled_qty": "1",
+                    "filled_avg_price": "500",
+                },
+            )
+            assert isinstance(result, AlpacaPaperOrderLedger)
+            return result
+        if writer == "record_cancel":
+            return await ledger.record_cancel(coid, cancel_status="canceled")
+        if writer == "record_position_snapshot":
+            return await ledger.record_position_snapshot(coid, position=None)
+        if writer == "record_close":
+            return await ledger.record_close(coid, qty_delta=Decimal("-1"))
+        assert writer == "record_final_reconcile"
+        return await ledger.record_final_reconcile(coid)
+
+    first = await invoke()
+    first_terminalized_at = first.terminalized_at
+    assert first_terminalized_at is not None
+
+    repeated = await invoke()
+    assert repeated.terminalized_at == first_terminalized_at
+
+
+async def test_terminal_insert_writers_stamp_at_insert(
+    db_session: AsyncSession,
+) -> None:
+    """Preview/validation anomaly inserts are terminal bookkeeping writes even
+    though record_kind filtering deliberately keeps them out of due-list scans."""
+    ledger = AlpacaPaperLedgerService(db_session)
+    preview = await ledger.record_preview(
+        client_order_id=_uniq("-preview-anomaly"),
+        execution_symbol="ISRG",
+        execution_venue="alpaca_paper",
+        instrument_type=InstrumentType.equity_us,
+        side="buy",
+        lifecycle_state="anomaly",
+    )
+    validation = await ledger.record_validation_attempt(
+        client_order_id=_uniq("-validation-anomaly"),
+        execution_symbol="ISRG",
+        execution_venue="alpaca_paper",
+        instrument_type=InstrumentType.equity_us,
+        side="buy",
+        validation_outcome="failed",
+    )
+    assert preview.terminalized_at is not None
+    assert validation.terminalized_at is not None
+
+
+async def test_zero_fill_terminal_reconcile_stamps_transition(
+    db_session: AsyncSession,
+) -> None:
+    """ROB-994 expired/rejected/canceled zero-fill booking uses record_status,
+    so the real reconcile integration must also populate terminalized_at."""
+    coid = _uniq("-zero-fill-expired")
+    ledger = AlpacaPaperLedgerService(db_session)
+    claim = await ledger.claim_submit(
+        client_order_id=coid,
+        execution_symbol="ISRG",
+        execution_venue="alpaca_paper",
+        instrument_type=InstrumentType.equity_us,
+        side="buy",
+        requested_qty=Decimal("1"),
+    )
+    assert claim.won is True
+    await ledger.record_submit(coid, {"id": f"broker-{coid}", "status": "new"})
+    expired = Order(
+        id=f"broker-{coid}",
+        client_order_id=coid,
+        symbol="ISRG",
+        qty=Decimal("1"),
+        filled_qty=Decimal("0"),
+        filled_avg_price=None,
+        side="buy",
+        type="limit",
+        time_in_force="day",
+        status="expired",
+    )
+    result = await AlpacaPaperReconcileService(
+        ledger, _FakeAlpacaBroker(expired)
+    ).reconcile(client_order_id=coid, dry_run=False)
+    assert result["reconciled"][0]["action"] == "booked_anomaly"
+    persisted = await ledger.get_execution_by_client_order_id(coid)
+    assert persisted is not None
+    assert persisted.lifecycle_state == "anomaly"
+    assert persisted.terminalized_at is not None
+
+
 # ---------------------------------------------------------------------------
 # HIGH-3 (round-3) — buy/sell roundtrip legs sharing one
 # lifecycle_correlation_id collapse to a single due entry, since

--- a/tests/test_trade_retrospective_pending.py
+++ b/tests/test_trade_retrospective_pending.py
@@ -23,7 +23,6 @@ from app.models.review import (
 )
 from app.models.trading import InstrumentType
 from app.services.trade_journal import trade_retrospective_service as svc
-from tests.conftest import _alpaca_paper_db_suite_lock
 
 pytestmark = [
     pytest.mark.integration,
@@ -51,17 +50,20 @@ async def _cleanup(
     # table globally shared with many other suites (see conftest's
     # `_serialize_alpaca_paper_db_suites`). Unlike the tables above this one is
     # NOT blind-truncated — only the two server-derived client_order_id
-    # prefixes every alpaca_paper writer actually uses are cleared, under the
-    # same cross-worker lock those suites use, so a concurrently-running
-    # alpaca_paper suite's committed rows are never deleted out from under it.
-    with _alpaca_paper_db_suite_lock():
-        await db_session.execute(
-            delete(AlpacaPaperOrderLedger).where(
-                AlpacaPaperOrderLedger.client_order_id.like("rob73-%")
-                | AlpacaPaperOrderLedger.client_order_id.like("rob74-crypto-%")
-            )
+    # prefixes every alpaca_paper writer actually uses are cleared. This
+    # whole file (this fixture's setup/teardown AND every test body) already
+    # runs under `_alpaca_paper_db_suite_lock()` via conftest's
+    # `_serialize_alpaca_paper_db_suites` (it matches on this file's name), so
+    # no local lock acquisition here — `fcntl.flock` is not reentrant across
+    # separate `open()` calls even within one process, and re-acquiring would
+    # deadlock against the outer fixture's held lock.
+    await db_session.execute(
+        delete(AlpacaPaperOrderLedger).where(
+            AlpacaPaperOrderLedger.client_order_id.like("rob73-%")
+            | AlpacaPaperOrderLedger.client_order_id.like("rob74-crypto-%")
         )
-        await db_session.commit()
+    )
+    await db_session.commit()
 
 
 def _kis_row(*, order_no, status="filled", report_item_uuid=None):

--- a/tests/test_trade_retrospective_pending.py
+++ b/tests/test_trade_retrospective_pending.py
@@ -14,6 +14,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.timezone import now_kst
 from app.models.paper_trading import PaperTrade
 from app.models.review import (
+    AlpacaPaperOrderLedger,
     KISLiveOrderLedger,
     KISMockOrderLedger,
     LiveOrderLedger,
@@ -22,6 +23,7 @@ from app.models.review import (
 )
 from app.models.trading import InstrumentType
 from app.services.trade_journal import trade_retrospective_service as svc
+from tests.conftest import _alpaca_paper_db_suite_lock
 
 pytestmark = [
     pytest.mark.integration,
@@ -45,6 +47,21 @@ async def _cleanup(
     ):
         await db_session.execute(delete(model))
     await db_session.commit()
+    # ROB-954: the pending scan now also reads the alpaca_paper ledger, a
+    # table globally shared with many other suites (see conftest's
+    # `_serialize_alpaca_paper_db_suites`). Unlike the tables above this one is
+    # NOT blind-truncated — only the two server-derived client_order_id
+    # prefixes every alpaca_paper writer actually uses are cleared, under the
+    # same cross-worker lock those suites use, so a concurrently-running
+    # alpaca_paper suite's committed rows are never deleted out from under it.
+    with _alpaca_paper_db_suite_lock():
+        await db_session.execute(
+            delete(AlpacaPaperOrderLedger).where(
+                AlpacaPaperOrderLedger.client_order_id.like("rob73-%")
+                | AlpacaPaperOrderLedger.client_order_id.like("rob74-crypto-%")
+            )
+        )
+        await db_session.commit()
 
 
 def _kis_row(*, order_no, status="filled", report_item_uuid=None):


### PR DESCRIPTION
## Summary
- Adds `review.alpaca_paper_order_ledger.terminalized_at` as an additive nullable `TIMESTAMPTZ` with **no `onupdate` hook**. It records the first non-terminal → retrospective-terminal lifecycle transition only; retries, terminal → terminal transitions, and metadata-only writes preserve it.
- Audits every Alpaca paper terminal writer: `record_submit`, `record_submit_failure`, `record_status` (including ROB-994 zero-fill anomaly/canceled booking), terminal `record_cancel`, `record_position_snapshot`, `record_close`, and `record_final_reconcile`. Terminal preview/validation anomaly inserts are stamped as well, though their bookkeeping record kinds remain excluded from retrospective scans.
- Realigns `trade_retrospective_pending` windowing and ordering to `terminalized_at`, while keeping `{execution,reconcile}` record-kind coverage for in-place final reconciliation.
- Replaces mutable-`updated_at` representative selection with a deterministic close/final → sell leg → lifecycle maturity → terminal window instant → primary-key order.
- A symbol/venue/instrument mismatch inside one `lifecycle_correlation_id` now surfaces one resolvable representative with `correlation_anomaly` evidence listing every member. This exposes corruption without creating duplicate due entries that conflict with `UNIQUE(correlation_id, account_mode)`.

## Existing terminal rows (`terminalized_at IS NULL`)
This PR deliberately chooses a scanner NULL fallback instead of a data backfill. Historical terminal-transition time cannot be reconstructed: copying mutable `updated_at` would fabricate a transition from the latest metadata write and retain the original window-churn defect. Therefore pre-migration terminal rows use stable `created_at`; later `record_reconcile`/non-terminal `record_cancel` writes cannot move them between windows. New transitions always use `terminalized_at`.

The WHERE clause is expressed as two indexable branches rather than `COALESCE`: non-NULL rows use the new `terminalized_at` index and legacy NULL rows use the existing `created_at` index. Ordering/reporting uses the equivalent `COALESCE(terminalized_at, created_at)` value.

## Migration
- Revision: `20260721_rob954_terminalized_at`
- Parent: `20260717_rob920_alpaca_canceled`
- Adds nullable `terminalized_at` and `ix_alpaca_paper_ledger_terminalized_at`; downgrade removes both.
- `uv run alembic heads` reports one head.
- On an isolated local PostgreSQL test DB stamped at the parent, `upgrade head → downgrade -1 → upgrade head` created, removed, and recreated the nullable column/index successfully. A full-from-base attempt was blocked earlier by the repository's pre-existing TimescaleDB extension prerequisite, before this revision.
- Deployment migration remains an operator procedure; this PR does not deploy or access production.

## Isolation and test cleanup
- The existing cross-worker Alpaca-paper lock remains in place, including `test_trade_retrospective_pending.py`.
- PaperTrade and AlpacaPaperOrderLedger writers remain structurally disjoint and surface as separate entries.
- The ROB-954 integration fixture now removes prefix-scoped `PaperAccount(name LIKE 'rob954-%')` rows as well as its ledger/trade rows; no global truncate is used.
- The entire real-DB test module is marked `integration`, so unit selection collects zero tests.

## Test plan
- [x] `uv run pytest tests/ -q -k "retrospective"` — 206 passed
- [x] `uv run pytest tests/ -q -k "alpaca_paper"` — 585 passed
- [x] `uv run pytest tests/services/test_alpaca_paper_ledger_service.py tests/services/test_alpaca_paper_retrospective_pending.py -q` — 105 passed
- [x] Two-file `-n 2 --dist=loadfile` gate repeated 3 times — 44 passed each run
- [x] `-m "not integration" --collect-only` on the new DB module — 0 collected / 30 deselected
- [x] RED→GREEN: pre-fix R3 counterexamples produced 6 failures; fixed suite is green
- [x] Controlled mutation checks: `created_at` window revert (2 RED), execution-only record-kind revert (1 RED), latest-`updated_at` representative revert (1 RED); restored tests green
- [x] Migration upgrade/downgrade/re-upgrade and single-head checks — passed
- [x] `make lint` — Ruff check/format and ty clean
- [x] `git diff --check` — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Alpaca paper-trading executions now appear in pending trade retrospectives when they reach a terminal state.
  * Retrospective pending detection now anchors to the first terminalization moment and supports lifecycle correlation anomalies when related rows disagree.
  * Pending results support filtering by account mode without merging distinct entries.
  * Canceled executions are excluded by default and can be included when requested.
* **Bug Fixes**
  * Improved ledger status handling prevents unintended follow-up processing and ensures terminal timestamps are stamped consistently.
  * Completed retrospective outcomes are excluded from pending results.

* **Database**
  * Added terminalization timestamp tracking for Alpaca paper order ledger entries (nullable for existing rows).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
